### PR TITLE
Bluetooth: BR: Format BR shell bredr.c

### DIFF
--- a/subsys/bluetooth/host/classic/shell/bredr.c
+++ b/subsys/bluetooth/host/classic/shell/bredr.c
@@ -200,6 +200,7 @@ static int cmd_discovery(const struct shell *sh, size_t argc, char *argv[])
 		shell_print(sh, "Discovery stopped");
 	} else {
 		shell_help(sh);
+		return SHELL_CMD_HELP_PRINTED;
 	}
 
 	return 0;
@@ -297,7 +298,7 @@ static int cmd_discoverable(const struct shell *sh,
 		err = bt_br_set_discoverable(false);
 	} else {
 		shell_help(sh);
-		return 0;
+		return SHELL_CMD_HELP_PRINTED;
 	}
 
 	if (err) {
@@ -325,7 +326,7 @@ static int cmd_connectable(const struct shell *sh,
 		err = bt_br_set_connectable(false);
 	} else {
 		shell_help(sh);
-		return 0;
+		return SHELL_CMD_HELP_PRINTED;
 	}
 
 	if (err) {
@@ -515,7 +516,7 @@ static int cmd_sdp_find_record(const struct shell *sh,
 		discov = discov_a2src;
 	} else {
 		shell_help(sh);
-		return 0;
+		return SHELL_CMD_HELP_PRINTED;
 	}
 
 	shell_print(sh, "SDP UUID \'%s\' gets applied", action);
@@ -552,8 +553,7 @@ static int cmd_br(const struct shell *sh, size_t argc, char **argv)
 {
 	if (argc == 1) {
 		shell_help(sh);
-		/* shell returns 1 when help is printed */
-		return 1;
+		return SHELL_CMD_HELP_PRINTED;
 	}
 
 	shell_error(sh, "%s unknown parameter: %s", argv[0], argv[1]);

--- a/subsys/bluetooth/host/classic/shell/bredr.c
+++ b/subsys/bluetooth/host/classic/shell/bredr.c
@@ -60,13 +60,13 @@ static int cmd_auth_pincode(const struct shell *sh,
 
 	if (!conn) {
 		shell_print(sh, "Not connected");
-		return 0;
+		return -ENOEXEC;
 	}
 
 	if (strlen(argv[1]) > max) {
 		shell_print(sh, "PIN code value invalid - enter max %u "
 			    "digits", max);
-		return 0;
+		return -ENOEXEC;
 	}
 
 	shell_print(sh, "PIN code \"%s\" applied", argv[1]);
@@ -91,6 +91,7 @@ static int cmd_connect(const struct shell *sh, size_t argc, char *argv[])
 	conn = bt_conn_create_br(&addr, BT_BR_CONN_PARAM_DEFAULT);
 	if (!conn) {
 		shell_print(sh, "Connection failed");
+		return -ENOEXEC;
 	} else {
 
 		shell_print(sh, "Connection pending");
@@ -187,14 +188,14 @@ static int cmd_discovery(const struct shell *sh, size_t argc, char *argv[])
 					  ARRAY_SIZE(br_discovery_results),
 					  br_discovery_complete) < 0) {
 			shell_print(sh, "Failed to start discovery");
-			return 0;
+			return -ENOEXEC;
 		}
 
 		shell_print(sh, "Discovery started");
 	} else if (!strcmp(action, "off")) {
 		if (bt_br_discovery_stop()) {
 			shell_print(sh, "Failed to stop discovery");
-			return 0;
+			return -ENOEXEC;
 		}
 
 		shell_print(sh, "Discovery stopped");
@@ -268,7 +269,7 @@ static int cmd_l2cap_register(const struct shell *sh,
 {
 	if (br_server.psm) {
 		shell_print(sh, "Already registered");
-		return 0;
+		return -ENOEXEC;
 	}
 
 	br_server.psm = strtoul(argv[1], NULL, 16);
@@ -505,7 +506,7 @@ static int cmd_sdp_find_record(const struct shell *sh,
 
 	if (!default_conn) {
 		shell_print(sh, "Not connected");
-		return 0;
+		return -ENOEXEC;
 	}
 
 	action = argv[1];

--- a/subsys/bluetooth/host/classic/shell/bredr.c
+++ b/subsys/bluetooth/host/classic/shell/bredr.c
@@ -92,13 +92,12 @@ static int cmd_connect(const struct shell *sh, size_t argc, char *argv[])
 	if (!conn) {
 		shell_print(sh, "Connection failed");
 		return -ENOEXEC;
-	} else {
-
-		shell_print(sh, "Connection pending");
-
-		/* unref connection obj in advance as app user */
-		bt_conn_unref(conn);
 	}
+
+	shell_print(sh, "Connection pending");
+
+	/* unref connection obj in advance as app user */
+	bt_conn_unref(conn);
 
 	return 0;
 }
@@ -278,9 +277,9 @@ static int cmd_l2cap_register(const struct shell *sh,
 		shell_error(sh, "Unable to register psm");
 		br_server.psm = 0U;
 		return -ENOEXEC;
-	} else {
-		shell_print(sh, "L2CAP psm %u registered", br_server.psm);
 	}
+
+	shell_print(sh, "L2CAP psm %u registered", br_server.psm);
 
 	return 0;
 }
@@ -306,9 +305,9 @@ static int cmd_discoverable(const struct shell *sh,
 		shell_print(sh, "BR/EDR set/reset discoverable failed "
 			    "(err %d)", err);
 		return -ENOEXEC;
-	} else {
-		shell_print(sh, "BR/EDR set/reset discoverable done");
 	}
+
+	shell_print(sh, "BR/EDR set/reset discoverable done");
 
 	return 0;
 }
@@ -334,9 +333,9 @@ static int cmd_connectable(const struct shell *sh,
 		shell_print(sh, "BR/EDR set/rest connectable failed "
 			    "(err %d)", err);
 		return -ENOEXEC;
-	} else {
-		shell_print(sh, "BR/EDR set/reset connectable done");
 	}
+
+	shell_print(sh, "BR/EDR set/reset connectable done");
 
 	return 0;
 }
@@ -526,9 +525,9 @@ static int cmd_sdp_find_record(const struct shell *sh,
 	if (err) {
 		shell_error(sh, "SDP discovery failed: err %d", err);
 		return -ENOEXEC;
-	} else {
-		shell_print(sh, "SDP discovery started");
 	}
+
+	shell_print(sh, "SDP discovery started");
 
 	return 0;
 }

--- a/subsys/bluetooth/host/classic/shell/bredr.c
+++ b/subsys/bluetooth/host/classic/shell/bredr.c
@@ -365,7 +365,7 @@ static uint8_t sdp_hfp_ag_user(struct bt_conn *conn,
 	char addr[BT_ADDR_STR_LEN];
 	uint16_t param, version;
 	uint16_t features;
-	int res;
+	int err;
 
 	conn_addr_str(conn, addr, sizeof(addr));
 
@@ -379,21 +379,21 @@ static uint8_t sdp_hfp_ag_user(struct bt_conn *conn,
 		 * Focus to get BT_SDP_ATTR_PROTO_DESC_LIST attribute item to
 		 * get HFPAG Server Channel Number operating on RFCOMM protocol.
 		 */
-		res = bt_sdp_get_proto_param(result->resp_buf,
+		err = bt_sdp_get_proto_param(result->resp_buf,
 					     BT_SDP_PROTO_RFCOMM, &param);
-		if (res < 0) {
+		if (err < 0) {
 			shell_error(ctx_shell, "Error getting Server CN, "
-				    "err %d", res);
+				    "err %d", err);
 			goto done;
 		}
 		shell_print(ctx_shell, "HFPAG Server CN param 0x%04x", param);
 
-		res = bt_sdp_get_profile_version(result->resp_buf,
+		err = bt_sdp_get_profile_version(result->resp_buf,
 						 BT_SDP_HANDSFREE_SVCLASS,
 						 &version);
-		if (res < 0) {
+		if (err < 0) {
 			shell_error(ctx_shell, "Error getting profile version, "
-				    "err %d", res);
+				    "err %d", err);
 			goto done;
 		}
 		shell_print(ctx_shell, "HFP version param 0x%04x", version);
@@ -402,10 +402,10 @@ static uint8_t sdp_hfp_ag_user(struct bt_conn *conn,
 		 * Focus to get BT_SDP_ATTR_SUPPORTED_FEATURES attribute item to
 		 * get profile Supported Features mask.
 		 */
-		res = bt_sdp_get_features(result->resp_buf, &features);
-		if (res < 0) {
+		err = bt_sdp_get_features(result->resp_buf, &features);
+		if (err < 0) {
 			shell_error(ctx_shell, "Error getting HFPAG Features, "
-				    "err %d", res);
+				    "err %d", err);
 			goto done;
 		}
 		shell_print(ctx_shell, "HFPAG Supported Features param 0x%04x",
@@ -424,7 +424,7 @@ static uint8_t sdp_a2src_user(struct bt_conn *conn,
 	char addr[BT_ADDR_STR_LEN];
 	uint16_t param, version;
 	uint16_t features;
-	int res;
+	int err;
 
 	conn_addr_str(conn, addr, sizeof(addr));
 
@@ -438,11 +438,11 @@ static uint8_t sdp_a2src_user(struct bt_conn *conn,
 		 * Focus to get BT_SDP_ATTR_PROTO_DESC_LIST attribute item to
 		 * get A2SRC Server PSM Number.
 		 */
-		res = bt_sdp_get_proto_param(result->resp_buf,
+		err = bt_sdp_get_proto_param(result->resp_buf,
 					     BT_SDP_PROTO_L2CAP, &param);
-		if (res < 0) {
+		if (err < 0) {
 			shell_error(ctx_shell, "A2SRC PSM Number not found, "
-				    "err %d", res);
+				    "err %d", err);
 			goto done;
 		}
 
@@ -453,12 +453,12 @@ static uint8_t sdp_a2src_user(struct bt_conn *conn,
 		 * Focus to get BT_SDP_ATTR_PROFILE_DESC_LIST attribute item to
 		 * get profile version number.
 		 */
-		res = bt_sdp_get_profile_version(result->resp_buf,
+		err = bt_sdp_get_profile_version(result->resp_buf,
 						 BT_SDP_ADVANCED_AUDIO_SVCLASS,
 						 &version);
-		if (res < 0) {
+		if (err < 0) {
 			shell_error(ctx_shell, "A2SRC version not found, "
-				    "err %d", res);
+				    "err %d", err);
 			goto done;
 		}
 		shell_print(ctx_shell, "A2SRC version param 0x%04x", version);
@@ -467,10 +467,10 @@ static uint8_t sdp_a2src_user(struct bt_conn *conn,
 		 * Focus to get BT_SDP_ATTR_SUPPORTED_FEATURES attribute item to
 		 * get profile supported features mask.
 		 */
-		res = bt_sdp_get_features(result->resp_buf, &features);
-		if (res < 0) {
+		err = bt_sdp_get_features(result->resp_buf, &features);
+		if (err < 0) {
 			shell_error(ctx_shell, "A2SRC Features not found, "
-				    "err %d", res);
+				    "err %d", err);
 			goto done;
 		}
 		shell_print(ctx_shell, "A2SRC Supported Features param 0x%04x",
@@ -500,7 +500,7 @@ static struct bt_sdp_discover_params discov;
 static int cmd_sdp_find_record(const struct shell *sh,
 			       size_t argc, char *argv[])
 {
-	int res;
+	int err;
 	const char *action;
 
 	if (!default_conn) {
@@ -521,9 +521,9 @@ static int cmd_sdp_find_record(const struct shell *sh,
 
 	shell_print(sh, "SDP UUID \'%s\' gets applied", action);
 
-	res = bt_sdp_discover(default_conn, &discov);
-	if (res) {
-		shell_error(sh, "SDP discovery failed: result %d", res);
+	err = bt_sdp_discover(default_conn, &discov);
+	if (err) {
+		shell_error(sh, "SDP discovery failed: err %d", err);
 		return -ENOEXEC;
 	} else {
 		shell_print(sh, "SDP discovery started");


### PR DESCRIPTION
Change `int res` to `int err`.

Return error code if the command is failed instead of `0`.

Return `SHELL_CMD_HELP_PRINTED` if `shell_help` is called.

Remove duplicate `else` statement if the function is returned from corresponding `if` statement.