### PR TITLE
MAINTAINERS: Remove sjanc from Bluetooth Classic group

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -496,7 +496,6 @@ Bluetooth Classic:
     - lylezhu2012
   collaborators:
     - jhedberg
-    - sjanc
   files:
     - subsys/bluetooth/common/
     - subsys/bluetooth/host/classic/


### PR DESCRIPTION
sjanc is not working on BT Classic and shouldn't be assigned as reviewer for those.