### PR TITLE
boards: stm32l562e_dk: add support for touchscreen

### DIFF
--- a/boards/st/stm32l562e_dk/Kconfig.defconfig
+++ b/boards/st/stm32l562e_dk/Kconfig.defconfig
@@ -42,4 +42,14 @@ config COMMON_LIBC_MALLOC_ARENA_SIZE
 
 endif # BUILD_WITH_TFM
 
+config INPUT
+	default y if LVGL
+
+if INPUT
+
+config INPUT_FT5336_INTERRUPT
+	default y
+
+endif # INPUT
+
 endif # BOARD_STM32L562E_DK

--- a/boards/st/stm32l562e_dk/doc/index.rst
+++ b/boards/st/stm32l562e_dk/doc/index.rst
@@ -153,6 +153,9 @@ hardware features:
 +-----------+------------+-------------------------------------+
 | DAC       | on-chip    | DAC Controller                      |
 +-----------+------------+-------------------------------------+
+| DISPLAY   | on-chip    | TFT LCD screen with st7789v driver  |
+|           |            | and touch panel with ft5336 driver  |
++-----------+------------+-------------------------------------+
 | DMA       | on-chip    | Direct Memory Access                |
 +-----------+------------+-------------------------------------+
 | GPIO      | on-chip    | gpio                                |
@@ -273,6 +276,16 @@ Serial Port
 STM32L562E-DK Discovery board has 6 U(S)ARTs. The Zephyr console output is
 assigned to USART1. Default settings are 115200 8N1.
 
+TFT LCD screen and touch panel
+------------------------------
+
+The TFT LCD screen and touch panel are supported for the STM32L562E-DK Discovery board.
+They can be tested using :zephyr:code-sample:`lvgl` sample:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/subsys/display/lvgl
+   :board: stm32l562e_dk
+   :goals: build
 
 Programming and Debugging
 *************************

--- a/boards/st/stm32l562e_dk/stm32l562e_dk_common.dtsi
+++ b/boards/st/stm32l562e_dk/stm32l562e_dk_common.dtsi
@@ -42,6 +42,12 @@
 	chosen {
 		zephyr,bt-hci = &hci_spi;
 	};
+
+	lvgl_pointer {
+		compatible = "zephyr,lvgl-pointer-input";
+		input = <&ft5336>;
+		invert-y;
+	};
 };
 
 &fmc {
@@ -176,6 +182,13 @@ stm32_lp_tick_source: &lptim1 {
 		compatible = "st,lsm6dso";
 		reg = <0x6a>;
 		irq-gpios = <&gpiof 3 GPIO_ACTIVE_HIGH>;
+	};
+
+	ft5336: ft5336@38 {
+		compatible = "focaltech,ft5336";
+		reg = <0x38>;
+		int-gpios = <&gpiof 1 GPIO_ACTIVE_LOW>;
+		reset-gpios = <&gpiof 15 GPIO_ACTIVE_LOW>;
 	};
 };
 


### PR DESCRIPTION
The stm32l562e_dk board uses a ft6x06 i2c controller for the touchscreen. The zephyr driver ft5336 can control it.