### PR TITLE
boards: st: fix spi warning

### DIFF
--- a/boards/st/b_l4s5i_iot01a/pre_dt_board.cmake
+++ b/boards/st/b_l4s5i_iot01a/pre_dt_board.cmake
@@ -1,0 +1,3 @@
+
+# SPI is implemented via octospi so node name isn't spi@...
+list(APPEND EXTRA_DTC_FLAGS "-Wno-spi_bus_bridge")

--- a/boards/st/stm32h573i_dk/pre_dt_board.cmake
+++ b/boards/st/stm32h573i_dk/pre_dt_board.cmake
@@ -1,0 +1,3 @@
+
+# SPI is implemented via octospi so node name isn't spi@...
+list(APPEND EXTRA_DTC_FLAGS "-Wno-spi_bus_bridge")

--- a/boards/st/stm32h735g_disco/pre_dt_board.cmake
+++ b/boards/st/stm32h735g_disco/pre_dt_board.cmake
@@ -1,0 +1,3 @@
+
+# SPI is implemented via octospi so node name isn't spi@...
+list(APPEND EXTRA_DTC_FLAGS "-Wno-spi_bus_bridge")

--- a/boards/st/stm32l4r9i_disco/pre_dt_board.cmake
+++ b/boards/st/stm32l4r9i_disco/pre_dt_board.cmake
@@ -1,0 +1,3 @@
+
+# SPI is implemented via octospi so node name isn't spi@...
+list(APPEND EXTRA_DTC_FLAGS "-Wno-spi_bus_bridge")

--- a/boards/st/stm32l562e_dk/pre_dt_board.cmake
+++ b/boards/st/stm32l562e_dk/pre_dt_board.cmake
@@ -1,0 +1,3 @@
+
+# SPI is implemented via octospi so node name isn't spi@...
+list(APPEND EXTRA_DTC_FLAGS "-Wno-spi_bus_bridge")


### PR DESCRIPTION
Some boards use the octospi interface. This raises a DTC warning because the spi node is named octospi@ instead of spi@.