### PR TITLE
shell: backend: telnet: Don't assert if connection closed

### DIFF
--- a/subsys/shell/backends/shell_telnet.c
+++ b/subsys/shell/backends/shell_telnet.c
@@ -708,7 +708,12 @@ static int telnet_write(const struct shell_transport *transport,
 			err = telnet_send(true);
 			if (err != 0) {
 				*cnt = length;
-				return err;
+				if ((err == -ENOTCONN) || (err == -ENETDOWN)) {
+					LOG_ERR("Network disconnected, shutting down");
+				} else {
+					LOG_ERR("Error %d, shutting down", err);
+				}
+				return 0; /* Return 0 to not trigger ASSERT in shell_ops.c */
 			}
 		}
 


### PR DESCRIPTION
The code in shell_ops.c that calls telnet_write will assert if it returns non-zero. For a telnet shell it's normal that the network might disconnect unexpectedly, so that should not trigger an assert.

Fixes #67637

Link: https://github.com/zephyrproject-rtos/zephyr/issues/67637