### PR TITLE
tests: net: http_server: Add netif dependency

### DIFF
--- a/tests/net/lib/http_server/common/testcase.yaml
+++ b/tests/net/lib/http_server/common/testcase.yaml
@@ -1,4 +1,5 @@
 common:
+  depends_on: netif
   min_ram: 40
   tags:
     - net

--- a/tests/net/lib/http_server/core/testcase.yaml
+++ b/tests/net/lib/http_server/core/testcase.yaml
@@ -1,4 +1,5 @@
 common:
+  depends_on: netif
   min_ram: 80
   tags:
     - http

--- a/tests/net/lib/http_server/crime/testcase.yaml
+++ b/tests/net/lib/http_server/crime/testcase.yaml
@@ -1,4 +1,5 @@
 common:
+  depends_on: netif
   min_ram: 60
   tags:
     - http

--- a/tests/net/lib/http_server/tls/testcase.yaml
+++ b/tests/net/lib/http_server/tls/testcase.yaml
@@ -1,4 +1,5 @@
 common:
+  depends_on: netif
   min_ram: 192
   tags:
     - http


### PR DESCRIPTION
Some of the http_server tests suites were missing netif dependency.