### PR TITLE
boards: NXP: mimxrt1040: added counter as supported

### DIFF
--- a/boards/nxp/mimxrt1040_evk/doc/index.rst
+++ b/boards/nxp/mimxrt1040_evk/doc/index.rst
@@ -118,6 +118,8 @@ already supported, which can also be re-used on this mimxrt1040_evk board:
 +-----------+------------+-------------------------------------+
 | I2C       | on-chip    | i2c                                 |
 +-----------+------------+-------------------------------------+
+| GPT       | on-chip    | gpt                                 |
++-----------+------------+-------------------------------------+
 | DISPLAY   | on-chip    | eLCDIF. Tested with                 |
 |           |            | :ref:`rk043fn02h_ct`, and           |
 |           |            | :ref:`rk043fn66hs_ctg` shields      |

--- a/boards/nxp/mimxrt1040_evk/mimxrt1040_evk.yaml
+++ b/boards/nxp/mimxrt1040_evk/mimxrt1040_evk.yaml
@@ -21,4 +21,5 @@ supported:
   - adc
   - spi
   - i2c
+  - counter
 vendor: nxp


### PR DESCRIPTION
Mimxrt1040_ebk board was missing counter in the .yml file