### PR TITLE
samples: display: make display samples testable by twister

### DIFF
--- a/samples/drivers/display/sample.yaml
+++ b/samples/drivers/display/sample.yaml
@@ -17,6 +17,12 @@ tests:
       - CONFIG_SDL_DISPLAY=n
       - CONFIG_TEST=y
     tags: display
+    harness: console
+    harness_config:
+      fixture: fixture_display
+      type: one_line
+      regex:
+        - "Display sample for (.*)"
   sample.display.g1120b0mipi:
     platform_allow: mimxrt595_evk/mimxrt595s/cm33
     tags: display
@@ -26,8 +32,14 @@ tests:
       - CONFIG_PM=y
       - CONFIG_PM_DEVICE=y
       - CONFIG_IDLE_STACK_SIZE=400
+      - CONFIG_TEST=y
     harness_config:
-      fixture: fixture_display
+      fixture: fixture_display_g1120b0mipi
+      type: multi_line
+      regex:
+        - "sample: Display sample for (.*)"
+        - "Display starts"
+        - "Display sample test mode done (.*)"
   sample.display.builtin:
     # This test case is intended to insure that this sample builds & runs
     # correctly for all boards that have a supported built-in display.
@@ -57,6 +69,9 @@ tests:
     extra_args: SHIELD=rk043fn02h_ct
     harness_config:
       fixture: fixture_display
+      type: one_line
+      regex:
+        - "Display sample for (.*)"
   sample.display.shield:
     # This test case is intended to verify support for shields on boards
     # known to support them. It is not intended to cover all combinations
@@ -66,6 +81,9 @@ tests:
     harness: console
     harness_config:
       fixture: fixture_display
+      type: one_line
+      regex:
+        - "Display sample for (.*)"
     extra_args:
       - platform:lpcxpresso55s69/lpc55s69/cpu0:SHIELD=adafruit_2_8_tft_touch_v2
       - platform:nrf52840dk/nrf52840:SHIELD=ssd1306_128x32

--- a/samples/drivers/display/src/main.c
+++ b/samples/drivers/display/src/main.c
@@ -334,13 +334,15 @@ int main(void)
 	x = 0;
 	y = capabilities.y_resolution - rect_h;
 
+	LOG_INF("Display starts");
 	while (1) {
 		fill_buffer_fnc(BOTTOM_LEFT, grey_count, buf, buf_size);
 		display_write(display_dev, x, y, &buf_desc, buf);
 		++grey_count;
 		k_msleep(grey_scale_sleep);
 #if CONFIG_TEST
-		if (grey_count >= 1024) {
+		if (grey_count >= 30) {
+			LOG_INF("Display sample test mode done %s", display_dev->name);
 			break;
 		}
 #endif

--- a/samples/modules/lvgl/demos/boards/mimxrt595_evk_mimxrt595s_cm33.conf
+++ b/samples/modules/lvgl/demos/boards/mimxrt595_evk_mimxrt595s_cm33.conf
@@ -1,0 +1,10 @@
+#
+# Copyright 2024, NXP
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+# Sample will allocate buffer equal to: (panelwidth / 8) * (panelwidth / 4) * pixel depth. For a
+# 1280x720 display in a 16-bpp format (e.g. RGB565), this is (1280 / 8) * (720 / 4) * 2 = 57600
+# bytes. We include 128 bytes of padding for kernel heap structures
+CONFIG_HEAP_MEM_POOL_SIZE=57600

--- a/samples/modules/lvgl/demos/sample.yaml
+++ b/samples/modules/lvgl/demos/sample.yaml
@@ -4,13 +4,22 @@ sample:
 common:
   modules:
     - lvgl
-  harness: none
+  harness: console
   filter: dt_chosen_enabled("zephyr,display")
+  extra_args:
+    - platform:mimxrt1060_evk:SHIELD=rk043fn66hs_ctg
+    - platform:mimxrt1170_evk/mimxrt1176/cm7:SHIELD=rk055hdmipi4ma0
+    - platform:mimxrt595_evk/mimxrt595s/cm33:SHIELD=rk055hdmipi4ma0
   tags:
     - samples
     - display
     - lvgl
     - gui
+  harness_config:
+    fixture: fixture_display
+    type: one_line
+    regex:
+      - "\\[\\w+ free bytes, \\w+ allocated bytes, overhead = \\w+ bytes | lvgl in malloc mode\\]"
 tests:
   sample.modules.lvgl.demo_music:
     extra_configs:
@@ -24,6 +33,7 @@ tests:
   sample.modules.lvgl.demo_widgets:
     extra_configs:
       - CONFIG_LV_Z_DEMO_WIDGETS=y
+
   sample.modules.lvgl.demos.st_b_lcd40_dsi1_mb1166:
     filter: dt_compat_enabled("orisetech,otm8009a")
     platform_allow: stm32h747i_disco/stm32h747xx/m7

--- a/samples/modules/lvgl/demos/src/main.c
+++ b/samples/modules/lvgl/demos/src/main.c
@@ -7,7 +7,9 @@
 #include <zephyr/kernel.h>
 #include <zephyr/drivers/display.h>
 #include <lvgl.h>
+#include <lvgl_mem.h>
 #include <lv_demos.h>
+#include <stdio.h>
 
 #define LOG_LEVEL CONFIG_LOG_DEFAULT_LEVEL
 #include <zephyr/logging/log.h>
@@ -38,7 +40,11 @@ int main(void)
 
 	lv_task_handler();
 	display_blanking_off(display_dev);
-
+#ifdef CONFIG_LV_Z_MEM_POOL_SYS_HEAP
+	lvgl_print_heap_info(false);
+#else
+	printf("lvgl in malloc mode\n");
+#endif
 	while (1) {
 		k_msleep(lv_task_handler());
 	}

--- a/samples/subsys/display/lvgl/sample.yaml
+++ b/samples/subsys/display/lvgl/sample.yaml
@@ -40,6 +40,8 @@ tests:
       - mimxrt595_evk/mimxrt595s/cm33
     integration_platforms:
       - mimxrt1170_evk/mimxrt1176/cm7
+    harness_config:
+      fixture: fixture_display_rk055hdmipi4m
   sample.subsys.display.lvgl.st_b_lcd40_dsi1_mb1166:
     filter: dt_compat_enabled("orisetech,otm8009a")
     platform_allow: stm32h747i_disco/stm32h747xx/m7
@@ -80,7 +82,7 @@ tests:
     harness: console
     extra_args: SHIELD=rk043fn66hs_ctg
     harness_config:
-      fixture: fixture_display
+      fixture: fixture_display_rk043fn66hs_ctg
   samples.subsys.display.lvgl.rk043fn02h_ct:
     platform_allow:
       - mimxrt1064_evk
@@ -91,4 +93,4 @@ tests:
     harness: console
     extra_args: SHIELD=rk043fn02h_ct
     harness_config:
-      fixture: fixture_display
+      fixture: fixture_display_rk043fn02h_ct


### PR DESCRIPTION

The original samples can not checked by twister only build check. with this PR, the board run testing can be checked by twister, although it can not check the display content, we can check the log and ensure the data flow is running.