### PR TITLE
lib: libc: common: time: Add toolchain include

### DIFF
--- a/lib/libc/common/source/time/gmtime_r.c
+++ b/lib/libc/common/source/time/gmtime_r.c
@@ -10,6 +10,7 @@
  * http://howardhinnant.github.io/date_algorithms.html#civil_from_days
  */
 
+#include <zephyr/toolchain.h>
 #include <time.h>
 
 /* A signed type with the representation of time_t without its


### PR DESCRIPTION
This file uses something that is defined in the toolchain files, fix a build error by including that header