### PR TITLE
hostap: Use proper value when generating supplicant event

### DIFF
--- a/include/zephyr/net/wifi_mgmt.h
+++ b/include/zephyr/net/wifi_mgmt.h
@@ -288,6 +288,8 @@ enum net_event_wifi_cmd {
 	NET_EVENT_WIFI_CMD_AP_STA_CONNECTED,
 	/** STA disconnected from AP */
 	NET_EVENT_WIFI_CMD_AP_STA_DISCONNECTED,
+	/** Supplicant specific event */
+	NET_EVENT_WIFI_CMD_SUPPLICANT,
 };
 
 /** Event emitted for Wi-Fi scan result */

--- a/modules/hostap/src/supp_events.c
+++ b/modules/hostap/src/supp_events.c
@@ -386,7 +386,7 @@ int supplicant_send_wifi_mgmt_event(const char *ifname, enum net_event_wifi_cmd 
 				(struct wifi_ap_sta_info *)supplicant_status);
 		break;
 #endif /* CONFIG_AP */
-	case NET_EVENT_SUPPLICANT_CMD_INT_EVENT:
+	case NET_EVENT_WIFI_CMD_SUPPLICANT:
 		event_data.data = &data;
 		if (supplicant_process_status(&event_data, (char *)supplicant_status) > 0) {
 			net_mgmt_event_notify_with_info(NET_EVENT_SUPPLICANT_INT_EVENT,

--- a/west.yml
+++ b/west.yml
@@ -259,7 +259,7 @@ manifest:
         - hal
     - name: hostap
       path: modules/lib/hostap
-      revision: 9896a2ea803ec62e0998c0e569f12af88537d647
+      revision: f6792cb45d848df5d562dd9255dfc6acf62be164
     - name: libmetal
       revision: a6851ba6dba8c9e87d00c42f171a822f7a29639b
       path: modules/hal/libmetal


### PR DESCRIPTION
The previous NET_EVENT_SUPPLICANT_CMD_INT_EVENT is from "enum net_event_supplicant_cmd" but the supplicant_send_wifi_mgmt_event() has the event parameter as an "enum net_event_wifi_cmd" and those event number spaces are different.

This meant that the wrong event value NET_EVENT_SUPPLICANT_CMD_INT_EVENT maps to NET_EVENT_WIFI_CMD_TWT (from "enum net_event_wifi_cmd") which fortunately did not cause issue in this case because the supplicant_send_wifi_mgmt_event() has no handling for this TWT event value.

It is important we fix this as this can cause great confusion in the future.
