### PR TITLE
Bluetooth: BAP: Modify unicast client callbacks to slist

### DIFF
--- a/doc/releases/migration-guide-4.0.rst
+++ b/doc/releases/migration-guide-4.0.rst
@@ -301,6 +301,10 @@ Bluetooth Audio
   is enabled and that all members are bonded, to comply with the requirements from the CSIP spec.
   (:github:`78877`)
 
+* The callback structure provided to :c:func:`bt_bap_unicast_client_register_cb` is no longer
+  :code:`const`, and now multiple callback structures can be registered.
+  (:github:`78999`)
+
 * The Broadcast Audio Scan Service (BASS) shall now be registered and unregistered dynamically
   at runtime within the scan delegator. Two new APIs, :c:func:`bt_bap_scan_delegator_register()`
   and :c:func:`bt_bap_scan_delegator_unregister()`, have been introduced to manage both BASS and

--- a/include/zephyr/bluetooth/audio/bap.h
+++ b/include/zephyr/bluetooth/audio/bap.h
@@ -1712,6 +1712,11 @@ struct bt_bap_unicast_client_cb {
 	 * If discovery procedure has complete both @p codec and @p ep are set to NULL.
 	 */
 	void (*discover)(struct bt_conn *conn, int err, enum bt_audio_dir dir);
+
+	/** @cond INTERNAL_HIDDEN */
+	/** Internally used field for list handling */
+	sys_snode_t _node;
+	/** @endcond */
 };
 
 /**
@@ -1722,9 +1727,11 @@ struct bt_bap_unicast_client_cb {
  *
  * @param cb  Unicast client callback structure.
  *
- * @return 0 in case of success or negative value in case of error.
+ * @retval 0 Success
+ * @retval -EINVAL @p cb is NULL.
+ * @retval -EEXIST @p cb is already registered.
  */
-int bt_bap_unicast_client_register_cb(const struct bt_bap_unicast_client_cb *cb);
+int bt_bap_unicast_client_register_cb(struct bt_bap_unicast_client_cb *cb);
 
 /**
  * @brief Discover remote capabilities and endpoints

--- a/tests/bsim/bluetooth/audio/src/cap_initiator_unicast_test.c
+++ b/tests/bsim/bluetooth/audio/src/cap_initiator_unicast_test.c
@@ -349,7 +349,7 @@ static void endpoint_cb(struct bt_conn *conn, enum bt_audio_dir dir, struct bt_b
 	}
 }
 
-static const struct bt_bap_unicast_client_cb unicast_client_cbs = {
+static struct bt_bap_unicast_client_cb unicast_client_cbs = {
 	.discover = discover_cb,
 	.pac_record = pac_record_cb,
 	.endpoint = endpoint_cb,


### PR DESCRIPTION
Modify the BAP unicast client callback structure to be a linked list. The purpose of this is to have multiple listeners of the unicast client changes and notifications.
This is needed for the CAP initiatior.