### PR TITLE
usb: device_next: usbd_hid: Fix size in HID report get

### DIFF
--- a/subsys/usb/device_next/class/usbd_hid.c
+++ b/subsys/usb/device_next/class/usbd_hid.c
@@ -235,7 +235,7 @@ static int handle_get_report(const struct device *dev,
 	const uint8_t id = HID_GET_REPORT_ID(setup->wValue);
 	struct hid_device_data *const ddata = dev->data;
 	const struct hid_device_ops *ops = ddata->ops;
-	const size_t size = net_buf_tailroom(buf);
+	const size_t size = setup->wLength;
 	int ret = 0;
 
 	switch (type) {
@@ -257,8 +257,9 @@ static int handle_get_report(const struct device *dev,
 	}
 
 	if (ret > 0) {
-		__ASSERT(ret <= size, "Buffer overflow in the HID driver");
-		net_buf_add(buf, MIN(size, ret));
+		__ASSERT(ret <= net_buf_tailroom(buf),
+			 "Buffer overflow in the HID driver");
+		net_buf_add(buf, MIN(net_buf_tailroom(buf), ret));
 	} else {
 		errno = ret ? ret : -ENOTSUP;
 	}


### PR DESCRIPTION
Since UDC buffers are allocated with `UDC_BUF_GRANULARITY` granularity, the `net_buf_tailroom` may no longer be equal to the HID report size. Use `setup->wLength` instead to ensure that proper HID report size is passed to the application's callback.