### PR TITLE
Bluetooth: Controller: add missing param. update in conn. param reply

### DIFF
--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -2535,9 +2535,8 @@ static void le_conn_update(struct net_buf *buf, struct net_buf **evt)
 	conn_latency = sys_le16_to_cpu(cmd->conn_latency);
 	supervision_timeout = sys_le16_to_cpu(cmd->supervision_timeout);
 
-	status = ll_conn_update(handle, 0, 0, conn_interval_min,
-				conn_interval_max, conn_latency,
-				supervision_timeout, NULL);
+	status = ll_conn_update(handle, conn_interval_min, conn_interval_max,
+				conn_latency, supervision_timeout, NULL);
 
 	*evt = cmd_status(status);
 }
@@ -2549,6 +2548,8 @@ static void le_conn_param_req_reply(struct net_buf *buf, struct net_buf **evt)
 	struct bt_hci_rp_le_conn_param_req_reply *rp;
 	uint16_t interval_min;
 	uint16_t interval_max;
+	uint16_t min_ce_len;
+	uint16_t max_ce_len;
 	uint16_t latency;
 	uint16_t timeout;
 	uint16_t handle;
@@ -2557,11 +2558,13 @@ static void le_conn_param_req_reply(struct net_buf *buf, struct net_buf **evt)
 	handle = sys_le16_to_cpu(cmd->handle);
 	interval_min = sys_le16_to_cpu(cmd->interval_min);
 	interval_max = sys_le16_to_cpu(cmd->interval_max);
+	min_ce_len = sys_le16_to_cpu(cmd->min_ce_len);
+	max_ce_len = sys_le16_to_cpu(cmd->max_ce_len);
 	latency = sys_le16_to_cpu(cmd->latency);
 	timeout = sys_le16_to_cpu(cmd->timeout);
 
-	status = ll_conn_update(handle, 2, 0, interval_min, interval_max,
-				latency, timeout, NULL);
+	status = ll_conn_update_reply(handle, 0, interval_min, interval_max,
+				latency, timeout, min_ce_len, max_ce_len);
 
 	rp = hci_cmd_complete(evt, sizeof(*rp));
 	rp->status = status;
@@ -2577,7 +2580,7 @@ static void le_conn_param_req_neg_reply(struct net_buf *buf,
 	uint8_t status;
 
 	handle = sys_le16_to_cpu(cmd->handle);
-	status = ll_conn_update(handle, 2, cmd->reason, 0, 0, 0, 0, NULL);
+	status = ll_conn_update_reply(handle, cmd->reason, 0, 0, 0, 0, 0, 0);
 
 	rp = hci_cmd_complete(evt, sizeof(*rp));
 	rp->status = status;
@@ -8742,8 +8745,8 @@ static void le_conn_param_req(struct pdu_data *pdu_data, uint16_t handle,
 	if (!(event_mask & BT_EVT_MASK_LE_META_EVENT) ||
 	    !(le_event_mask & BT_EVT_MASK_LE_CONN_PARAM_REQ)) {
 		/* event masked, reject the conn param req */
-		ll_conn_update(handle, 2, BT_HCI_ERR_UNSUPP_REMOTE_FEATURE, 0,
-			       0, 0, 0, NULL);
+		ll_conn_update_reply(handle, BT_HCI_ERR_UNSUPP_REMOTE_FEATURE, 0,
+				     0, 0, 0, 0, 0);
 
 		return;
 	}

--- a/subsys/bluetooth/controller/include/ll.h
+++ b/subsys/bluetooth/controller/include/ll.h
@@ -239,8 +239,11 @@ uint8_t ll_create_connection(uint16_t scan_interval, uint16_t scan_window,
 			  uint16_t interval, uint16_t latency, uint16_t timeout);
 #endif /* !CONFIG_BT_CTLR_ADV_EXT */
 uint8_t ll_connect_disable(void **rx);
-uint8_t ll_conn_update(uint16_t handle, uint8_t cmd, uint8_t status, uint16_t interval_min,
-		    uint16_t interval_max, uint16_t latency, uint16_t timeout, uint16_t *offset);
+uint8_t ll_conn_update(uint16_t handle, uint16_t interval_min, uint16_t interval_max,
+		       uint16_t latency, uint16_t timeout, uint16_t *offset);
+uint8_t ll_conn_update_reply(uint16_t handle, uint8_t status,
+			   uint16_t interval_min, uint16_t interval_max, uint16_t latency,
+			   uint16_t timeout, uint16_t min_ce_len, uint16_t max_ce_len);
 uint8_t ll_chm_update(uint8_t const *const chm);
 uint8_t ll_chm_get(uint16_t handle, uint8_t *const chm);
 uint8_t ll_enc_req_send(uint16_t handle, uint8_t const *const rand_num, uint8_t const *const ediv,

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -283,46 +283,42 @@ int ll_tx_mem_enqueue(uint16_t handle, void *tx)
 	return 0;
 }
 
-uint8_t ll_conn_update(uint16_t handle, uint8_t cmd, uint8_t status, uint16_t interval_min,
-		    uint16_t interval_max, uint16_t latency, uint16_t timeout, uint16_t *offset)
+uint8_t ll_conn_update(uint16_t handle, uint16_t interval_min, uint16_t interval_max,
+		       uint16_t latency, uint16_t timeout, uint16_t *offset)
 {
+	uint8_t err = BT_HCI_ERR_UNKNOWN_CONN_ID;
 	struct ll_conn *conn;
 
 	conn = ll_connected_get(handle);
-	if (!conn) {
-		return BT_HCI_ERR_UNKNOWN_CONN_ID;
-	}
-
-	if (cmd == 0U) {
-		uint8_t err;
-
+	if (conn) {
 		err = ull_cp_conn_update(conn, interval_min, interval_max, latency, timeout,
 					 offset);
-		if (err) {
-			return err;
-		}
 
-		if (IS_ENABLED(CONFIG_BT_PERIPHERAL) &&
-		    conn->lll.role) {
+		if (!err && IS_ENABLED(CONFIG_BT_PERIPHERAL) && conn->lll.role) {
 			ull_periph_latency_cancel(conn, handle);
 		}
-	} else if (cmd == 2U) {
-#if defined(CONFIG_BT_CTLR_CONN_PARAM_REQ)
-		if (status == 0U) {
-			ull_cp_conn_param_req_reply(conn);
-		} else {
-			ull_cp_conn_param_req_neg_reply(conn, status);
-		}
-		return BT_HCI_ERR_SUCCESS;
-#else /* !CONFIG_BT_CTLR_CONN_PARAM_REQ */
-		/* CPR feature not supported */
-		return BT_HCI_ERR_CMD_DISALLOWED;
-#endif /* !CONFIG_BT_CTLR_CONN_PARAM_REQ */
-	} else {
-		return BT_HCI_ERR_UNKNOWN_CMD;
 	}
 
-	return 0;
+	return err;
+}
+
+uint8_t ll_conn_update_reply(uint16_t handle, uint8_t status,
+			     uint16_t interval_min, uint16_t interval_max,
+			     uint16_t latency, uint16_t timeout,
+			     uint16_t min_ce_len, uint16_t max_ce_len)
+{
+	uint8_t ret = BT_HCI_ERR_UNKNOWN_CONN_ID;
+	struct ll_conn *conn;
+
+	conn = ll_connected_get(handle);
+	if (conn) {
+		ret = ull_cp_conn_param_req_reply(conn, status,
+					    interval_min, interval_max,
+					    latency, timeout,
+					    min_ce_len, max_ce_len);
+	}
+
+	return ret;
 }
 
 uint8_t ll_chm_get(uint16_t handle, uint8_t *chm)

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp.c
@@ -1030,28 +1030,36 @@ uint8_t ull_cp_remote_dle_pending(struct ll_conn *conn)
 }
 #endif /* CONFIG_BT_CTLR_DATA_LENGTH */
 
+uint8_t ull_cp_conn_param_req_reply(struct ll_conn *conn, uint8_t status,
+				  uint16_t interval_min, uint16_t interval_max, uint16_t latency,
+				  uint16_t timeout, uint16_t min_ce_len, uint16_t max_ce_len)
+{
+	ARG_UNUSED(min_ce_len);
+	ARG_UNUSED(max_ce_len);
+	uint8_t ret = BT_HCI_ERR_CMD_DISALLOWED;
 #if defined(CONFIG_BT_CTLR_CONN_PARAM_REQ)
-void ull_cp_conn_param_req_reply(struct ll_conn *conn)
-{
 	struct proc_ctx *ctx;
 
 	ctx = llcp_rr_peek(conn);
 	if (ctx && ctx->proc == PROC_CONN_PARAM_REQ) {
-		llcp_rp_conn_param_req_reply(conn, ctx);
+		if (status) {
+			ctx->data.cu.error = status;
+			llcp_rp_conn_param_req_neg_reply(conn, ctx);
+		} else {
+			ctx->data.cu.interval_min = interval_min;
+			ctx->data.cu.interval_max = interval_max;
+			ctx->data.cu.latency = latency;
+			ctx->data.cu.timeout = timeout;
+			llcp_rp_conn_param_req_reply(conn, ctx);
+		}
+		ret = BT_HCI_ERR_SUCCESS;
 	}
+#endif
+
+	return ret;
 }
 
-void ull_cp_conn_param_req_neg_reply(struct ll_conn *conn, uint8_t error_code)
-{
-	struct proc_ctx *ctx;
-
-	ctx = llcp_rr_peek(conn);
-	if (ctx && ctx->proc == PROC_CONN_PARAM_REQ) {
-		ctx->data.cu.error = error_code;
-		llcp_rp_conn_param_req_neg_reply(conn, ctx);
-	}
-}
-
+#if defined(CONFIG_BT_CTLR_CONN_PARAM_REQ)
 uint8_t ull_cp_remote_cpr_pending(struct ll_conn *conn)
 {
 	struct proc_ctx *ctx;

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp.h
@@ -129,14 +129,13 @@ uint8_t ull_cp_conn_update(struct ll_conn *conn, uint16_t interval_min, uint16_t
 			   uint16_t latency, uint16_t timeout, uint16_t *offsets);
 
 /**
- * @brief Accept the remote device’s request to change connection parameters.
+ * @brief Accept/decline the remote device’s request to change
+ *        connection parameters possibly requesting updated
+ *        parameters.
  */
-void ull_cp_conn_param_req_reply(struct ll_conn *conn);
-
-/**
- * @brief Reject the remote device’s request to change connection parameters.
- */
-void ull_cp_conn_param_req_neg_reply(struct ll_conn *conn, uint8_t error_code);
+uint8_t ull_cp_conn_param_req_reply(struct ll_conn *conn, uint8_t status,
+				  uint16_t interval_min, uint16_t interval_max, uint16_t latency,
+				  uint16_t timeout, uint16_t min_ce_len, uint16_t max_ce_len);
 
 /**
  * @brief Check if a remote data length update is in the works.

--- a/tests/bluetooth/controller/ctrl_conn_update/src/main.c
+++ b/tests/bluetooth/controller/ctrl_conn_update/src/main.c
@@ -1376,16 +1376,18 @@ ZTEST(central_rem, test_conn_update_central_rem_accept)
 
 	/*******************/
 
-	ull_cp_conn_param_req_reply(&conn);
+	ull_cp_conn_param_req_reply(&conn, 0,
+				    conn_param_req_B.interval_min, conn_param_req_B.interval_max,
+				    conn_param_req_B.latency, conn_param_req_B.timeout, 0, 0);
 
 	/*******************/
 
 	/* Prepare */
 	event_prepare(&conn);
 
-	/* Tx Queue should have one LL Control PDU */
-	conn_update_ind.instant = event_counter(&conn) + 6U;
-	lt_rx(LL_CONNECTION_UPDATE_IND, &conn, &tx, &conn_update_ind);
+	/* Tx Queue should have one LL Control PDU,  */
+	conn_update_ind_B.instant = event_counter(&conn) + 6U;
+	lt_rx(LL_CONNECTION_UPDATE_IND, &conn, &tx, &conn_update_ind_B);
 	lt_rx_q_is_empty(&conn);
 
 	/* Done */
@@ -1548,7 +1550,7 @@ ZTEST(central_rem, test_conn_update_central_rem_reject)
 
 	/*******************/
 
-	ull_cp_conn_param_req_neg_reply(&conn, BT_HCI_ERR_UNACCEPT_CONN_PARAM);
+	ull_cp_conn_param_req_reply(&conn, BT_HCI_ERR_UNACCEPT_CONN_PARAM, 0, 0, 0, 0, 0, 0);
 
 	/*******************/
 
@@ -1688,7 +1690,9 @@ ZTEST(central_rem, test_conn_update_central_rem_collision)
 	/*******************/
 
 	/* (A) */
-	ull_cp_conn_param_req_reply(&conn);
+	ull_cp_conn_param_req_reply(&conn, 0,
+				    conn_param_req.interval_min, conn_param_req.interval_max,
+				    conn_param_req.latency, conn_param_req.timeout, 0, 0);
 
 	/*******************/
 
@@ -2239,7 +2243,9 @@ ZTEST(periph_loc, test_conn_update_periph_loc_collision)
 	/*******************/
 
 	/* (B) */
-	ull_cp_conn_param_req_reply(&conn);
+	ull_cp_conn_param_req_reply(&conn, 0,
+				    req_B->interval_min, req_B->interval_max,
+				    req_B->latency, req_B->timeout, 0, 0);
 
 	/*******************/
 
@@ -2380,7 +2386,9 @@ ZTEST(periph_rem, test_conn_update_periph_rem_accept)
 
 	/*******************/
 
-	ull_cp_conn_param_req_reply(&conn);
+	ull_cp_conn_param_req_reply(&conn, 0,
+				    conn_param_req.interval_min, conn_param_req.interval_max,
+				    conn_param_req.latency, conn_param_req.timeout, 0, 0);
 
 	/*******************/
 
@@ -3218,7 +3226,9 @@ ZTEST(periph_loc, test_conn_update_periph_loc_collision_reject_2nd_cpr)
 	/*******************/
 
 	/* (B) */
-	ull_cp_conn_param_req_reply(&conn);
+	ull_cp_conn_param_req_reply(&conn, 0,
+				    req_B->interval_min, req_B->interval_max,
+				    req_B->latency, req_B->timeout, 0, 0);
 
 	/*******************/
 
@@ -3491,7 +3501,9 @@ ZTEST(periph_rem, test_conn_update_periph_rem_accept_reject_2nd_cpr)
 
 	/*******************/
 
-	ull_cp_conn_param_req_reply(&conn);
+	ull_cp_conn_param_req_reply(&conn, 0,
+				    conn_param_req.interval_min, conn_param_req.interval_max,
+				    conn_param_req.latency, conn_param_req.timeout, 0, 0);
 
 	{
 		/* Initiate a parallel local Connection Parameter Request Procedure */
@@ -3724,7 +3736,9 @@ ZTEST(periph_rem, test_conn_update_periph_rem_invalid_ind)
 
 	/*******************/
 
-	ull_cp_conn_param_req_reply(&conn);
+	ull_cp_conn_param_req_reply(&conn, 0,
+				    conn_param_req.interval_min, conn_param_req.interval_max,
+				    conn_param_req.latency, conn_param_req.timeout, 0, 0);
 
 	/*******************/
 
@@ -3785,7 +3799,9 @@ ZTEST(periph_rem, test_conn_update_periph_rem_invalid_ind)
 
 	/*******************/
 
-	ull_cp_conn_param_req_reply(&conn);
+	ull_cp_conn_param_req_reply(&conn, 0,
+				    conn_param_req.interval_min, conn_param_req.interval_max,
+				    conn_param_req.latency, conn_param_req.timeout, 0, 0);
 
 	/*******************/
 
@@ -3847,7 +3863,9 @@ ZTEST(periph_rem, test_conn_update_periph_rem_invalid_ind)
 
 	/*******************/
 
-	ull_cp_conn_param_req_reply(&conn);
+	ull_cp_conn_param_req_reply(&conn, 0,
+				    conn_param_req.interval_min, conn_param_req.interval_max,
+				    conn_param_req.latency, conn_param_req.timeout, 0, 0);
 
 	/*******************/
 
@@ -3946,7 +3964,7 @@ ZTEST(periph_rem, test_conn_update_periph_rem_reject)
 
 	/*******************/
 
-	ull_cp_conn_param_req_neg_reply(&conn, BT_HCI_ERR_UNACCEPT_CONN_PARAM);
+	ull_cp_conn_param_req_reply(&conn, BT_HCI_ERR_UNACCEPT_CONN_PARAM, 0, 0, 0, 0, 0, 0);
 
 	/*******************/
 
@@ -4086,7 +4104,9 @@ ZTEST(periph_rem, test_conn_update_periph_rem_collision)
 	/*******************/
 
 	/* (A) */
-	ull_cp_conn_param_req_reply(&conn);
+	ull_cp_conn_param_req_reply(&conn, 0,
+				    conn_param_req.interval_min, conn_param_req.interval_max,
+				    conn_param_req.latency, conn_param_req.timeout, 0, 0);
 
 	/*******************/
 
@@ -4336,7 +4356,9 @@ ZTEST(periph_rem, test_conn_update_periph_rem_late_collision)
 	lt_tx(LL_REJECT_EXT_IND, &conn, &reject_ext_ind);
 
 	/* (A) */
-	ull_cp_conn_param_req_reply(&conn);
+	ull_cp_conn_param_req_reply(&conn, 0,
+				    conn_param_req.interval_min, conn_param_req.interval_max,
+				    conn_param_req.latency, conn_param_req.timeout, 0, 0);
 
 	/*******************/
 


### PR DESCRIPTION
During LLCP refactoring code to handle updates to parameters on reply to connection update request was left out.
Adding this back as well as refactoring the controller api for handling this.