### PR TITLE
drivers/pinctrl.h: Resolve PINCTRL_DT_STATE_INIT Cpp Compatibility

### DIFF
--- a/include/zephyr/drivers/pinctrl.h
+++ b/include/zephyr/drivers/pinctrl.h
@@ -414,9 +414,9 @@ static inline int pinctrl_apply_state(const struct pinctrl_dev_config *config,
  */
 #define PINCTRL_DT_STATE_INIT(prop, state)				       \
 	{								       \
-		.id = state,						       \
 		.pins = prop ## _pins,					       \
-		.pin_cnt = ARRAY_SIZE(prop ## _pins)			       \
+		.pin_cnt = ARRAY_SIZE(prop ## _pins),			       \
+		.id = state						       \
 	}
 
 /**


### PR DESCRIPTION
This commit adds C++20 onwards support for the PINCTRL_DT_STATE_INIT macro. Since C++20, support was added for designated initializers but with the restriction that they're ordered. PINCTRL_DT_STATE_INIT initializes a pinctrl_state struct but the current initializer list is un-ordered, this PR resolves that for >= C++20 compat.