### PR TITLE
i2c_smartbond: Don't set STOP flag to last message

### DIFF
--- a/drivers/i2c/i2c_smartbond.c
+++ b/drivers/i2c/i2c_smartbond.c
@@ -247,8 +247,6 @@ static inline int i2c_smartbond_set_msg_flags(struct i2c_msg *msgs, uint8_t num_
 			if (current->flags & I2C_MSG_STOP) {
 				return -EINVAL;
 			}
-		} else {
-			current->flags |= I2C_MSG_STOP;
 		}
 		current++;
 	}


### PR DESCRIPTION
Setting STOP flag to last message it's done by z_impl_i2c_transfer().