### PR TITLE
net: Give name to logging choice

### DIFF
--- a/subsys/net/Kconfig.template.log_config.net
+++ b/subsys/net/Kconfig.template.log_config.net
@@ -4,7 +4,7 @@
 # Copyright (c) 2018 Intel Corporation.
 # SPDX-License-Identifier: Apache-2.0
 
-choice
+choice "$(module)_LOG_LEVEL_CHOICE"
 	prompt "$(module-str)"
 	default $(module)_LOG_LEVEL_DEFAULT
 	depends on $(module-dep)


### PR DESCRIPTION
This allows downstream modules to overwrite the default log level choice using Kconfig.defconfig files.

For example, this becomes possible:

```
choice LWM2M_LOG_LEVEL_CHOICE
  default LWM2M_LOG_LEVEL_WRN
endchoice
```

In contrast to the configuration method, this then has an effect on all applications stored in the downstream module.

<s>In case this idea seems acceptable I'll create more PRs for similar templates.</s> It already exists for e.g. `subsys/logging/Kconfig.template.log_config`.