### PR TITLE
hostap: Pull base64 name collision fix

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -259,7 +259,7 @@ manifest:
         - hal
     - name: hostap
       path: modules/lib/hostap
-      revision: cbae0170437dbe196d436b2b53d7aefb97044b0c
+      revision: pull/43/head
     - name: libmetal
       revision: a6851ba6dba8c9e87d00c42f171a822f7a29639b
       path: modules/hal/libmetal


### PR DESCRIPTION
Pull fix resolving base64 functions name collision between Zephyr and hostap.