### PR TITLE
LLEXT: support detached sections

### DIFF
--- a/include/zephyr/llext/llext.h
+++ b/include/zephyr/llext/llext.h
@@ -135,6 +135,12 @@ struct llext_load_param {
 	 * the memory buffer, when calculating relocation targets.
 	 */
 	bool pre_located;
+	/**
+	 * Extensions can implement custom ELF sections to be loaded in specific
+	 * memory regions, detached from other sections of compatible types.
+	 * This optional callback checks whether a section should be detached.
+	 */
+	bool (*section_detached)(const elf_shdr_t *shdr);
 };
 
 /** Default initializer for @ref llext_load_param */

--- a/include/zephyr/llext/llext_internal.h
+++ b/include/zephyr/llext/llext_internal.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2024 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_LLEXT_INTERNAL_H
+#define ZEPHYR_LLEXT_INTERNAL_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @file
+ * @brief Private header for linkable loadable extensions
+ */
+
+/** @cond ignore */
+
+struct llext_loader;
+struct llext;
+
+const void *llext_loaded_sect_ptr(struct llext_loader *ldr, struct llext *ext, unsigned int sh_ndx);
+
+/** @endcond */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_LLEXT_INTERNAL_H */

--- a/subsys/llext/llext_link.c
+++ b/subsys/llext/llext_link.c
@@ -9,6 +9,7 @@
 #include <zephyr/llext/elf.h>
 #include <zephyr/llext/loader.h>
 #include <zephyr/llext/llext.h>
+#include <zephyr/llext/llext_internal.h>
 #include <zephyr/kernel.h>
 #include <zephyr/cache.h>
 

--- a/subsys/llext/llext_link.c
+++ b/subsys/llext/llext_link.c
@@ -135,8 +135,8 @@ static const void *llext_find_extension_sym(const char *sym_name, struct llext *
 	return se.addr;
 }
 
-static void llext_link_plt(struct llext_loader *ldr, struct llext *ext,
-			   elf_shdr_t *shdr, bool do_local, elf_shdr_t *tgt)
+static void llext_link_plt(struct llext_loader *ldr, struct llext *ext, elf_shdr_t *shdr,
+			   const struct llext_load_param *ldr_parm, elf_shdr_t *tgt)
 {
 	unsigned int sh_cnt = shdr->sh_size / shdr->sh_entsize;
 	/*
@@ -252,7 +252,7 @@ static void llext_link_plt(struct llext_loader *ldr, struct llext *ext,
 			*(const void **)(text + got_offset) = link_addr;
 			break;
 		case STB_LOCAL:
-			if (do_local) {
+			if (ldr_parm->relocate_local) {
 				arch_elf_relocate_local(ldr, ext, &rela, &sym, got_offset);
 			}
 		}
@@ -263,7 +263,7 @@ static void llext_link_plt(struct llext_loader *ldr, struct llext *ext,
 	}
 }
 
-int llext_link(struct llext_loader *ldr, struct llext *ext, bool do_local)
+int llext_link(struct llext_loader *ldr, struct llext *ext, const struct llext_load_param *ldr_parm)
 {
 	uintptr_t sect_base = 0;
 	elf_rela_t rel;
@@ -330,7 +330,7 @@ int llext_link(struct llext_loader *ldr, struct llext *ext, bool do_local)
 				tgt = ldr->sect_hdrs + shdr->sh_info;
 			}
 
-			llext_link_plt(ldr, ext, shdr, do_local, tgt);
+			llext_link_plt(ldr, ext, shdr, ldr_parm, tgt);
 			continue;
 		}
 

--- a/subsys/llext/llext_link.c
+++ b/subsys/llext/llext_link.c
@@ -174,11 +174,11 @@ static void llext_link_plt(struct llext_loader *ldr, struct llext *ext,
 			continue;
 		}
 
-		elf_sym_t sym_tbl;
+		elf_sym_t sym;
 
 		ret = llext_seek(ldr, sym_shdr->sh_offset + j * sizeof(elf_sym_t));
 		if (!ret) {
-			ret = llext_read(ldr, &sym_tbl, sizeof(sym_tbl));
+			ret = llext_read(ldr, &sym, sizeof(sym));
 		}
 
 		if (ret < 0) {
@@ -187,16 +187,16 @@ static void llext_link_plt(struct llext_loader *ldr, struct llext *ext,
 			continue;
 		}
 
-		uint32_t stt = ELF_ST_TYPE(sym_tbl.st_info);
+		uint32_t stt = ELF_ST_TYPE(sym.st_info);
 
 		if (stt != STT_FUNC &&
 		    stt != STT_SECTION &&
 		    stt != STT_OBJECT &&
-		    (stt != STT_NOTYPE || sym_tbl.st_shndx != SHN_UNDEF)) {
+		    (stt != STT_NOTYPE || sym.st_shndx != SHN_UNDEF)) {
 			continue;
 		}
 
-		const char *name = llext_string(ldr, ext, LLEXT_MEM_STRTAB, sym_tbl.st_name);
+		const char *name = llext_string(ldr, ext, LLEXT_MEM_STRTAB, sym.st_name);
 
 		/*
 		 * Both r_offset and sh_addr are addresses for which the extension
@@ -219,14 +219,14 @@ static void llext_link_plt(struct llext_loader *ldr, struct llext *ext,
 				ldr->sects[LLEXT_MEM_TEXT].sh_offset;
 		}
 
-		uint32_t stb = ELF_ST_BIND(sym_tbl.st_info);
+		uint32_t stb = ELF_ST_BIND(sym.st_info);
 		const void *link_addr;
 
 		switch (stb) {
 		case STB_GLOBAL:
 			/* First try the global symbol table */
 			link_addr = llext_find_sym(NULL,
-				SYM_NAME_OR_SLID(name, sym_tbl.st_value));
+				SYM_NAME_OR_SLID(name, sym.st_value));
 
 			if (!link_addr) {
 				/* Next try internal tables */
@@ -253,7 +253,7 @@ static void llext_link_plt(struct llext_loader *ldr, struct llext *ext,
 			break;
 		case STB_LOCAL:
 			if (do_local) {
-				arch_elf_relocate_local(ldr, ext, &rela, &sym_tbl, got_offset);
+				arch_elf_relocate_local(ldr, ext, &rela, &sym, got_offset);
 			}
 		}
 

--- a/subsys/llext/llext_load.c
+++ b/subsys/llext/llext_load.c
@@ -9,6 +9,7 @@
 #include <zephyr/llext/elf.h>
 #include <zephyr/llext/loader.h>
 #include <zephyr/llext/llext.h>
+#include <zephyr/llext/llext_internal.h>
 #include <zephyr/kernel.h>
 
 #include <zephyr/logging/log.h>
@@ -37,6 +38,17 @@ LOG_MODULE_DECLARE(llext, CONFIG_LLEXT_LOG_LEVEL);
  */
 
 static const char ELF_MAGIC[] = {0x7f, 'E', 'L', 'F'};
+
+const void *llext_loaded_sect_ptr(struct llext_loader *ldr, struct llext *ext, unsigned int sh_ndx)
+{
+	enum llext_mem mem_idx = ldr->sect_map[sh_ndx].mem_idx;
+
+	if (mem_idx == LLEXT_MEM_COUNT) {
+		return NULL;
+	}
+
+	return (const uint8_t *)ext->mem[mem_idx] + ldr->sect_map[sh_ndx].offset;
+}
 
 /*
  * Load basic ELF file data

--- a/subsys/llext/llext_priv.h
+++ b/subsys/llext/llext_priv.h
@@ -62,7 +62,8 @@ static inline const char *llext_string(struct llext_loader *ldr, struct llext *e
  * Relocation (llext_link.c)
  */
 
-int llext_link(struct llext_loader *ldr, struct llext *ext, bool do_local);
+int llext_link(struct llext_loader *ldr, struct llext *ext,
+	       const struct llext_load_param *ldr_parm);
 void llext_dependency_remove_all(struct llext *ext);
 
 #endif /* ZEPHYR_SUBSYS_LLEXT_PRIV_H_ */

--- a/subsys/llext/llext_priv.h
+++ b/subsys/llext/llext_priv.h
@@ -58,18 +58,6 @@ static inline const char *llext_string(struct llext_loader *ldr, struct llext *e
 	return (char *)ext->mem[mem_idx] + idx;
 }
 
-static inline const void *llext_loaded_sect_ptr(struct llext_loader *ldr, struct llext *ext,
-						unsigned int sh_ndx)
-{
-	enum llext_mem mem_idx = ldr->sect_map[sh_ndx].mem_idx;
-
-	if (mem_idx == LLEXT_MEM_COUNT) {
-		return NULL;
-	}
-
-	return (const uint8_t *)ext->mem[mem_idx] + ldr->sect_map[sh_ndx].offset;
-}
-
 /*
  * Relocation (llext_link.c)
  */


### PR DESCRIPTION
SOF loads LLEXT objects into slower IMR memory but they're partially pre-linked for SRAM, where objects will be copied to after linking by LLEXT core. But some sections should not be copied to SRAM and be used in IMR directly. This PR adds support for such sections.