### PR TITLE
soc: esp32: add SPIRAM memory test kconfig option

### DIFF
--- a/soc/espressif/common/Kconfig.spiram
+++ b/soc/espressif/common/Kconfig.spiram
@@ -30,6 +30,12 @@ config ESP_SPIRAM_HEAP_SIZE
 	help
 	  Specify size of SPIRAM heap.
 
+config ESP_SPIRAM_MEMTEST
+	bool "Run memory test on SPI RAM initialization"
+	default y
+	help
+	  Runs a memory test on initialization. Disable this for faster startup.
+
 choice SPIRAM_MODE
 	prompt "Mode (QUAD/OCT) of SPI RAM chip in use"
 	default SPIRAM_MODE_QUAD

--- a/soc/espressif/common/psram.c
+++ b/soc/espressif/common/psram.c
@@ -40,10 +40,12 @@ void esp_init_psram(void)
 		ets_printf("External RAM size is less than configured.\n");
 	}
 
-	if (esp_psram_is_initialized()) {
-		if (!esp_psram_extram_test()) {
-			ets_printf("External RAM failed memory test!");
-			return;
+	if (IS_ENABLED(CONFIG_ESP_SPIRAM_MEMTEST)) {
+		if (esp_psram_is_initialized()) {
+			if (!esp_psram_extram_test()) {
+				ets_printf("External RAM failed memory test!");
+				return;
+			}
 		}
 	}
 


### PR DESCRIPTION
Add kconfig to disable SPIRAM memory test. Allows
faster SoC initialization when disabled.