### PR TITLE
boards: qorvo: add DWM3001CDK support

### DIFF
--- a/boards/qorvo/decawave_dwm3001cdk/Kconfig
+++ b/boards/qorvo/decawave_dwm3001cdk/Kconfig
@@ -1,0 +1,12 @@
+# DecaWave DWM3001CDK board configuration
+
+# Copyright (c) 2024 The Zephyr Project Contributors
+# # SPDX-License-Identifier: Apache-2.0
+
+if BOARD_DECAWAVE_DWM3001CDK
+
+config BOARD_SERIAL_BACKEND_CDC_ACM
+	bool "Use USB CDC as serial console backend"
+	default y
+
+endif # BOARD_DECAWAVE_DWM3001CDK

--- a/boards/qorvo/decawave_dwm3001cdk/Kconfig.decawave_dwm3001cdk
+++ b/boards/qorvo/decawave_dwm3001cdk/Kconfig.decawave_dwm3001cdk
@@ -1,0 +1,7 @@
+# DecaWave DWM3001CDK board configuration
+
+# Copyright (c) 2019 Stéphane D'Alu
+# SPDX-License-Identifier: Apache-2.0
+
+config BOARD_DECAWAVE_DWM3001CDK
+	select SOC_NRF52833_QDAA

--- a/boards/qorvo/decawave_dwm3001cdk/Kconfig.defconfig
+++ b/boards/qorvo/decawave_dwm3001cdk/Kconfig.defconfig
@@ -1,0 +1,70 @@
+# DecaWave DWM3001CDK board configuration
+
+# Copyright (c) 2019 Stéphane D'Alu
+# SPDX-License-Identifier: Apache-2.0
+
+if BOARD_DECAWAVE_DWM3001CDK
+
+config BT_CTLR
+	default BT
+
+config I2C
+	default SENSOR
+
+if BOARD_SERIAL_BACKEND_CDC_ACM
+
+config USB_DEVICE_STACK
+	default y
+
+config USB_CDC_ACM
+	default SERIAL
+
+config CONSOLE
+	default y
+
+config UART_CONSOLE
+	default CONSOLE
+
+config USB_DEVICE_INITIALIZE_AT_BOOT
+	default y if !MCUBOOT && CONSOLE
+
+config SHELL_BACKEND_SERIAL_CHECK_DTR
+	default SHELL
+	depends on UART_LINE_CTRL
+
+config UART_LINE_CTRL
+	default y
+
+config USB_DEVICE_REMOTE_WAKEUP
+	default n
+
+if LOG
+
+# Logger cannot use itself to log
+choice USB_CDC_ACM_LOG_LEVEL_CHOICE
+	default USB_CDC_ACM_LOG_LEVEL_OFF
+endchoice
+
+# Set USB log level to error only
+choice USB_DEVICE_LOG_LEVEL_CHOICE
+	default USB_DEVICE_LOG_LEVEL_ERR
+endchoice
+
+endif # LOG
+
+if USB_DEVICE_STACK
+
+# Enable UART driver, needed for CDC ACM
+config SERIAL
+	default y
+
+endif # USB_DEVICE_STACK
+
+endif # BOARD_SERIAL_BACKEND_CDC_ACM
+
+DT_CHOSEN_ZEPHYR_CONSOLE := zephyr,console
+
+config UART_CONSOLE
+	default y if $(dt_chosen_enabled,$(DT_CHOSEN_ZEPHYR_CONSOLE)) && CONSOLE
+
+endif # BOARD_DECAWAVE_DWM3001CDK

--- a/boards/qorvo/decawave_dwm3001cdk/board.cmake
+++ b/boards/qorvo/decawave_dwm3001cdk/board.cmake
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+
+board_runner_args(jlink "--device=nRF52833_xxAA" "--speed=4000")
+board_runner_args(pyocd "--target=nrf52833" "--frequency=4000000")
+include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/nrfutil.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-nrf5.board.cmake)

--- a/boards/qorvo/decawave_dwm3001cdk/board.yml
+++ b/boards/qorvo/decawave_dwm3001cdk/board.yml
@@ -1,0 +1,5 @@
+board:
+  name: decawave_dwm3001cdk
+  vendor: qorvo
+  socs:
+  - name: nrf52833

--- a/boards/qorvo/decawave_dwm3001cdk/decawave_dwm3001cdk-pinctrl.dtsi
+++ b/boards/qorvo/decawave_dwm3001cdk/decawave_dwm3001cdk-pinctrl.dtsi
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&pinctrl {
+	i2c0_default: i2c0_default {
+		group1 {
+			psels = <NRF_PSEL(TWIM_SDA, 0, 24)>,
+				<NRF_PSEL(TWIM_SCL, 1, 04)>;
+			bias-pull-up;
+		};
+	};
+
+	i2c0_sleep: i2c0_sleep {
+		group1 {
+			psels = <NRF_PSEL(TWIM_SDA, 0, 24)>,
+				<NRF_PSEL(TWIM_SCL, 1, 04)>;
+			low-power-enable;
+		};
+	};
+
+	spi3_default: spi3_default {
+		group1 {
+			psels = <NRF_PSEL(SPIM_SCK, 0, 3)>,
+				<NRF_PSEL(SPIM_MOSI, 0, 8)>,
+				<NRF_PSEL(SPIM_MISO, 0, 29)>;
+		};
+	};
+
+	spi3_sleep: spi3_sleep {
+		group1 {
+			psels = <NRF_PSEL(SPIM_SCK, 0, 3)>,
+				<NRF_PSEL(SPIM_MOSI, 0, 8)>,
+				<NRF_PSEL(SPIM_MISO, 0, 29)>;
+			low-power-enable;
+		};
+	};
+};

--- a/boards/qorvo/decawave_dwm3001cdk/decawave_dwm3001cdk.dts
+++ b/boards/qorvo/decawave_dwm3001cdk/decawave_dwm3001cdk.dts
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2019 Stéphane D'Alu
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/dts-v1/;
+#include <nordic/nrf52833_qdaa.dtsi>
+#include "decawave_dwm3001cdk-pinctrl.dtsi"
+#include <zephyr/dt-bindings/input/input-event-codes.h>
+
+/ {
+	model = "Decawave DWM3001CDK";
+	compatible = "decawave,dwm3001";
+
+	chosen {
+		zephyr,console = &cdc_acm_uart0;
+		zephyr,shell-uart = &cdc_acm_uart0;
+		zephyr,uart-mcumgr = &cdc_acm_uart0;
+		zephyr,bt-mon-uart = &cdc_acm_uart0;
+		zephyr,bt-c2h-uart = &cdc_acm_uart0;
+		zephyr,sram = &sram0;
+		zephyr,flash = &flash0;
+		zephyr,code-partition = &slot0_partition;
+		zephyr,ieee802154 = &ieee802154;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		// led from top of board down
+		// D20: something related to jlink, red
+		// D13: DW3000 tx(red)/rx(green)
+		led0: led_0 {
+			gpios = <&gpio0 04 GPIO_ACTIVE_LOW>;
+			label = "D9 green LED";
+		};
+		led1: led_1 {
+			gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
+			label = "D12 red LED";
+		};
+		led2: led_2 {
+			gpios = <&gpio0 22 GPIO_ACTIVE_LOW>;
+			label = "D11 red LED";
+		};
+		led3: led_3 {
+			gpios = <&gpio0 05 GPIO_ACTIVE_LOW>;
+			label = "D10 blue LED";
+		};
+	};
+
+	buttons {
+		compatible = "gpio-keys";
+		// SW1 is connected to P0.18, which by default is nRESET and
+		// will reset the board
+		button2: button_2 {
+			gpios = <&gpio0 2 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+			label = "Push button switch 2";
+			zephyr,code = <INPUT_KEY_1>;
+		};
+	};
+
+	/* These aliases are provided for compatibility with samples */
+	aliases {
+		sw0        = &button2;
+		led0       = &led0;
+		led1       = &led1;
+		led2       = &led2;
+		led3       = &led3;
+		watchdog0  = &wdt0;
+		accel0     = &lis2dh12;
+	};
+
+};
+
+&uicr {
+	gpio-as-nreset;
+};
+
+&gpiote {
+	status = "okay";
+};
+
+&gpio0 {
+	status = "okay";
+};
+
+&gpio1 {
+	status = "okay";
+};
+
+&i2c0 {
+	compatible = "nordic,nrf-twim";
+	status = "okay";
+	clock-frequency = <I2C_BITRATE_FAST>;
+
+	pinctrl-0 = <&i2c0_default>;
+	pinctrl-1 = <&i2c0_sleep>;
+	pinctrl-names = "default", "sleep";
+	lis2dh12: lis2dh12@19 {
+		compatible = "st,lis2dh12", "st,lis2dh";
+		reg = <0x19>;
+		irq-gpios = <&gpio0 16 GPIO_ACTIVE_HIGH>;
+	};
+};
+
+&spi3 {
+	compatible = "nordic,nrf-spim";
+	status = "okay";
+	cs-gpios = <&gpio1 6 GPIO_ACTIVE_LOW>;
+
+	pinctrl-0 = <&spi3_default>;
+	pinctrl-1 = <&spi3_sleep>;
+	pinctrl-names = "default", "sleep";
+};
+
+&ieee802154 {
+	status = "okay";
+};
+
+&flash0 {
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		boot_partition: partition@0 {
+			label = "mcuboot";
+			reg = <0x00000000 0xC000>;
+		};
+		slot0_partition: partition@c000 {
+			label = "image-0";
+			reg = <0x0000C000 0x38000>;
+		};
+		slot1_partition: partition@44000 {
+			label = "image-1";
+			reg = <0x00044000 0x36000>;
+		};
+		storage_partition: partition@7a000 {
+			label = "storage";
+			reg = <0x0007A000 0x00006000>;
+		};
+	};
+};
+
+zephyr_udc0: &usbd {
+	compatible = "nordic,nrf-usbd";
+	status = "okay";
+
+	cdc_acm_uart0: cdc_acm_uart0 {
+		compatible = "zephyr,cdc-acm-uart";
+	};
+};
+
+&reg1 {
+	regulator-initial-mode = <NRF5X_REG_MODE_DCDC>;
+};
+
+&adc {
+	status = "okay";
+};

--- a/boards/qorvo/decawave_dwm3001cdk/decawave_dwm3001cdk.yaml
+++ b/boards/qorvo/decawave_dwm3001cdk/decawave_dwm3001cdk.yaml
@@ -1,0 +1,20 @@
+identifier: decawave_dwm3001cdk
+name: Decawave-DWM3001CDK
+type: mcu
+arch: arm
+ram: 128
+flash: 512
+vendor: decawave
+toolchain:
+  - zephyr
+  - gnuarmemb
+  - xtools
+supported:
+  - adc
+  - usb_device
+  - ble
+  - gpio
+  - pwm
+  - watchdog
+  - counter
+  - netif:openthread

--- a/boards/qorvo/decawave_dwm3001cdk/decawave_dwm3001cdk_defconfig
+++ b/boards/qorvo/decawave_dwm3001cdk/decawave_dwm3001cdk_defconfig
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Enable MPU
+CONFIG_ARM_MPU=y
+
+# Enable hardware stack protection
+CONFIG_HW_STACK_PROTECTION=y
+
+# Enable GPIO
+CONFIG_GPIO=y

--- a/boards/qorvo/decawave_dwm3001cdk/doc/index.rst
+++ b/boards/qorvo/decawave_dwm3001cdk/doc/index.rst
@@ -1,0 +1,65 @@
+.. _decawave_dwm3001cdk:
+
+Decawave DWM3001CDK
+###################
+
+Overview
+********
+
+The DWM3001CDK development board includes the DWM3001C module, battery connector
+and charging circuit, LEDs, buttons, Raspberry Pi connector, and USB connector.
+In addition, the board comes with J-Link OB adding debugging and Virtual COM
+Port capabilities.
+
+See `Qorvo (Decawave) DWM3001CDK website`_ for more information about the
+development board, `Qorvo (Decawave) DWM3001C website`_ about the module
+itself, and `nRF52833 website`_ for the official reference on the IC itself.
+
+Programming and Debugging
+*************************
+
+Applications for the ``decawave_dwm3001cdk`` board target can be built, flashed,
+and debugged in the usual way. See :ref:`build_an_application` and
+:ref:`application_run` for more details on building and running.
+
+Flashing
+========
+
+Follow the instructions in the :ref:`nordic_segger` page to install
+and configure all the necessary software. Further information can be
+found in :ref:`nordic_segger_flashing`. Then build and flash
+applications as usual (see :ref:`build_an_application` and
+:ref:`application_run` for more details).
+
+There are two USB ports, the one farthest from the DWM3001C is connected to the
+J-Link debugger and the closer one is connected to the nRF52833, though you need
+to use CDC ACM USB to get output over it
+
+Here is an example for the :zephyr:code-sample:`usb-cdc-acm` application.
+
+Connect to the bottom USB port, and flash the sample
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/subsys/usb/console
+   :board: decawave_dwm3001cdk
+   :goals: build flash
+
+
+Then, connect the top USB port and open run your favorite terminal program to
+listen for output.
+
+.. code-block:: console
+
+   $ minicom -D <tty_device> -b 115200
+
+Replace :code:`<tty_device>` with the port where the board nRF52 DK
+can be found. For example, under Linux, :code:`/dev/ttyACM0`.
+
+
+References
+**********
+.. target-notes::
+
+.. _nRF52833 website: https://www.nordicsemi.com/products/nrf52833
+.. _Qorvo (Decawave) DWM3001C website: https://www.qorvo.com/products/p/DWM3001C
+.. _Qorvo (Decawave) DWM3001CDK website: https://www.qorvo.com/products/p/DWM3001CDK

--- a/boards/qorvo/decawave_dwm3001cdk/pre_dt_board.cmake
+++ b/boards/qorvo/decawave_dwm3001cdk/pre_dt_board.cmake
@@ -1,0 +1,7 @@
+# Copyright (c) 2022 Nordic Semiconductor
+# SPDX-License-Identifier: Apache-2.0
+
+# Suppress "unique_unit_address_if_enabled" to handle the following overlaps:
+# - power@40000000 & clock@40000000 & bprot@40000000
+# - acl@4001e000 & flash-controller@4001e000
+list(APPEND EXTRA_DTC_FLAGS "-Wno-unique_unit_address_if_enabled")

--- a/tests/drivers/adc/adc_api/boards/decawave_dwm3001cdk.overlay
+++ b/tests/drivers/adc/adc_api/boards/decawave_dwm3001cdk.overlay
@@ -1,0 +1,7 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2024 The Zephyr Project Contributors
+ */
+
+#include "nordic,nrf-saadc-common.dtsi"


### PR DESCRIPTION
This doensn't add any drivers for the DWM3001C, but it works with
https://github.com/br101/zephyr-dw3000-decadriver/

It's basically a copy of the decawave_dwm1001_dev with the modifications to work with the dwm3001cdk