### PR TITLE
cmake: add LATE_LINK to fix llext weak syscall definitions 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -961,6 +961,12 @@ foreach(zephyr_lib ${ZEPHYR_LIBS_PROPERTY})
     endif()
   endif()
 
+  # Add the library to the late list
+  get_property(late_link TARGET ${zephyr_lib} PROPERTY LATE_LINK)
+  if("${late_link}")
+    list(APPEND ZEPHYR_LATE_LIBS_PROPERTY ${zephyr_lib})
+  endif()
+
   # TODO: Could this become an INTERFACE property of zephyr_interface?
   add_dependencies(${zephyr_lib} zephyr_generated_headers)
 endforeach()
@@ -971,6 +977,18 @@ else()
   set(WHOLE_ARCHIVE_LIBS ${ZEPHYR_LIBS_PROPERTY})
   set(NO_WHOLE_ARCHIVE_LIBS kernel)
 endif()
+
+# Move the libraries that are supposed to be linked late in the link
+# process to the end of their respective list.
+foreach(zephyr_lib ${ZEPHYR_LATE_LIBS_PROPERTY})
+  if("${zephyr_lib}" IN_LIST WHOLE_ARCHIVE_LIBS)
+    list(REMOVE_ITEM WHOLE_ARCHIVE_LIBS ${zephyr_lib})
+    list(APPEND WHOLE_ARCHIVE_LIBS ${zephyr_lib})
+  elseif("${zephyr_lib}" IN_LIST NO_WHOLE_ARCHIVE_LIBS)
+    list(REMOVE_ITEM NO_WHOLE_ARCHIVE_LIBS ${zephyr_lib})
+    list(APPEND NO_WHOLE_ARCHIVE_LIBS ${zephyr_lib})
+  endif()
+endforeach()
 
 get_property(OUTPUT_FORMAT        GLOBAL PROPERTY PROPERTY_OUTPUT_FORMAT)
 

--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -593,8 +593,12 @@ endfunction()
 # ALLOW_EMPTY <TRUE:FALSE>: Allow a Zephyr library to be empty.
 #                           An empty Zephyr library will generate a CMake
 #                           configure time warning unless `ALLOW_EMPTY` is TRUE.
+# LATE_LINK <TRUE:FALSE>: Link the library "late" in the library group. When
+#                         set to TRUE, the library will be linked after all
+#                         other libraries that are _not_ marked "late". Ordering
+#                         between late libs is not guaranteed.
 function(zephyr_library_property)
-  set(single_args "ALLOW_EMPTY")
+  set(single_args "ALLOW_EMPTY" "LATE_LINK")
   cmake_parse_arguments(LIB_PROP "" "${single_args}" "" ${ARGN})
 
   if(LIB_PROP_UNPARSED_ARGUMENTS)

--- a/subsys/llext/CMakeLists.txt
+++ b/subsys/llext/CMakeLists.txt
@@ -7,14 +7,19 @@ if(CONFIG_LLEXT)
   zephyr_library_compile_definitions(-D_POSIX_C_SOURCE=200809L)
 
   zephyr_library_sources(
-		llext.c
-		llext_mem.c
-		llext_load.c
-		llext_link.c
-		llext_export.c
-		llext_handlers.c
-		buf_loader.c
+    llext.c
+    llext_mem.c
+    llext_load.c
+    llext_link.c
+    llext_handlers.c
+    buf_loader.c
     fs_loader.c
-	)
+  )
   zephyr_library_sources_ifdef(CONFIG_LLEXT_SHELL shell.c)
+
+  # The llext_export.c file must be linked late to prevent the weak symbols
+  # it defines from overriding actual symbols defined in later libs.
+  zephyr_library_named(llext_exports)
+  zephyr_library_sources(llext_export.c)
+  zephyr_library_property(LATE_LINK TRUE)
 endif()


### PR DESCRIPTION
Since 62b19ef65c0be6186ed9f07343c8242abf651e6c LLEXT has gained the ability to export all syscalls automatically. The export is done for any syscall **declared** in the build, including those that are never actually **defined** - most commonly due to not enabling some Kconfig. 
These undefined functions would normally cause a link error; the workaround has been to define, in an autogenerated file included by `llext_export.c`, weak implementations for all syscall symbols to the stock `no_handler` function, with the intention of providing a sensible default to link with. 

However, during development I discovered that some of these symbols were actually defined in the final ELF as `NULL`. This has been traced to the `llext_export.c` file being included in the middle of the `--whole-archive` list, instead of at the end.

This PR adds a `LATE_LINK` property to Zephyr libraries (by default disabled). Libraries that have this feature enabled will be placed after all the ones that do not enable it in the linker command line; no other ordering is enforced between these two groups.

This feature is then used to split build the `llext_exports.c` file in its own separate library and move it to the end of the link list, fixing the symbol definition issue.