### PR TITLE
soc: nxp: imx95: fix indent of MMU entry

### DIFF
--- a/soc/nxp/imx/imx9/imx95/a55/mmu_regions.c
+++ b/soc/nxp/imx/imx9/imx95/a55/mmu_regions.c
@@ -21,8 +21,8 @@ static const struct arm_mmu_region mmu_regions[] = {
 	MMU_REGION_DT_COMPAT_FOREACH_FLAT_ENTRY(nxp_mbox_imx_mu,
 						(MT_DEVICE_nGnRnE | MT_P_RW_U_NA | MT_NS))
 
-		MMU_REGION_DT_COMPAT_FOREACH_FLAT_ENTRY(nxp_kinetis_lpuart,
-							(MT_DEVICE_nGnRnE | MT_P_RW_U_NA | MT_NS))
+	MMU_REGION_DT_COMPAT_FOREACH_FLAT_ENTRY(nxp_kinetis_lpuart,
+						(MT_DEVICE_nGnRnE | MT_P_RW_U_NA | MT_NS))
 
 };
 


### PR DESCRIPTION
Fix the indent of LPUARTs MMU setup entry.