### PR TITLE
console: IPM sender/receiver kconfigs need to depend on IPM

### DIFF
--- a/drivers/console/Kconfig
+++ b/drivers/console/Kconfig
@@ -167,12 +167,14 @@ endif
 
 config IPM_CONSOLE_SENDER
 	bool "Inter-processor Mailbox console sender"
+	depends on IPM
 	select CONSOLE_HAS_DRIVER
 	help
 	  Enable the sending side of IPM console
 
 config IPM_CONSOLE_RECEIVER
 	bool "Inter-processor Mailbox console receiver"
+	depends on IPM
 	select RING_BUFFER
 	help
 	  Enable the receiving side of IPM console


### PR DESCRIPTION
Both IPM console sender and receiver need to call IPM functions which are only compiled when CONFIG_IPM is enabled. So mark both CONFIG_IPM_CONSOLE_SENDER and CONFIG_IPM_CONSOLE_RECEIVER to depend on CONFIG_IPM.