### PR TITLE
boards: frdm_mcxw71: Enabe LPI2C

### DIFF
--- a/boards/nxp/frdm_mcxw71/doc/index.rst
+++ b/boards/nxp/frdm_mcxw71/doc/index.rst
@@ -55,6 +55,8 @@ The ``frdm_mcxw71`` board target in Zephyr currently supports the following feat
 | LPUART    | on-chip    | serial port-polling;                |
 |           |            | serial port-interrupt               |
 +-----------+------------+-------------------------------------+
+| LPI2C     | on-chip    | i2c                                 |
++-----------+------------+-------------------------------------+
 | FMU       | on-chip    | flash                               |
 +-----------+------------+-------------------------------------+
 | TPM       | on-chip    | pwm                                 |

--- a/boards/nxp/frdm_mcxw71/frdm_mcxw71-pinctrl.dtsi
+++ b/boards/nxp/frdm_mcxw71/frdm_mcxw71-pinctrl.dtsi
@@ -23,4 +23,14 @@
 			slew-rate = "fast";
 		};
 	};
+
+	pinmux_lpi2c1: pinmux_lpi2c1 {
+		group0 {
+			pinmux = <LPI2C1_SCL_PTB5>,
+				<LPI2C1_SDA_PTB4>;
+			drive-strength = "low";
+			slew-rate = "fast";
+			drive-open-drain;
+		};
+	};
 };

--- a/boards/nxp/frdm_mcxw71/frdm_mcxw71.dts
+++ b/boards/nxp/frdm_mcxw71/frdm_mcxw71.dts
@@ -59,6 +59,12 @@
 	pinctrl-names = "default";
 };
 
+&lpi2c1 {
+	status = "okay";
+	pinctrl-0 = <&pinmux_lpi2c1>;
+	pinctrl-names = "default";
+};
+
 &flash {
 	partitions {
 		compatible = "fixed-partitions";

--- a/boards/nxp/frdm_mcxw71/frdm_mcxw71.yaml
+++ b/boards/nxp/frdm_mcxw71/frdm_mcxw71.yaml
@@ -16,3 +16,4 @@ supported:
   - watchdog
   - pinctrl
   - flash
+  - i2c

--- a/dts/arm/nxp/nxp_mcxw71.dtsi
+++ b/dts/arm/nxp/nxp_mcxw71.dtsi
@@ -170,6 +170,28 @@
 		status = "disabled";
 	};
 
+	lpi2c0: i2c@33000 {
+		compatible = "nxp,imx-lpi2c";
+		clock-frequency = <I2C_BITRATE_STANDARD>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+		reg = <0x33000 0x200>;
+		interrupts = <39 0>;
+		clocks = <&scg SCG_K4_FIRC_CLK 0xe0>;
+		status = "disabled";
+	};
+
+	lpi2c1: i2c@34000 {
+		compatible = "nxp,imx-lpi2c";
+		clock-frequency = <I2C_BITRATE_STANDARD>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+		reg = <0x34000 0x200>;
+		interrupts = <40 0>;
+		clocks = <&scg SCG_K4_FIRC_CLK 0xe4>;
+		status = "disabled";
+	};
+
 	gpiod: gpio@46000{
 		compatible = "nxp,kinetis-gpio";
 		status = "disabled";

--- a/soc/nxp/mcx/mcxw/soc.c
+++ b/soc/nxp/mcx/mcxw/soc.c
@@ -136,6 +136,14 @@ static ALWAYS_INLINE void clock_init(void)
 	if (DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(tpm1), nxp_kinetis_tpm, okay)) {
 		CLOCK_EnableClock(kCLOCK_Tpm1);
 	}
+
+	if (DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(lpi2c0), nxp_imx_lpi2c, okay)) {
+		CLOCK_EnableClock(kCLOCK_Lpi2c0);
+	}
+
+	if (DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(lpi2c1), nxp_imx_lpi2c, okay)) {
+		CLOCK_EnableClock(kCLOCK_Lpi2c1);
+	}
 }
 
 static void vbat_init(void)


### PR DESCRIPTION
has the same general fixing commits as #78964 and #78963 , doesnt matter which merges first

enables LPI2C

there is an I2C sensor on this board but there doesn't seem to be a driver in tree for it to work yet, that will come later