### PR TITLE
dts/x86: use proper unit-address values

### DIFF
--- a/boards/qemu/x86/qemu_x86_lakemont.dts
+++ b/boards/qemu/x86/qemu_x86_lakemont.dts
@@ -31,9 +31,9 @@
 		zephyr,shell-uart = &uart0;
 	};
 
-	dram0: memory@0 {
+	dram0: memory@DT_DRAM_BASE {
 		device_type = "memory";
-		reg = <DT_DRAM_BASE DT_DRAM_SIZE>;
+		reg = <DT_ADDR(DT_DRAM_BASE) DT_DRAM_SIZE>;
 	};
 
 	soc {

--- a/boards/qemu/x86/qemu_x86_tiny.dts
+++ b/boards/qemu/x86/qemu_x86_tiny.dts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#define DT_DRAM_BASE            0x100000
+/* Note: this is the unit-address (in hex) of the node */
+#define DT_DRAM_BASE            100000
 #define DT_DRAM_SIZE            DT_SIZE_K(256)
 #include "qemu_x86.dts"

--- a/dts/x86/intel/atom.dtsi
+++ b/dts/x86/intel/atom.dtsi
@@ -37,9 +37,9 @@
 		#address-cells = <1>;
 	};
 
-	dram0: memory@0 {
+	dram0: memory@DT_DRAM_BASE {
 		device_type = "memory";
-		reg = <DT_DRAM_BASE DT_DRAM_SIZE>;
+		reg = <DT_ADDR(DT_DRAM_BASE) DT_DRAM_SIZE>;
 	};
 
 	soc {


### PR DESCRIPTION
This PR changes the way some x86 devicetrees set the unit-address values of memory nodes. Before the change, they were always set to `0`. After the change, they are derived from the `DT_DRAM_BASE` macro to match the first address specified by the reg property.

From the [Devicetree specification](https://devicetree-specification.readthedocs.io/en/v0.3/devicetree-basics.html#node-name-requirements):

> The unit-address component of the name is specific to the bus type on which the node sits. It consists of one or more ASCII characters from the set of characters in [Table 2.1](https://devicetree-specification.readthedocs.io/en/v0.3/devicetree-basics.html#node-name-characters). The unit-address must match the first address specified in the reg property of the node