### PR TITLE
tests: drivers: Add PPR support in NRF GRTC timer test

### DIFF
--- a/tests/drivers/timer/nrf_grtc_timer/boards/nrf54h20dk_nrf54h20_cpuppr.overlay
+++ b/tests/drivers/timer/nrf_grtc_timer/boards/nrf54h20dk_nrf54h20_cpuppr.overlay
@@ -1,0 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+&grtc {
+	owned-channels = <5 6>;
+};


### PR DESCRIPTION
Test did not support PPR core due to failing GRTC channel allocation. This change fixes the channel allocation and enables PPR core test.