### PR TITLE
west_commands: build: add extra file arguments

### DIFF
--- a/scripts/west_commands/build.py
+++ b/scripts/west_commands/build.py
@@ -28,6 +28,8 @@ west build [-h] [-b BOARD[@REV]]] [-d BUILD_DIR]
            [-t TARGET] [-p {auto, always, never}] [-c] [--cmake-only]
            [-n] [-o BUILD_OPT] [-f]
            [--sysbuild | --no-sysbuild] [--domain DOMAIN]
+           [--extra-conf FILE.conf]
+           [--extra-dtc-overlay FILE.overlay]
            [source_dir] -- [cmake_opt [cmake_opt ...]]
 '''
 
@@ -150,6 +152,20 @@ class Build(Forceable):
                            Do not use this option with manually specified
                            -DSHIELD... cmake arguments: the results are
                            undefined''')
+        group.add_argument('--extra-conf', dest='extra_conf_files', metavar='EXTRA_CONF_FILE',
+                           action='append', default=[],
+                           help='''add the argument to EXTRA_CONF_FILE; may be given
+                           multiple times. Forces CMake to run again if given.
+                           Do not use this option with manually specified
+                           -DEXTRA_CONF_FILE... cmake arguments: the results are
+                           undefined''')
+        group.add_argument('--extra-dtc-overlay', dest='extra_dtc_overlay_files',
+                           metavar='EXTRA_DTC_OVERLAY_FILE', action='append', default=[],
+                           help='''add the argument to EXTRA_DTC_OVERLAY_FILE; may be given
+                           multiple times. Forces CMake to run again if given.
+                           Do not use this option with manually specified
+                           -DEXTRA_DTC_OVERLAY_FILE... cmake arguments: the results are
+                           undefined''')
 
         group = parser.add_mutually_exclusive_group()
         group.add_argument('--sysbuild', action='store_true',
@@ -223,7 +239,8 @@ class Build(Forceable):
                 self._update_cache()
                 if (self.args.cmake or self.args.cmake_opts or
                         self.args.cmake_only or self.args.snippets or
-                        self.args.shields):
+                        self.args.shields or self.args.extra_conf_files or
+                        self.args.extra_dtc_overlay_files):
                     self.run_cmake = True
         else:
             self.run_cmake = True
@@ -570,6 +587,13 @@ class Build(Forceable):
             cmake_opts.append(f'-DSNIPPET={";".join(self.args.snippets)}')
         if self.args.shields:
             cmake_opts.append(f'-DSHIELD={";".join(self.args.shields)}')
+        if self.args.extra_conf_files:
+            cmake_opts.append(f'-DEXTRA_CONF_FILE={";".join(self.args.extra_conf_files)}')
+        if self.args.extra_dtc_overlay_files:
+            cmake_opts.append(
+                f'-DEXTRA_DTC_OVERLAY_FILE='
+                f'{";".join(self.args.extra_dtc_overlay_files)}'
+            )
 
         user_args = config_get('cmake-args', None)
         if user_args:


### PR DESCRIPTION
Adds an argument to include additional .conf or .overlay files

Example use:

```
west build -b nrf52840dk/nrf52840 -p --extra-conf foo.conf
```

```
west build -b nrf52840dk/nrf52840 -p --extra-dtc-overlay foo.overlay
```

Or:

```
west build -b nrf52840dk/nrf52840 -p --extra-conf foo.conf --extra-conf bar.conf
```

```
west build -b nrf52840dk/nrf52840 -p --extra-dtc-overlay foo.overlay --extra-dtc-overlay bar.overlay
```

Signed-off-by: Helmut Lord <kellyhlord@gmail.com>