### PR TITLE
README: drop the stray link underscores between badges

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,15 +10,9 @@
      </p>
    </a>
 
-   <a href="https://bestpractices.coreinfrastructure.org/projects/74">
-     <img src="https://bestpractices.coreinfrastructure.org/projects/74/badge">
-   </a>
-   <a href="https://scorecard.dev/viewer/?uri=github.com/zephyrproject-rtos/zephyr">
-     <img src="https://api.securityscorecards.dev/projects/github.com/zephyrproject-rtos/zephyr/badge">
-   </a>
-   <a href="https://github.com/zephyrproject-rtos/zephyr/actions/workflows/twister.yaml?query=branch%3Amain">
-     <img src="https://github.com/zephyrproject-rtos/zephyr/actions/workflows/twister.yaml/badge.svg?event=push">
-   </a>
+   <a href="https://bestpractices.coreinfrastructure.org/projects/74"><img src="https://bestpractices.coreinfrastructure.org/projects/74/badge"></a>
+   <a href="https://scorecard.dev/viewer/?uri=github.com/zephyrproject-rtos/zephyr"><img src="https://api.securityscorecards.dev/projects/github.com/zephyrproject-rtos/zephyr/badge"></a>
+   <a href="https://github.com/zephyrproject-rtos/zephyr/actions/workflows/twister.yaml?query=branch%3Amain"><img src="https://github.com/zephyrproject-rtos/zephyr/actions/workflows/twister.yaml/badge.svg?event=push"></a>
 
 
 The Zephyr Project is a scalable real-time operating system (RTOS) supporting


### PR DESCRIPTION
The README HTML has some extra link underscore between spaces due to the extra newline and space between the <a> and <img> tags. Remove it.

---

![x](https://github.com/user-attachments/assets/a3bbe775-80e5-4b0c-a73e-9fc54fae5eb7)

^^^ these blue things here