### PR TITLE
ipc: icmsg: Check return error of pbuf_rx_init()

### DIFF
--- a/subsys/ipc/ipc_service/lib/icmsg.c
+++ b/subsys/ipc/ipc_service/lib/icmsg.c
@@ -273,11 +273,16 @@ int icmsg_open(const struct icmsg_config_t *conf,
 	int ret = pbuf_tx_init(dev_data->tx_pb);
 
 	if (ret < 0) {
-		__ASSERT(false, "Incorrect configuration");
+		__ASSERT(false, "Incorrect Tx configuration");
 		return ret;
 	}
 
-	(void)pbuf_rx_init(dev_data->rx_pb);
+	ret = pbuf_rx_init(dev_data->rx_pb);
+
+	if (ret < 0) {
+		__ASSERT(false, "Incorrect Rx configuration");
+		return ret;
+	}
 
 	ret = pbuf_write(dev_data->tx_pb, magic, sizeof(magic));
 


### PR DESCRIPTION
Following @arnopo https://github.com/zephyrproject-rtos/zephyr/pull/78390#discussion_r1776463721

When pbuf_rx_init() was added, this caller did not check for a possibly returned error to not have more overhead than before using this function.
Although unlikely let's check for a possible error (not configured Rx pbuf cfg).