### PR TITLE
drivers: spi: stm32h7: avoid unnecessary suspend

### DIFF
--- a/drivers/spi/spi_ll_stm32.h
+++ b/drivers/spi/spi_ll_stm32.h
@@ -219,26 +219,16 @@ static inline void ll_func_set_fifo_threshold_16bit(SPI_TypeDef *spi)
 static inline void ll_func_disable_spi(SPI_TypeDef *spi)
 {
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
-	if (LL_SPI_IsActiveMasterTransfer(spi)) {
-		LL_SPI_SuspendMasterTransfer(spi);
-		while (LL_SPI_IsActiveMasterTransfer(spi)) {
-			/* NOP */
-		}
-	}
-
-	LL_SPI_Disable(spi);
-	while (LL_SPI_IsEnabled(spi)) {
-		/* NOP */
-	}
-
 	/* Flush RX buffer */
 	while (LL_SPI_IsActiveFlag_RXP(spi)) {
 		(void)LL_SPI_ReceiveData8(spi);
 	}
-	LL_SPI_ClearFlag_SUSP(spi);
-#else
-	LL_SPI_Disable(spi);
 #endif /* st_stm32h7_spi */
+	LL_SPI_Disable(spi);
+
+	while (LL_SPI_IsEnabled(spi)) {
+		/* NOP */
+	}
 }
 
 #endif	/* ZEPHYR_DRIVERS_SPI_SPI_LL_STM32_H_ */


### PR DESCRIPTION
The stm32 H7 driver always suspends the transmission at the end of a transceive operation. However, according to the H7 datasheet, this is only needed when SPI is configured as receive-only. The driver never does this, as `LL_SPI_SetTransferDirection(spi, LL_SPI_FULL_DUPLEX);` is always called in `spi_stm32_configure`.

Unless there is a reason to still suspend the transaction, it should not be done. Thus, remove the unnecessary suspension to follow the datasheet instructions and to potentially reduce the minimum time between SPI transactions. 

Warning: this unnecessary operation is not causing problems at the moment as far as I know; this should be taken into consideration before approving this PR.

Here is the explanation about what receive-only mode is and how to set it:

![receive-only-mode](https://github.com/user-attachments/assets/e82a77a2-b0ff-4fb1-9be7-211df8eecf94)

![receive-only-mode-bits](https://github.com/user-attachments/assets/7df8805b-45f1-4658-86f9-baefac659890)


And here is the disabling procedure stated by the H7's datasheet:

![spi-disabling-procedure](https://github.com/user-attachments/assets/7eeff062-e1ed-4447-b934-184e00db7c57)



# Test plan

Run all the spi_loppback tests, with and without DMA/IRQs enabled, and with and without enabling the FIFO usage. That is:

Connect an STM32H7 board to the PC with pins D11 and D12 connected.

Open a minicom or equivalent terminal to read the test report.

Execute the following commands:

```
cd zephyrproject/zephyr

rm -rf zephyrproject/zephyr/build
west build -p auto -b nucleo_h753zi tests/drivers/spi/spi_loopback
west flash

rm -rf zephyrproject/zephyr/build
west build -p auto -b nucleo_h753zi -T tests/drivers/spi/spi_loopback/drivers.spi.stm32_spi_16bits_frames.loopback
west flash

rm -rf zephyrproject/zephyr/build
west build -p auto -b nucleo_h753zi -T tests/drivers/spi/spi_loopback/drivers.spi.stm32_spi_dma.loopback
west flash

rm -rf zephyrproject/zephyr/build
west build -p auto -b nucleo_h753zi -T tests/drivers/spi/spi_loopback/drivers.spi.stm32_spi_16bits_frames_dma.loopback
west flash

rm -rf zephyrproject/zephyr/build
west build -p auto -b nucleo_h753zi -T tests/drivers/spi/spi_loopback/drivers.spi.stm32_spi_dma_dt_nocache_mem.loopback
west flash

rm -rf zephyrproject/zephyr/build
west build -p auto -b nucleo_h753zi -T tests/drivers/spi/spi_loopback/drivers.spi.stm32_spi_16bits_frames_dma_dt_nocache_mem.loopback
west flash

rm -rf zephyrproject/zephyr/build
west build -p auto -b nucleo_h753zi -T tests/drivers/spi/spi_loopback/drivers.spi.stm32_spi_interrupt.loopback
west flash
```

Execute the commands above, this time with the SPI fifo enabled. To do this, add `fifo-enable;` to the `spi1` node in `tests/drivers/spi/spi_loopback/overlay-stm32-spi-16bits.overlay` and in `tests/drivers/spi/spi_loopback/boards/nucleo_h753zi.overlay`
