### PR TITLE
native_sim BOARD_NATIVE_POSIX/BOARD_NATIVE_SIM depend fixes

### DIFF
--- a/drivers/timer/Kconfig.native_posix
+++ b/drivers/timer/Kconfig.native_posix
@@ -6,7 +6,7 @@
 config NATIVE_POSIX_TIMER
 	bool "(POSIX) native_sim/posix timer driver"
 	default y
-	depends on BOARD_NATIVE_POSIX
+	depends on BOARD_NATIVE_POSIX || BOARD_NATIVE_SIM
 	select TICKLESS_CAPABLE
 	select TIMER_HAS_64BIT_CYCLE_COUNTER
 	select SYSTEM_TIMER_HAS_DISABLE_SUPPORT

--- a/tests/boards/native_sim/cpu_wait/src/main.c
+++ b/tests/boards/native_sim/cpu_wait/src/main.c
@@ -214,7 +214,7 @@ static void np_timer_isr_test_replacement(const void *arg)
  */
 ZTEST(native_cpu_hold, test_cpu_hold_with_interrupts)
 {
-#if defined(CONFIG_BOARD_NATIVE_POSIX)
+#if defined(CONFIG_BOARD_NATIVE_POSIX) || defined(CONFIG_BOARD_NATIVE_SIM)
 	/* So far we only have a test for native_posix.
 	 * As the test hooks into an interrupt to cause an extra delay
 	 * this is very platform specific


### PR DESCRIPTION
So far native_sim is setting NATIVE_SIM_NATIVE_POSIX_COMPAT, which make native_sim pretend to be native_posix from kconfig point of view. This is done to avoid breaking users during the transition, but native_sim will eventually stop doing it.
Let's fix to incorrect checks in tree of BOARD_NATIVE_POSIX, where a driver and test work both with native_posix and native_sim, but were checking still for BOARD_NATIVE_POSIX only.
