### PR TITLE
boards: nordic: do not enable DMA_RAM21 region by default

### DIFF
--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuapp.dts
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuapp.dts
@@ -193,10 +193,6 @@ ipc0: &cpuapp_cpurad_ipc {
 	status = "okay";
 };
 
-&dma_fast_region {
-	status = "okay";
-};
-
 &cpuapp_rx_partitions {
 	status = "okay";
 };

--- a/boards/nordic/nrf9280pdk/nrf9280pdk_nrf9280_cpuapp.dts
+++ b/boards/nordic/nrf9280pdk/nrf9280pdk_nrf9280_cpuapp.dts
@@ -197,10 +197,6 @@ ipc0: &cpuapp_cpurad_ipc {
 	status = "okay";
 };
 
-&dma_fast_region {
-	status = "okay";
-};
-
 &cpuapp_rx_partitions {
 	status = "okay";
 };

--- a/tests/boards/nrf/dmm/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/tests/boards/nrf/dmm/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -47,6 +47,10 @@
 	memory-regions = <&cpuapp_dma_region>;
 };
 
+&dma_fast_region {
+	status = "okay";
+};
+
 &spi120
 {
 	compatible = "nordic,nrf-spim";

--- a/tests/drivers/spi/spi_controller_peripheral/boards/nrf54h20dk_nrf54h20_cpuapp_fast.overlay
+++ b/tests/drivers/spi/spi_controller_peripheral/boards/nrf54h20dk_nrf54h20_cpuapp_fast.overlay
@@ -46,6 +46,10 @@
 	status = "okay";
 };
 
+&dma_fast_region {
+	status = "okay";
+};
+
 &spi121 {
 	compatible = "nordic,nrf-spim";
 	status = "okay";

--- a/tests/drivers/spi/spi_error_cases/boards/nrf54h20dk_nrf54h20_cpuapp_fast.overlay
+++ b/tests/drivers/spi/spi_error_cases/boards/nrf54h20dk_nrf54h20_cpuapp_fast.overlay
@@ -46,6 +46,10 @@
 	status = "okay";
 };
 
+&dma_fast_region {
+	status = "okay";
+};
+
 &spi121 {
 	compatible = "nordic,nrf-spim";
 	status = "okay";

--- a/tests/drivers/spi/spi_loopback/boards/nrf54h20dk_nrf54h20_cpuapp_fast.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nrf54h20dk_nrf54h20_cpuapp_fast.overlay
@@ -23,6 +23,10 @@
 	};
 };
 
+&dma_fast_region {
+	status = "okay";
+};
+
 &spi120 {
 	status = "okay";
 	pinctrl-0 = <&spi120_default>;


### PR DESCRIPTION
This region is only required if certain fast peripherals make use of such region for DMAing. It was now enabled on all builds, often resulting in:

```
[134/134] Linking C executable zephyr/zephyr.elf
Memory region         Used Size  Region Size  %age Used
           FLASH:       24372 B       248 KB      9.60%
             RAM:        4448 B       256 KB      1.70%
       DMA_RAM21:          0 GB        16 KB      0.00% <~~ Not used!
   DMA_RAM3x_APP:          40 B         4 KB      0.98%
        IDT_LIST:          0 GB        32 KB      0.00%
```