### PR TITLE
net: lib: coap: make ACK random factor runtime configurable

### DIFF
--- a/doc/releases/migration-guide-4.0.rst
+++ b/doc/releases/migration-guide-4.0.rst
@@ -306,6 +306,9 @@ Networking
   :c:func:`coap_get_block2_option` now accepts an additional ``bool *has_more``
   parameter, to store the value of the more flag. (:github:`76052`)
 
+* The struct :c:struct:`coap_transmission_parameters` has a new field ``ack_random_percent`` if
+  :kconfig:option:`CONFIG_COAP_RANDOMIZE_ACK_TIMEOUT` is enabled. (:github:`79058`)
+
 * The Ethernet bridge shell is moved under network shell. This is done so that
   all the network shell activities can be found under ``net`` shell command.
   After this change the bridge shell is used by ``net bridge`` command. (:github:`77235`)

--- a/include/zephyr/net/coap.h
+++ b/include/zephyr/net/coap.h
@@ -355,8 +355,15 @@ typedef int (*coap_reply_t)(const struct coap_packet *response,
  * @brief CoAP transmission parameters.
  */
 struct coap_transmission_parameters {
-	/**  Initial ACK timeout. Value is used as a base value to retry pending CoAP packets. */
+	/** Initial ACK timeout. Value is used as a base value to retry pending CoAP packets. */
 	uint32_t ack_timeout;
+#if defined(CONFIG_COAP_RANDOMIZE_ACK_TIMEOUT) || defined(__DOXYGEN__)
+	/**
+	 * Set CoAP ack random factor. A value of 150 means a factor of 1.5. A value of 0 defaults
+	 * to @kconfig{CONFIG_COAP_ACK_RANDOM_PERCENT}. The value must be >= 100.
+	 */
+	uint16_t ack_random_percent;
+#endif /* defined(CONFIG_COAP_RANDOMIZE_ACK_TIMEOUT) */
 	/** Set CoAP retry backoff factor. A value of 200 means a factor of 2.0. */
 	uint16_t coap_backoff_percent;
 	/** Maximum number of retransmissions. */

--- a/subsys/net/lib/coap/coap.c
+++ b/subsys/net/lib/coap/coap.c
@@ -59,6 +59,9 @@ static uint16_t message_id;
 static struct coap_transmission_parameters coap_transmission_params = {
 	.max_retransmission = CONFIG_COAP_MAX_RETRANSMIT,
 	.ack_timeout = CONFIG_COAP_INIT_ACK_TIMEOUT_MS,
+#if defined(CONFIG_COAP_RANDOMIZE_ACK_TIMEOUT)
+	.ack_random_percent = CONFIG_COAP_ACK_RANDOM_PERCENT,
+#endif /* defined(CONFIG_COAP_RANDOMIZE_ACK_TIMEOUT) */
 	.coap_backoff_percent = CONFIG_COAP_BACKOFF_PERCENT
 };
 
@@ -1706,8 +1709,9 @@ struct coap_pending *coap_pending_next_to_expire(
 static uint32_t init_ack_timeout(const struct coap_transmission_parameters *params)
 {
 #if defined(CONFIG_COAP_RANDOMIZE_ACK_TIMEOUT)
-	const uint32_t max_ack = params->ack_timeout *
-				 CONFIG_COAP_ACK_RANDOM_PERCENT / 100;
+	const uint16_t random_percent = params->ack_random_percent ? params->ack_random_percent
+								   : CONFIG_COAP_ACK_RANDOM_PERCENT;
+	const uint32_t max_ack = params->ack_timeout * random_percent / 100U;
 	const uint32_t min_ack = params->ack_timeout;
 
 	/* Randomly generated initial ACK timeout

--- a/tests/net/lib/coap/src/main.c
+++ b/tests/net/lib/coap/src/main.c
@@ -1750,12 +1750,15 @@ ZTEST(coap, test_transmission_parameters)
 
 	params = coap_get_transmission_parameters();
 	zassert_equal(params.ack_timeout, CONFIG_COAP_INIT_ACK_TIMEOUT_MS, "Wrong ACK timeout");
+	zassert_equal(params.ack_random_percent, CONFIG_COAP_ACK_RANDOM_PERCENT,
+		      "Wrong ACK random percent");
 	zassert_equal(params.coap_backoff_percent, CONFIG_COAP_BACKOFF_PERCENT,
 		      "Wrong backoff percent");
 	zassert_equal(params.max_retransmission, CONFIG_COAP_MAX_RETRANSMIT,
 		      "Wrong max retransmission value");
 
 	params.ack_timeout = 1000;
+	params.ack_random_percent = 110;
 	params.coap_backoff_percent = 150;
 	params.max_retransmission = 2;
 
@@ -1772,6 +1775,7 @@ ZTEST(coap, test_transmission_parameters)
 	zassert_not_null(pending, "No free pending");
 
 	params.ack_timeout = 3000;
+	params.ack_random_percent = 130;
 	params.coap_backoff_percent = 250;
 	params.max_retransmission = 3;
 
@@ -1780,6 +1784,7 @@ ZTEST(coap, test_transmission_parameters)
 	zassert_equal(r, 0, "Could not initialize packet");
 
 	zassert_equal(pending->params.ack_timeout, 3000, "Wrong ACK timeout");
+	zassert_equal(pending->params.ack_random_percent, 130, "Wrong ACK random percent");
 	zassert_equal(pending->params.coap_backoff_percent, 250, "Wrong backoff percent");
 	zassert_equal(pending->params.max_retransmission, 3, "Wrong max retransmission value");
 
@@ -1788,6 +1793,7 @@ ZTEST(coap, test_transmission_parameters)
 	zassert_equal(r, 0, "Could not initialize packet");
 
 	zassert_equal(pending->params.ack_timeout, 1000, "Wrong ACK timeout");
+	zassert_equal(pending->params.ack_random_percent, 110, "Wrong ACK random percent");
 	zassert_equal(pending->params.coap_backoff_percent, 150, "Wrong backoff percent");
 	zassert_equal(pending->params.max_retransmission, 2, "Wrong max retransmission value");
 }


### PR DESCRIPTION
Extend the `coap_transmission_parameters` struct with the field `ack_random_percent`. This was the last remaining CoAP transmission parameter that was not configurable at runtime.