### PR TITLE
soc: nxp: Fix MCXW71 initialization flow

### DIFF
--- a/soc/nxp/mcx/mcxw/Kconfig
+++ b/soc/nxp/mcx/mcxw/Kconfig
@@ -12,5 +12,5 @@ config SOC_SERIES_MCXW
 	select CPU_HAS_ARM_MPU
 	select ARMV8_M_DSP
 	select HAS_MCUX
-	select PLATFORM_SPECIFIC_INIT
+	select SOC_RESET_HOOK
 	select CLOCK_CONTROL

--- a/soc/nxp/mcx/mcxw/mcxw71_platform_init.S
+++ b/soc/nxp/mcx/mcxw/mcxw71_platform_init.S
@@ -16,13 +16,13 @@
 #include <zephyr/linker/sections.h>
 
 _ASM_FILE_PROLOGUE
-#ifdef CONFIG_PLATFORM_SPECIFIC_INIT
+#ifdef CONFIG_SOC_RESET_HOOK
 
 
-GTEXT(z_arm_platform_init)
-SECTION_SUBSEC_FUNC(TEXT,_reset_section,z_arm_platform_init)
+GTEXT(init_ecc_ram)
+SECTION_SUBSEC_FUNC(TEXT,_reset_section,init_ecc_ram)
 
-.z_arm_platform_init:
+.init_ecc_ram:
     ldr r0, =0x14000000
     ldr r1, =.ram_init_ctcm01
     bics r1, #0x10000000
@@ -56,4 +56,4 @@ SECTION_SUBSEC_FUNC(TEXT,_reset_section,z_arm_platform_init)
 .ram_init_done:
     b SystemInit
 
-#endif /* CONFIG_PLATFORM_SPECIFIC_INIT */
+#endif /* CONFIG_SOC_RESET_HOOK */

--- a/soc/nxp/mcx/mcxw/soc.c
+++ b/soc/nxp/mcx/mcxw/soc.c
@@ -17,6 +17,7 @@
 #include <fsl_clock.h>
 
 extern uint32_t SystemCoreClock;
+extern void init_ecc_ram(void);
 
 static ALWAYS_INLINE void clock_init(void)
 {
@@ -163,4 +164,8 @@ static int nxp_mcxw71_init(void)
 	return 0;
 }
 
+void soc_reset_hook(void)
+{
+	init_ecc_ram();
+}
 SYS_INIT(nxp_mcxw71_init, PRE_KERNEL_1, 0);


### PR DESCRIPTION
ECC Ram init was missing, which produces faults when accessing the memory region.