### PR TITLE
cmake: change test message overwrite to macro

### DIFF
--- a/tests/cmake/yaml/CMakeLists.txt
+++ b/tests/cmake/yaml/CMakeLists.txt
@@ -8,7 +8,7 @@ target_sources(app PRIVATE ${ZEPHYR_BASE}/misc/empty_file.c)
 
 set_property(GLOBAL PROPERTY EXPECTED_ERROR 0)
 
-function(message)
+macro(message)
   if(DEFINED expect_failure)
   if(${ARGV0} STREQUAL FATAL_ERROR)
     if("${ARGV1}" STREQUAL "${expect_failure}")
@@ -23,7 +23,7 @@ function(message)
     endif()
   endif()
   _message(${ARGN})
-endfunction()
+endmacro()
 
 macro(test_assert)
   cmake_parse_arguments(TA_ARG "" "COMMENT" "TEST" ${ARGN})


### PR DESCRIPTION
Fixes: #79052

The yaml CMake tests overwrites `message()` in order to verify correct error handling. This was original done in a function and then using a return call when an expected error has been raised. Using a function() means the `return()` only returns the `message()` and thus wrongly continue processing rest of the yaml file.

Change `message()` to macro so the return call correctly returns from the calling yaml functions.