### PR TITLE
Bluetooth: BAP: Disallow bt_bap_stream_stop when CIS is not connected

### DIFF
--- a/include/zephyr/bluetooth/audio/bap.h
+++ b/include/zephyr/bluetooth/audio/bap.h
@@ -815,6 +815,16 @@ int bt_bap_stream_start(struct bt_bap_stream *stream);
  *
  * @param stream Stream object
  *
+ * @retval 0 Success
+ * @retval -EINVAL The @p stream does not have an endpoint or a connection, of the stream's
+ *                 connection's role is not @p BT_HCI_ROLE_CENTRAL
+ * @retval -EBADMSG The state of the @p stream endpoint is not @ref BT_BAP_EP_STATE_DISABLING
+ * @retval -EALREADY The CIS state of the @p is not in a connected state, and thus is already
+ *                   stopping
+ * @retval -EBUSY The @p stream is busy with another operation
+ * @retval -ENOTCONN The @p stream ACL connection is not connected
+ * @retval -ENOMEM No memory to send request
+ * @retval -ENOEXEC The request was rejected by GATT
  * @return 0 in case of success or negative value in case of error.
  */
 int bt_bap_stream_stop(struct bt_bap_stream *stream);

--- a/subsys/bluetooth/audio/bap_unicast_client.c
+++ b/subsys/bluetooth/audio/bap_unicast_client.c
@@ -3395,7 +3395,18 @@ int bt_bap_unicast_client_stop(struct bt_bap_stream *stream)
 		}
 		req->num_ases++;
 
-		return bt_bap_unicast_client_ep_send(stream->conn, ep, buf);
+		err = bt_bap_unicast_client_ep_send(stream->conn, ep, buf);
+		if (err != 0) {
+			/* Return expected error directly */
+			if (err == -ENOTCONN || err == -ENOMEM) {
+				return err;
+			}
+
+			LOG_DBG("bt_bap_unicast_client_ep_send failed with unexpected error %d",
+				err);
+
+			return -ENOEXEC;
+		}
 	}
 
 	return 0;


### PR DESCRIPTION
When the CIS for a BAP stream is not connected, we cannot truly be in the disabling state (the only state the stop operation can be performed by the unicast client).

The reason for this is that if the CIS is disconnected, then the ASCS server shall transition to the QoS Configured state regardless of whether it has received a receiver stop ready command from the unicast client.