### PR TITLE
manifest: Update hal_silabs reference

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -223,7 +223,7 @@ manifest:
       groups:
         - hal
     - name: hal_silabs
-      revision: bb44c61d3f8b1e00d7b3d3804cfaf8df1e905d5d
+      revision: pull/71/head
       path: modules/hal/silabs
       groups:
         - hal


### PR DESCRIPTION
Update hal_silabs to latest revision, which removes some unused files in the gecko HAL.