### PR TITLE
boards: nxp: mimxrt1060_evk: Updated Active state for user_led

### DIFF
--- a/boards/nxp/mimxrt1060_evk/mimxrt1060_evkb.dts
+++ b/boards/nxp/mimxrt1060_evk/mimxrt1060_evkb.dts
@@ -13,6 +13,6 @@
 };
 
 &green_led {
-	gpios = <&gpio1 8 GPIO_ACTIVE_LOW>;
+	gpios = <&gpio1 8 GPIO_ACTIVE_HIGH>;
 	label = "User LED1";
 };


### PR DESCRIPTION
Fixes [#76502](https://github.com/zephyrproject-rtos/zephyr/issues/76502)