### PR TITLE
drivers: adc/wifi: esp32s2/esp32c3: call to adc2_init_code_calibration

### DIFF
--- a/drivers/adc/adc_esp32.c
+++ b/drivers/adc/adc_esp32.c
@@ -654,6 +654,12 @@ static int adc_esp32_init(const struct device *dev)
 
 	adc_hw_calibration(conf->unit);
 
+#if CONFIG_SOC_SERIES_ESP32S2 || CONFIG_SOC_SERIES_ESP32C3
+	if (conf->unit == ADC_UNIT_2) {
+		adc2_init_code_calibration();
+	}
+#endif /* CONFIG_SOC_SERIES_ESP32S2 || CONFIG_SOC_SERIES_ESP32C3 */
+
 #if defined(CONFIG_ADC_ESP32_DMA)
 	if (!device_is_ready(conf->gpio_port)) {
 		LOG_ERR("gpio0 port not ready");

--- a/drivers/wifi/esp32/src/esp_wifi_drv.c
+++ b/drivers/wifi/esp32/src/esp_wifi_drv.c
@@ -27,6 +27,10 @@ LOG_MODULE_REGISTER(esp32_wifi, CONFIG_WIFI_LOG_LEVEL);
 #include <esp_mac.h>
 #include "wifi/wifi_event.h"
 
+#if CONFIG_SOC_SERIES_ESP32S2 || CONFIG_SOC_SERIES_ESP32C3
+#include <esp_private/adc_share_hw_ctrl.h>
+#endif /* CONFIG_SOC_SERIES_ESP32S2 || CONFIG_SOC_SERIES_ESP32C3 */
+
 #define DHCPV4_MASK (NET_EVENT_IPV4_DHCP_BOUND | NET_EVENT_IPV4_DHCP_STOP)
 
 /* use global iface pointer to support any ethernet driver */
@@ -862,6 +866,10 @@ static int esp32_wifi_stats(const struct device *dev, struct net_stats_wifi *sta
 
 static int esp32_wifi_dev_init(const struct device *dev)
 {
+#if CONFIG_SOC_SERIES_ESP32S2 || CONFIG_SOC_SERIES_ESP32C3
+	adc2_init_code_calibration();
+#endif /* CONFIG_SOC_SERIES_ESP32S2 || CONFIG_SOC_SERIES_ESP32C3 */
+
 	esp_timer_init();
 	wifi_init_config_t config = WIFI_INIT_CONFIG_DEFAULT();
 	esp_err_t ret = esp_wifi_init(&config);


### PR DESCRIPTION
Add call to adc2_init_code_calibration() during adc and wifi initialization on esp32s2 and esp32c3