### PR TITLE
[v3.7-branch] soc: esp32s3: fix initialization code

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -157,7 +157,7 @@ manifest:
       groups:
         - hal
     - name: hal_espressif
-      revision: 796b3f62af6dc10cb7c7953f73c81882d4011d8d
+      revision: 012f61c5629f5b8f62928a772d80458341be8456
       path: modules/hal/espressif
       west-commands: west/west-commands.yml
       groups:


### PR DESCRIPTION
ESP32-S3 initialization code should apply the errata after cache
initialization. This fixes it making sure data and cache instruction are properly
handled and let following calls to work as needed.

This also update hal_espressif to force gcc to treat register bitfield
structs declared as volatile to ensure writes on 32 bit peripheral registers.

Fixes #71397
Fixes #76325

This PR backports partial changes of #78234 and https://github.com/zephyrproject-rtos/hal_espressif/pull/304 into v3.7-branch.
