### PR TITLE
picolibc: Update module to version 1.8.8

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -315,7 +315,7 @@ manifest:
         - debug
     - name: picolibc
       path: modules/lib/picolibc
-      revision: 06bde1fd7531b1f788f6e42b6f7b358c0fe4f814
+      revision: e15656f7682500fc8953e1a2008f7b1ae4f65ce8
     - name: segger
       revision: b011c45b585e097d95d9cf93edf4f2e01588d3cd
       path: modules/debug/segger


### PR DESCRIPTION
Switch to released version with all of the Zephyr build fixes.