### PR TITLE
samples: rtc: add a generic RTC sample

### DIFF
--- a/samples/drivers/rtc/CMakeLists.txt
+++ b/samples/drivers/rtc/CMakeLists.txt
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(rtc)
+
+FILE(GLOB app_sources src/*.c)
+target_sources(app PRIVATE ${app_sources})

--- a/samples/drivers/rtc/README.rst
+++ b/samples/drivers/rtc/README.rst
@@ -1,0 +1,34 @@
+.. zephyr:code-sample:: rtc
+   :name: Real-Time Clock (RTC)
+   :relevant-api: rtc_interface
+
+   Set and read the date/time from a Real-Time Clock.
+
+Overview
+********
+
+This sample shows how to use the :ref:`rtc driver API <rtc_api>`
+to set and read the date/time from RTC and display on the console
+and can be built and executed on boards supporting RTC.
+
+Building and Running
+********************
+
+Build and flash as follows, replacing ``stm32f3_disco`` with your board:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/drivers/rtc
+   :board: stm32f3_disco
+   :goals: build flash
+   :compact:
+
+Sample Output
+=============
+
+.. code-block:: console
+
+   RTC date and time: 2024-11-17 04:21:47
+   RTC date and time: 2024-11-17 04:21:48
+   RTC date and time: 2024-11-17 04:21:49
+
+   <repeats endlessly>

--- a/samples/drivers/rtc/boards/qemu_x86.overlay
+++ b/samples/drivers/rtc/boards/qemu_x86.overlay
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2023 Bjarki Arge Andreasen
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * The RTC IRQ is not routed to the IOAPIC if the legacy
+ * IRQ bit is set. The IRQ is required for alarm
+ * operation and the update callback.
+ */
+&hpet {
+	no-legacy-irq;
+};
+
+&rtc {
+	status = "okay";
+};

--- a/samples/drivers/rtc/boards/qemu_x86_64.overlay
+++ b/samples/drivers/rtc/boards/qemu_x86_64.overlay
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2023 Bjarki Arge Andreasen
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * The RTC IRQ is not routed to the IOAPIC if the legacy
+ * IRQ bit is set. The IRQ is required for alarm
+ * operation and the update callback.
+ */
+&hpet {
+	no-legacy-irq;
+};
+
+&rtc {
+	status = "okay";
+};

--- a/samples/drivers/rtc/boards/stm32f3_disco.overlay
+++ b/samples/drivers/rtc/boards/stm32f3_disco.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2024 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		rtc = &rtc;
+	};
+};

--- a/samples/drivers/rtc/prj.conf
+++ b/samples/drivers/rtc/prj.conf
@@ -1,0 +1,2 @@
+# Enable Peripheral
+CONFIG_RTC=y

--- a/samples/drivers/rtc/sample.yaml
+++ b/samples/drivers/rtc/sample.yaml
@@ -1,0 +1,12 @@
+sample:
+  name: Real-Time Clock Sample
+tests:
+  sample.drivers.rtc:
+    platform_allow:
+      - stm32f3_disco
+    tags:
+      - samples
+      - rtc
+      - api
+    depends_on:
+      - rtc

--- a/samples/drivers/rtc/src/main.c
+++ b/samples/drivers/rtc/src/main.c
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2024, Muhammad Waleed Badar
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/rtc.h>
+#include <zephyr/sys/util.h>
+
+const struct device *const rtc = DEVICE_DT_GET(DT_ALIAS(rtc));
+
+static int set_date_time(const struct device *rtc)
+{
+	int ret = 0;
+	struct rtc_time tm = {
+		.tm_year = 2024 - 1900,
+		.tm_mon = 11 - 1,
+		.tm_mday = 17,
+		.tm_hour = 4,
+		.tm_min = 19,
+		.tm_sec = 0,
+	};
+
+	ret = rtc_set_time(rtc, &tm);
+	if (ret < 0) {
+		printk("Cannot write date time: %d\n", ret);
+		return ret;
+	}
+	return ret;
+}
+
+static int get_date_time(const struct device *rtc)
+{
+	int ret = 0;
+	struct rtc_time tm;
+
+	ret = rtc_get_time(rtc, &tm);
+	if (ret < 0) {
+		printk("Cannot read date time: %d\n", ret);
+		return ret;
+	}
+
+	printk("RTC date and time: %04d-%02d-%02d %02d:%02d:%02d\n", tm.tm_year + 1900,
+	       tm.tm_mon + 1, tm.tm_mday, tm.tm_hour, tm.tm_min, tm.tm_sec);
+
+	return ret;
+}
+
+int main(void)
+{
+	/* Check if the RTC is ready */
+	if (!device_is_ready(rtc)) {
+		printk("Device is not ready\n");
+		return 0;
+	}
+
+	set_date_time(rtc);
+
+	/* Continuously read the current date and time from the RTC */
+	while (get_date_time(rtc) == 0) {
+		k_sleep(K_MSEC(1000));
+	};
+	return 0;
+}


### PR DESCRIPTION
This sample app sets and periodically reads date/time from the RTC.

Tested with stm32f3 discovery board internal RTC.

![image](https://github.com/user-attachments/assets/c36361af-eaaf-4772-b747-42d0fbe528c2)







