### PR TITLE
hostap: add crypto module test kconfig option

### DIFF
--- a/modules/hostap/CMakeLists.txt
+++ b/modules/hostap/CMakeLists.txt
@@ -503,6 +503,13 @@ zephyr_library_sources_ifdef(CONFIG_WIFI_NM_WPA_SUPPLICANT_CRYPTO_ENTERPRISE
 	${HOSTAP_SRC_BASE}/crypto/fips_prf_internal.c
 	${HOSTAP_SRC_BASE}/crypto/milenage.c
 )
+
+zephyr_library_sources_ifdef(CONFIG_WIFI_NM_WPA_SUPPLICANT_CRYPTO_TEST
+	${HOSTAP_SRC_BASE}/crypto/crypto_module_tests.c
+	${HOSTAP_SRC_BASE}/crypto/fips_prf_internal.c
+	${HOSTAP_SRC_BASE}/crypto/sha1-internal.c
+	${HOSTAP_SRC_BASE}/crypto/sha1-tlsprf.c
+)
 endif()
 
 zephyr_library_link_libraries_ifndef(CONFIG_WIFI_NM_WPA_SUPPLICANT_CRYPTO_NONE

--- a/modules/hostap/Kconfig
+++ b/modules/hostap/Kconfig
@@ -485,4 +485,8 @@ config SAE_PWE_EARLY_EXIT
 	  this can be intensive, so, add an option to exit early.
 	  Note that this is highly insecure and shouldn't be used in production
 
+config WIFI_NM_WPA_SUPPLICANT_CRYPTO_TEST
+	bool
+	depends on WIFI_NM_WPA_SUPPLICANT_CRYPTO_MBEDTLS_PSA
+
 endif # WIFI_NM_WPA_SUPPLICANT

--- a/west.yml
+++ b/west.yml
@@ -259,7 +259,7 @@ manifest:
         - hal
     - name: hostap
       path: modules/lib/hostap
-      revision: f6792cb45d848df5d562dd9255dfc6acf62be164
+      revision: d84b1ea174407f9a501976fb294e39c40c348645
     - name: libmetal
       revision: a6851ba6dba8c9e87d00c42f171a822f7a29639b
       path: modules/hal/libmetal


### PR DESCRIPTION
Add crypto module test kconfig option
CONFIG_WIFI_NM_WPA_SUPPLICANT_CRYPTO_TEST,
which is default n and hidden.
It is only available by developer for crypto module test.

460d08c0d56c39c00fa9d0155d7b03d519125592
west.yml: update hostap revision
    
    Update hostap revision to get crypto module test.