### PR TITLE
samples: button: add comment for `input` subsys

### DIFF
--- a/samples/basic/button/src/main.c
+++ b/samples/basic/button/src/main.c
@@ -3,6 +3,10 @@
  * Copyright (c) 2020 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * NOTE: If you are looking into an implementation of button events with
+ * debouncing, check out `input` subsystem and `samples/subsys/input/input_dump`
+ * example instead.
  */
 
 #include <zephyr/kernel.h>


### PR DESCRIPTION
We wanted to redirect users who wants a debounced driver, as discussed here 

Fixes #78813