### PR TITLE
Draft: lib: os: Extend hashmap support

### DIFF
--- a/include/zephyr/sys/hash_map.h
+++ b/include/zephyr/sys/hash_map.h
@@ -32,6 +32,48 @@ extern "C" {
  *
  * Declare a Hashmap with control over advanced parameters.
  *
+ * @param _name Name of the Hashmap.
+ * @param _config_type Variant of @ref sys_hashmap_config.
+ * @param _data_type Variant of @ref sys_hashmap_data.
+ */
+#define SYS_HASHMAP_DECLARE_ADVANCED(_name, _config_type, _data_type) \
+	struct _config_type _name##_config; \
+	struct _data_type _name##_data; \
+	struct sys_hashmap _name;
+
+/**
+ * @brief Init a Hashmap (advanced)
+ *
+ * Init a Hashmap with control over advanced parameters.
+ *
+ * @note The allocator @p _alloc is used for allocating internal Hashmap
+ * entries and does not interact with any user-provided keys or values.
+ *
+ * @param _name Name of the Hashmap.
+ * @param _api API pointer of type @ref sys_hashmap_api.
+ * @param _hash_func Hash function pointer of type @ref sys_hash_func32_t.
+ * @param _alloc_func Allocator function pointer of type @ref sys_hashmap_allocator_t.
+ * @param _max_size Maximum number of entries
+ * @param _load_factor Maximum load factor of expressed in hundredths
+ */
+#define SYS_HASHMAP_INIT_ADVANCED(_name, _api, _hash_func, _alloc_func, \
+								  _max_size, _load_factor) \
+    { \
+		SYS_HASHMAP_CONFIG_INIT(_name, _max_size, _load_factor) \
+		memset(&_name##_data, 0, sizeof(_name##_data)); \
+		memset(&_name, 0, sizeof(_name)); \
+		_name.api = (const struct sys_hashmap_api *)(_api); \
+		_name.config = (const struct sys_hashmap_config *)&_name##_config; \
+		_name.data = (struct sys_hashmap_data *)&_name##_data; \
+		_name.hash_func = (_hash_func); \
+		_name.alloc_func = (_alloc_func); \
+    }
+
+/**
+ * @brief Declare a Hashmap (advanced)
+ *
+ * Declare a Hashmap with control over advanced parameters.
+ *
  * @note The allocator @p _alloc is used for allocating internal Hashmap
  * entries and does not interact with any user-provided keys or values.
  *

--- a/include/zephyr/sys/hash_map_api.h
+++ b/include/zephyr/sys/hash_map_api.h
@@ -218,6 +218,23 @@ struct sys_hashmap_config {
 	}
 
 /**
+ * @brief Initialize @p sys_hashmap_config
+ *
+ * This macro helps to initialize a structure of type @p sys_hashmap_config.
+ *
+* @param _name Name of the Hashmap
+ * @param _max_size Maximum number of entries
+ * @param _load_factor Maximum load factor of expressed in hundredths
+ */
+#define SYS_HASHMAP_CONFIG_INIT(_name, _max_size, _load_factor) \
+	{ \
+		memset(&_name##_config, 0, sizeof(_name##_config)); \
+		_name##_config.max_size = (size_t)_max_size; \
+		_name##_config.load_factor = (uint8_t)_load_factor; \
+		_name##_config.initial_n_buckets = NHPOT(DIV_ROUND_UP(100, _load_factor)); \
+	}
+
+/**
  * @brief Generic Hashmap data
  *
  * @note When @a size is zero, @a buckets should be `NULL`.

--- a/include/zephyr/sys/hash_map_cxx.h
+++ b/include/zephyr/sys/hash_map_cxx.h
@@ -36,6 +36,34 @@ extern "C" {
  * entries and does not interact with any user-provided keys or values.
  *
  * @param _name Name of the Hashmap.
+ */
+#define SYS_HASHMAP_CXX_DECLARE(_name) \
+	SYS_HASHMAP_DECLARE_ADVANCED(_name, sys_hashmap_config, sys_hashmap_data)
+
+/**
+ * @brief Init a C++ Hashmap (advanced)
+ *
+ * Init a C++ Hashmap with control over advanced parameters.
+ *
+ * @note The allocator @p _alloc is used for allocating internal Hashmap
+ * entries and does not interact with any user-provided keys or values.
+ *
+ * @param _name Name of the Hashmap.
+ * @param _hash_func Hash function pointer of type @ref sys_hash_func32_t.
+ * @param _alloc_func Allocator function pointer of type @ref sys_hashmap_allocator_t.
+ */
+#define SYS_HASHMAP_CXX_INIT_ADVANCED(_name, _hash_func, _alloc_func, _max_size, _load_factor) \
+	SYS_HASHMAP_INIT_ADVANCED(_name, &sys_hashmap_cxx_api, _hash_func, _alloc_func, _max_size, _load_factor)
+
+/**
+ * @brief Declare a C++ Hashmap (advanced)
+ *
+ * Declare a C++ Hashmap with control over advanced parameters.
+ *
+ * @note The allocator @p _alloc is used for allocating internal Hashmap
+ * entries and does not interact with any user-provided keys or values.
+ *
+ * @param _name Name of the Hashmap.
  * @param _hash_func Hash function pointer of type @ref sys_hash_func32_t.
  * @param _alloc_func Allocator function pointer of type @ref sys_hashmap_allocator_t.
  * @param ... Variant-specific details for @ref sys_hashmap_config.
@@ -86,8 +114,11 @@ extern "C" {
 		SYS_HASHMAP_CONFIG(SIZE_MAX, SYS_HASHMAP_DEFAULT_LOAD_FACTOR))
 
 #ifdef CONFIG_SYS_HASH_MAP_CHOICE_CXX
+#define SYS_HASHMAP_DEFAULT_DECLARE(_name) SYS_HASHMAP_CXX_DECLARE(_name)
 #define SYS_HASHMAP_DEFAULT_DEFINE(_name)	 SYS_HASHMAP_CXX_DEFINE(_name)
 #define SYS_HASHMAP_DEFAULT_DEFINE_STATIC(_name) SYS_HASHMAP_CXX_DEFINE_STATIC(_name)
+#define SYS_HASHMAP_DEFAULT_INIT_ADVANCED(_name, _hash_func, _alloc_func, _max_size, _load_factor) \
+	SYS_HASHMAP_CXX_INIT_ADVANCED(_name, _hash_func, _alloc_func, _max_size, _load_factor)
 #define SYS_HASHMAP_DEFAULT_DEFINE_ADVANCED(_name, _hash_func, _alloc_func, ...)                   \
 	SYS_HASHMAP_CXX_DEFINE_ADVANCED(_name, _hash_func, _alloc_func, __VA_ARGS__)
 #define SYS_HASHMAP_DEFAULT_DEFINE_STATIC_ADVANCED(_name, _hash_func, _alloc_func, ...)            \

--- a/include/zephyr/sys/hash_map_oa_lp.h
+++ b/include/zephyr/sys/hash_map_oa_lp.h
@@ -32,6 +32,32 @@ struct sys_hashmap_oa_lp_data {
 };
 
 /**
+ * @brief Declare a Open Addressing Linear Probe Hashmap
+ *
+ * Declare a Open Addressing Linear Probe Hashmap
+ *
+ * @param _name Name of the Hashmap.
+ */
+#define SYS_HASHMAP_OA_LP_DECLARE(_name) \
+	SYS_HASHMAP_DECLARE_ADVANCED(_name, sys_hashmap_config, sys_hashmap_oa_lp_data)
+
+/**
+ * @brief Init a Open Addressing Linear Probe Hashmap (advanced)
+ *
+ * Init a Open Addressing Linear Probe Hashmap with control over advanced parameters.
+ *
+ * @note The allocator @p _alloc is used for allocating internal Hashmap
+ * entries and does not interact with any user-provided keys or values.
+ *
+ * @param _name Name of the Hashmap.
+ * @param _hash_func Hash function pointer of type @ref sys_hash_func32_t.
+ * @param _alloc_func Allocator function pointer of type @ref sys_hashmap_allocator_t.
+ * @param ... Variant-specific details for @ref sys_hashmap_config.
+ */
+#define SYS_HASHMAP_OA_LP_INIT_ADVANCED(_name, _hash_func, _alloc_func, _max_size, _load_factor) \
+	SYS_HASHMAP_INIT_ADVANCED(_name, &sys_hashmap_oa_lp_api, _hash_func, _alloc_func, _max_size, _load_factor)
+
+/**
  * @brief Declare a Open Addressing Linear Probe Hashmap (advanced)
  *
  * Declare a Open Addressing Linear Probe Hashmap with control over advanced parameters.
@@ -91,8 +117,11 @@ struct sys_hashmap_oa_lp_data {
 		SYS_HASHMAP_CONFIG(SIZE_MAX, SYS_HASHMAP_DEFAULT_LOAD_FACTOR))
 
 #ifdef CONFIG_SYS_HASH_MAP_CHOICE_OA_LP
+#define SYS_HASHMAP_DEFAULT_DECLARE(_name) SYS_HASHMAP_OA_LP_DECLARE(_name)
 #define SYS_HASHMAP_DEFAULT_DEFINE(_name)	 SYS_HASHMAP_OA_LP_DEFINE(_name)
 #define SYS_HASHMAP_DEFAULT_DEFINE_STATIC(_name) SYS_HASHMAP_OA_LP_DEFINE_STATIC(_name)
+#define SYS_HASHMAP_DEFAULT_INIT_ADVANCED(_name, _hash_func, _alloc_func, _max_size, _load_factor) \
+	SYS_HASHMAP_OA_LP_INIT_ADVANCED(_name, _hash_func, _alloc_func, _max_size, _load_factor)
 #define SYS_HASHMAP_DEFAULT_DEFINE_ADVANCED(_name, _hash_func, _alloc_func, ...)                   \
 	SYS_HASHMAP_OA_LP_DEFINE_ADVANCED(_name, _hash_func, _alloc_func, __VA_ARGS__)
 #define SYS_HASHMAP_DEFAULT_DEFINE_STATIC_ADVANCED(_name, _hash_func, _alloc_func, ...)            \

--- a/include/zephyr/sys/hash_map_sc.h
+++ b/include/zephyr/sys/hash_map_sc.h
@@ -28,6 +28,32 @@ extern "C" {
 #endif
 
 /**
+ * @brief Declare a Separate Chaining Hashmap
+ *
+ * Declare a Separate Chaining Hashmap
+ *
+ * @param _name Name of the Hashmap.
+ */
+#define SYS_HASHMAP_SC_DECLARE(_name) \
+	SYS_HASHMAP_DECLARE_ADVANCED(_name, sys_hashmap_config, sys_hashmap_data)
+
+/**
+ * @brief Init a Separate Chaining Hashmap (advanced)
+ *
+ * Init a Separate Chaining Hashmap with control over advanced parameters.
+ *
+ * @note The allocator @p _alloc_func is used for allocating internal Hashmap
+ * entries and does not interact with any user-provided keys or values.
+ *
+ * @param _name Name of the Hashmap.
+ * @param _hash_func Hash function pointer of type @ref sys_hash_func32_t.
+ * @param _alloc_func Allocator function pointer of type @ref sys_hashmap_allocator_t.
+ * @param ... Details for @ref sys_hashmap_config.
+ */
+#define SYS_HASHMAP_SC_INIT_ADVANCED(_name, _hash_func, _alloc_func, _max_size, _load_factor) \
+	SYS_HASHMAP_INIT_ADVANCED(_name, &sys_hashmap_sc_api, _hash_func, _alloc_func, _max_size, _load_factor)
+
+/**
  * @brief Declare a Separate Chaining Hashmap (advanced)
  *
  * Declare a Separate Chaining Hashmap with control over advanced parameters.
@@ -86,8 +112,11 @@ extern "C" {
 		SYS_HASHMAP_CONFIG(SIZE_MAX, SYS_HASHMAP_DEFAULT_LOAD_FACTOR))
 
 #ifdef CONFIG_SYS_HASH_MAP_CHOICE_SC
+#define SYS_HASHMAP_DEFAULT_DECLARE(_name) SYS_HASHMAP_SC_DECLARE(_name)
 #define SYS_HASHMAP_DEFAULT_DEFINE(_name)	 SYS_HASHMAP_SC_DEFINE(_name)
 #define SYS_HASHMAP_DEFAULT_DEFINE_STATIC(_name) SYS_HASHMAP_SC_DEFINE_STATIC(_name)
+#define SYS_HASHMAP_DEFAULT_INIT_ADVANCED(_name, _hash_func, _alloc_func, _max_size, _load_factor) \
+	SYS_HASHMAP_SC_INIT_ADVANCED(_name, _hash_func, _alloc_func, _max_size, _load_factor)
 #define SYS_HASHMAP_DEFAULT_DEFINE_ADVANCED(_name, _hash_func, _alloc_func, ...)                   \
 	SYS_HASHMAP_SC_DEFINE_ADVANCED(_name, _hash_func, _alloc_func, __VA_ARGS__)
 #define SYS_HASHMAP_DEFAULT_DEFINE_STATIC_ADVANCED(_name, _hash_func, _alloc_func, ...)            \


### PR DESCRIPTION
Draft: At present the hashmap can be used only if it is declared as a independent Global variable. 
Extending the support to use hashmap as a member of any structure, global/local/heap/stack etc.