### PR TITLE
tests: drivers: build_all: gnss: Add serial devices to build test

### DIFF
--- a/tests/drivers/build_all/gnss/app.overlay
+++ b/tests/drivers/build_all/gnss/app.overlay
@@ -14,8 +14,21 @@
 			reg = <0x0 0x1000>;
 			status = "okay";
 
-			gnss: gnss-nmea-generic {
+			gnss_nmea_generic: gnss-nmea-generic {
 				compatible = "gnss-nmea-generic";
+			};
+
+			gnss_air530z: air530z {
+				compatible = "luatos,air530z";
+			};
+
+			gnss_lc86g: lc86g {
+				compatible = "quectel,lc86g";
+				pps-mode = "GNSS_PPS_MODE_ENABLED";
+			};
+
+			gnss_m8: m8 {
+				compatible = "u-blox,m8";
 			};
 		};
 	};

--- a/tests/drivers/build_all/gnss/testcase.yaml
+++ b/tests/drivers/build_all/gnss/testcase.yaml
@@ -5,4 +5,6 @@ common:
   build_only: true
   platform_allow: native_sim
 tests:
-  drivers.gnss.default: {}
+  drivers.gnss.default:
+    extra_configs:
+      - CONFIG_PM_DEVICE=y


### PR DESCRIPTION
Add build tests for following devices.

- luatos,air530z
- quectel,lc86g
- u-blox,m8