### PR TITLE
Update HAL STM32

### DIFF
--- a/drivers/clock_control/clock_stm32_ll_common.c
+++ b/drivers/clock_control/clock_stm32_ll_common.c
@@ -24,8 +24,13 @@
 #define z_hsi_divider(v) LL_RCC_HSI_DIV_ ## v
 #define hsi_divider(v) z_hsi_divider(v)
 
+#if defined(LL_RCC_HCLK_DIV_1)
+#define fn_ahb_prescaler(v) LL_RCC_HCLK_DIV_ ## v
+#define ahb_prescaler(v) fn_ahb_prescaler(v)
+#else
 #define fn_ahb_prescaler(v) LL_RCC_SYSCLK_DIV_ ## v
 #define ahb_prescaler(v) fn_ahb_prescaler(v)
+#endif
 
 #define fn_apb1_prescaler(v) LL_RCC_APB1_DIV_ ## v
 #define apb1_prescaler(v) fn_apb1_prescaler(v)
@@ -537,7 +542,7 @@ static void set_up_plls(void)
 	 */
 	if (LL_RCC_GetSysClkSource() == LL_RCC_SYS_CLKSOURCE_STATUS_PLL) {
 		stm32_clock_switch_to_hsi();
-		LL_RCC_SetAHBPrescaler(LL_RCC_SYSCLK_DIV_1);
+		LL_RCC_SetAHBPrescaler(ahb_prescaler(1));
 	}
 	LL_RCC_PLL_Disable();
 
@@ -800,9 +805,9 @@ int stm32_clock_control_init(const struct device *dev)
 	set_up_plls();
 
 	if (DT_PROP(DT_NODELABEL(rcc), undershoot_prevention) &&
-		(STM32_CORE_PRESCALER == LL_RCC_SYSCLK_DIV_1) &&
+		(ahb_prescaler(STM32_CORE_PRESCALER) == ahb_prescaler(1)) &&
 		(MHZ(80) < CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC)) {
-		LL_RCC_SetAHBPrescaler(LL_RCC_SYSCLK_DIV_2);
+		LL_RCC_SetAHBPrescaler(ahb_prescaler(2));
 	} else {
 		LL_RCC_SetAHBPrescaler(ahb_prescaler(STM32_CORE_PRESCALER));
 	}
@@ -827,7 +832,7 @@ int stm32_clock_control_init(const struct device *dev)
 #endif /* STM32_SYSCLK_SRC_... */
 
 	if (DT_PROP(DT_NODELABEL(rcc), undershoot_prevention) &&
-		(STM32_CORE_PRESCALER == LL_RCC_SYSCLK_DIV_1) &&
+		(ahb_prescaler(STM32_CORE_PRESCALER) == ahb_prescaler(1)) &&
 		(MHZ(80) < CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC)) {
 		LL_RCC_SetAHBPrescaler(ahb_prescaler(STM32_CORE_PRESCALER));
 	}

--- a/drivers/dma/dmamux_stm32.c
+++ b/drivers/dma/dmamux_stm32.c
@@ -70,7 +70,8 @@ uint32_t table_ll_channel[] = {
 	LISTIFY(DT_INST_PROP(0, dma_channels), DMAMUX_CHANNEL, (,))
 };
 
-#if !defined(CONFIG_SOC_SERIES_STM32G0X)
+#if !defined(CONFIG_SOC_SERIES_STM32G0X) && \
+	!defined(CONFIG_SOC_SERIES_STM32C0X)
 #define dmamux_channel_typedef DMAMUX_Channel_TypeDef
 #else
 #define dmamux_channel_typedef const DMAMUX_Channel_TypeDef

--- a/west.yml
+++ b/west.yml
@@ -233,7 +233,7 @@ manifest:
       groups:
         - hal
     - name: hal_stm32
-      revision: 1ff820533c1b1c17f1a4d7d28ab99a94a234883b
+      revision: 6f0e5f70cb540c487e3e3678af2e95d0937f9863
       path: modules/hal/stm32
       groups:
         - hal


### PR DESCRIPTION
This PR updates west.yml to use the latest versions of the STM32 HAL.
Also updates the clock driver for STM32C0 which uses different macros to set the AHB prescaler.