### PR TITLE
include: types.h: toolchain.h: Move TLS macro definition

### DIFF
--- a/include/zephyr/toolchain/common.h
+++ b/include/zephyr/toolchain/common.h
@@ -40,24 +40,6 @@
 #endif
 
 /*
- * Thread local variables are declared with different keywords depending on
- * which C/C++ standard that is used. C++11 and C23 uses "thread_local" whilst
- * C11 uses "_Thread_local". Previously the GNU "__thread" keyword was used
- * which is the same in both gcc and g++.
- */
-#ifndef Z_THREAD_LOCAL
-#if defined(__cplusplus) && (__cplusplus) >= 201103L /* C++11 */
-#define Z_THREAD_LOCAL thread_local
-#elif defined(__STDC_VERSION__) && (__STDC_VERSION__) >= 202311L /* C23 */
-#define Z_THREAD_LOCAL thread_local
-#elif defined(__STDC_VERSION__) && (__STDC_VERSION__) >= 201112L /* C11 */
-#define Z_THREAD_LOCAL _Thread_local
-#else /* Default back to old behavior which used the GNU keyword. */
-#define Z_THREAD_LOCAL __thread
-#endif
-#endif /* Z_THREAD_LOCAL */
-
-/*
  * Generate a reference to an external symbol.
  * The reference indicates to the linker that the symbol is required
  * by the module containing the reference and should be included

--- a/include/zephyr/types.h
+++ b/include/zephyr/types.h
@@ -29,6 +29,24 @@ typedef union {
 	void            (*thepfunc)(void);
 } z_max_align_t;
 
+/*
+ * Thread local variables are declared with different keywords depending on
+ * which C/C++ standard that is used. C++11 and C23 uses "thread_local" whilst
+ * C11 uses "_Thread_local". Previously the GNU "__thread" keyword was used
+ * which is the same in both gcc and g++.
+ */
+#ifndef Z_THREAD_LOCAL
+#if defined(__cplusplus) && (__cplusplus) >= 201103L /* C++11 */
+#define Z_THREAD_LOCAL thread_local
+#elif defined(__STDC_VERSION__) && (__STDC_VERSION__) >= 202311L /* C23 */
+#define Z_THREAD_LOCAL thread_local
+#elif defined(__STDC_VERSION__) && (__STDC_VERSION__) >= 201112L /* C11 */
+#define Z_THREAD_LOCAL _Thread_local
+#else /* Default back to old behavior which used the GNU keyword. */
+#define Z_THREAD_LOCAL __thread
+#endif
+#endif /* Z_THREAD_LOCAL */
+
 #ifdef __cplusplus
 /* Zephyr requires an int main(void) signature with C linkage for the application main if present */
 extern int main(void);


### PR DESCRIPTION
Move the `Z_THREAD_LOCAL` macro from
`include/zephyr/toolchain/common.h` to `include/zephyr/types.h`.

This is needed since some `syscall.h` files are using TLS but aren't including `zephyr/toolchain.h` (but they are including `zephyr/types.h`).

Signed-off-by: Daniel Flodin <daniel.flodin@iar.com>