### PR TITLE
samples: boards: nordic: system_off: Add GRTC wakeup

### DIFF
--- a/samples/boards/nordic/system_off/Kconfig
+++ b/samples/boards/nordic/system_off/Kconfig
@@ -21,4 +21,9 @@ config APP_USE_RETAINED_MEM
 
 endchoice
 
+config GRTC_WAKEUP_ENABLE
+	bool "Use GRTC to wake up device from system off"
+	help
+	  Switch wake up source from pressing sw0 button to GRTC
+
 source "Kconfig.zephyr"

--- a/samples/boards/nordic/system_off/sample.yaml
+++ b/samples/boards/nordic/system_off/sample.yaml
@@ -29,3 +29,9 @@ tests:
     extra_configs:
       - CONFIG_APP_USE_RETAINED_MEM=y
       - CONFIG_RETAINED_MEM=y
+  sample.boards.nrf.system_off.grtc_wakeup:
+    build_only: true
+    platform_allow:
+      - nrf54l15dk/nrf54l15/cpuapp
+    extra_configs:
+      - CONFIG_GRTC_WAKEUP_ENABLE=y

--- a/samples/boards/nordic/system_off/src/main.c
+++ b/samples/boards/nordic/system_off/src/main.c
@@ -16,7 +16,12 @@
 #include <zephyr/sys/poweroff.h>
 #include <zephyr/sys/util.h>
 
+#if defined(CONFIG_GRTC_WAKEUP_ENABLE)
+#include <zephyr/drivers/timer/nrf_grtc_timer.h>
+#define DEEP_SLEEP_TIME_S 2
+#else
 static const struct gpio_dt_spec sw0 = GPIO_DT_SPEC_GET(DT_ALIAS(sw0), gpios);
+#endif
 
 int main(void)
 {
@@ -45,6 +50,15 @@ int main(void)
 		printf("Retained data not supported\n");
 	}
 
+#if defined(CONFIG_GRTC_WAKEUP_ENABLE)
+	int err = z_nrf_grtc_wakeup_prepare(DEEP_SLEEP_TIME_S * USEC_PER_SEC);
+
+	if (err < 0) {
+		printk("Unable to prepare GRTC as a wake up source (err = %d).\n", err);
+	} else {
+		printk("Entering system off; wait %u seconds to restart\n", DEEP_SLEEP_TIME_S);
+	}
+#else
 	/* configure sw0 as input, interrupt as level active to allow wake-up */
 	rc = gpio_pin_configure_dt(&sw0, GPIO_INPUT);
 	if (rc < 0) {
@@ -59,6 +73,7 @@ int main(void)
 	}
 
 	printf("Entering system off; press sw0 to restart\n");
+#endif
 
 	rc = pm_device_action_run(cons, PM_DEVICE_ACTION_SUSPEND);
 	if (rc < 0) {


### PR DESCRIPTION
Extend system_off sample to use GRTC timer as a wake up source.