### PR TITLE
dts: arm: nordic: Define power states for nrf54h20/cpuapp

### DIFF
--- a/dts/common/nordic/nrf54h20.dtsi
+++ b/dts/common/nordic/nrf54h20.dtsi
@@ -28,6 +28,7 @@
 			device_type = "cpu";
 			clocks = <&cpuapp_hsfll>;
 			clock-frequency = <DT_FREQ_M(320)>;
+			cpu-power-states = <&idle &s2ram>;
 		};
 
 		cpurad: cpu@3 {
@@ -120,6 +121,20 @@
 				#mbox-cells = <1>;
 				nordic,tasks = <32>;
 				nordic,tasks-mask = <0xffff0000>;
+			};
+		};
+
+		power-states {
+			idle: idle {
+				compatible = "zephyr,power-state";
+				power-state-name = "suspend-to-idle";
+				min-residency-us = <100000>;
+			};
+
+			s2ram: s2ram {
+				compatible = "zephyr,power-state";
+				power-state-name = "suspend-to-ram";
+				min-residency-us = <800000>;
 			};
 		};
 	};


### PR DESCRIPTION
Add definition of low power states 'idle' and 's2ram' for nrf54h20/cpuapp.