### PR TITLE
Bluetooth: Controller: Fix multiple Extended Adv chain reception

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
@@ -1549,6 +1549,11 @@ static int isr_rx_scan_report(struct lll_scan *lll, uint8_t devmatch_ok,
 			{
 				struct node_rx_ftr *ftr;
 
+				/* Reset Scan context association with any Aux context as a new
+				 * extended advertising chain is being setup for reception here.
+				 */
+				lll->lll_aux = NULL;
+
 				ftr = &(node_rx->rx_ftr);
 				ftr->param = lll;
 				ftr->ticks_anchor = radio_tmr_start_get();

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
@@ -1241,17 +1241,32 @@ static int isr_rx_pdu(struct lll_scan *lll, struct lll_scan_aux *lll_aux,
 
 		ftr = &(node_rx->rx_ftr);
 		if (lll_aux) {
+			/* Auxiliary context was used in ULL scheduling in the
+			 * reception of this current PDU.
+			 */
 			ftr->param = lll_aux;
 			ftr->scan_rsp = lll_aux->state;
 
 			/* Further auxiliary PDU reception will be chain PDUs */
 			lll_aux->is_chain_sched = 1U;
+
+			/* Reset auxiliary context association with scan context
+			 * as ULL scheduling has been used and may switch to
+			 * using LLL scheduling if the next auxiliary PDU in
+			 * chain is below the threshold to use ULL scheduling.
+			 */
+			lll->lll_aux = NULL;
+
 		} else if (lll->lll_aux) {
+			/* Auxiliary context was allocated to Scan context in
+			 * LLL scheduling in the reception of this current PDU.
+			 */
 			ftr->param = lll;
 			ftr->scan_rsp = lll->lll_aux->state;
 
 			/* Further auxiliary PDU reception will be chain PDUs */
 			lll->lll_aux->is_chain_sched = 1U;
+
 		} else {
 			/* Return -ECHILD, as ULL execution has not yet assigned
 			 * an aux context. This can happen only under LLL

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync.c
@@ -805,6 +805,11 @@ static int isr_rx(struct lll_sync *lll, uint8_t node_type, uint8_t crc_ok,
 		 * again a node_rx for periodic report incomplete.
 		 */
 		if (node_type != NODE_RX_TYPE_EXT_AUX_REPORT) {
+			/* Reset Sync context association with any Aux context
+			 * as a new chain is being setup for reception here.
+			 */
+			lll->lll_aux = NULL;
+
 			node_rx = ull_pdu_rx_alloc_peek(4);
 		} else {
 			node_rx = ull_pdu_rx_alloc_peek(3);


### PR DESCRIPTION
Fix assertion when enabling simultaneous multiple Extended Advertising chain reception that is enabled by increasing supported auxiliary scan contexts.

Supported auxiliary scan contexts can be increased using CONFIG_BT_CTLR_SCAN_AUX_SET value.

Fixes assertions like:
> ASSERTION FAIL [lll_aux] @ WEST_TOPDIR/zephyr/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c