### PR TITLE
driver: sensor: adxl372: Bug fix for status2 reg

### DIFF
--- a/drivers/sensor/adi/adxl372/adxl372.c
+++ b/drivers/sensor/adi/adxl372/adxl372.c
@@ -364,7 +364,16 @@ int adxl372_get_status(const struct device *dev,
 	}
 
 	if (fifo_entries) {
-		length += 2U;
+		if (status2) {
+			length += 2U;
+		} else {
+			/* Registers STATUS1, STATUS2, FIFO_ENTRIES2 and FIFO_ENTRIES1
+			 * are one after the other. If user wants fifo_entries and
+			 * not status2, to get the correct values, STATUS2 register
+			 * also must be read but read value will be ignored.
+			 */
+			length += 3U;
+		}
 	}
 
 	ret = data->hw_tf->read_reg_multiple(dev, ADXL372_STATUS_1, buf, length);


### PR DESCRIPTION
This is a bug fix for adxl372_get_status function. This function is used to get STATUS1, STATUS2, FIFO_ENTRIES2 and FIFO_ENTRIES1 registers (they are continuously present in the memory in this order). User can choose if it wants STATUS2 and/or FIFO registers by passing pointers where to store received values. Bug was when user doesn't want STATUS2 and want FIFO regs. In that case calculated length would be 3 which will result in reading of STATUS1, STATUS2 and FIFO_ENTRIES2 regs and not expected STATUS1, FIFO_ENTRIES2 and FIFO_ENTRIES1.

Signed-off-by: Vladislav Pejic <vladislav.pejic@orioninc.com>