### PR TITLE
 west.yml: MCUboot synchronization from upstream

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -285,7 +285,7 @@ manifest:
       groups:
         - crypto
     - name: mcuboot
-      revision: e890df7ab975da181a9f3fb3abc470bf935625ab
+      revision: 3a195f2207d5eadf45a5c989a870e91aff020d86
       path: bootloader/mcuboot
       groups:
         - bootloader


### PR DESCRIPTION
Update Zephyr fork of MCUboot to revision:
  3a195f2207d5eadf45a5c989a870e91aff020d86

Brings following Zephyr relevant fixes:
  - 3a195f22 boot: bootutil: loader: Fix issue with using pointers
  - cc7b97be boot: boot_serial: Fix wrong usage of slot numbers
  - 30109df3 boot: bootutil: loader: Fix slot info for directXIP/RAM load
  - 7f3c77e1 boot: bootutil: Add write block size checking
  - c40d237a boot: zephyr: Add check for unexpected flash sector size
  - f9fc5918 boot: zephyr: Remove broken target config header feature
  - f8d8004e boot: zephyr: Allow disabling NRFX_WDT on nRF devices
  - fe26c289 boot: zephyr: boards: nxp: clean .conf files
  - b553290f Add Conexio Stratus Pro board configuration for DFU
  - 41df52e6 boot: SHA512 verification
  - 75672000 cmake: zephyr: change ERROR into FATAL_ERROR

Notes on process:
 1) The MCUboot update from [mcu-tools/mcuboot/main](https://github.com/mcu-tools/mcuboot/tree/main) with the SHA used in west.yaml is already synchronized to [zephyrproject-rtos/mcuboot/upstream-sync](https://github.com/zephyrproject-rtos/mcuboot/tree/upstream-sync) branch, and is available in the Zephyr fork of MCUboot.
 2) The [DNM] on this PR should be kept until the PR passes all tests and is accepted.
 3) Once the PR passes all tests and gets accepted, the upstream-sync branch should be fast-forward merged to [zephyrproject-rtos/mcuboot/main](https://github.com/zephyrproject-rtos/mcuboot/tree/main) branch and [DNM] should be removed.
 4) After the main branch gets updated, this PR does not require further changes and should be merged as is.