### PR TITLE
lib: libc: common: Export z_malloc_heap

### DIFF
--- a/lib/libc/common/source/stdlib/malloc.c
+++ b/lib/libc/common/source/stdlib/malloc.c
@@ -114,7 +114,7 @@ extern char _heap_sentry[];
 
 # endif /* else ALLOCATE_HEAP_AT_STARTUP */
 
-Z_LIBC_DATA static struct sys_heap z_malloc_heap;
+Z_LIBC_DATA struct sys_heap z_malloc_heap;
 
 #ifdef CONFIG_MULTITHREADING
 Z_LIBC_DATA SYS_MUTEX_DEFINE(z_malloc_heap_mutex);


### PR DESCRIPTION
The heap used by malloc/free is a static, private to the malloc implementation.  Unfortunately, this makes it impossible to use tools like `sys_heap_runtime_stats_get()`, as they need access to the heap variable.

Remedy this by removing the static from this declaration.

Other options are to add an additional API to make the desired queries.