### PR TITLE
hostap: The security keys were checked in wrong function

### DIFF
--- a/modules/hostap/src/supp_api.c
+++ b/modules/hostap/src/supp_api.c
@@ -348,10 +348,6 @@ static inline int chan_to_freq(int chan)
 static inline enum wifi_frequency_bands wpas_band_to_zephyr(enum wpa_radio_work_band band)
 {
 	switch (band) {
-	case WPA_KEY_MGMT_IEEE8021X:
-	case WPA_KEY_MGMT_IEEE8021X_SUITE_B:
-	case WPA_KEY_MGMT_IEEE8021X_SUITE_B_192:
-		return WIFI_SECURITY_TYPE_EAP_TLS;
 	case BAND_2_4_GHZ:
 		return WIFI_FREQ_BAND_2_4_GHZ;
 	case BAND_5_GHZ:
@@ -364,6 +360,10 @@ static inline enum wifi_frequency_bands wpas_band_to_zephyr(enum wpa_radio_work_
 static inline enum wifi_security_type wpas_key_mgmt_to_zephyr(int key_mgmt, int proto)
 {
 	switch (key_mgmt) {
+	case WPA_KEY_MGMT_IEEE8021X:
+	case WPA_KEY_MGMT_IEEE8021X_SUITE_B:
+	case WPA_KEY_MGMT_IEEE8021X_SUITE_B_192:
+		return WIFI_SECURITY_TYPE_EAP_TLS;
 	case WPA_KEY_MGMT_NONE:
 		return WIFI_SECURITY_TYPE_NONE;
 	case WPA_KEY_MGMT_PSK:


### PR DESCRIPTION
The security check case statements were in frequency band setting checks. This is totally wrong and will cause compiler warnings. Moving the checks to correct function.