### PR TITLE
tests: net: wifi: Run wifi tests together with net tests

### DIFF
--- a/tests/net/wifi/wifi_nm/testcase.yaml
+++ b/tests/net/wifi/wifi_nm/testcase.yaml
@@ -6,6 +6,6 @@ tests:
     extra_args:
       # Will be ignored for other platforms
       - CONFIG_NRF_WIFI_BUILD_ONLY_MODE=y
-    tags: wifi
+    tags: wifi net
     platform_exclude:
       - rd_rw612_bga/rw612/ethernet # Requires binary blobs to build


### PR DESCRIPTION
Make sure wifi tests are run when verifying networking.