### PR TITLE
drivers: test: clock_control: esp32: Fix clock control and test

### DIFF
--- a/drivers/clock_control/clock_control_esp32.c
+++ b/drivers/clock_control/clock_control_esp32.c
@@ -689,9 +689,6 @@ static int esp32_cpu_clock_configure(const struct esp32_cpu_clock_config *cpu_cf
 #if !defined(ESP_CONSOLE_UART_NONE)
 #if !defined(CONFIG_SOC_SERIES_ESP32C2) && !defined(CONFIG_SOC_SERIES_ESP32C6)
 	uint32_t uart_clock_src_hz = esp_clk_apb_freq();
-#if ESP_ROM_UART_CLK_IS_XTAL
-	uart_clock_src_hz = (uint32_t)rtc_clk_xtal_freq_get() * MHZ(1);
-#endif
 
 	esp_rom_uart_set_clock_baudrate(ESP_CONSOLE_UART_NUM, uart_clock_src_hz,
 					ESP_CONSOLE_UART_BAUDRATE);

--- a/tests/drivers/clock_control/clock_control_api/src/esp32_device_subsys.h
+++ b/tests/drivers/clock_control/clock_control_api/src/esp32_device_subsys.h
@@ -12,9 +12,15 @@ static const struct device_subsys_data subsys_data[] = {
 	{.subsys = (void *) ESP32_LEDC_MODULE},
 	{.subsys = (void *) ESP32_UART1_MODULE},
 	{.subsys = (void *) ESP32_I2C0_MODULE},
+#if !defined(CONFIG_SOC_SERIES_ESP32C2)
 	{.subsys = (void *) ESP32_UHCI0_MODULE},
-	{.subsys = (void *) ESP32_RMT_MODULE},
-	{.subsys = (void *) ESP32_TWAI_MODULE},
+#endif
+#if defined(CONFIG_SOC_SERIES_ESP32C3) || defined(CONFIG_SOC_SERIES_ESP32S2) || \
+	defined(CONFIG_SOC_SERIES_ESP32S3)
+	{.subsys = (void *) ESP32_TIMG1_MODULE},
+#else
+	{.subsys = (void *) ESP32_TIMG0_MODULE},
+#endif
 	{.subsys = (void *) ESP32_RNG_MODULE},
 };
 


### PR DESCRIPTION
Fixes UART baud rate adjustment and generic clock control API testing for some ESP32 devices.