### PR TITLE
susbys/dfu/img_util: support ERASE PROGRESSIVELY for non-flash mem

### DIFF
--- a/subsys/dfu/Kconfig
+++ b/subsys/dfu/Kconfig
@@ -69,8 +69,7 @@ config IMG_BLOCK_BUF_SIZE
 
 config IMG_ERASE_PROGRESSIVELY
 	bool "Erase flash progressively when receiving new firmware"
-	select STREAM_FLASH_ERASE
-	depends on FLASH_HAS_EXPLICIT_ERASE
+	select STREAM_FLASH_ERASE if FLASH_HAS_EXPLICIT_ERASE
 	help
 	  If enabled, flash is erased as necessary when receiving new firmware,
 	  instead of erasing the whole image slot at once. This is necessary


### PR DESCRIPTION
Added support for devices don't require explicit pager erase. For these device flattening of mcuboot image status is relevant.