### PR TITLE
bluetooth: services: bas: Move log module to bas and guard BT_BAS_BLS

### DIFF
--- a/subsys/bluetooth/Kconfig.logging
+++ b/subsys/bluetooth/Kconfig.logging
@@ -488,14 +488,6 @@ endif # BT_MESH
 
 menu "Services"
 
-# BAS
-
-if BT_BAS
-module = BT_BAS
-module-str = BAS
-source "subsys/logging/Kconfig.template.log_config"
-endif # BT_BAS
-
 # CTS
 
 if BT_CTS

--- a/subsys/bluetooth/services/bas/Kconfig.bas
+++ b/subsys/bluetooth/services/bas/Kconfig.bas
@@ -6,6 +6,12 @@
 config BT_BAS
 	bool "GATT Battery service"
 
+if BT_BAS
+
+module = BT_BAS
+module-str = BAS
+source "subsys/logging/Kconfig.template.log_config"
+
 config BT_BAS_BLS
 	bool "Battery Level Status"
 	help
@@ -27,4 +33,7 @@ config BT_BAS_BLS_ADDITIONAL_STATUS_PRESENT
 	bool "Additional Battery Status Present"
 	help
 	Enable this option if Additional Battery Status information is present.
-endif
+
+endif # BT_BAS_BLS
+
+endif # BT_BAS

--- a/subsys/bluetooth/services/bas/bas.c
+++ b/subsys/bluetooth/services/bas/bas.c
@@ -25,7 +25,6 @@
 #include <zephyr/bluetooth/services/bas.h>
 #include "bas_internal.h"
 
-#define LOG_LEVEL CONFIG_BT_BAS_LOG_LEVEL
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(bas, CONFIG_BT_BAS_LOG_LEVEL);
 


### PR DESCRIPTION
The bas service can be used without BT_HCI=y. However, if BT_HCI is not set, the BT Kconfig.logging is not included, which results in

module = BT_BAS
module-str = BAS
source "subsys/logging/Kconfig.template.log_config"

not being defined. Furthermore, BT_BAS_BLS depends on BT_BAS, so move the log module definition to Kconfig.bas, guarded by BT_BAS, and guard BT_BAS_BLS behind BT_BAS.

This issue was detected by a project setting BT_HCI_IPC=y, LOG=y and BT=y

Lastly, remove redundant LOG_LEVEL define.