### PR TITLE
net: lib: http: ensure SYS_FOREVER_MS behavior

### DIFF
--- a/subsys/net/lib/http/http_client.c
+++ b/subsys/net/lib/http/http_client.c
@@ -562,7 +562,7 @@ int http_client_req(int sock, struct http_request *req,
 	int total_sent = 0;
 	int ret, total_recv, i;
 	const char *method;
-	k_timeout_t req_timeout = K_MSEC(timeout);
+	k_timeout_t req_timeout = (timeout == SYS_FOREVER_MS) ? K_FOREVER : K_MSEC(timeout);
 	k_timepoint_t req_end_timepoint = sys_timepoint_calc(req_timeout);
 
 	if (sock < 0 || req == NULL || req->response == NULL ||


### PR DESCRIPTION
The http_client_req() function's timeout parameter is allowed to be SYS_FOREVER_MS. However, K_MSEC() does not convert this to a proper k_timeout_t, so sys_timepoint_calc() ends up returning 0, which is causes immediate timeouts.

Check for this case specifically and force value passed to sys_timepoint_calc() to be correct.