### PR TITLE
net: lib: coap: Make use of ZSOCK_MSG_TRUNC configurable

### DIFF
--- a/subsys/net/lib/coap/Kconfig
+++ b/subsys/net/lib/coap/Kconfig
@@ -152,6 +152,14 @@ config COAP_CLIENT_MAX_REQUESTS
 	help
 	  Maximum number of CoAP requests a single client can handle at a time
 
+config COAP_CLIENT_TRUNCATE_MSGS
+	bool "Receive notification when blocks are truncated"
+	default y
+	help
+	  Include ZSOCK_MSG_TRUNC in flags passed to zsock_recvfrom() to
+	  receive network stack notifications about block truncation.
+	  Otherwise it happens silently.
+
 endif # COAP_CLIENT
 
 config COAP_SERVER


### PR DESCRIPTION
Not all offloaded network stacks support this socket option.

Enable CONFIG_COAP_CLIENT_TRUNCATE_MSGS by default but disable for
incompatible offloaded stack.