### PR TITLE
eth_stm32_hal: clean up defines

### DIFF
--- a/drivers/ethernet/eth_stm32_hal_priv.h
+++ b/drivers/ethernet/eth_stm32_hal_priv.h
@@ -22,12 +22,7 @@
 #define ST_OUI_B1 0x80
 #define ST_OUI_B2 0xE1
 
-#define ETH_STM32_HAL_MTU NET_ETH_MTU
-#define ETH_STM32_HAL_FRAME_SIZE_MAX (ETH_STM32_HAL_MTU + 18)
-
-/* Definition of the Ethernet driver buffers size and count */
-#define ETH_STM32_RX_BUF_SIZE	ETH_MAX_PACKET_SIZE /* buffer size for receive */
-#define ETH_STM32_TX_BUF_SIZE	ETH_MAX_PACKET_SIZE /* buffer size for transmit */
+#define ETH_STM32_HAL_FRAME_SIZE_MAX (NET_ETH_MTU + 18)
 
 /* Device constant configuration parameters */
 struct eth_stm32_hal_dev_cfg {

--- a/drivers/ethernet/eth_stm32_hal_priv.h
+++ b/drivers/ethernet/eth_stm32_hal_priv.h
@@ -22,8 +22,6 @@
 #define ST_OUI_B1 0x80
 #define ST_OUI_B2 0xE1
 
-#define ETH_STM32_HAL_FRAME_SIZE_MAX (NET_ETH_MTU + 18)
-
 /* Device constant configuration parameters */
 struct eth_stm32_hal_dev_cfg {
 	void (*config_func)(void);


### PR DESCRIPTION
Drop preprocessor redefinitions

Some preprocessor defines were redefined to follow stm32 hal naming conventions.
People seems to be confused by redefines and use
them with alternating names.
This PR does not change code behaviour,
but shall increase it's readability.