### PR TITLE
RFC: doc: Add an interactive board catalog

### DIFF
--- a/boards/index.rst
+++ b/boards/index.rst
@@ -1,23 +1,29 @@
 .. _boards:
 
-Supported Boards
-################
-
-Zephyr project developers are continually adding board-specific support as
-documented below.
+Supported Boards and Shields
+############################
 
 If you are looking to add Zephyr support for a new board, please start with the
 :ref:`board_porting_guide`.
 
-When adding support documentation for each board, remember to use the template
+When adding support documentation for a board, remember to use the template
 available under :zephyr_file:`doc/templates/board.tmpl`.
 
+Shields are hardware add-ons that can be stacked on top of a board to add extra
+functionality. They are listed separately from boards, towards :ref:`the end of
+this page <boards-shields>`.
+
+Use the interactive search form below to quickly navigate through the list of
+supported boards.
 
 .. toctree::
    :maxdepth: 2
    :glob:
+   :hidden:
 
    */index
+
+.. zephyr:board-catalog::
 
 .. _boards-shields:
 

--- a/doc/_extensions/zephyr/domain/static/css/board-catalog.css
+++ b/doc/_extensions/zephyr/domain/static/css/board-catalog.css
@@ -1,0 +1,214 @@
+/**
+ * Copyright (c) 2024, The Linux Foundation.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+.hidden {
+  display: none !important;
+}
+
+.filter-form {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-bottom: 20px;
+}
+
+.filter-form input,
+.filter-form select {
+  appearance: none;
+  font-family: var(--system-font-family);
+  font-size: 14px;
+  border-radius: 50px;
+  padding: 10px 18px;
+  flex: 1 1 200px;
+  background-color: var(--input-background-color);
+  color: var(--body-color);
+  transition: all 0.3s ease;
+  box-shadow: none;
+}
+
+.filter-form input:focus .filter-form select:focus {
+  border-color: var(--input-focus-border-color);
+}
+.select-container {
+  flex: 1 1 200px;
+  position: relative;
+}
+
+.select-container::after {
+  content: "\25BC";
+  position: absolute;
+  right: 20px;
+  top: 50%;
+  transform: translateY(-50%);
+  pointer-events: none;
+  font-size: 14px;
+  color: var(--body-color);
+}
+
+.filter-form select {
+  padding-right: 40px;
+  width: 100%;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+#catalog {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 20px;
+  justify-content: center;
+  margin-top: 20px;
+  margin-bottom: 40px;
+}
+
+.board-card {
+  flex: 1 1 calc(33.3% - 20px);
+  /* Three cards per row */
+  max-width: calc(33.3% - 20px);
+  border-radius: 8px;
+  padding: 15px 20px;
+  background-color: var(--admonition-note-background-color);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  transition: transform 0.3s ease;
+}
+
+.board-card:hover,
+.board-card:focus {
+  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.15);
+  transform: translateY(-5px);
+  text-decoration: none;
+}
+
+.board-card .picture {
+  width: auto;
+  height: auto;
+  min-height: 100px;
+  max-height: 180px;
+  border-radius: 4px;
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  flex-grow: 1;
+  padding: 10px 0px;
+}
+
+.board-card .no-picture {
+  font-size: 5em;
+  color: var(--admonition-note-title-background-color);
+  justify-content: center;
+}
+
+.board-card .vendor {
+  font-size: 12px;
+  color: var(--admonition-note-color);
+  font-weight: 900;
+  margin-bottom: 18px;
+  opacity: 0.5;
+}
+
+.board-card img {
+  max-height: 100%;
+  max-width: 100%;
+  object-fit: contain;
+}
+
+.board-card .board-name {
+  font-family: var(--header-font-family);
+  margin: auto 0 5px;
+  text-align: center;
+  font-size: 18px;
+  font-weight: 500;
+  color: var(--body-color);
+  padding-top: 10px;
+}
+
+.board-card .arch {
+  margin: 5px 0;
+  text-align: center;
+  font-size: 12px;
+  font-weight: 100;
+  color: var(--body-color);
+}
+
+@media (max-width: 1024px) {
+  .board-card {
+    flex: 1 1 calc(50% - 20px);
+    max-width: calc(50% - 20px);
+  }
+}
+
+@media (max-width: 768px) {
+  .board-card {
+    flex: 1 1 calc(100% - 20px);
+    max-width: calc(100% - 20px);
+  }
+
+  .board-card .picture {
+    min-height: 60px;
+    max-height: 120px;
+  }
+}
+
+#form-options .btn {
+  font-size: 14px;
+}
+
+#form-options .btn:focus {
+  outline-color: var(--body-color) !important;
+}
+
+#catalog.compact {
+  display: block;
+  list-style-type: disc;
+  margin: 20px;
+}
+
+#catalog.compact .board-card {
+  display: list-item;
+  padding: 4px 0;
+  border: none;
+  background-color: transparent;
+  box-shadow: none;
+  list-style-position: outside;
+  max-width: none;
+}
+
+#catalog.compact .board-card .vendor,
+#catalog.compact .board-card .picture {
+  display: none;
+}
+
+#catalog.compact .board-card .board-name {
+  display: inline;
+  font-family: var(--system-font-family);
+  text-align: left;
+  font-size: 16px;
+  font-weight: normal;
+  color: var(--body-color);
+  margin: 0;
+  padding: 0;
+}
+
+#catalog.compact .board-card .arch {
+  display: inline;
+}
+
+#catalog.compact .board-card .arch::before {
+  content: " (";
+}
+
+#catalog.compact .board-card .arch::after {
+  content: ")";
+}
+
+#catalog.compact .board-card:hover {
+  box-shadow: none;
+  transform: none;
+  text-decoration: underline;
+}

--- a/doc/_extensions/zephyr/domain/static/js/board-catalog.js
+++ b/doc/_extensions/zephyr/domain/static/js/board-catalog.js
@@ -1,0 +1,111 @@
+/**
+ * Copyright (c) 2024, The Linux Foundation.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+function toggleDisplayMode(btn) {
+  const catalog = document.getElementById("catalog");
+  catalog.classList.toggle("compact");
+  btn.classList.toggle("fa-bars");
+  btn.classList.toggle("fa-th");
+  btn.textContent = catalog.classList.contains("compact")
+    ? " Switch to Card View"
+    : " Switch to Compact View";
+}
+
+function populateFormFromURL() {
+  const params = ["name", "arch", "vendor"];
+  const hashParams = new URLSearchParams(window.location.hash.slice(1));
+  params.forEach((param) => {
+    const element = document.getElementById(param);
+    if (hashParams.has(param)) {
+      element.value = hashParams.get(param);
+    }
+  });
+
+  filterBoards();
+}
+
+function updateURL() {
+  const params = ["name", "arch", "vendor"];
+  const hashParams = new URLSearchParams(window.location.hash.slice(1));
+
+  params.forEach((param) => {
+    const value = document.getElementById(param).value;
+    value ? hashParams.set(param, value) : hashParams.delete(param);
+  });
+
+  window.history.replaceState({}, "", `#${hashParams.toString()}`);
+}
+
+document.addEventListener("DOMContentLoaded", function () {
+  updateBoardCount();
+  populateFormFromURL();
+
+  const form = document.querySelector(".filter-form");
+
+  // sort vendors alphabetically
+  vendorSelect = document.getElementById("vendor");
+  vendorOptions = Array.from(vendorSelect.options).slice(1);
+  vendorOptions.sort((a, b) => a.text.localeCompare(b.text));
+  while (vendorSelect.options.length > 1) {
+    vendorSelect.remove(1);
+  }
+  vendorOptions.forEach((option) => {
+    vendorSelect.appendChild(option);
+  });
+
+  form.addEventListener("submit", function (event) {
+    event.preventDefault();
+  });
+
+  form.addEventListener("input", function () {
+    filterBoards();
+    updateURL();
+  });
+});
+
+function updateBoardCount() {
+  const boards = document.getElementsByClassName("board-card");
+  const visibleBoards = Array.from(boards).filter(
+    (board) => !board.classList.contains("hidden")
+  ).length;
+  const totalBoards = boards.length;
+  document.getElementById("nb-matches").textContent = `Showing ${visibleBoards} of ${totalBoards}`;
+}
+
+function filterBoards() {
+  const nameInput = document.getElementById("name").value.toLowerCase();
+  const archSelect = document.getElementById("arch").value;
+  const vendorSelect = document.getElementById("vendor").value;
+
+  const resetFiltersBtn = document.getElementById("reset-filters");
+  if (nameInput || archSelect || vendorSelect) {
+    resetFiltersBtn.classList.remove("btn-disabled");
+  } else {
+    resetFiltersBtn.classList.add("btn-disabled");
+  }
+
+  const boards = document.getElementsByClassName("board-card");
+
+  Array.from(boards).forEach(function (board) {
+    const boardName = board.getAttribute("data-name").toLowerCase();
+    const boardArchs = board.getAttribute("data-arch").split(" ");
+    const boardVendor = board.getAttribute("data-vendor");
+
+    let matches = true;
+
+    matches =
+      !(nameInput && !boardName.includes(nameInput)) &&
+      !(archSelect && !boardArchs.includes(archSelect)) &&
+      !(vendorSelect && boardVendor !== vendorSelect);
+
+    if (matches) {
+      board.classList.remove("hidden");
+    } else {
+      board.classList.add("hidden");
+    }
+  });
+
+  updateBoardCount();
+}

--- a/doc/_extensions/zephyr/domain/templates/board-card.html
+++ b/doc/_extensions/zephyr/domain/templates/board-card.html
@@ -1,0 +1,26 @@
+{#
+  Copyright (c) 2024, The Linux Foundation.
+  SPDX-License-Identifier: Apache-2.0
+#}
+
+<a
+  class="board-card"
+  {% if board.doc_page %}
+  href="../{{ board.doc_page | replace(".rst", ".html") }}"
+  {% else %}
+  href="#"
+  {% endif %}
+  aria-label="Open the documentation page for {{ board.full_name }}"
+  data-name="{{ board.full_name}}"
+  data-arch="{{ board.archs | join(" ") }}"
+  data-vendor="{{ board.vendor }}"
+  tabindex="0">
+  <div class="vendor">{{ catalog.vendors[board.vendor] }}</div>
+  {% if board.image %}
+  <img alt="A picture of the {{ board.name }} board" src="{{ board.image }}" class="picture" />
+  {% else %}
+  <div class="no-picture fa fa-microchip picture"></div>
+  {% endif %}
+  <div class="board-name">{{ board.full_name }}</div>
+  <div class="arch">{{ board.archs | join(", ") }}</div>
+</a>

--- a/doc/_extensions/zephyr/domain/templates/board-catalog.html
+++ b/doc/_extensions/zephyr/domain/templates/board-catalog.html
@@ -1,0 +1,60 @@
+{#
+  Copyright (c) 2024, The Linux Foundation.
+  SPDX-License-Identifier: Apache-2.0
+#}
+
+<form class="filter-form" aria-label="Filter boards by name, architecture, and vendor">
+  <input type="text" id="name" placeholder="Name" style="flex-basis: 100%"
+         aria-label="Name" />
+  <div class="select-container">
+    <select id="arch" aria-label="Architecture">
+      <option value="" disabled selected>Select an architecture</option>
+      <option value="nios2">Altera Nios II</option>
+      <option value="arm">ARM</option>
+      <option value="arm64">ARM 64</option>
+      <option value="mips">MIPS</option>
+      <option value="posix">POSIX</option>
+      <option value="riscv">RISC-V</option>
+      <option value="sparc">SPARC</option>
+      <option value="arc">Synopsys DesignWare ARC</option>
+      <option value="x86">x86</option>
+      <option value="xtensa">Xtensa</option>
+    </select>
+  </div>
+  <div class="select-container" style="flex-basis: 400px">
+    <select id="vendor" aria-label="Vendor">
+      <option value="" disabled selected>Select a vendor</option>
+      {# Only show those vendors that have actual boards in the catalog.
+         Note: as sorting per vendor name is not feasible in Jinja, the option list is sorted in the
+         JavaScript code later #}
+      {% for vendor in (catalog.boards | items | map(attribute='1.vendor') | unique ) %}
+      <option value="{{ vendor }}">{{ catalog.vendors[vendor] }}</option>
+      {% endfor %}
+    </select>
+  </div>
+</form>
+
+<div id="form-options" style="text-align: center; margin-bottom: 20px">
+  <button
+    id="reset-filters"
+    class="btn btn-info btn-disabled fa fa-times"
+    tabindex="0"
+    onclick="document.querySelector('.filter-form').reset(); filterBoards(); updateURL();">
+    Reset Filters
+  </button>
+  <button
+    id="toggle-compact"
+    class="btn btn-info fa fa-bars"
+    tabindex="0"
+    onclick="toggleDisplayMode(this)">
+    Switch to Compact View
+  </button>
+</div>
+
+<div id="nb-matches" style="text-align: center"></div>
+
+<div id="catalog">
+  {% for board_name, board in catalog.boards | items | sort(attribute='1.full_name') %}
+  {% include "board-card.html" %}
+  {% endfor %}
+</div>

--- a/doc/_scripts/gen_boards_catalog.py
+++ b/doc/_scripts/gen_boards_catalog.py
@@ -1,0 +1,127 @@
+# Copyright (c) 2024 The Linux Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+import logging
+from collections import namedtuple
+from pathlib import Path
+
+import list_boards
+import pykwalify
+import yaml
+import zephyr_module
+from gen_devicetree_rest import VndLookup
+
+ZEPHYR_BASE = Path(__file__).parents[2]
+
+logger = logging.getLogger(__name__)
+
+def guess_file_from_patterns(directory, patterns, name, extensions):
+    for pattern in patterns:
+        for ext in extensions:
+            matching_file = next(directory.glob(pattern.format(name=name, ext=ext)), None)
+            if matching_file:
+                return matching_file
+    return None
+
+
+def guess_image(board_or_shield):
+    img_exts = ["jpg", "jpeg", "webp", "png"]
+    patterns = [
+        "**/{name}.{ext}",
+        "**/*{name}*.{ext}",
+        "**/*.{ext}",
+    ]
+    img_file = guess_file_from_patterns(
+        board_or_shield.dir, patterns, board_or_shield.name, img_exts
+    )
+    return (Path("../_images") / img_file.name).as_posix() if img_file else ""
+
+
+def guess_doc_page(board_or_shield):
+    patterns = [
+        "doc/index.{ext}",
+        "**/{name}.{ext}",
+        "**/*{name}*.{ext}",
+        "**/*.{ext}",
+    ]
+    doc_file = guess_file_from_patterns(
+        board_or_shield.dir, patterns, board_or_shield.name, ["rst"]
+    )
+    return doc_file
+
+
+def get_catalog():
+    pykwalify.init_logging(1)
+
+    vnd_lookup = VndLookup(ZEPHYR_BASE / "dts/bindings/vendor-prefixes.txt", [])
+
+    module_settings = {
+        "arch_root": [ZEPHYR_BASE],
+        "board_root": [ZEPHYR_BASE],
+        "soc_root": [ZEPHYR_BASE],
+    }
+
+    for module in zephyr_module.parse_modules(ZEPHYR_BASE):
+        for key in module_settings:
+            root = module.meta.get("build", {}).get("settings", {}).get(key)
+            if root is not None:
+                module_settings[key].append(Path(module.project) / root)
+
+    Args = namedtuple("args", ["arch_roots", "board_roots", "soc_roots", "board_dir", "board"])
+    args_find_boards = Args(
+        arch_roots=module_settings["arch_root"],
+        board_roots=module_settings["board_root"],
+        soc_roots=module_settings["soc_root"],
+        board_dir=ZEPHYR_BASE / "boards",
+        board=None,
+    )
+
+    boards = list_boards.find_v2_boards(args_find_boards)
+    board_catalog = {}
+
+    for board in boards:
+        # We could use board.vendor but it is often incorrect. Instead, deduce vendor from
+        # containing folder
+        for folder in board.dir.parents:
+            if vnd_lookup.vnd2vendor.get(folder.name):
+                vendor = folder.name
+                break
+
+        # Grab all the twister files for this board and use them to figure out all the archs it
+        # supports.
+        archs = set()
+        pattern = f"{board.name}*.yaml"
+        for twister_file in board.dir.glob(pattern):
+            try:
+                with open(twister_file, "r") as f:
+                    board_data = yaml.safe_load(f)
+                    archs.add(board_data.get("arch"))
+            except Exception as e:
+                logger.error(f"Error parsing twister file {twister_file}: {e}")
+
+        full_name = board.full_name
+        doc_page = guess_doc_page(board)
+
+        if not full_name:
+            # If full commercial name of the board is not available through board.full_name, we look
+            # for the title in the board's documentation page.
+            # /!\ This is a temporary solution until #79571 sets all the full names in the boards
+            if doc_page:
+                with open(doc_page, "r") as f:
+                    lines = f.readlines()
+                    for i, line in enumerate(lines):
+                        if line.startswith("#"):
+                            full_name = lines[i - 1].strip()
+                            break
+            else:
+                full_name = board.name
+
+        board_catalog[board.name] = {
+            "full_name": full_name,
+            "doc_page": doc_page.relative_to(ZEPHYR_BASE).as_posix() if doc_page else None,
+            "vendor": vendor,
+            "archs": list(archs),
+            "image": guess_image(board),
+        }
+
+    return {"boards": board_catalog, "vendors": vnd_lookup.vnd2vendor}

--- a/doc/contribute/documentation/guidelines.rst
+++ b/doc/contribute/documentation/guidelines.rst
@@ -1180,3 +1180,11 @@ Code samples
       A flag to include a search box right above the listing. The search box allows users to filter
       the listing by code sample name/description, which can be useful for categories with a large
       number of samples. This option is only available in the HTML builder.
+
+Boards
+======
+
+.. rst:directive:: .. zephyr:board-catalog::
+
+   This directive is used to generate a catalog of Zephyr-supported boards that can be used to
+   quickly browse the list of all supported boards and filter them according to various criteria.


### PR DESCRIPTION
📄  CI-built version of the PR:
- https://builds.zephyrproject.io/zephyr/pr/79160/docs/boards/index.html
- https://builds.zephyrproject.io/zephyr/pr/79160/docs/boards/index.html#vendor=nordic&name=52

IMPORTANT: an earlier version of the (draft) PR proposed to introduce not only a board catalog (which this PR now 100% focuses on) as well as a mechanism using DTS to extract boards' supported HW features from Devicetree. The latter is still very much planned (and the reader should certainly keep in mind that the catalog will be able to do more advanced filtering in the future), but will be addressed in a separate PR. The current PR is solely about the board catalog.

## Introduction

As the number of boards supported by Zephyr grows, it is becoming increasingly difficult for developers to easily find the right board for their project. Similarly, knowing which hardware features are supported by a board at a given time is not straightforward as the information -hopefully- captured in the "Supported features" section of the board's documentation is not always up-to-date.

This RFC proposes to address these issues by introducing an interactive board catalog that will allow developers to filter boards based on name, vendor, and architectures

### Problem description
<!--
Why do we want this change and what problem are we trying to address?
-->

https://docs.zephyrproject.org/latest/boards/index.html is not really a good user experience for it displays literally hundreds of boards in a very "flat" and laconic way. It makes it difficult for users (newcomers especially) to really grasp what the Zephyr project has to offer in terms of supported hardware, and now that we have re-organized boards per vendor, it also completely loses the notion of "architecture", making it *really* hard to know which boards are supported for a given architecture.


### Proposed change
<!--
A brief summary of the proposed change - the 10,000 ft view on what it will
change once this change is implemented.
-->

* Replace current "Supported boards" index page with an interactive list populated from board.yml metadata.

Should this new UI/UX move forward, a future iteration will introduce the ability to also search per supported HW feature (ex. "give me all ARM boards from Vendor Foo, *with a supported 802.15.4 radio*". (Early prototype here: https://builds.zephyrproject.io/zephyr/pr/79160-alt/boards/index.html for folks interested). This will be using DTS for extracting the list of supported features (related: https://github.com/zephyrproject-rtos/zephyr/issues/10157)


## Detailed RFC


### Proposed change (Detailed)

When building the HTML documentation, a Python script calls "list_boards.py" to get the list of all supported boards, and captures all the metadata we might need to build a comprehensive catalog of boards (board "technical" name, commercial name, image, vendor, ...). 

The boards/index documentation page is replaced by an interactive UI that lists all boards and allows to filter based on name/arch/vendor. Default visualization is in the form of fancy "cards" but can be switched to a more compact listing.

#### Card mode

<img width="855" alt="image" src="https://github.com/user-attachments/assets/3e5d1e02-747d-4dc7-9b48-e1d379709968">

#### Compact mode

<img width="847" alt="image" src="https://github.com/user-attachments/assets/7db616e7-f279-4c49-aa26-b93e027472bb">


### Dependencies

* As this effort requires some conventions to be followed to surface all the appropriate information, treewide cleanups will need to occur to ensure that all boards are properly listed. For example, current implementation makes a guess at the board's image in case a "board.[png|jpg|webp]" file is not found, but this is not 100% reliable. Similarly, documentation for a board is assumed to be in "doc/index.html" as this is what board porting guidelines advise, but this is not always the case. See ex. how #79503 cleans up some of the image names.

### Concerns and Unresolved Questions
<!--
List any concerns, unknowns, and generally unresolved questions etc.
-->

* --As the list of boards in boards/index.html is now generated on-the-fly in the browser, it *could* negatively impact SEO (Search Engine Optimization) due to the links to each board's doc page not being "baked" into HTML content anymore. Given that the side navbar still has links to vendors' index pages though (for now at least - I want to get rid of them eventually), I don't think it will be an issue (plus, we also have a sitemap file that search engines uses to know ahead of time all the pages in our docs without having to crawl the site).--

* I initially looked at also adding shields as part of the listing, but this too will be kept for a follow-up PR. We just don't have good enough metadata for shields and there is just too much guessing happening for the shield catalog to be accurate enough.

## Alternatives
<!--
List any alternatives considered, and the reasons for choosing this option
over them.
-->

* Status quo, i.e. stick to the rather bland list of boards in the documentation we currently have.