### PR TITLE
lib: net_buf_simple: introduce string handling utilities

### DIFF
--- a/tests/lib/net_buf/buf_simple/src/main.c
+++ b/tests/lib/net_buf/buf_simple/src/main.c
@@ -240,6 +240,34 @@ ZTEST(net_buf_simple_test_suite, test_net_buf_simple_add_be64)
 			  sizeof(be64), "Invalid 64 bits byte order");
 }
 
+ZTEST(net_buf_simple_test_suite, test_net_buf_simple_add_str)
+{
+	int ret;
+	char *str;
+
+	ret = net_buf_simple_add_str_len(&buf, "01234567", 5);
+	zassert_ok(ret, "Adding a string should have succeeded");
+
+	str = net_buf_simple_to_str(&buf);
+	zassert_str_equal(str, "01234", "Invalid character string produced");
+
+	ret = net_buf_simple_sprintf(&buf, ", %s, %u", "kite", 10);
+	zassert_ok(ret, "Formatting a string should have succeeded");
+
+	str = net_buf_simple_to_str(&buf);
+	zassert_str_equal("01234, kite, 10", str, "Invalid character string produced");
+
+	ret = net_buf_simple_add_str(&buf, "+");
+	zassert_ok(ret, "Should accept completely filling the buffer");
+	zassert_mem_equal(buf.data, "01234, kite, 10+", buf.len, "Invalid memory added");
+
+	ret = net_buf_simple_sprintf(&buf, "+");
+	zassert_equal(ret, -ENOMEM, "Should prevent buffer overflow");
+
+	str = net_buf_simple_to_str(&buf);
+	zassert_equal_ptr(str, NULL, "Should refuse adding \\0 when buffer is full");
+}
+
 ZTEST(net_buf_simple_test_suite, test_net_buf_simple_remove_le16)
 {
 	net_buf_simple_reserve(&buf, 16);


### PR DESCRIPTION
This implements the library proposed in:
- #78799

This is a minimal support with only `net_buf_simple` for now. Should it be `_sprintf()` or `_add_fmt()`?

```c
ret = net_buf_simple_add_str(buf, "string");
if (ret < 0) {
	return ret;
}

ret = net_buf_simple_sprintf(buf, "Max: %u\r\n", 127);
if (ret < 0) {
	return ret;
}

s = net_buf_simple_to_str(buf);
if (s == NULL) {
	return -ENOMEM;
}
```

There is still one potential issue: no guarantee that `s` stays safe to use, as `buf` may still be modified.

Maybe flagging `buf` as immutable in `net_buf_simple_to_str()` would work. The developer would have to manually unflag it before growing it further, raising awareness that all references to `s` should be removed first. Or maybe an alternate function to completely export `buf` as a `char *`, adding the immutable flag.

Tests run with:
```
west twister --inline-logs -p native_sim --all -T tests/lib/net_buf/buf_simple/
```