### PR TITLE
drivers: video: allow allocation with a header preceding the buffer

### DIFF
--- a/drivers/video/video_common.c
+++ b/drivers/video/video_common.c
@@ -28,7 +28,7 @@ struct mem_block {
 
 static struct mem_block video_block[CONFIG_VIDEO_BUFFER_POOL_NUM_MAX];
 
-struct video_buffer *video_buffer_aligned_alloc(size_t size, size_t align)
+struct video_buffer *z_video_buffer_alloc(size_t header_size, size_t buffer_size, size_t align)
 {
 	struct video_buffer *vbuf = NULL;
 	struct mem_block *block;
@@ -48,21 +48,17 @@ struct video_buffer *video_buffer_aligned_alloc(size_t size, size_t align)
 	}
 
 	/* Alloc buffer memory */
-	block->data = VIDEO_COMMON_HEAP_ALLOC(align, size, K_FOREVER);
+	block->data = VIDEO_COMMON_HEAP_ALLOC(align, header_size + buffer_size, K_FOREVER);
 	if (block->data == NULL) {
 		return NULL;
 	}
 
-	vbuf->buffer = block->data;
-	vbuf->size = size;
+	vbuf->header = block->data;
+	vbuf->buffer = block->data + header_size;
+	vbuf->size = buffer_size;
 	vbuf->bytesused = 0;
 
 	return vbuf;
-}
-
-struct video_buffer *video_buffer_alloc(size_t size)
-{
-	return video_buffer_aligned_alloc(size, sizeof(void *));
 }
 
 void video_buffer_release(struct video_buffer *vbuf)

--- a/include/zephyr/drivers/video.h
+++ b/include/zephyr/drivers/video.h
@@ -105,7 +105,9 @@ struct video_caps {
 struct video_buffer {
 	/** pointer to driver specific data. */
 	void *driver_data;
-	/** pointer to the start of the buffer. */
+	/** pointer to the start of the buffer header. */
+	uint8_t *header;
+	/** pointer to the start of the buffer active region. */
 	uint8_t *buffer;
 	/** size of the buffer in bytes. */
 	uint32_t size;
@@ -739,6 +741,8 @@ static inline int video_set_signal(const struct device *dev,
 	return api->set_signal(dev, ep, signal);
 }
 
+struct video_buffer *z_video_buffer_alloc(size_t header_size, size_t buffer_size, size_t align);
+
 /**
  * @brief Allocate aligned video buffer.
  *
@@ -747,7 +751,26 @@ static inline int video_set_signal(const struct device *dev,
  *
  * @retval pointer to allocated video buffer
  */
-struct video_buffer *video_buffer_aligned_alloc(size_t size, size_t align);
+static struct video_buffer *video_buffer_aligned_alloc(size_t size, size_t align)
+{
+	return z_video_buffer_alloc(0, size, align);
+}
+
+/**
+ * @brief Allocate video buffer with a header space available before it.
+ *
+ * This allows to access an extra @c vbuf->header field with @c headroom bytes
+ * before the start of @c vbuf->buffer.
+ *
+ * @param header_size Size available before the payload (in bytes).
+ * @param buffer_size Size of the video buffer payload (in bytes).
+ *
+ * @retval pointer to allocated video buffer
+ */
+static struct video_buffer *video_buffer_header_alloc(size_t header_size, size_t buffer_size)
+{
+	return z_video_buffer_alloc(header_size, buffer_size, sizeof(void *));
+}
 
 /**
  * @brief Allocate video buffer.
@@ -756,7 +779,10 @@ struct video_buffer *video_buffer_aligned_alloc(size_t size, size_t align);
  *
  * @retval pointer to allocated video buffer
  */
-struct video_buffer *video_buffer_alloc(size_t size);
+static struct video_buffer *video_buffer_alloc(size_t size)
+{
+	return z_video_buffer_alloc(0, size, sizeof(void *));
+}
 
 /**
  * @brief Release a video buffer.


### PR DESCRIPTION
Some protocols expect a header followed the buffer payload. Inserting a header at allocation time permits to have a single buffer including both the header and the payload in a continuous memory region as expected by some drivers, without requiring to `memcpy()` the header and payload every time.

Before:
```
vbuf
[                     ]
^.buffer              ^.buffer + .size
```

After:
```
vbuf
[          |                     ]
^.header   ^.buffer              ^.buffer + .size
```

