### PR TITLE
scripts: west_commands: Remove deprecated west.log

### DIFF
--- a/doc/develop/west/extensions.rst
+++ b/doc/develop/west/extensions.rst
@@ -87,7 +87,6 @@ details on the west APIs you can use, see :ref:`west-apis`.
    from textwrap import dedent            # just for nicer code indentation
 
    from west.commands import WestCommand  # your extension must subclass this
-   from west import log                   # use this for user output
 
    class MyCommand(WestCommand):
 
@@ -125,8 +124,8 @@ details on the west APIs you can use, see :ref:`west-apis`.
            #   $ west my-command-name -o FOO BAR
            #   --optional is FOO
            #   required is BAR
-           log.inf('--optional is', args.optional)
-           log.inf('required is', args.required)
+           self.inf('--optional is', args.optional)
+           self.inf('required is', args.required)
 
 You can ignore the second argument to ``do_run()`` (``unknown_args`` above), as
 ``WestCommand`` will reject unknown arguments by default. If you want to be

--- a/scripts/west_commands/boards.py
+++ b/scripts/west_commands/boards.py
@@ -9,7 +9,6 @@ import re
 import sys
 import textwrap
 
-from west import log
 from west.commands import WestCommand
 
 from zephyr_ext_common import ZEPHYR_BASE
@@ -94,13 +93,13 @@ class Boards(WestCommand):
         for board in list_boards.find_boards(args):
             if name_re is not None and not name_re.search(board.name):
                 continue
-            log.inf(args.format.format(name=board.name, arch=board.arch,
-                                       dir=board.dir, hwm=board.hwm, qualifiers=''))
+            self.inf(args.format.format(name=board.name, arch=board.arch,
+                                        dir=board.dir, hwm=board.hwm, qualifiers=''))
 
         for board in list_boards.find_v2_boards(args):
             if name_re is not None and not name_re.search(board.name):
                 continue
-            log.inf(
+            self.inf(
                 args.format.format(
                     name=board.name,
                     full_name=board.full_name,

--- a/scripts/west_commands/completion.py
+++ b/scripts/west_commands/completion.py
@@ -5,7 +5,6 @@
 import argparse
 import os
 
-from west import log
 from west.commands import WestCommand
 
 # Relative to the folder where this script lives
@@ -78,4 +77,4 @@ class Completion(WestCommand):
             with open(cf, 'r') as f:
                 print(f.read())
         except FileNotFoundError as e:
-            log.die('Unable to find completion file: {}'.format(e))
+            self.die('Unable to find completion file: {}'.format(e))

--- a/scripts/west_commands/export.py
+++ b/scripts/west_commands/export.py
@@ -4,10 +4,8 @@
 
 import argparse
 from pathlib import Path
-from shutil import rmtree
 
 from west.commands import WestCommand
-from west import log
 
 from zcmake import run_cmake
 
@@ -44,25 +42,17 @@ class ZephyrExport(WestCommand):
         # The 'share' subdirectory of the top level zephyr repository.
         share = Path(__file__).parents[2] / 'share'
 
-        run_cmake_export(share / 'zephyr-package' / 'cmake')
-        run_cmake_export(share / 'zephyrunittest-package' / 'cmake')
+        self.run_cmake_export(share / 'zephyr-package' / 'cmake')
+        self.run_cmake_export(share / 'zephyrunittest-package' / 'cmake')
 
-def run_cmake_export(path):
-    # Run a package installation script.
-    #
-    # Filtering out lines that start with -- ignores the normal
-    # CMake status messages and instead only prints the important
-    # information.
+    def run_cmake_export(self, path):
+        # Run a package installation script.
+        #
+        # Filtering out lines that start with -- ignores the normal
+        # CMake status messages and instead only prints the important
+        # information.
 
-    lines = run_cmake(['-P', str(path / 'zephyr_export.cmake')],
-                      capture_output=True)
-    msg = [line for line in lines if not line.startswith('-- ')]
-    log.inf('\n'.join(msg))
-
-def remove_if_exists(pathobj):
-    if pathobj.is_file():
-        log.inf(f'- removing: {pathobj}')
-        pathobj.unlink()
-    elif pathobj.is_dir():
-        log.inf(f'- removing: {pathobj}')
-        rmtree(pathobj)
+        lines = run_cmake(['-P', str(path / 'zephyr_export.cmake')],
+                          capture_output=True)
+        msg = [line for line in lines if not line.startswith('-- ')]
+        self.inf('\n'.join(msg))

--- a/scripts/west_commands/shields.py
+++ b/scripts/west_commands/shields.py
@@ -10,7 +10,6 @@ import re
 import sys
 import textwrap
 
-from west import log
 from west.commands import WestCommand
 
 from zephyr_ext_common import ZEPHYR_BASE
@@ -83,4 +82,4 @@ class Shields(WestCommand):
         for shield in list_shields.find_shields(args):
             if name_re is not None and not name_re.search(shield.name):
                 continue
-            log.inf(args.format.format(name=shield.name, dir=shield.dir))
+            self.inf(args.format.format(name=shield.name, dir=shield.dir))

--- a/scripts/west_commands/twister_cmd.py
+++ b/scripts/west_commands/twister_cmd.py
@@ -6,8 +6,7 @@ import argparse
 import os
 import sys
 
-from west import log
-from west.commands import WestCommand
+from west.commands import Verbosity, WestCommand
 
 from zephyr_ext_common import ZEPHYR_SCRIPTS
 
@@ -52,8 +51,8 @@ class Twister(WestCommand):
         return parser
 
     def do_run(self, args, remainder):
-        log.dbg(
-            "args: {} remainder: {}".format(args, remainder), level=log.VERBOSE_EXTREME
+        self.dbg(
+            "args: {} remainder: {}".format(args, remainder), level=Verbosity.DBG_EXTREME
         )
 
         options = parse_arguments(self.parser, args=remainder, options=args)

--- a/scripts/west_commands/zephyr_ext_common.py
+++ b/scripts/west_commands/zephyr_ext_common.py
@@ -12,7 +12,6 @@ import os
 import shlex
 from pathlib import Path
 
-from west import log
 from west.commands import WestCommand
 
 # This relies on this file being zephyr/scripts/foo/bar.py.
@@ -44,8 +43,8 @@ class Forceable(WestCommand):
         self.args.force being True can allow execution to proceed.
         '''
         if not (cond or self.args.force):
-            log.err(msg)
-            log.die('refusing to proceed without --force due to above error')
+            self.err(msg)
+            self.die('refusing to proceed without --force due to above error')
 
     def config_get_words(self, section_key, fallback=None):
         unparsed = self.config.get(section_key)


### PR DESCRIPTION
The global state `west.log` is deprecated, replace with `WestCommand` logging.

There are still more usages in tree, but those require more effort.