### PR TITLE
scripts: twisterlib: Enable multiple simulator support in twister

### DIFF
--- a/boards/arm/fvp_base_revc_2xaemv8a/fvp_base_revc_2xaemv8a.yaml
+++ b/boards/arm/fvp_base_revc_2xaemv8a/fvp_base_revc_2xaemv8a.yaml
@@ -5,6 +5,9 @@ identifier: fvp_base_revc_2xaemv8a
 name: FVP Emulation FVP_Base_RevC-2xAEMvA
 arch: arm64
 type: sim
+simulation:
+  - name: armfvp
+    exec: FVP_Base_RevC-2xAEMvA
 toolchain:
   - zephyr
   - cross-compile

--- a/boards/arm/fvp_base_revc_2xaemv8a/fvp_base_revc_2xaemv8a_fvp_base_revc_2xaemv8a_smp_ns.yaml
+++ b/boards/arm/fvp_base_revc_2xaemv8a/fvp_base_revc_2xaemv8a_fvp_base_revc_2xaemv8a_smp_ns.yaml
@@ -5,6 +5,9 @@ identifier: fvp_base_revc_2xaemv8a/fvp_base_revc_2xaemv8a/smp/ns
 name: FVP Emulation FVP_Base_RevC-2xAEMvA (SMP)
 arch: arm64
 type: sim
+simulation:
+  - name: armfvp
+    exec: FVP_Base_RevC-2xAEMvA
 toolchain:
   - zephyr
   - cross-compile

--- a/boards/arm/fvp_baser_aemv8r/fvp_baser_aemv8r_fvp_aemv8r_aarch32.yaml
+++ b/boards/arm/fvp_baser_aemv8r/fvp_baser_aemv8r_fvp_aemv8r_aarch32.yaml
@@ -6,6 +6,9 @@ identifier: fvp_baser_aemv8r/fvp_aemv8r_aarch32
 name: FVP Emulation FVP_BaseR_AEMv8R AArch32
 arch: arm
 type: sim
+simulation:
+  - name: armfvp
+    exec: FVP_BaseR_AEMv8R
 toolchain:
   - zephyr
   - cross-compile

--- a/boards/arm/fvp_baser_aemv8r/fvp_baser_aemv8r_fvp_aemv8r_aarch32_smp.yaml
+++ b/boards/arm/fvp_baser_aemv8r/fvp_baser_aemv8r_fvp_aemv8r_aarch32_smp.yaml
@@ -5,6 +5,9 @@ identifier: fvp_baser_aemv8r/fvp_aemv8r_aarch32/smp
 name: FVP Emulation FVP_BaseR_AEMv8R AArch32 (SMP)
 arch: arm
 type: sim
+simulation:
+  - name: armfvp
+    exec: FVP_BaseR_AEMv8R
 toolchain:
   - zephyr
   - cross-compile

--- a/boards/arm/fvp_baser_aemv8r/fvp_baser_aemv8r_fvp_aemv8r_aarch64.yaml
+++ b/boards/arm/fvp_baser_aemv8r/fvp_baser_aemv8r_fvp_aemv8r_aarch64.yaml
@@ -5,6 +5,9 @@ identifier: fvp_baser_aemv8r/fvp_aemv8r_aarch64
 name: FVP Emulation FVP_BaseR_AEMv8R
 arch: arm64
 type: sim
+simulation:
+  - name: armfvp
+    exec: FVP_BaseR_AEMv8R
 toolchain:
   - zephyr
   - cross-compile

--- a/boards/arm/fvp_baser_aemv8r/fvp_baser_aemv8r_fvp_aemv8r_aarch64_smp.yaml
+++ b/boards/arm/fvp_baser_aemv8r/fvp_baser_aemv8r_fvp_aemv8r_aarch64_smp.yaml
@@ -5,6 +5,9 @@ identifier: fvp_baser_aemv8r/fvp_aemv8r_aarch64/smp
 name: FVP Emulation FVP_BaseR_AEMv8R (SMP)
 arch: arm64
 type: sim
+simulation:
+  - name: armfvp
+    exec: FVP_BaseR_AEMv8R
 toolchain:
   - zephyr
   - cross-compile

--- a/boards/arm/mps2/mps2_an385.yaml
+++ b/boards/arm/mps2/mps2_an385.yaml
@@ -2,7 +2,8 @@ identifier: mps2/an385
 name: ARM V2M MPS2
 type: mcu
 arch: arm
-simulation: qemu
+simulation:
+  - name: qemu
 toolchain:
   - zephyr
   - gnuarmemb

--- a/boards/arm/mps2/mps2_an521_cpu0.yaml
+++ b/boards/arm/mps2/mps2_an521_cpu0.yaml
@@ -4,7 +4,9 @@ type: mcu
 arch: arm
 ram: 4096
 flash: 4096
-simulation: qemu
+simulation:
+  - name: qemu
+  - name: armfvp
 toolchain:
   - gnuarmemb
   - zephyr

--- a/boards/arm/mps2/mps2_an521_cpu0_ns.yaml
+++ b/boards/arm/mps2/mps2_an521_cpu0_ns.yaml
@@ -4,7 +4,9 @@ type: mcu
 arch: arm
 ram: 512
 flash: 512
-simulation: qemu
+simulation:
+  - name: qemu
+  - name: armfvp
 toolchain:
   - gnuarmemb
   - zephyr

--- a/boards/arm/mps2/mps2_an521_cpu1.yaml
+++ b/boards/arm/mps2/mps2_an521_cpu1.yaml
@@ -4,7 +4,9 @@ type: mcu
 arch: arm
 ram: 512
 flash: 468
-simulation: qemu
+simulation:
+  - name: qemu
+  - name: armfvp
 toolchain:
   - gnuarmemb
   - zephyr

--- a/boards/arm/mps3/mps3_corstone300_an547.yaml
+++ b/boards/arm/mps3/mps3_corstone300_an547.yaml
@@ -11,7 +11,9 @@ type: mcu
 arch: arm
 ram: 512
 flash: 512
-simulation: qemu
+simulation:
+  - name: qemu
+  - name: armfvp
 toolchain:
   - gnuarmemb
   - zephyr

--- a/boards/arm/mps3/mps3_corstone300_an547_ns.yaml
+++ b/boards/arm/mps3/mps3_corstone300_an547_ns.yaml
@@ -11,7 +11,8 @@ type: mcu
 arch: arm
 ram: 2048
 flash: 512
-simulation: qemu
+simulation:
+  - name: qemu
 toolchain:
   - gnuarmemb
   - zephyr

--- a/boards/arm/mps3/mps3_corstone300_fvp.yaml
+++ b/boards/arm/mps3/mps3_corstone300_fvp.yaml
@@ -7,8 +7,9 @@ type: mcu
 arch: arm
 ram: 512
 flash: 512
-simulation: armfvp
-simulation_exec: FVP_Corstone_SSE-300_Ethos-U55
+simulation:
+  - name: armfvp
+    exec: FVP_Corstone_SSE-300_Ethos-U55
 toolchain:
   - gnuarmemb
   - zephyr

--- a/boards/arm/mps3/mps3_corstone310_fvp.yaml
+++ b/boards/arm/mps3/mps3_corstone310_fvp.yaml
@@ -7,8 +7,9 @@ type: mcu
 arch: arm
 ram: 32
 flash: 32
-simulation: armfvp
-simulation_exec: FVP_Corstone_SSE-310
+simulation:
+  - name: armfvp
+    exec: FVP_Corstone_SSE-310
 toolchain:
   - gnuarmemb
   - zephyr

--- a/boards/gaisler/generic_leon3/generic_leon3.yaml
+++ b/boards/gaisler/generic_leon3/generic_leon3.yaml
@@ -1,8 +1,9 @@
 identifier: generic_leon3
 name: Generic LEON3 system
 type: mcu
-simulation: tsim
-simulation_exec: tsim-leon3
+simulation:
+  - name: tsim
+    exec: tsim-leon3
 arch: sparc
 ram: 4096
 flash: 2048

--- a/boards/gaisler/gr716a_mini/gr716a_mini.yaml
+++ b/boards/gaisler/gr716a_mini/gr716a_mini.yaml
@@ -1,8 +1,9 @@
 identifier: gr716a_mini
 name: GR716-MINI Development Board
 type: mcu
-simulation: tsim
-simulation_exec: tsim-leon3
+simulation:
+  - name: tsim
+    exec: tsim-leon3
 arch: sparc
 toolchain:
   - zephyr

--- a/boards/intel/adsp/twister.yaml
+++ b/boards/intel/adsp/twister.yaml
@@ -20,20 +20,23 @@ variants:
     twister: false
   intel_adsp/ace20_lnl/sim:
     type: sim
-    simulation: custom
-    simulation_exec: acesim
+    simulation:
+      - name: custom
+        exec: acesim
     testing:
       timeout_multiplier: 4
   intel_adsp/ace15_mtpm/sim:
     type: sim
-    simulation: custom
-    simulation_exec: acesim
+    simulation:
+      - name: custom
+        exec: acesim
     testing:
       timeout_multiplier: 4
   intel_adsp/ace30/ptl/sim:
     type: sim
-    simulation: custom
-    simulation_exec: acesim
+    simulation:
+      - name: custom
+        exec: acesim
     toolchain:
       - xt-clang
       - zephyr

--- a/boards/intel/ish/intel_ish_5_8_0.yaml
+++ b/boards/intel/ish/intel_ish_5_8_0.yaml
@@ -5,8 +5,9 @@ arch: x86
 toolchain:
   - zephyr
 ram: 640
-simulation: simics
-simulation_exec: simics
+simulation:
+  - name: simics
+    exec: simics
 supported:
   - serial
 testing:

--- a/boards/microchip/m2gl025_miv/m2gl025_miv.yaml
+++ b/boards/microchip/m2gl025_miv/m2gl025_miv.yaml
@@ -5,8 +5,9 @@ arch: riscv
 toolchain:
   - zephyr
 ram: 64
-simulation: renode
-simulation_exec: renode
+simulation:
+  - name: renode
+    exec: renode
 testing:
   default: true
   ignore_tags:

--- a/boards/native/native_posix/native_posix.yaml
+++ b/boards/native/native_posix/native_posix.yaml
@@ -1,7 +1,8 @@
 identifier: native_posix
 name: Native 32-bit POSIX port
 type: native
-simulation: native
+simulation:
+  - name: native
 arch: posix
 ram: 65536
 flash: 65536

--- a/boards/native/native_posix/native_posix_native_64.yaml
+++ b/boards/native/native_posix/native_posix_native_64.yaml
@@ -1,7 +1,8 @@
 identifier: native_posix/native/64
 name: Native 64-bit POSIX port
 type: native
-simulation: native
+simulation:
+  - name: native
 arch: posix
 ram: 65536
 flash: 65536

--- a/boards/native/native_sim/native_sim.yaml
+++ b/boards/native/native_sim/native_sim.yaml
@@ -1,7 +1,8 @@
 identifier: native_sim
 name: Native Simulation port - 32-bit
 type: native
-simulation: native
+simulation:
+  - name: native
 arch: posix
 ram: 65536
 flash: 65536

--- a/boards/native/native_sim/native_sim_native_64.yaml
+++ b/boards/native/native_sim/native_sim_native_64.yaml
@@ -1,7 +1,8 @@
 identifier: native_sim/native/64
 name: Native Simulation port - 64-bit variant
 type: native
-simulation: native
+simulation:
+  - name: native
 arch: posix
 ram: 65536
 flash: 65536

--- a/boards/native/nrf_bsim/nrf52_bsim.yaml
+++ b/boards/native/nrf_bsim/nrf52_bsim.yaml
@@ -2,7 +2,8 @@ identifier: nrf52_bsim
 name: NRF52 BabbleSim board
 type: native
 arch: posix
-simulation: native
+simulation:
+  - name: native
 env:
   - BSIM_OUT_PATH
 toolchain:

--- a/boards/native/nrf_bsim/nrf5340bsim_nrf5340_cpuapp.yaml
+++ b/boards/native/nrf_bsim/nrf5340bsim_nrf5340_cpuapp.yaml
@@ -2,7 +2,8 @@ identifier: nrf5340bsim/nrf5340/cpuapp
 name: NRF53 BabbleSim - Application Core target
 type: native
 arch: posix
-simulation: native
+simulation:
+  - name: native
 env:
   - BSIM_OUT_PATH
 toolchain:

--- a/boards/native/nrf_bsim/nrf5340bsim_nrf5340_cpunet.yaml
+++ b/boards/native/nrf_bsim/nrf5340bsim_nrf5340_cpunet.yaml
@@ -2,7 +2,8 @@ identifier: nrf5340bsim/nrf5340/cpunet
 name: NRF53 Net Core BabbleSim board
 type: native
 arch: posix
-simulation: native
+simulation:
+  - name: native
 env:
   - BSIM_OUT_PATH
 toolchain:

--- a/boards/native/nrf_bsim/nrf54l15bsim_nrf54l15_cpuapp.yaml
+++ b/boards/native/nrf_bsim/nrf54l15bsim_nrf54l15_cpuapp.yaml
@@ -2,7 +2,8 @@ identifier: nrf54l15bsim/nrf54l15/cpuapp
 name: NRF54L15 BabbleSim - Application Core target
 type: native
 arch: posix
-simulation: native
+simulation:
+  - name: native
 env:
   - BSIM_OUT_PATH
 toolchain:

--- a/boards/qemu/arc/qemu_arc_qemu_arc_em.yaml
+++ b/boards/qemu/arc/qemu_arc_qemu_arc_em.yaml
@@ -1,7 +1,8 @@
 identifier: qemu_arc/qemu_arc_em
 name: QEMU Emulation for ARC EM
 type: qemu
-simulation: qemu
+simulation:
+  - name: qemu
 arch: arc
 toolchain:
   - zephyr

--- a/boards/qemu/arc/qemu_arc_qemu_arc_hs.yaml
+++ b/boards/qemu/arc/qemu_arc_qemu_arc_hs.yaml
@@ -1,7 +1,8 @@
 identifier: qemu_arc/qemu_arc_hs
 name: QEMU Emulation for ARC HS
 type: qemu
-simulation: qemu
+simulation:
+  - name: qemu
 arch: arc
 toolchain:
   - zephyr

--- a/boards/qemu/arc/qemu_arc_qemu_arc_hs5x.yaml
+++ b/boards/qemu/arc/qemu_arc_qemu_arc_hs5x.yaml
@@ -1,7 +1,8 @@
 identifier: qemu_arc/qemu_arc_hs5x
 name: QEMU Emulation for ARC HS5x
 type: qemu
-simulation: qemu
+simulation:
+  - name: qemu
 arch: arc
 toolchain:
   - zephyr

--- a/boards/qemu/arc/qemu_arc_qemu_arc_hs6x.yaml
+++ b/boards/qemu/arc/qemu_arc_qemu_arc_hs6x.yaml
@@ -1,7 +1,8 @@
 identifier: qemu_arc/qemu_arc_hs6x
 name: QEMU Emulation for ARC HS6x
 type: qemu
-simulation: qemu
+simulation:
+  - name: qemu
 arch: arc
 toolchain:
   - cross-compile

--- a/boards/qemu/arc/qemu_arc_qemu_arc_hs_xip.yaml
+++ b/boards/qemu/arc/qemu_arc_qemu_arc_hs_xip.yaml
@@ -1,7 +1,8 @@
 identifier: qemu_arc/qemu_arc_hs/xip
 name: QEMU Emulation for ARC HS (XIP)
 type: qemu
-simulation: qemu
+simulation:
+  - name: qemu
 arch: arc
 toolchain:
   - zephyr

--- a/boards/qemu/cortex_a53/qemu_cortex_a53.yaml
+++ b/boards/qemu/cortex_a53/qemu_cortex_a53.yaml
@@ -1,7 +1,8 @@
 identifier: qemu_cortex_a53
 name: QEMU Emulation for Cortex-A53
 type: qemu
-simulation: qemu
+simulation:
+  - name: qemu
 arch: arm64
 toolchain:
   - zephyr

--- a/boards/qemu/cortex_a53/qemu_cortex_a53_qemu_cortex_a53_smp.yaml
+++ b/boards/qemu/cortex_a53/qemu_cortex_a53_qemu_cortex_a53_smp.yaml
@@ -1,7 +1,8 @@
 identifier: qemu_cortex_a53/qemu_cortex_a53/smp
 name: QEMU Emulation for Cortex-A53 SMP
 type: qemu
-simulation: qemu
+simulation:
+  - name: qemu
 arch: arm64
 toolchain:
   - zephyr

--- a/boards/qemu/cortex_a53/qemu_cortex_a53_qemu_cortex_a53_xip.yaml
+++ b/boards/qemu/cortex_a53/qemu_cortex_a53_qemu_cortex_a53_xip.yaml
@@ -1,7 +1,8 @@
 identifier: qemu_cortex_a53/qemu_cortex_a53/xip
 name: QEMU Emulation for Cortex-A53 (XIP)
 type: qemu
-simulation: qemu
+simulation:
+  - name: qemu
 arch: arm64
 toolchain:
   - zephyr

--- a/boards/qemu/cortex_a9/qemu_cortex_a9.yaml
+++ b/boards/qemu/cortex_a9/qemu_cortex_a9.yaml
@@ -8,7 +8,8 @@
 identifier: qemu_cortex_a9
 name: QEMU Emulation for Cortex-A9
 type: qemu
-simulation: qemu
+simulation:
+  - name: qemu
 arch: arm
 toolchain:
   - zephyr

--- a/boards/qemu/cortex_m0/qemu_cortex_m0.yaml
+++ b/boards/qemu/cortex_m0/qemu_cortex_m0.yaml
@@ -1,7 +1,8 @@
 identifier: qemu_cortex_m0
 name: QEMU Emulation for Cortex-M0
 type: qemu
-simulation: qemu
+simulation:
+  - name: qemu
 arch: arm
 toolchain:
   - zephyr

--- a/boards/qemu/cortex_m3/qemu_cortex_m3.yaml
+++ b/boards/qemu/cortex_m3/qemu_cortex_m3.yaml
@@ -1,7 +1,8 @@
 identifier: qemu_cortex_m3
 name: QEMU Emulation for Cortex-M3
 type: qemu
-simulation: qemu
+simulation:
+  - name: qemu
 arch: arm
 toolchain:
   - zephyr

--- a/boards/qemu/cortex_r5/qemu_cortex_r5.yaml
+++ b/boards/qemu/cortex_r5/qemu_cortex_r5.yaml
@@ -1,7 +1,8 @@
 identifier: qemu_cortex_r5
 name: QEMU Emulation for Cortex-R5
 type: qemu
-simulation: qemu
+simulation:
+  - name: qemu
 arch: arm
 toolchain:
   - zephyr

--- a/boards/qemu/leon3/qemu_leon3.yaml
+++ b/boards/qemu/leon3/qemu_leon3.yaml
@@ -1,7 +1,8 @@
 identifier: qemu_leon3
 name: QEMU Emulation for LEON3
 type: qemu
-simulation: qemu
+simulation:
+  - name: qemu
 arch: sparc
 ram: 1048576
 flash: 524288

--- a/boards/qemu/malta/qemu_malta.yaml
+++ b/boards/qemu/malta/qemu_malta.yaml
@@ -1,7 +1,8 @@
 identifier: qemu_malta
 name: QEMU emulation for MIPS (little endian)
 type: qemu
-simulation: qemu
+simulation:
+  - name: qemu
 arch: mips
 toolchain:
   - zephyr

--- a/boards/qemu/malta/qemu_malta_qemu_malta_be.yaml
+++ b/boards/qemu/malta/qemu_malta_qemu_malta_be.yaml
@@ -1,7 +1,8 @@
 identifier: qemu_malta/qemu_malta/be
 name: QEMU emulation for MIPS (big endian)
 type: qemu
-simulation: qemu
+simulation:
+  - name: qemu
 arch: mips
 toolchain:
   - zephyr

--- a/boards/qemu/nios2/qemu_nios2.yaml
+++ b/boards/qemu/nios2/qemu_nios2.yaml
@@ -1,7 +1,8 @@
 identifier: qemu_nios2
 name: QEMU Emulation for NIOS II
 type: qemu
-simulation: qemu
+simulation:
+  - name: qemu
 arch: nios2
 ram: 128
 flash: 128

--- a/boards/qemu/riscv32/qemu_riscv32.yaml
+++ b/boards/qemu/riscv32/qemu_riscv32.yaml
@@ -1,7 +1,8 @@
 identifier: qemu_riscv32
 name: QEMU Emulation for RISC-V 32-bit
 type: qemu
-simulation: qemu
+simulation:
+  - name: qemu
 arch: riscv
 toolchain:
   - zephyr

--- a/boards/qemu/riscv32/qemu_riscv32_qemu_virt_riscv32_smp.yaml
+++ b/boards/qemu/riscv32/qemu_riscv32_qemu_virt_riscv32_smp.yaml
@@ -1,7 +1,8 @@
 identifier: qemu_riscv32/qemu_virt_riscv32/smp
 name: QEMU Emulation for RISC-V 32-bit SMP
 type: qemu
-simulation: qemu
+simulation:
+  - name: qemu
 arch: riscv
 toolchain:
   - zephyr

--- a/boards/qemu/riscv32_xip/qemu_riscv32_xip.yaml
+++ b/boards/qemu/riscv32_xip/qemu_riscv32_xip.yaml
@@ -1,7 +1,8 @@
 identifier: qemu_riscv32_xip
 name: QEMU Emulation for RISC-V 32-bit in XIP mode
 type: qemu
-simulation: qemu
+simulation:
+  - name: qemu
 arch: riscv
 ram: 16
 toolchain:

--- a/boards/qemu/riscv32e/qemu_riscv32e.yaml
+++ b/boards/qemu/riscv32e/qemu_riscv32e.yaml
@@ -1,7 +1,8 @@
 identifier: qemu_riscv32e
 name: QEMU Emulation for RISC-V (RV32E) 32-bit
 type: qemu
-simulation: qemu
+simulation:
+  - name: qemu
 arch: riscv
 toolchain:
   - zephyr

--- a/boards/qemu/riscv64/qemu_riscv64.yaml
+++ b/boards/qemu/riscv64/qemu_riscv64.yaml
@@ -1,7 +1,8 @@
 identifier: qemu_riscv64
 name: QEMU Emulation for RISC-V 64-bit
 type: qemu
-simulation: qemu
+simulation:
+  - name: qemu
 arch: riscv
 toolchain:
   - zephyr

--- a/boards/qemu/riscv64/qemu_riscv64_qemu_virt_riscv64_smp.yaml
+++ b/boards/qemu/riscv64/qemu_riscv64_qemu_virt_riscv64_smp.yaml
@@ -1,7 +1,8 @@
 identifier: qemu_riscv64/qemu_virt_riscv64/smp
 name: QEMU Emulation for RISC-V 64-bit SMP
 type: qemu
-simulation: qemu
+simulation:
+  - name: qemu
 arch: riscv
 toolchain:
   - zephyr

--- a/boards/qemu/x86/qemu_x86.yaml
+++ b/boards/qemu/x86/qemu_x86.yaml
@@ -1,7 +1,8 @@
 identifier: qemu_x86
 name: QEMU Emulation for X86
 type: qemu
-simulation: qemu
+simulation:
+  - name: qemu
 arch: x86
 ram: 3000
 toolchain:

--- a/boards/qemu/x86/qemu_x86_64.yaml
+++ b/boards/qemu/x86/qemu_x86_64.yaml
@@ -5,7 +5,8 @@ arch: x86
 toolchain:
   - zephyr
   - xtools
-simulation: qemu
+simulation:
+  - name: qemu
 supported:
   - acpi
   - can

--- a/boards/qemu/x86/qemu_x86_64_atom_nokpti.yaml
+++ b/boards/qemu/x86/qemu_x86_64_atom_nokpti.yaml
@@ -7,7 +7,8 @@ toolchain:
   - xtools
 supported:
   - smp
-simulation: qemu
+simulation:
+  - name: qemu
 testing:
   default: true
   only_tags:

--- a/boards/qemu/x86/qemu_x86_atom_nokpti.yaml
+++ b/boards/qemu/x86/qemu_x86_atom_nokpti.yaml
@@ -2,7 +2,8 @@ identifier: qemu_x86/atom/nokpti
 name: QEMU Emulation for X86 (KPTI disabled)
 type: qemu
 arch: x86
-simulation: qemu
+simulation:
+  - name: qemu
 toolchain:
   - zephyr
   - xtools

--- a/boards/qemu/x86/qemu_x86_atom_nommu.yaml
+++ b/boards/qemu/x86/qemu_x86_atom_nommu.yaml
@@ -2,7 +2,8 @@ identifier: qemu_x86/atom/nommu
 name: QEMU Emulation for X86 (MMU disabled)
 type: qemu
 arch: x86
-simulation: qemu
+simulation:
+  - name: qemu
 toolchain:
   - zephyr
   - xtools

--- a/boards/qemu/x86/qemu_x86_atom_nopae.yaml
+++ b/boards/qemu/x86/qemu_x86_atom_nopae.yaml
@@ -2,7 +2,8 @@ identifier: qemu_x86/atom/nopae
 name: QEMU Emulation for X86 (32-bit page tables)
 type: qemu
 arch: x86
-simulation: qemu
+simulation:
+  - name: qemu
 toolchain:
   - zephyr
   - xtools

--- a/boards/qemu/x86/qemu_x86_atom_virt.yaml
+++ b/boards/qemu/x86/qemu_x86_atom_virt.yaml
@@ -2,7 +2,8 @@ identifier: qemu_x86/atom/virt
 name: QEMU Emulation for X86 (Run in Virtual Address Space)
 type: qemu
 arch: x86
-simulation: qemu
+simulation:
+  - name: qemu
 toolchain:
   - zephyr
   - xtools

--- a/boards/qemu/x86/qemu_x86_atom_xip.yaml
+++ b/boards/qemu/x86/qemu_x86_atom_xip.yaml
@@ -2,7 +2,8 @@ identifier: qemu_x86/atom/xip
 name: QEMU Emulation for X86 (XIP enabled)
 type: qemu
 arch: x86
-simulation: qemu
+simulation:
+  - name: qemu
 toolchain:
   - zephyr
   - xtools

--- a/boards/qemu/x86/qemu_x86_lakemont.yaml
+++ b/boards/qemu/x86/qemu_x86_lakemont.yaml
@@ -1,7 +1,8 @@
 identifier: qemu_x86_lakemont
 name: QEMU Emulation for X86 (Lakemont)
 type: qemu
-simulation: qemu
+simulation:
+  - name: qemu
 arch: x86
 toolchain:
   - zephyr

--- a/boards/qemu/x86/qemu_x86_tiny.yaml
+++ b/boards/qemu/x86/qemu_x86_tiny.yaml
@@ -2,7 +2,8 @@ identifier: qemu_x86_tiny
 name: QEMU Emulation for X86 (small VM)
 type: qemu
 arch: x86
-simulation: qemu
+simulation:
+  - name: qemu
 toolchain:
   - zephyr
   - xtools

--- a/boards/qemu/xtensa/qemu_xtensa_dc233c.yaml
+++ b/boards/qemu/xtensa/qemu_xtensa_dc233c.yaml
@@ -1,7 +1,8 @@
 identifier: qemu_xtensa/dc233c
 name: QEMU Emulation for Xtensa
 type: qemu
-simulation: qemu
+simulation:
+  - name: qemu
 arch: xtensa
 toolchain:
   - zephyr

--- a/boards/qemu/xtensa/qemu_xtensa_dc233c_mmu.yaml
+++ b/boards/qemu/xtensa/qemu_xtensa_dc233c_mmu.yaml
@@ -1,7 +1,8 @@
 identifier: qemu_xtensa/dc233c/mmu
 name: QEMU Emulation for Xtensa with MMU
 type: qemu
-simulation: qemu
+simulation:
+  - name: qemu
 arch: xtensa
 toolchain:
   - zephyr

--- a/boards/qemu/xtensa/qemu_xtensa_sample_controller32_mpu.yaml
+++ b/boards/qemu/xtensa/qemu_xtensa_sample_controller32_mpu.yaml
@@ -1,7 +1,8 @@
 identifier: qemu_xtensa/sample_controller32/mpu
 name: QEMU Emulation for Xtensa with MPU
 type: qemu
-simulation: qemu
+simulation:
+  - name: qemu
 arch: xtensa
 testing:
   default: true

--- a/boards/renode/cortex_r8_virtual/cortex_r8_virtual.yaml
+++ b/boards/renode/cortex_r8_virtual/cortex_r8_virtual.yaml
@@ -5,8 +5,9 @@ arch: arm
 toolchain:
   - zephyr
 ram: 131072
-simulation: renode
-simulation_exec: renode
+simulation:
+  - name: renode
+    exec: renode
 testing:
   ignore_tags:
     - net

--- a/boards/renode/riscv32_virtual/riscv32_virtual.yaml
+++ b/boards/renode/riscv32_virtual/riscv32_virtual.yaml
@@ -6,8 +6,9 @@ toolchain:
   - zephyr
 ram: 4096
 flash: 4096
-simulation: renode
-simulation_exec: renode
+simulation:
+  - name: renode
+    exec: renode
 testing:
   ignore_tags:
     - net

--- a/boards/sifive/hifive1/hifive1.yaml
+++ b/boards/sifive/hifive1/hifive1.yaml
@@ -5,8 +5,9 @@ arch: riscv
 toolchain:
   - zephyr
 ram: 16
-simulation: renode
-simulation_exec: renode
+simulation:
+  - name: renode
+    exec: renode
 supported:
   - pwm
   - gpio

--- a/boards/sifive/hifive_unleashed/hifive_unleashed_e51.yaml
+++ b/boards/sifive/hifive_unleashed/hifive_unleashed_e51.yaml
@@ -5,8 +5,9 @@ arch: riscv
 toolchain:
   - zephyr
 ram: 3840
-simulation: renode
-simulation_exec: renode
+simulation:
+  - name: renode
+    exec: renode
 testing:
   timeout_multiplier: 6
   ignore_tags:

--- a/boards/sifive/hifive_unleashed/hifive_unleashed_u54.yaml
+++ b/boards/sifive/hifive_unleashed/hifive_unleashed_u54.yaml
@@ -5,8 +5,9 @@ arch: riscv
 toolchain:
   - zephyr
 ram: 3840
-simulation: renode
-simulation_exec: renode
+simulation:
+  - name: renode
+    exec: renode
 testing:
   timeout_multiplier: 6
   ignore_tags:

--- a/boards/sifive/hifive_unmatched/hifive_unmatched_s7.yaml
+++ b/boards/sifive/hifive_unmatched/hifive_unmatched_s7.yaml
@@ -5,8 +5,9 @@ arch: riscv
 toolchain:
   - zephyr
 ram: 3840
-simulation: renode
-simulation_exec: renode
+simulation:
+  - name: renode
+    exec: renode
 testing:
   timeout_multiplier: 6
   ignore_tags:

--- a/boards/sifive/hifive_unmatched/hifive_unmatched_u74.yaml
+++ b/boards/sifive/hifive_unmatched/hifive_unmatched_u74.yaml
@@ -5,8 +5,9 @@ arch: riscv
 toolchain:
   - zephyr
 ram: 3840
-simulation: renode
-simulation_exec: renode
+simulation:
+  - name: renode
+    exec: renode
 testing:
   timeout_multiplier: 6
   ignore_tags:

--- a/boards/snps/nsim/arc_classic/nsim_nsim_em.yaml
+++ b/boards/snps/nsim/arc_classic/nsim_nsim_em.yaml
@@ -1,8 +1,9 @@
 identifier: nsim/nsim_em
 name: EM Nsim simulator
 type: sim
-simulation: nsim
-simulation_exec: nsimdrv
+simulation:
+  - name: nsim
+    exec: nsimdrv
 arch: arc
 toolchain:
   - zephyr

--- a/boards/snps/nsim/arc_classic/nsim_nsim_em11d.yaml
+++ b/boards/snps/nsim/arc_classic/nsim_nsim_em11d.yaml
@@ -1,8 +1,9 @@
 identifier: nsim/nsim_em11d
 name: EM11D Nsim simulator
 type: sim
-simulation: nsim
-simulation_exec: nsimdrv
+simulation:
+  - name: nsim
+    exec: nsimdrv
 arch: arc
 toolchain:
   - zephyr

--- a/boards/snps/nsim/arc_classic/nsim_nsim_em7d_v22.yaml
+++ b/boards/snps/nsim/arc_classic/nsim_nsim_em7d_v22.yaml
@@ -1,8 +1,9 @@
 identifier: nsim/nsim_em7d_v22
 name: EM nSIM simulator (EM7D_v22)
 type: sim
-simulation: nsim
-simulation_exec: nsimdrv
+simulation:
+  - name: nsim
+    exec: nsimdrv
 arch: arc
 toolchain:
   - zephyr

--- a/boards/snps/nsim/arc_classic/nsim_nsim_hs.yaml
+++ b/boards/snps/nsim/arc_classic/nsim_nsim_hs.yaml
@@ -1,8 +1,9 @@
 identifier: nsim/nsim_hs
 name: HS nSIM simulator
 type: sim
-simulation: nsim
-simulation_exec: nsimdrv
+simulation:
+  - name: nsim
+    exec: nsimdrv
 arch: arc
 toolchain:
   - zephyr

--- a/boards/snps/nsim/arc_classic/nsim_nsim_hs5x.yaml
+++ b/boards/snps/nsim/arc_classic/nsim_nsim_hs5x.yaml
@@ -1,8 +1,9 @@
 identifier: nsim/nsim_hs5x
 name: HS5x nSIM simulator
 type: sim
-simulation: nsim
-simulation_exec: nsimdrv
+simulation:
+  - name: nsim
+    exec: nsimdrv
 arch: arc
 toolchain:
   - zephyr

--- a/boards/snps/nsim/arc_classic/nsim_nsim_hs5x_smp.yaml
+++ b/boards/snps/nsim/arc_classic/nsim_nsim_hs5x_smp.yaml
@@ -1,8 +1,9 @@
 identifier: nsim/nsim_hs5x/smp
 name: Multi-core HS5x nSIM simulator
 type: sim
-simulation: mdb-nsim
-simulation_exec: mdb
+simulation:
+  - name: mdb-nsim
+    exec: mdb
 arch: arc
 toolchain:
   - zephyr

--- a/boards/snps/nsim/arc_classic/nsim_nsim_hs5x_smp_12cores.yaml
+++ b/boards/snps/nsim/arc_classic/nsim_nsim_hs5x_smp_12cores.yaml
@@ -1,8 +1,9 @@
 identifier: nsim/nsim_hs5x/smp/12cores
 name: Multi-core HS5x nSIM simulator (12 cores)
 type: sim
-simulation: mdb-nsim
-simulation_exec: mdb
+simulation:
+  - name: mdb-nsim
+    exec: mdb
 arch: arc
 toolchain:
   - zephyr

--- a/boards/snps/nsim/arc_classic/nsim_nsim_hs6x.yaml
+++ b/boards/snps/nsim/arc_classic/nsim_nsim_hs6x.yaml
@@ -1,8 +1,9 @@
 identifier: nsim/nsim_hs6x
 name: HS6x nSIM simulator
 type: sim
-simulation: nsim
-simulation_exec: nsimdrv
+simulation:
+  - name: nsim
+    exec: nsimdrv
 arch: arc
 toolchain:
   - arcmwdt

--- a/boards/snps/nsim/arc_classic/nsim_nsim_hs6x_smp.yaml
+++ b/boards/snps/nsim/arc_classic/nsim_nsim_hs6x_smp.yaml
@@ -1,8 +1,9 @@
 identifier: nsim/nsim_hs6x/smp
 name: Multi-core HS6x nSIM simulator
 type: sim
-simulation: mdb-nsim
-simulation_exec: mdb
+simulation:
+  - name: mdb-nsim
+    exec: mdb
 arch: arc
 toolchain:
   - cross-compile

--- a/boards/snps/nsim/arc_classic/nsim_nsim_hs6x_smp_12cores.yaml
+++ b/boards/snps/nsim/arc_classic/nsim_nsim_hs6x_smp_12cores.yaml
@@ -1,8 +1,9 @@
 identifier: nsim/nsim_hs6x/smp/12cores
 name: Multi-core HS6x nSIM simulator (12 cores)
 type: sim
-simulation: mdb-nsim
-simulation_exec: mdb
+simulation:
+  - name: mdb-nsim
+    exec: mdb
 arch: arc
 toolchain:
   - cross-compile

--- a/boards/snps/nsim/arc_classic/nsim_nsim_hs_flash_xip.yaml
+++ b/boards/snps/nsim/arc_classic/nsim_nsim_hs_flash_xip.yaml
@@ -1,8 +1,9 @@
 identifier: nsim/nsim_hs/flash_xip
 name: HS nSIM simulator (FLASH XIP)
 type: sim
-simulation: nsim
-simulation_exec: nsimdrv
+simulation:
+  - name: nsim
+    exec: nsimdrv
 arch: arc
 toolchain:
   - zephyr

--- a/boards/snps/nsim/arc_classic/nsim_nsim_hs_hostlink.yaml
+++ b/boards/snps/nsim/arc_classic/nsim_nsim_hs_hostlink.yaml
@@ -1,8 +1,9 @@
 identifier: nsim/nsim_hs/hostlink
 name: HS3x nSIM simulator
 type: sim
-simulation: nsim
-simulation_exec: nsimdrv
+simulation:
+  - name: nsim
+    exec: nsimdrv
 arch: arc
 toolchain:
   - zephyr

--- a/boards/snps/nsim/arc_classic/nsim_nsim_hs_mpuv6.yaml
+++ b/boards/snps/nsim/arc_classic/nsim_nsim_hs_mpuv6.yaml
@@ -1,8 +1,9 @@
 identifier: nsim/nsim_hs/mpuv6
 name: HS (with MPU v6) nSIM simulator
 type: sim
-simulation: nsim
-simulation_exec: nsimdrv
+simulation:
+  - name: nsim
+    exec: nsimdrv
 arch: arc
 toolchain:
   - zephyr

--- a/boards/snps/nsim/arc_classic/nsim_nsim_hs_smp.yaml
+++ b/boards/snps/nsim/arc_classic/nsim_nsim_hs_smp.yaml
@@ -1,8 +1,9 @@
 identifier: nsim/nsim_hs/smp
 name: Multi-core HS nSIM simulator
 type: sim
-simulation: mdb-nsim
-simulation_exec: mdb
+simulation:
+  - name: mdb-nsim
+    exec: mdb
 arch: arc
 toolchain:
   - zephyr

--- a/boards/snps/nsim/arc_classic/nsim_nsim_hs_sram.yaml
+++ b/boards/snps/nsim/arc_classic/nsim_nsim_hs_sram.yaml
@@ -1,8 +1,9 @@
 identifier: nsim/nsim_hs/sram
 name: HS nSIM simulator (SRAM)
 type: sim
-simulation: nsim
-simulation_exec: nsimdrv
+simulation:
+  - name: nsim
+    exec: nsimdrv
 arch: arc
 toolchain:
   - zephyr

--- a/boards/snps/nsim/arc_classic/nsim_nsim_sem.yaml
+++ b/boards/snps/nsim/arc_classic/nsim_nsim_sem.yaml
@@ -2,8 +2,9 @@ identifier: nsim/nsim_sem
 name: SEM Nsim simulator
 type: sim
 arch: arc
-simulation: nsim
-simulation_exec: nsimdrv
+simulation:
+  - name: nsim
+    exec: nsimdrv
 toolchain:
   - zephyr
   - cross-compile

--- a/boards/snps/nsim/arc_classic/nsim_nsim_sem_mpu_stack_guard.yaml
+++ b/boards/snps/nsim/arc_classic/nsim_nsim_sem_mpu_stack_guard.yaml
@@ -2,8 +2,9 @@ identifier: nsim/nsim_sem/mpu_stack_guard
 name: SEM nSIM simulator (stack guard)
 type: sim
 arch: arc
-simulation: nsim
-simulation_exec: nsimdrv
+simulation:
+  - name: nsim
+    exec: nsimdrv
 toolchain:
   - zephyr
   - cross-compile

--- a/boards/snps/nsim/arc_classic/nsim_nsim_vpx5.yaml
+++ b/boards/snps/nsim/arc_classic/nsim_nsim_vpx5.yaml
@@ -1,8 +1,9 @@
 identifier: nsim/nsim_vpx5
 name: VPX5 nSIM simulator
 type: sim
-simulation: nsim
-simulation_exec: nsimdrv
+simulation:
+  - name: nsim
+    exec: nsimdrv
 arch: arc
 toolchain:
   - arcmwdt

--- a/boards/snps/nsim/arc_v/nsim_arc_v_rmx100.yaml
+++ b/boards/snps/nsim/arc_v/nsim_arc_v_rmx100.yaml
@@ -1,7 +1,8 @@
 identifier: nsim_arc_v/rmx100
 name: Synopsys rmx100
-simulation: nsim
-simulation_exec: nsimdrv
+simulation:
+  - name: nsim
+    exec: nsimdrv
 type: sim
 arch: riscv
 toolchain:

--- a/doc/develop/test/twister.rst
+++ b/doc/develop/test/twister.rst
@@ -151,7 +151,23 @@ name:
 type:
   Type of the board or configuration, currently we support 2 types: mcu, qemu
 simulation:
-  Simulator used to simulate the platform, e.g. qemu.
+  Simulator(s) used to simulate the platform, e.g. qemu.
+
+  .. code-block:: yaml
+
+      simulation:
+        - name: qemu
+        - name: armfvp
+          exec: FVP_Some_Platform
+        - name: custom
+          exec: AnotherBinary
+
+  By default, tests will be executed using the first entry in the simulation array. Another
+  simulation can be selected with ``--simulation <simulation_name>``.
+  The ``exec`` attribute is optional. If it is set but the required simulator is not available, the
+  tests will be built only.
+  If it is not set and the required simulator is not available the tests will fail to run.
+  The simulation name must match one of the element of ``SUPPORTED_EMU_PLATFORMS``.
 arch:
   Architecture of the board
 toolchain:
@@ -918,8 +934,9 @@ To use this type of simulation, add the following properties to
 
 .. code-block:: yaml
 
-   simulation: custom
-   simulation_exec: <name_of_emu_binary>
+   simulation:
+     - name: custom
+       exec: <name_of_emu_binary>
 
 This tells Twister that the board is using a custom emulator called ``<name_of_emu_binary>``,
 make sure this binary exists in the PATH.

--- a/scripts/pylib/twister/twisterlib/constants.py
+++ b/scripts/pylib/twister/twisterlib/constants.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2024 Arm Limited (or its affiliates). All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+SUPPORTED_SIMS = [
+    "mdb-nsim",
+    "nsim",
+    "renode",
+    "qemu",
+    "tsim",
+    "armfvp",
+    "xt-sim",
+    "native",
+    "custom",
+    "simics",
+]
+SUPPORTED_SIMS_IN_PYTEST = ['native', 'qemu']
+SUPPORTED_SIMS_WITH_EXEC = ['nsim', 'mdb-nsim', 'renode', 'tsim', 'native', 'simics', 'custom']

--- a/scripts/pylib/twister/twisterlib/environment.py
+++ b/scripts/pylib/twister/twisterlib/environment.py
@@ -20,6 +20,7 @@ from importlib import metadata
 from pathlib import Path
 from typing import Generator, List
 
+from twisterlib.constants import SUPPORTED_SIMS
 from twisterlib.coverage import supported_coverage_formats
 
 logger = logging.getLogger('twister')
@@ -71,7 +72,7 @@ def norm_path(astring):
     return newstring
 
 
-def add_parse_arguments(parser = None):
+def add_parse_arguments(parser = None) -> argparse.ArgumentParser:
     if parser is None:
         parser = argparse.ArgumentParser(
             description=__doc__,
@@ -178,6 +179,13 @@ Artificially long but functional example:
                         and create a hardware map file to be used with
                         --device-testing
                         """)
+
+    run_group_option.add_argument(
+        "--simulation", dest="sim_name", choices=SUPPORTED_SIMS,
+        help="Selects which simulation to use. Must match one of the names defined in the board's "
+             "manifest. If multiple simulator are specified in the selected board and this "
+             "argument is not passed, then the first simulator is selected.")
+
 
     device.add_argument("--device-serial",
                         help="""Serial device for accessing the board
@@ -805,7 +813,7 @@ structure in the main Zephyr tree: boards/<vendor>/<board_name>/""")
     return parser
 
 
-def parse_arguments(parser, args, options = None, on_init=True):
+def parse_arguments(parser: argparse.ArgumentParser, args, options = None, on_init=True) -> argparse.Namespace:
     if options is None:
         options = parser.parse_args(args)
 
@@ -952,7 +960,7 @@ def strip_ansi_sequences(s: str) -> str:
 
 class TwisterEnv:
 
-    def __init__(self, options, default_options=None) -> None:
+    def __init__(self, options : argparse.Namespace, default_options=None) -> None:
         self.version = "Unknown"
         self.toolchain = None
         self.commit_date = "Unknown"

--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -48,9 +48,6 @@ except ImportError as capture_error:
 logger = logging.getLogger('twister')
 logger.setLevel(logging.DEBUG)
 
-SUPPORTED_SIMS = ["mdb-nsim", "nsim", "renode", "qemu", "tsim", "armfvp", "xt-sim", "native", "custom", "simics"]
-SUPPORTED_SIMS_IN_PYTEST = ['native', 'qemu']
-
 
 def terminate_process(proc):
     """
@@ -241,6 +238,7 @@ class BinaryHandler(Handler):
                 self.terminate(proc)
 
     def _create_command(self, robot_test):
+
         if robot_test:
             keywords = os.path.join(self.options.coverage_basedir, 'tests/robot/common.robot')
             elf = os.path.join(self.build_dir, "zephyr/zephyr.elf")
@@ -262,8 +260,14 @@ class BinaryHandler(Handler):
                             "--variable", "RESC:@" + resc,
                             "--variable", "UART:" + uart]
         elif self.call_make_run:
-            command = [self.generator_cmd, "-C", self.get_default_domain_build_dir(), "run"]
+            if self.options.sim_name:
+                target = f"run_{self.options.sim_name}"
+            else:
+                target = "run"
+
+            command = [self.generator_cmd, "-C", self.get_default_domain_build_dir(), target]
         elif self.instance.testsuite.type == "unit":
+            assert self.binary, "Missing binary in unit testsuite."
             command = [self.binary]
         else:
             binary = os.path.join(self.get_default_domain_build_dir(), "zephyr", "zephyr.exe")

--- a/scripts/pylib/twister/twisterlib/harness.py
+++ b/scripts/pylib/twister/twisterlib/harness.py
@@ -20,10 +20,10 @@ from pytest import ExitCode
 from twisterlib.reports import ReportStatus
 from twisterlib.error import ConfigurationError, StatusAttributeError
 from twisterlib.environment import ZEPHYR_BASE, PYTEST_PLUGIN_INSTALLED
-from twisterlib.handlers import Handler, terminate_process, SUPPORTED_SIMS_IN_PYTEST
+from twisterlib.handlers import Handler, terminate_process
 from twisterlib.statuses import TwisterStatus
 from twisterlib.testinstance import TestInstance
-
+from twisterlib.constants import SUPPORTED_SIMS_IN_PYTEST
 
 logger = logging.getLogger('twister')
 logger.setLevel(logging.DEBUG)

--- a/scripts/pylib/twister/twisterlib/platform.py
+++ b/scripts/pylib/twister/twisterlib/platform.py
@@ -2,15 +2,42 @@
 # vim: set syntax=python ts=4 :
 #
 # Copyright (c) 2018-2022 Intel Corporation
+# Copyright (c) 2024 Arm Limited (or its affiliates). All rights reserved.
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import os
+import shutil
 import scl
 from twisterlib.environment import ZEPHYR_BASE
+from twisterlib.constants import SUPPORTED_SIMS
 import logging
 
 logger = logging.getLogger('twister')
 logger.setLevel(logging.DEBUG)
+
+
+class Simulator:
+    """Class representing a simulator"""
+
+    def __init__(self, data: dict[str, str]):
+        assert "name" in data
+        assert data["name"] in SUPPORTED_SIMS
+        self.name = data["name"]
+        self.exec = data.get("exec")
+
+    def is_runnable(self) -> bool:
+        return not bool(self.exec) or bool(shutil.which(self.exec))
+
+    def __str__(self):
+        return f"Simulator(name: {self.name}, exec: {self.exec})"
+
+    def __eq__(self, other):
+        if isinstance(other, Simulator):
+            return self.name == other.name and self.exec == other.exec
+        else:
+            return False
+
 
 class Platform:
     """Class representing metadata for a particular platform
@@ -46,8 +73,8 @@ class Platform:
         self.vendor = ""
         self.tier = -1
         self.type = "na"
-        self.simulation = "na"
-        self.simulation_exec = None
+        self.simulators: list[Simulator] = []
+        self.simulation: str = "na"
         self.supported_toolchains = []
         self.env = []
         self.env_satisfied = True
@@ -103,8 +130,12 @@ class Platform:
         self.vendor = board.vendor
         self.tier = variant_data.get("tier", data.get("tier", self.tier))
         self.type = variant_data.get('type', data.get('type', self.type))
-        self.simulation = variant_data.get('simulation', data.get('simulation', self.simulation))
-        self.simulation_exec = variant_data.get('simulation_exec', data.get('simulation_exec', self.simulation_exec))
+
+        self.simulators = [Simulator(data) for data in variant_data.get('simulation', data.get('simulation', self.simulators))]
+        default_sim = self.simulator_by_name(None)
+        if default_sim:
+            self.simulation = default_sim.name
+
         self.supported_toolchains = variant_data.get("toolchain", data.get("toolchain", []))
         if self.supported_toolchains is None:
             self.supported_toolchains = []
@@ -137,6 +168,12 @@ class Platform:
         for env in self.env:
             if not os.environ.get(env, None):
                 self.env_satisfied = False
+
+    def simulator_by_name(self, sim_name: str | None) -> Simulator | None:
+        if sim_name:
+            return next(filter(lambda s: s.name == sim_name, iter(self.simulators)), None)
+        else:
+            return next(iter(self.simulators), None)
 
     def __repr__(self):
         return "<%s on %s>" % (self.name, self.arch)

--- a/scripts/pylib/twister/twisterlib/quarantine.py
+++ b/scripts/pylib/twister/twisterlib/quarantine.py
@@ -1,4 +1,6 @@
 # Copyright (c) 2022 Nordic Semiconductor ASA
+# Copyright (c) 2024 Arm Limited (or its affiliates). All rights reserved.
+#
 # SPDX-License-Identifier: Apache-2.0
 
 from __future__ import annotations
@@ -31,8 +33,8 @@ class Quarantine:
         for quarantine_file in quarantine_list:
             self.quarantine.extend(QuarantineData.load_data_from_yaml(quarantine_file))
 
-    def get_matched_quarantine(self, testname, platform, architecture, simulation):
-        qelem = self.quarantine.get_matched_quarantine(testname, platform, architecture, simulation)
+    def get_matched_quarantine(self, testname, platform, architecture, simulator):
+        qelem = self.quarantine.get_matched_quarantine(testname, platform, architecture, simulator)
         if qelem:
             logger.debug('%s quarantined with reason: %s' % (testname, qelem.comment))
             return qelem.comment
@@ -111,7 +113,7 @@ class QuarantineData:
                                scenario: str,
                                platform: str,
                                architecture: str,
-                               simulation: str) -> QuarantineElement | None:
+                               simulator_name: str) -> QuarantineElement | None:
         """Return quarantine element if test is matched to quarantine rules"""
         for qelem in self.qlist:
             matched: bool = False
@@ -125,7 +127,7 @@ class QuarantineData:
                     and (matched := _is_element_matched(architecture, qelem.re_architectures)) is False):
                 continue
             if (qelem.simulations
-                    and (matched := _is_element_matched(simulation, qelem.re_simulations)) is False):
+                    and (matched := _is_element_matched(simulator_name, qelem.re_simulations)) is False):
                 continue
 
             if matched:

--- a/scripts/schemas/twister/platform-schema.yaml
+++ b/scripts/schemas/twister/platform-schema.yaml
@@ -30,22 +30,28 @@ schema;platform-schema:
       type: str
       enum: ["mcu", "qemu", "sim", "unit", "native"]
     "simulation":
-      type: str
-      enum:
-        [
-          "qemu",
-          "simics",
-          "xt-sim",
-          "renode",
-          "nsim",
-          "mdb-nsim",
-          "tsim",
-          "armfvp",
-          "native",
-          "custom",
-        ]
-    "simulation_exec":
-      type: str
+      type: seq
+      seq:
+        - type: map
+          mapping:
+            "name":
+              type: str
+              required: true
+              enum:
+                [
+                  "qemu",
+                  "simics",
+                  "xt-sim",
+                  "renode",
+                  "nsim",
+                  "mdb-nsim",
+                  "tsim",
+                  "armfvp",
+                  "native",
+                  "custom",
+                ]
+            "exec":
+              type: str
     "arch":
       type: str
       enum:

--- a/scripts/tests/twister/test_handlers.py
+++ b/scripts/tests/twister/test_handlers.py
@@ -443,6 +443,7 @@ def test_binaryhandler_create_command(
     options = SimpleNamespace()
     options.enable_valgrind = enable_valgrind
     options.coverage_basedir = "coverage_basedir"
+    options.sim_name = None
     handler = BinaryHandler(mocked_instance, 'build', options, 'generator', False)
     handler.binary = 'bin'
     handler.call_make_run = call_make_run

--- a/scripts/tests/twister/test_platform.py
+++ b/scripts/tests/twister/test_platform.py
@@ -14,7 +14,7 @@ import pytest
 ZEPHYR_BASE = os.getenv("ZEPHYR_BASE")
 sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts/pylib/twister"))
 
-from twisterlib.platform import Platform
+from twisterlib.platform import Platform, Simulator
 
 
 TESTDATA_1 = [
@@ -38,8 +38,7 @@ arch: arc
             'vendor': '',
             'tier': -1,
             'type': 'na',
-            'simulation': 'na',
-            'simulation_exec': None,
+            'simulators': [],
             'supported_toolchains': [],
             'env': [],
             'env_satisfied': True
@@ -71,8 +70,9 @@ supported:
 vendor: vendor1
 tier: 1
 type: unit
-simulation: nsim
-simulation_exec: nsimdrv
+simulation:
+- name: nsim
+  exec: nsimdrv
 toolchain:
   - zephyr
   - llvm
@@ -94,8 +94,7 @@ env:
             'vendor': 'vendor1',
             'tier': 1,
             'type': 'unit',
-            'simulation': 'nsim',
-            'simulation_exec': 'nsimdrv',
+            'simulators': [Simulator({'name': 'nsim', 'exec': 'nsimdrv'})],
             'supported_toolchains': ['zephyr', 'llvm', 'cross-compile'],
             'env': ['dummynonexistentvar'],
             'env_satisfied': False

--- a/scripts/tests/twister/test_quarantine.py
+++ b/scripts/tests/twister/test_quarantine.py
@@ -263,12 +263,12 @@ def test_quarantinedata_get_matched_quarantine(
             scenario=scenario,
             platform=platform,
             architecture=architecture,
-            simulation=simulation
+            simulator_name=simulation
         ) is None
     else:
         assert quarantine_data.get_matched_quarantine(
             scenario=scenario,
             platform=platform,
             architecture=architecture,
-            simulation=simulation
+            simulator_name=simulation
         ) == qlist[expected_idx]

--- a/scripts/tests/twister/test_testinstance.py
+++ b/scripts/tests/twister/test_testinstance.py
@@ -16,6 +16,7 @@ import mock
 ZEPHYR_BASE = os.getenv("ZEPHYR_BASE")
 sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts/pylib/twister"))
 
+from pylib.twister.twisterlib.platform import Simulator
 from twisterlib.statuses import TwisterStatus
 from twisterlib.testinstance import TestInstance
 from twisterlib.error import BuildError
@@ -25,12 +26,12 @@ from expr_parser import reserved
 
 
 TESTDATA_PART_1 = [
-    (False, False, "console", "na", "qemu", False, [], (False, True)),
+    (False, False, "console", None, "qemu", False, [], (False, True)),
     (False, False, "console", "native", "qemu", False, [], (False, True)),
     (True, False, "console", "native", "nsim", False, [], (True, False)),
     (True, True, "console", "native", "renode", False, [], (True, False)),
     (False, False, "sensor", "native", "", False, [], (True, False)),
-    (False, False, "sensor", "na", "", False, [], (True, False)),
+    (False, False, "sensor", None, "", False, [], (True, False)),
     (False, True, "sensor", "native", "", True, [], (True, False)),
 ]
 @pytest.mark.parametrize(
@@ -62,7 +63,7 @@ def test_check_build_or_run(
     class_testplan.platforms = platforms_list
     platform = class_testplan.get_platform("demo_board_2")
     platform.type = platform_type
-    platform.simulation = platform_sim
+    platform.simulators = [Simulator({"name": platform_sim})] if platform_sim else []
     testsuite.harness = harness
     testsuite.build_only = build_only
     testsuite.slow = slow
@@ -73,7 +74,8 @@ def test_check_build_or_run(
             device_testing=False,
             enable_slow=slow,
             fixtures=fixture,
-            filter=""
+            filter="",
+            sim_name=platform_sim
         )
     )
     run = testinstance.check_runnable(env.options)
@@ -455,9 +457,9 @@ TESTDATA_4 = [
     (True, mock.ANY, mock.ANY, mock.ANY, None, [], False),
     (False, True, mock.ANY, mock.ANY, 'device', [], True),
     (False, False, 'qemu', mock.ANY, 'qemu', ['QEMU_PIPE=1'], True),
-    (False, False, 'dummy sim', mock.ANY, 'dummy sim', [], True),
-    (False, False, 'na', 'unit', 'unit', ['COVERAGE=1'], True),
-    (False, False, 'na', 'dummy type', '', [], False),
+    (False, False, 'armfvp', mock.ANY, 'armfvp', [], True),
+    (False, False, None, 'unit', 'unit', ['COVERAGE=1'], True),
+    (False, False, None, 'dummy type', '', [], False),
 ]
 
 @pytest.mark.parametrize(
@@ -479,13 +481,13 @@ def test_testinstance_setup_handler(
     expected_handler_ready
 ):
     testinstance.handler = mock.Mock() if preexisting_handler else None
-    testinstance.platform.simulation = platform_sim
-    testinstance.platform.simulation_exec = 'dummy exec'
+    testinstance.platform.simulators = [Simulator({"name": platform_sim, "exec": 'dummy exec'})] if platform_sim else []
     testinstance.testsuite.type = testsuite_type
     env = mock.Mock(
         options=mock.Mock(
             device_testing=device_testing,
-            enable_coverage=True
+            enable_coverage=True,
+            sim_name=platform_sim,
         )
     )
 
@@ -546,8 +548,7 @@ def test_testinstance_check_runnable(
     hardware_map,
     expected
 ):
-    testinstance.platform.simulation = platform_sim
-    testinstance.platform.simulation_exec = platform_sim_exec
+    testinstance.platform.simulators = [Simulator({"name": platform_sim, "exec": platform_sim_exec})]
     testinstance.testsuite.build_only = testsuite_build_only
     testinstance.testsuite.slow = testsuite_slow
     testinstance.testsuite.harness = testsuite_harness
@@ -557,7 +558,8 @@ def test_testinstance_check_runnable(
             device_testing=False,
             enable_slow=enable_slow,
             fixtures=fixtures,
-            filter=filter
+            filter=filter,
+            sim_name=platform_sim
         )
     )
     with mock.patch('os.name', os_name), \


### PR DESCRIPTION
This change introduces the ability in twister to select which
emulation/simulation tool to use on the command line.

If none is specified, it will select the first in the list.

Signed-off-by: Wilfried Chauveau <wilfried.chauveau@arm.com>