### PR TITLE
net: lib: coap: Initialize response_truncated

### DIFF
--- a/subsys/net/lib/coap/coap_client.c
+++ b/subsys/net/lib/coap/coap_client.c
@@ -928,7 +928,7 @@ static void coap_client_recv(void *coap_cl, void *a, void *b)
 		for (int i = 0; i < num_clients; i++) {
 			if (clients[i]->response_ready) {
 				struct coap_packet response;
-				bool response_truncated;
+				bool response_truncated = false;
 
 				k_mutex_lock(&clients[i]->lock, K_FOREVER);
 


### PR DESCRIPTION
Fix the following compilation warning given when using newlibc:
`warning: 'response_truncated' may be used uninitialized [-Wmaybe-uninitialized]`

Issue is not seen with picolibc.
The variable was introduced as part of PR #76257