### PR TITLE
samples: Bluetooth: Audio: Avoid uisng K_FOREVER in syswq

### DIFF
--- a/samples/bluetooth/bap_unicast_server/src/main.c
+++ b/samples/bluetooth/bap_unicast_server/src/main.c
@@ -229,7 +229,12 @@ static void audio_timer_timeout(struct k_work *work)
 	for (size_t i = 0; i < configured_source_stream_count; i++) {
 		struct bt_bap_stream *stream = &source_streams[i].stream;
 
-		buf = net_buf_alloc(&tx_pool, K_FOREVER);
+		buf = net_buf_alloc(&tx_pool, K_NO_WAIT);
+		if (buf == NULL) {
+			printk("Failed to allocate TX buffer\n");
+			/* Break and retry later */
+			break;
+		}
 		net_buf_reserve(buf, BT_ISO_CHAN_SEND_RESERVE);
 
 		net_buf_add_mem(buf, buf_data, ++source_streams[i].len_to_send);

--- a/samples/bluetooth/hap_ha/src/bap_unicast_sr.c
+++ b/samples/bluetooth/hap_ha/src/bap_unicast_sr.c
@@ -157,7 +157,12 @@ static void audio_timer_timeout(struct k_work *work)
 	for (size_t i = 0; i < configured_source_stream_count; i++) {
 		struct bt_bap_stream *stream = source_streams[i].stream;
 
-		buf = net_buf_alloc(&tx_pool, K_FOREVER);
+		buf = net_buf_alloc(&tx_pool, K_NO_WAIT);
+		if (buf == NULL) {
+			printk("Failed to allocate TX buffer\n");
+			/* Break and retry later */
+			break;
+		}
 		net_buf_reserve(buf, BT_ISO_CHAN_SEND_RESERVE);
 
 		net_buf_add_mem(buf, buf_data, len_to_send);

--- a/samples/bluetooth/iso_broadcast_benchmark/src/broadcaster.c
+++ b/samples/bluetooth/iso_broadcast_benchmark/src/broadcaster.c
@@ -589,7 +589,7 @@ static void iso_timer_timeout(struct k_work *work)
 	k_work_reschedule(&iso_send_work, K_USEC(big_create_param.interval - 100));
 
 	for (int i = 0; i < big_create_param.num_bis; i++) {
-		buf = net_buf_alloc(&bis_tx_pool, K_FOREVER);
+		buf = net_buf_alloc(&bis_tx_pool, K_NO_WAIT);
 		if (buf == NULL) {
 			LOG_ERR("Could not allocate buffer");
 			return;

--- a/samples/bluetooth/iso_connected_benchmark/src/main.c
+++ b/samples/bluetooth/iso_connected_benchmark/src/main.c
@@ -202,7 +202,7 @@ static void iso_send(struct bt_iso_chan *chan)
 	interval = (role == ROLE_CENTRAL) ?
 		   cig_create_param.c_to_p_interval : cig_create_param.p_to_c_interval;
 
-	buf = net_buf_alloc(&tx_pool, K_FOREVER);
+	buf = net_buf_alloc(&tx_pool, K_NO_WAIT);
 	if (buf == NULL) {
 		LOG_ERR("Could not allocate buffer");
 		k_work_reschedule(&chan_work->send_work, K_USEC(interval));

--- a/samples/bluetooth/tmap_bms/src/cap_initiator.c
+++ b/samples/bluetooth/tmap_bms/src/cap_initiator.c
@@ -52,6 +52,7 @@ struct bt_cap_initiator_broadcast_stream_param stream_params;
 struct bt_cap_initiator_broadcast_subgroup_param subgroup_param;
 struct bt_cap_initiator_broadcast_create_param create_param;
 struct bt_cap_broadcast_source *broadcast_source;
+static struct k_work_delayable audio_send_work;
 struct bt_le_ext_adv *ext_adv;
 
 static uint8_t tmap_addata[] = {
@@ -94,9 +95,12 @@ static void broadcast_sent_cb(struct bt_bap_stream *stream)
 		mock_data_initialized = true;
 	}
 
-	buf = net_buf_alloc(&tx_pool, K_FOREVER);
+	buf = net_buf_alloc(&tx_pool, K_NO_WAIT);
 	if (buf == NULL) {
 		printk("Could not allocate buffer when sending on %p\n", stream);
+
+		/* Retry next SDU interval */
+		k_work_schedule(&audio_send_work, K_USEC(broadcast_preset_48_2_1.qos.interval));
 		return;
 	}
 
@@ -104,10 +108,17 @@ static void broadcast_sent_cb(struct bt_bap_stream *stream)
 	net_buf_add_mem(buf, mock_data, broadcast_preset_48_2_1.qos.sdu);
 	ret = bt_bap_stream_send(stream, buf, seq_num++);
 	if (ret < 0) {
-		/* This will end broadcasting on this stream. */
 		net_buf_unref(buf);
+
+		/* Retry next SDU interval */
+		k_work_schedule(&audio_send_work, K_USEC(broadcast_preset_48_2_1.qos.interval));
 		return;
 	}
+}
+
+static void audio_timer_timeout(struct k_work *work)
+{
+	broadcast_sent_cb(&broadcast_stream->bap_stream);
 }
 
 static struct bt_bap_stream_ops broadcast_stream_ops = {
@@ -262,6 +273,7 @@ int cap_initiator_init(void)
 {
 	broadcast_stream = &broadcast_source_stream;
 	bt_bap_stream_cb_register(&broadcast_stream->bap_stream, &broadcast_stream_ops);
+	k_work_init_delayable(&audio_send_work, audio_timer_timeout);
 
 	return 0;
 }


### PR DESCRIPTION
Several samples used K_FOREVER when allocating buffers in the system workqueue thread, which is prohibited.

The samples should rather retry later if TX fails.

This is not the ideal solution for the samples, but fixes a bug. Ideally the samples would use a dedicated thread to handle TX, instead of the system workqueue.