### PR TITLE
samples: Align tests yaml and overlays to nrf54l15dk

### DIFF
--- a/samples/drivers/mbox/sample.yaml
+++ b/samples/drivers/mbox/sample.yaml
@@ -86,7 +86,6 @@ tests:
   sample.drivers.mbox.nrf54l15:
     platform_allow:
       - nrf54l15dk/nrf54l15/cpuapp
-      - nrf54l15pdk/nrf54l15/cpuapp
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp
     extra_args:
@@ -97,13 +96,12 @@ tests:
       type: multi_line
       ordered: false
       regex:
-        - "Ping \\(on channel 16\\)"
-        - "Pong \\(on channel 15\\)"
+        - "Ping \\(on channel 21\\)"
+        - "Pong \\(on channel 20\\)"
 
   sample.drivers.mbox.nrf54l15_no_multithreading:
     platform_allow:
       - nrf54l15dk/nrf54l15/cpuapp
-      - nrf54l15pdk/nrf54l15/cpuapp
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp
     extra_args:
@@ -116,13 +114,12 @@ tests:
       type: multi_line
       ordered: false
       regex:
-        - "Ping \\(on channel 16\\)"
-        - "Pong \\(on channel 15\\)"
+        - "Ping \\(on channel 21\\)"
+        - "Pong \\(on channel 20\\)"
 
   sample.drivers.mbox.nrf54l15_remote_no_multithreading:
     platform_allow:
       - nrf54l15dk/nrf54l15/cpuapp
-      - nrf54l15pdk/nrf54l15/cpuapp
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp
     extra_args:
@@ -134,5 +131,5 @@ tests:
       type: multi_line
       ordered: false
       regex:
-        - "Ping \\(on channel 16\\)"
-        - "Pong \\(on channel 15\\)"
+        - "Ping \\(on channel 21\\)"
+        - "Pong \\(on channel 20\\)"

--- a/samples/subsys/ipc/ipc_service/icmsg/boards/nrf54l15dk_nrf54l15_cpuapp_icbmsg.overlay
+++ b/samples/subsys/ipc/ipc_service/icmsg/boards/nrf54l15dk_nrf54l15_cpuapp_icbmsg.overlay
@@ -27,7 +27,7 @@
 			rx-region = <&sram_rx>;
 			tx-blocks = <16>;
 			rx-blocks = <18>;
-			mboxes = <&cpuapp_vevif_rx 15>, <&cpuapp_vevif_tx 16>;
+			mboxes = <&cpuapp_vevif_rx 20>, <&cpuapp_vevif_tx 21>;
 			mbox-names = "rx", "tx";
 			status = "okay";
 		};

--- a/samples/subsys/ipc/ipc_service/icmsg/remote/boards/nrf54l15dk_nrf54l15_cpuflpr.overlay
+++ b/samples/subsys/ipc/ipc_service/icmsg/remote/boards/nrf54l15dk_nrf54l15_cpuflpr.overlay
@@ -39,3 +39,7 @@
 &cpuflpr_vevif_tx {
 	status = "okay";
 };
+
+&uart30 {
+	/delete-property/ hw-flow-control;
+};

--- a/samples/subsys/ipc/ipc_service/icmsg/remote/boards/nrf54l15dk_nrf54l15_cpuflpr_icbmsg.overlay
+++ b/samples/subsys/ipc/ipc_service/icmsg/remote/boards/nrf54l15dk_nrf54l15_cpuflpr_icbmsg.overlay
@@ -27,7 +27,7 @@
 			rx-region = <&sram_rx>;
 			tx-blocks = <18>;
 			rx-blocks = <16>;
-			mboxes = <&cpuflpr_vevif_rx 16>, <&cpuflpr_vevif_tx 15>;
+			mboxes = <&cpuflpr_vevif_rx 21>, <&cpuflpr_vevif_tx 20>;
 			mbox-names = "rx", "tx";
 			status = "okay";
 		};

--- a/samples/subsys/ipc/ipc_service/icmsg/remote/boards/nrf54l15pdk_nrf54l15_cpuflpr.overlay
+++ b/samples/subsys/ipc/ipc_service/icmsg/remote/boards/nrf54l15pdk_nrf54l15_cpuflpr.overlay
@@ -39,3 +39,7 @@
 &cpuflpr_vevif_tx {
 	status = "okay";
 };
+
+&uart30 {
+	/delete-property/ hw-flow-control;
+};

--- a/samples/subsys/ipc/ipc_service/icmsg/sample.yaml
+++ b/samples/subsys/ipc/ipc_service/icmsg/sample.yaml
@@ -23,7 +23,7 @@ tests:
         - "host: IPC-service HOST demo ended"
 
   sample.ipc.icmsg.nrf54l15:
-    platform_allow: nrf54l15dk/nrf54l15/cpuapp nrf54l15pdk/nrf54l15/cpuapp
+    platform_allow: nrf54l15dk/nrf54l15/cpuapp
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp
     tags: ipc
@@ -43,7 +43,7 @@ tests:
         - "host: IPC-service HOST demo ended"
 
   sample.ipc.icmsg.nrf54l15_no_multithreading:
-    platform_allow: nrf54l15dk/nrf54l15/cpuapp nrf54l15pdk/nrf54l15/cpuapp
+    platform_allow: nrf54l15dk/nrf54l15/cpuapp
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp
     tags: ipc
@@ -67,7 +67,7 @@ tests:
         - "I: IPC-service HOST demo ended"
 
   sample.ipc.icmsg.nrf54l15_remote_no_multithreading:
-    platform_allow: nrf54l15dk/nrf54l15/cpuapp nrf54l15pdk/nrf54l15/cpuapp
+    platform_allow: nrf54l15dk/nrf54l15/cpuapp
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp
     tags: ipc
@@ -89,16 +89,16 @@ tests:
         - "host: IPC-service HOST demo ended"
 
   sample.ipc.icbmsg.nrf54l15:
-    platform_allow: nrf54l15pdk/nrf54l15/cpuapp
+    platform_allow: nrf54l15dk/nrf54l15/cpuapp
     integration_platforms:
-      - nrf54l15pdk/nrf54l15/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp
     tags: ipc
     extra_args:
       icmsg_SNIPPET=nordic-flpr
       icmsg_CONFIG_IPC_SERVICE_BACKEND_ICBMSG_NUM_EP=1
-      icmsg_DTC_OVERLAY_FILE="boards/nrf54l15pdk_nrf54l15_cpuapp_icbmsg.overlay"
+      icmsg_DTC_OVERLAY_FILE="boards/nrf54l15dk_nrf54l15_cpuapp_icbmsg.overlay"
       remote_CONFIG_IPC_SERVICE_BACKEND_ICBMSG_NUM_EP=1
-      remote_DTC_OVERLAY_FILE="boards/nrf54l15pdk_nrf54l15_cpuflpr_icbmsg.overlay"
+      remote_DTC_OVERLAY_FILE="boards/nrf54l15dk_nrf54l15_cpuflpr_icbmsg.overlay"
     sysbuild: true
     harness: console
     harness_config:
@@ -113,18 +113,18 @@ tests:
         - "host: IPC-service HOST demo ended"
 
   sample.ipc.icbmsg.nrf54l15_no_multithreading:
-    platform_allow: nrf54l15pdk/nrf54l15/cpuapp
+    platform_allow: nrf54l15dk/nrf54l15/cpuapp
     integration_platforms:
-      - nrf54l15pdk/nrf54l15/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp
     tags: ipc
     extra_args:
       icmsg_SNIPPET=nordic-flpr
       icmsg_CONFIG_IPC_SERVICE_BACKEND_ICBMSG_NUM_EP=1
-      icmsg_DTC_OVERLAY_FILE="boards/nrf54l15pdk_nrf54l15_cpuapp_icbmsg.overlay"
+      icmsg_DTC_OVERLAY_FILE="boards/nrf54l15dk_nrf54l15_cpuapp_icbmsg.overlay"
       icmsg_CONFIG_MULTITHREADING=n
       icmsg_CONFIG_LOG_MODE_MINIMAL=y
       remote_CONFIG_IPC_SERVICE_BACKEND_ICBMSG_NUM_EP=1
-      remote_DTC_OVERLAY_FILE="boards/nrf54l15pdk_nrf54l15_cpuflpr_icbmsg.overlay"
+      remote_DTC_OVERLAY_FILE="boards/nrf54l15dk_nrf54l15_cpuflpr_icbmsg.overlay"
       remote_CONFIG_MULTITHREADING=n
       remote_CONFIG_LOG_MODE_MINIMAL=y
     sysbuild: true
@@ -141,16 +141,16 @@ tests:
         - "host: IPC-service HOST demo ended"
 
   sample.ipc.icbmsg.nrf54l15_remote_no_multithreading:
-    platform_allow: nrf54l15pdk/nrf54l15/cpuapp
+    platform_allow: nrf54l15dk/nrf54l15/cpuapp
     integration_platforms:
-      - nrf54l15pdk/nrf54l15/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp
     tags: ipc
     extra_args:
       icmsg_SNIPPET=nordic-flpr
       icmsg_CONFIG_IPC_SERVICE_BACKEND_ICBMSG_NUM_EP=1
-      icmsg_DTC_OVERLAY_FILE="boards/nrf54l15pdk_nrf54l15_cpuapp_icbmsg.overlay"
+      icmsg_DTC_OVERLAY_FILE="boards/nrf54l15dk_nrf54l15_cpuapp_icbmsg.overlay"
       remote_CONFIG_IPC_SERVICE_BACKEND_ICBMSG_NUM_EP=1
-      remote_DTC_OVERLAY_FILE="boards/nrf54l15pdk_nrf54l15_cpuflpr_icbmsg.overlay"
+      remote_DTC_OVERLAY_FILE="boards/nrf54l15dk_nrf54l15_cpuflpr_icbmsg.overlay"
       remote_CONFIG_MULTITHREADING=n
       remote_CONFIG_LOG_MODE_MINIMAL=y
     sysbuild: true


### PR DESCRIPTION
Align mbox sample.yaml and icmsg flpr overlays to nrf54l15dk.