### PR TITLE
boards: nordic: nrf7002dk: re-enable external flash by default

### DIFF
--- a/boards/nordic/nrf7002dk/nrf5340_cpuapp_common.dtsi
+++ b/boards/nordic/nrf7002dk/nrf5340_cpuapp_common.dtsi
@@ -173,7 +173,6 @@ arduino_i2c: &i2c1 {
 	cs-gpios = <&gpio0 11 GPIO_ACTIVE_LOW>;
 	mx25r64: mx25r6435f@0 {
 		compatible = "jedec,spi-nor";
-		status = "disabled";
 		reg = <0>;
 		spi-max-frequency = <33000000>;
 		jedec-id = [c2 28 17];


### PR DESCRIPTION
The external flash (mx25r64) was accidentally disabled during testing. The node should be enabled by default like its spi.

This commit removes the `status = "disabled";`