### PR TITLE
Feature/imx95 rimage support

### DIFF
--- a/boards/nxp/imx95_evk/CMakeLists.txt
+++ b/boards/nxp/imx95_evk/CMakeLists.txt
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+
+if (CONFIG_SOF AND CONFIG_BOARD_IMX95_EVK_MIMX9596_M7_DDR)
+  add_custom_target(zephyr.ri ALL
+    DEPENDS ${CMAKE_BINARY_DIR}/zephyr/zephyr.ri
+  )
+
+  add_custom_command(
+    OUTPUT ${CMAKE_BINARY_DIR}/zephyr/zephyr.ri
+    COMMAND west sign --if-tool-available --tool rimage --build-dir ${CMAKE_BINARY_DIR} ${WEST_SIGN_OPTS}
+    DEPENDS ${CMAKE_BINARY_DIR}/zephyr/${KERNEL_ELF_NAME}
+  )
+endif()

--- a/boards/nxp/imx95_evk/board.cmake
+++ b/boards/nxp/imx95_evk/board.cmake
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
+if (CONFIG_SOF AND CONFIG_BOARD_IMX95_EVK_MIMX9596_M7_DDR)
+  board_set_rimage_target(imx95)
+endif()

--- a/scripts/west_commands/sign.py
+++ b/scripts/west_commands/sign.py
@@ -485,7 +485,7 @@ class RimageSigner(Signer):
         kernel_name = build_conf.get('CONFIG_KERNEL_BIN_NAME', 'zephyr')
 
         # TODO: make this a new sign.py --bootloader option.
-        if target in ('imx8', 'imx8m', 'imx8ulp'):
+        if target in ('imx8', 'imx8m', 'imx8ulp', 'imx95'):
             bootloader = None
             kernel = str(b / 'zephyr' / f'{kernel_name}.elf')
             out_bin = str(b / 'zephyr' / f'{kernel_name}.ri')


### PR DESCRIPTION
Add support for signing imx95 (M7, DDR variant only as this will be the only board used by SOF) images using rimage. This is needed for SOF.