### PR TITLE
Bluetooth: Mesh: Add prefix to Subnet Bridge API

### DIFF
--- a/doc/connectivity/bluetooth/api/mesh/brg_cfg.rst
+++ b/doc/connectivity/bluetooth/api/mesh/brg_cfg.rst
@@ -69,15 +69,15 @@ Enabling or disabling the Subnet Bridge feature
 
 The Bridge Configuration Client (or Configuration Manager) can enable or disable the Subnet Bridge
 feature on a node by sending a **Subnet Bridge Set** message to the Bridge Configuration
-Server model on the target node, using the :c:func:`bt_mesh_brg_cfg_cli_subnet_bridge_set` function.
+Server model on the target node, using the :c:func:`bt_mesh_brg_cfg_cli_set` function.
 
 Adding or removing subnets
 **************************
 
 The Bridge Configuration Client can add or remove an entry from the Bridging Table by sending a
 **Bridging Table Add** or **Bridging Table Remove** message to the Bridge Configuration
-Server model on the target node, calling the :c:func:`bt_mesh_brg_cfg_cli_bridging_table_add` or
-:c:func:`bt_mesh_brg_cfg_cli_bridging_table_remove` functions.
+Server model on the target node, calling the :c:func:`bt_mesh_brg_cfg_cli_table_add` or
+:c:func:`bt_mesh_brg_cfg_cli_table_remove` functions.
 
 .. _bluetooth_mesh_brg_cfg_states:
 
@@ -89,20 +89,19 @@ The Subnet Bridge has the following states:
 - *Subnet Bridge*: This state indicates whether the Subnet Bridge feature is enabled or disabled on
   the node.
   The Bridge Configuration Client can retrieve this information by sending a **Subnet Bridge Get**
-  message to the Bridge Configuration Server using the
-  :c:func:`bt_mesh_brg_cfg_cli_subnet_bridge_get` function.
+  message to the Bridge Configuration Server using the :c:func:`bt_mesh_brg_cfg_cli_get` function.
 
 - *Bridging Table*: This state holds the bridging table. The Client can request a list of
   entries from a Bridging Table by sending a **Bridging Table Get** message to the target node using
-  the :c:func:`bt_mesh_brg_cfg_cli_bridging_table_get` function.
+  the :c:func:`bt_mesh_brg_cfg_cli_table_get` function.
 
   The Client can get a list of subnets currently bridged by a Subnet Bridge by sending a
   **Bridged Subnets Get** message to the target Server by calling the
-  :c:func:`bt_mesh_brg_cfg_cli_bridged_subnets_get` function.
+  :c:func:`bt_mesh_brg_cfg_cli_subnets_get` function.
 
 - *Bridging Table Size*: This state reports the maximum number of entries the Bridging Table can
   store. The Client can retrieve this information by sending a **Bridging Table Size Get** message
-  using the :c:func:`bt_mesh_brg_cfg_cli_bridging_table_size_get` function.
+  using the :c:func:`bt_mesh_brg_cfg_cli_table_size_get` function.
   This is a read-only state.
 
 Subnet bridging and replay protection

--- a/include/zephyr/bluetooth/mesh/brg_cfg.h
+++ b/include/zephyr/bluetooth/mesh/brg_cfg.h
@@ -21,20 +21,20 @@ extern "C" {
  */
 
 /** Subnet Bridge states */
-enum bt_mesh_subnet_bridge_state {
+enum bt_mesh_brg_cfg_state {
 	/** Subnet bridge functionality is disabled. */
-	BT_MESH_SUBNET_BRIDGE_DISABLED,
+	BT_MESH_BRG_CFG_DISABLED,
 	/** Subnet bridge state functionality is enabled. */
-	BT_MESH_SUBNET_BRIDGE_ENABLED,
+	BT_MESH_BRG_CFG_ENABLED,
 };
 
 /* Briding from Addr1 to Addr2. */
-#define BT_MESH_SUBNET_BRIDGE_DIR_ONEWAY 1
+#define BT_MESH_BRG_CFG_DIR_ONEWAY 1
 /* Bidirectional briging between Addr1 and Addr2. */
-#define BT_MESH_SUBNET_BRIDGE_DIR_TWOWAY 2
+#define BT_MESH_BRG_CFG_DIR_TWOWAY 2
 
 /** Bridging Table state entry corresponding to a entry in the Bridging Table. */
-struct bt_mesh_bridging_table_entry {
+struct bt_mesh_brg_cfg_table_entry {
 	/** Allowed directions for the bridged traffic (or bridged traffic not allowed) */
 	uint8_t directions;
 	/** NetKey Index of the first subnet */
@@ -48,24 +48,24 @@ struct bt_mesh_bridging_table_entry {
 };
 
 /** Bridging Table Status response */
-struct bt_mesh_bridging_table_status {
+struct bt_mesh_brg_cfg_table_status {
 	/** Status Code of the requesting message */
 	uint8_t status;
 	/** Requested Bridging Table entry */
-	struct bt_mesh_bridging_table_entry entry;
+	struct bt_mesh_brg_cfg_table_entry entry;
 };
 
 /** Used to filter set of pairs of NetKey Indexes from the Bridging Table */
-struct bt_mesh_filter_netkey {
+struct bt_mesh_brg_cfg_filter_netkey {
 	uint16_t filter: 2,    /* Filter applied to the set of pairs of NetKey Indexes */
 		prohibited: 2, /* Prohibited */
 		net_idx: 12;   /* NetKey Index used for filtering or ignored */
 };
 
 /** Bridged Subnets List response */
-struct bt_mesh_bridged_subnets_list {
+struct bt_mesh_brg_cfg_subnets_list {
 	/** Filter applied NetKey Indexes, and NetKey Index used for filtering. */
-	struct bt_mesh_filter_netkey net_idx_filter;
+	struct bt_mesh_brg_cfg_filter_netkey net_idx_filter;
 	/** Start offset in units of bridges */
 	uint8_t start_idx;
 	/** Pointer to allocated buffer for storing filtered of NetKey Indexes */
@@ -73,7 +73,7 @@ struct bt_mesh_bridged_subnets_list {
 };
 
 /** Bridging Table List response */
-struct bt_mesh_bridging_table_list {
+struct bt_mesh_brg_cfg_table_list {
 	/** Status Code of the requesting message */
 	uint8_t status;
 	/** NetKey Index of the first subnet */

--- a/include/zephyr/bluetooth/mesh/brg_cfg.h
+++ b/include/zephyr/bluetooth/mesh/brg_cfg.h
@@ -28,9 +28,9 @@ enum bt_mesh_brg_cfg_state {
 	BT_MESH_BRG_CFG_ENABLED,
 };
 
-/* Briding from Addr1 to Addr2. */
+/* Bridging from Addr1 to Addr2. */
 #define BT_MESH_BRG_CFG_DIR_ONEWAY 1
-/* Bidirectional briging between Addr1 and Addr2. */
+/* Bidirectional bridging between Addr1 and Addr2. */
 #define BT_MESH_BRG_CFG_DIR_TWOWAY 2
 
 /** Bridging Table state entry corresponding to a entry in the Bridging Table. */

--- a/include/zephyr/bluetooth/mesh/brg_cfg_cli.h
+++ b/include/zephyr/bluetooth/mesh/brg_cfg_cli.h
@@ -42,8 +42,8 @@ struct bt_mesh_brg_cfg_cli_cb {
 	 *  @param addr     Address of the sender.
 	 *  @param status   Status received from the server.
 	 */
-	void (*subnet_bridge_status)(struct bt_mesh_brg_cfg_cli *cli, uint16_t addr,
-				     enum bt_mesh_subnet_bridge_state status);
+	void (*bridge_status)(struct bt_mesh_brg_cfg_cli *cli, uint16_t addr,
+			      enum bt_mesh_brg_cfg_state status);
 
 	/** @brief Optional callback for Bridging Table Size Status message.
 	 *
@@ -54,8 +54,7 @@ struct bt_mesh_brg_cfg_cli_cb {
 	 *  @param addr     Address of the sender.
 	 *  @param size     Size received from the server.
 	 */
-	void (*bridging_table_size_status)(struct bt_mesh_brg_cfg_cli *cli, uint16_t addr,
-					   uint16_t size);
+	void (*table_size_status)(struct bt_mesh_brg_cfg_cli *cli, uint16_t addr, uint16_t size);
 
 	/** @brief Optional callback for Bridging Table Status message.
 	 *
@@ -66,8 +65,8 @@ struct bt_mesh_brg_cfg_cli_cb {
 	 *  @param addr     Address of the sender.
 	 *  @param rsp      Response received from the Bridging Configuration Server.
 	 */
-	void (*bridging_table_status)(struct bt_mesh_brg_cfg_cli *cli, uint16_t addr,
-				      struct bt_mesh_bridging_table_status *rsp);
+	void (*table_status)(struct bt_mesh_brg_cfg_cli *cli, uint16_t addr,
+			     struct bt_mesh_brg_cfg_table_status *rsp);
 
 	/** @brief Optional callback for Bridged Subnets List message.
 	 *
@@ -78,8 +77,8 @@ struct bt_mesh_brg_cfg_cli_cb {
 	 *  @param addr     Address of the sender.
 	 *  @param rsp      Response received from the Bridging Configuration Server.
 	 */
-	void (*bridged_subnets_list)(struct bt_mesh_brg_cfg_cli *cli, uint16_t addr,
-				     struct bt_mesh_bridged_subnets_list *rsp);
+	void (*subnets_list)(struct bt_mesh_brg_cfg_cli *cli, uint16_t addr,
+			     struct bt_mesh_brg_cfg_subnets_list *rsp);
 
 	/** @brief Optional callback for Bridging Table List message.
 	 *
@@ -90,8 +89,8 @@ struct bt_mesh_brg_cfg_cli_cb {
 	 *  @param addr     Address of the sender.
 	 *  @param rsp      Response received from the Bridging Configuration Server.
 	 */
-	void (*bridging_table_list)(struct bt_mesh_brg_cfg_cli *cli, uint16_t addr,
-				    struct bt_mesh_bridging_table_list *rsp);
+	void (*table_list)(struct bt_mesh_brg_cfg_cli *cli, uint16_t addr,
+			   struct bt_mesh_brg_cfg_table_list *rsp);
 };
 
 /** Bridge Configuration Client Model Context */
@@ -121,13 +120,12 @@ struct bt_mesh_brg_cfg_cli {
  *  @param net_idx Network index to encrypt the message with.
  *  @param addr    Target node address.
  *  @param status  Status response parameter, returns one of
- *                 @ref BT_MESH_SUBNET_BRIDGE_DISABLED or
- *                 @ref BT_MESH_SUBNET_BRIDGE_ENABLED on success.
+ *                 @ref BT_MESH_BRG_CFG_DISABLED or
+ *                 @ref BT_MESH_BRG_CFG_ENABLED on success.
  *
  *  @return 0 on success, or (negative) error code on failure.
  */
-int bt_mesh_brg_cfg_cli_subnet_bridge_get(uint16_t net_idx, uint16_t addr,
-					  enum bt_mesh_subnet_bridge_state *status);
+int bt_mesh_brg_cfg_cli_get(uint16_t net_idx, uint16_t addr, enum bt_mesh_brg_cfg_state *status);
 
 /** @brief Sends a Subnet Bridge Set message to the given destination address
  *  with the given parameters
@@ -145,17 +143,16 @@ int bt_mesh_brg_cfg_cli_subnet_bridge_get(uint16_t net_idx, uint16_t addr,
  *  @param net_idx Network index to encrypt the message with.
  *  @param addr    Target node address.
  *  @param val     Value to set the Subnet Bridge state to. Must be one of
- *                 @ref BT_MESH_SUBNET_BRIDGE_DISABLED or
- *                 @ref BT_MESH_SUBNET_BRIDGE_ENABLED.
+ *                 @ref BT_MESH_BRG_CFG_DISABLED or
+ *                 @ref BT_MESH_BRG_CFG_ENABLED.
  *  @param status  Status response parameter, returns one of
- *                 @ref BT_MESH_SUBNET_BRIDGE_DISABLED or
- *                 @ref BT_MESH_SUBNET_BRIDGE_ENABLED on success.
+ *                 @ref BT_MESH_BRG_CFG_DISABLED or
+ *                 @ref BT_MESH_BRG_CFG_ENABLED on success.
  *
  *  @return 0 on success, or (negative) error code on failure.
  */
-int bt_mesh_brg_cfg_cli_subnet_bridge_set(uint16_t net_idx, uint16_t addr,
-					  enum bt_mesh_subnet_bridge_state val,
-					  enum bt_mesh_subnet_bridge_state *status);
+int bt_mesh_brg_cfg_cli_set(uint16_t net_idx, uint16_t addr, enum bt_mesh_brg_cfg_state val,
+			    enum bt_mesh_brg_cfg_state *status);
 
 /** @brief Sends a Bridging Table Size Get message to the given destination
  *  address with the given parameters
@@ -176,7 +173,7 @@ int bt_mesh_brg_cfg_cli_subnet_bridge_set(uint16_t net_idx, uint16_t addr,
  *
  *  @return 0 on success, or (negative) error code on failure.
  */
-int bt_mesh_brg_cfg_cli_bridging_table_size_get(uint16_t net_idx, uint16_t addr, uint16_t *size);
+int bt_mesh_brg_cfg_cli_table_size_get(uint16_t net_idx, uint16_t addr, uint16_t *size);
 
 /** @brief Sends a Bridging Table Add message to the given destination address
  *  with the given parameters
@@ -198,9 +195,9 @@ int bt_mesh_brg_cfg_cli_bridging_table_size_get(uint16_t net_idx, uint16_t addr,
  *
  *  @return 0 on success, or (negative) error code on failure.
  */
-int bt_mesh_brg_cfg_cli_bridging_table_add(uint16_t net_idx, uint16_t addr,
-					   struct bt_mesh_bridging_table_entry *entry,
-					   struct bt_mesh_bridging_table_status *rsp);
+int bt_mesh_brg_cfg_cli_table_add(uint16_t net_idx, uint16_t addr,
+				  struct bt_mesh_brg_cfg_table_entry *entry,
+				  struct bt_mesh_brg_cfg_table_status *rsp);
 
 /** @brief Sends a Bridging Table Remove message to the given destination
  *  address with the given parameters
@@ -226,9 +223,9 @@ int bt_mesh_brg_cfg_cli_bridging_table_add(uint16_t net_idx, uint16_t addr,
  *
  *  @return 0 on success, or (negative) error code on failure.
  */
-int bt_mesh_brg_cfg_cli_bridging_table_remove(uint16_t net_idx, uint16_t addr, uint16_t net_idx1,
-					      uint16_t net_idx2, uint16_t addr1, uint16_t addr2,
-					      struct bt_mesh_bridging_table_status *rsp);
+int bt_mesh_brg_cfg_cli_table_remove(uint16_t net_idx, uint16_t addr, uint16_t net_idx1,
+				     uint16_t net_idx2, uint16_t addr1, uint16_t addr2,
+				     struct bt_mesh_brg_cfg_table_status *rsp);
 
 /** @brief Sends a Bridged Subnets Get message to the given destination address
  *  with the given parameters
@@ -244,7 +241,7 @@ int bt_mesh_brg_cfg_cli_bridging_table_remove(uint16_t net_idx, uint16_t addr, u
  *
  *  When @c rsp is set, the user is responsible for providing a buffer for the
  *  filtered set of N pairs of NetKey Indexes in
- *  @ref bt_mesh_bridged_subnets_list::list. If a buffer is not provided, the
+ *  @ref bt_mesh_brg_cfg_subnets_list::list. If a buffer is not provided, the
  *  bridged subnets won't be copied.
 
  *  @param net_idx          Network index to encrypt the message with.
@@ -256,10 +253,9 @@ int bt_mesh_brg_cfg_cli_bridging_table_remove(uint16_t net_idx, uint16_t addr, u
  *
  *  @return 0 on success, or (negative) error code on failure.
  */
-int bt_mesh_brg_cfg_cli_bridged_subnets_get(uint16_t net_idx, uint16_t addr,
-					    struct bt_mesh_filter_netkey filter_net_idx,
-					    uint8_t start_idx,
-					    struct bt_mesh_bridged_subnets_list *rsp);
+int bt_mesh_brg_cfg_cli_subnets_get(uint16_t net_idx, uint16_t addr,
+				    struct bt_mesh_brg_cfg_filter_netkey filter_net_idx,
+				    uint8_t start_idx, struct bt_mesh_brg_cfg_subnets_list *rsp);
 
 /** @brief Sends a Bridging Table Get message to the given destination address
  *  with the given parameters
@@ -276,10 +272,10 @@ int bt_mesh_brg_cfg_cli_bridged_subnets_get(uint16_t net_idx, uint16_t addr,
  *
  *  When @c rsp is set, the user is responsible for providing a buffer for the
  *   filtered set of N pairs of NetKey Indexes in
- *  @ref bt_mesh_bridging_table_list::list. If a buffer is not provided, the
- *  bridged addresses won't be copied. If a buffer size is shorter than received
- *  list, only those many entries that fit in the buffer will be copied from the
- *  list, and rest will be discarded.
+ *  @ref bt_mesh_brg_cfg_table_list::list. If a buffer is not provided,
+ *  the bridged addresses won't be copied. If a buffer size is shorter than
+ *  received list, only those many entries that fit in the buffer will be copied
+ *  from the list, and rest will be discarded.
  *
  *  @param net_idx   Network index to encrypt the message with.
  *  @param addr      Target node address.
@@ -291,9 +287,9 @@ int bt_mesh_brg_cfg_cli_bridged_subnets_get(uint16_t net_idx, uint16_t addr,
  *
  *  @return 0 on success, or (negative) error code on failure.
  */
-int bt_mesh_brg_cfg_cli_bridging_table_get(uint16_t net_idx, uint16_t addr, uint16_t net_idx1,
-					   uint16_t net_idx2, uint16_t start_idx,
-					   struct bt_mesh_bridging_table_list *rsp);
+int bt_mesh_brg_cfg_cli_table_get(uint16_t net_idx, uint16_t addr, uint16_t net_idx1,
+				  uint16_t net_idx2, uint16_t start_idx,
+				  struct bt_mesh_brg_cfg_table_list *rsp);
 
 /** @brief Get the current transmission timeout value.
  *

--- a/subsys/bluetooth/mesh/brg_cfg.c
+++ b/subsys/bluetooth/mesh/brg_cfg.c
@@ -224,8 +224,8 @@ static bool netkey_check(uint16_t net_idx1, uint16_t net_idx2)
 	return bt_mesh_subnet_get(net_idx1) && bt_mesh_subnet_get(net_idx2);
 }
 
-int bt_mesh_brg_cfg_tbl_add(enum bt_mesh_brg_cfg_dir direction, uint16_t net_idx1,
-			    uint16_t net_idx2, uint16_t addr1, uint16_t addr2, uint8_t *status)
+int bt_mesh_brg_cfg_tbl_add(uint8_t direction, uint16_t net_idx1, uint16_t net_idx2, uint16_t addr1,
+			    uint16_t addr2, uint8_t *status)
 {
 	/* Sanity checks */
 	if (!BT_MESH_ADDR_IS_UNICAST(addr1) || net_idx1 == net_idx2 || addr1 == addr2 ||

--- a/subsys/bluetooth/mesh/brg_cfg.h
+++ b/subsys/bluetooth/mesh/brg_cfg.h
@@ -13,17 +13,6 @@
 
 #define BT_MESH_BRG_CFG_NKEY_PRHB_FLT_MASK 0x000C
 
-enum bt_mesh_brg_cfg_dir {
-	/* Value is prohibited. */
-	BT_MESH_BRG_CFG_DIR_PROHIBITED = 0,
-	/* Briging from Addr1 to Addr2. */
-	BT_MESH_BRG_CFG_DIR_ONEWAY = 1,
-	/* Briging to/from Addr1 from/to Addr2. */
-	BT_MESH_BRG_CFG_DIR_TWOWAY = 2,
-	/* Values above these are prohibited. */
-	BT_MESH_BRG_CFG_DIR_MAX = 3,
-};
-
 #define BT_MESH_BRG_CFG_NETIDX_NOMATCH 0xFFFF
 
 /* One row of the bridging table */
@@ -50,8 +39,8 @@ int bt_mesh_brg_cfg_tbl_reset(void);
 
 int bt_mesh_brg_cfg_tbl_get(const struct bt_mesh_brg_cfg_row **rows);
 
-int bt_mesh_brg_cfg_tbl_add(enum bt_mesh_brg_cfg_dir direction, uint16_t net_idx1,
-			    uint16_t net_idx2, uint16_t addr1, uint16_t addr2, uint8_t *status);
+int bt_mesh_brg_cfg_tbl_add(uint8_t direction, uint16_t net_idx1, uint16_t net_idx2, uint16_t addr1,
+			    uint16_t addr2, uint8_t *status);
 
 int bt_mesh_brg_cfg_tbl_remove(uint16_t net_idx1, uint16_t net_idx2, uint16_t addr1, uint16_t addr2,
 			       uint8_t *status);

--- a/subsys/bluetooth/mesh/brg_cfg_cli.c
+++ b/subsys/bluetooth/mesh/brg_cfg_cli.c
@@ -17,12 +17,11 @@ static int32_t msg_timeout;
 
 static struct bt_mesh_brg_cfg_cli *cli;
 
-static int subnet_bridge_status(const struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
-				struct net_buf_simple *buf)
+static int bridge_status(const struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+			 struct net_buf_simple *buf)
 {
-	enum bt_mesh_subnet_bridge_state status =
-		(enum bt_mesh_subnet_bridge_state)net_buf_simple_pull_u8(buf);
-	enum bt_mesh_subnet_bridge_state *rsp;
+	enum bt_mesh_brg_cfg_state status = (enum bt_mesh_brg_cfg_state)net_buf_simple_pull_u8(buf);
+	enum bt_mesh_brg_cfg_state *rsp;
 
 	if (bt_mesh_msg_ack_ctx_match(&cli->ack_ctx, OP_SUBNET_BRIDGE_STATUS, ctx->addr,
 				      (void **)&rsp)) {
@@ -30,17 +29,17 @@ static int subnet_bridge_status(const struct bt_mesh_model *model, struct bt_mes
 		bt_mesh_msg_ack_ctx_rx(&cli->ack_ctx);
 	}
 
-	if (cli->cb && cli->cb->subnet_bridge_status) {
-		cli->cb->subnet_bridge_status(cli, ctx->addr, status);
+	if (cli->cb && cli->cb->bridge_status) {
+		cli->cb->bridge_status(cli, ctx->addr, status);
 	}
 	return 0;
 }
 
-static int bridging_table_status(const struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
-				 struct net_buf_simple *buf)
+static int table_status(const struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+			struct net_buf_simple *buf)
 {
-	struct bt_mesh_bridging_table_status table_status;
-	struct bt_mesh_bridging_table_status *rsp;
+	struct bt_mesh_brg_cfg_table_status table_status;
+	struct bt_mesh_brg_cfg_table_status *rsp;
 
 	table_status.status = net_buf_simple_pull_u8(buf);
 	table_status.entry.directions = net_buf_simple_pull_u8(buf);
@@ -63,17 +62,17 @@ static int bridging_table_status(const struct bt_mesh_model *model, struct bt_me
 		bt_mesh_msg_ack_ctx_rx(&cli->ack_ctx);
 	}
 
-	if (cli->cb && cli->cb->bridging_table_status) {
-		cli->cb->bridging_table_status(cli, ctx->addr, &table_status);
+	if (cli->cb && cli->cb->table_status) {
+		cli->cb->table_status(cli, ctx->addr, &table_status);
 	}
 	return 0;
 }
 
-static int bridged_subnets_list(const struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
-				struct net_buf_simple *buf)
+static int subnets_list(const struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+			struct net_buf_simple *buf)
 {
-	struct bt_mesh_bridged_subnets_list subnets_list;
-	struct bt_mesh_bridged_subnets_list *rsp;
+	struct bt_mesh_brg_cfg_subnets_list subnets_list;
+	struct bt_mesh_brg_cfg_subnets_list *rsp;
 	uint16_t net_idx_filter;
 
 	net_idx_filter = net_buf_simple_pull_le16(buf);
@@ -102,17 +101,17 @@ static int bridged_subnets_list(const struct bt_mesh_model *model, struct bt_mes
 		bt_mesh_msg_ack_ctx_rx(&cli->ack_ctx);
 	}
 
-	if (cli->cb && cli->cb->bridged_subnets_list) {
-		cli->cb->bridged_subnets_list(cli, ctx->addr, &subnets_list);
+	if (cli->cb && cli->cb->subnets_list) {
+		cli->cb->subnets_list(cli, ctx->addr, &subnets_list);
 	}
 	return 0;
 }
 
-static int bridging_table_list(const struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
-			       struct net_buf_simple *buf)
+static int table_list(const struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+		      struct net_buf_simple *buf)
 {
-	struct bt_mesh_bridging_table_list table_list;
-	struct bt_mesh_bridging_table_list *rsp;
+	struct bt_mesh_brg_cfg_table_list table_list;
+	struct bt_mesh_brg_cfg_table_list *rsp;
 
 	table_list.status = net_buf_simple_pull_u8(buf);
 	key_idx_unpack_pair(buf, &table_list.net_idx1, &table_list.net_idx2);
@@ -141,14 +140,14 @@ static int bridging_table_list(const struct bt_mesh_model *model, struct bt_mesh
 		bt_mesh_msg_ack_ctx_rx(&cli->ack_ctx);
 	}
 
-	if (cli->cb && cli->cb->bridging_table_list) {
-		cli->cb->bridging_table_list(cli, ctx->addr, &table_list);
+	if (cli->cb && cli->cb->table_list) {
+		cli->cb->table_list(cli, ctx->addr, &table_list);
 	}
 	return 0;
 }
 
-static int bridging_table_size_status(const struct bt_mesh_model *model,
-				      struct bt_mesh_msg_ctx *ctx, struct net_buf_simple *buf)
+static int table_size_status(const struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+			     struct net_buf_simple *buf)
 {
 	uint16_t size = net_buf_simple_pull_le16(buf);
 	uint16_t *rsp;
@@ -159,18 +158,18 @@ static int bridging_table_size_status(const struct bt_mesh_model *model,
 		bt_mesh_msg_ack_ctx_rx(&cli->ack_ctx);
 	}
 
-	if (cli->cb && cli->cb->bridging_table_size_status) {
-		cli->cb->bridging_table_size_status(cli, ctx->addr, size);
+	if (cli->cb && cli->cb->table_size_status) {
+		cli->cb->table_size_status(cli, ctx->addr, size);
 	}
 	return 0;
 }
 
 const struct bt_mesh_model_op _bt_mesh_brg_cfg_cli_op[] = {
-	{OP_SUBNET_BRIDGE_STATUS, BT_MESH_LEN_EXACT(1), subnet_bridge_status},
-	{OP_BRIDGING_TABLE_STATUS, BT_MESH_LEN_EXACT(9), bridging_table_status},
-	{OP_BRIDGED_SUBNETS_LIST, BT_MESH_LEN_MIN(3), bridged_subnets_list},
-	{OP_BRIDGING_TABLE_LIST, BT_MESH_LEN_MIN(6), bridging_table_list},
-	{OP_BRIDGING_TABLE_SIZE_STATUS, BT_MESH_LEN_EXACT(2), bridging_table_size_status},
+	{OP_SUBNET_BRIDGE_STATUS, BT_MESH_LEN_EXACT(1), bridge_status},
+	{OP_BRIDGING_TABLE_STATUS, BT_MESH_LEN_EXACT(9), table_status},
+	{OP_BRIDGED_SUBNETS_LIST, BT_MESH_LEN_MIN(3), subnets_list},
+	{OP_BRIDGING_TABLE_LIST, BT_MESH_LEN_MIN(6), table_list},
+	{OP_BRIDGING_TABLE_SIZE_STATUS, BT_MESH_LEN_EXACT(2), table_size_status},
 	BT_MESH_MODEL_OP_END,
 };
 
@@ -202,8 +201,7 @@ const struct bt_mesh_model_cb _bt_mesh_brg_cfg_cli_cb = {
 	.init = brg_cfg_cli_init,
 };
 
-int bt_mesh_brg_cfg_cli_subnet_bridge_get(uint16_t net_idx, uint16_t addr,
-					  enum bt_mesh_subnet_bridge_state *status)
+int bt_mesh_brg_cfg_cli_get(uint16_t net_idx, uint16_t addr, enum bt_mesh_brg_cfg_state *status)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_SUBNET_BRIDGE_GET, 0);
 	struct bt_mesh_msg_ctx ctx = BT_MESH_MSG_CTX_INIT_DEV(net_idx, addr);
@@ -219,9 +217,8 @@ int bt_mesh_brg_cfg_cli_subnet_bridge_get(uint16_t net_idx, uint16_t addr,
 	return bt_mesh_msg_ackd_send(cli->model, &ctx, &msg, !status ? NULL : &rsp_ctx);
 }
 
-int bt_mesh_brg_cfg_cli_subnet_bridge_set(uint16_t net_idx, uint16_t addr,
-					  enum bt_mesh_subnet_bridge_state val,
-					  enum bt_mesh_subnet_bridge_state *status)
+int bt_mesh_brg_cfg_cli_set(uint16_t net_idx, uint16_t addr, enum bt_mesh_brg_cfg_state val,
+			    enum bt_mesh_brg_cfg_state *status)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_SUBNET_BRIDGE_SET, 1);
 	struct bt_mesh_msg_ctx ctx = BT_MESH_MSG_CTX_INIT_DEV(net_idx, addr);
@@ -238,7 +235,7 @@ int bt_mesh_brg_cfg_cli_subnet_bridge_set(uint16_t net_idx, uint16_t addr,
 	return bt_mesh_msg_ackd_send(cli->model, &ctx, &msg, !status ? NULL : &rsp_ctx);
 }
 
-int bt_mesh_brg_cfg_cli_bridging_table_size_get(uint16_t net_idx, uint16_t addr, uint16_t *size)
+int bt_mesh_brg_cfg_cli_table_size_get(uint16_t net_idx, uint16_t addr, uint16_t *size)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_BRIDGING_TABLE_SIZE_GET, 0);
 	struct bt_mesh_msg_ctx ctx = BT_MESH_MSG_CTX_INIT_DEV(net_idx, addr);
@@ -254,9 +251,9 @@ int bt_mesh_brg_cfg_cli_bridging_table_size_get(uint16_t net_idx, uint16_t addr,
 	return bt_mesh_msg_ackd_send(cli->model, &ctx, &msg, !size ? NULL : &rsp_ctx);
 }
 
-int bt_mesh_brg_cfg_cli_bridging_table_add(uint16_t net_idx, uint16_t addr,
-					   struct bt_mesh_bridging_table_entry *entry,
-					   struct bt_mesh_bridging_table_status *rsp)
+int bt_mesh_brg_cfg_cli_table_add(uint16_t net_idx, uint16_t addr,
+				  struct bt_mesh_brg_cfg_table_entry *entry,
+				  struct bt_mesh_brg_cfg_table_status *rsp)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_BRIDGING_TABLE_ADD, 8);
 	struct bt_mesh_msg_ctx ctx = BT_MESH_MSG_CTX_INIT_DEV(net_idx, addr);
@@ -292,9 +289,9 @@ int bt_mesh_brg_cfg_cli_bridging_table_add(uint16_t net_idx, uint16_t addr,
 	return bt_mesh_msg_ackd_send(cli->model, &ctx, &msg, !rsp ? NULL : &rsp_ctx);
 }
 
-int bt_mesh_brg_cfg_cli_bridging_table_remove(uint16_t net_idx, uint16_t addr, uint16_t net_idx1,
-					      uint16_t net_idx2, uint16_t addr1, uint16_t addr2,
-					      struct bt_mesh_bridging_table_status *rsp)
+int bt_mesh_brg_cfg_cli_table_remove(uint16_t net_idx, uint16_t addr, uint16_t net_idx1,
+				     uint16_t net_idx2, uint16_t addr1, uint16_t addr2,
+				     struct bt_mesh_brg_cfg_table_status *rsp)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_BRIDGING_TABLE_REMOVE, 7);
 	struct bt_mesh_msg_ctx ctx = BT_MESH_MSG_CTX_INIT_DEV(net_idx, addr);
@@ -321,10 +318,9 @@ int bt_mesh_brg_cfg_cli_bridging_table_remove(uint16_t net_idx, uint16_t addr, u
 	return bt_mesh_msg_ackd_send(cli->model, &ctx, &msg, !rsp ? NULL : &rsp_ctx);
 }
 
-int bt_mesh_brg_cfg_cli_bridged_subnets_get(uint16_t net_idx, uint16_t addr,
-					    struct bt_mesh_filter_netkey filter_net_idx,
-					    uint8_t start_idx,
-					    struct bt_mesh_bridged_subnets_list *rsp)
+int bt_mesh_brg_cfg_cli_subnets_get(uint16_t net_idx, uint16_t addr,
+				    struct bt_mesh_brg_cfg_filter_netkey filter_net_idx,
+				    uint8_t start_idx, struct bt_mesh_brg_cfg_subnets_list *rsp)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_BRIDGED_SUBNETS_GET, 3);
 	struct bt_mesh_msg_ctx ctx = BT_MESH_MSG_CTX_INIT_DEV(net_idx, addr);
@@ -342,9 +338,9 @@ int bt_mesh_brg_cfg_cli_bridged_subnets_get(uint16_t net_idx, uint16_t addr,
 	return bt_mesh_msg_ackd_send(cli->model, &ctx, &msg, !rsp ? NULL : &rsp_ctx);
 }
 
-int bt_mesh_brg_cfg_cli_bridging_table_get(uint16_t net_idx, uint16_t addr, uint16_t net_idx1,
-					   uint16_t net_idx2, uint16_t start_idx,
-					   struct bt_mesh_bridging_table_list *rsp)
+int bt_mesh_brg_cfg_cli_table_get(uint16_t net_idx, uint16_t addr, uint16_t net_idx1,
+				  uint16_t net_idx2, uint16_t start_idx,
+				  struct bt_mesh_brg_cfg_table_list *rsp)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_BRIDGING_TABLE_GET, 5);
 	struct bt_mesh_msg_ctx ctx = BT_MESH_MSG_CTX_INIT_DEV(net_idx, addr);

--- a/subsys/bluetooth/mesh/brg_cfg_srv.c
+++ b/subsys/bluetooth/mesh/brg_cfg_srv.c
@@ -40,7 +40,7 @@ static int subnet_bridge_set(const struct bt_mesh_model *model, struct bt_mesh_m
 {
 	uint8_t enable = net_buf_simple_pull_u8(buf);
 
-	if (enable > BT_MESH_SUBNET_BRIDGE_ENABLED) {
+	if (enable > BT_MESH_BRG_CFG_ENABLED) {
 		return -EINVAL;
 	}
 
@@ -52,7 +52,7 @@ static int subnet_bridge_set(const struct bt_mesh_model *model, struct bt_mesh_m
 
 static void bridging_table_status_send(const struct bt_mesh_model *model,
 				       struct bt_mesh_msg_ctx *ctx, uint8_t status,
-				       struct bt_mesh_bridging_table_entry *entry)
+				       struct bt_mesh_brg_cfg_table_entry *entry)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_BRIDGING_TABLE_STATUS, 9);
 
@@ -76,7 +76,7 @@ static bool netkey_check(uint16_t net_idx1, uint16_t net_idx2)
 static int bridging_table_add(const struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 			      struct net_buf_simple *buf)
 {
-	struct bt_mesh_bridging_table_entry entry;
+	struct bt_mesh_brg_cfg_table_entry entry;
 	uint8_t status = STATUS_SUCCESS;
 	int err;
 
@@ -99,7 +99,7 @@ static int bridging_table_add(const struct bt_mesh_model *model, struct bt_mesh_
 static int bridging_table_remove(const struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 				 struct net_buf_simple *buf)
 {
-	struct bt_mesh_bridging_table_entry entry;
+	struct bt_mesh_brg_cfg_table_entry entry;
 	uint8_t status = STATUS_SUCCESS;
 	int err;
 
@@ -135,7 +135,7 @@ static int bridged_subnets_get(const struct bt_mesh_model *model, struct bt_mesh
 		return -EINVAL;
 	}
 
-	struct bt_mesh_filter_netkey filter_net_idx;
+	struct bt_mesh_brg_cfg_filter_netkey filter_net_idx;
 
 	filter_net_idx.filter = net_idx_filter & BIT_MASK(2);
 	filter_net_idx.net_idx = (net_idx_filter >> 4) & BIT_MASK(12);

--- a/subsys/bluetooth/mesh/shell/brg_cfg.c
+++ b/subsys/bluetooth/mesh/shell/brg_cfg.c
@@ -14,43 +14,43 @@
 
 static int cmd_subnet_bridge_get(const struct shell *sh, size_t argc, char *argv[])
 {
-	enum bt_mesh_subnet_bridge_state rsp;
+	enum bt_mesh_brg_cfg_state rsp;
 	int err;
 
-	err = bt_mesh_brg_cfg_cli_subnet_bridge_get(bt_mesh_shell_target_ctx.net_idx,
-						    bt_mesh_shell_target_ctx.dst, &rsp);
+	err = bt_mesh_brg_cfg_cli_get(bt_mesh_shell_target_ctx.net_idx,
+				      bt_mesh_shell_target_ctx.dst, &rsp);
 	if (err) {
 		shell_error(sh, "Failed to send Subnet Bridge Get (err %d)", err);
 		return -ENOEXEC;
 	}
 
 	shell_print(sh, "Subnet Bridge State: %s",
-		    (rsp == BT_MESH_SUBNET_BRIDGE_ENABLED) ? "Enabled" : "Disabled");
+		    (rsp == BT_MESH_BRG_CFG_ENABLED) ? "Enabled" : "Disabled");
 	return 0;
 }
 
 static int cmd_subnet_bridge_set(const struct shell *sh, size_t argc, char *argv[])
 {
-	enum bt_mesh_subnet_bridge_state set, rsp;
+	enum bt_mesh_brg_cfg_state set, rsp;
 	int err = 0;
 
-	set = shell_strtobool(argv[1], 0, &err) ? BT_MESH_SUBNET_BRIDGE_ENABLED
-						: BT_MESH_SUBNET_BRIDGE_DISABLED;
+	set = shell_strtobool(argv[1], 0, &err) ? BT_MESH_BRG_CFG_ENABLED
+						: BT_MESH_BRG_CFG_DISABLED;
 
 	if (err) {
 		shell_warn(sh, "Unable to parse input string argument");
 		return err;
 	}
 
-	err = bt_mesh_brg_cfg_cli_subnet_bridge_set(bt_mesh_shell_target_ctx.net_idx,
-						    bt_mesh_shell_target_ctx.dst, set, &rsp);
+	err = bt_mesh_brg_cfg_cli_set(bt_mesh_shell_target_ctx.net_idx,
+				      bt_mesh_shell_target_ctx.dst, set, &rsp);
 	if (err) {
 		shell_error(sh, "Failed to send Subnet Bridge Set (err %d)", err);
 		return -ENOEXEC;
 	}
 
 	shell_print(sh, "Subnet Bridge State: %s",
-		    (rsp == BT_MESH_SUBNET_BRIDGE_ENABLED) ? "Enabled" : "Disabled");
+		    (rsp == BT_MESH_BRG_CFG_ENABLED) ? "Enabled" : "Disabled");
 	return 0;
 }
 
@@ -59,8 +59,8 @@ static int cmd_bridging_table_size_get(const struct shell *sh, size_t argc, char
 	uint16_t rsp;
 	int err;
 
-	err = bt_mesh_brg_cfg_cli_bridging_table_size_get(bt_mesh_shell_target_ctx.net_idx,
-							  bt_mesh_shell_target_ctx.dst, &rsp);
+	err = bt_mesh_brg_cfg_cli_table_size_get(bt_mesh_shell_target_ctx.net_idx,
+						 bt_mesh_shell_target_ctx.dst, &rsp);
 	if (err) {
 		shell_error(sh, "Failed to send Bridging Table Size Get (err %d)", err);
 		return -ENOEXEC;
@@ -72,8 +72,8 @@ static int cmd_bridging_table_size_get(const struct shell *sh, size_t argc, char
 
 static int cmd_bridging_table_add(const struct shell *sh, size_t argc, char *argv[])
 {
-	struct bt_mesh_bridging_table_entry entry;
-	struct bt_mesh_bridging_table_status rsp;
+	struct bt_mesh_brg_cfg_table_entry entry;
+	struct bt_mesh_brg_cfg_table_status rsp;
 	int err = 0;
 
 	entry.directions = shell_strtoul(argv[1], 0, &err);
@@ -86,8 +86,8 @@ static int cmd_bridging_table_add(const struct shell *sh, size_t argc, char *arg
 		return err;
 	}
 
-	err = bt_mesh_brg_cfg_cli_bridging_table_add(bt_mesh_shell_target_ctx.net_idx,
-						     bt_mesh_shell_target_ctx.dst, &entry, &rsp);
+	err = bt_mesh_brg_cfg_cli_table_add(bt_mesh_shell_target_ctx.net_idx,
+					    bt_mesh_shell_target_ctx.dst, &entry, &rsp);
 	if (err) {
 		shell_error(sh, "Failed to send Bridging Table Add (err %d)", err);
 		return -ENOEXEC;
@@ -104,7 +104,7 @@ static int cmd_bridging_table_add(const struct shell *sh, size_t argc, char *arg
 static int cmd_bridging_table_remove(const struct shell *sh, size_t argc, char *argv[])
 {
 	uint16_t net_idx1, net_idx2, addr1, addr2;
-	struct bt_mesh_bridging_table_status rsp;
+	struct bt_mesh_brg_cfg_table_status rsp;
 	int err = 0;
 
 	net_idx1 = shell_strtoul(argv[1], 0, &err);
@@ -116,9 +116,9 @@ static int cmd_bridging_table_remove(const struct shell *sh, size_t argc, char *
 		return err;
 	}
 
-	err = bt_mesh_brg_cfg_cli_bridging_table_remove(bt_mesh_shell_target_ctx.net_idx,
-							bt_mesh_shell_target_ctx.dst, net_idx1,
-							net_idx2, addr1, addr2, &rsp);
+	err = bt_mesh_brg_cfg_cli_table_remove(bt_mesh_shell_target_ctx.net_idx,
+					       bt_mesh_shell_target_ctx.dst, net_idx1, net_idx2,
+					       addr1, addr2, &rsp);
 	if (err) {
 		shell_error(sh, "Failed to send Bridging Table Remove (err %d)", err);
 		return -ENOEXEC;
@@ -134,9 +134,9 @@ static int cmd_bridging_table_remove(const struct shell *sh, size_t argc, char *
 
 static int cmd_bridged_subnets_get(const struct shell *sh, size_t argc, char *argv[])
 {
-	struct bt_mesh_filter_netkey filter_net_idx;
+	struct bt_mesh_brg_cfg_filter_netkey filter_net_idx;
 	uint8_t start_idx;
-	struct bt_mesh_bridged_subnets_list rsp = {
+	struct bt_mesh_brg_cfg_subnets_list rsp = {
 		.list = NET_BUF_SIMPLE(CONFIG_BT_MESH_BRG_TABLE_ITEMS_MAX * 3),
 	};
 	int err = 0;
@@ -151,9 +151,9 @@ static int cmd_bridged_subnets_get(const struct shell *sh, size_t argc, char *ar
 		return err;
 	}
 
-	err = bt_mesh_brg_cfg_cli_bridged_subnets_get(bt_mesh_shell_target_ctx.net_idx,
-						      bt_mesh_shell_target_ctx.dst, filter_net_idx,
-						      start_idx, &rsp);
+	err = bt_mesh_brg_cfg_cli_subnets_get(bt_mesh_shell_target_ctx.net_idx,
+					      bt_mesh_shell_target_ctx.dst, filter_net_idx,
+					      start_idx, &rsp);
 	if (err) {
 		shell_error(sh, "Failed to send Bridged Subnets Get (err %d)", err);
 		return -ENOEXEC;
@@ -180,7 +180,7 @@ static int cmd_bridged_subnets_get(const struct shell *sh, size_t argc, char *ar
 static int cmd_bridging_table_get(const struct shell *sh, size_t argc, char *argv[])
 {
 	uint16_t net_idx1, net_idx2, start_idx;
-	struct bt_mesh_bridging_table_list rsp = {
+	struct bt_mesh_brg_cfg_table_list rsp = {
 		.list = NET_BUF_SIMPLE(CONFIG_BT_MESH_BRG_TABLE_ITEMS_MAX * 5),
 	};
 	int err = 0;
@@ -195,9 +195,9 @@ static int cmd_bridging_table_get(const struct shell *sh, size_t argc, char *arg
 		return err;
 	}
 
-	err = bt_mesh_brg_cfg_cli_bridging_table_get(bt_mesh_shell_target_ctx.net_idx,
-						     bt_mesh_shell_target_ctx.dst, net_idx1,
-						     net_idx2, start_idx, &rsp);
+	err = bt_mesh_brg_cfg_cli_table_get(bt_mesh_shell_target_ctx.net_idx,
+					    bt_mesh_shell_target_ctx.dst, net_idx1, net_idx2,
+					    start_idx, &rsp);
 	if (err) {
 		shell_error(sh, "Failed to send Bridging Table Get (err %d)", err);
 		return -ENOEXEC;

--- a/tests/bluetooth/mesh/brg/src/main.c
+++ b/tests/bluetooth/mesh/brg/src/main.c
@@ -293,6 +293,11 @@ ZTEST(bt_mesh_brg_cfg, test_brg_tbl_pending_store)
 	bt_mesh_brg_cfg_pending_store();
 }
 
+/* Value is prohibited. */
+#define BT_MESH_BRG_CFG_DIR_PROHIBITED 0
+/* Values above and including this is prohibited. */
+#define BT_MESH_BRG_CFG_DIR_MAX 3
+
 /* Test if invalid entries are not added to the table. */
 ZTEST(bt_mesh_brg_cfg, test_tbl_add_invalid_ip)
 {

--- a/tests/bluetooth/tester/src/btp_mesh.c
+++ b/tests/bluetooth/tester/src/btp_mesh.c
@@ -2086,10 +2086,10 @@ static uint8_t models_metadata_get(const void *cmd, uint16_t cmd_len,
 static uint8_t subnet_bridge_get(const void *cmd, uint16_t cmd_len, void *rsp, uint16_t *rsp_len)
 {
 	const struct btp_mesh_subnet_bridge_get_cmd *cp = cmd;
-	enum bt_mesh_subnet_bridge_state state;
+	enum bt_mesh_brg_cfg_state state;
 	int err;
 
-	err = bt_mesh_brg_cfg_cli_subnet_bridge_get(net.net_idx, sys_le16_to_cpu(cp->addr), &state);
+	err = bt_mesh_brg_cfg_cli_get(net.net_idx, sys_le16_to_cpu(cp->addr), &state);
 	if (err) {
 		LOG_ERR("err=%d", err);
 		return BTP_STATUS_FAILED;
@@ -2103,13 +2103,12 @@ static uint8_t subnet_bridge_get(const void *cmd, uint16_t cmd_len, void *rsp, u
 static uint8_t subnet_bridge_set(const void *cmd, uint16_t cmd_len, void *rsp, uint16_t *rsp_len)
 {
 	const struct btp_mesh_subnet_bridge_set_cmd *cp = cmd;
-	enum bt_mesh_subnet_bridge_state state;
+	enum bt_mesh_brg_cfg_state state;
 	int err;
 
 	state = cp->val;
 
-	err = bt_mesh_brg_cfg_cli_subnet_bridge_set(net.net_idx, sys_le16_to_cpu(cp->addr), state,
-						    &state);
+	err = bt_mesh_brg_cfg_cli_set(net.net_idx, sys_le16_to_cpu(cp->addr), state, &state);
 	if (err) {
 		LOG_ERR("err=%d", err);
 		return BTP_STATUS_FAILED;
@@ -2123,8 +2122,8 @@ static uint8_t subnet_bridge_set(const void *cmd, uint16_t cmd_len, void *rsp, u
 static uint8_t bridging_table_add(const void *cmd, uint16_t cmd_len, void *rsp, uint16_t *rsp_len)
 {
 	const struct btp_mesh_bridging_table_add_cmd *cp = cmd;
-	struct bt_mesh_bridging_table_entry entry;
-	struct bt_mesh_bridging_table_status rp;
+	struct bt_mesh_brg_cfg_table_entry entry;
+	struct bt_mesh_brg_cfg_table_status rp;
 	int err;
 
 	LOG_DBG("");
@@ -2135,8 +2134,7 @@ static uint8_t bridging_table_add(const void *cmd, uint16_t cmd_len, void *rsp, 
 	entry.addr1 = sys_le16_to_cpu(cp->addr1);
 	entry.addr2 = sys_le16_to_cpu(cp->addr2);
 
-	err = bt_mesh_brg_cfg_cli_bridging_table_add(net_key_idx, sys_le16_to_cpu(cp->addr), &entry,
-						     &rp);
+	err = bt_mesh_brg_cfg_cli_table_add(net_key_idx, sys_le16_to_cpu(cp->addr), &entry, &rp);
 	if (err) {
 		LOG_ERR("err=%d", err);
 		return BTP_STATUS_FAILED;
@@ -2149,12 +2147,12 @@ static uint8_t bridging_table_remove(const void *cmd, uint16_t cmd_len, void *rs
 				     uint16_t *rsp_len)
 {
 	const struct btp_mesh_bridging_table_remove_cmd *cp = cmd;
-	struct bt_mesh_bridging_table_status rp;
+	struct bt_mesh_brg_cfg_table_status rp;
 	int err;
 
 	LOG_DBG("");
 
-	err = bt_mesh_brg_cfg_cli_bridging_table_remove(
+	err = bt_mesh_brg_cfg_cli_table_remove(
 		net_key_idx, sys_le16_to_cpu(cp->addr), sys_le16_to_cpu(cp->net_idx1),
 		sys_le16_to_cpu(cp->net_idx2), sys_le16_to_cpu(cp->addr1),
 		sys_le16_to_cpu(cp->addr2), &rp);
@@ -2170,8 +2168,8 @@ static uint8_t bridging_table_remove(const void *cmd, uint16_t cmd_len, void *rs
 static uint8_t bridged_subnets_get(const void *cmd, uint16_t cmd_len, void *rsp, uint16_t *rsp_len)
 {
 	const struct btp_mesh_bridged_subnets_get_cmd *cp = cmd;
-	struct bt_mesh_filter_netkey filter_net_idx;
-	struct bt_mesh_bridged_subnets_list rp;
+	struct bt_mesh_brg_cfg_filter_netkey filter_net_idx;
+	struct bt_mesh_brg_cfg_subnets_list rp;
 	int err;
 
 	LOG_DBG("");
@@ -2184,8 +2182,8 @@ static uint8_t bridged_subnets_get(const void *cmd, uint16_t cmd_len, void *rsp,
 	filter_net_idx.filter = cp->filter;
 	filter_net_idx.net_idx = sys_le16_to_cpu(cp->net_idx);
 
-	err = bt_mesh_brg_cfg_cli_bridged_subnets_get(net_key_idx, sys_le16_to_cpu(cp->addr),
-						      filter_net_idx, cp->start_idx, &rp);
+	err = bt_mesh_brg_cfg_cli_subnets_get(net_key_idx, sys_le16_to_cpu(cp->addr),
+					      filter_net_idx, cp->start_idx, &rp);
 	if (err) {
 		LOG_ERR("err=%d", err);
 		return BTP_STATUS_FAILED;
@@ -2197,7 +2195,7 @@ static uint8_t bridged_subnets_get(const void *cmd, uint16_t cmd_len, void *rsp,
 static uint8_t bridging_table_get(const void *cmd, uint16_t cmd_len, void *rsp, uint16_t *rsp_len)
 {
 	const struct btp_mesh_bridging_table_get_cmd *cp = cmd;
-	struct bt_mesh_bridging_table_list rp;
+	struct bt_mesh_brg_cfg_table_list rp;
 	int err;
 
 	LOG_DBG("");
@@ -2207,7 +2205,7 @@ static uint8_t bridging_table_get(const void *cmd, uint16_t cmd_len, void *rsp, 
 	 */
 	rp.list = NULL;
 
-	err = bt_mesh_brg_cfg_cli_bridging_table_get(
+	err = bt_mesh_brg_cfg_cli_table_get(
 		net_key_idx, sys_le16_to_cpu(cp->addr), sys_le16_to_cpu(cp->net_idx1),
 		sys_le16_to_cpu(cp->net_idx2), sys_le16_to_cpu(cp->start_idx), &rp);
 	if (err) {
@@ -2227,8 +2225,7 @@ static uint8_t bridging_table_size_get(const void *cmd, uint16_t cmd_len, void *
 
 	LOG_DBG("");
 
-	err = bt_mesh_brg_cfg_cli_bridging_table_size_get(net_key_idx, sys_le16_to_cpu(cp->addr),
-							  &size);
+	err = bt_mesh_brg_cfg_cli_table_size_get(net_key_idx, sys_le16_to_cpu(cp->addr), &size);
 	if (err) {
 		LOG_ERR("err=%d", err);
 		return BTP_STATUS_FAILED;


### PR DESCRIPTION
Adds the `bt_mesh_brg_cfg` prefix to the public Subnet Bridge API, and aligns the function and callback naming with the rest of the Bluetooth Mesh API.