### PR TITLE
usb: device_next: respect bMaxPacketSize0 in control transfers

### DIFF
--- a/include/zephyr/usb/usb_ch9.h
+++ b/include/zephyr/usb/usb_ch9.h
@@ -283,7 +283,12 @@ struct usb_association_descriptor {
 /** Macro to obtain descriptor index from USB_SREQ_GET_DESCRIPTOR request */
 #define USB_GET_DESCRIPTOR_INDEX(wValue)	((uint8_t)(wValue))
 
-/** USB Control Endpoints maximum packet size (MPS) */
+/**
+ * USB Control Endpoints maximum packet size (MPS)
+ *
+ * This value may not be correct for devices operating at speeds other than
+ * high speed.
+ */
 #define USB_CONTROL_EP_MPS		64U
 
 /** USB endpoint direction mask */


### PR DESCRIPTION
Only the device operating at high speed has bMaxPacketSize0 set to 64
bytes, the device operating at other speeds may have a different value.
For full speed, use the value from the full speed descriptor.

Fixes: #79194