### PR TITLE
Bluetooth audio samples: Fix build waning and build with warnings as errors

### DIFF
--- a/samples/bluetooth/cap_acceptor/src/cap_acceptor_broadcast.c
+++ b/samples/bluetooth/cap_acceptor/src/cap_acceptor_broadcast.c
@@ -10,6 +10,7 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <string.h>
+#include <strings.h>
 
 #include <zephyr/autoconf.h>
 #include <zephyr/bluetooth/audio/audio.h>

--- a/tests/bsim/bluetooth/audio_samples/compile.sh
+++ b/tests/bsim/bluetooth/audio_samples/compile.sh
@@ -24,13 +24,13 @@ if [ "${BOARD_TS}" == "nrf5340bsim_nrf5340_cpuapp" ]; then
     exe_name=bs_${BOARD_TS}_${app}_prj_conf sysbuild=1 compile
   app=tests/bsim/bluetooth/audio_samples/cap/initiator \
     sample=${ZEPHYR_BASE}/samples/bluetooth/cap_initiator \
-    cmake_args="-DCONFIG_SAMPLE_UNICAST=n" \
+    cmake_extra_args="-DCONFIG_SAMPLE_UNICAST=n" \
     conf_file=${sample}/prj.conf \
     conf_overlay=${sample}/boards/nrf5340_audio_dk_nrf5340_cpuapp.conf \
     exe_name=bs_${BOARD_TS}_${app}_broadcast_prj_conf sysbuild=1 compile
   app=tests/bsim/bluetooth/audio_samples/cap/acceptor \
     sample=${ZEPHYR_BASE}/samples/bluetooth/cap_acceptor \
-    cmake_args="-DCONFIG_SAMPLE_SCAN_SELF=y -DCONFIG_SAMPLE_UNICAST=n" \
+    cmake_extra_args="-DCONFIG_SAMPLE_SCAN_SELF=y -DCONFIG_SAMPLE_UNICAST=n" \
     conf_file=${sample}/prj.conf \
     conf_overlay=${sample}/boards/nrf5340_audio_dk_nrf5340_cpuapp.conf \
     exe_name=bs_${BOARD_TS}_${app}_broadcast_prj_conf sysbuild=1 compile
@@ -60,13 +60,13 @@ else
     exe_name=bs_${BOARD_TS}_${app}_prj_conf sysbuild=1 compile
   app=tests/bsim/bluetooth/audio_samples/cap/initiator \
     sample=${ZEPHYR_BASE}/samples/bluetooth/cap_initiator \
-    cmake_args="-DCONFIG_SAMPLE_UNICAST=n" \
+    cmake_extra_args="-DCONFIG_SAMPLE_UNICAST=n" \
     conf_file=${sample}/prj.conf \
     conf_overlay=${sample}/overlay-bt_ll_sw_split.conf \
     exe_name=bs_${BOARD_TS}_${app}_broadcast_prj_conf sysbuild=1 compile
   app=tests/bsim/bluetooth/audio_samples/cap/acceptor \
     sample=${ZEPHYR_BASE}/samples/bluetooth/cap_acceptor \
-    cmake_args="-DCONFIG_SAMPLE_SCAN_SELF=y -DCONFIG_SAMPLE_UNICAST=n" \
+    cmake_extra_args="-DCONFIG_SAMPLE_SCAN_SELF=y -DCONFIG_SAMPLE_UNICAST=n" \
     conf_file=${sample}/prj.conf \
     conf_overlay=${sample}/overlay-bt_ll_sw_split.conf \
     exe_name=bs_${BOARD_TS}_${app}_broadcast_prj_conf sysbuild=1 compile

--- a/tests/bsim/compile.source
+++ b/tests/bsim/compile.source
@@ -25,7 +25,7 @@ function _compile(){
   default_cmake_args=(-DCONFIG_COVERAGE=y -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
     -DCONFIG_COMPILER_WARNINGS_AS_ERRORS=y -DCONFIG_ASSERT=y)
   local cmake_args=(${cmake_args:-"${default_cmake_args[@]}"})
-  local cmake_extra_args="${cmake_extra_args:-""}"
+  local cmake_extra_args=(${cmake_extra_args:-""})
   local ninja_args="${ninja_args:-""}"
   local cc_flags="${cc_flags:-""}"
 
@@ -61,7 +61,7 @@ function _compile(){
   local cmake_cmd+=( -DOVERLAY_CONFIG="${conf_overlay}" \
             -DEXTRA_CONF_FILE="${extra_conf_file}" \
             ${modules_arg} \
-            "${cmake_args[@]}" ${cc_flags:+-DCMAKE_C_FLAGS=${cc_flags}} ${cmake_extra_args})
+            "${cmake_args[@]}" ${cc_flags:+-DCMAKE_C_FLAGS=${cc_flags}} "${cmake_extra_args[@]}")
   if [ -v sysbuild ]; then
     local cmake_cmd+=( -DAPP_DIR=${app_root}/${app} ${ZEPHYR_BASE}/share/sysbuild/)
   else


### PR DESCRIPTION
    samples/bluetooth/cap_acceptor: Add missing include
    
    strncasecmp()'s prototype is provided in strings.h
    let's include it to avoid a build warning.
    
    Signed-off-by: Alberto Escolar Piedras <alberto.escolar.piedras@nordicsemi.no>

---------

    tests/bsim/bluetooth/audio_samples: Error on warnings
    
    Do not override the cmake_args parameter, but instead use the
    cmake_extra_args one.
    Otherwise we lose the default -DCONFIG_COMPILER_WARNINGS_AS_ERRORS=y
    
--------

    tests/bsim/compile: Improve cmake_extra_args
    
    Allow cmake_extra_args to contain multiple arguments
    
