### PR TITLE
stepper: shell: fix uninitialized variable compiler warning

### DIFF
--- a/drivers/stepper/stepper_shell.c
+++ b/drivers/stepper/stepper_shell.c
@@ -360,7 +360,7 @@ static int cmd_stepper_enable_constant_velocity_mode(const struct shell *sh, siz
 {
 	const struct device *dev;
 	int err = -EINVAL;
-	enum stepper_direction direction;
+	enum stepper_direction direction = STEPPER_DIRECTION_POSITIVE;
 
 	for (int i = 0; i < ARRAY_SIZE(stepper_direction_map); i++) {
 		if (strcmp(argv[ARG_IDX_PARAM], stepper_direction_map[i].name) == 0) {


### PR DESCRIPTION
Fixes:

/__w/zephyr/zephyr/include/zephyr/drivers/stepper.h:429:16: error: 'direction' may be used uninitialized [-Werror=maybe-uninitialized]

found with:

west build -p -b esp32s3_touch_lcd_1_28/esp32s3/appcpu -T tests/drivers/stepper/shell/drivers.stepper.shell