### PR TITLE
manifest: update open-amp to include change to strlcpy

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -303,7 +303,7 @@ manifest:
       revision: 85944c64f224406e4d781aa382c5f1f71ed307fd
       path: modules/bsim_hw_models/nrf_hw_models
     - name: open-amp
-      revision: 76d2168bcdfcd23a9a7dce8c21f2083b90a1e60a
+      revision: b735edbc739ad59156eb55bb8ce2583d74537719
       path: modules/lib/open-amp
     - name: openthread
       revision: e10a92570f94ff1e0bc5e0da9ecf0ee135d955a6


### PR DESCRIPTION
This manifest update points open-amp to include a fix for unsafe use of strncpy by by replacing it with internal strlcpy.