### PR TITLE
manifest: Update nRF hw models to latest

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -300,7 +300,7 @@ manifest:
       groups:
         - tools
     - name: nrf_hw_models
-      revision: 85944c64f224406e4d781aa382c5f1f71ed307fd
+      revision: bf8e45bd1f870e49cc15392e045c28d54ea12285
       path: modules/bsim_hw_models/nrf_hw_models
     - name: open-amp
       revision: 76d2168bcdfcd23a9a7dce8c21f2083b90a1e60a


### PR DESCRIPTION
Update the HW models module to:
bf8e45bd1f870e49cc15392e045c28d54ea12285

Including the following:
* bf8e45b (52) CCM HAL: Support nrfx 3.7.0 with renamed TASK_CRYPT
* 14c14d7 HW_models/NHW_GRTC: Support MDK not exposing SYSCOUNTERVALID
* 6d66801 RADIO: Improve RSSISTART behaviour
* ceb6a80 hal grtc: Add replacements for new int group functions
* 838aa38 docs/README_HW_models: Add reference to Bsim HW models descr
* 0ff34d7 docs: Several updates and fixes
* 2972a93 AES_CCM: Avoid UBSAN pointer align warn when reading CNFPTR
* f8cd477 UART: Minor bugfix: Set rx status to off during ENABLE

This PR enables using the latest nrfx HAL (3.7.0) with the latest MDK, but it does not require it.