### PR TITLE
drivers: ethernet: adin2111: fix generic spi frame reception

### DIFF
--- a/drivers/ethernet/eth_adin2111.c
+++ b/drivers/ethernet/eth_adin2111.c
@@ -557,8 +557,8 @@ static int adin2111_read_fifo(const struct device *dev, const uint16_t port_idx)
 
 	/* burst read must be in multiples of 4 */
 	padding_len = ((fsize % 4) == 0) ? 0U : (ROUND_UP(fsize, 4U) - fsize);
-	/* actual frame length is FSIZE - FRAME HEADER - CRC32 */
-	fsize_real = fsize - (ADIN2111_FRAME_HEADER_SIZE + sizeof(uint32_t));
+	/* actual available frame length is FSIZE - FRAME HEADER */
+	fsize -= ADIN2111_FRAME_HEADER_SIZE;
 
 	/* spi header */
 	*(uint16_t *)cmd_buf = htons((ADIN2111_READ_TXN_CTRL | rx_reg));
@@ -574,7 +574,7 @@ static int adin2111_read_fifo(const struct device *dev, const uint16_t port_idx)
 	const struct spi_buf tx_buf = { .buf = cmd_buf, .len = sizeof(cmd_buf) };
 	const struct spi_buf rx_buf[3] = {
 		{.buf = NULL, .len = sizeof(cmd_buf) + ADIN2111_FRAME_HEADER_SIZE},
-		{.buf = ctx->buf, .len = fsize_real},
+		{.buf = ctx->buf, .len = fsize},
 		{.buf = NULL, .len = padding_len }
 	};
 	const struct spi_buf_set tx = { .buffers = &tx_buf, .count = 1U };
@@ -589,6 +589,9 @@ static int adin2111_read_fifo(const struct device *dev, const uint16_t port_idx)
 		LOG_ERR("Port %u failed to read RX FIFO, %d", port_idx, ret);
 		return ret;
 	}
+
+	/* remove CRC32 and pass to the stack */
+	fsize_real = fsize - sizeof(uint32_t);
 
 	pkt = net_pkt_rx_alloc_with_buffer(iface, fsize_real, AF_UNSPEC, 0,
 					   K_MSEC(CONFIG_ETH_ADIN2111_TIMEOUT));


### PR DESCRIPTION
Fixes a bug introduced in https://github.com/zephyrproject-rtos/zephyr/commit/06df4b5ae956f38e0175da721e8fc8f9ceb70db9#diff-859cca15b29dc1d7847b3bc4f9c79ddf4e1c80c65606d866429e613ecb1017a3L500 that results in double RX buffer read from ADIN when generic SPI protocol is used.

For every correct ethernet frame the `Pn_RX_RDY` continues to be asserted one more time. However, the second read results in a bad frame that consists of first frame leftovers (_that we fail to read fully_) and garbage.

The bug is easy to check by enabling:
```
CONFIG_NET_LOG=y
CONFIG_ETHERNET_LOG_LEVEL_DBG=y
CONFIG_NET_L2_ETHERNET_LOG_LEVEL_DBG=y
```

and observing something like:

```
[00:00:03.543,000] <dbg> net_ethernet: ethernet_recv: (rx_q[0]): Unknown hdr type 0x3271 iface 1
```

To fix the issue, we must read the whole frame in one SPI transaction. The actual frame size is `RX_FSIZE - FRAME_HEADER`.

The fix for "Still some length to go 2" is preserved. (https://github.com/zephyrproject-rtos/zephyr/commit/06df4b5ae956f38e0175da721e8fc8f9ceb70db9#diff-859cca15b29dc1d7847b3bc4f9c79ddf4e1c80c65606d866429e613ecb1017a3). We drop the CRC32 bytes from the frame prior allocation and passing that pkt to the network stack.

@spectrum70 
