### PR TITLE
drivers: cc: mcux: Fix incorrect clock source of FlexSPI2

### DIFF
--- a/drivers/clock_control/clock_control_mcux_ccm_rev2.c
+++ b/drivers/clock_control/clock_control_mcux_ccm_rev2.c
@@ -155,10 +155,8 @@ static int mcux_ccm_get_subsys_rate(const struct device *dev,
 
 #ifdef CONFIG_MEMC_MCUX_FLEXSPI
 	case IMX_CCM_FLEXSPI_CLK:
-		clock_root = kCLOCK_Root_Flexspi1;
-		break;
 	case IMX_CCM_FLEXSPI2_CLK:
-		clock_root = kCLOCK_Root_Flexspi2;
+		clock_root = kCLOCK_Root_Flexspi1 + instance;
 		break;
 #endif
 #ifdef CONFIG_COUNTER_NXP_PIT


### PR DESCRIPTION
Due to the following in line `45`, `FlexSPI2` actually returned the frequency of `FlexSPI1`:

```
peripheral = (clock_name & IMX_CCM_PERIPHERAL_MASK);
```

The fix is to adjust the `switch` case to match the `#1 + instance` scheme of the other clocks.

Needs backporting to 3.7.

Fixes #https://github.com/zephyrproject-rtos/zephyr/issues/79288