### PR TITLE
drivers: ethernet: adin2111: minor oa related fixes

### DIFF
--- a/drivers/ethernet/eth_adin2111.c
+++ b/drivers/ethernet/eth_adin2111.c
@@ -680,14 +680,6 @@ static void adin2111_offload_thread(void *p1, void *p2, void *p3)
 			goto continue_unlock;
 		}
 
-		if (!ctx->oa) {
-#if CONFIG_ETH_ADIN2111_SPI_CFG0
-			if (status0 & ADIN2111_STATUS1_SPI_ERR) {
-				LOG_WRN("Detected TX SPI CRC error");
-			}
-#endif
-		}
-
 		/* handle port 1 phy interrupts */
 		if (status0 & ADIN2111_STATUS0_PHYINT) {
 			adin2111_port_on_phyint(ctx->port[0]);
@@ -702,46 +694,53 @@ static void adin2111_offload_thread(void *p1, void *p2, void *p3)
 			if (status1 & ADIN2111_STATUS1_P1_RX_RDY) {
 				ret = eth_adin2111_oa_data_read(dev, 0);
 				if (ret < 0) {
-					break;
+					goto continue_unlock;
 				}
 			}
 			if (status1 & ADIN2111_STATUS1_P2_RX_RDY) {
 				ret = eth_adin2111_oa_data_read(dev, 1);
 				if (ret < 0) {
-					break;
+					goto continue_unlock;
 				}
 			}
-			goto continue_unlock;
-		}
+		} else {
+#if CONFIG_ETH_ADIN2111_SPI_CFG0
+			if (status0 & ADIN2111_STATUS1_SPI_ERR) {
+				LOG_WRN("Detected TX SPI CRC error");
+			}
+#endif /* CONFIG_ETH_ADIN2111_SPI_CFG0 */
 
-		/* handle port 1 rx */
-		if (status1 & ADIN2111_STATUS1_P1_RX_RDY) {
-			do {
-				ret = adin2111_read_fifo(dev, 0U);
-				if (ret < 0) {
-					break;
-				}
+			/* handle port 1 rx */
+			if (status1 & ADIN2111_STATUS1_P1_RX_RDY) {
+				do {
+					ret = adin2111_read_fifo(dev, 0U);
+					if (ret < 0) {
+						break;
+					}
 
-				ret = eth_adin2111_reg_read(dev, ADIN2111_STATUS1, &status1);
-				if (ret < 0) {
-					goto continue_unlock;
-				}
-			} while (!!(status1 & ADIN2111_STATUS1_P1_RX_RDY));
-		}
+					ret = eth_adin2111_reg_read(dev, ADIN2111_STATUS1,
+								    &status1);
+					if (ret < 0) {
+						goto continue_unlock;
+					}
+				} while (!!(status1 & ADIN2111_STATUS1_P1_RX_RDY));
+			}
 
-		/* handle port 2 rx */
-		if ((status1 & ADIN2111_STATUS1_P2_RX_RDY) && is_adin2111) {
-			do {
-				ret = adin2111_read_fifo(dev, 1U);
-				if (ret < 0) {
-					break;
-				}
+			/* handle port 2 rx */
+			if ((status1 & ADIN2111_STATUS1_P2_RX_RDY) && is_adin2111) {
+				do {
+					ret = adin2111_read_fifo(dev, 1U);
+					if (ret < 0) {
+						break;
+					}
 
-				ret = eth_adin2111_reg_read(dev, ADIN2111_STATUS1, &status1);
-				if (ret < 0) {
-					goto continue_unlock;
-				}
-			} while (!!(status1 & ADIN2111_STATUS1_P2_RX_RDY));
+					ret = eth_adin2111_reg_read(dev, ADIN2111_STATUS1,
+								    &status1);
+					if (ret < 0) {
+						goto continue_unlock;
+					}
+				} while (!!(status1 & ADIN2111_STATUS1_P2_RX_RDY));
+			}
 		}
 
 continue_unlock:

--- a/drivers/ethernet/eth_adin2111.c
+++ b/drivers/ethernet/eth_adin2111.c
@@ -648,7 +648,7 @@ static void adin2111_offload_thread(void *p1, void *p2, void *p3)
 	const struct device *dev = p1;
 	struct adin2111_data *ctx = dev->data;
 	const struct adin2111_config *adin_cfg = dev->config;
-	bool is_adin2111 = (adin_cfg->id == ADIN2111_MAC);
+	const bool is_adin2111 = (adin_cfg->id == ADIN2111_MAC);
 	uint32_t status0;
 	uint32_t status1;
 	int ret;
@@ -686,7 +686,7 @@ static void adin2111_offload_thread(void *p1, void *p2, void *p3)
 		}
 
 		/* handle port 2 phy interrupts */
-		if ((status1 & ADIN2111_STATUS1_PHYINT) && is_adin2111) {
+		if (is_adin2111 && (status1 & ADIN2111_STATUS1_PHYINT)) {
 			adin2111_port_on_phyint(ctx->port[1]);
 		}
 
@@ -697,7 +697,7 @@ static void adin2111_offload_thread(void *p1, void *p2, void *p3)
 					goto continue_unlock;
 				}
 			}
-			if ((status1 & ADIN2111_STATUS1_P2_RX_RDY ) && is_adin2111) {
+			if (is_adin2111 && (status1 & ADIN2111_STATUS1_P2_RX_RDY)) {
 				ret = eth_adin2111_oa_data_read(dev, 1);
 				if (ret < 0) {
 					goto continue_unlock;
@@ -727,7 +727,7 @@ static void adin2111_offload_thread(void *p1, void *p2, void *p3)
 			}
 
 			/* handle port 2 rx */
-			if ((status1 & ADIN2111_STATUS1_P2_RX_RDY) && is_adin2111) {
+			if (is_adin2111 && (status1 & ADIN2111_STATUS1_P2_RX_RDY)) {
 				do {
 					ret = adin2111_read_fifo(dev, 1U);
 					if (ret < 0) {
@@ -994,7 +994,7 @@ static int adin2111_write_filter_address(const struct device *dev,
 static int adin2111_filter_multicast(const struct device *dev)
 {
 	const struct adin2111_config *cfg = dev->config;
-	bool is_adin2111 = (cfg->id == ADIN2111_MAC);
+	const bool is_adin2111 = (cfg->id == ADIN2111_MAC);
 	uint8_t mm[NET_ETH_ADDR_LEN] = {BIT(0), 0U, 0U, 0U, 0U, 0U};
 	uint8_t mmask[NET_ETH_ADDR_LEN] = {0xFFU, 0U, 0U, 0U, 0U, 0U};
 	uint32_t rules = ADIN2111_ADDR_APPLY2PORT1 |
@@ -1009,7 +1009,7 @@ static int adin2111_filter_multicast(const struct device *dev)
 static int adin2111_filter_broadcast(const struct device *dev)
 {
 	const struct adin2111_config *cfg = dev->config;
-	bool is_adin2111 = (cfg->id == ADIN2111_MAC);
+	const bool is_adin2111 = (cfg->id == ADIN2111_MAC);
 	uint8_t mac[NET_ETH_ADDR_LEN] = {0xFFU, 0xFFU, 0xFFU, 0xFFU, 0xFFU, 0xFFU};
 	uint32_t rules = ADIN2111_ADDR_APPLY2PORT1 |
 			 (is_adin2111 ? ADIN2111_ADDR_APPLY2PORT2 : 0) |
@@ -1129,7 +1129,7 @@ static int eth_adin2111_set_promiscuous(const struct device *dev, const uint16_t
 					bool enable)
 {
 	const struct adin2111_config *cfg = dev->config;
-	bool is_adin2111 = (cfg->id == ADIN2111_MAC);
+	const bool is_adin2111 = (cfg->id == ADIN2111_MAC);
 	uint32_t fwd_mask;
 
 	if ((!is_adin2111 && port_idx > 0) || (is_adin2111 && port_idx > 1)) {
@@ -1354,7 +1354,7 @@ int eth_adin2111_sw_reset(const struct device *dev, uint16_t delay)
 static int adin2111_init(const struct device *dev)
 {
 	const struct adin2111_config *cfg = dev->config;
-	bool is_adin2111 = (cfg->id == ADIN2111_MAC);
+	const bool is_adin2111 = (cfg->id == ADIN2111_MAC);
 	struct adin2111_data *ctx = dev->data;
 	int ret;
 	uint32_t val;

--- a/drivers/ethernet/eth_adin2111.c
+++ b/drivers/ethernet/eth_adin2111.c
@@ -697,7 +697,7 @@ static void adin2111_offload_thread(void *p1, void *p2, void *p3)
 					goto continue_unlock;
 				}
 			}
-			if (status1 & ADIN2111_STATUS1_P2_RX_RDY) {
+			if ((status1 & ADIN2111_STATUS1_P2_RX_RDY ) && is_adin2111) {
 				ret = eth_adin2111_oa_data_read(dev, 1);
 				if (ret < 0) {
 					goto continue_unlock;


### PR DESCRIPTION
Bug fixes:

* As [ADIN1110](https://www.analog.com/en/products/adin1110.html) supports OPEN Alliance (_OA_) protocol we must check if we have
ADIN2111 before processing port 2 related events (_i.e. port 2 oa rx_).
* If OA RX fails, then the offload thread is going to be terminated due to `break` usage.

Refactoring:

* Make `is_adin2111` a const and check if first before any other port 2 related check (_should help compilers to optimize it out_).
* Split OA and Generic SPI parts into if/else statement within offload thread (_eliminates extra oa check_).