### PR TITLE
boards/seeed/xiao_ble: Fix sleep pinning of qspi flash

### DIFF
--- a/boards/seeed/xiao_ble/xiao_ble_common.dtsi
+++ b/boards/seeed/xiao_ble/xiao_ble_common.dtsi
@@ -119,7 +119,7 @@
 &qspi {
 	status = "okay";
 	pinctrl-0 = <&qspi_default>;
-	pinctrl-1 = <&qspi_sleep>;
+	pinctrl-1 = <&qspi_default>;
 	pinctrl-names = "default", "sleep";
 	p25q16h: p25q16h@0 {
 		compatible = "nordic,qspi-nor";


### PR DESCRIPTION
I have empirically observed (with a Nordic PPK2) that changing the pinning to the default sleep pinning causes the board to consume ~6mA.

By using the default pinning when suspended, the power consumption is the expected one.

Used code to test it:

```C
#define XIAO_QSPI DT_ALIAS(spi_flash0)
static const struct device *qspi_dev = DEVICE_DT_GET(XIAO_QSPI);

static void init_peripherals(void)
{
	int err = pm_device_action_run(qspi_dev, PM_DEVICE_ACTION_SUSPEND);
	if (err) {
		printk("cannot suspend qspi device\n");
	}
}
```