### PR TITLE
boards: mikroe: remove CONFIG_PINCTRL from defconfig of RA4M1 clicker

### DIFF
--- a/boards/mikroe/clicker_ra4m1/mikroe_clicker_ra4m1_defconfig
+++ b/boards/mikroe/clicker_ra4m1/mikroe_clicker_ra4m1_defconfig
@@ -5,18 +5,15 @@ CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC=12000000
 
 CONFIG_BUILD_OUTPUT_HEX=y
 
-# enable uart driver
+# Enable uart driver
 CONFIG_SERIAL=y
 
-# enable console
+# Enable console
 CONFIG_CONSOLE=y
 CONFIG_UART_CONSOLE=y
 
-# enable GPIO
+# Enable GPIO
 CONFIG_GPIO=y
 
-# enable pin controller
-CONFIG_PINCTRL=y
-
-# enable Clocks
+# Enable Clocks
 CONFIG_CLOCK_CONTROL=y

--- a/drivers/serial/Kconfig.renesas_ra
+++ b/drivers/serial/Kconfig.renesas_ra
@@ -8,6 +8,7 @@ config UART_RENESAS_RA
 	depends on DT_HAS_RENESAS_RA_UART_SCI_ENABLED
 	select SERIAL_HAS_DRIVER
 	select SERIAL_SUPPORT_INTERRUPT
+	select PINCTRL
 	help
 	  Enable Renesas RA series UART driver.
 
@@ -20,6 +21,7 @@ config UART_SCI_RA
 	select SERIAL_SUPPORT_ASYNC
 	select USE_RA_FSP_SCI_UART
 	select USE_RA_FSP_DTC if UART_ASYNC_API
+	select PINCTRL
 	help
 	  Enable Renesas RA SCI UART Driver.
 


### PR DESCRIPTION
This PR fixes #78619 for the Mikroe RA4M1 Clicker board.