### PR TITLE
sensor: tree-wide: Enforce dependency of int-gpios with Trigger feature

### DIFF
--- a/drivers/sensor/adi/adt7310/Kconfig
+++ b/drivers/sensor/adi/adt7310/Kconfig
@@ -29,12 +29,16 @@ config ADT7310_TRIGGER_NONE
 
 config ADT7310_TRIGGER_GLOBAL_THREAD
 	bool "Use global thread"
+	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_ADI_ADT7310),int-gpios)
 	select ADT7310_TRIGGER
 	help
 	  Use a global thread for the interrupt handler.
 
 config ADT7310_TRIGGER_OWN_THREAD
 	bool "Use own thread"
+	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_ADI_ADT7310),int-gpios)
 	select ADT7310_TRIGGER
 	help
 	  Use a separate thread for the interrupt handler.

--- a/drivers/sensor/adi/adt7420/Kconfig
+++ b/drivers/sensor/adi/adt7420/Kconfig
@@ -43,11 +43,13 @@ config ADT7420_TRIGGER_NONE
 config ADT7420_TRIGGER_GLOBAL_THREAD
 	bool "Use global thread"
 	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_ADI_ADT7420),int-gpios)
 	select ADT7420_TRIGGER
 
 config ADT7420_TRIGGER_OWN_THREAD
 	bool "Use own thread"
 	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_ADI_ADT7420),int-gpios)
 	select ADT7420_TRIGGER
 
 endchoice

--- a/drivers/sensor/adi/adxl362/Kconfig
+++ b/drivers/sensor/adi/adxl362/Kconfig
@@ -70,11 +70,13 @@ config ADXL362_TRIGGER_NONE
 config ADXL362_TRIGGER_GLOBAL_THREAD
 	bool "Use global thread"
 	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_ADI_ADXL362),int1-gpios)
 	select ADXL362_TRIGGER
 
 config ADXL362_TRIGGER_OWN_THREAD
 	bool "Use own thread"
 	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_ADI_ADXL362),int1-gpios)
 	select ADXL362_TRIGGER
 
 endchoice

--- a/drivers/sensor/adi/adxl367/Kconfig
+++ b/drivers/sensor/adi/adxl367/Kconfig
@@ -104,11 +104,13 @@ config ADXL367_TRIGGER_NONE
 config ADXL367_TRIGGER_GLOBAL_THREAD
 	bool "Use global thread"
 	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_ADI_ADXL367),int1-gpios)
 	select ADXL367_TRIGGER
 
 config ADXL367_TRIGGER_OWN_THREAD
 	bool "Use own thread"
 	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_ADI_ADXL367),int1-gpios)
 	select ADXL367_TRIGGER
 
 endchoice

--- a/drivers/sensor/adi/adxl372/Kconfig
+++ b/drivers/sensor/adi/adxl372/Kconfig
@@ -95,11 +95,13 @@ config ADXL372_TRIGGER_NONE
 config ADXL372_TRIGGER_GLOBAL_THREAD
 	bool "Use global thread"
 	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_ADI_ADXL372),int1-gpios)
 	select ADXL372_TRIGGER
 
 config ADXL372_TRIGGER_OWN_THREAD
 	bool "Use own thread"
 	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_ADI_ADXL372),int1-gpios)
 	select ADXL372_TRIGGER
 
 endchoice

--- a/drivers/sensor/amg88xx/Kconfig
+++ b/drivers/sensor/amg88xx/Kconfig
@@ -25,11 +25,13 @@ config AMG88XX_TRIGGER_NONE
 config AMG88XX_TRIGGER_GLOBAL_THREAD
 	bool "Use global thread"
 	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_PANASONIC_AMG88XX),int-gpios)
 	select AMG88XX_TRIGGER
 
 config AMG88XX_TRIGGER_OWN_THREAD
 	bool "Use own thread"
 	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_PANASONIC_AMG88XX),int-gpios)
 	select AMG88XX_TRIGGER
 
 endchoice

--- a/drivers/sensor/ams/ccs811/Kconfig
+++ b/drivers/sensor/ams/ccs811/Kconfig
@@ -53,11 +53,13 @@ config CCS811_TRIGGER_NONE
 config CCS811_TRIGGER_GLOBAL_THREAD
 	bool "Use global thread"
 	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_AMS_CCS811),irq-gpios)
 	select CCS811_TRIGGER
 
 config CCS811_TRIGGER_OWN_THREAD
 	bool "Use own thread"
 	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_AMS_CCS811),irq-gpios)
 	select CCS811_TRIGGER
 
 endchoice

--- a/drivers/sensor/ams/tmd2620/Kconfig
+++ b/drivers/sensor/ams/tmd2620/Kconfig
@@ -23,6 +23,7 @@ config TMD2620_TRIGGER_NONE
 config TMD2620_TRIGGER_GLOBAL_THREAD
 	bool "Use global thread"
 	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_AMS_TMD2620),int-gpios)
 	select TMD2620_TRIGGER
 
 endchoice # Trigger Mode

--- a/drivers/sensor/ams/tsl2540/Kconfig
+++ b/drivers/sensor/ams/tsl2540/Kconfig
@@ -28,11 +28,13 @@ config TSL2540_TRIGGER_NONE
 config TSL2540_TRIGGER_GLOBAL_THREAD
 	bool "Use global thread"
 	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_AMS_TSL2540),int-gpios)
 	select TSL2540_TRIGGER
 
 config TSL2540_TRIGGER_OWN_THREAD
 	bool "Use own thread"
 	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_AMS_TSL2540),int-gpios)
 	select TSL2540_TRIGGER
 
 endchoice

--- a/drivers/sensor/ams/tsl2591/Kconfig
+++ b/drivers/sensor/ams/tsl2591/Kconfig
@@ -37,11 +37,13 @@ config TSL2591_TRIGGER_NONE
 config TSL2591_TRIGGER_GLOBAL_THREAD
 	bool "Use global thread"
 	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_AMS_TSL2591),int-gpios)
 	select TSL2591_TRIGGER
 
 config TSL2591_TRIGGER_OWN_THREAD
 	bool "Use own thread"
 	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_AMS_TSL2591),int-gpios)
 	select TSL2591_TRIGGER
 
 endchoice

--- a/drivers/sensor/apds9960/Kconfig
+++ b/drivers/sensor/apds9960/Kconfig
@@ -24,6 +24,7 @@ config APDS9960_TRIGGER_NONE
 config APDS9960_TRIGGER_GLOBAL_THREAD
 	bool "Use global thread"
 	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_AVAGO_APDS9960),int-gpios)
 	select APDS9960_TRIGGER
 
 endchoice

--- a/drivers/sensor/bosch/bma280/Kconfig
+++ b/drivers/sensor/bosch/bma280/Kconfig
@@ -26,11 +26,13 @@ config BMA280_TRIGGER_NONE
 config BMA280_TRIGGER_GLOBAL_THREAD
 	bool "Use global thread"
 	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_BOSCH_BMA280),int1-gpios)
 	select BMA280_TRIGGER
 
 config BMA280_TRIGGER_OWN_THREAD
 	bool "Use own thread"
 	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_BOSCH_BMA280),int1-gpios)
 	select BMA280_TRIGGER
 
 endchoice

--- a/drivers/sensor/bosch/bmc150_magn/Kconfig
+++ b/drivers/sensor/bosch/bmc150_magn/Kconfig
@@ -56,6 +56,7 @@ endmenu
 config BMC150_MAGN_TRIGGER
 	bool "Triggers"
 	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_BOSCH_BMC150_MAGN),drdy-gpios)
 	help
 	  Enable triggers for BMC150 magnetometer
 

--- a/drivers/sensor/bosch/bmg160/Kconfig
+++ b/drivers/sensor/bosch/bmg160/Kconfig
@@ -39,10 +39,14 @@ config BMG160_TRIGGER_NONE
 
 config BMG160_TRIGGER_GLOBAL_THREAD
 	bool "Use global thread"
+	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_BOSCH_BMG160),int-gpios)
 	select BMG160_TRIGGER
 
 config BMG160_TRIGGER_OWN_THREAD
 	bool "Use own thread"
+	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_BOSCH_BMG160),int-gpios)
 	select BMG160_TRIGGER
 endchoice
 

--- a/drivers/sensor/bosch/bmi08x/Kconfig
+++ b/drivers/sensor/bosch/bmi08x/Kconfig
@@ -28,10 +28,14 @@ config BMI08X_ACCEL_TRIGGER_NONE
 
 config BMI08X_ACCEL_TRIGGER_GLOBAL_THREAD
 	bool "Use global thread"
+	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_BOSCH_BMI08X_ACCEL),int-gpios)
 	select BMI08X_ACCEL_TRIGGER
 
 config BMI08X_ACCEL_TRIGGER_OWN_THREAD
 	bool "Use own thread"
+	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_BOSCH_BMI08X_ACCEL),int-gpios)
 	select BMI08X_ACCEL_TRIGGER
 endchoice
 

--- a/drivers/sensor/bosch/bmi160/Kconfig
+++ b/drivers/sensor/bosch/bmi160/Kconfig
@@ -26,10 +26,14 @@ config BMI160_TRIGGER_NONE
 
 config BMI160_TRIGGER_GLOBAL_THREAD
 	bool "Use global thread"
+	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_BOSCH_BMI160),int-gpios)
 	select BMI160_TRIGGER
 
 config BMI160_TRIGGER_OWN_THREAD
 	bool "Use own thread"
+	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_BOSCH_BMI160),int-gpios)
 	select BMI160_TRIGGER
 endchoice
 

--- a/drivers/sensor/bosch/bmi270/Kconfig
+++ b/drivers/sensor/bosch/bmi270/Kconfig
@@ -36,11 +36,13 @@ config BMI270_TRIGGER_NONE
 config BMI270_TRIGGER_GLOBAL_THREAD
 	bool "Use global thread"
 	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_BOSCH_BMI270),irq-gpios)
 	select BMI270_TRIGGER
 
 config BMI270_TRIGGER_OWN_THREAD
 	bool "Use own thread"
 	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_BOSCH_BMI270),irq-gpios)
 	select BMI270_TRIGGER
 
 endchoice

--- a/drivers/sensor/bosch/bmm150/Kconfig
+++ b/drivers/sensor/bosch/bmm150/Kconfig
@@ -44,14 +44,20 @@ config BMM150_TRIGGER_NONE
 
 config BMM150_TRIGGER_GLOBAL_THREAD
 	bool "Use global thread"
+	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_BOSCH_BMM150),drdy-gpios)
 	select BMM150_TRIGGER
 
 config BMM150_TRIGGER_OWN_THREAD
 	bool "Use own thread"
+	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_BOSCH_BMM150),drdy-gpios)
 	select BMM150_TRIGGER
 
 config BMM150_TRIGGER_DIRECT
 	bool "Use IRQ handler"
+	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_BOSCH_BMM150),drdy-gpios)
 	select BMM150_TRIGGER
 endchoice
 

--- a/drivers/sensor/bosch/bmp388/Kconfig
+++ b/drivers/sensor/bosch/bmp388/Kconfig
@@ -23,14 +23,20 @@ config BMP388_TRIGGER_NONE
 
 config BMP388_TRIGGER_GLOBAL_THREAD
 	bool "Use global thread"
+	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_BOSCH_BMP388),int-gpios)
 	select BMP388_TRIGGER
 
 config BMP388_TRIGGER_OWN_THREAD
 	bool "Use own thread"
+	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_BOSCH_BMP388),int-gpios)
 	select BMP388_TRIGGER
 
 config BMP388_TRIGGER_DIRECT
 	bool "Use IRQ handler"
+	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_BOSCH_BMP388),int-gpios)
 	select BMP388_TRIGGER
 endchoice
 

--- a/drivers/sensor/ens160/Kconfig
+++ b/drivers/sensor/ens160/Kconfig
@@ -24,11 +24,13 @@ config ENS160_TRIGGER_NONE
 config ENS160_TRIGGER_GLOBAL_THREAD
 	bool "Use global thread"
 	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_SCIOSENSE_ENS160),int-gpios)
 	select ENS160_TRIGGER
 
 config ENS160_TRIGGER_OWN_THREAD
 	bool "Use own thread"
 	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_SCIOSENSE_ENS160),int-gpios)
 	select ENS160_TRIGGER
 
 endchoice # Trigger Mode

--- a/drivers/sensor/grow_r502a/Kconfig
+++ b/drivers/sensor/grow_r502a/Kconfig
@@ -39,6 +39,7 @@ config GROW_R502A_TRIGGER_GLOBAL_THREAD
 config GROW_R502A_TRIGGER_OWN_THREAD
 	bool "Use own thread"
 	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_HZGROW_R502A),int-gpios)
 	select GROW_R502A_TRIGGER
 
 endchoice

--- a/drivers/sensor/honeywell/hmc5883l/Kconfig
+++ b/drivers/sensor/honeywell/hmc5883l/Kconfig
@@ -23,11 +23,13 @@ config HMC5883L_TRIGGER_NONE
 config HMC5883L_TRIGGER_GLOBAL_THREAD
 	bool "Use global thread"
 	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_HONEYWELL_HMC5883L),int-gpios)
 	select HMC5883L_TRIGGER
 
 config HMC5883L_TRIGGER_OWN_THREAD
 	bool "Use own thread"
 	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_HONEYWELL_HMC5883L),int-gpios)
 	select HMC5883L_TRIGGER
 
 endchoice

--- a/drivers/sensor/jedec/jc42/Kconfig
+++ b/drivers/sensor/jedec/jc42/Kconfig
@@ -23,11 +23,13 @@ config JC42_TRIGGER_NONE
 
 config JC42_TRIGGER_GLOBAL_THREAD
 	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_JEDEC_JC_42_4_TEMP),int-gpios)
 	select JC42_TRIGGER
 	bool "Use global thread"
 
 config JC42_TRIGGER_OWN_THREAD
 	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_JEDEC_JC_42_4_TEMP),int-gpios)
 	select JC42_TRIGGER
 	bool "Use own thread"
 

--- a/drivers/sensor/lm77/Kconfig
+++ b/drivers/sensor/lm77/Kconfig
@@ -3,7 +3,7 @@
 # Copyright (c) 2021 Vestas Wind Systems A/S
 # SPDX-License-Identifier: Apache-2.0
 
-menuconfig LM77
+config LM77
 	bool "LM77 Temperature Sensor"
 	default y
 	depends on DT_HAS_LM77_ENABLED
@@ -13,9 +13,10 @@ menuconfig LM77
 	  Enable driver for the LM77 digital temperature sensor with 2-wire
 	  interface.
 
+if LM77
+
 config LM77_TRIGGER
 	bool "Trigger support"
-	depends on LM77
 	depends on GPIO
 	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_LM77),int-gpios)
 	default y
@@ -41,3 +42,4 @@ config LM77_TRIGGER_THREAD_PRIO
 	  Priority level for the internal trigger workqueue thread.
 
 endif # LM77_TRIGGER
+endif # LM77

--- a/drivers/sensor/lm77/Kconfig
+++ b/drivers/sensor/lm77/Kconfig
@@ -16,6 +16,8 @@ menuconfig LM77
 config LM77_TRIGGER
 	bool "Trigger support"
 	depends on LM77
+	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_LM77),int-gpios)
 	default y
 	help
 	  Enable trigger support for the LM77 digital temperature sensor.

--- a/drivers/sensor/memsic/mc3419/Kconfig
+++ b/drivers/sensor/memsic/mc3419/Kconfig
@@ -14,6 +14,8 @@ if MC3419
 
 config MC3419_TRIGGER
 	bool "Trigger mode"
+	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_MEMSIC_MC3419),int-gpios)
 
 choice MC3419_TRIGGER_MODE
 	prompt "Trigger mode"

--- a/drivers/sensor/microchip/tcn75a/Kconfig
+++ b/drivers/sensor/microchip/tcn75a/Kconfig
@@ -20,10 +20,14 @@ config TCN75A_TRIGGER_NONE
 
 config TCN75A_TRIGGER_OWN_THREAD
 	bool "Use own thread"
+	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_MICROCHIP_TCN75A),alert-gpios)
 	select TCN75A_TRIGGER
 
 config TCN75A_TRIGGER_GLOBAL_THREAD
 	bool "Use global thread"
+	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_MICROCHIP_TCN75A),alert-gpios)
 	select TCN75A_TRIGGER
 
 endchoice

--- a/drivers/sensor/nxp/fxas21002/Kconfig
+++ b/drivers/sensor/nxp/fxas21002/Kconfig
@@ -58,6 +58,9 @@ config FXAS21002_TRIGGER_NONE
 
 config FXAS21002_TRIGGER_GLOBAL_THREAD
 	bool "Use global thread"
+	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_NXP_FXAS21002),int1-gpios) ||\
+		   $(dt_compat_any_has_prop,$(DT_COMPAT_NXP_FXAS21002),int2-gpios)
 	select FXAS21002_TRIGGER
 
 config FXAS21002_TRIGGER_OWN_THREAD

--- a/drivers/sensor/nxp/fxls8974/Kconfig
+++ b/drivers/sensor/nxp/fxls8974/Kconfig
@@ -23,6 +23,9 @@ config FXLS8974_TRIGGER_NONE
 
 config FXLS8974_TRIGGER_GLOBAL_THREAD
 	bool "Use global thread"
+	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_NXP_FXLS8974),int1-gpios) || \
+		   $(dt_compat_any_has_prop,$(DT_COMPAT_NXP_FXLS8974),int2-gpios)
 	select FXLS8974_TRIGGER
 
 config FXLS8974_TRIGGER_OWN_THREAD

--- a/drivers/sensor/nxp/fxos8700/Kconfig
+++ b/drivers/sensor/nxp/fxos8700/Kconfig
@@ -49,6 +49,9 @@ config FXOS8700_TRIGGER_NONE
 
 config FXOS8700_TRIGGER_GLOBAL_THREAD
 	bool "Use global thread"
+	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_NXP_FXOS8700),int1-gpios) ||\
+		   $(dt_compat_any_has_prop,$(DT_COMPAT_NXP_FXOS8700),int2-gpios)
 	select FXOS8700_TRIGGER
 
 config FXOS8700_TRIGGER_OWN_THREAD

--- a/drivers/sensor/renesas/isl29035/Kconfig
+++ b/drivers/sensor/renesas/isl29035/Kconfig
@@ -94,11 +94,13 @@ config ISL29035_TRIGGER_NONE
 config ISL29035_TRIGGER_GLOBAL_THREAD
 	bool "Use global thread"
 	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_ISIL_ISL29035),int-gpios)
 	select ISL29035_TRIGGER
 
 config ISL29035_TRIGGER_OWN_THREAD
 	bool "Use own thread"
 	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_ISIL_ISL29035),int-gpios)
 	select ISL29035_TRIGGER
 
 endchoice

--- a/drivers/sensor/sensirion/sht3xd/Kconfig
+++ b/drivers/sensor/sensirion/sht3xd/Kconfig
@@ -26,11 +26,13 @@ config SHT3XD_TRIGGER_NONE
 config SHT3XD_TRIGGER_GLOBAL_THREAD
 	bool "Use global thread"
 	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_SENSIRION_SHT3XD),alert-gpios)
 	select SHT3XD_TRIGGER
 
 config SHT3XD_TRIGGER_OWN_THREAD
 	bool "Use own thread"
 	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_SENSIRION_SHT3XD),alert-gpios)
 	select SHT3XD_TRIGGER
 
 endchoice

--- a/drivers/sensor/st/hts221/Kconfig
+++ b/drivers/sensor/st/hts221/Kconfig
@@ -27,11 +27,13 @@ config HTS221_TRIGGER_NONE
 config HTS221_TRIGGER_GLOBAL_THREAD
 	bool "Use global thread"
 	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_ST_HTS221),drdy-gpios)
 	select HTS221_TRIGGER
 
 config HTS221_TRIGGER_OWN_THREAD
 	bool "Use own thread"
 	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_ST_HTS221),drdy-gpios)
 	select HTS221_TRIGGER
 
 endchoice # HTS221_TRIGGER_MODE

--- a/drivers/sensor/st/iis2dh/Kconfig
+++ b/drivers/sensor/st/iis2dh/Kconfig
@@ -28,11 +28,13 @@ config IIS2DH_TRIGGER_NONE
 config IIS2DH_TRIGGER_GLOBAL_THREAD
 	bool "Use global thread"
 	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_ST_IIS2DH),drdy-gpios)
 	select IIS2DH_TRIGGER
 
 config IIS2DH_TRIGGER_OWN_THREAD
 	bool "Use own thread"
 	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_ST_IIS2DH),drdy-gpios)
 	select IIS2DH_TRIGGER
 
 endchoice

--- a/drivers/sensor/st/iis2dlpc/Kconfig
+++ b/drivers/sensor/st/iis2dlpc/Kconfig
@@ -28,11 +28,13 @@ config IIS2DLPC_TRIGGER_NONE
 config IIS2DLPC_TRIGGER_GLOBAL_THREAD
 	bool "Use global thread"
 	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_ST_IIS2DLPC),drdy-gpios)
 	select IIS2DLPC_TRIGGER
 
 config IIS2DLPC_TRIGGER_OWN_THREAD
 	bool "Use own thread"
 	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_ST_IIS2DLPC),drdy-gpios)
 	select IIS2DLPC_TRIGGER
 
 endchoice

--- a/drivers/sensor/st/iis2iclx/Kconfig
+++ b/drivers/sensor/st/iis2iclx/Kconfig
@@ -29,11 +29,13 @@ config IIS2ICLX_TRIGGER_NONE
 config IIS2ICLX_TRIGGER_GLOBAL_THREAD
 	bool "Use global thread"
 	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_ST_IIS2ICLX),drdy-gpios)
 	select IIS2ICLX_TRIGGER
 
 config IIS2ICLX_TRIGGER_OWN_THREAD
 	bool "Use own thread"
 	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_ST_IIS2ICLX),drdy-gpios)
 	select IIS2ICLX_TRIGGER
 
 endchoice

--- a/drivers/sensor/st/iis2mdc/Kconfig
+++ b/drivers/sensor/st/iis2mdc/Kconfig
@@ -27,11 +27,13 @@ config IIS2MDC_TRIGGER_NONE
 config IIS2MDC_TRIGGER_GLOBAL_THREAD
 	bool "Use global thread"
 	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_ST_IIS2MDC),drdy-gpios)
 	select IIS2MDC_TRIGGER
 
 config IIS2MDC_TRIGGER_OWN_THREAD
 	bool "Use own thread"
 	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_ST_IIS2MDC),drdy-gpios)
 	select IIS2MDC_TRIGGER
 
 endchoice # IIS2MDC_TRIGGER_MODE

--- a/drivers/sensor/st/iis3dhhc/Kconfig
+++ b/drivers/sensor/st/iis3dhhc/Kconfig
@@ -28,11 +28,13 @@ config IIS3DHHC_TRIGGER_NONE
 config IIS3DHHC_TRIGGER_GLOBAL_THREAD
 	bool "Use global thread"
 	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_ST_IIS3DHHC),irq-gpios)
 	select IIS3DHHC_TRIGGER
 
 config IIS3DHHC_TRIGGER_OWN_THREAD
 	bool "Use own thread"
 	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_ST_IIS3DHHC),irq-gpios)
 	select IIS3DHHC_TRIGGER
 
 endchoice # IIS3DHHC_TRIGGER_MODE

--- a/drivers/sensor/st/ism330dhcx/Kconfig
+++ b/drivers/sensor/st/ism330dhcx/Kconfig
@@ -29,11 +29,13 @@ config ISM330DHCX_TRIGGER_NONE
 config ISM330DHCX_TRIGGER_GLOBAL_THREAD
 	bool "Use global thread"
 	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_ST_ISM330DHCX),drdy-gpios)
 	select ISM330DHCX_TRIGGER
 
 config ISM330DHCX_TRIGGER_OWN_THREAD
 	bool "Use own thread"
 	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_ST_ISM330DHCX),drdy-gpios)
 	select ISM330DHCX_TRIGGER
 
 endchoice

--- a/drivers/sensor/st/lis2dh/Kconfig
+++ b/drivers/sensor/st/lis2dh/Kconfig
@@ -26,11 +26,13 @@ config LIS2DH_TRIGGER_NONE
 config LIS2DH_TRIGGER_GLOBAL_THREAD
 	bool "Use global thread"
 	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_ST_LIS2DH),irq-gpios)
 	select LIS2DH_TRIGGER
 
 config LIS2DH_TRIGGER_OWN_THREAD
 	bool "Use own thread"
 	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_ST_LIS2DH),irq-gpios)
 	select LIS2DH_TRIGGER
 
 endchoice

--- a/drivers/sensor/st/lis2ds12/Kconfig
+++ b/drivers/sensor/st/lis2ds12/Kconfig
@@ -28,11 +28,13 @@ config LIS2DS12_TRIGGER_NONE
 config LIS2DS12_TRIGGER_GLOBAL_THREAD
 	bool "Use global thread"
 	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_ST_LIS2DS12),irq-gpios)
 	select LIS2DS12_TRIGGER
 
 config LIS2DS12_TRIGGER_OWN_THREAD
 	bool "Use own thread"
 	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_ST_LIS2DS12),irq-gpios)
 	select LIS2DS12_TRIGGER
 
 endchoice

--- a/drivers/sensor/st/lis2dw12/Kconfig
+++ b/drivers/sensor/st/lis2dw12/Kconfig
@@ -28,11 +28,13 @@ config LIS2DW12_TRIGGER_NONE
 config LIS2DW12_TRIGGER_GLOBAL_THREAD
 	bool "Use global thread"
 	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_ST_LIS2DW12),irq-gpios)
 	select LIS2DW12_TRIGGER
 
 config LIS2DW12_TRIGGER_OWN_THREAD
 	bool "Use own thread"
 	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_ST_LIS2DW12),irq-gpios)
 	select LIS2DW12_TRIGGER
 
 endchoice

--- a/drivers/sensor/st/lis2mdl/Kconfig
+++ b/drivers/sensor/st/lis2mdl/Kconfig
@@ -27,11 +27,13 @@ config LIS2MDL_TRIGGER_NONE
 config LIS2MDL_TRIGGER_GLOBAL_THREAD
 	bool "Use global thread"
 	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_ST_LIS2MDL),irq-gpios)
 	select LIS2MDL_TRIGGER
 
 config LIS2MDL_TRIGGER_OWN_THREAD
 	bool "Use own thread"
 	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_ST_LIS2MDL),irq-gpios)
 	select LIS2MDL_TRIGGER
 
 endchoice # LIS2MDL_TRIGGER_MODE

--- a/drivers/sensor/st/lis3mdl/Kconfig
+++ b/drivers/sensor/st/lis3mdl/Kconfig
@@ -23,11 +23,13 @@ config LIS3MDL_TRIGGER_NONE
 config LIS3MDL_TRIGGER_GLOBAL_THREAD
 	bool "Use global thread"
 	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_ST_LIS3MDL_MAGN),irq-gpios)
 	select LIS3MDL_TRIGGER
 
 config LIS3MDL_TRIGGER_OWN_THREAD
 	bool "Use own thread"
 	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_ST_LIS3MDL_MAGN),irq-gpios)
 	select LIS3MDL_TRIGGER
 
 endchoice # LIS3MDL_TRIGGER_MODE

--- a/drivers/sensor/st/lps22hh/Kconfig
+++ b/drivers/sensor/st/lps22hh/Kconfig
@@ -31,11 +31,13 @@ config LPS22HH_TRIGGER_NONE
 config LPS22HH_TRIGGER_GLOBAL_THREAD
 	bool "Use global thread"
 	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_ST_LPS22HH),drdy-gpios)
 	select LPS22HH_TRIGGER
 
 config LPS22HH_TRIGGER_OWN_THREAD
 	bool "Use own thread"
 	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_ST_LPS22HH),drdy-gpios)
 	select LPS22HH_TRIGGER
 
 endchoice # LPS22HH_TRIGGER_MODE

--- a/drivers/sensor/st/lps2xdf/Kconfig
+++ b/drivers/sensor/st/lps2xdf/Kconfig
@@ -35,6 +35,8 @@ config LPS2XDF_TRIGGER_NONE
 config LPS2XDF_TRIGGER_GLOBAL_THREAD
 	bool "Use global thread"
 	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_ST_LPS22DF),drdy-gpios) ||\
+		   $(dt_compat_any_has_prop,$(DT_COMPAT_ST_LPS28DFW),drdy-gpios)
 	select LPS2XDF_TRIGGER
 
 config LPS2XDF_TRIGGER_OWN_THREAD

--- a/drivers/sensor/st/lsm6dsl/Kconfig
+++ b/drivers/sensor/st/lsm6dsl/Kconfig
@@ -27,11 +27,13 @@ config LSM6DSL_TRIGGER_NONE
 config LSM6DSL_TRIGGER_GLOBAL_THREAD
 	bool "Use global thread"
 	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_ST_LSM6DSL),irq-gpios)
 	select LSM6DSL_TRIGGER
 
 config LSM6DSL_TRIGGER_OWN_THREAD
 	bool "Use own thread"
 	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_ST_LSM6DSL),irq-gpios)
 	select LSM6DSL_TRIGGER
 
 endchoice

--- a/drivers/sensor/st/lsm6dso/Kconfig
+++ b/drivers/sensor/st/lsm6dso/Kconfig
@@ -29,6 +29,7 @@ config LSM6DSO_TRIGGER_NONE
 config LSM6DSO_TRIGGER_GLOBAL_THREAD
 	bool "Use global thread"
 	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_ST_LSM6DSO),irq-gpios)
 	select LSM6DSO_TRIGGER
 
 config LSM6DSO_TRIGGER_OWN_THREAD

--- a/drivers/sensor/st/lsm6dso16is/Kconfig
+++ b/drivers/sensor/st/lsm6dso16is/Kconfig
@@ -29,11 +29,13 @@ config LSM6DSO16IS_TRIGGER_NONE
 config LSM6DSO16IS_TRIGGER_GLOBAL_THREAD
 	bool "Use global thread"
 	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_ST_LSM6DSO16IS),irq-gpios)
 	select LSM6DSO16IS_TRIGGER
 
 config LSM6DSO16IS_TRIGGER_OWN_THREAD
 	bool "Use own thread"
 	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_ST_LSM6DSO16IS),irq-gpios)
 	select LSM6DSO16IS_TRIGGER
 
 endchoice

--- a/drivers/sensor/st/lsm6dsv16x/Kconfig
+++ b/drivers/sensor/st/lsm6dsv16x/Kconfig
@@ -29,11 +29,15 @@ config LSM6DSV16X_TRIGGER_NONE
 config LSM6DSV16X_TRIGGER_GLOBAL_THREAD
 	bool "Use global thread"
 	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_ST_LSM6DSV16X),int1-gpios) ||\
+		   $(dt_compat_any_has_prop,$(DT_COMPAT_ST_LSM6DSV16X),int2-gpios)
 	select LSM6DSV16X_TRIGGER
 
 config LSM6DSV16X_TRIGGER_OWN_THREAD
 	bool "Use own thread"
 	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_ST_LSM6DSV16X),int1-gpios) ||\
+		   $(dt_compat_any_has_prop,$(DT_COMPAT_ST_LSM6DSV16X),int2-gpios)
 	select LSM6DSV16X_TRIGGER
 
 endchoice

--- a/drivers/sensor/st/lsm9ds0_gyro/Kconfig
+++ b/drivers/sensor/st/lsm9ds0_gyro/Kconfig
@@ -67,6 +67,7 @@ endmenu
 config LSM9DS0_GYRO_TRIGGERS
 	bool "Triggers"
 	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_ST_LSM9DS0_GYRO),irq-gpios)
 
 config LSM9DS0_GYRO_THREAD_STACK_SIZE
 	int "Thread stack size"

--- a/drivers/sensor/st/stts751/Kconfig
+++ b/drivers/sensor/st/stts751/Kconfig
@@ -28,11 +28,13 @@ config STTS751_TRIGGER_NONE
 config STTS751_TRIGGER_GLOBAL_THREAD
 	bool "Use global thread"
 	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_ST_STTS751),drdy-gpios)
 	select STTS751_TRIGGER
 
 config STTS751_TRIGGER_OWN_THREAD
 	bool "Use own thread"
 	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_ST_STTS751),drdy-gpios)
 	select STTS751_TRIGGER
 
 endchoice # STTS751_TRIGGER_MODE

--- a/drivers/sensor/sx9500/Kconfig
+++ b/drivers/sensor/sx9500/Kconfig
@@ -29,11 +29,13 @@ config SX9500_TRIGGER_NONE
 
 config SX9500_TRIGGER_GLOBAL_THREAD
 	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_SEMTECH_SX9500),int-gpios)
 	select SX9500_TRIGGER
 	bool "Use global thread"
 
 config SX9500_TRIGGER_OWN_THREAD
 	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_SEMTECH_SX9500),int-gpios)
 	select SX9500_TRIGGER
 	bool "Use own thread"
 

--- a/drivers/sensor/tdk/icm42605/Kconfig
+++ b/drivers/sensor/tdk/icm42605/Kconfig
@@ -25,6 +25,7 @@ config ICM42605_TRIGGER_NONE
 config ICM42605_TRIGGER_GLOBAL_THREAD
 	bool "Use global thread"
 	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_INVENSENSE_ICM42605),int-gpios)
 	select ICM42605_TRIGGER
 
 endchoice

--- a/drivers/sensor/tdk/icm42670/Kconfig
+++ b/drivers/sensor/tdk/icm42670/Kconfig
@@ -28,11 +28,13 @@ config ICM42670_TRIGGER_NONE
 config ICM42670_TRIGGER_GLOBAL_THREAD
 	bool "Use global thread"
 	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_INVENSENSE_ICM42670),int-gpios)
 	select ICM42670_TRIGGER
 
 config ICM42670_TRIGGER_OWN_THREAD
 	bool "Use own thread"
 	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_INVENSENSE_ICM42670),int-gpios)
 	select ICM42670_TRIGGER
 
 endchoice

--- a/drivers/sensor/tdk/icm42688/Kconfig
+++ b/drivers/sensor/tdk/icm42688/Kconfig
@@ -44,10 +44,14 @@ config ICM42688_TRIGGER_NONE
 
 config ICM42688_TRIGGER_GLOBAL_THREAD
 	bool "Use global thread"
+	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_INVENSENSE_ICM42688),int-gpios)
 	select ICM42688_TRIGGER
 
 config ICM42688_TRIGGER_OWN_THREAD
 	bool "Use own thread"
+	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_INVENSENSE_ICM42688),int-gpios)
 	select ICM42688_TRIGGER
 
 endchoice

--- a/drivers/sensor/tdk/mpu6050/Kconfig
+++ b/drivers/sensor/tdk/mpu6050/Kconfig
@@ -25,11 +25,13 @@ config MPU6050_TRIGGER_NONE
 config MPU6050_TRIGGER_GLOBAL_THREAD
 	bool "Use global thread"
 	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_INVENSENSE_MPU6050),int-gpios)
 	select MPU6050_TRIGGER
 
 config MPU6050_TRIGGER_OWN_THREAD
 	bool "Use own thread"
 	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_INVENSENSE_MPU6050),int-gpios)
 	select MPU6050_TRIGGER
 
 endchoice

--- a/drivers/sensor/tdk/mpu9250/Kconfig
+++ b/drivers/sensor/tdk/mpu9250/Kconfig
@@ -25,11 +25,13 @@ config MPU9250_TRIGGER_NONE
 config MPU9250_TRIGGER_GLOBAL_THREAD
 	bool "Use global thread"
 	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_INVENSENSE_MPU9250),irq-gpios)
 	select MPU9250_TRIGGER
 
 config MPU9250_TRIGGER_OWN_THREAD
 	bool "Use own thread"
 	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_INVENSENSE_MPU9250),irq-gpios)
 	select MPU9250_TRIGGER
 
 endchoice

--- a/drivers/sensor/ti/bq274xx/Kconfig
+++ b/drivers/sensor/ti/bq274xx/Kconfig
@@ -33,10 +33,14 @@ config BQ274XX_TRIGGER_NONE
 
 config BQ274XX_TRIGGER_GLOBAL_THREAD
 	bool "Use global thread"
+	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_TI_BQ274XX),int-gpios)
 	select BQ274XX_TRIGGER
 
 config BQ274XX_TRIGGER_OWN_THREAD
 	bool "Use own thread"
+	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_TI_BQ274XX),int-gpios)
 	select BQ274XX_TRIGGER
 
 endchoice # BQ274XX_TRIGGER_MODE

--- a/drivers/sensor/ti/fdc2x1x/Kconfig
+++ b/drivers/sensor/ti/fdc2x1x/Kconfig
@@ -26,11 +26,13 @@ config FDC2X1X_TRIGGER_NONE
 config FDC2X1X_TRIGGER_GLOBAL_THREAD
 	bool "Use global thread"
 	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_TI_FDC2X1X),intb-gpios)
 	select FDC2X1X_TRIGGER
 
 config FDC2X1X_TRIGGER_OWN_THREAD
 	bool "Use own thread"
 	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_TI_FDC2X1X),intb-gpios)
 	select FDC2X1X_TRIGGER
 
 endchoice

--- a/drivers/sensor/ti/ina23x/Kconfig
+++ b/drivers/sensor/ti/ina23x/Kconfig
@@ -43,6 +43,8 @@ config INA237_VSHUNT
 config INA230_TRIGGER
 	bool "INA230 trigger mode"
 	depends on INA230
+	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_TI_INA230),alert-gpios)
 	help
 	  Set to enable trigger mode using gpio interrupt, where
 	  interrupts are configured to line ALERT PIN.

--- a/drivers/sensor/ti/tmag5170/Kconfig
+++ b/drivers/sensor/ti/tmag5170/Kconfig
@@ -24,16 +24,19 @@ config TMAG5170_TRIGGER_NONE
 config TMAG5170_TRIGGER_GLOBAL_THREAD
 	bool "Use global thread"
 	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_TI_TMAG5170),int-gpios)
 	select TMAG5170_TRIGGER
 
 config TMAG5170_TRIGGER_OWN_THREAD
 	bool "Use own thread"
 	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_TI_TMAG5170),int-gpios)
 	select TMAG5170_TRIGGER
 
 config TMAG5170_TRIGGER_DIRECT
 	bool "Process trigger within interrupt context"
 	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_TI_TMAG5170),int-gpios)
 	select TMAG5170_TRIGGER
 
 endchoice

--- a/drivers/sensor/ti/tmp007/Kconfig
+++ b/drivers/sensor/ti/tmp007/Kconfig
@@ -25,11 +25,13 @@ config TMP007_TRIGGER_NONE
 config TMP007_TRIGGER_GLOBAL_THREAD
 	bool "Use global thread"
 	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_TI_TMP007),int-gpios)
 	select TMP007_TRIGGER
 
 config TMP007_TRIGGER_OWN_THREAD
 	bool "Use own thread"
 	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_TI_TMP007),int-gpios)
 	select TMP007_TRIGGER
 
 endchoice

--- a/drivers/sensor/vishay/vcnl4040/Kconfig
+++ b/drivers/sensor/vishay/vcnl4040/Kconfig
@@ -33,11 +33,13 @@ config VCNL4040_TRIGGER_NONE
 config VCNL4040_TRIGGER_GLOBAL_THREAD
 	bool "Use global thread"
 	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_VISHAY_VCNL4040),int-gpios)
 	select VCNL4040_TRIGGER
 
 config VCNL4040_TRIGGER_OWN_THREAD
 	bool "Use own thread"
 	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_VISHAY_VCNL4040),int-gpios)
 	select VCNL4040_TRIGGER
 
 endchoice

--- a/tests/drivers/build_all/sensor/spi.dtsi
+++ b/tests/drivers/build_all/sensor/spi.dtsi
@@ -199,6 +199,7 @@ test_spi_icm426888: icm42688@1a {
 	compatible = "invensense,icm42688";
 	reg = <0x1a>;
 	spi-max-frequency = <24000000>;
+	int-gpios = <&test_gpio 0 0>;
 };
 
 test_spi_max31855: max31855@1b {


### PR DESCRIPTION
### Description
This PR follows-up suggestion brought up on https://github.com/zephyrproject-rtos/zephyr/pull/74342#pullrequestreview-2139279450 by extending this pattern throughout the tree.

### Changes
- Extend int-gpio pattern to all sensors.
- Add missing int-gpios to ICM42688 which is required for trigger modes support.

> [!NOTE]
> This pattern has not been yet applied to instances using `Kconfig.trigger_template`.