### PR TITLE
net: shell: Make stack size for event_mon_stack configurable

### DIFF
--- a/subsys/net/ip/Kconfig.mgmt
+++ b/subsys/net/ip/Kconfig.mgmt
@@ -105,6 +105,13 @@ config NET_MGMT_EVENT_MONITOR
 	  NET_MGMT_EVENT_QUEUE_SIZE from the default in order not to miss
 	  any events.
 
+config NET_MGMT_EVENT_MONITOR_STACK_SIZE
+	int "Size of the stack allocated for the event_mon_stack thread"
+	depends on NET_MGMT_EVENT_MONITOR
+	default 1024
+	help
+	  Sets the size of the stack for event_mon_stack_thread.
+
 config NET_MGMT_EVENT_MONITOR_AUTO_START
 	bool "Start the event monitor automatically at boot"
 	depends on NET_MGMT_EVENT_MONITOR && SHELL_BACKEND_SERIAL

--- a/subsys/net/lib/shell/events.c
+++ b/subsys/net/lib/shell/events.c
@@ -17,7 +17,6 @@ LOG_MODULE_DECLARE(net_shell);
 #include "net_shell_private.h"
 
 #if defined(CONFIG_NET_MGMT_EVENT_MONITOR)
-#define EVENT_MON_STACK_SIZE 1024
 #define THREAD_PRIORITY K_PRIO_COOP(2)
 #define MAX_EVENT_INFO_SIZE NET_EVENT_INFO_MAX_SIZE
 #define MONITOR_L2_MASK (_NET_EVENT_IF_BASE)
@@ -32,7 +31,7 @@ static struct net_mgmt_event_callback l3_ipv4_cb;
 static struct net_mgmt_event_callback l3_ipv6_cb;
 static struct net_mgmt_event_callback l4_cb;
 static struct k_thread event_mon;
-static K_THREAD_STACK_DEFINE(event_mon_stack, EVENT_MON_STACK_SIZE);
+static K_THREAD_STACK_DEFINE(event_mon_stack, CONFIG_NET_MGMT_EVENT_MONITOR_STACK_SIZE);
 
 struct event_msg {
 	struct net_if *iface;


### PR DESCRIPTION
The stack size for the event_mon_stack task may need to be larger than the default 1024 to avoid crashes. It should be configurable through Kconfig so that source code doesn't need to be modified to increase it.