### PR TITLE
logging: dictionary: Support unsigned integers

### DIFF
--- a/scripts/logging/dictionary/dictionary_parser/data_types.py
+++ b/scripts/logging/dictionary/dictionary_parser/data_types.py
@@ -30,14 +30,19 @@ class DataTypes():
 
         if database.is_tgt_64bit():
             self.add_data_type(self.LONG, "q")
+            self.add_data_type(self.ULONG, "Q")
             self.add_data_type(self.LONG_LONG, "q")
+            self.add_data_type(self.ULONG_LONG, "Q")
             self.add_data_type(self.PTR, "Q")
         else:
             self.add_data_type(self.LONG, "i")
+            self.add_data_type(self.ULONG, "I")
             self.add_data_type(self.LONG_LONG, "q")
+            self.add_data_type(self.ULONG_LONG, "Q")
             self.add_data_type(self.PTR, "I")
 
         self.add_data_type(self.INT, "i")
+        self.add_data_type(self.UINT, "I")
         self.add_data_type(self.DOUBLE, "d")
         self.add_data_type(self.LONG_DOUBLE, "d")
 

--- a/scripts/logging/dictionary/dictionary_parser/log_parser_v1.py
+++ b/scripts/logging/dictionary/dictionary_parser/log_parser_v1.py
@@ -141,14 +141,16 @@ class LogParserV1(LogParser):
                 # intmax_t, size_t or ptrdiff_t
                 arg_data_type = DataTypes.LONG
 
-            elif fmt in ('c', 'd', 'i', 'o', 'u') or str.lower(fmt) == 'x':
+            elif fmt in ('c', 'd', 'i', 'o', 'u', 'x', 'X'):
+                unsigned = fmt in ('c', 'o', 'u', 'x', 'X')
+
                 if fmt_str[idx - 1] == 'l':
                     if fmt_str[idx - 2] == 'l':
-                        arg_data_type = DataTypes.LONG_LONG
+                        arg_data_type = DataTypes.ULONG_LONG if unsigned else DataTypes.LONG_LONG
                     else:
-                        arg_data_type = DataTypes.LONG
+                        arg_data_type = DataTypes.ULONG if unsigned else DataTypes.LONG
                 else:
-                    arg_data_type = DataTypes.INT
+                    arg_data_type = DataTypes.UINT if unsigned else DataTypes.INT
 
                 is_parsing = False
                 do_extract = True

--- a/scripts/logging/dictionary/dictionary_parser/log_parser_v3.py
+++ b/scripts/logging/dictionary/dictionary_parser/log_parser_v3.py
@@ -146,14 +146,16 @@ class LogParserV3(LogParser):
                 # intmax_t, size_t or ptrdiff_t
                 arg_data_type = DataTypes.LONG
 
-            elif fmt in ('c', 'd', 'i', 'o', 'u') or str.lower(fmt) == 'x':
+            elif fmt in ('c', 'd', 'i', 'o', 'u', 'x', 'X'):
+                unsigned = fmt in ('c', 'o', 'u', 'x', 'X')
+
                 if fmt_str[idx - 1] == 'l':
                     if fmt_str[idx - 2] == 'l':
-                        arg_data_type = DataTypes.LONG_LONG
+                        arg_data_type = DataTypes.ULONG_LONG if unsigned else DataTypes.LONG_LONG
                     else:
-                        arg_data_type = DataTypes.LONG
+                        arg_data_type = DataTypes.ULONG if unsigned else DataTypes.LONG
                 else:
-                    arg_data_type = DataTypes.INT
+                    arg_data_type = DataTypes.UINT if unsigned else DataTypes.INT
 
                 is_parsing = False
                 do_extract = True


### PR DESCRIPTION
Add unsigned integer support to the log parser.

This does not change the underlying log format,
it only allows the log parser to more accurately
read the log format.