### PR TITLE
boards: shields: Add EVAL-ADXL372-ARDZ accelerometer shield

### DIFF
--- a/boards/adi/apard32690/apard32690_max32690_m4.dts
+++ b/boards/adi/apard32690/apard32690_max32690_m4.dts
@@ -133,6 +133,22 @@ arduino_serial: &uart1 {
 	current-speed = <115200>;
 };
 
+&spi1a_miso_p1_28 {
+	power-source = <MAX32_VSEL_VDDIOH>;
+};
+
+&spi1a_mosi_p1_29 {
+	power-source = <MAX32_VSEL_VDDIOH>;
+};
+
+&spi1a_sck_p1_26 {
+	power-source = <MAX32_VSEL_VDDIOH>;
+};
+
+&spi1a_ss0_p1_23 {
+	power-source = <MAX32_VSEL_VDDIOH>;
+};
+
 arduino_spi: &spi1 {
 	pinctrl-0 = <&spi1a_miso_p1_28 &spi1a_mosi_p1_29 &spi1a_sck_p1_26
 		     &spi1a_ss0_p1_23>;

--- a/boards/adi/apard32690/apard32690_max32690_m4.dts
+++ b/boards/adi/apard32690/apard32690_max32690_m4.dts
@@ -53,6 +53,35 @@
 		led2 = &green_led;
 		sw0 = &usr_btn;
 	};
+
+	arduino_header: connector {
+		compatible = "arduino-header-r3";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map = <0 0 &gpio3 0 0>,	/* A0 */
+			   <1 0 &gpio3 1 0>,	/* A1 */
+			   <2 0 &gpio3 2 0>,	/* A2 */
+			   <3 0 &gpio3 3 0>,	/* A3 */
+			   <4 0 &gpio3 4 0>,	/* A4 */
+			   <5 0 &gpio3 5 0>,	/* A5 */
+			   <6 0 &gpio2 14 0>,	/* D0 */
+			   <7 0 &gpio2 16 0>,	/* D1 */
+			   <8 0 &gpio2 13 0>,	/* D2 */
+			   <9 0 &gpio2 15 0>,	/* D3 */
+			   <10 0 &gpio0 8 0>,	/* D4 */
+			   <11 0 &gpio0 7 0>,	/* D5 */
+			   <12 0 &gpio1 24 0>,	/* D6 */
+			   <13 0 &gpio1 25 0>,	/* D7 */
+			   <14 0 &gpio1 31 0>,	/* D8 */
+			   <15 0 &gpio1 30 0>,	/* D9 */
+			   <16 0 &gpio1 23 0>,	/* D10 */
+			   <17 0 &gpio1 29 0>,	/* D11 */
+			   <18 0 &gpio1 28 0>,	/* D12 */
+			   <19 0 &gpio1 26 0>,	/* D13 */
+			   <20 0 &gpio2 17 0>,	/* D14 */
+			   <21 0 &gpio2 18 0>;	/* D15 */
+	};
 };
 
 &clk_ipo {

--- a/boards/adi/apard32690/apard32690_max32690_m4.yaml
+++ b/boards/adi/apard32690/apard32690_max32690_m4.yaml
@@ -8,6 +8,7 @@ toolchain:
   - gnuarmemb
   - xtools
 supported:
+  - arduino_gpio
   - arduino_serial
   - arduino_spi
   - pmod_spi

--- a/boards/shields/eval_adxl372_ardz/Kconfig.shield
+++ b/boards/shields/eval_adxl372_ardz/Kconfig.shield
@@ -1,0 +1,5 @@
+# Copyright (c) 2024 Analog Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+config SHIELD_EVAL_ADXL372_ARDZ
+	def_bool $(shields_list_contains,eval_adxl372_ardz)

--- a/boards/shields/eval_adxl372_ardz/boards/apard32690_max32690_m4.overlay
+++ b/boards/shields/eval_adxl372_ardz/boards/apard32690_max32690_m4.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2024 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		accel0 = &adxl372_eval_adxl372_ardz;
+	};
+};

--- a/boards/shields/eval_adxl372_ardz/doc/index.rst
+++ b/boards/shields/eval_adxl372_ardz/doc/index.rst
@@ -1,0 +1,52 @@
+.. eval_adxl372_ardz:
+
+EVAL-ADXL372-ARDZ
+#################
+
+Overview
+********
+
+The EVAL-ADXL372-ARDZ is a 3-axis digital accelerometer Arduino shield powered
+by the Analog Devices ADXL372.
+
+Programming
+***********
+
+Set ``--shield eval_adxl372_ardz`` when you invoke ``west build``. For example:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/sensor/sensor_shell
+   :board: apard32690/max32690/m4
+   :shield: eval_adxl372_ardz
+   :goals: build
+
+Requirements
+************
+
+This shield can only be used with a board which provides a configuration for
+Arduino connectors and defines node aliases for SPI and GPIO interfaces (see
+:ref:`shields` for more details).
+
+References
+**********
+
+- `EVAL-ADXL372-ARDZ product page`_
+- `EVAL-ADXL372-ARDZ user guide`_
+- `EVAL-ADXL372-ARDZ schematic`_
+- `ADXL372 product page`_
+- `ADXL372 data sheet`_
+
+.. _EVAL-ADXL372-ARDZ product page:
+   https://www.analog.com/en/resources/evaluation-hardware-and-software/evaluation-boards-kits/eval-adxl372-ardz.html
+
+.. _EVAL-ADXL372-ARDZ user guide:
+   https://wiki.analog.com/resources/eval/user-guides/eval-adicup3029/hardware/adxl372
+
+.. _EVAL-ADXL372-ARDZ schematic:
+   https://www.analog.com/media/en/evaluation-documentation/evaluation-design-files/eval-adxl372-ardz-designsupport.zip
+
+.. _ADXL372 product page:
+   https://www.analog.com/en/products/adxl372.html
+
+.. _ADXL372 data sheet:
+   https://www.analog.com/media/en/technical-documentation/data-sheets/adxl372.pdf

--- a/boards/shields/eval_adxl372_ardz/eval_adxl372_ardz.overlay
+++ b/boards/shields/eval_adxl372_ardz/eval_adxl372_ardz.overlay
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2024 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&arduino_spi {
+	status = "okay";
+
+	adxl372_eval_adxl372_ardz: adxl372@0 {
+		compatible = "adi,adxl372";
+		reg = <0x0>;
+		spi-max-frequency = <DT_FREQ_M(1)>;
+		int1-gpios = <&arduino_header 13 GPIO_ACTIVE_HIGH>;
+		status = "okay";
+	};
+};


### PR DESCRIPTION
Adds a new shield definition for the Analog Devices EVAL-ADXL372-ARDZ
accelerometer shield. This shield provides support for an ADI ADXL372
3-axis accelerometer over an Arduino SPI connector.

Signed-off-by: Maureen Helm <maureen.helm@analog.com>

Related to #78941

cc: @vladislav-pejic @dimitrije-lilic