### PR TITLE
cmake: modules: dts: print stderr on failure

### DIFF
--- a/cmake/modules/dts.cmake
+++ b/cmake/modules/dts.cmake
@@ -398,7 +398,7 @@ execute_process(
   )
 
 if(NOT "${ret}" STREQUAL "0")
-  message(FATAL_ERROR "dtc failed with return code: ${ret}")
+  message(FATAL_ERROR "dtc failed with return code: ${ret}\n${stderr}")
 elseif(stderr)
   # dtc printed warnings on stderr but did not fail.
   # Display them as CMake warnings to draw attention.


### PR DESCRIPTION
059aae7c916 actually hid error messages completely instead of making them more visible.
db7a3901bde restored that for some processes, but not for dtc itself.

Without this patch, a device tree error like a missing `reg` property
failed the build without showing the reason:
```
CMake Error at zephyr/cmake/modules/dts.cmake:401 (message):
  dtc failed with return code: 2
Call Stack (most recent call first):
  zephyr/cmake/modules/zephyr_default.cmake:133 (include)
  zephyr/share/zephyr-package/cmake/ZephyrConfig.cmake:66 (include)
  zephyr/share/zephyr-package/cmake/ZephyrConfig.cmake:97 (include_boilerplate)
  CMakeLists.txt:5 (find_package)
```

With it, you can see the cause of the failure like before:
```
CMake Error at zephyr/cmake/modules/dts.cmake:401 (message):
  dtc failed with return code: 2

  build/zephyr/zephyr.dts:42.20-44.6:
  ERROR (unit_address_vs_reg): /soc/flash-controller@40020000/flash@0: node
  has a unit name, but no reg property

  ERROR: Input tree has errors, aborting (use -f to force output)

Call Stack (most recent call first):
  zephyr/cmake/modules/zephyr_default.cmake:133 (include)
  zephyr/share/zephyr-package/cmake/ZephyrConfig.cmake:66 (include)
  zephyr/share/zephyr-package/cmake/ZephyrConfig.cmake:92 (include_boilerplate)
  CMakeLists.txt:5 (find_package)
```