### PR TITLE
maintainers: Add wifi tag for hostap files

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -5160,6 +5160,8 @@ West:
     - modules/hostap/
   labels:
     - "area: Wi-Fi"
+  tests:
+    - net.wifi
 
 Xtensa arch:
   status: maintained

--- a/scripts/ci/tags.yaml
+++ b/scripts/ci/tags.yaml
@@ -56,6 +56,16 @@ net:
     - drivers/ieee802154/
     - drivers/ptp_clock/
 
+wifi:
+  files:
+    - modules/hostap/
+    - subsys/net/l2/wifi/
+    - drivers/wifi/
+    - include/zephyr/net/wifi.h
+    - include/zephyr/net/wifi_mgmt.h
+    - include/zephyr/net/wifi_nm.h
+    - include/zephyr/net/wifi_utils.h
+
 test_framework:
   files:
     - subsys/testsuite/


### PR DESCRIPTION
Make sure we run wifi tests for all hostap related files that are changed.