### PR TITLE
modules: hal_nordic: Require nrf-regtool 6.0.0

### DIFF
--- a/modules/hal_nordic/CMakeLists.txt
+++ b/modules/hal_nordic/CMakeLists.txt
@@ -12,7 +12,7 @@ if(CONFIG_NRF_REGTOOL_GENERATE_UICR)
   list(APPEND nrf_regtool_components GENERATE:UICR)
 endif()
 if(DEFINED nrf_regtool_components)
-  find_package(nrf-regtool 5.6.0 REQUIRED
+  find_package(nrf-regtool 6.0.0 REQUIRED
     COMPONENTS ${nrf_regtool_components}
     PATHS ${CMAKE_CURRENT_LIST_DIR}/nrf-regtool
     NO_CMAKE_PATH


### PR DESCRIPTION
nrf-regtool 6.0.0 introduced support for more trace configurations in the nrf54H20, so bump the version to make sure those new features can be used.