### PR TITLE
maintainers: Add doki-nordic as maintainer of IPC

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -2357,8 +2357,10 @@ Input:
 IPC:
   status: maintained
   maintainers:
-    - carlocaione
+    - doki-nordic
     - arnopo
+  collaborators:
+    - carlocaione
   files:
     - include/zephyr/ipc/
     - samples/subsys/ipc/


### PR DESCRIPTION
Become the maintainer for the IPC code.
Additionally, `carlocaione` becomes collaborator now.