### PR TITLE
boards: lilygo: ttgo_lora32: enable SDHC support

### DIFF
--- a/boards/lilygo/ttgo_lora32/doc/index.rst
+++ b/boards/lilygo/ttgo_lora32/doc/index.rst
@@ -39,13 +39,13 @@ of the Lilygo TTGO LoRa32 board.
 +------------------+-------------------------------------------------------------------------+
 | Power Switch     | Sliding power switch.                                                   |
 +------------------+-------------------------------------------------------------------------+
-| LCD screen       | Built-in OLED display \(`SSD1306`_, 0.96", 128x64 px\) controlled       |
+| OLED display     | Built-in OLED display \(`SSD1306`_, 0.96", 128x64 px\) controlled       |
 |                  | by I2C interface                                                        |
 +------------------+-------------------------------------------------------------------------+
 | SX1276/SX1278    | LoRa radio frontend chip, connected via SPI.                            |
 |                  | Use SX1276 for 433MHz and SX1276 for 868/915/923MHz.                    |
 +------------------+-------------------------------------------------------------------------+
-| TF card slot     | TF card slot wired to the SD interface of the MCU.                      |
+| TF card slot     | TF card slot wired to the SDHC interface of the MCU.                    |
 +------------------+-------------------------------------------------------------------------+
 
 
@@ -195,30 +195,15 @@ message in the monitor:
    ***** Booting Zephyr OS vx.x.x-xxx-gxxxxxxxxxxxx *****
    Hello World! ttgo_lora32
 
-LoRa samples
+Code samples
 ============
 
-There are two LoRa samples that will work out of the box with this board.
+The following sample applications will work out of the box with this board:
 
-To build the LoRa transmit sample application using sysbuild use the command:
-
-.. zephyr-app-commands::
-   :tool: west
-   :zephyr-app: samples/drivers/lora/send
-   :board: ttgo_lora32/esp32/procpu
-   :goals: build
-   :west-args: --sysbuild
-   :compact:
-
-To build the LoRa receive sample application using sysbuild use the command:
-
-.. zephyr-app-commands::
-   :tool: west
-   :zephyr-app: samples/drivers/lora/receive
-   :board: ttgo_lora32/esp32/procpu
-   :goals: build
-   :west-args: --sysbuild
-   :compact:
+* :zephyr:code-sample:`lora-send`
+* :zephyr:code-sample:`lora-receive`
+* :zephyr:code-sample:`fs`
+* :zephyr:code-sample:`character-frame-buffer`
 
 Debugging
 *********

--- a/boards/lilygo/ttgo_lora32/ttgo_lora32-pinctrl.dtsi
+++ b/boards/lilygo/ttgo_lora32/ttgo_lora32-pinctrl.dtsi
@@ -41,5 +41,11 @@
 			output-high;
 		};
 	};
-
+	sdhc0_default: sdhc0_default {
+		group1 {
+			pinmux = <SDHC0_CD_GPIO34>;
+			bias-pull-up;
+			output-high;
+		};
+	};
 };

--- a/boards/lilygo/ttgo_lora32/ttgo_lora32_esp32_appcpu.yaml
+++ b/boards/lilygo/ttgo_lora32/ttgo_lora32_esp32_appcpu.yaml
@@ -24,4 +24,5 @@ testing:
     - cmsis_rtos
     - jwt
     - zdsp
+    - sdhc
 vendor: lilygo

--- a/boards/lilygo/ttgo_lora32/ttgo_lora32_esp32_procpu.dts
+++ b/boards/lilygo/ttgo_lora32/ttgo_lora32_esp32_procpu.dts
@@ -18,6 +18,7 @@
 		uart-0 = &uart0;
 		i2c-0 = &i2c0;
 		watchdog0 = &wdt0;
+		sdhc0 = &sdhc1;
 		lora0 = &lora0;
 	};
 
@@ -28,6 +29,7 @@
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_partition;
 		zephyr,display = &ssd1306_128x64;
+		zephyr,sdhc = &sdhc1;
 	};
 
 	leds {
@@ -119,6 +121,31 @@
 
 &trng0 {
 	status = "okay";
+};
+
+&sdhc {
+	sdhc1: sdhc@1 {
+		status = "okay";
+
+		pinctrl-0 = <&sdhc0_default>;
+		pinctrl-names = "default";
+		power-delay-ms = <100>;
+		max-bus-freq = <52000000>;
+		bus-width = <4>;
+
+		clk-pin = <14>;
+		cmd-pin = <15>;
+		d0-pin = <2>;
+		d1-pin = <4>;
+		d2-pin = <12>;
+		d3-pin = <13>;
+
+		mmc {
+			compatible = "zephyr,sdmmc-disk";
+			disk-name = "SD";
+			status = "okay";
+		};
+	};
 };
 
 &flash0 {

--- a/boards/lilygo/ttgo_lora32/ttgo_lora32_esp32_procpu.yaml
+++ b/boards/lilygo/ttgo_lora32/ttgo_lora32_esp32_procpu.yaml
@@ -14,6 +14,7 @@ supported:
   - display
   - lora
   - nvs
+  - sdhc
 testing:
   ignore_tags:
     - net

--- a/boards/lilygo/ttgo_lora32/ttgo_lora32_esp32_procpu_defconfig
+++ b/boards/lilygo/ttgo_lora32/ttgo_lora32_esp32_procpu_defconfig
@@ -8,3 +8,6 @@ CONFIG_UART_CONSOLE=y
 
 CONFIG_GPIO=y
 CONFIG_I2C=y
+
+# the following config is required to support chips of revision 1
+CONFIG_ESP32_USE_UNSUPPORTED_REVISION=y


### PR DESCRIPTION
enable support for the SDHC controller to use the micro SD card slot