### PR TITLE
samples: net: wifi: Disable building on NS platform variants

### DIFF
--- a/samples/net/wifi/sample.yaml
+++ b/samples/net/wifi/sample.yaml
@@ -45,9 +45,7 @@ tests:
     extra_args: CONFIG_NRF_WIFI_BUILD_ONLY_MODE=y
     platform_allow:
       - nrf7002dk/nrf5340/cpuapp
-      - nrf7002dk/nrf5340/cpuapp/ns
       - nrf7002dk/nrf5340/cpuapp/nrf7001
-      - nrf7002dk/nrf5340/cpuapp/nrf7001/ns
     integration_platforms:
       - nrf7002dk/nrf5340/cpuapp
       - nrf7002dk/nrf5340/cpuapp/nrf7001
@@ -57,7 +55,6 @@ tests:
       - SHIELD=nrf7002ek
     platform_allow:
       - nrf5340dk/nrf5340/cpuapp
-      - nrf5340dk/nrf5340/cpuapp/ns
       - nucleo_h723zg
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp


### PR DESCRIPTION
The sample currently doesn't build for non-secure nRF platforms due to mbed TLS misconfiguration - TFM enforces PSA crypto API, while the default configuration for supplicant uses legacy crypto configuration. In result, build fails due to unsatisfied dependencies. Therefore, disable this variant from building temporarily to unblock the CI, until the issue is resolved.