### PR TITLE
drivers: udc_dwc2: Suspend if connected to suspended bus

### DIFF
--- a/drivers/usb/udc/udc_dwc2.c
+++ b/drivers/usb/udc/udc_dwc2.c
@@ -2727,11 +2727,6 @@ static void udc_dwc2_isr_handler(const struct device *dev)
 			/* Clear USB Suspend interrupt. */
 			sys_write32(USB_DWC2_GINTSTS_USBSUSP, gintsts_reg);
 
-			if (!priv->enumdone) {
-				/* Ignore stale suspend interrupt */
-				continue;
-			}
-
 			/* Notify the stack */
 			udc_set_suspended(dev, true);
 			udc_submit_event(dev, UDC_EVT_SUSPEND, 0);

--- a/drivers/usb/udc/udc_dwc2.c
+++ b/drivers/usb/udc/udc_dwc2.c
@@ -904,7 +904,7 @@ static void dwc2_backup_registers(const struct device *dev)
 }
 
 static void dwc2_restore_essential_registers(const struct device *dev,
-					     bool rwup)
+					     bool rwup, bool bus_reset)
 {
 	const struct udc_dwc2_config *const config = dev->config;
 	struct usb_dwc2_reg *const base = config->base;
@@ -924,6 +924,10 @@ static void dwc2_restore_essential_registers(const struct device *dev,
 
 	sys_write32(backup->gusbcfg, (mem_addr_t)&base->gusbcfg);
 	sys_write32(backup->dcfg, (mem_addr_t)&base->dcfg);
+
+	if (bus_reset) {
+		sys_write32(backup->dcfg, (mem_addr_t)&base->dcfg);
+	}
 
 	if (!rwup) {
 		pcgcctl |= USB_DWC2_PCGCCTL_RESTOREMODE | USB_DWC2_PCGCCTL_RSTPDWNMODULE;
@@ -1026,7 +1030,8 @@ static void dwc2_enter_hibernation(const struct device *dev)
 	LOG_DBG("Hibernated");
 }
 
-static void dwc2_exit_hibernation(const struct device *dev, bool rwup)
+static void dwc2_exit_hibernation(const struct device *dev,
+				  bool rwup, bool bus_reset)
 {
 	const struct udc_dwc2_config *const config = dev->config;
 	struct usb_dwc2_reg *const base = config->base;
@@ -1066,13 +1071,15 @@ static void dwc2_exit_hibernation(const struct device *dev, bool rwup)
 	/* Disable PMU interrupt */
 	sys_clear_bits(gpwrdn_reg, USB_DWC2_GPWRDN_PMUINTSEL);
 
-	dwc2_restore_essential_registers(dev, rwup);
+	dwc2_restore_essential_registers(dev, rwup, bus_reset);
 
 	/* Note: in Remote Wakeup case 15 ms max signaling time starts now */
 
 	/* Wait for Restore Done Interrupt */
 	dwc2_wait_for_bit(dev, (mem_addr_t)&base->gintsts, USB_DWC2_GINTSTS_RSTRDONEINT);
-	sys_write32(0xFFFFFFFFUL, (mem_addr_t)&base->gintsts);
+	if (!bus_reset) {
+		sys_write32(0xFFFFFFFFUL, (mem_addr_t)&base->gintsts);
+	}
 
 	/* Disable restore from PMU */
 	sys_clear_bits(gpwrdn_reg, USB_DWC2_GPWRDN_RESTORE);
@@ -2027,7 +2034,7 @@ static int udc_dwc2_disable(const struct device *dev)
 	config->irq_disable_func(dev);
 
 	if (priv->hibernated) {
-		dwc2_exit_hibernation(dev, false);
+		dwc2_exit_hibernation(dev, false, true);
 		priv->hibernated = 0;
 	}
 
@@ -2744,7 +2751,7 @@ static void dwc2_handle_hibernation_exit(const struct device *dev,
 	struct usb_dwc2_reg *const base = dwc2_get_base(dev);
 	struct udc_dwc2_data *const priv = udc_get_private(dev);
 
-	dwc2_exit_hibernation(dev, rwup);
+	dwc2_exit_hibernation(dev, rwup, bus_reset);
 	dwc2_restore_device_registers(dev, rwup);
 
 	priv->hibernated = 0;


### PR DESCRIPTION
Peripherals are required to support the suspend state whenever VBUS is powered, even if bus reset has not occurred (Mandate: Required, Effective Date: February, 2010).

Remove the stale suspend check that essentially prevented the device from hibernating when connected to already suspended bus.