### PR TITLE
drivers: gpio: stm32h7rs serie requires specific power rails

### DIFF
--- a/soc/st/stm32/stm32h7rsx/soc.c
+++ b/soc/st/stm32/stm32h7rsx/soc.c
@@ -68,4 +68,14 @@ void soc_early_init_hook(void)
 	LL_PWR_SetRegulVoltageScaling(LL_PWR_REGU_VOLTAGE_SCALE1);
 	while (LL_PWR_IsActiveFlag_VOSRDY() == 0) {
 	}
+
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(gpioo), okay) || DT_NODE_HAS_STATUS(DT_NODELABEL(gpiop), okay)
+	LL_PWR_EnableXSPIM1(); /* Required for powering GPIO O and P */
+#endif /* gpioo || gpio p */
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(gpion), okay)
+	LL_PWR_EnableXSPIM2(); /* Required for powering GPIO N */
+#endif /* gpio n */
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(gpiom), okay)
+	LL_PWR_EnableUSBVoltageDetector(); /* Required for powering GPIO M */
+#endif /* gpiom */
 }


### PR DESCRIPTION
mentionned by the [RM0477   ](https://www.st.com/resource/en/reference_manual/rm0477-stm32h7rx7sx-armbased-32bit-mcus-stmicroelectronics.pdf)10.3.16 High-speed low-voltage mode (HSLV

> The GPIOs are all programed with the same HSLV setting, except those from dedicated 
> power rail (OCTO, HEXA and USB):
> • XSPIM2 rail: PN[0:12]
> • XSPIM1 rail: PO[0:5], PP[0:15]
> • USB no software compensation setting

More power rails to enable when using GPIO bank M, N, O, P
Enables the XSPIM2 rail when using GPIO bank N
Enables the XSPIM1 rail when using GPIO bank O or P 
Enables the USBvoltage detector when using the GPIO M

