### PR TITLE
tests: Bluetooth: tester: Implement TBS registration

### DIFF
--- a/tests/bluetooth/tester/src/audio/btp_ccp.c
+++ b/tests/bluetooth/tester/src/audio/btp_ccp.c
@@ -11,7 +11,9 @@
 
 #include <../../subsys/bluetooth/audio/tbs_internal.h>
 
+#include <zephyr/bluetooth/audio/tbs.h>
 #include <zephyr/logging/log.h>
+
 #define LOG_MODULE_NAME bttester_ccp
 LOG_MODULE_REGISTER(LOG_MODULE_NAME, CONFIG_BTTESTER_LOG_LEVEL);
 
@@ -1162,10 +1164,45 @@ static const struct btp_handler tbs_handlers[] = {
 
 uint8_t tester_init_tbs(void)
 {
+	const struct bt_tbs_register_param gtbs_param = {
+		.provider_name = "Generic TBS",
+		.uci = "un000",
+		.uri_schemes_supported = "tel,skype",
+		.gtbs = true,
+		.authorization_required = false,
+		.technology = BT_TBS_TECHNOLOGY_3G,
+		.supported_features = CONFIG_BT_TBS_SUPPORTED_FEATURES,
+	};
+	const struct bt_tbs_register_param tbs_param = {
+		.provider_name = "TBS",
+		.uci = "un000",
+		.uri_schemes_supported = "tel,skype",
+		.gtbs = false,
+		.authorization_required = false,
+		/* Set different technologies per bearer */
+		.technology = BT_TBS_TECHNOLOGY_4G,
+		.supported_features = CONFIG_BT_TBS_SUPPORTED_FEATURES,
+	};
+	int err;
+
 	bt_tbs_register_cb(&tbs_cbs);
 
 	tester_register_command_handlers(BTP_SERVICE_ID_TBS, tbs_handlers,
 					 ARRAY_SIZE(tbs_handlers));
+
+	err = bt_tbs_register_bearer(&gtbs_param);
+	if (err < 0) {
+		LOG_DBG("Failed to register GTBS: %d", err);
+
+		return BTP_STATUS_FAILED;
+	}
+
+	err = bt_tbs_register_bearer(&tbs_param);
+	if (err < 0) {
+		LOG_DBG("Failed to register TBS: %d", err);
+
+		return BTP_STATUS_FAILED;
+	}
 
 	return BTP_STATUS_SUCCESS;
 }


### PR DESCRIPTION
TBS registration was changed from static to dynamic and the BT Tester application need to be updated to use the dynamic registration.