### PR TITLE
doc: migration-guide: Add LE Audio entry for dynamic TBS

### DIFF
--- a/doc/releases/migration-guide-4.0.rst
+++ b/doc/releases/migration-guide-4.0.rst
@@ -299,6 +299,11 @@ Bluetooth Audio
   to use these new APIs.
   (:github:`78751`)
 
+* The Telephone Bearer Service (TBS) and Generic Telephone Bearer Service (GTBS) shall now be
+  registered dynamically at runtime with :c:func:`bt_tbs_register_bearer`. The services can also be
+  unregistered with :c:func:`bt_tbs_unregister_bearer`.
+  (:github:`76108`)
+
 Bluetooth Classic
 =================
 


### PR DESCRIPTION
The TBS and GTBS shall now be registered at runtime and can no longer be registered statically. This requires a change in the applications using this.