### PR TITLE
tests: drivers: uart: uart_pm: Fix fail on nrf54h20

### DIFF
--- a/tests/drivers/uart/uart_pm/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/tests/drivers/uart/uart_pm/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -29,3 +29,7 @@ dut: &uart135 {
 	pinctrl-names = "default", "sleep";
 	memory-regions = <&cpuapp_dma_region>;
 };
+
+&cpu {
+	/delete-property/ cpu-power-states;
+};


### PR DESCRIPTION
Power states were recently added to the board definition of nrf54h20:
https://github.com/zephyrproject-rtos/zephyr/commit/5b607ed5c7869b6f01098bb02d5d81c357c3cb43
This has negative impact on drivers.uart.pm.int_driven test.

Delete property 'cpu-power-states' in the test overlay for nrf54h20.