### PR TITLE
net: lwm2m: Remove hostname_verify flag from context

### DIFF
--- a/include/zephyr/net/lwm2m.h
+++ b/include/zephyr/net/lwm2m.h
@@ -245,8 +245,6 @@ struct lwm2m_ctx {
 	char *desthostname;
 	/** Destination hostname length */
 	uint16_t desthostnamelen;
-	/** Flag to indicate if hostname verification is enabled */
-	bool hostname_verify;
 
 	/** Custom load_credentials function.
 	 *  Client can set load_credentials function as a way of overriding

--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -1070,7 +1070,7 @@ int lwm2m_set_default_sockopt(struct lwm2m_ctx *ctx)
 			}
 		}
 
-		if (ctx->hostname_verify && (ctx->desthostname != NULL)) {
+		if (ctx->desthostname != NULL && lwm2m_security_mode(ctx) == LWM2M_SECURITY_CERT) {
 			/** store character at len position */
 			tmp = ctx->desthostname[ctx->desthostnamelen];
 

--- a/subsys/net/lib/lwm2m/lwm2m_message_handling.c
+++ b/subsys/net/lib/lwm2m/lwm2m_message_handling.c
@@ -3324,7 +3324,6 @@ int lwm2m_parse_peerinfo(char *url, struct lwm2m_ctx *client_ctx, bool is_firmwa
 		/** copy url pointer to be used in socket */
 		client_ctx->desthostname = url + off;
 		client_ctx->desthostnamelen = len;
-		client_ctx->hostname_verify = true;
 #endif
 
 #else

--- a/tests/net/lib/lwm2m/lwm2m_engine/src/main.c
+++ b/tests/net/lib/lwm2m/lwm2m_engine/src/main.c
@@ -105,7 +105,6 @@ ZTEST(lwm2m_engine, test_start_stop)
 	ctx.load_credentials = NULL;
 	ctx.desthostname = host_name;
 	ctx.desthostnamelen = strlen(host_name);
-	ctx.hostname_verify = true;
 	ctx.use_dtls = true;
 
 	ret = lwm2m_engine_start(&ctx);
@@ -436,7 +435,6 @@ ZTEST(lwm2m_engine, test_security)
 	ctx.load_credentials = NULL;
 	ctx.desthostname = host_name;
 	ctx.desthostnamelen = strlen(host_name);
-	ctx.hostname_verify = true;
 	ctx.use_dtls = false;
 
 	lwm2m_security_mode_fake.return_val = LWM2M_SECURITY_NOSEC;
@@ -452,9 +450,8 @@ ZTEST(lwm2m_engine, test_security)
 	lwm2m_security_mode_fake.return_val = LWM2M_SECURITY_PSK;
 	zassert_equal(lwm2m_engine_start(&ctx), 0);
 	zassert_equal(z_impl_zsock_setsockopt_fake.arg2_history[0], TLS_SEC_TAG_LIST);
-	zassert_equal(z_impl_zsock_setsockopt_fake.arg2_history[1], TLS_HOSTNAME);
-	zassert_equal(z_impl_zsock_setsockopt_fake.arg2_history[2], TLS_PEER_VERIFY);
-	zassert_equal(z_impl_zsock_setsockopt_fake.arg2_history[3], TLS_CIPHERSUITE_LIST);
+	zassert_equal(z_impl_zsock_setsockopt_fake.arg2_history[1], TLS_PEER_VERIFY);
+	zassert_equal(z_impl_zsock_setsockopt_fake.arg2_history[2], TLS_CIPHERSUITE_LIST);
 	zassert_true(tls_credential_delete_fake.call_count > 3);
 	zassert_true(tls_credential_add_fake.call_count == 2);
 	zassert_equal(tls_credential_add_fake.arg1_history[0], TLS_CREDENTIAL_PSK_ID);
@@ -464,7 +461,7 @@ ZTEST(lwm2m_engine, test_security)
 	RESET_FAKE(z_impl_zsock_setsockopt);
 	RESET_FAKE(tls_credential_add);
 	lwm2m_security_mode_fake.return_val = LWM2M_SECURITY_CERT;
-	ctx.hostname_verify = false;
+	ctx.desthostname = NULL;
 	zassert_equal(lwm2m_engine_start(&ctx), 0);
 	zassert_equal(z_impl_zsock_setsockopt_fake.arg2_history[0], TLS_SEC_TAG_LIST);
 	zassert_equal(z_impl_zsock_setsockopt_fake.arg2_history[1], TLS_PEER_VERIFY);


### PR DESCRIPTION
Use security mode (PSK or X509) to detect if we should set the socket option to verify hostname.

PSK security mode cannot verify hostnames as this information is coming in the certificate, so don't set the options.