### PR TITLE
boards: st: nucleo_h7 boards correct LD2 on PE1 pin

### DIFF
--- a/boards/st/nucleo_h723zg/doc/index.rst
+++ b/boards/st/nucleo_h723zg/doc/index.rst
@@ -136,10 +136,10 @@ and a ST morpho connector. Board is configured as follows:
 - UART_3 TX/RX : PD8/PD9 (ST-Link Virtual Port Com)
 - USER_PB : PC13
 - LD1 : PB0
-- LD2 : PB7
+- LD2 : PE1
 - LD3 : PB14
 - I2C : PB8, PB9
-- SPI1 NSS/SCK/MISO/MOSI : PD14PA5/PA6/PB5 (Arduino SPI)
+- SPI1 NSS/SCK/MISO/MOSI : PD14/PA5/PA6/PB5 (Arduino SPI)
 - FDCAN1 RX/TX : PD0, PD1
 
 System Clock

--- a/boards/st/nucleo_h743zi/doc/index.rst
+++ b/boards/st/nucleo_h743zi/doc/index.rst
@@ -148,7 +148,7 @@ and a ST morpho connector. Board is configured as follows:
 - UART_3 TX/RX : PD8/PD9 (ST-Link Virtual Port Com)
 - USER_PB : PC13
 - LD1 : PB0
-- LD2 : PB7
+- LD2 : PE1
 - LD3 : PB14
 - I2C : PB8, PB9
 - ADC1_INP15 : PA3

--- a/boards/st/nucleo_h745zi_q/doc/index.rst
+++ b/boards/st/nucleo_h745zi_q/doc/index.rst
@@ -137,7 +137,7 @@ and a ST morpho connector. Board is configured as follows:
 - UART_3 TX/RX : PD8/PD9 (ST-Link Virtual Port Com)
 - USER_PB : PC13
 - LD1 : PB0
-- LD2 : PB7
+- LD2 : PE1
 - LD3 : PB14
 - I2C : PB8, PB9
 - SPI : PA5, PA6, PB5, PD14

--- a/boards/st/nucleo_h753zi/doc/index.rst
+++ b/boards/st/nucleo_h753zi/doc/index.rst
@@ -140,12 +140,12 @@ and a ST morpho connector. Board is configured as follows:
 - UART_3 TX/RX : PD8/PD9 (ST-Link Virtual Port Com)
 - USER_PB : PC13
 - LD1 : PB0
-- LD2 : PB7
+- LD2 : PE1
 - LD3 : PB14
 - I2C : PB8, PB9
 - ADC1_INP15 : PA3
 - ETH : PA1, PA2, PA7, PB13, PC1, PC4, PC5, PG11, PG13
-- SPI1 NSS/SCK/MISO/MOSI : PD14PA5/PA6/PB5 (Arduino SPI)
+- SPI1 NSS/SCK/MISO/MOSI : PD14/PA5/PA6/PB5 (Arduino SPI)
 - CAN/CANFD : PD0, PD1
 
 System Clock


### PR DESCRIPTION
The stm32h7 nucleo 144 boards (ref MB1364)
have the LD2 on PE1 pin (not PB7). This commit change this in the doc. Board DTS are correct.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/79182