### PR TITLE
net: ipv6: Make Multicast Listener Discovery API public

### DIFF
--- a/include/zephyr/net/mld.h
+++ b/include/zephyr/net/mld.h
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2016 Intel Corporation
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/** @file
+ * @brief Multicast Listener Discovery API
+ */
+
+#ifndef ZEPHYR_INCLUDE_NET_MLD_H_
+#define ZEPHYR_INCLUDE_NET_MLD_H_
+
+/**
+ * @brief MLD (Multicast Listener Discovery)
+ * @defgroup mld Multicast Listener Discovery API
+ * @since 1.8
+ * @version 0.8.0
+ * @ingroup networking
+ * @{
+ */
+
+#include <errno.h>
+
+#include <zephyr/net/net_if.h>
+#include <zephyr/net/net_ip.h>
+#include <zephyr/toolchain.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Join a given multicast group.
+ *
+ * @param iface Network interface where join message is sent
+ * @param addr Multicast group to join
+ *
+ * @return 0 if joining was done, <0 otherwise.
+ */
+#if defined(CONFIG_NET_IPV6_MLD)
+int net_ipv6_mld_join(struct net_if *iface, const struct in6_addr *addr);
+#else
+static inline int
+net_ipv6_mld_join(struct net_if *iface, const struct in6_addr *addr)
+{
+	ARG_UNUSED(addr);
+	ARG_UNUSED(iface);
+
+	return -ENOTSUP;
+}
+#endif /* CONFIG_NET_IPV6_MLD */
+
+/**
+ * @brief Leave a given multicast group.
+ *
+ * @param iface Network interface where leave message is sent
+ * @param addr Multicast group to leave
+ *
+ * @return 0 if leaving is done, <0 otherwise.
+ */
+#if defined(CONFIG_NET_IPV6_MLD)
+int net_ipv6_mld_leave(struct net_if *iface, const struct in6_addr *addr);
+#else
+static inline int
+net_ipv6_mld_leave(struct net_if *iface, const struct in6_addr *addr)
+{
+	ARG_UNUSED(iface);
+	ARG_UNUSED(addr);
+
+	return -ENOTSUP;
+}
+#endif /* CONFIG_NET_IPV6_MLD */
+
+#ifdef __cplusplus
+}
+#endif
+
+/**
+ * @}
+ */
+
+#endif /* ZEPHYR_INCLUDE_NET_MLD_H_ */

--- a/samples/net/sockets/coap_server/src/main.c
+++ b/samples/net/sockets/coap_server/src/main.c
@@ -8,6 +8,7 @@
 LOG_MODULE_REGISTER(net_coap_service_sample, LOG_LEVEL_DBG);
 
 #include <zephyr/net/coap_service.h>
+#include <zephyr/net/mld.h>
 
 #ifdef CONFIG_NET_IPV6
 #include "net_private.h"

--- a/subsys/net/ip/ipv6.h
+++ b/subsys/net/ip/ipv6.h
@@ -199,48 +199,6 @@ static inline int net_ipv6_finalize(struct net_pkt *pkt,
 #endif
 
 /**
- * @brief Join a given multicast group.
- *
- * @param iface Network interface where join message is sent
- * @param addr Multicast group to join
- *
- * @return Return 0 if joining was done, <0 otherwise.
- */
-#if defined(CONFIG_NET_IPV6_MLD)
-int net_ipv6_mld_join(struct net_if *iface, const struct in6_addr *addr);
-#else
-static inline int
-net_ipv6_mld_join(struct net_if *iface, const struct in6_addr *addr)
-{
-	ARG_UNUSED(iface);
-	ARG_UNUSED(addr);
-
-	return -ENOTSUP;
-}
-#endif /* CONFIG_NET_IPV6_MLD */
-
-/**
- * @brief Leave a given multicast group.
- *
- * @param iface Network interface where leave message is sent
- * @param addr Multicast group to leave
- *
- * @return Return 0 if leaving is done, <0 otherwise.
- */
-#if defined(CONFIG_NET_IPV6_MLD)
-int net_ipv6_mld_leave(struct net_if *iface, const struct in6_addr *addr);
-#else
-static inline int
-net_ipv6_mld_leave(struct net_if *iface, const struct in6_addr *addr)
-{
-	ARG_UNUSED(iface);
-	ARG_UNUSED(addr);
-
-	return -ENOTSUP;
-}
-#endif /* CONFIG_NET_IPV6_MLD */
-
-/**
  * @brief Send MLDv2 report message with a single entry.
  *
  * @param iface Network interface where message is sent

--- a/subsys/net/ip/ipv6_mld.c
+++ b/subsys/net/ip/ipv6_mld.c
@@ -12,6 +12,7 @@
 LOG_MODULE_DECLARE(net_ipv6, CONFIG_NET_IPV6_LOG_LEVEL);
 
 #include <errno.h>
+#include <zephyr/net/mld.h>
 #include <zephyr/net/net_core.h>
 #include <zephyr/net/net_pkt.h>
 #include <zephyr/net/net_stats.h>

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -17,6 +17,7 @@ LOG_MODULE_REGISTER(net_if, CONFIG_NET_IF_LOG_LEVEL);
 #include <string.h>
 #include <zephyr/net/igmp.h>
 #include <zephyr/net/ipv4_autoconf.h>
+#include <zephyr/net/mld.h>
 #include <zephyr/net/net_core.h>
 #include <zephyr/net/net_event.h>
 #include <zephyr/net/net_pkt.h>

--- a/subsys/net/lib/dns/llmnr_responder.c
+++ b/subsys/net/lib/dns/llmnr_responder.c
@@ -21,6 +21,7 @@ LOG_MODULE_REGISTER(net_llmnr_responder, CONFIG_LLMNR_RESPONDER_LOG_LEVEL);
 #include <errno.h>
 #include <stdlib.h>
 
+#include <zephyr/net/mld.h>
 #include <zephyr/net/net_ip.h>
 #include <zephyr/net/net_pkt.h>
 #include <zephyr/net/dns_resolve.h>

--- a/subsys/net/lib/dns/mdns_responder.c
+++ b/subsys/net/lib/dns/mdns_responder.c
@@ -22,6 +22,7 @@ LOG_MODULE_REGISTER(net_mdns_responder, CONFIG_MDNS_RESPONDER_LOG_LEVEL);
 #include <errno.h>
 #include <stdlib.h>
 
+#include <zephyr/net/mld.h>
 #include <zephyr/net/net_core.h>
 #include <zephyr/net/net_ip.h>
 #include <zephyr/net/net_pkt.h>

--- a/subsys/net/lib/shell/ipv6.c
+++ b/subsys/net/lib/shell/ipv6.c
@@ -8,6 +8,8 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(net_shell);
 
+#include <zephyr/net/mld.h>
+
 #include "net_shell_private.h"
 #include "../ip/ipv6.h"
 

--- a/subsys/net/lib/sockets/sockets_inet.c
+++ b/subsys/net/lib/sockets/sockets_inet.c
@@ -11,6 +11,7 @@
 LOG_MODULE_DECLARE(net_sock, CONFIG_NET_SOCKETS_LOG_LEVEL);
 
 #include <zephyr/kernel.h>
+#include <zephyr/net/mld.h>
 #include <zephyr/net/net_context.h>
 #include <zephyr/net/net_pkt.h>
 #include <zephyr/tracing/tracing.h>

--- a/subsys/net/lib/zperf/zperf_udp_receiver.c
+++ b/subsys/net/lib/zperf/zperf_udp_receiver.c
@@ -12,6 +12,7 @@ LOG_MODULE_DECLARE(net_zperf, CONFIG_NET_ZPERF_LOG_LEVEL);
 
 #include <zephyr/kernel.h>
 
+#include <zephyr/net/mld.h>
 #include <zephyr/net/socket.h>
 #include <zephyr/net/socket_service.h>
 #include <zephyr/net/zperf.h>

--- a/tests/net/ipv6/src/main.c
+++ b/tests/net/ipv6/src/main.c
@@ -19,6 +19,7 @@ LOG_MODULE_REGISTER(net_test, CONFIG_NET_IPV6_LOG_LEVEL);
 
 #include <zephyr/ztest.h>
 
+#include <zephyr/net/mld.h>
 #include <zephyr/net/net_core.h>
 #include <zephyr/net/net_pkt.h>
 #include <zephyr/net/net_ip.h>

--- a/tests/net/mld/src/main.c
+++ b/tests/net/mld/src/main.c
@@ -18,6 +18,7 @@ LOG_MODULE_REGISTER(net_test, CONFIG_NET_IPV6_LOG_LEVEL);
 
 #include <zephyr/ztest.h>
 
+#include <zephyr/net/mld.h>
 #include <zephyr/net/net_if.h>
 #include <zephyr/net/net_pkt.h>
 #include <zephyr/net/net_ip.h>


### PR DESCRIPTION
IPv6 MLD API was so far defined in an internal header. This does not seem correct though, as application code should be able to join/leave multicast groups, hence the API should be exposed in a public header, just as it is done for its IPv4 countepart - IGMP.