### PR TITLE
device.h: fix inconsistent semicolon logic for `DEVICE_DT_DEFINE`

### DIFF
--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -208,7 +208,7 @@ typedef int16_t device_handle_t;
 			level, prio, api,                                      \
 			&Z_DEVICE_STATE_NAME(Z_DEVICE_DT_DEV_ID(node_id)),     \
 			__VA_ARGS__)                                           \
-	IF_ENABLED(CONFIG_LLEXT_EXPORT_DEVICES, (; Z_DEVICE_EXPORT(node_id)))  \
+	IF_ENABLED(CONFIG_LLEXT_EXPORT_DEVICES, (Z_DEVICE_EXPORT(node_id);))
 
 /**
  * @brief Like DEVICE_DT_DEFINE(), but uses an instance of a `DT_DRV_COMPAT`


### PR DESCRIPTION
PR #78508 added optional export of DT devices in the `DEVICE_DT_DEFINE` macro, but created inconsistent semicolon semantics:

* When `CONFIG_LLEXT_EXPORT_DEVICES` **is not** enabled, the `DEVICE_DT_DEFINE` macro ends (as it was before the PR) with the contents of the `Z_DEVICE_DEFINE` macro, which [always include a terminating semicolon](https://github.com/zephyrproject-rtos/zephyr/blob/main/include/zephyr/device.h#L1163-L1180).

* When `CONFIG_LLEXT_EXPORT_DEVICES` **is** enabled, the macro ends with `Z_DEVICE_EXPORT`, which ultimately maps to `Z_EXPORT_SYMBOL` and [does _not_ include a terminating semicolon](https://github.com/zephyrproject-rtos/zephyr/blob/main/include/zephyr/llext/symbol.h#L132-L135). This leads to a syntax error in places where the `DEVICE_DT_DEFINE` macro is used without it, like [here](https://github.com/zephyrproject-rtos/zephyr/blob/main/subsys/bluetooth/controller/hci/hci_driver.c#L911-L912).

Fix this by adjusting the code added when `CONFIG_LLEXT_EXPORT_DEVICES` is enabled to include a semicolon after the `Z_DEVICE_EXPORT` macro; also remove a stray backslash that was added in the same PR.
