### PR TITLE
drivers: intc: stm32: correct inconsistent parameter names

### DIFF
--- a/drivers/interrupt_controller/intc_exti_stm32.c
+++ b/drivers/interrupt_controller/intc_exti_stm32.c
@@ -286,11 +286,11 @@ void stm32_gpio_intc_disable_line(stm32_gpio_irq_line_t line)
 #endif
 }
 
-void stm32_gpio_intc_select_line_trigger(stm32_gpio_irq_line_t line, uint32_t trigger)
+void stm32_gpio_intc_select_line_trigger(stm32_gpio_irq_line_t line, uint32_t trg)
 {
 	z_stm32_hsem_lock(CFG_HW_EXTI_SEMID, HSEM_LOCK_DEFAULT_RETRY);
 
-	switch (trigger) {
+	switch (trg) {
 	case STM32_GPIO_IRQ_TRIG_NONE:
 		LL_EXTI_DisableRisingTrig_0_31(line);
 		LL_EXTI_DisableFallingTrig_0_31(line);
@@ -314,13 +314,13 @@ void stm32_gpio_intc_select_line_trigger(stm32_gpio_irq_line_t line, uint32_t tr
 	z_stm32_hsem_unlock(CFG_HW_EXTI_SEMID);
 }
 
-int stm32_gpio_intc_set_irq_callback(stm32_gpio_irq_line_t line, stm32_gpio_irq_cb_t cb, void *arg)
+int stm32_gpio_intc_set_irq_callback(stm32_gpio_irq_line_t line, stm32_gpio_irq_cb_t cb, void *user)
 {
 	const struct device *const dev = DEVICE_DT_GET(EXTI_NODE);
 	struct stm32_exti_data *data = dev->data;
 	uint32_t line_num = ll_exti_line_to_linenum(line);
 
-	if ((data->cb[line_num].cb == cb) && (data->cb[line_num].data == arg)) {
+	if ((data->cb[line_num].cb == cb) && (data->cb[line_num].data == user)) {
 		return 0;
 	}
 
@@ -330,7 +330,7 @@ int stm32_gpio_intc_set_irq_callback(stm32_gpio_irq_line_t line, stm32_gpio_irq_
 	}
 
 	data->cb[line_num].cb = cb;
-	data->cb[line_num].data = arg;
+	data->cb[line_num].data = user;
 
 	return 0;
 }

--- a/drivers/interrupt_controller/intc_gpio_stm32wb0.c
+++ b/drivers/interrupt_controller/intc_gpio_stm32wb0.c
@@ -268,11 +268,11 @@ void stm32_gpio_intc_select_line_trigger(stm32_gpio_irq_line_t line, uint32_t tr
 }
 
 int stm32_gpio_intc_set_irq_callback(stm32_gpio_irq_line_t line,
-					stm32_gpio_irq_cb_t cb, void *data)
+					stm32_gpio_irq_cb_t cb, void *user)
 {
 	struct gpio_irq_cb_wrp *cb_wrp = irq_cb_wrp_for_line(line);
 
-	if ((cb_wrp->fn == cb) && (cb_wrp->data == data)) {
+	if ((cb_wrp->fn == cb) && (cb_wrp->data == user)) {
 		return 0;
 	}
 
@@ -282,7 +282,7 @@ int stm32_gpio_intc_set_irq_callback(stm32_gpio_irq_line_t line,
 	}
 
 	cb_wrp->fn = cb;
-	cb_wrp->data = data;
+	cb_wrp->data = user;
 
 	return 0;
 }

--- a/include/zephyr/drivers/interrupt_controller/gpio_intc_stm32.h
+++ b/include/zephyr/drivers/interrupt_controller/gpio_intc_stm32.h
@@ -84,11 +84,11 @@ typedef void (*stm32_gpio_irq_cb_t)(gpio_port_pins_t pin, void *user);
  *
  * @param line	GPIO interrupt line
  * @param cb	Interrupt callback function
- * @param data	Custom data for usage by the callback
+ * @param user	Custom user data for usage by the callback
  * @returns 0 on success, -EBUSY if a callback is already set for @p line
  */
 int stm32_gpio_intc_set_irq_callback(stm32_gpio_irq_line_t line,
-					stm32_gpio_irq_cb_t cb, void *data);
+					stm32_gpio_irq_cb_t cb, void *user);
 
 /**
  * @brief Removes the interrupt callback of specified EXTI line
@@ -114,7 +114,7 @@ void stm32_exti_set_line_src_port(gpio_pin_t line, uint32_t port);
  * @param line	EXTI line number (= pin number)
  * @returns GPIO port number (STM32_PORTA, STM32_PORTB, ...)
  */
-uint32_t stm32_exti_get_line_src_port(gpio_pin_t pin);
+uint32_t stm32_exti_get_line_src_port(gpio_pin_t line);
 #endif /* CONFIG_EXTI_STM32 */
 
 #endif /* ZEPHYR_DRIVERS_INTERRUPT_CONTROLLER_GPIO_INTC_STM32_H_ */


### PR DESCRIPTION
Correct several inconsistent parameter names in the following functions:
- **stm32_gpio_intc_select_line_trigger**:
  rename `trigger` to `trg` to match the header file.
- **stm32_gpio_intc_set_irq_callback**:
  rename the callback argument to `user` to match the `stm32_gpio_irq_cb_t` type.
- **stm32_exti_get_line_src_port**:
  rename `pin` to `line` to align with the Doxygen comment and implementation.