### PR TITLE
documentation: lilygo: fix formatting for LoRa32 and T8C3

### DIFF
--- a/boards/lilygo/ttgo_lora32/doc/index.rst
+++ b/boards/lilygo/ttgo_lora32/doc/index.rst
@@ -6,7 +6,7 @@ Lilygo TTGO LoRa32
 Overview
 ********
 
-The Lilygo TTGO LoRa32 is a development board for LoRa applications baesed on the ESP32-PICO-D4.
+The Lilygo TTGO LoRa32 is a development board for LoRa applications based on the ESP32-PICO-D4.
 
 It's available in two versions supporting two different frequency ranges and features the following integrated components:
 
@@ -178,8 +178,8 @@ Build and flash applications as usual (see :ref:`build_an_application` and
    :board: ttgo_lora32/esp32/procpu
    :goals: build
 
-The usual ``flash`` target will work with the ``ttgo_lora32`` board
-configuration. Here is an example for the :zephyr:code-sample:`hello_world`
+The usual ``flash`` target will work with the ``ttgo_lora32`` board target.
+Here is an example for the :zephyr:code-sample:`hello_world`
 application.
 
 .. zephyr-app-commands::

--- a/boards/lilygo/ttgo_t8c3/doc/index.rst
+++ b/boards/lilygo/ttgo_t8c3/doc/index.rst
@@ -33,7 +33,7 @@ enabled by moving a 0-ohm resistor.
 Connections and IOs
 ===================
 
-The TTGO T8-C3 board configuration supports the following hardware features:
+The ``ttgo_t8c3`` board target supports the following hardware features:
 
 +-----------+------------+------------------+
 | Interface | Controller | Driver/Component |
@@ -176,9 +176,8 @@ Build and flash applications as usual (see :ref:`build_an_application` and
    :board: ttgo_t8c3
    :goals: build
 
-The usual ``flash`` target will work with the ``ttgo_t8c3`` board
-configuration. Here is an example for the :zephyr:code-sample:`hello_world`
-application.
+The usual ``flash`` target will work with the ``ttgo_t8c3`` board target.
+Here is an example for the :zephyr:code-sample:`hello_world` application.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/hello_world


### PR DESCRIPTION
Fix the formatting of the doc/index.rst for Lilygo LoRa32 and T8C3 Requested by @nordicjm 