### PR TITLE
doc: connectivity: networking: Update some CMake linker examples

### DIFF
--- a/doc/connectivity/networking/api/coap_server.rst
+++ b/doc/connectivity/networking/api/coap_server.rst
@@ -34,14 +34,20 @@ prefixed with ``coap_resource_`` and added to a linker file:
 
     #include <zephyr/linker/iterable_sections.h>
 
-    ITERABLE_SECTION_RAM(coap_resource_my_service, 4)
+    ITERABLE_SECTION_RAM(coap_resource_my_service, Z_LINK_ITERABLE_SUBALIGN)
 
 Add this linker file to your application using CMake:
 
 .. code-block:: cmake
     :caption: ``CMakeLists.txt``
 
+    # Support LD linker template
     zephyr_linker_sources(DATA_SECTIONS sections-ram.ld)
+
+    # Support CMake linker generator
+    zephyr_iterable_section(NAME coap_resource_my_service
+                            GROUP DATA_REGION ${XIP_ALIGN_WITH_INPUT}
+                            SUBALIGN ${CONFIG_LINKER_ITERABLE_SUBALIGN})
 
 You can now define your service as part of the application:
 

--- a/doc/connectivity/networking/api/http_server.rst
+++ b/doc/connectivity/networking/api/http_server.rst
@@ -78,7 +78,7 @@ using CMake:
     zephyr_linker_sources(SECTIONS sections-rom.ld)
     zephyr_linker_section(NAME http_resource_desc_my_service
                           KVMA RAM_REGION GROUP RODATA_REGION
-                          SUBALIGN Z_LINK_ITERABLE_SUBALIGN)
+                          SUBALIGN ${CONFIG_LINKER_ITERABLE_SUBALIGN})
 
 .. note::
 

--- a/samples/net/sockets/http_server/CMakeLists.txt
+++ b/samples/net/sockets/http_server/CMakeLists.txt
@@ -35,11 +35,11 @@ zephyr_linker_sources(SECTIONS sections-rom.ld)
 zephyr_linker_section_ifdef(CONFIG_NET_SAMPLE_HTTPS_SERVICE NAME
 				http_resource_desc_test_https_service
 				KVMA RAM_REGION GROUP RODATA_REGION
-				SUBALIGN Z_LINK_ITERABLE_SUBALIGN)
+				SUBALIGN ${CONFIG_LINKER_ITERABLE_SUBALIGN})
 zephyr_linker_section_ifdef(CONFIG_NET_SAMPLE_HTTP_SERVICE NAME
 				http_resource_desc_test_http_service
 				KVMA RAM_REGION GROUP RODATA_REGION
-				SUBALIGN Z_LINK_ITERABLE_SUBALIGN)
+				SUBALIGN ${CONFIG_LINKER_ITERABLE_SUBALIGN})
 
 foreach(web_resource
   index.html


### PR DESCRIPTION
- Add cmake linker generator information to CoAP server documentation
- Update HTTP server documentation with CMake variables used for linker subalignment
- Update HTTP server examples with CMake variables used for linker subalignment