### PR TITLE
soc: rw: Fix stack over flow during BLE init

### DIFF
--- a/soc/nxp/rw/Kconfig.defconfig
+++ b/soc/nxp/rw/Kconfig.defconfig
@@ -25,6 +25,9 @@ config HCI_NXP_ENABLE_AUTO_SLEEP
 config HCI_NXP_SET_CAL_DATA
 	default y
 
+config MAIN_STACK_SIZE
+	default 1280
+
 endif # BT
 
 config NXP_MONOLITHIC_WIFI


### PR DESCRIPTION
RW requires more stack size now (after NXP HAL update to 2.16),
Main stack value changed from 1024 to 1280 by default when BT is enabled.