### PR TITLE
tests: net: ipv6: Enable mbed TLS heap

### DIFF
--- a/tests/net/ipv6/prj.conf
+++ b/tests/net/ipv6/prj.conf
@@ -36,3 +36,6 @@ CONFIG_NET_IPV6_PE_PREFER_PUBLIC_ADDRESSES=n
 
 # Increase the stack a bit for mps2/an385
 CONFIG_NET_RX_STACK_SIZE=1700
+
+# Make sure mbedTLS has access to heap
+CONFIG_MBEDTLS_ENABLE_HEAP=y


### PR DESCRIPTION
mbed TLS MD operations, used by IPv6 Privacy Extensions, require access to heap. This may vary depending on platform/mbed TLS variant used, hence enable CONFIG_MBEDTLS_ENABLE_HEAP in tests to ensure mbed TLS has always access to some heap memory.