### PR TITLE
drivers: i2c: Introduce I2C timeout for SAM0

### DIFF
--- a/drivers/i2c/Kconfig.sam0
+++ b/drivers/i2c/Kconfig.sam0
@@ -17,3 +17,11 @@ config I2C_SAM0_DMA_DRIVEN
 	  DMA driven mode requires fewer interrupts to handle the
 	  transaction and ensures that high speed modes are not delayed
 	  by data reloading.
+
+config I2C_SAM0_TRANSFER_TIMEOUT
+	int "Transfer timeout [ms]"
+	default 500
+	help
+	  Timeout in milliseconds used for each I2C transfer.
+	  0 means that the driver should use the K_FOREVER value,
+	  i.e. it should wait as long as necessary.


### PR DESCRIPTION
Adds configurable timeout for I2C transactions and provides bus recovery functionality.

Tested on SAME53J20A