### PR TITLE
irq_multilevel: explicitly initialize all members to avoid a warning

### DIFF
--- a/include/zephyr/irq_multilevel.h
+++ b/include/zephyr/irq_multilevel.h
@@ -140,7 +140,9 @@ static inline unsigned int irq_to_level_2(unsigned int irq)
 {
 	_z_irq_t z_irq = {
 		.bits = {
+			.l1 = 0,
 			.l2 = irq + 1,
+			.l3 = 0,
 		},
 	};
 
@@ -212,6 +214,8 @@ static inline unsigned int irq_to_level_3(unsigned int irq)
 {
 	_z_irq_t z_irq = {
 		.bits = {
+			.l1 = 0,
+			.l2 = 0,
 			.l3 = irq + 1,
 		},
 	};


### PR DESCRIPTION
As this is a header, let's explicitly initialize all members of the struct to avoid a "missing initializer for member" warning in case the file is built with -Wmissing-field-initializers, or worse, that warning set to be an error.

Note there is currently a failure in main due to this:
https://github.com/zephyrproject-rtos/zephyr/actions/runs/11140251015/job/30959248906#step:11:1007