### PR TITLE
toolchain: match gcc 'missing-field-initializers' with others

### DIFF
--- a/cmake/compiler/gcc/compiler_flags.cmake
+++ b/cmake/compiler/gcc/compiler_flags.cmake
@@ -59,7 +59,7 @@ set_compiler_property(PROPERTY warning_dw_1
 )
 check_set_compiler_property(APPEND PROPERTY warning_dw_1
                             -Wlogical-op
-                            -Wmissing-field-initializers
+                            -Wno-missing-field-initializers
 )
 
 set_compiler_property(PROPERTY warning_dw_2
@@ -71,6 +71,7 @@ set_compiler_property(PROPERTY warning_dw_2
                       -Wpointer-arith
                       -Wredundant-decls
                       -Wswitch-default
+                      -Wmissing-field-initializers
 )
 check_set_compiler_property(APPEND PROPERTY warning_dw_2
                             -Wpacked-bitfield-compat


### PR DESCRIPTION
`arcmwdt` and `clang` both have `-Wno-missing-field-initializers` in `warning_dw_1` and
`-Wmissing-field-initializers` in `warning_dw_2` while `gcc` has `-Wmissing-field-initializers` in `warning_dw_1`, so update it to match.