### PR TITLE
irq: multilevel: make gcc happy by initializing all the fields

### DIFF
--- a/include/zephyr/irq_multilevel.h
+++ b/include/zephyr/irq_multilevel.h
@@ -140,7 +140,9 @@ static inline unsigned int irq_to_level_2(unsigned int irq)
 {
 	_z_irq_t z_irq = {
 		.bits = {
+			.l1 = 0,
 			.l2 = irq + 1,
+			.l3 = 0,
 		},
 	};
 
@@ -212,6 +214,8 @@ static inline unsigned int irq_to_level_3(unsigned int irq)
 {
 	_z_irq_t z_irq = {
 		.bits = {
+			.l1 = 0,
+			.l2 = 0,
 			.l3 = irq + 1,
 		},
 	};


### PR DESCRIPTION
gcc is complaining about missing field initializers when compiling C++ code, initialize all the fields to appease it.