### PR TITLE
modules: hal_nordic: Accesses app memory from net core in 802.15.4 serialization

### DIFF
--- a/modules/hal_nordic/nrf_802154/serialization/platform/nrf_802154_spinel_backend_ipc.c
+++ b/modules/hal_nordic/nrf_802154/serialization/platform/nrf_802154_spinel_backend_ipc.c
@@ -9,6 +9,11 @@
 #include <zephyr/device.h>
 #include <zephyr/logging/log.h>
 
+#if defined(CONFIG_SOC_NRF5340_CPUAPP)
+#include <nrf53_cpunet_mgmt.h>
+#include <hal/nrf_spu.h>
+#endif
+
 #include "nrf_802154.h"
 #include "nrf_802154_spinel_backend_callouts.h"
 #include "nrf_802154_serialization_error.h"
@@ -55,6 +60,14 @@ nrf_802154_ser_err_t nrf_802154_backend_init(void)
 	int err;
 
 #if defined(CONFIG_SOC_NRF5340_CPUAPP)
+
+#if !defined(CONFIG_TRUSTED_EXECUTION_NONSECURE)
+	/* Retain nRF5340 Network MCU in Secure domain (bus
+	 * accesses by Network MCU will have Secure attribute set).
+	 */
+	nrf_spu_extdomain_set((NRF_SPU_Type *)DT_REG_ADDR(DT_NODELABEL(spu)), 0, true, false);
+#endif /* !defined(CONFIG_TRUSTED_EXECUTION_NONSECURE) */
+
 	nrf53_cpunet_enable(true);
 #endif
 


### PR DESCRIPTION
Currently, the serialization module for 802.15.4 enabled the network core without giving it access to application core memory in trusted execution mode. This commit grands this access.