### PR TITLE
Bluetooth: CCP: Add support for set/get provider name

### DIFF
--- a/doc/connectivity/bluetooth/shell/audio/ccp.rst
+++ b/doc/connectivity/bluetooth/shell/audio/ccp.rst
@@ -13,12 +13,18 @@ The Server can be controlled locally, or by a remote device (when in a call). Fo
 example a remote device may initiate a call to the server,
 or the Server may initiate a call to remote device, without a client.
 
+For all commands that take an optional :code:`index`, if the index is not supplied then it defaults
+to :code:`0` which is the GTBS bearer.
+
 .. code-block:: console
 
    ccp_call_control_server --help
    ccp_call_control_server - Bluetooth CCP Call Control Server shell commands
    Subcommands:
-     init  : Initialize CCP Call Control Server
+     init             : Initialize CCP Call Control Server
+     set_bearer_name  : Set bearer name [index] <name>
+     get_bearer_name  : Get bearer name [index]
+
 
 Example Usage
 =============
@@ -33,6 +39,25 @@ Setup
    Registered GTBS bearer
    Registered bearer[1]
    uart:~$ bt connect xx:xx:xx:xx:xx:xx public
+
+Setting and getting the bearer name
+-----------------------------------
+
+.. code-block:: console
+
+   uart:~$ ccp_call_control_server get_bearer_name
+   Bearer[0] name: Generic TBS
+   uart:~$ ccp_call_control_server set_bearer_name "New name"
+   Bearer[0] name: New name
+   uart:~$ ccp_call_control_server get_bearer_name
+   Bearer[0] name: New name
+   uart:~$ ccp_call_control_server get_bearer_name 1
+   Bearer[1] name: Telephone Bearer #1
+   uart:~$ ccp_call_control_server set_bearer_name 1 "New TBS name"
+   Bearer[1] name: New TBS name
+   uart:~$ ccp_call_control_server get_bearer_name 1
+   Bearer[1] name: New TBS name
+
 
 Call Control Client
 *******************

--- a/include/zephyr/bluetooth/audio/ccp.h
+++ b/include/zephyr/bluetooth/audio/ccp.h
@@ -93,6 +93,33 @@ int bt_ccp_call_control_server_register_bearer(const struct bt_tbs_register_para
  */
 int bt_ccp_call_control_server_unregister_bearer(struct bt_ccp_call_control_server_bearer *bearer);
 
+/**
+ * @brief Set a new bearer provider name.
+ *
+ * @param bearer  The bearer to set the name for.
+ * @param name    The new bearer provider name.
+ *
+ * @retval 0 Success
+ * @retval -EINVAL @p bearer or @p name is NULL, or @p name is the empty string or @p name is larger
+ *                 than @kconfig{CONFIG_BT_TBS_MAX_PROVIDER_NAME_LENGTH}
+ * @retval -EFAULT @p bearer is not registered
+ */
+int bt_ccp_call_control_server_set_bearer_provider_name(
+	struct bt_ccp_call_control_server_bearer *bearer, const char *name);
+
+/**
+ * @brief Get the bearer provider name.
+ *
+ * @param[in]  bearer  The bearer to get the name for.
+ * @param[out] name    Pointer that will be updated to be the bearer provider name.
+ *
+ * @retval 0 Success
+ * @retval -EINVAL @p bearer or @p name is NULL
+ * @retval -EFAULT @p bearer is not registered
+ */
+int bt_ccp_call_control_server_get_bearer_provider_name(
+	struct bt_ccp_call_control_server_bearer *bearer, const char **name);
+
 /** @} */ /* End of group bt_ccp_call_control_server */
 
 /**

--- a/subsys/bluetooth/audio/Kconfig.ccp
+++ b/subsys/bluetooth/audio/Kconfig.ccp
@@ -50,6 +50,13 @@ config BT_CCP_CALL_CONTROL_SERVER_BEARER_COUNT
 	help
 	  The number of supported telephone bearers on the CCP Call Control Server
 
+config BT_CCP_CALL_CONTROL_SERVER_PROVIDER_NAME_MAX_LENGTH
+	int "The maximum length of the bearer provider name excluding null terminator"
+	default BT_TBS_MAX_PROVIDER_NAME_LENGTH
+	range 1 BT_TBS_MAX_PROVIDER_NAME_LENGTH
+	help
+	  Sets the maximum length of the bearer provider name.
+
 module = BT_CCP_CALL_CONTROL_SERVER
 module-str = "Call Control Profile Call Control Server"
 source "subsys/logging/Kconfig.template.log_config"

--- a/subsys/bluetooth/audio/Kconfig.tbs
+++ b/subsys/bluetooth/audio/Kconfig.tbs
@@ -263,7 +263,7 @@ config BT_TBS_MAX_URI_LENGTH
 config BT_TBS_MAX_PROVIDER_NAME_LENGTH
 	int "The maximum length of the bearer provider name"
 	default 30
-	range 0 512
+	range 1 512
 	help
 	  Sets the maximum length of the bearer provider name.
 

--- a/subsys/bluetooth/audio/ccp_call_control_server.c
+++ b/subsys/bluetooth/audio/ccp_call_control_server.c
@@ -9,6 +9,7 @@
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <string.h>
 
 #include <zephyr/autoconf.h>
 #include <zephyr/bluetooth/audio/tbs.h>
@@ -20,6 +21,7 @@ LOG_MODULE_REGISTER(bt_ccp_call_control_server, CONFIG_BT_CCP_CALL_CONTROL_SERVE
 
 /* A service instance can either be a GTBS or a TBS instance */
 struct bt_ccp_call_control_server_bearer {
+	char provider_name[CONFIG_BT_CCP_CALL_CONTROL_SERVER_PROVIDER_NAME_MAX_LENGTH + 1];
 	uint8_t tbs_index;
 	bool registered;
 };
@@ -70,6 +72,8 @@ int bt_ccp_call_control_server_register_bearer(const struct bt_tbs_register_para
 
 	free_bearer->registered = true;
 	free_bearer->tbs_index = (uint8_t)ret;
+	(void)utf8_lcpy(free_bearer->provider_name, param->provider_name,
+			sizeof(free_bearer->provider_name));
 	*bearer = free_bearer;
 
 	return 0;
@@ -102,6 +106,71 @@ int bt_ccp_call_control_server_unregister_bearer(struct bt_ccp_call_control_serv
 	}
 
 	bearer->registered = false;
+
+	return 0;
+}
+
+int bt_ccp_call_control_server_set_bearer_provider_name(
+	struct bt_ccp_call_control_server_bearer *bearer, const char *name)
+{
+	size_t len;
+
+	CHECKIF(bearer == NULL) {
+		LOG_DBG("bearer is NULL");
+
+		return -EINVAL;
+	}
+
+	CHECKIF(name == NULL) {
+		LOG_DBG("name is NULL");
+
+		return -EINVAL;
+	}
+
+	if (!bearer->registered) {
+		LOG_DBG("Bearer %p not registered", bearer);
+
+		return -EFAULT;
+	}
+
+	len = strlen(name);
+	if (len > CONFIG_BT_CCP_CALL_CONTROL_SERVER_PROVIDER_NAME_MAX_LENGTH || len == 0) {
+		LOG_DBG("Invalid name length: %zu", len);
+
+		return -EINVAL;
+	}
+
+	if (strcmp(bearer->provider_name, name) == 0) {
+		return 0;
+	}
+
+	(void)utf8_lcpy(bearer->provider_name, name, sizeof(bearer->provider_name));
+
+	return bt_tbs_set_bearer_provider_name(bearer->tbs_index, name);
+}
+
+int bt_ccp_call_control_server_get_bearer_provider_name(
+	struct bt_ccp_call_control_server_bearer *bearer, const char **name)
+{
+	CHECKIF(bearer == NULL) {
+		LOG_DBG("bearer is NULL");
+
+		return -EINVAL;
+	}
+
+	CHECKIF(name == NULL) {
+		LOG_DBG("name is NULL");
+
+		return -EINVAL;
+	}
+
+	if (!bearer->registered) {
+		LOG_DBG("Bearer %p not registered", bearer);
+
+		return -EFAULT;
+	}
+
+	*name = bearer->provider_name;
 
 	return 0;
 }

--- a/subsys/bluetooth/audio/tbs.c
+++ b/subsys/bluetooth/audio/tbs.c
@@ -68,6 +68,10 @@ struct tbs_flags {
 /* A service instance can either be a GTBS or a TBS instance */
 struct tbs_inst {
 	/* Attribute values */
+	/* TODO: The provider name should be removed from the tbs_inst and instead by stored by the
+	 * user of TBS. This will be done once the CCP API is complete as the CCP Server will own
+	 * all the data instead of the TBS
+	 */
 	char provider_name[CONFIG_BT_TBS_MAX_PROVIDER_NAME_LENGTH];
 	char uci[BT_TBS_MAX_UCI_SIZE];
 	uint8_t technology;


### PR DESCRIPTION
Add support for setting and getting the bearer provider
name. For now the name will be duplicated by the TBS
implementation, but will be optimizied in the future
so only one copy of the name exists.