### PR TITLE
bluetooth: tester: audio: Add verification for bis stopping

### DIFF
--- a/tests/bluetooth/tester/src/audio/btp_bap_broadcast.h
+++ b/tests/bluetooth/tester/src/audio/btp_bap_broadcast.h
@@ -45,6 +45,7 @@ struct btp_bap_broadcast_local_source {
 	struct bt_audio_codec_qos qos;
 	struct btp_bap_broadcast_stream streams[CONFIG_BT_BAP_BROADCAST_SRC_STREAM_COUNT];
 	struct bt_audio_codec_cfg subgroup_codec_cfg[CONFIG_BT_BAP_BROADCAST_SRC_SUBGROUP_COUNT];
+	uint8_t stream_count;
 	/* Only for BTP BAP commands */
 	struct bt_bap_broadcast_source *bap_broadcast;
 	/* Only for BTP CAP commands */


### PR DESCRIPTION
Adds a semaphor to make sure the stream has properly been stopped by the
controller before returning from btp_bap_broadcast_source_stop.

fixes: https://github.com/zephyrproject-rtos/zephyr/issues/73411