### PR TITLE
drivers: adc: add support for nRF54L internal SAADC inputs

### DIFF
--- a/drivers/adc/adc_nrfx_saadc.c
+++ b/drivers/adc/adc_nrfx_saadc.c
@@ -7,7 +7,8 @@
 #define ADC_CONTEXT_USES_KERNEL_TIMER
 #include "adc_context.h"
 #include <haly/nrfy_saadc.h>
-#include <zephyr/dt-bindings/adc/nrf-adc.h>
+#include <zephyr/dt-bindings/adc/nrf-saadc-v3.h>
+#include <zephyr/dt-bindings/adc/nrf-saadc-nrf54l.h>
 #include <zephyr/linker/devicetree_regions.h>
 
 #define LOG_LEVEL CONFIG_ADC_LOG_LEVEL

--- a/dts/arm/nordic/nrf51822.dtsi
+++ b/dts/arm/nordic/nrf51822.dtsi
@@ -2,6 +2,7 @@
 
 #include <arm/armv6-m.dtsi>
 #include <nordic/nrf_common.dtsi>
+#include <zephyr/dt-bindings/adc/nrf-adc.h>
 
 / {
 	chosen {

--- a/dts/arm/nordic/nrf52805.dtsi
+++ b/dts/arm/nordic/nrf52805.dtsi
@@ -6,6 +6,7 @@
 
 #include <arm/armv7-m.dtsi>
 #include <nordic/nrf_common.dtsi>
+#include <zephyr/dt-bindings/adc/nrf-saadc-v2.h>
 #include <zephyr/dt-bindings/regulator/nrf5x.h>
 
 / {

--- a/dts/arm/nordic/nrf52810.dtsi
+++ b/dts/arm/nordic/nrf52810.dtsi
@@ -2,6 +2,7 @@
 
 #include <arm/armv7-m.dtsi>
 #include <nordic/nrf_common.dtsi>
+#include <zephyr/dt-bindings/adc/nrf-saadc-v2.h>
 #include <zephyr/dt-bindings/regulator/nrf5x.h>
 
 / {

--- a/dts/arm/nordic/nrf52811.dtsi
+++ b/dts/arm/nordic/nrf52811.dtsi
@@ -6,6 +6,7 @@
 
 #include <arm/armv7-m.dtsi>
 #include <nordic/nrf_common.dtsi>
+#include <zephyr/dt-bindings/adc/nrf-saadc-v2.h>
 #include <zephyr/dt-bindings/regulator/nrf5x.h>
 
 / {

--- a/dts/arm/nordic/nrf52832.dtsi
+++ b/dts/arm/nordic/nrf52832.dtsi
@@ -2,6 +2,7 @@
 
 #include <arm/armv7-m.dtsi>
 #include <nordic/nrf_common.dtsi>
+#include <zephyr/dt-bindings/adc/nrf-saadc-v2.h>
 #include <zephyr/dt-bindings/regulator/nrf5x.h>
 
 / {

--- a/dts/arm/nordic/nrf52833.dtsi
+++ b/dts/arm/nordic/nrf52833.dtsi
@@ -6,6 +6,7 @@
 
 #include <arm/armv7-m.dtsi>
 #include <nordic/nrf_common.dtsi>
+#include <zephyr/dt-bindings/adc/nrf-saadc-v3.h>
 #include <zephyr/dt-bindings/regulator/nrf5x.h>
 
 / {

--- a/dts/arm/nordic/nrf52840.dtsi
+++ b/dts/arm/nordic/nrf52840.dtsi
@@ -2,6 +2,7 @@
 
 #include <arm/armv7-m.dtsi>
 #include <nordic/nrf_common.dtsi>
+#include <zephyr/dt-bindings/adc/nrf-saadc-v3.h>
 #include <zephyr/dt-bindings/regulator/nrf5x.h>
 
 / {

--- a/dts/arm/nordic/nrf5340_cpuapp.dtsi
+++ b/dts/arm/nordic/nrf5340_cpuapp.dtsi
@@ -6,6 +6,7 @@
 
 #include <arm/armv8-m.dtsi>
 #include <nordic/nrf_common.dtsi>
+#include <zephyr/dt-bindings/adc/nrf-saadc-v3.h>
 
 / {
 	cpus {

--- a/dts/arm/nordic/nrf5340_cpuappns.dtsi
+++ b/dts/arm/nordic/nrf5340_cpuappns.dtsi
@@ -8,6 +8,7 @@
 
 #include <arm/armv8-m.dtsi>
 #include <nordic/nrf_common.dtsi>
+#include <zephyr/dt-bindings/adc/nrf-saadc-v3.h>
 
 / {
 	cpus {

--- a/dts/arm/nordic/nrf91.dtsi
+++ b/dts/arm/nordic/nrf91.dtsi
@@ -6,6 +6,7 @@
 
 #include <arm/armv8-m.dtsi>
 #include <nordic/nrf_common.dtsi>
+#include <zephyr/dt-bindings/adc/nrf-saadc-v2.h>
 
 / {
 	cpus {

--- a/dts/arm/nordic/nrf91ns.dtsi
+++ b/dts/arm/nordic/nrf91ns.dtsi
@@ -6,6 +6,7 @@
 
 #include <arm/armv8-m.dtsi>
 #include <nordic/nrf_common.dtsi>
+#include <zephyr/dt-bindings/adc/nrf-saadc-v2.h>
 
 / {
 	cpus {

--- a/dts/common/nordic/nrf54h20.dtsi
+++ b/dts/common/nordic/nrf54h20.dtsi
@@ -7,6 +7,7 @@
 #include <mem.h>
 #include <nordic/nrf_common.dtsi>
 
+#include <zephyr/dt-bindings/adc/nrf-saadc.h>
 #include <zephyr/dt-bindings/misc/nordic-nrf-ficr-nrf54h20.h>
 #include <zephyr/dt-bindings/misc/nordic-domain-id-nrf54h20.h>
 #include <zephyr/dt-bindings/misc/nordic-owner-id-nrf54h20.h>

--- a/dts/common/nordic/nrf54l15.dtsi
+++ b/dts/common/nordic/nrf54l15.dtsi
@@ -6,6 +6,7 @@
 
 #include <mem.h>
 #include <nordic/nrf_common.dtsi>
+#include <zephyr/dt-bindings/adc/nrf-saadc-nrf54l.h>
 #include <zephyr/dt-bindings/regulator/nrf5x.h>
 
 /delete-node/ &sw_pwm;

--- a/dts/common/nordic/nrf54l20.dtsi
+++ b/dts/common/nordic/nrf54l20.dtsi
@@ -6,6 +6,7 @@
 
 #include <mem.h>
 #include <nordic/nrf_common.dtsi>
+#include <zephyr/dt-bindings/adc/nrf-saadc-nrf54l.h>
 #include <zephyr/dt-bindings/regulator/nrf5x.h>
 
 /delete-node/ &sw_pwm;

--- a/dts/common/nordic/nrf9280.dtsi
+++ b/dts/common/nordic/nrf9280.dtsi
@@ -6,7 +6,7 @@
 
 #include <mem.h>
 #include <nordic/nrf_common.dtsi>
-
+#include <zephyr/dt-bindings/adc/nrf-saadc.h>
 #include <zephyr/dt-bindings/misc/nordic-nrf-ficr-nrf9230-engb.h>
 #include <zephyr/dt-bindings/misc/nordic-domain-id-nrf9230.h>
 #include <zephyr/dt-bindings/misc/nordic-owner-id-nrf9230.h>

--- a/dts/common/nordic/nrf_common.dtsi
+++ b/dts/common/nordic/nrf_common.dtsi
@@ -5,7 +5,6 @@
  */
 
 #include <zephyr/dt-bindings/adc/adc.h>
-#include <zephyr/dt-bindings/adc/nrf-adc.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>

--- a/include/zephyr/dt-bindings/adc/nrf-adc.h
+++ b/include/zephyr/dt-bindings/adc/nrf-adc.h
@@ -18,15 +18,4 @@
 #define NRF_ADC_AIN6 BIT(6)
 #define NRF_ADC_AIN7 BIT(7)
 
-#define NRF_SAADC_AIN0     1
-#define NRF_SAADC_AIN1     2
-#define NRF_SAADC_AIN2     3
-#define NRF_SAADC_AIN3     4
-#define NRF_SAADC_AIN4     5
-#define NRF_SAADC_AIN5     6
-#define NRF_SAADC_AIN6     7
-#define NRF_SAADC_AIN7     8
-#define NRF_SAADC_VDD      9
-#define NRF_SAADC_VDDHDIV5 13
-
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_ADC_NRF_ADC_H_ */

--- a/include/zephyr/dt-bindings/adc/nrf-saadc-nrf54l.h
+++ b/include/zephyr/dt-bindings/adc/nrf-saadc-nrf54l.h
@@ -1,0 +1,15 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ */
+
+#ifndef ZEPHYR_INCLUDE_DT_BINDINGS_ADC_NRF_SAADC_NRF54L_H_
+#define ZEPHYR_INCLUDE_DT_BINDINGS_ADC_NRF_SAADC_NRF54L_H_
+
+#include <zephyr/dt-bindings/adc/nrf-saadc-v2.h>
+
+#define NRF_SAADC_AVDD 10
+#define NRF_SAADC_DVDD 11
+
+#endif /* ZEPHYR_INCLUDE_DT_BINDINGS_ADC_NRF_SAADC_NRF54L_H_ */

--- a/include/zephyr/dt-bindings/adc/nrf-saadc-v2.h
+++ b/include/zephyr/dt-bindings/adc/nrf-saadc-v2.h
@@ -1,0 +1,14 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ */
+
+#ifndef ZEPHYR_INCLUDE_DT_BINDINGS_ADC_NRF_SAADC_V2_H_
+#define ZEPHYR_INCLUDE_DT_BINDINGS_ADC_NRF_SAADC_V2_H_
+
+#include <zephyr/dt-bindings/adc/nrf-saadc.h>
+
+#define NRF_SAADC_VDD 9
+
+#endif /* ZEPHYR_INCLUDE_DT_BINDINGS_ADC_NRF_SAADC_V2_H_ */

--- a/include/zephyr/dt-bindings/adc/nrf-saadc-v3.h
+++ b/include/zephyr/dt-bindings/adc/nrf-saadc-v3.h
@@ -1,0 +1,14 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ */
+
+#ifndef ZEPHYR_INCLUDE_DT_BINDINGS_ADC_NRF_SAADC_V3_H_
+#define ZEPHYR_INCLUDE_DT_BINDINGS_ADC_NRF_SAADC_V3_H_
+
+#include <zephyr/dt-bindings/adc/nrf-saadc-v2.h>
+
+#define NRF_SAADC_VDDHDIV5 13
+
+#endif /* ZEPHYR_INCLUDE_DT_BINDINGS_ADC_NRF_SAADC_V3_H_ */

--- a/include/zephyr/dt-bindings/adc/nrf-saadc.h
+++ b/include/zephyr/dt-bindings/adc/nrf-saadc.h
@@ -1,0 +1,19 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ */
+
+#ifndef ZEPHYR_INCLUDE_DT_BINDINGS_ADC_NRF_SAADC_H_
+#define ZEPHYR_INCLUDE_DT_BINDINGS_ADC_NRF_SAADC_H_
+
+#define NRF_SAADC_AIN0 1
+#define NRF_SAADC_AIN1 2
+#define NRF_SAADC_AIN2 3
+#define NRF_SAADC_AIN3 4
+#define NRF_SAADC_AIN4 5
+#define NRF_SAADC_AIN5 6
+#define NRF_SAADC_AIN6 7
+#define NRF_SAADC_AIN7 8
+
+#endif /* ZEPHYR_INCLUDE_DT_BINDINGS_ADC_NRF_SAADC_H_ */

--- a/samples/drivers/adc/adc_dt/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/samples/drivers/adc/adc_dt/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -6,7 +6,7 @@
 
 / {
 	zephyr,user {
-		io-channels = <&adc 0>, <&adc 1>, <&adc 7>;
+		io-channels = <&adc 0>, <&adc 1>, <&adc 2>, <&adc 7>;
 	};
 };
 
@@ -29,6 +29,16 @@
 		zephyr,reference = "ADC_REF_INTERNAL";
 		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
 		zephyr,input-positive = <NRF_SAADC_AIN2>; /* P1.06 */
+		zephyr,resolution = <12>;
+		zephyr,oversampling = <8>;
+	};
+
+	channel@2 {
+		reg = <2>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,input-positive = <NRF_SAADC_VDD>;
 		zephyr,resolution = <12>;
 		zephyr,oversampling = <8>;
 	};

--- a/samples/drivers/adc/adc_sequence/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/samples/drivers/adc/adc_sequence/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -6,7 +6,7 @@
 
 / {
 	zephyr,user {
-		io-channels = <&adc 0>, <&adc 1>, <&adc 7>;
+		io-channels = <&adc 0>, <&adc 1>, <&adc 2>, <&adc 7>;
 	};
 };
 
@@ -35,6 +35,16 @@
 		zephyr,reference = "ADC_REF_INTERNAL";
 		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
 		zephyr,input-positive = <NRF_SAADC_AIN2>; /* P1.06 */
+		zephyr,resolution = <12>;
+		zephyr,oversampling = <8>;
+	};
+
+	channel@2 {
+		reg = <2>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,input-positive = <NRF_SAADC_DVDD>; /* 0.9 V internal */
 		zephyr,resolution = <12>;
 		zephyr,oversampling = <8>;
 	};


### PR DESCRIPTION
Disregard first commit - this PR is based upon: https://github.com/zephyrproject-rtos/zephyr/pull/79121

nRF54L SAADC peripheral allows to choose internal voltage sources (VDD, AVDD, DVDD) as inputs. This PR allows to utilize those by the `adc` driver