### PR TITLE
net: lwm2m: Add shell command for listing resources

### DIFF
--- a/doc/connectivity/networking/api/lwm2m.rst
+++ b/doc/connectivity/networking/api/lwm2m.rst
@@ -789,6 +789,9 @@ required actions from the server side.
     resume  :LwM2M engine thread resume
     lock    :Lock the LwM2M registry
     unlock  :Unlock the LwM2M registry
+    obs     : List observations
+    ls      : ls [PATH]
+            List objects, instances, resources
 
 
 


### PR DESCRIPTION
Add shell command for listing multiple objects, resources or resource instances.

When developing or debugging, sometimes you don't remeber exact resource numbers, but still want to take a quick look of resource contents.
Instead of browsing the content through LwM2M server UI, you can now use shell to do so.

`lwm2m ls  /` for listing all objects and resources.
`lwm2m ls /<obj>` for listing all instances of specific object
`lwm2m ls /<obj>/<inst>` for listing all resources of this object instance.
`lwm2m ls /<obj>/<inst>/<res>` is just an alias for `lwm2m read <path>

### Example

```
uart:~$ lwm2m ls /
3/0/0 : Zephyr
3/0/1 : OMA-LWM2M Sample Client
3/0/2 : 345000123
3/0/3 : 1.0
3/0/6/0 : 1
3/0/6/1 : 5
3/0/7/0 : 3800
3/0/7/1 : 5000
3/0/8/0 : 125
3/0/8/1 : 900
3/0/9 : 95
3/0/10 : 15
3/0/11/0 : 0
3/0/16 : U
3/0/17 : mps2
3/0/18 : 1.0.1
3/0/20 : 1
3/0/21 : 25
5/0/3 : 0
5/0/5 : 0
5/0/8/0 : 0
5/0/9 : 2
0/0/0 : coaps://192.0.2.2:5784
0/0/1 : 1
0/0/2 : 0
0/0/3 : OPAQUE(4/32)
0/0/5 : OPAQUE(16/32)
0/0/10 : 0
0/1/0 : coap://192.0.2.2:5683
0/1/1 : 0
0/1/2 : 3
0/1/10 : 123
1/0/0 : 123
1/0/1 : 300
1/0/2 : 1
1/0/3 : 0
1/0/5 : 86400
1/0/6 : 1
1/0/7 : U
1/0/13 : 0
1/0/16 : 1
1/0/23 : 0
3311/0/5850 : 0
3311/0/5851 : 0
3311/0/5852 : 0
3311/0/5805 : 0.000000
3311/0/5820 : 0.000000
3311/0/5750 : Test light
3303/0/5700 : 23.259561
3303/0/5701 : Celcius
3303/0/5601 : 23.259561
3303/0/5602 : 23.259561
3303/0/5603 : 0.000000
3303/0/5604 : 100.000000
3340/0/5521 : 5.000000
3340/0/5538 : 0.000000
3340/0/5525 : 0.000000
3340/0/5850 : 1
3340/0/5544 : 0.000000
3340/0/5543 : 0
3340/0/5534 : 0
3340/0/5526 : 1
3340/0/5750 : Test timer
uart:~$ lwm2m ls /0
0/0/0 : coaps://192.0.2.2:5784
0/0/1 : 1
0/0/2 : 0
0/0/3 : OPAQUE(4/32)
0/0/5 : OPAQUE(16/32)
0/0/10 : 0
0/1/0 : coap://192.0.2.2:5683
0/1/1 : 0
0/1/2 : 3
0/1/10 : 123
uart:~$ lwm2m ls /0/1
0/1/0 : coap://192.0.2.2:5683
0/1/1 : 0
0/1/2 : 3
0/1/10 : 123
uart:~$ lwm2m ls /0/1/0
00000000: 63 6f 61 70 3a 2f 2f 31  39 32 2e 30 2e 32 2e 32 |coap://1 92.0.2.2|
00000010: 3a 35 36 38 33 00                                |:5683.           |

```