### PR TITLE
boards: nordic: Add cache alignment for cpusec IPC for nRF54H20DK and nRF9280PDK

### DIFF
--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20-ipc_conf.dtsi
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20-ipc_conf.dtsi
@@ -9,6 +9,7 @@
 		cpusec_cpuapp_ipc: ipc-1-2 {
 			compatible = "zephyr,ipc-icmsg";
 			status = "disabled";
+			dcache-alignment = <32>;
 			mboxes = <&cpusec_bellboard 12>,
 				 <&cpuapp_bellboard 0>;
 		};
@@ -16,6 +17,7 @@
 		cpusec_cpurad_ipc: ipc-1-3 {
 			compatible = "zephyr,ipc-icmsg";
 			status = "disabled";
+			dcache-alignment = <32>;
 			mboxes = <&cpusec_bellboard 18>,
 				 <&cpurad_bellboard 0>;
 		};

--- a/boards/nordic/nrf9280pdk/nrf9280pdk_nrf9280-ipc_conf.dtsi
+++ b/boards/nordic/nrf9280pdk/nrf9280pdk_nrf9280-ipc_conf.dtsi
@@ -9,6 +9,7 @@
 		cpusec_cpuapp_ipc: ipc-1-2 {
 			compatible = "zephyr,ipc-icmsg";
 			status = "disabled";
+			dcache-alignment = <32>;
 			mboxes = <&cpusec_bellboard 12>,
 				 <&cpuapp_bellboard 0>;
 		};
@@ -16,6 +17,7 @@
 		cpusec_cpurad_ipc: ipc-1-3 {
 			compatible = "zephyr,ipc-icmsg";
 			status = "disabled";
+			dcache-alignment = <32>;
 			mboxes = <&cpusec_bellboard 18>,
 				 <&cpurad_bellboard 0>;
 		};


### PR DESCRIPTION
Set data cache alignment for nodes defining IPC towards cpusec on nRF54H20 and nRF9280PDK.