### PR TITLE
devicetree: make DT_..._REG_SIZE return unsigned

### DIFF
--- a/doc/releases/migration-guide-4.0.rst
+++ b/doc/releases/migration-guide-4.0.rst
@@ -43,6 +43,8 @@ Devicetree
 * The :c:macro:`DT_REG_ADDR` macro and its variants are now expanding into an
   unsigned literals (i.e. with a ``U`` suffix). To use addresses as devicetree
   indexes use the :c:macro:`DT_REG_ADDR_RAW` variants.
+* The :c:macro:`DT_REG_SIZE` macro and its variants are also expanding into
+  unsigned literals, no raw variants are provided at this stage.
 
 STM32
 =====

--- a/include/zephyr/devicetree.h
+++ b/include/zephyr/devicetree.h
@@ -2292,7 +2292,7 @@
  * @return size of the idx-th register block
  */
 #define DT_REG_SIZE_BY_IDX(node_id, idx) \
-	DT_CAT4(node_id, _REG_IDX_, idx, _VAL_SIZE)
+	DT_U32_C(DT_CAT4(node_id, _REG_IDX_, idx, _VAL_SIZE))
 
 /**
  * @brief Get a node's (only) register block address
@@ -2367,7 +2367,7 @@
  * @return size of the register block specified by name
  */
 #define DT_REG_SIZE_BY_NAME(node_id, name) \
-	DT_CAT4(node_id, _REG_NAME_, name, _VAL_SIZE)
+	DT_U32_C(DT_CAT4(node_id, _REG_NAME_, name, _VAL_SIZE))
 
 /**
  * @brief Like DT_REG_SIZE_BY_NAME(), but with a fallback to @p default_value


### PR DESCRIPTION
Simiarly to f98fde07b30, make the SIZE macros return unsigned literal values.