### PR TITLE
xtensa: fix insecure userspace warning wording

### DIFF
--- a/arch/xtensa/CMakeLists.txt
+++ b/arch/xtensa/CMakeLists.txt
@@ -7,5 +7,5 @@ add_subdirectory(core)
 if (CONFIG_XTENSA_INSECURE_USERSPACE)
   message(WARNING "
   This userspace implementation uses the window ABI this means that the kernel
-  will spill registers in behave of the userpsace. Use it carefully.")
+  will spill registers on behalf of the userpsace. Use it carefully.")
 endif()


### PR DESCRIPTION
"in behave of" -> "on behalf of", which is more accurate of what is actually happening in the code.