### PR TITLE
boards: esp32xx: Use common partition tables

### DIFF
--- a/boards/01space/esp32c3_042_oled/esp32c3_042_oled.dts
+++ b/boards/01space/esp32c3_042_oled/esp32c3_042_oled.dts
@@ -9,6 +9,7 @@
 
 #include <espressif/esp32c3/esp32c3_fx4.dtsi>
 #include "esp32c3_042_oled-pinctrl.dtsi"
+#include <espressif/partitions_0x0_default.dtsi>
 
 / {
 	model = "01space ESP32C3 0.42 OLED";
@@ -103,38 +104,4 @@
 
 &esp32_bt_hci {
 	status = "okay";
-};
-
-&flash0 {
-	partitions {
-		compatible = "fixed-partitions";
-		#address-cells = <1>;
-		#size-cells = <1>;
-
-		boot_partition: partition@0 {
-			label = "mcuboot";
-			reg = <0x00000000 0x0000F000>;
-			read-only;
-		};
-
-		slot0_partition: partition@10000 {
-			label = "image-0";
-			reg = <0x00010000 0x00100000>;
-		};
-
-		slot1_partition: partition@110000 {
-			label = "image-1";
-			reg = <0x00110000 0x00100000>;
-		};
-
-		scratch_partition: partition@210000 {
-			label = "image-scratch";
-			reg = <0x00210000 0x00040000>;
-		};
-
-		storage_partition: partition@250000 {
-			label = "storage";
-			reg = <0x00250000 0x00006000>;
-		};
-	};
 };

--- a/boards/dptechnics/walter/walter_esp32s3_appcpu.dts
+++ b/boards/dptechnics/walter/walter_esp32s3_appcpu.dts
@@ -5,7 +5,7 @@
  */
 /dts-v1/;
 
-#include <espressif/esp32s3/esp32s3_appcpu.dtsi>
+#include "espressif/esp32s3/esp32s3_wroom_n16r2.dtsi"
 #include <espressif/partitions_0x0_amp.dtsi>
 
 / {

--- a/boards/espressif/esp32s3_devkitc/esp32s3_devkitc_appcpu.dts
+++ b/boards/espressif/esp32s3_devkitc/esp32s3_devkitc_appcpu.dts
@@ -5,7 +5,7 @@
  */
 /dts-v1/;
 
-#include <espressif/esp32s3/esp32s3_appcpu.dtsi>
+#include <espressif/esp32s3/esp32s3_wroom_n8.dtsi>
 #include <espressif/partitions_0x0_amp.dtsi>
 #include "esp32s3_devkitc-pinctrl.dtsi"
 

--- a/boards/espressif/esp32s3_devkitm/esp32s3_devkitm_appcpu.dts
+++ b/boards/espressif/esp32s3_devkitm/esp32s3_devkitm_appcpu.dts
@@ -5,7 +5,7 @@
  */
 /dts-v1/;
 
-#include <espressif/esp32s3/esp32s3_appcpu.dtsi>
+#include <espressif/esp32s3/esp32s3_mini_n8.dtsi>
 #include <espressif/partitions_0x0_amp.dtsi>
 #include "esp32s3_devkitm-pinctrl.dtsi"
 

--- a/boards/espressif/esp32s3_eye/esp32s3_eye_appcpu.dts
+++ b/boards/espressif/esp32s3_eye/esp32s3_eye_appcpu.dts
@@ -21,6 +21,10 @@
 	};
 };
 
+&flash0 {
+	reg = <0x0 DT_SIZE_M(4)>;
+};
+
 &trng0 {
 	status = "okay";
 };

--- a/boards/espressif/esp32s3_eye/esp32s3_eye_procpu.dts
+++ b/boards/espressif/esp32s3_eye/esp32s3_eye_procpu.dts
@@ -10,6 +10,7 @@
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 #include <zephyr/dt-bindings/input/esp32-touch-sensor-input.h>
 #include <zephyr/dt-bindings/mipi_dbi/mipi_dbi.h>
+#include <espressif/partitions_0x0_amp.dtsi>
 
 / {
 	model = "Espressif ESP32S3-EYE PROCPU";
@@ -198,45 +199,6 @@
 
 &trng0 {
 	status = "okay";
-};
-
-&flash0 {
-	status = "okay";
-	partitions {
-		compatible = "fixed-partitions";
-		#address-cells = <1>;
-		#size-cells = <1>;
-
-		/* Reserve 64kB for the bootloader */
-		boot_partition: partition@0 {
-			label = "mcuboot";
-			reg = <0x00000000 0x00010000>;
-			read-only;
-		};
-
-		/* Reserve 1024kB for the application in slot 0 */
-		slot0_partition: partition@10000 {
-			label = "image-0";
-			reg = <0x00010000 0x00100000>;
-		};
-
-		/* Reserve 1024kB for the application in slot 1 */
-		slot1_partition: partition@110000 {
-			label = "image-1";
-			reg = <0x00110000 0x00100000>;
-		};
-
-		/* Reserve 256kB for the scratch partition */
-		scratch_partition: partition@210000 {
-			   label = "image-scratch";
-			   reg = <0x00210000 0x00040000>;
-		};
-
-		storage_partition: partition@250000 {
-			label = "storage";
-			reg = <0x00250000 0x00006000>;
-		};
-	};
 };
 
 &esp32_bt_hci {

--- a/boards/franzininho/esp32s2_franzininho/esp32s2_franzininho.dts
+++ b/boards/franzininho/esp32s2_franzininho/esp32s2_franzininho.dts
@@ -8,6 +8,7 @@
 
 #include <espressif/esp32s2/esp32s2_wroom.dtsi>
 #include "esp32s2_franzininho-pinctrl.dtsi"
+#include <espressif/partitions_0x1000_default.dtsi>
 
 / {
 	model = "ESP32S2 Franzininho";
@@ -105,45 +106,6 @@
 	status = "okay";
 	pinctrl-0 = <&spim3_default>;
 	pinctrl-names = "default";
-};
-
-&flash0 {
-	status = "okay";
-	partitions {
-		compatible = "fixed-partitions";
-		#address-cells = <1>;
-		#size-cells = <1>;
-
-		/* Reserve 60kB for the bootloader */
-		boot_partition: partition@1000 {
-			label = "mcuboot";
-			reg = <0x00001000 0x0000F000>;
-			read-only;
-		};
-
-		/* Reserve 1024kB for the application in slot 0 */
-		slot0_partition: partition@10000 {
-			label = "image-0";
-			reg = <0x00010000 0x00100000>;
-		};
-
-		/* Reserve 1024kB for the application in slot 1 */
-		slot1_partition: partition@110000 {
-			label = "image-1";
-			reg = <0x00110000 0x00100000>;
-		};
-
-		/* Reserve 256kB for the scratch partition */
-		scratch_partition: partition@210000 {
-			   label = "image-scratch";
-			   reg = <0x00210000 0x00040000>;
-		};
-
-		storage_partition: partition@250000 {
-			label = "storage";
-			reg = <0x00250000 0x00006000>;
-		};
-	};
 };
 
 &wdt0 {

--- a/boards/heltec/heltec_wifi_lora32_v2/heltec_wifi_lora32_v2_appcpu.dts
+++ b/boards/heltec/heltec_wifi_lora32_v2/heltec_wifi_lora32_v2_appcpu.dts
@@ -6,6 +6,7 @@
 /dts-v1/;
 
 #include <espressif/esp32/esp32_appcpu.dtsi>
+#include <espressif/partitions_0x1000_amp.dtsi>
 
 / {
 	model = "Heltec Wi-Fi Lora32 V2 APPCPU";
@@ -24,43 +25,4 @@
 
 &trng0 {
 	status = "okay";
-};
-
-&flash0 {
-	status = "okay";
-	partitions {
-		compatible = "fixed-partitions";
-		#address-cells = <1>;
-		#size-cells = <1>;
-
-		/* Reserve 60kB for the bootloader */
-		boot_partition: partition@1000 {
-			label = "mcuboot";
-			reg = <0x00001000 0x0000F000>;
-			read-only;
-		};
-
-		/* Reserve 1024kB for the application in slot 0 */
-		slot0_partition: partition@10000 {
-			label = "image-0";
-			reg = <0x00010000 0x00100000>;
-		};
-
-		/* Reserve 1024kB for the application in slot 1 */
-		slot1_partition: partition@110000 {
-			label = "image-1";
-			reg = <0x00110000 0x00100000>;
-		};
-
-		/* Reserve 256kB for the scratch partition */
-		scratch_partition: partition@210000 {
-			   label = "image-scratch";
-			   reg = <0x00210000 0x00040000>;
-		};
-
-		storage_partition: partition@250000 {
-			label = "storage";
-			reg = <0x00250000 0x00006000>;
-		};
-	};
 };

--- a/boards/heltec/heltec_wifi_lora32_v2/heltec_wifi_lora32_v2_procpu.dts
+++ b/boards/heltec/heltec_wifi_lora32_v2/heltec_wifi_lora32_v2_procpu.dts
@@ -8,6 +8,7 @@
 #include <espressif/esp32/esp32_d0wd_v3.dtsi>
 #include "heltec_wifi_lora32_v2-pinctrl.dtsi"
 #include <zephyr/dt-bindings/input/input-event-codes.h>
+#include <espressif/partitions_0x1000_amp.dtsi>
 
 / {
 	model = "Heltec Wi-Fi Lora32 V2 PROCPU";
@@ -59,6 +60,10 @@
 	};
 };
 
+&flash0 {
+	reg = <0x0 DT_SIZE_M(4)>;
+};
+
 &uart0 {
 	status = "okay";
 	current-speed = <115200>;
@@ -103,50 +108,6 @@
 			<&gpio1 2 (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>;
 		spi-max-frequency = <1000000>;
 		power-amplifier-output = "pa-boost";
-	};
-};
-
-&flash0 {
-	/* the board is using plain d0wd SoC part without the flash
-	 * so any additional flash size should be defined at the board level
-	 */
-	reg = <0x0 DT_SIZE_M(8)>;
-
-	status = "okay";
-	partitions {
-		compatible = "fixed-partitions";
-		#address-cells = <1>;
-		#size-cells = <1>;
-
-		/* Reserve 60kB for the bootloader */
-		boot_partition: partition@1000 {
-			label = "mcuboot";
-			reg = <0x00001000 0x0000F000>;
-			read-only;
-		};
-
-		/* Reserve 1024kB for the application in slot 0 */
-		slot0_partition: partition@10000 {
-			label = "image-0";
-			reg = <0x00010000 0x00100000>;
-		};
-
-		/* Reserve 1024kB for the application in slot 1 */
-		slot1_partition: partition@110000 {
-			label = "image-1";
-			reg = <0x00110000 0x00100000>;
-		};
-
-		/* Reserve 256kB for the scratch partition */
-		scratch_partition: partition@210000 {
-			   label = "image-scratch";
-			   reg = <0x00210000 0x00040000>;
-		};
-
-		storage_partition: partition@250000 {
-			label = "storage";
-			reg = <0x00250000 0x00006000>;
-		};
 	};
 };
 

--- a/boards/heltec/heltec_wireless_stick_lite_v3/heltec_wireless_stick_lite_v3_appcpu.dts
+++ b/boards/heltec/heltec_wireless_stick_lite_v3/heltec_wireless_stick_lite_v3_appcpu.dts
@@ -21,6 +21,10 @@
 	};
 };
 
+&flash0 {
+	reg = <0x0 DT_SIZE_M(4)>;
+};
+
 &trng0 {
 	status = "okay";
 };

--- a/boards/heltec/heltec_wireless_stick_lite_v3/heltec_wireless_stick_lite_v3_procpu.dts
+++ b/boards/heltec/heltec_wireless_stick_lite_v3/heltec_wireless_stick_lite_v3_procpu.dts
@@ -12,6 +12,7 @@
 #include <zephyr/dt-bindings/pwm/pwm.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 #include <zephyr/dt-bindings/lora/sx126x.h>
+#include <espressif/partitions_0x0_amp.dtsi>
 
 / {
 	model = "Heltec Wireless Stick Lite V3 PROCPU";
@@ -74,6 +75,10 @@
 		zephyr,code-partition = &slot0_partition;
 		zephyr,bt-hci = &esp32_bt_hci;
 	};
+};
+
+&flash0 {
+	reg = <0x0 DT_SIZE_M(4)>;
 };
 
 &adc1 {
@@ -166,45 +171,6 @@
 	current-speed = <115200>;
 	pinctrl-0 = <&uart1_default>;
 	pinctrl-names = "default";
-};
-
-&flash0 {
-	status = "okay";
-	partitions {
-		compatible = "fixed-partitions";
-		#address-cells = <1>;
-		#size-cells = <1>;
-
-		/* Reserve 64kB for the bootloader */
-		boot_partition: partition@0 {
-			label = "mcuboot";
-			reg = <0x00000000 0x00010000>;
-			read-only;
-		};
-
-		/* Reserve 1024kB for the application in slot 0 */
-		slot0_partition: partition@10000 {
-			label = "image-0";
-			reg = <0x00010000 0x00100000>;
-		};
-
-		/* Reserve 1024kB for the application in slot 1 */
-		slot1_partition: partition@110000 {
-			label = "image-1";
-			reg = <0x00110000 0x00100000>;
-		};
-
-		/* Reserve 256kB for the scratch partition */
-		scratch_partition: partition@210000 {
-			   label = "image-scratch";
-			   reg = <0x00210000 0x00040000>;
-		};
-
-		storage_partition: partition@250000 {
-			label = "storage";
-			reg = <0x00250000 0x00006000>;
-		};
-	};
 };
 
 &esp32_bt_hci {

--- a/boards/lilygo/ttgo_lora32/ttgo_lora32_esp32_appcpu.dts
+++ b/boards/lilygo/ttgo_lora32/ttgo_lora32_esp32_appcpu.dts
@@ -6,6 +6,7 @@
 /dts-v1/;
 
 #include <espressif/esp32/esp32_appcpu.dtsi>
+#include <espressif/partitions_0x1000_amp.dtsi>
 
 / {
 	model = "ttgo LoRa32 APPCPU";
@@ -24,43 +25,4 @@
 
 &trng0 {
 	status = "okay";
-};
-
-&flash0 {
-	status = "okay";
-	partitions {
-		compatible = "fixed-partitions";
-		#address-cells = <1>;
-		#size-cells = <1>;
-
-		/* Reserve 60kB for the bootloader */
-		boot_partition: partition@1000 {
-			label = "mcuboot";
-			reg = <0x00001000 0x0000F000>;
-			read-only;
-		};
-
-		/* Reserve 1024kB for the application in slot 0 */
-		slot0_partition: partition@10000 {
-			label = "image-0";
-			reg = <0x00010000 0x00100000>;
-		};
-
-		/* Reserve 1024kB for the application in slot 1 */
-		slot1_partition: partition@110000 {
-			label = "image-1";
-			reg = <0x00110000 0x00100000>;
-		};
-
-		/* Reserve 256kB for the scratch partition */
-		scratch_partition: partition@210000 {
-			   label = "image-scratch";
-			   reg = <0x00210000 0x00040000>;
-		};
-
-		storage_partition: partition@250000 {
-			label = "storage";
-			reg = <0x00250000 0x00006000>;
-		};
-	};
 };

--- a/boards/lilygo/ttgo_lora32/ttgo_lora32_esp32_procpu.dts
+++ b/boards/lilygo/ttgo_lora32/ttgo_lora32_esp32_procpu.dts
@@ -8,6 +8,7 @@
 #include <espressif/esp32/esp32_pico_d4.dtsi>
 #include "ttgo_lora32-pinctrl.dtsi"
 #include <zephyr/dt-bindings/input/input-event-codes.h>
+#include <espressif/partitions_0x1000_amp.dtsi>
 
 / {
 	model = "ttgo LoRa32 PROCPU";
@@ -144,45 +145,6 @@
 			compatible = "zephyr,sdmmc-disk";
 			disk-name = "SD";
 			status = "okay";
-		};
-	};
-};
-
-&flash0 {
-	status = "okay";
-	partitions {
-		compatible = "fixed-partitions";
-		#address-cells = <1>;
-		#size-cells = <1>;
-
-		/* Reserve 60kB for the bootloader */
-		boot_partition: partition@1000 {
-			label = "mcuboot";
-			reg = <0x00001000 0x0000F000>;
-			read-only;
-		};
-
-		/* Reserve 1024kB for the application in slot 0 */
-		slot0_partition: partition@10000 {
-			label = "image-0";
-			reg = <0x00010000 0x00100000>;
-		};
-
-		/* Reserve 1024kB for the application in slot 1 */
-		slot1_partition: partition@110000 {
-			label = "image-1";
-			reg = <0x00110000 0x00100000>;
-		};
-
-		/* Reserve 256kB for the scratch partition */
-		scratch_partition: partition@210000 {
-			label = "image-scratch";
-			reg = <0x00210000 0x00040000>;
-		};
-
-		storage_partition: partition@250000 {
-			label = "storage";
-			reg = <0x00250000 0x00006000>;
 		};
 	};
 };

--- a/boards/lilygo/ttgo_t8c3/ttgo_t8c3.dts
+++ b/boards/lilygo/ttgo_t8c3/ttgo_t8c3.dts
@@ -8,6 +8,7 @@
 
 #include <espressif/esp32c3/esp32c3_common.dtsi>
 #include "ttgo_t8c3-pinctrl.dtsi"
+#include <espressif/partitions_0x0_default.dtsi>
 
 / {
 	model = "Lilygo TTGO T8-C3";
@@ -36,6 +37,10 @@
 			label = "Green - LED0";
 		};
 	};
+};
+
+&flash0 {
+	reg = <0x0 DT_SIZE_M(4)>;
 };
 
 &uart0 {
@@ -96,38 +101,4 @@
 
 &esp32_bt_hci{
 	status = "okay";
-};
-
-&flash0 {
-	partitions {
-		compatible = "fixed-partitions";
-		#address-cells = <1>;
-		#size-cells = <1>;
-
-		boot_partition: partition@0 {
-			label = "mcuboot";
-			reg = <0x00000000 0x0000F000>;
-			read-only;
-		};
-
-		slot0_partition: partition@10000 {
-			label = "image-0";
-			reg = <0x00010000 0x00100000>;
-		};
-
-		slot1_partition: partition@110000 {
-			label = "image-1";
-			reg = <0x00110000 0x00100000>;
-		};
-
-		scratch_partition: partition@210000 {
-			label = "image-scratch";
-			reg = <0x00210000 0x00040000>;
-		};
-
-		storage_partition: partition@250000 {
-			label = "storage";
-			reg = <0x00250000 0x00006000>;
-		};
-	};
 };

--- a/boards/luatos/esp32c3_luatos_core/esp32c3_luatos_core.dtsi
+++ b/boards/luatos/esp32c3_luatos_core/esp32c3_luatos_core.dtsi
@@ -7,6 +7,7 @@
 #include <espressif/esp32c3/esp32c3_mini_n4.dtsi>
 #include "esp32c3_luatos_core-pinctrl.dtsi"
 #include <zephyr/dt-bindings/input/input-event-codes.h>
+#include <espressif/partitions_0x0_default.dtsi>
 
 / {
 	model = "ESP32C3 Luatos Core";
@@ -90,45 +91,6 @@
 	status = "disabled";
 	pinctrl-0 = <&twai_default>;
 	pinctrl-names = "default";
-};
-
-&flash0 {
-	status = "okay";
-	partitions {
-		compatible = "fixed-partitions";
-		#address-cells = <1>;
-		#size-cells = <1>;
-
-		/* Reserve 60kB for the bootloader */
-		boot_partition: partition@0 {
-			label = "mcuboot";
-			reg = <0x00000000 0x0000F000>;
-			read-only;
-		};
-
-		/* Reserve 1024kB for the application in slot 0 */
-		slot0_partition: partition@10000 {
-			label = "image-0";
-			reg = <0x00010000 0x00100000>;
-		};
-
-		/* Reserve 1024kB for the application in slot 1 */
-		slot1_partition: partition@110000 {
-			label = "image-1";
-			reg = <0x00110000 0x00100000>;
-		};
-
-		/* Reserve 256kB for the scratch partition */
-		scratch_partition: partition@210000 {
-			label = "image-scratch";
-			reg = <0x00210000 0x00040000>;
-		};
-
-		storage_partition: partition@250000 {
-			label = "storage";
-			reg = <0x00250000 0x00006000>;
-		};
-	};
 };
 
 &esp32_bt_hci {

--- a/boards/luatos/esp32s3_luatos_core/esp32s3_luatos_core_appcpu.dts
+++ b/boards/luatos/esp32s3_luatos_core/esp32s3_luatos_core_appcpu.dts
@@ -5,7 +5,7 @@
  */
 /dts-v1/;
 
-#include <espressif/esp32s3/esp32s3_appcpu.dtsi>
+#include <espressif/esp32s3/esp32s3_mini_n8.dtsi>
 #include <espressif/partitions_0x0_amp.dtsi>
 
 / {

--- a/boards/luatos/esp32s3_luatos_core/esp32s3_luatos_core_appcpu_usb.dts
+++ b/boards/luatos/esp32s3_luatos_core/esp32s3_luatos_core_appcpu_usb.dts
@@ -5,7 +5,7 @@
  */
 /dts-v1/;
 
-#include <espressif/esp32s3/esp32s3_appcpu.dtsi>
+#include <espressif/esp32s3/esp32s3_mini_n8.dtsi>
 #include <espressif/partitions_0x0_amp.dtsi>
 
 / {

--- a/boards/m5stack/m5stack_atom_lite/m5stack_atom_lite_appcpu.dts
+++ b/boards/m5stack/m5stack_atom_lite/m5stack_atom_lite_appcpu.dts
@@ -6,6 +6,7 @@
 /dts-v1/;
 
 #include <espressif/esp32/esp32_appcpu.dtsi>
+#include <espressif/partitions_0x1000_amp.dtsi>
 
 / {
 	model = "M5Stack Atom Lite APPCPU";
@@ -24,43 +25,4 @@
 
 &trng0 {
 	status = "okay";
-};
-
-&flash0 {
-	status = "okay";
-	partitions {
-		compatible = "fixed-partitions";
-		#address-cells = <1>;
-		#size-cells = <1>;
-
-		/* Reserve 60kB for the bootloader */
-		boot_partition: partition@1000 {
-			label = "mcuboot";
-			reg = <0x00001000 0x0000F000>;
-			read-only;
-		};
-
-		/* Reserve 1024kB for the application in slot 0 */
-		slot0_partition: partition@10000 {
-			label = "image-0";
-			reg = <0x00010000 0x00100000>;
-		};
-
-		/* Reserve 1024kB for the application in slot 1 */
-		slot1_partition: partition@110000 {
-			label = "image-1";
-			reg = <0x00110000 0x00100000>;
-		};
-
-		/* Reserve 256kB for the scratch partition */
-		scratch_partition: partition@210000 {
-			   label = "image-scratch";
-			   reg = <0x00210000 0x00040000>;
-		};
-
-		storage_partition: partition@250000 {
-			label = "storage";
-			reg = <0x00250000 0x00006000>;
-		};
-	};
 };

--- a/boards/m5stack/m5stack_atom_lite/m5stack_atom_lite_procpu.dts
+++ b/boards/m5stack/m5stack_atom_lite/m5stack_atom_lite_procpu.dts
@@ -13,6 +13,7 @@
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 #include <zephyr/dt-bindings/led/led.h>
 #include <zephyr/dt-bindings/led/worldsemi_ws2812c.h>
+#include <espressif/partitions_0x1000_amp.dtsi>
 
 / {
 	model = "M5Stack ATOM Lite PROCPU";
@@ -141,45 +142,6 @@
 
 &wdt0 {
 	status = "okay";
-};
-
-&flash0 {
-	status = "okay";
-	partitions {
-		compatible = "fixed-partitions";
-		#address-cells = <1>;
-		#size-cells = <1>;
-
-		/* Reserve 60kB for the bootloader */
-		boot_partition: partition@1000 {
-			label = "mcuboot";
-			reg = <0x00001000 0x0000F000>;
-			read-only;
-		};
-
-		/* Reserve 1024kB for the application in slot 0 */
-		slot0_partition: partition@10000 {
-			label = "image-0";
-			reg = <0x00010000 0x00100000>;
-		};
-
-		/* Reserve 1024kB for the application in slot 1 */
-		slot1_partition: partition@110000 {
-			label = "image-1";
-			reg = <0x00110000 0x00100000>;
-		};
-
-		/* Reserve 256kB for the scratch partition */
-		scratch_partition: partition@210000 {
-			label = "image-scratch";
-			reg = <0x00210000 0x00040000>;
-		};
-
-		storage_partition: partition@250000 {
-			label = "storage";
-			reg = <0x00250000 0x00006000>;
-		};
-	};
 };
 
 &esp32_bt_hci {

--- a/boards/m5stack/m5stack_atoms3/m5stack_atoms3_appcpu.dts
+++ b/boards/m5stack/m5stack_atoms3/m5stack_atoms3_appcpu.dts
@@ -5,7 +5,7 @@
  */
 /dts-v1/;
 
-#include <espressif/esp32s3/esp32s3_appcpu.dtsi>
+#include <espressif/esp32s3/esp32s3_fn8.dtsi>
 #include <espressif/partitions_0x0_amp.dtsi>
 
 / {

--- a/boards/m5stack/m5stack_atoms3_lite/m5stack_atoms3_lite_appcpu.dts
+++ b/boards/m5stack/m5stack_atoms3_lite/m5stack_atoms3_lite_appcpu.dts
@@ -5,7 +5,7 @@
  */
 /dts-v1/;
 
-#include <espressif/esp32s3/esp32s3_appcpu.dtsi>
+#include <espressif/esp32s3/esp32s3_fn8.dtsi>
 #include <espressif/partitions_0x0_amp.dtsi>
 
 / {

--- a/boards/m5stack/m5stack_atoms3_lite/m5stack_atoms3_lite_procpu.dts
+++ b/boards/m5stack/m5stack_atoms3_lite/m5stack_atoms3_lite_procpu.dts
@@ -47,6 +47,7 @@
 &usb_serial {
 	status = "okay";
 };
+
 &uart0 {
 	status = "okay";
 	current-speed = <115200>;

--- a/boards/m5stack/m5stack_core2/m5stack_core2_appcpu.dts
+++ b/boards/m5stack/m5stack_core2/m5stack_core2_appcpu.dts
@@ -6,6 +6,7 @@
 /dts-v1/;
 
 #include <espressif/esp32/esp32_appcpu.dtsi>
+#include <espressif/partitions_0x1000_amp.dtsi>
 
 / {
 	model = "M5Stack Core2 APPCPU";
@@ -24,43 +25,4 @@
 
 &trng0 {
 	status = "okay";
-};
-
-&flash0 {
-	status = "okay";
-	partitions {
-		compatible = "fixed-partitions";
-		#address-cells = <1>;
-		#size-cells = <1>;
-
-		/* Reserve 60kB for the bootloader */
-		boot_partition: partition@1000 {
-			label = "mcuboot";
-			reg = <0x00001000 0x0000F000>;
-			read-only;
-		};
-
-		/* Reserve 1024kB for the application in slot 0 */
-		slot0_partition: partition@10000 {
-			label = "image-0";
-			reg = <0x00010000 0x00100000>;
-		};
-
-		/* Reserve 1024kB for the application in slot 1 */
-		slot1_partition: partition@110000 {
-			label = "image-1";
-			reg = <0x00110000 0x00100000>;
-		};
-
-		/* Reserve 256kB for the scratch partition */
-		scratch_partition: partition@210000 {
-			   label = "image-scratch";
-			   reg = <0x00210000 0x00040000>;
-		};
-
-		storage_partition: partition@250000 {
-			label = "storage";
-			reg = <0x00250000 0x00006000>;
-		};
-	};
 };

--- a/boards/m5stack/m5stack_core2/m5stack_core2_procpu.dts
+++ b/boards/m5stack/m5stack_core2/m5stack_core2_procpu.dts
@@ -11,6 +11,7 @@
 #include "m5stack_mbus_connectors.dtsi"
 #include <zephyr/dt-bindings/display/ili9xxx.h>
 #include <zephyr/dt-bindings/regulator/axp192.h>
+#include <espressif/partitions_0x1000_amp.dtsi>
 
 / {
 	model = "M5Stack Core2 PROCPU";
@@ -73,6 +74,10 @@
 			rotation = <0>;
 		};
 	};
+};
+
+&flash0 {
+	reg = <0x0 DT_SIZE_M(16)>;
 };
 
 &psram0 {
@@ -243,48 +248,6 @@
 
 &trng0 {
 	status = "okay";
-};
-
-&flash0 {
-	status = "okay";
-	reg = <0 DT_SIZE_M(16)>;
-
-	partitions {
-		compatible = "fixed-partitions";
-		#address-cells = <1>;
-		#size-cells = <1>;
-
-		/* Reserve 60kB for the bootloader */
-		boot_partition: partition@1000 {
-			label = "mcuboot";
-			reg = <0x00001000 0x0000F000>;
-			read-only;
-		};
-
-		/* Reserve 1024kB for the application in slot 0 */
-		slot0_partition: partition@10000 {
-			label = "image-0";
-			reg = <0x00010000 0x00100000>;
-		};
-
-		/* Reserve 1024kB for the application in slot 1 */
-		slot1_partition: partition@110000 {
-			label = "image-1";
-			reg = <0x00110000 0x00100000>;
-		};
-
-		/* Reserve 256kB for the scratch partition */
-		scratch_partition: partition@210000 {
-			label = "image-scratch";
-			reg = <0x00210000 0x00040000>;
-		};
-
-		/* 14MB storage */
-		storage_partition: partition@250000 {
-			label = "storage";
-			reg = <0x00250000 0x00db0000>;
-		};
-	};
 };
 
 &esp32_bt_hci {

--- a/boards/m5stack/m5stack_cores3/m5stack_cores3_appcpu.dts
+++ b/boards/m5stack/m5stack_cores3/m5stack_cores3_appcpu.dts
@@ -5,7 +5,7 @@
  */
 /dts-v1/;
 
-#include <espressif/esp32s3/esp32s3_appcpu.dtsi>
+#include <espressif/esp32s3/esp32s3_wroom_n16r8.dtsi>
 #include <espressif/partitions_0x0_amp.dtsi>
 #include "m5stack_cores3-pinctrl.dtsi"
 

--- a/boards/m5stack/m5stack_stamps3/m5stack_stamps3_appcpu.dts
+++ b/boards/m5stack/m5stack_stamps3/m5stack_stamps3_appcpu.dts
@@ -5,7 +5,7 @@
  */
 /dts-v1/;
 
-#include <espressif/esp32s3/esp32s3_appcpu.dtsi>
+#include <espressif/esp32s3/esp32s3_fn8.dtsi>
 #include <espressif/partitions_0x0_amp.dtsi>
 
 / {

--- a/boards/m5stack/m5stickc_plus/m5stickc_plus_appcpu.dts
+++ b/boards/m5stack/m5stickc_plus/m5stickc_plus_appcpu.dts
@@ -5,7 +5,7 @@
  */
 /dts-v1/;
 
-#include <espressif/esp32/esp32_appcpu.dtsi>
+#include <espressif/esp32/esp32_pico_d4.dtsi>
 #include <espressif/partitions_0x1000_amp.dtsi>
 
 / {

--- a/boards/m5stack/m5stickc_plus/m5stickc_plus_procpu.dts
+++ b/boards/m5stack/m5stickc_plus/m5stickc_plus_procpu.dts
@@ -10,7 +10,7 @@
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 #include <zephyr/dt-bindings/regulator/axp192.h>
 #include <zephyr/dt-bindings/mipi_dbi/mipi_dbi.h>
-#include <espressif/partitions_0x0_amp.dtsi>
+#include <espressif/partitions_0x1000_amp.dtsi>
 
 / {
 	model = "M5StickC Plus PROCPU";

--- a/boards/m5stack/stamp_c3/stamp_c3.dts
+++ b/boards/m5stack/stamp_c3/stamp_c3.dts
@@ -9,6 +9,7 @@
 #include <espressif/esp32c3/esp32c3_fx4.dtsi>
 #include "stamp_c3-pinctrl.dtsi"
 #include <zephyr/dt-bindings/input/input-event-codes.h>
+#include <espressif/partitions_0x0_default.dtsi>
 
 / {
 	model = "M5Stack STAMP-C3";
@@ -90,45 +91,6 @@
 	status = "disabled";
 	pinctrl-0 = <&twai_default>;
 	pinctrl-names = "default";
-};
-
-&flash0 {
-	status = "okay";
-	partitions {
-		compatible = "fixed-partitions";
-		#address-cells = <1>;
-		#size-cells = <1>;
-
-		/* Reserve 60kB for the bootloader */
-		boot_partition: partition@0 {
-			label = "mcuboot";
-			reg = <0x00000000 0x0000F000>;
-			read-only;
-		};
-
-		/* Reserve 1024kB for the application in slot 0 */
-		slot0_partition: partition@10000 {
-			label = "image-0";
-			reg = <0x00010000 0x00100000>;
-		};
-
-		/* Reserve 1024kB for the application in slot 1 */
-		slot1_partition: partition@110000 {
-			label = "image-1";
-			reg = <0x00110000 0x00100000>;
-		};
-
-		/* Reserve 256kB for the scratch partition */
-		scratch_partition: partition@210000 {
-			label = "image-scratch";
-			reg = <0x00210000 0x00040000>;
-		};
-
-		storage_partition: partition@250000 {
-			label = "storage";
-			reg = <0x00250000 0x00006000>;
-		};
-	};
 };
 
 &esp32_bt_hci {

--- a/boards/olimex/olimex_esp32_evb/olimex_esp32_evb_appcpu.dts
+++ b/boards/olimex/olimex_esp32_evb/olimex_esp32_evb_appcpu.dts
@@ -6,6 +6,7 @@
 /dts-v1/;
 
 #include <espressif/esp32/esp32_appcpu.dtsi>
+#include <espressif/partitions_0x1000_amp.dtsi>
 
 / {
 	model = "Espressif ESP32-DevkitC APPCPU";
@@ -24,43 +25,4 @@
 
 &trng0 {
 	status = "okay";
-};
-
-&flash0 {
-	status = "okay";
-	partitions {
-		compatible = "fixed-partitions";
-		#address-cells = <1>;
-		#size-cells = <1>;
-
-		/* Reserve 60kB for the bootloader */
-		boot_partition: partition@1000 {
-			label = "mcuboot";
-			reg = <0x00001000 0x0000F000>;
-			read-only;
-		};
-
-		/* Reserve 1024kB for the application in slot 0 */
-		slot0_partition: partition@10000 {
-			label = "image-0";
-			reg = <0x00010000 0x00100000>;
-		};
-
-		/* Reserve 1024kB for the application in slot 1 */
-		slot1_partition: partition@110000 {
-			label = "image-1";
-			reg = <0x00110000 0x00100000>;
-		};
-
-		/* Reserve 256kB for the scratch partition */
-		scratch_partition: partition@210000 {
-			   label = "image-scratch";
-			   reg = <0x00210000 0x00040000>;
-		};
-
-		storage_partition: partition@250000 {
-			label = "storage";
-			reg = <0x00250000 0x00006000>;
-		};
-	};
 };

--- a/boards/olimex/olimex_esp32_evb/olimex_esp32_evb_procpu.dts
+++ b/boards/olimex/olimex_esp32_evb/olimex_esp32_evb_procpu.dts
@@ -9,6 +9,7 @@
 #include <espressif/esp32/esp32_wrover_e_n4r2.dtsi>
 #include "olimex_esp32_evb-pinctrl.dtsi"
 #include <zephyr/dt-bindings/input/input-event-codes.h>
+#include <espressif/partitions_0x1000_amp.dtsi>
 
 / {
 	model = "Olimex ESP32-EVB";
@@ -125,45 +126,6 @@ uext_spi: &spi2 {};
 
 &trng0 {
 	status = "okay";
-};
-
-&flash0 {
-	status = "okay";
-	partitions {
-		compatible = "fixed-partitions";
-		#address-cells = <1>;
-		#size-cells = <1>;
-
-		/* Reserve 60kB for the bootloader */
-		boot_partition: partition@1000 {
-			label = "mcuboot";
-			reg = <0x00001000 DT_SIZE_K(60)>;
-			read-only;
-		};
-
-		/* Reserve 1024kB for the application in slot 0 */
-		slot0_partition: partition@10000 {
-			label = "image-0";
-			reg = <0x00010000 DT_SIZE_K(1024)>;
-		};
-
-		/* Reserve 1024kB for the application in slot 1 */
-		slot1_partition: partition@110000 {
-			label = "image-1";
-			reg = <0x00110000 DT_SIZE_K(1024)>;
-		};
-
-		/* Reserve 256kB for the scratch partition */
-		scratch_partition: partition@210000 {
-			   label = "image-scratch";
-			   reg = <0x00210000 DT_SIZE_K(256)>;
-		};
-
-		storage_partition: partition@250000 {
-			label = "storage";
-			reg = <0x00250000 DT_SIZE_K(24)>;
-		};
-	};
 };
 
 &esp32_bt_hci {

--- a/boards/seeed/xiao_esp32c3/xiao_esp32c3.dts
+++ b/boards/seeed/xiao_esp32c3/xiao_esp32c3.dts
@@ -7,9 +7,9 @@
 /dts-v1/;
 
 #include <espressif/esp32c3/esp32c3_fx4.dtsi>
-#include <espressif/partitions_0x0_amp.dtsi>
 #include "xiao_esp32c3-pinctrl.dtsi"
 #include "seeed_xiao_connector.dtsi"
+#include <espressif/partitions_0x0_default.dtsi>
 
 / {
 	model = "Seeed XIAO ESP32C3";

--- a/boards/seeed/xiao_esp32s3/xiao_esp32s3_appcpu.dts
+++ b/boards/seeed/xiao_esp32s3/xiao_esp32s3_appcpu.dts
@@ -5,7 +5,7 @@
  */
 /dts-v1/;
 
-#include <espressif/esp32s3/esp32s3_appcpu.dtsi>
+#include <espressif/esp32s3/esp32s3_wroom_n8r8.dtsi>
 #include <espressif/partitions_0x0_amp.dtsi>
 
 / {

--- a/boards/seeed/xiao_esp32s3/xiao_esp32s3_procpu.dts
+++ b/boards/seeed/xiao_esp32s3/xiao_esp32s3_procpu.dts
@@ -7,6 +7,8 @@
 /dts-v1/;
 
 #include "xiao_esp32s3_procpu_common.dtsi"
+#include "xiao_esp32s3-pinctrl.dtsi"
+#include "seeed_xiao_connector.dtsi"
 #include <espressif/partitions_0x0_amp.dtsi>
 
 / {

--- a/boards/vcc-gnd/yd_esp32/yd_esp32_appcpu.dts
+++ b/boards/vcc-gnd/yd_esp32/yd_esp32_appcpu.dts
@@ -6,6 +6,7 @@
 /dts-v1/;
 
 #include <espressif/esp32/esp32_appcpu.dtsi>
+#include <espressif/partitions_0x1000_amp.dtsi>
 
 / {
 	model = "VCC-GND Studio YD-ESP32 APPCPU";
@@ -24,43 +25,4 @@
 
 &trng0 {
 	status = "okay";
-};
-
-&flash0 {
-	status = "okay";
-	partitions {
-		compatible = "fixed-partitions";
-		#address-cells = <1>;
-		#size-cells = <1>;
-
-		/* Reserve 60kB for the bootloader */
-		boot_partition: partition@1000 {
-			label = "mcuboot";
-			reg = <0x00001000 0x0000F000>;
-			read-only;
-		};
-
-		/* Reserve 1024kB for the application in slot 0 */
-		slot0_partition: partition@10000 {
-			label = "image-0";
-			reg = <0x00010000 0x00100000>;
-		};
-
-		/* Reserve 1024kB for the application in slot 1 */
-		slot1_partition: partition@110000 {
-			label = "image-1";
-			reg = <0x00110000 0x00100000>;
-		};
-
-		/* Reserve 256kB for the scratch partition */
-		scratch_partition: partition@210000 {
-			   label = "image-scratch";
-			   reg = <0x00210000 0x00040000>;
-		};
-
-		storage_partition: partition@250000 {
-			label = "storage";
-			reg = <0x00250000 0x00006000>;
-		};
-	};
 };

--- a/boards/vcc-gnd/yd_esp32/yd_esp32_procpu.dts
+++ b/boards/vcc-gnd/yd_esp32/yd_esp32_procpu.dts
@@ -7,6 +7,7 @@
 #include <zephyr/dt-bindings/led/led.h>
 #include "yd_esp32-pinctrl.dtsi"
 #include <zephyr/dt-bindings/input/input-event-codes.h>
+#include <espressif/partitions_0x1000_amp.dtsi>
 
 / {
 	model = "VCC-GND Studio YD-ESP32 PROCPU";
@@ -134,45 +135,6 @@
 
 &trng0 {
 	status = "okay";
-};
-
-&flash0 {
-	status = "okay";
-	partitions {
-		compatible = "fixed-partitions";
-		#address-cells = <1>;
-		#size-cells = <1>;
-
-		/* Reserve 60kB for the bootloader */
-		boot_partition: partition@1000 {
-			label = "mcuboot";
-			reg = <0x00001000 0x0000F000>;
-			read-only;
-		};
-
-		/* Reserve 1024kB for the application in slot 0 */
-		slot0_partition: partition@10000 {
-			label = "image-0";
-			reg = <0x00010000 0x00100000>;
-		};
-
-		/* Reserve 1024kB for the application in slot 1 */
-		slot1_partition: partition@110000 {
-			label = "image-1";
-			reg = <0x00110000 0x00100000>;
-		};
-
-		/* Reserve 256kB for the scratch partition */
-		scratch_partition: partition@210000 {
-			   label = "image-scratch";
-			   reg = <0x00210000 0x00040000>;
-		};
-
-		storage_partition: partition@250000 {
-			label = "storage";
-			reg = <0x00250000 0x00006000>;
-		};
-	};
 };
 
 &esp32_bt_hci {

--- a/boards/waveshare/esp32s3_touch_lcd_1_28/esp32s3_touch_lcd_1_28_esp32s3_appcpu.dts
+++ b/boards/waveshare/esp32s3_touch_lcd_1_28/esp32s3_touch_lcd_1_28_esp32s3_appcpu.dts
@@ -4,7 +4,7 @@
  */
 
 /dts-v1/;
-#include <espressif/esp32s3/esp32s3_appcpu.dtsi>
+#include <espressif/esp32s3/esp32s3_r2.dtsi>
 #include <espressif/partitions_0x0_amp.dtsi>
 
 / {
@@ -18,6 +18,10 @@
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_appcpu_partition;
 	};
+};
+
+&flash0 {
+	reg = <0x0 DT_SIZE_M(16)>;
 };
 
 &trng0 {

--- a/boards/waveshare/esp32s3_touch_lcd_1_28/esp32s3_touch_lcd_1_28_esp32s3_procpu.dts
+++ b/boards/waveshare/esp32s3_touch_lcd_1_28/esp32s3_touch_lcd_1_28_esp32s3_procpu.dts
@@ -9,6 +9,7 @@
 #include <zephyr/dt-bindings/display/panel.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 #include <zephyr/dt-bindings/pwm/pwm.h>
+#include <espressif/partitions_0x0_amp.dtsi>
 
 / {
 	model = "ESP32-S3-Touch-LCD-1.28 PROCPU";
@@ -82,40 +83,7 @@
 };
 
 &flash0 {
-	status = "okay";
 	reg = <0x0 DT_SIZE_M(16)>;
-
-	partitions {
-		compatible = "fixed-partitions";
-		#address-cells = <1>;
-		#size-cells = <1>;
-
-		boot_partition: partition@0 {
-			label = "mcuboot";
-			reg = <0x00000000 0x0000F000>;
-			read-only;
-		};
-
-		slot0_partition: partition@10000 {
-			label = "image-0";
-			reg = <0x00010000 0x00100000>;
-		};
-
-		slot1_partition: partition@110000 {
-			label = "image-1";
-			reg = <0x00110000 0x00100000>;
-		};
-
-		scratch_partition: partition@210000 {
-			label = "image-scratch";
-			reg = <0x00210000 0x00040000>;
-		};
-
-		storage_partition: partition@250000 {
-			label = "storage";
-			reg = <0x00250000 0x00006000>;
-		};
-	};
 };
 
 &gpio0 {

--- a/boards/we/orthosie1ev/we_orthosie1ev.dts
+++ b/boards/we/orthosie1ev/we_orthosie1ev.dts
@@ -40,6 +40,10 @@
 	};
 };
 
+&flash0 {
+	reg = <0x0 DT_SIZE_M(4)>;
+};
+
 &uart0 {
 	status = "okay";
 	current-speed = <115200>;

--- a/boards/wemos/esp32s2_lolin_mini/esp32s2_lolin_mini.dts
+++ b/boards/wemos/esp32s2_lolin_mini/esp32s2_lolin_mini.dts
@@ -9,6 +9,7 @@
 #include <espressif/esp32s2/esp32s2.dtsi>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 #include "esp32s2_lolin_mini-pinctrl.dtsi"
+#include <espressif/partitions_0x1000_default.dtsi>
 
 / {
 	model = "Wemos ESP32S2-Lolin Mini";
@@ -46,6 +47,10 @@
 	};
 };
 
+&flash0 {
+	reg = <0x0 DT_SIZE_M(4)>;
+};
+
 &uart0 {
 	status = "okay";
 	current-speed = <115200>;
@@ -79,47 +84,6 @@
 
 &trng0 {
 	status = "okay";
-};
-
-&flash0 {
-	reg = <0x0 DT_SIZE_M(4)>;
-
-	status = "okay";
-	partitions {
-		compatible = "fixed-partitions";
-		#address-cells = <1>;
-		#size-cells = <1>;
-
-		/* Reserve 60kB for the bootloader */
-		boot_partition: partition@1000 {
-			label = "mcuboot";
-			reg = <0x00001000 0x0000F000>;
-			read-only;
-		};
-
-		/* Reserve 1024kB for the application in slot 0 */
-		slot0_partition: partition@10000 {
-			label = "image-0";
-			reg = <0x00010000 0x00100000>;
-		};
-
-		/* Reserve 1024kB for the application in slot 1 */
-		slot1_partition: partition@110000 {
-			label = "image-1";
-			reg = <0x00110000 0x00100000>;
-		};
-
-		/* Reserve 256kB for the scratch partition */
-		scratch_partition: partition@210000 {
-			   label = "image-scratch";
-			   reg = <0x00210000 0x00040000>;
-		};
-
-		storage_partition: partition@250000 {
-			label = "storage";
-			reg = <0x00250000 0x00006000>;
-		};
-	};
 };
 
 &wdt0 {

--- a/dts/riscv/espressif/esp32c2/esp32c2_common.dtsi
+++ b/dts/riscv/espressif/esp32c2/esp32c2_common.dtsi
@@ -105,9 +105,9 @@
 
 			flash0: flash@0 {
 				compatible = "soc-nv-flash";
-				reg = <0 0x400000>;
 				erase-block-size = <4096>;
 				write-block-size = <4>;
+				/* Flash size is specified in SOC/SIP dtsi */
 			};
 		};
 

--- a/dts/riscv/espressif/esp32c3/esp32c3_common.dtsi
+++ b/dts/riscv/espressif/esp32c3/esp32c3_common.dtsi
@@ -138,9 +138,9 @@
 
 			flash0: flash@0 {
 				compatible = "soc-nv-flash";
-				reg = <0 0x400000>;
 				erase-block-size = <4096>;
 				write-block-size = <4>;
+				/* Flash size is specified in SOC/SIP dtsi */
 			};
 		};
 

--- a/dts/riscv/espressif/esp32c6/esp32c6_common.dtsi
+++ b/dts/riscv/espressif/esp32c6/esp32c6_common.dtsi
@@ -154,6 +154,7 @@
 				compatible = "soc-nv-flash";
 				erase-block-size = <4096>;
 				write-block-size = <4>;
+				/* Flash size is specified in SOC/SIP dtsi */
 			};
 		};
 

--- a/dts/xtensa/espressif/esp32s3/esp32s3_common.dtsi
+++ b/dts/xtensa/espressif/esp32s3/esp32s3_common.dtsi
@@ -169,7 +169,6 @@
 
 			flash0: flash@0 {
 				compatible = "soc-nv-flash";
-				reg = <0 0x800000>;
 				erase-block-size = <4096>;
 				write-block-size = <4>;
 				/* Flash size is specified in SOC/SIP dtsi */


### PR DESCRIPTION
Use preset partition tables from dts/common/espressif. Replace copies of fixed-partitions nodes in related boards by referencing the apropriate partition table from the available list. For better reference the `partitions_*.dtsi` file has boot offset, purpose and the flash size encoded in the file name. Default flash size is considered to be 4MB.