### PR TITLE
modbus: reset wait semaphore before tx

### DIFF
--- a/subsys/modbus/modbus_core.c
+++ b/subsys/modbus/modbus_core.c
@@ -137,6 +137,8 @@ void modbus_tx_adu(struct modbus_context *ctx)
 
 int modbus_tx_wait_rx_adu(struct modbus_context *ctx)
 {
+	k_sem_reset(&ctx->client_wait_sem);
+
 	modbus_tx_adu(ctx);
 
 	if (k_sem_take(&ctx->client_wait_sem, K_USEC(ctx->rxwait_to)) != 0) {


### PR DESCRIPTION
A response returned after a request times out would increment the semaphore and stay until the next request is made which will immediately return when k_sem_take is called even before a response is returned. This will once again have the same problem when the actual response arrives. So the wait semaphore just needs to be reset before transmitting.

Ideally, I'd like to have the modbus test check for this edge case, but I don't have an frdm-k64f board, or the time to figure out how to configure a new board for the test to develop one. That said, I'm hoping this is simple and straightforward enough to get the point across. I've been running this modification on our boards for several days now and it's only improved behavior. But anecdotes only go so far.

Fixes #79518