### PR TITLE
drivers: i3c: cdns: implement support ibi thr interrupts

### DIFF
--- a/drivers/i3c/i3c_cdns.c
+++ b/drivers/i3c/i3c_cdns.c
@@ -1603,7 +1603,9 @@ static int cdns_i3c_i2c_api_configure(const struct device *dev, uint32_t config)
 		break;
 	}
 
+	k_mutex_lock(&data->bus_lock, K_FOREVER);
 	cdns_i3c_set_prescalers(dev);
+	k_mutex_unlock(&data->bus_lock);
 
 	return 0;
 }
@@ -1632,7 +1634,10 @@ static int cdns_i3c_configure(const struct device *dev, enum i3c_config_type typ
 
 	data->common.ctrl_config.scl.i3c = ctrl_cfg->scl.i3c;
 	data->common.ctrl_config.scl.i2c = ctrl_cfg->scl.i2c;
+
+	k_mutex_lock(&data->bus_lock, K_FOREVER);
 	cdns_i3c_set_prescalers(dev);
+	k_mutex_unlock(&data->bus_lock);
 
 	return 0;
 }

--- a/dts/bindings/i3c/cdns,i3c.yaml
+++ b/dts/bindings/i3c/cdns,i3c.yaml
@@ -19,3 +19,8 @@ properties:
     type: int
     required: true
     description: The controller input clock frequency
+
+  ibid-thr:
+    type: int
+    default: 1
+    description: IBI Data Fifo Threashold Value


### PR DESCRIPTION
Some IBI TIR packets can be larger than the ibi data fifo size which can prevent it from receiving the full packet. This adds a data struct in to the driver data where data can be pushed to as data is being transfered.

This also grabs the mutex before adjusting the prescalers.

Also, correct the comments and timing for the sda push-pull hold time configuration.