### PR TITLE
tests: input/api: limit to 1 CPU for thread mode test

### DIFF
--- a/tests/subsys/input/api/testcase.yaml
+++ b/tests/subsys/input/api/testcase.yaml
@@ -9,6 +9,13 @@ tests:
   input.api.thread:
     extra_configs:
       - CONFIG_INPUT_MODE_THREAD=y
+      # There is a check to see if it is no longer able to push more
+      # messages into a full queue. When these is another CPU consuming
+      # messages, the queue would not be full at that point. A new message
+      # can be pushed into the queue and thus failing the "full queue"
+      # check. So limit this to 1 CPU only so this check's assumption
+      # can be fulfilled.
+      - CONFIG_MP_MAX_NUM_CPUS=1
   input.api.synchronous:
     extra_configs:
       - CONFIG_INPUT_MODE_SYNCHRONOUS=y


### PR DESCRIPTION
The test for being unable to push another message into full queue would fail if there are another CPU processing the callbacks, thus making the queue non-full. So limit this to 1 CPU only so the test assumptions can be fulfilled.

Fixes #79319