### PR TITLE
drivers: i2c: Support Fast Plus Mode in I2C Designware

### DIFF
--- a/drivers/i2c/i2c_dw.c
+++ b/drivers/i2c/i2c_dw.c
@@ -70,11 +70,10 @@ void i2c_dw_enable_idma(const struct device *dev, bool enable)
 	}
 }
 
-void cb_i2c_idma_transfer(const struct device *dma, void *user_data,
-			 uint32_t channel, int status)
+void cb_i2c_idma_transfer(const struct device *dma, void *user_data, uint32_t channel, int status)
 {
 	const struct device *dev = (const struct device *)user_data;
-	const struct i2c_dw_rom_config * const rom = dev->config;
+	const struct i2c_dw_rom_config *const rom = dev->config;
 	struct i2c_dw_dev_config *const dw = dev->data;
 
 	dma_stop(rom->dma_dev, channel);
@@ -99,20 +98,20 @@ inline void *i2c_dw_dr_phy_addr(const struct device *dev)
 {
 	struct i2c_dw_dev_config *const dw = dev->data;
 
-	return (void *) (dw->phy_addr + DW_IC_REG_DATA_CMD);
+	return (void *)(dw->phy_addr + DW_IC_REG_DATA_CMD);
 }
 
 int32_t i2c_dw_idma_rx_transfer(const struct device *dev)
 {
 	struct i2c_dw_dev_config *const dw = dev->data;
-	const struct i2c_dw_rom_config * const rom = dev->config;
+	const struct i2c_dw_rom_config *const rom = dev->config;
 
-	struct dma_config dma_cfg = { 0 };
-	struct dma_block_config dma_block_cfg = { 0 };
+	struct dma_config dma_cfg = {0};
+	struct dma_block_config dma_block_cfg = {0};
 
 	if (!device_is_ready(rom->dma_dev)) {
 		LOG_DBG("DMA device is not ready");
-		return  -ENODEV;
+		return -ENODEV;
 	}
 
 	dma_cfg.dma_slot = 1U;
@@ -135,12 +134,12 @@ int32_t i2c_dw_idma_rx_transfer(const struct device *dev)
 
 	if (dma_config(rom->dma_dev, DMA_INTEL_LPSS_RX_CHAN, &dma_cfg)) {
 		LOG_DBG("Error transfer");
-		return  -EIO;
+		return -EIO;
 	}
 
 	if (dma_start(rom->dma_dev, DMA_INTEL_LPSS_RX_CHAN)) {
 		LOG_DBG("Error transfer");
-		return  -EIO;
+		return -EIO;
 	}
 
 	i2c_dw_enable_idma(dev, true);
@@ -149,18 +148,17 @@ int32_t i2c_dw_idma_rx_transfer(const struct device *dev)
 	return 0;
 }
 
-int32_t i2c_dw_idma_tx_transfer(const struct device *dev,
-				uint64_t data)
+int32_t i2c_dw_idma_tx_transfer(const struct device *dev, uint64_t data)
 {
-	const struct i2c_dw_rom_config * const rom = dev->config;
+	const struct i2c_dw_rom_config *const rom = dev->config;
 	struct i2c_dw_dev_config *const dw = dev->data;
 
-	struct dma_config dma_cfg = { 0 };
-	struct dma_block_config dma_block_cfg = { 0 };
+	struct dma_config dma_cfg = {0};
+	struct dma_block_config dma_block_cfg = {0};
 
 	if (!device_is_ready(rom->dma_dev)) {
 		LOG_DBG("DMA device is not ready");
-		return  -ENODEV;
+		return -ENODEV;
 	}
 
 	dma_cfg.dma_slot = 0U;
@@ -183,12 +181,12 @@ int32_t i2c_dw_idma_tx_transfer(const struct device *dev,
 
 	if (dma_config(rom->dma_dev, DMA_INTEL_LPSS_TX_CHAN, &dma_cfg)) {
 		LOG_DBG("Error transfer");
-		return  -EIO;
+		return -EIO;
 	}
 
 	if (dma_start(rom->dma_dev, DMA_INTEL_LPSS_TX_CHAN)) {
 		LOG_DBG("Error transfer");
-		return  -EIO;
+		return -EIO;
 	}
 	i2c_dw_enable_idma(dev, true);
 	i2c_dw_set_fifo_th(dev, 1);
@@ -199,7 +197,7 @@ int32_t i2c_dw_idma_tx_transfer(const struct device *dev,
 
 static inline void i2c_dw_data_ask(const struct device *dev)
 {
-	struct i2c_dw_dev_config * const dw = dev->data;
+	struct i2c_dw_dev_config *const dw = dev->data;
 	uint32_t data;
 	int tx_empty;
 	int rx_empty;
@@ -247,8 +245,7 @@ static inline void i2c_dw_data_ask(const struct device *dev)
 		}
 
 		/* After receiving the last byte, send STOP if needed */
-		if ((dw->xfr_flags & I2C_MSG_STOP)
-		    && (dw->request_bytes == 1U)) {
+		if ((dw->xfr_flags & I2C_MSG_STOP) && (dw->request_bytes == 1U)) {
 			data |= IC_DATA_CMD_STOP;
 		}
 
@@ -262,12 +259,11 @@ static inline void i2c_dw_data_ask(const struct device *dev)
 		dw->request_bytes--;
 		cnt--;
 	}
-
 }
 
 static void i2c_dw_data_read(const struct device *dev)
 {
-	struct i2c_dw_dev_config * const dw = dev->data;
+	struct i2c_dw_dev_config *const dw = dev->data;
 	uint32_t reg_base = get_regs(dev);
 
 #ifdef CONFIG_I2C_DW_LPSS_DMA
@@ -296,10 +292,9 @@ static void i2c_dw_data_read(const struct device *dev)
 	}
 }
 
-
 static int i2c_dw_data_send(const struct device *dev)
 {
-	struct i2c_dw_dev_config * const dw = dev->data;
+	struct i2c_dw_dev_config *const dw = dev->data;
 	uint32_t data = 0U;
 	uint32_t reg_base = get_regs(dev);
 
@@ -345,7 +340,7 @@ static int i2c_dw_data_send(const struct device *dev)
 
 static inline void i2c_dw_transfer_complete(const struct device *dev)
 {
-	struct i2c_dw_dev_config * const dw = dev->data;
+	struct i2c_dw_dev_config *const dw = dev->data;
 	uint32_t value;
 	uint32_t reg_base = get_regs(dev);
 
@@ -363,7 +358,7 @@ static void i2c_dw_slave_read_clear_intr_bits(const struct device *dev);
 
 static void i2c_dw_isr(const struct device *port)
 {
-	struct i2c_dw_dev_config * const dw = port->data;
+	struct i2c_dw_dev_config *const dw = port->data;
 	union ic_interrupt_register intr_stat;
 	uint32_t value;
 	int ret = 0;
@@ -395,16 +390,15 @@ static void i2c_dw_isr(const struct device *port)
 		uint32_t stat = sys_read32(reg_base + IDMA_REG_INTR_STS);
 
 		if (stat & IDMA_TX_RX_CHAN_MASK) {
-			const struct i2c_dw_rom_config * const rom = port->config;
+			const struct i2c_dw_rom_config *const rom = port->config;
 			/* Handle the DMA interrupt */
 			dma_intel_lpss_isr(rom->dma_dev);
-
 		}
 #endif
 
 		/* Bail early if there is any error. */
-		if ((DW_INTR_STAT_TX_ABRT | DW_INTR_STAT_TX_OVER |
-		     DW_INTR_STAT_RX_OVER | DW_INTR_STAT_RX_UNDER) &
+		if ((DW_INTR_STAT_TX_ABRT | DW_INTR_STAT_TX_OVER | DW_INTR_STAT_RX_OVER |
+		     DW_INTR_STAT_RX_UNDER) &
 		    intr_stat.raw) {
 			dw->state = I2C_DW_CMD_ERROR;
 			goto done;
@@ -420,15 +414,13 @@ static void i2c_dw_isr(const struct device *port)
 		 * TX FIFO also serves as command queue where read requests
 		 * are written to TX FIFO.
 		 */
-		if ((dw->xfr_flags & I2C_MSG_RW_MASK)
-			    == I2C_MSG_READ) {
+		if ((dw->xfr_flags & I2C_MSG_RW_MASK) == I2C_MSG_READ) {
 			set_bit_intr_mask_tx_empty(reg_base);
 		}
 #endif /* CONFIG_I2C_TARGET */
 
 		if (intr_stat.bits.tx_empty) {
-			if ((dw->xfr_flags & I2C_MSG_RW_MASK)
-			    == I2C_MSG_WRITE) {
+			if ((dw->xfr_flags & I2C_MSG_RW_MASK) == I2C_MSG_WRITE) {
 				ret = i2c_dw_data_send(port);
 			} else {
 				i2c_dw_data_ask(port);
@@ -437,12 +429,10 @@ static void i2c_dw_isr(const struct device *port)
 			/* If STOP is not expected, finish processing this
 			 * message if there is nothing left to do anymore.
 			 */
-			if (((dw->xfr_len == 0U)
-			     && !(dw->xfr_flags & I2C_MSG_STOP))
-			    || (ret != 0)) {
+			if (((dw->xfr_len == 0U) && !(dw->xfr_flags & I2C_MSG_STOP)) ||
+			    (ret != 0)) {
 				goto done;
 			}
-
 		}
 
 		/* STOP detected: finish processing this message */
@@ -497,10 +487,9 @@ done:
 	i2c_dw_transfer_complete(port);
 }
 
-
 static int i2c_dw_setup(const struct device *dev, uint16_t slave_address)
 {
-	struct i2c_dw_dev_config * const dw = dev->data;
+	struct i2c_dw_dev_config *const dw = dev->data;
 	uint32_t value;
 	union ic_con_register ic_con;
 	union ic_tar_register ic_tar;
@@ -625,11 +614,10 @@ static int i2c_dw_setup(const struct device *dev, uint16_t slave_address)
 	return 0;
 }
 
-static int i2c_dw_transfer(const struct device *dev,
-			   struct i2c_msg *msgs, uint8_t num_msgs,
+static int i2c_dw_transfer(const struct device *dev, struct i2c_msg *msgs, uint8_t num_msgs,
 			   uint16_t slave_address)
 {
-	struct i2c_dw_dev_config * const dw = dev->data;
+	struct i2c_dw_dev_config *const dw = dev->data;
 	struct i2c_msg *cur_msg = msgs;
 	uint8_t msg_left = num_msgs;
 	uint8_t pflags;
@@ -677,7 +665,7 @@ static int i2c_dw_transfer(const struct device *dev,
 	 */
 	pm_device_busy_set(dev);
 
-		/* Process all the messages */
+	/* Process all the messages */
 	while (msg_left > 0) {
 		/* Workaround for I2C scanner as DW HW does not support 0 byte transfers.*/
 		if ((cur_msg->len == 0) && (cur_msg->buf != NULL)) {
@@ -692,8 +680,7 @@ static int i2c_dw_transfer(const struct device *dev,
 		dw->rx_pending = 0U;
 
 		/* Need to RESTART if changing transfer direction */
-		if ((pflags & I2C_MSG_RW_MASK)
-		    != (dw->xfr_flags & I2C_MSG_RW_MASK)) {
+		if ((pflags & I2C_MSG_RW_MASK) != (dw->xfr_flags & I2C_MSG_RW_MASK)) {
 			dw->xfr_flags |= I2C_MSG_RESTART;
 		}
 
@@ -710,8 +697,8 @@ static int i2c_dw_transfer(const struct device *dev,
 		/* Enable interrupts to trigger ISR */
 		if (test_bit_con_master_mode(reg_base)) {
 			/* Enable necessary interrupts */
-			write_intr_mask((DW_ENABLE_TX_INT_I2C_MASTER |
-						  DW_ENABLE_RX_INT_I2C_MASTER), reg_base);
+			write_intr_mask((DW_ENABLE_TX_INT_I2C_MASTER | DW_ENABLE_RX_INT_I2C_MASTER),
+					reg_base);
 		} else {
 			/* Enable necessary interrupts */
 			write_intr_mask(DW_ENABLE_TX_INT_I2C_SLAVE, reg_base);
@@ -751,9 +738,9 @@ error:
 
 static int i2c_dw_runtime_configure(const struct device *dev, uint32_t config)
 {
-	struct i2c_dw_dev_config * const dw = dev->data;
-	uint32_t	value = 0U;
-	uint32_t	rc = 0U;
+	struct i2c_dw_dev_config *const dw = dev->data;
+	uint32_t value = 0U;
+	uint32_t rc = 0U;
 	uint32_t reg_base = get_regs(dev);
 
 	dw->app_config = config;
@@ -950,27 +937,24 @@ static int i2c_dw_set_slave_mode(const struct device *dev, uint8_t addr)
 	return 0;
 }
 
-static int i2c_dw_slave_register(const struct device *dev,
-				 struct i2c_target_config *cfg)
+static int i2c_dw_slave_register(const struct device *dev, struct i2c_target_config *cfg)
 {
-	struct i2c_dw_dev_config * const dw = dev->data;
+	struct i2c_dw_dev_config *const dw = dev->data;
 	uint32_t reg_base = get_regs(dev);
 	int ret;
 
 	dw->slave_cfg = cfg;
 	ret = i2c_dw_set_slave_mode(dev, cfg->address);
-	write_intr_mask(DW_INTR_MASK_RX_FULL |
-			DW_INTR_MASK_RD_REQ |
-			DW_INTR_MASK_TX_ABRT |
-			DW_INTR_MASK_STOP_DET, reg_base);
+	write_intr_mask(DW_INTR_MASK_RX_FULL | DW_INTR_MASK_RD_REQ | DW_INTR_MASK_TX_ABRT |
+				DW_INTR_MASK_STOP_DET,
+			reg_base);
 
 	return ret;
 }
 
-static int i2c_dw_slave_unregister(const struct device *dev,
-				   struct i2c_target_config *cfg)
+static int i2c_dw_slave_unregister(const struct device *dev, struct i2c_target_config *cfg)
 {
-	struct i2c_dw_dev_config * const dw = dev->data;
+	struct i2c_dw_dev_config *const dw = dev->data;
 	int ret;
 
 	dw->state = I2C_DW_STATE_READY;
@@ -981,7 +965,7 @@ static int i2c_dw_slave_unregister(const struct device *dev,
 
 static void i2c_dw_slave_read_clear_intr_bits(const struct device *dev)
 {
-	struct i2c_dw_dev_config * const dw = dev->data;
+	struct i2c_dw_dev_config *const dw = dev->data;
 	union ic_interrupt_register intr_stat;
 	uint32_t reg_base = get_regs(dev);
 
@@ -1053,8 +1037,8 @@ static const struct i2c_driver_api funcs = {
 
 static int i2c_dw_initialize(const struct device *dev)
 {
-	const struct i2c_dw_rom_config * const rom = dev->config;
-	struct i2c_dw_dev_config * const dw = dev->data;
+	const struct i2c_dw_rom_config *const rom = dev->config;
+	struct i2c_dw_dev_config *const dw = dev->data;
 	union ic_con_register ic_con;
 	int ret = 0;
 
@@ -1085,8 +1069,7 @@ static int i2c_dw_initialize(const struct device *dev)
 		pcie_probe_mbar(rom->pcie->bdf, 0, &mbar);
 		pcie_set_cmd(rom->pcie->bdf, PCIE_CONF_CMDSTAT_MEM, true);
 
-		device_map(DEVICE_MMIO_RAM_PTR(dev), mbar.phys_addr,
-			   mbar.size, K_MEM_CACHE_NONE);
+		device_map(DEVICE_MMIO_RAM_PTR(dev), mbar.phys_addr, mbar.size, K_MEM_CACHE_NONE);
 
 		pcie_set_cmd(rom->pcie->bdf, PCIE_CONF_CMDSTAT_MASTER, true);
 
@@ -1104,8 +1087,8 @@ static int i2c_dw_initialize(const struct device *dev)
 			    DEVICE_MMIO_GET(dev) + DMA_INTEL_LPSS_REMAP_LOW);
 		sys_write32((uint32_t)(dw->phy_addr >> DMA_INTEL_LPSS_ADDR_RIGHT_SHIFT),
 			    DEVICE_MMIO_GET(dev) + DMA_INTEL_LPSS_REMAP_HI);
-		LOG_DBG("i2c instance physical addr: [0x%lx], virtual addr: [0x%lx]",
-			 dw->phy_addr, dw->base_addr);
+		LOG_DBG("i2c instance physical addr: [0x%lx], virtual addr: [0x%lx]", dw->phy_addr,
+			dw->base_addr);
 #endif
 	} else
 #endif
@@ -1123,7 +1106,7 @@ static int i2c_dw_initialize(const struct device *dev)
 	/* verify that we have a valid DesignWare register first */
 	if (read_comp_type(reg_base) != I2C_DW_MAGIC_KEY) {
 		LOG_DBG("I2C: DesignWare magic key not found, check base "
-			    "address. Stopping initialization");
+			"address. Stopping initialization");
 		return -EIO;
 	}
 
@@ -1164,7 +1147,7 @@ static int i2c_dw_initialize(const struct device *dev)
 #endif
 
 #if defined(CONFIG_RESET)
-#define RESET_DW_CONFIG(n)                                                    \
+#define RESET_DW_CONFIG(n)                                                                         \
 	IF_ENABLED(DT_INST_NODE_HAS_PROP(0, resets),                          \
 		   (.reset = RESET_DT_SPEC_INST_GET(n),))
 #else
@@ -1173,83 +1156,71 @@ static int i2c_dw_initialize(const struct device *dev)
 
 #define I2C_DW_INIT_PCIE0(n)
 #define I2C_DW_INIT_PCIE1(n) DEVICE_PCIE_INST_INIT(n, pcie),
-#define I2C_DW_INIT_PCIE(n) \
-	_CONCAT(I2C_DW_INIT_PCIE, DT_INST_ON_BUS(n, pcie))(n)
+#define I2C_DW_INIT_PCIE(n)  _CONCAT(I2C_DW_INIT_PCIE, DT_INST_ON_BUS(n, pcie))(n)
 
 #define I2C_DEFINE_PCIE0(n)
 #define I2C_DEFINE_PCIE1(n) DEVICE_PCIE_INST_DECLARE(n)
-#define I2C_PCIE_DEFINE(n) \
-	_CONCAT(I2C_DEFINE_PCIE, DT_INST_ON_BUS(n, pcie))(n)
+#define I2C_PCIE_DEFINE(n)  _CONCAT(I2C_DEFINE_PCIE, DT_INST_ON_BUS(n, pcie))(n)
 
 #define I2C_DW_IRQ_FLAGS_SENSE0(n) 0
 #define I2C_DW_IRQ_FLAGS_SENSE1(n) DT_INST_IRQ(n, sense)
-#define I2C_DW_IRQ_FLAGS(n) \
-	_CONCAT(I2C_DW_IRQ_FLAGS_SENSE, DT_INST_IRQ_HAS_CELL(n, sense))(n)
+#define I2C_DW_IRQ_FLAGS_SENSE(n)  _CONCAT(I2C_DW_IRQ_FLAGS_SENSE, DT_INST_IRQ_HAS_CELL(n, sense))
+#define I2C_DW_IRQ_FLAGS(n)        I2C_DW_IRQ_FLAGS_SENSE(n)(n)
 
 /* not PCI(e) */
-#define I2C_DW_IRQ_CONFIG_PCIE0(n)                                            \
-	static void i2c_config_##n(const struct device *port)                 \
-	{                                                                     \
-		ARG_UNUSED(port);                                             \
-		IRQ_CONNECT(DT_INST_IRQN(n), DT_INST_IRQ(n, priority),	      \
-			    i2c_dw_isr, DEVICE_DT_INST_GET(n),                \
-			    I2C_DW_IRQ_FLAGS(n));                             \
-		irq_enable(DT_INST_IRQN(n));                                  \
+#define I2C_DW_IRQ_CONFIG_PCIE0(n)                                                                 \
+	static void i2c_config_##n(const struct device *port)                                      \
+	{                                                                                          \
+		ARG_UNUSED(port);                                                                  \
+		IRQ_CONNECT(DT_INST_IRQN(n), DT_INST_IRQ(n, priority), i2c_dw_isr,                 \
+			    DEVICE_DT_INST_GET(n), I2C_DW_IRQ_FLAGS(n));                           \
+		irq_enable(DT_INST_IRQN(n));                                                       \
 	}
 
 /* PCI(e) with auto IRQ detection */
-#define I2C_DW_IRQ_CONFIG_PCIE1(n)                                            \
-	static void i2c_config_##n(const struct device *port)                 \
-	{                                                                     \
-		BUILD_ASSERT(DT_INST_IRQN(n) == PCIE_IRQ_DETECT,              \
-			     "Only runtime IRQ configuration is supported");  \
-		BUILD_ASSERT(IS_ENABLED(CONFIG_DYNAMIC_INTERRUPTS),           \
-			     "DW I2C PCI needs CONFIG_DYNAMIC_INTERRUPTS");   \
-		const struct i2c_dw_rom_config * const dev_cfg = port->config;\
-		unsigned int irq = pcie_alloc_irq(dev_cfg->pcie->bdf);        \
-		if (irq == PCIE_CONF_INTR_IRQ_NONE) {                         \
-			return;                                               \
-		}                                                             \
-		pcie_connect_dynamic_irq(dev_cfg->pcie->bdf, irq,	      \
-				     DT_INST_IRQ(n, priority),		      \
-				    (void (*)(const void *))i2c_dw_isr,       \
-				    DEVICE_DT_INST_GET(n),                    \
-				    I2C_DW_IRQ_FLAGS(n));                     \
-		pcie_irq_enable(dev_cfg->pcie->bdf, irq);                     \
+#define I2C_DW_IRQ_CONFIG_PCIE1(n)                                                                 \
+	static void i2c_config_##n(const struct device *port)                                      \
+	{                                                                                          \
+		BUILD_ASSERT(DT_INST_IRQN(n) == PCIE_IRQ_DETECT,                                   \
+			     "Only runtime IRQ configuration is supported");                       \
+		BUILD_ASSERT(IS_ENABLED(CONFIG_DYNAMIC_INTERRUPTS),                                \
+			     "DW I2C PCI needs CONFIG_DYNAMIC_INTERRUPTS");                        \
+		const struct i2c_dw_rom_config *const dev_cfg = port->config;                      \
+		unsigned int irq = pcie_alloc_irq(dev_cfg->pcie->bdf);                             \
+		if (irq == PCIE_CONF_INTR_IRQ_NONE) {                                              \
+			return;                                                                    \
+		}                                                                                  \
+		pcie_connect_dynamic_irq(dev_cfg->pcie->bdf, irq, DT_INST_IRQ(n, priority),        \
+					 (void (*)(const void *))i2c_dw_isr,                       \
+					 DEVICE_DT_INST_GET(n), I2C_DW_IRQ_FLAGS(n));              \
+		pcie_irq_enable(dev_cfg->pcie->bdf, irq);                                          \
 	}
 
-#define I2C_DW_IRQ_CONFIG(n) \
-	_CONCAT(I2C_DW_IRQ_CONFIG_PCIE, DT_INST_ON_BUS(n, pcie))(n)
+#define I2C_DW_IRQ_CONFIG(n) _CONCAT(I2C_DW_IRQ_CONFIG_PCIE, DT_INST_ON_BUS(n, pcie))(n)
 
 #define I2C_CONFIG_REG_INIT_PCIE0(n) DEVICE_MMIO_ROM_INIT(DT_DRV_INST(n)),
 #define I2C_CONFIG_REG_INIT_PCIE1(n)
-#define I2C_CONFIG_REG_INIT(n) \
-	_CONCAT(I2C_CONFIG_REG_INIT_PCIE, DT_INST_ON_BUS(n, pcie))(n)
+#define I2C_CONFIG_REG_INIT(n) _CONCAT(I2C_CONFIG_REG_INIT_PCIE, DT_INST_ON_BUS(n, pcie))(n)
 
-#define I2C_CONFIG_DMA_INIT(n)						\
+#define I2C_CONFIG_DMA_INIT(n)                                                                     \
 	COND_CODE_1(CONFIG_I2C_DW_LPSS_DMA,				\
 	(COND_CODE_1(DT_INST_NODE_HAS_PROP(n, dmas),			\
 	(.dma_dev = DEVICE_DT_GET(DT_INST_DMAS_CTLR_BY_IDX(n, 0)),),	\
 	())), ())
 
-#define I2C_DEVICE_INIT_DW(n)                                                 \
-	PINCTRL_DW_DEFINE(n);                                                 \
-	I2C_PCIE_DEFINE(n);                                                   \
-	static void i2c_config_##n(const struct device *port);                \
-	static const struct i2c_dw_rom_config i2c_config_dw_##n = {           \
-		I2C_CONFIG_REG_INIT(n)                                        \
-		.config_func = i2c_config_##n,                                \
-		.bitrate = DT_INST_PROP(n, clock_frequency),                  \
-		RESET_DW_CONFIG(n)                                            \
-		PINCTRL_DW_CONFIG(n)                                          \
-		I2C_DW_INIT_PCIE(n)                                           \
-		I2C_CONFIG_DMA_INIT(n)					      \
-	};                                                                    \
-	static struct i2c_dw_dev_config i2c_##n##_runtime;                    \
-	I2C_DEVICE_DT_INST_DEFINE(n, i2c_dw_initialize, NULL,                 \
-			      &i2c_##n##_runtime, &i2c_config_dw_##n,         \
-			      POST_KERNEL, CONFIG_I2C_INIT_PRIORITY,          \
-			      &funcs);                                        \
+#define I2C_DEVICE_INIT_DW(n)                                                                      \
+	PINCTRL_DW_DEFINE(n);                                                                      \
+	I2C_PCIE_DEFINE(n);                                                                        \
+	static void i2c_config_##n(const struct device *port);                                     \
+	static const struct i2c_dw_rom_config i2c_config_dw_##n = {                                \
+		I2C_CONFIG_REG_INIT(n).config_func = i2c_config_##n,                               \
+		.bitrate = DT_INST_PROP(n, clock_frequency),                                       \
+		RESET_DW_CONFIG(n) PINCTRL_DW_CONFIG(n) I2C_DW_INIT_PCIE(n)                        \
+			I2C_CONFIG_DMA_INIT(n)};                                                   \
+	static struct i2c_dw_dev_config i2c_##n##_runtime;                                         \
+	I2C_DEVICE_DT_INST_DEFINE(n, i2c_dw_initialize, NULL, &i2c_##n##_runtime,                  \
+				  &i2c_config_dw_##n, POST_KERNEL, CONFIG_I2C_INIT_PRIORITY,       \
+				  &funcs);                                                         \
 	I2C_DW_IRQ_CONFIG(n)
 
 DT_INST_FOREACH_STATUS_OKAY(I2C_DEVICE_INIT_DW)

--- a/drivers/i2c/i2c_dw.c
+++ b/drivers/i2c/i2c_dw.c
@@ -785,8 +785,6 @@ static int i2c_dw_runtime_configure(const struct device *dev, uint32_t config)
 		dw->hcnt = value;
 		break;
 	case I2C_SPEED_FAST:
-		__fallthrough;
-	case I2C_SPEED_FAST_PLUS:
 		/*
 		 * Following the directions on DW spec page 59, IC_FS_SCL_LCNT
 		 * must have register values larger than IC_FS_SPKLEN + 7
@@ -807,6 +805,31 @@ static int i2c_dw_runtime_configure(const struct device *dev, uint32_t config)
 			value = read_fs_spklen(reg_base) + 6;
 		} else {
 			value = I2C_FS_HCNT;
+		}
+
+		dw->hcnt = value;
+		break;
+	case I2C_SPEED_FAST_PLUS:
+		/*
+		 * Following the directions on DW spec page 59, IC_FS_SCL_LCNT
+		 * must have register values larger than IC_FS_SPKLEN + 7
+		 */
+		if (I2C_FSP_LCNT <= (read_fs_spklen(reg_base) + 7)) {
+			value = read_fs_spklen(reg_base) + 8;
+		} else {
+			value = I2C_FSP_LCNT;
+		}
+
+		dw->lcnt = value;
+
+		/*
+		 * Following the directions on DW spec page 59, IC_FS_SCL_HCNT
+		 * must have register values larger than IC_FS_SPKLEN + 5
+		 */
+		if (I2C_FSP_HCNT <= (read_fs_spklen(reg_base) + 5)) {
+			value = read_fs_spklen(reg_base) + 6;
+		} else {
+			value = I2C_FSP_HCNT;
 		}
 
 		dw->hcnt = value;

--- a/drivers/i2c/i2c_dw.h
+++ b/drivers/i2c/i2c_dw.h
@@ -26,75 +26,64 @@ BUILD_ASSERT(IS_ENABLED(CONFIG_PCIE), "DW I2C in DT needs CONFIG_PCIE");
 extern "C" {
 #endif
 
-#define I2C_DW_MAGIC_KEY			0x44570140
-
+#define I2C_DW_MAGIC_KEY 0x44570140
 
 typedef void (*i2c_isr_cb_t)(const struct device *port);
 
-
-#define IC_ACTIVITY                     (1 << 0)
-#define IC_ENABLE_BIT                   (1 << 0)
-
+#define IC_ACTIVITY   (1 << 0)
+#define IC_ENABLE_BIT (1 << 0)
 
 /* dev->state values from IC_DATA_CMD Data transfer mode settings (bit 8) */
-#define I2C_DW_STATE_READY                 (0)
-#define I2C_DW_CMD_SEND                    (1 << 0)
-#define I2C_DW_CMD_RECV                    (1 << 1)
-#define I2C_DW_CMD_ERROR                   (1 << 2)
-#define I2C_DW_BUSY                        (1 << 3)
+#define I2C_DW_STATE_READY (0)
+#define I2C_DW_CMD_SEND    (1 << 0)
+#define I2C_DW_CMD_RECV    (1 << 1)
+#define I2C_DW_CMD_ERROR   (1 << 2)
+#define I2C_DW_BUSY        (1 << 3)
 
+#define DW_ENABLE_TX_INT_I2C_MASTER                                                                \
+	(DW_INTR_STAT_TX_OVER | DW_INTR_STAT_TX_EMPTY | DW_INTR_STAT_TX_ABRT |                     \
+	 DW_INTR_STAT_STOP_DET)
+#define DW_ENABLE_RX_INT_I2C_MASTER                                                                \
+	(DW_INTR_STAT_RX_UNDER | DW_INTR_STAT_RX_OVER | DW_INTR_STAT_RX_FULL |                     \
+	 DW_INTR_STAT_STOP_DET)
 
-#define DW_ENABLE_TX_INT_I2C_MASTER		(DW_INTR_STAT_TX_OVER |  \
-						 DW_INTR_STAT_TX_EMPTY | \
-						 DW_INTR_STAT_TX_ABRT |  \
-						 DW_INTR_STAT_STOP_DET)
-#define DW_ENABLE_RX_INT_I2C_MASTER		(DW_INTR_STAT_RX_UNDER | \
-						 DW_INTR_STAT_RX_OVER |  \
-						 DW_INTR_STAT_RX_FULL | \
-						 DW_INTR_STAT_STOP_DET)
+#define DW_ENABLE_TX_INT_I2C_SLAVE                                                                 \
+	(DW_INTR_STAT_RD_REQ | DW_INTR_STAT_TX_ABRT | DW_INTR_STAT_STOP_DET)
+#define DW_ENABLE_RX_INT_I2C_SLAVE (DW_INTR_STAT_RX_FULL | DW_INTR_STAT_STOP_DET)
 
-#define DW_ENABLE_TX_INT_I2C_SLAVE		(DW_INTR_STAT_RD_REQ | \
-						 DW_INTR_STAT_TX_ABRT | \
-						 DW_INTR_STAT_STOP_DET)
-#define DW_ENABLE_RX_INT_I2C_SLAVE		(DW_INTR_STAT_RX_FULL | \
-						 DW_INTR_STAT_STOP_DET)
-
-#define DW_DISABLE_ALL_I2C_INT		0x00000000
-
+#define DW_DISABLE_ALL_I2C_INT 0x00000000
 
 /* IC_CON Low count and high count default values */
 /* TODO verify values for high speed */
-#define I2C_STD_HCNT		(CONFIG_I2C_DW_CLOCK_SPEED * 4)
-#define I2C_STD_LCNT		(CONFIG_I2C_DW_CLOCK_SPEED * 5)
-#define I2C_FS_HCNT			((CONFIG_I2C_DW_CLOCK_SPEED * 6) / 8)
-#define I2C_FS_LCNT			((CONFIG_I2C_DW_CLOCK_SPEED * 7) / 8)
-#define I2C_FSP_HCNT		((CONFIG_I2C_DW_CLOCK_SPEED * 2) / 8)
-#define I2C_FSP_LCNT		((CONFIG_I2C_DW_CLOCK_SPEED * 2) / 8)
-#define I2C_HS_HCNT			((CONFIG_I2C_DW_CLOCK_SPEED * 6) / 8)
-#define I2C_HS_LCNT			((CONFIG_I2C_DW_CLOCK_SPEED * 7) / 8)
+#define I2C_STD_HCNT (CONFIG_I2C_DW_CLOCK_SPEED * 4)
+#define I2C_STD_LCNT (CONFIG_I2C_DW_CLOCK_SPEED * 5)
+#define I2C_FS_HCNT  ((CONFIG_I2C_DW_CLOCK_SPEED * 6) / 8)
+#define I2C_FS_LCNT  ((CONFIG_I2C_DW_CLOCK_SPEED * 7) / 8)
+#define I2C_FSP_HCNT ((CONFIG_I2C_DW_CLOCK_SPEED * 2) / 8)
+#define I2C_FSP_LCNT ((CONFIG_I2C_DW_CLOCK_SPEED * 2) / 8)
+#define I2C_HS_HCNT  ((CONFIG_I2C_DW_CLOCK_SPEED * 6) / 8)
+#define I2C_HS_LCNT  ((CONFIG_I2C_DW_CLOCK_SPEED * 7) / 8)
 
 /*
  * DesignWare speed values don't directly translate from the Zephyr speed
  * selections in include/i2c.h so here we do a little translation
  */
-#define I2C_DW_SPEED_STANDARD		0x1
-#define I2C_DW_SPEED_FAST		0x2
-#define I2C_DW_SPEED_FAST_PLUS		0x2
-#define I2C_DW_SPEED_HIGH		0x3
-
+#define I2C_DW_SPEED_STANDARD  0x1
+#define I2C_DW_SPEED_FAST      0x2
+#define I2C_DW_SPEED_FAST_PLUS 0x2
+#define I2C_DW_SPEED_HIGH      0x3
 
 /*
  * These values have been randomly selected.  It would be good to test different
  * watermark levels for performance capabilities
  */
-#define I2C_DW_TX_WATERMARK		2
-#define I2C_DW_RX_WATERMARK		7
-
+#define I2C_DW_TX_WATERMARK 2
+#define I2C_DW_RX_WATERMARK 7
 
 struct i2c_dw_rom_config {
 	DEVICE_MMIO_ROM;
-	i2c_isr_cb_t	config_func;
-	uint32_t		bitrate;
+	i2c_isr_cb_t config_func;
+	uint32_t bitrate;
 
 #if defined(CONFIG_PINCTRL)
 	const struct pinctrl_dev_config *pcfg;
@@ -114,21 +103,21 @@ struct i2c_dw_rom_config {
 
 struct i2c_dw_dev_config {
 	DEVICE_MMIO_RAM;
-	struct k_sem		device_sync_sem;
-	struct k_mutex		bus_mutex;
+	struct k_sem device_sync_sem;
+	struct k_mutex bus_mutex;
 	uint32_t app_config;
 
-	uint8_t			*xfr_buf;
-	uint32_t		xfr_len;
-	uint32_t		rx_pending;
+	uint8_t *xfr_buf;
+	uint32_t xfr_len;
+	uint32_t rx_pending;
 
-	uint16_t		hcnt;
-	uint16_t		lcnt;
+	uint16_t hcnt;
+	uint16_t lcnt;
 
-	volatile uint8_t	state;  /* last direction of transfer */
-	uint8_t			request_bytes;
-	uint8_t			xfr_flags;
-	bool			support_hs_mode;
+	volatile uint8_t state; /* last direction of transfer */
+	uint8_t request_bytes;
+	uint8_t xfr_flags;
+	bool support_hs_mode;
 #ifdef CONFIG_I2C_DW_LPSS_DMA
 	uintptr_t phy_addr;
 	uintptr_t base_addr;
@@ -139,39 +128,39 @@ struct i2c_dw_dev_config {
 	struct i2c_target_config *slave_cfg;
 };
 
-#define Z_REG_READ(__sz) sys_read##__sz
+#define Z_REG_READ(__sz)  sys_read##__sz
 #define Z_REG_WRITE(__sz) sys_write##__sz
-#define Z_REG_SET_BIT sys_set_bit
-#define Z_REG_CLEAR_BIT sys_clear_bit
-#define Z_REG_TEST_BIT sys_test_bit
+#define Z_REG_SET_BIT     sys_set_bit
+#define Z_REG_CLEAR_BIT   sys_clear_bit
+#define Z_REG_TEST_BIT    sys_test_bit
 
-#define DEFINE_MM_REG_READ(__reg, __off, __sz)				\
-	static inline uint32_t read_##__reg(uint32_t addr)			\
-	{								\
-		return Z_REG_READ(__sz)(addr + __off);			\
+#define DEFINE_MM_REG_READ(__reg, __off, __sz)                                                     \
+	static inline uint32_t read_##__reg(uint32_t addr)                                         \
+	{                                                                                          \
+		return Z_REG_READ(__sz)(addr + __off);                                             \
 	}
-#define DEFINE_MM_REG_WRITE(__reg, __off, __sz)				\
-	static inline void write_##__reg(uint32_t data, uint32_t addr)	\
-	{								\
-		Z_REG_WRITE(__sz)(data, addr + __off);			\
-	}
-
-#define DEFINE_SET_BIT_OP(__reg_bit, __reg_off, __bit)			\
-	static inline void set_bit_##__reg_bit(uint32_t addr)		\
-	{								\
-		Z_REG_SET_BIT(addr + __reg_off, __bit);			\
+#define DEFINE_MM_REG_WRITE(__reg, __off, __sz)                                                    \
+	static inline void write_##__reg(uint32_t data, uint32_t addr)                             \
+	{                                                                                          \
+		Z_REG_WRITE(__sz)(data, addr + __off);                                             \
 	}
 
-#define DEFINE_CLEAR_BIT_OP(__reg_bit, __reg_off, __bit)		\
-	static inline void clear_bit_##__reg_bit(uint32_t addr)		\
-	{								\
-		Z_REG_CLEAR_BIT(addr + __reg_off, __bit);		\
+#define DEFINE_SET_BIT_OP(__reg_bit, __reg_off, __bit)                                             \
+	static inline void set_bit_##__reg_bit(uint32_t addr)                                      \
+	{                                                                                          \
+		Z_REG_SET_BIT(addr + __reg_off, __bit);                                            \
 	}
 
-#define DEFINE_TEST_BIT_OP(__reg_bit, __reg_off, __bit)			\
-	static inline int test_bit_##__reg_bit(uint32_t addr)		\
-	{								\
-		return Z_REG_TEST_BIT(addr + __reg_off, __bit);		\
+#define DEFINE_CLEAR_BIT_OP(__reg_bit, __reg_off, __bit)                                           \
+	static inline void clear_bit_##__reg_bit(uint32_t addr)                                    \
+	{                                                                                          \
+		Z_REG_CLEAR_BIT(addr + __reg_off, __bit);                                          \
+	}
+
+#define DEFINE_TEST_BIT_OP(__reg_bit, __reg_off, __bit)                                            \
+	static inline int test_bit_##__reg_bit(uint32_t addr)                                      \
+	{                                                                                          \
+		return Z_REG_TEST_BIT(addr + __reg_off, __bit);                                    \
 	}
 
 #ifdef __cplusplus

--- a/drivers/i2c/i2c_dw.h
+++ b/drivers/i2c/i2c_dw.h
@@ -63,11 +63,13 @@ typedef void (*i2c_isr_cb_t)(const struct device *port);
 
 
 /* IC_CON Low count and high count default values */
-/* TODO verify values for high and fast speed */
-#define I2C_STD_HCNT			(CONFIG_I2C_DW_CLOCK_SPEED * 4)
-#define I2C_STD_LCNT			(CONFIG_I2C_DW_CLOCK_SPEED * 5)
+/* TODO verify values for high speed */
+#define I2C_STD_HCNT		(CONFIG_I2C_DW_CLOCK_SPEED * 4)
+#define I2C_STD_LCNT		(CONFIG_I2C_DW_CLOCK_SPEED * 5)
 #define I2C_FS_HCNT			((CONFIG_I2C_DW_CLOCK_SPEED * 6) / 8)
 #define I2C_FS_LCNT			((CONFIG_I2C_DW_CLOCK_SPEED * 7) / 8)
+#define I2C_FSP_HCNT		((CONFIG_I2C_DW_CLOCK_SPEED * 2) / 8)
+#define I2C_FSP_LCNT		((CONFIG_I2C_DW_CLOCK_SPEED * 2) / 8)
 #define I2C_HS_HCNT			((CONFIG_I2C_DW_CLOCK_SPEED * 6) / 8)
 #define I2C_HS_LCNT			((CONFIG_I2C_DW_CLOCK_SPEED * 7) / 8)
 

--- a/drivers/i2c/i2c_dw_registers.h
+++ b/drivers/i2c/i2c_dw_registers.h
@@ -14,154 +14,154 @@ extern "C" {
 
 /*  IC_CON bits */
 union ic_con_register {
-	uint32_t                raw;
+	uint32_t raw;
 	struct {
-		uint32_t         master_mode : 1 __packed;
-		uint32_t         speed : 2 __packed;
-		uint32_t         addr_slave_10bit : 1 __packed;
-		uint32_t         addr_master_10bit : 1 __packed;
-		uint32_t         restart_en : 1 __packed;
-		uint32_t         slave_disable : 1 __packed;
-		uint32_t         stop_det : 1 __packed;
-		uint32_t         tx_empty_ctl : 1 __packed;
-		uint32_t         rx_fifo_full : 1 __packed;
+		uint32_t master_mode: 1 __packed;
+		uint32_t speed: 2 __packed;
+		uint32_t addr_slave_10bit: 1 __packed;
+		uint32_t addr_master_10bit: 1 __packed;
+		uint32_t restart_en: 1 __packed;
+		uint32_t slave_disable: 1 __packed;
+		uint32_t stop_det: 1 __packed;
+		uint32_t tx_empty_ctl: 1 __packed;
+		uint32_t rx_fifo_full: 1 __packed;
 	} bits;
 };
 
 /* IC_DATA_CMD bits */
-#define IC_DATA_CMD_DAT_MASK		0xFF
-#define IC_DATA_CMD_CMD			BIT(8)
-#define IC_DATA_CMD_STOP		BIT(9)
-#define IC_DATA_CMD_RESTART		BIT(10)
+#define IC_DATA_CMD_DAT_MASK 0xFF
+#define IC_DATA_CMD_CMD      BIT(8)
+#define IC_DATA_CMD_STOP     BIT(9)
+#define IC_DATA_CMD_RESTART  BIT(10)
 
 /* DesignWare Interrupt bits positions */
-#define DW_INTR_STAT_RX_UNDER		BIT(0)
-#define DW_INTR_STAT_RX_OVER		BIT(1)
-#define DW_INTR_STAT_RX_FULL		BIT(2)
-#define DW_INTR_STAT_TX_OVER		BIT(3)
-#define DW_INTR_STAT_TX_EMPTY		BIT(4)
-#define DW_INTR_STAT_RD_REQ			BIT(5)
-#define DW_INTR_STAT_TX_ABRT		BIT(6)
-#define DW_INTR_STAT_RX_DONE		BIT(7)
-#define DW_INTR_STAT_ACTIVITY		BIT(8)
-#define DW_INTR_STAT_STOP_DET		BIT(9)
-#define DW_INTR_STAT_START_DET		BIT(10)
-#define DW_INTR_STAT_GEN_CALL		BIT(11)
-#define DW_INTR_STAT_RESTART_DET	BIT(12)
-#define DW_INTR_STAT_MST_ON_HOLD	BIT(13)
+#define DW_INTR_STAT_RX_UNDER    BIT(0)
+#define DW_INTR_STAT_RX_OVER     BIT(1)
+#define DW_INTR_STAT_RX_FULL     BIT(2)
+#define DW_INTR_STAT_TX_OVER     BIT(3)
+#define DW_INTR_STAT_TX_EMPTY    BIT(4)
+#define DW_INTR_STAT_RD_REQ      BIT(5)
+#define DW_INTR_STAT_TX_ABRT     BIT(6)
+#define DW_INTR_STAT_RX_DONE     BIT(7)
+#define DW_INTR_STAT_ACTIVITY    BIT(8)
+#define DW_INTR_STAT_STOP_DET    BIT(9)
+#define DW_INTR_STAT_START_DET   BIT(10)
+#define DW_INTR_STAT_GEN_CALL    BIT(11)
+#define DW_INTR_STAT_RESTART_DET BIT(12)
+#define DW_INTR_STAT_MST_ON_HOLD BIT(13)
 
-#define DW_INTR_MASK_RX_UNDER		BIT(0)
-#define DW_INTR_MASK_RX_OVER		BIT(1)
-#define DW_INTR_MASK_RX_FULL		BIT(2)
-#define DW_INTR_MASK_TX_OVER		BIT(3)
-#define DW_INTR_MASK_TX_EMPTY		BIT(4)
-#define DW_INTR_MASK_RD_REQ			BIT(5)
-#define DW_INTR_MASK_TX_ABRT		BIT(6)
-#define DW_INTR_MASK_RX_DONE		BIT(7)
-#define DW_INTR_MASK_ACTIVITY		BIT(8)
-#define DW_INTR_MASK_STOP_DET		BIT(9)
-#define DW_INTR_MASK_START_DET		BIT(10)
-#define DW_INTR_MASK_GEN_CALL		BIT(11)
-#define DW_INTR_MASK_RESTART_DET	BIT(12)
-#define DW_INTR_MASK_MST_ON_HOLD	BIT(13)
-#define DW_INTR_MASK_RESET		0x000008ff
+#define DW_INTR_MASK_RX_UNDER    BIT(0)
+#define DW_INTR_MASK_RX_OVER     BIT(1)
+#define DW_INTR_MASK_RX_FULL     BIT(2)
+#define DW_INTR_MASK_TX_OVER     BIT(3)
+#define DW_INTR_MASK_TX_EMPTY    BIT(4)
+#define DW_INTR_MASK_RD_REQ      BIT(5)
+#define DW_INTR_MASK_TX_ABRT     BIT(6)
+#define DW_INTR_MASK_RX_DONE     BIT(7)
+#define DW_INTR_MASK_ACTIVITY    BIT(8)
+#define DW_INTR_MASK_STOP_DET    BIT(9)
+#define DW_INTR_MASK_START_DET   BIT(10)
+#define DW_INTR_MASK_GEN_CALL    BIT(11)
+#define DW_INTR_MASK_RESTART_DET BIT(12)
+#define DW_INTR_MASK_MST_ON_HOLD BIT(13)
+#define DW_INTR_MASK_RESET       0x000008ff
 
 union ic_interrupt_register {
-	uint32_t			raw;
+	uint32_t raw;
 	struct {
-		uint32_t	rx_under : 1 __packed;
-		uint32_t	rx_over : 1 __packed;
-		uint32_t	rx_full : 1 __packed;
-		uint32_t	tx_over : 1 __packed;
-		uint32_t	tx_empty : 1 __packed;
-		uint32_t	rd_req : 1 __packed;
-		uint32_t	tx_abrt : 1 __packed;
-		uint32_t	rx_done : 1 __packed;
-		uint32_t	activity : 1 __packed;
-		uint32_t	stop_det : 1 __packed;
-		uint32_t	start_det : 1 __packed;
-		uint32_t	gen_call : 1 __packed;
-		uint32_t	restart_det : 1 __packed;
-		uint32_t	mst_on_hold : 1 __packed;
-		uint32_t	reserved : 2 __packed;
+		uint32_t rx_under: 1 __packed;
+		uint32_t rx_over: 1 __packed;
+		uint32_t rx_full: 1 __packed;
+		uint32_t tx_over: 1 __packed;
+		uint32_t tx_empty: 1 __packed;
+		uint32_t rd_req: 1 __packed;
+		uint32_t tx_abrt: 1 __packed;
+		uint32_t rx_done: 1 __packed;
+		uint32_t activity: 1 __packed;
+		uint32_t stop_det: 1 __packed;
+		uint32_t start_det: 1 __packed;
+		uint32_t gen_call: 1 __packed;
+		uint32_t restart_det: 1 __packed;
+		uint32_t mst_on_hold: 1 __packed;
+		uint32_t reserved: 2 __packed;
 	} bits;
 };
 
 /* IC_TAR */
 union ic_tar_register {
-	uint32_t		raw;
+	uint32_t raw;
 	struct {
-		uint32_t	ic_tar : 10 __packed;
-		uint32_t	gc_or_start : 1 __packed;
-		uint32_t	special : 1 __packed;
-		uint32_t	ic_10bitaddr_master : 1 __packed;
-		uint32_t	reserved : 3 __packed;
+		uint32_t ic_tar: 10 __packed;
+		uint32_t gc_or_start: 1 __packed;
+		uint32_t special: 1 __packed;
+		uint32_t ic_10bitaddr_master: 1 __packed;
+		uint32_t reserved: 3 __packed;
 	} bits;
 };
 
 /* IC_COMP_PARAM_1 */
 union ic_comp_param_1_register {
-	uint32_t		raw;
+	uint32_t raw;
 	struct {
-		uint32_t	apb_data_width : 2 __packed;
-		uint32_t	max_speed_mode : 2 __packed;
-		uint32_t	hc_count_values : 1 __packed;
-		uint32_t	intr_io : 1 __packed;
-		uint32_t	has_dma : 1 __packed;
-		uint32_t	add_encoded_params : 1 __packed;
-		uint32_t	rx_buffer_depth : 8 __packed;
-		uint32_t	tx_buffer_depth : 8 __packed;
-		uint32_t	reserved : 7 __packed;
+		uint32_t apb_data_width: 2 __packed;
+		uint32_t max_speed_mode: 2 __packed;
+		uint32_t hc_count_values: 1 __packed;
+		uint32_t intr_io: 1 __packed;
+		uint32_t has_dma: 1 __packed;
+		uint32_t add_encoded_params: 1 __packed;
+		uint32_t rx_buffer_depth: 8 __packed;
+		uint32_t tx_buffer_depth: 8 __packed;
+		uint32_t reserved: 7 __packed;
 	} bits;
 };
 
-#define DW_IC_REG_CON				(0x00)
-#define DW_IC_REG_TAR				(0x04)
-#define DW_IC_REG_SAR				(0x08)
-#define DW_IC_REG_DATA_CMD			(0x10)
-#define DW_IC_REG_SS_SCL_HCNT		(0x14)
-#define DW_IC_REG_SS_SCL_LCNT		(0x18)
-#define DW_IC_REG_FS_SCL_HCNT		(0x1C)
-#define DW_IC_REG_FS_SCL_LCNT		(0x20)
-#define DW_IC_REG_HS_SCL_HCNT		(0x24)
-#define DW_IC_REG_HS_SCL_LCNT		(0x28)
-#define DW_IC_REG_INTR_STAT			(0x2C)
-#define DW_IC_REG_INTR_MASK			(0x30)
-#define DW_IC_REG_RX_TL				(0x38)
-#define DW_IC_REG_TX_TL				(0x3C)
-#define DW_IC_REG_CLR_INTR			(0x40)
-#define DW_IC_REG_CLR_RX_UNDER		(0x44)
-#define DW_IC_REG_CLR_RX_OVER		(0x48)
-#define DW_IC_REG_CLR_TX_OVER		(0x4c)
-#define DW_IC_REG_CLR_RD_REQ		(0x50)
-#define DW_IC_REG_CLR_TX_ABRT		(0x54)
-#define DW_IC_REG_CLR_RX_DONE		(0x58)
-#define DW_IC_REG_CLR_ACTIVITY		(0x5c)
-#define DW_IC_REG_CLR_STOP_DET		(0x60)
-#define DW_IC_REG_CLR_START_DET		(0x64)
-#define DW_IC_REG_CLR_GEN_CALL		(0x68)
-#define DW_IC_REG_ENABLE			(0x6C)
-#define DW_IC_REG_STATUS			(0x70)
-#define DW_IC_REG_TXFLR				(0x74)
-#define DW_IC_REG_RXFLR				(0x78)
-#define DW_IC_REG_DMA_CR                        (0x88)
-#define DW_IC_REG_TDLR                          (0x8C)
-#define DW_IC_REG_RDLR                          (0x90)
-#define DW_IC_REG_FS_SPKLEN			(0xA0)
-#define DW_IC_REG_HS_SPKLEN			(0xA4)
-#define DW_IC_REG_COMP_PARAM_1		(0xF4)
-#define DW_IC_REG_COMP_TYPE			(0xFC)
+#define DW_IC_REG_CON           (0x00)
+#define DW_IC_REG_TAR           (0x04)
+#define DW_IC_REG_SAR           (0x08)
+#define DW_IC_REG_DATA_CMD      (0x10)
+#define DW_IC_REG_SS_SCL_HCNT   (0x14)
+#define DW_IC_REG_SS_SCL_LCNT   (0x18)
+#define DW_IC_REG_FS_SCL_HCNT   (0x1C)
+#define DW_IC_REG_FS_SCL_LCNT   (0x20)
+#define DW_IC_REG_HS_SCL_HCNT   (0x24)
+#define DW_IC_REG_HS_SCL_LCNT   (0x28)
+#define DW_IC_REG_INTR_STAT     (0x2C)
+#define DW_IC_REG_INTR_MASK     (0x30)
+#define DW_IC_REG_RX_TL         (0x38)
+#define DW_IC_REG_TX_TL         (0x3C)
+#define DW_IC_REG_CLR_INTR      (0x40)
+#define DW_IC_REG_CLR_RX_UNDER  (0x44)
+#define DW_IC_REG_CLR_RX_OVER   (0x48)
+#define DW_IC_REG_CLR_TX_OVER   (0x4c)
+#define DW_IC_REG_CLR_RD_REQ    (0x50)
+#define DW_IC_REG_CLR_TX_ABRT   (0x54)
+#define DW_IC_REG_CLR_RX_DONE   (0x58)
+#define DW_IC_REG_CLR_ACTIVITY  (0x5c)
+#define DW_IC_REG_CLR_STOP_DET  (0x60)
+#define DW_IC_REG_CLR_START_DET (0x64)
+#define DW_IC_REG_CLR_GEN_CALL  (0x68)
+#define DW_IC_REG_ENABLE        (0x6C)
+#define DW_IC_REG_STATUS        (0x70)
+#define DW_IC_REG_TXFLR         (0x74)
+#define DW_IC_REG_RXFLR         (0x78)
+#define DW_IC_REG_DMA_CR        (0x88)
+#define DW_IC_REG_TDLR          (0x8C)
+#define DW_IC_REG_RDLR          (0x90)
+#define DW_IC_REG_FS_SPKLEN     (0xA0)
+#define DW_IC_REG_HS_SPKLEN     (0xA4)
+#define DW_IC_REG_COMP_PARAM_1  (0xF4)
+#define DW_IC_REG_COMP_TYPE     (0xFC)
 
-#define IDMA_REG_INTR_STS               0xAE8
-#define IDMA_TX_RX_CHAN_MASK            0x3
+#define IDMA_REG_INTR_STS    0xAE8
+#define IDMA_TX_RX_CHAN_MASK 0x3
 
 /* CON Bit */
-#define DW_IC_CON_MASTER_MODE_BIT		(0)
+#define DW_IC_CON_MASTER_MODE_BIT (0)
 
 /* DMA control bits */
-#define DW_IC_DMA_RX_ENABLE                    BIT(0)
-#define DW_IC_DMA_TX_ENABLE                    BIT(1)
-#define DW_IC_DMA_ENABLE                       (BIT(0) | BIT(1))
+#define DW_IC_DMA_RX_ENABLE BIT(0)
+#define DW_IC_DMA_TX_ENABLE BIT(1)
+#define DW_IC_DMA_ENABLE    (BIT(0) | BIT(1))
 
 DEFINE_TEST_BIT_OP(con_master_mode, DW_IC_REG_CON, DW_IC_CON_MASTER_MODE_BIT)
 DEFINE_MM_REG_WRITE(con, DW_IC_REG_CON, 32)
@@ -179,14 +179,12 @@ DEFINE_MM_REG_WRITE(fs_scl_lcnt, DW_IC_REG_FS_SCL_LCNT, 32)
 DEFINE_MM_REG_WRITE(hs_scl_hcnt, DW_IC_REG_HS_SCL_HCNT, 32)
 DEFINE_MM_REG_WRITE(hs_scl_lcnt, DW_IC_REG_HS_SCL_LCNT, 32)
 
-
-
 DEFINE_MM_REG_READ(intr_stat, DW_IC_REG_INTR_STAT, 32)
-#define DW_IC_INTR_STAT_TX_ABRT_BIT		(6)
+#define DW_IC_INTR_STAT_TX_ABRT_BIT (6)
 DEFINE_TEST_BIT_OP(intr_stat_tx_abrt, DW_IC_REG_INTR_STAT, DW_IC_INTR_STAT_TX_ABRT_BIT)
 
 DEFINE_MM_REG_WRITE(intr_mask, DW_IC_REG_INTR_MASK, 32)
-#define DW_IC_INTR_MASK_TX_EMPTY_BIT		(4)
+#define DW_IC_INTR_MASK_TX_EMPTY_BIT (4)
 DEFINE_CLEAR_BIT_OP(intr_mask_tx_empty, DW_IC_REG_INTR_MASK, DW_IC_INTR_MASK_TX_EMPTY_BIT)
 DEFINE_SET_BIT_OP(intr_mask_tx_empty, DW_IC_REG_INTR_MASK, DW_IC_INTR_MASK_TX_EMPTY_BIT)
 
@@ -205,14 +203,13 @@ DEFINE_MM_REG_READ(clr_rx_done, DW_IC_REG_CLR_RX_DONE, 32)
 DEFINE_MM_REG_READ(clr_rd_req, DW_IC_REG_CLR_RD_REQ, 32)
 DEFINE_MM_REG_READ(clr_activity, DW_IC_REG_CLR_ACTIVITY, 32)
 
-#define DW_IC_ENABLE_EN_BIT		(0)
+#define DW_IC_ENABLE_EN_BIT (0)
 DEFINE_CLEAR_BIT_OP(enable_en, DW_IC_REG_ENABLE, DW_IC_ENABLE_EN_BIT)
 DEFINE_SET_BIT_OP(enable_en, DW_IC_REG_ENABLE, DW_IC_ENABLE_EN_BIT)
 
-
-#define DW_IC_STATUS_ACTIVITY_BIT	(0)
-#define DW_IC_STATUS_TFNT_BIT	(1)
-#define DW_IC_STATUS_RFNE_BIT	(3)
+#define DW_IC_STATUS_ACTIVITY_BIT (0)
+#define DW_IC_STATUS_TFNT_BIT     (1)
+#define DW_IC_STATUS_RFNE_BIT     (3)
 DEFINE_TEST_BIT_OP(status_activity, DW_IC_REG_STATUS, DW_IC_STATUS_ACTIVITY_BIT)
 DEFINE_TEST_BIT_OP(status_tfnt, DW_IC_REG_STATUS, DW_IC_STATUS_TFNT_BIT)
 DEFINE_TEST_BIT_OP(status_rfne, DW_IC_REG_STATUS, DW_IC_STATUS_RFNE_BIT)


### PR DESCRIPTION
Currently, the i2c driver for the Designware IP only has the right clock settings for Fast Mode and lower rates. This change adds the right clock settings for the Fast Plus Mode. Which the the original author left as a TODO

Similarly, I lack the hardware to test high-speed mode, and so that mode remains not well supported

Fast Plus Mode is confirmed by measuring with a logic analyzer that indicates a rate very close to 1MHz