### PR TITLE
samples: drivers: gnss: display more information

### DIFF
--- a/samples/drivers/gnss/src/main.c
+++ b/samples/drivers/gnss/src/main.c
@@ -36,7 +36,43 @@ static void gnss_satellites_cb(const struct device *dev, const struct gnss_satel
 #endif
 GNSS_SATELLITES_CALLBACK_DEFINE(GNSS_MODEM, gnss_satellites_cb);
 
+#define GNSS_SYSTEMS_PRINTF(define, supported, enabled)                                            \
+	printf("\t%20s: Supported: %3s Enabled: %3s\n",                                            \
+	       STRINGIFY(define), (supported & define) ? "Yes" : "No",                             \
+			 (enabled & define) ? "Yes" : "No");
+
 int main(void)
 {
+	gnss_systems_t supported, enabled;
+	uint32_t fix_interval;
+	int rc;
+
+	rc = gnss_get_supported_systems(GNSS_MODEM, &supported);
+	if (rc < 0) {
+		printf("Failed to query supported systems (%d)\n", rc);
+		return rc;
+	}
+	rc = gnss_get_enabled_systems(GNSS_MODEM, &enabled);
+	if (rc < 0) {
+		printf("Failed to query enabled systems (%d)\n", rc);
+		return rc;
+	}
+	printf("GNSS Systems:\n");
+	GNSS_SYSTEMS_PRINTF(GNSS_SYSTEM_GPS, supported, enabled);
+	GNSS_SYSTEMS_PRINTF(GNSS_SYSTEM_GLONASS, supported, enabled);
+	GNSS_SYSTEMS_PRINTF(GNSS_SYSTEM_GALILEO, supported, enabled);
+	GNSS_SYSTEMS_PRINTF(GNSS_SYSTEM_BEIDOU, supported, enabled);
+	GNSS_SYSTEMS_PRINTF(GNSS_SYSTEM_QZSS, supported, enabled);
+	GNSS_SYSTEMS_PRINTF(GNSS_SYSTEM_IRNSS, supported, enabled);
+	GNSS_SYSTEMS_PRINTF(GNSS_SYSTEM_SBAS, supported, enabled);
+	GNSS_SYSTEMS_PRINTF(GNSS_SYSTEM_IMES, supported, enabled);
+
+	rc = gnss_get_fix_rate(GNSS_MODEM, &fix_interval);
+	if (rc < 0) {
+		printf("Failed to query fix rate (%d)\n", rc);
+		return rc;
+	}
+	printf("Fix rate = %d ms\n", fix_interval);
+
 	return 0;
 }


### PR DESCRIPTION
Query additional information in the GNSS API sample. This exercises more of the API implemented by GNSS drivers without changing the behaviour of the sample while providing more information to the user.

Updated output looks like the following:
```
GNSS Systems:
             GNSS_SYSTEM_GPS: Supported: Yes Enabled: Yes
         GNSS_SYSTEM_GLONASS: Supported: Yes Enabled: Yes
         GNSS_SYSTEM_GALILEO: Supported: Yes Enabled:  No
          GNSS_SYSTEM_BEIDOU: Supported: Yes Enabled:  No
            GNSS_SYSTEM_QZSS: Supported: Yes Enabled: Yes
           GNSS_SYSTEM_IRNSS: Supported:  No Enabled:  No
            GNSS_SYSTEM_SBAS: Supported: Yes Enabled: Yes
            GNSS_SYSTEM_IMES: Supported:  No Enabled:  No
Fix rate = 1000 ms
```