### PR TITLE
net: posix: Fix close() not closing sockets properly

### DIFF
--- a/lib/os/fdtable.c
+++ b/lib/os/fdtable.c
@@ -371,6 +371,8 @@ int zvfs_close(int fd)
 
 	zvfs_free_fd(fd);
 
+	(void)sock_obj_core_dealloc(fd);
+
 	return res;
 }
 


### PR DESCRIPTION
With CONFIG_POSIX_API enabled close() does not call
 sock_obj_core_dealloc. This results in sockets not being
 closed properly, which can be verified by running the
 shell command 'net sockets'