### PR TITLE
MAINTAINERS: Add PHYTEC Platforms

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3082,6 +3082,18 @@ Open AMP:
   tests:
     - sample.ipc.openamp
 
+PHYTEC Platforms:
+  status: maintained
+  maintainers:
+    - dnltz
+  collaborators:
+    - jonas-rem
+    - pefech
+  files:
+    - boards/phytec/
+  labels:
+    - "platform: PHYTEC"
+
 POSIX API layer:
   status: maintained
   maintainers:
@@ -4005,8 +4017,6 @@ TI K3 Platforms:
     - gramsay0
     - dnltz
   files:
-    - boards/phytec/phyboard_lyra/
-    - boards/phytec/phyboard_electra/
     - boards/ti/*am62*/
     - drivers/*/*ti_k3*
     - dts/bindings/*/ti,k3*


### PR DESCRIPTION
PHYTEC currently supports five boards in Zephyr, with another in development. Given the growing interest from our customers and our commitment to expanding support for PHYTEC platforms, I am volunteering to take over the maintenance of these boards.

This will help streamline contributions and reduce the workload on the silicon vendor maintainers.

---

Additionally, please note that I am already active in the TI K3 Platforms and will continue in that capacity. I am also including Jonas Remmet (jonas-rem) and Peter Fecher (pefech) as collaborators to support the PHYTEC platforms in Zephyr.


