### PR TITLE
llext: hotfix: fix device API tests for platforms without console

### DIFF
--- a/tests/subsys/llext/simple/src/test_llext_simple.c
+++ b/tests/subsys/llext/simple/src/test_llext_simple.c
@@ -109,7 +109,7 @@ static void threads_objects_test_setup(struct llext *, struct k_thread *llext_th
 	k_object_access_grant(&my_sem, llext_thread);
 	k_object_access_grant(&my_thread, llext_thread);
 	k_object_access_grant(&my_thread_stack, llext_thread);
-#if DT_HAS_CHOSEN(zephyr_console)
+#if DT_HAS_CHOSEN(zephyr_console) && DT_NODE_HAS_STATUS_OKAY(DT_CHOSEN(zephyr_console))
 	k_object_access_grant(DEVICE_DT_GET(DT_CHOSEN(zephyr_console)), llext_thread);
 #endif
 }

--- a/tests/subsys/llext/simple/src/threads_kernel_objects_ext.c
+++ b/tests/subsys/llext/simple/src/threads_kernel_objects_ext.c
@@ -22,7 +22,7 @@
  * Some platforms do not define any usable DT devices (not even the console).
  * In those cases the device API test can't be executed.
  */
-#if DT_HAS_CHOSEN(zephyr_console)
+#if DT_HAS_CHOSEN(zephyr_console) && DT_NODE_HAS_STATUS_OKAY(DT_CHOSEN(zephyr_console))
 #define CONSOLE_DT_NODE DT_CHOSEN(zephyr_console)
 #endif
 


### PR DESCRIPTION
LLEXT tests currently fail on platforms where a console was chosen but its underlying device is not enabled. This might happen for example on multicore SoCs, where the console is only enabled on the most powerful CPU.
This is for example the case of PR #77981 that is currently [failing CI](https://github.com/zephyrproject-rtos/zephyr/actions/runs/11139087107/job/30962447824?pr=77981#step:12:1485).

Fix this by properly gating the LLEXT device API tests so they are executed only if the console device is both _chosen_ and _enabled_ in the final DT.