### PR TITLE
tests: coap_client: optimize/reduce sleep time

### DIFF
--- a/tests/net/lib/coap_client/src/stubs.c
+++ b/tests/net/lib/coap_client/src/stubs.c
@@ -13,7 +13,7 @@ DEFINE_FAKE_VALUE_FUNC(uint32_t, z_impl_sys_rand32_get);
 DEFINE_FAKE_VOID_FUNC(z_impl_sys_rand_get, void *, size_t);
 DEFINE_FAKE_VALUE_FUNC(ssize_t, z_impl_zsock_recvfrom, int, void *, size_t, int, struct sockaddr *,
 		       socklen_t *);
-DEFINE_FAKE_VALUE_FUNC(ssize_t, z_impl_zsock_sendto, int, void*, size_t, int,
+DEFINE_FAKE_VALUE_FUNC(ssize_t, z_impl_zsock_sendto, int, void *, size_t, int,
 		       const struct sockaddr *, socklen_t);
 
 struct zsock_pollfd {
@@ -42,11 +42,12 @@ int z_impl_zsock_socket(int family, int type, int proto)
 int z_impl_zsock_poll(struct zsock_pollfd *fds, int nfds, int poll_timeout)
 {
 	LOG_INF("Polling, events %d", my_events);
-	k_sleep(K_MSEC(10));
+	k_sleep(K_MSEC(1));
 	fds->revents = my_events;
+
 	if (my_events) {
 		return 1;
-	} else {
-		return 0;
 	}
+
+	return 0;
 }


### PR DESCRIPTION
The goal of this commit is to reduce the overall test time by optimizing the time spent sleeping as suggested here: https://github.com/zephyrproject-rtos/zephyr/pull/78904#discussion_r1776502342.

However while doing so, a few glitches became apparent and those have been fixed as well.

1. The way the ZSOCK_POLLIN event is managed has been modified

In most tests, the event would stick for the whole test and this would sometimes results in the client receiving more data than intended which in turn would results in various unexpected warnings and errors.

The management of the ZSOCK_POLLIN event has now been mostly moved to the send/receive overrides which better represent how things would happen outside of the test scenario.

For example, when sending data, if this send would normally result in receiving some response, the send function sets the ZSOCK_POLLIN event. Then when receiving, we clear the event as the data has been received.

There are a few exceptions to this for cases where we need to simulate some specific abnormal behavior.

2. The `messages_needing_response` queue now includes a valid bit

The test manages a queue of messages id to be able to respond to the correct id in the receive hooks.

It was built in a way that the id 0 would be treated as invalid although it is a valid id.
In practice, it would not be an issue in most cases however, it would result in an unexpected behavior if the `test_multiple_requests` test would be run first.

To fix this issue in the simplest way, the queue has been changed to uint32_t which gives us 16 extra bits for the management of the queue, 1 of which is used to tell if the entry is valid or not.