### PR TITLE
include: gpio: Add isr_ok to interrupt configure API

### DIFF
--- a/include/zephyr/drivers/gpio.h
+++ b/include/zephyr/drivers/gpio.h
@@ -845,6 +845,8 @@ static inline bool gpio_is_ready_dt(const struct gpio_dt_spec *spec)
  *       not controlled directly by the GPIO module. That is, pins which are
  *       routed to other modules such as I2C, SPI, UART.
  *
+ * @funcprops \isr_ok
+ *
  * @param port Pointer to device structure for the driver instance.
  * @param pin Pin number.
  * @param flags Interrupt configuration flags as defined by GPIO_INT_*.
@@ -926,6 +928,8 @@ static inline int z_impl_gpio_pin_interrupt_configure(const struct device *port,
 
 /**
  * @brief Configure pin interrupts from a @p gpio_dt_spec.
+ *
+ * @funcprops \isr_ok
  *
  * This is equivalent to:
  *


### PR DESCRIPTION
Add isr_ok property to the interrupt configure API. For level-triggered interrupt the interrupt may have to be disabled until a thread context can process it and clear the interrupt trigger.

The function is documented as returning an error if it would block. Drivers in zephyr already do this, so if this is not ISR safe function then they need to be fixed.