### PR TITLE
boards: nxp: Add Serial Recovery button alias

### DIFF
--- a/boards/nxp/frdm_k22f/frdm_k22f.dts
+++ b/boards/nxp/frdm_k22f/frdm_k22f.dts
@@ -28,6 +28,7 @@
 		red-pwm-led = &red_pwm_led;
 		magn0 = &fxos8700;
 		accel0 = &fxos8700;
+		mcuboot-button0 = &user_button_3;
 	};
 
 	chosen {

--- a/boards/nxp/frdm_k64f/frdm_k64f.dts
+++ b/boards/nxp/frdm_k64f/frdm_k64f.dts
@@ -18,6 +18,7 @@
 		sw1 = &user_button_2;
 		magn0 = &fxos8700;
 		accel0 = &fxos8700;
+		mcuboot-button0 = &user_button_3;
 	};
 
 	chosen {

--- a/boards/nxp/frdm_k82f/frdm_k82f.dts
+++ b/boards/nxp/frdm_k82f/frdm_k82f.dts
@@ -27,6 +27,7 @@
 		sw1 = &user_button_1;
 		magn0 = &fxos8700;
 		accel0 = &fxos8700;
+		mcuboot-button0 = &user_button_0;
 	};
 
 	chosen {

--- a/boards/nxp/frdm_ke17z/frdm_ke17z.dts
+++ b/boards/nxp/frdm_ke17z/frdm_ke17z.dts
@@ -25,6 +25,7 @@
 		pwm-led0 = &red_pwm_led;
 		pwm-led1 = &green_pwm_led;
 		pwm-led2 = &blue_pwm_led;
+		mcuboot-button0 = &user_button_0;
 	};
 
 	chosen {

--- a/boards/nxp/frdm_ke17z512/frdm_ke17z512.dts
+++ b/boards/nxp/frdm_ke17z512/frdm_ke17z512.dts
@@ -34,6 +34,7 @@
 		pwm-led0 = &red_pwm_led;
 		pwm-led1 = &green_pwm_led;
 		pwm-led2 = &blue_pwm_led;
+		mcuboot-button0 = &user_button_2;
 	};
 
 	leds {

--- a/boards/nxp/frdm_mcxn947/frdm_mcxn947.dtsi
+++ b/boards/nxp/frdm_mcxn947/frdm_mcxn947.dtsi
@@ -16,6 +16,7 @@
 		sw0 = &user_button_2;
 		sw1 = &user_button_3;
 		sdhc0 = &usdhc0;
+		mcuboot-button0 = &user_button_2;
 	};
 
 	leds {

--- a/boards/nxp/lpcxpresso55s06/lpcxpresso55s06_common.dtsi
+++ b/boards/nxp/lpcxpresso55s06/lpcxpresso55s06_common.dtsi
@@ -29,6 +29,7 @@
 		sw1 = &btn_usr;
 		sw2 = &btn_isp;
 		usart-0 = &flexcomm0;
+		mcuboot-button0 = &btn_wk;
 	};
 
 	leds {

--- a/boards/nxp/lpcxpresso55s16/lpcxpresso55s16_common.dtsi
+++ b/boards/nxp/lpcxpresso55s16/lpcxpresso55s16_common.dtsi
@@ -31,6 +31,7 @@
 		usart-0 = &flexcomm0;
 		magn0 = &fxos8700;
 		accel0 = &fxos8700;
+		mcuboot-button0 = &btn_wk;
 	};
 
 	leds {

--- a/boards/nxp/lpcxpresso55s28/lpcxpresso55s28.dts
+++ b/boards/nxp/lpcxpresso55s28/lpcxpresso55s28.dts
@@ -21,6 +21,7 @@
 		sw2 = &user_button_3;
 		watchdog0 = &wwdt0;
 		accel0 = &mma8652fc;
+		mcuboot-button0 = &user_button_1;
 	};
 
 	chosen {

--- a/boards/nxp/lpcxpresso55s36/lpcxpresso55s36.dts
+++ b/boards/nxp/lpcxpresso55s36/lpcxpresso55s36.dts
@@ -33,6 +33,7 @@
 		sw1 = &btn_usr;
 		usart-0 = &flexcomm0;
 		pwm-0 = &flexpwm1_pwm0;
+		mcuboot-button0 = &btn_wk;
 	};
 
 	leds {

--- a/boards/nxp/lpcxpresso55s69/lpcxpresso55s69_lpc55s69_cpu0.dts
+++ b/boards/nxp/lpcxpresso55s69/lpcxpresso55s69_lpc55s69_cpu0.dts
@@ -31,6 +31,7 @@
 		sdhc0 = &sdhc0;
 		accel0 = &mma8652fc;
 		sdhc0 = &sdif;
+		mcuboot-button0 = &user_button_1;
 	};
 
 	chosen {

--- a/boards/nxp/mimxrt1010_evk/mimxrt1010_evk.dts
+++ b/boards/nxp/mimxrt1010_evk/mimxrt1010_evk.dts
@@ -18,6 +18,7 @@
 	aliases {
 		led0 = &green_led;
 		sw0 = &user_button;
+		mcuboot-button0 = &user_button;
 	};
 
 	chosen {

--- a/boards/nxp/mimxrt1015_evk/mimxrt1015_evk.dts
+++ b/boards/nxp/mimxrt1015_evk/mimxrt1015_evk.dts
@@ -17,6 +17,7 @@
 	aliases {
 		led0 = &green_led;
 		sw0 = &user_button;
+		mcuboot-button0 = &user_button;
 	};
 
 	chosen {

--- a/boards/nxp/mimxrt1020_evk/mimxrt1020_evk.dts
+++ b/boards/nxp/mimxrt1020_evk/mimxrt1020_evk.dts
@@ -18,6 +18,7 @@
 		led0 = &green_led;
 		sw0 = &user_button;
 		sdhc0 = &usdhc1;
+		mcuboot-button0 = &user_button;
 	};
 
 	chosen {

--- a/boards/nxp/mimxrt1024_evk/mimxrt1024_evk.dts
+++ b/boards/nxp/mimxrt1024_evk/mimxrt1024_evk.dts
@@ -21,6 +21,7 @@
 		magn0 = &fxos8700;
 		accel0 = &fxos8700;
 		sdhc0 = &usdhc1;
+		mcuboot-button0 = &user_button;
 	};
 
 	chosen {

--- a/boards/nxp/mimxrt1040_evk/mimxrt1040_evk.dts
+++ b/boards/nxp/mimxrt1040_evk/mimxrt1040_evk.dts
@@ -19,6 +19,7 @@
 		sw0 = &user_button;
 		pwm-0 = &flexpwm1_pwm3;
 		accel0 = &fxls8974;
+		mcuboot-button0 = &user_button;
 	};
 
 	chosen {

--- a/boards/nxp/mimxrt1050_evk/mimxrt1050_evk.dts
+++ b/boards/nxp/mimxrt1050_evk/mimxrt1050_evk.dts
@@ -21,6 +21,7 @@
 		magn0 = &fxos8700;
 		accel0 = &fxos8700;
 		sdhc0 = &usdhc1;
+		mcuboot-button0 = &user_button;
 	};
 
 	chosen {

--- a/boards/nxp/mimxrt1060_evk/mimxrt1060_evk.dts
+++ b/boards/nxp/mimxrt1060_evk/mimxrt1060_evk.dts
@@ -20,6 +20,7 @@
 		sw0 = &user_button;
 		watchdog0 = &wdog0;
 		sdhc0 = &usdhc1;
+		mcuboot-button0 = &user_button;
 	};
 
 	chosen {

--- a/boards/nxp/mimxrt1064_evk/mimxrt1064_evk.dts
+++ b/boards/nxp/mimxrt1064_evk/mimxrt1064_evk.dts
@@ -20,6 +20,7 @@
 		sw0 = &user_button;
 		watchdog0 = &wdog0;
 		sdhc0 = &usdhc1;
+		mcuboot-button0 = &user_button;
 	};
 
 	chosen {

--- a/boards/nxp/mimxrt1160_evk/mimxrt1160_evk.dtsi
+++ b/boards/nxp/mimxrt1160_evk/mimxrt1160_evk.dtsi
@@ -15,6 +15,7 @@
 		magn0 = &fxos8700;
 		accel0 = &fxos8700;
 		sdhc0 = &usdhc1;
+		mcuboot-button0 = &user_button;
 	};
 
 	leds {

--- a/boards/nxp/mimxrt1170_evk/mimxrt1170_evk.dtsi
+++ b/boards/nxp/mimxrt1170_evk/mimxrt1170_evk.dtsi
@@ -17,6 +17,7 @@
 		accel0 = &fxos8700;
 		sdhc0 = &usdhc1;
 		pwm-led0 = &green_pwm_led;
+		mcuboot-button0 = &user_button;
 	};
 
 	leds {

--- a/boards/nxp/mimxrt595_evk/mimxrt595_evk_mimxrt595s_cm33.dts
+++ b/boards/nxp/mimxrt595_evk/mimxrt595_evk_mimxrt595s_cm33.dts
@@ -29,6 +29,7 @@
 		sdhc0 = &usdhc0;
 		pwm-0 = &sc_timer;
 		dmic-dev = &dmic0;
+		mcuboot-button0 = &user_button_1;
 	};
 
 	chosen {

--- a/boards/nxp/mimxrt685_evk/mimxrt685_evk_mimxrt685s_cm33.dts
+++ b/boards/nxp/mimxrt685_evk/mimxrt685_evk_mimxrt685s_cm33.dts
@@ -34,6 +34,7 @@
 		accel0 = &fxos8700;
 		sdhc0 = &usdhc0;
 		dmic-dev = &dmic0;
+		mcuboot-button0 = &user_button_1;
 	};
 
 	chosen {

--- a/boards/nxp/rd_rw612_bga/rd_rw612_bga.dtsi
+++ b/boards/nxp/rd_rw612_bga/rd_rw612_bga.dtsi
@@ -19,6 +19,7 @@
 		i2c-0 = &flexcomm2;
 		watchdog0 = &wwdt;
 		dmic-dev = &dmic0;
+		mcuboot-button0 = &sw_4;
 	};
 
 	chosen {

--- a/boards/nxp/twr_ke18f/twr_ke18f.dts
+++ b/boards/nxp/twr_ke18f/twr_ke18f.dts
@@ -35,6 +35,7 @@
 		sw1 = &user_button_2;
 		magn0 = &fxos8700;
 		accel0 = &fxos8700;
+		mcuboot-button0 = &user_button_3;
 	};
 
 	chosen {

--- a/boards/nxp/twr_kv58f220m/twr_kv58f220m.dts
+++ b/boards/nxp/twr_kv58f220m/twr_kv58f220m.dts
@@ -25,6 +25,7 @@
 		sw3 = &user_button_3;
 		magn0 = &fxos8700;
 		accel0 = &fxos8700;
+		mcuboot-button0 = &user_button_0;
 	};
 
 	chosen {

--- a/boards/nxp/vmu_rt1170/vmu_rt1170_mimxrt1176_cm7.dts
+++ b/boards/nxp/vmu_rt1170/vmu_rt1170_mimxrt1176_cm7.dts
@@ -22,6 +22,7 @@
 		sdhc0 = &usdhc1;
 		sw0 = &arming_button;
 		pwm-led0 = &buzzer0;
+		mcuboot-button0 = &arming_button;
 	};
 
 	chosen {


### PR DESCRIPTION
Fixes MCUBoot Serial Recovery compilation error "Serial recovery/USB DFU button must be declared in device tree as 'mcuboot_button0'"