### PR TITLE
fs: littlefs: Avoid using static buffers that are too small

### DIFF
--- a/subsys/fs/littlefs_fs.c
+++ b/subsys/fs/littlefs_fs.c
@@ -836,14 +836,30 @@ static int littlefs_init_cfg(struct fs_littlefs *fs, int flags)
 	lcp->context = fs->backend;
 	/* Set the validated/defaulted values. */
 	if (littlefs_on_blkdev(flags)) {
+		lfs_size_t new_cache_size = block_size;
+		lfs_size_t new_lookahead_size = block_size * 4;
+
 		lcp->read = lfs_api_read_blk;
 		lcp->prog = lfs_api_prog_blk;
 		lcp->erase = lfs_api_erase_blk;
 
 		lcp->read_size = block_size;
 		lcp->prog_size = block_size;
-		lcp->cache_size = block_size;
-		lcp->lookahead_size = block_size * 4;
+
+		if (lcp->cache_size < new_cache_size) {
+			LOG_ERR("Configured cache size is too small: %d < %d", lcp->cache_size,
+				new_cache_size);
+			return -ENOMEM;
+		}
+		lcp->cache_size = new_cache_size;
+
+		if (lcp->lookahead_size < new_lookahead_size) {
+			LOG_ERR("Configured lookahead size is too small: %d < %d",
+				lcp->lookahead_size, new_lookahead_size);
+			return -ENOMEM;
+		}
+		lcp->lookahead_size = new_lookahead_size;
+
 		lcp->sync = lfs_api_sync_blk;
 
 		LOG_INF("sizes: rd %u ; pr %u ; ca %u ; la %u",


### PR DESCRIPTION
The cache_size and lookahead_size are set at compile time using the CONFIG_FS_LITTLEFS_CACHE_SIZE and CONFIG_FS_LITTLEFS_LOOKAHEAD_SIZE values from Kconfig.  Those values are also used to statically allocate buffers that are pointed at by the read_buffer, prog_buffer, and lookahead_buffer members of the lfs_config structure.

At runtime, when using a block device, the cache_size and lookahead_size are updated to be multiples of the block device's block_size, which may make them bigger than the original size used to allocate the static buffers. Detect when the size increases and set the corresponding buffer pointers to NULL in those cases.  The littlefs module (in lfs_init) handles the buffer pointers being NULL by dynamically allocating appropriately sized buffers (based on the relevant updated size value).

Fixes: #77917 