### PR TITLE
scripts: Add Nordic build dependency

### DIFF
--- a/scripts/requirements-build-nordic.txt
+++ b/scripts/requirements-build-nordic.txt
@@ -1,0 +1,8 @@
+# Copyright (c) 2024 GARDENA GmbH
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# BUILD-NORDIC: required to do build for Nordic SoCs
+
+# Required by the Noridic HAL
+nrf-regtool>=6.0

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,4 +1,5 @@
 -r requirements-base.txt
+-r requirements-build-nordic.txt
 -r requirements-build-test.txt
 -r requirements-run-test.txt
 -r requirements-extras.txt


### PR DESCRIPTION
Without nrf-regtool, CMake fails for new Nordic boards (nrf54h20dk, nrf9280pdk) with errors like this:

```
CMake Error at <snip>/zephyr/modules/hal_nordic/CMakeLists.txt:15
(find_package):
  Could not find a configuration file for package "nrf-regtool" that is
  compatible with requested version "5.6.0".

  The following configuration files were considered but not accepted:

    <snip>/modules/hal_nordic/nrf-regtool/nrf-regtoolConfig.cmake,
    version: unknown
```

This should fix #79380.

Requiring version 6.0 or newer in antipication of #79244.