### PR TITLE
drivers: intc: plic: fix for `SMP=n` when `MP_MAX_NUM_CPUS > 1`

### DIFF
--- a/arch/riscv/core/smp.c
+++ b/arch/riscv/core/smp.c
@@ -74,11 +74,11 @@ void arch_secondary_cpu_init(int hartid)
 #endif
 #ifdef CONFIG_SMP
 	irq_enable(RISCV_IRQ_MSOFT);
+#endif /* CONFIG_SMP */
 #ifdef CONFIG_PLIC_IRQ_AFFINITY
 	/* Enable on secondary cores so that they can respond to PLIC */
 	irq_enable(RISCV_IRQ_MEXT);
 #endif /* CONFIG_PLIC_IRQ_AFFINITY */
-#endif /* CONFIG_SMP */
 	riscv_cpu_init[cpu_num].fn(riscv_cpu_init[cpu_num].arg);
 }
 

--- a/drivers/interrupt_controller/intc_plic.c
+++ b/drivers/interrupt_controller/intc_plic.c
@@ -164,7 +164,7 @@ static inline mem_addr_t get_context_en_addr(const struct device *dev, uint32_t 
 	/*
 	 * We want to return the irq_en address for the context of given hart.
 	 */
-#if CONFIG_SMP
+#if CONFIG_MP_MAX_NUM_CPUS > 1
 	hartid = _kernel.cpus[cpu_num].arch.hartid;
 #else
 	hartid = arch_proc_id();
@@ -188,7 +188,7 @@ static inline mem_addr_t get_threshold_priority_addr(const struct device *dev, u
 	const struct plic_config *config = dev->config;
 	uint32_t hartid;
 
-#if CONFIG_SMP
+#if CONFIG_MP_MAX_NUM_CPUS > 1
 	hartid = _kernel.cpus[cpu_num].arch.hartid;
 #else
 	hartid = arch_proc_id();
@@ -493,7 +493,7 @@ static void plic_irq_handler(const struct device *dev)
 	 *
 	 * (by RISC-V Privileged Architecture v1.10)
 	 */
-	if (IS_ENABLED(CONFIG_SMP) && (local_irq == 0U)) {
+	if ((CONFIG_MP_MAX_NUM_CPUS > 1) && (local_irq == 0U)) {
 		return;
 	}
 


### PR DESCRIPTION
The functions to obtain the address are hardcoded to return the address of the first core when `CONFIG_SMP != y`, this causes an issue with enabling an IRQ when there are more than one core in the system (`CONFIG_MP_MAX_NUM_CPUS > 1`), as the driver would first enable the IRQ on the first core, and when it tries to obtain the address for the following cores and disable the IRQ on them, the functions continue to return the address of the first core, causing the IRQ to be disabled on the first core.

Fix this by determine if `CONFIG_MP_MAX_NUM_CPUS > 1` instead of `CONFIG_SMP=y` when returning the address.


See https://github.com/zephyrproject-rtos/zephyr/pull/78681#issuecomment-2391954215


Ran

```
west build -p auto -t run -b qemu_riscv64/qemu_virt_riscv64/smp -T zephyr/samples/subsys/profiling/perf/sample.perf
```

and there's a prompt