### PR TITLE
uart: esp32: Fixing garbage characters on mcuboot

### DIFF
--- a/drivers/clock_control/clock_control_esp32.c
+++ b/drivers/clock_control/clock_control_esp32.c
@@ -688,8 +688,11 @@ static int esp32_cpu_clock_configure(const struct esp32_cpu_clock_config *cpu_cf
 
 #if !defined(ESP_CONSOLE_UART_NONE)
 #if !defined(CONFIG_SOC_SERIES_ESP32C2) && !defined(CONFIG_SOC_SERIES_ESP32C6)
+#if defined(CONFIG_MCUBOOT) && defined(ESP_ROM_UART_CLK_IS_XTAL)
+	uint32_t uart_clock_src_hz = (uint32_t)rtc_clk_xtal_freq_get() * MHZ(1);
+#else
 	uint32_t uart_clock_src_hz = esp_clk_apb_freq();
-
+#endif
 	esp_rom_uart_set_clock_baudrate(ESP_CONSOLE_UART_NUM, uart_clock_src_hz,
 					ESP_CONSOLE_UART_BAUDRATE);
 #endif


### PR DESCRIPTION
Fixes garbage characters on mcuboot by adjusting UART baudrate during boot phase according to clock source.