### PR TITLE
net: dns: Fix DNS resolver cache invalid find call

### DIFF
--- a/subsys/net/lib/dns/resolve.c
+++ b/subsys/net/lib/dns/resolve.c
@@ -1300,7 +1300,7 @@ int dns_resolve_name(struct dns_resolve_context *ctx,
 
 try_resolve:
 #ifdef CONFIG_DNS_RESOLVER_CACHE
-	ret = dns_cache_find(&dns_cache, query, cached_info, sizeof(cached_info));
+	ret = dns_cache_find(&dns_cache, query, cached_info, ARRAY_SIZE(cached_info));
 	if (ret > 0) {
 		/* The query was cached, no
 		 * need to continue further.


### PR DESCRIPTION
The size of the output array for the find call in resolver is invalid: expected array size while overall memory size provided. As the latter is bigger there is a high probability of memory overwrite occurring on the stack.

Fixes #79408
