### PR TITLE
[WIP][fs] Setup streams of minimal libc to use fdtable for more unified manner.

### DIFF
--- a/include/zephyr/sys/fdtable.h
+++ b/include/zephyr/sys/fdtable.h
@@ -48,6 +48,16 @@ struct fd_op_vtable {
 	int (*ioctl)(void *obj, unsigned int request, va_list args);
 };
 
+struct fd_entry {
+	void *obj;
+	const struct fd_op_vtable *vtable;
+	atomic_t refcount;
+	struct k_mutex lock;
+	struct k_condvar cond;
+	size_t offset;
+	uint32_t mode;
+};
+
 /**
  * @brief Reserve file descriptor.
  *
@@ -92,6 +102,8 @@ static inline void zvfs_finalize_fd(int fd, void *obj, const struct fd_op_vtable
 {
 	zvfs_finalize_typed_fd(fd, obj, vtable, ZVFS_MODE_UNSPEC);
 }
+
+struct fd_entry *zvfs_get_fd_entry(int fd);
 
 /**
  * @brief Allocate file descriptor for underlying I/O object.

--- a/lib/libc/minimal/include/stdio.h
+++ b/lib/libc/minimal/include/stdio.h
@@ -18,17 +18,27 @@ extern "C" {
 #endif
 
 #if !defined(__FILE_defined)
+
 #define __FILE_defined
-typedef int  FILE;
+#if defined(CONFIG_FDTABLE)
+typedef struct fd_entry  FILE;
+#else
+typedef int FILE;
+#endif
+
 #endif
 
 #if !defined(EOF)
 #define EOF  (-1)
 #endif
 
-#define stdin  ((FILE *) 1)
-#define stdout ((FILE *) 2)
-#define stderr ((FILE *) 3)
+extern FILE* _stdin;
+extern FILE* _stdout;
+extern FILE* _stderr;
+
+#define stdin _stdin
+#define stdout _stdout
+#define stderr _stderr
 
 #define SEEK_SET	0	/* Seek from beginning of file.  */
 #define SEEK_CUR	1	/* Seek from current position.  */

--- a/lib/libc/minimal/include/sys/_stdvtables.h
+++ b/lib/libc/minimal/include/sys/_stdvtables.h
@@ -1,0 +1,17 @@
+/*
+ * LICENSE - WIP
+ *
+ *
+ */
+
+
+#ifndef ZEPHYR_LIB_LIBC_MINIMAL_INCLUDE_SYS_XSTDVTABLES_H_
+#define ZEPHYR_LIB_LIBC_MINIMAL_INCLUDE_SYS_XSTDVTABLES_H_
+
+#include <zephyr/sys/fdtable.h>
+
+extern const struct fd_op_vtable stdin_fd_op_vtable; 
+extern const struct fd_op_vtable stdout_fd_op_vtable;
+extern const struct fd_op_vtable stderr_fd_op_vtable; 
+
+#endif /* ZEPHYR_LIB_LIBC_MINIMAL_INCLUDE_SYS_XSTDVTABLES_H_ */

--- a/lib/libc/minimal/source/stdout/stdout_console.c
+++ b/lib/libc/minimal/source/stdout/stdout_console.c
@@ -8,8 +8,28 @@
 
 #include <stdio.h>
 #include <zephyr/sys/libc-hooks.h>
+#include <zephyr/sys/fdtable.h>
 #include <zephyr/internal/syscall_handler.h>
+#include <sys/_stdvtables.h>
+#include <stdlib.h>
+
 #include <string.h>
+
+// Defined in stdio
+FILE* _stdin;
+FILE* _stdout;
+FILE* _stderr;
+
+int stdin_fd = 0;
+int stdout_fd = 1;
+int stderr_fd = 2;
+
+// Alternative to setting FIle to int if fdtable is not used. Good for memory eh?
+// #if !defined(CONFIG_FDTABLE)
+// 	static struct fd_entry stdin_simple_entry = {.obj = (void*)&stdin_fd, .vtable = NULL};
+//     static struct fd_entry stdout_simple_entry = {.obj = (void*)&stdout_fd, .vtable = NULL};
+//     static struct fd_entry stderr_simple_entry = {.obj = (void*)&stderr_fd, .vtable = NULL};
+// #endif
 
 static int _stdout_hook_default(int c)
 {
@@ -22,12 +42,65 @@ static int (*_stdout_hook)(int c) = _stdout_hook_default;
 
 void __stdout_hook_install(int (*hook)(int c))
 {
+#if defined(CONFIG_FDTABLE)
+	_stdin = zvfs_get_fd_entry(stdin_fd);
+	_stdout = zvfs_get_fd_entry(stdout_fd);
+	_stderr = zvfs_get_fd_entry(stderr_fd);
+#else
+	// fdtable not availabe fallback to primitive read and write.
+    _stdin = &stdin_fd;
+    _stdout = &stdout_fd;
+    _stderr = &stderr_fd;
+#endif
+
 	_stdout_hook = hook;
 }
 
+#if defined(CONFIG_FDTABLE)
+
+static ssize_t stdin_read_vmeth(void *obj, void *buffer, size_t count)
+{
+	return fputc('c', stdout);
+}
+
+static ssize_t stdout_write_vmeth(void *obj, const void *buffer, size_t count)
+{
+	int c = *((int *) buffer);
+	return _stdout_hook(c);
+}
+
+static ssize_t stderr_write_vmeth(void *obj, const void *buffer, size_t count)
+{
+	return 10;
+}
+
+const struct fd_op_vtable stdin_fd_op_vtable = {
+	.read = stdin_read_vmeth,
+};
+
+const struct fd_op_vtable stdout_fd_op_vtable = {
+	.write = stdout_write_vmeth,
+};
+
+const struct fd_op_vtable stderr_fd_op_vtable = {
+	.write = stderr_write_vmeth,
+};
+
+#endif
+
 int z_impl_zephyr_fputc(int c, FILE *stream)
 {
-	return ((stream == stdout) || (stream == stderr)) ? _stdout_hook(c) : EOF;
+#if defined(CONFIG_FDTABLE)
+	if(stream->vtable != NULL) {
+		return stream->vtable->write(stream->obj, &c, 1);
+	}
+#else
+	// usage of std streams without fdtable
+	if(stream != NULL && (stream == stdout || stream == stderr))
+		return _stdout_hook(c);
+#endif
+	// EOF for any other cases
+	return EOF;
 }
 
 #ifdef CONFIG_USERSPACE

--- a/lib/os/fdtable.c
+++ b/lib/os/fdtable.c
@@ -23,46 +23,43 @@
 #include <zephyr/internal/syscall_handler.h>
 #include <zephyr/sys/atomic.h>
 
+#if defined(CONFIG_MINIMAL_LIBC) && !defined(CONFIG_POSIX_DEVICE_IO)
+#include <sys/_stdvtables.h>
+#endif
+
 struct stat;
 
-struct fd_entry {
-	void *obj;
-	const struct fd_op_vtable *vtable;
-	atomic_t refcount;
-	struct k_mutex lock;
-	struct k_condvar cond;
-	size_t offset;
-	uint32_t mode;
-};
-
 #if defined(CONFIG_POSIX_DEVICE_IO)
-static const struct fd_op_vtable stdinout_fd_op_vtable;
+// Forward declaration
+static const struct fd_op_vtable stdin_fd_op_vtable;
+static const struct fd_op_vtable stdout_fd_op_vtable;
+static const struct fd_op_vtable stderr_fd_op_vtable;
 
 BUILD_ASSERT(CONFIG_ZVFS_OPEN_MAX >= 3, "CONFIG_ZVFS_OPEN_MAX >= 3 for CONFIG_POSIX_DEVICE_IO");
 #endif /* defined(CONFIG_POSIX_DEVICE_IO) */
 
 static struct fd_entry fdtable[CONFIG_ZVFS_OPEN_MAX] = {
-#if defined(CONFIG_POSIX_DEVICE_IO)
+#if defined(CONFIG_POSIX_DEVICE_IO) || defined(CONFIG_MINIMAL_LIBC)
 	/*
 	 * Predefine entries for stdin/stdout/stderr.
 	 */
 	{
 		/* STDIN */
-		.vtable = &stdinout_fd_op_vtable,
+		.vtable = &stdin_fd_op_vtable,
 		.refcount = ATOMIC_INIT(1),
 		.lock = Z_MUTEX_INITIALIZER(fdtable[0].lock),
 		.cond = Z_CONDVAR_INITIALIZER(fdtable[0].cond),
 	},
 	{
 		/* STDOUT */
-		.vtable = &stdinout_fd_op_vtable,
+		.vtable = &stdout_fd_op_vtable,
 		.refcount = ATOMIC_INIT(1),
 		.lock = Z_MUTEX_INITIALIZER(fdtable[1].lock),
 		.cond = Z_CONDVAR_INITIALIZER(fdtable[1].cond),
 	},
 	{
 		/* STDERR */
-		.vtable = &stdinout_fd_op_vtable,
+		.vtable = &stderr_fd_op_vtable,
 		.refcount = ATOMIC_INIT(1),
 		.lock = Z_MUTEX_INITIALIZER(fdtable[2].lock),
 		.cond = Z_CONDVAR_INITIALIZER(fdtable[2].cond),
@@ -159,6 +156,15 @@ bool fdtable_fd_is_initialized(int fd)
 	return true;
 }
 #endif /* CONFIG_ZTEST */
+
+struct fd_entry *zvfs_get_fd_entry(int fd)
+{
+	if(_check_fd(fd) < 0) {
+		return NULL;
+	}
+
+	return &fdtable[fd];
+}
 
 void *zvfs_get_fd_obj(int fd, const struct fd_op_vtable *vtable, int err)
 {
@@ -508,10 +514,23 @@ static int stdinout_ioctl_vmeth(void *obj, unsigned int request, va_list args)
 }
 
 
-static const struct fd_op_vtable stdinout_fd_op_vtable = {
+static const struct fd_op_vtable stdin_fd_op_vtable = {
 	.read = stdinout_read_vmeth,
 	.write = stdinout_write_vmeth,
 	.ioctl = stdinout_ioctl_vmeth,
 };
+
+static const struct fd_op_vtable stdout_fd_op_vtable = {
+	.read = stdinout_read_vmeth,
+	.write = stdinout_write_vmeth,
+	.ioctl = stdinout_ioctl_vmeth,
+};
+
+static const struct fd_op_vtable stderr_fd_op_vtable = {
+	.read = stdinout_read_vmeth,
+	.write = stdinout_write_vmeth,
+	.ioctl = stdinout_ioctl_vmeth,
+};
+
 
 #endif /* defined(CONFIG_POSIX_DEVICE_IO) */


### PR DESCRIPTION
This is a WIP PR, the description will be updated at a later point of time.

To implement file io functions like fopen, fwrite in minimal libc, fs support is needed. To have this support fdtable will be leveraged, as this facilitates the conversion between posix fd and standard files.

For starters, define the standard streams (stdio, stdout) as an fd_entry which has the virtual methods for read and write. This follows the same approach as POSIX DEVICE IO. The std streams will be installed during hook install step which zephyr os calls during application bootstrap. If the file support is not needed then the streams can fall back to integers (We can consider using fd_entry for them as well and have the fd numbers as an object - but it probably uses unnecessary space in code hence opted for simple integers).

Split the vmethods for each streams as each of them will perform different operations.

How can this be used for fopen, fwrite etc? Similar vmethods will be written on top of fs apis.

This PR just aims at showing the concept and get reviewers opinion on this approach, unit tests and proper flags will be defined  in a followup revision.

Tested locally using `./scripts/twister -i -T tests/posix -T tests/lib/c_lib -p qemu_x86_64 -p qemu_riscv64` and validated functionality using a simple app that prints hello world.