### PR TITLE
ztest: Dump content of memory when failing comparisation

### DIFF
--- a/include/zephyr/sys/printk_hexdump.h
+++ b/include/zephyr/sys/printk_hexdump.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2024 GARDENA GmbH
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_SYS_PRINTK_HEXDUMP_H_
+#define ZEPHYR_INCLUDE_SYS_PRINTK_HEXDUMP_H_
+
+#include <stdint.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ *
+ * @brief Print data buffer using printk().
+ *
+ * @param str Prefix for every line of data
+ * @param data Pointer to data
+ * @param data_length Number of bytes in @p data to be printed
+ */
+#ifdef CONFIG_PRINTK
+
+void printk_hexdump(const char *str, const uint8_t *data, size_t data_length);
+
+#else
+
+static inline void printk_hexdump(const char *str, const uint8_t *data, size_t data_length);
+{
+	ARG_UNUSED(str);
+	ARG_UNUSED(data);
+	ARG_UNUSED(data_length);
+}
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/lib/utils/CMakeLists.txt
+++ b/lib/utils/CMakeLists.txt
@@ -10,6 +10,8 @@ zephyr_sources(
   bitarray.c
   )
 
+zephyr_sources_ifdef(CONFIG_PRINTK printk_hexdump.c)
+
 zephyr_sources_ifdef(CONFIG_ONOFF onoff.c)
 zephyr_sources_ifdef(CONFIG_NOTIFY notify.c)
 

--- a/lib/utils/printk_hexdump.c
+++ b/lib/utils/printk_hexdump.c
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2024 GARDENA GmbH
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/sys/printk.h>
+
+#include <stdint.h>
+#include <stddef.h>
+
+void printk_hexdump(const char *str, const uint8_t *data, size_t data_length)
+{
+	size_t n = 0;
+
+	if (!data_length) {
+		printk("%s has no data\n", str);
+		return;
+	}
+
+	while (data_length--) {
+		if (n % 16 == 0) {
+			printk("%s %08zX ", str, n);
+		}
+
+		printk("%02X ", *data++);
+
+		n++;
+		if (n % 8 == 0) {
+			if (n % 16 == 0) {
+				printk("\n");
+			} else {
+				printk(" ");
+			}
+		}
+	}
+
+	if (n % 16) {
+		printk("\n");
+	}
+}

--- a/tests/net/mocks/CMakeLists.txt
+++ b/tests/net/mocks/CMakeLists.txt
@@ -2,6 +2,7 @@
 
 add_library(net_mocks STATIC
             assert.c
+            ${ZEPHYR_BASE}/lib/utils/printk_hexdump.c
 )
 
 target_include_directories(net_mocks PUBLIC

--- a/tests/unit/util/CMakeLists.txt
+++ b/tests/unit/util/CMakeLists.txt
@@ -10,6 +10,7 @@ target_sources(testbinary
   PRIVATE
   main.c
   ${ZEPHYR_BASE}/lib/utils/dec.c
+  ${ZEPHYR_BASE}/lib/utils/printk_hexdump.c
   ${ZEPHYR_BASE}/lib/utils/utf8.c
 )
 

--- a/tests/ztest/base/CMakeLists.txt
+++ b/tests/ztest/base/CMakeLists.txt
@@ -7,7 +7,11 @@ if(BOARD STREQUAL unit_testing)
 
   # This test suite depends on having this CONFIG_ value, so define it
   add_definitions( -DCONFIG_BUGxxxxx )
-  target_sources(testbinary PRIVATE src/main.c)
+  target_sources(testbinary
+    PRIVATE
+    src/main.c
+    ${ZEPHYR_BASE}/lib/utils/printk_hexdump.c
+  )
 else()
   find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
   project(base)


### PR DESCRIPTION
This is *NOT* yet ready to be merged, but I'd like to get feedback on this idea. If liked, I'd extend it to other areas in Ztest.

The goal of this PR is to simplify spotting errors during development.

Before this commit:

```
START - test_printk_hexdump_demo_fail

    Assertion failed at <snip>/src/main.c:494: printk_hexdump_demo_test_printk_hexdump_demo_fail: (buf not equal to exp)
Buffers must match
 at test function
 FAIL - test_printk_hexdump_demo_fail in 0.000 seconds
```

With this commit:

```
START - test_printk_hexdump_demo_fail
expected 00000000 11 22 33 44 55 66 77 88
actually 00000000 11 22 33 FF 55 66 77 88

    Assertion failed at <snip>/src/main.c:494: printk_hexdump_demo_test_printk_hexdump_demo_fail: (buf not equal to exp)
Buffers must match
 at test function
 FAIL - test_printk_hexdump_demo_fail in 0.000 seconds
```

TODOs:
- [ ] Write some tests
- [ ] Run twister on whole code base
- [ ] Put option behind a Kconfig symbol?

Hints
- This relates to #62127