### PR TITLE
doc: add references to extra file west args

### DIFF
--- a/boards/enjoydigital/litex_vexriscv/doc/index.rst
+++ b/boards/enjoydigital/litex_vexriscv/doc/index.rst
@@ -162,7 +162,7 @@ If you were generating bitstream with the official LiteX SoC builder you need to
 
 .. code-block:: bash
 
-   west build -b litex_vexriscv path/to/app -DDTC_OVERLAY_FILE=path/to/overlay.dts
+   west build -b litex_vexriscv --extra-dtc-overlay path/to/overlay.dts path/to/app
 
 Booting
 =======

--- a/boards/nxp/mimxrt1170_evk/doc/index.rst
+++ b/boards/nxp/mimxrt1170_evk/doc/index.rst
@@ -1,4 +1,4 @@
-﻿.. _mimxrt1170_evk:
+.. _mimxrt1170_evk:
 
 NXP MIMXRT1170-EVK/EVKB
 #######################
@@ -478,4 +478,4 @@ ENET1G Driver
 
 Current default of ethernet driver is to use 100M Ethernet instance ENET.
 To use the 1G Ethernet instance ENET1G, include the overlay to west build with
-the option ``-DEXTRA_DTC_OVERLAY_FILE=nxp,enet1g.overlay`` instead.
+the option ``--extra-dtc-overlay nxp,enet1g.overlay`` instead.

--- a/doc/connectivity/bluetooth/autopts/autopts-linux.rst
+++ b/doc/connectivity/bluetooth/autopts/autopts-linux.rst
@@ -301,7 +301,7 @@ Testing Zephyr Host Stack on :ref:`native_sim <native_sim>`:
     # A Bluetooth controller needs to be mounted.
     # For running with HCI UART, please visit: https://docs.zephyrproject.org/latest/samples/bluetooth/hci_uart/README.html#bluetooth-hci-uart
 
-    west build -b native_sim zephyr/tests/bluetooth/tester/ -DEXTRA_CONF_FILE=overlay-native.conf
+    west build -b native_sim zephyr/tests/bluetooth/tester/ --extra-conf overlay-native.conf
 
     sudo python ./autoptsclient-zephyr.py "C:\Users\USER_NAME\Documents\Profile Tuning Suite\PTS_PROJECT\PTS_PROJECT.pqw6" \
     	~/zephyrproject/build/zephyr/zephyr.exe -i SERVER_IP -l LOCAL_IP --hci 0

--- a/doc/connectivity/networking/native_sim_setup.rst
+++ b/doc/connectivity/networking/native_sim_setup.rst
@@ -110,7 +110,7 @@ Build and start the ``echo_server`` sample application:
    :zephyr-app: samples/net/sockets/echo_server
    :host-os: unix
    :board: native_sim
-   :gen-args: -DEXTRA_CONF_FILE=overlay-nsos.conf
+   :extra-conf: overlay-nsos.conf
    :goals: run
    :compact:
 

--- a/doc/connectivity/networking/networking_with_multiple_instances.rst
+++ b/doc/connectivity/networking/networking_with_multiple_instances.rst
@@ -132,8 +132,8 @@ In terminal #4, if you are using QEMU, type this:
 .. code-block:: console
 
    west build -d build/server -b qemu_x86 -t run \
+      --extra-conf overlay-e1000.conf \
       samples/net/sockets/echo_server -- \
-      -DEXTRA_CONF_FILE=overlay-e1000.conf \
       -DCONFIG_NET_CONFIG_MY_IPV4_ADDR=\"198.51.100.1\" \
       -DCONFIG_NET_CONFIG_PEER_IPV4_ADDR=\"203.0.113.1\" \
       -DCONFIG_NET_CONFIG_MY_IPV6_ADDR=\"2001:db8:100::1\" \
@@ -163,8 +163,8 @@ In terminal #5, if you are using QEMU, type this:
 .. code-block:: console
 
    west build -d build/client -b qemu_x86 -t run \
+      --extra-conf overlay-e1000.conf \
       samples/net/sockets/echo_client -- \
-      -DEXTRA_CONF_FILE=overlay-e1000.conf \
       -DCONFIG_NET_CONFIG_MY_IPV4_ADDR=\"203.0.113.1\" \
       -DCONFIG_NET_CONFIG_PEER_IPV4_ADDR=\"198.51.100.1\" \
       -DCONFIG_NET_CONFIG_MY_IPV6_ADDR=\"2001:db8:200::1\" \

--- a/doc/connectivity/networking/qemu_802154_setup.rst
+++ b/doc/connectivity/networking/qemu_802154_setup.rst
@@ -40,7 +40,7 @@ In terminal #1, type:
    :host-os: unix
    :board: qemu_x86
    :build-dir: server
-   :gen-args: -DEXTRA_CONF_FILE=overlay-qemu_802154.conf
+   :extra-conf: overlay-qemu_802154.conf
    :goals: server
    :compact:
 
@@ -51,7 +51,8 @@ If you want to capture the network traffic between the two QEMUs, type:
    :host-os: unix
    :board: qemu_x86
    :build-dir: server
-   :gen-args: -G'Unix Makefiles' -DEXTRA_CONF_FILE=overlay-qemu_802154.conf -DPCAP=capture.pcap
+   :extra-conf: overlay-qemu_802154.conf
+   :gen-args: -G'Unix Makefiles'  -DPCAP=capture.pcap
    :goals: server
    :compact:
 
@@ -69,7 +70,7 @@ In terminal #2, type:
    :host-os: unix
    :board: qemu_x86
    :build-dir: client
-   :gen-args: -DEXTRA_CONF_FILE=overlay-qemu_802154.conf
+   :extra-conf: overlay-qemu_802154.conf
    :goals: client
    :compact:
 

--- a/doc/connectivity/networking/qemu_eth_setup.rst
+++ b/doc/connectivity/networking/qemu_eth_setup.rst
@@ -81,7 +81,7 @@ In terminal #2, type:
    :zephyr-app: samples/net/sockets/echo_server
    :host-os: unix
    :board: qemu_x86
-   :gen-args: -DEXTRA_CONF_FILE=overlay-e1000.conf
+   :extra-conf: overlay-e1000.conf
    :goals: run
    :compact:
 

--- a/doc/connectivity/usb/device_next/usb_device.rst
+++ b/doc/connectivity/usb/device_next/usb_device.rst
@@ -51,8 +51,8 @@ configuration ``-DCONF_FILE=usbd_next_prj.conf`` either directly or via
 
 * :zephyr:code-sample:`zperf` To build the sample for the new device support,
   set the configuration overlay file
-  ``-DDEXTRA_CONF_FILE=overlay-usbd_next_ecm.conf`` and devicetree overlay file
-  ``-DDTC_OVERLAY_FILE="usbd_next_ecm.overlay`` either directly or via ``west``.
+  ``--extra-conf overlay-usbd_next_ecm.conf`` and devicetree overlay file
+  ``--extra-dtc-overlay usbd_next_ecm.overlay`` via ``west``.
 
 How to configure and enable USB device support
 **********************************************

--- a/doc/develop/west/build-flash-debug.rst
+++ b/doc/develop/west/build-flash-debug.rst
@@ -241,12 +241,12 @@ To set :ref:`DTC_OVERLAY_FILE <important-build-vars>` to
 :file:`enable-modem.overlay`, using that file as a
 :ref:`devicetree overlay <dt-guide>`::
 
-  west build -b reel_board -- -DDTC_OVERLAY_FILE=enable-modem.overlay
+  west build -b reel_board --extra-dtc-overlay enable-modem.overlay
 
 To merge the :file:`file.conf` Kconfig fragment into your build's
 :file:`.config`::
 
-  west build -- -DEXTRA_CONF_FILE=file.conf
+  west build --extra-conf file.conf
 
 .. _west-building-cmake-config:
 

--- a/doc/hardware/emulator/bus_emulators.rst
+++ b/doc/hardware/emulator/bus_emulators.rst
@@ -195,7 +195,8 @@ Here are some examples present in Zephyr:
       :zephyr-app: tests/drivers/eeprom/api
       :board: native_sim
       :goals: build
-      :gen-args: -DDTC_OVERLAY_FILE=at2x_emul.overlay -DOVERLAY_CONFIG=at2x_emul.conf
+      :extra-conf: at2x_emul.conf
+      :extra-dtc-overlay: at2x_emul.overlay
 
 API Reference
 =============

--- a/samples/bluetooth/direction_finding_central/README.rst
+++ b/samples/bluetooth/direction_finding_central/README.rst
@@ -33,7 +33,7 @@ changing ``nrf52833dk/nrf52833`` as needed for your board:
    :zephyr-app: samples/bluetooth/direction_finding_central
    :host-os: unix
    :board: nrf52833dk/nrf52833
-   :gen-args: -DEXTRA_CONF_FILE=overlay-aod.conf
+   :extra-conf: overlay-aod.conf
    :goals: build flash
    :compact:
 

--- a/samples/bluetooth/direction_finding_connectionless_rx/README.rst
+++ b/samples/bluetooth/direction_finding_connectionless_rx/README.rst
@@ -33,7 +33,7 @@ changing ``nrf52833dk/nrf52833`` as needed for your board:
    :zephyr-app: samples/bluetooth/direction_finding_connectionless_rx
    :host-os: unix
    :board: nrf52833dk/nrf52833
-   :gen-args: -DEXTRA_CONF_FILE=overlay-aod.conf
+   :extra-conf: overlay-aod.conf
    :goals: build flash
    :compact:
 

--- a/samples/bluetooth/direction_finding_connectionless_tx/README.rst
+++ b/samples/bluetooth/direction_finding_connectionless_tx/README.rst
@@ -33,7 +33,7 @@ To use Angle of Arrival mode only, build this application as follows, changing
    :zephyr-app: samples/bluetooth/direction_finding_connectionless_tx
    :host-os: unix
    :board: nrf52833dk/nrf52833
-   :gen-args: -DEXTRA_CONF_FILE=overlay-aoa.conf
+   :extra-conf: overlay-aoa.conf
    :goals: build flash
    :compact:
 

--- a/samples/bluetooth/direction_finding_peripheral/README.rst
+++ b/samples/bluetooth/direction_finding_peripheral/README.rst
@@ -32,7 +32,7 @@ changing ``nrf52833dk/nrf52833`` as needed for your board:
    :zephyr-app: samples/bluetooth/direction_finding_peripheral
    :host-os: unix
    :board: nrf52833dk/nrf52833
-   :gen-args: -DEXTRA_CONF_FILE=overlay-aoa.conf
+   :extra-conf: overlay-aoa.conf
    :goals: build flash
    :compact:
 

--- a/samples/bluetooth/hci_uart/README.rst
+++ b/samples/bluetooth/hci_uart/README.rst
@@ -123,7 +123,7 @@ application. To enable debug over RTT the debug configuration file can be used.
 
 .. code-block:: console
 
-   west build samples/bluetooth/hci_uart -- -DEXTRA_CONF_FILE='debug.conf'
+   west build --extra-conf debug.conf samples/bluetooth/hci_uart
 
 Then attach RTT as described here: :ref:`Using Segger J-Link <Using Segger J-Link>`
 

--- a/samples/bluetooth/hci_uart_3wire/README.rst
+++ b/samples/bluetooth/hci_uart_3wire/README.rst
@@ -123,7 +123,7 @@ application. To enable debug over RTT the debug configuration file can be used.
 
 .. code-block:: console
 
-   west build samples/bluetooth/hci_uart_3wire -- -DEXTRA_CONF_FILE='debug.conf'
+   west build --extra-conf debug.conf samples/bluetooth/hci_uart_3wire
 
 Then attach RTT as described here: :ref:`Using Segger J-Link <Using Segger J-Link>`
 

--- a/samples/bluetooth/iso_broadcast/README.rst
+++ b/samples/bluetooth/iso_broadcast/README.rst
@@ -22,7 +22,7 @@ Building and Running
 ********************
 
 This sample can be found under :zephyr_file:`samples/bluetooth/iso_broadcast` in
-the Zephyr tree. Use ``-DEXTRA_CONF_FILE=overlay-bt_ll_sw_split.conf`` to enable
+the Zephyr tree. Use ``-extra-conf overlay-bt_ll_sw_split.conf`` to enable
 required ISO feature support in Zephyr Bluetooth Controller on supported boards.
 
 Use the sample found under :zephyr_file:`samples/bluetooth/iso_receive` in the

--- a/samples/bluetooth/iso_receive/README.rst
+++ b/samples/bluetooth/iso_receive/README.rst
@@ -22,7 +22,7 @@ Building and Running
 ********************
 
 This sample can be found under :zephyr_file:`samples/bluetooth/iso_receive` in
-the Zephyr tree. Use ``-DEXTRA_CONF_FILE=overlay-bt_ll_sw_split.conf`` to enable
+the Zephyr tree. Use ``--extra-conf overlay-bt_ll_sw_split.conf`` to enable
 required ISO feature support in Zephyr Bluetooth Controller on supported boards.
 
 Use the sample found under :zephyr_file:`samples/bluetooth/iso_broadcast` on

--- a/samples/boards/nxp/s32/netc/README.rst
+++ b/samples/boards/nxp/s32/netc/README.rst
@@ -61,7 +61,7 @@ To build and run the sample application for use-case 2:
    :zephyr-app: samples/boards/nxp/s32/netc
    :board: s32z2xxdc2/s32z270/rtu0
    :goals: build flash
-   :gen-args: -DDTC_OVERLAY_FILE="./vsi-and-psi.overlay"
+   :extra-dtc-overlay: vsi-and-psi.overlay
 
 Once started, you should see the network interfaces details, for example:
 

--- a/samples/drivers/spi_flash_at45/README.rst
+++ b/samples/drivers/spi_flash_at45/README.rst
@@ -52,7 +52,7 @@ To build and flash with device power management enabled:
 .. zephyr-app-commands::
    :zephyr-app: samples/drivers/spi_flash_at45
    :board: nrf9160dk/nrf9160
-   :gen-args: -DEXTRA_CONF_FILE=overlay-pm.conf
+   :extra-conf: overlay-pm.conf
    :goals: build flash
    :compact:
 
@@ -61,7 +61,7 @@ To build and flash with flash page layout enabled:
 .. zephyr-app-commands::
    :zephyr-app: samples/drivers/spi_flash_at45
    :board: nrf9160dk/nrf9160
-   :gen-args: -DEXTRA_CONF_FILE=overlay-page_layout.conf
+   :extra-conf: overlay-page_layout.conf
    :goals: build flash
    :compact:
 
@@ -71,7 +71,8 @@ layout enabled:
 .. zephyr-app-commands::
    :zephyr-app: samples/drivers/spi_flash_at45
    :board: nrf9160dk/nrf9160
-   :gen-args: -DEXTRA_CONF_FILE="overlay-pm.conf overlay-page_layout.conf"
+   :extra-conf: overlay-pm.conf
+   :extra-conf: overlay-page_layout.conf
    :goals: build flash
    :compact:
 

--- a/samples/drivers/w1/scanner/README.rst
+++ b/samples/drivers/w1/scanner/README.rst
@@ -20,7 +20,7 @@ enable and configure the drivers.
 .. zephyr-app-commands::
    :zephyr-app: samples/drivers/w1/scanner
    :board: nrf52840dk/nrf52840
-   :gen-args: -DDTC_OVERLAY_FILE=w1_serial.overlay
+   :extra-dtc-overlay: w1_serial.overlay
    :goals: build flash
    :compact:
 

--- a/samples/net/cloud/tagoio_http_post/README.rst
+++ b/samples/net/cloud/tagoio_http_post/README.rst
@@ -67,7 +67,7 @@ need fill ``CONFIG_TAGOIO_HTTP_WIFI_SSID`` with your wifi network SSID and
 .. zephyr-app-commands::
    :zephyr-app: samples/net/cloud/tagoio_http_post
    :board: disco_l475_iot1
-   :gen-args: -DEXTRA_CONF_FILE=overlay-wifi.conf
+   :extra-conf: overlay-wifi.conf
    :goals: build flash
    :compact:
 
@@ -75,7 +75,7 @@ need fill ``CONFIG_TAGOIO_HTTP_WIFI_SSID`` with your wifi network SSID and
    :zephyr-app: samples/net/cloud/tagoio_http_post
    :board: [sam_v71_xult/samv71q21 | frdm_k64f | nucleo_f767zi]
    :shield: [esp_8266_arduino | inventek_eswifi_arduino_uart]
-   :gen-args: -DEXTRA_CONF_FILE=overlay-wifi.conf
+   :extra-conf: overlay-wifi.conf
    :goals: build flash
    :compact:
 

--- a/samples/net/mqtt_publisher/README.rst
+++ b/samples/net/mqtt_publisher/README.rst
@@ -157,7 +157,7 @@ try this sample with TLS enabled, by following these steps:
   i.e., the IP address of test.mosquitto.org ``"37.187.106.16"``
 - In :file:`src/main.c`, set TLS_SNI_HOSTNAME to ``"test.mosquitto.org"``
   to match the Common Name (CN) in the downloaded certificate.
-- Build the sample by specifying ``-DEXTRA_CONF_FILE=overlay-tls.conf``
+- Build the sample by specifying ``--extra-conf overlay-tls.conf``
   when running ``west build`` or ``cmake`` (or refer to the TLS offloading
   section below if your platform uses the offloading feature).
 - Flash the binary onto the device to run the sample:
@@ -170,7 +170,7 @@ TLS offloading
 ==============
 
 For boards that support this feature, TLS offloading is used by
-specifying ``-DEXTRA_CONF_FILE=overlay-tls-offload.conf`` when running ``west
+specifying ``--extra-conf overlay-tls-offload.conf`` when running ``west
 build`` or ``cmake``.
 
 Using this overlay enables TLS without bringing in mbedtls.
@@ -179,7 +179,7 @@ SOCKS5 proxy support
 ====================
 
 It is also possible to connect to the MQTT broker through a SOCKS5 proxy.
-To enable it, use ``-DEXTRA_CONF_FILE=overlay-socks5.conf`` when running ``west
+To enable it, use ``--extra-conf overlay-socks5.conf`` when running ``west
 build`` or  ``cmake``.
 
 By default, to make the testing easier, the proxy is expected to run on the

--- a/samples/net/openthread/coprocessor/README.rst
+++ b/samples/net/openthread/coprocessor/README.rst
@@ -41,7 +41,8 @@ Build the OpenThread NCP sample application which uses CDC ACM UART device:
    :zephyr-app: samples/net/openthread/coprocessor
    :board: nrf52840dk/nrf52840
    :goals: build flash
-   :gen-args: -DDTC_OVERLAY_FILE=usb.overlay -DEXTRA_CONF_FILE=overlay-usb-nrf-br.conf
+   :extra-conf: usb.overlay
+   :extra-conf: overlay-usb-nrf-br.conf
    :compact:
 
 Example building for the nrf52840dk/nrf52840 for RCP:

--- a/samples/net/sockets/big_http_download/README.rst
+++ b/samples/net/sockets/big_http_download/README.rst
@@ -75,7 +75,7 @@ Enable TLS support in the sample by building the project with the
    :goals: build
    :compact:
 
-An alternative way is to specify ``-DEXTRA_CONF_FILE=overlay-tls.conf`` when
+An alternative way is to specify ``--extra-conf overlay-tls.conf`` when
 running ``west build`` or ``cmake``.
 
 The TLS version of this sample downloads a file from

--- a/samples/net/sockets/echo_client/README.rst
+++ b/samples/net/sockets/echo_client/README.rst
@@ -73,7 +73,7 @@ Example building for the IEEE 802.15.4 RF2XX transceiver:
    :zephyr-app: samples/net/sockets/echo_client
    :host-os: unix
    :board: [samr21_xpro | sam4s_xplained | sam_v71_xult/samv71q21]
-   :gen-args: -DEXTRA_CONF_FILE=overlay-802154.conf
+   :extra-conf: overlay-802154.conf
    :goals: build flash
    :compact:
 
@@ -98,7 +98,7 @@ Enable TLS support in the sample by building the project with the
    :goals: build
    :compact:
 
-An alternative way is to specify ``-DEXTRA_CONF_FILE=overlay-tls.conf`` when
+An alternative way is to specify ``--extra-conf overlay-tls.conf`` when
 running ``west build`` or ``cmake``.
 
 The certificate and private key used by the sample can be found in the sample's
@@ -110,7 +110,7 @@ SOCKS5 proxy support
 ====================
 
 It is also possible to connect to the echo-server through a SOCKS5 proxy.
-To enable it, use ``-DEXTRA_CONF_FILE=overlay-socks5.conf`` when running ``west
+To enable it, use ``--extra-conf overlay-socks5.conf`` when running ``west
 build`` or  ``cmake``.
 
 By default, to make the testing easier, the proxy is expected to run on the

--- a/samples/net/sockets/echo_server/README.rst
+++ b/samples/net/sockets/echo_server/README.rst
@@ -77,7 +77,7 @@ Example building for the samr21_xpro with RF2XX driver support:
    :zephyr-app: samples/net/sockets/echo_server
    :host-os: unix
    :board: [samr21_xpro | sam4e_xpro | sam_v71_xult/samv71q21]
-   :gen-args: -DEXTRA_CONF_FILE=overlay-802154.conf
+   :extra-conf: overlay-802154.conf
    :goals: build flash
    :compact:
 
@@ -100,7 +100,7 @@ Enable TLS support in the sample by building the project with the
    :goals: build
    :compact:
 
-An alternative way is to specify ``-DEXTRA_CONF_FILE=overlay-tls.conf`` when
+An alternative way is to specify ``--extra-conf overlay-tls.conf`` when
 running ``west build`` or ``cmake``.
 
 The certificate used by the sample can be found in the sample's ``src``

--- a/samples/net/sockets/http_client/README.rst
+++ b/samples/net/sockets/http_client/README.rst
@@ -46,7 +46,7 @@ Enable TLS support in the sample by building the project with the
    :goals: build
    :compact:
 
-An alternative way is to specify ``-DEXTRA_CONF_FILE=overlay-tls.conf`` when
+An alternative way is to specify ``--extra-conf overlay-tls.conf`` when
 running ``west build`` or ``cmake``.
 
 The certificate and private key used by the sample can be found in the sample's

--- a/samples/net/sockets/http_get/README.rst
+++ b/samples/net/sockets/http_get/README.rst
@@ -54,7 +54,7 @@ Enable TLS support in the sample by building the project with the
    :goals: build
    :compact:
 
-An alternative way is to specify ``-DEXTRA_CONF_FILE=overlay-tls.conf`` when
+An alternative way is to specify ``--extra-conf overlay-tls.conf`` when
 running ``west build`` or ``cmake``.
 
 For boards that support TLS offloading (e.g. TI's cc3220sf_launchxl), use

--- a/samples/net/sockets/websocket_client/README.rst
+++ b/samples/net/sockets/websocket_client/README.rst
@@ -47,7 +47,7 @@ Enable TLS support in the sample by building the project with the
    :goals: build
    :compact:
 
-An alternative way is to specify ``-DEXTRA_CONF_FILE=overlay-tls.conf`` when
+An alternative way is to specify ``--extra-conf overlay-tls.conf`` when
 running ``west build`` or ``cmake``.
 
 The certificate and private key used by the sample can be found in the sample's

--- a/samples/sensor/bme280/README.rst
+++ b/samples/sensor/bme280/README.rst
@@ -53,7 +53,7 @@ flash with:
 .. zephyr-app-commands::
    :zephyr-app: samples/sensor/bme280
    :goals: build flash
-   :gen-args: -DDTC_OVERLAY_FILE=arduino_spi.overlay
+   :extra-dtc-overlay: arduino_spi.overlay
 
 The devicetree overlay :zephyr_file:`samples/sensor/bme280/arduino_spi.overlay`
 works on any board with a properly configured Arduino pin-compatible SPI
@@ -68,7 +68,7 @@ flash with:
 .. zephyr-app-commands::
    :zephyr-app: samples/sensor/bme280
    :goals: build flash
-   :gen-args: -DDTC_OVERLAY_FILE=arduino_i2c.overlay
+   :extra-dtc-overlay: arduino_i2c.overlay
 
 The devicetree overlay :zephyr_file:`samples/sensor/bme280/arduino_i2c.overlay`
 works on any board with a properly configured Arduino pin-compatible I2C
@@ -95,7 +95,7 @@ Build and flash with:
    :zephyr-app: samples/sensor/bme280
    :goals: build flash
    :board: rpi_pico
-   :gen-args: -DDTC_OVERLAY_FILE=rpi_pico_spi_pio.overlay
+   :extra-dtc-overlay: rpi_pico_spi_pio.overlay
 
 Note that miso-gpios, mosi-gpios, and clk-gpios need to be assigned to the
 selected PIO device in pinctrl, while cs-gpios should not;  chip select is
@@ -110,7 +110,7 @@ a board-specific devicetree overlay adding one in the :file:`boards` directory.
 See existing overlays for examples.
 
 The build system uses these overlays by default when targeting those boards, so
-no ``DTC_OVERLAY_FILE`` setting is needed when building and running.
+no ``--extra-dtc-overlay`` setting is needed when building and running.
 
 For example, to build for the :ref:`adafruit_feather_m0_basic_proto` using the
 :zephyr_file:`samples/sensor/bme280/boards/adafruit_feather_m0_basic_proto.overlay`

--- a/samples/sensor/ds18b20/README.rst
+++ b/samples/sensor/ds18b20/README.rst
@@ -53,7 +53,7 @@ to the 1-Wire bus, build and flash with:
 .. zephyr-app-commands::
    :zephyr-app: samples/sensor/ds18b20
    :goals: build flash
-   :gen-args: -DDTC_OVERLAY_FILE=arduino_serial.overlay
+   :extra-dtc-overlay: arduino_serial.overlay
 
 The devicetree overlay :zephyr_file:`samples/sensor/ds18b20/arduino_serial.overlay`
 should work on any board with a properly configured Arduino pin-compatible Serial

--- a/samples/subsys/fs/fs_sample/README.rst
+++ b/samples/subsys/fs/fs_sample/README.rst
@@ -58,7 +58,8 @@ and DTS overlays need to be also selected. The command would look like this:
 .. zephyr-app-commands::
    :zephyr-app: samples/subsys/fs/fs_sample
    :board: nrf52840dk/nrf52840
-   :gen-args: -DEXTRA_CONF_FILE=nrf52840dk_nrf52840_qspi.conf -DDTC_OVERLAY_FILE=nrf52840dk_nrf52840_qspi.overlay
+   :extra-conf: nrf52840dk_nrf52840_qspi.conf
+   :extra-dtc-overlay: nrf52840dk_nrf52840_qspi.overlay
    :goals: build
    :compact:
 

--- a/samples/subsys/ipc/ipc_service/multi_endpoint/README.rst
+++ b/samples/subsys/ipc/ipc_service/multi_endpoint/README.rst
@@ -69,6 +69,6 @@ overlay files as follows:
 
 .. code-block:: console
 
-   west build -b nrf5340dk/nrf5340/cpuapp --sysbuild -- \
-   -DDTC_OVERLAY_FILE=boards/nrf5340dk_nrf5340_cpuapp_icbmsg.overlay \
-   -Dremote_DTC_OVERLAY_FILE=boards/nrf5340dk_nrf5340_cpunet_icbmsg.overlay
+   west build -b nrf5340dk/nrf5340/cpuapp --sysbuild \
+   --extra-dtc-overlay boards/nrf5340dk_nrf5340_cpuapp_icbmsg.overlay \
+   -- -Dremote_DTC_OVERLAY_FILE=boards/nrf5340dk_nrf5340_cpunet_icbmsg.overlay

--- a/samples/subsys/mgmt/mcumgr/smp_svr/README.rst
+++ b/samples/subsys/mgmt/mcumgr/smp_svr/README.rst
@@ -89,9 +89,8 @@ Zephyr. The ``smp_svr`` sample comes in different flavours.
 
          west build \
             -b nrf52dk/nrf52832 \
+            --extra-conf overlay-bt.conf \
             samples/subsys/mgmt/mcumgr/smp_svr \
-            -- \
-            -DEXTRA_CONF_FILE=overlay-bt.conf
 
    .. group-tab:: Serial
 
@@ -101,9 +100,10 @@ Zephyr. The ``smp_svr`` sample comes in different flavours.
 
          west build \
             -b frdm_k64f \
+            --extra-conf overlay-serial.conf \
+            --extra-conf overlay-fs.conf \
+            --extra-conf overlay-shell-mgmt.conf \
             samples/subsys/mgmt/mcumgr/smp_svr \
-            -- \
-            -DEXTRA_CONF_FILE='overlay-serial.conf;overlay-fs.conf;overlay-shell-mgmt.conf'
 
    .. group-tab:: USB CDC_ACM
 
@@ -113,10 +113,9 @@ Zephyr. The ``smp_svr`` sample comes in different flavours.
 
          west build \
             -b nrf52840dk/nrf52840 \
+            --extra-conf overlay-cdc.conf \
+            --extra-dtc-overlay usb.overlay \
             samples/subsys/mgmt/mcumgr/smp_svr \
-            -- \
-            -DEXTRA_CONF_FILE=overlay-cdc.conf \
-            -DDTC_OVERLAY_FILE=usb.overlay
 
    .. group-tab:: Shell
 
@@ -126,9 +125,8 @@ Zephyr. The ``smp_svr`` sample comes in different flavours.
 
          west build \
             -b frdm_k64f \
+            --extra-conf overlay-shell.conf
             samples/subsys/mgmt/mcumgr/smp_svr \
-            -- \
-            -DEXTRA_CONF_FILE='overlay-shell.conf'
 
    .. group-tab:: UDP
 
@@ -142,9 +140,8 @@ Zephyr. The ``smp_svr`` sample comes in different flavours.
 
          west build \
             -b frdm_k64f \
+            --extra-conf overlay-udp.conf \
             samples/subsys/mgmt/mcumgr/smp_svr \
-            -- \
-            -DEXTRA_CONF_FILE=overlay-udp.conf
 
 .. _smp_svr_sample_sign:
 

--- a/samples/subsys/mgmt/updatehub/README.rst
+++ b/samples/subsys/mgmt/updatehub/README.rst
@@ -175,7 +175,7 @@ The ethernet depends only from base configuration.
     :zephyr-app: samples/subsys/mgmt/updatehub
     :board: [ frdm_k64f | nucleo_f767zi ]
     :build-dir: app
-    :gen-args: -DEXTRA_CONF_FILE=overlay-prj.conf
+    :extra-conf: overlay-prj.conf
     :goals: build
     :compact:
 
@@ -190,7 +190,8 @@ for details.
     :zephyr-app: samples/subsys/mgmt/updatehub
     :board: [ frdm_k64f | nrf52840dk/nrf52840 | nucleo_f767zi ]
     :build-dir: app
-    :gen-args: -DEXTRA_CONF_FILE="overlay-wifi.conf;overlay-prj.conf"
+    :extra-conf: overlay-wifi.conf
+    :extra-conf: overlay-prj.conf
     :shield: esp_8266_arduino
     :goals: build
     :compact:
@@ -212,7 +213,8 @@ tested with both native linux driver and ``atusb``.
     :zephyr-app: samples/subsys/mgmt/updatehub
     :board: nrf52840dk/nrf52840
     :build-dir: app
-    :gen-args: -DEXTRA_CONF_FILE="overlay-802154.conf;overlay-prj.conf"
+    :extra-conf: overlay-802154.conf
+    :extra-conf: overlay-prj.conf
     :goals: build
     :compact:
 
@@ -220,7 +222,8 @@ tested with both native linux driver and ``atusb``.
     :zephyr-app: samples/subsys/mgmt/updatehub
     :board: [ frdm_k64f | nucleo_f767zi ]
     :build-dir: app
-    :gen-args: -DEXTRA_CONF_FILE="overlay-802154.conf;overlay-prj.conf"
+    :extra-conf: overlay-802154.conf
+    :extra-conf: overlay-prj.conf
     :shield: atmel_rf2xx_arduino
     :goals: build
     :compact:
@@ -239,7 +242,8 @@ gateway was tested using two boards with OpenThread 1.1.1 on NCP mode.
     :zephyr-app: samples/subsys/mgmt/updatehub
     :board: nrf52840dk/nrf52840
     :build-dir: app
-    :gen-args: -DEXTRA_CONF_FILE="overlay-ot.conf;overlay-prj.conf"
+    :extra-conf: overlay-ot.conf
+    :extra-conf: overlay-prj.conf
     :goals: build
     :compact:
 

--- a/samples/subsys/modbus/rtu_server/README.rst
+++ b/samples/subsys/modbus/rtu_server/README.rst
@@ -68,7 +68,8 @@ The following commands build and flash RTU server sample using CDC ACM UART.
    :zephyr-app: samples/subsys/modbus/rtu_server
    :board: nrf52840dk/nrf52840
    :goals: build flash
-   :gen-args: -DDTC_OVERLAY_FILE=cdc-acm.overlay -DEXTRA_CONF_FILE=overlay-cdc-acm.conf
+   :extra-conf: overlay-cdc-acm.conf
+   :extra-dtc-overlay: cdc-acm.overlay
    :compact:
 
 On the client side, PC or laptop, the following command connects PyModbus

--- a/samples/subsys/usb/dfu/README.rst
+++ b/samples/subsys/usb/dfu/README.rst
@@ -128,9 +128,10 @@ Both symbols can be enabled with the :file:`overlay-permanent-download.conf` ove
 
 .. code-block:: console
 
-   west build -b nrf52840dk/nrf52840 zephyr/samples/subsys/usb/dfu -d build-dfu -- \
-   -DCONFIG_BOOTLOADER_MCUBOOT=y '-DCONFIG_MCUBOOT_SIGNATURE_KEY_FILE="bootloader/mcuboot/root-rsa-2048.pem"' \
-   -DEXTRA_CONF_FILE=overlay-permanent-download.conf
+   west build -b nrf52840dk/nrf52840 zephyr/samples/subsys/usb/dfu -d build-dfu \
+   --extra-conf overlay-permanent-download.conf \
+   -- -DCONFIG_BOOTLOADER_MCUBOOT=y \
+   '-DCONFIG_MCUBOOT_SIGNATURE_KEY_FILE="bootloader/mcuboot/root-rsa-2048.pem"' \
 
 
 The listing below shows the output to the console when downloading via dfu-util.

--- a/samples/subsys/usb/mass/README.rst
+++ b/samples/subsys/usb/mass/README.rst
@@ -35,7 +35,7 @@ for testing USB mass storage class implementation.
 .. zephyr-app-commands::
    :zephyr-app: samples/subsys/usb/mass
    :board: reel_board
-   :gen-args: -DEXTRA_DTC_OVERLAY_FILE="ramdisk.overlay"
+   :extra-dtc-overlay: ramdisk.overlay
    :goals: build
    :compact:
 
@@ -50,7 +50,8 @@ In this example we will build the sample with a RAM-based disk:
 .. zephyr-app-commands::
    :zephyr-app: samples/subsys/usb/mass
    :board: reel_board
-   :gen-args: -DEXTRA_DTC_OVERLAY_FILE="ramdisk.overlay" -DCONFIG_APP_MSC_STORAGE_RAM=y
+   :extra-dtc-overlay: ramdisk.overlay
+   :gen-args: -DCONFIG_APP_MSC_STORAGE_RAM=y
    :goals: build
    :compact:
 

--- a/samples/subsys/usb/shell/README.rst
+++ b/samples/subsys/usb/shell/README.rst
@@ -41,7 +41,8 @@ the platform has already defined or not ``zephyr_uhc0`` or ``zephyr_udc0`` nodel
 .. zephyr-app-commands::
    :zephyr-app: samples/subsys/usb/shell
    :board: nrf52840dk/nrf52840
-   :gen-args: -DEXTRA_CONF_FILE=virtual.conf -DDTC_OVERLAY_FILE=virtual.overlay
+   :extra-conf: virtual.conf
+   :extra-dtc-overlay: virtual.overlay
    :goals: flash
    :compact:
 


### PR DESCRIPTION
Adds references to the new extra file west arguments
instead of using CMake args.

Signed-off-by: Helmut Lord <kellyhlord@gmail.com>
