### PR TITLE
modules: segger: remove mutex locking

### DIFF
--- a/drivers/serial/uart_rtt.c
+++ b/drivers/serial/uart_rtt.c
@@ -10,8 +10,6 @@
 
 #define DT_DRV_COMPAT segger_rtt_uart
 
-extern struct k_mutex rtt_term_mutex;
-
 struct uart_rtt_config {
 	void *up_buffer;
 	size_t up_size;
@@ -100,21 +98,8 @@ static int uart_rtt_tx(const struct device *dev,
 
 	ARG_UNUSED(timeout);
 
-	/* RTT mutex cannot be claimed in ISRs */
-	if (k_is_in_isr()) {
-		return -ENOTSUP;
-	}
-
-	/* Claim the RTT lock */
-	if (k_mutex_lock(&rtt_term_mutex, K_NO_WAIT) != 0) {
-		return -EBUSY;
-	}
-
 	/* Output the buffer */
-	SEGGER_RTT_WriteNoLock(ch, buf, len);
-
-	/* Return RTT lock */
-	SEGGER_RTT_UNLOCK();
+	SEGGER_RTT_Write(ch, buf, len);
 
 	/* Send the TX complete callback */
 	if (data->callback) {

--- a/modules/segger/Kconfig
+++ b/modules/segger/Kconfig
@@ -23,7 +23,7 @@ if USE_SEGGER_RTT
 config SEGGER_RTT_CUSTOM_LOCKING
 	bool "Custom locking"
 	help
-	  Enable custom locking using a mutex.
+	  Enable custom locking using Zephyr APIs.
 
 config SEGGER_RTT_MAX_NUM_UP_BUFFERS
 	int "Maximum number of up-buffers"

--- a/modules/segger/SEGGER_RTT_zephyr.c
+++ b/modules/segger/SEGGER_RTT_zephyr.c
@@ -9,40 +9,12 @@
 #include <zephyr/init.h>
 #include "SEGGER_RTT.h"
 
-/*
- * Common mutex for locking access to terminal buffer.
- * Note that SEGGER uses same lock macros for both SEGGER_RTT_Write and
- * SEGGER_RTT_Read functions. Because of this we are not able generally
- * separate up and down access using two mutexes until SEGGER library fix
- * this.
- *
- * If sharing access cause performance problems, consider using another
- * non terminal buffers.
- */
-
-K_MUTEX_DEFINE(rtt_term_mutex);
-
 static int rtt_init(void)
 {
-
 	SEGGER_RTT_Init();
 
 	return 0;
 }
-
-#ifdef CONFIG_MULTITHREADING
-
-void zephyr_rtt_mutex_lock(void)
-{
-	k_mutex_lock(&rtt_term_mutex, K_FOREVER);
-}
-
-void zephyr_rtt_mutex_unlock(void)
-{
-	k_mutex_unlock(&rtt_term_mutex);
-}
-
-#endif /* CONFIG_MULTITHREADING */
 
 unsigned int zephyr_rtt_irq_lock(void)
 {
@@ -53,7 +25,5 @@ void zephyr_rtt_irq_unlock(unsigned int key)
 {
 	irq_unlock(key);
 }
-
-
 
 SYS_INIT(rtt_init, PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_OBJECTS);

--- a/west.yml
+++ b/west.yml
@@ -317,7 +317,7 @@ manifest:
       path: modules/lib/picolibc
       revision: 27746bbc246841852912fc3bb5b45094cd8a505a
     - name: segger
-      revision: b011c45b585e097d95d9cf93edf4f2e01588d3cd
+      revision: 798f95ea9304e5ed8165a661081443051f210733
       path: modules/debug/segger
       groups:
         - debug


### PR DESCRIPTION
Remove mutex locking in favour of the standard IRQ locking mechanism. The primary problem with the mutex implementation is that mutex locking is forbidden in ISR's. This means that any logging from an interrupt context (e.g. LOG_PANIC in an exception handler), will itself trigger another assertion due its attempt to use a mutex.

Furthermore, mutexes are a relatively heavyweight locking scheme, which doesn't necessarily make sense in the context of extremely short locking periods that would be expected from RTT.

This change aligns Zephyr with the default RTT locking scheme, which uses interrupt masking to perform access control.

Resolves #79403.