### PR TITLE
boards: beagle: beagleplay_cc1352p7: Disable 2.4g ieee802154

### DIFF
--- a/boards/beagle/beagleplay/beagleplay_cc1352p7.dts
+++ b/boards/beagle/beagleplay/beagleplay_cc1352p7.dts
@@ -87,7 +87,7 @@
 };
 
 &ieee802154 {
-	status = "okay";
+	status = "disabled";
 };
 
 &ieee802154g {

--- a/boards/beagle/beagleplay/beagleplay_cc1352p7_defconfig
+++ b/boards/beagle/beagleplay/beagleplay_cc1352p7_defconfig
@@ -18,3 +18,8 @@ CONFIG_HW_STACK_PROTECTION=y
 
 # Adjust for oscillator capacitors
 CONFIG_CC13X2_CC26X2_XOSC_CAPARRAY_DELTA=0x02
+
+# Enable default uart console
+CONFIG_SERIAL=y
+CONFIG_CONSOLE=y
+CONFIG_UART_CONSOLE=y


### PR DESCRIPTION
- A lot of zephyr networking samples (zperf, http_server, etc) will complain if both 2.4g and subg ieee802154 are enabled simultaneously.
- This leads to a lot of new people getting confused with the network code not working without any clear errors.
- As we already set the alias `zephyr,ieee802154 = &ieee802154g`, I think it would be best to enable only subg by default.
- Following the example of: https://github.com/zephyrproject-rtos/zephyr/pull/78667