### PR TITLE
bluetooth & net_buf: increase log level of timeout ignore

### DIFF
--- a/lib/net_buf/buf.c
+++ b/lib/net_buf/buf.c
@@ -273,7 +273,7 @@ struct net_buf *net_buf_alloc_len(struct net_buf_pool *pool, size_t size,
 
 	if (!K_TIMEOUT_EQ(timeout, K_NO_WAIT) &&
 	    k_current_get() == k_work_queue_thread_get(&k_sys_work_q)) {
-		LOG_DBG("Timeout discarded. No blocking in syswq");
+		LOG_WRN("Timeout discarded. No blocking in syswq");
 		timeout = K_NO_WAIT;
 	}
 

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -1581,7 +1581,7 @@ struct net_buf *bt_conn_create_pdu_timeout(struct net_buf_pool *pool,
 
 	if (!K_TIMEOUT_EQ(timeout, K_NO_WAIT) &&
 	    k_current_get() == k_work_queue_thread_get(&k_sys_work_q)) {
-		LOG_DBG("Timeout discarded. No blocking in syswq.");
+		LOG_WRN("Timeout discarded. No blocking in syswq.");
 		timeout = K_NO_WAIT;
 	}
 


### PR DESCRIPTION
Notifying users that the supplied timeout is being ignored is worthy of
a higher log level than debug. Any such usage should be changed at the
application level.