### PR TITLE
usb: device_next: USB reset clears remote wakeup permission

### DIFF
--- a/subsys/usb/device_next/usbd_core.c
+++ b/subsys/usb/device_next/usbd_core.c
@@ -127,6 +127,8 @@ static int event_handler_bus_reset(struct usbd_context *const uds_ctx)
 
 	uds_ctx->ch9_data.state = USBD_STATE_DEFAULT;
 
+	uds_ctx->status.rwup = false;
+
 	return 0;
 }
 


### PR DESCRIPTION
Verbatim from USB 2.0 specification:
The Remote Wakeup field indicates whether the device is currently enabled to request remote wakeup. The default mode for devices that support remote wakeup is disabled. If D1 is reset to zero, the ability of the device to signal remote wakeup is disabled. If D1 is set to one, the ability of the device to signal remote wakeup is enabled. The Remote Wakeup field can be modified by the SetFeature() and ClearFeature() requests using the DEVICE_REMOTE_WAKEUP feature selector. This field is reset to zero when the device is reset.

Related to #79341