### PR TITLE
logging: Add log_source_id helper function

### DIFF
--- a/include/zephyr/logging/log_core.h
+++ b/include/zephyr/logging/log_core.h
@@ -493,6 +493,20 @@ static inline uint32_t log_dynamic_source_id(struct log_source_dynamic_data *dat
 			sizeof(struct log_source_dynamic_data);
 }
 
+/** @brief Get index of the log source based on the address of the associated data.
+ *
+ * @param source Address of the data structure (dynamic if runtime filtering is
+ * enabled and static otherwise).
+ *
+ * @return Source ID.
+ */
+static inline uint32_t log_source_id(const void *source)
+{
+	return IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING) ?
+		log_dynamic_source_id((struct log_source_dynamic_data *)source) :
+		log_const_source_id((const struct log_source_const_data *)source);
+}
+
 /** @brief Dummy function to trigger log messages arguments type checking. */
 static inline __printf_like(1, 2)
 void z_log_printf_arg_checker(const char *fmt, ...)

--- a/subsys/logging/backends/log_multidomain_backend.c
+++ b/subsys/logging/backends/log_multidomain_backend.c
@@ -51,11 +51,8 @@ static void process(const struct log_backend *const backend,
 	/* Update package len field in the message descriptor. */
 	out_log_msg->hdr.desc.package_len = fsc_plen;
 
-	out_log_msg->hdr.source = out_log_msg->hdr.source ?
-			(const void *)(IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING) ?
-				log_dynamic_source_id((void *)out_log_msg->hdr.source) :
-				log_const_source_id((void *)out_log_msg->hdr.source)) :
-			(const void *)-1;
+	out_log_msg->hdr.source = (const void *)(out_log_msg->hdr.source ?
+				log_source_id(out_log_msg->hdr.source) : -1);
 
 	/* Fill new package. */
 	fsc_plen = cbprintf_fsc_package(msg->log.data, msg->log.hdr.desc.package_len,

--- a/subsys/logging/frontends/log_frontend_dict_uart.c
+++ b/subsys/logging/frontends/log_frontend_dict_uart.c
@@ -233,11 +233,7 @@ static inline void hdr_fill(struct log_dict_output_normal_msg_hdr_t *hdr,
 	hdr->package_len = desc.package_len;
 	hdr->data_len = desc.data_len;
 	hdr->timestamp = z_log_timestamp();
-	hdr->source = (source != NULL) ?
-			(IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING) ?
-				log_dynamic_source_id((void *)source) :
-				log_const_source_id((void *)source)) :
-			0U;
+	hdr->source = (source != NULL) ? log_source_id(source) : 0U;
 }
 
 /* Handle logging message in synchronous manner, in panic mode. */

--- a/subsys/logging/frontends/log_frontend_stmesp.c
+++ b/subsys/logging/frontends/log_frontend_stmesp.c
@@ -304,9 +304,7 @@ static inline uint16_t get_channel(void)
 static inline int16_t get_source_id(const void *source)
 {
 	if (source != NULL) {
-		return IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING)
-			       ? log_dynamic_source_id((void *)source)
-			       : log_const_source_id(source);
+		return log_source_id(source);
 	}
 
 	return LOG_FRONTEND_STM_NO_SOURCE;

--- a/subsys/logging/log_msg.c
+++ b/subsys/logging/log_msg.c
@@ -409,9 +409,7 @@ int16_t log_msg_get_source_id(struct log_msg *msg)
 	void *source = (void *)log_msg_get_source(msg);
 
 	if (source != NULL) {
-		return IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING)
-					? log_dynamic_source_id(source)
-					: log_const_source_id(source);
+		return log_source_id(source);
 	}
 
 	return -1;

--- a/subsys/logging/log_output_dict.c
+++ b/subsys/logging/log_output_dict.c
@@ -38,11 +38,7 @@ void log_dict_output_msg_process(const struct log_output *output,
 	output_hdr.data_len = msg->hdr.desc.data_len;
 	output_hdr.timestamp = msg->hdr.timestamp;
 
-	output_hdr.source = (source != NULL) ?
-				(IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING) ?
-					log_dynamic_source_id(source) :
-					log_const_source_id(source)) :
-				0U;
+	output_hdr.source = (source != NULL) ? log_source_id(source) : 0U;
 
 	buffer_write(output->func, (uint8_t *)&output_hdr, sizeof(output_hdr),
 		     (void *)output->control_block->ctx);

--- a/subsys/logging/log_output_syst.c
+++ b/subsys/logging/log_output_syst.c
@@ -795,9 +795,7 @@ void log_output_msg_syst_process(const struct log_output *output,
 		void *source = (void *)log_msg_get_source(msg);
 
 		if (source != NULL) {
-			source_id = IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING) ?
-					log_dynamic_source_id(source) :
-					log_const_source_id(source);
+			source_id = log_source_id(source);
 		}
 	}
 

--- a/tests/subsys/logging/log_api/src/mock_backend.c
+++ b/tests/subsys/logging/log_api/src/mock_backend.c
@@ -157,9 +157,7 @@ static void process(const struct log_backend *const backend,
 	} else if (source == NULL) {
 		source_id = 0;
 	} else {
-		source_id = IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING) ?
-		    log_dynamic_source_id((struct log_source_dynamic_data *)source) :
-		    log_const_source_id((const struct log_source_const_data *)source);
+		source_id = log_source_id(source);
 	}
 
 	zassert_equal(source_id, exp->source_id, "source_id:%p (exp: %d)",

--- a/tests/subsys/logging/log_api/src/mock_frontend.c
+++ b/tests/subsys/logging/log_api/src/mock_frontend.c
@@ -115,9 +115,7 @@ void log_frontend_msg(const void *source,
 	if (desc.level == LOG_LEVEL_NONE) {
 		source_id = (uintptr_t)source;
 	} else {
-		source_id = IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING) ?
-			log_dynamic_source_id((struct log_source_dynamic_data *)source) :
-			log_const_source_id((const struct log_source_const_data *)source);
+		source_id = log_source_id(source);
 	}
 
 	zassert_equal(source_id, exp_msg->source_id, "got: %d, exp: %d",


### PR DESCRIPTION
There are many places where source_id is retrieved and it depends on runtime filtering being enabled. So far it was all exposed but lets encapsulate that into a helper function.