### PR TITLE
logging: Cleanup and rafactoring in the internal logging macros

### DIFF
--- a/include/zephyr/logging/log_core.h
+++ b/include/zephyr/logging/log_core.h
@@ -16,19 +16,19 @@
 /* This header file keeps all macros and functions needed for creating logging
  * messages (macros like @ref LOG_ERR).
  */
-#define LOG_LEVEL_NONE 0U
-#define LOG_LEVEL_ERR  1U
-#define LOG_LEVEL_WRN  2U
-#define LOG_LEVEL_INF  3U
-#define LOG_LEVEL_DBG  4U
+#define LOG_LEVEL_NONE 0
+#define LOG_LEVEL_ERR  1
+#define LOG_LEVEL_WRN  2
+#define LOG_LEVEL_INF  3
+#define LOG_LEVEL_DBG  4
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 #ifndef CONFIG_LOG
-#define CONFIG_LOG_DEFAULT_LEVEL 0U
-#define CONFIG_LOG_MAX_LEVEL 0U
+#define CONFIG_LOG_DEFAULT_LEVEL 0
+#define CONFIG_LOG_MAX_LEVEL 0
 #endif
 
 /* Id of local domain. */
@@ -54,15 +54,10 @@ extern "C" {
 	__COND_CODE(_LOG_XXXX##_level, (_level), (_default))
 
 #define _LOG_XXXX0  _LOG_YYYY,
-#define _LOG_XXXX0U _LOG_YYYY,
 #define _LOG_XXXX1  _LOG_YYYY,
-#define _LOG_XXXX1U _LOG_YYYY,
 #define _LOG_XXXX2  _LOG_YYYY,
-#define _LOG_XXXX2U _LOG_YYYY,
 #define _LOG_XXXX3  _LOG_YYYY,
-#define _LOG_XXXX3U _LOG_YYYY,
 #define _LOG_XXXX4  _LOG_YYYY,
-#define _LOG_XXXX4U _LOG_YYYY,
 
 /**
  * @brief Macro for conditional code generation if provided log level allows.
@@ -85,13 +80,9 @@ extern "C" {
 	__COND_CODE(_LOG_ZZZZ##_eval_level, _iftrue, _iffalse)
 
 #define _LOG_ZZZZ1  _LOG_YYYY,
-#define _LOG_ZZZZ1U _LOG_YYYY,
 #define _LOG_ZZZZ2  _LOG_YYYY,
-#define _LOG_ZZZZ2U _LOG_YYYY,
 #define _LOG_ZZZZ3  _LOG_YYYY,
-#define _LOG_ZZZZ3U _LOG_YYYY,
 #define _LOG_ZZZZ4  _LOG_YYYY,
-#define _LOG_ZZZZ4U _LOG_YYYY,
 
 /**
  *
@@ -101,11 +92,11 @@ extern "C" {
 	log_const_source_id(__log_current_const_data) : 0U)
 
 /* Set of defines that are set to 1 if function name prefix is enabled for given level. */
-#define Z_LOG_FUNC_PREFIX_0U 0
-#define Z_LOG_FUNC_PREFIX_1U COND_CODE_1(CONFIG_LOG_FUNC_NAME_PREFIX_ERR, (1), (0))
-#define Z_LOG_FUNC_PREFIX_2U COND_CODE_1(CONFIG_LOG_FUNC_NAME_PREFIX_WRN, (1), (0))
-#define Z_LOG_FUNC_PREFIX_3U COND_CODE_1(CONFIG_LOG_FUNC_NAME_PREFIX_INF, (1), (0))
-#define Z_LOG_FUNC_PREFIX_4U COND_CODE_1(CONFIG_LOG_FUNC_NAME_PREFIX_DBG, (1), (0))
+#define Z_LOG_FUNC_PREFIX_0 0
+#define Z_LOG_FUNC_PREFIX_1 COND_CODE_1(CONFIG_LOG_FUNC_NAME_PREFIX_ERR, (1), (0))
+#define Z_LOG_FUNC_PREFIX_2 COND_CODE_1(CONFIG_LOG_FUNC_NAME_PREFIX_WRN, (1), (0))
+#define Z_LOG_FUNC_PREFIX_3 COND_CODE_1(CONFIG_LOG_FUNC_NAME_PREFIX_INF, (1), (0))
+#define Z_LOG_FUNC_PREFIX_4 COND_CODE_1(CONFIG_LOG_FUNC_NAME_PREFIX_DBG, (1), (0))
 
 /**
  * @brief Macro for optional injection of function name as first argument of

--- a/include/zephyr/logging/log_core.h
+++ b/include/zephyr/logging/log_core.h
@@ -134,6 +134,15 @@ extern "C" {
 #define Z_LOG_LEVEL_CHECK(_level, _check_level, _default_level) \
 	((_level) <= Z_LOG_RESOLVED_LEVEL(_check_level, _default_level))
 
+/** @brief Compile time level checking.
+ *
+ * This check is resolved at compile time and logging message is removed if check fails.
+ *
+ * @param _level Log level.
+ *
+ * @retval true Message shall be compiled in.
+ * @retval false Message shall removed during the compilation.
+ */
 #define Z_LOG_CONST_LEVEL_CHECK(_level)					    \
 	(IS_ENABLED(CONFIG_LOG) &&					    \
 	(Z_LOG_LEVEL_CHECK(_level, CONFIG_LOG_OVERRIDE_LEVEL, LOG_LEVEL_NONE) \
@@ -143,6 +152,63 @@ extern "C" {
 	((_level) <= CONFIG_LOG_MAX_LEVEL)				    \
 	)								    \
 	))
+
+/** @brief Static level checking for instance logging.
+ *
+ * This check applies only to instance logging and only if runtime filtering
+ * is disabled. It is performed in runtime but because level comes from the
+ * structure which is constant it is not exact runtime filtering because it
+ * cannot be changed in runtime.
+ *
+ * @param _level Log level.
+ * @param _inst 1 is source is the instance of a module.
+ * @param _source Data associated with the instance.
+ *
+ * @retval true Continue with log message creation.
+ * @retval false Drop that message.
+ */
+#define Z_LOG_STATIC_INST_LEVEL_CHECK(_level, _inst, _source)                                      \
+	(IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING) || !_inst ||                                     \
+	 (_level <= ((const struct log_source_const_data *)_source)->level))
+
+/** @brief Dynamic level checking.
+ *
+ * It uses the level from the dynamic structure.
+ *
+ * @param _level Log level.
+ * @param _source Data associated with the source.
+ *
+ * @retval true Continue with log message creation.
+ * @retval false Drop that message.
+ */
+#define Z_LOG_DYNAMIC_LEVEL_CHECK(_level, _source)                                                 \
+	(!IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING) || k_is_user_context() ||                       \
+	 ((_level) <= Z_LOG_RUNTIME_FILTER(((struct log_source_dynamic_data *)_source)->filters)))
+
+/** @brief Check if message shall be created.
+ *
+ * Aggregate all checks into a single one.
+ *
+ * @param _level Log level.
+ * @param _inst 1 is source is the instance of a module.
+ * @param _source Data associated with the source.
+ *
+ * @retval true Continue with log message creation.
+ * @retval false Drop that message.
+ */
+#define Z_LOG_LEVEL_ALL_CHECK(_level, _inst, _source)                                              \
+	(Z_LOG_CONST_LEVEL_CHECK(_level) &&                                                        \
+	 Z_LOG_STATIC_INST_LEVEL_CHECK(_level, _inst, _source) &&                                  \
+	 Z_LOG_DYNAMIC_LEVEL_CHECK(_level, _source))
+
+/** @brief Get current module data that is used for source id retrieving.
+ *
+ * If runtime filtering is used then pointer to dynamic data is returned and else constant
+ * data is used.
+ */
+#define Z_LOG_CURRENT_DATA()                                                                       \
+	COND_CODE_1(CONFIG_LOG_RUNTIME_FILTERING, \
+			(__log_current_dynamic_data), (__log_current_const_data))
 
 /*****************************************************************************/
 /****************** Definitions used by minimal logging *********************/
@@ -217,68 +283,41 @@ static inline char z_log_minimal_level_to_char(int level)
  * @param _level Log message severity level.
  *
  * @param _inst Set to 1 for instance specific log message. 0 otherwise.
- *
- * @param _source Pointer to static source descriptor object. NULL when runtime filtering
- * is enabled.
- *
- * @param _dsource Pointer to dynamic source descriptor. NULL when runtime filtering
- * is disabled.
+ * @param _source Pointer to a structure associated with the module or instance.
+ *                If it is a module then it is used only when runtime filtering is
+ *                enabled. If it is instance then it is used in both cases.
  *
  * @param ... String with arguments.
  */
-#define Z_LOG2(_level, _inst, _source, _dsource, ...) do { \
-	if (!Z_LOG_CONST_LEVEL_CHECK(_level)) { \
-		break; \
-	} \
-	if (IS_ENABLED(CONFIG_LOG_MODE_MINIMAL)) { \
-		Z_LOG_TO_PRINTK(_level, __VA_ARGS__); \
-		break; \
-	} \
-	/* For instance logging check instance specific static level */ \
-	if (_inst != 0 && !IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING)) { \
-		if (_level > ((struct log_source_const_data *)_source)->level) { \
-			break; \
-		} \
-	} \
-	\
-	bool is_user_context = k_is_user_context(); \
-	if (IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING) && \
-	    !is_user_context && _level > Z_LOG_RUNTIME_FILTER((_dsource)->filters)) { \
-		break; \
-	} \
-	int _mode; \
-	void *_src = IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING) ? \
-		(void *)(_dsource) : (void *)(_source); \
-	bool string_ok; \
-	LOG_POINTERS_VALIDATE(string_ok, __VA_ARGS__); \
-	if (!string_ok) { \
-		LOG_STRING_WARNING(_mode, _src, __VA_ARGS__); \
-		break; \
-	} \
-	Z_LOG_MSG_CREATE(UTIL_NOT(IS_ENABLED(CONFIG_USERSPACE)), _mode, \
-				  Z_LOG_LOCAL_DOMAIN_ID, _src, _level, NULL,\
-			  0, __VA_ARGS__); \
-	(void)_mode; \
-	if (false) { \
-		/* Arguments checker present but never evaluated.*/ \
-		/* Placed here to ensure that __VA_ARGS__ are*/ \
-		/* evaluated once when log is enabled.*/ \
-		z_log_printf_arg_checker(__VA_ARGS__); \
-	} \
-} while (false)
+#define Z_LOG2(_level, _inst, _source, ...)                                                        \
+	do {                                                                                       \
+		if (!Z_LOG_LEVEL_ALL_CHECK(_level, _inst, _source)) {                              \
+			break;                                                                     \
+		}                                                                                  \
+		if (IS_ENABLED(CONFIG_LOG_MODE_MINIMAL)) {                                         \
+			Z_LOG_TO_PRINTK(_level, __VA_ARGS__);                                      \
+			break;                                                                     \
+		}                                                                                  \
+		int _mode;                                                                         \
+		bool string_ok;                                                                    \
+		LOG_POINTERS_VALIDATE(string_ok, __VA_ARGS__);                                     \
+		if (!string_ok) {                                                                  \
+			LOG_STRING_WARNING(_mode, _source, __VA_ARGS__);                           \
+			break;                                                                     \
+		}                                                                                  \
+		Z_LOG_MSG_CREATE(UTIL_NOT(IS_ENABLED(CONFIG_USERSPACE)), _mode,                    \
+				 Z_LOG_LOCAL_DOMAIN_ID, _source, _level, NULL, 0, __VA_ARGS__);    \
+		(void)_mode;                                                                       \
+		if (false) {                                                                       \
+			/* Arguments checker present but never evaluated.*/                        \
+			/* Placed here to ensure that __VA_ARGS__ are*/                            \
+			/* evaluated once when log is enabled.*/                                   \
+			z_log_printf_arg_checker(__VA_ARGS__);                                     \
+		}                                                                                  \
+	} while (false)
 
-#define Z_LOG(_level, ...) \
-	Z_LOG2(_level, 0, __log_current_const_data, __log_current_dynamic_data, __VA_ARGS__)
-
-#define Z_LOG_INSTANCE(_level, _inst, ...) do { \
-	(void)_inst; \
-	Z_LOG2(_level, 1, \
-		COND_CODE_1(CONFIG_LOG_RUNTIME_FILTERING, (NULL), (Z_LOG_INST(_inst))), \
-		(struct log_source_dynamic_data *)COND_CODE_1( \
-						CONFIG_LOG_RUNTIME_FILTERING, \
-						(Z_LOG_INST(_inst)), (NULL)), \
-		__VA_ARGS__); \
-} while (0)
+#define Z_LOG(_level, ...)                 Z_LOG2(_level, 0, Z_LOG_CURRENT_DATA(), __VA_ARGS__)
+#define Z_LOG_INSTANCE(_level, _inst, ...) Z_LOG2(_level, 1, Z_LOG_INST(_inst), __VA_ARGS__)
 
 /*****************************************************************************/
 /****************** Macros for hexdump logging *******************************/
@@ -293,11 +332,9 @@ static inline char z_log_minimal_level_to_char(int level)
  *
  * @param _inst Set to 1 for instance specific log message. 0 otherwise.
  *
- * @param _source Pointer to static source descriptor object. NULL when runtime filtering
- * is enabled.
- *
- * @param _dsource Pointer to dynamic source descriptor. NULL when runtime filtering
- * is disabled.
+ * @param _source Pointer to a structure associated with the module or instance.
+ *                If it is a module then it is used only when runtime filtering is
+ *                enabled. If it is instance then it is used in both cases.
  *
  * @param _data Hexdump data;
  *
@@ -305,56 +342,31 @@ static inline char z_log_minimal_level_to_char(int level)
  *
  * @param ... String.
  */
-#define Z_LOG_HEXDUMP2(_level, _inst, _source, _dsource, _data, _len, ...) do { \
-	const char *_str = GET_ARG_N(1, __VA_ARGS__); \
-	if (!Z_LOG_CONST_LEVEL_CHECK(_level)) {	\
-		break; \
-	} \
-	/* For instance logging check instance specific static level */ \
-	if (_inst && !IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING)) { \
-		if (_level > ((struct log_source_const_data *)_source)->level) { \
-			break; \
-		} \
-	} \
-	bool is_user_context = k_is_user_context(); \
-	uint32_t filters = IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING) ? \
-						(_dsource)->filters : 0;\
-	\
-	if (IS_ENABLED(CONFIG_LOG_MODE_MINIMAL)) { \
-		Z_LOG_TO_PRINTK(_level, "%s", _str); \
-		z_log_minimal_hexdump_print((_level), \
-					    (const char *)(_data), (_len));\
-		break; \
-	} \
-	if (IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING) && \
-	    !is_user_context && (_level) > Z_LOG_RUNTIME_FILTER(filters)) { \
-		break; \
-	} \
-	int mode; \
-	void *_src = IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING) ? \
-		(void *)(_dsource) : (void *)(_source); \
-	Z_LOG_MSG_CREATE(UTIL_NOT(IS_ENABLED(CONFIG_USERSPACE)), mode, \
-				  Z_LOG_LOCAL_DOMAIN_ID, _src, _level, \
-			  _data, _len, \
-			COND_CODE_0(NUM_VA_ARGS_LESS_1(_, ##__VA_ARGS__), \
+#define Z_LOG_HEXDUMP2(_level, _inst, _source, _data, _len, ...)                                   \
+	do {                                                                                       \
+		if (!Z_LOG_LEVEL_ALL_CHECK(_level, _inst, _source)) {                              \
+			break;                                                                     \
+		}                                                                                  \
+		const char *_str = GET_ARG_N(1, __VA_ARGS__);                                      \
+		if (IS_ENABLED(CONFIG_LOG_MODE_MINIMAL)) {                                         \
+			Z_LOG_TO_PRINTK(_level, "%s", _str);                                       \
+			z_log_minimal_hexdump_print((_level), (const char *)(_data), (_len));      \
+			break;                                                                     \
+		}                                                                                  \
+		int mode;                                                                          \
+		Z_LOG_MSG_CREATE(UTIL_NOT(IS_ENABLED(CONFIG_USERSPACE)), mode,                     \
+				 Z_LOG_LOCAL_DOMAIN_ID, _source, _level, _data, _len,              \
+				 COND_CODE_0(NUM_VA_ARGS_LESS_1(_, ##__VA_ARGS__), \
 				(), \
 			  (COND_CODE_0(NUM_VA_ARGS_LESS_1(__VA_ARGS__), \
-				  ("%s", __VA_ARGS__), (__VA_ARGS__)))));\
-} while (false)
+				  ("%s", __VA_ARGS__), (__VA_ARGS__)))));   \
+	} while (false)
 
-#define Z_LOG_HEXDUMP(_level, _data, _length, ...) \
-	Z_LOG_HEXDUMP2(_level, 0, \
-		      __log_current_const_data, \
-		      __log_current_dynamic_data, \
-		      _data, _length, __VA_ARGS__)
+#define Z_LOG_HEXDUMP(_level, _data, _length, ...)                                                 \
+	Z_LOG_HEXDUMP2(_level, 0, Z_LOG_CURRENT_DATA(), _data, _length, __VA_ARGS__)
 
-#define Z_LOG_HEXDUMP_INSTANCE(_level, _inst, _data, _length, _str) \
-	Z_LOG_HEXDUMP2(_level, 1, \
-		COND_CODE_1(CONFIG_LOG_RUNTIME_FILTERING, (NULL), (Z_LOG_INST(_inst))), \
-		(struct log_source_dynamic_data *)COND_CODE_1( \
-						CONFIG_LOG_RUNTIME_FILTERING, \
-						(Z_LOG_INST(_inst)), (NULL)), \
-		_data, _length, _str)
+#define Z_LOG_HEXDUMP_INSTANCE(_level, _inst, _data, _length, ...)                                 \
+	Z_LOG_HEXDUMP2(_level, 1, Z_LOG_INST(_inst), _data, _length, __VA_ARGS__)
 
 /*****************************************************************************/
 /****************** Filtering macros *****************************************/
@@ -482,6 +494,20 @@ static inline uint32_t log_dynamic_source_id(struct log_source_dynamic_data *dat
 {
 	return ((uint8_t *)data - (uint8_t *)TYPE_SECTION_START(log_dynamic))/
 			sizeof(struct log_source_dynamic_data);
+}
+
+/** @brief Get index of the log source based on the address of the associated data.
+ *
+ * @param source Address of the data structure (dynamic if runtime filtering is
+ * enabled and static otherwise).
+ *
+ * @return Source ID.
+ */
+static inline uint32_t log_source_id(const void *source)
+{
+	return IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING) ?
+		log_dynamic_source_id((struct log_source_dynamic_data *)source) :
+		log_const_source_id((const struct log_source_const_data *)source);
 }
 
 /** @brief Dummy function to trigger log messages arguments type checking. */


### PR DESCRIPTION
There is no functional change.
- Created macros for message filtering and use that in standard and hexdump messages (instead of having copy in both)
- Changed value used for log level (e.g. `1U` to `1`).