### PR TITLE
net: lib: http-client: Use memcpy() to avoid gcc warning

### DIFF
--- a/subsys/net/lib/http/http_client.c
+++ b/subsys/net/lib/http/http_client.c
@@ -109,9 +109,9 @@ static int http_send_data(int sock, char *send_buf,
 				end_of_send = 0;
 				continue;
 			} else {
-				strncpy(send_buf + end_of_send,
-					data + end_of_data,
-					remaining_len);
+				memcpy(send_buf + end_of_send,
+				       data + end_of_data,
+				       remaining_len);
 				end_of_send += remaining_len;
 				remaining_len = 0;
 			}


### PR DESCRIPTION
GCC 12.2.0 can give this warning (version 11.4.0 did not), when `CONFIG_SPEED_OPTIMIZATIONS=y`
```
subsys/net/lib/http/http_client.c: In function 'http_send_data.constprop': subsys/net/lib/http/http_client.c:114:33: warning: 'strncpy' specified \
  bound depends on the length of the source argument [-Wstringop-truncation]
  114 |                                 strncpy(send_buf + end_of_send,
      |                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  115 |                                         data + end_of_data,
      |                                         ~~~~~~~~~~~~~~~~~~~
  116 |                                         remaining);
      |                                         ~~~~~~~~~~
subsys/net/lib/http/http_client.c:87:41: note: length computed here
   87 |                         remaining_len = strlen(data + end_of_data);
      |                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~
```

The code properly checks that we do not overwrite the destination buffer even if we use the source buffer length to determine how much to copy. One possible fix is to use `memcpy()` or `strcpy()`, I opted to use memcpy() because it has the length option which feels more natural.

Fixes #79326