### PR TITLE
boards: add board description field

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -568,6 +568,9 @@ Build system:
     - misc/generated/
     - snippets/
     - modules/Kconfig.sysbuild
+    - scripts/list_boards.py
+    - scripts/list_hardware.py
+    - scripts/schemas/*-schema.yml
   labels:
     - "area: Build System"
   tests:

--- a/boards/qemu/x86/board.yml
+++ b/boards/qemu/x86/board.yml
@@ -1,6 +1,7 @@
 boards:
 
   - name: qemu_x86
+    full_name: 'QEMU Emulation for X86'
     socs:
       - name: atom
         variants:
@@ -11,15 +12,18 @@ boards:
           - name: 'xip'
 
   - name: qemu_x86_lakemont
+    full_name: 'QEMU Emulation for X86 / Lakemont CPU'
     socs:
       - name: lakemont
 
   - name: qemu_x86_64
+    full_name: 'QEMU Emulation for X86 64bit'
     socs:
       - name: atom
         variants:
           - name: 'nokpti'
 
   - name: qemu_x86_tiny
+    full_name: 'QEMU Emulation for X86 Minimal Configuration'
     socs:
       - name: atom

--- a/scripts/list_boards.py
+++ b/scripts/list_boards.py
@@ -93,6 +93,7 @@ class Board:
     name: str
     dir: Path
     hwm: str
+    full_name: str = None
     arch: str = None
     vendor: str = None
     revision_format: str = None
@@ -223,6 +224,7 @@ def load_v2_boards(board_name, board_yml, systems):
                 name=board['name'],
                 dir=board_yml.parent,
                 vendor=board.get('vendor'),
+                full_name=board.get('full_name'),
                 revision_format=board.get('revision', {}).get('format'),
                 revision_default=board.get('revision', {}).get('default'),
                 revision_exact=board.get('revision', {}).get('exact', False),

--- a/scripts/schemas/board-schema.yml
+++ b/scripts/schemas/board-schema.yml
@@ -30,6 +30,10 @@ schema;board-schema:
       required: true
       type: str
       desc: Name of the board
+    full_name:
+      required: false
+      type: str
+      desc: Full name of the board. Typically set to the commercial name of the board.
     vendor:
       required: false
       type: str


### PR DESCRIPTION
Full name or description of a board is something we are missing in
HWVv2. It is right now being added to yaml files parsed by twister. This
should be generically available to tooling and documentation
independently from twister.

As we rework how twister parses board meta-data (#77250) and how we
generate board documentation (#79160), this becomes neceassry.

Moving the board full name/description from the twister yaml files to
the board.yaml is something we can automate once the schema is agreed
upon.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
