### PR TITLE
dts/smartbond: Move bt_hci_da1469x node outside of soc node

### DIFF
--- a/dts/arm/renesas/smartbond/da1469x.dtsi
+++ b/dts/arm/renesas/smartbond/da1469x.dtsi
@@ -397,11 +397,11 @@
 			reg = <0x34000000 0x48>;
 			status = "disabled";
 		};
+	};
 
-		bt_hci_da1469x: bt_hci_da1469x {
-			compatible = "renesas,bt-hci-da1469x";
-			status = "disabled";
-		};
+	bt_hci_da1469x: bt_hci_da1469x {
+		compatible = "renesas,bt-hci-da1469x";
+		status = "disabled";
 	};
 };
 


### PR DESCRIPTION
Move bt_hci_da1469x node outside of soc node to fix warning:

"Warning (simple_bus_reg): /soc/bt_hci_da1469x: missing or empty reg/ranges property"