### PR TITLE
boards: Fix duplicate image in MAX32666FTHR board doc

### DIFF
--- a/boards/adi/max32666fthr/doc/index.rst
+++ b/boards/adi/max32666fthr/doc/index.rst
@@ -21,7 +21,7 @@ The Zephyr port is running on the MAX32666 MCU.
    :align: center
    :alt: MAX32666FTHR Front
 
-.. image:: img/max32666fthr_img1.jpg
+.. image:: img/max32666fthr_img2.jpg
    :align: center
    :alt: MAX32666FTHR Back
 


### PR DESCRIPTION
Front picture was listed twice, despite the back picture (max32666fthr_img2.jpg) actually being checked into the repo, so switch to that one.