### PR TITLE
boards: st: stm32h750b-dk: enable usart1

### DIFF
--- a/boards/st/stm32h750b_dk/arduino_r3_connector.dtsi
+++ b/boards/st/stm32h750b_dk/arduino_r3_connector.dtsi
@@ -34,3 +34,5 @@
 			   <21 0 &gpiod 12 0>;	/* D15 */
 	};
 };
+
+arduino_serial: &usart1 {};

--- a/boards/st/stm32h750b_dk/doc/index.rst
+++ b/boards/st/stm32h750b_dk/doc/index.rst
@@ -84,6 +84,7 @@ Default Zephyr Peripheral Mapping:
 - UART_3 TX/RX : PB10/PB11 (ST-Link Virtual Port Com)
 - LD1 : PJ2
 - LD2 : PI13
+- USART1 TX/RX : PB6/PB7 (Arduino D1/D0)
 
 System Clock
 ============

--- a/boards/st/stm32h750b_dk/stm32h750b_dk.dts
+++ b/boards/st/stm32h750b_dk/stm32h750b_dk.dts
@@ -243,3 +243,13 @@
 	st,adc-prescaler = <4>;
 	status = "okay";
 };
+
+/* Arduino Header pins: Tx:D1, Rx:D0 */
+/* LPUART1 can also be used with this pins */
+&usart1 {
+	dma-names = "tx", "rx";
+	pinctrl-0 = <&usart1_tx_pb6 &usart1_rx_pb7>;
+	pinctrl-names = "default";
+	current-speed = <115200>;
+	status = "okay";
+};


### PR DESCRIPTION
Enable LPUART1 that can be used with external periphs via Arduino pins.
Tested with `tests/drivers/uart_basic_api`.