### PR TITLE
drivers: dma: stm32_bdma: fix regression

### DIFF
--- a/drivers/dma/dma_stm32_bdma.c
+++ b/drivers/dma/dma_stm32_bdma.c
@@ -758,8 +758,8 @@ BDMA_STM32_EXPORT_API int bdma_stm32_stop(const struct device *dev, uint32_t id)
 		return -EINVAL;
 	}
 
-	if (stream->hal_override) {
-		stream->busy = false;
+	if (channel->hal_override) {
+		channel->busy = false;
 		return 0;
 	}
 


### PR DESCRIPTION
Fix regression introduced by 1e1c14cfee99c2c28ec45fedd70d295bbb42fca4
undefined variable name is used.

Tested on STM32H750B-DK
`west build -p always -b stm32h750b_dk tests/drivers/dma/loop_transfer -T drivers.dma.loop_transfer`
```
SUITE PASS - 100.00% [dma_m2m_loop]: pass = 4, fail = 0, skip = 2, total = 6 duration = 1.172 seconds
 - PASS - [dma_m2m_loop.test_tst_dma0_m2m_loop] duration = 0.284 seconds
 - PASS - [dma_m2m_loop.test_tst_dma0_m2m_loop_repeated_start_stop] duration = 0.281 seconds
 - SKIP - [dma_m2m_loop.test_tst_dma0_m2m_loop_suspend_resume] duration = 0.021 seconds
 - PASS - [dma_m2m_loop.test_tst_dma1_m2m_loop] duration = 0.284 seconds
 - PASS - [dma_m2m_loop.test_tst_dma1_m2m_loop_repeated_start_stop] duration = 0.281 seconds
 - SKIP - [dma_m2m_loop.test_tst_dma1_m2m_loop_suspend_resume] duration = 0.021 seconds
```