### PR TITLE
MAINTAINERS: Remove decsny from ADC

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1012,8 +1012,6 @@ Release Notes:
   status: maintained
   maintainers:
     - anangl
-  collaborators:
-    - decsny
   files:
     - drivers/adc/
     - include/zephyr/drivers/adc.h


### PR DESCRIPTION
Remove myself from ADC collaborator

Originally I was added to help maintainer @anangl who had little time to be reviewing the ADC PRs which were stalling, but now I also am stretched thin, and @anangl seems to be more active now than when I was added, so just removing myself from this list to limit my review requests