### PR TITLE
storage/stream_flash: Make context const where not modified

### DIFF
--- a/include/zephyr/storage/stream_flash.h
+++ b/include/zephyr/storage/stream_flash.h
@@ -97,7 +97,7 @@ int stream_flash_init(struct stream_flash_ctx *ctx, const struct device *fdev,
  *
  * @return Number of payload bytes written to flash.
  */
-size_t stream_flash_bytes_written(struct stream_flash_ctx *ctx);
+size_t stream_flash_bytes_written(const struct stream_flash_ctx *ctx);
 
 /**
  * @brief Process input buffers to be written to flash device in single blocks.
@@ -163,7 +163,7 @@ int stream_flash_progress_load(struct stream_flash_ctx *ctx,
  *
  * @return non-negative on success, negative errno code on fail
  */
-int stream_flash_progress_save(struct stream_flash_ctx *ctx,
+int stream_flash_progress_save(const struct stream_flash_ctx *ctx,
 			       const char *settings_key);
 
 /**
@@ -175,7 +175,7 @@ int stream_flash_progress_save(struct stream_flash_ctx *ctx,
  *
  * @return non-negative on success, negative errno code on fail
  */
-int stream_flash_progress_clear(struct stream_flash_ctx *ctx,
+int stream_flash_progress_clear(const struct stream_flash_ctx *ctx,
 				const char *settings_key);
 
 #ifdef __cplusplus

--- a/subsys/storage/stream/stream_flash.c
+++ b/subsys/storage/stream/stream_flash.c
@@ -231,7 +231,7 @@ int stream_flash_buffered_write(struct stream_flash_ctx *ctx, const uint8_t *dat
 	return rc;
 }
 
-size_t stream_flash_bytes_written(struct stream_flash_ctx *ctx)
+size_t stream_flash_bytes_written(const struct stream_flash_ctx *ctx)
 {
 	return ctx->bytes_written;
 }
@@ -342,7 +342,7 @@ int stream_flash_progress_load(struct stream_flash_ctx *ctx,
 	return rc;
 }
 
-int stream_flash_progress_save(struct stream_flash_ctx *ctx,
+int stream_flash_progress_save(const struct stream_flash_ctx *ctx,
 			       const char *settings_key)
 {
 	if (!ctx || !settings_key) {
@@ -361,7 +361,7 @@ int stream_flash_progress_save(struct stream_flash_ctx *ctx,
 	return rc;
 }
 
-int stream_flash_progress_clear(struct stream_flash_ctx *ctx,
+int stream_flash_progress_clear(const struct stream_flash_ctx *ctx,
 				const char *settings_key)
 {
 	if (!ctx || !settings_key) {


### PR DESCRIPTION
The commit sets const qualifier struct stream_flash_ctx *ctx parameter of Stream Flash API calls:
  stream_flash_bytes_written
  stream_flash_progress_save
  stream_flash_progress_clear