### PR TITLE
ethernet: phy_mc_ksz8081: Don't reset in cfg link

### DIFF
--- a/drivers/ethernet/phy/phy_microchip_ksz8081.c
+++ b/drivers/ethernet/phy/phy_microchip_ksz8081.c
@@ -329,12 +329,6 @@ static int phy_mc_ksz8081_cfg_link(const struct device *dev,
 	/* We are going to reconfigure the phy, don't need to monitor until done */
 	k_work_cancel_delayable(&data->phy_monitor_work);
 
-	/* Reset PHY */
-	ret = phy_mc_ksz8081_reset(dev);
-	if (ret) {
-		goto done;
-	}
-
 	/* DT configurations */
 	ret = phy_mc_ksz8081_static_cfg(dev);
 	if (ret) {


### PR DESCRIPTION
No need to reset in cfg link, this was blocking system workqueue during phy callbacks that call cfg link, since this happens from monitor work handler which is in the system workqueue.

Meant to fix #78651