### PR TITLE
net: socket_service: remove `work_q` parameter

### DIFF
--- a/doc/releases/migration-guide-4.0.rst
+++ b/doc/releases/migration-guide-4.0.rst
@@ -316,6 +316,9 @@ Networking
   from :zephyr_file:`include/zephyr/net/buf.h` to :zephyr_file:`include/zephyr/net_buf.h` and the
   implementation moved to :zephyr_file:`lib/net_buf/`. (:github:`78009`)
 
+* The ``work_q`` parameter to ``NET_SOCKET_SERVICE_SYNC_DEFINE`` and
+  ``NET_SOCKET_SERVICE_SYNC_DEFINE_STATIC`` has been removed as it was always ignored. (:github:`79446`)
+
 Other Subsystems
 ****************
 

--- a/include/zephyr/net/socket_service.h
+++ b/include/zephyr/net/socket_service.h
@@ -67,8 +67,6 @@ struct net_socket_service_desc {
 	 */
 	const char *owner;
 #endif
-	/** Workqueue where the work is submitted. */
-	struct k_work_q *work_q;
 	/** Pointer to the list of services that we are listening */
 	struct net_socket_service_event *pev;
 	/** Length of the pollable socket array for this service. */
@@ -91,7 +89,7 @@ extern void net_socket_service_callback(struct k_work *work);
 #define NET_SOCKET_SERVICE_OWNER
 #endif
 
-#define __z_net_socket_service_define(_name, _work_q, _cb, _count, ...) \
+#define __z_net_socket_service_define(_name, _cb, _count, ...) \
 	static int __z_net_socket_svc_get_idx(_name);			\
 	static struct net_socket_service_event				\
 			__z_net_socket_svc_get_name(_name)[_count] = {	\
@@ -103,7 +101,6 @@ extern void net_socket_service_callback(struct k_work *work);
 	COND_CODE_0(NUM_VA_ARGS_LESS_1(__VA_ARGS__), (), __VA_ARGS__)	\
 	const STRUCT_SECTION_ITERABLE(net_socket_service_desc, _name) = { \
 		NET_SOCKET_SERVICE_OWNER				\
-		.work_q = (_work_q),                                    \
 		.pev = __z_net_socket_svc_get_name(_name),		\
 		.pev_len = (_count),					\
 		.idx = &__z_net_socket_svc_get_idx(_name),		\
@@ -126,13 +123,11 @@ extern void net_socket_service_callback(struct k_work *work);
  *       instead.
  *
  * @param name Name of the service.
- * @param work_q Pointer to workqueue where the work is done. Can be null in which case
- *        system workqueue is used.
  * @param cb Callback function that is called for socket activity.
  * @param count How many pollable sockets is needed for this service.
  */
-#define NET_SOCKET_SERVICE_SYNC_DEFINE(name, work_q, cb, count)	\
-	__z_net_socket_service_define(name, work_q, cb, count)
+#define NET_SOCKET_SERVICE_SYNC_DEFINE(name, cb, count)	\
+	__z_net_socket_service_define(name, cb, count)
 
 /**
  * @brief Statically define a network socket service in a private (static) scope.
@@ -141,13 +136,11 @@ extern void net_socket_service_callback(struct k_work *work);
  *        with next socket service.
  *
  * @param name Name of the service.
- * @param work_q Pointer to workqueue where the work is done. Can be null in which case
- *        system workqueue is used.
  * @param cb Callback function that is called for socket activity.
  * @param count How many pollable sockets is needed for this service.
  */
-#define NET_SOCKET_SERVICE_SYNC_DEFINE_STATIC(name, work_q, cb, count)	\
-	__z_net_socket_service_define(name, work_q, cb, count, static)
+#define NET_SOCKET_SERVICE_SYNC_DEFINE_STATIC(name, cb, count)	\
+	__z_net_socket_service_define(name, cb, count, static)
 
 /**
  * @brief Register pollable sockets.

--- a/samples/net/sockets/echo_service/src/main.c
+++ b/samples/net/sockets/echo_service/src/main.c
@@ -57,8 +57,8 @@ static void udp_service_handler(struct k_work *work)
 	receive_data(true, pev, buf, sizeof(buf));
 }
 
-NET_SOCKET_SERVICE_SYNC_DEFINE_STATIC(service_udp, NULL, udp_service_handler, MAX_SERVICES);
-NET_SOCKET_SERVICE_SYNC_DEFINE_STATIC(service_tcp, NULL, tcp_service_handler, MAX_SERVICES);
+NET_SOCKET_SERVICE_SYNC_DEFINE_STATIC(service_udp, udp_service_handler, MAX_SERVICES);
+NET_SOCKET_SERVICE_SYNC_DEFINE_STATIC(service_tcp, tcp_service_handler, MAX_SERVICES);
 
 static void receive_data(bool is_udp, struct net_socket_service_event *pev,
 			 char *buf, size_t buflen)

--- a/subsys/net/lib/dhcpv4/dhcpv4_server.c
+++ b/subsys/net/lib/dhcpv4/dhcpv4_server.c
@@ -1534,7 +1534,7 @@ static void dhcpv4_server_cb(struct k_work *work)
 	dhcpv4_process_data(ctx, recv_buf, ret);
 }
 
-NET_SOCKET_SERVICE_SYNC_DEFINE_STATIC(dhcpv4_server, NULL, dhcpv4_server_cb,
+NET_SOCKET_SERVICE_SYNC_DEFINE_STATIC(dhcpv4_server, dhcpv4_server_cb,
 				      CONFIG_NET_DHCPV4_SERVER_INSTANCES);
 
 int net_dhcpv4_server_start(struct net_if *iface, struct in_addr *base_addr)

--- a/subsys/net/lib/dns/llmnr_responder.c
+++ b/subsys/net/lib/dns/llmnr_responder.c
@@ -66,7 +66,7 @@ static struct net_mgmt_event_callback mgmt_cb;
 static struct zsock_pollfd fds[LLMNR_MAX_POLL];
 
 static void svc_handler(struct k_work *work);
-NET_SOCKET_SERVICE_SYNC_DEFINE_STATIC(svc_llmnr, NULL, svc_handler, LLMNR_MAX_POLL);
+NET_SOCKET_SERVICE_SYNC_DEFINE_STATIC(svc_llmnr, svc_handler, LLMNR_MAX_POLL);
 
 NET_BUF_POOL_DEFINE(llmnr_msg_pool, DNS_RESOLVER_BUF_CTR,
 		    DNS_RESOLVER_MAX_BUF_SIZE, 0, NULL);

--- a/subsys/net/lib/dns/mdns_responder.c
+++ b/subsys/net/lib/dns/mdns_responder.c
@@ -56,14 +56,14 @@ extern void dns_dispatcher_svc_handler(struct k_work *work);
 #if defined(CONFIG_NET_IPV4)
 static struct mdns_responder_context v4_ctx[MAX_IPV4_IFACE_COUNT];
 
-NET_SOCKET_SERVICE_SYNC_DEFINE_STATIC(v4_svc, NULL, dns_dispatcher_svc_handler,
+NET_SOCKET_SERVICE_SYNC_DEFINE_STATIC(v4_svc, dns_dispatcher_svc_handler,
 				      MDNS_MAX_IPV4_IFACE_COUNT);
 #endif
 
 #if defined(CONFIG_NET_IPV6)
 static struct mdns_responder_context v6_ctx[MAX_IPV6_IFACE_COUNT];
 
-NET_SOCKET_SERVICE_SYNC_DEFINE_STATIC(v6_svc, NULL, dns_dispatcher_svc_handler,
+NET_SOCKET_SERVICE_SYNC_DEFINE_STATIC(v6_svc, dns_dispatcher_svc_handler,
 				      MDNS_MAX_IPV6_IFACE_COUNT);
 #endif
 

--- a/subsys/net/lib/dns/resolve.c
+++ b/subsys/net/lib/dns/resolve.c
@@ -35,7 +35,7 @@ LOG_MODULE_REGISTER(net_dns_resolve, CONFIG_DNS_RESOLVER_LOG_LEVEL);
 
 extern void dns_dispatcher_svc_handler(struct k_work *work);
 
-NET_SOCKET_SERVICE_SYNC_DEFINE_STATIC(resolve_svc, NULL, dns_dispatcher_svc_handler,
+NET_SOCKET_SERVICE_SYNC_DEFINE_STATIC(resolve_svc, dns_dispatcher_svc_handler,
 				      DNS_RESOLVER_MAX_POLL);
 
 #define MDNS_IPV4_ADDR "224.0.0.251:5353"

--- a/subsys/net/lib/sockets/sockets_service.c
+++ b/subsys/net/lib/sockets/sockets_service.c
@@ -136,8 +136,7 @@ void net_socket_service_callback(struct k_work *work)
 	}
 }
 
-static int call_work(struct zsock_pollfd *pev, struct k_work_q *work_q,
-		     struct k_work *work)
+static int call_work(struct zsock_pollfd *pev, struct k_work *work)
 {
 	int ret = 0;
 
@@ -170,7 +169,7 @@ static int trigger_work(struct zsock_pollfd *pev)
 	 */
 	event->event = *pev;
 
-	return call_work(pev, svc->work_q, &event->work);
+	return call_work(pev, &event->work);
 }
 
 static void socket_service_thread(void)

--- a/subsys/net/lib/zperf/zperf_tcp_receiver.c
+++ b/subsys/net/lib/zperf/zperf_tcp_receiver.c
@@ -41,7 +41,7 @@ static struct sockaddr sock_addr[SOCK_ID_MAX];
 
 static void tcp_svc_handler(struct k_work *work);
 
-NET_SOCKET_SERVICE_SYNC_DEFINE_STATIC(svc_tcp, NULL, tcp_svc_handler,
+NET_SOCKET_SERVICE_SYNC_DEFINE_STATIC(svc_tcp, tcp_svc_handler,
 				      SOCK_ID_MAX);
 
 static void tcp_received(const struct sockaddr *addr, size_t datalen)

--- a/subsys/net/lib/zperf/zperf_udp_receiver.c
+++ b/subsys/net/lib/zperf/zperf_udp_receiver.c
@@ -47,7 +47,7 @@ struct zsock_pollfd fds[SOCK_ID_MAX] = { 0 };
 
 static void udp_svc_handler(struct k_work *work);
 
-NET_SOCKET_SERVICE_SYNC_DEFINE_STATIC(svc_udp, NULL, udp_svc_handler,
+NET_SOCKET_SERVICE_SYNC_DEFINE_STATIC(svc_udp, udp_svc_handler,
 				      SOCK_ID_MAX);
 static char udp_server_iface_name[IFNAMSIZ];
 

--- a/subsys/shell/backends/shell_telnet.c
+++ b/subsys/shell/backends/shell_telnet.c
@@ -42,7 +42,7 @@ struct shell_telnet *sh_telnet;
 static void telnet_server_cb(struct k_work *work);
 static int telnet_init(struct shell_telnet *ctx);
 
-NET_SOCKET_SERVICE_SYNC_DEFINE_STATIC(telnet_server, NULL, telnet_server_cb,
+NET_SOCKET_SERVICE_SYNC_DEFINE_STATIC(telnet_server, telnet_server_cb,
 				      SHELL_TELNET_POLLFD_COUNT);
 
 

--- a/tests/net/socket/service/src/main.c
+++ b/tests/net/socket/service/src/main.c
@@ -55,9 +55,9 @@ static void tcp_server_handler(struct k_work *work)
 	Z_SPIN_DELAY(100);
 }
 
-NET_SOCKET_SERVICE_SYNC_DEFINE(udp_service_sync, NULL, server_handler, 2);
-NET_SOCKET_SERVICE_SYNC_DEFINE(tcp_service_small_sync, NULL, tcp_server_handler, 1);
-NET_SOCKET_SERVICE_SYNC_DEFINE_STATIC(tcp_service_sync, NULL, tcp_server_handler, 2);
+NET_SOCKET_SERVICE_SYNC_DEFINE(udp_service_sync, server_handler, 2);
+NET_SOCKET_SERVICE_SYNC_DEFINE(tcp_service_small_sync, tcp_server_handler, 1);
+NET_SOCKET_SERVICE_SYNC_DEFINE_STATIC(tcp_service_sync, tcp_server_handler, 2);
 
 
 void run_test_service(const struct net_socket_service_desc *udp_service,


### PR DESCRIPTION
Remove the `work_q` parameter from `NET_SOCKET_SERVICE_SYNC_DEFINE` and `NET_SOCKET_SERVICE_SYNC_DEFINE_STATIC` as this feature was dropped during review but the removal was not 100% complete.

Original PR #66758