### PR TITLE
drivers: ipm: ipm_mbox: Initialize after mbox drivers

### DIFF
--- a/drivers/ipm/ipm_mbox.c
+++ b/drivers/ipm/ipm_mbox.c
@@ -109,7 +109,7 @@ static const struct ipm_driver_api ipm_mbox_funcs = {
 			      &ipm_mbox_data_##n,			\
 			      &ipm_mbox_config_##n,			\
 			      POST_KERNEL,				\
-			      0,					\
+			      CONFIG_KERNEL_INIT_PRIORITY_DEVICE,	\
 			      &ipm_mbox_funcs);
 
 DT_INST_FOREACH_STATUS_OKAY(IPM_MBOX_DEV_DEFINE)


### PR DESCRIPTION
This driver depends on its mboxes to be initialized, or the build will fail like this:

ERROR: Device initialization priority validation failed, the sequence of initialization calls does not match the devicetree dependencies.
ERROR: /ipm <ipm_mbox_init> is initialized before its dependency /mailbox0@31f80000 <omap_mailbox_0_init> (POST_KERNEL+0 < POST_KERNEL+2)

Lift its priority to device level.
@glneo 