### PR TITLE
arch: arm: cortex_r/a: Fix multiple use of ARCH_EXCEPT in same scope

### DIFF
--- a/include/zephyr/arch/arm/error.h
+++ b/include/zephyr/arch/arm/error.h
@@ -53,8 +53,8 @@ do {\
  * z_check_stack_sentinel call if it is not stacked before the svc.
  */
 #define ARCH_EXCEPT(reason_p) \
-register uint32_t r0 __asm__("r0") = reason_p; \
 do { \
+	register uint32_t r0 __asm__("r0") = reason_p; \
 	__asm__ volatile ( \
 		"push {lr}\n\t" \
 		"cpsie i\n\t" \


### PR DESCRIPTION
Pull the register variable into the private scope that ARCH_EXCEPT creates so that the macro can be used multiple times in the same caller scope. This can happen via k_panic(), e.g. in subsys/fs/ext2/ext2_impl.c.