### PR TITLE
boards: raspberrypi: rpi_pico: Remove i2c1 node (again)

### DIFF
--- a/boards/kws/pico_spe/pico_spe.dts
+++ b/boards/kws/pico_spe/pico_spe.dts
@@ -206,6 +206,5 @@ zephyr_udc0: &usbd {
 };
 
 pico_spi: &spi1 {};
-pico_i2c0: &i2c0 {};
-pico_i2c1: &i2c1 {};
+pico_i2c: &i2c0 {};
 pico_serial: &uart0 {};

--- a/boards/pimoroni/pico_plus2/pico_plus2.dtsi
+++ b/boards/pimoroni/pico_plus2/pico_plus2.dtsi
@@ -172,7 +172,6 @@ zephyr_udc0: &usbd {
 
 
 pico_spi: &spi0 {};
-pico_i2c0: &i2c0 {};
-pico_i2c1: &i2c1 {};
+pico_i2c: &i2c0 {};
 pico_serial: &uart0 {};
 stemma_qt_i2c: &i2c0 {};

--- a/boards/raspberrypi/common/rpi_pico-pinctrl-common.dtsi
+++ b/boards/raspberrypi/common/rpi_pico-pinctrl-common.dtsi
@@ -23,14 +23,6 @@
 		};
 	};
 
-	i2c1_default: i2c1_default {
-		group1 {
-			pinmux = <I2C1_SDA_P6>, <I2C1_SCL_P7>;
-			input-enable;
-			input-schmitt-enable;
-		};
-	};
-
 	spi0_default: spi0_default {
 		group1 {
 			pinmux = <SPI0_CSN_P17>, <SPI0_SCK_P18>, <SPI0_TX_P19>;

--- a/boards/raspberrypi/rpi_pico/rpi_pico-common.dtsi
+++ b/boards/raspberrypi/rpi_pico/rpi_pico-common.dtsi
@@ -155,6 +155,5 @@ zephyr_udc0: &usbd {
 };
 
 pico_spi: &spi0 {};
-pico_i2c0: &i2c0 {};
-pico_i2c1: &i2c1 {};
+pico_i2c: &i2c0 {};
 pico_serial: &uart0 {};

--- a/boards/raspberrypi/rpi_pico/rpi_pico-common.dtsi
+++ b/boards/raspberrypi/rpi_pico/rpi_pico-common.dtsi
@@ -107,13 +107,6 @@
 	pinctrl-names = "default";
 };
 
-&i2c1 {
-	pinctrl-0 = <&i2c1_default>;
-	pinctrl-names = "default";
-	status = "disabled";
-	clock-frequency = <I2C_BITRATE_FAST>;
-};
-
 &spi0 {
 	clock-frequency = <DT_FREQ_M(8)>;
 	status = "okay";

--- a/boards/raspberrypi/rpi_pico2/rpi_pico2.dtsi
+++ b/boards/raspberrypi/rpi_pico2/rpi_pico2.dtsi
@@ -114,13 +114,6 @@ gpio0_lo: &gpio0 {
 	status = "okay";
 };
 
-&i2c1 {
-	clock-frequency = <I2C_BITRATE_STANDARD>;
-	pinctrl-0 = <&i2c1_default>;
-	pinctrl-names = "default";
-	status = "okay";
-};
-
 &adc {
 	pinctrl-0 = <&adc_default>;
 	pinctrl-names = "default";

--- a/boards/shields/rpi_pico_uno_flexypin/rpi_pico_uno_flexypin.overlay
+++ b/boards/shields/rpi_pico_uno_flexypin/rpi_pico_uno_flexypin.overlay
@@ -37,5 +37,5 @@
 };
 
 arduino_spi: &pico_spi {};
-arduino_i2c: &pico_i2c0 {};
+arduino_i2c: &pico_i2c {};
 arduino_serial: &pico_serial {};

--- a/boards/shields/waveshare_ups/boards/rpi_pico.overlay
+++ b/boards/shields/waveshare_ups/boards/rpi_pico.overlay
@@ -8,11 +8,17 @@
 &pinctrl {
 	i2c1_default: i2c1_default {
 		group1 {
+			pinmux = <I2C1_SDA_P6>, <I2C1_SCL_P7>;
+			input-enable;
+			input-schmitt-enable;
 			bias-pull-up;
 		};
 	};
 };
 
-&pico_i2c1 {
+&i2c1 {
+	pinctrl-0 = <&i2c1_default>;
+	pinctrl-names = "default";
+	clock-frequency = <I2C_BITRATE_FAST>;
 	status = "okay";
 };

--- a/boards/shields/waveshare_ups/waveshare_pico_ups_b.overlay
+++ b/boards/shields/waveshare_ups/waveshare_pico_ups_b.overlay
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&pico_i2c1 {
+&i2c1 {
 	waveshare_pico_ups: ina219@43 {
 		status = "okay";
 		compatible = "ti,ina219";

--- a/boards/waveshare/rp2040_zero/rp2040_zero.dts
+++ b/boards/waveshare/rp2040_zero/rp2040_zero.dts
@@ -142,6 +142,5 @@ zephyr_udc0: &usbd {
 };
 
 pico_spi: &spi0 {};
-pico_i2c0: &i2c0 {};
-pico_i2c1: &i2c1 {};
+pico_i2c: &i2c0 {};
 pico_serial: &uart0 {};

--- a/boards/wiznet/w5500_evb_pico/w5500_evb_pico.dts
+++ b/boards/wiznet/w5500_evb_pico/w5500_evb_pico.dts
@@ -185,5 +185,4 @@ zephyr_udc0: &usbd {
 };
 
 pico_spi: &spi0 {};
-pico_i2c0: &i2c0 {};
-pico_i2c1: &i2c1 {};
+pico_i2c: &i2c0 {};

--- a/boards/wiznet/w5500_evb_pico2/w5500_evb_pico2.dtsi
+++ b/boards/wiznet/w5500_evb_pico2/w5500_evb_pico2.dtsi
@@ -171,6 +171,5 @@ zephyr_udc0: &usbd {
 };
 
 pico_spi: &spi0 {};
-pico_i2c0: &i2c0 {};
-pico_i2c1: &i2c1 {};
+pico_i2c: &i2c0 {};
 pico_serial: &uart0 {};


### PR DESCRIPTION
Zephyr's default settings usually enable only the minimum of
peripherals, and rpi_pico already has `i2c0` enabled.
Remove the `i2c1` node configuration.

I've dealt in https://github.com/zephyrproject-rtos/zephyr/commit/a82cc220d1a55c84b3e337f537ff32b8426b9270,
but it was added again by mistake. I'll delete it again.
