### PR TITLE
subsystem: tracing: test: fix k_pipe_put_* functions

### DIFF
--- a/subsys/tracing/test/tracing_test.h
+++ b/subsys/tracing/test/tracing_test.h
@@ -625,11 +625,11 @@ void sys_trace_k_pipe_flush_enter(struct k_pipe *pipe);
 void sys_trace_k_pipe_flush_exit(struct k_pipe *pipe);
 void sys_trace_k_pipe_buffer_flush_enter(struct k_pipe *pipe);
 void sys_trace_k_pipe_buffer_flush_exit(struct k_pipe *pipe);
-void sys_trace_k_pipe_put_enter(struct k_pipe *pipe, void *data, size_t bytes_to_write,
+void sys_trace_k_pipe_put_enter(struct k_pipe *pipe, const void *data, size_t bytes_to_write,
 				size_t *bytes_written, size_t min_xfer, k_timeout_t timeout);
-void sys_trace_k_pipe_put_blocking(struct k_pipe *pipe, void *data, size_t bytes_to_write,
+void sys_trace_k_pipe_put_blocking(struct k_pipe *pipe, const void *data, size_t bytes_to_write,
 				   size_t *bytes_written, size_t min_xfer, k_timeout_t timeout);
-void sys_trace_k_pipe_put_exit(struct k_pipe *pipe, void *data, size_t bytes_to_write,
+void sys_trace_k_pipe_put_exit(struct k_pipe *pipe, const void *data, size_t bytes_to_write,
 			       size_t *bytes_written, size_t min_xfer, k_timeout_t timeout,
 			       int ret);
 void sys_trace_k_pipe_get_enter(struct k_pipe *pipe, void *data, size_t bytes_to_read,


### PR DESCRIPTION
    k_pipe_put_* functions should take const void* data
    instead of void* data. This can lead to warnings at the
    the -Werror=discarded-qualifiers compiler flag, because the
    the input will be const void* and the parameter is void*.
    Fix it by replacing void* data with “const void* data”.