### PR TITLE
doc: update README.rst

### DIFF
--- a/samples/boards/espressif/wifi_apsta_mode/README.rst
+++ b/samples/boards/espressif/wifi_apsta_mode/README.rst
@@ -40,7 +40,7 @@ Building, Flashing and Running
 ******************************
 
 .. zephyr-app-commands::
-   :zephyr-app: samples/boards/espressif/deep_sleep
+   :zephyr-app: samples/boards/espressif/wifi_apsta_mode
    :board: esp32_devkitc_wroom/esp32/procpu
    :goals: build flash
    :compact:


### PR DESCRIPTION
Fix for misspelled example path for espressif wifi_apsta_mode