### PR TITLE
drivers: serial: pl011: Add fifo enable configuration

### DIFF
--- a/dts/bindings/serial/arm,pl011.yaml
+++ b/dts/bindings/serial/arm,pl011.yaml
@@ -10,3 +10,7 @@ properties:
 
   interrupts:
     required: true
+
+  fifo-disable:
+    type: boolean
+    description: Disable the UART FIFO


### PR DESCRIPTION
Add a setting to the devicetree for enabling or disabling
the PL011 FIFO.

fix #74914