### PR TITLE
Bluetooth: Controller: Fix short prepare timeout start (2nd attempt)

### DIFF
--- a/subsys/bluetooth/controller/Kconfig.ll_sw_split
+++ b/subsys/bluetooth/controller/Kconfig.ll_sw_split
@@ -1107,14 +1107,6 @@ config BT_CTLR_SCAN_UNRESERVED
 	  Scanner will not use time space reservation for scan window when in
 	  continuous scan mode.
 
-config BT_CTLR_EARLY_ABORT_PREVIOUS_PREPARE
-	bool "Early abort previous prepare"
-	depends on !BT_CTLR_LOW_LAT
-	default y
-	help
-	  Early abort previous prepare present before a short prepare is
-	  enqueued in the prepare pipeline.
-
 config BT_MAYFLY_YIELD_AFTER_CALL
 	bool "Yield from mayfly thread after first call"
 	default y

--- a/subsys/bluetooth/controller/Kconfig.ll_sw_split
+++ b/subsys/bluetooth/controller/Kconfig.ll_sw_split
@@ -119,7 +119,7 @@ config BT_CTLR_RX_PRIO_STACK_SIZE
 config BT_CTLR_RX_STACK_SIZE
 	# Hidden, Controller's Co-Operative Rx thread stack size.
 	int
-	default 768
+	default 896
 
 config BT_CTLR_SETTINGS
 	bool "Settings System"

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
@@ -1349,10 +1349,12 @@ uint32_t radio_tmr_start(uint8_t trx, uint32_t ticks_start, uint32_t remainder)
 	 * by the Radio ISR, the compare will trigger again.
 	 */
 	uint32_t latency_ticks;
+	uint32_t latency_us;
 
-	latency_ticks = HAL_TICKER_US_TO_TICKS(HAL_RADIO_ISR_LATENCY_MAX_US);
+	latency_us = MAX(remainder, HAL_RADIO_ISR_LATENCY_MAX_US) - remainder;
+	latency_ticks = HAL_TICKER_US_TO_TICKS(latency_us);
 	ticks_start -= latency_ticks;
-	remainder += HAL_TICKER_TICKS_TO_US(latency_ticks);
+	remainder += latency_us;
 #endif /* !CONFIG_BT_CTLR_SW_SWITCH_SINGLE_TIMER */
 
 	nrf_timer_task_trigger(EVENT_TIMER, NRF_TIMER_TASK_CLEAR);
@@ -1473,10 +1475,12 @@ uint32_t radio_tmr_start_tick(uint8_t trx, uint32_t ticks_start)
 	 * by the Radio ISR, the compare will trigger again.
 	 */
 	uint32_t latency_ticks;
+	uint32_t latency_us;
 
-	latency_ticks = HAL_TICKER_US_TO_TICKS(HAL_RADIO_ISR_LATENCY_MAX_US);
+	latency_us = MAX(remainder_us, HAL_RADIO_ISR_LATENCY_MAX_US) - remainder_us;
+	latency_ticks = HAL_TICKER_US_TO_TICKS(latency_us);
 	ticks_start -= latency_ticks;
-	remainder_us += HAL_TICKER_TICKS_TO_US(latency_ticks);
+	remainder_us += latency_us;
 #endif /* !CONFIG_BT_CTLR_SW_SWITCH_SINGLE_TIMER */
 
 	nrf_timer_task_trigger(EVENT_TIMER, NRF_TIMER_TASK_STOP);
@@ -1614,10 +1618,10 @@ uint32_t radio_tmr_start_us(uint8_t trx, uint32_t start_us)
 		 * The timer is cleared on Radio End and if the PPI/DPPI is not disabled
 		 * by the Radio ISR, the compare will trigger again.
 		 */
-		uint32_t latency_ticks;
+		uint32_t latency_us;
 
-		latency_ticks = HAL_TICKER_US_TO_TICKS(HAL_RADIO_ISR_LATENCY_MAX_US);
-		actual_us += HAL_TICKER_TICKS_TO_US(latency_ticks);
+		latency_us = MAX(actual_us, HAL_RADIO_ISR_LATENCY_MAX_US) - actual_us;
+		actual_us += latency_us;
 #endif /* !CONFIG_BT_CTLR_SW_SWITCH_SINGLE_TIMER */
 
 		nrf_timer_event_clear(EVENT_TIMER, NRF_TIMER_EVENT_COMPARE0);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
@@ -216,14 +216,13 @@ uint8_t lll_scan_aux_setup(struct pdu_adv *pdu, uint8_t pdu_phy,
 	overhead_us += EVENT_TICKER_RES_MARGIN_US;
 	overhead_us += EVENT_JITTER_US;
 
-	/* Minimum prepare tick offset + minimum preempt tick offset are the
-	 * overheads before ULL scheduling can setup radio for reception
+	/* CPU execution overhead to setup the radio for reception plus the
+	 * minimum prepare tick offset. And allow one additional event in
+	 * between as overhead (say, an advertising event in between got closed
+	 * when reception for auxiliary PDU is being setup).
 	 */
-	overhead_us +=
-		HAL_TICKER_TICKS_TO_US(HAL_TICKER_CNTR_CMP_OFFSET_MIN << 1);
-
-	/* CPU execution overhead to setup the radio for reception */
-	overhead_us += EVENT_OVERHEAD_END_US + EVENT_OVERHEAD_START_US;
+	overhead_us += (EVENT_OVERHEAD_END_US + EVENT_OVERHEAD_START_US +
+			HAL_TICKER_TICKS_TO_US(HAL_TICKER_CNTR_CMP_OFFSET_MIN)) << 1;
 
 	/* Sufficient offset to ULL schedule the auxiliary PDU scan? */
 	if (aux_offset_us > overhead_us) {

--- a/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
@@ -128,6 +128,7 @@ void ull_scan_aux_setup(memq_link_t *link, struct node_rx_pdu *rx)
 	uint8_t data_len;
 	uint8_t hdr_len;
 	uint32_t pdu_us;
+	uint8_t phy_aux;
 	uint8_t *ptr;
 	uint8_t phy;
 
@@ -528,6 +529,53 @@ void ull_scan_aux_setup(memq_link_t *link, struct node_rx_pdu *rx)
 		goto ull_scan_aux_rx_flush;
 	}
 
+	/* CA field contains the clock accuracy of the advertiser;
+	 * 0 - 51 ppm to 500 ppm
+	 * 1 - 0 ppm to 50 ppm
+	 */
+	if (aux_ptr->ca) {
+		window_widening_us = SCA_DRIFT_50_PPM_US(aux_offset_us);
+	} else {
+		window_widening_us = SCA_DRIFT_500_PPM_US(aux_offset_us);
+	}
+
+	phy_aux = BIT(PDU_ADV_AUX_PTR_PHY_GET(aux_ptr));
+	ready_delay_us = lll_radio_rx_ready_delay_get(phy_aux, PHY_FLAGS_S8);
+
+	/* Calculate the aux offset from start of the scan window */
+	aux_offset_us += ftr->radio_end_us;
+	aux_offset_us -= pdu_us;
+	aux_offset_us -= EVENT_TICKER_RES_MARGIN_US;
+	aux_offset_us -= EVENT_JITTER_US;
+	aux_offset_us -= ready_delay_us;
+	aux_offset_us -= window_widening_us;
+
+	ticks_aux_offset = HAL_TICKER_US_TO_TICKS(aux_offset_us);
+
+	/* Check if too late to ULL schedule an auxiliary PDU reception */
+	if (!ftr->aux_lll_sched) {
+		uint32_t ticks_at_expire;
+		uint32_t overhead_us;
+		uint32_t ticks_now;
+		uint32_t diff;
+
+		/* CPU execution overhead to setup the radio for reception plus the
+		 * minimum prepare tick offset. And allow one additional event in
+		 * between as overhead (say, an advertising event in between got closed
+		 * when reception for auxiliary PDU is being setup).
+		 */
+		overhead_us = (EVENT_OVERHEAD_END_US + EVENT_OVERHEAD_START_US +
+			       HAL_TICKER_TICKS_TO_US(HAL_TICKER_CNTR_CMP_OFFSET_MIN)) << 1;
+
+		ticks_now = ticker_ticks_now_get();
+		ticks_at_expire = ftr->ticks_anchor + ticks_aux_offset -
+				  HAL_TICKER_US_TO_TICKS(overhead_us);
+		diff = ticker_ticks_diff_get(ticks_now, ticks_at_expire);
+		if ((diff & BIT(HAL_TICKER_CNTR_MSBIT)) == 0U) {
+			goto ull_scan_aux_rx_flush;
+		}
+	}
+
 	if (!aux) {
 		aux = aux_acquire();
 		if (!aux) {
@@ -637,7 +685,7 @@ void ull_scan_aux_setup(memq_link_t *link, struct node_rx_pdu *rx)
 	/* Initialize the channel index and PHY for the Auxiliary PDU reception.
 	 */
 	lll_aux->chan = aux_ptr->chan_idx;
-	lll_aux->phy = BIT(PDU_ADV_AUX_PTR_PHY_GET(aux_ptr));
+	lll_aux->phy = phy_aux;
 
 	/* See if this was already scheduled from LLL. If so, store aux context
 	 * in global scan struct so we can pick it when scanned node is received
@@ -718,31 +766,6 @@ void ull_scan_aux_setup(memq_link_t *link, struct node_rx_pdu *rx)
 		aux->rx_head = rx;
 	}
 
-	/* CA field contains the clock accuracy of the advertiser;
-	 * 0 - 51 ppm to 500 ppm
-	 * 1 - 0 ppm to 50 ppm
-	 */
-	if (aux_ptr->ca) {
-		window_widening_us = SCA_DRIFT_50_PPM_US(aux_offset_us);
-	} else {
-		window_widening_us = SCA_DRIFT_500_PPM_US(aux_offset_us);
-	}
-
-	lll_aux->window_size_us = window_size_us;
-	lll_aux->window_size_us += ((EVENT_TICKER_RES_MARGIN_US + EVENT_JITTER_US +
-				     window_widening_us) << 1);
-
-	ready_delay_us = lll_radio_rx_ready_delay_get(lll_aux->phy,
-						      PHY_FLAGS_S8);
-
-	/* Calculate the aux offset from start of the scan window */
-	aux_offset_us += ftr->radio_end_us;
-	aux_offset_us -= pdu_us;
-	aux_offset_us -= EVENT_TICKER_RES_MARGIN_US;
-	aux_offset_us -= EVENT_JITTER_US;
-	aux_offset_us -= ready_delay_us;
-	aux_offset_us -= window_widening_us;
-
 	/* TODO: active_to_start feature port */
 	aux->ull.ticks_active_to_start = 0;
 	aux->ull.ticks_prepare_to_start =
@@ -763,7 +786,10 @@ void ull_scan_aux_setup(memq_link_t *link, struct node_rx_pdu *rx)
 	}
 	ticks_slot_offset += HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_START_US);
 
-	ticks_aux_offset = HAL_TICKER_US_TO_TICKS(aux_offset_us);
+	/* Initialize the window size for the Auxiliary PDU reception. */
+	lll_aux->window_size_us = window_size_us;
+	lll_aux->window_size_us += ((EVENT_TICKER_RES_MARGIN_US + EVENT_JITTER_US +
+				     window_widening_us) << 1);
 
 #if (CONFIG_BT_CTLR_ULL_HIGH_PRIO == CONFIG_BT_CTLR_ULL_LOW_PRIO)
 	/* disable ticker job, in order to chain yield and start to reduce

--- a/subsys/bluetooth/controller/ticker/ticker.c
+++ b/subsys/bluetooth/controller/ticker/ticker.c
@@ -1257,6 +1257,7 @@ void ticker_worker(void *param)
 	uint32_t ticks_elapsed;
 	uint32_t ticks_expired;
 	uint8_t ticker_id_head;
+	uint32_t ticks_now;
 
 	/* Defer worker if job running */
 	instance->worker_trigger = 1U;
@@ -1270,8 +1271,10 @@ void ticker_worker(void *param)
 		return;
 	}
 
+	ticks_now = cntr_cnt_get();
+
 	/* Get ticks elapsed since last job execution */
-	ticks_elapsed = ticker_ticks_diff_get(cntr_cnt_get(),
+	ticks_elapsed = ticker_ticks_diff_get(ticks_now,
 					      instance->ticks_current);
 
 	/* Initialize actual elapsed ticks being consumed */

--- a/subsys/bluetooth/controller/ticker/ticker.c
+++ b/subsys/bluetooth/controller/ticker/ticker.c
@@ -2469,10 +2469,14 @@ static uint8_t ticker_job_reschedule_in_window(struct ticker_instance *instance,
 			ticker_id_resched_prev = ticker_id_resched;
 			ticker_id_resched = ticker_resched->next;
 		}
+
+		/* Exit if no tickers to be rescheduled */
 		if (ticker_id_resched == TICKER_NULL) {
-			/* Done */
 			break;
 		}
+
+		/* Ensure that resched ticker is expired */
+		LL_ASSERT(ticker_resched->ticks_to_expire == 0U);
 
 		/* Check for intersection with already active node */
 		window_start_ticks = 0U;
@@ -2483,8 +2487,6 @@ static uint8_t ticker_job_reschedule_in_window(struct ticker_instance *instance,
 			window_start_ticks = instance->ticks_slot_previous -
 					     ticks_elapsed;
 		}
-
-		ticker_id_next = ticker_resched->next;
 
 		/* If drift was applied to this node, this must be
 		 * taken into consideration. Reduce the window with
@@ -2499,6 +2501,10 @@ static uint8_t ticker_job_reschedule_in_window(struct ticker_instance *instance,
 		if (ext_data->ticks_drift < ext_data->ticks_slot_window) {
 			ticks_slot_window = ext_data->ticks_slot_window -
 					    ext_data->ticks_drift;
+			/* Window available, proceed to calculate further
+			 * drift
+			 */
+			ticker_id_next = ticker_resched->next;
 		} else {
 			/* Window has been exhausted - we can't reschedule */
 			ticker_id_next = TICKER_NULL;
@@ -2556,7 +2562,7 @@ static uint8_t ticker_job_reschedule_in_window(struct ticker_instance *instance,
 				/* Next expiry is too close - try the next
 				 * node
 				 */
-				window_end_ticks = 0;
+				window_end_ticks = 0U;
 			}
 
 			/* Calculate new ticks_to_expire as end of window minus
@@ -2578,7 +2584,7 @@ static uint8_t ticker_job_reschedule_in_window(struct ticker_instance *instance,
 				}
 			} else {
 				/* No space in window - try the next node */
-				ticks_to_expire = 0;
+				ticks_to_expire = 0U;
 			}
 
 			/* Decide if the re-scheduling ticker node fits in the
@@ -2616,9 +2622,7 @@ static uint8_t ticker_job_reschedule_in_window(struct ticker_instance *instance,
 			ticker_id_next = ticker_next->next;
 		}
 
-		ext_data->ticks_drift += ticks_to_expire -
-					 ticker_resched->ticks_to_expire;
-		ticker_resched->ticks_to_expire = ticks_to_expire;
+		ext_data->ticks_drift += ticks_to_expire;
 
 		/* Place the ticker node sorted by expiration time and adjust
 		 * delta times
@@ -2629,20 +2633,19 @@ static uint8_t ticker_job_reschedule_in_window(struct ticker_instance *instance,
 			struct ticker_node *ticker_next;
 
 			ticker_next = &nodes[ticker_id_next];
-			if (ticker_resched->ticks_to_expire >
-			    ticker_next->ticks_to_expire) {
+			if (ticks_to_expire > ticker_next->ticks_to_expire) {
 				/* Node is after this - adjust delta */
-				ticker_resched->ticks_to_expire -=
-					ticker_next->ticks_to_expire;
+				ticks_to_expire -= ticker_next->ticks_to_expire;
 			} else {
 				/* Node is before this one */
-				ticker_next->ticks_to_expire -=
-					ticker_resched->ticks_to_expire;
+				ticker_next->ticks_to_expire -= ticks_to_expire;
 				break;
 			}
 			ticker_id_prev = ticker_id_next;
 			ticker_id_next = ticker_next->next;
 		}
+
+		ticker_resched->ticks_to_expire = ticks_to_expire;
 
 		/* If the node moved in the list, insert it */
 		if (ticker_id_prev != TICKER_NULL) {

--- a/subsys/bluetooth/controller/ticker/ticker.c
+++ b/subsys/bluetooth/controller/ticker/ticker.c
@@ -2529,17 +2529,6 @@ static uint8_t ticker_job_reschedule_in_window(struct ticker_instance *instance)
 			ticker_next = &nodes[ticker_id_next];
 			ticks_to_expire_offset += ticker_next->ticks_to_expire;
 
-			/* Skip other pending re-schedule nodes and
-			 * tickers with no reservation or not periodic
-			 */
-			if (TICKER_RESCHEDULE_PENDING(ticker_next) ||
-			    !ticker_next->ticks_slot ||
-			    !ticker_next->ticks_periodic) {
-				ticker_id_next = ticker_next->next;
-
-				continue;
-			}
-
 			/* Calculate end of window. Since window may be aligned
 			 * with expiry of next node, we add a margin
 			 */
@@ -2579,6 +2568,17 @@ static uint8_t ticker_job_reschedule_in_window(struct ticker_instance *instance)
 			} else {
 				/* No space in window - try the next node */
 				ticks_to_expire = 0U;
+			}
+
+			/* Skip other pending re-schedule nodes and
+			 * tickers with no reservation or not periodic
+			 */
+			if (TICKER_RESCHEDULE_PENDING(ticker_next) ||
+			    !ticker_next->ticks_slot ||
+			    !ticker_next->ticks_periodic) {
+				ticker_id_next = ticker_next->next;
+
+				continue;
 			}
 
 			/* Decide if the re-scheduling ticker node fits in the


### PR DESCRIPTION
Fix delayed ULL scheduling an auxiliary PDU reception by
skipping it. When many bufferred ADV_EXT_IND are to be
processed, the ULL scheduling could get late and then cause
the scan aux LLL to detect increased overhead start timing.


Fix to setup correct short prepare timeout when preempt
callback does not find the prepare in the head of the
pipeline. In this case, find the short prepare and setup
a fresh preempt timeout for the determined short prepare
present in the pipeline.

Relates to commit https://github.com/zephyrproject-rtos/zephyr/commit/7d1bc1789e5185353b520666743805ce5257cb71 ("Bluetooth: Controller: Fix
short prepare preempt timeout start").

Blocked by #79100.