### PR TITLE
sys: util: define bits per byte, nibble, and nibbles per byte

### DIFF
--- a/drivers/clock_control/clock_control_litex.h
+++ b/drivers/clock_control/clock_control_litex.h
@@ -7,11 +7,11 @@
 #ifndef LITEX_MMCM_H
 #define LITEX_MMCM_H
 
+#include <zephyr/sys/util.h>
 #include <zephyr/types.h>
 
 /* Common values */
-#define PICOS_IN_SEC		1000000000000
-#define BITS_PER_BYTE		8
+#define PICOS_IN_SEC 1000000000000
 
 /* MMCM specific numbers */
 #define CLKOUT_MAX		7

--- a/drivers/fpga/fpga_ice40.c
+++ b/drivers/fpga/fpga_ice40.c
@@ -19,6 +19,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/crc.h>
+#include <zephyr/sys/util.h>
 
 /*
  * Note: When loading a bitstream, the iCE40 has a 'quirk' in that the CS
@@ -49,18 +50,6 @@
  */
 #define FPGA_ICE40_LOAD_MODE_SPI  0
 #define FPGA_ICE40_LOAD_MODE_GPIO 1
-
-#ifndef BITS_PER_NIBBLE
-#define BITS_PER_NIBBLE 4
-#endif
-
-#ifndef BITS_PER_BYTE
-#define BITS_PER_BYTE 8
-#endif
-
-#ifndef NIBBLES_PER_BYTE
-#define NIBBLES_PER_BYTE (BITS_PER_BYTE / BITS_PER_NIBBLE)
-#endif
 
 /*
  * Values in Hz, intentionally to be comparable with the spi-max-frequency

--- a/include/zephyr/sys/util.h
+++ b/include/zephyr/sys/util.h
@@ -57,6 +57,15 @@ extern "C" {
 #	error Missing required predefined macros for BITS_PER_LONG calculation
 #endif
 
+/** Number of bits in a byte. */
+#define BITS_PER_BYTE (__CHAR_BIT__)
+
+/** Number of bits in a nibble. */
+#define BITS_PER_NIBBLE (__CHAR_BIT__ / 2)
+
+/** Number of nibbles in a byte. */
+#define NIBBLES_PER_BYTE (BITS_PER_BYTE / BITS_PER_NIBBLE)
+
 /** Number of bits in a long int. */
 #define BITS_PER_LONG	(__CHAR_BIT__ * __SIZEOF_LONG__)
 

--- a/subsys/shell/modules/devmem_service.c
+++ b/subsys/shell/modules/devmem_service.c
@@ -18,6 +18,7 @@
 #include <zephyr/device.h>
 #include <zephyr/shell/shell.h>
 #include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/util.h>
 
 #ifndef CONFIG_NATIVE_LIBC
 extern void getopt_init(void);
@@ -38,10 +39,6 @@ static bool littleendian;
 
 #define CHAR_CAN 0x18
 #define CHAR_DC1 0x11
-
-#ifndef BITS_PER_BYTE
-#define BITS_PER_BYTE 8
-#endif
 
 static int memory_dump(const struct shell *sh, mem_addr_t phys_addr, size_t size, uint8_t width)
 {


### PR DESCRIPTION
Collect some common bit-widths redefined in various locations and put them under `sys/util.h` .