### PR TITLE
dts: bindings: spi: pl022: Make included reset-device.yaml

### DIFF
--- a/dts/bindings/spi/arm,pl022.yaml
+++ b/dts/bindings/spi/arm,pl022.yaml
@@ -5,7 +5,7 @@ description: ARM PL022 SPI
 
 compatible: "arm,pl022"
 
-include: [spi-controller.yaml, pinctrl-device.yaml]
+include: [spi-controller.yaml, pinctrl-device.yaml, reset-device.yaml]
 
 properties:
   reg:

--- a/dts/bindings/spi/raspberrypi,pico-spi.yaml
+++ b/dts/bindings/spi/raspberrypi,pico-spi.yaml
@@ -2,4 +2,4 @@ description: Raspberry Pi Pico SPI
 
 compatible: "raspberrypi,pico-spi"
 
-include: ["arm,pl022.yaml", "reset-device.yaml"]
+include: "arm,pl022.yaml"


### PR DESCRIPTION
The PL022 driver has already implemented supporting reset device
behavior.
However, the support is incomplete because the `arm,pl022.yaml`,
does not contain a `reset-device.yaml`.

Add include directive to `arm,pl022.yaml` to including
`reset-device.yaml` to complete the support for reset device.

As a result, `raspberrypi,pico-spi.yaml` is no longer necessary,
so delete it. I also update the document accordingly.