### PR TITLE
drivers: timer: Disable prescalar for TI DM Timer

### DIFF
--- a/drivers/timer/ti_dmtimer.c
+++ b/drivers/timer/ti_dmtimer.c
@@ -138,6 +138,9 @@ static int sys_clock_driver_init(void)
 
 	IRQ_CONNECT(TIMER_IRQ_NUM, TIMER_IRQ_PRIO, ti_dmtimer_isr, NULL, TIMER_IRQ_FLAGS);
 
+	/* Disable prescalar */
+	TI_DM_TIMER_WRITE(0, TCLR, PRE);
+
 	/* Select autoreload mode */
 	TI_DM_TIMER_WRITE(1, TCLR, AR);
 


### PR DESCRIPTION
The timer count calculations are done with the assumption that the prescalar is disabled. When using u-boot's SPL as an early boot stage, the omap timer driver enables the prescalar leaving this driver to calculate incorrect counts. So explicitly disable the prescalar to match the driver expectation.