### PR TITLE
boards: nordic: nrf54h20dk: make RAM3x DMA region larger for cpurad

### DIFF
--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20-memory_map.dtsi
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20-memory_map.dtsi
@@ -183,16 +183,16 @@
 
 			cpuapp_dma_region: memory@e80 {
 				compatible = "zephyr,memory-region";
-				reg = <0xe80 DT_SIZE_K(4)>;
+				reg = <0xe80 DT_SIZE_K(3)>;
 				status = "disabled";
 				#memory-region-cells = <0>;
 				zephyr,memory-region = "DMA_RAM3x_APP";
 				zephyr,memory-attr = <( DT_MEM_DMA )>;
 			};
 
-			cpurad_dma_region: memory@1e80 {
+			cpurad_dma_region: memory@1a80 {
 				compatible = "zephyr,memory-region";
-				reg = <0x1e80 0x80>;
+				reg = <0x1a80 0x480>;
 				status = "disabled";
 				#memory-region-cells = <0>;
 				zephyr,memory-region = "DMA_RAM3x_RAD";


### PR DESCRIPTION
Some tests are failing on nrf54h20 cpurad in non-obvious manner because of this memory region being too small.
Instead of adding overlays to each individual application, make this region larger at expense of cpuapp equivalent.