### PR TITLE
twister: Fix reported testcase execution time

### DIFF
--- a/scripts/pylib/twister/twisterlib/reports.py
+++ b/scripts/pylib/twister/twisterlib/reports.py
@@ -243,7 +243,7 @@ class Reporting:
                     classname = f"{platform}:{name}"
                     log = ts.get("log")
                     fails, passes, errors, skips = self.xunit_testcase(eleTestsuite,
-                        name, classname, ts_status, ts_status, reason, duration, runnable,
+                        name, classname, ts_status, ts_status, reason, handler_time, runnable,
                         (fails, passes, errors, skips), log, False)
 
             total = errors + passes + fails + skips


### PR DESCRIPTION
Testcase execution time doesn't match between twister.xml and twister.log. 
Testcase execution time is the sum of the previous testcases' execution time
 plus its own execution time in twister.xml.

This patch fixes the issue above.