### PR TITLE
tests: mcumgr: Use EXTRA_ZEPHYR_MODULES

### DIFF
--- a/tests/subsys/mgmt/mcumgr/handler_demo/CMakeLists.txt
+++ b/tests/subsys/mgmt/mcumgr/handler_demo/CMakeLists.txt
@@ -4,7 +4,7 @@
 cmake_minimum_required(VERSION 3.20.0)
 
 # This adds the example module to the list of extra zephyr modules
-list(APPEND ZEPHYR_EXTRA_MODULES "${CMAKE_CURRENT_SOURCE_DIR}/example_as_module")
+list(APPEND EXTRA_ZEPHYR_MODULES "${CMAKE_CURRENT_SOURCE_DIR}/example_as_module")
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(handler_demo)


### PR DESCRIPTION
Use EXTRA_ZEPHYR_MODULES that replaced ZEPHYR_EXTRA_MODULES since the Zephyr v3.4 release.