### PR TITLE
yaml: use EXTRA_CONF_FILE in .yaml files

### DIFF
--- a/samples/drivers/jesd216/sample.yaml
+++ b/samples/drivers/jesd216/sample.yaml
@@ -24,7 +24,7 @@ tests:
   sample.drivers.jesd216.nrf52840dk_spi:
     extra_args:
       - DTC_OVERLAY_FILE=boards/nrf52840dk_nrf52840_spi.overlay
-      - OVERLAY_CONFIG=boards/nrf52840dk_nrf52840_spi.conf
+      - EXTRA_CONF_FILE=boards/nrf52840dk_nrf52840_spi.conf
     platform_allow: nrf52840dk/nrf52840
     integration_platforms:
       - nrf52840dk/nrf52840

--- a/samples/drivers/spi_flash_at45/sample.yaml
+++ b/samples/drivers/spi_flash_at45/sample.yaml
@@ -9,7 +9,7 @@ tests:
     filter: dt_compat_enabled("atmel,at45")
     build_only: true
   sample.drivers.spi.flash.at45.build.page_layout:
-    extra_args: OVERLAY_CONFIG="overlay-page_layout.conf"
+    extra_args: EXTRA_CONF_FILE="overlay-page_layout.conf"
     tags:
       - spi
       - flash
@@ -17,7 +17,7 @@ tests:
     filter: dt_compat_enabled("atmel,at45")
     build_only: true
   sample.drivers.spi.flash.at45.build.pm:
-    extra_args: OVERLAY_CONFIG="overlay-pm.conf"
+    extra_args: EXTRA_CONF_FILE="overlay-pm.conf"
     tags:
       - spi
       - flash
@@ -25,7 +25,7 @@ tests:
     filter: dt_compat_enabled("atmel,at45")
     build_only: true
   sample.drivers.spi.flash.at45.build.page_layout_pm:
-    extra_args: OVERLAY_CONFIG="overlay-page_layout.conf;overlay-pm.conf"
+    extra_args: EXTRA_CONF_FILE="overlay-page_layout.conf;overlay-pm.conf"
     tags:
       - spi
       - flash
@@ -33,7 +33,7 @@ tests:
     filter: dt_compat_enabled("atmel,at45")
     build_only: true
   sample.drivers.spi.flash.at45:
-    extra_args: OVERLAY_CONFIG="overlay-page_layout.conf;overlay-pm.conf"
+    extra_args: EXTRA_CONF_FILE="overlay-page_layout.conf;overlay-pm.conf"
     tags:
       - spi
       - flash

--- a/samples/modules/thrift/hello/client/sample.yaml
+++ b/samples/modules/thrift/hello/client/sample.yaml
@@ -21,4 +21,4 @@ tests:
     extra_configs:
       - CONFIG_THRIFT_COMPACT_PROTOCOL=y
   sample.thrift.hello.client.tlsTransport:
-    extra_args: OVERLAY_CONFIG="../overlay-tls.conf"
+    extra_args: EXTRA_CONF_FILE="../overlay-tls.conf"

--- a/samples/modules/thrift/hello/server/sample.yaml
+++ b/samples/modules/thrift/hello/server/sample.yaml
@@ -21,4 +21,4 @@ tests:
     extra_configs:
       - CONFIG_THRIFT_COMPACT_PROTOCOL=y
   sample.thrift.hello.server.tlsTransport:
-    extra_args: OVERLAY_CONFIG="../overlay-tls.conf"
+    extra_args: EXTRA_CONF_FILE="../overlay-tls.conf"

--- a/samples/net/cloud/tagoio_http_post/sample.yaml
+++ b/samples/net/cloud/tagoio_http_post/sample.yaml
@@ -18,12 +18,12 @@ tests:
     integration_platforms:
       - frdm_k64f
   sample.net.cloud.tagoio_http_post.wifi:
-    extra_args: OVERLAY_CONFIG="overlay-wifi.conf"
+    extra_args: EXTRA_CONF_FILE="overlay-wifi.conf"
     platform_allow: disco_l475_iot1
   sample.net.cloud.tagoio_http_post.wifi.esp:
     extra_args:
       - SHIELD=esp_8266_arduino
-      - OVERLAY_CONFIG="overlay-wifi.conf"
+      - EXTRA_CONF_FILE="overlay-wifi.conf"
     platform_allow:
       - frdm_k64f
       - nucleo_f767zi

--- a/samples/net/lwm2m_client/sample.yaml
+++ b/samples/net/lwm2m_client/sample.yaml
@@ -40,7 +40,7 @@ tests:
   sample.net.lwm2m_client.dtls:
     harness: net
     depends_on: netif
-    extra_args: OVERLAY_CONFIG=overlay-dtls.conf
+    extra_args: EXTRA_CONF_FILE=overlay-dtls.conf
     platform_allow:
       - qemu_x86
       - frdm_k64f
@@ -55,7 +55,7 @@ tests:
   sample.net.lwm2m_client.queue_mode:
     harness: net
     depends_on: netif
-    extra_args: OVERLAY_CONFIG=overlay-queue.conf
+    extra_args: EXTRA_CONF_FILE=overlay-queue.conf
     platform_allow:
       - qemu_x86
       - native_sim

--- a/samples/net/openthread/coprocessor/sample.yaml
+++ b/samples/net/openthread/coprocessor/sample.yaml
@@ -26,7 +26,7 @@ tests:
       - nrf52840dk/nrf52840
     tags: ci_build
     extra_args:
-      - OVERLAY_CONFIG=overlay-usb-nrf-br.conf
+      - EXTRA_CONF_FILE=overlay-usb-nrf-br.conf
       - DTC_OVERLAY_FILE="usb.overlay"
   sample.openthread.coprocessor.rcp:
     build_only: true
@@ -36,4 +36,4 @@ tests:
       - tlsr9518adk80d
     integration_platforms:
       - nrf52840dk/nrf52840
-    extra_args: OVERLAY_CONFIG=overlay-rcp.conf
+    extra_args: EXTRA_CONF_FILE=overlay-rcp.conf

--- a/samples/net/secure_mqtt_sensor_actuator/sample.yaml
+++ b/samples/net/secure_mqtt_sensor_actuator/sample.yaml
@@ -12,7 +12,7 @@ tests:
       - adi_eval_adin1110ebz
   sample.net.secure_mqtt_sensor_actuator.staticip:
     harness: net
-    extra_args: OVERLAY_CONFIG="overlay-static.conf"
+    extra_args: EXTRA_CONF_FILE="overlay-static.conf"
     tags:
       - net
       - mqtt
@@ -22,7 +22,7 @@ tests:
       - native_sim
   sample.net.secure_mqtt_sensor_actuator.staticip_insecure:
     harness: net
-    extra_args: OVERLAY_CONFIG="overlay-static-insecure.conf"
+    extra_args: EXTRA_CONF_FILE="overlay-static-insecure.conf"
     tags:
       - net
       - mqtt

--- a/samples/net/sockets/big_http_download/sample.yaml
+++ b/samples/net/sockets/big_http_download/sample.yaml
@@ -18,4 +18,4 @@ tests:
     extra_configs:
       - CONFIG_POSIX_API=y
   sample.net.sockets.big_http_download.ci:
-    extra_args: OVERLAY_CONFIG=overlay-ci.conf
+    extra_args: EXTRA_CONF_FILE=overlay-ci.conf

--- a/samples/net/sockets/dumb_http_server/sample.yaml
+++ b/samples/net/sockets/dumb_http_server/sample.yaml
@@ -17,7 +17,7 @@ tests:
   sample.net.sockets.dumb_http_server.netusb:
     depends_on: usb_device
     harness: net
-    extra_args: OVERLAY_CONFIG="overlay-netusb.conf"
+    extra_args: EXTRA_CONF_FILE="overlay-netusb.conf"
     tags: usb
     # native_sim usb driver does not work with CONFIG_POSIX_API
     platform_exclude:
@@ -28,7 +28,7 @@ tests:
   sample.net.sockets.dumb_http_server.netusb_zeroconf:
     depends_on: usb_device
     harness: net
-    extra_args: OVERLAY_CONFIG="overlay-netusb.conf;overlay-zeroconf.conf"
+    extra_args: EXTRA_CONF_FILE="overlay-netusb.conf;overlay-zeroconf.conf"
     tags: usb
     # native_sim usb driver does not work with CONFIG_POSIX_API
     platform_exclude:

--- a/samples/net/sockets/echo_client/sample.yaml
+++ b/samples/net/sockets/echo_client/sample.yaml
@@ -19,20 +19,20 @@ tests:
     integration_platforms:
       - qemu_x86
   sample.net.sockets.echo_client.802154:
-    extra_args: OVERLAY_CONFIG="overlay-qemu_802154.conf"
+    extra_args: EXTRA_CONF_FILE="overlay-qemu_802154.conf"
     platform_allow: qemu_x86
   sample.net.sockets.echo_client.802154.rf2xx:
-    extra_args: OVERLAY_CONFIG="overlay-802154.conf"
+    extra_args: EXTRA_CONF_FILE="overlay-802154.conf"
     platform_allow: samr21_xpro
   sample.net.sockets.echo_client.802154.rf2xx.xplained:
     extra_args:
       - SHIELD=atmel_rf2xx_xplained
-      - OVERLAY_CONFIG="overlay-802154.conf"
+      - EXTRA_CONF_FILE="overlay-802154.conf"
     platform_allow: sam4s_xplained
   sample.net.sockets.echo_client.802154.rf2xx.xpro:
     extra_args:
       - SHIELD=atmel_rf2xx_xpro
-      - OVERLAY_CONFIG="overlay-802154.conf"
+      - EXTRA_CONF_FILE="overlay-802154.conf"
     platform_allow:
       - sam4e_xpro
       - sam_v71_xult/samv71q21
@@ -41,7 +41,7 @@ tests:
   sample.net.sockets.echo_client.802154.rf2xx.legacy:
     extra_args:
       - SHIELD=atmel_rf2xx_legacy
-      - OVERLAY_CONFIG="overlay-802154.conf"
+      - EXTRA_CONF_FILE="overlay-802154.conf"
     platform_allow:
       - sam4e_xpro
       - sam_v71_xult/samv71q21
@@ -50,7 +50,7 @@ tests:
   sample.net.sockets.echo_client.802154.rf2xx.arduino:
     extra_args:
       - SHIELD=atmel_rf2xx_arduino
-      - OVERLAY_CONFIG="overlay-802154.conf"
+      - EXTRA_CONF_FILE="overlay-802154.conf"
     platform_allow:
       - sam_v71_xult/samv71q21
       - frdm_k64f
@@ -60,18 +60,18 @@ tests:
   sample.net.sockets.echo_client.802154.rf2xx.mikrobus:
     extra_args:
       - SHIELD=atmel_rf2xx_mikrobus
-      - OVERLAY_CONFIG="overlay-802154.conf"
+      - EXTRA_CONF_FILE="overlay-802154.conf"
     platform_allow: lpcxpresso55s69/lpc55s69/cpu0/ns
   sample.net.sockets.echo_client.mcr20a:
     extra_args:
       - SHIELD=frdm_cr20a
-      - OVERLAY_CONFIG=overlay-802154.conf
+      - EXTRA_CONF_FILE=overlay-802154.conf
     platform_allow: frdm_k64f
   sample.net.sockets.echo_client.nrf_802154:
-    extra_args: OVERLAY_CONFIG="overlay-802154.conf"
+    extra_args: EXTRA_CONF_FILE="overlay-802154.conf"
     platform_allow: nrf52840dk/nrf52840
   sample.net.sockets.echo_client.nrf_openthread:
-    extra_args: OVERLAY_CONFIG="overlay-ot.conf"
+    extra_args: EXTRA_CONF_FILE="overlay-ot.conf"
     slow: true
     tags:
       - net
@@ -79,10 +79,10 @@ tests:
     platform_allow: nrf52840dk/nrf52840
     filter: CONFIG_FULL_LIBC_SUPPORTED and not CONFIG_NATIVE_LIBC
   sample.net.sockets.echo_client.b91_802154:
-    extra_args: OVERLAY_CONFIG="overlay-802154.conf"
+    extra_args: EXTRA_CONF_FILE="overlay-802154.conf"
     platform_allow: tlsr9518adk80d
   sample.net.sockets.echo_client.b91_openthread:
-    extra_args: OVERLAY_CONFIG="overlay-ot.conf"
+    extra_args: EXTRA_CONF_FILE="overlay-ot.conf"
     slow: true
     tags:
       - net
@@ -90,7 +90,7 @@ tests:
     platform_allow: tlsr9518adk80d
     filter: CONFIG_FULL_LIBC_SUPPORTED and not CONFIG_NATIVE_LIBC
   sample.net.sockets.echo_client.kw41z_openthread:
-    extra_args: OVERLAY_CONFIG="overlay-ot.conf"
+    extra_args: EXTRA_CONF_FILE="overlay-ot.conf"
     slow: true
     tags:
       - net
@@ -100,7 +100,7 @@ tests:
   sample.net.sockets.echo_client.userspace:
     extra_args:
       - CONFIG_USERSPACE=y
-      - OVERLAY_CONFIG="overlay-e1000.conf"
+      - EXTRA_CONF_FILE="overlay-e1000.conf"
     platform_allow:
       - qemu_x86
       - qemu_x86_64

--- a/samples/net/sockets/echo_server/sample.yaml
+++ b/samples/net/sockets/echo_server/sample.yaml
@@ -22,19 +22,19 @@ tests:
     integration_platforms:
       - qemu_x86
   sample.net.sockets.echo_server.802154:
-    extra_args: OVERLAY_CONFIG="overlay-qemu_802154.conf"
+    extra_args: EXTRA_CONF_FILE="overlay-qemu_802154.conf"
     platform_allow: qemu_x86
     integration_platforms:
       - qemu_x86
   sample.net.sockets.echo_server.802154.rf2xx.xplained:
     extra_args:
       - SHIELD=atmel_rf2xx_xplained
-      - OVERLAY_CONFIG="overlay-802154.conf"
+      - EXTRA_CONF_FILE="overlay-802154.conf"
     platform_allow: sam4s_xplained
   sample.net.sockets.echo_server.802154.rf2xx.xpro:
     extra_args:
       - SHIELD=atmel_rf2xx_xpro
-      - OVERLAY_CONFIG="overlay-802154.conf"
+      - EXTRA_CONF_FILE="overlay-802154.conf"
     platform_allow:
       - sam4e_xpro
       - sam_v71_xult/samv71q21
@@ -43,7 +43,7 @@ tests:
   sample.net.sockets.echo_server.802154.rf2xx.legacy:
     extra_args:
       - SHIELD=atmel_rf2xx_legacy
-      - OVERLAY_CONFIG="overlay-802154.conf"
+      - EXTRA_CONF_FILE="overlay-802154.conf"
     platform_allow:
       - sam4e_xpro
       - sam_v71_xult/samv71q21
@@ -52,7 +52,7 @@ tests:
   sample.net.sockets.echo_server.802154.rf2xx.arduino:
     extra_args:
       - SHIELD=atmel_rf2xx_arduino
-      - OVERLAY_CONFIG="overlay-802154.conf"
+      - EXTRA_CONF_FILE="overlay-802154.conf"
     platform_allow:
       - sam_v71_xult/samv71q21
       - frdm_k64f
@@ -62,23 +62,23 @@ tests:
   sample.net.sockets.echo_server.802154.rf2xx.mikrobus:
     extra_args:
       - SHIELD=atmel_rf2xx_mikrobus
-      - OVERLAY_CONFIG="overlay-802154.conf"
+      - EXTRA_CONF_FILE="overlay-802154.conf"
     platform_allow: lpcxpresso55s69/lpc55s69/cpu0/ns
   sample.net.sockets.echo_server.mcr20a:
     extra_args:
       - SHIELD=frdm_cr20a
-      - OVERLAY_CONFIG=overlay-802154.conf
+      - EXTRA_CONF_FILE=overlay-802154.conf
     platform_allow: frdm_k64f
   sample.net.sockets.echo_server.nrf_802154:
-    extra_args: OVERLAY_CONFIG="overlay-802154.conf"
+    extra_args: EXTRA_CONF_FILE="overlay-802154.conf"
     platform_allow: nrf52840dk/nrf52840
   sample.net.sockets.echo_server.b91_802154:
-    extra_args: OVERLAY_CONFIG="overlay-802154.conf"
+    extra_args: EXTRA_CONF_FILE="overlay-802154.conf"
     platform_allow: tlsr9518adk80d
   sample.net.sockets.echo_server.usbnet:
     depends_on: usb_device
     harness: net
-    extra_args: OVERLAY_CONFIG="overlay-netusb.conf"
+    extra_args: EXTRA_CONF_FILE="overlay-netusb.conf"
     tags:
       - net
       - usb
@@ -89,7 +89,7 @@ tests:
       - native_posix
       - native_posix/native/64
   sample.net.sockets.echo_server.nrf_openthread:
-    extra_args: OVERLAY_CONFIG="overlay-ot.conf"
+    extra_args: EXTRA_CONF_FILE="overlay-ot.conf"
     slow: true
     tags:
       - net
@@ -97,7 +97,7 @@ tests:
     platform_allow: nrf52840dk/nrf52840
     filter: CONFIG_FULL_LIBC_SUPPORTED and not CONFIG_NATIVE_LIBC
   sample.net.sockets.echo_server.b91_openthread:
-    extra_args: OVERLAY_CONFIG="overlay-ot.conf"
+    extra_args: EXTRA_CONF_FILE="overlay-ot.conf"
     slow: true
     tags:
       - net
@@ -105,7 +105,7 @@ tests:
     platform_allow: tlsr9518adk80d
     filter: CONFIG_FULL_LIBC_SUPPORTED and not CONFIG_NATIVE_LIBC
   sample.net.sockets.echo_server.kw41z_openthread:
-    extra_args: OVERLAY_CONFIG="overlay-ot.conf"
+    extra_args: EXTRA_CONF_FILE="overlay-ot.conf"
     slow: true
     tags:
       - net
@@ -113,23 +113,23 @@ tests:
     platform_allow: frdm_kw41z
     filter: CONFIG_FULL_LIBC_SUPPORTED and not CONFIG_NATIVE_LIBC
   sample.net.sockets.echo_server.e1000:
-    extra_args: OVERLAY_CONFIG="overlay-e1000.conf"
+    extra_args: EXTRA_CONF_FILE="overlay-e1000.conf"
     tags: net
     platform_allow:
       - qemu_x86
       - qemu_x86_64
   sample.net.sockets.echo_server.stellaris:
-    extra_args: OVERLAY_CONFIG="overlay-qemu_cortex_m3_eth.conf"
+    extra_args: EXTRA_CONF_FILE="overlay-qemu_cortex_m3_eth.conf"
     tags: net
     platform_allow: qemu_cortex_m3
   sample.net.sockets.echo_server.smsc911x:
-    extra_args: OVERLAY_CONFIG="overlay-smsc911x.conf"
+    extra_args: EXTRA_CONF_FILE="overlay-smsc911x.conf"
     tags: net
     platform_allow: mps2/an385
   sample.net.sockets.echo_server.userspace:
     extra_args:
       - CONFIG_USERSPACE=y
-      - OVERLAY_CONFIG="overlay-e1000.conf"
+      - EXTRA_CONF_FILE="overlay-e1000.conf"
       - CONFIG_MAX_THREAD_BYTES=3
     platform_allow:
       - qemu_x86
@@ -141,7 +141,7 @@ tests:
       - native_sim
       - native_sim/native/64
     extra_args:
-      - OVERLAY_CONFIG="overlay-nsos.conf"
+      - EXTRA_CONF_FILE="overlay-nsos.conf"
   sample.net.sockets.echo_server.802154.subg:
     extra_args: EXTRA_CONF_FILE="overlay-802154-subg.conf"
     platform_allow: beagleconnect_freedom

--- a/samples/net/sockets/http_get/sample.yaml
+++ b/samples/net/sockets/http_get/sample.yaml
@@ -41,7 +41,7 @@ tests:
     platform_allow:
       - native_sim
       - native_sim/native/64
-    extra_args: OVERLAY_CONFIG="overlay-nsos.conf"
+    extra_args: EXTRA_CONF_FILE="overlay-nsos.conf"
   sample.net.sockets.http_get.nsos.https:
     harness: console
     harness_config:
@@ -54,7 +54,7 @@ tests:
     platform_allow:
       - native_sim
       - native_sim/native/64
-    extra_args: OVERLAY_CONFIG="overlay-nsos.conf;overlay-tls.conf"
+    extra_args: EXTRA_CONF_FILE="overlay-nsos.conf;overlay-tls.conf"
   sample.net.sockets.http_get.wifi.nrf70dk:
     extra_args:
       - SNIPPET=wifi-ipv4

--- a/samples/net/zperf/sample.yaml
+++ b/samples/net/zperf/sample.yaml
@@ -34,7 +34,7 @@ tests:
     platform_allow: qemu_x86
   sample.net.zperf.netusb_ecm:
     harness: net
-    extra_args: OVERLAY_CONFIG="overlay-netusb.conf"
+    extra_args: EXTRA_CONF_FILE="overlay-netusb.conf"
     tags:
       - usb
       - net
@@ -46,14 +46,14 @@ tests:
       - native_sim/native/64
   sample.net.zperf.device_next_ecm:
     harness: net
-    extra_args: OVERLAY_CONFIG="overlay-usbd_next_ecm.conf"
+    extra_args: EXTRA_CONF_FILE="overlay-usbd_next_ecm.conf"
                 DTC_OVERLAY_FILE="usbd_next_ecm.overlay"
     platform_allow: nrf52840dk/nrf52840 frdm_k64f
     tags: usb net zperf
     depends_on: usb_device
   sample.net.zperf.netusb_eem:
     harness: net
-    extra_args: OVERLAY_CONFIG="overlay-netusb.conf"
+    extra_args: EXTRA_CONF_FILE="overlay-netusb.conf"
     extra_configs:
       - CONFIG_USB_DEVICE_NETWORK_ECM=n
       - CONFIG_USB_DEVICE_NETWORK_EEM=y
@@ -68,7 +68,7 @@ tests:
       - native_sim/native/64
   sample.net.zperf.netusb_rndis:
     harness: net
-    extra_args: OVERLAY_CONFIG="overlay-netusb.conf"
+    extra_args: EXTRA_CONF_FILE="overlay-netusb.conf"
     extra_configs:
       - CONFIG_USB_DEVICE_NETWORK_ECM=n
       - CONFIG_USB_DEVICE_NETWORK_RNDIS=y

--- a/samples/subsys/fs/fs_sample/sample.yaml
+++ b/samples/subsys/fs/fs_sample/sample.yaml
@@ -47,13 +47,13 @@ tests:
     build_only: true
     platform_allow: nrf52840dk/nrf52840
     extra_args:
-      - OVERLAY_CONFIG=boards/nrf52840dk_nrf52840_ram_disk.conf
+      - EXTRA_CONF_FILE=boards/nrf52840dk_nrf52840_ram_disk.conf
       - DTC_OVERLAY_FILE=boards/nrf52840dk_nrf52840_ram_disk.overlay
   sample.filesystem.fat_fs.nrf52840dk_nrf52840_ram_disk_region:
     build_only: true
     platform_allow: nrf52840dk/nrf52840
     extra_args:
-      - OVERLAY_CONFIG=boards/nrf52840dk_nrf52840_ram_disk.conf
+      - EXTRA_CONF_FILE=boards/nrf52840dk_nrf52840_ram_disk.conf
       - DTC_OVERLAY_FILE=boards/nrf52840dk_nrf52840_ram_disk_region.overlay
   sample.filesystem.fat_fs.nrf54l15pdk:
     build_only: true
@@ -65,7 +65,7 @@ tests:
     build_only: true
     platform_allow: nrf52840dk/nrf52840
     extra_args:
-      - OVERLAY_CONFIG=boards/nrf52840dk_nrf52840_qspi.conf
+      - EXTRA_CONF_FILE=boards/nrf52840dk_nrf52840_qspi.conf
       - DTC_OVERLAY_FILE=boards/nrf52840dk_nrf52840_qspi.overlay
   sample.filesystem.fat_fs.has_sdmmc_disk:
     build_only: true

--- a/samples/subsys/fs/littlefs/sample.yaml
+++ b/samples/subsys/fs/littlefs/sample.yaml
@@ -40,19 +40,19 @@ tests:
     build_only: true
     platform_allow: nrf52840dk/nrf52840
     extra_args:
-      - OVERLAY_CONFIG=boards/nrf52840dk_nrf52840_spi.conf
+      - EXTRA_CONF_FILE=boards/nrf52840dk_nrf52840_spi.conf
       - DTC_OVERLAY_FILE=boards/nrf52840dk_nrf52840_spi.overlay
   sample.filesystem.littlefs.nrf52840dk_qspi:
     build_only: true
     platform_allow: nrf52840dk/nrf52840
     extra_args:
-      - OVERLAY_CONFIG=boards/nrf52840dk_nrf52840_qspi.conf
+      - EXTRA_CONF_FILE=boards/nrf52840dk_nrf52840_qspi.conf
       - DTC_OVERLAY_FILE=boards/nrf52840dk_nrf52840_qspi.overlay
   sample.filesystem.littlefs.stm32h747i_disco_m7_blk:
     build_only: true
     platform_allow: stm32h747i_disco/stm32h747xx/m7
     extra_args:
-      - OVERLAY_CONFIG=boards/stm32_blk.conf
+      - EXTRA_CONF_FILE=boards/stm32_blk.conf
       - CONF_FILE=prj_blk.conf
     extra_configs:
       - CONFIG_SDMMC_STM32_HWFC=y
@@ -60,23 +60,23 @@ tests:
     build_only: true
     platform_allow: nucleo_h743zi
     extra_args:
-      - OVERLAY_CONFIG=boards/nucleo_h743zi_qspi.conf
+      - EXTRA_CONF_FILE=boards/nucleo_h743zi_qspi.conf
   sample.filesystem.littlefs.nucleo_h743zi_blk:
     build_only: true
     platform_allow: nucleo_h743zi
     extra_args:
-      - OVERLAY_CONFIG=boards/nucleo_h743zi_blk.conf
+      - EXTRA_CONF_FILE=boards/nucleo_h743zi_blk.conf
       - CONF_FILE=prj_blk.conf
   sample.filesystem.littlefs.stm32l562e_dk_ospi:
     build_only: true
     platform_allow: stm32l562e_dk
     extra_args:
-      - OVERLAY_CONFIG=boards/stm32l562e_dk_ospi.conf
+      - EXTRA_CONF_FILE=boards/stm32l562e_dk_ospi.conf
   sample.filesystem.littlefs.stm32f746g_disco_blk:
     build_only: true
     platform_allow: stm32f746g_disco
     extra_args:
-      - OVERLAY_CONFIG=boards/stm32_blk.conf
+      - EXTRA_CONF_FILE=boards/stm32_blk.conf
       - CONF_FILE=prj_blk.conf
     extra_configs:
       - CONFIG_SDMMC_STM32_HWFC=y

--- a/samples/subsys/logging/logger/sample.yaml
+++ b/samples/subsys/logging/logger/sample.yaml
@@ -42,7 +42,7 @@ tests:
     arch_exclude:
       - posix
     extra_args:
-      - OVERLAY_CONFIG="overlay-bt.conf"
+      - EXTRA_CONF_FILE="overlay-bt.conf"
       - DTC_OVERLAY_FILE="bt.overlay"
 
   sample.logger.usermode:

--- a/samples/subsys/logging/syst/sample.yaml
+++ b/samples/subsys/logging/syst/sample.yaml
@@ -17,7 +17,7 @@ tests:
     integration_platforms:
       - mps2/an385
       - qemu_x86
-    extra_args: OVERLAY_CONFIG=overlay_deferred.conf
+    extra_args: EXTRA_CONF_FILE=overlay_deferred.conf
     harness: console
     harness_config:
       type: multi_line
@@ -35,7 +35,7 @@ tests:
       - CONFIG_REQUIRES_FULL_LIBC=y
   sample.logger.syst.immediate:
     toolchain_exclude: xcc
-    extra_args: OVERLAY_CONFIG=overlay_immediate.conf
+    extra_args: EXTRA_CONF_FILE=overlay_immediate.conf
     integration_platforms:
       - qemu_x86
       - sam_e70_xplained/same70q21
@@ -50,7 +50,7 @@ tests:
       - CONFIG_REQUIRES_FULL_LIBC=y
   sample.logger.syst.catalog.deferred:
     toolchain_exclude: xcc
-    extra_args: OVERLAY_CONFIG=overlay_deferred.conf
+    extra_args: EXTRA_CONF_FILE=overlay_deferred.conf
     integration_platforms:
       - qemu_x86
       - qemu_x86_64
@@ -79,7 +79,7 @@ tests:
     filter: CONFIG_FULL_LIBC_SUPPORTED
   sample.logger.syst.deferred_cpp:
     toolchain_exclude: xcc
-    extra_args: OVERLAY_CONFIG=overlay_deferred.conf
+    extra_args: EXTRA_CONF_FILE=overlay_deferred.conf
     integration_platforms:
       - qemu_x86
       - qemu_x86_64
@@ -108,7 +108,7 @@ tests:
     filter: CONFIG_FULL_LIBC_SUPPORTED
   sample.logger.syst.catalog.deferred_cpp:
     toolchain_exclude: xcc
-    extra_args: OVERLAY_CONFIG=overlay_deferred.conf
+    extra_args: EXTRA_CONF_FILE=overlay_deferred.conf
     integration_platforms:
       - qemu_x86
       - qemu_x86_64

--- a/samples/subsys/mgmt/mcumgr/smp_svr/sample.yaml
+++ b/samples/subsys/mgmt/mcumgr/smp_svr/sample.yaml
@@ -6,7 +6,7 @@ common:
   tags: bluetooth
 tests:
   sample.mcumgr.smp_svr.bt:
-    extra_args: OVERLAY_CONFIG="overlay-bt.conf"
+    extra_args: EXTRA_CONF_FILE="overlay-bt.conf"
     platform_allow:
       - nrf52dk/nrf52832
       - nrf52840dk/nrf52840
@@ -16,7 +16,7 @@ tests:
       - nrf52dk/nrf52832
       - nrf52840dk/nrf52840
   sample.mcumgr.smp_svr.bt_static_svc:
-    extra_args: OVERLAY_CONFIG="overlay-bt.conf"
+    extra_args: EXTRA_CONF_FILE="overlay-bt.conf"
     extra_configs:
       - CONFIG_MCUMGR_TRANSPORT_BT_DYNAMIC_SVC_REGISTRATION=n
     platform_allow:
@@ -26,13 +26,13 @@ tests:
     integration_platforms:
       - nrf52840dk/nrf52840
   sample.mcumgr.smp_svr.udp:
-    extra_args: OVERLAY_CONFIG="overlay-udp.conf"
+    extra_args: EXTRA_CONF_FILE="overlay-udp.conf"
     platform_allow: frdm_k64f
     integration_platforms:
       - frdm_k64f
   sample.mcumgr.smp_svr.cdc:
     extra_args:
-      - OVERLAY_CONFIG="overlay-cdc.conf"
+      - EXTRA_CONF_FILE="overlay-cdc.conf"
       - DTC_OVERLAY_FILE="usb.overlay"
     platform_allow:
       - nrf52833dk/nrf52820
@@ -46,7 +46,7 @@ tests:
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
   sample.mcumgr.smp_svr.serial:
-    extra_args: OVERLAY_CONFIG="overlay-serial.conf"
+    extra_args: EXTRA_CONF_FILE="overlay-serial.conf"
     platform_allow:
       - frdm_k22f
       - frdm_k64f
@@ -86,7 +86,7 @@ tests:
   # transport. Transport does not affect flags so it does not really matter which is selected,
   # flags should affect any transport the same way.
   sample.mcumgr.smp_svr.mcuboot_flags.direct_xip_withrevert:
-    extra_args: OVERLAY_CONFIG="overlay-serial.conf"
+    extra_args: EXTRA_CONF_FILE="overlay-serial.conf"
     extra_configs:
       - CONFIG_MCUBOOT_BOOTLOADER_MODE_DIRECT_XIP_WITH_REVERT=y
     platform_allow:
@@ -96,7 +96,7 @@ tests:
     integration_platforms:
       - nrf52840dk/nrf52840
   sample.mcumgr.smp_svr.serial-console:
-    extra_args: OVERLAY_CONFIG="overlay-serial-console.conf"
+    extra_args: EXTRA_CONF_FILE="overlay-serial-console.conf"
     platform_allow:
       - nrf52840dk/nrf52840
       - pinnacle_100_dvk
@@ -104,7 +104,7 @@ tests:
     integration_platforms:
       - nrf52840dk/nrf52840
   sample.mcumgr.smp_svr.shell:
-    extra_args: OVERLAY_CONFIG="overlay-shell.conf"
+    extra_args: EXTRA_CONF_FILE="overlay-shell.conf"
     platform_allow:
       - frdm_k22f
       - frdm_k64f
@@ -143,7 +143,7 @@ tests:
       - mimxrt1060_evk
       - mimxrt1064_evk
   sample.mcumgr.smp_svr.shell_mgmt:
-    extra_args: OVERLAY_CONFIG="overlay-shell-mgmt.conf"
+    extra_args: EXTRA_CONF_FILE="overlay-shell-mgmt.conf"
     platform_allow:
       - nrf52840dk/nrf52840
       - pinnacle_100_dvk
@@ -151,7 +151,7 @@ tests:
     integration_platforms:
       - nrf52840dk/nrf52840
   sample.mcumgr.smp_svr.fs:
-    extra_args: OVERLAY_CONFIG="overlay-fs.conf"
+    extra_args: EXTRA_CONF_FILE="overlay-fs.conf"
     platform_allow:
       - nrf52840dk/nrf52840
       - pinnacle_100_dvk

--- a/samples/subsys/mgmt/updatehub/sample.yaml
+++ b/samples/subsys/mgmt/updatehub/sample.yaml
@@ -20,7 +20,7 @@ tests:
       - CONFIG_UPDATEHUB_CE=y
       - CONFIG_UPDATEHUB_SERVER="updatehub.io"
   sample.net.updatehub.psa:
-    extra_args: OVERLAY_CONFIG="overlay-psa.conf"
+    extra_args: EXTRA_CONF_FILE="overlay-psa.conf"
     extra_configs:
       - CONFIG_UPDATEHUB_PRODUCT_UID="e4d37cfe6ec48a2d069cc0bbb8b078677e9a0d8df3a027c4d8ea131130c4265f"
       - CONFIG_UPDATEHUB_POLL_INTERVAL=1
@@ -34,7 +34,7 @@ tests:
       - CONFIG_UPDATEHUB_SERVER="updatehub.io"
       - CONFIG_USERSPACE=y
   sample.net.updatehub.dtls:
-    extra_args: OVERLAY_CONFIG="overlay-dtls.conf"
+    extra_args: EXTRA_CONF_FILE="overlay-dtls.conf"
     extra_configs:
       - CONFIG_UPDATEHUB_PRODUCT_UID="e4d37cfe6ec48a2d069cc0bbb8b078677e9a0d8df3a027c4d8ea131130c4265f"
       - CONFIG_UPDATEHUB_POLL_INTERVAL=1

--- a/samples/subsys/modbus/rtu_server/sample.yaml
+++ b/samples/subsys/modbus/rtu_server/sample.yaml
@@ -31,6 +31,6 @@ tests:
             dt_enabled_alias_with_parent_compat("led1", "gpio-leds") and
             dt_enabled_alias_with_parent_compat("led2", "gpio-leds")
     extra_args:
-      - OVERLAY_CONFIG="overlay-cdc-acm.conf"
+      - EXTRA_CONF_FILE="overlay-cdc-acm.conf"
       - DTC_OVERLAY_FILE="cdc-acm.overlay"
     depends_on: usb_device

--- a/samples/subsys/shell/devmem_load/sample.yaml
+++ b/samples/subsys/shell/devmem_load/sample.yaml
@@ -10,7 +10,7 @@ tests:
   sample.devmem_load.polled:
     integration_platforms:
       - native_sim
-    extra_args: OVERLAY_CONFIG="prj_poll.conf"
+    extra_args: EXTRA_CONF_FILE="prj_poll.conf"
   sample.devmem_load.uart.interrupt:
     integration_platforms:
       - frdm_k64f

--- a/samples/subsys/shell/shell_module/sample.yaml
+++ b/samples/subsys/shell/shell_module/sample.yaml
@@ -22,7 +22,7 @@ tests:
     harness: keyboard
     min_ram: 40
     extra_args:
-      - OVERLAY_CONFIG="overlay-usb.conf"
+      - EXTRA_CONF_FILE="overlay-usb.conf"
       - DTC_OVERLAY_FILE="usb.overlay"
     integration_platforms:
       - native_sim
@@ -62,7 +62,7 @@ tests:
     arch_exclude:
       - posix
     extra_args:
-      - OVERLAY_CONFIG="overlay-bt.conf"
+      - EXTRA_CONF_FILE="overlay-bt.conf"
       - DTC_OVERLAY_FILE="bt.overlay"
   sample.shell.shell_module.login:
     filter: CONFIG_SERIAL and dt_chosen_enabled("zephyr,shell-uart")

--- a/samples/subsys/usb/dfu/sample.yaml
+++ b/samples/subsys/usb/dfu/sample.yaml
@@ -32,4 +32,4 @@ tests:
     tags: usb
   sample.usb.dfu.permanent.download:
     tags: usb
-    extra_args: OVERLAY_CONFIG=overlay-permanent-download.conf
+    extra_args: EXTRA_CONF_FILE=overlay-permanent-download.conf

--- a/tests/boot/mcuboot_recovery_retention/testcase.yaml
+++ b/tests/boot/mcuboot_recovery_retention/testcase.yaml
@@ -30,7 +30,7 @@ tests:
   bootloader.mcuboot.recovery.retention.mem:
     platform_allow: nrf52840dk/nrf52840
     extra_args:
-      - OVERLAY_CONFIG="boards/nrf52840dk_nrf52840_mem.conf"
+      - EXTRA_CONF_FILE="boards/nrf52840dk_nrf52840_mem.conf"
       - DTC_OVERLAY_FILE="boards/nrf52840dk_nrf52840_mem.overlay"
       - mcuboot_TARGET_OVERLAY_CONFIG="boards/nrf52840dk_nrf52840_mem.conf"
       - mcuboot_TARGET_DTC_OVERLAY_FILE="boards/nrf52840dk_nrf52840_mem.overlay"

--- a/tests/crypto/secp256r1/testcase.yaml
+++ b/tests/crypto/secp256r1/testcase.yaml
@@ -10,8 +10,8 @@ common:
     - p256-m
 tests:
   crypto.secp256r1.mbedtls:
-    extra_args: OVERLAY_CONFIG=mbedtls.conf
+    extra_args: EXTRA_CONF_FILE=mbedtls.conf
   crypto.secp256r1.p256-m_raw:
-    extra_args: OVERLAY_CONFIG=p256-m_raw.conf
+    extra_args: EXTRA_CONF_FILE=p256-m_raw.conf
   crypto.secp256r1.tinycrypt:
-    extra_args: OVERLAY_CONFIG=tinycrypt.conf
+    extra_args: EXTRA_CONF_FILE=tinycrypt.conf

--- a/tests/drivers/adc/adc_api/testcase.yaml
+++ b/tests/drivers/adc/adc_api/testcase.yaml
@@ -16,7 +16,7 @@ tests:
       - b_u585i_iot02a
   drivers.adc.dma_st_stm32:
     extra_args:
-      - OVERLAY_CONFIG="overlay-dma-stm32.conf"
+      - EXTRA_CONF_FILE="overlay-dma-stm32.conf"
     depends_on:
       - adc
       - dma
@@ -45,7 +45,7 @@ tests:
       - stm32u083c_dk
   drivers.adc.dma_nxp_kinetis:
     extra_args:
-      - OVERLAY_CONFIG="overlay-dma-kinetis.conf"
+      - EXTRA_CONF_FILE="overlay-dma-kinetis.conf"
     depends_on:
       - adc
       - dma
@@ -57,7 +57,7 @@ tests:
       - frdm_k82f
   drivers.adc.dma_espressif:
     extra_args:
-      - OVERLAY_CONFIG="overlay-dma-esp32.conf"
+      - EXTRA_CONF_FILE="overlay-dma-esp32.conf"
     depends_on:
       - adc
       - dma

--- a/tests/drivers/bbram/testcase.yaml
+++ b/tests/drivers/bbram/testcase.yaml
@@ -18,13 +18,13 @@ tests:
     integration_platforms:
       - npcx9m6f_evb
   drivers.bbram.stm32:
-    extra_args: OVERLAY_CONFIG="stm32.conf"
+    extra_args: EXTRA_CONF_FILE="stm32.conf"
     filter: dt_compat_enabled("st,stm32-bbram")
     integration_platforms:
       - nucleo_g071rb
       - stm32f746g_disco
   drivers.bbram.stm32_rtc:
-    extra_args: OVERLAY_CONFIG="stm32_rtc.conf"
+    extra_args: EXTRA_CONF_FILE="stm32_rtc.conf"
     filter: dt_compat_enabled("st,stm32-bbram")
     integration_platforms:
       - nucleo_g071rb

--- a/tests/drivers/build_all/sensor/testcase.yaml
+++ b/tests/drivers/build_all/sensor/testcase.yaml
@@ -9,18 +9,18 @@ common:
   build_only: true
 tests:
   sensors.build.sensorhub:
-    extra_args: OVERLAY_CONFIG=sensors_shub.conf;sensors_die_temp.conf
+    extra_args: EXTRA_CONF_FILE=sensors_shub.conf;sensors_die_temp.conf
   sensors.build.trigger.own:
-    extra_args: OVERLAY_CONFIG=sensors_trigger_own.conf;sensors_die_temp.conf
+    extra_args: EXTRA_CONF_FILE=sensors_trigger_own.conf;sensors_die_temp.conf
   sensors.build.trigger.global:
-    extra_args: OVERLAY_CONFIG=sensors_trigger_global.conf;sensors_die_temp.conf
+    extra_args: EXTRA_CONF_FILE=sensors_trigger_global.conf;sensors_die_temp.conf
   sensors.build.trigger.none:
-    extra_args: OVERLAY_CONFIG=sensors_trigger_none.conf;sensors_die_temp.conf
+    extra_args: EXTRA_CONF_FILE=sensors_trigger_none.conf;sensors_die_temp.conf
   sensors.build.no_default:
-    extra_args: OVERLAY_CONFIG=sensors_no_default.conf
+    extra_args: EXTRA_CONF_FILE=sensors_no_default.conf
   sensors.build:
     tags: sensors
-    extra_args: OVERLAY_CONFIG=sensors_die_temp.conf
+    extra_args: EXTRA_CONF_FILE=sensors_die_temp.conf
     extra_configs:
       - CONFIG_UART_INTERRUPT_DRIVEN=y
   sensors.build.pm:

--- a/tests/drivers/eeprom/api/testcase.yaml
+++ b/tests/drivers/eeprom/api/testcase.yaml
@@ -18,7 +18,7 @@ tests:
     # Tests overwrite EEPROM content, only run on select boards
     extra_args:
       - DTC_OVERLAY_FILE=at2x_emul.overlay
-      - OVERLAY_CONFIG=at2x_emul.conf
+      - EXTRA_CONF_FILE=at2x_emul.conf
     platform_allow:
       - native_sim
       - native_sim/native/64

--- a/tests/drivers/entropy/api/testcase.yaml
+++ b/tests/drivers/entropy/api/testcase.yaml
@@ -10,7 +10,7 @@ tests:
       - nrf5340bsim/nrf5340/cpunet
     extra_args:
       - DTC_OVERLAY_FILE=./entropy_bt_hci.overlay
-      - OVERLAY_CONFIG=./entropy_bt_hci.conf
+      - EXTRA_CONF_FILE=./entropy_bt_hci.conf
     tags:
       - driver
       - entropy
@@ -19,7 +19,7 @@ tests:
     filter: CONFIG_BUILD_WITH_TFM
     extra_args:
       - DTC_OVERLAY_FILE=./entropy_psa_crypto.overlay
-      - OVERLAY_CONFIG=./entropy_psa_crypto.conf
+      - EXTRA_CONF_FILE=./entropy_psa_crypto.conf
     tags:
       - driver
       - entropy

--- a/tests/drivers/flash/common/testcase.yaml
+++ b/tests/drivers/flash/common/testcase.yaml
@@ -5,20 +5,20 @@ common:
 tests:
   drivers.flash.common.nrf_qspi_nor:
     platform_allow: nrf52840dk/nrf52840
-    extra_args: OVERLAY_CONFIG=boards/nrf52840dk_nrf52840_qspi_nor.conf
+    extra_args: EXTRA_CONF_FILE=boards/nrf52840dk_nrf52840_qspi_nor.conf
     integration_platforms:
       - nrf52840dk/nrf52840
   drivers.flash.common.nrf_qspi_nor.size_in_bytes:
     platform_allow: nrf52840dk/nrf52840
     extra_args:
-      - OVERLAY_CONFIG=boards/nrf52840dk_nrf52840_qspi_nor.conf
+      - EXTRA_CONF_FILE=boards/nrf52840dk_nrf52840_qspi_nor.conf
       - DTC_OVERLAY_FILE=boards/nrf52840_size_in_bytes.overlay
     integration_platforms:
       - nrf52840dk/nrf52840
   drivers.flash.common.nrf_qspi_nor_4B_addr:
     platform_allow: nrf52840dk/nrf52840
     extra_args:
-      - OVERLAY_CONFIG=boards/nrf52840dk_nrf52840_qspi_nor.conf
+      - EXTRA_CONF_FILE=boards/nrf52840dk_nrf52840_qspi_nor.conf
       - DTC_OVERLAY_FILE=boards/nrf52840dk_mx25l51245g.overlay
     harness_config:
       fixture: external_flash_mx25l51245g
@@ -26,7 +26,7 @@ tests:
       - nrf52840dk/nrf52840
   drivers.flash.common.soc_flash_nrf:
     platform_allow: nrf52840dk/nrf52840
-    extra_args: OVERLAY_CONFIG=boards/nrf52840dk_nrf52840_soc.conf
+    extra_args: EXTRA_CONF_FILE=boards/nrf52840dk_nrf52840_soc.conf
     integration_platforms:
       - nrf52840dk/nrf52840
   drivers.flash.common.default:
@@ -71,7 +71,7 @@ tests:
   drivers.flash.common.mx25r_high_perf:
     platform_allow: nrf52840dk/nrf52840
     extra_args:
-      - OVERLAY_CONFIG=boards/nrf52840dk_flash_spi.conf
+      - EXTRA_CONF_FILE=boards/nrf52840dk_flash_spi.conf
       - DTC_OVERLAY_FILE=boards/nrf52840dk_mx25r_high_perf.overlay
     integration_platforms:
       - nrf52840dk/nrf52840
@@ -82,14 +82,14 @@ tests:
   drivers.flash.common.spi_nor:
     platform_allow: nrf52840dk/nrf52840
     extra_args:
-      - OVERLAY_CONFIG=boards/nrf52840dk_flash_spi.conf
+      - EXTRA_CONF_FILE=boards/nrf52840dk_flash_spi.conf
       - DTC_OVERLAY_FILE=boards/nrf52840dk_spi_nor.overlay
     harness_config:
       fixture: external_flash_mx25v1635f
   drivers.flash.common.spi_nor_wp_hold:
     platform_allow: nrf52840dk/nrf52840
     extra_args:
-      - OVERLAY_CONFIG=boards/nrf52840dk_flash_spi.conf
+      - EXTRA_CONF_FILE=boards/nrf52840dk_flash_spi.conf
       - DTC_OVERLAY_FILE=boards/nrf52840dk_spi_nor_wp_hold.overlay
     harness_config:
       fixture: external_flash_mx25v1635f

--- a/tests/drivers/retained_mem/api/testcase.yaml
+++ b/tests/drivers/retained_mem/api/testcase.yaml
@@ -13,7 +13,7 @@ tests:
     platform_allow: nrf52840dk/nrf52840
     extra_args:
       - DTC_OVERLAY_FILE="boards/nrf52840dk_nrf52840_ram.overlay"
-      - OVERLAY_CONFIG="boards/nrf52840dk_nrf52840_ram.conf"
+      - EXTRA_CONF_FILE="boards/nrf52840dk_nrf52840_ram.conf"
     tags:
       - drivers
       - retained_mem

--- a/tests/drivers/spi/spi_loopback/testcase.yaml
+++ b/tests/drivers/spi/spi_loopback/testcase.yaml
@@ -35,12 +35,12 @@ tests:
       - mimxrt1170_evk/mimxrt1176/cm7
   drivers.spi.mcux_dspi_dma.loopback:
     extra_args:
-      - OVERLAY_CONFIG="overlay-mcux-dspi-dma.conf"
+      - EXTRA_CONF_FILE="overlay-mcux-dspi-dma.conf"
       - DTC_OVERLAY_FILE="overlay-mcux-dspi-dma.overlay"
     platform_allow: frdm_k64f
   drivers.spi.sam_spi_dma.loopback:
     extra_args:
-      - OVERLAY_CONFIG="overlay-sam-spi-dma.conf"
+      - EXTRA_CONF_FILE="overlay-sam-spi-dma.conf"
       - DTC_OVERLAY_FILE="overlay-sam-spi-dma.overlay"
     platform_allow:
       - sam_e70_xplained/same70q21
@@ -50,7 +50,7 @@ tests:
       - sam_e70_xplained/same70q21
   drivers.spi.stm32_spi_16bits_frames.loopback:
     extra_args:
-      - OVERLAY_CONFIG="overlay-stm32-spi-16bits.conf"
+      - EXTRA_CONF_FILE="overlay-stm32-spi-16bits.conf"
       - DTC_OVERLAY_FILE="overlay-stm32-spi-16bits.overlay"
     filter: CONFIG_SOC_FAMILY_STM32
     platform_allow:
@@ -59,7 +59,7 @@ tests:
       - nucleo_h745zi_q/stm32h745xx/m4
       - nucleo_h745zi_q/stm32h745xx/m7
   drivers.spi.stm32_spi_dma.loopback:
-    extra_args: OVERLAY_CONFIG="overlay-stm32-spi-dma.conf"
+    extra_args: EXTRA_CONF_FILE="overlay-stm32-spi-dma.conf"
     filter: CONFIG_SOC_FAMILY_STM32
     platform_allow:
       - b_u585i_iot02a
@@ -82,7 +82,7 @@ tests:
     # this test case is for when nocache memory region is defined in DT
     # using `zephyr,memory-attr = < DT_MEM_ARM_MPU_RAM_NOCACHE)>`
     extra_args:
-      - OVERLAY_CONFIG="overlay-stm32-spi-dma-dt-nocache-mem.conf"
+      - EXTRA_CONF_FILE="overlay-stm32-spi-dma-dt-nocache-mem.conf"
     filter: CONFIG_SOC_FAMILY_STM32 and CONFIG_CPU_HAS_DCACHE
     platform_allow:
       - nucleo_h743zi
@@ -91,7 +91,7 @@ tests:
       - nucleo_h745zi_q/stm32h745xx/m7
   drivers.spi.stm32_spi_16bits_frames_dma.loopback:
     extra_args:
-      - OVERLAY_CONFIG="overlay-stm32-spi-16bits-dma.conf"
+      - EXTRA_CONF_FILE="overlay-stm32-spi-16bits-dma.conf"
       - DTC_OVERLAY_FILE="overlay-stm32-spi-16bits.overlay"
     filter: CONFIG_SOC_FAMILY_STM32
     platform_allow:
@@ -101,7 +101,7 @@ tests:
       - nucleo_h745zi_q/stm32h745xx/m7
   drivers.spi.stm32_spi_16bits_frames_dma_dt_nocache_mem.loopback:
     extra_args:
-      - OVERLAY_CONFIG="overlay-stm32-spi-16bits-dma-dt-nocache-mem.conf"
+      - EXTRA_CONF_FILE="overlay-stm32-spi-16bits-dma-dt-nocache-mem.conf"
       - DTC_OVERLAY_FILE="overlay-stm32-spi-16bits.overlay"
     filter: CONFIG_SOC_FAMILY_STM32 and CONFIG_CPU_HAS_DCACHE
     platform_allow:
@@ -110,7 +110,7 @@ tests:
       - nucleo_h745zi_q/stm32h745xx/m4
       - nucleo_h745zi_q/stm32h745xx/m7
   drivers.spi.stm32_spi_interrupt.loopback:
-    extra_args: OVERLAY_CONFIG="overlay-stm32-spi-interrupt.conf"
+    extra_args: EXTRA_CONF_FILE="overlay-stm32-spi-interrupt.conf"
     filter: CONFIG_SOC_FAMILY_STM32
     platform_allow:
       - b_u585i_iot02a
@@ -129,7 +129,7 @@ tests:
       - stm32f3_disco
       - stm32h573i_dk
   drivers.spi.gd32_spi_interrupt.loopback:
-    extra_args: OVERLAY_CONFIG="overlay-gd32-spi-interrupt.conf"
+    extra_args: EXTRA_CONF_FILE="overlay-gd32-spi-interrupt.conf"
     platform_allow:
       - gd32f403z_eval
       - gd32f407v_start
@@ -142,7 +142,7 @@ tests:
       - longan_nano
       - longan_nano/gd32vf103/lite
   drivers.spi.gd32_spi_dma.loopback:
-    extra_args: OVERLAY_CONFIG="overlay-gd32-spi-dma.conf"
+    extra_args: EXTRA_CONF_FILE="overlay-gd32-spi-dma.conf"
     platform_allow:
       - gd32f403z_eval
       - gd32f407v_start
@@ -202,5 +202,5 @@ tests:
       - frdm_ke17z
       - frdm_ke17z512
   drivers.spi.max32_dma.loopback:
-    extra_args: OVERLAY_CONFIG="overlay-max32-spi-dma.conf"
+    extra_args: EXTRA_CONF_FILE="overlay-max32-spi-dma.conf"
     filter: CONFIG_SOC_FAMILY_MAX32

--- a/tests/drivers/uart/uart_basic_api/testcase.yaml
+++ b/tests/drivers/uart/uart_basic_api/testcase.yaml
@@ -39,7 +39,7 @@ tests:
       - mps2/an385
   drivers.uart.basic_api.cdc_acm:
     extra_args:
-      - OVERLAY_CONFIG="overlay-usb.conf"
+      - EXTRA_CONF_FILE="overlay-usb.conf"
       - DTC_OVERLAY_FILE="usb.overlay"
     tags:
       - drivers

--- a/tests/drivers/watchdog/wdt_basic_api/testcase.yaml
+++ b/tests/drivers/watchdog/wdt_basic_api/testcase.yaml
@@ -80,7 +80,7 @@ tests:
   drivers.watchdog.counter_watchdog:
     platform_allow: nrf52840dk/nrf52840
     extra_args:
-      - OVERLAY_CONFIG="boards/nrf52840dk_nrf52840_counter.conf"
+      - EXTRA_CONF_FILE="boards/nrf52840dk_nrf52840_counter.conf"
       - DTC_OVERLAY_FILE="boards/nrf52840dk_nrf52840_counter.overlay"
   drivers.watchdog.gd32fwdgt:
     filter: dt_compat_enabled("gd,gd32-fwdgt")

--- a/tests/lib/gui/lvgl/testcase.yaml
+++ b/tests/lib/gui/lvgl/testcase.yaml
@@ -77,6 +77,6 @@ tests:
       - CONFIG_DUMMY_DISPLAY=n
     extra_args:
       - SHIELD=st_b_lcd40_dsi1_mb1166
-      - OVERLAY_CONFIG=prj_blk.conf
+      - EXTRA_CONF_FILE=prj_blk.conf
     tags:
       - shield

--- a/tests/modules/thrift/ThriftTest/testcase.yaml
+++ b/tests/modules/thrift/ThriftTest/testcase.yaml
@@ -20,4 +20,4 @@ tests:
     extra_configs:
       - CONFIG_THRIFT_COMPACT_PROTOCOL=y
   thrift.ThriftTest.newlib.tlsTransport:
-    extra_args: OVERLAY_CONFIG="overlay-tls.conf"
+    extra_args: EXTRA_CONF_FILE="overlay-tls.conf"

--- a/tests/net/lib/tls_credentials/testcase.yaml
+++ b/tests/net/lib/tls_credentials/testcase.yaml
@@ -6,7 +6,7 @@ tests:
     depends_on: netif
   net.tls_credentials.trusted_tfm:
     filter: CONFIG_BUILD_WITH_TFM
-    extra_args: OVERLAY_CONFIG=./prj_trusted_tfm.conf
+    extra_args: EXTRA_CONF_FILE=./prj_trusted_tfm.conf
     tags:
       - net
       - tls

--- a/tests/subsys/dfu/img_util/testcase.yaml
+++ b/tests/subsys/dfu/img_util/testcase.yaml
@@ -9,5 +9,5 @@ tests:
   dfu.image_util:
     tags: dfu_image_util
   dfu.image_util.progressive:
-    extra_args: OVERLAY_CONFIG=progressively_overlay.conf
+    extra_args: EXTRA_CONF_FILE=progressively_overlay.conf
     tags: dfu_image_util

--- a/tests/subsys/logging/log_switch_format/testcase.yaml
+++ b/tests/subsys/logging/log_switch_format/testcase.yaml
@@ -15,7 +15,7 @@ tests:
     integration_platforms:
       - mps2/an385
       - qemu_x86
-    extra_args: OVERLAY_CONFIG=overlay_deferred.conf
+    extra_args: EXTRA_CONF_FILE=overlay_deferred.conf
     # "CONFIG_FULL_LIBC_SUPPORTED" filter was applied
     # because of following chain of dependencies:
     # LOG_MIPI_SYST_ENABLE=y --> CONFIG_MIPI_SYST_LIB --> \
@@ -26,7 +26,7 @@ tests:
     extra_configs:
       - CONFIG_REQUIRES_FULL_LIBC=y
   logging.format.switch.immediate:
-    extra_args: OVERLAY_CONFIG=overlay_immediate.conf
+    extra_args: EXTRA_CONF_FILE=overlay_immediate.conf
     integration_platforms:
       - mps2/an385
       - qemu_x86
@@ -34,7 +34,7 @@ tests:
     extra_configs:
       - CONFIG_REQUIRES_FULL_LIBC=y
   logging.format.switch.custom_output:
-    extra_args: OVERLAY_CONFIG=overlay_custom_output.conf
+    extra_args: EXTRA_CONF_FILE=overlay_custom_output.conf
     integration_platforms:
       - mps2/an385
       - qemu_x86

--- a/tests/subsys/mgmt/mcumgr/all_options/testcase.yaml
+++ b/tests/subsys/mgmt/mcumgr/all_options/testcase.yaml
@@ -14,4 +14,4 @@ tests:
   mgmt.mcumgr.all.options: {}
   mgmt.mcumgr.all.options.other:
     extra_args:
-      - OVERLAY_CONFIG="other-options.conf"
+      - EXTRA_CONF_FILE="other-options.conf"

--- a/tests/subsys/mgmt/mcumgr/fs_mgmt_hash_supported/testcase.yaml
+++ b/tests/subsys/mgmt/mcumgr/fs_mgmt_hash_supported/testcase.yaml
@@ -21,10 +21,10 @@ common:
 tests:
   mgmt.mcumgr.fs.mgmt.hash.supported.crc32:
     extra_args: >
-      OVERLAY_CONFIG="configuration/crc32.conf"
+      EXTRA_CONF_FILE="configuration/crc32.conf"
   mgmt.mcumgr.fs.mgmt.hash.supported.sha256:
     extra_args: >
-      OVERLAY_CONFIG="configuration/sha256.conf"
+      EXTRA_CONF_FILE="configuration/sha256.conf"
   mgmt.mcumgr.fs.mgmt.hash.supported.all:
     extra_args: >
-      OVERLAY_CONFIG="configuration/all.conf"
+      EXTRA_CONF_FILE="configuration/all.conf"

--- a/tests/subsys/mgmt/mcumgr/handler_demo/testcase.yaml
+++ b/tests/subsys/mgmt/mcumgr/handler_demo/testcase.yaml
@@ -18,7 +18,7 @@ tests:
     build_only: true
   mgmt.mcumgr.handler.demo.module:
     extra_args:
-      - OVERLAY_CONFIG="module.conf"
+      - EXTRA_CONF_FILE="module.conf"
     platform_allow:
       - nrf52840dk/nrf52840
     integration_platforms:

--- a/tests/subsys/pm/power_mgmt/testcase.yaml
+++ b/tests/subsys/pm/power_mgmt/testcase.yaml
@@ -5,4 +5,4 @@ tests:
   pm.system: {}
   pm.system.no.device.pm:
     extra_args:
-      - OVERLAY_CONFIG="no-device-pm.conf"
+      - EXTRA_CONF_FILE="no-device-pm.conf"

--- a/tests/subsys/settings/functional/nvs/testcase.yaml
+++ b/tests/subsys/settings/functional/nvs/testcase.yaml
@@ -16,7 +16,7 @@ tests:
       - settings
       - nvs
   settings.functional.nvs.dk:
-    extra_args: OVERLAY_CONFIG=mpu.conf
+    extra_args: EXTRA_CONF_FILE=mpu.conf
     platform_allow:
       - nrf52840dk/nrf52840
       - nrf52dk/nrf52832

--- a/tests/subsys/storage/flash_map/testcase.yaml
+++ b/tests/subsys/storage/flash_map/testcase.yaml
@@ -11,7 +11,7 @@ tests:
     integration_platforms:
       - native_sim
   storage.flash_map.mpu:
-    extra_args: OVERLAY_CONFIG=overlay-mpu.conf
+    extra_args: EXTRA_CONF_FILE=overlay-mpu.conf
     timeout: 120
     platform_allow:
       - nrf52840dk/nrf52840
@@ -23,7 +23,7 @@ tests:
       - nrf52840dk/nrf52840
     tags: flash_map
   storage.flash_map.mbedtls:
-    extra_args: OVERLAY_CONFIG=overlay-mbedtls.conf
+    extra_args: EXTRA_CONF_FILE=overlay-mbedtls.conf
     platform_allow:
       - nrf51dk/nrf51822
       - qemu_x86
@@ -34,7 +34,7 @@ tests:
     integration_platforms:
       - native_sim
   storage.flash_map.psa:
-    extra_args: OVERLAY_CONFIG=overlay-psa.conf
+    extra_args: EXTRA_CONF_FILE=overlay-psa.conf
     platform_allow:
       - nrf51dk/nrf51822
       - native_sim


### PR DESCRIPTION
Use EXTRA_CONF_FILE in sample yaml files, that replaced deprecated OVERLAY_CONFIG since the Zephyr v3.4 release.