### PR TITLE
samples: Bluetooth: Audio: Find device regardless of name type

### DIFF
--- a/samples/bluetooth/bap_broadcast_sink/src/main.c
+++ b/samples/bluetooth/bap_broadcast_sink/src/main.c
@@ -1194,14 +1194,21 @@ static bool is_substring(const char *substr, const char *str)
 
 static bool data_cb(struct bt_data *data, void *user_data)
 {
-	char *name = user_data;
+	bool *device_found = user_data;
+	char name[NAME_LEN] = {0};
 
 	switch (data->type) {
 	case BT_DATA_NAME_SHORTENED:
 	case BT_DATA_NAME_COMPLETE:
 	case BT_DATA_BROADCAST_NAME:
 		memcpy(name, data->data, MIN(data->data_len, NAME_LEN - 1));
-		return false;
+
+		if (is_substring(CONFIG_TARGET_BROADCAST_NAME, name)) {
+			/* Device found */
+			*device_found = true;
+			return false;
+		}
+		return true;
 	default:
 		return true;
 	}
@@ -1217,12 +1224,13 @@ static void broadcast_scan_recv(const struct bt_le_scan_recv_info *info, struct 
 		 * our own broadcast name filter.
 		 */
 		if (req_recv_state == NULL && strlen(CONFIG_TARGET_BROADCAST_NAME) > 0U) {
+			bool device_found = false;
 			struct net_buf_simple buf_copy;
-			char name[NAME_LEN] = {0};
 
 			net_buf_simple_clone(ad, &buf_copy);
-			bt_data_parse(&buf_copy, data_cb, name);
-			if (!(is_substring(CONFIG_TARGET_BROADCAST_NAME, name))) {
+			bt_data_parse(&buf_copy, data_cb, &device_found);
+
+			if (!device_found) {
 				return;
 			}
 		}


### PR DESCRIPTION
- Fixes bug where the sample would only look at the first name type and skip the rest.