### PR TITLE
dts: update memory map and remove ext-uicr

### DIFF
--- a/.github/workflows/bsim-tests.yaml
+++ b/.github/workflows/bsim-tests.yaml
@@ -37,7 +37,7 @@ jobs:
     runs-on:
       group: zephyr-runner-v2-linux-x64-4xlarge
     container:
-      image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.27.3.20241022
+      image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.27.4.20241026
       options: '--entrypoint /bin/bash'
     env:
       ZEPHYR_TOOLCHAIN_VARIANT: zephyr

--- a/.github/workflows/clang.yaml
+++ b/.github/workflows/clang.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on:
       group: zephyr-runner-v2-linux-x64-4xlarge
     container:
-      image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.27.3.20241022
+      image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.27.4.20241026
       options: '--entrypoint /bin/bash'
     strategy:
       fail-fast: false

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on:
       group: zephyr-runner-v2-linux-x64-4xlarge
     container:
-      image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.27.3.20241022
+      image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.27.4.20241026
       options: '--entrypoint /bin/bash'
     strategy:
       fail-fast: false

--- a/.github/workflows/errno.yml
+++ b/.github/workflows/errno.yml
@@ -10,7 +10,7 @@ jobs:
   check-errno:
     runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/zephyrproject-rtos/ci:v0.27.3
+      image: ghcr.io/zephyrproject-rtos/ci:v0.27.4
 
     steps:
       - name: Apply container owner mismatch workaround

--- a/.github/workflows/footprint-tracking.yml
+++ b/.github/workflows/footprint-tracking.yml
@@ -26,7 +26,7 @@ jobs:
       group: zephyr-runner-v2-linux-x64-4xlarge
     if: github.repository_owner == 'zephyrproject-rtos'
     container:
-      image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.27.3.20241022
+      image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.27.4.20241026
       options: '--entrypoint /bin/bash'
     defaults:
       run:

--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -25,7 +25,7 @@ jobs:
     runs-on:
       group: zephyr-runner-v2-linux-x64-4xlarge
     container:
-      image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.27.3.20241022
+      image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.27.4.20241026
       options: '--entrypoint /bin/bash'
     outputs:
       subset: ${{ steps.output-services.outputs.subset }}
@@ -130,7 +130,7 @@ jobs:
     needs: twister-build-prep
     if: needs.twister-build-prep.outputs.size != 0
     container:
-      image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.27.3.20241022
+      image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.27.4.20241026
       options: '--entrypoint /bin/bash'
     strategy:
       fail-fast: false

--- a/.github/workflows/twister_tests_blackbox.yml
+++ b/.github/workflows/twister_tests_blackbox.yml
@@ -24,7 +24,7 @@ jobs:
         python-version: ['3.10', '3.11', '3.12', '3.13']
         os: [ubuntu-22.04]
     container:
-      image: ghcr.io/zephyrproject-rtos/ci:v0.27.3
+      image: ghcr.io/zephyrproject-rtos/ci:v0.27.4
 
     steps:
     - name: Apply Container Owner Mismatch Workaround

--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_0_8_0.dtsi
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_0_8_0.dtsi
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/delete-node/ &suit_storage_partition;
+
+/ {
+	reserved-memory {
+		suit_storage_partition: memory@e1eb000 {
+			reg = <0xe1eb000 DT_SIZE_K(24)>;
+		};
+	};
+};

--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuapp_0_8_0.overlay
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuapp_0_8_0.overlay
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "nrf54h20dk_nrf54h20_0_8_0.dtsi"

--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuflpr_0_8_0.overlay
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuflpr_0_8_0.overlay
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "nrf54h20dk_nrf54h20_0_8_0.dtsi"

--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuppr_0_8_0.overlay
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuppr_0_8_0.overlay
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "nrf54h20dk_nrf54h20_0_8_0.dtsi"

--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpurad_0_8_0.overlay
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpurad_0_8_0.overlay
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "nrf54h20dk_nrf54h20_0_8_0.dtsi"

--- a/dts/bindings/arm/nordic,nrf-uicr-v2.yaml
+++ b/dts/bindings/arm/nordic,nrf-uicr-v2.yaml
@@ -17,10 +17,3 @@ properties:
     description: |
       Domain ID of the domain associated with this UICR instance. Must be unique
       across all UICR instances in the system.
-
-  ptr-ext-uicr:
-    type: phandle
-    required: true
-    description: |
-      Handle of a memory region reserved to contain an Extended UICR instance.
-      The address of that node will be stored in the UICR.PTREXTUICR register.

--- a/dts/common/nordic/nrf54h20.dtsi
+++ b/dts/common/nordic/nrf54h20.dtsi
@@ -145,16 +145,8 @@
 		#address-cells = <1>;
 		#size-cells = <1>;
 
-		suit_storage_partition: memory@e1eb000 {
-			reg = <0xe1eb000 DT_SIZE_K(24)>;
-		};
-
-		cpurad_uicr_ext: memory@e1ff000 {
-			reg = <0xe1ff000 DT_SIZE_K(2)>;
-		};
-
-		cpuapp_uicr_ext: memory@e1ff800 {
-			reg = <0xe1ff800 DT_SIZE_K(2)>;
+		suit_storage_partition: memory@e1ed000 {
+			reg = <0xe1ed000 DT_SIZE_K(20)>;
 		};
 	};
 
@@ -217,14 +209,12 @@
 			compatible = "nordic,nrf-uicr-v2";
 			reg = <0xfff8000 DT_SIZE_K(2)>;
 			domain = <2>;
-			ptr-ext-uicr = <&cpuapp_uicr_ext>;
 		};
 
 		cpurad_uicr: uicr@fffa000 {
 			compatible = "nordic,nrf-uicr-v2";
 			reg = <0xfffa000 DT_SIZE_K(2)>;
 			domain = <3>;
-			ptr-ext-uicr = <&cpurad_uicr_ext>;
 		};
 
 		ficr: ficr@fffe000 {

--- a/dts/common/nordic/nrf9280.dtsi
+++ b/dts/common/nordic/nrf9280.dtsi
@@ -74,14 +74,6 @@
 	reserved-memory {
 		#address-cells = <1>;
 		#size-cells = <1>;
-
-		cpurad_uicr_ext: memory@e401000 {
-			reg = <0xe401000 DT_SIZE_K(2)>;
-		};
-
-		cpuapp_uicr_ext: memory@e401800 {
-			reg = <0xe401800 DT_SIZE_K(2)>;
-		};
 	};
 
 	clocks {
@@ -113,14 +105,12 @@
 			compatible = "nordic,nrf-uicr-v2";
 			reg = <0xfff8000 DT_SIZE_K(2)>;
 			domain = <2>;
-			ptr-ext-uicr = <&cpuapp_uicr_ext>;
 		};
 
 		cpurad_uicr: uicr@fffa000 {
 			compatible = "nordic,nrf-uicr-v2";
 			reg = <0xfffa000 DT_SIZE_K(2)>;
 			domain = <3>;
-			ptr-ext-uicr = <&cpurad_uicr_ext>;
 		};
 
 		ficr: ficr@fffe000 {


### PR DESCRIPTION
Extended UICR will not be used as its configurations will be merged
with the UICR registers in NVR.

Memory maps changes are needed to align with pre compiled
firmware.