### PR TITLE
net: sockets: Move msghdr_non_empty_iov_count() to common file

### DIFF
--- a/subsys/net/lib/sockets/sockets.c
+++ b/subsys/net/lib/sockets/sockets.c
@@ -74,6 +74,19 @@ static inline void *get_sock_vtable(int sock,
 	return ctx;
 }
 
+size_t msghdr_non_empty_iov_count(const struct msghdr *msg)
+{
+	size_t non_empty_iov_count = 0;
+
+	for (size_t i = 0; i < msg->msg_iovlen; i++) {
+		if (msg->msg_iov[i].iov_len) {
+			non_empty_iov_count++;
+		}
+	}
+
+	return non_empty_iov_count;
+}
+
 void *z_impl_zsock_get_context_object(int sock)
 {
 	const struct socket_op_vtable *ignored;

--- a/subsys/net/lib/sockets/sockets_inet.c
+++ b/subsys/net/lib/sockets/sockets_inet.c
@@ -639,19 +639,6 @@ ssize_t zsock_sendto_ctx(struct net_context *ctx, const void *buf, size_t len,
 	return status;
 }
 
-size_t msghdr_non_empty_iov_count(const struct msghdr *msg)
-{
-	size_t non_empty_iov_count = 0;
-
-	for (size_t i = 0; i < msg->msg_iovlen; i++) {
-		if (msg->msg_iov[i].iov_len) {
-			non_empty_iov_count++;
-		}
-	}
-
-	return non_empty_iov_count;
-}
-
 ssize_t zsock_sendmsg_ctx(struct net_context *ctx, const struct msghdr *msg,
 			  int flags)
 {


### PR DESCRIPTION
msghdr_non_empty_iov_count() is used by TLS sockets too therefore should be available regardless of native IP sockets being enabled or not.