### PR TITLE
cmake: add linker_libraries.cmake for Cadence Xtensa linker

### DIFF
--- a/cmake/linker/xt-ld/linker_libraries.cmake
+++ b/cmake/linker/xt-ld/linker_libraries.cmake
@@ -1,0 +1,8 @@
+# Copyright (c) 2024 Nordic Semiconductor
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set_linker_property(NO_CREATE PROPERTY c_library    "-lc")
+set_linker_property(NO_CREATE PROPERTY rt_library   "-lgcc")
+set_linker_property(NO_CREATE PROPERTY c++_library  "-lstdc++")
+set_linker_property(PROPERTY link_order_library "c;rt")


### PR DESCRIPTION
Follow-up: #78320

Create linker_libraries.cmake for the Cadence Xtensa xt-ld linker to ensure correct linking of runtime and C libraries as well as correct link order.