### PR TITLE
boards: mimxrt1024_evk: enable support for linkserver

### DIFF
--- a/boards/nxp/mimxrt1024_evk/board.cmake
+++ b/boards/nxp/mimxrt1024_evk/board.cmake
@@ -1,11 +1,14 @@
 #
-# Copyright (c) 2020, NXP
+# Copyright (c) 2020, 2024 NXP
 #
 # SPDX-License-Identifier: Apache-2.0
 #
 
 board_runner_args(pyocd "--target=mimxrt1024")
 board_runner_args(jlink "--device=MIMXRT1024xxx5A")
+# MIMXRT1024xxxxx         MIMXRT1024-EVK           cm7
+board_runner_args(linkserver  "--device=MIMXRT1024xxxxx:MIMXRT1024-EVK")
 
+include(${ZEPHYR_BASE}/boards/common/linkserver.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)

--- a/boards/nxp/mimxrt1024_evk/doc/index.rst
+++ b/boards/nxp/mimxrt1024_evk/doc/index.rst
@@ -206,11 +206,12 @@ remaining are not used.
 Programming and Debugging
 *************************
 
-This board supports 2 debug host tools. Please install your preferred host
+This board supports 3 debug host tools. Please install your preferred host
 tool, then follow the instructions in `Configuring a Debug Probe`_ to
 configure the board appropriately.
 
-* :ref:`jlink-debug-host-tools` (Default, Supported by NXP)
+* :ref:`linkserver-debug-host-tools` (Default, Supported by NXP)
+* :ref:`jlink-debug-host-tools` (Supported by NXP)
 * :ref:`pyocd-debug-host-tools` (Not supported by NXP)
 
 Configuring a Debug Probe


### PR DESCRIPTION
 - update the EVK's board.cmake, making linkserver the default runner
 - update the board's document file