### PR TITLE
drivers: bt: airoc: fix compliance check

### DIFF
--- a/drivers/bluetooth/hci/Kconfig
+++ b/drivers/bluetooth/hci/Kconfig
@@ -188,7 +188,7 @@ config BT_STM32_IPM_RX_STACK_SIZE
 	depends on BT_STM32_IPM
 	default 512
 
-menuconfig BT_AIROC
+config BT_AIROC
 	bool "AIROC BT connectivity"
 	default y
 	select GPIO                          if BT_H4


### PR DESCRIPTION
Fix compliance check related to "symbols without children". Using regular 'config' entry.