### PR TITLE
boards: frdm_mcxw71: Enable mcuboot

### DIFF
--- a/boards/nxp/frdm_mcxw71/frdm_mcxw71.dts
+++ b/boards/nxp/frdm_mcxw71/frdm_mcxw71.dts
@@ -21,7 +21,7 @@
 	chosen {
 		zephyr,flash = &flash;
 		zephyr,flash-controller = &fmu;
-		zephyr,code-partition = &code_partition;
+		zephyr,code-partition = &slot0_partition;
 		zephyr,sram = &stcm0;
 		zephyr,console = &lpuart1;
 		zephyr,shell-uart = &lpuart1;
@@ -65,15 +65,20 @@
 		#address-cells = <1>;
 		#size-cells = <1>;
 
-		code_partition: partition@0 {
-			reg = <0x0 DT_SIZE_K(896)>;
-			label = "code";
-			read-only;
+		boot_partition: partition@0 {
+			reg = <0x0 DT_SIZE_K(64)>;
+		};
+
+		slot0_partition: partition@10000 {
+			reg = <0x10000 DT_SIZE_K(416)>;
+		};
+
+		slot1_partition: partition@78000 {
+			reg = <0x78000 DT_SIZE_K(416)>;
 		};
 
 		storage_partition: partition@e0000 {
 			reg = <0xe0000 DT_SIZE_K(128)>;
-			label = "storage";
 		};
 	};
 };

--- a/tests/boot/test_mcuboot/testcase.yaml
+++ b/tests/boot/test_mcuboot/testcase.yaml
@@ -44,6 +44,7 @@ tests:
       - nrf52840dk/nrf52840
       - rd_rw612_bga
       - nucleo_wba55cg
+      - frdm_mcxw71
     integration_platforms:
       - frdm_k64f
       - nrf52840dk/nrf52840


### PR DESCRIPTION
Enable mcuboot on frdm_mcxw71 by defining mcu boot required partitions