### PR TITLE
soc: esp32c6: add LLEXT linker entry

### DIFF
--- a/soc/espressif/esp32c6/default.ld
+++ b/soc/espressif/esp32c6/default.ld
@@ -136,6 +136,10 @@ SECTIONS
 
   #include <zephyr/linker/rel-sections.ld>
 
+#ifdef CONFIG_LLEXT
+  #include <zephyr/linker/llext-sections.ld>
+#endif
+
   /* --- START OF RTC --- */
 
   .rtc.text :


### PR DESCRIPTION
Make sure LLEXT sections are properly placed to avoid orphan declaration.