### PR TITLE
dts: remove zephyr,panel-timing compat

### DIFF
--- a/boards/renesas/da1469x_dk_pro/dts/da1469x_dk_pro_lcdc.overlay
+++ b/boards/renesas/da1469x_dk_pro/dts/da1469x_dk_pro_lcdc.overlay
@@ -65,7 +65,6 @@
 	 * driver IC.
 	 */
 	display-timings {
-		compatible = "zephyr,panel-timing";
 		hsync-len = <2>;
 		hfront-porch = <2>;
 		hback-porch = <3>;

--- a/boards/shields/rk043fn02h_ct/rk043fn02h_ct.overlay
+++ b/boards/shields/rk043fn02h_ct/rk043fn02h_ct.overlay
@@ -31,7 +31,6 @@
 	width = <480>;
 	height = <272>;
 	display-timings {
-		compatible = "zephyr,panel-timing";
 		hsync-len = <41>;
 		hfront-porch = <4>;
 		hback-porch = <8>;

--- a/boards/shields/rk043fn66hs_ctg/rk043fn66hs_ctg.overlay
+++ b/boards/shields/rk043fn66hs_ctg/rk043fn66hs_ctg.overlay
@@ -32,7 +32,6 @@
 	width = <480>;
 	height = <272>;
 	display-timings {
-		compatible = "zephyr,panel-timing";
 		hsync-len = <4>;
 		hfront-porch = <8>;
 		hback-porch = <43>;

--- a/boards/shields/rk055hdmipi4m/rk055hdmipi4m.overlay
+++ b/boards/shields/rk055hdmipi4m/rk055hdmipi4m.overlay
@@ -39,7 +39,6 @@
 	width = <720>;
 	height = <1280>;
 	display-timings {
-		compatible = "zephyr,panel-timing";
 		hsync-len = <8>;
 		hfront-porch = <32>;
 		hback-porch = <32>;

--- a/boards/shields/rk055hdmipi4ma0/rk055hdmipi4ma0.overlay
+++ b/boards/shields/rk055hdmipi4ma0/rk055hdmipi4ma0.overlay
@@ -39,7 +39,6 @@
 	width = <720>;
 	height = <1280>;
 	display-timings {
-		compatible = "zephyr,panel-timing";
 		hsync-len = <6>;
 		hfront-porch = <12>;
 		hback-porch = <24>;

--- a/boards/shields/st_b_lcd40_dsi1_mb1166/st_b_lcd40_dsi1_mb1166.overlay
+++ b/boards/shields/st_b_lcd40_dsi1_mb1166/st_b_lcd40_dsi1_mb1166.overlay
@@ -41,7 +41,6 @@
 	pixel-format = <PANEL_PIXEL_FORMAT_RGB_888>;
 	/* orisetech, otm8009a */
 	display-timings {
-		compatible = "zephyr,panel-timing";
 		hsync-active = <0>;
 		vsync-active = <0>;
 		de-active = <0>;

--- a/boards/shields/st_b_lcd40_dsi1_mb1166/st_b_lcd40_dsi1_mb1166_a09.overlay
+++ b/boards/shields/st_b_lcd40_dsi1_mb1166/st_b_lcd40_dsi1_mb1166_a09.overlay
@@ -41,7 +41,6 @@
 	pixel-format = <PANEL_PIXEL_FORMAT_RGB_888>;
 	/* frida, nt35510 */
 	display-timings {
-		compatible = "zephyr,panel-timing";
 		hsync-active = <0>;
 		vsync-active = <0>;
 		de-active = <0>;

--- a/boards/st/stm32f429i_disc1/stm32f429i_disc1.dts
+++ b/boards/st/stm32f429i_disc1/stm32f429i_disc1.dts
@@ -242,7 +242,6 @@
 	height = <320>;
 	pixel-format = <PANEL_PIXEL_FORMAT_RGB_565>;
 	display-timings {
-		compatible = "zephyr,panel-timing";
 		de-active = <0>;
 		pixelclk-active = <0>;
 		hsync-active = <0>;

--- a/boards/st/stm32f746g_disco/stm32f746g_disco.dts
+++ b/boards/st/stm32f746g_disco/stm32f746g_disco.dts
@@ -269,7 +269,6 @@ zephyr_udc0: &usbotg_fs {
 	height = <272>;
 	pixel-format = <PANEL_PIXEL_FORMAT_RGB_565>;
 	display-timings {
-		compatible = "zephyr,panel-timing";
 		de-active = <0>;
 		pixelclk-active = <0>;
 		hsync-active = <0>;

--- a/boards/st/stm32f7508_dk/stm32f7508_dk.dts
+++ b/boards/st/stm32f7508_dk/stm32f7508_dk.dts
@@ -265,7 +265,6 @@ zephyr_udc0: &usbotg_fs {
 	height = <272>;
 	pixel-format = <PANEL_PIXEL_FORMAT_RGB_565>;
 	display-timings {
-		compatible = "zephyr,panel-timing";
 		de-active = <0>;
 		pixelclk-active = <0>;
 		hsync-active = <0>;

--- a/boards/st/stm32h750b_dk/stm32h750b_dk.dts
+++ b/boards/st/stm32h750b_dk/stm32h750b_dk.dts
@@ -100,7 +100,6 @@
 	height = <272>;
 	pixel-format = <PANEL_PIXEL_FORMAT_RGB_565>;
 	display-timings {
-		compatible = "zephyr,panel-timing";
 		de-active = <1>;
 		pixelclk-active = <0>;
 		hsync-active = <0>;

--- a/boards/st/stm32h7b3i_dk/stm32h7b3i_dk.dts
+++ b/boards/st/stm32h7b3i_dk/stm32h7b3i_dk.dts
@@ -229,7 +229,6 @@
 	height = <272>;
 	pixel-format = <PANEL_PIXEL_FORMAT_RGB_565>;
 	display-timings {
-		compatible = "zephyr,panel-timing";
 		de-active = <0>;
 		pixelclk-active = <0>;
 		hsync-active = <0>;

--- a/boards/witte/linum/linum.dts
+++ b/boards/witte/linum/linum.dts
@@ -318,7 +318,6 @@ zephyr_udc0: &usbotg_fs {
 	height = <272>;
 	pixel-format = <PANEL_PIXEL_FORMAT_RGB_565>;
 	display-timings {
-		compatible = "zephyr,panel-timing";
 		de-active = <1>;
 		pixelclk-active = <0>;
 		hsync-active = <0>;

--- a/dts/bindings/display/lcd-controller.yaml
+++ b/dts/bindings/display/lcd-controller.yaml
@@ -12,3 +12,6 @@ properties:
     description: |
       Initial Pixel format for panel attached to this controller.
       See dt-bindings/display/panel.h for a list
+
+child-binding:
+  include: panel-timing.yaml

--- a/dts/bindings/display/panel/panel-timing.yaml
+++ b/dts/bindings/display/panel/panel-timing.yaml
@@ -4,28 +4,24 @@
 # Common fields for panel timings
 # inherited from Linux panel bindings.
 
-description: |
-  Common timing settings for display panels. These timings can be added to
-  a panel under display-timings node. For example:
-
-  &lcdif {
-    display-timings {
-      compatible = "zephyr,panel-timing";
-      hsync-len = <8>;
-      hfront-porch = <32>;
-      hback-porch = <32>;
-      vsync-len = <2>;
-      vfront-porch = <16>;
-      vback-porch = <14>;
-      hsync-active = <0>;
-      vsync-active = <0>;
-      de-active = <1>;
-      pixelclk-active = <0>;
-      clock-frequency = <62346240>;
-    };
-  };
-
-compatible: "zephyr,panel-timing"
+#  Common timing settings for display panels. These timings can be added to
+#  a panel under display-timings node. For example:
+#
+#  &lcdif {
+#    display-timings {
+#      hsync-len = <8>;
+#      hfront-porch = <32>;
+#      hback-porch = <32>;
+#      vsync-len = <2>;
+#      vfront-porch = <16>;
+#      vback-porch = <14>;
+#      hsync-active = <0>;
+#      vsync-active = <0>;
+#      de-active = <1>;
+#      pixelclk-active = <0>;
+#      clock-frequency = <62346240>;
+#    };
+#  };
 
 properties:
   clock-frequency:


### PR DESCRIPTION
Since the panel timing node comes from linux bindings, let's try to remove the zephyr-specific compatible by using a child binding. This would potentially require some other work if another type of child node is needed to be specified in the future.

This compatible was mentioned in #74415 as a supporting example for more zephyr-specific compatibles, hence the motivation of this PR.