### PR TITLE
dts: npcx: remove unnecessary sub-power state for npcx4

### DIFF
--- a/dts/arm/nuvoton/npcx/npcx.dtsi
+++ b/dts/arm/nuvoton/npcx/npcx.dtsi
@@ -26,23 +26,6 @@
 			device_type = "cpu";
 			compatible = "arm,cortex-m4f";
 			reg = <0>;
-			cpu-power-states = <&suspend_to_idle0 &suspend_to_idle1>;
-		};
-
-		power-states {
-			suspend_to_idle0: suspend-to-idle0 {
-				compatible = "zephyr,power-state";
-				power-state-name = "suspend-to-idle";
-				substate-id = <0>;
-				min-residency-us = <1000>;
-			};
-
-			suspend_to_idle1: suspend-to-idle1 {
-				compatible = "zephyr,power-state";
-				power-state-name = "suspend-to-idle";
-				substate-id = <1>;
-				min-residency-us = <201000>;
-			};
 		};
 	};
 

--- a/dts/arm/nuvoton/npcx/npcx4.dtsi
+++ b/dts/arm/nuvoton/npcx/npcx4.dtsi
@@ -21,6 +21,21 @@
 #include "npcx.dtsi"
 
 / {
+	cpus {
+		cpu0: cpu@0 {
+			cpu-power-states = <&suspend_to_idle0>;
+		};
+
+		power-states {
+			suspend_to_idle0: suspend-to-idle0 {
+				compatible = "zephyr,power-state";
+				power-state-name = "suspend-to-idle";
+				substate-id = <0>;
+				min-residency-us = <1000>;
+			};
+		};
+	};
+
 	def-io-conf-list {
 		pinmux = <&alt0_gpio_no_spip
 			  &alt0_gpio_no_fpip

--- a/dts/arm/nuvoton/npcx/npcx7.dtsi
+++ b/dts/arm/nuvoton/npcx/npcx7.dtsi
@@ -19,6 +19,28 @@
 #include "npcx.dtsi"
 
 / {
+	cpus {
+		cpu0: cpu@0 {
+			cpu-power-states = <&suspend_to_idle0 &suspend_to_idle1>;
+		};
+
+		power-states {
+			suspend_to_idle0: suspend-to-idle0 {
+				compatible = "zephyr,power-state";
+				power-state-name = "suspend-to-idle";
+				substate-id = <0>;
+				min-residency-us = <1000>;
+			};
+
+			suspend_to_idle1: suspend-to-idle1 {
+				compatible = "zephyr,power-state";
+				power-state-name = "suspend-to-idle";
+				substate-id = <1>;
+				min-residency-us = <201000>;
+			};
+		};
+	};
+
 	def-io-conf-list {
 		pinmux = <&alt0_gpio_no_spip
 			   &alt0_gpio_no_fpip

--- a/dts/arm/nuvoton/npcx/npcx9.dtsi
+++ b/dts/arm/nuvoton/npcx/npcx9.dtsi
@@ -19,6 +19,28 @@
 #include "npcx.dtsi"
 
 / {
+	cpus {
+		cpu0: cpu@0 {
+			cpu-power-states = <&suspend_to_idle0 &suspend_to_idle1>;
+		};
+
+		power-states {
+			suspend_to_idle0: suspend-to-idle0 {
+				compatible = "zephyr,power-state";
+				power-state-name = "suspend-to-idle";
+				substate-id = <0>;
+				min-residency-us = <1000>;
+			};
+
+			suspend_to_idle1: suspend-to-idle1 {
+				compatible = "zephyr,power-state";
+				power-state-name = "suspend-to-idle";
+				substate-id = <1>;
+				min-residency-us = <201000>;
+			};
+		};
+	};
+
 	def-io-conf-list {
 		pinmux = <&alt0_gpio_no_spip
 			   &alt0_gpio_no_fpip


### PR DESCRIPTION
NPCX9 and former chips defines two kinds of sub-power-states to support:
1. Standard wake-up time: if the chip needs to stay in the deep sleep state more than 200 ms.
2. Instant wake-up time: if the chip needs to stay in the deep sleep state less than 200 ms.

As NPCX4 can stay in the deep sleep state at more than 200 ms with the instant wake-up capability, we can define only one sub-power state.