### PR TITLE
Bluetooth: BASS: add scan cb to scan delegator module.

### DIFF
--- a/include/zephyr/bluetooth/audio/bap.h
+++ b/include/zephyr/bluetooth/audio/bap.h
@@ -658,6 +658,16 @@ struct bt_bap_scan_delegator_cb {
 	int (*bis_sync_req)(struct bt_conn *conn,
 			    const struct bt_bap_scan_delegator_recv_state *recv_state,
 			    const uint32_t bis_sync_req[CONFIG_BT_BAP_BASS_MAX_SUBGROUPS]);
+	/**
+	 * @brief Broadcast Assistant scanning state callback
+	 *
+	 * Callback triggered when a Broadcast Assistant notifies the Scan Delegator about the
+	 * assistants scanning state.
+	 *
+	 * @param conn Pointer to the connection that initiated the scan.
+	 * @param is_scanning true if scanning started, false if scanning stopped.
+	 */
+	void (*scanning_state)(struct bt_conn *conn, bool is_scanning);
 };
 
 /** Structure holding information of audio stream endpoint */

--- a/subsys/bluetooth/audio/bap_scan_delegator.c
+++ b/subsys/bluetooth/audio/bap_scan_delegator.c
@@ -60,11 +60,6 @@ enum bass_recv_state_internal_flag {
 	BASS_RECV_STATE_INTERNAL_FLAG_NUM,
 };
 
-struct broadcast_assistant {
-	struct bt_conn *conn;
-	uint8_t scanning;
-};
-
 /* TODO: Merge bass_recv_state_internal_t and bt_bap_scan_delegator_recv_state */
 struct bass_recv_state_internal {
 	const struct bt_gatt_attr *attr;
@@ -82,7 +77,6 @@ struct bass_recv_state_internal {
 
 struct bt_bap_scan_delegator_inst {
 	uint8_t next_src_id;
-	struct broadcast_assistant assistant_configs[CONFIG_BT_MAX_CONN];
 	struct bass_recv_state_internal recv_states
 		[CONFIG_BT_BAP_SCAN_DELEGATOR_RECV_STATE_COUNT];
 };
@@ -264,25 +258,6 @@ static void bis_sync_request_updated(struct bt_conn *conn,
 	}
 }
 
-static void scan_delegator_disconnected(struct bt_conn *conn, uint8_t reason)
-{
-	int i;
-	struct broadcast_assistant *assistant = NULL;
-
-	for (i = 0; i < ARRAY_SIZE(scan_delegator.assistant_configs); i++) {
-		if (scan_delegator.assistant_configs[i].conn == conn) {
-			assistant = &scan_delegator.assistant_configs[i];
-			break;
-		}
-	}
-
-	if (assistant != NULL) {
-		LOG_DBG("Instance %u with addr %s disconnected",
-		       i, bt_addr_le_str(bt_conn_get_dst(conn)));
-		(void)memset(assistant, 0, sizeof(*assistant));
-	}
-}
-
 static void scan_delegator_security_changed(struct bt_conn *conn,
 					    bt_security_t level,
 					    enum bt_security_err err)
@@ -315,32 +290,9 @@ static void scan_delegator_security_changed(struct bt_conn *conn,
 	}
 }
 
-static struct bt_conn_cb conn_cb = {
-	.disconnected = scan_delegator_disconnected,
+BT_CONN_CB_DEFINE(conn_callbacks) = {
 	.security_changed = scan_delegator_security_changed,
 };
-
-static struct broadcast_assistant *get_bap_broadcast_assistant(struct bt_conn *conn)
-{
-	struct broadcast_assistant *new = NULL;
-
-	for (size_t i = 0; i < ARRAY_SIZE(scan_delegator.assistant_configs); i++) {
-		if (scan_delegator.assistant_configs[i].conn == conn) {
-			return &scan_delegator.assistant_configs[i];
-		} else if (new == NULL &&
-			   scan_delegator.assistant_configs[i].conn == NULL) {
-			new = &scan_delegator.assistant_configs[i];
-			new->conn = conn;
-		}
-	}
-
-	if (!atomic_test_and_set_bit(scan_delegator_flags,
-				     SCAN_DELEGATOR_FLAG_REGISTERED_CONN_CB)) {
-		bt_conn_cb_register(&conn_cb);
-	}
-
-	return new;
-}
 
 static uint8_t next_src_id(void)
 {
@@ -1023,7 +975,6 @@ static ssize_t write_control_point(struct bt_conn *conn,
 				   const void *data, uint16_t len,
 				   uint16_t offset, uint8_t flags)
 {
-	struct broadcast_assistant *bap_broadcast_assistant;
 	struct net_buf_simple buf;
 	uint8_t opcode;
 	int err;
@@ -1042,12 +993,6 @@ static ssize_t write_control_point(struct bt_conn *conn,
 		return BT_GATT_ERR(BT_BAP_BASS_ERR_OPCODE_NOT_SUPPORTED);
 	}
 
-	bap_broadcast_assistant = get_bap_broadcast_assistant(conn);
-
-	if (bap_broadcast_assistant == NULL) {
-		return BT_GATT_ERR(BT_ATT_ERR_UNLIKELY);
-	}
-
 	LOG_HEXDUMP_DBG(data, len, "Data");
 
 	switch (opcode) {
@@ -1059,16 +1004,22 @@ static ssize_t write_control_point(struct bt_conn *conn,
 			return BT_GATT_ERR(BT_ATT_ERR_WRITE_REQ_REJECTED);
 		}
 
-		bap_broadcast_assistant->scanning = false;
+		if (scan_delegator_cbs != NULL && scan_delegator_cbs->scanning_state != NULL) {
+			scan_delegator_cbs->scanning_state(conn, false);
+		}
+
 		break;
 	case BT_BAP_BASS_OP_SCAN_START:
 		LOG_DBG("Assistant starting scanning");
 
 		if (buf.len != 0) {
-			LOG_DBG("Invalid length %u", buf.size);
 			return BT_GATT_ERR(BT_ATT_ERR_WRITE_REQ_REJECTED);
 		}
-		bap_broadcast_assistant->scanning = true;
+
+		if (scan_delegator_cbs != NULL && scan_delegator_cbs->scanning_state != NULL) {
+			scan_delegator_cbs->scanning_state(conn, true);
+		}
+
 		break;
 	case BT_BAP_BASS_OP_ADD_SRC:
 		LOG_DBG("Assistant adding source");

--- a/tests/bsim/bluetooth/audio/src/bap_broadcast_sink_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_broadcast_sink_test.c
@@ -410,7 +410,14 @@ static void broadcast_code_cb(struct bt_conn *conn,
 	memcpy(recv_state_broadcast_code, broadcast_code, BT_AUDIO_BROADCAST_CODE_SIZE);
 }
 
+static void scanning_state_cb(struct bt_conn *conn, bool is_scanning)
+{
+	printk("Assistant scanning %s\n", is_scanning ? "started" : "stopped");
+
+}
+
 static struct bt_bap_scan_delegator_cb scan_delegator_cbs = {
+	.scanning_state = scanning_state_cb,
 	.pa_sync_req = pa_sync_req_cb,
 	.pa_sync_term_req = pa_sync_term_req_cb,
 	.bis_sync_req = bis_sync_req_cb,


### PR DESCRIPTION
Add scan cb to scan delegator so that Application
can be notified  when assistant starts or stops
scanning.
Also state information of Broadcast Assistant
is removed as info is not used.