### PR TITLE
logging: Fix LOG_IMMEDIATE_CLEAN_OUTPUT

### DIFF
--- a/subsys/logging/log_core.c
+++ b/subsys/logging/log_core.c
@@ -114,6 +114,7 @@ static log_timestamp_t proc_latency;
 static log_timestamp_t prev_timestamp;
 static atomic_t unordered_cnt;
 static uint64_t last_failure_report;
+static struct k_spinlock process_lock;
 
 static STRUCT_SECTION_ITERABLE(log_msg_ptr, log_msg_ptr);
 static STRUCT_SECTION_ITERABLE_ALTERNATE(log_mpsc_pbuf, mpsc_pbuf_buffer, log_buffer);
@@ -163,7 +164,6 @@ static void z_log_msg_post_finalize(void)
 	atomic_val_t cnt = atomic_inc(&buffered_cnt);
 
 	if (panic_mode) {
-		static struct k_spinlock process_lock;
 		k_spinlock_key_t key = k_spin_lock(&process_lock);
 		(void)log_process();
 
@@ -664,7 +664,17 @@ static void msg_commit(struct mpsc_pbuf_buffer *buffer, struct log_msg *msg)
 	union log_msg_generic *m = (union log_msg_generic *)msg;
 
 	if (IS_ENABLED(CONFIG_LOG_MODE_IMMEDIATE)) {
+		k_spinlock_key_t key;
+
+		if (IS_ENABLED(CONFIG_LOG_IMMEDIATE_CLEAN_OUTPUT)) {
+			key = k_spin_lock(&process_lock);
+		}
+
 		msg_process(m);
+
+		if (IS_ENABLED(CONFIG_LOG_IMMEDIATE_CLEAN_OUTPUT)) {
+			k_spin_unlock(&process_lock, key);
+		}
 
 		return;
 	}


### PR DESCRIPTION
There was a kconfig option used in v1 logging to get clean output in the immediate mode. It was lost during the transition to v2 but Kconfig remained. Adding spin_lock to log processing to ensure that log messages are not interleaved in the output in the immediate mode.