### PR TITLE
hostap: fix other STA failed to connect to SAP

### DIFF
--- a/modules/hostap/src/supp_api.c
+++ b/modules/hostap/src/supp_api.c
@@ -1413,7 +1413,7 @@ int hapd_config_network(struct hostapd_iface *iface,
 			if (!hostapd_cli_cmd_v("set wpa_key_mgmt WPA-PSK")) {
 				goto out;
 			}
-			if (!hostapd_cli_cmd_v("set wpa_passphrase \"%s\"", params->psk)) {
+			if (!hostapd_cli_cmd_v("set wpa_passphrase %s", params->psk)) {
 				goto out;
 			}
 			if (!hostapd_cli_cmd_v("set wpa_pairwise CCMP")) {
@@ -1426,7 +1426,7 @@ int hapd_config_network(struct hostapd_iface *iface,
 			if (!hostapd_cli_cmd_v("set wpa_key_mgmt WPA-PSK")) {
 				goto out;
 			}
-			if (!hostapd_cli_cmd_v("set wpa_passphrase \"%s\"", params->psk)) {
+			if (!hostapd_cli_cmd_v("set wpa_passphrase %s", params->psk)) {
 				goto out;
 			}
 			if (!hostapd_cli_cmd_v("set rsn_pairwise CCMP")) {
@@ -1439,7 +1439,7 @@ int hapd_config_network(struct hostapd_iface *iface,
 			if (!hostapd_cli_cmd_v("set wpa_key_mgmt WPA-PSK-SHA256")) {
 				goto out;
 			}
-			if (!hostapd_cli_cmd_v("set wpa_passphrase \"%s\"", params->psk)) {
+			if (!hostapd_cli_cmd_v("set wpa_passphrase %s", params->psk)) {
 				goto out;
 			}
 			if (!hostapd_cli_cmd_v("set rsn_pairwise CCMP")) {
@@ -1452,7 +1452,7 @@ int hapd_config_network(struct hostapd_iface *iface,
 			if (!hostapd_cli_cmd_v("set wpa_key_mgmt SAE")) {
 				goto out;
 			}
-			if (!hostapd_cli_cmd_v("set sae_password \"%s\"",
+			if (!hostapd_cli_cmd_v("set sae_password %s",
 					       params->sae_password ? params->sae_password :
 					       params->psk)) {
 				goto out;


### PR DESCRIPTION
The format of wpa_passphrase and sae_password is wrong when start the SAP, which leads the invaild MIC check error when other STA try to connect in security mode. Change the wrong format can fix this issue.