### PR TITLE
tests: drivers: build_all: display: Add coverage

### DIFF
--- a/boards/native/native_posix/native_posix.yaml
+++ b/boards/native/native_posix/native_posix.yaml
@@ -11,6 +11,7 @@ toolchain:
 supported:
   - can
   - counter
+  - display
   - dma
   - eeprom
   - netif:eth

--- a/boards/native/native_posix/native_posix_native_64.yaml
+++ b/boards/native/native_posix/native_posix_native_64.yaml
@@ -11,6 +11,7 @@ toolchain:
 supported:
   - can
   - counter
+  - display
   - dma
   - eeprom
   - netif:eth

--- a/boards/native/native_sim/native_sim.yaml
+++ b/boards/native/native_sim/native_sim.yaml
@@ -11,6 +11,7 @@ toolchain:
 supported:
   - can
   - counter
+  - display
   - dma
   - eeprom
   - netif:eth

--- a/boards/native/native_sim/native_sim_native_64.yaml
+++ b/boards/native/native_sim/native_sim_native_64.yaml
@@ -11,6 +11,7 @@ toolchain:
 supported:
   - can
   - counter
+  - display
   - dma
   - eeprom
   - netif:eth

--- a/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm7.yaml
+++ b/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm7.yaml
@@ -18,6 +18,7 @@ supported:
   - adc
   - counter
   - can
+  - display
   - dma
   - gpio
   - hwinfo

--- a/tests/drivers/build_all/display/testcase.yaml
+++ b/tests/drivers/build_all/display/testcase.yaml
@@ -1,10 +1,18 @@
 common:
+  build_only: true
   tags:
     - drivers
     - display
-  build_only: true
-  platform_allow:
-    - native_posix
-    - native_sim
+  depends_on: display
+
 tests:
-  drivers.display.default: {}
+  drivers.display.build.default:
+    integration_platforms:
+      - native_sim
+      - native_sim/native/64
+
+  drivers.display.build.rk055hdmipi4ma0:
+    platform_allow:
+      - mimxrt1170_evk/mimxrt1176/cm7
+    extra_args:
+      - SHIELD=rk055hdmipi4ma0


### PR DESCRIPTION
Make display tests depend on the "display" feature. And add a testcase as example.