### PR TITLE
 MIPI_DBI driver - stm32-fmc :  fix  fmc_bank1  build error on stm32l562e_dk

### DIFF
--- a/drivers/mipi_dbi/mipi_dbi_stm32_fmc.c
+++ b/drivers/mipi_dbi/mipi_dbi_stm32_fmc.c
@@ -178,7 +178,8 @@ static struct mipi_dbi_driver_api mipi_dbi_stm32_fmc_driver_api = {
 	.write_display = mipi_dbi_stm32_fmc_write_display,
 };
 
-#define MIPI_DBI_FMC_GET_ADDRESS(n) _CONCAT(FMC_BANK1_, UTIL_INC(DT_REG_ADDR(DT_INST_PARENT(n))))
+#define MIPI_DBI_FMC_GET_ADDRESS(n) _CONCAT(FMC_BANK1_,                                            \
+					UTIL_INC(DT_REG_ADDR_RAW(DT_INST_PARENT(n))))
 
 #define MIPI_DBI_FMC_GET_DATA_ADDRESS(n)                                                           \
 	MIPI_DBI_FMC_GET_ADDRESS(n) + (1 << (DT_INST_PROP(n, register_select_pin) + 1))


### PR DESCRIPTION
This PR brings changes to fix a regression introduced by this PR #78766 on the mipi_dbi driver for stm32.

The macro DT_REG_ADDR_RAW is now used instead of DT_REG_ADDR to make sure that the address returned by the macro
 is always unsigned.