### PR TITLE
kernel: sched: remove call to flag_ipi when not in SMP mode

### DIFF
--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -749,10 +749,6 @@ bool z_thread_prio_set(struct k_thread *thread, int prio)
 				dequeue_thread(thread);
 				thread->base.prio = prio;
 				queue_thread(thread);
-
-				if (old_prio > prio) {
-					flag_ipi(ipi_mask_create(thread));
-				}
 			} else {
 				/*
 				 * This is a running thread on SMP. Update its


### PR DESCRIPTION
Here we are calling flag_ipi in the case of !CONFIG_SMP. flag_ip in this
case is an empty stub that does nothing, so this code is just doing
nothing.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
