### PR TITLE
ci: bsim tests: Also trigger on MbedTLS module changes

### DIFF
--- a/.github/workflows/bsim-tests.yaml
+++ b/.github/workflows/bsim-tests.yaml
@@ -18,6 +18,7 @@ on:
       - "include/zephyr/arch/posix/**"
       - "scripts/native_simulator/**"
       - "samples/net/sockets/echo_*/**"
+      - "modules/mbedtls/**"
       - "modules/openthread/**"
       - "subsys/net/l2/openthread/**"
       - "include/zephyr/net/openthread.h"
@@ -103,6 +104,7 @@ jobs:
             tests/bsim/*
             boards/nordic/nrf5*/*dt*
             dts/*/nordic/
+            modules/mbedtls/**
 
       - name: Check if Bluethooth files changed
         uses: tj-actions/changed-files@v45


### PR DESCRIPTION
Trigger bsim tests also on changes to the MbedTLS module code in Zephyr side. To avoid possible regressions in bsim tests when this code is changed getting into main.

It would have avoided #79533