### PR TITLE
Bluetooth: CCP: Client: Add get_bearers

### DIFF
--- a/include/zephyr/bluetooth/audio/ccp.h
+++ b/include/zephyr/bluetooth/audio/ccp.h
@@ -173,7 +173,7 @@ int bt_ccp_call_control_client_discover(struct bt_conn *conn,
  *
  * @param cb The callback struct
  *
- * @retval 0 Succsss
+ * @retval 0 Success
  * @retval -EINVAL @p cb is NULL
  * @retval -EEXISTS @p cb is already registered
  */
@@ -184,11 +184,24 @@ int bt_ccp_call_control_client_register_cb(struct bt_ccp_call_control_client_cb 
  *
  * @param cb The callback struct
  *
- * @retval 0 Succsss
+ * @retval 0 Success
  * @retval -EINVAL @p cb is NULL
  * @retval -EALREADY @p cb is not registered
  */
 int bt_ccp_call_control_client_unregister_cb(struct bt_ccp_call_control_client_cb *cb);
+
+/**
+ * @brief Get the bearers of a client instance
+ *
+ * @param[in]  client  The client to get the bearers of.
+ * @param[out] bearers The bearers struct that will be populated with the bearers of @p client.
+
+ * @retval 0 Success
+ * @retval -EINVAL @p client or @p bearers is NULL
+ */
+int bt_ccp_call_control_client_get_bearers(struct bt_ccp_call_control_client *client,
+					   struct bt_ccp_call_control_client_bearers *bearers);
+
 /** @} */ /* End of group bt_ccp_call_control_client */
 #ifdef __cplusplus
 }

--- a/subsys/bluetooth/audio/ccp_call_control_client.c
+++ b/subsys/bluetooth/audio/ccp_call_control_client.c
@@ -232,3 +232,22 @@ int bt_ccp_call_control_client_unregister_cb(struct bt_ccp_call_control_client_c
 
 	return 0;
 }
+
+int bt_ccp_call_control_client_get_bearers(struct bt_ccp_call_control_client *client,
+					   struct bt_ccp_call_control_client_bearers *bearers)
+{
+	CHECKIF(client == NULL) {
+		LOG_DBG("client is NULL");
+		return -EINVAL;
+	}
+
+	CHECKIF(bearers == NULL) {
+		LOG_DBG("bearers is NULL");
+		return -EINVAL;
+	}
+
+	memset(bearers, 0, sizeof(*bearers));
+	populate_bearers(client, bearers);
+
+	return 0;
+}

--- a/tests/bluetooth/audio/ccp_call_control_client/src/main.c
+++ b/tests/bluetooth/audio/ccp_call_control_client/src/main.c
@@ -210,3 +210,27 @@ static ZTEST_F(ccp_call_control_client_test_suite,
 	err = bt_ccp_call_control_client_discover(&fixture->conn, NULL);
 	zassert_equal(-EINVAL, err, "Unexpected return value %d", err);
 }
+
+static ZTEST_F(ccp_call_control_client_test_suite, test_ccp_call_control_client_get_bearers)
+{
+	struct bt_ccp_call_control_client_bearers bearers;
+	int err;
+
+	err = bt_ccp_call_control_client_register_cb(&mock_ccp_call_control_client_cb);
+	zassert_equal(0, err, "Unexpected return value %d", err);
+
+	err = bt_ccp_call_control_client_discover(&fixture->conn, &fixture->client);
+	zassert_equal(0, err, "Unexpected return value %d", err);
+
+	err = bt_ccp_call_control_client_get_bearers(fixture->client, &bearers);
+	zassert_equal(0, err, "Unexpected return value %d", err);
+
+#if defined(CONFIG_BT_TBS_CLIENT_GTBS)
+	zassert_not_null(bearers.gtbs_bearer);
+#endif /* CONFIG_BT_TBS_CLIENT_GTBS */
+
+#if defined(CONFIG_BT_TBS_CLIENT_TBS)
+	zassert_equal(CONFIG_BT_TBS_CLIENT_MAX_TBS_INSTANCES, bearers.tbs_count);
+	zassert_not_null(bearers.tbs_bearers);
+#endif /* CONFIG_BT_TBS_CLIENT_TBS */
+}


### PR DESCRIPTION
Add bt_ccp_client_get_bearers that will return the bearers of
a client so that the application can always retrieve them if they
do not store them from the discovery callback.