### PR TITLE
STM32U0 serie:  update documentation informations

### DIFF
--- a/boards/st/nucleo_u031r8/doc/index.rst
+++ b/boards/st/nucleo_u031r8/doc/index.rst
@@ -29,6 +29,12 @@ board:
 - Two push-buttons: USER and RESET
 - USB Type-C |reg| connector for the ST-LINK
 
+.. image:: img/nucleo_u031r8.jpg
+   :align: center
+   :alt: Nucleo U031R8
+
+More information about the board can be found at the `NUCLEO_U031R8 website`_.
+
 Hardware
 ********
 

--- a/boards/st/nucleo_u083rc/doc/index.rst
+++ b/boards/st/nucleo_u083rc/doc/index.rst
@@ -29,6 +29,12 @@ board:
 - Two push-buttons: USER and RESET
 - USB Type-C |reg| connector for the ST-LINK
 
+.. image:: img/nucleo_u083rc.jpg
+   :align: center
+   :alt: Nucleo U083RC
+
+More information about the board can be found at the `NUCLEO_U083RC website`_.
+
 Hardware
 ********
 

--- a/boards/st/stm32u083c_dk/doc/index.rst
+++ b/boards/st/stm32u083c_dk/doc/index.rst
@@ -36,6 +36,12 @@ board:
 - Touchkey
 - Temperature sensor
 
+.. image:: img/stm32u083c_dk.jpg
+   :align: center
+   :alt: STM32U083C_DK
+
+More information about the board can be found at the `STM32U083_DK website`_.
+
 Hardware
 ********
 


### PR DESCRIPTION
Add missing references in documentation for each available boards so that they can be displayed like others  boards documentation. 
update  index.rst files for : 
-  nucleo_u083rc 
- nucleo_u031r8
-  stm32u083c_dk 