### PR TITLE
Start TinyCrypt deprecation

### DIFF
--- a/doc/releases/migration-guide-4.0.rst
+++ b/doc/releases/migration-guide-4.0.rst
@@ -75,6 +75,19 @@ Mbed TLS
   corresponding build symbol was removed in Mbed TLS 3.1.0 and is now assumed to
   be enabled. (:github:`77657`)
 
+TinyCrypt
+=========
+
+* Starting from this release the library is marked as deprecated (:github:`79566`).
+  The reasons for this are (:github:`43712``):
+
+  * the upstream version of this library is unmaintained.
+
+  * to reduce the number of crypto libraries available in Zephyr (currently there are
+    3 different implementations: TinyCrypt, MbedTLS and PSA Crypto APIs).
+
+  The PSA Crypto API is now the de-facto standard to perform crypto operations.
+
 Trusted Firmware-M
 ==================
 

--- a/doc/releases/release-notes-4.0.rst
+++ b/doc/releases/release-notes-4.0.rst
@@ -56,6 +56,16 @@ Deprecated in this release
 
 * The :ref:`kscan_api` subsystem has been marked as deprecated.
 
+* The TinyCrypt library was marked as deprecated (:github:`79566`). The reasons
+  for this are (:github:`43712``):
+
+  * the upstream version of this library is unmaintained.
+
+  * to reduce the number of crypto libraries available in Zephyr (currently there are
+    3 different implementations: TinyCrypt, MbedTLS and PSA Crypto APIs).
+
+  The PSA Crypto API is now the de-facto standard to perform crypto operations.
+
 Architectures
 *************
 

--- a/modules/Kconfig.tinycrypt
+++ b/modules/Kconfig.tinycrypt
@@ -9,6 +9,7 @@ config ZEPHYR_TINYCRYPT_MODULE
 config TINYCRYPT
 	bool "TinyCrypt Support"
 	depends on ZEPHYR_TINYCRYPT_MODULE
+	select DEPRECATED
 	help
 	  This option enables the TinyCrypt cryptography library.
 


### PR DESCRIPTION
## Description

This PR:

- moves TinyCrypt library to the deprecation phase (as planned in #43712)
- updates the documentation (release-notes and migration-guide)

## Work in progress

Remove all usages of TinyCrypt from the Zephyr's codebase as required from the [API Lifecycle documentation](https://docs.zephyrproject.org/latest/develop/api/api_lifecycle.html#deprecated)

- https://github.com/zephyrproject-rtos/zephyr/pull/79653
- https://github.com/zephyrproject-rtos/zephyr/pull/79931

## To do

- add a new line in https://github.com/zephyrproject-rtos/zephyr/issues/77070