### PR TITLE
drivers: nrfwifi: Fix FW patch file linking

### DIFF
--- a/drivers/wifi/nrfwifi/CMakeLists.txt
+++ b/drivers/wifi/nrfwifi/CMakeLists.txt
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-zephyr_library()
+zephyr_library_named(nrfwifi)
 
 set(OS_AGNOSTIC_BASE ${ZEPHYR_HAL_NORDIC_MODULE_DIR}/drivers/nrf_wifi)
 set(FW_BINS_BASE ${ZEPHYR_HAL_NORDIC_MODULE_DIR}/zephyr/blobs/wifi_fw_bins)
@@ -166,8 +166,13 @@ else()
       ------------------------------------------------------------------------")
   endif()
 
-  zephyr_compile_definitions(
-    -DCONFIG_NRF_WIFI_FW_BIN=${NRF70_PATCH}
+  set(gen_inc_dir ${ZEPHYR_BINARY_DIR}/misc/generated)
+  zephyr_include_directories(${gen_inc_dir})
+  set(gen_dir ${gen_inc_dir}/nrf70_fw_patch)
+  generate_inc_file_for_target(
+    nrfwifi
+    ${NRF70_PATCH}
+    ${gen_dir}/nrf70.bin.inc
   )
 endif()
 

--- a/drivers/wifi/nrfwifi/CMakeLists.txt
+++ b/drivers/wifi/nrfwifi/CMakeLists.txt
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-zephyr_library_named(nrfwifi)
+zephyr_library()
 
 set(OS_AGNOSTIC_BASE ${ZEPHYR_HAL_NORDIC_MODULE_DIR}/drivers/nrf_wifi)
 set(FW_BINS_BASE ${ZEPHYR_HAL_NORDIC_MODULE_DIR}/zephyr/blobs/wifi_fw_bins)
@@ -169,22 +169,6 @@ else()
   zephyr_compile_definitions(
     -DCONFIG_NRF_WIFI_FW_BIN=${NRF70_PATCH}
   )
-
-  # Rebuild fw_load.c whenever the firmware binary changes
-  # a bit crude way to do it, but it works
-  add_custom_command(
-    OUTPUT ${CMAKE_SOURCE_DIR}/src/fw_load.c
-    COMMAND ${CMAKE_COMMAND} -E touch ${CMAKE_SOURCE_DIR}/src/fw_load.c
-    DEPENDS ${NRF70_PATCH}
-    COMMENT "Checking firmware blobs ${NRF70_PATCH}"
-  )
-
-  add_custom_target(
-    check_firmware_blobs ALL
-    DEPENDS ${CMAKE_SOURCE_DIR}/src/fw_load.c
-  )
-
-  add_dependencies(nrfwifi check_firmware_blobs)
 endif()
 
 

--- a/drivers/wifi/nrfwifi/src/fw_load.c
+++ b/drivers/wifi/nrfwifi/src/fw_load.c
@@ -17,57 +17,16 @@
 LOG_MODULE_DECLARE(wifi_nrf, CONFIG_WIFI_NRF70_LOG_LEVEL);
 
 #include <fmac_main.h>
-
-/* INCBIN macro Taken from https://gist.github.com/mmozeiko/ed9655cf50341553d282 */
-#define STR2(x) #x
-#define STR(x) STR2(x)
-
-#ifdef __APPLE__
-#define USTR(x) "_" STR(x)
-#else
-#define USTR(x) STR(x)
-#endif
-
-#ifdef _WIN32
-#define INCBIN_SECTION ".rdata, \"dr\""
-#elif defined __APPLE__
-#define INCBIN_SECTION "__TEXT,__const"
-#else
-#define INCBIN_SECTION ".rodata.*"
-#endif
-
-/* this aligns start address to 16 and terminates byte array with explicit 0
- * which is not really needed, feel free to change it to whatever you want/need
- */
-#define INCBIN(prefix, name, file) \
-	__asm__(".section " INCBIN_SECTION "\n" \
-			".global " USTR(prefix) "_" STR(name) "_start\n" \
-			".balign 16\n" \
-			USTR(prefix) "_" STR(name) "_start:\n" \
-			".incbin \"" file "\"\n" \
-			\
-			".global " STR(prefix) "_" STR(name) "_end\n" \
-			".balign 1\n" \
-			USTR(prefix) "_" STR(name) "_end:\n" \
-			".byte 0\n" \
-	); \
-	extern __aligned(16)    const char prefix ## _ ## name ## _start[]; \
-	extern                  const char prefix ## _ ## name ## _end[];
-
-INCBIN(_bin, nrf70_fw, STR(CONFIG_NRF_WIFI_FW_BIN));
+static const char fw_patch[] = {
+	#include <nrf70_fw_patch/nrf70.bin.inc>
+};
 
 enum nrf_wifi_status nrf_wifi_fw_load(void *rpu_ctx)
 {
 	enum nrf_wifi_status status = NRF_WIFI_STATUS_FAIL;
 	struct nrf_wifi_fmac_fw_info fw_info = { 0 };
-	uint8_t *fw_start;
-	uint8_t *fw_end;
 
-	fw_start = (uint8_t *)_bin_nrf70_fw_start;
-	fw_end = (uint8_t *)_bin_nrf70_fw_end;
-
-	status = nrf_wifi_fmac_fw_parse(rpu_ctx, fw_start, fw_end - fw_start,
-					&fw_info);
+	status = nrf_wifi_fmac_fw_parse(rpu_ctx, fw_patch, sizeof(fw_patch), &fw_info);
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		LOG_ERR("%s: nrf_wifi_fmac_fw_parse failed", __func__);
 		return status;


### PR DESCRIPTION
Use a Zephyr native approach to link a binary file instead of a custom INCBIN approach.