### PR TITLE
xtensa: enhanced handling of toolchain environment variables

### DIFF
--- a/arch/xtensa/core/CMakeLists.txt
+++ b/arch/xtensa/core/CMakeLists.txt
@@ -53,7 +53,7 @@ set(CORE_ISA_DM ${CMAKE_BINARY_DIR}/zephyr/include/generated/zephyr/core-isa-dM.
 set(CORE_ISA_IN ${CMAKE_BINARY_DIR}/zephyr/include/generated/core-isa-dM.c)
 file(WRITE ${CORE_ISA_IN} "#include <xtensa/config/core-isa.h>\n")
 add_custom_command(OUTPUT ${CORE_ISA_DM}
-  COMMAND ${CMAKE_C_COMPILER} -E -dM -U__XCC__
+  COMMAND ${CMAKE_C_COMPILER} -E -dM -U__XCC__ ${XTENSA_CORE_LOCAL_C_FLAG}
           -I${ZEPHYR_XTENSA_MODULE_DIR}/zephyr/soc/${CONFIG_SOC}
           -I${SOC_FULL_DIR}
           ${CORE_ISA_IN} -o ${CORE_ISA_DM})

--- a/cmake/compiler/xcc/generic.cmake
+++ b/cmake/compiler/xcc/generic.cmake
@@ -17,13 +17,13 @@ TOOLCHAIN_VER: ${TOOLCHAIN_VER}
 endif()
 
 execute_process(
-  COMMAND ${CMAKE_C_COMPILER} --version
+  COMMAND ${CMAKE_C_COMPILER} --version ${XTENSA_CORE_LOCAL_C_FLAG}
   RESULT_VARIABLE ret
   OUTPUT_VARIABLE stdoutput
   )
 if(ret)
   message(FATAL_ERROR "Executing the below command failed. Are permissions set correctly?
-  ${CMAKE_C_COMPILER} --version
+  ${CMAKE_C_COMPILER} --version ${XTENSA_CORE_LOCAL_C_FLAG}
   ${stdoutput}
 "
     )

--- a/cmake/toolchain/xcc/common.cmake
+++ b/cmake/toolchain/xcc/common.cmake
@@ -7,7 +7,29 @@ if(NOT EXISTS ${XTENSA_TOOLCHAIN_PATH})
   message(FATAL_ERROR "Nothing found at XTENSA_TOOLCHAIN_PATH: '${XTENSA_TOOLCHAIN_PATH}'")
 endif()
 
-set(TOOLCHAIN_HOME ${XTENSA_TOOLCHAIN_PATH}/$ENV{TOOLCHAIN_VER}/XtensaTools)
+zephyr_get(TOOLCHAIN_VER)
+if(DEFINED TOOLCHAIN_VER)
+  set(XTENSA_TOOLCHAIN_VER ${TOOLCHAIN_VER})
+else()
+  zephyr_get(TOOLCHAIN_VER_${NORMALIZED_BOARD_TARGET})
+  if(DEFINED TOOLCHAIN_VER_${NORMALIZED_BOARD_TARGET})
+    set(XTENSA_TOOLCHAIN_VER ${TOOLCHAIN_VER_${NORMALIZED_BOARD_TARGET}})
+  else()
+    message(FATAL "Environment variable TOOLCHAIN_VER must be set or given as -DTOOLCHAIN_VER=<var>")
+  endif()
+endif()
+
+zephyr_get(XTENSA_CORE_${NORMALIZED_BOARD_TARGET})
+if(DEFINED XTENSA_CORE_${NORMALIZED_BOARD_TARGET})
+  set(XTENSA_CORE_LOCAL_C_FLAG "--xtensa-core=${XTENSA_CORE_${NORMALIZED_BOARD_TARGET}}")
+  list(APPEND TOOLCHAIN_C_FLAGS "--xtensa-core=${XTENSA_CORE_${NORMALIZED_BOARD_TARGET}}")
+else()
+  # Not having XTENSA_CORE is not necessarily fatal as
+  # the toolchain can have a default core configuration to use.
+  set(XTENSA_CORE_LOCAL_C_FLAG)
+endif()
+
+set(TOOLCHAIN_HOME ${XTENSA_TOOLCHAIN_PATH}/${XTENSA_TOOLCHAIN_VER}/XtensaTools)
 
 set(LINKER ld)
 set(BINTOOLS gnu)

--- a/cmake/toolchain/xt-clang/generic.cmake
+++ b/cmake/toolchain/xt-clang/generic.cmake
@@ -7,4 +7,14 @@ set(CC clang)
 set(C++ clang++)
 set(LINKER xt-ld)
 
+# xt-clang uses GNU Assembler (xt-as) based on binutils.
+# However, CMake doesn't recognize it when invoking through xt-clang.
+# This results in CMake going through all possible combinations of
+# command line arguments while invoking xt-clang to determine
+# assembler vendor. This multiple invocation of xt-clang unnecessarily
+# lengthens the CMake phase of build, especially when xt-clang needs to
+# obtain license information from remote licensing servers. So here
+# forces the assembler ID to be GNU to speed things up a bit.
+set(CMAKE_ASM_COMPILER_ID "GNU")
+
 message(STATUS "Found toolchain: xt-clang (${XTENSA_TOOLCHAIN_PATH})")

--- a/doc/develop/toolchains/cadence_xcc.rst
+++ b/doc/develop/toolchains/cadence_xcc.rst
@@ -31,21 +31,46 @@ Cadence Tensilica Xtensa C/C++ Compiler (XCC)
    * Set :envvar:`ZEPHYR_TOOLCHAIN_VARIANT` to ``xcc`` or ``xt-clang``.
    * Set :envvar:`XTENSA_TOOLCHAIN_PATH` to the toolchain installation
      directory.
-   * Set :envvar:`XTENSA_CORE` to the SoC ID where application is being
-     targeting.
-   * Set :envvar:`TOOLCHAIN_VER` to the Xtensa SDK version.
+
+   * There are two ways to specify the SoC ID and the SDK version to use.
+     They are mutually exclusive, and cannot be used together.
+
+     #. When building for a single SoC:
+
+        * Set :envvar:`XTENSA_CORE` to the SoC ID where application is being
+          targeted.
+        * Set :envvar:`TOOLCHAIN_VER` to the Xtensa SDK version.
+
+     #. When building for multiple SoCs, for each SoC and board combination:
+
+        * Set :envvar:`XTENSA_CORE_{normalized_board_target}`
+          to the SoC ID where application is being targeted.
+        * Set :envvar:`TOOLCHAIN_VAR_{normalized_board_target}`
+          to the Xtensa SDK version.
 
 #. For example, assuming the SDK is installed in ``/opt/xtensa``, and
-   using the SDK for application development on ``intel_adsp_cavs15``,
-   setup the environment using:
+   using the SDK for application development on ``intel_adsp/ace15_mtpm``,
+   setup the environment using the two above mentioned ways:
 
-   .. code-block:: console
+   #. Single SoC:
 
-      # Linux
-      export ZEPHYR_TOOLCHAIN_VARIANT=xcc
-      export XTENSA_TOOLCHAIN_PATH=/opt/xtensa/XtDevTools/install/tools/
-      export XTENSA_CORE=X6H3SUE_RI_2018_0
-      export TOOLCHAIN_VER=RI-2018.0-linux
+      .. code-block:: console
+
+         # Linux
+         export ZEPHYR_TOOLCHAIN_VARIANT=xt-clang
+         export XTENSA_TOOLCHAIN_PATH=/opt/xtensa/XtDevTools/install/tools/
+         export XTENSA_CORE=ace10_LX7HiFi4_2022_10
+         export TOOLCHAIN_VER=RI-2022.10-linux
+
+   #. Muiltiple SoCs:
+
+      .. code-block:: console
+
+         # Linux
+         export ZEPHYR_TOOLCHAIN_VARIANT=xt-clang
+         export XTENSA_TOOLCHAIN_PATH=/opt/xtensa/XtDevTools/install/tools/
+         export TOOLCHAIN_VER_intel_adsp_ace15_mtpm=RI-2022.10-linux
+         export XTENSA_CORE_intel_adsp_ace15_mtpm=ace10_LX7HiFi4_2022_10
 
 #. To use Clang-based compiler:
 


### PR DESCRIPTION
To use Xtensa toolchain, various environment variables must be set so the executables can find necessary files and what core to compile for. This becomes an annoyance when you have to test multiple boards with different cores. You have to use one set of environment variables per core. Twister cannot test them all in one setting, and it is especially annoying doing west builds. So enhance the environment variables handling so that TOOLCHAIN_VER and XTENSA_CORE can be replaced by TOOLCHAIN_VAR_<board> and XTENSA_CORE_<board> where <board> is the normalized board target (think <board>.yaml). CMake will then figure out the core ID for the toolchain to use.

Also force `xt-as` to be identified as GNU Assembler via xt-clang to keep cmake from running it through a bunch of options to determine the assembler ID.