### PR TITLE
soc: nxp: lpc55xxx: fix dependencies for SOC_FLASH_MCUX

### DIFF
--- a/soc/nxp/lpc/lpc55xxx/Kconfig.defconfig
+++ b/soc/nxp/lpc/lpc55xxx/Kconfig.defconfig
@@ -53,7 +53,7 @@ config CAN_MCUX_MCAN
 
 endif # SOC_LPC55S16
 
-if SOC_LPC55S69
+if SOC_LPC55S69_CPU0
 
 config SOC_FLASH_MCUX
 	default y
@@ -63,7 +63,7 @@ config SOC_FLASH_MCUX
 config I2S_MCUX_FLEXCOMM
 	select INIT_PLL0
 
-endif # SOC_LPC55S69
+endif # SOC_LPC55S69_CPU0
 
 if SOC_LPC55S69_CPU1
 


### PR DESCRIPTION
SOC_FLASH_MCUX has additional dependencies for LPC55xxx CPUs, due to the fact that the flash should be disabled when executing in nonsecure mode.

Since the merge of HWMv2, this dependency has been set incorrectly at the SOC level, resulting in the IAP flash driver being enabled when targeting CPU1, which is incorrect. Fix the Kconfig dependency to resolve this issue.

Fixes #79576