### PR TITLE
twister: blackbox: coverage: fix matching pattern

### DIFF
--- a/scripts/tests/twister_blackbox/test_coverage.py
+++ b/scripts/tests/twister_blackbox/test_coverage.py
@@ -47,7 +47,7 @@ class TestCoverage:
                 'coverage.log', 'coverage.json',
                 'coverage'
             ],
-            r'{"files": \[], "gcovr/format_version": ".*"}'
+            r'{"files": \[\], "gcovr/format_version": ".*"}'
         ),
     ]
     TESTDATA_4 = [
@@ -244,7 +244,7 @@ class TestCoverage:
                 with open(path, "r") as json_file:
                     json_content = json.load(json_file)
                     pattern = re.compile(expected_content)
-                    assert pattern.match(json.dumps(json_content))
+                    assert pattern.match(json.dumps(json_content, sort_keys=True))
         if os.path.exists(base_dir):
             os.rmdir(base_dir)
 


### PR DESCRIPTION
Fix the expected pattern randomly matched to coverage.json contents ordered differently at test_coverage_basedir().

Observed at this CI run
https://github.com/zephyrproject-rtos/zephyr/actions/runs/11236963165/job/31244976048?pr=79510#step:9:93

```
E                    +  where None = <built-in method match of re.Pattern object at 0x562591a0ac60>('{"gcovr/format_version": "0.10", "files": []}')
E                    +    where <built-in method match of re.Pattern object at 0x562591a0ac60> = re.compile('{"files": \\[], "gcovr/format_version": ".*"}').match
E                    +    and   '{"gcovr/format_version": "0.10", "files": []}' = <function dumps at 0x7f23020beca0>({'files': [], 'gcovr/format_version': '0.10'})
E                    +      where <function dumps at 0x7f23020beca0> = json.dumps

scripts/tests/twister_blackbox/test_coverage.py:247: AssertionError
```