### PR TITLE
tests: drivers: build_all: gpio: Correct max14906 and max14916 compatibility

### DIFF
--- a/tests/drivers/build_all/gpio/app.overlay
+++ b/tests/drivers/build_all/gpio/app.overlay
@@ -443,8 +443,8 @@
 				#gpio-cells = <2>;
 			};
 
-			test_spi_max14906: max14906@5 {
-				compatible = "adi,max1906-gpio";
+			test_spi_max14906: max14906@6 {
+				compatible = "adi,max14906-gpio";
 				status = "okay";
 				reg = <0x06>;
 				spi-max-frequency = <0>;
@@ -463,8 +463,8 @@
 				en-gpios = <&test_gpio 0 0>;
 			};
 
-			test_spi_max14916: max14916@6 {
-				compatible = "adi,max1916-gpio";
+			test_spi_max14916: max14916@7 {
+				compatible = "adi,max14916-gpio";
 				status = "okay";
 				reg = <0x07>;
 				spi-max-frequency = <0>;


### PR DESCRIPTION
Replace wrong compatibility strings for max14906 and max14916.
Fix wrong addressees for max14906 and max14916.