### PR TITLE
Bluetooth: Add a validation for le_conn_update_complete() and bt_hci_le_subrate_change_event()

### DIFF
--- a/include/zephyr/bluetooth/hci_types.h
+++ b/include/zephyr/bluetooth/hci_types.h
@@ -2969,6 +2969,13 @@ struct bt_hci_evt_le_advertising_report {
 	struct bt_hci_evt_le_advertising_info adv_info[0];
 } __packed;
 
+/** All limits according to BT Core Spec v5.4 [Vol 4, Part E]. */
+#define BT_HCI_LE_INTERVAL_MIN           0x0006
+#define BT_HCI_LE_INTERVAL_MAX           0x0c80
+#define BT_HCI_LE_PERIPHERAL_LATENCY_MAX 0x01f3
+#define BT_HCI_LE_SUPERVISON_TIMEOUT_MIN 0x000a
+#define BT_HCI_LE_SUPERVISON_TIMEOUT_MAX 0x0c80
+
 #define BT_HCI_EVT_LE_CONN_UPDATE_COMPLETE      0x03
 struct bt_hci_evt_le_conn_update_complete {
 	uint8_t  status;
@@ -3337,6 +3344,11 @@ struct bt_hci_evt_le_biginfo_adv_report {
 	uint8_t  framing;
 	uint8_t  encryption;
 } __packed;
+
+/** All limits according to BT Core Spec v5.4 [Vol 4, Part E]. */
+#define BT_HCI_LE_SUBRATE_FACTOR_MIN   0x0001
+#define BT_HCI_LE_SUBRATE_FACTOR_MAX   0x01f4
+#define BT_HCI_LE_CONTINUATION_NUM_MAX 0x01f3
 
 #define BT_HCI_EVT_LE_SUBRATE_CHANGE            0x23
 struct bt_hci_evt_le_subrate_change {

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -1929,6 +1929,23 @@ static void le_conn_update_complete(struct net_buf *buf)
 			conn->le.latency = sys_le16_to_cpu(evt->latency);
 			conn->le.timeout = sys_le16_to_cpu(evt->supv_timeout);
 
+			if (!IS_ENABLED(CONFIG_BT_CONN_PARAM_ANY)) {
+				if (!IN_RANGE(conn->le.interval, BT_HCI_LE_INTERVAL_MIN,
+					      BT_HCI_LE_INTERVAL_MAX)) {
+					LOG_WRN("interval exceeds the valid range 0x%04x",
+						conn->le.interval);
+				}
+				if (conn->le.latency > BT_HCI_LE_PERIPHERAL_LATENCY_MAX) {
+					LOG_WRN("latency exceeds the valid range 0x%04x",
+						conn->le.latency);
+				}
+				if (!IN_RANGE(conn->le.timeout, BT_HCI_LE_SUPERVISON_TIMEOUT_MIN,
+					      BT_HCI_LE_SUPERVISON_TIMEOUT_MAX)) {
+					LOG_WRN("supv_timeout exceeds the valid range 0x%04x",
+						conn->le.timeout);
+				}
+			}
+
 #if defined(CONFIG_BT_GAP_AUTO_UPDATE_CONN_PARAMS)
 			atomic_clear_bit(conn->flags,
 					 BT_CONN_PERIPHERAL_PARAM_AUTO_UPDATE);
@@ -2626,6 +2643,27 @@ void bt_hci_le_subrate_change_event(struct net_buf *buf)
 		conn->le.subrate.continuation_number = sys_le16_to_cpu(evt->continuation_number);
 		conn->le.latency = sys_le16_to_cpu(evt->peripheral_latency);
 		conn->le.timeout = sys_le16_to_cpu(evt->supervision_timeout);
+
+		if (!IS_ENABLED(CONFIG_BT_CONN_PARAM_ANY)) {
+			if (!IN_RANGE(conn->le.subrate.factor, BT_HCI_LE_SUBRATE_FACTOR_MIN,
+				      BT_HCI_LE_SUBRATE_FACTOR_MAX)) {
+				LOG_WRN("subrate_factor exceeds the valid range %d",
+					conn->le.subrate.factor);
+			}
+			if (conn->le.latency > BT_HCI_LE_PERIPHERAL_LATENCY_MAX) {
+				LOG_WRN("peripheral_latency exceeds the valid range 0x%04x",
+					conn->le.latency);
+			}
+			if (conn->le.subrate.continuation_number > BT_HCI_LE_CONTINUATION_NUM_MAX) {
+				LOG_WRN("continuation_number exceeds the valid range %d",
+					conn->le.subrate.continuation_number);
+			}
+			if (!IN_RANGE(conn->le.timeout, BT_HCI_LE_SUPERVISON_TIMEOUT_MIN,
+				      BT_HCI_LE_SUPERVISON_TIMEOUT_MAX)) {
+				LOG_WRN("supervision_timeout exceeds the valid range 0x%04x",
+					conn->le.timeout);
+			}
+		}
 	}
 
 	params.status = evt->status;


### PR DESCRIPTION
Like 2ca179c96e3e, check and warn if incoming HCI event parameters exceed the specification to help debugging.  
Although this does not strictly comply with the specification, I don't see any misuse (like div-by-zero).  
So, adding warnings seems enough at this point.