### PR TITLE
west: boards: add full_name support in format string

### DIFF
--- a/scripts/west_commands/boards.py
+++ b/scripts/west_commands/boards.py
@@ -49,6 +49,7 @@ class Boards(WestCommand):
             The following arguments are available:
 
             - name: board name
+            - full_name: board full name (typically, its commercial name)
             - qualifiers: board qualifiers (will be empty for legacy boards)
             - arch: board architecture (deprecated)
                     (arch is ambiguous for boards described in new hw model)
@@ -102,6 +103,7 @@ class Boards(WestCommand):
             log.inf(
                 args.format.format(
                     name=board.name,
+                    full_name=board.full_name,
                     dir=board.dir,
                     hwm=board.hwm,
                     vendor=board.vendor,


### PR DESCRIPTION
The recently introduced board.full_name property can now be used as part of the format string in the `west boards -f ...` command.

With the changes from #79571, this gives:

```
$ west boards -f "{name} ({full_name})"

esp32c3_042_oled (ESP32C3 0.42 OLED)
roc_rk3568_pc (ROC-RK3568-PC (Quad-core Cortex-A55))
decawave_dwm1001_dev (Decawave DWM1001)
intel_ehl_crb (Elkhart Lake CRB)
intel_ish_5_4_1 (Integrated Sensor Hub (ISH) 5.4.1)
intel_ish_5_6_0 (Integrated Sensor Hub (ISH) 5.6.0)
intel_ish_5_8_0 (Integrated Sensor Hub (ISH) 5.8.0)
niosv_m (INTEL FPGA niosv_m)
intel_adl_crb (Alder Lake CRB)
intel_adl_rvp (Alder Lake RVP)
niosv_g (INTEL FPGA niosv_g)
intel_adsp (Intel ADSP)
intel_rpl_p_crb (Raptor Lake P CRB)
intel_rpl_s_crb (Raptor Lake S CRB)
...
```