### PR TITLE
cmake: flash: Update OPENOCD variables to work with sysbuild

### DIFF
--- a/cmake/flash/CMakeLists.txt
+++ b/cmake/flash/CMakeLists.txt
@@ -61,6 +61,8 @@ function(runners_yaml_append_config)
     runners_yaml_append("  uf2_file: ${uf2}")
   endif()
 
+  zephyr_get(OPENOCD)
+  zephyr_get(OPENOCD_DEFAULT_PATH)
   if(CMAKE_GDB OR OPENOCD OR OPENOCD_DEFAULT_PATH)
     runners_yaml_append("  # Host tools:")
   endif()


### PR DESCRIPTION
Defining OPENOCD and OPENOCD_DEFAULT_PATH when we are using sysbuild doesn't make any effect.
This updates flash.cmake to make these variables compatible with sysbuild.