### PR TITLE
arch: arm: core: cortex_a_r: enable the VFP unit on boot for FPU_SHARING

### DIFF
--- a/arch/arm/core/cortex_a_r/prep_c.c
+++ b/arch/arm/core/cortex_a_r/prep_c.c
@@ -111,7 +111,6 @@ static inline void z_arm_floating_point_init(void)
 	__set_CPACR(reg_val);
 	barrier_isync_fence_full();
 
-#if !defined(CONFIG_FPU_SHARING)
 	/*
 	 * FPEXC: Floating-Point Exception Control register
 	 * comp. ARM Architecture Reference Manual, ARMv7-A and ARMv7-R edition,
@@ -132,7 +131,6 @@ static inline void z_arm_floating_point_init(void)
 	 * [29..00]    = Subarchitecture defined -> not relevant here.
 	 */
 	__set_FPEXC(FPEXC_EN);
-#endif
 #endif
 }
 


### PR DESCRIPTION
The FPU is already disabled by the z_arm_svc function when the first thread starts. Therefore, disabling the FPU at boot is unnecessary for lazy FPU; instead, it must be enabled to handle floating-point instructions before the lazy FPU works.
This fixes #79585.