### PR TITLE
boards: nordic: ipc: added dcache alignement

### DIFF
--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20-ipc_conf.dtsi
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20-ipc_conf.dtsi
@@ -24,6 +24,7 @@
 
 		cpuapp_cpurad_ipc: ipc-2-3 {
 			compatible = "zephyr,ipc-icbmsg";
+			dcache-alignment = <32>;
 			status = "disabled";
 			mboxes = <&cpuapp_bellboard 18>,
 				 <&cpurad_bellboard 12>;

--- a/boards/nordic/nrf9280pdk/nrf9280pdk_nrf9280-ipc_conf.dtsi
+++ b/boards/nordic/nrf9280pdk/nrf9280pdk_nrf9280-ipc_conf.dtsi
@@ -24,6 +24,7 @@
 
 		cpuapp_cpurad_ipc: ipc-2-3 {
 			compatible = "zephyr,ipc-icbmsg";
+			dcache-alignment = <32>;
 			status = "disabled";
 			mboxes = <&cpuapp_bellboard 18>,
 				 <&cpurad_bellboard 12>;

--- a/doc/services/ipc/ipc_service/backends/ipc_service_icbmsg.rst
+++ b/doc/services/ipc/ipc_service/backends/ipc_service_icbmsg.rst
@@ -40,11 +40,20 @@ Configuration
 The backend is configured using Kconfig and devicetree.
 When configuring the backend, do the following:
 
+* If at least one of the cores uses data cache on shared memory, set the ``dcache-alignment`` value.
+  This must be the largest value of the invalidation or the write-back size for both sides of the communication.
+  You can skip it if none of the communication sides is using data cache on shared memory.
 * Define two memory regions and assign them to ``tx-region`` and ``rx-region`` of an instance.
   Ensure that the memory regions used for data exchange are unique (not overlapping any other region) and accessible by both domains (or CPUs).
 * Define the number of allocable blocks for each region with ``tx-blocks`` and ``rx-blocks``.
 * Define MBOX devices for sending a signal that informs the other domain (or CPU) of the written data.
   Ensure that the other domain (or CPU) can receive the signal.
+
+.. caution::
+
+    Make sure that you set correct value of the ``dcache-alignment``.
+    At first, wrong value may not show any signs, which may give a false impression that everything works.
+    Unstable behavior will appear sooner or later.
 
 See the following configuration example for one of the instances:
 
@@ -63,6 +72,7 @@ See the following configuration example for one of the instances:
    ipc {
       ipc0: ipc0 {
          compatible = "zephyr,ipc-icbmsg";
+         dcache-alignment = <32>;
          tx-region = <&tx>;
          rx-region = <&rx>;
          tx-blocks = <16>;

--- a/doc/services/ipc/ipc_service/backends/ipc_service_icmsg.rst
+++ b/doc/services/ipc/ipc_service/backends/ipc_service_icmsg.rst
@@ -24,6 +24,9 @@ Configuration
 The  backend is configured via Kconfig and devicetree.
 When configuring the backend, do the following:
 
+* If at least one of the cores uses data cache on shared memory, set the ``dcache-alignment`` value.
+  This must be the largest value of the invalidation or the write-back size for both sides of the communication.
+  You can skip it if none of the communication sides is using data cache on shared memory.
 * Define two memory regions and assign them to ``tx-region`` and ``rx-region``
   of an instance. Ensure that the memory regions used for data exchange are
   unique (not overlapping any other region) and accessible by both domains
@@ -31,6 +34,12 @@ When configuring the backend, do the following:
 * Define MBOX devices which are used to send the signal that informs the other
   domain (or CPU) that data has been written. Ensure that the other domain
   (or CPU) is able to receive the signal.
+
+.. caution::
+
+    Make sure that you set correct value of the ``dcache-alignment``.
+    At first, wrong value may not show any signs, which may give a false impression that everything works.
+    Unstable behavior will appear sooner or later.
 
 See the following configuration example for one of the instances:
 
@@ -49,6 +58,7 @@ See the following configuration example for one of the instances:
       ipc {
          ipc0: ipc0 {
             compatible = "zephyr,ipc-icmsg";
+            dcache-alignment = <32>;
             tx-region = <&tx>;
             rx-region = <&rx>;
             mboxes = <&mbox 0>, <&mbox 1>;

--- a/dts/bindings/ipc/zephyr,ipc-icmsg.yaml
+++ b/dts/bindings/ipc/zephyr,ipc-icmsg.yaml
@@ -32,7 +32,7 @@ properties:
       For example:
         Side A: no data cache
         Side B: 32 Bytes write-back size, 16 Bytes invalidation size
-        dcache-alignment = 32; for both
+        dcache-alignment = <32>; for both
 
   mboxes:
     description: phandle to the MBOX controller (TX and RX are required)

--- a/samples/subsys/ipc/ipc_service/icmsg/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/samples/subsys/ipc/ipc_service/icmsg/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -23,6 +23,7 @@
 	ipc {
 		ipc0: ipc0 {
 			compatible = "zephyr,ipc-icmsg";
+			dcache-alignment = <32>;
 			tx-region = <&sram_tx>;
 			rx-region = <&sram_rx>;
 			mboxes = <&cpuapp_vevif_rx 20>, <&cpuapp_vevif_tx 21>;

--- a/samples/subsys/ipc/ipc_service/icmsg/boards/nrf54l15dk_nrf54l15_cpuapp_icbmsg.overlay
+++ b/samples/subsys/ipc/ipc_service/icmsg/boards/nrf54l15dk_nrf54l15_cpuapp_icbmsg.overlay
@@ -23,6 +23,7 @@
 	ipc {
 		ipc0: ipc0 {
 			compatible = "zephyr,ipc-icbmsg";
+			dcache-alignment = <32>;
 			tx-region = <&sram_tx>;
 			rx-region = <&sram_rx>;
 			tx-blocks = <16>;

--- a/samples/subsys/ipc/ipc_service/icmsg/remote/boards/nrf54l15dk_nrf54l15_cpuflpr.overlay
+++ b/samples/subsys/ipc/ipc_service/icmsg/remote/boards/nrf54l15dk_nrf54l15_cpuflpr.overlay
@@ -23,6 +23,7 @@
 	ipc {
 		ipc0: ipc0 {
 			compatible = "zephyr,ipc-icmsg";
+			dcache-alignment = <32>;
 			tx-region = <&sram_tx>;
 			rx-region = <&sram_rx>;
 			mboxes = <&cpuflpr_vevif_rx 21>, <&cpuflpr_vevif_tx 20>;

--- a/samples/subsys/ipc/ipc_service/icmsg/remote/boards/nrf54l15dk_nrf54l15_cpuflpr_icbmsg.overlay
+++ b/samples/subsys/ipc/ipc_service/icmsg/remote/boards/nrf54l15dk_nrf54l15_cpuflpr_icbmsg.overlay
@@ -23,6 +23,7 @@
 	ipc {
 		ipc0: ipc0 {
 			compatible = "zephyr,ipc-icbmsg";
+			dcache-alignment = <32>;
 			tx-region = <&sram_tx>;
 			rx-region = <&sram_rx>;
 			tx-blocks = <18>;

--- a/subsys/ipc/ipc_service/backends/ipc_icbmsg.c
+++ b/subsys/ipc/ipc_service/backends/ipc_icbmsg.c
@@ -1434,11 +1434,11 @@ const static struct ipc_service_backend backend_ops = {
 	};										\
 	BUILD_ASSERT(IS_POWER_OF_TWO(GET_CACHE_ALIGNMENT(i)),				\
 		     "This module supports only power of two cache alignment");		\
-	BUILD_ASSERT((GET_BLOCK_SIZE_INST(i, tx, rx) > GET_CACHE_ALIGNMENT(i)) &&	\
+	BUILD_ASSERT((GET_BLOCK_SIZE_INST(i, tx, rx) >= GET_CACHE_ALIGNMENT(i)) &&	\
 		     (GET_BLOCK_SIZE_INST(i, tx, rx) <					\
 		      GET_MEM_SIZE_INST(i, tx)),					\
 		     "TX region is too small for provided number of blocks");		\
-	BUILD_ASSERT((GET_BLOCK_SIZE_INST(i, rx, tx) > GET_CACHE_ALIGNMENT(i)) &&	\
+	BUILD_ASSERT((GET_BLOCK_SIZE_INST(i, rx, tx) >= GET_CACHE_ALIGNMENT(i)) &&	\
 		     (GET_BLOCK_SIZE_INST(i, rx, tx) <					\
 		      GET_MEM_SIZE_INST(i, rx)),					\
 		     "RX region is too small for provided number of blocks");		\


### PR DESCRIPTION
The nRF54 and nRF92 chips has data cache, which means the ICMsg and ICBMsg must be configured to follow required cache alignment of the shared memory.
The `dcache-alignement` needs to be defined for that.