### PR TITLE
manifest: update picolibc to avoid setting of CMAKE_BUILD_TYPE

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -315,7 +315,7 @@ manifest:
         - debug
     - name: picolibc
       path: modules/lib/picolibc
-      revision: 27746bbc246841852912fc3bb5b45094cd8a505a
+      revision: d492d5fa7c96918e37653f303028346bb0dd51a2
     - name: segger
       revision: b011c45b585e097d95d9cf93edf4f2e01588d3cd
       path: modules/debug/segger


### PR DESCRIPTION
This commit updates picolibc module so that CMAKE_BUILD_TYPE is not defined by picolibc when building with Zephyr.

The avoids a situation where both picolibc and Zephyr defines the optimization level, for example like: `-Os -O2`.

And remove the warning:
> CMake Warning at .../zephyr/CMakeLists.txt:2166 (message):
>
> The CMake build type was set to 'MinSizeRel', but the optimization
> flag was set to '-O2'.