### PR TITLE
Bluetooth: BAP: Add BT_AUDIO_RTN_PREF_NONE

### DIFF
--- a/include/zephyr/bluetooth/audio/audio.h
+++ b/include/zephyr/bluetooth/audio/audio.h
@@ -47,6 +47,8 @@ extern "C" {
 #define BT_AUDIO_PD_PREF_NONE                    0x000000U
 /** Maximum presentation delay in microseconds */
 #define BT_AUDIO_PD_MAX                          0xFFFFFFU
+/** Indicates that the unicast server does not have a preference for any retransmission number */
+#define BT_AUDIO_RTN_PREF_NONE                   0xFFU
 /** Maximum size of the broadcast code in octets */
 #define BT_AUDIO_BROADCAST_CODE_SIZE             16
 

--- a/include/zephyr/bluetooth/audio/bap.h
+++ b/include/zephyr/bluetooth/audio/bap.h
@@ -245,7 +245,11 @@ struct bt_bap_qos_cfg_pref {
 	 */
 	uint8_t phy;
 
-	/** Preferred Retransmission Number */
+	/**
+	 * @brief Preferred Retransmission Number
+	 *
+	 * @ref BT_AUDIO_RTN_PREF_NONE indicates no preference.
+	 */
 	uint8_t rtn;
 
 	/**


### PR DESCRIPTION
Add BT_AUDIO_RTN_PREF_NONE which indicates no preference from the server for number of retransmissions chosen by the client.