### PR TITLE
drivers: ipm: xlnx: fix AMD copyright

### DIFF
--- a/drivers/ipm/ipm_xlnx_ipi.c
+++ b/drivers/ipm/ipm_xlnx_ipi.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 AMD-Xilinx Inc.
+ * Copyright (c) 2023 Advanced Micro Devices, Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */


### PR DESCRIPTION
There is nothing like AMD-Xilinx Inc. That's why use full AMD name instead.

Fixes: 09e2a4e9ebdb ("drivers: ipm: add zynqmp r5f support")
Co-developed-by: Sayyed, Mubin <mubin.sayyed@amd.com>