### PR TITLE
tests: build_all: input: clean up the i2c device list

### DIFF
--- a/tests/drivers/build_all/input/app.overlay
+++ b/tests/drivers/build_all/input/app.overlay
@@ -253,22 +253,21 @@
 				irq-gpios = <&test_gpio 0 0>;
 			};
 
-			pinnacle@2a {
+			pinnacle@8 {
 				compatible = "cirque,pinnacle";
-				reg = <0x2a>;
+				reg = <0x8>;
 				data-ready-gpios = <&test_gpio 0 0>;
 				data-mode = "relative";
 				primary-tap-enable;
 				swap-xy;
 			};
 
-			touch_dev: ili2132a@41 {
+			touch_dev: ili2132a@9 {
 				compatible = "ilitek,ili2132a";
-				reg = <0x41>;
+				reg = <0x9>;
 				irq-gpios = <&test_gpio 0 0>;
 				rst-gpios = <&test_gpio 1 0>;
 			};
-
 		};
 
 		spi@2 {


### PR DESCRIPTION
Make the address sequential again, drop a stray blank line.