### PR TITLE
MIMXRT1062 IVT needs to be FIRST

### DIFF
--- a/soc/nxp/imxrt/CMakeLists.txt
+++ b/soc/nxp/imxrt/CMakeLists.txt
@@ -31,6 +31,7 @@ if(CONFIG_SOC_SERIES_IMXRT10XX OR CONFIG_SOC_SERIES_IMXRT11XX)
           ${boot_hdr_dcd_data_section}
           ${boot_hdr_xmcd_data_section}
     OFFSET ${CONFIG_IMAGE_VECTOR_TABLE_OFFSET}
+    FIRST
     KEEP
     PRIO 11
   )


### PR DESCRIPTION
IMXRT1062 bootrom reads boothdr initial vector table from 0x60001000. In the CMAKE scatter linker scripts we put multiple sections at offset 0x1000 in the rom. In linkers other than LD, we are not guaranteed a particular order when placing these. If we specify FIRST we can count on the .ivt coming first. The other positions aren't as crucial.

From IMXRT1060RM.pdf 9.7.1

> The location of the IVT is the only fixed requirement by the ROM.
> The remainder or the image memory map is flexible and
> is determined by the contents of the IVT.