### PR TITLE
dts: nxp mcxc: Configure boot source to flash

### DIFF
--- a/dts/arm/nxp/nxp_mcxc_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxc_common.dtsi
@@ -57,7 +57,7 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 			fsec = <0xff>;
-			fopt = <0xff>;
+			fopt = <0x3d>;
 			config-field-offset = <0x400>;
 
 			flash0: flash@0 {


### PR DESCRIPTION
NXP mcxc series has boot source configured to ROM. ROM bootloader waits 5 sec for active peripheral detection timeout before jumping to application in flash which makes booting very slow. Change configuration to boot from flash and allow boot source selection by external pin.