### PR TITLE
net: lib: sntp_simple: Handle responses from previous iterations

### DIFF
--- a/include/zephyr/net/sntp.h
+++ b/include/zephyr/net/sntp.h
@@ -73,13 +73,24 @@ int sntp_init(struct sntp_ctx *ctx, struct sockaddr *addr,
  *
  * @param ctx Address of sntp context.
  * @param timeout Timeout of waiting for sntp response (in milliseconds).
- * @param time Timestamp including integer and fractional seconds since
+ * @param ts Timestamp including integer and fractional seconds since
  * 1 Jan 1970 (output).
  *
  * @return 0 if ok, <0 if error (-ETIMEDOUT if timeout).
  */
-int sntp_query(struct sntp_ctx *ctx, uint32_t timeout,
-	       struct sntp_time *time);
+int sntp_query(struct sntp_ctx *ctx, uint32_t timeout, struct sntp_time *ts);
+
+/**
+ * @brief Attempt to receive an SNTP response after issuing a query
+ *
+ * @param ctx Address of sntp context.
+ * @param timeout Timeout of waiting for sntp response (in milliseconds).
+ * @param ts Timestamp including integer and fractional seconds since
+ * 1 Jan 1970 (output).
+ *
+ * @return 0 if ok, <0 if error (-ETIMEDOUT if timeout).
+ */
+int sntp_recv_response(struct sntp_ctx *ctx, uint32_t timeout, struct sntp_time *ts);
 
 /**
  * @brief Release SNTP context


### PR DESCRIPTION
SNTP simple runs request iterations with exponential backoff. If the net interface is a slower connection (ie. CAT M1 modems) then the request will be sent but the response may take time to be received, thus causing a timeout and another request to be sent. Because of the nature of UDP and the fact that the same socket (source IP/port combo) is being used for both requests, a delayed response to the first request can be received as the response to the second request, causing -EINVAL to be returned when the timestamps mismatch (see subsys/net/lib/sntp/sntp.c). **Edit (old commit message):** ~The solution provided closes the sntp context (thus closing the socket) on timeout and opens a new one to be used for the next iteration.~ The solution provided retries receiving the response when the timestamp is mismatched (without sending an additional request).

Diagram of the current problem
```mermaid
sequenceDiagram
    Client->>+Server: Request1
    Client->>+Client: Timeout on socket read
    Client->>+Server: Request2
    Server->>+Client: Response1 (Processed on iteration 2, mismatch on timestamp comparison, returns -EINVAL, loop exits)
    Server->>+Client: Response2 (Not processed, dropped when the socket is closed)
```

Fixes #81120