### PR TITLE
Bluetooth: Audio: Fix initial Broadcast source values

### DIFF
--- a/include/zephyr/bluetooth/audio/bap.h
+++ b/include/zephyr/bluetooth/audio/bap.h
@@ -41,6 +41,9 @@
 extern "C" {
 #endif
 
+/** An invalid Broadcast ID */
+#define BT_BAP_INVALID_BROADCAST_ID 0xFFFFFFFFU
+
 /**
  * @brief Helper to declare elements of bt_bap_qos_cfg
  *

--- a/samples/bluetooth/bap_broadcast_assistant/src/main.c
+++ b/samples/bluetooth/bap_broadcast_assistant/src/main.c
@@ -33,7 +33,6 @@
 #define PA_SYNC_SKIP         5
 #define PA_SYNC_INTERVAL_TO_TIMEOUT_RATIO 20 /* Set the timeout relative to interval */
 /* Broadcast IDs are 24bit, so this is out of valid range */
-#define INVALID_BROADCAST_ID 0xFFFFFFFFU
 
 static void scan_for_broadcast_sink(void);
 
@@ -297,7 +296,7 @@ static void scan_recv_cb(const struct bt_le_scan_recv_info *info,
 	if (scanning_for_broadcast_source) {
 		/* Scan for and select Broadcast Source */
 
-		sr_info.broadcast_id = INVALID_BROADCAST_ID;
+		sr_info.broadcast_id = BT_BAP_INVALID_BROADCAST_ID;
 
 		/* We are only interested in non-connectable periodic advertisers */
 		if ((info->adv_props & BT_GAP_ADV_PROP_CONNECTABLE) != 0 ||
@@ -307,7 +306,7 @@ static void scan_recv_cb(const struct bt_le_scan_recv_info *info,
 
 		bt_data_parse(ad, device_found, (void *)&sr_info);
 
-		if (sr_info.broadcast_id != INVALID_BROADCAST_ID) {
+		if (sr_info.broadcast_id != BT_BAP_INVALID_BROADCAST_ID) {
 			printk("Broadcast Source Found:\n");
 			printk("  BT Name:        %s\n", sr_info.bt_name);
 			printk("  Broadcast Name: %s\n", sr_info.broadcast_name);
@@ -545,7 +544,7 @@ static void reset(void)
 	printk("\n\nReset...\n\n");
 
 	broadcast_sink_conn = NULL;
-	selected_broadcast_id = INVALID_BROADCAST_ID;
+	selected_broadcast_id = BT_BAP_INVALID_BROADCAST_ID;
 	selected_sid = 0;
 	selected_pa_interval = 0;
 	(void)memset(&selected_addr, 0, sizeof(selected_addr));

--- a/samples/bluetooth/bap_broadcast_sink/src/main.c
+++ b/samples/bluetooth/bap_broadcast_sink/src/main.c
@@ -58,7 +58,6 @@ BUILD_ASSERT(IS_ENABLED(CONFIG_SCAN_SELF) || IS_ENABLED(CONFIG_SCAN_OFFLOAD),
 #define ADV_TIMEOUT K_FOREVER
 #endif /* CONFIG_SCAN_SELF */
 
-#define INVALID_BROADCAST_ID        (BT_AUDIO_BROADCAST_ID_MAX + 1)
 #define PA_SYNC_INTERVAL_TO_TIMEOUT_RATIO 5 /* Set the timeout relative to interval */
 #define PA_SYNC_SKIP                5
 #define NAME_LEN                    sizeof(CONFIG_TARGET_BROADCAST_NAME) + 1
@@ -1361,7 +1360,7 @@ static int reset(void)
 	(void)memset(sink_broadcast_code, 0, sizeof(sink_broadcast_code));
 	(void)memset(&broadcaster_info, 0, sizeof(broadcaster_info));
 	(void)memset(&broadcaster_addr, 0, sizeof(broadcaster_addr));
-	broadcaster_broadcast_id = INVALID_BROADCAST_ID;
+	broadcaster_broadcast_id = BT_BAP_INVALID_BROADCAST_ID;
 
 	if (broadcast_sink != NULL) {
 		err = bt_bap_broadcast_sink_delete(broadcast_sink);

--- a/samples/bluetooth/pbp_public_broadcast_sink/src/main.c
+++ b/samples/bluetooth/pbp_public_broadcast_sink/src/main.c
@@ -36,7 +36,6 @@
 #define SEM_TIMEOUT K_SECONDS(10)
 #define PA_SYNC_SKIP         5
 #define PA_SYNC_INTERVAL_TO_TIMEOUT_RATIO 20 /* Set the timeout relative to interval */
-#define INVALID_BROADCAST_ID 0xFFFFFFFF
 
 static bool pbs_found;
 
@@ -203,7 +202,7 @@ static bool scan_check_and_sync_broadcast(struct bt_data *data, void *user_data)
 		 * Continue parsing if Broadcast Audio Announcement Service
 		 * was not found.
 		 */
-		if (*broadcast_id == INVALID_BROADCAST_ID) {
+		if (*broadcast_id == BT_BAP_INVALID_BROADCAST_ID) {
 			return true;
 		}
 	}
@@ -223,10 +222,10 @@ static void broadcast_scan_recv(const struct bt_le_scan_recv_info *info,
 		return;
 	}
 
-	broadcast_id = INVALID_BROADCAST_ID;
+	broadcast_id = BT_BAP_INVALID_BROADCAST_ID;
 	bt_data_parse(ad, scan_check_and_sync_broadcast, (void *)&broadcast_id);
 
-	if ((broadcast_id != INVALID_BROADCAST_ID) && pbs_found) {
+	if ((broadcast_id != BT_BAP_INVALID_BROADCAST_ID) && pbs_found) {
 		sync_broadcast_pa(info, broadcast_id);
 	}
 }

--- a/samples/bluetooth/tmap_bmr/src/bap_broadcast_sink.c
+++ b/samples/bluetooth/tmap_bmr/src/bap_broadcast_sink.c
@@ -29,7 +29,6 @@
 #define SEM_TIMEOUT K_SECONDS(10)
 #define PA_SYNC_SKIP         5
 #define PA_SYNC_INTERVAL_TO_TIMEOUT_RATIO 20 /* Set the timeout relative to interval */
-#define INVALID_BROADCAST_ID 0xFFFFFFFF
 
 static bool tmap_bms_found;
 
@@ -209,10 +208,10 @@ static void broadcast_scan_recv(const struct bt_le_scan_recv_info *info,
 		return;
 	}
 
-	broadcast_id = INVALID_BROADCAST_ID;
+	broadcast_id = BT_BAP_INVALID_BROADCAST_ID;
 	bt_data_parse(ad, scan_check_and_sync_broadcast, (void *)&broadcast_id);
 
-	if ((broadcast_id != INVALID_BROADCAST_ID) && tmap_bms_found) {
+	if ((broadcast_id != BT_BAP_INVALID_BROADCAST_ID) && tmap_bms_found) {
 		sync_broadcast_pa(info, broadcast_id);
 	}
 }

--- a/subsys/bluetooth/audio/bap_broadcast_assistant.c
+++ b/subsys/bluetooth/audio/bap_broadcast_assistant.c
@@ -955,6 +955,8 @@ static int broadcast_assistant_reset(struct bap_broadcast_assistant_instance *in
 
 	for (int i = 0U; i < CONFIG_BT_BAP_BROADCAST_ASSISTANT_RECV_STATE_COUNT; i++) {
 		memset(&inst->recv_states[i], 0, sizeof(inst->recv_states[i]));
+		inst->recv_states[i].broadcast_id = BT_BAP_INVALID_BROADCAST_ID;
+		inst->recv_states[i].adv_sid = BT_HCI_LE_EXT_ADV_SID_INVALID;
 		inst->recv_states[i].past_avail = false;
 		inst->recv_state_handles[i] = 0U;
 	}

--- a/subsys/bluetooth/audio/bap_broadcast_sink.c
+++ b/subsys/bluetooth/audio/bap_broadcast_sink.c
@@ -51,11 +51,6 @@ LOG_MODULE_REGISTER(bt_bap_broadcast_sink, CONFIG_BT_BAP_BROADCAST_SINK_LOG_LEVE
 #define PA_SYNC_INTERVAL_TO_TIMEOUT_RATIO 20 /* Set the timeout relative to interval */
 #define BROADCAST_SYNC_MIN_INDEX  (BIT(1))
 
-/* any value above 0xFFFFFF is invalid, so we can just use 0xFFFFFFFF to denote
- * invalid broadcast ID
- */
-#define INVALID_BROADCAST_ID 0xFFFFFFFF
-
 static struct bt_bap_ep broadcast_sink_eps[CONFIG_BT_BAP_BROADCAST_SNK_COUNT]
 					  [CONFIG_BT_BAP_BROADCAST_SNK_STREAM_COUNT];
 static struct bt_bap_broadcast_sink broadcast_sinks[CONFIG_BT_BAP_BROADCAST_SNK_COUNT];
@@ -435,7 +430,7 @@ static struct bt_bap_broadcast_sink *broadcast_sink_free_get(void)
 		if (!atomic_test_bit(broadcast_sinks[i].flags,
 				     BT_BAP_BROADCAST_SINK_FLAG_INITIALIZED)) {
 			broadcast_sinks[i].index = i;
-			broadcast_sinks[i].broadcast_id = INVALID_BROADCAST_ID;
+			broadcast_sinks[i].broadcast_id = BT_BAP_INVALID_BROADCAST_ID;
 
 			return &broadcast_sinks[i];
 		}

--- a/subsys/bluetooth/audio/shell/bap.c
+++ b/subsys/bluetooth/audio/shell/bap.c
@@ -2345,7 +2345,6 @@ static int cmd_preset(const struct shell *sh, size_t argc, char *argv[])
 #endif /* IS_BAP_INITIATOR */
 
 #if defined(CONFIG_BT_BAP_BROADCAST_SINK)
-#define INVALID_BROADCAST_ID (BT_AUDIO_BROADCAST_ID_MAX + 1)
 #define PA_SYNC_INTERVAL_TO_TIMEOUT_RATIO 20 /* Set the timeout relative to interval */
 #define PA_SYNC_SKIP         5
 
@@ -2354,14 +2353,14 @@ static struct broadcast_sink_auto_scan {
 	uint32_t broadcast_id;
 	struct bt_le_per_adv_sync **out_sync;
 } auto_scan = {
-	.broadcast_id = INVALID_BROADCAST_ID,
+	.broadcast_id = BT_BAP_INVALID_BROADCAST_ID,
 };
 
 static void clear_auto_scan(void)
 {
-	if (auto_scan.broadcast_id != INVALID_BROADCAST_ID) {
+	if (auto_scan.broadcast_id != BT_BAP_INVALID_BROADCAST_ID) {
 		memset(&auto_scan, 0, sizeof(auto_scan));
-		auto_scan.broadcast_id = INVALID_BROADCAST_ID;
+		auto_scan.broadcast_id = BT_BAP_INVALID_BROADCAST_ID;
 	}
 }
 

--- a/subsys/bluetooth/audio/shell/bap_broadcast_assistant.c
+++ b/subsys/bluetooth/audio/shell/bap_broadcast_assistant.c
@@ -36,8 +36,6 @@
 #include "../../host/hci_core.h"
 #include "audio.h"
 
-#define INVALID_BROADCAST_ID 0xFFFFFFFFU
-
 static uint8_t received_base[UINT8_MAX];
 static size_t received_base_size;
 
@@ -47,7 +45,7 @@ static struct bt_auto_scan {
 	bool pa_sync;
 	struct bt_bap_bass_subgroup subgroup;
 } auto_scan = {
-	.broadcast_id = INVALID_BROADCAST_ID,
+	.broadcast_id = BT_BAP_INVALID_BROADCAST_ID,
 };
 
 struct bt_scan_recv_info {
@@ -518,9 +516,9 @@ static void scan_recv_cb(const struct bt_le_scan_recv_info *info,
 	struct bt_bap_broadcast_assistant_add_src_param param = { 0 };
 	int err;
 
-	sr_info.broadcast_id = INVALID_BROADCAST_ID;
+	sr_info.broadcast_id = BT_BAP_INVALID_BROADCAST_ID;
 
-	if ((auto_scan.broadcast_id == INVALID_BROADCAST_ID) &&
+	if ((auto_scan.broadcast_id == BT_BAP_INVALID_BROADCAST_ID) &&
 	    (strlen(auto_scan.broadcast_name) == 0U)) {
 		/* no op */
 		return;
@@ -539,7 +537,7 @@ static void scan_recv_cb(const struct bt_le_scan_recv_info *info,
 	bt_data_parse(ad, broadcast_source_found, (void *)&sr_info);
 
 	/* Verify that it is a BAP broadcaster*/
-	if (sr_info.broadcast_id != INVALID_BROADCAST_ID) {
+	if (sr_info.broadcast_id != BT_BAP_INVALID_BROADCAST_ID) {
 		char addr_str[BT_ADDR_LE_STR_LEN];
 		bool identified_broadcast = false;
 
@@ -581,7 +579,7 @@ static void scan_recv_cb(const struct bt_le_scan_recv_info *info,
 			}
 
 			memset(&auto_scan, 0, sizeof(auto_scan));
-			auto_scan.broadcast_id = INVALID_BROADCAST_ID;
+			auto_scan.broadcast_id = BT_BAP_INVALID_BROADCAST_ID;
 		}
 	}
 }
@@ -591,7 +589,7 @@ static void scan_timeout_cb(void)
 	shell_print(ctx_shell, "Scan timeout");
 
 	memset(&auto_scan, 0, sizeof(auto_scan));
-	auto_scan.broadcast_id = INVALID_BROADCAST_ID;
+	auto_scan.broadcast_id = BT_BAP_INVALID_BROADCAST_ID;
 }
 
 static struct bt_le_scan_cb scan_callbacks = {
@@ -635,7 +633,7 @@ static int cmd_bap_broadcast_assistant_add_broadcast_id(const struct shell *sh,
 	unsigned long broadcast_id;
 	int err = 0;
 
-	if (auto_scan.broadcast_id != INVALID_BROADCAST_ID) {
+	if (auto_scan.broadcast_id != BT_BAP_INVALID_BROADCAST_ID) {
 		shell_info(sh, "Already scanning, wait for sync or timeout");
 
 		return -ENOEXEC;
@@ -764,7 +762,7 @@ static int cmd_bap_broadcast_assistant_add_broadcast_name(const struct shell *sh
 
 	/* Store results in the `auto_scan` struct */
 	utf8_lcpy(auto_scan.broadcast_name, broadcast_name, strlen(broadcast_name) + 1);
-	auto_scan.broadcast_id = INVALID_BROADCAST_ID;
+	auto_scan.broadcast_id = BT_BAP_INVALID_BROADCAST_ID;
 	memcpy(&auto_scan.subgroup, &subgroup, sizeof(subgroup));
 
 	return 0;

--- a/tests/bluetooth/tester/src/audio/btp_bap_broadcast.c
+++ b/tests/bluetooth/tester/src/audio/btp_bap_broadcast.c
@@ -31,7 +31,6 @@ static struct btp_bap_broadcast_local_source local_source;
 static struct btp_bap_broadcast_remote_source *broadcast_source_to_sync;
 /* A mask for the maximum BIS we can sync to. +1 since the BIS indexes start from 1. */
 static const uint32_t bis_index_mask = BIT_MASK(CONFIG_BT_BAP_BROADCAST_SNK_STREAM_COUNT + 1);
-#define INVALID_BROADCAST_ID      (BT_AUDIO_BROADCAST_ID_MAX + 1)
 #define PA_SYNC_INTERVAL_TO_TIMEOUT_RATIO 20 /* Set the timeout relative to interval */
 #define PA_SYNC_SKIP              5
 static struct bt_bap_bass_subgroup
@@ -62,7 +61,7 @@ static struct btp_bap_broadcast_remote_source *remote_broadcaster_alloc(void)
 	for (size_t i = 0; i < ARRAY_SIZE(remote_broadcast_sources); i++) {
 		struct btp_bap_broadcast_remote_source *broadcaster = &remote_broadcast_sources[i];
 
-		if (broadcaster->broadcast_id == INVALID_BROADCAST_ID) {
+		if (broadcaster->broadcast_id == BT_BAP_INVALID_BROADCAST_ID) {
 			return broadcaster;
 		}
 	}
@@ -214,7 +213,7 @@ static void remote_broadcaster_free(struct btp_bap_broadcast_remote_source *broa
 {
 	(void)memset(broadcaster, 0, sizeof(*broadcaster));
 
-	broadcaster->broadcast_id = INVALID_BROADCAST_ID;
+	broadcaster->broadcast_id = BT_BAP_INVALID_BROADCAST_ID;
 
 	for (size_t i = 0U; i < ARRAY_SIZE(broadcaster->sink_streams); i++) {
 		broadcaster->sink_streams[i] = stream_broadcast_to_bap(&broadcaster->streams[i]);

--- a/tests/bsim/bluetooth/audio/src/bap_broadcast_sink_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_broadcast_sink_test.c
@@ -755,7 +755,7 @@ static void test_broadcast_sink_create_inval(void)
 		return;
 	}
 
-	err = bt_bap_broadcast_sink_create(pa_sync, INVALID_BROADCAST_ID, &g_sink);
+	err = bt_bap_broadcast_sink_create(pa_sync, BT_BAP_INVALID_BROADCAST_ID, &g_sink);
 	if (err == 0) {
 		FAIL("bt_bap_broadcast_sink_create did not fail with invalid broadcast ID\n");
 		return;

--- a/tests/bsim/bluetooth/audio/src/common.h
+++ b/tests/bsim/bluetooth/audio/src/common.h
@@ -103,7 +103,6 @@ static const uint8_t mock_iso_data[] = {
 
 #define AD_SIZE 1
 
-#define INVALID_BROADCAST_ID (BT_AUDIO_BROADCAST_ID_MAX + 1)
 #define PA_SYNC_INTERVAL_TO_TIMEOUT_RATIO 20 /* Set the timeout relative to interval */
 #define PA_SYNC_SKIP         5
 

--- a/tests/bsim/bluetooth/audio/src/pbp_public_broadcast_sink_test.c
+++ b/tests/bsim/bluetooth/audio/src/pbp_public_broadcast_sink_test.c
@@ -183,7 +183,7 @@ static int reset(void)
 	k_sem_reset(&sem_pa_sync_lost);
 	k_sem_reset(&sem_data_received);
 
-	broadcast_id = INVALID_BROADCAST_ID;
+	broadcast_id = BT_BAP_INVALID_BROADCAST_ID;
 	bis_index_bitfield = 0U;
 	pbs_found = false;
 
@@ -275,7 +275,7 @@ static bool scan_check_and_sync_broadcast(struct bt_data *data, void *user_data)
 
 	if (!bt_uuid_cmp(&adv_uuid.uuid, BT_UUID_BROADCAST_AUDIO)) {
 		/* Save broadcast_id */
-		if (broadcast_id == INVALID_BROADCAST_ID) {
+		if (broadcast_id == BT_BAP_INVALID_BROADCAST_ID) {
 			broadcast_id = sys_get_le24(data->data + BT_UUID_SIZE_16);
 		}
 
@@ -292,7 +292,7 @@ static bool scan_check_and_sync_broadcast(struct bt_data *data, void *user_data)
 		pbs_found = true;
 
 		/* Continue parsing if Broadcast Audio Announcement Service was not found */
-		if (broadcast_id == INVALID_BROADCAST_ID) {
+		if (broadcast_id == BT_BAP_INVALID_BROADCAST_ID) {
 			return true;
 		}
 
@@ -316,7 +316,7 @@ static void broadcast_scan_recv(const struct bt_le_scan_recv_info *info,
 
 	bt_data_parse(ad, scan_check_and_sync_broadcast, (void *)&broadcast_id);
 
-	if ((broadcast_id != INVALID_BROADCAST_ID) && pbs_found) {
+	if ((broadcast_id != BT_BAP_INVALID_BROADCAST_ID) && pbs_found) {
 		sync_broadcast_pa(info);
 	}
 }


### PR DESCRIPTION
If the Broadcast ID is initially set to 0x000000,
which is valid, comparison logic on add of an
actual Broadcast ID of 0x000000 fails.

Likewise for SID.

Moving INVALID_BROADCAST_ID define to bap.h