### PR TITLE
cmake: libc: minimal: Avoid linking against other libc implementations

### DIFF
--- a/lib/libc/minimal/CMakeLists.txt
+++ b/lib/libc/minimal/CMakeLists.txt
@@ -1,5 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
+# As minimal libc will be built as a zephyr_library, clear c_library to
+# prevent accidentally requiring or linking against another libc implementation.
+set_property(TARGET linker PROPERTY c_library "")
+
 zephyr_system_include_directories(include)
 
 zephyr_library()


### PR DESCRIPTION
The minimal libc is currently built as a zephyr_library and will be included in the final link line as such. However, the c_library property will still be set as "-lc" (for most linkers) and will be added to the link line. This effectively requires that a separate libc implementation be available in the toolchain and makes it possible to accidentally pull from the non-minimal libc.

This doesn't seem desirable, so try to prevent this by clearing the c_library property if we are using the minimal libc.