### PR TITLE
tests: counter: add current counter value into no_alarm test

### DIFF
--- a/drivers/counter/counter_esp32_tmr.c
+++ b/drivers/counter/counter_esp32_tmr.c
@@ -138,7 +138,22 @@ static int counter_esp32_get_value(const struct device *dev, uint32_t *ticks)
 	struct counter_esp32_data *data = dev->data;
 	k_spinlock_key_t key = k_spin_lock(&lock);
 
+	timer_ll_trigger_soft_capture(data->hal_ctx.dev, data->hal_ctx.timer_id);
+	*ticks = (uint32_t)timer_ll_get_counter_value(data->hal_ctx.dev, data->hal_ctx.timer_id);
+
+	k_spin_unlock(&lock, key);
+
+	return 0;
+}
+
+static int counter_esp32_get_value_64(const struct device *dev, uint64_t *ticks)
+{
+	struct counter_esp32_data *data = dev->data;
+	k_spinlock_key_t key = k_spin_lock(&lock);
+
+	timer_ll_trigger_soft_capture(data->hal_ctx.dev, data->hal_ctx.timer_id);
 	*ticks = timer_ll_get_counter_value(data->hal_ctx.dev, data->hal_ctx.timer_id);
+
 	k_spin_unlock(&lock, key);
 
 	return 0;
@@ -217,6 +232,7 @@ static const struct counter_driver_api counter_api = {
 	.start = counter_esp32_start,
 	.stop = counter_esp32_stop,
 	.get_value = counter_esp32_get_value,
+	.get_value_64 = counter_esp32_get_value_64,
 	.set_alarm = counter_esp32_set_alarm,
 	.cancel_alarm = counter_esp32_cancel_alarm,
 	.set_top_value = counter_esp32_set_top_value,

--- a/tests/drivers/counter/counter_basic_api/src/test_counter.c
+++ b/tests/drivers/counter/counter_basic_api/src/test_counter.c
@@ -684,6 +684,7 @@ static void test_valid_function_without_alarm(const struct device *dev)
 	int err;
 	uint32_t ticks;
 	uint32_t ticks_expected;
+	uint32_t tick_current;
 	uint32_t ticks_tol;
 	uint32_t wait_for_us;
 	uint32_t freq = counter_get_frequency(dev);
@@ -724,6 +725,10 @@ static void test_valid_function_without_alarm(const struct device *dev)
 
 	err = counter_start(dev);
 	zassert_equal(0, err, "%s: counter failed to start", dev->name);
+
+	/* counter might not start from 0, use current value as offset */
+	counter_get_value(dev, &tick_current);
+	ticks_expected += tick_current;
 
 	k_busy_wait(wait_for_us);
 


### PR DESCRIPTION
  In the test scenario without alarms, it might
  be the case that counter is already running and
  it will not match the expected tick.
  This adds a tick offset into the expected value
  based on current counter reading.

Could fix #79574 considering the scenario where `counter_start()` do not reset the timer.