### PR TITLE
pm: Enable PM3 mode for RW612 and set IMU as wakeup source

### DIFF
--- a/boards/nxp/rd_rw612_bga/rd_rw612_bga.dtsi
+++ b/boards/nxp/rd_rw612_bga/rd_rw612_bga.dtsi
@@ -305,3 +305,8 @@ nxp_8080_touch_panel_i2c: &arduino_i2c {
 	status = "okay";
 	wakeup-level = "low";
 };
+
+&imu {
+	status = "okay";
+	wakeup-source;
+};

--- a/dts/bindings/arm/nxp,wifi.yaml
+++ b/dts/bindings/arm/nxp,wifi.yaml
@@ -1,0 +1,12 @@
+# Copyright 2023 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+description: IMU interrupt info
+
+compatible: "nxp,wifi"
+
+include: base.yaml
+
+properties:
+  interrupts:
+    required: true

--- a/samples/net/wifi/boards/rd_rw612_bga.overlay
+++ b/samples/net/wifi/boards/rd_rw612_bga.overlay
@@ -1,0 +1,9 @@
+/*
+ * Copyright 2023 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&standby {
+	status = "okay";
+};

--- a/samples/net/wifi/sample.yaml
+++ b/samples/net/wifi/sample.yaml
@@ -12,6 +12,7 @@ tests:
       - cc3220sf_launchxl
       - disco_l475_iot1
       - reel_board
+      - rd_rw612_bga
     integration_platforms:
       - cc3220sf_launchxl
   sample.net.wifi.mikroe_wifi_bt_click:


### PR DESCRIPTION
Add overlay file for RW612 to enable standby mode (PM3). Set IMU as wakeup source.