### PR TITLE
usb: device_next: uac2: Generate Feature Unit descriptor

### DIFF
--- a/dts/bindings/usb/uac2/zephyr,uac2-feature-unit.yaml
+++ b/dts/bindings/usb/uac2/zephyr,uac2-feature-unit.yaml
@@ -1,0 +1,134 @@
+# Copyright (c) 2024 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+description: USB Audio Class 2 Feature Unit entity
+
+compatible: "zephyr,uac2-feature-unit"
+
+# string-array properties start with Primary channel 0 and follow with Logical
+# channel(s). The "not-present" value is allowed to facilitate having controls
+# that are not present on the Primary channel, but only present at the Logical
+# channel(s).
+
+properties:
+  data-source:
+    type: phandle
+    description: Unit or Terminal to which this Feature Unit is connected
+
+  mute-control:
+    type: string-array
+    description: Mute Control capabilities
+    enum:
+      - "read-only"
+      - "host-programmable"
+      - "not-present"
+
+  volume-control:
+    type: string-array
+    description: Volume Control capabilities
+    enum:
+      - "read-only"
+      - "host-programmable"
+      - "not-present"
+
+  bass-control:
+    type: string-array
+    description: Bass Control capabilities
+    enum:
+      - "read-only"
+      - "host-programmable"
+      - "not-present"
+
+  mid-control:
+    type: string-array
+    description: Mid Control capabilities
+    enum:
+      - "read-only"
+      - "host-programmable"
+      - "not-present"
+
+  treble-control:
+    type: string-array
+    description: Treble Control capabilities
+    enum:
+      - "read-only"
+      - "host-programmable"
+      - "not-present"
+
+  graphic-equalizer-control:
+    type: string-array
+    description: Graphic Equalizer capabilities
+    enum:
+      - "read-only"
+      - "host-programmable"
+      - "not-present"
+
+  automatic-gain-control:
+    type: string-array
+    description: Automatic Gain Control capabilities
+    enum:
+      - "read-only"
+      - "host-programmable"
+      - "not-present"
+
+  delay-control:
+    type: string-array
+    description: Delay Control capabilities
+    enum:
+      - "read-only"
+      - "host-programmable"
+      - "not-present"
+
+  bass-boost-control:
+    type: string-array
+    description: Bass Boost Control capabilities
+    enum:
+      - "read-only"
+      - "host-programmable"
+      - "not-present"
+
+  loundness-control:
+    type: string-array
+    description: Loundness Control capabilities
+    enum:
+      - "read-only"
+      - "host-programmable"
+      - "not-present"
+
+  input-gain-control:
+    type: string-array
+    description: Input Gain Control capabilities
+    enum:
+      - "read-only"
+      - "host-programmable"
+      - "not-present"
+
+  input-gain-pad-control:
+    type: string-array
+    description: Input Gain Pad Control capabilities
+    enum:
+      - "read-only"
+      - "host-programmable"
+      - "not-present"
+
+  phase-inverter-control:
+    type: string-array
+    description: Phase Inverter Control capabilities
+    enum:
+      - "read-only"
+      - "host-programmable"
+      - "not-present"
+
+  underflow-control:
+    type: string-array
+    description: Underflow Control capabilities
+    enum:
+      - "read-only"
+      - "not-present"
+
+  overflow-control:
+    type: string-array
+    description: Overflow Control capabilities
+    enum:
+      - "read-only"
+      - "not-present"

--- a/tests/subsys/usb/uac2/app.overlay
+++ b/tests/subsys/usb/uac2/app.overlay
@@ -29,9 +29,19 @@
 			front-right;
 		};
 
+		out_feature_unit: out_feature_unit {
+			compatible = "zephyr,uac2-feature-unit";
+			data-source = <&out_terminal>;
+			mute-control = "host-programmable";
+			automatic-gain-control =
+				"host-programmable" /* Primary */,
+				"host-programmable" /* Channel 1 */,
+				"host-programmable" /* Channel 2 */;
+		};
+
 		headphones_output: headphones {
 			compatible = "zephyr,uac2-output-terminal";
-			data-source = <&out_terminal>;
+			data-source = <&out_feature_unit>;
 			clock-source = <&uac_aclk>;
 			terminal-type = <BIDIRECTIONAL_TERMINAL_HEADSET>;
 			assoc-terminal = <&mic_input>;
@@ -50,9 +60,18 @@
 			front-left;
 		};
 
+		in_feature_unit: in_feature_unit {
+			compatible = "zephyr,uac2-feature-unit";
+			data-source = <&mic_input>;
+			mute-control = "host-programmable";
+			automatic-gain-control =
+				"not-present" /* Primary */,
+				"host-programmable" /* Channel 1 */;
+		};
+
 		in_terminal: in_terminal {
 			compatible = "zephyr,uac2-output-terminal";
-			data-source = <&mic_input>;
+			data-source = <&in_feature_unit>;
 			clock-source = <&uac_aclk>;
 			terminal-type = <USB_TERMINAL_STREAMING>;
 		};

--- a/tests/subsys/usb/uac2/src/uac2_desc.c
+++ b/tests/subsys/usb/uac2/src/uac2_desc.c
@@ -18,7 +18,7 @@ static const uint8_t reference_ac_interface_descriptor[] = {
 	0x01,			/* bDescriptorSubtype = HEADER */
 	0x00, 0x02,		/* bcdADC = 02.00 */
 	0x04,			/* bCategory = HEADSET */
-	0x4b, 0x00,		/* wTotalLength = 0x4b = 75 */
+	0x6b, 0x00,		/* wTotalLength = 0x6b = 107 */
 	0x00,			/* bmControls = Latency Control not present */
 };
 
@@ -50,15 +50,28 @@ static const uint8_t reference_ac_hp_input_terminal_descriptor[] = {
 	0x00,			/* iTerminal = 0 (no string descriptor) */
 };
 
+static const uint8_t reference_ac_hp_feature_unit_descriptor[] = {
+	/* 4.7.2.8 Feature Unit Descriptor */
+	0x12,			/* bLength = 18 */
+	0x24,			/* bDescriptorType = CS_INTERFACE */
+	0x06,			/* bDescriptorSubtype = FEATURE_UNIT */
+	0x03,			/* bUnitID = 3 */
+	0x02,			/* bSourceID = 2 (streaming input) */
+	0x03, 0x30, 0x00, 0x00, /* bmaControls(0): Mute and Auto Gain */
+	0x00, 0x30, 0x00, 0x00, /* bmaControls(1): Auto Gain */
+	0x00, 0x30, 0x00, 0x00, /* bmaControls(2): Auto Gain */
+	0x00,			/* iFeature = 0 (no string descriptor)*/
+};
+
 static const uint8_t reference_ac_hp_output_terminal_descriptor[] = {
 	/* 4.7.2.5 Output Terminal Descriptor */
 	0x0c,			/* bLength = 12 */
 	0x24,			/* bDescriptorType = CS_INTERFACE */
 	0x03,			/* bDescriptorSubtype = OUTPUT_TERMINAL */
-	0x03,			/* bTerminalID = 3 */
+	0x04,			/* bTerminalID = 4 */
 	0x02, 0x04,		/* wTerminalType = 0x0402 (Headset) */
-	0x04,			/* bAssocTerminal = 4 (headset input) */
-	0x02,			/* bSourceID = 2 (streaming input) */
+	0x05,			/* bAssocTerminal = 5 (headset input) */
+	0x03,			/* bSourceID = 3 (headphones feature unit) */
 	0x01,			/* bCSourceID = 1 (main clock) */
 	0x00, 0x00,		/* bmControls = none present */
 	0x00,			/* iTerminal = 0 (no string descriptor) */
@@ -69,9 +82,9 @@ static const uint8_t reference_ac_mic_input_terminal_descriptor[] = {
 	0x11,			/* bLength = 17 */
 	0x24,			/* bDescriptorType = CS_INTERFACE */
 	0x02,			/* bDescriptorSubtype = INPUT_TERMINAL */
-	0x04,			/* bTerminalID = 4 */
+	0x05,			/* bTerminalID = 5 */
 	0x02, 0x04,		/* wTerminalType = 0x0402 (Headset) */
-	0x03,			/* bAssocTerminal = 3 (headset output) */
+	0x04,			/* bAssocTerminal = 4 (headset output) */
 	0x01,			/* bCSourceID = 1 (main clock) */
 	0x01,			/* bNrChannels = 1 */
 	0x01, 0x00, 0x00, 0x00,	/* bmChannelConfig = Front Left */
@@ -80,15 +93,27 @@ static const uint8_t reference_ac_mic_input_terminal_descriptor[] = {
 	0x00,			/* iTerminal = 0 (no string descriptor) */
 };
 
+static const uint8_t reference_ac_mic_feature_unit_descriptor[] = {
+	/* 4.7.2.8 Feature Unit Descriptor */
+	0x0e,			/* bLength = 14 */
+	0x24,			/* bDescriptorType = CS_INTERFACE */
+	0x06,			/* bDescriptorSubtype = FEATURE_UNIT */
+	0x06,			/* bUnitID = 6 */
+	0x05,			/* bSourceID = 5 (headset input) */
+	0x03, 0x00, 0x00, 0x00, /* bmaControls(0): Mute */
+	0x00, 0x30, 0x00, 0x00, /* bmaControls(1): Auto Gain */
+	0x00,			/* iFeature = 0 (no string descriptor)*/
+};
+
 static const uint8_t reference_ac_mic_output_terminal_descriptor[] = {
 	/* 4.7.2.5 Output Terminal Descriptor */
 	0x0c,			/* bLength = 12 */
 	0x24,			/* bDescriptorType = CS_INTERFACE */
 	0x03,			/* bDescriptorSubtype = OUTPUT_TERMINAL */
-	0x05,			/* bTerminalID = 5 */
+	0x07,			/* bTerminalID = 7 */
 	0x01, 0x01,		/* wTerminalType = 0x0101 (USB streaming) */
 	0x00,			/* bAssocTerminal = 0 (not associated) */
-	0x04,			/* bSourceID = 4 (headset input) */
+	0x06,			/* bSourceID = 6 (mic feature unit) */
 	0x01,			/* bCSourceID = 1 (main clock) */
 	0x00, 0x00,		/* bmControls = none present */
 	0x00,			/* iTerminal = 0 (no string descriptor) */
@@ -100,7 +125,7 @@ static const uint8_t reference_as_in_cs_general_descriptor[] = {
 	0x10,			/* bLength = 16 */
 	0x24,			/* bDescriptorType = CS_INTERFACE */
 	0x01,			/* bDescriptorSubtype = AS_GENERAL */
-	0x05,			/* bTerminalLink = 5 (USB streaming output) */
+	0x07,			/* bTerminalLink = 7 (USB streaming output) */
 	0x00,			/* bmControls = non present */
 	0x01,			/* bFormatType = 1 */
 	0x01, 0x00, 0x00, 0x00,	/* bmFormats = PCM */
@@ -308,11 +333,17 @@ static void test_uac2_descriptors(const struct usb_desc_header **descriptors,
 	zassert_mem_equal(reference_ac_hp_input_terminal_descriptor, *ptr,
 		ARRAY_SIZE(reference_ac_hp_input_terminal_descriptor));
 	ptr++;
+	zassert_mem_equal(reference_ac_hp_feature_unit_descriptor, *ptr,
+		ARRAY_SIZE(reference_ac_hp_feature_unit_descriptor));
+	ptr++;
 	zassert_mem_equal(reference_ac_hp_output_terminal_descriptor, *ptr,
 		ARRAY_SIZE(reference_ac_hp_output_terminal_descriptor));
 	ptr++;
 	zassert_mem_equal(reference_ac_mic_input_terminal_descriptor, *ptr,
 		ARRAY_SIZE(reference_ac_mic_input_terminal_descriptor));
+	ptr++;
+	zassert_mem_equal(reference_ac_mic_feature_unit_descriptor, *ptr,
+		ARRAY_SIZE(reference_ac_mic_feature_unit_descriptor));
 	ptr++;
 	zassert_mem_equal(reference_ac_mic_output_terminal_descriptor, *ptr,
 		ARRAY_SIZE(reference_ac_mic_output_terminal_descriptor));


### PR DESCRIPTION
This PR is limited to Feature Unit descriptor generation because the implementation needed a change in the Zephyr devicetree generator scripts to support string-array properties with enum.

Each Feature Unit control (15 different controls are defined by UAC2 specification) can be present on none (property absent), one channel (e.g. only on Primary channel = property present with just a single value), or any number of channel (e.g. only on Logical channel 1). The use of string-array allows to facilitate any possible control combination (instead of e.g. forcing all logical channels to have the same value as Primary channel) while making the devicetree representation easy to understand and allowing reasonable devicetree-level validation (the strings allowed are one of the enum values) and build-time (each control property can have at most 1 + logical channel values).