### PR TITLE
Bluetooth: audio: Merge ascs service and cb registration

### DIFF
--- a/include/zephyr/bluetooth/audio/bap.h
+++ b/include/zephyr/bluetooth/audio/bap.h
@@ -1024,22 +1024,6 @@ struct bt_bap_stream_ops {
 	void (*disconnected)(struct bt_bap_stream *stream, uint8_t reason);
 };
 
-/** Structure for registering Unicast Server */
-struct bt_bap_unicast_server_register_param {
-	/**
-	 * @brief Sink Count to register.
-	 *
-	 * Should be in range 0 to @kconfig{CONFIG_BT_ASCS_MAX_ASE_SNK_COUNT}
-	 */
-	uint8_t snk_cnt;
-
-	/** @brief Source Count to register.
-	 *
-	 * Should be in range 0 to @kconfig{CONFIG_BT_ASCS_MAX_ASE_SRC_COUNT}
-	 */
-	uint8_t src_cnt;
-};
-
 /**
  * @brief Register Audio callbacks for a stream.
  *
@@ -1434,11 +1418,32 @@ struct bt_bap_unicast_server_cb {
 	int (*release)(struct bt_bap_stream *stream, struct bt_bap_ascs_rsp *rsp);
 };
 
+/** Structure for registering Unicast Server */
+struct bt_bap_unicast_server_register_param {
+	/**
+	 * @brief Sink Count to register.
+	 *
+	 * Shall be in range [0, @kconfig{CONFIG_BT_ASCS_MAX_ASE_SNK_COUNT}]
+	 */
+	uint8_t snk_cnt;
+
+	/** @brief Source Count to register.
+	 *
+	 * Shall be in range [0, @kconfig{CONFIG_BT_ASCS_MAX_ASE_SRC_COUNT}]
+	 */
+	uint8_t src_cnt;
+
+	/** Pointer to the callback structure. */
+	struct bt_bap_unicast_server_cb *cb;
+};
+
 /**
  * @brief Register the Unicast Server.
  *
- * Register the Unicast Server. Only a single Unicast Server can be registered at any one time.
- * This will register ASCS in the GATT database.
+ * Register the Unicast Server. This will register ASCS in the GATT database.
+ * In addition, this will also register the callback structure for the Unicast Server.
+ *
+ * Only a single Unicast Server can be registered at any one time.
  *
  * @param param  Registration parameters for ascs.
  *
@@ -1450,46 +1455,13 @@ int bt_bap_unicast_server_register(const struct bt_bap_unicast_server_register_p
  * @brief Unregister the Unicast Server.
  *
  * Unregister the Unicast Server.
- * This will unregister ASCS in the GATT database.
- * Before calling this function, any callbacks registered through
- * bt_bap_unicast_server_register_cb() needs to be unregistered with
- * bt_bap_unicast_server_unregister_cb().
+ * This will unregister ASCS in the GATT database and unregister callbacks.
  *
- * Calling this function will issue an release operation on any ASE
- * in a non-idle state.
+ * Calling this function will force-release any ASE which are in a non-idle state.
  *
  * @return 0 in case of success, negative error code otherwise.
  */
 int bt_bap_unicast_server_unregister(void);
-
-/**
- * @brief Register unicast server callbacks.
- *
- * Only one callback structure can be registered, and attempting to
- * registering more than one will result in an error.
- * Prior to calling this function the Unicast Server needs to be
- * registered with bt_bap_unicast_server_register().
- *
- * @param cb  Unicast server callback structure.
- *
- * @return 0 in case of success or negative value in case of error.
- */
-int bt_bap_unicast_server_register_cb(const struct bt_bap_unicast_server_cb *cb);
-
-/**
- * @brief Unregister unicast server callbacks.
- *
- * May only unregister a callback structure that has previously been
- * registered by bt_bap_unicast_server_register_cb().
- *
- * Calling this function will issue an release operation on any ASE
- * in a non-idle state.
- *
- * @param cb  Unicast server callback structure.
- *
- * @return 0 in case of success or negative value in case of error.
- */
-int bt_bap_unicast_server_unregister_cb(const struct bt_bap_unicast_server_cb *cb);
 
 /**
  * @typedef bt_bap_ep_func_t

--- a/samples/bluetooth/bap_unicast_server/src/main.c
+++ b/samples/bluetooth/bap_unicast_server/src/main.c
@@ -485,12 +485,7 @@ static int lc3_release(struct bt_bap_stream *stream, struct bt_bap_ascs_rsp *rsp
 	return 0;
 }
 
-static struct bt_bap_unicast_server_register_param param = {
-	CONFIG_BT_ASCS_MAX_ASE_SNK_COUNT,
-	CONFIG_BT_ASCS_MAX_ASE_SRC_COUNT
-};
-
-static const struct bt_bap_unicast_server_cb unicast_server_cb = {
+static struct bt_bap_unicast_server_cb unicast_server_cb = {
 	.config = lc3_config,
 	.reconfig = lc3_reconfig,
 	.qos = lc3_qos,
@@ -502,6 +497,11 @@ static const struct bt_bap_unicast_server_cb unicast_server_cb = {
 	.release = lc3_release,
 };
 
+static struct bt_bap_unicast_server_register_param param = {
+	CONFIG_BT_ASCS_MAX_ASE_SNK_COUNT,
+	CONFIG_BT_ASCS_MAX_ASE_SRC_COUNT,
+	&unicast_server_cb
+};
 
 #if defined(CONFIG_LIBLC3)
 
@@ -748,7 +748,6 @@ int main(void)
 	}
 
 	bt_bap_unicast_server_register(&param);
-	bt_bap_unicast_server_register_cb(&unicast_server_cb);
 
 	bt_pacs_cap_register(BT_AUDIO_DIR_SINK, &cap_sink);
 	bt_pacs_cap_register(BT_AUDIO_DIR_SOURCE, &cap_source);

--- a/samples/bluetooth/cap_acceptor/src/cap_acceptor_unicast.c
+++ b/samples/bluetooth/cap_acceptor/src/cap_acceptor_unicast.c
@@ -236,7 +236,7 @@ static int unicast_server_release_cb(struct bt_bap_stream *bap_stream, struct bt
 	return 0;
 }
 
-static const struct bt_bap_unicast_server_cb unicast_server_cb = {
+static struct bt_bap_unicast_server_cb unicast_server_cb = {
 	.config = unicast_server_config_cb,
 	.reconfig = unicast_server_reconfig_cb,
 	.qos = unicast_server_qos_cb,
@@ -417,19 +417,13 @@ int init_cap_acceptor_unicast(struct peer_config *peer)
 		int err;
 		struct bt_bap_unicast_server_register_param param = {
 			CONFIG_BT_ASCS_MAX_ASE_SNK_COUNT,
-			CONFIG_BT_ASCS_MAX_ASE_SRC_COUNT
+			CONFIG_BT_ASCS_MAX_ASE_SRC_COUNT,
+			&unicast_server_cb
 		};
 
 		err = bt_bap_unicast_server_register(&param);
 		if (err != 0) {
 			LOG_ERR("Failed to register BAP unicast server: %d", err);
-
-			return -ENOEXEC;
-		}
-
-		err = bt_bap_unicast_server_register_cb(&unicast_server_cb);
-		if (err != 0) {
-			LOG_ERR("Failed to register BAP unicast server callbacks: %d", err);
 
 			return -ENOEXEC;
 		}

--- a/samples/bluetooth/hap_ha/src/bap_unicast_sr.c
+++ b/samples/bluetooth/hap_ha/src/bap_unicast_sr.c
@@ -333,12 +333,7 @@ static int lc3_release(struct bt_bap_stream *stream, struct bt_bap_ascs_rsp *rsp
 	return 0;
 }
 
-static struct bt_bap_unicast_server_register_param param = {
-	CONFIG_BT_ASCS_MAX_ASE_SNK_COUNT,
-	CONFIG_BT_ASCS_MAX_ASE_SRC_COUNT
-};
-
-static const struct bt_bap_unicast_server_cb unicast_server_cb = {
+static struct bt_bap_unicast_server_cb unicast_server_cb = {
 	.config = lc3_config,
 	.reconfig = lc3_reconfig,
 	.qos = lc3_qos,
@@ -348,6 +343,12 @@ static const struct bt_bap_unicast_server_cb unicast_server_cb = {
 	.disable = lc3_disable,
 	.stop = lc3_stop,
 	.release = lc3_release,
+};
+
+static struct bt_bap_unicast_server_register_param param = {
+	CONFIG_BT_ASCS_MAX_ASE_SNK_COUNT,
+	CONFIG_BT_ASCS_MAX_ASE_SRC_COUNT,
+	&unicast_server_cb
 };
 
 static void stream_recv(struct bt_bap_stream *stream, const struct bt_iso_recv_info *info,
@@ -420,7 +421,7 @@ int bap_unicast_sr_init(void)
 		.snk_pac = true,
 		.snk_loc = true,
 		.src_pac = true,
-		.src_loc = true,
+		.src_loc = true
 	};
 	int err;
 
@@ -431,7 +432,6 @@ int bap_unicast_sr_init(void)
 	}
 
 	bt_bap_unicast_server_register(&param);
-	bt_bap_unicast_server_register_cb(&unicast_server_cb);
 
 	bt_pacs_cap_register(BT_AUDIO_DIR_SINK, &cap_sink);
 

--- a/samples/bluetooth/tmap_peripheral/src/bap_unicast_sr.c
+++ b/samples/bluetooth/tmap_peripheral/src/bap_unicast_sr.c
@@ -284,12 +284,7 @@ static int lc3_release(struct bt_bap_stream *stream, struct bt_bap_ascs_rsp *rsp
 	return 0;
 }
 
-static struct bt_bap_unicast_server_register_param param = {
-	CONFIG_BT_ASCS_MAX_ASE_SNK_COUNT,
-	CONFIG_BT_ASCS_MAX_ASE_SRC_COUNT
-};
-
-static const struct bt_bap_unicast_server_cb unicast_server_cb = {
+static struct bt_bap_unicast_server_cb unicast_server_cb = {
 	.config = lc3_config,
 	.reconfig = lc3_reconfig,
 	.qos = lc3_qos,
@@ -299,6 +294,12 @@ static const struct bt_bap_unicast_server_cb unicast_server_cb = {
 	.disable = lc3_disable,
 	.stop = lc3_stop,
 	.release = lc3_release,
+};
+
+static struct bt_bap_unicast_server_register_param param = {
+	CONFIG_BT_ASCS_MAX_ASE_SNK_COUNT,
+	CONFIG_BT_ASCS_MAX_ASE_SRC_COUNT,
+	&unicast_server_cb
 };
 
 static void stream_recv(struct bt_bap_stream *stream, const struct bt_iso_recv_info *info,
@@ -385,7 +386,6 @@ int bap_unicast_sr_init(void)
 	}
 
 	bt_bap_unicast_server_register(&param);
-	bt_bap_unicast_server_register_cb(&unicast_server_cb);
 
 	if (IS_ENABLED(CONFIG_BT_PAC_SNK)) {
 		/* Register CT required capabilities */

--- a/subsys/bluetooth/audio/shell/bap.c
+++ b/subsys/bluetooth/audio/shell/bap.c
@@ -751,7 +751,7 @@ static int lc3_release(struct bt_bap_stream *stream, struct bt_bap_ascs_rsp *rsp
 	return 0;
 }
 
-static const struct bt_bap_unicast_server_cb unicast_server_cb = {
+static struct bt_bap_unicast_server_cb unicast_server_cb = {
 	.config = lc3_config,
 	.reconfig = lc3_reconfig,
 	.qos = lc3_qos,
@@ -3768,7 +3768,8 @@ static int cmd_init(const struct shell *sh, size_t argc, char *argv[])
 	unsigned long snk_cnt, src_cnt;
 	struct bt_bap_unicast_server_register_param unicast_server_param = {
 		CONFIG_BT_ASCS_MAX_ASE_SNK_COUNT,
-		CONFIG_BT_ASCS_MAX_ASE_SRC_COUNT
+		CONFIG_BT_ASCS_MAX_ASE_SRC_COUNT,
+		&unicast_server_cb
 	};
 	const struct bt_pacs_register_param pacs_param = {
 #if defined(CONFIG_BT_PAC_SNK)
@@ -3814,10 +3815,7 @@ static int cmd_init(const struct shell *sh, size_t argc, char *argv[])
 	__ASSERT(err == 0, "Failed to register PACS: %d", err);
 
 	err = bt_bap_unicast_server_register(&unicast_server_param);
-	__ASSERT(err == 0, "Failed to register Unicast Server: %d", err);
-
-	err = bt_bap_unicast_server_register_cb(&unicast_server_cb);
-	__ASSERT(err == 0, "Failed to register Unicast Server Callbacks: %d", err);
+	__ASSERT(err == 0, "Failed to register unicast server: %d", err);
 #endif /* CONFIG_BT_BAP_UNICAST_SERVER */
 
 #if defined(CONFIG_BT_PAC_SNK)

--- a/tests/bluetooth/audio/ascs/include/bap_unicast_server.h
+++ b/tests/bluetooth/audio/ascs/include/bap_unicast_server.h
@@ -14,7 +14,7 @@
 #include <zephyr/fff.h>
 #include <zephyr/bluetooth/audio/bap.h>
 
-extern const struct bt_bap_unicast_server_cb mock_bap_unicast_server_cb;
+extern struct bt_bap_unicast_server_cb mock_bap_unicast_server_cb;
 
 void mock_bap_unicast_server_init(void);
 void mock_bap_unicast_server_cleanup(void);

--- a/tests/bluetooth/audio/ascs/src/test_ase_state_transition.c
+++ b/tests/bluetooth/audio/ascs/src/test_ase_state_transition.c
@@ -67,14 +67,12 @@ static void test_ase_snk_state_transition_before(void *f)
 		(struct test_ase_state_transition_fixture *) f;
 	struct bt_bap_unicast_server_register_param param = {
 		CONFIG_BT_ASCS_MAX_ASE_SNK_COUNT,
-		CONFIG_BT_ASCS_MAX_ASE_SRC_COUNT
+		CONFIG_BT_ASCS_MAX_ASE_SRC_COUNT,
+		&mock_bap_unicast_server_cb
 	};
 	int err;
 
 	err = bt_bap_unicast_server_register(&param);
-	zassert_equal(err, 0, "unexpected err response %d", err);
-
-	err = bt_bap_unicast_server_register_cb(&mock_bap_unicast_server_cb);
 	zassert_equal(err, 0, "unexpected err response %d", err);
 
 	memset(fixture, 0, sizeof(struct test_ase_state_transition_fixture));
@@ -93,14 +91,12 @@ static void test_ase_src_state_transition_before(void *f)
 		(struct test_ase_state_transition_fixture *) f;
 	struct bt_bap_unicast_server_register_param param = {
 		CONFIG_BT_ASCS_MAX_ASE_SNK_COUNT,
-		CONFIG_BT_ASCS_MAX_ASE_SRC_COUNT
+		CONFIG_BT_ASCS_MAX_ASE_SRC_COUNT,
+		&mock_bap_unicast_server_cb
 	};
 	int err;
 
 	err = bt_bap_unicast_server_register(&param);
-	zassert_equal(err, 0, "unexpected err response %d", err);
-
-	err = bt_bap_unicast_server_register_cb(&mock_bap_unicast_server_cb);
 	zassert_equal(err, 0, "unexpected err response %d", err);
 
 	memset(fixture, 0, sizeof(struct test_ase_state_transition_fixture));
@@ -117,14 +113,15 @@ static void test_ase_state_transition_after(void *f)
 {
 	int err;
 
-	err = bt_bap_unicast_server_unregister_cb(&mock_bap_unicast_server_cb);
-	zassert_equal(err, 0, "unexpected err response %d", err);
-
-	/* Sleep to trigger any pending state changes from unregister_cb */
-	k_sleep(K_SECONDS(1));
-
 	err = bt_bap_unicast_server_unregister();
-	zassert_equal(err, 0, "Unexpected err response %d", err);
+
+	/* In case of a failure due to pending state change, try again */
+	while (err != 0 && err != -EALREADY) {
+		/* Only -EBUSY indicate pending state change */
+		zassert_equal(err, -EBUSY, "unexpected err response %d", err);
+		k_sleep(K_MSEC(10));
+		err = bt_bap_unicast_server_unregister();
+	}
 }
 
 static void test_ase_state_transition_teardown(void *f)

--- a/tests/bluetooth/audio/ascs/src/test_ase_state_transition_invalid.c
+++ b/tests/bluetooth/audio/ascs/src/test_ase_state_transition_invalid.c
@@ -60,14 +60,12 @@ static void test_ase_state_transition_invalid_before(void *f)
 		(struct test_ase_state_transition_invalid_fixture *)f;
 	struct bt_bap_unicast_server_register_param param = {
 		CONFIG_BT_ASCS_MAX_ASE_SNK_COUNT,
-		CONFIG_BT_ASCS_MAX_ASE_SRC_COUNT
+		CONFIG_BT_ASCS_MAX_ASE_SRC_COUNT,
+		&mock_bap_unicast_server_cb
 	};
 	int err;
 
 	err = bt_bap_unicast_server_register(&param);
-	zassert_equal(err, 0, "unexpected err response %d", err);
-
-	err = bt_bap_unicast_server_register_cb(&mock_bap_unicast_server_cb);
 	zassert_equal(err, 0, "unexpected err response %d", err);
 
 	memset(fixture, 0, sizeof(struct test_ase_state_transition_invalid_fixture));
@@ -81,14 +79,15 @@ static void test_ase_state_transition_invalid_after(void *f)
 {
 	int err;
 
-	err = bt_bap_unicast_server_unregister_cb(&mock_bap_unicast_server_cb);
-	zassert_equal(err, 0, "unexpected err response %d", err);
-
-	/* Sleep to trigger any pending state changes from unregister_cb */
-	k_sleep(K_SECONDS(1));
-
 	err = bt_bap_unicast_server_unregister();
-	zassert_equal(err, 0, "Unexpected err response %d", err);
+
+	/* In case of a failure due to pending state change, try again */
+	while (err != 0 && err != -EALREADY) {
+		/* Only -EBUSY indicate pending state change */
+		zassert_equal(err, -EBUSY, "unexpected err response %d", err);
+		k_sleep(K_MSEC(10));
+		err = bt_bap_unicast_server_unregister();
+	}
 }
 
 static void test_ase_state_transition_invalid_teardown(void *f)

--- a/tests/bluetooth/audio/ascs/uut/bap_unicast_server.c
+++ b/tests/bluetooth/audio/ascs/uut/bap_unicast_server.c
@@ -57,7 +57,7 @@ DEFINE_FAKE_VALUE_FUNC(int, mock_bap_unicast_server_cb_stop, struct bt_bap_strea
 DEFINE_FAKE_VALUE_FUNC(int, mock_bap_unicast_server_cb_release, struct bt_bap_stream *,
 		       struct bt_bap_ascs_rsp *);
 
-const struct bt_bap_unicast_server_cb mock_bap_unicast_server_cb = {
+struct bt_bap_unicast_server_cb mock_bap_unicast_server_cb = {
 	.config = mock_bap_unicast_server_cb_config,
 	.reconfig = mock_bap_unicast_server_cb_reconfig,
 	.qos = mock_bap_unicast_server_cb_qos,

--- a/tests/bluetooth/tester/src/audio/btp_bap_unicast.c
+++ b/tests/bluetooth/tester/src/audio/btp_bap_unicast.c
@@ -489,7 +489,7 @@ static int lc3_release(struct bt_bap_stream *stream, struct bt_bap_ascs_rsp *rsp
 	return 0;
 }
 
-static const struct bt_bap_unicast_server_cb unicast_server_cb = {
+static struct bt_bap_unicast_server_cb unicast_server_cb = {
 	.config = lc3_config,
 	.reconfig = lc3_reconfig,
 	.qos = lc3_qos,
@@ -907,7 +907,8 @@ static void discover_cb(struct bt_conn *conn, int err, enum bt_audio_dir dir)
 
 static struct bt_bap_unicast_server_register_param param = {
 	CONFIG_BT_ASCS_MAX_ASE_SNK_COUNT,
-	CONFIG_BT_ASCS_MAX_ASE_SRC_COUNT
+	CONFIG_BT_ASCS_MAX_ASE_SRC_COUNT,
+	&unicast_server_cb
 };
 
 static struct bt_bap_unicast_client_cb unicast_client_cbs = {
@@ -1670,12 +1671,6 @@ int btp_bap_unicast_init(void)
 	if (err != 0) {
 		LOG_DBG("Failed to register unicast server (err %d)\n", err);
 
-		return err;
-	}
-
-	err = bt_bap_unicast_server_register_cb(&unicast_server_cb);
-	if (err != 0) {
-		LOG_DBG("Failed to register client callbacks: %d", err);
 		return err;
 	}
 

--- a/tests/bsim/bluetooth/audio/src/bap_unicast_server_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_unicast_server_test.c
@@ -205,12 +205,7 @@ static int lc3_release(struct bt_bap_stream *stream, struct bt_bap_ascs_rsp *rsp
 	return 0;
 }
 
-static struct bt_bap_unicast_server_register_param param = {
-	CONFIG_BT_ASCS_MAX_ASE_SNK_COUNT,
-	CONFIG_BT_ASCS_MAX_ASE_SRC_COUNT
-};
-
-static const struct bt_bap_unicast_server_cb unicast_server_cb = {
+static struct bt_bap_unicast_server_cb unicast_server_cb = {
 	.config = lc3_config,
 	.reconfig = lc3_reconfig,
 	.qos = lc3_qos,
@@ -220,6 +215,12 @@ static const struct bt_bap_unicast_server_cb unicast_server_cb = {
 	.disable = lc3_disable,
 	.stop = lc3_stop,
 	.release = lc3_release,
+};
+
+static struct bt_bap_unicast_server_register_param param = {
+	CONFIG_BT_ASCS_MAX_ASE_SNK_COUNT,
+	CONFIG_BT_ASCS_MAX_ASE_SRC_COUNT,
+	&unicast_server_cb
 };
 
 static void stream_enabled_cb(struct bt_bap_stream *stream)
@@ -446,8 +447,6 @@ static void init(void)
 		return;
 	}
 
-	bt_bap_unicast_server_register_cb(&unicast_server_cb);
-
 	err = bt_pacs_cap_register(BT_AUDIO_DIR_SINK, &cap);
 	if (err != 0) {
 		FAIL("Failed to register capabilities: %d", err);
@@ -474,12 +473,6 @@ static void init(void)
 static void deinit(void)
 {
 	int err;
-
-	err = bt_bap_unicast_server_unregister_cb(&unicast_server_cb);
-	if (err != 0) {
-		FAIL("Failed to unregister unicast server callbacks (err %d)\n", err);
-		return;
-	}
 
 	err = bt_bap_unicast_server_unregister();
 	if (err != 0) {

--- a/tests/bsim/bluetooth/audio/src/cap_acceptor_test.c
+++ b/tests/bsim/bluetooth/audio/src/cap_acceptor_test.c
@@ -575,11 +575,6 @@ static int unicast_server_release(struct bt_bap_stream *stream, struct bt_bap_as
 	return 0;
 }
 
-static struct bt_bap_unicast_server_register_param param = {
-	CONFIG_BT_ASCS_MAX_ASE_SNK_COUNT,
-	CONFIG_BT_ASCS_MAX_ASE_SRC_COUNT
-};
-
 static struct bt_bap_unicast_server_cb unicast_server_cbs = {
 	.config = unicast_server_config,
 	.reconfig = unicast_server_reconfig,
@@ -590,6 +585,12 @@ static struct bt_bap_unicast_server_cb unicast_server_cbs = {
 	.disable = unicast_server_disable,
 	.stop = unicast_server_stop,
 	.release = unicast_server_release,
+};
+
+static struct bt_bap_unicast_server_register_param param = {
+	CONFIG_BT_ASCS_MAX_ASE_SNK_COUNT,
+	CONFIG_BT_ASCS_MAX_ASE_SRC_COUNT,
+	&unicast_server_cbs
 };
 
 static void set_location(void)
@@ -749,14 +750,6 @@ static void init(void)
 		err = bt_bap_unicast_server_register(&param);
 		if (err != 0) {
 			FAIL("Failed to register unicast server (err %d)\n", err);
-
-			return;
-		}
-
-		err = bt_bap_unicast_server_register_cb(&unicast_server_cbs);
-		if (err != 0) {
-			FAIL("Failed to register unicast server callbacks (err %d)\n",
-			     err);
 
 			return;
 		}

--- a/tests/bsim/bluetooth/audio/src/gmap_ugt_test.c
+++ b/tests/bsim/bluetooth/audio/src/gmap_ugt_test.c
@@ -257,11 +257,6 @@ static int unicast_server_release(struct bt_bap_stream *stream, struct bt_bap_as
 	return 0;
 }
 
-static struct bt_bap_unicast_server_register_param param = {
-	CONFIG_BT_ASCS_MAX_ASE_SNK_COUNT,
-	CONFIG_BT_ASCS_MAX_ASE_SRC_COUNT
-};
-
 static struct bt_bap_unicast_server_cb unicast_server_cbs = {
 	.config = unicast_server_config,
 	.reconfig = unicast_server_reconfig,
@@ -272,6 +267,12 @@ static struct bt_bap_unicast_server_cb unicast_server_cbs = {
 	.disable = unicast_server_disable,
 	.stop = unicast_server_stop,
 	.release = unicast_server_release,
+};
+
+static struct bt_bap_unicast_server_register_param param = {
+	CONFIG_BT_ASCS_MAX_ASE_SNK_COUNT,
+	CONFIG_BT_ASCS_MAX_ASE_SRC_COUNT,
+	&unicast_server_cbs
 };
 
 static void set_location(void)
@@ -483,13 +484,6 @@ static void test_main(void)
 	err = bt_bap_unicast_server_register(&param);
 	if (err != 0) {
 		FAIL("Failed to register unicast server (err %d)\n", err);
-
-		return;
-	}
-
-	err = bt_bap_unicast_server_register_cb(&unicast_server_cbs);
-	if (err != 0) {
-		FAIL("Failed to register unicast server callbacks (err %d)\n", err);
 
 		return;
 	}


### PR DESCRIPTION
This change merges service registration and callback registration in ASCS. This should eliminate any weird middle states. Since ASCS can't properely function without callbacks being registered anyway, this shouldn't have any downsides.