### PR TITLE
irq: multilevel: fix `irq_parent_level_3()`

### DIFF
--- a/include/zephyr/irq_multilevel.h
+++ b/include/zephyr/irq_multilevel.h
@@ -163,8 +163,9 @@ static inline unsigned int irq_to_level_3(unsigned int irq)
  */
 static inline unsigned int irq_parent_level_3(unsigned int irq)
 {
-	return (irq >> CONFIG_1ST_LEVEL_INTERRUPT_BITS) &
-		BIT_MASK(CONFIG_2ND_LEVEL_INTERRUPT_BITS);
+	return ((irq >> CONFIG_1ST_LEVEL_INTERRUPT_BITS) &
+		BIT_MASK(CONFIG_2ND_LEVEL_INTERRUPT_BITS)) -
+	       1;
 }
 
 /**

--- a/tests/kernel/gen_isr_table/src/main.c
+++ b/tests/kernel/gen_isr_table/src/main.c
@@ -437,8 +437,8 @@ static void test_multi_level_bit_masks_fn(uint32_t irq1, uint32_t irq2, uint32_t
 		zassert_equal(hwirq3, irq_from_level(irqn, 3));
 		zassert_equal((hwirq3 + 1) << l3_shift, irq_to_level_3(hwirq3));
 		zassert_equal((hwirq3 + 1) << l3_shift, irq_to_level(hwirq3, 3));
-		zassert_equal(hwirq2 + 1, irq_parent_level_3(irqn));
-		zassert_equal(hwirq2 + 1, irq_parent_level(irqn, 3));
+		zassert_equal(hwirq2, irq_parent_level_3(irqn));
+		zassert_equal(hwirq2, irq_parent_level(irqn, 3));
 	}
 
 	if (has_l3) {


### PR DESCRIPTION
The IRQ for level 1 and above is incremented by 1 when encoded with Zephyr's multilevel IRQ scheme, so it should be decremented by 1.

Fixes #79301