### PR TITLE
Bluetooth: Host: Fix issue where uninitialized value was used

### DIFF
--- a/subsys/bluetooth/host/id.c
+++ b/subsys/bluetooth/host/id.c
@@ -1785,6 +1785,13 @@ int bt_id_set_scan_own_addr(bool active_scan, uint8_t *own_addr_type)
 	}
 
 	if (IS_ENABLED(CONFIG_BT_PRIVACY)) {
+
+		if (BT_FEAT_LE_PRIVACY(bt_dev.le.features)) {
+			*own_addr_type = BT_HCI_OWN_ADDR_RPA_OR_RANDOM;
+		} else {
+			*own_addr_type = BT_ADDR_LE_RANDOM;
+		}
+
 		err = bt_id_set_private_addr(BT_ID_DEFAULT);
 		if (err == -EACCES && (atomic_test_bit(bt_dev.flags, BT_DEV_SCANNING) ||
 				       atomic_test_bit(bt_dev.flags, BT_DEV_INITIATING))) {
@@ -1793,12 +1800,6 @@ int bt_id_set_scan_own_addr(bool active_scan, uint8_t *own_addr_type)
 			return 0;
 		} else if (err) {
 			return err;
-		}
-
-		if (BT_FEAT_LE_PRIVACY(bt_dev.le.features)) {
-			*own_addr_type = BT_HCI_OWN_ADDR_RPA_OR_RANDOM;
-		} else {
-			*own_addr_type = BT_ADDR_LE_RANDOM;
 		}
 	} else {
 		*own_addr_type = bt_dev.id_addr[0].type;

--- a/tests/bluetooth/host/id/bt_id_set_scan_own_addr/src/test_suite_invalid_inputs.c
+++ b/tests/bluetooth/host/id/bt_id_set_scan_own_addr/src/test_suite_invalid_inputs.c
@@ -110,7 +110,6 @@ ZTEST(bt_id_set_scan_own_addr_invalid_inputs, test_set_random_address_fails)
  *  Expected behaviour:
  *   - bt_id_set_scan_own_addr() fails and returns the same error code returned by
  *     bt_id_set_private_addr()
- *   - Address type reference isn't set
  */
 ZTEST(bt_id_set_scan_own_addr_invalid_inputs, test_bt_id_set_private_addr_fails_privacy_enabled)
 {
@@ -131,6 +130,4 @@ ZTEST(bt_id_set_scan_own_addr_invalid_inputs, test_bt_id_set_private_addr_fails_
 #endif
 
 	zassert_true(err < 0, "Unexpected error code '%d' was returned", err);
-	zassert_true(own_addr_type == BT_ADDR_LE_ANONYMOUS,
-		     "Address type reference was unexpectedly modified");
 }


### PR DESCRIPTION
This change makes sure that when a call to `bt_id_set_scan_own_addr` is sucessful, i.e., the return value is 0, the `own_addr_type` will be set by the `bt_id_set_scan_own_addr`.

Not setting the `own_addr_type` in a successful call to `bt_id_set_scan_own_addr` causes, for example, the `start_le_scan_ext` method in `scan.c` to use an uninitialized `own_addr_type`.

Eventually this results in an unexpected failure further down in `start_le_scan_ext`, when sending HCI command to controller with an uninitialized `own_addr_type`.