### PR TITLE
adc: current_sense_amplifier: resolution change and reduced rounding error

### DIFF
--- a/boards/google/twinkie_v2/google_twinkie_v2.dts
+++ b/boards/google/twinkie_v2/google_twinkie_v2.dts
@@ -65,14 +65,14 @@
 	csa_vbus: vbusc {
 		compatible = "current-sense-amplifier";
 		io-channels = <&adc1 17>;
-		sense-resistor-micro-ohms = <3000>;
+		sense-resistor-milli-ohms = <3>;
 		sense-gain-mult = <100>;
 	};
 
 	csa_cc2: vconc {
 		compatible = "current-sense-amplifier";
 		io-channels = <&adc1 18>;
-		sense-resistor-micro-ohms = <10000>;
+		sense-resistor-milli-ohms = <10>;
 		sense-gain-mult = <25>;
 	};
 

--- a/boards/microchip/ev11l78a/ev11l78a.dts
+++ b/boards/microchip/ev11l78a/ev11l78a.dts
@@ -39,7 +39,7 @@
 	csa_i_sense: i_sense {
 		compatible = "current-sense-amplifier";
 		io-channels = <&adc 5>;
-		sense-resistor-micro-ohms = <4000>;
+		sense-resistor-milli-ohms = <4>;
 		sense-gain-mult = <100>;
 	};
 

--- a/doc/releases/migration-guide-4.0.rst
+++ b/doc/releases/migration-guide-4.0.rst
@@ -243,6 +243,9 @@ Sensors
 * The :dtcompatible:`current-sense-amplifier` sense resistor is now specified in milli-ohms
   (``sense-resistor-milli-ohms``) instead of micro-ohms in order to increase the maximum representable
   resistor from 4.2k to 4.2M.
+* The :dtcompatible:`current-sense-amplifier` properties ``sense-gain-mult`` and ``sense-gain-div``
+  are now limited to a maximum value of ``UINT16_MAX`` to enable smaller rounding errors in internal
+  calculations.
 
 Serial
 ======

--- a/doc/releases/migration-guide-4.0.rst
+++ b/doc/releases/migration-guide-4.0.rst
@@ -240,6 +240,9 @@ Sensors
 * The existing driver for the Microchip MCP9808 temperature sensor transformed and renamed
   to support all JEDEC JC 42.4 compatible temperature sensors. It now uses the
   :dtcompatible:`jedec,jc-42.4-temp` compatible string instead to the ``microchip,mcp9808`` string.
+* The :dtcompatible:`current-sense-amplifier` sense resistor is now specified in milli-ohms
+  (``sense-resistor-milli-ohms``) instead of micro-ohms in order to increase the maximum representable
+  resistor from 4.2k to 4.2M.
 
 Serial
 ======

--- a/drivers/sensor/current_amp/current_amp.c
+++ b/drivers/sensor/current_amp/current_amp.c
@@ -11,6 +11,7 @@
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/sensor.h>
 #include <zephyr/pm/device.h>
+#include <zephyr/sys/__assert.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(current_amp, CONFIG_SENSOR_LOG_LEVEL);
@@ -114,6 +115,8 @@ static int current_init(const struct device *dev)
 	const struct current_sense_amplifier_dt_spec *config = dev->config;
 	struct current_sense_amplifier_data *data = dev->data;
 	int ret;
+
+	__ASSERT(config->sense_milli_ohms != 0, "Milli-ohms must not be 0");
 
 	if (!adc_is_ready_dt(&config->port)) {
 		LOG_ERR("ADC is not ready");

--- a/dts/bindings/iio/afe/current-sense-amplifier.yaml
+++ b/dts/bindings/iio/afe/current-sense-amplifier.yaml
@@ -30,13 +30,13 @@ properties:
     type: int
     default: 1
     description: |
-      Amplifier gain multiplier. The default is <1>.
+      Amplifier gain multiplier. The default is <1>. The maximum value is <65535>.
 
   sense-gain-div:
     type: int
     default: 1
     description: |
-      Amplifier gain divider. The default is <1>.
+      Amplifier gain divider. The default is <1>. The maximum value is <65535>.
 
   power-gpios:
     type: phandle-array

--- a/dts/bindings/iio/afe/current-sense-amplifier.yaml
+++ b/dts/bindings/iio/afe/current-sense-amplifier.yaml
@@ -20,11 +20,11 @@ properties:
     description: |
       Channels available with this divider configuration.
 
-  sense-resistor-micro-ohms:
+  sense-resistor-milli-ohms:
     type: int
     required: true
     description: |
-      Resistance of the shunt resistor in micro-ohms
+      Resistance of the shunt resistor in milli-ohms.
 
   sense-gain-mult:
     type: int

--- a/include/zephyr/drivers/adc/current_sense_amplifier.h
+++ b/include/zephyr/drivers/adc/current_sense_amplifier.h
@@ -12,7 +12,7 @@
 
 struct current_sense_amplifier_dt_spec {
 	const struct adc_dt_spec port;
-	uint32_t sense_micro_ohms;
+	uint32_t sense_milli_ohms;
 	uint32_t sense_gain_mult;
 	uint32_t sense_gain_div;
 	struct gpio_dt_spec power_gpio;
@@ -31,7 +31,7 @@ struct current_sense_amplifier_dt_spec {
 #define CURRENT_SENSE_AMPLIFIER_DT_SPEC_GET(node_id)                                               \
 	{                                                                                          \
 		.port = ADC_DT_SPEC_GET(node_id),                                                  \
-		.sense_micro_ohms = DT_PROP(node_id, sense_resistor_micro_ohms),                   \
+		.sense_milli_ohms = DT_PROP(node_id, sense_resistor_milli_ohms),                   \
 		.sense_gain_mult = DT_PROP(node_id, sense_gain_mult),                              \
 		.sense_gain_div = DT_PROP(node_id, sense_gain_div),                                \
 		.power_gpio = GPIO_DT_SPEC_GET_OR(node_id, power_gpios, {0}),                      \
@@ -51,8 +51,8 @@ current_sense_amplifier_scale_dt(const struct current_sense_amplifier_dt_spec *s
 	/* store in a temporary 64 bit variable to prevent overflow during calculation */
 	int64_t tmp = *v_to_i;
 
-	/* multiplies by 1,000,000 before dividing by sense resistance in micro-ohms. */
-	tmp = tmp * 1000000 / spec->sense_micro_ohms * spec->sense_gain_div / spec->sense_gain_mult;
+	/* multiplies by 1,000 before dividing by sense resistance in milli-ohms. */
+	tmp = tmp * 1000 / spec->sense_milli_ohms * spec->sense_gain_div / spec->sense_gain_mult;
 
 	*v_to_i = (int32_t)tmp;
 }

--- a/tests/drivers/adc/adc_rescale/boards/native_sim.overlay
+++ b/tests/drivers/adc/adc_rescale/boards/native_sim.overlay
@@ -23,7 +23,7 @@
 	sensor2: csa {
 		compatible = "current-sense-amplifier";
 		io-channels = <&adc0 2>;
-		sense-resistor-micro-ohms = <5000>;
+		sense-resistor-milli-ohms = <5>;
 		sense-gain-mult = <100>;
 	};
 

--- a/tests/drivers/build_all/sensor/adc.dtsi
+++ b/tests/drivers/build_all/sensor/adc.dtsi
@@ -31,7 +31,7 @@ test_current: current_amp {
 	compatible = "current-sense-amplifier";
 	io-channels = <&test_adc 2>;
 	io-channel-names = "CURRENT_AMP";
-	sense-resistor-micro-ohms = <10>;
+	sense-resistor-milli-ohms = <1>;
 	sense-gain-mult = <1>;
 	sense-gain-div = <1>;
 };


### PR DESCRIPTION
Change the unit of the sense resistor in the devicetree binding from
micro-ohms to milli-ohms. This is done for three reasons.

Firstly, the maximum value resistor that can currently be represented
is 4.2 kOhms, due to the limitation of devicetree properties to 32 bits.

Secondly, storing the resistance at such a high resolution makes
overflows much more likely when the desired output unit is micro-amps,
not milli-amps.

Finally, micro-ohms, are an unnecessarily precise unit for the purpose
of these calculations, and a resolution that is not realistic to
achieve. The high resistor resolution results in large divisors that
reduce the resolution of outputs. Unlike resistors characterised down to
the micro-ohm, devices wanting to measure micro-amps are actually
realistic.

Reduce the valid scaling range for the gain multipliers and dividers to
provide more headroom on int64_t overflows in the calculations. Take
advantage of this headroom to perform all multiplications before
divisions.

Updated implementation of #77106
