### PR TITLE
Bluetooth:  Fix type use of own_addr_type

### DIFF
--- a/include/zephyr/bluetooth/hci_types.h
+++ b/include/zephyr/bluetooth/hci_types.h
@@ -33,7 +33,8 @@ extern "C" {
 #define BT_HCI_H4_EVT                   0x04    /* HCI Event packet */
 #define BT_HCI_H4_ISO                   0x05    /* HCI ISO Data packet */
 
-/* Special own address types for LL privacy (used in adv & scan parameters) */
+#define BT_HCI_OWN_ADDR_PUBLIC          0x00
+#define BT_HCI_OWN_ADDR_RANDOM          0x01
 #define BT_HCI_OWN_ADDR_RPA_OR_PUBLIC   0x02
 #define BT_HCI_OWN_ADDR_RPA_OR_RANDOM   0x03
 #define BT_HCI_OWN_ADDR_RPA_MASK        0x02

--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -455,8 +455,8 @@ uint8_t ll_adv_params_set(uint16_t interval, uint8_t adv_type,
 
 #if defined(CONFIG_BT_CTLR_PRIVACY)
 	adv->own_addr_type = own_addr_type;
-	if (adv->own_addr_type == BT_ADDR_LE_PUBLIC_ID ||
-	    adv->own_addr_type == BT_ADDR_LE_RANDOM_ID) {
+	if (adv->own_addr_type == BT_HCI_OWN_ADDR_RPA_OR_PUBLIC ||
+	    adv->own_addr_type == BT_HCI_OWN_ADDR_RPA_OR_RANDOM) {
 		adv->peer_addr_type = direct_addr_type;
 		memcpy(&adv->peer_addr, direct_addr, BDADDR_SIZE);
 	}
@@ -927,8 +927,8 @@ uint8_t ll_adv_enable(uint8_t enable)
 	/* Prepare filter accept list and optionally resolving list */
 	ull_filter_adv_update(lll->filter_policy);
 
-	if (adv->own_addr_type == BT_ADDR_LE_PUBLIC_ID ||
-	    adv->own_addr_type == BT_ADDR_LE_RANDOM_ID) {
+	if (adv->own_addr_type == BT_HCI_OWN_ADDR_RPA_OR_PUBLIC ||
+	    adv->own_addr_type == BT_HCI_OWN_ADDR_RPA_OR_RANDOM) {
 		/* Look up the resolving list */
 		lll->rl_idx = ull_filter_rl_find(adv->peer_addr_type,
 						 adv->peer_addr, NULL);
@@ -3132,7 +3132,7 @@ static void init_set(struct ll_adv_set *adv)
 {
 	adv->interval = BT_LE_ADV_INTERVAL_DEFAULT;
 #if defined(CONFIG_BT_CTLR_PRIVACY)
-	adv->own_addr_type = BT_ADDR_LE_PUBLIC;
+	adv->own_addr_type = BT_HCI_OWN_ADDR_RPA_OR_PUBLIC;
 #endif /* CONFIG_BT_CTLR_PRIVACY */
 	adv->lll.chan_map = BT_LE_ADV_CHAN_MAP_ALL;
 	adv->lll.filter_policy = BT_LE_ADV_FP_NO_FILTER;

--- a/subsys/bluetooth/controller/ll_sw/ull_central.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_central.c
@@ -380,8 +380,8 @@ conn_is_valid:
 						 NULL);
 	}
 
-	if (own_addr_type == BT_ADDR_LE_PUBLIC_ID ||
-	    own_addr_type == BT_ADDR_LE_RANDOM_ID) {
+	if (own_addr_type == BT_HCI_OWN_ADDR_RPA_OR_PUBLIC ||
+	    own_addr_type == BT_HCI_OWN_ADDR_RPA_OR_RANDOM) {
 
 		/* Generate RPAs if required */
 		ull_filter_rpa_update(false);

--- a/subsys/bluetooth/controller/ll_sw/ull_filter.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_filter.c
@@ -1153,8 +1153,8 @@ static void rpa_adv_refresh(struct ll_adv_set *adv)
 	uint8_t sec_idx;
 #endif /* CONFIG_BT_CTLR_ADV_EXT */
 
-	if (adv->own_addr_type != BT_ADDR_LE_PUBLIC_ID &&
-	    adv->own_addr_type != BT_ADDR_LE_RANDOM_ID) {
+	if (adv->own_addr_type != BT_HCI_OWN_ADDR_RPA_OR_PUBLIC &&
+	    adv->own_addr_type != BT_HCI_OWN_ADDR_RPA_OR_RANDOM) {
 		return;
 	}
 

--- a/subsys/bluetooth/controller/ll_sw/ull_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan.c
@@ -247,9 +247,8 @@ uint8_t ll_scan_enable(uint8_t enable)
 	lll->rl_idx = FILTER_IDX_NONE;
 	lll->rpa_gen = 0;
 
-	if ((lll->type & 0x1) &&
-	    (own_addr_type == BT_ADDR_LE_PUBLIC_ID ||
-	     own_addr_type == BT_ADDR_LE_RANDOM_ID)) {
+	if ((lll->type & 0x1) && (own_addr_type == BT_HCI_OWN_ADDR_RPA_OR_PUBLIC ||
+				  own_addr_type == BT_HCI_OWN_ADDR_RPA_OR_RANDOM)) {
 		/* Generate RPAs if required */
 		ull_filter_rpa_update(false);
 		lll->rpa_gen = 1;

--- a/subsys/bluetooth/host/id.c
+++ b/subsys/bluetooth/host/id.c
@@ -1,12 +1,14 @@
 /*
- * Copyright (c) 2017-2021 Nordic Semiconductor ASA
+ * Copyright (c) 2017-2024 Nordic Semiconductor ASA
  * Copyright (c) 2015-2016 Intel Corporation
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <stdbool.h>
+#include <stdint.h>
 
+#include <zephyr/bluetooth/hci_types.h>
 #include <zephyr/settings/settings.h>
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/check.h>
@@ -30,6 +32,7 @@
 #include "settings.h"
 
 #include <zephyr/bluetooth/hci.h>
+#include <zephyr/toolchain.h>
 
 #include "common/bt_str.h"
 
@@ -1733,7 +1736,7 @@ int bt_id_set_create_conn_own_addr(bool use_filter, uint8_t *own_addr_type)
 		if (BT_FEAT_LE_PRIVACY(bt_dev.le.features)) {
 			*own_addr_type = BT_HCI_OWN_ADDR_RPA_OR_RANDOM;
 		} else {
-			*own_addr_type = BT_ADDR_LE_RANDOM;
+			*own_addr_type = BT_HCI_OWN_ADDR_RANDOM;
 		}
 	} else {
 		const bt_addr_le_t *addr = &bt_dev.id_addr[BT_ID_DEFAULT];
@@ -1789,7 +1792,7 @@ int bt_id_set_scan_own_addr(bool active_scan, uint8_t *own_addr_type)
 		if (BT_FEAT_LE_PRIVACY(bt_dev.le.features)) {
 			*own_addr_type = BT_HCI_OWN_ADDR_RPA_OR_RANDOM;
 		} else {
-			*own_addr_type = BT_ADDR_LE_RANDOM;
+			*own_addr_type = BT_HCI_OWN_ADDR_RANDOM;
 		}
 
 		err = bt_id_set_private_addr(BT_ID_DEFAULT);
@@ -1820,9 +1823,9 @@ int bt_id_set_scan_own_addr(bool active_scan, uint8_t *own_addr_type)
 					err);
 			}
 
-			*own_addr_type = BT_ADDR_LE_RANDOM;
+			*own_addr_type = BT_HCI_OWN_ADDR_RANDOM;
 		} else if (IS_ENABLED(CONFIG_BT_SCAN_WITH_IDENTITY) &&
-			   *own_addr_type == BT_ADDR_LE_RANDOM) {
+			   *own_addr_type == BT_HCI_OWN_ADDR_RANDOM) {
 			/* If scanning with Identity Address we must set the
 			 * random identity address for both active and passive
 			 * scanner in order to receive adv reports that are
@@ -1866,7 +1869,7 @@ int bt_id_set_adv_own_addr(struct bt_le_ext_adv *adv, uint32_t options,
 		if (err) {
 			return err;
 		}
-		*own_addr_type = BT_ADDR_LE_RANDOM;
+		*own_addr_type = BT_HCI_OWN_ADDR_RANDOM;
 
 		return 0;
 	}
@@ -1887,7 +1890,7 @@ int bt_id_set_adv_own_addr(struct bt_le_ext_adv *adv, uint32_t options,
 			if (dir_adv && (options & BT_LE_ADV_OPT_DIR_ADDR_RPA)) {
 				*own_addr_type = BT_HCI_OWN_ADDR_RPA_OR_RANDOM;
 			} else {
-				*own_addr_type = BT_ADDR_LE_RANDOM;
+				*own_addr_type = BT_HCI_OWN_ADDR_RANDOM;
 			}
 		} else {
 			/*
@@ -1934,7 +1937,7 @@ int bt_id_set_adv_own_addr(struct bt_le_ext_adv *adv, uint32_t options,
 			}
 #endif /* defined(CONFIG_BT_OBSERVER) */
 			err = bt_id_set_adv_private_addr(adv);
-			*own_addr_type = BT_ADDR_LE_RANDOM;
+			*own_addr_type = BT_HCI_OWN_ADDR_RANDOM;
 
 #if defined(CONFIG_BT_OBSERVER)
 			if (scan_enabled) {
@@ -1943,7 +1946,7 @@ int bt_id_set_adv_own_addr(struct bt_le_ext_adv *adv, uint32_t options,
 #endif /* defined(CONFIG_BT_OBSERVER) */
 		} else {
 			err = bt_id_set_adv_private_addr(adv);
-			*own_addr_type = BT_ADDR_LE_RANDOM;
+			*own_addr_type = BT_HCI_OWN_ADDR_RANDOM;
 		}
 
 		if (err) {

--- a/tests/bluetooth/host/id/bt_id_set_adv_own_addr/src/main.c
+++ b/tests/bluetooth/host/id/bt_id_set_adv_own_addr/src/main.c
@@ -10,6 +10,7 @@
 #include "testing_common_defs.h"
 
 #include <zephyr/bluetooth/hci.h>
+#include <zephyr/bluetooth/hci_types.h>
 #include <zephyr/fff.h>
 #include <zephyr/kernel.h>
 
@@ -62,7 +63,7 @@ ZTEST(bt_id_set_adv_own_addr, test_bt_id_set_adv_private_addr_succeeds_adv_conne
 		err = bt_id_set_adv_own_addr(&adv, options, dir_adv_test_lut[i], &own_addr_type);
 
 		zassert_ok(err, "Unexpected error code '%d' was returned", err);
-		zassert_true(own_addr_type == BT_ADDR_LE_RANDOM,
+		zassert_true(own_addr_type == BT_HCI_OWN_ADDR_RANDOM,
 			     "Address type reference was incorrectly set");
 	}
 
@@ -114,7 +115,7 @@ ZTEST(bt_id_set_adv_own_addr, test_bt_id_set_adv_random_addr_succeeds_adv_connec
 		err = bt_id_set_adv_own_addr(&adv, options, dir_adv_test_lut[i], &own_addr_type);
 
 		zassert_ok(err, "Unexpected error code '%d' was returned", err);
-		zassert_true(own_addr_type == BT_ADDR_LE_RANDOM,
+		zassert_true(own_addr_type == BT_HCI_OWN_ADDR_RANDOM,
 			     "Address type reference was incorrectly set");
 	}
 
@@ -168,7 +169,7 @@ ZTEST(bt_id_set_adv_own_addr, test_bt_id_set_adv_random_addr_succeeds_not_connec
 		err = bt_id_set_adv_own_addr(&adv, options, dir_adv_test_lut[i], &own_addr_type);
 
 		zassert_ok(err, "Unexpected error code '%d' was returned", err);
-		zassert_true(own_addr_type == BT_ADDR_LE_RANDOM,
+		zassert_true(own_addr_type == BT_HCI_OWN_ADDR_RANDOM,
 			     "Address type reference was incorrectly set");
 	}
 }
@@ -206,7 +207,7 @@ ZTEST(bt_id_set_adv_own_addr, test_bt_id_set_adv_private_addr_succeeds_not_conne
 		err = bt_id_set_adv_own_addr(&adv, options, dir_adv_test_lut[i], &own_addr_type);
 
 		zassert_ok(err, "Unexpected error code '%d' was returned", err);
-		zassert_true(own_addr_type == BT_ADDR_LE_RANDOM,
+		zassert_true(own_addr_type == BT_HCI_OWN_ADDR_RANDOM,
 			     "Address type reference was incorrectly set");
 	}
 }

--- a/tests/bluetooth/host/id/bt_id_set_create_conn_own_addr/src/main.c
+++ b/tests/bluetooth/host/id/bt_id_set_create_conn_own_addr/src/main.c
@@ -9,6 +9,7 @@
 #include "testing_common_defs.h"
 
 #include <zephyr/bluetooth/hci.h>
+#include <zephyr/bluetooth/hci_types.h>
 #include <zephyr/fff.h>
 #include <zephyr/kernel.h>
 
@@ -54,17 +55,17 @@ ZTEST(bt_id_set_create_conn_own_addr, test_setting_conn_own_public_address_no_pr
 	err = bt_id_set_create_conn_own_addr(false, &own_addr_type);
 
 	zassert_ok(err, "Unexpected error code '%d' was returned", err);
-	zassert_true(own_addr_type == BT_ADDR_LE_PUBLIC,
+	zassert_true(own_addr_type == BT_HCI_OWN_ADDR_PUBLIC,
 		     "Address type reference was incorrectly set");
 }
 
 /*
  *  Test setting connection own address while 'CONFIG_BT_PRIVACY' isn't enabled.
- *  If the default identity has an RPA address of type 'BT_ADDR_LE_RANDOM', set_random_address()
- *  is called and address type reference is updated upon success.
+ *  If the default identity has an RPA address of type 'BT_HCI_OWN_ADDR_RANDOM',
+ * set_random_address() is called and address type reference is updated upon success.
  *
  *  Constraints:
- *   - Default identity has an address with the type 'BT_ADDR_LE_RANDOM'
+ *   - Default identity has an address with the type 'BT_HCI_OWN_ADDR_RANDOM'
  *   - 'CONFIG_BT_PRIVACY' isn't enabled
  *   - set_random_address() succeeds and returns 0
  *
@@ -87,7 +88,7 @@ ZTEST(bt_id_set_create_conn_own_addr, test_setting_conn_own_rpa_address_no_priva
 	err = bt_id_set_create_conn_own_addr(false, &own_addr_type);
 
 	zassert_ok(err, "Unexpected error code '%d' was returned", err);
-	zassert_true(own_addr_type == BT_ADDR_LE_RANDOM,
+	zassert_true(own_addr_type == BT_HCI_OWN_ADDR_RANDOM,
 		     "Address type reference was incorrectly set");
 }
 
@@ -104,7 +105,7 @@ ZTEST(bt_id_set_create_conn_own_addr, test_setting_conn_own_rpa_address_no_priva
  *
  *  Expected behaviour:
  *   - bt_id_set_create_conn_own_addr() returns 0
- *   - Address type reference is updated with the value 'BT_ADDR_LE_RANDOM'
+ *   - Address type reference is updated with the value 'BT_HCI_OWN_ADDR_RANDOM'
  */
 ZTEST(bt_id_set_create_conn_own_addr, test_setting_conn_own_address_privacy_enabled)
 {
@@ -119,7 +120,7 @@ ZTEST(bt_id_set_create_conn_own_addr, test_setting_conn_own_address_privacy_enab
 	err = bt_id_set_create_conn_own_addr(true, &own_addr_type);
 
 	zassert_ok(err, "Unexpected error code '%d' was returned", err);
-	zassert_true(own_addr_type == BT_ADDR_LE_RANDOM,
+	zassert_true(own_addr_type == BT_HCI_OWN_ADDR_RANDOM,
 		     "Address type reference was incorrectly set");
 }
 

--- a/tests/bluetooth/host/id/bt_id_set_scan_own_addr/src/main.c
+++ b/tests/bluetooth/host/id/bt_id_set_scan_own_addr/src/main.c
@@ -10,6 +10,7 @@
 #include "testing_common_defs.h"
 
 #include <zephyr/bluetooth/hci.h>
+#include <zephyr/bluetooth/hci_types.h>
 #include <zephyr/fff.h>
 #include <zephyr/kernel.h>
 
@@ -70,18 +71,18 @@ ZTEST(bt_id_set_scan_own_addr, test_set_nrpa_scan_address_no_privacy)
 	err = bt_id_set_scan_own_addr(false, &own_addr_type);
 
 	zassert_ok(err, "Unexpected error code '%d' was returned", err);
-	zassert_true(own_addr_type == BT_ADDR_LE_RANDOM,
+	zassert_true(own_addr_type == BT_HCI_OWN_ADDR_RANDOM,
 		     "Address type reference was incorrectly set");
 }
 
 /*
  *  Test setting scan own address while 'CONFIG_BT_PRIVACY' isn't enabled.
  *  If 'CONFIG_BT_SCAN_WITH_IDENTITY' is enabled and the default identity has an RPA address of type
- * 'BT_ADDR_LE_RANDOM', set_random_address() is called and address type reference is updated upon
- *  success.
+ * 'BT_HCI_OWN_ADDR_RANDOM', set_random_address() is called and address type reference is updated
+ * upon success.
  *
  *  Constraints:
- *   - Default identity has an address with the type 'BT_ADDR_LE_RANDOM'
+ *   - Default identity has an address with the type 'BT_HCI_OWN_ADDR_RANDOM'
  *   - 'CONFIG_BT_PRIVACY' isn't enabled
  *   - 'CONFIG_BT_SCAN_WITH_IDENTITY' is enabled
  *   - set_random_address() succeeds and returns 0
@@ -106,7 +107,7 @@ ZTEST(bt_id_set_scan_own_addr, test_setting_scan_own_rpa_address_no_privacy)
 	err = bt_id_set_scan_own_addr(false, &own_addr_type);
 
 	zassert_ok(err, "Unexpected error code '%d' was returned", err);
-	zassert_true(own_addr_type == BT_ADDR_LE_RANDOM,
+	zassert_true(own_addr_type == BT_HCI_OWN_ADDR_RANDOM,
 		     "Address type reference was incorrectly set");
 }
 
@@ -123,7 +124,7 @@ ZTEST(bt_id_set_scan_own_addr, test_setting_scan_own_rpa_address_no_privacy)
  *
  *  Expected behaviour:
  *   - bt_id_set_scan_own_addr() returns 0
- *   - Address type reference is updated with the value 'BT_ADDR_LE_RANDOM'
+ *   - Address type reference is updated with the value 'BT_HCI_OWN_ADDR_RANDOM'
  */
 ZTEST(bt_id_set_scan_own_addr, test_setting_scan_own_address_privacy_enabled)
 {
@@ -138,7 +139,7 @@ ZTEST(bt_id_set_scan_own_addr, test_setting_scan_own_address_privacy_enabled)
 	err = bt_id_set_scan_own_addr(true, &own_addr_type);
 
 	zassert_ok(err, "Unexpected error code '%d' was returned", err);
-	zassert_true(own_addr_type == BT_ADDR_LE_RANDOM,
+	zassert_true(own_addr_type == BT_HCI_OWN_ADDR_RANDOM,
 		     "Address type reference was incorrectly set");
 }
 

--- a/tests/bsim/bluetooth/host/att/pipeline/tester/src/main.c
+++ b/tests/bsim/bluetooth/host/att/pipeline/tester/src/main.c
@@ -14,6 +14,7 @@
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/bluetooth/hci_raw.h>
+#include <zephyr/bluetooth/hci_types.h>
 
 #include "common/bt_str.h"
 
@@ -483,7 +484,7 @@ void start_adv(void)
 	set_param.channel_map = 0x07;
 	set_param.filter_policy = BT_LE_ADV_FP_NO_FILTER;
 	set_param.type = BT_HCI_ADV_IND;
-	set_param.own_addr_type = 0x01; /* random */
+	set_param.own_addr_type = BT_HCI_OWN_ADDR_RANDOM;
 
 	/* configure */
 	buf = bt_hci_cmd_create(BT_HCI_OP_LE_SET_ADV_PARAM, sizeof(set_param));

--- a/tests/bsim/bluetooth/host/att/sequential/tester/src/main.c
+++ b/tests/bsim/bluetooth/host/att/sequential/tester/src/main.c
@@ -14,6 +14,7 @@
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/bluetooth/hci_raw.h>
+#include <zephyr/bluetooth/hci_types.h>
 
 #include "common/bt_str.h"
 
@@ -459,7 +460,7 @@ void start_adv(void)
 	set_param.channel_map = 0x07;
 	set_param.filter_policy = BT_LE_ADV_FP_NO_FILTER;
 	set_param.type = BT_HCI_ADV_IND;
-	set_param.own_addr_type = 0x01; /* random */
+	set_param.own_addr_type = BT_HCI_OWN_ADDR_RANDOM;
 
 	/* configure */
 	buf = bt_hci_cmd_create(BT_HCI_OP_LE_SET_ADV_PARAM, sizeof(set_param));

--- a/tests/bsim/bluetooth/host/l2cap/reassembly/peer/src/peer.c
+++ b/tests/bsim/bluetooth/host/l2cap/reassembly/peer/src/peer.c
@@ -14,6 +14,7 @@
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/bluetooth/hci_raw.h>
+#include <zephyr/bluetooth/hci_types.h>
 
 #include "common/bt_str.h"
 
@@ -402,7 +403,7 @@ static void start_adv(uint16_t interval, const char *name, size_t name_len)
 	set_param.channel_map = 0x07;
 	set_param.filter_policy = BT_LE_ADV_FP_NO_FILTER;
 	set_param.type = BT_HCI_ADV_IND;
-	set_param.own_addr_type = 0x01; /* random */
+	set_param.own_addr_type = BT_HCI_OWN_ADDR_RANDOM;
 
 	buf = bt_hci_cmd_create(BT_HCI_OP_LE_SET_ADV_PARAM, sizeof(set_param));
 	__ASSERT_NO_MSG(buf);

--- a/tests/bsim/bluetooth/host/l2cap/split/tester/src/main.c
+++ b/tests/bsim/bluetooth/host/l2cap/split/tester/src/main.c
@@ -14,6 +14,7 @@
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/bluetooth/hci_raw.h>
+#include <zephyr/bluetooth/hci_types.h>
 
 #include "common/bt_str.h"
 
@@ -438,7 +439,7 @@ void start_adv(uint16_t interval)
 	set_param.channel_map = 0x07;
 	set_param.filter_policy = BT_LE_ADV_FP_NO_FILTER;
 	set_param.type = BT_HCI_ADV_IND;
-	set_param.own_addr_type = 0x01; /* random */
+	set_param.own_addr_type = BT_HCI_OWN_ADDR_RANDOM;
 
 	buf = bt_hci_cmd_create(BT_HCI_OP_LE_SET_ADV_PARAM, sizeof(set_param));
 	__ASSERT_NO_MSG(buf);

--- a/tests/bsim/bluetooth/host/misc/disconnect/tester/src/main.c
+++ b/tests/bsim/bluetooth/host/misc/disconnect/tester/src/main.c
@@ -14,6 +14,7 @@
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/bluetooth/hci_raw.h>
+#include <zephyr/bluetooth/hci_types.h>
 
 #include "common/bt_str.h"
 
@@ -437,7 +438,7 @@ void start_adv(void)
 	set_param.channel_map = 0x07;
 	set_param.filter_policy = BT_LE_ADV_FP_NO_FILTER;
 	set_param.type = BT_HCI_ADV_IND;
-	set_param.own_addr_type = 0x01; /* random */
+	set_param.own_addr_type = BT_HCI_OWN_ADDR_RANDOM;
 
 	/* configure */
 	buf = bt_hci_cmd_create(BT_HCI_OP_LE_SET_ADV_PARAM, sizeof(set_param));

--- a/tests/bsim/bluetooth/host/misc/hfc_multilink/tester/src/tester.c
+++ b/tests/bsim/bluetooth/host/misc/hfc_multilink/tester/src/tester.c
@@ -14,6 +14,7 @@
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/bluetooth/hci_raw.h>
+#include <zephyr/bluetooth/hci_types.h>
 #include <zephyr/bluetooth/gap.h>
 
 #include "common/bt_str.h"
@@ -467,7 +468,7 @@ static void start_adv(uint16_t interval, const char *name, size_t name_len)
 	set_param.channel_map = 0x07;
 	set_param.filter_policy = BT_LE_ADV_FP_NO_FILTER;
 	set_param.type = BT_HCI_ADV_IND;
-	set_param.own_addr_type = 0x01; /* random */
+	set_param.own_addr_type = BT_HCI_OWN_ADDR_RANDOM;
 
 	buf = bt_hci_cmd_create(BT_HCI_OP_LE_SET_ADV_PARAM, sizeof(set_param));
 	__ASSERT_NO_MSG(buf);

--- a/tests/bsim/bluetooth/ll/advx/src/main.c
+++ b/tests/bsim/bluetooth/ll/advx/src/main.c
@@ -14,6 +14,7 @@
 
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/hci.h>
+#include <zephyr/bluetooth/hci_types.h>
 
 #include "ll.h"
 
@@ -28,8 +29,8 @@
 #define EVT_PROP_TXP    BIT(6)
 #define ADV_INTERVAL    0x20   /* 20 ms advertising interval */
 #define ADV_WAIT_MS     10     /* 10 ms wait loop */
-#define OWN_ADDR_TYPE   BT_ADDR_LE_RANDOM_ID
-#define PEER_ADDR_TYPE  BT_ADDR_LE_RANDOM_ID
+#define OWN_ADDR_TYPE   BT_HCI_OWN_ADDR_RANDOM
+#define PEER_ADDR_TYPE  BT_HCI_OWN_ADDR_RANDOM
 #define PEER_ADDR       peer_addr
 #define ADV_CHAN_MAP    0x07
 #define FILTER_POLICY   0x00


### PR DESCRIPTION
The own_addr_type used for various HCI commands sometimes had a BT_HCI_OWN_ADDR_* type value or a BT_ADDR_* type value. Those are 2 different value spaces, and if the public address types would ever change, it would start have incorrect behavior.

Modified all assignments of own_addr_type to use the HCI defined values, and added a conversion function similar to the other Zephyr->HCI type functions we have. The function can today simply return the same value with some build asserts to avoid actually requiring any conversions.