### PR TITLE
modules: hostap: Add config options for EAP types

### DIFF
--- a/modules/hostap/CMakeLists.txt
+++ b/modules/hostap/CMakeLists.txt
@@ -324,68 +324,157 @@ zephyr_library_compile_definitions_ifdef(CONFIG_WIFI_NM_WPA_SUPPLICANT_WPS
 )
 
 zephyr_library_sources_ifdef(CONFIG_WIFI_NM_WPA_SUPPLICANT_CRYPTO_ENTERPRISE
+	${HOSTAP_SRC_BASE}/eap_common/eap_common.c
+)
+
+zephyr_library_compile_definitions_ifdef(CONFIG_WIFI_NM_WPA_SUPPLICANT_CRYPTO_ENTERPRISE
+	IEEE8021X_EAPOL
+	EAP_IKEv2
+)
+
+zephyr_library_sources_ifdef(CONFIG_EAP_TLS
 	${HOSTAP_SRC_BASE}/eap_peer/eap_tls.c
 	${HOSTAP_SRC_BASE}/eap_peer/eap_tls_common.c
-	${HOSTAP_SRC_BASE}/eap_common/eap_common.c
+)
 
+zephyr_library_compile_definitions_ifdef(CONFIG_EAP_TLS
+	EAP_TLS
+)
+
+zephyr_library_sources_ifdef(CONFIG_EAP_TTLS
+	${HOSTAP_SRC_BASE}/eap_peer/eap_ttls.c
+)
+
+zephyr_library_compile_definitions_ifdef(CONFIG_EAP_TTLS
+        EAP_TTLS
+)
+
+zephyr_library_sources_ifdef(CONFIG_EAP_PEAP
 	${HOSTAP_SRC_BASE}/eap_peer/eap_peap.c
 	${HOSTAP_SRC_BASE}/eap_common/eap_peap_common.c
-	${HOSTAP_SRC_BASE}/eap_peer/eap_ttls.c
-	${HOSTAP_SRC_BASE}/eap_peer/eap_md5.c
-	${HOSTAP_SRC_BASE}/eap_peer/eap_mschapv2.c
-	${HOSTAP_SRC_BASE}/eap_common/chap.c
-	${HOSTAP_SRC_BASE}/eap_peer/mschapv2.c
-	${HOSTAP_SRC_BASE}/eap_peer/eap_leap.c
+)
 
+zephyr_library_compile_definitions_ifdef(CONFIG_EAP_PEAP
+        EAP_PEAP
+)
+
+zephyr_library_sources_ifdef(CONFIG_EAP_MD5
+	${HOSTAP_SRC_BASE}/eap_peer/eap_md5.c
+)
+
+zephyr_library_compile_definitions_ifdef(CONFIG_EAP_MD5
+        EAP_MD5
+)
+
+zephyr_library_sources_ifdef(CONFIG_EAP_MSCHAPV2
+	${HOSTAP_SRC_BASE}/eap_peer/eap_mschapv2.c
+	${HOSTAP_SRC_BASE}/eap_peer/mschapv2.c
+	${HOSTAP_SRC_BASE}/eap_common/chap.c
+)
+
+zephyr_library_compile_definitions_ifdef(CONFIG_EAP_MSCHAPV2
+        EAP_MSCHAPv2
+)
+
+zephyr_library_sources_ifdef(CONFIG_EAP_LEAP
+	${HOSTAP_SRC_BASE}/eap_peer/eap_leap.c
+)
+
+zephyr_library_compile_definitions_ifdef(CONFIG_EAP_LEAP
+        EAP_LEAP
+)
+
+zephyr_library_sources_ifdef(CONFIG_EAP_PSK
 	${HOSTAP_SRC_BASE}/eap_peer/eap_psk.c
 	${HOSTAP_SRC_BASE}/eap_common/eap_psk_common.c
+)
 
-	${HOSTAP_SRC_BASE}/eap_peer/eap_fast.c
-	${HOSTAP_SRC_BASE}/eap_peer/eap_fast_pac.c
-	${HOSTAP_SRC_BASE}/eap_common/eap_fast_common.c
+zephyr_library_compile_definitions_ifdef(CONFIG_EAP_PSK
+        EAP_PSK
+)
 
+zephyr_library_sources_ifdef(CONFIG_EAP_PAX
 	${HOSTAP_SRC_BASE}/eap_peer/eap_pax.c
 	${HOSTAP_SRC_BASE}/eap_common/eap_pax_common.c
+)
 
+zephyr_library_compile_definitions_ifdef(CONFIG_EAP_PAX
+        EAP_PAX
+)
+
+zephyr_library_sources_ifdef(CONFIG_EAP_SAKE
 	${HOSTAP_SRC_BASE}/eap_peer/eap_sake.c
 	${HOSTAP_SRC_BASE}/eap_common/eap_sake_common.c
+)
 
+zephyr_library_compile_definitions_ifdef(CONFIG_EAP_SAKE
+        EAP_SAKE
+)
+
+zephyr_library_sources_ifdef(CONFIG_EAP_GPSK
 	${HOSTAP_SRC_BASE}/eap_peer/eap_gpsk.c
 	${HOSTAP_SRC_BASE}/eap_common/eap_gpsk_common.c
+)
 
+zephyr_library_compile_definitions_ifdef(CONFIG_EAP_GPSK
+        EAP_GPSK
+)
+
+zephyr_library_sources_ifdef(CONFIG_EAP_PWD
 	${HOSTAP_SRC_BASE}/eap_peer/eap_pwd.c
 	${HOSTAP_SRC_BASE}/eap_common/eap_pwd_common.c
+)
 
+zephyr_library_compile_definitions_ifdef(CONFIG_EAP_PWD
+        EAP_PWD
+)
+
+zephyr_library_sources_ifdef(CONFIG_EAP_EKE
 	${HOSTAP_SRC_BASE}/eap_peer/eap_eke.c
 	${HOSTAP_SRC_BASE}/eap_common/eap_eke_common.c
+)
 
+zephyr_library_compile_definitions_ifdef(CONFIG_EAP_EKE
+        EAP_EKE
+)
+
+zephyr_library_sources_ifdef(CONFIG_EAP_IKEV2
 	${HOSTAP_SRC_BASE}/eap_peer/eap_ikev2.c
 	${HOSTAP_SRC_BASE}/eap_peer/ikev2.c
 	${HOSTAP_SRC_BASE}/eap_common/eap_ikev2_common.c
 	${HOSTAP_SRC_BASE}/eap_common/ikev2_common.c
+)
 
+zephyr_library_compile_definitions_ifdef(CONFIG_EAP_IKEV2
+        EAP_IKEV2
+)
+
+zephyr_library_sources_ifdef(CONFIG_EAP_SIM
 	${HOSTAP_SRC_BASE}/eap_peer/eap_sim.c
 	${HOSTAP_SRC_BASE}/eap_common/eap_sim_common.c
+)
 
+zephyr_library_compile_definitions_ifdef(CONFIG_EAP_SIM
+        EAP_SIM
+)
+
+zephyr_library_sources_ifdef(CONFIG_EAP_AKA
 	${HOSTAP_SRC_BASE}/eap_peer/eap_aka.c
 )
 
-zephyr_library_compile_definitions_ifdef(CONFIG_WIFI_NM_WPA_SUPPLICANT_CRYPTO_ENTERPRISE
-	EAP_TLS
-	IEEE8021X_EAPOL
-	EAP_PEAP
-	EAP_TTLS
-	EAP_MD5
-	EAP_MSCHAPv2
-	EAP_LEAP
-	EAP_PSK
-	EAP_FAST
-	EAP_PAX
-	EAP_SAKE
-	EAP_GPSK
-	EAP_PWD
-	EAP_EKE
-	EAP_IKEv2
+zephyr_library_compile_definitions_ifdef(CONFIG_EAP_AKA
+        EAP_AKA
+)
+
+# Needs TLS1.3 and SESSION_TICKETS
+zephyr_library_sources_ifdef(CONFIG_EAP_FAST
+  ${HOSTAP_SRC_BASE}/eap_peer/eap_fast.c
+  ${HOSTAP_SRC_BASE}/eap_peer/eap_fast_pac.c
+  ${HOSTAP_SRC_BASE}/eap_common/eap_fast_common.c
+)
+
+zephyr_library_compile_definitions_ifdef(CONFIG_EAP_FAST
+  EAP_FAST
 )
 
 zephyr_library_compile_definitions_ifndef(CONFIG_WIFI_NM_WPA_SUPPLICANT_CRYPTO_ENTERPRISE

--- a/modules/hostap/Kconfig
+++ b/modules/hostap/Kconfig
@@ -178,6 +178,56 @@ config WIFI_NM_WPA_SUPPLICANT_CRYPTO_ENTERPRISE
 	select MBEDTLS_PEM_CERTIFICATE_FORMAT
 	depends on !WIFI_NM_WPA_SUPPLICANT_CRYPTO_NONE
 
+config EAP_TLS
+	bool "EAP-TLS support"
+
+config EAP_TTLS
+	bool "EAP-TTLS support"
+
+config EAP_PEAP
+	bool "EAP-PEAP support"
+
+config EAP_MD5
+	bool "EAP-MD5 support"
+
+config EAP_MSCHAPV2
+	bool "EAP-MSCHAPv2 support"
+
+config EAP_LEAP
+	bool "EAP-LEAP support"
+
+config EAP_PSK
+	bool "EAP-PSK support"
+
+config EAP_PAX
+	bool "EAP-PAX support"
+
+config EAP_SAKE
+	bool "EAP-SAKE support"
+
+config EAP_GPSK
+	bool "EAP-GPSK support"
+
+config EAP_PWD
+	bool "EAP-PWD support"
+
+config EAP_EKE
+	bool "EAP-EKE support"
+
+config EAP_IKEV2
+	bool "EAP-IKEv2 support"
+
+config EAP_SIM
+	bool "EAP-SIM support"
+
+config EAP_AKA
+	bool "EAP-AKA support"
+
+config EAP_ALL
+	bool "All EAP methods support"
+	select EAP_TLS
+	default y if WIFI_NM_WPA_SUPPLICANT_CRYPTO_ENTERPRISE
+
 config WIFI_NM_WPA_SUPPLICANT_WPA3
 	bool "WPA3 support"
 	depends on !WIFI_NM_WPA_SUPPLICANT_CRYPTO_NONE

--- a/modules/hostap/src/supp_main.h
+++ b/modules/hostap/src/supp_main.h
@@ -6,6 +6,36 @@
 #ifndef __SUPP_MAIN_H_
 #define __SUPP_MAIN_H_
 
+#ifdef CONFIG_WIFI_NM_WPA_SUPPLICANT_CRYPTO_ENTERPRISE
+/* At least one of the EAP methods need to be enabled in enterprise mode */
+#if !defined(CONFIG_EAP_TLS) && !defined(CONFIG_EAP_TTLS) && \
+	!defined(CONFIG_EAP_PEAP) && !defined(CONFIG_EAP_FAST) && \
+	!defined(CONFIG_EAP_SIM) && !defined(CONFIG_EAP_AKA) && \
+	!defined(CONFIG_EAP_MD5) && !defined(CONFIG_EAP_MSCHAPV2) && \
+	!defined(CONFIG_EAP_PSK) && !defined(CONFIG_EAP_PAX) && \
+	!defined(CONFIG_EAP_SAKE) && !defined(CONFIG_EAP_GPSK) && \
+	!defined(CONFIG_EAP_PWD) && !defined(CONFIG_EAP_EKE) && \
+	!defined(CONFIG_EAP_IKEV2)
+#error "At least one of the following EAP methods need to be defined    \
+	CONFIG_EAP_TLS    \
+	CONFIG_EAP_TTLS   \
+	CONFIG_EAP_PEAP   \
+	CONFIG_EAP_MD5        \
+	CONFIG_EAP_MSCHAPV2    \
+	CONFIG_EAP_LEAP    \
+	CONFIG_EAP_PSK   \
+	CONFIG_EAP_PAX   \
+	CONFIG_EAP_SAKE   \
+	CONFIG_EAP_GPSK   \
+	CONFIG_EAP_PWD   \
+	CONFIG_EAP_EKE   \
+	CONFIG_EAP_IKEV2   \
+	CONFIG_EAP_SIM   \
+	CONFIG_EAP_AKA   \
+	CONFIG_EAP_ALL "
+#endif /* EAP METHODS */
+#endif /* CONFIG_WIFI_NM_WPA_SUPPLICANT_CRYPTO_ENTERPRISE */
+
 #if !defined(CONFIG_NET_DHCPV4)
 static inline void net_dhcpv4_start(struct net_if *iface)
 {


### PR DESCRIPTION
Enabling all EAP types for enterprise mode increases memory usage in both ROM and RAM. Provide config options for each type to let solutions choose the methods based on their requirements. 
`CONFIG_EAP_ALL` selects only `CONFIG_EAP_TLS` for now. It will be extended as and when support for other methods is added.