### PR TITLE
kconfig: openthread: Add OPENTHREAD_CLI_VENDOR_EXTENSION option

### DIFF
--- a/modules/openthread/CMakeLists.txt
+++ b/modules/openthread/CMakeLists.txt
@@ -137,6 +137,10 @@ if(CONFIG_OPENTHREAD_POWER_SUPPLY)
   set(OT_POWER_SUPPLY ${CONFIG_OPENTHREAD_POWER_SUPPLY} CACHE STRING "Power supply configuration" FORCE)
 endif()
 
+if (CONFIG_OPENTHREAD_CLI_VENDOR_EXTENSION)
+  set(OT_CLI_VENDOR_EXTENSION ${CONFIG_OPENTHREAD_CLI_VENDOR_EXTENSION} CACHE STRING "Path to CMake file to define and link Openthread CLI vendor extension" FORCE)
+endif()
+
 set(BUILD_TESTING OFF CACHE BOOL "Disable openthread cmake testing targets" FORCE)
 
 # Zephyr logging options

--- a/modules/openthread/Kconfig.features
+++ b/modules/openthread/Kconfig.features
@@ -389,3 +389,6 @@ config OPENTHREAD_UPTIME
 
 config OPENTHREAD_VERHOEFF_CHECKSUM
 	bool "Verhoeff checksum"
+
+config OPENTHREAD_CLI_VENDOR_EXTENSION
+	string "Path to CMake file to define and link Openthread CLI vendor extension"


### PR DESCRIPTION
This commit introduces a new option, OPENTHREAD_CLI_VENDOR_EXTENSION, in the Zephyr OpenThread module to map the upstream option OT_CLI_VENDOR_EXTENSION.

OPENTHREAD_CLI_VENDOR_EXTENSION option specifies the path to a CMake file that defines and links the CLI vendor extension. By setting this option, it enables the addition of vendor-specific commands to the OpenThread CLI interface.