### PR TITLE
kconfig: openthread: Increase range for OPENTHREAD_CLI_MAX_LINE_LENGTH

### DIFF
--- a/modules/openthread/Kconfig.thread
+++ b/modules/openthread/Kconfig.thread
@@ -146,7 +146,7 @@ config OPENTHREAD_PARENT_SEARCH_RSS_THRESHOLD
 
 config OPENTHREAD_CLI_MAX_LINE_LENGTH
 	int "The maximum size of the CLI line in bytes"
-	range 16 1024
+	range 16 $(UINT16_MAX)
 	default 384
 
 config OPENTHREAD_IP6_MAX_EXT_UCAST_ADDRS


### PR DESCRIPTION
This commit increases the range of value for the OPENTHREAD_CLI_MAX_LINE_LENGTH option to the maximum allowed.

The previous range may have been insufficient for Openthread vendor CLI commands.