### PR TITLE
Samples: Bluetooth: H5: Fixed the situation where the TX thread may no longer be sent out

### DIFF
--- a/samples/bluetooth/hci_uart_3wire/src/main.c
+++ b/samples/bluetooth/hci_uart_3wire/src/main.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Xiaomi Coopration
+ * Copyright (c) 2024 Xiaomi Corporation
  * Copyright (c) 2015-2016 Intel Corporation
  *
  * SPDX-License-Identifier: Apache-2.0
@@ -182,6 +182,7 @@ static void process_unack(void)
 {
 	uint8_t next_seq = h5.tx_seq;
 	uint8_t number_removed = unack_queue_len;
+	bool acked = false;
 
 	if (!unack_queue_len) {
 		return;
@@ -224,6 +225,12 @@ static void process_unack(void)
 		net_buf_unref(buf);
 		unack_queue_len--;
 		number_removed--;
+
+		acked = true;
+	}
+
+	if (acked) {
+		k_poll_signal_raise(&tx_queue_change, 0);
 	}
 }
 


### PR DESCRIPTION
When ever `unack_queue_len` changed, should raise signal
`tx_queue_change` to let's **tx_thread** known queue changed.

Fixed the situation where the TX thread may no longer be sent out