### PR TITLE
boards: doc: hwmv2: Update boards' index.rst to us HWMv2 terminology

### DIFF
--- a/boards/96boards/aerocore2/doc/index.rst
+++ b/boards/96boards/aerocore2/doc/index.rst
@@ -48,7 +48,7 @@ More information about STM32F427VIT6 can be found here:
 Supported Features
 ==================
 
-The Zephyr 96b_aerocore2 board configuration supports the following hardware
+The Zephyr ``96b_aerocore2`` board target supports the following hardware
 features:
 
 +------------+------------+-------------------------------------+

--- a/boards/96boards/argonkey/doc/index.rst
+++ b/boards/96boards/argonkey/doc/index.rst
@@ -51,7 +51,7 @@ Hardware
 Supported Features
 ==================
 
-The Zephyr 96b_argonkey board configuration supports the following hardware
+The Zephyr ``96b_argonkey`` board target supports the following hardware
 features:
 
 +-----------+------------+-------------------------------------+

--- a/boards/96boards/avenger96/doc/index.rst
+++ b/boards/96boards/avenger96/doc/index.rst
@@ -147,7 +147,7 @@ More information about STM32P157A can be found here:
 Supported Features
 ==================
 
-The Zephyr 96b_avenger96 board configuration supports the following hardware
+The Zephyr ``96b_avenger96`` board target supports the following hardware
 features:
 
 +-----------+------------+-------------------------------------+

--- a/boards/96boards/meerkat96/doc/index.rst
+++ b/boards/96boards/meerkat96/doc/index.rst
@@ -91,7 +91,7 @@ More information about the i.MX7 SoC can be found here:
 Supported Features
 ==================
 
-The Zephyr 96b_meerkat96 board configuration supports the following hardware
+The Zephyr ``96b_meerkat96`` board target supports the following hardware
 features:
 
 +-----------+------------+-------------------------------------+

--- a/boards/96boards/neonkey/doc/index.rst
+++ b/boards/96boards/neonkey/doc/index.rst
@@ -49,7 +49,7 @@ Hardware
 Supported Features
 ==================
 
-The Zephyr 96b_neonkey board configuration supports the following hardware
+The Zephyr ``96b_neonkey`` board target supports the following hardware
 features:
 
 +-----------+------------+-------------------------------------+

--- a/boards/96boards/nitrogen/doc/index.rst
+++ b/boards/96boards/nitrogen/doc/index.rst
@@ -50,7 +50,7 @@ Hardware
 Supported Features
 ==================
 
-The Zephyr 96b_nitrogen board configuration supports the following hardware
+The Zephyr ``96b_nitrogen`` board target supports the following hardware
 features:
 
 +-----------+------------+--------------------------------------+

--- a/boards/96boards/stm32_sensor_mez/doc/index.rst
+++ b/boards/96boards/stm32_sensor_mez/doc/index.rst
@@ -46,7 +46,7 @@ Hardware
 Supported Features
 ==================
 
-The Zephyr 96b_stm32_sensor_mez board configuration supports the following
+The Zephyr ``96b_stm32_sensor_mez`` board target supports the following
 hardware features:
 
 +-----------+------------+-------------------------------------+

--- a/boards/adafruit/grand_central_m4_express/doc/index.rst
+++ b/boards/adafruit/grand_central_m4_express/doc/index.rst
@@ -31,7 +31,7 @@ Hardware
 Supported Features
 ==================
 
-The adafruit_grand_central_m4_express board configuration supports the following
+The ``adafruit_grand_central_m4_express`` board target supports the following
 hardware features:
 
 +-----------+------------+------------------------------------------+

--- a/boards/adafruit/itsybitsy_m4_express/doc/index.rst
+++ b/boards/adafruit/itsybitsy_m4_express/doc/index.rst
@@ -29,7 +29,7 @@ Hardware
 Supported Features
 ==================
 
-The adafruit_itsybitsy_m4_express board configuration supports the following
+The ``adafruit_itsybitsy_m4_express`` board target supports the following
 hardware features:
 
 +-----------+------------+------------------------------------------+

--- a/boards/adafruit/kb2040/doc/index.rst
+++ b/boards/adafruit/kb2040/doc/index.rst
@@ -37,7 +37,7 @@ Hardware
 Supported Features
 ==================
 
-The adafruit_kb2040 board configuration supports the following
+The ``adafruit_kb2040`` board target supports the following
 hardware features:
 
 .. list-table::

--- a/boards/adafruit/qt_py_rp2040/doc/index.rst
+++ b/boards/adafruit/qt_py_rp2040/doc/index.rst
@@ -37,7 +37,7 @@ Hardware
 Supported Features
 ==================
 
-The adafruit_qt_py_rp2040 board configuration supports the following
+The ``adafruit_qt_py_rp2040`` board target supports the following
 hardware features:
 
 .. list-table::

--- a/boards/adafruit/trinket_m0/doc/index.rst
+++ b/boards/adafruit/trinket_m0/doc/index.rst
@@ -28,7 +28,7 @@ Hardware
 Supported Features
 ==================
 
-The adafruit_trinket_m0 board configuration supports the following hardware
+The ``adafruit_trinket_m0`` board target supports the following hardware
 features:
 
 +-----------+------------+------------------------------------------+

--- a/boards/adi/sdp_k1/doc/index.rst
+++ b/boards/adi/sdp_k1/doc/index.rst
@@ -74,7 +74,7 @@ More information about STM32F469NI can be found here:
 Supported Features
 ==================
 
-The Zephyr stm32f469i_disco board configuration supports the following hardware features:
+The Zephyr ``stm32f469i_disco`` board target supports the following hardware features:
 
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |

--- a/boards/arduino/due/doc/index.rst
+++ b/boards/arduino/due/doc/index.rst
@@ -32,7 +32,7 @@ Hardware
 Supported Features
 ==================
 
-The arduino_due board configuration supports the following hardware features:
+The ``arduino_due`` board target supports the following hardware features:
 
 +-----------+------------+----------------------+
 | Interface | Controller | Driver/Component     |

--- a/boards/arduino/mkrzero/doc/index.rst
+++ b/boards/arduino/mkrzero/doc/index.rst
@@ -27,7 +27,7 @@ Hardware
 Supported Features
 ==================
 
-The arduino_mkrzero board configuration supports the following hardware
+The ``arduino_mkrzero`` board target supports the following hardware
 features:
 
 +-----------+------------+------------------------------------------+

--- a/boards/arduino/nano_33_iot/doc/index.rst
+++ b/boards/arduino/nano_33_iot/doc/index.rst
@@ -28,7 +28,7 @@ Hardware
 Supported Features
 ==================
 
-The arduino_nano_33_iot board configuration supports the following hardware
+The ``arduino_nano_33_iot`` board target supports the following hardware
 features:
 
 +-----------+------------+------------------------------------------+

--- a/boards/arduino/portenta_h7/doc/index.rst
+++ b/boards/arduino/portenta_h7/doc/index.rst
@@ -35,7 +35,7 @@ More information about STM32H747XIH6 can be found here:
 Supported Features
 ==================
 
-The current Zephyr arduino_portenta_h7 board configuration supports the following hardware features:
+The current Zephyr ``arduino_portenta_h7`` board target supports the following hardware features:
 
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |

--- a/boards/arduino/zero/doc/index.rst
+++ b/boards/arduino/zero/doc/index.rst
@@ -28,7 +28,7 @@ Hardware
 Supported Features
 ==================
 
-The arduino_zero board configuration supports the following hardware
+The ``arduino_zero`` board target supports the following hardware
 features:
 
 +-----------+------------+------------------------------------------+

--- a/boards/arm/v2m_beetle/doc/index.rst
+++ b/boards/arm/v2m_beetle/doc/index.rst
@@ -49,7 +49,7 @@ ARM V2M BEETLE provides the following hardware components:
 Supported Features
 ===================
 
-The v2m_beetle board configuration supports the following hardware features:
+The ``v2m_beetle`` board target supports the following hardware features:
 
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |

--- a/boards/arm/v2m_musca_b1/doc/index.rst
+++ b/boards/arm/v2m_musca_b1/doc/index.rst
@@ -72,7 +72,7 @@ The v2m_musca_b1 board provides the following user push buttons:
 Supported Features
 ===================
 
-The v2m_musca_b1 board configuration supports the following hardware features:
+The ``v2m_musca_b1`` board target supports the following hardware features:
 
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |

--- a/boards/arm/v2m_musca_s1/doc/index.rst
+++ b/boards/arm/v2m_musca_s1/doc/index.rst
@@ -69,7 +69,7 @@ The v2m_musca_s1 board provides the following user push buttons:
 Supported Features
 ===================
 
-The v2m_musca_s1 board configuration supports the following hardware features:
+The ``v2m_musca_s1`` board target supports the following hardware features:
 
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |

--- a/boards/atmel/sam/sam4e_xpro/doc/index.rst
+++ b/boards/atmel/sam/sam4e_xpro/doc/index.rst
@@ -34,7 +34,7 @@ Hardware
 Supported Features
 ==================
 
-The sam4e_xpro board configuration supports the following hardware
+The ``sam4e_xpro`` board target supports the following hardware
 features:
 
 +-----------+------------+-------------------------------------+

--- a/boards/atmel/sam/sam4l_ek/doc/index.rst
+++ b/boards/atmel/sam/sam4l_ek/doc/index.rst
@@ -56,7 +56,7 @@ Hardware
 Supported Features
 ==================
 
-The sam4l_ek board configuration supports the following hardware features:
+The ``sam4l_ek`` board target supports the following hardware features:
 
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |

--- a/boards/atmel/sam/sam4s_xplained/doc/index.rst
+++ b/boards/atmel/sam/sam4s_xplained/doc/index.rst
@@ -30,7 +30,7 @@ Hardware
 Supported Features
 ==================
 
-The sam4s_xplained board configuration supports the following hardware
+The ``sam4s_xplained`` board target supports the following hardware
 features:
 
 +-----------+------------+-------------------------------------+

--- a/boards/atmel/sam/sam_e70_xplained/doc/index.rst
+++ b/boards/atmel/sam/sam_e70_xplained/doc/index.rst
@@ -34,7 +34,7 @@ Hardware
 Supported Features
 ==================
 
-The sam_e70_xplained board configuration supports the following hardware
+The ``sam_e70_xplained`` board target supports the following hardware
 features:
 
 +-----------+------------+-------------------------------------+

--- a/boards/atmel/sam0/samc21n_xpro/doc/index.rst
+++ b/boards/atmel/sam0/samc21n_xpro/doc/index.rst
@@ -32,7 +32,7 @@ Hardware
 Supported Features
 ==================
 
-The samc21n_xpro board configuration supports the following hardware
+The ``samc21n_xpro`` board target supports the following hardware
 features:
 
 .. list-table::

--- a/boards/atmel/sam0/samd20_xpro/doc/index.rst
+++ b/boards/atmel/sam0/samd20_xpro/doc/index.rst
@@ -33,7 +33,7 @@ Hardware
 Supported Features
 ==================
 
-The samd20_xpro board configuration supports the following hardware
+The ``samd20_xpro`` board target supports the following hardware
 features:
 
 .. list-table::

--- a/boards/atmel/sam0/samd21_xpro/doc/index.rst
+++ b/boards/atmel/sam0/samd21_xpro/doc/index.rst
@@ -33,7 +33,7 @@ Hardware
 Supported Features
 ==================
 
-The samd21_xpro board configuration supports the following hardware
+The ``samd21_xpro`` board target supports the following hardware
 features:
 
 .. list-table::

--- a/boards/atmel/sam0/same54_xpro/doc/index.rst
+++ b/boards/atmel/sam0/same54_xpro/doc/index.rst
@@ -43,7 +43,7 @@ Hardware
 Supported Features
 ==================
 
-The same54_xpro board configuration supports the following hardware
+The ``same54_xpro`` board target supports the following hardware
 features:
 
 +---------------+------------+----------------------------+

--- a/boards/atmel/sam0/saml21_xpro/doc/index.rst
+++ b/boards/atmel/sam0/saml21_xpro/doc/index.rst
@@ -30,7 +30,7 @@ Hardware
 Supported Features
 ==================
 
-The saml21_xpro board configuration supports the following hardware
+The ``saml21_xpro`` board target supports the following hardware
 features:
 
 .. list-table::

--- a/boards/atmel/sam0/samr21_xpro/doc/index.rst
+++ b/boards/atmel/sam0/samr21_xpro/doc/index.rst
@@ -30,7 +30,7 @@ Hardware
 Supported Features
 ==================
 
-The samr21_xpro board configuration supports the following hardware
+The ``samr21_xpro`` board target supports the following hardware
 features:
 
 +-----------+------------+--------------------------------------+

--- a/boards/atmel/sam0/samr34_xpro/doc/index.rst
+++ b/boards/atmel/sam0/samr34_xpro/doc/index.rst
@@ -35,7 +35,7 @@ Hardware
 Supported Features
 ==================
 
-The samr34_xpro board configuration supports the following hardware
+The ``samr34_xpro`` board target supports the following hardware
 features:
 
 .. list-table::

--- a/boards/bbc/microbit/doc/index.rst
+++ b/boards/bbc/microbit/doc/index.rst
@@ -48,7 +48,7 @@ The micro:bit has the following physical features:
 Supported Features
 ==================
 
-The bbc_microbit board configuration supports the following nRF51
+The ``bbc_microbit`` board target supports the following nRF51
 hardware features:
 
 +-----------+------------+----------------------+

--- a/boards/bbc/microbit_v2/doc/index.rst
+++ b/boards/bbc/microbit_v2/doc/index.rst
@@ -42,7 +42,7 @@ The micro:bit-v2 has the following physical features:
 Supported Features
 ==================
 
-The bbc_microbit_v2 board configuration supports the following
+The ``bbc_microbit_v2`` board target supports the following
 hardware features:
 
 +-----------+------------+----------------------+

--- a/boards/contextualelectronics/abc/doc/index.rst
+++ b/boards/contextualelectronics/abc/doc/index.rst
@@ -44,7 +44,7 @@ is 32.768 kHz. The frequency of the main clock is 32 MHz.
 Supported Features
 ==================
 
-The contextualelectronics_abc board configuration supports the following
+The ``contextualelectronics_abc`` board target supports the following
 hardware features:
 
 +-----------+------------+----------------------+

--- a/boards/digilent/zybo/doc/index.rst
+++ b/boards/digilent/zybo/doc/index.rst
@@ -23,7 +23,7 @@ Hardware
 Supported Features
 ==================
 
-The zybo board configuration supports the following hardware features:
+The ``zybo`` board target supports the following hardware features:
 
 +------------+------------+-------------------------------------+
 | Interface  | Controller | Driver/Component                    |

--- a/boards/electronut/nrf52840_blip/doc/index.rst
+++ b/boards/electronut/nrf52840_blip/doc/index.rst
@@ -43,7 +43,7 @@ is 32 MHz.
 Supported Features
 ==================
 
-The nrf52840_blip board configuration supports the following
+The ``nrf52840_blip`` board target supports the following
 hardware features currently:
 
 +-----------+------------+----------------------+

--- a/boards/ezurio/rm1xx_dvk/doc/index.rst
+++ b/boards/ezurio/rm1xx_dvk/doc/index.rst
@@ -57,7 +57,7 @@ is 16MHz.
 Supported Features
 ==================
 
-The rm1xx_dvk board configuration supports the following
+The ``rm1xx_dvk`` board target supports the following
 hardware features:
 
 +-----------+------------+----------------------+

--- a/boards/fanke/fk7b0m1_vbt6/doc/index.rst
+++ b/boards/fanke/fk7b0m1_vbt6/doc/index.rst
@@ -57,7 +57,7 @@ More information about STM32H7B0VB can be found here:
 Supported Features
 ==================
 
-The Zephyr fk7b0m1_vbt6 board configuration supports the following hardware
+The Zephyr ``fk7b0m1_vbt6`` board target supports the following hardware
 features:
 
 +-------------+------------+-------------------------------------+

--- a/boards/firefly/roc_rk3568_pc/doc/index.rst
+++ b/boards/firefly/roc_rk3568_pc/doc/index.rst
@@ -45,7 +45,7 @@ has frequency up to 2.0GHz. Zephyr OS is ported to run on it.
 Supported Features
 ==================
 
-The Zephyr roc_rk3568_pc board configuration supports the following hardware
+The Zephyr ``roc_rk3568_pc`` board target supports the following hardware
 features:
 
 +-----------+------------+-------------------------------------+

--- a/boards/hardkernel/odroid_go/doc/index.rst
+++ b/boards/hardkernel/odroid_go/doc/index.rst
@@ -60,7 +60,7 @@ External Connector
 Supported Features
 ==================
 
-The Zephyr odroid_go board configuration supports the following hardware
+The Zephyr ``odroid_go`` board target supports the following hardware
 features:
 
 +------------+------------+-------------------------------------+

--- a/boards/holyiot/yj16019/doc/index.rst
+++ b/boards/holyiot/yj16019/doc/index.rst
@@ -39,7 +39,7 @@ The nRF52832 of the Holyiot YJ-16019 is clocked by an external crystal with a fr
 Supported Features
 ==================
 
-The holyiot_yj16019 board configuration supports the following
+The ``holyiot_yj16019`` board target supports the following
 hardware features:
 
 +-----------+------------+----------------------+

--- a/boards/m5stack/m5stack_atom_lite/doc/index.rst
+++ b/boards/m5stack/m5stack_atom_lite/doc/index.rst
@@ -27,7 +27,7 @@ It features the following integrated components:
 Supported Features
 ==================
 
-The Zephyr m5stack_atom_lite board configuration supports the following hardware features:
+The Zephyr ``m5stack_atom_lite`` board target supports the following hardware features:
 
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |

--- a/boards/m5stack/m5stack_atoms3/doc/index.rst
+++ b/boards/m5stack/m5stack_atoms3/doc/index.rst
@@ -29,7 +29,7 @@ It features the following integrated components:
 Supported Features
 ==================
 
-The Zephyr m5stack_atoms3 board configuration supports the following hardware features:
+The Zephyr ``m5stack_atoms3`` board target supports the following hardware features:
 
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |

--- a/boards/m5stack/m5stack_core2/doc/index.rst
+++ b/boards/m5stack/m5stack_core2/doc/index.rst
@@ -114,7 +114,7 @@ These voltages can be controlled via regulator api.
 Supported Features
 ==================
 
-The Zephyr m5stack_core2 board configuration supports the following hardware features:
+The Zephyr ``m5stack_core2`` board target supports the following hardware features:
 
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |

--- a/boards/madmachine/mm_feather/doc/index.rst
+++ b/boards/madmachine/mm_feather/doc/index.rst
@@ -51,7 +51,7 @@ Hardware
 Supported Features
 ==================
 
-The mm_feather board configuration supports the following hardware
+The ``mm_feather`` board target supports the following hardware
 features:
 
 +-----------+------------+-------------------------------------+

--- a/boards/madmachine/mm_swiftio/doc/index.rst
+++ b/boards/madmachine/mm_swiftio/doc/index.rst
@@ -35,7 +35,7 @@ Hardware
 Supported Features
 ==================
 
-The mm_swiftio board configuration supports the following hardware
+The ``mm_swiftio`` board target supports the following hardware
 features:
 
 +-----------+------------+-------------------------------------+

--- a/boards/microchip/ev11l78a/doc/index.rst
+++ b/boards/microchip/ev11l78a/doc/index.rst
@@ -30,7 +30,7 @@ Hardware
 Supported Features
 ==================
 
-The ev11l78a board configuration supports the following hardware
+The ``ev11l78a`` board target supports the following hardware
 features:
 
 

--- a/boards/microchip/mec1501modular_assy6885/doc/index.rst
+++ b/boards/microchip/mec1501modular_assy6885/doc/index.rst
@@ -52,7 +52,7 @@ For more information about the SOC please see the `MEC152x Reference Manual`_
 Supported Features
 ==================
 
-The mec1501modular_assy6885 board configuration supports the following hardware
+The ``mec1501modular_assy6885`` board target supports the following hardware
 features:
 
 +-----------+------------+-------------------------------------+

--- a/boards/microchip/mec15xxevb_assy6853/doc/index.rst
+++ b/boards/microchip/mec15xxevb_assy6853/doc/index.rst
@@ -49,7 +49,7 @@ For more information about the SOC's please see `MEC152x Reference Manual`_
 Supported Features
 ==================
 
-The mec15xxevb_assy6853 board configuration supports the following hardware
+The ``mec15xxevb_assy6853`` board target supports the following hardware
 features:
 
 +-----------+------------+-------------------------------------+

--- a/boards/microchip/mec172xevb_assy6906/doc/index.rst
+++ b/boards/microchip/mec172xevb_assy6906/doc/index.rst
@@ -43,7 +43,7 @@ For more information about the SOC's please see `MEC172x Reference Manual`_
 Supported Features
 ==================
 
-The mec172xevb_assy6906 board configuration supports the following hardware
+The ``mec172xevb_assy6906`` board target supports the following hardware
 features:
 
 +-----------+------------+-------------------------------------+

--- a/boards/mxchip/az3166_iotdevkit/doc/index.rst
+++ b/boards/mxchip/az3166_iotdevkit/doc/index.rst
@@ -43,7 +43,7 @@ The MXChip AZ3166 IoT DevKit has the following physical features:
 Supported Features
 ==================
 
-The az3166_iotdevkit board configuration supports the following
+The ``az3166_iotdevkit`` board target supports the following
 hardware features:
 
 +-----------+------------+----------------------+

--- a/boards/nxp/frdm_ke15z/doc/index.rst
+++ b/boards/nxp/frdm_ke15z/doc/index.rst
@@ -39,7 +39,7 @@ these NXP reference documents:
 Supported Features
 ==================
 
-The frdm_ke15z board configuration supports the following hardware
+The ``frdm_ke15z`` board target supports the following hardware
 features:
 
 +-----------+------------+-------------------------------------+

--- a/boards/nxp/frdm_ke17z/doc/index.rst
+++ b/boards/nxp/frdm_ke17z/doc/index.rst
@@ -43,7 +43,7 @@ these NXP reference documents:
 Supported Features
 ==================
 
-The frdm_ke17z board configuration supports the following hardware
+The ``frdm_ke17z`` board target supports the following hardware
 features:
 
 +-----------+------------+-------------------------------------+

--- a/boards/nxp/frdm_ke17z512/doc/index.rst
+++ b/boards/nxp/frdm_ke17z512/doc/index.rst
@@ -44,7 +44,7 @@ these NXP reference documents:
 Supported Features
 ==================
 
-The frdm_ke17z512 board configuration supports the following hardware
+The ``frdm_ke17z512`` board target supports the following hardware
 features:
 
 +-----------+------------+-------------------------------------+

--- a/boards/nxp/frdm_kl25z/doc/index.rst
+++ b/boards/nxp/frdm_kl25z/doc/index.rst
@@ -38,7 +38,7 @@ For more information about the KL25Z SoC and FRDM-KL25Z board:
 Supported Features
 ==================
 
-The frdm_kl25z board configuration supports the following hardware features:
+The ``frdm_kl25z`` board target supports the following hardware features:
 
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |

--- a/boards/nxp/frdm_kw41z/doc/index.rst
+++ b/boards/nxp/frdm_kw41z/doc/index.rst
@@ -52,7 +52,7 @@ For more information about the KW41Z SoC and FRDM-KW41Z board:
 Supported Features
 ==================
 
-The frdm_kw41z board configuration supports the following hardware features:
+The ``frdm_kw41z`` board target supports the following hardware features:
 
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |

--- a/boards/nxp/twr_ke18f/doc/index.rst
+++ b/boards/nxp/twr_ke18f/doc/index.rst
@@ -46,7 +46,7 @@ these NXP reference documents:
 Supported Features
 ==================
 
-The twr_ke18f board configuration supports the following hardware
+The ``twr_ke18f`` board target supports the following hardware
 features:
 
 +-----------+------------+-------------------------------------+

--- a/boards/nxp/twr_kv58f220m/doc/index.rst
+++ b/boards/nxp/twr_kv58f220m/doc/index.rst
@@ -43,7 +43,7 @@ these NXP reference documents:
 Supported Features
 ==================
 
-The twr_kv58f220m board configuration supports the following hardware
+The ``twr_kv58f220m`` board target supports the following hardware
 features:
 
 +-----------+------------+-------------------------------------+

--- a/boards/olimex/olimex_esp32_evb/doc/index.rst
+++ b/boards/olimex/olimex_esp32_evb/doc/index.rst
@@ -50,7 +50,7 @@ these reference documents:
 Supported Features
 ******************
 
-The olimex_esp32_evb board configuration supports the following hardware
+The ``olimex_esp32_evb`` board target supports the following hardware
 features:
 
 +-----------+------------+-------------------------------------+

--- a/boards/olimex/olimexino_stm32/doc/index.rst
+++ b/boards/olimex/olimexino_stm32/doc/index.rst
@@ -23,7 +23,7 @@ information and the datasheet.
 Supported Features
 ==================
 
-The olimexino_stm32 board configuration supports the following
+The ``olimexino_stm32`` board target supports the following
 hardware features:
 
 +-----------+------------+-------------------------+

--- a/boards/olimex/stm32_e407/doc/index.rst
+++ b/boards/olimex/stm32_e407/doc/index.rst
@@ -26,7 +26,7 @@ information and the datasheet.
 Supported Features
 ==================
 
-The olimex_stm32_e407 board configuration supports the following
+The ``olimex_stm32_e407`` board target supports the following
 hardware features:
 
 +------------+------------+----------------------+

--- a/boards/olimex/stm32_h405/doc/index.rst
+++ b/boards/olimex/stm32_h405/doc/index.rst
@@ -32,7 +32,7 @@ information and the datasheet.
 Supported Features
 ==================
 
-The olimex_stm32_h405 board configuration supports the following
+The ``olimex_stm32_h405`` board target supports the following
 hardware features:
 
 +-----------+------------+-------------------------+

--- a/boards/olimex/stm32_h407/doc/index.rst
+++ b/boards/olimex/stm32_h407/doc/index.rst
@@ -26,7 +26,7 @@ information and the datasheet.
 Supported Features
 ==================
 
-The olimex_stm32_h407 board configuration supports the following
+The ``olimex_stm32_h407`` board target supports the following
 hardware features:
 
 +-----------+------------+----------------------+

--- a/boards/olimex/stm32_p405/doc/index.rst
+++ b/boards/olimex/stm32_p405/doc/index.rst
@@ -26,7 +26,7 @@ information and the datasheet.
 Supported Features
 ==================
 
-The olimex_stm32_p405 board configuration supports the following
+The ``olimex_stm32_p405`` board target supports the following
 hardware features:
 
 +-----------+------------+----------------------+

--- a/boards/others/black_f407ve/doc/index.rst
+++ b/boards/others/black_f407ve/doc/index.rst
@@ -88,7 +88,7 @@ More information about STM32F407VE SOC can be found here:
 Supported Features
 ==================
 
-The Zephyr black_f407ve board configuration supports the following hardware
+The Zephyr ``black_f407ve`` board target supports the following hardware
 features:
 
 +-----------+------------+-------------------------------------+

--- a/boards/others/black_f407zg_pro/doc/index.rst
+++ b/boards/others/black_f407zg_pro/doc/index.rst
@@ -85,7 +85,7 @@ More information about STM32F407ZG SOC can be found here:
 Supported Features
 ==================
 
-The Zephyr black_f407zg_pro board configuration supports the following hardware
+The Zephyr ``black_f407zg_pro`` board target supports the following hardware
 features:
 
 +-----------+------------+-------------------------------------+

--- a/boards/others/stm32_min_dev/doc/index.rst
+++ b/boards/others/stm32_min_dev/doc/index.rst
@@ -90,7 +90,7 @@ respectively.
 Supported Features
 ==================
 
-The stm32_min_dev board configuration supports the following hardware features:
+The ``stm32_min_dev`` board target supports the following hardware features:
 
 +-----------+------------+----------------------+
 | Interface | Controller | Driver/Component     |

--- a/boards/others/stm32f030_demo/doc/index.rst
+++ b/boards/others/stm32f030_demo/doc/index.rst
@@ -38,7 +38,7 @@ Hardware
 Supported Features
 ==================
 
-The Zephyr stm32f030_demo board configuration supports the following
+The Zephyr ``stm32f030_demo`` board target supports the following
 hardware features:
 
 +-----------+------------+-------------------------------------+

--- a/boards/others/stm32f103_mini/doc/index.rst
+++ b/boards/others/stm32f103_mini/doc/index.rst
@@ -45,7 +45,7 @@ More information about STM32F103RC can be found here:
 Supported Features
 ==================
 
-The Zephyr stm32f103_mini board configuration supports the following hardware features:
+The Zephyr ``stm32f103_mini`` board target supports the following hardware features:
 
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |

--- a/boards/others/stm32f401_mini/doc/index.rst
+++ b/boards/others/stm32f401_mini/doc/index.rst
@@ -42,7 +42,7 @@ hardware components:
 Supported Features
 ==================
 
-The Zephyr stm32f401_mini board configuration supports the following
+The Zephyr ``stm32f401_mini`` board target supports the following
 hardware features:
 
 +------------+------------+-------------------------------------+

--- a/boards/particle/argon/doc/index.rst
+++ b/boards/particle/argon/doc/index.rst
@@ -46,7 +46,7 @@ It contains circuitry for LIPO usage and can be charged via the USB port.
 Supported Features
 ==================
 
-The particle_argon board configuration supports the following
+The ``particle_argon`` board target supports the following
 hardware features:
 
 +-----------+------------+----------------------+

--- a/boards/particle/boron/doc/index.rst
+++ b/boards/particle/boron/doc/index.rst
@@ -46,7 +46,7 @@ It contains circuitry for LIPO usage and can be charged via the USB port.
 Supported Features
 ==================
 
-The particle_boron board configuration supports the following
+The ``particle_boron`` board target supports the following
 hardware features:
 
 +-----------+------------+----------------------+

--- a/boards/particle/nrf51_blenano/doc/index.rst
+++ b/boards/particle/nrf51_blenano/doc/index.rst
@@ -18,7 +18,7 @@ is 32.768 kHz. The frequency of the main clock is 16 MHz.
 Supported Features
 ==================
 
-The nrf51_blenano board configuration supports the following nRF51
+The ``nrf51_blenano`` board target supports the following nRF51
 hardware features:
 
 +-----------+------------+----------------------+

--- a/boards/particle/xenon/doc/index.rst
+++ b/boards/particle/xenon/doc/index.rst
@@ -45,7 +45,7 @@ It contains circuitry for LIPO usage and can be charged via the USB port.
 Supported Features
 ==================
 
-The particle_xenon board configuration supports the following
+The ``particle_xenon`` board target supports the following
 hardware features:
 
 +-----------+------------+----------------------+

--- a/boards/phytec/reel_board/doc/index.rst
+++ b/boards/phytec/reel_board/doc/index.rst
@@ -114,7 +114,7 @@ The mode is controlled by MODE pin (P1.00).
 Supported Features
 ==================
 
-The reel_board board configuration supports the following
+The ``reel_board`` board target supports the following
 hardware features:
 
 +-----------+------------+----------------------+

--- a/boards/pjrc/teensy4/doc/index.rst
+++ b/boards/pjrc/teensy4/doc/index.rst
@@ -47,7 +47,7 @@ See the `Teensy 4.0 Website`_ for a complete hardware description.
 Supported Features
 ==================
 
-The teensy40 board configuration supports the following hardware
+The ``teensy40`` board target supports the following hardware
 features:
 
 +-----------+------------+-------------------------------------+

--- a/boards/raspberrypi/rpi_pico/doc/index.rst
+++ b/boards/raspberrypi/rpi_pico/doc/index.rst
@@ -47,7 +47,7 @@ Hardware
 Supported Features
 ==================
 
-The rpi_pico board configuration supports the following
+The ``rpi_pico`` board target supports the following
 hardware features:
 
 .. list-table::

--- a/boards/renesas/rcar_salvator_xs/doc/index.rst
+++ b/boards/renesas/rcar_salvator_xs/doc/index.rst
@@ -31,7 +31,7 @@ The R-Car M3-W includes:
 
 Supported Features
 ==================
-The Renesas rcar_salvator_xs board configuration supports the following
+The Renesas ``rcar_salvator_xs`` board target supports the following
 hardware features:
 
 +-----------+------------------------------+--------------------------------+

--- a/boards/seco/stm32f3_seco_d23/doc/index.rst
+++ b/boards/seco/stm32f3_seco_d23/doc/index.rst
@@ -60,7 +60,7 @@ More information about STM32F302VC can be found here:
 Supported Features
 ==================
 
-The Zephyr stm32f3_seco_d23 board configuration supports the following hardware
+The Zephyr ``stm32f3_seco_d23`` board target supports the following hardware
 features:
 
 +-----------+------------+-------------------------------------+

--- a/boards/seeed/seeeduino_xiao/doc/index.rst
+++ b/boards/seeed/seeeduino_xiao/doc/index.rst
@@ -25,7 +25,7 @@ Hardware
 Supported Features
 ==================
 
-The seeeduino_xiao board configuration supports the following hardware
+The ``seeeduino_xiao`` board target supports the following hardware
 features:
 
 +-----------+------------+------------------------------------------+

--- a/boards/seeed/wio_terminal/doc/index.rst
+++ b/boards/seeed/wio_terminal/doc/index.rst
@@ -41,7 +41,7 @@ Hardware
 Supported Features
 ==================
 
-The wio_terminal board configuration supports the following hardware features:
+The ``wio_terminal`` board target supports the following hardware features:
 
 .. list-table::
     :header-rows: 1

--- a/boards/seeed/xiao_ble/doc/index.rst
+++ b/boards/seeed/xiao_ble/doc/index.rst
@@ -30,7 +30,7 @@ Hardware
 Supported Features
 ==================
 
-The xiao_ble board configuration supports the following hardware features:
+The ``xiao_ble`` board target supports the following hardware features:
 
 +-----------+------------+----------------------+
 | Interface | Controller | Driver/Component     |

--- a/boards/segger/ip_k66f/doc/index.rst
+++ b/boards/segger/ip_k66f/doc/index.rst
@@ -39,7 +39,7 @@ For more information about the K66F SoC and IP-K66F board:
 Supported Features
 ==================
 
-The ip_k66f board configuration supports the following hardware features:
+The ``ip_k66f`` board target supports the following hardware features:
 
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |

--- a/boards/silabs/dev_kits/sltb004a/doc/index.rst
+++ b/boards/silabs/dev_kits/sltb004a/doc/index.rst
@@ -50,7 +50,7 @@ For more information about the EFR32MG12 SoC and Thunderboard Sense 2 board:
 Supported Features
 ==================
 
-The sltb004a board configuration supports the following hardware features:
+The ``sltb004a`` board target supports the following hardware features:
 
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |

--- a/boards/silabs/dev_kits/sltb010a/doc/index.rst
+++ b/boards/silabs/dev_kits/sltb010a/doc/index.rst
@@ -49,7 +49,7 @@ For more information about the EFR32BG SoC and Thunderboard EFR32BG22 board:
 Supported Features
 ==================
 
-The sltb010a board configuration supports the following hardware features:
+The ``sltb010a`` board target supports the following hardware features:
 
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |

--- a/boards/silabs/dev_kits/xg27_dk2602a/doc/index.rst
+++ b/boards/silabs/dev_kits/xg27_dk2602a/doc/index.rst
@@ -42,7 +42,7 @@ For more information, refer to these documents:
 Supported Features
 ==================
 
-The xg27_dk2602a board configuration supports the following hardware features:
+The ``xg27_dk2602a`` board target supports the following hardware features:
 
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |

--- a/boards/silabs/radio_boards/slwrb4321a/doc/index.rst
+++ b/boards/silabs/radio_boards/slwrb4321a/doc/index.rst
@@ -42,7 +42,7 @@ For more information about the WGM160P and SLWSTK6121A board:
 Supported Features
 ==================
 
-The slwrb4321a board configuration supports the following hardware
+The ``slwrb4321a`` board target supports the following hardware
 features:
 
 +-----------+------------+-------------------------------------+

--- a/boards/silabs/starter_kits/efm32wg_stk3800/doc/index.rst
+++ b/boards/silabs/starter_kits/efm32wg_stk3800/doc/index.rst
@@ -40,7 +40,7 @@ For more information about the EFM32WG SoC and EFM32WG-STK3800 board:
 Supported Features
 ==================
 
-The efm32wg_stk3800 board configuration supports the following hardware features:
+The ``efm32wg_stk3800`` board target supports the following hardware features:
 
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |

--- a/boards/silabs/starter_kits/slstk3401a/doc/index.rst
+++ b/boards/silabs/starter_kits/slstk3401a/doc/index.rst
@@ -37,7 +37,7 @@ For more information about the EFM32PG SoC and SLSTK3401A board:
 Supported Features
 ==================
 
-The slstk3401a board configuration supports the following hardware features:
+The ``slstk3401a`` board target supports the following hardware features:
 
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |

--- a/boards/silabs/starter_kits/slstk3402a/doc/index.rst
+++ b/boards/silabs/starter_kits/slstk3402a/doc/index.rst
@@ -38,7 +38,7 @@ For more information about the EFM32PG SoC and SLSTK3402A board:
 Supported Features
 ==================
 
-The slstk3402a board configuration supports the following hardware features:
+The ``slstk3402a`` board target supports the following hardware features:
 
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |

--- a/boards/silabs/starter_kits/slstk3701a/doc/index.rst
+++ b/boards/silabs/starter_kits/slstk3701a/doc/index.rst
@@ -43,7 +43,7 @@ For more information about the EFM32GG11 SoC and SLSTK3701A board:
 Supported Features
 ==================
 
-The slstk3701a board configuration supports the following hardware
+The ``slstk3701a`` board target supports the following hardware
 features:
 
 +-----------+------------+-------------------------------------+

--- a/boards/sparkfun/pro_micro_rp2040/doc/index.rst
+++ b/boards/sparkfun/pro_micro_rp2040/doc/index.rst
@@ -37,7 +37,7 @@ Hardware
 Supported Features
 ==================
 
-The sparkfun_pro_micro_rp2040 board configuration supports the following
+The ``sparkfun_pro_micro_rp2040`` board target supports the following
 hardware features:
 
 .. list-table::

--- a/boards/st/b_g474e_dpow1/doc/index.rst
+++ b/boards/st/b_g474e_dpow1/doc/index.rst
@@ -50,7 +50,7 @@ More information about STM32G474RE can be found here:
 Supported Features
 ==================
 
-The Zephyr b_g474e_dpow1 board configuration supports the following hardware features:
+The Zephyr ``b_g474e_dpow1`` board target supports the following hardware features:
 
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |

--- a/boards/st/b_l4s5i_iot01a/doc/index.rst
+++ b/boards/st/b_l4s5i_iot01a/doc/index.rst
@@ -106,7 +106,7 @@ More information about STM32L4S5VI can be found here:
 Supported Features
 ==================
 
-The Zephyr b_l4s5i_iot01a board configuration supports the following hardware features:
+The Zephyr ``b_l4s5i_iot01a`` board target supports the following hardware features:
 
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |

--- a/boards/st/b_u585i_iot02a/doc/index.rst
+++ b/boards/st/b_u585i_iot02a/doc/index.rst
@@ -160,7 +160,7 @@ More information about STM32U585AI can be found here:
 Supported Features
 ==================
 
-The Zephyr b_u585i_iot02a board configuration supports the following hardware features:
+The Zephyr ``b_u585i_iot02a`` board target supports the following hardware features:
 
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |

--- a/boards/st/nucleo_c031c6/doc/index.rst
+++ b/boards/st/nucleo_c031c6/doc/index.rst
@@ -58,7 +58,7 @@ More information about STM32C031C6 can be found here:
 Supported Features
 ==================
 
-The Zephyr nucleo_c031c6 board configuration supports the following hardware features:
+The Zephyr ``nucleo_c031c6`` board target supports the following hardware features:
 
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |

--- a/boards/st/nucleo_f030r8/doc/index.rst
+++ b/boards/st/nucleo_f030r8/doc/index.rst
@@ -71,7 +71,7 @@ More information about STM32F030R8 can be found here:
 Supported Features
 ==================
 
-The Zephyr nucleo_f030r8 board configuration supports the following hardware features:
+The Zephyr ``nucleo_f030r8`` board target supports the following hardware features:
 
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |

--- a/boards/st/nucleo_f031k6/doc/index.rst
+++ b/boards/st/nucleo_f031k6/doc/index.rst
@@ -48,7 +48,7 @@ More information about STM32F031K6 can be found here:
 Supported Features
 ==================
 
-The Zephyr nucleo_f031k6 board configuration supports the following hardware features:
+The Zephyr ``nucleo_f031k6`` board target supports the following hardware features:
 
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |

--- a/boards/st/nucleo_f042k6/doc/index.rst
+++ b/boards/st/nucleo_f042k6/doc/index.rst
@@ -48,7 +48,7 @@ More information about STM32F042K6 can be found here:
 Supported Features
 ==================
 
-The Zephyr nucleo_f042k6 board configuration supports the following hardware features:
+The Zephyr ``nucleo_f042k6`` board target supports the following hardware features:
 
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |

--- a/boards/st/nucleo_f070rb/doc/index.rst
+++ b/boards/st/nucleo_f070rb/doc/index.rst
@@ -70,7 +70,7 @@ the `STM32F070 reference manual`_ .
 Supported Features
 ==================
 
-The Zephyr nucleo_f070rb board configuration supports the following hardware features:
+The Zephyr ``nucleo_f070rb`` board target supports the following hardware features:
 
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |

--- a/boards/st/nucleo_f091rc/doc/index.rst
+++ b/boards/st/nucleo_f091rc/doc/index.rst
@@ -70,7 +70,7 @@ More information about STM32F091RC can be found in the
 Supported Features
 ==================
 
-The Zephyr nucleo_f091rc board configuration supports the following hardware features:
+The Zephyr ``nucleo_f091rc`` board target supports the following hardware features:
 
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |

--- a/boards/st/nucleo_f103rb/doc/index.rst
+++ b/boards/st/nucleo_f103rb/doc/index.rst
@@ -71,7 +71,7 @@ More information about STM32F103RB can be found here:
 Supported Features
 ==================
 
-The Zephyr nucleo_f103rb board configuration supports the following hardware features:
+The Zephyr ``nucleo_f103rb`` board target supports the following hardware features:
 
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |

--- a/boards/st/nucleo_f302r8/doc/index.rst
+++ b/boards/st/nucleo_f302r8/doc/index.rst
@@ -74,7 +74,7 @@ More information about the STM32F302R8 can be found here:
 Supported Features
 ==================
 
-The Zephyr nucleo_f302r8 board configuration supports the following hardware
+The Zephyr ``nucleo_f302r8`` board target supports the following hardware
 features:
 
 +-----------+------------+-------------------------------------+

--- a/boards/st/nucleo_f303k8/doc/index.rst
+++ b/boards/st/nucleo_f303k8/doc/index.rst
@@ -70,7 +70,7 @@ More information about the STM32F303K8 can be found here:
 Supported Features
 ==================
 
-The Zephyr nucleo_f303k8 board configuration supports the following hardware
+The Zephyr ``nucleo_f303k8`` board target supports the following hardware
 features:
 
 +-----------+------------+-------------------------------------+

--- a/boards/st/nucleo_f303re/doc/index.rst
+++ b/boards/st/nucleo_f303re/doc/index.rst
@@ -75,7 +75,7 @@ More information about the STM32F303RE can be found here:
 Supported Features
 ==================
 
-The Zephyr nucleo_f303re board configuration supports the following hardware
+The Zephyr ``nucleo_f303re`` board target supports the following hardware
 features:
 
 +-----------+------------+-------------------------------------+

--- a/boards/st/nucleo_f334r8/doc/index.rst
+++ b/boards/st/nucleo_f334r8/doc/index.rst
@@ -71,7 +71,7 @@ More information about STM32F334R8 can be found in the
 Supported Features
 ==================
 
-The Zephyr nucleo_f334r8 board configuration supports the following hardware features:
+The Zephyr ``nucleo_f334r8`` board target supports the following hardware features:
 
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |

--- a/boards/st/nucleo_f410rb/doc/index.rst
+++ b/boards/st/nucleo_f410rb/doc/index.rst
@@ -64,7 +64,7 @@ More information about STM32F410RB can be found here:
 Supported Features
 ==================
 
-The Zephyr nucleo_f410rb board configuration supports the following hardware features:
+The Zephyr ``nucleo_f410rb`` board target supports the following hardware features:
 
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |

--- a/boards/st/nucleo_f411re/doc/index.rst
+++ b/boards/st/nucleo_f411re/doc/index.rst
@@ -64,7 +64,7 @@ More information about STM32F411RE can be found here:
 Supported Features
 ==================
 
-The Zephyr nucleo_f411re board configuration supports the following hardware features:
+The Zephyr ``nucleo_f411re`` board target supports the following hardware features:
 
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |

--- a/boards/st/nucleo_f429zi/doc/index.rst
+++ b/boards/st/nucleo_f429zi/doc/index.rst
@@ -77,7 +77,7 @@ More information about STM32F429ZI can be found here:
 Supported Features
 ==================
 
-The Zephyr nucleo_f429zi board configuration supports the following hardware features:
+The Zephyr ``nucleo_f429zi`` board target supports the following hardware features:
 
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |

--- a/boards/st/nucleo_f446re/doc/index.rst
+++ b/boards/st/nucleo_f446re/doc/index.rst
@@ -69,7 +69,7 @@ More information about STM32F446RE can be found here:
 Supported Features
 ==================
 
-The Zephyr nucleo_f446re board configuration supports the following hardware features:
+The Zephyr ``nucleo_f446re`` board target supports the following hardware features:
 
 +-------------+------------+-------------------------------------+
 | Interface   | Controller | Driver/Component                    |

--- a/boards/st/nucleo_f446ze/doc/index.rst
+++ b/boards/st/nucleo_f446ze/doc/index.rst
@@ -74,7 +74,7 @@ More information about STM32F446ZE can be found here:
 Supported Features
 ==================
 
-The Zephyr nucleo_f446ze board configuration supports the following hardware features:
+The Zephyr ``nucleo_f446ze`` board target supports the following hardware features:
 
 +-------------+------------+-------------------------------------+
 | Interface   | Controller | Driver/Component                    |

--- a/boards/st/nucleo_f746zg/doc/index.rst
+++ b/boards/st/nucleo_f746zg/doc/index.rst
@@ -88,7 +88,7 @@ Nucleo F746ZG provides the following hardware components:
 Supported Features
 ==================
 
-The Zephyr nucleo_f746zg board configuration supports the following hardware
+The Zephyr ``nucleo_f746zg`` board target supports the following hardware
 features:
 
 +-------------+------------+-------------------------------------+

--- a/boards/st/nucleo_f756zg/doc/index.rst
+++ b/boards/st/nucleo_f756zg/doc/index.rst
@@ -88,7 +88,7 @@ Nucleo F756ZG provides the following hardware components:
 Supported Features
 ==================
 
-The Zephyr nucleo_f756zg board configuration supports the following hardware
+The Zephyr ``nucleo_f756zg`` board target supports the following hardware
 features:
 
 +-----------+------------+-------------------------------------+

--- a/boards/st/nucleo_f767zi/doc/index.rst
+++ b/boards/st/nucleo_f767zi/doc/index.rst
@@ -88,7 +88,7 @@ Nucleo F767ZI provides the following hardware components:
 Supported Features
 ==================
 
-The Zephyr nucleo_f767zi board configuration supports the following hardware
+The Zephyr ``nucleo_f767zi`` board target supports the following hardware
 features:
 
 +-----------+------------+-------------------------------------+

--- a/boards/st/nucleo_g031k8/doc/index.rst
+++ b/boards/st/nucleo_g031k8/doc/index.rst
@@ -63,7 +63,7 @@ More information about STM32G031K8 can be found in the
 Supported Features
 ==================
 
-The Zephyr nucleo_g031k8 board configuration supports the following hardware features:
+The Zephyr ``nucleo_g031k8`` board target supports the following hardware features:
 
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |

--- a/boards/st/nucleo_g070rb/doc/index.rst
+++ b/boards/st/nucleo_g070rb/doc/index.rst
@@ -74,7 +74,7 @@ More information about STM32G070RB can be found here:
 Supported Features
 ==================
 
-The Zephyr nucleo_g070rb board configuration supports the following hardware features:
+The Zephyr ``nucleo_g070rb`` board target supports the following hardware features:
 
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |

--- a/boards/st/nucleo_g071rb/doc/index.rst
+++ b/boards/st/nucleo_g071rb/doc/index.rst
@@ -76,7 +76,7 @@ More information about STM32G071RB can be found here:
 Supported Features
 ==================
 
-The Zephyr nucleo_g071rb board configuration supports the following hardware features:
+The Zephyr ``nucleo_g071rb`` board target supports the following hardware features:
 
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |

--- a/boards/st/nucleo_g0b1re/doc/index.rst
+++ b/boards/st/nucleo_g0b1re/doc/index.rst
@@ -74,7 +74,7 @@ More information about STM32G0B1RE can be found here:
 Supported Features
 ==================
 
-The Zephyr nucleo_g0b1re board configuration supports the following hardware features:
+The Zephyr ``nucleo_g0b1re`` board target supports the following hardware features:
 
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |

--- a/boards/st/nucleo_g431rb/doc/index.rst
+++ b/boards/st/nucleo_g431rb/doc/index.rst
@@ -95,7 +95,7 @@ More information about STM32G431RB can be found here:
 Supported Features
 ==================
 
-The Zephyr nucleo_g431rb board configuration supports the following hardware features:
+The Zephyr ``nucleo_g431rb`` board target supports the following hardware features:
 
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |

--- a/boards/st/nucleo_g474re/doc/index.rst
+++ b/boards/st/nucleo_g474re/doc/index.rst
@@ -95,7 +95,7 @@ More information about STM32G474RE can be found here:
 Supported Features
 ==================
 
-The Zephyr nucleo_g474re board configuration supports the following hardware features:
+The Zephyr ``nucleo_g474re`` board target supports the following hardware features:
 
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |

--- a/boards/st/nucleo_h503rb/doc/index.rst
+++ b/boards/st/nucleo_h503rb/doc/index.rst
@@ -118,7 +118,7 @@ More information about STM32H533RE can be found here:
 Supported Features
 ==================
 
-The Zephyr nucleo_h503rb board configuration supports the following hardware features:
+The Zephyr ``nucleo_h503rb`` board target supports the following hardware features:
 
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |

--- a/boards/st/nucleo_h533re/doc/index.rst
+++ b/boards/st/nucleo_h533re/doc/index.rst
@@ -146,7 +146,7 @@ More information about STM32H533RE can be found here:
 Supported Features
 ==================
 
-The Zephyr nucleo_h533re board configuration supports the following hardware features:
+The Zephyr ``nucleo_h533re`` board target supports the following hardware features:
 
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |

--- a/boards/st/nucleo_h563zi/doc/index.rst
+++ b/boards/st/nucleo_h563zi/doc/index.rst
@@ -143,7 +143,7 @@ More information about STM32H563ZI can be found here:
 Supported Features
 ==================
 
-The Zephyr nucleo_h563zi board configuration supports the following hardware features:
+The Zephyr ``nucleo_h563zi`` board target supports the following hardware features:
 
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |

--- a/boards/st/nucleo_h723zg/doc/index.rst
+++ b/boards/st/nucleo_h723zg/doc/index.rst
@@ -87,7 +87,7 @@ Nucleo H723ZG provides the following hardware components:
 Supported Features
 ==================
 
-The Zephyr nucleo_h723zg board configuration supports the following hardware
+The Zephyr ``nucleo_h723zg`` board target supports the following hardware
 features:
 
 +-------------+------------+-------------------------------------+

--- a/boards/st/nucleo_h743zi/doc/index.rst
+++ b/boards/st/nucleo_h743zi/doc/index.rst
@@ -89,7 +89,7 @@ Nucleo H743ZI provides the following hardware components:
 Supported Features
 ==================
 
-The Zephyr nucleo_h743zi board configuration supports the following hardware
+The Zephyr ``nucleo_h743zi`` board target supports the following hardware
 features:
 
 +-------------+------------+-------------------------------------+

--- a/boards/st/nucleo_h753zi/doc/index.rst
+++ b/boards/st/nucleo_h753zi/doc/index.rst
@@ -91,7 +91,7 @@ Nucleo H753ZI provides the following hardware components:
 Supported Features
 ==================
 
-The Zephyr nucleo_h753zi board configuration supports the following hardware
+The Zephyr ``nucleo_h753zi`` board target supports the following hardware
 features:
 
 +-----------+------------+-------------------------------------+

--- a/boards/st/nucleo_h7a3zi_q/doc/index.rst
+++ b/boards/st/nucleo_h7a3zi_q/doc/index.rst
@@ -85,7 +85,7 @@ Nucleo H7A3ZI-Q provides the following hardware components:
 Supported Features
 ==================
 
-The Zephyr nucleo_h7a3zi_q board configuration supports the following hardware
+The Zephyr ``nucleo_h7a3zi_q`` board target supports the following hardware
 features:
 
 +-------------+------------+------------------------------------+

--- a/boards/st/nucleo_l011k4/doc/index.rst
+++ b/boards/st/nucleo_l011k4/doc/index.rst
@@ -69,7 +69,7 @@ More information about STM32L011K4 can be found in the
 Supported Features
 ==================
 
-The Zephyr nucleo_l011k4 board configuration supports the following hardware features:
+The Zephyr ``nucleo_l011k4`` board target supports the following hardware features:
 
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |

--- a/boards/st/nucleo_l031k6/doc/index.rst
+++ b/boards/st/nucleo_l031k6/doc/index.rst
@@ -62,7 +62,7 @@ More information about STM32L031K6 can be found in the
 Supported Features
 ==================
 
-The Zephyr nucleo_l031k6 board configuration supports the following hardware features:
+The Zephyr ``nucleo_l031k6`` board target supports the following hardware features:
 
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |

--- a/boards/st/nucleo_l053r8/doc/index.rst
+++ b/boards/st/nucleo_l053r8/doc/index.rst
@@ -70,7 +70,7 @@ More information about STM32L053R8 can be found in the
 Supported Features
 ==================
 
-The Zephyr nucleo_l053r8 board configuration supports the following hardware features:
+The Zephyr ``nucleo_l053r8`` board target supports the following hardware features:
 
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |

--- a/boards/st/nucleo_l073rz/doc/index.rst
+++ b/boards/st/nucleo_l073rz/doc/index.rst
@@ -70,7 +70,7 @@ More information about STM32L073RZ can be found in the
 Supported Features
 ==================
 
-The Zephyr nucleo_l073rz board configuration supports the following hardware features:
+The Zephyr ``nucleo_l073rz`` board target supports the following hardware features:
 
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |

--- a/boards/st/nucleo_l152re/doc/index.rst
+++ b/boards/st/nucleo_l152re/doc/index.rst
@@ -64,7 +64,7 @@ More information about STM32L152RE can be found here:
 Supported Features
 ==================
 
-The Zephyr nucleo_l152re board configuration supports the following hardware features:
+The Zephyr ``nucleo_l152re`` board target supports the following hardware features:
 
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |

--- a/boards/st/nucleo_l432kc/doc/index.rst
+++ b/boards/st/nucleo_l432kc/doc/index.rst
@@ -96,7 +96,7 @@ More information about STM32L432KC can be found here:
 Supported Features
 ==================
 
-The Zephyr nucleo_l432kc board configuration supports the following hardware features:
+The Zephyr ``nucleo_l432kc`` board target supports the following hardware features:
 
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |

--- a/boards/st/nucleo_l433rc_p/doc/index.rst
+++ b/boards/st/nucleo_l433rc_p/doc/index.rst
@@ -97,7 +97,7 @@ More information about STM32L433RC can be found here:
 Supported Features
 ==================
 
-The Zephyr nucleo_l433rc_p board configuration supports the following hardware features:
+The Zephyr ``nucleo_l433rc_p`` board target supports the following hardware features:
 
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |

--- a/boards/st/nucleo_l452re/doc/index.rst
+++ b/boards/st/nucleo_l452re/doc/index.rst
@@ -106,7 +106,7 @@ More information about STM32L452RE can be found here:
 Supported Features
 ==================
 
-The Zephyr nucleo_l452re board configuration supports the following hardware features:
+The Zephyr ``nucleo_l452re`` board target supports the following hardware features:
 
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |

--- a/boards/st/nucleo_l476rg/doc/index.rst
+++ b/boards/st/nucleo_l476rg/doc/index.rst
@@ -101,7 +101,7 @@ More information about STM32L476RG can be found here:
 Supported Features
 ==================
 
-The Zephyr nucleo_l476rg board configuration supports the following hardware features:
+The Zephyr ``nucleo_l476rg`` board target supports the following hardware features:
 
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |

--- a/boards/st/nucleo_l496zg/doc/index.rst
+++ b/boards/st/nucleo_l496zg/doc/index.rst
@@ -105,7 +105,7 @@ More information about STM32L496ZG can be found here:
 Supported Features
 ==================
 
-The Zephyr nucleo_l496zg board configuration supports the following hardware features:
+The Zephyr ``nucleo_l496zg`` board target supports the following hardware features:
 
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |

--- a/boards/st/nucleo_l4a6zg/doc/index.rst
+++ b/boards/st/nucleo_l4a6zg/doc/index.rst
@@ -106,7 +106,7 @@ More information about STM32L4A6ZG can be found here:
 Supported Features
 ==================
 
-The Zephyr nucleo_l4a6zg board configuration supports the following hardware features:
+The Zephyr ``nucleo_l4a6zg`` board target supports the following hardware features:
 
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |

--- a/boards/st/nucleo_l4r5zi/doc/index.rst
+++ b/boards/st/nucleo_l4r5zi/doc/index.rst
@@ -116,7 +116,7 @@ More information about STM32L4R5ZI can be found here:
 Supported Features
 ==================
 
-The Zephyr nucleo_l4r5zi board configuration supports the following
+The Zephyr ``nucleo_l4r5zi`` board target supports the following
 hardware features:
 
 +-----------+------------+-------------------------------------+

--- a/boards/st/nucleo_u083rc/doc/index.rst
+++ b/boards/st/nucleo_u083rc/doc/index.rst
@@ -138,7 +138,7 @@ More information about STM32U083RC can be found here:
 Supported Features
 ==================
 
-The Zephyr nucleo_u083rc board configuration supports the following hardware features:
+The Zephyr ``nucleo_u083rc`` board target supports the following hardware features:
 
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |

--- a/boards/st/nucleo_u575zi_q/doc/index.rst
+++ b/boards/st/nucleo_u575zi_q/doc/index.rst
@@ -141,7 +141,7 @@ More information about STM32U575ZI can be found here:
 Supported Features
 ==================
 
-The Zephyr nucleo_u575zi_q board configuration supports the following hardware features:
+The Zephyr ``nucleo_u575zi_q`` board target supports the following hardware features:
 
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |

--- a/boards/st/nucleo_u5a5zj_q/doc/index.rst
+++ b/boards/st/nucleo_u5a5zj_q/doc/index.rst
@@ -175,7 +175,7 @@ More information about STM32U5A5ZJ can be found here:
 Supported Features
 ==================
 
-The Zephyr nucleo_u5a5zj_q board configuration supports the following hardware features:
+The Zephyr ``nucleo_u5a5zj_q`` board target supports the following hardware features:
 
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |

--- a/boards/st/steval_fcu001v1/doc/index.rst
+++ b/boards/st/steval_fcu001v1/doc/index.rst
@@ -46,7 +46,7 @@ can be found in these documents:
 Supported Features
 ==================
 
-The Zephyr steval_fcu001v1 board configuration supports the following hardware features:
+The Zephyr ``steval_fcu001v1`` board target supports the following hardware features:
 
 +-----------+------------+------------------------------------+
 | Interface | Controller | Driver/Component                   |

--- a/boards/st/stm3210c_eval/doc/index.rst
+++ b/boards/st/stm3210c_eval/doc/index.rst
@@ -57,7 +57,7 @@ More information about STM32F107VCT can be found here:
 Supported Features
 ==================
 
-The Zephyr stm3210c_eval board configuration supports the following hardware features:
+The Zephyr ``stm3210c_eval`` board target supports the following hardware features:
 
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |

--- a/boards/st/stm32373c_eval/doc/index.rst
+++ b/boards/st/stm32373c_eval/doc/index.rst
@@ -61,7 +61,7 @@ More information about STM32F373VCT6 can be found here:
 Supported Features
 ==================
 
-The Zephyr stm32373c_eval board configuration supports the following hardware features:
+The Zephyr ``stm32373c_eval`` board target supports the following hardware features:
 
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |

--- a/boards/st/stm32c0116_dk/doc/index.rst
+++ b/boards/st/stm32c0116_dk/doc/index.rst
@@ -46,7 +46,7 @@ More information about STM32C011F6 can be found here:
 Supported Features
 ==================
 
-The Zephyr stm32c0116_dk board configuration supports the following hardware features:
+The Zephyr ``stm32c0116_dk`` board target supports the following hardware features:
 
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |

--- a/boards/st/stm32f072_eval/doc/index.rst
+++ b/boards/st/stm32f072_eval/doc/index.rst
@@ -76,7 +76,7 @@ More information about STM32F072VB can be found here:
 Supported Features
 ==================
 
-The Zephyr stm32f072_eval board configuration supports the following hardware features:
+The Zephyr ``stm32f072_eval`` board target supports the following hardware features:
 
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |

--- a/boards/st/stm32f072b_disco/doc/index.rst
+++ b/boards/st/stm32f072b_disco/doc/index.rst
@@ -67,7 +67,7 @@ More information about STM32F072RB can be found here:
 Supported Features
 ==================
 
-The Zephyr stm32f072b_disco board configuration supports the following hardware
+The Zephyr ``stm32f072b_disco`` board target supports the following hardware
 features:
 
 +-----------+------------+-------------------------------------+

--- a/boards/st/stm32f0_disco/doc/index.rst
+++ b/boards/st/stm32f0_disco/doc/index.rst
@@ -47,7 +47,7 @@ More information about STM32F051R8 can be found in the `STM32F0x8 reference manu
 Supported Features
 ==================
 
-The Zephyr stm32f0_disco board configuration supports the following hardware features:
+The Zephyr ``stm32f0_disco`` board target supports the following hardware features:
 
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |

--- a/boards/st/stm32f3_disco/doc/index.rst
+++ b/boards/st/stm32f3_disco/doc/index.rst
@@ -74,7 +74,7 @@ More information about STM32F303VC can be found here:
 Supported Features
 ==================
 
-The Zephyr stm32f3_disco board configuration supports the following hardware
+The Zephyr ``stm32f3_disco`` board target supports the following hardware
 features:
 
 +-----------+------------+-------------------------------------+

--- a/boards/st/stm32f411e_disco/doc/index.rst
+++ b/boards/st/stm32f411e_disco/doc/index.rst
@@ -66,7 +66,7 @@ More information about STM32F411VE can be found here:
 Supported Features
 ==================
 
-The Zephyr stm32f411e_disco board configuration supports the following
+The Zephyr ``stm32f411e_disco`` board target supports the following
 hardware features:
 
 +-----------+------------+-------------------------------------+

--- a/boards/st/stm32f412g_disco/doc/index.rst
+++ b/boards/st/stm32f412g_disco/doc/index.rst
@@ -79,7 +79,7 @@ More information about STM32F412ZG can be found here:
 Supported Features
 ==================
 
-The Zephyr stm32f412g_disco board configuration supports the following hardware features:
+The Zephyr ``stm32f412g_disco`` board target supports the following hardware features:
 
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |

--- a/boards/st/stm32f429i_disc1/doc/index.rst
+++ b/boards/st/stm32f429i_disc1/doc/index.rst
@@ -75,7 +75,7 @@ More information about STM32F429ZI can be found here:
 Supported Features
 ==================
 
-The Zephyr stm32f429i_disc1 board configuration supports the following hardware features:
+The Zephyr ``stm32f429i_disc1`` board target supports the following hardware features:
 
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |

--- a/boards/st/stm32f469i_disco/doc/index.rst
+++ b/boards/st/stm32f469i_disco/doc/index.rst
@@ -79,7 +79,7 @@ More information about STM32F469NI can be found here:
 Supported Features
 ==================
 
-The Zephyr stm32f469i_disco board configuration supports the following hardware features:
+The Zephyr ``stm32f469i_disco`` board target supports the following hardware features:
 
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |

--- a/boards/st/stm32f4_disco/doc/index.rst
+++ b/boards/st/stm32f4_disco/doc/index.rst
@@ -76,7 +76,7 @@ More information about STM32F407VG can be found here:
 Supported Features
 ==================
 
-The Zephyr stm32f4_disco board configuration supports the following hardware features:
+The Zephyr ``stm32f4_disco`` board target supports the following hardware features:
 
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |

--- a/boards/st/stm32f723e_disco/doc/index.rst
+++ b/boards/st/stm32f723e_disco/doc/index.rst
@@ -67,7 +67,7 @@ More information about STM32F723IEK6 can be found here:
 Supported Features
 ==================
 
-The Zephyr stm32f723e_disco board configuration supports the following hardware features:
+The Zephyr ``stm32f723e_disco`` board target supports the following hardware features:
 
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |

--- a/boards/st/stm32f746g_disco/doc/index.rst
+++ b/boards/st/stm32f746g_disco/doc/index.rst
@@ -84,7 +84,7 @@ More information about STM32F746NGH6 can be found here:
 Supported Features
 ==================
 
-The Zephyr stm32f746g_disco board configuration supports the following hardware features:
+The Zephyr ``stm32f746g_disco`` board target supports the following hardware features:
 
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |

--- a/boards/st/stm32f7508_dk/doc/index.rst
+++ b/boards/st/stm32f7508_dk/doc/index.rst
@@ -79,7 +79,7 @@ More information about STM32F750x8 can be found here:
 Supported Features
 ==================
 
-The Zephyr stm32f7508_dk board configuration supports the following hardware features:
+The Zephyr ``stm32f7508_dk`` board target supports the following hardware features:
 
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |

--- a/boards/st/stm32f769i_disco/doc/index.rst
+++ b/boards/st/stm32f769i_disco/doc/index.rst
@@ -94,7 +94,7 @@ More information about STM32F769NIH6 can be found here:
 Supported Features
 ==================
 
-The Zephyr stm32f769i_disco board configuration supports the following hardware features:
+The Zephyr ``stm32f769i_disco`` board target supports the following hardware features:
 
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |

--- a/boards/st/stm32g0316_disco/doc/index.rst
+++ b/boards/st/stm32g0316_disco/doc/index.rst
@@ -37,7 +37,7 @@ For more information about the STM32G03x SoC and the STM32G0316-DISCO board, see
 Supported Features
 ==================
 
-The Zephyr stm32g0316_disco board configuration supports the following hardware features:
+The Zephyr ``stm32g0316_disco`` board target supports the following hardware features:
 
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |

--- a/boards/st/stm32g071b_disco/doc/index.rst
+++ b/boards/st/stm32g071b_disco/doc/index.rst
@@ -59,7 +59,7 @@ More information about STM32G071RB can be found here:
 Supported Features
 ==================
 
-The Zephyr stm32g071b_disco board configuration supports the following hardware features:
+The Zephyr ``stm32g071b_disco`` board target supports the following hardware features:
 
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |

--- a/boards/st/stm32g081b_eval/doc/index.rst
+++ b/boards/st/stm32g081b_eval/doc/index.rst
@@ -100,7 +100,7 @@ More information about STM32G081RB can be found here:
 Supported Features
 ==================
 
-The Zephyr stm32g081b_eval board configuration supports the following hardware features:
+The Zephyr ``stm32g081b_eval`` board target supports the following hardware features:
 
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |

--- a/boards/st/stm32h735g_disco/doc/index.rst
+++ b/boards/st/stm32h735g_disco/doc/index.rst
@@ -41,7 +41,7 @@ More information about STM32H735 can be found here:
 Supported Features
 ==================
 
-The current Zephyr stm32h735g_disco board configuration supports the following hardware features:
+The current Zephyr ``stm32h735g_disco`` board target supports the following hardware features:
 
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |

--- a/boards/st/stm32h750b_dk/doc/index.rst
+++ b/boards/st/stm32h750b_dk/doc/index.rst
@@ -41,7 +41,7 @@ More information about STM32H750 can be found here:
 Supported Features
 ==================
 
-The current Zephyr stm32h750b_dk board configuration supports the following hardware features:
+The current Zephyr ``stm32h750b_dk`` board target supports the following hardware features:
 
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |

--- a/boards/st/stm32h7b3i_dk/doc/index.rst
+++ b/boards/st/stm32h7b3i_dk/doc/index.rst
@@ -101,7 +101,7 @@ More information about STM32H7B3 can be found here:
 Supported Features
 ==================
 
-The current Zephyr stm32h7b3i_dk board configuration supports the following hardware features:
+The current Zephyr ``stm32h7b3i_dk`` board target supports the following hardware features:
 
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |

--- a/boards/st/stm32l476g_disco/doc/index.rst
+++ b/boards/st/stm32l476g_disco/doc/index.rst
@@ -107,7 +107,7 @@ More information about STM32L476VG can be found here:
 Supported Features
 ==================
 
-The Zephyr stm32l476g_disco board configuration supports the following hardware features:
+The Zephyr ``stm32l476g_disco`` board target supports the following hardware features:
 
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |

--- a/boards/st/stm32l496g_disco/doc/index.rst
+++ b/boards/st/stm32l496g_disco/doc/index.rst
@@ -122,7 +122,7 @@ More information about STM32L496AG can be found in:
 Supported Features
 ==================
 
-The Zephyr stm32l496g_disco board configuration supports the following hardware features:
+The Zephyr ``stm32l496g_disco`` board target supports the following hardware features:
 
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |

--- a/boards/st/stm32l4r9i_disco/doc/index.rst
+++ b/boards/st/stm32l4r9i_disco/doc/index.rst
@@ -32,7 +32,7 @@ More information about STM32L4R9 can be found here:
 Supported Features
 ==================
 
-The current Zephyr stm32l4r9i_disco board configuration supports the following hardware features:
+The current Zephyr ``stm32l4r9i_disco`` board target supports the following hardware features:
 
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |

--- a/boards/st/stm32l562e_dk/doc/index.rst
+++ b/boards/st/stm32l562e_dk/doc/index.rst
@@ -146,7 +146,7 @@ More information about STM32L562QE can be found here:
 Supported Features
 ==================
 
-The Zephyr stm32l562e_dk board configuration supports the following
+The Zephyr ``stm32l562e_dk`` board target supports the following
 hardware features:
 
 +-----------+------------+-------------------------------------+

--- a/boards/st/stm32u083c_dk/doc/index.rst
+++ b/boards/st/stm32u083c_dk/doc/index.rst
@@ -151,7 +151,7 @@ More information about STM32U083MC can be found here:
 Supported Features
 ==================
 
-The Zephyr stm32u083c_dk board configuration supports the following hardware features:
+The Zephyr ``stm32u083c_dk`` board target supports the following hardware features:
 
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |

--- a/boards/st/stm32u5a9j_dk/doc/index.rst
+++ b/boards/st/stm32u5a9j_dk/doc/index.rst
@@ -50,7 +50,7 @@ More information about STM32U5A9NJH6Q can be found here:
 Supported Features
 ==================
 
-The current Zephyr stm32u5a9j_dk board configuration supports the following
+The current Zephyr ``stm32u5a9j_dk`` board target supports the following
 hardware features:
 
 +-----------+------------+-------------------------------------+

--- a/boards/st/stm32vl_disco/doc/index.rst
+++ b/boards/st/stm32vl_disco/doc/index.rst
@@ -42,7 +42,7 @@ More information about the STM32F100x can be found in the
 Supported Features
 ==================
 
-The Zephyr stm32vl_disco board configuration supports the following hardware features:
+The Zephyr ``stm32vl_disco`` board target supports the following hardware features:
 
 .. list-table:: Supported hardware
    :header-rows: 1

--- a/boards/vngiotlab/nrf52_vbluno52/doc/index.rst
+++ b/boards/vngiotlab/nrf52_vbluno52/doc/index.rst
@@ -34,7 +34,7 @@ is 64 MHz.
 Supported Features
 ==================
 
-The nrf52_vbluno52 board configuration supports the following
+The ``nrf52_vbluno52`` board target supports the following
 hardware features:
 
 +-----------+------------+----------------------+

--- a/boards/weact/blackpill_f401cc/doc/index.rst
+++ b/boards/weact/blackpill_f401cc/doc/index.rst
@@ -44,7 +44,7 @@ hardware components:
 Supported Features
 ==================
 
-The Zephyr blackpill_f401ce board configuration supports the following
+The Zephyr ``blackpill_f401ce`` board target supports the following
 hardware features:
 
 +------------+------------+-------------------------------------+

--- a/boards/weact/blackpill_f401ce/doc/index.rst
+++ b/boards/weact/blackpill_f401ce/doc/index.rst
@@ -44,7 +44,7 @@ hardware components:
 Supported Features
 ==================
 
-The Zephyr blackpill_f401ce board configuration supports the following
+The Zephyr ``blackpill_f401ce`` board target supports the following
 hardware features:
 
 +------------+------------+-------------------------------------+

--- a/boards/weact/blackpill_f411ce/doc/index.rst
+++ b/boards/weact/blackpill_f411ce/doc/index.rst
@@ -44,7 +44,7 @@ hardware components:
 Supported Features
 ==================
 
-The Zephyr blackpill_f411ce board configuration supports the following
+The Zephyr ``blackpill_f411ce`` board target supports the following
 hardware features:
 
 +------------+------------+-------------------------------------+

--- a/boards/weact/mini_stm32h743/doc/index.rst
+++ b/boards/weact/mini_stm32h743/doc/index.rst
@@ -80,7 +80,7 @@ More information about STM32H743 can be found here:
 Supported Features
 ==================
 
-The mini_stm32h743 board configuration supports the following hardware features:
+The ``mini_stm32h743`` board target supports the following hardware features:
 
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |

--- a/boards/weact/stm32f405_core/doc/index.rst
+++ b/boards/weact/stm32f405_core/doc/index.rst
@@ -52,7 +52,7 @@ hardware components:
 Supported Features
 ==================
 
-The Zephyr weact_stm32f405_core board configuration supports the following
+The Zephyr ``weact_stm32f405_core`` board target supports the following
 hardware features:
 
 +------------+------------+-------------------------------------+

--- a/boards/weact/stm32g431_core/doc/index.rst
+++ b/boards/weact/stm32g431_core/doc/index.rst
@@ -31,7 +31,7 @@ considered reserved for USB-C and not available for other applications.
 Supported Features
 ==================
 
-The Zephyr weact_stm32g431_core board configuration supports the following hardware
+The Zephyr ``weact_stm32g431_core`` board target supports the following hardware
 features:
 
 +------------+------------+-------------------------------------+

--- a/boards/wiznet/w5500_evb_pico/doc/index.rst
+++ b/boards/wiznet/w5500_evb_pico/doc/index.rst
@@ -40,7 +40,7 @@ Hardware
 Supported Features
 ==================
 
-The w5500_evb_pico board configuration supports the following
+The ``w5500_evb_pico`` board target supports the following
 hardware features:
 
 .. list-table::


### PR DESCRIPTION
The goal of this PR is to improve the developer, contributor, and maintainer experience.

- Developers who read the documentation will find more consistent usage of board terminology
- Contributors and maintainers can avoid churn in PR reviews by giving contributors more examples of preferred 'house style' in the documentation.

An incremental improvement in the documentation is taken here, using a scripted approach. It is a non-goal of this PR to modify every board's documentation to conform to a single style.

See #79621

cc: @kartben 

From the commit message:

HWMv2 introduced new terminology about board 'targets'. This terminology is not reflected in the documentation of many of the boards. Update the documentation to match.

N.b. this is a scripted bulk update: it is intended to pick the low-hanging fruit where the same style/format has been replicated across many documentation files. In pseudo-code (truncated and line wrapped to keep this commit message brief) the script is:
```
find . -type f -name "index.rst" -exec sed -E -i \
    '0,/(esp32c3_042_oled|96b_aerocore2|...|xenvm) board configuration \
    supports the following/s//``\1`` board target supports the \
    following/' {} +
```
where `(esp32c3_042_oled|...|xenvm)` is the complete list of boards output from running `west boards` with a little post-processing to give a pipe-delimited list of boards.

Known limitations include, but aren't limited to:

- It is not expected that this will catch the docuementation of every board, but it should be sufficient for the common use-case where a board contains (as far as Zephyr knows) a single SoC, no board revision (or the documentation is applicable to the default and/or all board revisions).
- This is case-sensitive match.
- Some docs simply refer to 'The board'.

References:
- https://docs.zephyrproject.org/latest/hardware/porting/board_porting.html#board-terminology