### PR TITLE
manifest: Update hal_adi to fix build errors for MAX32672

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -137,7 +137,7 @@ manifest:
       groups:
         - fs
     - name: hal_adi
-      revision: de5dadb5322c5da9647363a0d081aa002d4b796f
+      revision: a3eecfde1c76d38312b94fd346c7ba9fe2661992
       path: modules/hal/adi
       groups:
         - hal


### PR DESCRIPTION
Some deprecated inclusions in max32672.h are causing compilation warnings, which are interpreted as errors by twister. Grab relevant fixes from hal_adi.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/79283.