### PR TITLE
tests: secure_storage: update `integration_platforms`

### DIFF
--- a/tests/subsys/secure_storage/psa/crypto/testcase.yaml
+++ b/tests/subsys/secure_storage/psa/crypto/testcase.yaml
@@ -7,8 +7,8 @@ tests:
     extra_args: EXTRA_CONF_FILE=overlay-secure_storage.conf
     integration_platforms:
       - native_sim
-      - nrf9151dk/nrf9151
+      - nrf54l15dk/nrf54l15/cpuapp
   secure_storage.psa.crypto.tfm:
     filter: CONFIG_BUILD_WITH_TFM
     integration_platforms:
-      - nrf5340dk/nrf5340/cpuapp/ns
+      - nrf9151dk/nrf9151/ns

--- a/tests/subsys/secure_storage/psa/its/testcase.yaml
+++ b/tests/subsys/secure_storage/psa/its/testcase.yaml
@@ -12,19 +12,29 @@ tests:
     extra_args: "EXTRA_CONF_FILE=\
       overlay-secure_storage.conf;overlay-default_transform.conf;overlay-default_store.conf"
     integration_platforms:
-      - nrf5340dk/nrf5340/cpuapp
+      - native_sim
+      - nrf54l15dk/nrf54l15/cpuapp
   secure_storage.psa.its.secure_storage.custom.transform:
     filter: CONFIG_SECURE_STORAGE and not CONFIG_SECURE_STORAGE_ITS_STORE_IMPLEMENTATION_NONE
     extra_args: "EXTRA_CONF_FILE=\
       overlay-secure_storage.conf;overlay-custom_transform.conf;overlay-default_store.conf"
+    integration_platforms:
+      - native_sim
+      - nrf54l15dk/nrf54l15/cpuapp
   secure_storage.psa.its.secure_storage.custom.store:
     filter: CONFIG_SECURE_STORAGE
     extra_args: "EXTRA_CONF_FILE=\
       overlay-secure_storage.conf;overlay-default_transform.conf;overlay-custom_store.conf"
+    integration_platforms:
+      - native_sim
+      - nrf54l15dk/nrf54l15/cpuapp
   secure_storage.psa.its.secure_storage.custom.both:
     filter: CONFIG_SECURE_STORAGE
     extra_args: "EXTRA_CONF_FILE=\
       overlay-secure_storage.conf;overlay-custom_transform.conf;overlay-custom_store.conf"
+    integration_platforms:
+      - native_sim
+      - nrf54l15dk/nrf54l15/cpuapp
   secure_storage.psa.its.tfm:
     filter: CONFIG_BUILD_WITH_TFM
     extra_args: EXTRA_CONF_FILE=overlay-tfm.conf


### PR DESCRIPTION
Consistently use the nRF54L15 as the non-TF-M integration platform in addition to `native_sim`, and the nRF9151 as the TF-M one.
In addition, add the `integration_platforms` specification to the tests that were missing it.