### PR TITLE
soc: ti: simplelink: cc13x2x7_cc26x2x7: Enable baremetal ieee802154

### DIFF
--- a/soc/ti/simplelink/cc13x2x7_cc26x2x7/Kconfig
+++ b/soc/ti/simplelink/cc13x2x7_cc26x2x7/Kconfig
@@ -69,3 +69,10 @@ config CC13X2_CC26X2_XOSC_CAPARRAY_DELTA
 	  Enable a specific cap array tunning delta.
 
 endmenu
+
+config CC13X2_CC26X2_BASIC_IEEE802154
+	bool "Baremetal ieee802154 support"
+	depends on SOC_CC1352P7
+	help
+	  Enable IEEE802154 support for the CC13X2 and CC26X2 series of MCUs
+	  using the TI driverlib without the Zephyr or TI IEEE802154 stack.

--- a/soc/ti/simplelink/cc13x2x7_cc26x2x7/Kconfig.defconfig
+++ b/soc/ti/simplelink/cc13x2x7_cc26x2x7/Kconfig.defconfig
@@ -16,7 +16,7 @@ config SYS_CLOCK_TICKS_PER_SEC
 config NUM_IRQS
 	default 38
 
-if IEEE802154
+if IEEE802154 || CONFIG_CC13X2_CC26X2_BASIC_IEEE802154
 
 config IEEE802154_CC13XX_CC26XX
 	# required for linking with PowerCC26X2_config in


### PR DESCRIPTION
- Allow using baremetal ieee802154 APIs without the Zephyr ieee802154 stack.
- Enables customers to create their own networking stack on top of Zephyr and thus allow easier porting from FreeRTOS and TiRTOS.
- Basically, forcefully enable the variables that include the appropriate code in HAL.