### PR TITLE
Bluetooth: Tester: Added release parameter to CAP stop cmd

### DIFF
--- a/tests/bluetooth/tester/src/audio/btp/btp_cap.h
+++ b/tests/bluetooth/tester/src/audio/btp/btp_cap.h
@@ -60,7 +60,9 @@ struct btp_cap_unicast_audio_update_data {
 #define BTP_CAP_UNICAST_AUDIO_STOP		0x06
 struct btp_cap_unicast_audio_stop_cmd {
 	uint8_t cig_id;
+	uint8_t flags;
 } __packed;
+#define BTP_CAP_UNICAST_AUDIO_STOP_FLAG_RELEASE BIT(0)
 
 #define BTP_CAP_BROADCAST_SOURCE_SETUP_STREAM	0x07
 struct btp_cap_broadcast_source_setup_stream_cmd {

--- a/tests/bluetooth/tester/src/audio/btp_cap.c
+++ b/tests/bluetooth/tester/src/audio/btp_cap.c
@@ -438,7 +438,7 @@ static uint8_t btp_cap_unicast_audio_stop(const void *cmd, uint16_t cmd_len,
 	param.streams = streams;
 	param.count = stream_cnt;
 	param.type = BT_CAP_SET_TYPE_AD_HOC;
-	param.release = true;
+	param.release = (cp->flags & BTP_CAP_UNICAST_AUDIO_STOP_FLAG_RELEASE) != 0;
 
 	err = bt_cap_initiator_unicast_audio_stop(&param);
 	if (err != 0) {


### PR DESCRIPTION
Added a boolean "release" parameter so that it is possible to use the bt_cap_initiator_unicast_audio_stop to perform disable+stop without releasing the streams.

This requires https://github.com/auto-pts/auto-pts/pull/1271