### PR TITLE
west: promote config_get*() functions from sign.py to the base class

### DIFF
--- a/scripts/west_commands/zephyr_ext_common.py
+++ b/scripts/west_commands/zephyr_ext_common.py
@@ -9,6 +9,7 @@ commands are in run_common -- that's for common code used by
 commands which specifically execute runners.'''
 
 import os
+import shlex
 from pathlib import Path
 
 from west import log
@@ -45,3 +46,16 @@ class Forceable(WestCommand):
         if not (cond or self.args.force):
             log.err(msg)
             log.die('refusing to proceed without --force due to above error')
+
+    def config_get_words(self, section_key, fallback=None):
+        unparsed = self.config.get(section_key)
+        self.dbg(f'west config {section_key}={unparsed}')
+        return fallback if unparsed is None else shlex.split(unparsed)
+
+    def config_get(self, section_key, fallback=None):
+        words = self.config_get_words(section_key)
+        if words is None:
+            return fallback
+        if len(words) != 1:
+            self.die(f'Single word expected for: {section_key}={words}. Use quotes?')
+        return words[0]


### PR DESCRIPTION
These two functions have stood the test of the time and they have absolutely nothing specific to sign.py

This has the benefit of transitioning away from west's global and deprecated logging interface
(https://github.com/zephyrproject-rtos/west/issues/149) and this deprecation is what prompted this commit: see #79240.