### PR TITLE
kernel: Apply 'unlikely' attribute

### DIFF
--- a/kernel/condvar.c
+++ b/kernel/condvar.c
@@ -49,7 +49,7 @@ int z_impl_k_condvar_signal(struct k_condvar *condvar)
 
 	struct k_thread *thread = z_unpend_first_thread(&condvar->wait_q);
 
-	if (thread != NULL) {
+	if (unlikely(thread != NULL)) {
 		SYS_PORT_TRACING_OBJ_FUNC_BLOCKING(k_condvar, signal, condvar, K_FOREVER);
 
 		arch_thread_return_value_set(thread, 0);

--- a/kernel/mem_slab.c
+++ b/kernel/mem_slab.c
@@ -275,7 +275,7 @@ void k_mem_slab_free(struct k_mem_slab *slab, void *mem)
 	if ((slab->free_list == NULL) && IS_ENABLED(CONFIG_MULTITHREADING)) {
 		struct k_thread *pending_thread = z_unpend_first_thread(&slab->wait_q);
 
-		if (pending_thread != NULL) {
+		if (unlikely(pending_thread != NULL)) {
 			SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_mem_slab, free, slab);
 
 			z_thread_return_value_set_with_data(pending_thread, 0, mem);

--- a/kernel/msg_q.c
+++ b/kernel/msg_q.c
@@ -136,7 +136,7 @@ int z_impl_k_msgq_put(struct k_msgq *msgq, const void *data, k_timeout_t timeout
 	if (msgq->used_msgs < msgq->max_msgs) {
 		/* message queue isn't full */
 		pending_thread = z_unpend_first_thread(&msgq->wait_q);
-		if (pending_thread != NULL) {
+		if (unlikely(pending_thread != NULL)) {
 			SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_msgq, put, msgq, timeout, 0);
 
 			/* give message to waiting thread */
@@ -236,7 +236,7 @@ int z_impl_k_msgq_get(struct k_msgq *msgq, void *data, k_timeout_t timeout)
 
 		/* handle first thread waiting to write (if any) */
 		pending_thread = z_unpend_first_thread(&msgq->wait_q);
-		if (pending_thread != NULL) {
+		if (unlikely(pending_thread != NULL)) {
 			SYS_PORT_TRACING_OBJ_FUNC_BLOCKING(k_msgq, get, msgq, timeout);
 
 			/* add thread's message to queue */

--- a/kernel/mutex.c
+++ b/kernel/mutex.c
@@ -261,7 +261,7 @@ int z_impl_k_mutex_unlock(struct k_mutex *mutex)
 	LOG_DBG("new owner of mutex %p: %p (prio: %d)",
 		mutex, new_owner, new_owner ? new_owner->base.prio : -1000);
 
-	if (new_owner != NULL) {
+	if (unlikely(new_owner != NULL)) {
 		/*
 		 * new owner is already of higher or equal prio than first
 		 * waiter since the wait queue is priority-based: no need to

--- a/kernel/queue.c
+++ b/kernel/queue.c
@@ -133,7 +133,7 @@ static int32_t queue_insert(struct k_queue *queue, void *prev, void *data,
 	}
 	first_pending_thread = z_unpend_first_thread(&queue->wait_q);
 
-	if (first_pending_thread != NULL) {
+	if (unlikely(first_pending_thread != NULL)) {
 		SYS_PORT_TRACING_OBJ_FUNC_BLOCKING(k_queue, queue_insert, queue, alloc, K_FOREVER);
 
 		prepare_thread_to_run(first_pending_thread, data);

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -718,7 +718,7 @@ struct k_thread *z_unpend_first_thread(_wait_q_t *wait_q)
 	K_SPINLOCK(&_sched_spinlock) {
 		thread = _priq_wait_best(&wait_q->waitq);
 
-		if (thread != NULL) {
+		if (unlikely(thread != NULL)) {
 			unpend_thread_no_timeout(thread);
 			(void)z_abort_thread_timeout(thread);
 		}

--- a/kernel/sem.c
+++ b/kernel/sem.c
@@ -103,7 +103,7 @@ void z_impl_k_sem_give(struct k_sem *sem)
 
 	thread = z_unpend_first_thread(&sem->wait_q);
 
-	if (thread != NULL) {
+	if (unlikely(thread != NULL)) {
 		arch_thread_return_value_set(thread, 0);
 		z_ready_thread(thread);
 	} else {
@@ -111,7 +111,7 @@ void z_impl_k_sem_give(struct k_sem *sem)
 		resched = handle_poll_events(sem);
 	}
 
-	if (resched) {
+	if (unlikely(resched)) {
 		z_reschedule(&lock, key);
 	} else {
 		k_spin_unlock(&lock, key);

--- a/kernel/stack.c
+++ b/kernel/stack.c
@@ -113,7 +113,7 @@ int z_impl_k_stack_push(struct k_stack *stack, stack_data_t data)
 
 	first_pending_thread = z_unpend_first_thread(&stack->wait_q);
 
-	if (first_pending_thread != NULL) {
+	if (unlikely(first_pending_thread != NULL)) {
 		z_thread_return_value_set_with_data(first_pending_thread,
 						   0, (void *)data);
 


### PR DESCRIPTION
Applies the 'unlikely' attribute to various kernel objects that use z_unpend_first_thread() to optimize for the non-blocking path.

This boosts the thread_metric synchronization benchmark numbers on the frdm_k64f board by about 10%.