### PR TITLE
drivers: ethernet: enc28j60: Fix carrier on race on init

### DIFF
--- a/drivers/ethernet/eth_enc28j60_priv.h
+++ b/drivers/ethernet/eth_enc28j60_priv.h
@@ -240,6 +240,7 @@ struct eth_enc28j60_runtime {
 	struct k_sem tx_rx_sem;
 	struct k_sem int_sem;
 	bool iface_initialized : 1;
+	bool iface_carrier_on_init : 1;
 };
 
 #endif /*_ENC28J60_*/


### PR DESCRIPTION
If there is a carrier (cable plugged in) on device initialisation there is a race between the interrupt service and the L2 init. This caused a segfault on startup.
Tested with ESP32C3.