### PR TITLE
modules: tfm: interface: handle ISR context

### DIFF
--- a/modules/trusted-firmware-m/interface/interface.c
+++ b/modules/trusted-firmware-m/interface/interface.c
@@ -28,11 +28,11 @@ int32_t tfm_ns_interface_dispatch(veneer_fn fn,
 				  uint32_t arg0, uint32_t arg1,
 				  uint32_t arg2, uint32_t arg3)
 {
-	int32_t result;
-	bool is_pre_kernel = k_is_pre_kernel();
+	bool isr_mode = k_is_in_isr() || k_is_pre_kernel();
 	int tfm_ns_saved_prio;
+	int32_t result;
 
-	if (!is_pre_kernel) {
+	if (!isr_mode) {
 		/* TF-M request protected by NS lock */
 		if (k_mutex_lock(&tfm_mutex, K_FOREVER) != 0) {
 			return (int32_t)PSA_ERROR_GENERIC_ERROR;
@@ -61,7 +61,7 @@ int32_t tfm_ns_interface_dispatch(veneer_fn fn,
 
 	z_arm_restore_fp_context(&context_buffer);
 
-	if (!is_pre_kernel) {
+	if (!isr_mode) {
 #if !defined(CONFIG_ARM_NONSECURE_PREEMPTIBLE_SECURE_CALLS)
 		/* Restore thread priority, to allow the thread to be preempted. */
 		k_thread_priority_set(k_current_get(), tfm_ns_saved_prio);


### PR DESCRIPTION
Don't attempt to take a mutex if operating from inside an ISR. The only expected use-case where this should occur is when attempting to reboot via `tfm_platform_system_reset` from an exception handler.

Fixes #79687

Fixes #77778 