### PR TITLE
tests: zbus: fix ci by excluding m2gl025_miv board

### DIFF
--- a/tests/subsys/zbus/integration/testcase.yaml
+++ b/tests/subsys/zbus/integration/testcase.yaml
@@ -1,6 +1,7 @@
 tests:
   message_bus.zbus.module_interaction_no_error:
     platform_exclude:
+      - m2gl025_miv
       - qemu_cortex_a9
       - hifive_unleashed
       - fvp_base_revc_2xaemv8a//smp/ns


### PR DESCRIPTION
The `m2gl025_miv` is breaking the ci during the zbus integration tests. To solve that in a meanwhile, this commit excludes the board from the zbus integration tests.