### PR TITLE
ITE: it8xxx2: Remove CONFIG_PINCTRL from soc defconfig file

### DIFF
--- a/drivers/adc/Kconfig.it8xxx2
+++ b/drivers/adc/Kconfig.it8xxx2
@@ -7,6 +7,7 @@ config ADC_ITE_IT8XXX2
 	bool "ITE IT8XXX2 ADC driver"
 	default y
 	depends on DT_HAS_ITE_IT8XXX2_ADC_ENABLED
+	select PINCTRL
 	help
 	  This option enables the ADC driver for IT8XXX2
 	  family of processors.

--- a/drivers/i2c/Kconfig.it8xxx2
+++ b/drivers/i2c/Kconfig.it8xxx2
@@ -5,6 +5,7 @@ config I2C_ITE_IT8XXX2
 	bool "ITE IT8XXX2 I2C driver"
 	default y
 	depends on DT_HAS_ITE_IT8XXX2_I2C_ENABLED
+	select PINCTRL
 	help
 	  Enable I2C support on it8xxx2_evb.
 	  Supported Speeds: 100kHz, 400kHz and 1MHz.
@@ -30,6 +31,7 @@ config I2C_ITE_ENHANCE
 	bool "ITE IT8XXX2 I2C enhance driver"
 	default y
 	depends on DT_HAS_ITE_ENHANCE_I2C_ENABLED
+	select PINCTRL
 	help
 	  This option can enable the enhance I2C
 	  of IT8XXX2 and support three channels.

--- a/drivers/input/Kconfig.it8xxx2
+++ b/drivers/input/Kconfig.it8xxx2
@@ -6,5 +6,6 @@ config INPUT_ITE_IT8XXX2_KBD
 	default y
 	depends on DT_HAS_ITE_IT8XXX2_KBD_ENABLED
 	select INPUT_KBD_MATRIX
+	select PINCTRL
 	help
 	  This option enables the ITE keyboard scan driver.

--- a/drivers/peci/Kconfig.it8xxx2
+++ b/drivers/peci/Kconfig.it8xxx2
@@ -8,5 +8,6 @@ config PECI_ITE_IT8XXX2
 	default y
 	depends on DT_HAS_ITE_IT8XXX2_PECI_ENABLED
 	select PECI_INTERRUPT_DRIVEN
+	select PINCTRL
 	help
 	  Enable the ITE IT8XXX2 PECI IO driver.

--- a/drivers/pwm/Kconfig.it8xxx2
+++ b/drivers/pwm/Kconfig.it8xxx2
@@ -7,6 +7,7 @@ config PWM_ITE_IT8XXX2
 	bool "ITE IT8XXX2 embedded controller (EC) PWM driver"
 	default y
 	depends on DT_HAS_ITE_IT8XXX2_PWM_ENABLED
+	select PINCTRL
 	help
 	   Enable PWM driver for it8xxx2_evb.
 	   Supports three 16-bit prescalers each with 8-bit cycle timer, and

--- a/drivers/sensor/ite/ite_tach_it8xxx2/Kconfig
+++ b/drivers/sensor/ite/ite_tach_it8xxx2/Kconfig
@@ -8,6 +8,7 @@ config TACH_IT8XXX2
 	default y
 	depends on DT_HAS_ITE_IT8XXX2_TACH_ENABLED
 	depends on SOC_IT8XXX2
+	select PINCTRL
 	help
 	  Enable the ITE it8xxx2 tachometer sensor,
 	  it8xxx2 supports two 16-bit tachometer sensor, each sensor has two

--- a/drivers/serial/Kconfig.it8xxx2
+++ b/drivers/serial/Kconfig.it8xxx2
@@ -6,6 +6,7 @@ config UART_ITE_IT8XXX2
 	default y
 	select UART_NS16550_ITE_HIGH_SPEED_BAUDRATE
 	depends on DT_HAS_ITE_IT8XXX2_UART_ENABLED
+	select PINCTRL
 	help
 	  IT8XXX2 uses shared ns16550.c driver which does not
 	  provide a power management callback, so create driver

--- a/drivers/usb/device/Kconfig
+++ b/drivers/usb/device/Kconfig
@@ -193,6 +193,7 @@ config USB_DC_IT82XX2
 	bool "ITE IT82XX2 USB Device Controller Driver"
 	default y
 	depends on DT_HAS_ITE_IT82XX2_USB_ENABLED
+	select PINCTRL
 	help
 	  ITE IT82XX2 USB Device Controller Driver
 

--- a/drivers/usb/udc/Kconfig.it82xx2
+++ b/drivers/usb/udc/Kconfig.it82xx2
@@ -5,6 +5,7 @@ config UDC_IT82XX2
 	bool "IT82XX2 USB device controller driver"
 	default y
 	depends on DT_HAS_ITE_IT82XX2_USB_ENABLED
+	select PINCTRL
 	help
 	  IT82xx2 USB device controller driver.
 

--- a/soc/ite/ec/it8xxx2/Kconfig.defconfig.series
+++ b/soc/ite/ec/it8xxx2/Kconfig.defconfig.series
@@ -30,9 +30,6 @@ config IT8XXX2_PLL_SEQUENCE_PRIORITY
 config VCMP_IT8XXX2_INIT_PRIORITY
 	default 91 if VCMP_IT8XXX2_WORKQUEUE
 
-config PINCTRL
-	default y
-
 config NUM_IRQS
 	default 185
 

--- a/subsys/mgmt/ec_host_cmd/backends/Kconfig
+++ b/subsys/mgmt/ec_host_cmd/backends/Kconfig
@@ -62,6 +62,7 @@ config EC_HOST_CMD_BACKEND_SHI_NPCX
 config EC_HOST_CMD_BACKEND_SHI_ITE
 	bool "SHI by ITE"
 	depends on DT_HAS_ITE_IT8XXX2_SHI_ENABLED
+	select PINCTRL
 	help
 	  This option enables the driver for SHI backend in the
 	  ITE IT8xxx2 chips family.


### PR DESCRIPTION
The driver Kconfig determines whether pinctrl is enabled instead of soc defconfig.

Partial work for #78619