### PR TITLE
maintainers: move arnopo from maintainer to collaborator of IPC

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -2378,9 +2378,9 @@ IPC:
   status: maintained
   maintainers:
     - doki-nordic
-    - arnopo
   collaborators:
     - carlocaione
+    - arnopo
   files:
     - include/zephyr/ipc/
     - samples/subsys/ipc/


### PR DESCRIPTION
Move myself from maintainer to collaborator.
I am not active enough on Zephyr to take on the role of maintainer.

Of course fill free to ping me for review on OpenAMP topics or sepcific PR  requiring  more reviews.