### PR TITLE
sysbuild: images: bootloader: kconfig: Limit encryption

### DIFF
--- a/share/sysbuild/images/bootloader/Kconfig
+++ b/share/sysbuild/images/bootloader/Kconfig
@@ -148,9 +148,13 @@ config BOOT_SIGNATURE_KEY_FILE
 	help
 	  Absolute path to signing key file to use with MCUBoot.
 
+config SUPPORT_BOOT_ENCRYPTION
+	bool
+	depends on !BOOT_SIGNATURE_TYPE_NONE && !MCUBOOT_MODE_DIRECT_XIP && !MCUBOOT_MODE_DIRECT_XIP_WITH_REVERT && !MCUBOOT_MODE_FIRMWARE_UPDATER
+
 config BOOT_ENCRYPTION
 	bool "Encrypted image support"
-	depends on !BOOT_SIGNATURE_TYPE_NONE
+	depends on SUPPORT_BOOT_ENCRYPTION
 	help
 	  Support encrypted images.
 


### PR DESCRIPTION
Limits selecting the encryption option to MCUboot operating modes that support it