### PR TITLE
drivers: sensor: adxl362: Updated ADXL362 driver with RTIO stream functionality

### DIFF
--- a/drivers/sensor/adi/adxl362/CMakeLists.txt
+++ b/drivers/sensor/adi/adxl362/CMakeLists.txt
@@ -4,3 +4,5 @@ zephyr_library()
 
 zephyr_library_sources(adxl362.c)
 zephyr_library_sources_ifdef(CONFIG_ADXL362_TRIGGER adxl362_trigger.c)
+zephyr_library_sources_ifdef(CONFIG_SENSOR_ASYNC_API adxl362_rtio.c adxl362_decoder.c)
+zephyr_library_sources_ifdef(CONFIG_ADXL362_STREAM adxl362_stream.c adxl362_decoder.c)

--- a/drivers/sensor/adi/adxl362/Kconfig
+++ b/drivers/sensor/adi/adxl362/Kconfig
@@ -8,6 +8,7 @@ menuconfig ADXL362
 	default y
 	depends on DT_HAS_ADI_ADXL362_ENABLED
 	select SPI
+	select RTIO_WORKQ if SENSOR_ASYNC_API
 	help
 	  Enable driver for ADXL362 Three-Axis Digital Accelerometers.
 
@@ -78,6 +79,15 @@ config ADXL362_TRIGGER_OWN_THREAD
 	select ADXL362_TRIGGER
 
 endchoice
+
+config ADXL362_STREAM
+	bool "Use FIFO to stream data"
+	select ADXL362_TRIGGER
+	default y
+	depends on SPI_RTIO
+	depends on SENSOR_ASYNC_API
+	help
+	  Use this configuration option to enable streaming sensor data via RTIO.
 
 config ADXL362_TRIGGER
 	bool

--- a/drivers/sensor/adi/adxl362/adxl362_decoder.c
+++ b/drivers/sensor/adi/adxl362/adxl362_decoder.c
@@ -1,0 +1,356 @@
+/*
+ * Copyright (c) 2024 Analog Devices Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "adxl362.h"
+#include <zephyr/sys/byteorder.h>
+
+#ifdef CONFIG_ADXL362_STREAM
+
+#define ADXL362_COMPLEMENT         0xf000
+
+static const uint32_t accel_period_ns[] = {
+	[ADXL362_ODR_12_5_HZ] = UINT32_C(10000000000) / 125,
+	[ADXL362_ODR_25_HZ] = UINT32_C(1000000000) / 25,
+	[ADXL362_ODR_50_HZ] = UINT32_C(1000000000) / 50,
+	[ADXL362_ODR_100_HZ] = UINT32_C(1000000000) / 100,
+	[ADXL362_ODR_200_HZ] = UINT32_C(1000000000) / 200,
+	[ADXL362_ODR_400_HZ] = UINT32_C(1000000000) / 400,
+};
+
+static const int32_t range_to_scale[] = {
+	/* See table 1 in specifications section of datasheet */
+	[ADXL362_RANGE_2G] = ADXL362_ACCEL_2G_LSB_PER_G,
+	[ADXL362_RANGE_4G] = ADXL362_ACCEL_4G_LSB_PER_G,
+	[ADXL362_RANGE_8G] = ADXL362_ACCEL_8G_LSB_PER_G,
+};
+
+static inline void adxl362_temp_convert_q31(q31_t *out, int16_t data_in)
+{
+/* See sensitivity and bias specifications in table 1 of datasheet */
+	data_in &= 0xFFF;
+
+	if (data_in & BIT(11)) {
+		data_in |= ADXL362_COMPLEMENT;
+	}
+
+	int64_t milli_c = (data_in - ADXL362_TEMP_BIAS_LSB) * ADXL362_TEMP_MC_PER_LSB +
+		      (ADXL362_TEMP_BIAS_TEST_CONDITION * 1000);
+
+	*out = CLAMP(((milli_c * 1000) + ((milli_c % 1000) * 1000)), INT32_MIN, INT32_MAX);
+}
+
+static inline void adxl362_accel_convert_q31(q31_t *out, int16_t data_in, int32_t range)
+{
+	data_in &= 0xFFF;
+
+	if (data_in & BIT(11)) {
+		data_in |= ADXL362_COMPLEMENT;
+	}
+
+	int64_t micro_ms2 = data_in * SENSOR_G / range_to_scale[range];
+
+	*out = CLAMP((micro_ms2 + (micro_ms2 % 1000000)), INT32_MIN, INT32_MAX);
+}
+
+static int adxl362_decode_stream(const uint8_t *buffer, struct sensor_chan_spec chan_spec,
+				uint32_t *fit, uint16_t max_count, void *data_out)
+{
+	const struct adxl362_fifo_data *enc_data = (const struct adxl362_fifo_data *)buffer;
+	const uint8_t *buffer_end =
+			buffer + sizeof(struct adxl362_fifo_data) + enc_data->fifo_byte_count;
+	int count = 0;
+	uint8_t sample_num = 0;
+	int16_t data_in;
+
+	if ((uintptr_t)buffer_end <= *fit || chan_spec.chan_idx != 0) {
+		return 0;
+	}
+
+	buffer += sizeof(struct adxl362_fifo_data);
+
+	uint8_t sample_set_size = 6;
+
+	if (enc_data->has_tmp) {
+		sample_set_size = 8;
+	}
+
+	uint64_t period_ns = accel_period_ns[enc_data->accel_odr];
+
+	/* Calculate which sample is decoded. */
+	if ((uint8_t *)*fit >= buffer) {
+		sample_num = ((uint8_t *)*fit - buffer) / sample_set_size;
+	}
+
+	while (count < max_count && buffer < buffer_end) {
+		const uint8_t *sample_end = buffer;
+
+		sample_end += sample_set_size;
+
+		if ((uintptr_t)buffer < *fit) {
+			/* This frame was already decoded, move on to the next frame */
+			buffer = sample_end;
+			continue;
+		}
+
+		if (chan_spec.chan_type == SENSOR_CHAN_DIE_TEMP) {
+			if (enc_data->has_tmp) {
+				struct sensor_q31_data *data = (struct sensor_q31_data *)data_out;
+
+				memset(data, 0, sizeof(struct sensor_three_axis_data));
+				data->header.base_timestamp_ns = enc_data->timestamp;
+				data->header.reading_count = 1;
+
+				data->readings[count].timestamp_delta =
+						period_ns * sample_num;
+
+				data_in = sys_le16_to_cpu(*((int16_t *)(buffer + 6)));
+
+				/* Check if this sample contains temperature value. */
+				if (ADXL362_FIFO_HDR_CHECK_TEMP(data_in)) {
+					adxl362_temp_convert_q31(&data->readings[count].temperature,
+										data_in);
+				}
+			}
+		} else {
+			struct sensor_three_axis_data *data =
+					(struct sensor_three_axis_data *)data_out;
+
+			memset(data, 0, sizeof(struct sensor_three_axis_data));
+			data->header.base_timestamp_ns = enc_data->timestamp;
+			data->header.reading_count = 1;
+
+			switch (chan_spec.chan_type) {
+			case SENSOR_CHAN_ACCEL_X:
+				data->readings[count].timestamp_delta = sample_num
+					* period_ns;
+
+				/* Convert received data into signeg integer. */
+				data_in = sys_le16_to_cpu(*((int16_t *)buffer));
+
+				/* Check if this sample contains X value. */
+				if (ADXL362_FIFO_HDR_CHECK_ACCEL_X(data_in)) {
+					adxl362_accel_convert_q31(&data->readings[count].x,
+						data_in, enc_data->selected_range);
+				}
+				break;
+			case SENSOR_CHAN_ACCEL_Y:
+				data->readings[count].timestamp_delta = sample_num
+					* period_ns;
+
+				/* Convert received data into signeg integer. */
+				data_in = sys_le16_to_cpu(*((int16_t *)(buffer + 2)));
+
+				/* Check if this sample contains Y value. */
+				if (ADXL362_FIFO_HDR_CHECK_ACCEL_Y(data_in)) {
+					adxl362_accel_convert_q31(&data->readings[count].y,
+							data_in, enc_data->selected_range);
+				}
+				break;
+			case SENSOR_CHAN_ACCEL_Z:
+				data->readings[count].timestamp_delta = sample_num
+					* period_ns;
+				/* Convert received data into signeg integer. */
+				data_in = sys_le16_to_cpu(*((int16_t *)(buffer + 4)));
+
+				/* Check if this sample contains Y value. */
+				if (ADXL362_FIFO_HDR_CHECK_ACCEL_Z(data_in)) {
+					adxl362_accel_convert_q31(&data->readings[count].z,
+							data_in, enc_data->selected_range);
+				}
+				break;
+			case SENSOR_CHAN_ACCEL_XYZ:
+				data->readings[count].timestamp_delta = sample_num * period_ns;
+
+				/* Convert received data into signeg integer. */
+				data_in = sys_le16_to_cpu(*((int16_t *)buffer));
+
+				/* Check if this sample contains X value. */
+				if (ADXL362_FIFO_HDR_CHECK_ACCEL_X(data_in)) {
+					adxl362_accel_convert_q31(&data->readings[count].x,
+							data_in, enc_data->selected_range);
+				}
+
+				/* Convert received data into signeg integer. */
+				data_in = sys_le16_to_cpu(*((int16_t *)(buffer + 2)));
+
+				/* Check if this sample contains Y value. */
+				if (ADXL362_FIFO_HDR_CHECK_ACCEL_Y(data_in)) {
+					adxl362_accel_convert_q31(&data->readings[count].y,
+								data_in, enc_data->selected_range);
+				}
+
+				/* Convert received data into signeg integer. */
+				data_in = sys_le16_to_cpu(*((int16_t *)(buffer + 4)));
+
+				/* Check if this sample contains Z value. */
+				if (ADXL362_FIFO_HDR_CHECK_ACCEL_Z(data_in)) {
+					adxl362_accel_convert_q31(&data->readings[count].z,
+								data_in, enc_data->selected_range);
+				}
+				break;
+			default:
+				return -ENOTSUP;
+			}
+		}
+
+		buffer = sample_end;
+		*fit = (uintptr_t)sample_end;
+		count++;
+	}
+	return count;
+}
+
+#endif /* CONFIG_ADXL362_STREAM */
+
+static int adxl362_decoder_get_frame_count(const uint8_t *buffer,
+					     struct sensor_chan_spec chan_spec,
+					     uint16_t *frame_count)
+{
+	int32_t ret = -ENOTSUP;
+
+	if (chan_spec.chan_idx != 0) {
+		return ret;
+	}
+
+#ifdef CONFIG_ADXL362_STREAM
+	const struct adxl362_fifo_data *data = (const struct adxl362_fifo_data *)buffer;
+
+	if (!data->is_fifo) {
+#endif /* CONFIG_ADXL362_STREAM */
+		switch (chan_spec.chan_type) {
+		case SENSOR_CHAN_ACCEL_X:
+		case SENSOR_CHAN_ACCEL_Y:
+		case SENSOR_CHAN_ACCEL_Z:
+		case SENSOR_CHAN_ACCEL_XYZ:
+			*frame_count = 1;
+			ret = 0;
+			break;
+
+		default:
+			break;
+		}
+#ifdef CONFIG_ADXL362_STREAM
+	} else {
+		if (data->fifo_byte_count == 0)	{
+			*frame_count = 0;
+			ret = 0;
+		} else {
+			switch (chan_spec.chan_type) {
+			case SENSOR_CHAN_ACCEL_X:
+			case SENSOR_CHAN_ACCEL_Y:
+			case SENSOR_CHAN_ACCEL_Z:
+			case SENSOR_CHAN_ACCEL_XYZ:
+				if (data->has_tmp) {
+					/*6 bytes for XYZ and 2 bytes for TEMP*/
+					*frame_count = data->fifo_byte_count / 8;
+					ret = 0;
+				} else {
+					*frame_count = data->fifo_byte_count / 6;
+					ret = 0;
+				}
+				break;
+
+			case SENSOR_CHAN_DIE_TEMP:
+				if (data->has_tmp) {
+					/*6 bytes for XYZ and 2 bytes for TEMP*/
+					*frame_count = data->fifo_byte_count / 8;
+					ret = 0;
+				}
+				break;
+
+			default:
+				break;
+			}
+		}
+	}
+#endif /* CONFIG_ADXL362_STREAM */
+
+	return ret;
+}
+
+static int adxl362_decode_sample(const struct adxl362_sample_data *data,
+	struct sensor_chan_spec chan_spec, uint32_t *fit, uint16_t max_count, void *data_out)
+{
+	struct sensor_value *out = (struct sensor_value *) data_out;
+
+	if (*fit > 0) {
+		return -ENOTSUP;
+	}
+
+	switch (chan_spec.chan_type) {
+	case SENSOR_CHAN_ACCEL_X: /* Acceleration on the X axis, in m/s^2. */
+		adxl362_accel_convert(out, data->acc_x, data->selected_range);
+		break;
+	case SENSOR_CHAN_ACCEL_Y: /* Acceleration on the Y axis, in m/s^2. */
+		adxl362_accel_convert(out, data->acc_y, data->selected_range);
+		break;
+	case SENSOR_CHAN_ACCEL_Z: /* Acceleration on the Z axis, in m/s^2. */
+		adxl362_accel_convert(out, data->acc_z,  data->selected_range);
+		break;
+	case SENSOR_CHAN_ACCEL_XYZ: /* Acceleration on the XYZ axis, in m/s^2. */
+		adxl362_accel_convert(out++, data->acc_x, data->selected_range);
+		adxl362_accel_convert(out++, data->acc_y, data->selected_range);
+		adxl362_accel_convert(out, data->acc_z,  data->selected_range);
+		break;
+	case SENSOR_CHAN_DIE_TEMP: /* Temperature in degrees Celsius. */
+		adxl362_temp_convert(out, data->temp);
+		break;
+	default:
+		return -ENOTSUP;
+	}
+
+	*fit = 1;
+
+	return 0;
+}
+
+static int adxl362_decoder_decode(const uint8_t *buffer, struct sensor_chan_spec chan_spec,
+				    uint32_t *fit, uint16_t max_count, void *data_out)
+{
+	const struct adxl362_sample_data *data = (const struct adxl362_sample_data *)buffer;
+
+#ifdef CONFIG_ADXL362_STREAM
+	if (data->is_fifo) {
+		return adxl362_decode_stream(buffer, chan_spec, fit, max_count, data_out);
+	}
+#endif /* CONFIG_ADXL362_STREAM */
+
+	return adxl362_decode_sample(data, chan_spec, fit, max_count, data_out);
+}
+
+static bool adxl362_decoder_has_trigger(const uint8_t *buffer, enum sensor_trigger_type trigger)
+{
+	const struct adxl362_fifo_data *data = (const struct adxl362_fifo_data *)buffer;
+
+	if (!data->is_fifo) {
+		return false;
+	}
+
+	switch (trigger) {
+	case SENSOR_TRIG_DATA_READY:
+		return ADXL362_STATUS_CHECK_DATA_READY(data->int_status);
+	case SENSOR_TRIG_FIFO_WATERMARK:
+		return ADXL362_STATUS_CHECK_FIFO_WTR(data->int_status);
+	case SENSOR_TRIG_FIFO_FULL:
+		return ADXL362_STATUS_CHECK_FIFO_OVR(data->int_status);
+	default:
+		return false;
+	}
+}
+
+SENSOR_DECODER_API_DT_DEFINE() = {
+	.get_frame_count = adxl362_decoder_get_frame_count,
+	.decode = adxl362_decoder_decode,
+	.has_trigger = adxl362_decoder_has_trigger,
+};
+
+int adxl362_get_decoder(const struct device *dev, const struct sensor_decoder_api **decoder)
+{
+	ARG_UNUSED(dev);
+	*decoder = &SENSOR_DECODER_NAME();
+
+	return 0;
+}

--- a/drivers/sensor/adi/adxl362/adxl362_rtio.c
+++ b/drivers/sensor/adi/adxl362/adxl362_rtio.c
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2024 Analog Devices Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/rtio/work.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/drivers/sensor.h>
+
+#include "adxl362.h"
+
+LOG_MODULE_DECLARE(ADXL362, CONFIG_SENSOR_LOG_LEVEL);
+
+static void adxl362_submit_fetch(struct rtio_iodev_sqe *iodev_sqe)
+{
+	const struct sensor_read_config *cfg =
+			(const struct sensor_read_config *) iodev_sqe->sqe.iodev->data;
+	const struct device *dev = cfg->sensor;
+	int rc;
+	uint32_t min_buffer_len = sizeof(struct adxl362_sample_data);
+	uint8_t *buffer;
+	uint32_t buffer_len;
+
+	rc = rtio_sqe_rx_buf(iodev_sqe, min_buffer_len, min_buffer_len, &buffer, &buffer_len);
+	if (rc != 0) {
+		LOG_ERR("Failed to get a read buffer of size %u bytes", min_buffer_len);
+		rtio_iodev_sqe_err(iodev_sqe, rc);
+		return;
+	}
+
+	struct adxl362_sample_data *data = (struct adxl362_sample_data *)buffer;
+
+	rc = adxl362_rtio_fetch(dev, data);
+	if (rc != 0) {
+		LOG_ERR("Failed to fetch samples");
+		rtio_iodev_sqe_err(iodev_sqe, rc);
+		return;
+	}
+
+	rtio_iodev_sqe_ok(iodev_sqe, 0);
+}
+
+void adxl362_submit(const struct device *dev, struct rtio_iodev_sqe *iodev_sqe)
+{
+	const struct sensor_read_config *cfg =
+			(const struct sensor_read_config *) iodev_sqe->sqe.iodev->data;
+
+	if (!cfg->is_streaming) {
+		struct rtio_work_req *req = rtio_work_req_alloc();
+
+		__ASSERT_NO_MSG(req);
+
+		rtio_work_req_submit(req, iodev_sqe, adxl362_submit_fetch);
+	} else if (IS_ENABLED(CONFIG_ADXL362_STREAM)) {
+		adxl362_submit_stream(dev, iodev_sqe);
+	} else {
+		rtio_iodev_sqe_err(iodev_sqe, -ENOTSUP);
+	}
+}

--- a/drivers/sensor/adi/adxl362/adxl362_stream.c
+++ b/drivers/sensor/adi/adxl362/adxl362_stream.c
@@ -1,0 +1,405 @@
+/*
+ * Copyright (c) 2024 Analog Devices Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/logging/log.h>
+#include <zephyr/drivers/sensor.h>
+
+#include "adxl362.h"
+
+LOG_MODULE_DECLARE(ADXL362, CONFIG_SENSOR_LOG_LEVEL);
+
+static void adxl362_irq_en_cb(struct rtio *r, const struct rtio_sqe *sqr, void *arg)
+{
+	const struct device *dev = (const struct device *)arg;
+	const struct adxl362_config *cfg = dev->config;
+
+	gpio_pin_interrupt_configure_dt(&cfg->interrupt, GPIO_INT_EDGE_TO_ACTIVE);
+}
+
+static void adxl362_fifo_flush_rtio(const struct device *dev)
+{
+	struct adxl362_data *data = dev->data;
+
+	uint8_t fifo_config = ADXL362_FIFO_CTL_FIFO_MODE(ADXL362_FIFO_DISABLE);
+	struct rtio_sqe *write_fifo_addr = rtio_sqe_acquire(data->rtio_ctx);
+	const uint8_t reg_addr_w[3] = {ADXL362_WRITE_REG, ADXL362_REG_FIFO_CTL, fifo_config};
+
+	rtio_sqe_prep_tiny_write(write_fifo_addr, data->iodev, RTIO_PRIO_NORM, reg_addr_w, 3, NULL);
+
+	fifo_config = ADXL362_FIFO_CTL_FIFO_MODE(data->fifo_mode) |
+		   (data->en_temp_read * ADXL362_FIFO_CTL_FIFO_TEMP);
+	if (data->water_mark_lvl & 0x100) {
+		fifo_config |= ADXL362_FIFO_CTL_AH;
+	}
+	write_fifo_addr = rtio_sqe_acquire(data->rtio_ctx);
+	const uint8_t reg_addr_w2[3] = {ADXL362_WRITE_REG, ADXL362_REG_FIFO_CTL, fifo_config};
+
+	rtio_sqe_prep_tiny_write(write_fifo_addr, data->iodev, RTIO_PRIO_NORM,
+		reg_addr_w2, 3, NULL);
+	write_fifo_addr->flags |= RTIO_SQE_CHAINED;
+
+	struct rtio_sqe *complete_op = rtio_sqe_acquire(data->rtio_ctx);
+
+	rtio_sqe_prep_callback(complete_op, adxl362_irq_en_cb, (void *)dev, NULL);
+	rtio_submit(data->rtio_ctx, 0);
+}
+
+void adxl362_submit_stream(const struct device *dev, struct rtio_iodev_sqe *iodev_sqe)
+{
+	const struct sensor_read_config *cfg =
+			(const struct sensor_read_config *)iodev_sqe->sqe.iodev->data;
+	struct adxl362_data *data = (struct adxl362_data *)dev->data;
+	const struct adxl362_config *cfg_362 = dev->config;
+	uint8_t int_mask = 0;
+	uint8_t int_value = 0;
+	uint8_t fifo_wmark_irq = 0;
+	uint8_t fifo_full_irq = 0;
+
+	int rc = gpio_pin_interrupt_configure_dt(&cfg_362->interrupt,
+					      GPIO_INT_DISABLE);
+	if (rc < 0) {
+		return;
+	}
+
+	for (size_t i = 0; i < cfg->count; i++) {
+		if (cfg->triggers[i].trigger == SENSOR_TRIG_FIFO_WATERMARK) {
+			int_mask |= ADXL362_INTMAP1_FIFO_WATERMARK;
+			int_value |= ADXL362_INTMAP1_FIFO_WATERMARK;
+			fifo_wmark_irq = 1;
+		}
+
+		if (cfg->triggers[i].trigger == SENSOR_TRIG_FIFO_FULL) {
+			int_mask |= ADXL362_INTMAP1_FIFO_OVERRUN;
+			int_value |= ADXL362_INTMAP1_FIFO_OVERRUN;
+			fifo_full_irq = 1;
+		}
+	}
+
+	if (data->fifo_wmark_irq && (fifo_wmark_irq == 0)) {
+		int_mask |= ADXL362_INTMAP1_FIFO_WATERMARK;
+	}
+
+	if (data->fifo_full_irq && (fifo_full_irq == 0)) {
+		int_mask |= ADXL362_INTMAP1_FIFO_OVERRUN;
+	}
+
+	/* Do not flush the FIFO if interrupts are already enabled. */
+	if ((fifo_wmark_irq != data->fifo_wmark_irq) || (fifo_full_irq != data->fifo_full_irq)) {
+		data->fifo_wmark_irq = fifo_wmark_irq;
+		data->fifo_full_irq = fifo_full_irq;
+
+		rc = adxl362_reg_write_mask(dev, ADXL362_REG_INTMAP1, int_mask, int_value);
+		if (rc < 0) {
+			return;
+		}
+
+		/* Flush the FIFO by disabling it. Save current mode for after the reset. */
+		uint8_t fifo_mode = data->fifo_mode;
+		uint8_t en_temp_read = data->en_temp_read;
+		uint16_t water_mark_lvl = data->water_mark_lvl;
+
+		rc = adxl362_fifo_setup(dev, ADXL362_FIFO_DISABLE, 0, 0);
+		if (rc < 0) {
+			return;
+		}
+
+		if (fifo_mode == ADXL362_FIFO_DISABLE) {
+			fifo_mode = ADXL362_FIFO_STREAM;
+		}
+
+		if (en_temp_read == 0) {
+			en_temp_read = 1;
+		}
+
+		if (water_mark_lvl == 0) {
+			water_mark_lvl = 0x80;
+		}
+
+		rc = adxl362_fifo_setup(dev, fifo_mode, water_mark_lvl, en_temp_read);
+		if (rc < 0) {
+			return;
+		}
+	}
+
+	rc = gpio_pin_interrupt_configure_dt(&cfg_362->interrupt,
+					      GPIO_INT_EDGE_TO_ACTIVE);
+	if (rc < 0) {
+		return;
+	}
+
+	data->sqe = iodev_sqe;
+}
+
+static void adxl362_fifo_read_cb(struct rtio *rtio_ctx, const struct rtio_sqe *sqe, void *arg)
+{
+	const struct device *dev = (const struct device *)arg;
+	const struct adxl362_config *cfg = (const struct adxl362_config *)dev->config;
+	struct rtio_iodev_sqe *iodev_sqe = sqe->userdata;
+
+	rtio_iodev_sqe_ok(iodev_sqe, 0);
+
+	gpio_pin_interrupt_configure_dt(&cfg->interrupt, GPIO_INT_EDGE_TO_ACTIVE);
+}
+
+static void adxl362_process_fifo_samples_cb(struct rtio *r, const struct rtio_sqe *sqr, void *arg)
+{
+	const struct device *dev = (const struct device *)arg;
+	struct adxl362_data *data = (struct adxl362_data *)dev->data;
+	const struct adxl362_config *cfg = (const struct adxl362_config *)dev->config;
+	struct rtio_iodev_sqe *current_sqe = data->sqe;
+	uint16_t fifo_samples = ((data->fifo_ent[0]) | ((data->fifo_ent[1] & 0x3) << 8));
+	size_t sample_set_size = 6;
+
+	if (data->en_temp_read) {
+		sample_set_size += 2;
+	}
+
+	uint16_t fifo_bytes = fifo_samples * 2 /*sample size*/;
+
+	data->sqe = NULL;
+
+	/* Not inherently an underrun/overrun as we may have a buffer to fill next time */
+	if (current_sqe == NULL) {
+		LOG_ERR("No pending SQE");
+		gpio_pin_interrupt_configure_dt(&cfg->interrupt, GPIO_INT_EDGE_TO_ACTIVE);
+		return;
+	}
+
+	const size_t min_read_size = sizeof(struct adxl362_fifo_data) + sample_set_size;
+	const size_t ideal_read_size = sizeof(struct adxl362_fifo_data) + fifo_bytes;
+
+	uint8_t *buf;
+	uint32_t buf_len;
+
+	if (rtio_sqe_rx_buf(current_sqe, min_read_size, ideal_read_size, &buf, &buf_len) != 0) {
+		LOG_ERR("Failed to get buffer");
+		rtio_iodev_sqe_err(current_sqe, -ENOMEM);
+		gpio_pin_interrupt_configure_dt(&cfg->interrupt, GPIO_INT_EDGE_TO_ACTIVE);
+		return;
+	}
+	LOG_DBG("Requesting buffer [%u, %u] got %u", (unsigned int)min_read_size,
+		(unsigned int)ideal_read_size, buf_len);
+
+	/* Read FIFO and call back to rtio with rtio_sqe completion */
+	struct adxl362_fifo_data *hdr = (struct adxl362_fifo_data *) buf;
+
+	hdr->is_fifo = 1;
+	hdr->timestamp = data->timestamp;
+	hdr->int_status = data->status;
+	hdr->selected_range = data->selected_range;
+	hdr->has_tmp = data->en_temp_read;
+
+	uint32_t buf_avail = buf_len;
+
+	buf_avail -= sizeof(*hdr);
+
+	uint32_t read_len = MIN(fifo_bytes, buf_avail);
+	uint32_t pkts = read_len / sample_set_size;
+
+	read_len = pkts * sample_set_size;
+
+	((struct adxl362_fifo_data *)buf)->fifo_byte_count = read_len;
+
+	__ASSERT_NO_MSG(read_len % sample_set_size == 0);
+
+	uint8_t *read_buf = buf + sizeof(*hdr);
+
+	/* Flush completions */
+	struct rtio_cqe *cqe;
+	int res = 0;
+
+	do {
+		cqe = rtio_cqe_consume(data->rtio_ctx);
+		if (cqe != NULL) {
+			if ((cqe->result < 0 && res == 0)) {
+				LOG_ERR("Bus error: %d", cqe->result);
+				res = cqe->result;
+			}
+			rtio_cqe_release(data->rtio_ctx, cqe);
+		}
+	} while (cqe != NULL);
+
+	/* Bail/cancel attempt to read sensor on any error */
+	if (res != 0) {
+		rtio_iodev_sqe_err(current_sqe, res);
+		return;
+	}
+
+	/* Setup new rtio chain to read the fifo data and report then check the
+	 * result
+	 */
+	struct rtio_sqe *write_fifo_addr = rtio_sqe_acquire(data->rtio_ctx);
+	struct rtio_sqe *read_fifo_data = rtio_sqe_acquire(data->rtio_ctx);
+	struct rtio_sqe *complete_op = rtio_sqe_acquire(data->rtio_ctx);
+	const uint8_t reg_addr = ADXL362_READ_FIFO;
+
+	rtio_sqe_prep_tiny_write(write_fifo_addr, data->iodev, RTIO_PRIO_NORM, &reg_addr, 1, NULL);
+	write_fifo_addr->flags = RTIO_SQE_TRANSACTION;
+	rtio_sqe_prep_read(read_fifo_data, data->iodev, RTIO_PRIO_NORM, read_buf, read_len,
+			   current_sqe);
+	read_fifo_data->flags = RTIO_SQE_CHAINED;
+	rtio_sqe_prep_callback(complete_op, adxl362_fifo_read_cb, (void *)dev, current_sqe);
+
+	rtio_submit(data->rtio_ctx, 0);
+}
+
+static void adxl362_process_status_cb(struct rtio *r, const struct rtio_sqe *sqr, void *arg)
+{
+	const struct device *dev = (const struct device *)arg;
+	struct adxl362_data *data = (struct adxl362_data *) dev->data;
+	const struct adxl362_config *cfg = (const struct adxl362_config *) dev->config;
+	struct rtio_iodev_sqe *current_sqe = data->sqe;
+	struct sensor_read_config *read_config;
+	uint8_t status = data->status;
+
+	if (data->sqe == NULL) {
+		return;
+	}
+
+	read_config = (struct sensor_read_config *)data->sqe->sqe.iodev->data;
+
+	if (read_config == NULL) {
+		return;
+	}
+
+	if (read_config->is_streaming == false) {
+		return;
+	}
+
+	gpio_pin_interrupt_configure_dt(&cfg->interrupt, GPIO_INT_DISABLE);
+
+	struct sensor_stream_trigger *fifo_wmark_cfg = NULL;
+	struct sensor_stream_trigger *fifo_full_cfg = NULL;
+
+	for (int i = 0; i < read_config->count; ++i) {
+		if (read_config->triggers[i].trigger == SENSOR_TRIG_FIFO_WATERMARK) {
+			fifo_wmark_cfg = &read_config->triggers[i];
+			continue;
+		}
+
+		if (read_config->triggers[i].trigger == SENSOR_TRIG_FIFO_FULL) {
+			fifo_full_cfg = &read_config->triggers[i];
+			continue;
+		}
+	}
+
+	bool fifo_full_irq = false;
+	bool fifo_wmark_irq = false;
+
+	if ((fifo_wmark_cfg != NULL) && ADXL362_STATUS_CHECK_FIFO_WTR(status)) {
+		fifo_wmark_irq = true;
+	}
+
+	if ((fifo_full_cfg != NULL) && ADXL362_STATUS_CHECK_FIFO_OVR(status)) {
+		fifo_full_irq = true;
+	}
+
+	if (!fifo_full_irq && !fifo_wmark_irq) {
+		gpio_pin_interrupt_configure_dt(&cfg->interrupt, GPIO_INT_EDGE_TO_ACTIVE);
+		return;
+	}
+
+	/* Flush completions */
+	struct rtio_cqe *cqe;
+	int res = 0;
+
+	do {
+		cqe = rtio_cqe_consume(data->rtio_ctx);
+		if (cqe != NULL) {
+			if ((cqe->result < 0 && res == 0)) {
+				LOG_ERR("Bus error: %d", cqe->result);
+				res = cqe->result;
+			}
+			rtio_cqe_release(data->rtio_ctx, cqe);
+		}
+	} while (cqe != NULL);
+
+	/* Bail/cancel attempt to read sensor on any error */
+	if (res != 0) {
+		rtio_iodev_sqe_err(current_sqe, res);
+		return;
+	}
+
+	enum sensor_stream_data_opt data_opt;
+
+	if ((fifo_wmark_cfg != NULL) && (fifo_full_cfg == NULL)) {
+		data_opt = fifo_wmark_cfg->opt;
+	} else if ((fifo_wmark_cfg == NULL) && (fifo_full_cfg != NULL)) {
+		data_opt = fifo_full_cfg->opt;
+	} else {
+		data_opt = MIN(fifo_wmark_cfg->opt, fifo_full_cfg->opt);
+	}
+
+	if (data_opt == SENSOR_STREAM_DATA_NOP || data_opt == SENSOR_STREAM_DATA_DROP) {
+		uint8_t *buf;
+		uint32_t buf_len;
+
+		/* Clear streaming_sqe since we're done with the call */
+		data->sqe = NULL;
+		if (rtio_sqe_rx_buf(current_sqe, sizeof(struct adxl362_fifo_data),
+				    sizeof(struct adxl362_fifo_data), &buf, &buf_len) != 0) {
+			rtio_iodev_sqe_err(current_sqe, -ENOMEM);
+			gpio_pin_interrupt_configure_dt(&cfg->interrupt, GPIO_INT_EDGE_TO_ACTIVE);
+			return;
+		}
+
+		struct adxl362_fifo_data *rx_data = (struct adxl362_fifo_data *)buf;
+
+		memset(buf, 0, buf_len);
+		rx_data->is_fifo = 1;
+		rx_data->timestamp = data->timestamp;
+		rx_data->int_status = status;
+		rx_data->fifo_byte_count = 0;
+		rtio_iodev_sqe_ok(current_sqe, 0);
+
+		if (data_opt == SENSOR_STREAM_DATA_DROP) {
+			/* Flush the FIFO by disabling it. Save current mode for after the reset. */
+			adxl362_fifo_flush_rtio(dev);
+			return;
+		}
+
+		gpio_pin_interrupt_configure_dt(&cfg->interrupt, GPIO_INT_EDGE_TO_ACTIVE);
+		return;
+	}
+
+	struct rtio_sqe *write_fifo_addr = rtio_sqe_acquire(data->rtio_ctx);
+	struct rtio_sqe *read_fifo_data = rtio_sqe_acquire(data->rtio_ctx);
+	struct rtio_sqe *complete_op = rtio_sqe_acquire(data->rtio_ctx);
+	const uint8_t reg[2] = {ADXL362_READ_REG, ADXL362_REG_FIFO_L};
+
+	rtio_sqe_prep_tiny_write(write_fifo_addr, data->iodev, RTIO_PRIO_NORM, reg, 2, NULL);
+	write_fifo_addr->flags = RTIO_SQE_TRANSACTION;
+	rtio_sqe_prep_read(read_fifo_data, data->iodev, RTIO_PRIO_NORM, data->fifo_ent, 2,
+						current_sqe);
+	read_fifo_data->flags = RTIO_SQE_CHAINED;
+	rtio_sqe_prep_callback(complete_op, adxl362_process_fifo_samples_cb, (void *)dev,
+							current_sqe);
+
+	rtio_submit(data->rtio_ctx, 0);
+}
+
+void adxl362_stream_irq_handler(const struct device *dev)
+{
+	struct adxl362_data *data = (struct adxl362_data *) dev->data;
+
+	if (data->sqe == NULL) {
+		return;
+	}
+
+	data->timestamp = k_ticks_to_ns_floor64(k_uptime_ticks());
+
+	struct rtio_sqe *write_status_addr = rtio_sqe_acquire(data->rtio_ctx);
+	struct rtio_sqe *read_status_reg = rtio_sqe_acquire(data->rtio_ctx);
+	struct rtio_sqe *check_status_reg = rtio_sqe_acquire(data->rtio_ctx);
+	const uint8_t reg[2] = {ADXL362_READ_REG, ADXL362_REG_STATUS};
+
+	rtio_sqe_prep_tiny_write(write_status_addr, data->iodev, RTIO_PRIO_NORM, reg, 2, NULL);
+	write_status_addr->flags = RTIO_SQE_TRANSACTION;
+	rtio_sqe_prep_read(read_status_reg, data->iodev, RTIO_PRIO_NORM, &data->status, 1, NULL);
+	read_status_reg->flags = RTIO_SQE_CHAINED;
+	rtio_sqe_prep_callback(check_status_reg, adxl362_process_status_cb, (void *)dev, NULL);
+	rtio_submit(data->rtio_ctx, 0);
+}

--- a/drivers/sensor/adi/adxl362/adxl362_trigger.c
+++ b/drivers/sensor/adi/adxl362/adxl362_trigger.c
@@ -17,6 +17,7 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(ADXL362, CONFIG_SENSOR_LOG_LEVEL);
 
+#if defined(CONFIG_ADXL362_TRIGGER_OWN_THREAD) || defined(CONFIG_ADXL362_TRIGGER_GLOBAL_THREAD)
 static void adxl362_thread_cb(const struct device *dev)
 {
 	struct adxl362_data *drv_data = dev->data;
@@ -47,12 +48,17 @@ static void adxl362_thread_cb(const struct device *dev)
 	}
 	k_mutex_unlock(&drv_data->trigger_mutex);
 }
+#endif /* CONFIG_ADXL362_TRIGGER_OWN_THREAD || CONFIG_ADXL362_TRIGGER_GLOBAL_THREAD */
 
 static void adxl362_gpio_callback(const struct device *dev,
 				  struct gpio_callback *cb, uint32_t pins)
 {
 	struct adxl362_data *drv_data =
 		CONTAINER_OF(cb, struct adxl362_data, gpio_cb);
+
+	if (IS_ENABLED(CONFIG_ADXL362_STREAM)) {
+		adxl362_stream_irq_handler(drv_data->dev);
+	}
 
 #if defined(CONFIG_ADXL362_TRIGGER_OWN_THREAD)
 	k_sem_give(&drv_data->gpio_sem);


### PR DESCRIPTION
Updated ADXL362 driver with RTIO stream functionality. RTIO stream is using both FIFO threshold and FIFO full triggers. Together with RTIO stream, RTIO async read is also implemented.

Signed-off-by: Vladislav Pejic <vladislav.pejic@orioninc.com>