### PR TITLE
boards: nxp: frdm_k64f: use SW2 instead of SW3 for MCUboot

### DIFF
--- a/boards/nxp/frdm_k64f/frdm_k64f.dts
+++ b/boards/nxp/frdm_k64f/frdm_k64f.dts
@@ -18,7 +18,7 @@
 		sw1 = &user_button_2;
 		magn0 = &fxos8700;
 		accel0 = &fxos8700;
-		mcuboot-button0 = &user_button_3;
+		mcuboot-button0 = &user_button_2;
 	};
 
 	chosen {


### PR DESCRIPTION
Use SW2 instead of SW3 for entering MCUboot serial recovery/USB DFU mode. Holding SW3 during reset results in a NMI, causing the boot process to halt.