### PR TITLE
tests/stream_flash: Disable SPI_NOR on nrf54l devices

### DIFF
--- a/tests/subsys/storage/stream/stream_flash/testcase.yaml
+++ b/tests/subsys/storage/stream/stream_flash/testcase.yaml
@@ -15,6 +15,8 @@ tests:
   storage.stream_flash.no_explicit_erase:
     platform_allow:
       - nrf54l15dk/nrf54l15/cpuapp
+    extra_args:
+      - CONFIG_SPI_NOR=n
   storage.stream_flash.dword_wbs:
     extra_args: DTC_OVERLAY_FILE=unaligned_flush.overlay
     tags: stream_flash


### PR DESCRIPTION
The stream flash test has been written with SoC internal storage in mind and its simplified structure does not take into account possibility of existence of devices with different erase characteristics, at run time.
The commit fixes the test failing with Nordic bords that have CONFIG_SPI_NOR=y set by default, which made test to behave like device with erase capability has been tested.

The commit sets CONFIG_SPI_NOR=n for nrf54l devices.

Fixes #79181