### PR TITLE
net: fix note about source address in net_context

### DIFF
--- a/include/zephyr/net/net_context.h
+++ b/include/zephyr/net/net_context.h
@@ -200,7 +200,7 @@ struct net_conn_handle;
 
 /**
  * Note that we do not store the actual source IP address in the context
- * because the address is already be set in the network interface struct.
+ * because the address is already set in the network interface struct.
  * If there is no such source address there, the packet cannot be sent
  * anyway. This saves 12 bytes / context in IPv6.
  */


### PR DESCRIPTION
Removes extraneous word in note on net_context struct describing why the source address is not stored directly in struct.