### PR TITLE
Comparator: Add gpio_loopback based test suite

### DIFF
--- a/tests/drivers/comparator/gpio_loopback/CMakeLists.txt
+++ b/tests/drivers/comparator/gpio_loopback/CMakeLists.txt
@@ -1,0 +1,8 @@
+# Copyright (c) 2024 Nordic Semiconductor
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(comparator_gpio_loopback)
+
+target_sources(app PRIVATE src/test.c)

--- a/tests/drivers/comparator/gpio_loopback/boards/frdm_ke15z.overlay
+++ b/tests/drivers/comparator/gpio_loopback/boards/frdm_ke15z.overlay
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <nxp/kinetis/MKE17Z256VLL7-pinctrl.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+
+/*
+ * PTA1 looped back to PTA0
+ */
+
+/ {
+	aliases {
+		test-comp = &cmp0;
+	};
+
+	zephyr,user {
+		test-gpios = <&gpioa 1 GPIO_ACTIVE_HIGH>;
+	};
+};
+
+&gpioa {
+	status = "okay";
+};
+
+&pinctrl {
+	cmp0_default: cmp0_default {
+		group0 {
+			pinmux = <ACMP0_IN0_PTA0>;
+			drive-strength = "high";
+		};
+	};
+};
+
+&cmp0 {
+	pinctrl-0 = <&cmp0_default>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	positive-mux-input = "IN0";
+	positive-port-input = "MUX";
+	negative-mux-input = "IN0";
+	negative-port-input = "DAC";
+
+	dac-vref-source = "VIN1";
+	dac-value = <128>;
+	dac-enable;
+};

--- a/tests/drivers/comparator/gpio_loopback/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/tests/drivers/comparator/gpio_loopback/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/gpio/gpio.h>
+
+/*
+ * P0.05 looped back to P0.04
+ */
+
+/ {
+	aliases {
+		test-comp = &comp;
+	};
+
+	zephyr,user {
+		test-gpios = <&gpio0 5 GPIO_ACTIVE_HIGH>;
+	};
+};
+
+&gpio0{
+	status = "okay";
+};

--- a/tests/drivers/comparator/gpio_loopback/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/tests/drivers/comparator/gpio_loopback/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/gpio/gpio.h>
+
+/*
+ * P1.03 looped back to P1.02
+ */
+
+/ {
+	aliases {
+		test-comp = &comp;
+	};
+
+	zephyr,user {
+		test-gpios = <&gpio1 3 GPIO_ACTIVE_HIGH>;
+	};
+};
+
+&gpio1 {
+	status = "okay";
+};
+
+/* Temporary workaround to reserve P1.03 for cpuapp */
+&led1 {
+	gpios = < &gpio1 0x3 0x0 >;
+};
+
+/* Temporary workaround to reserve P1.02 for cpuapp */
+&led2 {
+	gpios = < &gpio1 0x2 0x0 >;
+};

--- a/tests/drivers/comparator/gpio_loopback/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/tests/drivers/comparator/gpio_loopback/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/gpio/gpio.h>
+
+/*
+ * P1.10 looped back to P1.11
+ */
+
+/ {
+	aliases {
+		test-comp = &comp;
+	};
+
+	zephyr,user {
+		test-gpios = <&gpio1 10 GPIO_ACTIVE_HIGH>;
+	};
+};
+
+&gpio1 {
+	status = "okay";
+};

--- a/tests/drivers/comparator/gpio_loopback/prj.conf
+++ b/tests/drivers/comparator/gpio_loopback/prj.conf
@@ -1,0 +1,6 @@
+# Copyright (c) 2024 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_ZTEST=y
+CONFIG_GPIO=y
+CONFIG_COMPARATOR=y

--- a/tests/drivers/comparator/gpio_loopback/snippets/nrf_comp/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/tests/drivers/comparator/gpio_loopback/snippets/nrf_comp/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&comp {
+	main-mode = "SE";
+	psel = "AIN0"; /* P0.04 */
+	refsel = "VDD";
+	sp-mode = "HIGH";
+	th-up = <34>;
+	th-down = <30>;
+	isource = "DISABLED";
+	status = "okay";
+};

--- a/tests/drivers/comparator/gpio_loopback/snippets/nrf_comp/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/tests/drivers/comparator/gpio_loopback/snippets/nrf_comp/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&comp {
+	main-mode = "SE";
+	psel = "AIN2"; /* P1.02 */
+	refsel = "INT_1V2";
+	sp-mode = "HIGH";
+	th-up = <63>;
+	th-down = <59>;
+	isource = "DISABLED";
+	status = "okay";
+};

--- a/tests/drivers/comparator/gpio_loopback/snippets/nrf_comp/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/tests/drivers/comparator/gpio_loopback/snippets/nrf_comp/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&comp {
+	main-mode = "SE";
+	psel = "AIN4"; /* P1.11 */
+	refsel = "INT_1V2";
+	sp-mode = "HIGH";
+	th-up = <63>;
+	th-down = <59>;
+	isource = "DISABLED";
+	status = "okay";
+};

--- a/tests/drivers/comparator/gpio_loopback/snippets/nrf_comp/snippet.yml
+++ b/tests/drivers/comparator/gpio_loopback/snippets/nrf_comp/snippet.yml
@@ -1,0 +1,15 @@
+# Copyright 2024 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+name: gpio_loopback_nrf_comp
+
+boards:
+  nrf54h20dk/nrf54h20/cpuapp:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+  nrf54l15dk/nrf54l15/cpuapp:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+  nrf5340dk/nrf5340/cpuapp:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: boards/nrf5340dk_nrf5340_cpuapp.overlay

--- a/tests/drivers/comparator/gpio_loopback/snippets/nrf_lpcomp/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/tests/drivers/comparator/gpio_loopback/snippets/nrf_lpcomp/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&comp {
+	compatible = "nordic,nrf-lpcomp";
+	psel = "AIN0"; /* P0.04 */
+	refsel = "VDD_4_8";
+	status = "okay";
+};

--- a/tests/drivers/comparator/gpio_loopback/snippets/nrf_lpcomp/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/tests/drivers/comparator/gpio_loopback/snippets/nrf_lpcomp/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&comp {
+	compatible = "nordic,nrf-lpcomp";
+	psel = "AIN2"; /* P1.02 */
+	refsel = "VDD_4_8";
+	status = "okay";
+};

--- a/tests/drivers/comparator/gpio_loopback/snippets/nrf_lpcomp/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/tests/drivers/comparator/gpio_loopback/snippets/nrf_lpcomp/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&comp {
+	compatible = "nordic,nrf-lpcomp";
+	psel = "AIN4"; /* P1.11 */
+	refsel = "VDD_4_8";
+	status = "okay";
+};

--- a/tests/drivers/comparator/gpio_loopback/snippets/nrf_lpcomp/snippet.yml
+++ b/tests/drivers/comparator/gpio_loopback/snippets/nrf_lpcomp/snippet.yml
@@ -1,0 +1,15 @@
+# Copyright 2024 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+name: gpio_loopback_nrf_lpcomp
+
+boards:
+  nrf54h20dk/nrf54h20/cpuapp:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+  nrf54l15dk/nrf54l15/cpuapp:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+  nrf5340dk/nrf5340/cpuapp:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: boards/nrf5340dk_nrf5340_cpuapp.overlay

--- a/tests/drivers/comparator/gpio_loopback/src/test.c
+++ b/tests/drivers/comparator/gpio_loopback/src/test.c
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/drivers/comparator.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/kernel.h>
+#include <zephyr/ztest.h>
+
+static const struct device *test_dev = DEVICE_DT_GET(DT_ALIAS(test_comp));
+static const struct gpio_dt_spec test_pin = GPIO_DT_SPEC_GET(DT_PATH(zephyr_user), test_gpios);
+static K_SEM_DEFINE(test_sem, 0, 1);
+
+static void test_callback(const struct device *dev, void *user_data)
+{
+	zassert_equal(&test_sem, user_data);
+	k_sem_give(&test_sem);
+}
+
+static void *test_setup(void)
+{
+	zassert_ok(gpio_pin_configure_dt(&test_pin, GPIO_OUTPUT_INACTIVE));
+	return NULL;
+}
+
+static void test_before(void *f)
+{
+	ARG_UNUSED(f);
+
+	k_sem_reset(&test_sem);
+	zassert_ok(gpio_pin_set_dt(&test_pin, 0));
+	zassert_ok(comparator_set_trigger(test_dev, COMPARATOR_TRIGGER_NONE));
+	zassert_ok(comparator_set_trigger_callback(test_dev, NULL, NULL));
+	zassert_between_inclusive(comparator_trigger_is_pending(test_dev), 0, 1);
+}
+
+ZTEST_SUITE(comparator_gpio_loopback, NULL, test_setup, test_before, NULL, NULL);
+
+ZTEST(comparator_gpio_loopback, test_get_output)
+{
+	zassert_equal(comparator_get_output(test_dev), 0);
+	k_msleep(1);
+	zassert_ok(gpio_pin_set_dt(&test_pin, 1));
+	k_msleep(1);
+	zassert_equal(comparator_get_output(test_dev), 1);
+	k_msleep(1);
+	zassert_ok(gpio_pin_set_dt(&test_pin, 0));
+	k_msleep(1);
+	zassert_equal(comparator_get_output(test_dev), 0);
+}
+
+ZTEST(comparator_gpio_loopback, test_no_trigger_no_pending)
+{
+	zassert_ok(gpio_pin_set_dt(&test_pin, 1));
+	k_msleep(1);
+	zassert_equal(comparator_trigger_is_pending(test_dev), 0);
+	zassert_ok(gpio_pin_set_dt(&test_pin, 0));
+	k_msleep(1);
+	zassert_equal(comparator_trigger_is_pending(test_dev), 0);
+}
+
+ZTEST(comparator_gpio_loopback, test_trigger_rising_edge_pending)
+{
+	zassert_ok(comparator_set_trigger(test_dev, COMPARATOR_TRIGGER_RISING_EDGE));
+	k_msleep(1);
+	zassert_equal(comparator_trigger_is_pending(test_dev), 0);
+	zassert_ok(gpio_pin_set_dt(&test_pin, 1));
+	k_msleep(1);
+	zassert_equal(comparator_trigger_is_pending(test_dev), 1);
+	zassert_equal(comparator_trigger_is_pending(test_dev), 0);
+	zassert_ok(gpio_pin_set_dt(&test_pin, 0));
+	k_msleep(1);
+	zassert_equal(comparator_trigger_is_pending(test_dev), 0);
+}
+
+ZTEST(comparator_gpio_loopback, test_trigger_falling_edge_pending)
+{
+	zassert_ok(comparator_set_trigger(test_dev, COMPARATOR_TRIGGER_FALLING_EDGE));
+	k_msleep(1);
+	zassert_equal(comparator_trigger_is_pending(test_dev), 0);
+	zassert_ok(gpio_pin_set_dt(&test_pin, 1));
+	k_msleep(1);
+	zassert_equal(comparator_trigger_is_pending(test_dev), 0);
+	zassert_ok(gpio_pin_set_dt(&test_pin, 0));
+	k_msleep(1);
+	zassert_equal(comparator_trigger_is_pending(test_dev), 1);
+	zassert_equal(comparator_trigger_is_pending(test_dev), 0);
+}
+
+ZTEST(comparator_gpio_loopback, test_trigger_both_edges_pending)
+{
+	zassert_ok(comparator_set_trigger(test_dev, COMPARATOR_TRIGGER_BOTH_EDGES));
+	k_msleep(1);
+	zassert_equal(comparator_trigger_is_pending(test_dev), 0);
+	zassert_ok(gpio_pin_set_dt(&test_pin, 1));
+	k_msleep(1);
+	zassert_equal(comparator_trigger_is_pending(test_dev), 1);
+	zassert_equal(comparator_trigger_is_pending(test_dev), 0);
+	zassert_ok(gpio_pin_set_dt(&test_pin, 0));
+	k_msleep(1);
+	zassert_equal(comparator_trigger_is_pending(test_dev), 1);
+	zassert_equal(comparator_trigger_is_pending(test_dev), 0);
+}
+
+ZTEST(comparator_gpio_loopback, test_trigger_callback)
+{
+	zassert_ok(comparator_set_trigger_callback(test_dev, test_callback, &test_sem));
+	k_msleep(1);
+	zassert_equal(k_sem_take(&test_sem, K_NO_WAIT), -EBUSY);
+	zassert_ok(comparator_set_trigger(test_dev, COMPARATOR_TRIGGER_RISING_EDGE));
+	k_msleep(1);
+	zassert_equal(k_sem_take(&test_sem, K_NO_WAIT), -EBUSY);
+	zassert_ok(gpio_pin_set_dt(&test_pin, 1));
+	k_msleep(1);
+	zassert_ok(k_sem_take(&test_sem, K_NO_WAIT));
+	zassert_equal(comparator_trigger_is_pending(test_dev), 0);
+}

--- a/tests/drivers/comparator/gpio_loopback/testcase.yaml
+++ b/tests/drivers/comparator/gpio_loopback/testcase.yaml
@@ -1,0 +1,27 @@
+# Copyright (c) 2024 Nordic Semiconductor
+# SPDX-License-Identifier: Apache-2.0
+
+common:
+  harness_config:
+    fixture: gpio_loopback
+  tags:
+    - drivers
+    - comparator
+tests:
+  drivers.comparator.gpio_loopback.mcux_acmp:
+    platform_allow:
+      - frdm_ke15z
+  drivers.comparator.gpio_loopback.nrf_comp:
+    extra_args:
+      - SNIPPET="gpio_loopback_nrf_comp"
+    platform_allow:
+      - nrf54h20dk/nrf54h20/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf5340dk/nrf5340/cpuapp
+  drivers.comparator.gpio_loopback.nrf_lpcomp:
+    extra_args:
+      - SNIPPET="gpio_loopback_nrf_lpcomp"
+    platform_allow:
+      - nrf54h20dk/nrf54h20/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf5340dk/nrf5340/cpuapp


### PR DESCRIPTION
Add test suite which uses GPIO loopback to produce a "very low" and "very high" voltage at the positive input of the comparator using the output of a GPIO. The negative input is set to a voltage between the high and low output voltages of the GPIO using whichever internal reference is available to the comparator.