### PR TITLE
board: mimxrt1170_evk: fix linkserver support to debug RAM images

### DIFF
--- a/boards/nxp/mimxrt1170_evk/board.cmake
+++ b/boards/nxp/mimxrt1170_evk/board.cmake
@@ -7,6 +7,9 @@
 if(CONFIG_SOC_MIMXRT1176_CM7 OR CONFIG_SECOND_CORE_MCUX)
  board_runner_args(pyocd "--target=mimxrt1170_cm7")
  board_runner_args(jlink "--device=MIMXRT1176xxxA_M7" "--reset-after-load")
+ # ITCM is not defined in RT1170's LinkServer device file
+ board_runner_args(linkserver "--override=/device/memory/-=\{\"location\":\"0x00000000\",\
+                               \"size\":\"0x00040000\",\"type\":\"RAM\"\}")
 
  if(${BOARD_REVISION} STREQUAL "A")
   board_runner_args(linkserver  "--device=MIMXRT1176xxxxx:MIMXRT1170-EVK")
@@ -27,6 +30,6 @@ elseif(CONFIG_SOC_MIMXRT1176_CM4)
  board_runner_args(linkserver "--core=cm4")
 endif()
 
+include(${ZEPHYR_BASE}/boards/common/linkserver.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/linkserver.board.cmake)

--- a/boards/nxp/mimxrt1170_evk/doc/index.rst
+++ b/boards/nxp/mimxrt1170_evk/doc/index.rst
@@ -362,11 +362,6 @@ EVK. See `Using J-Link with MIMXRT1170-EVKB`_ or
 Using LinkServer
 ----------------
 
-Known limitations with LinkServer and these boards include:
-- ``west flash`` will not write images to non-flash locations. The flash
-command only works when all data in the image is written to flash memory
-regions.
-
 Install the :ref:`linkserver-debug-host-tools` and make sure they are in your
 search path.  LinkServer works with the default CMSIS-DAP firmware included in
 the on-board debugger.

--- a/soc/nxp/imxrt/imxrt11xx/soc.c
+++ b/soc/nxp/imxrt/imxrt11xx/soc.c
@@ -729,8 +729,22 @@ static int imxrt_init(void)
 	return 0;
 }
 
+/*
+ * Stack pointer is not set at this point in the early init, but we call C
+ * functions from the SOC reset.
+ * Set a stack pointer so that C functions will work correctly
+ */
+
 #ifdef CONFIG_SOC_RESET_HOOK
-void soc_reset_hook(void)
+__asm__ (
+	".global soc_reset_hook\n"
+	"soc_reset_hook:\n"
+	"ldr r0, =z_main_stack+"STRINGIFY(CONFIG_MAIN_STACK_SIZE)";\n"
+	"msr msp, r0;\n"
+	"b _soc_reset_hook;\n"
+);
+
+void __used _soc_reset_hook(void)
 {
 	SystemInit();
 


### PR DESCRIPTION
- add ITCM definitions (for LinkServer) in board.cmake
- update of soc.c to support RAM images (stack pointer)

Change applies to both versions of the MIMXRT1170 EVK