### PR TITLE
cmake: xcc: fix compilation issues 

### DIFF
--- a/cmake/compiler/xcc/compiler_flags.cmake
+++ b/cmake/compiler/xcc/compiler_flags.cmake
@@ -15,3 +15,6 @@ set_compiler_property(PROPERTY no_position_independent "")
 
 # Remove after testing that -Wshadow works
 set_compiler_property(PROPERTY warning_shadow_variables)
+
+# xcc does not recognize -fno-printf-return-value
+set_compiler_property(PROPERTY no_printf_return_value)

--- a/cmake/compiler/xcc/target.cmake
+++ b/cmake/compiler/xcc/target.cmake
@@ -40,12 +40,6 @@ foreach(file_name include/stddef.h include-fixed/limits.h)
   list(APPEND NOSTDINC ${_OUTPUT})
 endforeach()
 
-list(APPEND TOOLCHAIN_LIBS
-  gcc
-  hal
-  )
-
-
 # For CMake to be able to test if a compiler flag is supported by the
 # toolchain we need to give CMake the necessary flags to compile and
 # link a dummy C file.

--- a/cmake/linker/xt-ld/linker_libraries.cmake
+++ b/cmake/linker/xt-ld/linker_libraries.cmake
@@ -5,4 +5,5 @@
 set_linker_property(NO_CREATE PROPERTY c_library    "-lc")
 set_linker_property(NO_CREATE PROPERTY rt_library   "-lgcc")
 set_linker_property(NO_CREATE PROPERTY c++_library  "-lstdc++")
-set_linker_property(PROPERTY link_order_library "c;rt")
+set_linker_property(NO_CREATE PROPERTY hal_library  "-lhal")
+set_linker_property(PROPERTY link_order_library "c;rt;hal")

--- a/cmake/linker/xt-ld/target.cmake
+++ b/cmake/linker/xt-ld/target.cmake
@@ -130,7 +130,6 @@ function(toolchain_ld_link_elf)
     ${NO_WHOLE_ARCHIVE_LIBS}
     $<TARGET_OBJECTS:${OFFSETS_LIB}>
     -L${PROJECT_BINARY_DIR}
-    ${TOOLCHAIN_LIBS}
 
     ${TOOLCHAIN_LD_LINK_ELF_DEPENDENCIES}
   )

--- a/cmake/toolchain/xcc/generic.cmake
+++ b/cmake/toolchain/xcc/generic.cmake
@@ -6,6 +6,7 @@ set(COMPILER xcc)
 set(OPTIMIZE_FOR_DEBUG_FLAG "-O0")
 set(CC xcc)
 set(C++ xc++)
+set(LINKER xt-ld)
 
 list(APPEND TOOLCHAIN_C_FLAGS
   -imacros${ZEPHYR_BASE}/include/zephyr/toolchain/xcc_missing_defs.h


### PR DESCRIPTION
* cmake: xcc: use xt-ld as linker
* cmake: xcc: do not use -fno-printf-return-value
* cmake: xcc: remove TOOLCHAIN_LIBS

Fixes some issues when compiling with good old XCC.