### PR TITLE
kernel: Remove unused z_ready_thread_locked()

### DIFF
--- a/kernel/include/ksched.h
+++ b/kernel/include/ksched.h
@@ -60,7 +60,6 @@ void z_reset_time_slice(struct k_thread *curr);
 void z_sched_ipi(void);
 void z_sched_start(struct k_thread *thread);
 void z_ready_thread(struct k_thread *thread);
-void z_ready_thread_locked(struct k_thread *thread);
 void z_requeue_current(struct k_thread *curr);
 struct k_thread *z_swap_next_thread(void);
 void z_thread_abort(struct k_thread *thread);

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -389,13 +389,6 @@ static void ready_thread(struct k_thread *thread)
 	}
 }
 
-void z_ready_thread_locked(struct k_thread *thread)
-{
-	if (thread_active_elsewhere(thread) == NULL) {
-		ready_thread(thread);
-	}
-}
-
 void z_ready_thread(struct k_thread *thread)
 {
 	K_SPINLOCK(&_sched_spinlock) {


### PR DESCRIPTION
Removing the routine z_ready_thread_locked() as it is not used anywhere. It was a leftover artefact from development that previously escaped cleanup.