### PR TITLE
dp: swdp_bitbang: fix unused variable build error

### DIFF
--- a/drivers/dp/swdp_bitbang.c
+++ b/drivers/dp/swdp_bitbang.c
@@ -677,7 +677,6 @@ static int sw_port_off(const struct device *dev)
 
 static int sw_gpio_init(const struct device *dev)
 {
-	const struct sw_config *config = dev->config;
 	struct sw_cfg_data *sw_data = dev->data;
 	int ret;
 


### PR DESCRIPTION
The variable config in sw_port_off() is not used, and it's causing CI build error about unused variable. So remove it.