### PR TITLE
modules: hostap: Fix memory leak of network

### DIFF
--- a/modules/hostap/src/supp_api.c
+++ b/modules/hostap/src/supp_api.c
@@ -844,6 +844,10 @@ out:
 		wifi_mgmt_raise_disconnect_complete_event(iface, ret);
 	}
 
+	if (!wpa_cli_cmd_v("remove_network all")) {
+		wpa_printf(MSG_ERROR, "Failed to remove all networks");
+	}
+
 	return ret;
 }
 

--- a/west.yml
+++ b/west.yml
@@ -259,7 +259,7 @@ manifest:
         - hal
     - name: hostap
       path: modules/lib/hostap
-      revision: 7c32520564908e1220976b6c185dec296b6d4a80
+      revision: ac59d28778b20cd68702f55dad2a27d648e3d571
     - name: libmetal
       revision: a6851ba6dba8c9e87d00c42f171a822f7a29639b
       path: modules/hal/libmetal


### PR DESCRIPTION
In "connect" all networks are removed and  new network is always added, but in disconnect the network isn't deleted, so, the memory is unnecessarily held till next connect. This is not exactly a leak, but if someone profiles using "kernel heap" then this can be construed as a leak.

Fix this by removing network during the disconnection (for now "all") so that the memory can be used by someone else.