### PR TITLE
MAINTAINERS.yml: patch comparator drivers area

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1159,8 +1159,6 @@ Release Notes:
     - dts/bindings/comparator/
     - include/zephyr/drivers/comparator.h
     - include/zephyr/drivers/comparator/
-    - include/zephyr/drivers/comparator/
-    - include/zephyr/dt-bindings/clock/
     - tests/drivers/build_all/comparator/
     - tests/drivers/comparator/
     - doc/hardware/peripherals/comparator.rst


### PR DESCRIPTION
The comparator drivers area contains the following incorrect area:
```
files:
  - include/zephyr/dt-bindings/clock/
```
and contains the following duplicate area:
```
files:
  - include/zephyr/drivers/comparator/
```
this PR removes them.