### PR TITLE
drivers: dp: swdp_bitbang: Remove unused variable

### DIFF
--- a/drivers/dp/swdp_bitbang.c
+++ b/drivers/dp/swdp_bitbang.c
@@ -677,7 +677,6 @@ static int sw_port_off(const struct device *dev)
 
 static int sw_gpio_init(const struct device *dev)
 {
-	const struct sw_config *config = dev->config;
 	struct sw_cfg_data *sw_data = dev->data;
 	int ret;
 


### PR DESCRIPTION
This causes a warning during compile