### PR TITLE
kernel: Update mailbox synchronous send logic

### DIFF
--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -4818,6 +4818,8 @@ struct k_mbox {
 	_wait_q_t tx_msg_queue;
 	/** Receive message queue */
 	_wait_q_t rx_msg_queue;
+	/** Sync send queue */
+	_wait_q_t matched_queue;
 	struct k_spinlock lock;
 
 	SYS_PORT_TRACING_TRACKING_FIELD(k_mbox)
@@ -4834,6 +4836,7 @@ struct k_mbox {
 	{ \
 	.tx_msg_queue = Z_WAIT_Q_INIT(&obj.tx_msg_queue), \
 	.rx_msg_queue = Z_WAIT_Q_INIT(&obj.rx_msg_queue), \
+	.matched_queue = Z_WAIT_Q_INIT(&obj.matched_queue), \
 	}
 
 /**

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -584,10 +584,8 @@ static void add_to_waitq_locked(struct k_thread *thread, _wait_q_t *wait_q)
 
 	SYS_PORT_TRACING_FUNC(k_thread, sched_pend, thread);
 
-	if (wait_q != NULL) {
-		thread->base.pended_on = wait_q;
-		_priq_wait_add(&wait_q->waitq, thread);
-	}
+	thread->base.pended_on = wait_q;
+	_priq_wait_add(&wait_q->waitq, thread);
 }
 
 static void add_thread_timeout(struct k_thread *thread, k_timeout_t timeout)
@@ -601,7 +599,7 @@ static void pend_locked(struct k_thread *thread, _wait_q_t *wait_q,
 			k_timeout_t timeout)
 {
 #ifdef CONFIG_KERNEL_COHERENCE
-	__ASSERT_NO_MSG(wait_q == NULL || arch_mem_coherent(wait_q));
+	__ASSERT_NO_MSG(arch_mem_coherent(wait_q));
 #endif /* CONFIG_KERNEL_COHERENCE */
 	add_to_waitq_locked(thread, wait_q);
 	add_thread_timeout(thread, timeout);


### PR DESCRIPTION
Removes a questionable optimization trick in the mailbox implementation that allowed a sender to "pend" without actually being on any wait queue. Removing this "trick" allows add_to_waitq_locked() to be slightly streamlined.