### PR TITLE
drivers: spi: stm32h7: Avoid unnecessary FIFO flush

### DIFF
--- a/drivers/spi/spi_ll_stm32.c
+++ b/drivers/spi/spi_ll_stm32.c
@@ -823,13 +823,6 @@ static int transceive(const struct device *dev,
 
 #endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi) */
 
-#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32_spi_fifo)
-	/* Flush RX buffer */
-	while (ll_func_rx_is_not_empty(spi)) {
-		(void) LL_SPI_ReceiveData8(spi);
-	}
-#endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32_spi_fifo) */
-
 	LL_SPI_Enable(spi);
 
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)

--- a/drivers/spi/spi_ll_stm32.h
+++ b/drivers/spi/spi_ll_stm32.h
@@ -218,12 +218,13 @@ static inline void ll_func_set_fifo_threshold_16bit(SPI_TypeDef *spi)
 
 static inline void ll_func_disable_spi(SPI_TypeDef *spi)
 {
-#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
+#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32_spi_fifo)
 	/* Flush RX buffer */
-	while (LL_SPI_IsActiveFlag_RXP(spi)) {
-		(void)LL_SPI_ReceiveData8(spi);
+	while (ll_func_rx_is_not_empty(spi)) {
+		(void) LL_SPI_ReceiveData8(spi);
 	}
-#endif /* st_stm32h7_spi */
+#endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32_spi_fifo) */
+
 	LL_SPI_Disable(spi);
 
 	while (LL_SPI_IsEnabled(spi)) {


### PR DESCRIPTION
This is a proposal to simplify the logic of the stm32 SPI driver. It has been tested by running the loopback tests on a H753 development board.

The stm32 SPI driver performs an RxFIFO flush before starting to transmit for devices that have FIFO, and again at the end of the transaction only for H7 devices.

According to the H7 datasheet, the RxFIFO does need to be flushed at the end of each transaction, but not at the beginning of the next one:

![spi_disable_marked](https://github.com/user-attachments/assets/af034cc6-67e9-4a65-bfa6-ddb9498a3732)

The H7 errata sheet doesn't mention anything about flushing the RxFIFO before transmitting either.

This PR proposes to flush the RxFIFO only at the end of the transaction for any device that has a FIFO, not only H7s.

However, notice:
 * This unnecessary flush is not causing problems at the moment as far as I know, other than a potential extra delay between transactions and make the logic more complex than necessary.
 * It has only been tested on H7 platforms.

Test plan
=========
Run all the spi_loppback tests, with and without DMA/IRQs enabled, and with and without enabling the FIFO usage. That is:

Connect an STM32H7 board to the PC with pins D11 and D12 connected.

Open a minicom or equivalent terminal to read the test report.

Execute the following commands:

```
cd zephyrproject/zephyr

rm -rf zephyrproject/zephyr/build
west build -p auto -b nucleo_h753zi tests/drivers/spi/spi_loopback
west flash

rm -rf zephyrproject/zephyr/build
west build -p auto -b nucleo_h753zi -T tests/drivers/spi/spi_loopback/drivers.spi.stm32_spi_16bits_frames.loopback
west flash

rm -rf zephyrproject/zephyr/build
west build -p auto -b nucleo_h753zi -T tests/drivers/spi/spi_loopback/drivers.spi.stm32_spi_dma.loopback
west flash

rm -rf zephyrproject/zephyr/build
west build -p auto -b nucleo_h753zi -T tests/drivers/spi/spi_loopback/drivers.spi.stm32_spi_16bits_frames_dma.loopback
west flash

rm -rf zephyrproject/zephyr/build
west build -p auto -b nucleo_h753zi -T tests/drivers/spi/spi_loopback/drivers.spi.stm32_spi_dma_dt_nocache_mem.loopback
west flash

rm -rf zephyrproject/zephyr/build
west build -p auto -b nucleo_h753zi -T tests/drivers/spi/spi_loopback/drivers.spi.stm32_spi_16bits_frames_dma_dt_nocache_mem.loopback
west flash

rm -rf ~/Repositories/zephyrproject/zephyr/build
west build -p auto -b nucleo_h753zi -T tests/drivers/spi/spi_loopback/drivers.spi.stm32_spi_interrupt.loopback
west flash
```

Execute the commands above, this time with the SPI fifo enabled. To do this, add `fifo-enable;` to the spi1 node in `tests/drivers/spi/spi_loopback/overlay-stm32-spi-16bits.overlay` and in `tests/drivers/spi/spi_loopback/boards/nucleo_h753zi.overlay`