### PR TITLE
board:pandora_stm32l475: fix flash write command for w25q128jv

### DIFF
--- a/boards/alientek/pandora_stm32l475/pandora_stm32l475.dts
+++ b/boards/alientek/pandora_stm32l475/pandora_stm32l475.dts
@@ -83,6 +83,7 @@
 			qspi-max-frequency = <80000000>;
 			jedec-id = [ef 40 18];
 			spi-bus-width = <4>;
+			writeoc = "PP_1_1_4";
 			status = "okay";
 	};
 };


### PR DESCRIPTION
w25q128jv only supports quad input page program instruction 0x32 (PP_1_1_4), and does not support 0x38 (PP_1_4_4).

w251128jv Datasheet:
https://www.mouser.com/datasheet/2/949/w25q128jv_revf_03272018_plus-1489608.pdf?srsltid=AfmBOoqBbPqhNSedqtemhJv9-8pwEkfgmtRdAnt1ncE5k35Tn2a6fg_d