### PR TITLE
DRAFT: Add specifically-named child nodes to DT bindings

### DIFF
--- a/scripts/dts/python-devicetree/src/devicetree/edtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/edtlib.py
@@ -243,6 +243,19 @@ class Binding:
         else:
             self.child_binding = None
 
+        self.child_nodes: Dict[str, 'Binding'] = {}
+        if "child-nodes" in raw:
+            #breakpoint()
+            if not (isinstance(raw["child-nodes"], list) and \
+                    all(isinstance(child_node, dict) for child_node in raw["child-nodes"])):
+                _err(f"malformed 'child-nodes:' in {self.path}, "
+                     "expected a sequence of bindings (list of dictionaries)")
+            for child_node in raw["child-nodes"]:
+                self.child_nodes[child_node["name"]]: Optional['Binding'] = Binding(
+                        path, fname2path, child_node,
+                        require_compatible=False, require_description=False)
+
+
         # Make sure this is a well defined object.
         self._check(require_compatible, require_description)
 
@@ -479,7 +492,7 @@ class Binding:
         # Allowed top-level keys. The 'include' key should have been
         # removed by _load_raw() already.
         ok_top = {"description", "compatible", "bus", "on-bus",
-                  "properties", "child-binding"}
+                  "properties", "child-binding", "child-nodes", "name"}
 
         # Descriptive errors for legacy bindings.
         legacy_errors = {
@@ -1442,6 +1455,9 @@ class Node:
         pbinding = self.parent._binding
         if not pbinding:
             return None
+
+        if pbinding.child_nodes and self.name in pbinding.child_nodes:
+            return pbinding.child_nodes[self.name]
 
         if pbinding.child_binding:
             return pbinding.child_binding


### PR DESCRIPTION
In dtschema (DT binding language used by other projects such as linux), it is possible to declare a child node as a "property" of another node, basically like this:

```yaml
properties:
  child-node:
    $ref: "child-schema.yaml#"
    description: | 
      This property is appears as a child node with the node name "child-node" in the DTS.
```

Example: 
[Panels](https://www.kernel.org/doc/Documentation/devicetree/bindings/display/panel/panel-common.yaml ) including [display-timing](https://www.kernel.org/doc/Documentation/devicetree/bindings/display/panel/display-timings.yaml) as a property

Zephyr only has child-binding, which currently applies to all child nodes without a compatible, so in order to process the devicetree properly, we require to put a compatible property string on the display-timing node, which we then don't even use anywhere in the C code in tree. This is therefore then a minor source incompatibility with other projects like linux.
https://docs.zephyrproject.org/latest/build/dts/api/bindings/display/panel/panel-timing.html

To fix this, in zephyr DT python tooling, it seems like it would be easier to introduce this DTS semantic/syntax capability in a different way, by making a new top level key in the zephyr DT bindings that is a list of child nodes with specific names, instead of as a property, like this:

```yaml
child-nodes:
  - name: some-child-node1
    include: "some-binding.yaml"
  - name: some-child-node2
    properties:
        some-child-prop:
          type: int
          description: |
            The child node binding can be declared like any other binding.
```

This draft shows a basic attempt at doing that that which is not really meant for serious code review right now, I just whipped this together in a few minutes, but I am looking for any feedback on the idea before I go off and try to implement it more seriously and show some examples and write documentation and test cases.