### PR TITLE
samples: dac: add arduino_giga_r1 overlay

### DIFF
--- a/samples/drivers/dac/boards/arduino_giga_r1_stm32h747xx_m7.overlay
+++ b/samples/drivers/dac/boards/arduino_giga_r1_stm32h747xx_m7.overlay
@@ -1,0 +1,7 @@
+/ {
+	zephyr,user {
+		dac = <&dac1>;
+		dac-channel-id = <1>;
+		dac-resolution = <12>;
+	};
+};


### PR DESCRIPTION
This PR adds Arduino Giga R1 overlay in the dac sample. 
Arduino Giga R1 has a 3.5mm audio jack connected to the dac.