### PR TITLE
arch: arm: mmu: Make all device memory shareable

### DIFF
--- a/arch/arm/core/mmu/arm_mmu.c
+++ b/arch/arm/core/mmu/arm_mmu.c
@@ -304,13 +304,15 @@ static struct arm_mmu_perms_attrs arm_mmu_convert_attr_flags(uint32_t attrs)
 		perms_attrs.cacheable = 0;
 		perms_attrs.domain    = ARM_MMU_DOMAIN_DEVICE;
 
-		if (attrs & MATTR_SHARED) {
-			perms_attrs.tex        = 0;
-			perms_attrs.bufferable = 1;
-		} else {
-			perms_attrs.tex        = 2;
-			perms_attrs.bufferable = 0;
-		}
+		/*
+		 * ARM deprecates the marking of Device memory with a
+		 * shareability attribute other than Outer Shareable
+		 * or Shareable. This means ARM strongly recommends
+		 * that Device memory is never assigned a shareability
+		 * attribute of Non-shareable or Inner Shareable.
+		 */
+		perms_attrs.tex        = 0;
+		perms_attrs.bufferable = 1;
 	} else if (attrs & MT_NORMAL) {
 		/*
 		 * TEX[2] is always 1. TEX[1:0] contain the outer cache attri-


### PR DESCRIPTION
ARM has deprecated usage of non-shareable device memory. K_MEM_CACHE_NONE flag used by devices to map physical memory translates to MT_DEVICE but no MATTR_SHARED attribute is set in such a request. This results in mapping device memory that is non-shareable.

Depending on the memory interconnect of a SoC, mapping the device memory as non-shareable can prevent access to the device. Such behavior has been observed on the TI AM3358 SoC.

To comply with the ARM deprecation notice and prevent access issues to device memory, all device memory is mapped as shareable.