### PR TITLE
drivers: wifi: nxp: fix build error

### DIFF
--- a/drivers/wifi/nxp/nxp_wifi_drv.c
+++ b/drivers/wifi/nxp/nxp_wifi_drv.c
@@ -547,7 +547,7 @@ static int nxp_wifi_stop_ap(const struct device *dev)
 
 static int nxp_wifi_ap_config_params(const struct device *dev, struct wifi_ap_config_params *params)
 {
-	nxp_wifi_ret_t status = NXP_WIFI_RET_SUCCESS;
+	int status = NXP_WIFI_RET_SUCCESS;
 	int ret = WM_SUCCESS;
 	interface_t *if_handle = (interface_t *)dev->data;
 


### PR DESCRIPTION
Fix build error of undefined 'nxp_wifi_ret_t'.