### PR TITLE
boards: frdm_mcxc242: Add uart support

### DIFF
--- a/boards/nxp/frdm_mcxc242/frdm_mcxc242-pinctrl.dtsi
+++ b/boards/nxp/frdm_mcxc242/frdm_mcxc242-pinctrl.dtsi
@@ -16,6 +16,14 @@
 			slew-rate = "slow";
 		};
 	};
+	pinmux_uart2: pinmux_uart2 {
+		group0 {
+			pinmux = <UART2_RX_PTD2>,
+				<UART2_TX_PTD3>;
+			drive-strength = "low";
+			slew-rate = "slow";
+		};
+	};
 	pinmux_i2c1: pinmux_i2c1 {
 		group0 {
 			pinmux = <I2C1_SCL_PTD7>,

--- a/boards/nxp/frdm_mcxc242/frdm_mcxc242.dts
+++ b/boards/nxp/frdm_mcxc242/frdm_mcxc242.dts
@@ -122,6 +122,13 @@
 	pinctrl-names = "default";
 };
 
+&uart2 {
+	status = "disabled";
+	current-speed = <115200>;
+	pinctrl-0 = <&pinmux_uart2>;
+	pinctrl-names = "default";
+};
+
 i2c1: &i2c1 {
 	status = "okay";
 	pinctrl-0 = <&pinmux_i2c1>;

--- a/boards/nxp/frdm_mcxc242/frdm_mcxc242.yaml
+++ b/boards/nxp/frdm_mcxc242/frdm_mcxc242.yaml
@@ -16,6 +16,7 @@ toolchain:
   - xtools
 supported:
   - gpio
+  - uart
   - i2c
   - pwm
   - adc


### PR DESCRIPTION
Board frdm_mcxc242 does not have UART IP configured. Add UART configuration and pin control. Set state to disabled, as it serves as alternative to default LPUART0 or as second uart only. Add uart to supported features in yaml.