### PR TITLE
zbus: remove `k_malloc` dependency for `ZBUS_RUNTIME_OBSERVERS`

### DIFF
--- a/doc/releases/migration-guide-4.0.rst
+++ b/doc/releases/migration-guide-4.0.rst
@@ -521,5 +521,10 @@ JWT (JSON Web Token)
   The conversion to the PSA Crypto API is being done in preparation for the
   deprecation of TinyCrypt. (:github:`78243` and :github:`43712`)
 
+ZBus
+====
+
+ * :kconfig:option:`CONFIG_ZBUS_RUNTIME_OBSERVERS` no longer requires the system heap to exist.
+
 Architectures
 *************

--- a/doc/services/zbus/index.rst
+++ b/doc/services/zbus/index.rst
@@ -669,10 +669,10 @@ Sections <iterable_sections_api>` documentation for details). ZBus also implemen
                LOG_INF("      - %s", observation->obs->name);
          }
 
-         struct zbus_observer_node *obs_nd, *tmp;
+         struct zbus_observer_data *obs_d, *tmp;
 
-         SYS_SLIST_FOR_EACH_CONTAINER_SAFE(chan->observers, obs_nd, tmp, node) {
-               LOG_INF("      - %s", obs_nd->obs->name);
+         SYS_SLIST_FOR_EACH_CONTAINER_SAFE(chan->observers, obs_d, tmp, node) {
+               LOG_INF("      - %s", obs_d->obs->name);
          }
 
          return true;

--- a/include/zephyr/zbus/zbus.h
+++ b/include/zephyr/zbus/zbus.h
@@ -124,6 +124,13 @@ struct zbus_observer_data {
 	/** Subscriber attached thread priority. */
 	int priority;
 #endif /* CONFIG_ZBUS_PRIORITY_BOOST */
+
+#if defined(CONFIG_ZBUS_RUNTIME_OBSERVERS) || defined(__DOXYGEN__)
+	/* Pointer back to parent observer struct */
+	const struct zbus_observer *obs;
+	/* List iteration node */
+	sys_snode_t node;
+#endif /* CONFIG_ZBUS_RUNTIME_OBSERVERS */
 };
 
 /**
@@ -852,15 +859,6 @@ int zbus_chan_add_obs(const struct zbus_channel *chan, const struct zbus_observe
  */
 int zbus_chan_rm_obs(const struct zbus_channel *chan, const struct zbus_observer *obs,
 		     k_timeout_t timeout);
-
-/** @cond INTERNAL_HIDDEN */
-
-struct zbus_observer_node {
-	sys_snode_t node;
-	const struct zbus_observer *obs;
-};
-
-/** @endcond */
 
 #endif /* CONFIG_ZBUS_RUNTIME_OBSERVERS */
 

--- a/samples/subsys/zbus/hello_world/src/main.c
+++ b/samples/subsys/zbus/hello_world/src/main.c
@@ -113,10 +113,10 @@ static bool print_channel_data_iterator(const struct zbus_channel *chan, void *u
 		LOG_INF("      - %s", observation->obs->name);
 	}
 
-	struct zbus_observer_node *obs_nd, *tmp;
+	struct zbus_observer_data *obs_d, *tmp;
 
-	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&chan->data->observers, obs_nd, tmp, node) {
-		LOG_INF("      - %s", obs_nd->obs->name);
+	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&chan->data->observers, obs_d, tmp, node) {
+		LOG_INF("      - %s", obs_d->obs->name);
 	}
 
 	return true;

--- a/subsys/zbus/zbus.c
+++ b/subsys/zbus/zbus.c
@@ -172,12 +172,12 @@ static inline int _zbus_vded_exec(const struct zbus_channel *chan, k_timepoint_t
 
 #if defined(CONFIG_ZBUS_RUNTIME_OBSERVERS)
 	/* Dynamic observer event dispatcher logic */
-	struct zbus_observer_node *obs_nd, *tmp;
+	struct zbus_observer_data *obs_d, *tmp;
 
-	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&chan->data->observers, obs_nd, tmp, node) {
-		const struct zbus_observer *obs = obs_nd->obs;
+	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&chan->data->observers, obs_d, tmp, node) {
+		const struct zbus_observer *obs = obs_d->obs;
 
-		if (!obs->data->enabled) {
+		if (!obs_d->enabled) {
 			continue;
 		}
 

--- a/tests/subsys/zbus/runtime_observers_registration/src/main.c
+++ b/tests/subsys/zbus/runtime_observers_registration/src/main.c
@@ -113,15 +113,6 @@ ZTEST(basic, test_specification_based__zbus_obs_add_rm_obs)
 	zassert_equal(0, zbus_chan_add_obs(&chan2, &lis5, K_MSEC(200)), "It must add the obs");
 	zassert_equal(0, zbus_chan_add_obs(&chan2, &lis6, K_MSEC(200)), "It must add the obs");
 
-	/* Make the heap full */
-	void *mem;
-
-	do {
-		mem = k_malloc(1);
-	} while (mem != NULL);
-
-	/* With the heap full it will not be possible to add another obs */
-	zassert_equal(-ENOMEM, zbus_chan_add_obs(&chan2, &lis7, K_MSEC(200)), NULL);
 	zassert_equal(0, zbus_chan_pub(&chan2, &sd, K_MSEC(500)), NULL);
 	zassert_equal(count_callback2, 5, NULL);
 


### PR DESCRIPTION
Remove the dependency on the system heap existing when enabling `ZBUS_RUNTIME_OBSERVERS`. This means the overhead of the runtime list is applied to all observers in the system, instead of just the observers that are added at runtime. However this overhead is only 8 bytes per observer (2 pointers). It is unlikely that this overhead is larger than the cost of enabling the system heap for applications that don't already have it enabled.