### PR TITLE
bindesc.h: Include missing device.h

### DIFF
--- a/include/zephyr/bindesc.h
+++ b/include/zephyr/bindesc.h
@@ -147,6 +147,7 @@ extern "C" {
 #if !defined(_LINKER) || defined(__DOXYGEN__)
 
 #include <zephyr/sys/byteorder.h>
+#include <zephyr/device.h>
 
 /**
  * @cond INTERNAL_HIDDEN


### PR DESCRIPTION
bindesc.h did not explicitly include device.h. For some build scenarios this caused compilation warnings, failing the CI.