### PR TITLE
drivers: rtio: workq

### DIFF
--- a/drivers/sensor/asahi_kasei/akm09918c/akm09918c_async.c
+++ b/drivers/sensor/asahi_kasei/akm09918c/akm09918c_async.c
@@ -48,7 +48,12 @@ void akm09918c_submit(const struct device *dev, struct rtio_iodev_sqe *iodev_sqe
 {
 	struct rtio_work_req *req = rtio_work_req_alloc();
 
-	__ASSERT_NO_MSG(req);
+	if (req == NULL) {
+		LOG_ERR("RTIO work item allocation failed. Consider to increase "
+			"CONFIG_RTIO_WORKQ_POOL_ITEMS.");
+		rtio_iodev_sqe_err(iodev_sqe, -ENOMEM);
+		return;
+	}
 
 	rtio_work_req_submit(req, iodev_sqe, akm09918c_submit_sync);
 }

--- a/drivers/sensor/bosch/bma4xx/bma4xx.c
+++ b/drivers/sensor/bosch/bma4xx/bma4xx.c
@@ -444,7 +444,12 @@ static void bma4xx_submit(const struct device *dev, struct rtio_iodev_sqe *iodev
 {
 	struct rtio_work_req *req = rtio_work_req_alloc();
 
-	__ASSERT_NO_MSG(req);
+	if (req == NULL) {
+		LOG_ERR("RTIO work item allocation failed. Consider to increase "
+			"CONFIG_RTIO_WORKQ_POOL_ITEMS.");
+		rtio_iodev_sqe_err(iodev_sqe, -ENOMEM);
+		return;
+	}
 
 	rtio_work_req_submit(req, iodev_sqe, bma4xx_submit_sync);
 }

--- a/drivers/sensor/bosch/bme280/bme280_async.c
+++ b/drivers/sensor/bosch/bme280/bme280_async.c
@@ -76,7 +76,12 @@ void bme280_submit(const struct device *dev, struct rtio_iodev_sqe *iodev_sqe)
 {
 	struct rtio_work_req *req = rtio_work_req_alloc();
 
-	__ASSERT_NO_MSG(req);
+	if (req == NULL) {
+		LOG_ERR("RTIO work item allocation failed. Consider to increase "
+			"CONFIG_RTIO_WORKQ_POOL_ITEMS.");
+		rtio_iodev_sqe_err(iodev_sqe, -ENOMEM);
+		return;
+	}
 
 	rtio_work_req_submit(req, iodev_sqe, bme280_submit_sync);
 }

--- a/drivers/sensor/default_rtio_sensor.c
+++ b/drivers/sensor/default_rtio_sensor.c
@@ -265,7 +265,12 @@ static void sensor_submit_fallback(const struct device *dev, struct rtio_iodev_s
 {
 	struct rtio_work_req *req = rtio_work_req_alloc();
 
-	__ASSERT_NO_MSG(req);
+	if (req == NULL) {
+		LOG_ERR("RTIO work item allocation failed. Consider to increase "
+			"CONFIG_RTIO_WORKQ_POOL_ITEMS.");
+		rtio_iodev_sqe_err(iodev_sqe, -ENOMEM);
+		return;
+	}
 
 	rtio_work_req_submit(req, iodev_sqe, sensor_submit_fallback_sync);
 }

--- a/drivers/sensor/memsic/mmc56x3/mmc56x3_async.c
+++ b/drivers/sensor/memsic/mmc56x3/mmc56x3_async.c
@@ -80,7 +80,12 @@ void mmc56x3_submit(const struct device *dev, struct rtio_iodev_sqe *iodev_sqe)
 {
 	struct rtio_work_req *req = rtio_work_req_alloc();
 
-	__ASSERT_NO_MSG(req);
+	if (req == NULL) {
+		LOG_ERR("RTIO work item allocation failed. Consider to increase "
+			"CONFIG_RTIO_WORKQ_POOL_ITEMS.");
+		rtio_iodev_sqe_err(iodev_sqe, -ENOMEM);
+		return;
+	}
 
 	rtio_work_req_submit(req, iodev_sqe, mmc56x3_submit_sync);
 }

--- a/drivers/sensor/tdk/icm42688/icm42688_rtio.c
+++ b/drivers/sensor/tdk/icm42688/icm42688_rtio.c
@@ -97,7 +97,12 @@ void icm42688_submit(const struct device *dev, struct rtio_iodev_sqe *iodev_sqe)
 {
 	struct rtio_work_req *req = rtio_work_req_alloc();
 
-	__ASSERT_NO_MSG(req);
+	if (req == NULL) {
+		LOG_ERR("RTIO work item allocation failed. Consider to increase "
+			"CONFIG_RTIO_WORKQ_POOL_ITEMS.");
+		rtio_iodev_sqe_err(iodev_sqe, -ENOMEM);
+		return;
+	}
 
 	rtio_work_req_submit(req, iodev_sqe, icm42688_submit_sync);
 }

--- a/drivers/spi/spi_rtio.c
+++ b/drivers/spi/spi_rtio.c
@@ -104,7 +104,12 @@ void spi_rtio_iodev_default_submit(const struct device *dev,
 
 	struct rtio_work_req *req = rtio_work_req_alloc();
 
-	__ASSERT_NO_MSG(req);
+	if (req == NULL) {
+		LOG_ERR("RTIO work item allocation failed. Consider to increase "
+			"CONFIG_RTIO_WORKQ_POOL_ITEMS.");
+		rtio_iodev_sqe_err(iodev_sqe, -ENOMEM);
+		return;
+	}
 
 	rtio_work_req_submit(req, iodev_sqe, spi_rtio_iodev_default_submit_sync);
 }


### PR DESCRIPTION
Inform the executor of a submissions completion with -ENOMEM if the size of the workq is not big enough.