### PR TITLE
drivers: ieee802154_nrf5: support selective TX channel

### DIFF
--- a/drivers/ieee802154/Kconfig
+++ b/drivers/ieee802154/Kconfig
@@ -92,6 +92,11 @@ config IEEE802154_CSL_DEBUG
 	help
 	  Enable support for CSL debugging by avoiding sleep state in favor of receive state.
 
+config IEEE802154_SELECTIVE_TXCHANNEL
+	bool "Support selective TX channel setting"
+	help
+	  Enable support for selectively setting TX channel for every transmission request.
+
 module = IEEE802154_DRIVER
 module-str = IEEE 802.15.4 driver
 module-help = Sets log level for IEEE 802.15.4 Device Drivers.

--- a/drivers/ieee802154/ieee802154_nrf5.c
+++ b/drivers/ieee802154/ieee802154_nrf5.c
@@ -486,6 +486,10 @@ static bool nrf5_tx_immediate(struct net_pkt *pkt, uint8_t *payload, bool cca)
 		},
 	};
 
+#if defined(CONFIG_IEEE802154_SELECTIVE_TXCHANNEL)
+	nrf_802154_channel_set(net_pkt_ieee802154_txchannel(pkt));
+#endif
+
 	return nrf_802154_transmit_raw(payload, &metadata);
 }
 
@@ -502,6 +506,10 @@ static bool nrf5_tx_csma_ca(struct net_pkt *pkt, uint8_t *payload)
 			.power = nrf5_data.txpwr,
 		},
 	};
+
+#if defined(CONFIG_IEEE802154_SELECTIVE_TXCHANNEL)
+	nrf_802154_channel_set(net_pkt_ieee802154_txchannel(pkt));
+#endif
 
 	return nrf_802154_transmit_csma_ca_raw(payload, &metadata);
 }
@@ -540,7 +548,11 @@ static bool nrf5_tx_at(struct nrf5_802154_data *nrf5_radio, struct net_pkt *pkt,
 			.dynamic_data_is_set = net_pkt_ieee802154_mac_hdr_rdy(pkt),
 		},
 		.cca = cca,
+#if defined(CONFIG_IEEE802154_SELECTIVE_TXCHANNEL)
+		.channel = net_pkt_ieee802154_txchannel(pkt),
+#else
 		.channel = nrf_802154_channel_get(),
+#endif
 		.tx_power = {
 			.use_metadata_value = true,
 			.power = nrf5_data.txpwr,

--- a/include/zephyr/net/ieee802154_pkt.h
+++ b/include/zephyr/net/ieee802154_pkt.h
@@ -59,6 +59,12 @@ struct net_pkt_cb_ieee802154 {
 			 */
 			uint8_t rssi;
 		};
+		/* TX packets */
+		struct {
+#if defined(CONFIG_IEEE802154_SELECTIVE_TXCHANNEL)
+			uint8_t txchannel; /* TX channel (channel page 0, 2.4GHz only) */
+#endif /* CONFIG_IEEE802154_SELECTIVE_TXCHANNEL */
+		};
 	};
 
 	/* Flags */
@@ -178,6 +184,18 @@ static inline void net_pkt_set_ieee802154_rssi_dbm(struct net_pkt *pkt, int16_t 
 
 	CODE_UNREACHABLE;
 }
+
+#if defined(CONFIG_IEEE802154_SELECTIVE_TXCHANNEL)
+static inline uint8_t net_pkt_ieee802154_txchannel(struct net_pkt *pkt)
+{
+	return net_pkt_cb_ieee802154(pkt)->txchannel;
+}
+
+static inline void net_pkt_set_ieee802154_txchannel(struct net_pkt *pkt, uint8_t channel)
+{
+	net_pkt_cb_ieee802154(pkt)->txchannel = channel;
+}
+#endif /* CONFIG_IEEE802154_SELECTIVE_TXCHANNEL */
 
 static inline bool net_pkt_ieee802154_ack_fpb(struct net_pkt *pkt)
 {

--- a/modules/openthread/platform/radio.c
+++ b/modules/openthread/platform/radio.c
@@ -396,8 +396,13 @@ void transmit_message(struct k_work *tx_job)
 
 	channel = sTransmitFrame.mChannel;
 
-	radio_api->set_channel(radio_dev, channel);
 	radio_api->set_txpower(radio_dev, get_transmit_power_for_channel(channel));
+
+#if defined(CONFIG_IEEE802154_SELECTIVE_TXCHANNEL)
+	net_pkt_set_ieee802154_txchannel(tx_pkt, channel);
+#else
+	radio_api->set_channel(radio_dev, channel);
+#endif /* CONFIG_IEEE802154_SELECTIVE_TXCHANNEL */
 
 #if defined(CONFIG_OPENTHREAD_TIME_SYNC)
 	if (sTransmitFrame.mInfo.mTxInfo.mIeInfo->mTimeIeOffset != 0) {


### PR DESCRIPTION
Add IEEE802154_SELECTIVE_TXCHANNEL Kconfig option to support setting TX channel independently for each transmitted packet. Use this feature in OpenThread radio implementation to keep listening on the current channel even if the next frame is scheduled on a different channel.

FYI: @Damian-Nordic 