### PR TITLE
net: openthread: add Kconfig for CSL request time ahead

### DIFF
--- a/modules/openthread/Kconfig.thread
+++ b/modules/openthread/Kconfig.thread
@@ -81,6 +81,12 @@ config OPENTHREAD_CSL_AUTO_SYNC
 	bool "CSL autosync"
 	default y if OPENTHREAD_CSL_RECEIVER
 
+config OPENTHREAD_CSL_REQUEST_TIME_AHEAD
+	int "CSL transmitter request time ahead"
+	default 2000
+	help
+	  Defines how many microseconds ahead should MAC deliver a CSL frame to the sub-MAC layer.
+
 config OPENTHREAD_CSL_RECEIVE_TIME_AHEAD
 	int "CSL receiver wake up margin in microseconds"
 	default 5000

--- a/modules/openthread/platform/openthread-core-zephyr-config.h
+++ b/modules/openthread/platform/openthread-core-zephyr-config.h
@@ -284,6 +284,16 @@
 #define RADIO_CONFIG_SRC_MATCH_EXT_ENTRY_NUM 0
 
 /**
+ * @def OPENTHREAD_CONFIG_MAC_CSL_REQUEST_AHEAD_US
+ *
+ * Define how many microseconds ahead should MAC deliver CSL frame to SubMac.
+ *
+ */
+#ifdef CONFIG_OPENTHREAD_CSL_REQUEST_TIME_AHEAD
+#define OPENTHREAD_CONFIG_MAC_CSL_REQUEST_AHEAD_US CONFIG_OPENTHREAD_CSL_REQUEST_TIME_AHEAD
+#endif /* CONFIG_OPENTHREAD_CSL_REQUEST_TIME_AHEAD */
+
+/**
  * @def OPENTHREAD_CONFIG_CSL_RECEIVE_TIME_AHEAD
  *
  * For some reasons, CSL receivers wake up a little later than expected. This


### PR DESCRIPTION
Add OPENTHREAD_CSL_REQUEST_TIME_AHEAD Kconfig variable.

FYI: @Damian-Nordic 