### PR TITLE
west.yml: MCUboot synchronization from upstream

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -285,7 +285,7 @@ manifest:
       groups:
         - crypto
     - name: mcuboot
-      revision: 3a195f2207d5eadf45a5c989a870e91aff020d86
+      revision: b9d69dd2a2d6df32da6608d549138288bb7d7aa5
       path: bootloader/mcuboot
       groups:
         - bootloader


### PR DESCRIPTION
Update Zephyr fork of MCUboot to revision:
  b9d69dd2a2d6df32da6608d549138288bb7d7aa5

Brings following Zephyr relevant fixes:
  - b9d69dd2 zephyr: print version number before boot
  - 08a71d10 boot: bootutil: swap_scratch: Fix compressed image sector size check
  - d69933cd scripts: imgtool: compression ARM thumb filter
  - a5f28c13 bootutil: Add SHA-512 support to Ed25519
  - 601463db bootutil: Add SHA-512 support with mbedTLS
  - f1f557fd zephyr: Fixing Kconfig dependency for SHA512
  - 5c21093a boot: zephyr: use EXTRA_CONF_FILE instead of deprecated OVERLAY_CONFIG
  - b233228a samples: zephyr: add sysbuild to the hello-world sample
  - a91a6156 boot: zephyr: Fix serial recovery for NXP IMX.RT platforms
  - a967c66e boot: zephyr: Fix Warning 'boot_serial_enter defined but not used'
  - a5e3d163 zephyr: hello_world: Fix the main() return type warning
  - 63fa7e45 scripts: imgtool: compression
  - 30bcd468 bootutil: Add SIG_PURE TLV
  - 8f759f2e boot: Replace boot_encrypt by boot_enc_encrypt and boot_enc_decrypt
  - c894d047 imgtool: Add support for calculating SHA512

Notes on process:
 1) The MCUboot update from [mcu-tools/mcuboot/main](https://github.com/mcu-tools/mcuboot/tree/main) with the SHA used in west.yaml is already synchronized to [zephyrproject-rtos/mcuboot/upstream-sync](https://github.com/zephyrproject-rtos/mcuboot/tree/upstream-sync) branch, and is available in the Zephyr fork of MCUboot.
 2) The [DNM] on this PR should be kept until the PR passes all tests and is accepted.
 3) Once the PR passes all tests and gets accepted, the upstream-sync branch should be fast-forward merged to [zephyrproject-rtos/mcuboot/main](https://github.com/zephyrproject-rtos/mcuboot/tree/main) branch and [DNM] should be removed.
 4) After the main branch gets updated, this PR does not require further changes and should be merged as is.