### PR TITLE
doc: vulnerabilities: use :cve: role to link to CVEs

### DIFF
--- a/doc/security/vulnerabilities.rst
+++ b/doc/security/vulnerabilities.rst
@@ -465,7 +465,7 @@ Improper Input Frame Validation in ieee802154 Processing
 - `CVE-2020-10064 <http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-10064>`_
 
 - `Zephyr project bug tracker ZEPSEC-65
-  <https://zephyrprojectsec.atlasssian.net/browse/ZEPSEC-65>`_
+  <https://zephyrprojectsec.atlassian.net/browse/ZEPSEC-65>`_
 
 - `PR24971 fix for v2.4
   <https://github.com/zephyrproject-rtos/zephyr/pull/24971>`_
@@ -483,7 +483,7 @@ bluetooth HCI over SPI driver.
 - `CVE-2020-10065 <http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-10065>`_
 
 - `Zephyr project bug tracker ZEPSEC-66
-  <https://zephyrprojectsec.atlasssian.net/browse/ZEPSEC-66>`_
+  <https://zephyrprojectsec.atlassian.net/browse/ZEPSEC-66>`_
 
 - This issue has not been fixed.
 
@@ -498,7 +498,7 @@ nullpointer dereference.
 - `CVE-2020-10066 <http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-10066>`_
 
 - `Zephyr project bug tracker ZEPSEC-67
-  <https://zephyrprojectsec.atlasssian.net/browse/ZEPSEC-67>`_
+  <https://zephyrprojectsec.atlassian.net/browse/ZEPSEC-67>`_
 
 - `PR24902 fix for v2.4
   <https://github.com/zephyrproject-rtos/zephyr/pull/24902>`_
@@ -650,7 +650,7 @@ descriptor.
 - `CVE-2020-10072 <http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-10072>`_
 
 - `Zephyr project bug tracker ZEPSEC-87
-  <https://zephyrprojectsec.atlasssian.net/browse/ZEPSEC-87>`_
+  <https://zephyrprojectsec.atlassian.net/browse/ZEPSEC-87>`_
 
 - `PR25804 fix for v2.4
   <https://github.com/zephyrproject-rtos/zephyr/pull/25804>`_
@@ -679,7 +679,7 @@ characters long will cause a buffer overflow.
 - `CVE-2020-13598 <http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-13598>`_
 
 - `Zephyr project bug tracker ZEPSEC-88
-  <https://zephyrprojectsec.atlasssian.net/browse/ZEPSEC-88>`_
+  <https://zephyrprojectsec.atlassian.net/browse/ZEPSEC-88>`_
 
 - `PR25852 fix for v2.4
   <https://github.com/zephyrproject-rtos/zephyr/pull/25852>`_
@@ -703,7 +703,7 @@ app keys from the device.
 - `CVE-2020-13599 <http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-13599>`_
 
 - `Zephyr project bug tracker ZEPSEC-57
-  <https://zephyrprojectsec.atlasssian.net/browse/ZEPSEC-57>`_
+  <https://zephyrprojectsec.atlassian.net/browse/ZEPSEC-57>`_
 
 - `PR26083 fix for v2.4
   <https://github.com/zephyrproject-rtos/zephyr/pull/26083>`_
@@ -749,7 +749,7 @@ infinite loop, resulting in a denial of service attack.
 - `CVE-2020-13602 <http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-13602>`_
 
 - `Zephyr project bug tracker ZEPSEC-56
-  <https://zephyrprojectsec.atlasssian.net/browse/ZEPSEC-56>`_
+  <https://zephyrprojectsec.atlassian.net/browse/ZEPSEC-56>`_
 
 - `PR26571 fix for v2.4
   <https://github.com/zephyrproject-rtos/zephyr/pull/26571>`_

--- a/doc/security/vulnerabilities.rst
+++ b/doc/security/vulnerabilities.rst
@@ -14,12 +14,10 @@ lifted.
 CVE-2017
 ========
 
-CVE-2017-14199
---------------
+:cve:`2017-14199`
+-----------------
 
 Buffer overflow in :code:`getaddrinfo()`.
-
-- `CVE-2017-14199 <http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-14199>`_
 
 - `Zephyr project bug tracker ZEPSEC-12
   <https://zephyrprojectsec.atlassian.net/browse/ZEPSEC-12>`_
@@ -27,8 +25,8 @@ Buffer overflow in :code:`getaddrinfo()`.
 - `PR6158 fix for 1.11.0
   <https://github.com/zephyrproject-rtos/zephyr/pull/6158>`_
 
-CVE-2017-14201
---------------
+:cve:`2017-14201`
+-----------------
 
 The shell DNS command can cause unpredictable results due to misuse of
 stack variables.
@@ -39,16 +37,14 @@ code execution.
 
 This has been fixed in release v1.14.0.
 
-- `CVE-2017-14201 <http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-14201>`_
-
 - `Zephyr project bug tracker ZEPSEC-17
   <https://zephyrprojectsec.atlassian.net/browse/ZEPSEC-17>`_
 
 - `PR13260 fix for v1.14.0
   <https://github.com/zephyrproject-rtos/zephyr/pull/13260>`_
 
-CVE-2017-14202
---------------
+:cve:`2017-14202`
+-----------------
 
 The shell implementation does not protect against buffer overruns
 resulting in unpredictable behavior.
@@ -60,8 +56,6 @@ code execution.
 
 This has been fixed in release v1.14.0.
 
-- `CVE-2017-14202 <http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-14202>`_
-
 - `Zephyr project bug tracker ZEPSEC-18
   <https://zephyrprojectsec.atlassian.net/browse/ZEPSEC-18>`_
 
@@ -71,16 +65,14 @@ This has been fixed in release v1.14.0.
 CVE-2019
 ========
 
-CVE-2019-9506
--------------
+:cve:`2019-9506`
+----------------
 
 The Bluetooth BR/EDR specification up to and including version 5.1
 permits sufficiently low encryption key length and does not prevent an
 attacker from influencing the key length negotiation. This allows
 practical brute-force attacks (aka "KNOB") that can decrypt traffic
 and inject arbitrary ciphertext without the victim noticing.
-
-- `CVE-2019-9506 <http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-9506>`_
 
 - `Zephyr project bug tracker ZEPSEC-20
   <https://zephyrprojectsec.atlassian.net/browse/ZEPSEC-20>`_
@@ -94,15 +86,13 @@ and inject arbitrary ciphertext without the victim noticing.
 CVE-2020
 ========
 
-CVE-2020-10019
---------------
+:cve:`2020-10019`
+-----------------
 
 Buffer Overflow vulnerability in USB DFU of zephyr allows a USB
 connected host to cause possible remote code execution.
 
 This has been fixed in releases v1.14.2, v2.2.0, and v2.1.1.
-
-- `CVE-2020-10019 <http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-10019>`_
 
 - `Zephyr project bug tracker ZEPSEC-25
   <https://zephyrprojectsec.atlassian.net/browse/ZEPSEC-25>`_
@@ -116,8 +106,8 @@ This has been fixed in releases v1.14.2, v2.2.0, and v2.1.1.
 - `PR23190 fix in 2.2.0
   <https://github.com/zephyrproject-rtos/zephyr/pull/23190>`_
 
-CVE-2020-10021
---------------
+:cve:`2020-10021`
+-----------------
 
 Out-of-bounds write in USB Mass Storage with unaligned sizes
 
@@ -127,8 +117,6 @@ unaligned Sizes.
 See NCC-ZEP-024, NCC-ZEP-025, NCC-ZEP-026
 
 This has been fixed in releases v1.14.2, and v2.2.0.
-
-- `CVE-2020-10021 <http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-10021>`_
 
 - `Zephyr project bug tracker ZEPSEC-26
   <https://zephyrprojectsec.atlassian.net/browse/ZEPSEC-26>`_
@@ -142,8 +130,8 @@ This has been fixed in releases v1.14.2, and v2.2.0.
 - `PR23240 fix for v2.2.0
   <https://github.com/zephyrproject-rtos/zephyr/pull/23240>`_
 
-CVE-2020-10022
---------------
+:cve:`2020-10022`
+-----------------
 
 UpdateHub Module Copies a Variable-Size Hash String Into a Fixed-Size Array
 
@@ -157,8 +145,6 @@ See NCC-ZEP-016
 This has been fixed in the below pull requests for main, branch from
 v2.1.0, and branch from v2.2.0.
 
-- `CVE-2020-10022 <http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-10022>`_
-
 - `Zephyr project bug tracker ZEPSEC-28
   <https://zephyrprojectsec.atlassian.net/browse/ZEPSEC-28>`_
 
@@ -171,8 +157,8 @@ v2.1.0, and branch from v2.2.0.
 - `PR24066 fix for branch from v2.2.0
   <https://github.com/zephyrproject-rtos/zephyr/pull/24066>`_
 
-CVE-2020-10023
---------------
+:cve:`2020-10023`
+-----------------
 
 Shell Subsystem Contains a Buffer Overflow Vulnerability In
 shell_spaces_trim
@@ -187,8 +173,6 @@ See NCC-ZEP-019
 This has been fixed in releases v1.14.2, v2.2.0, and in a branch from
 v2.1.0,
 
-- `CVE-2020-10023 <http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-10023>`_
-
 - `Zephyr project bug tracker ZEPSEC-29
   <https://zephyrprojectsec.atlassian.net/browse/ZEPSEC-29>`_
 
@@ -201,8 +185,8 @@ v2.1.0,
 - `PR23304 fix for v2.2.0
   <https://github.com/zephyrproject-rtos/zephyr/pull/23304>`_
 
-CVE-2020-10024
---------------
+:cve:`2020-10024`
+-----------------
 
 ARM Platform Uses Signed Integer Comparison When Validating Syscall
 Numbers
@@ -217,8 +201,6 @@ See NCC-ZEP-001
 This has been fixed in releases v1.14.2, and v2.2.0, and in a branch
 from v2.1.0,
 
-- `CVE-2020-10024 <http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-10024>`_
-
 - `Zephyr project bug tracker ZEPSEC-30
   <https://zephyrprojectsec.atlassian.net/browse/ZEPSEC-30>`_
 
@@ -231,8 +213,8 @@ from v2.1.0,
 - `PR23323 fix for v2.2.0
   <https://github.com/zephyrproject-rtos/zephyr/pull/23323>`_
 
-CVE-2020-10027
---------------
+:cve:`2020-10027`
+-----------------
 
 ARC Platform Uses Signed Integer Comparison When Validating Syscall
 Numbers
@@ -244,8 +226,6 @@ See NCC-ZEP-001
 
 This has been fixed in releases v1.14.2, and v2.2.0, and in a branch
 from v2.1.0.
-
-- `CVE-2020-10027 <http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-10027>`_
 
 - `Zephyr project bug tracker ZEPSEC-35
   <https://zephyrprojectsec.atlassian.net/browse/ZEPSEC-35>`_
@@ -259,8 +239,8 @@ from v2.1.0.
 - `PR23328 fix for v2.2.0
   <https://github.com/zephyrproject-rtos/zephyr/pull/23328>`_
 
-CVE-2020-10028
---------------
+:cve:`2020-10028`
+-----------------
 
 Multiple Syscalls In GPIO Subsystem Performs No Argument Validation
 
@@ -270,8 +250,6 @@ See NCC-ZEP-006
 
 This has been fixed in releases v1.14.2, and v2.2.0, and in a branch
 from v2.1.0.
-
-- `CVE-2020-10028 <http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-10028>`_
 
 - `Zephyr project bug tracker ZEPSEC-32
   <https://zephyrprojectsec.atlassian.net/browse/ZEPSEC-32>`_
@@ -285,8 +263,8 @@ from v2.1.0.
 - `PR23308 fix for v2.2.0 (gpio patch)
   <https://github.com/zephyrproject-rtos/zephyr/pull/23308>`_
 
-CVE-2020-10058
---------------
+:cve:`2020-10058`
+-----------------
 
 Multiple Syscalls In kscan Subsystem Performs No Argument Validation
 
@@ -298,8 +276,6 @@ See NCC-ZEP-006
 
 This has been fixed in a branch from v2.1.0, and release v2.2.0.
 
-- `CVE-2020-10058 <http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-10058>`_
-
 - `Zephyr project bug tracker ZEPSEC-34
   <https://zephyrprojectsec.atlassian.net/browse/ZEPSEC-34>`_
 
@@ -309,8 +285,8 @@ This has been fixed in a branch from v2.1.0, and release v2.2.0.
 - `PR23308 fix for v2.2.0 (kscan patch)
   <https://github.com/zephyrproject-rtos/zephyr/pull/23308>`_
 
-CVE-2020-10059
---------------
+:cve:`2020-10059`
+-----------------
 
 UpdateHub Module Explicitly Disables TLS Verification
 
@@ -322,8 +298,6 @@ without the peer checking.
 See NCC-ZEP-018
 
 This has been fixed in a PR against Zephyr main.
-
-- `CVE-2020-10059 <http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-10059>`_
 
 - `Zephyr project bug tracker ZEPSEC-36
   <https://zephyrprojectsec.atlassian.net/browse/ZEPSEC-36>`_
@@ -337,8 +311,8 @@ This has been fixed in a PR against Zephyr main.
 - `PR24954 fix v2.2.0
   <https://github.com/zephyrproject-rtos/zephyr/pull/24997>`_
 
-CVE-2020-10060
---------------
+:cve:`2020-10060`
+-----------------
 
 UpdateHub Might Dereference An Uninitialized Pointer
 
@@ -355,8 +329,6 @@ See NCC-ZEP-030
 
 This has been fixed in a PR against Zephyr main.
 
-- `CVE-2020-10060 <http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-10060>`_
-
 - `Zephyr project bug tracker ZEPSEC-37
   <https://zephyrprojectsec.atlassian.net/browse/ZEPSEC-37>`_
 
@@ -372,8 +344,8 @@ This has been fixed in a PR against Zephyr main.
 - `PR27865 fix for v2.1.0
   <https://github.com/zephyrproject-rtos/zephyr/pull/27893>`_
 
-CVE-2020-10061
---------------
+:cve:`2020-10061`
+-----------------
 
 Error handling invalid packet sequence
 
@@ -382,8 +354,6 @@ implementation can result in memory corruption.
 
 This has been fixed in branches for v1.14.0, v2.2.0, and will be
 included in v2.3.0.
-
-- `CVE-2020-10061 <http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-10061>`_
 
 - `Zephyr project bug tracker ZEPSEC-75
   <https://zephyrprojectsec.atlassian.net/browse/ZEPSEC-75>`_
@@ -400,8 +370,8 @@ included in v2.3.0.
 - `PR23547 fix for branch from v2.2.0
   <https://github.com/zephyrproject-rtos/zephyr/pull/23547>`_
 
-CVE-2020-10062
---------------
+:cve:`2020-10062`
+-----------------
 
 Packet length decoding error in MQTT
 
@@ -415,8 +385,6 @@ cause an integer overflow, resulting in memory corruption.
 
 This has been fixed in main for v2.3.
 
-- `CVE-2020-10062 <http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-10062>`_
-
 - `Zephyr project bug tracker ZEPSEC-84
   <https://zephyrprojectsec.atlassian.net/browse/ZEPSEC-84>`_
 
@@ -427,8 +395,8 @@ This has been fixed in main for v2.3.
 
 .. _NCC-ZEP report: https://research.nccgroup.com/2020/05/26/research-report-zephyr-and-mcuboot-security-assessment
 
-CVE-2020-10063
---------------
+:cve:`2020-10063`
+-----------------
 
 Remote Denial of Service in CoAP Option Parsing Due To Integer
 Overflow
@@ -437,8 +405,6 @@ A remote adversary with the ability to send arbitrary CoAP packets to
 be parsed by Zephyr is able to cause a denial of service.
 
 This has been fixed in main for v2.3.
-
-- `CVE-2020-10063 <http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-10063>`_
 
 - `Zephyr project bug tracker ZEPSEC-55
   <https://zephyrprojectsec.atlassian.net/browse/ZEPSEC-55>`_
@@ -457,12 +423,10 @@ This has been fixed in main for v2.3.
 
 - `NCC-ZEP report`_ (NCC-ZEP-032)
 
-CVE-2020-10064
---------------
+:cve:`2020-10064`
+-----------------
 
 Improper Input Frame Validation in ieee802154 Processing
-
-- `CVE-2020-10064 <http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-10064>`_
 
 - `Zephyr project bug tracker ZEPSEC-65
   <https://zephyrprojectsec.atlassian.net/browse/ZEPSEC-65>`_
@@ -473,29 +437,25 @@ Improper Input Frame Validation in ieee802154 Processing
 - `PR33451 fix for v1.4
   <https://github.com/zephyrproject-rtos/zephyr/pull/33451>`_
 
-CVE-2020-10065
---------------
+:cve:`2020-10065`
+-----------------
 
 OOB Write after not validating user-supplied length (<= 0xffff) and
 copying to fixed-size buffer (default: 77 bytes) for HCI_ACL packets in
 bluetooth HCI over SPI driver.
-
-- `CVE-2020-10065 <http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-10065>`_
 
 - `Zephyr project bug tracker ZEPSEC-66
   <https://zephyrprojectsec.atlassian.net/browse/ZEPSEC-66>`_
 
 - This issue has not been fixed.
 
-CVE-2020-10066
---------------
+:cve:`2020-10066`
+-----------------
 
 Incorrect Error Handling in Bluetooth HCI core
 
 In hci_cmd_done, the buf argument being passed as null causes
 nullpointer dereference.
-
-- `CVE-2020-10066 <http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-10066>`_
 
 - `Zephyr project bug tracker ZEPSEC-67
   <https://zephyrprojectsec.atlassian.net/browse/ZEPSEC-67>`_
@@ -506,8 +466,8 @@ nullpointer dereference.
 - `PR25089 fix for v1.4
   <https://github.com/zephyrproject-rtos/zephyr/pull/25089>`_
 
-CVE-2020-10067
---------------
+:cve:`2020-10067`
+-----------------
 
 Integer Overflow In is_in_region Allows User Thread To Access Kernel Memory
 
@@ -521,8 +481,6 @@ See NCC-ZEP-005
 
 This has been fixed in releases v1.14.2, and v2.2.0.
 
-- `CVE-2020-10067 <http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-10067>`_
-
 - `Zephyr project bug tracker ZEPSEC-27
   <https://zephyrprojectsec.atlassian.net/browse/ZEPSEC-27>`_
 
@@ -535,8 +493,8 @@ This has been fixed in releases v1.14.2, and v2.2.0.
 - `PR23239 fix for v2.2.0
   <https://github.com/zephyrproject-rtos/zephyr/pull/23239>`_
 
-CVE-2020-10068
---------------
+:cve:`2020-10068`
+-----------------
 
 Zephyr Bluetooth DLE duplicate requests vulnerability
 
@@ -546,8 +504,6 @@ denial of service.
 
 This has been fixed in branches for v1.14.0, v2.2.0, and will be
 included in v2.3.0.
-
-- `CVE-2020-10068 <http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-10068>`_
 
 - `Zephyr project bug tracker ZEPSEC-78
   <https://zephyrprojectsec.atlassian.net/browse/ZEPSEC-78>`_
@@ -564,8 +520,8 @@ included in v2.3.0.
 - `PR23964 fix for v2.2.0
   <https://github.com/zephyrproject-rtos/zephyr/pull/23964>`_
 
-CVE-2020-10069
---------------
+:cve:`2020-10069`
+-----------------
 
 Zephyr Bluetooth unchecked packet data results in denial of service
 
@@ -574,8 +530,6 @@ failure, or division by zero, resulting in a denial of service attack.
 
 This has been fixed in branches for v1.14.0, v2.2.0, and will be
 included in v2.3.0.
-
-- `CVE-2020-10069 <http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-10069>`_
 
 - `Zephyr project bug tracker ZEPSEC-81
   <https://zephyrprojectsec.atlassian.net/browse/ZEPSEC-81>`_
@@ -592,8 +546,8 @@ included in v2.3.0.
 - `PR23963 fix for branch from v2.2.0
   <https://github.com/zephyrproject-rtos/zephyr/pull/23963>`_
 
-CVE-2020-10070
---------------
+:cve:`2020-10070`
+-----------------
 
 MQTT buffer overflow on receive buffer
 
@@ -606,8 +560,6 @@ resulting in user data being written beyond this buffer.
 
 This has been fixed in main for v2.3.
 
-- `CVE-2020-10070 <http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-10070>`_
-
 - `Zephyr project bug tracker ZEPSEC-85
   <https://zephyrprojectsec.atlassian.net/browse/ZEPSEC-85>`_
 
@@ -616,8 +568,8 @@ This has been fixed in main for v2.3.
 
 - `NCC-ZEP report`_ (NCC-ZEP-031)
 
-CVE-2020-10071
---------------
+:cve:`2020-10071`
+-----------------
 
 Insufficient publish message length validation in MQTT
 
@@ -627,8 +579,6 @@ potentially remote code execution. NCC-ZEP-031
 
 This has been fixed in main for v2.3.
 
-- `CVE-2020-10071 <http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-10071>`_
-
 - `Zephyr project bug tracker ZEPSEC-86
   <https://zephyrprojectsec.atlassian.net/browse/ZEPSEC-86>`_
 
@@ -637,8 +587,8 @@ This has been fixed in main for v2.3.
 
 - `NCC-ZEP report`_ (NCC-ZEP-031)
 
-CVE-2020-10072
---------------
+:cve:`2020-10072`
+-----------------
 
 All threads can access all socket file descriptors
 
@@ -646,8 +596,6 @@ There is no management of permissions to network socket API file
 descriptors. Any thread running on the system may read/write a socket
 file descriptor knowing only the numerical value of the file
 descriptor.
-
-- `CVE-2020-10072 <http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-10072>`_
 
 - `Zephyr project bug tracker ZEPSEC-87
   <https://zephyrprojectsec.atlassian.net/browse/ZEPSEC-87>`_
@@ -658,25 +606,21 @@ descriptor.
 - `PR27176 fix for v1.4
   <https://github.com/zephyrproject-rtos/zephyr/pull/27176>`_
 
-CVE-2020-10136
--------------------
+:cve:`2020-10136`
+-----------------
 
 IP-in-IP protocol routes arbitrary traffic by default zephyrproject
-
-- `CVE-2020-10136 <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-10136>`_
 
 - `Zephyr project bug tracker ZEPSEC-64
   <https://zephyrprojectsec.atlassian.net/browse/ZEPSEC-64>`_
 
-CVE-2020-13598
---------------
+:cve:`2020-13598`
+-----------------
 
 FS: Buffer Overflow when enabling Long File Names in FAT_FS and calling fs_stat
 
 Performing fs_stat on a file with a filename longer than 12
 characters long will cause a buffer overflow.
-
-- `CVE-2020-13598 <http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-13598>`_
 
 - `Zephyr project bug tracker ZEPSEC-88
   <https://zephyrprojectsec.atlassian.net/browse/ZEPSEC-88>`_
@@ -690,8 +634,8 @@ characters long will cause a buffer overflow.
 - `PR33577 fix for v1.4
   <https://github.com/zephyrproject-rtos/zephyr/pull/33577>`_
 
-CVE-2020-13599
---------------
+:cve:`2020-13599`
+-----------------
 
 Security problem with settings and littlefs
 
@@ -700,21 +644,17 @@ related information can be extracted from the device using MCUmgr and
 this could be used e.g in bt-mesh to get the device key, network key,
 app keys from the device.
 
-- `CVE-2020-13599 <http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-13599>`_
-
 - `Zephyr project bug tracker ZEPSEC-57
   <https://zephyrprojectsec.atlassian.net/browse/ZEPSEC-57>`_
 
 - `PR26083 fix for v2.4
   <https://github.com/zephyrproject-rtos/zephyr/pull/26083>`_
 
-CVE-2020-13600
--------------------
+:cve:`2020-13600`
+-----------------
 
 Malformed SPI in response for eswifi can corrupt kernel memory
 
-
-- `CVE-2020-13600 <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-13600>`_
 
 - `Zephyr project bug tracker ZEPSEC-91
   <https://zephyrprojectsec.atlassian.net/browse/ZEPSEC-91>`_
@@ -722,12 +662,10 @@ Malformed SPI in response for eswifi can corrupt kernel memory
 - `PR26712 fix for v2.4
   <https://github.com/zephyrproject-rtos/zephyr/pull/26712>`_
 
-CVE-2020-13601
---------------
+:cve:`2020-13601`
+-----------------
 
 Possible read out of bounds in dns read
-
-- `CVE-2020-13601 <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-13601>`_
 
 - `Zephyr project bug tracker ZEPSEC-92
   <https://zephyrprojectsec.atlassian.net/browse/ZEPSEC-92>`_
@@ -738,15 +676,13 @@ Possible read out of bounds in dns read
 - `PR30503 fix for v1.4
   <https://github.com/zephyrproject-rtos/zephyr/pull/30503>`_
 
-CVE-2020-13602
---------------
+:cve:`2020-13602`
+-----------------
 
 Remote Denial of Service in LwM2M do_write_op_tlv
 
 In the Zephyr LwM2M implementation, malformed input can result in an
 infinite loop, resulting in a denial of service attack.
-
-- `CVE-2020-13602 <http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-13602>`_
 
 - `Zephyr project bug tracker ZEPSEC-56
   <https://zephyrprojectsec.atlassian.net/browse/ZEPSEC-56>`_
@@ -757,8 +693,8 @@ infinite loop, resulting in a denial of service attack.
 - `PR33578 fix for v1.4
   <https://github.com/zephyrproject-rtos/zephyr/pull/33578>`_
 
-CVE-2020-13603
---------------
+:cve:`2020-13603`
+-----------------
 
 Possible overflow in mempool
 
@@ -769,8 +705,6 @@ Possible overflow in mempool
  * Integer wrap-around leads to successful allocation of very small memory.
  * For example: calling malloc(0xffffffff) leads to successful allocation of 7 bytes.
  * That leads to heap overflow.
-
-- `CVE-2020-13603 <http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-13603>`_
 
 - `Zephyr project bug tracker ZEPSEC-111
   <https://zephyrprojectsec.atlassian.net/browse/ZEPSEC-111>`_
@@ -784,8 +718,8 @@ Possible overflow in mempool
 CVE-2021
 ========
 
-CVE-2021-3319
--------------
+:cve:`2021-3319`
+----------------
 
 DOS: Incorrect 802154 Frame Validation for Omitted Source / Dest Addresses
 
@@ -794,32 +728,26 @@ ieee802154 frame validation (ieee802154_validate_frame)
 
 This has been fixed in main for v2.5.0
 
-- `CVE-2020-3319 <http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3319>`_
-
 - `Zephyr project bug tracker GHSA-94jg-2p6q-5364
   <https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-94jg-2p6q-5364>`_
 
 - `PR31908 fix for main
   <https://github.com/zephyrproject-rtos/zephyr/pull/31908>`_
 
-CVE-2021-3320
--------------------
+:cve:`2021-3320`
+----------------
 Mismatch between validation and handling of 802154 ACK frames, where
 ACK frames are considered during validation, but not during actual
 processing, leading to a type confusion.
 
-- `CVE-2020-3320 <http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3320>`_
-
 - `PR31908 fix for main
   <https://github.com/zephyrproject-rtos/zephyr/pull/31908>`_
 
-CVE-2021-3321
--------------
+:cve:`2021-3321`
+----------------
 
 Incomplete check of minimum IEEE 802154 fragment size leading to an
 integer underflow.
-
-- `CVE-2020-3321 <http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3321>`_
 
 - `Zephyr project bug tracker ZEPSEC-114
   <https://zephyrprojectsec.atlassian.net/browse/ZEPSEC-114>`_
@@ -827,14 +755,12 @@ integer underflow.
 - `PR33453 fix for v2.4
   <https://github.com/zephyrproject-rtos/zephyr/pull/33453>`_
 
-CVE-2021-3323
--------------
+:cve:`2021-3323`
+----------------
 
 Integer Underflow in 6LoWPAN IPHC Header Uncompression
 
 This has been fixed in main for v2.5.0
-
-- `CVE-2020-3323 <http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3323>`_
 
 - `Zephyr project bug tracker GHSA-89j6-qpxf-pfpc
   <https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-89j6-qpxf-pfpc>`_
@@ -842,14 +768,12 @@ This has been fixed in main for v2.5.0
 - `PR 31971 fix for main
   <https://github.com/zephyrproject-rtos/zephyr/pull/31971>`_
 
-CVE-2021-3430
--------------
+:cve:`2021-3430`
+----------------
 
 Assertion reachable with repeated LL_CONNECTION_PARAM_REQ.
 
 This has been fixed in main for v2.6.0
-
-- `CVE-2021-3430 <http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3430>`_
 
 - `Zephyr project bug tracker GHSA-46h3-hjcq-2jjr
   <https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-46h3-hjcq-2jjr>`_
@@ -863,14 +787,12 @@ This has been fixed in main for v2.6.0
 - `PR 33759 fix for 1.14.2
   <https://github.com/zephyrproject-rtos/zephyr/pull/33759>`_
 
-CVE-2021-3431
--------------
+:cve:`2021-3431`
+----------------
 
 BT: Assertion failure on repeated LL_FEATURE_REQ
 
 This has been fixed in main for v2.6.0
-
-- `CVE-2021-3431 <http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3431>`_
 
 - `Zephyr project bug tracker GHSA-7548-5m6f-mqv9
   <https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-7548-5m6f-mqv9>`_
@@ -881,14 +803,12 @@ This has been fixed in main for v2.6.0
 - `PR 33369 fix for 2.5
   <https://github.com/zephyrproject-rtos/zephyr/pull/33369>`_
 
-CVE-2021-3432
--------------
+:cve:`2021-3432`
+----------------
 
 Invalid interval in CONNECT_IND leads to Division by Zero
 
 This has been fixed in main for v2.6.0
-
-- `CVE-2021-3432 <http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3432>`_
 
 - `Zephyr project bug tracker GHSA-7364-p4wc-8mj4
   <https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-7364-p4wc-8mj4>`_
@@ -899,14 +819,12 @@ This has been fixed in main for v2.6.0
 - `PR 33369 fix for 2.5
   <https://github.com/zephyrproject-rtos/zephyr/pull/33369>`_
 
-CVE-2021-3433
--------------
+:cve:`2021-3433`
+----------------
 
 BT: Invalid channel map in CONNECT_IND results to Deadlock
 
 This has been fixed in main for v2.6.0
-
-- `CVE-2021-3433 <http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3433>`_
 
 - `Zephyr project bug tracker GHSA-3c2f-w4v6-qxrp
   <https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-3c2f-w4v6-qxrp>`_
@@ -917,14 +835,12 @@ This has been fixed in main for v2.6.0
 - `PR 33369 fix for 2.5
   <https://github.com/zephyrproject-rtos/zephyr/pull/33369>`_
 
-CVE-2021-3434
--------------
+:cve:`2021-3434`
+----------------
 
 L2CAP: Stack based buffer overflow in le_ecred_conn_req()
 
 This has been fixed in main for v2.6.0
-
-- `CVE-2021-3434 <http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3434>`_
 
 - `Zephyr project bug tracker GHSA-8w87-6rfp-cfrm
   <https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-8w87-6rfp-cfrm>`_
@@ -938,14 +854,12 @@ This has been fixed in main for v2.6.0
 - `PR 33418 fix for 1.14.2
   <https://github.com/zephyrproject-rtos/zephyr/pull/33418>`_
 
-CVE-2021-3435
--------------
+:cve:`2021-3435`
+----------------
 
 L2CAP: Information leakage in le_ecred_conn_req()
 
 This has been fixed in main for v2.6.0
-
-- `CVE-2021-3435 <http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3435>`_
 
 - `Zephyr project bug tracker GHSA-xhg3-gvj6-4rqh
   <https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-xhg3-gvj6-4rqh>`_
@@ -959,8 +873,8 @@ This has been fixed in main for v2.6.0
 - `PR 33418 fix for 1.14.2
   <https://github.com/zephyrproject-rtos/zephyr/pull/33418>`_
 
-CVE-2021-3436
--------------
+:cve:`2021-3436`
+----------------
 
 Bluetooth: Possible to overwrite an existing bond during keys
 distribution phase when the identity address of the bond is known
@@ -971,8 +885,6 @@ that a duplicate entry will be created in RAM while the newest entry
 will overwrite the existing one in persistent storage.
 
 This has been fixed in main for v2.6.0
-
-- `CVE-2021-3436 <http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3436>`_
 
 - `Zephyr project bug tracker GHSA-j76f-35mc-4h63
   <https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-j76f-35mc-4h63>`_
@@ -989,8 +901,8 @@ This has been fixed in main for v2.6.0
 - `PR 33718 fix for 1.14.2
   <https://github.com/zephyrproject-rtos/zephyr/pull/33718>`_
 
-CVE-2021-3454
--------------
+:cve:`2021-3454`
+----------------
 
 Truncated L2CAP K-frame causes assertion failure
 
@@ -1000,8 +912,6 @@ Zephyr. This has been fixed in master by commit 0ba9437 but has not
 yet been backported to older release branches.
 
 This has been fixed in main for v2.6.0
-
-- `CVE-2021-3454 <http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3454>`_
 
 - `Zephyr project bug tracker GHSA-fx88-6c29-vrp3
   <https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-fx88-6c29-vrp3>`_
@@ -1015,8 +925,8 @@ This has been fixed in main for v2.6.0
 - `PR 33514 fix for 2.4
   <https://github.com/zephyrproject-rtos/zephyr/pull/33514>`_
 
-CVE-2021-3455
--------------
+:cve:`2021-3455`
+----------------
 
 Disconnecting L2CAP channel right after invalid ATT request leads freeze
 
@@ -1025,8 +935,6 @@ connection for Enhanced ATT, sending some invalid ATT request and
 disconnecting immediately causes freeze.
 
 This has been fixed in main for v2.6.0
-
-- `CVE-2021-3455 <http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3455>`_
 
 - `Zephyr project bug tracker GHSA-7g38-3x9v-v7vp
   <https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-7g38-3x9v-v7vp>`_
@@ -1040,8 +948,8 @@ This has been fixed in main for v2.6.0
 - `PR 36105 fix for 2.4
   <https://github.com/zephyrproject-rtos/zephyr/pull/36105>`_
 
-CVE-2021-3510
--------------
+:cve:`2021-3510`
+----------------
 
 Zephyr JSON decoder incorrectly decodes array of array
 
@@ -1053,8 +961,6 @@ object, and stores the length of the subarray in there.
 
 This has been fixed in main for v2.7.0
 
-- `CVE-2021-3510 <http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3510>`_
-
 - `Zephyr project bug tracker GHSA-289f-7mw3-2qf4
   <https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-289f-7mw3-2qf4>`_
 
@@ -1064,8 +970,8 @@ This has been fixed in main for v2.7.0
 - `PR 37816 fix for 2.6
   <https://github.com/zephyrproject-rtos/zephyr/pull/37816>`_
 
-CVE-2021-3581
--------------
+:cve:`2021-3581`
+----------------
 
 HCI data not properly checked leads to memory overflow in the Bluetooth stack
 
@@ -1075,8 +981,6 @@ incoming HCI data. Causes memory overflow, and then the data in the
 memory is overwritten, and may even cause arbitrary code execution.
 
 This has been fixed in main for v2.6.0
-
-- `CVE-2021-3581 <http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3581>`_
 
 - `Zephyr project bug tracker GHSA-8q65-5gqf-fmw5
   <https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-8q65-5gqf-fmw5>`_
@@ -1093,14 +997,12 @@ This has been fixed in main for v2.6.0
 - `PR 35985 fix for 1.14
   <https://github.com/zephyrproject-rtos/zephyr/pull/35985>`_
 
-CVE-2021-3625
--------------
+:cve:`2021-3625`
+----------------
 
 Buffer overflow in Zephyr USB DFU DNLOAD
 
 This has been fixed in main for v2.6.0
-
-- `CVE-2021-3625 <http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3625>`_
 
 - `Zephyr project bug tracker GHSA-c3gr-hgvr-f363
   <https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-c3gr-hgvr-f363>`_
@@ -1108,14 +1010,12 @@ This has been fixed in main for v2.6.0
 - `PR 36694 fix for main
   <https://github.com/zephyrproject-rtos/zephyr/pull/36694>`_
 
-CVE-2021-3835
--------------
+:cve:`2021-3835`
+----------------
 
 Buffer overflow in Zephyr USB device class
 
 This has been fixed in main for v3.0.0
-
-- `CVE-2021-3835 <http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3835>`_
 
 - `Zephyr project bug tracker GHSA-fm6v-8625-99jf
   <https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-fm6v-8625-99jf>`_
@@ -1126,14 +1026,12 @@ This has been fixed in main for v3.0.0
 - `PR 42167 fix for 2.7
   <https://github.com/zephyrproject-rtos/zephyr/pull/42167>`_
 
-CVE-2021-3861
--------------
+:cve:`2021-3861`
+----------------
 
 Buffer overflow in the RNDIS USB device class
 
 This has been fixed in main for v3.0.0
-
-- `CVE-2021-3861 <http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3861>`_
 
 - `Zephyr project bug tracker GHSA-hvfp-w4h8-gxvj
   <https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-hvfp-w4h8-gxvj>`_
@@ -1141,8 +1039,8 @@ This has been fixed in main for v3.0.0
 - `PR 39725 fix for main
   <https://github.com/zephyrproject-rtos/zephyr/pull/39725>`_
 
-CVE-2021-3966
--------------
+:cve:`2021-3966`
+----------------
 
 Usb bluetooth device ACL read cb buffer overflow
 
@@ -1160,8 +1058,8 @@ This has been fixed in main for v3.0.0
 CVE-2022
 ========
 
-CVE-2022-0553
--------------
+:cve:`2022-0553`
+----------------
 
 Possible to retrieve unencrypted firmware image
 
@@ -1173,8 +1071,8 @@ This has been fixed in main for v3.0.0
 - `PR 42424 fix for main
   <https://github.com/zephyrproject-rtos/zephyr/pull/42424>`_
 
-CVE-2022-1041
---------------
+:cve:`2022-1041`
+----------------
 
 Out-of-bound write vulnerability in the Bluetooth Mesh core stack can be triggered during provisioning
 
@@ -1192,8 +1090,8 @@ This has been fixed in main for v3.1.0
 - `PR 45187 fix for v2.7.0
   <https://github.com/zephyrproject-rtos/zephyr/pull/45187>`_
 
-CVE-2022-1042
---------------
+:cve:`2022-1042`
+----------------
 
 Out-of-bound write vulnerability in the Bluetooth Mesh core stack can be triggered during provisioning
 
@@ -1211,8 +1109,8 @@ This has been fixed in main for v3.1.0
 - `PR 45134 fix for v2.7.0
   <https://github.com/zephyrproject-rtos/zephyr/pull/45134>`_
 
-CVE-2022-1841
---------------
+:cve:`2022-1841`
+----------------
 
 Out-of-Bound Write in tcp_flags
 
@@ -1224,8 +1122,8 @@ This has been fixed in main for v3.1.0
 - `PR 45796 fix for main
   <https://github.com/zephyrproject-rtos/zephyr/pull/45796>`_
 
-CVE-2022-2741
---------------
+:cve:`2022-2741`
+----------------
 
 can: denial-of-service can be triggered by a crafted CAN frame
 
@@ -1246,8 +1144,8 @@ This has been fixed in main for v3.2.0
 - `PR 47959 fix for v2.7.0
   <https://github.com/zephyrproject-rtos/zephyr/pull/47959>`_
 
-CVE-2022-2993
---------------
+:cve:`2022-2993`
+----------------
 
 bt: host: Wrong key validation check
 
@@ -1259,8 +1157,8 @@ This has been fixed in main for v3.2.0
 - `PR 48733 fix for main
   <https://github.com/zephyrproject-rtos/zephyr/pull/48733>`_
 
-CVE-2022-3806
--------------
+:cve:`2022-3806`
+----------------
 
 DoS: Invalid Initialization in le_read_buffer_size_complete()
 
@@ -1270,16 +1168,16 @@ DoS: Invalid Initialization in le_read_buffer_size_complete()
 CVE-2023
 ========
 
-CVE-2023-0396
--------------
+:cve:`2023-0396`
+----------------
 
 Buffer Overreads in Bluetooth HCI
 
 - `Zephyr project bug tracker GHSA-8rpp-6vxq-pqg3
   <https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-8rpp-6vxq-pqg3>`_
 
-CVE-2023-0397
--------------
+:cve:`2023-0397`
+----------------
 
 DoS: Invalid Initialization in le_read_buffer_size_complete()
 
@@ -1300,8 +1198,8 @@ This has been fixed in main for v3.3.0
 - `PR 47959 fix for v2.7.4
   <https://github.com/zephyrproject-rtos/zephyr/pull/55022>`_
 
-CVE-2023-0779
--------------
+:cve:`2023-0779`
+----------------
 
 net: shell: Improper input validation
 
@@ -1319,8 +1217,8 @@ This has been fixed in main for v3.3.0
 - `PR 54381 fix for v2.7.4
   <https://github.com/zephyrproject-rtos/zephyr/pull/54381>`_
 
-CVE-2023-1901
--------------
+:cve:`2023-1901`
+----------------
 
 HCI send_sync Dangling Semaphore Reference Re-use
 
@@ -1332,8 +1230,8 @@ This has been fixed in main for v3.4.0
 - `PR 56709 fix for main
   <https://github.com/zephyrproject-rtos/zephyr/pull/56709>`_
 
-CVE-2023-1902
--------------
+:cve:`2023-1902`
+----------------
 
 HCI Connection Creation Dangling State Reference Re-use
 
@@ -1345,8 +1243,8 @@ This has been fixed in main for v3.4.0
 - `PR 56709 fix for main
   <https://github.com/zephyrproject-rtos/zephyr/pull/56709>`_
 
-CVE-2023-3725
--------------
+:cve:`2023-3725`
+----------------
 
 Potential buffer overflow vulnerability in the Zephyr CANbus subsystem.
 
@@ -1367,8 +1265,8 @@ This has been fixed in main for v3.5.0
 - `PR 61516 fix for 2.7
   <https://github.com/zephyrproject-rtos/zephyr/pull/61516>`_
 
-CVE-2023-4257
--------------
+:cve:`2023-4257`
+----------------
 
 Unchecked user input length in the Zephyr WiFi shell module can cause
 buffer overflows.
@@ -1384,8 +1282,8 @@ This has been fixed in main for v3.5.0
 - `PR 61383 fix for 3.4
   <https://github.com/zephyrproject-rtos/zephyr/pull/61383>`_
 
-CVE-2023-4258
--------------
+:cve:`2023-4258`
+----------------
 
 bt: mesh: vulnerability in provisioning protocol implementation on provisionee side
 
@@ -1403,8 +1301,8 @@ This has been fixed in main for v3.5.0
 - `PR 60079 fix for 3.3
   <https://github.com/zephyrproject-rtos/zephyr/pull/60079>`_
 
-CVE-2023-4259
--------------
+:cve:`2023-4259`
+----------------
 
 Buffer overflow vulnerabilities in the Zephyr eS-WiFi driver
 
@@ -1419,8 +1317,8 @@ This has been fixed in main for v3.5.0
 - `PR 63750 fix for main
   <https://github.com/zephyrproject-rtos/zephyr/pull/63750>`_
 
-CVE-2023-4260
--------------
+:cve:`2023-4260`
+----------------
 
 Off-by-one buffer overflow vulnerability in the Zephyr FS subsystem
 
@@ -1432,13 +1330,13 @@ This has been fixed in main for v3.5.0
 - `PR 63079 fix for main
   <https://github.com/zephyrproject-rtos/zephyr/pull/63079>`_
 
-CVE-2023-4262
--------------
+:cve:`2023-4262`
+----------------
 
 - This issue has been determined to be a false positive after further analysis.
 
-CVE-2023-4263
--------------
+:cve:`2023-4263`
+----------------
 
 Potential buffer overflow vulnerability in the Zephyr IEEE 802.15.4 nRF 15.4 driver.
 
@@ -1456,8 +1354,8 @@ This has been fixed in main for v3.5.0
 - `PR 61216 fix for 2.7
   <https://github.com/zephyrproject-rtos/zephyr/pull/61216>`_
 
-CVE-2023-4264
--------------
+:cve:`2023-4264`
+----------------
 
 Potential buffer overflow vulnerabilities in the Zephyr Bluetooth subsystem
 
@@ -1478,8 +1376,8 @@ This has been fixed in main for v3.5.0
 - `PR 61385 fix for 3.4
   <https://github.com/zephyrproject-rtos/zephyr/pull/61385>`_
 
-CVE-2023-4265
--------------
+:cve:`2023-4265`
+----------------
 
 Two potential buffer overflow vulnerabilities in Zephyr USB code
 
@@ -1493,8 +1391,8 @@ This has been fixed in main for v3.4.0
 - `PR 59018 fix for main
   <https://github.com/zephyrproject-rtos/zephyr/pull/59018>`_
 
-CVE-2023-4424
--------------
+:cve:`2023-4424`
+----------------
 
 bt: hci: DoS and possible RCE
 
@@ -1516,8 +1414,8 @@ This has been fixed in main for v3.5.0
   <https://github.com/zephyrproject-rtos/zephyr/pull/61694>`_
 
 
-CVE-2023-5055
--------------
+:cve:`2023-5055`
+----------------
 
 L2CAP: Possible Stack based buffer overflow in le_ecred_reconf_req()
 
@@ -1530,8 +1428,8 @@ This has been fixed in main for v3.5.0
   <https://github.com/zephyrproject-rtos/zephyr/pull/62381>`_
 
 
-CVE-2023-5139
--------------
+:cve:`2023-5139`
+----------------
 
 Potential buffer overflow vulnerability in the Zephyr STM32 Crypto driver.
 
@@ -1543,8 +1441,8 @@ This has been fixed in main for v3.5.0
 - `PR 61839 fix for main
   <https://github.com/zephyrproject-rtos/zephyr/pull/61839>`_
 
-CVE-2023-5184
--------------
+:cve:`2023-5184`
+----------------
 
 Potential signed to unsigned conversion errors and buffer overflow
 vulnerabilities in the Zephyr IPM driver
@@ -1557,8 +1455,8 @@ This has been fixed in main for v3.5.0
 - `PR 63069 fix for main
   <https://github.com/zephyrproject-rtos/zephyr/pull/63069>`_
 
-CVE-2023-5563
--------------
+:cve:`2023-5563`
+----------------
 
 The SJA1000 CAN controller driver backend automatically attempts to recover
 from a bus-off event when built with CONFIG_CAN_AUTO_BUS_OFF_RECOVERY=y. This
@@ -1578,8 +1476,8 @@ This has been fixed in main for v3.5.0
 - `PR 63717 fix for 3.3
   <https://github.com/zephyrproject-rtos/zephyr/pull/63717>`_
 
-CVE-2023-5753
--------------
+:cve:`2023-5753`
+----------------
 
 Potential buffer overflow vulnerabilities in the Zephyr Bluetooth
 subsystem source code when asserts are disabled.
@@ -1593,8 +1491,8 @@ This has been fixed in main for v3.5.0
   <https://github.com/zephyrproject-rtos/zephyr/pull/63605>`_
 
 
-CVE-2023-5779
--------------
+:cve:`2023-5779`
+----------------
 
 Out of bounds issue in remove_rx_filter in multiple can drivers.
 
@@ -1618,8 +1516,8 @@ This has been fixed in main for v3.6.0
 - `PR 64431 fix for 2.7
   <https://github.com/zephyrproject-rtos/zephyr/pull/64431>`_
 
-CVE-2023-6249
--------------
+:cve:`2023-6249`
+----------------
 
 Signed to unsigned conversion problem in esp32_ipm_send may lead to buffer overflow
 
@@ -1631,8 +1529,8 @@ This has been fixed in main for v3.6.0
 - `PR 65546 fix for main
   <https://github.com/zephyrproject-rtos/zephyr/pull/65546>`_
 
-CVE-2023-6749
--------------
+:cve:`2023-6749`
+----------------
 
 Potential buffer overflow due unchecked data coming from user input in settings shell.
 
@@ -1647,8 +1545,8 @@ This has been fixed in main for v3.6.0
 - `PR 66584 fix for 3.5
   <https://github.com/zephyrproject-rtos/zephyr/pull/66584>`_
 
-CVE-2023-6881
--------------
+:cve:`2023-6881`
+----------------
 
 Potential buffer overflow vulnerability in Zephyr fuse file system.
 
@@ -1660,8 +1558,8 @@ This has been fixed in main for v3.6.0
 - `PR 66592 fix for main
   <https://github.com/zephyrproject-rtos/zephyr/pull/66592>`_
 
-CVE-2023-7060
--------------
+:cve:`2023-7060`
+----------------
 
 Missing Security Control in Zephyr OS IP Packet Handling
 
@@ -1685,8 +1583,8 @@ This has been fixed in main for v3.6.0
 CVE-2024
 ========
 
-CVE-2024-1638
--------------
+:cve:`2024-1638`
+----------------
 
 Bluetooth characteristic LESC security requirement not enforced without additional flags
 
@@ -1698,8 +1596,8 @@ This has been fixed in main for v3.6.0
 - `PR 69170 fix for main
   <https://github.com/zephyrproject-rtos/zephyr/pull/69170>`_
 
-CVE-2024-3077
--------------
+:cve:`2024-3077`
+----------------
 
 Bluetooth: Integer underflow in gatt_find_info_rsp. A malicious BLE
 device can crash BLE victim device by sending malformed gatt packet.
@@ -1712,8 +1610,8 @@ This has been fixed in main for v3.7.0
 - `PR 69396 fix for main
   <https://github.com/zephyrproject-rtos/zephyr/pull/69396>`_
 
-CVE-2024-3332
--------------
+:cve:`2024-3332`
+----------------
 
 Bluetooth: DoS caused by null pointer dereference.
 
@@ -1729,8 +1627,8 @@ This has been fixed in main for v3.7.0
   <https://github.com/zephyrproject-rtos/zephyr/pull/71030>`_
 
 
-CVE-2024-4785
--------------
+:cve:`2024-4785`
+----------------
 
 Bluetooth: Missing Check in LL_CONNECTION_UPDATE_IND Packet Leads to Division by Zero
 
@@ -1742,8 +1640,8 @@ This has been fixed in main for v3.7.0
 - `PR 72608 fix for main
   <https://github.com/zephyrproject-rtos/zephyr/pull/72608>`_
 
-CVE-2024-5754
--------------
+:cve:`2024-5754`
+----------------
 
 BT: Encryption procedure host vulnerability
 
@@ -1764,8 +1662,8 @@ This has been fixed in main for v3.7.0
 - `PR 74122 fix for 2.7
   <https://github.com/zephyrproject-rtos/zephyr/pull/74122>`_
 
-CVE-2024-5931
--------------
+:cve:`2024-5931`
+----------------
 
 BT: Unchecked user input in bap_broadcast_assistant
 
@@ -1781,8 +1679,8 @@ This has been fixed in main for v3.7.0
   <https://github.com/zephyrproject-rtos/zephyr/pull/77966>`_
 
 
-CVE-2024-6135
--------------
+:cve:`2024-6135`
+----------------
 
 BT:Classic: Multiple missing buf length checks
 
@@ -1797,8 +1695,8 @@ This has been fixed in main for v3.7.0
 - `PR 77964 fix for 3.6
   <https://github.com/zephyrproject-rtos/zephyr/pull/77964>`_
 
-CVE-2024-6137
--------------
+:cve:`2024-6137`
+----------------
 
 BT: Classic: SDP OOB access in get_att_search_list
 
@@ -1810,8 +1708,8 @@ This has been fixed in main for v3.7.0
 - `PR 75575 fix for main
   <https://github.com/zephyrproject-rtos/zephyr/pull/75575>`_
 
-CVE-2024-6258
--------------
+:cve:`2024-6258`
+----------------
 
 BT: Missing length checks of net_buf in rfcomm_handle_data
 
@@ -1823,8 +1721,8 @@ This has been fixed in main for v3.7.0
 - `PR 74640 fix for main
   <https://github.com/zephyrproject-rtos/zephyr/pull/74640>`_
 
-CVE-2024-6259
--------------
+:cve:`2024-6259`
+----------------
 
 BT: HCI: adv_ext_report Improper discarding in adv_ext_report
 
@@ -1839,8 +1737,8 @@ This has been fixed in main for v3.7.0
 - `PR 77960 fix for 3.6
   <https://github.com/zephyrproject-rtos/zephyr/pull/77960>`_
 
-CVE-2024-6442
--------------
+:cve:`2024-6442`
+----------------
 
 Bluetooth: ASCS Unchecked tailroom of the response buffer
 
@@ -1855,8 +1753,8 @@ This has been fixed in main for v3.7.0
 - `PR 77958 fix for 3.6
   <https://github.com/zephyrproject-rtos/zephyr/pull/77958>`_
 
-CVE-2024-6443
--------------
+:cve:`2024-6443`
+----------------
 
 zephyr: out-of-bound read in utf8_trunc
 
@@ -1871,8 +1769,8 @@ This has been fixed in main for v3.7.0
 - `PR 78286 fix for 3.6
   <https://github.com/zephyrproject-rtos/zephyr/pull/78286>`_
 
-CVE-2024-6444
--------------
+:cve:`2024-6444`
+----------------
 
 Bluetooth: ots: missing buffer length check
 
@@ -1887,7 +1785,7 @@ This has been fixed in main for v3.7.0
 - `PR 77954 fix for 3.6
   <https://github.com/zephyrproject-rtos/zephyr/pull/77954>`_
 
-CVE-2024-8798
--------------
+:cve:`2024-8798`
+----------------
 
 Under embargo until 2024-11-22


### PR DESCRIPTION
https://builds.zephyrproject.io/zephyr/pr/79792/docs/security/vulnerabilities.html

This is a new role available in Sphinx 8.1 and it is very useful to avoid typos and to provide a consistent way to link to CVEs.
This PR actually fixes some such typos :)