### PR TITLE
zbus: fix extern declaration for cpp

### DIFF
--- a/include/zephyr/zbus/zbus.h
+++ b/include/zephyr/zbus/zbus.h
@@ -415,7 +415,7 @@ struct zbus_channel_observation {
 			.priority = ZBUS_MIN_THREAD_PRIORITY,                 \
 		))                                                            \
 	};                                                                    \
-	const STRUCT_SECTION_ITERABLE(zbus_observer, _name) = {               \
+	_ZBUS_CPP_EXTERN const STRUCT_SECTION_ITERABLE(zbus_observer, _name) = {  \
 		ZBUS_OBSERVER_NAME_INIT(_name) /* Name field */               \
 		.type = ZBUS_OBSERVER_SUBSCRIBER_TYPE,                        \
 		.data = &_CONCAT(_zbus_obs_data_, _name),                     \
@@ -457,7 +457,7 @@ struct zbus_channel_observation {
 			.priority = ZBUS_MIN_THREAD_PRIORITY,                                      \
 		))                                                                                 \
 	};                                                                                         \
-	const STRUCT_SECTION_ITERABLE(zbus_observer, _name) = {                                    \
+	_ZBUS_CPP_EXTERN const STRUCT_SECTION_ITERABLE(zbus_observer, _name) = {                   \
 		ZBUS_OBSERVER_NAME_INIT(_name) /* Name field */                                    \
 		.type = ZBUS_OBSERVER_LISTENER_TYPE,                                               \
 		.data = &_CONCAT(_zbus_obs_data_, _name),                                          \
@@ -497,7 +497,7 @@ struct zbus_channel_observation {
 			.priority = ZBUS_MIN_THREAD_PRIORITY,                 \
 		))                                                            \
 	};                                                                    \
-	const STRUCT_SECTION_ITERABLE(zbus_observer, _name) = {               \
+	_ZBUS_CPP_EXTERN const STRUCT_SECTION_ITERABLE(zbus_observer, _name) = {  \
 		ZBUS_OBSERVER_NAME_INIT(_name) /* Name field */               \
 		.type = ZBUS_OBSERVER_MSG_SUBSCRIBER_TYPE,                    \
 		.data = &_CONCAT(_zbus_obs_data_, _name),                     \


### PR DESCRIPTION
Declaration with const keyword (subscriber, listener, message)
requires external cpp declaration, otherwise the name will be mangled.

Fixes  https://github.com/zephyrproject-rtos/zephyr/issues/79664