### PR TITLE
stm32 boards with octo or quad spi nodes rename to spi node 

### DIFF
--- a/boards/st/b_u585i_iot02a/pre_dt_board.cmake
+++ b/boards/st/b_u585i_iot02a/pre_dt_board.cmake
@@ -1,3 +1,0 @@
-
-# SPI is implemented via octospi so node name isn't spi@...
-list(APPEND EXTRA_DTC_FLAGS "-Wno-spi_bus_bridge")

--- a/dts/arm/st/f4/stm32f412.dtsi
+++ b/dts/arm/st/f4/stm32f412.dtsi
@@ -212,7 +212,7 @@
 				 <&rcc STM32_SRC_CK48 SDIO_SEL(0)>;
 		};
 
-		quadspi: quadspi@a0001000 {
+		quadspi: spi@a0001000 {
 			compatible = "st,stm32-qspi";
 			#address-cells = <0x1>;
 			#size-cells = <0x0>;

--- a/dts/arm/st/f7/stm32f7.dtsi
+++ b/dts/arm/st/f7/stm32f7.dtsi
@@ -854,7 +854,7 @@
 			status = "disabled";
 		};
 
-		quadspi: quadspi@a0001000 {
+		quadspi: spi@a0001000 {
 			compatible = "st,stm32-qspi";
 			#address-cells = <0x1>;
 			#size-cells = <0x0>;

--- a/dts/arm/st/h5/stm32h562.dtsi
+++ b/dts/arm/st/h5/stm32h562.dtsi
@@ -258,7 +258,7 @@
 			status = "disabled";
 		};
 
-		xspi1: xspi@47001400 {
+		xspi1: spi@47001400 {
 			compatible = "st,stm32-xspi";
 			reg = <0x47001400 0x400>;
 			interrupts = <78 0>;

--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -1065,7 +1065,7 @@
 			status = "disabled";
 		};
 
-		quadspi: quadspi@52005000 {
+		quadspi: spi@52005000 {
 			compatible = "st,stm32-qspi";
 			#address-cells = <0x1>;
 			#size-cells = <0x0>;

--- a/dts/arm/st/h7/stm32h723.dtsi
+++ b/dts/arm/st/h7/stm32h723.dtsi
@@ -93,7 +93,7 @@
 			status = "disabled";
 		};
 
-		octospi1: octospi@52005000 {
+		octospi1: spi@52005000 {
 			compatible = "st,stm32-ospi";
 			reg = <0x52005000 0x1000>;
 			interrupts = <92 0>;
@@ -105,7 +105,7 @@
 			status = "disabled";
 		};
 
-		octospi2: octospi@5200a000 {
+		octospi2: spi@5200a000 {
 			compatible = "st,stm32-ospi";
 			reg = <0x5200a000 0x1000>;
 			interrupts = <150 0>;

--- a/dts/arm/st/h7/stm32h7a3.dtsi
+++ b/dts/arm/st/h7/stm32h7a3.dtsi
@@ -56,7 +56,7 @@
 			status = "disabled";
 		};
 
-		octospi1: octospi@52005000 {
+		octospi1: spi@52005000 {
 			compatible = "st,stm32-ospi";
 			reg = <0x52005000 0x1000>;
 			interrupts = <92 0>;
@@ -68,7 +68,7 @@
 			status = "disabled";
 		};
 
-		octospi2: octospi@5200a000 {
+		octospi2: spi@5200a000 {
 			compatible = "st,stm32-ospi";
 			reg = <0x5200a000 0x1000>;
 			interrupts = <150 0>;

--- a/dts/arm/st/l4/stm32l4.dtsi
+++ b/dts/arm/st/l4/stm32l4.dtsi
@@ -263,7 +263,7 @@
 			status = "disabled";
 		};
 
-		quadspi: quadspi@a0001000 {
+		quadspi: spi@a0001000 {
 			compatible = "st,stm32-qspi";
 			#address-cells = <1>;
 			#size-cells = <0>;

--- a/dts/arm/st/l4/stm32l4p5.dtsi
+++ b/dts/arm/st/l4/stm32l4p5.dtsi
@@ -363,7 +363,7 @@
 			#io-channel-cells = <1>;
 		};
 
-		octospi1: octospi@a0001000 {
+		octospi1: spi@a0001000 {
 			compatible = "st,stm32-ospi";
 			reg = <0xa0001000 0x400>;
 			interrupts = <71 0>;
@@ -377,7 +377,7 @@
 			status = "disabled";
 		};
 
-		octospi2: octospi@a0001400 {
+		octospi2: spi@a0001400 {
 			compatible = "st,stm32-ospi";
 			reg = <0xa0001400 0x400>;
 			interrupts = <76 0>;

--- a/dts/arm/st/l5/stm32l5.dtsi
+++ b/dts/arm/st/l5/stm32l5.dtsi
@@ -432,7 +432,7 @@
 			status = "disabled";
 		};
 
-		octospi1: octospi@44021000 {
+		octospi1: spi@44021000 {
 			compatible = "st,stm32-ospi";
 			reg = <0x44021000 0x400>;
 			interrupts = <76 0>;

--- a/dts/arm/st/u5/stm32u5.dtsi
+++ b/dts/arm/st/u5/stm32u5.dtsi
@@ -696,7 +696,7 @@
 			};
 		};
 
-		octospi1: octospi@420d1400 {
+		octospi1: spi@420d1400 {
 			compatible = "st,stm32-ospi";
 			reg = <0x420d1400 0x400>;
 			interrupts = <76 0>;
@@ -709,7 +709,7 @@
 			status = "disabled";
 		};
 
-		octospi2: octospi@420d2400 {
+		octospi2: spi@420d2400 {
 			compatible = "st,stm32-ospi";
 			reg = <0x420d2400 0x400>;
 			interrupts = <120 0>;

--- a/dts/arm/st/wb/stm32wb.dtsi
+++ b/dts/arm/st/wb/stm32wb.dtsi
@@ -493,7 +493,7 @@
 			status = "disabled";
 		};
 
-		quadspi: quadspi@a0001000 {
+		quadspi: spi@a0001000 {
 			compatible = "st,stm32-qspi";
 			#address-cells = <0x1>;
 			#size-cells = <0x0>;


### PR DESCRIPTION
Instead of adding a pre_dt_board.cmake to ignore spi node names when octospi or quaspi node also axists in the board device tree, This PR is changing the quadspi and octospi node names to **spi@...**

When building the quadspi or octospi  node  of a stm32 board with _also_ spi node, this PR will avoid the following warning :

```
CMake Warning at ./cmake/modules/dts.cmake:415 (message):
  dtc raised one or more warnings:

  
  ./build/zephyr/zephyr.dts:1272.29-1305.5:
  Warning (spi_bus_bridge): /soc/quadspi@52005000: node name for SPI buses
  should be 'spi'

  <stdout>: Warning (spi_bus_reg): Failed prerequisite 'spi_bus_bridge'
  
```

fixes [79654](https://github.com/zephyrproject-rtos/zephyr/issues/79654)

This was already done for the boards/st/b_u585i_iot02a/ and this PR extends to stm32 boards with octospi node:

- stm32h7b3i_dk
- stm32h735g_disco
- stm32l4r9i_disco
- stm32l562e_dk/

and quadspi node:

- b_l4s5i_iot01a
- stm32h745i_disco
- stm32h747i_disco
- stm32h750b_dk
- stm32l476g_disco and stm32l496g_disco

