### PR TITLE
openocd: esp32: gdb init command update

### DIFF
--- a/boards/common/esp32.board.cmake
+++ b/boards/common/esp32.board.cmake
@@ -6,7 +6,7 @@ board_set_debugger_ifnset(openocd)
 board_runner_args(openocd  --no-init --no-halt --no-targets --no-load)
 board_runner_args(openocd  --gdb-init "set remote hardware-watchpoint-limit 2")
 
-board_runner_args(openocd  --gdb-init "flushregs")
+board_runner_args(openocd  --gdb-init "maintenance flush register-cache")
 board_runner_args(openocd  --gdb-init "mon reset halt")
 board_runner_args(openocd  --gdb-init "thb main")
 


### PR DESCRIPTION
This PR fixes a warning regarding to deprecated alias when running the **west debug** command with Espressif boards:
- **flushregs** alias is deprecated and it was replaced by the command: **maintenance flush register-cache**