### PR TITLE
arch: arm: cortex_m: Include `TBLBASE` in VTOR mask if present

### DIFF
--- a/arch/arm/core/cortex_m/prep_c.c
+++ b/arch/arm/core/cortex_m/prep_c.c
@@ -45,9 +45,16 @@ void *_vector_table_pointer;
 
 #define VECTOR_ADDRESS ((uintptr_t)_vector_start)
 
+/* In some Cortex-M3 implementations SCB_VTOR bit[29] is called the TBLBASE bit */
+#ifdef SCB_VTOR_TBLBASE_Msk
+#define VTOR_MASK (SCB_VTOR_TBLBASE_Msk | SCB_VTOR_TBLOFF_Msk)
+#else
+#define VTOR_MASK SCB_VTOR_TBLOFF_Msk
+#endif
+
 static inline void relocate_vector_table(void)
 {
-	SCB->VTOR = VECTOR_ADDRESS & SCB_VTOR_TBLOFF_Msk;
+	SCB->VTOR = VECTOR_ADDRESS & VTOR_MASK;
 	barrier_dsync_fence_full();
 	barrier_isync_fence_full();
 }


### PR DESCRIPTION
Enables setting VTOR to SRAM (0x20000000) for qemu_cortex_m3.

---

I noticed XIP=n was crashing on qemu_cortex_m3 because VTOR (vector table offset register) was not getting set correctly:

* `VTOR = VECTOR_ADDRESS & SCB_VTOR_TBLOFF_Msk = 0x20000000 & 0x1fffff80 = 0`
* After adding `TBLBASE` to the mask:
`0x20000000 & (0x20000000 | 0x1fffff80) = 0x20000000`

To test, I used GDB to set the stack pointer and program counter:
```
west build -b qemu_cortex_m3 samples/hello_world -D CONFIG_XIP=n -t debugserver_qemu
```
```
gdb-multiarch build/zephyr/zephyr.elf
target remote localhost:1234
load
set $sp = {int} 0x20000000
set $pc = {int} 0x20000004
continue
```