### PR TITLE
drivers: touch/rtc/xt_wdt/wdt: esp32: fix conflict among device drivers

### DIFF
--- a/drivers/counter/counter_esp32_rtc.c
+++ b/drivers/counter/counter_esp32_rtc.c
@@ -57,18 +57,17 @@ static int counter_esp32_init(const struct device *dev)
 {
 	const struct counter_esp32_config *cfg = dev->config;
 	struct counter_esp32_data *data = dev->data;
+	int ret, flags;
 
 	/* RTC_SLOW_CLK is the default clk source */
 	clock_control_get_rate(cfg->clock_dev,
 			       (clock_control_subsys_t)ESP32_CLOCK_CONTROL_SUBSYS_RTC_SLOW,
 			       &data->clk_src_freq);
 
-	int ret = esp_intr_alloc(cfg->irq_source,
-				ESP_PRIO_TO_FLAGS(cfg->irq_priority) |
-				ESP_INT_FLAGS_CHECK(cfg->irq_flags),
-				(ESP32_COUNTER_RTC_ISR_HANDLER)counter_esp32_isr,
-				(void *)dev,
-				NULL);
+	flags = ESP_PRIO_TO_FLAGS(cfg->irq_priority) | ESP_INT_FLAGS_CHECK(cfg->irq_flags) |
+		ESP_INTR_FLAG_SHARED;
+	ret = esp_intr_alloc(cfg->irq_source, flags,
+			     (ESP32_COUNTER_RTC_ISR_HANDLER)counter_esp32_isr, (void *)dev, NULL);
 
 	if (ret != 0) {
 		LOG_ERR("could not allocate interrupt (err %d)", ret);
@@ -228,6 +227,11 @@ static void counter_esp32_isr(void *arg)
 	const struct device *dev = (const struct device *)arg;
 	struct counter_esp32_data *data = dev->data;
 	uint32_t now;
+	uint32_t status = REG_READ(RTC_CNTL_INT_ST_REG);
+
+	if (!(status & RTC_CNTL_MAIN_TIMER_INT_ST_M)) {
+		return;
+	}
 
 	counter_esp32_cancel_alarm(dev, 0);
 	counter_esp32_get_value(dev, &now);

--- a/drivers/watchdog/wdt_esp32.c
+++ b/drivers/watchdog/wdt_esp32.c
@@ -158,6 +158,7 @@ static int wdt_esp32_init(const struct device *dev)
 {
 	const struct wdt_esp32_config *const config = dev->config;
 	struct wdt_esp32_data *data = dev->data;
+	int ret, flags;
 
 	if (!device_is_ready(config->clock_dev)) {
 		LOG_ERR("clock control device not ready");
@@ -168,12 +169,10 @@ static int wdt_esp32_init(const struct device *dev)
 
 	wdt_hal_init(&data->hal, config->wdt_inst, MWDT_TICK_PRESCALER, true);
 
-	int ret = esp_intr_alloc(config->irq_source,
-				ESP_PRIO_TO_FLAGS(config->irq_priority) |
-				ESP_INT_FLAGS_CHECK(config->irq_flags),
-				(ISR_HANDLER)wdt_esp32_isr,
-				(void *)dev,
-				NULL);
+	flags = ESP_PRIO_TO_FLAGS(config->irq_priority) | ESP_INT_FLAGS_CHECK(config->irq_flags) |
+		ESP_INTR_FLAG_SHARED;
+	ret = esp_intr_alloc(config->irq_source, flags, (ISR_HANDLER)wdt_esp32_isr, (void *)dev,
+			     NULL);
 
 	if (ret != 0) {
 		LOG_ERR("could not allocate interrupt (err %d)", ret);
@@ -217,6 +216,11 @@ static void wdt_esp32_isr(void *arg)
 {
 	const struct device *dev = (const struct device *)arg;
 	struct wdt_esp32_data *data = dev->data;
+	uint32_t status = REG_READ(RTC_CNTL_INT_ST_REG);
+
+	if (!(status & RTC_CNTL_WDT_INT_ST)) {
+		return;
+	}
 
 	if (data->callback) {
 		data->callback(dev, 0);


### PR DESCRIPTION
This PR allows to use touch_sensor, rtc_counter, xt_wdt, and wdt simultaneously by enabling
ESP_INTR_FLAG_SHARED when calling esp_intr_alloc()