### PR TITLE
espi/it8xxx2: supports host command interrupt requested by custom opcode

### DIFF
--- a/drivers/espi/espi_it8xxx2.c
+++ b/drivers/espi/espi_it8xxx2.c
@@ -503,7 +503,9 @@ static void pmc1_it8xxx2_init(const struct device *dev)
 	pmc_reg->PM1CTL |= PMC_PM1CTL_IBFIE;
 	IRQ_CONNECT(IT8XXX2_PMC1_IBF_IRQ, 0, pmc1_it8xxx2_ibf_isr,
 			DEVICE_DT_INST_GET(0), 0);
-	irq_enable(IT8XXX2_PMC1_IBF_IRQ);
+	if (!IS_ENABLED(CONFIG_ESPI_PERIPHERAL_CUSTOM_OPCODE)) {
+		irq_enable(IT8XXX2_PMC1_IBF_IRQ);
+	}
 }
 #endif
 
@@ -579,7 +581,9 @@ static void pmc2_it8xxx2_init(const struct device *dev)
 	pmc_reg->PM2CTL |= PMC_PM2CTL_IBFIE;
 	IRQ_CONNECT(IT8XXX2_PMC2_IBF_IRQ, 0, pmc2_it8xxx2_ibf_isr,
 			DEVICE_DT_INST_GET(0), 0);
-	irq_enable(IT8XXX2_PMC2_IBF_IRQ);
+	if (!IS_ENABLED(CONFIG_ESPI_PERIPHERAL_CUSTOM_OPCODE)) {
+		irq_enable(IT8XXX2_PMC2_IBF_IRQ);
+	}
 }
 #endif
 
@@ -739,6 +743,28 @@ static int espi_it8xxx2_receive_vwire(const struct device *dev,
 
 	return 0;
 }
+
+#ifdef CONFIG_ESPI_PERIPHERAL_CUSTOM_OPCODE
+static void host_custom_opcode_enable_interrupts(void)
+{
+	if (IS_ENABLED(CONFIG_ESPI_PERIPHERAL_HOST_IO)) {
+		irq_enable(IT8XXX2_PMC1_IBF_IRQ);
+	}
+	if (IS_ENABLED(CONFIG_ESPI_PERIPHERAL_EC_HOST_CMD)) {
+		irq_enable(IT8XXX2_PMC2_IBF_IRQ);
+	}
+}
+
+static void host_custom_opcode_disable_interrupts(void)
+{
+	if (IS_ENABLED(CONFIG_ESPI_PERIPHERAL_HOST_IO)) {
+		irq_disable(IT8XXX2_PMC1_IBF_IRQ);
+	}
+	if (IS_ENABLED(CONFIG_ESPI_PERIPHERAL_EC_HOST_CMD)) {
+		irq_disable(IT8XXX2_PMC2_IBF_IRQ);
+	}
+}
+#endif /* CONFIG_ESPI_PERIPHERAL_CUSTOM_OPCODE */
 
 static int espi_it8xxx2_manage_callback(const struct device *dev,
 				    struct espi_callback *callback, bool set)
@@ -917,12 +943,12 @@ static int espi_it8xxx2_write_lpc_request(const struct device *dev,
 			(struct pmc_regs *)config->base_pmc;
 
 		switch (op) {
-		/* Enable/Disable PMC1 (port 62h/66h) interrupt */
+		/* Enable/Disable PMCx interrupt */
 		case ECUSTOM_HOST_SUBS_INTERRUPT_EN:
 			if (*data) {
-				irq_enable(IT8XXX2_PMC1_IBF_IRQ);
+				host_custom_opcode_enable_interrupts();
 			} else {
-				irq_disable(IT8XXX2_PMC1_IBF_IRQ);
+				host_custom_opcode_disable_interrupts();
 			}
 			break;
 		case ECUSTOM_HOST_CMD_SEND_RESULT:


### PR DESCRIPTION
Enables or disables host command interrupt when
ECUSTOM_HOST_SUBS_INTERRUPT_EN opcode is requested.