### PR TITLE
input: gpio_keys: add a no-disconnect property

### DIFF
--- a/dts/bindings/input/gpio-keys.yaml
+++ b/dts/bindings/input/gpio-keys.yaml
@@ -41,6 +41,12 @@ properties:
       Do not use interrupts for the key GPIOs, poll the pin periodically at the
       specified debounce-interval-ms instead.
 
+  no-disconnect:
+    type: boolean
+    description: |
+      Do not try to disconnect the pin on suspend. Can be used if the GPIO
+      controller does not support the GPIO_DISCONNECTED flag.
+
 child-binding:
   description: GPIO KEYS child node
   properties:


### PR DESCRIPTION
Add a no-disconnect property that skips the call to disconnect the pin during suspend, this is useful as not all gpio controllers supports pin disconnection, and right now using the gpio-keys driver on one of those results in a failed initialization if PM runtime is enabled.