### PR TITLE
i2c: nrfx-twim: enable pm runtime from the code

### DIFF
--- a/drivers/i2c/i2c_nrfx_twim.c
+++ b/drivers/i2c/i2c_nrfx_twim.c
@@ -322,6 +322,7 @@ static int i2c_nrfx_twim_init(const struct device *dev)
 {
 	const struct i2c_nrfx_twim_config *dev_config = dev->config;
 	struct i2c_nrfx_twim_data *dev_data = dev->data;
+	int ret;
 
 	dev_config->irq_connect();
 
@@ -336,7 +337,12 @@ static int i2c_nrfx_twim_init(const struct device *dev)
 		return -EIO;
 	}
 
-	return pm_device_driver_init(dev, twim_nrfx_pm_action);
+	ret = pm_device_driver_init(dev, twim_nrfx_pm_action);
+	if (ret < 0) {
+		return ret;
+	}
+
+	return pm_device_runtime_enable(dev);
 }
 
 #define I2C_NRFX_TWIM_INVALID_FREQUENCY  ((nrf_twim_frequency_t)-1)

--- a/dts/arm/nordic/nrf52805.dtsi
+++ b/dts/arm/nordic/nrf52805.dtsi
@@ -130,7 +130,6 @@
 			interrupts = <3 NRF_DEFAULT_IRQ_PRIORITY>;
 			easydma-maxcnt-bits = <14>;
 			status = "disabled";
-			zephyr,pm-device-runtime-auto;
 		};
 
 		spi0: spi@40004000 {

--- a/dts/arm/nordic/nrf52810.dtsi
+++ b/dts/arm/nordic/nrf52810.dtsi
@@ -134,7 +134,6 @@
 			interrupts = <3 NRF_DEFAULT_IRQ_PRIORITY>;
 			easydma-maxcnt-bits = <10>;
 			status = "disabled";
-			zephyr,pm-device-runtime-auto;
 		};
 
 		spi0: spi@40004000 {

--- a/dts/arm/nordic/nrf52811.dtsi
+++ b/dts/arm/nordic/nrf52811.dtsi
@@ -146,7 +146,6 @@
 			interrupts = <3 NRF_DEFAULT_IRQ_PRIORITY>;
 			easydma-maxcnt-bits = <14>;
 			status = "disabled";
-			zephyr,pm-device-runtime-auto;
 		};
 
 		spi1: spi@40003000 {

--- a/dts/arm/nordic/nrf52820.dtsi
+++ b/dts/arm/nordic/nrf52820.dtsi
@@ -149,7 +149,6 @@
 			interrupts = <3 NRF_DEFAULT_IRQ_PRIORITY>;
 			easydma-maxcnt-bits = <15>;
 			status = "disabled";
-			zephyr,pm-device-runtime-auto;
 		};
 
 		spi0: spi@40003000 {
@@ -186,7 +185,6 @@
 			interrupts = <4 NRF_DEFAULT_IRQ_PRIORITY>;
 			easydma-maxcnt-bits = <15>;
 			status = "disabled";
-			zephyr,pm-device-runtime-auto;
 		};
 
 		spi1: spi@40004000 {

--- a/dts/arm/nordic/nrf52832.dtsi
+++ b/dts/arm/nordic/nrf52832.dtsi
@@ -134,7 +134,6 @@
 			interrupts = <3 NRF_DEFAULT_IRQ_PRIORITY>;
 			easydma-maxcnt-bits = <8>;
 			status = "disabled";
-			zephyr,pm-device-runtime-auto;
 		};
 
 		spi0: spi@40003000 {
@@ -171,7 +170,6 @@
 			interrupts = <4 NRF_DEFAULT_IRQ_PRIORITY>;
 			easydma-maxcnt-bits = <8>;
 			status = "disabled";
-			zephyr,pm-device-runtime-auto;
 		};
 
 		spi1: spi@40004000 {

--- a/dts/arm/nordic/nrf52833.dtsi
+++ b/dts/arm/nordic/nrf52833.dtsi
@@ -148,7 +148,6 @@
 			interrupts = <3 NRF_DEFAULT_IRQ_PRIORITY>;
 			easydma-maxcnt-bits = <16>;
 			status = "disabled";
-			zephyr,pm-device-runtime-auto;
 		};
 
 		spi0: spi@40003000 {
@@ -185,7 +184,6 @@
 			interrupts = <4 NRF_DEFAULT_IRQ_PRIORITY>;
 			easydma-maxcnt-bits = <16>;
 			status = "disabled";
-			zephyr,pm-device-runtime-auto;
 		};
 
 		spi1: spi@40004000 {

--- a/dts/arm/nordic/nrf52840.dtsi
+++ b/dts/arm/nordic/nrf52840.dtsi
@@ -136,7 +136,6 @@
 			interrupts = <3 NRF_DEFAULT_IRQ_PRIORITY>;
 			easydma-maxcnt-bits = <16>;
 			status = "disabled";
-			zephyr,pm-device-runtime-auto;
 		};
 
 		spi0: spi@40003000 {
@@ -173,7 +172,6 @@
 			interrupts = <4 NRF_DEFAULT_IRQ_PRIORITY>;
 			easydma-maxcnt-bits = <16>;
 			status = "disabled";
-			zephyr,pm-device-runtime-auto;
 		};
 
 		spi1: spi@40004000 {

--- a/dts/arm/nordic/nrf5340_cpuapp_peripherals.dtsi
+++ b/dts/arm/nordic/nrf5340_cpuapp_peripherals.dtsi
@@ -119,7 +119,6 @@ i2c0: i2c@8000 {
 	interrupts = <8 NRF_DEFAULT_IRQ_PRIORITY>;
 	easydma-maxcnt-bits = <16>;
 	status = "disabled";
-	zephyr,pm-device-runtime-auto;
 };
 
 spi0: spi@8000 {
@@ -161,7 +160,6 @@ i2c1: i2c@9000 {
 	interrupts = <9 NRF_DEFAULT_IRQ_PRIORITY>;
 	easydma-maxcnt-bits = <16>;
 	status = "disabled";
-	zephyr,pm-device-runtime-auto;
 };
 
 spi1: spi@9000 {
@@ -216,7 +214,6 @@ i2c2: i2c@b000 {
 	interrupts = <11 NRF_DEFAULT_IRQ_PRIORITY>;
 	easydma-maxcnt-bits = <16>;
 	status = "disabled";
-	zephyr,pm-device-runtime-auto;
 };
 
 spi2: spi@b000 {
@@ -258,7 +255,6 @@ i2c3: i2c@c000 {
 	interrupts = <12 NRF_DEFAULT_IRQ_PRIORITY>;
 	easydma-maxcnt-bits = <16>;
 	status = "disabled";
-	zephyr,pm-device-runtime-auto;
 };
 
 spi3: spi@c000 {

--- a/dts/arm/nordic/nrf5340_cpunet.dtsi
+++ b/dts/arm/nordic/nrf5340_cpunet.dtsi
@@ -205,7 +205,6 @@
 			interrupts = <19 NRF_DEFAULT_IRQ_PRIORITY>;
 			easydma-maxcnt-bits = <16>;
 			status = "disabled";
-			zephyr,pm-device-runtime-auto;
 		};
 
 		spi0: spi@41013000 {

--- a/dts/arm/nordic/nrf91_peripherals.dtsi
+++ b/dts/arm/nordic/nrf91_peripherals.dtsi
@@ -160,7 +160,6 @@ i2c0: i2c@8000 {
 	interrupts = <8 NRF_DEFAULT_IRQ_PRIORITY>;
 	easydma-maxcnt-bits = <13>;
 	status = "disabled";
-	zephyr,pm-device-runtime-auto;
 };
 
 i2c1: i2c@9000 {
@@ -177,7 +176,6 @@ i2c1: i2c@9000 {
 	interrupts = <9 NRF_DEFAULT_IRQ_PRIORITY>;
 	easydma-maxcnt-bits = <13>;
 	status = "disabled";
-	zephyr,pm-device-runtime-auto;
 };
 
 i2c2: i2c@a000 {
@@ -194,7 +192,6 @@ i2c2: i2c@a000 {
 	interrupts = <10 NRF_DEFAULT_IRQ_PRIORITY>;
 	easydma-maxcnt-bits = <13>;
 	status = "disabled";
-	zephyr,pm-device-runtime-auto;
 };
 
 i2c3: i2c@b000 {
@@ -211,7 +208,6 @@ i2c3: i2c@b000 {
 	interrupts = <11 NRF_DEFAULT_IRQ_PRIORITY>;
 	easydma-maxcnt-bits = <13>;
 	status = "disabled";
-	zephyr,pm-device-runtime-auto;
 };
 
 spi0: spi@8000 {


### PR DESCRIPTION
Change all nrf twi instances to enable PM runtime using pm_device_runtime_enable() rather than the zephyr,pm-device-runtime-auto property.

The nrf TWI devices can use three different drivers: twi, twim and twis, only twim uses the PM runtime APIs internally.

Right now the nRF52 soc dtsi files set twim and enables PM runtime, but then the nRF5 DK files override the driver to twi but do not remove the zephyr,pm-device-runtime-auto property. This combination results in the twi driver initializing in suspended state and never being resumed.

Enabling PM runtime from the driver code itself resolves the situation and removes the ambiguity.