### PR TITLE
Add stream_flash_erase_page range check

### DIFF
--- a/include/zephyr/storage/stream_flash.h
+++ b/include/zephyr/storage/stream_flash.h
@@ -149,7 +149,8 @@ int stream_flash_erase_page(struct stream_flash_ctx *ctx, off_t off);
  * @param settings_key key to use with the settings module for loading
  *                     the stream write progress
  *
- * @return non-negative on success, negative errno code on fail
+ * @return non-negative on success, -ERANGE in case when @p off is out
+ * of area designated for stream or negative errno code on fail
  */
 int stream_flash_progress_load(struct stream_flash_ctx *ctx,
 			       const char *settings_key);

--- a/subsys/storage/stream/stream_flash.c
+++ b/subsys/storage/stream/stream_flash.c
@@ -79,6 +79,12 @@ int stream_flash_erase_page(struct stream_flash_ctx *ctx, off_t off)
 #if defined(CONFIG_FLASH_HAS_EXPLICIT_ERASE)
 	int rc;
 	struct flash_pages_info page;
+
+	if (off < ctx->offset || (off - ctx->offset) >= ctx->available) {
+		LOG_ERR("Offset out of designated range");
+		return -ERANGE;
+	}
+
 #if defined(CONFIG_FLASH_HAS_NO_EXPLICIT_ERASE)
 	/* There are both types of devices */
 	const struct flash_parameters *fparams = flash_get_parameters(ctx->fdev);


### PR DESCRIPTION
Two commits:
 - range check for stream_flash_erase_page, where given offset is validated to be within designated stream_flash area.
 - tests for range check

Fixes #79800 