### PR TITLE
scripts: Read yaml files using utf-8 encoding

### DIFF
--- a/scripts/ci/test_plan.py
+++ b/scripts/ci/test_plan.py
@@ -246,7 +246,7 @@ class Filters:
                 c = (zephyr_base / changed).resolve()
                 if c.is_relative_to(board.dir.resolve()):
                     for file in glob.glob(os.path.join(board.dir, f"{board.name}*.yaml")):
-                        with open(file, 'r') as f:
+                        with open(file, 'r', encoding='utf-8') as f:
                             b = yaml.load(f.read(), Loader=SafeLoader)
                             matched_boards[b['identifier']] = board
 

--- a/scripts/list_boards.py
+++ b/scripts/list_boards.py
@@ -183,7 +183,7 @@ def find_arch2board_set_in(root, arches, board_dir):
 def load_v2_boards(board_name, board_yml, systems):
     boards = []
     if board_yml.is_file():
-        with board_yml.open('r') as f:
+        with board_yml.open('r', encoding='utf-8') as f:
             b = yaml.load(f.read(), Loader=SafeLoader)
 
         try:

--- a/scripts/list_hardware.py
+++ b/scripts/list_hardware.py
@@ -188,7 +188,7 @@ def find_v2_archs(args):
         archs_yml = root / ARCHS_YML_PATH
 
         if Path(archs_yml).is_file():
-            with Path(archs_yml).open('r') as f:
+            with Path(archs_yml).open('r', encoding='utf-8') as f:
                 archs = yaml.load(f.read(), Loader=SafeLoader)
 
             try:

--- a/scripts/utils/board_v1_to_v2.py
+++ b/scripts/utils/board_v1_to_v2.py
@@ -74,7 +74,7 @@ def board_v1_to_v2(board_root, board, new_board, group, vendor, soc, variants):
             }
         }
     else:
-        with open(board_settings_file) as f:
+        with open(board_settings_file, encoding='utf-8') as f:
             yaml = ruamel.yaml.YAML(typ='safe', pure=True)
             board_settings = yaml.load(f) # pylint: disable=assignment-from-no-return
 

--- a/scripts/zephyr_module.py
+++ b/scripts/zephyr_module.py
@@ -193,7 +193,7 @@ def process_module(module):
     for module_yml in [module_path / MODULE_YML_PATH,
                        module_path / MODULE_YML_PATH.with_suffix('.yaml')]:
         if Path(module_yml).is_file():
-            with Path(module_yml).open('r') as f:
+            with Path(module_yml).open('r', encoding='utf-8') as f:
                 meta = yaml.load(f.read(), Loader=SafeLoader)
 
             try:


### PR DESCRIPTION
By default Windows does not use utf-8 encoding for reading files, set it explicitly.

Uncovered by #79571 which adds UTF-8 characters in board's full names.

Fixes #79745