### PR TITLE
drivers: i2c: nrfx_twi[m]: default to I2C_BITRATE_STANDARD 

### DIFF
--- a/drivers/i2c/i2c_nrfx_twi_common.h
+++ b/drivers/i2c/i2c_nrfx_twi_common.h
@@ -22,7 +22,8 @@ extern "C" {
 					  : I2C_NRFX_TWI_INVALID_FREQUENCY)
 #define I2C(idx) DT_NODELABEL(i2c##idx)
 #define I2C_FREQUENCY(idx)						       \
-	I2C_NRFX_TWI_FREQUENCY(DT_PROP(I2C(idx), clock_frequency))
+	I2C_NRFX_TWI_FREQUENCY(DT_PROP_OR(I2C(idx), clock_frequency,	       \
+					  I2C_BITRATE_STANDARD))
 
 struct i2c_nrfx_twi_common_data {
 	uint32_t dev_config;

--- a/drivers/i2c/i2c_nrfx_twim_common.h
+++ b/drivers/i2c/i2c_nrfx_twim_common.h
@@ -28,7 +28,8 @@ extern "C" {
 
 #define I2C(idx)                DT_NODELABEL(i2c##idx)
 #define I2C_HAS_PROP(idx, prop) DT_NODE_HAS_PROP(I2C(idx), prop)
-#define I2C_FREQUENCY(idx)      I2C_NRFX_TWIM_FREQUENCY(DT_PROP(I2C(idx), clock_frequency))
+#define I2C_FREQUENCY(idx)      I2C_NRFX_TWIM_FREQUENCY(DT_PROP_OR(I2C(idx), clock_frequency,      \
+								   I2C_BITRATE_STANDARD))
 
 struct i2c_nrfx_twim_common_config {
 	nrfx_twim_t twim;

--- a/dts/arm/nordic/nrf51822.dtsi
+++ b/dts/arm/nordic/nrf51822.dtsi
@@ -105,7 +105,6 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003000 0x1000>;
-			clock-frequency = <I2C_BITRATE_STANDARD>;
 			interrupts = <3 NRF_DEFAULT_IRQ_PRIORITY>;
 			easydma-maxcnt-bits = <8>;
 			status = "disabled";
@@ -133,7 +132,6 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40004000 0x1000>;
-			clock-frequency = <I2C_BITRATE_STANDARD>;
 			interrupts = <4 NRF_DEFAULT_IRQ_PRIORITY>;
 			easydma-maxcnt-bits = <8>;
 			status = "disabled";

--- a/dts/arm/nordic/nrf52805.dtsi
+++ b/dts/arm/nordic/nrf52805.dtsi
@@ -127,7 +127,6 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003000 0x1000>;
-			clock-frequency = <I2C_BITRATE_STANDARD>;
 			interrupts = <3 NRF_DEFAULT_IRQ_PRIORITY>;
 			easydma-maxcnt-bits = <14>;
 			status = "disabled";

--- a/dts/arm/nordic/nrf52810.dtsi
+++ b/dts/arm/nordic/nrf52810.dtsi
@@ -131,7 +131,6 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003000 0x1000>;
-			clock-frequency = <I2C_BITRATE_STANDARD>;
 			interrupts = <3 NRF_DEFAULT_IRQ_PRIORITY>;
 			easydma-maxcnt-bits = <10>;
 			status = "disabled";

--- a/dts/arm/nordic/nrf52811.dtsi
+++ b/dts/arm/nordic/nrf52811.dtsi
@@ -143,7 +143,6 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003000 0x1000>;
-			clock-frequency = <I2C_BITRATE_STANDARD>;
 			interrupts = <3 NRF_DEFAULT_IRQ_PRIORITY>;
 			easydma-maxcnt-bits = <14>;
 			status = "disabled";

--- a/dts/arm/nordic/nrf52820.dtsi
+++ b/dts/arm/nordic/nrf52820.dtsi
@@ -145,7 +145,6 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003000 0x1000>;
-			clock-frequency = <I2C_BITRATE_STANDARD>;
 			interrupts = <3 NRF_DEFAULT_IRQ_PRIORITY>;
 			easydma-maxcnt-bits = <15>;
 			status = "disabled";
@@ -182,7 +181,6 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40004000 0x1000>;
-			clock-frequency = <I2C_BITRATE_STANDARD>;
 			interrupts = <4 NRF_DEFAULT_IRQ_PRIORITY>;
 			easydma-maxcnt-bits = <15>;
 			status = "disabled";

--- a/dts/arm/nordic/nrf52832.dtsi
+++ b/dts/arm/nordic/nrf52832.dtsi
@@ -131,7 +131,6 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003000 0x1000>;
-			clock-frequency = <I2C_BITRATE_STANDARD>;
 			interrupts = <3 NRF_DEFAULT_IRQ_PRIORITY>;
 			easydma-maxcnt-bits = <8>;
 			status = "disabled";
@@ -168,7 +167,6 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40004000 0x1000>;
-			clock-frequency = <I2C_BITRATE_STANDARD>;
 			interrupts = <4 NRF_DEFAULT_IRQ_PRIORITY>;
 			easydma-maxcnt-bits = <8>;
 			status = "disabled";

--- a/dts/arm/nordic/nrf52833.dtsi
+++ b/dts/arm/nordic/nrf52833.dtsi
@@ -145,7 +145,6 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003000 0x1000>;
-			clock-frequency = <I2C_BITRATE_STANDARD>;
 			interrupts = <3 NRF_DEFAULT_IRQ_PRIORITY>;
 			easydma-maxcnt-bits = <16>;
 			status = "disabled";
@@ -182,7 +181,6 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40004000 0x1000>;
-			clock-frequency = <I2C_BITRATE_STANDARD>;
 			interrupts = <4 NRF_DEFAULT_IRQ_PRIORITY>;
 			easydma-maxcnt-bits = <16>;
 			status = "disabled";

--- a/dts/arm/nordic/nrf52840.dtsi
+++ b/dts/arm/nordic/nrf52840.dtsi
@@ -133,7 +133,6 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003000 0x1000>;
-			clock-frequency = <I2C_BITRATE_STANDARD>;
 			interrupts = <3 NRF_DEFAULT_IRQ_PRIORITY>;
 			easydma-maxcnt-bits = <16>;
 			status = "disabled";
@@ -170,7 +169,6 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40004000 0x1000>;
-			clock-frequency = <I2C_BITRATE_STANDARD>;
 			interrupts = <4 NRF_DEFAULT_IRQ_PRIORITY>;
 			easydma-maxcnt-bits = <16>;
 			status = "disabled";

--- a/dts/arm/nordic/nrf5340_cpuapp_peripherals.dtsi
+++ b/dts/arm/nordic/nrf5340_cpuapp_peripherals.dtsi
@@ -115,7 +115,6 @@ i2c0: i2c@8000 {
 	#address-cells = <1>;
 	#size-cells = <0>;
 	reg = <0x8000 0x1000>;
-	clock-frequency = <I2C_BITRATE_STANDARD>;
 	interrupts = <8 NRF_DEFAULT_IRQ_PRIORITY>;
 	easydma-maxcnt-bits = <16>;
 	status = "disabled";
@@ -157,7 +156,6 @@ i2c1: i2c@9000 {
 	#address-cells = <1>;
 	#size-cells = <0>;
 	reg = <0x9000 0x1000>;
-	clock-frequency = <I2C_BITRATE_STANDARD>;
 	interrupts = <9 NRF_DEFAULT_IRQ_PRIORITY>;
 	easydma-maxcnt-bits = <16>;
 	status = "disabled";
@@ -212,7 +210,6 @@ i2c2: i2c@b000 {
 	#address-cells = <1>;
 	#size-cells = <0>;
 	reg = <0xb000 0x1000>;
-	clock-frequency = <I2C_BITRATE_STANDARD>;
 	interrupts = <11 NRF_DEFAULT_IRQ_PRIORITY>;
 	easydma-maxcnt-bits = <16>;
 	status = "disabled";
@@ -254,7 +251,6 @@ i2c3: i2c@c000 {
 	#address-cells = <1>;
 	#size-cells = <0>;
 	reg = <0xc000 0x1000>;
-	clock-frequency = <I2C_BITRATE_STANDARD>;
 	interrupts = <12 NRF_DEFAULT_IRQ_PRIORITY>;
 	easydma-maxcnt-bits = <16>;
 	status = "disabled";

--- a/dts/arm/nordic/nrf5340_cpunet.dtsi
+++ b/dts/arm/nordic/nrf5340_cpunet.dtsi
@@ -201,7 +201,6 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x41013000 0x1000>;
-			clock-frequency = <I2C_BITRATE_STANDARD>;
 			interrupts = <19 NRF_DEFAULT_IRQ_PRIORITY>;
 			easydma-maxcnt-bits = <16>;
 			status = "disabled";

--- a/dts/arm/nordic/nrf91_peripherals.dtsi
+++ b/dts/arm/nordic/nrf91_peripherals.dtsi
@@ -156,7 +156,6 @@ i2c0: i2c@8000 {
 	#address-cells = <1>;
 	#size-cells = <0>;
 	reg = <0x8000 0x1000>;
-	clock-frequency = <I2C_BITRATE_STANDARD>;
 	interrupts = <8 NRF_DEFAULT_IRQ_PRIORITY>;
 	easydma-maxcnt-bits = <13>;
 	status = "disabled";
@@ -173,7 +172,6 @@ i2c1: i2c@9000 {
 	#address-cells = <1>;
 	#size-cells = <0>;
 	reg = <0x9000 0x1000>;
-	clock-frequency = <I2C_BITRATE_STANDARD>;
 	interrupts = <9 NRF_DEFAULT_IRQ_PRIORITY>;
 	easydma-maxcnt-bits = <13>;
 	status = "disabled";
@@ -190,7 +188,6 @@ i2c2: i2c@a000 {
 	#address-cells = <1>;
 	#size-cells = <0>;
 	reg = <0xa000 0x1000>;
-	clock-frequency = <I2C_BITRATE_STANDARD>;
 	interrupts = <10 NRF_DEFAULT_IRQ_PRIORITY>;
 	easydma-maxcnt-bits = <13>;
 	status = "disabled";
@@ -207,7 +204,6 @@ i2c3: i2c@b000 {
 	#address-cells = <1>;
 	#size-cells = <0>;
 	reg = <0xb000 0x1000>;
-	clock-frequency = <I2C_BITRATE_STANDARD>;
 	interrupts = <11 NRF_DEFAULT_IRQ_PRIORITY>;
 	easydma-maxcnt-bits = <13>;
 	status = "disabled";

--- a/dts/common/nordic/nrf54l15.dtsi
+++ b/dts/common/nordic/nrf54l15.dtsi
@@ -240,7 +240,6 @@
 				#address-cells = <1>;
 				#size-cells = <0>;
 				reg = <0xc6000 0x1000>;
-				clock-frequency = <I2C_BITRATE_STANDARD>;
 				interrupts = <198 NRF_DEFAULT_IRQ_PRIORITY>;
 				easydma-maxcnt-bits = <16>;
 				status = "disabled";
@@ -280,7 +279,6 @@
 				#address-cells = <1>;
 				#size-cells = <0>;
 				reg = <0xc7000 0x1000>;
-				clock-frequency = <I2C_BITRATE_STANDARD>;
 				interrupts = <199 NRF_DEFAULT_IRQ_PRIORITY>;
 				easydma-maxcnt-bits = <16>;
 				status = "disabled";
@@ -320,7 +318,6 @@
 				#address-cells = <1>;
 				#size-cells = <0>;
 				reg = <0xc8000 0x1000>;
-				clock-frequency = <I2C_BITRATE_STANDARD>;
 				interrupts = <200 NRF_DEFAULT_IRQ_PRIORITY>;
 				easydma-maxcnt-bits = <16>;
 				status = "disabled";
@@ -531,7 +528,6 @@
 				#address-cells = <1>;
 				#size-cells = <0>;
 				reg = <0x104000 0x1000>;
-				clock-frequency = <I2C_BITRATE_STANDARD>;
 				interrupts = <260 NRF_DEFAULT_IRQ_PRIORITY>;
 				easydma-maxcnt-bits = <16>;
 				status = "disabled";

--- a/dts/common/nordic/nrf54l20.dtsi
+++ b/dts/common/nordic/nrf54l20.dtsi
@@ -190,7 +190,6 @@
 				#address-cells = <1>;
 				#size-cells = <0>;
 				reg = <0xc6000 0x1000>;
-				clock-frequency = <I2C_BITRATE_STANDARD>;
 				interrupts = <198 NRF_DEFAULT_IRQ_PRIORITY>;
 				easydma-maxcnt-bits = <16>;
 				status = "disabled";
@@ -230,7 +229,6 @@
 				#address-cells = <1>;
 				#size-cells = <0>;
 				reg = <0xc7000 0x1000>;
-				clock-frequency = <I2C_BITRATE_STANDARD>;
 				interrupts = <199 NRF_DEFAULT_IRQ_PRIORITY>;
 				easydma-maxcnt-bits = <16>;
 				status = "disabled";
@@ -270,7 +268,6 @@
 				#address-cells = <1>;
 				#size-cells = <0>;
 				reg = <0xc8000 0x1000>;
-				clock-frequency = <I2C_BITRATE_STANDARD>;
 				interrupts = <200 NRF_DEFAULT_IRQ_PRIORITY>;
 				easydma-maxcnt-bits = <16>;
 				status = "disabled";
@@ -472,7 +469,6 @@
 				#address-cells = <1>;
 				#size-cells = <0>;
 				reg = <0x104000 0x1000>;
-				clock-frequency = <I2C_BITRATE_STANDARD>;
 				interrupts = <260 NRF_DEFAULT_IRQ_PRIORITY>;
 				easydma-maxcnt-bits = <16>;
 				status = "disabled";


### PR DESCRIPTION
Instead of forcing a definition in Devicetree. Currently, SoC DT files
contain this default, but it should not be part of SoC DT files.