### PR TITLE
hostap: fix DUT hang when start SAP on wrong channel

### DIFF
--- a/modules/hostap/src/supp_api.c
+++ b/modules/hostap/src/supp_api.c
@@ -1661,6 +1661,8 @@ int supplicant_ap_enable(const struct device *dev,
 		goto out;
 	}
 
+	iface->owner = iface;
+
 	if (iface->state == HAPD_IFACE_ENABLED) {
 		ret = -EBUSY;
 		wpa_printf(MSG_ERROR, "Interface %s is not in disable state", dev->name);


### PR DESCRIPTION
When try to start SAP on channel 12 with region code US, the channel check will fail and calls supplicant_send_wifi_mgmt_ap_status() with iface->owner is NULL, which causes DUT hang. Set iface->owner when enable the SAP can fix this issue.