### PR TITLE
[RFC] dts: nordic: merge seriobox nodes

### DIFF
--- a/boards/nordic/nrf52840dk/nrf52840dk_nrf52840-pinctrl.dtsi
+++ b/boards/nordic/nrf52840dk/nrf52840dk_nrf52840-pinctrl.dtsi
@@ -59,14 +59,14 @@
 		};
 	};
 
-	i2c1_default: i2c1_default {
+	/omit-if-no-ref/ i2c1_default: i2c1_default {
 		group1 {
 			psels = <NRF_PSEL(TWIM_SDA, 0, 30)>,
 				<NRF_PSEL(TWIM_SCL, 0, 31)>;
 		};
 	};
 
-	i2c1_sleep: i2c1_sleep {
+	/omit-if-no-ref/ i2c1_sleep: i2c1_sleep {
 		group1 {
 			psels = <NRF_PSEL(TWIM_SDA, 0, 30)>,
 				<NRF_PSEL(TWIM_SCL, 0, 31)>;
@@ -88,7 +88,7 @@
 		};
 	};
 
-	spi0_default: spi0_default {
+	/omit-if-no-ref/ spi0_default: spi0_default {
 		group1 {
 			psels = <NRF_PSEL(SPIM_SCK, 0, 27)>,
 				<NRF_PSEL(SPIM_MOSI, 0, 26)>,
@@ -96,7 +96,7 @@
 		};
 	};
 
-	spi0_sleep: spi0_sleep {
+	/omit-if-no-ref/ spi0_sleep: spi0_sleep {
 		group1 {
 			psels = <NRF_PSEL(SPIM_SCK, 0, 27)>,
 				<NRF_PSEL(SPIM_MOSI, 0, 26)>,

--- a/boards/nordic/nrf52840dk/nrf52840dk_nrf52840.dts
+++ b/boards/nordic/nrf52840dk/nrf52840dk_nrf52840.dts
@@ -192,28 +192,10 @@ arduino_i2c: &i2c0 {
 	pinctrl-names = "default", "sleep";
 };
 
-&i2c1 {
-	compatible = "nordic,nrf-twi";
-	/* Cannot be used together with spi1. */
-	/* status = "okay"; */
-	pinctrl-0 = <&i2c1_default>;
-	pinctrl-1 = <&i2c1_sleep>;
-	pinctrl-names = "default", "sleep";
-};
-
 &pwm0 {
 	status = "okay";
 	pinctrl-0 = <&pwm0_default>;
 	pinctrl-1 = <&pwm0_sleep>;
-	pinctrl-names = "default", "sleep";
-};
-
-&spi0 {
-	compatible = "nordic,nrf-spi";
-	/* Cannot be used together with i2c0. */
-	/* status = "okay"; */
-	pinctrl-0 = <&spi0_default>;
-	pinctrl-1 = <&spi0_sleep>;
 	pinctrl-names = "default", "sleep";
 };
 

--- a/drivers/i2c/i2c_nrfx_twi_common.h
+++ b/drivers/i2c/i2c_nrfx_twi_common.h
@@ -22,7 +22,8 @@ extern "C" {
 					  : I2C_NRFX_TWI_INVALID_FREQUENCY)
 #define I2C(idx) DT_NODELABEL(i2c##idx)
 #define I2C_FREQUENCY(idx)						       \
-	I2C_NRFX_TWI_FREQUENCY(DT_PROP(I2C(idx), clock_frequency))
+	I2C_NRFX_TWI_FREQUENCY(DT_PROP_OR(I2C(idx), clock_frequency,	       \
+					  I2C_BITRATE_STANDARD))
 
 struct i2c_nrfx_twi_common_data {
 	uint32_t dev_config;

--- a/drivers/i2c/i2c_nrfx_twim.c
+++ b/drivers/i2c/i2c_nrfx_twim.c
@@ -395,7 +395,7 @@ static int i2c_nrfx_twim_init(const struct device *dev)
 		IF_ENABLED(USES_MSG_BUF(idx),				       \
 			(.msg_buf = twim_##idx##_msg_buf,))		       \
 		.max_transfer_size = BIT_MASK(				       \
-				DT_PROP(I2C(idx), easydma_maxcnt_bits)),       \
+				DT_PROP(I2C(idx), nordic_easydma_maxcnt_bits)),\
 	};								       \
 	PM_DEVICE_DT_DEFINE(I2C(idx), twim_nrfx_pm_action);		       \
 	I2C_DEVICE_DT_DEFINE(I2C(idx),					       \

--- a/drivers/i2c/i2c_nrfx_twim.c
+++ b/drivers/i2c/i2c_nrfx_twim.c
@@ -351,7 +351,8 @@ static int i2c_nrfx_twim_init(const struct device *dev)
 #define I2C(idx) DT_NODELABEL(i2c##idx)
 #define I2C_HAS_PROP(idx, prop)	DT_NODE_HAS_PROP(I2C(idx), prop)
 #define I2C_FREQUENCY(idx)						       \
-	I2C_NRFX_TWIM_FREQUENCY(DT_PROP(I2C(idx), clock_frequency))
+	I2C_NRFX_TWIM_FREQUENCY(DT_PROP_OR(I2C(idx), clock_frequency,	       \
+					   I2C_BITRATE_STANDARD))
 
 #define CONCAT_BUF_SIZE(idx)						       \
 	COND_CODE_1(DT_NODE_HAS_PROP(I2C(idx), zephyr_concat_buf_size),	       \

--- a/drivers/spi/spi_nrfx_spim.c
+++ b/drivers/spi/spi_nrfx_spim.c
@@ -704,7 +704,7 @@ static int spi_nrfx_init(const struct device *dev)
 			.p_reg = (NRF_SPIM_Type *)DT_REG_ADDR(SPIM(idx)),      \
 			.drv_inst_idx = NRFX_SPIM##idx##_INST_IDX,	       \
 		},							       \
-		.max_freq = SPIM_PROP(idx, max_frequency),		       \
+		.max_freq = SPIM_PROP(idx, nordic_spi_max_frequency),	       \
 		.def_config = {						       \
 			.skip_gpio_cfg = true,				       \
 			.skip_psel_cfg = true,				       \
@@ -714,7 +714,8 @@ static int spi_nrfx_init(const struct device *dev)
 		},							       \
 		.irq_connect = irq_connect##idx,			       \
 		.pcfg = PINCTRL_DT_DEV_CONFIG_GET(SPIM(idx)),		       \
-		.max_chunk_len = BIT_MASK(SPIM_PROP(idx, easydma_maxcnt_bits)),\
+		.max_chunk_len = BIT_MASK(SPIM_PROP(idx,		       \
+					  nordic_easydma_maxcnt_bits)),        \
 		COND_CODE_1(CONFIG_SOC_NRF52832_ALLOW_SPIM_DESPITE_PAN_58,     \
 			(.anomaly_58_workaround =			       \
 				SPIM_PROP(idx, anomaly_58_workaround),),       \

--- a/drivers/spi/spi_nrfx_spis.c
+++ b/drivers/spi/spi_nrfx_spis.c
@@ -388,7 +388,8 @@ static int spi_nrfx_init(const struct device *dev)
 		},							       \
 		.irq_connect = irq_connect##idx,			       \
 		.pcfg = PINCTRL_DT_DEV_CONFIG_GET(SPIS(idx)),		       \
-		.max_buf_len = BIT_MASK(SPIS_PROP(idx, easydma_maxcnt_bits)),  \
+		.max_buf_len = BIT_MASK(SPIS_PROP(idx,			       \
+						nordic_easydma_maxcnt_bits)),  \
 		.wake_gpio = GPIO_DT_SPEC_GET_OR(SPIS(idx), wake_gpios, {0}),  \
 	};								       \
 	BUILD_ASSERT(!DT_NODE_HAS_PROP(SPIS(idx), wake_gpios) ||	       \

--- a/dts/arm/nordic/nrf51822.dtsi
+++ b/dts/arm/nordic/nrf51822.dtsi
@@ -104,7 +104,6 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003000 0x1000>;
-			clock-frequency = <I2C_BITRATE_STANDARD>;
 			interrupts = <3 NRF_DEFAULT_IRQ_PRIORITY>;
 			easydma-maxcnt-bits = <8>;
 			status = "disabled";
@@ -132,7 +131,6 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40004000 0x1000>;
-			clock-frequency = <I2C_BITRATE_STANDARD>;
 			interrupts = <4 NRF_DEFAULT_IRQ_PRIORITY>;
 			easydma-maxcnt-bits = <8>;
 			status = "disabled";

--- a/dts/arm/nordic/nrf51822.dtsi
+++ b/dts/arm/nordic/nrf51822.dtsi
@@ -94,8 +94,8 @@
 			#size-cells = <0>;
 			reg = <0x40003000 0x1000>;
 			interrupts = <3 NRF_DEFAULT_IRQ_PRIORITY>;
-			max-frequency = <DT_FREQ_M(8)>;
-			easydma-maxcnt-bits = <8>;
+			nordic,spi-max-frequency = <DT_FREQ_M(8)>;
+			nordic,easydma-maxcnt-bits = <8>;
 			status = "disabled";
 		};
 
@@ -105,7 +105,7 @@
 			#size-cells = <0>;
 			reg = <0x40003000 0x1000>;
 			interrupts = <3 NRF_DEFAULT_IRQ_PRIORITY>;
-			easydma-maxcnt-bits = <8>;
+			nordic,easydma-maxcnt-bits = <8>;
 			status = "disabled";
 		};
 
@@ -121,8 +121,8 @@
 			#size-cells = <0>;
 			reg = <0x40004000 0x1000>;
 			interrupts = <4 NRF_DEFAULT_IRQ_PRIORITY>;
-			max-frequency = <DT_FREQ_M(8)>;
-			easydma-maxcnt-bits = <8>;
+			nordic,spi-max-frequency = <DT_FREQ_M(8)>;
+			nordic,easydma-maxcnt-bits = <8>;
 			status = "disabled";
 		};
 
@@ -132,7 +132,7 @@
 			#size-cells = <0>;
 			reg = <0x40004000 0x1000>;
 			interrupts = <4 NRF_DEFAULT_IRQ_PRIORITY>;
-			easydma-maxcnt-bits = <8>;
+			nordic,easydma-maxcnt-bits = <8>;
 			status = "disabled";
 		};
 

--- a/dts/arm/nordic/nrf52805.dtsi
+++ b/dts/arm/nordic/nrf52805.dtsi
@@ -127,7 +127,7 @@
 			#size-cells = <0>;
 			reg = <0x40003000 0x1000>;
 			interrupts = <3 NRF_DEFAULT_IRQ_PRIORITY>;
-			easydma-maxcnt-bits = <14>;
+			nordic,easydma-maxcnt-bits = <14>;
 			status = "disabled";
 			zephyr,pm-device-runtime-auto;
 		};
@@ -145,8 +145,8 @@
 			#size-cells = <0>;
 			reg = <0x40004000 0x1000>;
 			interrupts = <4 NRF_DEFAULT_IRQ_PRIORITY>;
-			max-frequency = <DT_FREQ_M(8)>;
-			easydma-maxcnt-bits = <14>;
+			nordic,spi-max-frequency = <DT_FREQ_M(8)>;
+			nordic,easydma-maxcnt-bits = <14>;
 			status = "disabled";
 		};
 

--- a/dts/arm/nordic/nrf52805.dtsi
+++ b/dts/arm/nordic/nrf52805.dtsi
@@ -126,7 +126,6 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003000 0x1000>;
-			clock-frequency = <I2C_BITRATE_STANDARD>;
 			interrupts = <3 NRF_DEFAULT_IRQ_PRIORITY>;
 			easydma-maxcnt-bits = <14>;
 			status = "disabled";

--- a/dts/arm/nordic/nrf52810.dtsi
+++ b/dts/arm/nordic/nrf52810.dtsi
@@ -130,7 +130,6 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003000 0x1000>;
-			clock-frequency = <I2C_BITRATE_STANDARD>;
 			interrupts = <3 NRF_DEFAULT_IRQ_PRIORITY>;
 			easydma-maxcnt-bits = <10>;
 			status = "disabled";

--- a/dts/arm/nordic/nrf52810.dtsi
+++ b/dts/arm/nordic/nrf52810.dtsi
@@ -131,7 +131,7 @@
 			#size-cells = <0>;
 			reg = <0x40003000 0x1000>;
 			interrupts = <3 NRF_DEFAULT_IRQ_PRIORITY>;
-			easydma-maxcnt-bits = <10>;
+			nordic,easydma-maxcnt-bits = <10>;
 			status = "disabled";
 			zephyr,pm-device-runtime-auto;
 		};
@@ -149,8 +149,8 @@
 			#size-cells = <0>;
 			reg = <0x40004000 0x1000>;
 			interrupts = <4 NRF_DEFAULT_IRQ_PRIORITY>;
-			max-frequency = <DT_FREQ_M(8)>;
-			easydma-maxcnt-bits = <10>;
+			nordic,spi-max-frequency = <DT_FREQ_M(8)>;
+			nordic,easydma-maxcnt-bits = <10>;
 			status = "disabled";
 		};
 

--- a/dts/arm/nordic/nrf52811.dtsi
+++ b/dts/arm/nordic/nrf52811.dtsi
@@ -142,7 +142,6 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003000 0x1000>;
-			clock-frequency = <I2C_BITRATE_STANDARD>;
 			interrupts = <3 NRF_DEFAULT_IRQ_PRIORITY>;
 			easydma-maxcnt-bits = <14>;
 			status = "disabled";

--- a/dts/arm/nordic/nrf52811.dtsi
+++ b/dts/arm/nordic/nrf52811.dtsi
@@ -143,7 +143,7 @@
 			#size-cells = <0>;
 			reg = <0x40003000 0x1000>;
 			interrupts = <3 NRF_DEFAULT_IRQ_PRIORITY>;
-			easydma-maxcnt-bits = <14>;
+			nordic,easydma-maxcnt-bits = <14>;
 			status = "disabled";
 			zephyr,pm-device-runtime-auto;
 		};
@@ -162,8 +162,8 @@
 			#size-cells = <0>;
 			reg = <0x40003000 0x1000>;
 			interrupts = <3 NRF_DEFAULT_IRQ_PRIORITY>;
-			max-frequency = <DT_FREQ_M(8)>;
-			easydma-maxcnt-bits = <14>;
+			nordic,spi-max-frequency = <DT_FREQ_M(8)>;
+			nordic,easydma-maxcnt-bits = <14>;
 			status = "disabled";
 		};
 
@@ -180,8 +180,8 @@
 			#size-cells = <0>;
 			reg = <0x40004000 0x1000>;
 			interrupts = <4 NRF_DEFAULT_IRQ_PRIORITY>;
-			max-frequency = <DT_FREQ_M(8)>;
-			easydma-maxcnt-bits = <14>;
+			nordic,spi-max-frequency = <DT_FREQ_M(8)>;
+			nordic,easydma-maxcnt-bits = <14>;
 			status = "disabled";
 		};
 

--- a/dts/arm/nordic/nrf52820.dtsi
+++ b/dts/arm/nordic/nrf52820.dtsi
@@ -145,7 +145,6 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003000 0x1000>;
-			clock-frequency = <I2C_BITRATE_STANDARD>;
 			interrupts = <3 NRF_DEFAULT_IRQ_PRIORITY>;
 			easydma-maxcnt-bits = <15>;
 			status = "disabled";
@@ -182,7 +181,6 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40004000 0x1000>;
-			clock-frequency = <I2C_BITRATE_STANDARD>;
 			interrupts = <4 NRF_DEFAULT_IRQ_PRIORITY>;
 			easydma-maxcnt-bits = <15>;
 			status = "disabled";

--- a/dts/arm/nordic/nrf52820.dtsi
+++ b/dts/arm/nordic/nrf52820.dtsi
@@ -146,7 +146,7 @@
 			#size-cells = <0>;
 			reg = <0x40003000 0x1000>;
 			interrupts = <3 NRF_DEFAULT_IRQ_PRIORITY>;
-			easydma-maxcnt-bits = <15>;
+			nordic,easydma-maxcnt-bits = <15>;
 			status = "disabled";
 			zephyr,pm-device-runtime-auto;
 		};
@@ -164,8 +164,8 @@
 			#size-cells = <0>;
 			reg = <0x40003000 0x1000>;
 			interrupts = <3 NRF_DEFAULT_IRQ_PRIORITY>;
-			max-frequency = <DT_FREQ_M(8)>;
-			easydma-maxcnt-bits = <15>;
+			nordic,spi-max-frequency = <DT_FREQ_M(8)>;
+			nordic,easydma-maxcnt-bits = <15>;
 			status = "disabled";
 		};
 
@@ -182,7 +182,7 @@
 			#size-cells = <0>;
 			reg = <0x40004000 0x1000>;
 			interrupts = <4 NRF_DEFAULT_IRQ_PRIORITY>;
-			easydma-maxcnt-bits = <15>;
+			nordic,easydma-maxcnt-bits = <15>;
 			status = "disabled";
 			zephyr,pm-device-runtime-auto;
 		};
@@ -200,8 +200,8 @@
 			#size-cells = <0>;
 			reg = <0x40004000 0x1000>;
 			interrupts = <4 NRF_DEFAULT_IRQ_PRIORITY>;
-			max-frequency = <DT_FREQ_M(8)>;
-			easydma-maxcnt-bits = <15>;
+			nordic,spi-max-frequency = <DT_FREQ_M(8)>;
+			nordic,easydma-maxcnt-bits = <15>;
 			status = "disabled";
 		};
 

--- a/dts/arm/nordic/nrf52832.dtsi
+++ b/dts/arm/nordic/nrf52832.dtsi
@@ -130,7 +130,6 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003000 0x1000>;
-			clock-frequency = <I2C_BITRATE_STANDARD>;
 			interrupts = <3 NRF_DEFAULT_IRQ_PRIORITY>;
 			easydma-maxcnt-bits = <8>;
 			status = "disabled";
@@ -167,7 +166,6 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40004000 0x1000>;
-			clock-frequency = <I2C_BITRATE_STANDARD>;
 			interrupts = <4 NRF_DEFAULT_IRQ_PRIORITY>;
 			easydma-maxcnt-bits = <8>;
 			status = "disabled";

--- a/dts/arm/nordic/nrf52832.dtsi
+++ b/dts/arm/nordic/nrf52832.dtsi
@@ -131,7 +131,7 @@
 			#size-cells = <0>;
 			reg = <0x40003000 0x1000>;
 			interrupts = <3 NRF_DEFAULT_IRQ_PRIORITY>;
-			easydma-maxcnt-bits = <8>;
+			nordic,easydma-maxcnt-bits = <8>;
 			status = "disabled";
 			zephyr,pm-device-runtime-auto;
 		};
@@ -149,8 +149,8 @@
 			#size-cells = <0>;
 			reg = <0x40003000 0x1000>;
 			interrupts = <3 NRF_DEFAULT_IRQ_PRIORITY>;
-			max-frequency = <DT_FREQ_M(8)>;
-			easydma-maxcnt-bits = <8>;
+			nordic,spi-max-frequency = <DT_FREQ_M(8)>;
+			nordic,easydma-maxcnt-bits = <8>;
 			status = "disabled";
 		};
 
@@ -167,7 +167,7 @@
 			#size-cells = <0>;
 			reg = <0x40004000 0x1000>;
 			interrupts = <4 NRF_DEFAULT_IRQ_PRIORITY>;
-			easydma-maxcnt-bits = <8>;
+			nordic,easydma-maxcnt-bits = <8>;
 			status = "disabled";
 			zephyr,pm-device-runtime-auto;
 		};
@@ -185,8 +185,8 @@
 			#size-cells = <0>;
 			reg = <0x40004000 0x1000>;
 			interrupts = <4 NRF_DEFAULT_IRQ_PRIORITY>;
-			max-frequency = <DT_FREQ_M(8)>;
-			easydma-maxcnt-bits = <8>;
+			nordic,spi-max-frequency = <DT_FREQ_M(8)>;
+			nordic,easydma-maxcnt-bits = <8>;
 			status = "disabled";
 		};
 
@@ -450,8 +450,8 @@
 			#size-cells = <0>;
 			reg = <0x40023000 0x1000>;
 			interrupts = <35 NRF_DEFAULT_IRQ_PRIORITY>;
-			max-frequency = <DT_FREQ_M(8)>;
-			easydma-maxcnt-bits = <8>;
+			nordic,spi-max-frequency = <DT_FREQ_M(8)>;
+			nordic,easydma-maxcnt-bits = <8>;
 			status = "disabled";
 		};
 

--- a/dts/arm/nordic/nrf52833.dtsi
+++ b/dts/arm/nordic/nrf52833.dtsi
@@ -145,7 +145,7 @@
 			#size-cells = <0>;
 			reg = <0x40003000 0x1000>;
 			interrupts = <3 NRF_DEFAULT_IRQ_PRIORITY>;
-			easydma-maxcnt-bits = <16>;
+			nordic,easydma-maxcnt-bits = <16>;
 			status = "disabled";
 			zephyr,pm-device-runtime-auto;
 		};
@@ -163,8 +163,8 @@
 			#size-cells = <0>;
 			reg = <0x40003000 0x1000>;
 			interrupts = <3 NRF_DEFAULT_IRQ_PRIORITY>;
-			max-frequency = <DT_FREQ_M(8)>;
-			easydma-maxcnt-bits = <16>;
+			nordic,spi-max-frequency = <DT_FREQ_M(8)>;
+			nordic,easydma-maxcnt-bits = <16>;
 			status = "disabled";
 		};
 
@@ -181,7 +181,7 @@
 			#size-cells = <0>;
 			reg = <0x40004000 0x1000>;
 			interrupts = <4 NRF_DEFAULT_IRQ_PRIORITY>;
-			easydma-maxcnt-bits = <16>;
+			nordic,easydma-maxcnt-bits = <16>;
 			status = "disabled";
 			zephyr,pm-device-runtime-auto;
 		};
@@ -199,8 +199,8 @@
 			#size-cells = <0>;
 			reg = <0x40004000 0x1000>;
 			interrupts = <4 NRF_DEFAULT_IRQ_PRIORITY>;
-			max-frequency = <DT_FREQ_M(8)>;
-			easydma-maxcnt-bits = <16>;
+			nordic,spi-max-frequency = <DT_FREQ_M(8)>;
+			nordic,easydma-maxcnt-bits = <16>;
 			status = "disabled";
 		};
 
@@ -472,8 +472,8 @@
 			#size-cells = <0>;
 			reg = <0x40023000 0x1000>;
 			interrupts = <35 NRF_DEFAULT_IRQ_PRIORITY>;
-			max-frequency = <DT_FREQ_M(8)>;
-			easydma-maxcnt-bits = <16>;
+			nordic,spi-max-frequency = <DT_FREQ_M(8)>;
+			nordic,easydma-maxcnt-bits = <16>;
 			status = "disabled";
 		};
 
@@ -529,8 +529,8 @@
 			#size-cells = <0>;
 			reg = <0x4002f000 0x1000>;
 			interrupts = <47 NRF_DEFAULT_IRQ_PRIORITY>;
-			max-frequency = <DT_FREQ_M(32)>;
-			easydma-maxcnt-bits = <16>;
+			nordic,spi-max-frequency = <DT_FREQ_M(32)>;
+			nordic,easydma-maxcnt-bits = <16>;
 			rx-delay-supported;
 			rx-delay = <2>;
 			status = "disabled";

--- a/dts/arm/nordic/nrf52833.dtsi
+++ b/dts/arm/nordic/nrf52833.dtsi
@@ -144,7 +144,6 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003000 0x1000>;
-			clock-frequency = <I2C_BITRATE_STANDARD>;
 			interrupts = <3 NRF_DEFAULT_IRQ_PRIORITY>;
 			easydma-maxcnt-bits = <16>;
 			status = "disabled";
@@ -181,7 +180,6 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40004000 0x1000>;
-			clock-frequency = <I2C_BITRATE_STANDARD>;
 			interrupts = <4 NRF_DEFAULT_IRQ_PRIORITY>;
 			easydma-maxcnt-bits = <16>;
 			status = "disabled";

--- a/dts/arm/nordic/nrf52840.dtsi
+++ b/dts/arm/nordic/nrf52840.dtsi
@@ -133,7 +133,7 @@
 			#size-cells = <0>;
 			reg = <0x40003000 0x1000>;
 			interrupts = <3 NRF_DEFAULT_IRQ_PRIORITY>;
-			easydma-maxcnt-bits = <16>;
+			nordic,easydma-maxcnt-bits = <16>;
 			status = "disabled";
 			zephyr,pm-device-runtime-auto;
 		};
@@ -151,8 +151,8 @@
 			#size-cells = <0>;
 			reg = <0x40003000 0x1000>;
 			interrupts = <3 NRF_DEFAULT_IRQ_PRIORITY>;
-			max-frequency = <DT_FREQ_M(8)>;
-			easydma-maxcnt-bits = <16>;
+			nordic,spi-max-frequency = <DT_FREQ_M(8)>;
+			nordic,easydma-maxcnt-bits = <16>;
 			status = "disabled";
 		};
 
@@ -169,7 +169,7 @@
 			#size-cells = <0>;
 			reg = <0x40004000 0x1000>;
 			interrupts = <4 NRF_DEFAULT_IRQ_PRIORITY>;
-			easydma-maxcnt-bits = <16>;
+			nordic,easydma-maxcnt-bits = <16>;
 			status = "disabled";
 			zephyr,pm-device-runtime-auto;
 		};
@@ -187,8 +187,8 @@
 			#size-cells = <0>;
 			reg = <0x40004000 0x1000>;
 			interrupts = <4 NRF_DEFAULT_IRQ_PRIORITY>;
-			max-frequency = <DT_FREQ_M(8)>;
-			easydma-maxcnt-bits = <16>;
+			nordic,spi-max-frequency = <DT_FREQ_M(8)>;
+			nordic,easydma-maxcnt-bits = <16>;
 			status = "disabled";
 		};
 
@@ -459,8 +459,8 @@
 			#size-cells = <0>;
 			reg = <0x40023000 0x1000>;
 			interrupts = <35 NRF_DEFAULT_IRQ_PRIORITY>;
-			max-frequency = <DT_FREQ_M(8)>;
-			easydma-maxcnt-bits = <16>;
+			nordic,spi-max-frequency = <DT_FREQ_M(8)>;
+			nordic,easydma-maxcnt-bits = <16>;
 			status = "disabled";
 		};
 
@@ -526,8 +526,8 @@
 			#size-cells = <0>;
 			reg = <0x4002f000 0x1000>;
 			interrupts = <47 NRF_DEFAULT_IRQ_PRIORITY>;
-			max-frequency = <DT_FREQ_M(32)>;
-			easydma-maxcnt-bits = <16>;
+			nordic,spi-max-frequency = <DT_FREQ_M(32)>;
+			nordic,easydma-maxcnt-bits = <16>;
 			rx-delay-supported;
 			rx-delay = <2>;
 			status = "disabled";

--- a/dts/arm/nordic/nrf52840.dtsi
+++ b/dts/arm/nordic/nrf52840.dtsi
@@ -132,7 +132,6 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003000 0x1000>;
-			clock-frequency = <I2C_BITRATE_STANDARD>;
 			interrupts = <3 NRF_DEFAULT_IRQ_PRIORITY>;
 			easydma-maxcnt-bits = <16>;
 			status = "disabled";
@@ -169,7 +168,6 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40004000 0x1000>;
-			clock-frequency = <I2C_BITRATE_STANDARD>;
 			interrupts = <4 NRF_DEFAULT_IRQ_PRIORITY>;
 			easydma-maxcnt-bits = <16>;
 			status = "disabled";

--- a/dts/arm/nordic/nrf52840.dtsi
+++ b/dts/arm/nordic/nrf52840.dtsi
@@ -120,33 +120,17 @@
 			status = "disabled";
 		};
 
-		i2c0: i2c@40003000 {
+		i2c0: spi0: seriobox@40003000 {
 			/*
-			 * This i2c node can be TWI, TWIM, or TWIS,
-			 * for the user to pick:
-			 * compatible = "nordic,nrf-twi" or
-			 *              "nordic,nrf-twim" or
-			 *              "nordic,nrf-twis".
-			 */
-			compatible = "nordic,nrf-twim";
-			#address-cells = <1>;
-			#size-cells = <0>;
-			reg = <0x40003000 0x1000>;
-			interrupts = <3 NRF_DEFAULT_IRQ_PRIORITY>;
-			nordic,easydma-maxcnt-bits = <16>;
-			status = "disabled";
-			zephyr,pm-device-runtime-auto;
-		};
-
-		spi0: spi@40003000 {
-			/*
-			 * This spi node can be SPI, SPIM, or SPIS,
+			 * This node can be SPI/TWI, SPIM/TWIM, SPIS/TWIS,
 			 * for the user to pick:
 			 * compatible = "nordic,nrf-spi" or
 			 *              "nordic,nrf-spim" or
-			 *              "nordic,nrf-spis".
+			 *              "nordic,nrf-spis" pr
+			 *              "nordic,nrf-twi" or
+			 *              "nordic,nrf-twim" or
+			 *              "nordic,nrf-twis".
 			 */
-			compatible = "nordic,nrf-spim";
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003000 0x1000>;
@@ -154,35 +138,20 @@
 			nordic,spi-max-frequency = <DT_FREQ_M(8)>;
 			nordic,easydma-maxcnt-bits = <16>;
 			status = "disabled";
-		};
-
-		i2c1: i2c@40004000 {
-			/*
-			 * This i2c node can be TWI, TWIM, or TWIS,
-			 * for the user to pick:
-			 * compatible = "nordic,nrf-twi" or
-			 *              "nordic,nrf-twim" or
-			 *              "nordic,nrf-twis".
-			 */
-			compatible = "nordic,nrf-twim";
-			#address-cells = <1>;
-			#size-cells = <0>;
-			reg = <0x40004000 0x1000>;
-			interrupts = <4 NRF_DEFAULT_IRQ_PRIORITY>;
-			nordic,easydma-maxcnt-bits = <16>;
-			status = "disabled";
 			zephyr,pm-device-runtime-auto;
 		};
 
-		spi1: spi@40004000 {
+		i2c1: spi1: seriobox@40004000 {
 			/*
-			 * This spi node can be SPI, SPIM, or SPIS,
+			 * This node can be SPI/TWI, SPIM/TWIM, SPIS/TWIS,
 			 * for the user to pick:
 			 * compatible = "nordic,nrf-spi" or
 			 *              "nordic,nrf-spim" or
-			 *              "nordic,nrf-spis".
+			 *              "nordic,nrf-spis" pr
+			 *              "nordic,nrf-twi" or
+			 *              "nordic,nrf-twim" or
+			 *              "nordic,nrf-twis".
 			 */
-			compatible = "nordic,nrf-spim";
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40004000 0x1000>;
@@ -190,6 +159,7 @@
 			nordic,spi-max-frequency = <DT_FREQ_M(8)>;
 			nordic,easydma-maxcnt-bits = <16>;
 			status = "disabled";
+			zephyr,pm-device-runtime-auto;
 		};
 
 		nfct: nfct@40005000 {

--- a/dts/arm/nordic/nrf5340_cpuapp_peripherals.dtsi
+++ b/dts/arm/nordic/nrf5340_cpuapp_peripherals.dtsi
@@ -115,7 +115,6 @@ i2c0: i2c@8000 {
 	#address-cells = <1>;
 	#size-cells = <0>;
 	reg = <0x8000 0x1000>;
-	clock-frequency = <I2C_BITRATE_STANDARD>;
 	interrupts = <8 NRF_DEFAULT_IRQ_PRIORITY>;
 	easydma-maxcnt-bits = <16>;
 	status = "disabled";
@@ -157,7 +156,6 @@ i2c1: i2c@9000 {
 	#address-cells = <1>;
 	#size-cells = <0>;
 	reg = <0x9000 0x1000>;
-	clock-frequency = <I2C_BITRATE_STANDARD>;
 	interrupts = <9 NRF_DEFAULT_IRQ_PRIORITY>;
 	easydma-maxcnt-bits = <16>;
 	status = "disabled";
@@ -212,7 +210,6 @@ i2c2: i2c@b000 {
 	#address-cells = <1>;
 	#size-cells = <0>;
 	reg = <0xb000 0x1000>;
-	clock-frequency = <I2C_BITRATE_STANDARD>;
 	interrupts = <11 NRF_DEFAULT_IRQ_PRIORITY>;
 	easydma-maxcnt-bits = <16>;
 	status = "disabled";
@@ -254,7 +251,6 @@ i2c3: i2c@c000 {
 	#address-cells = <1>;
 	#size-cells = <0>;
 	reg = <0xc000 0x1000>;
-	clock-frequency = <I2C_BITRATE_STANDARD>;
 	interrupts = <12 NRF_DEFAULT_IRQ_PRIORITY>;
 	easydma-maxcnt-bits = <16>;
 	status = "disabled";

--- a/dts/arm/nordic/nrf5340_cpuapp_peripherals.dtsi
+++ b/dts/arm/nordic/nrf5340_cpuapp_peripherals.dtsi
@@ -116,7 +116,7 @@ i2c0: i2c@8000 {
 	#size-cells = <0>;
 	reg = <0x8000 0x1000>;
 	interrupts = <8 NRF_DEFAULT_IRQ_PRIORITY>;
-	easydma-maxcnt-bits = <16>;
+	nordic,easydma-maxcnt-bits = <16>;
 	status = "disabled";
 	zephyr,pm-device-runtime-auto;
 };
@@ -133,8 +133,8 @@ spi0: spi@8000 {
 	#size-cells = <0>;
 	reg = <0x8000 0x1000>;
 	interrupts = <8 NRF_DEFAULT_IRQ_PRIORITY>;
-	max-frequency = <DT_FREQ_M(8)>;
-	easydma-maxcnt-bits = <16>;
+	nordic,spi-max-frequency = <DT_FREQ_M(8)>;
+	nordic,easydma-maxcnt-bits = <16>;
 	status = "disabled";
 };
 
@@ -157,7 +157,7 @@ i2c1: i2c@9000 {
 	#size-cells = <0>;
 	reg = <0x9000 0x1000>;
 	interrupts = <9 NRF_DEFAULT_IRQ_PRIORITY>;
-	easydma-maxcnt-bits = <16>;
+	nordic,easydma-maxcnt-bits = <16>;
 	status = "disabled";
 	zephyr,pm-device-runtime-auto;
 };
@@ -174,8 +174,8 @@ spi1: spi@9000 {
 	#size-cells = <0>;
 	reg = <0x9000 0x1000>;
 	interrupts = <9 NRF_DEFAULT_IRQ_PRIORITY>;
-	max-frequency = <DT_FREQ_M(8)>;
-	easydma-maxcnt-bits = <16>;
+	nordic,spi-max-frequency = <DT_FREQ_M(8)>;
+	nordic,easydma-maxcnt-bits = <16>;
 	status = "disabled";
 };
 
@@ -192,8 +192,8 @@ spi4: spi@a000 {
 	#size-cells = <0>;
 	reg = <0xa000 0x1000>;
 	interrupts = <10 NRF_DEFAULT_IRQ_PRIORITY>;
-	max-frequency = <DT_FREQ_M(32)>;
-	easydma-maxcnt-bits = <16>;
+	nordic,spi-max-frequency = <DT_FREQ_M(32)>;
+	nordic,easydma-maxcnt-bits = <16>;
 	rx-delay-supported;
 	rx-delay = <2>;
 	status = "disabled";
@@ -211,7 +211,7 @@ i2c2: i2c@b000 {
 	#size-cells = <0>;
 	reg = <0xb000 0x1000>;
 	interrupts = <11 NRF_DEFAULT_IRQ_PRIORITY>;
-	easydma-maxcnt-bits = <16>;
+	nordic,easydma-maxcnt-bits = <16>;
 	status = "disabled";
 	zephyr,pm-device-runtime-auto;
 };
@@ -228,8 +228,8 @@ spi2: spi@b000 {
 	#size-cells = <0>;
 	reg = <0xb000 0x1000>;
 	interrupts = <11 NRF_DEFAULT_IRQ_PRIORITY>;
-	max-frequency = <DT_FREQ_M(8)>;
-	easydma-maxcnt-bits = <16>;
+	nordic,spi-max-frequency = <DT_FREQ_M(8)>;
+	nordic,easydma-maxcnt-bits = <16>;
 	status = "disabled";
 };
 
@@ -252,7 +252,7 @@ i2c3: i2c@c000 {
 	#size-cells = <0>;
 	reg = <0xc000 0x1000>;
 	interrupts = <12 NRF_DEFAULT_IRQ_PRIORITY>;
-	easydma-maxcnt-bits = <16>;
+	nordic,easydma-maxcnt-bits = <16>;
 	status = "disabled";
 	zephyr,pm-device-runtime-auto;
 };
@@ -269,8 +269,8 @@ spi3: spi@c000 {
 	#size-cells = <0>;
 	reg = <0xc000 0x1000>;
 	interrupts = <12 NRF_DEFAULT_IRQ_PRIORITY>;
-	max-frequency = <DT_FREQ_M(8)>;
-	easydma-maxcnt-bits = <16>;
+	nordic,spi-max-frequency = <DT_FREQ_M(8)>;
+	nordic,easydma-maxcnt-bits = <16>;
 	status = "disabled";
 };
 

--- a/dts/arm/nordic/nrf5340_cpunet.dtsi
+++ b/dts/arm/nordic/nrf5340_cpunet.dtsi
@@ -201,7 +201,6 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x41013000 0x1000>;
-			clock-frequency = <I2C_BITRATE_STANDARD>;
 			interrupts = <19 NRF_DEFAULT_IRQ_PRIORITY>;
 			easydma-maxcnt-bits = <16>;
 			status = "disabled";

--- a/dts/arm/nordic/nrf5340_cpunet.dtsi
+++ b/dts/arm/nordic/nrf5340_cpunet.dtsi
@@ -202,7 +202,7 @@
 			#size-cells = <0>;
 			reg = <0x41013000 0x1000>;
 			interrupts = <19 NRF_DEFAULT_IRQ_PRIORITY>;
-			easydma-maxcnt-bits = <16>;
+			nordic,easydma-maxcnt-bits = <16>;
 			status = "disabled";
 			zephyr,pm-device-runtime-auto;
 		};
@@ -219,8 +219,8 @@
 			#size-cells = <0>;
 			reg = <0x41013000 0x1000>;
 			interrupts = <19 NRF_DEFAULT_IRQ_PRIORITY>;
-			max-frequency = <DT_FREQ_M(8)>;
-			easydma-maxcnt-bits = <16>;
+			nordic,spi-max-frequency = <DT_FREQ_M(8)>;
+			nordic,easydma-maxcnt-bits = <16>;
 			status = "disabled";
 		};
 

--- a/dts/arm/nordic/nrf91_peripherals.dtsi
+++ b/dts/arm/nordic/nrf91_peripherals.dtsi
@@ -156,7 +156,6 @@ i2c0: i2c@8000 {
 	#address-cells = <1>;
 	#size-cells = <0>;
 	reg = <0x8000 0x1000>;
-	clock-frequency = <I2C_BITRATE_STANDARD>;
 	interrupts = <8 NRF_DEFAULT_IRQ_PRIORITY>;
 	easydma-maxcnt-bits = <13>;
 	status = "disabled";
@@ -173,7 +172,6 @@ i2c1: i2c@9000 {
 	#address-cells = <1>;
 	#size-cells = <0>;
 	reg = <0x9000 0x1000>;
-	clock-frequency = <I2C_BITRATE_STANDARD>;
 	interrupts = <9 NRF_DEFAULT_IRQ_PRIORITY>;
 	easydma-maxcnt-bits = <13>;
 	status = "disabled";
@@ -190,7 +188,6 @@ i2c2: i2c@a000 {
 	#address-cells = <1>;
 	#size-cells = <0>;
 	reg = <0xa000 0x1000>;
-	clock-frequency = <I2C_BITRATE_STANDARD>;
 	interrupts = <10 NRF_DEFAULT_IRQ_PRIORITY>;
 	easydma-maxcnt-bits = <13>;
 	status = "disabled";
@@ -207,7 +204,6 @@ i2c3: i2c@b000 {
 	#address-cells = <1>;
 	#size-cells = <0>;
 	reg = <0xb000 0x1000>;
-	clock-frequency = <I2C_BITRATE_STANDARD>;
 	interrupts = <11 NRF_DEFAULT_IRQ_PRIORITY>;
 	easydma-maxcnt-bits = <13>;
 	status = "disabled";

--- a/dts/arm/nordic/nrf91_peripherals.dtsi
+++ b/dts/arm/nordic/nrf91_peripherals.dtsi
@@ -157,7 +157,7 @@ i2c0: i2c@8000 {
 	#size-cells = <0>;
 	reg = <0x8000 0x1000>;
 	interrupts = <8 NRF_DEFAULT_IRQ_PRIORITY>;
-	easydma-maxcnt-bits = <13>;
+	nordic,easydma-maxcnt-bits = <13>;
 	status = "disabled";
 	zephyr,pm-device-runtime-auto;
 };
@@ -173,7 +173,7 @@ i2c1: i2c@9000 {
 	#size-cells = <0>;
 	reg = <0x9000 0x1000>;
 	interrupts = <9 NRF_DEFAULT_IRQ_PRIORITY>;
-	easydma-maxcnt-bits = <13>;
+	nordic,easydma-maxcnt-bits = <13>;
 	status = "disabled";
 	zephyr,pm-device-runtime-auto;
 };
@@ -189,7 +189,7 @@ i2c2: i2c@a000 {
 	#size-cells = <0>;
 	reg = <0xa000 0x1000>;
 	interrupts = <10 NRF_DEFAULT_IRQ_PRIORITY>;
-	easydma-maxcnt-bits = <13>;
+	nordic,easydma-maxcnt-bits = <13>;
 	status = "disabled";
 	zephyr,pm-device-runtime-auto;
 };
@@ -205,7 +205,7 @@ i2c3: i2c@b000 {
 	#size-cells = <0>;
 	reg = <0xb000 0x1000>;
 	interrupts = <11 NRF_DEFAULT_IRQ_PRIORITY>;
-	easydma-maxcnt-bits = <13>;
+	nordic,easydma-maxcnt-bits = <13>;
 	status = "disabled";
 	zephyr,pm-device-runtime-auto;
 };
@@ -221,8 +221,8 @@ spi0: spi@8000 {
 	#size-cells = <0>;
 	reg = <0x8000 0x1000>;
 	interrupts = <8 NRF_DEFAULT_IRQ_PRIORITY>;
-	max-frequency = <DT_FREQ_M(8)>;
-	easydma-maxcnt-bits = <13>;
+	nordic,spi-max-frequency = <DT_FREQ_M(8)>;
+	nordic,easydma-maxcnt-bits = <13>;
 	status = "disabled";
 };
 
@@ -237,8 +237,8 @@ spi1: spi@9000 {
 	#size-cells = <0>;
 	reg = <0x9000 0x1000>;
 	interrupts = <9 NRF_DEFAULT_IRQ_PRIORITY>;
-	max-frequency = <DT_FREQ_M(8)>;
-	easydma-maxcnt-bits = <13>;
+	nordic,spi-max-frequency = <DT_FREQ_M(8)>;
+	nordic,easydma-maxcnt-bits = <13>;
 	status = "disabled";
 };
 
@@ -253,8 +253,8 @@ spi2: spi@a000 {
 	#size-cells = <0>;
 	reg = <0xa000 0x1000>;
 	interrupts = <10 NRF_DEFAULT_IRQ_PRIORITY>;
-	max-frequency = <DT_FREQ_M(8)>;
-	easydma-maxcnt-bits = <13>;
+	nordic,spi-max-frequency = <DT_FREQ_M(8)>;
+	nordic,easydma-maxcnt-bits = <13>;
 	status = "disabled";
 };
 
@@ -269,8 +269,8 @@ spi3: spi@b000 {
 	#size-cells = <0>;
 	reg = <0xb000 0x1000>;
 	interrupts = <11 NRF_DEFAULT_IRQ_PRIORITY>;
-	max-frequency = <DT_FREQ_M(8)>;
-	easydma-maxcnt-bits = <13>;
+	nordic,spi-max-frequency = <DT_FREQ_M(8)>;
+	nordic,easydma-maxcnt-bits = <13>;
 	status = "disabled";
 };
 

--- a/dts/bindings/i2c/nordic,nrf-twi-common.yaml
+++ b/dts/bindings/i2c/nordic,nrf-twi-common.yaml
@@ -4,7 +4,7 @@
 
 # Common fields for Nordic nRF family TWI peripherals
 
-include: [i2c-controller.yaml, pinctrl-device.yaml, nordic-clockpin.yaml]
+include: [i2c-controller.yaml, pinctrl-device.yaml, nordic-nrf-seriobox.yaml, nordic-clockpin.yaml]
 
 properties:
   reg:
@@ -18,10 +18,3 @@ properties:
 
   pinctrl-names:
     required: true
-
-  easydma-maxcnt-bits:
-    type: int
-    required: true
-    description: |
-      Maximum number of bits available in the EasyDMA MAXCNT register. This
-      property must be set at SoC level DTS files.

--- a/dts/bindings/misc/nordic-nrf-seriobox.yaml
+++ b/dts/bindings/misc/nordic-nrf-seriobox.yaml
@@ -1,0 +1,17 @@
+# Copyright 2024 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  Common properties for the Nordic nRF serial-based peripheral (TWI[M/S],
+  SPI[M/S], UART[E]).
+
+properties:
+  nordic,spi-max-frequency:
+    type: int
+    description: |
+      Maximum SPI frequency supported by the peripheral.
+
+  nordic,easydma-maxcnt-bits:
+    type: int
+    description: |
+      Maximum number of bits available in the EasyDMA MAXCNT register.

--- a/dts/bindings/serial/nordic,nrf-uart-common.yaml
+++ b/dts/bindings/serial/nordic,nrf-uart-common.yaml
@@ -1,4 +1,4 @@
-include: [uart-controller.yaml, pinctrl-device.yaml, nordic-clockpin.yaml]
+include: [uart-controller.yaml, pinctrl-device.yaml, nordic-nrf-seriobox.yaml, nordic-clockpin.yaml]
 
 properties:
   reg:

--- a/dts/bindings/spi/nordic,nrf-spi-common.yaml
+++ b/dts/bindings/spi/nordic,nrf-spi-common.yaml
@@ -3,7 +3,7 @@
 
 # Common fields for Nordic nRF family SPI peripherals
 
-include: [spi-controller.yaml, pinctrl-device.yaml, nordic-clockpin.yaml]
+include: [spi-controller.yaml, pinctrl-device.yaml, nordic-nrf-seriobox.yaml, nordic-clockpin.yaml]
 
 properties:
   reg:
@@ -18,25 +18,11 @@ properties:
   pinctrl-names:
     required: true
 
-  max-frequency:
-    type: int
-    required: true
-    description: |
-      Maximum data rate the SPI peripheral can be driven at, in Hz. This
-      property must be set at SoC level DTS files.
-
   overrun-character:
     default: 0xff
     description: |
       Configurable, defaults to 0xff (line high), the most common value used
       in SPI transfers.
-
-  easydma-maxcnt-bits:
-    type: int
-    required: true
-    description: |
-      Maximum number of bits available in the EasyDMA MAXCNT register. This
-      property must be set at SoC level DTS files.
 
   wake-gpios:
     type: phandle-array

--- a/dts/common/nordic/nrf54h20.dtsi
+++ b/dts/common/nordic/nrf54h20.dtsi
@@ -370,7 +370,7 @@
 				interrupts = <40 NRF_DEFAULT_IRQ_PRIORITY>;
 				clocks = <&fll16m>;
 				max-bit-width = <32>;
-				max-frequency = <DT_FREQ_M(32)>;
+				nordic,spi-max-frequency = <DT_FREQ_M(32)>;
 				prescaler = <0>;
 			};
 
@@ -382,7 +382,7 @@
 				interrupts = <41 NRF_DEFAULT_IRQ_PRIORITY>;
 				clocks = <&fll16m>;
 				max-bit-width = <32>;
-				max-frequency = <DT_FREQ_M(32)>;
+				nordic,spi-max-frequency = <DT_FREQ_M(32)>;
 				prescaler = <0>;
 			};
 
@@ -394,7 +394,7 @@
 				interrupts = <42 NRF_DEFAULT_IRQ_PRIORITY>;
 				clocks = <&fll16m>;
 				max-bit-width = <32>;
-				max-frequency = <DT_FREQ_M(32)>;
+				nordic,spi-max-frequency = <DT_FREQ_M(32)>;
 				prescaler = <0>;
 			};
 
@@ -598,7 +598,7 @@
 				cc-num = <6>;
 				interrupts = <226 NRF_DEFAULT_IRQ_PRIORITY>;
 				max-bit-width = <32>;
-				max-frequency = <DT_FREQ_M(320)>;
+				nordic,spi-max-frequency = <DT_FREQ_M(320)>;
 				prescaler = <0>;
 			};
 
@@ -609,7 +609,7 @@
 				cc-num = <6>;
 				interrupts = <227 NRF_DEFAULT_IRQ_PRIORITY>;
 				max-bit-width = <32>;
-				max-frequency = <DT_FREQ_M(320)>;
+				nordic,spi-max-frequency = <DT_FREQ_M(320)>;
 				prescaler = <0>;
 			};
 
@@ -625,9 +625,9 @@
 				compatible = "nordic,nrf-spim";
 				reg = <0x8e6000 0x1000>;
 				status = "disabled";
-				easydma-maxcnt-bits = <15>;
+				nordic,easydma-maxcnt-bits = <15>;
 				interrupts = <230 NRF_DEFAULT_IRQ_PRIORITY>;
-				max-frequency = <DT_FREQ_M(32)>;
+				nordic,spi-max-frequency = <DT_FREQ_M(32)>;
 				#address-cells = <1>;
 				#size-cells = <0>;
 				rx-delay-supported;
@@ -650,9 +650,9 @@
 				compatible = "nordic,nrf-spim";
 				reg = <0x8e7000 0x1000>;
 				status = "disabled";
-				easydma-maxcnt-bits = <15>;
+				nordic,easydma-maxcnt-bits = <15>;
 				interrupts = <231 NRF_DEFAULT_IRQ_PRIORITY>;
-				max-frequency = <DT_FREQ_M(32)>;
+				nordic,spi-max-frequency = <DT_FREQ_M(32)>;
 				#address-cells = <1>;
 				#size-cells = <0>;
 				rx-delay-supported;
@@ -923,7 +923,7 @@
 				status = "disabled";
 				interrupts = <421 NRF_DEFAULT_IRQ_PRIORITY>;
 				clocks = <&fll16m>;
-				easydma-maxcnt-bits = <15>;
+				nordic,easydma-maxcnt-bits = <15>;
 				#address-cells = <1>;
 				#size-cells = <0>;
 				nordic,clockpin-enable = <NRF_FUN_TWIM_SDA>,
@@ -935,10 +935,10 @@
 				compatible = "nordic,nrf-spim";
 				reg = <0x9a5000 0x1000>;
 				status = "disabled";
-				easydma-maxcnt-bits = <15>;
+				nordic,easydma-maxcnt-bits = <15>;
 				interrupts = <421 NRF_DEFAULT_IRQ_PRIORITY>;
 				clocks = <&fll16m>;
-				max-frequency = <DT_FREQ_M(8)>;
+				nordic,spi-max-frequency = <DT_FREQ_M(8)>;
 				#address-cells = <1>;
 				#size-cells = <0>;
 				rx-delay-supported;
@@ -966,7 +966,7 @@
 				status = "disabled";
 				interrupts = <422 NRF_DEFAULT_IRQ_PRIORITY>;
 				clocks = <&fll16m>;
-				easydma-maxcnt-bits = <15>;
+				nordic,easydma-maxcnt-bits = <15>;
 				#address-cells = <1>;
 				#size-cells = <0>;
 				nordic,clockpin-enable = <NRF_FUN_TWIM_SDA>,
@@ -978,10 +978,10 @@
 				compatible = "nordic,nrf-spim";
 				reg = <0x9a6000 0x1000>;
 				status = "disabled";
-				easydma-maxcnt-bits = <15>;
+				nordic,easydma-maxcnt-bits = <15>;
 				interrupts = <422 NRF_DEFAULT_IRQ_PRIORITY>;
 				clocks = <&fll16m>;
-				max-frequency = <DT_FREQ_M(8)>;
+				nordic,spi-max-frequency = <DT_FREQ_M(8)>;
 				#address-cells = <1>;
 				#size-cells = <0>;
 				rx-delay-supported;
@@ -1046,7 +1046,7 @@
 				status = "disabled";
 				interrupts = <437 NRF_DEFAULT_IRQ_PRIORITY>;
 				clocks = <&fll16m>;
-				easydma-maxcnt-bits = <15>;
+				nordic,easydma-maxcnt-bits = <15>;
 				#address-cells = <1>;
 				#size-cells = <0>;
 				nordic,clockpin-enable = <NRF_FUN_TWIM_SDA>,
@@ -1058,10 +1058,10 @@
 				compatible = "nordic,nrf-spim";
 				reg = <0x9b5000 0x1000>;
 				status = "disabled";
-				easydma-maxcnt-bits = <15>;
+				nordic,easydma-maxcnt-bits = <15>;
 				interrupts = <437 NRF_DEFAULT_IRQ_PRIORITY>;
 				clocks = <&fll16m>;
-				max-frequency = <DT_FREQ_M(8)>;
+				nordic,spi-max-frequency = <DT_FREQ_M(8)>;
 				#address-cells = <1>;
 				#size-cells = <0>;
 				rx-delay-supported;
@@ -1089,7 +1089,7 @@
 				status = "disabled";
 				interrupts = <438 NRF_DEFAULT_IRQ_PRIORITY>;
 				clocks = <&fll16m>;
-				easydma-maxcnt-bits = <15>;
+				nordic,easydma-maxcnt-bits = <15>;
 				#address-cells = <1>;
 				#size-cells = <0>;
 				nordic,clockpin-enable = <NRF_FUN_TWIM_SDA>,
@@ -1101,10 +1101,10 @@
 				compatible = "nordic,nrf-spim";
 				reg = <0x9b6000 0x1000>;
 				status = "disabled";
-				easydma-maxcnt-bits = <15>;
+				nordic,easydma-maxcnt-bits = <15>;
 				interrupts = <438 NRF_DEFAULT_IRQ_PRIORITY>;
 				clocks = <&fll16m>;
-				max-frequency = <DT_FREQ_M(8)>;
+				nordic,spi-max-frequency = <DT_FREQ_M(8)>;
 				#address-cells = <1>;
 				#size-cells = <0>;
 				rx-delay-supported;
@@ -1169,7 +1169,7 @@
 				status = "disabled";
 				interrupts = <453 NRF_DEFAULT_IRQ_PRIORITY>;
 				clocks = <&fll16m>;
-				easydma-maxcnt-bits = <15>;
+				nordic,easydma-maxcnt-bits = <15>;
 				#address-cells = <1>;
 				#size-cells = <0>;
 				nordic,clockpin-enable = <NRF_FUN_TWIM_SDA>,
@@ -1181,10 +1181,10 @@
 				compatible = "nordic,nrf-spim";
 				reg = <0x9c5000 0x1000>;
 				status = "disabled";
-				easydma-maxcnt-bits = <15>;
+				nordic,easydma-maxcnt-bits = <15>;
 				interrupts = <453 NRF_DEFAULT_IRQ_PRIORITY>;
 				clocks = <&fll16m>;
-				max-frequency = <DT_FREQ_M(8)>;
+				nordic,spi-max-frequency = <DT_FREQ_M(8)>;
 				#address-cells = <1>;
 				#size-cells = <0>;
 				rx-delay-supported;
@@ -1212,7 +1212,7 @@
 				status = "disabled";
 				interrupts = <454 NRF_DEFAULT_IRQ_PRIORITY>;
 				clocks = <&fll16m>;
-				easydma-maxcnt-bits = <15>;
+				nordic,easydma-maxcnt-bits = <15>;
 				#address-cells = <1>;
 				#size-cells = <0>;
 				nordic,clockpin-enable = <NRF_FUN_TWIM_SDA>,
@@ -1224,10 +1224,10 @@
 				compatible = "nordic,nrf-spim";
 				reg = <0x9c6000 0x1000>;
 				status = "disabled";
-				easydma-maxcnt-bits = <15>;
+				nordic,easydma-maxcnt-bits = <15>;
 				interrupts = <454 NRF_DEFAULT_IRQ_PRIORITY>;
 				clocks = <&fll16m>;
-				max-frequency = <DT_FREQ_M(8)>;
+				nordic,spi-max-frequency = <DT_FREQ_M(8)>;
 				#address-cells = <1>;
 				#size-cells = <0>;
 				rx-delay-supported;
@@ -1292,7 +1292,7 @@
 				status = "disabled";
 				interrupts = <469 NRF_DEFAULT_IRQ_PRIORITY>;
 				clocks = <&fll16m>;
-				easydma-maxcnt-bits = <15>;
+				nordic,easydma-maxcnt-bits = <15>;
 				#address-cells = <1>;
 				#size-cells = <0>;
 				nordic,clockpin-enable = <NRF_FUN_TWIM_SDA>,
@@ -1304,10 +1304,10 @@
 				compatible = "nordic,nrf-spim";
 				reg = <0x9d5000 0x1000>;
 				status = "disabled";
-				easydma-maxcnt-bits = <15>;
+				nordic,easydma-maxcnt-bits = <15>;
 				interrupts = <469 NRF_DEFAULT_IRQ_PRIORITY>;
 				clocks = <&fll16m>;
-				max-frequency = <DT_FREQ_M(8)>;
+				nordic,spi-max-frequency = <DT_FREQ_M(8)>;
 				#address-cells = <1>;
 				#size-cells = <0>;
 				rx-delay-supported;
@@ -1335,7 +1335,7 @@
 				status = "disabled";
 				interrupts = <470 NRF_DEFAULT_IRQ_PRIORITY>;
 				clocks = <&fll16m>;
-				easydma-maxcnt-bits = <15>;
+				nordic,easydma-maxcnt-bits = <15>;
 				#address-cells = <1>;
 				#size-cells = <0>;
 				nordic,clockpin-enable = <NRF_FUN_TWIM_SDA>,
@@ -1347,10 +1347,10 @@
 				compatible = "nordic,nrf-spim";
 				reg = <0x9d6000 0x1000>;
 				status = "disabled";
-				easydma-maxcnt-bits = <15>;
+				nordic,easydma-maxcnt-bits = <15>;
 				interrupts = <470 NRF_DEFAULT_IRQ_PRIORITY>;
 				clocks = <&fll16m>;
-				max-frequency = <DT_FREQ_M(8)>;
+				nordic,spi-max-frequency = <DT_FREQ_M(8)>;
 				#address-cells = <1>;
 				#size-cells = <0>;
 				rx-delay-supported;

--- a/dts/common/nordic/nrf54l15.dtsi
+++ b/dts/common/nordic/nrf54l15.dtsi
@@ -124,8 +124,8 @@
 				#size-cells = <0>;
 				reg = <0x4a000 0x1000>;
 				interrupts = <74 NRF_DEFAULT_IRQ_PRIORITY>;
-				max-frequency = <DT_FREQ_M(32)>;
-				easydma-maxcnt-bits = <16>;
+				nordic,spi-max-frequency = <DT_FREQ_M(32)>;
+				nordic,easydma-maxcnt-bits = <16>;
 				rx-delay-supported;
 				rx-delay = <1>;
 				status = "disabled";
@@ -175,7 +175,7 @@
 				cc-num = <6>;
 				max-bit-width = <32>;
 				interrupts = <85 NRF_DEFAULT_IRQ_PRIORITY>;
-				max-frequency = <DT_FREQ_M(128)>;
+				nordic,spi-max-frequency = <DT_FREQ_M(128)>;
 				prescaler = <0>;
 			};
 
@@ -192,7 +192,7 @@
 				cc-num = <8>;
 				max-bit-width = <32>;
 				interrupts = <133 NRF_DEFAULT_IRQ_PRIORITY>;
-				max-frequency = <DT_FREQ_M(32)>;
+				nordic,spi-max-frequency = <DT_FREQ_M(32)>;
 				prescaler = <0>;
 			};
 
@@ -240,7 +240,7 @@
 				#size-cells = <0>;
 				reg = <0xc6000 0x1000>;
 				interrupts = <198 NRF_DEFAULT_IRQ_PRIORITY>;
-				easydma-maxcnt-bits = <16>;
+				nordic,easydma-maxcnt-bits = <16>;
 				status = "disabled";
 				zephyr,pm-device-runtime-auto;
 			};
@@ -257,8 +257,8 @@
 				#size-cells = <0>;
 				reg = <0xc6000 0x1000>;
 				interrupts = <198 NRF_DEFAULT_IRQ_PRIORITY>;
-				max-frequency = <DT_FREQ_M(8)>;
-				easydma-maxcnt-bits = <16>;
+				nordic,spi-max-frequency = <DT_FREQ_M(8)>;
+				nordic,easydma-maxcnt-bits = <16>;
 				rx-delay-supported;
 				rx-delay = <1>;
 				status = "disabled";
@@ -279,7 +279,7 @@
 				#size-cells = <0>;
 				reg = <0xc7000 0x1000>;
 				interrupts = <199 NRF_DEFAULT_IRQ_PRIORITY>;
-				easydma-maxcnt-bits = <16>;
+				nordic,easydma-maxcnt-bits = <16>;
 				status = "disabled";
 				zephyr,pm-device-runtime-auto;
 			};
@@ -296,8 +296,8 @@
 				#size-cells = <0>;
 				reg = <0xc7000 0x1000>;
 				interrupts = <199 NRF_DEFAULT_IRQ_PRIORITY>;
-				max-frequency = <DT_FREQ_M(8)>;
-				easydma-maxcnt-bits = <16>;
+				nordic,spi-max-frequency = <DT_FREQ_M(8)>;
+				nordic,easydma-maxcnt-bits = <16>;
 				rx-delay-supported;
 				rx-delay = <1>;
 				status = "disabled";
@@ -318,7 +318,7 @@
 				#size-cells = <0>;
 				reg = <0xc8000 0x1000>;
 				interrupts = <200 NRF_DEFAULT_IRQ_PRIORITY>;
-				easydma-maxcnt-bits = <16>;
+				nordic,easydma-maxcnt-bits = <16>;
 				status = "disabled";
 				zephyr,pm-device-runtime-auto;
 			};
@@ -335,8 +335,8 @@
 				#size-cells = <0>;
 				reg = <0xc8000 0x1000>;
 				interrupts = <200 NRF_DEFAULT_IRQ_PRIORITY>;
-				max-frequency = <DT_FREQ_M(8)>;
-				easydma-maxcnt-bits = <16>;
+				nordic,spi-max-frequency = <DT_FREQ_M(8)>;
+				nordic,easydma-maxcnt-bits = <16>;
 				rx-delay-supported;
 				rx-delay = <1>;
 				status = "disabled";
@@ -528,7 +528,7 @@
 				#size-cells = <0>;
 				reg = <0x104000 0x1000>;
 				interrupts = <260 NRF_DEFAULT_IRQ_PRIORITY>;
-				easydma-maxcnt-bits = <16>;
+				nordic,easydma-maxcnt-bits = <16>;
 				status = "disabled";
 				zephyr,pm-device-runtime-auto;
 			};
@@ -545,8 +545,8 @@
 				#size-cells = <0>;
 				reg = <0x104000 0x1000>;
 				interrupts = <260 NRF_DEFAULT_IRQ_PRIORITY>;
-				max-frequency = <DT_FREQ_M(8)>;
-				easydma-maxcnt-bits = <16>;
+				nordic,spi-max-frequency = <DT_FREQ_M(8)>;
+				nordic,easydma-maxcnt-bits = <16>;
 				rx-delay-supported;
 				rx-delay = <1>;
 				status = "disabled";

--- a/dts/common/nordic/nrf54l15.dtsi
+++ b/dts/common/nordic/nrf54l15.dtsi
@@ -239,7 +239,6 @@
 				#address-cells = <1>;
 				#size-cells = <0>;
 				reg = <0xc6000 0x1000>;
-				clock-frequency = <I2C_BITRATE_STANDARD>;
 				interrupts = <198 NRF_DEFAULT_IRQ_PRIORITY>;
 				easydma-maxcnt-bits = <16>;
 				status = "disabled";
@@ -279,7 +278,6 @@
 				#address-cells = <1>;
 				#size-cells = <0>;
 				reg = <0xc7000 0x1000>;
-				clock-frequency = <I2C_BITRATE_STANDARD>;
 				interrupts = <199 NRF_DEFAULT_IRQ_PRIORITY>;
 				easydma-maxcnt-bits = <16>;
 				status = "disabled";
@@ -319,7 +317,6 @@
 				#address-cells = <1>;
 				#size-cells = <0>;
 				reg = <0xc8000 0x1000>;
-				clock-frequency = <I2C_BITRATE_STANDARD>;
 				interrupts = <200 NRF_DEFAULT_IRQ_PRIORITY>;
 				easydma-maxcnt-bits = <16>;
 				status = "disabled";
@@ -530,7 +527,6 @@
 				#address-cells = <1>;
 				#size-cells = <0>;
 				reg = <0x104000 0x1000>;
-				clock-frequency = <I2C_BITRATE_STANDARD>;
 				interrupts = <260 NRF_DEFAULT_IRQ_PRIORITY>;
 				easydma-maxcnt-bits = <16>;
 				status = "disabled";

--- a/dts/common/nordic/nrf54l20.dtsi
+++ b/dts/common/nordic/nrf54l20.dtsi
@@ -189,7 +189,6 @@
 				#address-cells = <1>;
 				#size-cells = <0>;
 				reg = <0xc6000 0x1000>;
-				clock-frequency = <I2C_BITRATE_STANDARD>;
 				interrupts = <198 NRF_DEFAULT_IRQ_PRIORITY>;
 				easydma-maxcnt-bits = <16>;
 				status = "disabled";
@@ -229,7 +228,6 @@
 				#address-cells = <1>;
 				#size-cells = <0>;
 				reg = <0xc7000 0x1000>;
-				clock-frequency = <I2C_BITRATE_STANDARD>;
 				interrupts = <199 NRF_DEFAULT_IRQ_PRIORITY>;
 				easydma-maxcnt-bits = <16>;
 				status = "disabled";
@@ -269,7 +267,6 @@
 				#address-cells = <1>;
 				#size-cells = <0>;
 				reg = <0xc8000 0x1000>;
-				clock-frequency = <I2C_BITRATE_STANDARD>;
 				interrupts = <200 NRF_DEFAULT_IRQ_PRIORITY>;
 				easydma-maxcnt-bits = <16>;
 				status = "disabled";
@@ -471,7 +468,6 @@
 				#address-cells = <1>;
 				#size-cells = <0>;
 				reg = <0x104000 0x1000>;
-				clock-frequency = <I2C_BITRATE_STANDARD>;
 				interrupts = <260 NRF_DEFAULT_IRQ_PRIORITY>;
 				easydma-maxcnt-bits = <16>;
 				status = "disabled";

--- a/dts/common/nordic/nrf54l20.dtsi
+++ b/dts/common/nordic/nrf54l20.dtsi
@@ -93,8 +93,8 @@
 				#size-cells = <0>;
 				reg = <0x4d000 0x1000>;
 				interrupts = <77 NRF_DEFAULT_IRQ_PRIORITY>;
-				max-frequency = <DT_FREQ_M(32)>;
-				easydma-maxcnt-bits = <16>;
+				nordic,spi-max-frequency = <DT_FREQ_M(32)>;
+				nordic,easydma-maxcnt-bits = <16>;
 				rx-delay-supported;
 				rx-delay = <1>;
 				status = "disabled";
@@ -126,7 +126,7 @@
 				cc-num = <6>;
 				max-bit-width = <32>;
 				interrupts = <85 NRF_DEFAULT_IRQ_PRIORITY>;
-				max-frequency = <DT_FREQ_M(128)>;
+				nordic,spi-max-frequency = <DT_FREQ_M(128)>;
 				prescaler = <0>;
 			};
 
@@ -143,7 +143,7 @@
 				cc-num = <8>;
 				max-bit-width = <32>;
 				interrupts = <133 NRF_DEFAULT_IRQ_PRIORITY>;
-				max-frequency = <DT_FREQ_M(32)>;
+				nordic,spi-max-frequency = <DT_FREQ_M(32)>;
 				prescaler = <0>;
 			};
 
@@ -190,7 +190,7 @@
 				#size-cells = <0>;
 				reg = <0xc6000 0x1000>;
 				interrupts = <198 NRF_DEFAULT_IRQ_PRIORITY>;
-				easydma-maxcnt-bits = <16>;
+				nordic,easydma-maxcnt-bits = <16>;
 				status = "disabled";
 				zephyr,pm-device-runtime-auto;
 			};
@@ -207,8 +207,8 @@
 				#size-cells = <0>;
 				reg = <0xc6000 0x1000>;
 				interrupts = <198 NRF_DEFAULT_IRQ_PRIORITY>;
-				max-frequency = <DT_FREQ_M(8)>;
-				easydma-maxcnt-bits = <16>;
+				nordic,spi-max-frequency = <DT_FREQ_M(8)>;
+				nordic,easydma-maxcnt-bits = <16>;
 				rx-delay-supported;
 				rx-delay = <1>;
 				status = "disabled";
@@ -229,7 +229,7 @@
 				#size-cells = <0>;
 				reg = <0xc7000 0x1000>;
 				interrupts = <199 NRF_DEFAULT_IRQ_PRIORITY>;
-				easydma-maxcnt-bits = <16>;
+				nordic,easydma-maxcnt-bits = <16>;
 				status = "disabled";
 				zephyr,pm-device-runtime-auto;
 			};
@@ -246,8 +246,8 @@
 				#size-cells = <0>;
 				reg = <0xc7000 0x1000>;
 				interrupts = <199 NRF_DEFAULT_IRQ_PRIORITY>;
-				max-frequency = <DT_FREQ_M(8)>;
-				easydma-maxcnt-bits = <16>;
+				nordic,spi-max-frequency = <DT_FREQ_M(8)>;
+				nordic,easydma-maxcnt-bits = <16>;
 				rx-delay-supported;
 				rx-delay = <1>;
 				status = "disabled";
@@ -268,7 +268,7 @@
 				#size-cells = <0>;
 				reg = <0xc8000 0x1000>;
 				interrupts = <200 NRF_DEFAULT_IRQ_PRIORITY>;
-				easydma-maxcnt-bits = <16>;
+				nordic,easydma-maxcnt-bits = <16>;
 				status = "disabled";
 				zephyr,pm-device-runtime-auto;
 			};
@@ -285,8 +285,8 @@
 				#size-cells = <0>;
 				reg = <0xc8000 0x1000>;
 				interrupts = <200 NRF_DEFAULT_IRQ_PRIORITY>;
-				max-frequency = <DT_FREQ_M(8)>;
-				easydma-maxcnt-bits = <16>;
+				nordic,spi-max-frequency = <DT_FREQ_M(8)>;
+				nordic,easydma-maxcnt-bits = <16>;
 				rx-delay-supported;
 				rx-delay = <1>;
 				status = "disabled";
@@ -469,7 +469,7 @@
 				#size-cells = <0>;
 				reg = <0x104000 0x1000>;
 				interrupts = <260 NRF_DEFAULT_IRQ_PRIORITY>;
-				easydma-maxcnt-bits = <16>;
+				nordic,easydma-maxcnt-bits = <16>;
 				status = "disabled";
 				zephyr,pm-device-runtime-auto;
 			};
@@ -486,8 +486,8 @@
 				#size-cells = <0>;
 				reg = <0x104000 0x1000>;
 				interrupts = <260 NRF_DEFAULT_IRQ_PRIORITY>;
-				max-frequency = <DT_FREQ_M(8)>;
-				easydma-maxcnt-bits = <16>;
+				nordic,spi-max-frequency = <DT_FREQ_M(8)>;
+				nordic,easydma-maxcnt-bits = <16>;
 				rx-delay-supported;
 				rx-delay = <1>;
 				status = "disabled";

--- a/dts/common/nordic/nrf9280.dtsi
+++ b/dts/common/nordic/nrf9280.dtsi
@@ -270,7 +270,7 @@
 				cc-num = <8>;
 				interrupts = <40 NRF_DEFAULT_IRQ_PRIORITY>;
 				max-bit-width = <32>;
-				max-frequency = <DT_FREQ_M(32)>;
+				nordic,spi-max-frequency = <DT_FREQ_M(32)>;
 				prescaler = <0>;
 			};
 
@@ -281,7 +281,7 @@
 				cc-num = <8>;
 				interrupts = <41 NRF_DEFAULT_IRQ_PRIORITY>;
 				max-bit-width = <32>;
-				max-frequency = <DT_FREQ_M(32)>;
+				nordic,spi-max-frequency = <DT_FREQ_M(32)>;
 				prescaler = <0>;
 			};
 
@@ -292,7 +292,7 @@
 				cc-num = <8>;
 				interrupts = <42 NRF_DEFAULT_IRQ_PRIORITY>;
 				max-bit-width = <32>;
-				max-frequency = <DT_FREQ_M(32)>;
+				nordic,spi-max-frequency = <DT_FREQ_M(32)>;
 				prescaler = <0>;
 			};
 
@@ -472,7 +472,7 @@
 				cc-num = <6>;
 				interrupts = <226 NRF_DEFAULT_IRQ_PRIORITY>;
 				max-bit-width = <32>;
-				max-frequency = <DT_FREQ_M(320)>;
+				nordic,spi-max-frequency = <DT_FREQ_M(320)>;
 				prescaler = <0>;
 			};
 
@@ -483,7 +483,7 @@
 				cc-num = <6>;
 				interrupts = <227 NRF_DEFAULT_IRQ_PRIORITY>;
 				max-bit-width = <32>;
-				max-frequency = <DT_FREQ_M(320)>;
+				nordic,spi-max-frequency = <DT_FREQ_M(320)>;
 				prescaler = <0>;
 			};
 
@@ -499,9 +499,9 @@
 				compatible = "nordic,nrf-spim";
 				reg = <0x8e6000 0x1000>;
 				status = "disabled";
-				easydma-maxcnt-bits = <15>;
+				nordic,easydma-maxcnt-bits = <15>;
 				interrupts = <230 NRF_DEFAULT_IRQ_PRIORITY>;
-				max-frequency = <DT_FREQ_M(32)>;
+				nordic,spi-max-frequency = <DT_FREQ_M(32)>;
 				#address-cells = <1>;
 				#size-cells = <0>;
 				rx-delay-supported;
@@ -523,9 +523,9 @@
 				compatible = "nordic,nrf-spim";
 				reg = <0x8e7000 0x1000>;
 				status = "disabled";
-				easydma-maxcnt-bits = <15>;
+				nordic,easydma-maxcnt-bits = <15>;
 				interrupts = <231 NRF_DEFAULT_IRQ_PRIORITY>;
-				max-frequency = <DT_FREQ_M(32)>;
+				nordic,spi-max-frequency = <DT_FREQ_M(32)>;
 				#address-cells = <1>;
 				#size-cells = <0>;
 				rx-delay-supported;
@@ -819,7 +819,7 @@
 				reg = <0x9a5000 0x1000>;
 				status = "disabled";
 				interrupts = <421 NRF_DEFAULT_IRQ_PRIORITY>;
-				easydma-maxcnt-bits = <15>;
+				nordic,easydma-maxcnt-bits = <15>;
 				#address-cells = <1>;
 				#size-cells = <0>;
 				nordic,clockpin-enable = <NRF_FUN_TWIM_SDA>,
@@ -831,9 +831,9 @@
 				compatible = "nordic,nrf-spim";
 				reg = <0x9a5000 0x1000>;
 				status = "disabled";
-				easydma-maxcnt-bits = <15>;
+				nordic,easydma-maxcnt-bits = <15>;
 				interrupts = <421 NRF_DEFAULT_IRQ_PRIORITY>;
-				max-frequency = <DT_FREQ_M(8)>;
+				nordic,spi-max-frequency = <DT_FREQ_M(8)>;
 				#address-cells = <1>;
 				#size-cells = <0>;
 				rx-delay-supported;
@@ -859,7 +859,7 @@
 				reg = <0x9a6000 0x1000>;
 				status = "disabled";
 				interrupts = <422 NRF_DEFAULT_IRQ_PRIORITY>;
-				easydma-maxcnt-bits = <15>;
+				nordic,easydma-maxcnt-bits = <15>;
 				#address-cells = <1>;
 				#size-cells = <0>;
 				nordic,clockpin-enable = <NRF_FUN_TWIM_SDA>,
@@ -871,9 +871,9 @@
 				compatible = "nordic,nrf-spim";
 				reg = <0x9a6000 0x1000>;
 				status = "disabled";
-				easydma-maxcnt-bits = <15>;
+				nordic,easydma-maxcnt-bits = <15>;
 				interrupts = <422 NRF_DEFAULT_IRQ_PRIORITY>;
-				max-frequency = <DT_FREQ_M(8)>;
+				nordic,spi-max-frequency = <DT_FREQ_M(8)>;
 				#address-cells = <1>;
 				#size-cells = <0>;
 				rx-delay-supported;
@@ -933,7 +933,7 @@
 				reg = <0x9b5000 0x1000>;
 				status = "disabled";
 				interrupts = <437 NRF_DEFAULT_IRQ_PRIORITY>;
-				easydma-maxcnt-bits = <15>;
+				nordic,easydma-maxcnt-bits = <15>;
 				#address-cells = <1>;
 				#size-cells = <0>;
 				nordic,clockpin-enable = <NRF_FUN_TWIM_SDA>,
@@ -945,9 +945,9 @@
 				compatible = "nordic,nrf-spim";
 				reg = <0x9b5000 0x1000>;
 				status = "disabled";
-				easydma-maxcnt-bits = <15>;
+				nordic,easydma-maxcnt-bits = <15>;
 				interrupts = <437 NRF_DEFAULT_IRQ_PRIORITY>;
-				max-frequency = <DT_FREQ_M(8)>;
+				nordic,spi-max-frequency = <DT_FREQ_M(8)>;
 				#address-cells = <1>;
 				#size-cells = <0>;
 				rx-delay-supported;
@@ -973,7 +973,7 @@
 				reg = <0x9b6000 0x1000>;
 				status = "disabled";
 				interrupts = <438 NRF_DEFAULT_IRQ_PRIORITY>;
-				easydma-maxcnt-bits = <15>;
+				nordic,easydma-maxcnt-bits = <15>;
 				#address-cells = <1>;
 				#size-cells = <0>;
 				nordic,clockpin-enable = <NRF_FUN_TWIM_SDA>,
@@ -985,9 +985,9 @@
 				compatible = "nordic,nrf-spim";
 				reg = <0x9b6000 0x1000>;
 				status = "disabled";
-				easydma-maxcnt-bits = <15>;
+				nordic,easydma-maxcnt-bits = <15>;
 				interrupts = <438 NRF_DEFAULT_IRQ_PRIORITY>;
-				max-frequency = <DT_FREQ_M(8)>;
+				nordic,spi-max-frequency = <DT_FREQ_M(8)>;
 				#address-cells = <1>;
 				#size-cells = <0>;
 				rx-delay-supported;
@@ -1047,7 +1047,7 @@
 				reg = <0x9c5000 0x1000>;
 				status = "disabled";
 				interrupts = <453 NRF_DEFAULT_IRQ_PRIORITY>;
-				easydma-maxcnt-bits = <15>;
+				nordic,easydma-maxcnt-bits = <15>;
 				#address-cells = <1>;
 				#size-cells = <0>;
 				nordic,clockpin-enable = <NRF_FUN_TWIM_SDA>,
@@ -1059,9 +1059,9 @@
 				compatible = "nordic,nrf-spim";
 				reg = <0x9c5000 0x1000>;
 				status = "disabled";
-				easydma-maxcnt-bits = <15>;
+				nordic,easydma-maxcnt-bits = <15>;
 				interrupts = <453 NRF_DEFAULT_IRQ_PRIORITY>;
-				max-frequency = <DT_FREQ_M(8)>;
+				nordic,spi-max-frequency = <DT_FREQ_M(8)>;
 				#address-cells = <1>;
 				#size-cells = <0>;
 				rx-delay-supported;
@@ -1087,7 +1087,7 @@
 				reg = <0x9c6000 0x1000>;
 				status = "disabled";
 				interrupts = <454 NRF_DEFAULT_IRQ_PRIORITY>;
-				easydma-maxcnt-bits = <15>;
+				nordic,easydma-maxcnt-bits = <15>;
 				#address-cells = <1>;
 				#size-cells = <0>;
 				nordic,clockpin-enable = <NRF_FUN_TWIM_SDA>,
@@ -1099,9 +1099,9 @@
 				compatible = "nordic,nrf-spim";
 				reg = <0x9c6000 0x1000>;
 				status = "disabled";
-				easydma-maxcnt-bits = <15>;
+				nordic,easydma-maxcnt-bits = <15>;
 				interrupts = <454 NRF_DEFAULT_IRQ_PRIORITY>;
-				max-frequency = <DT_FREQ_M(8)>;
+				nordic,spi-max-frequency = <DT_FREQ_M(8)>;
 				#address-cells = <1>;
 				#size-cells = <0>;
 				rx-delay-supported;
@@ -1161,7 +1161,7 @@
 				reg = <0x9d5000 0x1000>;
 				status = "disabled";
 				interrupts = <469 NRF_DEFAULT_IRQ_PRIORITY>;
-				easydma-maxcnt-bits = <15>;
+				nordic,easydma-maxcnt-bits = <15>;
 				#address-cells = <1>;
 				#size-cells = <0>;
 				nordic,clockpin-enable = <NRF_FUN_TWIM_SDA>,
@@ -1173,9 +1173,9 @@
 				compatible = "nordic,nrf-spim";
 				reg = <0x9d5000 0x1000>;
 				status = "disabled";
-				easydma-maxcnt-bits = <15>;
+				nordic,easydma-maxcnt-bits = <15>;
 				interrupts = <469 NRF_DEFAULT_IRQ_PRIORITY>;
-				max-frequency = <DT_FREQ_M(8)>;
+				nordic,spi-max-frequency = <DT_FREQ_M(8)>;
 				#address-cells = <1>;
 				#size-cells = <0>;
 				rx-delay-supported;
@@ -1201,7 +1201,7 @@
 				reg = <0x9d6000 0x1000>;
 				status = "disabled";
 				interrupts = <470 NRF_DEFAULT_IRQ_PRIORITY>;
-				easydma-maxcnt-bits = <15>;
+				nordic,easydma-maxcnt-bits = <15>;
 				#address-cells = <1>;
 				#size-cells = <0>;
 				nordic,clockpin-enable = <NRF_FUN_TWIM_SDA>,
@@ -1213,9 +1213,9 @@
 				compatible = "nordic,nrf-spim";
 				reg = <0x9d6000 0x1000>;
 				status = "disabled";
-				easydma-maxcnt-bits = <15>;
+				nordic,easydma-maxcnt-bits = <15>;
 				interrupts = <470 NRF_DEFAULT_IRQ_PRIORITY>;
-				max-frequency = <DT_FREQ_M(8)>;
+				nordic,spi-max-frequency = <DT_FREQ_M(8)>;
 				#address-cells = <1>;
 				#size-cells = <0>;
 				rx-delay-supported;

--- a/soc/nordic/validate_enabled_instances.c
+++ b/soc/nordic/validate_enabled_instances.c
@@ -7,10 +7,16 @@
 #include <zephyr/kernel.h>
 
 #define I2C_ENABLED(idx)  (IS_ENABLED(CONFIG_I2C) && \
-			   DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(i2c##idx)))
+			   DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(i2c##idx)) && \
+			   (DT_NODE_HAS_COMPAT(DT_NODELABEL(i2c##idx), nordic_nrf_twi) || \
+			    DT_NODE_HAS_COMPAT(DT_NODELABEL(i2c##idx), nordic_nrf_twim) || \
+			    DT_NODE_HAS_COMPAT(DT_NODELABEL(i2c##idx), nordic_nrf_twis)))
 
 #define SPI_ENABLED(idx)  (IS_ENABLED(CONFIG_SPI) && \
-			   DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(spi##idx)))
+			   DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(spi##idx)) && \
+			   (DT_NODE_HAS_COMPAT(DT_NODELABEL(spi##idx), nordic_nrf_spi) || \
+			    DT_NODE_HAS_COMPAT(DT_NODELABEL(spi##idx), nordic_nrf_spim) || \
+			    DT_NODE_HAS_COMPAT(DT_NODELABEL(spi##idx), nordic_nrf_spis)))
 
 #define UART_ENABLED(idx) (IS_ENABLED(CONFIG_SERIAL) && \
 			   (IS_ENABLED(CONFIG_SOC_SERIES_NRF53X) || \


### PR DESCRIPTION
## Proposal

On Nordic nRF SoCs, some IP blocks can expose multiple functionality, e.g. SPI/I2C (or UART). This functionality is now exposed using one node for each, that is:

```
		i2c0: i2c@40003000 {
			/*
			 * This i2c node can be TWI, TWIM, or TWIS,
			 * for the user to pick:
			 * compatible = "nordic,nrf-twi" or
			 *              "nordic,nrf-twim" or
			 *              "nordic,nrf-twis".
			 */
			compatible = "nordic,nrf-twim";
			#address-cells = <1>;
			#size-cells = <0>;
			reg = <0x40003000 0x1000>;
			clock-frequency = <I2C_BITRATE_STANDARD>;
			interrupts = <3 NRF_DEFAULT_IRQ_PRIORITY>;
			easydma-maxcnt-bits = <16>;
			status = "disabled";
			zephyr,pm-device-runtime-auto;
		};

		spi0: spi@40003000 {
			/*
			 * This spi node can be SPI, SPIM, or SPIS,
			 * for the user to pick:
			 * compatible = "nordic,nrf-spi" or
			 *              "nordic,nrf-spim" or
			 *              "nordic,nrf-spis".
			 */
			compatible = "nordic,nrf-spim";
			#address-cells = <1>;
			#size-cells = <0>;
			reg = <0x40003000 0x1000>;
			interrupts = <3 NRF_DEFAULT_IRQ_PRIORITY>;
			max-frequency = <DT_FREQ_M(8)>;
			easydma-maxcnt-bits = <16>;
			status = "disabled";
		};
```

Above, you can see that the base address of both nodes are the same. This PR proposes to merge both into a unique node, leaving compatible empty so that the end user is who decides what they want.

```
		i2c0: spi0: seriobox@40003000 {
			/*
			 * This node can be SPI/TWI, SPIM/TWIM, SPIS/TWIS,
			 * for the user to pick:
			 * compatible = "nordic,nrf-spi" or
			 *              "nordic,nrf-spim" or
			 *              "nordic,nrf-spis" pr
			 *              "nordic,nrf-twi" or
			 *              "nordic,nrf-twim" or
			 *              "nordic,nrf-twis".
			 */
			#address-cells = <1>;
			#size-cells = <0>;
			reg = <0x40003000 0x1000>;
			interrupts = <3 NRF_DEFAULT_IRQ_PRIORITY>;
			nordic,spi-max-frequency = <DT_FREQ_M(8)>;
			nordic,easydma-maxcnt-bits = <16>;
			status = "disabled";
			zephyr,pm-device-runtime-auto;
		};
```

## Comments

Since in quite a few cases users are already setting the compatible on their boards (to choose twi/twim, spi/spim), the change will likely have a moderate impact, considering nodelabels are kept as they are.

Thanks to this change we won't trigger the `dtc` `unique_unit_address_if_enabled` warning, now masked by `-Wno-unique_unit_address_if_enabled` in `EXTRA_DTC_FLAGS`. We'll also be able to drop `soc/nordic/validate_enabled_instances.c`, as we'll have a single node.

## Other examples

We have similar cases in tree, in particular Atmel SAM SoCs have the same situation, and they seem to solve the problem as this PR proposes:

https://github.com/zephyrproject-rtos/zephyr/blob/6300e1bc253531b992c868424543cde112189915/boards/adafruit/trinket_m0/adafruit_trinket_m0.dts#L53-L96