### PR TITLE
net: lwm2m: Improve thread safety of the library

### DIFF
--- a/include/zephyr/net/lwm2m.h
+++ b/include/zephyr/net/lwm2m.h
@@ -217,6 +217,7 @@ struct lwm2m_ctx {
 	sys_slist_t queued_messages;
 #endif
 	sys_slist_t observer;
+	struct k_mutex lock;
 	/** @endcond */
 
 	/** A pointer to currently processed request, for internal LwM2M engine

--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -1338,7 +1338,9 @@ static int lwm2m_engine_init(void)
 
 	lwm2m_clear_block_contexts();
 #if defined(CONFIG_LWM2M_COAP_BLOCK_TRANSFER)
+	lwm2m_engine_lock();
 	(void)memset(output_block_contexts, 0, sizeof(output_block_contexts));
+	lwm2m_engine_unlock();
 #endif
 
 	STRUCT_SECTION_FOREACH(lwm2m_init_func, init) {

--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -96,6 +96,8 @@ static sys_slist_t engine_service_list;
 static K_KERNEL_STACK_DEFINE(engine_thread_stack, CONFIG_LWM2M_ENGINE_STACK_SIZE);
 static struct k_thread engine_thread_data;
 
+static K_MUTEX_DEFINE(engine_lock);
+
 #define MAX_POLL_FD CONFIG_ZVFS_POLL_MAX
 
 /* Resources */
@@ -1283,6 +1285,16 @@ int lwm2m_engine_resume(void)
 	lwm2m_engine_wake_up();
 
 	return 0;
+}
+
+void lwm2m_engine_lock(void)
+{
+	(void)k_mutex_lock(&engine_lock, K_FOREVER);
+}
+
+void lwm2m_engine_unlock(void)
+{
+	k_mutex_unlock(&engine_lock);
 }
 
 static int lwm2m_engine_init(void)

--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -369,6 +369,8 @@ static int64_t retransmit_request(struct lwm2m_ctx *client_ctx, const int64_t ti
 	int64_t remaining, next = INT64_MAX;
 	int i;
 
+	lwm2m_client_lock(client_ctx);
+
 	for (i = 0, p = client_ctx->pendings; i < ARRAY_SIZE(client_ctx->pendings); i++, p++) {
 		if (!p->timeout) {
 			continue;
@@ -405,6 +407,8 @@ static int64_t retransmit_request(struct lwm2m_ctx *client_ctx, const int64_t ti
 			next = remaining;
 		}
 	}
+
+	lwm2m_client_unlock(client_ctx);
 
 	return next;
 }

--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -234,6 +234,7 @@ int lwm2m_push_queued_buffers(struct lwm2m_ctx *client_ctx)
 {
 #if defined(CONFIG_LWM2M_QUEUE_MODE_ENABLED)
 	client_ctx->buffer_client_messages = false;
+	lwm2m_client_lock(client_ctx);
 	while (!sys_slist_is_empty(&client_ctx->queued_messages)) {
 		sys_snode_t *msg_node = sys_slist_get(&client_ctx->queued_messages);
 		struct lwm2m_message *msg;
@@ -245,6 +246,7 @@ int lwm2m_push_queued_buffers(struct lwm2m_ctx *client_ctx)
 		msg->pending->t0 = k_uptime_get();
 		sys_slist_append(&msg->ctx->pending_sends, &msg->node);
 	}
+	lwm2m_client_unlock(client_ctx);
 #endif
 	return 0;
 }
@@ -643,17 +645,22 @@ cleanup:
  */
 static void hint_socket_state(struct lwm2m_ctx *ctx, struct lwm2m_message *ongoing_tx)
 {
+	bool empty;
+	size_t pendings;
+
 	if (!ctx || !ctx->set_socket_state) {
 		return;
 	}
 
+	lwm2m_client_lock(ctx);
 #if defined(CONFIG_LWM2M_QUEUE_MODE_ENABLED)
-	bool empty = sys_slist_is_empty(&ctx->pending_sends) &&
-		     sys_slist_is_empty(&ctx->queued_messages);
+	empty = sys_slist_is_empty(&ctx->pending_sends) &&
+		sys_slist_is_empty(&ctx->queued_messages);
 #else
-	bool empty = sys_slist_is_empty(&ctx->pending_sends);
+	empty = sys_slist_is_empty(&ctx->pending_sends);
 #endif
-	size_t pendings = coap_pendings_count(ctx->pendings, ARRAY_SIZE(ctx->pendings));
+	pendings = coap_pendings_count(ctx->pendings, ARRAY_SIZE(ctx->pendings));
+	lwm2m_client_unlock(ctx);
 
 	if (ongoing_tx) {
 		/* Check if more than current TX is in pendings list*/
@@ -712,8 +719,12 @@ static int socket_recv_message(struct lwm2m_ctx *client_ctx)
 static int socket_send_message(struct lwm2m_ctx *ctx)
 {
 	int rc;
-	sys_snode_t *msg_node = sys_slist_get(&ctx->pending_sends);
+	sys_snode_t *msg_node;
 	struct lwm2m_message *msg;
+
+	lwm2m_client_lock(ctx);
+	msg_node = sys_slist_get(&ctx->pending_sends);
+	lwm2m_client_unlock(ctx);
 
 	if (!msg_node) {
 		return 0;
@@ -752,11 +763,17 @@ static int socket_send_message(struct lwm2m_ctx *ctx)
 static void socket_reset_pollfd_events(void)
 {
 	for (int i = 0; i < MAX_POLL_FD; ++i) {
+		bool set_pollout = false;
+
+		if (sock_ctx[i] != NULL) {
+			lwm2m_client_lock(sock_ctx[i]);
+			set_pollout = !sys_slist_is_empty(&sock_ctx[i]->pending_sends);
+			lwm2m_client_unlock(sock_ctx[i]);
+		}
+
 		sock_fds[i].events =
 			ZSOCK_POLLIN |
-			(!sock_ctx[i] || sys_slist_is_empty(&sock_ctx[i]->pending_sends)
-				 ? 0
-				 : ZSOCK_POLLOUT);
+			(set_pollout ? ZSOCK_POLLOUT : 0);
 		sock_fds[i].revents = 0;
 	}
 }
@@ -802,13 +819,20 @@ static void socket_loop(void *p1, void *p2, void *p3)
 
 		for (i = 0; i < sock_nfds; ++i) {
 			struct lwm2m_ctx *ctx = sock_ctx[i];
+			bool is_empty;
 
 			if (ctx == NULL) {
 				continue;
 			}
-			if (!sys_slist_is_empty(&ctx->pending_sends)) {
+
+			lwm2m_client_lock(ctx);
+			is_empty = sys_slist_is_empty(&ctx->pending_sends);
+			lwm2m_client_unlock(ctx);
+
+			if (!is_empty) {
 				continue;
 			}
+
 			next_tx = retransmit_request(ctx, now);
 			if (next_tx < next) {
 				next = next_tx;
@@ -1295,6 +1319,16 @@ void lwm2m_engine_lock(void)
 void lwm2m_engine_unlock(void)
 {
 	k_mutex_unlock(&engine_lock);
+}
+
+void lwm2m_client_lock(struct lwm2m_ctx *ctx)
+{
+	(void)k_mutex_lock(&ctx->lock, K_FOREVER);
+}
+
+void lwm2m_client_unlock(struct lwm2m_ctx *ctx)
+{
+	k_mutex_unlock(&ctx->lock);
 }
 
 static int lwm2m_engine_init(void)

--- a/subsys/net/lib/lwm2m/lwm2m_engine.h
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.h
@@ -385,4 +385,18 @@ void lwm2m_engine_lock(void);
  */
 void lwm2m_engine_unlock(void);
 
+/**
+ * @brief Locks the client.
+ *
+ * @param[in] client_ctx LwM2M context
+ */
+void lwm2m_client_lock(struct lwm2m_ctx *ctx);
+
+/**
+ * @brief Unlocks the client previously locked by lwm2m_client_lock().
+ *
+ * @param[in] client_ctx LwM2M context
+ */
+void lwm2m_client_unlock(struct lwm2m_ctx *ctx);
+
 #endif /* LWM2M_ENGINE_H */

--- a/subsys/net/lib/lwm2m/lwm2m_engine.h
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.h
@@ -375,4 +375,14 @@ int lwm2m_sock_nfds(void);
  */
 void lwm2m_engine_wake_up(void);
 
+/**
+ * @brief Locks the access to shared LwM2M engine variables.
+ */
+void lwm2m_engine_lock(void);
+
+/**
+ * @brief Unlocks the access to shared LwM2M engine variables.
+ */
+void lwm2m_engine_unlock(void);
+
 #endif /* LWM2M_ENGINE_H */

--- a/subsys/net/lib/lwm2m/lwm2m_message_handling.c
+++ b/subsys/net/lib/lwm2m/lwm2m_message_handling.c
@@ -450,6 +450,8 @@ void lwm2m_engine_context_close(struct lwm2m_ctx *client_ctx)
 	struct observe_node *obs;
 	size_t i;
 
+	lwm2m_client_lock(client_ctx);
+
 	/* Remove observes for this context */
 	while (!sys_slist_is_empty(&client_ctx->observer)) {
 		obs_node = sys_slist_get_not_empty(&client_ctx->observer);
@@ -466,11 +468,11 @@ void lwm2m_engine_context_close(struct lwm2m_ctx *client_ctx)
 	coap_pendings_clear(client_ctx->pendings, ARRAY_SIZE(client_ctx->pendings));
 	coap_replies_clear(client_ctx->replies, ARRAY_SIZE(client_ctx->replies));
 
-
 	client_ctx->connection_suspended = false;
 #if defined(CONFIG_LWM2M_QUEUE_MODE_ENABLED)
 	client_ctx->buffer_client_messages = true;
 #endif
+	lwm2m_client_unlock(client_ctx);
 }
 
 void lwm2m_engine_context_init(struct lwm2m_ctx *client_ctx)
@@ -663,12 +665,14 @@ int lwm2m_init_message(struct lwm2m_message *msg)
 		return 0;
 	}
 
+	lwm2m_client_lock(msg->ctx);
+
 	msg->pending = coap_pending_next_unused(msg->ctx->pendings, ARRAY_SIZE(msg->ctx->pendings));
 	if (!msg->pending) {
 		LOG_ERR("Unable to find a free pending to track "
 			"retransmissions.");
 		r = -ENOMEM;
-		goto cleanup;
+		goto cleanup_unlock;
 	}
 
 	r = coap_pending_init(msg->pending, &msg->cpkt, &msg->ctx->remote_addr, NULL);
@@ -676,7 +680,7 @@ int lwm2m_init_message(struct lwm2m_message *msg)
 		LOG_ERR("Unable to initialize a pending "
 			"retransmission (err:%d).",
 			r);
-		goto cleanup;
+		goto cleanup_unlock;
 	}
 
 	if (msg->reply_cb) {
@@ -685,7 +689,7 @@ int lwm2m_init_message(struct lwm2m_message *msg)
 		if (!msg->reply) {
 			LOG_ERR("No resources for waiting for replies.");
 			r = -ENOMEM;
-			goto cleanup;
+			goto cleanup_unlock;
 		}
 
 		coap_reply_clear(msg->reply);
@@ -693,8 +697,12 @@ int lwm2m_init_message(struct lwm2m_message *msg)
 		msg->reply->reply = msg->reply_cb;
 	}
 
+	lwm2m_client_unlock(msg->ctx);
+
 	return 0;
 
+cleanup_unlock:
+	lwm2m_client_unlock(msg->ctx);
 cleanup:
 	lwm2m_reset_message(msg, true);
 
@@ -2645,11 +2653,14 @@ static int lwm2m_response_promote_to_con(struct lwm2m_message *msg)
 		coap_pending_clear(msg->pending);
 	}
 
+	lwm2m_client_lock(msg->ctx);
+
 	/* Add the packet to the pending list. */
 	msg->pending = coap_pending_next_unused(msg->ctx->pendings, ARRAY_SIZE(msg->ctx->pendings));
 	if (!msg->pending) {
 		LOG_ERR("Unable to find a free pending to track "
 			"retransmissions.");
+		lwm2m_client_unlock(msg->ctx);
 		return -ENOMEM;
 	}
 
@@ -2659,6 +2670,8 @@ static int lwm2m_response_promote_to_con(struct lwm2m_message *msg)
 			"retransmission (err:%d).",
 			ret);
 	}
+
+	lwm2m_client_unlock(msg->ctx);
 
 	return ret;
 }
@@ -2738,6 +2751,9 @@ void lwm2m_udp_receive(struct lwm2m_ctx *client_ctx, uint8_t *buf, uint16_t buf_
 	}
 
 	has_block2 = coap_get_option_int(&response, COAP_OPTION_BLOCK2) > 0 ? true : false;
+
+	lwm2m_client_lock(client_ctx);
+
 	pending = coap_pending_received(&response, client_ctx->pendings,
 					ARRAY_SIZE(client_ctx->pendings));
 	if (pending && coap_header_get_type(&response) == COAP_TYPE_ACK) {
@@ -2745,7 +2761,7 @@ void lwm2m_udp_receive(struct lwm2m_ctx *client_ctx, uint8_t *buf, uint16_t buf_
 		if (msg == NULL) {
 			LOG_DBG("Orphaned pending %p.", pending);
 			coap_pending_clear(pending);
-			return;
+			goto client_unlock;
 		}
 
 		msg->acknowledged = true;
@@ -2753,7 +2769,7 @@ void lwm2m_udp_receive(struct lwm2m_ctx *client_ctx, uint8_t *buf, uint16_t buf_
 		if (msg->reply == NULL) {
 			/* No response expected, release the message. */
 			lwm2m_reset_message(msg, true);
-			return;
+			goto client_unlock;
 		}
 
 		/* If the original message was a request and an empty
@@ -2762,7 +2778,7 @@ void lwm2m_udp_receive(struct lwm2m_ctx *client_ctx, uint8_t *buf, uint16_t buf_
 		if ((msg->code >= COAP_METHOD_GET) && (msg->code <= COAP_METHOD_DELETE) &&
 		    (coap_header_get_code(&response) == COAP_CODE_EMPTY)) {
 			LOG_DBG("Empty ACK, expect separate response.");
-			return;
+			goto client_unlock;
 		}
 	}
 
@@ -2784,7 +2800,7 @@ void lwm2m_udp_receive(struct lwm2m_ctx *client_ctx, uint8_t *buf, uint16_t buf_
 			r = coap_get_block1_option(&response, &more_blocks, &block_num);
 			if (r < 0) {
 				LOG_ERR("Missing block1 option in response with continue");
-				return;
+				goto client_unlock;
 			}
 
 			enum coap_block_size block_size = coap_bytes_to_block_size(r);
@@ -2796,36 +2812,36 @@ void lwm2m_udp_receive(struct lwm2m_ctx *client_ctx, uint8_t *buf, uint16_t buf_
 			if (!more_blocks) {
 				lwm2m_reset_message(msg, true);
 				LOG_ERR("Missing more flag in response with continue");
-				return;
+				goto client_unlock;
 			}
 
 			last_block_num = msg->out.block_ctx->current /
 					 coap_block_size_to_bytes(block_size);
 			if (last_block_num > block_num) {
 				LOG_INF("Block already sent: ignore");
-				return;
+				goto client_unlock;
 			} else if (last_block_num < block_num) {
 				LOG_WRN("Requested block out of order");
-				return;
+				goto client_unlock;
 			}
 
 			r = build_msg_block_for_send(msg, block_num + 1, block_size);
 			if (r < 0) {
 				lwm2m_reset_message(msg, true);
 				LOG_ERR("Unable to build next block of lwm2m message!");
-				return;
+				goto client_unlock;
 			}
 
 			r = lwm2m_send_message_async(msg);
 			if (r < 0) {
 				lwm2m_reset_message(msg, true);
 				LOG_ERR("Unable to send next block of lwm2m message!");
-				return;
+				goto client_unlock;
 			}
 
 			/* skip release as message was reused for new block */
 			LOG_DBG("Block # %d sent", block_num + 1);
-			return;
+			goto client_unlock;
 		}
 #endif
 
@@ -2834,7 +2850,7 @@ void lwm2m_udp_receive(struct lwm2m_ctx *client_ctx, uint8_t *buf, uint16_t buf_
 			/* reset reply->user_data for next time */
 			reply->user_data = (void *)COAP_REPLY_STATUS_NONE;
 			LOG_DBG("reply %p NOT removed", reply);
-			return;
+			goto client_unlock;
 		}
 
 		/* free up msg resources */
@@ -2843,8 +2859,10 @@ void lwm2m_udp_receive(struct lwm2m_ctx *client_ctx, uint8_t *buf, uint16_t buf_
 		}
 
 		LOG_DBG("reply %p handled and removed", reply);
-		return;
+		goto client_unlock;
 	}
+
+	lwm2m_client_unlock(client_ctx);
 
 	if (coap_header_get_type(&response) == COAP_TYPE_CON) {
 		if (has_block2 && IS_ENABLED(CONFIG_LWM2M_COAP_BLOCK_TRANSFER)) {
@@ -2895,6 +2913,11 @@ void lwm2m_udp_receive(struct lwm2m_ctx *client_ctx, uint8_t *buf, uint16_t buf_
 	} else {
 		LOG_DBG("No handler for response");
 	}
+
+	return;
+
+client_unlock:
+	lwm2m_client_unlock(client_ctx);
 }
 
 static void notify_message_timeout_cb(struct lwm2m_message *msg)


### PR DESCRIPTION
With preemptive network threads enabled, the LwM2M could crash when for example LwM2M send was issued from another thread. This PR addresses the potential thread-safety issues detected with the library.

Fixes #78989