### PR TITLE
Add ilps22qs sensor support to lps2xdf driver

### DIFF
--- a/boards/st/steval_stwinbx1/steval_stwinbx1.dts
+++ b/boards/st/steval_stwinbx1/steval_stwinbx1.dts
@@ -218,6 +218,12 @@ stm32_lp_tick_source: &lptim1 {
 		drdy-gpios = <&gpiof 9 GPIO_ACTIVE_HIGH>;
 		status = "okay";
 	};
+
+	ilps22qs@5c {
+		compatible = "st,ilps22qs";
+		reg = <0x5c>;
+		status = "okay";
+	};
 };
 
 &timers5 {

--- a/drivers/sensor/st/lps2xdf/CMakeLists.txt
+++ b/drivers/sensor/st/lps2xdf/CMakeLists.txt
@@ -8,6 +8,7 @@
 zephyr_library()
 
 zephyr_library_sources(lps2xdf.c)
+zephyr_library_sources_ifdef(CONFIG_DT_HAS_ST_ILPS22QS_ENABLED ilps22qs.c )
 zephyr_library_sources_ifdef(CONFIG_DT_HAS_ST_LPS22DF_ENABLED  lps22df.c )
 zephyr_library_sources_ifdef(CONFIG_DT_HAS_ST_LPS28DFW_ENABLED lps28dfw.c )
 zephyr_library_sources_ifdef(CONFIG_LPS2XDF_TRIGGER            lps2xdf_trigger.c)

--- a/drivers/sensor/st/lps2xdf/Kconfig
+++ b/drivers/sensor/st/lps2xdf/Kconfig
@@ -11,7 +11,7 @@ menuconfig LPS2XDF
 	depends on ZEPHYR_HAL_ST_MODULE
 	select I2C if $(dt_compat_on_bus,$(DT_COMPAT_ST_LPS22DF),i2c) ||\
 		      $(dt_compat_on_bus,$(DT_COMPAT_ST_LPS28DFW),i2c)
-	select I2C if $(dt_compat_on_bus,$(DT_COMPAT_ST_LPS22DF),i3c) ||\
+	select I3C if $(dt_compat_on_bus,$(DT_COMPAT_ST_LPS22DF),i3c) ||\
 		      $(dt_compat_on_bus,$(DT_COMPAT_ST_LPS28DFW),i3c)
 	select SPI if $(dt_compat_on_bus,$(DT_COMPAT_ST_LPS22DF),spi)
 	select HAS_STMEMSC

--- a/drivers/sensor/st/lps2xdf/Kconfig
+++ b/drivers/sensor/st/lps2xdf/Kconfig
@@ -7,14 +7,19 @@
 menuconfig LPS2XDF
 	bool "LPS2xDF pressure and temperature"
 	default y
-	depends on DT_HAS_ST_LPS22DF_ENABLED || DT_HAS_ST_LPS28DFW_ENABLED
+	depends on DT_HAS_ST_LPS22DF_ENABLED || DT_HAS_ST_LPS28DFW_ENABLED ||\
+		   DT_HAS_ST_ILPS22QS_ENABLED
 	depends on ZEPHYR_HAL_ST_MODULE
 	select I2C if $(dt_compat_on_bus,$(DT_COMPAT_ST_LPS22DF),i2c) ||\
+		      $(dt_compat_on_bus,$(DT_COMPAT_ST_ILPS22QS),i2c) ||\
 		      $(dt_compat_on_bus,$(DT_COMPAT_ST_LPS28DFW),i2c)
 	select I3C if $(dt_compat_on_bus,$(DT_COMPAT_ST_LPS22DF),i3c) ||\
+		      $(dt_compat_on_bus,$(DT_COMPAT_ST_ILPS22QS),i3c) ||\
 		      $(dt_compat_on_bus,$(DT_COMPAT_ST_LPS28DFW),i3c)
-	select SPI if $(dt_compat_on_bus,$(DT_COMPAT_ST_LPS22DF),spi)
+	select SPI if $(dt_compat_on_bus,$(DT_COMPAT_ST_LPS22DF),spi) ||\
+		      $(dt_compat_on_bus,$(DT_COMPAT_ST_ILPS22QS),spi)
 	select HAS_STMEMSC
+	select USE_STDC_ILPS22QS if DT_HAS_ST_ILPS22QS_ENABLED
 	select USE_STDC_LPS22DF if DT_HAS_ST_LPS22DF_ENABLED
 	select USE_STDC_LPS28DFW if DT_HAS_ST_LPS28DFW_ENABLED
 	help

--- a/drivers/sensor/st/lps2xdf/ilps22qs.c
+++ b/drivers/sensor/st/lps2xdf/ilps22qs.c
@@ -1,0 +1,175 @@
+/* ST Microelectronics ILPS22QS pressure and temperature sensor
+ *
+ * Copyright (c) 2023-2024 STMicroelectronics
+ * Copyright (c) 2023 PHYTEC Messtechnik GmbH
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "lps2xdf.h"
+#include "ilps22qs.h"
+#include <zephyr/logging/log.h>
+
+LOG_MODULE_DECLARE(LPS2XDF, CONFIG_SENSOR_LOG_LEVEL);
+
+static inline int ilps22qs_mode_set_odr_raw(const struct device *dev, uint8_t odr)
+{
+	const struct lps2xdf_config *const cfg = dev->config;
+	stmdev_ctx_t *ctx = (stmdev_ctx_t *)&cfg->ctx;
+	ilps22qs_md_t md = { 0 };
+
+	md.odr = odr;
+	md.avg = cfg->avg;
+	md.lpf = cfg->lpf;
+	md.fs = cfg->fs;
+
+	return ilps22qs_mode_set(ctx, &md);
+}
+
+static int ilps22qs_sample_fetch(const struct device *dev, enum sensor_channel chan)
+{
+	struct lps2xdf_data *data = dev->data;
+	const struct lps2xdf_config *const cfg = dev->config;
+	stmdev_ctx_t *ctx = (stmdev_ctx_t *)&cfg->ctx;
+	ilps22qs_data_t raw_data;
+	ilps22qs_md_t md = { 0 };
+
+	md.fs = cfg->fs;
+
+	if (ilps22qs_data_get(ctx, &md, &raw_data) < 0) {
+		LOG_DBG("Failed to read sample");
+		return -EIO;
+	}
+
+	data->sample_press = raw_data.pressure.raw;
+	data->sample_temp = raw_data.heat.raw;
+
+	return 0;
+}
+
+#ifdef CONFIG_LPS2XDF_TRIGGER
+/**
+ * ilps22qs_config_interrupt - not supported
+ */
+static int ilps22qs_config_interrupt(const struct device *dev)
+{
+	return -ENOTSUP;
+}
+
+/**
+ * ilps22qs_handle_interrupt - not supported
+ */
+static void ilps22qs_handle_interrupt(const struct device *dev)
+{
+}
+
+/**
+ * ilps22qs_trigger_set - not supported
+ */
+static int ilps22qs_trigger_set(const struct device *dev,
+				const struct sensor_trigger *trig,
+				sensor_trigger_handler_t handler)
+{
+	return -ENOTSUP;
+}
+#endif /* CONFIG_LPS2XDF_TRIGGER */
+
+const struct lps2xdf_chip_api st_ilps22qs_chip_api = {
+	.mode_set_odr_raw = ilps22qs_mode_set_odr_raw,
+	.sample_fetch = ilps22qs_sample_fetch,
+#if CONFIG_LPS2XDF_TRIGGER
+	.config_interrupt = ilps22qs_config_interrupt,
+	.handle_interrupt = ilps22qs_handle_interrupt,
+	.trigger_set = ilps22qs_trigger_set,
+#endif
+};
+
+int st_ilps22qs_init(const struct device *dev)
+{
+	const struct lps2xdf_config *const cfg = dev->config;
+	stmdev_ctx_t *ctx = (stmdev_ctx_t *)&cfg->ctx;
+	ilps22qs_id_t id;
+	ilps22qs_stat_t status;
+	uint8_t tries = 10;
+	int ret;
+
+#if DT_HAS_COMPAT_ON_BUS_STATUS_OKAY(st_ilps22qs, i3c)
+	if (cfg->i3c.bus != NULL) {
+		struct lps2xdf_data *data = dev->data;
+		/*
+		 * Need to grab the pointer to the I3C device descriptor
+		 * before we can talk to the sensor.
+		 */
+		data->i3c_dev = i3c_device_find(cfg->i3c.bus, &cfg->i3c.dev_id);
+		if (data->i3c_dev == NULL) {
+			LOG_ERR("Cannot find I3C device descriptor");
+			return -ENODEV;
+		}
+	}
+#endif
+
+	if (ilps22qs_id_get(ctx, &id) < 0) {
+		LOG_ERR("%s: Not able to read dev id", dev->name);
+		return -EIO;
+	}
+
+	if (id.whoami != ILPS22QS_ID) {
+		LOG_ERR("%s: Invalid chip ID 0x%02x", dev->name, id.whoami);
+		return -EIO;
+	}
+
+	LOG_DBG("%s: chip id 0x%x", dev->name, id.whoami);
+
+	/* Restore default configuration */
+	if (ilps22qs_init_set(ctx, ILPS22QS_RESET) < 0) {
+		LOG_ERR("%s: Not able to reset device", dev->name);
+		return -EIO;
+	}
+
+	do {
+		if (!--tries) {
+			LOG_DBG("sw reset timed out");
+			return -ETIMEDOUT;
+		}
+		k_usleep(LPS2XDF_SWRESET_WAIT_TIME_US);
+
+		if (ilps22qs_status_get(ctx, &status) < 0) {
+			return -EIO;
+		}
+	} while (status.sw_reset);
+
+	/* Set bdu and if_inc recommended for driver usage */
+	if (ilps22qs_init_set(ctx, ILPS22QS_DRV_RDY) < 0) {
+		LOG_ERR("%s: Not able to set device to ready state", dev->name);
+		return -EIO;
+	}
+
+	if (ON_I3C_BUS(cfg)) {
+		ilps22qs_bus_mode_t bus_mode;
+
+		/* Select bus interface */
+		ilps22qs_bus_mode_get(ctx, &bus_mode);
+		bus_mode.filter = ILPS22QS_AUTO;
+		bus_mode.interface = ILPS22QS_SEL_BY_HW;
+		ilps22qs_bus_mode_set(ctx, &bus_mode);
+	}
+
+	/* set sensor default odr */
+	LOG_DBG("%s: odr: %d", dev->name, cfg->odr);
+	ret = ilps22qs_mode_set_odr_raw(dev, cfg->odr);
+	if (ret < 0) {
+		LOG_ERR("%s: Failed to set odr %d", dev->name, cfg->odr);
+		return ret;
+	}
+
+#ifdef CONFIG_LPS2XDF_TRIGGER
+	if (cfg->trig_enabled) {
+		if (lps2xdf_init_interrupt(dev, DEVICE_VARIANT_ILPS22QS) < 0) {
+			LOG_ERR("Failed to initialize interrupt.");
+			return -EIO;
+		}
+	}
+#endif
+
+	return 0;
+}

--- a/drivers/sensor/st/lps2xdf/ilps22qs.h
+++ b/drivers/sensor/st/lps2xdf/ilps22qs.h
@@ -1,0 +1,23 @@
+/* ST Microelectronics ILPS22QS pressure and temperature sensor
+ *
+ * Copyright (c) 2023-2024 STMicroelectronics
+ * Copyright (c) 2023 PHYTEC Messtechnik GmbH
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdint.h>
+#include <stmemsc.h>
+
+#include "ilps22qs_reg.h"
+
+#include <zephyr/drivers/sensor.h>
+
+#ifndef ZEPHYR_DRIVERS_SENSOR_ILPS22QS_ILPS22QS_H_
+#define ZEPHYR_DRIVERS_SENSOR_ILPS22QS_ILPS22QS_H_
+
+extern const struct lps2xdf_chip_api st_ilps22qs_chip_api;
+
+int st_ilps22qs_init(const struct device *dev);
+
+#endif /* ZEPHYR_DRIVERS_SENSOR_ILPS22QS_H_ */

--- a/drivers/sensor/st/lps2xdf/lps2xdf.c
+++ b/drivers/sensor/st/lps2xdf/lps2xdf.c
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: Apache-2.0
  *
  * Datasheet:
+ * https://www.st.com/resource/en/datasheet/ilps22qs.pdf
  * https://www.st.com/resource/en/datasheet/lps22df.pdf
  * https://www.st.com/resource/en/datasheet/lps28df.pdf
  */
@@ -19,6 +20,10 @@
 #include <zephyr/logging/log.h>
 
 #include "lps2xdf.h"
+
+#if DT_HAS_COMPAT_STATUS_OKAY(st_ilps22qs)
+#include "ilps22qs.h"
+#endif
 
 #if DT_HAS_COMPAT_STATUS_OKAY(st_lps22df)
 #include "lps22df.h"
@@ -159,7 +164,7 @@ static const struct sensor_driver_api lps2xdf_driver_api = {
 	.lpf = DT_INST_PROP(inst, lpf),                                        \
 	.avg = DT_INST_PROP(inst, avg),                                        \
 	.chip_api = &name##_chip_api,                                          \
-	IF_ENABLED(DT_INST_NODE_HAS_COMPAT(inst, st_lps28dfw),                 \
+	IF_ENABLED(DT_INST_NODE_HAS_PROP(inst, fs),                            \
 		   (.fs = DT_INST_PROP(inst, fs),))                            \
 	IF_ENABLED(DT_INST_NODE_HAS_PROP(inst, drdy_gpios),                    \
 		   (LPS2XDF_CFG_IRQ(inst)))
@@ -213,6 +218,10 @@ static const struct sensor_driver_api lps2xdf_driver_api = {
 	SENSOR_DEVICE_DT_INST_DEFINE(inst, name##_init, NULL, &lps2xdf_data_##name##_##inst, \
 				     &lps2xdf_config_##name##_##inst, POST_KERNEL,           \
 				     CONFIG_SENSOR_INIT_PRIORITY, &lps2xdf_driver_api);
+
+#define DT_DRV_COMPAT st_ilps22qs
+DT_INST_FOREACH_STATUS_OKAY_VARGS(LPS2XDF_DEFINE, DT_DRV_COMPAT)
+#undef DT_DRV_COMPAT
 
 #define DT_DRV_COMPAT st_lps22df
 DT_INST_FOREACH_STATUS_OKAY_VARGS(LPS2XDF_DEFINE, DT_DRV_COMPAT)

--- a/drivers/sensor/st/lps2xdf/lps2xdf.h
+++ b/drivers/sensor/st/lps2xdf/lps2xdf.h
@@ -41,6 +41,7 @@
 typedef int32_t (*api_lps2xdf_mode_set_odr_raw)(const struct device *dev, uint8_t odr);
 typedef int32_t (*api_lps2xdf_sample_fetch)(const struct device *dev, enum sensor_channel chan);
 #ifdef CONFIG_LPS2XDF_TRIGGER
+typedef int (*api_lps2xdf_config_interrupt)(const struct device *dev);
 typedef void (*api_lps2xdf_handle_interrupt)(const struct device *dev);
 typedef int (*api_lps2xdf_trigger_set)(const struct device *dev,
 				       const struct sensor_trigger *trig,
@@ -51,6 +52,7 @@ struct lps2xdf_chip_api {
 	api_lps2xdf_mode_set_odr_raw mode_set_odr_raw;
 	api_lps2xdf_sample_fetch sample_fetch;
 #ifdef CONFIG_LPS2XDF_TRIGGER
+	api_lps2xdf_config_interrupt config_interrupt;
 	api_lps2xdf_handle_interrupt handle_interrupt;
 	api_lps2xdf_trigger_set trigger_set;
 #endif
@@ -126,6 +128,8 @@ struct lps2xdf_data {
 };
 
 #ifdef CONFIG_LPS2XDF_TRIGGER
+int lps2xdf_config_int(const struct device *dev);
+
 int lps2xdf_trigger_set(const struct device *dev,
 			const struct sensor_trigger *trig,
 			sensor_trigger_handler_t handler);

--- a/drivers/sensor/st/lps2xdf/lps2xdf.h
+++ b/drivers/sensor/st/lps2xdf/lps2xdf.h
@@ -4,10 +4,6 @@
  * Copyright (c) 2023 PHYTEC Messtechnik GmbH
  *
  * SPDX-License-Identifier: Apache-2.0
- *
- * Datasheets:
- * https://www.st.com/resource/en/datasheet/lps22df.pdf
- * https://www.st.com/resource/en/datasheet/lps28dfw.pdf
  */
 
 #ifndef ZEPHYR_DRIVERS_SENSOR_LPS2XDF_LPS2XDF_H_
@@ -15,6 +11,10 @@
 
 #include <stdint.h>
 #include <stmemsc.h>
+
+#if DT_HAS_COMPAT_STATUS_OKAY(st_ilps22qs)
+#include "ilps22qs_reg.h"
+#endif
 
 #if DT_HAS_COMPAT_STATUS_OKAY(st_lps28dfw)
 #include "lps28dfw_reg.h"
@@ -32,6 +32,7 @@
 #define LPS2XDF_SWRESET_WAIT_TIME_US 50
 
 #if (DT_HAS_COMPAT_ON_BUS_STATUS_OKAY(st_lps22df, i3c) || \
+	DT_HAS_COMPAT_ON_BUS_STATUS_OKAY(st_ilps22qs, i3c) || \
 	DT_HAS_COMPAT_ON_BUS_STATUS_OKAY(st_lps28dfw, i3c))
 	#define ON_I3C_BUS(cfg) (cfg->i3c.bus != NULL)
 #else
@@ -62,6 +63,7 @@ struct lps2xdf_chip_api {
 enum sensor_variant {
 	DEVICE_VARIANT_LPS22DF = 0,
 	DEVICE_VARIANT_LPS28DFW = 1,
+	DEVICE_VARIANT_ILPS22QS = 2,
 };
 
 
@@ -69,13 +71,16 @@ struct lps2xdf_config {
 	stmdev_ctx_t ctx;
 	union {
 #if (DT_HAS_COMPAT_ON_BUS_STATUS_OKAY(st_lps22df, i2c) || \
+	DT_HAS_COMPAT_ON_BUS_STATUS_OKAY(st_ilps22qs, i2c) || \
 	DT_HAS_COMPAT_ON_BUS_STATUS_OKAY(st_lps28dfw, i2c))
 		const struct i2c_dt_spec i2c;
 #endif
-#if DT_HAS_COMPAT_ON_BUS_STATUS_OKAY(st_lps22df, spi)
+#if (DT_HAS_COMPAT_ON_BUS_STATUS_OKAY(st_lps22df, spi) ||\
+	DT_HAS_COMPAT_ON_BUS_STATUS_OKAY(st_ilps22qs, spi))
 		const struct spi_dt_spec spi;
 #endif
 #if (DT_HAS_COMPAT_ON_BUS_STATUS_OKAY(st_lps22df, i3c) || \
+	DT_HAS_COMPAT_ON_BUS_STATUS_OKAY(st_ilps22qs, i3c) || \
 	DT_HAS_COMPAT_ON_BUS_STATUS_OKAY(st_lps28dfw, i3c))
 		struct i3c_device_desc **i3c;
 #endif
@@ -91,6 +96,7 @@ struct lps2xdf_config {
 #endif
 
 #if (DT_HAS_COMPAT_ON_BUS_STATUS_OKAY(st_lps22df, i3c) || \
+	DT_HAS_COMPAT_ON_BUS_STATUS_OKAY(st_ilps22qs, i3c) || \
 	DT_HAS_COMPAT_ON_BUS_STATUS_OKAY(st_lps28dfw, i3c))
 	struct {
 		const struct device *bus;
@@ -122,6 +128,7 @@ struct lps2xdf_data {
 #endif /* CONFIG_LPS2XDF_TRIGGER */
 
 #if (DT_HAS_COMPAT_ON_BUS_STATUS_OKAY(st_lps22df, i3c) || \
+	DT_HAS_COMPAT_ON_BUS_STATUS_OKAY(st_ilps22qs, i3c) || \
 	DT_HAS_COMPAT_ON_BUS_STATUS_OKAY(st_lps28dfw, i3c))
 	struct i3c_device_desc *i3c_dev;
 #endif

--- a/drivers/sensor/st/lps2xdf/lps2xdf.h
+++ b/drivers/sensor/st/lps2xdf/lps2xdf.h
@@ -40,8 +40,8 @@
 
 typedef int32_t (*api_lps2xdf_mode_set_odr_raw)(const struct device *dev, uint8_t odr);
 typedef int32_t (*api_lps2xdf_sample_fetch)(const struct device *dev, enum sensor_channel chan);
-typedef void (*api_lps2xdf_handle_interrupt)(const struct device *dev);
 #ifdef CONFIG_LPS2XDF_TRIGGER
+typedef void (*api_lps2xdf_handle_interrupt)(const struct device *dev);
 typedef int (*api_lps2xdf_trigger_set)(const struct device *dev,
 				       const struct sensor_trigger *trig,
 				       sensor_trigger_handler_t handler);
@@ -50,8 +50,8 @@ typedef int (*api_lps2xdf_trigger_set)(const struct device *dev,
 struct lps2xdf_chip_api {
 	api_lps2xdf_mode_set_odr_raw mode_set_odr_raw;
 	api_lps2xdf_sample_fetch sample_fetch;
-	api_lps2xdf_handle_interrupt handle_interrupt;
 #ifdef CONFIG_LPS2XDF_TRIGGER
+	api_lps2xdf_handle_interrupt handle_interrupt;
 	api_lps2xdf_trigger_set trigger_set;
 #endif
 };

--- a/dts/bindings/sensor/st,ilps22qs-common.yaml
+++ b/dts/bindings/sensor/st,ilps22qs-common.yaml
@@ -1,0 +1,83 @@
+# Copyright (c) 2023-2024 STMicroelectronics
+# Copyright (c) 2023 PHYTEC Messtechnik GmbH
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+    When setting the odr, lpf, avg properties in a .dts or .dtsi file
+    you may include ilps22qs.h and use the macros defined there.
+
+    Example:
+    #include <zephyr/dt-bindings/sensor/ilps22qs.h>
+
+    ilps22qs@5d {
+      ...
+
+      odr = <LPS2xDF_DT_ODR_10HZ>;
+      lpf = <LPS2xDF_DT_LP_FILTER_ODR_4>;
+      avg = <LPS2xDF_DT_AVG_128_SAMPLES>;
+    };
+
+include: sensor-device.yaml
+
+properties:
+  odr:
+    type: int
+    default: 0
+    description: |
+        Specify the output data rate expressed in samples per second (Hz).
+        The default is the power-on reset value.
+
+        - 0 # LPS2xDF_DT_ODR_POWER_DOWN
+        - 1 # LPS2xDF_DT_ODR_1HZ
+        - 2 # LPS2xDF_DT_ODR_4HZ
+        - 3 # LPS2xDF_DT_ODR_10HZ
+        - 4 # LPS2xDF_DT_ODR_25HZ
+        - 5 # LPS2xDF_DT_ODR_50HZ
+        - 6 # LPS2xDF_DT_ODR_75HZ
+        - 7 # LPS2xDF_DT_ODR_100HZ
+        - 8 # LPS2xDF_DT_ODR_200HZ
+
+    enum: [0, 1, 2, 3, 4, 5, 6, 7, 8]
+
+  lpf:
+    type: int
+    default: 0
+    description: |
+        Specify the low pass filter value to be applied to pressure data.
+        The default is the power-on reset value.
+
+        - 0 # LPS2xDF_DT_LP_FILTER_OFF
+        - 1 # LPS2xDF_DT_LP_FILTER_ODR_4
+        - 3 # LPS2xDF_DT_LP_FILTER_ODR_9
+
+    enum: [0, 1, 3]
+
+  avg:
+    type: int
+    default: 0
+    description: |
+        Specify the average filter value (i.e. number of samples) to be applied
+        to pressure and temperature data.
+        The default is the power-on reset value.
+
+        - 0 # LPS2xDF_DT_AVG_4_SAMPLES
+        - 1 # LPS2xDF_DT_AVG_8_SAMPLES
+        - 2 # LPS2xDF_DT_AVG_16_SAMPLES
+        - 3 # LPS2xDF_DT_AVG_32_SAMPLES
+        - 4 # LPS2xDF_DT_AVG_64_SAMPLES
+        - 5 # LPS2xDF_DT_AVG_128_SAMPLES
+        - 6 # LPS2xDF_DT_AVG_256_SAMPLES
+        - 7 # LPS2xDF_DT_AVG_512_SAMPLES
+
+    enum: [0, 1, 2, 3, 4, 5, 6, 7]
+
+  fs:
+    type: int
+    default: 0
+    description: |
+        Specify the full-scale mode.
+        The default is the power-on reset value.
+
+        - 0 # ILPS22QS_DT_FS_MODE_1_1260
+        - 1 # ILPS22QS_DT_FS_MODE_2_4060
+    enum: [0, 1]

--- a/dts/bindings/sensor/st,ilps22qs-i2c.yaml
+++ b/dts/bindings/sensor/st,ilps22qs-i2c.yaml
@@ -1,0 +1,10 @@
+# Copyright (c) 2024 STMicroelectronics
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+    STMicroelectronics LPS22DF pressure and temperature sensor connected to I2C
+    bus
+
+compatible: "st,ilps22qs"
+
+include: ["i2c-device.yaml", "st,ilps22qs-common.yaml"]

--- a/dts/bindings/sensor/st,ilps22qs-i3c.yaml
+++ b/dts/bindings/sensor/st,ilps22qs-i3c.yaml
@@ -1,0 +1,10 @@
+# Copyright (c) 2024 STMicroelectronics
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+    STMicroelectronics LPS22DF pressure and temperature sensor connected to I3C
+    bus
+
+compatible: "st,ilps22qs"
+
+include: ["i3c-device.yaml", "st,ilps22qs-common.yaml"]

--- a/dts/bindings/sensor/st,ilps22qs-spi.yaml
+++ b/dts/bindings/sensor/st,ilps22qs-spi.yaml
@@ -1,0 +1,10 @@
+# Copyright (c) 2024 STMicroelectronics
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+    STMicroelectronics LPS22DF pressure and temperature sensor connected to SPI
+    bus
+
+compatible: "st,ilps22qs"
+
+include: ["spi-device.yaml", "st,ilps22qs-common.yaml"]

--- a/include/zephyr/dt-bindings/sensor/lps2xdf.h
+++ b/include/zephyr/dt-bindings/sensor/lps2xdf.h
@@ -37,4 +37,8 @@
 #define LPS28DFW_DT_FS_MODE_1_1260		0
 #define LPS28DFW_DT_FS_MODE_2_4060		1
 
+/* Full Scale Pressure Mode */
+#define ILPS22QS_DT_FS_MODE_1_1260		0
+#define ILPS22QS_DT_FS_MODE_2_4060		1
+
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_ST_LPS22DF_H_ */

--- a/samples/boards/st/steval_stwinbx1/sensors/README.rst
+++ b/samples/boards/st/steval_stwinbx1/sensors/README.rst
@@ -17,6 +17,7 @@ sensors:
 - ISM330DHCX: IMU, 3D accelerometer and 3D gyroscope with Machine Learning Core and Finite State Machine
 - IIS2DLPC: high-performance ultra-low-power 3-axis accelerometer for industrial applications
 - IIS2ICLX: high-accuracy, high-resolution, low-power, 2-axis digital inclinometer with Machine Learning Core
+- ILPS22QS: ultra-compact piezoresistive absolute pressure sensor
 
 Requirements
 ************
@@ -70,6 +71,8 @@ The sample code outputs sensors data on the STWIN.box console.
     ISM330DHCX: Accel (m.s-2): x: 0.000, y: 5.704, z: 7.982
     ISM330DHCX: Gyro (dps): x: 0.026, y: -0.006, z: -0.008
     IIS2ICLX: Accel (m.s-2): x: -0.157, y: 5.699
+    ILPS22QS: Temperature: 26.4 C
+    ILPS22QS: Pressure: 100.539 kpa
     1:: iis2dlpc trig 2021
     1:: iis2mdc trig 993
     1:: ism330dhcx acc trig 4447

--- a/tests/drivers/build_all/sensor/app.overlay
+++ b/tests/drivers/build_all/sensor/app.overlay
@@ -146,7 +146,8 @@
 				   <&test_gpio 0 0>,
 				   <&test_gpio 0 0>,
 				   <&test_gpio 0 0>,
-				   <&test_gpio 0 0>;	/* 0x2f */
+				   <&test_gpio 0 0>,
+				   <&test_gpio 0 0>;	/* 0x30 */
 
 			#include "spi.dtsi"
 		};

--- a/tests/drivers/build_all/sensor/i2c.dtsi
+++ b/tests/drivers/build_all/sensor/i2c.dtsi
@@ -1101,17 +1101,27 @@ test_i2c_bmp390: bmp390@99 {
 	iir-filter = <3>;
 };
 
-apds_9306: apds9306@92 {
+apds_9306: apds9306@9a {
 	compatible = "avago,apds9306";
-	reg = <0x92>;
+	reg = <0x9a>;
 	status = "okay";
 	gain = <1>;
 	resolution = <13>;
 	frequency = <2000>;
 };
 
-test_i2c_wsen_hids_2525020210002: wsen_hids_2525020210002@99 {
+test_i2c_wsen_hids_2525020210002: wsen_hids_2525020210002@9b {
 	compatible = "we,wsen-hids-2525020210002";
-	reg = <0x99>;
+	reg = <0x9b>;
 	precision = "high";
+};
+
+test_i2c_ilps22qs: ilps22qs@9c {
+	compatible = "st,ilps22qs";
+	reg = <0x9c>;
+	status = "okay";
+	odr = <LPS2xDF_DT_ODR_10HZ>;
+	lpf = <LPS2xDF_DT_LP_FILTER_ODR_4>;
+	avg = <LPS2xDF_DT_AVG_128_SAMPLES>;
+	fs = <ILPS22QS_DT_FS_MODE_1_1260>;
 };

--- a/tests/drivers/build_all/sensor/i3c.dtsi
+++ b/tests/drivers/build_all/sensor/i3c.dtsi
@@ -30,3 +30,9 @@ test_i3c_lps28dfw: lps28dfw@300000803E0000003 {
 	assigned-address = <0x3>;
 	drdy-gpios = <&test_gpio 0 0>;
 };
+
+test_i3c_ilps22qs: ilps22qs@400000803E0000004 {
+	compatible = "st,ilps22qs";
+	reg = <0x3 0x00000803 0xE0000004>;
+	assigned-address = <0x4>;
+};

--- a/tests/drivers/build_all/sensor/spi.dtsi
+++ b/tests/drivers/build_all/sensor/spi.dtsi
@@ -392,3 +392,10 @@ test_spi_bmp390: bmp390@2f {
 	osr-temp = <1>;
 	iir-filter = <3>;
 };
+
+test_spi_ilps22qs: ilps22qs@30 {
+	compatible = "st,ilps22qs";
+	reg = <0x30>;
+	spi-max-frequency = <0>;
+	status = "okay";
+};


### PR DESCRIPTION
The ILPS22QS is an ultra-compact piezoresistive absolute pressure and temperature sensor from ST Microelectronics.
https://www.st.com/en/mems-and-sensors/ilps22qs.html

It is register compatible with lps2xdf, which already handles lps22df and lps28dfw, so we will use it to handle ilps22qs as well. During the implementation few issues/improvements have been found and fixed.

The new driver has been verified on STM steval_stwinbx1 board.