### PR TITLE
ci: doc: don't fail publish job if there's nothing to publish

### DIFF
--- a/.github/workflows/doc-publish-pr.yml
+++ b/.github/workflows/doc-publish-pr.yml
@@ -21,16 +21,20 @@ jobs:
 
     steps:
     - name: Download artifacts
+      id: download-artifacts
       uses: dawidd6/action-download-artifact@v6
       with:
         workflow: doc-build.yml
         run_id: ${{ github.event.workflow_run.id }}
+        if_no_artifact_found: ignore
 
     - name: Load PR number
+      if: steps.download-artifacts.outputs.found_artifact == 'true'
       run: |
         echo "PR_NUM=$(<pr_num/pr_num)" >> $GITHUB_ENV
 
     - name: Check PR number
+      if: steps.download-artifacts.outputs.found_artifact == 'true'
       id: check-pr
       uses: carpentries/actions/check-valid-pr@v0.14.0
       with:
@@ -38,12 +42,15 @@ jobs:
         sha: ${{ github.event.workflow_run.head_sha }}
 
     - name: Validate PR number
-      if: steps.check-pr.outputs.VALID != 'true'
+      if: |
+        steps.download-artifacts.outputs.found_artifact == 'true' &&
+        steps.check-pr.outputs.VALID != 'true'
       run: |
         echo "ABORT: PR number validation failed!"
         exit 1
 
     - name: Uncompress HTML docs
+      if: steps.download-artifacts.outputs.found_artifact == 'true'
       run: |
         tar xf html-output/html-output.tar.xz -C html-output
         if [ -f api-coverage/api-coverage.tar.xz ]; then
@@ -51,6 +58,7 @@ jobs:
         fi
 
     - name: Configure AWS Credentials
+      if: steps.download-artifacts.outputs.found_artifact == 'true'
       uses: aws-actions/configure-aws-credentials@v4
       with:
         aws-access-key-id: ${{ vars.AWS_BUILDS_ZEPHYR_PR_ACCESS_KEY_ID }}
@@ -58,6 +66,7 @@ jobs:
         aws-region: us-east-1
 
     - name: Upload to AWS S3
+      if: steps.download-artifacts.outputs.found_artifact == 'true'
       env:
         HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
       run: |


### PR DESCRIPTION
If doc build has not generated any artifact, gracefully skip publication instead of failing, as this can be pretty confusing...

tested as working in my fork https://github.com/kartben/zephyr/actions/runs/11348482946/job/31562362519