### PR TITLE
tests: drivers: spi: spi_slave: Fix memory corruption

### DIFF
--- a/tests/drivers/spi/spi_controller_peripheral/boards/nrf52840dk_nrf52840.overlay
+++ b/tests/drivers/spi/spi_controller_peripheral/boards/nrf52840dk_nrf52840.overlay
@@ -52,6 +52,7 @@
 	cs-gpios = <&gpio1 11 GPIO_ACTIVE_LOW>;
 	dut_spi_dt: test-spi-dev@0 {
 		compatible = "vnd,spi-device";
+		spi-max-frequency = <DT_FREQ_M(8)>;
 		reg = <0>;
 	};
 };

--- a/tests/drivers/spi/spi_controller_peripheral/src/main.c
+++ b/tests/drivers/spi/spi_controller_peripheral/src/main.c
@@ -530,9 +530,16 @@ static void before(void *not_used)
 	k_sem_init(&tdata.sem, 0, 1);
 }
 
+static void after(void *not_used)
+{
+	ARG_UNUSED(not_used);
+
+	k_work_cancel_delayable(&tdata.test_work);
+}
+
 static void *suite_setup(void)
 {
 	return NULL;
 }
 
-ZTEST_SUITE(spi_controller_peripheral, NULL, suite_setup, before, NULL, NULL);
+ZTEST_SUITE(spi_controller_peripheral, NULL, suite_setup, before, after, NULL);


### PR DESCRIPTION
This fixes memory corruption of delayable work when
tests executes unsupported function.

When test (e.g. only_rx_in_chunks) is executed it starts
delayed work for master functionality (with 10 ms delay).
Later when slave function is tried and reports that
function is unsupported, test is terminated (task ends)
but work is still scheduled.

When next test starts it clears work that is already
scheduled:

```c
static void before(void *not_used)
{
	ARG_UNUSED(not_used);

	memset(&tdata, 0, sizeof(tdata));
```

this leads to memory corruption and system work queue
tries to remove work but it never does since head/next
pointers are zeroed at that time.

This just adds `after` function that cancels work
regardless if it was scheduled or not.

Additionally overlay used for testing is updated with spi frequency that seems to be missing.