### PR TITLE
soc: nxp: k6x: disable on reset NMI and EzPort

### DIFF
--- a/soc/nxp/kinetis/k6x/Kconfig.defconfig
+++ b/soc/nxp/kinetis/k6x/Kconfig.defconfig
@@ -19,4 +19,10 @@ config GPIO
 config SPI
 	default n if SOC_MK64F12
 
+# The flash option register (FOPT) boot options
+# 1111 1001 - Set NMI pin/interrupts and EzPort reset default to disabled
+config KINETIS_FLASH_CONFIG_FOPT
+	default 0xF9
+	depends on KINETIS_FLASH_CONFIG
+
 endif # SOC_SERIES_KINETIS_K6X


### PR DESCRIPTION
- Disables on reset NMI and EzPort.
- Fixes frdm-k64 SW3 user button on reset issue. So it can be assigned to the mcuboot-button0 alias.