### PR TITLE
drivers: pwm: implement fake-pwm driver

### DIFF
--- a/drivers/pwm/CMakeLists.txt
+++ b/drivers/pwm/CMakeLists.txt
@@ -47,7 +47,7 @@ zephyr_library_sources_ifdef(CONFIG_PWM_NXP_S32_EMIOS pwm_nxp_s32_emios.c)
 zephyr_library_sources_ifdef(CONFIG_PWM_ENE_KB1200	pwm_ene_kb1200.c)
 zephyr_library_sources_ifdef(CONFIG_PWM_RENESAS_RA8	pwm_renesas_ra8.c)
 zephyr_library_sources_ifdef(CONFIG_PWM_INFINEON_CAT1	pwm_ifx_cat1.c)
-
+zephyr_library_sources_ifdef(CONFIG_PWM_FAKE	pwm_fake.c)
 zephyr_library_sources_ifdef(CONFIG_USERSPACE   pwm_handlers.c)
 zephyr_library_sources_ifdef(CONFIG_PWM_CAPTURE pwm_capture.c)
 zephyr_library_sources_ifdef(CONFIG_PWM_SHELL   pwm_shell.c)

--- a/drivers/pwm/Kconfig
+++ b/drivers/pwm/Kconfig
@@ -114,4 +114,6 @@ source "drivers/pwm/Kconfig.renesas_ra8"
 
 source "drivers/pwm/Kconfig.ifx_cat1"
 
+source "drivers/pwm/Kconfig.fake"
+
 endif # PWM

--- a/drivers/pwm/Kconfig.fake
+++ b/drivers/pwm/Kconfig.fake
@@ -1,0 +1,11 @@
+# Fake PWM configuration options
+
+# Copyright (c) 2024 Kickmaker
+# SPDX-License-Identifier: Apache-2.0
+
+config PWM_FAKE
+	bool "Fake PWM driver"
+	default y
+	depends on DT_HAS_ZEPHYR_FAKE_PWM_ENABLED
+	help
+	  Enable support for the FFF-based fake PWM driver.

--- a/drivers/pwm/pwm_fake.c
+++ b/drivers/pwm/pwm_fake.c
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2024 Kickmaker
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/device.h>
+#include <zephyr/drivers/pwm.h>
+#include <zephyr/drivers/pwm/pwm_fake.h>
+#include <zephyr/fff.h>
+#include <zephyr/sys/util.h>
+
+#ifdef CONFIG_ZTEST
+#include <zephyr/ztest.h>
+#endif /* CONFIG_ZTEST */
+
+#define DT_DRV_COMPAT zephyr_fake_pwm
+
+/** Fake PWM config structure */
+struct fake_pwm_config {
+	/** Frequency of the (fake) underlying timer */
+	uint64_t frequency_hz;
+};
+
+DEFINE_FAKE_VALUE_FUNC(int, fake_pwm_set_cycles, const struct device *, uint32_t, uint32_t,
+		       uint32_t, pwm_flags_t);
+
+#ifdef CONFIG_ZTEST
+static void fake_pwm_reset_rule_before(const struct ztest_unit_test *test, void *fixture)
+{
+	ARG_UNUSED(test);
+	ARG_UNUSED(fixture);
+
+	RESET_FAKE(fake_pwm_set_cycles);
+}
+
+ZTEST_RULE(fake_pwm_reset_rule, fake_pwm_reset_rule_before, NULL);
+#endif /* CONFIG_ZTEST */
+
+static int fake_pwm_get_cycles_per_sec(const struct device *dev, uint32_t channel, uint64_t *cycles)
+{
+	ARG_UNUSED(channel);
+	const struct fake_pwm_config *config = dev->config;
+
+	*cycles = config->frequency_hz;
+
+	return 0;
+}
+
+static DEVICE_API(pwm, fake_pwm_driver_api) = {
+	.set_cycles = fake_pwm_set_cycles,
+	.get_cycles_per_sec = fake_pwm_get_cycles_per_sec,
+};
+
+#define FAKE_PWM_INIT(inst)                                                                        \
+	static const struct fake_pwm_config fake_pwm_config_##inst = {                             \
+		.frequency_hz = DT_INST_PROP(inst, frequency),                                     \
+	};                                                                                         \
+                                                                                                   \
+	DEVICE_DT_INST_DEFINE(inst, NULL, NULL, NULL, &fake_pwm_config_##inst, POST_KERNEL,        \
+			      CONFIG_PWM_INIT_PRIORITY, &fake_pwm_driver_api);
+
+DT_INST_FOREACH_STATUS_OKAY(FAKE_PWM_INIT)

--- a/dts/bindings/pwm/zephyr,fake-pwm.yaml
+++ b/dts/bindings/pwm/zephyr,fake-pwm.yaml
@@ -1,0 +1,26 @@
+# Copyright (c) 2024 Kickmaker
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+    This binding provides a fake PWM for use as either a stub or a mock in Zephyr
+    testing.
+
+compatible: "zephyr,fake-pwm"
+
+include: [pwm-controller.yaml, base.yaml, pinctrl-device.yaml]
+
+properties:
+  "#pwm-cells":
+    const: 2
+    description: |
+      Number of items to expect in a PWM
+      - channel of the timer used for PWM
+      - period to set in ns
+  frequency:
+    type: int
+    description: |
+      Frequency for the underlying timer (in Hz)
+
+pwm-cells:
+  - channel
+  - period

--- a/include/zephyr/drivers/pwm/pwm_fake.h
+++ b/include/zephyr/drivers/pwm/pwm_fake.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2024, Kickmaker
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef INCLUDE_DRIVERS_PWM_PWM_FAKE_H_
+#define INCLUDE_DRIVERS_PWM_PWM_FAKE_H_
+
+#include <zephyr/drivers/pwm.h>
+#include <zephyr/fff.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+DECLARE_FAKE_VALUE_FUNC(int, fake_pwm_set_cycles, const struct device *, uint32_t, uint32_t,
+			uint32_t, pwm_flags_t);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* INCLUDE_DRIVERS_PWM_PWM_FAKE_H_ */

--- a/tests/drivers/pwm/pwm_api/boards/native_sim.overlay
+++ b/tests/drivers/pwm/pwm_api/boards/native_sim.overlay
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2024 Kickmaker
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/{
+	pwm0: pwm0 {
+		compatible = "zephyr,fake-pwm";
+		status = "okay";
+		#pwm-cells = <2>;
+		frequency = <10000000>;
+	};
+
+	aliases {
+		pwm-0 = &pwm0;
+	};
+};

--- a/tests/drivers/pwm/pwm_api/src/test_pwm.c
+++ b/tests/drivers/pwm/pwm_api/src/test_pwm.c
@@ -79,6 +79,11 @@
 #define DEFAULT_PULSE_NSEC 1000000
 #endif
 
+#if DT_HAS_COMPAT_STATUS_OKAY(zephyr_fake_pwm)
+#include <zephyr/fff.h>
+DEFINE_FFF_GLOBALS;
+#endif
+
 #if defined CONFIG_BOARD_SAM_E70_XPLAINED
 #define DEFAULT_PWM_PORT 2 /* PWM on EXT2 connector, pin 8 */
 #elif defined CONFIG_PWM_NRFX

--- a/tests/drivers/pwm/pwm_api/testcase.yaml
+++ b/tests/drivers/pwm/pwm_api/testcase.yaml
@@ -30,3 +30,8 @@ tests:
     platform_allow:
       - frdm_mcxn947/mcxn947/cpu0
       - frdm_mcxn947/mcxn947/cpu0/qspi
+  drivers.pwm.native_sim:
+    platform_allow:
+      - native_sim
+    integration_platforms:
+      - native_sim


### PR DESCRIPTION
Based on fake can and fake gpio driver, this PR implements a fake pwm driver to be used with native_sim target for unit testing purposes

It only implements basic PWM functionality (no capture)