### PR TITLE
llext: xtensa: fix relocations with multiple SLOT0_OP

### DIFF
--- a/arch/xtensa/core/elf.c
+++ b/arch/xtensa/core/elf.c
@@ -71,7 +71,7 @@ void arch_elf_relocate_local(struct llext_loader *ldr, struct llext *ext,
 			return;
 
 		uintptr_t link_addr = (uintptr_t)llext_loaded_sect_ptr(ldr, ext, rsym.st_shndx) +
-			rsym.st_value;
+			rsym.st_value + rel->r_addend;
 
 		ssize_t value = (link_addr - (((uintptr_t)got_entry + 3) & ~3)) >> 2;
 


### PR DESCRIPTION
Support for R_XTENSA_SLOT0_OP was implemented with a relocation table test case, containing only one entry at offset 0. For multiple entries .r_addend has to be taken into account.