### PR TITLE
thrift: Define module-wide _POSIX_C_SOURCE feature test macro

### DIFF
--- a/modules/thrift/CMakeLists.txt
+++ b/modules/thrift/CMakeLists.txt
@@ -39,4 +39,7 @@ zephyr_library_sources_ifdef(CONFIG_THRIFT_SSL_SOCKET
 # needed because std::iterator was deprecated with -std=c++17
 zephyr_library_compile_options(-Wno-deprecated-declarations)
 
+# needed for ctime_r
+zephyr_library_compile_definitions(_POSIX_C_SOURCE=200809L)
+
 endif(CONFIG_THRIFT)

--- a/tests/modules/thrift/ThriftTest/testcase.yaml
+++ b/tests/modules/thrift/ThriftTest/testcase.yaml
@@ -15,9 +15,9 @@ common:
     - qemu_riscv64
     - qemu_x86_64
 tests:
-  thrift.ThriftTest.newlib.binaryProtocol: {}
-  thrift.ThriftTest.newlib.compactProtocol:
+  thrift.ThriftTest.binaryProtocol: {}
+  thrift.ThriftTest.compactProtocol:
     extra_configs:
       - CONFIG_THRIFT_COMPACT_PROTOCOL=y
-  thrift.ThriftTest.newlib.tlsTransport:
+  thrift.ThriftTest.tlsTransport:
     extra_args: EXTRA_CONF_FILE="overlay-tls.conf"


### PR DESCRIPTION
The Thrift library makes use of POSIX C functions such as ctime_r(), which
are not part of the ISO C standard.

This commit adds a Thrift module-wide `_POSIX_C_SOURCE` feature test macro
definition in order to ensure that the required POSIX C functions are
available when compiling the Thrift library.

Note that this was not caught earlier because Newlib and older versions of
Picolibc did not properly fence off some POSIX functions behind the feature
test macros.
