### PR TITLE
soc: nordic: nrf53: SOC_NRF53_CPUNET_ENABLE should not depend on !BT

### DIFF
--- a/soc/nordic/nrf53/Kconfig
+++ b/soc/nordic/nrf53/Kconfig
@@ -177,7 +177,6 @@ config SOC_NRF53_CPUNET_MGMT
 
 config SOC_NRF53_CPUNET_ENABLE
 	bool "NRF53 Network MCU is enabled at boot time"
-	depends on !BT
 	default y if NRF_802154_SER_HOST
 	select SOC_NRF53_CPUNET_MGMT
 	select SOC_NRF_GPIO_FORWARDER_FOR_NRF5340 if \
@@ -197,7 +196,6 @@ config BOARD_ENABLE_CPUNET
 	bool "[DEPRECATED] NRF53 Network MCU is enabled at boot time"
 	select SOC_NRF53_CPUNET_ENABLE
 	select DEPRECATED
-	depends on !BT
 	help
 	  Use SOC_NRF53_CPUNET_ENABLE instead.
 


### PR DESCRIPTION
This causes issues as we still want the net core to be set up on initialisation if CONFIG_BT is enabled in many cases.

The previous changes in
https://github.com/zephyrproject-rtos/zephyr/pull/74304 assumed that because this is also handled in
`bt_hci_transport_setup` that it shouldn't be done on initialisation too.

Also, I think that
`bt_hci_transport_setup` should not be even controlling the network core state like it is currently and should be looked at being changed in a future PR.