### PR TITLE
modules: thrift: private includes and posix app conformance

### DIFF
--- a/modules/thrift/CMakeLists.txt
+++ b/modules/thrift/CMakeLists.txt
@@ -3,27 +3,27 @@
 
 if(CONFIG_THRIFT)
 
-set(THRIFT_UPSTREAM ${ZEPHYR_THRIFT_MODULE_DIR})
-
 zephyr_library()
 
-zephyr_include_directories(src)
-zephyr_include_directories(include)
-zephyr_include_directories(${THRIFT_UPSTREAM}/lib/cpp/src)
+zephyr_library_include_directories(
+  src
+  include
+  ${ZEPHYR_THRIFT_MODULE_DIR}/lib/cpp/src
+)
 
 zephyr_library_sources(
   src/thrift/server/TFDServer.cpp
-  ${THRIFT_UPSTREAM}/lib/cpp/src/thrift/protocol/TProtocol.cpp
-  ${THRIFT_UPSTREAM}/lib/cpp/src/thrift/server/TConnectedClient.cpp
-  ${THRIFT_UPSTREAM}/lib/cpp/src/thrift/server/TSimpleServer.cpp
-  ${THRIFT_UPSTREAM}/lib/cpp/src/thrift/transport/SocketCommon.cpp
-  ${THRIFT_UPSTREAM}/lib/cpp/src/thrift/transport/TBufferTransports.cpp
-  ${THRIFT_UPSTREAM}/lib/cpp/src/thrift/transport/TFDTransport.cpp
-  ${THRIFT_UPSTREAM}/lib/cpp/src/thrift/transport/TTransportException.cpp
-  ${THRIFT_UPSTREAM}/lib/cpp/src/thrift/transport/TServerSocket.cpp
-  ${THRIFT_UPSTREAM}/lib/cpp/src/thrift/transport/TSocket.cpp
-  ${THRIFT_UPSTREAM}/lib/cpp/src/thrift/TApplicationException.cpp
-  ${THRIFT_UPSTREAM}/lib/cpp/src/thrift/TOutput.cpp
+  ${ZEPHYR_THRIFT_MODULE_DIR}/lib/cpp/src/thrift/protocol/TProtocol.cpp
+  ${ZEPHYR_THRIFT_MODULE_DIR}/lib/cpp/src/thrift/server/TConnectedClient.cpp
+  ${ZEPHYR_THRIFT_MODULE_DIR}/lib/cpp/src/thrift/server/TSimpleServer.cpp
+  ${ZEPHYR_THRIFT_MODULE_DIR}/lib/cpp/src/thrift/transport/SocketCommon.cpp
+  ${ZEPHYR_THRIFT_MODULE_DIR}/lib/cpp/src/thrift/transport/TBufferTransports.cpp
+  ${ZEPHYR_THRIFT_MODULE_DIR}/lib/cpp/src/thrift/transport/TFDTransport.cpp
+  ${ZEPHYR_THRIFT_MODULE_DIR}/lib/cpp/src/thrift/transport/TTransportException.cpp
+  ${ZEPHYR_THRIFT_MODULE_DIR}/lib/cpp/src/thrift/transport/TServerSocket.cpp
+  ${ZEPHYR_THRIFT_MODULE_DIR}/lib/cpp/src/thrift/transport/TSocket.cpp
+  ${ZEPHYR_THRIFT_MODULE_DIR}/lib/cpp/src/thrift/TApplicationException.cpp
+  ${ZEPHYR_THRIFT_MODULE_DIR}/lib/cpp/src/thrift/TOutput.cpp
 
   # Replace with upstream equivalents when Zephyr's std::thread, etc, are fixed
   src/thrift/concurrency/Mutex.cpp

--- a/modules/thrift/cmake/thrift.cmake
+++ b/modules/thrift/cmake/thrift.cmake
@@ -29,5 +29,9 @@ function(thrift
     DEPENDS ${source_file}
     )
 
-    target_include_directories(${target} PRIVATE ${out_dir}/gen-${lang})
+    target_include_directories(
+      ${target} PRIVATE ${out_dir}/gen-${lang}
+      ${target} PRIVATE ${ZEPHYR_BASE}/modules/thrift/src
+      ${target} PRIVATE ${ZEPHYR_THRIFT_MODULE_DIR}/lib/cpp/src
+    )
 endfunction()


### PR DESCRIPTION
Do not export Thrift header paths to the global build / include paths