### PR TITLE
Bluetooth: HCI: Use lower-case values for bus and quirks in devicetree

### DIFF
--- a/doc/releases/migration-guide-4.0.rst
+++ b/doc/releases/migration-guide-4.0.rst
@@ -309,6 +309,9 @@ Bluetooth
 Bluetooth HCI
 =============
 
+* The ``bt-hci-bus`` and ``bt-hci-quirks`` devicetree properties for HCI bindings have been changed
+  to use lower-case strings without the ``BT_HCI_QUIRK_`` and ``BT_HCI_BUS_`` prefixes.
+
 Bluetooth Mesh
 ==============
 

--- a/dts/bindings/bluetooth/ambiq,bt-hci-spi.yaml
+++ b/dts/bindings/bluetooth/ambiq,bt-hci-spi.yaml
@@ -37,4 +37,4 @@ properties:
     default: "ambiq hci"
 
   bt-hci-bus:
-    default: "BT_HCI_BUS_SPI"
+    default: "spi"

--- a/dts/bindings/bluetooth/bt-hci.yaml
+++ b/dts/bindings/bluetooth/bt-hci.yaml
@@ -10,19 +10,22 @@ properties:
     type: string
     description: Bus of the transport
     enum:
-      - "BT_HCI_BUS_VIRTUAL"
-      - "BT_HCI_BUS_USB"
-      - "BT_HCI_BUS_PCCARD"
-      - "BT_HCI_BUS_UART"
-      - "BT_HCI_BUS_RS232"
-      - "BT_HCI_BUS_PCI"
-      - "BT_HCI_BUS_SDIO"
-      - "BT_HCI_BUS_SPI"
-      - "BT_HCI_BUS_I2C"
-      - "BT_HCI_BUS_IPM"
+      - "virtual"
+      - "usb"
+      - "pccard"
+      - "uart"
+      - "rs232"
+      - "pci"
+      - "sdio"
+      - "spi"
+      - "i2c"
+      - "ipm"
   bt-hci-quirks:
     type: string-array
     description: HCI device quirks
+    enum:
+      - "no-reset"
+      - "no-auto-dle"
   bt-hci-vs-ext:
     type: boolean
     description: Zephyr HCI vendor extensions are supported

--- a/dts/bindings/bluetooth/espressif,esp32-bt-hci.yaml
+++ b/dts/bindings/bluetooth/espressif,esp32-bt-hci.yaml
@@ -8,6 +8,6 @@ properties:
   bt-hci-name:
     default: "BT ESP32"
   bt-hci-bus:
-    default: "BT_HCI_BUS_IPM"
+    default: "ipm"
   bt-hci-quirks:
-    default: ["BT_HCI_QUIRK_NO_AUTO_DLE"]
+    default: ["no-auto-dle"]

--- a/dts/bindings/bluetooth/infineon,cat1-bless-hci.yaml
+++ b/dts/bindings/bluetooth/infineon,cat1-bless-hci.yaml
@@ -14,8 +14,8 @@ properties:
   bt-hci-name:
     default: "PSoC 6 BLESS"
   bt-hci-bus:
-    default: "BT_HCI_BUS_VIRTUAL"
+    default: "virtual"
   bt-hci-quirks:
-    default: ["BT_HCI_QUIRK_NO_RESET"]
+    default: ["no-reset"]
   interrupts:
     required: true

--- a/dts/bindings/bluetooth/infineon,cyw208xx-hci.yaml
+++ b/dts/bindings/bluetooth/infineon,cyw208xx-hci.yaml
@@ -18,4 +18,4 @@ properties:
   bt-hci-name:
     default: "CYW208XX"
   bt-hci-bus:
-    default: "BT_HCI_BUS_VIRTUAL"
+    default: "virtual"

--- a/dts/bindings/bluetooth/nxp,hci-ble.yaml
+++ b/dts/bindings/bluetooth/nxp,hci-ble.yaml
@@ -13,4 +13,4 @@ properties:
   bt-hci-name:
     default: "BT NXP"
   bt-hci-bus:
-    default: "BT_HCI_BUS_IPM"
+    default: "ipm"

--- a/dts/bindings/bluetooth/renesas,bt-hci-da1469x.yaml
+++ b/dts/bindings/bluetooth/renesas,bt-hci-da1469x.yaml
@@ -8,4 +8,4 @@ properties:
   bt-hci-name:
     default: "BT DA1469x"
   bt-hci-bus:
-    default: "BT_HCI_BUS_IPM"
+    default: "ipm"

--- a/dts/bindings/bluetooth/silabs,bt-hci.yaml
+++ b/dts/bindings/bluetooth/silabs,bt-hci.yaml
@@ -8,6 +8,6 @@ properties:
   bt-hci-name:
     default: "sl:bt"
   bt-hci-bus:
-    default: "BT_HCI_BUS_VIRTUAL"
+    default: "virtual"
   bt-hci-quirks:
-    default: ["BT_HCI_QUIRK_NO_RESET"]
+    default: ["no-reset"]

--- a/dts/bindings/bluetooth/st,hci-spi-v1.yaml
+++ b/dts/bindings/bluetooth/st,hci-spi-v1.yaml
@@ -9,4 +9,4 @@ include: zephyr,bt-hci-spi.yaml
 
 properties:
   bt-hci-quirks:
-    default: ["BT_HCI_QUIRK_NO_RESET"]
+    default: ["no-reset"]

--- a/dts/bindings/bluetooth/st,hci-spi-v2.yaml
+++ b/dts/bindings/bluetooth/st,hci-spi-v2.yaml
@@ -9,4 +9,4 @@ include: zephyr,bt-hci-spi.yaml
 
 properties:
   bt-hci-quirks:
-    default: ["BT_HCI_QUIRK_NO_RESET"]
+    default: ["no-reset"]

--- a/dts/bindings/bluetooth/st,hci-stm32wba.yaml
+++ b/dts/bindings/bluetooth/st,hci-stm32wba.yaml
@@ -8,4 +8,4 @@ properties:
   bt-hci-name:
     default: "BT IPM"
   bt-hci-bus:
-    default: "BT_HCI_BUS_IPM"
+    default: "ipm"

--- a/dts/bindings/bluetooth/st,stm32wb-ble-rf.yaml
+++ b/dts/bindings/bluetooth/st,stm32wb-ble-rf.yaml
@@ -14,4 +14,4 @@ properties:
   bt-hci-name:
     default: "BT IPM"
   bt-hci-bus:
-    default: "BT_HCI_BUS_IPM"
+    default: "ipm"

--- a/dts/bindings/bluetooth/zephyr,bt-hci-3wire-uart.yaml
+++ b/dts/bindings/bluetooth/zephyr,bt-hci-3wire-uart.yaml
@@ -10,4 +10,4 @@ properties:
   bt-hci-name:
     default: "H:5"
   bt-hci-bus:
-    default: "BT_HCI_BUS_UART"
+    default: "uart"

--- a/dts/bindings/bluetooth/zephyr,bt-hci-ipc.yaml
+++ b/dts/bindings/bluetooth/zephyr,bt-hci-ipc.yaml
@@ -8,9 +8,9 @@ properties:
   bt-hci-name:
     default: "IPC"
   bt-hci-bus:
-    default: "BT_HCI_BUS_IPM"
+    default: "ipm"
   bt-hci-quirks:
-    default: ["BT_HCI_QUIRK_NO_AUTO_DLE"]
+    default: ["no-auto-dle"]
   bt-hci-ipc-name:
     type: string
     default: "nrf_bt_hci"

--- a/dts/bindings/bluetooth/zephyr,bt-hci-ll-sw-split.yaml
+++ b/dts/bindings/bluetooth/zephyr,bt-hci-ll-sw-split.yaml
@@ -8,6 +8,6 @@ properties:
   bt-hci-name:
     default: "Controller"
   bt-hci-bus:
-    default: "BT_HCI_BUS_VIRTUAL"
+    default: "virtual"
   bt-hci-quirks:
-    default: ["BT_HCI_QUIRK_NO_AUTO_DLE"]
+    default: ["no-auto-dle"]

--- a/dts/bindings/bluetooth/zephyr,bt-hci-spi.yaml
+++ b/dts/bindings/bluetooth/zephyr,bt-hci-spi.yaml
@@ -40,4 +40,4 @@ properties:
     default: "SPI"
 
   bt-hci-bus:
-    default: "BT_HCI_BUS_SPI"
+    default: "spi"

--- a/dts/bindings/bluetooth/zephyr,bt-hci-uart.yaml
+++ b/dts/bindings/bluetooth/zephyr,bt-hci-uart.yaml
@@ -10,4 +10,4 @@ properties:
   bt-hci-name:
     default: "H:4"
   bt-hci-bus:
-    default: "BT_HCI_BUS_UART"
+    default: "uart"

--- a/dts/bindings/bluetooth/zephyr,bt-hci-userchan.yaml
+++ b/dts/bindings/bluetooth/zephyr,bt-hci-userchan.yaml
@@ -8,4 +8,4 @@ properties:
   bt-hci-name:
     default: "HCI User Channel"
   bt-hci-bus:
-    default: "BT_HCI_BUS_UART"
+    default: "uart"

--- a/include/zephyr/drivers/bluetooth.h
+++ b/include/zephyr/drivers/bluetooth.h
@@ -72,7 +72,8 @@ enum bt_hci_bus {
 	BT_HCI_BUS_IPM           = 9,
 };
 
-#define BT_DT_HCI_QUIRK_OR(node_id, prop, idx) DT_STRING_TOKEN_BY_IDX(node_id, prop, idx)
+#define BT_DT_HCI_QUIRK_OR(node_id, prop, idx) \
+	UTIL_CAT(BT_HCI_QUIRK_, DT_STRING_UPPER_TOKEN_BY_IDX(node_id, prop, idx))
 #define BT_DT_HCI_QUIRKS_GET(node_id) COND_CODE_1(DT_NODE_HAS_PROP(node_id, bt_hci_quirks), \
 						  (DT_FOREACH_PROP_ELEM_SEP(node_id, \
 									    bt_hci_quirks, \
@@ -84,7 +85,8 @@ enum bt_hci_bus {
 #define BT_DT_HCI_NAME_GET(node_id) DT_PROP_OR(node_id, bt_hci_name, "HCI")
 #define BT_DT_HCI_NAME_INST_GET(inst) BT_DT_HCI_NAME_GET(DT_DRV_INST(inst))
 
-#define BT_DT_HCI_BUS_GET(node_id) DT_STRING_TOKEN_OR(node_id, bt_hci_bus, BT_HCI_BUS_VIRTUAL)
+#define BT_DT_HCI_BUS_GET(node_id) \
+	UTIL_CAT(BT_HCI_BUS_, DT_STRING_UPPER_TOKEN_OR(node_id, bt_hci_bus, VIRTUAL))
 #define BT_DT_HCI_BUS_INST_GET(inst) BT_DT_HCI_BUS_GET(DT_DRV_INST(inst))
 
 typedef int (*bt_hci_recv_t)(const struct device *dev, struct net_buf *buf);

--- a/tests/bluetooth/bluetooth/dts/bindings/zephyr,bt-hci-test.yaml
+++ b/tests/bluetooth/bluetooth/dts/bindings/zephyr,bt-hci-test.yaml
@@ -8,4 +8,4 @@ properties:
   bt-hci-name:
     default: "test"
   bt-hci-bus:
-    default: "BT_HCI_BUS_VIRTUAL"
+    default: "virtual"

--- a/tests/bluetooth/hci_prop_evt/dts/bindings/zephyr,bt-hci-test.yaml
+++ b/tests/bluetooth/hci_prop_evt/dts/bindings/zephyr,bt-hci-test.yaml
@@ -8,6 +8,6 @@ properties:
   bt-hci-name:
     default: "test"
   bt-hci-bus:
-    default: "BT_HCI_BUS_VIRTUAL"
+    default: "virtual"
   bt-hci-quirks:
-    default: ["BT_HCI_QUIRK_NO_RESET"]
+    default: ["no-reset"]

--- a/tests/bluetooth/hci_uart_async/dts/bindings/zephyr,bt-hci-test.yaml
+++ b/tests/bluetooth/hci_uart_async/dts/bindings/zephyr,bt-hci-test.yaml
@@ -8,4 +8,4 @@ properties:
   bt-hci-name:
     default: "Mock Controller"
   bt-hci-bus:
-    default: "BT_HCI_BUS_VIRTUAL"
+    default: "virtual"

--- a/tests/bluetooth/host_long_adv_recv/dts/bindings/zephyr,bt-hci-test.yaml
+++ b/tests/bluetooth/host_long_adv_recv/dts/bindings/zephyr,bt-hci-test.yaml
@@ -8,6 +8,6 @@ properties:
   bt-hci-name:
     default: "test"
   bt-hci-bus:
-    default: "BT_HCI_BUS_VIRTUAL"
+    default: "virtual"
   bt-hci-quirks:
-    default: ["BT_HCI_QUIRK_NO_RESET"]
+    default: ["no-reset"]


### PR DESCRIPTION
It's more common (and more readable) convention to use lower-case names for string-based device tree property values. Convert the HCI bus and quirks to follow this convention. Also take advantage of the recently added support for string-array enums to enforce that the correct values are used.