### PR TITLE
boards: st: nucleo_wba55cg: Fix west debug

### DIFF
--- a/boards/st/nucleo_wba55cg/support/openocd.cfg
+++ b/boards/st/nucleo_wba55cg/support/openocd.cfg
@@ -22,5 +22,3 @@ set CLOCK_FREQ 8000
 reset_config srst_only srst_nogate
 
 source [find target/stm32wbax.cfg]
-
-gdb_memory_map disable


### PR DESCRIPTION
To enable breakpoints on this board, remove the `dgdb_memory_map disable`, which is a leftover from early development steps.