### PR TITLE
tests: posix: net: fix missing clock_t and clockid_t with newlib

### DIFF
--- a/include/zephyr/posix/posix_types.h
+++ b/include/zephyr/posix/posix_types.h
@@ -11,6 +11,18 @@
 #include <sys/types.h>
 #endif
 
+#if !defined(_CLOCK_T_DECLARED) && !defined(__clock_t_defined)
+typedef unsigned long clock_t;
+#define _CLOCK_T_DECLARED
+#define __clock_t_defined
+#endif
+
+#if !defined(_CLOCKID_T_DECLARED) && !defined(__clockid_t_defined)
+typedef unsigned long clockid_t;
+#define _CLOCKID_T_DECLARED
+#define __clockid_t_defined
+#endif
+
 #ifdef CONFIG_NEWLIB_LIBC
 #include <sys/_pthreadtypes.h>
 #endif

--- a/include/zephyr/posix/sys/select.h
+++ b/include/zephyr/posix/sys/select.h
@@ -6,6 +6,8 @@
 #ifndef ZEPHYR_INCLUDE_POSIX_SYS_SELECT_H_
 #define ZEPHYR_INCLUDE_POSIX_SYS_SELECT_H_
 
+#include "posix_types.h"
+
 #include <zephyr/sys/fdtable.h>
 
 #ifdef __cplusplus

--- a/tests/posix/net/CMakeLists.txt
+++ b/tests/posix/net/CMakeLists.txt
@@ -7,3 +7,5 @@ project(posix_net)
 FILE(GLOB app_sources src/*.c)
 
 target_sources(app PRIVATE ${app_sources})
+
+target_compile_options(app PRIVATE -U_POSIX_C_SOURCE -D_POSIX_C_SOURCE=200809L)


### PR DESCRIPTION
Fix errors found in CI for missing `clock_t` and `clockid_t` types when building the `tests/posix/net` testsuite.

```shell
$ twister -i -p thingy53/nrf5340/cpuapp/ns -s tests/posix/net/portability.posix.net.newlib
INFO    - Total complete:    1/   1  100%  skipped:    0, failed:    0, error:    0
INFO    - 1 test scenarios (1 test instances) selected, 0 configurations skipped (0 by static filter, 0 at runtime).
INFO    - 1 of 1 test configurations passed (100.00%), 0 failed, 0 errored, 0 skipped with 0 warnings in 42.31 seconds
INFO    - In total 6 test cases were executed, 0 skipped on 1 out of total 3 platforms (33.33%)
INFO    - 0 test configurations executed on platforms, 1 test configurations were only built.
INFO    - Saving reports...
INFO    - Writing JSON report /Users/cfriedt/zephyrproject/zephyr/twister-out/twister.json
INFO    - Writing xunit report /Users/cfriedt/zephyrproject/zephyr/twister-out/twister.xml...
INFO    - Writing xunit report /Users/cfriedt/zephyrproject/zephyr/twister-out/twister_report.xml...
INFO    - Run completed
```

Fixes #79892