### PR TITLE
Support toolchain with optimization levels included in multilib configurations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2167,6 +2167,7 @@ if((CMAKE_BUILD_TYPE IN_LIST build_types) AND (NOT NO_BUILD_TYPE_WARNING))
       The CMake build type was set to '${CMAKE_BUILD_TYPE}', but the optimization flag was set to '${OPTIMIZATION_FLAG}'.
       This may be intentional and the warning can be turned off by setting the CMake variable 'NO_BUILD_TYPE_WARNING'"
       )
+    set(CMAKE_C_FLAGS_${CMAKE_BUILD_TYPE_uppercase} ${OPTIMIZATION_FLAG})
   endif()
 endif()
 

--- a/cmake/compiler/gcc/target.cmake
+++ b/cmake/compiler/gcc/target.cmake
@@ -85,31 +85,19 @@ if(SYSROOT_DIR)
   list(APPEND TOOLCHAIN_C_FLAGS
     --sysroot=${SYSROOT_DIR}
     )
-
-  # Use sysroot dir to set the libc path's
-  execute_process(
-    COMMAND ${CMAKE_C_COMPILER} ${TOOLCHAIN_C_FLAGS} --print-multi-directory
-    OUTPUT_VARIABLE NEWLIB_DIR
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-    )
-
-  set(LIBC_LIBRARY_DIR "\"${SYSROOT_DIR}\"/lib/${NEWLIB_DIR}")
 endif()
 
-# This libgcc code is partially duplicated in compiler/*/target.cmake
-execute_process(
-  COMMAND ${CMAKE_C_COMPILER} ${TOOLCHAIN_C_FLAGS} --print-libgcc-file-name
-  OUTPUT_VARIABLE LIBGCC_FILE_NAME
-  OUTPUT_STRIP_TRAILING_WHITESPACE
-  )
-
-assert_exists(LIBGCC_FILE_NAME)
-
-get_filename_component(LIBGCC_DIR ${LIBGCC_FILE_NAME} DIRECTORY)
-
-assert_exists(LIBGCC_DIR)
-
-set_linker_property(PROPERTY lib_include_dir "-L\"${LIBGCC_DIR}\"")
+# Use the compiler to find a file within the toolchain
+# This can be used to find files like crtbegin.o and crtend.o
+function(compiler_file_name file output)
+  execute_process(COMMAND ${CMAKE_C_COMPILER}
+    ${TOOLCHAIN_C_FLAGS} ${OPTIMIZATION_FLAG}
+    --print-file-name=${file}
+    OUTPUT_VARIABLE file_name
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+  set(${output} ${file_name} PARENT_SCOPE)
+endfunction()
 
 # For CMake to be able to test if a compiler flag is supported by the
 # toolchain we need to give CMake the necessary flags to compile and

--- a/cmake/linker/ld/target.cmake
+++ b/cmake/linker/ld/target.cmake
@@ -155,10 +155,16 @@ macro(toolchain_linker_finalize)
 
   set(cpp_link "${common_link}")
   if(NOT "${ZEPHYR_TOOLCHAIN_VARIANT}" STREQUAL "host")
-    if(CONFIG_CPP_EXCEPTIONS AND LIBGCC_DIR)
-      # When building with C++ Exceptions, it is important that crtbegin and crtend
-      # are linked at specific locations.
-      set(cpp_link "<LINK_FLAGS> ${LIBGCC_DIR}/crtbegin.o ${link_libraries} ${LIBGCC_DIR}/crtend.o")
+    if(CONFIG_CPP_EXCEPTIONS)
+      if(LIBGCC_DIR)
+        # When building with C++ Exceptions, it is important that crtbegin and crtend
+        # are linked at specific locations.
+        set(cpp_link "<LINK_FLAGS> ${LIBGCC_DIR}/crtbegin.o ${link_libraries} ${LIBGCC_DIR}/crtend.o")
+      elseif(COMMAND compiler_file_name)
+        compiler_file_name("crtbegin.o" CRTBEGIN)
+        compiler_file_name("crtend.o" CRTEND)
+        set(cpp_link "<LINK_FLAGS> ${CRTBEGIN} ${link_libraries} ${CRTEND}")
+      endif()
     endif()
   endif()
   set(CMAKE_CXX_LINK_EXECUTABLE "<CMAKE_CXX_COMPILER> <FLAGS> <CMAKE_CXX_LINK_FLAGS> ${cpp_link}")

--- a/cmake/linker/xt-ld/target.cmake
+++ b/cmake/linker/xt-ld/target.cmake
@@ -17,8 +17,15 @@ if(CONFIG_CPP_EXCEPTIONS)
   # The location is so important that we cannot let this be controlled by normal
   # link libraries, instead we must control the link command specifically as
   # part of toolchain.
-  set(CMAKE_CXX_LINK_EXECUTABLE
+  if (LIBGCC_DIR)
+    set(CMAKE_CXX_LINK_EXECUTABLE
       "<CMAKE_CXX_COMPILER> <FLAGS> <CMAKE_CXX_LINK_FLAGS> <LINK_FLAGS> ${LIBGCC_DIR}/crtbegin.o <OBJECTS> -o <TARGET> <LINK_LIBRARIES> ${LIBGCC_DIR}/crtend.o")
+  elseif(COMMAND compiler_file_name)
+    compiler_file_name("crtbegin.o" CRTBEGIN)
+    compiler_file_name("crtend.o" CRTEND)
+    set(CMAKE_CXX_LINK_EXECUTABLE
+      "<CMAKE_CXX_COMPILER> <FLAGS> <CMAKE_CXX_LINK_FLAGS> <LINK_FLAGS> ${CRTBEGIN} <OBJECTS> -o <TARGET> <LINK_LIBRARIES> ${CRTEND}")
+  endif()
 endif()
 
 # Run $LINKER_SCRIPT file through the C preprocessor, producing ${linker_script_gen}

--- a/tests/kernel/common/testcase.yaml
+++ b/tests/kernel/common/testcase.yaml
@@ -47,6 +47,12 @@ tests:
     tags: picolibc
     extra_configs:
       - CONFIG_PICOLIBC=y
+  kernel.common.newlib:
+    filter: CONFIG_NEWLIB_LIBC_SUPPORTED
+    min_ram: 32
+    tags: newlib
+    extra_configs:
+      - CONFIG_NEWLIB_LIBC=y
   kernel.common.lto:
     # CONFIG_CODE_DATA_RELOCATION causes a build error (issue #69730)
     filter: CONFIG_ISR_TABLES_LOCAL_DECLARATION_SUPPORTED and not CONFIG_CODE_DATA_RELOCATION


### PR DESCRIPTION
As a way to provide both space and speed optimized versions of every library provided by a toolchain, one option I'm exploring is adding optimization level to the existing multilib infrastructure. With this, specifying -Os during the linking phase will cause the compiler driver to adjust the link path to point at a directory containing libraries also build with -Os.

To make this work in Zephyr, a couple of changes are required:

 1. CMAKE_C_FLAGS_${CMAKE_BUILD_TYPE} must match  ${OPTIMIZATION_FLAG}. That's because multi-lib semantics are different from how optimization flags are otherwise used. The multi-lib matcher only looks for the presence of the -Os flag; further -O2 or -O3 flags later in the command line have no impact. As a result, when you set CMAKE_BUILD_TYPE to MinSizeRel and CMAKE_C_FLAGS_MINSIZEREL contains '-Os', that drives the multi-lib code to select the space optimized libraries.
 2. Library paths generated by the compiler now depend on the optimization level. That affects the computation of gcc's LIBC_LIBRARY_DIR and LIBGCC_DIR variables. Neither of these is needed to locate any libraries; the compiler driver will already look for those in the correct multi-lib directory anyways, so I've removed their default computations. However, there is one case where LIBGCC_DIR is used to fine object files: `crtbegin.o` and `crtend.o`. I've created a function, `compiler_file_name` which uses the gcc `--print-file-name` option to search for those files. Because those file names are needed well after OPTIMIZATION_FLAG is set, we can add that to the gcc command line and have it perform the full multi-lib search for us.

With these changes, I've got -Os and -O2 tests for at least a few cases working using locally-built SDK toolchains that include the necessary changes.

Size:
```
$ west build -b qemu_cortex_m3 samples/hello_world -- -DCONFIG_SIZE_OPTIMIZATIONS=y
...
Memory region         Used Size  Region Size  %age Used
           FLASH:        8122 B       256 KB      3.10%
             RAM:          4 KB        64 KB      6.25%
        IDT_LIST:          0 GB        32 KB      0.00%
```

Speed:
```
$ west build -b qemu_cortex_m3 samples/hello_world -- -DCONFIG_SPEED_OPTIMIZATIONS=y
...
Memory region         Used Size  Region Size  %age Used
           FLASH:        9350 B       256 KB      3.57%
             RAM:          4 KB        64 KB      6.25%
        IDT_LIST:          0 GB        32 KB      0.00%
```

Note that this extends to *all* toolchain-provided libraries, including newlib and libstdc++.