### PR TITLE
runners: jlink: Fix NoneType object error

### DIFF
--- a/scripts/west_commands/runners/jlink.py
+++ b/scripts/west_commands/runners/jlink.py
@@ -37,7 +37,7 @@ def is_ip(ip):
     return True
 
 def is_tunnel(tunnel):
-    return tunnel.startswith("tunnel:")
+    return tunnel.startswith("tunnel:") if tunnel else False
 
 class ToggleAction(argparse.Action):
 


### PR DESCRIPTION
The commit 221199e15b85a070b3d81709eee3d533c9f99967 presents a bug that makes west flash failed with error.

AttributeError: 'NoneType' object has no attribute 'startswith'

In function is_tunnel(), tunnel may contain None and has no attribute "startswith".