### PR TITLE
include: zephyr: correct inclusion for fdtable.h

### DIFF
--- a/include/zephyr/sys/fdtable.h
+++ b/include/zephyr/sys/fdtable.h
@@ -7,7 +7,12 @@
 #define ZEPHYR_INCLUDE_SYS_FDTABLE_H_
 
 #include <stdarg.h>
+#ifdef CONFIG_NEWLIB_LIBC
+/* Do not include <time.h> directly, clock_t may not be defined at this point */
+#include <sys/timespec.h>
+#else
 #include <time.h>
+#endif
 
 /* FIXME: For native_posix ssize_t, off_t. */
 #include <sys/types.h>


### PR DESCRIPTION
fdtable.h requires the definition of `struct timespec`, not the full set of definitions available within `time.h`.

Including `time.h` causes build errors when _GNU_SOURCE is defined to 1 (as `time.h` will be included before `clock_t` is defined in `sys/types.h`), so let's only include <sys/timespec.h> to get the required `struct timespec` definition.

Fixes #79892