### PR TITLE
[Backport v3.7-branch] soc: nxp: lpc55xxx: fix dependencies for SOC_FLASH_MCUX

### DIFF
--- a/soc/nxp/lpc/lpc55xxx/Kconfig.defconfig
+++ b/soc/nxp/lpc/lpc55xxx/Kconfig.defconfig
@@ -74,7 +74,7 @@ endchoice
 
 endif # SOC_LPC55S36
 
-if SOC_LPC55S69
+if SOC_LPC55S69_CPU0
 
 config SOC_FLASH_MCUX
 	default y
@@ -88,7 +88,7 @@ endchoice
 config I2S_MCUX_FLEXCOMM
 	select INIT_PLL0
 
-endif # SOC_LPC55S69
+endif # SOC_LPC55S69_CPU0
 
 if SOC_LPC55S69_CPU1
 


### PR DESCRIPTION
soc: nxp: lpc55xxx: fix dependencies for SOC_FLASH_MCUX

SOC_FLASH_MCUX has additional dependencies for LPC55xxx CPUs, due to the
fact that the flash should be disabled when executing in nonsecure mode.

Since the merge of HWMv2, this dependency has been set incorrectly at
the SOC level, resulting in the IAP flash driver being enabled when
targeting CPU1, which is incorrect. Fix the Kconfig dependency to
resolve this issue.

Fixes #79576

Signed-off-by: Daniel DeGrasse <daniel.degrasse@nxp.com>
(cherry picked from commit feb0241536886726a28b4377237873f771ad57ed)
