### PR TITLE
drivers: misc: devmux: Include correct header for ssize_t

### DIFF
--- a/include/zephyr/drivers/misc/devmux/devmux.h
+++ b/include/zephyr/drivers/misc/devmux/devmux.h
@@ -13,6 +13,7 @@
 #define INCLUDE_ZEPHYR_DRIVERS_MISC_DEVMUX_H_
 
 #include <stdint.h>
+#include <sys/types.h>
 
 #include <zephyr/device.h>
 #include <zephyr/kernel.h>


### PR DESCRIPTION
devmux.h makes use of the type `ssize_t`, which is defined in <sys/types.h>.