### PR TITLE
modules: hostap: fix DPP build error

### DIFF
--- a/modules/hostap/src/supp_api.c
+++ b/modules/hostap/src/supp_api.c
@@ -2218,7 +2218,6 @@ int supplicant_dpp_dispatch(const struct device *dev, struct wifi_dpp_params *pa
 	os_free(cmd);
 	return 0;
 }
-#endif /* CONFIG_WIFI_NM_WPA_SUPPLICANT_DPP */
 
 #ifdef CONFIG_WIFI_NM_HOSTAPD_AP
 int hapd_dpp_dispatch(const struct device *dev, struct wifi_dpp_params *params)
@@ -2252,3 +2251,4 @@ int hapd_dpp_dispatch(const struct device *dev, struct wifi_dpp_params *params)
 	return 0;
 }
 #endif /* CONFIG_WIFI_NM_HOSTAPD_AP */
+#endif /* CONFIG_WIFI_NM_WPA_SUPPLICANT_DPP */

--- a/modules/hostap/src/supp_api.h
+++ b/modules/hostap/src/supp_api.h
@@ -296,7 +296,6 @@ int supplicant_ap_sta_disconnect(const struct device *dev,
  * @return 0 for OK; -1 for ERROR
  */
 int supplicant_dpp_dispatch(const struct device *dev, struct wifi_dpp_params *params);
-#endif /* CONFIG_WIFI_NM_WPA_SUPPLICANT_DPP */
 
 #ifdef CONFIG_WIFI_NM_HOSTAPD_AP
 /**
@@ -308,4 +307,5 @@ int supplicant_dpp_dispatch(const struct device *dev, struct wifi_dpp_params *pa
  */
 int hapd_dpp_dispatch(const struct device *dev, struct wifi_dpp_params *params);
 #endif /* CONFIG_WIFI_NM_HOSTAPD_AP */
+#endif /* CONFIG_WIFI_NM_WPA_SUPPLICANT_DPP */
 #endif /* ZEPHYR_SUPP_MGMT_H */


### PR DESCRIPTION
Fix DPP build error when HOSTAPD enabled and DPP disabled.
Guard hapd_dpp_dispatch in both CONFIG_WIFI_NM_WPA_SUPPLICANT_DPP
and CONFIG_WIFI_NM_HOSTAPD_AP.