### PR TITLE
net: l2: wifi: fix AP sets band failed with channel 0

### DIFF
--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -587,7 +587,8 @@ static int __wifi_args_to_params(const struct shell *sh, size_t argc, char *argv
 			params->channel = channel;
 			break;
 		case 'b':
-			if (iface_mode == WIFI_MODE_INFRA) {
+			if (iface_mode == WIFI_MODE_INFRA ||
+				iface_mode == WIFI_MODE_AP) {
 				switch (atoi(state->optarg)) {
 				case 2:
 					params->band = WIFI_FREQ_BAND_2_4_GHZ;


### PR DESCRIPTION
Should support setting band for both STA and SAP mode.