### PR TITLE
mbedtls: update to 3.6.2

### DIFF
--- a/doc/releases/release-notes-4.0.rst
+++ b/doc/releases/release-notes-4.0.rst
@@ -399,8 +399,11 @@ Libraries / Subsystems
 
 * Crypto
 
-  * Mbed TLS was updated to version 3.6.1. The release notes can be found at:
-    https://github.com/Mbed-TLS/mbedtls/releases/tag/mbedtls-3.6.1
+  * Mbed TLS was updated to version 3.6.2 (from 3.6.0). The release notes can be found at:
+
+    * https://github.com/Mbed-TLS/mbedtls/releases/tag/mbedtls-3.6.1
+    * https://github.com/Mbed-TLS/mbedtls/releases/tag/mbedtls-3.6.2
+
   * The Kconfig symbol :kconfig:option:`CONFIG_MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG_ALLOW_NON_CSPRNG`
     was added to allow ``psa_get_random()`` to make use of non-cryptographically
     secure random sources when :kconfig:option:`CONFIG_MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG`

--- a/west.yml
+++ b/west.yml
@@ -280,7 +280,7 @@ manifest:
       revision: 2b498e6f36d6b82ae1da12c8b7742e318624ecf5
       path: modules/lib/gui/lvgl
     - name: mbedtls
-      revision: eb55f4734585dfd8cd3da6d4b01a6e372f073ee1
+      revision: a78176c6ff0733ba08018cba4447bd3f20de7978
       path: modules/crypto/mbedtls
       groups:
         - crypto


### PR DESCRIPTION
https://github.com/Mbed-TLS/mbedtls/releases/tag/mbedtls-3.6.2