### PR TITLE
tests: pwm_api: enable dma_fast_region in nRF54H20 DK overlay

### DIFF
--- a/tests/drivers/pwm/pwm_api/boards/nrf54h20dk_nrf54h20_cpuapp_fast.overlay
+++ b/tests/drivers/pwm/pwm_api/boards/nrf54h20dk_nrf54h20_cpuapp_fast.overlay
@@ -12,6 +12,10 @@
 	};
 };
 
+&dma_fast_region {
+	status = "okay";
+};
+
 &pwm120 {
 	status = "okay";
 	pinctrl-0 = <&pwm_default>;


### PR DESCRIPTION
The overlay makes use of the dma_fast_region without enabling it.

Fixes: #79903