### PR TITLE
dma: nxp: edma: remove the `hal-cfg-index` property

### DIFF
--- a/drivers/dma/dma_nxp_edma.h
+++ b/drivers/dma/dma_nxp_edma.h
@@ -88,11 +88,6 @@ LOG_MODULE_REGISTER(nxp_edma);
 		    (_EDMA_CHANNEL_ARRAY_EXPLICIT(inst)),				\
 		    (_EDMA_CHANNEL_ARRAY(inst)))
 
-#define EDMA_HAL_CFG_GET(inst)								\
-	COND_CODE_1(DT_NODE_HAS_PROP(DT_INST(inst, DT_DRV_COMPAT), hal_cfg_index),	\
-		    (s_edmaConfigs[DT_INST_PROP(inst, hal_cfg_index)]),			\
-		    (s_edmaConfigs[0]))
-
 /* used to register edma_isr for all specified interrupts */
 #define EDMA_CONNECT_INTERRUPTS(inst)				\
 	FOR_EACH_FIXED_ARG(_EDMA_INT_CONNECT, (;),		\

--- a/dts/arm64/nxp/nxp_mimx93_a55.dtsi
+++ b/dts/arm64/nxp/nxp_mimx93_a55.dtsi
@@ -359,7 +359,6 @@
 		interrupts = <GIC_SPI 128 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
 			<GIC_SPI 128 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
 		#dma-cells = <2>;
-		hal-cfg-index = <1>;
 		status = "disabled";
 	};
 

--- a/dts/bindings/dma/nxp,edma.yaml
+++ b/dts/bindings/dma/nxp,edma.yaml
@@ -23,22 +23,6 @@ properties:
       and "dma-channels" are mutually exclusive, meaning you
       can't specify both properties as this will lead to a
       BUILD_ASSERT() failure.
-  hal-cfg-index:
-    type: int
-    description: |
-      Use this property to specify which HAL configuration
-      should be used. In the case of some SoCs (e.g: i.MX93),
-      there can be multiple eDMA variants, each of them having
-      different configurations (e.g: i.MX93 eDMA3 has 31 channels,
-      i.MX93 eDMA4 has 64 channels and both of them have slightly
-      different register layouts). To overcome this issue, the HAL
-      exposes an array of configurations called "edma_hal_configs".
-      To perform various operations, the HAL uses an eDMA configuration
-      which will tell it what register layout the IP has, the number of
-      channels, various flags and offsets. As such, if there's multiple
-      configurations available, the user will have to specify which
-      configuration to use through this property. If missing, the
-      configuration found at index 0 will be used.
   "#dma-cells":
     const: 2
 


### PR DESCRIPTION
The HAL configuration binding can be done dynamically based on the IP's address space. The `hal-config-index` property is more tied to software rather than hardware so remove it as an attempt to clean up the binding.