### PR TITLE
pm: s/power-domain/power-domains and add power-domain-names

### DIFF
--- a/doc/releases/migration-guide-4.0.rst
+++ b/doc/releases/migration-guide-4.0.rst
@@ -124,6 +124,12 @@ Device Drivers and Devicetree
   their driver API, users of these devices should ensure they pass appropriate values to
   :c:func:`gpio_pin_set`. (:github:`65797`)
 
+* The ``power-domain`` property has been removed in favor of ``power-domains``.
+  The new property allows to add more than one power domain.
+  ``power-domain-names`` is also available to optionally name each entry in
+  ``power-domains``. The number of cells in the ``power-domains`` property need
+  to be defined using ``#power-domain-cells``.
+
 Analog Digital Converter (ADC)
 ==============================
 

--- a/doc/services/pm/device_runtime.rst
+++ b/doc/services/pm/device_runtime.rst
@@ -26,7 +26,7 @@ asynchronously, it will be put into the
 :c:enumerator:`PM_DEVICE_STATE_SUSPENDING` state first and then into the
 :c:enumerator:`PM_DEVICE_STATE_SUSPENDED` state when the action is run.
 
-For devices on a power domain (via the devicetree 'power-domain' property), device runtime
+For devices on a power domain (via the devicetree 'power-domains' property), device runtime
 power management automatically attempts to request and release the dependent domain
 in response to :c:func:`pm_device_runtime_get` and :c:func:`pm_device_runtime_put`
 calls on the child device.

--- a/doc/services/pm/power_domain.rst
+++ b/doc/services/pm/power_domain.rst
@@ -131,13 +131,13 @@ Devices belonging to this device can be declared referring it in the
         &gpio0 {
                 compatible = "zephyr,gpio-emul";
                 gpio-controller;
-                power-domain = <&gpio_domain>;
+                power-domains = <&gpio_domain>;
         };
 
         &gpio1 {
                 compatible = "zephyr,gpio-emul";
                 gpio-controller;
-                power-domain = <&gpio_domain>;
+                power-domains = <&gpio_domain>;
         };
 
 All devices under a domain will be notified when the domain changes

--- a/dts/bindings/base/base.yaml
+++ b/dts/bindings/base/base.yaml
@@ -93,6 +93,18 @@ properties:
     type: string-array
     description: Provided names of mailbox / IPM channel specifiers
 
+  power-domains:
+    type: phandle-array
+    description: Power domain specifiers
+
+  power-domain-names:
+    type: string-array
+    description: Provided names of power domain specifiers
+
+  "#power-domain-cells":
+    type: int
+    description: Number of cells in power-domains property
+
   zephyr,deferred-init:
     type: boolean
     description: |

--- a/dts/bindings/base/pm.yaml
+++ b/dts/bindings/base/pm.yaml
@@ -16,15 +16,6 @@ properties:
       Wake up capable devices are disabled (interruptions will not wake up
       the system) by default but they can be enabled at runtime if necessary.
 
-  power-domain:
-    type: phandle
-    description: |
-
-      Power domain the device belongs to.
-
-      The device will be notified when the power domain it belongs to is either
-      suspended or resumed.
-
   zephyr,pm-device-runtime-auto:
     type: boolean
     description: |

--- a/dts/bindings/power-domain/intel,adsp-power-domain.yaml
+++ b/dts/bindings/power-domain/intel,adsp-power-domain.yaml
@@ -17,3 +17,6 @@ properties:
       read_address (PWRSTS) to set power active or confirm power active
       for a desired domain.
       Same for write and read addresses
+
+  "#power-domain-cells":
+    const: 0

--- a/dts/bindings/power-domain/nxp,scu-pd.yaml
+++ b/dts/bindings/power-domain/nxp,scu-pd.yaml
@@ -15,3 +15,6 @@ properties:
       Number used by the firmware running on the SCU to identify
       the resource on which the PD-related operations are to be
       performed.
+
+  "#power-domain-cells":
+    const: 0

--- a/dts/bindings/power-domain/power-domain-gpio-monitor.yaml
+++ b/dts/bindings/power-domain/power-domain-gpio-monitor.yaml
@@ -20,3 +20,6 @@ properties:
     required: true
     description: |
       GPIO to use to sense if rail is powered on.
+
+  "#power-domain-cells":
+    const: 0

--- a/dts/bindings/power-domain/power-domain-gpio.yaml
+++ b/dts/bindings/power-domain/power-domain-gpio.yaml
@@ -28,3 +28,6 @@ properties:
     type: int
     default: 0
     description: Off delay time, in microseconds
+
+  "#power-domain-cells":
+    const: 0

--- a/dts/bindings/power-domain/power-domain.yaml
+++ b/dts/bindings/power-domain/power-domain.yaml
@@ -6,3 +6,7 @@ description: Properties for power domains
 compatible: "power-domain"
 
 include: base.yaml
+
+properties:
+  "#power-domain-cells":
+    const: 0

--- a/dts/xtensa/intel/intel_adsp_ace15_mtpm.dtsi
+++ b/dts/xtensa/intel/intel_adsp_ace15_mtpm.dtsi
@@ -150,7 +150,7 @@
 			fifo = <0x0008>;
 			interrupts = <0x08 0 0>;
 			interrupt-parent = <&ace_intc>;
-			power-domain = <&hub_ulp_domain>;
+			power-domains = <&hub_ulp_domain>;
 		};
 
 		dmic1: dmic1@10000 {
@@ -160,7 +160,7 @@
 			fifo = <0x0108>;
 			interrupts = <0x09 0 0>;
 			interrupt-parent = <&ace_intc>;
-			power-domain = <&hub_ulp_domain>;
+			power-domains = <&hub_ulp_domain>;
 		};
 
 		/*
@@ -285,7 +285,7 @@
 			dmas = <&lpgpdma0 2
 					&lpgpdma0 3>;
 			dma-names = "tx", "rx";
-			power-domain = <&io0_domain>;
+			power-domains = <&io0_domain>;
 			ssp-index = <0>;
 			status = "okay";
 
@@ -307,7 +307,7 @@
 			dmas = <&lpgpdma0 4
 					&lpgpdma0 5>;
 			dma-names = "tx", "rx";
-			power-domain = <&io0_domain>;
+			power-domains = <&io0_domain>;
 			ssp-index = <1>;
 			status = "okay";
 
@@ -329,7 +329,7 @@
 			dmas = <&lpgpdma0 6
 					&lpgpdma0 7>;
 			dma-names = "tx", "rx";
-			power-domain = <&io0_domain>;
+			power-domains = <&io0_domain>;
 			ssp-index = <2>;
 			status = "okay";
 
@@ -387,38 +387,47 @@
 			hub_ulp_domain: hub_ulp_domain {
 				compatible = "intel,adsp-power-domain";
 				bit-position = <15>;
+				#power-domain-cells = <0>;
 			};
 			ml1_domain: ml1_domain {
 				compatible = "intel,adsp-power-domain";
 				bit-position = <13>;
+				#power-domain-cells = <0>;
 			};
 			ml0_domain: ml0_domain {
 				compatible = "intel,adsp-power-domain";
 				bit-position = <12>;
+				#power-domain-cells = <0>;
 			};
 			io3_domain: io3_domain {
 				compatible = "intel,adsp-power-domain";
 				bit-position = <11>;
+				#power-domain-cells = <0>;
 			};
 			io2_domain: io2_domain {
 				compatible = "intel,adsp-power-domain";
 				bit-position = <10>;
+				#power-domain-cells = <0>;
 			};
 			io1_domain: io1_domain {
 				compatible = "intel,adsp-power-domain";
 				bit-position = <9>;
+				#power-domain-cells = <0>;
 			};
 			io0_domain: io0_domain {
 				compatible = "intel,adsp-power-domain";
 				bit-position = <8>;
+				#power-domain-cells = <0>;
 			};
 			hub_hp_domain: hub_hp_domain {
 				compatible = "intel,adsp-power-domain";
 				bit-position = <6>;
+				#power-domain-cells = <0>;
 			};
 			hst_domain: hst_domain {
 				compatible = "intel,adsp-power-domain";
 				bit-position = <4>;
+				#power-domain-cells = <0>;
 			};
 		};
 
@@ -464,7 +473,7 @@
 			dma-buf-addr-alignment = <128>;
 			dma-buf-size-alignment = <32>;
 			dma-copy-alignment = <16>;
-			power-domain = <&io0_domain>;
+			power-domains = <&io0_domain>;
 			status = "okay";
 		};
 
@@ -476,7 +485,7 @@
 			dma-buf-addr-alignment = <128>;
 			dma-buf-size-alignment = <32>;
 			dma-copy-alignment = <16>;
-			power-domain = <&io0_domain>;
+			power-domains = <&io0_domain>;
 			status = "okay";
 		};
 
@@ -488,7 +497,7 @@
 			dma-buf-addr-alignment = <128>;
 			dma-buf-size-alignment = <32>;
 			dma-copy-alignment = <16>;
-			power-domain = <&hst_domain>;
+			power-domains = <&hst_domain>;
 			interrupts = <13 0 0>;
 			interrupt-parent = <&ace_intc>;
 			status = "okay";
@@ -502,7 +511,7 @@
 			dma-buf-addr-alignment = <128>;
 			dma-buf-size-alignment = <32>;
 			dma-copy-alignment = <16>;
-			power-domain = <&hst_domain>;
+			power-domains = <&hst_domain>;
 			interrupts = <12 0 0>;
 			interrupt-parent = <&ace_intc>;
 			status = "okay";
@@ -541,7 +550,7 @@
 			dma-buf-size-alignment = <4>;
 			dma-copy-alignment = <4>;
 			status = "okay";
-			power-domain = <&hub_ulp_domain>;
+			power-domains = <&hub_ulp_domain>;
 			zephyr,pm-device-runtime-auto;
 		};
 
@@ -555,7 +564,7 @@
 			dma-buf-size-alignment = <4>;
 			dma-copy-alignment = <4>;
 			status = "okay";
-			power-domain = <&io0_domain>;
+			power-domains = <&io0_domain>;
 			zephyr,pm-device-runtime-auto;
 		};
 
@@ -568,7 +577,7 @@
 			interrupt-parent = <&core_intc>;
 			dma-buf-size-alignment = <4>;
 			dma-copy-alignment = <4>;
-			power-domain = <&io0_domain>;
+			power-domains = <&io0_domain>;
 			status = "okay";
 			zephyr,pm-device-runtime-auto;
 		};

--- a/dts/xtensa/intel/intel_adsp_ace20_lnl.dtsi
+++ b/dts/xtensa/intel/intel_adsp_ace20_lnl.dtsi
@@ -215,7 +215,7 @@
 			dmas = <&hda_link_out 1
 				&hda_link_in 1>;
 			dma-names = "tx", "rx";
-			power-domain = <&io0_domain>;
+			power-domains = <&io0_domain>;
 			ssp-index = <0>;
 			status = "okay";
 
@@ -238,7 +238,7 @@
 			dmas = <&hda_link_out 2
 				&hda_link_in 2>;
 			dma-names = "tx", "rx";
-			power-domain = <&io0_domain>;
+			power-domains = <&io0_domain>;
 			ssp-index = <1>;
 			status = "okay";
 
@@ -261,7 +261,7 @@
 			dmas = <&hda_link_out 3
 				&hda_link_in 3>;
 			dma-names = "tx", "rx";
-			power-domain = <&io0_domain>;
+			power-domains = <&io0_domain>;
 			ssp-index = <2>;
 			status = "okay";
 
@@ -319,26 +319,32 @@
 			hub_ulp_domain: hub_ulp_domain {
 				compatible = "intel,adsp-power-domain";
 				bit-position = <15>;
+				#power-domain-cells = <0>;
 			};
 			ml0_domain: ml0_domain {
 				compatible = "intel,adsp-power-domain";
 				bit-position = <12>;
+				#power-domain-cells = <0>;
 			};
 			io1_domain: io1_domain {
 				compatible = "intel,adsp-power-domain";
 				bit-position = <9>;
+				#power-domain-cells = <0>;
 			};
 			io0_domain: io0_domain {
 				compatible = "intel,adsp-power-domain";
 				bit-position = <8>;
+				#power-domain-cells = <0>;
 			};
 			hub_hp_domain: hub_hp_domain {
 				compatible = "intel,adsp-power-domain";
 				bit-position = <6>;
+				#power-domain-cells = <0>;
 			};
 			hst_domain: hst_domain {
 				compatible = "intel,adsp-power-domain";
 				bit-position = <5>;
+				#power-domain-cells = <0>;
 			};
 		};
 

--- a/dts/xtensa/intel/intel_adsp_ace30.dtsi
+++ b/dts/xtensa/intel/intel_adsp_ace30.dtsi
@@ -169,7 +169,7 @@
 			fifo = <0x0008>;
 			interrupts = <0x08 0 0>;
 			interrupt-parent = <&ace_intc>;
-			power-domain = <&hub_ulp_domain>;
+			power-domains = <&hub_ulp_domain>;
 		};
 
 		dmic1: dai-dmic1@10100 {
@@ -179,7 +179,7 @@
 			fifo = <0x0108>;
 			interrupts = <0x08 0 0>;
 			interrupt-parent = <&ace_intc>;
-			power-domain = <&hub_ulp_domain>;
+			power-domains = <&hub_ulp_domain>;
 		};
 
 		dmicvss: dmicvss@16000 {
@@ -212,7 +212,7 @@
 				&hda_link_in 1>;
 			dma-names = "tx", "rx";
 			ssp-index = <0>;
-			power-domain = <&io0_domain>;
+			power-domains = <&io0_domain>;
 			status = "okay";
 
 			ssp00: ssp@0 {
@@ -277,7 +277,7 @@
 				&hda_link_in 2>;
 			dma-names = "tx", "rx";
 			ssp-index = <1>;
-			power-domain = <&io0_domain>;
+			power-domains = <&io0_domain>;
 			status = "okay";
 
 			ssp10: ssp@10 {
@@ -342,7 +342,7 @@
 				&hda_link_in 3>;
 			dma-names = "tx", "rx";
 			ssp-index = <2>;
-			power-domain = <&io0_domain>;
+			power-domains = <&io0_domain>;
 			status = "okay";
 
 			ssp20: ssp@20 {
@@ -441,26 +441,32 @@
 			hub_ulp_domain: hub_ulp_domain {
 				compatible = "intel,adsp-power-domain";
 				bit-position = <15>;
+				#power-domain-cells = <0>;
 			};
 			ml0_domain: ml0_domain {
 				compatible = "intel,adsp-power-domain";
 				bit-position = <12>;
+				#power-domain-cells = <0>;
 			};
 			io1_domain: io1_domain {
 				compatible = "intel,adsp-power-domain";
 				bit-position = <9>;
+				#power-domain-cells = <0>;
 			};
 			io0_domain: io0_domain {
 				compatible = "intel,adsp-power-domain";
 				bit-position = <8>;
+				#power-domain-cells = <0>;
 			};
 			hub_hp_domain: hub_hpp_domain {
 				compatible = "intel,adsp-power-domain";
 				bit-position = <6>;
+				#power-domain-cells = <0>;
 			};
 			hst_domain: hst_domain {
 				compatible = "intel,adsp-power-domain";
 				bit-position = <5>;
+				#power-domain-cells = <0>;
 			};
 		};
 
@@ -498,7 +504,7 @@
 			dma-buf-addr-alignment = <128>;
 			dma-buf-size-alignment = <32>;
 			dma-copy-alignment = <32>;
-			power-domain = <&hst_domain>;
+			power-domains = <&hst_domain>;
 			interrupts = <13 0 0>;
 			interrupt-parent = <&ace_intc>;
 			status = "okay";
@@ -512,7 +518,7 @@
 			dma-buf-addr-alignment = <128>;
 			dma-buf-size-alignment = <32>;
 			dma-copy-alignment = <32>;
-			power-domain = <&hst_domain>;
+			power-domains = <&hst_domain>;
 			interrupts = <12 0 0>;
 			interrupt-parent = <&ace_intc>;
 			status = "okay";
@@ -534,7 +540,7 @@
 			dma-buf-addr-alignment = <128>;
 			dma-buf-size-alignment = <32>;
 			dma-copy-alignment = <32>;
-			power-domain = <&io0_domain>;
+			power-domains = <&io0_domain>;
 			status = "okay";
 		};
 
@@ -546,7 +552,7 @@
 			dma-buf-addr-alignment = <128>;
 			dma-buf-size-alignment = <32>;
 			dma-copy-alignment = <32>;
-			power-domain = <&io0_domain>;
+			power-domains = <&io0_domain>;
 			status = "okay";
 		};
 

--- a/dts/xtensa/intel/intel_adsp_ace30_ptl.dtsi
+++ b/dts/xtensa/intel/intel_adsp_ace30_ptl.dtsi
@@ -169,7 +169,7 @@
 			fifo = <0x0008>;
 			interrupts = <0x08 0 0>;
 			interrupt-parent = <&ace_intc>;
-			power-domain = <&hub_ulp_domain>;
+			power-domains = <&hub_ulp_domain>;
 		};
 
 		dmic1: dai-dmic1@10100 {
@@ -179,7 +179,7 @@
 			fifo = <0x0108>;
 			interrupts = <0x08 0 0>;
 			interrupt-parent = <&ace_intc>;
-			power-domain = <&hub_ulp_domain>;
+			power-domains = <&hub_ulp_domain>;
 		};
 
 		dmicvss: dmicvss@16000 {
@@ -212,7 +212,7 @@
 				&hda_link_in 1>;
 			dma-names = "tx", "rx";
 			ssp-index = <0>;
-			power-domain = <&io0_domain>;
+			power-domains = <&io0_domain>;
 			status = "okay";
 
 			ssp00: ssp@0 {
@@ -277,7 +277,7 @@
 				&hda_link_in 2>;
 			dma-names = "tx", "rx";
 			ssp-index = <1>;
-			power-domain = <&io0_domain>;
+			power-domains = <&io0_domain>;
 			status = "okay";
 
 			ssp10: ssp@10 {
@@ -342,7 +342,7 @@
 				&hda_link_in 3>;
 			dma-names = "tx", "rx";
 			ssp-index = <2>;
-			power-domain = <&io0_domain>;
+			power-domains = <&io0_domain>;
 			status = "okay";
 
 			ssp20: ssp@20 {
@@ -441,26 +441,32 @@
 			hub_ulp_domain: hub_ulp_domain {
 				compatible = "intel,adsp-power-domain";
 				bit-position = <15>;
+				#power-domain-cells = <0>;
 			};
 			ml0_domain: ml0_domain {
 				compatible = "intel,adsp-power-domain";
 				bit-position = <12>;
+				#power-domain-cells = <0>;
 			};
 			io1_domain: io1_domain {
 				compatible = "intel,adsp-power-domain";
 				bit-position = <9>;
+				#power-domain-cells = <0>;
 			};
 			io0_domain: io0_domain {
 				compatible = "intel,adsp-power-domain";
 				bit-position = <8>;
+				#power-domain-cells = <0>;
 			};
 			hub_hp_domain: hub_hpp_domain {
 				compatible = "intel,adsp-power-domain";
 				bit-position = <6>;
+				#power-domain-cells = <0>;
 			};
 			hst_domain: hst_domain {
 				compatible = "intel,adsp-power-domain";
 				bit-position = <5>;
+				#power-domain-cells = <0>;
 			};
 		};
 
@@ -498,7 +504,7 @@
 			dma-buf-addr-alignment = <128>;
 			dma-buf-size-alignment = <32>;
 			dma-copy-alignment = <32>;
-			power-domain = <&hst_domain>;
+			power-domains = <&hst_domain>;
 			interrupts = <13 0 0>;
 			interrupt-parent = <&ace_intc>;
 			status = "okay";
@@ -512,7 +518,7 @@
 			dma-buf-addr-alignment = <128>;
 			dma-buf-size-alignment = <32>;
 			dma-copy-alignment = <32>;
-			power-domain = <&hst_domain>;
+			power-domains = <&hst_domain>;
 			interrupts = <12 0 0>;
 			interrupt-parent = <&ace_intc>;
 			status = "okay";
@@ -534,7 +540,7 @@
 			dma-buf-addr-alignment = <128>;
 			dma-buf-size-alignment = <32>;
 			dma-copy-alignment = <32>;
-			power-domain = <&io0_domain>;
+			power-domains = <&io0_domain>;
 			status = "okay";
 		};
 
@@ -546,7 +552,7 @@
 			dma-buf-addr-alignment = <128>;
 			dma-buf-size-alignment = <32>;
 			dma-copy-alignment = <32>;
-			power-domain = <&io0_domain>;
+			power-domains = <&io0_domain>;
 			status = "okay";
 		};
 

--- a/dts/xtensa/nxp/nxp_imx8.dtsi
+++ b/dts/xtensa/nxp/nxp_imx8.dtsi
@@ -35,7 +35,7 @@
 	irqsteer: interrupt-controller@510a0000 {
 		compatible = "nxp,irqsteer-intc";
 		reg = <0x510a0000 DT_SIZE_K(64)>;
-		power-domain = <&irqstr_pd>;
+		power-domains = <&irqstr_pd>;
 
 		#size-cells = <0>;
 		#address-cells = <1>;
@@ -178,6 +178,7 @@
 				compatible = "nxp,imx8qm-scu-pd", "nxp,scu-pd";
 				reg = <0>;
 				nxp,resource-id = <IMX_SC_R_IRQSTR_DSP>;
+				#power-domain-cells = <0>;
 			};
 		};
 	};

--- a/include/zephyr/pm/device.h
+++ b/include/zephyr/pm/device.h
@@ -208,7 +208,7 @@ BUILD_ASSERT(offsetof(struct pm_device_isr, base) == 0);
 #ifdef CONFIG_PM_DEVICE_POWER_DOMAIN
 #define	Z_PM_DEVICE_POWER_DOMAIN_INIT(_node_id)			\
 	.domain = DEVICE_DT_GET_OR_NULL(DT_PHANDLE(_node_id,	\
-				   power_domain)),
+				   power_domains)),
 #else
 #define Z_PM_DEVICE_POWER_DOMAIN_INIT(obj)
 #endif /* CONFIG_PM_DEVICE_POWER_DOMAIN */

--- a/tests/drivers/build_all/power_domain/app.overlay
+++ b/tests/drivers/build_all/power_domain/app.overlay
@@ -19,6 +19,7 @@
 		power_domain_gpio {
 			compatible = "power-domain-gpio";
 			enable-gpios = <&test_gpio 0 0>;
+			#power-domain-cells = <0>;
 			zephyr,pm-device-runtime-auto;
 		};
 
@@ -26,6 +27,7 @@
 			compatible = "power-domain-gpio-monitor";
 			status = "okay";
 			gpios = <&test_gpio 0 0>;
+			#power-domain-cells = <0>;
 		};
 	};
 };

--- a/tests/kernel/device/app.overlay
+++ b/tests/kernel/device/app.overlay
@@ -69,17 +69,20 @@
 	fakedomain_0: fakedomain_0 {
 		compatible = "fakedomain";
 		status = "okay";
-		power-domain = <&fakedomain_2>;
+		power-domains = <&fakedomain_2>;
+		#power-domain-cells = <0>;
 	};
 
 	fakedomain_1: fakedomain_1 {
 		compatible = "fakedomain";
 		status = "okay";
-		power-domain = <&fakedomain_0>;
+		power-domains = <&fakedomain_0>;
+		#power-domain-cells = <0>;
 	};
 
 	fakedomain_2: fakedomain_2 {
 		compatible = "fakedomain";
 		status = "okay";
+		#power-domain-cells = <0>;
 	};
 };

--- a/tests/kernel/device/boards/hifive_unmatched.overlay
+++ b/tests/kernel/device/boards/hifive_unmatched.overlay
@@ -66,13 +66,13 @@
 	fakedomain_0: fakedomain_0 {
 		compatible = "fakedomain";
 		status = "okay";
-		power-domain = <&fakedomain_2>;
+		power-domains = <&fakedomain_2>;
 	};
 
 	fakedomain_1: fakedomain_1 {
 		compatible = "fakedomain";
 		status = "okay";
-		power-domain = <&fakedomain_0>;
+		power-domains = <&fakedomain_0>;
 	};
 
 	fakedomain_2: fakedomain_2 {

--- a/tests/subsys/pm/device_driver_init/app.overlay
+++ b/tests/subsys/pm/device_driver_init/app.overlay
@@ -2,43 +2,50 @@
 	test_reg: test_reg {
 		compatible = "power-domain-gpio";
 		enable-gpios = <&gpio0 0 0>;
+		#power-domain-cells = <0>;
 	};
 
 	test_reg_chained: test_reg_chained {
 		compatible = "power-domain-gpio";
 		enable-gpios = <&gpio0 1 0>;
-		power-domain = <&test_reg>;
+		power-domains = <&test_reg>;
+		#power-domain-cells = <0>;
 	};
 
 	test_reg_chained_auto: test_reg_chained_auto {
 		compatible = "power-domain-gpio";
 		enable-gpios = <&gpio0 2 0>;
-		power-domain = <&test_reg>;
+		power-domains = <&test_reg>;
+		#power-domain-cells = <0>;
 		zephyr,pm-device-runtime-auto;
 	};
 
 	test_reg_auto: test_reg_auto {
 		compatible = "power-domain-gpio";
 		enable-gpios = <&gpio0 3 0>;
+		#power-domain-cells = <0>;
 		zephyr,pm-device-runtime-auto;
 	};
 
 	test_reg_auto_chained: test_reg_auto_chained {
 		compatible = "power-domain-gpio";
 		enable-gpios = <&gpio0 4 0>;
-		power-domain = <&test_reg_auto>;
+		#power-domain-cells = <0>;
+		power-domains = <&test_reg_auto>;
 	};
 
 	test_reg_auto_chained_auto: test_reg_auto_chained_auto {
 		compatible = "power-domain-gpio";
 		enable-gpios = <&gpio0 5 0>;
-		power-domain = <&test_reg_auto>;
+		power-domains = <&test_reg_auto>;
+		#power-domain-cells = <0>;
 		zephyr,pm-device-runtime-auto;
 	};
 
 	test_reg_disabled: test_reg_disabled {
 		compatible = "power-domain-gpio";
 		enable-gpios = <&gpio0 6 0>;
+		#power-domain-cells = <0>;
 		status = "disabled";
 	};
 };

--- a/tests/subsys/pm/device_power_domains/app.overlay
+++ b/tests/subsys/pm/device_power_domains/app.overlay
@@ -2,23 +2,26 @@
 	test_reg_0: test_reg_0 {
 		compatible = "power-domain-gpio";
 		enable-gpios = <&gpio0 0 0>;
+		#power-domain-cells = <0>;
 	};
 
 	test_reg_1: test_reg_1 {
 		compatible = "power-domain-gpio";
 		enable-gpios = <&gpio0 1 0>;
+		#power-domain-cells = <0>;
 	};
 
 	test_reg_chained: test_reg_chained {
 		compatible = "power-domain-gpio";
 		enable-gpios = <&gpio0 2 0>;
-		power-domain = <&test_reg_0>;
+		power-domains = <&test_reg_0>;
+		#power-domain-cells = <0>;
 	};
 
 	test_dev: test_dev {
 		compatible = "test-device-pm";
 		status = "okay";
-		power-domain = <&test_reg_1>;
+		power-domains = <&test_reg_1>;
 		alternate-domain = <&test_reg_chained>;
 	};
 };

--- a/tests/subsys/pm/power_domain/app.overlay
+++ b/tests/subsys/pm/power_domain/app.overlay
@@ -8,28 +8,30 @@
 	test_domain: test_domain {
 		compatible = "power-domain";
 		status = "okay";
+		#power-domain-cells = <0>;
 	};
 
 	test_dev_a: test_dev_a {
 		compatible = "test-device-pm";
 		status = "okay";
-		power-domain = <&test_domain>;
+		power-domains = <&test_domain>;
 	};
 
 	test_dev_b: test_dev_b {
 		compatible = "test-device-pm";
 		status = "okay";
-		power-domain = <&test_domain>;
+		power-domains = <&test_domain>;
 	};
 
 	test_domain_balanced: test_domain_balanced {
 		compatible = "power-domain";
 		status = "okay";
+		#power-domain-cells = <0>;
 	};
 
 	test_dev_balanced: test_dev_balanced {
 		compatible = "test-device-pm";
 		status = "okay";
-		power-domain = <&test_domain_balanced>;
+		power-domains = <&test_domain_balanced>;
 	};
 };


### PR DESCRIPTION
Some devices may belong to >1 power domain, so with the current design this is something not possible to describe. It's worth to note that Linux also uses the `power-domains` naming scheme, not `power-domain`. This patch also introduces `power-domain-names` so that each entry in `power-domains` can be given a name if needed.