### PR TITLE
soc/sifive/sifive-freedom: enable PMP by default on 64-bit SoCs

### DIFF
--- a/soc/sifive/sifive_freedom/fu500/Kconfig
+++ b/soc/sifive/sifive_freedom/fu500/Kconfig
@@ -5,17 +5,21 @@
 config SOC_SERIES_SIFIVE_FREEDOM_FU500
 	bool
 
+	select 64BIT
+
 	# RISC-V options
 	select RISCV
 	select RISCV_PRIVILEGED
 	select RISCV_HAS_PLIC
+	select RISCV_PMP
+
 	select RISCV_ISA_RV64I
 	select RISCV_ISA_EXT_M
 	select RISCV_ISA_EXT_A
 	select RISCV_ISA_EXT_C
 	select RISCV_ISA_EXT_ZICSR
 	select RISCV_ISA_EXT_ZIFENCEI
-	imply XIP
+
 	select SOC_EARLY_INIT_HOOK
-	select 64BIT
 	select INCLUDE_RESET_VECTOR
+	imply XIP

--- a/soc/sifive/sifive_freedom/fu700/Kconfig
+++ b/soc/sifive/sifive_freedom/fu700/Kconfig
@@ -4,17 +4,21 @@
 config SOC_SERIES_SIFIVE_FREEDOM_FU700
 	bool
 
+	select 64BIT
+
 	# RISC-V options
 	select RISCV
 	select RISCV_PRIVILEGED
 	select RISCV_HAS_PLIC
+	select RISCV_PMP
+
 	select RISCV_ISA_RV64I
 	select RISCV_ISA_EXT_M
 	select RISCV_ISA_EXT_A
 	select RISCV_ISA_EXT_C
 	select RISCV_ISA_EXT_ZICSR
 	select RISCV_ISA_EXT_ZIFENCEI
-	imply XIP
+
 	select SOC_EARLY_INIT_HOOK
 	select INCLUDE_RESET_VECTOR
-	select 64BIT
+	imply XIP


### PR DESCRIPTION
This PR enables PMP on 64-bit SoCs from the SiFive Freedom SoC series by default.

This change is needed to e.g. run the Userspace Hello World demo.