### PR TITLE
net: silence no sources cmake warning

### DIFF
--- a/subsys/net/CMakeLists.txt
+++ b/subsys/net/CMakeLists.txt
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 zephyr_library()
+zephyr_library_property(ALLOW_EMPTY TRUE)
 zephyr_library_sources_ifdef(CONFIG_NET_HOSTNAME_ENABLE hostname.c)
 
 if(CONFIG_NETWORKING)


### PR DESCRIPTION
add `ALLOW_EMPTY TRUE` property to silence cmake warnings in case when no sources are added to subsys__net library