### PR TITLE
net: dns: Make dispatcher check also network interface

### DIFF
--- a/include/zephyr/net/dns_resolve.h
+++ b/include/zephyr/net/dns_resolve.h
@@ -202,6 +202,8 @@ struct dns_socket_dispatcher {
 	int fds_len;
 	/** Local socket to dispatch */
 	int sock;
+	/** Interface we are bound to */
+	int ifindex;
 	/** There can be two contexts to dispatch. This points to the other
 	 * context if sharing the socket between resolver / responder.
 	 */

--- a/subsys/net/lib/dns/dispatcher.c
+++ b/subsys/net/lib/dns/dispatcher.c
@@ -140,9 +140,12 @@ static int recv_data(struct net_socket_service_event *pev)
 	    (pev->event.revents & ZSOCK_POLLNVAL)) {
 		(void)zsock_getsockopt(pev->event.fd, SOL_SOCKET,
 				       SO_ERROR, &sock_error, &optlen);
-		NET_ERR("Receiver IPv%d socket error (%d)",
-			family == AF_INET ? 4 : 6, sock_error);
-		ret = DNS_EAI_SYSTEM;
+		if (sock_error > 0) {
+			NET_ERR("Receiver IPv%d socket error (%d)",
+				family == AF_INET ? 4 : 6, sock_error);
+			ret = DNS_EAI_SYSTEM;
+		}
+
 		goto unlock;
 	}
 

--- a/subsys/net/lib/dns/dispatcher.c
+++ b/subsys/net/lib/dns/dispatcher.c
@@ -213,7 +213,8 @@ int dns_dispatcher_register(struct dns_socket_dispatcher *ctx)
 		 * already registered.
 		 */
 		if (ctx->type == entry->type &&
-		    ctx->local_addr.sa_family == entry->local_addr.sa_family) {
+		    ctx->local_addr.sa_family == entry->local_addr.sa_family &&
+		    ctx->ifindex == entry->ifindex) {
 			if (net_sin(&entry->local_addr)->sin_port ==
 			    net_sin(&ctx->local_addr)->sin_port) {
 				dup = true;

--- a/subsys/net/lib/dns/mdns_responder.c
+++ b/subsys/net/lib/dns/mdns_responder.c
@@ -684,7 +684,8 @@ static int dispatcher_cb(void *my_ctx, int sock,
 
 static int register_dispatcher(struct mdns_responder_context *ctx,
 			       const struct net_socket_service_desc *svc,
-			       struct sockaddr *local)
+			       struct sockaddr *local,
+			       int ifindex)
 {
 	ctx->dispatcher.type = DNS_SOCKET_RESPONDER;
 	ctx->dispatcher.cb = dispatcher_cb;
@@ -694,6 +695,7 @@ static int register_dispatcher(struct mdns_responder_context *ctx,
 	ctx->dispatcher.svc = svc;
 	ctx->dispatcher.mdns_ctx = ctx;
 	ctx->dispatcher.pair = NULL;
+	ctx->dispatcher.ifindex = ifindex;
 
 	/* Mark the fd so that "net sockets" can show it. This is needed if there
 	 * is already a socket bound to same port and the dispatcher will mux
@@ -799,7 +801,8 @@ static int init_listener(void)
 			continue;
 		}
 
-		ret = register_dispatcher(&v6_ctx[i], &v6_svc, (struct sockaddr *)&local_addr6);
+		ret = register_dispatcher(&v6_ctx[i], &v6_svc, (struct sockaddr *)&local_addr6,
+					  ifindex);
 		if (ret < 0) {
 			NET_DBG("Cannot register %s %s socket service (%d)",
 				"IPv6", "mDNS", ret);
@@ -882,7 +885,8 @@ static int init_listener(void)
 			continue;
 		}
 
-		ret = register_dispatcher(&v4_ctx[i], &v4_svc, (struct sockaddr *)&local_addr4);
+		ret = register_dispatcher(&v4_ctx[i], &v4_svc, (struct sockaddr *)&local_addr4,
+					  ifindex);
 		if (ret < 0) {
 			NET_DBG("Cannot register %s %s socket service (%d)",
 				"IPv4", "mDNS", ret);

--- a/subsys/net/lib/dns/mdns_responder.c
+++ b/subsys/net/lib/dns/mdns_responder.c
@@ -685,12 +685,14 @@ static int dispatcher_cb(void *my_ctx, int sock,
 static int register_dispatcher(struct mdns_responder_context *ctx,
 			       const struct net_socket_service_desc *svc,
 			       struct sockaddr *local,
-			       int ifindex)
+			       int ifindex,
+			       struct zsock_pollfd *fds,
+			       size_t fds_len)
 {
 	ctx->dispatcher.type = DNS_SOCKET_RESPONDER;
 	ctx->dispatcher.cb = dispatcher_cb;
-	ctx->dispatcher.fds = ctx->fds;
-	ctx->dispatcher.fds_len = ARRAY_SIZE(ctx->fds);
+	ctx->dispatcher.fds = fds;
+	ctx->dispatcher.fds_len = fds_len;
 	ctx->dispatcher.sock = ctx->sock;
 	ctx->dispatcher.svc = svc;
 	ctx->dispatcher.mdns_ctx = ctx;
@@ -723,13 +725,17 @@ static int init_listener(void)
 	char name[INTERFACE_NAME_LEN + 1];
 	struct ifreq if_req;
 	struct net_if *iface;
-	int iface_count;
+	int iface_count, fds_pos;
 
 	NET_IFACE_COUNT(&iface_count);
 	NET_DBG("Setting %s listener to %d interface%s", "mDNS", iface_count,
 		iface_count > 1 ? "s" : "");
 
 #if defined(CONFIG_NET_IPV6)
+	/* Because there is only one IPv6 socket service context for all
+	 * IPv6 sockets, we must collect the sockets in one place.
+	 */
+	struct zsock_pollfd ipv6_fds[MAX_IPV6_IFACE_COUNT];
 	struct sockaddr_in6 local_addr6;
 	int v6;
 
@@ -740,6 +746,12 @@ static int init_listener(void)
 	}
 
 	setup_ipv6_addr(&local_addr6);
+
+	ARRAY_FOR_EACH(ipv6_fds, i) {
+		ipv6_fds[i].fd = -1;
+	}
+
+	fds_pos = 0;
 
 	ARRAY_FOR_EACH(v6_ctx, i) {
 		ARRAY_FOR_EACH(v6_ctx[i].fds, j) {
@@ -790,6 +802,8 @@ static int init_listener(void)
 			if (v6_ctx[i].fds[j].fd < 0) {
 				v6_ctx[i].fds[j].fd = v6;
 				v6_ctx[i].fds[j].events = ZSOCK_POLLIN;
+				ipv6_fds[fds_pos].fd = v6;
+				ipv6_fds[fds_pos++].events = ZSOCK_POLLIN;
 				ret = 0;
 				break;
 			}
@@ -802,7 +816,7 @@ static int init_listener(void)
 		}
 
 		ret = register_dispatcher(&v6_ctx[i], &v6_svc, (struct sockaddr *)&local_addr6,
-					  ifindex);
+					  ifindex, ipv6_fds, ARRAY_SIZE(ipv6_fds));
 		if (ret < 0) {
 			NET_DBG("Cannot register %s %s socket service (%d)",
 				"IPv6", "mDNS", ret);
@@ -814,6 +828,7 @@ static int init_listener(void)
 #endif /* CONFIG_NET_IPV6 */
 
 #if defined(CONFIG_NET_IPV4)
+	struct zsock_pollfd ipv4_fds[MAX_IPV4_IFACE_COUNT];
 	struct sockaddr_in local_addr4;
 	int v4;
 
@@ -824,6 +839,12 @@ static int init_listener(void)
 	}
 
 	setup_ipv4_addr(&local_addr4);
+
+	ARRAY_FOR_EACH(ipv4_fds, i) {
+		ipv4_fds[i].fd = -1;
+	}
+
+	fds_pos = 0;
 
 	ARRAY_FOR_EACH(v4_ctx, i) {
 		ARRAY_FOR_EACH(v4_ctx[i].fds, j) {
@@ -874,6 +895,8 @@ static int init_listener(void)
 			if (v4_ctx[i].fds[j].fd < 0) {
 				v4_ctx[i].fds[j].fd = v4;
 				v4_ctx[i].fds[j].events = ZSOCK_POLLIN;
+				ipv4_fds[fds_pos].fd = v4;
+				ipv4_fds[fds_pos++].events = ZSOCK_POLLIN;
 				ret = 0;
 				break;
 			}
@@ -886,7 +909,7 @@ static int init_listener(void)
 		}
 
 		ret = register_dispatcher(&v4_ctx[i], &v4_svc, (struct sockaddr *)&local_addr4,
-					  ifindex);
+					  ifindex, ipv4_fds, ARRAY_SIZE(ipv4_fds));
 		if (ret < 0) {
 			NET_DBG("Cannot register %s %s socket service (%d)",
 				"IPv4", "mDNS", ret);


### PR DESCRIPTION
As the DNS might listen to multicast addresses (like in mDNS) in different network interfaces, make sure to check the network interface index when registering the dispatcher context. This allows two mDNS registrations to more than one network interface.