### PR TITLE
soc: nordic: Add approtect workaround for 91x1

### DIFF
--- a/modules/hal_nordic/nrfx/CMakeLists.txt
+++ b/modules/hal_nordic/nrfx/CMakeLists.txt
@@ -80,6 +80,8 @@ zephyr_compile_definitions_ifdef(CONFIG_NRF_SECURE_APPROTECT_LOCK
                                  ENABLE_SECURE_APPROTECT)
 zephyr_compile_definitions_ifdef(CONFIG_NRF_SECURE_APPROTECT_USER_HANDLING
                                  ENABLE_SECURE_APPROTECT_USER_HANDLING)
+zephyr_compile_definitions_ifdef(CONFIG_NRF_CONSTANT_LATENCY_WORKAROUND
+                                 ENABLE_CONSTANT_LATENCY_WORKAROUND)
 zephyr_library_compile_definitions_ifdef(CONFIG_NRF_TRACE_PORT
                                  ENABLE_TRACE)
 

--- a/soc/nordic/Kconfig
+++ b/soc/nordic/Kconfig
@@ -163,6 +163,25 @@ config NRF_SECURE_APPROTECT_USER_HANDLING
 
 endchoice
 
+config NRF_CONSTANT_LATENCY_WORKAROUND
+	bool "Constant latency mode for debugging purposes"
+	depends on SOC_NRF9120 && \
+		   !NRF_APPROTECT_LOCK && !NRF_SECURE_APPROTECT_LOCK
+	default n
+	help
+	  This option enables a workaround for the nRF9161 anomaly
+	  [36] Debug and Trace: Access port gets locked in WFI and WFE.
+	  It is only for debugging purposes. Do not enable it in production
+	  code.
+
+	  When this option is selected, the SystemInit() function enables
+	  the constant latency mode by triggering the CONSTLAT task. This
+	  prevents WFI and WFE instructions from entering SYSTEM ON IDLE mode.
+	  As a result, anomaly is avoided with the cost of increased power
+	  consumption.
+
+	  Note: With multiple images, add this for the first image.
+
 config NRF_TRACE_PORT
 	bool "nRF TPIU"
 	depends on !SOC_SERIES_NRF51X

--- a/west.yml
+++ b/west.yml
@@ -188,7 +188,7 @@ manifest:
       groups:
         - hal
     - name: hal_nordic
-      revision: d5c70305b2389641b0a166d0714775a1b13319a2
+      revision: pull/231/head
       path: modules/hal/nordic
       groups:
         - hal


### PR DESCRIPTION
Add CONFIG_NRF_CONSTANT_LATENCY_WORKAROUND for enabling a constant latency mode workaround for the nRF9161 anomaly: [36] Debug and Trace: Access port gets locked in WFI and WFE.

Constant latency mode prevents WFI and WFE instructions from entering SYSTEM ON IDLE mode, which would reset the approtect.