### PR TITLE
usb: device_next: Remove experimental status

### DIFF
--- a/include/zephyr/drivers/usb/udc.h
+++ b/include/zephyr/drivers/usb/udc.h
@@ -6,7 +6,7 @@
 
 /**
  * @file
- * @brief New USB device controller (UDC) driver API
+ * @brief USB device controller (UDC) driver API
  */
 
 #ifndef ZEPHYR_INCLUDE_UDC_H
@@ -17,6 +17,15 @@
 #include <zephyr/drivers/usb/udc_buf.h>
 #include <zephyr/sys/atomic.h>
 #include <zephyr/usb/usb_ch9.h>
+
+/**
+ * @brief USB device controller (UDC) API
+ * @defgroup udc_api USB device controller API
+ * @ingroup io_interfaces
+ * @since 3.3
+ * @version 0.2.0
+ * @{
+ */
 
 /**
  * @brief Maximum packet size of control endpoint supported by the controller.

--- a/include/zephyr/drivers/usb/uhc.h
+++ b/include/zephyr/drivers/usb/uhc.h
@@ -22,6 +22,8 @@
  * @brief USB host controller (UHC) driver API
  * @defgroup uhc_api USB host controller driver API
  * @ingroup io_interfaces
+ * @since 3.3
+ * @version 0.2.0
  * @{
  */
 

--- a/include/zephyr/usb/usbd.h
+++ b/include/zephyr/usb/usbd.h
@@ -29,9 +29,11 @@ extern "C" {
 #endif
 
 /**
- * @brief New USB device stack core API
+ * @brief USB device stack core API
  * @defgroup usbd_api USB device core API
  * @ingroup usb
+ * @since 3.3
+ * @version 0.2.0
  * @{
  */
 

--- a/include/zephyr/usb/usbh.h
+++ b/include/zephyr/usb/usbh.h
@@ -6,9 +6,9 @@
 
 /**
  * @file
- * @brief New experimental USB device stack APIs and structures
+ * @brief New USB Host stack APIs and structures
  *
- * This file contains the USB device stack APIs and structures.
+ * This file contains the USB Host stack APIs and structures.
  */
 
 #ifndef ZEPHYR_INCLUDE_USBH_H_
@@ -26,9 +26,11 @@ extern "C" {
 #endif
 
 /**
- * @brief USB HOST Core Layer API
+ * @brief USB Host Core Layer API
  * @defgroup usb_host_core_api USB Host Core API
  * @ingroup usb
+ * @since 3.3
+ * @version 0.2.0
  * @{
  */
 

--- a/subsys/usb/device_next/Kconfig
+++ b/subsys/usb/device_next/Kconfig
@@ -3,8 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig USB_DEVICE_STACK_NEXT
-	bool "New USB device stack [EXPERIMENTAL]"
-	select EXPERIMENTAL
+	bool "New USB device stack"
 	select UDC_DRIVER
 	imply HWINFO
 	help


### PR DESCRIPTION
The device_next stack now supports almost all classes that were covered by the legacy stack, and many controllers have been ported already.

See #42066 for more info.