### PR TITLE
tests: mcuboot: add "depends_on: mcuboot"

### DIFF
--- a/boards/nordic/nrf52840dk/nrf52840dk_nrf52840.yaml
+++ b/boards/nordic/nrf52840dk/nrf52840dk_nrf52840.yaml
@@ -25,4 +25,5 @@ supported:
   - usbd
   - watchdog
   - netif:openthread
+  - mcuboot
 vendor: nordic

--- a/boards/nxp/frdm_k22f/frdm_k22f.yaml
+++ b/boards/nxp/frdm_k22f/frdm_k22f.yaml
@@ -19,4 +19,5 @@ supported:
   - spi
   - usb_device
   - watchdog
+  - mcuboot
 vendor: nxp

--- a/boards/nxp/frdm_k64f/frdm_k64f.yaml
+++ b/boards/nxp/frdm_k64f/frdm_k64f.yaml
@@ -27,4 +27,5 @@ supported:
   - usb_device
   - usbd
   - watchdog
+  - mcuboot
 vendor: nxp

--- a/boards/nxp/frdm_k82f/frdm_k82f.yaml
+++ b/boards/nxp/frdm_k82f/frdm_k82f.yaml
@@ -22,4 +22,5 @@ supported:
   - spi
   - usb_device
   - watchdog
+  - mcuboot
 vendor: nxp

--- a/boards/nxp/frdm_ke17z/frdm_ke17z.yaml
+++ b/boards/nxp/frdm_ke17z/frdm_ke17z.yaml
@@ -18,4 +18,5 @@ supported:
   - spi
   - dma
   - watchdog
+  - mcuboot
 vendor: nxp

--- a/boards/nxp/frdm_ke17z512/frdm_ke17z512.yaml
+++ b/boards/nxp/frdm_ke17z512/frdm_ke17z512.yaml
@@ -24,4 +24,5 @@ supported:
   - spi
   - dma
   - watchdog
+  - mcuboot
 vendor: nxp

--- a/boards/nxp/frdm_mcxn947/frdm_mcxn947_mcxn947_cpu0.yaml
+++ b/boards/nxp/frdm_mcxn947/frdm_mcxn947_mcxn947_cpu0.yaml
@@ -28,4 +28,5 @@ supported:
   - regulator
   - adc
   - usb_device
+  - mcuboot
 vendor: nxp

--- a/boards/nxp/frdm_mcxw71/frdm_mcxw71.yaml
+++ b/boards/nxp/frdm_mcxw71/frdm_mcxw71.yaml
@@ -17,3 +17,4 @@ supported:
   - pinctrl
   - flash
   - i2c
+  - mcuboot

--- a/boards/nxp/lpcxpresso55s06/lpcxpresso55s06.yaml
+++ b/boards/nxp/lpcxpresso55s06/lpcxpresso55s06.yaml
@@ -16,4 +16,5 @@ toolchain:
 supported:
   - gpio
   - can
+  - mcuboot
 vendor: nxp

--- a/boards/nxp/lpcxpresso55s16/lpcxpresso55s16.yaml
+++ b/boards/nxp/lpcxpresso55s16/lpcxpresso55s16.yaml
@@ -25,4 +25,5 @@ supported:
   - spi
   - usb_device
   - usbd
+  - mcuboot
 vendor: nxp

--- a/boards/nxp/lpcxpresso55s28/lpcxpresso55s28.yaml
+++ b/boards/nxp/lpcxpresso55s28/lpcxpresso55s28.yaml
@@ -23,4 +23,5 @@ supported:
   - spi
   - usb_device
   - watchdog
+  - mcuboot
 vendor: nxp

--- a/boards/nxp/lpcxpresso55s36/lpcxpresso55s36.yaml
+++ b/boards/nxp/lpcxpresso55s36/lpcxpresso55s36.yaml
@@ -21,4 +21,5 @@ supported:
   - dac
   - usb_device
   - usbd
+  - mcuboot
 vendor: nxp

--- a/boards/nxp/lpcxpresso55s69/lpcxpresso55s69_lpc55s69_cpu0.yaml
+++ b/boards/nxp/lpcxpresso55s69/lpcxpresso55s69_lpc55s69_cpu0.yaml
@@ -27,4 +27,5 @@ supported:
   - sdhc
   - usb_device
   - watchdog
+  - mcuboot
 vendor: nxp

--- a/boards/nxp/mimxrt1010_evk/mimxrt1010_evk.yaml
+++ b/boards/nxp/mimxrt1010_evk/mimxrt1010_evk.yaml
@@ -27,4 +27,5 @@ supported:
   - spi
   - adc
   - gpio
+  - mcuboot
 vendor: nxp

--- a/boards/nxp/mimxrt1015_evk/mimxrt1015_evk.yaml
+++ b/boards/nxp/mimxrt1015_evk/mimxrt1015_evk.yaml
@@ -24,4 +24,5 @@ supported:
   - usb_device
   - spi
   - adc
+  - mcuboot
 vendor: nxp

--- a/boards/nxp/mimxrt1020_evk/mimxrt1020_evk.yaml
+++ b/boards/nxp/mimxrt1020_evk/mimxrt1020_evk.yaml
@@ -26,4 +26,5 @@ supported:
   - usb_device
   - adc
   - sdhc
+  - mcuboot
 vendor: nxp

--- a/boards/nxp/mimxrt1024_evk/mimxrt1024_evk.yaml
+++ b/boards/nxp/mimxrt1024_evk/mimxrt1024_evk.yaml
@@ -28,4 +28,5 @@ supported:
   - usb_device
   - pwm
   - gpio
+  - mcuboot
 vendor: nxp

--- a/boards/nxp/mimxrt1040_evk/mimxrt1040_evk.yaml
+++ b/boards/nxp/mimxrt1040_evk/mimxrt1040_evk.yaml
@@ -22,4 +22,5 @@ supported:
   - spi
   - i2c
   - counter
+  - mcuboot
 vendor: nxp

--- a/boards/nxp/mimxrt1050_evk/mimxrt1050_evk_mimxrt1052_hyperflash.yaml
+++ b/boards/nxp/mimxrt1050_evk/mimxrt1050_evk_mimxrt1052_hyperflash.yaml
@@ -29,4 +29,5 @@ supported:
   - usbd
   - watchdog
   - adc
+  - mcuboot
 vendor: nxp

--- a/boards/nxp/mimxrt1050_evk/mimxrt1050_evk_mimxrt1052_qspi.yaml
+++ b/boards/nxp/mimxrt1050_evk/mimxrt1050_evk_mimxrt1052_qspi.yaml
@@ -29,4 +29,5 @@ supported:
   - usbd
   - watchdog
   - adc
+  - mcuboot
 vendor: nxp

--- a/boards/nxp/mimxrt1060_evk/mimxrt1060_evk_mimxrt1062_hyperflash.yaml
+++ b/boards/nxp/mimxrt1060_evk/mimxrt1060_evk_mimxrt1062_hyperflash.yaml
@@ -31,4 +31,5 @@ supported:
   - usb_device
   - usbd
   - watchdog
+  - mcuboot
 vendor: nxp

--- a/boards/nxp/mimxrt1060_evk/mimxrt1060_evk_mimxrt1062_qspi.yaml
+++ b/boards/nxp/mimxrt1060_evk/mimxrt1060_evk_mimxrt1062_qspi.yaml
@@ -33,4 +33,5 @@ supported:
   - usb_device
   - usbd
   - watchdog
+  - mcuboot
 vendor: nxp

--- a/boards/nxp/mimxrt1060_evk/mimxrt1060_evkb.yaml
+++ b/boards/nxp/mimxrt1060_evk/mimxrt1060_evkb.yaml
@@ -31,4 +31,5 @@ supported:
   - can
   - watchdog
   - adc
+  - mcuboot
 vendor: nxp

--- a/boards/nxp/mimxrt1062_fmurt6/mimxrt1062_fmurt6.yaml
+++ b/boards/nxp/mimxrt1062_fmurt6/mimxrt1062_fmurt6.yaml
@@ -28,4 +28,5 @@ supported:
   - watchdog
   - adc
   - pwm
+  - mcuboot
 vendor: nxp

--- a/boards/nxp/mimxrt1064_evk/mimxrt1064_evk.yaml
+++ b/boards/nxp/mimxrt1064_evk/mimxrt1064_evk.yaml
@@ -32,4 +32,5 @@ supported:
   - can
   - watchdog
   - adc
+  - mcuboot
 vendor: nxp

--- a/boards/nxp/mimxrt1160_evk/mimxrt1160_evk_mimxrt1166_cm7.yaml
+++ b/boards/nxp/mimxrt1160_evk/mimxrt1160_evk_mimxrt1166_cm7.yaml
@@ -26,4 +26,5 @@ supported:
   - spi
   - usb_device
   - watchdog
+  - mcuboot
 vendor: nxp

--- a/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm7.yaml
+++ b/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm7.yaml
@@ -31,4 +31,5 @@ supported:
   - watchdog
   - video
   - usbd
+  - mcuboot
 vendor: nxp

--- a/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm7_B.yaml
+++ b/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm7_B.yaml
@@ -27,4 +27,5 @@ supported:
   - usb_device
   - watchdog
   - video
+  - mcuboot
 vendor: nxp

--- a/boards/nxp/mimxrt595_evk/mimxrt595_evk_mimxrt595s_cm33.yaml
+++ b/boards/nxp/mimxrt595_evk/mimxrt595_evk_mimxrt595s_cm33.yaml
@@ -29,4 +29,5 @@ supported:
   - pwm
   - i2s
   - dmic
+  - mcuboot
 vendor: nxp

--- a/boards/nxp/mimxrt685_evk/mimxrt685_evk_mimxrt685s_cm33.yaml
+++ b/boards/nxp/mimxrt685_evk/mimxrt685_evk_mimxrt685s_cm33.yaml
@@ -32,4 +32,5 @@ supported:
   - watchdog
   - usb_device
   - usbd
+  - mcuboot
 vendor: nxp

--- a/boards/nxp/rd_rw612_bga/rd_rw612_bga.yaml
+++ b/boards/nxp/rd_rw612_bga/rd_rw612_bga.yaml
@@ -27,3 +27,4 @@ supported:
   - hwinfo
   - adc
   - dac
+  - mcuboot

--- a/boards/nxp/twr_ke18f/twr_ke18f.yaml
+++ b/boards/nxp/twr_ke18f/twr_ke18f.yaml
@@ -18,4 +18,5 @@ supported:
   - pwm
   - spi
   - watchdog
+  - mcuboot
 vendor: nxp

--- a/boards/nxp/twr_kv58f220m/twr_kv58f220m.yaml
+++ b/boards/nxp/twr_kv58f220m/twr_kv58f220m.yaml
@@ -6,6 +6,7 @@ toolchain:
   - zephyr
   - gnuarmemb
   - xtools
+  - mcuboot
 ram: 128
 flash: 1024
 supported:

--- a/boards/st/b_u585i_iot02a/b_u585i_iot02a.yaml
+++ b/boards/st/b_u585i_iot02a/b_u585i_iot02a.yaml
@@ -25,4 +25,5 @@ supported:
   - i2c
   - rtc
   - usbd
+  - mcuboot
 vendor: st

--- a/boards/st/nucleo_wba55cg/nucleo_wba55cg.yaml
+++ b/boards/st/nucleo_wba55cg/nucleo_wba55cg.yaml
@@ -17,6 +17,7 @@ supported:
   - arduino_spi
   - counter
   - rtc
+  - mcuboot
 ram: 128
 flash: 1024
 vendor: st

--- a/tests/boot/test_mcuboot/testcase.yaml
+++ b/tests/boot/test_mcuboot/testcase.yaml
@@ -1,5 +1,6 @@
 common:
   sysbuild: true
+  depends_on: mcuboot
   harness: console
   harness_config:
     type: multi_line
@@ -12,39 +13,6 @@ common:
 tests:
   bootloader.mcuboot:
     tags: mcuboot
-    platform_allow:
-      - frdm_k22f
-      - frdm_k64f
-      - frdm_k82f
-      - frdm_ke17z
-      - frdm_ke17z512
-      - rddrone_fmuk66
-      - twr_ke18f
-      - twr_kv58f220m
-      - frdm_mcxn947/mcxn947/cpu0
-      - lpcxpresso55s06
-      - lpcxpresso55s16
-      - lpcxpresso55s28
-      - lpcxpresso55s36
-      - lpcxpresso55s69/lpc55s69/cpu0
-      - mimxrt1010_evk
-      - mimxrt1015_evk
-      - mimxrt1020_evk
-      - mimxrt1024_evk
-      - mimxrt1040_evk
-      - mimxrt1050_evk
-      - mimxrt1060_evk
-      - mimxrt1062_fmurt6
-      - mimxrt1064_evk
-      - mimxrt1160_evk/mimxrt1166/cm7
-      - mimxrt1170_evk/mimxrt1176/cm7
-      - vmu_rt1170/mimxrt1176/cm7
-      - mimxrt595_evk/mimxrt595s/cm33
-      - mimxrt685_evk/mimxrt685s/cm33
-      - nrf52840dk/nrf52840
-      - rd_rw612_bga
-      - nucleo_wba55cg
-      - frdm_mcxw71
     integration_platforms:
       - frdm_k64f
       - nrf52840dk/nrf52840


### PR DESCRIPTION
- Adds "depends_on: mcuboot" to the test_mcuboot testcase.yaml.
- Adds "supported: mcuboot" to the board yaml files, found in the testcase.yaml platform_allow list.
- Avoid appending of the platform_allow list for new platforms.