### PR TITLE
modules: hal_nordic: Integrate nrf-regtool 7.0.0

### DIFF
--- a/modules/hal_nordic/Kconfig.nrf_regtool
+++ b/modules/hal_nordic/Kconfig.nrf_regtool
@@ -26,11 +26,4 @@ config NRF_REGTOOL_VERBOSITY
 	  3. Print even more details, which are typically only useful for
 	     nrf-regtool developers.
 
-config NRF_REGTOOL_EXTRA_GENERATE_ARGS
-	string "Extra arguments to 'nrf-regtool generate'"
-	help
-	  List of additional arguments to every nrf-regtool invocation used for
-	  generating hex files. Example value: "--fill all --fill-byte 0xff".
-	  Run "nrf-regtool generate -h" to see all of the available options.
-
 endmenu

--- a/modules/hal_nordic/nrf-regtool/nrf-regtoolConfig.cmake
+++ b/modules/hal_nordic/nrf-regtool/nrf-regtoolConfig.cmake
@@ -1,16 +1,26 @@
 # Copyright (c) 2024 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-function(nrf_regtool_generate_hex_from_dts peripheral)
-  string(TOLOWER "${peripheral}.hex" generated_hex_name)
-  string(TOLOWER "${peripheral}_merged.hex" merged_hex_name)
+function(nrf_regtool_generate_uicr generated_hex_file)
+  string(REPEAT "-v;" ${CONFIG_NRF_REGTOOL_VERBOSITY} verbosity)
+  execute_process(
+    COMMAND
+    ${CMAKE_COMMAND} -E env PYTHONPATH=${ZEPHYR_BASE}/scripts/dts/python-devicetree/src
+    ${NRF_REGTOOL} ${verbosity} uicr-compile
+    --edt-pickle-file ${EDT_PICKLE}
+    --product-name ${CONFIG_SOC}
+    --output-file ${generated_hex_file}
+    WORKING_DIRECTORY ${APPLICATION_SOURCE_DIR}
+    COMMAND_ERROR_IS_FATAL ANY
+  )
+  message(STATUS "Generated UICR hex file: ${generated_hex_file}")
+endfunction()
 
+function(nrf_regtool_generate_peripheral peripheral generated_hex_file)
   # Prepare common argument sub-lists.
   string(REPEAT "-v;" ${CONFIG_NRF_REGTOOL_VERBOSITY} verbosity)
   list(TRANSFORM CACHED_DTS_ROOT_BINDINGS PREPEND "--bindings-dir;" OUTPUT_VARIABLE bindings_dirs)
-  separate_arguments(extra_args UNIX_COMMAND "${CONFIG_NRF_REGTOOL_EXTRA_GENERATE_ARGS}")
 
-  set(generated_hex_file ${PROJECT_BINARY_DIR}/${generated_hex_name})
   execute_process(
     COMMAND
     ${CMAKE_COMMAND} -E env PYTHONPATH=${ZEPHYR_BASE}/scripts/dts/python-devicetree/src
@@ -25,25 +35,29 @@ function(nrf_regtool_generate_hex_from_dts peripheral)
     COMMAND_ERROR_IS_FATAL ANY
   )
   message(STATUS "Generated ${peripheral} hex file: ${generated_hex_file}")
-
-  set(merged_hex_file ${PROJECT_BINARY_DIR}/${merged_hex_name})
-  set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
-    COMMAND ${PYTHON_EXECUTABLE} ${ZEPHYR_BASE}/scripts/build/mergehex.py
-    -o ${merged_hex_file}
-    ${generated_hex_file}
-    ${PROJECT_BINARY_DIR}/${KERNEL_HEX_NAME}
-  )
-  set_property(TARGET runners_yaml_props_target PROPERTY hex_file ${merged_hex_file})
 endfunction()
 
+get_property(version GLOBAL PROPERTY nrf_regtool_version)
 
 foreach(component IN LISTS ${CMAKE_FIND_PACKAGE_NAME}_FIND_COMPONENTS)
-  string(REGEX MATCH "(^.*):(.*$)" match ${component})
-  set(operation  "${CMAKE_MATCH_1}")
-  set(peripheral "${CMAKE_MATCH_2}")
+  if(component STREQUAL "GENERATE:UICR")
+    set(generated_hex_file ${PROJECT_BINARY_DIR}/uicr.hex)
+    if(version VERSION_GREATER_EQUAL 7.0.0)
+      nrf_regtool_generate_uicr(${generated_hex_file})
+    else()
+      nrf_regtool_generate_peripheral(UICR ${generated_hex_file})
+    endif()
 
-  if(operation STREQUAL "GENERATE")
-    nrf_regtool_generate_hex_from_dts(${peripheral})
+    # UICR must be flashed together with the Zephyr binary.
+    set(merged_hex_file ${PROJECT_BINARY_DIR}/uicr_merged.hex)
+    set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
+      COMMAND ${PYTHON_EXECUTABLE} ${ZEPHYR_BASE}/scripts/build/mergehex.py
+      -o ${merged_hex_file}
+      ${generated_hex_file}
+      ${PROJECT_BINARY_DIR}/${KERNEL_HEX_NAME}
+    )
+    set_property(TARGET runners_yaml_props_target PROPERTY hex_file ${merged_hex_file})
+
   else()
     message(FATAL_ERROR "Unrecognized package component: \"${component}\"")
   endif()

--- a/modules/hal_nordic/nrf-regtool/nrf-regtoolConfigVersion.cmake
+++ b/modules/hal_nordic/nrf-regtool/nrf-regtoolConfigVersion.cmake
@@ -22,6 +22,7 @@ if(NRF_REGTOOL)
         "Found nrf-regtool (found suitable version \"${PACKAGE_VERSION}\", "
         "minimum required is \"${PACKAGE_FIND_VERSION}\")"
       )
+      set_property(GLOBAL PROPERTY nrf_regtool_version ${PACKAGE_VERSION})
       return()
     endif()
   endif()


### PR DESCRIPTION
This new version introduces a new sub-command `uicr-compile`, which will generate `uicr.hex` based on a new binary format required by an upcoming release of Secure Domain Firmware (SDFW) closer to production.

Since this is a breaking change, and SDFW is not finalized yet, we need to support two nrf-regtool versions for a short time, and use different CLI invocations based on which version is installed. Hence, the minimum required version is unchanged.

Additionally, retire CONFIG_NRF_REGTOOL_EXTRA_GENERATE_ARGS. There will be no use for it moving forward.