### PR TITLE
modules: hal_nordic: NRFX_RRAMC not available for Non-Secure

### DIFF
--- a/modules/hal_nordic/nrfx/Kconfig
+++ b/modules/hal_nordic/nrfx/Kconfig
@@ -286,6 +286,7 @@ config NRFX_RNG
 
 config NRFX_RRAMC
 	bool "RRAMC driver"
+	depends on !TRUSTED_EXECUTION_NONSECURE
 	depends on $(dt_has_compat,$(DT_COMPAT_NORDIC_RRAM_CONTROLLER))
 
 config NRFX_RTC


### PR DESCRIPTION
nrfx drivers does not support RRAMC for Non-Secure. Make the Kconfig option depend on not Non-Secure to reflect this.