### PR TITLE
Bluetooth: Tester: Send test data when entering streaming state 

### DIFF
--- a/tests/bluetooth/tester/overlay-le-audio.conf
+++ b/tests/bluetooth/tester/overlay-le-audio.conf
@@ -20,6 +20,11 @@ CONFIG_BT_BUF_EVT_RX_COUNT=16
 CONFIG_BT_BUF_EVT_RX_SIZE=255
 CONFIG_BT_BUF_CMD_TX_SIZE=255
 
+# 48_6 configuration uses 155 octets for max SDU
+# allow for 2 audio streams in single ISO channel
+CONFIG_BT_ISO_TX_MTU=310
+CONFIG_BT_ISO_RX_MTU=310
+
 # When initiating Codec Config by server for 3 ASEs one by one, MTU buffers
 # were freed too slow. The bt_bap_stream_ops.configured callback comes earlier.
 CONFIG_BT_L2CAP_TX_BUF_COUNT=10

--- a/tests/bluetooth/tester/src/audio/btp_bap_audio_stream.c
+++ b/tests/bluetooth/tester/src/audio/btp_bap_audio_stream.c
@@ -152,6 +152,11 @@ void btp_bap_audio_stream_stopped(struct btp_bap_audio_stream *a_stream)
 	k_work_cancel_delayable(&a_stream->audio_send_work);
 }
 
+uint8_t btp_bap_audio_stream_send_data(const uint8_t *data, uint8_t data_len)
+{
+	return ring_buf_put(&audio_ring_buf, data, data_len);
+}
+
 uint8_t btp_bap_audio_stream_send(const void *cmd, uint16_t cmd_len,
 				  void *rsp, uint16_t *rsp_len)
 {
@@ -159,7 +164,7 @@ uint8_t btp_bap_audio_stream_send(const void *cmd, uint16_t cmd_len,
 	const struct btp_bap_send_cmd *cp = cmd;
 	uint32_t ret;
 
-	ret = ring_buf_put(&audio_ring_buf, cp->data, cp->data_len);
+	ret = btp_bap_audio_stream_send_data(cp->data, cp->data_len);
 
 	rp->data_len = ret;
 	*rsp_len = sizeof(*rp) + 1;

--- a/tests/bluetooth/tester/src/audio/btp_bap_audio_stream.c
+++ b/tests/bluetooth/tester/src/audio/btp_bap_audio_stream.c
@@ -167,7 +167,7 @@ uint8_t btp_bap_audio_stream_send(const void *cmd, uint16_t cmd_len,
 	ret = btp_bap_audio_stream_send_data(cp->data, cp->data_len);
 
 	rp->data_len = ret;
-	*rsp_len = sizeof(*rp) + 1;
+	*rsp_len = sizeof(*rp);
 
 	return BTP_STATUS_SUCCESS;
 }

--- a/tests/bluetooth/tester/src/audio/btp_bap_audio_stream.h
+++ b/tests/bluetooth/tester/src/audio/btp_bap_audio_stream.h
@@ -21,3 +21,4 @@ int btp_bap_audio_stream_init_send_worker(void);
 void btp_bap_audio_stream_started(struct btp_bap_audio_stream *stream);
 void btp_bap_audio_stream_stopped(struct btp_bap_audio_stream *a_stream);
 uint8_t btp_bap_audio_stream_send(const void *cmd, uint16_t cmd_len, void *rsp, uint16_t *rsp_len);
+uint8_t btp_bap_audio_stream_send_data(const uint8_t *data, uint8_t data_len);

--- a/tests/bluetooth/tester/src/audio/btp_bap_unicast.c
+++ b/tests/bluetooth/tester/src/audio/btp_bap_unicast.c
@@ -626,6 +626,8 @@ static void stream_started(struct bt_bap_stream *stream)
 {
 	struct btp_bap_unicast_stream *u_stream = stream_bap_to_unicast(stream);
 	struct bt_bap_ep_info info;
+	static uint8_t test_data[CONFIG_BT_ISO_TX_MTU];
+	uint16_t sdu;
 
 	/* Callback called on transition to Streaming state */
 
@@ -635,6 +637,14 @@ static void stream_started(struct bt_bap_stream *stream)
 
 	(void)bt_bap_ep_get_info(stream->ep, &info);
 	btp_send_ascs_ase_state_changed_ev(stream->conn, u_stream->ase_id, info.state);
+
+	/* Send test data after entering streaming state. For now this seems to
+	 * be required by PTS as there is not Upper Tester action for this in
+	 * Test Specification
+	 */
+	memset(test_data, 42, sizeof(test_data));
+	sdu = MIN(stream->qos->sdu, sizeof(test_data));
+	btp_bap_audio_stream_send_data(test_data, sdu);
 }
 
 static void stream_connected(struct bt_bap_stream *stream)


### PR DESCRIPTION
For now this seems to be required by PTS as there is not Upper Tester
action for this in Test Specification.

This is affecting few BAP/USR/STR qualifications tests

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/79059
