### PR TITLE
display: add display_show

### DIFF
--- a/doc/releases/release-notes-4.1.rst
+++ b/doc/releases/release-notes-4.1.rst
@@ -92,6 +92,10 @@ Drivers and Sensors
 
 * Display
 
+  * Added API function :c:func:`display_show` and display capability
+    :c:enum:`SCREEN_INFO_REQUIRES_SHOW` for displays that allow tearing prevention of segmented
+    updates. (:github:`79936`)
+
 * Ethernet
 
 * Flash

--- a/doc/releases/release-notes-4.1.rst
+++ b/doc/releases/release-notes-4.1.rst
@@ -282,6 +282,9 @@ Trusted Firmware-M
 LVGL
 ****
 
+* Added support for displays with the capability :c:enum:`SCREEN_INFO_REQUIRES_SHOW`.
+  (:github:`79936`)
+
 Tests and Samples
 *****************
 

--- a/doc/releases/release-notes-4.1.rst
+++ b/doc/releases/release-notes-4.1.rst
@@ -95,6 +95,8 @@ Drivers and Sensors
   * Added API function :c:func:`display_show` and display capability
     :c:enum:`SCREEN_INFO_REQUIRES_SHOW` for displays that allow tearing prevention of segmented
     updates. (:github:`79936`)
+  * Implemented :c:func:`display_show` for SDL display driver (:dtcompatible:`zephyr,sdl-dc`)
+    and added display capability :c:enum:`SCREEN_INFO_REQUIRES_SHOW`. (:github:`79936`)
 
 * Ethernet
 

--- a/drivers/display/display_dummy.c
+++ b/drivers/display/display_dummy.c
@@ -57,6 +57,11 @@ static int dummy_display_write(const struct device *dev, const uint16_t x,
 	return 0;
 }
 
+static int dummy_display_show(const struct device *dev)
+{
+	return 0;
+}
+
 static int dummy_display_blanking_off(const struct device *dev)
 {
 	return 0;
@@ -93,8 +98,8 @@ static void dummy_display_get_capabilities(const struct device *dev,
 		PIXEL_FORMAT_MONO01 |
 		PIXEL_FORMAT_MONO10;
 	capabilities->current_pixel_format = disp_data->current_pixel_format;
-	capabilities->screen_info = SCREEN_INFO_MONO_VTILED |
-		SCREEN_INFO_MONO_MSB_FIRST;
+	capabilities->screen_info =
+		SCREEN_INFO_MONO_VTILED | SCREEN_INFO_MONO_MSB_FIRST | SCREEN_INFO_REQUIRES_SHOW;
 }
 
 static int dummy_display_set_pixel_format(const struct device *dev,
@@ -110,6 +115,7 @@ static const struct display_driver_api dummy_display_api = {
 	.blanking_on = dummy_display_blanking_on,
 	.blanking_off = dummy_display_blanking_off,
 	.write = dummy_display_write,
+	.show = dummy_display_show,
 	.set_brightness = dummy_display_set_brightness,
 	.set_contrast = dummy_display_set_contrast,
 	.get_capabilities = dummy_display_get_capabilities,

--- a/drivers/display/display_sdl_bottom.h
+++ b/drivers/display/display_sdl_bottom.h
@@ -23,16 +23,15 @@ extern "C" {
 int sdl_display_init_bottom(uint16_t height, uint16_t width, uint16_t zoom_pct,
 			    bool use_accelerator, void **window, void **renderer, void **mutex,
 			    void **texture, void **read_texture);
-void sdl_display_write_bottom(const uint16_t height, const uint16_t width,
-			      const uint16_t x, const uint16_t y,
-			      void *renderer, void *mutex, void *texture,
-			      uint8_t *buf, bool display_on);
-int sdl_display_read_bottom(const uint16_t height, const uint16_t width,
-			    const uint16_t x, const uint16_t y,
-			    void *renderer, void *buf, uint16_t pitch,
-			    void *mutex, void *texture, void **read_texture);
-void sdl_display_blanking_off_bottom(void *renderer, void *texture);
-void sdl_display_blanking_on_bottom(void *renderer);
+void sdl_display_write_bottom(const uint16_t height, const uint16_t width, const uint16_t x,
+			      const uint16_t y, void *renderer, void *mutex, void *texture,
+			      uint8_t *buf);
+void sdl_display_show_bottom(void *renderer, void *texture, void *mutex, bool display_on);
+int sdl_display_read_bottom(const uint16_t height, const uint16_t width, const uint16_t x,
+			    const uint16_t y, void *renderer, void *buf, uint16_t pitch,
+			    void *mutex, void *texture, void *read_texture);
+void sdl_display_blanking_off_bottom(void *renderer, void *texture, void *mutex);
+void sdl_display_blanking_on_bottom(void *renderer, void *mutex);
 void sdl_display_cleanup_bottom(void **window, void **renderer, void **mutex, void **texture,
 				void **read_texture);
 

--- a/modules/lvgl/Kconfig
+++ b/modules/lvgl/Kconfig
@@ -102,6 +102,7 @@ config LV_Z_FLUSH_THREAD_STACK_SIZE
 	default 1024
 	help
 	  Stack size for LVGL flush thread, which will call display_write
+	  and display_show
 
 config LV_Z_FLUSH_THREAD_PRIO
 	int "LVGL flush thread priority"

--- a/modules/lvgl/lvgl_display_mono.c
+++ b/modules/lvgl/lvgl_display_mono.c
@@ -48,6 +48,10 @@ void lvgl_flush_cb_mono(lv_disp_drv_t *disp_drv, const lv_area_t *area, lv_color
 	}
 
 	lv_disp_flush_ready(disp_drv);
+
+	if (is_last && (data->cap.screen_info & SCREEN_INFO_REQUIRES_SHOW)) {
+		display_show(display_dev);
+	}
 }
 
 void lvgl_set_px_cb_mono(lv_disp_drv_t *disp_drv, uint8_t *buf, lv_coord_t buf_w, lv_coord_t x,

--- a/samples/drivers/display/src/main.c
+++ b/samples/drivers/display/src/main.c
@@ -328,6 +328,14 @@ int main(void)
 	y = capabilities.y_resolution - rect_h;
 	display_write(display_dev, x, y, &buf_desc, buf);
 
+	if (capabilities.screen_info & SCREEN_INFO_REQUIRES_SHOW) {
+		/*
+		 * If the screen implements some kind of pixel buffering,
+		 * tell it that we are done with rendering and it should
+		 * now show the updated image.
+		 */
+		display_show(display_dev);
+	}
 	display_blanking_off(display_dev);
 
 	grey_count = 0;
@@ -336,9 +344,14 @@ int main(void)
 
 	while (1) {
 		fill_buffer_fnc(BOTTOM_LEFT, grey_count, buf, buf_size);
+
 		display_write(display_dev, x, y, &buf_desc, buf);
-		++grey_count;
+		if (capabilities.screen_info & SCREEN_INFO_REQUIRES_SHOW) {
+			display_show(display_dev);
+		}
 		k_msleep(grey_scale_sleep);
+
+		++grey_count;
 #if CONFIG_TEST
 		if (grey_count >= 1024) {
 			break;


### PR DESCRIPTION
Fixes https://github.com/zephyrproject-rtos/zephyr/issues/79798.

Indicates to the display that all previous writes should be flushed to the display.

This adds support for display drivers that internally contain a double-buffering or latching mechanism.
Currently the only way to implement those displays is to present all `write`s to the user immediately, which could cause tearing artifacts for multi-write renders. (it's quite common for UI managers to render to partial framebuffers in low-memory situations. LVGL, for example, recommends 1/10th of the screen size)

Open questions:
- Name of the 'end-of-frame' display driver api function?
  - `display_show` (current PR code)
  -  `display_present` (could be confused with "display is present")
  - `display_flush` (sounds like it's optional)
  - `display_finalize_frame` (might be a little too verbose)
  - `display_flip` (probably not because could be confused with x or y pixel order setting, like, 'flipping' the image)
  - `display_pageflip` (might be too usecase specific)
