### PR TITLE
manifest: hostap: Pull in changes for mbedtls CFLAGS

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -259,7 +259,7 @@ manifest:
         - hal
     - name: hostap
       path: modules/lib/hostap
-      revision: 7c32520564908e1220976b6c185dec296b6d4a80
+      revision: pull/54/head
     - name: libmetal
       revision: a6851ba6dba8c9e87d00c42f171a822f7a29639b
       path: modules/hal/libmetal


### PR DESCRIPTION
Pull in changes done to resolve conflict between CFLAGS used for mbedtls and hostap.