### PR TITLE
drivers: usb_c: numaker: update UTCPD.VBSCALE register field

### DIFF
--- a/drivers/usb_c/tcpc/ucpd_numaker.c
+++ b/drivers/usb_c/tcpc/ucpd_numaker.c
@@ -2374,21 +2374,17 @@ static const struct tcpc_driver_api numaker_tcpc_driver_api = {
 								   : 0)
 
 /* UTCPD.VBVOL.VBSCALE cast */
-#define NUMAKER_UTCPD_VBUS_DIVIDE_CAST(inst) NUMAKER_UTCPD_VBUS_DIVIDE_CAST_NO_DIVIDE(inst)
-/* no_divide */
-#define NUMAKER_UTCPD_VBUS_DIVIDE_CAST_NO_DIVIDE(inst)                                             \
-	COND_CODE_1(DT_ENUM_HAS_VALUE(DT_DRV_INST(inst), vbus_divide, no_divice),                  \
-		    ({.bit = (0 << UTCPD_VBVOL_VBSCALE_Pos), .value = 1}),                         \
+#define NUMAKER_UTCPD_VBUS_DIVIDE_CAST(inst) NUMAKER_UTCPD_VBUS_DIVIDE_CAST_DIVIDE_20(inst)
+/* divide_20 */
+#define NUMAKER_UTCPD_VBUS_DIVIDE_CAST_DIVIDE_20(inst)                                             \
+	COND_CODE_1(DT_ENUM_HAS_VALUE(DT_DRV_INST(inst), vbus_divide, divide_20),                  \
+		    ({.bit = (0 << UTCPD_VBVOL_VBSCALE_Pos), .value = 20}),                        \
 		    (NUMAKER_UTCPD_VBUS_DIVIDE_CAST_DIVIDE_10(inst)))
 /* divide_10 */
 #define NUMAKER_UTCPD_VBUS_DIVIDE_CAST_DIVIDE_10(inst)                                             \
 	COND_CODE_1(DT_ENUM_HAS_VALUE(DT_DRV_INST(inst), vbus_divide, divide_10),                  \
 		    ({.bit = (1 << UTCPD_VBVOL_VBSCALE_Pos), .value = 10}),                        \
-		    (NUMAKER_UTCPD_VBUS_DIVIDE_CAST_DIVIDE_20(inst)))
-/* divide_20 */
-#define NUMAKER_UTCPD_VBUS_DIVIDE_CAST_DIVIDE_20(inst)                                             \
-	COND_CODE_1(DT_ENUM_HAS_VALUE(DT_DRV_INST(inst), vbus_divide, divide_20),                  \
-		    ({.bit = (2 << UTCPD_VBVOL_VBSCALE_Pos), .value = 20}), (no_divide error))
+		    (vbus-divide error))
 
 /* UTCPD.PINPL */
 #define NUMAKER_UTCPD_PINPL_INIT(inst)                                                             \

--- a/dts/bindings/tcpc/nuvoton,numaker-tcpc.yaml
+++ b/dts/bindings/tcpc/nuvoton,numaker-tcpc.yaml
@@ -96,11 +96,16 @@ properties:
     type: string
     required: true
     description: |
-      VBUS measurement divider
+      VBUS measurement divider:
+      "divide-20": External VBUS voltage divider circuit should be 1/20
+                   for EPR application. The divided voltage compares with
+                   200mV to set or clean VBUS Present bit.
+      "divide-10": External VBUS voltage divider circuit should be 1/10
+                   for SPR application. The divided voltage compares with
+                   400mV to set or clean VBUS Present bit.
     enum:
-      - "no-divide"
-      - "divide-10"
       - "divide-20"
+      - "divide-10"
 
   dead-battery:
     type: boolean


### PR DESCRIPTION
For nuvoton numaker soc series, this follows update of `UTCPD.VBSCALE` register field. It supports:
- "divide-20": External VBUS voltage divider circuit should be 1/20 for EPR application. The divided voltage compares with 200mV to set or clean VBUS Present bit.
- "divide-10": External VBUS voltage divider circuit should be 1/10 for SPR application. The divided voltage compares with 400mV to set or clean VBUS Present bit.
