### PR TITLE
include: posix: update path of posix_types.h for CONFIG_POSIX_API=n

### DIFF
--- a/include/zephyr/posix/sys/select.h
+++ b/include/zephyr/posix/sys/select.h
@@ -6,7 +6,7 @@
 #ifndef ZEPHYR_INCLUDE_POSIX_SYS_SELECT_H_
 #define ZEPHYR_INCLUDE_POSIX_SYS_SELECT_H_
 
-#include "posix_types.h"
+#include "../posix_types.h"
 
 #include <zephyr/sys/fdtable.h>
 


### PR DESCRIPTION
According to `lib/posix/options/CMakeLists.txt`, `include/zephyr/posix/` isn't in the include path when `CONFIG_POSIX_API` isn't selected.

Update the include to relative path so that it works universally.

`CONFIG_POSIX_API=n`:
```
$ west build -p -b m2gl025_miv zephyr/tests/posix/headers -T portability.posix.headers.without_posix_api
-- west build: making build dir /home/ycsin/zephyrproject/build pristine
-- west build: generating a build system
Loading Zephyr default modules (Zephyr base).
-- Application: /home/ycsin/zephyrproject/zephyr/tests/posix/headers
-- CMake version: 3.30.2
-- Found Python3: /home/ycsin/zephyrproject/.venv/bin/python3 (found suitable version "3.12.3", minimum required is "3.10") found components: Interpreter
-- Cache files will be written to: /home/ycsin/.cache/zephyr
-- Zephyr version: 3.7.99 (/home/ycsin/zephyrproject/zephyr)
-- Found west (found suitable version "1.2.0", minimum required is "0.14.0")
-- Board: m2gl025_miv, qualifiers: miv
-- ZEPHYR_TOOLCHAIN_VARIANT not set, trying to locate Zephyr SDK
-- Found host-tools: zephyr 0.16.8 (/home/ycsin/zephyr-sdk-0.16.8)
-- Found toolchain: zephyr 0.16.8 (/home/ycsin/zephyr-sdk-0.16.8)
-- Found Dtc: /home/ycsin/zephyr-sdk-0.16.8/sysroots/x86_64-pokysdk-linux/usr/bin/dtc (found suitable version "1.6.0", minimum required is "1.4.6")
-- Found BOARD.dts: /home/ycsin/zephyrproject/zephyr/boards/microchip/m2gl025_miv/m2gl025_miv.dts
-- Generated zephyr.dts: /home/ycsin/zephyrproject/build/zephyr/zephyr.dts
-- Generated pickled edt: /home/ycsin/zephyrproject/build/zephyr/edt.pickle
-- Generated zephyr.dts: /home/ycsin/zephyrproject/build/zephyr/zephyr.dts
-- Generated devicetree_generated.h: /home/ycsin/zephyrproject/build/zephyr/include/generated/zephyr/devicetree_generated.h
-- Including generated dts.cmake file: /home/ycsin/zephyrproject/build/zephyr/dts.cmake
Parsing /home/ycsin/zephyrproject/zephyr/Kconfig
Loaded configuration '/home/ycsin/zephyrproject/zephyr/boards/microchip/m2gl025_miv/m2gl025_miv_defconfig'
Merged configuration '/home/ycsin/zephyrproject/zephyr/tests/posix/headers/prj.conf'
Merged configuration '/home/ycsin/zephyrproject/build/zephyr/misc/generated/extra_kconfig_options.conf'
Configuration saved to '/home/ycsin/zephyrproject/build/zephyr/.config'
Kconfig header saved to '/home/ycsin/zephyrproject/build/zephyr/include/generated/zephyr/autoconf.h'
-- Found GnuLd: /home/ycsin/zephyr-sdk-0.16.8/riscv64-zephyr-elf/riscv64-zephyr-elf/bin/ld.bfd (found version "2.38")
-- The C compiler identification is GNU 12.2.0
-- The CXX compiler identification is GNU 12.2.0
-- The ASM compiler identification is GNU
-- Found assembler: /home/ycsin/zephyr-sdk-0.16.8/riscv64-zephyr-elf/bin/riscv64-zephyr-elf-gcc
CMake Warning at /home/ycsin/zephyrproject/zephyr/subsys/random/CMakeLists.txt:12 (message):
  

      Warning: CONFIG_TIMER_RANDOM_GENERATOR and CONFIG_TEST_CSPRNG_GENERATOR are
      not truly random generators. This capability is not secure and it is
      provided for testing purposes only. Use it carefully.


-- Setting build type to 'MinSizeRel' as none was specified.
-- Using ccache: /usr/bin/ccache
CMake Warning at /home/ycsin/zephyrproject/zephyr/CMakeLists.txt:953 (message):
  No SOURCES given to Zephyr library: drivers__entropy

  Excluding target from build.


-- Configuring done (3.7s)
-- Generating done (0.1s)
-- Build files have been written to: /home/ycsin/zephyrproject/build
-- west build: building application
[1/194] Preparing syscall dependency handling

[3/194] Generating include/generated/zephyr/version.h
-- Zephyr version: 3.7.99 (/home/ycsin/zephyrproject/zephyr), build: v3.7.0-4579-g34e92c15900c
[194/194] Linking C executable zephyr/zephyr.elf
Memory region         Used Size  Region Size  %age Used
             ROM:      126104 B       256 KB     48.10%
             RAM:       22624 B       256 KB      8.63%
        IDT_LIST:          0 GB         2 KB      0.00%
Generating files from /home/ycsin/zephyrproject/build/zephyr/zephyr.elf for board: m2gl025_miv
```

`CONFIG_POSIX_API=y`:
```
$ west build -p -b thingy53/nrf5340/cpuapp/ns zephyr/tests/posix/net/ -T portability.posix.net.newlib
-- west build: making build dir /home/ycsin/zephyrproject/build pristine
-- west build: generating a build system
Loading Zephyr default modules (Zephyr base).
-- Application: /home/ycsin/zephyrproject/zephyr/tests/posix/net
-- CMake version: 3.30.2
-- Found Python3: /home/ycsin/zephyrproject/.venv/bin/python3 (found suitable version "3.12.3", minimum required is "3.10") found components: Interpreter
-- Cache files will be written to: /home/ycsin/.cache/zephyr
-- Zephyr version: 3.7.99 (/home/ycsin/zephyrproject/zephyr)
-- Found west (found suitable version "1.2.0", minimum required is "0.14.0")
-- Board: thingy53, qualifiers: nrf5340/cpuapp/ns
-- ZEPHYR_TOOLCHAIN_VARIANT not set, trying to locate Zephyr SDK
-- Found host-tools: zephyr 0.16.8 (/home/ycsin/zephyr-sdk-0.16.8)
-- Found toolchain: zephyr 0.16.8 (/home/ycsin/zephyr-sdk-0.16.8)
-- Found Dtc: /home/ycsin/zephyr-sdk-0.16.8/sysroots/x86_64-pokysdk-linux/usr/bin/dtc (found suitable version "1.6.0", minimum required is "1.4.6")
-- Found BOARD.dts: /home/ycsin/zephyrproject/zephyr/boards/nordic/thingy53/thingy53_nrf5340_cpuapp_ns.dts
-- Generated zephyr.dts: /home/ycsin/zephyrproject/build/zephyr/zephyr.dts
-- Generated pickled edt: /home/ycsin/zephyrproject/build/zephyr/edt.pickle
-- Generated zephyr.dts: /home/ycsin/zephyrproject/build/zephyr/zephyr.dts
-- Generated devicetree_generated.h: /home/ycsin/zephyrproject/build/zephyr/include/generated/zephyr/devicetree_generated.h
-- Including generated dts.cmake file: /home/ycsin/zephyrproject/build/zephyr/dts.cmake
Parsing /home/ycsin/zephyrproject/zephyr/Kconfig
Loaded configuration '/home/ycsin/zephyrproject/zephyr/boards/nordic/thingy53/thingy53_nrf5340_cpuapp_ns_defconfig'
Merged configuration '/home/ycsin/zephyrproject/zephyr/tests/posix/net/prj.conf'
Merged configuration '/home/ycsin/zephyrproject/build/zephyr/misc/generated/extra_kconfig_options.conf'
Configuration saved to '/home/ycsin/zephyrproject/build/zephyr/.config'
Kconfig header saved to '/home/ycsin/zephyrproject/build/zephyr/include/generated/zephyr/autoconf.h'
-- Found GnuLd: /home/ycsin/zephyr-sdk-0.16.8/arm-zephyr-eabi/arm-zephyr-eabi/bin/ld.bfd (found version "2.38")
-- The C compiler identification is GNU 12.2.0
-- The CXX compiler identification is GNU 12.2.0
-- The ASM compiler identification is GNU
-- Found assembler: /home/ycsin/zephyr-sdk-0.16.8/arm-zephyr-eabi/bin/arm-zephyr-eabi-gcc
-- Setting build type to 'MinSizeRel' as none was specified.
-- Using ccache: /usr/bin/ccache
CMake Warning at /home/ycsin/zephyrproject/zephyr/modules/trusted-firmware-m/CMakeLists.txt:527 (message):
  TFM_DUMMY_PROVISIONING is enabled:

        The device will be provisioned using dummy keys and is NOT secure!
        This is not suitable for production


-- Configuring done (3.8s)
-- Generating done (0.1s)
-- Build files have been written to: /home/ycsin/zephyrproject/build
-- west build: building application
[1/370] Preparing syscall dependency handling

[3/370] Generating include/generated/zephyr/version.h
-- Zephyr version: 3.7.99 (/home/ycsin/zephyrproject/zephyr), build: v3.7.0-4579-g34e92c15900c
[8/370] Generating ../../tfm/CMakeCache.txt
-- Found Git: /usr/bin/git (found version "2.43.0")
-- The C compiler identification is GNU 12.2.0
-- The CXX compiler identification is GNU 12.2.0
-- The ASM compiler identification is GNU
-- Found assembler: /home/ycsin/zephyr-sdk-0.16.8/arm-zephyr-eabi/bin/arm-zephyr-eabi-gcc
-- Found Python3: /home/ycsin/zephyrproject/.venv/bin/python3 (found version "3.12.3") found components: Interpreter
CMake Warning (dev) at /usr/share/cmake-3.30/Modules/GNUInstallDirs.cmake:253 (message):
  Unable to determine default CMAKE_INSTALL_LIBDIR directory because no
  target architecture is known.  Please enable at least one language before
  including GNUInstallDirs.
Call Stack (most recent call first):
  /home/ycsin/zephyrproject/modules/crypto/mbedtls/CMakeLists.txt:52 (include)
This warning is for project developers.  Use -Wno-dev to suppress it.

-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Failed
-- Check if compiler accepts -pthread
-- Check if compiler accepts -pthread - no
-- Looking for pthread_create in pthreads
-- Looking for pthread_create in pthreads - not found
-- Looking for pthread_create in pthread
-- Looking for pthread_create in pthread - not found
-- Could NOT find Threads (missing: Threads_FOUND) 
-- Performing Test C_COMPILER_SUPPORTS_WFORMAT_SIGNEDNESS
-- Performing Test C_COMPILER_SUPPORTS_WFORMAT_SIGNEDNESS - Failed
-- Could NOT find Threads (missing: Threads_FOUND) 
-- Configuring done (1.6s)
-- Generating done (0.1s)
-- Build files have been written to: /home/ycsin/zephyrproject/build/tfm
[13/370] Performing build step for 'tfm'
[367/376] Linking C executable bin/bl2.axf
Memory region         Used Size  Region Size  %age Used
           FLASH:       17752 B        64 KB     27.09%
             RAM:       23424 B       512 KB      4.47%
[371/376] Linking C executable bin/tfm_s.axf
Memory region         Used Size  Region Size  %age Used
           FLASH:      129312 B       254 KB     49.72%
             RAM:       50208 B       256 KB     19.15%
[376/376] Generating tfm_s_signed.bin
image.py: sign the payload
[15/370] Performing install step for 'tfm'
-- Install configuration: "MinSizeRel"
-- Installing: /home/ycsin/zephyrproject/build/tfm/api_ns/interface/include/tfm_ioctl_core_api.h
...
-- Installing: /home/ycsin/zephyrproject/build/tfm/api_ns/cmake/set_extensions.cmake
[370/370] Linking C executable zephyr/zephyr.elf
Memory region         Used Size  Region Size  %age Used
           FLASH:      163352 B       192 KB     83.09%
             RAM:       33512 B       192 KB     17.05%
        IDT_LIST:          0 GB        32 KB      0.00%
Generating files from /home/ycsin/zephyrproject/build/zephyr/zephyr.elf for board: thingy53
image.py: sign the payload
image.py: sign the payload
```