### PR TITLE
include: posix: fix path reference to posix header files

### DIFF
--- a/include/zephyr/posix/dirent.h
+++ b/include/zephyr/posix/dirent.h
@@ -7,7 +7,7 @@
 #define ZEPHYR_INCLUDE_POSIX_DIRENT_H_
 
 #include <limits.h>
-#include "posix_types.h"
+#include <zephyr/posix/posix_types.h>
 
 #ifdef CONFIG_POSIX_FILE_SYSTEM
 #include <zephyr/fs/fs.h>

--- a/include/zephyr/posix/mqueue.h
+++ b/include/zephyr/posix/mqueue.h
@@ -12,7 +12,7 @@
 #include <zephyr/posix/fcntl.h>
 #include <zephyr/posix/signal.h>
 #include <zephyr/posix/sys/stat.h>
-#include "posix_types.h"
+#include <zephyr/posix/posix_types.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/zephyr/posix/sched.h
+++ b/include/zephyr/posix/sched.h
@@ -8,7 +8,7 @@
 
 #include <zephyr/kernel.h>
 
-#include "posix_types.h"
+#include <zephyr/posix/posix_types.h>
 
 #include <time.h>
 

--- a/include/zephyr/posix/semaphore.h
+++ b/include/zephyr/posix/semaphore.h
@@ -7,7 +7,7 @@
 #define ZEPHYR_INCLUDE_POSIX_SEMAPHORE_H_
 
 #include <zephyr/posix/time.h>
-#include "posix_types.h"
+#include <zephyr/posix/posix_types.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/zephyr/posix/signal.h
+++ b/include/zephyr/posix/signal.h
@@ -6,8 +6,8 @@
 #ifndef ZEPHYR_INCLUDE_POSIX_SIGNAL_H_
 #define ZEPHYR_INCLUDE_POSIX_SIGNAL_H_
 
-#include "posix_types.h"
-#include "posix_features.h"
+#include <zephyr/posix/posix_types.h>
+#include <zephyr/posix/posix_features.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/zephyr/posix/sys/select.h
+++ b/include/zephyr/posix/sys/select.h
@@ -6,7 +6,7 @@
 #ifndef ZEPHYR_INCLUDE_POSIX_SYS_SELECT_H_
 #define ZEPHYR_INCLUDE_POSIX_SYS_SELECT_H_
 
-#include "posix_types.h"
+#include <zephyr/posix/posix_types.h>
 
 #include <zephyr/sys/fdtable.h>
 

--- a/include/zephyr/posix/time.h
+++ b/include/zephyr/posix/time.h
@@ -58,7 +58,7 @@ struct itimerspec {
 
 #include <zephyr/kernel.h>
 #include <errno.h>
-#include "posix_types.h"
+#include <zephyr/posix/posix_types.h>
 #include <zephyr/posix/signal.h>
 
 #ifdef __cplusplus

--- a/include/zephyr/posix/unistd.h
+++ b/include/zephyr/posix/unistd.h
@@ -6,7 +6,7 @@
 #ifndef ZEPHYR_INCLUDE_POSIX_UNISTD_H_
 #define ZEPHYR_INCLUDE_POSIX_UNISTD_H_
 
-#include "posix_types.h"
+#include <zephyr/posix/posix_types.h>
 
 #ifdef CONFIG_POSIX_API
 #include <zephyr/fs/fs.h>
@@ -20,7 +20,7 @@
 #include <zephyr/posix/sys/stat.h>
 #include <zephyr/posix/sys/sysconf.h>
 
-#include "posix_features.h"
+#include <zephyr/posix/posix_features.h>
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
If CONFIG_POSIX_API is not set, the include path to zephyr\posix is specified to the compiler. The posix_types.h and posix_features.h inclusion was not fully qualified resulting in a build error.

Fixes #79961