### PR TITLE
manifest: hostap: Pull build configuration checks in crypto_alt

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -259,7 +259,7 @@ manifest:
         - hal
     - name: hostap
       path: modules/lib/hostap
-      revision: 7c32520564908e1220976b6c185dec296b6d4a80
+      revision: pull/55/head
     - name: libmetal
       revision: a6851ba6dba8c9e87d00c42f171a822f7a29639b
       path: modules/hal/libmetal


### PR DESCRIPTION
This pulls in configuration checks that are added in crypto_mbedtls_alt.c, supp_psa_api.c and tls_mbedtls_alt.c. It also pulls in hmac_prf256 PSA API invocation for sha256_prf_bits API.