### PR TITLE
doc: boards: extensions: board catalog is only available in HTML

### DIFF
--- a/doc/_extensions/zephyr/domain/__init__.py
+++ b/doc/_extensions/zephyr/domain/__init__.py
@@ -586,6 +586,8 @@ class BoardCatalogDirective(SphinxDirective):
             renderer = SphinxRenderer([TEMPLATES_DIR])
             rendered = renderer.render("board-catalog.html", {"catalog": board_catalog})
             return [nodes.raw("", rendered, format="html")]
+        else:
+            return [nodes.paragraph(text="Board catalog is only available in HTML.")]
 
 
 class ZephyrDomain(Domain):


### PR DESCRIPTION
Although boards/index.rst is not included in the PDF toc, it seems as if Sphinx tries to build the page anyway, which fails because the board catalog directive is not outputting any node on non-HTML builders.

This commit fixes it by returning a "Board catalog is only available in HTML." paragraph. In the future, we might want to output some kind of static table or bullet list for non-HTML builders.