### PR TITLE
boards: rpi: Fix selection of symbol

### DIFF
--- a/boards/adafruit/kb2040/Kconfig
+++ b/boards/adafruit/kb2040/Kconfig
@@ -1,0 +1,5 @@
+# Copyright (c) 2022 Peter Johanson
+# SPDX-License-Identifier: Apache-2.0
+
+config BOARD_ADAFRUIT_KB2040
+	select RP2_FLASH_W25Q080

--- a/boards/adafruit/kb2040/Kconfig.defconfig
+++ b/boards/adafruit/kb2040/Kconfig.defconfig
@@ -3,9 +3,6 @@
 
 if BOARD_ADAFRUIT_KB2040
 
-config RP2_FLASH_W25Q080
-	default y
-
 if I2C_DW
 
 config I2C_DW_CLOCK_SPEED

--- a/boards/adafruit/qt_py_rp2040/Kconfig
+++ b/boards/adafruit/qt_py_rp2040/Kconfig
@@ -1,0 +1,5 @@
+# Copyright (c) 2022 Peter Johanson
+# SPDX-License-Identifier: Apache-2.0
+
+config BOARD_ADAFRUIT_QT_PY_RP2040
+	select RP2_FLASH_W25Q080

--- a/boards/adafruit/qt_py_rp2040/Kconfig.defconfig
+++ b/boards/adafruit/qt_py_rp2040/Kconfig.defconfig
@@ -3,9 +3,6 @@
 
 if BOARD_ADAFRUIT_QT_PY_RP2040
 
-config RP2_FLASH_W25Q080
-	default y
-
 if I2C_DW
 
 config I2C_DW_CLOCK_SPEED

--- a/boards/raspberrypi/rpi_pico/Kconfig
+++ b/boards/raspberrypi/rpi_pico/Kconfig
@@ -1,0 +1,5 @@
+# Copyright (c) 2021 Yonatan Schachter
+# SPDX-License-Identifier: Apache-2.0
+
+config BOARD_RPI_PICO
+	select RP2_FLASH_W25Q080

--- a/boards/raspberrypi/rpi_pico/Kconfig.defconfig
+++ b/boards/raspberrypi/rpi_pico/Kconfig.defconfig
@@ -3,9 +3,6 @@
 
 if BOARD_RPI_PICO
 
-config RP2_FLASH_W25Q080
-	default y
-
 if I2C_DW
 
 config I2C_DW_CLOCK_SPEED

--- a/boards/seeed/xiao_rp2040/Kconfig
+++ b/boards/seeed/xiao_rp2040/Kconfig
@@ -1,0 +1,5 @@
+# Copyright (c) 2023 Seeed Studio inc.
+# SPDX-License-Identifier: Apache-2.0
+
+config BOARD_XIAO_RP2040
+	select RP2_FLASH_W25Q080

--- a/boards/seeed/xiao_rp2040/Kconfig.defconfig
+++ b/boards/seeed/xiao_rp2040/Kconfig.defconfig
@@ -3,9 +3,6 @@
 
 if BOARD_XIAO_RP2040
 
-config RP2_FLASH_W25Q080
-	default y
-
 if I2C_DW
 
 config I2C_DW_CLOCK_SPEED

--- a/boards/sparkfun/pro_micro_rp2040/Kconfig
+++ b/boards/sparkfun/pro_micro_rp2040/Kconfig
@@ -1,0 +1,5 @@
+# Copyright (c) 2021 Pete Johanson
+# SPDX-License-Identifier: Apache-2.0
+
+config BOARD_SPARKFUN_PRO_MICRO_RP2040
+	select RP2_FLASH_W25Q080

--- a/boards/sparkfun/pro_micro_rp2040/Kconfig.defconfig
+++ b/boards/sparkfun/pro_micro_rp2040/Kconfig.defconfig
@@ -3,9 +3,6 @@
 
 if BOARD_SPARKFUN_PRO_MICRO_RP2040
 
-config RP2_FLASH_W25Q080
-	default y
-
 if I2C_DW
 
 config I2C_DW_CLOCK_SPEED

--- a/boards/wiznet/w5500_evb_pico/Kconfig
+++ b/boards/wiznet/w5500_evb_pico/Kconfig
@@ -1,0 +1,6 @@
+# Copyright (c) 2021 Yonatan Schachter
+# Copyright (c) 2023 Ian Wakely
+# SPDX-License-Identifier: Apache-2.0
+
+config BOARD_W5500_EVB_PICO
+	select RP2_FLASH_W25Q080

--- a/boards/wiznet/w5500_evb_pico/Kconfig.defconfig
+++ b/boards/wiznet/w5500_evb_pico/Kconfig.defconfig
@@ -4,9 +4,6 @@
 
 if BOARD_W5500_EVB_PICO
 
-config RP2_FLASH_W25Q080
-	default y
-
 if NETWORKING
 
 config NET_L2_ETHERNET


### PR DESCRIPTION
Fixes selection of a symbol that was done in a defconfig file, when actually it should be done in a Kconfig file as a dependency for the board