### PR TITLE
doc: Use EXTRA_CONF_FILE in .rst/.md files

### DIFF
--- a/boards/shields/arduino_uno_click/doc/index.rst
+++ b/boards/shields/arduino_uno_click/doc/index.rst
@@ -45,7 +45,7 @@ other mikroBUS shields. For example:
    :zephyr-app: samples/net/sockets/echo_server
    :host-os: unix
    :board: sam_v71_xult/samv71q21
-   :gen-args: -DOVERLAY_CONFIG=overlay-802154.conf
+   :gen-args: -DEXTRA_CONF_FILE=overlay-802154.conf
    :shield: arduino_uno_click,atmel_rf2xx_mikrobus
    :goals: build
 

--- a/boards/shields/atmel_rf2xx/doc/index.rst
+++ b/boards/shields/atmel_rf2xx/doc/index.rst
@@ -295,7 +295,7 @@ Set ``--shield <shield designator>`` when you invoke ``west build``.
    :zephyr-app: samples/net/sockets/echo_server
    :host-os: unix
    :board: sam4s_xplained
-   :gen-args: -DOVERLAY_CONFIG=overlay-802154.conf
+   :gen-args: -DEXTRA_CONF_FILE=overlay-802154.conf
    :shield: atmel_rf2xx_xplained
    :goals: build flash
    :compact:
@@ -304,7 +304,7 @@ Set ``--shield <shield designator>`` when you invoke ``west build``.
    :zephyr-app: samples/net/sockets/echo_server
    :host-os: unix
    :board: [sam4e_xpro | sam_v71_xult/samv71q21]
-   :gen-args: -DOVERLAY_CONFIG=overlay-802154.conf
+   :gen-args: -DEXTRA_CONF_FILE=overlay-802154.conf
    :shield: [atmel_rf2xx_xpro | atmel_rf2xx_legacy]
    :goals: build flash
    :compact:
@@ -313,7 +313,7 @@ Set ``--shield <shield designator>`` when you invoke ``west build``.
    :zephyr-app: samples/net/sockets/echo_server
    :host-os: unix
    :board: [sam_v71_xult/samv71q21 | frdm_k64f | nucleo_f767zi]
-   :gen-args: -DOVERLAY_CONFIG=overlay-802154.conf
+   :gen-args: -DEXTRA_CONF_FILE=overlay-802154.conf
    :shield: atmel_rf2xx_arduino
    :goals: build flash
    :compact:
@@ -322,7 +322,7 @@ Set ``--shield <shield designator>`` when you invoke ``west build``.
    :zephyr-app: samples/net/sockets/echo_server
    :host-os: unix
    :board: lpcxpresso55s69_ns
-   :gen-args: -DOVERLAY_CONFIG=overlay-802154.conf
+   :gen-args: -DEXTRA_CONF_FILE=overlay-802154.conf
    :shield: atmel_rf2xx_microbus
    :goals: build flash
    :compact:

--- a/doc/hardware/emulator/bus_emulators.rst
+++ b/doc/hardware/emulator/bus_emulators.rst
@@ -195,7 +195,7 @@ Here are some examples present in Zephyr:
       :zephyr-app: tests/drivers/eeprom/api
       :board: native_sim
       :goals: build
-      :gen-args: -DDTC_OVERLAY_FILE=at2x_emul.overlay -DOVERLAY_CONFIG=at2x_emul.conf
+      :gen-args: -DDTC_OVERLAY_FILE=at2x_emul.overlay -DEXTRA_CONF_FILE=at2x_emul.conf
 
 API Reference
 =============

--- a/samples/bluetooth/bap_broadcast_sink/README.rst
+++ b/samples/bluetooth/bap_broadcast_sink/README.rst
@@ -30,7 +30,7 @@ Building and Running
 ********************
 
 When building targeting an nrf52 series board with the Zephyr Bluetooth Controller,
-use ``-DOVERLAY_CONFIG=overlay-bt_ll_sw_split.conf`` to enable the required ISO
+use ``-DEXTRA_CONF_FILE=overlay-bt_ll_sw_split.conf`` to enable the required ISO
 feature support.
 
 Building for an nrf5340dk
@@ -77,4 +77,4 @@ Building for a simulated nrf52_bsim
    :zephyr-app: samples/bluetooth/bap_broadcast_sink/
    :board: nrf52_bsim
    :goals: build
-   :gen-args: -DOVERLAY_CONFIG=overlay-bt_ll_sw_split.conf
+   :gen-args: -DEXTRA_CONF_FILE=overlay-bt_ll_sw_split.conf

--- a/samples/bluetooth/bap_broadcast_source/README.rst
+++ b/samples/bluetooth/bap_broadcast_source/README.rst
@@ -29,7 +29,7 @@ Building and Running
 ********************
 
 When building targeting an nrf52 series board with the Zephyr Bluetooth Controller,
-use ``-DOVERLAY_CONFIG=overlay-bt_ll_sw_split.conf`` to enable the required ISO
+use ``-DEXTRA_CONF_FILE=overlay-bt_ll_sw_split.conf`` to enable the required ISO
 feature support.
 
 Building for an nrf5340dk
@@ -76,4 +76,4 @@ Building for a simulated nrf52_bsim
    :zephyr-app: samples/bluetooth/bap_broadcast_source/
    :board: nrf52_bsim
    :goals: build
-   :gen-args: -DOVERLAY_CONFIG=overlay-bt_ll_sw_split.conf
+   :gen-args: -DEXTRA_CONF_FILE=overlay-bt_ll_sw_split.conf

--- a/samples/bluetooth/bap_unicast_client/README.rst
+++ b/samples/bluetooth/bap_unicast_client/README.rst
@@ -25,7 +25,7 @@ Building and Running
 ********************
 
 When building targeting an nrf52 series board with the Zephyr Bluetooth Controller,
-use ``-DOVERLAY_CONFIG=overlay-bt_ll_sw_split.conf`` to enable the required ISO
+use ``-DEXTRA_CONF_FILE=overlay-bt_ll_sw_split.conf`` to enable the required ISO
 feature support.
 
 Building for an nrf52840dk
@@ -35,7 +35,7 @@ Building for an nrf52840dk
    :zephyr-app: samples/bluetooth/bap_unicast_client/
    :board: nrf52840dk/nrf52840
    :goals: build
-   :gen-args: -DOVERLAY_CONFIG=overlay-bt_ll_sw_split.conf
+   :gen-args: -DEXTRA_CONF_FILE=overlay-bt_ll_sw_split.conf
 
 Building for an nrf5340dk
 -------------------------
@@ -69,7 +69,7 @@ Similarly to how you would for real HW, you can do:
    :zephyr-app: samples/bluetooth/bap_unicast_client/
    :board: nrf52_bsim
    :goals: build
-   :gen-args: -DOVERLAY_CONFIG=overlay-bt_ll_sw_split.conf
+   :gen-args: -DEXTRA_CONF_FILE=overlay-bt_ll_sw_split.conf
 
 Note this will produce a Linux executable in :file:`./build/zephyr/zephyr.exe`.
 For more information, check :ref:`this board documentation <nrf52_bsim>`.

--- a/samples/bluetooth/bap_unicast_server/README.rst
+++ b/samples/bluetooth/bap_unicast_server/README.rst
@@ -25,7 +25,7 @@ Building and Running
 ********************
 
 When building targeting an nrf52 series board with the Zephyr Bluetooth Controller,
-use ``-DOVERLAY_CONFIG=overlay-bt_ll_sw_split.conf`` to enable the required ISO
+use ``-DEXTRA_CONF_FILE=overlay-bt_ll_sw_split.conf`` to enable the required ISO
 feature support.
 
 Building for an nrf52840dk
@@ -35,7 +35,7 @@ Building for an nrf52840dk
    :zephyr-app: samples/bluetooth/bap_unicast_server/
    :board: nrf52840dk/nrf52840
    :goals: build
-   :gen-args: -DOVERLAY_CONFIG=overlay-bt_ll_sw_split.conf
+   :gen-args: -DEXTRA_CONF_FILE=overlay-bt_ll_sw_split.conf
 
 Building for an nrf5340dk
 -------------------------
@@ -69,7 +69,7 @@ Similarly to how you would for real HW, you can do:
    :zephyr-app: samples/bluetooth/bap_unicast_server/
    :board: nrf52_bsim
    :goals: build
-   :gen-args: -DOVERLAY_CONFIG=overlay-bt_ll_sw_split.conf
+   :gen-args: -DEXTRA_CONF_FILE=overlay-bt_ll_sw_split.conf
 
 Note this will produce a Linux executable in :file:`./build/zephyr/zephyr.exe`.
 For more information, check :ref:`this board documentation <nrf52_bsim>`.

--- a/samples/bluetooth/cap_acceptor/README.rst
+++ b/samples/bluetooth/cap_acceptor/README.rst
@@ -25,7 +25,7 @@ Building and Running
 ********************
 
 When building targeting an nrf52 series board with the Zephyr Bluetooth Controller,
-use ``-DOVERLAY_CONFIG=overlay-bt_ll_sw_split.conf`` to enable the required ISO
+use ``-DEXTRA_CONF_FILE=overlay-bt_ll_sw_split.conf`` to enable the required ISO
 feature support.
 
 Building for an nrf5340dk
@@ -72,4 +72,4 @@ Building for a simulated nrf52_bsim
    :zephyr-app: samples/bluetooth/cap_acceptor/
    :board: nrf52_bsim
    :goals: build
-   :gen-args: -DOVERLAY_CONFIG=overlay-bt_ll_sw_split.conf
+   :gen-args: -DEXTRA_CONF_FILE=overlay-bt_ll_sw_split.conf

--- a/samples/bluetooth/cap_initiator/README.rst
+++ b/samples/bluetooth/cap_initiator/README.rst
@@ -25,7 +25,7 @@ Building and Running
 ********************
 
 When building targeting an nrf52 series board with the Zephyr Bluetooth Controller,
-use ``-DOVERLAY_CONFIG=overlay-bt_ll_sw_split.conf`` to enable the required ISO
+use ``-DEXTRA_CONF_FILE=overlay-bt_ll_sw_split.conf`` to enable the required ISO
 feature support.
 
 Building for an nrf5340dk
@@ -72,4 +72,4 @@ Building for a simulated nrf52_bsim
    :zephyr-app: samples/bluetooth/cap_initiator/
    :board: nrf52_bsim
    :goals: build
-   :gen-args: -DOVERLAY_CONFIG=overlay-bt_ll_sw_split.conf
+   :gen-args: -DEXTRA_CONF_FILE=overlay-bt_ll_sw_split.conf

--- a/samples/bluetooth/pbp_public_broadcast_sink/README.rst
+++ b/samples/bluetooth/pbp_public_broadcast_sink/README.rst
@@ -27,7 +27,7 @@ Building and Running
 ********************
 
 When building targeting an nrf52 series board with the Zephyr Bluetooth Controller,
-use ``-DOVERLAY_CONFIG=overlay-bt_ll_sw_split.conf`` to enable the required ISO
+use ``-DEXTRA_CONF_FILE=overlay-bt_ll_sw_split.conf`` to enable the required ISO
 feature support.
 
 Building for an nrf5340dk
@@ -74,4 +74,4 @@ Building for a simulated nrf52_bsim
    :zephyr-app: samples/bluetooth/pbp_public_broadcast_sink/
    :board: nrf52_bsim
    :goals: build
-   :gen-args: -DOVERLAY_CONFIG=overlay-bt_ll_sw_split.conf
+   :gen-args: -DEXTRA_CONF_FILE=overlay-bt_ll_sw_split.conf

--- a/samples/bluetooth/pbp_public_broadcast_source/README.rst
+++ b/samples/bluetooth/pbp_public_broadcast_source/README.rst
@@ -27,7 +27,7 @@ Building and Running
 ********************
 
 When building targeting an nrf52 series board with the Zephyr Bluetooth Controller,
-use ``-DOVERLAY_CONFIG=overlay-bt_ll_sw_split.conf`` to enable the required ISO
+use ``-DEXTRA_CONF_FILE=overlay-bt_ll_sw_split.conf`` to enable the required ISO
 feature support.
 
 Building for an nrf5340dk
@@ -74,4 +74,4 @@ Building for a simulated nrf52_bsim
    :zephyr-app: samples/bluetooth/pbp_public_broadcast_source/
    :board: nrf52_bsim
    :goals: build
-   :gen-args: -DOVERLAY_CONFIG=overlay-bt_ll_sw_split.conf
+   :gen-args: -DEXTRA_CONF_FILE=overlay-bt_ll_sw_split.conf

--- a/samples/subsys/shell/devmem_load/README.md
+++ b/samples/subsys/shell/devmem_load/README.md
@@ -20,7 +20,7 @@ west flash
 
 Building for boards without UART interrupt support:
 ```bash
-west build -b native_sim -- -DOVERLAY_CONFIG=prj_poll.conf  samples/subsys/shell/devmem_load
+west build -b native_sim -- -DEXTRA_CONF_FILE=prj_poll.conf  samples/subsys/shell/devmem_load
 ```
 ## Running
 After connecting to the UART console you should see the following output:


### PR DESCRIPTION
Use EXTRA_CONF_FILE in documentation .rst/.md files, that replaced deprecated OVERLAY_CONFIG since the Zephyr v3.4 release.