### PR TITLE
Expose tainted builds

### DIFF
--- a/doc/contribute/bin_blobs.rst
+++ b/doc/contribute/bin_blobs.rst
@@ -92,6 +92,7 @@ Tainting will be communicated to the user in the following manners:
 - The ``west spdx`` command will include the tainted status in its output
 - The kernel's default fatal error handler will also explicitly print out the
   kernel's tainted status
+- The boot banner prints the kernel's tainted status
 
 .. _bin-blobs-types:
 

--- a/doc/contribute/bin_blobs.rst
+++ b/doc/contribute/bin_blobs.rst
@@ -5,7 +5,7 @@ Binary Blobs
 
 In the context of an operating system that supports multiple architectures and
 many different IC families, some functionality may be unavailable without the
-help of executable code distributed in binary form.  Binary blobs (or blobs for
+help of executable code distributed in binary form. Binary blobs (or blobs for
 short) are files containing proprietary machine code or data in a binary format,
 e.g. without corresponding source code released under an OSI approved license.
 
@@ -47,7 +47,7 @@ Blobs are fetched from official third-party sources by the :ref:`west blobs
 
 The blobs themselves must be specified in the :ref:`module.yml
 <modules-bin-blobs>` files included in separate Zephyr :ref:`module repositories
-<modules>` maintained by their respective vendors.  This means that in order to
+<modules>` maintained by their respective vendors. This means that in order to
 include a reference to a binary blob to the upstream Zephyr distribution, a
 module repository must exist first or be created as part of the submission
 process.
@@ -104,7 +104,7 @@ The following binary blob types are acceptable in Zephyr:
   precompiled binary form, typically for SoC peripherals. An example could be an
   enablement library for a wireless peripheral
 * Firmware images: An image containing the executable code for a secondary
-  processor or CPU.  This can be full or partial (typically delta or patch data)
+  processor or CPU. This can be full or partial (typically delta or patch data)
   and is generally copied into RAM or flash memory by the main CPU. An example
   could be the firmware for the core running a Bluetooth LE Controller
 * Miscellaneous binary data files. An example could be pre-trained neural
@@ -158,7 +158,7 @@ Toolchain requirements
 ======================
 
 Precompiled library blobs must be in a data format which is compatible with and
-can be linked by a toolchain supported by the Zephyr Project.  This is required
+can be linked by a toolchain supported by the Zephyr Project. This is required
 for maintainability and usability. Use of such libraries may require special
 compiler and/or linker flags, however. For example, a porting layer may require
 special flags, or a static archive may require use of specific linker flags.

--- a/doc/contribute/bin_blobs.rst
+++ b/doc/contribute/bin_blobs.rst
@@ -152,7 +152,7 @@ blob requires the build system to provide.
   provided by Zephyr (or an RTOS in general), an implementation of an OS
   abstraction layer (aka porting layer) can be provided alongside the library.
   The implementation of this OS abstraction layer must be in source code form,
-  released under an OSI approved license and documented using Doxygen
+  released under an OSI approved license and documented using Doxygen.
 
 Toolchain requirements
 ======================

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -450,6 +450,7 @@ config BOOT_BANNER
 config BOOT_BANNER_STRING
 	string "Boot banner string"
 	depends on BOOT_BANNER
+	default "Booting Zephyr OS build (tainted)" if TAINT
 	default "Booting Zephyr OS build"
 	help
 	  Use this option to set the boot banner.


### PR DESCRIPTION
Due to the (potentially) hard to understand effects of blobs, it seems prudent to make their presence more noticeable.

Hopefully, this will make it easier to identify issues (such as those reported on GitHub) that have been observed on devices running a tainted build.

And on a personal note, making the tainted status more prominent makes it easier for me to argue for blob-less products (i.e. MCUs with BLE) at my day job.

Please note:
 - Since having any blobs in a work space causes TAINT to be set, using this workspace to build an actually blob-free application causes this application to be marked as tainted too. IMHO, this is actually a feature, not a bug.