### PR TITLE
drivers: spi: stm32: Automatically reapply configuration after device suspend

### DIFF
--- a/drivers/spi/spi_ll_stm32.c
+++ b/drivers/spi/spi_ll_stm32.c
@@ -582,7 +582,7 @@ static int spi_stm32_configure(const struct device *dev,
 	uint32_t clock;
 	int br;
 
-	if (spi_context_configured(&data->ctx, config)) {
+	if (!data->need_reconfigure && spi_context_configured(&data->ctx, config)) {
 		/* Nothing to do */
 		return 0;
 	}
@@ -701,6 +701,7 @@ static int spi_stm32_configure(const struct device *dev,
 
 	/* At this point, it's mandatory to set this on the context! */
 	data->ctx.config = config;
+	data->need_reconfigure = false;
 
 	LOG_DBG("Installed config %p: freq %uHz (div = %u),"
 		    " mode %u/%u/%u, slave %u",
@@ -1182,6 +1183,8 @@ static int spi_stm32_init(const struct device *dev)
 	const struct spi_stm32_config *cfg = dev->config;
 	int err;
 
+	data->need_reconfigure = true;
+
 	if (!device_is_ready(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE))) {
 		LOG_ERR("clock control device not ready");
 		return -ENODEV;
@@ -1250,6 +1253,7 @@ static int spi_stm32_pm_action(const struct device *dev,
 {
 	const struct spi_stm32_config *config = dev->config;
 	const struct device *const clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
+	struct spi_stm32_data *data = dev->data;
 	int err;
 
 
@@ -1293,6 +1297,8 @@ static int spi_stm32_pm_action(const struct device *dev,
 				return err;
 			}
 		}
+		data->need_reconfigure = true;
+
 		break;
 	default:
 		return -ENOTSUP;

--- a/drivers/spi/spi_ll_stm32.h
+++ b/drivers/spi/spi_ll_stm32.h
@@ -69,6 +69,7 @@ struct spi_stm32_data {
 	struct stream dma_tx;
 #endif /* CONFIG_SPI_STM32_DMA */
 	bool pm_policy_state_on;
+	bool need_reconfigure;
 };
 
 #ifdef CONFIG_SPI_STM32_DMA


### PR DESCRIPTION
When using power management and SPI on some STM32s, an issue arises when using system power states and/or Device Power Management (`CONFIG_PM_DEVICE`): In some power states (Stop2, Standby, Shutdown), the SPI peripheral's state is not retained, i.e. its control registers lose their configuration. When the driver naively tries to use the SPI peripheral after the device entered and left a power saving mode, the peripheral's configuration is corrupt/unusable and the next SPI transfer will fail/freeze.

This PR proposes to fix this by remembering when the SPI peripheral was suspended by `PM_DEVICE_ACTION_SUSPEND`. When a transceive operation is done subsequently, the configuration is automatically re-applied beforehand, restoring the registers that have become invalid during the low power state. This should catch all system power state switches (as the system can't suspend *while* the SPI peripheral is enabled as the driver calls `pm_policy_state_lock_get`, only when it's disabled anyways), but:

This means configuration is re-applied on every SPI transfer if the SPI peripheral was disabled temporarily, even when the system *didn't* switch to a low power state after last SPI usage. This results in slower SPI operation. This can be alleviated somewhat by locking the SPI peripheral using `pm_device_runtime_get` when multiple successive SPI operations are done (without delays in-between), but apparently few drivers do this.

Perhaps there is a better way for the SPI driver to find out when the system was suspended since the last configuration operation?