### PR TITLE
Revert "tests: posix: net: fix missing clock_t and clockid_t with newlib"

### DIFF
--- a/include/zephyr/posix/posix_types.h
+++ b/include/zephyr/posix/posix_types.h
@@ -11,18 +11,6 @@
 #include <sys/types.h>
 #endif
 
-#if !defined(_CLOCK_T_DECLARED) && !defined(__clock_t_defined)
-typedef unsigned long clock_t;
-#define _CLOCK_T_DECLARED
-#define __clock_t_defined
-#endif
-
-#if !defined(_CLOCKID_T_DECLARED) && !defined(__clockid_t_defined)
-typedef unsigned long clockid_t;
-#define _CLOCKID_T_DECLARED
-#define __clockid_t_defined
-#endif
-
 #ifdef CONFIG_NEWLIB_LIBC
 #include <sys/_pthreadtypes.h>
 #endif

--- a/include/zephyr/posix/sys/select.h
+++ b/include/zephyr/posix/sys/select.h
@@ -6,8 +6,6 @@
 #ifndef ZEPHYR_INCLUDE_POSIX_SYS_SELECT_H_
 #define ZEPHYR_INCLUDE_POSIX_SYS_SELECT_H_
 
-#include "posix_types.h"
-
 #include <zephyr/sys/fdtable.h>
 
 #ifdef __cplusplus

--- a/tests/posix/net/CMakeLists.txt
+++ b/tests/posix/net/CMakeLists.txt
@@ -7,5 +7,3 @@ project(posix_net)
 FILE(GLOB app_sources src/*.c)
 
 target_sources(app PRIVATE ${app_sources})
-
-target_compile_options(app PRIVATE -U_POSIX_C_SOURCE -D_POSIX_C_SOURCE=200809L)


### PR DESCRIPTION
This reverts commit 45b3010d74924b4a4b5a72b782abb73dcefe76f3.

Issue introduced in #79884.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
