### PR TITLE
cmake: modules: west: Prevent colorized output

### DIFF
--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -1812,7 +1812,10 @@ function(zephyr_blobs_verify)
   endif()
 
   execute_process(
-    COMMAND ${WEST} blobs list ${BLOBS_VERIFY_MODULE} --format "{status} {abspath}"
+    COMMAND ${CMAKE_COMMAND} -E env
+    # Prevent colorama from using colors
+    TERM=none
+    ${WEST} blobs list ${BLOBS_VERIFY_MODULE} --format "{status} {abspath}"
     OUTPUT_VARIABLE BLOBS_LIST_OUTPUT
     OUTPUT_STRIP_TRAILING_WHITESPACE
     COMMAND_ERROR_IS_FATAL ANY

--- a/cmake/modules/west.cmake
+++ b/cmake/modules/west.cmake
@@ -81,7 +81,10 @@ else()
   message(STATUS "Found west (found suitable version \"${west_version}\", minimum required is \"${MIN_WEST_VERSION}\")")
 
   execute_process(
-    COMMAND ${WEST} topdir
+    COMMAND ${CMAKE_COMMAND} -E env
+    # Prevent colorama from using colors
+    TERM=none
+    ${WEST} topdir
     OUTPUT_VARIABLE WEST_TOPDIR
     ERROR_QUIET
     RESULT_VARIABLE west_topdir_result


### PR DESCRIPTION
`west` uses Colorama with heuristics to detect if colorized output is supported. It should never have this when running inside a cmake context.

Colorama allows to set the `TERM=none` environment variable to prevent this.