### PR TITLE
doc: boards: extensions: introduce zephyr:board role and directive

### DIFF
--- a/boards/seeed/lora_e5_dev_board/doc/lora_e5_dev_board.rst
+++ b/boards/seeed/lora_e5_dev_board/doc/lora_e5_dev_board.rst
@@ -1,7 +1,4 @@
-.. _lora_e5_dev_board:
-
-Seeed Studio LoRa-E5 Dev Board
-##############################
+.. zephyr:board:: lora_e5_dev_board
 
 Overview
 ********
@@ -12,10 +9,6 @@ The LoRa-E5-HF STM32WLE5JC Module supports multiple LPWAN protocols on the
 868/915MHz frequency bands with up to 20.8dBm output power at 3.3V.
 All GPIOs of the LoRa-E5 Module are laid out supporting
 various data protocols and interfaces including RS-485 and Grove.
-
-.. image:: img/lora_e5_dev_board.jpg
-   :align: center
-   :alt: LoRa-E5 Dev board
 
 Hardware
 ********

--- a/boards/seeed/lora_e5_mini/doc/index.rst
+++ b/boards/seeed/lora_e5_mini/doc/index.rst
@@ -1,7 +1,4 @@
-.. _lora_e5_mini:
-
-Seeed Studio LoRa-E5 mini
-#########################
+.. zephyr:board:: lora_e5_mini
 
 Overview
 ********
@@ -9,10 +6,6 @@ Overview
 LoRa-E5 mini is a compacted-sized development board suitable for the rapid
 testing and building of small-sized LoRa device, exposing all capabilities of
 Seeed Studio LoRa-E5 STM32WLE5JC module.
-
-.. image:: img/lora_e5_mini.jpg
-   :align: center
-   :alt: LoRa-E5 mini
 
 Hardware
 ********

--- a/boards/seeed/seeeduino_xiao/doc/index.rst
+++ b/boards/seeed/seeeduino_xiao/doc/index.rst
@@ -1,7 +1,4 @@
-.. _seeeduino_xiao:
-
-Seeeduino XIAO
-##############
+.. zephyr:board:: seeeduino_xiao
 
 Overview
 ********
@@ -9,10 +6,6 @@ Overview
 The Seeeduino XIAO is a tiny (20 mm x 17.5 mm) ARM development
 board with onboard LEDs, USB port, and range of I/O broken out
 onto 14 pins.
-
-.. image:: img/seeeduino_xiao.jpg
-     :align: center
-     :alt: Seeeduino XIAO
 
 Hardware
 ********

--- a/boards/seeed/wio_terminal/doc/index.rst
+++ b/boards/seeed/wio_terminal/doc/index.rst
@@ -1,7 +1,4 @@
-.. _wio_terminal:
-
-Wio Terminal
-############
+.. zephyr:board:: wio_terminal
 
 Overview
 ********
@@ -10,11 +7,6 @@ The Wio Terminal is a small (72 mm x 57 mm x 12 mm) and powerful ARM board with
 wireless connectivity (2.4G/5G dual-band Wi-Fi and BLE 5.0), LCD display,
 USB C port, FPC connector, microSD card slot, Raspberry Pi compatible 40-pins
 header and 2 Grove connectors.
-
-.. image:: img/wio_terminal.png
-     :width: 500px
-     :align: center
-     :alt: Seeed Studio Wio Terminal
 
 Hardware
 ********

--- a/boards/seeed/xiao_ble/doc/index.rst
+++ b/boards/seeed/xiao_ble/doc/index.rst
@@ -1,7 +1,4 @@
-.. _xiao_ble:
-
-XIAO BLE (Sense)
-################
+.. zephyr:board:: xiao_ble
 
 Overview
 ********
@@ -9,10 +6,6 @@ Overview
 The Seeed XIAO BLE (Sense) is a tiny (21 mm x 17.5 mm) Nordic Semiconductor
 nRF52840 ARM Cortex-M4F development board with onboard LEDs, USB port, QSPI
 flash, battery charger, and range of I/O broken out into 14 pins.
-
-.. figure:: img/xiao_ble.jpg
-     :align: center
-     :alt: XIAO BLE
 
 Hardware
 ********

--- a/boards/seeed/xiao_esp32c3/doc/index.rst
+++ b/boards/seeed/xiao_esp32c3/doc/index.rst
@@ -1,7 +1,4 @@
-.. _xiao_esp32c3:
-
-XIAO ESP32C3
-############
+.. zephyr:board:: xiao_esp32c3
 
 Overview
 ********
@@ -10,12 +7,6 @@ Seeed Studio XIAO ESP32C3 is an IoT mini development board based on the
 Espressif ESP32-C3 WiFi/Bluetooth dual-mode chip.
 
 For more details see the `Seeed Studio XIAO ESP32C3`_ wiki page.
-
-.. figure:: img/xiao_esp32c.jpg
-   :align: center
-   :alt: XIAO ESP32C3
-
-   XIAO ESP32C3
 
 Hardware
 ********

--- a/boards/seeed/xiao_esp32s3/doc/index.rst
+++ b/boards/seeed/xiao_esp32s3/doc/index.rst
@@ -1,7 +1,4 @@
-.. _xiao_esp32s3:
-
-XIAO ESP32S3
-############
+.. zephyr:board:: xiao_esp32s3
 
 Overview
 ********
@@ -10,12 +7,6 @@ Seeed Studio XIAO ESP32S3 is an IoT mini development board based on the
 Espressif ESP32-S3 WiFi/Bluetooth dual-mode chip.
 
 For more details see the `Seeed Studio XIAO ESP32S3`_ wiki page.
-
-.. figure:: img/xiao_esp32s3.jpg
-   :align: center
-   :alt: XIAO ESP32S3
-
-   XIAO ESP32S3
 
 Hardware
 ********

--- a/boards/seeed/xiao_rp2040/doc/index.rst
+++ b/boards/seeed/xiao_rp2040/doc/index.rst
@@ -1,7 +1,4 @@
-.. _xiao_rp2040:
-
-XIAO RP2040
-###########
+.. zephyr:board:: xiao_rp2040
 
 Overview
 ********
@@ -12,12 +9,6 @@ LED, and USB connector. The USB bootloader allows it
 to be flashed without any adapter, in a drag-and-drop manner.
 
 For more details see the `Seeed Studio XIAO RP2040`_ wiki page.
-
-.. figure:: img/xiao_rp2040.webp
-   :align: center
-   :alt: XIAO RP2040
-
-   XIAO RP2040
 
 Hardware
 ********

--- a/doc/_extensions/zephyr/domain/__init__.py
+++ b/doc/_extensions/zephyr/domain/__init__.py
@@ -30,7 +30,7 @@ from pathlib import Path
 from typing import Any, Dict, Iterator, List, Tuple, Final
 
 from docutils import nodes
-from docutils.parsers.rst import Directive, directives
+from docutils.parsers.rst import directives
 from docutils.statemachine import StringList
 
 from sphinx import addnodes
@@ -434,7 +434,7 @@ class ProcessRelatedCodeSamplesNode(SphinxPostTransform):
                 node.replace_self([])
 
 
-class CodeSampleDirective(Directive):
+class CodeSampleDirective(SphinxDirective):
     """
     A directive for creating a code sample node in the Zephyr documentation.
     """

--- a/doc/_extensions/zephyr/domain/templates/board-card.html
+++ b/doc/_extensions/zephyr/domain/templates/board-card.html
@@ -18,7 +18,8 @@
   tabindex="0">
   <div class="vendor">{{ catalog.vendors[board.vendor] }}</div>
   {% if board.image -%}
-  <img alt="A picture of the {{ board.name }} board" src="{{ board.image }}" class="picture" />
+  <img alt="A picture of the {{ board.full_name }} board"
+    src="../_images/{{ board.image.split('/')[-1] }}" class="picture" />
   {% else -%}
   <div class="no-picture fa fa-microchip picture"></div>
   {% endif -%}

--- a/doc/_extensions/zephyr/domain/templates/board-card.html
+++ b/doc/_extensions/zephyr/domain/templates/board-card.html
@@ -16,7 +16,7 @@
   data-vendor="{{ board.vendor }}"
   data-socs="{{ board.socs | join(" ") }}"
   tabindex="0">
-  <div class="vendor">{{ catalog.vendors[board.vendor] }}</div>
+  <div class="vendor">{{ vendors[board.vendor] }}</div>
   {% if board.image -%}
   <img alt="A picture of the {{ board.full_name }} board"
     src="../_images/{{ board.image.split('/')[-1] }}" class="picture" />

--- a/doc/_extensions/zephyr/domain/templates/board-catalog.html
+++ b/doc/_extensions/zephyr/domain/templates/board-catalog.html
@@ -38,8 +38,8 @@
         <option value="" disabled selected>Select a vendor</option>
         {# Only show those vendors that have actual boards in the catalog.
            Note: as sorting per vendor name is not feasible in Jinja, the option list is sorted in the JavaScript code later #}
-        {% for vendor in (catalog.boards | items | map(attribute='1.vendor') | unique ) -%}
-        <option value="{{ vendor }}">{{ catalog.vendors[vendor] }}</option>
+        {% for vendor in (boards | items | map(attribute='1.vendor') | unique ) -%}
+        <option value="{{ vendor }}">{{ vendors[vendor] }}</option>
         {% endfor %}
       </select>
     </div>
@@ -82,11 +82,11 @@
 <div id="nb-matches" style="text-align: center"></div>
 
 <div id="catalog">
-  {% for board_name, board in catalog.boards | items | sort(attribute='1.full_name') -%}
+  {% for board_name, board in boards | items | sort(attribute='1.full_name') -%}
   {% include "board-card.html" %}
   {% endfor %}
 </div>
 
 <script>
-  socs_data = {{ catalog.socs | tojson }};
+  socs_data = {{ socs | tojson }};
 </script>

--- a/doc/_scripts/gen_boards_catalog.py
+++ b/doc/_scripts/gen_boards_catalog.py
@@ -35,8 +35,8 @@ def guess_image(board_or_shield):
     img_file = guess_file_from_patterns(
         board_or_shield.dir, patterns, board_or_shield.name, img_exts
     )
-    return (Path("../_images") / img_file.name).as_posix() if img_file else ""
 
+    return (img_file.relative_to(ZEPHYR_BASE)).as_posix() if img_file else None
 
 def guess_doc_page(board_or_shield):
     patterns = [

--- a/doc/_scripts/gen_boards_catalog.py
+++ b/doc/_scripts/gen_boards_catalog.py
@@ -106,6 +106,7 @@ def get_catalog():
         doc_page = guess_doc_page(board)
 
         board_catalog[board.name] = {
+            "name": board.name,
             "full_name": full_name,
             "doc_page": doc_page.relative_to(ZEPHYR_BASE).as_posix() if doc_page else None,
             "vendor": vendor,

--- a/doc/_scripts/gen_boards_catalog.py
+++ b/doc/_scripts/gen_boards_catalog.py
@@ -6,7 +6,6 @@ from collections import namedtuple
 from pathlib import Path
 
 import list_boards, list_hardware
-import pykwalify
 import yaml
 import zephyr_module
 from gen_devicetree_rest import VndLookup
@@ -52,8 +51,6 @@ def guess_doc_page(board_or_shield):
 
 
 def get_catalog():
-    pykwalify.init_logging(1)
-
     vnd_lookup = VndLookup(ZEPHYR_BASE / "dts/bindings/vendor-prefixes.txt", [])
 
     module_settings = {

--- a/doc/_static/css/custom.css
+++ b/doc/_static/css/custom.css
@@ -1061,3 +1061,56 @@ li>a.code-sample-link.reference.internal {
 li>a.code-sample-link.reference.internal.current {
     text-decoration: underline;
 }
+
+/* Board overview "card" on board documentation pages */
+.sidebar.board-overview {
+    border-radius: 12px;
+    padding: 0px;
+    background: var(--admonition-note-background-color);
+    color: var(--admonition-note-title-color);
+    border-color: var(--admonition-note-title-background-color);
+}
+
+@media screen and (max-width: 480px) {
+    .sidebar.board-overview {
+        float: none;
+        margin-left: 0;
+    }
+}
+
+.sidebar.board-overview .sidebar-title {
+    font-family: var(--header-font-family);
+    background: var(--admonition-note-title-background-color);
+    color: var(--admonition-note-title-color);
+    border-radius: 12px 12px 0px 0px;
+    margin: 0px;
+    text-align: center;
+}
+
+.sidebar.board-overview * {
+    color: var(--admonition-note-color);
+}
+
+.sidebar.board-overview figure {
+    padding: 1rem;
+    margin-bottom: -1rem;
+}
+
+.sidebar.board-overview figure img {
+    height: auto !important;
+}
+
+.sidebar.board-overview figure figcaption p {
+    margin-bottom: 0px;
+}
+
+.sidebar.board-overview dl.field-list {
+    align-items: center;
+    margin-top: 12px !important;
+    margin-bottom: 12px !important;
+    grid-template-columns: auto 1fr !important;
+}
+
+.sidebar.board-overview dl.field-list > dt {
+    background: transparent !important;
+}

--- a/doc/contribute/documentation/guidelines.rst
+++ b/doc/contribute/documentation/guidelines.rst
@@ -1201,6 +1201,14 @@ Boards
 
    This role is used to reference a board documented using :rst:dir:`zephyr:board`.
 
+   For example::
+
+      Check out :zephyr:board:`wio_terminal` for more information.
+
+   Will render as:
+
+      Check out :zephyr:board:`wio_terminal` for more information.
+
 .. rst:directive:: .. zephyr:board-catalog::
 
    This directive is used to generate a catalog of Zephyr-supported boards that can be used to

--- a/doc/contribute/documentation/guidelines.rst
+++ b/doc/contribute/documentation/guidelines.rst
@@ -1184,6 +1184,23 @@ Code samples
 Boards
 ======
 
+.. rst:directive:: .. zephyr:board:: name
+
+   This directive is used at the beginning of a document to indicate it is the main documentation
+   page for a board whose name is given as the directive argument.
+
+   For example::
+
+      .. zephyr:board:: wio_terminal
+
+   The metadata for the board is read from various config files and used to automatically populate
+   some sections of the board documentation. A board documentation page that uses this directive
+   can be linked to using the :rst:role:`zephyr:board` role.
+
+.. rst:role:: zephyr:board
+
+   This role is used to reference a board documented using :rst:dir:`zephyr:board`.
+
 .. rst:directive:: .. zephyr:board-catalog::
 
    This directive is used to generate a catalog of Zephyr-supported boards that can be used to

--- a/doc/releases/release-notes-3.7.rst
+++ b/doc/releases/release-notes-3.7.rst
@@ -834,15 +834,15 @@ Drivers and Sensors
   * Added support for Ambiq Apollo3 series.
   * Added support for multiple instances of the SPI NOR driver (spi_nor.c).
   * Added preliminary support for non-erase devices with introduction of
-    device capabilities to c:struct:`flash_parameters` and the utility function
-    c:func:`flash_params_get_erase_cap` that allows to obtain the erase type
-    provided by a device; added c:macro:`FLASH_ERASE_C_EXPLICIT`, which is
+    device capabilities to :c:struct:`flash_parameters` and the utility function
+    :c:func:`flash_params_get_erase_cap` that allows to obtain the erase type
+    provided by a device; added :c:macro:`FLASH_ERASE_C_EXPLICIT`, which is
     currently the only supported erase type and is set by all flash devices.
-  * Added the c:func:`flash_flatten` function that can be used on devices,
+  * Added the :c:func:`flash_flatten` function that can be used on devices,
     with or without erase requirement, when erase has been used not for preparing
     a device for a random data write, but rather to remove/scramble data from
     that device.
-  * Added the c:func:`flash_fill` utility function which allows to write
+  * Added the :c:func:`flash_fill` utility function which allows to write
     a single value across a provided range in a selected device.
   * Added support for RRAM on nrf54l15 devices.
   * Added support of non busy wait polling in STM32 OSPI driver.
@@ -868,7 +868,7 @@ Drivers and Sensors
 
   * Added support for Ambiq Apollo3 series.
   * Added Broadcom Set-top box(brcmstb) SoC GPIO driver.
-  * Added c:macro:`STM32_GPIO_WKUP` flag which allows to configure specific pins as wakeup source
+  * Added :c:macro:`STM32_GPIO_WKUP` flag which allows to configure specific pins as wakeup source
     from Power Off state on STM32 L4, U5, WB, & WL SoC series.
   * Added driver for Analog Devices MAX32 SoC series.
   * Added support for Nuvoton Numaker M2L31X series.
@@ -1047,7 +1047,7 @@ Drivers and Sensors
   * Added support for STM32H7R/S series.
   * Added a Add QTMR PWM driver for NXP imxrt11xx
   * Made the NXP MCUX PWM driver thread safe
-  * Fix zephyr:code-sample:`pwm-blinky` code sample to demonstrate PWM support for
+  * Fix :zephyr:code-sample:`pwm-blinky` code sample to demonstrate PWM support for
     :ref:`beagleconnect_freedom`.
   * Added driver for ENE KB1200.
   * Added support for Nordic nRF54H and nRF54L Series SoCs.
@@ -1403,7 +1403,7 @@ Networking
   * Implemented IPv6 Privacy Extensions according to RFC 8981.
   * Added :c:func:`net_ipv6_is_private_addr` API function.
   * Implemented reachability hint for IPv6. Upper layers can use
-    c:func:`net_if_nbr_reachability_hint` to report Neighbor reachability and
+    :c:func:`net_if_nbr_reachability_hint` to report Neighbor reachability and
     avoid unnecessary Neighbor Discovery solicitations.
   * Added :kconfig:option:`CONFIG_NET_IPV6_MTU` allowing to set custom IPv6 MTU.
   * Added :kconfig:option:`CONFIG_NET_MCAST_ROUTE_MAX_IFACES` which allows to set

--- a/doc/releases/release-notes-3.7.rst
+++ b/doc/releases/release-notes-3.7.rst
@@ -410,7 +410,7 @@ Boards & SoC Support
   * Added support for :ref:`Ambiq Apollo3 Blue board <apollo3_evb>`: ``apollo3_evb``.
   * Added support for :ref:`Ambiq Apollo3 Blue Plus board <apollo3p_evb>`: ``apollo3p_evb``.
   * Added support for :ref:`Raspberry Pi 5 board <rpi_5>`: ``rpi_5``.
-  * Added support for :ref:`Seeed Studio XIAO RP2040 board <xiao_rp2040>`: ``xiao_rp2040``.
+  * Added support for :zephyr:board:`Seeed Studio XIAO RP2040 board <xiao_rp2040>`: ``xiao_rp2040``.
   * Added support for :ref:`Mikroe RA4M1 Clicker board <mikroe_clicker_ra4m1>`: ``mikroe_clicker_ra4m1``.
   * Added support for :ref:`Arduino UNO R4 WiFi board <arduino_uno_r4>`: ``arduino_uno_r4_wifi``.
   * Added support for :ref:`Renesas EK-RA8M1 board <ek_ra8m1>`: ``ek_ra8m1``.

--- a/doc/templates/board.tmpl
+++ b/doc/templates/board.tmpl
@@ -1,19 +1,15 @@
-.. _boardname_linkname:
+.. zephyr:board:: board_name
 
-[Board Name]
-#############
+.. To ensure the board documentation page displays correctly, it is highly
+   recommended to include a picture alongside the documentation page.
+
+   The picture should be named after the board (e.g., "board_name.webp")
+   and preferably be in webp format. Alternatively, png or jpg formats
+   are also accepted.
 
 Overview
 ********
 [A short description about the board, its main features and availability]
-
-
-.. figure:: board_name.png
-   :width: 800px
-   :align: center
-   :alt: Board Name
-
-   Board Name (Credit: <owner>)
 
 Hardware
 ********

--- a/samples/subsys/display/lvgl/README.rst
+++ b/samples/subsys/display/lvgl/README.rst
@@ -41,7 +41,7 @@ for corresponding connectors, for example:
 - :ref:`adafruit_2_8_tft_touch_v2` and :ref:`nrf52840dk_nrf52840`
 - :ref:`buydisplay_2_8_tft_touch_arduino` and :ref:`nrf52840dk_nrf52840`
 - :ref:`ssd1306_128_shield` and :ref:`frdm_k64f`
-- :ref:`seeed_xiao_round_display` and :ref:`xiao_ble`
+- :ref:`seeed_xiao_round_display` and :zephyr:board:`xiao_ble`
 
 or a board with an integrated display:
 


### PR DESCRIPTION
https://builds.zephyrproject.io/zephyr/pr/79994/docs/boards/seeed/wio_terminal/doc/index.html
https://builds.zephyrproject.io/zephyr/pr/79994/docs/contribute/documentation/guidelines.html#boards

A new `zephyr:board::` Sphinx directive allows to flag a documentation page as being the documentation for a specific board, allowing to auto-populate some of the contents, ex. by adding a board overview *à la Wikipedia*, and later things like supported HW features, a ready-to-copy-paste example of how to build Hello World, etc.

<img width="1331" alt="image" src="https://github.com/user-attachments/assets/204ba606-a0e6-4610-bd83-1f2e0ed916a7">

A corresponding `:zephyr:board:` role allows to link to a board doc page.