### PR TITLE
Bluetooth: Audio: add create_by_broadcast_name for the broadcast sink …

### DIFF
--- a/doc/connectivity/bluetooth/api/audio/shell/bap.rst
+++ b/doc/connectivity/bluetooth/api/audio/shell/bap.rst
@@ -23,6 +23,7 @@ Commands
       stop_broadcast         :
       delete_broadcast       :
       create_broadcast_sink  : 0x<broadcast_id>
+      create_sink_by_name    : <broadcast_name>
       sync_broadcast         : 0x<bis_index> [[[0x<bis_index>] 0x<bis_index>] ...]
                               [bcode <broadcast code> || bcode_str <broadcast code
                               as string>]
@@ -181,6 +182,59 @@ ID before syncing to the BIG.
    Attempting to PA sync to the broadcaster
    PA synced to broadcast with broadcast ID 0xEF6716
    Attempting to sync to the BIG
+   Received BASE from sink 0x20019080:
+   Presentation delay: 40000
+   Subgroup count: 1
+   Subgroup 0x20024182:
+      Codec Format: 0x06
+      Company ID  : 0x0000
+      Vendor ID   : 0x0000
+      codec cfg id 0x06 cid 0x0000 vid 0x0000 count 16
+         Codec specific configuration:
+         Sampling frequency: 16000 Hz (3)
+         Frame duration: 10000 us (1)
+         Channel allocation:
+                  Front left (0x00000001)
+                  Front right (0x00000002)
+         Octets per codec frame: 40
+         Codec specific metadata:
+         Streaming audio contexts:
+            Unspecified (0x0001)
+         BIS index: 0x01
+            codec cfg id 0x06 cid 0x0000 vid 0x0000 count 6
+            Codec specific configuration:
+               Channel allocation:
+                  Front left (0x00000001)
+            Codec specific metadata:
+               None
+         BIS index: 0x02
+            codec cfg id 0x06 cid 0x0000 vid 0x0000 count 6
+            Codec specific configuration:
+               Channel allocation:
+                  Front right (0x00000002)
+            Codec specific metadata:
+               None
+   Possible indexes: 0x01 0x02
+   Sink 0x20019110 is ready to sync without encryption
+   uart:~$ bap sync_broadcast 0x01
+
+
+Scan for and establish a broadcast sink stream by broadcast name
+----------------------------------------------------------------
+
+The command :code:`bap create_sink_by_name` will start scanning and sync to the periodic
+advertising with the provided broadcast name before syncing to the BIG.
+
+.. code-block:: console
+
+   uart:~$ bap init
+   uart:~$ bap create_sink_by_name "Test Broadcast"
+   Starting scanning for broadcast_name
+   Found matched broadcast name 'Test Broadcast' with address 03:47:95:75:C0:08 (random)
+   Found broadcaster with ID 0xEF6716 and addr 03:47:95:75:C0:08 (random) and sid 0x00
+   Attempting to PA sync to the broadcaster
+   PA synced to broadcast with broadcast ID 0xEF6716
+   Attempting to create the sink
    Received BASE from sink 0x20019080:
    Presentation delay: 40000
    Subgroup count: 1

--- a/subsys/bluetooth/audio/shell/bap.c
+++ b/subsys/bluetooth/audio/shell/bap.c
@@ -2348,20 +2348,25 @@ static int cmd_preset(const struct shell *sh, size_t argc, char *argv[])
 #define PA_SYNC_INTERVAL_TO_TIMEOUT_RATIO 20 /* Set the timeout relative to interval */
 #define PA_SYNC_SKIP         5
 
+struct bt_broadcast_info {
+	uint32_t broadcast_id;
+	char broadcast_name[BT_AUDIO_BROADCAST_NAME_LEN_MAX + 1];
+};
+
 static struct broadcast_sink_auto_scan {
 	struct broadcast_sink *broadcast_sink;
-	uint32_t broadcast_id;
+	struct bt_broadcast_info broadcast_info;
 	struct bt_le_per_adv_sync **out_sync;
 } auto_scan = {
-	.broadcast_id = BT_BAP_INVALID_BROADCAST_ID,
+	.broadcast_info = {
+		.broadcast_id = BT_BAP_INVALID_BROADCAST_ID,
+	},
 };
 
 static void clear_auto_scan(void)
 {
-	if (auto_scan.broadcast_id != BT_BAP_INVALID_BROADCAST_ID) {
-		memset(&auto_scan, 0, sizeof(auto_scan));
-		auto_scan.broadcast_id = BT_BAP_INVALID_BROADCAST_ID;
-	}
+	memset(&auto_scan, 0, sizeof(auto_scan));
+	auto_scan.broadcast_info.broadcast_id = BT_BAP_INVALID_BROADCAST_ID;
 }
 
 static uint16_t interval_to_sync_timeout(uint16_t interval)
@@ -2381,40 +2386,85 @@ static uint16_t interval_to_sync_timeout(uint16_t interval)
 
 static bool scan_check_and_sync_broadcast(struct bt_data *data, void *user_data)
 {
-	const struct bt_le_scan_recv_info *info = user_data;
-	char le_addr[BT_ADDR_LE_STR_LEN];
+	struct bt_broadcast_info *sr_info = (struct bt_broadcast_info *)user_data;
 	struct bt_uuid_16 adv_uuid;
-	uint32_t broadcast_id;
 
-	if (data->type != BT_DATA_SVC_DATA16) {
+	switch (data->type) {
+	case BT_DATA_SVC_DATA16:
+		if (data->data_len < BT_UUID_SIZE_16 + BT_AUDIO_BROADCAST_ID_SIZE) {
+			return true;
+		}
+
+		if (!bt_uuid_create(&adv_uuid.uuid, data->data, BT_UUID_SIZE_16)) {
+			return true;
+		}
+
+		if (bt_uuid_cmp(&adv_uuid.uuid, BT_UUID_BROADCAST_AUDIO) != 0) {
+			return true;
+		}
+
+		sr_info->broadcast_id = sys_get_le24(data->data + BT_UUID_SIZE_16);
+		return true;
+	case BT_DATA_BROADCAST_NAME:
+		if (!IN_RANGE(data->data_len, BT_AUDIO_BROADCAST_NAME_LEN_MIN,
+			      BT_AUDIO_BROADCAST_NAME_LEN_MAX)) {
+			return false;
+		}
+
+		memcpy(sr_info->broadcast_name, data->data, data->data_len);
+		sr_info->broadcast_name[data->data_len] = '\0';
+		return true;
+	default:
 		return true;
 	}
+}
 
-	if (data->data_len < BT_UUID_SIZE_16 + BT_AUDIO_BROADCAST_ID_SIZE) {
-		return true;
+static void broadcast_scan_recv(const struct bt_le_scan_recv_info *info, struct net_buf_simple *ad)
+{
+	struct bt_broadcast_info sr_info = {0};
+	char addr_str[BT_ADDR_LE_STR_LEN];
+	bool identified_broadcast = false;
+
+	sr_info.broadcast_id = BT_BAP_INVALID_BROADCAST_ID;
+
+	if ((auto_scan.broadcast_info.broadcast_id == BT_BAP_INVALID_BROADCAST_ID) &&
+	    (strlen(auto_scan.broadcast_info.broadcast_name) == 0U)) {
+		/* no op */
+		return;
 	}
 
-	if (!bt_uuid_create(&adv_uuid.uuid, data->data, BT_UUID_SIZE_16)) {
-		return true;
+	if (!passes_scan_filter(info, ad)) {
+		return;
 	}
 
-	if (bt_uuid_cmp(&adv_uuid.uuid, BT_UUID_BROADCAST_AUDIO)) {
-		return true;
+	bt_data_parse(ad, scan_check_and_sync_broadcast, (void *)&sr_info);
+
+	/* Verify that it is a BAP broadcaster*/
+	if (sr_info.broadcast_id == BT_BAP_INVALID_BROADCAST_ID) {
+		return;
 	}
 
-	broadcast_id = sys_get_le24(data->data + BT_UUID_SIZE_16);
+	bt_addr_le_to_str(info->addr, addr_str, sizeof(addr_str));
 
-	bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
+	if (sr_info.broadcast_id == auto_scan.broadcast_info.broadcast_id) {
+		identified_broadcast = true;
+	} else if ((strlen(auto_scan.broadcast_info.broadcast_name) != 0U) &&
+		   is_substring(auto_scan.broadcast_info.broadcast_name, sr_info.broadcast_name)) {
+		auto_scan.broadcast_info.broadcast_id = sr_info.broadcast_id;
+		identified_broadcast = true;
 
-	shell_print(ctx_shell,
-		    "Found broadcaster with ID 0x%06X and addr %s and sid 0x%02X (looking for "
-		    "0x%06X)",
-		    broadcast_id, le_addr, info->sid, auto_scan.broadcast_id);
+		shell_print(ctx_shell, "Found matched broadcast name '%s' with address %s",
+			    sr_info.broadcast_name, addr_str);
+	}
 
-	if (auto_scan.broadcast_id == broadcast_id && auto_scan.broadcast_sink != NULL &&
-	    auto_scan.broadcast_sink->pa_sync == NULL) {
+	if (identified_broadcast && (auto_scan.broadcast_sink != NULL) &&
+	    (auto_scan.broadcast_sink->pa_sync == NULL)) {
 		struct bt_le_per_adv_sync_param create_params = {0};
 		int err;
+
+		shell_print(ctx_shell,
+			    "Found broadcaster with ID 0x%06X and addr %s and sid 0x%02X ",
+			    sr_info.broadcast_id, addr_str, info->sid);
 
 		err = bt_le_scan_stop();
 		if (err != 0) {
@@ -2434,16 +2484,6 @@ static bool scan_check_and_sync_broadcast(struct bt_data *data, void *user_data)
 		} else {
 			auto_scan.broadcast_sink->pa_sync = *auto_scan.out_sync;
 		}
-	}
-
-	/* Stop parsing */
-	return false;
-}
-
-static void broadcast_scan_recv(const struct bt_le_scan_recv_info *info, struct net_buf_simple *ad)
-{
-	if (passes_scan_filter(info, ad)) {
-		bt_data_parse(ad, scan_check_and_sync_broadcast, (void *)info);
 	}
 }
 
@@ -2480,13 +2520,14 @@ static void bap_pa_sync_synced_cb(struct bt_le_per_adv_sync *sync,
 	if (auto_scan.broadcast_sink != NULL && auto_scan.out_sync != NULL &&
 	    sync == *auto_scan.out_sync) {
 		shell_print(ctx_shell, "PA synced to broadcast with broadcast ID 0x%06x",
-			    auto_scan.broadcast_id);
+			    auto_scan.broadcast_info.broadcast_id);
 
 		if (auto_scan.broadcast_sink->bap_sink == NULL) {
 			shell_print(ctx_shell, "Attempting to create the sink");
 			int err;
 
-			err = bt_bap_broadcast_sink_create(sync, auto_scan.broadcast_id,
+			err = bt_bap_broadcast_sink_create(sync,
+							   auto_scan.broadcast_info.broadcast_id,
 							   &auto_scan.broadcast_sink->bap_sink);
 			if (err != 0) {
 				shell_error(ctx_shell, "Could not create broadcast sink: %d", err);
@@ -3408,7 +3449,7 @@ static int cmd_create_broadcast_sink(const struct shell *sh, size_t argc, char *
 
 	if (per_adv_sync == NULL) {
 		const struct bt_le_scan_param param = {
-			.type = BT_LE_SCAN_TYPE_ACTIVE,
+			.type = BT_LE_SCAN_TYPE_PASSIVE,
 			.options = BT_LE_SCAN_OPT_NONE,
 			.interval = BT_GAP_SCAN_FAST_INTERVAL,
 			.window = BT_GAP_SCAN_FAST_WINDOW,
@@ -3425,7 +3466,7 @@ static int cmd_create_broadcast_sink(const struct shell *sh, size_t argc, char *
 		}
 
 		auto_scan.broadcast_sink = &default_broadcast_sink;
-		auto_scan.broadcast_id = broadcast_id;
+		auto_scan.broadcast_info.broadcast_id = broadcast_id;
 		auto_scan.out_sync = &per_adv_syncs[selected_per_adv_sync];
 	} else {
 		shell_print(sh, "Creating broadcast sink with broadcast ID 0x%06X",
@@ -3440,6 +3481,46 @@ static int cmd_create_broadcast_sink(const struct shell *sh, size_t argc, char *
 			return -ENOEXEC;
 		}
 	}
+
+	return 0;
+}
+
+static int cmd_create_sink_by_name(const struct shell *sh, size_t argc, char *argv[])
+{
+	const struct bt_le_scan_param param = {
+		.type = BT_LE_SCAN_TYPE_PASSIVE,
+		.options = BT_LE_SCAN_OPT_NONE,
+		.interval = BT_GAP_SCAN_FAST_INTERVAL,
+		.window = BT_GAP_SCAN_FAST_WINDOW,
+		.timeout = 1000, /* 10ms units -> 10 second timeout */
+	};
+	char *broadcast_name;
+	int err = 0;
+
+	broadcast_name = argv[1];
+	if (!IN_RANGE(strlen(broadcast_name), BT_AUDIO_BROADCAST_NAME_LEN_MIN,
+		      BT_AUDIO_BROADCAST_NAME_LEN_MAX)) {
+		shell_error(sh, "Broadcast name should be minimum %d and maximum %d characters",
+			    BT_AUDIO_BROADCAST_NAME_LEN_MIN, BT_AUDIO_BROADCAST_NAME_LEN_MAX);
+
+		return -ENOEXEC;
+	}
+
+	shell_print(sh, "Starting scanning for broadcast_name");
+
+	err = bt_le_scan_start(&param, NULL);
+	if (err) {
+		shell_print(sh, "Fail to start scanning: %d", err);
+
+		return -ENOEXEC;
+	}
+
+	memcpy(auto_scan.broadcast_info.broadcast_name, broadcast_name, strlen(broadcast_name));
+	auto_scan.broadcast_info.broadcast_name[strlen(broadcast_name)] = '\0';
+
+	auto_scan.broadcast_info.broadcast_id = BT_BAP_INVALID_BROADCAST_ID;
+	auto_scan.broadcast_sink = &default_broadcast_sink;
+	auto_scan.out_sync = &per_adv_syncs[selected_per_adv_sync];
 
 	return 0;
 }
@@ -4048,8 +4129,9 @@ static int cmd_print_ase_info(const struct shell *sh, size_t argc, char *argv[])
 	"[bcast_flag]" HELP_SEP "[extended <meta>]" HELP_SEP "[vendor <meta>]]"
 
 SHELL_STATIC_SUBCMD_SET_CREATE(
-	bap_cmds, SHELL_CMD_ARG(init, NULL, NULL, cmd_init, 1,
-				IS_ENABLED(CONFIG_BT_BAP_UNICAST_SERVER) ? 2 : 0),
+	bap_cmds,
+	SHELL_CMD_ARG(init, NULL, NULL, cmd_init, 1,
+		      IS_ENABLED(CONFIG_BT_BAP_UNICAST_SERVER) ? 2 : 0),
 #if defined(CONFIG_BT_BAP_BROADCAST_SOURCE)
 	SHELL_CMD_ARG(select_broadcast, NULL, "<stream>", cmd_select_broadcast_source, 2, 0),
 	SHELL_CMD_ARG(create_broadcast, NULL, "[preset <preset_name>] [enc <broadcast_code>]",
@@ -4061,6 +4143,8 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 #if defined(CONFIG_BT_BAP_BROADCAST_SINK)
 	SHELL_CMD_ARG(create_broadcast_sink, NULL, "0x<broadcast_id>", cmd_create_broadcast_sink, 2,
 		      0),
+	SHELL_CMD_ARG(create_sink_by_name, NULL, "<broadcast_name>",
+		      cmd_create_sink_by_name, 2, 0),
 	SHELL_CMD_ARG(sync_broadcast, NULL,
 		      "0x<bis_index> [[[0x<bis_index>] 0x<bis_index>] ...] "
 		      "[bcode <broadcast code> || bcode_str <broadcast code as string>]",


### PR DESCRIPTION
…shell

Add create_by_broadcast_name command that scans for broadcast sources with BT_DATA_BROADCAST_NAME matching the name given to the shell command.

Fixes #70837