### PR TITLE
tests: posix: net: fix missing clock_t and clockid_t with newlib

### DIFF
--- a/include/zephyr/posix/dirent.h
+++ b/include/zephyr/posix/dirent.h
@@ -7,7 +7,8 @@
 #define ZEPHYR_INCLUDE_POSIX_DIRENT_H_
 
 #include <limits.h>
-#include "posix_types.h"
+
+#include <zephyr/posix/posix_types.h>
 
 #ifdef CONFIG_POSIX_FILE_SYSTEM
 #include <zephyr/fs/fs.h>

--- a/include/zephyr/posix/mqueue.h
+++ b/include/zephyr/posix/mqueue.h
@@ -12,7 +12,7 @@
 #include <zephyr/posix/fcntl.h>
 #include <zephyr/posix/signal.h>
 #include <zephyr/posix/sys/stat.h>
-#include "posix_types.h"
+#include <zephyr/posix/posix_types.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/zephyr/posix/posix_types.h
+++ b/include/zephyr/posix/posix_types.h
@@ -11,6 +11,18 @@
 #include <sys/types.h>
 #endif
 
+#if !defined(_CLOCK_T_DECLARED) && !defined(__clock_t_defined)
+typedef unsigned long clock_t;
+#define _CLOCK_T_DECLARED
+#define __clock_t_defined
+#endif
+
+#if !defined(_CLOCKID_T_DECLARED) && !defined(__clockid_t_defined)
+typedef unsigned long clockid_t;
+#define _CLOCKID_T_DECLARED
+#define __clockid_t_defined
+#endif
+
 #ifdef CONFIG_NEWLIB_LIBC
 #include <sys/_pthreadtypes.h>
 #endif

--- a/include/zephyr/posix/sched.h
+++ b/include/zephyr/posix/sched.h
@@ -7,8 +7,7 @@
 #define ZEPHYR_INCLUDE_POSIX_SCHED_H_
 
 #include <zephyr/kernel.h>
-
-#include "posix_types.h"
+#include <zephyr/posix/posix_types.h>
 
 #include <time.h>
 

--- a/include/zephyr/posix/semaphore.h
+++ b/include/zephyr/posix/semaphore.h
@@ -7,7 +7,7 @@
 #define ZEPHYR_INCLUDE_POSIX_SEMAPHORE_H_
 
 #include <zephyr/posix/time.h>
-#include "posix_types.h"
+#include <zephyr/posix/posix_types.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/zephyr/posix/signal.h
+++ b/include/zephyr/posix/signal.h
@@ -6,7 +6,8 @@
 #ifndef ZEPHYR_INCLUDE_POSIX_SIGNAL_H_
 #define ZEPHYR_INCLUDE_POSIX_SIGNAL_H_
 
-#include "posix_types.h"
+/* include posix_types.h before posix_features.h (here) to avoid build errors against newlib */
+#include <zephyr/posix/posix_types.h>
 #include "posix_features.h"
 
 #ifdef __cplusplus

--- a/include/zephyr/posix/sys/select.h
+++ b/include/zephyr/posix/sys/select.h
@@ -6,6 +6,7 @@
 #ifndef ZEPHYR_INCLUDE_POSIX_SYS_SELECT_H_
 #define ZEPHYR_INCLUDE_POSIX_SYS_SELECT_H_
 
+#include <zephyr/posix/posix_types.h>
 #include <zephyr/sys/fdtable.h>
 
 #ifdef __cplusplus

--- a/include/zephyr/posix/time.h
+++ b/include/zephyr/posix/time.h
@@ -58,7 +58,7 @@ struct itimerspec {
 
 #include <zephyr/kernel.h>
 #include <errno.h>
-#include "posix_types.h"
+#include <zephyr/posix/posix_types.h>
 #include <zephyr/posix/signal.h>
 
 #ifdef __cplusplus

--- a/include/zephyr/posix/unistd.h
+++ b/include/zephyr/posix/unistd.h
@@ -6,7 +6,7 @@
 #ifndef ZEPHYR_INCLUDE_POSIX_UNISTD_H_
 #define ZEPHYR_INCLUDE_POSIX_UNISTD_H_
 
-#include "posix_types.h"
+#include <zephyr/posix/posix_types.h>
 
 #ifdef CONFIG_POSIX_API
 #include <zephyr/fs/fs.h>

--- a/tests/posix/net/CMakeLists.txt
+++ b/tests/posix/net/CMakeLists.txt
@@ -7,3 +7,5 @@ project(posix_net)
 FILE(GLOB app_sources src/*.c)
 
 target_sources(app PRIVATE ${app_sources})
+
+target_compile_options(app PRIVATE -U_POSIX_C_SOURCE -D_POSIX_C_SOURCE=200809L)


### PR DESCRIPTION
Fix errors found in CI for missing clock_t and clockid_t types when building the tests/posix/net testsuite against newlib.

Also use angle-brackets and prefixed path with `<zephyr/posix/posix_types.h>` since it is not in the default search path and is analagous to `<sys/types.h>`.

Testing done:

```shell
$ twister --retry-failed 3 --no-clean -T tests/posix
Keeping artifacts untouched
INFO    - Using Ninja..
INFO    - Zephyr version: v3.7.0-4640-g908a9d213e6b
INFO    - Using 'zephyr' toolchain.
INFO    - Selecting default platforms per test case
INFO    - Building initial testsuite list...
INFO    - JOBS: 12
INFO    - Adding tasks to the queue...
INFO    - Added initial list of jobs to queue
INFO    - Total complete: 2542/2542  100%  built (not run):    9, skipped: 2083, failed:    0, error:    0
INFO    - 62 test scenarios (2542 test instances) selected, 2083 configurations skipped (2007 by static filter, 76 at runtime).
INFO    - 450 of 2542 test configurations passed (98.04%), 9 built (not run), 0 failed, 0 errored, 2083 skipped with 0 warnings in 967.93 seconds
INFO    - In total 13608 test cases were executed, 69941 skipped on 41 out of total 856 platforms (4.79%)
INFO    - 450 test configurations executed on platforms, 9 test configurations were only built.
INFO    - Saving reports...
INFO    - Writing JSON report /home/cfriedt/zephyrproject/zephyr/twister-out/twister.json
INFO    - Writing xunit report /home/cfriedt/zephyrproject/zephyr/twister-out/twister.xml...
INFO    - Writing xunit report /home/cfriedt/zephyrproject/zephyr/twister-out/twister_report.xml...
INFO    - Run completed
```

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/79961