### PR TITLE
drivers: serial: nrfx_uarte: Add support to DMM  and data cache and other minor tweaks

### DIFF
--- a/boards/native/nrf_bsim/CMakeLists.txt
+++ b/boards/native/nrf_bsim/CMakeLists.txt
@@ -56,6 +56,7 @@ zephyr_include_directories(
   common
   common/cmsis
   ${NSI_DIR}/common/src/include
+  ${ZEPHYR_BASE}/soc/nordic/common
 )
 
 zephyr_library_include_directories(

--- a/drivers/serial/Kconfig.nrfx
+++ b/drivers/serial/Kconfig.nrfx
@@ -57,6 +57,16 @@ config UART_ASYNC_TX_CACHE_SIZE
 	  in RAM, because EasyDMA in UARTE peripherals can only transfer data
 	  from RAM.
 
+config UART_NRFX_UARTE_RX_FLUSH_MAGIC_BYTE
+	hex "Byte used for RX FIFO flush workaround"
+	default 0xAA
+	range 0x00 0xFF
+	help
+	  Byte used to fill the buffer before RX FIFO is flushed into it. Due to the
+	  HW anomaly a workaround need to be applied which checks if content of the
+	  buffer changed. There are cases when specific value of the magic byte is
+	  used if it is known that certain bytes are less likely to occur.
+
 if HAS_HW_NRF_UART0 || HAS_HW_NRF_UARTE0
 nrfx_uart_num = 0
 rsource "Kconfig.nrfx_uart_instance"

--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -1398,7 +1398,7 @@ static void endrx_isr(const struct device *dev)
 static uint8_t rx_flush(const struct device *dev, uint8_t *buf)
 {
 	/* Flushing RX fifo requires buffer bigger than 4 bytes to empty fifo*/
-	static const uint8_t dirty = 0xAA;
+	static const uint8_t dirty = CONFIG_UART_NRFX_UARTE_RX_FLUSH_MAGIC_BYTE;
 	NRF_UARTE_Type *uarte = get_uarte_instance(dev);
 	const struct uarte_nrfx_config *config = dev->config;
 	uint32_t prev_rx_amount;


### PR DESCRIPTION
Add support for DMM and cache.
Add configurable magic word used for RX flush workaround.
Add workaround for lack of retention of the BAUDRATE register in UARTE120.
Add lock to uart_rx_disable.

Fixes #77060.