### PR TITLE
drivers: flash: flash_mcux_flexspi_nor: fix IS25WP flash support

### DIFF
--- a/boards/madmachine/mm_feather/mm_feather.dts
+++ b/boards/madmachine/mm_feather/mm_feather.dts
@@ -61,7 +61,7 @@
 		compatible = "nxp,imx-flexspi-nor";
 		size = <67108864>;
 		reg = <0>;
-		spi-max-frequency = <133000000>;
+		spi-max-frequency = <104000000>;
 		status = "okay";
 		jedec-id = [9d 70 17];
 	};

--- a/boards/madmachine/mm_swiftio/mm_swiftio.dts
+++ b/boards/madmachine/mm_swiftio/mm_swiftio.dts
@@ -61,7 +61,7 @@
 		compatible = "nxp,imx-flexspi-nor";
 		size = <67108864>;
 		reg = <0>;
-		spi-max-frequency = <133000000>;
+		spi-max-frequency = <104000000>;
 		status = "okay";
 		jedec-id = [9d 70 17];
 	};

--- a/boards/nxp/mimxrt1020_evk/mimxrt1020_evk.dts
+++ b/boards/nxp/mimxrt1020_evk/mimxrt1020_evk.dts
@@ -99,7 +99,7 @@ arduino_serial: &lpuart2 {
 		compatible = "nxp,imx-flexspi-nor";
 		size = <67108864>;
 		reg = <0>;
-		spi-max-frequency = <133000000>;
+		spi-max-frequency = <104000000>;
 		status = "okay";
 		jedec-id = [9d 70 17];
 		erase-block-size = <4096>;

--- a/boards/nxp/mimxrt1020_evk/mimxrt1020_evk.dts
+++ b/boards/nxp/mimxrt1020_evk/mimxrt1020_evk.dts
@@ -22,8 +22,8 @@
 	};
 
 	chosen {
-		zephyr,flash-controller = &is25wp064;
-		zephyr,flash = &is25wp064;
+		zephyr,flash-controller = &is25lp064;
+		zephyr,flash = &is25lp064;
 		zephyr,code-partition = &slot0_partition;
 		zephyr,uart-mcumgr = &lpuart1;
 		zephyr,sram = &sdram0;
@@ -95,7 +95,7 @@ arduino_serial: &lpuart2 {
 &flexspi {
 	status = "okay";
 	reg = <0x402a8000 0x4000>, <0x60000000 DT_SIZE_M(8)>;
-	is25wp064: is25wp064@0 {
+	is25lp064: is25lp064@0 {
 		compatible = "nxp,imx-flexspi-nor";
 		size = <67108864>;
 		reg = <0>;

--- a/boards/nxp/mimxrt1050_evk/mimxrt1050_evk_mimxrt1052_qspi.overlay
+++ b/boards/nxp/mimxrt1050_evk/mimxrt1050_evk_mimxrt1052_qspi.overlay
@@ -22,7 +22,7 @@
 		compatible = "nxp,imx-flexspi-nor";
 		size = <67108864>;
 		reg = <0>;
-		spi-max-frequency = <133000000>;
+		spi-max-frequency = <104000000>;
 		status = "okay";
 		jedec-id = [9d 70 17];
 		erase-block-size = <4096>;

--- a/boards/nxp/mimxrt1060_evk/mimxrt1060_evk_mimxrt1062_qspi.overlay
+++ b/boards/nxp/mimxrt1060_evk/mimxrt1060_evk_mimxrt1062_qspi.overlay
@@ -24,7 +24,7 @@
 		compatible = "nxp,imx-flexspi-nor";
 		size = <67108864>;
 		reg = <0>;
-		spi-max-frequency = <133000000>;
+		spi-max-frequency = <104000000>;
 		status = "okay";
 		jedec-id = [9d 70 17];
 		erase-block-size = <4096>;

--- a/boards/nxp/mimxrt1064_evk/mimxrt1064_evk.dts
+++ b/boards/nxp/mimxrt1064_evk/mimxrt1064_evk.dts
@@ -164,7 +164,7 @@ nxp_parallel_i2c: &lpi2c1 {};
 		compatible = "nxp,imx-flexspi-nor";
 		size = <67108864>;
 		reg = <0>;
-		spi-max-frequency = <133000000>;
+		spi-max-frequency = <104000000>;
 		status = "okay";
 		jedec-id = [9d 70 17];
 

--- a/boards/nxp/mimxrt1160_evk/mimxrt1160_evk.dtsi
+++ b/boards/nxp/mimxrt1160_evk/mimxrt1160_evk.dtsi
@@ -95,7 +95,7 @@
 		compatible = "nxp,imx-flexspi-nor";
 		size = <DT_SIZE_M(16*8)>;
 		reg = <0>;
-		spi-max-frequency = <133000000>;
+		spi-max-frequency = <104000000>;
 		status = "okay";
 		jedec-id = [9d 70 17];
 		erase-block-size = <4096>;

--- a/boards/nxp/mimxrt1170_evk/mimxrt1170_evk.dtsi
+++ b/boards/nxp/mimxrt1170_evk/mimxrt1170_evk.dtsi
@@ -222,7 +222,7 @@
 		compatible = "nxp,imx-flexspi-nor";
 		size = <DT_SIZE_M(16*8)>;
 		reg = <0>;
-		spi-max-frequency = <133000000>;
+		spi-max-frequency = <104000000>;
 		status = "okay";
 		jedec-id = [9d 70 17];
 		erase-block-size = <4096>;

--- a/drivers/flash/flash_mcux_flexspi_nor.c
+++ b/drivers/flash/flash_mcux_flexspi_nor.c
@@ -936,6 +936,7 @@ static int flash_flexspi_nor_check_jedec(struct flash_flexspi_nor_data *data,
 {
 	int ret;
 	uint32_t vendor_id;
+	uint32_t read_params;
 
 	ret = flash_flexspi_nor_read_id_helper(data, (uint8_t *)&vendor_id);
 	if (ret < 0) {
@@ -944,13 +945,26 @@ static int flash_flexspi_nor_check_jedec(struct flash_flexspi_nor_data *data,
 
 	/* Switch on manufacturer and vendor ID */
 	switch (vendor_id & 0xFFFF) {
+	case 0x609d: /* IS25LP flash, needs P[4:3] cleared with same method as IS25WP */
+		read_params = 0xE0U;
+		ret = flash_flexspi_nor_is25_clear_read_param(data, flexspi_lut, &read_params);
+		if (ret < 0) {
+			while (1) {
+				/*
+				 * Spin here, this flash won't configure correctly.
+				 * We can't print a warning, as we are unlikely to
+				 * be able to XIP at this point.
+				 */
+			}
+		}
+		/* Still return an error- we want the JEDEC configuration to run */
+		return -ENOTSUP;
 	case 0x709d:
 		/*
 		 * IS25WP flash. We can support this flash with the JEDEC probe,
 		 * but we need to insure P[6:3] are at the default value
 		 */
-		/* Install Set Read Parameters (Volatile) command */
-		uint32_t read_params = 0;
+		read_params = 0;
 		ret = flash_flexspi_nor_is25_clear_read_param(data, flexspi_lut, &read_params);
 		if (ret < 0) {
 			while (1) {

--- a/drivers/flash/flash_mcux_flexspi_nor.c
+++ b/drivers/flash/flash_mcux_flexspi_nor.c
@@ -596,6 +596,10 @@ static int flash_flexspi_nor_quad_enable(struct flash_flexspi_nor_data *data,
 	if (ret < 0) {
 		return ret;
 	}
+	if (qer == JESD216_DW15_QER_VAL_S2B1v5) {
+		/* Left shift buffer by a byte */
+		buffer = buffer << 8;
+	}
 	buffer |= bit;
 	transfer.dataSize = wr_size;
 	transfer.seqIndex = SCRATCH_CMD2;


### PR DESCRIPTION
Some NXP boards program the IS25WP flash read parameters bits (P[6:3]) to use a higher frequency at boot, which interferes with the SFDP probe commands in the FlexSPI NOR driver. Reprogram these bits at boot time so the probe works as expected.

This PR also corrects the following issues with the FlexSPI NOR driver:
- Write enable instruction should be issued before setting the status register for quad enable
- After setting quad enable, the flash will be busy. The busy bit should be polled until it is ready to be accessed again
- Quad enable method 5 reads from status register 2, and writes to status register 1. We need to shift the buffer value written to account for this difference
- move the LUT table used during probing to the `.data` section, to reduce stack usage
- The maximum frequency for the IS25WP flash when using SFDP probe is 104 MHz. Set this correctly for boards using the flash chip.

Verified using `tests/drivers/flash/common` on the following boards:
- mimxrt1020_evk
- mimxrt1060_evk
- mimxrt1064_evk
- mixmrt1170_evk//cm7