### PR TITLE
net: lib: lwm2m: lwm2m_rw_senml_cbor: fix temp64 uninitialized warning

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_rw_senml_cbor.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rw_senml_cbor.c
@@ -601,7 +601,9 @@ static int get_time(struct lwm2m_input_context *in, time_t *value)
 	int ret;
 
 	ret = get_s64(in, &temp64);
-	*value = (time_t)temp64;
+	if (ret == 0) {
+		*value = (time_t)temp64;
+	}
 
 	return ret;
 }


### PR DESCRIPTION
Currently GCC complains that temp64 may be used uninitialized
 
 ```bash
 /home/runner/work/etc-em3-firmware/etc-em3-firmware/zephyr/subsys/net/lib/lwm2m/lwm2m_rw_senml_cbor.c:604:18: error: ‘temp64’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
  604 |         *value = (time_t)temp64;
      |                  ^~~~~~~~~~~~~~
cc1: all warnings being treated as errors
```