### PR TITLE
Documentation: Update documentation for Infineon boards

### DIFF
--- a/boards/cypress/cy8ckit_062_ble/Kconfig.cy8ckit_062_ble
+++ b/boards/cypress/cy8ckit_062_ble/Kconfig.cy8ckit_062_ble
@@ -1,4 +1,4 @@
-# PSoC6 BLE Pioneer Kit configuration
+# PSOC 6 BLE Pioneer Kit configuration
 
 # Copyright (c) 2018 Cypress
 # Copyright (c) 2020 ATL Electronics

--- a/boards/cypress/cy8ckit_062_ble/board.yml
+++ b/boards/cypress/cy8ckit_062_ble/board.yml
@@ -1,6 +1,6 @@
 board:
   name: cy8ckit_062_ble
-  full_name: PSoC63 BLE Pioneer Kit
+  full_name: PSOC 63 BLE Pioneer Kit
   vendor: cypress
   revision:
     format: "major.minor.patch"

--- a/boards/cypress/cy8ckit_062_ble/cy8ckit_062_ble_cy8c6347_m0.dts
+++ b/boards/cypress/cy8ckit_062_ble/cy8ckit_062_ble_cy8c6347_m0.dts
@@ -11,7 +11,7 @@
 #include "cy8ckit_062_ble_common.dtsi"
 
 / {
-	model = "Cypress PSoC6 BLE Pioneer Kit";
+	model = "Cypress PSOC 6 BLE Pioneer Kit";
 	compatible = "cypress,cy8c6xx7_cm0p", "cypress,psoc6";
 
 	chosen {

--- a/boards/cypress/cy8ckit_062_ble/cy8ckit_062_ble_cy8c6347_m0_0_0_0.yaml
+++ b/boards/cypress/cy8ckit_062_ble/cy8ckit_062_ble_cy8c6347_m0_0_0_0.yaml
@@ -6,7 +6,7 @@
 #
 
 identifier: cy8ckit_062_ble@0.0.0/cy8c6347/m0
-name: Cypress PSoC6 BLE Pioneer Kit (M0, rev. 0.0.0)
+name: Cypress PSOC 6 BLE Pioneer Kit (M0, rev. 0.0.0)
 type: mcu
 arch: arm
 ram: 288

--- a/boards/cypress/cy8ckit_062_ble/cy8ckit_062_ble_cy8c6347_m0_1_0_0.yaml
+++ b/boards/cypress/cy8ckit_062_ble/cy8ckit_062_ble_cy8c6347_m0_1_0_0.yaml
@@ -6,7 +6,7 @@
 #
 
 identifier: cy8ckit_062_ble@1.0.0/cy8c6347/m0
-name: Cypress PSoC6 BLE Pioneer Kit (M0, rev. 1.0.0)
+name: Cypress PSOC 6 BLE Pioneer Kit (M0, rev. 1.0.0)
 type: mcu
 arch: arm
 ram: 288

--- a/boards/cypress/cy8ckit_062_ble/cy8ckit_062_ble_cy8c6347_m4.dts
+++ b/boards/cypress/cy8ckit_062_ble/cy8ckit_062_ble_cy8c6347_m4.dts
@@ -11,7 +11,7 @@
 #include "cy8ckit_062_ble_common.dtsi"
 
 / {
-	model = "Cypress PSoC6 BLE Pioneer Kit";
+	model = "Cypress PSOC 6 BLE Pioneer Kit";
 	compatible = "cypress,cy8c6xx7_cm4", "cypress,psoc6";
 
 	chosen {

--- a/boards/cypress/cy8ckit_062_ble/cy8ckit_062_ble_cy8c6347_m4_0_0_0.yaml
+++ b/boards/cypress/cy8ckit_062_ble/cy8ckit_062_ble_cy8c6347_m4_0_0_0.yaml
@@ -6,7 +6,7 @@
 #
 
 identifier: cy8ckit_062_ble@0.0.0/cy8c6347/m4
-name: Cypress PSoC6 BLE Pioneer Kit (M4, rev. 0.0.0)
+name: Cypress PSOC 6 BLE Pioneer Kit (M4, rev. 0.0.0)
 type: mcu
 arch: arm
 ram: 288

--- a/boards/cypress/cy8ckit_062_ble/cy8ckit_062_ble_cy8c6347_m4_1_0_0.yaml
+++ b/boards/cypress/cy8ckit_062_ble/cy8ckit_062_ble_cy8c6347_m4_1_0_0.yaml
@@ -6,7 +6,7 @@
 #
 
 identifier: cy8ckit_062_ble@1.0.0/cy8c6347/m4
-name: Cypress PSoC6 BLE Pioneer Kit (M4, rev. 1.0.0)
+name: Cypress PSOC 6 BLE Pioneer Kit (M4, rev. 1.0.0)
 type: mcu
 arch: arm
 ram: 288

--- a/boards/cypress/cy8ckit_062_ble/doc/index.rst
+++ b/boards/cypress/cy8ckit_062_ble/doc/index.rst
@@ -1,21 +1,21 @@
 .. _cy8ckit_062_ble:
 
-INFINEON PSoC63 BLE Pioneer Kit
-###############################
+INFINEON PSOC 63 BLE Pioneer Kit
+################################
 
 Overview
 ********
 
-The PSoC 6 BLE Pioneer Kit (CY8CKIT-062-BLE) is a hardware platform that
-enables design and debug of the Cypress PSoC 63 BLE MCU.
+The PSOC 6 BLE Pioneer Kit (CY8CKIT-062-BLE) is a hardware platform that
+enables design and debug of the Cypress PSOC 63 BLE MCU.
 
-The PSoC 6 BLE Pioneer Kit features the PSoC 63 MCU: a dual-core MCU, with a
+The PSOC 6 BLE Pioneer Kit features the PSOC 63 MCU: a dual-core MCU, with a
 150-MHz Arm Cortex-M4 as the primary application processor and a 100-MHz Arm
 Cortex-M0+ that supports low-power operations, 1MB of Flash, 288KB of SRAM,
 an integrated BLE 4.2 radio, 78 GPIO, 7 programmable analog blocks, 12
 programmable digital blocks, and capacitive-sensing with CapSense.
 
-The PSoC 6 BLE Pioneer board offers compatibility with Arduino shields, a
+The PSOC 6 BLE Pioneer board offers compatibility with Arduino shields, a
 512-Mb NOR flash, onboard programmer/debugger (KitProg2), USB Type-C power
 delivery system (EZ-PD™ CCG3), 5-segment CapSense slider, two CapSense
 buttons, one CapSense proximity sensing header, an RGB LED, two user LEDs,
@@ -42,45 +42,45 @@ enables the CM4 core.
 6. KitProg2 I/O header (J6)1
 7. KitProg2 programming/custom application header (J7)1
 8. External power supply connector (J9)
-9. PSoC 6 BLE user button (SW2)
+9. PSOC 6 BLE user button (SW2)
 10. KitProg2 application selection button (SW4)
 11. Digilent® Pmod™ compatible I/O header (J14)1
 12. Power LED (LED4)
 13. KitProg2 status LEDs (LED1, LED2, and LED3)
-14. PSoC 6 reset button (SW1)
-15. PSoC 6 I/O header (J18, J19 and J20)
+14. PSOC 6 reset button (SW1)
+15. PSOC 6 I/O header (J18, J19 and J20)
 16. Arduino™ Uno R3 compatible power header (J1)
-17. PSoC 6 debug and trace header (J12)
-18. Arduino Uno R3 compatible PSoC 6 I/O header (J2, J3 and J4)
-19. PSoC 6 program and debug header (J11)
+17. PSOC 6 debug and trace header (J12)
+18. Arduino Uno R3 compatible PSOC 6 I/O header (J2, J3 and J4)
+19. PSOC 6 program and debug header (J11)
 20. KitProg2 programming target selection switch (SW6)
 21. CapSense slider and buttons
 22. CapSense proximity header (J13)
-23. PSoC 6 BLE VDD selection switch (SW5)
-24. PSoC 6 BLE power monitoring jumper (J8)2
+23. PSOC 6 BLE VDD selection switch (SW5)
+24. PSOC 6 BLE power monitoring jumper (J8)2
 25. Arduino Uno R3 compatible ICSP header (J5)1
-26. PSoC 6 user LEDs (LED8 and LED9)
+26. PSOC 6 user LEDs (LED8 and LED9)
 27. RGB LED (LED5)
 28. Cypress  512-Mbit  serial  NOR  Flash  memory  (S25FL512S, U4)
 29. Cypress serial Ferroelectric RAM (U5)1
 30. VBACKUP and PMIC control selection switch (SW7)2
-31. Cypress PSoC 6 BLE (CY8C6347BZI-BLD53, U1)
+31. Cypress PSOC 6 BLE (CY8C6347BZI-BLD53, U1)
 32. BLE Antenna
 33. U.FL connector for external antenna (J17)1
 34. Cypress main voltage regulator (MB39C022G, U6)
-35. KitProg2  (PSoC  5LP)  programmer  and  debugger(CY8C5868LTI-LP039, U2)
+35. KitProg2  (PSOC  5LP)  programmer  and  debugger(CY8C5868LTI-LP039, U2)
 36. Battery connector (J15)1,2
 37. USB PD output voltage (9V/12V) connector (J16)
 
 Hardware
 ********
 
-For more information about the PSoC 63 BLE MCU SoC and CY8CKIT-062-BLE board:
+For more information about the PSOC 63 BLE MCU SoC and CY8CKIT-062-BLE board:
 
-- `PSoC 63 BLE MCU SoC Website`_
-- `PSoC 63 BLE MCU Datasheet`_
-- `PSoC 63 BLE MCU Architecture Reference Manual`_
-- `PSoC 63 BLE MCU Register Reference Manual`_
+- `PSOC 63 BLE MCU SoC Website`_
+- `PSOC 63 BLE MCU Datasheet`_
+- `PSOC 63 BLE MCU Architecture Reference Manual`_
+- `PSOC 63 BLE MCU Register Reference Manual`_
 - `CY8CKIT-062-BLE Website`_
 - `CY8CKIT-062-BLE User Guide`_
 - `CY8CKIT-062-BLE Schematics`_
@@ -118,18 +118,18 @@ Cortex-M4
 System Clock
 ============
 
-The PSoC 63 BLE MCU SoC is configured to use the internal IMO+FLL as a source for
+The PSOC 63 BLE MCU SoC is configured to use the internal IMO+FLL as a source for
 the system clock. CM0+ works at 50MHz, CM4 - at 100MHz. Other sources for the
 system clock are provided in the SOC, depending on your system requirements.
 
 Serial Port
 ===========
 
-The PSoC 63 BLE MCU SoC has 8 SCB blocks and each one can be configured as
+The PSOC 63 BLE MCU SoC has 8 SCB blocks and each one can be configured as
 UART/SPI/I2C interfaces for serial communication. At the moment UART5 on SCB5
 and UART6 on SCB6 are configured. SCB5 is connected to the onboard KitProg2's
 USB-UART Bridge working as a serial console interface. SCB6 to P13_0, P13_1
-pins on the J3 of the Arduino Uno R3 compatible PSoC6 I/O header for general
+pins on the J3 of the Arduino Uno R3 compatible PSOC 6 I/O header for general
 purposes.
 
 OpenOCD Installation
@@ -149,7 +149,7 @@ Programming and Debugging
 
 The CY8CKIT-062-BLE includes an onboard programmer/debugger (KitProg2) with
 mass storage programming to provide debugging, flash programming, and serial
-communication over USB. There are also PSoC 6 program and debug headers J11
+communication over USB. There are also PSOC 6 program and debug headers J11
 and J12 that can be used with Segger J-Link [default].
 A watchdog timer is enabled by default. To disable it call Cy_WDT_Unlock() and
 Cy_WDT_Disable().
@@ -285,16 +285,16 @@ References
 
 .. target-notes::
 
-.. _PSoC 63 BLE MCU SoC Website:
+.. _PSOC 63 BLE MCU SoC Website:
 	https://www.cypress.com/products/32-bit-arm-cortex-m4-cortex-m0-psoc-63-connectivity-line
 
-.. _PSoC 63 BLE MCU Datasheet:
+.. _PSOC 63 BLE MCU Datasheet:
 	https://www.cypress.com/documentation/datasheets/psoc-6-mcu-psoc-63-ble-datasheet-programmable-system-chip-psoc
 
-.. _PSoC 63 BLE MCU Architecture Reference Manual:
+.. _PSOC 63 BLE MCU Architecture Reference Manual:
 	https://www.cypress.com/documentation/technical-reference-manuals/psoc-6-mcu-psoc-63-ble-architecture-technical-reference
 
-.. _PSoC 63 BLE MCU Register Reference Manual:
+.. _PSOC 63 BLE MCU Register Reference Manual:
 	https://www.cypress.com/documentation/technical-reference-manuals/psoc-6-mcu-cy8c63x6-cy8c63x7-cy8c63x6-cy8c63x7-registers
 
 .. _CY8CKIT-062-BLE Website:

--- a/boards/cypress/cy8ckit_062_wifi_bt/Kconfig.cy8ckit_062_wifi_bt
+++ b/boards/cypress/cy8ckit_062_wifi_bt/Kconfig.cy8ckit_062_wifi_bt
@@ -1,4 +1,4 @@
-# PSoC6 WiFi-BT Pioneer Kit configuration
+# PSOC 6 WiFi-BT Pioneer Kit configuration
 
 # Copyright (c) 2018 Cypress
 # Copyright (c) 2020 ATL Electronics

--- a/boards/cypress/cy8ckit_062_wifi_bt/board.yml
+++ b/boards/cypress/cy8ckit_062_wifi_bt/board.yml
@@ -1,6 +1,6 @@
 board:
   name: cy8ckit_062_wifi_bt
-  full_name: PSoC6 WiFi-BT Pioneer Kit
+  full_name: PSOC 6 WiFi-BT Pioneer Kit
   vendor: cypress
   socs:
   - name: cy8c6247

--- a/boards/cypress/cy8ckit_062_wifi_bt/cy8ckit_062_wifi_bt_cy8c6247_m0.dts
+++ b/boards/cypress/cy8ckit_062_wifi_bt/cy8ckit_062_wifi_bt_cy8c6247_m0.dts
@@ -12,8 +12,8 @@
 #include "cy8ckit_062_wifi_bt_cy8c6247-pinctrl.dtsi"
 
 / {
-	model = "cy8ckit_062_wifi_bt_m0 with a Cypress PSoC6 SoC";
-	compatible = "cypress,cy8ckit_062_wifi_bt_m0", "cypress,PSoC6";
+	model = "cy8ckit_062_wifi_bt_m0 with a Cypress PSOC 6 SoC";
+	compatible = "cypress,cy8ckit_062_wifi_bt_m0", "cypress,PSOC6";
 
 	aliases {
 		sw0 = &user_bt;

--- a/boards/cypress/cy8ckit_062_wifi_bt/cy8ckit_062_wifi_bt_cy8c6247_m0.yaml
+++ b/boards/cypress/cy8ckit_062_wifi_bt/cy8ckit_062_wifi_bt_cy8c6247_m0.yaml
@@ -5,7 +5,7 @@
 #
 
 identifier: cy8ckit_062_wifi_bt/cy8c6247/m0
-name: Cypress PSoC6 WiFi-BT Pioneer Kit (M0)
+name: Cypress PSOC 6 WiFi-BT Pioneer Kit (M0)
 type: mcu
 arch: arm
 ram: 288

--- a/boards/cypress/cy8ckit_062_wifi_bt/cy8ckit_062_wifi_bt_cy8c6247_m4.dts
+++ b/boards/cypress/cy8ckit_062_wifi_bt/cy8ckit_062_wifi_bt_cy8c6247_m4.dts
@@ -10,8 +10,8 @@
 #include "cy8ckit_062_wifi_bt_cy8c6247-pinctrl.dtsi"
 
 / {
-	model = "cy8ckit_062_wifi_bt_m4 with a Cypress PSoC6 SoC";
-	compatible = "cypress,cy8ckit_062_wifi_bt_m4", "cypress,PSoC6";
+	model = "cy8ckit_062_wifi_bt_m4 with a Cypress PSOC 6 SoC";
+	compatible = "cypress,cy8ckit_062_wifi_bt_m4", "cypress,PSOC6";
 
 	aliases {
 		uart-5 = &uart5;

--- a/boards/cypress/cy8ckit_062_wifi_bt/cy8ckit_062_wifi_bt_cy8c6247_m4.yaml
+++ b/boards/cypress/cy8ckit_062_wifi_bt/cy8ckit_062_wifi_bt_cy8c6247_m4.yaml
@@ -5,7 +5,7 @@
 #
 
 identifier: cy8ckit_062_wifi_bt/cy8c6247/m4
-name: Cypress PSoC6 WiFi-BT Pioneer Kit (M4)
+name: Cypress PSOC 6 WiFi-BT Pioneer Kit (M4)
 type: mcu
 arch: arm
 ram: 288

--- a/boards/cypress/cy8ckit_062_wifi_bt/doc/index.rst
+++ b/boards/cypress/cy8ckit_062_wifi_bt/doc/index.rst
@@ -1,16 +1,16 @@
 .. _cy8ckit_062_wifi_bt:
 
-INFINEON PSoC6 WiFi-BT Pioneer Kit
-##################################
+INFINEON PSOC 6 WiFi-BT Pioneer Kit
+###################################
 
 Overview
 ********
 
-The PSoC 6 WiFi-BT Pioneer Kit (CY8CKIT-062-WiFi-BT) is a low-cost hardware
-platform that enables design and debug of the PSoC 62 MCU and the Murata
+The PSOC 6 WiFi-BT Pioneer Kit (CY8CKIT-062-WiFi-BT) is a low-cost hardware
+platform that enables design and debug of the PSOC 62 MCU and the Murata
 LBEE5KL1DX Module (CYW4343W WiFi + Bluetooth Combo Chip).
 
-The PSoC 6 WiFi-BT Pioneer Kit features the PSoC 62 MCU: a
+The PSOC 6 WiFi-BT Pioneer Kit features the PSOC 62 MCU: a
 dual-core MCU, with a 150-MHz Arm Cortex-M4 as the primary application
 processor and a 100-MHz Arm Cortex-M0+ that supports low-power operations,
 1MB of Flash, 288KB of SRAM, 104 GPIO, 7 programmable analog blocks,
@@ -18,7 +18,7 @@ processor and a 100-MHz Arm Cortex-M0+ that supports low-power operations,
 a PDM-PCM digital microphone interface, and industry-leading capacitive-sensing
 with CapSense.
 
-The PSoC 6 WiFi-BT Pioneer board offers compatibility with Arduino shields.
+The PSOC 6 WiFi-BT Pioneer board offers compatibility with Arduino shields.
 
 The Cortex-M0+ is a primary core on the board's SoC. It starts first and
 enables the CM4 core.
@@ -35,45 +35,45 @@ enables the CM4 core.
 6. KitProg2 I/O header (J6)1
 7. KitProg2 programming/custom application header (J7)1
 8. External power supply connector (J9)
-9. PSoC 6 user button (SW2)
+9. PSOC 6 user button (SW2)
 10. KitProg2 application selection button (SW4)
 11. Digilent® Pmod™ compatible I/O header (J14)1
 12. Power LED (LED4)
 13. KitProg2 status LEDs (LED1, LED2, and LED3)
-14. PSoC 6 reset button (SW1)
-15. PSoC 6 I/O header (J18, J19 and J20)
+14. PSOC 6 reset button (SW1)
+15. PSOC 6 I/O header (J18, J19 and J20)
 16. Arduino™ Uno R3 compatible power header (J1)
-17. PSoC 6 debug and trace header (J12)
-18. Arduino Uno R3 compatible PSoC 6 I/O header (J2, J3 and J4)
-19. PSoC 6 program and debug header (J11)
+17. PSOC 6 debug and trace header (J12)
+18. Arduino Uno R3 compatible PSOC 6 I/O header (J2, J3 and J4)
+19. PSOC 6 program and debug header (J11)
 20. CapSense proximity header (J13)
 21. CapSense slider and buttons
-22. PSoC 6 VDD selection switch (SW5)
+22. PSOC 6 VDD selection switch (SW5)
 23. Cypress  512-Mbit  serial  NOR  Flash  memory  (S25-FL512S, U4)
-24. PSoC 6 user LEDs (LED8 and LED9)
+24. PSOC 6 user LEDs (LED8 and LED9)
 25. RGB LED (LED5)
 26. WiFi/BT module (LBEE5KL 1DX, U6)
 27. Cypress serial Ferroelectric RAM (U5)1
 28. WiFi-BT Antenna
 29. VBACKUP and PMIC control selection switch (SW7)2
-30. PSoC 6 USB device Type-C connector (J28)
-31. Cypress PSoC 6 (CY8C6247BZI-D54, U1)
-32. PSoC 6 USB Host Type-A connector (J27)
+30. PSOC 6 USB device Type-C connector (J28)
+31. Cypress PSOC 6 (CY8C6247BZI-D54, U1)
+32. PSOC 6 USB Host Type-A connector (J27)
 33. Arduino Uno R3 compatible ICSP header (J5)1
-34. PSoC 6 power monitoring jumper (J8)2
-35. KitProg2  (PSoC  5LP)  programmer  and  debugger(CY8C5868LTI-LP039, U2)
+34. PSOC 6 power monitoring jumper (J8)2
+35. KitProg2  (PSOC  5LP)  programmer  and  debugger(CY8C5868LTI-LP039, U2)
 36. Battery connector (J15)1,2
 37. USB PD output voltage (9V/12V) connector (J16)
 
 Hardware
 ********
 
-For more information about the PSoC 62 MCU SoC and CY8CKIT-062-WiFi-BT board:
+For more information about the PSOC 62 MCU SoC and CY8CKIT-062-WiFi-BT board:
 
-- `PSoC 62 MCU SoC Website`_
-- `PSoC 62 MCU Datasheet`_
-- `PSoC 62 MCU Architecture Reference Manual`_
-- `PSoC 62 MCU Register Reference Manual`_
+- `PSOC 62 MCU SoC Website`_
+- `PSOC 62 MCU Datasheet`_
+- `PSOC 62 MCU Architecture Reference Manual`_
+- `PSOC 62 MCU Register Reference Manual`_
 - `CY8CKIT-062-WiFi-BT Website`_
 - `CY8CKIT-062-WiFi-BT User Guide`_
 - `CY8CKIT-062-WiFi-BT Schematics`_
@@ -105,18 +105,18 @@ The default configuration can be found in the Kconfig
 System Clock
 ============
 
-The PSoC 62 MCU SoC is configured to use the internal IMO+FLL as a source for
+The PSOC 62 MCU SoC is configured to use the internal IMO+FLL as a source for
 the system clock. CM0+ works at 50MHz, CM4 - at 100MHz. Other sources for the
 system clock are provided in the SOC, depending on your system requirements.
 
 Serial Port
 ===========
 
-The PSoC 62 MCU SoC has 9 SCB blocks 8 of each can be configured as UART
+The PSOC 62 MCU SoC has 9 SCB blocks 8 of each can be configured as UART
 interfaces for serial communication. At the moment UART5 on SCB5 and UART6 on
 SCB6 are configured. SCB5 is connected to the onboard KitProg2's USB-UART
 Bridge, SCB6 to P12_0, P12_1 pins on the J3 of the Arduino Uno R3 compatible
-PSoC6 I/O header.
+PSOC 6 I/O header.
 
 OpenOCD Installation
 ====================
@@ -136,7 +136,7 @@ Programming and Debugging
 
 The CY8CKIT-062-WiFi-BT includes an onboard programmer/debugger (KitProg2) with
 mass storage programming to provide debugging, flash programming, and serial
-communication over USB. There are also PSoC 6 program and debug headers J11
+communication over USB. There are also PSOC 6 program and debug headers J11
 and J12 that can be used with Segger J-Link.
 A watchdog timer is enabled by default. To disable it call Cy_WDT_Unlock() and
 Cy_WDT_Disable().
@@ -188,16 +188,16 @@ References
 
 .. target-notes::
 
-.. _PSoC 62 MCU SoC Website:
+.. _PSOC 62 MCU SoC Website:
 	https://www.cypress.com/products/32-bit-arm-cortex-m4-psoc-6
 
-.. _PSoC 62 MCU Datasheet:
+.. _PSOC 62 MCU Datasheet:
 	https://www.cypress.com/documentation/datasheets/psoc-6-mcu-psoc-62-datasheet-programmable-system-chip-psoc-preliminary
 
-.. _PSoC 62 MCU Architecture Reference Manual:
+.. _PSOC 62 MCU Architecture Reference Manual:
 	https://www.cypress.com/documentation/technical-reference-manuals/psoc-6-mcu-psoc-62-architecture-technical-reference-manual
 
-.. _PSoC 62 MCU Register Reference Manual:
+.. _PSOC 62 MCU Register Reference Manual:
 	https://www.cypress.com/documentation/technical-reference-manuals/psoc-6-mcu-psoc-62-register-technical-reference-manual-trm
 
 .. _CY8CKIT-062-WiFi-BT Website:

--- a/boards/infineon/cy8ckit_062s4/cy8ckit_062s4.dts
+++ b/boards/infineon/cy8ckit_062s4/cy8ckit_062s4.dts
@@ -7,7 +7,7 @@
 #include <infineon/cat1a/mpns/CY8C6244LQI_S4D92.dtsi>
 
 / {
-	model = "Infineon PSoC 62S4 Pioneer Kit";
+	model = "Infineon PSOC 62S4 Pioneer Kit";
 	compatible ="cypress,psoc6";
 	chosen {
 		zephyr,sram = &sram0;

--- a/boards/infineon/cy8ckit_062s4/cy8ckit_062s4.yaml
+++ b/boards/infineon/cy8ckit_062s4/cy8ckit_062s4.yaml
@@ -2,7 +2,7 @@
 # Copyright (c) 2023 David Ullmann
 
 identifier: cy8ckit_062s4
-name: CY8CKIT-062S4 PSoC 62S4
+name: CY8CKIT-062S4 PSOC 62S4
 type: mcu
 arch: arm
 ram: 128

--- a/boards/infineon/cy8ckit_062s4/doc/index.rst
+++ b/boards/infineon/cy8ckit_062s4/doc/index.rst
@@ -2,7 +2,7 @@
 
 Overview
 ********
-The PSOC 62S4 Pioneer kit has a CY8C62x4 MCU, which is an ultra-low-power PSoC device specifically designed for battery-operated analog
+The PSOC 62S4 Pioneer kit has a CY8C62x4 MCU, which is an ultra-low-power PSOC device specifically designed for battery-operated analog
 sensing applications. It includes a 150-MHz Arm® Cortex®-M4 CPU as the primary application processor, a 100-MHz Arm® Cortex®-M0+ CPU that
 supports low-power operations, up to 256 KB Flash and 128 KB SRAM, programmable analog sensing,
 CapSense™ touch-sensing, and programmable digital peripherals.
@@ -39,8 +39,10 @@ The board configuration supports the following hardware features:
 | UART      | on-chip    | serial port-polling;  |
 +-----------+------------+-----------------------+
 
+
 The default configuration can be found in the Kconfig
-:zephyr_file:`boards/infineon/cy8ckit_062s4/cy8ckit_062s4_defconfig`.
+
+:zephyr_file:`boards/infineon/cy8ckit_062s4/cy8ckit_062s4_defconfig`
 
 Clock Configuration
 ===================
@@ -56,37 +58,67 @@ Clock Configuration
 +-----------+------------+-----------------------+
 
 Fetch Binary Blobs
-==================
+******************
 
 .. code-block:: console
 
    west blobs fetch hal_infineon
 
+Build blinking led sample
+*************************
 
-Build and flash hello world sample
-**********************************
+Here is an example for building the :zephyr:code-sample:`blinky` sample application.
 
+.. zephyr-app-commands::
+   :zephyr-app: samples/basic/blinky
+   :board: cy8ckit_062s4
+   :goals: build
 
-.. code-block:: console
+Programming and Debugging
+*************************
 
-   cd zephyr/samples/hello_world
-   west build -p auto -b cy8ckit_062s4 --pristine
-   west flash
-   picocom /dev/ttyACM0 -b 115200
+The CY8CKIT-062S4 includes an onboard programmer/debugger (`KitProg3`_) to provide debugging, flash programming, and serial communication over USB. Flash and debug commands use OpenOCD and require a custom Infineon OpenOCD version, that supports KitProg3, to be installed.
 
-OpenOCD Installation
-====================
+Infineon OpenOCD Installation
+=============================
 
-To get the OpenOCD package, it is required that you
+Both the full `ModusToolbox`_ and the `ModusToolbox Programming Tools`_ packages include Infineon OpenOCD. Installing either of these packages will also install Infineon OpenOCD. If neither package is installed, a minimal installation can be done by downloading the `Infineon OpenOCD`_ release for your system and manually extract the files to a location of your choice.
 
-1. Download the software ModusToolbox 3.1. https://softwaretools.infineon.com/tools/com.ifx.tb.tool.modustoolbox
-2. Once downloaded add the path to access the Scripts folder provided by ModusToolbox::
+.. note:: Linux requires device access rights to be set up for KitProg3. This is handled automatically by the ModusToolbox and ModusToolbox Programming Tools installations. When doing a minimal installation, this can be done manually by executing the script ``openocd/udev_rules/install_rules.sh``.
 
-      export PATH=$PATH:/path/to/ModusToolbox/tools_3.1/openocd/scripts
+West Commands
+=============
 
-3. Add the OpenOCD executable file's path to west flash/debug.
-4. Flash using: ``west flash --openocd path/to/infineon/openocd/bin/openocd``
-5. Debug using: ``west debug --openocd path/to/infineon/openocd/bin/openocd``
+The path to the installed Infineon OpenOCD executable must be available to the ``west`` tool commands. There are multiple ways of doing this. The example below uses a permanent CMake argument to set the CMake variable ``OPENOCD``.
+
+   .. tabs::
+      .. group-tab:: Windows
+
+         .. code-block:: shell
+
+            # Run west config once to set permanent CMake argument
+            west config build.cmake-args -- -DOPENOCD=path/to/infineon/openocd/bin/openocd.exe
+
+            # Do a pristine build once after setting CMake argument
+            west build -b cy8ckit_062s4 -p always samples/basic/blinky
+
+            west flash
+            west debug
+
+      .. group-tab:: Linux
+
+         .. code-block:: shell
+
+            # Run west config once to set permanent CMake argument
+            west config build.cmake-args -- -DOPENOCD=path/to/infineon/openocd/bin/openocd
+
+            # Do a pristine build once after setting CMake argument
+            west build -b cy8ckit_062s4 -p always samples/basic/blinky
+
+            west flash
+            west debug
+
+Once the gdb console starts after executing the west debug command, you may now set breakpoints and perform other standard GDB debugging on the PSOC 6 CM4 core.
 
 References
 **********
@@ -94,16 +126,28 @@ References
 .. target-notes::
 
 .. _CY8CKIT 062S4 Pioneer Kit Guide:
-    https://www.infineon.com/dgdl/Infineon-CY8CKIT_062S4_PSoC62S4_pioneer_kit_guide-UserManual-v01_00-EN.pdf?fileId=8ac78c8c7e7124d1017e962f98992207
+    https://www.infineon.com/dgdl/Infineon-CY8CKIT_062S4_PSOC62S4_pioneer_kit_guide-UserManual-v01_00-EN.pdf?fileId=8ac78c8c7e7124d1017e962f98992207
 
 .. _CY8CKIT 062S4 Pioneer Kit Website:
     https://www.infineon.com/cms/en/product/evaluation-boards/cy8ckit-062s4/?redirId=VL1508&utm_medium=referral&utm_source=cypress&utm_campaign=202110_globe_en_all_integration-dev_kit
 
 .. _CY8CKIT 062S4 Pioneer Kit Schematic:
-    https://www.infineon.com/dgdl/Infineon-CY8CKIT-062S4_PSoC_62S4_Pioneer_Kit_Schematic-PCBDesignData-v01_00-EN.pdf?fileId=8ac78c8c7d710014017d7153484d2081
+    https://www.infineon.com/dgdl/Infineon-CY8CKIT-062S4_PSOC_62S4_Pioneer_Kit_Schematic-PCBDesignData-v01_00-EN.pdf?fileId=8ac78c8c7d710014017d7153484d2081
 
 .. _CY8CKIT 062S4 Pioneer Kit Technical Reference Manual:
     https://www.infineon.com/dgdl/Infineon-PSOC_6_MCU_CY8C61X4CY8C62X4_REGISTERS_TECHNICAL_REFERENCE_MANUAL_(TRM)_PSOC_61_PSOC_62_MCU-AdditionalTechnicalInformation-v03_00-EN.pdf?fileId=8ac78c8c7d0d8da4017d0fb34f0627a7
 
 .. _CY8CKIT 062S4 Pioneer Kit Datasheet:
-   https://www.infineon.com/dgdl/Infineon-PSoC_6_MCU_CY8C62X4-DataSheet-v12_00-EN.pdf?fileId=8ac78c8c7ddc01d7017ddd026d585901
+   https://www.infineon.com/dgdl/Infineon-PSOC_6_MCU_CY8C62X4-DataSheet-v12_00-EN.pdf?fileId=8ac78c8c7ddc01d7017ddd026d585901
+
+.. _ModusToolbox:
+    https://softwaretools.infineon.com/tools/com.ifx.tb.tool.modustoolbox
+
+.. _ModusToolbox Programming Tools:
+    https://softwaretools.infineon.com/tools/com.ifx.tb.tool.modustoolboxprogtools
+
+.. _Infineon OpenOCD:
+    https://github.com/Infineon/openocd/releases/latest
+
+.. _KitProg3:
+    https://github.com/Infineon/KitProg3

--- a/boards/infineon/cy8cproto_062_4343w/Kconfig.cy8cproto_062_4343w
+++ b/boards/infineon/cy8cproto_062_4343w/Kconfig.cy8cproto_062_4343w
@@ -1,4 +1,4 @@
-# CY8CPROTO-062-4343W PSoC™ 6 Wi-Fi BT Prototyping Kit
+# CY8CPROTO-062-4343W PSOC™ 6 Wi-Fi BT Prototyping Kit
 
 # Copyright (c) 2021 Cypress Semiconductor Corporation.
 # SPDX-License-Identifier: Apache-2.0

--- a/boards/infineon/cy8cproto_062_4343w/Kconfig.defconfig
+++ b/boards/infineon/cy8cproto_062_4343w/Kconfig.defconfig
@@ -1,4 +1,4 @@
-# CY8CPROTO-062-4343W PSoC™ 6 Wi-Fi BT Prototyping Kit configuration
+# CY8CPROTO-062-4343W PSOC™ 6 Wi-Fi BT Prototyping Kit configuration
 
 # Copyright (c) 2021 Cypress Semiconductor Corporation.
 # SPDX-License-Identifier: Apache-2.0

--- a/boards/infineon/cy8cproto_062_4343w/cy8cproto_062_4343w.dts
+++ b/boards/infineon/cy8cproto_062_4343w/cy8cproto_062_4343w.dts
@@ -10,8 +10,8 @@
 #include "cy8cproto_062_4343w-pinctrl.dtsi"
 
 / {
-	model = "cy8cproto_062_4343w with an Cypress PSoC™ 6 SoC";
-	compatible = "cypress,cy8cproto_062_4343w", "cypress,PSoC6";
+	model = "cy8cproto_062_4343w with an Cypress PSOC™ 6 SoC";
+	compatible = "cypress,cy8cproto_062_4343w", "cypress,PSOC6";
 
 	aliases {
 		uart-5 = &uart5;

--- a/boards/infineon/cy8cproto_062_4343w/cy8cproto_062_4343w.yaml
+++ b/boards/infineon/cy8cproto_062_4343w/cy8cproto_062_4343w.yaml
@@ -4,7 +4,7 @@
 #
 
 identifier: cy8cproto_062_4343w
-name: CY8CPROTO-062-4343W PSoC 6 Wi-Fi BT Prototyping Kit
+name: CY8CPROTO-062-4343W PSOC 6 Wi-Fi BT Prototyping Kit
 type: mcu
 arch: arm
 ram: 1024

--- a/boards/infineon/cy8cproto_062_4343w/doc/index.rst
+++ b/boards/infineon/cy8cproto_062_4343w/doc/index.rst
@@ -3,8 +3,8 @@
 Overview
 ********
 
-The CY8CPROTO-062-4343W PSoC 6 Wi-Fi BT Prototyping Kit is a low-cost hardware
-platform that enables design and debug of PSoC 6 MCUs. It comes with a Murata
+The CY8CPROTO-062-4343W PSOC 6 Wi-Fi BT Prototyping Kit is a low-cost hardware
+platform that enables design and debug of PSOC 6 MCUs. It comes with a Murata
 LBEE5KL1DX module, based on the CYW4343W combo device, industry-leading CAPSENSE
 for touch buttons and slider, on-board debugger/programmer with KitProg3, microSD
 card interface, 512-Mb Quad-SPI NOR flash, PDM-PCM microphone, and a thermistor.
@@ -16,15 +16,15 @@ In addition, support for Digilent's Pmod interface is also provided with this ki
 Hardware
 ********
 
-For more information about the PSoC 62 MCU SoC and CY8CPROTO-062-4343W board:
+For more information about the PSOC 62 MCU SoC and CY8CPROTO-062-4343W board:
 
-- `PSoC 62 MCU SoC Website`_
-- `PSoC 62 MCU Datasheet`_
-- `PSoC 62 MCU Architecture Reference Manual`_
-- `PSoC 62 MCU Register Reference Manual`_
-- `CY8CPROTO-062-4343W PSoC 6 Wi-Fi BT Website`_
-- `CY8CPROTO-062-4343W PSoC 6 Wi-Fi BT User Guide`_
-- `CY8CPROTO-062-4343W PSoC 6 Wi-Fi BT Schematics`_
+- `PSOC 62 MCU SoC Website`_
+- `PSOC 62 MCU Datasheet`_
+- `PSOC 62 MCU Architecture Reference Manual`_
+- `PSOC 62 MCU Register Reference Manual`_
+- `CY8CPROTO-062-4343W PSOC 6 Wi-Fi BT Website`_
+- `CY8CPROTO-062-4343W PSOC 6 Wi-Fi BT User Guide`_
+- `CY8CPROTO-062-4343W PSOC 6 Wi-Fi BT Schematics`_
 
 Kit Features:
 =============
@@ -41,9 +41,10 @@ Kit Features:
 Kit Contents:
 =============
 
-- PSoC 6 Wi-Fi BT Prototyping Board
+- PSOC 6 Wi-Fi BT Prototyping Board
 - USB Type-A to Micro-B cable
-- Quick Start Guide
+- Quick start guide
+
 
 Supported Features
 ==================
@@ -73,7 +74,7 @@ The default configuration can be found in the Kconfig
 System Clock
 ============
 
-The PSoC 62 MCU SoC is configured to use the internal IMO+FLL as a source for
+The PSOC 62 MCU SoC is configured to use the internal IMO+FLL as a source for
 the system clock. CM0+ works at 50MHz, CM4 - at 100MHz. Other sources for the
 system clock are provided in the SOC, depending on your system requirements.
 
@@ -94,50 +95,58 @@ To fetch Binary Blobs:
 Build blinking led sample
 *************************
 
-Here is an example for the :zephyr:code-sample:`blinky` application.
+Here is an example for building the :zephyr:code-sample:`blinky` sample application.
 
-.. code-block:: console
-
-   cd zephyr
-   west build -p auto -b cy8cproto_062_4343w samples/basic/blink
-
-OpenOCD Installation
-====================
-
-To get the OpenOCD package, it is required that you
-
-1. Download the software ModusToolbox 3.1. https://softwaretools.infineon.com/tools/com.ifx.tb.tool.modustoolbox
-2. Once downloaded add the path to access the Scripts folder provided by ModusToolbox
-   export PATH=$PATH:/path/to/ModusToolbox/tools_3.1/openocd/scripts
-3. Add the OpenOCD executable file's path to west flash/debug.
-4. Flash using: west flash --openocd path/to/infineon/openocd/bin/openocd
-5. Debug using: west debug --openocd path/to/infineon/openocd/bin/openocd
-
+.. zephyr-app-commands::
+   :zephyr-app: samples/basic/blinky
+   :board: cy8cproto_062_4343w
+   :goals: build
 
 Programming and Debugging
 *************************
 
-The CY8CPROTO-062-4343W includes an onboard programmer/debugger (KitProg2) with
-mass storage programming to provide debugging, flash programming, and serial
-communication over USB. Flash and debug commands must be pointed to the Cypress
-OpenOCD you downloaded above.
+The CY8CPROTO-062-4343W includes an onboard programmer/debugger (`KitProg3`_) to provide debugging, flash programming, and serial communication over USB. Flash and debug commands use OpenOCD and require a custom Infineon OpenOCD version, that supports KitProg3, to be installed.
 
-On Windows:
+Infineon OpenOCD Installation
+=============================
 
-.. code-block:: console
+Both the full `ModusToolbox`_ and the `ModusToolbox Programming Tools`_ packages include Infineon OpenOCD. Installing either of these packages will also install Infineon OpenOCD. If neither package is installed, a minimal installation can be done by downloading the `Infineon OpenOCD`_ release for your system and manually extract the files to a location of your choice.
 
-   west flash --openocd path/to/infineon/openocd/bin/openocd.exe
-   west debug --openocd path/to/infineon/openocd/bin/openocd.exe
+.. note:: Linux requires device access rights to be set up for KitProg3. This is handled automatically by the ModusToolbox and ModusToolbox Programming Tools installations. When doing a minimal installation, this can be done manually by executing the script ``openocd/udev_rules/install_rules.sh``.
 
-On Linux:
+West Commands
+=============
 
-.. code-block:: console
+The path to the installed Infineon OpenOCD executable must be available to the ``west`` tool commands. There are multiple ways of doing this. The example below uses a permanent CMake argument to set the CMake variable ``OPENOCD``.
 
-   west flash --openocd path/to/infineon/openocd/bin/openocd
-   west debug --openocd path/to/infineon/openocd/bin/openocd
+   .. tabs::
+      .. group-tab:: Windows
 
-Once the gdb console starts after executing the west debug command, you may
-now set breakpoints and perform other standard GDB debugging on the PSoC 6 CM4 core.
+         .. code-block:: shell
+
+            # Run west config once to set permanent CMake argument
+            west config build.cmake-args -- -DOPENOCD=path/to/infineon/openocd/bin/openocd.exe
+
+            # Do a pristine build once after setting CMake argument
+            west build -b cy8cproto_062_4343w -p always samples/basic/blinky
+
+            west flash
+            west debug
+
+      .. group-tab:: Linux
+
+         .. code-block:: shell
+
+            # Run west config once to set permanent CMake argument
+            west config build.cmake-args -- -DOPENOCD=path/to/infineon/openocd/bin/openocd
+
+            # Do a pristine build once after setting CMake argument
+            west build -b cy8cproto_062_4343w -p always samples/basic/blinky
+
+            west flash
+            west debug
+
+Once the gdb console starts after executing the west debug command, you may now set breakpoints and perform other standard GDB debugging on the PSOC 6 CM4 core.
 
 Errata
 ======
@@ -152,26 +161,35 @@ Errata
 | a server instance started by west debugserver. |                                        |
 +------------------------------------------------+----------------------------------------+
 
-.. _PSoC 62 MCU SoC Website:
+.. _PSOC 62 MCU SoC Website:
     https://www.cypress.com/products/32-bit-arm-cortex-m4-psoc-6
 
-.. _PSoC 62 MCU Datasheet:
+.. _PSOC 62 MCU Datasheet:
     https://www.cypress.com/documentation/datasheets/psoc-6-mcu-psoc-62-datasheet-programmable-system-chip-psoc-preliminary
 
-.. _PSoC 62 MCU Architecture Reference Manual:
+.. _PSOC 62 MCU Architecture Reference Manual:
     https://www.cypress.com/documentation/technical-reference-manuals/psoc-6-mcu-psoc-62-architecture-technical-reference-manual
 
-.. _PSoC 62 MCU Register Reference Manual:
+.. _PSOC 62 MCU Register Reference Manual:
     https://www.cypress.com/documentation/technical-reference-manuals/psoc-6-mcu-psoc-62-register-technical-reference-manual-trm
 
-.. _CY8CPROTO-062-4343W PSoC 6 Wi-Fi BT Website:
+.. _CY8CPROTO-062-4343W PSOC 6 Wi-Fi BT Website:
     https://www.infineon.com/cms/en/product/evaluation-boards/cy8cproto-062-4343w/
 
-.. _CY8CPROTO-062-4343W PSoC 6 Wi-Fi BT User Guide:
+.. _CY8CPROTO-062-4343W PSOC 6 Wi-Fi BT User Guide:
     https://www.infineon.com/cms/en/product/evaluation-boards/cy8cproto-062-4343w/#!?fileId=8ac78c8c7d0d8da4017d0f0118571844
 
-.. _CY8CPROTO-062-4343W PSoC 6 Wi-Fi BT Schematics:
+.. _CY8CPROTO-062-4343W PSOC 6 Wi-Fi BT Schematics:
     https://www.infineon.com/cms/en/product/evaluation-boards/cy8cproto-062-4343w/#!?fileId=8ac78c8c7d0d8da4017d0f01126b183f
 
+.. _ModusToolbox:
+    https://softwaretools.infineon.com/tools/com.ifx.tb.tool.modustoolbox
+
+.. _ModusToolbox Programming Tools:
+    https://softwaretools.infineon.com/tools/com.ifx.tb.tool.modustoolboxprogtools
+
 .. _Infineon OpenOCD:
-    https://github.com/infineon/openocd/releases/tag/release-v4.3.0
+    https://github.com/Infineon/openocd/releases/latest
+
+.. _KitProg3:
+    https://github.com/Infineon/KitProg3

--- a/boards/infineon/cy8cproto_063_ble/Kconfig.cy8cproto_063_ble
+++ b/boards/infineon/cy8cproto_063_ble/Kconfig.cy8cproto_063_ble
@@ -1,4 +1,4 @@
-# CY8CPROTO-063-BLE PSoC™ 6 BLE Prototyping Kit
+# CY8CPROTO-063-BLE PSOC™ 6 BLE Prototyping Kit
 #
 # Copyright (c) 2023 Cypress Semiconductor Corporation (an Infineon company) or
 # an affiliate of Cypress Semiconductor Corporation

--- a/boards/infineon/cy8cproto_063_ble/Kconfig.defconfig
+++ b/boards/infineon/cy8cproto_063_ble/Kconfig.defconfig
@@ -1,4 +1,4 @@
-# CY8CPROTO-063-BLE PSoC™ 6 BLE Prototyping Kit
+# CY8CPROTO-063-BLE PSOC™ 6 BLE Prototyping Kit
 
 # Copyright (c) 2023 Cypress Semiconductor Corporation (an Infineon company) or
 # an affiliate of Cypress Semiconductor Corporation

--- a/boards/infineon/cy8cproto_063_ble/cy8cproto_063_ble.dts
+++ b/boards/infineon/cy8cproto_063_ble/cy8cproto_063_ble.dts
@@ -12,8 +12,8 @@
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 
 / {
-	model = "CY8CPROTO-063-BLE PSoC™ 6 BLE Prototyping Kit";
-	compatible = "cypress,cy8cproto_063_ble", "cypress,PSoC6";
+	model = "CY8CPROTO-063-BLE PSOC™ 6 BLE Prototyping Kit";
+	compatible = "cypress,cy8cproto_063_ble", "cypress,PSOC6";
 
 	aliases {
 		uart-5 = &uart5;

--- a/boards/infineon/cy8cproto_063_ble/cy8cproto_063_ble.yaml
+++ b/boards/infineon/cy8cproto_063_ble/cy8cproto_063_ble.yaml
@@ -4,7 +4,7 @@
 #
 
 identifier: cy8cproto_063_ble
-name: CY8CPROTO-063-BLE PSoC™ 6 BLE Prototyping Kit
+name: CY8CPROTO-063-BLE PSOC™ 6 BLE Prototyping Kit
 type: mcu
 arch: arm
 ram: 288

--- a/boards/infineon/cy8cproto_063_ble/doc/index.rst
+++ b/boards/infineon/cy8cproto_063_ble/doc/index.rst
@@ -3,18 +3,18 @@
 Overview
 ********
 
-The PSoC 6 BLE Proto Kit (CY8CPROTO-063-BLE) is a hardware platform that
-enables design and debug of the Cypress PSoC 63 BLE MCU.
+The PSOC 6 BLE Proto Kit (CY8CPROTO-063-BLE) is a hardware platform that
+enables design and debug of the Cypress PSOC 63 BLE MCU.
 
 Hardware
 ********
 
-For more information about the PSoC 63 BLE MCU SoC and CY8CPROTO-063-BLE board:
+For more information about the PSOC 63 BLE MCU SoC and CY8CPROTO-063-BLE board:
 
-- `PSoC 63 BLE MCU SoC Website`_
-- `PSoC 63 BLE MCU Datasheet`_
-- `PSoC 63 BLE MCU Architecture Reference Manual`_
-- `PSoC 63 BLE MCU Register Reference Manual`_
+- `PSOC 63 BLE MCU SoC Website`_
+- `PSOC 63 BLE MCU Datasheet`_
+- `PSOC 63 BLE MCU Architecture Reference Manual`_
+- `PSOC 63 BLE MCU Register Reference Manual`_
 - `CY8CPROTO-063-BLE Website`_
 - `CY8CPROTO-063-BLE User Guide`_
 - `CY8CPROTO-063-BLE Schematics`_
@@ -32,11 +32,11 @@ The board configuration supports the following hardware features:
 +-----------+------------+-----------------------+
 | SYSTICK   | on-chip    | system clock          |
 +-----------+------------+-----------------------+
-| GPIO      | on-chip    | gpio                  |
+| GPIO      | on-chip    | GPIO                  |
 +-----------+------------+-----------------------+
 | PINCTRL   | on-chip    | pin control           |
 +-----------+------------+-----------------------+
-| SPI       | on-chip    | spi                   |
+| SPI       | on-chip    | SPI                   |
 +-----------+------------+-----------------------+
 | UART      | on-chip    | serial port-polling;  |
 |           |            | serial port-interrupt |
@@ -51,28 +51,16 @@ The board configuration supports the following hardware features:
 +-----------+------------+-----------------------+
 
 
-The default configurations can be found in
+The default configuration can be found in the Kconfig
+
 :zephyr_file:`boards/infineon/cy8cproto_063_ble/cy8cproto_063_ble_defconfig`
 
 System Clock
 ============
 
-The PSoC 63 BLE MCU SoC is configured to use the internal IMO+FLL as a source for
+The PSOC 63 BLE MCU SoC is configured to use the internal IMO+FLL as a source for
 the system clock. CM0+ works at 50MHz, CM4 - at 100MHz. Other sources for the
 system clock are provided in the SOC, depending on your system requirements.
-
-
-OpenOCD Installation
-====================
-
-To get the OpenOCD package, it is required that you
-
-1. Download the software ModusToolbox 3.1. https://softwaretools.infineon.com/tools/com.ifx.tb.tool.modustoolbox
-2. Once downloaded add the path to access the Scripts folder provided by ModusToolbox
-   export PATH=$PATH:/path/to/ModusToolbox/tools_3.1/openocd/scripts
-3. Add the OpenOCD executable file's path to west flash/debug.
-4. Flash using: west flash --openocd path/to/infineon/openocd/bin/openocd
-5. Debug using: west debug --openocd path/to/infineon/openocd/bin/openocd
 
 
 Fetch Binary Blobs
@@ -87,43 +75,77 @@ To fetch Binary Blobs:
 
    west blobs fetch hal_infineon
 
+
+Build blinking led sample
+*************************
+
+Here is an example for building the :zephyr:code-sample:`blinky` sample application.
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/basic/blinky
+   :board: cy8cproto_063_ble
+   :goals: build
+
 Programming and Debugging
 *************************
 
-The CY8CPROTO-063-BLE includes an onboard programmer/debugger (KitProg3) with
-mass storage programming to provide debugging, flash programming, and serial
-communication over USB. Flash and debug commands must be pointed to the Cypress
-OpenOCD you downloaded above.
+The CY8CPROTO-063-BLE includes an onboard programmer/debugger (`KitProg3`_) to provide debugging, flash programming, and serial communication over USB. Flash and debug commands use OpenOCD and require a custom Infineon OpenOCD version, that supports KitProg3, to be installed.
 
-On Windows:
+Infineon OpenOCD Installation
+=============================
 
-.. code-block:: console
+Both the full `ModusToolbox`_ and the `ModusToolbox Programming Tools`_ packages include Infineon OpenOCD. Installing either of these packages will also install Infineon OpenOCD. If neither package is installed, a minimal installation can be done by downloading the `Infineon OpenOCD`_ release for your system and manually extract the files to a location of your choice.
 
-   west flash --openocd path/to/infineon/openocd/bin/openocd.exe
-   west debug --openocd path/to/infineon/openocd/bin/openocd.exe
+.. note:: Linux requires device access rights to be set up for KitProg3. This is handled automatically by the ModusToolbox and ModusToolbox Programming Tools installations. When doing a minimal installation, this can be done manually by executing the script ``openocd/udev_rules/install_rules.sh``.
 
-On Linux:
+West Commands
+=============
 
-.. code-block:: console
+The path to the installed Infineon OpenOCD executable must be available to the ``west`` tool commands. There are multiple ways of doing this. The example below uses a permanent CMake argument to set the CMake variable ``OPENOCD``.
 
-   west flash --openocd path/to/infineon/openocd/bin/openocd
-   west debug --openocd path/to/infineon/openocd/bin/openocd
+   .. tabs::
+      .. group-tab:: Windows
+
+         .. code-block:: shell
+
+            # Run west config once to set permanent CMake argument
+            west config build.cmake-args -- -DOPENOCD=path/to/infineon/openocd/bin/openocd.exe
+
+            # Do a pristine build once after setting CMake argument
+            west build -b cy8cproto_063_ble -p always samples/basic/blinky
+
+            west flash
+            west debug
+
+      .. group-tab:: Linux
+
+         .. code-block:: shell
+
+            # Run west config once to set permanent CMake argument
+            west config build.cmake-args -- -DOPENOCD=path/to/infineon/openocd/bin/openocd
+
+            # Do a pristine build once after setting CMake argument
+            west build -b cy8cproto_063_ble -p always samples/basic/blinky
+
+            west flash
+            west debug
+
 
 References
 **********
 
 .. target-notes::
 
-.. _PSoC 63 BLE MCU SoC Website:
+.. _PSOC 63 BLE MCU SoC Website:
     https://www.cypress.com/products/32-bit-arm-cortex-m4-psoc-6
 
-.. _PSoC 63 BLE MCU Datasheet:
-    https://www.infineon.com/dgdl/Infineon-PSoC_6_MCU_PSoC_63_with_BLE_Datasheet_Programmable_System-on-Chip_(PSoC)-DataSheet-v16_00-EN.pdf?fileId=8ac78c8c7d0d8da4017d0ee4efe46c37&utm_source=cypress&utm_medium=referral&utm_campaign=202110_globe_en_all_integration-files
+.. _PSOC 63 BLE MCU Datasheet:
+    https://www.infineon.com/dgdl/Infineon-PSOC_6_MCU_PSOC_63_with_BLE_Datasheet_Programmable_System-on-Chip_(PSOC)-DataSheet-v16_00-EN.pdf?fileId=8ac78c8c7d0d8da4017d0ee4efe46c37&utm_source=cypress&utm_medium=referral&utm_campaign=202110_globe_en_all_integration-files
 
-.. _PSoC 63 BLE MCU Architecture Reference Manual:
+.. _PSOC 63 BLE MCU Architecture Reference Manual:
     https://documentation.infineon.com/html/psoc6/zrs1651212645947.html
 
-.. _PSoC 63 BLE MCU Register Reference Manual:
+.. _PSOC 63 BLE MCU Register Reference Manual:
     https://documentation.infineon.com/html/psoc6/bnm1651211483724.html
 
 .. _CY8CPROTO-063-BLE Website:
@@ -135,5 +157,14 @@ References
 .. _CY8CPROTO-063-BLE Schematics:
     https://www.infineon.com/cms/en/product/evaluation-boards/cy8cproto-063-ble/#!?fileId=8ac78c8c7d0d8da4017d0f00ea3c1821
 
+.. _ModusToolbox:
+    https://softwaretools.infineon.com/tools/com.ifx.tb.tool.modustoolbox
+
+.. _ModusToolbox Programming Tools:
+    https://softwaretools.infineon.com/tools/com.ifx.tb.tool.modustoolboxprogtools
+
 .. _Infineon OpenOCD:
-    https://github.com/infineon/openocd/releases/tag/release-v4.3.0
+    https://github.com/Infineon/openocd/releases/latest
+
+.. _KitProg3:
+    https://github.com/Infineon/KitProg3

--- a/boards/infineon/xmc45_relax_kit/doc/index.rst
+++ b/boards/infineon/xmc45_relax_kit/doc/index.rst
@@ -60,31 +60,50 @@ The Relax Kit development board configuration supports the following hardware fe
 +-----------+------------+-----------------------+
 
 More details about the supported peripherals are available in `XMC4500 TRM`_
+
+The default configuration can be found in the Kconfig
+
+:zephyr_file:`boards/infineon/xmc45_relax_kit/xmc45_relax_kit_defconfig`
+
 Other hardware features are not currently supported by the Zephyr kernel.
 
-Building and Flashing
-*********************
-Flashing
-========
-
-Here is an example for the :zephyr:code-sample:`hello_world` application.
+Build hello world sample
+************************
+Here is an example for building the :zephyr:code-sample:`hello_world` sample application.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/hello_world
    :board: xmc45_relax_kit
-   :goals: flash
+   :goals: build
 
-Debugging
-=========
-
+Programming and Debugging
+*************************
+West Commands
+=============
 Here is an example for the :zephyr:code-sample:`hello_world` application.
 
-.. zephyr-app-commands::
-   :zephyr-app: samples/hello_world
-   :board: xmc45_relax_kit
-   :goals: debug
+   .. tabs::
+      .. group-tab:: Windows
 
-Step through the application in your debugger.
+         .. code-block:: shell
+
+            # Do a pristine build
+            west build -b xmc45_relax_kit -p always samples/hello_world
+
+            west flash
+            west debug
+
+      .. group-tab:: Linux
+
+         .. code-block:: shell
+
+            # Do a pristine build
+            west build -b xmc45_relax_kit -p always samples/hello_world
+
+            west flash
+            west debug
+
+Once the gdb console starts after executing the west debug command, you may now set breakpoints and perform other standard GDB debugging.
 
 References
 **********

--- a/boards/infineon/xmc47_relax_kit/doc/index.rst
+++ b/boards/infineon/xmc47_relax_kit/doc/index.rst
@@ -65,29 +65,47 @@ The Relax Kit development board configuration supports the following hardware fe
 More details about the supported peripherals are available in `XMC4700 TRM`_
 Other hardware features are not currently supported by the Zephyr kernel.
 
-Building and Flashing
-*********************
-Flashing
-========
+The default configuration can be found in the Kconfig
 
-Here is an example for the :zephyr:code-sample:`hello_world` application.
+:zephyr_file:`boards/infineon/xmc47_relax_kit/xmc47_relax_kit_defconfig`
 
-.. zephyr-app-commands::
-   :zephyr-app: samples/hello_world
-   :board: xmc47_relax_kit
-   :goals: flash
-
-Debugging
-=========
-
-Here is an example for the :zephyr:code-sample:`hello_world` application.
+Build hello world sample
+************************
+Here is an example for building the :zephyr:code-sample:`hello_world` sample application.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/hello_world
    :board: xmc47_relax_kit
-   :goals: debug
+   :goals: build
 
-Step through the application in your debugger.
+Programming and Debugging
+*************************
+West Commands
+=============
+Here is an example for the :zephyr:code-sample:`hello_world` application.
+
+   .. tabs::
+      .. group-tab:: Windows
+
+         .. code-block:: shell
+
+            # Do a pristine build
+            west build -b xmc47_relax_kit -p always samples/hello_world
+
+            west flash
+            west debug
+
+      .. group-tab:: Linux
+
+         .. code-block:: shell
+
+            # Do a pristine build
+            west build -b xmc47_relax_kit -p always samples/hello_world
+
+            west flash
+            west debug
+
+Once the gdb console starts after executing the west debug command, you may now set breakpoints and perform other standard GDB debugging.
 
 References
 **********

--- a/drivers/bluetooth/hci/Kconfig
+++ b/drivers/bluetooth/hci/Kconfig
@@ -151,7 +151,7 @@ config BT_PSOC6_BLESS
 	depends on ZEPHYR_HAL_INFINEON_MODULE_BLOBS
 	select BT_HCI_SETUP
 	help
-	  PSOC6 BLESS driver with BLE Controller which operates in
+	  PSOC 6 BLESS driver with BLE Controller which operates in
 	  Single CPU mode.
 
 config BT_DA1469X

--- a/drivers/bluetooth/hci/hci_ifx_psoc6_bless.c
+++ b/drivers/bluetooth/hci/hci_ifx_psoc6_bless.c
@@ -6,7 +6,7 @@
  */
 
 /**
- * @brief PSoC 6 BLE (BLESS) driver.
+ * @brief PSOC 6 BLE (BLESS) driver.
  */
 
 #include <errno.h>
@@ -245,7 +245,7 @@ static int psoc6_bless_hci_init(const struct device *dev)
 	/* Registers the generic callback functions.  */
 	Cy_BLE_RegisterEventCallback(psoc6_bless_events_handler);
 
-	/* Initializes the PSoC 6 BLESS Controller. */
+	/* Initializes the PSOC 6 BLESS Controller. */
 	result = Cy_BLE_InitController(&psoc6_bless_config);
 	if (result != CY_BLE_SUCCESS) {
 		LOG_ERR("Failed to init the BLE Controller");

--- a/drivers/gpio/Kconfig.psoc6
+++ b/drivers/gpio/Kconfig.psoc6
@@ -2,8 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config GPIO_PSOC6
-	bool "Cypress PSoC-6 GPIO driver"
+	bool "Cypress PSOC 6 GPIO driver"
 	default y
 	depends on DT_HAS_CYPRESS_PSOC6_GPIO_ENABLED
 	help
-	  Enable support for the Cypress PSoC-6 GPIO controllers.
+	  Enable support for the Cypress PSOC 6 GPIO controllers.

--- a/drivers/hwinfo/Kconfig
+++ b/drivers/hwinfo/Kconfig
@@ -194,12 +194,12 @@ config HWINFO_LITEX
 	  Enable LiteX hwinfo driver
 
 config HWINFO_PSOC6
-	bool "Cypress PSoC-6 unique device ID"
+	bool "Cypress PSOC 6 unique device ID"
 	default y
 	depends on SOC_FAMILY_PSOC6_LEGACY
 	select HWINFO_HAS_DRIVER
 	help
-	  Enable Cypress PSoC-6 hwinfo driver.
+	  Enable Cypress PSOC 6 hwinfo driver.
 
 config HWINFO_GECKO
 	bool "GECKO hwinfo"

--- a/drivers/serial/Kconfig.psoc6
+++ b/drivers/serial/Kconfig.psoc6
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config UART_PSOC6
-	bool "PSoC-6 MCU SCB serial driver"
+	bool "PSOC 6 MCU SCB serial driver"
 	default y
 	depends on DT_HAS_CYPRESS_PSOC6_UART_ENABLED
 	select SERIAL_HAS_DRIVER
@@ -13,4 +13,4 @@ config UART_PSOC6
 	select USE_INFINEON_UART
 	select PINCTRL
 	help
-	  This option enables the SCB[UART] driver for PSoC-6 SoC family.
+	  This option enables the SCB[UART] driver for PSOC 6 SoC family.

--- a/drivers/serial/uart_psoc6.c
+++ b/drivers/serial/uart_psoc6.c
@@ -6,7 +6,7 @@
 #define DT_DRV_COMPAT cypress_psoc6_uart
 
 /** @file
- * @brief UART driver for Cypress PSoC6 MCU family.
+ * @brief UART driver for Cypress PSOC 6 MCU family.
  *
  * Note:
  * - Error handling is not implemented.

--- a/drivers/spi/Kconfig.psoc6
+++ b/drivers/spi/Kconfig.psoc6
@@ -4,10 +4,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config SPI_PSOC6
-	bool "PSoC-6 MCU SCB spi driver"
+	bool "PSOC 6 MCU SCB spi driver"
 	default y
 	depends on DT_HAS_CYPRESS_PSOC6_SPI_ENABLED
 	select USE_INFINEON_SPI
 	select PINCTRL
 	help
-	  This option enables the SCB[SPI] driver for PSoC-6 SoC family.
+	  This option enables the SCB[SPI] driver for PSOC 6 SoC family.

--- a/drivers/spi/spi_psoc6.c
+++ b/drivers/spi/spi_psoc6.c
@@ -169,7 +169,7 @@ static uint32_t spi_psoc6_get_freqdiv(uint32_t frequency)
 	uint32_t oversample;
 	uint32_t bus_freq = 100000000UL;
 	/*
-	 * TODO: Get PerBusSpeed when clocks are available to PSoC-6.
+	 * TODO: Get PerBusSpeed when clocks are available to PSOC 6.
 	 * Currently the bus freq is fixed to 50Mhz and max SPI clk can be
 	 * 12.5MHz.
 	 */

--- a/dts/bindings/adc/infineon,cat1-adc.yaml
+++ b/dts/bindings/adc/infineon,cat1-adc.yaml
@@ -5,7 +5,7 @@
 
 description: |
   Infineon Cat1 ADC
-  Each ADC group Cat1 is assigned to a Zephyr device. Refer to the Infineon PSoC6 reference
+  Each ADC group Cat1 is assigned to a Zephyr device. Refer to the Infineon PSOC 6 reference
   manual (Section Port I/O functions) for the group/channel mapping to a specific port-pin on
   the board.  For example on the cy8cproto_062_4343w P10.0 is mapped to adc0,channel0 and
   P10.1 is mapped to adc0,channel1.

--- a/dts/bindings/bluetooth/infineon,cat1-bless-hci.yaml
+++ b/dts/bindings/bluetooth/infineon,cat1-bless-hci.yaml
@@ -12,7 +12,7 @@ include: bt-hci.yaml
 
 properties:
   bt-hci-name:
-    default: "PSoC 6 BLESS"
+    default: "PSOC 6 BLESS"
   bt-hci-bus:
     default: "virtual"
   bt-hci-quirks:

--- a/dts/bindings/hwinfo/cypress,psoc6-uid.yaml
+++ b/dts/bindings/hwinfo/cypress,psoc6-uid.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2020 ATL Electronics
 # SPDX-License-Identifier: Apache-2.0
 
-description: Cypress PSoC-6 Unique 88-bit Serial Number
+description: Cypress PSOC 6 Unique 88-bit Serial Number
 
 compatible: "cypress,psoc6-uid"
 

--- a/dts/bindings/interrupt-controller/cypress,psoc6-intmux.yaml
+++ b/dts/bindings/interrupt-controller/cypress,psoc6-intmux.yaml
@@ -5,7 +5,7 @@
 description: |
   Cypress Interrupt Multiplex
 
-  The PSoC-6 Cortex-M0+ NVIC can handle up to 32 interrupts. This means that
+  The PSOC 6 Cortex-M0+ NVIC can handle up to 32 interrupts. This means that
   user can select up to 32 interrupts sources from the 240 possible vectors
   to be processed in the Cortex-M0+ CPU.
 
@@ -20,7 +20,7 @@ description: |
   On a general view, the below represents the Interrupt Multiplexer
   configuration and how the Cortex-M0+ NVIC sources are organized. Each
   channel chX represents a Cortex-M0+ NVIC line and it stores a vector number.
-  The vector number selects the PSoC-6 peripheral interrupt source for the
+  The vector number selects the PSOC 6 peripheral interrupt source for the
   Cortex-M0+ NVIC controller line.
 
   intmux[0] = {ch03, ch02, ch01, ch00}
@@ -31,7 +31,7 @@ description: |
   In practical terms, the Cortex-M0+ requires user to define all NVIC interrupt
   sources and the proper NVIC interrupt order. With that, the system configures
   the Cortex-M0+ Interrupt Multiplexer and interrupts can be processed.
-  More information about it at PSoC-6 Architecture Technical Reference Manual,
+  More information about it at PSOC 6 Architecture Technical Reference Manual,
   section CPU Sub System (CPUSS) Registers.
 
 
@@ -56,7 +56,7 @@ description: |
          CH   REGS  INT NUM    CH   CH/REG
   intmux[20 mod 8] |= 0x02 << (20 mod 4);
 
-  These results in Cortex-M0+ NVIC line 20 handling PSoC-6 interrupt source 2.
+  These results in Cortex-M0+ NVIC line 20 handling PSOC 6 interrupt source 2.
   The interrupt can be enabled/disabled at NVIC at line 20 as usual.
 
   Notes:

--- a/dts/bindings/serial/cypress,psoc6-uart.yaml
+++ b/dts/bindings/serial/cypress,psoc6-uart.yaml
@@ -28,7 +28,7 @@ properties:
       nodelabel that matches the Cypress SoC HAL defines and be of the
       form p<port>_<pin>_<periph><inst>_<signal>.
 
-      For example the UART on PSoC-63 Pioneer Kit would be
+      For example the UART on PSOC 63 Pioneer Kit would be
          pinctrl-0 = <&p5_0_uart5_rx &p5_1_uart5_tx>;
 
     required: true

--- a/dts/bindings/spi/cypress,psoc6-spi.yaml
+++ b/dts/bindings/spi/cypress,psoc6-spi.yaml
@@ -28,7 +28,7 @@ properties:
       nodes will have a nodelabel that matches the Cypress SoC HAL defines
       and be of the form p<port>_<pin>_<periph><inst>_<signal>.
 
-      For example the SPI on PSoC-63 Pioneer Kit would be
+      For example the SPI on PSOC 63 Pioneer Kit would be
          pinctrl-0 = <&p12_0_spi6_mosi &p12_1_spi6_miso &p12_2_spi6_clk &p12_3_spi6_sel0>;
 
     required: true

--- a/modules/hal_infineon/mtb-hal-cat1/CMakeLists.txt
+++ b/modules/hal_infineon/mtb-hal-cat1/CMakeLists.txt
@@ -7,7 +7,7 @@ set(hal_dir         ${ZEPHYR_HAL_INFINEON_MODULE_DIR}/mtb-hal-cat1)
 set(hal_cat1a_dir   ${hal_dir}/COMPONENT_CAT1A)
 set(hal_cat1b_dir   ${hal_dir}/COMPONENT_CAT1B)
 
-# PSoC 6 family defines
+# PSOC 6 family defines
 zephyr_compile_definitions_ifdef(CONFIG_SOC_FAMILY_INFINEON_CAT1A COMPONENT_CAT1A)
 zephyr_compile_definitions_ifdef(CONFIG_SOC_FAMILY_INFINEON_CAT1B COMPONENT_CAT1B)
 zephyr_compile_definitions_ifdef(CONFIG_SOC_FAMILY_INFINEON_CAT1 COMPONENT_CAT1)

--- a/soc/infineon/cat1a/Kconfig
+++ b/soc/infineon/cat1a/Kconfig
@@ -35,17 +35,17 @@ config SOC_PSOC6_M0_ENABLES_M4
 	  Cortex-M0 CPU should boot Cortex-M4
 
 if SOC_FAMILY_PSOC6
-## PSoC™ 6 Cortex M0+ prebuilt images
+## PSOC™ 6 Cortex M0+ prebuilt images
 choice
-	prompt "PSoC™ 6 Cortex M0+ prebuilt images"
+	prompt "PSOC™ 6 Cortex M0+ prebuilt images"
 	help
-	  Choose the prebuilt application image to be executed on the Cortex-M0+ core of the PSoC™ 6
+	  Choose the prebuilt application image to be executed on the Cortex-M0+ core of the PSOC™ 6
 	  dual-core MCU. The image is responsible for booting the Cortex-M4 on the device.
 
 config SOC_PSOC6_CM0P_IMAGE_SLEEP
 	bool "DeepSleep"
 	help
-	  DeepSleep prebuilt application image is executed on the Cortex-M0+ core of the PSoC™ 6 BLE
+	  DeepSleep prebuilt application image is executed on the Cortex-M0+ core of the PSOC™ 6 BLE
 	  dual-core MCU.The image is provided as C array ready to be compiled as part of the Cortex-M4
 	  application. The Cortex-M0+ application code is placed to internal flash by the Cortex-M4
 	  linker script.

--- a/soc/infineon/cat1a/Kconfig.soc
+++ b/soc/infineon/cat1a/Kconfig.soc
@@ -27,7 +27,7 @@ config SOC_FAMILY_PSOC6_LEGACY_M4
 config SOC_FAMILY_PSOC6_LEGACY_M0
 	bool
 
-# Cypress PSoC™ 6 MCU lines
+# Cypress PSOC™ 6 MCU lines
 config SOC_SERIES_PSOC6_60
 	bool
 	select SOC_FAMILY_PSOC6 if !SOC_FAMILY_PSOC6_LEGACY

--- a/soc/infineon/cat1a/common/soc.c
+++ b/soc/infineon/cat1a/common/soc.c
@@ -6,7 +6,7 @@
  */
 
 /**
- * @brief Infineon PSoC 6 SOC.
+ * @brief Infineon PSOC 6 SOC.
  */
 
 #include <zephyr/device.h>

--- a/soc/infineon/cat1a/common/soc.h
+++ b/soc/infineon/cat1a/common/soc.h
@@ -6,7 +6,7 @@
  */
 
 /**
- * @brief Infineon PSoC 6 SOC.
+ * @brief Infineon PSOC 6 SOC.
  */
 
 #ifndef _SOC__H_

--- a/soc/infineon/cat1a/psoc6_01/Kconfig.defconfig
+++ b/soc/infineon/cat1a/psoc6_01/Kconfig.defconfig
@@ -2,7 +2,7 @@
 # an affiliate of Cypress Semiconductor Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-# Infineon PSoC6_01 based MCU default configuration
+# Infineon PSOC 6_01 based MCU default configuration
 
 if SOC_DIE_PSOC6_01
 

--- a/soc/infineon/cat1a/psoc6_01/Kconfig.soc
+++ b/soc/infineon/cat1a/psoc6_01/Kconfig.soc
@@ -31,7 +31,7 @@ config SOC_PACKAGE_PSOC6_01_104_M_CSP_BLE_USB
 config SOC_PACKAGE_PSOC6_01_68_QFN_BLE
 	bool
 
-# Infineon PSoC6_01 series MCUs
+# Infineon PSOC 6_01 series MCUs
 config SOC_CY8C6036BZI_F04
 	bool
 	select SOC_DIE_PSOC6_01

--- a/soc/infineon/cat1a/psoc6_02/Kconfig.defconfig
+++ b/soc/infineon/cat1a/psoc6_02/Kconfig.defconfig
@@ -2,7 +2,7 @@
 # an affiliate of Cypress Semiconductor Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-# Infineon PSoC6_02 based MCU default configuration
+# Infineon PSOC 6_02 based MCU default configuration
 
 if SOC_DIE_PSOC6_02
 

--- a/soc/infineon/cat1a/psoc6_02/Kconfig.soc
+++ b/soc/infineon/cat1a/psoc6_02/Kconfig.soc
@@ -19,7 +19,7 @@ config SOC_PACKAGE_PSOC6_02_128_TQFP
 config SOC_PACKAGE_PSOC6_02_68_QFN
 	bool
 
-# Infineon PSoC6_02 series MCUs
+# Infineon PSOC 6_02 series MCUs
 config SOC_CYB0644ABZI_S2D44
 	bool
 	select SOC_DIE_PSOC6_02

--- a/soc/infineon/cat1a/psoc6_03/Kconfig.defconfig
+++ b/soc/infineon/cat1a/psoc6_03/Kconfig.defconfig
@@ -2,7 +2,7 @@
 # an affiliate of Cypress Semiconductor Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-# Infineon PSoC6_03 based MCU default configuration
+# Infineon PSOC 6_03 based MCU default configuration
 
 if SOC_DIE_PSOC6_03
 

--- a/soc/infineon/cat1a/psoc6_03/Kconfig.soc
+++ b/soc/infineon/cat1a/psoc6_03/Kconfig.soc
@@ -16,7 +16,7 @@ config SOC_PACKAGE_PSOC6_03_68_QFN
 config SOC_PACKAGE_PSOC6_03_49_WLCSP
 	bool
 
-# Infineon PSoC6_03 series MCUs
+# Infineon PSOC 6_03 series MCUs
 config SOC_CY8C6245AZI_S3D72
 	bool
 	select SOC_DIE_PSOC6_03

--- a/soc/infineon/cat1a/psoc6_04/Kconfig.defconfig
+++ b/soc/infineon/cat1a/psoc6_04/Kconfig.defconfig
@@ -2,7 +2,7 @@
 # an affiliate of Cypress Semiconductor Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-# Infineon PSoC6_04 based MCU default configuration
+# Infineon PSOC 6_04 based MCU default configuration
 
 if SOC_DIE_PSOC6_04
 

--- a/soc/infineon/cat1a/psoc6_04/Kconfig.soc
+++ b/soc/infineon/cat1a/psoc6_04/Kconfig.soc
@@ -19,7 +19,7 @@ config SOC_PACKAGE_PSOC6_04_80_TQFP
 config SOC_PACKAGE_PSOC6_04_80_M_CSP
 	bool
 
-# Infineon PSoC6_04 series MCUs
+# Infineon PSOC 6_04 series MCUs
 config SOC_CY8C6244AZI_S4D92
 	bool
 	select SOC_DIE_PSOC6_04

--- a/soc/infineon/cat1a/psoc6_legacy/Kconfig.defconfig
+++ b/soc/infineon/cat1a/psoc6_legacy/Kconfig.defconfig
@@ -2,7 +2,7 @@
 # an affiliate of Cypress Semiconductor Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-# Infineon PSoC6 (Legacy) based MCU default configuration
+# Infineon PSOC 6 (Legacy) based MCU default configuration
 
 if SOC_FAMILY_PSOC6_LEGACY
 

--- a/soc/infineon/cat1a/psoc6_legacy/Kconfig.soc
+++ b/soc/infineon/cat1a/psoc6_legacy/Kconfig.soc
@@ -2,7 +2,7 @@
 # an affiliate of Cypress Semiconductor Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-# Infineon PSoC6 (legacy) series MCUs
+# Infineon PSOC 6 (legacy) series MCUs
 config SOC_CY8C6247_M0
 	bool
 	select SOC_SERIES_PSOC6_62

--- a/soc/infineon/cat1a/psoc6_legacy/cypress_psoc6_dt.h
+++ b/soc/infineon/cat1a/psoc6_legacy/cypress_psoc6_dt.h
@@ -6,7 +6,7 @@
  */
 
 /** @file
- * @brief Cypress PSoC-6 MCU family devicetree helper macros
+ * @brief Cypress PSOC 6 MCU family devicetree helper macros
  */
 
 #ifndef _CYPRESS_PSOC6_DT_H_
@@ -19,7 +19,7 @@
  * Devicetree macros related to interrupt
  *
  * The main "API" macro is CY_PSOC6_IRQ_CONFIG. It is an internal definition
- * used to configure the PSoC-6 interrupts in a generic way. This is necessary
+ * used to configure the PSOC 6 interrupts in a generic way. This is necessary
  * because Cortex-M0+ can handle a limited number of interrupts and have
  * multiplexers in front of any NVIC interrupt line.
  *
@@ -48,7 +48,7 @@
  * configuration code.
  *
  * The Cortex-M0+ must get from interrupt parent the interrupt line and
- * configure the interrupt channel to connect PSoC-6 peripheral interrupt to
+ * configure the interrupt channel to connect PSOC 6 peripheral interrupt to
  * Cortex-M0+ NVIC. The multiplexer is configured by CY_PSOC6_DT_NVIC_MUX_MAP
  * using the interrupt value from the interrupt parent.
  *

--- a/soc/infineon/cat1a/psoc6_legacy/soc.c
+++ b/soc/infineon/cat1a/psoc6_legacy/soc.c
@@ -38,7 +38,7 @@
 #define CY_CFG_PWR_USING_ULP 0
 
 /* Dummy symbols, requres for cy_sysint.c module.
- * NOTE: in this PSoC 6 integration, PSoC 6 Zephyr drivers (uart, spi, gpio)
+ * NOTE: in this PSOC 6 integration, PSOC 6 Zephyr drivers (uart, spi, gpio)
  * do not use cy_sysint.c implementation to handle interrupt routine.
  * Instead this they use IRQ_CONNECT to define ISR.
  */


### PR DESCRIPTION
Documentation: Update documentation for Infineon boards

	-Update formatting and contents of index.rst for cy8ckit_062s4
	-Update formatting and contents of index.rst for cy8ckit_064s0s2_4343w
	-Update formatting and contents of index.rst for cy8cproto_062_4343w
	-Update formatting and contents of index.rst for cy8cproto_063_ble
	-Update formatting and contents of index.rst for xmc45_relax_kit
	-Update formatting and contents of index.rst for xmc47_relax_kit
	-Change all instances of "PSoC" to "PSOC" for infineon platforms