### PR TITLE
Add MAX32xxx counter RTC driver

### DIFF
--- a/boards/adi/max32655evkit/max32655evkit_max32655_m4.dts
+++ b/boards/adi/max32655evkit/max32655evkit_max32655_m4.dts
@@ -78,6 +78,13 @@
 	status = "okay";
 };
 
+/*
+ * ERTCO is required for counter RTC
+ */
+&clk_ertco {
+	status = "okay";
+};
+
 &gpio0 {
 	status = "okay";
 };
@@ -121,4 +128,8 @@
 &w1 {
 	pinctrl-0 = <&owm_io_p0_6 &owm_pe_p0_7>;
 	pinctrl-names = "default";
+};
+
+&rtc_counter {
+	status = "okay";
 };

--- a/boards/adi/max32655evkit/max32655evkit_max32655_m4.yaml
+++ b/boards/adi/max32655evkit/max32655evkit_max32655_m4.yaml
@@ -17,6 +17,7 @@ supported:
   - spi
   - adc
   - counter
+  - rtc_counter
   - pwm
   - w1
   - flash

--- a/boards/adi/max32655fthr/max32655fthr_max32655_m4.dts
+++ b/boards/adi/max32655fthr/max32655fthr_max32655_m4.dts
@@ -112,6 +112,13 @@
 	status = "okay";
 };
 
+/*
+ * ERTCO is required for counter RTC
+ */
+&clk_ertco {
+	status = "okay";
+};
+
 &gpio0 {
 	status = "okay";
 };
@@ -150,4 +157,8 @@
 	status = "okay";
 	pinctrl-0 = <&spi1_mosi_p0_21 &spi1_miso_p0_22 &spi1_sck_p0_23 &spi1_ss0_p0_20>;
 	pinctrl-names = "default";
+};
+
+&rtc_counter {
+	status = "okay";
 };

--- a/boards/adi/max32655fthr/max32655fthr_max32655_m4.yaml
+++ b/boards/adi/max32655fthr/max32655fthr_max32655_m4.yaml
@@ -17,6 +17,7 @@ supported:
   - spi
   - adc
   - counter
+  - rtc_counter
   - pwm
   - flash
 ram: 128

--- a/boards/adi/max32662evkit/max32662evkit.dts
+++ b/boards/adi/max32662evkit/max32662evkit.dts
@@ -102,6 +102,13 @@
 	status = "okay";
 };
 
+/*
+ * ERTCO is required for counter RTC
+ */
+&clk_ertco {
+	status = "okay";
+};
+
 &gpio0 {
 	status = "okay";
 };
@@ -117,6 +124,10 @@
 };
 
 &wdt0 {
+	status = "okay";
+};
+
+&rtc_counter {
 	status = "okay";
 };
 

--- a/boards/adi/max32662evkit/max32662evkit.yaml
+++ b/boards/adi/max32662evkit/max32662evkit.yaml
@@ -17,6 +17,7 @@ supported:
   - spi
   - adc
   - counter
+  - rtc_counter
   - pwm
   - flash
 ram: 80

--- a/boards/adi/max32666evkit/max32666evkit_max32666_cpu0.dts
+++ b/boards/adi/max32666evkit/max32666evkit_max32666_cpu0.dts
@@ -110,3 +110,7 @@
 	pinctrl-0 = <&owm_io_p0_4 &owm_pe_p0_5>;
 	pinctrl-names = "default";
 };
+
+&rtc_counter {
+	status = "okay";
+};

--- a/boards/adi/max32666evkit/max32666evkit_max32666_cpu0.yaml
+++ b/boards/adi/max32666evkit/max32666evkit_max32666_cpu0.yaml
@@ -16,6 +16,7 @@ supported:
   - watchdog
   - adc
   - counter
+  - rtc_counter
   - pwm
   - w1
   - flash

--- a/boards/adi/max32666fthr/max32666fthr_max32666_cpu0.dts
+++ b/boards/adi/max32666fthr/max32666fthr_max32666_cpu0.dts
@@ -120,6 +120,10 @@
 	status = "okay";
 };
 
+&rtc_counter {
+	status = "okay";
+};
+
 &spi1 {
 	status = "okay";
 	pinctrl-0 = <&spi1_mosi_p0_17 &spi1_miso_p0_18 &spi1_sck_p0_19 &spi1_ss0_p0_16>;

--- a/boards/adi/max32666fthr/max32666fthr_max32666_cpu0.yaml
+++ b/boards/adi/max32666fthr/max32666fthr_max32666_cpu0.yaml
@@ -17,6 +17,7 @@ supported:
   - spi
   - adc
   - counter
+  - rtc_counter
   - pwm
   - w1
   - flash

--- a/boards/adi/max32670evkit/max32670evkit.dts
+++ b/boards/adi/max32670evkit/max32670evkit.dts
@@ -65,6 +65,13 @@
 	status = "okay";
 };
 
+/*
+ * ERTCO is required for counter RTC
+ */
+&clk_ertco {
+	status = "okay";
+};
+
 &gpio0 {
 	status = "okay";
 };
@@ -95,4 +102,8 @@
 	status = "okay";
 	pinctrl-0 = <&spi0_mosi_p0_3 &spi0_miso_p0_2 &spi0_sck_p0_4 &spi0_ss0_p0_5>;
 	pinctrl-names = "default";
+};
+
+&rtc_counter {
+	status = "okay";
 };

--- a/boards/adi/max32670evkit/max32670evkit.yaml
+++ b/boards/adi/max32670evkit/max32670evkit.yaml
@@ -16,6 +16,7 @@ supported:
   - watchdog
   - spi
   - counter
+  - rtc_counter
   - pwm
   - flash
 ram: 160

--- a/boards/adi/max32672evkit/max32672evkit.dts
+++ b/boards/adi/max32672evkit/max32672evkit.dts
@@ -103,6 +103,13 @@
 	status = "okay";
 };
 
+/*
+ * ERTCO is required for counter RTC
+ */
+&clk_ertco {
+	status = "okay";
+};
+
 &gpio0 {
 	status = "okay";
 };
@@ -148,4 +155,8 @@
 	pinctrl-0 = <&spi0a_mosi_p0_3 &spi0a_miso_p0_2 &spi0a_sck_p0_4>;
 	pinctrl-names = "default";
 	cs-gpios = <&gpio0 5 (GPIO_ACTIVE_LOW | MAX32_VSEL_VDDIOH)>;
+};
+
+&rtc_counter {
+	status = "okay";
 };

--- a/boards/adi/max32672evkit/max32672evkit.yaml
+++ b/boards/adi/max32672evkit/max32672evkit.yaml
@@ -17,6 +17,7 @@ supported:
   - spi
   - adc
   - counter
+  - rtc_counter
   - pwm
   - flash
 ram: 200

--- a/boards/adi/max32672fthr/max32672fthr.dts
+++ b/boards/adi/max32672fthr/max32672fthr.dts
@@ -100,6 +100,13 @@
 	status = "okay";
 };
 
+/*
+ * ERTCO is required for counter RTC
+ */
+&clk_ertco {
+	status = "okay";
+};
+
 &gpio0 {
 	status = "okay";
 };
@@ -147,4 +154,8 @@
 	status = "okay";
 	pinctrl-0 = <&spi1a_mosi_p0_15 &spi1a_miso_p0_14 &spi1a_sck_p0_16 &spi1a_ss0_p0_17>;
 	pinctrl-names = "default";
+};
+
+&rtc_counter {
+	status = "okay";
 };

--- a/boards/adi/max32672fthr/max32672fthr.yaml
+++ b/boards/adi/max32672fthr/max32672fthr.yaml
@@ -17,6 +17,7 @@ supported:
   - spi
   - adc
   - counter
+  - rtc_counter
   - pwm
   - flash
 ram: 200

--- a/boards/adi/max32690evkit/max32690evkit_max32690_m4.dts
+++ b/boards/adi/max32690evkit/max32690evkit_max32690_m4.dts
@@ -163,3 +163,7 @@
 	pinctrl-0 = <&owm_io_p0_8 &owm_pe_p0_7>;
 	pinctrl-names = "default";
 };
+
+&rtc_counter {
+	status = "okay";
+};

--- a/boards/adi/max32690evkit/max32690evkit_max32690_m4.yaml
+++ b/boards/adi/max32690evkit/max32690evkit_max32690_m4.yaml
@@ -17,6 +17,7 @@ supported:
   - watchdog
   - adc
   - counter
+  - rtc_counter
   - pwm
   - w1
   - flash

--- a/drivers/counter/CMakeLists.txt
+++ b/drivers/counter/CMakeLists.txt
@@ -50,5 +50,6 @@ zephyr_library_sources_ifdef(CONFIG_COUNTER_SNPS_DW             counter_dw_timer
 zephyr_library_sources_ifdef(CONFIG_COUNTER_SHELL               counter_timer_shell.c)
 zephyr_library_sources_ifdef(CONFIG_COUNTER_TIMER_RPI_PICO      counter_rpi_pico_timer.c)
 zephyr_library_sources_ifdef(CONFIG_COUNTER_TIMER_MAX32         counter_max32_timer.c)
+zephyr_library_sources_ifdef(CONFIG_COUNTER_RTC_MAX32           counter_max32_rtc.c)
 zephyr_library_sources_ifdef(CONFIG_COUNTER_NXP_MRT             counter_nxp_mrt.c)
 zephyr_library_sources_ifdef(CONFIG_COUNTER_RA_AGT              counter_renesas_ra_agt.c)

--- a/drivers/counter/Kconfig
+++ b/drivers/counter/Kconfig
@@ -98,6 +98,8 @@ source "drivers/counter/Kconfig.rpi_pico"
 
 source "drivers/counter/Kconfig.max32_timer"
 
+source "drivers/counter/Kconfig.max32_rtc"
+
 source "drivers/counter/Kconfig.nxp_mrt"
 
 source "drivers/counter/Kconfig.renesas_ra"

--- a/drivers/counter/Kconfig.max32_rtc
+++ b/drivers/counter/Kconfig.max32_rtc
@@ -1,0 +1,9 @@
+# Copyright (c) 2024 Analog Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+config COUNTER_RTC_MAX32
+	bool "MAX32xxx counter rtc driver"
+	default y
+	depends on DT_HAS_ADI_MAX32_RTC_COUNTER_ENABLED
+	help
+	  Enable the counter rtc driver for MAX32 MCUs.

--- a/drivers/counter/counter_max32_rtc.c
+++ b/drivers/counter/counter_max32_rtc.c
@@ -1,0 +1,266 @@
+/*
+ * Copyright (c) 2024 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT adi_max32_rtc_counter
+
+#include <zephyr/drivers/counter.h>
+#include <zephyr/drivers/clock_control/adi_max32_clock_control.h>
+#include <zephyr/drivers/pinctrl.h>
+#include <zephyr/irq.h>
+
+#include <rtc.h>
+#include <wrap_max32_lp.h>
+
+/* Resoultion is 1sec for time of day alarm*/
+#define MAX32_RTC_COUNTER_FREQ 1
+
+/* 20bits used for time of day alarm */
+#define MAX32_RTC_COUNTER_MAX_VALUE ((1 << 21) - 1)
+
+#define MAX32_RTC_COUNTER_INT_FL MXC_RTC_INT_FL_LONG
+#define MAX32_RTC_COUNTER_INT_EN MXC_RTC_INT_EN_LONG
+
+struct max32_rtc_data {
+	counter_alarm_callback_t alarm_callback;
+	counter_top_callback_t top_callback;
+	void *alarm_user_data;
+	void *top_user_data;
+};
+
+struct max32_rtc_config {
+	struct counter_config_info info;
+	mxc_rtc_regs_t *regs;
+	void (*irq_func)(void);
+};
+
+static int api_start(const struct device *dev)
+{
+	/* Ensure that both sec and subsec are reset to 0 */
+	while (MXC_RTC_Init(0, 0) == E_BUSY) {
+		;
+	}
+
+	while (MXC_RTC_Start() == E_BUSY) {
+		;
+	}
+
+	while (MXC_RTC_EnableInt(MAX32_RTC_COUNTER_INT_EN) == E_BUSY) {
+		;
+	}
+
+	return 0;
+}
+
+static int api_stop(const struct device *dev)
+{
+	ARG_UNUSED(dev);
+
+	while (MXC_RTC_DisableInt(MAX32_RTC_COUNTER_INT_EN) == E_BUSY) {
+		;
+	}
+	MXC_RTC_Stop();
+
+	return 0;
+}
+
+static int api_get_value(const struct device *dev, uint32_t *ticks)
+{
+	const struct max32_rtc_config *cfg = dev->config;
+	mxc_rtc_regs_t *regs = cfg->regs;
+	uint32_t sec = 0, subsec = 0;
+
+	/* Read twice incase of glitch */
+	sec = regs->sec;
+	if (regs->sec != sec) {
+		sec = regs->sec;
+	}
+
+	/* Read twice incase of glitch */
+	subsec = regs->ssec;
+	if (regs->ssec != subsec) {
+		subsec = regs->ssec;
+	}
+
+	*ticks = sec;
+	if (subsec >= (MXC_RTC_MAX_SSEC / 2)) {
+		*ticks += 1;
+	}
+
+	return 0;
+}
+
+static int api_set_top_value(const struct device *dev, const struct counter_top_cfg *counter_cfg)
+{
+	const struct max32_rtc_config *cfg = dev->config;
+	struct max32_rtc_data *const data = dev->data;
+
+	if (counter_cfg->ticks == 0) {
+		return -EINVAL;
+	}
+
+	if (counter_cfg->ticks != cfg->info.max_top_value) {
+		return -ENOTSUP;
+	}
+
+	data->top_callback = counter_cfg->callback;
+	data->top_user_data = counter_cfg->user_data;
+
+	return 0;
+}
+
+static uint32_t api_get_pending_int(const struct device *dev)
+{
+	ARG_UNUSED(dev);
+	int flags = MXC_RTC_GetFlags();
+
+	if (flags & MAX32_RTC_COUNTER_INT_FL) {
+		return 1;
+	}
+
+	return 0;
+}
+
+static uint32_t api_get_top_value(const struct device *dev)
+{
+	const struct max32_rtc_config *cfg = dev->config;
+
+	return cfg->info.max_top_value;
+}
+
+static int api_set_alarm(const struct device *dev, uint8_t chan,
+			 const struct counter_alarm_cfg *alarm_cfg)
+{
+	int ret;
+	struct max32_rtc_data *data = dev->data;
+	uint32_t ticks = alarm_cfg->ticks;
+	uint32_t current;
+
+	/* Alarm frequenct is 1Hz so that it seems ticks becomes 0
+	 * some times, in that case system being blocked.
+	 * Set it to 1 if ticks is 0
+	 */
+	if (ticks == 0) {
+		ticks = 1;
+	}
+
+	if (alarm_cfg->ticks > api_get_top_value(dev)) {
+		return -EINVAL;
+	}
+
+	if (data->alarm_callback != NULL) {
+		return -EBUSY;
+	}
+
+	api_stop(dev);
+
+	api_get_value(dev, &current);
+	if ((alarm_cfg->flags & COUNTER_ALARM_CFG_ABSOLUTE) == 0) {
+		ticks += current;
+	}
+
+	ret = MXC_RTC_SetTimeofdayAlarm(ticks);
+	if (ret == E_BUSY) {
+		ret = -EBUSY;
+	}
+
+	if (ret == 0) {
+		data->alarm_callback = alarm_cfg->callback;
+		data->alarm_user_data = alarm_cfg->user_data;
+	}
+
+	api_start(dev);
+
+	return ret;
+}
+
+static int api_cancel_alarm(const struct device *dev, uint8_t chan)
+{
+	struct max32_rtc_data *data = dev->data;
+
+	while (MXC_RTC_DisableInt(MAX32_RTC_COUNTER_INT_EN) == E_BUSY) {
+		;
+	}
+	data->alarm_callback = NULL;
+
+	return 0;
+}
+
+static void rtc_max32_isr(const struct device *dev)
+{
+	struct max32_rtc_data *const data = dev->data;
+	int flags = MXC_RTC_GetFlags();
+
+	if (flags & MAX32_RTC_COUNTER_INT_FL) {
+		if (data->alarm_callback) {
+			counter_alarm_callback_t cb;
+			uint32_t current;
+
+			api_get_value(dev, &current);
+
+			cb = data->alarm_callback;
+			data->alarm_callback = NULL;
+			cb(dev, 0, current, data->alarm_user_data);
+		}
+	}
+
+	/* Clear all flags */
+	MXC_RTC_ClearFlags(flags);
+}
+
+static int rtc_max32_init(const struct device *dev)
+{
+	const struct max32_rtc_config *cfg = dev->config;
+
+	while (MXC_RTC_Init(0, 0) == E_BUSY) {
+		;
+	}
+
+	api_stop(dev);
+
+	cfg->irq_func();
+
+	return 0;
+}
+
+static const struct counter_driver_api counter_rtc_max32_driver_api = {
+	.start = api_start,
+	.stop = api_stop,
+	.get_value = api_get_value,
+	.set_top_value = api_set_top_value,
+	.get_pending_int = api_get_pending_int,
+	.get_top_value = api_get_top_value,
+	.set_alarm = api_set_alarm,
+	.cancel_alarm = api_cancel_alarm,
+};
+
+#define COUNTER_RTC_MAX32_INIT(_num)                                                               \
+	static struct max32_rtc_data rtc_max32_data_##_num;                                        \
+	static void max32_rtc_irq_init_##_num(void)                                                \
+	{                                                                                          \
+		IRQ_CONNECT(DT_INST_IRQN(_num), DT_INST_IRQ(_num, priority), rtc_max32_isr,        \
+			    DEVICE_DT_INST_GET(_num), 0);                                          \
+		irq_enable(DT_INST_IRQN(_num));                                                    \
+		if (DT_INST_PROP(_num, wakeup_source)) {                                           \
+			MXC_LP_EnableRTCAlarmWakeup();                                             \
+		}                                                                                  \
+	};                                                                                         \
+	static const struct max32_rtc_config rtc_max32_config_##_num = {                           \
+		.info =                                                                            \
+			{                                                                          \
+				.max_top_value = MAX32_RTC_COUNTER_MAX_VALUE,                      \
+				.freq = MAX32_RTC_COUNTER_FREQ,                                    \
+				.flags = COUNTER_CONFIG_INFO_COUNT_UP,                             \
+				.channels = 1,                                                     \
+			},                                                                         \
+		.regs = (mxc_rtc_regs_t *)DT_INST_REG_ADDR(_num),                                  \
+		.irq_func = max32_rtc_irq_init_##_num,                                             \
+	};                                                                                         \
+                                                                                                   \
+	DEVICE_DT_INST_DEFINE(_num, &rtc_max32_init, NULL, &rtc_max32_data_##_num,                 \
+			      &rtc_max32_config_##_num, PRE_KERNEL_1,                              \
+			      CONFIG_COUNTER_INIT_PRIORITY, &counter_rtc_max32_driver_api);
+
+DT_INST_FOREACH_STATUS_OKAY(COUNTER_RTC_MAX32_INIT)

--- a/dts/arm/adi/max32/max32xxx.dtsi
+++ b/dts/arm/adi/max32/max32xxx.dtsi
@@ -294,6 +294,13 @@
 				#pwm-cells = <3>;
 			};
 		};
+
+		rtc_counter: rtc_counter@40006000 {
+			compatible = "adi,max32-rtc-counter";
+			reg = <0x40006000 0x400>;
+			interrupts = <3 0>;
+			status = "disabled";
+		};
 	};
 };
 

--- a/dts/bindings/counter/adi,max32-rtc-counter.yaml
+++ b/dts/bindings/counter/adi,max32-rtc-counter.yaml
@@ -1,0 +1,9 @@
+# Copyright (c) 2024 Analog Devices, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+description: ADI MAX32 compatible Counter RTC
+
+compatible: "adi,max32-rtc-counter"
+
+include: [base.yaml]

--- a/tests/drivers/counter/counter_basic_api/src/test_counter.c
+++ b/tests/drivers/counter/counter_basic_api/src/test_counter.c
@@ -117,6 +117,9 @@ static const struct device *const devices[] = {
 #ifdef CONFIG_COUNTER_TIMER_RPI_PICO
 	DEVS_FOR_DT_COMPAT(raspberrypi_pico_timer)
 #endif
+#ifdef CONFIG_COUNTER_RTC_MAX32
+	DEVS_FOR_DT_COMPAT(adi_max32_rtc_counter)
+#endif
 #ifdef CONFIG_COUNTER_AMBIQ
 	DEVS_FOR_DT_COMPAT(ambiq_counter)
 #endif
@@ -134,6 +137,9 @@ static const struct device *const period_devs[] = {
 #endif
 #ifdef CONFIG_COUNTER_RTC_STM32
 	DEVS_FOR_DT_COMPAT(st_stm32_rtc)
+#endif
+#ifdef CONFIG_COUNTER_RTC_MAX32
+	DEVS_FOR_DT_COMPAT(adi_max32_rtc_counter)
 #endif
 };
 


### PR DESCRIPTION
This PR adds counter RTC driver for ADI MAX32xxx series microcontrollers. Counter tests are also enabled.