### PR TITLE
net: sockets: socket_service: change callback arg to `struct net_socket_service_event`

### DIFF
--- a/doc/releases/migration-guide-4.0.rst
+++ b/doc/releases/migration-guide-4.0.rst
@@ -496,6 +496,10 @@ Networking
 * The ``work_q`` parameter to ``NET_SOCKET_SERVICE_SYNC_DEFINE`` and
   ``NET_SOCKET_SERVICE_SYNC_DEFINE_STATIC`` has been removed as it was always ignored. (:github:`79446`)
 
+* The callback function for the socket service has changed. The
+  ``struct k_work *work`` parameter has been replaced with a pointer to the
+  ``struct net_socket_service_event *pev`` parameter. (:github:`80041`)
+
 * Deprecated the :kconfig:option:`CONFIG_NET_SOCKETS_POLL_MAX` option in favour of
   :kconfig:option:`CONFIG_ZVFS_POLL_MAX`.
 

--- a/include/zephyr/net/socket_service.h
+++ b/include/zephyr/net/socket_service.h
@@ -81,8 +81,6 @@ struct net_socket_service_desc {
 #define __z_net_socket_svc_get_idx(_svc_id) __z_net_socket_service_idx_##_svc_id
 #define __z_net_socket_svc_get_owner __FILE__ ":" STRINGIFY(__LINE__)
 
-extern void net_socket_service_callback(struct k_work *work);
-
 #if CONFIG_NET_SOCKETS_LOG_LEVEL >= LOG_LEVEL_DBG
 #define NET_SOCKET_SERVICE_OWNER .owner = __z_net_socket_svc_get_owner,
 #else

--- a/include/zephyr/net/socket_service.h
+++ b/include/zephyr/net/socket_service.h
@@ -32,15 +32,23 @@
 extern "C" {
 #endif
 
+struct net_socket_service_event;
+
+/** @brief The signature for a net socket service handler function.
+ *
+ * The function will be invoked by the socket service.
+ *
+ * @param pev the socket service event that provided the handler.
+ */
+typedef void (*net_socket_service_handler_t)(struct net_socket_service_event *pev);
+
 /**
  * This struct contains information which socket triggered
  * calls to the callback function.
  */
 struct net_socket_service_event {
-	/** k_work that is done when there is desired activity in file descriptor. */
-	struct k_work work;
 	/** Callback to be called for desired socket activity */
-	k_work_handler_t callback;
+	net_socket_service_handler_t callback;
 	/** Socket information that triggered this event. */
 	struct zsock_pollfd event;
 	/** User data */

--- a/samples/net/sockets/echo_service/src/main.c
+++ b/samples/net/sockets/echo_service/src/main.c
@@ -34,10 +34,8 @@ static struct pollfd sockfd_tcp[1] = {
 static void receive_data(bool is_udp, struct net_socket_service_event *pev,
 			 char *buf, size_t buflen);
 
-static void tcp_service_handler(struct k_work *work)
+static void tcp_service_handler(struct net_socket_service_event *pev)
 {
-	struct net_socket_service_event *pev =
-		CONTAINER_OF(work, struct net_socket_service_event, work);
 	static char buf[1500];
 
 	/* Note that in this application we receive / send data from
@@ -48,10 +46,8 @@ static void tcp_service_handler(struct k_work *work)
 	receive_data(false, pev, buf, sizeof(buf));
 }
 
-static void udp_service_handler(struct k_work *work)
+static void udp_service_handler(struct net_socket_service_event *pev)
 {
-	struct net_socket_service_event *pev =
-		CONTAINER_OF(work, struct net_socket_service_event, work);
 	static char buf[1500];
 
 	receive_data(true, pev, buf, sizeof(buf));

--- a/subsys/net/lib/dhcpv4/dhcpv4_server.c
+++ b/subsys/net/lib/dhcpv4/dhcpv4_server.c
@@ -1489,10 +1489,8 @@ static void dhcpv4_process_data(struct dhcpv4_server_ctx *ctx, uint8_t *data,
 	k_mutex_unlock(&server_lock);
 }
 
-static void dhcpv4_server_cb(struct k_work *work)
+static void dhcpv4_server_cb(struct net_socket_service_event *evt)
 {
-	struct net_socket_service_event *evt =
-		CONTAINER_OF(work, struct net_socket_service_event, work);
 	struct dhcpv4_server_ctx *ctx = NULL;
 	uint8_t recv_buf[NET_IPV4_MTU];
 	int ret;

--- a/subsys/net/lib/dns/dispatcher.c
+++ b/subsys/net/lib/dns/dispatcher.c
@@ -181,10 +181,8 @@ unlock:
 	return ret;
 }
 
-void dns_dispatcher_svc_handler(struct k_work *work)
+void dns_dispatcher_svc_handler(struct net_socket_service_event *pev)
 {
-	struct net_socket_service_event *pev =
-		CONTAINER_OF(work, struct net_socket_service_event, work);
 	int ret;
 
 	ret = recv_data(pev);

--- a/subsys/net/lib/dns/llmnr_responder.c
+++ b/subsys/net/lib/dns/llmnr_responder.c
@@ -67,7 +67,7 @@ static struct net_mgmt_event_callback mgmt_cb;
 /* Socket polling for each server connection */
 static struct zsock_pollfd fds[LLMNR_MAX_POLL];
 
-static void svc_handler(struct k_work *work);
+static void svc_handler(struct net_socket_service_event *pev);
 NET_SOCKET_SERVICE_SYNC_DEFINE_STATIC(svc_llmnr, svc_handler, LLMNR_MAX_POLL);
 
 NET_BUF_POOL_DEFINE(llmnr_msg_pool, DNS_RESOLVER_BUF_CTR,
@@ -564,10 +564,8 @@ quit:
 	return ret;
 }
 
-static void svc_handler(struct k_work *work)
+static void svc_handler(struct net_socket_service_event *pev)
 {
-	struct net_socket_service_event *pev =
-		CONTAINER_OF(work, struct net_socket_service_event, work);
 	int ret;
 
 	ret = recv_data(pev);

--- a/subsys/net/lib/dns/mdns_responder.c
+++ b/subsys/net/lib/dns/mdns_responder.c
@@ -49,7 +49,7 @@ LOG_MODULE_REGISTER(net_mdns_responder, CONFIG_MDNS_RESPONDER_LOG_LEVEL);
 #pragma GCC diagnostic ignored "-Wstringop-overread"
 #endif
 
-extern void dns_dispatcher_svc_handler(struct k_work *work);
+extern void dns_dispatcher_svc_handler(struct net_socket_service_event *pev);
 
 #define MDNS_LISTEN_PORT 5353
 

--- a/subsys/net/lib/dns/resolve.c
+++ b/subsys/net/lib/dns/resolve.c
@@ -34,7 +34,7 @@ LOG_MODULE_REGISTER(net_dns_resolve, CONFIG_DNS_RESOLVER_LOG_LEVEL);
 #define DNS_SERVER_COUNT CONFIG_DNS_RESOLVER_MAX_SERVERS
 #define SERVER_COUNT     (DNS_SERVER_COUNT + DNS_MAX_MCAST_SERVERS)
 
-extern void dns_dispatcher_svc_handler(struct k_work *work);
+extern void dns_dispatcher_svc_handler(struct net_socket_service_event *pev);
 
 NET_SOCKET_SERVICE_SYNC_DEFINE_STATIC(resolve_svc, dns_dispatcher_svc_handler,
 				      DNS_RESOLVER_MAX_POLL);

--- a/subsys/net/lib/shell/sockets.c
+++ b/subsys/net/lib/shell/sockets.c
@@ -123,10 +123,7 @@ static void walk_socket_services(const struct net_socket_service_desc *svc,
 	snprintk(owner, sizeof(owner), "<unknown>");
 #endif
 
-	PR("%32s  %-6s  %-5d %s\n",
-	   owner,
-	   svc->pev->work.handler == NULL ? "SYNC" : "ASYNC",
-	   svc->pev_len, pev_output);
+	PR("%32s  %-5d %s\n", owner, svc->pev_len, pev_output);
 
 	(*count)++;
 }
@@ -183,8 +180,7 @@ static int cmd_net_sockets(const struct shell *sh, size_t argc, char *argv[])
 	svc_user_data.user_data = &svc_count;
 
 	PR("Services:\n");
-	PR("%32s  %-6s  %-5s %s\n",
-	   "Owner", "Mode", "Count", "FDs");
+	PR("%32s  %-5s %s\n", "Owner", "Count", "FDs");
 	PR("\n");
 
 	net_socket_service_foreach(walk_socket_services, (void *)&svc_user_data);

--- a/subsys/net/lib/sockets/Kconfig
+++ b/subsys/net/lib/sockets/Kconfig
@@ -119,20 +119,13 @@ config NET_SOCKETS_SERVICE_THREAD_PRIO
 	depends on NET_SOCKETS_SERVICE
 	help
 	  Set the priority of the socket service dispatcher thread. This handler
-	  polls the sockets and either places the triggered socket to work queue
-	  for asynchronous handlers, or calls the user supplied callback directly
-	  for synchronous handlers.
-	  The value should be selected carefully because if this thread priority
-	  is too high, the work queue handlers might not be able to run if using
-	  asynchronous handlers that are called via a work queue.
+	  polls the sockets and calls the user supplied callback directly.
 
 	  Note that >= 0 value means preemptive thread priority, the lowest
 	  value is NUM_PREEMPT_PRIORITIES.
 	  Highest preemptive thread priority is 0.
 	  Lowest cooperative thread priority is -1.
 	  Highest cooperative thread priority is -NUM_COOP_PRIORITIES.
-	  Make sure the priority is lower than workqueue priority so that
-	  we never block the workqueue handler.
 
 config NET_SOCKETS_SERVICE_STACK_SIZE
 	int "Stack size for the thread handling socket services"

--- a/subsys/net/lib/sockets/sockets_service.c
+++ b/subsys/net/lib/sockets/sockets_service.c
@@ -124,7 +124,7 @@ void net_socket_service_callback(struct net_socket_service_event *pev)
 	struct net_socket_service_desc *svc = pev->svc;
 	struct net_socket_service_event ev = *pev;
 
-	ev.callback(&ev.work);
+	ev.callback(&ev);
 
 	/* Copy back the socket fd to the global array because we marked
 	 * it as -1 when triggering the work.

--- a/subsys/net/lib/sockets/sockets_service.c
+++ b/subsys/net/lib/sockets/sockets_service.c
@@ -119,10 +119,8 @@ static struct net_socket_service_desc *find_svc_and_event(
  * round will not notice it and call the callback again while we are
  * servicing the callback.
  */
-void net_socket_service_callback(struct k_work *work)
+void net_socket_service_callback(struct net_socket_service_event *pev)
 {
-	struct net_socket_service_event *pev =
-		CONTAINER_OF(work, struct net_socket_service_event, work);
 	struct net_socket_service_desc *svc = pev->svc;
 	struct net_socket_service_event ev = *pev;
 
@@ -136,7 +134,7 @@ void net_socket_service_callback(struct k_work *work)
 	}
 }
 
-static int call_work(struct zsock_pollfd *pev, struct k_work *work)
+static int call_work(struct zsock_pollfd *pev, struct net_socket_service_event *event)
 {
 	int ret = 0;
 
@@ -146,7 +144,7 @@ static int call_work(struct zsock_pollfd *pev, struct k_work *work)
 	pev->fd = -1;
 
 	/* Synchronous call */
-	net_socket_service_callback(work);
+	net_socket_service_callback(event);
 
 	return ret;
 
@@ -169,7 +167,7 @@ static int trigger_work(struct zsock_pollfd *pev)
 	 */
 	event->event = *pev;
 
-	return call_work(pev, &event->work);
+	return call_work(pev, event);
 }
 
 static void socket_service_thread(void)

--- a/subsys/net/lib/zperf/zperf_tcp_receiver.c
+++ b/subsys/net/lib/zperf/zperf_tcp_receiver.c
@@ -39,7 +39,7 @@ static struct sockaddr tcp_server_addr;
 static struct zsock_pollfd fds[SOCK_ID_MAX];
 static struct sockaddr sock_addr[SOCK_ID_MAX];
 
-static void tcp_svc_handler(struct k_work *work);
+static void tcp_svc_handler(struct net_socket_service_event *pev);
 
 NET_SOCKET_SERVICE_SYNC_DEFINE_STATIC(svc_tcp, tcp_svc_handler,
 				      SOCK_ID_MAX);
@@ -231,10 +231,8 @@ error:
 	return ret;
 }
 
-static void tcp_svc_handler(struct k_work *work)
+static void tcp_svc_handler(struct net_socket_service_event *pev)
 {
-	struct net_socket_service_event *pev =
-		CONTAINER_OF(work, struct net_socket_service_event, work);
 	int ret;
 
 	ret = tcp_recv_data(pev);

--- a/subsys/net/lib/zperf/zperf_udp_receiver.c
+++ b/subsys/net/lib/zperf/zperf_udp_receiver.c
@@ -46,7 +46,7 @@ static struct sockaddr udp_server_addr;
 
 struct zsock_pollfd fds[SOCK_ID_MAX] = { 0 };
 
-static void udp_svc_handler(struct k_work *work);
+static void udp_svc_handler(struct net_socket_service_event *pev);
 
 NET_SOCKET_SERVICE_SYNC_DEFINE_STATIC(svc_udp, udp_svc_handler,
 				      SOCK_ID_MAX);
@@ -364,10 +364,8 @@ error:
 	return ret;
 }
 
-static void udp_svc_handler(struct k_work *work)
+static void udp_svc_handler(struct net_socket_service_event *pev)
 {
-	struct net_socket_service_event *pev =
-		CONTAINER_OF(work, struct net_socket_service_event, work);
 	int ret;
 
 	ret = udp_recv_data(pev);

--- a/subsys/shell/backends/shell_telnet.c
+++ b/subsys/shell/backends/shell_telnet.c
@@ -39,7 +39,7 @@ struct shell_telnet *sh_telnet;
 
 /* Basic TELNET implementation. */
 
-static void telnet_server_cb(struct k_work *work);
+static void telnet_server_cb(struct net_socket_service_event *evt);
 static int telnet_init(struct shell_telnet *ctx);
 
 NET_SOCKET_SERVICE_SYNC_DEFINE_STATIC(telnet_server, telnet_server_cb,
@@ -462,10 +462,8 @@ error:
 	}
 }
 
-static void telnet_server_cb(struct k_work *work)
+static void telnet_server_cb(struct net_socket_service_event *evt)
 {
-	struct net_socket_service_event *evt =
-		CONTAINER_OF(work, struct net_socket_service_event, work);
 	int sock_error;
 	socklen_t optlen = sizeof(int);
 

--- a/subsys/shell/backends/shell_websocket.c
+++ b/subsys/shell/backends/shell_websocket.c
@@ -24,7 +24,7 @@ LOG_MODULE_REGISTER(shell_websocket, CONFIG_SHELL_WEBSOCKET_INIT_LOG_LEVEL);
 #define WEBSOCKET_MIN_COMMAND_LEN 2
 #define WEBSOCKET_WILL_DO_COMMAND_LEN 3
 
-static void ws_server_cb(struct k_work *work);
+static void ws_server_cb(struct net_socket_service_event *evt);
 
 NET_SOCKET_SERVICE_SYNC_DEFINE_STATIC(websocket_server, NULL, ws_server_cb,
 				      SHELL_WEBSOCKET_SERVICE_COUNT);
@@ -157,10 +157,8 @@ error:
 	ws_end_client_connection(ws);
 }
 
-static void ws_server_cb(struct k_work *work)
+static void ws_server_cb(struct net_socket_service_event *evt)
 {
-	struct net_socket_service_event *evt =
-		CONTAINER_OF(work, struct net_socket_service_event, work);
 	socklen_t optlen = sizeof(int);
 	struct shell_websocket *ws;
 	int sock_error;

--- a/tests/net/socket/service/src/main.c
+++ b/tests/net/socket/service/src/main.c
@@ -31,21 +31,15 @@ K_SEM_DEFINE(wait_data, 0, UINT_MAX);
 K_SEM_DEFINE(wait_data_tcp, 0, UINT_MAX);
 #define WAIT_TIME 500
 
-static void server_handler(struct k_work *work)
+static void server_handler(struct net_socket_service_event *pev)
 {
-	struct net_socket_service_event *pev =
-		CONTAINER_OF(work, struct net_socket_service_event, work);
-
 	ARG_UNUSED(pev);
 
 	k_sem_give(&wait_data);
 }
 
-static void tcp_server_handler(struct k_work *work)
+static void tcp_server_handler(struct net_socket_service_event *pev)
 {
-	struct net_socket_service_event *pev =
-		CONTAINER_OF(work, struct net_socket_service_event, work);
-
 	ARG_UNUSED(pev);
 
 	k_sem_give(&wait_data_tcp);


### PR DESCRIPTION
This removes the remains from when there was a async mode for the socket service. 
Mainly it changes the callback argument from `struct k_work *work` to `struct net_socket_service_event`. 