### PR TITLE
tests: drivers: comparator: shell: use platform_allow

### DIFF
--- a/tests/drivers/comparator/shell/testcase.yaml
+++ b/tests/drivers/comparator/shell/testcase.yaml
@@ -3,7 +3,7 @@
 
 tests:
   drivers.comparator.shell:
-    integration_platforms:
+    platform_allow:
       - native_sim
       - native_sim/native/64
     tags:


### PR DESCRIPTION
Change integration_platform -> platform_allow to not build the shell test suite for all supported boards. Issue detected downstream when we tried to build the shell sample for the tiny nrf54h20 vpr core :)

Fixes #79918