### PR TITLE
tests: boards: nrf: qdec: Fix failing drivers.sensor.qdec.pm_runtime

### DIFF
--- a/tests/boards/nrf/qdec/src/main.c
+++ b/tests/boards/nrf/qdec/src/main.c
@@ -308,11 +308,11 @@ ZTEST(qdec_sensor, test_sensor_channel_get_empty)
 		pm_device_runtime_get(qdec_dev);
 	}
 
-	rc = sensor_sample_fetch(qdec_dev);
-	zassert_true(rc == 0, "Failed to fetch sample (%d)", rc);
-
 	/* wait for potential new readings */
 	k_msleep(100);
+
+	rc = sensor_sample_fetch(qdec_dev);
+	zassert_true(rc == 0, "Failed to fetch sample (%d)", rc);
 
 	/* get readings but ignore them, as they may include reading from time
 	 * when emulation was still working (i.e. during previous test)


### PR DESCRIPTION
Test was failing because after re-enabling QDEC there is an interrupt REPORTRDY coming after some time. Test had k_msleep(100) added to accomodate for that but it was added after sensor_sample_fetch and should be added before so that sample with data from REPORTRDY event is fetched so that next read is empty as expected.

Fixes #80050.