### PR TITLE
video pipeline on rt10xx: Fix chicken-egg issue in init priority

### DIFF
--- a/boards/madmachine/mm_swiftio/mm_swiftio.dts
+++ b/boards/madmachine/mm_swiftio/mm_swiftio.dts
@@ -192,7 +192,6 @@
 
 &csi {
 	status = "okay";
-	source = <&ov7725>;
 	pinctrl-0 = <&pinmux_csi>;
 	pinctrl-names = "default";
 

--- a/boards/madmachine/mm_swiftio/mm_swiftio.dts
+++ b/boards/madmachine/mm_swiftio/mm_swiftio.dts
@@ -198,7 +198,7 @@
 
 	port {
 		csi_ep_in: endpoint {
-			remote-endpoint = <&ov7725_ep_out>;
+			remote-endpoint-label = "ov7725_ep_out";
 		};
 	};
 };

--- a/boards/madmachine/mm_swiftio/mm_swiftio.dts
+++ b/boards/madmachine/mm_swiftio/mm_swiftio.dts
@@ -115,7 +115,7 @@
 
 		port {
 			ov7725_ep_out: endpoint {
-				remote-endpoint = <&csi_ep_in>;
+				remote-endpoint-label = "csi_ep_in";
 			};
 		};
 	};

--- a/boards/shields/dvp_fpc24_mt9m114/boards/mimxrt1060_evkb.overlay
+++ b/boards/shields/dvp_fpc24_mt9m114/boards/mimxrt1060_evkb.overlay
@@ -1,9 +1,0 @@
-/*
- * Copyright 2024 NXP
- *
- * SPDX-License-Identifier: Apache-2.0
- */
-
-&dvp_fpc24_interface {
-	source = <&mt9m114>;
-};

--- a/boards/shields/dvp_fpc24_mt9m114/boards/mimxrt1064_evk.overlay
+++ b/boards/shields/dvp_fpc24_mt9m114/boards/mimxrt1064_evk.overlay
@@ -1,9 +1,0 @@
-/*
- * Copyright 2024 NXP
- *
- * SPDX-License-Identifier: Apache-2.0
- */
-
-&dvp_fpc24_interface {
-	source = <&mt9m114>;
-};

--- a/boards/shields/dvp_fpc24_mt9m114/dvp_fpc24_mt9m114.overlay
+++ b/boards/shields/dvp_fpc24_mt9m114/dvp_fpc24_mt9m114.overlay
@@ -17,7 +17,7 @@
 
 		port {
 			mt9m114_ep_out: endpoint {
-				remote-endpoint = <&dfi_ep_in>;
+				remote-endpoint-label = "dfi_ep_in";
 			};
 		};
 	};
@@ -28,7 +28,7 @@
 
 	port {
 		dfi_ep_in: endpoint {
-			remote-endpoint = <&mt9m114_ep_out>;
+			remote-endpoint-label = "mt9m114_ep_out";
 		};
 	};
 };

--- a/boards/shields/nxp_btb44_ov5640/nxp_btb44_ov5640.overlay
+++ b/boards/shields/nxp_btb44_ov5640/nxp_btb44_ov5640.overlay
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/video/video-interfaces.h>
+
 /{
 	chosen {
 		zephyr,camera = &nxp_csi;
@@ -22,6 +24,8 @@
 		port {
 			ov5640_ep_out: endpoint {
 				remote-endpoint-label = "mipi_csi2rx_ep_in";
+				bus-type = <VIDEO_BUS_TYPE_CSI2_DPHY>;
+				data-lanes = <1 2>;
 			};
 		};
 	};
@@ -38,6 +42,7 @@
 
 			mipi_csi2rx_ep_in: endpoint {
 				remote-endpoint-label = "ov5640_ep_out";
+				data-lanes = <1 2>;
 			};
 		};
 	};

--- a/boards/shields/nxp_btb44_ov5640/nxp_btb44_ov5640.overlay
+++ b/boards/shields/nxp_btb44_ov5640/nxp_btb44_ov5640.overlay
@@ -21,7 +21,7 @@
 
 		port {
 			ov5640_ep_out: endpoint {
-				remote-endpoint = <&mipi_csi2rx_ep_in>;
+				remote-endpoint-label = "mipi_csi2rx_ep_in";
 			};
 		};
 	};

--- a/boards/shields/nxp_btb44_ov5640/nxp_btb44_ov5640.overlay
+++ b/boards/shields/nxp_btb44_ov5640/nxp_btb44_ov5640.overlay
@@ -37,7 +37,7 @@
 			reg = <1>;
 
 			mipi_csi2rx_ep_in: endpoint {
-				remote-endpoint = <&ov5640_ep_out>;
+				remote-endpoint-label = "ov5640_ep_out";
 			};
 		};
 	};

--- a/boards/shields/nxp_btb44_ov5640/nxp_btb44_ov5640.overlay
+++ b/boards/shields/nxp_btb44_ov5640/nxp_btb44_ov5640.overlay
@@ -34,8 +34,6 @@
 &nxp_mipi_csi {
 	status = "okay";
 
-	sensor = <&ov5640>;
-
 	ports {
 		port@1 {
 			reg = <1>;

--- a/drivers/video/Kconfig.mcux_csi
+++ b/drivers/video/Kconfig.mcux_csi
@@ -11,7 +11,7 @@ config VIDEO_MCUX_CSI
 
 config VIDEO_MCUX_CSI_INIT_PRIORITY
 	int "NXP MCUX CSI init priority"
-	default 61
+	default 59
 	depends on VIDEO_MCUX_CSI
 	help
 	  Initialization priority for the CSI interface on an NXP MCUX device.

--- a/drivers/video/video_mcux_csi.c
+++ b/drivers/video/video_mcux_csi.c
@@ -32,25 +32,6 @@ struct video_mcux_csi_data {
 	struct k_poll_signal *signal;
 };
 
-static inline unsigned int video_pix_fmt_bpp(uint32_t pixelformat)
-{
-	switch (pixelformat) {
-	case VIDEO_PIX_FMT_BGGR8:
-	case VIDEO_PIX_FMT_GBRG8:
-	case VIDEO_PIX_FMT_GRBG8:
-	case VIDEO_PIX_FMT_RGGB8:
-		return 1;
-	case VIDEO_PIX_FMT_RGB565:
-	case VIDEO_PIX_FMT_YUYV:
-		return 2;
-	case VIDEO_PIX_FMT_XRGB32:
-	case VIDEO_PIX_FMT_XYUV32:
-		return 4;
-	default:
-		return 0;
-	}
-}
-
 static void __frame_done_cb(CSI_Type *base, csi_handle_t *handle, status_t status, void *user_data)
 {
 	struct video_mcux_csi_data *data = user_data;

--- a/drivers/video/video_mcux_csi.c
+++ b/drivers/video/video_mcux_csi.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2019, Linaro Limited
+ * Copyright 2024 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/drivers/video/video_mcux_csi.c
+++ b/drivers/video/video_mcux_csi.c
@@ -18,6 +18,16 @@
 #include <fsl_cache.h>
 #endif
 
+#if defined(CONFIG_VIDEO_MCUX_MIPI_CSI2RX)
+#define DEVICE_DT_INST_GET_SOURCE_DEV(n)                                                           \
+	DEVICE_DT_GET(DT_PARENT(DT_GPARENT(DT_NODELABEL(DT_STRING_TOKEN(                           \
+		DT_CHILD(DT_INST_CHILD(n, port), endpoint), remote_endpoint_label)))))
+#else
+#define DEVICE_DT_INST_GET_SOURCE_DEV(n)                                                           \
+	DEVICE_DT_GET(DT_GPARENT(DT_NODELABEL(DT_STRING_TOKEN(                                     \
+		DT_CHILD(DT_INST_CHILD(n, port), endpoint), remote_endpoint_label))))
+#endif
+
 struct video_mcux_csi_config {
 	CSI_Type *base;
 	const struct device *source_dev;
@@ -497,7 +507,7 @@ PINCTRL_DT_INST_DEFINE(0);
 
 static const struct video_mcux_csi_config video_mcux_csi_config_0 = {
 	.base = (CSI_Type *)DT_INST_REG_ADDR(0),
-	.source_dev = DEVICE_DT_GET(DT_INST_PHANDLE(0, source)),
+	.source_dev = DEVICE_DT_INST_GET_SOURCE_DEV(0),
 	.pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(0),
 };
 

--- a/drivers/video/video_mcux_csi.c
+++ b/drivers/video/video_mcux_csi.c
@@ -436,6 +436,42 @@ static int video_mcux_csi_set_signal(const struct device *dev, enum video_endpoi
 }
 #endif
 
+static int video_mcux_csi_set_frmival(const struct device *dev, enum video_endpoint_id ep,
+				      struct video_frmival *frmival)
+{
+	const struct video_mcux_csi_config *config = dev->config;
+
+	return video_set_frmival(config->source_dev, ep, frmival);
+}
+
+static int video_mcux_csi_get_frmival(const struct device *dev, enum video_endpoint_id ep,
+				      struct video_frmival *frmival)
+{
+	const struct video_mcux_csi_config *config = dev->config;
+
+	return video_get_frmival(config->source_dev, ep, frmival);
+}
+
+static int video_mcux_csi_enum_frmival(const struct device *dev, enum video_endpoint_id ep,
+				       struct video_frmival_enum *fie)
+{
+	const struct video_mcux_csi_config *config = dev->config;
+	const struct video_format *fie_fmt = fie->format;
+	int ret;
+
+#if defined(CONFIG_VIDEO_MCUX_MIPI_CSI2RX)
+	struct video_format converted_fmt = *fie->format;
+
+	video_pix_fmt_convert(&converted_fmt, false);
+	fie->format = &converted_fmt;
+#endif
+
+	ret = video_enum_frmival(config->source_dev, ep, fie);
+	fie->format = fie_fmt;
+
+	return ret;
+}
+
 static const struct video_driver_api video_mcux_csi_driver_api = {
 	.set_format = video_mcux_csi_set_fmt,
 	.get_format = video_mcux_csi_get_fmt,
@@ -447,6 +483,9 @@ static const struct video_driver_api video_mcux_csi_driver_api = {
 	.set_ctrl = video_mcux_csi_set_ctrl,
 	.get_ctrl = video_mcux_csi_get_ctrl,
 	.get_caps = video_mcux_csi_get_caps,
+	.set_frmival = video_mcux_csi_set_frmival,
+	.get_frmival = video_mcux_csi_get_frmival,
+	.enum_frmival = video_mcux_csi_enum_frmival,
 #ifdef CONFIG_POLL
 	.set_signal = video_mcux_csi_set_signal,
 #endif

--- a/drivers/video/video_mcux_csi.c
+++ b/drivers/video/video_mcux_csi.c
@@ -198,6 +198,11 @@ static int video_mcux_csi_stream_start(const struct device *dev)
 	const struct video_mcux_csi_config *config = dev->config;
 	struct video_mcux_csi_data *data = dev->data;
 	status_t ret;
+	struct video_buf *vbuf;
+
+	while ((vbuf = k_fifo_get(&data->fifo_out, K_NO_WAIT))) {
+		k_fifo_put(&data->fifo_in, vbuf);
+	};
 
 	ret = CSI_TransferStart(config->base, &data->csi_handle);
 	if (ret != kStatus_Success) {

--- a/drivers/video/video_mcux_csi.c
+++ b/drivers/video/video_mcux_csi.c
@@ -471,11 +471,6 @@ static int video_mcux_csi_init_0(const struct device *dev)
 	return video_mcux_csi_init(dev);
 }
 
-/* CONFIG_KERNEL_INIT_PRIORITY_DEVICE is used to make sure the
- * CSI peripheral is initialized before the camera, which is
- * necessary since the clock to the camera is provided by the
- * CSI peripheral.
- */
 DEVICE_DT_INST_DEFINE(0, &video_mcux_csi_init_0, NULL, &video_mcux_csi_data_0,
 		      &video_mcux_csi_config_0, POST_KERNEL, CONFIG_VIDEO_MCUX_CSI_INIT_PRIORITY,
 		      &video_mcux_csi_driver_api);

--- a/drivers/video/video_mcux_mipi_csi2rx.c
+++ b/drivers/video/video_mcux_mipi_csi2rx.c
@@ -14,11 +14,6 @@
 
 LOG_MODULE_REGISTER(video_mipi_csi2rx, CONFIG_VIDEO_LOG_LEVEL);
 
-/*
- * Two data lanes are set by default as 2-lanes camera sensors are
- * more common and more performant but single lane is also supported.
- */
-#define DEFAULT_MIPI_CSI_NUM_LANES 2
 #define DEFAULT_CAMERA_FRAME_RATE  30
 
 struct mipi_csi2rx_config {
@@ -101,8 +96,6 @@ static int mipi_csi2rx_set_fmt(const struct device *dev, enum video_endpoint_id 
 			0x24,
 		},
 	};
-
-	csi2rxConfig.laneNum = DEFAULT_MIPI_CSI_NUM_LANES;
 
 	for (i = 0; i < ARRAY_SIZE(csi2rxHsSettle); i++) {
 		if ((fmt->width == csi2rxHsSettle[i][0]) && (fmt->height == csi2rxHsSettle[i][1]) &&
@@ -203,7 +196,11 @@ static int mipi_csi2rx_init(const struct device *dev)
 }
 
 #define MIPI_CSI2RX_INIT(n)                                                                        \
-	static struct mipi_csi2rx_data mipi_csi2rx_data_##n;                                       \
+	static struct mipi_csi2rx_data mipi_csi2rx_data_##n = {                                    \
+		.csi2rxConfig.laneNum =                                                            \
+			DT_PROP_LEN(DT_CHILD(DT_CHILD(DT_INST_CHILD(n, ports), port_1), endpoint), \
+				    data_lanes),                                                   \
+	};                                                                                         \
                                                                                                    \
 	static const struct mipi_csi2rx_config mipi_csi2rx_config_##n = {                          \
 		.base = (MIPI_CSI2RX_Type *)DT_INST_REG_ADDR(n),                                   \

--- a/drivers/video/video_mcux_mipi_csi2rx.c
+++ b/drivers/video/video_mcux_mipi_csi2rx.c
@@ -7,6 +7,7 @@
 #define DT_DRV_COMPAT nxp_mipi_csi2rx
 
 #include <zephyr/drivers/video.h>
+#include <zephyr/drivers/video-controls.h>
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 #include <soc.h>
@@ -173,6 +174,115 @@ static inline int mipi_csi2rx_set_ctrl(const struct device *dev, unsigned int ci
 	return -ENOTSUP;
 }
 
+static int mipi_csi2rx_set_frmival(const struct device *dev, enum video_endpoint_id ep,
+				   struct video_frmival *frmival)
+{
+	const struct mipi_csi2rx_config *config = dev->config;
+	int ret;
+
+	ret = video_set_frmival(config->sensor_dev, ep, frmival);
+	if (ret) {
+		LOG_ERR("Cannot set sensor_dev frmival");
+		return ret;
+	}
+
+	ret = mipi_csi2rx_update_settings(dev, ep);
+
+	return ret;
+}
+
+static int mipi_csi2rx_get_frmival(const struct device *dev, enum video_endpoint_id ep,
+				   struct video_frmival *frmival)
+{
+	const struct mipi_csi2rx_config *config = dev->config;
+
+	return video_get_frmival(config->sensor_dev, ep, frmival);
+}
+
+static uint64_t mipi_csi2rx_cal_frame_size(const struct video_format *fmt)
+{
+	return fmt->height * fmt->width * video_pix_fmt_bpp(fmt->pixelformat) * 8;
+}
+
+static uint64_t mipi_csi2rx_estimate_pixel_rate(const struct video_frmival *cur_fmival,
+						const struct video_frmival *fie_frmival,
+						const struct video_format *cur_format,
+						const struct video_format *fie_format,
+						uint64_t cur_pixel_rate, uint8_t laneNum)
+{
+	return mipi_csi2rx_cal_frame_size(cur_format) * fie_frmival->denominator *
+	       cur_fmival->numerator * cur_pixel_rate /
+	       (mipi_csi2rx_cal_frame_size(fie_format) * fie_frmival->numerator *
+		cur_fmival->denominator);
+}
+
+static int mipi_csi2rx_enum_frmival(const struct device *dev, enum video_endpoint_id ep,
+				    struct video_frmival_enum *fie)
+{
+	const struct mipi_csi2rx_config *config = dev->config;
+	struct mipi_csi2rx_data *drv_data = dev->data;
+	int ret;
+	uint64_t cur_pixel_rate, est_pixel_rate;
+	struct video_frmival cur_frmival;
+	struct video_format cur_fmt;
+
+	ret = video_enum_frmival(config->sensor_dev, ep, fie);
+	if (ret) {
+		return ret;
+	}
+
+	ret = video_get_ctrl(config->sensor_dev, VIDEO_CID_PIXEL_RATE, &cur_pixel_rate);
+	if (ret) {
+		LOG_ERR("Cannot get sensor_dev pixel rate");
+		return ret;
+	}
+
+	ret = video_get_frmival(config->sensor_dev, ep, &cur_frmival);
+	if (ret) {
+		LOG_ERR("Cannot get sensor_dev frame rate");
+		return ret;
+	}
+
+	ret = video_get_format(config->sensor_dev, ep, &cur_fmt);
+	if (ret) {
+		LOG_ERR("Cannot get sensor_dev format");
+		return ret;
+	}
+
+	if (fie->type == VIDEO_FRMIVAL_TYPE_DISCRETE) {
+		est_pixel_rate = mipi_csi2rx_estimate_pixel_rate(
+			&cur_frmival, &fie->discrete, &cur_fmt, fie->format, cur_pixel_rate,
+			drv_data->csi2rxConfig.laneNum);
+		if (est_pixel_rate > MAX_SUPPORTED_PIXEL_RATE) {
+			return -EINVAL;
+		}
+
+	} else {
+		/* Check the lane rate of the lower bound framerate */
+		est_pixel_rate = mipi_csi2rx_estimate_pixel_rate(
+			&cur_frmival, &fie->stepwise.min, &cur_fmt, fie->format, cur_pixel_rate,
+			drv_data->csi2rxConfig.laneNum);
+		if (est_pixel_rate > MAX_SUPPORTED_PIXEL_RATE) {
+			return -EINVAL;
+		}
+
+		/* Check the lane rate of the upper bound framerate */
+		est_pixel_rate = mipi_csi2rx_estimate_pixel_rate(
+			&cur_frmival, &fie->stepwise.max, &cur_fmt, fie->format, cur_pixel_rate,
+			drv_data->csi2rxConfig.laneNum);
+		if (est_pixel_rate > MAX_SUPPORTED_PIXEL_RATE) {
+			fie->stepwise.max.denominator =
+				(mipi_csi2rx_cal_frame_size(&cur_fmt) * MAX_SUPPORTED_PIXEL_RATE *
+				 cur_frmival.denominator) /
+				(mipi_csi2rx_cal_frame_size(fie->format) * cur_pixel_rate *
+				 cur_frmival.numerator);
+			fie->stepwise.max.numerator = 1;
+		}
+	}
+
+	return 0;
+}
+
 static const struct video_driver_api mipi_csi2rx_driver_api = {
 	.get_caps = mipi_csi2rx_get_caps,
 	.get_format = mipi_csi2rx_get_fmt,
@@ -180,6 +290,9 @@ static const struct video_driver_api mipi_csi2rx_driver_api = {
 	.stream_start = mipi_csi2rx_stream_start,
 	.stream_stop = mipi_csi2rx_stream_stop,
 	.set_ctrl = mipi_csi2rx_set_ctrl,
+	.set_frmival = mipi_csi2rx_set_frmival,
+	.get_frmival = mipi_csi2rx_get_frmival,
+	.enum_frmival = mipi_csi2rx_enum_frmival,
 };
 
 static int mipi_csi2rx_init(const struct device *dev)

--- a/drivers/video/video_mcux_mipi_csi2rx.c
+++ b/drivers/video/video_mcux_mipi_csi2rx.c
@@ -175,12 +175,24 @@ static int mipi_csi2rx_get_caps(const struct device *dev, enum video_endpoint_id
 	return video_get_caps(config->sensor_dev, ep, caps);
 }
 
+static inline int mipi_csi2rx_set_ctrl(const struct device *dev, unsigned int cid, void *value)
+{
+	const struct mipi_csi2rx_config *config = dev->config;
+
+	if (config->sensor_dev) {
+		return video_set_ctrl(config->sensor_dev, cid, value);
+	}
+
+	return -ENOTSUP;
+}
+
 static const struct video_driver_api mipi_csi2rx_driver_api = {
 	.get_caps = mipi_csi2rx_get_caps,
 	.get_format = mipi_csi2rx_get_fmt,
 	.set_format = mipi_csi2rx_set_fmt,
 	.stream_start = mipi_csi2rx_stream_start,
 	.stream_stop = mipi_csi2rx_stream_stop,
+	.set_ctrl = mipi_csi2rx_set_ctrl,
 };
 
 static int mipi_csi2rx_init(const struct device *dev)

--- a/drivers/video/video_mcux_mipi_csi2rx.c
+++ b/drivers/video/video_mcux_mipi_csi2rx.c
@@ -20,6 +20,10 @@ LOG_MODULE_REGISTER(video_mipi_csi2rx, CONFIG_VIDEO_LOG_LEVEL);
 
 #define ABS(a, b) (a > b ? a - b : b - a)
 
+#define DEVICE_DT_INST_GET_SENSOR_DEV(n)                                                           \
+	DEVICE_DT_GET(DT_GPARENT(DT_NODELABEL(DT_STRING_TOKEN(                                     \
+		DT_CHILD(DT_CHILD(DT_INST_CHILD(n, ports), port_1), endpoint), remote_endpoint_label))))
+
 struct mipi_csi2rx_config {
 	const MIPI_CSI2RX_Type *base;
 	const struct device *sensor_dev;
@@ -322,7 +326,7 @@ static int mipi_csi2rx_init(const struct device *dev)
                                                                                                    \
 	static const struct mipi_csi2rx_config mipi_csi2rx_config_##n = {                          \
 		.base = (MIPI_CSI2RX_Type *)DT_INST_REG_ADDR(n),                                   \
-		.sensor_dev = DEVICE_DT_GET(DT_INST_PHANDLE(n, sensor)),                           \
+		.sensor_dev = DEVICE_DT_INST_GET_SENSOR_DEV(n),                           \
 	};                                                                                         \
                                                                                                    \
 	DEVICE_DT_INST_DEFINE(n, &mipi_csi2rx_init, NULL, &mipi_csi2rx_data_##n,                   \

--- a/dts/arm/nxp/nxp_rt11xx.dtsi
+++ b/dts/arm/nxp/nxp_rt11xx.dtsi
@@ -888,7 +888,6 @@
 			reg = <0x40800000 0x4000>;
 			interrupts = <56 1>;
 			status = "disabled";
-			source = <&mipi_csi2rx>;
 
 			port {
 				csi_ep_in: endpoint {

--- a/dts/arm/nxp/nxp_rt11xx.dtsi
+++ b/dts/arm/nxp/nxp_rt11xx.dtsi
@@ -892,7 +892,7 @@
 
 			port {
 				csi_ep_in: endpoint {
-					remote-endpoint = <&mipi_csi2rx_ep_out>;
+					remote-endpoint-label = "mipi_csi2rx_ep_out";
 				};
 			};
 		};

--- a/dts/arm/nxp/nxp_rt11xx.dtsi
+++ b/dts/arm/nxp/nxp_rt11xx.dtsi
@@ -909,7 +909,7 @@
 				port@0 {
 					reg = <0>;
 					mipi_csi2rx_ep_out: endpoint {
-						remote-endpoint = <&csi_ep_in>;
+						remote-endpoint-label = "csi_ep_in";
 					};
 				};
 

--- a/dts/bindings/video/aptina,mt9m114.yaml
+++ b/dts/bindings/video/aptina,mt9m114.yaml
@@ -6,3 +6,7 @@ description: MT9M114 CMOS video sensor
 compatible: "aptina,mt9m114"
 
 include: i2c-device.yaml
+
+child-binding:
+  child-binding:
+    include: video-interfaces.yaml

--- a/dts/bindings/video/nxp,imx-csi.yaml
+++ b/dts/bindings/video/nxp,imx-csi.yaml
@@ -19,3 +19,7 @@ properties:
     type: phandle
     description: the connected source device,
       e.g., a mipi csi or a camera sensor
+
+child-binding:
+  child-binding:
+    include: video-interfaces.yaml

--- a/dts/bindings/video/nxp,imx-csi.yaml
+++ b/dts/bindings/video/nxp,imx-csi.yaml
@@ -14,12 +14,6 @@ properties:
   interrupts:
     required: true
 
-  source:
-    required: true
-    type: phandle
-    description: the connected source device,
-      e.g., a mipi csi or a camera sensor
-
 child-binding:
   child-binding:
     include: video-interfaces.yaml

--- a/dts/bindings/video/nxp,mipi-csi2rx.yaml
+++ b/dts/bindings/video/nxp,mipi-csi2rx.yaml
@@ -15,3 +15,8 @@ properties:
     required: true
     type: phandle
     description: the connected camera sensor
+
+child-binding:
+  child-binding:
+    child-binding:
+      include: video-interfaces.yaml

--- a/dts/bindings/video/nxp,mipi-csi2rx.yaml
+++ b/dts/bindings/video/nxp,mipi-csi2rx.yaml
@@ -10,12 +10,6 @@ compatible: "nxp,mipi-csi2rx"
 
 include: [base.yaml]
 
-properties:
-  sensor:
-    required: true
-    type: phandle
-    description: the connected camera sensor
-
 child-binding:
   child-binding:
     child-binding:

--- a/dts/bindings/video/ovti,ov5640.yaml
+++ b/dts/bindings/video/ovti,ov5640.yaml
@@ -18,3 +18,7 @@ properties:
     description: |
       The PWDN pin is asserted to disable the sensor. The sensor
       receives this as an active-high signal.
+
+child-binding:
+  child-binding:
+    include: video-interfaces.yaml

--- a/dts/bindings/video/ovti,ov7725.yaml
+++ b/dts/bindings/video/ovti,ov7725.yaml
@@ -13,3 +13,7 @@ properties:
       reset.  The sensor receives this as an active-low signal.
 
 include: i2c-device.yaml
+
+child-binding:
+  child-binding:
+    include: video-interfaces.yaml

--- a/include/zephyr/drivers/video.h
+++ b/include/zephyr/drivers/video.h
@@ -827,6 +827,30 @@ void video_buffer_release(struct video_buffer *buf);
  * @}
  */
 
+/**
+ * @brief Get number of bytes per pixel of a pixel format
+ *
+ * @param pixfmt FourCC pixel format value (\ref video_pixel_formats).
+ */
+static inline unsigned int video_pix_fmt_bpp(uint32_t pixfmt)
+{
+	switch (pixfmt) {
+	case VIDEO_PIX_FMT_BGGR8:
+	case VIDEO_PIX_FMT_GBRG8:
+	case VIDEO_PIX_FMT_GRBG8:
+	case VIDEO_PIX_FMT_RGGB8:
+		return 1;
+	case VIDEO_PIX_FMT_RGB565:
+	case VIDEO_PIX_FMT_YUYV:
+		return 2;
+	case VIDEO_PIX_FMT_XRGB32:
+	case VIDEO_PIX_FMT_XYUV32:
+		return 4;
+	default:
+		return 0;
+	}
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/soc/nxp/imxrt/imxrt11xx/soc.c
+++ b/soc/nxp/imxrt/imxrt11xx/soc.c
@@ -474,17 +474,6 @@ static ALWAYS_INLINE void clock_init(void)
 	CLOCK_EnableClock(kCLOCK_Video_Mux);
 	VIDEO_MUX->VID_MUX_CTRL.SET = VIDEO_MUX_VID_MUX_CTRL_CSI_SEL_MASK;
 
-	/* Configure MIPI CSI-2 Rx clocks */
-	rootCfg.div = 8;
-	rootCfg.mux = kCLOCK_CSI2_ClockRoot_MuxSysPll3Out;
-	CLOCK_SetRootClock(kCLOCK_Root_Csi2, &rootCfg);
-
-	rootCfg.mux = kCLOCK_CSI2_ESC_ClockRoot_MuxSysPll3Out;
-	CLOCK_SetRootClock(kCLOCK_Root_Csi2_Esc, &rootCfg);
-
-	rootCfg.mux = kCLOCK_CSI2_UI_ClockRoot_MuxSysPll3Out;
-	CLOCK_SetRootClock(kCLOCK_Root_Csi2_Ui, &rootCfg);
-
 	/* Enable power domain for MIPI CSI-2 */
 	PGMC_BPC4->BPC_POWER_CTRL |= (PGMC_BPC_BPC_POWER_CTRL_PSW_ON_SOFT_MASK |
 				      PGMC_BPC_BPC_POWER_CTRL_ISO_OFF_SOFT_MASK);
@@ -680,6 +669,35 @@ void imxrt_post_init_display_interface(void)
 			      IOMUXC_GPR_GPR62_MIPI_DSI_DPI_SOFT_RESET_N_MASK);
 }
 
+#endif
+
+#if CONFIG_VIDEO_MCUX_MIPI_CSI2RX
+void mipi_csi2rx_clock_set_freq(clock_root_t clock_root, uint32_t rate)
+{
+	clock_root_config_t rootCfg = {0};
+	uint32_t freq;
+	clock_name_t clk_source;
+
+	switch (clock_root) {
+	case kCLOCK_Root_Csi2:
+		rootCfg.mux = kCLOCK_CSI2_ClockRoot_MuxSysPll3Out;
+		break;
+	case kCLOCK_Root_Csi2_Esc:
+		rootCfg.mux = kCLOCK_CSI2_ESC_ClockRoot_MuxSysPll3Out;
+		break;
+	case kCLOCK_Root_Csi2_Ui:
+		rootCfg.mux = kCLOCK_CSI2_UI_ClockRoot_MuxSysPll3Out;
+		break;
+	default:
+		return;
+	}
+
+	clk_source = CLOCK_GetRootClockSource(clock_root, rootCfg.mux);
+	freq = CLOCK_GetFreq(clk_source);
+	__ASSERT(rate < freq, "Requested rate is higher than the maximum clock frequency");
+	rootCfg.div = (uint32_t)freq / rate;
+	CLOCK_SetRootClock(clock_root, &rootCfg);
+}
 #endif
 
 /**

--- a/soc/nxp/imxrt/imxrt11xx/soc.h
+++ b/soc/nxp/imxrt/imxrt11xx/soc.h
@@ -32,6 +32,10 @@ void imxrt_pre_init_display_interface(void);
 void imxrt_post_init_display_interface(void);
 #endif
 
+#if CONFIG_VIDEO_MCUX_MIPI_CSI2RX
+void mipi_csi2rx_clock_set_freq(clock_root_t clock_root, uint32_t rate);
+#endif
+
 void flexspi_clock_set_div(uint32_t value);
 uint32_t flexspi_clock_get_freq(void);
 

--- a/tests/drivers/build_all/video/mimxrt1170_evk_mimxrt1176_cm7.overlay
+++ b/tests/drivers/build_all/video/mimxrt1170_evk_mimxrt1176_cm7.overlay
@@ -60,7 +60,6 @@
 			compatible = "nxp,mipi-csi2rx";
 			reg = <0x33334444 0x200>;
 			status = "okay";
-			sensor = <&test_i2c_ov5640>;
 
 			ports {
 				#address-cells = <1>;

--- a/tests/drivers/build_all/video/mimxrt1170_evk_mimxrt1176_cm7.overlay
+++ b/tests/drivers/build_all/video/mimxrt1170_evk_mimxrt1176_cm7.overlay
@@ -8,6 +8,8 @@
  * (and be extended to test) real hardware.
  */
 
+#include <zephyr/dt-bindings/video/video-interfaces.h>
+
 / {
 	test {
 		#address-cells = <1>;
@@ -34,6 +36,14 @@
 				reg = <0x1>;
 				reset-gpios = <&test_gpio 0 0>;
 				powerdown-gpios = <&test_gpio 1 0>;
+
+				port {
+					ov5640_ep_out: endpoint {
+						remote-endpoint-label = "mipi_csi2rx_ep_in";
+						bus-type = <VIDEO_BUS_TYPE_CSI2_DPHY>;
+						data-lanes = <1 2>;
+					};
+				};
 			};
 		};
 
@@ -51,6 +61,20 @@
 			reg = <0x33334444 0x200>;
 			status = "okay";
 			sensor = <&test_i2c_ov5640>;
+
+			ports {
+				#address-cells = <1>;
+				#size-cells = <0>;
+
+				port@1 {
+					reg = <1>;
+
+					mipi_csi2rx_ep_in: endpoint {
+						remote-endpoint-label = "ov5640_ep_out";
+						data-lanes = <1 2>;
+					};
+				};
+			};
 		};
 	};
 };

--- a/tests/drivers/build_all/video/mimxrt1170_evk_mimxrt1176_cm7.overlay
+++ b/tests/drivers/build_all/video/mimxrt1170_evk_mimxrt1176_cm7.overlay
@@ -53,7 +53,6 @@
 			status = "okay";
 			interrupt-parent = <&nvic>;
 			interrupts = <56 1>;
-			source = <&test_mipi_csi2rx>;
 		};
 
 		test_mipi_csi2rx: mipi_csi2rx@33334444 {


### PR DESCRIPTION
Similar to the mcxn947 (ov7670/smartDMA) issue, the CSI needs to be initialized BEFORE the camera sensor to provide clock to the camera sensor. However, the CSI node refers to the camera sensor node in the DT so it has to be initialized AFTER the sensor to be able to compile.

This is a **deadlock/chicken-egg** issue as Zephyr currently does not allow [circular dependency](https://github.com/zephyrproject-rtos/zephyr/issues/57708). Disable the init priority check as a work-around for this.