### PR TITLE
MAINTAINERS: add myself to collaborators list

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -4074,8 +4074,12 @@ Xilinx Platforms:
   collaborators:
     - henrikbrixandersen
     - ibirnbaum
+    - michalsimek
   files:
+    - boards/amd/
+    - drivers/*/*xilinx*
     - drivers/*/*xlnx*
+    - drivers/*/*zynq*
     - dts/*/xilinx/
     - dts/bindings/*/*xlnx*
     - include/zephyr/*/*/*xlnx*


### PR DESCRIPTION
Add myself to collaborators list for Xilinx/AMD platforms and also cover missing files and folders.

These files are not cover by the fragment:
./drivers/i2c/i2c_xilinx_axi*
./drivers/watchdog/wdt_xilinx_axi.c

And also files in drivers folder which don't contain xlnx like Kconfigs or fpga
./drivers/fpga/fpga_zynqmp*
./drivers/pinctrl/Kconfig.zynqmp
