### PR TITLE
drivers: ieee802154_nrf5: skip Enh Ack conf for invalid short address

### DIFF
--- a/drivers/ieee802154/ieee802154_nrf5.c
+++ b/drivers/ieee802154/ieee802154_nrf5.c
@@ -927,7 +927,10 @@ static int nrf5_configure(const struct device *dev,
 		sys_memcpy_swap(ext_addr_le, config->ack_ie.ext_addr, EXTENDED_ADDRESS_SIZE);
 
 		if (config->ack_ie.header_ie == NULL || config->ack_ie.header_ie->length == 0) {
-			nrf_802154_ack_data_clear(short_addr_le, false, NRF_802154_ACK_DATA_IE);
+			if (config->ack_ie.short_addr != IEEE802154_NO_SHORT_ADDRESS_ASSIGNED) {
+				nrf_802154_ack_data_clear(short_addr_le, false,
+					NRF_802154_ACK_DATA_IE);
+			}
 			nrf_802154_ack_data_clear(ext_addr_le, true, NRF_802154_ACK_DATA_IE);
 		} else {
 			element_id = ieee802154_header_ie_get_element_id(config->ack_ie.header_ie);
@@ -948,10 +951,13 @@ static int nrf5_configure(const struct device *dev,
 				return -ENOTSUP;
 			}
 
-			nrf_802154_ack_data_set(short_addr_le, false, config->ack_ie.header_ie,
-						config->ack_ie.header_ie->length +
-							IEEE802154_HEADER_IE_HEADER_LENGTH,
-						NRF_802154_ACK_DATA_IE);
+			if (config->ack_ie.short_addr != IEEE802154_NO_SHORT_ADDRESS_ASSIGNED) {
+				nrf_802154_ack_data_set(
+					short_addr_le, false, config->ack_ie.header_ie,
+					config->ack_ie.header_ie->length +
+						IEEE802154_HEADER_IE_HEADER_LENGTH,
+					NRF_802154_ACK_DATA_IE);
+			}
 			nrf_802154_ack_data_set(ext_addr_le, true, config->ack_ie.header_ie,
 						config->ack_ie.header_ie->length +
 							IEEE802154_HEADER_IE_HEADER_LENGTH,


### PR DESCRIPTION
If the invalid short address (0xfffe) is specified, configure the Enhanced Ack just for the extended address. This is needed because Header IEs for Enhanced Ack must be configured before the short address has been assigned to the child.

orig ref: `9f673d2c25b3dbc3ea2878ddc3f7609e56ff376a`