### PR TITLE
serial: xilinx: uartlite: switch to `DT_INST_IRQN_BY_IDX`

### DIFF
--- a/drivers/serial/uart_xlnx_uartlite.c
+++ b/drivers/serial/uart_xlnx_uartlite.c
@@ -377,7 +377,7 @@ static const struct uart_driver_api xlnx_uartlite_driver_api = {
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 #define XLNX_UARTLITE_IRQ_INIT(n, i)					\
 	do {								\
-		IRQ_CONNECT(DT_INST_IRQ_BY_IDX(n, i, irq),		\
+		IRQ_CONNECT(DT_INST_IRQN_BY_IDX(n, i),			\
 			    DT_INST_IRQ_BY_IDX(n, i, priority),		\
 			    xlnx_uartlite_isr,				\
 			    DEVICE_DT_INST_GET(n), 0);			\


### PR DESCRIPTION
Use DT_*IRQN helper to get the IRQ number on systems with multi-level interrupt configuration instead of IRQ number on particular interrupt controller.