### PR TITLE
soc: kinetis: disable on reset NMI and EzPort

### DIFF
--- a/soc/nxp/kinetis/k2x/Kconfig.defconfig
+++ b/soc/nxp/kinetis/k2x/Kconfig.defconfig
@@ -23,4 +23,10 @@ config NUM_IRQS
 config CPU_HAS_CUSTOM_FIXED_SOC_MPU_REGIONS
 	default y if SOC_MK22F12
 
+# The flash option register (FOPT) boot options
+# 1111 1001 - Set NMI pin/interrupts and EzPort reset default to disabled
+config KINETIS_FLASH_CONFIG_FOPT
+	default 0xF9
+	depends on KINETIS_FLASH_CONFIG
+
 endif # SOC_SERIES_KINETIS_K2X

--- a/soc/nxp/kinetis/k8x/Kconfig.defconfig
+++ b/soc/nxp/kinetis/k8x/Kconfig.defconfig
@@ -13,8 +13,11 @@ config NUM_IRQS
 config CPU_HAS_CUSTOM_FIXED_SOC_MPU_REGIONS
 	default y
 
+# The flash option register (FOPT) boot options
+# 0011 1001 - Boot from Internal Flash.
+#             Set NMI pin/interrupts to disabled.
 config KINETIS_FLASH_CONFIG_FOPT
-	default 0x3f
+	default 0x3B
 	depends on KINETIS_FLASH_CONFIG
 
 config GPIO

--- a/soc/nxp/kinetis/ke1xf/Kconfig.defconfig
+++ b/soc/nxp/kinetis/ke1xf/Kconfig.defconfig
@@ -23,8 +23,11 @@ config NUM_IRQS
 config CPU_HAS_CUSTOM_FIXED_SOC_MPU_REGIONS
 	default y
 
+# The flash option register (FOPT) boot options
+# 0111 1011 - Boot from Internal Flash.
+#             Set NMI pin/interrupts to disabled.
 config KINETIS_FLASH_CONFIG_FOPT
-	default 0x7d
+	default 0x7B
 	depends on KINETIS_FLASH_CONFIG
 
 config PWM_MCUX_PWT

--- a/soc/nxp/kinetis/ke1xz/Kconfig.defconfig
+++ b/soc/nxp/kinetis/ke1xz/Kconfig.defconfig
@@ -22,14 +22,13 @@ config NUM_IRQS
 config CPU_HAS_CUSTOM_FIXED_SOC_MPU_REGIONS
 	default y
 
-# This Kconfig is SOC Specific and configures the MCU at boot time
-# This SOC is configured via the following bits
+# The flash option register (FOPT) boot options:
 # 0000 0001 - Normal Boot
-# 0000 0100 - Enable Interrupts
+# 0000 0000 - Set NMI pin/interrupts to disabled
 # 0000 1000 - Allow Reset detection from RESET_Pin
-# 0111 0000 - Reserved for Future Expansion
+# 1111 0010 - Reserved for Future Expansion
 config KINETIS_FLASH_CONFIG_FOPT
-	default 0x7d
+	default 0xFB
 	depends on KINETIS_FLASH_CONFIG
 
 endif # SOC_SERIES_KE1XZ

--- a/soc/nxp/kinetis/kl2x/Kconfig.defconfig
+++ b/soc/nxp/kinetis/kl2x/Kconfig.defconfig
@@ -8,4 +8,11 @@ if SOC_SERIES_KINETIS_KL2X
 config NUM_IRQS
 	default 32 if SOC_MKL25Z4
 
+# The flash option register (FOPT) boot options
+# 0011 1011 - Boot from Internal Flash.
+#             Set NMI pin/interrupts to disabled.
+config KINETIS_FLASH_CONFIG_FOPT
+	default 0x3B
+	depends on KINETIS_FLASH_CONFIG
+
 endif # SOC_SERIES_KINETIS_KL2X

--- a/soc/nxp/kinetis/kv5x/Kconfig.defconfig
+++ b/soc/nxp/kinetis/kv5x/Kconfig.defconfig
@@ -13,4 +13,10 @@ config NUM_IRQS
 config GPIO
 	default y
 
+# The flash option register (FOPT) boot options
+# 1111 1011 - Set NMI pin/interrupts to disabled.
+config KINETIS_FLASH_CONFIG_FOPT
+	default 0xFB
+	depends on KINETIS_FLASH_CONFIG
+
 endif # SOC_SERIES_KINETIS_KV5X

--- a/soc/nxp/kinetis/kwx/Kconfig.defconfig
+++ b/soc/nxp/kinetis/kwx/Kconfig.defconfig
@@ -25,6 +25,22 @@ choice RNG_GENERATOR_CHOICE
 	default XOSHIRO_RANDOM_GENERATOR
 endchoice
 
+# The flash option register (FOPT) boot options
+# 1111 1011 - Set NMI pin/interrupts to disabled.
+config KINETIS_FLASH_CONFIG_FOPT
+	default 0xFB
+	depends on KINETIS_FLASH_CONFIG
+
 endif # SOC_MKW40Z4 || SOC_MKW41Z4
+
+if SOC_MKW22D5 || SOC_MKW24D5
+
+# The flash option register (FOPT) boot options
+# 1111 1001 - Set NMI pin/interrupts and EzPort reset default to disabled
+config KINETIS_FLASH_CONFIG_FOPT
+	default 0xF9
+	depends on KINETIS_FLASH_CONFIG
+
+endif # SOC_MKW22D5 || SOC_MKW24D5
 
 endif # SOC_SERIES_KINETIS_KWX


### PR DESCRIPTION
- Disables on reset NMI and EzPort.
- Fixes possible reset and power-on issues.
- Already applied for K64, now applying for the rest of Kinetis.