### PR TITLE
tests: drivers: can: api: Extend can api test

### DIFF
--- a/tests/drivers/can/api/src/canfd.c
+++ b/tests/drivers/can/api/src/canfd.c
@@ -239,6 +239,45 @@ ZTEST(canfd, test_canfd_get_capabilities)
 }
 
 /**
+ * @brief Test sending CAN FD frame with too big payload.
+ */
+ZTEST(canfd, test_send_fd_dlc_out_of_range)
+{
+	struct can_frame frame = {
+		.flags = CAN_FRAME_FDF | CAN_FRAME_BRS,
+		.id = TEST_CAN_STD_ID_1,
+		.dlc = CANFD_MAX_DLC + 1U,
+	};
+	int err;
+
+	Z_TEST_SKIP_IFNDEF(CONFIG_RUNTIME_ERROR_CHECKS);
+
+	err = can_send(can_dev, &frame, TEST_SEND_TIMEOUT, NULL, NULL);
+	zassert_equal(err, -EINVAL, "wrong error on sending invalid frame (err %d)", err);
+}
+
+/**
+ * @brief Test error when CAN FD Error State Indicator (ESI) is send without FD format flag (FDF).
+ *
+ * CAN FD Error State Indicator (ESI) indicates that the transmitting node is
+ * in error-passive state. Only valid in combination with CAN_FRAME_FDF.
+ */
+ZTEST(canfd, test_send_fd_incorrect_esi)
+{
+	struct can_frame frame = {
+		.flags = CAN_FRAME_ESI,
+		.id = TEST_CAN_STD_ID_1,
+		.dlc = 0,
+	};
+	int err;
+
+	Z_TEST_SKIP_IFNDEF(CONFIG_RUNTIME_ERROR_CHECKS);
+
+	err = can_send(can_dev, &frame, TEST_SEND_TIMEOUT, NULL, NULL);
+	zassert_equal(err, -ENOTSUP, "wrong error on sending invalid frame (err %d)", err);
+}
+
+/**
  * @brief Test send/receive with standard (11-bit) CAN IDs and classic CAN frames.
  */
 ZTEST(canfd, test_send_receive_classic)

--- a/tests/drivers/can/api/src/canfd.c
+++ b/tests/drivers/can/api/src/canfd.c
@@ -396,6 +396,31 @@ ZTEST_USER(canfd, test_set_timing_data_min)
 }
 
 /**
+ * @brief Test setting a too low data phase bitrate.
+ */
+ZTEST_USER(canfd, test_set_bitrate_data_too_low)
+{
+	uint32_t min = can_get_bitrate_min(can_dev);
+	int err;
+
+	if (min == 0) {
+		ztest_test_skip();
+	}
+
+	err = can_stop(can_dev);
+	zassert_equal(err, 0, "failed to stop CAN controller (err %d)", err);
+
+	err = can_set_bitrate_data(can_dev, min - 1);
+	zassert_equal(err, -ENOTSUP, "too low data phase bitrate accepted");
+
+	err = can_set_bitrate_data(can_dev, CONFIG_CAN_DEFAULT_BITRATE_DATA);
+	zassert_equal(err, 0, "failed to restore default data bitrate");
+
+	err = can_start(can_dev);
+	zassert_equal(err, 0, "failed to start CAN controller (err %d)", err);
+}
+
+/**
  * @brief Test setting a too high data phase bitrate.
  */
 ZTEST_USER(canfd, test_set_bitrate_too_high)

--- a/tests/drivers/can/api/src/classic.c
+++ b/tests/drivers/can/api/src/classic.c
@@ -616,6 +616,19 @@ ZTEST(can_classic, test_add_filter)
 }
 
 /**
+ * @brief Test adding filter without callback.
+ */
+ZTEST(can_classic, test_add_filter_without_callback)
+{
+	int err;
+
+	Z_TEST_SKIP_IFNDEF(CONFIG_RUNTIME_ERROR_CHECKS);
+
+	err = can_add_rx_filter(can_dev, NULL, NULL, &test_std_filter_1);
+	zassert_equal(err, -EINVAL, "added filter with NULL callback");
+}
+
+/**
  * @brief Test adding an invalid CAN RX filter.
  *
  * @param dev   Pointer to the device structure for the driver instance.

--- a/tests/drivers/can/api/src/classic.c
+++ b/tests/drivers/can/api/src/classic.c
@@ -857,6 +857,33 @@ ZTEST(can_classic, test_send_ext_id_out_of_range)
 }
 
 /**
+ * @brief Test sending standard (11-bit ID) CAN frame with too big payload.
+ */
+ZTEST(can_classic, test_send_std_id_dlc_of_range)
+{
+	struct can_frame frame = {
+		.id = TEST_CAN_STD_ID_1,
+		.dlc = CAN_MAX_DLC + 1U,
+	};
+
+	send_invalid_frame(can_dev, &frame);
+}
+
+/**
+ * @brief Test sending extended (29-bit ID) CAN frame with too big payload.
+ */
+ZTEST(can_classic, test_send_ext_id_dlc_of_range)
+{
+	struct can_frame frame = {
+		.flags = CAN_FRAME_IDE,
+		.id = TEST_CAN_EXT_ID_1,
+		.dlc = CAN_MAX_DLC + 1U,
+	};
+
+	send_invalid_frame(can_dev, &frame);
+}
+
+/**
  * @brief Test send/receive with standard (11-bit) CAN IDs.
  */
 ZTEST(can_classic, test_send_receive_std_id)

--- a/tests/drivers/can/api/src/classic.c
+++ b/tests/drivers/can/api/src/classic.c
@@ -487,6 +487,31 @@ ZTEST_USER(can_classic, test_bitrate_limits)
 }
 
 /**
+ * @brief Test setting a too low bitrate.
+ */
+ZTEST_USER(can_classic, test_set_bitrate_too_low)
+{
+	uint32_t min = can_get_bitrate_min(can_dev);
+	int err;
+
+	if (min == 0) {
+		ztest_test_skip();
+	}
+
+	err = can_stop(can_dev);
+	zassert_equal(err, 0, "failed to stop CAN controller (err %d)", err);
+
+	err = can_set_bitrate(can_dev, min - 1);
+	zassert_equal(err, -ENOTSUP, "too low bitrate accepted");
+
+	err = can_set_bitrate(can_dev, CONFIG_CAN_DEFAULT_BITRATE);
+	zassert_equal(err, 0, "failed to restore default bitrate");
+
+	err = can_start(can_dev);
+	zassert_equal(err, 0, "failed to start CAN controller (err %d)", err);
+}
+
+/**
  * @brief Test setting a too high bitrate.
  */
 ZTEST_USER(can_classic, test_set_bitrate_too_high)


### PR DESCRIPTION
(Removed as it doesn't restore CAN configuration fully.)
// tests: drivers: can: api: Set default CAN state before each test
// Tests assume that CAN is started.
// When previous test stops CAN and fails on assertion then remaining tests may fail.
// Start CAN before every tests. Ignore error code returned when starting CAN that is already started.

tests: drivers: can: api: Add negative test for can_send()
Check error codes when sending invalid frames:
- too big data payload;
- wrong set of flags.

(Removed as there are dependencies to CAN core clock frequency and timing setting.)
// tests: drivers: can: api: Check value returned by can_get_bitrate_max()
// Function can_get_bitrate_max() shall return maximum supported bitrate for the CAN controller/transceiver combination.
// Check if that bitrate can be set with can_set_bitrate_data().

(Removed as there are dependencies to CAN core clock frequency and timing setting.)
// tests: drivers: can: api: Check value returned by can_get_bitrate_min()
// Function can_get_bitrate_min() shall return minimum supported bitrate for the CAN controller/transceiver combination.
// Check if that bitrate can be set with can_set_bitrate().

tests: drivers: can: api: Add negative test for can_set_bitrate_data()
There is negative test for too high data bitrate.
Add test that checks too low data bitrate.

tests: drivers: can: api: Add negative test for can_set_bitrate()
There is negative test for too high bitrate.
Add test that checks too low bitrate.

tests: drivers: can: api: Add negative test for can_add_rx_filter()
Check that error is reported when CAN filter is added without callback function.