### PR TITLE
driver: interrupt_controller: intc_xlnx: add Xilinx driver

### DIFF
--- a/drivers/interrupt_controller/CMakeLists.txt
+++ b/drivers/interrupt_controller/CMakeLists.txt
@@ -43,6 +43,7 @@ zephyr_library_sources_ifdef(CONFIG_NXP_PINT                intc_nxp_pint.c)
 zephyr_library_sources_ifdef(CONFIG_RENESAS_RA_ICU          intc_renesas_ra_icu.c)
 zephyr_library_sources_ifdef(CONFIG_NXP_IRQSTEER            intc_nxp_irqsteer.c)
 zephyr_library_sources_ifdef(CONFIG_INTC_MTK_ADSP           intc_mtk_adsp.c)
+zephyr_library_sources_ifdef(CONFIG_XLNX_INTC               intc_xlnx.c)
 
 if(CONFIG_INTEL_VTD_ICTL)
   zephyr_library_include_directories(${ZEPHYR_BASE}/arch/x86/include)

--- a/drivers/interrupt_controller/Kconfig
+++ b/drivers/interrupt_controller/Kconfig
@@ -108,4 +108,6 @@ source "drivers/interrupt_controller/Kconfig.nxp_irqsteer"
 
 source "drivers/interrupt_controller/Kconfig.mtk_adsp"
 
+source "drivers/interrupt_controller/Kconfig.xlnx"
+
 endmenu

--- a/drivers/interrupt_controller/Kconfig.xlnx
+++ b/drivers/interrupt_controller/Kconfig.xlnx
@@ -1,0 +1,44 @@
+# Copyright (c) 2023-2024 Advanced Micro Devices, Inc. (AMD)
+# Copyright (c) 2023 Alp Sayin <alpsayin@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+config XLNX_INTC
+	bool "Xilinx interrupt controller"
+	help
+	  The AXI Interrupt Controller (INTC).
+
+menu "AXI Interrupt Controller Optional Registers"
+	depends on XLNX_INTC
+
+	config XLNX_INTC_USE_IPR
+	bool "Use Interrupt Pending Register"
+	help
+	  Each bit in this register is the logical AND of the bits in the ISR and the IER.
+	  This is an optional read-only register. Don't choose to use it if it doesn't exist.
+
+	config XLNX_INTC_USE_SIE
+	bool "Use Set Interrupt Enables Register"
+	help
+	  Writing a 1 to a bit location in SIE sets the corresponding bit in the IER.
+	  This is an optional write-only register. Don't choose to use it if it doesn't exist.
+
+	config XLNX_INTC_USE_CIE
+	bool "Use Clear Interrupt Enables Register"
+	help
+	  Writing a 1 to a bit location in CIE clears the corresponding bit in the IER.
+	  This is an optional write-only register. Don't choose to use it if it doesn't exist.
+
+	config XLNX_INTC_USE_IVR
+	bool "Use Interrupt Vector Register"
+	help
+	  The IVR contains the ordinal value of the highest priority, enabled, and active interrupt input.
+	  The IVR acts as an index to the correct Interrupt Vector Address.
+	  This is an optional read-only register. Don't choose to use it if it doesn't exist.
+
+	config XLNX_INTC_INITIALIZE_IVAR_REGISTERS
+	bool "Initialize Interrupt Vector Address Registers"
+	help
+	  The IVAR contains the addresses for fast-interrupts. This flag enables initializing all
+	  the address registers to point them to default interrupt handler which is `0x10` for Microblaze.
+
+endmenu

--- a/drivers/interrupt_controller/intc_xlnx.c
+++ b/drivers/interrupt_controller/intc_xlnx.c
@@ -1,0 +1,241 @@
+/*
+ * Copyright (c) 2023 - 2024 Advanced Micro Devices, Inc. (AMD)
+ * Copyright (c) 2023 Alp Sayin <alpsayin@gmail.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * This file implements AXI Interrupt Controller (INTC)
+ * For more details about the INTC see PG 099
+ *
+ * The functionality has been based on intc_v3_12 package
+ *
+ * Right now the implementation:
+ *  - does not support fast interrupt mode
+ *  - does not support Cascade mode
+ *  - does not support XIN_SVC_SGL_ISR_OPTION
+ */
+
+#include <errno.h>
+#include <zephyr/arch/cpu.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/drivers/interrupt_controller/intc_xlnx.h>
+#include <zephyr/init.h>
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/sys/__assert.h>
+#include <zephyr/sys/atomic.h>
+#include <zephyr/sys_clock.h>
+
+LOG_MODULE_REGISTER(xlnx_intc);
+
+#define DT_DRV_COMPAT xlnx_xps_intc_1_00_a
+
+#define BASE_ADDRESS	 DT_INST_REG_ADDR(0)
+#define INTC_REG(offset) (uint32_t *)(BASE_ADDRESS + offset)
+
+#define xlnx_intc_read(offset)	      sys_read32(BASE_ADDRESS + offset)
+#define xlnx_intc_write(data, offset) sys_write32(data, BASE_ADDRESS + offset)
+
+#define XIN_SVC_SGL_ISR_OPTION	1UL
+#define XIN_SVC_ALL_ISRS_OPTION 2UL
+
+#define XIN_ISR_OFFSET 0x0  /* Interrupt Status Register */
+#define XIN_IPR_OFFSET 0x4  /* Interrupt Pending Register */
+#define XIN_IER_OFFSET 0x8  /* Interrupt Enable Register */
+#define XIN_IAR_OFFSET 0xc /* Interrupt Acknowledge Register */
+#define XIN_SIE_OFFSET 0x10 /* Set Interrupt Enable Register */
+#define XIN_CIE_OFFSET 0x14 /* Clear Interrupt Enable Register */
+#define XIN_IVR_OFFSET 0x18 /* Interrupt Vector Register */
+#define XIN_MER_OFFSET 0x1C /* Master Enable Register */
+#define XIN_IMR_OFFSET 0x20 /* Interrupt Mode Register, only for Fast Interrupt */
+#define XIN_IVAR_OFFSET	0x100 /* Interrupt Vector Address Register, only for Fast Interrupt */
+
+/* Bit definitions for the bits of the MER register */
+#define XIN_INT_MASTER_ENABLE_MASK	BIT(0)
+#define XIN_INT_HARDWARE_ENABLE_MASK	BIT(1) /* once set cannot be cleared */
+
+struct xlnx_intc_state {
+	bool is_ready;	 /* Device is initialized and ready */
+	bool is_started; /* Device has been started */
+};
+
+static struct xlnx_intc_state intc_state = {
+	.is_ready = false,
+	.is_started = false,
+};
+
+uint32_t xlnx_intc_irq_get_enabled(void)
+{
+	return xlnx_intc_read(XIN_IER_OFFSET);
+}
+
+uint32_t xlnx_intc_get_status_register(void)
+{
+	return xlnx_intc_read(XIN_ISR_OFFSET);
+}
+
+uint32_t xlnx_intc_irq_pending(void)
+{
+#if defined(CONFIG_XLNX_INTC_USE_IPR)
+	return xlnx_intc_read(XIN_IPR_OFFSET);
+#else
+	uint32_t enabled = xlnx_intc_irq_get_enabled();
+	uint32_t interrupt_status_register = xlnx_intc_get_status_register();
+
+	return enabled & interrupt_status_register;
+#endif
+}
+
+uint32_t xlnx_intc_irq_pending_vector(void)
+{
+#if defined(CONFIG_XLNX_INTC_USE_IVR)
+	return xlnx_intc_read(XIN_IVR_OFFSET);
+#else
+	return find_lsb_set(xlnx_intc_irq_pending()) - 1;
+#endif
+}
+
+void xlnx_intc_irq_enable(uint32_t irq)
+{
+	__ASSERT_NO_MSG(irq < 32);
+
+	if (intc_state.is_ready != true) {
+		LOG_DBG("Interrupt controller is not ready\n");
+		k_panic();
+	}
+
+	uint32_t mask = BIT(irq);
+
+#if defined(CONFIG_XLNX_INTC_USE_SIE)
+	xlnx_intc_write(mask, XIN_SIE_OFFSET);
+#else
+	atomic_or((atomic_t *)INTC_REG(XIN_IER_OFFSET), mask);
+#endif /* CONFIG_XLNX_INTC_USE_SIE */
+}
+
+void xlnx_intc_irq_disable(uint32_t irq)
+{
+	__ASSERT_NO_MSG(irq < 32);
+
+	uint32_t mask = BIT(irq);
+
+#if defined(CONFIG_XLNX_INTC_USE_CIE)
+	xlnx_intc_write(mask, XIN_CIE_OFFSET);
+#else
+	atomic_and((atomic_t *)INTC_REG(XIN_IER_OFFSET), ~mask);
+#endif /* CONFIG_XLNX_INTC_USE_CIE */
+}
+
+void xlnx_intc_irq_acknowledge(uint32_t mask)
+{
+	xlnx_intc_write(mask, XIN_IAR_OFFSET);
+}
+
+int32_t xlnx_intc_controller_init(void)
+{
+	if (intc_state.is_started == true) {
+		return -EEXIST;
+	}
+
+	/*
+	 * Disable IRQ output signal
+	 * Disable all interrupt sources
+	 * Acknowledge all sources
+	 * Disable fast interrupt mode
+	 */
+	xlnx_intc_write(0, XIN_MER_OFFSET);
+	xlnx_intc_write(0, XIN_IER_OFFSET);
+	xlnx_intc_write(0xFFFFFFFF, XIN_IAR_OFFSET);
+
+#if defined(CONFIG_XLNX_INTC_INITIALIZE_IVAR_REGISTERS)
+	xlnx_intc_write(0, XIN_IMR_OFFSET);
+
+	for (int idx = 0; idx < 32; idx++) {
+		xlnx_intc_write(0x10, XIN_IVAR_OFFSET + (idx * 4));
+	}
+#endif
+
+	intc_state.is_ready = true;
+
+	return 0;
+}
+
+int32_t xlnx_intc_irq_start(void)
+{
+	if (intc_state.is_started != false) {
+		return -EEXIST;
+	}
+	if (intc_state.is_ready != true) {
+		return -ENOENT;
+	}
+
+	intc_state.is_started = true;
+
+	xlnx_intc_write(XIN_INT_MASTER_ENABLE_MASK | XIN_INT_HARDWARE_ENABLE_MASK, XIN_MER_OFFSET);
+
+	return 0;
+}
+
+static void xlnx_irq_handler(const void *arg)
+{
+	uint32_t irq, irq_mask;
+	struct _isr_table_entry *ite;
+	uint32_t level = POINTER_TO_UINT(arg);
+
+	/* Get the IRQ number generating the interrupt */
+	irq_mask = xlnx_intc_irq_pending();
+	irq = find_lsb_set(irq_mask);
+
+	/*
+	 * If the IRQ is out of range, call z_irq_spurious.
+	 * A call to z_irq_spurious will not return.
+	 */
+	if (irq == 0U || irq >= 32)
+		z_irq_spurious(NULL);
+
+	/*
+	 * xlnx_intc_irq_pending is returning values >= 1 but because it is second level offset
+	 * needs to be found and _sw_isr_table starting from 0 not 1.
+	 */
+	irq -= 1;
+
+	/* Apply level offset from registration as primary or secondary controller */
+	irq += level;
+
+	/* Call the corresponding IRQ handler in _sw_isr_table */
+	ite = (struct _isr_table_entry *)&_sw_isr_table[irq];
+
+	/* Table is already filled by z_irq_spurious calls that's why likely save to call it */
+	ite->isr(ite->arg);
+
+	/* When IRQ is handled and solved by driver, irq should be ACK to interrupt controller */
+	xlnx_intc_irq_acknowledge(irq_mask);
+}
+
+static int xlnx_intc_init(const struct device *dev)
+{
+	int32_t status = xlnx_intc_controller_init();
+
+	if (status != 0) {
+		return status;
+	}
+
+#if defined(RISCV_IRQ_MEXT)
+	/* Setup IRQ handler for PLIC driver */
+	IRQ_CONNECT(RISCV_IRQ_MEXT, 0, xlnx_irq_handler,
+		    UINT_TO_POINTER(CONFIG_2ND_LVL_ISR_TBL_OFFSET), 0);
+
+	/* Enable external IRQ */
+	irq_enable(RISCV_IRQ_MEXT);
+#endif
+
+	return xlnx_intc_irq_start();
+}
+
+#define XILINX_INTC_INIT(inst) \
+	DEVICE_DT_INST_DEFINE(inst, &xlnx_intc_init, NULL, NULL, NULL, \
+			      PRE_KERNEL_1, CONFIG_INTC_INIT_PRIORITY, NULL);
+
+DT_INST_FOREACH_STATUS_OKAY(XILINX_INTC_INIT)

--- a/dts/bindings/interrupt-controller/xlnx,xps-intc-1.00.a.yaml
+++ b/dts/bindings/interrupt-controller/xlnx,xps-intc-1.00.a.yaml
@@ -1,0 +1,28 @@
+# Copyright (c) 2023-2024 Advanced Micro Devices, Inc. (AMD)
+# Copyright (c) 2023 Alp Sayin <alpsayin@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+description: Xilinx AXI Interrupt Controller
+
+compatible: "xlnx,xps-intc-1.00.a"
+
+include: [interrupt-controller.yaml, base.yaml]
+
+properties:
+  reg:
+    required: true
+
+  "#interrupt-cells":
+    const: 2
+
+  xlnx,kind-of-intr:
+    type: int
+    required: true
+
+  xlnx,num-intr-inputs:
+    type: int
+    required: true
+
+interrupt-cells:
+  - irq
+  - priority

--- a/include/zephyr/drivers/interrupt_controller/intc_xlnx.h
+++ b/include/zephyr/drivers/interrupt_controller/intc_xlnx.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2024 Advanced Micro Devices, Inc. (AMD)
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_INTC_XLNX_H_
+#define ZEPHYR_INCLUDE_DRIVERS_INTC_XLNX_H_
+
+#ifndef _ASMLANGUAGE
+extern void xlnx_intc_irq_enable(uint32_t irq);
+extern void xlnx_intc_irq_disable(uint32_t irq);
+extern void xlnx_intc_irq_acknowledge(uint32_t mask);
+extern uint32_t xlnx_intc_irq_pending(void);
+extern uint32_t xlnx_intc_irq_get_enabled(void);
+extern uint32_t xlnx_intc_irq_pending_vector(void);
+#endif /* _ASMLANGUAGE */
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_INTC_XLNX_H_ */


### PR DESCRIPTION
Add driver for Xilinx interrupt controller. Controller can be used in connection to Microblaze, Microblaze V or Xilinx ARM SOCs. In Microblaze case it is primary interrupt controller. In other cases it is secondary interrupt controller in cascade mode.

Patch is adding support for configuration for Microblaze V that's why xilinx_intc_init() is checking if RISCV_IRQ_MEXT is present and creating connection. And because it is secondary interrupt controller CONFIG_2ND_LVL_ISR_TBL_OFFSET is passed via argument.

