### PR TITLE
drivers: nrfwifi: Allow scan-only for all platforms

### DIFF
--- a/drivers/wifi/nrfwifi/Kconfig.nrfwifi
+++ b/drivers/wifi/nrfwifi/Kconfig.nrfwifi
@@ -62,7 +62,6 @@ config NRF70_SYSTEM_MODE
 
 config NRF70_SCAN_ONLY
 	bool "nRF70 scan only mode"
-	depends on WIFI_NRF7000
 	help
 	  Select this option to enable scan only mode of the nRF70 driver
 


### PR DESCRIPTION
Though nRF7000 is a special Scan only chipset, scan only can work with any nRF70 platforms, no need for this enforcement and we can keep things flexible.