### PR TITLE
MAINTAINERS: Devicetree: Match common bindings

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -881,6 +881,7 @@ Devicetree:
     - galak
   files-regex:
     - dts/bindings/.*zephyr.*
+    - dts/bindings/[^,]+$
   files:
     - scripts/dts/
     - dts/common/


### PR DESCRIPTION
In addition to matching zephyr, prefixed bindings, match common bindings (assuming that common bindings are those that do not have any prefix ie comma)