### PR TITLE
EDF: adding code sample + getter function

### DIFF
--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -944,6 +944,24 @@ __syscall void k_thread_priority_set(k_tid_t thread, int prio);
  *
  */
 __syscall void k_thread_deadline_set(k_tid_t thread, int deadline);
+
+/**
+ * @brief Get the absolute deadline of a thread.
+ *
+ * This routine gets the deadline of a thread to be used by the EDF
+ * scheduler when deciding which thread has the highest priority.
+ * The value returned is the absolute point in time calculated from
+ * the relative deadline value passed in k_thread_deadline_set().
+ *
+ * @note You should enable @kconfig{CONFIG_SCHED_DEADLINE} in your project
+ * configuration.
+ *
+ * @param thread Thread from which to get the deadline
+ * @return absolute deadline value, in cycle units
+ *
+ */
+int32_t k_thread_deadline_get(k_tid_t thread);
+
 #endif
 
 /**

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -1034,6 +1034,14 @@ void z_impl_k_thread_deadline_set(k_tid_t tid, int deadline)
 	}
 }
 
+int32_t k_thread_deadline_get(k_tid_t thread)
+{
+	if (!thread) {
+		return 0;
+	}
+	return (int32_t)thread->base.prio_deadline;
+}
+
 #ifdef CONFIG_USERSPACE
 static inline void z_vrfy_k_thread_deadline_set(k_tid_t tid, int deadline)
 {

--- a/samples/edf/CMakeLists.txt
+++ b/samples/edf/CMakeLists.txt
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(edf_sample)
+
+target_sources(app PRIVATE src/main.c)

--- a/samples/edf/README.rst
+++ b/samples/edf/README.rst
@@ -1,0 +1,70 @@
+.. zephyr:code-sample:: edf
+   :name: Earliest Deadline First (EDF)
+
+   Runs three threads under the EDF scheduler.
+
+Overview
+********
+
+A sample that creates a set of periodic threads and run them
+under the Earliest Deadline First scheduling algorithm. The
+threads do nothing special - they just busy wait for the
+configured WCET (worst-case execution time) and sleep waiting
+for the next period to come.
+
+Each thread has a timer and a message queue associated with it.
+What makes them run periodically is the timer, which regularly
+sends a message to the respective thread message queue. Keep in
+mind that the *message* is not important; instead, the *act* of
+sending the message is. When the thread receives a message, it
+unblocks and executes for a cycle, remaining dormant afterwards
+until a new message comes by.
+
+
+Building and Running
+********************
+
+This application can be built and executed on QEMU as follows:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/edf
+   :host-os: unix
+   :board: qemu_riscv32
+   :goals: run
+   :compact:
+
+To build and run on a physical target (i.e. XIAO ESP32-C3) instead,
+run the following:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/edf
+   :board: xiao_esp32c3
+   :goals: build flash
+   :compact:
+
+Sample Output
+=============
+
+A thread execution cycle is composed of, for a thread of id = 1:
+
+.. code-block:: console
+
+  [1-x-1-1-1-1]
+
+Where **x** is the thread absolute deadline and gets updated at every
+new cycle based on the relative value. The interval between the ids
+is given by the task's wcet/5 (thus, the quicker the task, the smaller
+the period). An expected outcome would be the following:
+
+.. code-block:: console
+
+   [1-3009-1-1-1-1-1]-[2-6010-2-2-2-2-2]-[3-10010-3-3-3-3-[1-9009-1-1-1-1-1]-3]
+
+In this setting, tasks 1, 2 and 3 are activated at the same instant, so
+they execute sequentially in the order of their absolute deadlines.
+However, the second instance of task 1 is activated with an absolute
+deadline of T=9009, which is smaller than the T=10010 of the running
+task 3. Thus, task 1 *preempts* task 3.
+
+The sample allows the user to tweak the values of each thread and watch
+the outcome following the convention above.

--- a/samples/edf/boards/rpi_pico.overlay
+++ b/samples/edf/boards/rpi_pico.overlay
@@ -1,0 +1,15 @@
+/*** insert the following in your app.overlay file if using ******/
+/*** the Raspberry Pi Pico and targeting USB as the log output ***/
+
+&zephyr_udc0 {
+	usb_cdc: usb_cdc_0 {
+		compatible = "zephyr,cdc-acm-uart";
+	};
+};
+
+/ {
+	chosen {
+		zephyr,console = &usb_cdc;
+		zephyr,shell-uart = &usb_cdc;
+	};
+};

--- a/samples/edf/prj.conf
+++ b/samples/edf/prj.conf
@@ -1,0 +1,35 @@
+CONFIG_SYS_CLOCK_TICKS_PER_SEC=10000
+CONFIG_SCHED_SCALABLE=y
+CONFIG_SCHED_DEADLINE=y
+CONFIG_LOG=y                  # makes printk be executed by a background thread
+
+###############################################################################
+### Uncomment the following if target is meant to use USB, but ################
+### remains invisible to the computer after flashing the code. ################
+### Such was the case for Raspberry Pi Pico. ##################################
+###############################################################################
+
+# CONFIG_USB_DEVICE_STACK=y
+# CONFIG_USB_DEVICE_INITIALIZE_AT_BOOT=y
+
+# CONFIG_USB_DEVICE_VID=0x2e8a
+# CONFIG_USB_DEVICE_PID=0x000a
+# CONFIG_USB_DEVICE_PRODUCT="MCU name (Zephyr)"
+# CONFIG_USB_DEVICE_MANUFACTURER="MCU vendor"
+
+# CONFIG_USB_SELF_POWERED=n
+# CONFIG_USB_MAX_POWER=125
+
+# CONFIG_SERIAL=y
+# CONFIG_CONSOLE=y
+# CONFIG_UART_CONSOLE=y
+# CONFIG_UART_LINE_CTRL=y
+
+###############################################################################
+### Uncomment the following if using QEMU targets. ############################
+###############################################################################
+
+CONFIG_QEMU_ICOUNT=n
+CONFIG_STDOUT_CONSOLE=y
+
+###############################################################################

--- a/samples/edf/sample.yaml
+++ b/samples/edf/sample.yaml
@@ -1,0 +1,15 @@
+sample:
+  description: A basic Earliest Deadline First (EDF) example
+  name: Earliest Deadline First (EDF) sample
+common:
+  tags: EDF
+tests:
+  sample.subsys.basic.edf:
+    build_only: true
+    platform_allow:
+      - qemu_x86
+      - qemu_riscv32
+      - qemu_cortex_a53
+    integration_platforms:
+      - qemu_riscv32
+    tags: edf

--- a/samples/edf/src/lib/helper.h
+++ b/samples/edf/src/lib/helper.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2024 Instituto Superior de Engenharia do Porto (ISEP).
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef _APP_HELPER_H_
+#define _APP_HELPER_H_
+
+#include <stdio.h>
+
+/*
+ * Remember that for "pure" EDF results, all
+ * user threads must have the same static priority.
+ * That happens because EDF will be a tie-breaker
+ * among two or more ready tasks of the same static
+ * priority. An arbitrary positive number is chosen here.
+ */
+
+#define EDF_PRIORITY       5
+#define INACTIVE           -1
+#define MSEC_TO_CYC(msec)  k_ms_to_cyc_near32(msec)
+#define MSEC_TO_USEC(msec) (msec * USEC_PER_MSEC)
+#define CYC_TO_MSEC(cyc)   k_cyc_to_ms_floor32(cyc)
+
+typedef struct {
+	int id;
+	int32_t initial_delay_msec;
+	int32_t rel_deadline_msec;
+	int32_t period_msec;
+	uint32_t wcet_msec;
+	k_tid_t thread;
+	struct k_msgq queue;
+	struct k_timer timer;
+} edf_t;
+
+void cycle(int id, uint32_t wcet, int32_t deadline)
+{
+	printf("[%d-%d-", id, CYC_TO_MSEC(deadline));
+	k_busy_wait(wcet / 5);
+	for (int i = 0; i < 4; i++) {
+		printf("%d-", id);
+		k_busy_wait(wcet / 5);
+	}
+	printf("%d]-", id);
+}
+
+#endif

--- a/samples/edf/src/main.c
+++ b/samples/edf/src/main.c
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2024 Instituto Superior de Engenharia do Porto (ISEP).
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <zephyr/kernel.h>
+#include "lib/helper.h"
+
+/*
+ * A simple EDF sample with three threads.
+ * Their properties are defined in the
+ * structs below, so feel free to change
+ * them as you will. Keep in mind that
+ * the sum of all threads' wcet/deadline
+ * should be <= 1 for guarantees that no
+ * deadline will be missed.
+ */
+
+edf_t task1 = {.id = 1,
+	       .initial_delay_msec = 1000,
+	       .rel_deadline_msec = 3000,
+	       .period_msec = 6000,
+	       .wcet_msec = 1000};
+
+edf_t task2 = {.id = 2,
+	       .initial_delay_msec = 1000,
+	       .rel_deadline_msec = 6000,
+	       .period_msec = 8000,
+	       .wcet_msec = 2000};
+
+edf_t task3 = {.id = 3,
+	       .initial_delay_msec = 1000,
+	       .rel_deadline_msec = 10000,
+	       .period_msec = 10000,
+	       .wcet_msec = 3000};
+
+void trigger(struct k_timer *timer)
+{
+	const char t = 1;
+	edf_t *task = (edf_t *)k_timer_user_data_get(timer);
+	int deadline = MSEC_TO_CYC(task->rel_deadline_msec);
+
+	/*
+	 * the message itself is not relevant -
+	 * the *act* of sending the message is.
+	 * That's what unblocks the thread to
+	 * execute a cycle.
+	 */
+	k_msgq_put(&task->queue, &t, K_NO_WAIT);
+
+	/*
+	 * sets the task deadline. Note that
+	 * after setting the deadline, we need
+	 * to trigger a rescheduling so the
+	 * earliest thread gets properly selected.
+	 */
+	k_thread_deadline_set(task->thread, deadline);
+	k_reschedule();
+}
+
+void thread_function(void *task_props, void *a2, void *a3)
+{
+	char buffer[10];
+	char message;
+	int32_t deadline;
+	edf_t *task = (edf_t *)task_props;
+
+	task->thread = k_current_get();
+
+	/* value passed to k_busy_wait needs to be in usec */
+	uint32_t wcet = MSEC_TO_USEC(task->wcet_msec);
+
+	k_msgq_init(&task->queue, buffer, sizeof(char), 10);
+	k_timer_init(&task->timer, trigger, NULL);
+	k_timer_user_data_set(&task->timer, (void *)task);
+	k_timer_start(&task->timer, K_MSEC(task->initial_delay_msec), K_MSEC(task->period_msec));
+
+	/* allow other threads to set up */
+	k_sleep(K_MSEC(1));
+
+	for (;;) {
+		/*
+		 * The periodic thread has no period, ironically.
+		 * What makes it periodic is that it has a timer
+		 * associated with it that regularly sends new
+		 * messages to the thread queue (e.g. every two
+		 * seconds).
+		 *
+		 * This thread itself does nothing special. It
+		 * just remains in the processor for a given
+		 * amount of time ("busy wait") to emulate
+		 * the WCET (worst case execution time). Thus,
+		 * what we want to see with this example is
+		 * just if the edf scheduler works alright
+		 */
+		k_msgq_get(&task->queue, &message, K_FOREVER);
+		deadline = k_thread_deadline_get(task->thread);
+		cycle(task->id, wcet, deadline);
+	}
+}
+
+K_THREAD_DEFINE(task1_thread, 2048, thread_function, &task1, NULL, NULL, EDF_PRIORITY, 0, INACTIVE);
+K_THREAD_DEFINE(task2_thread, 2048, thread_function, &task2, NULL, NULL, EDF_PRIORITY, 0, INACTIVE);
+K_THREAD_DEFINE(task3_thread, 2048, thread_function, &task3, NULL, NULL, EDF_PRIORITY, 0, INACTIVE);
+
+int main(void)
+{
+	printk("\n");
+	k_thread_start(task1_thread);
+	k_thread_start(task2_thread);
+	k_thread_start(task3_thread);
+	return 0;
+}


### PR DESCRIPTION
This PR simply includes a sample for the Earliest Deadline First (EDF) scheduler and adds a getter function to a thread deadline - `k_thread_deadline_get()`. This prevents the application code from needing to access the thread structure directly to retrieve this information.

Signed-off-by: Alexander Paschoaletto <alexp@isep.ipp.pt> 