### PR TITLE
doc: sign: minor rimage update following imgtool removal

### DIFF
--- a/doc/develop/west/sign.rst
+++ b/doc/develop/west/sign.rst
@@ -12,8 +12,8 @@ the image together. Run ``west sign -h`` for command line help.
 rimage
 ******
 
-rimage configuration uses a different approach that does not rely on Kconfig or CMake
-but on :ref:`west config<west-config>` instead, similar to
+rimage configuration uses an approach that does not rely on Kconfig or CMake
+but on :ref:`west config<west-config>`, similar to
 :ref:`west-building-cmake-config`.
 
 Signing involves a number of "wrapper" scripts stacked on top of each other: ``west
@@ -31,8 +31,8 @@ build logs can be unreliable: it may produce different results because of subtle
 environment differences. Last and worst: new signing feature and options are
 impossible to use until more boilerplate code has been added in each layer.
 
-To avoid these issues, ``rimage`` parameters can bet set in ``west config``
-instead. Here's a ``workspace/.west/config`` example:
+To avoid these issues, ``rimage`` parameters can bet set in ``west config``.
+Here's a ``workspace/.west/config`` example:
 
 .. code-block:: ini
 


### PR DESCRIPTION
Fixes commit 1df078158fc7 ("doc: build: Add signing page") that removed the `imgtool` section from the `sign.rst` page.

rimage configuration was designed in a very different way from imgtool configuration. The rimage doc section was following the imgtool doc section and constrating the two approaches. Now that the previous imgtool doc section has just been removed, some words like "different" and "instead" don't make sense anymore. Drop them.

----------

cc:
- #78983