### PR TITLE
Handle `descriptor` field from `FragSessionSetupReq` at application level

### DIFF
--- a/include/zephyr/lorawan/lorawan.h
+++ b/include/zephyr/lorawan/lorawan.h
@@ -218,6 +218,27 @@ typedef uint8_t (*lorawan_battery_level_cb_t)(void);
 typedef void (*lorawan_dr_changed_cb_t)(enum lorawan_datarate dr);
 
 /**
+ * @brief Defines the user's descriptor callback handler function signature.
+ *
+ * The use of this callback is optional. When Fragmented Data Block Transport
+ * is enabled, the application will be notified with the descriptor field present on
+ * the FragSessionSetupReq command.
+ *
+ * @param descriptor Descriptor value given on the FragSessionSetupReq command.
+ *
+ * The meaning of Descriptor is application dependent. When doing a FUOTA
+ * with a binary image, it may represent the version of the firmware
+ * transported.
+ *
+ * @return 0 if successful. This represents, in the case that the descriptor is the firmware
+ * version, that the end-device is able to receive binary firmware. Otherwise, a negative error code
+ * (errno.h) indicating the reason for failure. Any negative error code will result in setting
+ * the Wrong Descriptor status bit mask when sending FragSessionSetupAns to the Network Server.
+ *
+ */
+typedef int (*transport_descriptor_cb)(uint32_t descriptor);
+
+/**
  * @brief Register a battery level callback function.
  *
  * Provide the LoRaWAN stack with a function to be called whenever a battery
@@ -438,6 +459,17 @@ int lorawan_clock_sync_get(uint32_t *gps_time);
 #endif /* CONFIG_LORAWAN_APP_CLOCK_SYNC */
 
 #ifdef CONFIG_LORAWAN_FRAG_TRANSPORT
+
+/**
+ * @brief Register a handle descriptor callback function.
+ *
+ * Provide to the fragmentation transport service a function to be called
+ * whenever a FragSessionSetupReq is received and Descriptor field should be
+ * handled.
+ *
+ * @param transport_descriptor_cb Callback for notification.
+ */
+void lorawan_frag_transport_register_descriptor_callback(transport_descriptor_cb cb);
 
 /**
  * @brief Run Fragmented Data Block Transport service

--- a/samples/subsys/lorawan/fuota/src/main.c
+++ b/samples/subsys/lorawan/fuota/src/main.c
@@ -41,6 +41,18 @@ static void datarate_changed(enum lorawan_datarate dr)
 	LOG_INF("New Datarate: DR %d, Max Payload %d", dr, max_size);
 }
 
+int descriptor_cb(uint32_t descriptor)
+{
+	/*
+	 * In an actual application the firmware may be able to handle
+	 * the descriptor field
+	 */
+
+	LOG_INF("Received descriptor %u", descriptor);
+
+	return 0;
+}
+
 static void fuota_finished(void)
 {
 	LOG_INF("FUOTA finished. Reset device to apply firmware upgrade.");
@@ -113,6 +125,8 @@ int main(void)
 	 * in that case.
 	 */
 	lorawan_frag_transport_run(fuota_finished);
+
+	lorawan_frag_transport_register_descriptor_callback(descriptor_cb);
 
 	/*
 	 * Regular uplinks are required to open downlink slots in class A for


### PR DESCRIPTION
The following pull request proposes a logic to add a callback into the `frag_transport` module so that , at application level, the fuota process can be aborted if `Descriptor` field sent from `FragSessionSetupReq` does not meet the application conditions to keep going. 

Here is an excerpt of what the Fragmented Data Block Transport [TS004-1.0.0](https://resources.lora-alliance.org/technical-specifications/lorawan-fragmented-data-block-transport-specification-v1-0-0) stated about this field:
![image](https://github.com/user-attachments/assets/129924af-5ff2-4434-a23c-953f07b2cf76)


The logic implemented has been similar to the one used in the module `lorawan` when external callbacks are added for example to obtain the battery level of devices. 

Also, an extra piece of code has been added in lorawan fuota sample to illustrate how to use it.