### PR TITLE
boards: shields: Add EVAL-ADXL362-ARDZ accelerometer shield

### DIFF
--- a/boards/shields/eval_adxl362_ardz/Kconfig.shield
+++ b/boards/shields/eval_adxl362_ardz/Kconfig.shield
@@ -1,0 +1,5 @@
+# Copyright (c) 2024 Analog Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+config SHIELD_EVAL_ADXL362_ARDZ
+	def_bool $(shields_list_contains,eval_adxl362_ardz)

--- a/boards/shields/eval_adxl362_ardz/boards/apard32690_max32690_m4.overlay
+++ b/boards/shields/eval_adxl362_ardz/boards/apard32690_max32690_m4.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2024 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		accel0 = &adxl362_eval_adxl362_ardz;
+	};
+};

--- a/boards/shields/eval_adxl362_ardz/doc/index.rst
+++ b/boards/shields/eval_adxl362_ardz/doc/index.rst
@@ -1,0 +1,52 @@
+.. eval_adxl362_ardz:
+
+EVAL-ADXL362-ARDZ
+#################
+
+Overview
+********
+
+The EVAL-ADXL362-ARDZ is a 3-axis digital accelerometer Arduino shield powered
+by the Analog Devices ADXL362.
+
+Programming
+***********
+
+Set ``--shield eval_adxl362_ardz`` when you invoke ``west build``. For example:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/sensor/sensor_shell
+   :board: apard32690/max32690/m4
+   :shield: eval_adxl362_ardz
+   :goals: build
+
+Requirements
+************
+
+This shield can only be used with a board which provides a configuration for
+Arduino connectors and defines node aliases for SPI and GPIO interfaces (see
+:ref:`shields` for more details).
+
+References
+**********
+
+- `EVAL-ADXL362-ARDZ product page`_
+- `EVAL-ADXL362-ARDZ user guide`_
+- `EVAL-ADXL362-ARDZ schematic`_
+- `ADXL362 product page`_
+- `ADXL362 data sheet`_
+
+.. _EVAL-ADXL362-ARDZ product page:
+   https://www.analog.com/en/resources/evaluation-hardware-and-software/evaluation-boards-kits/eval-adxl362-ardz.html
+
+.. _EVAL-ADXL362-ARDZ user guide:
+   https://wiki.analog.com/resources/eval/user-guides/eval-adicup360/hardware/adxl362
+
+.. _EVAL-ADXL362-ARDZ schematic:
+   https://www.analog.com/media/en/reference-design-documentation/design-integration-files/eval-adxl362-ardz-designsupport.zip
+
+.. _ADXL362 product page:
+   https://www.analog.com/en/products/adxl362.html
+
+.. _ADXL362 data sheet:
+   https://www.analog.com/media/en/technical-documentation/data-sheets/adxl362.pdf

--- a/boards/shields/eval_adxl362_ardz/eval_adxl362_ardz.overlay
+++ b/boards/shields/eval_adxl362_ardz/eval_adxl362_ardz.overlay
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2024 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&arduino_spi {
+	status = "okay";
+
+	adxl362_eval_adxl362_ardz: adxl362@0 {
+		compatible = "adi,adxl362";
+		reg = <0x0>;
+		spi-max-frequency = <DT_FREQ_M(1)>;
+		int1-gpios = <&arduino_header 8 GPIO_ACTIVE_HIGH>;
+		status = "okay";
+	};
+};


### PR DESCRIPTION
Adds a new shield definition for the Analog Devices EVAL-ADXL362-ARDZ accelerometer shield. This shield provides support for an ADI ADXL362 3-axis accelerometer over an Arduino SPI connector.

Related to #79712

cc: @vladislav-pejic @dimitrije-lilic