### PR TITLE
doc: gsg: Installing OpenOCD with Chocolatey on Windows environment

### DIFF
--- a/doc/develop/flash_debug/host-tools.rst
+++ b/doc/develop/flash_debug/host-tools.rst
@@ -324,12 +324,10 @@ Check if your SoC is listed in `OpenOCD Supported Devices`_.
 
 .. note:: On Linux, openocd is available though the `Zephyr SDK
    <https://github.com/zephyrproject-rtos/sdk-ng/releases>`_.
-   Windows users should use the following steps to install
-   openocd:
+   To install OpenOCD on Windows, run ``choco install openocd`` as an Administrator.
+   On macOS, run ``brew install openocd``.
 
-   - Download openocd for Windows from here: `OpenOCD Windows`_
-   - Copy bin and share dirs to ``C:\Program Files\OpenOCD\``
-   - Add ``C:\Program Files\OpenOCD\bin`` to 'PATH' environment variable
+   If you did instructions of :ref:`install-required-tools`, OpenOCD is already installed.
 
 .. _pyocd-debug-host-tools:
 

--- a/doc/develop/getting_started/index.rst
+++ b/doc/develop/getting_started/index.rst
@@ -185,7 +185,7 @@ The current minimum required version for the main dependencies are:
          .. code-block:: bat
 
             choco install cmake --installargs 'ADD_CMAKE_TO_PATH=System'
-            choco install ninja gperf python311 git dtc-msys2 wget 7zip
+            choco install ninja gperf python311 git dtc-msys2 wget 7zip openocd
 
          .. warning::
 


### PR DESCRIPTION
Chocolatey distributes OpenOCD, which we can use in Windows environments. Using this, we can include the installation of OpenOCD to the GSG procedure also on Windows.
The GSG procedure has included installing OpenOCD on Linux/macOS so that we can align things on a level with this.

I added "openocd" to the `choco install` command-line and fit related descriptions.