### PR TITLE
Fix incorrect DT macro usage in MSPI API test and controller emulator

### DIFF
--- a/drivers/mspi/mspi_emul.c
+++ b/drivers/mspi/mspi_emul.c
@@ -860,8 +860,8 @@ static struct emul_mspi_driver_api emul_mspi_driver_api = {
 #define MSPI_CONFIG(n)                                                                            \
 	{                                                                                         \
 		.channel_num           = EMUL_MSPI_INST_ID,                                       \
-		.op_mode               = DT_ENUM_IDX_OR(n, op_mode, MSPI_OP_MODE_CONTROLLER),     \
-		.duplex                = DT_ENUM_IDX_OR(n, duplex, MSPI_HALF_DUPLEX),             \
+		.op_mode               = DT_INST_ENUM_IDX_OR(n, op_mode, MSPI_OP_MODE_CONTROLLER),\
+		.duplex                = DT_INST_ENUM_IDX_OR(n, duplex, MSPI_HALF_DUPLEX),        \
 		.max_freq              = DT_INST_PROP(n, clock_frequency),                        \
 		.dqs_support           = DT_INST_PROP_OR(n, dqs_support, false),                  \
 		.sw_multi_periph       = DT_INST_PROP(n, software_multiperipheral),               \

--- a/tests/drivers/mspi/api/src/main.c
+++ b/tests/drivers/mspi/api/src/main.c
@@ -31,8 +31,8 @@ static struct gpio_dt_spec ce_gpios[] = MSPI_CE_GPIOS_DT_SPEC_GET(MSPI_BUS_NODE)
 #if TEST_MSPI_REINIT
 struct mspi_cfg hardware_cfg = {
 	.channel_num              = 0,
-	.op_mode                  = DT_PROP_OR(MSPI_BUS_NODE, op_mode, MSPI_OP_MODE_CONTROLLER),
-	.duplex                   = DT_PROP_OR(MSPI_BUS_NODE, duplex, MSPI_HALF_DUPLEX),
+	.op_mode                  = DT_ENUM_IDX_OR(MSPI_BUS_NODE, op_mode, MSPI_OP_MODE_CONTROLLER),
+	.duplex                   = DT_ENUM_IDX_OR(MSPI_BUS_NODE, duplex, MSPI_HALF_DUPLEX),
 	.dqs_support              = DT_PROP_OR(MSPI_BUS_NODE, dqs_support, false),
 	.ce_group                 = ce_gpios,
 	.num_ce_gpios             = ARRAY_SIZE(ce_gpios),


### PR DESCRIPTION
Fixes https://github.com/zephyrproject-rtos/zephyr/issues/80064.
And the incorrect usage of DT_ENUM_INDEX_OR causes slient fail in the controller emulator, it should be DT_INST_ENUM_INDEX_OR.