### PR TITLE
sys_clock: extra time defines

### DIFF
--- a/include/zephyr/sys_clock.h
+++ b/include/zephyr/sys_clock.h
@@ -94,6 +94,12 @@ typedef struct {
 /** number of seconds per minute */
 #define SEC_PER_MIN 60U
 
+/** number of seconds per hour */
+#define SEC_PER_HOUR 3600U
+
+/** number of seconds per day */
+#define SEC_PER_DAY 86400U
+
 /** number of minutes per hour */
 #define MIN_PER_HOUR 60U
 


### PR DESCRIPTION
Add additional time defines to round out the `SEC_PER_*` family. These are easier to type than `SEC_PER_MIN * MIN_PER_HOUR` and `SEC_PER_MIN * MIN_PER_HOUR * HOUR_PER_DAY`.