### PR TITLE
boards: weact: mini_stm32h743: Fix flash size and partition size

### DIFF
--- a/boards/weact/mini_stm32h743/mini_stm32h743.dts
+++ b/boards/weact/mini_stm32h743/mini_stm32h743.dts
@@ -148,7 +148,7 @@ zephyr_udc0: &usbotg_fs {
 
 	w25q64_qspi: qspi-nor-flash@90000000 {
 		compatible = "st,stm32-qspi-nor";
-		reg = <0x90000000 DT_SIZE_M(64)>; /* 64 Mbits */
+		reg = <0x90000000 DT_SIZE_M(8)>; /* 64 Mbits */
 		qspi-max-frequency = <40000000>;
 		status = "okay";
 		spi-bus-width = <4>;
@@ -159,7 +159,7 @@ zephyr_udc0: &usbotg_fs {
 			#address-cells = <1>;
 			#size-cells = <1>;
 			slot0_partition: partition@0 {
-				reg = <0x00000000 DT_SIZE_M(64)>;
+				reg = <0x00000000 DT_SIZE_M(8)>;
 			};
 		};
 	};
@@ -186,7 +186,7 @@ zephyr_udc0: &usbotg_fs {
 			#size-cells = <1>;
 			storage_partition: partition@0 {
 				label = "storage";
-				reg = <0x00000000 DT_SIZE_M(64)>;
+				reg = <0x00000000 DT_SIZE_M(8)>;
 			};
 		};
 	};


### PR DESCRIPTION
Ensured flash size and partition size are specified in bytes as required by the STM32 QSPI NOR driver.