### PR TITLE
wifi: Hostap WPA control interface configurable timeout

### DIFF
--- a/modules/hostap/Kconfig
+++ b/modules/hostap/Kconfig
@@ -545,4 +545,11 @@ config WIFI_NM_WPA_SUPPLICANT_CRYPTO_TEST
 	bool
 	depends on WIFI_NM_WPA_SUPPLICANT_CRYPTO_MBEDTLS_PSA
 
+config WIFI_NM_WPA_CTRL_RESP_TIMEOUT_S
+	int "WPA supplicant control interface response timeout in seconds"
+	default 15
+	help
+	  Timeout for the control interface commands to get a response from the
+	  supplicant.
+
 endif # WIFI_NM_WPA_SUPPLICANT

--- a/west.yml
+++ b/west.yml
@@ -259,7 +259,7 @@ manifest:
         - hal
     - name: hostap
       path: modules/lib/hostap
-      revision: ac59d28778b20cd68702f55dad2a27d648e3d571
+      revision: 978f1fa082c49381530d983345333d5cab83c00b
     - name: libmetal
       revision: a6851ba6dba8c9e87d00c42f171a822f7a29639b
       path: modules/hal/libmetal


### PR DESCRIPTION
    WPA control interface timeout is hardcoded to 10s, add a configuration
    option to remove the hardcode, this is needed sometimes as a workaround
    e.g., crypto taking too long to complete the request.
    
    Work around for #79834, increase the default from 10 to 15s, in positive
    case this will have no impact.