### PR TITLE
Introducing Zephyr Guru on Gurubase.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,6 +58,7 @@ Getting Started
   | 🚀 `Getting Started Guide`_
   | 🙋🏽 `Tips when asking for help`_
   | 💻 `Code samples`_
+  | 🤖 `Ask Zephyr Guru`_
 
 Code and Development
 --------------------
@@ -107,3 +108,4 @@ Additional Resources
 .. _Security Advisories Repository: https://github.com/zephyrproject-rtos/zephyr/security
 .. _Tips when asking for help: https://docs.zephyrproject.org/latest/develop/getting_started/index.html#asking-for-help
 .. _Zephyr Tech Talks: https://www.zephyrproject.org/tech-talks
+.. _Ask Zephyr Guru: https://gurubase.io/g/zephyr


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Zephyr Guru](https://gurubase.io/g/zephyr) to Gurubase. Zephyr Guru uses the data from this repo and data from the [docs](https://docs.zephyrproject.org/latest/) to answer questions by leveraging the LLM.

In this PR, I showcased the "Zephyr Guru", which highlights that Zephyr now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Zephyr Guru in Gurubase, just let me know that's totally fine.