### PR TITLE
doc: gsg: Add second note about different Linux distributions

### DIFF
--- a/doc/develop/getting_started/index.rst
+++ b/doc/develop/getting_started/index.rst
@@ -23,6 +23,7 @@ Click the operating system you are using.
    .. group-tab:: Ubuntu
 
       This guide covers Ubuntu version 20.04 LTS and later.
+      If you are using a different Linux distribution see :ref:`installation_linux`.
 
       .. code-block:: bash
 


### PR DESCRIPTION
The initial note about the install guide for different distributions can be easily overlooked. Add a second note to make it more prominent in the first step.
Motivated after wanting to contribute package install instructions for Fedora and noticing the separate guide in the docs folder :)