### PR TITLE
bluetooth: shell: Fix includes

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/shell/ll.c
+++ b/subsys/bluetooth/controller/ll_sw/shell/ll.c
@@ -53,7 +53,7 @@ int cmd_ll_addr_read(const struct shell *sh, size_t argc, char *argv[])
 }
 
 #if defined(CONFIG_BT_CTLR_DTM)
-#include "../controller/ll_sw/ll_test.h"
+#include "controller/ll_sw/ll_test.h"
 
 int cmd_test_tx(const struct shell *sh, size_t  argc, char *argv[])
 {

--- a/tests/bluetooth/shell/testcase.yaml
+++ b/tests/bluetooth/shell/testcase.yaml
@@ -73,6 +73,13 @@ tests:
     build_only: true
     extra_args: CONF_FILE="log.conf"
     tags: bluetooth
+  bluetooth.shell.bt_ctrl_dtm:
+    build_only: true
+    extra_args:
+      - CONFIG_BT_CTLR_DTM_HCI=y
+    tags: bluetooth
+    platform_allow:
+      - nrf52840dk/nrf52840
 
   # Bluetooth Audio Compile validation tests
   bluetooth.shell.audio:


### PR DESCRIPTION
This allows to build the shell with BT_CTLR_DTM and/or BT_CTLR_ADV_EXT enabled.

The issues has been introduced by commit
bf897cf941a514e7ea7a5f837d2287e360281f24 (Bluetooth: Shell: Restructure shell files).

Question:
- For those two settings, would it be okay (tolerated? appreciated?) to add an an extra build in CI "just" to test whether enabling those flags does not break the build?