### PR TITLE
drivers: esp32: Fix esp_wifi_drv strncpy warning

### DIFF
--- a/drivers/wifi/esp32/src/esp_wifi_drv.c
+++ b/drivers/wifi/esp32/src/esp_wifi_drv.c
@@ -734,6 +734,7 @@ static int esp32_wifi_status(const struct device *dev, struct wifi_iface_status 
 	}
 
 	strncpy(status->ssid, data->status.ssid, WIFI_SSID_MAX_LEN);
+	status->ssid[WIFI_SSID_MAX_LEN] = '\0';
 	status->ssid_len = strnlen(data->status.ssid, WIFI_SSID_MAX_LEN);
 	status->band = WIFI_FREQ_BAND_2_4_GHZ;
 	status->link_mode = WIFI_LINK_MODE_UNKNOWN;


### PR DESCRIPTION
## issue

https://github.com/zephyrproject-rtos/zephyr/issues/80066

Fixed '-Wstringop-truncation' warning thrown by ssid when using strncpy on esp32.

other code:
https://github.com/zephyrproject-rtos/zephyr/blob/6f64f77557967a41ef7df429f0a831787bb8418f/drivers/wifi/nxp/nxp_wifi_drv.c#L696-L697

This code does not do this:
https://github.com/zephyrproject-rtos/zephyr/blob/6f64f77557967a41ef7df429f0a831787bb8418f/drivers/wifi/esp32/src/esp_wifi_drv.c#L736-L740

Fixes: #80066