### PR TITLE
Profiling sensor triggering vs. RTIO-enabled streaming

### DIFF
--- a/drivers/sensor/adi/adt7310/adt7310_trigger.c
+++ b/drivers/sensor/adi/adt7310/adt7310_trigger.c
@@ -133,6 +133,7 @@ int adt7310_init_interrupt(const struct device *dev)
 			adt7310_thread, drv_data,
 			NULL, NULL, K_PRIO_COOP(CONFIG_ADT7310_THREAD_PRIORITY),
 			0, K_NO_WAIT);
+	k_thread_name_set(&drv_data->thread, dev->name);
 #elif defined(CONFIG_ADT7310_TRIGGER_GLOBAL_THREAD)
 	drv_data->work.handler = adt7310_work_cb;
 #endif

--- a/drivers/sensor/adi/adt7420/adt7420_trigger.c
+++ b/drivers/sensor/adi/adt7420/adt7420_trigger.c
@@ -170,6 +170,8 @@ int adt7420_init_interrupt(const struct device *dev)
 			adt7420_thread, drv_data,
 			NULL, NULL, K_PRIO_COOP(CONFIG_ADT7420_THREAD_PRIORITY),
 			0, K_NO_WAIT);
+
+	k_thread_name_set(&drv_data->thread, dev->name);
 #elif defined(CONFIG_ADT7420_TRIGGER_GLOBAL_THREAD)
 	drv_data->work.handler = adt7420_work_cb;
 #endif

--- a/drivers/sensor/adi/adxl362/adxl362_trigger.c
+++ b/drivers/sensor/adi/adxl362/adxl362_trigger.c
@@ -185,6 +185,8 @@ int adxl362_init_interrupt(const struct device *dev)
 			adxl362_thread, drv_data,
 			NULL, NULL, K_PRIO_COOP(CONFIG_ADXL362_THREAD_PRIORITY),
 			0, K_NO_WAIT);
+
+	k_thread_name_set(&drv_data->thread, dev->name);
 #elif defined(CONFIG_ADXL362_TRIGGER_GLOBAL_THREAD)
 	drv_data->work.handler = adxl362_work_cb;
 #endif

--- a/drivers/sensor/adi/adxl367/adxl367_trigger.c
+++ b/drivers/sensor/adi/adxl367/adxl367_trigger.c
@@ -174,6 +174,8 @@ int adxl367_init_interrupt(const struct device *dev)
 			(k_thread_entry_t)adxl367_thread, drv_data,
 			NULL, NULL, K_PRIO_COOP(CONFIG_ADXL367_THREAD_PRIORITY),
 			0, K_NO_WAIT);
+
+	k_thread_name_set(&drv_data->thread, dev->name);
 #elif defined(CONFIG_ADXL367_TRIGGER_GLOBAL_THREAD)
 	drv_data->work.handler = adxl367_work_cb;
 #endif

--- a/drivers/sensor/adi/adxl372/adxl372_trigger.c
+++ b/drivers/sensor/adi/adxl372/adxl372_trigger.c
@@ -192,6 +192,8 @@ int adxl372_init_interrupt(const struct device *dev)
 			adxl372_thread, drv_data,
 			NULL, NULL, K_PRIO_COOP(CONFIG_ADXL372_THREAD_PRIORITY),
 			0, K_NO_WAIT);
+
+	k_thread_name_set(&drv_data->thread, dev->name);
 #elif defined(CONFIG_ADXL372_TRIGGER_GLOBAL_THREAD)
 	drv_data->work.handler = adxl372_work_cb;
 #endif

--- a/samples/sensor/accel_polling/adxl362-stream.conf
+++ b/samples/sensor/accel_polling/adxl362-stream.conf
@@ -1,0 +1,7 @@
+# Copyright (c) 2024 Analog Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_SPI_RTIO=y
+CONFIG_SENSOR_ASYNC_API=y
+CONFIG_ADXL362_STREAM=y
+CONFIG_ADXL362_ACCEL_ODR_400=y

--- a/samples/sensor/accel_polling/sample.yaml
+++ b/samples/sensor/accel_polling/sample.yaml
@@ -26,3 +26,17 @@ tests:
       - b_l4s5i_iot01a                  # lsm6dsl
       - sensortile_box                  # lis2dw12, lsm6dso, iisdhhc
       - thingy53/nrf5340/cpuapp         # adxl362, bmi270
+  sample.sensor.accel_polling.adxl362-stream:
+    harness: console
+    tags: sensors
+    harness_config:
+      type: one_line
+      regex:
+        - "^\\s*[0-9A-Za-z_,+-.]*@[0-9A-Fa-f]* \\[m\/s\\^2\\]:    \
+           \\(\\s*-?[0-9\\.]*,\\s*-?[0-9\\.]*,\\s*-?[0-9\\.]*\\)$"
+    extra_args:
+      - SHIELD=eval_adxl362_ardz
+      - EXTRA_CONF_FILE=adxl362-stream.conf
+      - SNIPPET=rtt-tracing;rtt-console
+    platform_allow:
+      - apard32690/max32690/m4

--- a/samples/sensor/accel_trig/adxl362-trigger.conf
+++ b/samples/sensor/accel_trig/adxl362-trigger.conf
@@ -1,0 +1,5 @@
+# Copyright (c) 2024 Analog Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_ADXL362_TRIGGER_OWN_THREAD=y
+CONFIG_ADXL362_ACCEL_ODR_400=y

--- a/samples/sensor/accel_trig/sample.yaml
+++ b/samples/sensor/accel_trig/sample.yaml
@@ -12,3 +12,17 @@ tests:
           \\(\\s*-?[0-9\\.]*,\\s*-?[0-9\\.]*,\\s*-?[0-9\\.]*\\)$"
     integration_platforms:
       - frdm_k64f                       # fxos8700
+  sample.sensor.accel_trig.adxl362-trigger:
+    harness: console
+    tags: sensors
+    harness_config:
+      type: one_line
+      regex:
+        - "^\\s*[0-9A-Za-z_,+-.]*@[0-9A-Fa-f]* \\[m\/s\\^2\\]:    \
+          \\(\\s*-?[0-9\\.]*,\\s*-?[0-9\\.]*,\\s*-?[0-9\\.]*\\)$"
+    extra_args:
+      - SHIELD=eval_adxl362_ardz
+      - EXTRA_CONF_FILE=adxl362-trigger.conf
+      - SNIPPET=rtt-tracing;rtt-console
+    platform_allow:
+      - apard32690/max32690/m4


### PR DESCRIPTION
## Triggering
The ADXL362 accelerometer is configured to sample data at 400 Hz with the hardware FIFO and RTIO subsystem disabled. The data ready interrupt fires after every sample, every 2.5 ms.
```
west build -p -b apard32690//m4 samples/sensor/accel_trig/ -T sample.sensor.accel_trig.adxl362-trigger
```
![image](https://github.com/user-attachments/assets/0ea0ee29-2b4a-4b42-9427-7724323dcbf1)

## Streaming
The ADXL362 accelerometer is configured to sample data at 400 Hz with the hardware FIFO and RTIO subsystem enabled. The FIFO watermark interrupt fires after every 32 samples, every 80 ms.
```
 west build -p -b apard32690//m4 samples/sensor/accel_polling/ -T sample.sensor.accel_polling.adxl362-stream
```
![image](https://github.com/user-attachments/assets/80f65af8-07a2-4c62-9c5e-3686b761b442)

## Depends on
- #78346
- #79712 
- #80085 
- #79233 
- #80116

cc: @vladislav-pejic @dimitrije-lilic