### PR TITLE
boards: nxp mpu: update supported features and fix ram size

### DIFF
--- a/boards/nxp/imx8mm_evk/imx8mm_evk_mimx8mm6_a53.yaml
+++ b/boards/nxp/imx8mm_evk/imx8mm_evk_mimx8mm6_a53.yaml
@@ -11,9 +11,11 @@ arch: arm64
 toolchain:
   - zephyr
   - cross-compile
-ram: 128
+ram: 1024
+supported:
+  - uart
+  - net
 testing:
   ignore_tags:
-    - net
     - bluetooth
 vendor: nxp

--- a/boards/nxp/imx8mm_evk/imx8mm_evk_mimx8mm6_a53_smp.yaml
+++ b/boards/nxp/imx8mm_evk/imx8mm_evk_mimx8mm6_a53_smp.yaml
@@ -11,11 +11,12 @@ arch: arm64
 toolchain:
   - zephyr
   - cross-compile
-ram: 128
+ram: 1024
 supported:
   - smp
+  - uart
+  - net
 testing:
   ignore_tags:
-    - net
     - bluetooth
 vendor: nxp

--- a/boards/nxp/imx8mn_evk/imx8mn_evk_mimx8mn6_a53.yaml
+++ b/boards/nxp/imx8mn_evk/imx8mn_evk_mimx8mn6_a53.yaml
@@ -12,8 +12,10 @@ toolchain:
   - zephyr
   - cross-compile
 ram: 1024
+supported:
+  - uart
+  - net
 testing:
   ignore_tags:
-    - net
     - bluetooth
 vendor: nxp

--- a/boards/nxp/imx8mn_evk/imx8mn_evk_mimx8mn6_a53_smp.yaml
+++ b/boards/nxp/imx8mn_evk/imx8mn_evk_mimx8mn6_a53_smp.yaml
@@ -14,8 +14,9 @@ toolchain:
 ram: 1024
 supported:
   - smp
+  - uart
+  - net
 testing:
   ignore_tags:
-    - net
     - bluetooth
 vendor: nxp

--- a/boards/nxp/imx8mp_evk/imx8mp_evk_mimx8ml8_a53.yaml
+++ b/boards/nxp/imx8mp_evk/imx8mp_evk_mimx8ml8_a53.yaml
@@ -11,9 +11,11 @@ arch: arm64
 toolchain:
   - zephyr
   - cross-compile
-ram: 128
+ram: 1024
+supported:
+  - uart
+  - net
 testing:
   ignore_tags:
-    - net
     - bluetooth
 vendor: nxp

--- a/boards/nxp/imx8mp_evk/imx8mp_evk_mimx8ml8_a53_smp.yaml
+++ b/boards/nxp/imx8mp_evk/imx8mp_evk_mimx8ml8_a53_smp.yaml
@@ -11,11 +11,12 @@ arch: arm64
 toolchain:
   - zephyr
   - cross-compile
-ram: 128
+ram: 1024
 supported:
   - smp
+  - uart
+  - net
 testing:
   ignore_tags:
-    - net
     - bluetooth
 vendor: nxp

--- a/boards/nxp/imx93_evk/imx93_evk_mimx9352_a55.yaml
+++ b/boards/nxp/imx93_evk/imx93_evk_mimx9352_a55.yaml
@@ -18,8 +18,8 @@ supported:
   - i2c
   - spi
   - can
+  - net
 testing:
   ignore_tags:
-    - net
     - bluetooth
 vendor: nxp


### PR DESCRIPTION
Updated imx8mm/n/p and imx93 Cortex-A Core supported features in board yaml file, and also fixed ram size for the board.