### PR TITLE
driver: arduino_gpio: mimxrt1010_evk arduino d9 defines

### DIFF
--- a/boards/nxp/mimxrt1010_evk/mimxrt1010_evk.dts
+++ b/boards/nxp/mimxrt1010_evk/mimxrt1010_evk.dts
@@ -70,7 +70,7 @@
 			   <12 0 &gpio1 15 0>,	/* D6 (shared with A4) */
 			   <13 0 &gpio1 16 0>,	/* D7 (shared with A5) */
 			   <14 0 &gpio2 2 0>,	/* D8 */
-			   /* R795 not populated,  D9 */
+			   <15 0 &gpio2 3 0>,	/* D9 R795 not populated */
 			   <16 0 &gpio1 19 0>,	/* D10 (shared with D2) */
 			   <17 0 &gpio1 18 0>,	/* D11 */
 			   <18 0 &gpio1 17 0>,	/* D12 */


### PR DESCRIPTION
add D9 to arduino_gpio map, to avoid build error.

```
2024-10-21 07:19:25,771 - __main__ -zephyr_ci_build_deploy_test.py : 187 - INFO - -- Found BOARD.dts: /home/jenkins/agent/workspace/zephyr_test_pipe/zephyr/boards/nxp/mimxrt1010_evk/mimxrt1010_evk.dts
2024-10-21 07:19:25,771 - __main__ -zephyr_ci_build_deploy_test.py : 187 - INFO - -- Found devicetree overlay: arduino_D9D10.overlay
2024-10-21 07:19:25,771 - __main__ -zephyr_ci_build_deploy_test.py : 187 - INFO - devicetree error: child specifier for <Node /resources in '/home/jenkins/agent/workspace/zephyr_test_pipe/zephyr/misc/empty_file.c'> (b'\x00\x00\x00\x0f\x00\x00\x00\x10') does not appear in <Property 'gpio-map' at '/connector' in '/home/jenkins/agent/workspace/zephyr_test_pipe/zephyr/misc/empty_file.c'>
2024-10-21 07:19:25,771 - __main__ -zephyr_ci_build_deploy_test.py : 187 - INFO - CMake Error at cmake/modules/dts.cmake:301 (execute_process):
```