### PR TITLE
MAINTAINERS: Update patterns for Silabs platforms

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3530,9 +3530,9 @@ Silabs Platforms:
     - boards/silabs/
     - dts/arm/silabs/
     - dts/bindings/*/silabs*
-    - drivers/*/*_gecko*
+    - drivers/*/*gecko*
     - drivers/bluetooth/hci/slz_hci*
-    - drivers/*/*_silabs*
+    - drivers/*/*silabs*
   labels:
     - "platform: Silabs"
 


### PR DESCRIPTION
Silabs maintainer patterns did not match drivers that have the vendor prefix before the driver name, e.g. gecko_burtc_timer.