### PR TITLE
Bluetooth: Audio: Add bt_audio_data_get_val

### DIFF
--- a/include/zephyr/bluetooth/audio/audio.h
+++ b/include/zephyr/bluetooth/audio/audio.h
@@ -764,6 +764,24 @@ int bt_audio_data_parse(const uint8_t ltv[], size_t size,
 			bool (*func)(struct bt_data *data, void *user_data), void *user_data);
 
 /**
+ * @brief Get the value of a specific data type in an length-type-value data array
+ *
+ * @param[in]  ltv_data The array containing the length-type-value tuples
+ * @param[in]  size The size of @p ltv_data
+ * @param[in]  type The type to get the value for. May be any type, but typically either
+ *             @ref bt_audio_codec_cap_type, @ref bt_audio_codec_cfg_type or
+ *             @ref bt_audio_metadata_type.
+ * @param[out] data Pointer to the data-pointer to update when item is found.
+ *                  Any found data will be little endian.
+ *
+ * @retval Length The length of found @p data (may be 0).
+ * @retval -EINVAL if arguments are invalid
+ * @retval -ENODATA if not found
+ */
+int bt_audio_data_get_val(const uint8_t ltv_data[], size_t size, uint8_t type,
+			  const uint8_t **data);
+
+/**
  * @brief Function to get the number of channels from the channel allocation
  *
  * @param chan_allocation The channel allocation

--- a/subsys/bluetooth/audio/audio.c
+++ b/subsys/bluetooth/audio/audio.c
@@ -77,6 +77,68 @@ int bt_audio_data_parse(const uint8_t ltv[], size_t size,
 	return 0;
 }
 
+struct search_type_param {
+	bool found;
+	uint8_t type;
+	uint8_t data_len;
+	const uint8_t **data;
+};
+
+static bool parse_cb(struct bt_data *data, void *user_data)
+{
+	struct search_type_param *param = (struct search_type_param *)user_data;
+
+	if (param->type == data->type) {
+		param->found = true;
+		param->data_len = data->data_len;
+		*param->data = data->data;
+
+		return false;
+	}
+
+	return true;
+}
+
+int bt_audio_data_get_val(const uint8_t ltv_data[], size_t size, uint8_t type, const uint8_t **data)
+{
+	struct search_type_param param = {
+		.found = false,
+		.type = type,
+		.data_len = 0U,
+		.data = data,
+	};
+	int err;
+
+	CHECKIF(ltv_data == NULL) {
+		LOG_DBG("ltv_data is NULL");
+		return -EINVAL;
+	}
+
+	CHECKIF(data == NULL) {
+		LOG_DBG("data is NULL");
+		return -EINVAL;
+	}
+
+	*data = NULL;
+
+	/* If the size is 0 we can terminate early */
+	if (size == 0U) {
+		return -ENODATA;
+	}
+
+	err = bt_audio_data_parse(ltv_data, size, parse_cb, &param);
+	if (err != 0 && err != -ECANCELED) {
+		LOG_DBG("Could not parse the data: %d", err);
+		return err;
+	}
+
+	if (!param.found) {
+		return -ENODATA;
+	}
+
+	return param.data_len;
+}
+
 uint8_t bt_audio_get_chan_count(enum bt_audio_location chan_allocation)
 {
 	if (chan_allocation == BT_AUDIO_LOCATION_MONO_AUDIO) {

--- a/subsys/bluetooth/audio/codec.c
+++ b/subsys/bluetooth/audio/codec.c
@@ -125,28 +125,6 @@ int bt_audio_codec_cfg_frame_dur_us_to_frame_dur(uint32_t frame_dur_us)
 	CONFIG_BT_AUDIO_CODEC_CAP_MAX_DATA_SIZE > 0 ||                                             \
 	CONFIG_BT_AUDIO_CODEC_CAP_MAX_METADATA_SIZE > 0
 
-struct search_type_param {
-	bool found;
-	uint8_t type;
-	uint8_t data_len;
-	const uint8_t **data;
-};
-
-static bool parse_cb(struct bt_data *data, void *user_data)
-{
-	struct search_type_param *param = (struct search_type_param *)user_data;
-
-	if (param->type == data->type) {
-		param->found = true;
-		param->data_len = data->data_len;
-		*param->data = data->data;
-
-		return false;
-	}
-
-	return true;
-}
-
 static int ltv_set_val(struct net_buf_simple *buf, uint8_t type, const uint8_t *data,
 		       size_t data_len)
 {
@@ -290,14 +268,6 @@ static void init_net_buf_simple_from_codec_cfg(struct net_buf_simple *buf,
 int bt_audio_codec_cfg_get_val(const struct bt_audio_codec_cfg *codec_cfg,
 			       enum bt_audio_codec_cfg_type type, const uint8_t **data)
 {
-	struct search_type_param param = {
-		.found = false,
-		.type = (uint8_t)type,
-		.data_len = 0,
-		.data = data,
-	};
-	int err;
-
 	CHECKIF(codec_cfg == NULL) {
 		LOG_DBG("codec is NULL");
 		return -EINVAL;
@@ -308,19 +278,7 @@ int bt_audio_codec_cfg_get_val(const struct bt_audio_codec_cfg *codec_cfg,
 		return -EINVAL;
 	}
 
-	*data = NULL;
-
-	err = bt_audio_data_parse(codec_cfg->data, codec_cfg->data_len, parse_cb, &param);
-	if (err != 0 && err != -ECANCELED) {
-		LOG_DBG("Could not parse the data: %d", err);
-		return err;
-	}
-
-	if (!param.found) {
-		return -ENODATA;
-	}
-
-	return param.data_len;
+	return bt_audio_data_get_val(codec_cfg->data, codec_cfg->data_len, (uint8_t)type, data);
 }
 
 int bt_audio_codec_cfg_set_val(struct bt_audio_codec_cfg *codec_cfg,
@@ -608,14 +566,6 @@ static void init_net_buf_simple_from_meta(struct net_buf_simple *buf, uint8_t me
 static int codec_meta_get_val(const uint8_t meta[], size_t meta_len,
 			      enum bt_audio_metadata_type type, const uint8_t **data)
 {
-	struct search_type_param param = {
-		.found = false,
-		.type = (uint8_t)type,
-		.data_len = 0,
-		.data = data,
-	};
-	int err;
-
 	CHECKIF(meta == NULL) {
 		LOG_DBG("meta is NULL");
 		return -EINVAL;
@@ -626,19 +576,7 @@ static int codec_meta_get_val(const uint8_t meta[], size_t meta_len,
 		return -EINVAL;
 	}
 
-	*data = NULL;
-
-	err = bt_audio_data_parse(meta, meta_len, parse_cb, &param);
-	if (err != 0 && err != -ECANCELED) {
-		LOG_DBG("Could not parse the meta data: %d", err);
-		return err;
-	}
-
-	if (!param.found) {
-		return -ENODATA;
-	}
-
-	return param.data_len;
+	return bt_audio_data_get_val(meta, meta_len, (uint8_t)type, data);
 }
 
 static int codec_meta_set_val(uint8_t meta[], size_t meta_len, size_t meta_size,
@@ -1919,14 +1857,6 @@ static void init_net_buf_simple_from_codec_cap(struct net_buf_simple *buf,
 int bt_audio_codec_cap_get_val(const struct bt_audio_codec_cap *codec_cap,
 			       enum bt_audio_codec_cap_type type, const uint8_t **data)
 {
-	struct search_type_param param = {
-		.found = false,
-		.type = (uint8_t)type,
-		.data_len = 0,
-		.data = data,
-	};
-	int err;
-
 	CHECKIF(codec_cap == NULL) {
 		LOG_DBG("codec_cap is NULL");
 		return -EINVAL;
@@ -1937,19 +1867,7 @@ int bt_audio_codec_cap_get_val(const struct bt_audio_codec_cap *codec_cap,
 		return -EINVAL;
 	}
 
-	*data = NULL;
-
-	err = bt_audio_data_parse(codec_cap->data, codec_cap->data_len, parse_cb, &param);
-	if (err != 0 && err != -ECANCELED) {
-		LOG_DBG("Could not parse the data: %d", err);
-		return err;
-	}
-
-	if (!param.found) {
-		return -ENODATA;
-	}
-
-	return param.data_len;
+	return bt_audio_data_get_val(codec_cap->data, codec_cap->data_len, (uint8_t)type, data);
 }
 
 int bt_audio_codec_cap_set_val(struct bt_audio_codec_cap *codec_cap,


### PR DESCRIPTION
Add a generic function to retrieve any data based on an assigned numbers type. This function can in theory be used for any data type, and not just LE Audio types, but since it relies on bt_audio_data_parse it was made specificially for LE Audio.

The function can be used in cases where
bt_audio_codec_cfg_get_val, bt_audio_codec_cfg_meta_get_val, bt_audio_codec_cap_get_val or
bt_audio_codec_cap_meta_get_val (or their derivation) are not easily applicable due to the type constrainst.