### PR TITLE
net: openthread: support WC and WED

### DIFF
--- a/drivers/ieee802154/Kconfig.nrf5
+++ b/drivers/ieee802154/Kconfig.nrf5
@@ -94,4 +94,12 @@ config IEEE802154_NRF5_MULTIPLE_CCA
 	  When this option is enabled the OpenThread capability
 	  IEEE802154_OPENTHREAD_HW_MULTIPLE_CCA is supported by the ieee802154_nrf5.
 
+config IEEE802154_NRF5_CST_ENDPOINT
+	bool "Support for OpenThread CST Endpoint extension in the ieee802154_nrf5."
+	help
+	  Enable support for OpenThread CST (Coordinated Sampled Transmitter) Endpoint
+	  with CST IE injection as an extension to ieee802154_nrf5 driver.
+	  When this option is enabled, the ieee802154_nrf5 driver supports the
+	  IEEE802154_OPENTHREAD_HW_CST capability.
+
 endif

--- a/drivers/ieee802154/Kconfig.nrf5
+++ b/drivers/ieee802154/Kconfig.nrf5
@@ -96,6 +96,7 @@ config IEEE802154_NRF5_MULTIPLE_CCA
 
 config IEEE802154_NRF5_CST_ENDPOINT
 	bool "Support for OpenThread CST Endpoint extension in the ieee802154_nrf5."
+	default y if OPENTHREAD_WAKEUP_COORDINATOR
 	help
 	  Enable support for OpenThread CST (Coordinated Sampled Transmitter) Endpoint
 	  with CST IE injection as an extension to ieee802154_nrf5 driver.

--- a/drivers/ieee802154/ieee802154_nrf5.c
+++ b/drivers/ieee802154/ieee802154_nrf5.c
@@ -259,6 +259,9 @@ static void nrf5_get_capabilities_at_boot(void)
 #if defined(CONFIG_IEEE802154_SELECTIVE_TXCHANNEL)
 		| IEEE802154_HW_SELECTIVE_TXCHANNEL
 #endif
+#if defined(CONFIG_IEEE802154_NRF5_CST_ENDPOINT)
+		| IEEE802154_OPENTHREAD_HW_CST
+#endif
 		;
 }
 
@@ -1027,6 +1030,17 @@ static int nrf5_configure(const struct device *dev,
 			(void)nrf_802154_sleep_if_idle();
 		}
 		break;
+
+#if defined(CONFIG_IEEE802154_NRF5_CST_ENDPOINT)
+	case IEEE802154_OPENTHREAD_CONFIG_CST_PERIOD:
+		nrf_802154_cst_writer_period_set(config->cst_period);
+		break;
+
+	case IEEE802154_OPENTHREAD_CONFIG_EXPECTED_TX_TIME:
+		nrf_802154_cst_writer_anchor_time_set(nrf_802154_timestamp_phr_to_mhr_convert(
+			config->expected_tx_time / NSEC_PER_USEC));
+		break;
+#endif /* CONFIG_IEEE802154_NRF5_CST_ENDPOINT */
 
 	default:
 		return -EINVAL;

--- a/include/zephyr/net/ieee802154_radio_openthread.h
+++ b/include/zephyr/net/ieee802154_radio_openthread.h
@@ -14,6 +14,9 @@
 
 #include <zephyr/net/ieee802154_radio.h>
 
+/** Bit number starting the OpenThread specific capabilities of ieee802154 driver. */
+#define IEEE802154_OPENTHREAD_HW_CAPS_BITS_START IEEE802154_HW_CAPS_BITS_PRIV_START
+
 /**
  *  OpenThread specific capabilities of ieee802154 driver.
  *  This type extends @ref ieee802154_hw_caps.
@@ -22,7 +25,26 @@ enum ieee802154_openthread_hw_caps {
 	/** Capability to transmit with @ref IEEE802154_OPENTHREAD_TX_MODE_TXTIME_MULTIPLE_CCA
 	 *  mode.
 	 */
-	IEEE802154_OPENTHREAD_HW_MULTIPLE_CCA = BIT(IEEE802154_HW_CAPS_BITS_PRIV_START),
+	IEEE802154_OPENTHREAD_HW_MULTIPLE_CCA = BIT(IEEE802154_OPENTHREAD_HW_CAPS_BITS_START),
+
+	/** Capability to support CST-related features.
+	 *
+	 * The CST-related features are described by "Specification changes for Thread-in-Mobile"
+	 * Draft version 1, July 11, 2024. The CST allows to transmit a frame with CST Phase and
+	 * CST Period IEs as described by chapter 4.6.6.1 of the Thread-in-Mobile specification
+	 * change. The upper layer implementation (OpenThread) is responsible for preparing
+	 * a frame to be transmitted that contains placeholders where the CST Phase and CST Period
+	 * are to be placed. The implementation of a driver is responsible for injecting
+	 * correct value for CST Phase IE and CST Period IE based on configuration parameters
+	 * @ref IEEE802154_OPENTHREAD_CONFIG_CST_PERIOD and
+	 * @ref IEEE802154_OPENTHREAD_CONFIG_EXPECTED_TX_TIME.
+	 *
+	 * @note The CST transmission in its design is very similar to CSL reception.
+	 * In the CSL reception the receiver side informs its peer about the moment in time
+	 * when it will be able to receive. In the CST transmission the transmitter side informs
+	 * its peer about the moment in time when the next transmission will occur.
+	 */
+	IEEE802154_OPENTHREAD_HW_CST = BIT(IEEE802154_OPENTHREAD_HW_CAPS_BITS_START + 1),
 };
 
 /** @brief TX mode */
@@ -80,7 +102,33 @@ enum ieee802154_openthread_config_type {
 	 *  @ref IEEE802154_OPENTHREAD_TX_MODE_TXTIME_MULTIPLE_CCA.
 	 *  Requires IEEE802154_OPENTHREAD_HW_MULTIPLE_CCA capability.
 	 */
-	IEEE802154_OPENTHREAD_CONFIG_MAX_EXTRA_CCA_ATTEMPTS  = IEEE802154_CONFIG_PRIV_START
+	IEEE802154_OPENTHREAD_CONFIG_MAX_EXTRA_CCA_ATTEMPTS  = IEEE802154_CONFIG_PRIV_START,
+
+	/** Configures the CST period of a device.
+	 *
+	 *  When a frame containing CST Period IE is about to be transmitted by a driver,
+	 *  the driver SHALL inject the CST Period value to the CST Period IE based on
+	 *  the value of this configuration parameter.
+	 *
+	 *  Requires IEEE802154_OPENTHREAD_HW_CST capability.
+	 */
+	IEEE802154_OPENTHREAD_CONFIG_CST_PERIOD,
+
+	/** Configure a point in time at which a TX frame is expected to be transmitted.
+	 *
+	 *  When a frame containing CST Phase IE is about to be transmitted by a driver,
+	 *  the driver SHALL inject the CST Phase IE value to the CST Phase IE based on
+	 *  the value of this configuration parameter parameter, the time of transmission
+	 *  and the CST Period value.
+	 *
+	 *  This parameter configures the nanosecond resolution timepoint relative to
+	 *  the network subsystem's local clock at which a TX frame's end of SFD
+	 *  (i.e. equivalently its end of SHR, start of PHR) is expected to be transmitted
+	 *  at the local antenna.
+	 *
+	 *  Requires IEEE802154_OPENTHREAD_HW_CST capability.
+	 */
+	IEEE802154_OPENTHREAD_CONFIG_EXPECTED_TX_TIME,
 };
 
 /**
@@ -106,6 +154,18 @@ struct ieee802154_openthread_config {
 		 *  requested with mode @ref IEEE802154_OPENTHREAD_TX_MODE_TXTIME_MULTIPLE_CCA.
 		 */
 		uint8_t max_extra_cca_attempts;
+
+		/** ``IEEE802154_OPENTHREAD_CONFIG_CST_PERIOD``
+		 *
+		 *  The CST period (in CPU byte order).
+		 */
+		uint32_t cst_period;
+
+		/** ``IEEE802154_OPENTHREAD_CONFIG_EXPECTED_TX_TIME``
+		 *
+		 *  A point in time at which a TX frame is expected to be transmitted.
+		 */
+		net_time_t expected_tx_time;
 	};
 };
 

--- a/modules/openthread/CMakeLists.txt
+++ b/modules/openthread/CMakeLists.txt
@@ -128,6 +128,7 @@ kconfig_to_ot_option(CONFIG_OPENTHREAD_TX_QUEUE_STATISTICS OT_TX_QUEUE_STATS "En
 kconfig_to_ot_option(CONFIG_OPENTHREAD_UDP_FORWARD OT_UDP_FORWARD "Enable UDP forward feature")
 kconfig_to_ot_option(CONFIG_OPENTHREAD_UPTIME OT_UPTIME "Enable support for tracking OpenThread instance's uptime")
 kconfig_to_ot_option(CONFIG_OPENTHREAD_VERHOEFF_CHECKSUM OT_VERHOEFF_CHECKSUM "Verhoeff checksum")
+kconfig_to_ot_option(CONFIG_OPENTHREAD_WAKEUP_COORDINATOR OT_WAKEUP_COORDINATOR "Enable Wake-up Coordinator role")
 
 if(CONFIG_OPENTHREAD_COPROCESSOR_VENDOR_HOOK_SOURCE)
   set(OT_NCP_VENDOR_HOOK_SOURCE ${CONFIG_OPENTHREAD_COPROCESSOR_VENDOR_HOOK_SOURCE} CACHE STRING "NCP vendor hook source file name" FORCE)

--- a/modules/openthread/CMakeLists.txt
+++ b/modules/openthread/CMakeLists.txt
@@ -129,6 +129,7 @@ kconfig_to_ot_option(CONFIG_OPENTHREAD_UDP_FORWARD OT_UDP_FORWARD "Enable UDP fo
 kconfig_to_ot_option(CONFIG_OPENTHREAD_UPTIME OT_UPTIME "Enable support for tracking OpenThread instance's uptime")
 kconfig_to_ot_option(CONFIG_OPENTHREAD_VERHOEFF_CHECKSUM OT_VERHOEFF_CHECKSUM "Verhoeff checksum")
 kconfig_to_ot_option(CONFIG_OPENTHREAD_WAKEUP_COORDINATOR OT_WAKEUP_COORDINATOR "Enable Wake-up Coordinator role")
+kconfig_to_ot_option(CONFIG_OPENTHREAD_WAKEUP_END_DEVICE OT_WAKEUP_END_DEVICE "Enable Wake-up End Device role")
 
 if(CONFIG_OPENTHREAD_COPROCESSOR_VENDOR_HOOK_SOURCE)
   set(OT_NCP_VENDOR_HOOK_SOURCE ${CONFIG_OPENTHREAD_COPROCESSOR_VENDOR_HOOK_SOURCE} CACHE STRING "NCP vendor hook source file name" FORCE)

--- a/modules/openthread/Kconfig.features
+++ b/modules/openthread/Kconfig.features
@@ -128,6 +128,10 @@ config OPENTHREAD_DEVICE_PROP_LEADER_WEIGHT
 config OPENTHREAD_DATASET_UPDATER
 	bool "Dataset updater"
 
+config OPENTHREAD_WAKEUP_COORDINATOR
+	bool "Wake-up Coordinator support"
+	select OPENTHREAD_CSL_RECEIVER
+
 config OPENTHREAD_DHCP6_CLIENT
 	bool "DHCPv6 client support"
 

--- a/modules/openthread/Kconfig.features
+++ b/modules/openthread/Kconfig.features
@@ -132,6 +132,10 @@ config OPENTHREAD_WAKEUP_COORDINATOR
 	bool "Wake-up Coordinator support"
 	select OPENTHREAD_CSL_RECEIVER
 
+config OPENTHREAD_WAKEUP_END_DEVICE
+	bool "Wake-up End Device support"
+	imply OPENTHREAD_CSL_RECEIVER
+
 config OPENTHREAD_DHCP6_CLIENT
 	bool "DHCPv6 client support"
 

--- a/modules/openthread/platform/openthread-core-zephyr-config.h
+++ b/modules/openthread/platform/openthread-core-zephyr-config.h
@@ -211,8 +211,9 @@
  *
  */
 #define OPENTHREAD_CONFIG_PLATFORM_USEC_TIMER_ENABLE                                               \
-	(CONFIG_OPENTHREAD_CSL_RECEIVER &&                                                         \
-	 (OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2))
+	((CONFIG_OPENTHREAD_CSL_RECEIVER &&                                                        \
+	  (OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2)) ||                          \
+	 CONFIG_OPENTHREAD_WAKEUP_END_DEVICE)
 
 /* Zephyr does not use OpenThread's heap. mbedTLS will use heap memory allocated
  * by Zephyr. Here, we use some dummy values to prevent OpenThread warnings.

--- a/modules/openthread/platform/radio.c
+++ b/modules/openthread/platform/radio.c
@@ -802,7 +802,7 @@ otError otPlatRadioReceive(otInstance *aInstance, uint8_t aChannel)
 	return OT_ERROR_NONE;
 }
 
-#if defined(CONFIG_OPENTHREAD_CSL_RECEIVER)
+#if defined(CONFIG_OPENTHREAD_CSL_RECEIVER) || defined(CONFIG_OPENTHREAD_WAKEUP_END_DEVICE)
 otError otPlatRadioReceiveAt(otInstance *aInstance, uint8_t aChannel,
 			     uint32_t aStart, uint32_t aDuration)
 {


### PR DESCRIPTION
This PR adds support code for new roles Wake-Up Coordinator and Wake-Up End Device developed in OpenThread.
Related Thread Specification changes named collectively as Thread-In-Mobile (SPEC-1267).

The features require additional Information Elements (OpenThread-specific) to be sent, what's covered by the SPEC-1267.
The driver supporting the new feature CST (Coordinated Sampled Transmitting) has the capability `IEE802154_OPENTHREAD_HW_CST` which is OpenThread's extension to a ieee802154 driver. This capability allows to configure CST period and CST expected transmission time point.
No driver has the duty to support the capability.

The support for  IEE802154_OPENTHREAD_HW_CST capability is added to the ieee802154_nrf5 driver.

The new Kconfig options `OPENTHREAD_WAKEUP_COORDINATOR` and `OPENTHREAD_WAKEUP_END_DEVICE` are added to configure the OpenThread. When `OPENTHREAD_WAKEUP_COORDINATOR` is enabled it enables the `IEE802154_OPENTHREAD_HW_CST` within the ieee802154_nrf5 driver by default.

Refs:
`7ec824602518060a19b7ba851435f043b5ca8a8d`
`f59ec0e8af9f1c373752bdf1324befb27de1f493`
`a3dcf1c536387a0f9ba662436ce37617cf9cedf7`
