### PR TITLE
arm64: linker: fix: broken tests for fvp_aemv8r_aarch64

### DIFF
--- a/include/zephyr/arch/arm/cortex_a_r/scripts/linker.ld
+++ b/include/zephyr/arch/arm/cortex_a_r/scripts/linker.ld
@@ -293,6 +293,7 @@ SECTIONS
     _app_smem_rom_start = LOADADDR(_APP_SMEM_SECTION_NAME);
 #endif  /* CONFIG_USERSPACE */
 
+    __kernel_ram_start = .;
     SECTION_DATA_PROLOGUE(_BSS_SECTION_NAME,(NOLOAD), BSS_ALIGN)
     {
         /*
@@ -301,7 +302,6 @@ SECTIONS
          */
         . = ALIGN(4);
         __bss_start = .;
-        __kernel_ram_start = .;
 
         *(.bss)
         *(".bss.*")

--- a/include/zephyr/arch/arm/cortex_m/scripts/linker.ld
+++ b/include/zephyr/arch/arm/cortex_m/scripts/linker.ld
@@ -289,6 +289,7 @@ SECTIONS
 	_app_smem_size = _app_smem_end - _app_smem_start;
 	_app_smem_rom_start = LOADADDR(_APP_SMEM_SECTION_NAME);
 
+	__kernel_ram_start = .;
     SECTION_DATA_PROLOGUE(_BSS_SECTION_NAME,(NOLOAD),)
 	{
         /*
@@ -297,7 +298,6 @@ SECTIONS
          */
         . = ALIGN(4);
 	__bss_start = .;
-	__kernel_ram_start = .;
 
 	*(.bss)
 	*(".bss.*")
@@ -358,6 +358,7 @@ SECTIONS
     __data_region_end = .;
 
 #ifndef CONFIG_USERSPACE
+   __kernel_ram_start = .;
    SECTION_DATA_PROLOGUE(_BSS_SECTION_NAME,(NOLOAD),)
 	{
         /*
@@ -366,7 +367,6 @@ SECTIONS
          */
         . = ALIGN(4);
 	__bss_start = .;
-	__kernel_ram_start = .;
 
 	*(.bss)
 	*(".bss.*")

--- a/include/zephyr/arch/arm64/scripts/linker.ld
+++ b/include/zephyr/arch/arm64/scripts/linker.ld
@@ -241,6 +241,7 @@ SECTIONS
     _app_smem_rom_start = LOADADDR(_APP_SMEM_SECTION_NAME);
 #endif  /* CONFIG_USERSPACE */
 
+    __kernel_ram_start = .;
     __data_region_start = .;
 
     SECTION_DATA_PROLOGUE(_DATA_SECTION_NAME,,)
@@ -273,7 +274,6 @@ SECTIONS
     {
         . = ALIGN(8);
         __bss_start = .;
-        __kernel_ram_start = .;
 
         *(.bss)
         *(".bss.*")


### PR DESCRIPTION
What is changed?
Twister tests and sample applications can now run successfully again for `fvp_aemv8r_aarch64`.
`__kernal_ram_start` is also modified for cortex_m and cortex_a_r to be consistent with aarch64 linker script and avoid such issue in the future.

How is it changed?
Modified linker script to make sure that `__kernal_ram_start` to `__kernal_ram_end` includes both, bss and data, sections as before.

Why do we need this change?
Twister tests and sample applications failed for `fvp_aemv8r_aarch64` and it was found that commit #87f68b4dfed14eb08132fe9798fb209f1bed64f2 moved the bss section but missed moving the __kernal_ram_start to the data section which resulted in a crash.

The change is tested with FVP_BaseR_AEMv8R version: 11.27.19.