### PR TITLE
drivers: sensor: Add RRH46410 driver

### DIFF
--- a/drivers/sensor/renesas/CMakeLists.txt
+++ b/drivers/sensor/renesas/CMakeLists.txt
@@ -5,4 +5,5 @@
 add_subdirectory_ifdef(CONFIG_HS300X hs300x)
 add_subdirectory_ifdef(CONFIG_HS400X hs400x)
 add_subdirectory_ifdef(CONFIG_ISL29035 isl29035)
+add_subdirectory_ifdef(CONFIG_RRH46410 rrh46410)
 # zephyr-keep-sorted-stop

--- a/drivers/sensor/renesas/Kconfig
+++ b/drivers/sensor/renesas/Kconfig
@@ -5,4 +5,5 @@
 source "drivers/sensor/renesas/hs300x/Kconfig"
 source "drivers/sensor/renesas/hs400x/Kconfig"
 source "drivers/sensor/renesas/isl29035/Kconfig"
+source "drivers/sensor/renesas/rrh46410/Kconfig"
 # zephyr-keep-sorted-stop

--- a/drivers/sensor/renesas/rrh46410/CMakeLists.txt
+++ b/drivers/sensor/renesas/rrh46410/CMakeLists.txt
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
+zephyr_library()
+
+zephyr_library_sources(rrh46410.c rrh46410_i2c.c rrh46410_uart.c)

--- a/drivers/sensor/renesas/rrh46410/Kconfig
+++ b/drivers/sensor/renesas/rrh46410/Kconfig
@@ -1,0 +1,15 @@
+# RRH46410 air quality sensor
+
+# Copyright (c) 2024 Renesas Electronics Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+config RRH46410
+	bool "RRH46410 sensor"
+	default y
+	depends on DT_HAS_RENESAS_RRH46410_ENABLED
+	select I2C if $(dt_compat_on_bus,$(DT_COMPAT_RENESAS_RRH46410),i2c)
+	select UART if $(dt_compat_on_bus,$(DT_COMPAT_RENESAS_RRH46410),uart)
+	depends on GPIO
+
+	help
+	  Enable driver for RRH46410 TVOC sensor.

--- a/drivers/sensor/renesas/rrh46410/rrh46410.c
+++ b/drivers/sensor/renesas/rrh46410/rrh46410.c
@@ -1,0 +1,301 @@
+/*
+ * Copyright (c) 2024 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT renesas_rrh46410
+
+#include <zephyr/kernel.h>
+#include <zephyr/drivers/sensor.h>
+#include <zephyr/sys/__assert.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/drivers/sensor/rrh46410.h>
+#include "rrh46410.h"
+
+LOG_MODULE_REGISTER(RRH46410, CONFIG_SENSOR_LOG_LEVEL);
+
+static uint8_t rrh46410_get_operation_mode(const struct device *dev)
+{
+	struct rrh46410_data *data = dev->data;
+	int rc;
+	uint8_t checksum = ~RRH46410_GET_OPERATION_MODE;
+	uint8_t operation_mode;
+	uint8_t get_operation[2];
+
+	get_operation[0] = RRH46410_GET_OPERATION_MODE;
+	get_operation[1] = checksum;
+	rc = data->hw_tf->write_data(dev, get_operation, sizeof(get_operation));
+
+	if (rc < 0) {
+		LOG_ERR("Failed to send get.");
+		return (uint8_t) rc;
+	}
+
+	rc = data->hw_tf->read_data(dev, data->read_buffer, 2);
+	if (rc < 0) {
+		LOG_ERR("Failed to read data from device.");
+		return (uint8_t) rc;
+	}
+
+	operation_mode = data->read_buffer[1];
+
+	return operation_mode;
+}
+
+static int rrh46410_set_operation_mode(const struct device *dev)
+{
+	struct rrh46410_data *data = dev->data;
+	int rc;
+	uint8_t checksum = ~(RRH46410_SET_OPERATION_MODE + RRH46410_OPERATION_MODE_IAQ_2ND_GEN);
+	uint8_t set_operation[3];
+
+	set_operation[0] = RRH46410_SET_OPERATION_MODE;
+	set_operation[1] = RRH46410_OPERATION_MODE_IAQ_2ND_GEN;
+	set_operation[2] = checksum;
+
+	rc = data->hw_tf->write_data(dev, set_operation, sizeof(set_operation));
+
+	if (rc < 0) {
+		LOG_ERR("Failed to send set.");
+		return rc;
+	}
+
+	return 0;
+}
+
+static int rrh46410_attr_set(const struct device *dev, enum sensor_channel chan,
+			     enum sensor_attribute attr, const struct sensor_value *val)
+{
+	struct rrh46410_data *data = dev->data;
+	double val_rrh46410 = sensor_value_to_double(val);
+	uint8_t encoded_humidity = (uint8_t)((val_rrh46410 / 100) * 255);
+	uint8_t command_data = encoded_humidity;
+	uint8_t checksum = ~(RRH46410_SET_HUMIDITY + command_data);
+	uint8_t set_humidity[3];
+	int rc;
+
+	set_humidity[0] = RRH46410_SET_HUMIDITY;
+	set_humidity[1] = command_data;
+	set_humidity[2] = checksum;
+
+	if (chan != SENSOR_CHAN_ALL) {
+		return -ENOTSUP;
+	}
+
+	switch (attr) {
+	case SENSOR_ATTR_RRH46410_HUMIDITY:
+		rc = data->hw_tf->write_data(dev, set_humidity, sizeof(set_humidity));
+		if (rc < 0) {
+			LOG_ERR("Failed to send humidity.");
+			return rc;
+		}
+
+		k_msleep(10);
+
+		rc = data->hw_tf->read_data(dev, data->read_buffer, 1);
+		if (rc < 0) {
+			LOG_ERR("Failed to read data from device.");
+			return rc;
+		}
+
+		break;
+
+	default:
+		return -ENOTSUP;
+	}
+
+	return 0;
+}
+
+static int rrh46410_read_sample(const struct device *dev, uint8_t *sample_counter,
+				uint8_t *iaq_sample, uint16_t *tvoc_sample, uint16_t *etoh_sample,
+				uint16_t *eco2_sample, uint8_t *reliaq_sample)
+{
+	struct rrh46410_data *data = dev->data;
+	uint8_t status;
+	int rc;
+
+	rc = data->hw_tf->read_data(dev, data->read_buffer, sizeof(data->read_buffer));
+	if (rc < 0) {
+		LOG_ERR("Failed to read data from device.");
+		return rc;
+	}
+
+	status = data->read_buffer[0];
+	*sample_counter = data->read_buffer[1];
+	*iaq_sample = data->read_buffer[2];
+	*tvoc_sample = sys_get_be16(&data->read_buffer[3]);
+	*etoh_sample = sys_get_be16(&data->read_buffer[5]);
+	*eco2_sample = sys_get_be16(&data->read_buffer[7]);
+	*reliaq_sample = data->read_buffer[9];
+
+	if (status != 0x00) {
+		LOG_ERR("Status error.");
+	}
+
+	return 0;
+}
+
+static int rrh46410_sample_fetch(const struct device *dev, enum sensor_channel chan)
+{
+	struct rrh46410_data *data = dev->data;
+	int rc;
+	uint8_t checksum = ~RRH46410_GET_MEASUREMENT_RESULTS;
+	uint8_t fetch_sample[2];
+	enum sensor_channel_rrh46410 rrh46410_chan = (enum sensor_channel_rrh46410)chan;
+
+	if (chan != SENSOR_CHAN_ALL && rrh46410_chan != SENSOR_CHAN_RRH46410_IAQ &&
+	    rrh46410_chan != SENSOR_CHAN_RRH46410_TVOC &&
+	    rrh46410_chan != SENSOR_CHAN_RRH46410_ETOH &&
+	    rrh46410_chan != SENSOR_CHAN_RRH46410_ECO2 &&
+	    rrh46410_chan != SENSOR_CHAN_RRH46410_RELIAQ) {
+		return -ENOTSUP;
+	}
+
+	fetch_sample[0] = RRH46410_GET_MEASUREMENT_RESULTS;
+	fetch_sample[1] = checksum;
+
+	rc = data->hw_tf->write_data(dev, fetch_sample, sizeof(fetch_sample));
+	if (rc < 0) {
+		LOG_ERR("Failed to send fetch.");
+		return rc;
+	}
+
+	rc = rrh46410_read_sample(dev, &data->sample_counter, &data->iaq_sample, &data->tvoc_sample,
+				  &data->etoh_sample, &data->eco2_sample, &data->reliaq_sample);
+	if (rc < 0) {
+		LOG_ERR("Failed to fetch data.");
+		return rc;
+	}
+
+	return 0;
+}
+
+static int rrh46410_channel_get(const struct device *dev, enum sensor_channel chan,
+				struct sensor_value *val)
+{
+	const struct rrh46410_data *data = dev->data;
+	int32_t convert_val;
+
+	switch ((enum sensor_channel_rrh46410)chan) {
+	case SENSOR_CHAN_RRH46410_IAQ:
+		convert_val = ((int32_t)data->iaq_sample) * 10;
+		val->val1 = convert_val / 100;
+		val->val2 = convert_val % 100;
+		break;
+	case SENSOR_CHAN_RRH46410_TVOC:
+		convert_val = ((int32_t)data->tvoc_sample) * 100;
+		val->val1 = convert_val / 1000000;
+		val->val2 = convert_val % 1000000;
+		break;
+	case SENSOR_CHAN_RRH46410_ETOH:
+		convert_val = ((int32_t)data->etoh_sample) * 100;
+		val->val1 = convert_val / 10000;
+		val->val2 = convert_val % 10000;
+		break;
+	case SENSOR_CHAN_RRH46410_ECO2:
+		convert_val = (int32_t)data->eco2_sample;
+		val->val1 = convert_val / 100;
+		val->val2 = convert_val % 100;
+		break;
+	case SENSOR_CHAN_RRH46410_RELIAQ:
+		convert_val = ((int32_t)data->reliaq_sample) / 10;
+		val->val1 = convert_val * 10;
+		val->val2 = convert_val % 10;
+		break;
+	default:
+		return -ENOTSUP;
+	}
+
+	return 0;
+}
+
+static int rrh46410_init(const struct device *dev)
+{
+	const struct rrh46410_config *cfg = dev->config;
+	int err;
+	int status;
+	uint8_t rrh46410_mode;
+
+	LOG_DBG("Initializing %s", dev->name);
+
+	status = cfg->bus_init(dev);
+
+	if (status < 0) {
+		return status;
+	}
+
+	if (!gpio_is_ready_dt(&cfg->reset_gpio)) {
+		LOG_ERR("The reset pin GPIO port is not ready.\n");
+		return 0;
+	}
+
+	err = gpio_pin_configure_dt(&cfg->reset_gpio, GPIO_OUTPUT_INACTIVE);
+	if (err != 0) {
+		LOG_ERR("Configuring GPIO pin failed: %d\n", err);
+		return 0;
+	}
+
+	err = gpio_pin_set_dt(&cfg->reset_gpio, 1);
+	if (err != 0) {
+		LOG_ERR("Setting GPIO pin level failed: %d\n", err);
+	}
+
+	k_sleep(K_MSEC(100));
+
+	err = gpio_pin_set_dt(&cfg->reset_gpio, 0);
+	if (err != 0) {
+		LOG_ERR("Setting GPIO pin level failed: %d\n", err);
+	}
+
+	k_sleep(K_MSEC(600));
+
+	rrh46410_mode = rrh46410_get_operation_mode(dev);
+	if (rrh46410_mode != RRH46410_OPERATION_MODE_IAQ_2ND_GEN) {
+		rrh46410_set_operation_mode(dev);
+	}
+
+	return 0;
+}
+
+static DEVICE_API(sensor, rrh46410_driver_api) = {
+	.sample_fetch = rrh46410_sample_fetch,
+	.channel_get = rrh46410_channel_get,
+	.attr_set = rrh46410_attr_set,
+};
+
+#define RRH46410_CONFIG_I2C(n)                                                                     \
+	{                                                                                          \
+		.bus_init = rrh46410_i2c_init,                                                     \
+		.bus_cfg =                                                                         \
+			{                                                                          \
+				.i2c = I2C_DT_SPEC_INST_GET(n),                                    \
+			},                                                                         \
+		.reset_gpio = GPIO_DT_SPEC_INST_GET(n, reset_gpios),                               \
+	}
+
+#define RRH46410_CONFIG_UART(n)                                                                    \
+	{                                                                                          \
+		.bus_init = rrh46410_uart_init,                                                    \
+		.bus_cfg =                                                                         \
+			{                                                                          \
+				.uart_dev = DEVICE_DT_GET(DT_INST_BUS(n)),                         \
+			},                                                                         \
+		.reset_gpio = GPIO_DT_SPEC_INST_GET(n, reset_gpios),                               \
+	}
+
+#define DEFINE_RRH46410(n)                                                                         \
+	static struct rrh46410_data rrh46410_data_##n;                                             \
+                                                                                                   \
+	static const struct rrh46410_config rrh46410_config_##n = COND_CODE_1(DT_INST_ON_BUS	\
+				(n, i2c),\
+			    (RRH46410_CONFIG_I2C(n)),						\
+			    (RRH46410_CONFIG_UART(n)));                     \
+                                                                                                   \
+	SENSOR_DEVICE_DT_INST_DEFINE(n, rrh46410_init, NULL, &rrh46410_data_##n,                   \
+				     &rrh46410_config_##n, POST_KERNEL,                            \
+				     CONFIG_SENSOR_INIT_PRIORITY, &rrh46410_driver_api);
+
+DT_INST_FOREACH_STATUS_OKAY(DEFINE_RRH46410)

--- a/drivers/sensor/renesas/rrh46410/rrh46410.h
+++ b/drivers/sensor/renesas/rrh46410/rrh46410.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2024 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_DRIVERS_SENSOR_RRH46410_RRH46410_H_
+#define ZEPHYR_DRIVERS_SENSOR_RRH46410_RRH46410_H_
+
+#include <zephyr/types.h>
+#include <zephyr/device.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/drivers/sensor.h>
+#include <zephyr/rtio/rtio.h>
+#include <zephyr/drivers/i2c.h>
+
+#define DT_DRV_COMPAT renesas_rrh46410
+
+#define RRH46410_OPERATION_MODE_IAQ_2ND_GEN 0x01
+#define RRH46410_GET_OPERATION_MODE         0x10
+#define RRH46410_SET_OPERATION_MODE         0x11
+#define RRH46410_SET_HUMIDITY               0x12
+#define RRH46410_GET_MEASUREMENT_RESULTS    0x18
+
+/* 1 byte status, 1 byte sample counter, 8 bytes data, 1 byte checksum */
+#define RRH46410_BUFFER_LENGTH 11
+
+#define RRH46410_MAX_RESPONSE_DELAY 150 /* Add margin to the specified 50 in datasheet */
+
+union rrh46410_bus_cfg {
+#if DT_ANY_INST_ON_BUS_STATUS_OKAY(i2c)
+	struct i2c_dt_spec i2c;
+#endif
+
+#if DT_ANY_INST_ON_BUS_STATUS_OKAY(uart)
+	const struct device *uart_dev;
+#endif /* DT_ANY_INST_ON_BUS_STATUS_OKAY(uart) */
+};
+
+struct rrh46410_config {
+	int (*bus_init)(const struct device *dev);
+	const union rrh46410_bus_cfg bus_cfg;
+	struct gpio_dt_spec reset_gpio;
+};
+
+struct rrh46410_transfer_function {
+	int (*read_data)(const struct device *dev, uint8_t *rx_buff, size_t data_size);
+	int (*write_data)(const struct device *dev, uint8_t *command_data, size_t data_size);
+};
+
+struct rrh46410_data {
+	struct k_mutex uart_mutex;
+	struct k_sem uart_rx_sem;
+	uint8_t read_index;
+	uint8_t read_buffer[RRH46410_BUFFER_LENGTH];
+	uint8_t uart_buffer[RRH46410_BUFFER_LENGTH];
+	uint8_t sample_counter;
+	uint8_t iaq_sample;
+	uint16_t tvoc_sample;
+	uint16_t etoh_sample;
+	uint16_t eco2_sample;
+	uint8_t reliaq_sample;
+	const struct rrh46410_transfer_function *hw_tf;
+};
+
+int rrh46410_i2c_init(const struct device *dev);
+int rrh46410_uart_init(const struct device *dev);
+
+#endif /* ZEPHYR_DRIVERS_SENSOR_RRH46410_RRH46410_H_ */

--- a/drivers/sensor/renesas/rrh46410/rrh46410_i2c.c
+++ b/drivers/sensor/renesas/rrh46410/rrh46410_i2c.c
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2024 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT renesas_rrh46410
+
+#include <string.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/drivers/i2c.h>
+
+#include "rrh46410.h"
+
+#if DT_ANY_INST_ON_BUS_STATUS_OKAY(i2c)
+
+LOG_MODULE_DECLARE(RRH46410, CONFIG_SENSOR_LOG_LEVEL);
+
+static int rrh46410_i2c_read_data(const struct device *dev, uint8_t *rx_buff, size_t data_size)
+{
+	const struct rrh46410_config *cfg = dev->config;
+
+	return i2c_read_dt(&cfg->bus_cfg.i2c, rx_buff, data_size);
+}
+
+static int rrh46410_i2c_write_data(const struct device *dev, uint8_t *command_data,
+				   size_t data_size)
+{
+	const struct rrh46410_config *cfg = dev->config;
+
+	return i2c_write_dt(&cfg->bus_cfg.i2c, command_data, data_size);
+}
+
+static const struct rrh46410_transfer_function rrh46410_i2c_transfer_fn = {
+	.read_data = rrh46410_i2c_read_data,
+	.write_data = rrh46410_i2c_write_data,
+};
+
+int rrh46410_i2c_init(const struct device *dev)
+{
+	struct rrh46410_data *data = dev->data;
+	const struct rrh46410_config *cfg = dev->config;
+
+	data->hw_tf = &rrh46410_i2c_transfer_fn;
+
+	if (!i2c_is_ready_dt(&cfg->bus_cfg.i2c)) {
+		return -ENODEV;
+	}
+
+	return 0;
+}
+#endif /* DT_ANY_INST_ON_BUS_STATUS_OKAY(i2c) */

--- a/drivers/sensor/renesas/rrh46410/rrh46410_uart.c
+++ b/drivers/sensor/renesas/rrh46410/rrh46410_uart.c
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2024 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT renesas_rrh46410
+
+#include <string.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/drivers/uart.h>
+
+#include "rrh46410.h"
+
+#if DT_ANY_INST_ON_BUS_STATUS_OKAY(uart)
+
+LOG_MODULE_DECLARE(RRH46410, CONFIG_SENSOR_LOG_LEVEL);
+
+static void rrh46410_uart_flush(const struct device *uart_dev)
+{
+	uint8_t tmp;
+
+	while (uart_fifo_read(uart_dev, &tmp, 1) > 0) {
+		LOG_ERR("flush: %d", tmp);
+		continue;
+	}
+}
+
+static void rrh46410_buffer_reset(struct rrh46410_data *data)
+{
+	memset(data->uart_buffer, 0, data->read_index);
+	data->read_index = 0;
+}
+
+static void rrh46410_uart_isr(const struct device *uart_dev, void *user_data)
+{
+	const struct device *dev = user_data;
+	struct rrh46410_data *data = dev->data;
+	int rc;
+	uint8_t received_checksum = 0x00;
+
+	if (!device_is_ready(uart_dev)) {
+		LOG_DBG("UART device is not ready");
+		return;
+	}
+
+	if (!uart_irq_update(uart_dev)) {
+		LOG_DBG("Unable to process interrupts");
+		return;
+	}
+
+	if (!uart_irq_rx_ready(uart_dev)) {
+		LOG_DBG("No RX data");
+		return;
+	}
+
+	rc = uart_fifo_read(uart_dev, &data->uart_buffer[data->read_index], RRH46410_BUFFER_LENGTH);
+
+	if (rc < 0) {
+		LOG_ERR("UART read failed: %d", rc < 0 ? rc : -ERANGE);
+		rrh46410_uart_flush(uart_dev);
+		LOG_HEXDUMP_WRN(data->uart_buffer, data->read_index, "Discarding");
+		rrh46410_buffer_reset(data);
+	} else {
+		data->read_index += rc;
+
+		for (int i = 1; i < data->read_index - 1; i++) {
+			received_checksum += data->uart_buffer[i];
+		}
+
+		received_checksum = ~received_checksum;
+
+		if (data->uart_buffer[data->read_index - 1] == received_checksum) {
+			k_sem_give(&data->uart_rx_sem);
+		}
+	}
+}
+
+static int rrh46410_await_receive(struct rrh46410_data *data)
+{
+	int rc = k_sem_take(&data->uart_rx_sem, K_MSEC(RRH46410_MAX_RESPONSE_DELAY));
+
+	/* Reset semaphore if sensor did not respond within maximum specified response time */
+	if (rc == -EAGAIN) {
+		k_sem_reset(&data->uart_rx_sem);
+	}
+
+	return rc;
+}
+
+static int rrh46410_uart_transceive(const struct device *dev, uint8_t *command_data,
+				    size_t data_size)
+{
+	const struct rrh46410_config *cfg = dev->config;
+	struct rrh46410_data *data = dev->data;
+	int rc;
+
+	k_mutex_lock(&data->uart_mutex, K_FOREVER);
+
+	rrh46410_buffer_reset(data);
+
+	for (int i = 0; i != data_size; i++) {
+		uart_poll_out(cfg->bus_cfg.uart_dev, command_data[i]);
+	}
+
+	rc = rrh46410_await_receive(data);
+	if (rc != 0) {
+		LOG_WRN("UART did not receive a response: %d", rc);
+	}
+
+	k_mutex_unlock(&data->uart_mutex);
+
+	return rc;
+}
+
+static int rrh46410_uart_read_data(const struct device *dev, uint8_t *rx_buff, size_t data_size)
+{
+	struct rrh46410_data *data = dev->data;
+
+	if (data_size > sizeof(data->read_buffer)) {
+		return -EIO;
+	}
+
+	memcpy(data->read_buffer, data->uart_buffer, data_size);
+
+	return 0;
+}
+
+static const struct rrh46410_transfer_function rrh46410_uart_transfer_fn = {
+	.read_data = rrh46410_uart_read_data,
+	.write_data = rrh46410_uart_transceive,
+};
+
+int rrh46410_uart_init(const struct device *dev)
+{
+	struct rrh46410_data *data = dev->data;
+	const struct rrh46410_config *cfg = dev->config;
+	int rc;
+
+	data->hw_tf = &rrh46410_uart_transfer_fn;
+
+	k_mutex_init(&data->uart_mutex);
+	k_sem_init(&data->uart_rx_sem, 0, 1);
+
+	uart_irq_rx_disable(cfg->bus_cfg.uart_dev);
+	uart_irq_tx_disable(cfg->bus_cfg.uart_dev);
+
+	rc = uart_irq_callback_user_data_set(cfg->bus_cfg.uart_dev, rrh46410_uart_isr, (void *)dev);
+	if (rc != 0) {
+		LOG_ERR("UART IRQ setup failed: %d", rc);
+		return rc;
+	}
+
+	uart_irq_rx_enable(cfg->bus_cfg.uart_dev);
+
+	return 0;
+}
+#endif /* DT_ANY_INST_ON_BUS_STATUS_OKAY(uart) */

--- a/dts/bindings/sensor/renesas,rrh46410-common.yaml
+++ b/dts/bindings/sensor/renesas,rrh46410-common.yaml
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2024 Renesas Electronics Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+description: Renesas RRH46410 TVOC sensor
+
+compatible: "renesas,rrh46410"
+
+include: sensor-device.yaml
+
+properties:
+  reset-gpios:
+    type: phandle-array
+    description: |
+      The RESET pin is asserted to disable the sensor causing a hard
+      reset.  The sensor receives this as an active-low signal.

--- a/dts/bindings/sensor/renesas,rrh46410-i2c.yaml
+++ b/dts/bindings/sensor/renesas,rrh46410-i2c.yaml
@@ -1,0 +1,10 @@
+#
+# Copyright (c) 2024 Renesas Electronics Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+description: Renesas RRH46410 TVOC sensor
+
+compatible: "renesas,rrh46410"
+
+include: [i2c-device.yaml, "renesas,rrh46410-common.yaml"]

--- a/dts/bindings/sensor/renesas,rrh46410-uart.yaml
+++ b/dts/bindings/sensor/renesas,rrh46410-uart.yaml
@@ -1,0 +1,10 @@
+#
+# Copyright (c) 2024 Renesas Electronics Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+description: Renesas RRH46410 TVOC sensor
+
+compatible: "renesas,rrh46410"
+
+include: [uart-device.yaml, "renesas,rrh46410-common.yaml"]

--- a/include/zephyr/drivers/sensor/rrh46410.h
+++ b/include/zephyr/drivers/sensor/rrh46410.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2024 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_SENSOR_RRH46410_H_
+#define ZEPHYR_INCLUDE_DRIVERS_SENSOR_RRH46410_H_
+
+#include <zephyr/drivers/sensor.h>
+
+enum sensor_channel_rrh46410 {
+	/** 1 byte Indoor Air Quality */
+	SENSOR_CHAN_RRH46410_IAQ = SENSOR_CHAN_PRIV_START,
+	/** 2 bytes Total Volatile Organic Compounds */
+	SENSOR_CHAN_RRH46410_TVOC,
+	/**  2 bytes Ethanol Equivalent */
+	SENSOR_CHAN_RRH46410_ETOH,
+	/** 2 bytes Estimated CO2 */
+	SENSOR_CHAN_RRH46410_ECO2,
+	/** 1 byte Relative IAQ */
+	SENSOR_CHAN_RRH46410_RELIAQ,
+};
+
+enum sensor_attribute_rrh46410 {
+	SENSOR_ATTR_RRH46410_HUMIDITY = SENSOR_ATTR_PRIV_START,
+};
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_SENSOR_RRH46410_H_ */

--- a/tests/drivers/build_all/sensor/i2c.dtsi
+++ b/tests/drivers/build_all/sensor/i2c.dtsi
@@ -1296,3 +1296,9 @@ test_i2c_icm45686: icm45686@b1 {
 	reg = <0xb1>;
 	int-gpios = <&test_gpio 0 0>;
 };
+
+test_i2c_rrh46410: rrh46410@b2 {
+	compatible = "renesas,rrh46410";
+	reg = <0xb2>;
+	reset-gpios = <&test_gpio 0 0>;
+};

--- a/tests/drivers/build_all/sensor/uart.dtsi
+++ b/tests/drivers/build_all/sensor/uart.dtsi
@@ -38,3 +38,8 @@ test_uart_explorir_m: explorir-m {
 test_uart_fcx_mldx5: fcx-mldx5 {
 	compatible = "ap,fcx-mldx5";
 };
+
+test_uart_rrh46410: rrh46410 {
+	compatible = "renesas,rrh46410";
+	reset-gpios = <&test_gpio 0 0>;
+};


### PR DESCRIPTION
Adds Renesas RRH46410 gas sensor module driver.
The reset pin gets used to make sure the sensor starts from suspend mode.