### PR TITLE
Mbed TLS 3.6.2 update backport to v3.7 branch

### DIFF
--- a/doc/releases/release-notes-3.7.rst
+++ b/doc/releases/release-notes-3.7.rst
@@ -18,11 +18,13 @@ These GitHub issues were addressed since the previous 3.7.0 tagged release:
 Mbed TLS
 ********
 
-Mbed TLS was updated to version 3.6.1. The release notes can be found at:
-https://github.com/Mbed-TLS/mbedtls/releases/tag/mbedtls-3.6.1
+Mbed TLS was updated to version 3.6.2 (from 3.6.0). The release notes can be found at:
+
+  * https://github.com/Mbed-TLS/mbedtls/releases/tag/mbedtls-3.6.1
+  * https://github.com/Mbed-TLS/mbedtls/releases/tag/mbedtls-3.6.2
 
 Mbed TLS 3.6 is an LTS release that will be supported
-with bug and security fixes until at least March 2027.
+with security and bug fixes until at least March 2027.
 
 .. _zephyr_3.7.0:
 

--- a/west.yml
+++ b/west.yml
@@ -282,7 +282,7 @@ manifest:
       revision: 2b498e6f36d6b82ae1da12c8b7742e318624ecf5
       path: modules/lib/gui/lvgl
     - name: mbedtls
-      revision: fb36f3fe20f9f62e67b1a20c0cfe0a6788ec2bf6
+      revision: a78176c6ff0733ba08018cba4447bd3f20de7978
       path: modules/crypto/mbedtls
       groups:
         - crypto


### PR DESCRIPTION
Backport of #79902

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/80133.
(Issue made by the bot due to a conflict but I don't think we need an actual issue written for that.)