### PR TITLE
west.yml: MCUboot synchronization from upstream

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -285,7 +285,7 @@ manifest:
       groups:
         - crypto
     - name: mcuboot
-      revision: b9d69dd2a2d6df32da6608d549138288bb7d7aa5
+      revision: 33de65cebaf78b306501a4195dc0ce4008315e1a
       path: bootloader/mcuboot
       groups:
         - bootloader


### PR DESCRIPTION
Update Zephyr fork of MCUboot to revision:
  33de65cebaf78b306501a4195dc0ce4008315e1a

Brings following Zephyr relevant fixes:
  - 33de65c scipts: imgtool: bugfix #2096

Notes on process:
 1) The MCUboot update from [mcu-tools/mcuboot/main](https://github.com/mcu-tools/mcuboot/tree/main) with the SHA used in west.yaml is already synchronized to [zephyrproject-rtos/mcuboot/upstream-sync](https://github.com/zephyrproject-rtos/mcuboot/tree/upstream-sync) branch, and is available in the Zephyr fork of MCUboot.
 2) The [DNM] on this PR should be kept until the PR passes all tests and is accepted.
 3) Once the PR passes all tests and gets accepted, the upstream-sync branch should be fast-forward merged to [zephyrproject-rtos/mcuboot/main](https://github.com/zephyrproject-rtos/mcuboot/tree/main) branch and [DNM] should be removed.
 4) After the main branch gets updated, this PR does not require further changes and should be merged as is.