### PR TITLE
nrfbsim: Provide a few updated to enable more apps

### DIFF
--- a/boards/native/nrf_bsim/board_irq.h
+++ b/boards/native/nrf_bsim/board_irq.h
@@ -18,6 +18,7 @@ void nrfbsim_WFE_model(void);
 void nrfbsim_SEV_model(void);
 
 #define IRQ_ZERO_LATENCY	BIT(1) /* Unused in this board*/
+#define IRQ_PRIO_LOWEST		UINT8_MAX
 
 #ifdef __cplusplus
 }

--- a/boards/native/nrf_bsim/common/cmsis/cmsis.c
+++ b/boards/native/nrf_bsim/common/cmsis/cmsis.c
@@ -30,6 +30,11 @@ void NVIC_DisableIRQ(IRQn_Type IRQn)
 	hw_irq_ctrl_disable_irq(CONFIG_NATIVE_SIMULATOR_MCU_N, IRQn);
 }
 
+uint32_t NVIC_GetPendingIRQ(IRQn_Type IRQn)
+{
+	return hw_irq_ctrl_is_irq_pending(CONFIG_NATIVE_SIMULATOR_MCU_N, IRQn);
+}
+
 void NVIC_EnableIRQ(IRQn_Type IRQn)
 {
 	hw_irq_ctrl_enable_irq(CONFIG_NATIVE_SIMULATOR_MCU_N, IRQn);

--- a/boards/native/nrf_bsim/common/cmsis/cmsis.h
+++ b/boards/native/nrf_bsim/common/cmsis/cmsis.h
@@ -30,6 +30,7 @@ void __set_PRIMASK(uint32_t primask);
 void NVIC_SetPendingIRQ(IRQn_Type IRQn);
 void NVIC_ClearPendingIRQ(IRQn_Type IRQn);
 void NVIC_DisableIRQ(IRQn_Type IRQn);
+uint32_t NVIC_GetPendingIRQ(IRQn_Type IRQn);
 void NVIC_EnableIRQ(IRQn_Type IRQn);
 void NVIC_SetPriority(IRQn_Type IRQn, uint32_t priority);
 uint32_t NVIC_GetPriority(IRQn_Type IRQn);

--- a/scripts/native_simulator/common/src/include/nsi_utils.h
+++ b/scripts/native_simulator/common/src/include/nsi_utils.h
@@ -28,6 +28,7 @@
 #define NSI_CODE_UNREACHABLE __builtin_unreachable()
 
 #define NSI_FUNC_NORETURN __attribute__((__noreturn__))
+#define NSI_WEAK __attribute__((__weak__))
 
 #if defined(__clang__)
   /* The address sanitizer in llvm adds padding (redzones) after data

--- a/west.yml
+++ b/west.yml
@@ -300,7 +300,7 @@ manifest:
       groups:
         - tools
     - name: nrf_hw_models
-      revision: eeed2591d38e5e9bf89658df67555f2777249fc0
+      revision: aca798cf7cf0c5dc1fd89c66cf62670051feb8d0
       path: modules/bsim_hw_models/nrf_hw_models
     - name: open-amp
       revision: b735edbc739ad59156eb55bb8ce2583d74537719


### PR DESCRIPTION
A few minor updates which enable more apps.
One commit provides a macro defined for ARM some apps need. The other 2 are minor updates to the native simulator and HW models.

* boards nrf_bsim: Add NVIC_GetPendingIRQ() equivalent
* boards nrf_bsim: Provide IRQ_PRIO_LOWEST
* manifest: Update nRF hw models to latest
* native_simulator: Get latest from upstream