### PR TITLE
scripts: twister: Python Version Guard

### DIFF
--- a/scripts/pylib/twister/twisterlib/environment.py
+++ b/scripts/pylib/twister/twisterlib/environment.py
@@ -51,6 +51,17 @@ def _get_installed_packages() -> Generator[str, None, None]:
         yield dist.metadata['Name']
 
 
+def python_version_guard():
+    min_ver = (3, 10)
+    if sys.version_info < min_ver:
+        min_ver_str = '.'.join([str(v) for v in min_ver])
+        cur_ver_line = f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
+        print(f"Unsupported Python version {cur_ver_line}.")
+        print(f"Currently, Twister requires at least Python {min_ver_str}.")
+        print("Install a newer Python version and retry.")
+        sys.exit(1)
+
+
 installed_packages: List[str] = list(_get_installed_packages())
 PYTEST_PLUGIN_INSTALLED = 'pytest-twister-harness' in installed_packages
 

--- a/scripts/twister
+++ b/scripts/twister
@@ -203,12 +203,15 @@ if not ZEPHYR_BASE:
 sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts/pylib/twister/"))
 sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts/pylib/build_helpers"))
 
-from twisterlib.environment import add_parse_arguments, parse_arguments
+from twisterlib.environment import add_parse_arguments, parse_arguments, python_version_guard
 from twisterlib.twister_main import main
+
 
 if __name__ == "__main__":
     ret = 0
     try:
+        python_version_guard()
+
         parser = add_parse_arguments()
         options = parse_arguments(parser, sys.argv[1:])
         default_options = parse_arguments(parser, [], on_init=False)

--- a/scripts/west_commands/twister_cmd.py
+++ b/scripts/west_commands/twister_cmd.py
@@ -18,7 +18,7 @@ os.environ["ZEPHYR_BASE"] = str(twister_path.parent)
 sys.path.insert(0, str(twister_path))
 sys.path.insert(0, str(twister_path / "pylib" / "twister"))
 
-from twisterlib.environment import add_parse_arguments, parse_arguments
+from twisterlib.environment import add_parse_arguments, parse_arguments, python_version_guard
 from twisterlib.twister_main import main
 
 TWISTER_DESCRIPTION = """\
@@ -37,6 +37,7 @@ class Twister(WestCommand):
             TWISTER_DESCRIPTION,
             accepts_unknown_args=True,
         )
+        python_version_guard()
 
     def do_add_parser(self, parser_adder):
         parser = parser_adder.add_parser(


### PR DESCRIPTION
Twister shall now verify that the user does not use an obsolete Python version. If user's Python is deemed too old, it will exit and log a relevant error.