### PR TITLE
doc: extensions: boards: Better handle unknown/other vendors

### DIFF
--- a/doc/_scripts/gen_boards_catalog.py
+++ b/doc/_scripts/gen_boards_catalog.py
@@ -83,9 +83,13 @@ def get_catalog():
 
     for board in boards:
         # We could use board.vendor but it is often incorrect. Instead, deduce vendor from
-        # containing folder
+        # containing folder. There are a few exceptions, like the "native" and "others" folders
+        # which we know are not actual vendors so treat them as such.
         for folder in board.dir.parents:
-            if vnd_lookup.vnd2vendor.get(folder.name):
+            if folder.name in ["native", "others"]:
+                vendor = "others"
+                break
+            elif vnd_lookup.vnd2vendor.get(folder.name):
                 vendor = folder.name
                 break
 
@@ -120,4 +124,8 @@ def get_catalog():
         series = soc.series or "<no series>"
         socs_hierarchy.setdefault(family, {}).setdefault(series, []).append(soc.name)
 
-    return {"boards": board_catalog, "vendors": vnd_lookup.vnd2vendor, "socs": socs_hierarchy}
+    return {
+        "boards": board_catalog,
+        "vendors": {**vnd_lookup.vnd2vendor, "others": "Other/Unknown"},
+        "socs": socs_hierarchy,
+    }


### PR DESCRIPTION
Boards under a folder that doesn't directly match a vendor prefix incorrectly end up being categorized as "zephyr" since that's the only prefix that is eventually found when navigating up the folder hierarchy.

This commits treats boards in the "others" and "native" folders as special cases and associates them to an "Unknown/Other" category.