### PR TITLE
tests/libcxx: Check for newlib nano when testing that

### DIFF
--- a/tests/lib/cpp/libcxx/testcase.yaml
+++ b/tests/lib/cpp/libcxx/testcase.yaml
@@ -12,7 +12,7 @@ tests:
     integration_platforms:
       - mps2/an385
   cpp.libcxx.glibcxx.newlib_nano:
-    filter: TOOLCHAIN_HAS_NEWLIB == 1
+    filter: TOOLCHAIN_HAS_NEWLIB == 1 and CONFIG_HAS_NEWLIB_LIBC_NANO
     toolchain_exclude: xcc
     min_flash: 54
     tags: cpp


### PR DESCRIPTION
Add a check for CONFIG_HAS_NEWLIB_LIBC_NANO in the cpp.libcxx.glibcxx.newlib_nano test.