### PR TITLE
drivers: sensor: lsm6dsv16x: fix temperature overflow

### DIFF
--- a/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x.c
+++ b/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x.c
@@ -563,15 +563,14 @@ static int lsm6dsv16x_gyro_channel_get(enum sensor_channel chan,
 static void lsm6dsv16x_gyro_channel_get_temp(struct sensor_value *val,
 					  struct lsm6dsv16x_data *data)
 {
-	int32_t micro_c;
-
 	/* convert units to micro Celsius. Raw temperature samples are
 	 * expressed in 256 LSB/deg_C units. And LSB output is 0 at 25 C.
 	 */
-	micro_c = (data->temp_sample * 1000000) / 256;
+	int64_t temp_sample = data->temp_sample;
+	int64_t micro_c = (temp_sample * 1000000LL) / 256;
 
-	val->val1 = micro_c / 1000000 + 25;
-	val->val2 = micro_c % 1000000;
+	val->val1 = (int32_t)(micro_c / 1000000) + 25;
+	val->val2 = (int32_t)(micro_c % 1000000);
 }
 #endif
 


### PR DESCRIPTION
Fixed integer overflow by explicit casting. Can edit for styling if requested.

Tested by test suite:
```
void test_critical_temps(void) {
    struct lsm6dsv16x_data test_data;
    struct sensor_value result;
    
    // Test around INT32_MAX/1000000 * 256 area
    for (int16_t i = 2145; i < 2150; i++) {
        test_data.temp_sample = i;
        int32_t expected_mc = ((int32_t)i * 1000) / 256 + 25000;
        int64_t debug_mult = (int64_t)i * 1000000LL;
        
        lsm6dsv16x_gyro_channel_get_temp(&result, &test_data);
        
        LOG_WRN("LSB: %d, Expected mC: %d, Debug mult: %lld, Reported: %d.%06d",
                i, expected_mc, debug_mult, result.val1, result.val2);
    }
}
```