### PR TITLE
doc: add target-notes directive where missing

### DIFF
--- a/boards/96boards/neonkey/doc/index.rst
+++ b/boards/96boards/neonkey/doc/index.rst
@@ -216,6 +216,8 @@ GDB instance. To reattach, just follow the same steps above, till
 References
 **********
 
+.. target-notes::
+
 .. _96Boards website:
    https://www.96boards.org/product/neonkey/
 

--- a/boards/96boards/wistrio/doc/96b_wistrio.rst
+++ b/boards/96boards/wistrio/doc/96b_wistrio.rst
@@ -189,6 +189,8 @@ GDB instance. To reattach, just follow the same steps above, till
 References
 **********
 
+.. target-notes::
+
 .. _AN2606:
    https://www.st.com/resource/en/application_note/cd00167594.pdf
 

--- a/boards/arduino/due/doc/index.rst
+++ b/boards/arduino/due/doc/index.rst
@@ -205,6 +205,8 @@ Now press the Reset button and you should see "Hello World! arduino_due" in your
 References
 **********
 
+.. target-notes::
+
 .. _Arduino Due website: https://www.arduino.cc/en/Main/ArduinoBoardDue
 
 .. _Atmel SAM3X8E Datasheet: http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-11057-32-bit-Cortex-M3-Microcontroller-SAM3X-SAM3A_Datasheet.pdf

--- a/boards/arm/fvp_base_revc_2xaemv8a/doc/index.rst
+++ b/boards/arm/fvp_base_revc_2xaemv8a/doc/index.rst
@@ -117,6 +117,8 @@ Networking
 References
 **********
 
+.. target-notes::
+
 1. (ID070919) Arm® Architecture Reference Manual - Armv8, for Armv8-A architecture profile
 2. AArch64 Exception and Interrupt Handling
 3. https://developer.arm.com/tools-and-software/simulation-models/fixed-virtual-platforms

--- a/boards/arm/fvp_baser_aemv8r/doc/aarch32.rst
+++ b/boards/arm/fvp_baser_aemv8r/doc/aarch32.rst
@@ -96,6 +96,8 @@ Refer to the detailed overview about :ref:`application_debugging`.
 References
 **********
 
+.. target-notes::
+
 .. [1] https://developer.arm.com/tools-and-software/simulation-models/fixed-virtual-platforms/arm-ecosystem-models
 .. [2] Arm Architecture Reference Manual Supplement - Armv8, for Armv8-R AArch32 architecture profile
        https://developer.arm.com/documentation/ddi0568/latest

--- a/boards/arm/fvp_baser_aemv8r/doc/aarch64.rst
+++ b/boards/arm/fvp_baser_aemv8r/doc/aarch64.rst
@@ -106,6 +106,8 @@ See :ref:`debug_with_arm_ds` for how to debug with Arm Development Studio [5]_.
 References
 **********
 
+.. target-notes::
+
 .. [1] https://developer.arm.com/tools-and-software/simulation-models/fixed-virtual-platforms/arm-ecosystem-models
 .. [2] Arm Architecture Reference Manual Supplement - Armv8, for Armv8-R AArch64 architecture profile
        https://developer.arm.com/documentation/ddi0600/latest/

--- a/boards/arm/fvp_baser_aemv8r/doc/debug-with-arm-ds.rst
+++ b/boards/arm/fvp_baser_aemv8r/doc/debug-with-arm-ds.rst
@@ -141,5 +141,7 @@ connected in ``Debug Control`` window.
 References
 **********
 
+.. target-notes::
+
 .. [1] https://developer.arm.com/tools-and-software/embedded/arm-development-studio
 .. [2] https://developer.arm.com/tools-and-software/simulation-models/fixed-virtual-platforms/arm-ecosystem-models

--- a/boards/blues/swan_r5/doc/index.rst
+++ b/boards/blues/swan_r5/doc/index.rst
@@ -222,6 +222,8 @@ You should see the following message on the console:
 References
 **********
 
+.. target-notes::
+
 .. _Swan Product Page:
    https://blues.io/products/swan
 

--- a/boards/cdns/xt-sim/doc/index.rst
+++ b/boards/cdns/xt-sim/doc/index.rst
@@ -177,4 +177,6 @@ Build and run as follows:
 References
 **********
 
+.. target-notes::
+
 .. _Xtensa tools: https://ip.cadence.com/support/sdk-evaluation-request

--- a/boards/cypress/cy8ckit_062_ble/doc/index.rst
+++ b/boards/cypress/cy8ckit_062_ble/doc/index.rst
@@ -283,6 +283,8 @@ UART_RTS with UART_CTS from KitProg2.
 References
 **********
 
+.. target-notes::
+
 .. _PSoC 63 BLE MCU SoC Website:
 	https://www.cypress.com/products/32-bit-arm-cortex-m4-cortex-m0-psoc-63-connectivity-line
 

--- a/boards/cypress/cy8ckit_062_wifi_bt/doc/index.rst
+++ b/boards/cypress/cy8ckit_062_wifi_bt/doc/index.rst
@@ -186,6 +186,8 @@ serial port:
 References
 **********
 
+.. target-notes::
+
 .. _PSoC 62 MCU SoC Website:
 	https://www.cypress.com/products/32-bit-arm-cortex-m4-psoc-6
 

--- a/boards/espressif/esp32_devkitc_wroom/doc/index.rst
+++ b/boards/espressif/esp32_devkitc_wroom/doc/index.rst
@@ -292,6 +292,8 @@ GDB stub is enabled on ESP32.
 References
 **********
 
+.. target-notes::
+
 .. _`ESP32-DevKitC-WROOM`: https://docs.espressif.com/projects/esp-idf/en/stable/esp32/hw-reference/esp32/get-started-devkitc.html#
 .. _`ESP32 Datasheet`: https://www.espressif.com/sites/default/files/documentation/esp32_datasheet_en.pdf
 .. _`ESP32 Technical Reference Manual`: https://espressif.com/sites/default/files/documentation/esp32_technical_reference_manual_en.pdf

--- a/boards/espressif/esp32_devkitc_wrover/doc/index.rst
+++ b/boards/espressif/esp32_devkitc_wrover/doc/index.rst
@@ -292,6 +292,8 @@ GDB stub is enabled on ESP32.
 References
 **********
 
+.. target-notes::
+
 .. _`ESP32-DevKitC-WROVER`: https://docs.espressif.com/projects/esp-idf/en/stable/esp32/hw-reference/esp32/get-started-devkitc.html#
 .. _`ESP32 Datasheet`: https://www.espressif.com/sites/default/files/documentation/esp32_datasheet_en.pdf
 .. _`ESP32 Technical Reference Manual`: https://espressif.com/sites/default/files/documentation/esp32_technical_reference_manual_en.pdf

--- a/boards/espressif/esp32_ethernet_kit/doc/index.rst
+++ b/boards/espressif/esp32_ethernet_kit/doc/index.rst
@@ -615,6 +615,8 @@ during board initialization (board_init.c)
 References
 **********
 
+.. target-notes::
+
 .. _`ESP32-Ethernet-Kit V1.2 Ethernet Board (A) Schematic`: https://dl.espressif.com/dl/schematics/SCH_ESP32-Ethernet-Kit_A_V1.2_20200528.pdf
 .. _`ESP32-WROVER-E Datasheet`: https://www.espressif.com/sites/default/files/documentation/esp32-wrover-e_esp32-wrover-ie_datasheet_en.pdf
 .. _`OpenOCD ESP32`: https://github.com/espressif/openocd-esp32/releases

--- a/boards/espressif/esp32c3_devkitc/doc/index.rst
+++ b/boards/espressif/esp32c3_devkitc/doc/index.rst
@@ -246,6 +246,8 @@ You can debug an application in the usual way. Here is an example for the :zephy
 References
 **********
 
+.. target-notes::
+
 .. _`ESP32-C3-DevKitC`: https://docs.espressif.com/projects/esp-dev-kits/en/latest/esp32c3/esp32-c3-devkitc-02/index.html
 .. _`ESP32-C3 Datasheet`: https://www.espressif.com/sites/default/files/documentation/esp32-c3_datasheet_en.pdf
 .. _`ESP32-C3 Technical Reference Manual`: https://espressif.com/sites/default/files/documentation/esp32-c3_technical_reference_manual_en.pdf

--- a/boards/espressif/esp32c3_devkitm/doc/index.rst
+++ b/boards/espressif/esp32c3_devkitm/doc/index.rst
@@ -246,6 +246,8 @@ You can debug an application in the usual way. Here is an example for the :zephy
 References
 **********
 
+.. target-notes::
+
 .. _`ESP32-C3-DevKitM`: https://docs.espressif.com/projects/esp-idf/en/latest/esp32c3/hw-reference/esp32c3/user-guide-devkitm-1.html
 .. _`ESP32-C3 Datasheet`: https://www.espressif.com/sites/default/files/documentation/esp32-c3_datasheet_en.pdf
 .. _`ESP32-C3 Technical Reference Manual`: https://espressif.com/sites/default/files/documentation/esp32-c3_technical_reference_manual_en.pdf

--- a/boards/espressif/esp32c3_rust/doc/index.rst
+++ b/boards/espressif/esp32c3_rust/doc/index.rst
@@ -291,6 +291,8 @@ You can debug an application in the usual way. Here is an example for the :zephy
 References
 **********
 
+.. target-notes::
+
 .. _`ESP32-C3-DevKit-RUST`: https://github.com/esp-rs/esp-rust-board/tree/v1.2
 .. _`ESP32-C3 Datasheet`: https://www.espressif.com/sites/default/files/documentation/esp32-c3_datasheet_en.pdf
 .. _`ESP32-C3 Technical Reference Manual`: https://espressif.com/sites/default/files/documentation/esp32-c3_technical_reference_manual_en.pdf

--- a/boards/espressif/esp32c6_devkitc/doc/index.rst
+++ b/boards/espressif/esp32c6_devkitc/doc/index.rst
@@ -281,6 +281,8 @@ You can debug an application in the usual way. Here is an example for the :zephy
 References
 **********
 
+.. target-notes::
+
 .. _`ESP32-C6-DevKitC`: https://docs.espressif.com/projects/esp-dev-kits/en/latest/esp32c6/esp32-c6-devkitc-1/user_guide.html
 .. _`ESP32-C6 Datasheet`: https://www.espressif.com/sites/default/files/documentation/esp32-c6_datasheet_en.pdf
 .. _`ESP32-C6 Technical Reference Manual`: https://espressif.com/sites/default/files/documentation/esp32-c6_technical_reference_manual_en.pdf

--- a/boards/espressif/esp32s2_devkitc/doc/index.rst
+++ b/boards/espressif/esp32s2_devkitc/doc/index.rst
@@ -252,6 +252,8 @@ You can debug an application in the usual way. Here is an example for the :zephy
 References
 **********
 
+.. target-notes::
+
 .. _`ESP32-S3-DevKitC`: https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/hw-reference/esp32s2/user-guide-saola-1-v1.2.html
 .. _`ESP32-S2 Datasheet`: https://www.espressif.com/sites/default/files/documentation/esp32-s2_datasheet_en.pdf
 .. _`ESP32-S2 Technical Reference Manual`: https://espressif.com/sites/default/files/documentation/esp32-s2_technical_reference_manual_en.pdf

--- a/boards/espressif/esp32s2_saola/doc/index.rst
+++ b/boards/espressif/esp32s2_saola/doc/index.rst
@@ -252,6 +252,8 @@ You can debug an application in the usual way. Here is an example for the :zephy
 References
 **********
 
+.. target-notes::
+
 .. _`ESP32-S3-DevKitC`: https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/hw-reference/esp32s2/user-guide-saola-1-v1.2.html
 .. _`ESP32-S2 Datasheet`: https://www.espressif.com/sites/default/files/documentation/esp32-s2_datasheet_en.pdf
 .. _`ESP32-S2 Technical Reference Manual`: https://espressif.com/sites/default/files/documentation/esp32-s2_technical_reference_manual_en.pdf

--- a/boards/espressif/esp32s3_devkitc/doc/index.rst
+++ b/boards/espressif/esp32s3_devkitc/doc/index.rst
@@ -279,6 +279,8 @@ You can debug an application in the usual way. Here is an example for the :zephy
 References
 **********
 
+.. target-notes::
+
 .. _`ESP32-S3-DevKitC`: https://docs.espressif.com/projects/esp-idf/en/latest/esp32s3/hw-reference/esp32s3/user-guide-devkitc-1.html
 .. _`ESP32-S3 Datasheet`: https://www.espressif.com/sites/default/files/documentation/esp32-s3-wroom-1_wroom-1u_datasheet_en.pdf
 .. _`ESP32-S3 Technical Reference Manual`: https://www.espressif.com/sites/default/files/documentation/esp32-s3_technical_reference_manual_en.pdf

--- a/boards/espressif/esp32s3_devkitm/doc/index.rst
+++ b/boards/espressif/esp32s3_devkitm/doc/index.rst
@@ -279,6 +279,8 @@ You can debug an application in the usual way. Here is an example for the :zephy
 References
 **********
 
+.. target-notes::
+
 .. _`ESP32-S3-DevKitM User Guide`: https://docs.espressif.com/projects/esp-idf/en/latest/esp32s3/hw-reference/esp32s3/user-guide-devkitm-1.html
 .. _`ESP32-S3 Datasheet`: https://www.espressif.com/sites/default/files/documentation/esp32-s3-mini-1_mini-1u_datasheet_en.pdf
 .. _`ESP32-S3 Technical Reference Manual`: https://www.espressif.com/sites/default/files/documentation/esp32-s3_technical_reference_manual_en.pdf

--- a/boards/espressif/esp8684_devkitm/doc/index.rst
+++ b/boards/espressif/esp8684_devkitm/doc/index.rst
@@ -242,6 +242,8 @@ You can debug an application in the usual way. Here is an example for the :zephy
 References
 **********
 
+.. target-notes::
+
 .. _`ESP8684-DevKitM User Guide`: https://docs.espressif.com/projects/esp-dev-kits/en/latest/esp8684/esp8684-devkitm-1/user_guide.html
 .. _`ESP8684 Datasheet`: https://www.espressif.com/sites/default/files/documentation/esp8684_datasheet_en.pdf
 .. _`ESP8684 Technical Reference Manual`: https://www.espressif.com/sites/default/files/documentation/esp8684_technical_reference_manual_en.pdf

--- a/boards/espressif/esp_wrover_kit/doc/index.rst
+++ b/boards/espressif/esp_wrover_kit/doc/index.rst
@@ -652,6 +652,8 @@ You can debug an application in the usual way. Here is an example for the :zephy
 References
 **********
 
+.. target-notes::
+
 .. _`ESP32 Datasheet`: https://www.espressif.com/sites/default/files/documentation/esp32_datasheet_en.pdf (PDF)
 .. _`ESP32-WROVER-E Datasheet`: https://www.espressif.com/sites/default/files/documentation/esp32-wrover-e_esp32-wrover-ie_datasheet_en.pdf (PDF)
 .. _`OpenOCD ESP32`: https://github.com/espressif/openocd-esp32/releases

--- a/boards/franzininho/esp32s2_franzininho/doc/index.rst
+++ b/boards/franzininho/esp32s2_franzininho/doc/index.rst
@@ -173,6 +173,8 @@ message in the monitor:
 References
 **********
 
+.. target-notes::
+
 .. [1] https://www.espressif.com/en/products/socs/esp32-s2
 .. _`ESP32S2 Technical Reference Manual`: https://espressif.com/sites/default/files/documentation/esp32-s2_technical_reference_manual_en.pdf
 .. _`ESP32S2 Datasheet`: https://www.espressif.com/sites/default/files/documentation/esp32-s2_datasheet_en.pdf

--- a/boards/infineon/cy8ckit_062s4/doc/index.rst
+++ b/boards/infineon/cy8ckit_062s4/doc/index.rst
@@ -100,6 +100,8 @@ To get the OpenOCD package, it is required that you
 References
 **********
 
+.. target-notes::
+
 .. _CY8CKIT 062S4 Pioneer Kit Guide:
     https://www.infineon.com/dgdl/Infineon-CY8CKIT_062S4_PSoC62S4_pioneer_kit_guide-UserManual-v01_00-EN.pdf?fileId=8ac78c8c7e7124d1017e962f98992207
 

--- a/boards/infineon/cy8cproto_063_ble/doc/index.rst
+++ b/boards/infineon/cy8cproto_063_ble/doc/index.rst
@@ -119,6 +119,8 @@ On Linux:
 References
 **********
 
+.. target-notes::
+
 .. _PSoC 63 BLE MCU SoC Website:
     https://www.cypress.com/products/32-bit-arm-cortex-m4-psoc-6
 

--- a/boards/infineon/xmc45_relax_kit/doc/index.rst
+++ b/boards/infineon/xmc45_relax_kit/doc/index.rst
@@ -96,6 +96,8 @@ Step through the application in your debugger.
 References
 **********
 
+.. target-notes::
+
 .. _Relax Kit User Manual:
    https://www.infineon.com/dgdl/Board_Users_Manual_XMC4500_Relax_Kit-V1_R1.2_released.pdf?fileId=db3a30433acf32c9013adf6b97b112f9
 

--- a/boards/infineon/xmc47_relax_kit/doc/index.rst
+++ b/boards/infineon/xmc47_relax_kit/doc/index.rst
@@ -99,6 +99,8 @@ Step through the application in your debugger.
 References
 **********
 
+.. target-notes::
+
 .. _Relax Kit User Manual:
    https://www.infineon.com/dgdl/Infineon-Board_User_Manual_XMC4700_XMC4800_Relax_Kit_Series-UserManual-v01_04-EN.pdf?fileId=5546d46250cc1fdf01513f8e052d07fc
 

--- a/boards/kincony/kincony_kc868_a32/doc/index.rst
+++ b/boards/kincony/kincony_kc868_a32/doc/index.rst
@@ -94,4 +94,6 @@ Enable Ethernet in KConfig:
 References
 **********
 
+.. target-notes::
+
 .. _KINCONY KC868-A32 User Guide: https://www.kincony.com/arduino-esp32-32-channel-relay-module-kc868-a32.html

--- a/boards/luatos/esp32c3_luatos_core/doc/index.rst
+++ b/boards/luatos/esp32c3_luatos_core/doc/index.rst
@@ -256,6 +256,8 @@ You can debug an application in the usual way. Here is an example for the :zephy
 References
 **********
 
+.. target-notes::
+
 .. [1] https://www.espressif.com/en/products/socs/esp32-c3
 .. _ESP32C3 Core Website: https://wiki.luatos.com/chips/esp32c3/board.html
 .. _ESP32C3 Technical Reference Manual: https://espressif.com/sites/default/files/documentation/esp32-c3_technical_reference_manual_en.pdf

--- a/boards/luatos/esp32s3_luatos_core/doc/index.rst
+++ b/boards/luatos/esp32s3_luatos_core/doc/index.rst
@@ -286,6 +286,8 @@ You can debug an application in the usual way. Here is an example for the :zephy
 References
 **********
 
+.. target-notes::
+
 .. _`ESP32S3-Luatos-Core`: https://wiki.luatos.com/chips/esp32s3/board.html
 .. _`ESP32-S3 Datasheet`: https://www.espressif.com/sites/default/files/documentation/esp32-s3-mini-1_mini-1u_datasheet_en.pdf
 .. _`ESP32-S3 Technical Reference Manual`: https://www.espressif.com/sites/default/files/documentation/esp32-s3_technical_reference_manual_en.pdf

--- a/boards/nuvoton/numaker_m2l31ki/doc/index.rst
+++ b/boards/nuvoton/numaker_m2l31ki/doc/index.rst
@@ -89,6 +89,8 @@ Step through the application in your debugger.
 References
 **********
 
+.. target-notes::
+
 .. _NuMaker M2L31KI User Manual:
    https://www.nuvoton.com/products/microcontrollers/arm-cortex-m23-mcus/m2l31-series/
 .. _M2L31 TRM:

--- a/boards/nuvoton/numaker_pfm_m467/doc/index.rst
+++ b/boards/nuvoton/numaker_pfm_m467/doc/index.rst
@@ -93,6 +93,8 @@ Step through the application in your debugger.
 References
 **********
 
+.. target-notes::
+
 .. _PFM M467 User Manual:
    https://www.nuvoton.com/export/resource-files/UM_NuMaker-PFM-M467_User_Manual_EN_Rev1.01.pdf
 .. _M460 TRM:

--- a/boards/nuvoton/numaker_pfm_m487/doc/index.rst
+++ b/boards/nuvoton/numaker_pfm_m487/doc/index.rst
@@ -92,6 +92,8 @@ Step through the application in your debugger.
 References
 **********
 
+.. target-notes::
+
 .. _PFM M487 User Manual:
    https://www.nuvoton.com/export/resource-files/UM_NuMaker-PFM-M487_User_Manual_EN_Rev1.01.pdf
 .. _M480 TRM:

--- a/boards/nxp/frdm_mcxw71/doc/index.rst
+++ b/boards/nxp/frdm_mcxw71/doc/index.rst
@@ -194,6 +194,8 @@ For more details:
 References
 **********
 
+.. target-notes::
+
 .. _MCXW71 SoC Website:
    https://www.nxp.com/products/processors-and-microcontrollers/arm-microcontrollers/general-purpose-mcus/mcx-arm-cortex-m/mcx-w-series-microcontrollers/mcx-w71x-secure-and-ultra-low-power-mcus-for-matter-thread-zigbee-and-bluetooth-le:MCX-W71X
 

--- a/boards/nxp/rd_rw612_bga/doc/index.rst
+++ b/boards/nxp/rd_rw612_bga/doc/index.rst
@@ -249,5 +249,7 @@ Then, build for the board target ``rd_rw612_bga//ethernet``.
 Resources
 *********
 
+.. target-notes::
+
 .. _RW612 Website:
    https://www.nxp.com/products/wireless-connectivity/wi-fi-plus-bluetooth-plus-802-15-4/wireless-mcu-with-integrated-tri-radiobr1x1-wi-fi-6-plus-bluetooth-low-energy-5-3-802-15-4:RW612

--- a/boards/olimex/olimex_esp32_evb/doc/index.rst
+++ b/boards/olimex/olimex_esp32_evb/doc/index.rst
@@ -256,6 +256,8 @@ You can debug an application in the usual way. Here is an example for the :zephy
 References
 **********
 
+.. target-notes::
+
 .. _ESP32-EVB Website:
    https://www.olimex.com/Products/IoT/ESP32/ESP32-EVB/open-source-hardware
 

--- a/boards/others/icev_wireless/doc/index.rst
+++ b/boards/others/icev_wireless/doc/index.rst
@@ -244,6 +244,8 @@ You can debug an application in the usual way. Here is an example for the
 References
 **********
 
+.. target-notes::
+
 .. _ICE-V Wireless Github Project:
    https://github.com/ICE-V-Wireless/ICE-V-Wireless
 

--- a/boards/phytec/reel_board/doc/index.rst
+++ b/boards/phytec/reel_board/doc/index.rst
@@ -552,6 +552,8 @@ your board.
 References
 **********
 
+.. target-notes::
+
 .. _reel board Website:
    https://www.phytec.de/reelboard/
 

--- a/boards/pjrc/teensy4/doc/index.rst
+++ b/boards/pjrc/teensy4/doc/index.rst
@@ -225,6 +225,8 @@ etc.):
 References
 **********
 
+.. target-notes::
+
 .. _Teensy 4.0 Website:
    https://www.pjrc.com/store/teensy40.html
 

--- a/boards/qemu/cortex_a53/doc/index.rst
+++ b/boards/qemu/cortex_a53/doc/index.rst
@@ -103,6 +103,8 @@ and shell would need to be disabled, therefore this is not directly supported.
 References
 **********
 
+.. target-notes::
+
 1. (ID050815) ARM® Cortex®-A Series - Programmer’s Guide for ARMv8-A
 2. (ID070919) Arm® Architecture Reference Manual - Armv8, for Armv8-A architecture profile
 3. (ARM DAI 0527A) Application Note Bare-metal Boot Code for ARMv8-A Processors

--- a/boards/qemu/cortex_r5/doc/index.rst
+++ b/boards/qemu/cortex_r5/doc/index.rst
@@ -99,6 +99,8 @@ Refer to the detailed overview about :ref:`application_debugging`.
 References
 **********
 
+.. target-notes::
+
 1. ARMv7-A and ARMv7-R Architecture Reference Manual (ARM DDI 0406C ID051414)
 2. Cortex-R5 and Cortex-R5F Technical Reference Manual (ARM DDI 0460C ID021511)
 3. Zynq UltraScale+ Device Technical Reference Manual (UG1085)

--- a/boards/raytac/mdbt53_db_40/doc/index.rst
+++ b/boards/raytac/mdbt53_db_40/doc/index.rst
@@ -259,6 +259,8 @@ boards with a Segger IC.
 References
 **********
 
+.. target-notes::
+
 .. _IDAU:
    https://developer.arm.com/docs/100690/latest/attribution-units-sau-and-idau
 .. _MDBT53-DB-40 website:

--- a/boards/raytac/mdbt53v_db_40/doc/index.rst
+++ b/boards/raytac/mdbt53v_db_40/doc/index.rst
@@ -249,6 +249,8 @@ J-Link OB IF to debug.
 References
 **********
 
+.. target-notes::
+
 .. _IDAU:
    https://developer.arm.com/docs/100690/latest/attribution-units-sau-and-idau
 .. _MDBT53V-DB-40 website:

--- a/boards/renesas/ek_ra2a1/doc/index.rst
+++ b/boards/renesas/ek_ra2a1/doc/index.rst
@@ -101,5 +101,7 @@ Also, see the instructions specific to the debug server that you use.
 References
 **********
 
+.. target-notes::
+
 .. EK-RA2A1 Web site:
    https://www.renesas.com/us/en/products/microcontrollers-microprocessors/ra-cortex-m-mcus/ek-ra2a1-evaluation-kit-ra2a1-mcu-group

--- a/boards/renesas/rzt2m_starterkit/doc/index.rst
+++ b/boards/renesas/rzt2m_starterkit/doc/index.rst
@@ -95,4 +95,6 @@ Connect GDB to the server and load an application:
 References
 **********
 
+.. target-notes::
+
 .. _RZT2M Product page: https://www.renesas.com/us/en/products/microcontrollers-microprocessors/rz-mpus/rzt2m-high-performance-multi-function-mpu-realizing-high-speed-processing-and-high-precision-control

--- a/boards/seeed/xiao_esp32s3/doc/index.rst
+++ b/boards/seeed/xiao_esp32s3/doc/index.rst
@@ -237,6 +237,8 @@ You can debug an application in the usual way. Here is an example for the :zephy
 References
 **********
 
+.. target-notes::
+
 .. _`Seeed Studio XIAO ESP32S3`: https://wiki.seeedstudio.com/xiao_esp32s3_getting_started/
 .. _`JTAG debugging for ESP32-S3`: https://docs.espressif.com/projects/esp-idf/en/latest/esp32s3/api-guides/jtag-debugging/
 .. _`OpenOCD ESP32`: https://github.com/espressif/openocd-esp32/releases

--- a/boards/snps/em_starterkit/doc/index.rst
+++ b/boards/snps/em_starterkit/doc/index.rst
@@ -307,6 +307,8 @@ The following is a list of TODO items:
 References
 **********
 
+.. target-notes::
+
 .. _embARC website: https://www.embarc.org
 
 .. _Designware ARC EM Starter Kit website: https://www.synopsys.com/dw/ipdir.php?ds=arc_em_starter_kit

--- a/boards/snps/hsdk/doc/index.rst
+++ b/boards/snps/hsdk/doc/index.rst
@@ -518,6 +518,8 @@ Release Notes
 References
 **********
 
+.. target-notes::
+
 .. _embARC website: https://www.embarc.org
 
 .. _Designware HS Development Kit website: https://www.synopsys.com/dw/ipdir.php?ds=arc-hs-development-kit

--- a/boards/snps/hsdk4xd/doc/index.rst
+++ b/boards/snps/hsdk4xd/doc/index.rst
@@ -547,6 +547,8 @@ The following list indicates the state of HS4x/HS4xD Development Kit peripherals
 References
 **********
 
+.. target-notes::
+
 .. _embARC website: https://www.embarc.org
 
 .. _Designware HS Development Kit website: https://www.synopsys.com/dw/ipdir.php?ds=arc-hs-development-kit

--- a/boards/snps/iotdk/doc/index.rst
+++ b/boards/snps/iotdk/doc/index.rst
@@ -189,6 +189,8 @@ Release Notes
 References
 **********
 
+.. target-notes::
+
 .. _embARC website: https://www.embarc.org
 
 .. _Designware ARC IoT Development Kit website: https://www.synopsys.com/dw/ipdir.php?ds=arc_iot_development_kit

--- a/boards/snps/nsim/arc_classic/doc/index.rst
+++ b/boards/snps/nsim/arc_classic/doc/index.rst
@@ -333,6 +333,8 @@ For the MWDT toolchain all hardware-specific compiler options are set directly i
 References
 **********
 
+.. target-notes::
+
 .. _Designware ARC nSIM: https://www.synopsys.com/dw/ipdir.php?ds=sim_nsim
 .. _DesignWare ARC Free nSIM: https://www.synopsys.com/cgi-bin/dwarcnsim/req1.cgi
 .. _HAPS: https://www.synopsys.com/verification/prototyping/haps.html

--- a/boards/snps/nsim/arc_v/doc/index.rst
+++ b/boards/snps/nsim/arc_v/doc/index.rst
@@ -193,6 +193,8 @@ on SoC level.
 References
 **********
 
+.. target-notes::
+
 .. _Designware ARC nSIM: https://www.synopsys.com/dw/ipdir.php?ds=sim_nsim
 .. _DesignWare ARC Free nSIM: https://www.synopsys.com/cgi-bin/dwarcnsim/req1.cgi
 .. _HAPS: https://www.synopsys.com/verification/prototyping/haps.html

--- a/boards/ti/cc3235sf_launchxl/doc/index.rst
+++ b/boards/ti/cc3235sf_launchxl/doc/index.rst
@@ -266,6 +266,8 @@ using the TI UniFlash tool for certificate programming.
 References
 **********
 
+.. target-notes::
+
 TI SimpleLink MCUs:
     http://www.ti.com/microcontrollers/simplelink-mcus/overview.html
 

--- a/boards/ti/msp_exp432p401r_launchxl/doc/index.rst
+++ b/boards/ti/msp_exp432p401r_launchxl/doc/index.rst
@@ -133,6 +133,8 @@ build target:
 References
 **********
 
+.. target-notes::
+
 TI MSP432 Wiki:
    https://en.wikipedia.org/wiki/TI_MSP432
 

--- a/boards/vcc-gnd/yd_esp32/doc/index.rst
+++ b/boards/vcc-gnd/yd_esp32/doc/index.rst
@@ -306,6 +306,8 @@ GDB stub is enabled on ESP32.
 References
 **********
 
+.. target-notes::
+
 .. _`ESP32-DevKitC-WROVER`: https://docs.espressif.com/projects/esp-idf/en/stable/esp32/hw-reference/esp32/get-started-devkitc.html#
 .. _`ESP32 Datasheet`: https://www.espressif.com/sites/default/files/documentation/esp32_datasheet_en.pdf
 .. _`ESP32 Technical Reference Manual`: https://espressif.com/sites/default/files/documentation/esp32_technical_reference_manual_en.pdf

--- a/boards/waveshare/esp32s3_touch_lcd_1_28/doc/index.rst
+++ b/boards/waveshare/esp32s3_touch_lcd_1_28/doc/index.rst
@@ -122,6 +122,8 @@ It is the default option when building the application without additional config
 References
 **********
 
+.. target-notes::
+
 .. _ESP32-S3-Touch-LCD-1.28 Waveshare Wiki: https://www.waveshare.com/wiki/ESP32-S3-Touch-LCD-1.28
 .. _ESP32-S3 Datasheet: https://www.espressif.com/sites/default/files/documentation/esp32-s3-mini-1_mini-1u_datasheet_en.pdf
 .. _ESP32-S3 Technical Reference Manual: https://www.espressif.com/sites/default/files/documentation/esp32-s3_technical_reference_manual_en.pdf

--- a/boards/wemos/esp32s2_lolin_mini/doc/index.rst
+++ b/boards/wemos/esp32s2_lolin_mini/doc/index.rst
@@ -91,6 +91,8 @@ message in the monitor:
 References
 **********
 
+.. target-notes::
+
 .. [1] https://www.espressif.com/en/products/socs/esp32-s2
 .. _`ESP32S2 Technical Reference Manual`: https://espressif.com/sites/default/files/documentation/esp32-s2_technical_reference_manual_en.pdf
 .. _`ESP32S2 Datasheet`: https://www.espressif.com/sites/default/files/documentation/esp32-s2_datasheet_en.pdf

--- a/doc/contribute/documentation/guidelines.rst
+++ b/doc/contribute/documentation/guidelines.rst
@@ -655,6 +655,19 @@ you can reference it with::
    Read the `Zephyr Wikipedia Page`_ for more information about the
    project.
 
+.. tip::
+
+   When a document contains many external links, it can be useful to list them in a single
+   "References" section at the end of the document. This can be done using the
+   :rst:dir:`target-notes` directive. Example::
+
+      References
+      ==========
+
+      .. target-notes::
+
+      .. _external_link1: https://example.com
+      .. _external_link2: https://example.org
 
 Cross-referencing C documentation
 =================================
@@ -683,7 +696,6 @@ Cross-referencing C documentation
       Check out :c:func:`gpio_pin_configure` for more information.
 
    You may provide a custom link text, similar to the built-in :rst:role:`ref` role.
-
 
 Visual Elements
 ***************
@@ -1188,3 +1200,9 @@ Boards
 
    This directive is used to generate a catalog of Zephyr-supported boards that can be used to
    quickly browse the list of all supported boards and filter them according to various criteria.
+
+
+References
+**********
+
+.. target-notes::

--- a/samples/drivers/fpga/fpga_controller/README.rst
+++ b/samples/drivers/fpga/fpga_controller/README.rst
@@ -117,5 +117,7 @@ Now the bitstream can be uploaded again.
 References
 **********
 
+.. target-notes::
+
 .. _Quicklogic Quickfeather board:
    https://github.com/QuickLogic-Corp/quick-feather-dev-board

--- a/samples/drivers/video/capture/README.rst
+++ b/samples/drivers/video/capture/README.rst
@@ -107,6 +107,8 @@ Sample Output
 References
 **********
 
+.. target-notes::
+
 .. _Camera iMXRT: https://community.nxp.com/t5/i-MX-RT-Knowledge-Base/Connecting-camera-and-LCD-to-i-MX-RT-EVKs/ta-p/1122183
 .. _MT9M114 camera module: https://www.onsemi.com/PowerSolutions/product.do?id=MT9M114
 .. _OV5640 camera module: https://cdn.sparkfun.com/datasheets/Sensors/LightImaging/OV5640_datasheet.pdf

--- a/samples/drivers/video/capture_to_lvgl/README.rst
+++ b/samples/drivers/video/capture_to_lvgl/README.rst
@@ -70,4 +70,6 @@ Sample Output
 References
 **********
 
+.. target-notes::
+
 .. _WeAct Studio STM32H743: https://github.com/WeActStudio/MiniSTM32H7xx

--- a/samples/drivers/video/tcpserversink/README.rst
+++ b/samples/drivers/video/tcpserversink/README.rst
@@ -64,4 +64,6 @@ For video software generator, the default resolution should be width=320 and hei
 References
 **********
 
+.. target-notes::
+
 .. _MT9M114 camera module: https://www.onsemi.com/PowerSolutions/product.do?id=MT9M114

--- a/samples/modules/lvgl/demos/README.rst
+++ b/samples/modules/lvgl/demos/README.rst
@@ -78,4 +78,6 @@ board argument may also be replaced by ``native_sim/native/64``.
 References
 **********
 
+.. target-notes::
+
 .. _LVGL demos Readme: https://github.com/zephyrproject-rtos/lvgl/blob/zephyr/demos/README.md

--- a/samples/sensor/max17262/README.rst
+++ b/samples/sensor/max17262/README.rst
@@ -53,6 +53,8 @@ This example uses ``picocom`` on the serial port ``/dev/ttyUSB0``:
         V: 3.626406 V; I: -3.437500 mA; T: 28.011718 °C
 
 References
-***********
+**********
+
+.. target-notes::
 
 .. _max17262 datasheet: https://datasheets.maximintegrated.com/en/ds/MAX17262.pdf


### PR DESCRIPTION
For the "References" section to be useful, it needs to include a call to the target-notes directive, which is the one that actually generates the list of references made in the current document.

Update pages that were missing the directive, and update doc writing guidelines to help ensure better usage going forward.

Example of a before/after:

- **BEFORE**: https://docs.zephyrproject.org/latest/boards/espressif/esp32_devkitc_wroom/doc/index.html#references
- **AFTER**: https://builds.zephyrproject.io/zephyr/pr/80165/docs/boards/espressif/esp32_devkitc_wroom/doc/index.html#references
