### PR TITLE
ci: footprint: Fix shopt not found

### DIFF
--- a/.github/workflows/footprint-tracking.yml
+++ b/.github/workflows/footprint-tracking.yml
@@ -95,6 +95,7 @@ jobs:
           aws s3 sync  --quiet footprint_data/ s3://testing.zephyrproject.org/footprint_data/
 
       - name: Transform Footprint data to Twister JSON reports
+        shell: bash
         run: |
           shopt -s globstar
           export ZEPHYR_BASE=${PWD}


### PR DESCRIPTION
Use bash explicitly to have `shopt` available.

https://github.com/zephyrproject-rtos/zephyr/actions/runs/11387394798/job/31681892595#step:13:20