### PR TITLE
reports: footprint: Print footprint output

### DIFF
--- a/cmake/reports/CMakeLists.txt
+++ b/cmake/reports/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 set(flag_for_ram_report ram)
 set(flag_for_rom_report rom)
-set(flag_for_footprint all -q)
+set(flag_for_footprint all)
 set(report_depth 99)
 
 if(DEFINED ZEPHYR_WORKSPACE)


### PR DESCRIPTION
Both ram and rom reports print their outputs in the console and publish their reports in json.

footprint is wrapper to generate both reports but it is currently not printing their outputs in the console nor given any feedback to the user that those reports were generated.

Change it to behave like the others reports allowing the user to see them and / or redirect to a file if they want.