### PR TITLE
drivers: can: select CONFIG_PINCTRL where needed

### DIFF
--- a/drivers/can/Kconfig.esp32
+++ b/drivers/can/Kconfig.esp32
@@ -8,6 +8,7 @@ config CAN_ESP32_TWAI
 	default y
 	depends on DT_HAS_ESPRESSIF_ESP32_TWAI_ENABLED
 	select CAN_SJA1000
+	select PINCTRL
 	help
 	  This enables support for the Espressif Two-Wire Automotive Interface
 	  (TWAI) CAN driver.

--- a/drivers/can/Kconfig.nrf
+++ b/drivers/can/Kconfig.nrf
@@ -7,5 +7,6 @@ config CAN_NRF
 	depends on DT_HAS_NORDIC_NRF_CAN_ENABLED
 	select CAN_MCAN
 	select CLOCK_CONTROL
+	select PINCTRL
 	help
 	  Driver for nRF CAN.

--- a/drivers/can/Kconfig.numaker
+++ b/drivers/can/Kconfig.numaker
@@ -7,6 +7,7 @@ config CAN_NUMAKER
 	bool "Nuvoton NuMaker CAN FD driver"
 	default y
 	select CAN_MCAN
+	select PINCTRL
 	depends on DT_HAS_NUVOTON_NUMAKER_CANFD_ENABLED
 	depends on SOC_SERIES_M46X || SOC_SERIES_M2L31X
 	help

--- a/drivers/can/Kconfig.rcar
+++ b/drivers/can/Kconfig.rcar
@@ -7,6 +7,7 @@ config CAN_RCAR
 	bool "Renesas R-Car CAN Driver"
 	default y
 	depends on DT_HAS_RENESAS_RCAR_CAN_ENABLED
+	select PINCTRL
 	help
 	  Enable Renesas R-Car CAN Driver.
 

--- a/drivers/can/Kconfig.sam
+++ b/drivers/can/Kconfig.sam
@@ -7,3 +7,4 @@ config CAN_SAM
 	default y
 	depends on DT_HAS_ATMEL_SAM_CAN_ENABLED
 	select CAN_MCAN
+	select PINCTRL

--- a/drivers/can/Kconfig.sam0
+++ b/drivers/can/Kconfig.sam0
@@ -7,3 +7,4 @@ config CAN_SAM0
 	default y
 	depends on DT_HAS_ATMEL_SAM0_CAN_ENABLED
 	select CAN_MCAN
+	select PINCTRL

--- a/drivers/can/Kconfig.stm32
+++ b/drivers/can/Kconfig.stm32
@@ -53,6 +53,7 @@ config CAN_STM32_FDCAN
 	default y
 	depends on DT_HAS_ST_STM32_FDCAN_ENABLED
 	select CAN_MCAN
+	select PINCTRL
 	select USE_STM32_LL_RCC
 
 if CAN_STM32_FDCAN
@@ -80,4 +81,5 @@ config CAN_STM32H7_FDCAN
 	default y
 	depends on DT_HAS_ST_STM32H7_FDCAN_ENABLED
 	select CAN_MCAN
+	select PINCTRL
 	select USE_STM32_LL_RCC

--- a/drivers/can/Kconfig.xmc4xxx
+++ b/drivers/can/Kconfig.xmc4xxx
@@ -29,6 +29,7 @@ config CAN_XMC4XXX_RX_FIFO_ITEMS
 
 config CAN_XMC4XXX_INTERNAL_BUS_MODE
 	bool "Internal bus mode"
+	select PINCTRL
 	help
 	  Connects all XMC4XXX CAN devices to an internal bus. Enables
 	  message exchange between MCU CAN devices without any external connectors.


### PR DESCRIPTION
Select CONFIG_PINCTRL for all CAN controller drivers using pinctrl.