### PR TITLE
drivers: i2c: i2c_dw: allow pinctrl configuration to be unspecified

### DIFF
--- a/drivers/i2c/i2c_dw.c
+++ b/drivers/i2c/i2c_dw.c
@@ -1053,7 +1053,10 @@ static int i2c_dw_initialize(const struct device *dev)
 
 #if defined(CONFIG_PINCTRL)
 	ret = pinctrl_apply_state(rom->pcfg, PINCTRL_STATE_DEFAULT);
-	if (ret) {
+	if (ret == -ENOENT) {
+		/* Allow pinctrl configuration to be unspecified. */
+		ret = 0;
+	} else if (ret) {
 		return ret;
 	}
 #endif


### PR DESCRIPTION
Allows the pinctl to be unspecified in the device tree when CONFIG_PINCTRL is enabled for SoCs that have a pinctrl driver, but no pin specific configuration for a particular I2C device.