### PR TITLE
boards: esp32c3: Increase heap when BT is enabled

### DIFF
--- a/boards/espressif/esp32c3_devkitm/Kconfig
+++ b/boards/espressif/esp32c3_devkitm/Kconfig
@@ -3,4 +3,5 @@
 
 config HEAP_MEM_POOL_ADD_SIZE_BOARD
 	int
+	default 32768 if BT
 	default 4096


### PR DESCRIPTION
The default heap is not enough not even to initialize the Bluetooth stack. Increase the memory heap when Bluetooth is selected to be able at least to do basic things.