### PR TITLE
MAINTAINERS: Add Si32 binding header

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3551,6 +3551,7 @@ Silabs SiM3U Platforms:
     - drivers/*/Kconfig.si32
     - dts/arm/silabs/sim3u*
     - dts/bindings/*/*silabs,si32*
+    - include/zephyr/dt-bindings/pinctrl/*si32*
     - soc/silabs/silabs_sim3/
   labels:
     - "platform: Silabs SiM3U"


### PR DESCRIPTION
Without this change, `get_maintainer.py path ...` did not return a SiLabs/SiM3U specific maintainer information when querying for include/zephyr/dt-bindings/pinctrl/si32-pinctrl.h.