### PR TITLE
samples: bluetooth: central_hr/peripheral_hr: Add sysbuild configuration

### DIFF
--- a/samples/bluetooth/central_hr/Kconfig.sysbuild
+++ b/samples/bluetooth/central_hr/Kconfig.sysbuild
@@ -13,3 +13,28 @@ config NET_CORE_IMAGE_HCI_IPC
 	bool "HCI IPC image on network core"
 	default y
 	depends on NET_CORE_BOARD != ""
+
+config BT_CTLR_SCAN_DATA_LEN_MAX
+	int "Scan data length max"
+	default 36
+	depends on TEST_MODE_EXTENDED || TEST_MODE_PHY_CODED
+
+config BT_BUF_EVT_DISCARDABLE_SIZE
+	int "Discardable buffer size"
+	default 58
+	depends on TEST_MODE_EXTENDED || TEST_MODE_PHY_CODED
+
+choice TEST_MODE
+	prompt "Test mode"
+	default TEST_MODE_MINIMAL
+
+config TEST_MODE_MINIMAL
+	bool "Minimal"
+
+config TEST_MODE_EXTENDED
+	bool "Extended"
+
+config TEST_MODE_PHY_CODED
+	bool "PHY coded"
+
+endchoice

--- a/samples/bluetooth/central_hr/sample.yaml
+++ b/samples/bluetooth/central_hr/sample.yaml
@@ -27,7 +27,8 @@ tests:
       - nrf52dk/nrf52832
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
-    extra_args: EXTRA_CONF_FILE=overlay-extended.conf
+    extra_args: SB_CONFIG_TEST_MODE_EXTENDED=y
+    sysbuild: true
     tags: bluetooth
   sample.bluetooth.central_hr.bt_ll_sw_split.phy_coded:
     harness: bluetooth
@@ -43,5 +44,6 @@ tests:
       - nrf52dk/nrf52832
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
-    extra_args: EXTRA_CONF_FILE=overlay-phy_coded.conf
+    extra_args: SB_CONFIG_TEST_MODE_PHY_CODED=y
+    sysbuild: true
     tags: bluetooth

--- a/samples/bluetooth/central_hr/sysbuild.cmake
+++ b/samples/bluetooth/central_hr/sysbuild.cmake
@@ -2,23 +2,55 @@
 # SPDX-License-Identifier: Apache-2.0
 
 if(SB_CONFIG_NET_CORE_IMAGE_HCI_IPC)
-	# For builds in the nrf5340, we build the netcore image with the controller
+  # For builds in the nrf5340, we build the netcore image with the controller
+  set(NET_APP hci_ipc)
+  set(NET_APP_SRC_DIR ${ZEPHYR_BASE}/samples/bluetooth/${NET_APP})
 
-	set(NET_APP hci_ipc)
-	set(NET_APP_SRC_DIR ${ZEPHYR_BASE}/samples/bluetooth/${NET_APP})
+  ExternalZephyrProject_Add(
+    APPLICATION ${NET_APP}
+    SOURCE_DIR  ${NET_APP_SRC_DIR}
+    BOARD       ${SB_CONFIG_NET_CORE_BOARD}
+  )
 
-	ExternalZephyrProject_Add(
-		APPLICATION ${NET_APP}
-		SOURCE_DIR  ${NET_APP_SRC_DIR}
-		BOARD       ${SB_CONFIG_NET_CORE_BOARD}
-	)
+  set(${NET_APP}_CONF_FILE
+      ${NET_APP_SRC_DIR}/nrf5340_cpunet_iso-bt_ll_sw_split.conf
+      CACHE INTERNAL ""
+  )
 
-	set(${NET_APP}_CONF_FILE
-	 ${NET_APP_SRC_DIR}/nrf5340_cpunet_iso-bt_ll_sw_split.conf
-	 CACHE INTERNAL ""
-	)
+  if(SB_CONFIG_TEST_MODE_PHY_CODED)
+    set_config_bool(${NET_APP} CONFIG_BT_CTLR_PHY_CODED y)
+    set_config_bool(${NET_APP} CONFIG_BT_EXT_ADV y)
+  elseif(SB_CONFIG_TEST_MODE_EXTENDED)
+    set_config_bool(${NET_APP} CONFIG_BT_CTLR_PHY_CODED n)
+    set_config_bool(${NET_APP} CONFIG_BT_EXT_ADV y)
+  else()
+    set_config_bool(${NET_APP} CONFIG_BT_CTLR_PHY_CODED n)
+    set_config_bool(${NET_APP} CONFIG_BT_EXT_ADV n)
+  endif()
 
-	native_simulator_set_child_images(${DEFAULT_IMAGE} ${NET_APP})
+  if(SB_CONFIG_TEST_MODE_EXTENDED OR SB_CONFIG_TEST_MODE_PHY_CODED)
+    set_config_int(${NET_APP} CONFIG_BT_CTLR_SCAN_DATA_LEN_MAX ${SB_CONFIG_BT_CTLR_SCAN_DATA_LEN_MAX})
+    set_config_int(${NET_APP} CONFIG_BT_BUF_EVT_DISCARDABLE_SIZE ${SB_CONFIG_BT_BUF_EVT_DISCARDABLE_SIZE})
+  endif()
+
+  native_simulator_set_child_images(${DEFAULT_IMAGE} ${NET_APP})
 endif()
 
 native_simulator_set_final_executable(${DEFAULT_IMAGE})
+
+if(SB_CONFIG_BT_CTLR_PHY_CODED)
+  set_config_bool(${DEFAULT_IMAGE} CONFIG_BT_CTLR_PHY_CODED y)
+  set_config_bool(${DEFAULT_IMAGE} CONFIG_BT_EXT_ADV y)
+  set_config_bool(${DEFAULT_IMAGE} CONFIG_BT_AUTO_PHY_UPDATE n)
+elseif(SB_CONFIG_TEST_MODE_EXTENDED)
+  set_config_bool(${DEFAULT_IMAGE} CONFIG_BT_CTLR_PHY_CODED n)
+  set_config_bool(${DEFAULT_IMAGE} CONFIG_BT_EXT_ADV y)
+else()
+  set_config_bool(${DEFAULT_IMAGE} CONFIG_BT_CTLR_PHY_CODED n)
+  set_config_bool(${DEFAULT_IMAGE} CONFIG_BT_EXT_ADV n)
+endif()
+
+if(SB_CONFIG_TEST_MODE_EXTENDED OR SB_CONFIG_TEST_MODE_PHY_CODED)
+  set_config_int(${DEFAULT_IMAGE} CONFIG_BT_CTLR_SCAN_DATA_LEN_MAX ${SB_CONFIG_BT_CTLR_SCAN_DATA_LEN_MAX})
+  set_config_int(${DEFAULT_IMAGE} CONFIG_BT_BUF_EVT_DISCARDABLE_SIZE ${SB_CONFIG_BT_BUF_EVT_DISCARDABLE_SIZE})
+endif()

--- a/samples/bluetooth/peripheral_hr/Kconfig.sysbuild
+++ b/samples/bluetooth/peripheral_hr/Kconfig.sysbuild
@@ -13,3 +13,28 @@ config NET_CORE_IMAGE_HCI_IPC
 	bool "HCI IPC image on network core"
 	default y
 	depends on NET_CORE_BOARD != ""
+
+config BT_CTLR_SCAN_DATA_LEN_MAX
+	int "Scan data length max"
+	default 36
+	depends on TEST_MODE_EXTENDED || TEST_MODE_PHY_CODED
+
+config BT_BUF_EVT_DISCARDABLE_SIZE
+	int "Discardable buffer size"
+	default 58
+	depends on TEST_MODE_EXTENDED || TEST_MODE_PHY_CODED
+
+choice TEST_MODE
+	prompt "Test mode"
+	default TEST_MODE_MINIMAL
+
+config TEST_MODE_MINIMAL
+	bool "Minimal"
+
+config TEST_MODE_EXTENDED
+	bool "Extended"
+
+config TEST_MODE_PHY_CODED
+	bool "PHY coded"
+
+endchoice

--- a/samples/bluetooth/peripheral_hr/sample.yaml
+++ b/samples/bluetooth/peripheral_hr/sample.yaml
@@ -46,7 +46,8 @@ tests:
       - nrf52dk/nrf52832
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
-    extra_args: EXTRA_CONF_FILE=overlay-extended.conf
+    extra_args: SB_CONFIG_TEST_MODE_EXTENDED=y
+    sysbuild: true
     tags: bluetooth
   sample.bluetooth.peripheral_hr.bt_ll_sw_split.phy_coded:
     harness: bluetooth
@@ -62,7 +63,8 @@ tests:
       - nrf52dk/nrf52832
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
-    extra_args: EXTRA_CONF_FILE=overlay-phy_coded.conf
+    extra_args: SB_CONFIG_TEST_MODE_PHY_CODED=y
+    sysbuild: true
     tags: bluetooth
   sample.bluetooth.peripheral_hr_rv32m1_vega_openisa_rv32m1_ri5cy:
     platform_allow: rv32m1_vega/openisa_rv32m1/ri5cy

--- a/samples/bluetooth/peripheral_hr/sysbuild.cmake
+++ b/samples/bluetooth/peripheral_hr/sysbuild.cmake
@@ -2,23 +2,55 @@
 # SPDX-License-Identifier: Apache-2.0
 
 if(SB_CONFIG_NET_CORE_IMAGE_HCI_IPC)
-	# For builds in the nrf5340, we build the netcore image with the controller
+  # For builds in the nrf5340, we build the netcore image with the controller
+  set(NET_APP hci_ipc)
+  set(NET_APP_SRC_DIR ${ZEPHYR_BASE}/samples/bluetooth/${NET_APP})
 
-	set(NET_APP hci_ipc)
-	set(NET_APP_SRC_DIR ${ZEPHYR_BASE}/samples/bluetooth/${NET_APP})
+  ExternalZephyrProject_Add(
+    APPLICATION ${NET_APP}
+    SOURCE_DIR  ${NET_APP_SRC_DIR}
+    BOARD       ${SB_CONFIG_NET_CORE_BOARD}
+  )
 
-	ExternalZephyrProject_Add(
-		APPLICATION ${NET_APP}
-		SOURCE_DIR  ${NET_APP_SRC_DIR}
-		BOARD       ${SB_CONFIG_NET_CORE_BOARD}
-	)
+  set(${NET_APP}_CONF_FILE
+      ${NET_APP_SRC_DIR}/nrf5340_cpunet_iso-bt_ll_sw_split.conf
+      CACHE INTERNAL ""
+  )
 
-	set(${NET_APP}_CONF_FILE
-	 ${NET_APP_SRC_DIR}/nrf5340_cpunet_iso-bt_ll_sw_split.conf
-	 CACHE INTERNAL ""
-	)
+  if(SB_CONFIG_TEST_MODE_PHY_CODED)
+    set_config_bool(${NET_APP} CONFIG_BT_CTLR_PHY_CODED y)
+    set_config_bool(${NET_APP} CONFIG_BT_EXT_ADV y)
+  elseif(SB_CONFIG_TEST_MODE_EXTENDED)
+    set_config_bool(${NET_APP} CONFIG_BT_CTLR_PHY_CODED n)
+    set_config_bool(${NET_APP} CONFIG_BT_EXT_ADV y)
+  else()
+    set_config_bool(${NET_APP} CONFIG_BT_CTLR_PHY_CODED n)
+    set_config_bool(${NET_APP} CONFIG_BT_EXT_ADV n)
+  endif()
 
-	native_simulator_set_child_images(${DEFAULT_IMAGE} ${NET_APP})
+  if(SB_CONFIG_TEST_MODE_EXTENDED OR SB_CONFIG_TEST_MODE_PHY_CODED)
+    set_config_int(${NET_APP} CONFIG_BT_CTLR_SCAN_DATA_LEN_MAX ${SB_CONFIG_BT_CTLR_SCAN_DATA_LEN_MAX})
+    set_config_int(${NET_APP} CONFIG_BT_BUF_EVT_DISCARDABLE_SIZE ${SB_CONFIG_BT_BUF_EVT_DISCARDABLE_SIZE})
+  endif()
+
+  native_simulator_set_child_images(${DEFAULT_IMAGE} ${NET_APP})
 endif()
 
 native_simulator_set_final_executable(${DEFAULT_IMAGE})
+
+if(SB_CONFIG_BT_CTLR_PHY_CODED)
+  set_config_bool(${DEFAULT_IMAGE} CONFIG_BT_CTLR_PHY_CODED y)
+  set_config_bool(${DEFAULT_IMAGE} CONFIG_BT_EXT_ADV y)
+  set_config_bool(${DEFAULT_IMAGE} CONFIG_BT_AUTO_PHY_UPDATE n)
+elseif(SB_CONFIG_TEST_MODE_EXTENDED)
+  set_config_bool(${DEFAULT_IMAGE} CONFIG_BT_CTLR_PHY_CODED n)
+  set_config_bool(${DEFAULT_IMAGE} CONFIG_BT_EXT_ADV y)
+else()
+  set_config_bool(${DEFAULT_IMAGE} CONFIG_BT_CTLR_PHY_CODED n)
+  set_config_bool(${DEFAULT_IMAGE} CONFIG_BT_EXT_ADV n)
+endif()
+
+if(SB_CONFIG_TEST_MODE_EXTENDED OR SB_CONFIG_TEST_MODE_PHY_CODED)
+  set_config_int(${DEFAULT_IMAGE} CONFIG_BT_CTLR_SCAN_DATA_LEN_MAX ${SB_CONFIG_BT_CTLR_SCAN_DATA_LEN_MAX})
+  set_config_int(${DEFAULT_IMAGE} CONFIG_BT_BUF_EVT_DISCARDABLE_SIZE ${SB_CONFIG_BT_BUF_EVT_DISCARDABLE_SIZE})
+endif()

--- a/tests/bsim/bluetooth/samples/central_hr_peripheral_hr/prj_extended.conf
+++ b/tests/bsim/bluetooth/samples/central_hr_peripheral_hr/prj_extended.conf
@@ -1,5 +1,9 @@
+# From prj.conf
 CONFIG_BT=y
 CONFIG_LOG=y
 CONFIG_BT_CENTRAL=y
 CONFIG_BT_SMP=y
 CONFIG_BT_GATT_CLIENT=y
+
+# Extra for prj_extended.conf
+CONFIG_BT_EXT_ADV=y

--- a/tests/bsim/bluetooth/samples/central_hr_peripheral_hr/tests_scripts/central_hr_peripheral_hr_extended.sh
+++ b/tests/bsim/bluetooth/samples/central_hr_peripheral_hr/tests_scripts/central_hr_peripheral_hr_extended.sh
@@ -11,10 +11,10 @@ EXECUTE_TIMEOUT=60
 
 cd ${BSIM_OUT_PATH}/bin
 
-Execute ./bs_${BOARD_TS}_samples_bluetooth_peripheral_hr_prj_conf_overlay-extended_conf \
+Execute ./bs_${BOARD_TS}_samples_bluetooth_peripheral_hr_prj_conf_FILE_SUFFIX_extended \
   -v=${verbosity_level} -s=${simulation_id} -d=0
 
-Execute ./bs_${BOARD_TS}_${test_long_name}_prj_conf_overlay-extended_conf \
+Execute ./bs_${BOARD_TS}_${test_long_name}_prj_conf_FILE_SUFFIX_extended \
   -v=${verbosity_level} -s=${simulation_id} -d=1 \
   -testid=central_hr_peripheral_hr
 

--- a/tests/bsim/bluetooth/samples/central_hr_peripheral_hr/tests_scripts/central_hr_peripheral_hr_phy_coded.sh
+++ b/tests/bsim/bluetooth/samples/central_hr_peripheral_hr/tests_scripts/central_hr_peripheral_hr_phy_coded.sh
@@ -11,10 +11,10 @@ EXECUTE_TIMEOUT=60
 
 cd ${BSIM_OUT_PATH}/bin
 
-Execute ./bs_${BOARD_TS}_samples_bluetooth_peripheral_hr_prj_conf_overlay-phy_coded_conf \
+Execute ./bs_${BOARD_TS}_samples_bluetooth_peripheral_hr_prj_conf_FILE_SUFFIX_phy_coded \
   -v=${verbosity_level} -s=${simulation_id} -d=0
 
-Execute ./bs_${BOARD_TS}_${test_long_name}_prj_conf_overlay-phy_coded_conf \
+Execute ./bs_${BOARD_TS}_${test_long_name}_prj_conf_FILE_SUFFIX_phy_coded \
   -v=${verbosity_level} -s=${simulation_id} -d=1 \
   -testid=central_hr_peripheral_hr
 

--- a/tests/bsim/bluetooth/samples/compile.sh
+++ b/tests/bsim/bluetooth/samples/compile.sh
@@ -17,25 +17,22 @@ app=samples/bluetooth/peripheral_hr \
   compile
 app=tests/bsim/bluetooth/samples/central_hr_peripheral_hr \
   sysbuild=1 \
-  extra_conf_file=${ZEPHYR_BASE}/samples/bluetooth/central_hr/prj.conf \
   compile
 app=samples/bluetooth/peripheral_hr \
   sysbuild=1 \
-  conf_overlay=overlay-extended.conf \
+  file_suffix=extended \
   compile
 app=tests/bsim/bluetooth/samples/central_hr_peripheral_hr \
   sysbuild=1 \
-  extra_conf_file=${ZEPHYR_BASE}/samples/bluetooth/central_hr/prj.conf \
-  conf_overlay=${ZEPHYR_BASE}/samples/bluetooth/central_hr/overlay-extended.conf \
+  file_suffix=extended \
   compile
 app=samples/bluetooth/peripheral_hr \
   sysbuild=1 \
-  conf_overlay=overlay-phy_coded.conf \
+  file_suffix=phy_coded \
   compile
 app=tests/bsim/bluetooth/samples/central_hr_peripheral_hr \
   sysbuild=1 \
-  extra_conf_file=${ZEPHYR_BASE}/samples/bluetooth/central_hr/prj.conf \
-  conf_overlay=${ZEPHYR_BASE}/samples/bluetooth/central_hr/overlay-phy_coded.conf \
+  file_suffix=phy_coded \
   compile
 if [ ${BOARD} == "nrf52_bsim" ]; then
   app=tests/bsim/bluetooth/samples/battery_service \

--- a/tests/bsim/compile.source
+++ b/tests/bsim/compile.source
@@ -21,6 +21,7 @@ function _compile(){
   local conf_file="${conf_file:-prj.conf}"
   local extra_conf_file="${extra_conf_file:-""}"
   local conf_overlay="${conf_overlay:-""}"
+  local file_suffix="${file_suffix:-""}"
 
   default_cmake_args=(-DCONFIG_COVERAGE=y -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
     -DCONFIG_COMPILER_WARNINGS_AS_ERRORS=y -DCONFIG_ASSERT=y)
@@ -35,6 +36,11 @@ function _compile(){
     local exe_basename="${exe_name:-bs_${BOARD}_${app}_${conf_file}_${overlay_file}}"
   else
     local exe_basename="${exe_name:-bs_${BOARD}_${app}_${conf_file}}"
+  fi
+
+  if [ "${file_suffix}" ]; then
+    cmake_args+=" -DFILE_SUFFIX='${file_suffix}'"
+    exe_basename+="_FILE_SUFFIX_${file_suffix}"
   fi
 
   local exe_basename=$(echo ${exe_basename} | tr \"/\\.\; _ )


### PR DESCRIPTION
    Adds configuration to build this sample through sysbuild


and


    tests: bsim: bluetooth: samples: Update HR to use file suffix
    
    Adds support for bsim and this test to use FILE_SUFFIX to select
    the configuration


A re-imaginaing of https://github.com/zephyrproject-rtos/zephyr/pull/75773/