### PR TITLE
drivers: serial: nrfx_uarte: Add support for device runtime PM and other minor improvements

### DIFF
--- a/drivers/serial/Kconfig.nrfx
+++ b/drivers/serial/Kconfig.nrfx
@@ -31,8 +31,6 @@ config UART_NRFX_UARTE
 config UART_NRFX_UARTE_LEGACY_SHIM
 	bool "Legacy UARTE shim"
 	depends on UART_NRFX_UARTE
-	depends on !SOC_SERIES_NRF54HX || RISCV
-	depends on !SOC_SERIES_NRF92X || RISCV
 	default y
 
 config UART_NRFX_UARTE_ENHANCED_RX

--- a/drivers/serial/Kconfig.nrfx
+++ b/drivers/serial/Kconfig.nrfx
@@ -57,16 +57,6 @@ config UART_ASYNC_TX_CACHE_SIZE
 	  in RAM, because EasyDMA in UARTE peripherals can only transfer data
 	  from RAM.
 
-config UART_NRFX_UARTE_RX_FLUSH_MAGIC_BYTE
-	hex "Byte used for RX FIFO flush workaround"
-	default 0xAA
-	range 0x00 0xFF
-	help
-	  Byte used to fill the buffer before RX FIFO is flushed into it. Due to the
-	  HW anomaly a workaround need to be applied which checks if content of the
-	  buffer changed. There are cases when specific value of the magic byte is
-	  used if it is known that certain bytes are less likely to occur.
-
 if HAS_HW_NRF_UART0 || HAS_HW_NRF_UARTE0
 nrfx_uart_num = 0
 rsource "Kconfig.nrfx_uart_instance"

--- a/drivers/serial/Kconfig.nrfx_uart_instance
+++ b/drivers/serial/Kconfig.nrfx_uart_instance
@@ -68,11 +68,14 @@ config UART_$(nrfx_uart_num)_NRF_ASYNC_LOW_POWER
 	depends on HAS_HW_NRF_UARTE$(nrfx_uart_num)
 	depends on UART_ASYNC_API
 	depends on UART_NRFX_UARTE_LEGACY_SHIM
-	default y
+	default y if !PM_DEVICE
 	help
 	  When enabled, UARTE is enabled before each TX or RX usage and disabled
 	  when not used. Disabling UARTE while in idle allows to achieve lowest
 	  power consumption. It is only feasible if receiver is not always on.
+	  This option is irrelevant when device power management (PM) is enabled
+	  because then device state is controlled by the PM actions.
+
 
 config UART_$(nrfx_uart_num)_NRF_HW_ASYNC_TIMER
 	int "Timer instance"

--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -162,7 +162,6 @@ struct uarte_async_rx {
 	uint8_t flush_cnt;
 	volatile bool enabled;
 	volatile bool discard_fifo;
-	volatile bool aborted;
 };
 
 struct uarte_async_cb {

--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -2187,7 +2187,7 @@ static int uarte_nrfx_pm_action(const struct device *dev,
 #if UARTE_BAUDRATE_RETENTION_WORKAROUND
 		nrf_uarte_baudrate_set(get_uarte_instance(dev),
 			COND_CODE_1(CONFIG_UART_USE_RUNTIME_CONFIGURE,
-				(data->nrf_baudrate), (cfg->nrf_baudrate));
+				(data->nrf_baudrate), (cfg->nrf_baudrate)));
 #endif
 
 #ifdef UARTE_ANY_ASYNC


### PR DESCRIPTION
PR adds:
- support for internal device runtime PM. Driver is internally calling `pm_device_runtime_get/put` when RX or TX activity is started. Additionally, initialization was reworked to call `pm_device_driver_init`.
- improvements in handling RX FIFO flushing. Additional workaround that attempts to detect if there are any bytes in FIFO by checking if RXDRDY event came after ENDRX. Also when PM is used, flushing happens only when UARTE is disabled and not on every RXTO.
- Minor: Fix compilation due to missing closing bracket, removal of unused element in the structure
- Making legacy shim the default for all targets.