### PR TITLE
scripts: Fix CMake spelling

### DIFF
--- a/scripts/pylib/twister/twisterlib/environment.py
+++ b/scripts/pylib/twister/twisterlib/environment.py
@@ -1075,7 +1075,7 @@ class TwisterEnv:
             results = {"returncode": p.returncode, "msg": msg, "stdout": out}
 
         else:
-            logger.error("Cmake script failure: %s" % (args[0]))
+            logger.error("CMake script failure: %s" % (args[0]))
             results = {"returncode": p.returncode, "returnmsg": out}
 
         return results

--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -437,12 +437,12 @@ class CMake:
                     }
         else:
             self.instance.status = TwisterStatus.ERROR
-            self.instance.reason = "Cmake build failure"
+            self.instance.reason = "CMake build failure"
 
             for tc in self.instance.testcases:
                 tc.status = self.instance.status
 
-            logger.error("Cmake build failure: %s for %s" % (self.source_dir, self.platform.name))
+            logger.error("CMake build failure: %s for %s" % (self.source_dir, self.platform.name))
             ret = {"returncode": p.returncode}
 
         if out:
@@ -820,7 +820,7 @@ class ProjectBuilder(FilterBuilder):
                 mode = message.get("mode")
                 if mode == "device":
                     self.cleanup_device_testing_artifacts()
-                elif mode == "passed" or (mode == "all" and self.instance.reason != "Cmake build failure"):
+                elif mode == "passed" or (mode == "all" and self.instance.reason != "CMake build failure"):
                     self.cleanup_artifacts()
             except StatusAttributeError as sae:
                 logger.error(str(sae))

--- a/scripts/tests/twister/test_environment.py
+++ b/scripts/tests/twister/test_environment.py
@@ -488,7 +488,7 @@ TESTDATA_5 = [
         True,
         1,
         b'another\x1B_dummy',
-        'Cmake script failure: dummy/script/path',
+        'CMake script failure: dummy/script/path',
         {
             'returncode': 1,
             'returnmsg': 'anotherdummy'

--- a/scripts/tests/twister/test_runner.py
+++ b/scripts/tests/twister/test_runner.py
@@ -383,7 +383,7 @@ TESTDATA_2_2 = [
     (False, [],
      1, True, 'ERROR: region `FLASH\' overflowed by 123 MB',
      True, False, True,
-     TwisterStatus.ERROR, 'Cmake build failure',
+     TwisterStatus.ERROR, 'CMake build failure',
      [os.path.join('dummy', 'cmake'),
       '-B' + os.path.join('build', 'dir'), '-DTC_RUNID=1', '-DTC_NAME=testcase',
       '-DSB_CONFIG_COMPILER_WARNINGS_AS_ERRORS=n',
@@ -1421,7 +1421,7 @@ TESTDATA_6 = [
     (
         {'op': 'cleanup', 'mode': 'all'},
         mock.ANY,
-        'Cmake build failure',
+        'CMake build failure',
         mock.ANY,
         mock.ANY,
         mock.ANY,

--- a/scripts/tests/twister_blackbox/test_outfile.py
+++ b/scripts/tests/twister_blackbox/test_outfile.py
@@ -15,6 +15,7 @@ import pytest
 import sys
 import tarfile
 
+# pylint: disable=no-name-in-module
 from conftest import ZEPHYR_BASE, TEST_DATA, sample_filename_mock, testsuite_filename_mock
 from twisterlib.testplan import TestPlan
 
@@ -149,7 +150,7 @@ class TestOutfile:
         flag_pattern = r'(?:\S+(?: \\)?)+- '
         cmake_path = shutil.which('cmake')
         if not cmake_path:
-            assert False, 'Cmake not found.'
+            assert False, 'CMake not found.'
 
         cmake_call_section = r'^Calling cmake: ' + re.escape(cmake_path)
         calling_line = re.sub(cmake_call_section, '', calling_line)

--- a/scripts/west_commands/spdx.py
+++ b/scripts/west_commands/spdx.py
@@ -64,7 +64,7 @@ class ZephyrSpdx(WestCommand):
             self.do_run_spdx(args)
 
     def do_run_init(self, args):
-        self.inf("initializing Cmake file-based API prior to build")
+        self.inf("initializing CMake file-based API prior to build")
 
         if not args.build_dir:
             self.die("Build directory not specified; call `west spdx --init --build-dir=BUILD_DIR`")
@@ -74,7 +74,7 @@ class ZephyrSpdx(WestCommand):
         if query_ready:
             self.inf("initialized; run `west build` then run `west spdx`")
         else:
-            self.err("Couldn't create Cmake file-based API query directory")
+            self.err("Couldn't create CMake file-based API query directory")
             self.err("You can manually create an empty file at $BUILDDIR/.cmake/api/v1/query/codemodel-v2")
 
     def do_run_spdx(self, args):


### PR DESCRIPTION
As per its creators, CMake is written with a capital "M".

If approved I'll also fix the spelling in areas other than the scripts folder.

<del>Note: CI (compliance checks) is failing due to what seems unrelated findings? I'd rather not address that in this PR.</del> suppressed