### PR TITLE
manifest: hal_nxp: Pull in change to fix irqsteer mask computation

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -198,7 +198,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: 4a4741fa2be33f6b638a49e357c5e33bb7ad0544
+      revision: ca9c81a06fbd3db10faf708194443511f1eadacb
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
This fixes irq_steer channel mask index computation for i.MX8MP platform.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/80681