### PR TITLE
Adjust timeouts for ipc samples

### DIFF
--- a/samples/drivers/mbox/sample.yaml
+++ b/samples/drivers/mbox/sample.yaml
@@ -3,6 +3,7 @@ sample:
 common:
   sysbuild: true
   tags: mbox
+  timeout: 30
 tests:
   sample.drivers.mbox.real_hw:
     platform_allow:

--- a/samples/subsys/ipc/ipc_service/icmsg/sample.yaml
+++ b/samples/subsys/ipc/ipc_service/icmsg/sample.yaml
@@ -1,5 +1,7 @@
 sample:
   name: IPC Service example integration (icmsg backend)
+common:
+  timeout: 30
 tests:
   sample.ipc.icmsg:
     platform_allow:


### PR DESCRIPTION
30 sec is enough.