### PR TITLE
CI: Upgrade test to ubuntu-24.04

### DIFF
--- a/.github/workflows/pylib_tests.yml
+++ b/.github/workflows/pylib_tests.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.10', '3.11', '3.12', '3.13']
-        os: [ubuntu-22.04]
+        os: [ubuntu-24.04]
     steps:
     - name: checkout
       uses: actions/checkout@v4

--- a/.github/workflows/twister_tests.yml
+++ b/.github/workflows/twister_tests.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.10', '3.11', '3.12', '3.13']
-        os: [ubuntu-22.04]
+        os: [ubuntu-24.04]
     steps:
     - name: checkout
       uses: actions/checkout@v4


### PR DESCRIPTION
Update `pylib_test`,`twister_test` to use `ubuntu-24.04` as it`s GA now. 