### PR TITLE
modules: hostap: add tls_cipher param

### DIFF
--- a/include/zephyr/net/wifi.h
+++ b/include/zephyr/net/wifi.h
@@ -118,6 +118,15 @@ enum wifi_suiteb_type {
 	WIFI_SUITEB_192,
 };
 
+enum wifi_eap_tls_cipher_type {
+	/** EAP TLS with NONE */
+	WIFI_EAP_TLS_NONE,
+	/** EAP TLS with ECDH & ECDSA with p384 */
+	WIFI_EAP_TLS_ECC_P384,
+	/** EAP TLS with ECDH & RSA with > 3K */
+	WIFI_EAP_TLS_RSA_3K,
+};
+
 /** @brief Group cipher and pairwise cipher types. */
 enum wifi_cipher_type {
 	/** AES in counter mode with CBC-MAC (CCMP-128). */

--- a/include/zephyr/net/wifi_mgmt.h
+++ b/include/zephyr/net/wifi_mgmt.h
@@ -540,6 +540,8 @@ struct wifi_connect_req_params {
 	uint8_t key2_passwd_length;
 	/** suiteb or suiteb-192 */
 	uint8_t suiteb_type;
+	/** TLS cipher */
+	uint8_t TLS_cipher;
 	/** eap version */
 	int eap_ver;
 	/** Identity for EAP */

--- a/modules/hostap/src/supp_api.c
+++ b/modules/hostap/src/supp_api.c
@@ -1045,6 +1045,20 @@ static int wpas_add_and_config_network(struct wpa_supplicant *wpa_s,
 				goto out;
 			}
 
+			if (params->suiteb_type == WIFI_SUITEB_192) {
+				if (params->TLS_cipher == WIFI_EAP_TLS_ECC_P384) {
+					if (!wpa_cli_cmd_v("set_network %d openssl_ciphers \"%s\"",
+							resp.network_id,
+							cipher_config.openssl_ciphers))
+						goto out;
+				} else if (params->TLS_cipher == WIFI_EAP_TLS_RSA_3K) {
+					snprintf(phase1, sizeof(phase1), "tls_suiteb=1");
+					if (!wpa_cli_cmd_v("set_network %d phase1 \"%s\"",
+							resp.network_id, &phase1[0]))
+						goto out;
+				}
+			}
+
 			if (!wpa_cli_cmd_v("set_network %d key_mgmt %s", resp.network_id,
 					   cipher_config.key_mgmt)) {
 				goto out;

--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -580,6 +580,7 @@ static int __wifi_args_to_params(const struct shell *sh, size_t argc, char *argv
 		{"key1-pwd", required_argument, 0, 'K'},
 		{"key2-pwd", required_argument, 0, 'K'},
 		{"suiteb-type", required_argument, 0, 'S'},
+		{"TLS-cipher", required_argument, 0, 'T'},
 		{"eap-version", required_argument, 0, 'V'},
 		{"eap-id1", required_argument, 0, 'I'},
 		{"eap-id2", required_argument, 0, 'I'},
@@ -626,7 +627,7 @@ static int __wifi_args_to_params(const struct shell *sh, size_t argc, char *argv
 	params->ignore_broadcast_ssid = 0;
 	params->bandwidth = WIFI_FREQ_BANDWIDTH_20MHZ;
 
-	while ((opt = getopt_long(argc, argv, "s:p:k:e:w:b:c:m:t:a:B:K:S:V:I:P:i:Rh",
+	while ((opt = getopt_long(argc, argv, "s:p:k:e:w:b:c:m:t:a:B:K:S:T:V:I:P:i:Rh",
 				  long_options, &opt_index)) != -1) {
 		state = getopt_state_get();
 		switch (opt) {
@@ -784,6 +785,9 @@ static int __wifi_args_to_params(const struct shell *sh, size_t argc, char *argv
 			break;
 		case 'S':
 			params->suiteb_type = atoi(state->optarg);
+			break;
+		case 'T':
+			params->TLS_cipher = atoi(state->optarg);
 			break;
 		case 'V':
 			params->eap_ver = atoi(state->optarg);
@@ -3406,6 +3410,7 @@ SHELL_SUBCMD_ADD((wifi), connect, NULL,
 		  "[-K, --key1-pwd for eap phase1 or --key2-pwd for eap phase2]:\n"
 		  "Private key passwd for enterprise mode. Default no password for private key.\n"
 		  "[-S, --suiteb-type]: 1:suiteb, 2:suiteb-192. Default 0: not suiteb mode.\n"
+		  "[-T, --TLS-cipher]: 0:TLS-NONE, 1:TLS-ECC-P384, 2:TLS-RSA-3K.\n"
 		  "[-V, --eap-version]: 0 or 1. Default 1: eap version 1.\n"
 		  "[-I, --eap-id1]: Client Identity. Default no eap identity.\n"
 		  "[-P, --eap-pwd1]: Client Password.\n"


### PR DESCRIPTION
Add tls_cipher param for client WPA3 enterprise suiteb-192. Add parameter "-T" to specify tls_cipher:
Specify "-T 1": client use ECC P384.
Specify "-T 2": client use RSA 3K.