### PR TITLE
Bluetooth: Audio: Remove BT_AUDIO_BROADCAST_CODE_SIZE

### DIFF
--- a/doc/releases/migration-guide-4.0.rst
+++ b/doc/releases/migration-guide-4.0.rst
@@ -395,6 +395,9 @@ Bluetooth Audio
   instances of :c:func:`bt_cap_initiator_broadcast_get_id` and
   :c:func:`bt_bap_broadcast_source_get_id` has been removed(:github:`80228`)
 
+* ``BT_AUDIO_BROADCAST_CODE_SIZE`` has been removed and ``BT_ISO_BROADCAST_CODE_SIZE`` should be
+  used instead. (:github:`80217`)
+
 Bluetooth Classic
 =================
 

--- a/include/zephyr/bluetooth/audio/audio.h
+++ b/include/zephyr/bluetooth/audio/audio.h
@@ -49,9 +49,6 @@ extern "C" {
 #define BT_AUDIO_PD_MAX                          0xFFFFFFU
 /** Indicates that the unicast server does not have a preference for any retransmission number */
 #define BT_AUDIO_RTN_PREF_NONE                   0xFFU
-/** Maximum size of the broadcast code in octets */
-#define BT_AUDIO_BROADCAST_CODE_SIZE             16
-
 /** The minimum size of a Broadcast Name as defined by Bluetooth Assigned Numbers */
 #define BT_AUDIO_BROADCAST_NAME_LEN_MIN          4
 /** The maximum size of a Broadcast Name as defined by Bluetooth Assigned Numbers */

--- a/include/zephyr/bluetooth/audio/bap.h
+++ b/include/zephyr/bluetooth/audio/bap.h
@@ -572,7 +572,7 @@ struct bt_bap_scan_delegator_recv_state {
 	 *
 	 * Only valid if encrypt_state is @ref BT_BAP_BIG_ENC_STATE_BCODE_REQ
 	 */
-	uint8_t bad_code[BT_AUDIO_BROADCAST_CODE_SIZE];
+	uint8_t bad_code[BT_ISO_BROADCAST_CODE_SIZE];
 
 	/** Number of subgroups */
 	uint8_t num_subgroups;
@@ -652,7 +652,7 @@ struct bt_bap_scan_delegator_cb {
 	 */
 	void (*broadcast_code)(struct bt_conn *conn,
 			       const struct bt_bap_scan_delegator_recv_state *recv_state,
-			       const uint8_t broadcast_code[BT_AUDIO_BROADCAST_CODE_SIZE]);
+			       const uint8_t broadcast_code[BT_ISO_BROADCAST_CODE_SIZE]);
 	/**
 	 * @brief Broadcast Isochronous Stream synchronize request
 	 *
@@ -2058,7 +2058,7 @@ struct bt_bap_broadcast_source_param {
 	 *   The string "Broadcast Code" shall be
 	 *   [42 72 6F 61 64 63 61 73 74 20 43 6F 64 65 00 00]
 	 */
-	uint8_t broadcast_code[BT_AUDIO_BROADCAST_CODE_SIZE];
+	uint8_t broadcast_code[BT_ISO_BROADCAST_CODE_SIZE];
 
 #if defined(CONFIG_BT_ISO_TEST_PARAMS) || defined(__DOXYGEN__)
 	/**
@@ -2298,7 +2298,8 @@ int bt_bap_broadcast_sink_create(struct bt_le_per_adv_sync *pa_sync, uint32_t br
  * @return 0 in case of success or negative value in case of error.
  */
 int bt_bap_broadcast_sink_sync(struct bt_bap_broadcast_sink *sink, uint32_t indexes_bitfield,
-			       struct bt_bap_stream *streams[], const uint8_t broadcast_code[16]);
+			       struct bt_bap_stream *streams[],
+			       const uint8_t broadcast_code[BT_ISO_BROADCAST_CODE_SIZE]);
 
 /**
  * @brief Stop audio broadcast sink.
@@ -2799,7 +2800,7 @@ int bt_bap_broadcast_assistant_mod_src(
  */
 int bt_bap_broadcast_assistant_set_broadcast_code(
 	struct bt_conn *conn, uint8_t src_id,
-	const uint8_t broadcast_code[BT_AUDIO_BROADCAST_CODE_SIZE]);
+	const uint8_t broadcast_code[BT_ISO_BROADCAST_CODE_SIZE]);
 
 /**
  * @brief Remove a source from the server.

--- a/include/zephyr/bluetooth/audio/cap.h
+++ b/include/zephyr/bluetooth/audio/cap.h
@@ -482,7 +482,7 @@ struct bt_cap_initiator_broadcast_create_param {
 	 *   The string "Broadcast Code" shall be
 	 *   [42 72 6F 61 64 63 61 73 74 20 43 6F 64 65 00 00]
 	 */
-	uint8_t broadcast_code[BT_AUDIO_BROADCAST_CODE_SIZE];
+	uint8_t broadcast_code[BT_ISO_BROADCAST_CODE_SIZE];
 
 #if defined(CONFIG_BT_ISO_TEST_PARAMS) || defined(__DOXYGEN__)
 	/**

--- a/samples/bluetooth/bap_broadcast_sink/src/main.c
+++ b/samples/bluetooth/bap_broadcast_sink/src/main.c
@@ -148,7 +148,7 @@ static const struct bt_audio_codec_cap codec_cap = BT_AUDIO_CODEC_CAP_LC3(
 static const uint32_t bis_index_mask = BIT_MASK(ARRAY_SIZE(streams));
 static uint32_t requested_bis_sync;
 static uint32_t bis_index_bitfield;
-static uint8_t sink_broadcast_code[BT_AUDIO_BROADCAST_CODE_SIZE];
+static uint8_t sink_broadcast_code[BT_ISO_BROADCAST_CODE_SIZE];
 
 uint64_t total_rx_iso_packet_count; /* This value is exposed to test code */
 
@@ -966,13 +966,13 @@ static int pa_sync_term_req_cb(struct bt_conn *conn,
 
 static void broadcast_code_cb(struct bt_conn *conn,
 			      const struct bt_bap_scan_delegator_recv_state *recv_state,
-			      const uint8_t broadcast_code[BT_AUDIO_BROADCAST_CODE_SIZE])
+			      const uint8_t broadcast_code[BT_ISO_BROADCAST_CODE_SIZE])
 {
 	printk("Broadcast code received for %p\n", recv_state);
 
 	req_recv_state = recv_state;
 
-	(void)memcpy(sink_broadcast_code, broadcast_code, BT_AUDIO_BROADCAST_CODE_SIZE);
+	(void)memcpy(sink_broadcast_code, broadcast_code, BT_ISO_BROADCAST_CODE_SIZE);
 
 	k_sem_give(&sem_broadcast_code_received);
 }

--- a/samples/bluetooth/bap_broadcast_source/src/main.c
+++ b/samples/bluetooth/bap_broadcast_source/src/main.c
@@ -27,8 +27,7 @@
 #include <zephyr/sys_clock.h>
 #include <zephyr/toolchain.h>
 
-BUILD_ASSERT(strlen(CONFIG_BROADCAST_CODE) <= BT_AUDIO_BROADCAST_CODE_SIZE,
-	     "Invalid broadcast code");
+BUILD_ASSERT(strlen(CONFIG_BROADCAST_CODE) <= BT_ISO_BROADCAST_CODE_SIZE, "Invalid broadcast code");
 
 /* Zephyr Controller works best while Extended Advertising interval to be a multiple
  * of the ISO Interval minus 10 ms (max. advertising random delay). This is

--- a/samples/bluetooth/cap_acceptor/src/cap_acceptor_broadcast.c
+++ b/samples/bluetooth/cap_acceptor/src/cap_acceptor_broadcast.c
@@ -54,7 +54,7 @@ ATOMIC_DEFINE(flags, FLAG_NUM);
 
 static struct broadcast_sink {
 	const struct bt_bap_scan_delegator_recv_state *req_recv_state;
-	uint8_t sink_broadcast_code[BT_AUDIO_BROADCAST_CODE_SIZE];
+	uint8_t sink_broadcast_code[BT_ISO_BROADCAST_CODE_SIZE];
 	struct bt_bap_broadcast_sink *bap_broadcast_sink;
 	struct bt_cap_stream broadcast_stream;
 	struct bt_le_per_adv_sync *pa_sync;
@@ -424,14 +424,14 @@ static int pa_sync_term_req_cb(struct bt_conn *conn,
 
 static void broadcast_code_cb(struct bt_conn *conn,
 			      const struct bt_bap_scan_delegator_recv_state *recv_state,
-			      const uint8_t broadcast_code[BT_AUDIO_BROADCAST_CODE_SIZE])
+			      const uint8_t broadcast_code[BT_ISO_BROADCAST_CODE_SIZE])
 {
 	LOG_INF("Broadcast code received for %p", recv_state);
 
 	broadcast_sink.req_recv_state = recv_state;
 
 	(void)memcpy(broadcast_sink.sink_broadcast_code, broadcast_code,
-		     BT_AUDIO_BROADCAST_CODE_SIZE);
+		     BT_ISO_BROADCAST_CODE_SIZE);
 
 	atomic_set_bit(flags, FLAG_BROADCAST_CODE_RECEIVED);
 }

--- a/subsys/bluetooth/audio/bap_broadcast_assistant.c
+++ b/subsys/bluetooth/audio/bap_broadcast_assistant.c
@@ -24,6 +24,7 @@
 #include <zephyr/bluetooth/gatt.h>
 #include <zephyr/bluetooth/att.h>
 #include <zephyr/bluetooth/hci_types.h>
+#include <zephyr/bluetooth/iso.h>
 #include <zephyr/bluetooth/l2cap.h>
 #include <zephyr/bluetooth/buf.h>
 #include <zephyr/bluetooth/uuid.h>
@@ -262,8 +263,7 @@ static int parse_recv_state(const void *data, uint16_t length,
 			return BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
 		}
 
-		broadcast_code = net_buf_simple_pull_mem(&buf,
-							 BT_AUDIO_BROADCAST_CODE_SIZE);
+		broadcast_code = net_buf_simple_pull_mem(&buf, BT_ISO_BROADCAST_CODE_SIZE);
 		(void)memcpy(recv_state->bad_code, broadcast_code,
 			     sizeof(recv_state->bad_code));
 	}
@@ -1446,7 +1446,7 @@ int bt_bap_broadcast_assistant_mod_src(struct bt_conn *conn,
 
 int bt_bap_broadcast_assistant_set_broadcast_code(
 	struct bt_conn *conn, uint8_t src_id,
-	const uint8_t broadcast_code[BT_AUDIO_BROADCAST_CODE_SIZE])
+	const uint8_t broadcast_code[BT_ISO_BROADCAST_CODE_SIZE])
 {
 	struct bt_bap_bass_cp_broadcase_code *cp;
 	struct bap_broadcast_assistant_instance *inst;
@@ -1479,10 +1479,9 @@ int bt_bap_broadcast_assistant_set_broadcast_code(
 	cp->opcode = BT_BAP_BASS_OP_BROADCAST_CODE;
 	cp->src_id = src_id;
 
-	(void)memcpy(cp->broadcast_code, broadcast_code,
-		     BT_AUDIO_BROADCAST_CODE_SIZE);
+	(void)memcpy(cp->broadcast_code, broadcast_code, BT_ISO_BROADCAST_CODE_SIZE);
 
-	LOG_HEXDUMP_DBG(cp->broadcast_code, BT_AUDIO_BROADCAST_CODE_SIZE, "broadcast code:");
+	LOG_HEXDUMP_DBG(cp->broadcast_code, BT_ISO_BROADCAST_CODE_SIZE, "broadcast code:");
 
 	return bt_bap_broadcast_assistant_common_cp(conn, &att_buf);
 }

--- a/subsys/bluetooth/audio/bap_broadcast_sink.c
+++ b/subsys/bluetooth/audio/bap_broadcast_sink.c
@@ -1157,7 +1157,8 @@ int bt_bap_broadcast_sink_create(struct bt_le_per_adv_sync *pa_sync, uint32_t br
 }
 
 int bt_bap_broadcast_sink_sync(struct bt_bap_broadcast_sink *sink, uint32_t indexes_bitfield,
-			       struct bt_bap_stream *streams[], const uint8_t broadcast_code[16])
+			       struct bt_bap_stream *streams[],
+			       const uint8_t broadcast_code[BT_ISO_BROADCAST_CODE_SIZE])
 {
 	struct bt_iso_big_sync_param param;
 	struct bt_audio_codec_cfg *codec_cfgs[CONFIG_BT_BAP_BROADCAST_SNK_STREAM_COUNT] = {NULL};

--- a/subsys/bluetooth/audio/bap_endpoint.h
+++ b/subsys/bluetooth/audio/bap_endpoint.h
@@ -122,7 +122,7 @@ struct bt_bap_broadcast_source {
 	/* The codec specific configured data for each stream in the subgroup */
 	struct bt_audio_broadcast_stream_data stream_data[BROADCAST_STREAM_CNT];
 #endif /* CONFIG_BT_AUDIO_CODEC_CFG_MAX_DATA_SIZE > 0 */
-	uint8_t broadcast_code[BT_AUDIO_BROADCAST_CODE_SIZE];
+	uint8_t broadcast_code[BT_ISO_BROADCAST_CODE_SIZE];
 
 	/* The complete codec specific configured data for each stream in the subgroup.
 	 * This contains both the subgroup and the BIS-specific data for each stream.

--- a/subsys/bluetooth/audio/bap_internal.h
+++ b/subsys/bluetooth/audio/bap_internal.h
@@ -78,7 +78,7 @@ struct bt_bap_bass_cp_mod_src {
 struct bt_bap_bass_cp_broadcase_code {
 	uint8_t opcode;
 	uint8_t src_id;
-	uint8_t broadcast_code[16];
+	uint8_t broadcast_code[BT_ISO_BROADCAST_CODE_SIZE];
 } __packed;
 
 struct bt_bap_bass_cp_rem_src {

--- a/subsys/bluetooth/audio/bap_scan_delegator.c
+++ b/subsys/bluetooth/audio/bap_scan_delegator.c
@@ -24,6 +24,7 @@
 #include <zephyr/bluetooth/gap.h>
 #include <zephyr/bluetooth/gatt.h>
 #include <zephyr/bluetooth/hci_types.h>
+#include <zephyr/bluetooth/iso.h>
 #include <zephyr/bluetooth/l2cap.h>
 #include <zephyr/bluetooth/buf.h>
 #include <zephyr/bluetooth/uuid.h>
@@ -67,7 +68,7 @@ struct bass_recv_state_internal {
 	bool active;
 	uint8_t index;
 	struct bt_bap_scan_delegator_recv_state state;
-	uint8_t broadcast_code[BT_AUDIO_BROADCAST_CODE_SIZE];
+	uint8_t broadcast_code[BT_ISO_BROADCAST_CODE_SIZE];
 	struct bt_le_per_adv_sync *pa_sync;
 	/** Requested BIS sync bitfield for each subgroup */
 	uint32_t requested_bis_sync[CONFIG_BT_BAP_BASS_MAX_SUBGROUPS];

--- a/subsys/bluetooth/audio/cap_initiator.c
+++ b/subsys/bluetooth/audio/cap_initiator.c
@@ -186,9 +186,9 @@ static void cap_initiator_broadcast_to_bap_broadcast_param(
 	bap_param->encryption = cap_param->encryption;
 	if (bap_param->encryption) {
 		memcpy(bap_param->broadcast_code, cap_param->broadcast_code,
-		       BT_AUDIO_BROADCAST_CODE_SIZE);
+		       BT_ISO_BROADCAST_CODE_SIZE);
 	} else {
-		memset(bap_param->broadcast_code, 0, BT_AUDIO_BROADCAST_CODE_SIZE);
+		memset(bap_param->broadcast_code, 0, BT_ISO_BROADCAST_CODE_SIZE);
 	}
 
 	for (size_t i = 0U; i < bap_param->params_count; i++) {

--- a/subsys/bluetooth/audio/shell/bap.c
+++ b/subsys/bluetooth/audio/shell/bap.c
@@ -3528,7 +3528,7 @@ static int cmd_create_sink_by_name(const struct shell *sh, size_t argc, char *ar
 static int cmd_sync_broadcast(const struct shell *sh, size_t argc, char *argv[])
 {
 	struct bt_bap_stream *streams[ARRAY_SIZE(broadcast_sink_streams)];
-	uint8_t bcode[BT_AUDIO_BROADCAST_CODE_SIZE] = {0};
+	uint8_t bcode[BT_ISO_BROADCAST_CODE_SIZE] = {0};
 	bool bcode_set = false;
 	uint32_t bis_bitfield;
 	size_t stream_cnt;

--- a/subsys/bluetooth/audio/shell/bap_broadcast_assistant.c
+++ b/subsys/bluetooth/audio/shell/bap_broadcast_assistant.c
@@ -139,8 +139,7 @@ static void bap_broadcast_assistant_recv_state_cb(
 	}
 
 	bt_addr_le_to_str(&state->addr, le_addr, sizeof(le_addr));
-	bin2hex(state->bad_code, BT_AUDIO_BROADCAST_CODE_SIZE,
-		bad_code, sizeof(bad_code));
+	bin2hex(state->bad_code, BT_ISO_BROADCAST_CODE_SIZE, bad_code, sizeof(bad_code));
 
 	is_bad_code = state->encrypt_state == BT_BAP_BIG_ENC_STATE_BAD_CODE;
 	shell_print(ctx_shell,
@@ -1041,7 +1040,7 @@ static int cmd_bap_broadcast_assistant_add_pa_sync(const struct shell *sh,
 static int cmd_bap_broadcast_assistant_broadcast_code(const struct shell *sh,
 						      size_t argc, char **argv)
 {
-	uint8_t broadcast_code[BT_AUDIO_BROADCAST_CODE_SIZE] = { 0 };
+	uint8_t broadcast_code[BT_ISO_BROADCAST_CODE_SIZE] = {0};
 	size_t broadcast_code_len;
 	unsigned long src_id;
 	int result = 0;
@@ -1060,7 +1059,7 @@ static int cmd_bap_broadcast_assistant_broadcast_code(const struct shell *sh,
 	}
 
 	broadcast_code_len = strlen(argv[2]);
-	if (!IN_RANGE(broadcast_code_len, 1, BT_AUDIO_BROADCAST_CODE_SIZE)) {
+	if (!IN_RANGE(broadcast_code_len, 1, BT_ISO_BROADCAST_CODE_SIZE)) {
 		shell_error(sh, "Invalid broadcast code length: %zu", broadcast_code_len);
 
 		return -ENOEXEC;

--- a/subsys/bluetooth/audio/shell/bap_scan_delegator.c
+++ b/subsys/bluetooth/audio/shell/bap_scan_delegator.c
@@ -21,6 +21,7 @@
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/gap.h>
 #include <zephyr/bluetooth/gatt.h>
+#include <zephyr/bluetooth/iso.h>
 #include <zephyr/bluetooth/uuid.h>
 #include <zephyr/kernel.h>
 #include <zephyr/shell/shell.h>
@@ -45,7 +46,7 @@ static struct sync_state {
 	struct bt_conn *conn;
 	struct bt_le_per_adv_sync *pa_sync;
 	const struct bt_bap_scan_delegator_recv_state *recv_state;
-	uint8_t broadcast_code[BT_AUDIO_BROADCAST_CODE_SIZE];
+	uint8_t broadcast_code[BT_ISO_BROADCAST_CODE_SIZE];
 } sync_states[CONFIG_BT_BAP_SCAN_DELEGATOR_RECV_STATE_COUNT];
 
 static bool past_preference = true;
@@ -335,12 +336,12 @@ static int pa_sync_term_req_cb(struct bt_conn *conn,
 
 static void broadcast_code_cb(struct bt_conn *conn,
 			      const struct bt_bap_scan_delegator_recv_state *recv_state,
-			      const uint8_t broadcast_code[BT_AUDIO_BROADCAST_CODE_SIZE])
+			      const uint8_t broadcast_code[BT_ISO_BROADCAST_CODE_SIZE])
 {
 	struct sync_state *state;
 
 	shell_info(ctx_shell, "Broadcast code received for %p", recv_state);
-	shell_hexdump(ctx_shell, broadcast_code, BT_AUDIO_BROADCAST_CODE_SIZE);
+	shell_hexdump(ctx_shell, broadcast_code, BT_ISO_BROADCAST_CODE_SIZE);
 
 	state = sync_state_get(recv_state);
 	if (state == NULL) {
@@ -349,7 +350,7 @@ static void broadcast_code_cb(struct bt_conn *conn,
 		return;
 	}
 
-	(void)memcpy(state->broadcast_code, broadcast_code, BT_AUDIO_BROADCAST_CODE_SIZE);
+	(void)memcpy(state->broadcast_code, broadcast_code, BT_ISO_BROADCAST_CODE_SIZE);
 }
 
 static int bis_sync_req_cb(struct bt_conn *conn,

--- a/tests/bluetooth/tester/src/audio/btp/btp_bap.h
+++ b/tests/bluetooth/tester/src/audio/btp/btp_bap.h
@@ -167,7 +167,7 @@ struct btp_bap_modify_broadcast_src_cmd {
 struct btp_bap_set_broadcast_code_cmd {
 	bt_addr_le_t address;
 	uint8_t src_id;
-	uint8_t broadcast_code[BT_AUDIO_BROADCAST_CODE_SIZE];
+	uint8_t broadcast_code[BT_ISO_BROADCAST_CODE_SIZE];
 } __packed;
 
 #define BTP_BAP_SEND_PAST			0x18

--- a/tests/bluetooth/tester/src/audio/btp/btp_cap.h
+++ b/tests/bluetooth/tester/src/audio/btp/btp_cap.h
@@ -97,7 +97,7 @@ struct btp_cap_broadcast_source_setup_cmd {
 	uint16_t max_transport_latency;
 	uint8_t presentation_delay[3];
 	uint8_t flags;
-	uint8_t broadcast_code[BT_AUDIO_BROADCAST_CODE_SIZE];
+	uint8_t broadcast_code[BT_ISO_BROADCAST_CODE_SIZE];
 } __packed;
 struct btp_cap_broadcast_source_setup_rp {
 	uint8_t source_id;

--- a/tests/bluetooth/tester/src/audio/btp_bap_broadcast.c
+++ b/tests/bluetooth/tester/src/audio/btp_bap_broadcast.c
@@ -939,7 +939,7 @@ static int pa_sync_term_req_cb(struct bt_conn *conn,
 
 static void broadcast_code_cb(struct bt_conn *conn,
 			      const struct bt_bap_scan_delegator_recv_state *recv_state,
-			      const uint8_t broadcast_code[BT_AUDIO_BROADCAST_CODE_SIZE])
+			      const uint8_t broadcast_code[BT_ISO_BROADCAST_CODE_SIZE])
 {
 	int err;
 	uint32_t index_bitfield;
@@ -955,8 +955,7 @@ static void broadcast_code_cb(struct bt_conn *conn,
 	}
 
 	broadcaster->sink_recv_state = recv_state;
-	(void)memcpy(broadcaster->sink_broadcast_code, broadcast_code,
-		     BT_AUDIO_BROADCAST_CODE_SIZE);
+	(void)memcpy(broadcaster->sink_broadcast_code, broadcast_code, BT_ISO_BROADCAST_CODE_SIZE);
 
 	if (!broadcaster->requested_bis_sync) {
 		return;

--- a/tests/bluetooth/tester/src/audio/btp_bap_broadcast.h
+++ b/tests/bluetooth/tester/src/audio/btp_bap_broadcast.h
@@ -36,7 +36,7 @@ struct btp_bap_broadcast_remote_source {
 	/* BIS Index bitfield read from sync request */
 	uint32_t requested_bis_sync;
 	bool assistant_request;
-	uint8_t sink_broadcast_code[BT_AUDIO_BROADCAST_CODE_SIZE];
+	uint8_t sink_broadcast_code[BT_ISO_BROADCAST_CODE_SIZE];
 	const struct bt_bap_scan_delegator_recv_state *sink_recv_state;
 };
 

--- a/tests/bsim/bluetooth/audio/src/bap_broadcast_assistant_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_broadcast_assistant_test.c
@@ -116,7 +116,7 @@ static void bap_broadcast_assistant_recv_state_cb(
 	const struct bt_bap_scan_delegator_recv_state *state)
 {
 	char le_addr[BT_ADDR_LE_STR_LEN];
-	char bad_code[BT_AUDIO_BROADCAST_CODE_SIZE * 2 + 1];
+	char bad_code[BT_ISO_BROADCAST_CODE_SIZE * 2 + 1];
 
 	if (err != 0) {
 		FAIL("BASS recv state read failed (%d)\n", err);
@@ -131,8 +131,7 @@ static void bap_broadcast_assistant_recv_state_cb(
 	}
 
 	bt_addr_le_to_str(&state->addr, le_addr, sizeof(le_addr));
-	(void)bin2hex(state->bad_code, BT_AUDIO_BROADCAST_CODE_SIZE, bad_code,
-		      sizeof(bad_code));
+	(void)bin2hex(state->bad_code, BT_ISO_BROADCAST_CODE_SIZE, bad_code, sizeof(bad_code));
 	printk("BASS recv state: src_id %u, addr %s, sid %u, sync_state %u, encrypt_state %u%s%s\n",
 	       state->src_id, le_addr, state->adv_sid, state->pa_sync_state, state->encrypt_state,
 	       state->encrypt_state == BT_BAP_BIG_ENC_STATE_BAD_CODE ? ", bad code: " : "",
@@ -142,8 +141,8 @@ static void bap_broadcast_assistant_recv_state_cb(
 		SET_FLAG(flag_broadcast_code_requested);
 	} else if (state->encrypt_state == BT_BAP_BIG_ENC_STATE_BAD_CODE) {
 		SET_FLAG(flag_incorrect_broadcast_code);
-		if (memcmp(state->bad_code, INCORRECT_BROADCAST_CODE,
-			   BT_AUDIO_BROADCAST_CODE_SIZE) != 0) {
+		if (memcmp(state->bad_code, INCORRECT_BROADCAST_CODE, BT_ISO_BROADCAST_CODE_SIZE) !=
+		    0) {
 			FAIL("Bad code is not what we sent");
 			return;
 		}
@@ -518,7 +517,7 @@ static void test_bass_mod_source_long_meta(void)
 	printk("Server PA synced\n");
 }
 
-static void test_bass_broadcast_code(const uint8_t broadcast_code[BT_AUDIO_BROADCAST_CODE_SIZE])
+static void test_bass_broadcast_code(const uint8_t broadcast_code[BT_ISO_BROADCAST_CODE_SIZE])
 {
 	int err;
 

--- a/tests/bsim/bluetooth/audio/src/bap_broadcast_sink_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_broadcast_sink_test.c
@@ -59,7 +59,7 @@ static struct bt_bap_stream *streams[ARRAY_SIZE(broadcast_sink_streams)];
 static uint32_t requested_bis_sync;
 static struct bt_le_ext_adv *ext_adv;
 static const struct bt_bap_scan_delegator_recv_state *req_recv_state;
-static uint8_t recv_state_broadcast_code[BT_AUDIO_BROADCAST_CODE_SIZE];
+static uint8_t recv_state_broadcast_code[BT_ISO_BROADCAST_CODE_SIZE];
 
 #define SUPPORTED_CHAN_COUNTS          BT_AUDIO_CODEC_CAP_CHAN_COUNT_SUPPORT(1, 2)
 #define SUPPORTED_MIN_OCTETS_PER_FRAME 30
@@ -403,11 +403,11 @@ static int bis_sync_req_cb(struct bt_conn *conn,
 
 static void broadcast_code_cb(struct bt_conn *conn,
 			      const struct bt_bap_scan_delegator_recv_state *recv_state,
-			      const uint8_t broadcast_code[BT_AUDIO_BROADCAST_CODE_SIZE])
+			      const uint8_t broadcast_code[BT_ISO_BROADCAST_CODE_SIZE])
 {
 	req_recv_state = recv_state;
 
-	memcpy(recv_state_broadcast_code, broadcast_code, BT_AUDIO_BROADCAST_CODE_SIZE);
+	memcpy(recv_state_broadcast_code, broadcast_code, BT_ISO_BROADCAST_CODE_SIZE);
 }
 
 static void scanning_state_cb(struct bt_conn *conn, bool is_scanning)
@@ -775,7 +775,7 @@ static void test_broadcast_sink_create_inval(void)
 	}
 }
 
-static void test_broadcast_sync(const uint8_t broadcast_code[BT_AUDIO_BROADCAST_CODE_SIZE])
+static void test_broadcast_sync(const uint8_t broadcast_code[BT_ISO_BROADCAST_CODE_SIZE])
 {
 	int err;
 

--- a/tests/bsim/bluetooth/audio/src/bap_scan_delegator_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_scan_delegator_test.c
@@ -48,7 +48,7 @@ struct sync_state {
 	bool pa_syncing;
 	struct k_work_delayable pa_timer;
 	struct bt_le_per_adv_sync *pa_sync;
-	uint8_t broadcast_code[BT_AUDIO_BROADCAST_CODE_SIZE];
+	uint8_t broadcast_code[BT_ISO_BROADCAST_CODE_SIZE];
 	uint32_t bis_sync_req[CONFIG_BT_BAP_BASS_MAX_SUBGROUPS];
 } sync_states[CONFIG_BT_BAP_SCAN_DELEGATOR_RECV_STATE_COUNT];
 
@@ -300,7 +300,7 @@ static int pa_sync_term_req_cb(struct bt_conn *conn,
 
 static void broadcast_code_cb(struct bt_conn *conn,
 			      const struct bt_bap_scan_delegator_recv_state *recv_state,
-			      const uint8_t broadcast_code[BT_AUDIO_BROADCAST_CODE_SIZE])
+			      const uint8_t broadcast_code[BT_ISO_BROADCAST_CODE_SIZE])
 {
 	struct sync_state *state;
 
@@ -312,7 +312,7 @@ static void broadcast_code_cb(struct bt_conn *conn,
 		return;
 	}
 
-	(void)memcpy(state->broadcast_code, broadcast_code, BT_AUDIO_BROADCAST_CODE_SIZE);
+	(void)memcpy(state->broadcast_code, broadcast_code, BT_ISO_BROADCAST_CODE_SIZE);
 
 	SET_FLAG(flag_broadcast_code_received);
 }

--- a/tests/bsim/bluetooth/audio/src/cap_acceptor_test.c
+++ b/tests/bsim/bluetooth/audio/src/cap_acceptor_test.c
@@ -414,7 +414,7 @@ static int bis_sync_req_cb(struct bt_conn *conn,
 
 static void broadcast_code_cb(struct bt_conn *conn,
 			      const struct bt_bap_scan_delegator_recv_state *recv_state,
-			      const uint8_t broadcast_code[BT_AUDIO_BROADCAST_CODE_SIZE])
+			      const uint8_t broadcast_code[BT_ISO_BROADCAST_CODE_SIZE])
 {
 	printk("Broadcast code received for %p\n", recv_state);
 

--- a/tests/bsim/bluetooth/audio/src/cap_commander_test.c
+++ b/tests/bsim/bluetooth/audio/src/cap_commander_test.c
@@ -23,6 +23,7 @@
 #include <zephyr/bluetooth/gap.h>
 #include <zephyr/bluetooth/gatt.h>
 #include <zephyr/bluetooth/hci_types.h>
+#include <zephyr/bluetooth/iso.h>
 #include <zephyr/bluetooth/uuid.h>
 #include <zephyr/kernel.h>
 #include <zephyr/net_buf.h>
@@ -426,7 +427,7 @@ bap_broadcast_assistant_recv_state_cb(struct bt_conn *conn, int err,
 				      const struct bt_bap_scan_delegator_recv_state *state)
 {
 	char le_addr[BT_ADDR_LE_STR_LEN];
-	char bad_code[BT_AUDIO_BROADCAST_CODE_SIZE * 2 + 1];
+	char bad_code[BT_ISO_BROADCAST_CODE_SIZE * 2 + 1];
 
 	if (err != 0) {
 		FAIL("BASS recv state read failed (%d)\n", err);
@@ -439,7 +440,7 @@ bap_broadcast_assistant_recv_state_cb(struct bt_conn *conn, int err,
 	}
 
 	bt_addr_le_to_str(&state->addr, le_addr, sizeof(le_addr));
-	(void)bin2hex(state->bad_code, BT_AUDIO_BROADCAST_CODE_SIZE, bad_code, sizeof(bad_code));
+	(void)bin2hex(state->bad_code, BT_ISO_BROADCAST_CODE_SIZE, bad_code, sizeof(bad_code));
 	printk("BASS recv state: src_id %u, addr %s, sid %u, sync_state %u, "
 	       "encrypt_state %u%s%s\n",
 	       state->src_id, le_addr, state->adv_sid, state->pa_sync_state, state->encrypt_state,


### PR DESCRIPTION
Removed the LE Audio specific definition and instead refer to the value defined by iso.h as it is ISO/Core that defines this size, and not BAP/Audio.