### PR TITLE
net: sockets: Cleanup socket properly if POSIX API is enabled

### DIFF
--- a/include/zephyr/sys/fdtable.h
+++ b/include/zephyr/sys/fdtable.h
@@ -64,7 +64,10 @@ struct fd_op_vtable {
 		ssize_t (*write)(void *obj, const void *buf, size_t sz);
 		ssize_t (*write_offs)(void *obj, const void *buf, size_t sz, size_t offset);
 	};
-	int (*close)(void *obj);
+	union {
+		int (*close)(void *obj);
+		int (*close2)(void *obj, int fd);
+	};
 	int (*ioctl)(void *obj, unsigned int request, va_list args);
 };
 

--- a/subsys/net/lib/sockets/sockets_internal.h
+++ b/subsys/net/lib/sockets/sockets_internal.h
@@ -15,7 +15,7 @@
 #define SOCK_NONBLOCK 2
 #define SOCK_ERROR 4
 
-int zsock_close_ctx(struct net_context *ctx);
+int zsock_close_ctx(struct net_context *ctx, int sock);
 int zsock_poll_internal(struct zsock_pollfd *fds, int nfds, k_timeout_t timeout);
 
 int zsock_wait_data(struct net_context *ctx, k_timeout_t *timeout);

--- a/subsys/net/lib/sockets/sockets_packet.c
+++ b/subsys/net/lib/sockets/sockets_packet.c
@@ -462,16 +462,16 @@ static int packet_sock_setsockopt_vmeth(void *obj, int level, int optname,
 	return zpacket_setsockopt_ctx(obj, level, optname, optval, optlen);
 }
 
-static int packet_sock_close_vmeth(void *obj)
+static int packet_sock_close2_vmeth(void *obj, int fd)
 {
-	return zsock_close_ctx(obj);
+	return zsock_close_ctx(obj, fd);
 }
 
 static const struct socket_op_vtable packet_sock_fd_op_vtable = {
 	.fd_vtable = {
 		.read = packet_sock_read_vmeth,
 		.write = packet_sock_write_vmeth,
-		.close = packet_sock_close_vmeth,
+		.close2 = packet_sock_close2_vmeth,
 		.ioctl = packet_sock_ioctl_vmeth,
 	},
 	.bind = packet_sock_bind_vmeth,


### PR DESCRIPTION
The sock_obj_core_dealloc() was not called if close() is called instead of zsock_close(). This happens if POSIX API is enabled.

Fix this by calling zvfs_close() from zsock_close() and then pass the socket number to zsock_close_ctx() so that the cleanup can be done properly.

Reported-by: Andreas Ålgård <aal@ixys.no>

Fixes #80997