### PR TITLE
Bug: Fix AGT renesas prefix properties

### DIFF
--- a/drivers/counter/counter_renesas_ra_agt.c
+++ b/drivers/counter/counter_renesas_ra_agt.c
@@ -552,14 +552,14 @@ static const struct counter_driver_api ra_agt_driver_api = {
 			},                                                                         \
 		.agtio_filter = AGT_AGTIO_FILTER_NONE,                                             \
 		.measurement_mode = 0U,                                                            \
-		.source_div = DT_PROP(TIMER(n), prescaler),                                        \
-		.count_source = DT_STRING_TOKEN(TIMER(n), count_source),                           \
+		.source_div = DT_PROP(TIMER(n), renesas_prescaler),                                \
+		.count_source = DT_STRING_TOKEN(TIMER(n), renesas_count_source),                   \
 		.channel = DT_PROP(TIMER(n), channel),                                             \
 		.channel_irq = DT_IRQ_BY_NAME(TIMER(n), agtcmai, irq),                             \
 		.channel_ipl = DT_IRQ_BY_NAME(TIMER(n), agtcmai, priority),                        \
 		.cycle_end_irq = DT_IRQ_BY_NAME(TIMER(n), agti, irq),                              \
 		.cycle_end_ipl = DT_IRQ_BY_NAME(TIMER(n), agti, priority),                         \
-		.resolution = DT_PROP(TIMER(n), resolution),                                       \
+		.resolution = DT_PROP(TIMER(n), renesas_resolution),                               \
 		.dt_reg = DT_REG_ADDR(TIMER(n)),                                                   \
 	};                                                                                         \
                                                                                                    \

--- a/dts/arm/renesas/ra/ra8/ra8x1.dtsi
+++ b/dts/arm/renesas/ra/ra8/ra8x1.dtsi
@@ -494,7 +494,7 @@
 			status = "okay";
 		};
 
-		agt0: agt0@40221000 {
+		agt0: agt@40221000 {
 			compatible = "renesas,ra-agt";
 			channel = <0>;
 			reg = <0x40221000 0x100>;
@@ -511,7 +511,7 @@
 			};
 		};
 
-		agt1: agt0@40221100 {
+		agt1: agt@40221100 {
 			compatible = "renesas,ra-agt";
 			channel = <1>;
 			reg = <0x40221100 0x100>;

--- a/samples/drivers/counter/alarm/boards/ek_ra8d1.overlay
+++ b/samples/drivers/counter/alarm/boards/ek_ra8d1.overlay
@@ -6,7 +6,7 @@
 
 &agt0 {
 	status = "okay";
-	prescaler = <4>;
+	renesas,prescaler = <4>;
 	counter0: counter {
 		status = "okay";
 	};

--- a/samples/drivers/counter/alarm/boards/ek_ra8m1.overlay
+++ b/samples/drivers/counter/alarm/boards/ek_ra8m1.overlay
@@ -6,7 +6,7 @@
 
 &agt0 {
 	status = "okay";
-	prescaler = <4>;
+	renesas,prescaler = <4>;
 	counter0: counter {
 		status = "okay";
 	};

--- a/samples/drivers/counter/alarm/boards/mck_ra8t1.overlay
+++ b/samples/drivers/counter/alarm/boards/mck_ra8t1.overlay
@@ -6,7 +6,7 @@
 
 &agt0 {
 	status = "okay";
-	prescaler = <4>;
+	renesas,prescaler = <4>;
 	counter0: counter {
 		status = "okay";
 	};


### PR DESCRIPTION
- Modify the macro that is used in source code AGT to get the right data from the device tree
- Modify the name of agt node in RA8 device tree
- Modify the name of the `prescaler` property of RA8 in `samples/drivers/counter/alarm/`
Bug PR: #76141 