### PR TITLE
MAINTAINERS: Add rugeGerritsen to BT host as collaborator

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -359,8 +359,9 @@ Bluetooth Host:
     - alwa-nordic
   collaborators:
     - hermabe
-    - Thalley
+    - rugeGerritsen
     - sjanc
+    - Thalley
     - theob-pro
   files:
     - doc/connectivity/bluetooth/
@@ -506,6 +507,7 @@ Bluetooth ISO:
   collaborators:
     - jhedberg
     - kruithofa
+    - rugeGerritsen
   files:
     - include/zephyr/bluetooth/iso.h
     - doc/connectivity/bluetooth/api/shell/iso.rst


### PR DESCRIPTION
Add Rubin Gerritsen as collaborator to the BT host and BT ISO.
He has been very active in these areas.
See for more info:
https://github.com/zephyrproject-rtos/zephyr/issues/80233

List the host collaborators in alphabetical order while at it.