### PR TITLE
ci: footprint: Fix missing globstar

### DIFF
--- a/.github/workflows/footprint-tracking.yml
+++ b/.github/workflows/footprint-tracking.yml
@@ -28,6 +28,9 @@ jobs:
     container:
       image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.26.14.20240823
       options: '--entrypoint /bin/bash'
+    defaults:
+      run:
+        shell: bash
     strategy:
       fail-fast: false
     env:
@@ -95,7 +98,6 @@ jobs:
           aws s3 sync  --quiet footprint_data/ s3://testing.zephyrproject.org/footprint_data/
 
       - name: Transform Footprint data to Twister JSON reports
-        shell: bash
         run: |
           shopt -s globstar
           export ZEPHYR_BASE=${PWD}
@@ -110,6 +112,7 @@ jobs:
           ELASTICSEARCH_SERVER: "https://elasticsearch.zephyrproject.io:443"
           ELASTICSEARCH_INDEX: ${{ vars.FOOTPRINT_TRACKING_INDEX }}
         run: |
+          shopt -s globstar
           pip3 install -U elasticsearch
           run_date=`date --iso-8601=minutes`
           python3 ./scripts/ci/upload_test_results_es.py -r ${run_date} \


### PR DESCRIPTION
Add missing `globstar` wildcard option.

To fix
`FileNotFoundError: [Errno 2] No such file or directory: './footprint_data/**/twister_footprint.json'`
 https://github.com/zephyrproject-rtos/zephyr/actions/runs/11459954282/job/31885588961#step:14:58