### PR TITLE
drivers: wifi: eswifi: fix casts for 64 bit pointers

### DIFF
--- a/drivers/wifi/eswifi/eswifi_socket_offload.c
+++ b/drivers/wifi/eswifi/eswifi_socket_offload.c
@@ -28,7 +28,7 @@ LOG_MODULE_DECLARE(LOG_MODULE_NAME);
  * a special meaning in the fdtable subsys.
  */
 #define SD_TO_OBJ(sd) ((void *)(sd + 1))
-#define OBJ_TO_SD(obj) (((int)obj) - 1)
+#define OBJ_TO_SD(obj) (((intptr_t)obj) - 1)
 /* Default socket context (50CE) */
 #define ESWIFI_INIT_CONTEXT	INT_TO_POINTER(0x50CE)
 
@@ -55,7 +55,7 @@ static void __process_received(struct net_context *context,
 static int eswifi_socket_connect(void *obj, const struct sockaddr *addr,
 				 socklen_t addrlen)
 {
-	int sock = OBJ_TO_SD(obj);
+	intptr_t sock = OBJ_TO_SD(obj);
 	struct eswifi_off_socket *socket;
 	int ret;
 
@@ -94,7 +94,7 @@ static int eswifi_socket_connect(void *obj, const struct sockaddr *addr,
 static int eswifi_socket_listen(void *obj, int backlog)
 {
 	struct eswifi_off_socket *socket;
-	int sock = OBJ_TO_SD(obj);
+	intptr_t sock = OBJ_TO_SD(obj);
 	int ret;
 
 	eswifi_lock(eswifi);
@@ -107,7 +107,7 @@ static int eswifi_socket_listen(void *obj, int backlog)
 }
 
 void __eswifi_socket_accept_cb(struct net_context *context, struct sockaddr *addr,
-			       unsigned int len, int val, void *data)
+			       size_t len, int val, void *data)
 {
 	struct sockaddr *addr_target = data;
 
@@ -117,7 +117,7 @@ void __eswifi_socket_accept_cb(struct net_context *context, struct sockaddr *add
 static int __eswifi_socket_accept(void *obj, struct sockaddr *addr,
 				  socklen_t *addrlen)
 {
-	int sock = OBJ_TO_SD(obj);
+	intptr_t sock = OBJ_TO_SD(obj);
 	struct eswifi_off_socket *socket;
 	int ret;
 
@@ -146,7 +146,7 @@ static int eswifi_socket_accept(void *obj, struct sockaddr *addr,
 				socklen_t *addrlen)
 {
 	int fd = zvfs_reserve_fd();
-	int sock;
+	intptr_t sock;
 
 	if (fd < 0) {
 		return -1;
@@ -240,7 +240,7 @@ static int map_credentials(int sd, const void *optval, socklen_t optlen)
 static int eswifi_socket_setsockopt(void *obj, int level, int optname,
 				    const void *optval, socklen_t optlen)
 {
-	int sd = OBJ_TO_SD(obj);
+	intptr_t sd = OBJ_TO_SD(obj);
 	int ret;
 
 	if (IS_ENABLED(CONFIG_NET_SOCKETS_SOCKOPT_TLS) && level == SOL_TLS) {
@@ -265,7 +265,7 @@ static int eswifi_socket_setsockopt(void *obj, int level, int optname,
 static ssize_t eswifi_socket_send(void *obj, const void *buf, size_t len,
 				  int flags)
 {
-	int sock = OBJ_TO_SD(obj);
+	intptr_t sock = OBJ_TO_SD(obj);
 	struct eswifi_off_socket *socket;
 	int ret;
 	int offset;
@@ -320,7 +320,7 @@ static ssize_t eswifi_socket_sendto(void *obj, const void *buf, size_t len,
 static ssize_t eswifi_socket_recv(void *obj, void *buf, size_t max_len,
 				  int flags)
 {
-	int sock = OBJ_TO_SD(obj);
+	intptr_t sock = OBJ_TO_SD(obj);
 	struct eswifi_off_socket *socket;
 	int len = 0, ret = 0;
 	struct net_pkt *pkt;
@@ -400,7 +400,7 @@ static ssize_t eswifi_socket_recvfrom(void *obj, void *buf, size_t len,
 
 static int eswifi_socket_close(void *obj)
 {
-	int sock = OBJ_TO_SD(obj);
+	intptr_t sock = OBJ_TO_SD(obj);
 	struct eswifi_off_socket *socket;
 	struct net_pkt *pkt;
 	int ret;
@@ -467,7 +467,8 @@ static int eswifi_socket_poll(struct zsock_pollfd *fds, int nfds, int msecs)
 {
 	struct eswifi_off_socket *socket;
 	k_timeout_t timeout;
-	int sock, ret;
+	intptr_t sock;
+	int ret;
 	void *obj;
 
 	if (nfds != 1) {
@@ -540,7 +541,7 @@ done:
 static int eswifi_socket_bind(void *obj, const struct sockaddr *addr,
 			      socklen_t addrlen)
 {
-	int sock = OBJ_TO_SD(obj);
+	intptr_t sock = OBJ_TO_SD(obj);
 	struct eswifi_off_socket *socket;
 	int ret;
 
@@ -582,7 +583,7 @@ static bool eswifi_socket_is_supported(int family, int type, int proto)
 int eswifi_socket_create(int family, int type, int proto)
 {
 	int fd = zvfs_reserve_fd();
-	int sock;
+	intptr_t sock;
 
 	if (fd < 0) {
 		return -1;


### PR DESCRIPTION
The eswifi driver uses an integer to identify the socket used for each connection, which must be cast to and from a `void *`. This causes warnings on 64 bit platforms, as precision is lost when casting from a `void *` to `int`. Use a `uintptr_t` type to store the socket value to resolve this warning. Also, fix a function signature for the `accept_cb` to use `size_t` instead of `int` for the length

Fixes #80242