### PR TITLE
drivers: display: ssd1322: fix non working display writing

### DIFF
--- a/drivers/display/ssd1322.c
+++ b/drivers/display/ssd1322.c
@@ -358,7 +358,9 @@ static struct display_driver_api ssd1322_driver_api = {
 };
 
 #define SSD1322_CONV_BUFFER_SIZE(node_id)                                                          \
-	(DT_PROP(node_id, width) * DT_PROP(node_id, segments_per_pixel) * 4)
+	DIV_ROUND_UP(DT_PROP(node_id, width) * DT_PROP(node_id, height) *                          \
+			     DT_PROP(node_id, segments_per_pixel),                                 \
+		     SEGMENTS_PER_BYTE)
 
 #define SSD1322_DEFINE(node_id)                                                                    \
 	static uint8_t conversion_buf##node_id[SSD1322_CONV_BUFFER_SIZE(node_id)];                 \

--- a/drivers/display/ssd1322.c
+++ b/drivers/display/ssd1322.c
@@ -107,7 +107,7 @@ static int ssd1322_conv_mono01_grayscale(const uint8_t **buf_in, uint32_t *pixel
 	}
 
 	buf_in += pixels_in_chunk / 8;
-	pixel_count -= pixels_in_chunk;
+	*pixel_count -= pixels_in_chunk;
 	return pixels_in_chunk * segments_per_pixel / 2;
 }
 


### PR DESCRIPTION
Fixes couple of bugs:

- A call to ssd1322_write_pixels was never returning
- In case more than one segment per pixel is required, only part of the segments were written resulting in low and uneven pixel brightness (at least on NHD-2.7-12864WDW3)
- The internal mono01 to 4bit grayscale conversion buffer size was not computed correctly resulting in only the first chunk of the desired image being displayed repeatedly over the screen height

Tested on a NHD-2.7-12864WDW3 display.

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/80834