### PR TITLE
Bluetooth: Controller: Accept CIS create using normalized cis_offset

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_llcp.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp.c
@@ -1214,15 +1214,30 @@ void ull_cp_cc_accept(struct ll_conn *conn, uint32_t cis_offset_min)
 
 	ctx = llcp_rr_peek(conn);
 	if (ctx && ctx->proc == PROC_CIS_CREATE) {
-		if (cis_offset_min > ctx->data.cis_create.cis_offset_min) {
-			if (cis_offset_min > ctx->data.cis_create.cis_offset_max) {
+		uint32_t conn_interval_us;
+		uint32_t offset_min;
+
+		offset_min = ctx->data.cis_create.cis_offset_min;
+		conn_interval_us = conn->lll.interval * CONN_INT_UNIT_US;
+		while (offset_min > conn_interval_us) {
+			offset_min -= conn_interval_us;
+		}
+
+		if (cis_offset_min > offset_min) {
+			offset_min = cis_offset_min;
+			cis_offset_min = ctx->data.cis_create.cis_offset_min;
+			while (offset_min < cis_offset_min) {
+				offset_min += conn_interval_us;
+			}
+
+			if (offset_min > ctx->data.cis_create.cis_offset_max) {
 				ctx->data.cis_create.error = BT_HCI_ERR_UNSUPP_LL_PARAM_VAL;
 				llcp_rp_cc_reject(conn, ctx);
 
 				return;
 			}
 
-			ctx->data.cis_create.cis_offset_min = cis_offset_min;
+			ctx->data.cis_create.cis_offset_min = offset_min;
 		}
 
 		llcp_rp_cc_accept(conn, ctx);


### PR DESCRIPTION
Calculate the cis_offset_min relative to connection interval value, so that at the instant we still honour the minimum supported CIS offset in our local implementation.