### PR TITLE
llext: rename symbol struct identifiers with SLID

### DIFF
--- a/include/zephyr/llext/symbol.h
+++ b/include/zephyr/llext/symbol.h
@@ -123,10 +123,10 @@ struct llext_symtable {
 /* SLID-enabled LLEXT application: export symbols, names in separate section */
 #define Z_EXPORT_SYMBOL(x)							\
 	static const char Z_GENERIC_SECTION("llext_exports_strtab") __used	\
-		x ## _sym_name[] = STRINGIFY(x);				\
+		__llext_sym_name_ ## x[] = STRINGIFY(x);				\
 	static const STRUCT_SECTION_ITERABLE(llext_const_symbol,                \
 					     __llext_sym_ ## x) = {	        \
-		.name = x ## _sym_name, .addr = (const void *)&x,		\
+		.name = __llext_sym_name_ ## x, .addr = (const void *)&x,		\
 	}
 #elif defined(CONFIG_LLEXT)
 /* LLEXT application: export symbols */


### PR DESCRIPTION
Similar to commit aeec014cbe5ff4d93b128fb6f218c41965ffac3b, this renames the identifiers to have prefix of "__llext_sym_name_" instead of having suffix of "_sym_name" in LLEXT symbol tables for SLID-enabled applications. This is needed to avoid confusing the gen_device_deps.py script as it searches for objects (e.g. __device_dts_ord_*) by matching name stems without regard to suffixes.

Relates to https://github.com/zephyrproject-rtos/zephyr/pull/79260