### PR TITLE
tests: benchmarks/latency: limit CPU to 1 for Intel ADSP ACE

### DIFF
--- a/tests/benchmarks/latency_measure/boards/intel_adsp_ace15_mtpm_sim.conf
+++ b/tests/benchmarks/latency_measure/boards/intel_adsp_ace15_mtpm_sim.conf
@@ -1,0 +1,6 @@
+# Due to addition of busy threads running on other cores,
+# and the simulator runs in single thread bouncing through
+# all cores, we are wasting quite a bit of time just busy
+# waiting. This makes each simulator run too long for CI.
+# So limit CPU number to 1.
+CONFIG_MP_MAX_NUM_CPUS=1

--- a/tests/benchmarks/latency_measure/boards/intel_adsp_ace20_lnl_sim.conf
+++ b/tests/benchmarks/latency_measure/boards/intel_adsp_ace20_lnl_sim.conf
@@ -1,0 +1,6 @@
+# Due to addition of busy threads running on other cores,
+# and the simulator runs in single thread bouncing through
+# all cores, we are wasting quite a bit of time just busy
+# waiting. This makes each simulator run too long for CI.
+# So limit CPU number to 1.
+CONFIG_MP_MAX_NUM_CPUS=1

--- a/tests/benchmarks/latency_measure/boards/intel_adsp_ace30_ptl_sim.conf
+++ b/tests/benchmarks/latency_measure/boards/intel_adsp_ace30_ptl_sim.conf
@@ -1,0 +1,6 @@
+# Due to addition of busy threads running on other cores,
+# and the simulator runs in single thread bouncing through
+# all cores, we are wasting quite a bit of time just busy
+# waiting. This makes each simulator run too long for CI.
+# So limit CPU number to 1.
+CONFIG_MP_MAX_NUM_CPUS=1


### PR DESCRIPTION
Due to addition of busy threads running on other cores, and the simulator runs in single thread bouncing through all cores, we are wasting quite a bit of time just busy waiting. This makes each simulator run too long for CI. So limit CPU number to 1.