### PR TITLE
drivers: ethernet: add get_phy callback for stm32 driver

### DIFF
--- a/drivers/ethernet/eth_stm32_hal_priv.h
+++ b/drivers/ethernet/eth_stm32_hal_priv.h
@@ -32,6 +32,7 @@ struct eth_stm32_hal_dev_cfg {
 	struct stm32_pclken pclken_ptp;
 #endif
 	const struct pinctrl_dev_config *pcfg;
+	const struct device *phy_dev;
 };
 
 /* Device run time data */


### PR DESCRIPTION
Adds a `get_phy` callback for the Ethernet API in STM32 driver.