### PR TITLE
drivers: flash: flash_mcux_flexspi: add support for W25Q512JV

### DIFF
--- a/boards/nxp/frdm_rw612/frdm_rw612.dts
+++ b/boards/nxp/frdm_rw612/frdm_rw612.dts
@@ -71,7 +71,7 @@
 		status = "okay";
 		erase-block-size = <4096>;
 		write-block-size = <1>;
-		spi-max-frequency = <133000000>;
+		spi-max-frequency = <104000000>;
 	};
 	aps6404l: aps6404l@2 {
 			compatible = "nxp,imx-flexspi-aps6404l";


### PR DESCRIPTION
 Add support for the W25Q512JV with the FLEXSPI, using a custom LUT table.
