### PR TITLE
drivers: esp32: Fix esp_wifi_drv strncpy warning

### DIFF
--- a/drivers/wifi/esp32/src/esp_wifi_drv.c
+++ b/drivers/wifi/esp32/src/esp_wifi_drv.c
@@ -735,6 +735,7 @@ static int esp32_wifi_status(const struct device *dev, struct wifi_iface_status 
 
 	strncpy(status->ssid, data->status.ssid, WIFI_SSID_MAX_LEN);
 	status->ssid_len = strnlen(data->status.ssid, WIFI_SSID_MAX_LEN);
+	status->ssid[status->ssid_len] = '\0';
 	status->band = WIFI_FREQ_BAND_2_4_GHZ;
 	status->link_mode = WIFI_LINK_MODE_UNKNOWN;
 	status->mfp = WIFI_MFP_DISABLE;

--- a/include/zephyr/net/wifi_mgmt.h
+++ b/include/zephyr/net/wifi_mgmt.h
@@ -419,7 +419,7 @@ struct wifi_scan_params {
  */
 struct wifi_scan_result {
 	/** SSID */
-	uint8_t ssid[WIFI_SSID_MAX_LEN];
+	uint8_t ssid[WIFI_SSID_MAX_LEN + 1];
 	/** SSID length */
 	uint8_t ssid_length;
 	/** Frequency band */
@@ -576,7 +576,7 @@ struct wifi_iface_status {
 	/** SSID length */
 	unsigned int ssid_len;
 	/** SSID */
-	char ssid[WIFI_SSID_MAX_LEN];
+	char ssid[WIFI_SSID_MAX_LEN + 1];
 	/** BSSID */
 	char bssid[WIFI_MAC_ADDR_LEN];
 	/** Frequency band */


### PR DESCRIPTION
Change the bytes occupied by the ssid member in the wifi structure to 'WIFI_SSID_MAX_LEN + 1' so that it can eliminate the '-Wstringop-truncation' warning.

Fixes #80066