### PR TITLE
subsys: fs: fcb: struct flash_sector usually const

### DIFF
--- a/include/zephyr/fs/fcb.h
+++ b/include/zephyr/fs/fcb.h
@@ -49,7 +49,7 @@ extern "C" {
  * within that area.
  */
 struct fcb_entry {
-	struct flash_sector *fe_sector;
+	const struct flash_sector *fe_sector;
 	/**< Pointer to info about sector where data are placed */
 
 	uint32_t fe_elem_off;
@@ -109,14 +109,14 @@ struct fcb {
 	 * to have scratch space for garbage collecting when FCB fills up.
 	 */
 
-	struct flash_sector *f_sectors;
+	const struct flash_sector *f_sectors;
 	/**< Array of sectors, must be contiguous */
 
 	/* Flash circular buffer internal state */
 	struct k_mutex f_mtx;
 	/**< Locking for accessing the FCB data, internal state */
 
-	struct flash_sector *f_oldest;
+	const struct flash_sector *f_oldest;
 	/**< Pointer to flash sector containing the oldest data,
 	 * internal state
 	 */
@@ -223,7 +223,7 @@ typedef int (*fcb_walk_cb)(struct fcb_entry_ctx *loc_ctx, void *arg);
  * @return 0 on success, negative on failure (or transferred form callback
  *         return-value), positive transferred form callback return-value
  */
-int fcb_walk(struct fcb *fcbp, struct flash_sector *sector, fcb_walk_cb cb, void *cb_arg);
+int fcb_walk(struct fcb *fcbp, const struct flash_sector *sector, fcb_walk_cb cb, void *cb_arg);
 
 /**
  * Get next fcb entry location.

--- a/subsys/fs/fcb/fcb.c
+++ b/subsys/fs/fcb/fcb.c
@@ -91,12 +91,13 @@ int fcb_erase_sector(const struct fcb *fcbp, const struct flash_sector *sector)
 
 int fcb_init(int f_area_id, struct fcb *fcbp)
 {
-	struct flash_sector *sector;
+	const struct flash_sector *sector;
 	int rc;
 	int i;
 	uint8_t align;
 	int oldest = -1, newest = -1;
-	struct flash_sector *oldest_sector = NULL, *newest_sector = NULL;
+	const struct flash_sector *oldest_sector = NULL;
+	const struct flash_sector *newest_sector = NULL;
 	struct fcb_disk_area fda;
 	const struct flash_parameters *fparam;
 
@@ -174,7 +175,7 @@ int fcb_init(int f_area_id, struct fcb *fcbp)
 int fcb_free_sector_cnt(struct fcb *fcbp)
 {
 	int i;
-	struct flash_sector *fa;
+	const struct flash_sector *fa;
 
 	fa = fcbp->f_active.fe_sector;
 	for (i = 0; i < fcbp->f_sector_cnt; i++) {
@@ -252,7 +253,7 @@ int fcb_get_len(const struct fcb *fcbp, uint8_t *buf, uint16_t *len)
 /**
  * Initialize erased sector for use.
  */
-int fcb_sector_hdr_init(struct fcb *fcbp, struct flash_sector *sector, uint16_t id)
+int fcb_sector_hdr_init(struct fcb *fcbp, const struct flash_sector *sector, uint16_t id)
 {
 	struct fcb_disk_area fda;
 	int rc;
@@ -275,7 +276,8 @@ int fcb_sector_hdr_init(struct fcb *fcbp, struct flash_sector *sector, uint16_t 
  * Returns 0 if sector is unused;
  * Returns 1 if sector has data.
  */
-int fcb_sector_hdr_read(struct fcb *fcbp, struct flash_sector *sector, struct fcb_disk_area *fdap)
+int fcb_sector_hdr_read(struct fcb *fcbp, const struct flash_sector *sector,
+			struct fcb_disk_area *fdap)
 {
 	struct fcb_disk_area fda;
 	int rc;

--- a/subsys/fs/fcb/fcb_append.c
+++ b/subsys/fs/fcb/fcb_append.c
@@ -11,11 +11,10 @@
 #include <zephyr/fs/fcb.h>
 #include "fcb_priv.h"
 
-static struct flash_sector *
-fcb_new_sector(struct fcb *fcb, int cnt)
+static const struct flash_sector *fcb_new_sector(struct fcb *fcb, int cnt)
 {
-	struct flash_sector *prev;
-	struct flash_sector *cur;
+	const struct flash_sector *prev;
+	const struct flash_sector *cur;
 	int i;
 
 	prev = NULL;
@@ -39,7 +38,7 @@ fcb_new_sector(struct fcb *fcb, int cnt)
 int
 fcb_append_to_scratch(struct fcb *fcb)
 {
-	struct flash_sector *sector;
+	const struct flash_sector *sector;
 	int rc;
 
 	sector = fcb_new_sector(fcb, 0);
@@ -59,7 +58,7 @@ fcb_append_to_scratch(struct fcb *fcb)
 int
 fcb_append(struct fcb *fcb, uint16_t len, struct fcb_entry *append_loc)
 {
-	struct flash_sector *sector;
+	const struct flash_sector *sector;
 	struct fcb_entry *active;
 	int cnt;
 	int rc;

--- a/subsys/fs/fcb/fcb_getnext.c
+++ b/subsys/fs/fcb/fcb_getnext.c
@@ -30,8 +30,7 @@ fcb_getnext_in_sector(struct fcb *fcb, struct fcb_entry *loc)
 	return rc;
 }
 
-struct flash_sector *
-fcb_getnext_sector(struct fcb *fcb, struct flash_sector *sector)
+const struct flash_sector *fcb_getnext_sector(struct fcb *fcb, const struct flash_sector *sector)
 {
 	sector++;
 	if (sector >= &fcb->f_sectors[fcb->f_sector_cnt]) {

--- a/subsys/fs/fcb/fcb_priv.h
+++ b/subsys/fs/fcb/fcb_priv.h
@@ -69,14 +69,15 @@ uint8_t fcb_get_align(const struct fcb *fcbp);
 int fcb_erase_sector(const struct fcb *fcbp, const struct flash_sector *sector);
 
 int fcb_getnext_in_sector(struct fcb *fcbp, struct fcb_entry *loc);
-struct flash_sector *fcb_getnext_sector(struct fcb *fcbp, struct flash_sector *sector);
+const struct flash_sector *fcb_getnext_sector(struct fcb *fcbp, const struct flash_sector *sector);
 int fcb_getnext_nolock(struct fcb *fcbp, struct fcb_entry *loc);
 
 int fcb_elem_info(struct fcb *fcbp, struct fcb_entry *loc);
 int fcb_elem_endmarker(struct fcb *fcbp, struct fcb_entry *loc, uint8_t *crc8p);
 
-int fcb_sector_hdr_init(struct fcb *fcbp, struct flash_sector *sector, uint16_t id);
-int fcb_sector_hdr_read(struct fcb *fcbp, struct flash_sector *sector, struct fcb_disk_area *fdap);
+int fcb_sector_hdr_init(struct fcb *fcbp, const struct flash_sector *sector, uint16_t id);
+int fcb_sector_hdr_read(struct fcb *fcbp, const struct flash_sector *sector,
+			struct fcb_disk_area *fdap);
 
 #ifdef __cplusplus
 }

--- a/subsys/fs/fcb/fcb_rotate.c
+++ b/subsys/fs/fcb/fcb_rotate.c
@@ -11,7 +11,7 @@
 int
 fcb_rotate(struct fcb *fcb)
 {
-	struct flash_sector *sector;
+	const struct flash_sector *sector;
 	int rc = 0;
 
 	rc = k_mutex_lock(&fcb->f_mtx, K_FOREVER);

--- a/subsys/fs/fcb/fcb_walk.c
+++ b/subsys/fs/fcb/fcb_walk.c
@@ -12,9 +12,7 @@
  * Call 'cb' for every element in flash circular buffer. If sector is specified,
  * only elements with that flash_sector are reported.
  */
-int
-fcb_walk(struct fcb *fcb, struct flash_sector *sector, fcb_walk_cb cb,
-	 void *cb_arg)
+int fcb_walk(struct fcb *fcb, const struct flash_sector *sector, fcb_walk_cb cb, void *cb_arg)
 {
 	struct fcb_entry_ctx entry_ctx;
 	int rc;

--- a/tests/subsys/fs/fcb/src/fcb_test.h
+++ b/tests/subsys/fs/fcb/src/fcb_test.h
@@ -28,7 +28,7 @@ extern struct fcb test_fcb;
 extern struct fcb test_fcb_crc_disabled;
 #endif
 
-extern struct flash_sector test_fcb_sector[];
+extern const struct flash_sector test_fcb_sector[];
 
 extern uint8_t fcb_test_erase_value;
 

--- a/tests/subsys/fs/fcb/src/main.c
+++ b/tests/subsys/fs/fcb/src/main.c
@@ -30,25 +30,11 @@ uint8_t fcb_test_erase_value;
  * area. This test suite is the non bootable application so 1. image slot is
  * suitable for it.
  */
-struct flash_sector test_fcb_sector[] = {
-	[0] = {
-		.fs_off = 0,
-		.fs_size = SECTOR_SIZE
-	},
-	[1] = {
-		.fs_off = SECTOR_SIZE,
-		.fs_size = SECTOR_SIZE
-	},
-	[2] = {
-		.fs_off = 2 * SECTOR_SIZE,
-		.fs_size = SECTOR_SIZE
-	},
-	[3] = {
-		.fs_off = 3 * SECTOR_SIZE,
-		.fs_size = SECTOR_SIZE
-	}
-};
-
+const struct flash_sector test_fcb_sector[] = {
+	[0] = {.fs_off = 0, .fs_size = SECTOR_SIZE},
+	[1] = {.fs_off = SECTOR_SIZE, .fs_size = SECTOR_SIZE},
+	[2] = {.fs_off = 2 * SECTOR_SIZE, .fs_size = SECTOR_SIZE},
+	[3] = {.fs_off = 3 * SECTOR_SIZE, .fs_size = SECTOR_SIZE}};
 
 void test_fcb_wipe(void)
 {

--- a/tests/subsys/settings/fcb/src/settings_test.h
+++ b/tests/subsys/settings/fcb/src/settings_test.h
@@ -35,7 +35,7 @@ extern int test_export_block;
 
 extern int c2_var_count;
 
-extern struct flash_sector fcb_sectors[SETTINGS_TEST_FCB_FLASH_CNT];
+extern const struct flash_sector fcb_sectors[SETTINGS_TEST_FCB_FLASH_CNT];
 
 extern char val_string[SETTINGS_TEST_FCB_VAL_STR_CNT][SETTINGS_MAX_VAL_LEN];
 extern char test_ref_value[SETTINGS_TEST_FCB_VAL_STR_CNT][SETTINGS_MAX_VAL_LEN];
@@ -46,7 +46,7 @@ void ctest_clear_call_state(void);
 int ctest_get_call_state(void);
 
 void config_wipe_srcs(void);
-void config_wipe_fcb(struct flash_sector *fs, int cnt);
+void config_wipe_fcb(const struct flash_sector *fs, int cnt);
 
 void test_config_fill_area(
 	char test_value[SETTINGS_TEST_FCB_VAL_STR_CNT][SETTINGS_MAX_VAL_LEN],

--- a/tests/subsys/settings/fcb/src/settings_test_compress_deleted.c
+++ b/tests/subsys/settings/fcb/src/settings_test_compress_deleted.c
@@ -9,16 +9,9 @@
 
 #define NAME_DELETABLE "4/deletable"
 
-struct flash_sector fcb_small_sectors[2] = {
-	[0] = {
-		.fs_off = 0x00000000,
-		.fs_size = 4 * 1024
-	},
-	[1] = {
-		.fs_off = 0x00001000,
-		.fs_size = 4 * 1024
-	}
-};
+const struct flash_sector fcb_small_sectors[2] = {
+	[0] = {.fs_off = 0x00000000, .fs_size = 4 * 1024},
+	[1] = {.fs_off = 0x00001000, .fs_size = 4 * 1024}};
 
 struct deletable_s {
 	bool valid;

--- a/tests/subsys/settings/fcb/src/settings_test_compress_reset.c
+++ b/tests/subsys/settings/fcb/src/settings_test_compress_reset.c
@@ -12,7 +12,7 @@ ZTEST(settings_config_fcb, test_config_compress_reset)
 {
 	int rc;
 	struct settings_fcb cf;
-	struct flash_sector *fa;
+	const struct flash_sector *fa;
 	int elems[4];
 	int i;
 

--- a/tests/subsys/settings/fcb/src/settings_test_fcb.c
+++ b/tests/subsys/settings/fcb/src/settings_test_fcb.c
@@ -165,26 +165,13 @@ void config_wipe_srcs(void)
 	settings_save_dst = NULL;
 }
 
-struct flash_sector fcb_sectors[SETTINGS_TEST_FCB_FLASH_CNT] = {
-	[0] = {
-		.fs_off = 0x00000000,
-		.fs_size = 16 * 1024
-	},
-	[1] = {
-		.fs_off = 0x00004000,
-		.fs_size = 16 * 1024
-	},
-	[2] = {
-		.fs_off = 0x00008000,
-		.fs_size = 16 * 1024
-	},
-	[3] = {
-		.fs_off = 0x0000c000,
-		.fs_size = 16 * 1024
-	}
-};
+const struct flash_sector fcb_sectors[SETTINGS_TEST_FCB_FLASH_CNT] = {
+	[0] = {.fs_off = 0x00000000, .fs_size = 16 * 1024},
+	[1] = {.fs_off = 0x00004000, .fs_size = 16 * 1024},
+	[2] = {.fs_off = 0x00008000, .fs_size = 16 * 1024},
+	[3] = {.fs_off = 0x0000c000, .fs_size = 16 * 1024}};
 
-void config_wipe_fcb(struct flash_sector *fs, int cnt)
+void config_wipe_fcb(struct flash_sector const *fs, int cnt)
 {
 	const struct flash_area *fap;
 	int rc;


### PR DESCRIPTION
Generally, the flash_sector array is known at compile time and is immutable, therefore developers may like to store it in ROM. The only function that requires a mutable struct flash_sector seems to be flash_area_get_sectors(), allowing the developer to store a mutable sector definition in persistent RAM rather than ROM.  An example of this approach is in setting_fcb.c.