### PR TITLE
tests: debug/coredump: Change to call k_panic() for ISH SoCs

### DIFF
--- a/tests/subsys/debug/coredump/src/main.c
+++ b/tests/subsys/debug/coredump/src/main.c
@@ -39,6 +39,7 @@ __no_optimization void func_3(uint32_t *addr)
 	defined(CONFIG_BOARD_LONGAN_NANO) || \
 	defined(CONFIG_BOARD_QEMU_XTENSA) || \
 	defined(CONFIG_BOARD_RISCV32_VIRTUAL) || \
+	defined(CONFIG_SOC_FAMILY_INTEL_ISH) || \
 	defined(CONFIG_SOC_FAMILY_INTEL_ADSP)
 	ARG_UNUSED(addr);
 	/* Call k_panic() directly so Renode doesn't pause execution.


### PR DESCRIPTION
ISH SoCs have zero-address memory mapped to I2C0 controller. Coredump cannot be triggered by zero-address access.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/79698