### PR TITLE
tests: ztest: fix board name

### DIFF
--- a/tests/ztest/zexpect/CMakeLists.txt
+++ b/tests/ztest/zexpect/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.20.0)
-if(BOARD STREQUAL unit_testing)
+if(BOARD STREQUAL unit_testing/unit_testing)
   find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
   project(base)
 


### PR DESCRIPTION
Use full board name in cmake file.

Fixes https://github.com/zephyrproject-rtos/zephyr/actions/runs/11470485057/job/31920079496

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
