### PR TITLE
samples: net: prometheus: add filter to not build with Renesas RA FSP

### DIFF
--- a/samples/net/prometheus/sample.yaml
+++ b/samples/net/prometheus/sample.yaml
@@ -13,5 +13,7 @@ common:
   platform_exclude:
     - native_posix
     - native_posix/native/64
+  # Exclude CONFIG_HAS_RENESAS_RA_FSP as Renesas RA HAL has build error with mbedtls Socket
+  filter: not CONFIG_HAS_RENESAS_RA_FSP
 tests:
   sample.net.prometheus: {}


### PR DESCRIPTION
Exclude Twister build `sample.net.prometheus` for Renesas RA boards due to an issue that reported in #80121