### PR TITLE
driver: regulator: npm1300: fix build warning

### DIFF
--- a/drivers/regulator/regulator_npm1300.c
+++ b/drivers/regulator/regulator_npm1300.c
@@ -533,7 +533,7 @@ static int get_enabled_reg(const struct device *dev, uint8_t base, uint8_t offse
 
 	int ret = mfd_npm1300_reg_read(config->mfd, base, offset, &data);
 
-	if (ret != 0) {
+	if (ret < 0) {
 		return ret;
 	}
 


### PR DESCRIPTION
regulator_npm1300_init() generated uninitialized variable warning. Fix this by being consistent in the error checking in underlying function.