### PR TITLE
tests: ztest base: fix board name

### DIFF
--- a/tests/subsys/testsuite/fff_fake_contexts/CMakeLists.txt
+++ b/tests/subsys/testsuite/fff_fake_contexts/CMakeLists.txt
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.20.0)
-if(BOARD STREQUAL unit_testing)
+if(BOARD STREQUAL unit_testing/unit_testing)
   find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
   set(target testbinary)
 else()

--- a/tests/ztest/base/CMakeLists.txt
+++ b/tests/ztest/base/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.20.0)
-if(BOARD STREQUAL unit_testing)
+if(BOARD STREQUAL unit_testing/unit_testing)
   find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
   project(base)
 


### PR DESCRIPTION
Use full board name in cmake file.
Akin to the fix done in 
https://github.com/zephyrproject-rtos/zephyr/pull/80270/ following the changes from
https://github.com/zephyrproject-rtos/zephyr/pull/77250/ In which twister now uses the full board name when calling cmake.