### PR TITLE
tests/ztest/fail: Fix unit_testing part

### DIFF
--- a/tests/subsys/testsuite/fff_fake_contexts/CMakeLists.txt
+++ b/tests/subsys/testsuite/fff_fake_contexts/CMakeLists.txt
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.20.0)
-if(BOARD STREQUAL unit_testing/unit_testing)
+if(BOARD STREQUAL "unit_testing" OR BOARD STREQUAL "unit_testing/unit_testing")
   find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
   set(target testbinary)
 else()

--- a/tests/ztest/base/CMakeLists.txt
+++ b/tests/ztest/base/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.20.0)
-if(BOARD STREQUAL unit_testing/unit_testing)
+if(BOARD STREQUAL "unit_testing" OR BOARD STREQUAL "unit_testing/unit_testing")
   find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
   project(base)
 

--- a/tests/ztest/fail/CMakeLists.txt
+++ b/tests/ztest/fail/CMakeLists.txt
@@ -4,7 +4,7 @@
 cmake_minimum_required(VERSION 3.20.0)
 include(ExternalProject)
 
-if(BOARD STREQUAL unit_testing/unit_testing)
+if(BOARD STREQUAL "unit_testing" OR BOARD STREQUAL "unit_testing/unit_testing")
   find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
   set(target testbinary)
   # Set the target binary for the 'core' external project. The path to this must match the one set

--- a/tests/ztest/fail/CMakeLists.txt
+++ b/tests/ztest/fail/CMakeLists.txt
@@ -4,7 +4,7 @@
 cmake_minimum_required(VERSION 3.20.0)
 include(ExternalProject)
 
-if(BOARD STREQUAL unit_testing)
+if(BOARD STREQUAL unit_testing/unit_testing)
   find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
   set(target testbinary)
   # Set the target binary for the 'core' external project. The path to this must match the one set
@@ -36,7 +36,7 @@ string(REPLACE ";" " " fail_test_config "${fail_test_config}")
 ExternalProject_Add(core
     SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/core
     CMAKE_ARGS
-      -DBOARD:STRING=${BOARD}
+      -DBOARD:STRING=${BOARD}${BOARD_QUALIFIERS}
       -DCMAKE_INSTALL_PREFIX:PATH=${CMAKE_BINARY_DIR}/core
       ${fail_test_config}
 )

--- a/tests/ztest/fail/core/CMakeLists.txt
+++ b/tests/ztest/fail/core/CMakeLists.txt
@@ -23,7 +23,7 @@ elseif(CONFIG_ZTEST_FAIL_TEST_UNEXPECTED_ASSUME)
   list(APPEND test_sources src/unexpected_assume.cpp)
 endif()
 
-if(BOARD STREQUAL unit_testing)
+if(BOARD STREQUAL unit_testing/unit_testing)
   find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
   project(base)
 

--- a/tests/ztest/fail/core/CMakeLists.txt
+++ b/tests/ztest/fail/core/CMakeLists.txt
@@ -23,7 +23,7 @@ elseif(CONFIG_ZTEST_FAIL_TEST_UNEXPECTED_ASSUME)
   list(APPEND test_sources src/unexpected_assume.cpp)
 endif()
 
-if(BOARD STREQUAL unit_testing/unit_testing)
+if(BOARD STREQUAL "unit_testing" OR BOARD STREQUAL "unit_testing/unit_testing")
   find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
   project(base)
 

--- a/tests/ztest/fail/testcase.yaml
+++ b/tests/ztest/fail/testcase.yaml
@@ -6,27 +6,34 @@ common:
     - test_framework
   # test has dependencies on host libc
   platform_allow:
+    - unit_testing
     - native_sim
     - native_sim/native/64
   integration_platforms:
     - native_sim
 tests:
   testing.fail.unit.assert_after:
+    type: unit
     extra_configs:
       - CONFIG_ZTEST_FAIL_TEST_ASSERT_AFTER=y
   testing.fail.unit.assert_teardown:
+    type: unit
     extra_configs:
       - CONFIG_ZTEST_FAIL_TEST_ASSERT_TEARDOWN=y
   testing.fail.unit.assume_after:
+    type: unit
     extra_configs:
       - CONFIG_ZTEST_FAIL_TEST_ASSUME_AFTER=y
   testing.fail.unit.assume_teardown:
+    type: unit
     extra_configs:
       - CONFIG_ZTEST_FAIL_TEST_ASSUME_TEARDOWN=y
   testing.fail.unit.pass_after:
+    type: unit
     extra_configs:
       - CONFIG_ZTEST_FAIL_TEST_PASS_AFTER=y
   testing.fail.unit.pass_teardown:
+    type: unit
     extra_configs:
       - CONFIG_ZTEST_FAIL_TEST_PASS_TEARDOWN=y
   testing.fail.zephyr.assert_after:

--- a/tests/ztest/zexpect/CMakeLists.txt
+++ b/tests/ztest/zexpect/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.20.0)
-if(BOARD STREQUAL unit_testing/unit_testing)
+if(BOARD STREQUAL "unit_testing" OR BOARD STREQUAL "unit_testing/unit_testing")
   find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
   project(base)
 


### PR DESCRIPTION

    tests: Support targeting unit_testing with and without qualifier
    
    For tests that support both targeting unit_testing and
    other targets, we check in the cmake code the BOARD variable.
    Let's allow users to set this to either of unit_testing
    or unit_testing/unit_testing so it behaves like for other
    tests.

----

    Use full board name in cmake file.
    Akin to the fix done in
    https://github.com/zephyrproject-rtos/zephyr/pull/80270/
    following the changes from
    https://github.com/zephyrproject-rtos/zephyr/pull/77250/
    
    Note after the Zephyr cmake code has been run the BOARD
    variable is split into BOARD BOARD_QUALIFIERS,
    where BOARD does not contain the qualifiers anymore
    (see cmake/modules/boards.cmake for more info).

-----

    Fix filtering done in
    22c3438f1b9589d31777912528f42312a28e2f8e
    Otherwise we end up with tests defined twice, as a .unit and .zerphyr
    variant but both run in normal builds, and none for unit tests.

Note this PR is not marked as a hotfix, as these tests are currently filtered out for `unit_testing` and therefore cannot trigger in main.

Related to
* https://github.com/zephyrproject-rtos/zephyr/pull/77250/
* https://github.com/zephyrproject-rtos/zephyr/commit/22c3438f1b9589d31777912528f42312a28e2f8e
* https://github.com/zephyrproject-rtos/zephyr/pull/80280
* https://github.com/zephyrproject-rtos/zephyr/pull/80270/

