### PR TITLE
doc: boards/nxp/lpcxpresso55s36: improve debug documentation

### DIFF
--- a/boards/nxp/lpcxpresso55s36/doc/index.rst
+++ b/boards/nxp/lpcxpresso55s36/doc/index.rst
@@ -166,19 +166,17 @@ and :ref:`application_run` for more details).
 Configuring a Debug Probe
 =========================
 
-A debug probe is used for both flashing and debugging the board. This
-board is configured by default to use the LPC-Link2 CMSIS-DAP Onboard
-Debug Probe, however the :ref:`pyocd-debug-host-tools` does not yet
-support the LPC55S36 so you must reconfigure the board for one of the
-J-Link debug probe instead.
+A debug probe is used for both flashing and debugging the board. This board is
+configured by default to use the integrated :ref:`mcu-link-onboard-debug-probe`
+in the CMSIS-DAP mode. To use this probe with Zephyr, you need to install the
+:ref:`linkserver-debug-host-tools` and make sure they are in your search path.
+Then, use the ``linkserver`` runner option to flash and debug the board. Refer
+to the detailed overview about :ref:`application_debugging` for additional
+information.
 
-First install the :ref:`jlink-debug-host-tools` and make sure they are
-in your search path.
-
-Then follow the instructions in
-:ref:`lpclink2-jlink-onboard-debug-probe` to program the J-Link
-firmware. Please make sure you have the latest firmware for this
-board.
+The integrated MCU-Link hardware can also be used as a J-Link probe with a
+firmware update, as described in :ref:`mcu-link-jlink-onboard-debug-probe`.
+The :ref:`jlink-debug-host-tools` should be available in this case.
 
 Configuring a Console
 =====================


### PR DESCRIPTION
The LPCXpresso55S36 board has an integrated MCU-Link debug probe, not an LPC-Link2 ([ref](https://docs.nxp.com/bundle/LPCXpresso55S36UM/page/topics/LPCXpresso55S36_overview.html)). Also, it is now possible to directly use the stock CMSIS-DAP mode with the `linkserver` runner.

[Link to the updated doc page](https://builds.zephyrproject.io/zephyr/pr/80286/docs/boards/nxp/lpcxpresso55s36/doc/index.html#configuring-a-debug-probe)