### PR TITLE
drivers: serial: gecko: Add device power management

### DIFF
--- a/drivers/serial/Kconfig.gecko
+++ b/drivers/serial/Kconfig.gecko
@@ -12,5 +12,6 @@ config UART_GECKO
 	select SOC_GECKO_USART
 	select PINCTRL if SOC_FAMILY_SILABS_S1
 	select CLOCK_CONTROL if SOC_FAMILY_SILABS_S2
+	select PM_DEVICE if PM && SOC_FAMILY_SILABS_S2
 	help
 	  Enable the Gecko uart driver.


### PR DESCRIPTION
Add basic device power management to USART driver. The initial implementation only ensures that the TX FIFO is flushed before allowing the system to go to sleep by polling the TXIDLE status register.

This fixes an issue where the last 1-2 characters would be lost if transmitted immediately before going to deep sleep.