### PR TITLE
soc: espressif: esp32s3: Adjust DRAM size for .bss.sector_buffers to prevent overflow with larger images

### DIFF
--- a/soc/espressif/esp32s3/memory.h
+++ b/soc/espressif/esp32s3/memory.h
@@ -10,6 +10,7 @@
 #define SRAM0_IRAM_START    0x40370000
 #define SRAM0_SIZE          0x8000
 #define SRAM1_DRAM_START    0x3fc88000
+
 /* IRAM equivalent address where DRAM actually start */
 #define SRAM1_IRAM_START    (SRAM0_IRAM_START + SRAM0_SIZE)
 #define SRAM2_DRAM_START    0x3fcf0000
@@ -49,7 +50,7 @@
 
 /* For safety margin between bootloader data section and startup stacks */
 #define BOOTLOADER_STACK_OVERHEAD      0x0
-#define BOOTLOADER_DRAM_SEG_LEN        0x9000
+#define BOOTLOADER_DRAM_SEG_LEN        0x15000
 #define BOOTLOADER_IRAM_LOADER_SEG_LEN 0x1a00
 #define BOOTLOADER_IRAM_SEG_LEN        0xc000
 


### PR DESCRIPTION
This pull request solves the issue descried in https://github.com/zephyrproject-rtos/zephyr/issues/80138

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/80138