### PR TITLE
zephyr: add support for running lopper commands using west

### DIFF
--- a/scripts/west-commands.yml
+++ b/scripts/west-commands.yml
@@ -84,3 +84,13 @@ west-commands:
       - name: sdk
         class: Sdk
         help: manage Zephyr SDK
+  - file: scripts/west_commands/lopper_install.py
+    commands:
+      - name: lopper-install
+        class: LopperInstall
+        help: Install lopper as a part of environment
+  - file: scripts/west_commands/lopper_command.py
+    commands:
+      - name: lopper-command
+        class: LopperCommand
+        help: work with Lopper Commands

--- a/scripts/west_commands/lopper_command.py
+++ b/scripts/west_commands/lopper_command.py
@@ -1,0 +1,91 @@
+# Copyright (c) 2024 Advanced Micro Devices, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import subprocess
+import sys
+import lopper
+import os
+from west.commands import WestCommand
+
+def get_dir_path(fpath):
+    """
+    This api takes file path and returns it's directory path
+
+    Args:
+        fpath: Path to get the directory path from.
+    Returns:
+        string: Full Directory path of the passed path
+    """
+    return os.path.dirname(fpath.rstrip(os.path.sep))
+
+def runcmd(cmd, cwd=None, logfile=None) -> bool:
+    """
+    Run the shell commands.
+
+    Args:
+        | cmd: shell command that needs to be called
+        | logfile: file to save the command output if required
+    """
+    ret = True
+    if logfile is None:
+        try:
+            subprocess.check_call(cmd, cwd=cwd, shell=True)
+        except subprocess.CalledProcessError as exc:
+            ret = False
+            sys.exit(1)
+    else:
+        try:
+            subprocess.check_call(cmd, cwd=cwd, shell=True, stdout=logfile, stderr=logfile)
+        except subprocess.CalledProcessError:
+            ret = False
+    return ret
+
+class LopperCommand(WestCommand):
+    def __init__(self):
+        super().__init__(
+            'lopper-command',  # The name of the command
+            'Install lopper dependencies and run lopper commands',  # Help text for the command
+            'This command runs lopper commands based on user inputs.'
+        )
+
+    def do_add_parser(self, parser_adder):
+        parser = parser_adder.add_parser(self.name, help=self.help)
+        required_argument = parser.add_argument_group("Required arguments")
+        required_argument.add_argument(
+            "-p",
+            "--proc",
+            action="store",
+            help="Specify the processor name",
+            required=True,
+        )
+        required_argument.add_argument(
+            "-s",
+            "--sdt",
+            action="store",
+            help="Specify the System device-tree path (till system-top.dts file)",
+            required=True,
+        )
+        parser.add_argument(
+            "-w",
+            "--ws_dir",
+            action="store",
+            help="Workspace directory where domain will be created (Default: Current Work Directory)",
+            default='.',
+        )
+
+        return parser
+
+    def do_run(self, args, unknown_args):
+        sdt = os.path.abspath(args.sdt)
+        proc = args.proc
+        workspace = os.path.abspath(args.ws_dir)
+        lops_dir = os.path.join(get_dir_path(lopper.__file__), "lops")
+
+
+        lops_file = os.path.join(lops_dir, "lop-microblaze-riscv.dts")
+        runcmd(f"lopper -f --enhanced -O {workspace} -i {lops_file} {sdt} {workspace}/system-domain.dts -- gen_domain_dts microblaze_riscv_0",
+                cwd = workspace)
+        runcmd(f"lopper -f --enhanced -O {workspace} -i {lops_file} {workspace}/system-domain.dts {workspace}/system-zephyr.dts -- gen_domain_dts microblaze_riscv_0 zephyr_dt",
+                cwd = workspace)
+

--- a/scripts/west_commands/lopper_install.py
+++ b/scripts/west_commands/lopper_install.py
@@ -1,0 +1,52 @@
+# Copyright (c) 2024 Advanced Micro Devices, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import subprocess
+import sys
+import os
+from west.commands import WestCommand
+
+def runcmd(cmd, cwd=None, logfile=None) -> bool:
+    """
+    Run the shell commands.
+
+    Args:
+        | cmd: shell command that needs to be called
+        | logfile: file to save the command output if required
+    """
+    ret = True
+    if logfile is None:
+        try:
+            subprocess.check_call(cmd, cwd=cwd, shell=True)
+        except subprocess.CalledProcessError as exc:
+            ret = False
+            sys.exit(1)
+    else:
+        try:
+            subprocess.check_call(cmd, cwd=cwd, shell=True, stdout=logfile, stderr=logfile)
+        except subprocess.CalledProcessError:
+            ret = False
+    return ret
+
+class LopperInstall(WestCommand):
+    def __init__(self):
+        super().__init__(
+            'lopper-install',  # The name of the command
+            'Install lopper after west update',  # Help text for the command
+            'This command installs lopper after west update.'
+        )
+
+    def do_add_parser(self, parser_adder):
+        parser = parser_adder.add_parser(self.name, help=self.help)
+        return parser
+
+    def do_run(self, args, unknown_args):
+        # Install lopper and its dependencies
+        self.install_lopper()
+
+    def install_lopper(self):
+        env_path = os.environ.get("VIRTUAL_ENV")
+        lopper_dir = os.path.join(env_path, "../", "lopper")
+        runcmd(f"pip install ./[dt,server,yaml,pcpp]",
+                cwd = lopper_dir)

--- a/west.yml
+++ b/west.yml
@@ -23,6 +23,8 @@ manifest:
       url-base: https://github.com/zephyrproject-rtos
     - name: babblesim
       url-base: https://github.com/BabbleSim
+    - name: devicetree-org
+      url-base: https://github.com/devicetree-org
 
   group-filter: [-babblesim, -optional]
 
@@ -342,6 +344,10 @@ manifest:
     - name: zcbor
       revision: 47f34dd7f5284e8750b5a715dee7f77c6c5bdc3f
       path: modules/lib/zcbor
+    - name: lopper
+      repo-path: lopper
+      revision: master
+      remote: devicetree-org
 
   self:
     path: zephyr


### PR DESCRIPTION
Update the west to install lopper and use lopper to generate zephyr specific device-trees and config files, not sure whether it's proper way of doing or not, please suggest the proper way for plumbing the lopper into west tool.

Usage:
1) west update
   i) clones the lopper repo from github repo.
2) west lopper-install
   i) installs the lopper binary so that subsequent scripts can import
    the lopper binary.
3) west lopper-command -p <processor name> -s <system device-tree
   system-top.dts path> -w <workspace path>
   i) generates the zephyr specific device-tree's and config files like Kconfig
    etc, currently script supports only microblaze risc-v.