### PR TITLE
soc: silabs: Only initialize HFXO Manager if HFXO is enabled

### DIFF
--- a/dts/arm/silabs/efr32bg22.dtsi
+++ b/dts/arm/silabs/efr32bg22.dtsi
@@ -31,6 +31,11 @@
 	interrupts = <46 0>;
 };
 
+&hfxo {
+	interrupts = <44 0>;
+	interrupt-names = "hfxo";
+};
+
 &msc {
 	flash0: flash@0 {
 		compatible = "soc-nv-flash";

--- a/dts/arm/silabs/efr32bg27.dtsi
+++ b/dts/arm/silabs/efr32bg27.dtsi
@@ -41,6 +41,11 @@
 	interrupts = <52 0>;
 };
 
+&hfxo {
+	interrupts = <50 0>;
+	interrupt-names = "hfxo";
+};
+
 &msc {
 	flash0: flash@8000000 {
 		compatible = "soc-nv-flash";

--- a/dts/arm/silabs/efr32mg21.dtsi
+++ b/dts/arm/silabs/efr32mg21.dtsi
@@ -138,6 +138,8 @@
 			#clock-cells = <0>;
 			compatible = "silabs,hfxo";
 			reg = <0x5000c000 0x4000>;
+			interrupts = <45 0>;
+			interrupt-names = "hfxo";
 			clock-frequency = <DT_FREQ_K(38400)>;
 			ctune = <140>;
 			precision = <50>;

--- a/dts/arm/silabs/efr32mg24.dtsi
+++ b/dts/arm/silabs/efr32mg24.dtsi
@@ -208,6 +208,8 @@
 			#clock-cells = <0>;
 			compatible = "silabs,hfxo";
 			reg = <0x5a004000 0x4000>;
+			interrupts = <44 0>;
+			interrupt-names = "hfxo";
 			clock-frequency = <DT_FREQ_M(39)>;
 			ctune = <140>;
 			precision = <50>;

--- a/modules/hal_silabs/simplicity_sdk/CMakeLists.txt
+++ b/modules/hal_silabs/simplicity_sdk/CMakeLists.txt
@@ -114,11 +114,6 @@ zephyr_compile_definitions(
   ${SILABS_DEVICE_PART_NUMBER}
 )
 
-zephyr_compile_definitions_ifdef(CONFIG_SOC_GECKO_DEV_INIT
-  SL_CATALOG_POWER_MANAGER_PRESENT
-  SL_CATALOG_HFXO_MANAGER_PRESENT
-)
-
 zephyr_library_sources(
   ${DEVICE_DIR}/SiliconLabs/${SILABS_DEVICE_FAMILY}/Source/system_${CONFIG_SOC_SERIES}.c
   ${EMLIB_DIR}/src/em_system.c
@@ -131,6 +126,7 @@ zephyr_library_sources(
   ${SERVICE_DIR}/device_manager/src/sl_device_clock.c
   ${SERVICE_DIR}/device_manager/src/sl_device_gpio.c
   ${SERVICE_DIR}/device_manager/src/sl_device_peripheral.c
+  ${SERVICE_DIR}/memory_manager/profiler/src/sli_memory_profiler_stubs.c
 )
 
 if(NOT SILABS_DEVICE_FAMILY_NUMBER EQUAL "21")
@@ -156,18 +152,37 @@ zephyr_library_sources_ifdef(CONFIG_SOC_GECKO_IADC         ${EMLIB_DIR}/src/em_i
 zephyr_library_sources_ifdef(CONFIG_SOC_GECKO_BURTC        ${EMLIB_DIR}/src/em_burtc.c)
 zephyr_library_sources_ifdef(CONFIG_SOC_GECKO_CMU          ${EMLIB_DIR}/src/em_cmu.c)
 
+# Device Init
 if(CONFIG_SOC_GECKO_DEV_INIT)
-zephyr_library_sources_ifdef(CONFIG_DT_HAS_SILABS_SERIES2_DCDC_ENABLED
-  ${SERVICE_DIR}/device_init/src/sl_device_init_dcdc_s2.c
-)
+  zephyr_library_sources_ifdef(CONFIG_DT_HAS_SILABS_SERIES2_DCDC_ENABLED
+    ${SERVICE_DIR}/device_init/src/sl_device_init_dcdc_s2.c
+  )
 endif()
-zephyr_library_sources_ifdef(CONFIG_SOC_GECKO_DEV_INIT
-  ${SERVICE_DIR}/power_manager/src/sl_power_manager.c
-  ${SERVICE_DIR}/power_manager/src/sl_power_manager_hal_s2.c
-  ${SERVICE_DIR}/hfxo_manager/src/sl_hfxo_manager.c
-  ${SERVICE_DIR}/hfxo_manager/src/sl_hfxo_manager_hal_s2.c
-  ${SERVICE_DIR}/memory_manager/profiler/src/sli_memory_profiler_stubs.c
-)
+
+# Power Manager
+if(CONFIG_SOC_GECKO_PM_BACKEND_PMGR)
+  zephyr_library_sources(
+    ${SERVICE_DIR}/power_manager/src/sl_power_manager.c
+    ${SERVICE_DIR}/power_manager/src/sl_power_manager_hal_s2.c
+  )
+  zephyr_compile_definitions(
+    SL_CATALOG_POWER_MANAGER_PRESENT
+  )
+  zephyr_compile_definitions_ifdef(CONFIG_SOC_GECKO_RTCC
+    SL_CATALOG_POWER_MANAGER_DEEPSLEEP_BLOCKING_HFXO_RESTORE_PRESENT
+  )
+endif()
+
+# HFXO Manager
+if(CONFIG_SOC_SILABS_HFXO_MANAGER)
+  zephyr_library_sources(
+    ${SERVICE_DIR}/hfxo_manager/src/sl_hfxo_manager.c
+    ${SERVICE_DIR}/hfxo_manager/src/sl_hfxo_manager_hal_s2.c
+  )
+  zephyr_compile_definitions(
+    SL_CATALOG_HFXO_MANAGER_PRESENT
+  )
+endif()
 
 zephyr_library_sources_ifdef(CONFIG_SOC_GECKO_DEV_INIT     ${COMMON_DIR}/src/sl_slist.c)
 zephyr_library_sources_ifdef(CONFIG_SOC_GECKO_CORE

--- a/soc/silabs/Kconfig
+++ b/soc/silabs/Kconfig
@@ -128,6 +128,12 @@ config SOC_SILABS_SLEEPTIMER
 	help
 	  Set if the Sleeptimer HAL module is used.
 
+config SOC_SILABS_HFXO_MANAGER
+	bool
+	default y if PM && $(dt_nodelabel_enabled,sysrtc0) && $(dt_nodelabel_enabled,hfxo)
+	help
+	  Set if the HFXO Manager HAL module is used.
+
 if PM
 
 config SOC_GECKO_PM_BACKEND_PMGR

--- a/soc/silabs/silabs_s2/soc.c
+++ b/soc/silabs/silabs_s2/soc.c
@@ -32,6 +32,10 @@
 
 LOG_MODULE_REGISTER(soc, CONFIG_SOC_LOG_LEVEL);
 
+#if defined(CONFIG_SOC_SILABS_HFXO_MANAGER)
+Z_ISR_DECLARE_DIRECT(DT_IRQ(DT_NODELABEL(hfxo), irq), 0, sl_hfxo_manager_irq_handler);
+#endif
+
 void soc_early_init_hook(void)
 {
 	/* Handle chip errata */
@@ -42,9 +46,12 @@ void soc_early_init_hook(void)
 	}
 	sl_clock_manager_init();
 
+	if (IS_ENABLED(CONFIG_SOC_SILABS_HFXO_MANAGER)) {
+		sl_hfxo_manager_init_hardware();
+		sl_hfxo_manager_init();
+	}
 	if (IS_ENABLED(CONFIG_PM)) {
 		sl_power_manager_init();
-		sl_hfxo_manager_init();
 	}
 }
 


### PR DESCRIPTION
Only initialize the HFXO Manager HAL driver if the HFXO is enabled in DeviceTree, the device uses SYSRTC for timekeeping, and Power Manager is enabled. HFXO Manager integrates with the Sleeptimer HAL driver for SYSRTC to autonomously wake the HFXO prior to Sleeptimer wakeup from deep sleep. It is not needed on devices that don't have HFXO-SYSRTC integration, and it is not needed if the application doesn't use deep sleep.

Add missing call to init_hardware() prior to init().