### PR TITLE
drivers: audio: dmic: remove compatible from nxp,dmic child binding

### DIFF
--- a/dts/arm/nxp/nxp_rt5xx_common.dtsi
+++ b/dts/arm/nxp/nxp_rt5xx_common.dtsi
@@ -438,56 +438,48 @@
 		clocks = <&clkctl0 MCUX_DMIC_CLK>;
 
 		pdmc0: dmic-channel@0 {
-			compatible = "nxp,dmic-channel";
 			reg = <0>;
 			dmas = <&dma0 16>;
 			status = "disabled";
 		};
 
 		pdmc1: dmic-channel@1 {
-			compatible = "nxp,dmic-channel";
 			reg = <1>;
 			dmas = <&dma0 17>;
 			status = "disabled";
 		};
 
 		pdmc2: dmic-channel@2 {
-			compatible = "nxp,dmic-channel";
 			reg = <2>;
 			dmas = <&dma0 18>;
 			status = "disabled";
 		};
 
 		pdmc3: dmic-channel@3 {
-			compatible = "nxp,dmic-channel";
 			reg = <3>;
 			dmas = <&dma0 19>;
 			status = "disabled";
 		};
 
 		pdmc4: dmic-channel@4 {
-			compatible = "nxp,dmic-channel";
 			reg = <4>;
 			dmas = <&dma0 20>;
 			status = "disabled";
 		};
 
 		pdmc5: dmic-channel@5 {
-			compatible = "nxp,dmic-channel";
 			reg = <5>;
 			dmas = <&dma0 21>;
 			status = "disabled";
 		};
 
 		pdmc6: dmic-channel@6 {
-			compatible = "nxp,dmic-channel";
 			reg = <6>;
 			dmas = <&dma0 22>;
 			status = "disabled";
 		};
 
 		pdmc7: dmic-channel@7 {
-			compatible = "nxp,dmic-channel";
 			reg = <7>;
 			dmas = <&dma0 23>;
 			status = "disabled";

--- a/dts/arm/nxp/nxp_rt6xx_common.dtsi
+++ b/dts/arm/nxp/nxp_rt6xx_common.dtsi
@@ -345,56 +345,48 @@
 		clocks = <&clkctl0 MCUX_DMIC_CLK>;
 
 		pdmc0: dmic-channel@0 {
-			compatible = "nxp,dmic-channel";
 			reg = <0>;
 			dmas = <&dma0 16>;
 			status = "disabled";
 		};
 
 		pdmc1: dmic-channel@1 {
-			compatible = "nxp,dmic-channel";
 			reg = <1>;
 			dmas = <&dma0 17>;
 			status = "disabled";
 		};
 
 		pdmc2: dmic-channel@2 {
-			compatible = "nxp,dmic-channel";
 			reg = <2>;
 			dmas = <&dma0 18>;
 			status = "disabled";
 		};
 
 		pdmc3: dmic-channel@3 {
-			compatible = "nxp,dmic-channel";
 			reg = <3>;
 			dmas = <&dma0 19>;
 			status = "disabled";
 		};
 
 		pdmc4: dmic-channel@4 {
-			compatible = "nxp,dmic-channel";
 			reg = <4>;
 			dmas = <&dma0 20>;
 			status = "disabled";
 		};
 
 		pdmc5: dmic-channel@5 {
-			compatible = "nxp,dmic-channel";
 			reg = <5>;
 			dmas = <&dma0 21>;
 			status = "disabled";
 		};
 
 		pdmc6: dmic-channel@6 {
-			compatible = "nxp,dmic-channel";
 			reg = <6>;
 			dmas = <&dma0 22>;
 			status = "disabled";
 		};
 
 		pdmc7: dmic-channel@7 {
-			compatible = "nxp,dmic-channel";
 			reg = <7>;
 			dmas = <&dma0 23>;
 			status = "disabled";

--- a/dts/arm/nxp/nxp_rw6xx_common.dtsi
+++ b/dts/arm/nxp/nxp_rw6xx_common.dtsi
@@ -457,28 +457,24 @@
 
 		pdmc0: dmic-channel@0 {
 			reg = <0>;
-			compatible = "nxp,dmic-channel";
 			dmas = <&dma0 16>;
 			status = "disabled";
 		};
 
 		pdmc1: dmic-channel@1 {
 			reg = <1>;
-			compatible = "nxp,dmic-channel";
 			dmas = <&dma0 17>;
 			status = "disabled";
 		};
 
 		pdmc2: dmic-channel@2 {
 			reg = <2>;
-			compatible = "nxp,dmic-channel";
 			dmas = <&dma0 18>;
 			status = "disabled";
 		};
 
 		pdmc3: dmic-channel@3 {
 			reg = <3>;
-			compatible = "nxp,dmic-channel";
 			dmas = <&dma0 19>;
 			status = "disabled";
 		};

--- a/dts/bindings/audio/nxp,dmic.yaml
+++ b/dts/bindings/audio/nxp,dmic.yaml
@@ -32,8 +32,11 @@ child-binding:
   description: |
     NXP DMIC channel. Can be used to configure filtering and gain attributes
     of each channel
-  include: base.yaml
-  compatible: "nxp,dmic-channel"
+  include:
+    - name: base.yaml
+      property-allowlist:
+        - reg
+        - dmas
   properties:
     reg:
       required: true


### PR DESCRIPTION
There is no such thing as associating a compatible to a child binding so remove this from the `nxp,dmic` binding definition as well as devicetree files that incorrectly set one.

As I don't think integration CI has coverage for the actual change, took some time to run the below:

```console
$ ./scripts/twister -T samples/drivers/audio/dmic --all
ZEPHYR_BASE unset, using "/Users/kartben/zephyrproject/zephyr"
INFO    - Using Ninja..
INFO    - Zephyr version: v3.7.0-5187-g8581a4c42552
INFO    - Using 'zephyr' toolchain.
INFO    - Selecting all possible platforms per test case
INFO    - Building initial testsuite list...
INFO    - Writing JSON report /Users/kartben/zephyrproject/zephyr/twister-out/testplan.json
INFO    - Adding tasks to the queue...
INFO    - Added initial list of jobs to queue
INFO    - Total complete:  283/ 849  33%  built (not run):    1, skipped:  282, failed:    0, error:    0

INFO    - Total complete:  486/ 849  57%  built (not run):    1, skipped:  485, failed:    0, error:    0

INFO    - Total complete:  849/ 849  100%  built (not run):    6, skipped:  843, failed:    0, error:    0
INFO    - 1 test scenarios (849 test instances) selected, 843 configurations skipped (32 by static filter, 811 at runtime).
INFO    - 0 of 849 test configurations passed (0.00%), 6 built (not run), 0 failed, 0 errored, 843 skipped with 0 warnings in 750.67 seconds
INFO    - In total 0 test cases were executed, 843 skipped on 849 out of total 850 platforms (99.88%)
INFO    - 0 test configurations executed on platforms, 6 test configurations were only built.
INFO    - Saving reports...
INFO    - Writing JSON report /Users/kartben/zephyrproject/zephyr/twister-out/twister.json
INFO    - Writing xunit report /Users/kartben/zephyrproject/zephyr/twister-out/twister.xml...
INFO    - Writing xunit report /Users/kartben/zephyrproject/zephyr/twister-out/twister_report.xml...
INFO    - Run completed
```
