### PR TITLE
tests/samples: use platform_key on cmsis_rtos tests/samples

### DIFF
--- a/samples/subsys/portability/cmsis_rtos_v1/philosophers/sample.yaml
+++ b/samples/subsys/portability/cmsis_rtos_v1/philosophers/sample.yaml
@@ -1,6 +1,9 @@
 sample:
   name: CMSIS_RTOS_V1 Dining Philosophers
 common:
+  platform_key:
+    - arch
+    - simulation
   integration_platforms:
     - native_sim
   extra_args: DEBUG_PRINTF=1

--- a/samples/subsys/portability/cmsis_rtos_v1/timer_synchronization/sample.yaml
+++ b/samples/subsys/portability/cmsis_rtos_v1/timer_synchronization/sample.yaml
@@ -2,6 +2,9 @@ sample:
   name: CMSIS_RTOS_V1 Synchronization
 tests:
   sample.portability.cmsis_rtos_v1.timer_synchronization:
+    platform_key:
+      - arch
+      - simulation
     integration_platforms:
       - native_sim
     tags: cmsis_rtos

--- a/samples/subsys/portability/cmsis_rtos_v2/philosophers/sample.yaml
+++ b/samples/subsys/portability/cmsis_rtos_v2/philosophers/sample.yaml
@@ -1,6 +1,9 @@
 sample:
   name: CMSIS_RTOS_V2 Dining Philosophers
 common:
+  platform_key:
+    - arch
+    - simulation
   integration_platforms:
     - native_sim
   extra_args: DEBUG_PRINTF=1

--- a/samples/subsys/portability/cmsis_rtos_v2/timer_synchronization/sample.yaml
+++ b/samples/subsys/portability/cmsis_rtos_v2/timer_synchronization/sample.yaml
@@ -2,6 +2,9 @@ sample:
   name: CMSIS_RTOS_V2 Synchronization
 tests:
   sample.portability.cmsis_rtos_v2.timer_synchronization:
+    platform_key:
+      - arch
+      - simulation
     integration_platforms:
       - native_sim
     platform_exclude:

--- a/tests/subsys/portability/cmsis_rtos_v1/testcase.yaml
+++ b/tests/subsys/portability/cmsis_rtos_v1/testcase.yaml
@@ -1,5 +1,8 @@
 tests:
   portability.cmsis_rtos_v1:
+    platform_key:
+      - arch
+      - simulation
     tags: cmsis_rtos
     min_ram: 32
     min_flash: 34

--- a/tests/subsys/portability/cmsis_rtos_v2/testcase.yaml
+++ b/tests/subsys/portability/cmsis_rtos_v2/testcase.yaml
@@ -1,6 +1,8 @@
 tests:
   portability.cmsis_rtos_v2:
-    platform_exclude: m2gl025_miv
+    platform_key:
+      - arch
+      - simulation
     tags: cmsis_rtos
     min_ram: 32
     min_flash: 34


### PR DESCRIPTION
Coverage for cmsis rtos APIS should is provided using simulation, we
should not build those on every platform we have. Avoid failures due to
incompatiblities in requirements coming from various boards and also
reduce churn and noise during testing and CI.

Fixes #80215

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
