### PR TITLE
drivers: watchdog: wdt_dw: add missing header

### DIFF
--- a/drivers/watchdog/wdt_dw.c
+++ b/drivers/watchdog/wdt_dw.c
@@ -13,6 +13,7 @@
 #include <zephyr/math/ilog2.h>
 #include <zephyr/drivers/reset.h>
 #include <zephyr/drivers/clock_control.h>
+#include <zephyr/irq.h>
 
 #include "wdt_dw.h"
 #include "wdt_dw_common.h"


### PR DESCRIPTION
Needs zephyr/irq.h to compile it.

Signed-off-by: Savent Gate <savent_gate@outlook.com>