### PR TITLE
boards: st: stm32h745i_disco: m7: Fix PHY address

### DIFF
--- a/boards/st/stm32h745i_disco/Kconfig.defconfig
+++ b/boards/st/stm32h745i_disco/Kconfig.defconfig
@@ -14,6 +14,10 @@ config NET_L2_ETHERNET
 config ETH_STM32_HAL_MII
 	default y
 
+# STM32H745I-DISCO have PHY connected to address 1
+config ETH_STM32_HAL_PHY_ADDRESS
+	default 1
+
 endif # NETWORKING
 
 config MEMC

--- a/boards/st/stm32h745i_disco/stm32h745i_disco_stm32h745xx_m7.dts
+++ b/boards/st/stm32h745i_disco/stm32h745i_disco_stm32h745xx_m7.dts
@@ -151,9 +151,9 @@
 	pinctrl-0 = <&eth_mdio_pa2 &eth_mdc_pc1>;
 	pinctrl-names = "default";
 
-	ethernet-phy@0 {
+	ethernet-phy@1 {
 		compatible = "ethernet-phy";
-		reg = <0x00>;
+		reg = <0x01>;
 		status = "okay";
 	};
 };


### PR DESCRIPTION
According to the datasheet, the PHY address is 0x1. When changed to this value the PHY id is correctly read.

Before:
```
[00:00:00.602,000] <err> phy_mii: No PHY found at address 0
```

After:
```
[00:00:00.051,000] <inf> phy_mii: PHY (1) ID 7C111
```

fixes #80880