### PR TITLE
kernel: Show tainted status on crash

### DIFF
--- a/kernel/fatal.c
+++ b/kernel/fatal.c
@@ -40,7 +40,7 @@ __weak void k_sys_fatal_error_handler(unsigned int reason,
 	ARG_UNUSED(esf);
 
 	LOG_PANIC();
-	LOG_ERR("Halting system");
+	LOG_ERR("Halting system" IF_ENABLED(CONFIG_TAINT, (" (tainted)")));
 	arch_system_halt(reason);
 	CODE_UNREACHABLE;
 }


### PR DESCRIPTION
This implements the following statement from the Zephyr binary blob documentation:

> The kernel’s default fatal error handler will also explicitly print
> out the kernel’s tainted status

The resulting failure the may look like this:

```
[00:00:00.003,000] <err> os: >>> ZEPHYR FATAL ERROR 0: CPU exception on
  CPU 0
[00:00:00.003,000] <err> os: Current thread: 0x20000610 (unknown)
[00:00:00.024,000] <err> os: Halting system (tainted)
```

Instead of this (for a non-tainted build, when no blobs are present):
```
[00:00:00.003,000] <err> os: >>> ZEPHYR FATAL ERROR 0: CPU exception on
  CPU 0
[00:00:00.003,000] <err> os: Current thread: 0x20000610 (unknown)
[00:00:00.024,000] <err> os: Halting system
```

I tested this on a `sim3u1xx_dk` board using binary blobs from Espressif (`west blobs fetch hal_espressif`/`west blobs clean`).

Notes:
- Using IS_ENABLED(...) because I want to avoid string formatting code from within the fatal handler - regardless of any compiler optimization that might avoid that
- Maybe should wait for this to be settled: #80285
- 1st part: #79980