### PR TITLE
MAINTAINERS: soburi takeover RaspberryPi Pico maintainer from yonsch

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3503,9 +3503,9 @@ Nuvoton NPCM Platforms:
 Raspberry Pi Pico Platforms:
   status: maintained
   maintainers:
-    - yonsch
-  collaborators:
     - soburi
+  collaborators:
+    - yonsch
   files:
     - boards/raspberrypi/
     - boards/adafruit/kb2040/
@@ -4801,6 +4801,8 @@ West:
 "West project: hal_rpi_pico":
   status: maintained
   maintainers:
+    - soburi
+  collaborators:
     - yonsch
   files:
     - modules/hal_rpi_pico/


### PR DESCRIPTION
I am taking over the maintainer role of the Raspberry Pi Pico platform.

- - -

@yonsch 

@carlescufi told me you will be retiring as a maintainer.
Thank you for your years of service as a maintainer. I'm glad we could grow this platform together.