### PR TITLE
net: socket: service: mark as unstable

### DIFF
--- a/include/zephyr/net/socket_service.h
+++ b/include/zephyr/net/socket_service.h
@@ -19,7 +19,7 @@
  * @brief BSD socket service API
  * @defgroup bsd_socket_service BSD socket service API
  * @since 3.6
- * @version 0.1.0
+ * @version 0.2.0
  * @ingroup networking
  * @{
  */

--- a/subsys/net/lib/sockets/Kconfig
+++ b/subsys/net/lib/sockets/Kconfig
@@ -101,8 +101,7 @@ config NET_SOCKET_MAX_SEND_WAIT
 	  returning an ENOBUFS error.
 
 config NET_SOCKETS_SERVICE
-	bool "Socket service support [EXPERIMENTAL]"
-	select EXPERIMENTAL
+	bool "Socket service support"
 	select EVENTFD
 	help
 	  The socket service can monitor multiple sockets and save memory


### PR DESCRIPTION
As the socket service API is currently used by mutiple applications
(dhcpv4 server, dns, telnet), it should be marked as unstable,
according to the docs:
https://docs.zephyrproject.org/latest/develop/api/api_lifecycle.html

Signed-off-by: Fin Maaß <f.maass@vogl-electronic.com>