### PR TITLE
samples/drivers/led/pwm    regex matching the LOG output

### DIFF
--- a/samples/drivers/led/pwm/sample.yaml
+++ b/samples/drivers/led/pwm/sample.yaml
@@ -17,6 +17,6 @@ tests:
         - "Turned on"
         - "Turned off"
         - "Increasing brightness gradually"
-        - "Blinking on: 0.1 sec, off: 0.1 sec"
-        - "(Blinking on: 1 sec, off: 1 sec|Cycle period not supported)"
+        - "Blinking on: \\d+ msec, off: \\d+ msec"
+        - "(Blinking on: 1000 msec, off: 1000 msec|Cycle period not supported)"
         - "Turned off, loop end"


### PR DESCRIPTION
Change the expected regex of the sample.yaml   to what the main.c is LOGGING

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/80319