### PR TITLE
west.yml: Update libmetal and open-amp for v2024.10.0 release

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -270,7 +270,7 @@ manifest:
       revision: 1a5938ebaca4f13fe79ce074f5dee079783aa29f
       path: modules/lib/liblc3
     - name: libmetal
-      revision: a6851ba6dba8c9e87d00c42f171a822f7a29639b
+      revision: 3e8781aae9d7285203118c05bc01d4eb0ca565a7
       path: modules/hal/libmetal
       groups:
         - hal
@@ -312,7 +312,7 @@ manifest:
       revision: f9e2abdb70761003912b1b929a37b536f68a91da
       path: modules/lib/nrf_wifi
     - name: open-amp
-      revision: b735edbc739ad59156eb55bb8ce2583d74537719
+      revision: 52bb1783521c62c019451cee9b05b8eda9d7425f
       path: modules/lib/open-amp
     - name: openthread
       revision: 2aeb8b833ba760ec29d5f340dd1ce7bcb61c5d56


### PR DESCRIPTION
Update to the last release of open-amp and libmetal libraries