### PR TITLE
drivers: sai: Use clock id 0 if none provided

### DIFF
--- a/drivers/dai/nxp/sai/sai.h
+++ b/drivers/dai/nxp/sai/sai.h
@@ -38,7 +38,7 @@ LOG_MODULE_REGISTER(nxp_dai_sai);
 
 /* used to retrieve a clock's ID using its index generated via _SAI_CLOCK_INDEX_ARRAY */
 #define _SAI_GET_CLOCK_ID(clock_idx, inst)\
-	DT_INST_CLOCKS_CELL_BY_IDX(inst, clock_idx, name)
+	DT_INST_PHA_BY_IDX_OR(inst, clocks, clock_idx, name, 0x0)
 
 /* used to retrieve a clock's name using its index generated via _SAI_CLOCK_INDEX_ARRAY */
 #define _SAI_GET_CLOCK_NAME(clock_idx, inst)\


### PR DESCRIPTION
This allows us to use fixed-clock for SAI mclk and it is useful for platforms that are enabling clocks from the Host processor which is the case for imx8mp for now.