### PR TITLE
input: kbd_matrix: implement stable poll period support

### DIFF
--- a/drivers/input/input_gpio_kbd_matrix.c
+++ b/drivers/input/input_gpio_kbd_matrix.c
@@ -121,7 +121,7 @@ static __maybe_unused void gpio_kbd_matrix_idle_poll_handler(const struct device
 
 	if (gpio_kbd_matrix_read_row(dev) == 0) {
 		k_work_reschedule(cfg->idle_poll_dwork,
-				  K_USEC(common->poll_period_us));
+				  K_USEC(common->stable_poll_period_us));
 		return;
 	}
 
@@ -137,7 +137,7 @@ static void gpio_kbd_matrix_set_detect_mode(const struct device *dev, bool enabl
 	if (cfg->idle_poll_dwork != NULL) {
 		if (enabled) {
 			k_work_reschedule(cfg->idle_poll_dwork,
-					  K_USEC(common->poll_period_us));
+					  K_USEC(common->stable_poll_period_us));
 		}
 		return;
 	}

--- a/dts/bindings/input/kbd-matrix-common.yaml
+++ b/dts/bindings/input/kbd-matrix-common.yaml
@@ -23,6 +23,12 @@ properties:
       Defines the poll period in msecs between between matrix scans, set to 0
       to never exit poll mode. Defaults to 5ms if unspecified.
 
+  stable-poll-period-ms:
+    type: int
+    description: |
+      Defines the poll period in msecs between matrix scans when the matrix is
+      stable, defaults to poll-period-ms value if unspecified.
+
   poll-timeout-ms:
     type: int
     default: 100

--- a/include/zephyr/input/input_kbd_matrix.h
+++ b/include/zephyr/input/input_kbd_matrix.h
@@ -113,6 +113,7 @@ struct input_kbd_matrix_common_config {
 	uint8_t row_size;
 	uint8_t col_size;
 	uint32_t poll_period_us;
+	uint32_t stable_poll_period_us;
 	uint32_t poll_timeout_ms;
 	uint32_t debounce_down_us;
 	uint32_t debounce_up_us;
@@ -192,6 +193,9 @@ struct input_kbd_matrix_common_config {
 		.row_size = _row_size, \
 		.col_size = _col_size, \
 		.poll_period_us = DT_PROP(node_id, poll_period_ms) * USEC_PER_MSEC, \
+		.stable_poll_period_us = DT_PROP_OR(node_id, stable_poll_period_ms, \
+						    DT_PROP(node_id, poll_period_ms)) * \
+							USEC_PER_MSEC, \
 		.poll_timeout_ms = DT_PROP(node_id, poll_timeout_ms), \
 		.debounce_down_us = DT_PROP(node_id, debounce_down_ms) * USEC_PER_MSEC, \
 		.debounce_up_us = DT_PROP(node_id, debounce_up_ms) * USEC_PER_MSEC, \


### PR DESCRIPTION
Implement a new stable-poll-period-ms property to specify a new (slower) polling rate for when the matrix is stable.

The keyboard thread can eat up a surprisingly high amount of cpu cycles in busy waiting if the specific hardware implementation happen to have a particularly slow settle time, but high frequency polling is really only needed when debouncing.

The new property allow slowing down the polling rate when the matrix is stable (either key pressed but none to be debounced or idle in the case of the gpio implementation with no interrupts), this allows reducing the overall cpu time taken by the keyboard scanning thread when keys are persistently pressed.