### PR TITLE
mgmt: mcumgr: grp: zephyr_basic: Add missing FLASH_MAP dependency

### DIFF
--- a/subsys/mgmt/mcumgr/grp/zephyr_basic/Kconfig
+++ b/subsys/mgmt/mcumgr/grp/zephyr_basic/Kconfig
@@ -10,6 +10,7 @@ if MCUMGR_GRP_ZBASIC
 
 config MCUMGR_GRP_ZBASIC_STORAGE_ERASE
 	bool "Storage erase command"
+	depends on FLASH_MAP
 	help
 	  Enables command that allows to erase storage partition.
 


### PR DESCRIPTION
Adds a missing dependency, this command requires it to erase the storage area