### PR TITLE
cmake: gcc/ld: Fix LTO warnings

### DIFF
--- a/cmake/compiler/gcc/compiler_flags.cmake
+++ b/cmake/compiler/gcc/compiler_flags.cmake
@@ -23,7 +23,7 @@ set_compiler_property(PROPERTY optimization_size  -Os)
 set_compiler_property(PROPERTY optimization_size_aggressive -Oz)
 
 if(CMAKE_C_COMPILER_VERSION GREATER_EQUAL "4.5.0")
-  set_compiler_property(PROPERTY optimization_lto -flto)
+  set_compiler_property(PROPERTY optimization_lto -flto=auto)
   set_compiler_property(PROPERTY prohibit_lto -fno-lto)
 endif()
 

--- a/cmake/linker/ld/linker_flags.cmake
+++ b/cmake/linker/ld/linker_flags.cmake
@@ -36,7 +36,7 @@ endif()
 
 set_property(TARGET linker PROPERTY partial_linking "-r")
 
-set_property(TARGET linker PROPERTY lto_arguments -flto -fno-ipa-sra -ffunction-sections -fdata-sections)
+set_property(TARGET linker PROPERTY lto_arguments -flto=auto -fno-ipa-sra -ffunction-sections -fdata-sections)
 
 check_set_linker_property(TARGET linker PROPERTY no_relax ${LINKERFLAGPREFIX},--no-relax)
 


### PR DESCRIPTION
Fix the following warnings:
[255/261] Linking C executable zephyr/zephyr_pre0.elf lto-wrapper: warning: using serial compilation of 8 LTRANS jobs lto-wrapper: note: see the '-flto' option documentation for more information
[260/261] Linking C executable zephyr/zephyr.elf
lto-wrapper: warning: using serial compilation of 8 LTRANS jobs lto-wrapper: note: see the '-flto' option documentation for more information