### PR TITLE
bluetooth: Remove migration hints

### DIFF
--- a/drivers/bluetooth/hci/CMakeLists.txt
+++ b/drivers/bluetooth/hci/CMakeLists.txt
@@ -1,18 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
-# Remove after 3.7.0 is released
-if(CONFIG_BT_RPMSG)
-	message(FATAL_ERROR  "CONFIG_BT_RPMSG has been renamed to CONFIG_BT_HCI_IPC")
-endif()
-
-# Remove after 3.7.0 is released
-if(CONFIG_BT_HCI_IPC)
-  dt_chosen(chosen_hci_rpmsg PROPERTY "zephyr,bt-hci-rpmsg-ipc")
-  if(DEFINED chosen_hci_rpmsg)
-	message(FATAL_ERROR  "zephyr,bt-hci-rpmsg-ipc has been renamed to zephyr,bt-hci-ipc")
-  endif()
-endif()
-
 zephyr_library_sources_ifdef(CONFIG_BT_ESP32       hci_esp32.c)
 if(CONFIG_DT_HAS_ESPRESSIF_ESP32_BT_HCI_ENABLED)
   zephyr_blobs_verify(MODULE hal_espressif REQUIRED)

--- a/drivers/bluetooth/hci/Kconfig
+++ b/drivers/bluetooth/hci/Kconfig
@@ -29,13 +29,6 @@ config BT_H5
 	  Bluetooth three-wire (H:5) UART driver. Implementation of HCI
 	  Three-Wire UART Transport Layer.
 
-# Removed: Here only to give the user a warning about its removal
-# Remove after 3.7.0 is released
-config BT_RPMSG
-	bool
-	help
-	  Use BT_HCI_IPC instead
-
 config BT_HCI_IPC
 	bool
 	default y

--- a/samples/bluetooth/hci_ipc/CMakeLists.txt
+++ b/samples/bluetooth/hci_ipc/CMakeLists.txt
@@ -6,9 +6,3 @@ find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(hci_ipc)
 
 target_sources(app PRIVATE src/main.c)
-
-# Remove after 3.7.0 is released
-dt_chosen(chosen_hci_rpmsg PROPERTY "zephyr,bt-hci-rpmsg-ipc")
-if(DEFINED chosen_hci_rpmsg)
-  message(FATAL_ERROR  "zephyr,bt-hci-rpmsg-ipc has been renamed to zephyr,bt-hci-ipc")
-endif()


### PR DESCRIPTION
Zephyr 3.7.0 has been released and it is time to remove the migration code added in 9cf07bbdb55f4264062297d2bee00779c7627604 (bluetooth: Rename rpmsg HCI driver and sample to ipc).