### PR TITLE
Adds charge enable support to BQ24190

### DIFF
--- a/drivers/charger/charger_bq24190.c
+++ b/drivers/charger/charger_bq24190.c
@@ -433,6 +433,21 @@ static int bq24190_set_prop(const struct device *dev, charger_prop_t prop,
 	}
 }
 
+static int bq24190_charge_enable(const struct device *dev, const bool enable)
+{
+	const struct bq24190_config *const config = dev->config;
+
+	if (config->ce_gpio.port != NULL) {
+		if (enable == true) {
+			return gpio_pin_set_dt(&config->ce_gpio, 1);
+		} else {
+			return gpio_pin_set_dt(&config->ce_gpio, 0);
+		}
+	} else {
+		return -ENOTSUP;
+	}
+}
+
 static int bq24190_init(const struct device *dev)
 {
 	const struct bq24190_config *const config = dev->config;
@@ -457,6 +472,19 @@ static int bq24190_init(const struct device *dev)
 		return -ENODEV;
 	}
 
+	if (config->ce_gpio.port != NULL) {
+		if (!gpio_is_ready_dt(&config->ce_gpio)) {
+			return -ENODEV;
+		}
+
+		ret = gpio_pin_configure_dt(&config->ce_gpio, GPIO_OUTPUT_INACTIVE);
+		if (ret < 0) {
+			return ret;
+		}
+	} else {
+		LOG_DBG("Assuming charge enable pin is pulled low");
+	}
+
 	ret = bq24190_register_reset(dev);
 	if (ret) {
 		return ret;
@@ -473,12 +501,14 @@ static int bq24190_init(const struct device *dev)
 static const struct charger_driver_api bq24190_driver_api = {
 	.get_property = bq24190_get_prop,
 	.set_property = bq24190_set_prop,
+	.charge_enable = bq24190_charge_enable,
 };
 
 #define BQ24190_INIT(inst)                                                                         \
                                                                                                    \
 	static const struct bq24190_config bq24190_config_##inst = {                               \
 		.i2c = I2C_DT_SPEC_INST_GET(inst),                                                 \
+		.ce_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, ce_gpios, {}),                           \
 	};                                                                                         \
                                                                                                    \
 	static struct bq24190_data bq24190_data_##inst = {                                         \

--- a/dts/bindings/charger/ti,bq24190.yaml
+++ b/dts/bindings/charger/ti,bq24190.yaml
@@ -13,3 +13,7 @@ properties:
 
   constant-charge-voltage-max-microvolt:
     required: true
+
+  ce-gpios:
+    type: phandle-array
+    description: Active low, charge enable pin

--- a/tests/drivers/build_all/charger/i2c.dtsi
+++ b/tests/drivers/build_all/charger/i2c.dtsi
@@ -14,6 +14,8 @@ bq24190@0 {
 
 	constant-charge-current-max-microamp = <1000000>;
 	constant-charge-voltage-max-microvolt = <4208000>;
+
+	ce-gpios = <&test_gpio 0 0>;
 };
 
 max20335@1 {


### PR DESCRIPTION
Adds driver support for the charge enable (ce) pin on the BQ24190 family of devices.