### PR TITLE
twister: fix platform filter when loading plan from file

### DIFF
--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -230,11 +230,21 @@ class TestPlan:
             # Get list of connected hardware and filter tests to only be run on connected hardware.
             # If the platform does not exist in the hardware map or was not specified by --platform,
             # just skip it.
-            connected_list = self.options.platform
+
+            connected_list = []
+            excluded_list = []
+            for _cp in self.options.platform:
+                if _cp in self.platform_names:
+                    connected_list.append(self.get_platform(_cp).name)
+
             if self.options.exclude_platform:
-                for excluded in self.options.exclude_platform:
+                for _p in self.options.exclude_platform:
+                    if _p in self.platform_names:
+                        excluded_list.append(self.get_platform(_p).name)
+                for excluded in excluded_list:
                     if excluded in connected_list:
                         connected_list.remove(excluded)
+
             self.load_from_file(last_run, filter_platform=connected_list)
             self.selected_platforms = set(p.platform.name for p in self.instances.values())
         else:

--- a/scripts/pylib/twister/twisterlib/twister_main.py
+++ b/scripts/pylib/twister/twisterlib/twister_main.py
@@ -181,6 +181,15 @@ def main(options: argparse.Namespace, default_options: argparse.Namespace):
         tplan.create_build_dir_links()
 
     runner = TwisterRunner(tplan.instances, tplan.testsuites, env)
+    # FIXME: This is a workaround for the fact that the hardware map can be usng
+    # the short name of the platform, while the testplan is using the full name.
+    #
+    # convert platform names coming from the hardware map to the full target
+    # name.
+    # this is needed to match the platform names in the testplan.
+    for d in hwm.duts:
+        if d.platform in tplan.platform_names:
+            d.platform = tplan.get_platform(d.platform).name
     runner.duts = hwm.duts
     runner.run()
 

--- a/scripts/tests/twister/test_testplan.py
+++ b/scripts/tests/twister/test_testplan.py
@@ -594,7 +594,7 @@ TESTDATA_4 = [
     (None, None, 'load_tests.json', None, '0/4',
      TwisterRuntimeError, set(['lt-p1', 'lt-p3', 'lt-p4', 'lt-p2']), []),
     ('suffix', None, None, True, '2/4',
-     None, set(['ts-p4', 'ts-p2', 'ts-p3']), [2, 4]),
+     None, set(['ts-p4', 'ts-p2', 'ts-p1', 'ts-p3']), [2, 4]),
 ]
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
if alias or shorthand name is provided on the command line, we need
convert this to complete target name for the filters to work.

Fixes #80332

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
