### PR TITLE
wifi: Fix typo in wifi.rst

### DIFF
--- a/doc/connectivity/networking/api/wifi.rst
+++ b/doc/connectivity/networking/api/wifi.rst
@@ -15,7 +15,7 @@ Only personal mode security is supported with below types:
 
 * Open
 * WPA2-PSK
-* WPA3-PSK-256
+* WPA2-PSK-256
 * WPA3-SAE
 
 The Wi-Fi management API is implemented in the ``wifi_mgmt`` module as a part of the networking L2


### PR DESCRIPTION
`WPA2-PSK-256` is supported, not `WPA3-PSK-256`, which does not exist.