### PR TITLE
scripts: west_commands: runners: Fix jlink is_ip

### DIFF
--- a/scripts/west_commands/runners/jlink.py
+++ b/scripts/west_commands/runners/jlink.py
@@ -30,6 +30,8 @@ DEFAULT_JLINK_GDB_PORT = 2331
 DEFAULT_JLINK_RTT_PORT = 19021
 
 def is_ip(ip):
+    if not ip:
+        return False
     try:
         ipaddress.ip_address(ip.split(':')[0])
     except ValueError:


### PR DESCRIPTION
Commit f987e8c6f0a49b04a1184b1a36612612482e3d24 introduced a regression where the is_ip check fails if no --id is passed as an argument.