### PR TITLE
drivers: spi: litex: add flush of rx buffer

### DIFF
--- a/drivers/spi/spi_litex_litespi.c
+++ b/drivers/spi/spi_litex_litespi.c
@@ -152,6 +152,13 @@ static int spi_litex_xfer(const struct device *dev, const struct spi_config *con
 
 	litex_write32(BIT(config->slave), dev_config->core_master_cs_addr);
 
+	/* Flush RX buffer */
+	while ((litex_read8(dev_config->core_master_status_addr) &
+		BIT(SPIFLASH_CORE_MASTER_STATUS_RX_READY_OFFSET))) {
+		rxd = litex_read32(dev_config->core_master_rxtx_addr);
+		LOG_DBG("flushed rxd: 0x%x", rxd);
+	}
+
 	do {
 		len = MIN(spi_context_max_continuous_chunk(ctx), dev_config->core_master_rxtx_size);
 		if (len != old_len) {


### PR DESCRIPTION
this flushes the rx buffer before the
start of a new transaction. It is needed
because the litex bios is not always
reading the rx buffer.

In the litex bios flushing the rx buffer at the begin of each transaction is done the same. https://github.com/enjoy-digital/litex/blob/60c4a1b667b81c5d4d3dab6b8d63b457e05ce18c/litex/soc/software/liblitespi/spiflash.c#L61

Without this, when using quad-capable flashes, the spi-nor driver get stuck in the `spi_nor_wait_until_ready` function, because the read rx buffer is that of the former transaction.