### PR TITLE
flash: fix `flash_read` API for NXP LPC55S36

### DIFF
--- a/drivers/flash/soc_flash_mcux.c
+++ b/drivers/flash/soc_flash_mcux.c
@@ -221,7 +221,9 @@ static int flash_mcux_read(const struct device *dev, off_t offset,
 		/* Check id the ECC issue is due to the Flash being erased
 		 * ("addr" and "len" must be word-aligned for this call).
 		 */
-		rc = FLASH_VerifyErase(&priv->config, ((addr + 0x3) & ~0x3),  ((len + 0x3) & ~0x3));
+		rc = FLASH_VerifyErase(&priv->config,
+				       ROUND_DOWN(addr, 4),
+				       ROUND_DOWN(addr + len + 3, 4) - ROUND_DOWN(addr, 4));
 		if (rc == kStatus_FLASH_Success) {
 			rc = -ENODATA;
 		} else {


### PR DESCRIPTION
This PR reworks the LPC55S36 implementation of the `flash_mcux_read()` function to work around issue #80325. Feedback welcome!

This is achieved on the `CONFIG_CHECK_BEFORE_READING` path (the default) by using the `FLASH_Read()` HAL API call, which is resilient to errors, and map the error codes to properly emulate an erased page read. 

When `CONFIG_CHECK_BEFORE_READING` is disabled, the code reverts to the previous `memcpy()` operation, which is faster but unsafe on erased or otherwise unreadable pages.

`#ifdef` guards kept in the style of the file, though some may be changed to `if (IS_ENABLED(...))` if desired.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/80325