### PR TITLE
boards: arduino_nicla_vision: fix hardware information

### DIFF
--- a/boards/arduino/nicla_vision/arduino_nicla_vision_stm32h747xx_m7.dts
+++ b/boards/arduino/nicla_vision/arduino_nicla_vision_stm32h747xx_m7.dts
@@ -25,14 +25,6 @@
 		zephyr,camera = &dcmi;
 	};
 
-	sdram1: sdram@c0000000 {
-		compatible = "zephyr,memory-region", "mmio-sram";
-		device_type = "memory";
-		reg = <0xc0000000 DT_SIZE_M(8)>;
-		zephyr,memory-region = "SDRAM1";
-		zephyr,memory-attr = <( DT_MEM_ARM(ATTR_MPU_RAM) )>;
-	};
-
 	aliases {
 		led0 = &red_led;
 		led1 = &green_led;
@@ -46,10 +38,12 @@
 
 &clk_hse {
 	status = "okay";
+	hse-bypass;
 	clock-frequency = <DT_FREQ_M(25)>;
 };
 
 &clk_lse {
+	lse-bypass;
 	status = "okay";
 };
 
@@ -160,6 +154,37 @@
 		slot0_partition: partition@40000 {
 			label = "image-0";
 			reg = <0x40000 0x000c0000>;
+		};
+	};
+};
+
+&quadspi {
+	pinctrl-0 = <&quadspi_clk_pf10 &quadspi_bk1_ncs_pg6
+		     &quadspi_bk1_io0_pd11 &quadspi_bk1_io1_pf9
+		     &quadspi_bk1_io2_pe2 &quadspi_bk1_io3_pd13>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	n25q128a1: qspi-nor-flash@90000000 {
+		compatible = "st,stm32-qspi-nor";
+		reg = <0x90000000 DT_SIZE_M(16)>; /* 128 Mbits */
+		qspi-max-frequency = <72000000>;
+		status = "okay";
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			slot1_partition: partition@0 {
+				label = "image-1";
+				reg = <0x00000000 DT_SIZE_M(1)>;
+			};
+
+			storage_partition: partition@100000 {
+				label = "storage";
+				reg = <0x00100000 DT_SIZE_M(15)>;
+			};
 		};
 	};
 };

--- a/boards/arduino/nicla_vision/board_gpio_hse.c
+++ b/boards/arduino/nicla_vision/board_gpio_hse.c
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2024 DNDG srl
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/init.h>
+#include <stm32h7xx_ll_bus.h>
+#include <stm32h7xx_ll_gpio.h>
+
+static int board_gpio_hse(void)
+{
+	/* The external oscillator that drives the HSE clock should be enabled
+	 * by setting the GPIOH1 pin. This function is registered at priority
+	 * RE_KERNEL_1 to be executed before the standard STM clock
+	 * setup code.
+	 */
+
+	LL_AHB4_GRP1_EnableClock(LL_AHB4_GRP1_PERIPH_GPIOH);
+
+	LL_GPIO_SetPinMode(GPIOH, LL_GPIO_PIN_1, LL_GPIO_MODE_OUTPUT);
+	LL_GPIO_SetPinSpeed(GPIOH, LL_GPIO_PIN_1, LL_GPIO_SPEED_FREQ_LOW);
+	LL_GPIO_SetPinOutputType(GPIOH, LL_GPIO_PIN_1, LL_GPIO_OUTPUT_PUSHPULL);
+	LL_GPIO_SetPinPull(GPIOH, LL_GPIO_PIN_1, LL_GPIO_PULL_UP);
+	LL_GPIO_SetOutputPin(GPIOH, LL_GPIO_PIN_1);
+
+	return 0;
+}
+
+SYS_INIT(board_gpio_hse, PRE_KERNEL_1, 0);


### PR DESCRIPTION
The board shares many features with other Arduinos based on STM32H747 (like the HSE in bypass mode). Once https://github.com/zephyrproject-rtos/zephyr/pull/76542 is merged, PF1550 support should be added too to allow switching IO voltage from 3v3 to 1v8