### PR TITLE
drivers: serial: uart_async_to_irq: Fix uart_irq_tx_complete

### DIFF
--- a/drivers/serial/uart_async_to_irq.c
+++ b/drivers/serial/uart_async_to_irq.c
@@ -284,7 +284,7 @@ void z_uart_async_to_irq_irq_rx_disable(const struct device *dev)
 /** Interrupt driven transfer complete function */
 int z_uart_async_to_irq_irq_tx_complete(const struct device *dev)
 {
-	return z_uart_async_to_irq_irq_tx_ready(dev);
+	return z_uart_async_to_irq_irq_tx_ready(dev) > 0 ? 1 : 0;
 }
 
 /** Interrupt driven receiver ready function */


### PR DESCRIPTION
uart_irq_tx_complete is implemented by z_uart_async_to_irq_irq_tx_ready which changed recently to return positive value that may be bigger than 1. uart_irq_tx_complete shall not return value bigger than 1.