### PR TITLE
Fix tests/bluetooth/host/keys/bt_keys_get_addr/*

### DIFF
--- a/subsys/bluetooth/host/keys.h
+++ b/subsys/bluetooth/host/keys.h
@@ -6,6 +6,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#ifndef ZEPHYR_SUBSYS_BLUETOOTH_HOST_KEYS_H_
+#define ZEPHYR_SUBSYS_BLUETOOTH_HOST_KEYS_H_
+
+#include <zephyr/bluetooth/bluetooth.h>
+
 /** @cond INTERNAL_HIDDEN */
 
 enum bt_keys_type {
@@ -233,3 +238,5 @@ void bt_keys_link_key_update_usage(const bt_addr_t *addr);
 void bt_keys_show_sniffer_info(struct bt_keys *keys, void *data);
 
 /** @endcond */
+
+#endif /* ZEPHYR_SUBSYS_BLUETOOTH_HOST_KEYS_H_ */

--- a/tests/bluetooth/host/keys/bt_keys_get_addr/src/test_suite_full_list_invalid_values.c
+++ b/tests/bluetooth/host/keys/bt_keys_get_addr/src/test_suite_full_list_invalid_values.c
@@ -28,14 +28,14 @@ static int bt_unpair_unreachable_custom_fake(uint8_t id, const bt_addr_le_t *add
 	return 0;
 }
 
-static void bt_conn_foreach_conn_ref_null_custom_fake(int type, bt_conn_foreach_cb func,
-							void *data)
+static void bt_conn_foreach_conn_ref_null_custom_fake(enum bt_conn_type type,
+						      bt_conn_foreach_cb func, void *data)
 {
 	func(NULL, data);
 }
 
-static void bt_conn_foreach_data_ref_null_custom_fake(int type, bt_conn_foreach_cb func,
-							void *data)
+static void bt_conn_foreach_data_ref_null_custom_fake(enum bt_conn_type type,
+						      bt_conn_foreach_cb func, void *data)
 {
 	struct bt_conn conn;
 

--- a/tests/bluetooth/host/keys/bt_keys_get_addr/src/test_suite_full_list_overwrite_oldest.c
+++ b/tests/bluetooth/host/keys/bt_keys_get_addr/src/test_suite_full_list_overwrite_oldest.c
@@ -46,8 +46,8 @@ static int bt_unpair_unreachable_custom_fake(uint8_t id, const bt_addr_le_t *add
 	return 0;
 }
 
-static void bt_conn_foreach_key_slot_0_in_use_custom_fake(int type, bt_conn_foreach_cb func,
-							  void *data)
+static void bt_conn_foreach_key_slot_0_in_use_custom_fake(enum bt_conn_type type,
+							  bt_conn_foreach_cb func, void *data)
 {
 	struct bt_conn conn;
 
@@ -71,8 +71,8 @@ static void bt_conn_foreach_key_slot_0_in_use_custom_fake(int type, bt_conn_fore
 	func(&conn, data);
 }
 
-static void bt_conn_foreach_all_keys_in_use_custom_fake(int type, bt_conn_foreach_cb func,
-							void *data)
+static void bt_conn_foreach_all_keys_in_use_custom_fake(enum bt_conn_type type,
+							bt_conn_foreach_cb func, void *data)
 {
 	struct bt_conn conn;
 
@@ -86,8 +86,8 @@ static void bt_conn_foreach_all_keys_in_use_custom_fake(int type, bt_conn_foreac
 	}
 }
 
-static void bt_conn_foreach_no_keys_in_use_custom_fake(int type, bt_conn_foreach_cb func,
-							void *data)
+static void bt_conn_foreach_no_keys_in_use_custom_fake(enum bt_conn_type type,
+						       bt_conn_foreach_cb func, void *data)
 {
 	struct bt_conn conn;
 


### PR DESCRIPTION
    subsys/bluetooth/host/keys.h: Add include guard and required include
    
    This header requires bluetooth.h but was not including it itself.
    Due to this we had 2 tests failing to build.
    Let's just include the dependencies to this header instead of
    relaying on users including the dependencies dependencies in
    the right order.
    
    Also, let's add an include guard as in a test this header was
    included twice leading to weird build errors.

---

    tests/bluetooth/host/keys/bt_keys_get_addr: Correct mock prototypes
    
    In 82d8f09de18708259b85e5bbf5e32541fd807ed4
    the bt_conn_foreach prototype was changed, but these unit tests
    kept using the old prototype which leads to a build warning.
    Let's fix the prototype in the tests.

Fixes #80357
Related to 82d8f09de18708259b85e5bbf5e32541fd807ed4