### PR TITLE
drivers: flash: spi_nor: fix config struct

### DIFF
--- a/drivers/flash/spi_nor.c
+++ b/drivers/flash/spi_nor.c
@@ -1632,20 +1632,12 @@ static const struct flash_driver_api spi_nor_api = {
 
 #define INST_HAS_LOCK(idx) DT_INST_NODE_HAS_PROP(idx, has_lock)
 
-#define INST_HAS_WP_GPIO(idx) DT_INST_NODE_HAS_PROP(idx, wp_gpios)
-
-#define INST_HAS_HOLD_GPIO(idx) DT_INST_NODE_HAS_PROP(idx, hold_gpios)
-
 #define LOCK_DEFINE(idx)								\
 	IF_ENABLED(INST_HAS_LOCK(idx), (BUILD_ASSERT(DT_INST_PROP(idx, has_lock) ==	\
 					(DT_INST_PROP(idx, has_lock) & 0xFF),		\
 					"Need support for lock clear beyond SR1");))
 
-#define INST_HAS_ENTER_4BYTE_ADDR(idx) DT_INST_NODE_HAS_PROP(idx, enter_4byte_addr)
-
-#define CONFIGURE_4BYTE_ADDR(idx)					\
-	IF_ENABLED(INST_HAS_ENTER_4BYTE_ADDR(idx),			\
-		(.enter_4byte_addr = DT_INST_PROP(idx, enter_4byte_addr),))
+#define CONFIGURE_4BYTE_ADDR(idx) .enter_4byte_addr = DT_INST_PROP_OR(idx, enter_4byte_addr, 0),
 
 #define INIT_T_ENTER_DPD(idx)								\
 	COND_CODE_1(DT_INST_NODE_HAS_PROP(idx, t_enter_dpd),				\
@@ -1661,15 +1653,9 @@ static const struct flash_driver_api spi_nor_api = {
 		(.t_exit_dpd = 0))
 #endif
 
-#define INIT_WP_GPIOS(idx) \
-	COND_CODE_1(DT_INST_NODE_HAS_PROP(idx, wp_gpios), \
-		(.wp = GPIO_DT_SPEC_INST_GET(idx, wp_gpios)), \
-		(.wp = {0}))
+#define INIT_WP_GPIOS(idx) .wp = GPIO_DT_SPEC_INST_GET_OR(idx, wp_gpios, {0})
 
-#define INIT_HOLD_GPIOS(idx) \
-	COND_CODE_1(DT_INST_NODE_HAS_PROP(idx, hold_gpios), \
-		(.hold = GPIO_DT_SPEC_INST_GET(idx, hold_gpios)), \
-		(.hold = {0},))
+#define INIT_HOLD_GPIOS(idx) .hold = GPIO_DT_SPEC_INST_GET_OR(idx, hold_gpios, {0})
 
 #define INIT_WAKEUP_SEQ_PARAMS(idx)							\
 	COND_CODE_1(DT_INST_NODE_HAS_PROP(idx, dpd_wakeup_sequence),			\
@@ -1681,15 +1667,10 @@ static const struct flash_driver_api spi_nor_api = {
 			DT_INST_PROP_BY_IDX(idx, dpd_wakeup_sequence, 2), NSEC_PER_MSEC)),\
 		(.t_dpdd_ms = 0, .t_crdp_ms = 0, .t_rdp_ms = 0))
 
-#define INIT_MXICY_MX25R_POWER_MODE(idx)						\
-	COND_CODE_1(DT_INST_NODE_HAS_PROP(idx, mxicy_mx25r_power_mode),			\
-		(.mxicy_mx25r_power_mode = DT_INST_ENUM_IDX(idx, mxicy_mx25r_power_mode)),\
-		(.mxicy_mx25r_power_mode = 0))
+#define INIT_MXICY_MX25R_POWER_MODE(idx)							\
+	.mxicy_mx25r_power_mode = DT_INST_ENUM_IDX_OR(idx, mxicy_mx25r_power_mode, 0)
 
-#define INIT_RESET_GPIOS(idx) \
-	COND_CODE_1(DT_INST_NODE_HAS_PROP(idx, reset_gpios), \
-		(.reset = GPIO_DT_SPEC_INST_GET(idx, reset_gpios)), \
-		(.reset = {0}))
+#define INIT_RESET_GPIOS(idx) .reset = GPIO_DT_SPEC_INST_GET_OR(idx, reset_gpios, {0})
 
 #define INST_CONFIG_STRUCT_GEN(idx)								\
 	DEFINE_PAGE_LAYOUT(idx)									\

--- a/drivers/flash/spi_nor.c
+++ b/drivers/flash/spi_nor.c
@@ -1695,30 +1695,33 @@ static const struct flash_driver_api spi_nor_api = {
 	DEFINE_PAGE_LAYOUT(idx)									\
 	.flash_size = DT_INST_PROP(idx, size) / 8,						\
 	.jedec_id = DT_INST_PROP(idx, jedec_id),						\
-	.dpd_exist = DT_INST_PROP(idx, has_dpd),						\
-	.dpd_wakeup_sequence_exist = DT_INST_NODE_HAS_PROP(idx, dpd_wakeup_sequence),		\
-	.mxicy_mx25r_power_mode_exist = DT_INST_NODE_HAS_PROP(idx, mxicy_mx25r_power_mode),	\
-	.reset_gpios_exist = DT_INST_NODE_HAS_PROP(idx, reset_gpios),				\
-	.requires_ulbpr_exist = DT_INST_PROP(idx, requires_ulbpr),				\
-	.wp_gpios_exist = DT_INST_NODE_HAS_PROP(idx, wp_gpios),					\
-	.hold_gpios_exist = DT_INST_NODE_HAS_PROP(idx, hold_gpios),				\
-	IF_ENABLED(INST_HAS_LOCK(idx), (.has_lock = DT_INST_PROP(idx, has_lock),))		\
 	IF_ENABLED(CONFIG_SPI_NOR_SFDP_MINIMAL, (CONFIGURE_4BYTE_ADDR(idx)))			\
 	IF_ENABLED(CONFIG_SPI_NOR_SFDP_DEVICETREE,						\
 		(.bfp_len = sizeof(bfp_##idx##_data) / 4,					\
-		 .bfp = (const struct jesd216_bfp *)bfp_##idx##_data,))				\
-	IF_ENABLED(ANY_INST_HAS_DPD, (INIT_T_ENTER_DPD(idx),))					\
-	IF_ENABLED(UTIL_AND(ANY_INST_HAS_DPD, ANY_INST_HAS_T_EXIT_DPD), (INIT_T_EXIT_DPD(idx),))\
-	IF_ENABLED(ANY_INST_HAS_DPD_WAKEUP_SEQUENCE, (INIT_WAKEUP_SEQ_PARAMS(idx),))		\
-	IF_ENABLED(ANY_INST_HAS_MXICY_MX25R_POWER_MODE, (INIT_MXICY_MX25R_POWER_MODE(idx),))	\
-	IF_ENABLED(ANY_INST_HAS_RESET_GPIOS, (INIT_RESET_GPIOS(idx),))				\
-	IF_ENABLED(ANY_INST_HAS_WP_GPIOS, (INIT_WP_GPIOS(idx),))				\
-	IF_ENABLED(ANY_INST_HAS_HOLD_GPIOS, (INIT_HOLD_GPIOS(idx),))
+		 .bfp = (const struct jesd216_bfp *)bfp_##idx##_data,))
 
 #define GENERATE_CONFIG_STRUCT(idx)								\
 	static const struct spi_nor_config spi_nor_##idx##_config = {				\
 		.spi = SPI_DT_SPEC_INST_GET(idx, SPI_WORD_SET(8), CONFIG_SPI_NOR_CS_WAIT_DELAY),\
-		COND_CODE_1(CONFIG_SPI_NOR_SFDP_RUNTIME, EMPTY(), (INST_CONFIG_STRUCT_GEN(idx)))};
+		.dpd_exist = DT_INST_PROP(idx, has_dpd),					\
+		.dpd_wakeup_sequence_exist = DT_INST_NODE_HAS_PROP(idx, dpd_wakeup_sequence),	\
+		.mxicy_mx25r_power_mode_exist =							\
+			DT_INST_NODE_HAS_PROP(idx, mxicy_mx25r_power_mode),			\
+		.reset_gpios_exist = DT_INST_NODE_HAS_PROP(idx, reset_gpios),			\
+		.requires_ulbpr_exist = DT_INST_PROP(idx, requires_ulbpr),			\
+		.wp_gpios_exist = DT_INST_NODE_HAS_PROP(idx, wp_gpios),				\
+		.hold_gpios_exist = DT_INST_NODE_HAS_PROP(idx, hold_gpios),			\
+		IF_ENABLED(INST_HAS_LOCK(idx), (.has_lock = DT_INST_PROP(idx, has_lock),))	\
+		IF_ENABLED(ANY_INST_HAS_DPD, (INIT_T_ENTER_DPD(idx),))				\
+		IF_ENABLED(UTIL_AND(ANY_INST_HAS_DPD, ANY_INST_HAS_T_EXIT_DPD),			\
+			(INIT_T_EXIT_DPD(idx),))						\
+		IF_ENABLED(ANY_INST_HAS_DPD_WAKEUP_SEQUENCE, (INIT_WAKEUP_SEQ_PARAMS(idx),))	\
+		IF_ENABLED(ANY_INST_HAS_MXICY_MX25R_POWER_MODE,					\
+			(INIT_MXICY_MX25R_POWER_MODE(idx),))					\
+		IF_ENABLED(ANY_INST_HAS_RESET_GPIOS, (INIT_RESET_GPIOS(idx),))			\
+		IF_ENABLED(ANY_INST_HAS_WP_GPIOS, (INIT_WP_GPIOS(idx),))			\
+		IF_ENABLED(ANY_INST_HAS_HOLD_GPIOS, (INIT_HOLD_GPIOS(idx),))			\
+		IF_DISABLED(CONFIG_SPI_NOR_SFDP_RUNTIME, (INST_CONFIG_STRUCT_GEN(idx)))};
 
 #define ASSIGN_PM(idx)							\
 		PM_DEVICE_DT_INST_DEFINE(idx, spi_nor_pm_control);


### PR DESCRIPTION
lots of values from the DT where not set corretly, if
`CONFIG_SPI_NOR_SFDP_RUNTIME` was
enabled. This fixes it.

Got introduced with https://github.com/zephyrproject-rtos/zephyr/pull/70415

Fixes #80383