### PR TITLE
timing: fix ARM Cortex-M timing functions wrap-around issue

### DIFF
--- a/arch/arm/core/cortex_m/timing.c
+++ b/arch/arm/core/cortex_m/timing.c
@@ -104,7 +104,7 @@ timing_t arch_timing_counter_get(void)
 uint64_t arch_timing_cycles_get(volatile timing_t *const start,
 				volatile timing_t *const end)
 {
-	return (*end - *start);
+	return ((uint32_t)*end - (uint32_t)*start);
 }
 
 uint64_t arch_timing_freq_get(void)


### PR DESCRIPTION
Added casts to uint32_t in arch_timing_cycles_get() to handle the wrap-around of the 32-bit cycle counter correctly.

Fixes #80008 