### PR TITLE
doc: porting_guide: encourage the use of webp for board images

### DIFF
--- a/doc/hardware/porting/board_porting.rst
+++ b/doc/hardware/porting/board_porting.rst
@@ -261,7 +261,7 @@ Your board directory should look like this:
    ├── board.cmake
    ├── CMakeLists.txt
    ├── doc
-   │   ├── plank.png
+   │   ├── plank.webp
    │   └── index.rst
    ├── Kconfig.plank
    ├── Kconfig.defconfig
@@ -301,7 +301,7 @@ The optional files are:
 - :file:`board.cmake`: used for :ref:`flash-and-debug-support`
 - :file:`CMakeLists.txt`: if you need to add additional source files to
   your build.
-- :file:`doc/index.rst`, :file:`doc/plank.png`: documentation for and a picture
+- :file:`doc/index.rst`, :file:`doc/plank.webp`: documentation for and a picture
   of your board. You only need this if you're :ref:`contributing-your-board` to
   Zephyr.
 - :file:`plank.yaml`: a YAML file with miscellaneous metadata used by the


### PR DESCRIPTION
It's already mentioned in the board.tmpl template file as well as in documentation writing guidelines so fix this leftover and make sure people contributing boards aim for webp format as it helps with file size while supporting transparency.