### PR TITLE
boards: up_squared: add timeout multiplier

### DIFF
--- a/boards/up-bridge-the-gap/up_squared/up_squared.yaml
+++ b/boards/up-bridge-the-gap/up_squared/up_squared.yaml
@@ -9,6 +9,7 @@ supported:
   - acpi
   - smp
 testing:
+  timeout_multiplier: 2
   ignore_tags:
     - net
     - bluetooth


### PR DESCRIPTION
To accommodate for some slow tests on up2.
For example: tests/arch/x86/info/arch.x86.info.userspace
Execution time of this test is close to 55s and sometimes above up to the 60s.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/80134