### PR TITLE
driver: sensor: adxl345: Bug fix for q31_t conv

### DIFF
--- a/drivers/sensor/adi/adxl345/adxl345.c
+++ b/drivers/sensor/adi/adxl345/adxl345.c
@@ -438,7 +438,7 @@ static int adxl345_init(const struct device *dev)
 #ifdef CONFIG_ADXL345_TRIGGER
 	const struct adxl345_dev_config *cfg = dev->config;
 #endif
-	uint8_t dev_id;
+	uint8_t dev_id, full_res;
 
 	data->sample_number = 0;
 
@@ -459,11 +459,13 @@ static int adxl345_init(const struct device *dev)
 		return -EIO;
 	}
 
-	rc = adxl345_reg_write_byte(dev, ADXL345_DATA_FORMAT_REG, ADXL345_RANGE_16G);
+	rc = adxl345_reg_write_byte(dev, ADXL345_DATA_FORMAT_REG, ADXL345_RANGE_8G);
 	if (rc < 0) {
 		LOG_ERR("Data format set failed\n");
 		return -EIO;
 	}
+
+	data->selected_range = ADXL345_RANGE_8G;
 
 	rc = adxl345_reg_write_byte(dev, ADXL345_RATE_REG, ADXL345_RATE_25HZ);
 	if (rc < 0) {
@@ -497,11 +499,16 @@ static int adxl345_init(const struct device *dev)
 	if (rc) {
 		return rc;
 	}
-		rc = adxl345_interrupt_config(dev, ADXL345_INT_MAP_WATERMARK_MSK);
+	rc = adxl345_interrupt_config(dev, ADXL345_INT_MAP_WATERMARK_MSK);
 	if (rc) {
 		return rc;
 	}
 #endif
+
+	rc = adxl345_reg_read_byte(dev, ADXL345_DATA_FORMAT_REG, &full_res);
+	uint8_t is_full_res_set = (full_res & ADXL345_DATA_FORMAT_FULL_RES) != 0;
+
+	data->is_full_res = is_full_res_set;
 	return 0;
 }
 

--- a/drivers/sensor/adi/adxl345/adxl345.h
+++ b/drivers/sensor/adi/adxl345/adxl345.h
@@ -40,13 +40,14 @@
 #define SAMPLE_NUM  0x1F
 
 /* Registers */
-#define ADXL345_DEVICE_ID_REG      0x00
-#define ADXL345_RATE_REG           0x2c
-#define ADXL345_POWER_CTL_REG      0x2d
-#define ADXL345_DATA_FORMAT_REG    0x31
-#define ADXL345_X_AXIS_DATA_0_REG  0x32
-#define ADXL345_FIFO_CTL_REG       0x38
-#define ADXL345_FIFO_STATUS_REG    0x39
+#define ADXL345_DEVICE_ID_REG           0x00
+#define ADXL345_RATE_REG                0x2c
+#define ADXL345_POWER_CTL_REG           0x2d
+#define ADXL345_DATA_FORMAT_REG         0x31
+#define ADXL345_DATA_FORMAT_FULL_RES    0x08
+#define ADXL345_X_AXIS_DATA_0_REG       0x32
+#define ADXL345_FIFO_CTL_REG            0x38
+#define ADXL345_FIFO_STATUS_REG         0x39
 
 #define ADXL345_PART_ID            0xe5
 
@@ -58,6 +59,7 @@
 #define ADXL345_ENABLE_MEASURE_BIT (1 << 3)
 #define ADXL345_FIFO_STREAM_MODE   (1 << 7)
 #define ADXL345_FIFO_COUNT_MASK    0x3f
+#define ADXL345_COMPLEMENT_MASK(x) GENMASK(15, (x))
 #define ADXL345_COMPLEMENT         0xfc00
 
 #define ADXL345_MAX_FIFO_SIZE      32
@@ -149,6 +151,8 @@ struct adxl345_dev_data {
 	int16_t bufy[ADXL345_MAX_FIFO_SIZE];
 	int16_t bufz[ADXL345_MAX_FIFO_SIZE];
 	struct adxl345_fifo_config fifo_config;
+	uint8_t is_full_res;
+	uint8_t selected_range;
 #ifdef CONFIG_ADXL345_TRIGGER
 	struct gpio_callback gpio_cb;
 
@@ -182,6 +186,8 @@ struct adxl345_dev_data {
 
 struct adxl345_fifo_data {
 	uint8_t is_fifo: 1;
+	uint8_t is_full_res: 1;
+	uint8_t selected_range: 2;
 	uint8_t sample_set_size: 4;
 	uint8_t int_status;
 	uint16_t accel_odr: 4;
@@ -194,6 +200,7 @@ struct adxl345_sample {
 	uint8_t is_fifo: 1;
 	uint8_t res: 7;
 #endif /* CONFIG_ADXL345_STREAM */
+	uint8_t selected_range;
 	int16_t x;
 	int16_t y;
 	int16_t z;

--- a/drivers/sensor/adi/adxl345/adxl345_stream.c
+++ b/drivers/sensor/adi/adxl345/adxl345_stream.c
@@ -157,6 +157,8 @@ static void adxl345_process_fifo_samples_cb(struct rtio *r, const struct rtio_sq
 	hdr->is_fifo = 1;
 	hdr->timestamp = data->timestamp;
 	hdr->int_status = data->status1;
+	hdr->is_full_res = data->is_full_res;
+	hdr->selected_range = data->selected_range;
 	hdr->accel_odr = cfg->odr;
 	hdr->sample_set_size = sample_set_size;
 


### PR DESCRIPTION
This is a bug fix for adxl345_accel_convert_q31 functions. Functions are used to convert samples received from sensor to q31_t format when RTIO stream is used.

Signed-off-by: Dimitrije Lilic dimitrije.lilic@orioninc.com