### PR TITLE
tests: net: wifi_credentials: restrict to native_sim

### DIFF
--- a/tests/net/lib/wifi_credentials/testcase.yaml
+++ b/tests/net/lib/wifi_credentials/testcase.yaml
@@ -2,5 +2,7 @@ tests:
   net.wifi_credentials:
     tags:
       - net
+    platform_allow:
+      - native_sim
     integration_platforms:
       - native_sim

--- a/tests/net/lib/wifi_credentials_backend_psa/testcase.yaml
+++ b/tests/net/lib/wifi_credentials_backend_psa/testcase.yaml
@@ -2,5 +2,7 @@ tests:
   net.wifi_credentials_backend_psa:
     tags:
       - net
+    platform_allow:
+      - native_sim
     integration_platforms:
       - native_sim

--- a/tests/net/lib/wifi_credentials_backend_settings/testcase.yaml
+++ b/tests/net/lib/wifi_credentials_backend_settings/testcase.yaml
@@ -2,5 +2,7 @@ tests:
   net.wifi_credentials_backend_settings:
     tags:
       - net
+    platform_allow:
+      - native_sim
     integration_platforms:
       - native_sim


### PR DESCRIPTION
Adjust the testcase.yaml files to only allow running on native_sim. These tests use mocking and are not meant to run on embedded platforms.