### PR TITLE
manifest: hal_nxp: Pull in change to include SDMA/MICFIL hal drivers

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -199,7 +199,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: c42d70dba969de09c0e43d3b26a3ffcb015f6f33
+      revision: d291bdcc4a59bace5ae7453e777e06080ccda8ce
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
SDMA hal driver API is used by the upcoming Zephyr SDMA driver