### PR TITLE
Revert "kernel: banner: Expose tainted builds"

### DIFF
--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -450,7 +450,6 @@ config BOOT_BANNER
 config BOOT_BANNER_STRING
 	string "Boot banner string"
 	depends on BOOT_BANNER
-	default "Booting Zephyr OS build (tainted)" if TAINT
 	default "Booting Zephyr OS build"
 	help
 	  Use this option to set the boot banner.


### PR DESCRIPTION
This reverts commit 6d4031f96c87d761fb198daebbd78e18b3c61edf.

Those makes majority of builds og platforms with blobs tainted although
the blob were not used or compiled in. So it is very misleading.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
