### PR TITLE
soc: dts: esp32c3: esp8685: Add files to indicate support

### DIFF
--- a/dts/riscv/espressif/esp32c3/esp8685.dtsi
+++ b/dts/riscv/espressif/esp32c3/esp8685.dtsi
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2024 Espressif Systems (Shanghai) Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "esp32c3_common.dtsi"

--- a/dts/riscv/espressif/esp32c3/esp8685_h4.dtsi
+++ b/dts/riscv/espressif/esp32c3/esp8685_h4.dtsi
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2024 Espressif Systems (Shanghai) Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "esp32c3_common.dtsi"
+
+/* 4MB flash */
+&flash0 {
+	reg = <0x0 DT_SIZE_M(4)>;
+};


### PR DESCRIPTION
Add SoC dtsi files to indicate support/compatibility with ESP32C3.