### PR TITLE
twister: terminate_process: fix NoSuchProcess error

### DIFF
--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/device/utils.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/device/utils.py
@@ -42,9 +42,10 @@ def terminate_process(proc: subprocess.Popen) -> None:
     """
     Try to terminate provided process and all its subprocesses recursively.
     """
-    for child in psutil.Process(proc.pid).children(recursive=True):
-        with contextlib.suppress(ProcessLookupError, psutil.NoSuchProcess):
-            os.kill(child.pid, signal.SIGTERM)
+    with contextlib.suppress(ProcessLookupError, psutil.NoSuchProcess):
+        for child in psutil.Process(proc.pid).children(recursive=True):
+            with contextlib.suppress(ProcessLookupError, psutil.NoSuchProcess):
+                os.kill(child.pid, signal.SIGTERM)
     proc.terminate()
     # sleep for a while before attempting to kill
     time.sleep(0.5)

--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/device/utils.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/device/utils.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import logging
 import os
 import platform
@@ -42,10 +43,8 @@ def terminate_process(proc: subprocess.Popen) -> None:
     Try to terminate provided process and all its subprocesses recursively.
     """
     for child in psutil.Process(proc.pid).children(recursive=True):
-        try:
+        with contextlib.suppress(ProcessLookupError, psutil.NoSuchProcess):
             os.kill(child.pid, signal.SIGTERM)
-        except (ProcessLookupError, psutil.NoSuchProcess):
-            pass
     proc.terminate()
     # sleep for a while before attempting to kill
     time.sleep(0.5)

--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -59,9 +59,10 @@ def terminate_process(proc):
     so we need to use try_kill_process_by_pid.
     """
 
-    for child in psutil.Process(proc.pid).children(recursive=True):
-        with contextlib.suppress(ProcessLookupError, psutil.NoSuchProcess):
-            os.kill(child.pid, signal.SIGTERM)
+    with contextlib.suppress(ProcessLookupError, psutil.NoSuchProcess):
+        for child in psutil.Process(proc.pid).children(recursive=True):
+            with contextlib.suppress(ProcessLookupError, psutil.NoSuchProcess):
+                os.kill(child.pid, signal.SIGTERM)
     proc.terminate()
     # sleep for a while before attempting to kill
     time.sleep(0.5)


### PR DESCRIPTION
NOTE: Even though previous commits indicate, that this can only happen on MacOS, that's actually not true. It happens on Linux as well.

The constructor of `psutil.Process` can throw an exception as well, so we need to wrap the whole loop in another try, unfortunately.