### PR TITLE
net: lib: http_server: add option to use ALPN

### DIFF
--- a/subsys/net/lib/http/Kconfig
+++ b/subsys/net/lib/http/Kconfig
@@ -179,6 +179,15 @@ config HTTP_SERVER_RESTART_DELAY
 	  allow any existing connections to finalize to avoid binding errors
 	  during initialization.
 
+config HTTP_SERVER_TLS_USE_ALPN
+	bool "ALPN support for HTTPS server"
+	depends on NET_SOCKETS_SOCKOPT_TLS
+	depends on MBEDTLS_SSL_ALPN
+	help
+	  Use ALPN (application layer protocol negotiation) to negotiate HTTP2
+	  protocol for TLS connections. Web browsers use this mechanism to determine
+	  whether HTTP2 is supported.
+
 config WEBSOCKET_CONSOLE
 	bool
 	default y if HTTP_SERVER_WEBSOCKET && SHELL_BACKEND_WEBSOCKET


### PR DESCRIPTION
Web browsers don't support HTTP Upgrade mechanism to upgrade to HTTP2. Instead, HTTP2 is supported only over TLS, and ALPN is used to negotiate the protocol to be used.

This commit adds the option use ALPN, so that web browsers can use HTTP2 with the server.

Note: web browsers are more strict with security when using HTTP2, depending on the browser:
- Some cipher suites are not allowed with HTTP2 but are fine with HTTP1
- Checking that the hostname/IP matches the certificate seems to be more strict (no option to ignore and continue anyway in some browsers)

Because of this I think it's best to keep the option as `default n` to avoid any unexpected issues.

I have some changes to the http server sample to get this working over HTTP2 with ALPN, but it's currently only working with Chrome and not Firefox, so may need a bit more experimentation with the certificate options before this is ready. I'll create a separate PR later on once I have something I think is good enough.