### PR TITLE
net: http_server: Fix possible buffer underrun

### DIFF
--- a/subsys/net/lib/http/http_server_core.c
+++ b/subsys/net/lib/http/http_server_core.c
@@ -760,7 +760,13 @@ void http_server_get_content_type_from_extension(char *url, char *content_type,
 	size_t url_len = strlen(url);
 
 	HTTP_SERVER_CONTENT_TYPE_FOREACH(ct) {
-		char *ext = &url[url_len - ct->extension_len];
+		char *ext;
+
+		if (url_len <= ct->extension_len) {
+			continue;
+		}
+
+		ext = &url[url_len - ct->extension_len];
 
 		if (strncmp(ext, ct->extension, ct->extension_len) == 0) {
 			strncpy(content_type, ct->content_type, content_type_size);


### PR DESCRIPTION
Avoid possible underruns when an url is shorter than a handled extension.