### PR TITLE
Fix stream_flash_init issue with auto-detecting device size

### DIFF
--- a/include/zephyr/storage/stream_flash.h
+++ b/include/zephyr/storage/stream_flash.h
@@ -79,8 +79,6 @@ struct stream_flash_ctx {
  *                Must be multiple of the flash device write-block-size.
  * @param offset Offset within flash device to start writing to
  * @param size Number of bytes available for performing buffered write.
- *             If this is '0', the size will be set to the total size
- *             of the flash device minus the offset.
  * @param cb Callback to be invoked on completed flash write operations.
  *
  * @return non-negative on success, negative errno code on fail

--- a/subsys/storage/stream/Kconfig
+++ b/subsys/storage/stream/Kconfig
@@ -19,6 +19,17 @@ config STREAM_FLASH_ERASE
 	  If disabled an external actor must erase the flash area being written
 	  to.
 
+config STREAM_FLASH_VALIDATE_LAYOUT
+	bool "Validate designated range agains page layout"
+	default y
+	help
+	  Enables validation of designated Stream Flash area on device agains
+	  page layout of device. Validation ensures that area is aligned
+	  to erase page of device.
+	  This option may be disabled to reduce code size and Stream Flash
+	  instance initialization time once testing ensures that all
+	  Stream Flash instances are properly aligned on devices.
+
 config STREAM_FLASH_PROGRESS
 	bool "Persistent stream write progress"
 	depends on SETTINGS


### PR DESCRIPTION
Two commits:
 - Removal of size auto-detection that could lead to potential problems with Stream Flash overwriting area that could be plaed behind it on storage device
 - Improvement in tests that take into account the change

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/71042