### PR TITLE
dts: arm: nxp_mcxn94x: fix support for NS mode

### DIFF
--- a/dts/arm/nxp/nxp_mcxn94x_ns.dtsi
+++ b/dts/arm/nxp/nxp_mcxn94x_ns.dtsi
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <mem.h>
+#include <arm/armv8-m.dtsi>
+
 / {
 	soc {
 		sram: sram@4000000 {


### PR DESCRIPTION
Fix build error for MCXN94X devicetree for nonsecure mode