### PR TITLE
drivers: serial: nrfx_uart: Fix poll_out for low baudrates

### DIFF
--- a/drivers/serial/uart_nrfx_uart.c
+++ b/drivers/serial/uart_nrfx_uart.c
@@ -287,7 +287,7 @@ static void uart_nrfx_poll_out(const struct device *dev, unsigned char c)
 	/* Wait until the transmitter is ready, i.e. the character is sent. */
 	bool res;
 
-	NRFX_WAIT_FOR(event_txdrdy_check(), 1000, 1, res);
+	NRFX_WAIT_FOR(event_txdrdy_check(), 10000, 1, res);
 
 	/* Deactivate the transmitter so that it does not needlessly
 	 * consume power.


### PR DESCRIPTION
uart_poll_out had 1 ms timeout which is too short for lower baudrates. Increase to 10 ms.