### PR TITLE
logging: backend: websocket: Add missing header file

### DIFF
--- a/include/zephyr/logging/log_backend_ws.h
+++ b/include/zephyr/logging/log_backend_ws.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_LOG_BACKEND_WS_H_
+#define ZEPHYR_LOG_BACKEND_WS_H_
+
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Register websocket socket where the logging output is sent.
+ *
+ * @param fd Websocket socket value.
+ *
+ * @return 0 if ok, <0 if error
+ */
+int log_backend_ws_register(int fd);
+
+/**
+ * @brief Unregister websocket socket where the logging output was sent.
+ *
+ * @details After this the websocket output is disabled.
+ *
+ * @param fd Websocket socket value.
+ *
+ * @return 0 if ok, <0 if error
+ */
+int log_backend_ws_unregister(int fd);
+
+/**
+ * @brief Get the websocket logger backend
+ *
+ * @details This function returns the websocket logger backend.
+ *
+ * @return Pointer to the websocket logger backend.
+ */
+const struct log_backend *log_backend_ws_get(void);
+
+/**
+ * @brief Start the websocket logger backend
+ *
+ * @details This function starts the websocket logger backend.
+ */
+void log_backend_ws_start(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_LOG_BACKEND_WS_H_ */

--- a/samples/net/sockets/echo_server/sample.yaml
+++ b/samples/net/sockets/echo_server/sample.yaml
@@ -145,3 +145,9 @@ tests:
   sample.net.sockets.echo_server.802154.subg:
     extra_args: EXTRA_CONF_FILE="overlay-802154-subg.conf"
     platform_allow: beagleconnect_freedom
+  sample.net.sockets.echo_server.ws_console:
+    platform_allow:
+      - native_sim
+      - native_sim/native/64
+    extra_args:
+      - EXTRA_CONF_FILE="overlay-ws-console.conf"

--- a/samples/net/sockets/echo_server/src/tcp.c
+++ b/samples/net/sockets/echo_server/src/tcp.c
@@ -250,7 +250,7 @@ static int process_tcp(struct data *data)
 
 	LOG_INF("TCP (%s): Accepted connection", data->proto);
 
-#define MAX_NAME_LEN sizeof("tcp6[0]")
+#define MAX_NAME_LEN sizeof("tcp6[xxx]")
 
 #if defined(CONFIG_NET_IPV6)
 	if (client_addr.sin_family == AF_INET6) {
@@ -270,7 +270,7 @@ static int process_tcp(struct data *data)
 		if (IS_ENABLED(CONFIG_THREAD_NAME)) {
 			char name[MAX_NAME_LEN];
 
-			snprintk(name, sizeof(name), "tcp6[%d]", slot);
+			snprintk(name, sizeof(name), "tcp6[%3d]", (uint8_t)slot);
 			k_thread_name_set(&tcp6_handler_thread[slot], name);
 		}
 	}
@@ -294,7 +294,7 @@ static int process_tcp(struct data *data)
 		if (IS_ENABLED(CONFIG_THREAD_NAME)) {
 			char name[MAX_NAME_LEN];
 
-			snprintk(name, sizeof(name), "tcp4[%d]", slot);
+			snprintk(name, sizeof(name), "tcp4[%3d]", (uint8_t)slot);
 			k_thread_name_set(&tcp4_handler_thread[slot], name);
 		}
 	}

--- a/subsys/logging/backends/log_backend_ws.c
+++ b/subsys/logging/backends/log_backend_ws.c
@@ -64,7 +64,7 @@ static int ws_console_out(struct log_backend_ws_ctx *ctx, int c)
 	static int max_cnt = CONFIG_LOG_BACKEND_WS_TX_RETRY_CNT;
 	bool printnow = false;
 	unsigned int cnt = 0;
-	int ret;
+	int ret = 0;
 
 	if (pos >= (sizeof(output_buf) - 1)) {
 		printnow = true;

--- a/subsys/shell/backends/shell_websocket.c
+++ b/subsys/shell/backends/shell_websocket.c
@@ -26,7 +26,7 @@ LOG_MODULE_REGISTER(shell_websocket, CONFIG_SHELL_WEBSOCKET_INIT_LOG_LEVEL);
 
 static void ws_server_cb(struct net_socket_service_event *evt);
 
-NET_SOCKET_SERVICE_SYNC_DEFINE_STATIC(websocket_server, NULL, ws_server_cb,
+NET_SOCKET_SERVICE_SYNC_DEFINE_STATIC(websocket_server, ws_server_cb,
 				      SHELL_WEBSOCKET_SERVICE_COUNT);
 
 static void ws_end_client_connection(struct shell_websocket *ws)


### PR DESCRIPTION
The log_backend_ws.h include file was missing which caused build issues.
Fixing also other bit-rotted things because proper compile testing was missing. Adding also ws-console compile testing to echo-server.

Fixes #80392