### PR TITLE
usb-c sink/source fixes

### DIFF
--- a/subsys/usb/usb_c/usbc_pe_common.c
+++ b/subsys/usb/usb_c/usbc_pe_common.c
@@ -1371,6 +1371,12 @@ static const struct smf_state pe_states[PE_STATE_COUNT] = {
 		pe_src_ready_exit,
 		NULL,
 		NULL),
+	[PE_SRC_DISABLED] = SMF_CREATE_STATE(
+		pe_src_disabled_entry,
+		NULL,
+		NULL,
+		NULL,
+		NULL),
 	[PE_SRC_TRANSITION_TO_DEFAULT] = SMF_CREATE_STATE(
 		pe_src_transition_to_default_entry,
 		pe_src_transition_to_default_run,

--- a/subsys/usb/usb_c/usbc_pe_common_internal.h
+++ b/subsys/usb/usb_c/usbc_pe_common_internal.h
@@ -83,6 +83,8 @@ enum usbc_pe_state {
 	PE_SRC_TRANSITION_SUPPLY,
 	/** PE_SRC_Ready */
 	PE_SRC_READY,
+	/** PE_SRC_Disabled */
+	PE_SRC_DISABLED,
 	/** PE_SRC_Hard_Reset */
 	PE_SRC_HARD_RESET,
 	/** PE_SRC_Hard_Reset_Received */

--- a/subsys/usb/usb_c/usbc_pe_snk_states.c
+++ b/subsys/usb/usb_c/usbc_pe_snk_states.c
@@ -432,6 +432,15 @@ void pe_snk_ready_run(void *obj)
 			case PD_DATA_SOURCE_CAP:
 				pe_set_state(dev, PE_SNK_EVALUATE_CAPABILITY);
 				break;
+			case PD_DATA_VENDOR_DEF:
+				/**
+				 * VDM is unsupported. PD2.0 ignores and PD3.0
+				 * reply with not supported.
+				 */
+				if (prl_get_rev(dev, PD_PACKET_SOP) > PD_REV20) {
+					pe_set_state(dev, PE_SEND_NOT_SUPPORTED);
+				}
+				break;
 			default:
 				pe_set_state(dev, PE_SEND_NOT_SUPPORTED);
 			}

--- a/subsys/usb/usb_c/usbc_pe_src_states.c
+++ b/subsys/usb/usb_c/usbc_pe_src_states.c
@@ -408,6 +408,15 @@ void pe_src_ready_run(void *obj)
 			case PD_DATA_REQUEST:
 				pe_set_state(dev, PE_SRC_NEGOTIATE_CAPABILITY);
 				break;
+			case PD_DATA_VENDOR_DEF:
+				/**
+				 * VDM is unsupported. PD2.0 ignores and PD3.0
+				 * reply with not supported.
+				 */
+				if (prl_get_rev(dev, PD_PACKET_SOP) > PD_REV20) {
+					pe_set_state(dev, PE_SEND_NOT_SUPPORTED);
+				}
+				break;
 			default:
 				pe_set_state(dev, PE_SEND_NOT_SUPPORTED);
 			}

--- a/subsys/usb/usb_c/usbc_pe_src_states.c
+++ b/subsys/usb/usb_c/usbc_pe_src_states.c
@@ -154,9 +154,12 @@ void pe_src_discovery_run(void *obj)
 	 *	1) The SourceCapabilityTimer times out
 	 *	2) And CapsCounter ≤ nCapsCount
 	 */
-	if (usbc_timer_expired(&pe->pd_t_typec_send_source_cap)
-			&& pe->caps_counter <= PD_N_CAPS_COUNT) {
-		pe_set_state(dev, PE_SRC_SEND_CAPABILITIES);
+	if (usbc_timer_expired(&pe->pd_t_typec_send_source_cap)) {
+		if (pe->caps_counter <= PD_N_CAPS_COUNT) {
+			pe_set_state(dev, PE_SRC_SEND_CAPABILITIES);
+		} else {
+			pe_set_state(dev, PE_SRC_DISABLED);
+		}
 	}
 }
 
@@ -481,6 +484,19 @@ void pe_src_ready_exit(void *obj)
 	if (pe_dpm_initiated_ams(dev)) {
 		prl_first_msg_notificaiton(dev);
 	}
+}
+
+/**
+ * @brief 8.3.3.2.7 PE_SRC_Disabled State
+ */
+void pe_src_disabled_entry(void *obj)
+{
+	LOG_INF("PE_SRC_Disabled");
+
+	/*
+	 * Unresponsive to USB Power Delivery messaging, but not to Hard Reset
+	 * Signaling. See pe_got_hard_reset
+	 */
 }
 
 /**

--- a/subsys/usb/usb_c/usbc_pe_src_states_internal.h
+++ b/subsys/usb/usb_c/usbc_pe_src_states_internal.h
@@ -58,6 +58,11 @@ void pe_src_ready_run(void *obj);
 void pe_src_ready_exit(void *obj);
 
 /**
+ * @brief PE_SRC_Disabled State
+ */
+void pe_src_disabled_entry(void *obj);
+
+/**
  * @brief PE_SRC_Transition_To_Default State
  */
 void pe_src_transition_to_default_entry(void *obj);

--- a/subsys/usb/usb_c/usbc_tc_snk_states.c
+++ b/subsys/usb/usb_c/usbc_tc_snk_states.c
@@ -205,6 +205,9 @@ void tc_attached_snk_entry(void *obj)
 
 	LOG_INF("Attached.SNK");
 
+	/* Clear cached CC voltage */
+	tc->cc_voltage = TC_CC_VOLT_OPEN;
+
 	/* Set CC polarity */
 	ret = tcpc_set_cc_polarity(tcpc, tc->cc_polarity);
 	if (ret != 0) {


### PR DESCRIPTION
these fixes are a result from integrating the pd stack for sink and source ports on a custom board.
the fixes are crucial to have to support the most basic sink/source use cases.

the implementation is similar to how the EC usb pd stack solves it.
