### PR TITLE
Bluetooth: Shell: Set err to 0 before shell_strtoul

### DIFF
--- a/subsys/bluetooth/host/shell/iso.c
+++ b/subsys/bluetooth/host/shell/iso.c
@@ -806,6 +806,7 @@ static int cmd_big_sync(const struct shell *sh, size_t argc, char *argv[])
 		return -ENOEXEC;
 	}
 
+	err = 0;
 	bis_bitfield = shell_strtoul(argv[1], 0, &err);
 	if (err != 0) {
 		shell_error(sh, "Could not parse bis_bitfield: %d", err);


### PR DESCRIPTION
The value of err was not initialized to 0 prior
to calling shell_strtoul, which only sets err
on actual error.