### PR TITLE
west.yml: MCUboot synchronization from v3.7-branch

### DIFF
--- a/doc/releases/release-notes-3.7.rst
+++ b/doc/releases/release-notes-3.7.rst
@@ -26,6 +26,21 @@ Mbed TLS was updated to version 3.6.2 (from 3.6.0). The release notes can be fou
 Mbed TLS 3.6 is an LTS release that will be supported
 with security and bug fixes until at least March 2027.
 
+MCUboot
+*******
+
+MCUboot commit has been updated to ``ea2410697dd0262edec041a0ccb07fdbde7c1aff``.
+
+Trusted Firmware-M
+******************
+
+TF-M was updated to version 2.1.1 (from 2.1.0). The release notes can be found at:
+
+  * https://trustedfirmware-m.readthedocs.io/en/tf-mv2.1.1/releases/2.1.1.html
+
+TF-M 2.1 is an LTS release synchronized with Mbed TLS 3.6 that
+will be supported with security and bug fixes until March 2027.
+
 .. _zephyr_3.7.0:
 
 Zephyr 3.7.0

--- a/submanifests/optional.yaml
+++ b/submanifests/optional.yaml
@@ -40,7 +40,7 @@ manifest:
       groups:
         - optional
     - name: tf-m-tests
-      revision: d552e4f18b92032bd335d5e3aa312f6acd82a83b
+      revision: 502ea90105ee18f20c78f710e2ba2ded0fc0756e
       path: modules/tee/tf-m/tf-m-tests
       remote: upstream
       groups:

--- a/west.yml
+++ b/west.yml
@@ -287,7 +287,7 @@ manifest:
       groups:
         - crypto
     - name: mcuboot
-      revision: fb2cf0ec3da3687b93f28e556ab682bdd4b85223
+      revision: ea2410697dd0262edec041a0ccb07fdbde7c1aff
       path: bootloader/mcuboot
     - name: mipi-sys-t
       path: modules/debug/mipi-sys-t

--- a/west.yml
+++ b/west.yml
@@ -327,7 +327,7 @@ manifest:
       groups:
         - crypto
     - name: trusted-firmware-m
-      revision: 069455be098383bf96eab73e3ff8e0c66c60fa5a
+      revision: 60ebade5d3d381a210af90191e475d8870b8adbc
       path: modules/tee/tf-m/trusted-firmware-m
       groups:
         - tee


### PR DESCRIPTION
west.yml: MCUboot synchronization from v3.7-branch

Update Zephyr fork of MCUboot to revision:
  ea2410697dd0262edec041a0ccb07fdbde7c1aff

Brings following Zephyr relevant fixes:

  - ea241069 boot: bootutil: boot_record: Fix issue with saving image data
  - 03b64828 boards: mcxn947_qspi: fix mcuboot partition allocation
  - 4a0f42c0 doc: remove repetition
  - 1c47465c boot: zephyr: use EXTRA_CONF_FILE instead of deprecated OVERLAY_CONFIG
  - 8e8ecd91 boot: zephyr: Fix serial recovery for NXP IMX.RT platforms
  - 52c7231a boot: zephyr: Fix Warning 'boot_serial_enter defined but not used'
  - a58d9026 zephyr: hello_world: Fix the main() return type warning
  - 50b7b9ee bootutil: Fix AES and SHA-256 contexts not zeroized with mbedTLS
  - 9b1b95c1 ci: Fix zephyr workflow
  - 809b0e42 bootutil: Add better mode selection checks
  - 0fe7ffd8 ci: Fix FIH Docker image release usage
  - a990c6b6 ci: Update FIH docker to Ubuntu Jammy (22.04)
  - 03d1a443 boot: zephyr: board: Fix nrf54l15pdk Kconfig fragment
  - 323eb8d1 boot: zephyr: MCXN947 currently only does not support swap mode
  - 0a88733d boot_serial: Fix `format` warning
  - 157547c8 boot_serial: Fix `incompatible-pointer-types` warning
  - 60ac682a bootutil: loader: Verify image header before checking image
  - 1cd53982 boot: main: avoid unused build warning
  - 587289d6 bootutil: Fix missing include
  - 610b8e2b bootutil: Fix swap move max app size calculation
  - a4800ce0 imgtool: Add missing encodings to emitter tests
  - 80397e0f imgtool: Fix getpub fails for ed25519 key
  - e29a123d docs: release-notes: Add note on name clash fix
  - a375a14d zephyr: Fix issue with sysbuild if something else is named mcuboot
  - 77b03c7f Fix style issues
  - 35bf48c5 boot: Change boot_enc_load to take slot number instead of image
  - 90836499 docs: release-notes: Add note on fixed zephyr RAM load address
  - 24de0fbc boot: zephyr: Fix RAM load chain load address
  - 197287ce imgtool: Bump cryptography library version
  - 7566edaf boot: Move encryption context invalidation to boot_enc_drop.
  - 86b1ef19 boot: Rename boot_enc_decrypt to boot_decrypt_key
  - 597a1996 boot: boot_serial: change logging to debug level
  - 2fa42bfa doc: readme-zephyr: fix the scratch partition example
  - f2971d20 boot: Add missing boot_enc_init
  - 071b3b8e boot: Remove pointless slot identification
  - 2cd6ce9f sim: Fix MCUBOOT_SWAP_USING_SCRATCH defined in direct-xip and ram-load


Fixes #80439