### PR TITLE
net: ipv4: Fix ARP probe check in address conflict detection

### DIFF
--- a/subsys/net/ip/ipv4_acd.c
+++ b/subsys/net/ip/ipv4_acd.c
@@ -288,15 +288,18 @@ enum net_verdict net_ipv4_acd_input(struct net_if *iface, struct net_pkt *pkt)
 		ll_addr = net_if_get_link_addr(addr_iface);
 
 		/* RFC 5227, ch. 2.1.1 Probe Details:
-		 * - Sender IP address match OR,
-		 * - Target IP address match with different sender HW address,
+		 * - ARP Request/Reply with Sender IP address match OR,
+		 * - ARP Probe where Target IP address match with different sender HW address,
 		 * indicate a conflict.
+		 * ARP Probe has an all-zero sender IP address
 		 */
 		if (net_ipv4_addr_cmp_raw(arp_hdr->src_ipaddr,
 					  (uint8_t *)&ifaddr->address.in_addr) ||
 		    (net_ipv4_addr_cmp_raw(arp_hdr->dst_ipaddr,
 					  (uint8_t *)&ifaddr->address.in_addr) &&
-		     memcmp(&arp_hdr->src_hwaddr, ll_addr->addr, ll_addr->len) != 0)) {
+				 (memcmp(&arp_hdr->src_hwaddr, ll_addr->addr, ll_addr->len) != 0) &&
+				 (net_ipv4_addr_cmp_raw(arp_hdr->src_ipaddr,
+						(uint8_t *)&(struct in_addr)INADDR_ANY_INIT)))) {
 			NET_DBG("Conflict detected from %s for %s",
 				net_sprint_ll_addr((uint8_t *)&arp_hdr->src_hwaddr,
 						   arp_hdr->hwlen),


### PR DESCRIPTION
The second condition needs to check ARP probes only

Fixes #80429