### PR TITLE
modules/hostap: Fix size_t print format specifier

### DIFF
--- a/modules/hostap/src/supp_main.c
+++ b/modules/hostap/src/supp_main.c
@@ -381,7 +381,7 @@ static int del_interface(struct supplicant_context *ctx, struct net_if *iface)
 	supplicant_generate_state_event(ifname, NET_EVENT_SUPPLICANT_CMD_IFACE_REMOVING, 0);
 
 	if (sizeof(event->interface_status.ifname) < strlen(ifname)) {
-		wpa_printf(MSG_ERROR, "Interface name too long: %s (max: %d)",
+		wpa_printf(MSG_ERROR, "Interface name too long: %s (max: %zu)",
 			ifname, sizeof(event->interface_status.ifname));
 		goto free;
 	}


### PR DESCRIPTION
The format specifier for size_t is zu.
Using d only works when int and size_t are the same underlying type which is not the case for 64bit systems, which leads to a build warning in this case.

Partial fix for
https://github.com/zephyrproject-rtos/zephyr/issues/80437