### PR TITLE
boards: infineon: cyw920829m2evk_02: set openocd target handle

### DIFF
--- a/boards/infineon/cyw920829m2evk_02/board.cmake
+++ b/boards/infineon/cyw920829m2evk_02/board.cmake
@@ -1,6 +1,7 @@
 # Copyright (c) 2024 Cypress Semiconductor Corporation.
 # SPDX-License-Identifier: Apache-2.0
 
+board_runner_args(openocd "--target-handle=TARGET.cm33")
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
 board_runner_args(jlink "--device=CYW20829_tm")
 include (${ZEPHYR_BASE}/boards/common/jlink.board.cmake)


### PR DESCRIPTION
Openocd target cyw20829 does not define _TARGETNAME which is used by default by the openocd west runner when using CONFIG_DEBUG_THREAD_INFO.

This is similar to the issue previously addressed for STM32H7:

Link: https://github.com/zephyrproject-rtos/zephyr/issues/45778