### PR TITLE
Bluetooth: Shell: Fix missing RX QoS param and MSE check

### DIFF
--- a/subsys/bluetooth/host/shell/iso.c
+++ b/subsys/bluetooth/host/shell/iso.c
@@ -820,6 +820,7 @@ static int cmd_big_sync(const struct shell *sh, size_t argc, char *argv[])
 	}
 
 	bis_iso_qos.tx = NULL;
+	bis_iso_qos.rx = &iso_rx_qos;
 
 	param.bis_channels = bis_channels;
 	param.num_bis = BIS_ISO_CHAN_COUNT;
@@ -845,9 +846,8 @@ static int cmd_big_sync(const struct shell *sh, size_t argc, char *argv[])
 				return -ENOEXEC;
 			}
 
-			if (!IN_RANGE(mse,
-				      BT_ISO_SYNC_MSE_MIN,
-				      BT_ISO_SYNC_MSE_MAX)) {
+			if (mse != BT_ISO_SYNC_MSE_ANY &&
+			    !IN_RANGE(mse, BT_ISO_SYNC_MSE_MIN, BT_ISO_SYNC_MSE_MAX)) {
 				shell_error(sh, "Invalid mse %lu", mse);
 
 				return -ENOEXEC;


### PR DESCRIPTION
The bis_iso_qos.rx was missing in param sent in bt_iso_big_sync

Also, MSE = 0 is valid (fixed error check)