### PR TITLE
arch: arm: cortex_m: Use Thumb-1 compatible 'mov reg, imm' mnemonic

### DIFF
--- a/arch/arm/core/cortex_m/thread.c
+++ b/arch/arm/core/cortex_m/thread.c
@@ -576,14 +576,14 @@ void arch_switch_to_main_thread(struct k_thread *main_thread, char *stack_ptr,
 	"mov   r4,  %0\n"	/* force _main to be stored in a register */
 	"msr   PSP, %1\n"	/* __set_PSP(stack_ptr) */
 
-	"mov   r0,  #0\n"	/* arch_irq_unlock(0) */
+	"movs  r0,  #0\n"	/* arch_irq_unlock(0) */
 	"ldr   r3, =arch_irq_unlock_outlined\n"
 	"blx   r3\n"
 
 	"mov   r0, r4\n"	/* z_thread_entry(_main, NULL, NULL, NULL) */
-	"mov   r1, #0\n"
-	"mov   r2, #0\n"
-	"mov   r3, #0\n"
+	"movs  r1, #0\n"
+	"movs  r2, #0\n"
+	"movs  r3, #0\n"
 	"ldr   r4, =z_thread_entry\n"
 	"bx    r4\n"		/* We don’t intend to return, so there is no need to link. */
 	: "+r" (_main)


### PR DESCRIPTION
The ARM Thumb-1 instruction set, used by ARMv6-M and ARMv8-M Baseline cores, does not have a valid encoding for "immediate-to-register move without affecting flags" instruction (i.e. `mov reg, imm`), and the only valid variant of immediate-to-register move instruction for it is `movs`, which affects the flags.

Since none of the register initialisation instructions used here are flag-sensitive in their context, this commit changes `mov` to `movs`.

This fixes the compilation errors with Clang/LLVM, which is more picky about the `mov` mnemonic usage and prints out an "invalid instruction" error when `mov reg, imm` is specified in Thumb-1 mode.

Note that GNU assembler implicitly converts `mov reg, imm` to `movs reg, imm` when assembling in Thumb-1 mode.