### PR TITLE
tests: net: wifi: Disable native/64 from tests

### DIFF
--- a/tests/net/wifi/configs/testcase.yaml
+++ b/tests/net/wifi/configs/testcase.yaml
@@ -6,7 +6,6 @@ common:
     - net
   platform_allow:
     - native_sim
-    - native_sim/native/64
 tests:
   wifi.build.crypto_default:
     extra_configs:


### PR DESCRIPTION
There are issues with 64 bit compilation in hostap so disable native_sim/native/64 board from the tests. The board will be enabled again after updating the hostap from upstream and fixing the issues.

Fixes #80437