### PR TITLE
arch: arm: cortex_a_r: Fix mrc/mcr instruction usage

### DIFF
--- a/arch/arm/core/cortex_a_r/__aeabi_read_tp.S
+++ b/arch/arm/core/cortex_a_r/__aeabi_read_tp.S
@@ -14,5 +14,5 @@ SECTION_FUNC(text, __aeabi_read_tp)
 	/*
 	 * TPIDRURW will be used as a base pointer point to TLS aera.
 	 */
-	mrc 15, 0, r0, c13, c0, 2
+	mrc p15, 0, r0, c13, c0, 2
 	bx lr

--- a/arch/arm/core/cortex_a_r/swap_helper.S
+++ b/arch/arm/core/cortex_a_r/swap_helper.S
@@ -126,7 +126,7 @@ out_fp_inactive:
      * TPIDRURW is used as a base pointer to all
      * thread variables with offsets added by toolchain.
      */
-    mcr 15, 0, r0, c13, c0, 2
+    mcr p15, 0, r0, c13, c0, 2
 #endif
 
 #if defined(CONFIG_ARM_STORE_EXC_RETURN)


### PR DESCRIPTION
The coprocessor number in ARM `mrc` and `mcr` instructions must be prefixed with `p`.

GNU assembler allows specifying coprocessor number without the `p` prefix; but, LLVM assembler is more picky about this and prints out "invalid instruction" error otherwise.