### PR TITLE
twister: --device-testing always implies --filter runnable

### DIFF
--- a/scripts/pylib/twister/twisterlib/environment.py
+++ b/scripts/pylib/twister/twisterlib/environment.py
@@ -382,7 +382,7 @@ structure in the main Zephyr tree: boards/<vendor>/<board_name>/""")
 
     parser.add_argument(
         "--filter", choices=['buildable', 'runnable'],
-        default='buildable',
+        default='runnable' if "--device-testing" in sys.argv else 'buildable',
         help="""Filter tests to be built and executed. By default everything is
         built and if a test is runnable (emulation or a connected device), it
         is run. This option allows for example to only build tests that can

--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -644,9 +644,6 @@ class TestPlan:
                     if ts.get("run_id"):
                         instance.run_id = ts.get("run_id")
 
-                    if self.options.device_testing:
-                        self.options.filter = 'runnable'
-
                     instance.run = instance.check_runnable(
                         self.options,
                         self.hwm


### PR DESCRIPTION
--device-testing implies runnable tests, this was the case before the
rework and was missed in one spot, so instead do that directly in the
argument parser.

Fixes #80428

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
