### PR TITLE
arch: arm64: Make write_sysreg() register size explicit

### DIFF
--- a/include/zephyr/arch/arm64/lib_helpers.h
+++ b/include/zephyr/arch/arm64/lib_helpers.h
@@ -24,8 +24,9 @@
 
 #define write_sysreg(val, reg)						\
 ({									\
+	uint64_t reg_val = val;						\
 	__asm__ volatile ("msr " STRINGIFY(reg) ", %0"			\
-			  :: "r" (val) : "memory");			\
+			  :: "r" (reg_val) : "memory");			\
 })
 
 #define zero_sysreg(reg)						\


### PR DESCRIPTION
The A64 `msr` instruction always takes a 64-bit register (`xN`) value operand.

When a value of size other than 64-bit is specified as an operand to this instruction, Clang prints out the following warning:

  warning: value size does not match register size specified by the
  constraint and modifier [-Wasm-operand-widths]

This commit modifies the `write_sysreg()` macro to cast its value parameter into `uint64_t` before specifying it as an operand to `msr` instruction in order to ensure that always a 64-bit value is specified.