### PR TITLE
kernel: Add k_thread_runtime_stats_is_enabled function

### DIFF
--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -155,6 +155,10 @@ New APIs and options
   * :c:func:`haptics_set_level`
   * :c:func:`haptics_stream_samples`
 
+* Kernel
+
+  * :c:func:`k_thread_runtime_stats_is_enabled`
+
 * LoRa
 
   * :c:func:`lora_recv_duty_cycle`

--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -7076,6 +7076,16 @@ int k_thread_runtime_stats_enable(k_tid_t thread);
 int k_thread_runtime_stats_disable(k_tid_t thread);
 
 /**
+ * @brief Check if runtime statistics gathering is enabled for a thread
+ *
+ * This routine checks whether the specified thread has enabled runtime statistics.
+ *
+ * @param thread ID of thread
+ * @return true if usage statistics are enabled for the given thread, otherwise false
+ */
+bool k_thread_runtime_stats_is_enabled(k_tid_t thread);
+
+/**
  * @brief Enable gathering of system runtime statistics
  *
  * This routine enables the gathering of system runtime statistics. Note that

--- a/kernel/usage.c
+++ b/kernel/usage.c
@@ -271,6 +271,11 @@ int k_thread_runtime_stats_disable(k_tid_t  thread)
 
 	return 0;
 }
+
+bool k_thread_runtime_stats_is_enabled(k_tid_t thread)
+{
+	return thread->base.usage.track_usage;
+}
 #endif /* CONFIG_SCHED_THREAD_USAGE_ANALYSIS */
 
 #ifdef CONFIG_SCHED_THREAD_USAGE_ALL

--- a/tests/kernel/usage/thread_runtime_stats/src/test_thread_runtime_stats.c
+++ b/tests/kernel/usage/thread_runtime_stats/src/test_thread_runtime_stats.c
@@ -224,7 +224,9 @@ ZTEST(usage_api, test_thread_stats_enable_disable)
 
 	k_thread_runtime_stats_get(_current, &stats1);
 	k_thread_runtime_stats_get(tid, &helper_stats1);
+	zassert_true(k_thread_runtime_stats_is_enabled(tid));
 	k_thread_runtime_stats_disable(tid);
+	zassert_false(k_thread_runtime_stats_is_enabled(tid));
 
 	/*
 	 * Busy wait for the remaining tick before re-enabling the thread


### PR DESCRIPTION
Add 'k_thread_runtime_stats_is_enabled' to 'usage.c', which's used to check whether runtime statistics collection is enabled for a thread.

It can determine whether the thread has enabled runtime statistics collection when the program is running. It allows users to add conditional statements based on this function when using it.

for example:
```
void f()
{
    // Assume there is a thread id
    if (k_thread_runtime_stats_is_enabled(id)) {
        /* do something */
    }
    ...
}
```
And it can provide a complete support when similar operations are needed. for example `enable`, `disable`, `is_enabled`.
For example, its use in the implementation of CLOCK_THREAD_CPUTIME_ID actually lacks k_thread_runtime_stats_is_enabled, which makes the entire function impossible to implement safely. It is necessary.

..