### PR TITLE
boards: nxp: add documentation for SEGGER SystemView support with ECC

### DIFF
--- a/boards/nxp/common/segger-ecc-systemview.rst
+++ b/boards/nxp/common/segger-ecc-systemview.rst
@@ -1,0 +1,17 @@
+:orphan:
+
+.. segger-ecc-systemview
+
+Using Segger SystemView and RTT
+-------------------------------
+
+Note that when using SEGGER SystemView or RTT with this SOC, the RTT control
+block address must be set manually within SystemView or the RTT Viewer. The
+address provided to the tool should be the location of the ``_SEGGER_RTT``
+symbol, which can be found using a debugger or by examining the ``zephyr.map``
+file output by the linker.
+
+The RTT control block address must be provided manually because this SOC
+supports ECC RAM. If the SEGGER tooling searches the ECC RAM space for the
+control block a fault will occur, provided that ECC is enabled and the RAM
+segment being searched has not been initialized to a known value.

--- a/boards/nxp/frdm_mcxa156/doc/index.rst
+++ b/boards/nxp/frdm_mcxa156/doc/index.rst
@@ -175,6 +175,12 @@ should see the following message in the terminal:
    *** Booting Zephyr OS build v3.6.0-4478-ge6c3a42f5f52 ***
    Hello World! frdm_mcxa156/mcxa156
 
+Troubleshooting
+===============
+
+.. include:: ../../common/segger-ecc-systemview.rst
+   :start-after: segger-ecc-systemview
+
 .. _MCX-A156 SoC Website:
    https://www.nxp.com/products/processors-and-microcontrollers/arm-microcontrollers/general-purpose-mcus/mcx-arm-cortex-m/mcx-a-series-microcontrollers/mcx-a13x-14x-15x-mcus-with-arm-cortex-m33-scalable-device-options-low-power-and-intelligent-peripherals:MCX-A13X-A14X-A15X
 

--- a/boards/nxp/frdm_mcxn236/doc/index.rst
+++ b/boards/nxp/frdm_mcxn236/doc/index.rst
@@ -197,6 +197,12 @@ should see the following message in the terminal:
    *** Booting Zephyr OS build v3.6.0-4478-ge6c3a42f5f52 ***
    Hello World! frdm_mcxn236/mcxn236
 
+Troubleshooting
+===============
+
+.. include:: ../../common/segger-ecc-systemview.rst
+   :start-after: segger-ecc-systemview
+
 .. _MCX-N236 SoC Website:
    https://www.nxp.com/products/processors-and-microcontrollers/arm-microcontrollers/general-purpose-mcus/mcx-arm-cortex-m/mcx-n-series-microcontrollers/mcx-n23x-highly-integrated-mcus-with-on-chip-accelerators-intelligent-peripherals-and-advanced-security:MCX-N23X
 

--- a/boards/nxp/frdm_mcxn947/doc/index.rst
+++ b/boards/nxp/frdm_mcxn947/doc/index.rst
@@ -257,6 +257,12 @@ should see the following message in the terminal:
    *** Booting Zephyr OS build v3.6.0-479-g91faa20c6741 ***
    Hello World! frdm_mcxn947/mcxn947/cpu0
 
+Troubleshooting
+===============
+
+.. include:: ../../common/segger-ecc-systemview.rst
+   :start-after: segger-ecc-systemview
+
 .. _MCX-N947 SoC Website:
    https://www.nxp.com/products/processors-and-microcontrollers/arm-microcontrollers/general-purpose-mcus/mcx-arm-cortex-m/mcx-n-series-microcontrollers/mcx-n94x-54x-highly-integrated-multicore-mcus-with-on-chip-accelerators-intelligent-peripherals-and-advanced-security:MCX-N94X-N54X
 

--- a/boards/nxp/frdm_mcxw71/doc/index.rst
+++ b/boards/nxp/frdm_mcxw71/doc/index.rst
@@ -192,6 +192,12 @@ For more details:
 .. _blhost Website:
    https://www.nxp.com/search?keyword=blhost&start=0
 
+Troubleshooting
+===============
+
+.. include:: ../../common/segger-ecc-systemview.rst
+   :start-after: segger-ecc-systemview
+
 References
 **********
 


### PR DESCRIPTION
SOCs using ECC require the SEGGER RTT control block address to be provided to the tooling, as the SEGGER tools will not scan the memory range of ECC ram. Add documentation making this clear to boards with these SOCs.