### PR TITLE
soc: nxp: mcx: do not select HAS_SEGGER_RTT unless segger module is present

### DIFF
--- a/soc/nxp/mcx/mcxa/Kconfig
+++ b/soc/nxp/mcx/mcxa/Kconfig
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config SOC_SERIES_MCXA
-	select HAS_SEGGER_RTT
+	select HAS_SEGGER_RTT if ZEPHYR_SEGGER_MODULE
 	select CLOCK_CONTROL
 	select ARM
 	select HAS_MCUX

--- a/soc/nxp/mcx/mcxn/Kconfig
+++ b/soc/nxp/mcx/mcxn/Kconfig
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config SOC_SERIES_MCXN
-	select HAS_SEGGER_RTT
+	select HAS_SEGGER_RTT if ZEPHYR_SEGGER_MODULE
 	select CLOCK_CONTROL
 	select ARM
 	select HAS_MCUX


### PR DESCRIPTION
Do not select HAS_SEGGER_RTT unless the segger module is present. This avoids a Kconfig error when SEGGER's debug module is not present in the west manifest

Fixes #80529