### PR TITLE
boards: weact: usb2canfdv1: fix broken link

### DIFF
--- a/boards/weact/usb2canfdv1/doc/index.rst
+++ b/boards/weact/usb2canfdv1/doc/index.rst
@@ -34,7 +34,7 @@ The ``usb2canfdv1`` board configuration supports the following hardware features
 +-----------+------------+-------------------------------------+
 
 The default configuration can be found in the defconfig file:
-:zephyr_file:`boards/weact/usb2canfd/usb2canfdv1_defconfig`.
+:zephyr_file:`boards/weact/usb2canfdv1/usb2canfdv1_defconfig`.
 
 Other hardware features are not currently supported by the port.
 


### PR DESCRIPTION
Fix broken link to the usb2canfdv1 default board configuration file.

Fixes: 25d9fc118f61c049a58858703ea354a1b833ca6d