### PR TITLE
manifest: update zephyr-lang-rust to latest code

### DIFF
--- a/submanifests/optional.yaml
+++ b/submanifests/optional.yaml
@@ -34,7 +34,7 @@ manifest:
       groups:
         - optional
     - name: zephyr-lang-rust
-      revision: f20afb5bae9a4b64332a230a734c0244b39d4035
+      revision: b765109a46d2cb83cf80f683f4bc701f3e152622
       path: modules/lang/rust
       remote: upstream
       groups:


### PR DESCRIPTION
This brings in the latest work on zephyr-lang-rust, which includes, among other things:

  - Rust interfaces to thread creation, mutex/condvar, semaphores, and k_queue.
  - A Rust friendly interface for timeouts.
  - A port of the dining philosophers problem as a sample, with Kconfig selectable backends supporting all of the above sync mechanisms.
  - An implementation of crossbeam-channel's unbounded queue interface, built on top of `k_queue`.
  - Support for Zephyr kernel objects, both statically declared, with macro support for setting linker sections, and dynamically allocated, for applications that don't use userspace, and use allocation.
  - A provider of Rust's `log` mechanmism that directs to the printk output.  Interfacing with Zephyr's log is ongoing work.