### PR TITLE
kernel: add __BUG macros for fatal runtime conditions

### DIFF
--- a/subsys/debug/Kconfig
+++ b/subsys/debug/Kconfig
@@ -374,6 +374,16 @@ config OMIT_FRAME_POINTER
 	  If unsure, disable OVERRIDE_FRAME_POINTER_DEFAULT to allow the compiler
 	  to adopt sensible defaults for your architecture.
 
+config BUG_NO_PANIC
+	bool "Disable kernel panic in __BUG macros"
+	help
+	  This option prevents the system from panicking on __BUG macros.
+
+config BUG_PRINT_LOCATION
+	bool "Print file location and line number in __BUG macros"
+	help
+	  This option will cause __BUG macros to print out file and line
+	  information similar to asserts.
 
 #
 # Generic Debugging Options

--- a/tests/kernel/fatal/exception/src/main.c
+++ b/tests/kernel/fatal/exception/src/main.c
@@ -178,6 +178,14 @@ void entry_arbitrary_reason_negative(void *p1, void *p2, void *p3)
 	rv = TC_FAIL;
 }
 
+void entry_zephyr_bug(void *p1, void *p2, void *p3)
+{
+	expected_reason = K_ERR_KERNEL_PANIC;
+
+	__BUG();
+	rv = TC_FAIL;
+}
+
 #ifndef CONFIG_ARCH_POSIX
 #ifdef CONFIG_STACK_SENTINEL
 __no_optimization void blow_up_stack(void)
@@ -385,6 +393,12 @@ ZTEST(fatal_exception, test_fatal)
 			entry_arbitrary_reason_negative,
 			NULL, NULL, NULL, K_PRIO_COOP(PRIORITY), 0,
 			K_NO_WAIT);
+	k_thread_abort(&alt_thread);
+	zassert_not_equal(rv, TC_FAIL, "thread was not aborted");
+
+	TC_PRINT("test alt thread 7: bug\n");
+	k_thread_create(&alt_thread, alt_stack, K_THREAD_STACK_SIZEOF(alt_stack), entry_zephyr_bug,
+			NULL, NULL, NULL, K_PRIO_COOP(PRIORITY), 0, K_NO_WAIT);
 	k_thread_abort(&alt_thread);
 	zassert_not_equal(rv, TC_FAIL, "thread was not aborted");
 

--- a/tests/kernel/fatal/exception/testcase.yaml
+++ b/tests/kernel/fatal/exception/testcase.yaml
@@ -1,6 +1,12 @@
 common:
   ignore_faults: true
 tests:
+  kernel.common.no_assert:
+    extra_configs:
+      - CONFIG_ASSERT=n
+      - CONFIG_BUG_PRINT_LOCATION=y
+    tags:
+      - kernel
   kernel.common.stack_protection:
     extra_args: CONF_FILE=prj.conf
     platform_exclude:


### PR DESCRIPTION
There are cases where we to mark conditions as fatal during runtime that do not compile out when asserts are disabled. This change adds the __BUG/__BUG_ON macros that are similar to their Linux kernel counterparts and standardize how these conditions can be marked in the codebase.