### PR TITLE
style: Inconsistent macro names changed

### DIFF
--- a/include/zephyr/app_memory/mem_domain.h
+++ b/include/zephyr/app_memory/mem_domain.h
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef INCLUDE_APP_MEMORY_MEM_DOMAIN_H
-#define INCLUDE_APP_MEMORY_MEM_DOMAIN_H
+#ifndef ZEPHYR_INCLUDE_APP_MEMORY_MEM_DOMAIN_H_
+#define ZEPHYR_INCLUDE_APP_MEMORY_MEM_DOMAIN_H_
 
 #include <stdint.h>
 #include <stddef.h>
@@ -193,4 +193,4 @@ int k_mem_domain_add_thread(struct k_mem_domain *domain,
 #endif
 
 /** @} */
-#endif /* INCLUDE_APP_MEMORY_MEM_DOMAIN_H */
+#endif /* ZEPHYR_INCLUDE_APP_MEMORY_MEM_DOMAIN_H_ */

--- a/include/zephyr/display/cfb.h
+++ b/include/zephyr/display/cfb.h
@@ -9,8 +9,8 @@
  * @brief Public Monochrome Character Framebuffer API
  */
 
-#ifndef __CFB_H__
-#define __CFB_H__
+#ifndef ZEPHYR_INCLUDE_DISPLAY_CFB_H_
+#define ZEPHYR_INCLUDE_DISPLAY_CFB_H_
 
 #include <zephyr/device.h>
 #include <zephyr/drivers/display.h>
@@ -256,4 +256,4 @@ void cfb_framebuffer_deinit(const struct device *dev);
  * @}
  */
 
-#endif /* __CFB_H__ */
+#endif /* ZEPHYR_INCLUDE_DISPLAY_CFB_H_ */

--- a/include/zephyr/mgmt/osdp.h
+++ b/include/zephyr/mgmt/osdp.h
@@ -9,8 +9,8 @@
  * @brief Open Supervised Device Protocol (OSDP) public API header file.
  */
 
-#ifndef _OSDP_H_
-#define _OSDP_H_
+#ifndef ZEPHYR_INCLUDE_MGMT_OSDP_H_
+#define ZEPHYR_INCLUDE_MGMT_OSDP_H_
 
 #include <zephyr/kernel.h>
 #include <stdint.h>
@@ -480,4 +480,4 @@ uint32_t osdp_get_sc_status_mask(void);
 }
 #endif
 
-#endif	/* _OSDP_H_ */
+#endif	/* ZEPHYR_INCLUDE_MGMT_OSDP_H_ */

--- a/include/zephyr/shell/shell_backend.h
+++ b/include/zephyr/shell/shell_backend.h
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef SHELL_BACKEND_H__
-#define SHELL_BACKEND_H__
+#ifndef ZEPHYR_INCLUDE_SHELL_BACKEND_H_
+#define ZEPHYR_INCLUDE_SHELL_BACKEND_H_
 
 #include <zephyr/types.h>
 #include <zephyr/shell/shell.h>
@@ -58,4 +58,4 @@ const struct shell *shell_backend_get_by_name(const char *backend_name);
 }
 #endif
 
-#endif /* SHELL_BACKEND_H__ */
+#endif /* ZEPHYR_INCLUDE_SHELL_BACKEND_H_ */

--- a/include/zephyr/shell/shell_dummy.h
+++ b/include/zephyr/shell/shell_dummy.h
@@ -6,8 +6,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef SHELL_DUMMY_H__
-#define SHELL_DUMMY_H__
+#ifndef ZEPHYR_INCLUDE_SHELL_DUMMY_H_
+#define ZEPHYR_INCLUDE_SHELL_DUMMY_H_
 
 #include <zephyr/shell/shell.h>
 
@@ -68,4 +68,4 @@ void shell_backend_dummy_clear_output(const struct shell *sh);
 }
 #endif
 
-#endif /* SHELL_DUMMY_H__ */
+#endif /* ZEPHYR_INCLUDE_SHELL_DUMMY_H_ */

--- a/include/zephyr/shell/shell_fprintf.h
+++ b/include/zephyr/shell/shell_fprintf.h
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef SHELL_FPRINTF_H__
-#define SHELL_FPRINTF_H__
+#ifndef ZEPHYR_INCLUDE_SHELL_FPRINTF_H_
+#define ZEPHYR_INCLUDE_SHELL_FPRINTF_H_
 
 #include <zephyr/kernel.h>
 #include <stdbool.h>
@@ -80,4 +80,4 @@ void z_shell_fprintf_buffer_flush(const struct shell_fprintf *sh_fprintf);
 }
 #endif
 
-#endif /* SHELL_FPRINTF_H__ */
+#endif /* ZEPHYR_INCLUDE_SHELL_FPRINTF_H_ */

--- a/include/zephyr/shell/shell_history.h
+++ b/include/zephyr/shell/shell_history.h
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef SHELL_HISTORY_H__
-#define SHELL_HISTORY_H__
+#ifndef ZEPHYR_INCLUDE_SHELL_HISTORY_H_
+#define ZEPHYR_INCLUDE_SHELL_HISTORY_H_
 
 #include <zephyr/kernel.h>
 #include <zephyr/sys/util.h>
@@ -111,4 +111,4 @@ static inline bool z_shell_history_active(struct shell_history *history)
 }
 #endif
 
-#endif /* SHELL_HISTORY_H__ */
+#endif /* ZEPHYR_INCLUDE_SHELL_HISTORY_H_ */

--- a/include/zephyr/shell/shell_log_backend.h
+++ b/include/zephyr/shell/shell_log_backend.h
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef SHELL_LOG_BACKEND_H__
-#define SHELL_LOG_BACKEND_H__
+#ifndef ZEPHYR_INCLUDE_SHELL_LOG_BACKEND_H_
+#define ZEPHYR_INCLUDE_SHELL_LOG_BACKEND_H_
 
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log_backend.h>
@@ -124,4 +124,4 @@ bool z_shell_log_backend_process(const struct shell_log_backend *backend);
 }
 #endif
 
-#endif /* SHELL_LOG_BACKEND_H__ */
+#endif /* ZEPHYR_INCLUDE_SHELL_LOG_BACKEND_H_ */

--- a/include/zephyr/shell/shell_mqtt.h
+++ b/include/zephyr/shell/shell_mqtt.h
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef SHELL_MQTT_H__
-#define SHELL_MQTT_H__
+#ifndef ZEPHYR_INCLUDE_SHELL_MQTT_H_
+#define ZEPHYR_INCLUDE_SHELL_MQTT_H_
 
 #include <zephyr/kernel.h>
 #include <zephyr/shell/shell.h>
@@ -137,4 +137,4 @@ bool shell_mqtt_get_devid(char *id, int id_max_len);
 }
 #endif
 
-#endif /* SHELL_MQTT_H__ */
+#endif /* ZEPHYR_INCLUDE_SHELL_MQTT_H_ */

--- a/include/zephyr/shell/shell_rpmsg.h
+++ b/include/zephyr/shell/shell_rpmsg.h
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef SHELL_RPMSG_H__
-#define SHELL_RPMSG_H__
+#ifndef ZEPHYR_INCLUDE_SHELL_RPMSG_H_
+#define ZEPHYR_INCLUDE_SHELL_RPMSG_H_
 
 #include <zephyr/kernel.h>
 #include <zephyr/shell/shell.h>
@@ -84,4 +84,4 @@ const struct shell *shell_backend_rpmsg_get_ptr(void);
 }
 #endif
 
-#endif /* SHELL_RPMSG_H__ */
+#endif /* ZEPHYR_INCLUDE_SHELL_RPMSG_H_ */

--- a/include/zephyr/shell/shell_rtt.h
+++ b/include/zephyr/shell/shell_rtt.h
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef SHELL_RTT_H__
-#define SHELL_RTT_H__
+#ifndef ZEPHYR_INCLUDE_SHELL_RTT_H_
+#define ZEPHYR_INCLUDE_SHELL_RTT_H_
 
 #include <zephyr/shell/shell.h>
 
@@ -41,4 +41,4 @@ const struct shell *shell_backend_rtt_get_ptr(void);
 }
 #endif
 
-#endif /* SHELL_RTT_H__ */
+#endif /* ZEPHYR_INCLUDE_SHELL_RTT_H_ */

--- a/include/zephyr/shell/shell_string_conv.h
+++ b/include/zephyr/shell/shell_string_conv.h
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef SHELL_STRING_CONV_H__
-#define SHELL_STRING_CONV_H__
+#ifndef ZEPHYR_INCLUDE_SHELL_STRING_CONV_H_
+#define ZEPHYR_INCLUDE_SHELL_STRING_CONV_H_
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -86,4 +86,4 @@ bool shell_strtobool(const char *str, int base, int *err);
 }
 #endif
 
-#endif /* SHELL_STRING_CONV_H__ */
+#endif /* ZEPHYR_INCLUDE_SHELL_STRING_CONV_H_ */

--- a/include/zephyr/shell/shell_telnet.h
+++ b/include/zephyr/shell/shell_telnet.h
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef SHELL_TELNET_H__
-#define SHELL_TELNET_H__
+#ifndef ZEPHYR_INCLUDE_SHELL_TELNET_H_
+#define ZEPHYR_INCLUDE_SHELL_TELNET_H_
 
 #include <zephyr/net/socket.h>
 #include <zephyr/shell/shell.h>
@@ -85,4 +85,4 @@ const struct shell *shell_backend_telnet_get_ptr(void);
 }
 #endif
 
-#endif /* SHELL_TELNET_H__ */
+#endif /* ZEPHYR_INCLUDE_SHELL_TELNET_H_ */

--- a/include/zephyr/shell/shell_types.h
+++ b/include/zephyr/shell/shell_types.h
@@ -3,8 +3,8 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#ifndef SHELL_TYPES_H__
-#define SHELL_TYPES_H__
+#ifndef ZEPHYR_INCLUDE_SHELL_TYPES_H_
+#define ZEPHYR_INCLUDE_SHELL_TYPES_H_
 
 
 #ifdef __cplusplus
@@ -51,4 +51,4 @@ struct shell_vt100_ctx {
 }
 #endif
 
-#endif /* SHELL_TYPES_H__ */
+#endif /* ZEPHYR_INCLUDE_SHELL_TYPES_H_ */

--- a/include/zephyr/shell/shell_uart.h
+++ b/include/zephyr/shell/shell_uart.h
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef SHELL_UART_H__
-#define SHELL_UART_H__
+#ifndef ZEPHYR_INCLUDE_SHELL_UART_H_
+#define ZEPHYR_INCLUDE_SHELL_UART_H_
 
 #include <zephyr/drivers/serial/uart_async_rx.h>
 #include <zephyr/mgmt/mcumgr/transport/smp_shell.h>
@@ -115,4 +115,4 @@ struct smp_shell_data *shell_uart_smp_shell_data_get_ptr(void);
 }
 #endif
 
-#endif /* SHELL_UART_H__ */
+#endif /* ZEPHYR_INCLUDE_SHELL_UART_H_ */

--- a/include/zephyr/shell/shell_websocket.h
+++ b/include/zephyr/shell/shell_websocket.h
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef SHELL_WEBSOCKET_H__
-#define SHELL_WEBSOCKET_H__
+#ifndef ZEPHYR_INCLUDE_SHELL_WEBSOCKET_H_
+#define ZEPHYR_INCLUDE_SHELL_WEBSOCKET_H_
 
 #include <zephyr/net/socket.h>
 #include <zephyr/net/http/server.h>
@@ -148,4 +148,4 @@ extern int shell_websocket_enable(const struct shell *sh);
 }
 #endif
 
-#endif /* SHELL_WEBSOCKET_H__ */
+#endif /* ZEPHYR_INCLUDE_SHELL_WEBSOCKET_H_ */

--- a/include/zephyr/task_wdt/task_wdt.h
+++ b/include/zephyr/task_wdt/task_wdt.h
@@ -14,8 +14,8 @@
  * threads. It can be used together with a hardware watchdog as a fallback.
  */
 
-#ifndef TASK_WDT_H_
-#define TASK_WDT_H_
+#ifndef ZEPHYR_INCLUDE_TASK_WDT_H_
+#define ZEPHYR_INCLUDE_TASK_WDT_H_
 
 #include <zephyr/types.h>
 #include <zephyr/kernel.h>
@@ -110,4 +110,4 @@ int task_wdt_feed(int channel_id);
  * @}
  */
 
-#endif /* TASK_WDT_H_ */
+#endif /* ZEPHYR_INCLUDE_TASK_WDT_H_ */


### PR DESCRIPTION
Fix incorrect header file pre-macro names in 'include/zephyr/xen', 'include/zephyr/display' and 'include/zephyr/mgmt'.

good
https://github.com/zephyrproject-rtos/zephyr/blob/4a8a035bd7b9178e6ae31d56e931aa9b9a40f9b9/include/zephyr/display/ssd16xx.h#L8

https://github.com/zephyrproject-rtos/zephyr/blob/4a8a035bd7b9178e6ae31d56e931aa9b9a40f9b9/include/zephyr/mgmt/updatehub.h#L14

bad
https://github.com/zephyrproject-rtos/zephyr/blob/4a8a035bd7b9178e6ae31d56e931aa9b9a40f9b9/include/zephyr/mgmt/osdp.h#L12

https://github.com/zephyrproject-rtos/zephyr/blob/4a8a035bd7b9178e6ae31d56e931aa9b9a40f9b9/include/zephyr/display/cfb.h#L12