### PR TITLE
net: nsos_sockets: free allocated socket on close

### DIFF
--- a/drivers/net/nsos_sockets.c
+++ b/drivers/net/nsos_sockets.c
@@ -256,6 +256,8 @@ static int nsos_close(void *obj)
 		errno = nsos_adapt_get_zephyr_errno();
 	}
 
+	k_free(sock);
+
 	return ret;
 }
 


### PR DESCRIPTION
Free the socket object allocated in `nsos_socket_create` when closing the socket.

Object originally allocated here:
https://github.com/zephyrproject-rtos/zephyr/blob/4a8a035bd7b9178e6ae31d56e931aa9b9a40f9b9/drivers/net/nsos_sockets.c#L189
and not freed in:
https://github.com/zephyrproject-rtos/zephyr/blob/4a8a035bd7b9178e6ae31d56e931aa9b9a40f9b9/drivers/net/nsos_sockets.c#L249-L260