### PR TITLE
drivers: clock: fix STM32_PERIPH_BUS_MIN for STM32U0

### DIFF
--- a/include/zephyr/dt-bindings/clock/stm32u0_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32u0_clock.h
@@ -9,12 +9,12 @@
 #include "stm32_common_clocks.h"
 
 /** Bus gatting clocks */
-#define STM32_CLOCK_BUS_IOP     0x4C
 #define STM32_CLOCK_BUS_AHB1    0x48
+#define STM32_CLOCK_BUS_IOP     0x4C
 #define STM32_CLOCK_BUS_APB1    0x58
 #define STM32_CLOCK_BUS_APB1_2  0x60
 
-#define STM32_PERIPH_BUS_MIN	STM32_CLOCK_BUS_IOP
+#define STM32_PERIPH_BUS_MIN	STM32_CLOCK_BUS_AHB1
 #define STM32_PERIPH_BUS_MAX	STM32_CLOCK_BUS_APB1_2
 
 /** Domain clocks */


### PR DESCRIPTION
`STM32_PERIPH_BUS_MIN` value does not point to the minimum bus address in `stm32u0_clock.h` which is `AHB1` and has value of `0x48`. Instead `IOP` is used which has the value `0x4C` this causes `clock_control_on` to fail when enabling anything clocked by `AHB1`

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/80817