### PR TITLE
cmake: linker: ld: Do not link libc when minimal libc is selected

### DIFF
--- a/cmake/linker/ld/linker_libraries.cmake
+++ b/cmake/linker/ld/linker_libraries.cmake
@@ -33,6 +33,8 @@ if(CONFIG_NEWLIB_LIBC AND CMAKE_C_COMPILER_ID STREQUAL "GNU")
   # link dependency to libc (strchr), but libc also has dependencies to libgcc.
   # Lib C depends on libgcc. e.g. libc.a(lib_a-fvwrite.o) references __aeabi_idiv
   set_property(TARGET linker APPEND PROPERTY link_order_library "math;c;rt;c")
-else()
+elseif(NOT CONFIG_MINIMAL_LIBC)
   set_property(TARGET linker APPEND PROPERTY link_order_library "c;rt")
+else()
+  set_property(TARGET linker APPEND PROPERTY link_order_library "rt")
 endif()


### PR DESCRIPTION
When GNU linker is used, the toolchain-provided C standard library is always linked, even when the Zephyr minimal libc is selected, because `c` is unconditionally specified in `link_order_library`, which causes `-lc` to be specified in the linker flags.

This commit adds a check to ensure that `-lc` is not specified when the Zephyr minimal libc is selected because it is a standalone C standard library and it does not make sense to link two C standard libraries at once.