### PR TITLE
cmake: linker: lld: Do not link libc when minimal libc is used

### DIFF
--- a/cmake/linker/lld/linker_libraries.cmake
+++ b/cmake/linker/lld/linker_libraries.cmake
@@ -18,4 +18,8 @@ if(CONFIG_CPP
   set_property(TARGET linker PROPERTY link_order_library "c++")
 endif()
 
-set_property(TARGET linker APPEND PROPERTY link_order_library "c;rt")
+if(NOT CONFIG_MINIMAL_LIBC)
+  set_property(TARGET linker APPEND PROPERTY link_order_library "c")
+endif()
+
+set_property(TARGET linker APPEND PROPERTY link_order_library "rt")


### PR DESCRIPTION
When LLVM linker is used, the toolchain-provided C standard library is always linked, even when the Zephyr minimal libc is selected, because `c` is unconditionally specified in `link_order_library`, which causes `-lc` to be specified in the linker flags.

This commit adds a check to ensure that `-lc` is not specified when the Zephyr minimal libc is selected because it is a standalone C standard library and it does not make sense to link two C standard libraries at once.