### PR TITLE
boards: nordic: Fix the label for nRF70 SR co-existence

### DIFF
--- a/boards/nordic/nrf7002dk/nrf7002dk_nrf5340_cpunet.dts
+++ b/boards/nordic/nrf7002dk/nrf7002dk_nrf5340_cpunet.dts
@@ -82,7 +82,7 @@
 			   <21 0 &gpio1 3 0>;	/* D15 */
 	};
 
-	nrf70: coex {
+	nrf_radio_coex: coex {
 		status = "okay";
 		compatible = "nordic,nrf7002-coex";
 

--- a/boards/shields/nrf7002eb/nrf7002eb.overlay
+++ b/boards/shields/nrf7002eb/nrf7002eb.overlay
@@ -24,6 +24,7 @@
 		bucken-gpios = <&edge_connector 9 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
 		iovdd-ctrl-gpios = <&edge_connector 9 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
 		host-irq-gpios = <&edge_connector 19 GPIO_ACTIVE_HIGH>;
+		srrf-switch-gpios = <&gpio1 13 GPIO_ACTIVE_HIGH>;
 
 		wlan0: wlan0 {
 			compatible = "nordic,wlan";

--- a/boards/shields/nrf7002eb/nrf7002eb_coex.overlay
+++ b/boards/shields/nrf7002eb/nrf7002eb_coex.overlay
@@ -5,7 +5,7 @@
  */
 
 / {
-	nrf70: coex {
+	nrf_radio_coex: coex {
 		compatible = "nordic,nrf7002-coex";
 		status = "okay";
 

--- a/boards/shields/nrf7002ek/nrf7002ek_coex.overlay
+++ b/boards/shields/nrf7002ek/nrf7002ek_coex.overlay
@@ -5,7 +5,7 @@
  */
 
 / {
-	nrf70: coex {
+	nrf_radio_coex: coex {
 		compatible = "nordic,nrf7002-coex";
 		status = "okay";
 


### PR DESCRIPTION
The co-existence modules expect a common and fixed name, so, rename it to avoid churn.