### PR TITLE
mgmt: mcumgr: stat: Fix stat_mgmt_list behavior

### DIFF
--- a/subsys/mgmt/mcumgr/grp/stat_mgmt/src/stat_mgmt.c
+++ b/subsys/mgmt/mcumgr/grp/stat_mgmt/src/stat_mgmt.c
@@ -190,7 +190,7 @@ stat_mgmt_list(struct smp_streamer *ctxt)
 {
 	const struct stats_hdr *cur = NULL;
 	zcbor_state_t *zse = ctxt->writer->zs;
-	bool ok;
+	bool ok = true;
 	size_t counter = 0;
 
 	do {
@@ -200,10 +200,15 @@ stat_mgmt_list(struct smp_streamer *ctxt)
 		}
 	} while (cur != NULL);
 
-	ok = zcbor_tstr_put_lit(zse, "rc")		&&
-	     zcbor_int32_put(zse, MGMT_ERR_EOK)		&&
-	     zcbor_tstr_put_lit(zse, "stat_list")	&&
-	     zcbor_list_start_encode(zse, counter);
+	if (IS_ENABLED(CONFIG_MCUMGR_SMP_LEGACY_RC_BEHAVIOUR)) {
+		ok = zcbor_tstr_put_lit(zse, "rc") &&
+		zcbor_int32_put(zse, MGMT_ERR_EOK);
+	}
+
+	if (ok) {
+		ok = zcbor_tstr_put_lit(zse, "stat_list") &&
+		zcbor_list_start_encode(zse, counter);
+	}
 
 	if (!ok) {
 		return MGMT_ERR_EMSGSIZE;
@@ -224,7 +229,7 @@ stat_mgmt_list(struct smp_streamer *ctxt)
 		return MGMT_ERR_EMSGSIZE;
 	}
 
-	return 0;
+	return MGMT_ERR_EOK;
 }
 
 #ifdef CONFIG_MCUMGR_SMP_SUPPORT_ORIGINAL_PROTOCOL


### PR DESCRIPTION
The MCUmgr statistics only work correctly when selecting MCUMGR_SMP_LEGACY_RC_BEHAVIOUR option. Checks the option flag on the stat_mgmt_list and fix the behavior.

Fixes: #80476
CC: @otavio 