### PR TITLE
samples: sensor: die temperature polling: remove redundant configuration

### DIFF
--- a/samples/sensor/die_temp_polling/boards/rpi_pico.conf
+++ b/samples/sensor/die_temp_polling/boards/rpi_pico.conf
@@ -1,1 +1,0 @@
-CONFIG_ADC=y


### PR DESCRIPTION
rpi_pico.conf only adds CONFIG_ADC=y which already exists in the prj.conf so it's redundant and can be removed.