### PR TITLE
doc: project: Fix collaborator reference

### DIFF
--- a/doc/project/working_groups.rst
+++ b/doc/project/working_groups.rst
@@ -18,8 +18,8 @@ Working Group Membership Eligibility
   consultation with the TSC.
 - Each working group shall have a team of members who are actively involved
   in its activities and decision-making processes.
-- It is expected that WG membership shall be **open to all Zephyr project
-  :ref:`Collaborators <collaborator>`**; however, working groups may impose
+- It is expected that WG membership shall be **open to all** Zephyr project
+  :ref:`Collaborators <collaborator>`; however, working groups may impose
   restrictions such as the number of participants from a single company.
 - All TSC members are eligible to join a working group as members, part of
   the responsibilities being a TSC member.


### PR DESCRIPTION
Commit 52e8b1058cc074725603a3f20baa807f0c4ab3ca (doc: project: clarify WG member eligibility) broke the link to the collaborator section by using nested inline markup, which is currently not supported:

https://docutils.sourceforge.io/FAQ.html#is-nested-inline-markup-possible

As the various workarounds are not recommended by Docutils, this change simply ends the bold formatting before the link.

Currently:
![image](https://github.com/user-attachments/assets/21b96527-3242-49ce-8126-fe9666f7d1d5)

After:
![image](https://github.com/user-attachments/assets/df8126d2-d55d-4388-819e-de09ed920094)
