### PR TITLE
net: lwm2m: Add TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8 to cipher list

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -1053,6 +1053,7 @@ static const int cipher_list_psk[] = {
 };
 
 static const int cipher_list_cert[] = {
+	MBEDTLS_TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8,
 	MBEDTLS_TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
 };
 


### PR DESCRIPTION
Add TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8 to the list for use with x509 certificates. 
The LWM2M v1.1 specification says that a LWM2M client which used X509 certificates must support this ciphersuite and additional ciphersuites may be supported.

Fixes: #80497