### PR TITLE
drivers: flash: Removed a __packed attribute from struct jesd216_bfp

### DIFF
--- a/drivers/flash/jesd216.h
+++ b/drivers/flash/jesd216.h
@@ -129,6 +129,8 @@ static inline uint32_t jesd216_sfdp_magic(const struct jesd216_sfdp_header *hp)
  * the standard.  Rather than pre-define layouts to access to all
  * potential fields this header provides functions for specific fields
  * known to be important, such as density and erase command support.
+ *
+ * Must be aligned to a DWORD (32-bit) address according to JESD216F.
  */
 struct jesd216_bfp {
 	uint32_t dw1;
@@ -141,7 +143,7 @@ struct jesd216_bfp {
 	uint32_t dw8;
 	uint32_t dw9;
 	uint32_t dw10[];
-} __packed;
+} __aligned(4);
 
 /* Provide a few word-specific flags and bitfield ranges for values
  * that an application or driver might expect to want to extract.


### PR DESCRIPTION
The struct jesd216_bfp was declared as __packed but later in the code the address of a member was given to a non-packed pointer, potentially causing reading of wrong addresses, and causing warnings with the IAR ICCARM compiler.

After studying the JEDEC documentation JESD216F.02, section 6.4.2 JEDEC Basic Flash Parameter Header: 2nd DWORD, the struct must be aligned to 4 so __packed is not necessary, just 4 byte alignment.