### PR TITLE
tests/kernel/device: add missing `#power-domain-cells` in overlays

### DIFF
--- a/tests/kernel/device/boards/hifive_unmatched.overlay
+++ b/tests/kernel/device/boards/hifive_unmatched.overlay
@@ -66,17 +66,20 @@
 	fakedomain_0: fakedomain_0 {
 		compatible = "fakedomain";
 		status = "okay";
+		#power-domain-cells = <0>;
 		power-domains = <&fakedomain_2>;
 	};
 
 	fakedomain_1: fakedomain_1 {
 		compatible = "fakedomain";
 		status = "okay";
+		#power-domain-cells = <0>;
 		power-domains = <&fakedomain_0>;
 	};
 
 	fakedomain_2: fakedomain_2 {
 		compatible = "fakedomain";
 		status = "okay";
+		#power-domain-cells = <0>;
 	};
 };


### PR DESCRIPTION
This commits defines the `#power-domain-cells` properties for fakedomain nodes in the HiFive Unmatched devicetree overlay file.

Without this change, this tests fails to build for the `hifive_unmatched` Zephyr target.

Fixes #80503.