### PR TITLE
NXP: add SPSDK as runner and support i.MX95 firmware build and flashing

### DIFF
--- a/boards/common/spsdk.board.cmake
+++ b/boards/common/spsdk.board.cmake
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
+
+board_set_flasher_ifnset(spsdk)
+board_finalize_runner_args(spsdk)

--- a/boards/nxp/common/Kconfig
+++ b/boards/nxp/common/Kconfig
@@ -1,0 +1,8 @@
+# Copyright 2025 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+config BOARD_NXP_SPSDK_IMAGE
+	bool "Generate bootable firmware image with SPSDK"
+	help
+	  Generate bootable firmware image with NXP Secure
+	  Provisioning SDK (SPSDK).

--- a/boards/nxp/imx95_evk/CMakeLists.txt
+++ b/boards/nxp/imx95_evk/CMakeLists.txt
@@ -12,5 +12,118 @@ if (CONFIG_SOF AND CONFIG_BOARD_IMX95_EVK_MIMX9596_M7_DDR)
   )
 endif()
 
+if(CONFIG_BOARD_NXP_SPSDK_IMAGE OR (DEFINED ENV{USE_NXP_SPSDK_IMAGE}
+  AND "$ENV{USE_NXP_SPSDK_IMAGE}" STREQUAL "y"))
+  find_program(7Z_EXECUTABLE 7z REQUIRED)
+  set(FIRMWARE_RELEASE "imx95-19x19-lpddr5-evk-boot-firmware-0.1")
+  # Parse SPSDK version
+  execute_process(
+    COMMAND spsdk --version
+    OUTPUT_VARIABLE SPSDK_VERSION_OUTPUT
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+  string(REGEX MATCH "[0-9]+\\.[0-9]+\\.[0-9]+" SPSDK_VERSION "${SPSDK_VERSION_OUTPUT}")
+  message(STATUS "SPSDK version is ${SPSDK_VERSION}")
+
+  if(CONFIG_BOARD_IMX95_EVK_MIMX9596_M7)
+    set(AHAB_CONFIG_FILE "imx95_evk_mimx9596_m7_ahab.yaml")
+
+    file(WRITE ${CMAKE_BINARY_DIR}/zephyr/${AHAB_CONFIG_FILE}
+      "
+      family: mimx9596
+      revision: a1
+      target_memory: standard
+      output:                   ${CMAKE_BINARY_DIR}/zephyr/flash.bin
+      containers:
+        - binary_container:
+            path:               ${CMAKE_BINARY_DIR}/zephyr/${FIRMWARE_RELEASE}/mx95a0-ahab-container.img
+        - container:
+            srk_set: none
+            images:
+              - lpddr_imem:     ${CMAKE_BINARY_DIR}/zephyr/${FIRMWARE_RELEASE}/lpddr5_imem_v202311.bin
+                lpddr_imem_qb:  ${CMAKE_BINARY_DIR}/zephyr/${FIRMWARE_RELEASE}/lpddr5_imem_qb_v202311.bin
+                lpddr_dmem:     ${CMAKE_BINARY_DIR}/zephyr/${FIRMWARE_RELEASE}/lpddr5_dmem_v202311.bin
+                lpddr_dmem_qb:  ${CMAKE_BINARY_DIR}/zephyr/${FIRMWARE_RELEASE}/lpddr5_dmem_qb_v202311.bin
+                oei_ddr:        ${CMAKE_BINARY_DIR}/zephyr/${FIRMWARE_RELEASE}/oei-m33-ddr.bin
+              - oei_tcm:        ${CMAKE_BINARY_DIR}/zephyr/${FIRMWARE_RELEASE}/oei-m33-tcm.bin
+              - system_manager: ${CMAKE_BINARY_DIR}/zephyr/${FIRMWARE_RELEASE}/m33_image-mx95alt.bin
+              - cortex_m7_app:  ${CMAKE_BINARY_DIR}/zephyr/${CONFIG_KERNEL_BIN_NAME}.bin
+              - v2x_dummy: true
+      ")
+    set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
+      COMMAND ${7Z_EXECUTABLE} x ${ZEPHYR_HAL_NXP_MODULE_DIR}/zephyr/blobs/imx-boot-firmware/${FIRMWARE_RELEASE}.bin -o./imx-boot-firmware -aos -bso0 -bse1
+      COMMAND ${7Z_EXECUTABLE} x imx-boot-firmware/${FIRMWARE_RELEASE} -aos -bso0 -bse1
+      COMMAND nxpimage ahab export -c ${CMAKE_BINARY_DIR}/zephyr/${AHAB_CONFIG_FILE}
+    )
+  elseif(CONFIG_SOC_MIMX9596_A55)
+    file(WRITE ${CMAKE_BINARY_DIR}/zephyr/imx95_evk_mimx9596_a55_ahab_primary.yaml
+      "
+      family: mimx9596
+      revision: a1
+      target_memory: standard
+      output:                   ${CMAKE_BINARY_DIR}/zephyr/primary_ahab.bin
+      containers:
+        - binary_container:
+            path:               ${CMAKE_BINARY_DIR}/zephyr/${FIRMWARE_RELEASE}/mx95a0-ahab-container.img
+        - container:
+            srk_set: none
+            images:
+              - lpddr_imem:     ${CMAKE_BINARY_DIR}/zephyr/${FIRMWARE_RELEASE}/lpddr5_imem_v202311.bin
+                lpddr_imem_qb:  ${CMAKE_BINARY_DIR}/zephyr/${FIRMWARE_RELEASE}/lpddr5_imem_qb_v202311.bin
+                lpddr_dmem:     ${CMAKE_BINARY_DIR}/zephyr/${FIRMWARE_RELEASE}/lpddr5_dmem_v202311.bin
+                lpddr_dmem_qb:  ${CMAKE_BINARY_DIR}/zephyr/${FIRMWARE_RELEASE}/lpddr5_dmem_qb_v202311.bin
+                oei_ddr:        ${CMAKE_BINARY_DIR}/zephyr/${FIRMWARE_RELEASE}/oei-m33-ddr.bin
+              - oei_tcm:        ${CMAKE_BINARY_DIR}/zephyr/${FIRMWARE_RELEASE}/oei-m33-tcm.bin
+              - system_manager: ${CMAKE_BINARY_DIR}/zephyr/${FIRMWARE_RELEASE}/m33_image-mx95evk.bin
+              - spl:            ${CMAKE_BINARY_DIR}/zephyr/${FIRMWARE_RELEASE}/u-boot-spl.bin-imx95-19x19-lpddr5-evk-sd
+              - v2x_dummy: true
+    ")
+    file(WRITE ${CMAKE_BINARY_DIR}/zephyr/imx95_evk_mimx9596_a55_ahab_secondary.yaml
+      "
+      family: mimx9596
+      revision: a1
+      target_memory: standard
+      output:                   ${CMAKE_BINARY_DIR}/zephyr/secondary_ahab.bin
+      containers:
+        - container:
+            srk_set: none
+            images:
+              - atf:            ${CMAKE_BINARY_DIR}/zephyr/${FIRMWARE_RELEASE}/bl31-imx95-zephyr.bin
+              - image_path:     ${CMAKE_BINARY_DIR}/zephyr/${CONFIG_KERNEL_BIN_NAME}.bin
+                load_address:   '${CONFIG_SRAM_BASE_ADDRESS}'
+                entry_point:    '${CONFIG_SRAM_BASE_ADDRESS}'
+                image_type:     executable
+                core_id:        cortex-a55
+                is_encrypted:   false
+    ")
+    file(WRITE ${CMAKE_BINARY_DIR}/zephyr/imx95_evk_mimx9596_a55_ahab_flash_template.yaml
+      "
+      family: mimx9596
+      revision: latest
+      memory_type: serial_downloader
+      primary_image_container_set: ${CMAKE_BINARY_DIR}/zephyr/imx95_evk_mimx9596_a55_ahab_primary.yaml
+      secondary_image_container_set: ${CMAKE_BINARY_DIR}/zephyr/imx95_evk_mimx9596_a55_ahab_secondary.yaml
+   ")
+    set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
+      COMMAND ${7Z_EXECUTABLE} x ${ZEPHYR_HAL_NXP_MODULE_DIR}/zephyr/blobs/imx-boot-firmware/${FIRMWARE_RELEASE}.bin -o./imx-boot-firmware -aos -bso0 -bse1
+      COMMAND ${7Z_EXECUTABLE} x imx-boot-firmware/${FIRMWARE_RELEASE} -aos -bso0 -bse1
+    )
+    if(SPSDK_VERSION VERSION_GREATER_EQUAL "3.0.0")
+      set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
+        COMMAND nxpimage bootable-image export -c ${CMAKE_BINARY_DIR}/zephyr/imx95_evk_mimx9596_a55_ahab_flash_template.yaml -o flash.bin
+      )
+    else()
+      set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
+        COMMAND nxpimage bootable-image merge -c ${CMAKE_BINARY_DIR}/zephyr/imx95_evk_mimx9596_a55_ahab_flash_template.yaml -o flash.bin
+      )
+    endif()
+  else()
+    message(FATAL_ERROR "SPSDK Image not supported on the platform!")
+  endif()
+  zephyr_blobs_verify(FILES
+    ${ZEPHYR_HAL_NXP_MODULE_DIR}/zephyr/blobs/imx-boot-firmware/${FIRMWARE_RELEASE}.bin
+    REQUIRED)
+endif()
+
 zephyr_library()
 zephyr_library_sources(board.c)

--- a/boards/nxp/imx95_evk/Kconfig
+++ b/boards/nxp/imx95_evk/Kconfig
@@ -1,0 +1,4 @@
+# Copyright 2025 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+source "boards/nxp/common/Kconfig"

--- a/boards/nxp/imx95_evk/board.cmake
+++ b/boards/nxp/imx95_evk/board.cmake
@@ -3,3 +3,19 @@
 if (CONFIG_SOF AND CONFIG_BOARD_IMX95_EVK_MIMX9596_M7_DDR)
   board_set_rimage_target(imx95)
 endif()
+
+if(CONFIG_BOARD_NXP_SPSDK_IMAGE OR (DEFINED ENV{USE_NXP_SPSDK_IMAGE}
+  AND "$ENV{USE_NXP_SPSDK_IMAGE}" STREQUAL "y"))
+  board_set_flasher_ifnset(spsdk)
+
+  board_runner_args(spsdk "--family=mimx9596")
+  board_runner_args(spsdk "--bootloader=${CMAKE_BINARY_DIR}/zephyr/imx95-19x19-lpddr5-evk-boot-firmware-0.1/imx-boot-imx95-19x19-lpddr5-evk-sd.bin-flash_all")
+  board_runner_args(spsdk "--flashbin=${CMAKE_BINARY_DIR}/zephyr/flash.bin")
+  if(CONFIG_CPU_CORTEX_A55)
+    board_runner_args(spsdk "--containers=two")
+  else()
+    board_runner_args(spsdk "--containers=one")
+  endif()
+
+  include(${ZEPHYR_BASE}/boards/common/spsdk.board.cmake)
+endif()

--- a/boards/nxp/imx95_evk/imx95_evk_mimx9596_a55.yaml
+++ b/boards/nxp/imx95_evk/imx95_evk_mimx9596_a55.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 NXP
+# Copyright 2024-2025 NXP
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -16,4 +16,7 @@ supported:
   - counter
   - i2c
   - uart
+testing:
+  binaries:
+    - flash.bin
 vendor: nxp

--- a/boards/nxp/imx95_evk/imx95_evk_mimx9596_m7.yaml
+++ b/boards/nxp/imx95_evk/imx95_evk_mimx9596_m7.yaml
@@ -20,4 +20,7 @@ supported:
   - spi
   - netif:eth
   - counter
+testing:
+  binaries:
+    - flash.bin
 vendor: nxp

--- a/scripts/requirements-extras.txt
+++ b/scripts/requirements-extras.txt
@@ -15,6 +15,9 @@ junit2html
 # Script used to build firmware images for NXP LPC MCUs.
 lpc_checksum
 
+# used by NXP platform to generate/flash firmware images
+spsdk == 2.6.0
+
 # used by scripts/build/gen_cfb_font_header.py - helper script for user
 Pillow>=10.3.0
 

--- a/scripts/west_commands/runners/__init__.py
+++ b/scripts/west_commands/runners/__init__.py
@@ -58,6 +58,7 @@ _names = [
     'rfp',
     'silabs_commander',
     'spi_burn',
+    'spsdk',
     'stm32cubeprogrammer',
     'stm32flash',
     'sy1xx',

--- a/scripts/west_commands/runners/spsdk.py
+++ b/scripts/west_commands/runners/spsdk.py
@@ -1,0 +1,131 @@
+# Copyright 2025 NXP
+#
+# SPDX-License-Identifier: Apache-2.0
+
+'''Runner for flashing with SPSDK.'''
+
+import logging
+import os
+import subprocess
+from pathlib import Path
+
+from runners.core import RunnerCaps, ZephyrBinaryRunner
+
+
+class SPSDKBinaryRunner(ZephyrBinaryRunner):
+    '''Runner front-end for SPSDK.'''
+
+    def __init__(
+        self,
+        cfg,
+        dev_id,
+        bootdevice=None,
+        family=None,
+        bootloader=None,
+        flashbin=None,
+        containers=None,
+        commander=None,
+    ):
+        super().__init__(cfg)
+        self.dev_id = dev_id
+        self.file = cfg.file
+        self.file_type = cfg.file_type
+        self.hex_name = cfg.hex_file
+        self.bin_name = cfg.bin_file
+        self.elf_name = cfg.elf_file
+
+        self.bootdevice = bootdevice
+        self.family = family
+        self.bootloader = bootloader
+        self.flashbin = flashbin
+        self.containers = containers
+        self.commander = commander
+
+    @classmethod
+    def name(cls):
+        return 'spsdk'
+
+    @classmethod
+    def capabilities(cls):
+        return RunnerCaps(commands={'flash'}, dev_id=True)
+
+    @classmethod
+    def dev_id_help(cls) -> str:
+        return 'SPSDK serial number for the board.'
+
+    @classmethod
+    def do_add_parser(cls, parser):
+        parser.add_argument('--bootdevice', default='spl', help='boot device')
+        parser.add_argument('--family', required=True, help='family')
+        parser.add_argument('--bootloader', required=True, help='bootloader')
+        parser.add_argument('--flashbin', required=True, help='nxp container image flash.bin')
+        parser.add_argument(
+            '--containers', required=True, help='container count in flash.bin: one or two'
+        )
+        parser.add_argument(
+            '--commander',
+            default='nxpuuu',
+            help="SPSDK Commander, default is nxpuuu",
+        )
+
+    @classmethod
+    def do_create(cls, cfg, args):
+        return SPSDKBinaryRunner(
+            cfg,
+            bootdevice=args.bootdevice,
+            family=args.family,
+            bootloader=args.bootloader,
+            flashbin=args.flashbin,
+            containers=args.containers,
+            commander=args.commander,
+            dev_id=args.dev_id,
+        )
+
+    def do_run(self, command, **kwargs):
+        self.commander = os.fspath(Path(self.require(self.commander)).resolve())
+
+        if command == 'flash':
+            self.flash(**kwargs)
+
+    def flash(self, **kwargs):
+        self.logger.info(f"Flashing file: {self.flashbin}")
+
+        kwargs = {}
+        if not self.logger.isEnabledFor(logging.DEBUG):
+            kwargs['stdout'] = subprocess.DEVNULL
+
+        if self.dev_id:
+            cmd_with_id = [self.commander] + [(f'-us={self.dev_id}' if self.dev_id else '')]
+        else:
+            cmd_with_id = [self.commander]
+        if self.bootdevice == 'spl':
+            if self.containers == 'one':
+                cmd = cmd_with_id + ['run'] + [f"SDPS[-t 10000]: boot -f {self.flashbin}"]
+                self.logger.info(f"Command: {cmd}")
+                self.check_call(cmd, **kwargs)
+            elif self.containers == 'two':
+                cmd = cmd_with_id + ['run'] + [f"SDPS[-t 10000]: boot -f {self.flashbin}"]
+                self.logger.info(f"Command: {cmd}")
+                self.check_call(cmd, **kwargs)
+                cmd = cmd_with_id + ['run'] + ["SDPV: delay 1000"]
+                self.logger.info(f"Command: {cmd}")
+                self.check_call(cmd, **kwargs)
+                cmd = cmd_with_id + ['run'] + [f"SDPV: write -f {self.flashbin} -skipspl"]
+                self.logger.info(f"Command: {cmd}")
+                self.check_call(cmd, **kwargs)
+                cmd = cmd_with_id + ['run'] + ["SDPV: jump"]
+                self.logger.info(f"Command: {cmd}")
+                self.check_call(cmd, **kwargs)
+            else:
+                raise ValueError(f"Invalid containers count: {self.containers}")
+        else:
+            cmd = (
+                [self.commander]
+                + ['write']
+                + ['-b', f'{self.bootdevice}']
+                + ['-f', f'{self.family}']
+                + [f'{self.bootloader}']
+                + [f'{self.flashbin}']
+            )
+            self.logger.info(f"Command: {cmd}")
+            self.check_call(cmd, **kwargs)

--- a/scripts/west_commands/tests/test_imports.py
+++ b/scripts/west_commands/tests/test_imports.py
@@ -49,6 +49,7 @@ def test_runner_imports():
         'rfp',
         'silabs_commander',
         'spi_burn',
+        'spsdk',
         'stm32cubeprogrammer',
         'stm32flash',
         'sy1xx',

--- a/west.yml
+++ b/west.yml
@@ -210,7 +210,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: 0575edec4c4d2a9c31e50974024e0ace9514f7a3
+      revision: dcb80803ee9d528c600d012aa4ac6515bbd8fb3d
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
This PR is to make it easier to build and flash NXP i.MX platforms having firmware images dependency with NXP SPSDK (https://spsdk.readthedocs.io).
For i.MX95, an bootable image depends on many firmware images besides m7 zephyr.bin, like ddr firmware, system manager image, oei images, ahab container image and so on.

This PR is to support west build  to generate a bootable flash.bin.
And west flash to program flash.bin to SD boot device through USB.

Thanks.
