### PR TITLE
net: openthread: Add platform message management

### DIFF
--- a/modules/openthread/platform/CMakeLists.txt
+++ b/modules/openthread/platform/CMakeLists.txt
@@ -16,6 +16,7 @@ zephyr_library_sources_ifdef(CONFIG_OPENTHREAD_COPROCESSOR uart.c)
 zephyr_library_sources_ifdef(CONFIG_OPENTHREAD_CRYPTO_PSA crypto_psa.c)
 zephyr_library_sources_ifdef(CONFIG_OPENTHREAD_SHELL shell.c)
 zephyr_library_sources_ifdef(CONFIG_OPENTHREAD_EXTERNAL_HEAP memory.c)
+zephyr_library_sources_ifdef(CONFIG_OPENTHREAD_PLATFORM_MESSAGE_MANAGEMENT messagepool.c)
 zephyr_library_sources_ifdef(CONFIG_SETTINGS settings.c)
 zephyr_library_sources_ifndef(CONFIG_LOG_BACKEND_SPINEL logging.c)
 

--- a/modules/openthread/platform/messagepool.c
+++ b/modules/openthread/platform/messagepool.c
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+
+#include <openthread/platform/messagepool.h>
+
+#define LOG_MODULE_NAME net_otPlat_messagepool
+#define LOG_LEVEL       CONFIG_OPENTHREAD_LOG_LEVEL
+
+LOG_MODULE_REGISTER(LOG_MODULE_NAME);
+
+#define BUF_TIMEOUT K_MSEC(50)
+
+#define MESSAGE_POOL_SIZE                                                                          \
+	(CONFIG_OPENTHREAD_NUM_MESSAGE_BUFFERS * CONFIG_OPENTHREAD_MESSAGE_BUFFER_SIZE)
+#define MAX_ALIGNMENT __alignof__(z_max_align_t)
+
+BUILD_ASSERT(CONFIG_OPENTHREAD_MESSAGE_BUFFER_SIZE % MAX_ALIGNMENT == 0,
+	     "Invalid message buffer size");
+
+static struct k_mem_slab message_pool;
+__aligned(MAX_ALIGNMENT) static uint8_t message_pool_buffer[MESSAGE_POOL_SIZE];
+
+void otPlatMessagePoolInit(otInstance *aInstance, uint16_t aMinNumFreeBuffers, size_t aBufferSize)
+{
+	ARG_UNUSED(aInstance);
+
+	__ASSERT(aBufferSize == CONFIG_OPENTHREAD_MESSAGE_BUFFER_SIZE,
+		 "Message buffer size does not match configuration");
+
+	if (aMinNumFreeBuffers > CONFIG_OPENTHREAD_NUM_MESSAGE_BUFFERS) {
+		LOG_WRN("Minimum number of free buffers (%d) is greater than number of allocated "
+			"buffers (%d)",
+			aMinNumFreeBuffers, CONFIG_OPENTHREAD_NUM_MESSAGE_BUFFERS);
+	}
+
+	if (k_mem_slab_init(&message_pool, message_pool_buffer, aBufferSize,
+			    CONFIG_OPENTHREAD_NUM_MESSAGE_BUFFERS) != 0) {
+		__ASSERT(false, "Failed to initialize message pool");
+	}
+}
+
+otMessageBuffer *otPlatMessagePoolNew(otInstance *aInstance)
+{
+	ARG_UNUSED(aInstance);
+
+	otMessageBuffer *buffer;
+
+	if (k_mem_slab_alloc(&message_pool, (void **)&buffer, BUF_TIMEOUT) != 0) {
+		LOG_ERR("Failed to allocate message buffer");
+		return NULL;
+	}
+
+	buffer->mNext = NULL;
+	return buffer;
+}
+
+void otPlatMessagePoolFree(otInstance *aInstance, otMessageBuffer *aBuffer)
+{
+	ARG_UNUSED(aInstance);
+
+	k_mem_slab_free(&message_pool, (void *)aBuffer);
+}

--- a/modules/openthread/platform/openthread-core-zephyr-config.h
+++ b/modules/openthread/platform/openthread-core-zephyr-config.h
@@ -427,6 +427,16 @@
 #endif
 
 /**
+ * @def OPENTHREAD_CONFIG_PLATFORM_MESSAGE_MANAGEMENT
+ *
+ * The message pool is managed by platform defined logic.
+ *
+ */
+#ifdef CONFIG_OPENTHREAD_PLATFORM_MESSAGE_MANAGEMENT
+#define OPENTHREAD_CONFIG_PLATFORM_MESSAGE_MANAGEMENT CONFIG_OPENTHREAD_PLATFORM_MESSAGE_MANAGEMENT
+#endif
+
+/**
  * @def OPENTHREAD_CONFIG_MAC_STAY_AWAKE_BETWEEN_FRAGMENTS
  *
  * Enable to stay awake between fragments while transmitting a large packet,

--- a/subsys/net/l2/openthread/Kconfig
+++ b/subsys/net/l2/openthread/Kconfig
@@ -273,6 +273,11 @@ config OPENTHREAD_MESSAGE_BUFFER_SIZE
 	help
 	  "The size of a message buffer in bytes"
 
+config OPENTHREAD_PLATFORM_MESSAGE_MANAGEMENT
+	bool "Use platform message management"
+	help
+	  The message pool is managed by platform defined logic.
+
 config OPENTHREAD_MAX_STATECHANGE_HANDLERS
 	int "The maximum number of state-changed callback handlers"
 	default 2


### PR DESCRIPTION
* Add CONFIG_OPENTHREAD_PLATFORM_MESSAGE_MANAGEMENT to allow enabling message management by the platform.
* Add implementation of `otPlatMessagePoolInit`, `otPlatMessagePoolNew` and `otPlatMessagePoolFree`.