### PR TITLE
include: clock: stm32f4 high speed clock definition

### DIFF
--- a/include/zephyr/dt-bindings/clock/stm32f4_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32f4_clock.h
@@ -28,8 +28,10 @@
 /* defined in stm32_common_clocks.h */
 /** Fixed clocks */
 /* Low speed clocks defined in stm32_common_clocks.h */
+#define STM32_SRC_HSI      (STM32_SRC_LSI + 1)
+#define STM32_SRC_HSE      (STM32_SRC_HSI + 1)
 /** PLL clock outputs */
-#define STM32_SRC_PLL_P		(STM32_SRC_LSI + 1)
+#define STM32_SRC_PLL_P		(STM32_SRC_HSE + 1)
 #define STM32_SRC_PLL_Q		(STM32_SRC_PLL_P + 1)
 #define STM32_SRC_PLL_R		(STM32_SRC_PLL_Q + 1)
 /** I2S sources */

--- a/include/zephyr/dt-bindings/clock/stm32f4_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32f4_clock.h
@@ -11,15 +11,15 @@
 /** Domain clocks */
 
 /** Bus clocks */
-#define STM32_CLOCK_BUS_AHB1    0x030
-#define STM32_CLOCK_BUS_AHB2    0x034
-#define STM32_CLOCK_BUS_AHB3    0x038
-#define STM32_CLOCK_BUS_APB1    0x040
-#define STM32_CLOCK_BUS_APB2    0x044
-#define STM32_CLOCK_BUS_APB3    0x0A8
+#define STM32_CLOCK_BUS_AHB1 0x030
+#define STM32_CLOCK_BUS_AHB2 0x034
+#define STM32_CLOCK_BUS_AHB3 0x038
+#define STM32_CLOCK_BUS_APB1 0x040
+#define STM32_CLOCK_BUS_APB2 0x044
+#define STM32_CLOCK_BUS_APB3 0x0A8
 
-#define STM32_PERIPH_BUS_MIN	STM32_CLOCK_BUS_AHB1
-#define STM32_PERIPH_BUS_MAX	STM32_CLOCK_BUS_APB3
+#define STM32_PERIPH_BUS_MIN STM32_CLOCK_BUS_AHB1
+#define STM32_PERIPH_BUS_MAX STM32_CLOCK_BUS_APB3
 
 /** Domain clocks */
 /* RM0386, 0390, 0402, 0430 § Dedicated Clock configuration register (RCC_DCKCFGRx) */
@@ -31,14 +31,13 @@
 #define STM32_SRC_HSI      (STM32_SRC_LSI + 1)
 #define STM32_SRC_HSE      (STM32_SRC_HSI + 1)
 /** PLL clock outputs */
-#define STM32_SRC_PLL_P		(STM32_SRC_HSE + 1)
-#define STM32_SRC_PLL_Q		(STM32_SRC_PLL_P + 1)
-#define STM32_SRC_PLL_R		(STM32_SRC_PLL_Q + 1)
+#define STM32_SRC_PLL_P    (STM32_SRC_HSE + 1)
+#define STM32_SRC_PLL_Q    (STM32_SRC_PLL_P + 1)
+#define STM32_SRC_PLL_R    (STM32_SRC_PLL_Q + 1)
 /** I2S sources */
-#define STM32_SRC_PLLI2S_R	(STM32_SRC_PLL_R + 1)
+#define STM32_SRC_PLLI2S_R (STM32_SRC_PLL_R + 1)
 /* I2S_CKIN not supported yet */
 /* #define STM32_SRC_I2S_CKIN	TBD */
-
 
 #define STM32_CLOCK_REG_MASK    0xFFU
 #define STM32_CLOCK_REG_SHIFT   0U
@@ -62,25 +61,25 @@
  * @param mask Mask for the RCC_CFGRx field.
  * @param val Clock value (0, 1, ... 7).
  */
-#define STM32_DOMAIN_CLOCK(val, mask, shift, reg)					\
-	((((reg) & STM32_CLOCK_REG_MASK) << STM32_CLOCK_REG_SHIFT) |		\
-	 (((shift) & STM32_CLOCK_SHIFT_MASK) << STM32_CLOCK_SHIFT_SHIFT) |	\
-	 (((mask) & STM32_CLOCK_MASK_MASK) << STM32_CLOCK_MASK_SHIFT) |		\
+#define STM32_DOMAIN_CLOCK(val, mask, shift, reg)                                                  \
+	((((reg) & STM32_CLOCK_REG_MASK) << STM32_CLOCK_REG_SHIFT) |                               \
+	 (((shift) & STM32_CLOCK_SHIFT_MASK) << STM32_CLOCK_SHIFT_SHIFT) |                         \
+	 (((mask) & STM32_CLOCK_MASK_MASK) << STM32_CLOCK_MASK_SHIFT) |                            \
 	 (((val) & STM32_CLOCK_VAL_MASK) << STM32_CLOCK_VAL_SHIFT))
 
 /** @brief RCC_CFGRx register offset */
-#define CFGR_REG		0x08
+#define CFGR_REG 0x08
 /** @brief RCC_BDCR register offset */
-#define BDCR_REG		0x70
+#define BDCR_REG 0x70
 
 /** @brief Device domain clocks selection helpers */
 /** CFGR devices */
-#define I2S_SEL(val)		STM32_DOMAIN_CLOCK(val, 1, 23, CFGR_REG)
-#define MCO1_SEL(val)           STM32_MCO_CFGR(val, 0x3, 21, CFGR_REG)
-#define MCO1_PRE(val)           STM32_MCO_CFGR(val, 0x7, 24, CFGR_REG)
-#define MCO2_SEL(val)           STM32_MCO_CFGR(val, 0x3, 30, CFGR_REG)
-#define MCO2_PRE(val)           STM32_MCO_CFGR(val, 0x7, 27, CFGR_REG)
+#define I2S_SEL(val)  STM32_DOMAIN_CLOCK(val, 1, 23, CFGR_REG)
+#define MCO1_SEL(val) STM32_MCO_CFGR(val, 0x3, 21, CFGR_REG)
+#define MCO1_PRE(val) STM32_MCO_CFGR(val, 0x7, 24, CFGR_REG)
+#define MCO2_SEL(val) STM32_MCO_CFGR(val, 0x3, 30, CFGR_REG)
+#define MCO2_PRE(val) STM32_MCO_CFGR(val, 0x7, 27, CFGR_REG)
 /** BDCR devices */
-#define RTC_SEL(val)		STM32_DOMAIN_CLOCK(val, 3, 8, BDCR_REG)
+#define RTC_SEL(val)  STM32_DOMAIN_CLOCK(val, 3, 8, BDCR_REG)
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32F4_CLOCK_H_ */

--- a/samples/boards/st/mco/boards/nucleo_f429zi.overlay
+++ b/samples/boards/st/mco/boards/nucleo_f429zi.overlay
@@ -1,0 +1,31 @@
+/* The clock that is output must be enabled. */
+&clk_hse {
+	status = "okay";
+};
+
+/* See reference manual (RM0090):
+ *   0b010: HSE clock selected
+ */
+#define MCO_SEL_HSE 2
+
+/* See reference manual (RM0090):
+ *   0b100: MCO divided by 2
+ */
+#define MCO_PRE_DIV_2 4
+
+&mco1 {
+	status = "okay";
+	clocks = <&rcc STM32_SRC_HSE MCO1_SEL(MCO_SEL_HSE)>;
+	prescaler = <MCO1_PRE(MCO_PRE_DIV_2)>;
+	pinctrl-0 = <&rcc_mco_1_pa8>;
+	pinctrl-names = "default";
+};
+
+
+&mco2 {
+	status = "okay";
+	clocks = <&rcc STM32_SRC_HSE MCO2_SEL(MCO_SEL_HSE)>;
+	prescaler = <MCO2_PRE(MCO_PRE_DIV_2)>;
+	pinctrl-0 = <&rcc_mco_2_pc9>;
+	pinctrl-names = "default";
+};


### PR DESCRIPTION
Add the HSI and HSE clock source for the stm32f4 serie

Fixes https://github.com/zephyrproject-rtos/zephyr/discussions/80465