### PR TITLE
manifest: Update bsim to version v2.4

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -34,7 +34,7 @@ manifest:
       path: modules/lib/acpica
     - name: bsim
       repo-path: babblesim-manifest
-      revision: 9ee22c707970f6621adba0375841c0a609e24628
+      revision: 1f242f4ed7fc141fdfcfeca8d21c6d9e801179d7
       path: tools/bsim
       groups:
         - babblesim
@@ -42,21 +42,21 @@ manifest:
       remote: babblesim
       repo-path: base
       path: tools/bsim/components
-      revision: a3dff9a57f334fb25daa9625841cd64cbfe56681
+      revision: 0cc70e78a88c1de9d8ec045a703b38134861e7e7
       groups:
         - babblesim
     - name: babblesim_ext_2G4_libPhyComv1
       remote: babblesim
       repo-path: ext_2G4_libPhyComv1
       path: tools/bsim/components/ext_2G4_libPhyComv1
-      revision: aa4951317cc7d84f24152ea38ac9ac21e6d78a76
+      revision: 15ae0f87fa049e04cbec48a866f3bc37d903f950
       groups:
         - babblesim
     - name: babblesim_ext_2G4_phy_v1
       remote: babblesim
       repo-path: ext_2G4_phy_v1
       path: tools/bsim/components/ext_2G4_phy_v1
-      revision: 04eeb3c3794444122fbeeb3715f4233b0b50cfbb
+      revision: 62e797b2c518e5bb6123a198382ed2b64b8c068e
       groups:
         - babblesim
     - name: babblesim_ext_2G4_channel_NtNcable


### PR DESCRIPTION
Main changes since v2.3:
* Support for immediate RSSI measurements during abort reevaluations
* Several minor improvements in the base components, including tolerating better under-setup docker images, improved C++ compatibility, a new sanity check for problematic user provided sim_ids, and other minor improvements.

Note: Like before, bsim remains fully backwards compatible

Note: This change is not required for Zephyr 4.0, but does not harm either