### PR TITLE
devicetree: Add `DT_HAS_ALIAS` macro

### DIFF
--- a/doc/build/dts/api-usage.rst
+++ b/doc/build/dts/api-usage.rst
@@ -50,6 +50,8 @@ By alias
    :zephyr:code-sample:`blinky`, which uses the ``led0`` alias) that need to
    refer to *some* device of a particular type ("the board's user LED") but
    don't care which one is used.
+   You may also use :c:macro:`DT_HAS_ALIAS()` to verify whether an alias
+   node exists.
 
 By instance number
    This is done primarily by device drivers, as instance numbers are a way to

--- a/include/zephyr/devicetree.h
+++ b/include/zephyr/devicetree.h
@@ -240,6 +240,13 @@
 #define DT_ALIAS(alias) DT_CAT(DT_N_ALIAS_, alias)
 
 /**
+ * @brief Test if the devicetree has a given alias
+ * @param alias_name lowercase-and-underscores devicetree alias name
+ * @return 1 if the alias exists and refers to a node, 0 otherwise
+ */
+#define DT_HAS_ALIAS(alias_name) DT_NODE_EXISTS(DT_ALIAS(alias_name))
+
+/**
  * @brief Get a node identifier for an instance of a compatible
  *
  * All nodes with a particular compatible property value are assigned

--- a/tests/lib/devicetree/api/src/main.c
+++ b/tests/lib/devicetree/api/src/main.c
@@ -127,6 +127,8 @@ ZTEST(devicetree_api, test_path_props)
 
 ZTEST(devicetree_api, test_alias_props)
 {
+	zassert_equal(DT_HAS_ALIAS(test_alias), 1, "");
+	zassert_equal(DT_HAS_ALIAS(test_alias_none), 0, "");
 	zassert_equal(DT_NUM_REGS(TEST_ALIAS), 1, "");
 	zassert_equal(DT_REG_ADDR(TEST_ALIAS), 0xdeadbeef, "");
 	zassert_equal(DT_REG_SIZE(TEST_ALIAS), 0x1000, "");


### PR DESCRIPTION
Add 'DT_HAS_ALIAS' macro to verify node alias existence.

for example
```
#if DT_HAS_ALIAS(led_gpio)
# define LED_GPIO 0x00
#endif
```