### PR TITLE
linker: lto: Remove experimental label

### DIFF
--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -536,11 +536,10 @@ config NO_OPTIMIZATIONS
 endchoice
 
 config LTO
-	bool "Link Time Optimization [EXPERIMENTAL]"
+	bool "Link Time Optimization"
 	depends on !(GEN_ISR_TABLES || GEN_IRQ_VECTOR_TABLE) || ISR_TABLES_LOCAL_DECLARATION
 	depends on !NATIVE_LIBRARY
 	depends on !CODE_DATA_RELOCATION
-	select EXPERIMENTAL
 	help
 	  This option enables Link Time Optimization.
 


### PR DESCRIPTION
LTO support was added with Zephyr 3.6.0, and it has been used in production with Nordic devices for a long time. Remove the experimental label to mark it ready for production.