### PR TITLE
doc: add missing Ethernet Support in section Supported Features for Nucleo H563ZI and STM32H573I-DK

### DIFF
--- a/boards/st/nucleo_h563zi/doc/index.rst
+++ b/boards/st/nucleo_h563zi/doc/index.rst
@@ -174,7 +174,8 @@ The Zephyr nucleo_h563zi board configuration supports the following hardware fea
 +-----------+------------+-------------------------------------+
 | USB       | on-chip    | USB full-speed host/device bus      |
 +-----------+------------+-------------------------------------+
-
+| ETHERNET  | on-chip    | ethernet                            |
++-----------+------------+-------------------------------------+
 
 Other hardware features are not yet supported on this Zephyr port.
 

--- a/boards/st/stm32h573i_dk/doc/index.rst
+++ b/boards/st/stm32h573i_dk/doc/index.rst
@@ -192,7 +192,8 @@ hardware features:
 +-----------+------------+-------------------------------------+
 | RTC       | on-chip    | rtc                                 |
 +-----------+------------+-------------------------------------+
-
+| ETHERNET  | on-chip    | ethernet                            |
++-----------+------------+-------------------------------------+
 
 Other hardware features are not yet supported on this Zephyr port.
 


### PR DESCRIPTION
I recently found out, that the Ethernet support for the boards Nucleo H563ZI and STM32H573I-DK is already available but it isn't mentioned in the "Supported Features" section.