### PR TITLE
stm32h7 dual-core have a bit to clock the internal flash

### DIFF
--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -144,7 +144,6 @@
 			compatible = "st,stm32-flash-controller", "st,stm32h7-flash-controller";
 			reg = <0x52002000 0x400>;
 			interrupts = <4 0>;
-			clocks = <&rcc STM32_CLOCK(AHB3, 8U)>;
 
 			#address-cells = <1>;
 			#size-cells = <1>;

--- a/dts/arm/st/h7/stm32h7_dualcore.dtsi
+++ b/dts/arm/st/h7/stm32h7_dualcore.dtsi
@@ -25,3 +25,7 @@
 		};
 	};
 };
+
+&flash {
+	clocks = <&rcc STM32_CLOCK(AHB3, 8U)>;
+};


### PR DESCRIPTION
Not all the stm32H7 have a clock enable for their flash; only the dual-core.
For the st,stm32h7-flash-controller with "clocks" property, the flash_stm32h7 driver
   will enable the flash clock bit in the corresponding RCC register.
    
This bit is at 8th position RCC_AHB3ENR_FLASHEN of the RCC_AHB3ENR register

Fixes  https://github.com/zephyrproject-rtos/zephyr/issues/79660