### PR TITLE
tests: Bluetooth: tester: Add logging of messages for BTP

### DIFF
--- a/tests/bluetooth/tester/src/btp.c
+++ b/tests/bluetooth/tester/src/btp.c
@@ -96,6 +96,9 @@ static void cmd_handler(void *p1, void *p2, void *p3)
 
 		cmd = k_fifo_get(&cmds_queue, K_FOREVER);
 
+		LOG_DBG("cmd service %u opcode %u index %u", cmd->hdr.service, cmd->hdr.opcode,
+			cmd->hdr.index);
+
 		len = sys_le16_to_cpu(cmd->hdr.len);
 
 		btp = find_btp_handler(cmd->hdr.service, cmd->hdr.opcode);
@@ -293,6 +296,8 @@ static void tester_rsp_with_index(uint8_t service, uint8_t opcode, uint8_t index
 {
 	struct btp_status s;
 
+	LOG_DBG("service %u opcode %u index %u status %u", service, opcode, index, status);
+
 	if (status == BTP_STATUS_SUCCESS) {
 		tester_send_with_index(service, opcode, index, NULL, 0);
 		return;
@@ -305,6 +310,9 @@ static void tester_rsp_with_index(uint8_t service, uint8_t opcode, uint8_t index
 void tester_event(uint8_t service, uint8_t opcode, const void *data, size_t len)
 {
 	__ASSERT_NO_MSG(opcode >= 0x80);
+
+	LOG_DBG("service %u opcode %u", service, opcode);
+
 	tester_send_with_index(service, opcode, BTP_INDEX, data, len);
 }
 
@@ -314,6 +322,8 @@ void tester_rsp_full(uint8_t service, uint8_t opcode, const void *rsp, size_t le
 
 	__ASSERT_NO_MSG(opcode < 0x80);
 	__ASSERT_NO_MSG(delayed_cmd != NULL);
+
+	LOG_DBG("service %u opcode %u", service, opcode);
 
 	tester_send_with_index(service, opcode, BTP_INDEX, rsp, len);
 
@@ -330,6 +340,8 @@ void tester_rsp(uint8_t service, uint8_t opcode, uint8_t status)
 
 	__ASSERT_NO_MSG(opcode < 0x80);
 	__ASSERT_NO_MSG(delayed_cmd != NULL);
+
+	LOG_DBG("service %u opcode %u status %u", service, opcode, status);
 
 	tester_rsp_with_index(service, opcode, BTP_INDEX, status);
 


### PR DESCRIPTION
Add log statements for each command, event and response for debugging purposes.

Tests do not send enough of these to clutter the IUT logs and it is useful for debugging to more easily determine what command triggered a function call or when the responses and events are sent to the AutoPTS client.