### PR TITLE
nxp: imx8: misc PM-related bug fixes

### DIFF
--- a/drivers/dma/dma_nxp_edma.c
+++ b/drivers/dma/dma_nxp_edma.c
@@ -332,6 +332,8 @@ static int edma_config(const struct device *dev, uint32_t chan_id,
 				      EDMA_TCD_CSR_INTHALF_MASK, 0);
 	}
 
+	irq_enable(chan->irq);
+
 	/* dump register status - for debugging purposes */
 	edma_dump_channel_registers(data, chan_id);
 
@@ -510,8 +512,6 @@ static int edma_start(const struct device *dev, uint32_t chan_id)
 	}
 
 	LOG_DBG("starting channel %u", chan_id);
-
-	irq_enable(chan->irq);
 
 	/* enable HW requests */
 	EDMA_ChannelRegUpdate(data->hal_cfg, chan_id,

--- a/drivers/interrupt_controller/intc_nxp_irqsteer.c
+++ b/drivers/interrupt_controller/intc_nxp_irqsteer.c
@@ -385,7 +385,7 @@ static void _irqstr_disp_put_unlocked(struct irqsteer_dispatcher *disp)
 	if (!disp->refcnt) {
 		_irqstr_disp_enable_disable(disp, false);
 
-		ret = pm_device_runtime_put(disp->dev);
+		ret = pm_device_runtime_put_async(disp->dev, K_NO_WAIT);
 		if (ret < 0) {
 			LOG_ERR("failed to disable PM resources: %d", ret);
 			return;

--- a/drivers/power_domain/power_domain_nxp_scu.c
+++ b/drivers/power_domain/power_domain_nxp_scu.c
@@ -20,8 +20,8 @@ struct scu_pd_data {
 	sc_rsrc_t rsrc;
 };
 
-static int scu_pd_pm_action(const struct device *dev,
-			    enum pm_device_action action)
+__maybe_unused static int scu_pd_pm_action(const struct device *dev,
+					   enum pm_device_action action)
 {
 	int ret;
 	sc_pm_power_mode_t mode;


### PR DESCRIPTION
Misc imx8 PM-related bug fixes, including:

1. Making irq_disable() `isr-ok`.
2. Moving irq_enable() call from edma_start() to edma_config().
3. Adding `__maybe_unused` tag to `scu_pd_pm_action`.