### PR TITLE
soc: st: stm32U5/L5 series also have SWO line

### DIFF
--- a/soc/st/stm32/common/soc_config.c
+++ b/soc/st/stm32/common/soc_config.c
@@ -28,14 +28,15 @@ static int st_stm32_common_config(void)
 {
 #ifdef CONFIG_LOG_BACKEND_SWO
 	/* Enable SWO trace asynchronous mode */
-#if defined(CONFIG_SOC_SERIES_STM32WBX) || defined(CONFIG_SOC_SERIES_STM32H5X)
+#if defined(CONFIG_SOC_SERIES_STM32H5X) || defined(CONFIG_SOC_SERIES_STM32H7RSX) ||                \
+	defined(CONFIG_SOC_SERIES_STM32L5X) || defined(CONFIG_SOC_SERIES_STM32U5X) ||              \
+	defined(CONFIG_SOC_SERIES_STM32WBX)
 	LL_DBGMCU_EnableTraceClock();
 #endif
 #if !defined(CONFIG_SOC_SERIES_STM32WBX) && defined(DBGMCU_CR_TRACE_IOEN)
 	LL_DBGMCU_SetTracePinAssignment(LL_DBGMCU_TRACE_ASYNCH);
 #endif
 #endif /* CONFIG_LOG_BACKEND_SWO */
-
 
 #if defined(CONFIG_USE_SEGGER_RTT)
 	/* On some STM32 boards, for unclear reason,
@@ -48,7 +49,6 @@ static int st_stm32_common_config(void)
 #elif defined(__HAL_RCC_GPDMA1_CLK_ENABLE)
 	__HAL_RCC_GPDMA1_CLK_ENABLE();
 #endif /* __HAL_RCC_DMA1_CLK_ENABLE */
-
 
 #endif /* CONFIG_USE_SEGGER_RTT */
 

--- a/soc/st/stm32/stm32l5x/Kconfig
+++ b/soc/st/stm32/stm32l5x/Kconfig
@@ -13,5 +13,6 @@ config SOC_SERIES_STM32L5X
 	select ARMV8_M_DSP
 	select CPU_CORTEX_M_HAS_DWT
 	select HAS_STM32CUBE
+	select HAS_SWO
 	select HAS_PM
 	select SOC_EARLY_INIT_HOOK

--- a/soc/st/stm32/stm32u5x/Kconfig
+++ b/soc/st/stm32/stm32u5x/Kconfig
@@ -16,6 +16,7 @@ config SOC_SERIES_STM32U5X
 	select CPU_CORTEX_M_HAS_DWT
 	select HAS_STM32CUBE
 	select HAS_PM
+	select HAS_SWO
 	select HAS_POWEROFF
 	select SOC_EARLY_INIT_HOOK
 


### PR DESCRIPTION
Add the SWO trace output to the stm32U5/L5/H7RS series

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/80479