### PR TITLE
Flash API: flash_mmap syscall allowing to obtain mapping of flash device in CPU address space

### DIFF
--- a/drivers/flash/flash_handlers.c
+++ b/drivers/flash/flash_handlers.c
@@ -45,6 +45,18 @@ static inline int z_vrfy_flash_get_size(const struct device *dev, uint64_t *size
 }
 #include <zephyr/syscalls/flash_get_size_mrsh.c>
 
+static inline int z_vrfy_flash_mmap(const struct device *dev, void **base,
+				    uint64_t *size, uint32_t flags)
+{
+	K_OOPS(K_SYSCALL_OBJ(dev, K_OBJ_DRIVER_FLASH));
+	K_OOPS(K_SYSCALL_MEMORY_READ(*base, sizeof(*base)));
+	K_OOPS(K_SYSCALL_MEMORY_WRITE(*base, sizeof(*base)));
+	K_OOPS(K_SYSCALL_MEMORY_READ(size, sizeof(*size)));
+	K_OOPS(K_SYSCALL_MEMORY_WRITE(size, sizeof(*size)));
+	return z_impl_flash_mmap((const struct device *)dev, base, size, flags);
+}
+#include <zephyr/syscalls/flash_mmap_mrsh.c>
+
 static inline size_t z_vrfy_flash_get_write_block_size(const struct device *dev)
 {
 	K_OOPS(K_SYSCALL_OBJ(dev, K_OBJ_DRIVER_FLASH));

--- a/drivers/flash/flash_simulator.c
+++ b/drivers/flash/flash_simulator.c
@@ -372,6 +372,22 @@ static int flash_sim_get_size(const struct device *dev, uint64_t *size)
 
 	return 0;
 }
+
+static int flash_sim_mmap(const struct device *dev, void **base, uint64_t *size,
+			  uint32_t flags)
+{
+	ARG_UNUSED(dev);
+
+	if (flags & ~(FLASH_MMAP_F_READ | FLASH_MMAP_F_WRITE)) {
+		return -EINVAL;
+	}
+
+	*base = (void *)&mock_flash[0];
+	*size = (uint64_t)FLASH_SIMULATOR_FLASH_SIZE;
+
+	return 0;
+}
+
 static const struct flash_parameters *
 flash_sim_get_parameters(const struct device *dev)
 {
@@ -384,6 +400,7 @@ static DEVICE_API(flash, flash_sim_api) = {
 	.read = flash_sim_read,
 	.write = flash_sim_write,
 	.erase = flash_sim_erase,
+	.mmap = flash_sim_mmap,
 	.get_parameters = flash_sim_get_parameters,
 	.get_size = flash_sim_get_size,
 #ifdef CONFIG_FLASH_PAGE_LAYOUT

--- a/drivers/flash/soc_flash_nrf.c
+++ b/drivers/flash/soc_flash_nrf.c
@@ -270,6 +270,20 @@ static int flash_nrf_get_size(const struct device *dev, uint64_t *size)
 	return 0;
 }
 
+static int flash_nrf_mmap(const struct device *dev, void **base, uint64_t *size,
+			  uint32_t flags)
+{
+	/* Currently supporting read operation only */
+	if (flags & ~(FLASH_MMAP_F_READ)) {
+		return -EINVAL;
+	}
+
+	*base = (void *)DT_REG_ADDR(SOC_NV_FLASH_NODE);
+	*size = nrfx_nvmc_flash_size_get();
+
+	return 0;
+}
+
 #if defined(CONFIG_FLASH_PAGE_LAYOUT)
 static struct flash_pages_layout dev_layout;
 
@@ -294,6 +308,7 @@ static DEVICE_API(flash, flash_nrf_api) = {
 	.read = flash_nrf_read,
 	.write = flash_nrf_write,
 	.erase = flash_nrf_erase,
+	.mmap = flash_nrf_mmap,
 	.get_parameters = flash_nrf_get_parameters,
 	.get_size = flash_nrf_get_size,
 #if defined(CONFIG_FLASH_PAGE_LAYOUT)

--- a/tests/drivers/flash_api/src/main.c
+++ b/tests/drivers/flash_api/src/main.c
@@ -20,12 +20,16 @@ static struct {
 	int ret;
 	/* Some size */
 	uint64_t size;
+	/* Device mmap test values */
+	void *mmap_base;
+	ssize_t mmap_size;
+	uint32_t mmap_flags;
 } simulated_values = {
 	.ret = 0,
 	.size = 0,
 };
 
-/*** Device definition atd == API Test Dev ***/
+/*** Device definition of API pseudo functions **/
 static int some_get_size(const struct device *dev, uint64_t *size)
 {
 	__ASSERT_NO_MSG(dev != NULL);
@@ -42,6 +46,36 @@ static int enotsup_get_size(const struct device *dev, uint64_t *size)
 	return -ENOTSUP;
 }
 
+static int some_mmap(const struct device *dev, void **base, uint64_t *size,
+		     uint32_t flags)
+{
+	__ASSERT_NO_MSG(dev != NULL);
+
+	if (flags != simulated_values.mmap_flags) {
+		return -EINVAL;
+	}
+
+	if (base == NULL || size == NULL) {
+		return -EINVAL;
+	}
+
+	*base = simulated_values.mmap_base;
+	*size = simulated_values.mmap_size;
+
+	return 0;
+}
+
+static int enotsup_mmap(const struct device *dev, void **base, uint64_t *size,
+			uint32_t flags)
+{
+	ARG_UNUSED(dev);
+	ARG_UNUSED(base);
+	ARG_UNUSED(size);
+	ARG_UNUSED(flags);
+
+	return 0;
+}
+
 /** Device objects **/
 /* The device state, just to make it "ready" device */
 static struct device_state some_dev_state = {
@@ -49,14 +83,16 @@ static struct device_state some_dev_state = {
 	.initialized = 1,
 };
 
-/* Device with get_size */
-static DEVICE_API(flash, size_fun_api) = {
+/* Device with implemented api calls */
+static DEVICE_API(flash, some_fun_api) = {
 	.get_size = some_get_size,
+	.mmap = some_mmap,
 };
-const static struct device size_fun_dev = {
-	"get_size",
+
+const static struct device some_fun_dev = {
+	"some_fun",
 	NULL,
-	&size_fun_api,
+	&some_fun_api,
 	&some_dev_state,
 };
 
@@ -72,6 +108,7 @@ const static struct device no_fun_dev = {
 /* Device with get_size implemented but returning -ENOTSUP */
 static DEVICE_API(flash, enotsup_fun_api) = {
 	.get_size = enotsup_get_size,
+	.mmap = enotsup_mmap,
 };
 static struct device enotsup_fun_dev = {
 	"enotsup",
@@ -85,14 +122,53 @@ ZTEST(flash_api, test_get_size)
 	uint64_t size = 0;
 
 	simulated_values.size = 45;
-	zassert_ok(flash_get_size(&size_fun_dev, &size), "Expected success");
+	zassert_ok(flash_get_size(&some_fun_dev, &size), "Expected success");
 	zassert_equal(size, simulated_values.size, "Size mismatch");
 	simulated_values.size = 46;
-	zassert_ok(flash_get_size(&size_fun_dev, &size), "Expected success");
+	zassert_ok(flash_get_size(&some_fun_dev, &size), "Expected success");
 	zassert_equal(size, simulated_values.size, "Size mismatch");
 	zassert_equal(flash_get_size(&no_fun_dev, &size), -ENOSYS);
 
 	zassert_equal(flash_get_size(&enotsup_fun_dev, &size), -ENOTSUP);
+}
+
+
+ZTEST(flash_api, test_flash_mmap)
+{
+	void *base = NULL;
+	uint64_t size = 0;
+
+	simulated_values.mmap_size = 40;
+	/* Just need some pointer */
+	simulated_values.mmap_base = (void *)&simulated_values;
+	/* 0 for error tests */
+	simulated_values.mmap_flags = 0;
+
+	zassert_equal(flash_mmap(&some_fun_dev, NULL, NULL, 0), -EINVAL);
+	zassert_equal(flash_mmap(&some_fun_dev, &base, NULL, 0), -EINVAL);
+	zassert_equal(flash_mmap(&some_fun_dev, NULL, &size, 0), -EINVAL);
+	zassert_equal(flash_mmap(&some_fun_dev, &base, &size, FLASH_MMAP_F_READ), -EINVAL);
+	zassert_equal(flash_mmap(&some_fun_dev, &base, &size, FLASH_MMAP_F_WRITE), -EINVAL);
+	zassert_equal(flash_mmap(&some_fun_dev, &base, &size,
+		      FLASH_MMAP_F_READ | FLASH_MMAP_F_WRITE), -EINVAL);
+
+	simulated_values.mmap_flags = FLASH_MMAP_F_READ;
+	zassert_equal(flash_mmap(&some_fun_dev, &base, &size, FLASH_MMAP_F_WRITE), -EINVAL);
+
+	simulated_values.mmap_flags = FLASH_MMAP_F_WRITE;
+	zassert_equal(flash_mmap(&some_fun_dev, &base, &size, FLASH_MMAP_F_READ), -EINVAL);
+
+	zassert_equal(flash_get_size(&enotsup_fun_dev, &size), -ENOTSUP);
+
+	/* After all failures the base and size are expected to be not modified */
+	zassert_equal(base, NULL);
+	zassert_equal(size, 0);
+
+	simulated_values.mmap_flags = FLASH_MMAP_F_READ;
+	zassert_ok(flash_mmap(&some_fun_dev, &base, &size, FLASH_MMAP_F_READ));
+	/* Expected values to be read by API and updated */
+	zassert_equal(base, simulated_values.mmap_base);
+	zassert_equal(size, simulated_values.mmap_size);
 }
 
 ZTEST_SUITE(flash_api, NULL, NULL, NULL, NULL, NULL);

--- a/tests/drivers/flash_api/testcase.yaml
+++ b/tests/drivers/flash_api/testcase.yaml
@@ -17,5 +17,9 @@ tests:
       - driver
       - flash
       - userspace
+    platform_allow:
+      - nrf52840dk/nrf52840
+    integration_platforms:
+      - nrf52840dk/nrf52840
     extra_configs:
       - CONFIG_USERSPACE=y


### PR DESCRIPTION
The PR consists of:
 - Flash API modification that provides implementation of `flash_mmap` API call and type definition for `flash_driver_api` callback.
 - soc_flash_nrf.c driver modification that provides support for the API call
 - Flash Simulator modification that provides support for the API call
 - tests/drivers/flash/common flash_mmap test scenario
 - test/drivers/flash_simulator flash_mmap test scenario

Fixes #80524