### PR TITLE
arm: linker: fix: incorrect __kernel_ram_start

### DIFF
--- a/include/zephyr/arch/arm/cortex_a_r/scripts/linker.ld
+++ b/include/zephyr/arch/arm/cortex_a_r/scripts/linker.ld
@@ -293,7 +293,6 @@ SECTIONS
     _app_smem_rom_start = LOADADDR(_APP_SMEM_SECTION_NAME);
 #endif  /* CONFIG_USERSPACE */
 
-    __kernel_ram_start = .;
     SECTION_DATA_PROLOGUE(_BSS_SECTION_NAME,(NOLOAD), BSS_ALIGN)
     {
         /*
@@ -302,6 +301,7 @@ SECTIONS
          */
         . = ALIGN(4);
         __bss_start = .;
+        __kernel_ram_start = .;
 
         *(.bss)
         *(".bss.*")

--- a/include/zephyr/arch/arm/cortex_m/scripts/linker.ld
+++ b/include/zephyr/arch/arm/cortex_m/scripts/linker.ld
@@ -289,7 +289,6 @@ SECTIONS
 	_app_smem_size = _app_smem_end - _app_smem_start;
 	_app_smem_rom_start = LOADADDR(_APP_SMEM_SECTION_NAME);
 
-	__kernel_ram_start = .;
     SECTION_DATA_PROLOGUE(_BSS_SECTION_NAME,(NOLOAD),)
 	{
         /*
@@ -298,6 +297,7 @@ SECTIONS
          */
         . = ALIGN(4);
 	__bss_start = .;
+	__kernel_ram_start = .;
 
 	*(.bss)
 	*(".bss.*")
@@ -358,7 +358,6 @@ SECTIONS
     __data_region_end = .;
 
 #ifndef CONFIG_USERSPACE
-   __kernel_ram_start = .;
    SECTION_DATA_PROLOGUE(_BSS_SECTION_NAME,(NOLOAD),)
 	{
         /*
@@ -367,6 +366,7 @@ SECTIONS
          */
         . = ALIGN(4);
 	__bss_start = .;
+	__kernel_ram_start = .;
 
 	*(.bss)
 	*(".bss.*")


### PR DESCRIPTION
### What is changed?
arch32 related changes in linker script made in commit ad719014901303a0b89200ea7c80672dd7d75805 are reverted.

### Why do we need this change?
The main intention of the previous commit was to fix the broken ci for aarch64.
There was no issue reported for aarch32 and changes were made for consistency.
However, it looks like keeping the `__kernel_ram_start` outside of the bss section works differently for different boards. For fvp_baser_aemv8r arch32, _bss_start points to _rom_region_end and __kernel_ram_start points to some region between _rom_region_start and _rom_region_end which leads to test failure.
While for other board like v2m_musca_b1, _bss_start and __kernel_ram_start are same.
The linker scripts might need a cleanup to avoid issues because of these inconsistncies however, till we understand this better, we need to revert this change.