### PR TITLE
tests: timer_behavior: fix double float mismatch

### DIFF
--- a/tests/kernel/timer/timer_behavior/src/jitter_drift.c
+++ b/tests/kernel/timer/timer_behavior/src/jitter_drift.c
@@ -333,7 +333,7 @@ static void do_test_using(void (*sample_collection_fn)(void), const char *mechan
 		     "Standard deviation (in microseconds) outside expected bound");
 
 	/* Validate the timer drift (accuracy over time) is within a configurable bound */
-	zassert_true(abs(time_diff_us) < CONFIG_TIMER_TEST_MAX_DRIFT,
+	zassert_true(fabs(time_diff_us) < CONFIG_TIMER_TEST_MAX_DRIFT,
 		     "Drift (in microseconds) outside expected bound");
 }
 

--- a/tests/kernel/timer/timer_behavior/src/jitter_drift.c
+++ b/tests/kernel/timer/timer_behavior/src/jitter_drift.c
@@ -209,8 +209,8 @@ static void do_test_using(void (*sample_collection_fn)(void), const char *mechan
 	variance_cyc = variance_cyc / (double)(CONFIG_TIMER_TEST_SAMPLES - periodic_rollovers);
 
 	/* A measure of timer precision, ideal is 0 */
-	double stddev_us = sqrtf(variance_us);
-	double stddev_cyc = sqrtf(variance_cyc);
+	double stddev_us = sqrt(variance_us);
+	double stddev_cyc = sqrt(variance_cyc);
 
 	/* Use double precision math here as integer overflows are possible in doing all the
 	 * conversions otherwise


### PR DESCRIPTION
* Use `sqrt()` instead of `sqrtf()` as arguments and resulting variables are all of doubles.
* Use `fabs()` instead of `abs()` as the argument is of double.

Note that the issue can be seen via LLVM/Clang: `west build -p -b native_sim tests/kernel/timer/timer_behavior/`

Fixes #80424 