### PR TITLE
twister: oot soc: set soc_root using Path

### DIFF
--- a/scripts/pylib/twister/twisterlib/environment.py
+++ b/scripts/pylib/twister/twisterlib/environment.py
@@ -980,13 +980,13 @@ class TwisterEnv:
         for module in modules:
             soc_root = module.meta.get("build", {}).get("settings", {}).get("soc_root")
             if soc_root:
-                self.soc_roots.append(os.path.join(module.project, soc_root))
+                self.soc_roots.append(Path(module.project) / Path(soc_root))
             dts_root = module.meta.get("build", {}).get("settings", {}).get("dts_root")
             if dts_root:
-                self.dts_roots.append(os.path.join(module.project, dts_root))
+                self.dts_roots.append(Path(module.project) / Path(dts_root))
             arch_root = module.meta.get("build", {}).get("settings", {}).get("arch_root")
             if arch_root:
-                self.arch_roots.append(os.path.join(module.project, arch_root))
+                self.arch_roots.append(Path(module.project) / Path(arch_root))
 
         self.hwm = None
 


### PR DESCRIPTION
Set soc_root using Path to avoid wrong generated path in the list of
soc_roots and other roots read from module.yml file

Fixes #80531

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
