### PR TITLE
net: dhcpv4: update DNS address assignment to be optional

### DIFF
--- a/subsys/net/lib/dhcpv4/Kconfig
+++ b/subsys/net/lib/dhcpv4/Kconfig
@@ -86,6 +86,14 @@ config NET_DHCPV4_OPTION_NTP_SERVER
 	  If this option is set, then the NTP server can be set from the
 	  DHCPv4 option.
 
+config NET_DHCPV4_OPTION_DNS_ADDRESS
+	bool "Use DNS server from DHCPv4 option and save it in the DNS resolver default context"
+	default y
+	depends on DNS_RESOLVER
+	help
+	  If this option is set, then the DNS server can be set from the
+	  DHCPv4 option.
+
 endif # NET_DHCPV4
 
 config NET_DHCPV4_SERVER

--- a/subsys/net/lib/dhcpv4/dhcpv4.c
+++ b/subsys/net/lib/dhcpv4/dhcpv4.c
@@ -1053,7 +1053,7 @@ static bool dhcpv4_parse_options(struct net_pkt *pkt,
 
 			break;
 		}
-#if defined(CONFIG_DNS_RESOLVER)
+#if defined(CONFIG_NET_DHCPV4_OPTION_DNS_ADDRESS)
 #define MAX_DNS_SERVERS CONFIG_DNS_RESOLVER_MAX_SERVERS
 		case DHCPV4_OPTIONS_DNS_SERVER: {
 			struct dns_resolve_context *ctx;


### PR DESCRIPTION
The DHCPv4 options always assigns the DNS address if the router provides one through the DHCP callback. There are times a developer may not always want to assign the server from the router, but only manually assign them. Adding a Kconfig option for assigning the DNS address and defaulting to true to not interfere with previously expected functionality.
