### PR TITLE
drivers: wifi: esp_at: Fix serial receive interrupt can't exit

### DIFF
--- a/drivers/wifi/esp_at/esp.c
+++ b/drivers/wifi/esp_at/esp.c
@@ -1606,6 +1606,14 @@ static int esp_init(const struct device *dev)
 		.hw_flow_control = DT_PROP(ESP_BUS, hw_flow_control),
 	};
 
+	/* The context must be registered before the serial port is initialised. */
+	data->mctx.driver_data = data;
+	ret = modem_context_register(&data->mctx);
+	if (ret < 0) {
+		LOG_ERR("Error registering modem context: %d", ret);
+		goto error;
+	}
+
 	ret = modem_iface_uart_init(&data->mctx.iface, &data->iface_data, &uart_config);
 	if (ret < 0) {
 		goto error;
@@ -1626,14 +1634,6 @@ static int esp_init(const struct device *dev)
 		goto error;
 	}
 #endif
-
-	data->mctx.driver_data = data;
-
-	ret = modem_context_register(&data->mctx);
-	if (ret < 0) {
-		LOG_ERR("Error registering modem context: %d", ret);
-		goto error;
-	}
 
 	/* start RX thread */
 	k_thread_create(&esp_rx_thread, esp_rx_stack,


### PR DESCRIPTION
If the serial port receives data after calling modem_iface_uart_init and before calling modem_context_register, the modem_iface_uart_isr function will not read the data in the serial port fifo register as the context has not been registered at this time, which will result in the program not being able to exit the interrupt. So I moved modem_context_register to before modem_iface_uart_init.

Fixes #80506