### PR TITLE
tests: Bluetooth: Tester: Fix use of uninitialized cig_id for CAP

### DIFF
--- a/tests/bluetooth/tester/src/audio/btp_bap_unicast.c
+++ b/tests/bluetooth/tester/src/audio/btp_bap_unicast.c
@@ -1140,6 +1140,7 @@ int btp_bap_unicast_group_create(uint8_t cig_id,
 	}
 
 	cigs[cig_id].in_use = true;
+	cigs[cig_id].cig_id = cig_id;
 	*out_unicast_group = &cigs[cig_id];
 
 	return 0;

--- a/tests/bluetooth/tester/src/audio/btp_bap_unicast.h
+++ b/tests/bluetooth/tester/src/audio/btp_bap_unicast.h
@@ -2,9 +2,12 @@
 
 /*
  * Copyright (c) 2023 Codecoup
+ * Copyright (c) 2024 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+#include <stdint.h>
 
 #include <zephyr/bluetooth/audio/cap.h>
 
@@ -20,6 +23,7 @@
 struct btp_bap_unicast_group {
 	struct bt_bap_qos_cfg qos[CONFIG_BT_BAP_UNICAST_CLIENT_GROUP_STREAM_COUNT];
 	struct bt_bap_unicast_group *cig;
+	uint8_t cig_id;
 	bool in_use;
 };
 

--- a/tests/bluetooth/tester/src/audio/btp_cap.c
+++ b/tests/bluetooth/tester/src/audio/btp_cap.c
@@ -104,13 +104,13 @@ static void unicast_start_complete_cb(int err, struct bt_conn *conn)
 
 	if (err != 0) {
 		LOG_DBG("Failed to unicast-start, err %d", err);
-		btp_send_cap_unicast_start_completed_ev(u_group->cig->index,
+		btp_send_cap_unicast_start_completed_ev(u_group->cig_id,
 							BTP_CAP_UNICAST_START_STATUS_FAILED);
 
 		return;
 	}
 
-	btp_send_cap_unicast_start_completed_ev(u_group->cig->index,
+	btp_send_cap_unicast_start_completed_ev(u_group->cig_id,
 						BTP_CAP_UNICAST_START_STATUS_SUCCESS);
 }
 
@@ -129,13 +129,13 @@ static void unicast_stop_complete_cb(int err, struct bt_conn *conn)
 
 	if (err != 0) {
 		LOG_DBG("Failed to unicast-stop, err %d", err);
-		btp_send_cap_unicast_stop_completed_ev(u_group->cig->index,
+		btp_send_cap_unicast_stop_completed_ev(u_group->cig_id,
 						       BTP_CAP_UNICAST_START_STATUS_FAILED);
 
 		return;
 	}
 
-	btp_send_cap_unicast_stop_completed_ev(u_group->cig->index,
+	btp_send_cap_unicast_stop_completed_ev(u_group->cig_id,
 					       BTP_CAP_UNICAST_START_STATUS_SUCCESS);
 }
 


### PR DESCRIPTION
The CAP tests used u_group->cig->index but the u_group->cig may have been deleted when the stream is released, which meant that u_group->cig == NULL when e.g. unicast_stop_complete_cb was called and that could cause failing tests as the index would just be a uninitialized value.

fixes https://github.com/zephyrproject-rtos/zephyr/issues/80551