### PR TITLE
Fix ELF generation for qemu_x86_tiny

### DIFF
--- a/include/zephyr/linker/ram-end.ld
+++ b/include/zephyr/linker/ram-end.ld
@@ -12,4 +12,4 @@
 	_image_ram_size = _image_ram_end - _image_ram_start;
 	_end = .; /* end of image */
 	z_mapped_end = .;
-    } GROUP_NOLOAD_LINK_IN(RAMABLE_REGION, RAMABLE_REGION)
+    } GROUP_NOLOAD_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)


### PR DESCRIPTION
When building `hello_world` for `qemu_x86_tiny`:

```
west build -p -b qemu_x86_tiny samples/hello_world
```

`.last_ram_section` gets wrong `LMA` - it's the same as virtual address, but it should be physical.
```
objdump -h build/zephyr/zephyr.elf
[...]
Sections:                                                                                                                                                       
Idx Name          Size      VMA       LMA       File off  Algn
[...]
 21 .last_ram_section 00000ff0  40115010  40115010  0000f0e0  2**0
                  ALLOC
```

Following change in `ram-end.ld`:

```
diff --git a/include/zephyr/linker/ram-end.ld b/include/zephyr/linker/ram-end.ld
index ad4da2b46f3..71d4571e0fb 100644
--- a/include/zephyr/linker/ram-end.ld
+++ b/include/zephyr/linker/ram-end.ld
@@ -12,4 +12,4 @@
 	_image_ram_size = _image_ram_end - _image_ram_start;
 	_end = .; /* end of image */
 	z_mapped_end = .;
-    } GROUP_NOLOAD_LINK_IN(RAMABLE_REGION, RAMABLE_REGION)
+    } GROUP_NOLOAD_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
```

Fixes the issue:

```
objdump -h build/zephyr/zephyr.elf
[...]
Sections:                                                                                                                                                       
Idx Name          Size      VMA       LMA       File off  Algn
[...]
 21 .last_ram_section 00000ff0  40115010  00515010  0000f0c0  2**0
                  ALLOC
```