### PR TITLE
submanifests: optional: Bump nanopb to 0.4.9

### DIFF
--- a/doc/releases/release-notes-4.0.rst
+++ b/doc/releases/release-notes-4.0.rst
@@ -556,6 +556,12 @@ OSDP
 Trusted Firmware-M
 ******************
 
+Nanopb
+******
+
+* Updated the nanopb module to version 0.4.9.
+  Full release notes at https://github.com/nanopb/nanopb/blob/0.4.9/CHANGELOG.txt
+
 LVGL
 ****
 

--- a/submanifests/optional.yaml
+++ b/submanifests/optional.yaml
@@ -22,7 +22,7 @@ manifest:
       groups:
         - optional
     - name: nanopb
-      revision: 4474bd35bd39de067f0532a1b19ce3aed9ed9807
+      revision: 98bf4db69897b53434f3d0ba72e0a3ab1a902824
       path: modules/lib/nanopb
       remote: upstream
       groups:


### PR DESCRIPTION
Sync upstream and get the latest tagged version 0.4.9.