### PR TITLE
net: mqtt: Fix missing close function

### DIFF
--- a/subsys/net/lib/mqtt/mqtt_transport_websocket.c
+++ b/subsys/net/lib/mqtt/mqtt_transport_websocket.c
@@ -77,7 +77,7 @@ int mqtt_client_websocket_connect(struct mqtt_client *client)
 		NET_ERR("Websocket connect failed (%d)",
 			 client->transport.websocket.sock);
 
-		(void)close(transport_sock);
+		(void)zsock_close(transport_sock);
 		return client->transport.websocket.sock;
 	}
 


### PR DESCRIPTION
If POSIX_API is not configured the close function is not available.
Use zsock_close instead.