### PR TITLE
mgmt: mcumgr: Remove deprecated function smp_add_cmd_ret

### DIFF
--- a/include/zephyr/mgmt/mcumgr/smp/smp.h
+++ b/include/zephyr/mgmt/mcumgr/smp/smp.h
@@ -121,12 +121,6 @@ int smp_process_request_packet(struct smp_streamer *streamer, void *req);
  */
 bool smp_add_cmd_err(zcbor_state_t *zse, uint16_t group, uint16_t ret);
 
-/** @deprecated Deprecated after Zephyr 3.4, use smp_add_cmd_err() instead */
-__deprecated inline bool smp_add_cmd_ret(zcbor_state_t *zse, uint16_t group, uint16_t ret)
-{
-	return smp_add_cmd_err(zse, group, ret);
-}
-
 #if defined(CONFIG_MCUMGR_SMP_SUPPORT_ORIGINAL_PROTOCOL)
 /** @typedef	smp_translate_error_fn
  * @brief	Translates a SMP version 2 error response to a legacy SMP version 1 error code.


### PR DESCRIPTION
    Removes a function that was deprecated in Zephyr 3.4

Requested in https://github.com/zephyrproject-rtos/zephyr/issues/76943