### PR TITLE
PM policy: Separate default policy and events

### DIFF
--- a/subsys/pm/policy/policy_default.c
+++ b/subsys/pm/policy/policy_default.c
@@ -9,7 +9,6 @@
 #include <zephyr/sys_clock.h>
 #include <zephyr/pm/device.h>
 
-extern struct pm_policy_event *next_event;
 extern int32_t max_latency_cyc;
 
 const struct pm_state_info *pm_policy_next_state(uint8_t cpu, int32_t ticks)
@@ -29,27 +28,6 @@ const struct pm_state_info *pm_policy_next_state(uint8_t cpu, int32_t ticks)
 	}
 
 	num_cpu_states = pm_state_cpu_get_all(cpu, &cpu_states);
-
-	if ((next_event) && (next_event->value_cyc >= 0)) {
-		uint32_t cyc_curr = k_cycle_get_32();
-		int64_t cyc_evt = next_event->value_cyc - cyc_curr;
-
-		/* event happening after cycle counter max value, pad */
-		if (next_event->value_cyc <= cyc_curr) {
-			cyc_evt += UINT32_MAX;
-		}
-
-		if (cyc_evt > 0) {
-			/* if there's no system wakeup event always wins,
-			 * otherwise, who comes earlier wins
-			 */
-			if (cyc < 0) {
-				cyc = cyc_evt;
-			} else {
-				cyc = MIN(cyc, cyc_evt);
-			}
-		}
-	}
 
 	for (int16_t i = (int16_t)num_cpu_states - 1; i >= 0; i--) {
 		const struct pm_state_info *state = &cpu_states[i];

--- a/subsys/pm/policy/policy_events.c
+++ b/subsys/pm/policy/policy_events.c
@@ -68,14 +68,13 @@ int32_t pm_policy_next_event_ticks(void)
 	return -1;
 }
 
-void pm_policy_event_register(struct pm_policy_event *evt, uint32_t time_us)
+void pm_policy_event_register(struct pm_policy_event *evt, uint32_t cycle)
 {
 	k_spinlock_key_t key = k_spin_lock(&events_lock);
-	uint32_t cyc = k_cycle_get_32();
 
-	evt->value_cyc = cyc + k_us_to_cyc_ceil32(time_us);
+	evt->value_cyc = cycle;
 	sys_slist_append(&events_list, &evt->node);
-	update_next_event(cyc);
+	update_next_event(k_cycle_get_32());
 
 	k_spin_unlock(&events_lock, key);
 }


### PR DESCRIPTION
The default policy currently directly references the private variable `next_event` `from policy_events.c`:

https://github.com/zephyrproject-rtos/zephyr/blob/e1389fa2cff66c4f0c1ac5d0b1b932ef0e3faf06/subsys/pm/policy/policy_default.c#L12

to then convert the cycle of said event (if exists) to a cycle in the future:

https://github.com/zephyrproject-rtos/zephyr/blob/e1389fa2cff66c4f0c1ac5d0b1b932ef0e3faf06/subsys/pm/policy/policy_default.c#L33-L52

something `policy_events.c` already implements quite similarly and exposes through `pm_policy_next_event_ticks()`:

https://github.com/zephyrproject-rtos/zephyr/blob/e1389fa2cff66c4f0c1ac5d0b1b932ef0e3faf06/subsys/pm/policy/policy_events.c#L56-L69

Additionally, the implementation of `pm_policy_next_state()` in `policy_default.c` already gets the nearest kernel tick, wherein the next event has already been accounted for, see implementation of `pm_system_suspend()`:

https://github.com/zephyrproject-rtos/zephyr/blob/e1389fa2cff66c4f0c1ac5d0b1b932ef0e3faf06/subsys/pm/pm.c#L155-L156

https://github.com/zephyrproject-rtos/zephyr/blob/e1389fa2cff66c4f0c1ac5d0b1b932ef0e3faf06/subsys/pm/pm.c#L165

This commit removes the redundant and layer violating computation of the tick of the next event from `policy_default.c` and updates the test `test_pm_policy_events` to not use default policy to determine if `pm_policy_next_event_ticks()` is correct.

This PR updates the test suite to actually be able to detect the incorrect argument handling of `pm_policy_event_register()` fixed with PR #80556 so this PR includes said fix, to be dropped from here when fix is merged :)