### PR TITLE
arm: fix boot looping when building with GCC 14

### DIFF
--- a/arch/arm/core/cortex_m/thread.c
+++ b/arch/arm/core/cortex_m/thread.c
@@ -588,7 +588,7 @@ void arch_switch_to_main_thread(struct k_thread *main_thread, char *stack_ptr,
 	"bx    r4\n"		/* We don’t intend to return, so there is no need to link. */
 	:
 	: "r" (_main), "r" (stack_ptr)
-	: "r0", "r1", "r2", "r3", "r4", "ip", "lr");
+	: "r0", "r1", "r2", "r3", "r4", "ip", "lr", "memory");
 
 	CODE_UNREACHABLE;
 }

--- a/arch/arm/core/cortex_m/thread.c
+++ b/arch/arm/core/cortex_m/thread.c
@@ -586,8 +586,8 @@ void arch_switch_to_main_thread(struct k_thread *main_thread, char *stack_ptr,
 	"mov   r3, #0\n"
 	"ldr   r4, =z_thread_entry\n"
 	"bx    r4\n"		/* We don’t intend to return, so there is no need to link. */
-	: "+r" (_main)
-	: "r" (stack_ptr)
+	:
+	: "r" (_main), "r" (stack_ptr)
 	: "r0", "r1", "r2", "r3", "r4", "ip", "lr");
 
 	CODE_UNREACHABLE;


### PR DESCRIPTION
Fix a boot loop when building with GCC on ARM platforms due to some extra optimizations introduced in GCC 14 combined with some missing specs on an __asm__ block.

Fixes #80542

Tested on an NPCX9, GCC 14.2.0 of some flavor