### PR TITLE
PM Policy Event: Update to use uptime ticks and be "sticky"

### DIFF
--- a/subsys/pm/policy/policy_events.c
+++ b/subsys/pm/policy/policy_events.c
@@ -20,81 +20,66 @@ static sys_slist_t events_list;
 /** Pointer to Next Event. */
 struct pm_policy_event *next_event;
 
-/** @brief Update next event. */
-static void update_next_event(uint32_t cyc)
+static void update_next_event(void)
 {
-	int64_t new_next_event_cyc = -1;
 	struct pm_policy_event *evt;
 
-	/* unset the next event pointer */
 	next_event = NULL;
 
 	SYS_SLIST_FOR_EACH_CONTAINER(&events_list, evt, node) {
-		uint64_t cyc_evt = evt->value_cyc;
-
-		/*
-		 * cyc value is a 32-bit rolling counter:
-		 *
-		 * |---------------->-----------------------|
-		 * 0               cyc                  UINT32_MAX
-		 *
-		 * Values from [0, cyc) are events happening later than
-		 * [cyc, UINT32_MAX], so pad [0, cyc) with UINT32_MAX + 1 to do
-		 * the comparison.
-		 */
-		if (cyc_evt < cyc) {
-			cyc_evt += (uint64_t)UINT32_MAX + 1U;
-		}
-
-		if ((new_next_event_cyc < 0) || (cyc_evt < new_next_event_cyc)) {
-			new_next_event_cyc = cyc_evt;
+		if (next_event == NULL) {
 			next_event = evt;
+			continue;
+		}
+
+		if (next_event->uptime_ticks <= evt->uptime_ticks) {
+			continue;
+		}
+
+		next_event = evt;
+	}
+}
+
+int64_t pm_policy_next_event_ticks(void)
+{
+	int64_t ticks = -1;
+
+	K_SPINLOCK(&events_lock) {
+		if (next_event == NULL) {
+			K_SPINLOCK_BREAK;
+		}
+
+		ticks = next_event->uptime_ticks - k_uptime_ticks();
+
+		if (ticks < 0) {
+			ticks = 0;
 		}
 	}
+
+	return ticks;
 }
 
-int32_t pm_policy_next_event_ticks(void)
+void pm_policy_event_register(struct pm_policy_event *evt, int64_t uptime_ticks)
 {
-	int32_t cyc_evt = -1;
-
-	if ((next_event) && (next_event->value_cyc > 0)) {
-		cyc_evt = next_event->value_cyc - k_cycle_get_32();
-		cyc_evt = MAX(0, cyc_evt);
-		BUILD_ASSERT(CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC >= CONFIG_SYS_CLOCK_TICKS_PER_SEC,
-			     "HW Cycles per sec should be greater that ticks per sec");
-		return k_cyc_to_ticks_floor32(cyc_evt);
+	K_SPINLOCK(&events_lock) {
+		evt->uptime_ticks = uptime_ticks;
+		sys_slist_append(&events_list, &evt->node);
+		update_next_event();
 	}
-
-	return -1;
 }
 
-void pm_policy_event_register(struct pm_policy_event *evt, uint32_t cycle)
+void pm_policy_event_update(struct pm_policy_event *evt, int64_t uptime_ticks)
 {
-	k_spinlock_key_t key = k_spin_lock(&events_lock);
-
-	evt->value_cyc = cycle;
-	sys_slist_append(&events_list, &evt->node);
-	update_next_event(k_cycle_get_32());
-
-	k_spin_unlock(&events_lock, key);
-}
-
-void pm_policy_event_update(struct pm_policy_event *evt, uint32_t cycle)
-{
-	k_spinlock_key_t key = k_spin_lock(&events_lock);
-
-	evt->value_cyc = cycle;
-	update_next_event(k_cycle_get_32());
-
-	k_spin_unlock(&events_lock, key);
+	K_SPINLOCK(&events_lock) {
+		evt->uptime_ticks = uptime_ticks;
+		update_next_event();
+	}
 }
 
 void pm_policy_event_unregister(struct pm_policy_event *evt)
 {
-	k_spinlock_key_t key = k_spin_lock(&events_lock);
-
-	(void)sys_slist_find_and_remove(&events_list, &evt->node);
-	update_next_event(k_cycle_get_32());
-
-	k_spin_unlock(&events_lock, key);
+	K_SPINLOCK(&events_lock) {
+		(void)sys_slist_find_and_remove(&events_list, &evt->node);
+		update_next_event();
+	}
 }

--- a/tests/subsys/pm/policy_api/src/main.c
+++ b/tests/subsys/pm/policy_api/src/main.c
@@ -308,29 +308,29 @@ ZTEST(policy_api, test_pm_policy_events)
 {
 	struct pm_policy_event evt1;
 	struct pm_policy_event evt2;
-	uint32_t now_cycle;
-	uint32_t evt1_1_cycle;
-	uint32_t evt1_2_cycle;
-	uint32_t evt2_cycle;
+	int64_t now_uptime_ticks;
+	int64_t evt1_1_uptime_ticks;
+	int64_t evt1_2_uptime_ticks;
+	int64_t evt2_uptime_ticks;
 
-	now_cycle = k_cycle_get_32();
-	evt1_1_cycle = now_cycle + k_ticks_to_cyc_floor32(100);
-	evt1_2_cycle = now_cycle + k_ticks_to_cyc_floor32(200);
-	evt2_cycle = now_cycle + k_ticks_to_cyc_floor32(2000);
+	now_uptime_ticks = k_uptime_ticks();
+	evt1_1_uptime_ticks = now_uptime_ticks + 100;
+	evt1_2_uptime_ticks = now_uptime_ticks + 200;
+	evt2_uptime_ticks = now_uptime_ticks + 2000;
 
 	zassert_equal(pm_policy_next_event_ticks(), -1);
-	pm_policy_event_register(&evt1, evt1_1_cycle);
-	pm_policy_event_register(&evt2, evt2_cycle);
+	pm_policy_event_register(&evt1, evt1_1_uptime_ticks);
+	pm_policy_event_register(&evt2, evt2_uptime_ticks);
 	zassert_within(pm_policy_next_event_ticks(), 100, 50);
 	pm_policy_event_unregister(&evt1);
 	zassert_within(pm_policy_next_event_ticks(), 2000, 50);
 	pm_policy_event_unregister(&evt2);
 	zassert_equal(pm_policy_next_event_ticks(), -1);
-	pm_policy_event_register(&evt2, evt2_cycle);
+	pm_policy_event_register(&evt2, evt2_uptime_ticks);
 	zassert_within(pm_policy_next_event_ticks(), 2000, 50);
-	pm_policy_event_register(&evt1, evt1_1_cycle);
+	pm_policy_event_register(&evt1, evt1_1_uptime_ticks);
 	zassert_within(pm_policy_next_event_ticks(), 100, 50);
-	pm_policy_event_update(&evt1, evt1_2_cycle);
+	pm_policy_event_update(&evt1, evt1_2_uptime_ticks);
 	zassert_within(pm_policy_next_event_ticks(), 200, 50);
 	pm_policy_event_unregister(&evt1);
 	pm_policy_event_unregister(&evt2);


### PR DESCRIPTION
Registering a pm policy event will now represent a single event in absolute time, which will remain active, preventing the system from suspending, until the event has been handled. To indicate an event has been handled, it must be updated to a time in the future, or unregistered.

To greatly simplify the events and the "sticky" logic, the time primitive used is updated to the monotonic uptime in ticks. This ensures an event can be determined to be in the past, since unlike the HW cycle, uptime can't wrap. Additionally, the kernel works in ticks, which aligns the resolution with the requirements of the kernel, and removes the need for conversions between pm and the kernel, see `pm_policy_next_event_ticks()` before this PR.

fixes: #80386