### PR TITLE
boards: shields: rk055hdmipi4ma0: increase DSI clock for RT1160

### DIFF
--- a/boards/shields/rk055hdmipi4ma0/boards/mimxrt1160_evk_mimxrt1166_cm7.overlay
+++ b/boards/shields/rk055hdmipi4ma0/boards/mimxrt1160_evk_mimxrt1166_cm7.overlay
@@ -1,0 +1,10 @@
+/*
+ * Copyright 2024, NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&zephyr_mipi_dsi {
+	/* Raise the DSI clock frequency */
+	phy-clock = <792000000>;
+};


### PR DESCRIPTION
Increase target DSI clock frequency for the RT1160, as the DSI peripheral requires a faster clock to account for the DSI packets that must be sent outside of video mode frames.

This fix was previously applied for the RT1170, but is also needed for the RT1160 SOC as they use the same DSI IP.

Fixes #78299