### PR TITLE
cmake: lld: Remove duplicate -fuse-ld=lld

### DIFF
--- a/cmake/linker/lld/linker_flags.cmake
+++ b/cmake/linker/lld/linker_flags.cmake
@@ -11,11 +11,6 @@ if(NOT CONFIG_MINIMAL_LIBCPP AND NOT CONFIG_NATIVE_LIBRARY AND NOT CONFIG_EXTERN
   set_property(TARGET linker PROPERTY cpp_base ${LINKERFLAGPREFIX},-z,norelro)
 endif()
 
-# Force LLVM to use built-in lld linker
-if(NOT CONFIG_LLVM_USE_LD)
-  check_set_linker_property(TARGET linker APPEND PROPERTY baremetal -fuse-ld=lld)
-endif()
-
 set_property(TARGET linker PROPERTY no_position_independent "${LINKERFLAGPREFIX},--no-pie")
 
 set_property(TARGET linker PROPERTY lto_arguments)


### PR DESCRIPTION
-fuse-ld=lld is currently specified twice through the baremetal property (in cmake/linker/lld/linker_flags.cmake) and TOOLCHAIN_LD_FLAGS (in cmake/linker/lld/target.cmake). This doesn't really harm anything as it isn't duplicated on the link line (and specifying it multiple times wouldn't hurt even if it was), but it also doesn't really help anything.

-fuse-ld isn't baremetal-specific and setting it via TOOLCHAIN_LD_FLAGS will cover this case anyway, so remove this duplicate.