### PR TITLE
drivers: display: mcux_elcdif: rework frame completion logic

### DIFF
--- a/drivers/display/Kconfig.mcux_elcdif
+++ b/drivers/display/Kconfig.mcux_elcdif
@@ -54,18 +54,6 @@ config MCUX_ELCDIF_PXP
 	  display_write is called with a framebuffer equal in size to the
 	  display.
 
-config MCUX_ELCDIF_LP
-	bool "ELCDIF low power"
-	help
-	  This option, when enabled, will enable CUR_FRAME_DONE_IRQ at the display
-	  write function and disable it at the interruption handler for each new frame.
-	  Disabling the interrupt when no new frame needs to be sent gives the CPU the
-	  possibility to enter low-power mode, thus saving energy.
-	  This option, when disabled, CUR_FRAME_DONE_IRQ will be enabled only
-	  once at initialization. This option should be disabled when the application's
-	  frame rate is close to the display's refresh rate to avoid introducing
-	  additional latency caused by frequently enabling and disabling CUR_FRAME_DONE_IRQ.
-
 if MCUX_ELCDIF_PXP
 
 choice MCUX_ELCDIF_PXP_ROTATE_DIRECTION

--- a/drivers/display/display_mcux_elcdif.c
+++ b/drivers/display/display_mcux_elcdif.c
@@ -214,10 +214,8 @@ static int mcux_elcdif_write(const struct device *dev, const uint16_t x, const u
 	/* Update index of active framebuffer */
 	dev_data->next_idx = (dev_data->next_idx + 1) % CONFIG_MCUX_ELCDIF_FB_NUM;
 #endif
-
-	if (IS_ENABLED(CONFIG_MCUX_ELCDIF_LP)) {
-		ELCDIF_EnableInterrupts(config->base, kELCDIF_CurFrameDoneInterruptEnable);
-	}
+	/* Enable frame buffer completion interrupt */
+	ELCDIF_EnableInterrupts(config->base, kELCDIF_CurFrameDoneInterruptEnable);
 	/* Wait for frame send to complete */
 	k_sem_take(&dev_data->sem, K_FOREVER);
 	return ret;
@@ -310,11 +308,10 @@ static void mcux_elcdif_isr(const struct device *dev)
 	status = ELCDIF_GetInterruptStatus(config->base);
 	ELCDIF_ClearInterruptStatus(config->base, status);
 	if (config->base->CUR_BUF == ((uint32_t)dev_data->active_fb)) {
-		if (IS_ENABLED(CONFIG_MCUX_ELCDIF_LP)) {
-			/* Disable frame completion interrupt if Low power mode is activated*/
-			ELCDIF_DisableInterrupts(config->base, kELCDIF_CurFrameDoneInterruptEnable);
-		}
-		/* Post to sem to notify that frame display is complete.*/
+		/* Disable frame completion interrupt, post to
+		 * sem to notify that frame send is complete.
+		 */
+		ELCDIF_DisableInterrupts(config->base, kELCDIF_CurFrameDoneInterruptEnable);
 		k_sem_give(&dev_data->sem);
 	}
 }
@@ -352,9 +349,6 @@ static int mcux_elcdif_init(const struct device *dev)
 	dev_data->active_fb = dev_data->fb[0];
 
 	ELCDIF_RgbModeInit(config->base, &dev_data->rgb_mode);
-	if (!IS_ENABLED(CONFIG_MCUX_ELCDIF_LP)) {
-		ELCDIF_EnableInterrupts(config->base, kELCDIF_CurFrameDoneInterruptEnable);
-	}
 	ELCDIF_RgbModeStart(config->base);
 
 	return 0;


### PR DESCRIPTION
 Revert "drivers: display: elcdif: Modify interrupt enablement"

This reverts commit 206897658ab88444f32d59e2dbcec65e38d66779.

We must keep the frame completion interrupt disabled until we send a new
frame to the eLCDIF, as the frame completion interrupt fires at each
vertical blank interval. If we keep it enabled, then the semaphore we
use to indicate the frame has been loaded by the eLCDIF will be posted
to when we do not have a frame queued, and calls to `display_write` will
return before the eLCDIF has actually loaded the new framebuffer.

Fixes #80590