### PR TITLE
devicetree: Remove deprecated enum macro

### DIFF
--- a/doc/releases/release-notes-4.0.rst
+++ b/doc/releases/release-notes-4.0.rst
@@ -47,6 +47,8 @@ Removed APIs in this release
 * Macro ``K_THREAD_STACK_MEMBER``, deprecated since v3.5.0, has been removed.
   Use :c:macro:`K_KERNEL_STACK_MEMBER` instead.
 * ``CBPRINTF_PACKAGE_COPY_*`` macros, deprecated since Zephyr 3.5.0, have been removed.
+* ``_ENUM_TOKEN`` and ``_ENUM_UPPER_TOKEN`` macros, deprecated since Zephyr 2.7.0,
+  are no longer generated.
 
 Deprecated in this release
 ==========================

--- a/include/zephyr/devicetree.h
+++ b/include/zephyr/devicetree.h
@@ -47,10 +47,6 @@
  *
  * _ENUM_IDX: property's value as an index into bindings enum
  * _ENUM_VAL_<val>_EXISTS property's value as a token exists
- * _ENUM_TOKEN: property's value as a token into bindings enum (string
- *              enum values are identifiers) [deprecated, use _STRING_TOKEN]
- * _ENUM_UPPER_TOKEN: like _ENUM_TOKEN, but uppercased [deprecated, use
- *		      _STRING_UPPER_TOKEN]
  * _EXISTS: property is defined
  * _FOREACH_PROP_ELEM: helper for "iterating" over values in the property
  * _FOREACH_PROP_ELEM_VARGS: foreach functions with variable number of arguments

--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -672,14 +672,6 @@ def enum_macros(prop: edtlib.Property, macro: str):
         ret[macro + f"_IDX_{i}_EXISTS"] = 1
         # DT_N_<node-id>_P_<prop-id>_IDX_<i>_ENUM_VAL_<val>_EXISTS 1
         ret[macro + f"_IDX_{i}_ENUM_VAL_{subval}_EXISTS"] = 1
-        if not spec.enum_tokenizable:
-            continue
-
-        # DT_N_<node-id>_P_<prop-id>_IDX_<i>_ENUM_TOKEN
-        ret[macro + f"_IDX_{i}_ENUM_TOKEN"] = subval
-        if spec.enum_upper_tokenizable:
-            # DT_N_<node-id>_P_<prop-id>_IDX_<i>_ENUM_UPPER_TOKEN
-            ret[macro + f"_IDX_{i}_ENUM_UPPER_TOKEN"] = subval.upper()
 
     return ret
 


### PR DESCRIPTION
Remove deprecated _ENUM_TOKEN and _ENUM_UPPER_TOKEN. They're deprecated for over three years by now.