### PR TITLE
tests/kernel/device/boards: Fix compilation error

### DIFF
--- a/tests/kernel/device/boards/hifive_unmatched_fu740_s7.overlay
+++ b/tests/kernel/device/boards/hifive_unmatched_fu740_s7.overlay
@@ -68,6 +68,7 @@
 		status = "okay";
 		#power-domain-cells = <0>;
 		power-domains = <&fakedomain_2>;
+		#power-domain-cells = <0>;
 	};
 
 	fakedomain_1: fakedomain_1 {


### PR DESCRIPTION
The #power-domain-cells in hifive_unmatched.overlay does not exist, 
add #power-domain-cells = <0> to it

Fixes #80503