### PR TITLE
drivers: intc: multi-level: enforce at least 1 bit in every level

### DIFF
--- a/drivers/interrupt_controller/Kconfig.multilevel
+++ b/drivers/interrupt_controller/Kconfig.multilevel
@@ -21,7 +21,7 @@ config MULTI_LEVEL_INTERRUPTS
 if MULTI_LEVEL_INTERRUPTS
 config 1ST_LEVEL_INTERRUPT_BITS
 	int "Total number of first level interrupt bits"
-	range 1 32
+	range 1 30
 	default 8
 	help
 	  The number of bits to use of the 32 bit interrupt mask for first
@@ -62,7 +62,7 @@ config NUM_2ND_LEVEL_AGGREGATORS
 
 config 2ND_LEVEL_INTERRUPT_BITS
 	int "Total number of second level interrupt bits"
-	range 0 31
+	range 1 30
 	default 8
 	help
 	  The number of bits to use of the 32 bit interrupt mask for second
@@ -116,7 +116,7 @@ config 3RD_LVL_ISR_TBL_OFFSET
 
 config 3RD_LEVEL_INTERRUPT_BITS
 	int "Total number of third level interrupt bits"
-	range 0 30
+	range 1 30
 	default 8
 	help
 	  The number of bits to use of the 32 bit interrupt mask for third


### PR DESCRIPTION
Since #78845, we must have at least one bit in every level, otherwise it wouldn't compile. Enforce this constraint at the Kconfig level.