### PR TITLE
drivers: serial: fix potential overflow in fifo_fill and fifo_read

### DIFF
--- a/drivers/serial/leuart_gecko.c
+++ b/drivers/serial/leuart_gecko.c
@@ -101,7 +101,7 @@ static int leuart_gecko_fifo_fill(const struct device *dev,
 				  int len)
 {
 	LEUART_TypeDef *base = DEV_BASE(dev);
-	uint8_t num_tx = 0U;
+	int num_tx = 0U;
 
 	while ((len - num_tx > 0) &&
 	       (base->STATUS & LEUART_STATUS_TXBL)) {
@@ -116,7 +116,7 @@ static int leuart_gecko_fifo_read(const struct device *dev, uint8_t *rx_data,
 				  const int len)
 {
 	LEUART_TypeDef *base = DEV_BASE(dev);
-	uint8_t num_rx = 0U;
+	int num_rx = 0U;
 
 	while ((len - num_rx > 0) &&
 	       (base->STATUS & LEUART_STATUS_RXDATAV)) {

--- a/drivers/serial/uart_gecko.c
+++ b/drivers/serial/uart_gecko.c
@@ -222,7 +222,7 @@ static int uart_gecko_fifo_fill(const struct device *dev, const uint8_t *tx_data
 			       int len)
 {
 	const struct uart_gecko_config *config = dev->config;
-	uint8_t num_tx = 0U;
+	int num_tx = 0U;
 
 	while ((len - num_tx > 0) &&
 	       (config->base->STATUS & USART_STATUS_TXBL)) {
@@ -237,7 +237,7 @@ static int uart_gecko_fifo_read(const struct device *dev, uint8_t *rx_data,
 			       const int len)
 {
 	const struct uart_gecko_config *config = dev->config;
-	uint8_t num_rx = 0U;
+	int num_rx = 0U;
 
 	while ((len - num_rx > 0) &&
 	       (config->base->STATUS & USART_STATUS_RXDATAV)) {

--- a/drivers/serial/uart_mcux.c
+++ b/drivers/serial/uart_mcux.c
@@ -179,7 +179,7 @@ static int uart_mcux_fifo_fill(const struct device *dev,
 			       int len)
 {
 	const struct uart_mcux_config *config = dev->config;
-	uint8_t num_tx = 0U;
+	int num_tx = 0U;
 
 	while ((len - num_tx > 0) &&
 	       (UART_GetStatusFlags(config->base) & kUART_TxDataRegEmptyFlag)) {
@@ -194,7 +194,7 @@ static int uart_mcux_fifo_read(const struct device *dev, uint8_t *rx_data,
 			       const int len)
 {
 	const struct uart_mcux_config *config = dev->config;
-	uint8_t num_rx = 0U;
+	int num_rx = 0U;
 
 	while ((len - num_rx > 0) &&
 	       (UART_GetStatusFlags(config->base) & kUART_RxDataRegFullFlag)) {

--- a/drivers/serial/uart_mcux_flexcomm.c
+++ b/drivers/serial/uart_mcux_flexcomm.c
@@ -146,7 +146,7 @@ static int mcux_flexcomm_fifo_fill(const struct device *dev,
 				   int len)
 {
 	const struct mcux_flexcomm_config *config = dev->config;
-	uint8_t num_tx = 0U;
+	int num_tx = 0U;
 
 	while ((len - num_tx > 0) &&
 	       (USART_GetStatusFlags(config->base)
@@ -162,7 +162,7 @@ static int mcux_flexcomm_fifo_read(const struct device *dev, uint8_t *rx_data,
 				   const int len)
 {
 	const struct mcux_flexcomm_config *config = dev->config;
-	uint8_t num_rx = 0U;
+	int num_rx = 0U;
 
 	while ((len - num_rx > 0) &&
 	       (USART_GetStatusFlags(config->base)

--- a/drivers/serial/uart_mcux_iuart.c
+++ b/drivers/serial/uart_mcux_iuart.c
@@ -86,7 +86,7 @@ static int mcux_iuart_fifo_fill(const struct device *dev,
 				int len)
 {
 	const struct mcux_iuart_config *config = dev->config;
-	uint8_t num_tx = 0U;
+	int num_tx = 0U;
 
 	while ((len - num_tx > 0) &&
 	       (UART_GetStatusFlag(config->base, kUART_TxEmptyFlag))) {
@@ -101,7 +101,7 @@ static int mcux_iuart_fifo_read(const struct device *dev, uint8_t *rx_data,
 				const int len)
 {
 	const struct mcux_iuart_config *config = dev->config;
-	uint8_t num_rx = 0U;
+	int num_rx = 0U;
 
 	while ((len - num_rx > 0) &&
 	       (UART_GetStatusFlag(config->base, kUART_RxDataReadyFlag))) {

--- a/drivers/serial/uart_mcux_lpsci.c
+++ b/drivers/serial/uart_mcux_lpsci.c
@@ -89,7 +89,7 @@ static int mcux_lpsci_fifo_fill(const struct device *dev,
 				int len)
 {
 	const struct mcux_lpsci_config *config = dev->config;
-	uint8_t num_tx = 0U;
+	int num_tx = 0U;
 
 	while ((len - num_tx > 0) &&
 	       (LPSCI_GetStatusFlags(config->base)
@@ -105,7 +105,7 @@ static int mcux_lpsci_fifo_read(const struct device *dev, uint8_t *rx_data,
 				const int len)
 {
 	const struct mcux_lpsci_config *config = dev->config;
-	uint8_t num_rx = 0U;
+	int num_rx = 0U;
 
 	while ((len - num_rx > 0) &&
 	       (LPSCI_GetStatusFlags(config->base)

--- a/drivers/serial/uart_mcux_lpuart.c
+++ b/drivers/serial/uart_mcux_lpuart.c
@@ -233,7 +233,7 @@ static int mcux_lpuart_fifo_fill(const struct device *dev,
 				 int len)
 {
 	const struct mcux_lpuart_config *config = dev->config;
-	uint8_t num_tx = 0U;
+	int num_tx = 0U;
 
 	while ((len - num_tx > 0) &&
 	       (LPUART_GetStatusFlags(config->base)
@@ -248,7 +248,7 @@ static int mcux_lpuart_fifo_read(const struct device *dev, uint8_t *rx_data,
 				 const int len)
 {
 	const struct mcux_lpuart_config *config = dev->config;
-	uint8_t num_rx = 0U;
+	int num_rx = 0U;
 
 	while ((len - num_rx > 0) &&
 	       (LPUART_GetStatusFlags(config->base)

--- a/drivers/serial/uart_nrfx_uart.c
+++ b/drivers/serial/uart_nrfx_uart.c
@@ -786,7 +786,7 @@ static int uart_nrfx_fifo_fill(const struct device *dev,
 			       const uint8_t *tx_data,
 			       int len)
 {
-	uint8_t num_tx = 0U;
+	int num_tx = 0U;
 
 	while ((len - num_tx > 0) &&
 	       event_txdrdy_check()) {
@@ -806,7 +806,7 @@ static int uart_nrfx_fifo_read(const struct device *dev,
 			       uint8_t *rx_data,
 			       const int size)
 {
-	uint8_t num_rx = 0U;
+	int num_rx = 0U;
 
 	while ((size - num_rx > 0) &&
 	       nrf_uart_event_check(uart0_addr, NRF_UART_EVENT_RXDRDY)) {

--- a/drivers/serial/uart_pl011.c
+++ b/drivers/serial/uart_pl011.c
@@ -317,7 +317,7 @@ static int pl011_runtime_config_get(const struct device *dev,
 static int pl011_fifo_fill(const struct device *dev,
 				    const uint8_t *tx_data, int len)
 {
-	uint8_t num_tx = 0U;
+	int num_tx = 0U;
 
 	while (!(get_uart(dev)->fr & PL011_FR_TXFF) && (len - num_tx > 0)) {
 		get_uart(dev)->dr = tx_data[num_tx++];
@@ -328,7 +328,7 @@ static int pl011_fifo_fill(const struct device *dev,
 static int pl011_fifo_read(const struct device *dev,
 				    uint8_t *rx_data, const int len)
 {
-	uint8_t num_rx = 0U;
+	int num_rx = 0U;
 
 	while ((len - num_rx > 0) && !(get_uart(dev)->fr & PL011_FR_RXFE)) {
 		rx_data[num_rx++] = get_uart(dev)->dr;

--- a/drivers/serial/uart_renesas_ra8_sci_b.c
+++ b/drivers/serial/uart_renesas_ra8_sci_b.c
@@ -256,7 +256,7 @@ static int uart_ra_sci_b_fifo_fill(const struct device *dev, const uint8_t *tx_d
 {
 	struct uart_ra_sci_b_data *data = dev->data;
 	const struct uart_ra_sci_b_config *cfg = dev->config;
-	uint8_t num_tx = 0U;
+	int num_tx = 0U;
 
 	if (IS_ENABLED(CONFIG_UART_RA_SCI_B_UART_FIFO_ENABLE) && data->sci.fifo_depth > 0) {
 		while ((size - num_tx > 0) && cfg->regs->FTSR != 0x10U) {
@@ -281,7 +281,7 @@ static int uart_ra_sci_b_fifo_read(const struct device *dev, uint8_t *rx_data, c
 {
 	struct uart_ra_sci_b_data *data = dev->data;
 	const struct uart_ra_sci_b_config *cfg = dev->config;
-	uint8_t num_rx = 0U;
+	int num_rx = 0U;
 
 	if (IS_ENABLED(CONFIG_UART_RA_SCI_B_UART_FIFO_ENABLE) && data->sci.fifo_depth > 0) {
 		while ((size - num_rx > 0) && cfg->regs->FRSR_b.R > 0U) {

--- a/drivers/serial/uart_renesas_ra_sci.c
+++ b/drivers/serial/uart_renesas_ra_sci.c
@@ -301,7 +301,7 @@ static int uart_ra_sci_fifo_fill(const struct device *dev, const uint8_t *tx_dat
 {
 	struct uart_ra_sci_data *data = dev->data;
 	const struct uart_ra_sci_config *cfg = dev->config;
-	uint8_t num_tx = 0U;
+	int num_tx = 0U;
 
 #if CONFIG_UART_RA_SCI_UART_FIFO_ENABLE
 	if (data->sci.fifo_depth != 0) {
@@ -326,7 +326,7 @@ static int uart_ra_sci_fifo_read(const struct device *dev, uint8_t *rx_data, con
 {
 	struct uart_ra_sci_data *data = dev->data;
 	const struct uart_ra_sci_config *cfg = dev->config;
-	uint8_t num_rx = 0U;
+	int num_rx = 0U;
 
 #if CONFIG_UART_RA_SCI_UART_FIFO_ENABLE
 	if (data->sci.fifo_depth != 0) {

--- a/drivers/serial/uart_rv32m1_lpuart.c
+++ b/drivers/serial/uart_rv32m1_lpuart.c
@@ -93,7 +93,7 @@ static int rv32m1_lpuart_fifo_fill(const struct device *dev,
 				   int len)
 {
 	const struct rv32m1_lpuart_config *config = dev->config;
-	uint8_t num_tx = 0U;
+	int num_tx = 0U;
 
 	while ((len - num_tx > 0) &&
 	       (LPUART_GetStatusFlags(config->base)
@@ -109,7 +109,7 @@ static int rv32m1_lpuart_fifo_read(const struct device *dev, uint8_t *rx_data,
 				   const int len)
 {
 	const struct rv32m1_lpuart_config *config = dev->config;
-	uint8_t num_rx = 0U;
+	int num_rx = 0U;
 
 	while ((len - num_rx > 0) &&
 	       (LPUART_GetStatusFlags(config->base)

--- a/drivers/serial/uart_stellaris.c
+++ b/drivers/serial/uart_stellaris.c
@@ -313,7 +313,7 @@ static int uart_stellaris_fifo_fill(const struct device *dev,
 				    int len)
 {
 	const struct uart_stellaris_config *config = dev->config;
-	uint8_t num_tx = 0U;
+	int num_tx = 0U;
 
 	while ((len - num_tx > 0) && ((config->uart->fr & UARTFR_TXFF) == 0U)) {
 		config->uart->dr = (uint32_t)tx_data[num_tx++];
@@ -336,7 +336,7 @@ static int uart_stellaris_fifo_read(const struct device *dev,
 				    const int size)
 {
 	const struct uart_stellaris_config *config = dev->config;
-	uint8_t num_rx = 0U;
+	int num_rx = 0U;
 
 	while ((size - num_rx > 0) && ((config->uart->fr & UARTFR_RXFE) == 0U)) {
 		rx_data[num_rx++] = (uint8_t)config->uart->dr;

--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -816,15 +816,14 @@ static inline void __uart_stm32_get_clock(const struct device *dev)
 
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 
-typedef void (*fifo_fill_fn)(USART_TypeDef *usart, const void *tx_data,
-			     const uint8_t offset);
+typedef void (*fifo_fill_fn)(USART_TypeDef *usart, const void *tx_data, const int offset);
 
 static int uart_stm32_fifo_fill_visitor(const struct device *dev, const void *tx_data, int size,
 					fifo_fill_fn fill_fn)
 {
 	const struct uart_stm32_config *config = dev->config;
 	USART_TypeDef *usart = config->usart;
-	uint8_t num_tx = 0U;
+	int num_tx = 0U;
 	unsigned int key;
 
 	if (!LL_USART_IsActiveFlag_TXE(usart)) {
@@ -847,8 +846,7 @@ static int uart_stm32_fifo_fill_visitor(const struct device *dev, const void *tx
 	return num_tx;
 }
 
-static void fifo_fill_with_u8(USART_TypeDef *usart,
-					 const void *tx_data, const uint8_t offset)
+static void fifo_fill_with_u8(USART_TypeDef *usart, const void *tx_data, const int offset)
 {
 	const uint8_t *data = (const uint8_t *)tx_data;
 	/* Send a character (8bit) */
@@ -865,15 +863,14 @@ static int uart_stm32_fifo_fill(const struct device *dev, const uint8_t *tx_data
 					    fifo_fill_with_u8);
 }
 
-typedef void (*fifo_read_fn)(USART_TypeDef *usart, void *rx_data,
-			     const uint8_t offset);
+typedef void (*fifo_read_fn)(USART_TypeDef *usart, void *rx_data, const int offset);
 
 static int uart_stm32_fifo_read_visitor(const struct device *dev, void *rx_data, const int size,
 					fifo_read_fn read_fn)
 {
 	const struct uart_stm32_config *config = dev->config;
 	USART_TypeDef *usart = config->usart;
-	uint8_t num_rx = 0U;
+	int num_rx = 0U;
 
 	while ((size - num_rx > 0) && LL_USART_IsActiveFlag_RXNE(usart)) {
 		/* RXNE flag will be cleared upon read from DR|RDR register */
@@ -894,8 +891,7 @@ static int uart_stm32_fifo_read_visitor(const struct device *dev, void *rx_data,
 	return num_rx;
 }
 
-static void fifo_read_with_u8(USART_TypeDef *usart, void *rx_data,
-					 const uint8_t offset)
+static void fifo_read_with_u8(USART_TypeDef *usart, void *rx_data, const int offset)
 {
 	uint8_t *data = (uint8_t *)rx_data;
 
@@ -914,8 +910,7 @@ static int uart_stm32_fifo_read(const struct device *dev, uint8_t *rx_data, cons
 
 #ifdef CONFIG_UART_WIDE_DATA
 
-static void fifo_fill_with_u16(USART_TypeDef *usart,
-					  const void *tx_data, const uint8_t offset)
+static void fifo_fill_with_u16(USART_TypeDef *usart, const void *tx_data, const int offset)
 {
 	const uint16_t *data = (const uint16_t *)tx_data;
 
@@ -933,8 +928,7 @@ static int uart_stm32_fifo_fill_u16(const struct device *dev, const uint16_t *tx
 					    fifo_fill_with_u16);
 }
 
-static void fifo_read_with_u16(USART_TypeDef *usart, void *rx_data,
-					  const uint8_t offset)
+static void fifo_read_with_u16(USART_TypeDef *usart, void *rx_data, const int offset)
 {
 	uint16_t *data = (uint16_t *)rx_data;
 

--- a/drivers/serial/usart_gd32.c
+++ b/drivers/serial/usart_gd32.c
@@ -167,7 +167,7 @@ int usart_gd32_fifo_fill(const struct device *dev, const uint8_t *tx_data,
 			 int len)
 {
 	const struct gd32_usart_config *const cfg = dev->config;
-	uint8_t num_tx = 0U;
+	int num_tx = 0U;
 
 	while ((len - num_tx > 0) &&
 	       usart_flag_get(cfg->reg, USART_FLAG_TBE)) {
@@ -181,7 +181,7 @@ int usart_gd32_fifo_read(const struct device *dev, uint8_t *rx_data,
 			 const int size)
 {
 	const struct gd32_usart_config *const cfg = dev->config;
-	uint8_t num_rx = 0U;
+	int num_rx = 0U;
 
 	while ((size - num_rx > 0) &&
 	       usart_flag_get(cfg->reg, USART_FLAG_RBNE)) {


### PR DESCRIPTION
try to fix issue #80599 , a error of type transform(?) in serial drivers. For `fifo_read` it may cause wrong read data if parameter `size` is over 255, while endless looping for `fifo_fill`, if uart is running faster than cpu.

Fixes #80599