### PR TITLE
boards: ambiq: add ITM node to Apollo boards

### DIFF
--- a/boards/ambiq/apollo3_evb/Kconfig.defconfig
+++ b/boards/ambiq/apollo3_evb/Kconfig.defconfig
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright (c) 2024 Ambiq Micro Inc. <www.ambiq.com>
+
+if BOARD_APOLLO3_EVB
+
+config LOG_BACKEND_SWO_FREQ_HZ
+	default 1000000
+	depends on LOG_BACKEND_SWO
+
+endif # BOARD_APOLLO3_EVB

--- a/boards/ambiq/apollo3_evb/apollo3_evb-pinctrl.dtsi
+++ b/boards/ambiq/apollo3_evb/apollo3_evb-pinctrl.dtsi
@@ -17,6 +17,11 @@
 			input-enable;
 		};
 	};
+	itm_default: itm_default {
+		group1 {
+			pinmux = <SWO_P41>;
+		};
+	};
 	i2c0_default: i2c0_default {
 		group1 {
 			pinmux = <M0SCL_P5>, <M0SDAWIR3_P6>;

--- a/boards/ambiq/apollo3_evb/apollo3_evb.dts
+++ b/boards/ambiq/apollo3_evb/apollo3_evb.dts
@@ -98,6 +98,12 @@
 	status = "okay";
 };
 
+&itm {
+	pinctrl-0 = <&itm_default>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
 &wdt0 {
 	status = "okay";
 };

--- a/boards/ambiq/apollo3p_evb/Kconfig.defconfig
+++ b/boards/ambiq/apollo3p_evb/Kconfig.defconfig
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright (c) 2024 Ambiq Micro Inc. <www.ambiq.com>
+
+if BOARD_APOLLO3P_EVB
+
+config LOG_BACKEND_SWO_FREQ_HZ
+	default 1000000
+	depends on LOG_BACKEND_SWO
+
+endif # BOARD_APOLLO3P_EVB

--- a/boards/ambiq/apollo3p_evb/apollo3p_evb-pinctrl.dtsi
+++ b/boards/ambiq/apollo3p_evb/apollo3p_evb-pinctrl.dtsi
@@ -17,6 +17,11 @@
 			input-enable;
 		};
 	};
+	itm_default: itm_default {
+		group1 {
+			pinmux = <SWO_P41>;
+		};
+	};
 	i2c0_default: i2c0_default {
 		group1 {
 			pinmux = <M0SCL_P5>, <M0SDAWIR3_P6>;

--- a/boards/ambiq/apollo3p_evb/apollo3p_evb.dts
+++ b/boards/ambiq/apollo3p_evb/apollo3p_evb.dts
@@ -98,6 +98,12 @@
 	status = "okay";
 };
 
+&itm {
+	pinctrl-0 = <&itm_default>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
 &wdt0 {
 	status = "okay";
 };

--- a/boards/ambiq/apollo4p_blue_kxr_evb/Kconfig.defconfig
+++ b/boards/ambiq/apollo4p_blue_kxr_evb/Kconfig.defconfig
@@ -4,6 +4,10 @@
 
 if BOARD_APOLLO4P_BLUE_KXR_EVB
 
+config LOG_BACKEND_SWO_FREQ_HZ
+	default 1000000
+	depends on LOG_BACKEND_SWO
+
 if BT
 
 config MAIN_STACK_SIZE

--- a/boards/ambiq/apollo4p_blue_kxr_evb/apollo4p_blue_kxr_evb-pinctrl.dtsi
+++ b/boards/ambiq/apollo4p_blue_kxr_evb/apollo4p_blue_kxr_evb-pinctrl.dtsi
@@ -16,6 +16,11 @@
 			input-enable;
 		};
 	};
+	itm_default: itm_default {
+		group1 {
+			pinmux = <SWO_P28>;
+		};
+	};
 	i2c0_default: i2c0_default {
 		group1 {
 			pinmux = <M0SCL_P5>, <M0SDAWIR3_P6>;

--- a/boards/ambiq/apollo4p_blue_kxr_evb/apollo4p_blue_kxr_evb.dts
+++ b/boards/ambiq/apollo4p_blue_kxr_evb/apollo4p_blue_kxr_evb.dts
@@ -63,6 +63,12 @@
 	status = "okay";
 };
 
+&itm {
+	pinctrl-0 = <&itm_default>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
 &counter0 {
 	status = "okay";
 };

--- a/boards/ambiq/apollo4p_evb/Kconfig.defconfig
+++ b/boards/ambiq/apollo4p_evb/Kconfig.defconfig
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright (c) 2024 Ambiq Micro Inc. <www.ambiq.com>
+
+if BOARD_APOLLO4P_EVB
+
+config LOG_BACKEND_SWO_FREQ_HZ
+	default 1000000
+	depends on LOG_BACKEND_SWO
+
+endif # BOARD_APOLLO4P_EVB

--- a/boards/ambiq/apollo4p_evb/apollo4p_evb-pinctrl.dtsi
+++ b/boards/ambiq/apollo4p_evb/apollo4p_evb-pinctrl.dtsi
@@ -17,6 +17,11 @@
 			input-enable;
 		};
 	};
+	itm_default: itm_default {
+		group1 {
+			pinmux = <SWO_P28>;
+		};
+	};
 	adc0_default: adc0_default{
 		group1 {
 			pinmux = <ADCSE4_P15>, <ADCSE7_P12>;

--- a/boards/ambiq/apollo4p_evb/apollo4p_evb.dts
+++ b/boards/ambiq/apollo4p_evb/apollo4p_evb.dts
@@ -63,6 +63,12 @@
 	status = "okay";
 };
 
+&itm {
+	pinctrl-0 = <&itm_default>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
 &adc0 {
 compatible = "ambiq,adc";
 	pinctrl-0 = <&adc0_default>;

--- a/dts/arm/ambiq/ambiq_apollo3_blue.dtsi
+++ b/dts/arm/ambiq/ambiq_apollo3_blue.dtsi
@@ -24,6 +24,14 @@
 			compatible = "arm,cortex-m4f";
 			reg = <0>;
 			cpu-power-states = <&idle &suspend_to_ram>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			itm: itm@e0000000 {
+				compatible = "arm,armv7m-itm";
+				reg = <0xe0000000 0x1000>;
+				swo-ref-frequency = <DT_FREQ_M(6)>;
+			};
 		};
 
 		power-states {

--- a/dts/arm/ambiq/ambiq_apollo3p_blue.dtsi
+++ b/dts/arm/ambiq/ambiq_apollo3p_blue.dtsi
@@ -24,6 +24,14 @@
 			compatible = "arm,cortex-m4f";
 			reg = <0>;
 			cpu-power-states = <&idle &suspend_to_ram>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			itm: itm@e0000000 {
+				compatible = "arm,armv7m-itm";
+				reg = <0xe0000000 0x1000>;
+				swo-ref-frequency = <DT_FREQ_M(6)>;
+			};
 		};
 
 		power-states {

--- a/dts/arm/ambiq/ambiq_apollo4p.dtsi
+++ b/dts/arm/ambiq/ambiq_apollo4p.dtsi
@@ -24,6 +24,14 @@
 			compatible = "arm,cortex-m4f";
 			reg = <0>;
 			cpu-power-states = <&idle &suspend_to_ram>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			itm: itm@e0000000 {
+				compatible = "arm,armv7m-itm";
+				reg = <0xe0000000 0x1000>;
+				swo-ref-frequency = <DT_FREQ_M(48)>;
+			};
 		};
 		power-states {
 			idle: idle {

--- a/dts/arm/ambiq/ambiq_apollo4p_blue.dtsi
+++ b/dts/arm/ambiq/ambiq_apollo4p_blue.dtsi
@@ -32,6 +32,14 @@
 		cpu0: cpu@0 {
 			compatible = "arm,cortex-m4f";
 			reg = <0>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			itm: itm@e0000000 {
+				compatible = "arm,armv7m-itm";
+				reg = <0xe0000000 0x1000>;
+				swo-ref-frequency = <DT_FREQ_M(48)>;
+			};
 		};
 	};
 

--- a/soc/ambiq/apollo3x/soc.c
+++ b/soc/ambiq/apollo3x/soc.c
@@ -28,4 +28,10 @@ void soc_early_init_hook(void)
 #ifdef CONFIG_PM
 	ambiq_power_init();
 #endif
+
+#ifdef CONFIG_LOG_BACKEND_SWO
+	/* Select HFRC/8 (6MHz) for the TPIU clock source */
+	MCUCTRL->TPIUCTRL_b.CLKSEL = MCUCTRL_TPIUCTRL_CLKSEL_HFRCDIV8;
+	MCUCTRL->TPIUCTRL_b.ENABLE = MCUCTRL_TPIUCTRL_ENABLE_EN;
+#endif
 }

--- a/soc/ambiq/apollo4x/soc.c
+++ b/soc/ambiq/apollo4x/soc.c
@@ -23,4 +23,10 @@ void soc_early_init_hook(void)
 #ifdef CONFIG_PM
 	ambiq_power_init();
 #endif
+
+#ifdef CONFIG_LOG_BACKEND_SWO
+	/* Select HFRC 48MHz for the TPIU clock source */
+	MCUCTRL->DBGCTRL_b.CM4CLKSEL = MCUCTRL_DBGCTRL_CM4CLKSEL_HFRC48;
+	MCUCTRL->DBGCTRL_b.CM4TPIUENABLE = MCUCTRL_DBGCTRL_CM4TPIUENABLE_EN;
+#endif
 }


### PR DESCRIPTION
This PR adds the ITM node to the Ambiq Apollo3 and Apollo3 series soc and enables it in supported EVB.

Test boards:
- ambiq/apollo3_evb
- ambiq/apollo3p_evb
- ambiq/apollo4p_evb
- ambiq/apollo4p_blue_kxr_evb

Test samples:
- samples/subsys/logging/logger