### PR TITLE
samples: led: pwm: fix console harness regex

### DIFF
--- a/samples/drivers/led/pwm/sample.yaml
+++ b/samples/drivers/led/pwm/sample.yaml
@@ -17,6 +17,6 @@ tests:
         - "Turned on"
         - "Turned off"
         - "Increasing brightness gradually"
-        - "Blinking on: 0.1 sec, off: 0.1 sec"
-        - "(Blinking on: 1 sec, off: 1 sec|Cycle period not supported)"
+        - "Blinking on: ([0-9]+) msec, off: ([0-9]+) msec"
+        - "(Blinking on: ([0-9]+) msec, off: ([0-9]+) msec|Cycle period not supported)"
         - "Turned off, loop end"


### PR DESCRIPTION
Led blinking period was made configurable and time unit changed from sec to msec recently in the source code of the sample. Console harness regex was not changed accordingly in sample.yaml. Device testing fails when run with twister.
Change the regex to accept any period and change the units to msec.

Fixes: #80319