### PR TITLE
Bluetooth: Host: Don't do `tx_notify` in `conn_recv`

### DIFF
--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -478,14 +478,6 @@ static void bt_acl_recv(struct bt_conn *conn, struct net_buf *buf, uint8_t flags
 
 void bt_conn_recv(struct bt_conn *conn, struct net_buf *buf, uint8_t flags)
 {
-	/* Make sure we notify any pending TX callbacks before processing
-	 * new data for this connection.
-	 *
-	 * Always do so from the same context for sanity. In this case that will
-	 * be either a dedicated Bluetooth connection TX workqueue or system workqueue.
-	 */
-	bt_conn_tx_notify(conn, true);
-
 	LOG_DBG("handle %u len %u flags %02x", conn->handle, buf->len, flags);
 
 	if (IS_ENABLED(CONFIG_BT_ISO_RX) && conn->type == BT_CONN_TYPE_ISO) {


### PR DESCRIPTION
TLDR: The removed code could not guarantee its purpose and was prone to deadlocks.

Digging in git history:

The code, introduced in https://github.com/zephyrproject-rtos/zephyr/pull/21056, was there to make sure the Host has invoked all pending HCI Number of Packets Completed callbacks before accepting new ACL data.

This was done to ensure the higher layers are informed of a successful TX by the Controller before any ACL data that is the result of that TX arrives at the application. Concretely, this was used by ATT to detect pipelined requests from the peer.

ATT pipelining detection was added in https://github.com/zephyrproject-rtos/zephyr/commit/4a57bf6e6cd1e4b1fad87ff2611ff604800ec7b6.

However this relies on the Controller delivering the Number of Packets Completed event promptly, which it is not required to do by spec. So, while this happens to work with some Controllers, there is no guarantee.

When we found some Controller implementations that did not deliver the Number of Packets Completed event promptly, we removed the ATT pipelining detection in https://github.com/zephyrproject-rtos/zephyr/pull/66012. But we forgot to remove the call to `tx_notify` in `conn_recv`, which suffers from the same lack of guarantee.

It used to be that BT RX thread would perform the work of `tx_notify` itself when it needed it to be done. This was changed in https://github.com/zephyrproject-rtos/zephyr/pull/68394. After this, the code forms a dependency from the BT RX thread to the system work queue. Dependencies like this are a liability and should not exist unless necessary. If the system work queue is busy with long-running work, this delays the processing of the ACL data. And if the system work queue is blocked, e.g. by a call into Bluetooth API, this can cause a deadlock.

There is probably more to add to this, but I think this change is sufficiently motivated already. Removing this code should be fine because of the lack of guarantee that it does anything useful.