### PR TITLE
boards: nrf54l15bsim doc: Clarify around entropy and crypto

### DIFF
--- a/boards/native/nrf_bsim/doc/nrf54l15bsim.rst
+++ b/boards/native/nrf_bsim/doc/nrf54l15bsim.rst
@@ -89,5 +89,6 @@ ARM's TrustZone is not modeled in this board. This means that:
   can be labeled as restricted for secure or non secure access.
 * TF-M cannot be used.
 
-Note that the CRACEN peripheral is not modeled. The mbedTLS library can still be used
-but with a SW crypto backend.
+Note that the CRACEN peripheral is not modeled.
+As crypto library, Mbed TLS can be used with its SW crypto backend.
+As entropy driver, the :dtcompatible:`zephyr,native-posix-rng` is enabled by default.


### PR DESCRIPTION
Let's explicitly mention we are enabling the native_posix entropy driver for this board (the real nrf54l15dk does not have an entropy driver in Zephyr yet).
And correct a bit the wording around mbedtls as for the real target we don't have mbedtls with HW acceleration.