### PR TITLE
doc: fix body length in SMP UART transport

### DIFF
--- a/doc/services/device_mgmt/smp_transport.rst
+++ b/doc/services/device_mgmt/smp_transport.rst
@@ -179,7 +179,7 @@ taking form:
     | Content       | Size          | Description               |
     +===============+===============+===========================+
     | body          | no more than  | Raw body data fragment    |
-    |               | MTU - 3       |                           |
+    |               | MTU - 5       |                           |
     +---------------+---------------+---------------------------+
     | crc16         | 2 bytes       | CRC16 of entire packet    |
     |               |               | body, preceding length    |


### PR DESCRIPTION
In the description of the partial-final frame of the SMP UART transport specification was a typo in the maximum allowed raw body size. The size must not be larger than MTU-5 because there are 5 bytes occupied by total length (2), frame termination (1) and crc (2).