### PR TITLE
`west build`: warn about conditional flags in `extra_configs`

### DIFF
--- a/scripts/west_commands/build.py
+++ b/scripts/west_commands/build.py
@@ -361,7 +361,19 @@ class Build(Forceable):
                         arg_list = extra
 
                     if data == 'extra_configs':
-                        args = ["-D{}".format(arg.replace('"', '\"')) for arg in arg_list]
+                        args = []
+                        for arg in arg_list:
+                            equals = arg.find('=')
+                            colon = arg.rfind(':', 0, equals)
+                            if colon != -1:
+                                # conditional configs (xxx:yyy:CONFIG_FOO=bar)
+                                # are not supported by 'west build'
+                                self.wrn('"west build" does not support '
+                                         'conditional config "{}". Add "-D{}" '
+                                         'to the supplied CMake arguments if '
+                                         'desired.'.format(arg, arg[colon+1:]))
+                                continue
+                            args.append("-D{}".format(arg.replace('"', '\"')))
                     elif data == 'extra_args':
                         # Retain quotes around config options
                         config_options = [arg for arg in arg_list if arg.startswith("CONFIG_")]

--- a/scripts/west_commands/build.py
+++ b/scripts/west_commands/build.py
@@ -265,7 +265,7 @@ class Build(Forceable):
                 with open(build_info_file, "w") as f:
                     yaml.dump(build_command, f, default_flow_style=False)
             except Exception as e:
-                log.wrn(f'Failed to create info file: {build_info_file},', e)
+                self.wrn(f'Failed to create info file: {build_info_file},', e)
 
         board, origin = self._find_board()
         self._run_cmake(board, origin, self.args.cmake_opts)


### PR DESCRIPTION
The `west build` command does not know about conditional flags (in the format `type:value:CONFIG_FOO=bar`) in the `extra_configs` argument of Twister `testcase.yaml` files, and currently converts them to malformed arguments that are silently ignored by `cmake`.

This change adds a check to `west build` to clearly warn the user if the `extra_configs` list contains conditional flags and provide a hint on how to add them to the `west` command line.

Fixes #80170 (or, at least, makes the missing flags obvious to the user).

Also fixes one leftover use of the global `west.log` instance that was added by #79118 while at the same time #79239 removed all other usages.