### PR TITLE
driver: sensor: adxl367: Fix for conversion and SPI

### DIFF
--- a/drivers/sensor/adi/adxl367/adxl367.c
+++ b/drivers/sensor/adi/adxl367/adxl367.c
@@ -890,7 +890,7 @@ static void adxl367_accel_convert(struct sensor_value *val, int16_t value,
 				enum adxl367_range range)
 #endif /*CONFIG_SENSOR_ASYNC_API*/
 {
-	int64_t micro_ms2 = value * (SENSOR_G * 250 / 10000 *
+	int64_t micro_ms2 = value * (SENSOR_G * 250 / 1000 *
 			  adxl367_scale_mul[range] / 1000);
 
 	val->val1 = micro_ms2 / 1000000;

--- a/drivers/sensor/adi/adxl367/adxl367.c
+++ b/drivers/sensor/adi/adxl367/adxl367.c
@@ -903,10 +903,10 @@ void adxl367_temp_convert(struct sensor_value *val, int16_t value)
 static void adxl367_temp_convert(struct sensor_value *val, int16_t value)
 #endif /*CONFIG_SENSOR_ASYNC_API*/
 {
-	int64_t temp_data = (value + ADXL367_TEMP_OFFSET) * ADXL367_TEMP_SCALE;
+	int64_t temp_data = (value - ADXL367_TEMP_25C);
 
-	val->val1 = temp_data / ADXL367_TEMP_SCALE_DIV;
-	val->val2 = temp_data % ADXL367_TEMP_SCALE_DIV;
+	val->val1 = temp_data / 54 /*temp sensitivity LSB/C*/ + 25/*bias test conditions*/;
+	val->val2 = temp_data % 54 * 10000;
 }
 
 static int adxl367_channel_get(const struct device *dev,
@@ -932,6 +932,7 @@ static int adxl367_channel_get(const struct device *dev,
 		break;
 	case SENSOR_CHAN_DIE_TEMP:
 		adxl367_temp_convert(val, data->temp_val);
+		break;
 	default:
 		return -ENOTSUP;
 	}

--- a/drivers/sensor/adi/adxl367/adxl367_spi.c
+++ b/drivers/sensor/adi/adxl367/adxl367_spi.c
@@ -32,13 +32,12 @@ static int adxl367_bus_access(const struct device *dev, uint8_t reg,
 
 	addr_reg = ADXL367_TO_REG(reg);
 
-	const struct spi_buf buf[3] = {
+	uint8_t access[2] = {rw_reg, addr_reg};
+
+	const struct spi_buf buf[2] = {
 		{
-			.buf = &rw_reg,
-			.len = 1
-		}, {
-			.buf = &addr_reg,
-			.len = 1
+			.buf = access,
+			.len = 2
 		}, {
 			.buf = data,
 			.len = length
@@ -52,15 +51,15 @@ static int adxl367_bus_access(const struct device *dev, uint8_t reg,
 	if ((reg & ADXL367_READ) != 0) {
 		const struct spi_buf_set rx = {
 			.buffers = buf,
-			.count = 3
+			.count = 2
 		};
 
-		tx.count = 2;
+		tx.count = 1;
 
 		return spi_transceive_dt(&config->spi, &tx, &rx);
 	}
 
-	tx.count = 3;
+	tx.count = 2;
 
 	return spi_write_dt(&config->spi, &tx);
 }


### PR DESCRIPTION
This is a fix for:
- Extra 0 in conversion of acceleration values in adxl367_accel_convert.
- Conversion of temperature values in adxl367_temp_convert.
- SPI communication when RTIO is used in SPI driver. When in adxl367_bus_access, const struct spi_buf buf[3] is used, spi_rtio_copy function won't set correct buffers and length for buf[2] and that will cause exception when that buffer is processed.

Signed-off-by: Vladislav Pejic [vladislav.pejic@orioninc.com](mailto:vladislav.pejic@orioninc.com)