### PR TITLE
tests: drivers: flash: Fix MAX32666 flash error

### DIFF
--- a/tests/drivers/flash/common/boards/max32666evkit_max32666_cpu0.overlay
+++ b/tests/drivers/flash/common/boards/max32666evkit_max32666_cpu0.overlay
@@ -11,13 +11,13 @@
 		#size-cells = <1>;
 
 		code_partition: partition@0 {
-			reg = <0x0 DT_SIZE_K(512)>;
+			reg = <0x0 DT_SIZE_K(256)>;
 			read-only;
 		};
 
-		storage_partition: partition@80000 {
+		storage_partition: partition@40000 {
 			label = "storage";
-			reg = <0x80000 DT_SIZE_K(512)>;
+			reg = <0x40000 DT_SIZE_K(256)>;
 		};
 	};
 };

--- a/tests/drivers/flash/common/boards/max32666fthr_max32666_cpu0.overlay
+++ b/tests/drivers/flash/common/boards/max32666fthr_max32666_cpu0.overlay
@@ -11,13 +11,13 @@
 		#size-cells = <1>;
 
 		code_partition: partition@0 {
-			reg = <0x0 DT_SIZE_K(512)>;
+			reg = <0x0 DT_SIZE_K(256)>;
 			read-only;
 		};
 
-		storage_partition: partition@80000 {
+		storage_partition: partition@40000 {
 			label = "storage";
-			reg = <0x80000 DT_SIZE_K(512)>;
+			reg = <0x40000 DT_SIZE_K(256)>;
 		};
 	};
 };


### PR DESCRIPTION
Flash driver test (tests/drivers/flash/common) is failing on MAX32666 boards.
This PR fixes this failure by correcting flash sizes in overlay files for corresponding flash controller.