### PR TITLE
doc: move less important information under the fold

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -21,14 +21,6 @@ Zephyr Project Documentation
 Use the version selection menu on the left to view
 documentation for a specific version of Zephyr.
 
-For information about the changes and additions for releases, please
-consult the published :ref:`zephyr_release_notes` documentation.
-
-The Zephyr OS is provided under the `Apache 2.0 license`_ (as found in
-the LICENSE file in the project's `GitHub repo`_).  The Zephyr OS also
-imports or reuses packages, scripts, and other files that use other
-licensing, as described in :ref:`Zephyr_Licensing`.
-
 
 .. raw:: html
 
@@ -90,6 +82,14 @@ licensing, as described in :ref:`Zephyr_Licensing`.
 	   <p>OS Services and usage guides</p>
        </li>
    </ul>
+
+For information about the changes and additions for past releases, please
+consult the published :ref:`zephyr_release_notes` documentation.
+
+The Zephyr OS is provided under the `Apache 2.0 license`_ (as found in
+the LICENSE file in the project's `GitHub repo`_).  The Zephyr OS also
+imports or reuses packages, scripts, and other files that use other
+licensing, as described in :ref:`Zephyr_Licensing`.
 
 .. toctree::
    :maxdepth: 1

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -93,7 +93,7 @@ licensing, as described in :ref:`Zephyr_Licensing`.
 
 .. toctree::
    :maxdepth: 1
-   :caption: Contents
+   :hidden:
 
    introduction/index.rst
    develop/index.rst


### PR DESCRIPTION
https://builds.zephyrproject.io/zephyr/pr/80620/docs/index.html

- Help make sure the most important documentation entry points are visible
without scrolling by moving less important information "under the fold".

- Also hide the main table of contents from the index doc page.

<img width="1436" alt="image" src="https://github.com/user-attachments/assets/0a5abdf3-5345-430e-9385-f5b4fe87af8f">