### PR TITLE
tests: twister: using statemachine for status

### DIFF
--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -1551,7 +1551,7 @@ class ProjectBuilder(FilterBuilder):
                 for tc in self.instance.testcases:
                     color = TwisterStatus.get_color(tc.status)
                     logger.info(f'    {" ":<{total_tests_width+25+4}} {tc.name:<75} '
-                                f'{color}{str.upper(tc.status.value):<12}{Fore.RESET}'
+                                f'{color}{str.upper(tc.status):<12}{Fore.RESET}'
                                 f'{" " + tc.reason if tc.reason else ""}')
 
             if instance.status in [TwisterStatus.ERROR, TwisterStatus.FAIL]:
@@ -1960,6 +1960,7 @@ class TwisterRunner:
                 return True
         except Exception as e:
             logger.error(f"General exception: {e}")
+            logger.error(traceback.format_exc())
             sys.exit(1)
 
     def execute(self, pipeline, done):

--- a/scripts/pylib/twister/twisterlib/statuses.py
+++ b/scripts/pylib/twister/twisterlib/statuses.py
@@ -1,15 +1,34 @@
 #!/usr/bin/env python3
 # Copyright (c) 2024 Intel Corporation
+# Copyright (c) 2024 NXP
 #
 # SPDX-License-Identifier: Apache-2.0
 """
 Status classes to be used instead of str statuses.
+set environment variable TWISTER_STATUS_CHECK
+to enable check
 """
 from __future__ import annotations
 
+import logging
+import os
+import pickle
+import traceback
+from abc import ABC, abstractmethod
 from enum import Enum
 
-from colorama import Fore
+from colorama import Fore, init
+from statemachine import State, StateMachine, exceptions
+from statemachine.contrib.diagram import DotGraphMachine
+
+logger = logging.getLogger('twister')
+logger.setLevel(logging.DEBUG)
+
+def g():
+    logger.warning("======call stack dump start==========")
+    for line in traceback.format_stack():
+        logger.info(line.strip())
+    logger.warning("======call stack dump end============")
 
 
 class TwisterStatus(str, Enum):
@@ -52,3 +71,444 @@ class TwisterStatus(str, Enum):
     FAIL = 'failed'
     PASS = 'passed'
     SKIP = 'skipped'
+
+class TwisterStateMachine(StateMachine):
+    '''
+        TwisterStatemachine basic
+    '''
+    def is_start(self, cond: TwisterStatus):
+        return cond == TwisterStatus.STARTED
+
+    def is_abnormal(self, cond: TwisterStatus):
+        return cond == TwisterStatus.FAIL
+
+    def is_pass(self, cond: TwisterStatus):
+        return cond == TwisterStatus.PASS
+
+    def is_skip(self, cond: TwisterStatus):
+        return cond == TwisterStatus.SKIP
+
+    def is_filtered(self, cond: TwisterStatus):
+        return cond == TwisterStatus.FILTER
+
+    def is_blocked(self, cond: TwisterStatus):
+        return cond == TwisterStatus.BLOCK
+
+    def is_error(self, cond: TwisterStatus):
+        return cond == TwisterStatus.ERROR
+
+    def is_build_only(self, cond: TwisterStatus):
+        return cond == TwisterStatus.NOTRUN
+
+    def is_force(self, cond: TwisterStatus):
+        return cond == TwisterStatus.NONE
+
+    def is_load_pass(self, cond: TwisterStatus):
+        return cond == TwisterStatus.PASS
+
+    def is_load_skip(self, cond: TwisterStatus):
+        return cond == TwisterStatus.SKIP
+
+    def is_load_filtered(self, cond: TwisterStatus):
+        return cond == TwisterStatus.FILTER
+
+    def is_load_blocked(self, cond: TwisterStatus):
+        return cond == TwisterStatus.BLOCK
+
+    def is_load_error(self, cond: TwisterStatus):
+        return cond == TwisterStatus.ERROR
+
+    def is_load_build_only(self, cond: TwisterStatus):
+        return cond == TwisterStatus.NOTRUN
+
+    def after_transition(self, event: str, source: State, target: State, event_data):
+        # logger.info(f"Running {event} from {source!s} to {target!s} on {event_data!s}")
+        pass
+
+class TwisterCaseStatusMachineInner(TwisterStateMachine):
+    '''
+        twister status state machine
+    '''
+    none_state = State(str(TwisterStatus.NONE), initial=True)
+    pass_state = State(str(TwisterStatus.PASS))
+    notrun_state = State(str(TwisterStatus.NOTRUN))
+    skip_state = State(str(TwisterStatus.SKIP))
+    filter_state = State(str(TwisterStatus.FILTER))
+    block_state = State(str(TwisterStatus.BLOCK))
+    fail_state = State(str(TwisterStatus.FAIL))
+    error_state = State(str(TwisterStatus.ERROR))
+    started_state = State(str(TwisterStatus.STARTED))
+
+    # Define transitions
+    # for TestCase
+    cycles_case = (
+        none_state.to(started_state,    cond="is_start")
+        | none_state.to(fail_state,     cond="is_abnormal")
+        | started_state.to(fail_state,  cond="is_abnormal")
+        | started_state.to(pass_state,  cond="is_pass")
+        | started_state.to(skip_state,  cond="is_skip")
+        #| started_state.to(filter_state,cond="is_filtered")
+        #| started_state.to(block_state, cond="is_blocked")
+        | started_state.to(error_state, cond="is_error")
+        | started_state.to(notrun_state,cond="is_build_only")
+        | none_state.to(pass_state,  cond="is_load_pass")
+        | none_state.to(skip_state,  cond="is_load_skip")
+        | none_state.to(filter_state,cond="is_load_filtered")
+        | none_state.to(block_state, cond="is_load_blocked")
+        | none_state.to(error_state, cond="is_load_error")
+        | none_state.to(notrun_state,cond="is_load_build_only")
+        | fail_state.to(none_state,    cond="is_force")
+        | pass_state.to(none_state,    cond="is_force")
+        | skip_state.to(none_state,    cond="is_force")
+        | block_state.to(none_state,   cond="is_force")
+        | error_state.to(none_state,   cond="is_force")
+        | filter_state.to(none_state,  cond="is_force")
+        | none_state.to.itself(internal=True,    cond="is_force")
+        | started_state.to.itself(internal=True, cond="is_start")
+        | fail_state.to.itself(internal=True,   cond="is_abnormal")
+        | pass_state.to.itself(internal=True,   cond="is_pass")
+        | skip_state.to.itself(internal=True,   cond="is_skip")
+        | block_state.to.itself(internal=True,  cond="is_blocked")
+        | error_state.to.itself(internal=True,  cond="is_error")
+        | notrun_state.to.itself(internal=True, cond="is_force")
+        | filter_state.to.itself(internal=True, cond="is_filtered")
+    )
+
+    def trigger_case(self, event : TwisterStatus) -> None:
+        '''
+            trigger state
+        '''
+        self.send("cycles_case", event)
+
+    def force_state_case(self, event : TwisterStatus) -> None:
+        '''
+            trigger state
+        '''
+        if event == TwisterStatus.NONE:
+            self.send("cycles_case", event)
+            return
+
+        if self.current_state.id != "none_state":
+            self.send("cycles_case", TwisterStatus.NONE)
+        self.send("cycles_case", TwisterStatus.STARTED)
+        self.send("cycles_case", event)
+
+class TwisterHarnessStatusMachineInner(TwisterStateMachine):
+    '''
+        twister status state machine
+    '''
+    none_state = State(str(TwisterStatus.NONE), initial=True)
+    pass_state = State(str(TwisterStatus.PASS))
+    skip_state = State(str(TwisterStatus.SKIP))
+    fail_state = State(str(TwisterStatus.FAIL))
+    error_state = State(str(TwisterStatus.ERROR))
+
+    # Define transitions
+    # for harness
+    cycles_harness = (
+        none_state.to(fail_state,     cond="is_abnormal")
+        | none_state.to(pass_state,  cond="is_load_pass")
+        | none_state.to(skip_state,  cond="is_load_skip")
+        | none_state.to(error_state, cond="is_load_error")
+        | fail_state.to(none_state,    cond="is_force")
+        | pass_state.to(none_state,    cond="is_force")
+        | skip_state.to(none_state,    cond="is_force")
+        | error_state.to(none_state,   cond="is_force")
+        | none_state.to.itself(internal=True,    cond="is_force")
+        | fail_state.to.itself(internal=True,   cond="is_abnormal")
+        | pass_state.to.itself(internal=True,   cond="is_pass")
+        | skip_state.to.itself(internal=True,   cond="is_skip")
+        | error_state.to.itself(internal=True,  cond="is_error")
+    )
+
+    def trigger_harness(self, event : TwisterStatus) -> None:
+        '''
+            trigger state
+        '''
+        self.send("cycles_harness", event)
+
+    def force_state_harness(self, event : TwisterStatus) -> None:
+        '''
+            trigger state
+        '''
+        if event == TwisterStatus.NONE:
+            self.send("cycles_harness", event)
+            return
+
+        if self.current_state.id != "none_state":
+            self.send("cycles_harness", TwisterStatus.NONE)
+        self.send("cycles_harness", event)
+
+class TwisterInstanceStatusMachineInner(TwisterStateMachine):
+    '''
+        twister status state machine
+    '''
+    none_state = State(str(TwisterStatus.NONE), initial=True)
+    pass_state = State(str(TwisterStatus.PASS))
+    notrun_state = State(str(TwisterStatus.NOTRUN))
+    skip_state = State(str(TwisterStatus.SKIP))
+    filter_state = State(str(TwisterStatus.FILTER))
+    fail_state = State(str(TwisterStatus.FAIL))
+    error_state = State(str(TwisterStatus.ERROR))
+
+    # Define transitions
+    # for TestInstance
+    cycles_instance = (
+        none_state.to(fail_state,     cond="is_abnormal")
+        | none_state.to(pass_state,  cond="is_load_pass")
+        | none_state.to(skip_state,  cond="is_load_skip")
+        | none_state.to(filter_state,cond="is_load_filtered")
+        | none_state.to(error_state, cond="is_load_error")
+        | none_state.to(notrun_state,cond="is_load_build_only")
+        | fail_state.to(none_state,    cond="is_force")
+        | pass_state.to(none_state,    cond="is_force")
+        | skip_state.to(none_state,    cond="is_force")
+        | error_state.to(none_state,   cond="is_force")
+        | filter_state.to(none_state,  cond="is_force")
+        | none_state.to.itself(internal=True,    cond="is_force")
+        | fail_state.to.itself(internal=True,   cond="is_abnormal")
+        | pass_state.to.itself(internal=True,   cond="is_pass")
+        | skip_state.to.itself(internal=True,   cond="is_skip")
+        | error_state.to.itself(internal=True,  cond="is_error")
+        | notrun_state.to.itself(internal=True, cond="is_force")
+        | filter_state.to.itself(internal=True, cond="is_filtered")
+    )
+
+    def trigger_instance(self, event : TwisterStatus) -> None:
+        '''
+            trigger state
+        '''
+        self.send("cycles_instance", event)
+
+    def force_state_instance(self, event : TwisterStatus) -> None:
+        '''
+            trigger state
+        '''
+        if event == TwisterStatus.NONE:
+            self.send("cycles_instance", event)
+            return
+
+        if self.current_state.id != "none_state":
+            self.send("cycles_instance", TwisterStatus.NONE)
+        self.send("cycles_instance", event)
+
+class TwisterSuiteStatusMachineInner(TwisterStateMachine):
+    '''
+        twister status state machine
+    '''
+    none_state = State(str(TwisterStatus.NONE), initial=True)
+    pass_state = State(str(TwisterStatus.PASS))
+    notrun_state = State(str(TwisterStatus.NOTRUN))
+    skip_state = State(str(TwisterStatus.SKIP))
+    filter_state = State(str(TwisterStatus.FILTER))
+    fail_state = State(str(TwisterStatus.FAIL))
+    error_state = State(str(TwisterStatus.ERROR))
+
+    # Define transitions
+    # for TestSuite
+    cycles_suite = (
+        none_state.to(fail_state,     cond="is_abnormal")
+        | none_state.to(pass_state,  cond="is_load_pass")
+        | none_state.to(skip_state,  cond="is_load_skip")
+        | none_state.to(filter_state,cond="is_load_filtered")
+        | none_state.to(error_state, cond="is_load_error")
+        | none_state.to(notrun_state,cond="is_load_build_only")
+        | fail_state.to(none_state,    cond="is_force")
+        | pass_state.to(none_state,    cond="is_force")
+        | skip_state.to(none_state,    cond="is_force")
+        | error_state.to(none_state,   cond="is_force")
+        | filter_state.to(none_state,  cond="is_force")
+        | none_state.to.itself(internal=True,    cond="is_force")
+        | fail_state.to.itself(internal=True,   cond="is_abnormal")
+        | pass_state.to.itself(internal=True,   cond="is_pass")
+        | skip_state.to.itself(internal=True,   cond="is_skip")
+        | error_state.to.itself(internal=True,  cond="is_error")
+        | notrun_state.to.itself(internal=True, cond="is_force")
+        | filter_state.to.itself(internal=True, cond="is_filtered")
+    )
+
+    def trigger_suite(self, event : TwisterStatus) -> None:
+        '''
+            trigger state
+        '''
+        self.send("cycles_suite", event)
+
+    def force_state_suite(self, event : TwisterStatus) -> None:
+        '''
+            trigger state
+        '''
+        if event == TwisterStatus.NONE:
+            self.send("cycles_suite", event)
+            return
+
+        if self.current_state.id != "none_state":
+            self.send("cycles_suite", TwisterStatus.NONE)
+        self.send("cycles_suite", event)
+
+class TwisterStatusMachine(ABC):
+    '''
+        TwisterStatusMachine abstract class
+    '''
+
+    @abstractmethod
+    def trigger(self, event : TwisterStatus):
+        pass
+
+    @abstractmethod
+    def force_state(self, event : TwisterStatus):
+        pass
+
+class TwisterStatusMachineCase(TwisterStatusMachine):
+    '''
+        TwisterStatusMachine_Case TestCase Statemachine
+    '''
+    def __init__(self, state=TwisterStatus.NONE):
+        self.current_state = state
+
+    def trigger(self, event : TwisterStatus) -> None:
+        check_enable = os.environ.get("TWISTER_STATUS_CHECK")
+        if check_enable:
+            tsm = TwisterCaseStatusMachineInner()
+            tsm.force_state_case(self.current_state)
+            try:
+                tsm.trigger_case(event)
+            except exceptions.TransitionNotAllowed:
+                # here we violate the pre-defined transition rules
+                logger.warning(f"Transition from {self.current_state} to {event} is not allowed.")
+                g()
+            finally:
+                self.force_state(event)
+        else:
+            self.force_state(event)
+
+    def force_state(self, event : TwisterStatus) -> None:
+        self.current_state = event
+
+class TwisterStatusMachineHarness(TwisterStatusMachine):
+    '''
+        TwisterStatusMachineHarness Harness Statemachine
+    '''
+    def __init__(self, state=TwisterStatus.NONE):
+        self.current_state = state
+
+    def trigger(self, event : TwisterStatus) -> None:
+        check_enable = os.environ.get("TWISTER_STATUS_CHECK")
+        if check_enable:
+            tsm = TwisterHarnessStatusMachineInner()
+            tsm.force_state_harness(self.current_state)
+            try:
+                tsm.trigger_harness(event)
+            except exceptions.TransitionNotAllowed:
+                # here we violate the pre-defined transition rules
+                logger.warning(f"Transition from {self.current_state} to {event} is not allowed.")
+                g()
+            finally:
+                self.force_state(event)
+        else:
+            self.force_state(event)
+
+    def force_state(self, event : TwisterStatus) -> None:
+        self.current_state = event
+
+class TwisterStatusMachineInstance(TwisterStatusMachine):
+    '''
+        TwisterStatusMachineInstance TestInstance Statemachine
+    '''
+    def __init__(self, state=TwisterStatus.NONE):
+        self.current_state = state
+
+    def trigger(self, event : TwisterStatus) -> None:
+        check_enable = os.environ.get("TWISTER_STATUS_CHECK")
+        if check_enable:
+            tsm = TwisterInstanceStatusMachineInner()
+            tsm.force_state_instance(self.current_state)
+            try:
+                tsm.trigger_instance(event)
+            except exceptions.TransitionNotAllowed:
+                # here we violate the pre-defined transition rules
+                logger.warning(f"Transition from {self.current_state} to {event} is not allowed.")
+                g()
+            finally:
+                self.force_state(event)
+        else:
+            self.force_state(event)
+
+    def force_state(self, event : TwisterStatus) -> None:
+        self.current_state = event
+
+class TwisterStatusMachineSuite(TwisterStatusMachine):
+    '''
+        TwisterStatusMachineSuite TestSuite Statemachine
+    '''
+    def __init__(self, state=TwisterStatus.NONE):
+        self.current_state = state
+
+    def trigger(self, event : TwisterStatus) -> None:
+        check_enable = os.environ.get("TWISTER_STATUS_CHECK")
+        if check_enable:
+            tsm = TwisterSuiteStatusMachineInner()
+            tsm.force_state_suite(self.current_state)
+            try:
+                tsm.trigger_suite(event)
+            except exceptions.TransitionNotAllowed:
+                # here we violate the pre-defined transition rules
+                logger.warning(f"Transition from {self.current_state} to {event} is not allowed.")
+                g()
+            finally:
+                self.force_state(event)
+        else:
+            self.force_state(event)
+
+    def force_state(self, event : TwisterStatus) -> None:
+        self.current_state = event
+
+def get_graph(tm: TwisterStateMachine, file_name: str)-> None:
+    '''
+        draw graphic
+    '''
+    graph = DotGraphMachine(tm)
+    dot = graph()
+    dot.write_png(file_name)
+
+def main():
+    # Initialize the colorama library
+    init()
+    os.environ["TWISTER_STATUS_CHECK"] = "y"
+    tm = TwisterStatusMachineCase()
+    serialized = pickle.dumps(tm)
+    deserialized = pickle.loads(serialized)
+    assert deserialized
+    tsm = TwisterCaseStatusMachineInner()
+    get_graph(tsm, "case.png")
+    tsm = TwisterHarnessStatusMachineInner()
+    get_graph(tsm, "harness.png")
+    tsm = TwisterInstanceStatusMachineInner()
+    get_graph(tsm, "instance.png")
+    tsm = TwisterSuiteStatusMachineInner()
+    get_graph(tsm, "suite.png")
+    tm.trigger(TwisterStatus.NONE)
+    assert str(tm.current_state) == TwisterStatus.NONE
+    tm.trigger(TwisterStatus.STARTED)
+    assert str(tm.current_state) == TwisterStatus.STARTED
+    tm.trigger(TwisterStatus.PASS)
+    assert str(tm.current_state) == TwisterStatus.PASS
+    tm.trigger(TwisterStatus.NONE)
+    assert str(tm.current_state) == TwisterStatus.NONE
+    tm.force_state(TwisterStatus.FILTER)
+    assert str(tm.current_state) == TwisterStatus.FILTER
+    tm.force_state(TwisterStatus.PASS)
+    assert str(tm.current_state) == TwisterStatus.PASS
+    tm.force_state(TwisterStatus.FAIL)
+    assert str(tm.current_state) == TwisterStatus.FAIL
+    tm.trigger(TwisterStatus.NONE)
+    assert str(tm.current_state) == TwisterStatus.NONE
+    tm.force_state(TwisterStatus.PASS)
+    assert str(tm.current_state) == TwisterStatus.PASS
+    tm.force_state(TwisterStatus.NONE)
+    assert str(tm.current_state) == TwisterStatus.NONE
+    tm.trigger(TwisterStatus.FILTER)
+    assert str(tm.current_state) == TwisterStatus.FILTER
+    print("ALL Tests PASS")
+
+if __name__ == "__main__":
+    main()

--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -1205,7 +1205,7 @@ class TestPlan:
         for filtered_instance in filtered_instances:
             change_skip_to_error_if_integration(self.options, filtered_instance)
 
-            filtered_instance.add_missing_case_status(filtered_instance.status)
+            filtered_instance.add_missing_case_status(TwisterStatus.FILTER)
 
     def add_instances(self, instance_list):
         for instance in instance_list:

--- a/scripts/requirements-build-test.txt
+++ b/scripts/requirements-build-test.txt
@@ -19,3 +19,10 @@ mypy
 
 # used for mocking functions in pytest
 mock>=4.0.1
+
+# used for twister statemachine
+python-statemachine>=2.3.6
+
+# to view the twister statemachine
+pydot
+graphviz


### PR DESCRIPTION
using statuemachine in status change.
in stastus.py we can generated the statuemachine
by get_graph

The purposes of this PR:

1. use statuemachine transition to verify the status change in twister runtime. if there is a violate, `TransitionNotAllowed` exception will be triggered, and call context will be print.
2. the transition is defined in the statues.py with class `TwisterStatusMachine_inner.cycles`, you can generate the status.png by run `python3 ./statues.py`
3. with this, we can see and control the status flow to avoid mis-use.
4. enable call stack print if a exception is triggered, in error.py
5. fix some status error found by this.