### PR TITLE
Bluetooth: Host: Fix monitor UART selection

### DIFF
--- a/subsys/bluetooth/host/monitor.c
+++ b/subsys/bluetooth/host/monitor.c
@@ -150,7 +150,15 @@ static void poll_out(char c)
 }
 #elif defined(CONFIG_BT_DEBUG_MONITOR_UART)
 static const struct device *const monitor_dev =
+#if DT_HAS_CHOSEN(zephyr_bt_mon_uart)
 	DEVICE_DT_GET(DT_CHOSEN(zephyr_bt_mon_uart));
+#elif !defined(CONFIG_UART_CONSOLE) && DT_HAS_CHOSEN(zephyr_console)
+	/* Fall back to console UART if it's available */
+	DEVICE_DT_GET(DT_CHOSEN(zephyr_console));
+#else
+	NULL;
+#error "BT_DEBUG_MONITOR_UART enabled but no UART specified"
+#endif
 
 static void poll_out(char c)
 {


### PR DESCRIPTION
Most boards set zephyr,bt-mon-uart to point at the same device as zephyr,console. It's still useful to have the possibility of having these as two different devices, however it's also useful to fall back to the UART console in case a dedicated monitor UART hasn't been specified.

This also ensures that the fallback only happens if the console UART isn't enabled, but a DT chosen property exists for it. Additionally, we now get a user friendly error in case the Bluetooth UART monitor feature has been enabled in Kconfig but there isn't a suitable UART available for it in devicetree.
