### PR TITLE
[Backport v3.6-branch] stream_flash: stream_flash_erase_page does not check whether requested offset is in range of stream flash owned area

### DIFF
--- a/include/zephyr/storage/stream_flash.h
+++ b/include/zephyr/storage/stream_flash.h
@@ -141,7 +141,8 @@ int stream_flash_erase_page(struct stream_flash_ctx *ctx, off_t off);
  * @param settings_key key to use with the settings module for loading
  *                     the stream write progress
  *
- * @return non-negative on success, negative errno code on fail
+ * @return non-negative on success, -ERANGE in case when @p off is out
+ * of area designated for stream or negative errno code on fail
  */
 int stream_flash_progress_load(struct stream_flash_ctx *ctx,
 			       const char *settings_key);

--- a/subsys/storage/stream/stream_flash.c
+++ b/subsys/storage/stream/stream_flash.c
@@ -79,6 +79,11 @@ int stream_flash_erase_page(struct stream_flash_ctx *ctx, off_t off)
 	int rc;
 	struct flash_pages_info page;
 
+	if (off < ctx->offset || (off - ctx->offset) >= ctx->available) {
+		LOG_ERR("Offset out of designated range");
+		return -ERANGE;
+	}
+
 	rc = flash_get_page_info_by_offs(ctx->fdev, off, &page);
 	if (rc != 0) {
 		LOG_ERR("Error %d while getting page info", rc);


### PR DESCRIPTION
Fixes https://github.com/zephyrproject-rtos/zephyr/issues/79800
failed backport: #80461