### PR TITLE
testsuite: coverage: fix typo in the CMakeLists.txt

### DIFF
--- a/subsys/testsuite/CMakeLists.txt
+++ b/subsys/testsuite/CMakeLists.txt
@@ -6,6 +6,6 @@ if(CONFIG_TEST)
   zephyr_include_directories(${ZEPHYR_BASE}/subsys/testsuite/include)
 endif()
 add_subdirectory_ifdef(CONFIG_COVERAGE_GCOV coverage)
-zephyr_include_directories_ifdef(CONFIG_COVERAGE_GCOV ${zephyr_BASE}/subsys/testsuite/coverage)
+zephyr_include_directories_ifdef(CONFIG_COVERAGE_GCOV ${ZEPHYR_BASE}/subsys/testsuite/coverage)
 
 zephyr_library_sources_ifdef(CONFIG_TEST_BUSY_SIM busy_sim/busy_sim.c)


### PR DESCRIPTION
`zephyr_BASE` should have been `ZEPHYR_BASE`, fix it.

Fixes #80723