### PR TITLE
include: devicetree: Add port and endpoint macros

### DIFF
--- a/drivers/video/video_emul_rx.c
+++ b/drivers/video/video_emul_rx.c
@@ -294,33 +294,10 @@ int emul_rx_init(const struct device *dev)
 	return 0;
 }
 
-/* See #80649 */
-
-/* Handle the variability of "ports{port@0{}};" vs "port{};" while going down */
-#define DT_INST_PORT_BY_ID(inst, pid)                                                              \
-	COND_CODE_1(DT_NODE_EXISTS(DT_INST_CHILD(inst, ports)),                                    \
-		    (DT_CHILD(DT_INST_CHILD(inst, ports), port_##pid)),                            \
-		    (DT_INST_CHILD(inst, port)))
-
-/* Handle the variability of "endpoint@0{};" vs "endpoint{};" while going down */
-#define DT_INST_ENDPOINT_BY_ID(inst, pid, eid)                                                     \
-	COND_CODE_1(DT_NODE_EXISTS(DT_CHILD(DT_INST_PORT_BY_ID(inst, pid), endpoint)),             \
-		    (DT_CHILD(DT_INST_PORT_BY_ID(inst, pid), endpoint)),                           \
-		    (DT_CHILD(DT_INST_PORT_BY_ID(inst, pid), endpoint_##eid)))
-
-/* Handle the variability of "ports{port@0{}};" vs "port{};" while going up */
-#define DT_ENDPOINT_PARENT_DEVICE(node)                                                            \
-	COND_CODE_1(DT_NODE_EXISTS(DT_CHILD(DT_GPARENT(node), port)),                              \
-		    (DT_GPARENT(node)), (DT_PARENT(DT_GPARENT(node))))
-
-/* Handle the "remote-endpoint-label" */
-#define DEVICE_DT_GET_REMOTE_DEVICE(node)                                                          \
-	DEVICE_DT_GET(DT_ENDPOINT_PARENT_DEVICE(                                                   \
-		DT_NODELABEL(DT_STRING_TOKEN(node, remote_endpoint_label))))
-
 #define EMUL_RX_DEFINE(n)                                                                          \
 	static const struct emul_rx_config emul_rx_cfg_##n = {                                     \
-		.source_dev = DEVICE_DT_GET_REMOTE_DEVICE(DT_INST_ENDPOINT_BY_ID(n, 0, 0)),        \
+		.source_dev =                                                                      \
+			DEVICE_DT_GET(DT_NODE_REMOTE_DEVICE(DT_INST_ENDPOINT_BY_ID(n, 0, 0))),     \
 	};                                                                                         \
                                                                                                    \
 	static struct emul_rx_data emul_rx_data_##n = {                                            \

--- a/drivers/video/video_mcux_csi.c
+++ b/drivers/video/video_mcux_csi.c
@@ -18,16 +18,6 @@
 #include <fsl_cache.h>
 #endif
 
-#if defined(CONFIG_VIDEO_MCUX_MIPI_CSI2RX)
-#define DEVICE_DT_INST_GET_SOURCE_DEV(n)                                                           \
-	DEVICE_DT_GET(DT_PARENT(DT_GPARENT(DT_NODELABEL(DT_STRING_TOKEN(                           \
-		DT_CHILD(DT_INST_CHILD(n, port), endpoint), remote_endpoint_label)))))
-#else
-#define DEVICE_DT_INST_GET_SOURCE_DEV(n)                                                           \
-	DEVICE_DT_GET(DT_GPARENT(DT_NODELABEL(DT_STRING_TOKEN(                                     \
-		DT_CHILD(DT_INST_CHILD(n, port), endpoint), remote_endpoint_label))))
-#endif
-
 struct video_mcux_csi_config {
 	CSI_Type *base;
 	const struct device *source_dev;
@@ -502,7 +492,7 @@ PINCTRL_DT_INST_DEFINE(0);
 
 static const struct video_mcux_csi_config video_mcux_csi_config_0 = {
 	.base = (CSI_Type *)DT_INST_REG_ADDR(0),
-	.source_dev = DEVICE_DT_INST_GET_SOURCE_DEV(0),
+	.source_dev = DEVICE_DT_GET(DT_NODE_REMOTE_DEVICE(DT_INST_ENDPOINT_BY_ID(0, 0, 0))),
 	.pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(0),
 };
 

--- a/drivers/video/video_mcux_mipi_csi2rx.c
+++ b/drivers/video/video_mcux_mipi_csi2rx.c
@@ -21,11 +21,6 @@ LOG_MODULE_REGISTER(video_mipi_csi2rx, CONFIG_VIDEO_LOG_LEVEL);
 
 #define ABS(a, b) (a > b ? a - b : b - a)
 
-#define DEVICE_DT_INST_GET_SENSOR_DEV(n)                                                           \
-	DEVICE_DT_GET(DT_GPARENT(DT_NODELABEL(                                                     \
-		DT_STRING_TOKEN(DT_CHILD(DT_CHILD(DT_INST_CHILD(n, ports), port_1), endpoint),     \
-				remote_endpoint_label))))
-
 struct mipi_csi2rx_config {
 	const MIPI_CSI2RX_Type *base;
 	const struct device *sensor_dev;
@@ -349,9 +344,7 @@ static int mipi_csi2rx_init(const struct device *dev)
 
 #define MIPI_CSI2RX_INIT(n)                                                                        \
 	static struct mipi_csi2rx_data mipi_csi2rx_data_##n = {                                    \
-		.csi2rxConfig.laneNum =                                                            \
-			DT_PROP_LEN(DT_CHILD(DT_CHILD(DT_INST_CHILD(n, ports), port_1), endpoint), \
-				    data_lanes),                                                   \
+		.csi2rxConfig.laneNum = DT_PROP_LEN(DT_INST_ENDPOINT_BY_ID(n, 1, 0), data_lanes),  \
 		.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(n)),                                \
 		.clock_root = (clock_control_subsys_t)DT_INST_CLOCKS_CELL_BY_IDX(n, 0, name),      \
 		.clock_ui = (clock_control_subsys_t)DT_INST_CLOCKS_CELL_BY_IDX(n, 1, name),        \
@@ -360,7 +353,8 @@ static int mipi_csi2rx_init(const struct device *dev)
                                                                                                    \
 	static const struct mipi_csi2rx_config mipi_csi2rx_config_##n = {                          \
 		.base = (MIPI_CSI2RX_Type *)DT_INST_REG_ADDR(n),                                   \
-		.sensor_dev = DEVICE_DT_INST_GET_SENSOR_DEV(n),                                    \
+		.sensor_dev =                                                                      \
+			DEVICE_DT_GET(DT_NODE_REMOTE_DEVICE(DT_INST_ENDPOINT_BY_ID(n, 1, 0))),     \
 	};                                                                                         \
                                                                                                    \
 	DEVICE_DT_INST_DEFINE(n, &mipi_csi2rx_init, NULL, &mipi_csi2rx_data_##n,                   \

--- a/dts/bindings/test/vnd,video-multi-port.yaml
+++ b/dts/bindings/test/vnd,video-multi-port.yaml
@@ -1,0 +1,14 @@
+# Copyright (c) 2024 tinyVision.ai Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+description: Test Video device
+
+compatible: "vnd,video-multi-port"
+
+child-binding:
+  child-binding:
+    child-binding:
+      include: video-interfaces.yaml
+      properties:
+        reg:
+          type: array

--- a/dts/bindings/test/vnd,video-single-port.yaml
+++ b/dts/bindings/test/vnd,video-single-port.yaml
@@ -1,0 +1,13 @@
+# Copyright (c) 2024 tinyVision.ai Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+description: Test Video device
+
+compatible: "vnd,video-single-port"
+
+child-binding:
+  child-binding:
+    include: video-interfaces.yaml
+    properties:
+      reg:
+        type: array

--- a/include/zephyr/devicetree.h
+++ b/include/zephyr/devicetree.h
@@ -5242,5 +5242,6 @@
 #include <zephyr/devicetree/can.h>
 #include <zephyr/devicetree/reset.h>
 #include <zephyr/devicetree/mbox.h>
+#include <zephyr/devicetree/port-endpoint.h>
 
 #endif /* ZEPHYR_INCLUDE_DEVICETREE_H_ */

--- a/include/zephyr/devicetree/port-endpoint.h
+++ b/include/zephyr/devicetree/port-endpoint.h
@@ -1,0 +1,275 @@
+/**
+ * @file
+ * @brief Port / Endpoint Devicetree macro public API header file.
+ */
+
+/*
+ * Copyright 2024 NXP
+ * Copyright (c) 2024 tinyVision.ai Inc
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_DEVICETREE_PORT_ENDPOINT_H_
+#define ZEPHYR_INCLUDE_DEVICETREE_PORT_ENDPOINT_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @defgroup devicetree-port-endpoint Devicetree Port Endpoint API
+ * @ingroup devicetree
+ * @{
+ */
+
+/**
+ * @brief Helper for @ref DT_INST_PORT_BY_ID
+ *
+ * This behaves the same way as @ref DT_INST_PORT_BY_ID but does not work if there is only
+ * a single port without address.
+ *
+ * @param inst instance number
+ * @param pid port ID
+ * @return port node associated with @p pid
+ */
+#define _DT_INST_PORT_BY_ID(inst, pid)                                                             \
+	COND_CODE_1(DT_NODE_EXISTS(DT_INST_CHILD(inst, ports)),                                    \
+	    (DT_CHILD(DT_INST_CHILD(inst, ports), port_##pid)), (DT_INST_CHILD(inst, port_##pid)))
+
+/**
+ * @brief Get a port node from its id
+ *
+ * Given a device instance number, return a port node specified by its ID.
+ * It handles various ways of how a port could be defined.
+ *
+ * Example usage with DT_INST_PORT_BY_ID() to get the @c port@0 or @c port node:
+ *
+ * @code{.c}
+ *	DT_INST_PORT_BY_ID(inst, 0)
+ * @endcode
+ *
+ * Example devicetree fragment:
+ *
+ * @code{.dts}
+ *	&device {
+ *		ports {
+ *			#address-cells = <1>;
+ *			#size-cells = <0>;
+ *			port@0 {
+ *				reg = <0x0>;
+ *			};
+ *		};
+ *	};
+ * @endcode
+ *
+ * @code{.dts}
+ *	&device {
+ *		#address-cells = <1>;
+ *		#size-cells = <0>;
+ *		port@0 {
+ *			reg = <0x0>;
+ *		};
+ *	};
+ * @endcode
+ *
+ * @code{.dts}
+ *	&device {
+ *		port {
+ *		};
+ *	};
+ * @endcode
+ *
+ * @param inst instance number
+ * @param pid port ID
+ * @return port node associated with @p pid
+ */
+#define DT_INST_PORT_BY_ID(inst, pid)                                                              \
+	COND_CODE_1(DT_NODE_EXISTS(_DT_INST_PORT_BY_ID(inst, pid)),                                \
+		(_DT_INST_PORT_BY_ID(inst, pid)), (DT_INST_CHILD(inst, port)))
+
+/**
+ * @brief Helper for @ref DT_INST_ENDPOINT_BY_ID
+ *
+ * This behaves the same way as @ref DT_INST_PORT_BY_ID but does not work if there is only
+ * a single endpoint without address.
+ *
+ * @param inst instance number
+ * @param pid port ID
+ * @param eid endpoint ID
+ * @return endpoint node associated with @p eid and @p pid
+ */
+#define _DT_INST_ENDPOINT_BY_ID(inst, pid, eid)                                                    \
+	DT_CHILD(DT_INST_PORT_BY_ID(inst, pid), endpoint_##eid)
+
+/**
+ * @brief Get an endpoint node from its id and its parent port id
+ *
+ * Given a device instance number, a port ID and an endpoint ID, return the endpoint node.
+ * It handles various ways of how a port and an endpoint could be defined as described in
+ * @ref DT_INST_PORT_BY_ID and below.
+ *
+ * Example usage with DT_INST_ENDPOINT_BY_ID() to get the @c endpoint or @c endpoint@0 node:
+ *
+ * @code{.c}
+ *	DT_INST_ENDPOINT_BY_ID(inst, 0, 0)
+ * @endcode
+ *
+ * Example devicetree fragment:
+ *
+ * @code{.dts}
+ *	&device {
+ *		port {
+ *			endpoint {
+ *			};
+ *		};
+ *	};
+ * @endcode
+ *
+ * @code{.dts}
+ *	&device {
+ *		port {
+ *			#address-cells = <1>;
+ *			#size-cells = <0>;
+ *			endpoint@0 {
+ *				reg = <0x0>;
+ *			};
+ *		};
+ *	};
+ * @endcode
+ *
+ * @code{.dts}
+ *	&device {
+ *		ports {
+ *			#address-cells = <1>;
+ *			#size-cells = <0>;
+ *			port@0 {
+ *				reg = <0x0>;
+ *				#address-cells = <1>;
+ *				#size-cells = <0>;
+ *				endpoint@0 {
+ *					reg = <0x0>;
+ *				};
+ *			};
+ *		};
+ *	};
+ * @endcode
+ *
+ * @param inst instance number
+ * @param pid port ID
+ * @param eid endpoint ID
+ * @return endpoint node associated with @p eid and @p pid
+ */
+#define DT_INST_ENDPOINT_BY_ID(inst, pid, eid)                                                     \
+	COND_CODE_1(DT_NODE_EXISTS(_DT_INST_ENDPOINT_BY_ID(inst, pid, eid)),                       \
+		(_DT_INST_ENDPOINT_BY_ID(inst, pid, eid)),                                         \
+			(DT_CHILD(DT_INST_PORT_BY_ID(inst, pid), endpoint)))
+
+/**
+ * @brief Get the device node from its endpoint node.
+ *
+ * Given an endpoint node id, return its device node id.
+ * This handles various ways of how a port and an endpoint could be defined as described in
+ * @ref DT_NODE_BY_ENDPOINT.
+ *
+ * Example usage with DT_NODE_BY_ENDPOINT() to get the @c &device node from its @c ep0 node:
+ *
+ * @code{.c}
+ *	DT_NODE_BY_ENDPOINT(DT_NODELABEL(ep0))
+ * @endcode
+ *
+ * Example devicetree fragment:
+ *
+ * @code{.dts}
+ *	&device {
+ *		port {
+ *			#address-cells = <1>;
+ *			#size-cells = <0>;
+ *			ep0: endpoint@0 {
+ *				reg = <0x0>;
+ *			};
+ *		};
+ *	};
+ * @endcode
+ *
+ * @code{.dts}
+ *	&device {
+ *		ports {
+ *			#address-cells = <1>;
+ *			#size-cells = <0>;
+ *			port@0 {
+ *				reg = <0x0>;
+ *				#address-cells = <1>;
+ *				#size-cells = <0>;
+ *				ep0: endpoint@0 {
+ *					reg = <0x0>;
+ *				};
+ *			};
+ *		};
+ *	};
+ * @endcode
+ *
+ * @param ep endpoint node
+ * @return device node associated with @p ep
+ */
+#define DT_NODE_BY_ENDPOINT(ep)                                                                    \
+	COND_CODE_1(DT_NODE_EXISTS(DT_CHILD(DT_PARENT(DT_GPARENT(ep)), ports)),                    \
+		(DT_PARENT(DT_GPARENT(ep))), (DT_GPARENT(ep)))
+
+/**
+ * @brief Get the remote device node from a local endpoint node.
+ *
+ * Given an endpoint node id, return the remote device node that connects to this device via this
+ * local endpoint. This handles various ways of how a port and an endpoint could be defined as
+ * described in @ref DT_INST_PORT_BY_ID and @ref DT_INST_ENDPOINT_BY_ID.
+ *
+ * Example usage with DT_NODE_REMOTE_DEVICE() to get the remote device node @c &device1 from the
+ * local endpoint @c endpoint@0 node of the device @c &device0 node:
+ *
+ * @code{.c}
+ *	DT_NODE_REMOTE_DEVICE(DT_NODELABEL(device0_ep_out))
+ * @endcode
+ *
+ * Example devicetree fragment:
+ *
+ * @code{.dts}
+ *	&device0 {
+ *		port {
+ *			#address-cells = <1>;
+ *			#size-cells = <0>;
+ *			device0_ep_out: endpoint@0 {
+ *				reg = <0x0>;
+ *				remote-endpoint-label = "device1_ep_in";
+ *			};
+ *		};
+ *	};
+ *
+ *	&device1 {
+ *		ports {
+ *			#address-cells = <1>;
+ *			#size-cells = <0>;
+ *			port@0 {
+ *				reg = <0x0>;
+ *				device1_ep_in: endpoint {
+ *					remote-endpoint-label = "device0_ep_out";
+ *				};
+ *			};
+ *		};
+ *	};
+ * @endcode
+ *
+ * @param ep endpoint node
+ * @return remote device node that connects to this device via @p ep
+ */
+#define DT_NODE_REMOTE_DEVICE(ep)                                                                \
+	DT_NODE_BY_ENDPOINT(DT_NODELABEL(DT_STRING_TOKEN(ep, remote_endpoint_label)))
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_DEVICETREE_PORT_ENDPOINT_H_ */

--- a/tests/lib/devicetree/api/app.overlay
+++ b/tests/lib/devicetree/api/app.overlay
@@ -506,6 +506,71 @@
 			status = "okay";
 		};
 
+		test_video0: video@10010000 {
+			compatible = "vnd,video-single-port";
+			reg = <0x10010000 0x1000>;
+
+			test_video0_port: port {
+				test_video0_out: endpoint {
+					remote-endpoint-label = "test_video2_port0_in0";
+				};
+			};
+		};
+
+		test_video1: video@10011000 {
+			compatible = "vnd,video-single-port";
+			reg = <0x10011000 0x1000>;
+
+			test_video1_port: port {
+				#address-cells = <1>;
+				#size-cells = <0>;
+
+				test_video1_out0: endpoint@0 {
+					reg = <0x0>;
+					remote-endpoint-label = "test_video2_port0_in1";
+				};
+
+				test_video1_out1: endpoint@1 {
+					reg = <0x1>;
+					remote-endpoint-label = "test_video2_port1_in";
+				};
+			};
+		};
+
+		test_video2: video@10012000 {
+			compatible = "vnd,video-multi-port";
+			reg = <0x10012000 0x1000>;
+
+			ports {
+				#address-cells = <1>;
+				#size-cells = <0>;
+
+				test_video2_port0: port@0 {
+					reg = <0x0>;
+					#address-cells = <1>;
+					#size-cells = <0>;
+
+					test_video2_port0_in0: endpoint@0 {
+						reg = <0x0>;
+						remote-endpoint-label = "test_video0_out";
+					};
+
+					test_video2_port0_in1: endpoint@1 {
+						reg = <0x1>;
+						remote-endpoint-label = "test_video1_out0";
+					};
+				};
+
+				test_video2_port1: port@1 {
+					reg = <0x1>;
+
+					test_video2_port1_in: endpoint {
+						remote-endpoint-label = "test_video1_out1";
+					};
+				};
+			};
+		};
+
 		test_pwm1: pwm@55551111 {
 			compatible = "vnd,pwm";
 			#pwm-cells = <3>;

--- a/tests/lib/devicetree/api/src/main.c
+++ b/tests/lib/devicetree/api/src/main.c
@@ -76,6 +76,20 @@
 #define TEST_DMA_CTLR_1 DT_NODELABEL(test_dma1)
 #define TEST_DMA_CTLR_2 DT_NODELABEL(test_dma2)
 
+#define TEST_VIDEO2           DT_NODELABEL(test_video2)
+#define TEST_VIDEO2_PORT0     DT_NODELABEL(test_video2_port0)
+#define TEST_VIDEO2_PORT0_IN0 DT_NODELABEL(test_video2_port0_in0)
+#define TEST_VIDEO2_PORT0_IN1 DT_NODELABEL(test_video2_port0_in1)
+#define TEST_VIDEO2_PORT1     DT_NODELABEL(test_video2_port1)
+#define TEST_VIDEO2_PORT1_IN  DT_NODELABEL(test_video2_port1_in)
+#define TEST_VIDEO0           DT_NODELABEL(test_video0)
+#define TEST_VIDEO0_OUT       DT_NODELABEL(test_video0_out)
+#define TEST_VIDEO0_PORT      DT_NODELABEL(test_video0_port)
+#define TEST_VIDEO1           DT_NODELABEL(test_video1)
+#define TEST_VIDEO1_OUT0      DT_NODELABEL(test_video1_out0)
+#define TEST_VIDEO1_OUT1      DT_NODELABEL(test_video1_out1)
+#define TEST_VIDEO1_PORT      DT_NODELABEL(test_video1_port)
+
 #define TEST_IO_CHANNEL_CTLR_1 DT_NODELABEL(test_adc_1)
 #define TEST_IO_CHANNEL_CTLR_2 DT_NODELABEL(test_adc_2)
 
@@ -1307,6 +1321,78 @@ ZTEST(devicetree_api, test_dma)
 	zassert_true(DT_INST_DMAS_HAS_IDX(0, 1), "");
 	zassert_false(DT_DMAS_HAS_IDX(TEST_TEMP, 2), "");
 	zassert_false(DT_INST_DMAS_HAS_IDX(0, 2), "");
+}
+
+#undef DT_DRV_COMPAT
+DT_FOREACH_STATUS_OKAY_VARGS(vnd_video_single_port, DEVICE_DT_DEFINE, NULL, NULL, NULL, NULL,
+			     POST_KERNEL, CONFIG_APPLICATION_INIT_PRIORITY, NULL);
+DT_FOREACH_STATUS_OKAY_VARGS(vnd_video_multi_port, DEVICE_DT_DEFINE, NULL, NULL, NULL, NULL,
+			     POST_KERNEL, CONFIG_APPLICATION_INIT_PRIORITY, NULL);
+ZTEST(devicetree_api, test_video)
+{
+	/* DT_INST_PORT_BY_ID */
+#define DT_DRV_COMPAT vnd_video_single_port
+	zassert_true(DT_SAME_NODE(DT_INST_PORT_BY_ID(0, 0),
+				  TEST_VIDEO0_PORT), "get port node of video0");
+	zassert_true(DT_SAME_NODE(DT_INST_PORT_BY_ID(1, 0), TEST_VIDEO1_PORT),
+		     "get port node of video1");
+#undef DT_DRV_COMPAT
+#define DT_DRV_COMPAT vnd_video_multi_port
+	zassert_true(DT_SAME_NODE(DT_INST_PORT_BY_ID(0, 0), TEST_VIDEO2_PORT0),
+		     "get port@0 node of video2");
+	zassert_true(DT_SAME_NODE(DT_INST_PORT_BY_ID(0, 1), TEST_VIDEO2_PORT1),
+		     "get port@1 node of video2");
+#undef DT_DRV_COMPAT
+
+	/* DT_INST_ENDPOINT_BY_ID */
+#define DT_DRV_COMPAT vnd_video_single_port
+	zassert_true(DT_SAME_NODE(DT_INST_ENDPOINT_BY_ID(0, 0, 0), TEST_VIDEO0_OUT),
+		     "get endpoint node of port node of video0");
+	zassert_true(DT_SAME_NODE(DT_INST_ENDPOINT_BY_ID(1, 0, 0), TEST_VIDEO1_OUT0),
+		     "get endpoint@0 node of port node of video1");
+	zassert_true(DT_SAME_NODE(DT_INST_ENDPOINT_BY_ID(1, 0, 1), TEST_VIDEO1_OUT1),
+		     "get endpoint@1 node of port node of video1");
+#undef DT_DRV_COMPAT
+#define DT_DRV_COMPAT vnd_video_multi_port
+	zassert_true(DT_SAME_NODE(DT_INST_ENDPOINT_BY_ID(0, 0, 0), TEST_VIDEO2_PORT0_IN0),
+		     "get endpoint@0 node of port@0 node of video2");
+	zassert_true(DT_SAME_NODE(DT_INST_ENDPOINT_BY_ID(0, 0, 1), TEST_VIDEO2_PORT0_IN1),
+		     "get endpoint@1 node of port@0 node of video2");
+	zassert_true(DT_SAME_NODE(DT_INST_ENDPOINT_BY_ID(0, 1, 0), TEST_VIDEO2_PORT1_IN),
+		     "get endpoint node of port@1 node of video2");
+#undef DT_DRV_COMPAT
+
+	/* DT_NODE_BY_ENDPOINT */
+	zassert_true(DT_SAME_NODE(DT_NODE_BY_ENDPOINT(TEST_VIDEO0_OUT),
+				  TEST_VIDEO0), "get video0 node from its endpoint");
+	zassert_true(DT_SAME_NODE(DT_NODE_BY_ENDPOINT(TEST_VIDEO1_OUT0), TEST_VIDEO1),
+		     "get video1 node from its endpoint@0");
+	zassert_true(DT_SAME_NODE(DT_NODE_BY_ENDPOINT(TEST_VIDEO1_OUT1), TEST_VIDEO1),
+		     "get video1 node from its endpoint@1");
+	zassert_true(DT_SAME_NODE(DT_NODE_BY_ENDPOINT(TEST_VIDEO2_PORT0_IN0), TEST_VIDEO2),
+		     "get video2 node from its endpoint@0 at port@0");
+	zassert_true(DT_SAME_NODE(DT_NODE_BY_ENDPOINT(TEST_VIDEO2_PORT0_IN1), TEST_VIDEO2),
+		     "get video2 node from its endpoint@1 at port@0");
+	zassert_true(DT_SAME_NODE(DT_NODE_BY_ENDPOINT(TEST_VIDEO2_PORT1_IN), TEST_VIDEO2),
+		     "get video2 node from its endpoint at port@1");
+
+	/* DT_NODE_REMOTE_DEVICE */
+#define DT_DRV_COMPAT vnd_video_single_port
+	zassert_true(DT_SAME_NODE(DT_NODE_REMOTE_DEVICE(TEST_VIDEO0_OUT), TEST_VIDEO2),
+			 "get remote device node of video0's endpoint");
+	zassert_true(DT_SAME_NODE(DT_NODE_REMOTE_DEVICE(TEST_VIDEO1_OUT0), TEST_VIDEO2),
+		     "get remote device node of video1's endpoint@0");
+	zassert_true(DT_SAME_NODE(DT_NODE_REMOTE_DEVICE(TEST_VIDEO1_OUT1), TEST_VIDEO2),
+		     "get remote device node of video1's endpoint@1");
+#undef DT_DRV_COMPAT
+#define DT_DRV_COMPAT vnd_video_multi_port
+	zassert_true(DT_SAME_NODE(DT_NODE_REMOTE_DEVICE(TEST_VIDEO2_PORT0_IN0), TEST_VIDEO0),
+		     "get remote device node of video2's port@0 endpoint@0");
+	zassert_true(DT_SAME_NODE(DT_NODE_REMOTE_DEVICE(TEST_VIDEO2_PORT0_IN1), TEST_VIDEO1),
+		     "get remote device node of video2's port@0 endpoint@1");
+	zassert_true(DT_SAME_NODE(DT_NODE_REMOTE_DEVICE(TEST_VIDEO2_PORT1_IN), TEST_VIDEO1),
+		     "get remote device node of video2's port@1 endpoint");
+#undef DT_DRV_COMPAT
 }
 
 #undef DT_DRV_COMPAT


### PR DESCRIPTION
This PR adds some port / endpoint DT helpers for the video drivers or others (e.g. display) and some examples of their _simple_ usage in video drivers. Two main macros helpers are

- `DT_INST_ENDPOINT_BY_ID(inst, pid, id)` : to get the (local) endpoint node id from a port id and an endpoint id
- `DT_NODE_REMOTE_DEVICE(ep)` : to get the peer remote device node from the local endpoint node

_A typical usage would be parsing all endpoints in a loop, or automatically parsing all endpoints till the end._