### PR TITLE
tests: counter: RW612 dts overlay support for basic_api tests

### DIFF
--- a/tests/drivers/counter/counter_basic_api/boards/frdm_rw612.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/frdm_rw612.overlay
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 NXP
+ * Copyright 2024 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */


### PR DESCRIPTION
Remove memory spaces not needed for the counter_basic_api test for RW612 boards. Add frdm_rw612.overlay

Fixes #80650