### PR TITLE
boards: beaglev_fire: improve docs, fix uart, expand RAM

### DIFF
--- a/boards/beagle/beaglev_fire/beaglev_fire_common.dtsi
+++ b/boards/beagle/beaglev_fire/beaglev_fire_common.dtsi
@@ -14,6 +14,18 @@
 	compatible = "beagle,beaglev-fire", "microchip,mpfs";
 	aliases {
 	};
+
+	chosen {
+		zephyr,console = &uart0;
+		zephyr,shell-uart = &uart0;
+		zephyr,sram = &sram1;
+	};
+};
+
+&uart0 {
+	status = "okay";
+	current-speed = <115200>;
+	clock-frequency = <150000000>;
 };
 
 &gpio2 {

--- a/boards/beagle/beaglev_fire/beaglev_fire_common.dtsi
+++ b/boards/beagle/beaglev_fire/beaglev_fire_common.dtsi
@@ -15,6 +15,13 @@
 	aliases {
 	};
 
+	soc {
+		sram1: memory@80000000 {
+			compatible = "mmio-sram";
+			reg = <0x80000000 0x77F80000>; /* Size = 2GB - 0x80000 */
+		};
+	};
+
 	chosen {
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;

--- a/boards/beagle/beaglev_fire/beaglev_fire_common.dtsi
+++ b/boards/beagle/beaglev_fire/beaglev_fire_common.dtsi
@@ -15,17 +15,20 @@
 	aliases {
 	};
 
-	soc {
-		sram1: memory@80000000 {
+	beaglev {
+		#address-cells = <2>;
+		#size-cells = <1>;
+
+		ddr_cached_high: memory@1000000000 {
 			compatible = "mmio-sram";
-			reg = <0x80000000 0x77F80000>; /* Size = 2GB - 0x80000 */
+			reg = <0x10 0x00000000 0x80000000>; /* 2GB */
 		};
 	};
 
 	chosen {
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
-		zephyr,sram = &sram1;
+		zephyr,sram = &ddr_cached_high;
 	};
 };
 

--- a/boards/beagle/beaglev_fire/beaglev_fire_polarfire_e51.dts
+++ b/boards/beagle/beaglev_fire/beaglev_fire_polarfire_e51.dts
@@ -21,16 +21,4 @@
 			status = "disabled";
 		};
 	};
-
-	chosen {
-		zephyr,console = &uart0;
-		zephyr,shell-uart = &uart0;
-		zephyr,sram = &sram1;
-	};
-};
-
-&uart0 {
-	status = "okay";
-	current-speed = <115200>;
-	clock-frequency = <150000000>;
 };

--- a/boards/beagle/beaglev_fire/beaglev_fire_polarfire_e51.yaml
+++ b/boards/beagle/beaglev_fire/beaglev_fire_polarfire_e51.yaml
@@ -4,7 +4,7 @@ type: mcu
 arch: riscv
 toolchain:
   - zephyr
-ram: 3840
+ram: 2012741
 testing:
   ignore_tags:
     - net

--- a/boards/beagle/beaglev_fire/beaglev_fire_polarfire_e51.yaml
+++ b/boards/beagle/beaglev_fire/beaglev_fire_polarfire_e51.yaml
@@ -4,7 +4,7 @@ type: mcu
 arch: riscv
 toolchain:
   - zephyr
-ram: 2012741
+ram: 2048000
 testing:
   ignore_tags:
     - net

--- a/boards/beagle/beaglev_fire/beaglev_fire_polarfire_u54.dts
+++ b/boards/beagle/beaglev_fire/beaglev_fire_polarfire_u54.dts
@@ -5,21 +5,9 @@
 	model = "beagle,beaglev-fire";
 	compatible = "beagle,beaglev-fire", "microchip,mpfs";
 
-	chosen {
-		zephyr,console = &uart1;
-		zephyr,shell-uart = &uart1;
-		zephyr,sram = &sram1;
-	};
-
 	cpus {
 		cpu@0 {
 			status = "disabled";
 		};
 	};
-};
-
-&uart1 {
-	status = "okay";
-	current-speed = <115200>;
-	clock-frequency = <150000000>;
 };

--- a/boards/beagle/beaglev_fire/beaglev_fire_polarfire_u54.yaml
+++ b/boards/beagle/beaglev_fire/beaglev_fire_polarfire_u54.yaml
@@ -4,7 +4,7 @@ type: mcu
 arch: riscv
 toolchain:
   - zephyr
-ram: 3840
+ram: 2012741
 testing:
   ignore_tags:
     - net

--- a/boards/beagle/beaglev_fire/beaglev_fire_polarfire_u54.yaml
+++ b/boards/beagle/beaglev_fire/beaglev_fire_polarfire_u54.yaml
@@ -4,7 +4,7 @@ type: mcu
 arch: riscv
 toolchain:
   - zephyr
-ram: 2012741
+ram: 2048000
 testing:
   ignore_tags:
     - net

--- a/boards/beagle/beaglev_fire/beaglev_fire_polarfire_u54_smp.dts
+++ b/boards/beagle/beaglev_fire/beaglev_fire_polarfire_u54_smp.dts
@@ -4,16 +4,4 @@
 / {
 	model = "beagle,beaglev-fire";
 	compatible = "beagle,beaglev-fire", "microchip,mpfs";
-
-	chosen {
-		zephyr,console = &uart1;
-		zephyr,shell-uart = &uart1;
-		zephyr,sram = &sram1;
-	};
-};
-
-&uart1 {
-	status = "okay";
-	current-speed = <115200>;
-	clock-frequency = <150000000>;
 };

--- a/boards/beagle/beaglev_fire/beaglev_fire_polarfire_u54_smp.yaml
+++ b/boards/beagle/beaglev_fire/beaglev_fire_polarfire_u54_smp.yaml
@@ -4,7 +4,7 @@ type: mcu
 arch: riscv
 toolchain:
   - zephyr
-ram: 3840
+ram: 2012741
 testing:
   ignore_tags:
     - net

--- a/boards/beagle/beaglev_fire/beaglev_fire_polarfire_u54_smp.yaml
+++ b/boards/beagle/beaglev_fire/beaglev_fire_polarfire_u54_smp.yaml
@@ -4,7 +4,7 @@ type: mcu
 arch: riscv
 toolchain:
   - zephyr
-ram: 2012741
+ram: 2048000
 testing:
   ignore_tags:
     - net

--- a/boards/beagle/beaglev_fire/doc/index.rst
+++ b/boards/beagle/beaglev_fire/doc/index.rst
@@ -93,12 +93,12 @@ When using the PolarFire `Hart Software Services <https://github.com/polarfire-s
 
   # Define the entry point address for each hart (U54 cores)
   hart-entry-points:
-    u54_1: '0x80000000'
+    u54_1: '0x1000000000'
 
   # Define the payloads (ELF binaries or raw blobs)
   payloads:
     <path_to_zephyr.elf>:
-      exec-addr: '0x80000000'  # Where Zephyr should be loaded
+      exec-addr: '0x1000000000'  # Where Zephyr should be loaded
       owner-hart: u54_1  # Primary hart that runs Zephyr
       priv-mode: prv_m  # Start in Machine mode
       skip-opensbi: true  # Boot directly without OpenSBI

--- a/boards/beagle/beaglev_fire/doc/index.rst
+++ b/boards/beagle/beaglev_fire/doc/index.rst
@@ -15,11 +15,17 @@ hobbyists, and researchers to explore and experiment with RISC-V technology.
 Building
 ========
 
+There are three board configurations provided for the BeagleV-Fire:
+
+* ``beaglev_fire_polarfire_e51``: Uses only the E51 core
+* ``beaglev_fire_polarfire_u54``: Uses the U54 cores
+* ``beaglev_fire_polarfire_u54_smp``: Uses the U54 cores with CONFIG_SMP=y
+
 Applications for the ``beaglev_fire`` board configuration can be built as usual:
 
 .. zephyr-app-commands::
    :zephyr-app: samples/hello_world
-   :board: beaglev_fire
+   :board: beaglev_fire_polarfire_u54
    :goals: build
 
 Debugging
@@ -76,3 +82,49 @@ and load the binary:
    load
    break main
    continue
+
+Flashing
+========
+When using the PolarFire `Hart Software Services <https://github.com/polarfire-soc/hart-software-services>`_ along with Zephyr, you need to use the `hss-payload-generator <https://github.com/polarfire-soc/hart-software-services/tree/master/tools/hss-payload-generator>`_ tool to generate an image that HSS can boot.
+
+.. code-block:: yaml
+
+  set-name: 'ZephyrImage'
+
+  # Define the entry point address for each hart (U54 cores)
+  hart-entry-points:
+    u54_1: '0x80000000'
+
+  # Define the payloads (ELF binaries or raw blobs)
+  payloads:
+    <path_to_zephyr.elf>:
+      exec-addr: '0x80000000'  # Where Zephyr should be loaded
+      owner-hart: u54_1  # Primary hart that runs Zephyr
+      priv-mode: prv_m  # Start in Machine mode
+      skip-opensbi: true  # Boot directly without OpenSBI
+
+After generating the image, you can flash it to the board by restarting a board that's connected over USB and UART, interrupting the HSS boot process with a key press, and then running the ``mmc`` and ``usbdmsc`` commands:
+
+.. code-block:: bash
+
+  Press a key to enter CLI, ESC to skip
+  Timeout in 1 second
+  .[6.304162] Character 100 pressed
+  [6.308415] Type HELP for list of commands
+  [6.313276] >> mmc
+  [10.450867] Selecting SDCARD/MMC (fallback) as boot source ...
+  [10.457550] Attempting to select eMMC ... Passed
+  [10.712708] >> usbdmsc
+  [14.732841] initialize MMC
+  [14.736400] Attempting to select eMMC ... Passed
+  [15.168707] MMC - 512 byte pages, 512 byte blocks, 30621696 pages
+  Waiting for USB Host to connect... (CTRL-C to quit)
+  . 0 bytes written, 0 bytes read
+  USB Host connected. Waiting for disconnect... (CTRL-C to quit)
+  / 0 bytes written, 219136 bytes read
+
+This will cause the board to appear as a USB mass storage device. You can then then flash the image with ``dd`` or other tools like `BalenaEtcher <https://www.balena.io/etcher/>`_:
+
+.. code-block:: bash
+
+  dd if=<path_to_zephyr.elf> of=/dev/sdXD bs=4M status=progress oflag=sync

--- a/boards/beagle/beaglev_fire/doc/index.rst
+++ b/boards/beagle/beaglev_fire/doc/index.rst
@@ -17,15 +17,15 @@ Building
 
 There are three board configurations provided for the BeagleV-Fire:
 
-* ``beaglev_fire_polarfire_e51``: Uses only the E51 core
-* ``beaglev_fire_polarfire_u54``: Uses the U54 cores
-* ``beaglev_fire_polarfire_u54_smp``: Uses the U54 cores with CONFIG_SMP=y
+* ``beaglev_fire/polarfire/e51``: Uses only the E51 core
+* ``beaglev_fire/polarfire/u54``: Uses the U54 cores
+* ``beaglev_fire/polarfire/u54/smp``: Uses the U54 cores with CONFIG_SMP=y
 
 Applications for the ``beaglev_fire`` board configuration can be built as usual:
 
 .. zephyr-app-commands::
    :zephyr-app: samples/hello_world
-   :board: beaglev_fire_polarfire_u54
+   :board: beaglev_fire/polarfire/u54
    :goals: build
 
 Debugging


### PR DESCRIPTION
This PR makes three small changes, all aimed at improving BeagleV-Fire support.

### Update documentation
Aside from some minor clarifications, a "Flashing" section was added, since the steps to flash the Fire in a way that's compatible with the Microchip-provided [Hart Software Services](https://github.com/polarfire-soc/hart-software-services) (HSS) is not readily accomplished with `west/make flash`. An example of west scripts that are able to flash the Fire can be seen [here](https://github.com/polarfire-soc/zephyr-applications/), but I doubt this ought to live in Zephyr proper.

### Change selected UART
In https://github.com/zephyrproject-rtos/zephyr/commit/166b9bf35acc3a6c8a3665c11fa6e9b7054506c0#diff-01f5d360c1043dce50bf74fbb1cc056d2049160741e483f843c19d081c065252R18 the selected UART was changed from `uart0` to `uart1`, presumably to mirror the changes made to the other PolarFire boards. While this makes sense to do for the Icicle kit, from looking at the [Fire's schematics](https://git.beagleboard.org/beaglev-fire/beaglev-fire/-/blob/main/BeagleV-Fire_sch.pdf), I don't believe any of the UARTs other than `uart0` is hooked up to anything. 

### Expand available RAM
`sram0` is a relatively small region of RAM, meant to be used by the HSS (see [Linux device tree](https://github.com/linux4sam/linux-at91/blob/bf96df830936986fdb3c7789749ff599300dae01/arch/riscv/boot/dts/microchip/mpfs-beaglev-fire.dts#L73)). I see no reason why `sram1` shouldn't occupy the remaining ~2GB present on the Fire. I'm a Zephyr newbie, however, so I'm not sure if there are any reasons why you would want to limit the RAM defined.