### PR TITLE
scripts: twister: Fix serial_py referenced before assignment

### DIFF
--- a/scripts/pylib/twister/twisterlib/hardwaremap.py
+++ b/scripts/pylib/twister/twisterlib/hardwaremap.py
@@ -257,6 +257,7 @@ class HardwareMap:
             flash_with_test = dut.get('flash_with_test')
             if flash_with_test is None:
                 flash_with_test = self.options.device_flash_with_test
+            serial_pty = dut.get('serial_pty')
             flash_before = dut.get('flash_before')
             if flash_before is None:
                 flash_before = self.options.flash_before and (not (flash_with_test or serial_pty))
@@ -264,7 +265,6 @@ class HardwareMap:
             id = dut.get('id')
             runner = dut.get('runner')
             runner_params = dut.get('runner_params')
-            serial_pty = dut.get('serial_pty')
             serial = dut.get('serial')
             baud = dut.get('baud', None)
             product = dut.get('product')


### PR DESCRIPTION
This fixes `serial_py referenced before assignment` if `flash_before` is set.