### PR TITLE
scripts: twister: Add Espressif as manufacturer

### DIFF
--- a/scripts/pylib/twister/twisterlib/hardwaremap.py
+++ b/scripts/pylib/twister/twisterlib/hardwaremap.py
@@ -147,7 +147,8 @@ class HardwareMap:
         'FTDI',
         'Digilent',
         'Microsoft',
-        'Nuvoton'
+        'Nuvoton',
+        'Espressif',
     ]
 
     runner_mapping = {


### PR DESCRIPTION
Adds Espressif as manufacturer so that generation of HW-Map file is possible

Signed-off-by: Armin Kessler ake@espros.com