### PR TITLE
drivers: video: Fix blocking `video_buffer_alloc`

### DIFF
--- a/doc/releases/migration-guide-4.1.rst
+++ b/doc/releases/migration-guide-4.1.rst
@@ -75,6 +75,9 @@ Device Drivers and Devicetree
 
     * :c:struct:`adc_driver_api`
 
+* The :c:func:`video_buffer_alloc` and :c:func:`video_buffer_aligned_alloc` functions in the
+  video API now take an additional timeout parameter.
+
 ADC
 ===
 

--- a/drivers/video/video_common.c
+++ b/drivers/video/video_common.c
@@ -31,7 +31,7 @@ struct mem_block {
 
 static struct mem_block video_block[CONFIG_VIDEO_BUFFER_POOL_NUM_MAX];
 
-struct video_buffer *video_buffer_aligned_alloc(size_t size, size_t align)
+struct video_buffer *video_buffer_aligned_alloc(size_t size, size_t align, k_timeout_t timeout)
 {
 	struct video_buffer *vbuf = NULL;
 	struct mem_block *block;
@@ -51,7 +51,7 @@ struct video_buffer *video_buffer_aligned_alloc(size_t size, size_t align)
 	}
 
 	/* Alloc buffer memory */
-	block->data = VIDEO_COMMON_HEAP_ALLOC(align, size, K_FOREVER);
+	block->data = VIDEO_COMMON_HEAP_ALLOC(align, size, timeout);
 	if (block->data == NULL) {
 		return NULL;
 	}
@@ -63,9 +63,9 @@ struct video_buffer *video_buffer_aligned_alloc(size_t size, size_t align)
 	return vbuf;
 }
 
-struct video_buffer *video_buffer_alloc(size_t size)
+struct video_buffer *video_buffer_alloc(size_t size, k_timeout_t timeout)
 {
-	return video_buffer_aligned_alloc(size, sizeof(void *));
+	return video_buffer_aligned_alloc(size, sizeof(void *), timeout);
 }
 
 void video_buffer_release(struct video_buffer *vbuf)

--- a/include/zephyr/drivers/video.h
+++ b/include/zephyr/drivers/video.h
@@ -732,19 +732,21 @@ static inline int video_set_signal(const struct device *dev, enum video_endpoint
  *
  * @param size Size of the video buffer (in bytes).
  * @param align Alignment of the requested memory, must be a power of two.
+ * @param timeout Timeout duration or K_NO_WAIT
  *
  * @retval pointer to allocated video buffer
  */
-struct video_buffer *video_buffer_aligned_alloc(size_t size, size_t align);
+struct video_buffer *video_buffer_aligned_alloc(size_t size, size_t align, k_timeout_t timeout);
 
 /**
  * @brief Allocate video buffer.
  *
  * @param size Size of the video buffer (in bytes).
+ * @param timeout Timeout duration or K_NO_WAIT
  *
  * @retval pointer to allocated video buffer
  */
-struct video_buffer *video_buffer_alloc(size_t size);
+struct video_buffer *video_buffer_alloc(size_t size, k_timeout_t timeout);
 
 /**
  * @brief Release a video buffer.

--- a/samples/drivers/video/capture/src/main.c
+++ b/samples/drivers/video/capture/src/main.c
@@ -211,7 +211,8 @@ int main(void)
 		 * For some hardwares, such as the PxP used on i.MX RT1170 to do image rotation,
 		 * buffer alignment is needed in order to achieve the best performance
 		 */
-		buffers[i] = video_buffer_aligned_alloc(bsize, CONFIG_VIDEO_BUFFER_POOL_ALIGN);
+		buffers[i] = video_buffer_aligned_alloc(bsize, CONFIG_VIDEO_BUFFER_POOL_ALIGN,
+							K_FOREVER);
 		if (buffers[i] == NULL) {
 			LOG_ERR("Unable to alloc video buffer");
 			return 0;

--- a/samples/drivers/video/capture_to_lvgl/src/main.c
+++ b/samples/drivers/video/capture_to_lvgl/src/main.c
@@ -97,7 +97,7 @@ int main(void)
 
 	/* Alloc video buffers and enqueue for capture */
 	for (i = 0; i < ARRAY_SIZE(buffers); i++) {
-		buffers[i] = video_buffer_alloc(bsize);
+		buffers[i] = video_buffer_alloc(bsize, K_FOREVER);
 		if (buffers[i] == NULL) {
 			LOG_ERR("Unable to alloc video buffer");
 			return 0;

--- a/samples/drivers/video/tcpserversink/src/main.c
+++ b/samples/drivers/video/tcpserversink/src/main.c
@@ -105,7 +105,7 @@ int main(void)
 
 	/* Alloc Buffers */
 	for (i = 0; i < ARRAY_SIZE(buffers); i++) {
-		buffers[i] = video_buffer_alloc(fmt.pitch * fmt.height);
+		buffers[i] = video_buffer_alloc(fmt.pitch * fmt.height, K_FOREVER);
 		if (buffers[i] == NULL) {
 			LOG_ERR("Unable to alloc video buffer");
 			return 0;

--- a/tests/drivers/video/api/src/video_emul.c
+++ b/tests/drivers/video/api/src/video_emul.c
@@ -157,7 +157,7 @@ ZTEST(video_common, test_video_vbuf)
 	zexpect_ok(video_set_format(rx_dev, VIDEO_EP_OUT, &fmt));
 
 	/* Allocate a buffer, assuming prj.conf gives enough memory for it */
-	vbuf = video_buffer_alloc(fmt.pitch * fmt.height);
+	vbuf = video_buffer_alloc(fmt.pitch * fmt.height, K_FOREVER);
 	zexpect_not_null(vbuf);
 
 	/* Start the virtual hardware */


### PR DESCRIPTION
This PR fixes a blocking call to `video_buffer_alloc` in case of memory shortage by introducing a the Kconfig option `CONFIG_VIDEO_BUFFER_ALLOC_TIMEOUT`. 

I've added a new Kconfig option for backwards compatibility, but I'm open to alternative approaches.