### PR TITLE
bluetooth: mesh: Mark BT_MESH_USES_TINYCRYPT as deprecated

### DIFF
--- a/doc/releases/release-notes-4.0.rst
+++ b/doc/releases/release-notes-4.0.rst
@@ -146,6 +146,13 @@ Bluetooth
 
 * HCI Drivers
 
+* Mesh
+
+  * The :kconfig:option:`CONFIG_BT_MESH_USES_TINYCRYPT` Kconfig option is marked as deprecated. The
+    reason is that the TinyCrypt library is deprecated and will be removed in a future release.
+    The :kconfig:option:`CONFIG_BT_MESH_USES_MBEDTLS_PSA` option should be used from now on.
+    Changing this option requires devices to be unprovisioned as the keys will not be restored.
+
 Boards & SoC Support
 ********************
 

--- a/subsys/bluetooth/mesh/Kconfig
+++ b/subsys/bluetooth/mesh/Kconfig
@@ -1412,6 +1412,7 @@ config BT_MESH_USES_TINYCRYPT
 	select TINYCRYPT_SHA256
 	select TINYCRYPT_SHA256_HMAC
 	select BT_HOST_CCM
+	select DEPRECATED
 	help
 	  Use TinyCrypt library to perform crypto operations.
 


### PR DESCRIPTION
Since TinyCrypt is deprecated, we need to mark BT_MESH_USES_TINYCRYPT option as deprecated too so it is visible for the customers that they need to switch to MbedTLS.