### PR TITLE
tests: llext: cleanup `testcase.yaml`

### DIFF
--- a/tests/subsys/llext/simple/no_mem_protection.conf
+++ b/tests/subsys/llext/simple/no_mem_protection.conf
@@ -1,0 +1,8 @@
+# Disable MPU and MMU on all supported arches for the bulk of the tests.
+#
+# This uses the fact that setting an unknown symbol to 'n' has no effect,
+# so it is safe to group different arch-specific settings here.
+#
+CONFIG_ARM_MPU=n
+CONFIG_ARM_AARCH32_MMU=n
+CONFIG_RISCV_PMP=n

--- a/tests/subsys/llext/simple/prj.conf
+++ b/tests/subsys/llext/simple/prj.conf
@@ -7,3 +7,6 @@ CONFIG_LLEXT_EXPORT_DEVICES=y
 CONFIG_LLEXT_LOG_LEVEL_DBG=y
 
 CONFIG_APPLICATION_DEFINED_SYSCALL=y
+
+# The bulk of the tests run with MPU/MMU disabled by including additional
+# configuration entries from no_mem_protection.conf.

--- a/tests/subsys/llext/simple/testcase.yaml
+++ b/tests/subsys/llext/simple/testcase.yaml
@@ -20,6 +20,8 @@ common:
     - mps2/an521/cpu0         # ARM Cortex-M33 (ARMv8-M ISA)
   extra_configs:
     - arch:arm64:CONFIG_LLEXT_HEAP_SIZE=128
+  extra_conf_files:
+    - prj.conf
 
 tests:
   # While there is in practice no value in compiling subsys/llext/*.c
@@ -29,15 +31,15 @@ tests:
   llext.simple.loader_build:
     build_only: true
 
-  # Run the suite with all combinations of core Kconfig options for the llext
-  # subsystem (storage type, ELF type, MPU/MMU etc)
+  # Run the suite with all combinations of core Kconfig options for the LLEXT
+  # subsystem (storage type, ELF type, MPU/MMU etc). To focus on LLEXT issues,
+  # most tests include no_mem_protection.conf, which disables memory protection
+  # hardware completely.
   llext.simple.readonly:
     arch_allow: arm riscv # Xtensa needs writable storage
     filter: not CONFIG_MPU and not CONFIG_MMU
+    extra_conf_files: ['no_mem_protection.conf']
     extra_configs:
-      - arch:arm:CONFIG_ARM_MPU=n
-      - arch:arm:CONFIG_ARM_AARCH32_MMU=n
-      - arch:riscv:CONFIG_RISCV_PMP=n
       - CONFIG_LLEXT_STORAGE_WRITABLE=n
   llext.simple.readonly_mpu:
     min_ram: 128
@@ -58,20 +60,16 @@ tests:
     integration_platforms:
       - qemu_xtensa/dc233c      # Xtensa ISA
     filter: not CONFIG_MPU and not CONFIG_MMU
+    extra_conf_files: ['no_mem_protection.conf']
     extra_configs:
-      - arch:arm:CONFIG_ARM_MPU=n
-      - arch:arm:CONFIG_ARM_AARCH32_MMU=n
-      - arch:riscv:CONFIG_RISCV_PMP=n
       - CONFIG_LLEXT_STORAGE_WRITABLE=y
   llext.simple.writable_relocatable:
     arch_allow: arm xtensa riscv
     integration_platforms:
       - qemu_xtensa/dc233c      # Xtensa ISA
     filter: not CONFIG_MPU and not CONFIG_MMU
+    extra_conf_files: ['no_mem_protection.conf']
     extra_configs:
-      - arch:arm:CONFIG_ARM_MPU=n
-      - arch:arm:CONFIG_ARM_AARCH32_MMU=n
-      - arch:riscv:CONFIG_RISCV_PMP=n
       - CONFIG_LLEXT_STORAGE_WRITABLE=y
       - CONFIG_LLEXT_TYPE_ELF_RELOCATABLE=y
 
@@ -82,10 +80,8 @@ tests:
     integration_platforms:
       - qemu_xtensa/dc233c      # Xtensa ISA
     filter: not CONFIG_MPU and not CONFIG_MMU
+    extra_conf_files: ['no_mem_protection.conf']
     extra_configs:
-      - arch:arm:CONFIG_ARM_MPU=n
-      - arch:arm:CONFIG_ARM_AARCH32_MMU=n
-      - arch:riscv:CONFIG_RISCV_PMP=n
       - CONFIG_LLEXT_STORAGE_WRITABLE=y
       - CONFIG_LLEXT_EXPORT_BUILTINS_BY_SLID=y
   llext.simple.writable_relocatable_slid_linking:
@@ -93,10 +89,8 @@ tests:
     integration_platforms:
       - qemu_xtensa/dc233c      # Xtensa ISA
     filter: not CONFIG_MPU and not CONFIG_MMU
+    extra_conf_files: ['no_mem_protection.conf']
     extra_configs:
-      - arch:arm:CONFIG_ARM_MPU=n
-      - arch:arm:CONFIG_ARM_AARCH32_MMU=n
-      - arch:riscv:CONFIG_RISCV_PMP=n
       - CONFIG_LLEXT_STORAGE_WRITABLE=y
       - CONFIG_LLEXT_TYPE_ELF_RELOCATABLE=y
       - CONFIG_LLEXT_EXPORT_BUILTINS_BY_SLID=y

--- a/tests/subsys/llext/simple/testcase.yaml
+++ b/tests/subsys/llext/simple/testcase.yaml
@@ -48,14 +48,6 @@ tests:
     extra_configs:
       - CONFIG_USERSPACE=y
       - CONFIG_LLEXT_STORAGE_WRITABLE=n
-  llext.simple.readonly_fs_loader:
-    arch_allow: arm riscv # Xtensa needs writable storage
-    filter: not CONFIG_MPU and not CONFIG_MMU and not CONFIG_SOC_SERIES_S32ZE
-    extra_configs:
-      - arch:arm:CONFIG_ARM_MPU=n
-      - arch:arm:CONFIG_ARM_AARCH32_MMU=n
-      - arch:riscv:CONFIG_RISCV_PMP=n
-      - CONFIG_LLEXT_STORAGE_WRITABLE=n
   llext.simple.readonly_mmu:
     arch_allow: arm64 arm riscv
     filter: CONFIG_ARM_MMU

--- a/tests/subsys/llext/simple/testcase.yaml
+++ b/tests/subsys/llext/simple/testcase.yaml
@@ -50,10 +50,11 @@ tests:
       - CONFIG_LLEXT_STORAGE_WRITABLE=n
   llext.simple.readonly_mmu:
     arch_allow: arm64 arm riscv
-    filter: CONFIG_ARM_MMU
+    filter: CONFIG_MMU or CONFIG_RISCV_PMP
     integration_platforms:
       - qemu_cortex_a53         # ARM Cortex-A53 (ARMv8-A ISA)
     extra_configs:
+      - CONFIG_LLEXT_HEAP_SIZE=128 # qemu_cortex_a9 requires larger heap
       - CONFIG_LLEXT_STORAGE_WRITABLE=n
   llext.simple.writable:
     arch_allow: arm xtensa riscv

--- a/tests/subsys/llext/simple/testcase.yaml
+++ b/tests/subsys/llext/simple/testcase.yaml
@@ -2,8 +2,6 @@ common:
   tags: llext
   platform_exclude:
     # platforms with active issues
-    - apollo4p_evb            # See #73443
-    - apollo4p_blue_kxr_evb   # See #73443
     - numaker_pfm_m487        # See #63167
     - s32z2xxdc2/s32z270/rtu0 # See commit 18a0660
     - s32z2xxdc2/s32z270/rtu1 # See commit 18a0660
@@ -35,7 +33,7 @@ tests:
   # subsystem (storage type, ELF type, MPU/MMU etc)
   llext.simple.readonly:
     arch_allow: arm riscv # Xtensa needs writable storage
-    filter: not CONFIG_MPU and not CONFIG_MMU and not CONFIG_SOC_SERIES_S32ZE
+    filter: not CONFIG_MPU and not CONFIG_MMU
     extra_configs:
       - arch:arm:CONFIG_ARM_MPU=n
       - arch:arm:CONFIG_ARM_AARCH32_MMU=n
@@ -59,7 +57,7 @@ tests:
     arch_allow: arm xtensa riscv
     integration_platforms:
       - qemu_xtensa/dc233c      # Xtensa ISA
-    filter: not CONFIG_MPU and not CONFIG_MMU and not CONFIG_SOC_SERIES_S32ZE
+    filter: not CONFIG_MPU and not CONFIG_MMU
     extra_configs:
       - arch:arm:CONFIG_ARM_MPU=n
       - arch:arm:CONFIG_ARM_AARCH32_MMU=n
@@ -83,7 +81,7 @@ tests:
     arch_allow: arm xtensa riscv
     integration_platforms:
       - qemu_xtensa/dc233c      # Xtensa ISA
-    filter: not CONFIG_MPU and not CONFIG_MMU and not CONFIG_SOC_SERIES_S32ZE
+    filter: not CONFIG_MPU and not CONFIG_MMU
     extra_configs:
       - arch:arm:CONFIG_ARM_MPU=n
       - arch:arm:CONFIG_ARM_AARCH32_MMU=n


### PR DESCRIPTION
A number of cleanups / improvements on the test descriptions and coverage:
- Remove the `readonly_fs_loader` case, as it is an exact duplicate of `readonly`. The FS test already runs where applicable, with per-board configs. 
- Remove old limitations (`S32ZE` already added to `platform_excluded`, issues with Apollo HAL have been fixed)
- Move the list of arch-specific MMU/MPU enables to a common config file and include it where necessary (also improving the situation with respect to #80170 and #80613).
- Fix the filter for `readonly_mmu` to actually let `arm` and `riscv` platforms through. 