### PR TITLE
drivers: pwm: nrfx: adjust PWM driver to fast PWM120

### DIFF
--- a/drivers/pwm/pwm_nrfx.c
+++ b/drivers/pwm/pwm_nrfx.c
@@ -13,6 +13,9 @@
 #include <zephyr/linker/devicetree_regions.h>
 #include <zephyr/cache.h>
 #include <zephyr/mem_mgmt/mem_attr.h>
+#ifdef CONFIG_SOC_NRF54H20_GPD
+#include <nrf/gpd.h>
+#endif
 
 #include <zephyr/logging/log.h>
 
@@ -274,6 +277,10 @@ static void pwm_resume(const struct device *dev)
 
 	(void)pinctrl_apply_state(config->pcfg, PINCTRL_STATE_DEFAULT);
 
+#ifdef CONFIG_SOC_NRF54H20_GPD
+	nrf_gpd_retain_pins_set(config->pcfg, false);
+#endif
+
 	for (size_t i = 0; i < NRF_PWM_CHANNEL_COUNT; i++) {
 		uint32_t psel;
 
@@ -301,6 +308,10 @@ static void pwm_suspend(const struct device *dev)
 	nrfx_pwm_stop(&config->pwm, false);
 	while (!nrfx_pwm_stopped_check(&config->pwm)) {
 	}
+
+#ifdef CONFIG_SOC_NRF54H20_GPD
+	nrf_gpd_retain_pins_set(config->pcfg, true);
+#endif
 
 	memset(dev->data, 0, sizeof(struct pwm_nrfx_data));
 	(void)pinctrl_apply_state(config->pcfg, PINCTRL_STATE_SLEEP);

--- a/dts/common/nordic/nrf54h20.dtsi
+++ b/dts/common/nordic/nrf54h20.dtsi
@@ -627,6 +627,7 @@
 				reg = <0x8e4000 0x1000>;
 				status = "disabled";
 				interrupts = <228 NRF_DEFAULT_IRQ_PRIORITY>;
+				clocks = <&hsfll120>;
 				power-domains = <&gpd NRF_GPD_FAST_ACTIVE1>;
 				#pwm-cells = <3>;
 			};


### PR DESCRIPTION
Fast PWM120 instance works with 320MHz clock, thus `pwm_nrfx_get_cycles_per_sec` needs to be adjusted.
Also, it uses cachable RAM, thus sys_cache function needs to be added to flush the cached sequence.