### PR TITLE
tests: drivers: display: fix filtering

### DIFF
--- a/tests/drivers/display/display_read_write/testcase.yaml
+++ b/tests/drivers/display/display_read_write/testcase.yaml
@@ -5,48 +5,55 @@ common:
   tags:
     - drivers
     - display
-  filter: dt_chosen_enabled("zephyr,display")
-  build_only: true # The CI environment has no display device
+  harness: display
 tests:
   drivers.display.read_write.sdl.argb8888:
-    filter: dt_compat_enabled("zephyr,sdl-dc")
+    platform_allow:
+      - native_sim
     extra_configs:
       - CONFIG_SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_ARGB_8888=y
       - CONFIG_SDL_DISPLAY_USE_HARDWARE_ACCELERATOR=n
   drivers.display.read_write.sdl.rgb888:
-    filter: dt_compat_enabled("zephyr,sdl-dc")
+    platform_allow:
+      - native_sim
     extra_configs:
       - CONFIG_SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_RGB_888=y
       - CONFIG_SDL_DISPLAY_USE_HARDWARE_ACCELERATOR=n
   drivers.display.read_write.sdl.mono01:
-    filter: dt_compat_enabled("zephyr,sdl-dc")
+    platform_allow:
+      - native_sim
     extra_configs:
       - CONFIG_SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_MONO01=y
       - CONFIG_SDL_DISPLAY_USE_HARDWARE_ACCELERATOR=n
   drivers.display.read_write.sdl.mono10:
-    filter: dt_compat_enabled("zephyr,sdl-dc")
+    platform_allow:
+      - native_sim
     extra_configs:
       - CONFIG_SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_MONO10=y
       - CONFIG_SDL_DISPLAY_USE_HARDWARE_ACCELERATOR=n
   drivers.display.read_write.sdl.mono01.lsbfirst:
-    filter: dt_compat_enabled("zephyr,sdl-dc")
+    platform_allow:
+      - native_sim
     extra_configs:
       - CONFIG_SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_MONO01=y
       - CONFIG_SDL_DISPLAY_USE_HARDWARE_ACCELERATOR=n
       - CONFIG_SDL_DISPLAY_MONO_MSB_FIRST=n
   drivers.display.read_write.sdl.mono10.lsbfirst:
-    filter: dt_compat_enabled("zephyr,sdl-dc")
+    platform_allow:
+      - native_sim
     extra_configs:
       - CONFIG_SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_MONO10=y
       - CONFIG_SDL_DISPLAY_USE_HARDWARE_ACCELERATOR=n
       - CONFIG_SDL_DISPLAY_MONO_MSB_FIRST=n
   drivers.display.read_write.sdl.rgb565:
-    filter: dt_compat_enabled("zephyr,sdl-dc")
+    platform_allow:
+      - native_sim
     extra_configs:
       - CONFIG_SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_RGB_565=y
       - CONFIG_SDL_DISPLAY_USE_HARDWARE_ACCELERATOR=n
   drivers.display.read_write.sdl.bgr565:
-    filter: dt_compat_enabled("zephyr,sdl-dc")
+    platform_allow:
+      - native_sim
     extra_configs:
       - CONFIG_SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_BGR_565=y
       - CONFIG_SDL_DISPLAY_USE_HARDWARE_ACCELERATOR=n


### PR DESCRIPTION
Test was marked build only with filters in each scenario looking for
sdl-dc which is only available on native_sim, so cut the chase and use
platform_only to narrow things down to native_sim directly instead of
building the world to get information we already know.

reduces build/run time from 78s to 17s on invocation of twister with
default options, saves a ton more when running twister with --all.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
