### PR TITLE
soc: nordic: dmm: Fix DMM_REG_ALIGN_SIZE macro when CONFIG_DCACHE=n

### DIFF
--- a/soc/nordic/common/dmm.h
+++ b/soc/nordic/common/dmm.h
@@ -23,18 +23,26 @@ extern "C" {
 
 /** @cond INTERNAL_HIDDEN */
 
+#ifdef CONFIG_DCACHE
+
 /* Determine if memory region is cacheable. */
-#define DMM_IS_REG_CACHEABLE(node_id)					 \
-	COND_CODE_1(CONFIG_DCACHE,					 \
-	   (COND_CODE_1(DT_NODE_HAS_PROP(node_id, zephyr_memory_attr),	 \
-	    ((DT_PROP(node_id, zephyr_memory_attr) & DT_MEM_CACHEABLE)), \
-	    (0))), (0))
+#define DMM_IS_REG_CACHEABLE(node_id)					     \
+	COND_CODE_1(DT_NODE_HAS_PROP(node_id, zephyr_memory_attr),	     \
+		((DT_PROP(node_id, zephyr_memory_attr) & DT_MEM_CACHEABLE)), \
+		(0))
 
 /* Determine required alignment of the data buffers in specified memory region.
  * Cache line alignment is required if region is cacheable and data cache is enabled.
  */
 #define DMM_REG_ALIGN_SIZE(node_id) \
 	(DMM_IS_REG_CACHEABLE(node_id) ? CONFIG_DCACHE_LINE_SIZE : sizeof(uint8_t))
+
+#else
+
+#define DMM_IS_REG_CACHEABLE(node_id) 0
+#define DMM_REG_ALIGN_SIZE(node_id) (sizeof(uint8_t))
+
+#endif /* CONFIG_DCACHE */
 
 /* Determine required alignment of the data buffers in memory region
  * associated with specified device node.


### PR DESCRIPTION
Make sure this expansion doesn't include `CONFIG_DCACHE_LINE_SIZE`, which would be undefined and produce a build error.

Fixes #80873