### PR TITLE
input: it8xxx2_kbd: add a kso-ignore-mask property

### DIFF
--- a/dts/bindings/input/ite,it8xxx2-kbd.yaml
+++ b/dts/bindings/input/ite,it8xxx2-kbd.yaml
@@ -35,6 +35,14 @@ properties:
     description: |
       The KSO17 pin for the selected port.
 
+  kso-ignore-mask:
+    type: int
+    default: 0
+    description: |
+      Bitmask of KSO signals to ignore, this can be used to instruct the driver
+      to skip KSO signals between 0 and (col-size - 1) that are used as GPIOs.
+      Default to 0 (no signals masked).
+
   pinctrl-0:
     required: true
 


### PR DESCRIPTION
The it8xxx2_kbd KSO pins can be used as both keyboard scan and GPIO. By default the keyboard scanning driver controls the output level of all the KSO signals from 0 to (col-size - 1), meaning that any line in between used as GPIO is going to have its output value overridden.

Add a kso-ignore-mask property to the keyboard scan driver to allow specifiying extra pins that should not be controlled by the driver.