### PR TITLE
posix: fix one-time timer for SIGEV_SIGNAL

### DIFF
--- a/lib/posix/options/timer.c
+++ b/lib/posix/options/timer.c
@@ -43,7 +43,6 @@ static void zephyr_timer_wrapper(struct k_timer *ztimer)
 	if (timer->reload == 0U) {
 		timer->status = NOT_ACTIVE;
 		LOG_DBG("timer %p not active", timer);
-		return;
 	}
 
 	if (timer->evp.sigev_notify == SIGEV_NONE) {

--- a/tests/posix/common/src/timer.c
+++ b/tests/posix/common/src/timer.c
@@ -104,7 +104,7 @@ ZTEST(timer, test_CLOCK_MONOTONIC__SIGEV_THREAD)
 
 ZTEST(timer, test_timer_overrun)
 {
-	struct sigevent sig = { 0 };
+	struct sigevent sig = {0};
 	struct itimerspec value;
 
 	sig.sigev_notify = SIGEV_NONE;

--- a/tests/posix/common/src/timer.c
+++ b/tests/posix/common/src/timer.c
@@ -122,6 +122,29 @@ ZTEST(timer, test_timer_overrun)
 	zassert_equal(timer_getoverrun(timerid), 4, "Number of overruns is incorrect");
 }
 
+ZTEST(timer, test_one_shot__SIGEV_SIGNAL)
+{
+	struct sigevent sig = {0};
+	struct itimerspec value;
+
+	exp_count = 0;
+	sig.sigev_notify = SIGEV_SIGNAL;
+	sig.sigev_notify_function = handler;
+	sig.sigev_value.sival_int = TEST_SIGNAL_VAL;
+
+	zassert_ok(timer_create(CLOCK_MONOTONIC, &sig, &timerid));
+
+	/*Set the timer to expire only once*/
+	value.it_interval.tv_sec = 0;
+	value.it_interval.tv_nsec = 0;
+	value.it_value.tv_sec = 0;
+	value.it_value.tv_nsec = 100 * NSEC_PER_MSEC;
+	zassert_ok(timer_settime(timerid, 0, &value, NULL));
+	k_sleep(K_MSEC(300));
+
+	zassert_equal(exp_count, 1, "Number of expiry is incorrect");
+}
+
 static void after(void *arg)
 {
 	ARG_UNUSED(arg);


### PR DESCRIPTION
For SIGEV_SIGNAL, the function zephyr_timer_wrapper() is the handler between kernel and posix layer. Here, for one-time timer, reload is equal to 0 and function returns. As a consequence, handler function was never called.

Add test one one-time SIGEV_SIGNAL timer
- Set a one shot timer to expiry in 1s.
- After 5s, check that the timer handler has been called only once. Without the fix, it was never called.