### PR TITLE
soc: fix the IPM and MBOX dependency condition

### DIFF
--- a/soc/espressif/esp32/Kconfig
+++ b/soc/espressif/esp32/Kconfig
@@ -32,8 +32,7 @@ config ESP32_APPCPU_DRAM
 config SOC_ENABLE_APPCPU
 	bool
 	default y
-	depends on IPM && SOC_ESP32_PROCPU
-	depends on MBOX && SOC_ESP32_PROCPU
+	depends on (IPM || MBOX) && SOC_ESP32_PROCPU
 	help
 	  This hidden configuration lets PROCPU core to map and start APPCPU whenever IPM is enabled.
 

--- a/soc/espressif/esp32s3/Kconfig
+++ b/soc/espressif/esp32s3/Kconfig
@@ -31,8 +31,7 @@ config ESP32S3_APPCPU_DRAM
 config SOC_ENABLE_APPCPU
 	bool
 	default y
-	depends on IPM && SOC_ESP32S3_PROCPU
-	depends on MBOX && SOC_ESP32S3_PROCPU
+	depends on (IPM || MBOX) && SOC_ESP32S3_PROCPU
 	help
 	  This hidden configuration lets PROCPU core to map and start APPCPU whenever IPM is enabled.
 


### PR DESCRIPTION
The APP_CPU usage as standalone CPU should depend
either on MBOX or IPM enabled, but it was depending on both which is not allowed by hardware, this patch
fixes the condition.