### PR TITLE
C library: Implement feof

### DIFF
--- a/lib/libc/common/CMakeLists.txt
+++ b/lib/libc/common/CMakeLists.txt
@@ -20,6 +20,7 @@ zephyr_library_sources_ifdef(CONFIG_COMMON_LIBC_THRD
     source/thrd/tss.c
     )
 zephyr_library_sources_ifdef(CONFIG_COMMON_LIBC_REMOVE source/stdio/remove.c)
+zephyr_library_sources_ifdef(CONFIG_COMMON_LIBC_FEOF source/stdio/feof.c)
 
 # Prevent compiler from optimizing calloc into an infinite recursive call
 zephyr_library_compile_options($<TARGET_PROPERTY:compiler,no_builtin_malloc>)

--- a/lib/libc/common/Kconfig
+++ b/lib/libc/common/Kconfig
@@ -120,3 +120,8 @@ config COMMON_LIBC_REMOVE
 	default y if FILE_SYSTEM
 	help
 	  Common implementation of remove().
+
+config COMMON_LIBC_FEOF
+	bool "Common C library feof"
+	help
+	  Common implementation of feof().

--- a/lib/libc/common/source/stdio/feof.c
+++ b/lib/libc/common/source/stdio/feof.c
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2024 Daniel Hajjar
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdio.h>
+
+int zvfs_feof(FILE *);
+
+int feof(FILE *file)
+{
+	return zvfs_feof(file);
+}


### PR DESCRIPTION
Added ZVFS implementation and common libc wrapper for feof.
Introduced flags variable to `fd_entry` for ZVFS implementation.

Fixes #66933 