### PR TITLE
samples: tests: bluetooth: Add CI coverage for frdm_mcxw71

### DIFF
--- a/samples/bluetooth/central_ht/sample.yaml
+++ b/samples/bluetooth/central_ht/sample.yaml
@@ -18,5 +18,6 @@ tests:
     platform_allow:
       - rd_rw612_bga
       - frdm_rw612
+      - frdm_mcxw71
     extra_configs:
       - CONFIG_NXP_MONOLITHIC_BT=n

--- a/samples/bluetooth/peripheral_ht/sample.yaml
+++ b/samples/bluetooth/peripheral_ht/sample.yaml
@@ -30,5 +30,6 @@ tests:
     platform_allow:
       - rd_rw612_bga
       - frdm_rw612
+      - frdm_mcxw71
     extra_configs:
       - CONFIG_NXP_MONOLITHIC_BT=n

--- a/tests/bluetooth/tester/testcase.yaml
+++ b/tests/bluetooth/tester/testcase.yaml
@@ -14,8 +14,66 @@ tests:
     platform_allow:
       - rd_rw612_bga
       - frdm_rw612
+      - frdm_mcxw71
     extra_configs:
       - CONFIG_NXP_MONOLITHIC_BT=n
+  bluetooth.general.tester_gatt_long_dev_name:
+    build_only: true
+    harness: bluetooth
+    platform_allow:
+      - frdm_mcxw71
+    extra_configs:
+      - CONFIG_BT_CONN_DISABLE_SECURITY=y
+      - CONFIG_BT_DEVICE_NAME_MAX=64
+      - CONFIG_BT_DEVICE_NAME="TTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT"
+  bluetooth.general.tester_enforce_mitm:
+    build_only: true
+    harness: bluetooth
+    platform_allow:
+      - frdm_mcxw71
+    extra_configs:
+      - CONFIG_BT_SMP_ENFORCE_MITM=y
+  bluetooth.general.tester_sc_m1l2:
+    build_only: true
+    harness: bluetooth
+    platform_allow:
+      - frdm_mcxw71
+    extra_configs:
+      - CONFIG_BT_PRIVACY=y
+      - CONFIG_BT_SMP_ENFORCE_MITM=n
+  bluetooth.general.tester_sc_m1l3:
+    build_only: true
+    harness: bluetooth
+    platform_allow:
+      - frdm_mcxw71
+    extra_configs:
+      - CONFIG_BT_PRIVACY=y
+      - CONFIG_BT_SMP_ENFORCE_MITM=y
+  bluetooth.general.tester_sec_m1l4:
+    build_only: true
+    harness: bluetooth
+    platform_allow:
+      - frdm_mcxw71
+    extra_configs:
+      - CONFIG_BT_PRIVACY=y
+      - CONFIG_BT_SMP_ENFORCE_MITM=y
+      - CONFIG_BT_SMP_SC_ONLY=y
+      - CONFIG_BT_SMP_SC_PAIR_ONLY=y
+  bluetooth.general.tester_privacy:
+    build_only: true
+    harness: bluetooth
+    platform_allow:
+      - frdm_mcxw71
+    extra_configs:
+      - CONFIG_BT_PRIVACY=y
+      - CONFIG_BT_RPA_TIMEOUT=30
+  bluetooth.general.tester_eatt_two_channels:
+    build_only: true
+    harness: bluetooth
+    platform_allow:
+      - frdm_mcxw71
+    extra_configs:
+      - CONFIG_BT_EATT_MAX=2
   bluetooth.general.tester_le_audio:
     build_only: true
     platform_allow:


### PR DESCRIPTION
Adding CI coverage for:
-peripheral_ht
-central_ht
-tester

Also adding some test variants to the tester application, for now only adding MCXW71 platform.