### PR TITLE
Remove FLASH_0 mpu region when CONFIG_XIP=n

### DIFF
--- a/arch/arm/core/mpu/arm_mpu_regions.c
+++ b/arch/arm/core/mpu/arm_mpu_regions.c
@@ -10,6 +10,7 @@
 #include <zephyr/arch/arm/cortex_m/arm_mpu_mem_cfg.h>
 
 static const struct arm_mpu_region mpu_regions[] = {
+#ifdef CONFIG_XIP
 	/* Region 0 */
 	MPU_REGION_ENTRY("FLASH_0",
 			 CONFIG_FLASH_BASE_ADDRESS,
@@ -19,6 +20,8 @@ static const struct arm_mpu_region mpu_regions[] = {
 #else
 			 REGION_FLASH_ATTR(REGION_FLASH_SIZE)),
 #endif
+#endif
+
 	/* Region 1 */
 	MPU_REGION_ENTRY("SRAM_0",
 			 CONFIG_SRAM_BASE_ADDRESS,


### PR DESCRIPTION
When not using CONFIG_XIP (CONFIG_XIP=n)
the FLASH_0 mpu region needs to be removed,
otherwise it will have the default base
address = 0, which means that MPU will try
to configure the region with address 0.
We don't want this as in some situations
address 0 can be a restricted memory region
such as ROM code.

I am making this PR to solve this PR https://github.com/zephyrproject-rtos/zephyr/pull/79993 .Here as CONFIG_XIP=n, both .text and .data are placed in SRAM region and FLASH section get the default value 0 and size 0. Even it is not used FLASH_0 mpu region is created for address 0. So even if just the SRAM_0 will be used, both SRAM_0 and FLASH_0  will be configured by MPU. After these 2 regions are configured, MPU should be enabled, but immediately after it is enabled, the m33 jumps to an exception. Probably because the address 0 that is configured by MPU is M33 boot rom code. 
I managed to solve this issue by not configuring the FLASH_0 when CONFIG_XIP=n.

Also I think that FLASH_0 should not be configured by MPU if CONFIG_XIP=n, as this imply that only the CONFIG_SRAM_BASE_ADDRESS will be used for both .text and .data.

Let me know you opinion.
