### PR TITLE
soc: gd32: Drop PINCTRL from Kconfig.defconfig

### DIFF
--- a/drivers/adc/Kconfig.gd32
+++ b/drivers/adc/Kconfig.gd32
@@ -7,5 +7,6 @@ config ADC_GD32
 	bool "GD32 ADC driver"
 	default y
 	depends on DT_HAS_GD_GD32_ADC_ENABLED
+	select PINCTRL
 	help
 	  Enable GigaDevice GD32 ADC driver

--- a/drivers/dac/Kconfig.gd32
+++ b/drivers/dac/Kconfig.gd32
@@ -8,5 +8,6 @@ config DAC_GD32
 	bool "GD32 DAC driver"
 	default y
 	depends on DT_HAS_GD_GD32_DAC_ENABLED
+	select PINCTRL
 	help
 	  Enable GigaDevice GD32 DAC driver

--- a/drivers/i2c/Kconfig.gd32
+++ b/drivers/i2c/Kconfig.gd32
@@ -5,5 +5,6 @@ config I2C_GD32
 	bool "GigaDevice GD32 I2C driver"
 	default y
 	depends on DT_HAS_GD_GD32_I2C_ENABLED
+	select PINCTRL
 	help
 	  Enables GigaDevice GD32 I2C driver

--- a/drivers/pwm/Kconfig.gd32
+++ b/drivers/pwm/Kconfig.gd32
@@ -5,5 +5,6 @@ config PWM_GD32
 	bool "GigaDevice GD32 PWM driver"
 	default y
 	depends on DT_HAS_GD_GD32_PWM_ENABLED
+	select PINCTRL
 	help
 	  Enable the GigaDevice GD32 PWM driver.

--- a/drivers/serial/Kconfig.gd32
+++ b/drivers/serial/Kconfig.gd32
@@ -5,6 +5,7 @@ config USART_GD32
 	bool "GD32 serial driver"
 	default y
 	depends on DT_HAS_GD_GD32_USART_ENABLED
+	select PINCTRL
 	select SERIAL_HAS_DRIVER
 	select SERIAL_SUPPORT_INTERRUPT
 	select USE_GD32_USART

--- a/drivers/spi/Kconfig.gd32
+++ b/drivers/spi/Kconfig.gd32
@@ -5,6 +5,7 @@ config SPI_GD32
 	bool "Gigadevice GD32 SPI driver"
 	default y
 	depends on DT_HAS_GD_GD32_SPI_ENABLED
+	select PINCTRL
 	help
 	  Enables Gigadevice GD32 SPI driver.
 

--- a/soc/gd/gd32/Kconfig.defconfig
+++ b/soc/gd/gd32/Kconfig.defconfig
@@ -5,9 +5,6 @@ if SOC_FAMILY_GD_GD32
 
 rsource "*/Kconfig.defconfig.series"
 
-config PINCTRL
-	default y
-
 config RESET
 	default y
 


### PR DESCRIPTION
This Kconfig has wrongly been added to defconfig files. It is not the right place for it. It has never been the right place for it. Drivers that need it should select the symbol in their Kconfig entries. Drop PINCTL from Kconfig.defconfig and add proper select at Kconfig.gd32.

Fixes #78619