### PR TITLE
drivers: crypto/tc: Deprecate TC shim driver

### DIFF
--- a/drivers/crypto/Kconfig
+++ b/drivers/crypto/Kconfig
@@ -29,7 +29,7 @@ config CRYPTO_TINYCRYPT_SHIM
 	select TINYCRYPT_AES_CTR
 	select TINYCRYPT_AES_CCM
 	select TINYCRYPT_AES_CMAC
-	select EXPERIMENTAL
+	select DEPRECATED
 	help
 	  Enable TinyCrypt shim layer compliant with crypto APIs.
 


### PR DESCRIPTION
TinyCrypt has been deprecated and so has all the code depending on it.