### PR TITLE
twister: propagate NOTRUN status to twister.json report

### DIFF
--- a/scripts/pylib/twister/twisterlib/reports.py
+++ b/scripts/pylib/twister/twisterlib/reports.py
@@ -335,7 +335,6 @@ class Reporting:
             if available_rom:
                 suite["available_rom"] = available_rom
             if instance.status in [TwisterStatus.ERROR, TwisterStatus.FAIL]:
-                suite['status'] = instance.status
                 suite["reason"] = instance.reason
                 # FIXME
                 if os.path.exists(pytest_log):
@@ -347,12 +346,8 @@ class Reporting:
                 else:
                     suite["log"] = self.process_log(build_log)
             elif instance.status == TwisterStatus.FILTER:
-                suite["status"] = TwisterStatus.FILTER
                 suite["reason"] = instance.reason
-            elif instance.status == TwisterStatus.PASS:
-                suite["status"] = TwisterStatus.PASS
             elif instance.status == TwisterStatus.SKIP:
-                suite["status"] = TwisterStatus.SKIP
                 suite["reason"] = instance.reason
             elif instance.status == TwisterStatus.NOTRUN:
                 suite["status"] = TwisterStatus.NOTRUN
@@ -362,6 +357,7 @@ class Reporting:
                 suite["reason"] = 'Unknown Instance status.'
 
             if instance.status != TwisterStatus.NONE:
+                suite["status"] = instance.status
                 suite["execution_time"] =  f"{float(handler_time):.2f}"
             suite["build_time"] =  f"{float(instance.build_time):.2f}"
 


### PR DESCRIPTION
All statuses were propagated manually using if/elif branches. When NOTRUN
status was added, it was not handled in `twister.json` report generation and
was not propagated to this file.

Propagate status by default regardless of what the status value is, unless
it is None. This handles recently introduced NOTRUN status, so it can be
read out from `twister.json`.

This fixes following error when `--package-artifacts ARCHIVE.TAR` is
passed to twister invocation:

```
Traceback (most recent call last):
  File "/.venv/bin/west", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/west/app/main.py", line 1085, in main
    app.run(argv or sys.argv[1:])
  File "/west/app/main.py", line 244, in run
    self.run_command(argv, early_args)
  File "/west/app/main.py", line 505, in run_command
    self.run_extension(args.command, argv)
  File "/west/app/main.py", line 654, in run_extension
    self.cmd.run(args, unknown, self.topdir, manifest=self.manifest,
  File "/west/commands.py", line 194, in run
    self.do_run(args, unknown)
  File "/zephyr/scripts/west_commands/twister_cmd.py", line 61, in do_run
    ret = main(options, default_options)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/zephyr/scripts/pylib/twister/twisterlib/twister_main.py", line 240, in main
    artifacts.package()
  File "/zephyr/scripts/pylib/twister/twisterlib/package.py", line 30, in package
    if t['status'] != TwisterStatus.FILTER:
       ~^^^^^^^^^^
KeyError: 'status'
```

Fixes: 5dc5fa5ee2ac ("scripts: print the file name when decode syscall")