### PR TITLE
soc: raspberrypi: Drop PINCTRL from Kconfig.defconfig

### DIFF
--- a/drivers/adc/Kconfig.rpi_pico
+++ b/drivers/adc/Kconfig.rpi_pico
@@ -6,4 +6,5 @@ config ADC_RPI_PICO
 	default y
 	depends on DT_HAS_RASPBERRYPI_PICO_ADC_ENABLED
 	select PICOSDK_USE_ADC
+	select PINCTRL
 	depends on RESET

--- a/drivers/clock_control/Kconfig.rpi_pico
+++ b/drivers/clock_control/Kconfig.rpi_pico
@@ -7,6 +7,7 @@ config CLOCK_CONTROL_RPI_PICO
 	bool "Raspberry Pi Pico Clock Controller Driver"
 	default y
 	depends on DT_HAS_RASPBERRYPI_PICO_CLOCK_CONTROLLER_ENABLED
+	select PINCTRL
 
 if CLOCK_CONTROL_RPI_PICO
 

--- a/drivers/gpio/Kconfig.rpi_pico
+++ b/drivers/gpio/Kconfig.rpi_pico
@@ -5,4 +5,5 @@ config GPIO_RPI_PICO
 	default y
 	depends on DT_HAS_RASPBERRYPI_PICO_GPIO_ENABLED
 	select PICOSDK_USE_GPIO
+	select PINCTRL
 	bool "Raspberry Pi Pico GPIO driver"

--- a/drivers/i2c/Kconfig.dw
+++ b/drivers/i2c/Kconfig.dw
@@ -5,6 +5,7 @@ menuconfig I2C_DW
 	bool "Design Ware I2C support"
 	default y
 	depends on DT_HAS_SNPS_DESIGNWARE_I2C_ENABLED
+	select PINCTRL if DT_HAS_RASPBERRYPI_PICO_I2C_ENABLED
 	help
 	  Enable the Design Ware I2C driver
 

--- a/drivers/misc/pio_rpi_pico/Kconfig
+++ b/drivers/misc/pio_rpi_pico/Kconfig
@@ -7,3 +7,4 @@ config PIO_RPI_PICO
 	depends on DT_HAS_RASPBERRYPI_PICO_PIO_ENABLED
 	depends on RESET
 	select PICOSDK_USE_PIO
+	select PINCTRL

--- a/drivers/pwm/Kconfig.rpi_pico
+++ b/drivers/pwm/Kconfig.rpi_pico
@@ -7,5 +7,6 @@ config PWM_RPI_PICO
 	depends on DT_HAS_RASPBERRYPI_PICO_PWM_ENABLED
 	depends on RESET
 	select PICOSDK_USE_PWM
+	select PINCTRL
 	help
 	  Enable PWM driver for RPi Pico family of MCUs

--- a/drivers/serial/Kconfig.rpi_pico
+++ b/drivers/serial/Kconfig.rpi_pico
@@ -8,4 +8,5 @@ config UART_RPI_PICO_PIO
 	select SERIAL_HAS_DRIVER
 	select PICOSDK_USE_PIO
 	select PICOSDK_USE_CLAIM
+	select PINCTRL
 	depends on RESET

--- a/drivers/spi/Kconfig.pl022
+++ b/drivers/spi/Kconfig.pl022
@@ -4,6 +4,7 @@
 config SPI_PL022
 	default y
 	depends on DT_HAS_ARM_PL022_ENABLED
+	select PINCTRL if DT_HAS_RASPBERRYPI_PICO_SPI_ENABLED
 	bool "ARM PL022 SPI driver"
 
 if SPI_PL022

--- a/drivers/spi/Kconfig.rpi_pico
+++ b/drivers/spi/Kconfig.rpi_pico
@@ -7,5 +7,6 @@ config SPI_RPI_PICO_PIO
 	depends on DT_HAS_RASPBERRYPI_PICO_SPI_PIO_ENABLED
 	select PICOSDK_USE_PIO
 	select PICOSDK_USE_CLAIM
+	select PINCTRL
 	help
 	  Enable driving SPI via PIO on the PICO

--- a/drivers/usb/device/Kconfig
+++ b/drivers/usb/device/Kconfig
@@ -37,6 +37,7 @@ config USB_DC_RPI_PICO
 	bool "USB device controller driver for Raspberry Pi Pico devices"
 	default y
 	depends on DT_HAS_RASPBERRYPI_PICO_USBD_ENABLED
+	select PINCTRL
 	help
 	  Enable USB support on the RP2 family of processors.
 

--- a/soc/raspberrypi/Kconfig.defconfig
+++ b/soc/raspberrypi/Kconfig.defconfig
@@ -7,7 +7,4 @@ if SOC_FAMILY_RPI_PICO
 
 rsource "*/Kconfig.defconfig"
 
-config PINCTRL
-	default y
-
 endif # SOC_FAMILY_RPI_PICO


### PR DESCRIPTION
The `Kconfig.defconfig` is not good place for put `select PINCTRL`. Drop `select PINCTL` from `Kconfig.defconfig` and add it at each driver's Kconfig.