### PR TITLE
Support AGT Counter driver for Renesas RA6, RA4, RA2 devices

### DIFF
--- a/boards/renesas/ek_ra2a1/doc/index.rst
+++ b/boards/renesas/ek_ra2a1/doc/index.rst
@@ -80,6 +80,8 @@ hardware features:
 +-----------+------------+-------------------------------+
 | SPI       | on-chip    | spi                           |
 +-----------+------------+-------------------------------+
+| COUNTER   | on-chip    | counter                       |
++-----------+------------+-------------------------------+
 
 The default configuration can be found in
 :zephyr_file:`boards/renesas/ek_ra2a1/ek_ra2a1_defconfig`

--- a/boards/renesas/ek_ra4m2/doc/index.rst
+++ b/boards/renesas/ek_ra4m2/doc/index.rst
@@ -100,6 +100,8 @@ The below features are currently supported on Zephyr OS for EK-RA4M2 board:
 +-----------+------------+----------------------+
 | SPI       | on-chip    | spi                  |
 +-----------+------------+----------------------+
+| COUNTER   | on-chip    | counter              |
++-----------+------------+----------------------+
 
 Other hardware features are currently not supported by the port.
 

--- a/boards/renesas/ek_ra4m3/doc/index.rst
+++ b/boards/renesas/ek_ra4m3/doc/index.rst
@@ -102,6 +102,8 @@ The below features are currently supported on Zephyr OS for EK-RA4M3 board:
 +-----------+------------+----------------------+
 | SPI       | on-chip    | spi                  |
 +-----------+------------+----------------------+
+| COUNTER   | on-chip    | counter              |
++-----------+------------+----------------------+
 
 Other hardware features are currently not supported by the port.
 

--- a/boards/renesas/ek_ra4w1/doc/index.rst
+++ b/boards/renesas/ek_ra4w1/doc/index.rst
@@ -92,6 +92,8 @@ The below features are currently supported on Zephyr OS for EK-RA4W1 board:
 +-----------+------------+----------------------+
 | SPI       | on-chip    | spi                  |
 +-----------+------------+----------------------+
+| COUNTER   | on-chip    | counter              |
++-----------+------------+----------------------+
 
 Other hardware features are currently not supported by the port.
 

--- a/boards/renesas/ek_ra6m1/doc/index.rst
+++ b/boards/renesas/ek_ra6m1/doc/index.rst
@@ -98,6 +98,8 @@ The below features are currently supported on Zephyr OS for EK-RA6M1 board:
 +-----------+------------+----------------------+
 | SPI       | on-chip    | spi                  |
 +-----------+------------+----------------------+
+| COUNTER   | on-chip    | counter              |
++-----------+------------+----------------------+
 
 Other hardware features are currently not supported by the port.
 

--- a/boards/renesas/ek_ra6m2/doc/index.rst
+++ b/boards/renesas/ek_ra6m2/doc/index.rst
@@ -92,6 +92,8 @@ The below features are currently supported on Zephyr OS for EK-RA6M2 board:
 +-----------+------------+----------------------+
 | SPI       | on-chip    | spi                  |
 +-----------+------------+----------------------+
+| COUNTER   | on-chip    | counter              |
++-----------+------------+----------------------+
 
 Other hardware features are currently not supported by the port.
 

--- a/boards/renesas/ek_ra6m3/doc/index.rst
+++ b/boards/renesas/ek_ra6m3/doc/index.rst
@@ -100,6 +100,8 @@ The below features are currently supported on Zephyr OS for EK-RA6M3 board:
 +-----------+------------+----------------------+
 | SPI       | on-chip    | spi                  |
 +-----------+------------+----------------------+
+| COUNTER   | on-chip    | counter              |
++-----------+------------+----------------------+
 
 Other hardware features are currently not supported by the port.
 

--- a/boards/renesas/ek_ra6m4/doc/index.rst
+++ b/boards/renesas/ek_ra6m4/doc/index.rst
@@ -105,6 +105,8 @@ The below features are currently supported on Zephyr OS for EK-RA6M4 board:
 +-----------+------------+----------------------+
 | SPI       | on-chip    | spi                  |
 +-----------+------------+----------------------+
+| COUNTER   | on-chip    | counter              |
++-----------+------------+----------------------+
 
 Other hardware features are currently not supported by the port.
 

--- a/boards/renesas/ek_ra6m5/doc/index.rst
+++ b/boards/renesas/ek_ra6m5/doc/index.rst
@@ -103,6 +103,8 @@ The below features are currently supported on Zephyr OS for EK-RA6M5 board:
 +-----------+------------+----------------------+
 | SPI       | on-chip    | spi                  |
 +-----------+------------+----------------------+
+| COUNTER   | on-chip    | counter              |
++-----------+------------+----------------------+
 
 Other hardware features are currently not supported by the port.
 

--- a/boards/renesas/fpb_ra6e1/doc/index.rst
+++ b/boards/renesas/fpb_ra6e1/doc/index.rst
@@ -87,6 +87,8 @@ The below features are currently supported on Zephyr OS for FPB-RA6E1 board:
 +-----------+------------+----------------------+
 | SPI       | on-chip    | spi                  |
 +-----------+------------+----------------------+
+| COUNTER   | on-chip    | counter              |
++-----------+------------+----------------------+
 
 Other hardware features are currently not supported by the port.
 

--- a/dts/arm/renesas/ra/ra2/ra2xx.dtsi
+++ b/dts/arm/renesas/ra/ra2/ra2xx.dtsi
@@ -231,6 +231,36 @@
 			#size-cells = <1>;
 		};
 
+		agt0: agt@40084000  {
+			compatible = "renesas,ra-agt";
+			channel = <0>;
+			reg = <0x40084000 0x100>;
+			renesas,count-source = "AGT_CLOCK_LOCO";
+			renesas,prescaler = <0>;
+			renesas,resolution = <16>;
+			status = "disabled";
+
+			counter {
+				compatible = "renesas,ra-agt-counter";
+				status = "disabled";
+			};
+		};
+
+		agt1: agt@40084100 {
+			compatible = "renesas,ra-agt";
+			channel = <1>;
+			reg = <0x40084100 0x100>;
+			renesas,count-source = "AGT_CLOCK_LOCO";
+			renesas,prescaler = <0>;
+			renesas,resolution = <16>;
+			status = "disabled";
+
+			counter {
+				compatible = "renesas,ra-agt-counter";
+				status = "disabled";
+			};
+		};
+
 		id_code: id_code@1010018 {
 			compatible = "zephyr,memory-region";
 			reg = <0x01010018 0x20>;

--- a/dts/arm/renesas/ra/ra4/r7fa4e2b93cfm.dtsi
+++ b/dts/arm/renesas/ra/ra4/r7fa4e2b93cfm.dtsi
@@ -7,6 +7,13 @@
 #include <zephyr/dt-bindings/clock/ra_clock.h>
 #include <arm/renesas/ra/ra4/ra4-cm33-common.dtsi>
 
+/delete-node/ &agt0;
+/delete-node/ &agt1;
+/delete-node/ &agt2;
+/delete-node/ &agt3;
+/delete-node/ &agt4;
+/delete-node/ &agt5;
+
 / {
 	soc {
 		sram0: memory@20000000 {

--- a/dts/arm/renesas/ra/ra4/ra4-cm33-common.dtsi
+++ b/dts/arm/renesas/ra/ra4/ra4-cm33-common.dtsi
@@ -157,6 +157,96 @@
 			status = "disabled";
 		};
 
+		agt0: agt@400e8000 {
+			compatible = "renesas,ra-agt";
+			channel = <0>;
+			reg = <0x400e8000 0x100>;
+			renesas,count-source = "AGT_CLOCK_LOCO";
+			renesas,prescaler = <0>;
+			renesas,resolution = <16>;
+			status = "disabled";
+
+			counter {
+				compatible = "renesas,ra-agt-counter";
+				status = "disabled";
+			};
+		};
+
+		agt1: agt@400e8100 {
+			compatible = "renesas,ra-agt";
+			channel = <1>;
+			reg = <0x400e8100 0x100>;
+			renesas,count-source = "AGT_CLOCK_LOCO";
+			renesas,prescaler = <0>;
+			renesas,resolution = <16>;
+			status = "disabled";
+
+			counter {
+				compatible = "renesas,ra-agt-counter";
+				status = "disabled";
+			};
+		};
+
+		agt2: agt@400e8200 {
+			compatible = "renesas,ra-agt";
+			channel = <2>;
+			reg = <0x400e8200 0x100>;
+			renesas,count-source = "AGT_CLOCK_LOCO";
+			renesas,prescaler = <0>;
+			renesas,resolution = <16>;
+			status = "disabled";
+
+			counter {
+				compatible = "renesas,ra-agt-counter";
+				status = "disabled";
+			};
+		};
+
+		agt3: agt@400e8300 {
+			compatible = "renesas,ra-agt";
+			channel = <3>;
+			reg = <0x400e8300 0x100>;
+			renesas,count-source = "AGT_CLOCK_LOCO";
+			renesas,prescaler = <0>;
+			renesas,resolution = <16>;
+			status = "disabled";
+
+			counter {
+				compatible = "renesas,ra-agt-counter";
+				status = "disabled";
+			};
+		};
+
+		agt4: agt@400e8400 {
+			compatible = "renesas,ra-agt";
+			channel = <4>;
+			reg = <0x400e8400 0x100>;
+			renesas,count-source = "AGT_CLOCK_LOCO";
+			renesas,prescaler = <0>;
+			renesas,resolution = <16>;
+			status = "disabled";
+
+			counter {
+				compatible = "renesas,ra-agt-counter";
+				status = "disabled";
+			};
+		};
+
+		agt5: agt@400e8500 {
+			compatible = "renesas,ra-agt";
+			channel = <5>;
+			reg = <0x400e8500 0x100>;
+			renesas,count-source = "AGT_CLOCK_LOCO";
+			renesas,prescaler = <0>;
+			renesas,resolution = <16>;
+			status = "disabled";
+
+			counter {
+				compatible = "renesas,ra-agt-counter";
+				status = "disabled";
+			};
+		};
+
 		option_setting_ofs: option_setting_ofs@100a100 {
 			compatible = "zephyr,memory-region";
 			reg = <0x0100a100 0x18>;

--- a/dts/arm/renesas/ra/ra4/ra4-cm4-common.dtsi
+++ b/dts/arm/renesas/ra/ra4/ra4-cm4-common.dtsi
@@ -180,6 +180,36 @@
 			status = "disabled";
 		};
 
+		agt0: agt@40084000  {
+			compatible = "renesas,ra-agt";
+			channel = <0>;
+			reg = <0x40084000 0x100>;
+			renesas,count-source = "AGT_CLOCK_LOCO";
+			renesas,prescaler = <0>;
+			renesas,resolution = <16>;
+			status = "disabled";
+
+			counter {
+				compatible = "renesas,ra-agt-counter";
+				status = "disabled";
+			};
+		};
+
+		agt1: agt@40084100 {
+			compatible = "renesas,ra-agt";
+			channel = <1>;
+			reg = <0x40084100 0x100>;
+			renesas,count-source = "AGT_CLOCK_LOCO";
+			renesas,prescaler = <0>;
+			renesas,resolution = <16>;
+			status = "disabled";
+
+			counter {
+				compatible = "renesas,ra-agt-counter";
+				status = "disabled";
+			};
+		};
+
 		id_code: id_code@1010018 {
 			compatible = "zephyr,memory-region";
 			reg = <0x01010018 0x20>;

--- a/dts/arm/renesas/ra/ra6/r7fa6e2bx.dtsi
+++ b/dts/arm/renesas/ra/ra6/r7fa6e2bx.dtsi
@@ -7,6 +7,13 @@
 #include <arm/renesas/ra/ra6/ra6-cm33-common.dtsi>
 #include <zephyr/dt-bindings/clock/ra_clock.h>
 
+/delete-node/ &agt0;
+/delete-node/ &agt1;
+/delete-node/ &agt2;
+/delete-node/ &agt3;
+/delete-node/ &agt4;
+/delete-node/ &agt5;
+
 / {
 	soc {
 		sram0: memory@20000000 {

--- a/dts/arm/renesas/ra/ra6/ra6-cm33-common.dtsi
+++ b/dts/arm/renesas/ra/ra6/ra6-cm33-common.dtsi
@@ -168,6 +168,96 @@
 			status = "disabled";
 		};
 
+		agt0: agt@400e8000 {
+			compatible = "renesas,ra-agt";
+			channel = <0>;
+			reg = <0x400e8000 0x100>;
+			renesas,count-source = "AGT_CLOCK_LOCO";
+			renesas,prescaler = <0>;
+			renesas,resolution = <16>;
+			status = "disabled";
+
+			counter {
+				compatible = "renesas,ra-agt-counter";
+				status = "disabled";
+			};
+		};
+
+		agt1: agt@400e8100 {
+			compatible = "renesas,ra-agt";
+			channel = <1>;
+			reg = <0x400e8100 0x100>;
+			renesas,count-source = "AGT_CLOCK_LOCO";
+			renesas,prescaler = <0>;
+			renesas,resolution = <16>;
+			status = "disabled";
+
+			counter {
+				compatible = "renesas,ra-agt-counter";
+				status = "disabled";
+			};
+		};
+
+		agt2: agt@400e8200 {
+			compatible = "renesas,ra-agt";
+			channel = <2>;
+			reg = <0x400e8200 0x100>;
+			renesas,count-source = "AGT_CLOCK_LOCO";
+			renesas,prescaler = <0>;
+			renesas,resolution = <16>;
+			status = "disabled";
+
+			counter {
+				compatible = "renesas,ra-agt-counter";
+				status = "disabled";
+			};
+		};
+
+		agt3: agt@400e8300 {
+			compatible = "renesas,ra-agt";
+			channel = <3>;
+			reg = <0x400e8300 0x100>;
+			renesas,count-source = "AGT_CLOCK_LOCO";
+			renesas,prescaler = <0>;
+			renesas,resolution = <16>;
+			status = "disabled";
+
+			counter {
+				compatible = "renesas,ra-agt-counter";
+				status = "disabled";
+			};
+		};
+
+		agt4: agt@400e8400 {
+			compatible = "renesas,ra-agt";
+			channel = <4>;
+			reg = <0x400e8400 0x100>;
+			renesas,count-source = "AGT_CLOCK_LOCO";
+			renesas,prescaler = <0>;
+			renesas,resolution = <16>;
+			status = "disabled";
+
+			counter {
+				compatible = "renesas,ra-agt-counter";
+				status = "disabled";
+			};
+		};
+
+		agt5: agt@400e8500 {
+			compatible = "renesas,ra-agt";
+			channel = <5>;
+			reg = <0x400e8500 0x100>;
+			renesas,count-source = "AGT_CLOCK_LOCO";
+			renesas,prescaler = <0>;
+			renesas,resolution = <16>;
+			status = "disabled";
+
+			counter {
+				compatible = "renesas,ra-agt-counter";
+				status = "disabled";
+			};
+		};
+
 		option_setting_ofs: option_setting_ofs@100a100 {
 			compatible = "zephyr,memory-region";
 			reg = <0x0100a100 0x18>;

--- a/dts/arm/renesas/ra/ra6/ra6-cm4-common.dtsi
+++ b/dts/arm/renesas/ra/ra6/ra6-cm4-common.dtsi
@@ -257,6 +257,36 @@
 			status = "disabled";
 		};
 
+		agt0: agt@40084000  {
+			compatible = "renesas,ra-agt";
+			channel = <0>;
+			reg = <0x40084000 0x100>;
+			renesas,count-source = "AGT_CLOCK_LOCO";
+			renesas,prescaler = <0>;
+			renesas,resolution = <16>;
+			status = "disabled";
+
+			counter {
+				compatible = "renesas,ra-agt-counter";
+				status = "disabled";
+			};
+		};
+
+		agt1: agt@40084100 {
+			compatible = "renesas,ra-agt";
+			channel = <1>;
+			reg = <0x40084100 0x100>;
+			renesas,count-source = "AGT_CLOCK_LOCO";
+			renesas,prescaler = <0>;
+			renesas,resolution = <16>;
+			status = "disabled";
+
+			counter {
+				compatible = "renesas,ra-agt-counter";
+				status = "disabled";
+			};
+		};
+
 		id_code: id_code@100a150 {
 			compatible = "zephyr,memory-region";
 			reg = <0x0100a150 0x10>;

--- a/samples/drivers/counter/alarm/boards/ek_ra2a1.overlay
+++ b/samples/drivers/counter/alarm/boards/ek_ra2a1.overlay
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2024 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&agt0 {
+	status = "okay";
+	interrupts = <21 1>, <22 1>;
+	interrupt-names = "agti", "agtcmai";
+	renesas,prescaler = <4>;
+	counter0: counter {
+		status = "okay";
+	};
+};

--- a/samples/drivers/counter/alarm/boards/ek_ra4m2.overlay
+++ b/samples/drivers/counter/alarm/boards/ek_ra4m2.overlay
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2024 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&agt0 {
+	status = "okay";
+	interrupts = <83 1>, <84 1>;
+	interrupt-names = "agti", "agtcmai";
+	renesas,prescaler = <4>;
+	counter0: counter {
+		status = "okay";
+	};
+};

--- a/samples/drivers/counter/alarm/boards/ek_ra4m3.overlay
+++ b/samples/drivers/counter/alarm/boards/ek_ra4m3.overlay
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2024 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&agt0 {
+	status = "okay";
+	interrupts = <83 1>, <84 1>;
+	interrupt-names = "agti", "agtcmai";
+	renesas,prescaler = <4>;
+	counter0: counter {
+		status = "okay";
+	};
+};

--- a/samples/drivers/counter/alarm/boards/ek_ra4w1.overlay
+++ b/samples/drivers/counter/alarm/boards/ek_ra4w1.overlay
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2024 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&agt0 {
+	status = "okay";
+	interrupts = <21 1>, <22 1>;
+	interrupt-names = "agti", "agtcmai";
+	renesas,prescaler = <4>;
+	counter0: counter {
+		status = "okay";
+	};
+};

--- a/samples/drivers/counter/alarm/boards/ek_ra6m1.overlay
+++ b/samples/drivers/counter/alarm/boards/ek_ra6m1.overlay
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2024 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&agt0 {
+	status = "okay";
+	interrupts = <83 1>, <84 1>;
+	interrupt-names = "agti", "agtcmai";
+	renesas,prescaler = <4>;
+	counter0: counter {
+		status = "okay";
+	};
+};

--- a/samples/drivers/counter/alarm/boards/ek_ra6m2.overlay
+++ b/samples/drivers/counter/alarm/boards/ek_ra6m2.overlay
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2024 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&agt0 {
+	status = "okay";
+	interrupts = <83 1>, <84 1>;
+	interrupt-names = "agti", "agtcmai";
+	renesas,prescaler = <4>;
+	counter0: counter {
+		status = "okay";
+	};
+};

--- a/samples/drivers/counter/alarm/boards/ek_ra6m3.overlay
+++ b/samples/drivers/counter/alarm/boards/ek_ra6m3.overlay
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2024 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&agt0 {
+	status = "okay";
+	interrupts = <83 1>, <84 1>;
+	interrupt-names = "agti", "agtcmai";
+	renesas,prescaler = <4>;
+	counter0: counter {
+		status = "okay";
+	};
+};

--- a/samples/drivers/counter/alarm/boards/ek_ra6m4.overlay
+++ b/samples/drivers/counter/alarm/boards/ek_ra6m4.overlay
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2024 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&agt0 {
+	status = "okay";
+	interrupts = <83 1>, <84 1>;
+	interrupt-names = "agti", "agtcmai";
+	renesas,prescaler = <4>;
+	counter0: counter {
+		status = "okay";
+	};
+};

--- a/samples/drivers/counter/alarm/boards/ek_ra6m5.overlay
+++ b/samples/drivers/counter/alarm/boards/ek_ra6m5.overlay
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2024 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&agt0 {
+	status = "okay";
+	interrupts = <83 1>, <84 1>;
+	interrupt-names = "agti", "agtcmai";
+	renesas,prescaler = <4>;
+	counter0: counter {
+		status = "okay";
+	};
+};

--- a/samples/drivers/counter/alarm/boards/fpb_ra6e1.overlay
+++ b/samples/drivers/counter/alarm/boards/fpb_ra6e1.overlay
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2024 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&agt0 {
+	status = "okay";
+	interrupts = <83 1>, <84 1>;
+	interrupt-names = "agti", "agtcmai";
+	renesas,prescaler = <4>;
+	counter0: counter {
+		status = "okay";
+	};
+};


### PR DESCRIPTION
Add support for AGT Counter driver for RA6, RA4, RA2 devices

- Add AGT Counter driver support on RA6M1, RA6M2, RA6M3, RA6M4, RA6M5, RA6E1, RA4M2, RA4M3, RA4W1, RA2A1
- Add support `samples/drivers/counter/alarm` for RA6M1, RA6M2, RA6M3, RA6M4, RA6M5, RA6E1, RA4M2, RA4M3, RA4W1, RA2A1