### PR TITLE
Support ADC driver for Renesas RA8, RA6, RA4 devices

### DIFF
--- a/boards/renesas/ek_ra4e2/doc/index.rst
+++ b/boards/renesas/ek_ra4e2/doc/index.rst
@@ -100,6 +100,8 @@ The below features are currently supported on Zephyr OS for EK-RA4E2 board:
 +-----------+------------+----------------------+
 | SPI       | on-chip    | spi                  |
 +-----------+------------+----------------------+
+| ADC       | on-chip    | adc                  |
++-----------+------------+----------------------+
 
 Other hardware features are currently not supported by the port.
 

--- a/boards/renesas/ek_ra4e2/ek_ra4e2-pinctrl.dtsi
+++ b/boards/renesas/ek_ra4e2/ek_ra4e2-pinctrl.dtsi
@@ -30,4 +30,12 @@
 			drive-strength = "high";
 		};
 	};
+
+	adc0_default: adc0_default {
+		group1 {
+			/* input */
+			psels = <RA_PSEL(RA_PSEL_ADC, 0, 0)>;
+			renesas,analog-enable;
+		};
+	};
 };

--- a/boards/renesas/ek_ra4e2/ek_ra4e2.dts
+++ b/boards/renesas/ek_ra4e2/ek_ra4e2.dts
@@ -7,6 +7,7 @@
 
 #include <renesas/ra/ra4/r7fa4e2b93cfm.dtsi>
 #include <dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/adc/adc.h>
 #include "ek_ra4e2-pinctrl.dtsi"
 
 / {
@@ -110,4 +111,10 @@
 		rx-max-filters = <16>;
 		status = "okay";
 	};
+};
+
+&adc0 {
+	status = "okay";
+	pinctrl-0 = <&adc0_default>;
+	pinctrl-names = "default";
 };

--- a/boards/renesas/ek_ra4m2/doc/index.rst
+++ b/boards/renesas/ek_ra4m2/doc/index.rst
@@ -102,6 +102,8 @@ The below features are currently supported on Zephyr OS for EK-RA4M2 board:
 +-----------+------------+----------------------+
 | COUNTER   | on-chip    | counter              |
 +-----------+------------+----------------------+
+| ADC       | on-chip    | adc                  |
++-----------+------------+----------------------+
 
 Other hardware features are currently not supported by the port.
 

--- a/boards/renesas/ek_ra4m2/ek_ra4m2-pinctrl.dtsi
+++ b/boards/renesas/ek_ra4m2/ek_ra4m2-pinctrl.dtsi
@@ -21,4 +21,12 @@
 			<RA_PSEL(RA_PSEL_SPI, 3, 0)>;
 		};
 	};
+
+	adc0_default: adc0_default {
+		group1 {
+			/* input */
+			psels = <RA_PSEL(RA_PSEL_ADC, 0, 0)>;
+			renesas,analog-enable;
+		};
+	};
 };

--- a/boards/renesas/ek_ra4m2/ek_ra4m2.dts
+++ b/boards/renesas/ek_ra4m2/ek_ra4m2.dts
@@ -7,6 +7,7 @@
 
 #include <renesas/ra/ra4/r7fa4m2ad3cfp.dtsi>
 #include <dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/adc/adc.h>
 #include "ek_ra4m2-pinctrl.dtsi"
 
 / {
@@ -77,4 +78,10 @@
 	pinctrl-0 = <&spi0_default>;
 	pinctrl-names = "default";
 	status = "okay";
+};
+
+&adc0 {
+	status = "okay";
+	pinctrl-0 = <&adc0_default>;
+	pinctrl-names = "default";
 };

--- a/boards/renesas/ek_ra4m3/doc/index.rst
+++ b/boards/renesas/ek_ra4m3/doc/index.rst
@@ -104,6 +104,8 @@ The below features are currently supported on Zephyr OS for EK-RA4M3 board:
 +-----------+------------+----------------------+
 | COUNTER   | on-chip    | counter              |
 +-----------+------------+----------------------+
+| ADC       | on-chip    | adc                  |
++-----------+------------+----------------------+
 
 Other hardware features are currently not supported by the port.
 

--- a/boards/renesas/ek_ra4m3/ek_ra4m3-pinctrl.dtsi
+++ b/boards/renesas/ek_ra4m3/ek_ra4m3-pinctrl.dtsi
@@ -21,4 +21,12 @@
 			<RA_PSEL(RA_PSEL_SPI, 7, 3)>;
 		};
 	};
+
+	adc0_default: adc0_default {
+		group1 {
+			/* input */
+			psels = <RA_PSEL(RA_PSEL_ADC, 0, 0)>;
+			renesas,analog-enable;
+		};
+	};
 };

--- a/boards/renesas/ek_ra4m3/ek_ra4m3.dts
+++ b/boards/renesas/ek_ra4m3/ek_ra4m3.dts
@@ -7,6 +7,7 @@
 
 #include <renesas/ra/ra4/r7fa4m3af3cfb.dtsi>
 #include <dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/adc/adc.h>
 #include "ek_ra4m3-pinctrl.dtsi"
 
 / {
@@ -77,4 +78,10 @@
 	pinctrl-0 = <&spi0_default>;
 	pinctrl-names = "default";
 	status = "okay";
+};
+
+&adc0 {
+	status = "okay";
+	pinctrl-0 = <&adc0_default>;
+	pinctrl-names = "default";
 };

--- a/boards/renesas/ek_ra4w1/doc/index.rst
+++ b/boards/renesas/ek_ra4w1/doc/index.rst
@@ -96,6 +96,8 @@ The below features are currently supported on Zephyr OS for EK-RA4W1 board:
 +-----------+------------+----------------------+
 | ENTROPY   | on-chip    | entropy              |
 +-----------+------------+----------------------+
+| ADC       | on-chip    | adc                  |
++-----------+------------+----------------------+
 
 Other hardware features are currently not supported by the port.
 

--- a/boards/renesas/ek_ra4w1/ek_ra4w1-pinctrl.dtsi
+++ b/boards/renesas/ek_ra4w1/ek_ra4w1-pinctrl.dtsi
@@ -21,4 +21,12 @@
 			<RA_PSEL(RA_PSEL_SPI, 1, 12)>;
 		};
 	};
+
+	adc0_default: adc0_default {
+		group1 {
+			/* input */
+			psels = <RA_PSEL(RA_PSEL_ADC, 0, 4)>;
+			renesas,analog-enable;
+		};
+	};
 };

--- a/boards/renesas/ek_ra4w1/ek_ra4w1.dts
+++ b/boards/renesas/ek_ra4w1/ek_ra4w1.dts
@@ -7,6 +7,7 @@
 
 #include <renesas/ra/ra4/r7fa4w1ad2cng.dtsi>
 #include <dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/adc/adc.h>
 #include "ek_ra4w1-pinctrl.dtsi"
 
 / {
@@ -69,4 +70,10 @@
 
 &trng {
 	status = "okay";
+};
+
+&adc0 {
+	status = "okay";
+	pinctrl-0 = <&adc0_default>;
+	pinctrl-names = "default";
 };

--- a/boards/renesas/ek_ra6e2/doc/index.rst
+++ b/boards/renesas/ek_ra6e2/doc/index.rst
@@ -100,6 +100,8 @@ The below features are currently supported on Zephyr OS for EK-RA6E2 board:
 +-----------+------------+----------------------+
 | SPI       | on-chip    | spi                  |
 +-----------+------------+----------------------+
+| ADC       | on-chip    | adc                  |
++-----------+------------+----------------------+
 
 Other hardware features are currently not supported by the port.
 

--- a/boards/renesas/ek_ra6e2/ek_ra6e2-pinctrl.dtsi
+++ b/boards/renesas/ek_ra6e2/ek_ra6e2-pinctrl.dtsi
@@ -30,4 +30,12 @@
 			drive-strength = "high";
 		};
 	};
+
+	adc0_default: adc0_default {
+		group1 {
+			/* input */
+			psels = <RA_PSEL(RA_PSEL_ADC, 0, 0)>;
+			renesas,analog-enable;
+		};
+	};
 };

--- a/boards/renesas/ek_ra6e2/ek_ra6e2.dts
+++ b/boards/renesas/ek_ra6e2/ek_ra6e2.dts
@@ -7,6 +7,7 @@
 
 #include <renesas/ra/ra6/r7fa6e2bb3cfm.dtsi>
 #include <dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/adc/adc.h>
 
 #include "ek_ra6e2-pinctrl.dtsi"
 
@@ -125,4 +126,10 @@
 			max-bitrate = <5000000>;
 		};
 	};
+};
+
+&adc0 {
+	status = "okay";
+	pinctrl-0 = <&adc0_default>;
+	pinctrl-names = "default";
 };

--- a/boards/renesas/ek_ra6m1/doc/index.rst
+++ b/boards/renesas/ek_ra6m1/doc/index.rst
@@ -100,6 +100,8 @@ The below features are currently supported on Zephyr OS for EK-RA6M1 board:
 +-----------+------------+----------------------+
 | COUNTER   | on-chip    | counter              |
 +-----------+------------+----------------------+
+| ADC       | on-chip    | adc                  |
++-----------+------------+----------------------+
 
 Other hardware features are currently not supported by the port.
 

--- a/boards/renesas/ek_ra6m1/ek_ra6m1-pinctrl.dtsi
+++ b/boards/renesas/ek_ra6m1/ek_ra6m1-pinctrl.dtsi
@@ -30,4 +30,12 @@
 			<RA_PSEL(RA_PSEL_SPI, 4, 13)>;
 		};
 	};
+
+	adc0_default: adc0_default {
+		group1 {
+			/* input */
+			psels = <RA_PSEL(RA_PSEL_ADC, 0, 0)>;
+			renesas,analog-enable;
+		};
+	};
 };

--- a/boards/renesas/ek_ra6m1/ek_ra6m1.dts
+++ b/boards/renesas/ek_ra6m1/ek_ra6m1.dts
@@ -7,6 +7,7 @@
 
 #include <renesas/ra/ra6/r7fa6m1ad3cfp.dtsi>
 #include <dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/adc/adc.h>
 
 #include "ek_ra6m1-pinctrl.dtsi"
 
@@ -86,4 +87,10 @@
 
 &trng {
 	status ="okay";
+};
+
+&adc0 {
+	status = "okay";
+	pinctrl-0 = <&adc0_default>;
+	pinctrl-names = "default";
 };

--- a/boards/renesas/ek_ra6m2/doc/index.rst
+++ b/boards/renesas/ek_ra6m2/doc/index.rst
@@ -94,6 +94,8 @@ The below features are currently supported on Zephyr OS for EK-RA6M2 board:
 +-----------+------------+----------------------+
 | COUNTER   | on-chip    | counter              |
 +-----------+------------+----------------------+
+| ADC       | on-chip    | adc                  |
++-----------+------------+----------------------+
 
 Other hardware features are currently not supported by the port.
 

--- a/boards/renesas/ek_ra6m2/ek_ra6m2-pinctrl.dtsi
+++ b/boards/renesas/ek_ra6m2/ek_ra6m2-pinctrl.dtsi
@@ -30,4 +30,12 @@
 			<RA_PSEL(RA_PSEL_SPI, 4, 13)>;
 		};
 	};
+
+	adc0_default: adc0_default {
+		group1 {
+			/* input */
+			psels = <RA_PSEL(RA_PSEL_ADC, 0, 0)>;
+			renesas,analog-enable;
+		};
+	};
 };

--- a/boards/renesas/ek_ra6m2/ek_ra6m2.dts
+++ b/boards/renesas/ek_ra6m2/ek_ra6m2.dts
@@ -7,6 +7,7 @@
 
 #include <renesas/ra/ra6/r7fa6m2af3cfb.dtsi>
 #include <dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/adc/adc.h>
 
 #include "ek_ra6m2-pinctrl.dtsi"
 
@@ -86,4 +87,10 @@
 
 &trng {
 	status ="okay";
+};
+
+&adc0 {
+	status = "okay";
+	pinctrl-0 = <&adc0_default>;
+	pinctrl-names = "default";
 };

--- a/boards/renesas/ek_ra6m3/doc/index.rst
+++ b/boards/renesas/ek_ra6m3/doc/index.rst
@@ -104,6 +104,8 @@ The below features are currently supported on Zephyr OS for EK-RA6M3 board:
 +-----------+------------+----------------------+
 | USBHS     | on-chip    | udc                  |
 +-----------+------------+----------------------+
+| ADC       | on-chip    | adc                  |
++-----------+------------+----------------------+
 
 Other hardware features are currently not supported by the port.
 

--- a/boards/renesas/ek_ra6m3/ek_ra6m3-pinctrl.dtsi
+++ b/boards/renesas/ek_ra6m3/ek_ra6m3-pinctrl.dtsi
@@ -37,4 +37,12 @@
 			drive-strength = "high";
 		};
 	};
+
+	adc0_default: adc0_default {
+		group1 {
+			/* input */
+			psels = <RA_PSEL(RA_PSEL_ADC, 0, 0)>;
+			renesas,analog-enable;
+		};
+	};
 };

--- a/boards/renesas/ek_ra6m3/ek_ra6m3.dts
+++ b/boards/renesas/ek_ra6m3/ek_ra6m3.dts
@@ -7,6 +7,7 @@
 
 #include <renesas/ra/ra6/r7fa6m3ah3cfc.dtsi>
 #include <dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/adc/adc.h>
 
 #include "ek_ra6m3-pinctrl.dtsi"
 
@@ -112,4 +113,10 @@
 
 &usbhs_phy {
 	phys-clock-src = "xtal";
+};
+
+&adc0 {
+	status = "okay";
+	pinctrl-0 = <&adc0_default>;
+	pinctrl-names = "default";
 };

--- a/boards/renesas/ek_ra6m4/doc/index.rst
+++ b/boards/renesas/ek_ra6m4/doc/index.rst
@@ -107,6 +107,8 @@ The below features are currently supported on Zephyr OS for EK-RA6M4 board:
 +-----------+------------+----------------------+
 | COUNTER   | on-chip    | counter              |
 +-----------+------------+----------------------+
+| ADC       | on-chip    | adc                  |
++-----------+------------+----------------------+
 
 Other hardware features are currently not supported by the port.
 

--- a/boards/renesas/ek_ra6m4/ek_ra6m4-pinctrl.dtsi
+++ b/boards/renesas/ek_ra6m4/ek_ra6m4-pinctrl.dtsi
@@ -30,4 +30,12 @@
 			<RA_PSEL(RA_PSEL_SPI, 2, 5)>;
 		};
 	};
+
+	adc0_default: adc0_default {
+		group1 {
+			/* input */
+			psels = <RA_PSEL(RA_PSEL_ADC, 0, 0)>;
+			renesas,analog-enable;
+		};
+	};
 };

--- a/boards/renesas/ek_ra6m4/ek_ra6m4.dts
+++ b/boards/renesas/ek_ra6m4/ek_ra6m4.dts
@@ -7,6 +7,7 @@
 
 #include <renesas/ra/ra6/r7fa6m4af3cfb.dtsi>
 #include <dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/adc/adc.h>
 
 #include "ek_ra6m4-pinctrl.dtsi"
 
@@ -95,4 +96,10 @@
 	clocks = <&pll>;
 	div = <2>;
 	status = "okay";
+};
+
+&adc0 {
+	status = "okay";
+	pinctrl-0 = <&adc0_default>;
+	pinctrl-names = "default";
 };

--- a/boards/renesas/ek_ra6m5/doc/index.rst
+++ b/boards/renesas/ek_ra6m5/doc/index.rst
@@ -107,6 +107,8 @@ The below features are currently supported on Zephyr OS for EK-RA6M5 board:
 +-----------+------------+----------------------+
 | USBHS     | on-chip    | udc                  |
 +-----------+------------+----------------------+
+| ADC       | on-chip    | adc                  |
++-----------+------------+----------------------+
 
 Other hardware features are currently not supported by the port.
 

--- a/boards/renesas/ek_ra6m5/ek_ra6m5-pinctrl.dtsi
+++ b/boards/renesas/ek_ra6m5/ek_ra6m5-pinctrl.dtsi
@@ -37,4 +37,12 @@
 			drive-strength = "high";
 		};
 	};
+
+	adc0_default: adc0_default {
+		group1 {
+			/* input */
+			psels = <RA_PSEL(RA_PSEL_ADC, 0, 0)>;
+			renesas,analog-enable;
+		};
+	};
 };

--- a/boards/renesas/ek_ra6m5/ek_ra6m5.dts
+++ b/boards/renesas/ek_ra6m5/ek_ra6m5.dts
@@ -7,6 +7,7 @@
 
 #include <renesas/ra/ra6/r7fa6m5bh3cfc.dtsi>
 #include <dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/adc/adc.h>
 
 #include "ek_ra6m5-pinctrl.dtsi"
 
@@ -103,4 +104,10 @@
 
 &usbhs_phy {
 	phys-clock-src = "xtal";
+};
+
+&adc0 {
+	status = "okay";
+	pinctrl-0 = <&adc0_default>;
+	pinctrl-names = "default";
 };

--- a/boards/renesas/ek_ra8d1/doc/index.rst
+++ b/boards/renesas/ek_ra8d1/doc/index.rst
@@ -116,6 +116,8 @@ The below features are currently supported on Zephyr OS for EK-RA8D1 board:
 +--------------+------------+------------------+
 | ETHERNET     | on-chip    | ethernet         |
 +--------------+------------+------------------+
+| ADC          | on-chip    | adc              |
++--------------+------------+------------------+
 
 **Note:** for using Ethernet on RA8D1 board please set switch SW1 as following configuration:
 

--- a/boards/renesas/ek_ra8d1/ek_ra8d1-pinctrl.dtsi
+++ b/boards/renesas/ek_ra8d1/ek_ra8d1-pinctrl.dtsi
@@ -77,4 +77,12 @@
 			drive-strength = "high";
 		};
 	};
+
+	adc0_default: adc0_default {
+		group1 {
+			/* input */
+			psels = <RA_PSEL(RA_PSEL_ADC, 0, 4)>;
+			renesas,analog-enable;
+		};
+	};
 };

--- a/boards/renesas/ek_ra8d1/ek_ra8d1.dts
+++ b/boards/renesas/ek_ra8d1/ek_ra8d1.dts
@@ -7,7 +7,7 @@
 
 #include <renesas/ra/ra8/r7fa8d1bhecbd.dtsi>
 #include <dt-bindings/gpio/gpio.h>
-
+#include <zephyr/dt-bindings/adc/adc.h>
 #include "ek_ra8d1-pinctrl.dtsi"
 
 / {
@@ -191,4 +191,10 @@
 
 &usbhs_phy {
 	phys-clock-src = "xtal";
+};
+
+&adc0 {
+	status = "okay";
+	pinctrl-0 = <&adc0_default>;
+	pinctrl-names = "default";
 };

--- a/boards/renesas/ek_ra8m1/doc/index.rst
+++ b/boards/renesas/ek_ra8m1/doc/index.rst
@@ -116,6 +116,8 @@ The below features are currently supported on Zephyr OS for EK-RA8M1 board:
 +-----------+------------+----------------------+
 | ETHERNET  | on-chip    | ethernet             |
 +-----------+------------+----------------------+
+| ADC       | on-chip    | adc                  |
++-----------+------------+----------------------+
 
 **Note:** For using Ethernet module on EK-RA8M1, remove jumper J61 to enable Ethernet B
 

--- a/boards/renesas/ek_ra8m1/ek_ra8m1.dts
+++ b/boards/renesas/ek_ra8m1/ek_ra8m1.dts
@@ -238,6 +238,7 @@ mikrobus_serial: &uart3 {};
 	status = "okay";
 	pinctrl-0 = <&adc0_default>;
 	pinctrl-names = "default";
+	average-count = <4>;
 };
 
 &trng {

--- a/boards/renesas/fpb_ra6e1/doc/index.rst
+++ b/boards/renesas/fpb_ra6e1/doc/index.rst
@@ -89,6 +89,8 @@ The below features are currently supported on Zephyr OS for FPB-RA6E1 board:
 +-----------+------------+----------------------+
 | COUNTER   | on-chip    | counter              |
 +-----------+------------+----------------------+
+| ADC       | on-chip    | adc                  |
++-----------+------------+----------------------+
 
 Other hardware features are currently not supported by the port.
 

--- a/boards/renesas/fpb_ra6e1/fpb_ra6e1-pinctrl.dtsi
+++ b/boards/renesas/fpb_ra6e1/fpb_ra6e1-pinctrl.dtsi
@@ -30,4 +30,12 @@
 			<RA_PSEL(RA_PSEL_SPI, 4, 13)>;
 		};
 	};
+
+	adc0_default: adc0_default {
+		group1 {
+			/* input */
+			psels = <RA_PSEL(RA_PSEL_ADC, 0, 0)>;
+			renesas,analog-enable;
+		};
+	};
 };

--- a/boards/renesas/fpb_ra6e1/fpb_ra6e1.dts
+++ b/boards/renesas/fpb_ra6e1/fpb_ra6e1.dts
@@ -7,6 +7,7 @@
 
 #include <renesas/ra/ra6/r7fa6e10f2cfp.dtsi>
 #include <dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/adc/adc.h>
 
 #include "fpb_ra6e1-pinctrl.dtsi"
 
@@ -96,4 +97,10 @@
 			reg = <0x80000 DT_SIZE_K(512)>;
 		};
 	};
+};
+
+&adc0 {
+	status = "okay";
+	pinctrl-0 = <&adc0_default>;
+	pinctrl-names = "default";
 };

--- a/boards/renesas/fpb_ra6e2/doc/index.rst
+++ b/boards/renesas/fpb_ra6e2/doc/index.rst
@@ -87,6 +87,8 @@ The below features are currently supported on Zephyr OS for FPB-RA6E2 board:
 +-----------+------------+----------------------+
 | SPI       | on-chip    | spi                  |
 +-----------+------------+----------------------+
+| ADC       | on-chip    | adc                  |
++-----------+------------+----------------------+
 
 Other hardware features are currently not supported by the port.
 

--- a/boards/renesas/fpb_ra6e2/fpb_ra6e2-pinctrl.dtsi
+++ b/boards/renesas/fpb_ra6e2/fpb_ra6e2-pinctrl.dtsi
@@ -21,4 +21,12 @@
 			<RA_PSEL(RA_PSEL_SPI, 3, 1)>;
 		};
 	};
+
+	adc0_default: adc0_default {
+		group1 {
+			/* input */
+			psels = <RA_PSEL(RA_PSEL_ADC, 0, 0)>;
+			renesas,analog-enable;
+		};
+	};
 };

--- a/boards/renesas/fpb_ra6e2/fpb_ra6e2.dts
+++ b/boards/renesas/fpb_ra6e2/fpb_ra6e2.dts
@@ -7,6 +7,7 @@
 
 #include <renesas/ra/ra6/r7fa6e2bb3cfm.dtsi>
 #include <dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/adc/adc.h>
 
 #include "fpb_ra6e2-pinctrl.dtsi"
 
@@ -86,4 +87,10 @@
 	div = <1>;
 	mul = <10 0>;
 	status = "okay";
+};
+
+&adc0 {
+	status = "okay";
+	pinctrl-0 = <&adc0_default>;
+	pinctrl-names = "default";
 };

--- a/boards/renesas/mck_ra8t1/doc/index.rst
+++ b/boards/renesas/mck_ra8t1/doc/index.rst
@@ -112,6 +112,8 @@ The below features are currently supported on Zephyr OS for MCB-RA8T1 board:
 +--------------+------------+----------------------+
 | ETHERNET     | on-chip    | ethernet             |
 +--------------+------------+----------------------+
+| ADC          | on-chip    | adc                  |
++--------------+------------+----------------------+
 
 Other hardware features are currently not supported by the port.
 

--- a/boards/renesas/mck_ra8t1/mck_ra8t1-pinctrl.dtsi
+++ b/boards/renesas/mck_ra8t1/mck_ra8t1-pinctrl.dtsi
@@ -70,4 +70,12 @@
 			drive-strength = "high";
 		};
 	};
+
+	adc0_default: adc0_default {
+		group1 {
+			/* input */
+			psels = <RA_PSEL(RA_PSEL_ADC, 0, 4)>;
+			renesas,analog-enable;
+		};
+	};
 };

--- a/boards/renesas/mck_ra8t1/mck_ra8t1.dts
+++ b/boards/renesas/mck_ra8t1/mck_ra8t1.dts
@@ -7,7 +7,7 @@
 
 #include <renesas/ra/ra8/r7fa8t1ahecbd.dtsi>
 #include <dt-bindings/gpio/gpio.h>
-
+#include <zephyr/dt-bindings/adc/adc.h>
 #include "mck_ra8t1-pinctrl.dtsi"
 
 / {
@@ -170,4 +170,11 @@
 		reg = <5>;
 		status = "okay";
 	};
+};
+
+&adc0 {
+	status = "okay";
+	pinctrl-0 = <&adc0_default>;
+	pinctrl-names = "default";
+	average-count = <4>;
 };

--- a/drivers/adc/adc_renesas_ra.c
+++ b/drivers/adc/adc_renesas_ra.c
@@ -11,6 +11,7 @@
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/drivers/reset.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/sys/util_internal.h>
 #include <instances/r_adc.h>
 
 #include <zephyr/irq.h>
@@ -21,6 +22,11 @@ LOG_MODULE_REGISTER(adc_ra, CONFIG_ADC_LOG_LEVEL);
 #include "adc_context.h"
 
 #define ADC_RA_MAX_RESOLUTION 12
+#define ADC_AVERAGE_1         ADC_ADD_OFF
+#define ADC_AVERAGE_2         ADC_ADD_AVERAGE_TWO
+#define ADC_AVERAGE_4         ADC_ADD_AVERAGE_FOUR
+#define ADC_AVERAGE_8         ADC_ADD_AVERAGE_EIGHT
+#define ADC_AVERAGE_16        ADC_ADD_AVERAGE_SIXTEEN
 
 void adc_scan_end_isr(void);
 
@@ -32,6 +38,8 @@ void adc_scan_end_isr(void);
 struct adc_ra_config {
 	/** Number of supported channels */
 	uint8_t num_channels;
+	/** Mask for channels existed in each board */
+	uint32_t channel_available_mask;
 	/** pinctrl configs */
 	const struct pinctrl_dev_config *pcfg;
 	/** function pointer to irq setup */
@@ -76,10 +84,9 @@ static int adc_ra_channel_setup(const struct device *dev, const struct adc_chann
 {
 	fsp_err_t fsp_err = FSP_SUCCESS;
 	struct adc_ra_data *data = dev->data;
+	const struct adc_ra_config *config = dev->config;
 
-	if (!((channel_cfg->channel_id >= 0 && channel_cfg->channel_id <= 2) ||
-	      (channel_cfg->channel_id >= 4 && channel_cfg->channel_id <= 8) ||
-	      (channel_cfg->channel_id >= 16 && channel_cfg->channel_id <= 19))) {
+	if (!((config->channel_available_mask & (1 << channel_cfg->channel_id)) != 0)) {
 		LOG_ERR("unsupported channel id '%d'", channel_cfg->channel_id);
 		return -ENOTSUP;
 	}
@@ -312,20 +319,6 @@ static int adc_ra_init(const struct device *dev)
 	return 0;
 }
 
-const adc_extended_cfg_t g_adc_cfg_extend = {
-	.add_average_count = ADC_ADD_OFF,
-	.clearing = ADC_CLEAR_AFTER_READ_ON,
-	.trigger_group_b = ADC_START_SOURCE_DISABLED,
-	.double_trigger_mode = ADC_DOUBLE_TRIGGER_DISABLED,
-	.adc_vref_control = ADC_VREF_CONTROL_VREFH,
-	.enable_adbuf = 0,
-	.window_a_irq = FSP_INVALID_VECTOR,
-	.window_a_ipl = (1),
-	.window_b_irq = FSP_INVALID_VECTOR,
-	.window_b_ipl = (BSP_IRQ_DISABLED),
-	.trigger = ADC_START_SOURCE_DISABLED, /* Use Software trigger */
-};
-
 #define IRQ_CONFIGURE_FUNC(idx)                                                                    \
 	static void adc_ra_configure_func_##idx(void)                                              \
 	{                                                                                          \
@@ -342,6 +335,19 @@ const adc_extended_cfg_t g_adc_cfg_extend = {
 #define ADC_RA_INIT(idx)                                                                           \
 	IRQ_CONFIGURE_FUNC(idx)                                                                    \
 	PINCTRL_DT_INST_DEFINE(idx);                                                               \
+	static const adc_extended_cfg_t g_adc_cfg_extend_##idx = {                                 \
+		.add_average_count = UTIL_CAT(ADC_AVERAGE_, DT_INST_PROP(idx, average_count)),     \
+		.clearing = ADC_CLEAR_AFTER_READ_ON,                                               \
+		.trigger_group_b = ADC_START_SOURCE_DISABLED,                                      \
+		.double_trigger_mode = ADC_DOUBLE_TRIGGER_DISABLED,                                \
+		.adc_vref_control = ADC_VREF_CONTROL_VREFH,                                        \
+		.enable_adbuf = 0,                                                                 \
+		.window_a_irq = FSP_INVALID_VECTOR,                                                \
+		.window_a_ipl = (1),                                                               \
+		.window_b_irq = FSP_INVALID_VECTOR,                                                \
+		.window_b_ipl = (BSP_IRQ_DISABLED),                                                \
+		.trigger = ADC_START_SOURCE_DISABLED,                                              \
+	};                                                                                         \
 	static DEVICE_API(adc, adc_ra_api_##idx) = {                                               \
 		.channel_setup = adc_ra_channel_setup,                                             \
 		.read = adc_ra_read,                                                               \
@@ -349,6 +355,7 @@ const adc_extended_cfg_t g_adc_cfg_extend = {
 		IF_ENABLED(CONFIG_ADC_ASYNC, (.read_async = adc_ra_read_async))};                  \
 	static const struct adc_ra_config adc_ra_config_##idx = {                                  \
 		.num_channels = DT_INST_PROP(idx, channel_count),                                  \
+		.channel_available_mask = DT_INST_PROP(idx, channel_available_mask),               \
 		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(idx),                                       \
 		IRQ_CONFIGURE_DEFINE(idx),                                                         \
 	};                                                                                         \
@@ -366,7 +373,7 @@ const adc_extended_cfg_t g_adc_cfg_extend = {
 				.trigger = 0,                                                      \
 				.p_callback = NULL,                                                \
 				.p_context = NULL,                                                 \
-				.p_extend = &g_adc_cfg_extend,                                     \
+				.p_extend = &g_adc_cfg_extend_##idx,                               \
 				.scan_end_irq = DT_INST_IRQ_BY_NAME(idx, scanend, irq),            \
 				.scan_end_ipl = DT_INST_IRQ_BY_NAME(idx, scanend, priority),       \
 				.scan_end_b_irq = FSP_INVALID_VECTOR,                              \
@@ -377,7 +384,7 @@ const adc_extended_cfg_t g_adc_cfg_extend = {
 				.scan_mask = 0,                                                    \
 				.scan_mask_group_b = 0,                                            \
 				.priority_group_a = ADC_GROUP_A_PRIORITY_OFF,                      \
-				.add_mask = 0,                                                     \
+				.add_mask = UINT16_MAX,                                            \
 				.sample_hold_mask = 0,                                             \
 				.sample_hold_states = 24,                                          \
 				.p_window_cfg = NULL,                                              \

--- a/dts/arm/renesas/ra/ra4/r7fa4e2b93cfm.dtsi
+++ b/dts/arm/renesas/ra/ra4/r7fa4e2b93cfm.dtsi
@@ -14,6 +14,8 @@
 /delete-node/ &agt4;
 /delete-node/ &agt5;
 
+/delete-node/ &adc1;
+
 / {
 	soc {
 		sram0: memory@20000000 {
@@ -39,6 +41,11 @@
 				compatible = "soc-nv-flash";
 				reg = <0x0 DT_SIZE_K(128)>;
 			};
+		};
+
+		adc@40170000 {
+			channel-count = <12>;
+			channel-available-mask = <0x139f7>;
 		};
 
 		id_code: id_code@100a120 {

--- a/dts/arm/renesas/ra/ra4/r7fa4m2ax.dtsi
+++ b/dts/arm/renesas/ra/ra4/r7fa4m2ax.dtsi
@@ -9,6 +9,8 @@
 
 /delete-node/ &spi1;
 
+/delete-node/ &adc1;
+
 / {
 	soc {
 		sram0: memory@20000000 {
@@ -90,6 +92,11 @@
 				channel = <4>;
 				status = "disabled";
 			};
+		};
+
+		adc@40170000 {
+			channel-count = <13>;
+			channel-available-mask = <0x139ff>;
 		};
 	};
 

--- a/dts/arm/renesas/ra/ra4/r7fa4m3ax.dtsi
+++ b/dts/arm/renesas/ra/ra4/r7fa4m3ax.dtsi
@@ -101,6 +101,16 @@
 				status = "disabled";
 			};
 		};
+
+		adc@40170000 {
+			channel-count = <12>;
+			channel-available-mask = <0x33ff>;
+		};
+
+		adc@40170200 {
+			channel-count = <10>;
+			channel-available-mask = <0x7f0007>;
+		};
 	};
 
 	clocks: clocks {

--- a/dts/arm/renesas/ra/ra4/r7fa4w1ad2cng.dtsi
+++ b/dts/arm/renesas/ra/ra4/r7fa4w1ad2cng.dtsi
@@ -7,6 +7,8 @@
 #include <zephyr/dt-bindings/clock/ra_clock.h>
 #include <arm/renesas/ra/ra4/ra4-cm4-common.dtsi>
 
+/delete-node/ &adc1;
+
 / {
 	soc {
 		sram0: memory@20000000 {
@@ -44,6 +46,12 @@
 		trng: trng {
 			compatible = "renesas,ra-sce5-rng";
 			status = "disabled";
+		};
+
+		adc@4005c000 {
+			interrupts = <20 1>;
+			channel-count = <8>;
+			channel-available-mask = <0x1a0670>;
 		};
 	};
 

--- a/dts/arm/renesas/ra/ra4/ra4-cm33-common.dtsi
+++ b/dts/arm/renesas/ra/ra4/ra4-cm33-common.dtsi
@@ -247,6 +247,26 @@
 			};
 		};
 
+		adc0: adc@40170000 {
+			compatible = "renesas,ra-adc";
+			interrupts = <40 1>;
+			interrupt-names = "scanend";
+			reg = <0x40170000 0x100>;
+			#io-channel-cells = <1>;
+			vref-mv = <3300>;
+			status = "disabled";
+		};
+
+		adc1: adc@40170200 {
+			compatible = "renesas,ra-adc";
+			interrupts = <41 1>;
+			interrupt-names = "scanend";
+			reg = <0x40170200 0x100>;
+			#io-channel-cells = <1>;
+			vref-mv = <3300>;
+			status = "disabled";
+		};
+
 		option_setting_ofs: option_setting_ofs@100a100 {
 			compatible = "zephyr,memory-region";
 			reg = <0x0100a100 0x18>;

--- a/dts/arm/renesas/ra/ra4/ra4-cm4-common.dtsi
+++ b/dts/arm/renesas/ra/ra4/ra4-cm4-common.dtsi
@@ -210,6 +210,24 @@
 			};
 		};
 
+		adc0: adc@4005c000 {
+			compatible = "renesas,ra-adc";
+			interrupt-names = "scanend";
+			reg = <0x4005c000 0x100>;
+			#io-channel-cells = <1>;
+			vref-mv = <3300>;
+			status = "disabled";
+		};
+
+		adc1: adc@4005c200 {
+			compatible = "renesas,ra-adc";
+			interrupt-names = "scanend";
+			reg = <0x4005c200 0x100>;
+			#io-channel-cells = <1>;
+			vref-mv = <3300>;
+			status = "disabled";
+		};
+
 		id_code: id_code@1010018 {
 			compatible = "zephyr,memory-region";
 			reg = <0x01010018 0x20>;

--- a/dts/arm/renesas/ra/ra6/r7fa6e10x.dtsi
+++ b/dts/arm/renesas/ra/ra6/r7fa6e10x.dtsi
@@ -7,6 +7,8 @@
 #include <arm/renesas/ra/ra6/ra6-cm33-common.dtsi>
 #include <zephyr/dt-bindings/clock/ra_clock.h>
 
+/delete-node/ &adc1;
+
 / {
 	soc {
 		sram0: memory@20000000 {
@@ -88,6 +90,11 @@
 				channel = <4>;
 				status = "disabled";
 			};
+		};
+
+		adc@40170000 {
+			channel-count = <11>;
+			channel-available-mask = <0x31ff>;
 		};
 	};
 

--- a/dts/arm/renesas/ra/ra6/r7fa6e2bx.dtsi
+++ b/dts/arm/renesas/ra/ra6/r7fa6e2bx.dtsi
@@ -14,6 +14,8 @@
 /delete-node/ &agt4;
 /delete-node/ &agt5;
 
+/delete-node/ &adc1;
+
 / {
 	soc {
 		sram0: memory@20000000 {
@@ -29,6 +31,11 @@
 			#gpio-cells = <2>;
 			ngpios = <16>;
 			status = "disabled";
+		};
+
+		adc@40170000 {
+			channel-count = <12>;
+			channel-available-mask = <0x139f7>;
 		};
 
 		id_code: id_code@100a120 {

--- a/dts/arm/renesas/ra/ra6/r7fa6m1ad3cfp.dtsi
+++ b/dts/arm/renesas/ra/ra6/r7fa6m1ad3cfp.dtsi
@@ -29,6 +29,16 @@
 			compatible = "renesas,ra-sce7-rng";
 			status = "disabled";
 		};
+
+		adc@4005c000 {
+			channel-count = <11>;
+			channel-available-mask = <0x1700ef>;
+		};
+
+		adc@4005c200 {
+			channel-count = <8>;
+			channel-available-mask = <0x300e7>;
+		};
 	};
 
 	clocks: clocks {

--- a/dts/arm/renesas/ra/ra6/r7fa6m2ax.dtsi
+++ b/dts/arm/renesas/ra/ra6/r7fa6m2ax.dtsi
@@ -62,6 +62,16 @@
 			reg = <0x40053200 0x100>;
 			status = "disabled";
 		};
+
+		adc@4005c000 {
+			channel-count = <13>;
+			channel-available-mask = <0x1f00ff>;
+		};
+
+		adc@4005c200 {
+			channel-count = <9>;
+			channel-available-mask = <0x700e7>;
+		};
 	};
 
 	clocks: clocks {

--- a/dts/arm/renesas/ra/ra6/r7fa6m3ax.dtsi
+++ b/dts/arm/renesas/ra/ra6/r7fa6m3ax.dtsi
@@ -116,6 +116,16 @@
 				status = "disabled";
 			};
 		};
+
+		adc@4005c000 {
+			channel-count = <13>;
+			channel-available-mask = <0x1f00ff>;
+		};
+
+		adc@4005c200 {
+			channel-count = <11>;
+			channel-available-mask = <0xf00ef>;
+		};
 	};
 
 	clocks: clocks {

--- a/dts/arm/renesas/ra/ra6/r7fa6m4ax.dtsi
+++ b/dts/arm/renesas/ra/ra6/r7fa6m4ax.dtsi
@@ -125,6 +125,16 @@
 				status = "disabled";
 			};
 		};
+
+		adc@40170000 {
+			channel-count = <12>;
+			channel-available-mask = <0x33ff>;
+		};
+
+		adc@40170200 {
+			channel-count = <10>;
+			channel-available-mask = <0x7f0007>;
+		};
 	};
 
 	clocks: clocks {

--- a/dts/arm/renesas/ra/ra6/r7fa6m5xh.dtsi
+++ b/dts/arm/renesas/ra/ra6/r7fa6m5xh.dtsi
@@ -206,6 +206,16 @@
 				status = "disabled";
 			};
 		};
+
+		adc@40170000 {
+			channel-count = <13>;
+			channel-available-mask = <0x37ff>;
+		};
+
+		adc@40170200 {
+			channel-count = <16>;
+			channel-available-mask = <0x1fff0007>;
+		};
 	};
 
 	clocks: clocks {

--- a/dts/arm/renesas/ra/ra6/ra6-cm33-common.dtsi
+++ b/dts/arm/renesas/ra/ra6/ra6-cm33-common.dtsi
@@ -258,6 +258,26 @@
 			};
 		};
 
+		adc0: adc@40170000 {
+			compatible = "renesas,ra-adc";
+			interrupts = <40 1>;
+			interrupt-names = "scanend";
+			reg = <0x40170000 0x100>;
+			#io-channel-cells = <1>;
+			vref-mv = <3300>;
+			status = "disabled";
+		};
+
+		adc1: adc@40170200 {
+			compatible = "renesas,ra-adc";
+			interrupts = <41 1>;
+			interrupt-names = "scanend";
+			reg = <0x40170200 0x100>;
+			#io-channel-cells = <1>;
+			vref-mv = <3300>;
+			status = "disabled";
+		};
+
 		option_setting_ofs: option_setting_ofs@100a100 {
 			compatible = "zephyr,memory-region";
 			reg = <0x0100a100 0x18>;

--- a/dts/arm/renesas/ra/ra6/ra6-cm4-common.dtsi
+++ b/dts/arm/renesas/ra/ra6/ra6-cm4-common.dtsi
@@ -287,6 +287,26 @@
 			};
 		};
 
+		adc0: adc@4005c000 {
+			compatible = "renesas,ra-adc";
+			interrupts = <40 1>;
+			interrupt-names = "scanend";
+			reg = <0x4005c000 0x100>;
+			#io-channel-cells = <1>;
+			vref-mv = <3300>;
+			status = "disabled";
+		};
+
+		adc1: adc@4005c200 {
+			compatible = "renesas,ra-adc";
+			interrupts = <41 1>;
+			interrupt-names = "scanend";
+			reg = <0x4005c200 0x100>;
+			#io-channel-cells = <1>;
+			vref-mv = <3300>;
+			status = "disabled";
+		};
+
 		id_code: id_code@100a150 {
 			compatible = "zephyr,memory-region";
 			reg = <0x0100a150 0x10>;

--- a/dts/arm/renesas/ra/ra8/ra8x1.dtsi
+++ b/dts/arm/renesas/ra/ra8/ra8x1.dtsi
@@ -289,6 +289,7 @@
 			#io-channel-cells = <1>;
 			vref-mv = <3300>;
 			channel-count = <12>;
+			channel-available-mask = <0xf01f7>;
 			status = "disabled";
 		};
 
@@ -300,6 +301,7 @@
 			#io-channel-cells = <1>;
 			vref-mv = <3300>;
 			channel-count = <13>;
+			channel-available-mask = <0x7f0077>;
 			status = "disabled";
 		};
 

--- a/dts/bindings/adc/renesas,ra-adc.yaml
+++ b/dts/bindings/adc/renesas,ra-adc.yaml
@@ -24,5 +24,18 @@ properties:
   "#io-channel-cells":
     const: 1
 
+  channel-available-mask:
+    type: int
+    required: true
+    description: Mask for ADC channels existed in each board
+
+  average-count:
+    type: int
+    default: 1
+    enum: [1, 2, 4, 8, 16]
+    description: The conversion count of the average mode
+      The ADC module will take multiple samples of an analog signal
+      and averages them to reduce noise and enhance accuracy
+
 io-channel-cells:
   - input

--- a/tests/drivers/adc/adc_accuracy_test/boards/ek_ra4e2.overlay
+++ b/tests/drivers/adc/adc_accuracy_test/boards/ek_ra4e2.overlay
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2024 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	zephyr,user {
+		io-channels = <&adc0 0>;
+		reference_mv = <3300>;
+		expected_accuracy = <32>;
+	};
+};
+
+&adc0{
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+		zephyr,vref-mv = <3300>;
+	};
+};

--- a/tests/drivers/adc/adc_accuracy_test/boards/ek_ra4m2.overlay
+++ b/tests/drivers/adc/adc_accuracy_test/boards/ek_ra4m2.overlay
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2024 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	zephyr,user {
+		io-channels = <&adc0 0>;
+		reference_mv = <3300>;
+		expected_accuracy = <32>;
+	};
+};
+
+&adc0{
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+		zephyr,vref-mv = <3300>;
+	};
+};

--- a/tests/drivers/adc/adc_accuracy_test/boards/ek_ra4m3.overlay
+++ b/tests/drivers/adc/adc_accuracy_test/boards/ek_ra4m3.overlay
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2024 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	zephyr,user {
+		io-channels = <&adc0 0>;
+		reference_mv = <3300>;
+		expected_accuracy = <32>;
+	};
+};
+
+&adc0{
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+		zephyr,vref-mv = <3300>;
+	};
+};

--- a/tests/drivers/adc/adc_accuracy_test/boards/ek_ra4w1.overlay
+++ b/tests/drivers/adc/adc_accuracy_test/boards/ek_ra4w1.overlay
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2024 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	zephyr,user {
+		io-channels = <&adc0 4>;
+		reference_mv = <3300>;
+		expected_accuracy = <32>;
+	};
+};
+
+&adc0{
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	channel@4 {
+		reg = <4>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+		zephyr,vref-mv = <3300>;
+	};
+};

--- a/tests/drivers/adc/adc_accuracy_test/boards/ek_ra6e2.overlay
+++ b/tests/drivers/adc/adc_accuracy_test/boards/ek_ra6e2.overlay
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2024 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	zephyr,user {
+		io-channels = <&adc0 0>;
+		reference_mv = <3300>;
+		expected_accuracy = <32>;
+	};
+};
+
+&adc0{
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+		zephyr,vref-mv = <3300>;
+	};
+};

--- a/tests/drivers/adc/adc_accuracy_test/boards/ek_ra6m1.overlay
+++ b/tests/drivers/adc/adc_accuracy_test/boards/ek_ra6m1.overlay
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2024 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	zephyr,user {
+		io-channels = <&adc0 0>;
+		reference_mv = <3300>;
+		expected_accuracy = <32>;
+	};
+};
+
+&adc0{
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+		zephyr,vref-mv = <3300>;
+	};
+};

--- a/tests/drivers/adc/adc_accuracy_test/boards/ek_ra6m2.overlay
+++ b/tests/drivers/adc/adc_accuracy_test/boards/ek_ra6m2.overlay
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2024 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	zephyr,user {
+		io-channels = <&adc0 0>;
+		reference_mv = <3300>;
+		expected_accuracy = <32>;
+	};
+};
+
+&adc0{
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+		zephyr,vref-mv = <3300>;
+	};
+};

--- a/tests/drivers/adc/adc_accuracy_test/boards/ek_ra6m3.overlay
+++ b/tests/drivers/adc/adc_accuracy_test/boards/ek_ra6m3.overlay
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2024 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	zephyr,user {
+		io-channels = <&adc0 0>;
+		reference_mv = <3300>;
+		expected_accuracy = <32>;
+	};
+};
+
+&adc0{
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+		zephyr,vref-mv = <3300>;
+	};
+};

--- a/tests/drivers/adc/adc_accuracy_test/boards/ek_ra6m4.overlay
+++ b/tests/drivers/adc/adc_accuracy_test/boards/ek_ra6m4.overlay
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2024 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	zephyr,user {
+		io-channels = <&adc0 0>;
+		reference_mv = <3300>;
+		expected_accuracy = <32>;
+	};
+};
+
+&adc0{
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+		zephyr,vref-mv = <3300>;
+	};
+};

--- a/tests/drivers/adc/adc_accuracy_test/boards/ek_ra6m5.overlay
+++ b/tests/drivers/adc/adc_accuracy_test/boards/ek_ra6m5.overlay
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2024 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	zephyr,user {
+		io-channels = <&adc0 0>;
+		reference_mv = <3300>;
+		expected_accuracy = <32>;
+	};
+};
+
+&adc0{
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+		zephyr,vref-mv = <3300>;
+	};
+};

--- a/tests/drivers/adc/adc_accuracy_test/boards/ek_ra8d1.overlay
+++ b/tests/drivers/adc/adc_accuracy_test/boards/ek_ra8d1.overlay
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2024 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	zephyr,user {
+		io-channels = <&adc0 0>;
+		reference_mv = <3300>;
+		expected_accuracy = <32>;
+	};
+};
+
+&adc0{
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+		zephyr,vref-mv = <3300>;
+	};
+};

--- a/tests/drivers/adc/adc_accuracy_test/boards/fpb_ra6e1.overlay
+++ b/tests/drivers/adc/adc_accuracy_test/boards/fpb_ra6e1.overlay
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2024 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	zephyr,user {
+		io-channels = <&adc0 0>;
+		reference_mv = <3300>;
+		expected_accuracy = <32>;
+	};
+};
+
+&adc0{
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+		zephyr,vref-mv = <3300>;
+	};
+};

--- a/tests/drivers/adc/adc_accuracy_test/boards/fpb_ra6e2.overlay
+++ b/tests/drivers/adc/adc_accuracy_test/boards/fpb_ra6e2.overlay
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2024 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	zephyr,user {
+		io-channels = <&adc0 0>;
+		reference_mv = <3300>;
+		expected_accuracy = <32>;
+	};
+};
+
+&adc0{
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+		zephyr,vref-mv = <3300>;
+	};
+};

--- a/tests/drivers/adc/adc_accuracy_test/boards/mck_ra8t1.overlay
+++ b/tests/drivers/adc/adc_accuracy_test/boards/mck_ra8t1.overlay
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2024 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	zephyr,user {
+		io-channels = <&adc0 0>;
+		reference_mv = <3300>;
+		expected_accuracy = <32>;
+	};
+};
+
+&adc0{
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+		zephyr,vref-mv = <3300>;
+	};
+};

--- a/tests/drivers/adc/adc_accuracy_test/testcase.yaml
+++ b/tests/drivers/adc/adc_accuracy_test/testcase.yaml
@@ -12,7 +12,6 @@ tests:
       fixture: dac_adc_loopback
     platform_allow:
       - frdm_k64f
-      - ek_ra8m1
   drivers.adc.accuracy.ref_volt:
     harness_config:
       fixture: adc_ref_volt

--- a/tests/drivers/adc/adc_accuracy_test/testcase.yaml
+++ b/tests/drivers/adc/adc_accuracy_test/testcase.yaml
@@ -22,5 +22,19 @@ tests:
       - nrf52840dk/nrf52840
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
+      - ek_ra8d1
+      - mck_ra8t1
+      - ek_ra6e2
+      - ek_ra6m1
+      - ek_ra6m2
+      - ek_ra6m3
+      - ek_ra6m4
+      - ek_ra6m5
+      - fpb_ra6e1
+      - fpb_ra6e2
+      - ek_ra4e2
+      - ek_ra4m2
+      - ek_ra4m3
+      - ek_ra4w1
     integration_platforms:
       - frdm_kl25z

--- a/tests/drivers/adc/adc_api/boards/ek_ra4e2.overlay
+++ b/tests/drivers/adc/adc_api/boards/ek_ra4e2.overlay
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2024 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
+/ {
+	zephyr,user {
+		io-channels = <&adc0 0>, <&adc0 2>;
+	};
+};
+
+&adc0 {
+	status = "okay";
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,resolution = <12>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,vref-mv = <3300>;
+	};
+
+	channel@2 {
+		reg = <2>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,resolution = <12>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,vref-mv = <3300>;
+	};
+};

--- a/tests/drivers/adc/adc_api/boards/ek_ra4m2.overlay
+++ b/tests/drivers/adc/adc_api/boards/ek_ra4m2.overlay
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2024 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
+/ {
+	zephyr,user {
+		io-channels = <&adc0 0>, <&adc0 2>;
+	};
+};
+
+&adc0 {
+	status = "okay";
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,resolution = <12>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,vref-mv = <3300>;
+	};
+
+	channel@2 {
+		reg = <2>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,resolution = <12>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,vref-mv = <3300>;
+	};
+};

--- a/tests/drivers/adc/adc_api/boards/ek_ra4m3.overlay
+++ b/tests/drivers/adc/adc_api/boards/ek_ra4m3.overlay
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2024 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
+/ {
+	zephyr,user {
+		io-channels = <&adc1 0>, <&adc1 2>;
+	};
+};
+
+&pinctrl {
+	adc1_default: adc1_default {
+		group1 {
+			/* input */
+			psels = <RA_PSEL(RA_PSEL_ADC, 0, 0)>;
+			renesas,analog-enable;
+		};
+	};
+};
+
+&adc1 {
+	pinctrl-0 = <&adc1_default>;
+	pinctrl-names = "default";
+	status = "okay";
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,resolution = <12>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,vref-mv = <3300>;
+	};
+
+	channel@2 {
+		reg = <2>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,resolution = <12>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,vref-mv = <3300>;
+	};
+};

--- a/tests/drivers/adc/adc_api/boards/ek_ra4w1.overlay
+++ b/tests/drivers/adc/adc_api/boards/ek_ra4w1.overlay
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2024 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
+/ {
+	zephyr,user {
+		io-channels = <&adc0 4>, <&adc0 6>;
+	};
+};
+
+&adc0 {
+	status = "okay";
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@4 {
+		reg = <4>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,resolution = <12>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,vref-mv = <3300>;
+	};
+
+	channel@6 {
+		reg = <6>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,resolution = <12>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,vref-mv = <3300>;
+	};
+};

--- a/tests/drivers/adc/adc_api/boards/ek_ra6e2.overlay
+++ b/tests/drivers/adc/adc_api/boards/ek_ra6e2.overlay
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2024 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
+/ {
+	zephyr,user {
+		io-channels = <&adc0 0>, <&adc0 2>;
+	};
+};
+
+&adc0 {
+	status = "okay";
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,resolution = <12>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,vref-mv = <3300>;
+	};
+
+	channel@2 {
+		reg = <2>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,resolution = <12>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,vref-mv = <3300>;
+	};
+};

--- a/tests/drivers/adc/adc_api/boards/ek_ra6m1.overlay
+++ b/tests/drivers/adc/adc_api/boards/ek_ra6m1.overlay
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2024 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
+/ {
+	zephyr,user {
+		io-channels = <&adc1 0>, <&adc1 2>;
+	};
+};
+
+&pinctrl {
+	adc1_default: adc1_default {
+		group1 {
+			/* input */
+			psels = <RA_PSEL(RA_PSEL_ADC, 0, 0)>;
+			renesas,analog-enable;
+		};
+	};
+};
+
+&adc1 {
+	pinctrl-0 = <&adc1_default>;
+	pinctrl-names = "default";
+	status = "okay";
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,resolution = <12>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,vref-mv = <3300>;
+	};
+
+	channel@2 {
+		reg = <2>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,resolution = <12>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,vref-mv = <3300>;
+	};
+};

--- a/tests/drivers/adc/adc_api/boards/ek_ra6m2.overlay
+++ b/tests/drivers/adc/adc_api/boards/ek_ra6m2.overlay
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2024 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
+/ {
+	zephyr,user {
+		io-channels = <&adc1 0>, <&adc1 2>;
+	};
+};
+
+&pinctrl {
+	adc1_default: adc1_default {
+		group1 {
+			/* input */
+			psels = <RA_PSEL(RA_PSEL_ADC, 0, 0)>;
+			renesas,analog-enable;
+		};
+	};
+};
+
+&adc1 {
+	pinctrl-0 = <&adc1_default>;
+	pinctrl-names = "default";
+	status = "okay";
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,resolution = <12>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,vref-mv = <3300>;
+	};
+
+	channel@2 {
+		reg = <2>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,resolution = <12>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,vref-mv = <3300>;
+	};
+};

--- a/tests/drivers/adc/adc_api/boards/ek_ra6m3.overlay
+++ b/tests/drivers/adc/adc_api/boards/ek_ra6m3.overlay
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2024 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
+/ {
+	zephyr,user {
+		io-channels = <&adc1 0>, <&adc1 2>;
+	};
+};
+
+&pinctrl {
+	adc1_default: adc1_default {
+		group1 {
+			/* input */
+			psels = <RA_PSEL(RA_PSEL_ADC, 0, 0)>;
+			renesas,analog-enable;
+		};
+	};
+};
+
+&adc1 {
+	pinctrl-0 = <&adc1_default>;
+	pinctrl-names = "default";
+	status = "okay";
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,resolution = <12>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,vref-mv = <3300>;
+	};
+
+	channel@2 {
+		reg = <2>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,resolution = <12>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,vref-mv = <3300>;
+	};
+};

--- a/tests/drivers/adc/adc_api/boards/ek_ra6m4.overlay
+++ b/tests/drivers/adc/adc_api/boards/ek_ra6m4.overlay
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2024 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
+/ {
+	zephyr,user {
+		io-channels = <&adc1 0>, <&adc1 2>;
+	};
+};
+
+&pinctrl {
+	adc1_default: adc1_default {
+		group1 {
+			/* input */
+			psels = <RA_PSEL(RA_PSEL_ADC, 0, 0)>;
+			renesas,analog-enable;
+		};
+	};
+};
+
+&adc1 {
+	pinctrl-0 = <&adc1_default>;
+	pinctrl-names = "default";
+	status = "okay";
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,resolution = <12>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,vref-mv = <3300>;
+	};
+
+	channel@2 {
+		reg = <2>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,resolution = <12>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,vref-mv = <3300>;
+	};
+};

--- a/tests/drivers/adc/adc_api/boards/ek_ra6m5.overlay
+++ b/tests/drivers/adc/adc_api/boards/ek_ra6m5.overlay
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2024 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
+/ {
+	zephyr,user {
+		io-channels = <&adc1 0>, <&adc1 2>;
+	};
+};
+
+&pinctrl {
+	adc1_default: adc1_default {
+		group1 {
+			/* input */
+			psels = <RA_PSEL(RA_PSEL_ADC, 0, 0)>;
+			renesas,analog-enable;
+		};
+	};
+};
+
+&adc1 {
+	pinctrl-0 = <&adc1_default>;
+	pinctrl-names = "default";
+	status = "okay";
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,resolution = <12>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,vref-mv = <3300>;
+	};
+
+	channel@2 {
+		reg = <2>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,resolution = <12>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,vref-mv = <3300>;
+	};
+};

--- a/tests/drivers/adc/adc_api/boards/ek_ra8d1.overlay
+++ b/tests/drivers/adc/adc_api/boards/ek_ra8d1.overlay
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2024 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
+/ {
+	zephyr,user {
+		io-channels = <&adc1 0>, <&adc1 2>;
+	};
+};
+
+&pinctrl {
+	adc1_default: adc1_default {
+		group1 {
+			/* input */
+			psels = <RA_PSEL(RA_PSEL_ADC, 0, 0)>;
+			renesas,analog-enable;
+		};
+	};
+};
+
+&adc1 {
+	pinctrl-0 = <&adc1_default>;
+	pinctrl-names = "default";
+	status = "okay";
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,resolution = <12>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,vref-mv = <3300>;
+	};
+
+	channel@2 {
+		reg = <2>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,resolution = <12>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,vref-mv = <3300>;
+	};
+};

--- a/tests/drivers/adc/adc_api/boards/fpb_ra6e1.overlay
+++ b/tests/drivers/adc/adc_api/boards/fpb_ra6e1.overlay
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2024 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
+/ {
+	zephyr,user {
+		io-channels = <&adc0 0>, <&adc0 2>;
+	};
+};
+
+&adc0 {
+	status = "okay";
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,resolution = <12>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,vref-mv = <3300>;
+	};
+
+	channel@2 {
+		reg = <2>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,resolution = <12>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,vref-mv = <3300>;
+	};
+};

--- a/tests/drivers/adc/adc_api/boards/fpb_ra6e2.overlay
+++ b/tests/drivers/adc/adc_api/boards/fpb_ra6e2.overlay
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2024 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
+/ {
+	zephyr,user {
+		io-channels = <&adc0 0>, <&adc0 2>;
+	};
+};
+
+&adc0 {
+	status = "okay";
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,resolution = <12>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,vref-mv = <3300>;
+	};
+
+	channel@2 {
+		reg = <2>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,resolution = <12>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,vref-mv = <3300>;
+	};
+};

--- a/tests/drivers/adc/adc_api/boards/mck_ra8t1.overlay
+++ b/tests/drivers/adc/adc_api/boards/mck_ra8t1.overlay
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2024 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
+/ {
+	zephyr,user {
+		io-channels = <&adc1 0>, <&adc1 2>;
+	};
+};
+
+&pinctrl {
+	adc1_default: adc1_default {
+		group1 {
+			/* input */
+			psels = <RA_PSEL(RA_PSEL_ADC, 0, 0)>;
+			renesas,analog-enable;
+		};
+	};
+};
+
+&adc1 {
+	pinctrl-0 = <&adc1_default>;
+	pinctrl-names = "default";
+	status = "okay";
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,resolution = <12>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,vref-mv = <3300>;
+	};
+
+	channel@2 {
+		reg = <2>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,resolution = <12>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,vref-mv = <3300>;
+	};
+};


### PR DESCRIPTION
- Add missing ADC document for ek_ra8m1 board
- Remove test id for ek_ra8m1 in the `adc_accuracy_test`
- Add 2 ADC properties in Renesas RA ADC node
- Enable ADC support on these boards:
RA8: ek_ra8d1, mck_ra8t1
RA6: ek_ra6m1, ek_ra6m2, ek_ra6m3, ek_ra6m4, ek_ra6m5, ek_ra6e2, fpb_ra6e1, fpb_ra6e2,
RA4: ek_ra4m2, ek_ra4m3, ek_ra4e2, ek_ra4w1