### PR TITLE
board: frdmmcxc444: Add uart support

### DIFF
--- a/boards/nxp/frdm_mcxc444/frdm_mcxc444-pinctrl.dtsi
+++ b/boards/nxp/frdm_mcxc444/frdm_mcxc444-pinctrl.dtsi
@@ -16,4 +16,12 @@
 			slew-rate = "slow";
 		};
 	};
+	pinmux_uart2: pinmux_uart2 {
+		group0 {
+			pinmux = <UART2_RX_PTD2>,
+				<UART2_TX_PTD3>;
+			drive-strength = "low";
+			slew-rate = "slow";
+		};
+	};
 };

--- a/boards/nxp/frdm_mcxc444/frdm_mcxc444.dts
+++ b/boards/nxp/frdm_mcxc444/frdm_mcxc444.dts
@@ -100,3 +100,10 @@
 &lptmr0 {
 	status = "okay";
 };
+
+&uart2 {
+	status = "disabled";
+	current-speed = <115200>;
+	pinctrl-0 = <&pinmux_uart2>;
+	pinctrl-names = "default";
+};

--- a/boards/nxp/frdm_mcxc444/frdm_mcxc444.yaml
+++ b/boards/nxp/frdm_mcxc444/frdm_mcxc444.yaml
@@ -16,6 +16,7 @@ toolchain:
   - xtools
 supported:
   - gpio
+  - uart
   - counter
 testing:
   ignore_tags:


### PR DESCRIPTION
Add UART configuration and pin control. Set state to disabled, as it serves as alternative to default LPUART0 or as second uart only.