### PR TITLE
tests: ztest: use platform_key for filtering

### DIFF
--- a/tests/ztest/base/testcase.yaml
+++ b/tests/ztest/base/testcase.yaml
@@ -1,4 +1,6 @@
 common:
+  platform_key:
+    - arch
   tags:
     - test_framework
 tests:

--- a/tests/ztest/error_hook/testcase.yaml
+++ b/tests/ztest/error_hook/testcase.yaml
@@ -1,4 +1,6 @@
 common:
+  platform_key:
+    - arch
   tags:
     - test_framework
 tests:

--- a/tests/ztest/summary/testcase.yaml
+++ b/tests/ztest/summary/testcase.yaml
@@ -1,4 +1,6 @@
 tests:
   testing.ztest.summary.shared_unit_test:
+    platform_key:
+      - arch
     tags:
       - test_framework

--- a/tests/ztest/zexpect/testcase.yaml
+++ b/tests/ztest/zexpect/testcase.yaml
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 common:
+  platform_key:
+    - arch
   integration_platforms:
     - native_sim
   tags:

--- a/tests/ztest/ztress/testcase.yaml
+++ b/tests/ztest/ztress/testcase.yaml
@@ -3,6 +3,8 @@ common:
     - test_framework
   platform_type:
     - qemu
+  platform_key:
+    - arch
 tests:
   testing.ztest.ztress:
     # FIXME: qemu_cortex_r5 is excluded due to a run-time failure, see #49494


### PR DESCRIPTION
Use platform_key to control filtering and test target scope.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
