### PR TITLE
doc: releases: Add list of added shields in 4.0 cycle

### DIFF
--- a/boards/shields/eval_adxl362_ardz/doc/index.rst
+++ b/boards/shields/eval_adxl362_ardz/doc/index.rst
@@ -1,4 +1,4 @@
-.. eval_adxl362_ardz:
+.. _eval_adxl362_ardz:
 
 EVAL-ADXL362-ARDZ
 #################

--- a/boards/shields/eval_adxl372_ardz/doc/index.rst
+++ b/boards/shields/eval_adxl372_ardz/doc/index.rst
@@ -1,4 +1,4 @@
-.. eval_adxl372_ardz:
+.. _eval_adxl372_ardz:
 
 EVAL-ADXL372-ARDZ
 #################

--- a/boards/shields/pmod_acl/doc/index.rst
+++ b/boards/shields/pmod_acl/doc/index.rst
@@ -1,4 +1,4 @@
-.. pmod_acl:
+.. _pmod_acl:
 
 Digilent Pmod ACL
 #################

--- a/doc/releases/release-notes-4.0.rst
+++ b/doc/releases/release-notes-4.0.rst
@@ -182,6 +182,15 @@ Boards & SoC Support
 
 * Added support for the following shields:
 
+  * :ref:`ADI EVAL-ADXL362-ARDZ <eval_adxl362_ardz>`
+  * :ref:`ADI EVAL-ADXL372-ARDZ <eval_adxl372_ardz>`
+  * :ref:`Digilent Pmod ACL <pmod_acl>`
+  * :ref:`MikroElektronika BLE TINY Click <mikroe_ble_tiny_click_shield>`
+  * :ref:`Nordic SemiConductor nRF7002 EB <nrf7002eb>`
+  * :ref:`Nordic SemiConductor nRF7002 EK <nrf7002ek>`
+  * :ref:`ST X-NUCLEO-WB05KN1: BLE expansion board <x-nucleo-wb05kn1>`
+  * :ref:`WeAct Studio MiniSTM32H7xx OV2640 Camera Sensor <weact_ov2640_cam_module>`
+
 Build system and Infrastructure
 *******************************
 

--- a/doc/releases/release-notes-4.0.rst
+++ b/doc/releases/release-notes-4.0.rst
@@ -25,7 +25,7 @@ The following CVEs are addressed by this release:
 More detailed information can be found in:
 https://docs.zephyrproject.org/latest/security/vulnerabilities.html
 
-* CVE-2024-8798: Under embargo until 2024-11-22
+* :cve:`2024-8798`: Under embargo until 2024-11-22
 
 API Changes
 ***********


### PR DESCRIPTION
Adds the list of new shields for 4.0 release, sorted by vendor name.

(also sneaking in a tiny commit improving cross referencing of CVEs)