### PR TITLE
Bluetooth: Log Controller Build Information

### DIFF
--- a/doc/connectivity/bluetooth/api/hci.txt
+++ b/doc/connectivity/bluetooth/api/hci.txt
@@ -213,8 +213,8 @@ additional counter for incremental builds.
 	+--------------------+--------------------------------------+
 	| Value              | Parameter Description                |
 	+--------------------+--------------------------------------+
-	| 0x00               | Standard Bluetooth controller        |
-	| 0x01               | Vendor specific controller           |
+	| 0x00               | Zephyr(R) Bluetooth Controller       |
+	| 0x01               | Vendor specific Controller           |
 	| 0x02               | Firmware loader                      |
 	| 0x03               | Rescue image                         |
 	| All other values   | Reserved for future use              |

--- a/include/zephyr/bluetooth/hci_vs.h
+++ b/include/zephyr/bluetooth/hci_vs.h
@@ -35,6 +35,8 @@ extern "C" {
 
 #define BT_VS_CMD_SUP_FEAT(cmd)                 BT_LE_FEAT_TEST(cmd, \
 						BT_VS_CMD_BIT_SUP_FEAT)
+#define BT_VS_CMD_SUP_BUILD_INFO(cmd)           BT_LE_FEAT_TEST(cmd, \
+						BT_VS_CMD_BIT_READ_BUILD_INFO)
 #define BT_VS_CMD_READ_STATIC_ADDRS(cmd)        BT_LE_FEAT_TEST(cmd, \
 						BT_VS_CMD_BIT_READ_STATIC_ADDRS)
 #define BT_VS_CMD_READ_KEY_ROOTS(cmd)           BT_LE_FEAT_TEST(cmd, \


### PR DESCRIPTION
Add implementation to use Vendor Specific HCI Zephyr Read Build Information Command and print the information in the logs.

Change the string "Standard Bluetooth Controller" to "Zephyr(R) Bluetooth Controller".

```
[00:08:04.186,065] <inf> bt_hci_core: HW Platform: Nordic Semiconductor (0x0002)
[00:08:04.186,096] <inf> bt_hci_core: HW Variant: nRF52x (0x0002)
[00:08:04.186,126] <inf> bt_hci_core: Firmware: Zephyr(R) Bluetooth Controller (0x00) Version 4.0 Build 0
[00:08:04.186,370] <inf> bt_hci_core: Build Information: Zephyr OS v4.0.0-rc1
[00:08:04.186,645] <inf> bt_hci_core: No ID address. App must call settings_load()
[00:08:04.187,957] <inf> bt_hci_core: Identity: D2:79:ED:18:CA:84 (random)
[00:08:04.187,988] <inf> bt_hci_core: HCI: version 5.4 (0x0d) revision 0x0000, manufacturer 0x05f1
[00:08:04.188,018] <inf> bt_hci_core: LMP: version 5.4 (0x0d) subver 0xffff
```

Fixes #80679.