### PR TITLE
cmake: use CMake variable KERNEL_VERSION_CUSTOMIZATION for default value

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -598,6 +598,8 @@ add_custom_command(
   COMMAND_EXPAND_LISTS
 )
 add_custom_target(version_h DEPENDS ${PROJECT_BINARY_DIR}/include/generated/zephyr/version.h)
+zephyr_get(KERNEL_VERSION_CUSTOMIZATION SYSBUILD LOCAL)
+set_property(TARGET version_h PROPERTY KERNEL_VERSION_CUSTOMIZATION ${KERNEL_VERSION_CUSTOMIZATION})
 
 if(EXISTS ${APPLICATION_SOURCE_DIR}/VERSION)
   add_custom_command(
@@ -616,6 +618,8 @@ if(EXISTS ${APPLICATION_SOURCE_DIR}/VERSION)
     app_version_h
     DEPENDS ${PROJECT_BINARY_DIR}/include/generated/zephyr/app_version.h)
   add_dependencies(zephyr_interface app_version_h)
+  zephyr_get(APP_VERSION_CUSTOMIZATION SYSBUILD LOCAL)
+  set_property(TARGET app_version_h PROPERTY APP_VERSION_CUSTOMIZATION ${APP_VERSION_CUSTOMIZATION})
 endif()
 
 # Unfortunately, the order in which CMakeLists.txt code is processed


### PR DESCRIPTION
Fixes: #80193

With #62395 the Zephyr kernel and app version customization values were moved to target properties to allow Zephyr modules to adjust the values.

This had the consequence described by #80193 that version customization using CMake arguments, `-D`, or CMakeList.txt toplevel file can no longer be used for customizing the version.

To support both CMake variable as well as Zephyr module version customization use-cases then this commit uses `zephyr_get()` to fetch any CMake variable adjustments and uses the value for default property setting. This allows users to set customized version while still allow Zephyr modules to overrule this as intended with #62395.