### PR TITLE
include: dma: add release API function and drop `isr-ok` tag from channel request/release functions

### DIFF
--- a/include/zephyr/drivers/dma.h
+++ b/include/zephyr/drivers/dma.h
@@ -553,7 +553,9 @@ static inline int z_impl_dma_resume(const struct device *dev, uint32_t channel)
  * request DMA channel resources
  * return -EINVAL if there is no valid channel available.
  *
- * @funcprops \isr_ok
+ * @note It is safe to use this function in contexts where blocking
+ * is not allowed, e.g. ISR, provided the implementation of the filter
+ * function does not block.
  *
  * @param dev Pointer to the device structure for the driver instance.
  * @param filter_param filter function parameter
@@ -598,7 +600,9 @@ static inline int z_impl_dma_request_channel(const struct device *dev,
  *
  * release DMA channel resources
  *
- * @funcprops \isr_ok
+ * @note It is safe to use this function in contexts where blocking
+ * is not allowed, e.g. ISR, provided the implementation of the release
+ * function does not block.
  *
  * @param dev  Pointer to the device structure for the driver instance.
  * @param channel  channel number


### PR DESCRIPTION
Solution proposed for https://github.com/zephyrproject-rtos/zephyr/issues/80746. Drop the `isr-ok` tag from `dma_request_channel()`/`dma_release_channel()`, while adding a comment about the `isr-ok` being implementation-dependent. Also, a new API function is added: `chan_release`.