### PR TITLE
doc: fix scrolling glitch causing search bar to be partially hidden

### DIFF
--- a/doc/_static/js/custom.js
+++ b/doc/_static/js/custom.js
@@ -16,7 +16,7 @@ const registerOnScrollEvent = (function(){
         // Configuration.
 
         // The number of pixels the user must scroll by before the logo is completely hidden.
-        const scrollTopPixels = 156;
+        const scrollTopPixels = 137;
         // The target margin to be applied to the navigation bar when the logo is hidden.
         const menuTopMargin = 54;
         // The max-height offset when the logo is completely visible.


### PR DESCRIPTION
With the recent update to Sphinx RTD theme 3.0.0, a 19px-high element that used to display the version number is not visible anymore, so the JS code that hides the upper-left logo when scrolling down needs to be adjusted to account for this change.

Note that https://github.com/readthedocs/sphinx_rtd_theme/issues/1624 might look at re-introducing the version number as it's not clear that the fact it disappeared was fully intentional.

BEFORE the fix

<img width="534" alt="image" src="https://github.com/user-attachments/assets/48ea8932-478f-48e5-be95-49d3aeb6291e">


AFTER the fix

<img width="440" alt="image" src="https://github.com/user-attachments/assets/f8b2cf2c-26e7-499f-801c-edffe7e9f4db">
