### PR TITLE
drivers: comparator: fix wrong @since tag

### DIFF
--- a/include/zephyr/drivers/comparator.h
+++ b/include/zephyr/drivers/comparator.h
@@ -10,7 +10,7 @@
 /**
  * @brief Comparator Interface
  * @defgroup comparator_interface Comparator Interface
- * @since 3.7
+ * @since 4.0
  * @version 0.1.0
  * @ingroup io_interfaces
  * @{


### PR DESCRIPTION
The Comparator API was introduced in 4.0, not 3.7