### PR TITLE
drivers: pwm: ledc: esp32c2: esp32c6: Fix clock frequency

### DIFF
--- a/drivers/pwm/pwm_led_esp32.c
+++ b/drivers/pwm/pwm_led_esp32.c
@@ -22,6 +22,17 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(pwm_ledc_esp32, CONFIG_PWM_LOG_LEVEL);
 
+#if SOC_LEDC_SUPPORT_APB_CLOCK
+#define CLOCK_SOURCE LEDC_APB_CLK
+#elif SOC_LEDC_SUPPORT_PLL_DIV_CLOCK
+#define CLOCK_SOURCE LEDC_SCLK
+#if defined(CONFIG_SOC_SERIES_ESP32C2)
+#define SCLK_CLK_FREQ MHZ(60)
+#elif defined(CONFIG_SOC_SERIES_ESP32C6)
+#define SCLK_CLK_FREQ MHZ(80)
+#endif
+#endif
+
 struct pwm_ledc_esp32_data {
 	ledc_hal_context_t hal;
 	struct k_sem cmd_sem;
@@ -349,12 +360,6 @@ static const struct pwm_driver_api pwm_led_esp32_api = {
 };
 
 PINCTRL_DT_INST_DEFINE(0);
-
-#if SOC_LEDC_SUPPORT_APB_CLOCK
-	#define CLOCK_SOURCE	LEDC_APB_CLK
-#elif SOC_LEDC_SUPPORT_PLL_DIV_CLOCK
-	#define CLOCK_SOURCE	LEDC_SCLK
-#endif
 
 #define CHANNEL_CONFIG(node_id)                                                \
 	{                                                                      \

--- a/west.yml
+++ b/west.yml
@@ -157,7 +157,7 @@ manifest:
       groups:
         - hal
     - name: hal_espressif
-      revision: 0f1874284f5dee0d49cb23f44f756e7be404e7b7
+      revision: 23c17a8735d3047da95e3a81adafa36425636c55
       path: modules/hal/espressif
       west-commands: west/west-commands.yml
       groups:


### PR DESCRIPTION
After PR #80404 PWM LEDC won't build for ESP32C6, so fix is necessary.
Fix clock frequency for both devices.

Fixes #80879