### PR TITLE
arm: tests: kernel: fix bug in fatal_exception test

### DIFF
--- a/tests/kernel/fatal/exception/src/main.c
+++ b/tests/kernel/fatal/exception/src/main.c
@@ -108,16 +108,16 @@ void entry_cpu_exception_extend(void *p1, void *p2, void *p3)
 #if defined(CONFIG_ARM64)
 	__asm__ volatile ("svc 0");
 #elif defined(CONFIG_CPU_AARCH32_CORTEX_R) || defined(CONFIG_CPU_AARCH32_CORTEX_A)
-	__asm__ volatile ("BKPT");
+	__asm__ volatile ("udf #0");
 #elif defined(CONFIG_CPU_CORTEX_M)
-	__asm__ volatile ("swi 0");
+	__asm__ volatile ("udf #0");
 #elif defined(CONFIG_NIOS2)
 	__asm__ volatile ("trap");
 #elif defined(CONFIG_RISCV)
 	/* In riscv architecture, use an undefined
 	 * instruction to trigger illegal instruction on RISCV.
 	 */
-	__asm__ volatile (".word 0x77777777");
+	__asm__ volatile ("unimp");
 	/* In arc architecture, SWI instruction is used
 	 * to trigger soft interrupt.
 	 */


### PR DESCRIPTION
In Cortex-M the entry_cpu_exception_extend function calls `svc #0` when trying to generate a `K_ERR_CPU_EXCEPTION`, however `z_arm_svc` calls `z_do_kernel_oops` with a stack frame only, and gets the reason from `r0`. This means that the test working was just lucky and running it with another compiler (or setting the value of `r0` before the `svc #0` call, made the test fail).
Cortex-A/R 32-bit architectures was doing a BKPT, this works better but will not be a hard exception when debugger is attached.

It looks like arm64 is doing this correctly however, so maybe a better solution would be to make arm behave like arm64?
(see https://github.com/zephyrproject-rtos/zephyr/blob/main/arch/arm64/core/switch.S#L213). This would a bigger maneuver and I did not find the mapping of `svc` codes to `reasons` particularly well-defined and documented, so I started with proposing this solution, but if you prefer a more proper fix I can look into that as well.

I switched all the Cortex 32-bits to the ARM specified undefined instruction.

Also RISC-V has a designated `unimp` (see [here](https://github.com/riscv-non-isa/riscv-asm-manual/blob/3b06fa93fd52f277e8e0dc180bbb2ceec1ff5957/src/asm-manual.adoc#instruction-aliases)) instruction that should be used to guarantee trap.