### PR TITLE
random: random_timer.c Remove __GNUC__ ifdef

### DIFF
--- a/subsys/random/random_timer.c
+++ b/subsys/random/random_timer.c
@@ -20,8 +20,6 @@
 #include <zephyr/spinlock.h>
 #include <string.h>
 
-#if defined(__GNUC__)
-
 static struct k_spinlock rand32_lock;
 
 /**
@@ -71,4 +69,3 @@ void z_impl_sys_rand_get(void *dst, size_t outlen)
 		outlen -= blocksize;
 	}
 }
-#endif /* __GNUC__ */


### PR DESCRIPTION
Remove an old __GNUC__ ifdef.
This is causing issues for IAR toolchain.

I don't really understand what it is/was protecting however, is it long long?
I don't see how getting a linker error instead of a compiler error is that much clearer however