### PR TITLE
arm: cortex_m: restore fix for loading z_arm_int_exit

### DIFF
--- a/arch/arm/core/cortex_m/swap_helper.S
+++ b/arch/arm/core/cortex_m/swap_helper.S
@@ -429,7 +429,9 @@ _stack_frame_endif:
 #endif
 
     /* exception return is done in z_arm_int_exit() */
-    b z_arm_int_exit
+    ldr r0, =z_arm_int_exit
+    bx r0
+
 #endif
 
 _oops:


### PR DESCRIPTION
This change was in the same commit previously reverted and seem to be
unrelated and should not be reverted.

Fixes the problem:

..... /swap_helper.S:432:(.text.z_arm_svc+0x26):
relocation truncated to fit: R_ARM_THM_JUMP11 against symbol
`z_arm_int_exit' defined in .text._HandlerModeExit section in
....core/cortex_m/libarch__arm__core__cortex_m.a(exc_exit.c.obj)

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
