### PR TITLE
drivers: sensor: default_rtio_sensor: fix limited range warning

### DIFF
--- a/drivers/sensor/default_rtio_sensor.c
+++ b/drivers/sensor/default_rtio_sensor.c
@@ -348,7 +348,7 @@ int sensor_natively_supported_channel_size_info(struct sensor_chan_spec channel,
 	__ASSERT_NO_MSG(base_size != NULL);
 	__ASSERT_NO_MSG(frame_size != NULL);
 
-	if (((int)channel.chan_type < 0) || channel.chan_type >= (SENSOR_CHAN_ALL)) {
+	if (channel.chan_type >= SENSOR_CHAN_ALL) {
 		return -ENOTSUP;
 	}
 
@@ -474,7 +474,7 @@ static int decode(const uint8_t *buffer, struct sensor_chan_spec chan_spec,
 		return -EINVAL;
 	}
 
-	if (((int)chan_spec.chan_type < 0) || chan_spec.chan_type >= (SENSOR_CHAN_ALL)) {
+	if (chan_spec.chan_type >= SENSOR_CHAN_ALL) {
 		return 0;
 	}
 


### PR DESCRIPTION
`chan_type` is defined as a `uint16_t`. This makes checking if it is < 0 always false. A warning is shown with -Wtype-limits. Remove the check as it is unnecessary.

```
zephyr/drivers/sensor/default_rtio_sensor.c:346:37: warning: comparison is always false due to limited range of data type [-Wtype-limits]
  346 |         if (((int)channel.chan_type < 0) || channel.chan_type >= (SENSOR_CHAN_ALL)) {
      |                                     ^
zephyr/drivers/sensor/default_rtio_sensor.c: In function 'decode':
zephyr/drivers/sensor/default_rtio_sensor.c:472:39: warning: comparison is always false due to limited range of data type [-Wtype-limits]
  472 |         if (((int)chan_spec.chan_type < 0) || chan_spec.chan_type >= (SENSOR_CHAN_ALL)) {
      |                                       ^
```