### PR TITLE
debug: symtab: fix ignored type qualifiers on func return type

### DIFF
--- a/include/zephyr/debug/symtab.h
+++ b/include/zephyr/debug/symtab.h
@@ -46,7 +46,7 @@ struct symtab_info {
  *
  * @return Pointer to the symbol table.
  */
-const struct symtab_info *const symtab_get(void);
+const struct symtab_info *symtab_get(void);
 
 /**
  * @brief Find the symbol name with a binary search
@@ -57,7 +57,7 @@ const struct symtab_info *const symtab_get(void);
  *
  * @return Name of the nearest symbol if found, otherwise "?" is returned.
  */
-const char *const symtab_find_symbol_name(uintptr_t addr, uint32_t *offset);
+const char *symtab_find_symbol_name(uintptr_t addr, uint32_t *offset);
 
 /**
  * @}

--- a/subsys/debug/symtab/symtab.c
+++ b/subsys/debug/symtab/symtab.c
@@ -10,14 +10,14 @@
 #include <zephyr/debug/symtab.h>
 #include <zephyr/shell/shell.h>
 
-const struct symtab_info *const symtab_get(void)
+const struct symtab_info *symtab_get(void)
 {
 	extern const struct symtab_info z_symtab;
 
 	return &z_symtab;
 }
 
-const char *const symtab_find_symbol_name(uintptr_t addr, uint32_t *offset)
+const char *symtab_find_symbol_name(uintptr_t addr, uint32_t *offset)
 {
 	const struct symtab_info *const symtab = symtab_get();
 	const uint32_t symbol_offset = addr - symtab->first_addr;


### PR DESCRIPTION
const is ignored on the function return type. A warning is reported with -Wignored-qualifers. Remove the ignored qualifier.

```
In file included from zephyr/subsys/shell/modules/kernel_service.c:27:
zephyr/include/zephyr/debug/symtab.h:49:1: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
   49 | const struct symtab_info *const symtab_get(void);
      | ^~~~~
zephyr/include/zephyr/debug/symtab.h:60:1: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
   60 | const char *const symtab_find_symbol_name(uintptr_t addr, uint32_t *offset);
      | ^~~~~
```