### PR TITLE
tests: bsim: support snippets

### DIFF
--- a/boards/native/nrf_bsim/soc/soc_secure.h
+++ b/boards/native/nrf_bsim/soc/soc_secure.h
@@ -21,4 +21,10 @@ static inline void soc_secure_read_deviceid(uint32_t deviceid[2])
 	deviceid[1] = nrf_ficr_deviceid_get(NRF_FICR, 1);
 }
 
+static inline int soc_secure_mem_read(void *dst, void *src, size_t len)
+{
+	(void)memcpy(dst, src, len);
+	return 0;
+}
+
 #endif /* BOARDS_POSIX_NRF52_BSIM_SOC_SECURE_H */

--- a/tests/bsim/compile.source
+++ b/tests/bsim/compile.source
@@ -21,6 +21,7 @@ function _compile(){
   local conf_file="${conf_file:-prj.conf}"
   local extra_conf_file="${extra_conf_file:-""}"
   local conf_overlay="${conf_overlay:-""}"
+  local snippet="${snippet:-""}"
 
   default_cmake_args=(-DCONFIG_COVERAGE=y -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
     -DCONFIG_COMPILER_WARNINGS_AS_ERRORS=y -DCONFIG_ASSERT=y)
@@ -60,6 +61,7 @@ function _compile(){
   orifs="$IFS"; IFS=
   local cmake_cmd+=( -DOVERLAY_CONFIG="${conf_overlay}" \
             -DEXTRA_CONF_FILE="${extra_conf_file}" \
+            -DSNIPPET="${snippet}" \
             ${modules_arg} \
             "${cmake_args[@]}" ${cc_flags:+-DCMAKE_C_FLAGS=${cc_flags}} "${cmake_extra_args[@]}")
   if [ -v sysbuild ]; then


### PR DESCRIPTION
Support specifying a snippet when compiling bsim applications.

Add the default implementation of `soc_secure_mem_read` from `nordic/common/soc_secure.h`.