### PR TITLE
drivers: Backlight PWM driver

### DIFF
--- a/drivers/display/CMakeLists.txt
+++ b/drivers/display/CMakeLists.txt
@@ -31,6 +31,7 @@ zephyr_library_sources_ifdef(CONFIG_GC9X01X		display_gc9x01x.c)
 zephyr_library_sources_ifdef(CONFIG_LED_STRIP_MATRIX	display_led_strip_matrix.c)
 zephyr_library_sources_ifdef(CONFIG_DISPLAY_RENESAS_LCDC display_renesas_lcdc.c)
 zephyr_library_sources_ifdef(CONFIG_NT35510		display_nt35510.c)
+zephyr_library_sources_ifdef(CONFIG_BACKLIGHT_PWM		backlight_pwm.c)
 
 zephyr_library_sources_ifdef(CONFIG_MICROBIT_DISPLAY
 	mb_display.c

--- a/drivers/display/Kconfig
+++ b/drivers/display/Kconfig
@@ -48,5 +48,6 @@ source "drivers/display/Kconfig.gc9x01x"
 source "drivers/display/Kconfig.led_strip_matrix"
 source "drivers/display/Kconfig.renesas_lcdc"
 source "drivers/display/Kconfig.nt35510"
+source "drivers/display/Kconfig.backlight_pwm"
 
 endif # DISPLAY

--- a/drivers/display/Kconfig.backlight_pwm
+++ b/drivers/display/Kconfig.backlight_pwm
@@ -1,0 +1,18 @@
+# Configuration for backlight pwm driver
+
+# Copyright (c) 2024 Martin Kiepfer <mrmarteng@teleschirm.org>
+# SPDX-License-Identifier: Apache-2.0
+
+config BACKLIGHT_PWM
+	bool "Backlight PWM driver"
+	default y
+	depends on DT_HAS_BACKLIGHT_PWM_ENABLED
+	help
+	  Enable Backlight PWM driver.
+
+config BACKLIGHT_PWM_INIT_PRIORITY
+	int "Backlight-PWM driver initialization priority"
+	default 70
+	help
+	  Initialization priority for the Backlight-PWM driver. It must be
+	  greater than the PWM controller init priority.

--- a/drivers/display/backlight_pwm.c
+++ b/drivers/display/backlight_pwm.c
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2023 Martin Kiepfer <mrmarteng@teleschirm.org>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT backlight_pwm
+
+/**
+ * @file
+ * @brief Backlight-PWM driver
+ */
+
+#include <zephyr/display/backlight.h>
+#include <zephyr/drivers/pwm.h>
+#include <zephyr/device.h>
+#include <zephyr/pm/device.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/math_extras.h>
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(backlight_pwm, CONFIG_DISPLAY_LOG_LEVEL);
+
+struct backlight_pwm_config {
+	const struct pwm_dt_spec pwm;
+	const int init_level;
+};
+
+struct backlight_pwm_data {
+	int level;
+};
+
+static int backlight_pwm_set_brightness(const struct device *dev, uint8_t value)
+{
+	const struct backlight_pwm_config *config = dev->config;
+	const struct pwm_dt_spec *pwm = &config->pwm;
+	struct backlight_pwm_data *data = dev->data;
+
+	if (value > 100U) {
+		return -EINVAL;
+	}
+
+	if (pwm != 0) {
+		data->level = value;
+		return pwm_set_pulse_dt(&config->pwm,
+					(uint32_t)((uint64_t)pwm->period * value / 100U));
+	}
+
+	return -EINVAL;
+}
+
+static int backlight_pwm_on(const struct device *dev)
+{
+	const struct backlight_pwm_data *data = dev->data;
+	const struct backlight_pwm_config *config = dev->config;
+
+	return pwm_set_pulse_dt(&config->pwm, data->level);
+}
+
+static int backlight_pwm_off(const struct device *dev)
+{
+	const struct backlight_pwm_config *config = dev->config;
+
+	return pwm_set_pulse_dt(&config->pwm, 0);
+}
+
+static int backlight_pwm_init(const struct device *dev)
+{
+	const struct backlight_pwm_config *config = dev->config;
+	const struct pwm_dt_spec *pwm = &config->pwm;
+
+	if (pwm != 0) {
+		if (!device_is_ready(pwm->dev)) {
+			LOG_ERR("%s: pwm device not ready", pwm->dev->name);
+			return -ENODEV;
+		}
+
+		backlight_pwm_set_brightness(dev, config->init_level);
+	}
+
+	return 0;
+}
+
+#ifdef CONFIG_PM_DEVICE
+static int backlight_pwm_pm_action(const struct device *dev, enum pm_device_action action)
+{
+	const struct backlight_pwm_config *config = dev->config;
+
+	/* switch PWM device to the new state */
+	int err;
+	const struct pwm_dt_spec *pwm = &config->pwm;
+
+	LOG_DBG("PWM %p running pm action %" PRIu32, pwm->dev, action);
+
+	err = pm_device_action_run(pwm->dev, action);
+	if (err && (err != -EALREADY)) {
+		LOG_DBG("Cannot switch PWM %p power state (err = %d)", pwm->dev, err);
+	}
+
+	return 0;
+}
+#endif /* CONFIG_PM_DEVICE */
+
+static const struct backlight_driver_api backlight_pwm_api = {
+	.on = backlight_pwm_on,
+	.off = backlight_pwm_off,
+	.set_brightness = backlight_pwm_set_brightness,
+};
+
+#define BACKLIGHT_PWM_DEVICE(id)                                                                   \
+                                                                                                   \
+	BUILD_ASSERT(DT_INST_PROP_LEN(id, pwms) <= 1,                                              \
+		     "One PWM per clock control node is supported");                               \
+                                                                                                   \
+	static const struct backlight_pwm_config backlight_pwm_config_##id = {                     \
+		.pwm = PWM_DT_SPEC_INST_GET(id),                                                   \
+		.init_level = DT_INST_PROP(id, init_level),                                        \
+	};                                                                                         \
+                                                                                                   \
+	static struct backlight_pwm_data backlight_pwm_data_##id = {                               \
+		.level = 0,                                                                        \
+	};                                                                                         \
+                                                                                                   \
+	PM_DEVICE_DT_INST_DEFINE(id, backlight_pwm_pm_action);                                     \
+                                                                                                   \
+	DEVICE_DT_INST_DEFINE(id, &backlight_pwm_init, PM_DEVICE_DT_INST_GET(id),                  \
+			      &backlight_pwm_data_##id, &backlight_pwm_config_##id, POST_KERNEL,   \
+			      CONFIG_BACKLIGHT_PWM_INIT_PRIORITY, &backlight_pwm_api);
+
+DT_INST_FOREACH_STATUS_OKAY(BACKLIGHT_PWM_DEVICE)

--- a/dts/bindings/display/backlight-pwm.yaml
+++ b/dts/bindings/display/backlight-pwm.yaml
@@ -1,0 +1,25 @@
+# Copyright (c) 2024, Maritn Kiepfer
+# SPDX-License-Identifier: Apache-2.0
+
+description: Backlight PWM node
+
+compatible: "backlight-pwm"
+
+include: [base.yaml, backlight.yaml]
+
+properties:
+  pwms:
+    required: true
+    type: phandle-array
+    description: |
+      Reference to a PWM instance.
+
+      The period field is used by the set_brightness function of the
+      Backlight-PWM API.
+      Its value should at least be greater than 100 nanoseconds (for a full
+      brigtness granularity) and lesser than 50 milliseconds (average visual
+      persistence time of the human eye). Typical values for the PWM period
+      are 10 or 20 milliseconds.
+
+clock-cells:
+  - id

--- a/dts/bindings/display/backlight.yaml
+++ b/dts/bindings/display/backlight.yaml
@@ -1,0 +1,24 @@
+# Copyright (c) 2024, Martin Kiepfer
+# SPDX-License-Identifier: Apache-2.0
+
+include: [base.yaml]
+
+properties:
+  init-level:
+    type: int
+    default: 80
+    description: Initial value of the Backlight.
+
+  disable-init-on-boot:
+    type: boolean
+    description: |
+      Disable the initial value during bootup of the device. By default the
+      init-level is applied on boot. This option can prevent from this default
+      behaviour. Backlight needs to be enabled manually later in this case.
+
+  label:
+    type: string
+    description: |
+      Human readable string describing the Backlight. It can be used by an
+      application to identify this Backlight or to retrieve its
+      number/index (i.e. child node number) on the parent device.

--- a/include/zephyr/display/backlight.h
+++ b/include/zephyr/display/backlight.h
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2024 Martin Kiepfer <mrmarteng@teleschirm.org>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief Public Backlight driver APIs
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_BACKLIGHT_H_
+#define ZEPHYR_INCLUDE_DRIVERS_BACKLIGHT_H_
+
+/**
+ * @brief Backlight Driver Interface
+ * @defgroup backlight_interface Interface
+ * @ingroup io_interfaces
+ * @{
+ */
+
+#include <errno.h>
+
+#include <zephyr/types.h>
+#include <zephyr/device.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Backlight information structure
+ *
+ * This structure gathers useful information about Backlight controller.
+ */
+struct backlight_info {
+	/** Backlight label */
+	const char *label;
+};
+
+/**
+ * @typedef backlight_api_set_brightness()
+ * @brief Callback API for setting brightness of an Backlight
+ *
+ * @see backlight_set_brightness() for argument descriptions.
+ */
+typedef int (*backlight_api_set_brightness)(const struct device *dev, uint8_t value);
+
+/**
+ * @typedef backlight_api_get_brightness()
+ * @brief Callback API for getting brightness of an Backlight
+ *
+ * @see backlight_set_brightness() for argument descriptions.
+ */
+typedef int (*backlight_api_get_brightness)(const struct device *dev, uint8_t *value);
+
+/**
+ * @typedef backlight_api_on()
+ * @brief Callback API for turning on the Backlight
+
+ * @see backlight_on() for argument descriptions.
+ */
+typedef int (*backlight_api_on)(const struct device *dev);
+
+/**
+ * @typedef backlight_api_off()
+ * @brief Callback API for turning off Backlight
+ *
+ * @see backlight_off() for argument descriptions.
+ */
+typedef int (*backlight_api_off)(const struct device *dev);
+
+/**
+ * @brief Backlight driver API
+ */
+__subsystem struct backlight_driver_api {
+	/* Mandatory callbacks. */
+	backlight_api_on set_on;
+	backlight_api_off set_off;
+	/* Optional callbacks. */
+	backlight_api_set_brightness set_brightness;
+	backlight_api_get_brightness get_brightness;
+};
+
+/**
+ * @brief Set Backlight brightness
+ *
+ * This optional routine sets the brightness of a Backlight to the given value.
+ *
+ * These should simply turn the Backlight on if @p value is nonzero, and off
+ * if @p value is zero.
+ *
+ * @param dev Backlight device
+ * @param value Brightness value to set in percent (0..100)
+ * @return 0 on success, negative on error
+ */
+__syscall int backlight_set_brightness(const struct device *dev, uint8_t value);
+
+static inline int z_impl_backlight_set_brightness(const struct device *dev, uint8_t value)
+{
+	const struct backlight_driver_api *api = (const struct backlight_driver_api *)dev->api;
+
+	if (api->set_brightness == NULL) {
+		return -ENOSYS;
+	}
+	return api->set_brightness(dev, value);
+}
+
+/**
+ * @brief Turn on an Backlight
+ *
+ * This routine turns on Backlight. It will restore the previous set value
+ * or the initial value automatically.
+ *
+ * @param dev Backlight device
+ * @return 0 on success, negative on error
+ */
+__syscall int backlight_on(const struct device *dev);
+
+static inline int z_impl_backlight_on(const struct device *dev)
+{
+	const struct backlight_driver_api *api = (const struct backlight_driver_api *)dev->api;
+
+	return api->set_on(dev);
+}
+
+/**
+ * @brief Turn off an Backlight
+ *
+ * This routine turns off an Backlight
+ *
+ * @param dev Backlight device
+ * @return 0 on success, negative on error
+ */
+__syscall int backlight_off(const struct device *dev);
+
+static inline int z_impl_backlight_off(const struct device *dev)
+{
+	const struct backlight_driver_api *api = (const struct backlight_driver_api *)dev->api;
+
+	return api->set_off(dev);
+}
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#include <syscalls/backlight.h>
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_BACKLIGHT_H_ */


### PR DESCRIPTION
Adding backlight driver api to enable possibility to control display backlight commonly.
This PR includes PWM version of a backlight driver.

I would like to bring up the discussion about the possibilities for a flexible way to control backlight. There currently exists no possibility to automatically initialise backlight on boot up. There also is no common way to control backlights (e.g. API).  

@faxe1008 brought up the idea to integrate backlight control into display drivers (#70663). I am emphasising creation of a dedicated backlight API just like it is used on linux. Imo a simple and unique backlight API offers best flexibility. This PR adds a PWM backlight driver and a general backlight API. Further backlight implementations can follow (e.g. via buck, gpio,... ). The overhead is minimal and it is an optional feature.