### PR TITLE
driver: bt: esp32: use BUILD_ONLY_NO_BLOBS to allow CI tests

### DIFF
--- a/boards/01space/esp32c3_042_oled/esp32c3_042_oled.yaml
+++ b/boards/01space/esp32c3_042_oled/esp32c3_042_oled.yaml
@@ -11,7 +11,4 @@ supported:
   - spi
   - uart
   - watchdog
-testing:
-  ignore_tags:
-    - bluetooth
 vendor: 01space

--- a/boards/dptechnics/walter/walter_esp32s3_procpu.yaml
+++ b/boards/dptechnics/walter/walter_esp32s3_procpu.yaml
@@ -16,7 +16,4 @@ supported:
   - pwm
   - dma
   - input
-testing:
-  ignore_tags:
-    - bluetooth
 vendor: dptechnics

--- a/boards/espressif/esp32_devkitc_wroom/esp32_devkitc_wroom_procpu.yaml
+++ b/boards/espressif/esp32_devkitc_wroom/esp32_devkitc_wroom_procpu.yaml
@@ -18,7 +18,4 @@ supported:
   - counter
   - entropy
   - input
-testing:
-  ignore_tags:
-    - bluetooth
 vendor: espressif

--- a/boards/espressif/esp32_devkitc_wrover/esp32_devkitc_wrover_procpu.yaml
+++ b/boards/espressif/esp32_devkitc_wrover/esp32_devkitc_wrover_procpu.yaml
@@ -18,7 +18,4 @@ supported:
   - counter
   - entropy
   - input
-testing:
-  ignore_tags:
-    - bluetooth
 vendor: espressif

--- a/boards/espressif/esp32_ethernet_kit/esp32_ethernet_kit_procpu.yaml
+++ b/boards/espressif/esp32_ethernet_kit/esp32_ethernet_kit_procpu.yaml
@@ -10,7 +10,4 @@ supported:
   - uart
   - nvs
   - pwm
-testing:
-  ignore_tags:
-    - bluetooth
 vendor: espressif

--- a/boards/espressif/esp32c3_devkitc/esp32c3_devkitc.yaml
+++ b/boards/espressif/esp32c3_devkitc/esp32c3_devkitc.yaml
@@ -15,7 +15,4 @@ supported:
   - spi
   - counter
   - entropy
-testing:
-  ignore_tags:
-    - bluetooth
 vendor: espressif

--- a/boards/espressif/esp32c3_devkitm/esp32c3_devkitm.yaml
+++ b/boards/espressif/esp32c3_devkitm/esp32c3_devkitm.yaml
@@ -16,7 +16,4 @@ supported:
   - spi
   - counter
   - entropy
-testing:
-  ignore_tags:
-    - bluetooth
 vendor: espressif

--- a/boards/espressif/esp32c3_rust/esp32c3_rust.yaml
+++ b/boards/espressif/esp32c3_rust/esp32c3_rust.yaml
@@ -18,7 +18,4 @@ supported:
   - spi
   - counter
   - entropy
-testing:
-  ignore_tags:
-    - bluetooth
 vendor: espressif

--- a/boards/espressif/esp32c6_devkitc/esp32c6_devkitc.yaml
+++ b/boards/espressif/esp32c6_devkitc/esp32c6_devkitc.yaml
@@ -14,6 +14,3 @@ supported:
   - spi
   - entropy
   - i2c
-testing:
-  ignore_tags:
-    - bluetooth

--- a/boards/espressif/esp32s2_devkitc/esp32s2_devkitc.yaml
+++ b/boards/espressif/esp32s2_devkitc/esp32s2_devkitc.yaml
@@ -19,7 +19,4 @@ supported:
   - input
   - can
   - dma
-testing:
-  ignore_tags:
-    - bluetooth
 vendor: espressif

--- a/boards/espressif/esp32s3_devkitc/esp32s3_devkitc_procpu.yaml
+++ b/boards/espressif/esp32s3_devkitc/esp32s3_devkitc_procpu.yaml
@@ -17,7 +17,4 @@ supported:
   - pwm
   - dma
   - input
-testing:
-  ignore_tags:
-    - bluetooth
 vendor: espressif

--- a/boards/espressif/esp32s3_devkitm/esp32s3_devkitm_procpu.yaml
+++ b/boards/espressif/esp32s3_devkitm/esp32s3_devkitm_procpu.yaml
@@ -18,7 +18,4 @@ supported:
   - dma
   - input
   - video
-testing:
-  ignore_tags:
-    - bluetooth
 vendor: espressif

--- a/boards/espressif/esp32s3_eye/esp32s3_eye_procpu.yaml
+++ b/boards/espressif/esp32s3_eye/esp32s3_eye_procpu.yaml
@@ -17,7 +17,4 @@ supported:
   - dma
   - input
   - video
-testing:
-  ignore_tags:
-    - bluetooth
 vendor: espressif

--- a/boards/espressif/esp8684_devkitm/esp8684_devkitm.yaml
+++ b/boards/espressif/esp8684_devkitm/esp8684_devkitm.yaml
@@ -12,7 +12,4 @@ supported:
   - entropy
   - pwm
   - spi
-testing:
-  ignore_tags:
-    - bluetooth
 vendor: espressif

--- a/boards/espressif/esp_wrover_kit/esp_wrover_kit_procpu.yaml
+++ b/boards/espressif/esp_wrover_kit/esp_wrover_kit_procpu.yaml
@@ -17,7 +17,4 @@ supported:
   - spi
   - counter
   - entropy
-testing:
-  ignore_tags:
-    - bluetooth
 vendor: espressif

--- a/boards/franzininho/esp32s2_franzininho/esp32s2_franzininho.yaml
+++ b/boards/franzininho/esp32s2_franzininho/esp32s2_franzininho.yaml
@@ -14,5 +14,4 @@ supported:
 testing:
   ignore_tags:
     - heap
-    - bluetooth
 vendor: franzininho

--- a/boards/hardkernel/odroid_go/odroid_go_procpu.yaml
+++ b/boards/hardkernel/odroid_go/odroid_go_procpu.yaml
@@ -11,7 +11,4 @@ supported:
   - watchdog
   - uart
   - nvs
-testing:
-  ignore_tags:
-    - bluetooth
 vendor: hardkernel

--- a/boards/heltec/heltec_wifi_lora32_v2/heltec_wifi_lora32_v2_procpu.yaml
+++ b/boards/heltec/heltec_wifi_lora32_v2/heltec_wifi_lora32_v2_procpu.yaml
@@ -10,7 +10,4 @@ supported:
   - watchdog
   - uart
   - nvs
-testing:
-  ignore_tags:
-    - bluetooth
 vendor: espressif

--- a/boards/heltec/heltec_wireless_stick_lite_v3/heltec_wireless_stick_lite_v3_procpu.yaml
+++ b/boards/heltec/heltec_wireless_stick_lite_v3/heltec_wireless_stick_lite_v3_procpu.yaml
@@ -16,7 +16,4 @@ supported:
   - pwm
   - dma
   - lora
-testing:
-  ignore_tags:
-    - bluetooth
 vendor: heltec

--- a/boards/kincony/kincony_kc868_a32/kincony_kc868_a32_procpu.yaml
+++ b/boards/kincony/kincony_kc868_a32/kincony_kc868_a32_procpu.yaml
@@ -12,7 +12,4 @@ supported:
   - nvs
   - counter
   - entropy
-testing:
-  ignore_tags:
-    - bluetooth
 vendor: kincony

--- a/boards/lilygo/ttgo_lora32/ttgo_lora32_esp32_procpu.yaml
+++ b/boards/lilygo/ttgo_lora32/ttgo_lora32_esp32_procpu.yaml
@@ -15,7 +15,4 @@ supported:
   - lora
   - nvs
   - sdhc
-testing:
-  ignore_tags:
-    - bluetooth
 vendor: lilygo

--- a/boards/lilygo/ttgo_t7v1_5/ttgo_t7v1_5_esp32_procpu.yaml
+++ b/boards/lilygo/ttgo_t7v1_5/ttgo_t7v1_5_esp32_procpu.yaml
@@ -14,7 +14,4 @@ supported:
   - display
   - lora
   - nvs
-testing:
-  ignore_tags:
-    - bluetooth
 vendor: lilygo

--- a/boards/lilygo/ttgo_t8c3/ttgo_t8c3.yaml
+++ b/boards/lilygo/ttgo_t8c3/ttgo_t8c3.yaml
@@ -11,7 +11,4 @@ supported:
   - uart
   - watchdog
   - can
-testing:
-  ignore_tags:
-    - bluetooth
 vendor: lilygo

--- a/boards/lilygo/ttgo_t8s3/ttgo_t8s3_procpu.yaml
+++ b/boards/lilygo/ttgo_t8s3/ttgo_t8s3_procpu.yaml
@@ -18,7 +18,4 @@ supported:
   - dma
   - input
   - video
-testing:
-  ignore_tags:
-    - bluetooth
 vendor: lilygo

--- a/boards/luatos/esp32c3_luatos_core/esp32c3_luatos_core.yaml
+++ b/boards/luatos/esp32c3_luatos_core/esp32c3_luatos_core.yaml
@@ -15,7 +15,4 @@ supported:
   - spi
   - counter
   - entropy
-testing:
-  ignore_tags:
-    - bluetooth
 vendor: luatos

--- a/boards/luatos/esp32c3_luatos_core/esp32c3_luatos_core_esp32c3_usb.yaml
+++ b/boards/luatos/esp32c3_luatos_core/esp32c3_luatos_core_esp32c3_usb.yaml
@@ -15,7 +15,4 @@ supported:
   - spi
   - counter
   - entropy
-testing:
-  ignore_tags:
-    - bluetooth
 vendor: luatos

--- a/boards/luatos/esp32s3_luatos_core/esp32s3_luatos_core_procpu.yaml
+++ b/boards/luatos/esp32s3_luatos_core/esp32s3_luatos_core_procpu.yaml
@@ -15,7 +15,4 @@ supported:
   - entropy
   - pwm
   - dma
-testing:
-  ignore_tags:
-    - bluetooth
 vendor: luatos

--- a/boards/luatos/esp32s3_luatos_core/esp32s3_luatos_core_procpu_usb.yaml
+++ b/boards/luatos/esp32s3_luatos_core/esp32s3_luatos_core_procpu_usb.yaml
@@ -15,7 +15,4 @@ supported:
   - entropy
   - pwm
   - dma
-testing:
-  ignore_tags:
-    - bluetooth
 vendor: luatos

--- a/boards/m5stack/m5stack_atom_lite/m5stack_atom_lite_procpu.yaml
+++ b/boards/m5stack/m5stack_atom_lite/m5stack_atom_lite_procpu.yaml
@@ -12,7 +12,4 @@ supported:
   - uart
   - pinmux
   - nvs
-testing:
-  ignore_tags:
-    - bluetooth
 vendor: m5stack

--- a/boards/m5stack/m5stack_atoms3/m5stack_atoms3_procpu.yaml
+++ b/boards/m5stack/m5stack_atoms3/m5stack_atoms3_procpu.yaml
@@ -14,7 +14,4 @@ supported:
   - pinmux
   - nvs
   - display
-testing:
-  ignore_tags:
-    - bluetooth
 vendor: m5stack

--- a/boards/m5stack/m5stack_atoms3_lite/m5stack_atoms3_lite_procpu.yaml
+++ b/boards/m5stack/m5stack_atoms3_lite/m5stack_atoms3_lite_procpu.yaml
@@ -16,7 +16,4 @@ supported:
   - pinmux
   - nvs
   - dma
-testing:
-  ignore_tags:
-    - bluetooth
 vendor: m5stack

--- a/boards/m5stack/m5stack_core2/m5stack_core2_procpu.yaml
+++ b/boards/m5stack/m5stack_core2/m5stack_core2_procpu.yaml
@@ -13,7 +13,4 @@ supported:
   - uart
   - pinmux
   - nvs
-testing:
-  ignore_tags:
-    - bluetooth
 vendor: m5stack

--- a/boards/m5stack/m5stack_stamps3/m5stack_stamps3_procpu.yaml
+++ b/boards/m5stack/m5stack_stamps3/m5stack_stamps3_procpu.yaml
@@ -13,7 +13,4 @@ supported:
   - pwm
   - pinmux
   - nvs
-testing:
-  ignore_tags:
-    - bluetooth
 vendor: m5stack

--- a/boards/m5stack/m5stickc_plus/m5stickc_plus_procpu.yaml
+++ b/boards/m5stack/m5stickc_plus/m5stickc_plus_procpu.yaml
@@ -14,7 +14,4 @@ supported:
   - nvs
   - regulator
   - display
-testing:
-  ignore_tags:
-    - bluetooth
 vendor: m5stack

--- a/boards/m5stack/stamp_c3/stamp_c3.yaml
+++ b/boards/m5stack/stamp_c3/stamp_c3.yaml
@@ -10,7 +10,4 @@ supported:
   - spi
   - uart
   - watchdog
-testing:
-  ignore_tags:
-    - bluetooth
 vendor: m5stack

--- a/boards/olimex/olimex_esp32_evb/olimex_esp32_evb_procpu.yaml
+++ b/boards/olimex/olimex_esp32_evb/olimex_esp32_evb_procpu.yaml
@@ -13,7 +13,4 @@ supported:
   - spi
   - uart
   - watchdog
-testing:
-  ignore_tags:
-    - bluetooth
 vendor: olimex

--- a/boards/others/icev_wireless/icev_wireless.yaml
+++ b/boards/others/icev_wireless/icev_wireless.yaml
@@ -4,7 +4,4 @@ type: mcu
 arch: riscv
 toolchain:
   - zephyr
-testing:
-  ignore_tags:
-    - bluetooth
 vendor: espressif

--- a/boards/seeed/xiao_esp32c3/xiao_esp32c3.yaml
+++ b/boards/seeed/xiao_esp32c3/xiao_esp32c3.yaml
@@ -11,7 +11,4 @@ supported:
   - uart
   - watchdog
   - can
-testing:
-  ignore_tags:
-    - bluetooth
 vendor: seeed

--- a/boards/seeed/xiao_esp32c6/xiao_esp32c6.yaml
+++ b/boards/seeed/xiao_esp32c6/xiao_esp32c6.yaml
@@ -14,6 +14,5 @@ supported:
   - i2c
 testing:
   ignore_tags:
-    - bluetooth
     - tracing
 vendor: seeed

--- a/boards/seeed/xiao_esp32s3/xiao_esp32s3_procpu.yaml
+++ b/boards/seeed/xiao_esp32s3/xiao_esp32s3_procpu.yaml
@@ -15,7 +15,4 @@ supported:
   - entropy
   - pwm
   - dma
-testing:
-  ignore_tags:
-    - bluetooth
 vendor: seeed

--- a/boards/seeed/xiao_esp32s3/xiao_esp32s3_procpu_sense.yaml
+++ b/boards/seeed/xiao_esp32s3/xiao_esp32s3_procpu_sense.yaml
@@ -15,7 +15,4 @@ supported:
   - entropy
   - pwm
   - dma
-testing:
-  ignore_tags:
-    - bluetooth
 vendor: seeed

--- a/boards/vcc-gnd/yd_esp32/yd_esp32_procpu.yaml
+++ b/boards/vcc-gnd/yd_esp32/yd_esp32_procpu.yaml
@@ -17,7 +17,4 @@ supported:
   - spi
   - counter
   - entropy
-testing:
-  ignore_tags:
-    - bluetooth
 vendor: vcc-gnd

--- a/boards/waveshare/esp32s3_touch_lcd_1_28/esp32s3_touch_lcd_1_28_esp32s3_procpu.yaml
+++ b/boards/waveshare/esp32s3_touch_lcd_1_28/esp32s3_touch_lcd_1_28_esp32s3_procpu.yaml
@@ -15,7 +15,4 @@ supported:
   - pinmux
   - nvs
   - display
-testing:
-  ignore_tags:
-    - bluetooth
 vendor: waveshare

--- a/boards/we/orthosie1ev/we_orthosie1ev.yaml
+++ b/boards/we/orthosie1ev/we_orthosie1ev.yaml
@@ -16,7 +16,4 @@ supported:
   - spi
   - counter
   - entropy
-testing:
-  ignore_tags:
-    - bluetooth
 vendor: we

--- a/drivers/bluetooth/hci/CMakeLists.txt
+++ b/drivers/bluetooth/hci/CMakeLists.txt
@@ -1,9 +1,33 @@
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_library_sources_ifdef(CONFIG_BT_ESP32       hci_esp32.c)
+if (CONFIG_BUILD_ONLY_NO_BLOBS)
+  message(WARNING "
+  ---------------------------------------------------------------------------
+  Building only the Bluetooth driver without binary blobs and patches.
+  This is only for building (CI) purposes and will not work on a real device.
+  ---------------------------------------------------------------------------
+  ")
+else()
+
 if(CONFIG_DT_HAS_ESPRESSIF_ESP32_BT_HCI_ENABLED)
   zephyr_blobs_verify(MODULE hal_espressif REQUIRED)
 endif()
+
+if((CONFIG_DT_HAS_ST_HCI_STM32WBA_ENABLED) OR (CONFIG_DT_HAS_ST_HCI_STM32WB0_ENABLED))
+  zephyr_blobs_verify(MODULE hal_stm32 REQUIRED)
+endif()
+
+if(CONFIG_DT_HAS_SILABS_BT_HCI_EFR32_ENABLED)
+  zephyr_blobs_verify(MODULE hal_silabs REQUIRED)
+endif()
+
+if(CONFIG_DT_HAS_INFINEON_CAT1_BLESS_HCI_ENABLED)
+  zephyr_blobs_verify(MODULE hal_infineon REQUIRED)
+endif()
+
+endif() # CONFIG_BUILD_ONLY_NO_BLOBS
+
+zephyr_library_sources_ifdef(CONFIG_BT_ESP32       hci_esp32.c)
 zephyr_library_sources_ifdef(CONFIG_BT_H4          h4.c)
 zephyr_library_sources_ifdef(CONFIG_BT_H5          h5.c)
 zephyr_library_sources_ifdef(CONFIG_BT_HCI_IPC     ipc.c)
@@ -11,22 +35,12 @@ zephyr_library_sources_ifdef(CONFIG_BT_SPI_ZEPHYR  spi.c)
 zephyr_library_sources_ifdef(CONFIG_BT_SPI_BLUENRG hci_spi_st.c)
 zephyr_library_sources_ifdef(CONFIG_BT_CYW43XX   h4_ifx_cyw43xxx.c)
 zephyr_library_sources_ifdef(CONFIG_BT_CYW208XX  hci_ifx_cyw208xx.c)
-
 zephyr_library_sources_ifdef(CONFIG_BT_STM32_IPM   ipm_stm32wb.c)
 zephyr_library_sources_ifdef(CONFIG_BT_STM32WBA    hci_stm32wba.c)
 zephyr_library_sources_ifdef(CONFIG_BT_STM32WB0    hci_stm32wb0.c)
-if((CONFIG_DT_HAS_ST_HCI_STM32WBA_ENABLED) OR (CONFIG_DT_HAS_ST_HCI_STM32WB0_ENABLED))
-  zephyr_blobs_verify(MODULE hal_stm32 REQUIRED)
-endif()
 zephyr_library_sources_ifdef(CONFIG_BT_USERCHAN    userchan.c)
 zephyr_library_sources_ifdef(CONFIG_BT_SILABS_EFR32 hci_silabs_efr32.c)
-if(CONFIG_DT_HAS_SILABS_BT_HCI_EFR32_ENABLED)
-  zephyr_blobs_verify(MODULE hal_silabs REQUIRED)
-endif()
 zephyr_library_sources_ifdef(CONFIG_BT_PSOC6_BLESS hci_ifx_psoc6_bless.c)
-if(CONFIG_DT_HAS_INFINEON_CAT1_BLESS_HCI_ENABLED)
-  zephyr_blobs_verify(MODULE hal_infineon REQUIRED)
-endif()
 zephyr_library_sources_ifdef(CONFIG_SOC_NRF5340_CPUAPP nrf53_support.c)
 zephyr_library_sources_ifdef(CONFIG_BT_AMBIQ_HCI   hci_ambiq.c apollox_blue.c)
 zephyr_library_sources_ifdef(CONFIG_BT_DA1453X     hci_da1453x.c)

--- a/drivers/bluetooth/hci/Kconfig
+++ b/drivers/bluetooth/hci/Kconfig
@@ -153,7 +153,7 @@ config BT_ESP32
 	bool
 	default y
 	depends on DT_HAS_ESPRESSIF_ESP32_BT_HCI_ENABLED
-	depends on ZEPHYR_HAL_ESPRESSIF_MODULE_BLOBS
+	depends on ZEPHYR_HAL_ESPRESSIF_MODULE_BLOBS || BUILD_ONLY_NO_BLOBS
 	help
 	  Espressif HCI bluetooth interface
 

--- a/samples/bluetooth/central/sample.yaml
+++ b/samples/bluetooth/central/sample.yaml
@@ -9,3 +9,10 @@ tests:
     tags: bluetooth
     integration_platforms:
       - qemu_cortex_m3
+  sample.bluetooth.central.esp32:
+    extra_args:
+      - CONFIG_BUILD_ONLY_NO_BLOBS=y
+    platform_allow:
+      - esp32_devkitc_wroom/esp32/procpu
+      - esp32s3_devkitm/esp32s3/procpu
+      - esp32c3_devkitm

--- a/samples/bluetooth/peripheral/sample.yaml
+++ b/samples/bluetooth/peripheral/sample.yaml
@@ -19,3 +19,10 @@ tests:
     extra_args: SHIELD=x_nucleo_idb05a1
     integration_platforms:
       - nucleo_l4r5zi
+  sample.bluetooth.periodic_adv.esp32:
+    extra_args:
+      - CONFIG_BUILD_ONLY_NO_BLOBS=y
+    platform_allow:
+      - esp32_devkitc_wroom/esp32/procpu
+      - esp32s3_devkitm/esp32s3/procpu
+      - esp32c3_devkitm

--- a/west.yml
+++ b/west.yml
@@ -162,7 +162,7 @@ manifest:
       groups:
         - hal
     - name: hal_espressif
-      revision: 9fbf519573e713bd92bb8222bcfef77e7219584b
+      revision: e52371024732a47a67fa9c889fbccd0aa6355f3a
       path: modules/hal/espressif
       west-commands: west/west-commands.yml
       groups:


### PR DESCRIPTION
Add BUILD_ONLY_NO_BLOBS to allow CI tests.

Read this before: #80785

Depends on #82931 due to HAL merging sequence.