### PR TITLE
Fix ls0xx display driver sample

### DIFF
--- a/samples/drivers/display/README.rst
+++ b/samples/drivers/display/README.rst
@@ -46,3 +46,35 @@ List of Arduino-based display shields
 - :ref:`ssd1306_128_shield`
 - :ref:`st7789v_generic`
 - :ref:`waveshare_epaper`
+
+Changes for ls0xx Display
+*************************
+
+To run the sample on an Adafruit Sharp memory display 2.7 inch (ls0xx) on a STM32H7B0 board, ensure the following:
+
+1. Modify the device tree snippet to match the display configuration.
+2. Ensure the `buf_desc.width` is set to 400 in the sample code.
+3. Check the return value of `display_get_capabilities()` in the sample code.
+
+Example device tree snippet:
+
+.. code-block:: dts
+
+   &spi2 {
+   	pinctrl-0 = <&spi2_sck_pb10 &spi2_miso_pc2_c &spi2_mosi_pc1>;
+   	cs-gpios = <&gpioc 0 GPIO_ACTIVE_HIGH>;
+   	pinctrl-names = "default";
+   	status = "okay";
+
+   	ls0xx_ls027b7dh01: ls0xx@0 {
+   		compatible = "sharp,ls0xx";
+   		spi-max-frequency = <2000000>;
+   		reg = <0>;
+   		width = <400>;
+   		height = <240>;
+   		extcomin-gpios = <&gpioc 3 GPIO_ACTIVE_HIGH>;
+   		extcomin-frequency = <60>; /* required if extcomin-gpios is defined */
+   		disp-en-gpios = <&gpioc 13 GPIO_ACTIVE_HIGH>;
+   	};
+
+   };

--- a/samples/drivers/display/src/main.c
+++ b/samples/drivers/display/src/main.c
@@ -199,8 +199,15 @@ int main(void)
 #endif
 	}
 
-	LOG_INF("Display sample for %s", display_dev->name);
-	display_get_capabilities(display_dev, &capabilities);
+LOG_INF("Display sample for %s", display_dev->name);
+	if (display_get_capabilities(display_dev, &capabilities) != 0) {
+		LOG_ERR("Failed to get display capabilities. Aborting sample.");
+#ifdef CONFIG_ARCH_POSIX
+		posix_exit_main(1);
+#else
+		return 0;
+#endif
+	}
 
 	if (capabilities.screen_info & SCREEN_INFO_MONO_VTILED) {
 		rect_w = 16;
@@ -296,6 +303,10 @@ int main(void)
 	buf_desc.pitch = capabilities.x_resolution;
 	buf_desc.width = capabilities.x_resolution;
 	buf_desc.height = h_step;
+
+	if (strcmp(display_dev->name, "ls0xx") == 0) {
+		buf_desc.width = 400;
+	}
 
 	for (int idx = 0; idx < capabilities.y_resolution; idx += h_step) {
 		/*


### PR DESCRIPTION
Modify `samples/drivers/display/src/main.c` to handle ls0xx display.

* Check the return value of `display_get_capabilities()` and log an error if it fails.
* Ensure `buf_desc.width` is set to 400 if the display is `ls0xx`.
* Add a condition to handle the `ls0xx` display specifically.

Update `samples/drivers/display/README.rst` to reflect the changes made in `samples/drivers/display/src/main.c`.

* Add a section for the ls0xx display.
* Provide an example device tree snippet for ls0xx display configuration.
