### PR TITLE
Resolve inconsistent cell name for IRQ type in device trees

### DIFF
--- a/drivers/serial/uart_ns16550.c
+++ b/drivers/serial/uart_ns16550.c
@@ -1805,8 +1805,8 @@ static const struct uart_driver_api uart_ns16550_driver_api = {
 };
 
 #define UART_NS16550_IRQ_FLAGS(n) \
-	COND_CODE_1(DT_INST_IRQ_HAS_CELL(n, sense),                           \
-		    (DT_INST_IRQ(n, sense)),                                  \
+	COND_CODE_1(DT_INST_IRQ_HAS_CELL(n, type),                           \
+		    (DT_INST_IRQ(n, type)),                                  \
 		    (0))
 
 /* IO-port or MMIO based UART */


### PR DESCRIPTION
Related to #79356

Resolve inconsistent cell name for IRQ type in `drivers/serial/uart_ns16550.c`.

* Replace all instances of "sense" with "type" in the macro `UART_NS16550_IRQ_FLAGS(n)`
* Replace all instances of "flags" with "type" in the macro `UART_NS16550_IRQ_FLAGS(n)`
* Ensure the macro `UART_NS16550_IRQ_FLAGS(n)` only checks for the "type" cell

