### PR TITLE
Fix color inversion issue in GC9X01X display driver

### DIFF
--- a/drivers/display/display_gc9x01x.c
+++ b/drivers/display/display_gc9x01x.c
@@ -215,6 +215,11 @@ static const struct gc9x01x_default_init_regs default_init_regs[] = {
 		.len = 2U,
 		.data = {0x3EU, 0x07U},
 	},
+	{
+		.cmd = 0x21U,
+		.len = 1U,
+		.data = {0x00U},
+	},
 };
 
 static int gc9x01x_transmit(const struct device *dev, uint8_t cmd, const void *tx_data,

--- a/dts/bindings/display/galaxycore,gc9x01x.yaml
+++ b/dts/bindings/display/galaxycore,gc9x01x.yaml
@@ -44,6 +44,7 @@ properties:
 
   display-inversion:
     type: boolean
+    default: false
     description: |
       Display inversion mode. Every bit is inverted from the frame memory to
       the display.


### PR DESCRIPTION
Related to #80578

Add the `GC9X01X_CMD_INVON` command to the `default_init_regs` array in `drivers/display/display_gc9x01x.c` to set color inversion to false.

* Update the `gc9x01x_regs_init` function to include the new command in the initialization sequence.
* Set the default value of the `display-inversion` property to false in `dts/bindings/display/galaxycore,gc9x01x.yaml`.

