### PR TITLE
tests: crypto: tinycrypt: Fix premature Ztest end logging

### DIFF
--- a/tests/crypto/tinycrypt/src/cbc_mode.c
+++ b/tests/crypto/tinycrypt/src/cbc_mode.c
@@ -128,7 +128,7 @@ ZTEST(tinycrypt, test_cbc_sp_800_38a_encrypt_decrypt)
 
 	result = check_result(1, ciphertext, sizeof(encrypted),
 			      encrypted, sizeof(encrypted), 1);
-	TC_END_RESULT(result);
+	zassert_false(result, "CBC test #1 failed.");
 
 	TC_PRINT("CBC test #2 (decryption SP 800-38a tests):\n");
 	(void)tc_aes128_set_decrypt_key(&a, key);
@@ -145,5 +145,5 @@ ZTEST(tinycrypt, test_cbc_sp_800_38a_encrypt_decrypt)
 			      decrypted, sizeof(decrypted), 1);
 
 	/**TESTPOINT: Check result*/
-	zassert_false(result, "CBC test #1 failed.");
+	zassert_false(result, "CBC test #2 failed.");
 }

--- a/tests/crypto/tinycrypt/src/ccm_mode.c
+++ b/tests/crypto/tinycrypt/src/ccm_mode.c
@@ -464,7 +464,6 @@ ZTEST(tinycrypt, test_ccm_vector_8)
 	}
 
 	result = TC_PASS;
-	TC_END_RESULT(result);
 
 	/**TESTPOINT: Check result*/
 	zassert_false(result, "CCM test #8 (no payload data) failed.");

--- a/tests/crypto/tinycrypt/src/cmac_mode.c
+++ b/tests/crypto/tinycrypt/src/cmac_mode.c
@@ -111,7 +111,6 @@ static uint32_t verify_gf_2_128_double(uint8_t *K1, uint8_t *K2, struct tc_cmac_
 		return TC_FAIL;
 	}
 
-	TC_END_RESULT(result);
 	return result;
 }
 
@@ -138,7 +137,6 @@ static uint32_t verify_cmac_null_msg(TCCmacState_t s)
 		return TC_FAIL;
 	}
 
-	TC_END_RESULT(result);
 	return result;
 }
 
@@ -170,7 +168,6 @@ static uint32_t verify_cmac_1_block_msg(TCCmacState_t s)
 		return TC_FAIL;
 	}
 
-	TC_END_RESULT(result);
 	return result;
 }
 
@@ -205,7 +202,6 @@ static uint32_t verify_cmac_320_bit_msg(TCCmacState_t s)
 		return TC_FAIL;
 	}
 
-	TC_END_RESULT(result);
 	return result;
 }
 
@@ -243,7 +239,6 @@ static uint32_t verify_cmac_512_bit_msg(TCCmacState_t s)
 		return TC_FAIL;
 	}
 
-	TC_END_RESULT(result);
 	return result;
 }
 


### PR DESCRIPTION
Don't use TC_END_RESULT() to report Ztest's result prematurely.