### PR TITLE
sys: util: use BITS_PER_BYTE macro instead of the magic number 8

### DIFF
--- a/drivers/display/display_mcux_dcnano_lcdif.c
+++ b/drivers/display/display_mcux_dcnano_lcdif.c
@@ -256,8 +256,8 @@ static const struct display_driver_api mcux_dcnano_lcdif_api = {
 	.get_framebuffer = mcux_dcnano_lcdif_get_framebuffer,
 };
 
-#define MCUX_DCNANO_LCDIF_PIXEL_BYTES(n)					\
-	(DISPLAY_BITS_PER_PIXEL(DT_INST_PROP(n, pixel_format)) / 8)
+#define MCUX_DCNANO_LCDIF_PIXEL_BYTES(n)                                                           \
+	(DISPLAY_BITS_PER_PIXEL(DT_INST_PROP(n, pixel_format)) / BITS_PER_BYTE)
 #define MCUX_DCNANO_LCDIF_FB_SIZE(n) DT_INST_PROP(n, width) *			\
 	DT_INST_PROP(n, height) * MCUX_DCNANO_LCDIF_PIXEL_BYTES(n)
 

--- a/drivers/display/display_mcux_elcdif.c
+++ b/drivers/display/display_mcux_elcdif.c
@@ -249,7 +249,7 @@ static int mcux_elcdif_set_pixel_format(const struct device *dev,
 	}
 
 	dev_data->pixel_format = pixel_format;
-	dev_data->pixel_bytes = DISPLAY_BITS_PER_PIXEL(pixel_format) / 8;
+	dev_data->pixel_bytes = DISPLAY_BITS_PER_PIXEL(pixel_format) / BITS_PER_BYTE;
 	dev_data->fb_bytes =
 		config->rgb_mode.panelWidth * config->rgb_mode.panelHeight * dev_data->pixel_bytes;
 

--- a/drivers/display/display_renesas_lcdc.c
+++ b/drivers/display/display_renesas_lcdc.c
@@ -44,8 +44,8 @@ LOG_MODULE_REGISTER(smartbond_display, CONFIG_DISPLAY_LOG_LEVEL);
 	(((_val) << LCDC_LCDC_LAYER0_OFFSETX_REG_ ## _field ## _Pos) &	\
 	LCDC_LCDC_LAYER0_OFFSETX_REG_ ## _field ## _Msk)
 
-#define DISPLAY_SMARTBOND_PIXEL_SIZE(inst)	\
-	(DISPLAY_BITS_PER_PIXEL(DT_INST_PROP(inst, pixel_format)) / 8)
+#define DISPLAY_SMARTBOND_PIXEL_SIZE(inst)                                                         \
+	(DISPLAY_BITS_PER_PIXEL(DT_INST_PROP(inst, pixel_format)) / BITS_PER_BYTE)
 
 #if CONFIG_DISPLAY_RENESAS_LCDC_BUFFER_PSRAM
 #define DISPLAY_BUFFER_LINKER_SECTION \

--- a/drivers/mipi_dbi/mipi_dbi_smartbond.c
+++ b/drivers/mipi_dbi/mipi_dbi_smartbond.c
@@ -338,8 +338,8 @@ static int mipi_dbi_smartbond_write_display(const struct device *dev,
 	lcdc_smartbond_mipi_dbi_cfg mipi_dbi_cfg;
 	uint8_t layer_color = lcdc_smartbond_pixel_to_lcm(pixfmt);
 
-	if (desc->width * desc->height * (DISPLAY_BITS_PER_PIXEL(pixfmt) / 8) !=
-		desc->buf_size) {
+	if (desc->width * desc->height * (DISPLAY_BITS_PER_PIXEL(pixfmt) / BITS_PER_BYTE) !=
+	    desc->buf_size) {
 		LOG_ERR("Incorrect buffer size for given width and height");
 		return -EINVAL;
 	}

--- a/include/zephyr/sys/atomic.h
+++ b/include/zephyr/sys/atomic.h
@@ -73,7 +73,7 @@ extern "C" {
  * @cond INTERNAL_HIDDEN
  */
 
-#define ATOMIC_BITS (sizeof(atomic_val_t) * 8)
+#define ATOMIC_BITS            (sizeof(atomic_val_t) * BITS_PER_BYTE)
 #define ATOMIC_MASK(bit) BIT((unsigned long)(bit) & (ATOMIC_BITS - 1U))
 #define ATOMIC_ELEM(addr, bit) ((addr) + ((bit) / ATOMIC_BITS))
 

--- a/include/zephyr/sys/rb.h
+++ b/include/zephyr/sys/rb.h
@@ -66,8 +66,8 @@ struct rbnode {
  * packed binary tree, plus root...  Works out to 59 entries for 32
  * bit pointers and 121 at 64 bits.
  */
-#define Z_TBITS(t) ((sizeof(t)) < 8 ? 2 : 3)
-#define Z_PBITS(t) (8 * sizeof(t))
+#define Z_TBITS(t)         ((sizeof(t)) < sizeof(uint64_t) ? 2 : 3)
+#define Z_PBITS(t)         (BITS_PER_BYTE * sizeof(t))
 #define Z_MAX_RBTREE_DEPTH (2 * (Z_PBITS(int *) - Z_TBITS(int *) - 1) + 1)
 
 /**

--- a/include/zephyr/sys/util.h
+++ b/include/zephyr/sys/util.h
@@ -30,7 +30,7 @@
 #include <stdint.h>
 
 /** @brief Number of bits that make up a type */
-#define NUM_BITS(t) (sizeof(t) * 8)
+#define NUM_BITS(t) (sizeof(t) * BITS_PER_BYTE)
 
 #ifdef __cplusplus
 extern "C" {

--- a/kernel/userspace.c
+++ b/kernel/userspace.c
@@ -20,6 +20,7 @@
 #include <zephyr/app_memory/app_memdomain.h>
 #include <zephyr/sys/libc-hooks.h>
 #include <zephyr/sys/mutex.h>
+#include <zephyr/sys/util.h>
 #include <inttypes.h>
 #include <zephyr/linker/linker-defs.h>
 
@@ -71,7 +72,7 @@ static struct k_spinlock objfree_lock;     /* k_object_free */
 #endif /* CONFIG_DYNAMIC_OBJECTS */
 static struct k_spinlock obj_lock;         /* kobj struct data */
 
-#define MAX_THREAD_BITS		(CONFIG_MAX_THREAD_BYTES * 8)
+#define MAX_THREAD_BITS (CONFIG_MAX_THREAD_BYTES * BITS_PER_BYTE)
 
 #ifdef CONFIG_DYNAMIC_OBJECTS
 extern uint8_t _thread_idx_map[CONFIG_MAX_THREAD_BYTES];

--- a/samples/subsys/input/draw_touch_events/src/main.c
+++ b/samples/subsys/input/draw_touch_events/src/main.c
@@ -9,6 +9,7 @@
 #include <zephyr/device.h>
 #include <zephyr/input/input.h>
 #include <zephyr/drivers/display.h>
+#include <zephyr/sys/util.h>
 
 LOG_MODULE_REGISTER(sample, LOG_LEVEL_INF);
 
@@ -25,7 +26,7 @@ LOG_MODULE_REGISTER(sample, LOG_LEVEL_INF);
 #define CROSS_DIM (WIDTH / CONFIG_SCREEN_WIDTH_TO_CROSS_DIM)
 
 #define PIXEL_FORMAT (DT_PROP_OR(DT_CHOSEN(zephyr_display), pixel_format, PIXEL_FORMAT_ARGB_8888))
-#define BPP          ((DISPLAY_BITS_PER_PIXEL(PIXEL_FORMAT)) / 8)
+#define BPP          ((DISPLAY_BITS_PER_PIXEL(PIXEL_FORMAT)) / BITS_PER_BYTE)
 
 #define BUFFER_SIZE  (CROSS_DIM * CROSS_DIM * BPP)
 #define REFRESH_RATE 100

--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -655,7 +655,7 @@ static bool cf_set_value(struct gatt_cf_cfg *cfg, const uint8_t *value, uint16_t
 	/* Set the bits for each octet */
 	for (i = 0U; i < len && i < CF_NUM_BYTES; i++) {
 		if (i == (CF_NUM_BYTES - 1)) {
-			cfg->data[i] |= value[i] & BIT_MASK(CF_NUM_BITS % 8);
+			cfg->data[i] |= value[i] & BIT_MASK(CF_NUM_BITS % BITS_PER_BYTE);
 		} else {
 			cfg->data[i] |= value[i];
 		}

--- a/subsys/demand_paging/eviction/lru.c
+++ b/subsys/demand_paging/eviction/lru.c
@@ -36,6 +36,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/kernel/mm/demand_paging.h>
 #include <zephyr/spinlock.h>
+#include <zephyr/sys/util.h>
 #include <mmu.h>
 #include <kernel_arch_interface.h>
 
@@ -51,7 +52,7 @@
  * boundary for best compromize between code performance and space saving.
  * The extra entry is used to store head and tail indexes.
  */
-#define PF_IDX_BITS ROUND_UP(LOG2CEIL(K_MEM_NUM_PAGE_FRAMES + 1), 8)
+#define PF_IDX_BITS ROUND_UP(LOG2CEIL(K_MEM_NUM_PAGE_FRAMES + 1), BITS_PER_BYTE)
 
 /* For each page frame, track the previous and next page frame in the queue. */
 struct lru_pf_idx {

--- a/subsys/testsuite/ztest/src/ztest_mock.c
+++ b/subsys/testsuite/ztest/src/ztest_mock.c
@@ -76,13 +76,12 @@ int snprintk(char *str, size_t size, const char *fmt, ...)
  * FIXME: move to sys_io.h once the argument signature for bitmap has
  * been fixed to void* or similar GH-2825
  */
-#define BITS_PER_UL                 (8 * sizeof(unsigned long))
-#define DEFINE_BITFIELD(name, bits) unsigned long(name)[DIV_ROUND_UP(bits, BITS_PER_UL)]
+#define DEFINE_BITFIELD(name, bits) unsigned long(name)[DIV_ROUND_UP(bits, BITS_PER_LONG)]
 
 static inline int sys_bitfield_find_first_clear(const unsigned long *bitmap,
 						const unsigned int bits)
 {
-	const size_t words = DIV_ROUND_UP(bits, BITS_PER_UL);
+	const size_t words = DIV_ROUND_UP(bits, BITS_PER_LONG);
 	size_t cnt;
 	unsigned int long neg_bitmap;
 
@@ -97,10 +96,10 @@ static inline int sys_bitfield_find_first_clear(const unsigned long *bitmap,
 			continue;
 		} else if (neg_bitmap == ~0UL) {
 			/* First bit is free */
-			return cnt * BITS_PER_UL;
+			return cnt * BITS_PER_LONG;
 		} else {
 			const unsigned int bit =
-				(cnt * BITS_PER_UL) + __builtin_ffsl(neg_bitmap) - 1;
+				(cnt * BITS_PER_LONG) + __builtin_ffsl(neg_bitmap) - 1;
 			/* Ensure first free bit is within total bits count */
 			if (bit < bits) {
 				return bit;

--- a/tests/kernel/mem_protect/mem_protect/src/kobject.c
+++ b/tests/kernel/mem_protect/mem_protect/src/kobject.c
@@ -1183,7 +1183,7 @@ ZTEST(mem_protect_kobj, test_kobj_create_out_of_memory)
 #ifdef CONFIG_DYNAMIC_OBJECTS
 extern uint8_t _thread_idx_map[CONFIG_MAX_THREAD_BYTES];
 
-#define MAX_THREAD_BITS         (CONFIG_MAX_THREAD_BYTES * 8)
+#define MAX_THREAD_BITS (CONFIG_MAX_THREAD_BYTES * BITS_PER_BYTE)
 #endif
 
 /* @brief Test alloc thread object until out of idex

--- a/tests/subsys/secure_storage/psa/crypto/src/main.c
+++ b/tests/subsys/secure_storage/psa/crypto/src/main.c
@@ -2,6 +2,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <zephyr/ztest.h>
+#include <zephyr/sys/util.h>
 #include <psa/crypto.h>
 #include <psa/internal_trusted_storage.h>
 #include <psa/protected_storage.h>
@@ -87,7 +88,7 @@ ZTEST(secure_storage_psa_crypto, test_persistent_key_usage)
 	psa_status_t ret;
 	psa_key_attributes_t key_attributes;
 	psa_key_id_t key_id;
-	uint8_t key_material[KEY_BITS / 8];
+	uint8_t key_material[KEY_BITS / BITS_PER_BYTE];
 
 	fill_key_attributes(&key_attributes);
 	fill_data(key_material, sizeof(key_material));


### PR DESCRIPTION
Obviously, everyone knows that there are 8 bits per byte, so there isn't a lot of magic happening, per se, but it's also helpful to clearly denote where the magic number 8 is referring to the number of bits in a byte.

Occasionally, 8 will refer to a field size or offset in a structure, MMR, or word. Occasionally, the number 8 will refer to the number of bytes in a 64-bit value (which should probably be replaced with `sizeof(uint64_t)`).

For converting bits to bytes, or vice-versa, let's use `BITS_PER_BYTE` for clarity (or other appropriate `BITS_PER_*` macros).