### PR TITLE
twister: Fix NOTRUN status

### DIFF
--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -900,7 +900,9 @@ class ProjectBuilder(FilterBuilder):
                     next_op = 'report'
                 elif self.options.cmake_only:
                     if self.instance.status == TwisterStatus.NONE:
-                        self.instance.status = TwisterStatus.PASS
+                        logger.debug("CMake only: PASS %s" % self.instance.name)
+                        self.instance.status = TwisterStatus.NOTRUN
+                        self.instance.add_missing_case_status(TwisterStatus.NOTRUN, 'CMake only')
                     next_op = 'report'
                 else:
                     # Here we check the runtime filter results coming from running cmake
@@ -974,6 +976,10 @@ class ProjectBuilder(FilterBuilder):
                 elif self.instance.run and self.instance.handler.ready:
                     next_op = 'run'
                 else:
+                    if self.instance.status == TwisterStatus.NOTRUN:
+                        run_conditions =  f"(run:{self.instance.run}, handler.ready:{self.instance.handler.ready})"
+                        logger.debug(f"Instance {self.instance.name} can't run {run_conditions}")
+                        self.instance.add_missing_case_status(TwisterStatus.NOTRUN, f"Nowhere to run")
                     next_op = 'report'
             except StatusAttributeError as sae:
                 logger.error(str(sae))

--- a/scripts/tests/twister/test_runner.py
+++ b/scripts/tests/twister/test_runner.py
@@ -978,7 +978,7 @@ TESTDATA_6 = [
         mock.ANY,
         [],
         {'op': 'report', 'test': mock.ANY},
-        TwisterStatus.PASS,
+        TwisterStatus.NOTRUN,
         mock.ANY,
         0,
         None

--- a/scripts/tests/twister_blackbox/test_runner.py
+++ b/scripts/tests/twister_blackbox/test_runner.py
@@ -73,7 +73,7 @@ class TestRunner:
             os.path.join(TEST_DATA, 'tests', 'dummy', 'agnostic'),
             ['qemu_x86', 'qemu_x86_64'],
             {
-                'passed_configurations': 6,
+                'passed_configurations': 0,
                 'selected_test_instances': 6,
                 'executed_on_platform': 0,
                 'only_built': 6,


### PR DESCRIPTION
Fixes: #80801

Fix Twister TestCase statuses left not assigned ('NONE') in these 'NOTRUN' situations:

 * a test suite has `integration platform` which is not available to run.

 * `--cmake-only` execution.