### PR TITLE
drivers: flash: sam: fix flash erase last page

### DIFF
--- a/dts/arm/atmel/samx7xx21.dtsi
+++ b/dts/arm/atmel/samx7xx21.dtsi
@@ -16,7 +16,7 @@
 		flash-controller@400e0c00 {
 			flash0: flash@400000 {
 				reg = <0x00400000 DT_SIZE_K(2048)>;
-				erase-blocks = <&eefc 8 2048>, <&eefc 252 8192>;
+				erase-blocks = <&eefc 8 2048>, <&eefc 254 8192>;
 			};
 		};
 	};


### PR DESCRIPTION
The implementation for erasing pages in the flash_sam.c driver indicated a successful erase after exceeding the last page to be erased successfully. Since the last page has no proceeding page, the succeeded status was not set.

This fix switches around the status to be set as succeeded before erase begins, to have the succeeded status cleared if page unlock or erase fails.

fixes: #70344