### PR TITLE
boards: frdm_mcxc444: Add usb support

### DIFF
--- a/boards/nxp/frdm_mcxc444/doc/index.rst
+++ b/boards/nxp/frdm_mcxc444/doc/index.rst
@@ -63,6 +63,8 @@ The ``frdm_mcxc444`` board target supports the following hardware features:
 +-----------+------------+-------------------------------------+
 | RTC       | on-chip    | counter                             |
 +-----------+------------+-------------------------------------+
+| USB       | on-chip    | USB device                          |
++-----------+------------+-------------------------------------+
 
 
 Targets available

--- a/boards/nxp/frdm_mcxc444/frdm_mcxc444.dts
+++ b/boards/nxp/frdm_mcxc444/frdm_mcxc444.dts
@@ -137,3 +137,8 @@ i2c0: &i2c0 {
 &pit0_channel1 {
 	status = "okay";
 };
+
+zephyr_udc0: &usb {
+	status = "okay";
+	num-bidir-endpoints = <8>;
+};

--- a/boards/nxp/frdm_mcxc444/frdm_mcxc444.yaml
+++ b/boards/nxp/frdm_mcxc444/frdm_mcxc444.yaml
@@ -20,6 +20,8 @@ supported:
   - gpio
   - i2c
   - uart
+  - usb_device
+  - usbd
 testing:
   ignore_tags:
     - net

--- a/doc/releases/release-notes-4.1.rst
+++ b/doc/releases/release-notes-4.1.rst
@@ -101,7 +101,6 @@ Boards & SoC Support
 
   * All HWMv1 board name aliases which were added as deprecated in v3.7 are now removed
     (:github:`82247`).
-  * Enabled USB, RTC on NXP ``frdm_mcxn236``
 
 * Added support for the following shields:
 

--- a/samples/subsys/usb/dfu/sample.yaml
+++ b/samples/subsys/usb/dfu/sample.yaml
@@ -19,6 +19,7 @@ common:
     - b_u585i_iot02a
     - frdm_kl25z
     - frdm_mcxc242
+    - frdm_mcxc444
     - lpcxpresso55s69/lpc55s69/cpu0
     - stm32l562e_dk/stm32l562xx/ns
   depends_on: usb_device


### PR DESCRIPTION
Support usb for NXP frdm_mcxc444 board