### PR TITLE
Bluetooth: drivers: Sync bus types with BlueZ

### DIFF
--- a/dts/bindings/bluetooth/bt-hci.yaml
+++ b/dts/bindings/bluetooth/bt-hci.yaml
@@ -19,6 +19,8 @@ properties:
       - "sdio"
       - "spi"
       - "i2c"
+      - "smd"
+      - "virtio"
       - "ipm"
   bt-hci-quirks:
     type: string-array

--- a/dts/bindings/bluetooth/bt-hci.yaml
+++ b/dts/bindings/bluetooth/bt-hci.yaml
@@ -21,7 +21,8 @@ properties:
       - "i2c"
       - "smd"
       - "virtio"
-      - "ipm"
+      - "ipm"    # Deprecated. "ipc" should be used instead.
+      - "ipc"
   bt-hci-quirks:
     type: string-array
     description: HCI device quirks

--- a/dts/bindings/bluetooth/zephyr,bt-hci-ipc.yaml
+++ b/dts/bindings/bluetooth/zephyr,bt-hci-ipc.yaml
@@ -8,7 +8,7 @@ properties:
   bt-hci-name:
     default: "IPC"
   bt-hci-bus:
-    default: "ipm"
+    default: "ipc"
   bt-hci-quirks:
     default: ["no-auto-dle"]
   bt-hci-ipc-name:

--- a/include/zephyr/drivers/bluetooth.h
+++ b/include/zephyr/drivers/bluetooth.h
@@ -71,7 +71,9 @@ enum bt_hci_bus {
 	BT_HCI_BUS_I2C           = 8,
 	BT_HCI_BUS_SMD           = 9,
 	BT_HCI_BUS_VIRTIO        = 10,
-	BT_HCI_BUS_IPM           = 11,
+	BT_HCI_BUS_IPC           = 11,
+	/* IPM is deprecated and simply an alias for IPC */
+	BT_HCI_BUS_IPM           = BT_HCI_BUS_IPC,
 };
 
 #define BT_DT_HCI_QUIRK_OR(node_id, prop, idx) \

--- a/include/zephyr/drivers/bluetooth.h
+++ b/include/zephyr/drivers/bluetooth.h
@@ -69,7 +69,9 @@ enum bt_hci_bus {
 	BT_HCI_BUS_SDIO          = 6,
 	BT_HCI_BUS_SPI           = 7,
 	BT_HCI_BUS_I2C           = 8,
-	BT_HCI_BUS_IPM           = 9,
+	BT_HCI_BUS_SMD           = 9,
+	BT_HCI_BUS_VIRTIO        = 10,
+	BT_HCI_BUS_IPM           = 11,
 };
 
 #define BT_DT_HCI_QUIRK_OR(node_id, prop, idx) \


### PR DESCRIPTION
The authoritative source of these values is BlueZ:

https://git.kernel.org/pub/scm/bluetooth/bluez.git/tree/lib/hci.h#n38

Update our values with the above. The IPM definiton doesn't exist in BlueZ, but should be added there to make sure we don't get out of sync again.

Fixes #80984