### PR TITLE
arch: riscv64: smp: get msip base address from dts

### DIFF
--- a/arch/riscv/core/ipi_clint.c
+++ b/arch/riscv/core/ipi_clint.c
@@ -9,7 +9,11 @@
 
 #include <zephyr/kernel.h>
 
-#define MSIP_BASE    0x2000000UL
+#define CLINT_NODE DT_NODELABEL(clint)
+#if !DT_NODE_EXISTS(CLINT_NODE)
+#error "Label 'clint' is not defined in the devicetree."
+#endif
+#define MSIP_BASE DT_REG_ADDR_RAW(CLINT_NODE)
 #define MSIP(hartid) ((volatile uint32_t *)MSIP_BASE)[hartid]
 
 static atomic_val_t cpu_pending_ipi[CONFIG_MP_MAX_NUM_CPUS];

--- a/dts/riscv/qemu/virt-riscv.dtsi
+++ b/dts/riscv/qemu/virt-riscv.dtsi
@@ -181,7 +181,7 @@
 			#interrupt-cells = < 0x02 >;
 		};
 
-		clint@2000000 {
+		clint: clint@2000000 {
 			compatible = "sifive,clint0";
 			reg = <0x2000000 0x10000>;
 			interrupts-extended = <&hlic0 0x03 &hlic0 0x07


### PR DESCRIPTION
In most implements, the msip base address is 0x2000000. But the address is not fixed in all boards.