### PR TITLE
net: wifi: Fix 11k command errors

### DIFF
--- a/subsys/net/l2/wifi/wifi_mgmt.c
+++ b/subsys/net/l2/wifi/wifi_mgmt.c
@@ -723,7 +723,9 @@ static int wifi_11k_cfg(uint32_t mgmt_request, struct net_if *iface,
 	}
 
 #ifdef CONFIG_WIFI_NM_WPA_SUPPLICANT_ROAMING
-	roaming_params.is_11k_enabled = params->enable_11k;
+	if (params->oper == WIFI_MGMT_SET) {
+		roaming_params.is_11k_enabled = params->enable_11k;
+	}
 #endif
 
 	return wifi_mgmt_api->cfg_11k(dev, params);

--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -1248,7 +1248,7 @@ static int cmd_wifi_11k(const struct shell *sh, size_t argc, char *argv[])
 	}
 
 	if (params.oper == WIFI_MGMT_GET) {
-		PR("11k is %s\n", params.enable_11k ? "disabled" : "enabled");
+		PR("11k is %s\n", params.enable_11k ? "enabled" : "disabled");
 	} else {
 		PR("%s %s requested\n", argv[0], argv[1]);
 	}


### PR DESCRIPTION
Add condition check so that the 11k flag will be updated for set operation only.
Fix print log error when getting 11k status.

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/81111