### PR TITLE
MAINTAINERS: Fix issues with Bluetooth HCI section

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -314,12 +314,13 @@ Bluetooth HCI:
     - HoZHel
   files:
     - include/zephyr/drivers/bluetooth/
+    - include/zephyr/drivers/bluetooth.h
     - drivers/bluetooth/
     - samples/bluetooth/hci_*/
     - tests/bsim/bluetooth/hci_uart/
     - dts/bindings/bluetooth/
   labels:
-    - "area: Bluetooth Host"
+    - "area: Bluetooth HCI"
     - "area: Bluetooth"
   tests:
     - bluetooth


### PR DESCRIPTION
The primary header file was missing, and one of the labels was wrong.