### PR TITLE
doc: releases: 4.0: add CAN and EEPROM release notes

### DIFF
--- a/doc/releases/migration-guide-4.0.rst
+++ b/doc/releases/migration-guide-4.0.rst
@@ -196,9 +196,6 @@ Clock control
            load-capacitance-femtofarad = <...>;
      };
 
-Controller Area Network (CAN)
-=============================
-
 Crypto
 ======
 

--- a/doc/releases/release-notes-4.0.rst
+++ b/doc/releases/release-notes-4.0.rst
@@ -323,6 +323,11 @@ Drivers and Sensors
 
 * Display
 
+* EEPROM
+
+  * Added support for using the EEPROM simulator with embedded C standard libraries
+    (:dtcompatible:`zephyr,sim-eeprom`).
+
 * Ethernet
 
   * LiteX: Renamed the ``compatible`` from ``litex,eth0`` to :dtcompatible:`litex,liteeth`.

--- a/doc/releases/release-notes-4.0.rst
+++ b/doc/releases/release-notes-4.0.rst
@@ -298,6 +298,11 @@ Drivers and Sensors
 
 * CAN
 
+  * Added initial support for Renesas RA CANFD (:dtcompatible:`renesas,ra-canfd-global`,
+    :dtcompatible:`renesas,ra-canfd`)
+  * Added Flexcan support for S32Z27x (:dtcompatible:`nxp,flexcan`, :dtcompatible:`nxp,flexcan-fd`)
+  * Improved NXP S32 CANXL error reporting (:dtcompatible:`nxp,s32-canxl`)
+
 * Charger
 
 * Clock control


### PR DESCRIPTION
Add CAN and EEPROM related release notes for Zephyr v4.0.0.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>