### PR TITLE
include: bindings: clock stm32u0 Min bus clock is STM32_CLOCK_BUS_AHB

### DIFF
--- a/include/zephyr/dt-bindings/clock/stm32u0_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32u0_clock.h
@@ -9,12 +9,12 @@
 #include "stm32_common_clocks.h"
 
 /** Bus gatting clocks */
-#define STM32_CLOCK_BUS_IOP     0x4C
 #define STM32_CLOCK_BUS_AHB1    0x48
+#define STM32_CLOCK_BUS_IOP     0x4C
 #define STM32_CLOCK_BUS_APB1    0x58
 #define STM32_CLOCK_BUS_APB1_2  0x60
 
-#define STM32_PERIPH_BUS_MIN	STM32_CLOCK_BUS_IOP
+#define STM32_PERIPH_BUS_MIN	STM32_CLOCK_BUS_AHB1
 #define STM32_PERIPH_BUS_MAX	STM32_CLOCK_BUS_APB1_2
 
 /** Domain clocks */


### PR DESCRIPTION
Fix the minimum CLOCK BUS address to be the AHB: STM32_CLOCK_BUS_AHB1 instead of the STM32_CLOCK_BUS_IOP
from the RCC register Map


Fixes https://github.com/zephyrproject-rtos/zephyr/issues/80817
