### PR TITLE
drivers: nrfiwif: Enable recovery by default

### DIFF
--- a/drivers/wifi/nrfwifi/Kconfig.nrfwifi
+++ b/drivers/wifi/nrfwifi/Kconfig.nrfwifi
@@ -655,6 +655,7 @@ config NRF_WIFI_AP_DEAD_DETECT_TIMEOUT
 config NRF_WIFI_RPU_RECOVERY
 	bool "RPU recovery mechanism"
 	depends on NRF_WIFI_LOW_POWER
+	default y
 	select EXPERIMENTAL
 	help
 		Enable RPU recovery mechanism to recover from RPU (nRF70) hang.


### PR DESCRIPTION
This is needed to ensure Wi-Fi can always be used.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/80971