### PR TITLE
MAINTAINERS: Change collaborator and code owner for SPARC and LEON

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -340,7 +340,7 @@
 /drivers/serial/uart_xlnx_uartlite.c      @henrikbrixandersen
 /drivers/serial/*xmc4xxx*                 @parthitce
 /drivers/serial/*numicro*                 @ssekar15
-/drivers/serial/*apbuart*                 @julius-barendt
+/drivers/serial/*apbuart*                 @tbr-tt
 /drivers/serial/*rcar*                    @aaillet
 /drivers/serial/Kconfig.xen               @lorc @firscity
 /drivers/serial/uart_hvc_xen.c            @lorc @firscity
@@ -365,7 +365,7 @@
 /drivers/timer/*xlnx_psttc*               @wjliang @stephanosio
 /drivers/timer/*cc13xx_cc26xx_rtc*        @vanti
 /drivers/timer/*cavs*                     @dcpleung
-/drivers/timer/*leon_gptimer*             @julius-barendt
+/drivers/timer/*leon_gptimer*             @tbr-tt
 /drivers/timer/*mips_cp0*                 @frantony
 /drivers/timer/*rcar_cmt*                 @aaillet
 /drivers/timer/*esp32_sys*                @uLipe

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3330,7 +3330,7 @@ Shields:
 SPARC arch:
   status: odd fixes
   collaborators:
-    - julius-barendt
+    - tbr-tt
   files:
     - arch/sparc/
     - include/zephyr/arch/sparc/
@@ -3342,7 +3342,7 @@ SPARC arch:
 Gaisler Platforms:
   status: odd fixes
   collaborators:
-    - julius-barendt
+    - tbr-tt
   files:
     - dts/sparc/gaisler/
     - soc/gaisler/


### PR DESCRIPTION
Due to change of responsibilities in our organization:
- Remove @julius-barendt as collaborator and code owner for areas related to SPARC and LEON.
- Add myself to the same areas.

Role nomination: #80831
