### PR TITLE
Bluetooth: Host: Fix unsafe ccc cast

### DIFF
--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -3475,19 +3475,19 @@ bool bt_gatt_is_subscribed(struct bt_conn *conn,
 
 	/* Check if attribute is a characteristic declaration */
 	if (!bt_uuid_cmp(attr->uuid, BT_UUID_GATT_CHRC)) {
-		uint8_t properties;
+		uint8_t properties = 0;
 		ssize_t len;
 
-		CHECKIF(!attr->read) {
+		if (!attr->read) {
 			LOG_ERR("Read method not set");
 			return false;
 		}
 		/* The charactestic properties is the first byte of the attribute value */
-		len = attr->read(NULL, attr, &properties, 1, 0);
+		len = attr->read(NULL, attr, &properties, sizeof(properties), 0);
 		if (len < 0) {
 			LOG_ERR("Failed to read attribute (err %zd)", len);
 			return false;
-		} else if (len != 1) {
+		} else if (len != sizeof(properties)) {
 			LOG_ERR("Invalid read length: %zd", len);
 			return false;
 		}

--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -3464,7 +3464,9 @@ static uint8_t disconnected_cb(const struct bt_gatt_attr *attr, uint16_t handle,
 bool bt_gatt_is_subscribed(struct bt_conn *conn,
 			   const struct bt_gatt_attr *attr, uint16_t ccc_type)
 {
-	const struct _bt_gatt_ccc *ccc;
+	uint16_t ccc_bits;
+	uint8_t ccc_bits_encoded[sizeof(ccc_bits)];
+	ssize_t len;
 
 	__ASSERT(conn, "invalid parameter\n");
 	__ASSERT(attr, "invalid parameter\n");
@@ -3475,8 +3477,7 @@ bool bt_gatt_is_subscribed(struct bt_conn *conn,
 
 	/* Check if attribute is a characteristic declaration */
 	if (!bt_uuid_cmp(attr->uuid, BT_UUID_GATT_CHRC)) {
-		uint8_t properties = 0;
-		ssize_t len;
+		uint8_t properties;
 
 		if (!attr->read) {
 			LOG_ERR("Read method not set");
@@ -3485,7 +3486,7 @@ bool bt_gatt_is_subscribed(struct bt_conn *conn,
 		/* The charactestic properties is the first byte of the attribute value */
 		len = attr->read(NULL, attr, &properties, sizeof(properties), 0);
 		if (len < 0) {
-			LOG_ERR("Failed to read attribute (err %zd)", len);
+			LOG_ERR("Failed to read attribute %p (err %zd)", attr, len);
 			return false;
 		} else if (len != sizeof(properties)) {
 			LOG_ERR("Invalid read length: %zd", len);
@@ -3523,16 +3524,25 @@ bool bt_gatt_is_subscribed(struct bt_conn *conn,
 		return false;
 	}
 
-	ccc = attr->user_data;
+	if (!attr->read) {
+		LOG_ERR("Read method not set");
+		return false;
+	}
 
-	/* Check if the connection is subscribed */
-	for (size_t i = 0; i < BT_GATT_CCC_MAX; i++) {
-		const struct bt_gatt_ccc_cfg *cfg = &ccc->cfg[i];
+	len = attr->read(conn, attr, ccc_bits_encoded, sizeof(ccc_bits_encoded), 0);
+	if (len < 0) {
+		LOG_ERR("Failed to read attribute %p (err %zd)", attr, len);
+		return false;
+	} else if (len != sizeof(ccc_bits_encoded)) {
+		LOG_ERR("Invalid read length: %zd", len);
+		return false;
+	}
 
-		if (bt_conn_is_peer_addr_le(conn, cfg->id, &cfg->peer) &&
-		    (ccc_type & ccc->cfg[i].value)) {
-			return true;
-		}
+	ccc_bits = sys_get_le16(ccc_bits_encoded);
+
+	/* Check if the CCC bits match the subscription type */
+	if (ccc_bits & ccc_type) {
+		return true;
 	}
 
 	return false;


### PR DESCRIPTION
Contains two commits:

- Refactors `bt_gatt_is_subscribed` when checking the characteristics declaration to avoid undefined behavior.
- Fixes an unsafe cast in the same function when extracting the CCC attribute value.