### PR TITLE
drivers: interrupt_controller: do not set sgi type

### DIFF
--- a/drivers/interrupt_controller/intc_gic.c
+++ b/drivers/interrupt_controller/intc_gic.c
@@ -113,13 +113,16 @@ void arm_gic_irq_set_priority(
 	int_grp = (irq / 16) * 4;
 	int_off = (irq % 16) * 2;
 
-	val = sys_read32(GICD_ICFGRn + int_grp);
-	val &= ~(GICD_ICFGR_MASK << int_off);
-	if (flags & IRQ_TYPE_EDGE) {
-		val |= (GICD_ICFGR_TYPE << int_off);
-	}
+	/* GICD_ICFGR0 is read-only; SGIs are always edge-triggered */
+	if (int_grp != 0) {
+		val = sys_read32(GICD_ICFGRn + int_grp);
+		val &= ~(GICD_ICFGR_MASK << int_off);
+		if (flags & IRQ_TYPE_EDGE) {
+			val |= (GICD_ICFGR_TYPE << int_off);
+		}
 
-	sys_write32(val, GICD_ICFGRn + int_grp);
+		sys_write32(val, GICD_ICFGRn + int_grp);
+	}
 }
 
 unsigned int arm_gic_get_active(void)


### PR DESCRIPTION
In the [ARM® Generic Interrupt Controller Architecture Specification (Architecture version 2.0)](https://developer.arm.com/documentation/ihi0069/latest/), it says in 4.3.13
>For SGIs, Int_config fields are read-only, meaning that GICD_ICFGR0 is read-only.

Because SGIs are always edge-triggered, the value does not need to be set.
I changed the driver to not write to the GICD_ICFGR0 register.