### PR TITLE
test: net: lib: prometheus: formatter: Fix test flakiness

### DIFF
--- a/tests/net/lib/prometheus/formatter/src/main.c
+++ b/tests/net/lib/prometheus/formatter/src/main.c
@@ -36,7 +36,7 @@ PROMETHEUS_COLLECTOR_DEFINE(test_custom_collector);
 ZTEST(test_formatter, test_prometheus_formatter_simple)
 {
 	int ret;
-	char formatted[MAX_BUFFER_SIZE];
+	char formatted[MAX_BUFFER_SIZE] = { 0 };
 	struct prometheus_counter *counter;
 	char exposed[] = "# HELP test_counter Test counter\n"
 			 "# TYPE test_counter counter\n"


### PR DESCRIPTION
If a string is already present in the provided buffer, prometheus_format_exposition() appends it instead of overwriting, hence the buffer needs to be cleared on the test start, otherwise it works by chance.

Fixes #80827