### PR TITLE
tests: kernel: mutex.error needs CONFIG_USERSPACE

### DIFF
--- a/tests/kernel/mutex/mutex_error_case/testcase.yaml
+++ b/tests/kernel/mutex/mutex_error_case/testcase.yaml
@@ -1,6 +1,6 @@
 tests:
   kernel.mutex.error:
-    filter: CONFIG_ARCH_HAS_USERSPACE
+    filter: CONFIG_USERSPACE
     arch_exclude:
       - posix
     tags:


### PR DESCRIPTION
This test fails with CONFIG_USERSPACE=n
Since this test checks for error conditions
requiring userspace, we need to require it.

To reproduce
```
user@2910b946914f:/workdir/zephyr$ scripts/twister -p nrf52840dk/nrf52840 -T tests/kernel/mutex/mutex_error_case/ -x CONFIG_USERSPACE=n --hardware-map mapnrf.yml --device-testing --verbose
INFO    - 1/1 nrf52840dk/nrf52840       tests/kernel/mutex/mutex_error_case/kernel.mutex.error  FAILED Failed (device: 001050277191, 2.720s)
ERROR   - see: /workdir/zephyr/twister-out/nrf52840dk_nrf52840/tests/kernel/mutex/mutex_error_case/kernel.mutex.error/handler.log
```
[handler.log](https://github.com/user-attachments/files/17618849/handler.log)

This is all new to me, but this change matches thread_error_case which works as I expect.
