### PR TITLE
Fix crash unprogrammed board

### DIFF
--- a/drivers/wifi/nrfwifi/src/net_if.c
+++ b/drivers/wifi/nrfwifi/src/net_if.c
@@ -877,7 +877,7 @@ int nrf_wifi_if_stop_zep(const struct device *dev)
 	}
 
 	rpu_ctx_zep = vif_ctx_zep->rpu_ctx_zep;
-	if (!rpu_ctx_zep) {
+	if (!rpu_ctx_zep || !rpu_ctx_zep->rpu_ctx) {
 		LOG_ERR("%s: rpu_ctx_zep is NULL",
 			__func__);
 		goto unlock;

--- a/drivers/wifi/nrfwifi/src/net_if.c
+++ b/drivers/wifi/nrfwifi/src/net_if.c
@@ -980,10 +980,23 @@ int nrf_wifi_if_get_config_zep(const struct device *dev,
 		goto unlock;
 	}
 
+	memset(config, 0, sizeof(struct ethernet_config));
+
 	if (type == ETHERNET_CONFIG_TYPE_TXINJECTION_MODE) {
 		config->txinjection_mode =
 			def_dev_ctx->vif_ctx[vif_ctx_zep->vif_idx]->txinjection_mode;
 	}
+#ifdef CONFIG_NRF70_TCP_IP_CHECKSUM_OFFLOAD
+	if (type  == ETHERNET_CONFIG_TYPE_TX_CHECKSUM_SUPPORT ||
+	    type == ETHERNET_CONFIG_TYPE_RX_CHECKSUM_SUPPORT) {
+		config->chksum_support = ETHERNET_CHECKSUM_SUPPORT_IPV4_HEADER |
+					 ETHERNET_CHECKSUM_SUPPORT_IPV4_ICMP |
+					 ETHERNET_CHECKSUM_SUPPORT_IPV6_HEADER |
+					 ETHERNET_CHECKSUM_SUPPORT_IPV6_ICMP |
+					 ETHERNET_CHECKSUM_SUPPORT_TCP |
+					 ETHERNET_CHECKSUM_SUPPORT_UDP;
+	}
+#endif
 	ret = 0;
 unlock:
 	k_mutex_unlock(&vif_ctx_zep->vif_lock);

--- a/west.yml
+++ b/west.yml
@@ -188,7 +188,7 @@ manifest:
       groups:
         - hal
     - name: hal_nordic
-      revision: cb7600a1be4c8b177867e6d463729c07dd3f6d73
+      revision: 2d78179cc4f0601a891553132b13184fa51b6ef9
       path: modules/hal/nordic
       groups:
         - hal


### PR DESCRIPTION
    In case the driver UP fails, the FMAC context will be NULL, so, add a
    NULL check in the DOWN.
    
    Fixes a crash seen when working with unprogrammed OTP (no MAC) that
    fails the interface UP.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/80972