### PR TITLE
doc: releases: introduce release notes and migration guide docs for 4.1

### DIFF
--- a/doc/releases/eol_releases.rst
+++ b/doc/releases/eol_releases.rst
@@ -1,7 +1,15 @@
-End-of-life releases
-====================
+.. _eol_releases:
 
-Release notes for end-of-life releases of Zephyr RTOS are kept here for historical purposes.
+End-of-life releases
+####################
+
+Release notes and migration guides for end-of-life releases of Zephyr RTOS are kept here for
+historical purposes.
+
+.. _eol_releases_relesase_notes:
+
+Release Notes
+*************
 
 .. toctree::
    :maxdepth: 1
@@ -12,3 +20,15 @@ Release notes for end-of-life releases of Zephyr RTOS are kept here for historic
    release-notes-1.*
    release-notes-2.[0-6]
    release-notes-3.[0-5]
+
+.. _eol_releases_migration_guides:
+
+Migration Guides
+****************
+
+.. toctree::
+   :maxdepth: 1
+   :glob:
+   :reversed:
+
+   migration-guide-3.[5]

--- a/doc/releases/index.rst
+++ b/doc/releases/index.rst
@@ -81,7 +81,6 @@ needs to be changed are to be detailed in the release's migration guide.
    :glob:
    :reversed:
 
-   eol_releases
    release-notes-2.7
    release-notes-3.[6-7]
    release-notes-4.0
@@ -115,7 +114,20 @@ to be able to understand the context of the change.
    :glob:
    :reversed:
 
-   migration-guide-*
+   migration-guide-3.[6-7]
+   migration-guide-4.[0]
+
+End-of-life Releases
+********************
+
+.. toctree::
+   :hidden:
+   :maxdepth: 1
+
+   eol_releases
+
+Release notes and migration guides for end-of-life releases of Zephyr RTOS can be accessed
+:ref:`here <eol_releases>`.
 
 .. _`GitHub repository`: https://github.com/zephyrproject-rtos/zephyr
 .. _`GitHub tagged releases`: https://github.com/zephyrproject-rtos/zephyr/tags

--- a/doc/releases/migration-guide-4.1.rst
+++ b/doc/releases/migration-guide-4.1.rst
@@ -1,0 +1,112 @@
+:orphan:
+
+.. _migration_4.1:
+
+Migration guide to Zephyr v4.1.0 (Working Draft)
+################################################
+
+This document describes the changes required when migrating your application from Zephyr v4.0.0 to
+Zephyr v4.1.0.
+
+Any other changes (not directly related to migrating applications) can be found in
+the :ref:`release notes<zephyr_4.1>`.
+
+.. contents::
+    :local:
+    :depth: 2
+
+Build System
+************
+
+Kernel
+******
+
+Boards
+******
+
+Modules
+*******
+
+Mbed TLS
+========
+
+Trusted Firmware-M
+==================
+
+LVGL
+====
+
+Device Drivers and Devicetree
+*****************************
+
+Controller Area Network (CAN)
+=============================
+
+Display
+=======
+
+Enhanced Serial Peripheral Interface (eSPI)
+===========================================
+
+GNSS
+====
+
+Input
+=====
+
+Interrupt Controller
+====================
+
+LED Strip
+=========
+
+Sensors
+=======
+
+Serial
+======
+
+Regulator
+=========
+
+Bluetooth
+*********
+
+Bluetooth HCI
+=============
+
+Bluetooth Mesh
+==============
+
+Bluetooth Audio
+===============
+
+Bluetooth Classic
+=================
+
+Bluetooth Host
+==============
+
+Bluetooth Crypto
+================
+
+Networking
+**********
+
+Other Subsystems
+****************
+
+Flash map
+=========
+
+hawkBit
+=======
+
+MCUmgr
+======
+
+Modem
+=====
+
+Architectures
+*************

--- a/doc/releases/release-notes-4.1.rst
+++ b/doc/releases/release-notes-4.1.rst
@@ -1,0 +1,288 @@
+:orphan:
+
+.. _zephyr_4.1:
+
+Zephyr 4.1.0 (Working Draft)
+############################
+
+We are pleased to announce the release of Zephyr version 4.1.0.
+
+Major enhancements with this release include:
+
+An overview of the changes required or recommended when migrating your application from Zephyr
+v4.0.0 to Zephyr v4.1.0 can be found in the separate :ref:`migration guide<migration_4.1>`.
+
+The following sections provide detailed lists of changes by component.
+
+Security Vulnerability Related
+******************************
+The following CVEs are addressed by this release:
+
+More detailed information can be found in:
+https://docs.zephyrproject.org/latest/security/vulnerabilities.html
+
+API Changes
+***********
+
+Removed APIs in this release
+============================
+
+Deprecated in this release
+==========================
+
+Architectures
+*************
+
+* ARC
+
+* ARM
+
+* ARM64
+
+* RISC-V
+
+* Xtensa
+
+Kernel
+******
+
+Bluetooth
+*********
+
+* Audio
+
+* Host
+
+* HCI Drivers
+
+Boards & SoC Support
+********************
+
+* Added support for these SoC series:
+
+* Made these changes in other SoC series:
+
+* Added support for these boards:
+
+* Made these board changes:
+
+* Added support for the following shields:
+
+Build system and Infrastructure
+*******************************
+
+Drivers and Sensors
+*******************
+
+* ADC
+
+* Battery
+
+* CAN
+
+* Charger
+
+* Clock control
+
+* Counter
+
+* DAC
+
+* Disk
+
+* Display
+
+* Ethernet
+
+* Flash
+
+* GNSS
+
+* GPIO
+
+* Hardware info
+
+* I2C
+
+* I2S
+
+* I3C
+
+* Input
+
+* LED
+
+* LED Strip
+
+* LoRa
+
+* Mailbox
+
+* MDIO
+
+* MFD
+
+* Modem
+
+* MIPI-DBI
+
+* MSPI
+
+* Pin control
+
+* PWM
+
+* Regulators
+
+* Reset
+
+* RTC
+
+* RTIO
+
+* SDHC
+
+* Sensors
+
+* Serial
+
+* SPI
+
+* USB
+
+* Video
+
+* Watchdog
+
+* Wi-Fi
+
+Networking
+**********
+
+* ARP:
+
+* CoAP:
+
+* Connection manager:
+
+* DHCPv4:
+
+* DHCPv6:
+
+* DNS/mDNS/LLMNR:
+
+* gPTP/PTP:
+
+* HTTP:
+
+* IPSP:
+
+* IPv4:
+
+* IPv6:
+
+* LwM2M:
+
+* Misc:
+
+* MQTT:
+
+* Network Interface:
+
+* OpenThread
+
+* PPP
+
+* Shell:
+
+* Sockets:
+
+* Syslog:
+
+* TCP:
+
+* Websocket:
+
+* Wi-Fi:
+
+* zperf:
+
+USB
+***
+
+Devicetree
+**********
+
+Kconfig
+*******
+
+Libraries / Subsystems
+**********************
+
+* Debug
+
+* Demand Paging
+
+* Formatted output
+
+* Management
+
+* Logging
+
+* Modem modules
+
+* Power management
+
+* Crypto
+
+* CMSIS-NN
+
+* FPGA
+
+* Random
+
+* SD
+
+* State Machine Framework
+
+* Storage
+
+* Task Watchdog
+
+* POSIX API
+
+* LoRa/LoRaWAN
+
+* ZBus
+
+HALs
+****
+
+* Nordic
+
+* STM32
+
+* ADI
+
+* Espressif
+
+MCUboot
+*******
+
+OSDP
+****
+
+Trusted Firmware-M
+******************
+
+LVGL
+****
+
+Tests and Samples
+*****************
+
+Issue Related Items
+*******************
+
+Known Issues
+============


### PR DESCRIPTION
https://builds.zephyrproject.io/zephyr/pr/80859/docs/releases/index.html
https://builds.zephyrproject.io/zephyr/pr/80859/docs/releases/release-notes-4.1.html
https://builds.zephyrproject.io/zephyr/pr/80859/docs/releases/migration-guide-4.1.html

This introduces the release notes and migration guide for 4.1.0 earlier than we typically do, so that people have a placeholder to start adding content as they line up pull requests for 4.1. 
The two documents are currently orphan and not visible from the main documentation as this would confuse users of 4.0.

See commit messages for other minor touch-up