### PR TITLE
dts: bindings: base: Undeprecate label

### DIFF
--- a/dts/bindings/base/base.yaml
+++ b/dts/bindings/base/base.yaml
@@ -46,11 +46,11 @@ properties:
     type: phandle
     description: phandle to interrupt controller node
 
+  # description of label should be given in bindings inheriting base.yaml
+  # label property is included here to help enforce its type being string
   label:
     type: string
-    deprecated: true
-    description: |
-      Human readable string describing the device (used as device_get_binding() argument)
+    description: No description provided for this label
 
   clocks:
     type: phandle-array

--- a/dts/bindings/test/vnd,gpio-device.yaml
+++ b/dts/bindings/test/vnd,gpio-device.yaml
@@ -8,15 +8,10 @@ compatible: "vnd,gpio-device"
 include:
   - name: gpio-controller.yaml
   - name: base.yaml
-    property-blocklist:
-      - label
 
 properties:
   reg:
     required: true
-
-  label:
-    type: string
 
   "#gpio-cells":
     const: 2

--- a/dts/bindings/test/vnd,gpio-expander-i2c.yaml
+++ b/dts/bindings/test/vnd,gpio-expander-i2c.yaml
@@ -7,12 +7,4 @@ compatible: "vnd,gpio-expander"
 
 include:
   - name: "vnd,gpio-expander-common.yaml"
-    property-blocklist:
-      - label
   - name: i2c-device.yaml
-    property-blocklist:
-      - label
-
-properties:
-  label:
-    type: string

--- a/dts/bindings/test/vnd,i2c.yaml
+++ b/dts/bindings/test/vnd,i2c.yaml
@@ -7,9 +7,3 @@ compatible: "vnd,i2c"
 
 include:
   - name: i2c-controller.yaml
-    property-blocklist:
-      - label
-
-properties:
-  label:
-    type: string

--- a/dts/bindings/test/vnd,i3c-device.yaml
+++ b/dts/bindings/test/vnd,i3c-device.yaml
@@ -9,9 +9,3 @@ compatible: "vnd,i3c-device"
 
 include:
   - name: i3c-device.yaml
-    property-blocklist:
-      - label
-
-properties:
-  label:
-    type: string

--- a/dts/bindings/test/vnd,i3c-i2c-device.yaml
+++ b/dts/bindings/test/vnd,i3c-i2c-device.yaml
@@ -9,9 +9,3 @@ compatible: "vnd,i3c-i2c-device"
 
 include:
   - name: i2c-device.yaml
-    property-blocklist:
-      - label
-
-properties:
-  label:
-    type: string

--- a/dts/bindings/test/vnd,i3c.yaml
+++ b/dts/bindings/test/vnd,i3c.yaml
@@ -9,9 +9,3 @@ compatible: "vnd,i3c"
 
 include:
   - name: i3c-controller.yaml
-    property-blocklist:
-      - label
-
-properties:
-  label:
-    type: string

--- a/dts/bindings/test/vnd,spi-device.yaml
+++ b/dts/bindings/test/vnd,spi-device.yaml
@@ -7,9 +7,3 @@ compatible: "vnd,spi-device"
 
 include:
   - name: spi-device.yaml
-    property-blocklist:
-      - label
-
-properties:
-  label:
-    type: string


### PR DESCRIPTION
Label property is described in DT spec and does not need to be deprecated in base.yaml anymore. It was originally deprecated to discourage what was previously the most common use case of labels in zephyr which was the old device_get_binding, which was rightfully removed. However, labels do have a purpose as described in DT spec of providing a human readable string to software to describe the device, which there is some use for.

The description of a label should be given in the device binding, as stated in DT spec.

Label properties should be of type string.

TODO:
 - [x] ensure documentation of correct and incorrect usage of the label property
