### PR TITLE
drivers: gpio: esp32: Add input/output enable flags

### DIFF
--- a/drivers/gpio/gpio_esp32.c
+++ b/drivers/gpio/gpio_esp32.c
@@ -263,13 +263,17 @@ static int gpio_esp32_config(const struct device *dev,
 			gpio_ll_set_level(cfg->gpio_base, io_pin, 0);
 		}
 	} else {
-		gpio_ll_output_disable(&GPIO, io_pin);
+		if (!(flags & ESP32_GPIO_PIN_OUT_EN)) {
+			gpio_ll_output_disable(&GPIO, io_pin);
+		}
 	}
 
 	if (flags & GPIO_INPUT) {
 		gpio_ll_input_enable(&GPIO, io_pin);
 	} else {
-		gpio_ll_input_disable(&GPIO, io_pin);
+		if (!(flags & ESP32_GPIO_PIN_IN_EN)) {
+			gpio_ll_input_disable(&GPIO, io_pin);
+		}
 	}
 
 end:

--- a/include/zephyr/dt-bindings/gpio/espressif-esp32-gpio.h
+++ b/include/zephyr/dt-bindings/gpio/espressif-esp32-gpio.h
@@ -32,4 +32,24 @@
 
 /** @} */
 
+/**
+ * @name GPIO pin input/output enable flags
+ *
+ * These flags allow configuring a pin as input or output while keeping untouched
+ * its complementary configuration. By instance, if we configure a GPIO pin as an
+ * input and pass the flag ESP32_GPIO_PIN_OUT_EN, the driver will not disable the
+ * pin's output buffer. This functionality can be useful to render a pin both an
+ * input and output, for diagnose or testing purposes.
+ *
+ * @{
+ */
+
+/** Keep GPIO pin enabled as output */
+#define ESP32_GPIO_PIN_OUT_EN (1 << 12)
+
+/** Keep GPIO pin enabled as input */
+#define ESP32_GPIO_PIN_IN_EN (1 << 13)
+
+/** @} */
+
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_GPIO_ESPRESSIF_ESP32_GPIO_H_ */


### PR DESCRIPTION
Flags added allow keeping a pin as input/output by not disabling the output buffer when configuring it as an input and by not disabling input enable when configuring it as output. This can be useful to implement signal diagnosis or for testing purposes.

Approach is similar to PR #58736.