### PR TITLE
drivers: nrfwifi: Fix CSUM support

### DIFF
--- a/drivers/wifi/nrfwifi/src/net_if.c
+++ b/drivers/wifi/nrfwifi/src/net_if.c
@@ -980,10 +980,23 @@ int nrf_wifi_if_get_config_zep(const struct device *dev,
 		goto unlock;
 	}
 
+	memset(config, 0, sizeof(struct ethernet_config));
+
 	if (type == ETHERNET_CONFIG_TYPE_TXINJECTION_MODE) {
 		config->txinjection_mode =
 			def_dev_ctx->vif_ctx[vif_ctx_zep->vif_idx]->txinjection_mode;
 	}
+#ifdef CONFIG_NRF70_TCP_IP_CHECKSUM_OFFLOAD
+	if (type  == ETHERNET_CONFIG_TYPE_TX_CHECKSUM_SUPPORT ||
+	    type == ETHERNET_CONFIG_TYPE_RX_CHECKSUM_SUPPORT) {
+		config->chksum_support = ETHERNET_CHECKSUM_SUPPORT_IPV4_HEADER |
+					 ETHERNET_CHECKSUM_SUPPORT_IPV4_ICMP |
+					 ETHERNET_CHECKSUM_SUPPORT_IPV6_HEADER |
+					 ETHERNET_CHECKSUM_SUPPORT_IPV6_ICMP |
+					 ETHERNET_CHECKSUM_SUPPORT_TCP |
+					 ETHERNET_CHECKSUM_SUPPORT_UDP;
+	}
+#endif
 	ret = 0;
 unlock:
 	k_mutex_unlock(&vif_ctx_zep->vif_lock);


### PR DESCRIPTION
With introduction of Raw modes, nRF70 driver now advertises get_config OP, but doesn't implement all types.

This causes problems two-fold with checksum calculations:
  1. The "config" isn't initialized, so, every call returns different values. So, for UDP header checksum would be done and pkt->chksumdone would be set. But for IPv4 header checksum might be skipped.
  2. Even if we initialize to zero, then network stack gets all zeros and calculates checksum by itself rendering offload moot.

There is another problem in #1, as there is only single flag for pkt for all checksum, nRF70 driver sees this and tells UMAC to skip checksum for the entire packet. The design isn't coherent, and should be converted to communicate per-type checksum status (some are filled by network stack and some HW).

But as nRF70 support all checksum offloads, advertise all types for both RX and TX.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/80973