### PR TITLE
xtensa: remove mem_domain excess padding

### DIFF
--- a/include/zephyr/arch/xtensa/arch.h
+++ b/include/zephyr/arch/xtensa/arch.h
@@ -63,7 +63,7 @@ extern "C" {
 
 struct arch_mem_domain {
 #ifdef CONFIG_XTENSA_MMU
-	uint32_t *ptables __aligned(CONFIG_MMU_PAGE_SIZE);
+	uint32_t *ptables;
 	uint8_t asid;
 	bool dirty;
 #endif

--- a/tests/kernel/threads/thread_error_case/boards/qemu_xtensa_dc233c_mmu.conf
+++ b/tests/kernel/threads/thread_error_case/boards/qemu_xtensa_dc233c_mmu.conf
@@ -1,0 +1,3 @@
+# For some weird reasons, enabling ICOUNT would crash QEMU
+# on this test. So disable it.
+CONFIG_QEMU_ICOUNT=n


### PR DESCRIPTION
The ptables field in arch_mem_domain for Xtensa has excessive padding as it is incorrectly marked with needing page size alignment. This is simply a pointer and not the actual page table so there is no need for that alignment. So remove it.

Fixes #71896