### PR TITLE
tests:kernel:fpu_sharing Fixed missing struct defs for ARM

### DIFF
--- a/tests/kernel/fpu_sharing/generic/src/float_context.h
+++ b/tests/kernel/fpu_sharing/generic/src/float_context.h
@@ -96,6 +96,16 @@ struct fp_non_volatile_register_set {
 	float s[16];
 };
 
+#else
+
+struct fp_volatile_register_set {
+	/* No volatile floating point registers */
+};
+
+struct fp_non_volatile_register_set {
+	/* No non-volatile floating point registers */
+};
+
 #endif
 
 #define SIZEOF_FP_VOLATILE_REGISTER_SET	\


### PR DESCRIPTION
Added empty fp register structs for ARM combinations not handled.