### PR TITLE
drivers: bluetooth: hci: add close function for Ambiq Apollo3x

### DIFF
--- a/drivers/bluetooth/hci/apollox_blue.c
+++ b/drivers/bluetooth/hci/apollox_blue.c
@@ -341,6 +341,25 @@ int bt_apollo_controller_init(spi_transmit_fun transmit)
 	return ret;
 }
 
+int bt_apollo_controller_deinit(void)
+{
+	int ret = -ENOTSUP;
+
+#if (CONFIG_SOC_SERIES_APOLLO3X)
+	irq_disable(DT_IRQN(SPI_DEV_NODE));
+
+	ret = am_apollo3_bt_controller_deinit();
+	if (ret == AM_HAL_STATUS_SUCCESS) {
+		LOG_INF("BT controller deinitialized");
+	} else {
+		ret = -EPERM;
+		LOG_ERR("BT controller deinitialization fails");
+	}
+#endif /* CONFIG_SOC_SERIES_APOLLO3X */
+
+	return ret;
+}
+
 #if (CONFIG_SOC_SERIES_APOLLO4X)
 static int bt_apollo_set_nvds(void)
 {

--- a/drivers/bluetooth/hci/apollox_blue.h
+++ b/drivers/bluetooth/hci/apollox_blue.h
@@ -82,6 +82,13 @@ int bt_apollo_spi_rcv(uint8_t *data, uint16_t *len, bt_spi_transceive_fun transc
 int bt_apollo_controller_init(spi_transmit_fun transmit);
 
 /**
+ * @brief Deinitialize the BLE controller.
+ *
+ * @return 0 on success or negative error number on failure.
+ */
+int bt_apollo_controller_deinit(void);
+
+/**
  * @brief Vendor specific setup before general HCI command sequence for
  * Bluetooth application.
  *

--- a/drivers/bluetooth/hci/hci_ambiq.c
+++ b/drivers/bluetooth/hci/hci_ambiq.c
@@ -396,6 +396,21 @@ static int bt_apollo_open(const struct device *dev, bt_hci_recv_t recv)
 	return ret;
 }
 
+static int bt_apollo_close(const struct device *dev)
+{
+	int ret;
+	struct bt_apollo_data *hci = dev->data;
+
+	ret = bt_apollo_controller_deinit();
+	if (ret) {
+		return ret;
+	}
+
+	hci->recv = NULL;
+
+	return ret;
+}
+
 static int bt_apollo_setup(const struct device *dev, const struct bt_hci_setup_params *params)
 {
 	ARG_UNUSED(params);
@@ -409,6 +424,7 @@ static int bt_apollo_setup(const struct device *dev, const struct bt_hci_setup_p
 
 static const struct bt_hci_driver_api drv = {
 	.open = bt_apollo_open,
+	.close = bt_apollo_close,
 	.send = bt_apollo_send,
 	.setup = bt_apollo_setup,
 };

--- a/west.yml
+++ b/west.yml
@@ -147,7 +147,7 @@ manifest:
       groups:
         - hal
     - name: hal_ambiq
-      revision: d3092f9b82874a1791baa3ac41c3795d108fbbdb
+      revision: 87a188b91aca22ce3ce7deb4a1cbf7780d784673
       path: modules/hal/ambiq
       groups:
         - hal


### PR DESCRIPTION
This PR adds the bt_hci_driver.close function for Ambiq Apollo3x SoC. Also update the hal_ambiq revision including the necessary support.

Test boards:
- ambiq/apollo3_evb
- ambiq/apollo3p_evb

Test sample:
- tests/bluetooth/shell