### PR TITLE
Bluetooth: Controller: Fix spurious ISO Sync receiver stall

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync_iso.c
@@ -427,6 +427,7 @@ static void abort_cb(struct lll_prepare_param *prepare_param, void *param)
 	LL_ASSERT(e);
 
 	e->type = EVENT_DONE_EXTRA_TYPE_SYNC_ISO;
+	e->estab_failed = 0U;
 	e->trx_cnt = 0U;
 	e->crc_valid = 0U;
 
@@ -1281,6 +1282,7 @@ static void isr_rx_done(void *param)
 
 	/* Calculate and place the drift information in done event */
 	e->type = EVENT_DONE_EXTRA_TYPE_SYNC_ISO;
+	e->estab_failed = 0U;
 	e->trx_cnt = trx_cnt;
 	e->crc_valid = crc_ok_anchor;
 


### PR DESCRIPTION
Fix spurious ISO Sync Receiver stall due to uninitialised value accessed due to regression introduced by
commit 64faceea7270 ("Bluetooth: controller: Stop Sync ISO ticker when establishment fails").

Cherry-pick of the bugfix from https://github.com/zephyrproject-rtos/zephyr/pull/80775 so it can go in right away as a hotfix

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/80734

This is just the first commit from from https://github.com/zephyrproject-rtos/zephyr/pull/80775 as is. So that we can have a path to fix the linked issue even if it would be considered to late to merge that whole PR as is.