### PR TITLE
tests bsim bt audio: Increase execution timeout

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync_iso.c
@@ -427,6 +427,7 @@ static void abort_cb(struct lll_prepare_param *prepare_param, void *param)
 	LL_ASSERT(e);
 
 	e->type = EVENT_DONE_EXTRA_TYPE_SYNC_ISO;
+	e->estab_failed = 0U;
 	e->trx_cnt = 0U;
 	e->crc_valid = 0U;
 
@@ -1281,6 +1282,7 @@ static void isr_rx_done(void *param)
 
 	/* Calculate and place the drift information in done event */
 	e->type = EVENT_DONE_EXTRA_TYPE_SYNC_ISO;
+	e->estab_failed = 0U;
 	e->trx_cnt = trx_cnt;
 	e->crc_valid = crc_ok_anchor;
 

--- a/tests/bsim/bluetooth/audio/test_scripts/bap_broadcast_audio_assistant_incorrect_code.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/bap_broadcast_audio_assistant_incorrect_code.sh
@@ -6,6 +6,7 @@
 
 SIMULATION_ID="bap_broadcast_audio_assistant_incorrect_code"
 VERBOSITY_LEVEL=2
+EXECUTE_TIMEOUT=180
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 

--- a/tests/bsim/bluetooth/audio/test_scripts/bap_unicast_audio.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/bap_unicast_audio.sh
@@ -6,6 +6,7 @@
 
 SIMULATION_ID="unicast_audio"
 VERBOSITY_LEVEL=2
+EXECUTE_TIMEOUT=120
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 

--- a/tests/bsim/bluetooth/audio/test_scripts/bap_unicast_audio_acl_disconnect.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/bap_unicast_audio_acl_disconnect.sh
@@ -6,6 +6,7 @@
 
 SIMULATION_ID="unicast_audio_acl_disconnect"
 VERBOSITY_LEVEL=2
+EXECUTE_TIMEOUT=120
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 


### PR DESCRIPTION
These tests have been seen failing in CI due to the real time execution timeout. Let's increase it so it does not happen.

Sits on top of the hotfix:
* https://github.com/zephyrproject-rtos/zephyr/pull/80894

Otherwise CI will fail due to that other bug

Fixes #80907