### PR TITLE
boards: nuvoton: numaker: Drop PINCTRL from board defconfig

### DIFF
--- a/boards/nuvoton/numaker_m2l31ki/numaker_m2l31ki_defconfig
+++ b/boards/nuvoton/numaker_m2l31ki/numaker_m2l31ki_defconfig
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
-CONFIG_PINCTRL=y
 CONFIG_GPIO=y
 
 # Enable system clock controller driver

--- a/boards/nuvoton/numaker_pfm_m467/numaker_pfm_m467_defconfig
+++ b/boards/nuvoton/numaker_pfm_m467/numaker_pfm_m467_defconfig
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
-CONFIG_PINCTRL=y
 CONFIG_GPIO=y
 
 # Enable system clock controller driver

--- a/boards/nuvoton/numaker_pfm_m487/numaker_pfm_m487_defconfig
+++ b/boards/nuvoton/numaker_pfm_m487/numaker_pfm_m487_defconfig
@@ -4,9 +4,8 @@
 CONFIG_ARM_MPU=y
 CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC=192000000
 
-# Enable GPIO and pinctrl drivers
+# Enable GPIO driver
 CONFIG_GPIO=y
-CONFIG_PINCTRL=y
 
 # Enable UART driver
 CONFIG_SERIAL=y

--- a/drivers/adc/Kconfig.numaker
+++ b/drivers/adc/Kconfig.numaker
@@ -7,6 +7,7 @@ config ADC_NUMAKER
 	bool "Nuvoton NuMaker MCU ADC driver"
 	default y
 	select HAS_NUMAKER_ADC
+	select PINCTRL
 	depends on DT_HAS_NUVOTON_NUMAKER_ADC_ENABLED
 	help
 	  This option enables the ADC driver for Nuvoton NuMaker family of

--- a/drivers/ethernet/Kconfig.numaker
+++ b/drivers/ethernet/Kconfig.numaker
@@ -7,6 +7,7 @@ config ETH_NUMAKER
 	bool "Nuvoton NUMAKER MCU Ethernet driver"
 	default y
 	select HAS_NUMAKER_ETH
+	select PINCTRL
 	depends on DT_HAS_NUVOTON_NUMAKER_ETHERNET_ENABLED
 	help
 	  This option enables the Ethernet driver for Nuvoton NuMaker family of

--- a/drivers/gpio/Kconfig.numaker
+++ b/drivers/gpio/Kconfig.numaker
@@ -7,6 +7,7 @@ config GPIO_NUMAKER
 	bool "Nuvoton NUMAKER MCU gpio driver"
 	default y
 	select HAS_NUMAKER_GPIO
+	select PINCTRL
 	depends on DT_HAS_NUVOTON_NUMAKER_GPIO_ENABLED
 	help
 	  This option enables the GPIO driver for Nuvoton NUMAKER family of

--- a/drivers/gpio/Kconfig.numicro
+++ b/drivers/gpio/Kconfig.numicro
@@ -6,6 +6,7 @@
 config GPIO_NUMICRO
 	bool "Nuvoton NuMicro GPIO driver"
 	default y
+	select PINCTRL
 	depends on DT_HAS_NUVOTON_NUMICRO_GPIO_ENABLED
 	help
 	  Enable the GPIO driver for the NuMicro family of processors.

--- a/drivers/i2c/Kconfig.numaker
+++ b/drivers/i2c/Kconfig.numaker
@@ -7,6 +7,7 @@ config I2C_NUMAKER
 	bool "Nuvoton NuMaker I2C driver"
 	default y
 	select HAS_NUMAKER_I2C
+	select PINCTRL
 	depends on DT_HAS_NUVOTON_NUMAKER_I2C_ENABLED
 	help
 	  This option enables I2C driver for Nuvoton NuMaker family of

--- a/drivers/pwm/Kconfig.numaker
+++ b/drivers/pwm/Kconfig.numaker
@@ -7,6 +7,7 @@ config PWM_NUMAKER
 	bool "Nuvoton NuMaker MCU PWM driver"
 	default y
 	select HAS_NUMAKER_PWM
+	select PINCTRL
 	depends on DT_HAS_NUVOTON_NUMAKER_PWM_ENABLED
 	help
 	  This option enables the PWM driver for Nuvoton NuMaker family of

--- a/drivers/serial/Kconfig.numaker
+++ b/drivers/serial/Kconfig.numaker
@@ -9,6 +9,7 @@ config UART_NUMAKER
 	select SERIAL_HAS_DRIVER
 	select HAS_NUMAKER_UART
 	select SERIAL_SUPPORT_INTERRUPT
+	select PINCTRL
 	depends on DT_HAS_NUVOTON_NUMAKER_UART_ENABLED
 	help
 	  This option enables the UART driver for Nuvoton Numaker family of

--- a/drivers/serial/Kconfig.numicro
+++ b/drivers/serial/Kconfig.numicro
@@ -11,6 +11,7 @@ config UART_NUMICRO
 	depends on DT_HAS_NUVOTON_NUMICRO_UART_ENABLED
 	select SERIAL_HAS_DRIVER
 	select HAS_NUMICRO_UART
+	select PINCTRL
 	help
 	  This option enables the UART driver for Nuvoton Numicro
 	  family of processors.

--- a/drivers/spi/Kconfig.numaker
+++ b/drivers/spi/Kconfig.numaker
@@ -7,6 +7,7 @@ config SPI_NUMAKER
 	bool "Nuvoton NuMaker MCU SPI driver"
 	default y
 	select HAS_NUMAKER_SPI
+	select PINCTRL
 	depends on DT_HAS_NUVOTON_NUMAKER_SPI_ENABLED
 	help
 	  This option enables the SPI driver for Nuvoton NuMaker family of

--- a/drivers/usb/device/Kconfig
+++ b/drivers/usb/device/Kconfig
@@ -204,6 +204,7 @@ config USB_DC_NUMAKER
 	bool "Nuvoton NuMaker USB 1.1 device controller"
 	default y
 	depends on DT_HAS_NUVOTON_NUMAKER_USBD_ENABLED
+	select PINCTRL
 	help
 	  Enable Nuvoton NuMaker USB 1.1 device controller driver
 

--- a/drivers/usb/udc/Kconfig.numaker
+++ b/drivers/usb/udc/Kconfig.numaker
@@ -5,6 +5,7 @@ config UDC_NUMAKER
 	bool "Nuvoton NuMaker USB 1.1 device controller"
 	default y
 	depends on DT_HAS_NUVOTON_NUMAKER_USBD_ENABLED
+	select PINCTRL
 	help
 	  Enable Nuvoton NuMaker USB 1.1 device controller driver
 

--- a/drivers/usb_c/ppc/Kconfig.numaker
+++ b/drivers/usb_c/ppc/Kconfig.numaker
@@ -7,5 +7,6 @@ config USBC_PPC_NUMAKER
 	bool "Nuvoton NuMaker USB-C PPC"
 	default y
 	depends on DT_HAS_NUVOTON_NUMAKER_PPC_ENABLED && USBC_TCPC_NUMAKER
+	select PINCTRL
 	help
 	  Enable USB-C PPC support for Nuvoton NuMaker chip with UTCPD.

--- a/drivers/usb_c/tcpc/Kconfig.tcpc_numaker
+++ b/drivers/usb_c/tcpc/Kconfig.tcpc_numaker
@@ -8,6 +8,7 @@ config USBC_TCPC_NUMAKER
 	default y
 	select HAS_NUMAKER_ADC
 	select HAS_NUMAKER_TMR
+	select PINCTRL
 	depends on DT_HAS_NUVOTON_NUMAKER_TCPC_ENABLED
 	help
 	  Enable USB-C TCPC support for Nuvoton NuMaker chip with UTCPD.

--- a/drivers/usb_c/vbus/Kconfig.numaker
+++ b/drivers/usb_c/vbus/Kconfig.numaker
@@ -7,5 +7,6 @@ config USBC_VBUS_NUMAKER
 	bool "Nuvoton NuMaker USB-C VBUS"
 	default y
 	depends on DT_HAS_NUVOTON_NUMAKER_VBUS_ENABLED && USBC_TCPC_NUMAKER
+	select PINCTRL
 	help
 	  Enable USB-C VBUS support for Nuvoton NuMaker chip with UTCPD.


### PR DESCRIPTION
This PR addresses the Nuvoton Numaker portion of https://github.com/zephyrproject-rtos/zephyr/issues/78619.

To remove CONFIG_PINCTRL from board side for numaker boards.
The Drivers using Pinctrl should be turning Pinctrl on instead of the responsibility of the board.