### PR TITLE
Increase bsim tests watchdog deadline - again

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync_iso.c
@@ -427,6 +427,7 @@ static void abort_cb(struct lll_prepare_param *prepare_param, void *param)
 	LL_ASSERT(e);
 
 	e->type = EVENT_DONE_EXTRA_TYPE_SYNC_ISO;
+	e->estab_failed = 0U;
 	e->trx_cnt = 0U;
 	e->crc_valid = 0U;
 
@@ -1281,6 +1282,7 @@ static void isr_rx_done(void *param)
 
 	/* Calculate and place the drift information in done event */
 	e->type = EVENT_DONE_EXTRA_TYPE_SYNC_ISO;
+	e->estab_failed = 0U;
 	e->trx_cnt = trx_cnt;
 	e->crc_valid = crc_ok_anchor;
 

--- a/tests/bsim/bluetooth/audio/test_scripts/bap_bass_client_sync.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/bap_bass_client_sync.sh
@@ -6,6 +6,7 @@
 
 SIMULATION_ID="bass_client_sync"
 VERBOSITY_LEVEL=2
+EXECUTE_TIMEOUT=120
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 

--- a/tests/bsim/bluetooth/audio/test_scripts/bap_broadcast_audio.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/bap_broadcast_audio.sh
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=100
+EXECUTE_TIMEOUT=240
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 

--- a/tests/bsim/bluetooth/audio/test_scripts/bap_broadcast_audio_assistant.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/bap_broadcast_audio_assistant.sh
@@ -6,7 +6,7 @@
 
 SIMULATION_ID="bap_broadcast_audio_assistant"
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=100
+EXECUTE_TIMEOUT=240
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 

--- a/tests/bsim/bluetooth/audio/test_scripts/bap_broadcast_audio_assistant_incorrect_code.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/bap_broadcast_audio_assistant_incorrect_code.sh
@@ -6,6 +6,7 @@
 
 SIMULATION_ID="bap_broadcast_audio_assistant_incorrect_code"
 VERBOSITY_LEVEL=2
+EXECUTE_TIMEOUT=180
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 

--- a/tests/bsim/bluetooth/audio/test_scripts/bap_unicast_audio.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/bap_unicast_audio.sh
@@ -6,6 +6,7 @@
 
 SIMULATION_ID="unicast_audio"
 VERBOSITY_LEVEL=2
+EXECUTE_TIMEOUT=120
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 

--- a/tests/bsim/bluetooth/audio/test_scripts/bap_unicast_audio_acl_disconnect.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/bap_unicast_audio_acl_disconnect.sh
@@ -6,6 +6,7 @@
 
 SIMULATION_ID="unicast_audio_acl_disconnect"
 VERBOSITY_LEVEL=2
+EXECUTE_TIMEOUT=120
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 

--- a/tests/bsim/bluetooth/audio/test_scripts/cap_broadcast.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/cap_broadcast.sh
@@ -6,6 +6,7 @@
 
 SIMULATION_ID="cap_broadcast"
 VERBOSITY_LEVEL=2
+EXECUTE_TIMEOUT=120
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 

--- a/tests/bsim/bluetooth/audio/test_scripts/cap_capture_and_render.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/cap_capture_and_render.sh
@@ -6,6 +6,7 @@
 
 SIMULATION_ID="cap_capture_and_render"
 VERBOSITY_LEVEL=2
+EXECUTE_TIMEOUT=120
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 

--- a/tests/bsim/bluetooth/audio/test_scripts/cap_unicast.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/cap_unicast.sh
@@ -6,6 +6,7 @@
 
 SIMULATION_ID="cap_unicast"
 VERBOSITY_LEVEL=2
+EXECUTE_TIMEOUT=240
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 

--- a/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_ase_error.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_ase_error.sh
@@ -6,6 +6,7 @@
 
 SIMULATION_ID="cap_unicast_ase_error"
 VERBOSITY_LEVEL=2
+EXECUTE_TIMEOUT=120
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 

--- a/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_inval.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_inval.sh
@@ -6,6 +6,7 @@
 
 SIMULATION_ID="cap_unicast_inval"
 VERBOSITY_LEVEL=2
+EXECUTE_TIMEOUT=120
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 

--- a/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_timeout.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_timeout.sh
@@ -6,6 +6,7 @@
 
 SIMULATION_ID="cap_unicast_timeout"
 VERBOSITY_LEVEL=2
+EXECUTE_TIMEOUT=240
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 

--- a/tests/bsim/bluetooth/audio/test_scripts/csip_encrypted_sirk.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/csip_encrypted_sirk.sh
@@ -9,6 +9,7 @@
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 VERBOSITY_LEVEL=2
+EXECUTE_TIMEOUT=120
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/audio/test_scripts/csip_forced_release.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/csip_forced_release.sh
@@ -9,6 +9,7 @@
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 VERBOSITY_LEVEL=2
+EXECUTE_TIMEOUT=120
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/audio/test_scripts/csip_new_sirk.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/csip_new_sirk.sh
@@ -10,6 +10,7 @@
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 VERBOSITY_LEVEL=2
+EXECUTE_TIMEOUT=120
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/audio/test_scripts/csip_no_lock.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/csip_no_lock.sh
@@ -9,6 +9,7 @@
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 VERBOSITY_LEVEL=2
+EXECUTE_TIMEOUT=120
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/audio/test_scripts/csip_no_rank.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/csip_no_rank.sh
@@ -9,6 +9,7 @@
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 VERBOSITY_LEVEL=2
+EXECUTE_TIMEOUT=120
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/audio/test_scripts/csip_no_size.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/csip_no_size.sh
@@ -9,7 +9,7 @@
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=60
+EXECUTE_TIMEOUT=180
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/audio/test_scripts/tbs.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/tbs.sh
@@ -9,6 +9,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 SIMULATION_ID="tbs_ccp"
 VERBOSITY_LEVEL=2
+EXECUTE_TIMEOUT=120
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/audio_samples/cap/tests_scripts/cap_broadcast.sh
+++ b/tests/bsim/bluetooth/audio_samples/cap/tests_scripts/cap_broadcast.sh
@@ -9,6 +9,7 @@
 
 simulation_id="cap_broadcast_test"
 verbosity_level=2
+EXECUTE_TIMEOUT=120
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 

--- a/tests/bsim/bluetooth/audio_samples/cap/tests_scripts/cap_unicast.sh
+++ b/tests/bsim/bluetooth/audio_samples/cap/tests_scripts/cap_unicast.sh
@@ -9,6 +9,7 @@
 
 simulation_id="cap_unicast_test"
 verbosity_level=2
+EXECUTE_TIMEOUT=120
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 

--- a/tests/bsim/bluetooth/host/att/pipeline/test_scripts/run.sh
+++ b/tests/bsim/bluetooth/host/att/pipeline/test_scripts/run.sh
@@ -10,6 +10,7 @@ tester_exe="bs_${BOARD_TS}_tests_bsim_bluetooth_host_att_pipeline_tester_prj_con
 simulation_id="att_pipeline"
 verbosity_level=2
 sim_length_us=100e6
+EXECUTE_TIMEOUT=240
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/host/att/pipeline/test_scripts/run_test_tolerate_pipeline_variant_rx_tx_prio_invert.sh
+++ b/tests/bsim/bluetooth/host/att/pipeline/test_scripts/run_test_tolerate_pipeline_variant_rx_tx_prio_invert.sh
@@ -37,6 +37,7 @@ tester_exe="bs_${BOARD_TS}_tests_bsim_bluetooth_host_att_pipeline_tester_prj_con
 simulation_id="att_pipeline_test_tolerate_pipeline_variant_rx_tx_prio_invert"
 verbosity_level=2
 sim_length_us=100e6
+EXECUTE_TIMEOUT=240
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/host/att/timeout/test_scripts/run.sh
+++ b/tests/bsim/bluetooth/host/att/timeout/test_scripts/run.sh
@@ -5,6 +5,7 @@
 set -eu -x
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+EXECUTE_TIMEOUT=120
 
 simulation_id="timeout"
 dev_exe=bs_${BOARD_TS}_$(guess_test_long_name)_prj_conf

--- a/tests/bsim/bluetooth/host/gatt/ccc_store/test_scripts/ccc_store.sh
+++ b/tests/bsim/bluetooth/host/gatt/ccc_store/test_scripts/ccc_store.sh
@@ -7,6 +7,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 test_exe="bs_${BOARD_TS}_$(guess_test_long_name)_prj_conf"
 simulation_id="ccc_store"
 verbosity_level=2
+EXECUTE_TIMEOUT=60
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/host/gatt/ccc_store/test_scripts/ccc_store_2.sh
+++ b/tests/bsim/bluetooth/host/gatt/ccc_store/test_scripts/ccc_store_2.sh
@@ -7,6 +7,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 test_exe="bs_${BOARD_TS}_$(guess_test_long_name)_prj_2_conf"
 simulation_id="ccc_store_2"
 verbosity_level=2
+EXECUTE_TIMEOUT=60
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/host/iso/cis/tests_scripts/cis_disable.sh
+++ b/tests/bsim/bluetooth/host/iso/cis/tests_scripts/cis_disable.sh
@@ -6,6 +6,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 simulation_id="iso_cis_disable"
 verbosity_level=2
+EXECUTE_TIMEOUT=120
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/host/misc/acl_tx_frag/test_scripts/run.sh
+++ b/tests/bsim/bluetooth/host/misc/acl_tx_frag/test_scripts/run.sh
@@ -9,6 +9,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 test_name="$(guess_test_long_name)"
 simulation_id=${test_name}
 verbosity_level=2
+EXECUTE_TIMEOUT=120
 
 # sixty-second (maximum) sim time.
 # The test will exit simulation as soon as it has passed.

--- a/tests/bsim/bluetooth/host/privacy/peripheral/test_scripts/run_test.sh
+++ b/tests/bsim/bluetooth/host/privacy/peripheral/test_scripts/run_test.sh
@@ -7,7 +7,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 verbosity_level=2
 simulation_id="host_privacy_peripheral"
-EXECUTE_TIMEOUT=100
+EXECUTE_TIMEOUT=240
 
 central_exe="${BSIM_OUT_PATH}/bin/bs_${BOARD_TS}_$(guess_test_long_name)_prj_conf"
 peripheral_exe="${central_exe}"

--- a/tests/bsim/bluetooth/host/privacy/peripheral/test_scripts/run_test_rpa_expired.sh
+++ b/tests/bsim/bluetooth/host/privacy/peripheral/test_scripts/run_test_rpa_expired.sh
@@ -7,7 +7,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 verbosity_level=2
 simulation_id="rpa_expired"
-EXECUTE_TIMEOUT=100
+EXECUTE_TIMEOUT=240
 
 central_exe_rpa_expired="\
 ${BSIM_OUT_PATH}/bin/bs_${BOARD_TS}_$(guess_test_long_name)_prj_rpa_expired_conf"

--- a/tests/bsim/bluetooth/host/privacy/peripheral/test_scripts/run_test_rpa_sharing.sh
+++ b/tests/bsim/bluetooth/host/privacy/peripheral/test_scripts/run_test_rpa_sharing.sh
@@ -7,7 +7,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 verbosity_level=2
 simulation_id="$(guess_test_long_name)_rpa_sharing"
-EXECUTE_TIMEOUT=60
+EXECUTE_TIMEOUT=240
 
 central_exe_rpa_sharing="\
 ${BSIM_OUT_PATH}/bin/bs_${BOARD_TS}_$(guess_test_long_name)_prj_rpa_sharing_conf"

--- a/tests/bsim/bluetooth/ll/bis/tests_scripts/broadcast_iso.sh
+++ b/tests/bsim/bluetooth/ll/bis/tests_scripts/broadcast_iso.sh
@@ -8,6 +8,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 # to the BIS.
 simulation_id="broadcast_iso"
 verbosity_level=2
+EXECUTE_TIMEOUT=120
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/ll/bis/tests_scripts/broadcast_iso_scan_aux_use_chains.sh
+++ b/tests/bsim/bluetooth/ll/bis/tests_scripts/broadcast_iso_scan_aux_use_chains.sh
@@ -8,6 +8,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 # to the BIS.
 simulation_id="broadcast_iso_scan_aux_use_chains"
 verbosity_level=2
+EXECUTE_TIMEOUT=120
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/ll/bis/tests_scripts/broadcast_iso_ticker_expire_info.sh
+++ b/tests/bsim/bluetooth/ll/bis/tests_scripts/broadcast_iso_ticker_expire_info.sh
@@ -8,6 +8,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 # to the BIS.
 simulation_id="broadcast_iso_ticker_expire_info"
 verbosity_level=2
+EXECUTE_TIMEOUT=120
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/ll/cis/tests_scripts/connected_iso.sh
+++ b/tests/bsim/bluetooth/ll/cis/tests_scripts/connected_iso.sh
@@ -8,7 +8,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 # 1 CIS each to 9 Peripherals (9 CIS in a CIG)
 simulation_id="connected_iso"
 verbosity_level=2
-EXECUTE_TIMEOUT=200
+EXECUTE_TIMEOUT=600
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/ll/cis/tests_scripts/connected_iso_legacy_adv.sh
+++ b/tests/bsim/bluetooth/ll/cis/tests_scripts/connected_iso_legacy_adv.sh
@@ -8,7 +8,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 # 1 CIS each to 9 Peripherals (9 CIS in a CIG)
 simulation_id="connected_iso_legacy_adv"
 verbosity_level=2
-EXECUTE_TIMEOUT=200
+EXECUTE_TIMEOUT=500
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/ll/cis/tests_scripts/connected_iso_peripheral_cis.sh
+++ b/tests/bsim/bluetooth/ll/cis/tests_scripts/connected_iso_peripheral_cis.sh
@@ -7,7 +7,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 # Basic Connected ISO test: multiple peripheral CIS establishment
 simulation_id="connected_iso_peripheral_cis"
 verbosity_level=2
-EXECUTE_TIMEOUT=100
+EXECUTE_TIMEOUT=240
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/ll/conn/tests_scripts/basic_conn_split_1ms.sh
+++ b/tests/bsim/bluetooth/ll/conn/tests_scripts/basic_conn_split_1ms.sh
@@ -9,6 +9,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 # interval
 simulation_id="basic_conn_split_1ms"
 verbosity_level=2
+EXECUTE_TIMEOUT=120
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/ll/throughput/tests_scripts/gatt_write.sh
+++ b/tests/bsim/bluetooth/ll/throughput/tests_scripts/gatt_write.sh
@@ -6,7 +6,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 simulation_id="ll-throughput"
 verbosity_level=2
-EXECUTE_TIMEOUT=60
+EXECUTE_TIMEOUT=240
 
 cd ${BSIM_OUT_PATH}/bin
 


### PR DESCRIPTION
Very much like it was done in https://github.com/zephyrproject-rtos/zephyr/pull/70750
Increase tests timeouts to ensure they do not trigger in CI.
A test timeout has been increased if the time it took in one recent CI run was > 1/3 of the timeout (or what it took in my own machine > 1/30 of the timeout)
If anyhow, I was increasing the timing I have increased it by quite a bit, so we are far from the 3x limit.
(Note the default timeout is 30 seconds)

Sits on top of 
* https://github.com/zephyrproject-rtos/zephyr/pull/80896 as it extends it 
* https://github.com/zephyrproject-rtos/zephyr/pull/80894 (as that fix is needed or CI fails)
(Those 2 commits are already in main, so they can be ignored in this PR. Merging this PR will drop those 2 commits)

This PR is not urgent, as the urgent timeout increases should be in #80896, but all changes are trivial and harmless enough.
