### PR TITLE
tests: Bluetooth: PBP: Fix adv data for PBP BSIM test

### DIFF
--- a/tests/bsim/bluetooth/audio/src/pbp_public_broadcast_source_test.c
+++ b/tests/bsim/bluetooth/audio/src/pbp_public_broadcast_source_test.c
@@ -127,7 +127,7 @@ static int setup_extended_adv_data(struct bt_cap_broadcast_source *source,
 {
 	/* Broadcast Audio Streaming Endpoint advertising data */
 	NET_BUF_SIMPLE_DEFINE(ad_buf, BT_UUID_SIZE_16 + BT_AUDIO_BROADCAST_ID_SIZE);
-	NET_BUF_SIMPLE_DEFINE(pbp_ad_buf, BT_UUID_SIZE_16 + 1 + ARRAY_SIZE(pba_metadata));
+	NET_BUF_SIMPLE_DEFINE(pbp_ad_buf, BT_PBP_MIN_PBA_SIZE + ARRAY_SIZE(pba_metadata));
 	NET_BUF_SIMPLE_DEFINE(base_buf, 128);
 	static enum bt_pbp_announcement_feature pba_params;
 	struct bt_data ext_ad[2];
@@ -145,7 +145,7 @@ static int setup_extended_adv_data(struct bt_cap_broadcast_source *source,
 	net_buf_simple_add_le16(&ad_buf, BT_UUID_BROADCAST_AUDIO_VAL);
 	net_buf_simple_add_le24(&ad_buf, broadcast_id);
 	ext_ad[0].type = BT_DATA_SVC_DATA16;
-	ext_ad[0].data_len = ad_buf.len + sizeof(ext_ad[0].type);
+	ext_ad[0].data_len = ad_buf.len;
 	ext_ad[0].data = ad_buf.data;
 
 	/**
@@ -162,8 +162,8 @@ static int setup_extended_adv_data(struct bt_cap_broadcast_source *source,
 		printk("Starting stream with high quality!\n");
 	}
 
-	err = bt_pbp_get_announcement(pba_metadata, ARRAY_SIZE(pba_metadata) - 1,
-				      pba_params, &pbp_ad_buf);
+	err = bt_pbp_get_announcement(pba_metadata, ARRAY_SIZE(pba_metadata), pba_params,
+				      &pbp_ad_buf);
 	if (err != 0) {
 		printk("Failed to create public broadcast announcement!: %d\n", err);
 


### PR DESCRIPTION
The test had a few off-by-ones in the code, which caused access to invalid data.

Fixed by setting the right buffer sizes and the right AD length fields.

fixes https://github.com/zephyrproject-rtos/zephyr/issues/80918