### PR TITLE
Fix for situation where smp shell transport can respond on a different device than it receives from

### DIFF
--- a/subsys/mgmt/mcumgr/transport/src/smp_shell.c
+++ b/subsys/mgmt/mcumgr/transport/src/smp_shell.c
@@ -39,6 +39,8 @@ static struct smp_transport smp_shell_transport;
 
 static struct mcumgr_serial_rx_ctxt smp_shell_rx_ctxt;
 
+static const struct shell_uart_common *shell_uart;
+
 #ifdef CONFIG_SMP_CLIENT
 static struct smp_client_transport_entry smp_client_transport;
 #endif
@@ -210,11 +212,10 @@ static uint16_t smp_shell_get_mtu(const struct net_buf *nb)
 
 static int smp_shell_tx_raw(const void *data, int len)
 {
-	static const struct device *const sh_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_shell_uart));
 	const uint8_t *out = data;
 
 	while ((out != NULL) && (len != 0)) {
-		uart_poll_out(sh_dev, *out);
+		uart_poll_out(shell_uart->dev, *out);
 		++out;
 		--len;
 	}
@@ -226,6 +227,7 @@ static int smp_shell_tx_pkt(struct net_buf *nb)
 {
 	int rc;
 
+	shell_uart = (struct shell_uart_common *)shell_backend_uart_get_ptr()->iface->ctx;
 	rc = mcumgr_serial_tx_pkt(nb->data, nb->len, smp_shell_tx_raw);
 	smp_packet_free(nb);
 


### PR DESCRIPTION
The smp shell transport is configured to work over uart shell.
The uart shell's device can be reconfigured at runtime.
The Smp shell driver currently responds on the device defined as shell in the device tree while receiving data from the uart shell whose device can be changed during runtime.

A similar fix from 2020:
https://github.com/zephyrproject-rtos/zephyr/pull/27871

The issue came back here when the shell structures were changed.
https://github.com/zephyrproject-rtos/zephyr/commit/6d2e3b59a5d1ae0d6ca6e94ee95dc68459b5fea8

This pull request takes the device from the uart_shell structures.
Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/81144