### PR TITLE
boards: nordic: Enable IPC and bellboard on nRF54H20

### DIFF
--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuapp.dts
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuapp.dts
@@ -143,9 +143,14 @@
 };
 
 &cpusec_cpuapp_ipc {
+	status = "okay";
 	mbox-names = "tx", "rx";
 	tx-region = <&cpuapp_cpusec_ipc_shm>;
 	rx-region = <&cpusec_cpuapp_ipc_shm>;
+};
+
+&cpusec_bellboard {
+	status = "okay";
 };
 
 ipc0: &cpuapp_cpurad_ipc {

--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpurad.dts
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpurad.dts
@@ -38,6 +38,10 @@
 	status = "okay";
 };
 
+&cpurad_ram0x_region {
+	status = "okay";
+};
+
 &cpurad_bellboard {
 	status = "okay";
 	interrupts = <96 NRF_DEFAULT_IRQ_PRIORITY>;
@@ -55,9 +59,14 @@
 };
 
 &cpusec_cpurad_ipc {
+	status = "okay";
 	mbox-names = "tx", "rx";
 	tx-region = <&cpurad_cpusec_ipc_shm>;
 	rx-region = <&cpusec_cpurad_ipc_shm>;
+};
+
+&cpusec_bellboard {
+	status = "okay";
 };
 
 ipc0: &cpuapp_cpurad_ipc {

--- a/tests/arch/arm/arm_thread_swap/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/tests/arch/arm/arm_thread_swap/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -1,0 +1,9 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+&cpusec_cpuapp_ipc {
+	status = "disabled";
+};
+
+&cpusec_bellboard {
+	status = "disabled";
+};


### PR DESCRIPTION
Enable the cpusec IPC and the bellboard nodes for
the nrf54h20dk cpuapp and cpurad targets to enable communication between domains.

Also enables the region cpurad_ram0x_region since
it is also required for the communication.