### PR TITLE
LLEXT: fix a needless allocation

### DIFF
--- a/include/zephyr/llext/llext.h
+++ b/include/zephyr/llext/llext.h
@@ -132,7 +132,10 @@ struct llext_load_param {
 	bool relocate_local;
 	/**
 	 * Use the virtual symbol addresses from the ELF, not addresses within
-	 * the memory buffer, when calculating relocation targets.
+	 * the memory buffer, when calculating relocation targets. It also
+	 * means, that the application will take care to place the extension at
+	 * those pre-defined addresses, so the LLEXT core doesn't have to do any
+	 * allocation and copying internally.
 	 */
 	bool pre_located;
 	/**

--- a/subsys/llext/llext_load.c
+++ b/subsys/llext/llext_load.c
@@ -684,7 +684,7 @@ int do_llext_load(struct llext_loader *ldr, struct llext *ext,
 	}
 
 	LOG_DBG("Allocate and copy regions...");
-	ret = llext_copy_regions(ldr, ext);
+	ret = llext_copy_regions(ldr, ext, ldr_parm);
 	if (ret != 0) {
 		LOG_ERR("Failed to copy regions, ret %d", ret);
 		goto out;

--- a/subsys/llext/llext_priv.h
+++ b/subsys/llext/llext_priv.h
@@ -20,7 +20,8 @@ struct llext_elf_sect_map {
  */
 
 int llext_copy_strings(struct llext_loader *ldr, struct llext *ext);
-int llext_copy_regions(struct llext_loader *ldr, struct llext *ext);
+int llext_copy_regions(struct llext_loader *ldr, struct llext *ext,
+		       const struct llext_load_param *ldr_parm);
 void llext_free_regions(struct llext *ext);
 void llext_adjust_mmu_permissions(struct llext *ext);
 


### PR DESCRIPTION
When CONFIG_LLEXT_STORAGE_WRITABLE is selected and .pre_located is set, the BSS section is allocated by the user too, no need to allocate it internally.