### PR TITLE
drivers: adc: microchip: Different channels per package type

### DIFF
--- a/drivers/adc/adc_mchp_xec.c
+++ b/drivers/adc/adc_mchp_xec.c
@@ -47,6 +47,7 @@ enum adc_pm_policy_state_flag {
 	ADC_PM_POLICY_STATE_FLAG_COUNT,
 };
 
+#define XEC_ADC_CFG_CHANNELS DT_INST_PROP(0, channels)
 
 struct adc_xec_regs {
 	uint32_t control_reg;
@@ -54,8 +55,8 @@ struct adc_xec_regs {
 	uint32_t status_reg;
 	uint32_t single_reg;
 	uint32_t repeat_reg;
-	uint32_t channel_read_reg[8];
-	uint32_t unused[18];
+	uint32_t channel_read_reg[XEC_ADC_CFG_CHANNELS];
+	uint32_t unused[10 + (MCHP_ADC_MAX_CHAN - XEC_ADC_CFG_CHANNELS)];
 	uint32_t config_reg;
 	uint32_t vref_channel_reg;
 	uint32_t vref_control_reg;
@@ -139,7 +140,7 @@ static int adc_xec_channel_setup(const struct device *dev,
 		return -EINVAL;
 	}
 
-	if (channel_cfg->channel_id >= MCHP_ADC_MAX_CHAN) {
+	if (channel_cfg->channel_id >= XEC_ADC_CFG_CHANNELS) {
 		return -EINVAL;
 	}
 
@@ -205,7 +206,7 @@ static int adc_xec_start_read(const struct device *dev,
 	struct adc_xec_data * const data = dev->data;
 	uint32_t sar_ctrl;
 
-	if (sequence->channels & ~BIT_MASK(MCHP_ADC_MAX_CHAN)) {
+	if (sequence->channels & ~BIT_MASK(XEC_ADC_CFG_CHANNELS)) {
 		LOG_ERR("Incorrect channels, bitmask 0x%x", sequence->channels);
 		return -EINVAL;
 	}

--- a/dts/arm/microchip/mec1501hsz.dtsi
+++ b/dts/arm/microchip/mec1501hsz.dtsi
@@ -442,6 +442,7 @@
 			status = "disabled";
 			#io-channel-cells = <1>;
 			clktime = <32>;
+			channels = <8>;
 		};
 		kbd0: kbd@40009c00 {
 			compatible = "microchip,xec-kbd";

--- a/dts/arm/microchip/mec172x_common.dtsi
+++ b/dts/arm/microchip/mec172x_common.dtsi
@@ -650,6 +650,7 @@ adc0: adc@40007c00 {
 	status = "disabled";
 	#io-channel-cells = <1>;
 	clktime = <32>;
+	channels = <16>;
 };
 kbd0: kbd@40009c00 {
 	compatible = "microchip,xec-kbd";

--- a/dts/arm/microchip/mec172xnsz.dtsi
+++ b/dts/arm/microchip/mec172xnsz.dtsi
@@ -75,3 +75,7 @@
 &systick {
 	status = "disabled";
 };
+
+&adc0 {
+	channels = <8>;
+};

--- a/dts/bindings/adc/microchip,xec-adc.yaml
+++ b/dts/bindings/adc/microchip,xec-adc.yaml
@@ -33,6 +33,11 @@ properties:
     required: true
     description: ADC clock high & low time count value <1:255>
 
+  channels:
+    type: int
+    required: true
+    description: Number of ADC channels supported by SoC
+
   pinctrl-0:
     required: true
 

--- a/soc/microchip/mec/common/reg/mec_adc.h
+++ b/soc/microchip/mec/common/reg/mec_adc.h
@@ -10,9 +10,15 @@
 #include <stdint.h>
 #include <stddef.h>
 
+#if defined(CONFIG_SOC_MEC172X_NLJ)
+/* 16 ADC channels numbered 0 - 15 */
+#define MCHP_ADC_MAX_CHAN		16u
+#define MCHP_ADC_MAX_CHAN_MASK		0x0fu
+#else
 /* Eight ADC channels numbered 0 - 7 */
 #define MCHP_ADC_MAX_CHAN		8u
 #define MCHP_ADC_MAX_CHAN_MASK		0x07u
+#endif
 
 /* Control register */
 #define MCHP_ADC_CTRL_REG_OFS		0u
@@ -42,15 +48,27 @@
 
 /* Single Conversion Select register */
 #define MCHP_ADC_SCS_REG_OFS		0x0cu
+#if defined(CONFIG_SOC_MEC172X_NLJ)
+#define MCHP_ADC_SCS_REG_MASK		0xffffu
+#define MCHP_ADC_SCS_CH_0_15		0xffffu
+#define MCHP_ADC_SCS_CH(n)		BIT(((n) & 0x0fu))
+#else
 #define MCHP_ADC_SCS_REG_MASK		0xffu
 #define MCHP_ADC_SCS_CH_0_7		0xffu
 #define MCHP_ADC_SCS_CH(n)		BIT(((n) & 0x07u))
+#endif
 
 /* Repeat Conversion Select register */
 #define MCHP_ADC_RCS_REG_OFS		0x10u
+#if defined(CONFIG_SOC_MEC172X_NLJ)
+#define MCHP_ADC_RCS_REG_MASK		0xffffu
+#define MCHP_ADC_RCS_CH_0_15		0xffffu
+#define MCHP_ADC_RCS_CH(n)		BIT(((n) & 0x0fu))
+#else
 #define MCHP_ADC_RCS_REG_MASK		0xffu
 #define MCHP_ADC_RCS_CH_0_7		0xffu
 #define MCHP_ADC_RCS_CH(n)		BIT(((n) & 0x07u))
+#endif
 
 /* Channel reading registers */
 #define MCHP_ADC_RDCH_REG_MASK		0xfffu
@@ -62,6 +80,14 @@
 #define MCHP_ADC_RDCH5_REG_OFS		0x28u
 #define MCHP_ADC_RDCH6_REG_OFS		0x2cu
 #define MCHP_ADC_RDCH7_REG_OFS		0x30u
+#define MCHP_ADC_RDCH8_REG_OFS		0x34u
+#define MCHP_ADC_RDCH9_REG_OFS		0x38u
+#define MCHP_ADC_RDCH10_REG_OFS		0x3cu
+#define MCHP_ADC_RDCH11_REG_OFS		0x40u
+#define MCHP_ADC_RDCH12_REG_OFS		0x44u
+#define MCHP_ADC_RDCH13_REG_OFS		0x48u
+#define MCHP_ADC_RDCH14_REG_OFS		0x4cu
+#define MCHP_ADC_RDCH15_REG_OFS		0x50u
 
 /* Configuration register */
 #define MCHP_ADC_CFG_REG_OFS		0x7cu
@@ -76,9 +102,15 @@
 /* Channel Vref Select register */
 #define MCHP_ADC_CH_VREF_SEL_REG_OFS	0x80u
 #define MCHP_ADC_CH_VREF_SEL_REG_MASK	0x00ffffffu
+#if defined(CONFIG_SOC_MEC172X_NLJ)
+#define MCHP_ADC_CH_VREF_SEL_MASK(n)	SHLU32(0x03u, (((n) & 0x0f) * 2u))
+#define MCHP_ADC_CH_VREF_SEL_PAD(n)	0u
+#define MCHP_ADC_CH_VREF_SEL_GPIO(n)	SHLU32(0x01u, (((n) & 0x0f) * 2u))
+#else
 #define MCHP_ADC_CH_VREF_SEL_MASK(n)	SHLU32(0x03u, (((n) & 0x07) * 2u))
 #define MCHP_ADC_CH_VREF_SEL_PAD(n)	0u
 #define MCHP_ADC_CH_VREF_SEL_GPIO(n)	SHLU32(0x01u, (((n) & 0x07) * 2u))
+#endif
 
 /* Vref Control register */
 #define MCHP_ADC_VREF_CTRL_REG_OFS		0x84u
@@ -131,8 +163,8 @@ struct adc_regs {
 	volatile uint32_t STATUS;
 	volatile uint32_t SINGLE;
 	volatile uint32_t REPEAT;
-	volatile uint32_t RD[8];
-	uint8_t RSVD1[0x7c - 0x34];
+	volatile uint32_t RD[MCHP_ADC_MAX_CHAN];
+	uint8_t RSVD1[0x7c - ((MCHP_ADC_MAX_CHAN * 4) + 0x14)];
 	volatile uint32_t CONFIG;
 	volatile uint32_t VREF_CHAN_SEL;
 	volatile uint32_t VREF_CTRL;


### PR DESCRIPTION
LJ packages have 16 ADC channels vs 8 for SZ packages.  Enhance devicetree to account for this as well as conditional defines/code.