### PR TITLE
Bluetooth: CSIP: Fix off-by-one in in lock restore

### DIFF
--- a/subsys/bluetooth/audio/csip_set_coordinator.c
+++ b/subsys/bluetooth/audio/csip_set_coordinator.c
@@ -1113,7 +1113,7 @@ static void csip_set_coordinator_write_lock_cb(struct bt_conn *conn,
 
 			active.members_restored = 0;
 
-			member = active.members[active.members_handled - active.members_restored];
+			member = active.members[active.members_handled - 1];
 			client->cur_inst = lookup_instance_by_set_info(member, &active.info);
 			if (client->cur_inst == NULL) {
 				LOG_DBG("Failed to lookup instance by set_info");
@@ -1130,9 +1130,9 @@ static void csip_set_coordinator_write_lock_cb(struct bt_conn *conn,
 				active_members_reset();
 				return;
 			}
+		} else {
+			lock_set_complete(err);
 		}
-
-		lock_set_complete(err);
 
 		return;
 	}


### PR DESCRIPTION
If the lock request was rejected by a set member we should restore any previously written logs in reverse order.

However there was a off-by-one error in
csip_set_coordinator_write_lock_cb which caused us to attempt to release member[1] instead of member[0] if member[1] was the one that rejected the lock request.

Additionally, the lock_set_complete would be called prematurely before we get the response from the restore request.

fixes https://github.com/zephyrproject-rtos/zephyr/issues/80936