### PR TITLE
tests: CONFIG_TEST_USERSPACE selects CONFIG_USERSPACE

### DIFF
--- a/subsys/testsuite/Kconfig
+++ b/subsys/testsuite/Kconfig
@@ -132,7 +132,7 @@ config TEST_ENABLE_USERSPACE
 	bool
 	depends on TEST_USERSPACE
 	depends on ARCH_HAS_USERSPACE
-	imply USERSPACE
+	select USERSPACE
 	imply DYNAMIC_OBJECTS
 	default y
 	help


### PR DESCRIPTION
CONFIG_TEST_USERSPACE should select CONFIG_USERSPACE as they should be enabled together. It is no use to enable userspace tests without enabling userspace.