### PR TITLE
Updated documentation references in index.rst

### DIFF
--- a/boards/adi/max32690evkit/doc/index.rst
+++ b/boards/adi/max32690evkit/doc/index.rst
@@ -303,7 +303,7 @@ instead of ``west flash``.
 References
 **********
 
-- `MAX32690EVKIT web page`_
+- `MAX32690EVKIT solution center`_
 
-.. _MAX32690EVKIT web page:
-   https://www.analog.com/en/design-center/evaluation-hardware-and-software/evaluation-boards-kits/MAX32690EVKIT.html
+.. _MAX32690EVKIT solution center:
+   https://developer.analog.com/solutions/max32690


### PR DESCRIPTION
Changed the title and link for MAX32690EVKIT web page (https://www.analog.com/en/design-center/evaluation-hardware-and-software/evaluation-boards-kits/MAX32690EVKIT.html) 

to point to the MAX32690 solution center on the developer portal (developer.analog.com/solutions/max32690) the solution center has links to the product specific page and offers more content for developers.