### PR TITLE
drivers: nrfwifi: WAR for performance regression

### DIFF
--- a/drivers/wifi/nrfwifi/src/qspi/src/qspi_if.c
+++ b/drivers/wifi/nrfwifi/src/qspi/src/qspi_if.c
@@ -125,7 +125,10 @@ BUILD_ASSERT(QSPI_IF_DEVICE_FREQUENCY >= (NRF_QSPI_BASE_CLOCK_FREQ / 16),
  * starts. It was measured with a logic analyzer (unfortunately, the nRF5340
  * specification does not provide any numbers in this regard).
  */
-#define BASE_CLOCK_SWITCH_DELAY_US 7
+/* FIXME: This has adverse impact on performance, ~3Mbps, so, for now, it is
+ * disabled till further investigation.
+ */
+#define BASE_CLOCK_SWITCH_DELAY_US 0
 
 #else
 /*


### PR DESCRIPTION
With the newly introduced settling time for PLLS, we are seeing a peak performance drop of 3Mbps in Zperf benchmarks, and also other performance tests are also impacted.

This settling time was introduced based on observations in lab and not because of any real problem or bug reported, so, for now, use zero settling time (same as earlier) till we fully investigate and understand the impacts and need.

Fixes #80951.