### PR TITLE
Update Ram Size On MCXW71 and testcase.yaml for CMSIS_DSP/Transform

### DIFF
--- a/dts/arm/nxp/nxp_mcxw71.dtsi
+++ b/dts/arm/nxp/nxp_mcxw71.dtsi
@@ -57,7 +57,8 @@
 
 			stcm0: system_memory@0 {
 				compatible = "mmio-sram";
-				reg = <0x0 DT_SIZE_K(64)>;
+				/* With only the first 64KB having ECC */
+				reg = <0x0 DT_SIZE_K(104)>;
 			};
 
 			stcm1: system_memory@1a000 {

--- a/tests/lib/cmsis_dsp/transform/testcase.yaml
+++ b/tests/lib/cmsis_dsp/transform/testcase.yaml
@@ -70,7 +70,7 @@ tests:
       - native_sim
     tags: cmsis-dsp
     min_flash: 1024
-    min_ram: 64
+    min_ram: 80
     extra_args: CONF_FILE=prj_base.conf
     extra_configs:
       - CONFIG_CMSIS_DSP_TEST_TRANSFORM_CQ31=y
@@ -81,7 +81,7 @@ tests:
       - cmsis-dsp
       - fpu
     min_flash: 1024
-    min_ram: 64
+    min_ram: 80
     extra_args: CONF_FILE=prj_base.conf
     extra_configs:
       - CONFIG_CMSIS_DSP_TEST_TRANSFORM_CQ31=y
@@ -256,7 +256,7 @@ tests:
       - native_sim
     tags: cmsis-dsp
     min_flash: 1024
-    min_ram: 64
+    min_ram: 80
     extra_args: CONF_FILE=prj_base.conf
     extra_configs:
       - CONFIG_CMSIS_DSP_TEST_TRANSFORM_RF64=y
@@ -267,7 +267,7 @@ tests:
       - cmsis-dsp
       - fpu
     min_flash: 1024
-    min_ram: 64
+    min_ram: 80
     extra_args: CONF_FILE=prj_base.conf
     extra_configs:
       - CONFIG_CMSIS_DSP_TEST_TRANSFORM_RF64=y


### PR DESCRIPTION
Fixes [79840](https://github.com/zephyrproject-rtos/zephyr/issues/79840)

Note that the integration platform [frdm_k64f] requires at least 71KB of ram to pass the transform.rf64 test
but the mcxw71 only needs 70KB. I am unsure of the reasoning as the test only does allocations.