### PR TITLE
sca: Add cppcheck (FOSS and premium)

### DIFF
--- a/cmake/sca/cppcheck/sca.cmake
+++ b/cmake/sca/cppcheck/sca.cmake
@@ -1,0 +1,136 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: Copyright (c) 2025 GARDENA GmbH
+
+# If not specified manually, let Cppcheck to use all available (logical) CPU
+# cores.
+if(NOT DEFINED CPPCHECK_JOBS_COUNT)
+  cmake_host_system_information(RESULT CPPCHECK_JOBS_COUNT
+                                QUERY NUMBER_OF_LOGICAL_CORES)
+endif()
+
+find_program(CPPCHECK_EXE NAMES cppcheck REQUIRED)
+message(STATUS "Found SCA: cppcheck (${CPPCHECK_EXE})")
+
+# Defaulting to exhaustive to prevent normalCheckLevelMaxBranches "findings"
+set(CPPCHECK_CHECK_LEVEL "exhaustive" CACHE STRING
+    "Value of the --check-level argument passed to cppcheck")
+
+# The premium edition exits with a non-zero exit code whenever it finds a bug,
+# causing the SCA infrastructure of Zephyr to quit with an error too.
+# We can prevent this by adding the "--premium=safety-off" argument. However,
+# this is known only the the Premium edition of Cppcheck.
+if(NOT DEFINED CPPCHECK_IS_PREMIUM)
+  execute_process(COMMAND "${CPPCHECK_EXE}" "--version"
+                  OUTPUT_VARIABLE CPPCHECK_VERSION_STRING
+                  COMMAND_ERROR_IS_FATAL ANY)
+  if("${CPPCHECK_VERSION_STRING}" MATCHES "Premium")
+    set(CPPCHECK_IS_PREMIUM 1)
+  endif()
+endif()
+option(CPPCHECK_IS_PREMIUM "Whether we run Cppcheck premium" 0)
+if(CPPCHECK_IS_PREMIUM)
+  set(CPPCHECK_PREMIUM_ARGUMENT "--premium=safety-off")
+  message(STATUS "Using the Premium version of Cppcheck")
+else()
+  set(CPPCHECK_PREMIUM_ARGUMENT "")
+  message(STATUS "Using the Open Source version of Cppcheck")
+endif()
+
+# Cppcheck uses the compile_commands.json as input
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+# Create an output directory for our tool
+set(output_dir ${CMAKE_BINARY_DIR}/sca/cppcheck)
+file(MAKE_DIRECTORY ${output_dir})
+
+# Help Cppcheck parse the Zephyr headers, reduce runtime by ensuring all
+# relevant configs defined
+set_property(
+    GLOBAL
+    APPEND
+    PROPERTY
+        extra_post_build_commands
+            COMMAND
+            ${CMAKE_COMMAND}
+            ARGS
+            -E
+            touch
+            ${output_dir}/compiler-macros.c
+)
+set_property(
+    GLOBAL
+    APPEND
+    PROPERTY extra_post_build_byproducts ${output_dir}/compiler-macros.c
+)
+
+# Note: This works only for GCC and compatibles. Please add support for other
+# compilers!
+set_property(
+    GLOBAL
+    APPEND
+    PROPERTY
+        extra_post_build_commands
+            COMMAND
+            ${CMAKE_C_COMPILER}
+            ARGS
+            -dM
+            -E
+            ${output_dir}/compiler-macros.c
+            -o
+            ${output_dir}/compiler-macros.h
+)
+
+set_property(
+    GLOBAL
+    APPEND
+    PROPERTY extra_post_build_byproducts ${output_dir}/compiler-macros.h
+)
+
+add_custom_target(
+    cppcheck
+    ALL
+    COMMAND
+        ${CPPCHECK_EXE} --project=${CMAKE_BINARY_DIR}/compile_commands.json
+        --xml # Write results in XML format
+        --output-file=${output_dir}/cppcheck.xml # write output to file, not stderr
+        --library=zephyr.cfg # Enable Zephyr specific knowledge
+        --quiet # Suppress progress reporting
+        --include=${CMAKE_BINARY_DIR}/zephyr/include/generated/zephyr/autoconf.h
+        --include=${output_dir}/compiler-macros.h # Use exact compiler macros
+        -j ${CPPCHECK_JOBS_COUNT} # Parallelize analysis
+        -D__cppcheck__ # As recommended by the Cppcheck manual
+        --check-level=${CPPCHECK_CHECK_LEVEL}
+        ${CPPCHECK_PREMIUM_ARGUMENT}
+        ${CODECHECKER_ANALYZE_OPTS}
+    DEPENDS
+        ${CMAKE_BINARY_DIR}/compile_commands.json
+        ${output_dir}/compiler-macros.h
+    BYPRODUCTS ${output_dir}/cppcheck.xml
+    VERBATIM
+)
+
+# Cleanup helper files
+add_custom_command(
+    TARGET cppcheck
+    POST_BUILD
+    COMMAND ${CMAKE_COMMAND}
+    ARGS -E rm ${output_dir}/compiler-macros.c ${output_dir}/compiler-macros.h
+)
+
+find_program(CPPCHECK_HTMLREPORT_EXE NAMES cppcheck-htmlreport REQUIRED)
+message(STATUS "Found SCA: cppcheck-htmlreport (${CPPCHECK_HTMLREPORT_EXE})")
+add_custom_command(
+    TARGET cppcheck
+    POST_BUILD
+    COMMAND
+        ${CPPCHECK_HTMLREPORT_EXE} --title=Zephyr
+        --file=${output_dir}/cppcheck.xml # Read in file created by Cppcheck
+        --report-dir=${output_dir} # Set output directory
+        ${CPPCHECK_HTMLREPORT_OPTS}
+    BYPRODUCTS
+        ${output_dir}/index.html
+        ${output_dir}/stats.html
+        ${output_dir}/style.css
+    VERBATIM
+)


### PR DESCRIPTION
This allows to use cppcheck directly, without going trough CodeChecker.

Warning: As of 2026-05-11, [the latest Cppcheck Git version (combined with the latest simplecpp version)](https://github.com/husqvarnagroup/cppcheck/releases/tag/gardena%2Frs%2Fzephyr-2026-05-11) has problems with parsing the Zephyr code base.

Cppcheck FOSS :
```console
$ west build --pristine --board sim3u1xx_dk zephyr/samples/hello_world/ -- -DZEPHYR_SCA_VARIANT=cppcheck -DCPPCHECK_EXE=~/opt/cppcheck-git/bin/cppcheck
-- west build: making build dir /home/reto/code/3rd-party/zephyrproject/build pristine
-- west build: generating a build system
Loading Zephyr default modules (Zephyr base).
-- Application: /home/reto/code/3rd-party/zephyrproject/zephyr/samples/hello_world
-- CMake version: 3.31.6
-- Found Python3: /home/reto/tmp/venv/home/reto/code/3rd-party/zephyrproject/bin/python3 (found suitable version "3.13.5", minimum required is "3.12") found components: Interpreter
-- Cache files will be written to: /home/reto/.cache/zephyr
-- Zephyr version: 4.4.99 (/home/reto/code/3rd-party/zephyrproject/zephyr)
-- Found west (found suitable version "1.5.0", minimum required is "0.14.0")
-- Board: sim3u1xx_dk, qualifiers: sim3u167
-- ZEPHYR_TOOLCHAIN_VARIANT not set, trying to locate Zephyr SDK
-- Found host-tools: zephyr 1.0.1 (/home/reto/.local/opt/zephyr-sdk-1.0.1)
-- Found toolchain: zephyr 1.0.1 (/home/reto/.local/opt/zephyr-sdk-1.0.1)
-- Found Dtc: /home/reto/.local/opt/zephyr-sdk-1.0.1/hosttools/sysroots/x86_64-pokysdk-linux/usr/bin/dtc (found suitable version "1.7.0", minimum required is "1.4.6")
-- Found BOARD.dts: /home/reto/code/3rd-party/zephyrproject/zephyr/boards/silabs/dev_kits/sim3u1xx_dk/sim3u1xx_dk.dts
-- Generated zephyr.dts: /home/reto/code/3rd-party/zephyrproject/build/zephyr/zephyr.dts
-- Generated pickled edt: /home/reto/code/3rd-party/zephyrproject/build/zephyr/edt.pickle
-- Generated devicetree_generated.h: /home/reto/code/3rd-party/zephyrproject/build/zephyr/include/generated/zephyr/devicetree_generated.h
Parsing /home/reto/code/3rd-party/zephyrproject/zephyr/Kconfig
Loaded configuration '/home/reto/code/3rd-party/zephyrproject/zephyr/boards/silabs/dev_kits/sim3u1xx_dk/sim3u1xx_dk_defconfig'
Merged configuration '/home/reto/code/3rd-party/zephyrproject/zephyr/samples/hello_world/prj.conf'
Configuration saved to '/home/reto/code/3rd-party/zephyrproject/build/zephyr/.config'
Kconfig header saved to '/home/reto/code/3rd-party/zephyrproject/build/zephyr/include/generated/zephyr/autoconf.h'
-- Found GnuLd: /home/reto/opt/zephyr-sdk-1.0.1/gnu/arm-zephyr-eabi/arm-zephyr-eabi/bin/ld.bfd (found version "2.43.1")
-- Found SCA: cppcheck (/home/reto/opt/cppcheck-git/bin/cppcheck)
-- Using the Open Source version of Cppcheck
-- Found SCA: cppcheck-htmlreport (/home/reto/.local/bin/cppcheck-htmlreport)
-- The C compiler identification is GNU 14.3.0
-- The CXX compiler identification is GNU 14.3.0
-- The ASM compiler identification is GNU
-- Found assembler: /home/reto/.local/opt/zephyr-sdk-1.0.1/gnu/arm-zephyr-eabi/bin/arm-zephyr-eabi-gcc
-- Using ccache: /usr/bin/ccache
-- Found gen_kobject_list: /home/reto/code/3rd-party/zephyrproject/zephyr/scripts/build/gen_kobject_list.py
-- Configuring done (10.7s)
-- Generating done (0.2s)
-- Build files have been written to: /home/reto/code/3rd-party/zephyrproject/build
-- west build: building application
[1/140] Preparing syscall dependency handling

[3/140] Generating include/generated/zephyr/version.h
-- Zephyr version: 4.4.99 (/home/reto/code/3rd-party/zephyrproject/zephyr), build: v4.4.0-2259-g541e1ee0cb65
[138/140] Linking C executable zephyr/zephyr.elf
Memory region         Used Size  Region Size  %age Used
           FLASH:       11964 B       256 KB      4.56%
             RAM:        3944 B        32 KB     12.04%
        IDT_LIST:           0 B        32 KB      0.00%
Generating files from /home/reto/code/3rd-party/zephyrproject/build/zephyr/zephyr.elf for board: sim3u1xx_dk/sim3u167
[140/140] Running utility command for cppcheck
Parsing xml report.
Creating /home/reto/code/3rd-party/zephyrproject/build/sca/cppcheck directory
Processing errors
  /home/reto/code/3rd-party/zephyrproject/modules/hal/cmsis_6/CMSIS/Core/Include/cmsis_gcc.h
  /home/reto/code/3rd-party/zephyrproject/zephyr/arch/common/init.c
  /home/reto/code/3rd-party/zephyrproject/zephyr/include/zephyr/kernel/internal/mm.h
  /home/reto/code/3rd-party/zephyrproject/zephyr/include/zephyr/sys/util.h
Creating index.html
Creating style.css file
Creating stats.html (statistics)


Open '/home/reto/code/3rd-party/zephyrproject/build/sca/cppcheck/index.html' to see the results.

```

TODO:
 - [x] Get cppcheck premium to not (always) exit with code 1
 - [x] Test with newer (post 2.10) cppcheck (non premium) to see if zephyr.cfg is supported
 - [x] Support all platforms, not just ARM 32-bit
 - [ ] Support variables set by Twister (similar to CodeChecker)
 - [ ] Export cppcheck command line to CMake (similar to CodeChecker)
 - [x] Use parallelization properly (set `-j <n>`)
 - [ ] Fix asserts in `include/zephyr/kernel/internal/mm.h`
 - [ ] Fix true positive Zephyr issues found by Cppcheck

Background: I am doing this because I am currently evaluating [Cppcheck Premium](https://www.cppcheck.com/).