### PR TITLE
ci: Add '-specs' to ccache ignore option list

### DIFF
--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -34,7 +34,7 @@ jobs:
       CCACHE_REMOTE_STORAGE: "redis://cache-*.keydb-cache.svc.cluster.local|shards=1,2,3"
       CCACHE_REMOTE_ONLY: "true"
       # `--specs` is ignored because ccache is unable to resovle the toolchain specs file path.
-      CCACHE_IGNOREOPTIONS: '--specs=*'
+      CCACHE_IGNOREOPTIONS: '-specs=* --specs=*'
     steps:
       - name: Apply container owner mismatch workaround
         run: |

--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -142,7 +142,7 @@ jobs:
       CCACHE_REMOTE_STORAGE: "redis://cache-*.keydb-cache.svc.cluster.local|shards=1,2,3"
       CCACHE_REMOTE_ONLY: "true"
       # `--specs` is ignored because ccache is unable to resolve the toolchain specs file path.
-      CCACHE_IGNOREOPTIONS: '--specs=*'
+      CCACHE_IGNOREOPTIONS: '-specs=* --specs=*'
       BSIM_OUT_PATH: /opt/bsim/
       BSIM_COMPONENTS_PATH: /opt/bsim/components
       TWISTER_COMMON: ' --force-color --inline-logs -v -N -M --retry-failed 3 --timeout-multiplier 2 '


### PR DESCRIPTION
`-specs=` is an alternate form of `--specs=`, which is now used by the Zephyr build system.

This commit adds `-specs=*` to the ccache ignore option list because, as with `--specs=*`, ccache is unable to resolve the toolchain specs file path and refuses to cache when this option is specified.