### PR TITLE
boards: st: stm32l5: Fix TF-M by restricting Libc malloc area

### DIFF
--- a/boards/st/nucleo_l552ze_q/Kconfig.defconfig
+++ b/boards/st/nucleo_l552ze_q/Kconfig.defconfig
@@ -1,0 +1,20 @@
+# STM32L552ZE-Q Nucleo board configuration
+
+# Copyright (c) 2024 STMicroelectronics
+# SPDX-License-Identifier: Apache-2.0
+
+if BOARD_NUCLEO_L552ZE_Q
+
+if BUILD_WITH_TFM
+
+# Not defining LIBC malloc arena has the effect of declaring all available RAM
+# as available for malloc.
+# This currently conflicts with TF-M MPU setting, resulting in a hard fault.
+# Define a specific size to avoid this situation.
+
+config COMMON_LIBC_MALLOC_ARENA_SIZE
+	default 2048
+
+endif # BUILD_WITH_TFM
+
+endif # BOARD_NUCLEO_L552ZE_Q

--- a/boards/st/stm32l562e_dk/Kconfig.defconfig
+++ b/boards/st/stm32l562e_dk/Kconfig.defconfig
@@ -30,4 +30,16 @@ endchoice
 
 endif # DISPLAY
 
+if BUILD_WITH_TFM
+
+# Not defining LIBC malloc arena has the effect of declaring all available RAM
+# as available for malloc.
+# This currently conflicts with TF-M MPU setting, resulting in a hard fault.
+# Define a specific size to avoid this situation.
+
+config COMMON_LIBC_MALLOC_ARENA_SIZE
+	default 2048
+
+endif # BUILD_WITH_TFM
+
 endif # BOARD_STM32L562E_DK


### PR DESCRIPTION
By default, libc malloc allocated area is using all available RAM. For some yet unknown reason, this conflicts with TF-M resulting in a Hard Fault before jumping in the non secure application.

Fow now, define a Libc malloc area defined to 2048 which is the default in some other typical applications (ARMv7 targets enabling USERSPACE).

Fixes #77847

Thanks to @norrathep for the hint.