### PR TITLE
mdio: fmurt6: dts: Enable the parent node of mdio

### DIFF
--- a/boards/nxp/mimxrt1062_fmurt6/mimxrt1062_fmurt6.dts
+++ b/boards/nxp/mimxrt1062_fmurt6/mimxrt1062_fmurt6.dts
@@ -385,12 +385,17 @@
 	nxp,prescaler = <64>;
 };
 
+&enet2 {
+	status = "okay";
+};
+
 &enet2_mac {
 	pinctrl-0 = <&pinmux_enet>;
 	pinctrl-names = "default";
 	zephyr,random-mac-address;
 	phy-connection-type = "rmii";
 	phy-handle = <&phy>;
+	status = "okay";
 };
 
 &enet2_mdio {


### PR DESCRIPTION
mdio_enet_nxp driver accesses the registers of its parent node Ethernet MAC, which was disabled by default.
This commit enables this parent node in mimxrt1062_fmurt6 board's device tree. 
This also fixes Issue #80881 