### PR TITLE
soc: ambiq: apollo3x: Flash-controller reconfigured for mcuboot

### DIFF
--- a/boards/ambiq/apollo3_evb/apollo3_evb.dts
+++ b/boards/ambiq/apollo3_evb/apollo3_evb.dts
@@ -2,6 +2,7 @@
 #include <ambiq/ambiq_apollo3_blue.dtsi>
 
 #include "apollo3_evb-pinctrl.dtsi"
+#include <zephyr/dt-bindings/input/input-event-codes.h>
 
 / {
 	model = "Ambiq Apollo3 Blue evaluation board";
@@ -13,9 +14,11 @@
 		zephyr,flash = &flash0;
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
+		zephyr,uart-mcumgr = &uart0;
 		zephyr,uart-pipe = &uart0;
 		zephyr,flash-controller = &flash;
 		zephyr,bt_hci = &bt_hci_apollo;
+		zephyr,code-partition = &slot0_partition;
 	};
 
 	aliases {
@@ -25,6 +28,8 @@
 		led2 = &led2;
 		sw0 = &button0;
 		sw1 = &button1;
+		bootloader-led0 = &led0;
+		mcuboot-led0 = &led0;
 	};
 
 	leds {
@@ -56,14 +61,17 @@
 		button0: button_0 {
 			gpios = <&gpio0_31 16 GPIO_ACTIVE_LOW>;
 			label = "BTN0";
+			zephyr,code = <INPUT_KEY_0>;
 		};
 		button1: button_1 {
 			gpios = <&gpio0_31 18 GPIO_ACTIVE_LOW>;
 			label = "BTN1";
+			zephyr,code = <INPUT_KEY_1>;
 		};
 		button2: button_2 {
 			gpios = <&gpio0_31 19 GPIO_ACTIVE_LOW>;
 			label = "BTN2";
+			zephyr,code = <INPUT_KEY_2>;
 		};
 	};
 };
@@ -77,10 +85,28 @@
 		#address-cells = <1>;
 		#size-cells = <1>;
 
-		/* Set 16KB of storage at the end of the 976KB of flash */
-		storage_partition: partition@f0000 {
+		internal_boot_partition: partition@0 {
+			label = "internal_bootloader";
+			reg = <0x00000000 0xc000>;
+		};
+
+		boot_partition: partition@c000 {
+			label = "mcuboot";
+			reg = <0x0000c000 0xc000>;
+		};
+		slot0_partition: partition@18000 {
+			label = "image-0";
+			reg = <0x00018000 0x72000>;
+		};
+		slot1_partition: partition@8a000 {
+			label = "image-1";
+			reg = <0x0008a000 0x72000>;
+		};
+
+		/* Set 16KB of storage at the end of the 1024KB of flash */
+		storage_partition: partition@fc000 {
 			label = "storage";
-			reg = <0x000f0000 0x4000>;
+			reg = <0x000fc000 0x4000>;
 		};
 	};
 };

--- a/boards/rakwireless/rak11720/rak11720.dts
+++ b/boards/rakwireless/rak11720/rak11720.dts
@@ -8,6 +8,7 @@
 #include <ambiq/ambiq_apollo3_blue.dtsi>
 #include <zephyr/dt-bindings/lora/sx126x.h>
 #include "rak11720_apollo3-pinctrl.dtsi"
+#include <zephyr/dt-bindings/input/input-event-codes.h>
 
 / {
 	model = "RAKwireless RAK11720 WisBlock LPWAN Module";
@@ -19,9 +20,11 @@
 		zephyr,flash = &flash0;
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
+		zephyr,uart-mcumgr = &uart0;
 		zephyr,uart-pipe = &uart0;
 		zephyr,flash-controller = &flash;
 		zephyr,bt_hci = &bt_hci_apollo;
+		zephyr,code-partition = &slot0_partition;
 	};
 
 	aliases {
@@ -29,6 +32,8 @@
 		led0 = &blue_led;
 		led1 = &green_led;
 		lora0 = &lora;
+		bootloader-led0 = &blue_led;
+		mcuboot-led0 = &blue_led;
 	};
 
 	leds {
@@ -53,10 +58,28 @@
 		#address-cells = <1>;
 		#size-cells = <1>;
 
-		/* Set 16KB of storage at the end of the 976KB of flash */
-		storage_partition: partition@f0000 {
+		internal_boot_partition: partition@0 {
+			label = "internal_bootloader";
+			reg = <0x00000000 0xc000>;
+		};
+
+		boot_partition: partition@c000 {
+			label = "mcuboot";
+			reg = <0x0000c000 0xc000>;
+		};
+		slot0_partition: partition@18000 {
+			label = "image-0";
+			reg = <0x00018000 0x72000>;
+		};
+		slot1_partition: partition@8a000 {
+			label = "image-1";
+			reg = <0x0008a000 0x72000>;
+		};
+
+		/* Set 16KB of storage at the end of the 1024KB of flash */
+		storage_partition: partition@fc000 {
 			label = "storage";
-			reg = <0x000f0000 0x4000>;
+			reg = <0x000fc000 0x4000>;
 		};
 	};
 };

--- a/dts/arm/ambiq/ambiq_apollo3_blue.dtsi
+++ b/dts/arm/ambiq/ambiq_apollo3_blue.dtsi
@@ -68,17 +68,17 @@
 	soc {
 		compatible = "ambiq,apollo3-blue", "ambiq,apollo3x", "simple-bus";
 
-		flash: flash-controller@c000 {
+		flash: flash-controller@0 {
 			compatible = "ambiq,flash-controller";
-			reg = <0x0000c000 0xf4000>;
+			reg = <0x00000000 0x100000>;
 
 			#address-cells = <1>;
 			#size-cells = <1>;
 
 			/* Flash region */
-			flash0: flash@c000 {
+			flash0: flash@0 {
 				compatible = "soc-nv-flash";
-				reg = <0x0000c000 0xf4000>;
+				reg = <0x00000000 0x100000>;
 			};
 		};
 

--- a/soc/ambiq/apollo3x/Kconfig.defconfig.apollo3_blue
+++ b/soc/ambiq/apollo3x/Kconfig.defconfig.apollo3_blue
@@ -37,4 +37,11 @@ config BT_HCI_ACL_FLOW_CONTROL
 
 endif # BT
 
+if !BOOTLOADER_MCUBOOT
+
+config FLASH_LOAD_OFFSET
+	default 0xc000
+
+endif # !BOOTLOADER_MCUBOOT
+
 endif # SOC_APOLLO3_BLUE


### PR DESCRIPTION
Due to Apollo3's internal bootloader, zephyr build is not able to create correct flash address on linker.cmd while using mcuboot. The PR configures flash-controller start address to solve this problem.

Test board: rakwireless/rak11720
Test project: samples/subsys/mgmt/mcumgr/smp_svr

Please close SHELL options on overlay-bt.conf  and  overlay-shell-mgmt.conf files to see log messages. I tested update over uart and ble.