### PR TITLE
tests: Bluetooth: tester: Workaround Bus Fault in nRF53x using full RAM

### DIFF
--- a/tests/bluetooth/tester/Kconfig.sysbuild
+++ b/tests/bluetooth/tester/Kconfig.sysbuild
@@ -1,0 +1,14 @@
+# Copyright 2023-2024 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+source "share/sysbuild/Kconfig"
+
+config NET_CORE_BOARD
+	string
+	default "nrf5340dk/nrf5340/cpunet" if "$(BOARD)" = "nrf5340dk"
+	default "nrf5340_audio_dk/nrf5340/cpunet" if "$(BOARD)" = "nrf5340_audio_dk"
+
+config NET_CORE_IMAGE_HCI_IPC
+	bool "HCI IPC image on network core"
+	default y
+	depends on NET_CORE_BOARD != ""

--- a/tests/bluetooth/tester/nrf5340_hci_ipc_cpunet.conf
+++ b/tests/bluetooth/tester/nrf5340_hci_ipc_cpunet.conf
@@ -1,5 +1,11 @@
 # Apply this overlay at hci_ipc controller build
-CONFIG_BT_CTLR_CONN_ISO_LOW_LATENCY_POLICY=y
+
+# Changes towards reduced RAM usage, in order to fit the tweaks
+CONFIG_HEAP_MEM_POOL_SIZE=7168
+
+# PTS required counts
+CONFIG_BT_MAX_CONN=3
+
+# PTS tests specific tweaks
 CONFIG_BT_CTLR_PERIPHERAL_ISO_EARLY_CIG_START=y
 CONFIG_BT_CTLR_ISOAL_PSN_IGNORE=y
-CONFIG_BT_MAX_CONN=3

--- a/tests/bluetooth/tester/sysbuild.cmake
+++ b/tests/bluetooth/tester/sysbuild.cmake
@@ -1,0 +1,29 @@
+# Copyright (c) 2023-2024 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+if(SB_CONFIG_NET_CORE_IMAGE_HCI_IPC)
+	# For builds in the nrf5340, we build the netcore image with the controller
+
+	set(NET_APP hci_ipc)
+	set(NET_APP_SRC_DIR ${ZEPHYR_BASE}/samples/bluetooth/${NET_APP})
+
+	ExternalZephyrProject_Add(
+		APPLICATION ${NET_APP}
+		SOURCE_DIR  ${NET_APP_SRC_DIR}
+		BOARD       ${SB_CONFIG_NET_CORE_BOARD}
+	)
+
+	set(${NET_APP}_CONF_FILE
+	 ${NET_APP_SRC_DIR}/nrf5340_cpunet_iso-bt_ll_sw_split.conf
+	 CACHE INTERNAL ""
+	)
+
+	set(${NET_APP}_EXTRA_CONF_FILE
+	 ${APP_DIR}/nrf5340_hci_ipc_cpunet.conf
+	 CACHE INTERNAL ""
+	)
+
+	native_simulator_set_child_images(${DEFAULT_IMAGE} ${NET_APP})
+endif()
+
+native_simulator_set_final_executable(${DEFAULT_IMAGE})

--- a/tests/bluetooth/tester/testcase.yaml
+++ b/tests/bluetooth/tester/testcase.yaml
@@ -23,9 +23,14 @@ tests:
       - native_sim
       - nrf5340dk/nrf5340/cpuapp
       - nrf5340_audio_dk/nrf5340/cpuapp
-    extra_args: EXTRA_CONF_FILE="overlay-le-audio.conf"
+    integration_platforms:
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf5340_audio_dk/nrf5340/cpuapp
+    extra_args:
+      - EXTRA_CONF_FILE="overlay-le-audio.conf"
     tags: bluetooth
     harness: bluetooth
+    sysbuild: true
   bluetooth.general.tester_mesh:
     build_only: true
     platform_allow:


### PR DESCRIPTION
Workaround failing autopts weekly run due to tester application having Bus Fault in the nRF53 NET core hci_ipc firmware at startup.

Having atleast 32 bytes free in nRF53x hci_ipc sample to avoid Bus Fault when Zephyr Kernel does SYSINIT calls.

Reduce supported ISO Broadcaster instance and ISO TX buffer counts in the Controller hci_ipc firmware.

Add sysbuild support for tester application so that the build is CI verified.

sysbuild commandline for LE audio PTS testing:

```
  # west build --sysbuild -b nrf5340_audio_dk/nrf5340/cpuapp -d build/tester tests/bluetooth/tester -DEXTRA_CONF_FILE="overlay-le-audio.conf"
```


Fixes #80852.