### PR TITLE
tests: Bluetooth: ISO: Add validation of broadcast info

### DIFF
--- a/include/zephyr/bluetooth/hci_types.h
+++ b/include/zephyr/bluetooth/hci_types.h
@@ -3403,6 +3403,13 @@ struct bt_hci_evt_le_cis_req {
 	uint8_t  cis_id;
 } __packed;
 
+#define BT_HCI_LE_BIG_HANDLE_MIN            0x00U
+#define BT_HCI_LE_BIG_HANDLE_MAX            0xEFU
+#define BT_HCI_LE_BIG_SYNC_DELAY_MIN        0x000030U
+#define BT_HCI_LE_BIG_SYNC_DELAY_MAX        0x7FFFFFU
+#define BT_HCI_LE_TRANSPORT_LATENCY_BIG_MIN 0x000030U
+#define BT_HCI_LE_TRANSPORT_LATENCY_BIG_MAX 0x7FFFFFU
+
 #define BT_HCI_EVT_LE_BIG_COMPLETE              0x1b
 struct bt_hci_evt_le_big_complete {
 	uint8_t  status;

--- a/tests/bsim/bluetooth/host/iso/bis/src/bis_receiver.c
+++ b/tests/bsim/bluetooth/host/iso/bis/src/bis_receiver.c
@@ -87,9 +87,34 @@ static void iso_connected(struct bt_iso_chan *chan)
 		.pid = BT_ISO_DATA_PATH_HCI,
 		.format = BT_HCI_CODING_FORMAT_TRANSPARENT,
 	};
+	struct bt_iso_info info;
 	int err;
 
 	LOG_INF("ISO Channel %p connected", chan);
+
+	err = bt_iso_chan_get_info(chan, &info);
+	TEST_ASSERT(err == 0, "Failed to get BIS info: %d", err);
+
+	TEST_ASSERT(info.can_recv);
+	TEST_ASSERT(!info.can_send);
+	TEST_ASSERT(info.type == BT_ISO_CHAN_TYPE_SYNC_RECEIVER);
+	TEST_ASSERT(IN_RANGE(info.iso_interval, BT_ISO_ISO_INTERVAL_MIN, BT_ISO_ISO_INTERVAL_MAX),
+		    "Invalid ISO interval 0x%04x", info.iso_interval);
+	TEST_ASSERT(IN_RANGE(info.max_subevent, BT_ISO_NSE_MIN, BT_ISO_NSE_MAX),
+		    "Invalid subevent number 0x%02x", info.max_subevent);
+	TEST_ASSERT(IN_RANGE(info.sync_receiver.latency, BT_HCI_LE_TRANSPORT_LATENCY_BIG_MIN,
+			     BT_HCI_LE_TRANSPORT_LATENCY_BIG_MAX),
+		    "Invalid transport latency 0x%06x", info.sync_receiver.latency);
+	TEST_ASSERT((info.sync_receiver.pto % info.iso_interval) == 0U,
+		    "PTO in ms %u shall be a multiple of the ISO interval %u",
+		    info.sync_receiver.pto, info.iso_interval);
+	TEST_ASSERT(IN_RANGE((info.sync_receiver.pto / info.iso_interval), BT_ISO_PTO_MIN,
+			     BT_ISO_PTO_MAX),
+		    "Invalid PTO 0x%x", (info.sync_receiver.pto / info.iso_interval));
+	TEST_ASSERT(IN_RANGE(info.sync_receiver.bn, BT_ISO_BN_MIN, BT_ISO_BN_MAX),
+		    "Invalid BN 0x%02x", info.sync_receiver.bn);
+	TEST_ASSERT(IN_RANGE(info.sync_receiver.irc, BT_ISO_IRC_MIN, BT_ISO_IRC_MAX),
+		    "Invalid IRC 0x%02x", info.sync_receiver.irc);
 
 	SET_FLAG(flag_iso_connected);
 


### PR DESCRIPTION
Add validation of the info the application can retrieve by calling bt_iso_chan_get_info.