### PR TITLE
drivers: eth_nxp_enet: use net_if_carrier_off init

### DIFF
--- a/drivers/ethernet/nxp_enet/eth_nxp_enet.c
+++ b/drivers/ethernet/nxp_enet/eth_nxp_enet.c
@@ -262,7 +262,7 @@ static void eth_nxp_enet_iface_init(struct net_if *iface)
 #endif
 
 	ethernet_init(iface);
-	net_eth_carrier_off(data->iface);
+	net_if_carrier_off(data->iface);
 
 	config->irq_config_func();
 


### PR DESCRIPTION
Use net_if_carrier_off during iface init instead of net_eth_carrier_off, to immediately mark net if as down

Fixes #80824