### PR TITLE
doc: release/4.0: add bits about serial/UART and demand paging

### DIFF
--- a/doc/releases/migration-guide-4.0.rst
+++ b/doc/releases/migration-guide-4.0.rst
@@ -300,6 +300,8 @@ Serial
    can accept data bytes, instead of ``ret == 1``. The function now returns a lower bound on the
    number of bytes that can be provided to :c:func:`uart_fifo_fill` without truncation.
 
+ * LiteX: ``CONFIG_UART_LITEUART`` has been renamed to :kconfig:option:`CONFIG_UART_LITEX`.
+
 Regulator
 =========
 

--- a/doc/releases/release-notes-4.0.rst
+++ b/doc/releases/release-notes-4.0.rst
@@ -410,6 +410,9 @@ Drivers and Sensors
   * LiteX: Renamed the ``compatible`` from ``litex,uart0`` to :dtcompatible:`litex,uart`.
   * Nordic: Removed ``CONFIG_UART_n_GPIO_MANAGEMENT`` Kconfig options (where n is an instance
     index) which had no use after pinctrl driver was introduced.
+  * NS16550: Added support for Synopsys Designware 8250 UART.
+  * Renesas: Added support for SCI UART.
+  * Sensry: Added UART support for Ganymed SY1XX.
 
 * SPI
 

--- a/doc/releases/release-notes-4.0.rst
+++ b/doc/releases/release-notes-4.0.rst
@@ -79,6 +79,8 @@ Architectures
 
   * Added initial support for :c:func:`arch_stack_walk` that supports unwinding via esf only
 
+  * Added support for demand paging.
+
 * RISC-V
 
   * The stack traces upon fatal exception now prints the address of stack pointer (sp) or frame
@@ -501,6 +503,8 @@ Libraries / Subsystems
 * Debug
 
 * Demand Paging
+
+  * Added LRU (Least Recently Used) eviction algorithm.
 
 * Formatted output
 


### PR DESCRIPTION
Add some bits about serial/UART and demand paging in the release note and migration notes for 4.0.