### PR TITLE
MAINTAINERS: remove duplicate soc/cdns/dc233c

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -5250,7 +5250,6 @@ Xtensa arch:
     - boards/qemu/xtensa/
     - boards/cdns/xt-sim/
     - soc/cdns/dc233c/
-    - soc/cdns/dc233c/
     - soc/cdns/xtensa_sample_controller/
     - tests/arch/xtensa/
   labels:


### PR DESCRIPTION
This removes the duplicate soc/cdns/dc233c paths from the Xtensa arch.