### PR TITLE
soc: mcxw: Fix CONFIG_NUM_IRQS to not incude last reserved irq

### DIFF
--- a/soc/nxp/mcx/mcxw/Kconfig.defconfig
+++ b/soc/nxp/mcx/mcxw/Kconfig.defconfig
@@ -4,7 +4,7 @@
 if SOC_SERIES_MCXW
 
 config NUM_IRQS
-	default 76
+	default 75
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default 96000000 if CORTEX_M_SYSTICK


### PR DESCRIPTION
Fixes #79837
The FRDM_MCXW71 Platform has a reserved IRQ as its last IRQ in the NVIC, this test was using this IRQ to test an interrupt and would not fire. This change
ensures the test does not use the reserved IRQ.
