### PR TITLE
tests: drivers: ipm: Fix drivers.ipc.mailbox

### DIFF
--- a/tests/drivers/ipm/src/main.c
+++ b/tests/drivers/ipm/src/main.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Intel Corporation
+ * Copyright (c) 2015-2024 Intel Corporation
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -34,7 +34,7 @@ extern struct ipm_driver_api ipm_dummy_api;
 struct ipm_dummy_driver_data ipm_dummy0_driver_data;
 DEVICE_DEFINE(ipm_dummy0, "ipm_dummy0", NULL,
 		NULL, &ipm_dummy0_driver_data, NULL,
-		POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
+		PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 		&ipm_dummy_api);
 
 /* Sending side of the console IPM driver, will forward anything sent
@@ -81,24 +81,35 @@ int main(void)
 	int rv, i;
 	const struct device *ipm;
 
+	rv = TC_PASS;
+
 	TC_SUITE_START("test_ipm");
 	ipm = device_get_binding("ipm_dummy0");
+	if (ipm == NULL) {
+		TC_ERROR("unable to get device 'ipm_dummy0'\n");
+		rv = TC_FAIL;
+	} else {
+		/* Try sending a raw string to the IPM device to show that the
+		 * receiver works
+		 */
+		int rc = 0;
 
-	/* Try sending a raw string to the IPM device to show that the
-	 * receiver works
-	 */
-	for (i = 0; i < strlen(thestr); i++) {
-		ipm_send(ipm, 1, thestr[i], NULL, 0);
+		for (i = 0; i < strlen(thestr) && rc == 0; i++) {
+			rc = ipm_send(ipm, 1, thestr[i], NULL, 0);
+		}
+		if (rc) {
+			TC_ERROR("ipm_send() error=%u\n", rc);
+			rv = TC_FAIL;
+		} else {
+			/* Now do this through printf() to exercise the sender */
+			/* I will be split to lines of LINE_BUF_SIZE           */
+			printf(LOREM_IPSUM_SHORT "\n");
+		}
 	}
-
-	/* Now do this through printf() to exercise the sender */
-	printf(LOREM_IPSUM_SHORT "\n");
-
-	/* XXX how to tell if something was actually printed out for
-	 * automation purposes?
+	/* Twister Console Harness checks the output actually printed out for
+	 * automation purposes.
 	 */
 
-	rv = TC_PASS;
 	TC_END_RESULT(rv);
 	TC_SUITE_END("test_ipm", rv);
 	TC_END_REPORT(rv);

--- a/tests/drivers/ipm/testcase.yaml
+++ b/tests/drivers/ipm/testcase.yaml
@@ -8,3 +8,22 @@ tests:
       - ipc
     integration_platforms:
       - qemu_x86
+    harness: console
+    harness_config:
+      type: multi_line
+      ordered: true
+      regex:
+        - "Running TESTSUITE test_ipm"
+        - "ipm_console: 'everything is awesome'"
+        - "ipm_console: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, \
+           sed do eiusmod tempor '"
+        - "ipm_console: 'incididunt ut labore et dolore magna aliqua. Ut enim ad \
+           minim veniam, quis nost'"
+        - "ipm_console: 'rud exercitation ullamco laboris nisi ut aliquip ex ea commodo \
+           consequat. Duis '"
+        - "ipm_console: 'aute irure dolor in reprehenderit in voluptate velit esse cillum \
+           dolore eu fugi'"
+        - "ipm_console: 'at nulla pariatur. Excepteur sint occaecat cupidatat non proident, \
+           sunt in culp'"
+        - "ipm_console: 'a qui officia deserunt mollit anim id est laborum.'"
+        - "TESTSUITE test_ipm succeeded"


### PR DESCRIPTION
Fix `drivers.ipc.mailbox` test suite to restore and improve its testing functionality:

 * fix printf() redirection through IPM console.

 * fix and check the dummy driver initialization.

 * specify correct Twister harness type (Console) and use matching patterns to recognize the expected console output.

Before the fix: `./scripts/twister -p qemu_x86 -T tests/drivers/ipm`
```
QEMU (2848302): Booting from ROM..                                                              
QEMU (2848302): unable to bind IPM console sender to 'ipm_dummy0'                               
QEMU (2848302): *** Booting Zephyr OS build v3.7.0-4704-g04dfd54eeb00 ***                       
QEMU (2848302): Running TESTSUITE test_ipm                                                      
QEMU (2848302): ===================================================================             
QEMU (2848302): ipm_console: 'everything is awesome'                                            
QEMU (2848302): TESTSUITE test_ipm succeeded                                                    
QEMU (2848302): ===================================================================             
QEMU (2848302): PROJECT EXECUTION SUCCESSFUL                                                    
not a ztest and no state for drivers.ipc.mailbox                                                
```
with the fix:
```
QEMU (2851700): Booting from ROM..
QEMU (2851700): *** Booting Zephyr OS build v4.0.0-rc2-103-g157180d515e6 ***
QEMU (2851700): Running TESTSUITE test_ipm
QEMU (2851700): ===================================================================
QEMU (2851700): ipm_console: 'everything is awesome'
QEMU (2851700): ipm_console: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor '
QEMU (2851700): ipm_console: 'incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nost'
QEMU (2851700): ipm_console: 'rud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis '
QEMU (2851700): ipm_console: 'aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugi'
QEMU (2851700): ipm_console: 'at nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culp'
QEMU (2851700): ipm_console: 'a qui officia deserunt mollit anim id est laborum.'
QEMU (2851700): TESTSUITE test_ipm succeeded
QEMU (2851700): ===================================================================
QEMU (2851700): PROJECT EXECUTION SUCCESSFUL
```