### PR TITLE
Revert "tinycrypt: deprecate the library"

### DIFF
--- a/doc/releases/migration-guide-4.0.rst
+++ b/doc/releases/migration-guide-4.0.rst
@@ -75,19 +75,6 @@ Mbed TLS
   corresponding build symbol was removed in Mbed TLS 3.1.0 and is now assumed to
   be enabled. (:github:`77657`)
 
-TinyCrypt
-=========
-
-* Starting from this release the library is marked as deprecated (:github:`79566`).
-  The reasons for this are (:github:`43712``):
-
-  * the upstream version of this library is unmaintained.
-
-  * to reduce the number of crypto libraries available in Zephyr (currently there are
-    3 different implementations: TinyCrypt, MbedTLS and PSA Crypto APIs).
-
-  The PSA Crypto API is now the de-facto standard to perform crypto operations.
-
 Trusted Firmware-M
 ==================
 

--- a/doc/releases/migration-guide-4.0.rst
+++ b/doc/releases/migration-guide-4.0.rst
@@ -75,6 +75,12 @@ Mbed TLS
   corresponding build symbol was removed in Mbed TLS 3.1.0 and is now assumed to
   be enabled. (:github:`77657`)
 
+TinyCrypt
+=========
+
+Albeit the formal deprecation of TinyCrypt is not started yet, its removal from
+the Zephyr codebase is. Formal deprecation will happen in the next release.
+
 Trusted Firmware-M
 ==================
 

--- a/doc/releases/release-notes-4.0.rst
+++ b/doc/releases/release-notes-4.0.rst
@@ -58,16 +58,6 @@ Deprecated in this release
 
 * The :ref:`kscan_api` subsystem has been marked as deprecated.
 
-* The TinyCrypt library was marked as deprecated (:github:`79566`). The reasons
-  for this are (:github:`43712``):
-
-  * the upstream version of this library is unmaintained.
-
-  * to reduce the number of crypto libraries available in Zephyr (currently there are
-    3 different implementations: TinyCrypt, MbedTLS and PSA Crypto APIs).
-
-  The PSA Crypto API is now the de-facto standard to perform crypto operations.
-
 Architectures
 *************
 

--- a/modules/Kconfig.tinycrypt
+++ b/modules/Kconfig.tinycrypt
@@ -9,7 +9,6 @@ config ZEPHYR_TINYCRYPT_MODULE
 config TINYCRYPT
 	bool "TinyCrypt Support"
 	depends on ZEPHYR_TINYCRYPT_MODULE
-	select DEPRECATED
 	help
 	  This option enables the TinyCrypt cryptography library.
 


### PR DESCRIPTION
This reverts commit 5e225e0c8b2fb1ceb290fe91170b0e2d5bc46259.

Based on #79931 and TSC discussions, it was decided that TinyCrypt will be deprecated *AFTER* 4.0.