### PR TITLE
Xtensa C++ Exception Handling Support

### DIFF
--- a/cmake/compiler/xcc/target.cmake
+++ b/cmake/compiler/xcc/target.cmake
@@ -40,6 +40,17 @@ foreach(file_name include/stddef.h include-fixed/limits.h)
   list(APPEND NOSTDINC ${_OUTPUT})
 endforeach()
 
+# This libgcc code is partially duplicated in compiler/*/target.cmake
+execute_process(
+  COMMAND ${CMAKE_C_COMPILER} ${TOOLCHAIN_C_FLAGS} --print-libgcc-file-name
+  OUTPUT_VARIABLE LIBGCC_FILE_NAME
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+
+get_filename_component(LIBGCC_DIR ${LIBGCC_FILE_NAME} DIRECTORY)
+
+list(APPEND LIB_INCLUDE_DIR "-L\"${LIBGCC_DIR}\"")
+
 # For CMake to be able to test if a compiler flag is supported by the
 # toolchain we need to give CMake the necessary flags to compile and
 # link a dummy C file.


### PR DESCRIPTION
In order to compile with C++ exception handling for xtensa, the libgcc location needs to be known. This change uses the same logic from gcc's target.cmake to query the compiler for libgcc location and add the lib to the include list