### PR TITLE
soc: nxp: imx95: A55: enable SDK cache driver

### DIFF
--- a/soc/nxp/imx/imx9/imx95/Kconfig
+++ b/soc/nxp/imx/imx9/imx95/Kconfig
@@ -18,6 +18,7 @@ config SOC_MIMX9596_A55
 	select CPU_CORTEX_A55
 	select ARM_ARCH_TIMER if SYS_CLOCK_EXISTS
 	select HAS_MCUX
+	select HAS_MCUX_CACHE
 
 config MCUX_CORE_SUFFIX
 	default "_cm7" if SOC_MIMX9596_M7


### PR DESCRIPTION
Enable the SDK cache driver for A core.