### PR TITLE
doc: release: 4.0: mention LLEXT for ARM64

### DIFF
--- a/doc/releases/release-notes-4.0.rst
+++ b/doc/releases/release-notes-4.0.rst
@@ -81,6 +81,8 @@ Architectures
 
   * Added support for demand paging.
 
+  * Added support for Linkable Loadable Extensions (LLEXT).
+
 * RISC-V
 
   * The stack traces upon fatal exception now prints the address of stack pointer (sp) or frame


### PR DESCRIPTION
Mention LLEXT for ARM64 in the release notes.
