### PR TITLE
kernel/smp: add a Kconfig to disable validation of `_current_cpu`

### DIFF
--- a/include/zephyr/kernel_structs.h
+++ b/include/zephyr/kernel_structs.h
@@ -258,8 +258,11 @@ extern atomic_t _cpus_active;
  */
 bool z_smp_cpu_mobile(void);
 
-#define _current_cpu ({ __ASSERT_NO_MSG(!z_smp_cpu_mobile()); \
-			arch_curr_cpu(); })
+#define _current_cpu                                                                               \
+	({                                                                                         \
+		IF_ENABLED(CONFIG_CURRENT_CPU_VALIDATE, (__ASSERT_NO_MSG(!z_smp_cpu_mobile())));   \
+		arch_curr_cpu();                                                                   \
+	})
 #define _current k_sched_current_thread_query()
 
 #else

--- a/kernel/Kconfig.smp
+++ b/kernel/Kconfig.smp
@@ -126,4 +126,12 @@ config TICKET_SPINLOCKS
 	  which resolves such unfairness issue at the cost of slightly
 	  increased memory footprint.
 
+config CURRENT_CPU_VALIDATE
+	bool "Validate usage of _current_cpu"
+	depends on SMP && ASSERT
+	default y if MP_MAX_NUM_CPUS > 1
+	help
+	  The `_current_cpu` pointer should only ever be used in non-preemptible
+	  contexts. When assertions are enabled in SMP systems, this option guarantees
+	  correct `_current_cpu` usage with runtime checks.
 endmenu


### PR DESCRIPTION
The assert validation was added in eefd3da to ensure that `_current_cpu` is used safely. However, since `_current_cpu` is used frequently in the kernel/scheduler, especially when SMP is enabled, the assertion has a negative impact on the performance.

This commit introduces a Kconfig to disable just the assert validation of the `_current_cpu`, without having to disable `CONFIG_ASSERT` entirely.

___

# Benchmark

<details>
  <summary>Show</summary>

  ## latency_measure
  ![newplot](https://github.com/user-attachments/assets/562ce348-0da9-47fd-9971-a340a7570a59)
  ![newplot (1)](https://github.com/user-attachments/assets/19db418f-df5e-4681-9be4-9a2dbe415ca7)
  ![newplot (2)](https://github.com/user-attachments/assets/a5c29d60-a163-42d0-aac1-cb263f7ce798)
  ![newplot (3)](https://github.com/user-attachments/assets/be8c8279-4bab-4d6f-a0ce-f60801a33a3d)
  ![newplot (4)](https://github.com/user-attachments/assets/1f8b08b6-447b-44ac-ae1b-1f07d145dba2)
  ![newplot (5)](https://github.com/user-attachments/assets/1307524c-6016-4838-9a7e-1c6d7c6eb8d0)

  ## scheduler
  ![newplot (6)](https://github.com/user-attachments/assets/56c67979-634e-4fbd-b22e-60f842ed4c50)
  ![newplot (7)](https://github.com/user-attachments/assets/f075705e-e053-4b92-a253-1ee8c3ac16bc)
  ![newplot (8)](https://github.com/user-attachments/assets/3beff993-6b2c-4119-a6c1-750fd569eac6)

  ## sys_kernel
  ![newplot (9)](https://github.com/user-attachments/assets/70c62b30-735e-438d-bdf0-cc1b5c429735)
  ![newplot (10)](https://github.com/user-attachments/assets/26f478e6-2f67-491c-b182-f2591a07420f)

</details>
