### PR TITLE
tests: sched: Add busy threads for SMP

### DIFF
--- a/tests/benchmarks/sched/boards/intel_adsp_ace15_mtpm_sim.conf
+++ b/tests/benchmarks/sched/boards/intel_adsp_ace15_mtpm_sim.conf
@@ -1,0 +1,6 @@
+# Due to addition of busy threads running on other cores,
+# and the simulator runs in single thread bouncing through
+# all cores, we are wasting quite a bit of time just busy
+# waiting. This makes each simulator run too long for CI.
+# So limit CPU number to 1.
+CONFIG_MP_MAX_NUM_CPUS=1

--- a/tests/benchmarks/sched/boards/intel_adsp_ace20_lnl_sim.conf
+++ b/tests/benchmarks/sched/boards/intel_adsp_ace20_lnl_sim.conf
@@ -1,0 +1,6 @@
+# Due to addition of busy threads running on other cores,
+# and the simulator runs in single thread bouncing through
+# all cores, we are wasting quite a bit of time just busy
+# waiting. This makes each simulator run too long for CI.
+# So limit CPU number to 1.
+CONFIG_MP_MAX_NUM_CPUS=1

--- a/tests/benchmarks/sched/boards/intel_adsp_ace30_ptl_sim.conf
+++ b/tests/benchmarks/sched/boards/intel_adsp_ace30_ptl_sim.conf
@@ -1,0 +1,6 @@
+# Due to addition of busy threads running on other cores,
+# and the simulator runs in single thread bouncing through
+# all cores, we are wasting quite a bit of time just busy
+# waiting. This makes each simulator run too long for CI.
+# So limit CPU number to 1.
+CONFIG_MP_MAX_NUM_CPUS=1


### PR DESCRIPTION
Basically the same idea as #77038

The sched benchmark is designed for systems with a single CPU. Otherwise, the timestamps would be wrong when the partner thread is scheduled on another CPU, i.e. negative values:

```
unpend   63 ready   62 switch -16562 pend 18937 tot 2500 (avg  928)
```

When the system allows for multiple CPUs, spawn a non-preemptible thread to keep the other CPUs busy.