### PR TITLE
soc: Remove re-defining some defined types

### DIFF
--- a/soc/atmel/sam0/samd51/Kconfig.defconfig
+++ b/soc/atmel/sam0/samd51/Kconfig.defconfig
@@ -7,7 +7,6 @@
 if SOC_SERIES_SAMD51
 
 config NUM_IRQS
-	int
 	default 137
 
 config ROM_START_OFFSET

--- a/soc/brcm/bcm2711/Kconfig.defconfig
+++ b/soc/brcm/bcm2711/Kconfig.defconfig
@@ -4,11 +4,9 @@
 if SOC_BCM2711
 
 config NUM_IRQS
-	int
 	default 260
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
-	int
 	default 54000000
 
 endif

--- a/soc/brcm/bcm2712/Kconfig.defconfig
+++ b/soc/brcm/bcm2712/Kconfig.defconfig
@@ -4,11 +4,9 @@
 if SOC_BCM2712
 
 config NUM_IRQS
-	int
 	default 280
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
-	int
 	default 54000000
 
 endif

--- a/soc/brcm/bcmvk/valkyrie/Kconfig.defconfig
+++ b/soc/brcm/bcmvk/valkyrie/Kconfig.defconfig
@@ -6,11 +6,9 @@
 if SOC_SERIES_VALKYRIE
 
 config NUM_IRQS
-	int
 	default 240
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
-	int
 	default 500000000
 
 endif # SOC_SERIES_VALKYRIE

--- a/soc/brcm/bcmvk/viper/Kconfig.defconfig.viper_bcm58402_a72
+++ b/soc/brcm/bcmvk/viper/Kconfig.defconfig.viper_bcm58402_a72
@@ -4,11 +4,9 @@
 if SOC_BCM58402_A72
 
 config NUM_IRQS
-	int
 	default 260
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
-	int
 	default 25000000
 
 endif

--- a/soc/brcm/bcmvk/viper/Kconfig.defconfig.viper_bcm58402_m7
+++ b/soc/brcm/bcmvk/viper/Kconfig.defconfig.viper_bcm58402_m7
@@ -4,11 +4,9 @@
 if SOC_BCM58402_M7
 
 config NUM_IRQS
-	int
 	default 240
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
-	int
 	default 500000000
 
 endif

--- a/soc/efinix/sapphire/Kconfig.defconfig
+++ b/soc/efinix/sapphire/Kconfig.defconfig
@@ -7,11 +7,9 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default 100000000
 
 config RISCV_SOC_INTERRUPT_INIT
-	bool
 	default y
 
 config NUM_IRQS
-	int
 	default 36
 
 config 2ND_LVL_INTR_00_OFFSET

--- a/soc/gaisler/gr716a/Kconfig.defconfig
+++ b/soc/gaisler/gr716a/Kconfig.defconfig
@@ -7,7 +7,6 @@ config SPARC_NWIN
 	default 31
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
-	int
 	default 50000000
 
 if FLASH

--- a/soc/intel/intel_socfpga/agilex/Kconfig.defconfig.agilex
+++ b/soc/intel/intel_socfpga/agilex/Kconfig.defconfig.agilex
@@ -6,11 +6,9 @@ if SOC_AGILEX
 # must be >= the highest interrupt number used
 # - include the UART interrupts 173 or 204
 config NUM_IRQS
-	int
 	default 205
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
-	int
 	default 25000000
 
 config KERNEL_VM_SIZE

--- a/soc/intel/intel_socfpga/agilex5/Kconfig.defconfig.agilex5
+++ b/soc/intel/intel_socfpga/agilex5/Kconfig.defconfig.agilex5
@@ -6,11 +6,9 @@ if SOC_AGILEX5
 # must be >= the highest interrupt number used
 # - include the UART interrupts 173 or 274
 config NUM_IRQS
-	int
 	default 274
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
-	int
 	default 400000000
 
 config KERNEL_VM_SIZE

--- a/soc/intel/intel_socfpga_std/cyclonev/Kconfig.defconfig.cyclonev
+++ b/soc/intel/intel_socfpga_std/cyclonev/Kconfig.defconfig.cyclonev
@@ -4,11 +4,9 @@
 if SOC_CYCLONEV
 
 config NUM_IRQS
-	int
 	default 211
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
-	int
 	default 231250000
 
 endif

--- a/soc/nordic/nrf52/Kconfig.defconfig.nrf52820_QDAA
+++ b/soc/nordic/nrf52/Kconfig.defconfig.nrf52820_QDAA
@@ -6,7 +6,6 @@
 if SOC_NRF52820_QDAA
 
 config NUM_IRQS
-	int
 	default 40
 
 endif # SOC_NRF52820_QDAA

--- a/soc/nordic/nrf52/Kconfig.defconfig.nrf52833_QDAA
+++ b/soc/nordic/nrf52/Kconfig.defconfig.nrf52833_QDAA
@@ -6,7 +6,6 @@
 if SOC_NRF52833_QDAA
 
 config NUM_IRQS
-	int
 	default 48
 
 endif # SOC_NRF52833_QDAA

--- a/soc/nordic/nrf52/Kconfig.defconfig.nrf52833_QIAA
+++ b/soc/nordic/nrf52/Kconfig.defconfig.nrf52833_QIAA
@@ -6,7 +6,6 @@
 if SOC_NRF52833_QIAA
 
 config NUM_IRQS
-	int
 	default 48
 
 endif # SOC_NRF52833_QIAA

--- a/soc/nxp/imx/imx8m/Kconfig.defconfig.mimx8ml8_a53
+++ b/soc/nxp/imx/imx8m/Kconfig.defconfig.mimx8ml8_a53
@@ -13,11 +13,9 @@ config FLASH_BASE_ADDRESS
 	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_FLASH))
 
 config NUM_IRQS
-	int
 	default 240
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
-	int
 	default 8000000
 
 config PINCTRL_IMX

--- a/soc/nxp/imx/imx8m/Kconfig.defconfig.mimx8ml8_m7
+++ b/soc/nxp/imx/imx8m/Kconfig.defconfig.mimx8ml8_m7
@@ -7,7 +7,6 @@
 if SOC_MIMX8ML8_M7
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
-	int
 	default 800000000
 
 config GPIO
@@ -38,7 +37,6 @@ config FLASH_BASE_ADDRESS
 endif # CODE_DDR
 
 config NUM_IRQS
-	int
 	# must be >= the highest interrupt number used
 	default 159
 

--- a/soc/nxp/imx/imx8m/Kconfig.defconfig.mimx8mm6_a53
+++ b/soc/nxp/imx/imx8m/Kconfig.defconfig.mimx8mm6_a53
@@ -13,11 +13,9 @@ config FLASH_BASE_ADDRESS
 	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_FLASH))
 
 config NUM_IRQS
-	int
 	default 240
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
-	int
 	default 8000000
 
 config PINCTRL_IMX

--- a/soc/nxp/imx/imx8m/Kconfig.defconfig.mimx8mm6_m4
+++ b/soc/nxp/imx/imx8m/Kconfig.defconfig.mimx8mm6_m4
@@ -7,7 +7,6 @@
 if SOC_MIMX8MM6_M4
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
-	int
 	default 400000000
 
 config IPM_IMX
@@ -15,7 +14,6 @@ config IPM_IMX
 	depends on IPM
 
 config NUM_IRQS
-	int
 	# must be >= the highest interrupt number used
 	default 127
 

--- a/soc/nxp/imx/imx8m/Kconfig.defconfig.mimx8mn6_a53
+++ b/soc/nxp/imx/imx8m/Kconfig.defconfig.mimx8mn6_a53
@@ -13,11 +13,9 @@ config FLASH_BASE_ADDRESS
 	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_FLASH))
 
 config NUM_IRQS
-	int
 	default 240
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
-	int
 	default 8000000
 
 config PINCTRL_IMX

--- a/soc/nxp/imx/imx8m/Kconfig.defconfig.mimx8mq6_m4
+++ b/soc/nxp/imx/imx8m/Kconfig.defconfig.mimx8mq6_m4
@@ -7,7 +7,6 @@
 if SOC_MIMX8MQ6_M4
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
-	int
 	default 266000000
 
 config PINCTRL_IMX
@@ -15,7 +14,6 @@ config PINCTRL_IMX
 	depends on PINCTRL
 
 config NUM_IRQS
-	int
 	# must be >= the highest interrupt number used
 	default 127
 

--- a/soc/nxp/imx/imx9/imx93/Kconfig.defconfig.mimx93.a55
+++ b/soc/nxp/imx/imx9/imx93/Kconfig.defconfig.mimx93.a55
@@ -13,11 +13,9 @@ config FLASH_BASE_ADDRESS
 	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_FLASH))
 
 config NUM_IRQS
-	int
 	default 240
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
-	int
 	default 24000000
 
 config PINCTRL_IMX

--- a/soc/nxp/imx/imx9/imx93/Kconfig.defconfig.mimx93.m33
+++ b/soc/nxp/imx/imx9/imx93/Kconfig.defconfig.mimx93.m33
@@ -12,11 +12,9 @@ config FLASH_BASE_ADDRESS
 	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_FLASH))
 
 config NUM_IRQS
-	int
 	default 268
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
-	int
 	default 200000000
 
 endif

--- a/soc/nxp/imx/imx9/imx95/Kconfig.defconfig.mimx95.a55
+++ b/soc/nxp/imx/imx9/imx95/Kconfig.defconfig.mimx95.a55
@@ -13,11 +13,9 @@ config FLASH_BASE_ADDRESS
 	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_FLASH))
 
 config NUM_IRQS
-	int
 	default 320
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
-	int
 	default 24000000
 
 endif

--- a/soc/nxp/imx/imx9/imx95/Kconfig.defconfig.mimx95.m7
+++ b/soc/nxp/imx/imx9/imx95/Kconfig.defconfig.mimx95.m7
@@ -12,11 +12,9 @@ config FLASH_BASE_ADDRESS
 	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_FLASH))
 
 config NUM_IRQS
-	int
 	default 230
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
-	int
 	default 800000000
 
 config CACHE_MANAGEMENT

--- a/soc/nxp/imxrt/Kconfig.defconfig
+++ b/soc/nxp/imxrt/Kconfig.defconfig
@@ -95,7 +95,6 @@ if MBEDTLS
 # what the ztest_thread_stack defaults to.
 #
 config TEST_EXTRA_STACK_SIZE
-	int
 	default 1024
 endif # MBEDTLS
 

--- a/soc/nxp/imxrt/imxrt5xx/Kconfig.defconfig
+++ b/soc/nxp/imxrt/imxrt5xx/Kconfig.defconfig
@@ -30,7 +30,6 @@ if MBEDTLS
 # what the ztest_thread_stack defaults to.
 #
 config TEST_EXTRA_STACK_SIZE
-	int
 	default 1024
 endif # MBEDTLS
 

--- a/soc/nxp/imxrt/imxrt6xx/Kconfig.defconfig
+++ b/soc/nxp/imxrt/imxrt6xx/Kconfig.defconfig
@@ -48,7 +48,6 @@ if MBEDTLS
 # what the ztest_thread_stack defaults to.
 #
 config TEST_EXTRA_STACK_SIZE
-	int
 	default 1024
 endif # MBEDTLS
 

--- a/soc/nxp/layerscape/ls1046a/Kconfig.defconfig
+++ b/soc/nxp/layerscape/ls1046a/Kconfig.defconfig
@@ -7,7 +7,6 @@
 if SOC_LS1046A
 
 config NUM_IRQS
-	int
 	default 240
 
 config FLASH_SIZE

--- a/soc/rockchip/rk3399/Kconfig.defconfig.rk3399
+++ b/soc/rockchip/rk3399/Kconfig.defconfig.rk3399
@@ -7,7 +7,6 @@
 if SOC_RK3399
 
 config NUM_IRQS
-	int
 	default 240
 
 config FLASH_SIZE

--- a/soc/rockchip/rk3568/Kconfig.defconfig.rk3568
+++ b/soc/rockchip/rk3568/Kconfig.defconfig.rk3568
@@ -11,11 +11,9 @@ config FLASH_BASE_ADDRESS
 	default 0
 
 config NUM_IRQS
-	int
 	default 240
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
-	int
 	default 24000000
 
 endif

--- a/soc/silabs/silabs_s1/efm32gg11b/Kconfig.defconfig
+++ b/soc/silabs/silabs_s1/efm32gg11b/Kconfig.defconfig
@@ -5,7 +5,6 @@
 if SOC_SERIES_EFM32GG11B
 
 config NUM_IRQS
-	int
 	# must be >= the highest interrupt number used
 	default 68
 

--- a/soc/silabs/silabs_s1/efm32gg12b/Kconfig.defconfig
+++ b/soc/silabs/silabs_s1/efm32gg12b/Kconfig.defconfig
@@ -4,7 +4,6 @@
 if SOC_SERIES_EFM32GG12B
 
 config NUM_IRQS
-	int
 	# must be >= the highest interrupt number used
 	default 68
 

--- a/soc/silabs/silabs_s2/efr32mg21/Kconfig.defconfig
+++ b/soc/silabs/silabs_s2/efr32mg21/Kconfig.defconfig
@@ -4,7 +4,6 @@
 if SOC_SERIES_EFR32MG21
 
 config NUM_IRQS
-	int
 	# must be >= the highest interrupt number used
 	default 61
 

--- a/soc/silabs/silabs_sim3/sim3u/Kconfig.defconfig
+++ b/soc/silabs/silabs_sim3/sim3u/Kconfig.defconfig
@@ -10,7 +10,6 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default $(dt_node_int_prop_int,/cpus/cpu@0,clock-frequency)
 
 config NUM_IRQS
-	int
 	# must be >= the highest interrupt number used
 	default 53
 

--- a/soc/snps/qemu_arc/Kconfig.defconfig
+++ b/soc/snps/qemu_arc/Kconfig.defconfig
@@ -4,7 +4,6 @@
 if SOC_QEMU_ARC
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
-	int
 	default 10000000
 
 config RGF_NUM_BANKS

--- a/soc/st/stm32/stm32f1x/Kconfig.defconfig.stm32f105xx
+++ b/soc/st/stm32/stm32f1x/Kconfig.defconfig.stm32f105xx
@@ -6,7 +6,6 @@
 if SOC_STM32F105XC || SOC_STM32F105XB
 
 config NUM_IRQS
-	int
 	default 68
 
 endif # SOC_STM32F105XC || STM32F105XB

--- a/soc/st/stm32/stm32l1x/Kconfig.defconfig.stm32l152xc
+++ b/soc/st/stm32/stm32l1x/Kconfig.defconfig.stm32l152xc
@@ -6,7 +6,6 @@
 if SOC_STM32L152XC
 
 config NUM_IRQS
-	int
 	default 57
 
 endif # SOC_STM32L152XC

--- a/soc/st/stm32/stm32l1x/Kconfig.defconfig.stm32l152xe
+++ b/soc/st/stm32/stm32l1x/Kconfig.defconfig.stm32l152xe
@@ -6,7 +6,6 @@
 if SOC_STM32L152XE
 
 config NUM_IRQS
-	int
 	default 57
 
 endif # SOC_STM32L152XE

--- a/soc/telink/tlsr/tlsr951x/Kconfig.defconfig
+++ b/soc/telink/tlsr/tlsr951x/Kconfig.defconfig
@@ -4,38 +4,30 @@
 if SOC_SERIES_TLSR951X
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
-	int
 	default 32000
 
 config RISCV_SOC_INTERRUPT_INIT
-	bool
 	default y
 
 config RISCV_GP
-	bool
 	default y
 
 config NUM_IRQS
-	int
 	default 64
 
 config PINCTRL
 	default y
 
 config XIP
-	bool
 	default n
 
 config MAIN_STACK_SIZE
-	int
 	default 2048
 
 config IDLE_STACK_SIZE
-	int
 	default 1536
 
 config TEST_EXTRA_STACK_SIZE
-	int
 	default 1024
 
 config 2ND_LVL_INTR_00_OFFSET

--- a/soc/ti/k3/am6x/Kconfig.defconfig
+++ b/soc/ti/k3/am6x/Kconfig.defconfig
@@ -16,13 +16,11 @@ config FLASH_BASE_ADDRESS
 	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_FLASH))
 
 config NUM_IRQS
-	int
 	default 64 if SOC_SERIES_AM6X_M4
 	default 280 if SOC_SERIES_AM6X_A53
 	default 512 if SOC_SERIES_AM6X_R5
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
-	int
 	default 400000000 if SOC_SERIES_AM6X_M4
 	default 200000000 if SOC_SERIES_AM6X_A53
 	default 19200000 if SOC_SERIES_AM6X_R5

--- a/soc/xen/Kconfig.defconfig
+++ b/soc/xen/Kconfig.defconfig
@@ -4,11 +4,9 @@
 if SOC_XENVM
 
 config NUM_IRQS
-	int
 	default 500
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
-	int
 	default 8320000
 
 # We need at least 16M of virtual address space to map memory of Xen node

--- a/soc/xlnx/zynq7000/Kconfig.defconfig
+++ b/soc/xlnx/zynq7000/Kconfig.defconfig
@@ -8,7 +8,6 @@ if SOC_FAMILY_XILINX_ZYNQ7000
 rsource "*/Kconfig.defconfig"
 
 config NUM_IRQS
-	int
 	# must be >= the highest interrupt number used
 	default 96
 


### PR DESCRIPTION
Removes re-defining some Kconfigs that are already defined e.g. in arch