### PR TITLE
soc: Fix wrong hwmv2 Kconfigs

### DIFF
--- a/soc/gd/gd32/gd32a50x/Kconfig.defconfig.series
+++ b/soc/gd/gd32/gd32a50x/Kconfig.defconfig.series
@@ -3,9 +3,6 @@
 
 if SOC_SERIES_GD32A50X
 
-config SOC_SERIES
-	default "gd32a50x"
-
 rsource "Kconfig.defconfig.gd32*"
 
 endif # SOC_SERIES_GD32A50X

--- a/soc/gd/gd32/gd32e10x/Kconfig.defconfig.series
+++ b/soc/gd/gd32/gd32e10x/Kconfig.defconfig.series
@@ -3,9 +3,6 @@
 
 if SOC_SERIES_GD32E10X
 
-config SOC_SERIES
-	default "gd32e10x"
-
 rsource "Kconfig.defconfig.gd32*"
 
 endif # SOC_SERIES_GD32E10X

--- a/soc/gd/gd32/gd32e50x/Kconfig.defconfig.series
+++ b/soc/gd/gd32/gd32e50x/Kconfig.defconfig.series
@@ -3,9 +3,6 @@
 
 if SOC_SERIES_GD32E50X
 
-config SOC_SERIES
-	default "gd32e50x"
-
 rsource "Kconfig.defconfig.gd32*"
 
 endif # SOC_SERIES_GD32E50X

--- a/soc/gd/gd32/gd32f3x0/Kconfig.defconfig.series
+++ b/soc/gd/gd32/gd32f3x0/Kconfig.defconfig.series
@@ -3,9 +3,6 @@
 
 if SOC_SERIES_GD32F3X0
 
-config SOC_SERIES
-	default "gd32f3x0"
-
 rsource "Kconfig.defconfig.gd32*"
 
 endif # SOC_SERIES_GD32F3X0

--- a/soc/gd/gd32/gd32f4xx/Kconfig.defconfig.series
+++ b/soc/gd/gd32/gd32f4xx/Kconfig.defconfig.series
@@ -3,9 +3,6 @@
 
 if SOC_SERIES_GD32F4XX
 
-config SOC_SERIES
-	default "gd32f4xx"
-
 rsource "Kconfig.defconfig.gd32*"
 
 endif # SOC_SERIES_GD32F4XX

--- a/soc/gd/gd32/gd32l23x/Kconfig.defconfig.series
+++ b/soc/gd/gd32/gd32l23x/Kconfig.defconfig.series
@@ -3,9 +3,6 @@
 
 if SOC_SERIES_GD32L23X
 
-config SOC_SERIES
-	default "gd32l23x"
-
 rsource "Kconfig.defconfig.gd32*"
 
 endif # SOC_SERIES_GD32L23X

--- a/soc/mediatek/mtk_adsp/Kconfig
+++ b/soc/mediatek/mtk_adsp/Kconfig
@@ -2,18 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config SOC_FAMILY_MTK_ADSP
-	bool
 	select XTENSA
 	select XTENSA_GEN_HANDLERS
-	help
-	  Mediatek MT8xxx Series Audio DSPs
-
-config SOC_SERIES_MT8195_ADSP
-	bool
-	select SOC_FAMILY_MTK_ADSP
-	help
-	  Mediatek MT8195 Audio DSP
-
-config SOC_MT8195_ADSP
-	bool
-	select SOC_SERIES_MT8195_ADSP

--- a/soc/mediatek/mtk_adsp/Kconfig.defconfig
+++ b/soc/mediatek/mtk_adsp/Kconfig.defconfig
@@ -5,9 +5,6 @@ orsource "*/Kconfig.defconfig"
 
 if SOC_FAMILY_MTK_ADSP
 
-config SOC_FAMILY
-	default "mtk_adsp"
-
 config INTC_MTK_ADSP
 	default y
 

--- a/soc/mediatek/mtk_adsp/Kconfig.soc
+++ b/soc/mediatek/mtk_adsp/Kconfig.soc
@@ -1,8 +1,26 @@
 # Copyright 2024 The ChromiumOS Authors
 # SPDX-License-Identifier: Apache-2.0
 
+config SOC_FAMILY_MTK_ADSP
+	bool
+	help
+	  Mediatek MT8xxx Series Audio DSPs
+
+config SOC_SERIES_MT8195_ADSP
+	bool
+	select SOC_FAMILY_MTK_ADSP
+	help
+	  Mediatek MT8195 Audio DSP
+
 config SOC_MT8195_ADSP
 	bool
+	select SOC_SERIES_MT8195_ADSP
+
+config SOC_FAMILY
+	default "mtk_adsp" if SOC_FAMILY_MTK_ADSP
+
+config SOC_SERIES
+	default "mt8195_adsp" if SOC_SERIES_MT8195_ADSP
 
 config SOC
 	default "mt8195_adsp" if SOC_MT8195_ADSP

--- a/soc/mediatek/mtk_adsp/mt8195_adsp/Kconfig.defconfig
+++ b/soc/mediatek/mtk_adsp/mt8195_adsp/Kconfig.defconfig
@@ -3,12 +3,6 @@
 
 if SOC_SERIES_MT8195_ADSP
 
-config SOC
-	default "mt8195_adsp"
-
-config SOC_SERIES
-	default "mt8195_adsp"
-
 config NUM_2ND_LEVEL_AGGREGATORS
 	default 2
 config 2ND_LVL_INTR_00_OFFSET

--- a/soc/nxp/imx/imx8m/Kconfig.defconfig.mimx8ml8_m7
+++ b/soc/nxp/imx/imx8m/Kconfig.defconfig.mimx8ml8_m7
@@ -6,10 +6,6 @@
 
 if SOC_MIMX8ML8_M7
 
-config SOC
-	string
-	default "mimx8ml8"
-
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	int
 	default 800000000


### PR DESCRIPTION
    Fixes Kconfigs for hwmv2 being defined in the wrong files