### PR TITLE
Drop IP packet if there is a fragmentation failure

### DIFF
--- a/subsys/net/ip/ipv4_fragment.c
+++ b/subsys/net/ip/ipv4_fragment.c
@@ -635,16 +635,15 @@ enum net_verdict net_ipv4_prepare_for_send(struct net_pkt *pkt)
 			if (ret < 0) {
 				LOG_DBG("Cannot fragment IPv4 pkt (%d)", ret);
 
-				if (ret == -ENOMEM || ret == -ENOBUFS || ret == -EPERM) {
-					/* Try to send the packet if we could not allocate enough
-					 * network packets or if the don't fragment flag is set
+				if (ret == -EPERM) {
+					/* Try to send the packet if the don't fragment flag is set
 					 * and hope the original large packet can be sent OK.
 					 */
 					goto ignore_frag_error;
-				} else {
-					/* Other error, drop the packet */
-					return NET_DROP;
 				}
+
+				/* Other error, drop the packet */
+				return NET_DROP;
 			}
 
 			/* We need to unref here because we simulate the packet being sent. */

--- a/subsys/net/ip/ipv6_nbr.c
+++ b/subsys/net/ip/ipv6_nbr.c
@@ -818,15 +818,7 @@ enum net_verdict net_ipv6_prepare_for_send(struct net_pkt *pkt)
 							   pkt, pkt_len);
 			if (ret < 0) {
 				NET_DBG("Cannot fragment IPv6 pkt (%d)", ret);
-
-				if (ret == -ENOMEM) {
-					/* Try to send the packet if we could
-					 * not allocate enough network packets
-					 * and hope the original large packet
-					 * can be sent ok.
-					 */
-					goto ignore_frag_error;
-				}
+				return NET_DROP;
 			}
 
 			/* We need to unref here because we simulate the packet
@@ -841,7 +833,6 @@ enum net_verdict net_ipv6_prepare_for_send(struct net_pkt *pkt)
 			return NET_CONTINUE;
 		}
 	}
-ignore_frag_error:
 #endif /* CONFIG_NET_IPV6_FRAGMENT */
 
 	/* If the IPv6 destination address is not link local, then try to get


### PR DESCRIPTION
If we could not fragment the IPv4 or IPv6 packet, then drop it and do not try to send it. Let the upper layer re-send the packet if needed. It is causing more trouble if we try to send the packet and not honor the MTU setting.

Fixes #81021
