### PR TITLE
tests: kernel: timer: timer_behavior: Adjust TIMER_TEST_SAMPLES

### DIFF
--- a/tests/kernel/timer/timer_behavior/Kconfig
+++ b/tests/kernel/timer/timer_behavior/Kconfig
@@ -10,11 +10,11 @@ source "Kconfig.zephyr"
 
 config TIMER_TEST_SAMPLES
 	int "The number of timer samples to gather for statistics"
-	default 1000 if (SRAM_SIZE < 24)
-	default 2000 if (SRAM_SIZE < 32)
-	default 3000 if (SRAM_SIZE < 48)
-	default 5000 if (SRAM_SIZE < 64)
-	default 7000 if (SRAM_SIZE < 96)
+	default 1000 if (SRAM_SIZE <= 24)
+	default 2000 if (SRAM_SIZE <= 32)
+	default 3000 if (SRAM_SIZE <= 48)
+	default 5000 if (SRAM_SIZE <= 64)
+	default 7000 if (SRAM_SIZE <= 96)
 	default 10000
 
 config TIMER_TEST_PERIOD


### PR DESCRIPTION
Adjust default number of test samples which is based on SRAM size. Test is using 8*TIMER_TEST_SAMPLES and with previous defaults for the device with 64k RAM it was using 56k of test data leaving only 8k RAM and that was easily not enough. Adjust conditions to take less samples when SRAM_SIZE is equal to the threshold.