### PR TITLE
twister: fix custom simulator dependencies

### DIFF
--- a/boards/intel/adsp/twister.yaml
+++ b/boards/intel/adsp/twister.yaml
@@ -20,16 +20,19 @@ variants:
   intel_adsp/ace20_lnl/sim:
     type: sim
     simulation: custom
+    simulation_exec: acesim
     testing:
       timeout_multiplier: 4
   intel_adsp/ace15_mtpm/sim:
     type: sim
     simulation: custom
+    simulation_exec: acesim
     testing:
       timeout_multiplier: 4
   intel_adsp/ace30/ptl/sim:
     type: sim
     simulation: custom
+    simulation_exec: acesim
     toolchain:
       - xt-clang
     testing:

--- a/scripts/pylib/twister/twisterlib/testinstance.py
+++ b/scripts/pylib/twister/twisterlib/testinstance.py
@@ -277,7 +277,7 @@ class TestInstance:
         if self.testsuite.harness == 'pytest':
             target_ready = bool(filter == 'runnable' or self.platform.simulation in SUPPORTED_SIMS_IN_PYTEST)
 
-        SUPPORTED_SIMS_WITH_EXEC = ['nsim', 'mdb-nsim', 'renode', 'tsim', 'native', 'simics']
+        SUPPORTED_SIMS_WITH_EXEC = ['nsim', 'mdb-nsim', 'renode', 'tsim', 'native', 'simics', 'custom']
         if filter != 'runnable' and \
                 self.platform.simulation in SUPPORTED_SIMS_WITH_EXEC and \
                 self.platform.simulation_exec:


### PR DESCRIPTION
- **twister: custom simulator needs an exec defined**
- **intel_adsp: set exec for simulator targets**
