### PR TITLE
Bluetooth: Host: Add conversion macros from ms to various units

### DIFF
--- a/include/zephyr/bluetooth/conn.h
+++ b/include/zephyr/bluetooth/conn.h
@@ -74,9 +74,9 @@ struct bt_le_conn_param {
  *    Latency: 0
  *    Timeout: 4 s
  */
-#define BT_LE_CONN_PARAM_DEFAULT BT_LE_CONN_PARAM(BT_GAP_INIT_CONN_INT_MIN, \
-						  BT_GAP_INIT_CONN_INT_MAX, \
-						  0, 400)
+#define BT_LE_CONN_PARAM_DEFAULT                                                                   \
+	BT_LE_CONN_PARAM(BT_GAP_INIT_CONN_INT_MIN, BT_GAP_INIT_CONN_INT_MAX, 0,                    \
+			 BT_GAP_MS_TO_CONN_TIMEOUT(4000))
 
 /** Connection PHY information for LE connections */
 struct bt_conn_le_phy_info {

--- a/include/zephyr/bluetooth/gap.h
+++ b/include/zephyr/bluetooth/gap.h
@@ -826,11 +826,224 @@ enum {
 #define BT_GAP_PER_ADV_MAX_INTERVAL             0xFFFF /* 81.91875 s */
 
 /**
+ * @brief Convert periodic advertising interval (N * 0.625 ms) to microseconds
+ *
+ * Value range of @p _interval is @ref BT_LE_ADV_INTERVAL_MIN to @ref BT_LE_ADV_INTERVAL_MAX
+ */
+#define BT_GAP_ADV_INTERVAL_TO_US(_interval) ((uint32_t)((_interval) * 625U))
+
+/**
+ * @brief Convert periodic advertising interval (N * 0.625 ms) to milliseconds
+ *
+ * Value range of @p _interval is @ref BT_LE_ADV_INTERVAL_MIN to @ref BT_LE_ADV_INTERVAL_MAX
+ *
+ * @note When intervals cannot be represented in milliseconds, this will round down.
+ * For example BT_GAP_ADV_INTERVAL_TO_MS(0x0021) will become 20 ms instead of 20.625 ms
+ */
+#define BT_GAP_ADV_INTERVAL_TO_MS(_interval) (BT_GAP_ADV_INTERVAL_TO_US(_interval) / USEC_PER_MSEC)
+
+/**
+ * @brief Convert isochronous interval (N * 1.25 ms) to microseconds
+ *
+ * Value range of @p _interval is @ref BT_HCI_ISO_INTERVAL_MIN to @ref BT_HCI_ISO_INTERVAL_MAX
+ */
+#define BT_GAP_ISO_INTERVAL_TO_US(_interval) ((uint32_t)((_interval) * 1250U))
+
+/**
+ * @brief Convert isochronous interval (N * 1.25 ms) to milliseconds
+ *
+ * Value range of @p _interval is @ref BT_HCI_ISO_INTERVAL_MIN to @ref BT_HCI_ISO_INTERVAL_MAX
+ *
+ * @note When intervals cannot be represented in milliseconds, this will round down.
+ * For example BT_GAP_ISO_INTERVAL_TO_MS(0x0005) will become 6 ms instead of 6.25 ms
+ */
+#define BT_GAP_ISO_INTERVAL_TO_MS(_interval) (BT_GAP_ISO_INTERVAL_TO_US(_interval) / USEC_PER_MSEC)
+
+/** @brief Convert periodic advertising interval (N * 1.25 ms) to microseconds *
+ *
+ * Value range of @p _interval is @ref BT_HCI_LE_PER_ADV_INTERVAL_MIN to @ref
+ * BT_HCI_LE_PER_ADV_INTERVAL_MAX
+ */
+#define BT_GAP_PER_ADV_INTERVAL_TO_US(_interval) ((uint32_t)((_interval) * 1250U))
+
+/**
  * @brief Convert periodic advertising interval (N * 1.25 ms) to milliseconds
  *
- * 5 / 4 represents 1.25 ms unit.
+ * @note When intervals cannot be represented in milliseconds, this will round down.
+ * For example BT_GAP_PER_ADV_INTERVAL_TO_MS(0x0009) will become 11 ms instead of 11.25 ms
  */
-#define BT_GAP_PER_ADV_INTERVAL_TO_MS(interval) ((interval) * 5 / 4)
+#define BT_GAP_PER_ADV_INTERVAL_TO_MS(_interval)                                                   \
+	(BT_GAP_PER_ADV_INTERVAL_TO_US(_interval) / USEC_PER_MSEC)
+
+/**
+ * @brief Convert microseconds to advertising interval units (0.625 ms)
+ *
+ * Value range of @p _interval is 20000 to 1024000
+ *
+ * @note If @p _interval is not a multiple of the unit, it will round down to nearest.
+ * For example BT_GAP_US_TO_ADV_INTERVAL(21000) will become 20625 microseconds
+ */
+#define BT_GAP_US_TO_ADV_INTERVAL(_interval) ((uint16_t)((_interval) / 625U))
+
+/**
+ * @brief Convert milliseconds to advertising interval units (0.625 ms)
+ *
+ * Value range of @p _interval is 20 to 1024
+ *
+ * @note If @p _interval is not a multiple of the unit, it will round down to nearest.
+ * For example BT_GAP_MS_TO_ADV_INTERVAL(21) will become 20.625 milliseconds
+ */
+#define BT_GAP_MS_TO_ADV_INTERVAL(_interval)                                                       \
+	(BT_GAP_US_TO_ADV_INTERVAL((_interval) * USEC_PER_MSEC))
+
+/**
+ * @brief Convert microseconds to periodic advertising interval units (1.25 ms)
+ *
+ * Value range of @p _interval is 7500 to 81918750
+ *
+ * @note If @p _interval is not a multiple of the unit, it will round down to nearest.
+ * For example BT_GAP_US_TO_PER_ADV_INTERVAL(11000) will become 10000 microseconds
+ */
+#define BT_GAP_US_TO_PER_ADV_INTERVAL(_interval) ((uint16_t)((_interval) / 1250U))
+
+/**
+ * @brief Convert milliseconds to periodic advertising interval units (1.25 ms)
+ *
+ * Value range of @p _interval is 7.5 to 81918.75
+ *
+ * @note If @p _interval is not a multiple of the unit, it will round down to nearest.
+ * For example BT_GAP_MS_TO_PER_ADV_INTERVAL(11) will become 10 milliseconds
+ */
+#define BT_GAP_MS_TO_PER_ADV_INTERVAL(_interval)                                                   \
+	(BT_GAP_US_TO_PER_ADV_INTERVAL((_interval) * USEC_PER_MSEC))
+
+/**
+ * @brief Convert milliseconds to periodic advertising sync timeout units (10 ms)
+ *
+ * Value range of @p _timeout is 100 to 163840
+ *
+ * @note If @p _timeout is not a multiple of the unit, it will round down to nearest.
+ * For example BT_GAP_MS_TO_PER_ADV_SYNC_TIMEOUT(4005) will become 4000 milliseconds
+ */
+#define BT_GAP_MS_TO_PER_ADV_SYNC_TIMEOUT(_timeout) ((uint16_t)((_timeout) / 10U))
+
+/**
+ * @brief Convert microseconds to periodic advertising sync timeout units (10 ms)
+ *
+ * Value range of @p _timeout is 100000 to 163840000
+ *
+ * @note If @p _timeout is not a multiple of the unit, it will round down to nearest.
+ * For example BT_GAP_MS_TO_PER_ADV_SYNC_TIMEOUT(4005000) will become 4000000 microseconds
+ */
+#define BT_GAP_US_TO_PER_ADV_SYNC_TIMEOUT(_timeout)                                                \
+	(BT_GAP_MS_TO_PER_ADV_SYNC_TIMEOUT((_timeout) / USEC_PER_MSEC))
+
+/**
+ * @brief Convert microseconds to scan interval units (0.625 ms)
+ *
+ * Value range of @p _interval is 2500 to 40959375 if @kconfig{CONFIG_BT_EXT_ADV} else
+ * 2500 to 10240000
+ *
+ * @note If @p _interval is not a multiple of the unit, it will round down to nearest.
+ * For example BT_GAP_US_TO_SCAN_INTERVAL(21000) will become 20625 microseconds
+ */
+#define BT_GAP_US_TO_SCAN_INTERVAL(_interval) ((uint16_t)((_interval) / 625U))
+
+/**
+ * @brief Convert milliseconds to scan interval units (0.625 ms)
+ *
+ * Value range of @p _interval is 2.5 to 40959.375 if @kconfig{CONFIG_BT_EXT_ADV} else
+ * 2500 to 10240
+ *
+ * @note If @p _interval is not a multiple of the unit, it will round down to nearest.
+ * For example BT_GAP_MS_TO_SCAN_INTERVAL(21) will become 20.625 milliseconds
+ */
+#define BT_GAP_MS_TO_SCAN_INTERVAL(_interval)                                                      \
+	(BT_GAP_US_TO_SCAN_INTERVAL((_interval) * USEC_PER_MSEC))
+
+/**
+ * @brief Convert microseconds to scan window units (0.625 ms)
+ *
+ * Value range of @p _window is 2500 to 40959375 if @kconfig{CONFIG_BT_EXT_ADV} else
+ * 2500 to 10240000
+ *
+ * @note If @p _window is not a multiple of the unit, it will round down to nearest.
+ * For example BT_GAP_US_TO_SCAN_WINDOW(21000) will become 20625 microseconds
+ */
+#define BT_GAP_US_TO_SCAN_WINDOW(_window) ((uint16_t)((_window) / 625U))
+
+/**
+ * @brief Convert milliseconds to scan window units (0.625 ms)
+ *
+ * Value range of @p _window is 2.5 to 40959.375 if @kconfig{CONFIG_BT_EXT_ADV} else
+ * 2500 to 10240
+ *
+ * @note If @p _window is not a multiple of the unit, it will round down to nearest.
+ * For example BT_GAP_MS_TO_SCAN_WINDOW(21) will become 20.625 milliseconds
+ */
+#define BT_GAP_MS_TO_SCAN_WINDOW(_window) (BT_GAP_US_TO_SCAN_WINDOW((_window) * USEC_PER_MSEC))
+
+/**
+ * @brief Convert microseconds to connection interval units (1.25 ms)
+ *
+ * Value range of @p _interval is 7500 to 4000000
+ *
+ * @note If @p _interval is not a multiple of the unit, it will round down to nearest.
+ * For example BT_GAP_US_TO_CONN_INTERVAL(21000) will become 20000 microseconds
+ */
+#define BT_GAP_US_TO_CONN_INTERVAL(_interval) ((uint16_t)((_interval) / 1250U))
+
+/**
+ * @brief Convert milliseconds to connection interval units (1.25 ms)
+ *
+ * Value range of @p _interval is 7.5 to 4000
+ *
+ * @note If @p _interval is not a multiple of the unit, it will round down to nearest.
+ * For example BT_GAP_MS_TO_CONN_INTERVAL(21) will become 20 milliseconds
+ */
+#define BT_GAP_MS_TO_CONN_INTERVAL(_interval)                                                      \
+	(BT_GAP_US_TO_CONN_INTERVAL((_interval) * USEC_PER_MSEC))
+
+/**
+ * @brief Convert milliseconds to connection supervision timeout units (10 ms)
+ *
+ * Value range of @p _timeout is 100 to 32000
+ *
+ * @note If @p _timeout is not a multiple of the unit, it will round down to nearest.
+ * For example BT_GAP_MS_TO_CONN_TIMEOUT(4005) will become 4000 milliseconds
+ */
+#define BT_GAP_MS_TO_CONN_TIMEOUT(_timeout) ((uint16_t)((_timeout) / 10U))
+
+/**
+ * @brief Convert microseconds to connection supervision timeout units (10 ms)
+
+ * Value range of @p _timeout is 100000 to 32000000
+ *
+ * @note If @p _timeout is not a multiple of the unit, it will round down to nearest.
+ * For example BT_GAP_MS_TO_CONN_TIMEOUT(4005000) will become 4000000 microseconds
+ */
+#define BT_GAP_US_TO_CONN_TIMEOUT(_timeout) (BT_GAP_MS_TO_CONN_TIMEOUT((_timeout) / USEC_PER_MSEC))
+
+/**
+ * @brief Convert milliseconds to connection event length units (0.625)
+ *
+ * Value range of @p _event_len is 0 to 40959375
+ *
+ * @note If @p _event_len is not a multiple of the unit, it will round down to nearest.
+ * For example BT_GAP_US_TO_CONN_EVENT_LEN(21000) will become 20625 milliseconds
+ */
+#define BT_GAP_US_TO_CONN_EVENT_LEN(_event_len) ((uint16_t)((_event_len) / 625U))
+
+/**
+ * @brief Convert milliseconds to connection event length units (0.625)
+ *
+ * Value range of @p _event_len is 0 to 40959.375
+ *
+ * @note If @p _event_len is not a multiple of the unit, it will round down to nearest.
+ * For example BT_GAP_MS_TO_CONN_EVENT_LEN(21) will become 20.625 milliseconds
+ */
+#define BT_GAP_MS_TO_CONN_EVENT_LEN(_event_len)                                                    \
+	(BT_GAP_US_TO_CONN_EVENT_LEN((_event_len) * USEC_PER_MSEC))
 
 /** Constant Tone Extension (CTE) types */
 enum {

--- a/samples/bluetooth/bap_broadcast_assistant/src/main.c
+++ b/samples/bluetooth/bap_broadcast_assistant/src/main.c
@@ -260,12 +260,13 @@ static uint16_t interval_to_sync_timeout(uint16_t pa_interval)
 		/* Use maximum value to maximize chance of success */
 		pa_timeout = BT_GAP_PER_ADV_MAX_TIMEOUT;
 	} else {
-		uint32_t interval_ms;
+		uint32_t interval_us;
 		uint32_t timeout;
 
 		/* Add retries and convert to unit in 10's of ms */
-		interval_ms = BT_GAP_PER_ADV_INTERVAL_TO_MS(pa_interval);
-		timeout = (interval_ms * PA_SYNC_INTERVAL_TO_TIMEOUT_RATIO) / 10;
+		interval_us = BT_GAP_PER_ADV_INTERVAL_TO_US(pa_interval);
+		timeout = BT_GAP_US_TO_PER_ADV_SYNC_TIMEOUT(interval_us) *
+			  PA_SYNC_INTERVAL_TO_TIMEOUT_RATIO;
 
 		/* Enforce restraints */
 		pa_timeout = CLAMP(timeout, BT_GAP_PER_ADV_MIN_TIMEOUT, BT_GAP_PER_ADV_MAX_TIMEOUT);

--- a/samples/bluetooth/bap_broadcast_sink/src/main.c
+++ b/samples/bluetooth/bap_broadcast_sink/src/main.c
@@ -851,12 +851,13 @@ static uint16_t interval_to_sync_timeout(uint16_t pa_interval)
 		/* Use maximum value to maximize chance of success */
 		pa_timeout = BT_GAP_PER_ADV_MAX_TIMEOUT;
 	} else {
-		uint32_t interval_ms;
+		uint32_t interval_us;
 		uint32_t timeout;
 
 		/* Add retries and convert to unit in 10's of ms */
-		interval_ms = BT_GAP_PER_ADV_INTERVAL_TO_MS(pa_interval);
-		timeout = (interval_ms * PA_SYNC_INTERVAL_TO_TIMEOUT_RATIO) / 10;
+		interval_us = BT_GAP_PER_ADV_INTERVAL_TO_US(pa_interval);
+		timeout = BT_GAP_US_TO_PER_ADV_SYNC_TIMEOUT(interval_us) *
+			  PA_SYNC_INTERVAL_TO_TIMEOUT_RATIO;
 
 		/* Enforce restraints */
 		pa_timeout = CLAMP(timeout, BT_GAP_PER_ADV_MIN_TIMEOUT, BT_GAP_PER_ADV_MAX_TIMEOUT);

--- a/samples/bluetooth/bap_broadcast_source/src/main.c
+++ b/samples/bluetooth/bap_broadcast_source/src/main.c
@@ -39,7 +39,9 @@ BUILD_ASSERT(strlen(CONFIG_BROADCAST_CODE) <= BT_ISO_BROADCAST_CODE_SIZE, "Inval
  * And, for 10 ms ISO interval, can use 90 ms minus 10 ms ==> 80 ms advertising
  * interval.
  */
-#define BT_LE_EXT_ADV_CUSTOM BT_LE_ADV_PARAM(BT_LE_ADV_OPT_EXT_ADV, 0x0080, 0x0080, NULL)
+#define BT_LE_EXT_ADV_CUSTOM                                                                       \
+	BT_LE_ADV_PARAM(BT_LE_ADV_OPT_EXT_ADV, BT_GAP_MS_TO_ADV_INTERVAL(80),                      \
+			BT_GAP_MS_TO_ADV_INTERVAL(80), NULL)
 
 /* When BROADCAST_ENQUEUE_COUNT > 1 we can enqueue enough buffers to ensure that
  * the controller is never idle

--- a/samples/bluetooth/cap_acceptor/src/cap_acceptor_broadcast.c
+++ b/samples/bluetooth/cap_acceptor/src/cap_acceptor_broadcast.c
@@ -291,12 +291,13 @@ static uint16_t interval_to_sync_timeout(uint16_t pa_interval)
 		/* Use maximum value to maximize chance of success */
 		pa_timeout = BT_GAP_PER_ADV_MAX_TIMEOUT;
 	} else {
-		uint32_t interval_ms;
+		uint32_t interval_us;
 		uint32_t timeout;
 
 		/* Add retries and convert to unit in 10's of ms */
-		interval_ms = BT_GAP_PER_ADV_INTERVAL_TO_MS(pa_interval);
-		timeout = (interval_ms * PA_SYNC_INTERVAL_TO_TIMEOUT_RATIO) / 10;
+		interval_us = BT_GAP_PER_ADV_INTERVAL_TO_US(pa_interval);
+		timeout = BT_GAP_US_TO_PER_ADV_SYNC_TIMEOUT(interval_us) *
+			  PA_SYNC_INTERVAL_TO_TIMEOUT_RATIO;
 
 		/* Enforce restraints */
 		pa_timeout = CLAMP(timeout, BT_GAP_PER_ADV_MIN_TIMEOUT, BT_GAP_PER_ADV_MAX_TIMEOUT);

--- a/samples/bluetooth/central_past/src/main.c
+++ b/samples/bluetooth/central_past/src/main.c
@@ -1,15 +1,19 @@
 /*
- * Copyright (c) 2021 Nordic Semiconductor ASA
+ * Copyright (c) 2021-2024 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <stdint.h>
+
+#include <zephyr/bluetooth/gap.h>
 #include <zephyr/device.h>
 #include <zephyr/devicetree.h>
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/hci.h>
+#include <zephyr/sys/util.h>
 
 #define NAME_LEN            30
 
@@ -17,7 +21,7 @@ static bool per_adv_found;
 static bt_addr_le_t per_addr;
 static uint8_t per_sid;
 static struct bt_conn *default_conn;
-static uint32_t per_adv_interval_ms;
+static uint16_t per_adv_sync_timeout;
 
 static K_SEM_DEFINE(sem_conn, 0, 1);
 static K_SEM_DEFINE(sem_conn_lost, 0, 1);
@@ -106,8 +110,22 @@ static void scan_recv(const struct bt_le_scan_recv_info *info,
 	} else {
 		/* If info->interval it is a periodic advertiser, mark for sync */
 		if (!per_adv_found && info->interval) {
+			uint32_t interval_us;
+			uint32_t timeout;
+
 			per_adv_found = true;
-			per_adv_interval_ms = BT_GAP_PER_ADV_INTERVAL_TO_MS(info->interval);
+
+			/* Add retries and convert to unit in 10's of ms */
+			interval_us = BT_GAP_PER_ADV_INTERVAL_TO_US(info->interval);
+
+			timeout = BT_GAP_US_TO_PER_ADV_SYNC_TIMEOUT(interval_us);
+
+			/* 10 attempts */
+			timeout *= 10;
+
+			/* Enforce restraints */
+			per_adv_sync_timeout = CLAMP(timeout, BT_GAP_PER_ADV_MIN_TIMEOUT,
+						     BT_GAP_PER_ADV_MAX_TIMEOUT);
 
 			per_sid = info->sid;
 			bt_addr_le_copy(&per_addr, info->addr);
@@ -296,7 +314,7 @@ int main(void)
 		sync_create_param.options = 0;
 		sync_create_param.sid = per_sid;
 		sync_create_param.skip = 0;
-		sync_create_param.timeout = per_adv_interval_ms * 10 / 10; /* 10 attempts */
+		sync_create_param.timeout = per_adv_sync_timeout;
 		err = bt_le_per_adv_sync_create(&sync_create_param, &sync);
 		if (err != 0) {
 			printk("failed (err %d)\n", err);

--- a/samples/bluetooth/hci_pwr_ctrl/src/main.c
+++ b/samples/bluetooth/hci_pwr_ctrl/src/main.c
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/bluetooth/gap.h>
 #include <zephyr/types.h>
 #include <stddef.h>
 #include <zephyr/sys/printk.h>
@@ -42,8 +43,8 @@ static K_THREAD_STACK_DEFINE(pwr_thread_stack, 512);
 
 static const int8_t txpower[DEVICE_BEACON_TXPOWER_NUM] = {4, 0, -3, -8,
 							  -15, -18, -23, -30};
-static const struct bt_le_adv_param *param =
-	BT_LE_ADV_PARAM(BT_LE_ADV_OPT_CONN, 0x0020, 0x0020, NULL);
+static const struct bt_le_adv_param *param = BT_LE_ADV_PARAM(
+	BT_LE_ADV_OPT_CONN, BT_GAP_MS_TO_ADV_INTERVAL(20), BT_GAP_MS_TO_ADV_INTERVAL(20), NULL);
 
 static void read_conn_rssi(uint16_t handle, int8_t *rssi)
 {

--- a/samples/bluetooth/pbp_public_broadcast_sink/src/main.c
+++ b/samples/bluetooth/pbp_public_broadcast_sink/src/main.c
@@ -122,12 +122,13 @@ static struct bt_pacs_cap cap = {
 
 static uint16_t interval_to_sync_timeout(uint16_t interval)
 {
-	uint32_t interval_ms;
+	uint32_t interval_us;
 	uint32_t timeout;
 
 	/* Add retries and convert to unit in 10's of ms */
-	interval_ms = BT_GAP_PER_ADV_INTERVAL_TO_MS(interval);
-	timeout = (interval_ms * PA_SYNC_INTERVAL_TO_TIMEOUT_RATIO) / 10;
+	interval_us = BT_GAP_PER_ADV_INTERVAL_TO_US(interval);
+	timeout =
+		BT_GAP_US_TO_PER_ADV_SYNC_TIMEOUT(interval_us) * PA_SYNC_INTERVAL_TO_TIMEOUT_RATIO;
 
 	/* Enforce restraints */
 	timeout = CLAMP(timeout, BT_GAP_PER_ADV_MIN_TIMEOUT, BT_GAP_PER_ADV_MAX_TIMEOUT);

--- a/samples/bluetooth/periodic_sync/src/main.c
+++ b/samples/bluetooth/periodic_sync/src/main.c
@@ -1,20 +1,23 @@
 /*
- * Copyright (c) 2020 Nordic Semiconductor ASA
+ * Copyright (c) 2020-2024 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+#include <stdint.h>
 
+#include <zephyr/bluetooth/gap.h>
 #include <zephyr/device.h>
 #include <zephyr/devicetree.h>
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/sys/util.h>
 
 #define TIMEOUT_SYNC_CREATE K_SECONDS(10)
 #define NAME_LEN            30
 
 static bool         per_adv_found;
 static bt_addr_le_t per_addr;
-static uint32_t     per_adv_interval_ms;
+static uint16_t per_adv_sync_timeout;
 static uint8_t      per_sid;
 
 static K_SEM_DEFINE(sem_per_adv, 0, 1);
@@ -97,8 +100,22 @@ static void scan_recv(const struct bt_le_scan_recv_info *info,
 	       info->interval, info->interval * 5 / 4, info->sid);
 
 	if (!per_adv_found && info->interval) {
+		uint32_t interval_us;
+		uint32_t timeout;
+
 		per_adv_found = true;
-		per_adv_interval_ms = BT_GAP_PER_ADV_INTERVAL_TO_MS(info->interval);
+
+		/* Add retries and convert to unit in 10's of ms */
+		interval_us = BT_GAP_PER_ADV_INTERVAL_TO_US(info->interval);
+
+		timeout = BT_GAP_US_TO_PER_ADV_SYNC_TIMEOUT(interval_us);
+
+		/* 10 attempts */
+		timeout *= 10;
+
+		/* Enforce restraints */
+		per_adv_sync_timeout =
+			CLAMP(timeout, BT_GAP_PER_ADV_MIN_TIMEOUT, BT_GAP_PER_ADV_MAX_TIMEOUT);
 
 		per_sid = info->sid;
 		bt_addr_le_copy(&per_addr, info->addr);
@@ -235,7 +252,7 @@ int main(void)
 		sync_create_param.options = 0;
 		sync_create_param.sid = per_sid;
 		sync_create_param.skip = 0;
-		sync_create_param.timeout = per_adv_interval_ms * 10 / 10; /* 10 attempts */
+		sync_create_param.timeout = per_adv_sync_timeout;
 		err = bt_le_per_adv_sync_create(&sync_create_param, &sync);
 		if (err) {
 			printk("failed (err %d)\n", err);

--- a/samples/bluetooth/tmap_bmr/src/bap_broadcast_sink.c
+++ b/samples/bluetooth/tmap_bmr/src/bap_broadcast_sink.c
@@ -113,12 +113,13 @@ static struct bt_pacs_cap cap = {
 
 static uint16_t interval_to_sync_timeout(uint16_t interval)
 {
-	uint32_t interval_ms;
+	uint32_t interval_us;
 	uint32_t timeout;
 
 	/* Add retries and convert to unit in 10's of ms */
-	interval_ms = BT_GAP_PER_ADV_INTERVAL_TO_MS(interval);
-	timeout = (interval_ms * PA_SYNC_INTERVAL_TO_TIMEOUT_RATIO) / 10;
+	interval_us = BT_GAP_PER_ADV_INTERVAL_TO_US(interval);
+	timeout =
+		BT_GAP_US_TO_PER_ADV_SYNC_TIMEOUT(interval_us) * PA_SYNC_INTERVAL_TO_TIMEOUT_RATIO;
 
 	/* Enforce restraints */
 	timeout = CLAMP(timeout, BT_GAP_PER_ADV_MIN_TIMEOUT, BT_GAP_PER_ADV_MAX_TIMEOUT);

--- a/subsys/bluetooth/audio/bap_broadcast_sink.c
+++ b/subsys/bluetooth/audio/bap_broadcast_sink.c
@@ -952,12 +952,13 @@ static void biginfo_recv(struct bt_le_per_adv_sync *sync,
 
 static uint16_t interval_to_sync_timeout(uint16_t interval)
 {
-	uint32_t interval_ms;
+	uint32_t interval_us;
 	uint32_t timeout;
 
 	/* Add retries and convert to unit in 10's of ms */
-	interval_ms = BT_GAP_PER_ADV_INTERVAL_TO_MS(interval);
-	timeout = (interval_ms * PA_SYNC_INTERVAL_TO_TIMEOUT_RATIO) / 10;
+	interval_us = BT_GAP_PER_ADV_INTERVAL_TO_US(interval);
+	timeout =
+		BT_GAP_US_TO_PER_ADV_SYNC_TIMEOUT(interval_us) * PA_SYNC_INTERVAL_TO_TIMEOUT_RATIO;
 
 	/* Enforce restraints */
 	timeout = CLAMP(timeout, BT_GAP_PER_ADV_MIN_TIMEOUT, BT_GAP_PER_ADV_MAX_TIMEOUT);

--- a/subsys/bluetooth/audio/shell/bap.c
+++ b/subsys/bluetooth/audio/shell/bap.c
@@ -2371,12 +2371,13 @@ static void clear_auto_scan(void)
 
 static uint16_t interval_to_sync_timeout(uint16_t interval)
 {
-	uint32_t interval_ms;
+	uint32_t interval_us;
 	uint32_t timeout;
 
 	/* Add retries and convert to unit in 10's of ms */
-	interval_ms = BT_GAP_PER_ADV_INTERVAL_TO_MS(interval);
-	timeout = (interval_ms * PA_SYNC_INTERVAL_TO_TIMEOUT_RATIO) / 10;
+	interval_us = BT_GAP_PER_ADV_INTERVAL_TO_US(interval);
+	timeout =
+		BT_GAP_US_TO_PER_ADV_SYNC_TIMEOUT(interval_us) * PA_SYNC_INTERVAL_TO_TIMEOUT_RATIO;
 
 	/* Enforce restraints */
 	timeout = CLAMP(timeout, BT_GAP_PER_ADV_MIN_TIMEOUT, BT_GAP_PER_ADV_MAX_TIMEOUT);

--- a/subsys/bluetooth/audio/shell/bap_broadcast_assistant.c
+++ b/subsys/bluetooth/audio/shell/bap_broadcast_assistant.c
@@ -107,10 +107,11 @@ static void bap_broadcast_assistant_scan_cb(const struct bt_le_scan_recv_info *i
 	char le_addr[BT_ADDR_LE_STR_LEN];
 
 	bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
-	shell_print(ctx_shell,
-		    "[DEVICE]: %s, broadcast_id 0x%06X, interval (ms) %u), SID 0x%x, RSSI %i",
-		    le_addr, broadcast_id, BT_GAP_PER_ADV_INTERVAL_TO_MS(info->interval), info->sid,
-		    info->rssi);
+	shell_print(
+		ctx_shell,
+		"[DEVICE]: %s, broadcast_id 0x%06X, interval (ms) %u (0x%04x)), SID 0x%x, RSSI %i",
+		le_addr, broadcast_id, BT_GAP_PER_ADV_INTERVAL_TO_MS(info->interval),
+		info->interval, info->sid, info->rssi);
 }
 
 static bool metadata_entry(struct bt_data *data, void *user_data)

--- a/subsys/bluetooth/audio/shell/bap_scan_delegator.c
+++ b/subsys/bluetooth/audio/shell/bap_scan_delegator.c
@@ -151,12 +151,13 @@ static uint16_t interval_to_sync_timeout(uint16_t pa_interval)
 		/* Use maximum value to maximize chance of success */
 		pa_timeout = BT_GAP_PER_ADV_MAX_TIMEOUT;
 	} else {
-		uint32_t interval_ms;
+		uint32_t interval_us;
 		uint32_t timeout;
 
 		/* Add retries and convert to unit in 10's of ms */
-		interval_ms = BT_GAP_PER_ADV_INTERVAL_TO_MS(pa_interval);
-		timeout = (interval_ms * PA_SYNC_INTERVAL_TO_TIMEOUT_RATIO) / 10;
+		interval_us = BT_GAP_PER_ADV_INTERVAL_TO_US(pa_interval);
+		timeout = BT_GAP_US_TO_PER_ADV_SYNC_TIMEOUT(interval_us) *
+			  PA_SYNC_INTERVAL_TO_TIMEOUT_RATIO;
 
 		/* Enforce restraints */
 		pa_timeout = CLAMP(timeout, BT_GAP_PER_ADV_MIN_TIMEOUT, BT_GAP_PER_ADV_MAX_TIMEOUT);

--- a/tests/bluetooth/gap/CMakeLists.txt
+++ b/tests/bluetooth/gap/CMakeLists.txt
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
+
+project(bt_gap)
+
+target_sources(testbinary
+  PRIVATE
+    src/main.c
+)

--- a/tests/bluetooth/gap/prj.conf
+++ b/tests/bluetooth/gap/prj.conf
@@ -1,0 +1,3 @@
+CONFIG_ZTEST=y
+
+CONFIG_BT=y

--- a/tests/bluetooth/gap/src/main.c
+++ b/tests/bluetooth/gap/src/main.c
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stddef.h>
+
+#include <zephyr/bluetooth/gap.h>
+#include <zephyr/ztest.h>
+#include <zephyr/ztest_test.h>
+#include <zephyr/ztest_assert.h>
+
+ZTEST_SUITE(gap_test_suite, NULL, NULL, NULL, NULL, NULL);
+
+static ZTEST(gap_test_suite, test_bt_gap_conversion_macros)
+{
+	zassert_equal(BT_GAP_ADV_INTERVAL_TO_US(0x0020U), 20000U);
+	zassert_equal(BT_GAP_ADV_INTERVAL_TO_US(0x0021U), 20625U);
+	zassert_equal(BT_GAP_ADV_INTERVAL_TO_US(0x0022U), 21250U);
+
+	zassert_equal(BT_GAP_ADV_INTERVAL_TO_MS(0x0020U), 20U);
+	/* Round down expected from 20.625 */
+	zassert_equal(BT_GAP_ADV_INTERVAL_TO_MS(0x0021U), 20U);
+	/* Round down expected from 21.250 */
+	zassert_equal(BT_GAP_ADV_INTERVAL_TO_MS(0x0022U), 21U);
+
+	zassert_equal(BT_GAP_ISO_INTERVAL_TO_US(0x0004U), 5000U);
+	zassert_equal(BT_GAP_ISO_INTERVAL_TO_US(0x0005U), 6250U);
+	zassert_equal(BT_GAP_ISO_INTERVAL_TO_US(0x0006U), 7500U);
+
+	zassert_equal(BT_GAP_ISO_INTERVAL_TO_MS(0x0004U), 5U);
+	/* Round down expected from 6.25 */
+	zassert_equal(BT_GAP_ISO_INTERVAL_TO_MS(0x0005U), 6U);
+	/* Round down expected from 7.50 */
+	zassert_equal(BT_GAP_ISO_INTERVAL_TO_MS(0x0006U), 7U);
+
+	zassert_equal(BT_GAP_PER_ADV_INTERVAL_TO_US(0x0008U), 10000U);
+	zassert_equal(BT_GAP_PER_ADV_INTERVAL_TO_US(0x0009U), 11250U);
+	zassert_equal(BT_GAP_PER_ADV_INTERVAL_TO_US(0x000aU), 12500U);
+
+	zassert_equal(BT_GAP_PER_ADV_INTERVAL_TO_MS(0x0008U), 10U);
+	/* Round down expected from 11.25 */
+	zassert_equal(BT_GAP_PER_ADV_INTERVAL_TO_MS(0x0009U), 11U);
+	/* Round down expected from 12.50 */
+	zassert_equal(BT_GAP_PER_ADV_INTERVAL_TO_MS(0x000aU), 12U);
+
+	zassert_equal(BT_GAP_US_TO_ADV_INTERVAL(20000U), 0x0020U);
+	/* Round down expected from 33.60 */
+	zassert_equal(BT_GAP_US_TO_ADV_INTERVAL(21000U), 0x0021U);
+	/* Round down expected from 35.20 */
+	zassert_equal(BT_GAP_US_TO_ADV_INTERVAL(22000U), 0x0023U);
+
+	zassert_equal(BT_GAP_MS_TO_ADV_INTERVAL(20U), 0x0020U);
+	/* Round down expected from 33.60 */
+	zassert_equal(BT_GAP_MS_TO_ADV_INTERVAL(21U), 0x0021U);
+	/* Round down expected from 35.20 */
+	zassert_equal(BT_GAP_MS_TO_ADV_INTERVAL(22U), 0x0023U);
+
+	zassert_equal(BT_GAP_US_TO_PER_ADV_INTERVAL(10000U), 0x0008U);
+	/* Round down expected from 8.8 */
+	zassert_equal(BT_GAP_US_TO_PER_ADV_INTERVAL(11000U), 0x0008U);
+	/* Round down expected from 9.6 */
+	zassert_equal(BT_GAP_US_TO_PER_ADV_INTERVAL(12000U), 0x0009U);
+
+	zassert_equal(BT_GAP_MS_TO_PER_ADV_INTERVAL(10U), 0x0008U);
+	/* Round down expected from 8.8 */
+	zassert_equal(BT_GAP_MS_TO_PER_ADV_INTERVAL(11U), 0x0008U);
+	/* Round down expected from 9.6 */
+	zassert_equal(BT_GAP_MS_TO_PER_ADV_INTERVAL(12U), 0x0009U);
+
+	zassert_equal(BT_GAP_MS_TO_PER_ADV_SYNC_TIMEOUT(4000U), 0x0190U);
+	/* Round down expected from 400.5 */
+	zassert_equal(BT_GAP_MS_TO_PER_ADV_SYNC_TIMEOUT(4005U), 0x0190U);
+
+	zassert_equal(BT_GAP_US_TO_PER_ADV_SYNC_TIMEOUT(4000000U), 0x0190U);
+	/* Round down expected from 400.5 */
+	zassert_equal(BT_GAP_US_TO_PER_ADV_SYNC_TIMEOUT(4005000U), 0x0190U);
+
+	zassert_equal(BT_GAP_US_TO_SCAN_INTERVAL(20000U), 0x0020U);
+	/* Round down expected from 33.60 */
+	zassert_equal(BT_GAP_US_TO_SCAN_INTERVAL(21000U), 0x0021U);
+	/* Round down expected from 35.20 */
+	zassert_equal(BT_GAP_US_TO_SCAN_INTERVAL(22000U), 0x0023U);
+
+	zassert_equal(BT_GAP_MS_TO_SCAN_INTERVAL(20U), 0x0020U);
+	/* Round down expected from 33.60 */
+	zassert_equal(BT_GAP_MS_TO_SCAN_INTERVAL(21U), 0x0021U);
+	/* Round down expected from 35.20 */
+	zassert_equal(BT_GAP_MS_TO_SCAN_INTERVAL(22U), 0x0023U);
+
+	zassert_equal(BT_GAP_US_TO_SCAN_WINDOW(20000U), 0x0020U);
+	/* Round down expected from 33.60 */
+	zassert_equal(BT_GAP_US_TO_SCAN_WINDOW(21000U), 0x0021U);
+	/* Round down expected from 35.20 */
+	zassert_equal(BT_GAP_US_TO_SCAN_WINDOW(22000U), 0x0023U);
+
+	zassert_equal(BT_GAP_MS_TO_SCAN_WINDOW(20U), 0x0020U);
+	/* Round down expected from 33.60 */
+	zassert_equal(BT_GAP_MS_TO_SCAN_WINDOW(21U), 0x0021U);
+	/* Round down expected from 35.20 */
+	zassert_equal(BT_GAP_MS_TO_SCAN_WINDOW(22U), 0x0023U);
+
+	zassert_equal(BT_GAP_US_TO_CONN_INTERVAL(10000U), 0x0008U);
+	/* Round down expected from 8.8 */
+	zassert_equal(BT_GAP_US_TO_CONN_INTERVAL(11000U), 0x0008U);
+	/* Round down expected from 9.6 */
+	zassert_equal(BT_GAP_US_TO_CONN_INTERVAL(12000U), 0x0009U);
+
+	zassert_equal(BT_GAP_MS_TO_CONN_INTERVAL(10U), 0x0008U);
+	/* Round down expected from 8.8 */
+	zassert_equal(BT_GAP_MS_TO_CONN_INTERVAL(11U), 0x0008U);
+	/* Round down expected from 9.6 */
+	zassert_equal(BT_GAP_MS_TO_CONN_INTERVAL(12U), 0x0009U);
+
+	zassert_equal(BT_GAP_MS_TO_CONN_TIMEOUT(4000U), 0x0190U);
+	/* Round down expected from 400.5 */
+	zassert_equal(BT_GAP_MS_TO_CONN_TIMEOUT(4005U), 0x0190U);
+
+	zassert_equal(BT_GAP_US_TO_CONN_TIMEOUT(4000000U), 0x0190U);
+	/* Round down expected from 400.5 */
+	zassert_equal(BT_GAP_US_TO_CONN_TIMEOUT(4005000U), 0x0190U);
+
+	zassert_equal(BT_GAP_US_TO_CONN_EVENT_LEN(20000U), 0x0020U);
+	/* Round down expected from 33.60 */
+	zassert_equal(BT_GAP_US_TO_CONN_EVENT_LEN(21000U), 0x0021U);
+	/* Round down expected from 35.20 */
+	zassert_equal(BT_GAP_US_TO_CONN_EVENT_LEN(22000U), 0x0023U);
+
+	zassert_equal(BT_GAP_MS_TO_CONN_EVENT_LEN(20U), 0x0020U);
+	/* Round down expected from 33.60 */
+	zassert_equal(BT_GAP_MS_TO_CONN_EVENT_LEN(21U), 0x0021U);
+	/* Round down expected from 35.20 */
+	zassert_equal(BT_GAP_MS_TO_CONN_EVENT_LEN(22U), 0x0023U);
+}

--- a/tests/bluetooth/gap/testcase.yaml
+++ b/tests/bluetooth/gap/testcase.yaml
@@ -1,0 +1,7 @@
+common:
+  tags:
+    - bluetooth
+    - host
+tests:
+  bluetooth.gap.test:
+    type: unit

--- a/tests/bluetooth/tester/src/audio/btp_bap_broadcast.c
+++ b/tests/bluetooth/tester/src/audio/btp_bap_broadcast.c
@@ -13,6 +13,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/sys/ring_buffer.h>
 #include <zephyr/bluetooth/audio/audio.h>
+#include <zephyr/bluetooth/gap.h>
 
 #include "bap_endpoint.h"
 #include <zephyr/logging/log.h>
@@ -1261,8 +1262,9 @@ static void bap_broadcast_assistant_scan_cb(const struct bt_le_scan_recv_info *i
 	char le_addr[BT_ADDR_LE_STR_LEN];
 
 	bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
-	LOG_DBG("[DEVICE]: %s, broadcast_id 0x%06X, interval (ms) %u), SID 0x%x, RSSI %i", le_addr,
-		broadcast_id, BT_GAP_PER_ADV_INTERVAL_TO_MS(info->interval), info->sid, info->rssi);
+	LOG_DBG("[DEVICE]: %s, broadcast_id 0x%06X, interval (ms) %u (0x%04x)), SID 0x%x, RSSI %i",
+		le_addr, broadcast_id, BT_GAP_PER_ADV_INTERVAL_TO_MS(info->interval),
+		info->interval, info->sid, info->rssi);
 }
 
 static void bap_broadcast_assistant_recv_state_cb(struct bt_conn *conn, int err,

--- a/tests/bluetooth/tester/src/btp_gap.c
+++ b/tests/bluetooth/tester/src/btp_gap.c
@@ -989,7 +989,8 @@ static uint8_t connect(const void *cmd, uint16_t cmd_len,
 		       void *rsp, uint16_t *rsp_len)
 {
 	const struct bt_le_conn_param *conn_param =
-		BT_LE_CONN_PARAM(BT_GAP_INIT_CONN_INT_MIN, BT_GAP_INIT_CONN_INT_MIN, 0, 400);
+		BT_LE_CONN_PARAM(BT_GAP_INIT_CONN_INT_MIN, BT_GAP_INIT_CONN_INT_MIN, 0,
+				 BT_GAP_MS_TO_CONN_TIMEOUT(4000));
 	const struct btp_gap_connect_cmd *cp = cmd;
 	int err;
 

--- a/tests/bsim/bluetooth/audio/src/cap_commander_test.c
+++ b/tests/bsim/bluetooth/audio/src/cap_commander_test.c
@@ -586,10 +586,10 @@ static void cap_device_found(const bt_addr_le_t *addr, int8_t rssi, uint8_t type
 		return;
 	}
 
-	err = bt_conn_le_create(
-		addr, BT_CONN_LE_CREATE_CONN,
-		BT_LE_CONN_PARAM(BT_GAP_INIT_CONN_INT_MIN, BT_GAP_INIT_CONN_INT_MIN, 0, 400),
-		&connected_conns[connected_conn_cnt]);
+	err = bt_conn_le_create(addr, BT_CONN_LE_CREATE_CONN,
+				BT_LE_CONN_PARAM(BT_GAP_INIT_CONN_INT_MIN, BT_GAP_INIT_CONN_INT_MIN,
+						 0, BT_GAP_MS_TO_CONN_TIMEOUT(4000)),
+				&connected_conns[connected_conn_cnt]);
 	if (err) {
 		FAIL("Could not connect to peer: %d", err);
 	}

--- a/tests/bsim/bluetooth/audio/src/cap_initiator_broadcast_test.c
+++ b/tests/bsim/bluetooth/audio/src/cap_initiator_broadcast_test.c
@@ -38,14 +38,13 @@
  * required to place the AUX_ADV_IND PDUs in a non-overlapping interval with the
  * Broadcast ISO radio events.
  */
-#define BT_LE_EXT_ADV_CUSTOM \
-		BT_LE_ADV_PARAM(BT_LE_ADV_OPT_EXT_ADV, \
-				0x0080, 0x0080, NULL)
+#define BT_LE_EXT_ADV_CUSTOM                                                                       \
+	BT_LE_ADV_PARAM(BT_LE_ADV_OPT_EXT_ADV, BT_GAP_MS_TO_ADV_INTERVAL(80),                      \
+			BT_GAP_MS_TO_ADV_INTERVAL(80), NULL)
 
-#define BT_LE_PER_ADV_CUSTOM \
-		BT_LE_PER_ADV_PARAM(0x0048, \
-				    0x0048, \
-				    BT_LE_PER_ADV_OPT_NONE)
+#define BT_LE_PER_ADV_CUSTOM                                                                       \
+	BT_LE_PER_ADV_PARAM(BT_GAP_MS_TO_PER_ADV_INTERVAL(90), BT_GAP_MS_TO_PER_ADV_INTERVAL(90),  \
+			    BT_LE_PER_ADV_OPT_NONE)
 
 #define BROADCAST_STREMT_CNT    CONFIG_BT_BAP_BROADCAST_SRC_STREAM_COUNT
 #define BROADCAST_ENQUEUE_COUNT 2U

--- a/tests/bsim/bluetooth/audio/src/cap_initiator_unicast_test.c
+++ b/tests/bsim/bluetooth/audio/src/cap_initiator_unicast_test.c
@@ -438,10 +438,10 @@ static void cap_device_found(const bt_addr_le_t *addr, int8_t rssi, uint8_t type
 		return;
 	}
 
-	err = bt_conn_le_create(
-		addr, BT_CONN_LE_CREATE_CONN,
-		BT_LE_CONN_PARAM(BT_GAP_INIT_CONN_INT_MIN, BT_GAP_INIT_CONN_INT_MIN, 0, 400),
-		&connected_conns[connected_conn_cnt]);
+	err = bt_conn_le_create(addr, BT_CONN_LE_CREATE_CONN,
+				BT_LE_CONN_PARAM(BT_GAP_INIT_CONN_INT_MIN, BT_GAP_INIT_CONN_INT_MIN,
+						 0, BT_GAP_MS_TO_CONN_TIMEOUT(4000)),
+				&connected_conns[connected_conn_cnt]);
 	if (err) {
 		FAIL("Could not connect to peer: %d", err);
 	}

--- a/tests/bsim/bluetooth/audio/src/common.c
+++ b/tests/bsim/bluetooth/audio/src/common.c
@@ -231,12 +231,13 @@ uint16_t interval_to_sync_timeout(uint16_t pa_interval)
 		/* Use maximum value to maximize chance of success */
 		pa_timeout = BT_GAP_PER_ADV_MAX_TIMEOUT;
 	} else {
-		uint32_t interval_ms;
+		uint32_t interval_us;
 		uint32_t timeout;
 
 		/* Add retries and convert to unit in 10's of ms */
-		interval_ms = BT_GAP_PER_ADV_INTERVAL_TO_MS(pa_interval);
-		timeout = (interval_ms * PA_SYNC_INTERVAL_TO_TIMEOUT_RATIO) / 10;
+		interval_us = BT_GAP_PER_ADV_INTERVAL_TO_US(pa_interval);
+		timeout = BT_GAP_US_TO_PER_ADV_SYNC_TIMEOUT(interval_us) *
+			  PA_SYNC_INTERVAL_TO_TIMEOUT_RATIO;
 
 		/* Enforce restraints */
 		pa_timeout = CLAMP(timeout, BT_GAP_PER_ADV_MIN_TIMEOUT, BT_GAP_PER_ADV_MAX_TIMEOUT);

--- a/tests/bsim/bluetooth/audio/src/gmap_ugg_test.c
+++ b/tests/bsim/bluetooth/audio/src/gmap_ugg_test.c
@@ -44,14 +44,13 @@
  * required to place the AUX_ADV_IND PDUs in a non-overlapping interval with the
  * Broadcast ISO radio events.
  */
-#define BT_LE_EXT_ADV_CUSTOM \
-		BT_LE_ADV_PARAM(BT_LE_ADV_OPT_EXT_ADV, \
-				0x0080, 0x0080, NULL)
+#define BT_LE_EXT_ADV_CUSTOM                                                                       \
+	BT_LE_ADV_PARAM(BT_LE_ADV_OPT_EXT_ADV, BT_GAP_MS_TO_ADV_INTERVAL(80),                      \
+			BT_GAP_MS_TO_ADV_INTERVAL(80), NULL)
 
-#define BT_LE_PER_ADV_CUSTOM \
-		BT_LE_PER_ADV_PARAM(0x0048, \
-				    0x0048, \
-				    BT_LE_PER_ADV_OPT_NONE)
+#define BT_LE_PER_ADV_CUSTOM                                                                       \
+	BT_LE_PER_ADV_PARAM(BT_GAP_MS_TO_PER_ADV_INTERVAL(90), BT_GAP_MS_TO_PER_ADV_INTERVAL(90),  \
+			    BT_LE_PER_ADV_OPT_NONE)
 
 #define UNICAST_SINK_SUPPORTED (CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SNK_COUNT > 0)
 #define UNICAST_SRC_SUPPORTED  (CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC_COUNT > 0)
@@ -546,10 +545,10 @@ static void gmap_device_found(const bt_addr_le_t *addr, int8_t rssi, uint8_t typ
 		return;
 	}
 
-	err = bt_conn_le_create(
-		addr, BT_CONN_LE_CREATE_CONN,
-		BT_LE_CONN_PARAM(BT_GAP_INIT_CONN_INT_MIN, BT_GAP_INIT_CONN_INT_MIN, 0, 400),
-		&connected_conns[connected_conn_cnt]);
+	err = bt_conn_le_create(addr, BT_CONN_LE_CREATE_CONN,
+				BT_LE_CONN_PARAM(BT_GAP_INIT_CONN_INT_MIN, BT_GAP_INIT_CONN_INT_MIN,
+						 0, BT_GAP_MS_TO_CONN_TIMEOUT(4000)),
+				&connected_conns[connected_conn_cnt]);
 	if (err) {
 		FAIL("Could not connect to peer: %d", err);
 	}

--- a/tests/bsim/bluetooth/audio/src/mcc_test.c
+++ b/tests/bsim/bluetooth/audio/src/mcc_test.c
@@ -14,6 +14,7 @@
 #include <zephyr/bluetooth/audio/media_proxy.h>
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/conn.h>
+#include <zephyr/bluetooth/gap.h>
 #include <zephyr/bluetooth/hci_types.h>
 #include <zephyr/bluetooth/services/ots.h>
 #include <zephyr/kernel.h>
@@ -2462,7 +2463,10 @@ void test_main(void)
 		bt_addr_le_to_str(bt_conn_get_dst(default_conn), addr, sizeof(addr));
 		printk("Connected: %s\n", addr);
 
-		bt_conn_le_param_update(default_conn, BT_LE_CONN_PARAM(0x06U, 0x10U, 0U, 400U));
+		bt_conn_le_param_update(default_conn,
+					BT_LE_CONN_PARAM(BT_GAP_US_TO_CONN_INTERVAL(7500),
+							 BT_GAP_US_TO_CONN_INTERVAL(20000), 0U,
+							 BT_GAP_MS_TO_CONN_TIMEOUT(4000U)));
 		WAIT_FOR_FLAG(flag_conn_updated);
 
 		test_discover();


### PR DESCRIPTION
Add conversion macros from milliseconds to various units. The purpose of these macros is to make it more clear/easier for users to set and read values using milliseconds rather than the various BT units which may be in 0.625, 1.25 or 10ms units.

This is especially useful when comparing related values using different units, such as advertising interval (0.625ms units) and periodic advertising interval units (1.25ms units).

Users will have to be aware that these macros can provide slightly different values than what is provided, if the provided values do not match the units.

A followup PR for audio can be found here https://github.com/zephyrproject-rtos/zephyr/pull/81093 which uses more of these macros. 