### PR TITLE
Remove BOOTLOADER_BUILD flag from Espressif hal (Zephyr side)

### DIFF
--- a/soc/espressif/esp32/default.ld
+++ b/soc/espressif/esp32/default.ld
@@ -351,6 +351,7 @@ SECTIONS
     *libzephyr.a:mspi_timing_config.*(.literal .literal.* .text .text.*)
     *libzephyr.a:mspi_timing_tuning.*(.literal .literal.* .text .text.*)
     *libzephyr.a:periph_ctrl.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:regi2c_ctrl.*(.literal .text .literal.* .text.*)
     *(.literal.sar_periph_ctrl_power_enable .text.sar_periph_ctrl_power_enable)
 
     *libzephyr.a:esp_system_chip.*(.literal.esp_system_abort .text.esp_system_abort)
@@ -644,6 +645,7 @@ SECTIONS
     *libzephyr.a:cpu_region_protect.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
 
     *libzephyr.a:periph_ctrl.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *libzephyr.a:regi2c_ctrl.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
 
     *libzephyr.a:esp_flash_api.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
     *libzephyr.a:esp_flash_spi_init.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)

--- a/soc/espressif/esp32s3/default.ld
+++ b/soc/espressif/esp32s3/default.ld
@@ -509,7 +509,13 @@ SECTIONS
     . = ALIGN(4) + 16;
   } GROUP_LINK_IN(RAMABLE_REGION)
 
+
+//#ifdef CONFIG_BOOTLOADER_MCUBOOT
+#ifdef CONFIG_MCUBOOT
+  .dram1.data :
+#else
   .dram0.data :
+#endif
   {
     . = ALIGN (8);
     _data_start = ABSOLUTE(.);

--- a/west.yml
+++ b/west.yml
@@ -157,7 +157,7 @@ manifest:
       groups:
         - hal
     - name: hal_espressif
-      revision: 23c17a8735d3047da95e3a81adafa36425636c55
+      revision: pull/362/head
       path: modules/hal/espressif
       west-commands: west/west-commands.yml
       groups:


### PR DESCRIPTION
This PR is the complementary to [hal_espressif PR#362](https://github.com/zephyrproject-rtos/hal_espressif/pull/362) which aims to get rid of the BOOTLOADER_BUILD flag and split API for a group of functions