### PR TITLE
drivers: w1: updates to reflect acquistion of maxim by analog devices

### DIFF
--- a/doc/hardware/peripherals/w1.rst
+++ b/doc/hardware/peripherals/w1.rst
@@ -52,7 +52,7 @@ In Zephyr this API is split into the following layers.
      includes a 8-bit `1-Wire Family Code`_ and a 8-bit CRC.
    * In order to find slaves on the bus, the standard specifies an search
      algorithm which successively detects all slaves on the bus.
-     This algorithm is described in detail by `Maxim's Applicationnote 187`_.
+     This algorithm is described in the `1-Wire Search Algorithm Application Note`_.
 
 * Transport layer and Presentation layer functions are not implemented in the
   generic 1-Wire driver and therefore must be handled in individual slave drivers.
@@ -91,10 +91,10 @@ Functions that are not directly related to any of the networking layers.
 
 
 .. _BOOK OF IBUTTON STANDARDS:
-   https://www.maximintegrated.com/en/design/technical-documents/app-notes/9/937.html
+   https://www.analog.com/en/resources/technical-articles/book-of-ibuttonreg-standards.html
 
 .. _1-Wire Family Code:
-   https://www.maximintegrated.com/en/design/technical-documents/app-notes/1/155.html
+   https://www.analog.com/en/resources/technical-articles/1wire-software-resource-guide-device-description.html
 
-.. _Maxim's Applicationnote 187:
-   https://www.maximintegrated.com/en/design/technical-documents/app-notes/1/187.html
+.. _1-Wire Search Algorithm Application Note:
+   https://www.analog.com/en/resources/app-notes/1wire-search-algorithm.html

--- a/drivers/sensor/maxim/ds18b20/ds18b20.c
+++ b/drivers/sensor/maxim/ds18b20/ds18b20.c
@@ -5,12 +5,10 @@
  */
 
 /**
- * Driver for DS18B20 1-Wire temperature sensors
- * A datasheet is available at:
- * https://datasheets.maximintegrated.com/en/ds/DS18B20.pdf
- *
- * Driver also support the older DS18S20 1-Wire temperature sensors.
- * https://www.analog.com/media/en/technical-documentation/data-sheets/ds18b20.pdf
+ * Driver for DS18B20 and DS18S20 1-Wire temperature sensors
+ * Datasheets for the compatible sensors are available at:
+ * - https://www.analog.com/media/en/technical-documentation/data-sheets/ds18b20.pdf
+ * - https://www.analog.com/media/en/technical-documentation/data-sheets/ds18s20.pdf
  *
  * Parasite power configuration is not supported by the driver.
  */

--- a/drivers/w1/w1_ds2477_85_common.c
+++ b/drivers/w1/w1_ds2477_85_common.c
@@ -5,7 +5,7 @@
  */
 
 /**
- * @brief Common functions for Maxim DS2477,DS2485 1-Wire Masters
+ * @brief Common functions for Analog Devices DS2477,DS2485 1-Wire Masters
  */
 
 #include "w1_ds2477_85_common.h"

--- a/drivers/w1/w1_ds2485.c
+++ b/drivers/w1/w1_ds2485.c
@@ -7,7 +7,7 @@
 #define DT_DRV_COMPAT maxim_ds2485
 
 /**
- * @brief Driver for the Maxim ds2485 1-Wire Master
+ * @brief Driver for the Analog Devices DS2485 1-Wire Master
  */
 
 #include "w1_ds2477_85_common.h"

--- a/drivers/w1/w1_net.c
+++ b/drivers/w1/w1_net.c
@@ -31,7 +31,9 @@ LOG_MODULE_REGISTER(w1, CONFIG_W1_LOG_LEVEL);
  * W1_SEARCH_LAST_SLAVE, and in case no slave participated in the search,
  * the discrepancy is set to W1_SEARCH_NO_SLAVE.
  *
- * The implementation is similar to suggested in the maxim application note 187.
+ * The implementation is similar to that suggested in the Maxim Integrated
+ * application note 187.
+ * @see https://www.analog.com/media/en/technical-documentation/app-notes/1wire-search-algorithm.pdf
  * The master reads the first ROM bit and its complementary value of all slaves.
  * Due to physical characteristics, the value received is a
  * logical AND of all slaves' 1st bit. Slaves only continue to

--- a/drivers/w1/w1_zephyr_gpio.c
+++ b/drivers/w1/w1_zephyr_gpio.c
@@ -16,11 +16,11 @@
  * The driver supports both standard speed and overdrive speed modes.
  *
  * This driver is heavily based on the w1_zephyr_serial.c driver and the
- * technical documentation from Maxim Integrated.
+ * technical article from Analog Devices.
  *
  * - w1_zephyr_serial.c: drivers/w1/w1_zephyr_serial.c
- * - Maxim Integrated 1-Wire Communication Through Software:
- * https://www.analog.com/en/technical-articles/1wire-communication-through-software.html
+ * - Analog Devices 1-Wire Communication Through Software:
+ * https://www.analog.com/en/resources/technical-articles/1wire-communication-through-software.html
  */
 
 #include <zephyr/drivers/gpio.h>

--- a/drivers/w1/w1_zephyr_serial.c
+++ b/drivers/w1/w1_zephyr_serial.c
@@ -13,7 +13,7 @@
  * The driver uses a uart peripheral with a baudrate of 115.2 kBd to send
  * and receive data bits and a baurade of 9.6 kBd for slave reset and
  * presence detection as suggested for normal speed operating mode in:
- * https://www.maximintegrated.com/en/design/technical-documents/tutorials/2/214.html
+ * https://www.analog.com/en/resources/technical-articles/using-a-uart-to-implement-a-1wire-bus-master.html
  * For overdrive speed communication baudrates of 1 MBd and 115.2 kBd
  * are used, respectively.
  */

--- a/include/zephyr/drivers/w1.h
+++ b/include/zephyr/drivers/w1.h
@@ -435,7 +435,7 @@ struct w1_rom {
 	/** @brief The 1-Wire family code identifying the slave device type.
 	 *
 	 * An incomplete list of family codes is available at:
-	 * https://www.maximintegrated.com/en/app-notes/index.mvp/id/155
+	 * https://www.analog.com/en/resources/technical-articles/1wire-software-resource-guide-device-description.html
 	 * others are documented in the respective device data sheet.
 	 */
 	uint8_t family;
@@ -584,7 +584,7 @@ int w1_write_read(const struct device *dev, const struct w1_slave_config *config
  * If a callback is passed, the callback is called for each found slave.
  *
  * The algorithm mostly follows the suggestions of
- * https://pdfserv.maximintegrated.com/en/an/AN187.pdf
+ * https://www.analog.com/en/resources/app-notes/1wire-search-algorithm.html
  *
  * Note: Filtering on families is not supported.
  *
@@ -695,7 +695,7 @@ static inline uint8_t w1_crc8(const uint8_t *src, size_t len)
  * X^16 + X^15 * + X^2 + 1 with the initial value set to 0x0000.
  * See also APPLICATION NOTE 27:
  * "UNDERSTANDING AND USING CYCLIC REDUNDANCY CHECKS WITH MAXIM 1-WIRE AND IBUTTON PRODUCTS"
- * https://www.maximintegrated.com/en/design/technical-documents/app-notes/2/27.html
+ * https://www.analog.com/en/resources/technical-articles/understanding-and-using-cyclic-redundancy-checks-with-maxim-1wire-and-ibutton-products.html
  *
  * @param seed    Init value for the CRC, it is usually set to 0x0000.
  * @param[in] src Input bytes for the computation.

--- a/samples/sensor/ds18b20/README.rst
+++ b/samples/sensor/ds18b20/README.rst
@@ -8,10 +8,10 @@ Overview
 ********
 
 This sample shows how to use the Zephyr :ref:`sensor` API driver for the
-`Maxim DS18B20`_ temperature sensor.
+`DS18B20`_ 1-Wire temperature sensor.
 
-.. _Maxim DS18B20:
-   https://www.maximintegrated.com/en/products/sensors/DS18B20.html
+.. _DS18B20:
+   https://www.analog.com/en/products/ds18b20.html
 
 The sample periodically reads temperature data from the
 first available DS18B20 device discovered in the system. The sample checks the
@@ -28,7 +28,7 @@ as shown in the Figure Hardware Configuration of the `DS18B20 datasheet`_ at
 page 10.
 
 .. _DS18B20 datasheet:
-   https://datasheets.maximintegrated.com/en/ds/DS18B20.pdf
+   https://www.analog.com/media/en/technical-documentation/data-sheets/ds18b20.pdf
 
 Boards with a built-in DS18B20 or a board-specific overlay
 ==========================================================


### PR DESCRIPTION
After the acquisition of Maxim Integrated the documentation of these devices has been moved to the analog.com website. Redirects exist, so they are not broken yet, but we should not rely on that forever.
Therefore the links in the drivers and the sensor sample are updated.