### PR TITLE
driver/dma_smartbond: Fix driver initialization when PM_DEVICE is set

### DIFF
--- a/drivers/dma/dma_smartbond.c
+++ b/drivers/dma/dma_smartbond.c
@@ -188,7 +188,9 @@ static inline void dma_smartbond_pm_policy_state_lock_get(void)
 static inline void dma_smartbond_pm_policy_state_lock_put(void)
 {
 #if defined(CONFIG_PM_DEVICE)
-	pm_policy_state_lock_put(PM_STATE_STANDBY, PM_ALL_SUBSTATES);
+	if (pm_policy_state_lock_is_active(PM_STATE_STANDBY, PM_ALL_SUBSTATES)) {
+		pm_policy_state_lock_put(PM_STATE_STANDBY, PM_ALL_SUBSTATES);
+	}
 #endif
 }
 


### PR DESCRIPTION
Fix DMA driver initialization when PM_DEVICE is set.
Don't put PM policy state lock if it is not active.

Fixes #81083