### PR TITLE
doc: twister: Clarify that the minimums are rough

### DIFF
--- a/doc/develop/test/twister.rst
+++ b/doc/develop/test/twister.rst
@@ -415,11 +415,11 @@ levels: <list of levels>
     test will be selectable using the command line option ``--level <level name>``
 
 min_ram: <integer>
-    minimum amount of RAM in KB needed for this test to build and run. This is
+    estimated minimum amount of RAM in KB needed for this test to build and run. This is
     compared with information provided by the board metadata.
 
 min_flash: <integer>
-    minimum amount of ROM in KB needed for this test to build and run. This is
+    estimated minimum amount of ROM in KB needed for this test to build and run. This is
     compared with information provided by the board metadata.
 
 .. _twister_test_case_timeout:


### PR DESCRIPTION
There is no way to know for sure the size of an image built for a test, given that zephyr can build for so many different architectures, platforms, software supports, etc. So it should be clear that the filter for min_ram and min_flash on the twister testcases is an estimate, and not a strictly well known value.