### PR TITLE
Fix a disconnection 0x23 issue encoutered with new Intel meteor lake chip

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_remote.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_remote.c
@@ -682,11 +682,11 @@ static void rr_st_idle(struct ll_conn *conn, uint8_t evt, void *param)
 				    (ctx_local->proc == PROC_CONN_UPDATE &&
 				     ctx->proc == PROC_CONN_PARAM_REQ)) {
 					/* Central collision
-					* => Send reject
-					*
-					* Local central shall reject the PDU received from the 
-					* peripheral by issuing a reject, continues unaffected.
-					*/
+					 * => Send reject
+					 *
+					 * Local central shall reject the PDU received from the 
+					 * peripheral by issuing a reject, continues unaffected.
+					 */
 
 					/* Send reject */
 					struct node_rx_pdu *rx = (struct node_rx_pdu *)param;

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_remote.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_remote.c
@@ -681,8 +681,19 @@ static void rr_st_idle(struct ll_conn *conn, uint8_t evt, void *param)
 				if (ctx_local->proc == ctx->proc ||
 				    (ctx_local->proc == PROC_CONN_UPDATE &&
 				     ctx->proc == PROC_CONN_PARAM_REQ)) {
-					conn->llcp_terminate.reason_final =
-						BT_HCI_ERR_LL_PROC_COLLISION;
+					/* Central collision
+					* => Send reject
+					*
+					* Local central shall reject the PDU received from the 
+					* peripheral by issuing a reject, continues unaffected.
+					*/
+
+					/* Send reject */
+					struct node_rx_pdu *rx = (struct node_rx_pdu *)param;
+					struct pdu_data *pdu = (struct pdu_data *)rx->pdu;
+
+					conn->llcp.remote.reject_opcode = pdu->llctrl.opcode;
+					rr_act_reject(conn);
 				} else {
 					conn->llcp_terminate.reason_final =
 						BT_HCI_ERR_DIFF_TRANS_COLLISION;

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_remote.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_remote.c
@@ -684,7 +684,7 @@ static void rr_st_idle(struct ll_conn *conn, uint8_t evt, void *param)
 					/* Central collision
 					 * => Send reject
 					 *
-					 * Local central shall reject the PDU received from the 
+					 * Local central shall reject the PDU received from the
 					 * peripheral by issuing a reject, continues unaffected.
 					 */
 


### PR DESCRIPTION
From an improved BLE project on nRF5340, switch to new gen ULTRA7 (Meteor Lake soc integrating the bluetooth 5.4) and get issue on ble connections: disconnection with reason 35 (BT_HCI_ERR_LL_PROC_COLLISION) following the connection. 

From BLUETOOTH CORE SPECIFICATION Version 5.3, seems that the central should reject instead of disconnect. This fixs the disconnection issue.