### PR TITLE
tests: drivers: clock control stm32 adc device clock setting

### DIFF
--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32_common_devices/boards/g0_i2c1_sysclk_lptim1_lsi.overlay
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32_common_devices/boards/g0_i2c1_sysclk_lptim1_lsi.overlay
@@ -77,6 +77,6 @@
 };
 
 &adc1 {
-	/* Basic test only. Don't configure domain clock. */
+	/* Basic test only. ADC1 domain clock is set by the board DTS : SYSCLK */
 	status = "okay";
 };


### PR DESCRIPTION
Tests the ADC clock domain on the stm32g0 serie
Possible ADC clock sources are system clock or PLL_P or HSI

Running the tests/drivers/clock_control/stm32_clock_configuration/stm32_common_devices on the nucleo_g071rb
with boards/g0_i2c1_sysclk_lptim1_lsi.overlay, can detect the ADC clock sources :
- STM32_SRC_SYSCLK
- STM32_SRC_PLL_P
- STM32_SRC_HSI