### PR TITLE
drivers: sensor: sensirion: sht4x: update measurement duration

### DIFF
--- a/drivers/sensor/sensirion/sht4x/sht4x.h
+++ b/drivers/sensor/sensirion/sht4x/sht4x.h
@@ -41,7 +41,7 @@ static const uint8_t measure_cmd[3] = {
 };
 
 static const uint16_t measure_wait_us[3] = {
-	1700, 4500, 8200
+	1600, 4500, 8300
 };
 
 /*


### PR DESCRIPTION
Update the measurement durations for the sht4x sensor driver in accordance with the datasheet revision 6.6 (2024-04).

According to the revision history the timings have been slightly adjusted by Sensirion in rev. 3 of the datasheet.
They can be found in section _3.1 Timings_.

https://sensirion.com/media/documents/33FD6951/662A593A/HT_DS_Datasheet_SHT4x.pdf