### PR TITLE
bluetooth: shell: avoid multiple `strlen` calls

### DIFF
--- a/subsys/bluetooth/host/shell/bt.c
+++ b/subsys/bluetooth/host/shell/bt.c
@@ -1769,16 +1769,17 @@ static int cmd_scan_filter_set_addr(const struct shell *sh, size_t argc,
 {
 	const size_t max_cpy_len = sizeof(scan_filter.addr) - 1;
 	const char *addr_arg = argv[1];
+	size_t len = strlen(addr_arg);
 
 	/* Validate length including null terminator. */
-	if (strlen(addr_arg) > max_cpy_len) {
+	if (len > max_cpy_len) {
 		shell_error(ctx_shell, "Invalid address string: %s\n",
 			    addr_arg);
 		return -ENOEXEC;
 	}
 
 	/* Validate input to check if valid (subset of) BT address */
-	for (size_t i = 0; i < strlen(addr_arg); i++) {
+	for (size_t i = 0; i < len; i++) {
 		const char c = addr_arg[i];
 		uint8_t tmp;
 


### PR DESCRIPTION
Add `len` to store the result of `strlen(addr_arg)` to avoid multiple calls to `strlen` within the `for-loop` in `cmd_scan_filter_set_addr`.
While the performance impact may be minimal in a shell context, storing `strlen(addr_arg)` in `len` ensures a single call, making the code more predictable and consistent.
