### PR TITLE
eSPI: NPCX/ITE: Enable conditional virtual wire valid bit check

### DIFF
--- a/drivers/espi/Kconfig
+++ b/drivers/espi/Kconfig
@@ -46,6 +46,15 @@ config ESPI_VWIRE_CHANNEL
 	help
 	  eSPI Controller supports virtual wires channel.
 
+config ESPI_VWIRE_VALID_BIT_CHECK
+	bool "eSPI virtual wire valid bit check"
+	default y
+	depends on ESPI_VWIRE_CHANNEL
+	help
+	  Enable the checking of the eSPI virtual wire valid bit. If this
+	  configuration is not set, treat the new values as the previously
+	  retained valid values and return the received virtual wire level.
+
 config ESPI_AUTOMATIC_WARNING_ACKNOWLEDGE
 	bool "Automatic acknowledge for eSPI HOST warnings"
 	default y

--- a/drivers/espi/espi_it8xxx2.c
+++ b/drivers/espi/espi_it8xxx2.c
@@ -730,11 +730,15 @@ static int espi_it8xxx2_receive_vwire(const struct device *dev,
 		return -EIO;
 	}
 
-	if (vw_reg->VW_INDEX[vw_index] & valid_mask) {
-		*level = !!(vw_reg->VW_INDEX[vw_index] & level_mask);
+	if (IS_ENABLED(CONFIG_ESPI_VWIRE_VALID_BIT_CHECK)) {
+		if (vw_reg->VW_INDEX[vw_index] & valid_mask) {
+			*level = !!(vw_reg->VW_INDEX[vw_index] & level_mask);
+		} else {
+			/* Not valid */
+			*level = 0;
+		}
 	} else {
-		/* Not valid */
-		*level = 0;
+		*level = !!(vw_reg->VW_INDEX[vw_index] & level_mask);
 	}
 
 	return 0;

--- a/drivers/espi/espi_npcx.c
+++ b/drivers/espi/espi_npcx.c
@@ -872,8 +872,11 @@ static int espi_npcx_receive_vwire(const struct device *dev,
 
 			val = GET_FIELD(inst->VWEVMS[reg_idx],
 							NPCX_VWEVMS_WIRE);
-			val &= GET_FIELD(inst->VWEVMS[reg_idx],
+
+			if (IS_ENABLED(CONFIG_ESPI_VWIRE_VALID_BIT_CHECK)) {
+				val &= GET_FIELD(inst->VWEVMS[reg_idx],
 							NPCX_VWEVMS_VALID);
+			}
 
 			*level = !!(val & bitmask);
 			return 0;
@@ -888,8 +891,12 @@ static int espi_npcx_receive_vwire(const struct device *dev,
 
 			val = GET_FIELD(inst->VWEVSM[reg_idx],
 							NPCX_VWEVSM_WIRE);
-			val &= GET_FIELD(inst->VWEVSM[reg_idx],
+
+			if (IS_ENABLED(CONFIG_ESPI_VWIRE_VALID_BIT_CHECK)) {
+				val &= GET_FIELD(inst->VWEVSM[reg_idx],
 							NPCX_VWEVSM_VALID);
+			}
+
 			*level = !!(val & bitmask);
 			return 0;
 		}


### PR DESCRIPTION
On the new Intel SoC, the "Valid" bit of the Virtual Wire is set only for Virtual Wires that undergo changes. This behavior differs from previous generations. Therefore, to maintain backward compatibility, a conditional check for the virtual wire valid bit is added for processing the virtual wire level.