### PR TITLE
drivers: flexspi_nor: Fix Flash failures seen on FRDM-MCXN947

### DIFF
--- a/drivers/flash/flash_mcux_flexspi_nor.c
+++ b/drivers/flash/flash_mcux_flexspi_nor.c
@@ -978,6 +978,13 @@ static int flash_flexspi_nor_check_jedec(struct flash_flexspi_nor_data *data,
 		/* Still return an error- we want the JEDEC configuration to run */
 		return -ENOTSUP;
 	case 0x40ef:
+		if ((vendor_id & 0xFFFFFF) != 0x2040ef) {
+			/*
+			 * This is not the correct flash chip, and will not
+			 * support the LUT table. Return here
+			 */
+			return -ENOTSUP;
+		}
 		/* W25Q512JV flash, use 4 byte read/write */
 		flexspi_lut[READ][0] = FLEXSPI_LUT_SEQ(
 				kFLEXSPI_Command_SDR, kFLEXSPI_1PAD, SPI_NOR_CMD_4READ_4B,


### PR DESCRIPTION
The flash_flexspi_nor_check_jedec() checks the lower 16-bits of the manufacturer ID and installs a custom LUT table. Add an exception to check for the whole 24-bits so we do not accidentally install custom LUT for flash devices that do not support this LUT table.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/80223