### PR TITLE
modules: hal: nxp: update to include fix for CACHE64_GetInstanceByAddr()

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -198,7 +198,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: 6e7d5cf2e6463e1b6c967d85ce0032deaa15fb59
+      revision: c410b73bd00c2025b9f62bb53f99c5e8b6e45eb2
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
CACHE64_GetInstanceByAddr() function was asserting when an instance was requested for an invalid address that the CACHE64 controller does not manage. This behavior is not correct, as the CACHE64 management functions check to see if the instance number returned by this function is out of range (and if so, simply return without modifying the cache).

This assertion was causing a failure within the USDHC driver, which performs a cache clean/invalidate for tx/rx transfers within the HAL layer. When a transfer was run using a data buffer not in the CACHE64 address range, this assertion failed and caused the application to crash

Fixes #80901