### PR TITLE
tests: Fix sched benchmark exception on qemu_riscv64

### DIFF
--- a/tests/benchmarks/sched/src/main.c
+++ b/tests/benchmarks/sched/src/main.c
@@ -112,6 +112,7 @@ int main(void)
 		key = arch_irq_lock();
 		stamp(UNPENDING);
 		z_unpend_first_thread(&waitq);
+		arch_irq_unlock(key);
 		stamp(UNPENDED_READYING);
 		z_ready_thread(th);
 		stamp(READIED_YIELDING);
@@ -124,7 +125,6 @@ int main(void)
 		 */
 		k_yield();
 		stamp(YIELDED);
-		arch_irq_unlock(key);
 
 		uint32_t avg, whole = stamps[4] - stamps[0];
 


### PR DESCRIPTION
Corrects an issue that was introduced when the interrupt locking/unlocking was added to the 'sched' benchmark by unlocking the interrupts before the context switch done by k_yield(), but after the call to z_unpend_first_thread().

Fixes #81050