### PR TITLE
Restore missing tests for nrf54l15

### DIFF
--- a/tests/drivers/gpio/gpio_basic_api/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	resources {
+		compatible = "test-gpio-basic-api";
+		out-gpios = <&gpio1 10 0>;
+		in-gpios = <&gpio1 11 0>;
+	};
+};
+
+&gpiote20 {
+	status = "okay";
+};
+
+&gpio1 {
+	status = "okay";
+};

--- a/tests/drivers/sensor/temp_sensor/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/tests/drivers/sensor/temp_sensor/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -1,0 +1,3 @@
+temp_sensor: &temp {
+	status = "okay";
+};


### PR DESCRIPTION
Incorrectly removed during transfer pdk->dk at #79944