### PR TITLE
doc: ci: Build documentation on board documentation changes

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -42,6 +42,7 @@ jobs:
       with:
         files: |
           doc/
+          boards/**/doc/
           **.rst
           include/
           kernel/include/kernel_arch_interface.h


### PR DESCRIPTION
Adds glob expression triggering CI for *all* changes in boards' documentation, not just those matching the "*.rst" pattern since there can also be images being changed without any other change on RST files.