### PR TITLE
drivers: nrfwifi: Fix recovery for SAP

### DIFF
--- a/drivers/wifi/nrfwifi/Kconfig.nrfwifi
+++ b/drivers/wifi/nrfwifi/Kconfig.nrfwifi
@@ -650,7 +650,9 @@ config NRF_WIFI_AP_DEAD_DETECT_TIMEOUT
 
 config NRF_WIFI_RPU_RECOVERY
 	bool "RPU recovery mechanism"
+	# Relies on power-save mode, so, LPM is needed and AP mode is not supported
 	depends on NRF_WIFI_LOW_POWER
+	depends on !NRF70_AP_MODE
 	default y
 	select EXPERIMENTAL
 	help


### PR DESCRIPTION
nRF70 recovery relies on power-management feature which isn't applicable for SAP, so, we keep seeing false recovery causing interface restart.

Disabled recovery for SAP to fix the issue.

Fixes #81130.