### PR TITLE
doc: release-notes: Add 4.0.0 release notes for networking

### DIFF
--- a/doc/releases/release-notes-4.0.rst
+++ b/doc/releases/release-notes-4.0.rst
@@ -537,58 +537,245 @@ Drivers and Sensors
 Networking
 **********
 
+* 802.15.4:
+
+  * Implemented support for beacons without association bit.
+  * Implemented support for beacons payload.
+  * Fixed a bug where LL address endianness was swapped twice when deciphering a frame.
+  * Fixed missing context lock release when checking destination address.
+  * Improved error logging in 6LoWPAN fragmentation.
+  * Improved error logging in 802.15.4 management commands.
+
 * ARP:
+
+  * Fixed ARP probe verification during IPv4 address conflict detection.
 
 * CoAP:
 
-* Connection manager:
+  * Added new API :c:func:`coap_rst_init` to simplify creating RST replies.
+  * Implemented replying with CoAP RST response for unknown queries in CoAP client.
+  * Added support for runtime configuration of ACK random factor parameter.
+  * Added support for No Response CoAP option.
+  * Added a new sample demonstrating downloading a resource with GET request.
+  * Fixed handling of received CoAP RST reply in CoAP client.
+  * Fixed socket error reporting to the application in CoAP client.
+  * Fixed handling of response retransmissions in CoAP client.
+  * Fixed a bug where CoAP block numbers were limited to ``uint8_t``.
+  * Various fixes in the block transfer support in CoAP client.
+  * Improved handling of truncated datagrams in CoAP client.
+  * Improved thread safety of CoAP client.
+  * Fixed missing ``static`` keyword in some internal functions.
+  * Various other minor fixes in CoAP client.
 
 * DHCPv4:
 
+  * Added support for parsing multiple DNS servers received from DHCP server.
+  * Added support for DNS Server option in DHCPv4 server.
+  * Added support for Router option in DHCPv4 server.
+  * Added support for application callback which allows to assign custom addresses
+    in DHCPv4 server.
+  * Fixed DNS server list allocation in DHCPv4 client.
+  * Fixed a bug where system workqueue could be blocked indefinitely by DHCPv4 client.
+
 * DHCPv6:
+
+  * Fixed a bug where system workqueue could be blocked indefinitely by DHCPv6 client.
 
 * DNS/mDNS/LLMNR:
 
+  * Added support for collecting DNS statistics.
+  * Added support for more error codes in :c:func:`zsock_gai_strerror`.
+  * Fixed handling of DNS responses encoded with capital letters.
+  * Fixed DNS dispatcher operation on multiple network interfaces.
+  * Fixed error being reported for mDNS queries with query count equal to 0.
+  * Various other minor fixes in DNS/mDNS implementations.
+
+* Ethernet:
+
 * gPTP/PTP:
+
+  * Fixed handling of second overflow/underflow.
+  * Fixed PTP clock adjusting with offset.
 
 * HTTP:
 
-* IPSP:
+  * Added support for specifying response headers and response code by the application.
+  * Added support for netusb in the HTTP server sample.
+  * Added support for accessing HTTP request headers from the application callback.
+  * Added support for handling IPv4 connections over IPv6 socket in HTTP server.
+  * Added support for creating HTTP server instances without specifying local host.
+  * Added overlays to support HTTP over IEEE 802.15.4 for HTTP client and server
+    samples.
+  * Added support for static filesystem resources in HTTP server.
+  * Fixed assertion in HTTP server sample when resource upload was aborted.
+  * Refactored dynamic resource callback format for easier handling of short
+    requests/replies.
+  * Fixed possible busy-looping in case of errors in the HTTP server sample.
+  * Fixed possible incorrect HTTP headers matching in HTTP server.
+  * Refactored HTTP server sample to better demonstrate server use cases.
+  * Fixed processing of multiple HTTP/1 requests over the same connection.
+  * Improved HTTP server test coverage.
+  * Various other minor fixes in HTTP server.
 
 * IPv4:
 
+  * Improved IGMP test coverage.
+  * Fixed IGMPv2 queries processing when IGMPv3 is enabled.
+  * Fixed :kconfig:option:`CONFIG_NET_NATIVE_IPV4` dependency for native IPv4 options.
+  * Fix net_pkt leak in :c:func:`send_ipv4_fragment`.`
+
 * IPv6:
 
-* LwM2M:
-  * Location object: optional resources altitude, radius, and speed can now be
-  used optionally as per the location object's specification. Users of these
-  resources will now need to provide a read buffer.
+  * Added a public header for Multicast Listener Discovery APIs.
+  * Added new :c:func:`net_ipv6_addr_prefix_mask` API function.
+  * Made IPv6 Router Solicitation timeout configurable.
+  * Fixed endless IPv6 packet looping with both routing and VLAN support enabled.
+  * Fixed unneeded error logging in case of dropped NS packets.
+  * Fixed accepting of incoming DAD NS messages.
+  * Various fixes improving IPv6 routing.
 
-  * lwm2m_senml_cbor: Regenerated generated code files using zcbor 0.9.0
+* LwM2M:
+
+  * Added TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8 to DTLS cipher list.
+  * Added LwM2M shell command for listing resources.
+  * Added LwM2M shell command to list observations.
+  * Added support for accepting SenML-CBOR floats decoded as integers.
+  * Added support for X509 hostname verification if using certificates, when
+    URI contains valid name.
+  * Regenerated generated code files using zcbor 0.9.0 for lwm2m_senml_cbor.
+  * Improved thread safety of the LwM2M engine.
+  * Fixed block transfer issues for composite operations.
+  * Fixed enabler version reporting during bootstrap discovery.
+  * Removed unneeded Security object instance from the LwM2M client sample.
+  * Fixed buffer size check for U16 resource.
+  * Removed deprecated APIs and configs.
+  * Optional Location object resources altitude, radius, and speed can now be
+    used optionally as per the location object's specification. Users of these
+    resources will now need to provide a read buffer.
+  * Fixed the retry counter not being reset on successful Registration update.
+  * Fixed REGISTRATION_TIMEOUT event not always being emitted on registration
+    errors.
+  * Fixed c++ support in LwM2M public header.
+  * Fixed a bug where DISCONNECTED event was not always emitted when needed.
 
 * Misc:
 
+  * Added support for network packet allocation statistics.
+  * Added a new library implementing Prometheus monitoring support.
+  * Added USB CDC NCM support for Echo Server sample.
+  * Added packet drop statistics for capture interfaces.
+  * Added new :c:func:`net_hostname_set_postfix_str` API function to set hostname
+    postfix in non-hexadecimal format.
+  * Added API version information to public networking headers.
+  * Implemented optional periodic SNTP time resynchronization.
+  * Improved error reporting when starting/stopping virtual interfaces.
+  * Fixed build error of packet capture library when variable sized buffers are used.
+  * Fixed build error of packet capture library when either IPv4 or IPv6 is disabled.
+  * Fixed CMake complaint about missing sources in net library in certain
+    configurations.
+  * Fixed compilation issues with networking and SystemView Tracing enabled.
+  * Removed redundant DHCPv4 code from telnet sample.
+  * Fixed build warnings in Echo Client sample with IPv6 disabled.
+  * Removed deprecated net_pkt functions.
+  * Extended network tracing support and added documentation page
+    (:ref:`network_tracing`).
+  * Moved network buffers implementation out of net subsystem into lib directory
+    and renamed public header to :zephyr_file:`include/zephyr/net_buf.h`.
+  * Deprecated the :c:func:`net_buf_put` and :c:func:`net_buf_get` API functions.
+  * Removed ``wpansub`` sample.
+
 * MQTT:
+
+  * Updated information in the mqtt_publisher sample about Mosquitto broker
+    configuration.
+  * Updated MQTT tests to be self-contained, no longer requiring external broker.
+  * Optimized buffer handling in MQTT encoder/decoder.
+
+* Network contexts:
+
+  * Fixed IPv4 destination address setting when using :c:func:`sendmsg` with
+    :kconfig:option:`CONFIG_NET_IPV4_MAPPING_TO_IPV6` option enabled.
+  * Fixed possible unaligned memory access when in :c:func:`net_context_bind`.
+  * Fixed missing NULL pointer check for V6ONLY option read.
 
 * Network Interface:
 
-* OpenThread
+  * Added new :c:func:`net_if_ipv4_get_gw` API function.
+  * Fixed checksum offloading checks for VLAN interfaces.
+  * Fixed native IP support being required to  register IP addresses on an
+    interface.
+  * Fixed missing mutex locks in a few net_if functions.
+  * Fixed rejoining of IPv6 multicast groups.
+  * Fixed :c:func:`net_if_send_data` operation for offloaded interfaces.
+  * Fixed needless IPv6 multicast groups joining if IPv6 is disabled.
+  * Fixed compiler warnings when building with ``-Wtype-limits``.
 
-* PPP
+* OpenThread:
+
+  * Added support for :kconfig:option:`CONFIG_IEEE802154_SELECTIVE_TXCHANNEL`
+    option in OpenThread radio platform.
+  * Added NAT64 send and receive callbacks.
+  * Added new Kconfig options:
+
+    * :kconfig:option:`CONFIG_OPENTHREAD_NAT64_CIDR`
+    * :kconfig:option:`CONFIG_OPENTHREAD_STORE_FRAME_COUNTER_AHEAD`
+    * :kconfig:option:`CONFIG_OPENTHREAD_DEFAULT_RX_SENSITIVITY`
+    * :kconfig:option:`CONFIG_OPENTHREAD_CSL_REQUEST_TIME_AHEAD`
+
+  * Fixed deprecated/preferred IPv6 address state transitions.
+  * Fixed handling of deprecated IPv6 addresses.
+  * Other various minor fixes in Zephyr's OpenThread port.
 
 * Shell:
 
+  * Added support for enabling/disabling individual network shell commands with
+    Kconfig.
+  * Added new ``net dhcpv4/6 client`` commands for DHCPv4/6 client management.
+  * Added new ``net virtual`` commands for virtual interface management.
+  * ``net ipv4/6`` commands are now available even if native IP stack is disabled.
+  * Added new ``net cm`` commands exposing Connection Manager functionality.
+  * Fixed possible assertion if telnet shell backend connection is terminated.
+  * Event monitor thread stack size is now configurable with Kconfig.
+  * Relocated ``bridge`` command under ``net`` command, i. e. ``net bridge``.
+  * Multiple minor improvements in various command outputs.
+
 * Sockets:
 
-* Syslog:
+  * Added dedicated ``net_socket_service_handler_t`` callback function type for
+    socket services.
+  * Added TLS 1.3 support for TLS sockets.
+  * Fixed socket leak when closing NSOS socket.
+  * Moved socket service library out of experimental.
+  * Deprecated ``CONFIG_NET_SOCKETS_POLL_MAX``.
+  * Moved ``zsock_poll()`` and ``zsock_select`` implementations into ``zvfs``
+    library.
+  * Removed ``work_q`` parameter from socket service macros as it was no longer
+    used.
+  * Separated native INET sockets implementation from socket syscalls so that
+    it doesn't have to be built when offloaded sockets are used.
+  * Fixed possible infinite block inside TLS socket :c:func:`zsock_connect` when
+    peer goes down silently.
+  * Fixed ``msg_controllen`` not being set correctly in :c:func:`zsock_recvmsg`.
+  * Fixed possible busy-looping when polling TLS socket for POLLOUT event.
 
 * TCP:
 
+  * Fixed propagating connection errors to the socket layer.
+  * Improved ACK reply logic when peer does not send PSH flag with data.
+
 * Websocket:
+
+  * Added support for Websocket console in the Echo Server sample.
+  * Fixed undefined reference to ``MSG_DONTWAIT`` while building websockets
+    without POSIX.
 
 * Wi-Fi:
 
 * zperf:
+
+  * Added support for USB CDC NCM in the zperf sample.
+  * Fixed DHCPv4 client not being started in the zperf sample in certain
+    configurations.
 
 USB
 ***


### PR DESCRIPTION
Add 4.0.0 release notes for networking.

Ethernet && Wi-Fi TBD separately.