### PR TITLE
tests: drivers: watchdog window reduced to fit stm32 board config

### DIFF
--- a/tests/drivers/watchdog/wdt_basic_api/src/test_wdt.c
+++ b/tests/drivers/watchdog/wdt_basic_api/src/test_wdt.c
@@ -71,7 +71,12 @@
 #elif DT_HAS_COMPAT_STATUS_OKAY(st_stm32_window_watchdog)
 #define WDT_NODE DT_INST(0, st_stm32_window_watchdog)
 #define TIMEOUTS 0
-#define WDT_TEST_MAX_WINDOW 200
+/* Boards where the sysclock is high and APB1 prescaler 16 requires a lower WDG window */
+#if defined(CONFIG_SOC_SERIES_STM32H7X)
+#define WDT_TEST_MAX_WINDOW 200U
+#else
+#define WDT_TEST_MAX_WINDOW 170U
+#endif /* CONFIG_SOC_SERIES_STM32H7X */
 #elif DT_HAS_COMPAT_STATUS_OKAY(st_stm32_watchdog)
 #define WDT_NODE DT_INST(0, st_stm32_watchdog)
 #define TIMEOUTS 0
@@ -159,8 +164,8 @@ static struct wdt_timeout_cfg m_cfg_wdt1;
  */
 volatile DATATYPE m_state __attribute__((section(NOINIT_SECTION)));
 
-/* m_testcase_index is incremented after each test to make test possible
- * switch to next testcase.
+	/* m_testcase_index is incremented after each test to make test possible
+	 * switch to next testcase.
  */
 volatile DATATYPE m_testcase_index __attribute__((section(NOINIT_SECTION)));
 


### PR DESCRIPTION
Reduce the windows watchdog so that any stm32 target can pass the tests/drivers/watchdog/wdt_basic_api whatever their sysclock and APB clock.
Especially nucleo_f429 and nucleo_f746

