### PR TITLE
Add Posix netinet_in.h additions

### DIFF
--- a/include/zephyr/net/net_ip.h
+++ b/include/zephyr/net/net_ip.h
@@ -438,6 +438,9 @@ extern const struct in6_addr in6addr_loopback;
 /** IPv4 any address */
 #define INADDR_ANY 0
 
+/** IPv4 broadcast address */
+#define INADDR_BROADCAST 0xffffffff
+
 /** IPv4 address initializer */
 #define INADDR_ANY_INIT { { { INADDR_ANY } } }
 

--- a/include/zephyr/net/socket.h
+++ b/include/zephyr/net/socket.h
@@ -1295,6 +1295,46 @@ struct in6_pktinfo {
 #define SOMAXCONN 128
 /** @} */
 
+/**
+ * @name Macros for checking special IPv6 addresses.
+ * @{
+ */
+/** Check unspecified IPv6 address. */
+#define IN6_IS_ADDR_UNSPECIFIED(addr) \
+	net_ipv6_addr_cmp(net_ipv6_unspecified_address(), addr)
+
+/** Check loopback IPv6 address. */
+#define IN6_IS_ADDR_LOOPBACK(addr) net_ipv6_is_addr_loopback(addr)
+
+/** Check IPv6 multicast address */
+#define IN6_IS_ADDR_MULTICAST(addr) net_ipv6_is_addr_mcast(addr)
+
+/** Check IPv6 link local address */
+#define IN6_IS_ADDR_LINKLOCAL(addr) net_ipv6_is_ll_addr(addr)
+
+/** Check IPv6 site local address */
+#define IN6_IS_ADDR_SITELOCAL(addr) net_ipv6_is_sl_addr(addr)
+
+/** Check IPv6 v4 mapped address */
+#define IN6_IS_ADDR_V4MAPPED(addr) net_ipv6_addr_is_v4_mapped(addr)
+
+/** Check IPv6 multicast global address */
+#define IN6_IS_ADDR_MC_GLOBAL(addr) net_ipv6_is_addr_mcast_global(addr)
+
+/** Check IPv6 multicast node local address */
+#define IN6_IS_ADDR_MC_NODELOCAL(addr) net_ipv6_is_addr_mcast_iface(addr)
+
+/** Check IPv6 multicast link local address */
+#define IN6_IS_ADDR_MC_LINKLOCAL(addr) net_ipv6_is_addr_mcast_link(addr)
+
+/** Check IPv6 multicast site local address */
+#define IN6_IS_ADDR_MC_SITELOCAL(addr) net_ipv6_is_addr_mcast_site(addr)
+
+/** Check IPv6 multicast organization local address */
+#define IN6_IS_ADDR_MC_ORGLOCAL(addr) net_ipv6_is_addr_mcast_org(addr)
+
+/** @} */
+
 /** @cond INTERNAL_HIDDEN */
 /**
  * @brief Registration information for a given BSD socket family.

--- a/include/zephyr/net/socket.h
+++ b/include/zephyr/net/socket.h
@@ -1225,6 +1225,12 @@ struct ip_mreqn {
 /** Leave IPv6 multicast group. */
 #define IPV6_DROP_MEMBERSHIP 21
 
+/** Join IPv6 multicast group. */
+#define IPV6_JOIN_GROUP IPV6_ADD_MEMBERSHIP
+
+/** Leave IPv6 multicast group. */
+#define IPV6_LEAVE_GROUP IPV6_DROP_MEMBERSHIP
+
 /**
  * @brief Struct used when joining or leaving a IPv6 multicast group.
  */

--- a/tests/posix/headers/src/netinet_in_h.c
+++ b/tests/posix/headers/src/netinet_in_h.c
@@ -58,7 +58,7 @@ ZTEST(posix_headers, test_netinet_in_h)
 	zassert_not_equal(-1, IPPROTO_UDP);
 
 	zassert_not_equal(-1, INADDR_ANY);
-	/* zassert_not_equal(-1, INADDR_BROADCAST); */ /* not implemented */
+	zassert_equal(0xffffffff, INADDR_BROADCAST);
 
 	zassert_equal(INET_ADDRSTRLEN, 16);
 	zassert_equal(INET6_ADDRSTRLEN, 46);

--- a/tests/posix/headers/src/netinet_in_h.c
+++ b/tests/posix/headers/src/netinet_in_h.c
@@ -65,10 +65,10 @@ ZTEST(posix_headers, test_netinet_in_h)
 
 	zassert_equal(IPV6_ADD_MEMBERSHIP, IPV6_JOIN_GROUP);
 	zassert_equal(IPV6_DROP_MEMBERSHIP, IPV6_LEAVE_GROUP);
-	/* zassert_not_equal(-1, IPV6_MULTICAST_HOPS); */ /* not implemented */
+	zassert_not_equal(-1, IPV6_MULTICAST_HOPS);
 	/* zassert_not_equal(-1, IPV6_MULTICAST_IF); */ /* not implemented */
 	/* zassert_not_equal(-1, IPV6_MULTICAST_LOOP); */ /* not implemented */
-	/* zassert_not_equal(-1, IPV6_UNICAST_HOPS); */ /* not implemented */
+	zassert_not_equal(-1, IPV6_UNICAST_HOPS);
 	zassert_not_equal(-1, IPV6_V6ONLY);
 
 	/* IN6_IS_ADDR_UNSPECIFIED(&any6); */ /* not implemented */

--- a/tests/posix/headers/src/netinet_in_h.c
+++ b/tests/posix/headers/src/netinet_in_h.c
@@ -62,10 +62,8 @@ ZTEST(posix_headers, test_netinet_in_h)
 	struct in6_addr mcg6 = { { { 0xff, 0x0e, 0, 0, 0, 0, 0, 0,
 				0, 0, 0, 0, 0, 0, 0, 0x01 } } };
 
-	/* not implemented */
-	/* zassert_not_equal(-1, offsetof(struct ipv6_mreq, ipv6mr_multiaddr)); */
-	/* not implemented */
-	/* zassert_not_equal(-1, offsetof(struct ipv6_mreq, ipv6mr_interface)); */
+	zassert_not_equal(-1, offsetof(struct ipv6_mreq, ipv6mr_multiaddr));
+	zassert_not_equal(-1, offsetof(struct ipv6_mreq, ipv6mr_ifindex));
 
 	zassert_not_equal(-1, IPPROTO_IP);
 	zassert_not_equal(-1, IPPROTO_IPV6);

--- a/tests/posix/headers/src/netinet_in_h.c
+++ b/tests/posix/headers/src/netinet_in_h.c
@@ -45,6 +45,23 @@ ZTEST(posix_headers, test_netinet_in_h)
 	struct in6_addr any6 = IN6ADDR_ANY_INIT;
 	struct in6_addr lo6 = IN6ADDR_LOOPBACK_INIT;
 
+	struct in6_addr mcast6 = { { { 0xff, 0 } } };
+	struct in6_addr ll6 = { { { 0xfe, 0x80, 0x01, 0x02,
+				0, 0, 0, 0, 0, 0x01 } } };
+	struct in6_addr sl6  = { { { 0xfe, 0xc0, 0, 0x01, 0x02 } } };
+	struct in6_addr v4mapped = { { { 0, 0, 0, 0, 0, 0, 0, 0,
+				0xff, 0xff, 0xff, 0xff, 0xc0, 0, 0x02, 0x01 } } };
+	struct in6_addr mcnl6 = { { { 0xff, 0x01, 0, 0, 0, 0, 0, 0,
+				0, 0, 0, 0, 0, 0, 0, 0x01 } } };
+	struct in6_addr mcll6 = { { { 0xff, 0x02, 0, 0, 0, 0, 0, 0,
+				0, 0, 0, 0, 0, 0, 0, 0x01 } } };
+	struct in6_addr mcsl6 = { { { 0xff, 0x05, 0, 0, 0, 0, 0, 0,
+				0, 0, 0, 0, 0, 0, 0, 0x01 } } };
+	struct in6_addr mcol6 = { { { 0xff, 0x08, 0, 0, 0, 0, 0, 0,
+				0, 0, 0, 0, 0, 0, 0, 0x01 } } };
+	struct in6_addr mcg6 = { { { 0xff, 0x0e, 0, 0, 0, 0, 0, 0,
+				0, 0, 0, 0, 0, 0, 0, 0x01 } } };
+
 	/* not implemented */
 	/* zassert_not_equal(-1, offsetof(struct ipv6_mreq, ipv6mr_multiaddr)); */
 	/* not implemented */
@@ -71,18 +88,18 @@ ZTEST(posix_headers, test_netinet_in_h)
 	zassert_not_equal(-1, IPV6_UNICAST_HOPS);
 	zassert_not_equal(-1, IPV6_V6ONLY);
 
-	/* IN6_IS_ADDR_UNSPECIFIED(&any6); */ /* not implemented */
-	/* IN6_IS_ADDR_LOOPBACK(&lo6); */ /* not implemented */
+	zassert_true(IN6_IS_ADDR_UNSPECIFIED(&any6));
+	zassert_true(IN6_IS_ADDR_LOOPBACK(&lo6));
 
-	/* IN6_IS_ADDR_MULTICAST(&lo6); */ /* not implemented */
-	/* IN6_IS_ADDR_LINKLOCAL(&lo6); */ /* not implemented */
-	/* IN6_IS_ADDR_SITELOCAL(&lo6); */ /* not implemented */
-	/* IN6_IS_ADDR_V4MAPPED(&lo6); */ /* not implemented */
+	zassert_true(IN6_IS_ADDR_MULTICAST(&mcast6));
+	zassert_true(IN6_IS_ADDR_LINKLOCAL(&ll6));
+	zassert_true(IN6_IS_ADDR_SITELOCAL(&sl6));
+	zassert_true(IN6_IS_ADDR_V4MAPPED(&v4mapped));
 	/* IN6_IS_ADDR_V4COMPAT(&lo6); */ /* not implemented */
-	/* IN6_IS_ADDR_MC_NODELOCAL(&lo6); */ /* not implemented */
-	/* IN6_IS_ADDR_MC_LINKLOCAL(&lo6); */ /* not implemented */
-	/* IN6_IS_ADDR_MC_SITELOCAL(&lo6); */ /* not implemented */
-	/* IN6_IS_ADDR_MC_ORGLOCAL(&lo6); */ /* not implemented */
-	/* IN6_IS_ADDR_MC_GLOBAL(&lo6); */ /* not implemented */
+	zassert_true(IN6_IS_ADDR_MC_NODELOCAL(&mcnl6));
+	zassert_true(IN6_IS_ADDR_MC_LINKLOCAL(&mcll6));
+	zassert_true(IN6_IS_ADDR_MC_SITELOCAL(&mcsl6));
+	zassert_true(IN6_IS_ADDR_MC_ORGLOCAL(&mcol6));
+	zassert_true(IN6_IS_ADDR_MC_GLOBAL(&mcg6));
 }
 #pragma GCC diagnostic pop

--- a/tests/posix/headers/src/netinet_in_h.c
+++ b/tests/posix/headers/src/netinet_in_h.c
@@ -21,27 +21,27 @@
  */
 ZTEST(posix_headers, test_netinet_in_h)
 {
-	zassert_equal(sizeof(in_port_t), sizeof(uint16_t));
-	zassert_equal(sizeof(in_addr_t), sizeof(uint32_t));
+	zexpect_equal(sizeof(in_port_t), sizeof(uint16_t));
+	zexpect_equal(sizeof(in_addr_t), sizeof(uint32_t));
 
-	zassert_not_equal(-1, offsetof(struct in_addr, s_addr));
+	zexpect_not_equal(-1, offsetof(struct in_addr, s_addr));
 
-	zassert_not_equal(-1, offsetof(struct sockaddr_in, sin_family));
-	zassert_not_equal(-1, offsetof(struct sockaddr_in, sin_port));
-	zassert_not_equal(-1, offsetof(struct sockaddr_in, sin_addr));
+	zexpect_not_equal(-1, offsetof(struct sockaddr_in, sin_family));
+	zexpect_not_equal(-1, offsetof(struct sockaddr_in, sin_port));
+	zexpect_not_equal(-1, offsetof(struct sockaddr_in, sin_addr));
 
-	zassert_not_equal(-1, offsetof(struct in6_addr, s6_addr));
-	zassert_equal(sizeof(((struct in6_addr *)NULL)->s6_addr), 16 * sizeof(uint8_t));
+	zexpect_not_equal(-1, offsetof(struct in6_addr, s6_addr));
+	zexpect_equal(sizeof(((struct in6_addr *)NULL)->s6_addr), 16 * sizeof(uint8_t));
 
-	zassert_not_equal(-1, offsetof(struct sockaddr_in6, sin6_family));
-	zassert_not_equal(-1, offsetof(struct sockaddr_in6, sin6_port));
+	zexpect_not_equal(-1, offsetof(struct sockaddr_in6, sin6_family));
+	zexpect_not_equal(-1, offsetof(struct sockaddr_in6, sin6_port));
 	/* not implemented */
-	/* zassert_not_equal(-1, offsetof(struct sockaddr_in6, sin6_flowinfo)); */
-	zassert_not_equal(-1, offsetof(struct sockaddr_in6, sin6_addr));
-	zassert_not_equal(-1, offsetof(struct sockaddr_in6, sin6_scope_id));
+	/* zexpect_not_equal(-1, offsetof(struct sockaddr_in6, sin6_flowinfo)); */
+	zexpect_not_equal(-1, offsetof(struct sockaddr_in6, sin6_addr));
+	zexpect_not_equal(-1, offsetof(struct sockaddr_in6, sin6_scope_id));
 
-	zassert_not_null(&in6addr_any);
-	zassert_not_null(&in6addr_loopback);
+	zexpect_not_null(&in6addr_any);
+	zexpect_not_null(&in6addr_loopback);
 	struct in6_addr any6 = IN6ADDR_ANY_INIT;
 	struct in6_addr lo6 = IN6ADDR_LOOPBACK_INIT;
 
@@ -62,42 +62,42 @@ ZTEST(posix_headers, test_netinet_in_h)
 	struct in6_addr mcg6 = { { { 0xff, 0x0e, 0, 0, 0, 0, 0, 0,
 				0, 0, 0, 0, 0, 0, 0, 0x01 } } };
 
-	zassert_not_equal(-1, offsetof(struct ipv6_mreq, ipv6mr_multiaddr));
-	zassert_not_equal(-1, offsetof(struct ipv6_mreq, ipv6mr_ifindex));
+	zexpect_not_equal(-1, offsetof(struct ipv6_mreq, ipv6mr_multiaddr));
+	zexpect_not_equal(-1, offsetof(struct ipv6_mreq, ipv6mr_ifindex));
 
-	zassert_not_equal(-1, IPPROTO_IP);
-	zassert_not_equal(-1, IPPROTO_IPV6);
-	zassert_not_equal(-1, IPPROTO_ICMP);
-	zassert_not_equal(-1, IPPROTO_RAW);
-	zassert_not_equal(-1, IPPROTO_TCP);
-	zassert_not_equal(-1, IPPROTO_UDP);
+	zexpect_not_equal(-1, IPPROTO_IP);
+	zexpect_not_equal(-1, IPPROTO_IPV6);
+	zexpect_not_equal(-1, IPPROTO_ICMP);
+	zexpect_not_equal(-1, IPPROTO_RAW);
+	zexpect_not_equal(-1, IPPROTO_TCP);
+	zexpect_not_equal(-1, IPPROTO_UDP);
 
-	zassert_not_equal(-1, INADDR_ANY);
-	zassert_equal(0xffffffff, INADDR_BROADCAST);
+	zexpect_not_equal(-1, INADDR_ANY);
+	zexpect_equal(0xffffffff, INADDR_BROADCAST);
 
-	zassert_equal(INET_ADDRSTRLEN, 16);
-	zassert_equal(INET6_ADDRSTRLEN, 46);
+	zexpect_equal(INET_ADDRSTRLEN, 16);
+	zexpect_equal(INET6_ADDRSTRLEN, 46);
 
-	zassert_equal(IPV6_ADD_MEMBERSHIP, IPV6_JOIN_GROUP);
-	zassert_equal(IPV6_DROP_MEMBERSHIP, IPV6_LEAVE_GROUP);
-	zassert_not_equal(-1, IPV6_MULTICAST_HOPS);
-	/* zassert_not_equal(-1, IPV6_MULTICAST_IF); */ /* not implemented */
-	/* zassert_not_equal(-1, IPV6_MULTICAST_LOOP); */ /* not implemented */
-	zassert_not_equal(-1, IPV6_UNICAST_HOPS);
-	zassert_not_equal(-1, IPV6_V6ONLY);
+	zexpect_equal(IPV6_ADD_MEMBERSHIP, IPV6_JOIN_GROUP);
+	zexpect_equal(IPV6_DROP_MEMBERSHIP, IPV6_LEAVE_GROUP);
+	zexpect_not_equal(-1, IPV6_MULTICAST_HOPS);
+	/* zexpect_not_equal(-1, IPV6_MULTICAST_IF); */ /* not implemented */
+	/* zexpect_not_equal(-1, IPV6_MULTICAST_LOOP); */ /* not implemented */
+	zexpect_not_equal(-1, IPV6_UNICAST_HOPS);
+	zexpect_not_equal(-1, IPV6_V6ONLY);
 
-	zassert_true(IN6_IS_ADDR_UNSPECIFIED(&any6));
-	zassert_true(IN6_IS_ADDR_LOOPBACK(&lo6));
+	zexpect_true(IN6_IS_ADDR_UNSPECIFIED(&any6));
+	zexpect_true(IN6_IS_ADDR_LOOPBACK(&lo6));
 
-	zassert_true(IN6_IS_ADDR_MULTICAST(&mcast6));
-	zassert_true(IN6_IS_ADDR_LINKLOCAL(&ll6));
-	zassert_true(IN6_IS_ADDR_SITELOCAL(&sl6));
-	zassert_true(IN6_IS_ADDR_V4MAPPED(&v4mapped));
+	zexpect_true(IN6_IS_ADDR_MULTICAST(&mcast6));
+	zexpect_true(IN6_IS_ADDR_LINKLOCAL(&ll6));
+	zexpect_true(IN6_IS_ADDR_SITELOCAL(&sl6));
+	zexpect_true(IN6_IS_ADDR_V4MAPPED(&v4mapped));
 	/* IN6_IS_ADDR_V4COMPAT(&lo6); */ /* not implemented */
-	zassert_true(IN6_IS_ADDR_MC_NODELOCAL(&mcnl6));
-	zassert_true(IN6_IS_ADDR_MC_LINKLOCAL(&mcll6));
-	zassert_true(IN6_IS_ADDR_MC_SITELOCAL(&mcsl6));
-	zassert_true(IN6_IS_ADDR_MC_ORGLOCAL(&mcol6));
-	zassert_true(IN6_IS_ADDR_MC_GLOBAL(&mcg6));
+	zexpect_true(IN6_IS_ADDR_MC_NODELOCAL(&mcnl6));
+	zexpect_true(IN6_IS_ADDR_MC_LINKLOCAL(&mcll6));
+	zexpect_true(IN6_IS_ADDR_MC_SITELOCAL(&mcsl6));
+	zexpect_true(IN6_IS_ADDR_MC_ORGLOCAL(&mcol6));
+	zexpect_true(IN6_IS_ADDR_MC_GLOBAL(&mcg6));
 }
 #pragma GCC diagnostic pop

--- a/tests/posix/headers/src/netinet_in_h.c
+++ b/tests/posix/headers/src/netinet_in_h.c
@@ -38,8 +38,7 @@ ZTEST(posix_headers, test_netinet_in_h)
 	/* not implemented */
 	/* zassert_not_equal(-1, offsetof(struct sockaddr_in6, sin6_flowinfo)); */
 	zassert_not_equal(-1, offsetof(struct sockaddr_in6, sin6_addr));
-	/* not implemented */
-	/* zassert_not_equal(-1, offsetof(struct sockaddr_in6, scope_id)); */
+	zassert_not_equal(-1, offsetof(struct sockaddr_in6, sin6_scope_id));
 
 	zassert_not_null(&in6addr_loopback);
 	struct in6_addr any6 = IN6ADDR_ANY_INIT;

--- a/tests/posix/headers/src/netinet_in_h.c
+++ b/tests/posix/headers/src/netinet_in_h.c
@@ -63,8 +63,8 @@ ZTEST(posix_headers, test_netinet_in_h)
 	zassert_equal(INET_ADDRSTRLEN, 16);
 	zassert_equal(INET6_ADDRSTRLEN, 46);
 
-	/* zassert_not_equal(-1, IPV6_JOIN_GROUP); */ /* not implemented */
-	/* zassert_not_equal(-1, IPV6_LEAVE_GROUP); */ /* not implemented */
+	zassert_equal(IPV6_ADD_MEMBERSHIP, IPV6_JOIN_GROUP);
+	zassert_equal(IPV6_DROP_MEMBERSHIP, IPV6_LEAVE_GROUP);
 	/* zassert_not_equal(-1, IPV6_MULTICAST_HOPS); */ /* not implemented */
 	/* zassert_not_equal(-1, IPV6_MULTICAST_IF); */ /* not implemented */
 	/* zassert_not_equal(-1, IPV6_MULTICAST_LOOP); */ /* not implemented */

--- a/tests/posix/headers/src/netinet_in_h.c
+++ b/tests/posix/headers/src/netinet_in_h.c
@@ -40,6 +40,7 @@ ZTEST(posix_headers, test_netinet_in_h)
 	zassert_not_equal(-1, offsetof(struct sockaddr_in6, sin6_addr));
 	zassert_not_equal(-1, offsetof(struct sockaddr_in6, sin6_scope_id));
 
+	zassert_not_null(&in6addr_any);
 	zassert_not_null(&in6addr_loopback);
 	struct in6_addr any6 = IN6ADDR_ANY_INIT;
 	struct in6_addr lo6 = IN6ADDR_LOOPBACK_INIT;


### PR DESCRIPTION
Most of the tests in `tests/posix/headers` related to networking are already supported so mark them so.
Add implementation to various IPv6 address checking macros we were missing and tests for them.
