### PR TITLE
linker: llext: avoid modifying current address in linker script snippet

### DIFF
--- a/include/zephyr/linker/llext-sections.ld
+++ b/include/zephyr/linker/llext-sections.ld
@@ -1,12 +1,16 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 	/*
-	 * Map the no_syscall_impl symbol in llext_export_syscalls.c to
+	 * Save the current address to avoid changing it in this file.
+	 */
+	HIDDEN(__llext_current_addr = .);
+
+	/*
+	 * Map the 'no_syscall_impl' symbol in 'syscall_export_llext.c' to
 	 * absolute address 0 so other weak symbols are exported as NULL.
 	 * This section is used for mapping that symbol only and is not
 	 * to be included in the final binary.
 	 */
-
 	SECTION_PROLOGUE(llext_no_syscall_impl, 0 (COPY), )
 	{
 	  *(llext_no_syscall_impl)
@@ -29,3 +33,5 @@
 	  KEEP(*(llext_exports_strtab))
 	}
 #endif
+
+	. = __llext_current_addr;


### PR DESCRIPTION
The linker script snippet that places the `llext_no_syscall_impl` section has the unfortunate side effect of overwriting the current linker address. This can lead to unexpected behavior of the caller script.

Saving the current address before defining the section and restoring it afterwards avoids this issue.

Fixes weekly CI issue #81136.