### PR TITLE
boards: adi: apard32690: doc: update reference link

### DIFF
--- a/boards/adi/apard32690/doc/index.rst
+++ b/boards/adi/apard32690/doc/index.rst
@@ -209,7 +209,7 @@ instead of ``west flash``.
 References
 **********
 
-- `AD-APARD32690-SL web page`_
+- `AD-APARD32690-SL solution center`_
 
-.. _AD-APARD32690-SL web page:
-   https://www.analog.com/en/resources/evaluation-hardware-and-software/evaluation-boards-kits/ad-apard32690-sl.html
+.. _AD-APARD32690-SL solution center:
+   https://developer.analog.com/solutions/max32690


### PR DESCRIPTION
Changed the References to point to the 32690 solution center on the ADI Developer Portal.