### PR TITLE
drivers: dma: intel-adsp-hda: optimize L1 exit handling in ISR

### DIFF
--- a/drivers/dma/dma_intel_adsp_hda.c
+++ b/drivers/dma/dma_intel_adsp_hda.c
@@ -488,8 +488,9 @@ void intel_adsp_hda_dma_isr(void)
 			enabled_chs &= ~(BIT(j));
 
 			if (!intel_adsp_hda_is_buffer_interrupt_enabled(cfg->base,
-									cfg->regblock_size, j))
+									cfg->regblock_size, j)) {
 				continue;
+			}
 
 			if (intel_adsp_hda_check_buffer_interrupt(cfg->base,
 								  cfg->regblock_size, j)) {


### PR DESCRIPTION
Use the existing 'atomic' bitmask to speed up ISR processing for CONFIG_DMA_INTEL_ADSP_HDA_TIMING_L1_EXIT. This bitmask is used to track enabled DMA channels.

In the common case, only a few DMA channels are active and low channels are allocated first. Take advantage of this and not iterate over all DMA channels of all all host devices. Rather break out as soon as L1 exit handling is done for all enabled channels.