### PR TITLE
drivers: spi_mcux_lpspi: Fix DMA path on RT

### DIFF
--- a/drivers/spi/spi_mcux_lpspi.c
+++ b/drivers/spi/spi_mcux_lpspi.c
@@ -483,7 +483,9 @@ static int transceive_dma(const struct device *dev, const struct spi_config *spi
 		return ret;
 	}
 
+#ifdef CONFIG_SOC_SERIES_MCXN
 	base->TCR |= LPSPI_TCR_CONT_MASK;
+#endif
 
 	/* DMA is fast enough watermarks are not required */
 	LPSPI_SetFifoWatermarks(base, 0U, 0U);
@@ -500,9 +502,11 @@ static int transceive_dma(const struct device *dev, const struct spi_config *spi
 				goto out;
 			}
 
+#ifdef CONFIG_SOC_SERIES_MCXN
 			while (!(LPSPI_GetStatusFlags(base) & kLPSPI_TxDataRequestFlag)) {
 				/* wait until previous tx finished */
 			}
+#endif
 
 			/* Enable DMA Requests */
 			LPSPI_EnableDMA(base, kLPSPI_TxDmaEnable | kLPSPI_RxDmaEnable);
@@ -512,6 +516,12 @@ static int transceive_dma(const struct device *dev, const struct spi_config *spi
 			if (ret != 0) {
 				goto out;
 			}
+
+#ifndef CONFIG_SOC_SERIES_MCXN
+			while ((LPSPI_GetStatusFlags(base) & kLPSPI_ModuleBusyFlag)) {
+				/* wait until module is idle */
+			}
+#endif
 
 			/* Disable DMA */
 			LPSPI_DisableDMA(base, kLPSPI_TxDmaEnable | kLPSPI_RxDmaEnable);


### PR DESCRIPTION
Apparently, the previous change to fix the chip select only works on some newer revisions of the LPSPI, and the behavior is different on older parts like RT. For now put some #ifdef to keep the fixed CS on MCXN but have the old behavior on RT and other platforms.

Fixes #81033 

The issue is the lpspi receiver appears to works differently about when it writes to the fifo, RM says on MCXN it is at the end of a word, but on RT is at the end of a frame, and the new code didnt work because of that, need to investigate further