### PR TITLE
build: support newlines in syscall decls

### DIFF
--- a/scripts/build/gen_syscalls.py
+++ b/scripts/build/gen_syscalls.py
@@ -184,6 +184,7 @@ class SyscallParseException(Exception):
 
 
 def typename_split(item):
+    item = item.strip().replace("\n", " ")
     if "[" in item:
         raise SyscallParseException(
             "Please pass arrays to syscalls as pointers, unable to process '%s'" %
@@ -396,7 +397,7 @@ def analyze_fn(match_group, fn, userspace_only):
         if args == "void":
             args = []
         else:
-            args = [typename_split(a.strip()) for a in args.split(",")]
+            args = [typename_split(a) for a in args.split(",")]
 
         func_type, func_name = typename_split(func)
     except SyscallParseException:


### PR DESCRIPTION
Some auto formatters will wrap long lines of code and insert newlines that are part of function decls outside of arguments. This change strips out all newlines so syscall typename regex function as expected.