### PR TITLE
tests/benchmarks: latency_measure: add qemu_riscv_64_smp board

### DIFF
--- a/tests/benchmarks/sched/testcase.yaml
+++ b/tests/benchmarks/sched/testcase.yaml
@@ -6,6 +6,7 @@ tests:
     integration_platforms:
       - mps2/an385
       - qemu_x86
+      - qemu_riscv64/qemu_virt_riscv64/smp
     slow: true
     harness: console
     harness_config:


### PR DESCRIPTION
Add `qemu_riscv64/qemu_virt_riscv64/smp` to the list of integration_platforms.