### PR TITLE
boards: st: nucleo_h533re: add arduino_{gpio,serial} supported tags

### DIFF
--- a/boards/st/nucleo_h533re/nucleo_h533re.yaml
+++ b/boards/st/nucleo_h533re/nucleo_h533re.yaml
@@ -10,6 +10,8 @@ toolchain:
 ram: 272
 flash: 512
 supported:
+  - arduino_gpio
+  - arduino_serial
   - gpio
   - watchdog
   - pwm


### PR DESCRIPTION
This allows to build samples by twister which depend on 'arduino_gpio'
and/or 'arduino_serial'.