### PR TITLE
samples: dap: drop 'sample.dap.bulk.nrf'

### DIFF
--- a/samples/subsys/dap/sample.yaml
+++ b/samples/subsys/dap/sample.yaml
@@ -8,9 +8,3 @@ tests:
       - nrf52840dk/nrf52840
       - frdm_k64f
     tags: dap
-  sample.dap.bulk.nrf:
-    build_only: true
-    depends_on: gpio usb_device
-    platform_allow:
-      - nrf52840dk/nrf52840
-    tags: dap


### PR DESCRIPTION
'nrf52840dk/nrf52840' is already listed under "generic" 'sample.dap.bulk',
so keeping 'sample.dap.bulk.nrf' has no value. The only difference is
dependency on 'gpio' instead of 'arduino_gpio', but
'nrf52840dk_nrf52840.overlay' references arduino header gpios only.