### PR TITLE
boards: nordic: nrf5340dk: add arduino_* supported tags

### DIFF
--- a/boards/nordic/nrf5340dk/nrf5340dk_nrf5340_cpuapp.yaml
+++ b/boards/nordic/nrf5340dk/nrf5340dk_nrf5340_cpuapp.yaml
@@ -9,6 +9,10 @@ toolchain:
 ram: 448
 flash: 1024
 supported:
+  - arduino_gpio
+  - arduino_i2c
+  - arduino_serial
+  - arduino_spi
   - gpio
   - i2c
   - i2s

--- a/boards/nordic/nrf5340dk/nrf5340dk_nrf5340_cpunet.yaml
+++ b/boards/nordic/nrf5340dk/nrf5340dk_nrf5340_cpunet.yaml
@@ -9,6 +9,7 @@ toolchain:
 ram: 64
 flash: 256
 supported:
+  - arduino_gpio
   - watchdog
   - gpio
 vendor: nordic


### PR DESCRIPTION
This allows to build samples by twister which depend on 'arduino_gpio',
'arduino_i2c', 'arduino_serial' and 'arduino_spi'.