### PR TITLE
soc: Fix missing mem.h include in stm32h562

### DIFF
--- a/dts/arm/st/h5/stm32h562.dtsi
+++ b/dts/arm/st/h5/stm32h562.dtsi
@@ -8,6 +8,7 @@
 #include <zephyr/dt-bindings/flash_controller/ospi.h>
 /* keep both header files for compatibility */
 #include <zephyr/dt-bindings/flash_controller/xspi.h>
+#include <mem.h>
 
 / {
 	clocks {


### PR DESCRIPTION
This caused failed builds due to the missing DT_SIZE_K(x) macro.