### PR TITLE
drivers: sensor: fxls8974: Remove redundant error check

### DIFF
--- a/drivers/sensor/nxp/fxls8974/fxls8974.c
+++ b/drivers/sensor/nxp/fxls8974/fxls8974.c
@@ -379,9 +379,8 @@ static int fxls8974_channel_get(const struct device *dev,
 
 			val += FXLS8974_MAX_ACCEL_CHANNELS;
 
-			if (fxls8974_get_temp_data(dev, val)) {
-				return -EIO;
-			}
+			return fxls8974_get_temp_data(dev, val);
+
 			break;
 		case SENSOR_CHAN_ACCEL_XYZ:
 			return fxls8974_get_accel_data(dev, val, SENSOR_CHAN_ACCEL_XYZ);

--- a/drivers/sensor/ti/ina219/ina219.c
+++ b/drivers/sensor/ti/ina219/ina219.c
@@ -269,11 +269,7 @@ static int ina219_init(const struct device *dev)
 	}
 
 	/* Set measurement delay */
-	rc = ina219_set_msr_delay(dev);
-	if (rc) {
-		LOG_ERR("Could not get measurement delay.");
-		return rc;
-	}
+	ina219_set_msr_delay(dev);
 
 	k_sleep(K_USEC(INA219_WAIT_STARTUP));
 

--- a/drivers/sensor/ti/ina219/ina219.c
+++ b/drivers/sensor/ti/ina219/ina219.c
@@ -269,7 +269,11 @@ static int ina219_init(const struct device *dev)
 	}
 
 	/* Set measurement delay */
-	ina219_set_msr_delay(dev);
+	rc = ina219_set_msr_delay(dev);
+	if (rc) {
+		LOG_ERR("Could not get measurement delay.");
+		return rc;
+	}
 
 	k_sleep(K_USEC(INA219_WAIT_STARTUP));
 


### PR DESCRIPTION
The function fxls8974_get_temp_data always returns zero, indicating success. Therefore, the error checking if condition is unnecessary and can be removed.