### PR TITLE
board: silabs: slstk3701a: add i2c2 node

### DIFF
--- a/boards/silabs/starter_kits/slstk3701a/slstk3701a-pinctrl.dtsi
+++ b/boards/silabs/starter_kits/slstk3701a/slstk3701a-pinctrl.dtsi
@@ -43,4 +43,13 @@
 				<GECKO_LOC(I2C_SCL, 0)>;
 		};
 	};
+
+	i2c2_default: i2c2_default {
+		group1 {
+			psels = <GECKO_PSEL(I2C_SDA, I, 4)>,
+				<GECKO_PSEL(I2C_SCL, I, 5)>,
+				<GECKO_LOC(I2C_SDA, 7)>,
+				<GECKO_LOC(I2C_SCL, 7)>;
+		};
+	};
 };

--- a/boards/silabs/starter_kits/slstk3701a/slstk3701a.dts
+++ b/boards/silabs/starter_kits/slstk3701a/slstk3701a.dts
@@ -92,6 +92,12 @@
 	status = "okay";
 };
 
+&i2c2 {
+	pinctrl-0 = <&i2c2_default>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
 &rtcc0 {
 	prescaler = <1>;
 	status = "okay";


### PR DESCRIPTION
Enable the I2C2 node on the EFM32GG11 SLSTK3701A board