### PR TITLE
west: runners: openocd: fix broken rtt implementation

### DIFF
--- a/cmake/flash/CMakeLists.txt
+++ b/cmake/flash/CMakeLists.txt
@@ -154,7 +154,7 @@ endif()
 
 # Generate the flash, debug, debugserver, attach targets within the build
 # system itself.
-foreach(target flash debug debugserver attach)
+foreach(target flash debug debugserver attach rtt)
   if(target STREQUAL flash)
     set(comment "Flashing ${BOARD}")
   elseif(target STREQUAL debug)
@@ -168,6 +168,8 @@ foreach(target flash debug debugserver attach)
     endif()
   elseif(target STREQUAL attach)
     set(comment "Debugging ${BOARD}")
+  elseif(target STREQUAL rtt)
+    set(comment "RTT ${BOARD}")
   endif()
   string(TOUPPER ${target} TARGET_UPPER)
 

--- a/scripts/west_commands/debug.py
+++ b/scripts/west_commands/debug.py
@@ -85,7 +85,7 @@ class Rtt(WestCommand):
             'open an rtt shell',
             "",
             accepts_unknown_args=True)
-        self.runner_key = 'rtt-runner'  # in runners.yaml
+        self.runner_key = 'debug-runner'  # in runners.yaml
 
     def do_add_parser(self, parser_adder):
         return add_parser_common(self, parser_adder)

--- a/scripts/west_commands/runners/jlink.py
+++ b/scripts/west_commands/runners/jlink.py
@@ -169,6 +169,9 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
         self.logger.info('J-Link GDB server running on port '
                          f'{self.gdb_port}{thread_msg}')
 
+    def print_rttserver_message(self):
+        self.logger.info(f'J-Link RTT server running on port {self.rtt_port}')
+
     @property
     def jlink_version(self):
         # Get the J-Link version as a (major, minor, rev) tuple of integers.
@@ -276,6 +279,7 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
             self.check_call(server_cmd)
         elif command == 'rtt':
             self.print_gdbserver_message()
+            self.print_rttserver_message()
             server_cmd += ['-nohalt']
             server_proc = self.popen_ignore_int(server_cmd)
             try:

--- a/scripts/west_commands/runners/openocd.py
+++ b/scripts/west_commands/runners/openocd.py
@@ -29,6 +29,18 @@ DEFAULT_OPENOCD_RTT_PORT = 5555
 DEFAULT_OPENOCD_RESET_HALT_CMD = 'reset init'
 DEFAULT_OPENOCD_TARGET_HANDLE = "_TARGETNAME"
 
+def to_num(number):
+    dev_match = re.search(r"^\d*\+dev", number)
+    dev_version = dev_match is not None
+
+    num_match = re.search(r"^\d*", number)
+    num = int(num_match.group(0))
+
+    if dev_version:
+        num += 1
+
+    return num
+
 class OpenOcdBinaryRunner(ZephyrBinaryRunner):
     '''Runner front-end for openocd.'''
 
@@ -200,19 +212,6 @@ class OpenOcdBinaryRunner(ZephyrBinaryRunner):
         self.logger.info('OpenOCD GDB server running on port '
                          f'{self.gdb_port}{thread_msg}')
 
-    # pylint: disable=R0201
-    def to_num(self, number):
-        dev_match = re.search(r"^\d*\+dev", number)
-        dev_version = not dev_match is None
-
-        num_match = re.search(r"^\d*", number)
-        num = int(num_match.group(0))
-
-        if dev_version:
-            num += 1
-
-        return num
-
     def read_version(self):
         self.require(self.openocd_cmd[0])
 
@@ -223,7 +222,7 @@ class OpenOcdBinaryRunner(ZephyrBinaryRunner):
         version_match = re.search(r"Open On-Chip Debugger (\d+.\d+.\d+)", out)
         version = version_match.group(1).split('.')
 
-        return [self.to_num(i) for i in version]
+        return [to_num(i) for i in version]
 
     def supports_thread_info(self):
         # Zephyr rtos was introduced after 0.11.0


### PR DESCRIPTION
* cmake: flash: update cmake to support rtt target
* west: runners: jlink: print RTT server port
* west: runners: openocd: mitigate pylint R0201 warning
* west: runners: openocd: fix rtt implementation

Fixes #81156

Testing done:

```shell
west build -p -S rtt-console -b <board> -t flash samples/hello_world/
...
west rtt -r openocd --cmd-pre-init 'adapter serial <serial>'
...
*** Booting Zephyr OS build v4.0.0-371-g8b7d3d663704 ***
Hello World! <board>
```

```shell
west build -p -S rtt-console -b <board> -t flash samples/hello_world/
...
west rtt -r jlink
...
*** Booting Zephyr OS build v4.0.0-371-g8b7d3d663704 ***
Hello World! <board>
```

> [!NOTE]  
> Due to the init strategy for the RTT buffer, either a power-cycle or reflash is required between `west rtt` invocations
> to observe the Hello World message again, since buffer contents and positions are preserved by default (e.g. from
> mcuboot). A simple reset via gdb is not sufficient to clear the RTT buffer. Alternatively, manually erase the RTT block
> via gdb memory write commands. 
