### PR TITLE
dts: arm: rpi_pico: remove #define from dts

### DIFF
--- a/dts/arm/rpi_pico/override.dtsi
+++ b/dts/arm/rpi_pico/override.dtsi
@@ -1,0 +1,7 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/*
+ * File intentionally left blank. Will be used when there is no other
+ * higher-priority override.dtsi file in use.
+ */

--- a/dts/arm/rpi_pico/rp2040.dtsi
+++ b/dts/arm/rpi_pico/rp2040.dtsi
@@ -10,9 +10,17 @@
 #include <zephyr/dt-bindings/clock/rpi_pico_clock.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/regulator/rpi_pico.h>
+#include <zephyr/dt-bindings/reset/rpi_pico_reset.h>
 #include <mem.h>
 
-#include "rpi_pico_common.dtsi"
+#include <arm/rpi_pico/override.dtsi>
+/*
+ * This value can be overridden at the board level or in an application specific
+ * override.dtsi file.
+ */
+#ifndef RPI_PICO_DEFAULT_IRQ_PRIORITY
+#define RPI_PICO_DEFAULT_IRQ_PRIORITY 3
+#endif
 
 / {
 	aliases {

--- a/include/zephyr/dt-bindings/reset/rpi_pico_reset.h
+++ b/include/zephyr/dt-bindings/reset/rpi_pico_reset.h
@@ -4,10 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef RPI_PICO_DEFAULT_IRQ_PRIORITY
-#define RPI_PICO_DEFAULT_IRQ_PRIORITY 3
-#endif
-
 #define RPI_PICO_RESETS_RESET_ADC		0
 #define RPI_PICO_RESETS_RESET_BUSCTRL		1
 #define RPI_PICO_RESETS_RESET_DMA		2


### PR DESCRIPTION
we can not use #define. Instead, include a dt-bindings header including the definitions.

Fixes: #79719