### PR TITLE
tests: pwm_loopback: Capture disable omission issue

### DIFF
--- a/tests/drivers/pwm/pwm_loopback/src/main.c
+++ b/tests/drivers/pwm/pwm_loopback/src/main.c
@@ -22,4 +22,18 @@ static void *pwm_loopback_setup(void)
 	return NULL;
 }
 
-ZTEST_SUITE(pwm_loopback, NULL, pwm_loopback_setup, NULL, NULL, NULL);
+static void pwm_loopback_after(void *f)
+{
+	struct test_pwm in;
+	struct test_pwm out;
+	int err;
+
+	ARG_UNUSED(f);
+
+	get_test_pwms(&out, &in);
+
+	err = pwm_disable_capture(in.dev, in.pwm);
+	zassert_equal(err, 0, "failed to disable pwm capture (err %d)", err);
+}
+
+ZTEST_SUITE(pwm_loopback, NULL, pwm_loopback_setup, NULL, pwm_loopback_after, NULL);

--- a/tests/drivers/pwm/pwm_loopback/src/test_pwm_loopback.c
+++ b/tests/drivers/pwm/pwm_loopback/src/test_pwm_loopback.c
@@ -85,6 +85,8 @@ static void test_capture(uint32_t period, uint32_t pulse, enum test_pwm_unit uni
 		ztest_test_fail();
 	}
 
+	pwm_disable_capture(in.dev, in.pwm);
+
 	if (err == -ENOTSUP) {
 		TC_PRINT("capture type not supported\n");
 		ztest_test_skip();

--- a/tests/drivers/pwm/pwm_loopback/src/test_pwm_loopback.c
+++ b/tests/drivers/pwm/pwm_loopback/src/test_pwm_loopback.c
@@ -99,9 +99,12 @@ static void test_capture(uint32_t period, uint32_t pulse, enum test_pwm_unit uni
 			       "period capture off by more than 1%");
 	}
 
-	if (flags & PWM_CAPTURE_TYPE_PULSE) {
+	if (flags & PWM_POLARITY_INVERTED) {
+		zassert_within(pulse_capture, period - pulse, (period - pulse) / 100,
+				"pulse capture off by more than 1%");
+	} else {
 		zassert_within(pulse_capture, pulse, pulse / 100,
-			       "pulse capture off by more than 1%");
+				"pulse capture off by more than 1%");
 	}
 }
 


### PR DESCRIPTION
1. As per the PWM API definition, `-EBUSY` should be returned when `pwm_enable_capture` is called while capturing
is already enabled. This commit should deal with adding a `ztest_suite_before_t` function that should disable capturing.
Some tests, though, such as `test_pulse_capture`, execute two sub-tests and so, capturing is disabled in between.
In fact, the omission of `pwm_disable_capture` should not only result in aborting a single test, but it can also raise system exception due to invalid context. This is the case for `z_impl_pwm_capture_cycles` where `z_pwm_capture_cycles_callback` can be fired whilst the routine has already aborted (without disabling capturing) and so `struct z_pwm_capture_cb_data data`, defined within function declaration, should not longer be valid.
2. For the inverted pulse measurements, that should reflect the duty-cycle off interval, the 1% deviation in `test_capture` should be adjusted so it reflects duty-cycle off.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/81199