### PR TITLE
drivers: counter: Fix unbalanced policy state locks

### DIFF
--- a/drivers/counter/counter_smartbond_timer.c
+++ b/drivers/counter/counter_smartbond_timer.c
@@ -68,7 +68,9 @@ static void counter_smartbond_pm_policy_state_lock_get(const struct device *dev)
 static void counter_smartbond_pm_policy_state_lock_put(const struct device *dev)
 {
 	pm_device_runtime_put(dev);
-	pm_policy_state_lock_put(PM_STATE_STANDBY, PM_ALL_SUBSTATES);
+	if (pm_policy_state_lock_is_active(PM_STATE_STANDBY, PM_ALL_SUBSTATES)) {
+		pm_policy_state_lock_put(PM_STATE_STANDBY, PM_ALL_SUBSTATES);
+	}
 }
 
 /*


### PR DESCRIPTION
This commit should deal with fixing unbalanced policy state locks. When `PM` and `PM_DEVICE` are declared, default state, policy lock should be given only when active. Otherwise, an assertion should be raised for unbalanced `pm_policy_state_lock_get` and `pm_policy_state_lock_put` calls. 

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/81201