### PR TITLE
manifest: Update hal_nxp to fix psa_crypto_init failure

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -198,7 +198,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: c410b73bd00c2025b9f62bb53f99c5e8b6e45eb2
+      revision: 3c64cd63125c86870802a561ce79dc33697b005c
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
The MBEDTLS_PSA_ACCEL_xxx macro means it will not enable the SW/Builtin implementation of the feature. The PSA_WANT_xxx macro means it will enable the PSA-API usage of the feature, and can use SW or HW acceleration. If enable the MBEDTLS_PSA_ACCEL_xxx macros, during psa_crypto_init, mbedtls_psa_hash_setup will failed, as the macro MBEDTLS_PSA_BUILTIN_ALG_SHA_512 is undefined. Remove the marco of MBEDTLS_PSA_ACCEL_xxx can enable maco MBEDTLS_PSA_BUILTIN_ALG_xxx, and fix the supp_psa_crypto_init fail and Wi-Fi connection failed issue.
Fix https://github.com/zephyrproject-rtos/zephyr/issues/81025