### PR TITLE
boards: stm32f4_disco: Add pwm leds

### DIFF
--- a/boards/st/stm32f4_disco/stm32f4_disco.dts
+++ b/boards/st/stm32f4_disco/stm32f4_disco.dts
@@ -51,6 +51,26 @@
 		};
 	};
 
+	pwmleds: pwmleds {
+		compatible = "pwm-leds";
+
+		orange_pwm_led: orange_pwm_led {
+			pwms = <&pwm4 2 PWM_USEC(100) PWM_POLARITY_NORMAL>;
+		};
+
+		green_pwm_led: green_pwm_led {
+			pwms = <&pwm4 1 PWM_USEC(100) PWM_POLARITY_NORMAL>;
+		};
+
+		red_pwm_led: red_pwm_led {
+			pwms = <&pwm4 3 PWM_USEC(100) PWM_POLARITY_NORMAL>;
+		};
+
+		blue_pwm_led: blue_pwm_led {
+			pwms = <&pwm4 4 PWM_USEC(100) PWM_POLARITY_NORMAL>;
+		};
+	};
+
 	aliases {
 		led0 = &green_led_4;
 		led1 = &orange_led_3;
@@ -106,6 +126,16 @@
 	pwm2: pwm {
 		status = "okay";
 		pinctrl-0 = <&tim2_ch1_pa0>;
+		pinctrl-names = "default";
+	};
+};
+
+&timers4 {
+	status = "okay";
+
+	pwm4: pwm {
+		status = "okay";
+		pinctrl-0 = <&tim4_ch1_pd12 &tim4_ch2_pd13 &tim4_ch3_pd14 &tim4_ch4_pd15>;
 		pinctrl-names = "default";
 	};
 };


### PR DESCRIPTION
Add four PWM leds for stm32f4_disco in order to run the samples/basic/fade_led application.