### PR TITLE
Bluetooth: Mesh: Use relay bufs/pool for brg_cfg

### DIFF
--- a/doc/connectivity/bluetooth/api/mesh/brg_cfg.rst
+++ b/doc/connectivity/bluetooth/api/mesh/brg_cfg.rst
@@ -113,13 +113,16 @@ protection to ensure network security. Key considerations to take into account a
 Relay buffer considerations
 ===========================
 
-When a message is relayed between subnets by a Subnet Bridge, it is allocated from the relay buffer.
-To ensure that messages can be retransmitted to all subnetworks,
-the :kconfig:option:`CONFIG_BT_MESH_RELAY_BUF_COUNT` option should be increased accordingly.
+When a message is relayed between subnets by a Subnet Bridge, it is allocated from the relay buffer
+pool. The number of relay buffers are configurable using the
+:kconfig:option:`CONFIG_BT_MESH_RELAY_BUF_COUNT` Kconfig option.
 
-However, if the :kconfig:option:`CONFIG_BT_MESH_RELAY` feature is disabled, the messages will be
-allocated from the advertising buffer instead. In this case, increase the
-:kconfig:option:`CONFIG_BT_MESH_ADV_BUF_COUNT` option to allow for sufficient buffer space.
+When :kconfig:option:`CONFIG_BT_MESH_ADV_EXT` is enabled, messages will be transmitted using the
+relay advertising sets. The number of advertising sets are configurable using the
+:kconfig:option:`CONFIG_BT_MESH_RELAY_ADV_SETS` Kconfig option.
+
+Both the relay buffer pool and advertising sets can be used even if the relay feature
+:kconfig:option:`CONFIG_BT_MESH_RELAY` is disabled.
 
 Replay protection and Bridging Table
 ====================================

--- a/subsys/bluetooth/mesh/Kconfig
+++ b/subsys/bluetooth/mesh/Kconfig
@@ -165,10 +165,12 @@ config BT_MESH_RELAY_ADV_SETS
 	int "Maximum of simultaneous relay message support"
 	default 0
 	range 0 BT_EXT_ADV_MAX_ADV_SET
-	depends on BT_MESH_RELAY
+	depends on BT_MESH_RELAY || BT_MESH_BRG_CFG_SRV
 	help
 	  Maximum of simultaneous relay message support. Requires controller support
 	  multiple advertising sets.
+
+	  Note that: The Subnet Bridge feature uses the relay advertising sets.
 
 config BT_MESH_ADV_EXT_RELAY_USING_MAIN_ADV_SET
 	bool "Use the main advertising set to relay messages"
@@ -471,8 +473,11 @@ config BT_MESH_RELAY_RETRANSMIT_INTERVAL
 	  messages, in milliseconds. Can be changed through runtime
 	  configuration.
 
+endif # BT_MESH_RELAY
+
 config BT_MESH_RELAY_BUF_COUNT
 	int "Number of advertising buffers for relayed messages"
+	depends on BT_MESH_RELAY || BT_MESH_BRG_CFG_SRV
 	default 32
 	range 1 256
 	help
@@ -486,7 +491,9 @@ config BT_MESH_RELAY_BUF_COUNT
 	  BT_MESH_RELAY_ADV_SETS allows the increase in the number of buffers
 	  while maintaining the latency.
 
-endif # BT_MESH_RELAY
+	  Note that: The Subnet Bridge feature uses the relay advertising buffers. If both the Relay
+	  feature and the Subnet Bridge feature is enabled, the added load should be taken into
+	  account.
 
 endmenu # Network layer
 

--- a/subsys/bluetooth/mesh/adv.c
+++ b/subsys/bluetooth/mesh/adv.c
@@ -137,7 +137,7 @@ void bt_mesh_adv_unref(struct bt_mesh_adv *adv)
 
 	struct k_mem_slab *slab = &local_adv_pool;
 
-#if defined(CONFIG_BT_MESH_RELAY)
+#if (defined(CONFIG_BT_MESH_RELAY) || defined(CONFIG_BT_MESH_BRG_CFG_SRV))
 	if (adv->ctx.tag == BT_MESH_ADV_TAG_RELAY) {
 		slab = &relay_adv_pool;
 	}
@@ -156,7 +156,7 @@ struct bt_mesh_adv *bt_mesh_adv_create(enum bt_mesh_adv_type type,
 				       enum bt_mesh_adv_tag tag,
 				       uint8_t xmit, k_timeout_t timeout)
 {
-#if defined(CONFIG_BT_MESH_RELAY)
+#if (defined(CONFIG_BT_MESH_RELAY) || defined(CONFIG_BT_MESH_BRG_CFG_SRV))
 	if (tag == BT_MESH_ADV_TAG_RELAY) {
 		return adv_create_from_pool(&relay_adv_pool,
 					    type, tag, xmit, timeout);
@@ -202,7 +202,7 @@ struct bt_mesh_adv *bt_mesh_adv_get(k_timeout_t timeout)
 						K_POLL_MODE_NOTIFY_ONLY,
 						&bt_mesh_adv_queue,
 						0),
-#if defined(CONFIG_BT_MESH_RELAY) && \
+#if (defined(CONFIG_BT_MESH_RELAY) || defined(CONFIG_BT_MESH_BRG_CFG_SRV)) && \
 	(defined(CONFIG_BT_MESH_ADV_LEGACY) || \
 	 defined(CONFIG_BT_MESH_ADV_EXT_RELAY_USING_MAIN_ADV_SET) || \
 	 !(CONFIG_BT_MESH_RELAY_ADV_SETS))
@@ -228,7 +228,7 @@ struct bt_mesh_adv *bt_mesh_adv_get_by_tag(enum bt_mesh_adv_tag_bit tags, k_time
 		return k_fifo_get(&bt_mesh_friend_queue, timeout);
 	}
 
-	if (IS_ENABLED(CONFIG_BT_MESH_RELAY) &&
+	if ((IS_ENABLED(CONFIG_BT_MESH_RELAY) || IS_ENABLED(CONFIG_BT_MESH_BRG_CFG_SRV)) &&
 	    !(tags & BT_MESH_ADV_TAG_BIT_LOCAL)) {
 		return k_fifo_get(&bt_mesh_relay_queue, timeout);
 	}
@@ -242,7 +242,7 @@ void bt_mesh_adv_get_cancel(void)
 
 	k_fifo_cancel_wait(&bt_mesh_adv_queue);
 
-	if (IS_ENABLED(CONFIG_BT_MESH_RELAY)) {
+	if ((IS_ENABLED(CONFIG_BT_MESH_RELAY) || IS_ENABLED(CONFIG_BT_MESH_BRG_CFG_SRV))) {
 		k_fifo_cancel_wait(&bt_mesh_relay_queue);
 	}
 
@@ -276,7 +276,7 @@ void bt_mesh_adv_send(struct bt_mesh_adv *adv, const struct bt_mesh_send_cb *cb,
 		return;
 	}
 
-	if ((IS_ENABLED(CONFIG_BT_MESH_RELAY) &&
+	if (((IS_ENABLED(CONFIG_BT_MESH_RELAY) || IS_ENABLED(CONFIG_BT_MESH_BRG_CFG_SRV)) &&
 	    adv->ctx.tag == BT_MESH_ADV_TAG_RELAY) ||
 	    (IS_ENABLED(CONFIG_BT_MESH_PB_ADV_USE_RELAY_SETS) &&
 	     adv->ctx.tag == BT_MESH_ADV_TAG_PROV)) {

--- a/subsys/bluetooth/mesh/adv_ext.c
+++ b/subsys/bluetooth/mesh/adv_ext.c
@@ -108,9 +108,9 @@ static struct bt_mesh_ext_adv advs[] = {
 #if CONFIG_BT_MESH_RELAY_ADV_SETS
 	[1 ... CONFIG_BT_MESH_RELAY_ADV_SETS] = {
 		.tags = (
-#if defined(CONFIG_BT_MESH_RELAY)
+#if (defined(CONFIG_BT_MESH_RELAY) || defined(CONFIG_BT_MESH_BRG_CFG_SRV))
 			BT_MESH_ADV_TAG_BIT_RELAY |
-#endif /* CONFIG_BT_MESH_RELAY */
+#endif /* CONFIG_BT_MESH_RELAY || CONFIG_BT_MESH_BRG_CFG_SRV */
 #if defined(CONFIG_BT_MESH_PB_ADV_USE_RELAY_SETS)
 			BT_MESH_ADV_TAG_BIT_PROV |
 #endif /* CONFIG_BT_MESH_PB_ADV_USE_RELAY_SETS */

--- a/subsys/bluetooth/mesh/net.c
+++ b/subsys/bluetooth/mesh/net.c
@@ -705,7 +705,7 @@ static void bt_mesh_net_relay(struct net_buf_simple *sbuf, struct bt_mesh_net_rx
 	 * Anything else (like GATT to adv, or locally originated packets)
 	 * use the Network Transmit state.
 	 */
-	if (rx->net_if == BT_MESH_NET_IF_ADV && !rx->friend_cred) {
+	if (rx->net_if == BT_MESH_NET_IF_ADV && !rx->friend_cred && !bridge) {
 		transmit = bt_mesh_relay_retransmit_get();
 	} else {
 		transmit = bt_mesh_net_transmit_get();


### PR DESCRIPTION
Adds support for using relay buffers and advertising set for the subnet bridge feature, even if the relay feature is disabled. Introduces new Kconfig options that allows the user to configure the relay buffer count and advertising sets in the case when the relay feature is disabled.