### PR TITLE
samples: Bluetooth: ISO: Update conn and adv intervals

### DIFF
--- a/samples/bluetooth/iso_broadcast/src/main.c
+++ b/samples/bluetooth/iso_broadcast/src/main.c
@@ -1,10 +1,13 @@
 /*
- * Copyright (c) 2021 Nordic Semiconductor ASA
+ * Copyright (c) 2021-2024 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+#include <stddef.h>
+#include <stdint.h>
 
 #include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/gap.h>
 #include <zephyr/bluetooth/iso.h>
 #include <zephyr/sys/byteorder.h>
 
@@ -88,6 +91,20 @@ static const struct bt_data ad[] = {
 
 int main(void)
 {
+	/* Some controllers work best while Extended Advertising interval to be a multiple
+	 * of the ISO Interval minus 10 ms (max. advertising random delay). This is
+	 * required to place the AUX_ADV_IND PDUs in a non-overlapping interval with the
+	 * Broadcast ISO radio events.
+	 * For 10ms SDU interval a extended advertising interval of 60 - 10 = 50 is suitable
+	 */
+	const uint16_t adv_interval_ms = 60U;
+	const uint16_t ext_adv_interval_ms = adv_interval_ms - 10U;
+	const struct bt_le_adv_param *ext_adv_param = BT_LE_ADV_PARAM(
+		BT_LE_ADV_OPT_EXT_ADV, BT_GAP_MS_TO_ADV_INTERVAL(ext_adv_interval_ms),
+		BT_GAP_MS_TO_ADV_INTERVAL(ext_adv_interval_ms), NULL);
+	const struct bt_le_per_adv_param *per_adv_param = BT_LE_PER_ADV_PARAM(
+		BT_GAP_MS_TO_PER_ADV_INTERVAL(adv_interval_ms),
+		BT_GAP_MS_TO_PER_ADV_INTERVAL(adv_interval_ms), BT_LE_PER_ADV_OPT_NONE);
 	uint32_t timeout_counter = INITIAL_TIMEOUT_COUNTER;
 	struct bt_le_ext_adv *adv;
 	struct bt_iso_big *big;
@@ -106,7 +123,7 @@ int main(void)
 	}
 
 	/* Create a non-connectable advertising set */
-	err = bt_le_ext_adv_create(BT_LE_EXT_ADV_NCONN, NULL, &adv);
+	err = bt_le_ext_adv_create(ext_adv_param, NULL, &adv);
 	if (err) {
 		printk("Failed to create advertising set (err %d)\n", err);
 		return 0;
@@ -120,7 +137,7 @@ int main(void)
 	}
 
 	/* Set periodic advertising parameters */
-	err = bt_le_per_adv_set_param(adv, BT_LE_PER_ADV_DEFAULT);
+	err = bt_le_per_adv_set_param(adv, per_adv_param);
 	if (err) {
 		printk("Failed to set periodic advertising parameters"
 		       " (err %d)\n", err);

--- a/samples/bluetooth/iso_central/src/main.c
+++ b/samples/bluetooth/iso_central/src/main.c
@@ -1,9 +1,10 @@
 /*
- * Copyright (c) 2021 2021 Nordic Semiconductor ASA
+ * Copyright (c) 2021-2024 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/bluetooth/gap.h>
 #include <zephyr/types.h>
 #include <stddef.h>
 #include <errno.h>
@@ -90,6 +91,9 @@ static void iso_timer_timeout(struct k_work *work)
 static void device_found(const bt_addr_le_t *addr, int8_t rssi, uint8_t type,
 			 struct net_buf_simple *ad)
 {
+	const struct bt_le_conn_param *conn_param =
+		BT_LE_CONN_PARAM(BT_GAP_MS_TO_CONN_INTERVAL(60), BT_GAP_MS_TO_CONN_INTERVAL(60), 0,
+				 BT_GAP_MS_TO_CONN_TIMEOUT(4000));
 	char addr_str[BT_ADDR_LE_STR_LEN];
 	int err;
 
@@ -115,8 +119,7 @@ static void device_found(const bt_addr_le_t *addr, int8_t rssi, uint8_t type,
 		return;
 	}
 
-	err = bt_conn_le_create(addr, BT_CONN_LE_CREATE_CONN, BT_LE_CONN_PARAM_DEFAULT,
-				&default_conn);
+	err = bt_conn_le_create(addr, BT_CONN_LE_CREATE_CONN, conn_param, &default_conn);
 	if (err) {
 		printk("Create conn to %s failed (%u)\n", addr_str, err);
 		start_scan();


### PR DESCRIPTION
Update the connection and advertising intervals of the
broadcast and connected ISO samples (including benchmark
samples) to work better with the selected SDU intervals
and the resulting ISO intervals.