### PR TITLE
boards: add common configuration for CDC ACM UART

### DIFF
--- a/boards/common/Kconfig.cdc_acm_serial
+++ b/boards/common/Kconfig.cdc_acm_serial
@@ -1,0 +1,44 @@
+# Copyright (c) 2023-2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+
+config SERIAL
+	default y
+
+config CONSOLE
+	default y
+
+config UART_CONSOLE
+	default CONSOLE
+
+config SHELL_BACKEND_SERIAL_CHECK_DTR
+	default SHELL
+	depends on UART_LINE_CTRL
+
+config UART_LINE_CTRL
+	default SHELL
+
+config USB_DEVICE_STACK
+	default y
+
+config USB_DEVICE_INITIALIZE_AT_BOOT
+	default y if !MCUBOOT
+
+config USB_DEVICE_REMOTE_WAKEUP
+	default n
+
+if LOG
+
+choice USB_CDC_ACM_LOG_LEVEL_CHOICE
+	default USB_CDC_ACM_LOG_LEVEL_OFF
+endchoice
+
+choice USB_DEVICE_LOG_LEVEL_CHOICE
+	default USB_DEVICE_LOG_LEVEL_OFF
+endchoice
+
+# Wait 4000ms at startup for logging
+config LOG_PROCESS_THREAD_STARTUP_DELAY_MS
+	default 4000
+
+endif # LOG

--- a/boards/common/cdc_acm_serial.dts
+++ b/boards/common/cdc_acm_serial.dts
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	chosen {
+		zephyr,console = &cdc_acm_uart;
+		zephyr,shell-uart = &cdc_acm_uart;
+		zephyr,uart-mcumgr = &cdc_acm_uart;
+		zephyr,bt-mon-uart = &cdc_acm_uart;
+		zephyr,bt-c2h-uart = &cdc_acm_uart;
+	};
+};
+
+zephyr_udc0: &usbd {
+	cdc_acm_uart: cdc_acm_uart {
+		compatible = "zephyr,cdc-acm-uart";
+	};
+};

--- a/boards/nordic/nrf52840dongle/Kconfig
+++ b/boards/nordic/nrf52840dongle/Kconfig
@@ -12,8 +12,4 @@ config BOARD_HAS_NRF5_BOOTLOADER
 	  If selected, applications are linked so that they can be loaded by Nordic
 	  nRF5 bootloader.
 
-config BOARD_SERIAL_BACKEND_CDC_ACM
-	bool "USB CDC"
-	default y
-
 endif # BOARD_NRF52840DONGLE

--- a/boards/nordic/nrf52840dongle/Kconfig.defconfig
+++ b/boards/nordic/nrf52840dongle/Kconfig.defconfig
@@ -4,7 +4,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-if BOARD_NRF52840DONGLE
+if BOARD_NRF52840DONGLE_NRF52840 || BOARD_NRF52840DONGLE_NRF52840_CDC_ACM_SERIAL
 
 # To let the nRF5 bootloader load an application, the application
 # must be linked after Nordic MBR, that is factory-programmed on the board.
@@ -22,62 +22,11 @@ config FLASH_LOAD_OFFSET
 	default 0x1000
 	depends on BOARD_HAS_NRF5_BOOTLOADER && (MCUBOOT || !USE_DT_CODE_PARTITION)
 
-if BOARD_SERIAL_BACKEND_CDC_ACM
-
-config USB_DEVICE_STACK
-	default y
-
-config USB_CDC_ACM
-	default SERIAL
-
-config CONSOLE
-	default y
-
-config UART_CONSOLE
-	default CONSOLE
-
-config USB_DEVICE_INITIALIZE_AT_BOOT
-	default y if !MCUBOOT && CONSOLE
-
-config SHELL_BACKEND_SERIAL_CHECK_DTR
-	default SHELL
-	depends on UART_LINE_CTRL
-
-config UART_LINE_CTRL
-	default SHELL
-
-config USB_DEVICE_REMOTE_WAKEUP
-	default n
-
-if LOG
-
-# Logger cannot use itself to log
-choice USB_CDC_ACM_LOG_LEVEL_CHOICE
-	default USB_CDC_ACM_LOG_LEVEL_OFF
-endchoice
-
-# Set USB log level to error only
-choice USB_DEVICE_LOG_LEVEL_CHOICE
-	default USB_DEVICE_LOG_LEVEL_ERR
-endchoice
-
-# Wait 4000ms at startup for logging
-config LOG_PROCESS_THREAD_STARTUP_DELAY_MS
-	default 4000
-
-endif # LOG
-
-if USB_DEVICE_STACK
-
-# Enable UART driver, needed for CDC ACM
-config SERIAL
-	default y
-
-endif # USB_DEVICE_STACK
-
-endif # BOARD_SERIAL_BACKEND_CDC_ACM
-
 config BT_CTLR
 	default BT
 
-endif # BOARD_NRF52840DONGLE
+if BOARD_NRF52840DONGLE_NRF52840_CDC_ACM_SERIAL
+source "${ZEPHYR_BASE}/boards/common/Kconfig.cdc_acm_serial"
+endif
+
+endif #BOARD_NRF52840DONGLE || BOARD_NRF52840DONGLE_NRF52840_CDC_ACM_SERIAL

--- a/boards/nordic/nrf52840dongle/board.yml
+++ b/boards/nordic/nrf52840dongle/board.yml
@@ -4,3 +4,5 @@ board:
   vendor: nordic
   socs:
   - name: nrf52840
+    variants:
+    - name: 'cdc_acm_serial'

--- a/boards/nordic/nrf52840dongle/nrf52840dongle_nrf52840.dts
+++ b/boards/nordic/nrf52840dongle/nrf52840dongle_nrf52840.dts
@@ -15,11 +15,6 @@
 	compatible = "nordic,nrf52840-dongle-nrf52840";
 
 	chosen {
-		zephyr,console = &cdc_acm_uart;
-		zephyr,shell-uart = &cdc_acm_uart;
-		zephyr,uart-mcumgr = &cdc_acm_uart;
-		zephyr,bt-mon-uart = &cdc_acm_uart;
-		zephyr,bt-c2h-uart = &cdc_acm_uart;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_partition;
@@ -188,8 +183,4 @@
 zephyr_udc0: &usbd {
 	compatible = "nordic,nrf-usbd";
 	status = "okay";
-
-	cdc_acm_uart: cdc_acm_uart {
-		compatible = "zephyr,cdc-acm-uart";
-	};
 };

--- a/boards/nordic/nrf52840dongle/nrf52840dongle_nrf52840_cdc_acm_serial.dts
+++ b/boards/nordic/nrf52840dongle/nrf52840dongle_nrf52840_cdc_acm_serial.dts
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "nrf52840dongle_nrf52840.dts"
+#include <../boards/common/cdc_acm_serial.dts>


### PR DESCRIPTION
Many boards have similar code to configure the USB and CDC ACM UART that they want to use as a logging or shell backend. Also, many boards have incorrect or incomplete configuration.

Remove all USB and CDC ACM configuration in favor of common configuration for all boards and use common board variant to configure CDC ACM UART as backend.

This is an alternative for #81220 (but not for snippet changes). It has few drawbacks, there is already a known snippet that is not used here but will contain similar code, probably not usable by out-of-tree boards, confusing as it puts USB-related code under boards/common, requires more work to clean up the boards.