### PR TITLE
boards native_sim: Deprecate CONFIG_NATIVE_APPLICATION & CONFIG_NATIVE_SIM_NATIVE_POSIX_COMPAT

### DIFF
--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -470,9 +470,11 @@ config NATIVE_APPLICATION
 	default y if ARCH_POSIX
 	depends on !NATIVE_LIBRARY
 	select NATIVE_BUILD
+	select DEPRECATED
 	help
 	  Build as a native application that can run on the host and using
-	  resources and libraries provided by the host.
+	  resources and libraries provided by the host. This option is deprecated
+	  and will be removed in Zephyr v4.3
 
 config NATIVE_LIBRARY
 	bool

--- a/boards/native/native_sim/Kconfig
+++ b/boards/native/native_sim/Kconfig
@@ -18,12 +18,13 @@ comment "Native Simular (Single Core) options"
 
 config NATIVE_SIM_NATIVE_POSIX_COMPAT
 	bool "Pretend to be a native_posix board"
-	default y
+	select DEPRECATED
 	help
 	  When this option is set the native_sim board will pretend to be
 	  a native_posix board from kconfig point of view, to allow using it directly with
 	  code which was meant for the native_posix board and checks for the macro
 	  CONFIG_BOARD_NATIVE_POSIX, or requires other kconfig options which depend on it.
+	  This option is deprecated and will be removed in Zephyr v4.3
 
 config NATIVE_SIM_SLOWDOWN_TO_REAL_TIME
 	bool "Slow down execution to real time"

--- a/doc/releases/migration-guide-4.1.rst
+++ b/doc/releases/migration-guide-4.1.rst
@@ -115,3 +115,12 @@ Modem
 
 Architectures
 *************
+
+* native/POSIX
+
+  * :kconfig:option:`CONFIG_NATIVE_APPLICATION` has been deprecated. Out-of-tree boards using this
+    option should migrate to the native_simulator runner (:github:`81232`).
+    For an example of how this was done with a board in-tree check :github:`61481`.
+  * For the native_sim target :kconfig:option:`CONFIG_NATIVE_SIM_NATIVE_POSIX_COMPAT` has been
+    switched to ``n`` by default, and this option has been deprecated. Ensure your code does not
+    use the :kconfig:option:`CONFIG_BOARD_NATIVE_POSIX` option anymore (:github:`81232`).

--- a/doc/releases/release-notes-4.1.rst
+++ b/doc/releases/release-notes-4.1.rst
@@ -43,6 +43,12 @@ Architectures
 
 * Xtensa
 
+* native/POSIX
+
+  * :kconfig:option:`CONFIG_NATIVE_APPLICATION` has been deprecated.
+  * For the native_sim target :kconfig:option:`CONFIG_NATIVE_SIM_NATIVE_POSIX_COMPAT` has been
+    switched to ``n`` by default, and this option has been deprecated.
+
 Kernel
 ******
 


### PR DESCRIPTION
    boards native: Deprecate CONFIG_NATIVE_APPLICATION
    
    This option is used in tree only by native_posix, which is deprecated
    and being replaced by native_sim. But may be used also in out of tree
    targets.
    As part of the native_posix deprecation, and therefore the lack of
    testing this feature would have in the future, we are also deprecating
    this option.

----

    boards native_sim: Deprecate CONFIG_NATIVE_SIM_NATIVE_POSIX_COMPAT
    
    This option existed only to make the transition from native_posix to
    native_sim easier. As native_posix is going to be removed in v4.2
    we deprecate this option now, so it will also be removed.
    
    We also switch this option to default to false already now.

& add to release notes and migration guide
