### PR TITLE
lib/cpp: Remove deprecated CONFIG_CPP_STATIC_INIT_GNU

### DIFF
--- a/lib/cpp/Kconfig
+++ b/lib/cpp/Kconfig
@@ -143,14 +143,6 @@ config CPP_RTTI
 
 endif # !MINIMAL_LIBCPP
 
-config CPP_STATIC_INIT_GNU
-	bool
-	select STATIC_INIT_GNU
-	select DEPRECATED
-	help
-	  GNU-compatible initialization of CPP static objects.
-	  This option is deprecated in favour of STATIC_INIT_GNU
-
 endif # CPP
 
 endmenu


### PR DESCRIPTION
This option was replaced with CONFIG_STATIC_INIT_GNU 2 releases ago in 6e977ae2d54c4f5443f752ce3a88f22043dcbf07