### PR TITLE
Enhance GPIO hogs for application control and shell commands

### DIFF
--- a/drivers/gpio/Kconfig
+++ b/drivers/gpio/Kconfig
@@ -85,6 +85,14 @@ config GPIO_HOGS_INIT_PRIORITY
 	  GPIO hogs initialization priority. GPIO hogs must be initialized after the
 	  GPIO controller drivers.
 
+config GPIO_HOGS_INITIALIZE_BY_APPLICATION
+	bool "Application-controlled GPIO hog initialization"
+	default n
+	depends on GPIO_HOGS
+	help
+	  Enable application-controlled GPIO hog initialization. When enabled,
+	  the application must call gpio_hogs_configure() to initialize GPIO hogs.
+
 config GPIO_ENABLE_DISABLE_INTERRUPT
 	bool "Support for enable/disable interrupt without re-config [EXPERIMENTAL]"
 	select EXPERIMENTAL


### PR DESCRIPTION
Related to #55617

Enhance the GPIO hogs driver to allow application control over GPIO configuration and add a shell command for managing GPIOs.

* Add `gpio_hogs_configure()` function in `drivers/gpio/gpio_hogs.c` to allow application-controlled GPIO configuration.
* Implement logic to filter GPIOs based on the provided port and mask in `gpio_hogs_configure()`.
* Modify `gpio_hogs_init()` in `drivers/gpio/gpio_hogs.c` to check the `GPIO_HOGS_INITIALIZE_BY_APPLICATION` Kconfig option.
* Update shell commands in `drivers/gpio/gpio_shell.c` to use the `line-names` property for referencing GPIOs by their names.
* Add tab completion for GPIO names in the shell commands in `drivers/gpio/gpio_shell.c`.
* Add a new Kconfig option `GPIO_HOGS_INITIALIZE_BY_APPLICATION` in `drivers/gpio/Kconfig` to enable application-controlled GPIO initialization.

