### PR TITLE
storage: flash_map: Don't generate flash area when no device

### DIFF
--- a/subsys/storage/flash_map/flash_map.c
+++ b/subsys/storage/flash_map/flash_map.c
@@ -39,7 +39,7 @@ int flash_area_open(uint8_t id, const struct flash_area **fap)
 		return -ENOENT;
 	}
 
-	if (!area->fa_dev || !device_is_ready(area->fa_dev)) {
+	if (!device_is_ready(area->fa_dev)) {
 		return -ENODEV;
 	}
 

--- a/subsys/storage/flash_map/flash_map_default.c
+++ b/subsys/storage/flash_map/flash_map_default.c
@@ -16,18 +16,22 @@
 #define FLASH_AREA_FOO(part)							\
 	{.fa_id = DT_FIXED_PARTITION_ID(part),					\
 	 .fa_off = DT_REG_ADDR(part),						\
-	 .fa_dev = DEVICE_DT_GET_OR_NULL(DT_MTD_FROM_FIXED_PARTITION(part)),	\
+	 .fa_dev = DEVICE_DT_GET(DT_MTD_FROM_FIXED_PARTITION(part)),	        \
 	 .fa_size = DT_REG_SIZE(part),						\
 	 .fa_label = DT_PROP_OR(part, label, NULL),	},
 #else
 #define FLASH_AREA_FOO(part)							\
 	{.fa_id = DT_FIXED_PARTITION_ID(part),					\
 	 .fa_off = DT_REG_ADDR(part),						\
-	 .fa_dev = DEVICE_DT_GET_OR_NULL(DT_MTD_FROM_FIXED_PARTITION(part)),	\
+	 .fa_dev = DEVICE_DT_GET(DT_MTD_FROM_FIXED_PARTITION(part)),	        \
 	 .fa_size = DT_REG_SIZE(part), },
 #endif
 
-#define FOREACH_PARTITION(n) DT_FOREACH_CHILD(DT_DRV_INST(n), FLASH_AREA_FOO)
+#define FLASH_AREA_FOOO(part)	\
+	COND_CODE_1(DT_NODE_HAS_STATUS_OKAY(DT_MTD_FROM_FIXED_PARTITION(part)), \
+		(FLASH_AREA_FOO(part)), ())
+
+#define FOREACH_PARTITION(n) DT_FOREACH_CHILD(DT_DRV_INST(n), FLASH_AREA_FOOO)
 
 /* We iterate over all compatible 'fixed-partitions' nodes and
  * use DT_FOREACH_CHILD to iterate over all the partitions for that

--- a/tests/subsys/storage/flash_map/src/main.c
+++ b/tests/subsys/storage/flash_map/src/main.c
@@ -26,9 +26,9 @@ ZTEST(flash_map, test_flash_area_disabled_device)
 
 	/* Test that attempting to open a disabled flash area fails */
 	rc = flash_area_open(FIXED_PARTITION_ID(disabled_a), &fa);
-	zassert_equal(rc, -ENODEV, "Open did not fail");
+	zassert_equal(rc, -ENOENT, "Open did not fail");
 	rc = flash_area_open(FIXED_PARTITION_ID(disabled_b), &fa);
-	zassert_equal(rc, -ENODEV, "Open did not fail");
+	zassert_equal(rc, -ENOENT, "Open did not fail");
 }
 
 /**


### PR DESCRIPTION
Change in default flash map generation, where partitions hanging of disabled devices will not have flash area generated.