### PR TITLE
modules: hostap: Add external crypto support

### DIFF
--- a/modules/hostap/Kconfig
+++ b/modules/hostap/Kconfig
@@ -166,6 +166,14 @@ config WIFI_NM_WPA_SUPPLICANT_CRYPTO_ALT
 config WIFI_NM_WPA_SUPPLICANT_CRYPTO_NONE
 	bool "No Crypto support for WiFi"
 
+config WIFI_NM_WPA_SUPPLICANT_CRYPTO_EXT
+	bool "External Crypto support for hostap"
+	help
+	  Use external crypto implementation for hostp, this is useful for
+	  platforms where the crypto implementation is provided by the platform
+	  and not by Zephyr. The external crypto implementation should provide
+	  the required APIs and any other dependencies required by hostap.
+
 endchoice
 
 config WIFI_NM_WPA_SUPPLICANT_CRYPTO_MBEDTLS_PSA


### PR DESCRIPTION
Add an option for platforms or forks to provide their own hostap compatible crypto implementation. This may include proprietary or platform specific stuff that may or may not be upstreamed to Zephyr.

The motivation is mainly for NCS (fork) to implement it's own crypto, but can be used by other platforms as well, esp. as crypto is very platform specific.