### PR TITLE
instantiation of flash area objects at point of usage

### DIFF
--- a/include/zephyr/storage/flash_map.h
+++ b/include/zephyr/storage/flash_map.h
@@ -255,6 +255,20 @@ int flash_area_get_sectors(int fa_id, uint32_t *count,
 			   struct flash_sector *sectors);
 
 /**
+ * Retrieve info about sectors within the area.
+ *
+ * @param[in]  fa       pointer to flash area object.
+ * @param[out] sectors  buffer for sectors data
+ * @param[in,out] count On input Capacity of @p sectors, on output number of
+ * sectors Retrieved.
+ *
+ * @return  0 on success, negative errno code on fail. Especially returns
+ * -ENOMEM if There are too many flash pages on the flash_area to fit in the
+ * array.
+ */
+int flash_area_sectors(const struct flash_area *fa, uint32_t *count, struct flash_sector *sectors);
+
+/**
  * Flash map iteration callback
  *
  * @param fa flash area

--- a/subsys/storage/flash_map/flash_map_default.c
+++ b/subsys/storage/flash_map/flash_map_default.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 Nordic Semiconductor ASA
+ * Copyright (c) 2017-2024 Nordic Semiconductor ASA
  * Copyright (c) 2015 Runtime Inc
  * Copyright (c) 2023 Sensorfy B.V.
  *
@@ -39,3 +39,21 @@ const struct flash_area default_flash_map[] = {
 
 const int flash_map_entries = ARRAY_SIZE(default_flash_map);
 const struct flash_area *flash_map = default_flash_map;
+
+/* Generate objects representing each partition in system. In the end only
+ * objects referenced by code will be included into build.
+ */
+#define DEFINE_PARTITION(part) DEFINE_PARTITION_1(part, DT_DEP_ORD(part))
+#define DEFINE_PARTITION_1(part, ord)								\
+	COND_CODE_1(DT_NODE_HAS_STATUS_OKAY(DT_MTD_FROM_FIXED_PARTITION(part)),			\
+		(DEFINE_PARTITION_0(part, ord)), ())
+#define DEFINE_PARTITION_0(part, ord)								\
+	const struct flash_area DT_CAT(global_fixed_partition_ORD_, ord) = {			\
+		.fa_id = DT_FIXED_PARTITION_ID(part),						\
+		.fa_off = DT_REG_ADDR(part),							\
+		.fa_dev = DEVICE_DT_GET(DT_MTD_FROM_FIXED_PARTITION(part)),			\
+		.fa_size = DT_REG_SIZE(part),							\
+	};
+
+#define FOR_EACH_PARTITION_TABLE(table) DT_FOREACH_CHILD(table, DEFINE_PARTITION)
+DT_FOREACH_STATUS_OKAY(fixed_partitions, FOR_EACH_PARTITION_TABLE)

--- a/subsys/storage/flash_map/flash_map_layout.c
+++ b/subsys/storage/flash_map/flash_map_layout.c
@@ -78,8 +78,6 @@ static bool get_sectors_cb(const struct flash_pages_info *info, void *datav)
 
 int flash_area_get_sectors(int idx, uint32_t *cnt, struct flash_sector *ret)
 {
-	struct layout_data data;
-	const struct device *flash_dev;
 	const struct flash_area *fa;
 	int rc = flash_area_open(idx, &fa);
 
@@ -87,7 +85,17 @@ int flash_area_get_sectors(int idx, uint32_t *cnt, struct flash_sector *ret)
 		return -EINVAL;
 	}
 
-	data.area_idx = idx;
+	rc = flash_area_sectors(fa, cnt, ret);
+	flash_area_close(fa);
+
+	return rc;
+}
+
+int flash_area_sectors(const struct flash_area *fa, uint32_t *cnt, struct flash_sector *ret)
+{
+	struct layout_data data;
+	const struct device *flash_dev;
+
 	data.area_off = fa->fa_off;
 	data.area_len = fa->fa_size;
 
@@ -97,10 +105,6 @@ int flash_area_get_sectors(int idx, uint32_t *cnt, struct flash_sector *ret)
 	data.status = 0;
 
 	flash_dev = fa->fa_dev;
-	flash_area_close(fa);
-	if (flash_dev == NULL) {
-		return -ENODEV;
-	}
 
 	flash_page_foreach(flash_dev, get_sectors_cb, &data);
 


### PR DESCRIPTION
The PR consists of  commits adding: 
 -  `FIXED_PARTITION(label)` macro that allows to directly access flash_area object instead of using flash_area_open to search it in map; this should reduce size of rom usage by applications since only the directly referenced by code partitions will be linked in instead of entire flash map that flash_area_open has to iterate on; the commit also adds supporting code that generates the object and proper declarations.
 - `flash_area_device_is_ready` to be used instead of `flash_area_open` to check if object obtained by invocation of `FIXED_PARTITION` is pointing to device ready for operation.
 -  `flash_area_sectors` which is equivalent to `flash_are_get_sectors` except it takes flash_area object pointer instead of flash area index, and does not use flash_area_open internally; this change is needed as replacement for `flash_area_get_sectors` so that generating of default flash_map could be removed;
 - Changes for flash map tests, where `flash_area_open/flash_area_close` is no longer used in tests.
