### PR TITLE
drivers: mipi_dbi: mipi_dbi_nxp_lcdic: allow config of timer bases

### DIFF
--- a/boards/nxp/rd_rw612_bga/dts/goworld_16880_lcm.overlay
+++ b/boards/nxp/rd_rw612_bga/dts/goworld_16880_lcm.overlay
@@ -17,6 +17,8 @@
 &lcdic {
 	status = "okay";
 	nxp,swap-bytes;
+	/* Raise the timer0 ratio to enable longer reset delay */
+	nxp,timer0-ratio = <15>;
 	/*
 	 * Settings to connect this display:
 	 * Populate the following resistors:

--- a/boards/shields/adafruit_2_8_tft_touch_v2/boards/rd_rw612_bga.overlay
+++ b/boards/shields/adafruit_2_8_tft_touch_v2/boards/rd_rw612_bga.overlay
@@ -22,6 +22,8 @@
 &lcdic {
 	/* Byte swapping not supported for this display */
 	/delete-property/ nxp,swap-bytes;
+	/* Set timer0 ratio to enable longer resets */
+	nxp,timer0-ratio = <15>;
 
 	/*
 	 * Settings to connect this display:

--- a/boards/shields/lcd_par_s035/boards/rd_rw612_bga.overlay
+++ b/boards/shields/lcd_par_s035/boards/rd_rw612_bga.overlay
@@ -92,4 +92,6 @@
 	/* Set pulse width for write active and write inactive to min value */
 	nxp,write-active-cycles = <1>;
 	nxp,write-inactive-cycles = <1>;
+	/* Raise the timer0 ratio to enable longer reset delay */
+	nxp,timer0-ratio = <15>;
 };

--- a/dts/bindings/mipi-dbi/nxp,lcdic.yaml
+++ b/dts/bindings/mipi-dbi/nxp,lcdic.yaml
@@ -46,3 +46,21 @@ properties:
       Set minimum count of write active cycles, as a multiple of the module
       clock frequency. This controls the length of the active period of the
       WRX signal. Default is IP reset value. Only valid in 8080 mode.
+
+  nxp,timer0-ratio:
+    type: int
+    default: 8
+    description: |
+      Ratio for timer0, used for setting timer0 period (which is used for reset
+      and TX/RX short command timeout). Formula is:
+      timer0_period = (2 ^ timer0_ratio) / lcdic_freq
+      Default is IP reset value
+
+  nxp,timer1-ratio:
+    type: int
+    default: 9
+    description: |
+      Ratio for timer1, used for setting timer1 period (which is used for TE
+      wait time, timeout, and long command timeout). Formula is:
+      timer1_period = (2 ^ timer1_ratio) * timer0_period
+      Default is IP reset value


### PR DESCRIPTION
The NXP LCDIC peripheral contains two internal timers, with configurable
periods. These times are used to determine delays within the peripheral,
such as the reset and tearing enable signal delays. Allow these periods
to be set within the devicetree for the peripheral.

Raise the period where required for display drivers that need a value
other than the reset setting