### PR TITLE
drivers: nxp_enet: Add get_config to re-enable ipv6 checksum acceleration

### DIFF
--- a/drivers/ethernet/nxp_enet/Kconfig
+++ b/drivers/ethernet/nxp_enet/Kconfig
@@ -57,7 +57,6 @@ config ETH_NXP_ENET_USE_DTCM_FOR_DMA_BUFFER
 config ETH_NXP_ENET_HW_ACCELERATION
 	bool "Hardware acceleration"
 	default y
-	depends on !NET_IPV6
 	help
 	  Enable hardware acceleration for the following:
 	  - IPv4, UDP and TCP checksum (both Rx and Tx)

--- a/drivers/ethernet/nxp_enet/eth_nxp_enet.c
+++ b/drivers/ethernet/nxp_enet/eth_nxp_enet.c
@@ -315,6 +315,26 @@ static int eth_nxp_enet_set_config(const struct device *dev,
 	return -ENOTSUP;
 }
 
+static int eth_nxp_enet_get_config(const struct device *dev,
+			       enum ethernet_config_type type,
+			       struct ethernet_config *cfg)
+{
+	switch (type) {
+	case ETHERNET_CONFIG_TYPE_RX_CHECKSUM_SUPPORT:
+	case ETHERNET_CONFIG_TYPE_TX_CHECKSUM_SUPPORT:
+		cfg->chksum_support = ETHERNET_CHECKSUM_SUPPORT_IPV4_HEADER	|
+				      ETHERNET_CHECKSUM_SUPPORT_IPV4_ICMP	|
+				      ETHERNET_CHECKSUM_SUPPORT_IPV6_HEADER	|
+				      ETHERNET_CHECKSUM_SUPPORT_TCP		|
+				      ETHERNET_CHECKSUM_SUPPORT_UDP;
+		return 0;
+	default:
+		break;
+	}
+
+	return -ENOTSUP;
+}
+
 static int eth_nxp_enet_rx(const struct device *dev)
 {
 #if defined(CONFIG_PTP_CLOCK_NXP_ENET)
@@ -845,6 +865,7 @@ static const struct ethernet_api api_funcs = {
 	.get_capabilities	= eth_nxp_enet_get_capabilities,
 	.get_phy                = eth_nxp_enet_get_phy,
 	.set_config		= eth_nxp_enet_set_config,
+	.get_config		= eth_nxp_enet_get_config,
 	.send			= NXP_ENET_SEND_FUNC,
 #if defined(CONFIG_PTP_CLOCK)
 	.get_ptp_clock		= eth_nxp_enet_get_ptp_clock,


### PR DESCRIPTION
Previously, ipv6 being disabled was a dependency of the hw acceleration of the checksums for the nxp enet driver, because this ethernet has an errata causing icmpv6 checksum to not be supported (see #73518). Now, there is a new config type in ethernet api added in #73985 for checksum types, so we can re-enable hardware acceleration for ipv6 by implementing this type in the get_config api in this driver.