### PR TITLE
cmake: extensions: use INTERFACE_SOURCES as property for code relocation

### DIFF
--- a/cmake/linker/arcmwdt/target.cmake
+++ b/cmake/linker/arcmwdt/target.cmake
@@ -155,7 +155,7 @@ macro(toolchain_ld_relocation)
     ${ZEPHYR_BASE}/scripts/build/gen_relocate_app.py
     $<$<BOOL:${CMAKE_VERBOSE_MAKEFILE}>:--verbose>
     -d ${APPLICATION_BINARY_DIR}
-    -i \"$<TARGET_PROPERTY:code_data_relocation_target,COMPILE_DEFINITIONS>\"
+    -i \"$<TARGET_PROPERTY:code_data_relocation_target,INTERFACE_SOURCES>\"
     -o ${MEM_RELOCATION_LD}
     -s ${MEM_RELOCATION_SRAM_DATA_LD}
     -b ${MEM_RELOCATION_SRAM_BSS_LD}

--- a/cmake/linker/ld/target_relocation.cmake
+++ b/cmake/linker/ld/target_relocation.cmake
@@ -16,7 +16,7 @@ macro(toolchain_ld_relocation)
   OUTPUT
     ${DICT_FILE}
   CONTENT
-    $<TARGET_PROPERTY:code_data_relocation_target,COMPILE_DEFINITIONS>
+    $<TARGET_PROPERTY:code_data_relocation_target,INTERFACE_SOURCES>
   )
 
   add_custom_command(

--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -1526,9 +1526,9 @@ function(zephyr_code_relocate)
   # each directive can embed multiple CMake lists, representing flags and files,
   # the latter of which can come from generator expressions.
   get_property(code_rel_str TARGET code_data_relocation_target
-    PROPERTY COMPILE_DEFINITIONS)
+    PROPERTY INTERFACE_SOURCES)
   set_property(TARGET code_data_relocation_target
-    PROPERTY COMPILE_DEFINITIONS
+    PROPERTY INTERFACE_SOURCES
     "${code_rel_str}|${CODE_REL_LOCATION}:${flag_list}:${file_list}")
 endfunction()
 


### PR DESCRIPTION
In order to enable code relocation, we use a custom target (code_data_relocation_target), and add files we wish to relocate, as well as which sections should be relocated to the COMPILE_DEFINITIONS property for the target.

This approach has been fragile, because COMPILE_DEFINITIONS can also be added to for all targets using `add_definitions`. This means if another part of the project uses `add_definitions` and
CONFIG_CODE_DATA_RELOCATION is on, a warning will appear about the "file" not being found. The "file" of course, is just the definition added by `add_definitions`.

To work around this, switch to overloading the INTERFACE_SOURCES property. This property should be a bit more robust, because nobody else will add sources to the code_data_relocation_target.

However, this approach has the downside that the CMake documentation pstates targets created with `add_custom_target()` (which the code_data_relocation_target is) do not have an INTERFACE scope for their sources- so while this approach works, it is not officially supported by CMake

Fixes #60220