### PR TITLE
soc: Move up SRAM definitions for stm32h56/7x

### DIFF
--- a/dts/arm/st/h5/stm32h562.dtsi
+++ b/dts/arm/st/h5/stm32h562.dtsi
@@ -56,6 +56,24 @@
 			};
 		};
 
+		sram1: memory@20000000 {
+			compatible = "zephyr,memory-region", "mmio-sram";
+			reg = <0x20000000 DT_SIZE_K(256)>;
+			zephyr,memory-region = "SRAM1";
+		};
+
+		sram2: memory@20040000 {
+			compatible = "zephyr,memory-region", "mmio-sram";
+			reg = <0x20040000 DT_SIZE_K(64)>;
+			zephyr,memory-region = "SRAM2";
+		};
+
+		sram3: memory@20050000 {
+			compatible = "zephyr,memory-region", "mmio-sram";
+			reg = <0x20050000 DT_SIZE_K(320)>;
+			zephyr,memory-region = "SRAM3";
+		};
+
 		backup_sram: memory@40036400 {
 			reg = <0x40036400 DT_SIZE_K(4)>;
 		};

--- a/dts/arm/st/h5/stm32h563Xi.dtsi
+++ b/dts/arm/st/h5/stm32h563Xi.dtsi
@@ -8,24 +8,6 @@
 #include <st/h5/stm32h563.dtsi>
 
 / {
-	sram1: memory@20000000 {
-		compatible = "zephyr,memory-region", "mmio-sram";
-		reg = <0x20000000 DT_SIZE_K(256)>;
-		zephyr,memory-region = "SRAM1";
-	};
-
-	sram2: memory@20040000 {
-		compatible = "zephyr,memory-region", "mmio-sram";
-		reg = <0x20040000 DT_SIZE_K(64)>;
-		zephyr,memory-region = "SRAM2";
-	};
-
-	sram3: memory@20050000 {
-		compatible = "zephyr,memory-region", "mmio-sram";
-		reg = <0x20050000 DT_SIZE_K(320)>;
-		zephyr,memory-region = "SRAM3";
-	};
-
 	soc {
 		flash-controller@40022000 {
 			flash0: flash@8000000 {

--- a/dts/arm/st/h5/stm32h573Xi.dtsi
+++ b/dts/arm/st/h5/stm32h573Xi.dtsi
@@ -7,24 +7,6 @@
 #include <st/h5/stm32h573.dtsi>
 
 / {
-	sram1: memory@20000000 {
-		compatible = "zephyr,memory-region", "mmio-sram";
-		reg = <0x20000000 DT_SIZE_K(256)>;
-		zephyr,memory-region = "SRAM1";
-	};
-
-	sram2: memory@20040000 {
-		compatible = "zephyr,memory-region", "mmio-sram";
-		reg = <0x20040000 DT_SIZE_K(64)>;
-		zephyr,memory-region = "SRAM2";
-	};
-
-	sram3: memory@20050000 {
-		compatible = "zephyr,memory-region", "mmio-sram";
-		reg = <0x20050000 DT_SIZE_K(320)>;
-		zephyr,memory-region = "SRAM3";
-	};
-
 	soc {
 		flash-controller@40022000 {
 			flash0: flash@8000000 {


### PR DESCRIPTION
This moves the SRAM definitions for STM32H56/7x chips up to the top level since they are common to all of them.