### PR TITLE
fuel_gauge: sbs_gauge: fix negative currents

### DIFF
--- a/drivers/fuel_gauge/sbs_gauge/sbs_gauge.c
+++ b/drivers/fuel_gauge/sbs_gauge/sbs_gauge.c
@@ -83,7 +83,7 @@ static int sbs_gauge_get_prop(const struct device *dev, fuel_gauge_prop_t prop,
 		break;
 	case FUEL_GAUGE_CURRENT:
 		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_CURRENT, &tmp_val);
-		val->current = tmp_val * 1000;
+		val->current = (int16_t)tmp_val * 1000;
 		break;
 	case FUEL_GAUGE_FULL_CHARGE_CAPACITY:
 		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_FULL_CAPACITY, &tmp_val);

--- a/tests/drivers/fuel_gauge/sbs_gauge/src/test_sbs_gauge.c
+++ b/tests/drivers/fuel_gauge/sbs_gauge/src/test_sbs_gauge.c
@@ -206,7 +206,24 @@ ZTEST_USER_F(sbs_gauge_new_api, test_get_buffer_props__returns_ok)
 ZTEST_USER_F(sbs_gauge_new_api, test_charging_5v_3a)
 {
 	uint32_t expected_uV = 5000 * 1000;
-	uint32_t expected_uA = 3000 * 1000;
+	int32_t expected_uA = 3000 * 1000;
+
+	union fuel_gauge_prop_val voltage;
+	union fuel_gauge_prop_val current;
+
+	zassume_ok(emul_fuel_gauge_set_battery_charging(fixture->sbs_fuel_gauge, expected_uV,
+							expected_uA));
+	zassert_ok(fuel_gauge_get_prop(fixture->dev, FUEL_GAUGE_VOLTAGE, &voltage));
+	zassert_ok(fuel_gauge_get_prop(fixture->dev, FUEL_GAUGE_CURRENT, &current));
+
+	zassert_equal(voltage.voltage, expected_uV, "Got %d instead of %d", voltage, expected_uV);
+	zassert_equal(current.current, expected_uA, "Got %d instead of %d", current, expected_uA);
+}
+
+ZTEST_USER_F(sbs_gauge_new_api, test_charging_5v_neg_1a)
+{
+	uint32_t expected_uV = 5000 * 1000;
+	int32_t expected_uA = -1000 * 1000;
 
 	union fuel_gauge_prop_val voltage;
 	union fuel_gauge_prop_val current;


### PR DESCRIPTION
Fix negative currents being read as extremely high currents due to unsigned variable use.