### PR TITLE
drivers: cache: andes: Improve cache_andes driver

### DIFF
--- a/drivers/cache/Kconfig.andes
+++ b/drivers/cache/Kconfig.andes
@@ -2,8 +2,6 @@
 #
 # Copyright (c) 2024 ANDES Technology Inc.
 
-DT_COMPAT_ANDESTECH_L2C := andestech,l2c
-
 config CACHE_ANDES
 bool "ANDES external cache driver"
 	default y
@@ -18,7 +16,7 @@ if CACHE_ANDES
 
 config L2C_INCLUSIVE_POLICY
 	bool
-	depends on $(dt_compat_enabled,$(DT_COMPAT_ANDESTECH_L2C))
+	depends on DT_HAS_ANDESTECH_L2C_ENABLED
 	help
 	  When L2 cache is inclusive of L1, CPU only needs to perform operations
 	  on L2 cache, instead of on both L1 and L2 caches.

--- a/drivers/cache/Kconfig.andes
+++ b/drivers/cache/Kconfig.andes
@@ -7,8 +7,6 @@ bool "ANDES external cache driver"
 	default y
 	depends on SOC_FAMILY_ANDES_V5
 	select CACHE_HAS_DRIVER
-	imply DCACHE_LINE_SIZE_DETECT
-	imply ICACHE_LINE_SIZE_DETECT
 	help
 	  This option enables the CACHE driver for ANDES V5 series SOC.
 

--- a/drivers/cache/cache_andes.c
+++ b/drivers/cache/cache_andes.c
@@ -544,7 +544,7 @@ static int andes_cache_init(void)
 		}
 	}
 
-	cache_cfg.l2_cache_size = nds_l2_cache_init();
+	cache_cfg.l2_cache_size = nds_l2_cache_init(cache_cfg.data_line_size);
 	cache_cfg.l2_cache_inclusive = nds_l2_cache_is_inclusive();
 
 	return 0;

--- a/drivers/cache/cache_andes.c
+++ b/drivers/cache/cache_andes.c
@@ -536,7 +536,7 @@ static int andes_cache_init(void)
 		cache_cfg.instr_line_size = CONFIG_ICACHE_LINE_SIZE;
 #elif DT_NODE_HAS_PROP(DT_PATH(cpus, cpu_0), i_cache_line_size)
 		cache_cfg.instr_line_size =
-			DT_PROP(DT_PATH(cpus, cpu_0), "i_cache_line_size");
+			DT_PROP(DT_PATH(cpus, cpu_0), i_cache_line_size);
 #else
 		LOG_ERR("Please specific the i-cache-line-size "
 			"CPU0 property of the DT");
@@ -560,7 +560,7 @@ static int andes_cache_init(void)
 		cache_cfg.data_line_size = CONFIG_DCACHE_LINE_SIZE;
 #elif DT_NODE_HAS_PROP(DT_PATH(cpus, cpu_0), d_cache_line_size)
 		cache_cfg.data_line_size =
-			DT_PROP(DT_PATH(cpus, cpu_0), "d_cache_line_size");
+			DT_PROP(DT_PATH(cpus, cpu_0), d_cache_line_size);
 #else
 		LOG_ERR("Please specific the d-cache-line-size "
 			"CPU0 property of the DT");


### PR DESCRIPTION
This PR refines the Andes cache driver:
1. Support enable/disable on CPUs lacking cache operation capability
2. Decouple cache line size calculation option
3. Dynamically calculate L2 cache parameters


Signed-off-by: Wei-Tai Lee [wtlee@andestech.com](mailto:wtlee@andestech.com)