### PR TITLE
drivers: sensor: fxls8974: remove redundant error check

### DIFF
--- a/drivers/sensor/nxp/fxls8974/fxls8974.c
+++ b/drivers/sensor/nxp/fxls8974/fxls8974.c
@@ -379,9 +379,7 @@ static int fxls8974_channel_get(const struct device *dev,
 
 			val += FXLS8974_MAX_ACCEL_CHANNELS;
 
-			if (fxls8974_get_temp_data(dev, val)) {
-				return -EIO;
-			}
+			return fxls8974_get_temp_data(dev, val);
 			break;
 		case SENSOR_CHAN_ACCEL_XYZ:
 			return fxls8974_get_accel_data(dev, val, SENSOR_CHAN_ACCEL_XYZ);


### PR DESCRIPTION
The function fxls8974_get_temp_data always returns zero, indicating success.Therefore, the error checking if condition is unnecessary and can be removed