### PR TITLE
drivers: sensor: ina219: remove redundant error check

### DIFF
--- a/drivers/sensor/ti/ina219/ina219.c
+++ b/drivers/sensor/ti/ina219/ina219.c
@@ -269,11 +269,7 @@ static int ina219_init(const struct device *dev)
 	}
 
 	/* Set measurement delay */
-	rc = ina219_set_msr_delay(dev);
-	if (rc) {
-		LOG_ERR("Could not get measurement delay.");
-		return rc;
-	}
+	ina219_set_msr_delay(dev);
 
 	k_sleep(K_USEC(INA219_WAIT_STARTUP));
 


### PR DESCRIPTION
The function ina219_set_msr_delay always returns zero, indicating success. Therefore, the error check on its return value is unnecessary and can be removed.