### PR TITLE
drivers: display: dummy: Add pixel format property

### DIFF
--- a/drivers/display/display_dummy.c
+++ b/drivers/display/display_dummy.c
@@ -24,10 +24,6 @@ struct dummy_display_data {
 
 static int dummy_display_init(const struct device *dev)
 {
-	struct dummy_display_data *disp_data = dev->data;
-
-	disp_data->current_pixel_format = PIXEL_FORMAT_ARGB_8888;
-
 	return 0;
 }
 
@@ -122,7 +118,9 @@ static const struct display_driver_api dummy_display_api = {
 		.width = DT_INST_PROP(n, width),			\
 	};								\
 									\
-	static struct dummy_display_data dd_data_##n;			\
+	static struct dummy_display_data dd_data_##n = {		\
+		.current_pixel_format = DT_INST_PROP(n, pixel_format),	\
+	};								\
 									\
 	DEVICE_DT_INST_DEFINE(n, &dummy_display_init, NULL,		\
 			      &dd_data_##n,				\

--- a/dts/bindings/display/zephyr,dummy-dc.yaml
+++ b/dts/bindings/display/zephyr,dummy-dc.yaml
@@ -6,3 +6,18 @@ description: Dummy display controller
 compatible: "zephyr,dummy-dc"
 
 include: display-controller.yaml
+
+properties:
+  pixel-format:
+    type: int
+    default: 1
+    enum:
+      - 1  # PIXEL_FORMAT_RGB_888
+      - 2  # PIXEL_FORMAT_MONO01
+      - 4  # PIXEL_FORMAT_MONO10
+      - 8  # PIXEL_FORMAT_ARGB_8888
+      - 16 # PIXEL_FORMAT_RGB_565
+      - 32 # PIXEL_FORMAT_BGR_565
+    description:
+      Display pixel format. Defaults to RGB888 since its the most common
+      format of any native application.


### PR DESCRIPTION
Adds the pixel-format property to the dts binding for the dummy display. This allows for testing cases where things like buffer allocation happen before any test code is executed which rely on the pixelformat of the display.