### PR TITLE
Ethernet initialization sequence

### DIFF
--- a/drivers/ethernet/Kconfig.stm32_hal
+++ b/drivers/ethernet/Kconfig.stm32_hal
@@ -56,6 +56,19 @@ config ETH_STM32_HAL_RX_THREAD_PRIO
 	  Preemptive scheduling can lead to more responsive handling of network traffic,
 	  especially under high load.
 
+config ETH_STM32_HAL_ETH_POST_INIT_PRIO
+	int "Second part of the ethernet initialization"
+	default 89
+	help
+	  In order to allow transactions with external PHY connected over MDIO bus, like
+	  PHY initialization, the ethernet initialization sequence must be split. The
+	  reason is that the ethernet initialization process can't start MDIO
+	  communication until MDIO bus will be ready. First part initialized the ethernet
+	  clocks. Second part is starting the MDIO communications. MDIO initialization
+	  is realized between these two parts. It is important to note, that this option is
+	  corelated with the ETH_INIT_PRIORITY, which must be always lower than
+	  ETH_STM32_HAL_ETH_POST_INIT_PRIO
+
 config ETH_STM32_HAL_USE_DTCM_FOR_DMA_BUFFER
 	bool "Use DTCM for DMA buffers"
 	default y

--- a/drivers/ethernet/eth_stm32_hal.c
+++ b/drivers/ethernet/eth_stm32_hal.c
@@ -911,8 +911,6 @@ static int eth_initialize(const struct device *dev)
 {
 	struct eth_stm32_hal_dev_data *dev_data;
 	const struct eth_stm32_hal_dev_cfg *cfg;
-	ETH_HandleTypeDef *heth;
-	HAL_StatusTypeDef hal_ret = HAL_OK;
 	int ret = 0;
 
 	__ASSERT_NO_MSG(dev != NULL);
@@ -953,6 +951,15 @@ static int eth_initialize(const struct device *dev)
 		LOG_ERR("Could not configure ethernet pins");
 		return ret;
 	}
+	return 0;
+}
+
+static int eth_configure(void)
+{
+	const struct device *const dev = DEVICE_DT_GET(DT_NODELABEL(mac));
+	struct eth_stm32_hal_dev_data *dev_data = dev->data;
+	ETH_HandleTypeDef *heth = &dev_data->heth;
+	HAL_StatusTypeDef hal_ret = HAL_OK;
 
 	heth = &dev_data->heth;
 
@@ -1048,7 +1055,6 @@ static int eth_initialize(const struct device *dev)
 	}
 
 	setup_mac_filter(heth);
-
 
 	LOG_DBG("MAC %02x:%02x:%02x:%02x:%02x:%02x",
 		dev_data->mac_addr[0], dev_data->mac_addr[1],
@@ -1639,3 +1645,5 @@ DEVICE_DEFINE(stm32_ptp_clock_0, PTP_CLOCK_NAME, ptp_stm32_init,
 		CONFIG_ETH_STM32_HAL_PTP_CLOCK_INIT_PRIO, &api);
 
 #endif /* CONFIG_PTP_CLOCK_STM32_HAL */
+
+SYS_INIT(eth_configure, POST_KERNEL, CONFIG_ETH_STM32_HAL_ETH_POST_INIT_PRIO);


### PR DESCRIPTION
In case of external PHY connected via MDIO interace, the initialization sequence must initialize GPIO and MDIO peripheral first, before ethernet initialization function eth_initialize() will try to requesting data over MDIO.

Current solution is the proposition and attempt to highlight the problem. Without this change, the system is trying to use MDIO during ethernet initialization before it will be ready. Afte this change, we get the initialization order like below:
1. eth_initialize() - partially, because it's splitted now
2. mdio_stm32_init()
3. phy_dm8806_init() - new driver from PR77812: zephyrproject-rtos#77812
4. hal_init() - rest part of ethernet initialization

To be able to reproduce this error, the Davicom DM8806 MAC PHY driver from: zephyrproject-rtos#77812 must be
integrated and MDIO interface must be a child of mac node, below an example of device tree with MDIO interface:
&mac {
	status = "okay";
	pinctrl-0 = <&eth_crs_dv_pax
		     &eth_ref_clk_pax
		     &eth_tx_en_pbx
		     &eth_txd1_pbx
		     &eth_txd0_pbx
		     &eth_rxd1_pcx
		     &eth_rxd0_pcx>;
	pinctrl-names = "default";

	mdio {
		compatible = "st,stm32-mdio";
		status = "okay";