### PR TITLE
drivers: serial: nrfx_uarte: Improve pin retention

### DIFF
--- a/dts/bindings/serial/nordic,nrf-uarte.yaml
+++ b/dts/bindings/serial/nordic,nrf-uarte.yaml
@@ -14,3 +14,9 @@ properties:
     type: boolean
     description: |
       UARTE has RX frame timeout HW feature.
+  pin-retention:
+    type: boolean
+    description: |
+      UARTE pin states must be retained when peripheral is disabled.
+      It is required when CTRLSEL is used to route UARTE pins. It is always the
+      case for fast peripheral and in special cases for slow peripherals.

--- a/dts/common/nordic/nrf54h20.dtsi
+++ b/dts/common/nordic/nrf54h20.dtsi
@@ -661,6 +661,7 @@
 				power-domains = <&gpd NRF_GPD_FAST_ACTIVE1>;
 				endtx-stoptx-supported;
 				frame-timeout-supported;
+				pin-retention;
 			};
 
 			spi121: spi@8e7000 {

--- a/dts/common/nordic/nrf9280.dtsi
+++ b/dts/common/nordic/nrf9280.dtsi
@@ -508,6 +508,7 @@
 				interrupts = <230 NRF_DEFAULT_IRQ_PRIORITY>;
 				endtx-stoptx-supported;
 				frame-timeout-supported;
+				pin-retention;
 			};
 
 			spi121: spi@8e7000 {


### PR DESCRIPTION
- Fix case when device PM is not used but low power mode is used and UARTE is disabled when idle. In that case pins retention was not enabled.
- Perform pin retention only when needed (always for UARTE120 and optional for other instances). Pin retention requires 4 register access to the slow domain which will take ~2us and it is done with interrupts locked so we want to avoid it if possible.