### PR TITLE
Fix nxp enet carrier after boot

### DIFF
--- a/drivers/ethernet/nxp_enet/eth_nxp_enet.c
+++ b/drivers/ethernet/nxp_enet/eth_nxp_enet.c
@@ -502,6 +502,8 @@ static void eth_nxp_enet_iface_init(struct net_if *iface)
 	const struct device *dev = net_if_get_device(iface);
 	struct nxp_enet_mac_data *data = dev->data;
 	const struct nxp_enet_mac_config *config = dev->config;
+	const struct device *phy_dev = config->phy_dev;
+	struct phy_link_state state;
 
 	net_if_set_link_addr(iface, data->mac_addr,
 			     sizeof(data->mac_addr),
@@ -517,6 +519,14 @@ static void eth_nxp_enet_iface_init(struct net_if *iface)
 
 	ethernet_init(iface);
 	net_if_carrier_off(iface);
+
+	/* In case the phy driver doesn't report a state change due to link being up
+	 * before calling phy_configure, we should check the state ourself, and then do a
+	 * pseudo-callback
+	 */
+	phy_get_link_state(phy_dev, &state);
+
+	nxp_enet_phy_cb(phy_dev, &state, (void *)dev);
 
 	config->irq_config_func();
 

--- a/drivers/ethernet/nxp_enet/eth_nxp_enet.c
+++ b/drivers/ethernet/nxp_enet/eth_nxp_enet.c
@@ -243,32 +243,6 @@ exit:
 	return ret;
 }
 
-static void eth_nxp_enet_iface_init(struct net_if *iface)
-{
-	const struct device *dev = net_if_get_device(iface);
-	struct nxp_enet_mac_data *data = dev->data;
-	const struct nxp_enet_mac_config *config = dev->config;
-
-	net_if_set_link_addr(iface, data->mac_addr,
-			     sizeof(data->mac_addr),
-			     NET_LINK_ETHERNET);
-
-	if (data->iface == NULL) {
-		data->iface = iface;
-	}
-
-#if defined(CONFIG_NET_DSA)
-	dsa_register_master_tx(iface, &eth_nxp_enet_tx);
-#endif
-
-	ethernet_init(iface);
-	net_if_carrier_off(data->iface);
-
-	config->irq_config_func();
-
-	nxp_enet_driver_cb(config->mdio, NXP_ENET_MDIO, NXP_ENET_INTERRUPT_ENABLED, NULL);
-}
-
 static enum ethernet_hw_caps eth_nxp_enet_get_capabilities(const struct device *dev)
 {
 #if defined(CONFIG_ETH_NXP_ENET_1G)
@@ -523,6 +497,31 @@ static void nxp_enet_phy_cb(const struct device *phy,
 	}
 }
 
+static void eth_nxp_enet_iface_init(struct net_if *iface)
+{
+	const struct device *dev = net_if_get_device(iface);
+	struct nxp_enet_mac_data *data = dev->data;
+	const struct nxp_enet_mac_config *config = dev->config;
+
+	net_if_set_link_addr(iface, data->mac_addr,
+			     sizeof(data->mac_addr),
+			     NET_LINK_ETHERNET);
+
+	if (data->iface == NULL) {
+		data->iface = iface;
+	}
+
+#if defined(CONFIG_NET_DSA)
+	dsa_register_master_tx(iface, &eth_nxp_enet_tx);
+#endif
+
+	ethernet_init(iface);
+	net_if_carrier_off(iface);
+
+	config->irq_config_func();
+
+	nxp_enet_driver_cb(config->mdio, NXP_ENET_MDIO, NXP_ENET_INTERRUPT_ENABLED, NULL);
+}
 
 static int nxp_enet_phy_init(const struct device *dev)
 {


### PR DESCRIPTION
#81020 revealed a bug that the carrier can be marked down after boot even if link is up, fixes #81274

the diff is larger than what's really the fix, I just moved one function before another, there are really only two lines added to check the phy link state and update the iface state 

this is to fix the case where the phy driver does not see a link state change after the iface init of the ethernet mac