### PR TITLE
boards/arduino/portenta_h7: enable USART1 on M4

### DIFF
--- a/boards/arduino/portenta_h7/arduino_portenta_h7_stm32h747xx_m4.dts
+++ b/boards/arduino/portenta_h7/arduino_portenta_h7_stm32h747xx_m4.dts
@@ -28,5 +28,5 @@
 };
 
 &usart1 {
-	status = "disabled";
+	status = "okay";
 };

--- a/boards/arduino/portenta_h7/arduino_portenta_h7_stm32h747xx_m4_defconfig
+++ b/boards/arduino/portenta_h7/arduino_portenta_h7_stm32h747xx_m4_defconfig
@@ -10,9 +10,7 @@ CONFIG_ARM_MPU=y
 # Enable HW stack protection
 CONFIG_HW_STACK_PROTECTION=y
 
-# Enable uart driver
-# CONFIG_SERIAL=y
-
-# By default CONSOLE is assigned to m7
-# CONFIG_CONSOLE=y
-# CONFIG_UART_CONSOLE=y
+# On M4, USART1 is used as the UART console backend by default
+CONFIG_SERIAL=y
+CONFIG_CONSOLE=y
+CONFIG_UART_CONSOLE=y

--- a/boards/arduino/portenta_h7/arduino_portenta_h7_stm32h747xx_m7.dts
+++ b/boards/arduino/portenta_h7/arduino_portenta_h7_stm32h747xx_m7.dts
@@ -80,9 +80,9 @@
 	clock-frequency = <DT_FREQ_M(400)>;
 };
 
-
+/* USART1 is enabled on M4 by default */
 &usart1 {
-	status = "okay";
+	status = "disabled";
 };
 
 &i2c1 {

--- a/boards/arduino/portenta_h7/arduino_portenta_h7_stm32h747xx_m7_defconfig
+++ b/boards/arduino/portenta_h7/arduino_portenta_h7_stm32h747xx_m7_defconfig
@@ -16,12 +16,8 @@ CONFIG_HW_STACK_PROTECTION=y
 # Use zephyr,code-partition as flash offset
 CONFIG_USE_DT_CODE_PARTITION=y
 
-# Disable following to assign serial ports to m4 core
-
-# Enable uart driver
+# On M7, USB CDC ACM is used as the UART console backend by default
 CONFIG_SERIAL=y
-
-# Enable console
 CONFIG_CONSOLE=y
 CONFIG_UART_CONSOLE=y
 CONFIG_UART_LINE_CTRL=y


### PR DESCRIPTION
Right now, USART1 is enabled on the M7 target variant by default, leaving M4 without a UART to use; this is the way this port was originally contributed.

Since then, USB was enabled on M7, changing the console backend from USART1 to USB CDC ACM; the M4 target was left unchanged.

This PR enabled USART1 on the M4 variant and disabled it on the M7 variant, so that the M4 variant can use it as its console backend.

Note that, for the M4 variant, USART1 has been assigned to `zephyr,console` and `zephyr,shell-uart` since this port was contributed, even though USART1 was always disabled on M4.

Original port: https://github.com/zephyrproject-rtos/zephyr/pull/45221/files#diff-f358a7cdc75425a345797de2ad620f03e84bd5fff885583e610c96f0b7a67cc5
USART1 originally used by M7: https://github.com/zephyrproject-rtos/zephyr/pull/45221/files#diff-7677cf951c934ab01432008243aa5d8a0b73c40a606b9fd6d207d883b3ad7490
M7 switches from USART1 to CDC ACM: https://github.com/zephyrproject-rtos/zephyr/commit/d86334365f8880319744561fffa977d4c9ced402#diff-5754d71b0f03ec5deb0c225ef1c776e934ddc7909856a757b75971dfa693ca7e