### PR TITLE
Add support for IPV6_MULTICAST_IF and IP_MULTICAST_IF socket options

### DIFF
--- a/drivers/net/loopback.c
+++ b/drivers/net/loopback.c
@@ -25,6 +25,16 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 
 #include <zephyr/net/dummy.h>
 
+/* Allow network tests to control the IP addresses swapping */
+#if defined(CONFIG_NET_TEST)
+static bool loopback_dont_swap_addresses;
+
+void loopback_enable_address_swap(bool swap_addresses)
+{
+	loopback_dont_swap_addresses = !swap_addresses;
+}
+#endif /* CONFIG_NET_TEST */
+
 int loopback_dev_init(const struct device *dev)
 {
 	ARG_UNUSED(dev);
@@ -123,17 +133,22 @@ static int loopback_send(const struct device *dev, struct net_pkt *pkt)
 
 	/* We need to swap the IP addresses because otherwise
 	 * the packet will be dropped.
+	 *
+	 * Some of the network tests require that addresses are not swapped so allow
+	 * the test to control this remotely.
 	 */
-	if (net_pkt_family(pkt) == AF_INET6) {
-		net_ipv6_addr_copy_raw(NET_IPV6_HDR(cloned)->src,
-				       NET_IPV6_HDR(pkt)->dst);
-		net_ipv6_addr_copy_raw(NET_IPV6_HDR(cloned)->dst,
-				       NET_IPV6_HDR(pkt)->src);
-	} else {
-		net_ipv4_addr_copy_raw(NET_IPV4_HDR(cloned)->src,
-				       NET_IPV4_HDR(pkt)->dst);
-		net_ipv4_addr_copy_raw(NET_IPV4_HDR(cloned)->dst,
-				       NET_IPV4_HDR(pkt)->src);
+	if (!COND_CODE_1(CONFIG_NET_TEST, (loopback_dont_swap_addresses), (false))) {
+		if (net_pkt_family(pkt) == AF_INET6) {
+			net_ipv6_addr_copy_raw(NET_IPV6_HDR(cloned)->src,
+					       NET_IPV6_HDR(pkt)->dst);
+			net_ipv6_addr_copy_raw(NET_IPV6_HDR(cloned)->dst,
+					       NET_IPV6_HDR(pkt)->src);
+		} else {
+			net_ipv4_addr_copy_raw(NET_IPV4_HDR(cloned)->src,
+					       NET_IPV4_HDR(pkt)->dst);
+			net_ipv4_addr_copy_raw(NET_IPV4_HDR(cloned)->dst,
+					       NET_IPV4_HDR(pkt)->src);
+		}
 	}
 
 	res = net_recv_data(net_pkt_iface(cloned), cloned);

--- a/include/zephyr/net/net_context.h
+++ b/include/zephyr/net/net_context.h
@@ -361,13 +361,23 @@ __net_socket struct net_context {
 		 * see RFC 5014 for details.
 		 */
 		uint16_t addr_preferences;
-
-		/**
-		 * IPv6 multicast output network interface for this context/socket.
-		 * Only allowed for SOCK_DGRAM or SOCK_RAW type sockets.
-		 */
-		uint8_t ipv6_mcast_ifindex;
 #endif
+#if defined(CONFIG_NET_IPV6) || defined(CONFIG_NET_IPV4)
+		union {
+			/**
+			 * IPv6 multicast output network interface for this context/socket.
+			 * Only allowed for SOCK_DGRAM or SOCK_RAW type sockets.
+			 */
+			uint8_t ipv6_mcast_ifindex;
+
+			/**
+			 * IPv4 multicast output network interface for this context/socket.
+			 * Only allowed for SOCK_DGRAM type sockets.
+			 */
+			uint8_t ipv4_mcast_ifindex;
+		};
+#endif /* CONFIG_NET_IPV6 || CONFIG_NET_IPV4 */
+
 #if defined(CONFIG_NET_CONTEXT_TIMESTAMPING)
 		/** Enable RX, TX or both timestamps of packets send through sockets. */
 		uint8_t timestamping;

--- a/include/zephyr/net/net_context.h
+++ b/include/zephyr/net/net_context.h
@@ -361,6 +361,12 @@ __net_socket struct net_context {
 		 * see RFC 5014 for details.
 		 */
 		uint16_t addr_preferences;
+
+		/**
+		 * IPv6 multicast output network interface for this context/socket.
+		 * Only allowed for SOCK_DGRAM or SOCK_RAW type sockets.
+		 */
+		uint8_t ipv6_mcast_ifindex;
 #endif
 #if defined(CONFIG_NET_CONTEXT_TIMESTAMPING)
 		/** Enable RX, TX or both timestamps of packets send through sockets. */
@@ -1292,6 +1298,7 @@ enum net_context_option {
 	NET_OPT_TTL               = 16, /**< IPv4 unicast TTL */
 	NET_OPT_ADDR_PREFERENCES  = 17, /**< IPv6 address preference */
 	NET_OPT_TIMESTAMPING      = 18, /**< Packet timestamping */
+	NET_OPT_MCAST_IFINDEX     = 19, /**< IPv6 multicast output network interface index */
 	NET_OPT_MTU               = 20, /**< IPv4 socket path MTU */
 };
 

--- a/include/zephyr/net/socket.h
+++ b/include/zephyr/net/socket.h
@@ -1222,6 +1222,9 @@ struct ip_mreqn {
 /** Set the unicast hop limit for the socket. */
 #define IPV6_UNICAST_HOPS	16
 
+/** Set multicast output network interface index for the socket. */
+#define IPV6_MULTICAST_IF       17
+
 /** Set the multicast hop limit for the socket. */
 #define IPV6_MULTICAST_HOPS 18
 

--- a/include/zephyr/net/socket.h
+++ b/include/zephyr/net/socket.h
@@ -1196,6 +1196,8 @@ struct in_pktinfo {
  */
 #define IP_MTU 14
 
+/** Set IPv4 multicast datagram network interface. */
+#define IP_MULTICAST_IF 32
 /** Set IPv4 multicast TTL value. */
 #define IP_MULTICAST_TTL 33
 /** Join IPv4 multicast group. */
@@ -1210,6 +1212,14 @@ struct ip_mreqn {
 	struct in_addr imr_multiaddr; /**< IP multicast group address */
 	struct in_addr imr_address;   /**< IP address of local interface */
 	int            imr_ifindex;   /**< Network interface index */
+};
+
+/**
+ * @brief Struct used when setting a IPv4 multicast network interface.
+ */
+struct ip_mreq  {
+	struct in_addr imr_multiaddr;   /**< IP multicast group address */
+	struct in_addr imr_interface;   /**< IP address of local interface */
 };
 
 /** @} */

--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -767,6 +767,17 @@ int net_context_bind(struct net_context *context, const struct sockaddr *addr,
 		if (net_ipv6_is_addr_mcast(&addr6->sin6_addr)) {
 			struct net_if_mcast_addr *maddr;
 
+			if (IS_ENABLED(CONFIG_NET_UDP) &&
+			    net_context_get_type(context) == SOCK_DGRAM) {
+				if (COND_CODE_1(CONFIG_NET_IPV6,
+						(context->options.ipv6_mcast_ifindex > 0),
+						(false))) {
+					IF_ENABLED(CONFIG_NET_IPV6,
+						   (iface = net_if_get_by_index(
+							   context->options.ipv6_mcast_ifindex)));
+				}
+			}
+
 			maddr = net_if_ipv6_maddr_lookup(&addr6->sin6_addr,
 							 &iface);
 			if (!maddr) {
@@ -1830,6 +1841,55 @@ out:
 	return 0;
 }
 
+static int get_context_mcast_ifindex(struct net_context *context,
+				     void *value, size_t *len)
+{
+#if defined(CONFIG_NET_IPV6)
+	if (net_context_get_family(context) != AF_INET6) {
+		return -EAFNOSUPPORT;
+	}
+
+	/* If user has not set the ifindex, then get the interface
+	 * that this socket is bound to.
+	 */
+	if (context->options.ipv6_mcast_ifindex == 0) {
+		struct net_if *iface;
+		int ifindex;
+
+		if (net_context_is_bound_to_iface(context)) {
+			iface = net_context_get_iface(context);
+		} else {
+			iface = net_if_get_default();
+		}
+
+		if (!net_if_flag_is_set(iface, NET_IF_IPV6)) {
+			return -EPROTOTYPE;
+		}
+
+		ifindex = net_if_get_by_iface(iface);
+		if (ifindex < 1) {
+			return -ENOENT;
+		}
+
+		*((int *)value) = ifindex;
+	} else {
+		*((int *)value) = context->options.ipv6_mcast_ifindex;
+	}
+
+	if (len) {
+		*len = sizeof(int);
+	}
+
+	return 0;
+#else
+	ARG_UNUSED(context);
+	ARG_UNUSED(value);
+	ARG_UNUSED(len);
+
+	return -ENOTSUP;
+#endif
+}
+
 /* If buf is not NULL, then use it. Otherwise read the data to be written
  * to net_pkt from msghdr.
  */
@@ -2007,7 +2067,7 @@ static int context_sendto(struct net_context *context,
 			  bool sendto)
 {
 	const struct msghdr *msghdr = NULL;
-	struct net_if *iface;
+	struct net_if *iface = NULL;
 	struct net_pkt *pkt = NULL;
 	sa_family_t family;
 	size_t tmp_len;
@@ -2067,6 +2127,17 @@ static int context_sendto(struct net_context *context,
 			return -EDESTADDRREQ;
 		}
 
+		if (IS_ENABLED(CONFIG_NET_UDP) &&
+		    net_context_get_type(context) == SOCK_DGRAM) {
+			if (net_ipv6_is_addr_mcast(&addr6->sin6_addr) &&
+			    COND_CODE_1(CONFIG_NET_IPV6,
+					(context->options.ipv6_mcast_ifindex > 0), (false))) {
+				IF_ENABLED(CONFIG_NET_IPV6,
+					   (iface = net_if_get_by_index(
+						   context->options.ipv6_mcast_ifindex)));
+			}
+		}
+
 		/* If application has not yet set the destination address
 		 * i.e., by not calling connect(), then set the interface
 		 * here so that the packet gets sent to the correct network
@@ -2074,11 +2145,13 @@ static int context_sendto(struct net_context *context,
 		 * network interfaces and we are trying to send data to
 		 * second or later network interface.
 		 */
-		if (net_ipv6_is_addr_unspecified(
-				&net_sin6(&context->remote)->sin6_addr) &&
-		    !net_context_is_bound_to_iface(context)) {
-			iface = net_if_ipv6_select_src_iface(&addr6->sin6_addr);
-			net_context_set_iface(context, iface);
+		if (iface == NULL) {
+			if (net_ipv6_is_addr_unspecified(
+				    &net_sin6(&context->remote)->sin6_addr) &&
+			    !net_context_is_bound_to_iface(context)) {
+				iface = net_if_ipv6_select_src_iface(&addr6->sin6_addr);
+				net_context_set_iface(context, iface);
+			}
 		}
 
 	} else if (IS_ENABLED(CONFIG_NET_IPV4) && family == AF_INET) {
@@ -3211,6 +3284,58 @@ static int set_context_timestamping(struct net_context *context,
 #endif
 }
 
+static int set_context_mcast_ifindex(struct net_context *context,
+				     const void *value, size_t len)
+{
+#if defined(CONFIG_NET_IPV6)
+	int mcast_ifindex = *((int *)value);
+	enum net_sock_type type;
+	struct net_if *iface;
+
+	if (net_context_get_family(context) != AF_INET6) {
+		return -EAFNOSUPPORT;
+	}
+
+	if (len != sizeof(int)) {
+		return -EINVAL;
+	}
+
+	type = net_context_get_type(context);
+	if (type != SOCK_DGRAM && type != SOCK_RAW) {
+		return -EINVAL;
+	}
+
+	/* optlen equal to 0 then remove the binding */
+	if (mcast_ifindex == 0) {
+		context->options.ipv6_mcast_ifindex = 0;
+		return 0;
+	}
+
+	if (mcast_ifindex < 1 || mcast_ifindex > 255) {
+		return -EINVAL;
+	}
+
+	iface = net_if_get_by_index(mcast_ifindex);
+	if (iface == NULL) {
+		return -ENOENT;
+	}
+
+	if (!net_if_flag_is_set(iface, NET_IF_IPV6)) {
+		return -EPROTOTYPE;
+	}
+
+	context->options.ipv6_mcast_ifindex = mcast_ifindex;
+
+	return 0;
+#else
+	ARG_UNUSED(context);
+	ARG_UNUSED(value);
+	ARG_UNUSED(len);
+
+	return -ENOTSUP;
+#endif
+}
+
 int net_context_set_option(struct net_context *context,
 			   enum net_context_option option,
 			   const void *value, size_t len)
@@ -3291,6 +3416,9 @@ int net_context_set_option(struct net_context *context,
 		}
 
 		break;
+	case NET_OPT_MCAST_IFINDEX:
+		ret = set_context_mcast_ifindex(context, value, len);
+		break;
 	}
 
 	k_mutex_unlock(&context->lock);
@@ -3369,6 +3497,9 @@ int net_context_get_option(struct net_context *context,
 		break;
 	case NET_OPT_MTU:
 		ret = get_context_mtu(context, value, len);
+		break;
+	case NET_OPT_MCAST_IFINDEX:
+		ret = get_context_mcast_ifindex(context, value, len);
 		break;
 	}
 

--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -1324,7 +1324,13 @@ int net_context_connect(struct net_context *context,
 			goto unlock;
 		}
 
-		/* FIXME - Add multicast and broadcast address check */
+		if (net_context_get_proto(context) == IPPROTO_TCP &&
+		    (net_ipv4_is_addr_mcast(&addr4->sin_addr) ||
+		     net_ipv4_is_addr_bcast(net_context_get_iface(context),
+					    &addr4->sin_addr))) {
+			ret = -EADDRNOTAVAIL;
+			goto unlock;
+		}
 
 		memcpy(&addr4->sin_addr, &net_sin(addr)->sin_addr,
 		       sizeof(struct in_addr));

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -3728,6 +3728,40 @@ out:
 	return src;
 }
 
+/* Internal function to get the first IPv4 address of the interface */
+struct net_if_addr *net_if_ipv4_addr_get_first_by_index(int ifindex)
+{
+	struct net_if *iface = net_if_get_by_index(ifindex);
+	struct net_if_addr *ifaddr = NULL;
+	struct net_if_ipv4 *ipv4;
+
+	if (!iface) {
+		return NULL;
+	}
+
+	net_if_lock(iface);
+
+	ipv4 = iface->config.ip.ipv4;
+	if (!ipv4) {
+		goto out;
+	}
+
+	ARRAY_FOR_EACH(ipv4->unicast, i) {
+		if (!ipv4->unicast[i].ipv4.is_used ||
+		    ipv4->unicast[i].ipv4.address.family != AF_INET) {
+			continue;
+		}
+
+		ifaddr = &ipv4->unicast[i].ipv4;
+		break;
+	}
+
+out:
+	net_if_unlock(iface);
+
+	return ifaddr;
+}
+
 struct net_if_addr *net_if_ipv4_addr_lookup(const struct in_addr *addr,
 					    struct net_if **ret)
 {

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -3538,22 +3538,17 @@ out:
 struct net_if *net_if_ipv4_select_src_iface(const struct in_addr *dst)
 {
 	struct net_if *selected = NULL;
+	const struct in_addr *src;
 
-	STRUCT_SECTION_FOREACH(net_if, iface) {
-		bool ret;
-
-		ret = net_if_ipv4_addr_mask_cmp(iface, dst);
-		if (ret) {
-			selected = iface;
-			goto out;
-		}
+	src = net_if_ipv4_select_src_addr(NULL, dst);
+	if (src != net_ipv4_unspecified_address()) {
+		net_if_ipv4_addr_lookup(src, &selected);
 	}
 
 	if (selected == NULL) {
 		selected = net_if_get_default();
 	}
 
-out:
 	return selected;
 }
 

--- a/subsys/net/ip/net_private.h
+++ b/subsys/net/ip/net_private.h
@@ -142,6 +142,10 @@ extern void mdns_init_responder(void);
 static inline void mdns_init_responder(void) { }
 #endif /* CONFIG_MDNS_RESPONDER */
 
+#if defined(CONFIG_NET_TEST)
+extern void loopback_enable_address_swap(bool swap_addresses);
+#endif /* CONFIG_NET_TEST */
+
 #if defined(CONFIG_NET_NATIVE)
 enum net_verdict net_ipv4_input(struct net_pkt *pkt, bool is_loopback);
 enum net_verdict net_ipv6_input(struct net_pkt *pkt, bool is_loopback);

--- a/subsys/net/ip/net_private.h
+++ b/subsys/net/ip/net_private.h
@@ -62,6 +62,8 @@ extern void net_if_stats_reset_all(void);
 extern void net_process_rx_packet(struct net_pkt *pkt);
 extern void net_process_tx_packet(struct net_pkt *pkt);
 
+extern struct net_if_addr *net_if_ipv4_addr_get_first_by_index(int ifindex);
+
 extern int net_icmp_call_ipv4_handlers(struct net_pkt *pkt,
 				       struct net_ipv4_hdr *ipv4_hdr,
 				       struct net_icmp_hdr *icmp_hdr);

--- a/subsys/net/lib/sockets/sockets_inet.c
+++ b/subsys/net/lib/sockets/sockets_inet.c
@@ -1931,6 +1931,17 @@ int zsock_getsockopt_ctx(struct net_context *ctx, int level, int optname,
 
 			return 0;
 
+		case IPV6_MULTICAST_IF:
+			ret = net_context_get_option(ctx,
+						     NET_OPT_MCAST_IFINDEX,
+						     optval, optlen);
+			if (ret < 0) {
+				errno  = -ret;
+				return -1;
+			}
+
+			return 0;
+
 		case IPV6_MULTICAST_HOPS:
 			ret = net_context_get_option(ctx,
 						     NET_OPT_MCAST_HOP_LIMIT,
@@ -2516,6 +2527,17 @@ int zsock_setsockopt_ctx(struct net_context *ctx, int level, int optname,
 		case IPV6_UNICAST_HOPS:
 			ret = net_context_set_option(ctx,
 						     NET_OPT_UNICAST_HOP_LIMIT,
+						     optval, optlen);
+			if (ret < 0) {
+				errno  = -ret;
+				return -1;
+			}
+
+			return 0;
+
+		case IPV6_MULTICAST_IF:
+			ret = net_context_set_option(ctx,
+						     NET_OPT_MCAST_IFINDEX,
 						     optval, optlen);
 			if (ret < 0) {
 				errno  = -ret;


### PR DESCRIPTION
Allow user to set the network interface for IPv6 and IPv4 multicast sockets.
