### PR TITLE
doc: release-notes-4.0: reset notes (none)

### DIFF
--- a/doc/releases/release-notes-4.0.rst
+++ b/doc/releases/release-notes-4.0.rst
@@ -497,8 +497,6 @@ Drivers and Sensors
   * Upgraded CP9314 driver to B1 silicon revision
   * Added basic driver for MPS MPM54304
 
-* Reset
-
 * RTC
 
   * STM32: HSE can now be used as domain clock.


### PR DESCRIPTION
There were no reset driver changes in this cycle, so delete the section in the release notes.