### PR TITLE
dts: arm: st: Fix memory mapping and size for STM32L47x/8x/9x/ax

### DIFF
--- a/boards/st/b_l4s5i_iot01a/b_l4s5i_iot01a.yaml
+++ b/boards/st/b_l4s5i_iot01a/b_l4s5i_iot01a.yaml
@@ -6,7 +6,7 @@ toolchain:
   - zephyr
   - gnuarmemb
   - xtools
-ram: 640
+ram: 192
 flash: 2048
 supported:
   - arduino_gpio

--- a/boards/st/nucleo_l496zg/nucleo_l496zg.yaml
+++ b/boards/st/nucleo_l496zg/nucleo_l496zg.yaml
@@ -5,7 +5,7 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
-ram: 320
+ram: 256
 flash: 1024
 supported:
   - arduino_i2c

--- a/boards/st/nucleo_l4a6zg/nucleo_l4a6zg.yaml
+++ b/boards/st/nucleo_l4a6zg/nucleo_l4a6zg.yaml
@@ -5,7 +5,7 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
-ram: 320
+ram: 256
 flash: 1024
 supported:
   - arduino_i2c

--- a/boards/st/nucleo_l4r5zi/nucleo_l4r5zi.yaml
+++ b/boards/st/nucleo_l4r5zi/nucleo_l4r5zi.yaml
@@ -19,6 +19,6 @@ supported:
   - counter
   - adc
   - rtc
-ram: 640
+ram: 192
 flash: 2048
 vendor: st

--- a/boards/st/stm32l496g_disco/stm32l496g_disco.yaml
+++ b/boards/st/stm32l496g_disco/stm32l496g_disco.yaml
@@ -6,7 +6,7 @@ toolchain:
   - zephyr
   - gnuarmemb
   - xtools
-ram: 320
+ram: 256
 flash: 1024
 supported:
   - arduino_i2c

--- a/boards/st/stm32l4r9i_disco/stm32l4r9i_disco.yaml
+++ b/boards/st/stm32l4r9i_disco/stm32l4r9i_disco.yaml
@@ -6,7 +6,7 @@ toolchain:
   - zephyr
   - gnuarmemb
   - xtools
-ram: 640
+ram: 192
 flash: 2048
 vendor: st
 supported:

--- a/dts/arm/st/l4/stm32l471Xg.dtsi
+++ b/dts/arm/st/l4/stm32l471Xg.dtsi
@@ -14,6 +14,7 @@
 	sram1: memory@10000000 {
 		reg = <0x10000000 DT_SIZE_K(32)>;
 	};
+
 	soc {
 		flash-controller@40022000 {
 			flash0: flash@8000000 {

--- a/dts/arm/st/l4/stm32l475Xg.dtsi
+++ b/dts/arm/st/l4/stm32l475Xg.dtsi
@@ -10,6 +10,9 @@
 	sram0: memory@20000000 {
 		reg = <0x20000000 DT_SIZE_K(96)>;
 	};
+	sram1: memory@10000000 {
+		reg = <0x10000000 DT_SIZE_K(32)>;
+	};
 
 	soc {
 		flash-controller@40022000 {

--- a/dts/arm/st/l4/stm32l476Xg.dtsi
+++ b/dts/arm/st/l4/stm32l476Xg.dtsi
@@ -10,6 +10,9 @@
 	sram0: memory@20000000 {
 		reg = <0x20000000 DT_SIZE_K(96)>;
 	};
+	sram1: memory@10000000 {
+		reg = <0x10000000 DT_SIZE_K(32)>;
+	};
 
 	soc {
 		flash-controller@40022000 {

--- a/dts/arm/st/l4/stm32l486Xg.dtsi
+++ b/dts/arm/st/l4/stm32l486Xg.dtsi
@@ -9,7 +9,10 @@
 
 / {
 	sram0: memory@20000000 {
-		reg = <0x20000000 DT_SIZE_K(128)>;
+		reg = <0x20000000 DT_SIZE_K(96)>;
+	};
+	sram1: memory@10000000 {
+		reg = <0x10000000 DT_SIZE_K(32)>;
 	};
 
 	soc {

--- a/dts/arm/st/l4/stm32l496Xe.dtsi
+++ b/dts/arm/st/l4/stm32l496Xe.dtsi
@@ -10,6 +10,9 @@
 	sram0: memory@20000000 {
 		reg = <0x20000000 DT_SIZE_K(256)>;
 	};
+	sram1: memory@10000000 {
+		reg = <0x10000000 DT_SIZE_K(64)>;
+	};
 
 	soc {
 		flash-controller@40022000 {

--- a/dts/arm/st/l4/stm32l496Xg.dtsi
+++ b/dts/arm/st/l4/stm32l496Xg.dtsi
@@ -8,7 +8,10 @@
 
 / {
 	sram0: memory@20000000 {
-		reg = <0x20000000 DT_SIZE_K(320)>;
+		reg = <0x20000000 DT_SIZE_K(256)>;
+	};
+	sram1: memory@10000000 {
+		reg = <0x10000000 DT_SIZE_K(64)>;
 	};
 
 	soc {

--- a/dts/arm/st/l4/stm32l4a6Xg.dtsi
+++ b/dts/arm/st/l4/stm32l4a6Xg.dtsi
@@ -9,7 +9,10 @@
 
 / {
 	sram0: memory@20000000 {
-		reg = <0x20000000 DT_SIZE_K(320)>;
+		reg = <0x20000000 DT_SIZE_K(256)>;
+	};
+	sram1: memory@10000000 {
+		reg = <0x10000000 DT_SIZE_K(64)>;
 	};
 
 	soc {

--- a/dts/arm/st/l4/stm32l4p5.dtsi
+++ b/dts/arm/st/l4/stm32l4p5.dtsi
@@ -11,8 +11,15 @@
 /delete-node/ &quadspi;
 
 / {
+	/* total SRAM 320KB for the stm32L4P5x and stm32L4Q5x */
 	sram0: memory@20000000 {
-		reg = <0x20000000 DT_SIZE_K(320)>;
+		reg = <0x20000000 DT_SIZE_K(128)>;
+	};
+	sram1: memory@10000000 {
+		reg = <0x10000000 DT_SIZE_K(64)>;
+	};
+	sram2: memory@20030000 {
+		reg = <0x20030000 DT_SIZE_K(128)>;
 	};
 
 	clocks {

--- a/dts/arm/st/l4/stm32l4r5.dtsi
+++ b/dts/arm/st/l4/stm32l4r5.dtsi
@@ -8,10 +8,18 @@
 #include <st/l4/stm32l4p5.dtsi>
 
 /delete-node/ &sdmmc2;
+/delete-node/ &sram2; /* different memory address */
 
 / {
+	/* total SRAM 640KB for the stm32L4R5x and stm32L4S5x */
 	sram0: memory@20000000 {
-		reg = <0x20000000 DT_SIZE_K(640)>;
+		reg = <0x20000000 DT_SIZE_K(192)>;
+	};
+	sram1: memory@10000000 {
+		reg = <0x10000000 DT_SIZE_K(64)>;
+	};
+	sram2: memory@20040000 {
+		reg = <0x20040000 DT_SIZE_K(384)>;
 	};
 
 	soc {


### PR DESCRIPTION
Split and fix the total SRAM size for STM32L47x/L48x/L49x/L4Ax devices.
Those MCUs with up to 320 Kbytes SRAM:
• 96 Kbytes SRAM1 and 32 Kbyte SRAM2 on STM32L47x/L48x.
• 256 Kbyte SRAM1 and 64 Kbyte SRAM2 on STM32L49x/L4Ax devices
The sram0 node at address 0x20000000 and sram1 at address 0x10000000

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/79607

This PR extends what was done by  https://github.com/zephyrproject-rtos/zephyr/pull/71456/