### PR TITLE
scripts: logging: dictionary: Add support for size_t %z format specifier

### DIFF
--- a/scripts/logging/dictionary/dictionary_parser/log_parser.py
+++ b/scripts/logging/dictionary/dictionary_parser/log_parser.py
@@ -46,6 +46,9 @@ def formalize_fmt_string(fmt_str):
     # No %p for pointer either, so use %x
     new_str = new_str.replace("%p", "0x%x")
 
+    # No %z support, use %d instead
+    new_str = new_str.replace("%z", "%d")
+
     return new_str
 
 


### PR DESCRIPTION
This patch adds support for the size_t %z format specifier to the dictionary parser.
It's the correct format to use for size_t types in modern C, but it's not supported in python directly.