### PR TITLE
doc: releases: 4.0: Add LVGL capture sample to Video

### DIFF
--- a/doc/releases/release-notes-4.0.rst
+++ b/doc/releases/release-notes-4.0.rst
@@ -677,6 +677,8 @@ Drivers and Sensors
     :kconfig:option:`CONFIG_VIDEO_BUFFER_USE_SHARED_MULTI_HEAP`
   * Introduced bindings for common video link properties in ``video-interfaces.yaml``
   * Introduced missing :kconfig:option:`CONFIG_VIDEO_LOG_LEVEL`
+  * Added a sample for capturing video and displaying it with LVGL
+    (:zephyr:code-sample:`video-capture-to-lvgl`)
   * Added support for GalaxyCore GC2145 image sensor (:dtcompatible:`gc,gc2145`)
   * Added support for ESP32-S3 LCD-CAM interface (:dtcompatible:`espressif,esp32-lcd-cam`)
   * Added support for NXP MCUX SMARTDMA interface (:dtcompatible:`nxp,smartdma`)


### PR DESCRIPTION
The LVGL pull request was started before v3.7 release but merged after, so needs to be included in v4.0 release notes.
This was an omission in commit 467f31190e6e111edf7ee204ecd3de27c3ff9c9a.