### PR TITLE
boards: st: Update nucleo_wba55cg dts file

### DIFF
--- a/boards/st/nucleo_wba55cg/nucleo_wba55cg.dts
+++ b/boards/st/nucleo_wba55cg/nucleo_wba55cg.dts
@@ -6,8 +6,7 @@
 
 /dts-v1/;
 #include <st/wba/stm32wba55Xg.dtsi>
-/* Todo: Once available, use wba55 dedicated pinctrl.dtsi */
-#include <st/wba/stm32wba52cgux-pinctrl.dtsi>
+#include <st/wba/stm32wba55cgux-pinctrl.dtsi>
 #include "arduino_r3_connector.dtsi"
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 


### PR DESCRIPTION
Update nucleo_wba55cg dts file to use pinctrl dtsi file of WBA55 instead of WBA52.