### PR TITLE
drivers: mipi-dbi: use string for mipi-mode property

### DIFF
--- a/boards/adi/max32662evkit/max32662evkit.dts
+++ b/boards/adi/max32662evkit/max32662evkit.dts
@@ -61,7 +61,7 @@
 		st7735: st7735@0 {
 			compatible = "sitronix,st7735r";
 			mipi-max-frequency = <DT_FREQ_M(6)>;
-			mipi-mode = <MIPI_DBI_MODE_SPI_3WIRE>;
+			mipi-mode = "MIPI_DBI_MODE_SPI_3WIRE";
 
 			reg = <0>;
 			width = <130>;

--- a/boards/adi/max32672evkit/max32672evkit.dts
+++ b/boards/adi/max32672evkit/max32672evkit.dts
@@ -66,7 +66,7 @@
 		st7735: st7735@0 {
 			compatible = "sitronix,st7735r";
 			mipi-max-frequency = <DT_FREQ_M(6)>;
-			mipi-mode = <MIPI_DBI_MODE_SPI_3WIRE>;
+			mipi-mode = "MIPI_DBI_MODE_SPI_3WIRE";
 
 			reg = <0>;
 			width = <130>;

--- a/boards/adi/max32680evkit/max32680evkit_max32680_m4.dts
+++ b/boards/adi/max32680evkit/max32680evkit_max32680_m4.dts
@@ -72,7 +72,7 @@
 		st7735: st7735@0 {
 			compatible = "sitronix,st7735r";
 			mipi-max-frequency = <DT_FREQ_M(6)>;
-			mipi-mode = <MIPI_DBI_MODE_SPI_3WIRE>;
+			mipi-mode = "MIPI_DBI_MODE_SPI_3WIRE";
 
 			reg = <0>;
 			width = <130>;

--- a/boards/adi/max32690evkit/max32690evkit_max32690_m4.dts
+++ b/boards/adi/max32690evkit/max32690evkit_max32690_m4.dts
@@ -63,7 +63,7 @@
 		st7735: st7735@0 {
 			compatible = "sitronix,st7735r";
 			mipi-max-frequency = <DT_FREQ_M(6)>;
-			mipi-mode = <MIPI_DBI_MODE_SPI_3WIRE>;
+			mipi-mode = "MIPI_DBI_MODE_SPI_3WIRE";
 
 			reg = <0>;
 			width = <130>;

--- a/boards/espressif/esp32s3_eye/esp32s3_eye_procpu.dts
+++ b/boards/espressif/esp32s3_eye/esp32s3_eye_procpu.dts
@@ -109,7 +109,7 @@
 			nvgam-param = [D0 04 0C 11 13 2C 3F 44 51 2F 1F 1F 20 23];
 			ram-param = [00 F0];
 			rgb-param = [CD 08 14];
-			mipi-mode = <MIPI_DBI_MODE_SPI_4WIRE>;
+			mipi-mode = "MIPI_DBI_MODE_SPI_4WIRE";
 		};
 	};
 };

--- a/boards/m5stack/m5stack_atoms3/m5stack_atoms3_procpu.dts
+++ b/boards/m5stack/m5stack_atoms3/m5stack_atoms3_procpu.dts
@@ -85,7 +85,7 @@
 			nvgam-param = [d0 00 02 07 0a 28 31 54 47 0e 1c 17 1b 1e];
 			ram-param = [00 E0];
 			rgb-param = [40 02 14];
-			mipi-mode = <MIPI_DBI_MODE_SPI_4WIRE>;
+			mipi-mode = "MIPI_DBI_MODE_SPI_4WIRE";
 		};
 
 	};

--- a/boards/m5stack/m5stickc_plus/m5stickc_plus_procpu.dts
+++ b/boards/m5stack/m5stickc_plus/m5stickc_plus_procpu.dts
@@ -96,7 +96,7 @@
 			nvgam-param = [d0 00 02 07 0a 28 31 54 47 0e 1c 17 1b 1e];
 			ram-param = [00 F0];
 			rgb-param = [40 02 14];
-			mipi-mode = <MIPI_DBI_MODE_SPI_4WIRE>;
+			mipi-mode = "MIPI_DBI_MODE_SPI_4WIRE";
 		};
 	};
 };

--- a/boards/pine64/pinetime_devkit0/pinetime_devkit0.dts
+++ b/boards/pine64/pinetime_devkit0/pinetime_devkit0.dts
@@ -112,7 +112,7 @@
 			nvgam-param = [D0 04 0C 11 13 2C 3F 44 51 2F 1F 1F 20 23];
 			ram-param = [00 F0];
 			rgb-param = [CD 08 14];
-			mipi-mode = <MIPI_DBI_MODE_SPI_4WIRE>;
+			mipi-mode = "MIPI_DBI_MODE_SPI_4WIRE";
 		};
 	};
 };

--- a/boards/shields/lcd_par_s035/boards/rd_rw612_bga.overlay
+++ b/boards/shields/lcd_par_s035/boards/rd_rw612_bga.overlay
@@ -64,7 +64,7 @@
 };
 
 &st7796s {
-	mipi-mode = <MIPI_DBI_MODE_8080_BUS_8_BIT>;
+	mipi-mode = "MIPI_DBI_MODE_8080_BUS_8_BIT";
 	/*
 	 * Display supports minimum write cycle time of 66ns. This
 	 * means we can clock the LCDIC module at 30MHz, as

--- a/boards/shields/lcd_par_s035/lcd_par_s035_8080.overlay
+++ b/boards/shields/lcd_par_s035/lcd_par_s035_8080.overlay
@@ -39,7 +39,7 @@
 		reg = <0>;
 		/* Baud rate on each pin is 1MHz */
 		mipi-max-frequency = <10000000>;
-		mipi-mode = <MIPI_DBI_MODE_8080_BUS_16_BIT>;
+		mipi-mode = "MIPI_DBI_MODE_8080_BUS_16_BIT";
 		height = <320>;
 		width = <480>;
 		invert-mode = "1-dot";

--- a/boards/shields/st7735r/st7735r_ada_160x128.overlay
+++ b/boards/shields/st7735r/st7735r_ada_160x128.overlay
@@ -22,7 +22,7 @@
 		st7735r_st7735r_ada_160x128: st7735r@0 {
 			compatible = "sitronix,st7735r";
 			mipi-max-frequency = <20000000>;
-			mipi-mode = <MIPI_DBI_MODE_SPI_4WIRE>;
+			mipi-mode = "MIPI_DBI_MODE_SPI_4WIRE";
 			reg = <0>;
 			width = <160>;
 			height = <128>;

--- a/boards/shields/st7789v_generic/st7789v_tl019fqv01.overlay
+++ b/boards/shields/st7789v_generic/st7789v_tl019fqv01.overlay
@@ -42,7 +42,7 @@
 			nvgam-param = [D0 00 02 07 05 15 2D 44 44 1C 18 16 1C 1D];
 			ram-param = [00 F8];
 			rgb-param = [CD 08 14];
-			mipi-mode = <MIPI_DBI_MODE_SPI_4WIRE>;
+			mipi-mode = "MIPI_DBI_MODE_SPI_4WIRE";
 		};
 	};
 };

--- a/boards/shields/st7789v_generic/st7789v_waveshare_240x240.overlay
+++ b/boards/shields/st7789v_generic/st7789v_waveshare_240x240.overlay
@@ -44,7 +44,7 @@
 			nvgam-param = [D0 04 0C 11 13 2C 3F 44 51 2F 1F 1F 20 23];
 			ram-param = [00 F0];
 			rgb-param = [CD 08 14];
-			mipi-mode = <MIPI_DBI_MODE_SPI_4WIRE>;
+			mipi-mode = "MIPI_DBI_MODE_SPI_4WIRE";
 		};
 	};
 };

--- a/boards/sipeed/longan_nano/longan_nano-common.dtsi
+++ b/boards/sipeed/longan_nano/longan_nano-common.dtsi
@@ -106,7 +106,7 @@
 			caset = [00 01 00 a0];
 			raset = [00 1a 00 69];
 
-			mipi-mode = <MIPI_DBI_MODE_SPI_4WIRE>;
+			mipi-mode = "MIPI_DBI_MODE_SPI_4WIRE";
 			mipi-max-frequency = <4000000>;
 		};
 	};

--- a/boards/st/stm32l562e_dk/stm32l562e_dk_common.dtsi
+++ b/boards/st/stm32l562e_dk/stm32l562e_dk_common.dtsi
@@ -87,7 +87,7 @@
 				st7789v: lcd-panel@0 {
 					compatible = "sitronix,st7789v";
 					reg = <0>;
-					mipi-mode = <MIPI_DBI_MODE_8080_BUS_16_BIT>;
+					mipi-mode = "MIPI_DBI_MODE_8080_BUS_16_BIT";
 					/* A write cycle should be 68ns */
 					mipi-max-frequency = <14705882>;
 					width = <240>;

--- a/boards/weact/mini_stm32h743/mini_stm32h743.dts
+++ b/boards/weact/mini_stm32h743/mini_stm32h743.dts
@@ -49,7 +49,7 @@
 		st7735r_160x80: st7735r@0 {
 			compatible = "sitronix,st7735r";
 			mipi-max-frequency = <20000000>;
-			mipi-mode = <MIPI_DBI_MODE_SPI_4WIRE>;
+			mipi-mode = "MIPI_DBI_MODE_SPI_4WIRE";
 			reg = <0>;
 			width = <160>;
 			height = <80>;

--- a/doc/releases/migration-guide-4.1.rst
+++ b/doc/releases/migration-guide-4.1.rst
@@ -55,6 +55,29 @@ Controller Area Network (CAN)
 Display
 =======
 
+* Displays using the MIPI DBI driver which set their MIPI DBI mode via the
+  ``mipi-mode`` property in devicetree should now use a string property of
+  the same name, like so:
+
+  .. code-block:: devicetree
+
+    /* Legacy display definition */
+
+    st7735r: st7735r@0 {
+        ...
+        mipi-mode = <MIPI_DBI_MODE_SPI_4WIRE>;
+        ...
+    };
+
+    /* New display definition */
+
+    st7735r: st7735r@0 {
+        ...
+        mipi-mode = "MIPI_DBI_MODE_SPI_4WIRE";
+        ...
+    };
+
+
 Enhanced Serial Peripheral Interface (eSPI)
 ===========================================
 

--- a/drivers/display/display_ili9xxx.c
+++ b/drivers/display/display_ili9xxx.c
@@ -521,7 +521,8 @@ static const struct ili9xxx_quirks ili9488_quirks = {
 		.quirks = &ili##t##_quirks,                                    \
 		.mipi_dev = DEVICE_DT_GET(DT_PARENT(INST_DT_ILI9XXX(n, t))),   \
 		.dbi_config = {                                                \
-			.mode = DT_PROP_OR(INST_DT_ILI9XXX(n, t),              \
+			.mode = DT_STRING_UPPER_TOKEN_OR(                      \
+				INST_DT_ILI9XXX(n, t),                         \
 				mipi_mode, MIPI_DBI_MODE_SPI_4WIRE),           \
 			.config = MIPI_DBI_SPI_CONFIG_DT(                      \
 						INST_DT_ILI9XXX(n, t),         \

--- a/drivers/display/display_st7735r.c
+++ b/drivers/display/display_st7735r.c
@@ -494,7 +494,7 @@ static const struct display_driver_api st7735r_api = {
 		.mipi_dev = DEVICE_DT_GET(DT_INST_PARENT(inst)),		\
 		.dbi_config = MIPI_DBI_CONFIG_DT_INST(inst,			\
 				SPI_OP_MODE_MASTER |				\
-				((DT_INST_PROP(inst, mipi_mode) ==		\
+				((DT_INST_STRING_UPPER_TOKEN(inst, mipi_mode) == \
 				 MIPI_DBI_MODE_SPI_4WIRE) ? SPI_WORD_SET(8) :	\
 				 SPI_WORD_SET(9)) |				\
 				SPI_HOLD_ON_CS | SPI_LOCK_ON, 0),		\

--- a/drivers/display/display_st7789v.c
+++ b/drivers/display/display_st7789v.c
@@ -370,7 +370,7 @@ static const struct display_driver_api st7789v_api = {
 };
 
 #define ST7789V_WORD_SIZE(inst)								\
-	((DT_INST_PROP(inst, mipi_mode) == MIPI_DBI_MODE_SPI_4WIRE) ?                   \
+	((DT_INST_STRING_UPPER_TOKEN(inst, mipi_mode) == MIPI_DBI_MODE_SPI_4WIRE) ?     \
 	SPI_WORD_SET(8) : SPI_WORD_SET(9))
 #define ST7789V_INIT(inst)								\
 	static const struct st7789v_config st7789v_config_ ## inst = {			\

--- a/drivers/display/display_st7796s.c
+++ b/drivers/display/display_st7796s.c
@@ -364,7 +364,7 @@ static const struct display_driver_api st7796s_api = {
 						SPI_OP_MODE_MASTER |		\
 						SPI_WORD_SET(8),		\
 						0),				\
-			.mode = DT_INST_PROP_OR(n, mipi_mode,			\
+			.mode = DT_INST_STRING_UPPER_TOKEN_OR(n, mipi_mode,     \
 						MIPI_DBI_MODE_SPI_4WIRE),	\
 		},								\
 		.width = DT_INST_PROP(n, width),				\

--- a/dts/bindings/mipi-dbi/mipi-dbi-device.yaml
+++ b/dts/bindings/mipi-dbi/mipi-dbi-device.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 NXP
+# Copyright 2023-2024 NXP
 # SPDX-License-Identifier: Apache-2.0
 #
 # Common fields for MIPI-DBI devices
@@ -13,24 +13,16 @@ properties:
     description: Maximum clock frequency of device's MIPI interface in Hz
 
   mipi-mode:
-    type: int
+    type: string
     description: |
-      MIPI DBI mode in use. Use the macros, not the actual enum value. Here is
-      the concordance list (see dt-bindings/mipi_dbi/mipi_dbi.h)
-        1     MIPI_DBI_MODE_SPI_3WIRE
-        2     MIPI_DBI_MODE_SPI_4WIRE
-        3     MIPI_DBI_MODE_6800_BUS_16_BIT
-        4     MIPI_DBI_MODE_6800_BUS_9_BIT
-        5     MIPI_DBI_MODE_6800_BUS_8_BIT
-        6     MIPI_DBI_MODE_8080_BUS_16_BIT
-        7     MIPI_DBI_MODE_8080_BUS_9_BIT
-        8     MIPI_DBI_MODE_8080_BUS_8_BIT
+      MIPI DBI mode in use. These definitions should match those in
+      dt-bindings/mipi_dbi/mipi_dbi.h
     enum:
-      - 1
-      - 2
-      - 3
-      - 4
-      - 5
-      - 6
-      - 7
-      - 8
+      - "MIPI_DBI_MODE_SPI_3WIRE"
+      - "MIPI_DBI_MODE_SPI_4WIRE"
+      - "MIPI_DBI_MODE_6800_BUS_16_BIT"
+      - "MIPI_DBI_MODE_6800_BUS_9_BIT"
+      - "MIPI_DBI_MODE_6800_BUS_8_BIT"
+      - "MIPI_DBI_MODE_8080_BUS_16_BIT"
+      - "MIPI_DBI_MODE_8080_BUS_9_BIT"
+      - "MIPI_DBI_MODE_8080_BUS_8_BIT"

--- a/include/zephyr/drivers/mipi_dbi.h
+++ b/include/zephyr/drivers/mipi_dbi.h
@@ -96,7 +96,7 @@ extern "C" {
  */
 #define MIPI_DBI_CONFIG_DT(node_id, operation_, delay_)			\
 	{								\
-		.mode = DT_PROP(node_id, mipi_mode),			\
+		.mode = DT_STRING_UPPER_TOKEN(node_id, mipi_mode),	\
 		.config = MIPI_DBI_SPI_CONFIG_DT(node_id, operation_, delay_), \
 	}
 

--- a/tests/drivers/build_all/display/app.overlay
+++ b/tests/drivers/build_all/display/app.overlay
@@ -60,7 +60,7 @@
 			test_mipi_dbi_st7735r: st7735t@2 {
 				compatible = "sitronix,st7735r";
 				mipi-max-frequency = <250000000>;
-				mipi-mode = <MIPI_DBI_MODE_SPI_4WIRE>;
+				mipi-mode = "MIPI_DBI_MODE_SPI_4WIRE";
 				reg = <2>;
 				/* Arbitrary values */
 				x-offset = <0>;
@@ -96,7 +96,7 @@
 				nvgam-param = [d0 00 02 07 0a 28 31 54 47 0e 1c 17 1b 1e];
 				ram-param = [00 E0];
 				rgb-param = [40 02 14];
-				mipi-mode = <MIPI_DBI_MODE_SPI_4WIRE>;
+				mipi-mode = "MIPI_DBI_MODE_SPI_4WIRE";
 			};
 
 			test_mipi_dbi_ssd1680: ssd1680@4 {


### PR DESCRIPTION
Use a string for the mipi-mode property over an integer value, as this
significantly improves the readability of the MIPI DBI device binding.

Open to feedback as to whether we feel this improvement is work breaking downstream user devicetrees. Personally I think it is ok given the transition note in the migration guide, but I'm not strongly committed to this change.
