### PR TITLE
docs: add 4.0 release notes for SD and disk

### DIFF
--- a/doc/releases/release-notes-4.0.rst
+++ b/doc/releases/release-notes-4.0.rst
@@ -1070,6 +1070,8 @@ Libraries / Subsystems
 
 * SD
 
+  * No significant changes in this release
+
 * Settings
 
   * Settings has been extended to allow prioritizing the commit handlers using

--- a/doc/releases/release-notes-4.0.rst
+++ b/doc/releases/release-notes-4.0.rst
@@ -584,6 +584,7 @@ Drivers and Sensors
 * SDHC
 
   * Added ESP32-S3 driver support.
+  * SPI SDHC driver now handles SPI devices with runtime PM support correctly
 
 * Sensors
 

--- a/doc/releases/release-notes-4.0.rst
+++ b/doc/releases/release-notes-4.0.rst
@@ -370,6 +370,8 @@ Drivers and Sensors
 
   * STM32F7 SDMMC driver now supports usage of DMA.
   * STM32 mem controller driver now supports FMC for STM32H5.
+  * SDMMC subsystem driver will now power down the SD card when the disk is
+    deinitialized
 
 * Display
 


### PR DESCRIPTION
Add release notes for the disk and SD subsystems. Note that the SD section has been removed for this release, as no significant changes were made to the subsystem since 3.7.