### PR TITLE
kernel: Improve cooperative and preemptive performance as per thread_metric benchmark

### DIFF
--- a/include/zephyr/kernel_structs.h
+++ b/include/zephyr/kernel_structs.h
@@ -122,6 +122,9 @@ struct _priq_rb {
 struct _priq_mq {
 	sys_dlist_t queues[K_NUM_THREAD_PRIO];
 	unsigned long bitmask[PRIQ_BITMAP_SIZE];
+#ifndef CONFIG_SMP
+	unsigned int cached_queue_index;
+#endif
 };
 
 struct _ready_q {

--- a/include/zephyr/sys/dlist.h
+++ b/include/zephyr/sys/dlist.h
@@ -495,6 +495,29 @@ static inline void sys_dlist_insert_at(sys_dlist_t *list, sys_dnode_t *node,
 /**
  * @brief remove a specific node from a list
  *
+ * Like :c:func:`sys_dlist_remove()`, this routine removes a specific node
+ * from a list. However, unlike :c:func:`sys_dlist_remove()`, this routine
+ * does not re-initialize the removed node. One significant implication of
+ * this difference is that the function :c:func`sys_dnode_is_linked()` will
+ * not work on a dequeued node.
+ *
+ * The list is implicit from the node. The node must be part of a list.
+ * This and other sys_dlist_*() functions are not thread safe.
+ *
+ * @param node the node to dequeue
+ */
+static inline void sys_dlist_dequeue(sys_dnode_t *node)
+{
+	sys_dnode_t *const prev = node->prev;
+	sys_dnode_t *const next = node->next;
+
+	prev->next = next;
+	next->prev = prev;
+}
+
+/**
+ * @brief remove a specific node from a list
+ *
  * The list is implicit from the node. The node must be part of a list.
  * This and other sys_dlist_*() functions are not thread safe.
  *

--- a/kernel/include/ksched.h
+++ b/kernel/include/ksched.h
@@ -119,8 +119,6 @@ static inline bool z_is_prio_lower_or_equal(int prio1, int prio2)
 	return z_is_prio1_lower_than_or_equal_to_prio2(prio1, prio2);
 }
 
-int32_t z_sched_prio_cmp(struct k_thread *thread_1, struct k_thread *thread_2);
-
 static inline bool _is_valid_prio(int prio, void *entry_point)
 {
 	if ((prio == K_IDLE_PRIO) && z_is_idle_thread_entry(entry_point)) {

--- a/kernel/include/kthread.h
+++ b/kernel/include/kthread.h
@@ -128,6 +128,16 @@ static inline bool z_is_thread_queued(struct k_thread *thread)
 	return z_is_thread_state_set(thread, _THREAD_QUEUED);
 }
 
+static inline void z_mark_thread_as_queued(struct k_thread *thread)
+{
+	thread->base.thread_state |= _THREAD_QUEUED;
+}
+
+static inline void z_mark_thread_as_not_queued(struct k_thread *thread)
+{
+	thread->base.thread_state &= ~_THREAD_QUEUED;
+}
+
 static inline void z_mark_thread_as_suspended(struct k_thread *thread)
 {
 	thread->base.thread_state |= _THREAD_SUSPENDED;

--- a/kernel/include/priority_q.h
+++ b/kernel/include/priority_q.h
@@ -10,9 +10,6 @@
 #include <zephyr/sys/math_extras.h>
 #include <zephyr/sys/dlist.h>
 
-extern int32_t z_sched_prio_cmp(struct k_thread *thread_1,
-	struct k_thread *thread_2);
-
 bool z_priq_rb_lessthan(struct rbnode *a, struct rbnode *b);
 
 /* Dumb Scheduling */
@@ -62,6 +59,47 @@ bool z_priq_rb_lessthan(struct rbnode *a, struct rbnode *b);
 static ALWAYS_INLINE void z_priq_dumb_init(sys_dlist_t *pq)
 {
 	sys_dlist_init(pq);
+}
+
+/*
+ * Return value same as e.g. memcmp
+ * > 0 -> thread 1 priority  > thread 2 priority
+ * = 0 -> thread 1 priority == thread 2 priority
+ * < 0 -> thread 1 priority  < thread 2 priority
+ * Do not rely on the actual value returned aside from the above.
+ * (Again, like memcmp.)
+ */
+static ALWAYS_INLINE int32_t z_sched_prio_cmp(struct k_thread *thread_1, struct k_thread *thread_2)
+{
+	/* `prio` is <32b, so the below cannot overflow. */
+	int32_t b1 = thread_1->base.prio;
+	int32_t b2 = thread_2->base.prio;
+
+	if (b1 != b2) {
+		return b2 - b1;
+	}
+
+#ifdef CONFIG_SCHED_DEADLINE
+	/* If we assume all deadlines live within the same "half" of
+	 * the 32 bit modulus space (this is a documented API rule),
+	 * then the latest deadline in the queue minus the earliest is
+	 * guaranteed to be (2's complement) non-negative.  We can
+	 * leverage that to compare the values without having to check
+	 * the current time.
+	 */
+	uint32_t d1 = thread_1->base.prio_deadline;
+	uint32_t d2 = thread_2->base.prio_deadline;
+
+	if (d1 != d2) {
+		/* Sooner deadline means higher effective priority.
+		 * Doing the calculation with unsigned types and casting
+		 * to signed isn't perfect, but at least reduces this
+		 * from UB on overflow to impdef.
+		 */
+		return (int32_t)(d2 - d1);
+	}
+#endif /* CONFIG_SCHED_DEADLINE */
+	return 0;
 }
 
 static ALWAYS_INLINE void z_priq_dumb_add(sys_dlist_t *pq, struct k_thread *thread)

--- a/kernel/include/priority_q.h
+++ b/kernel/include/priority_q.h
@@ -241,8 +241,8 @@ static ALWAYS_INLINE void z_priq_mq_remove(struct _priq_mq *pq,
 {
 	struct prio_info pos = get_prio_info(thread->base.prio);
 
-	sys_dlist_remove(&thread->base.qnode_dlist);
-	if (sys_dlist_is_empty(&pq->queues[pos.offset_prio])) {
+	sys_dlist_dequeue(&thread->base.qnode_dlist);
+	if (unlikely(sys_dlist_is_empty(&pq->queues[pos.offset_prio]))) {
 		pq->bitmask[pos.idx] &= ~BIT(pos.bit);
 	}
 }

--- a/kernel/include/priority_q.h
+++ b/kernel/include/priority_q.h
@@ -33,18 +33,10 @@ bool z_priq_rb_lessthan(struct rbnode *a, struct rbnode *b);
 #define _priq_run_best		z_priq_rb_best
  /* Multi Queue Scheduling */
 #elif defined(CONFIG_SCHED_MULTIQ)
-
-#if defined(CONFIG_64BIT)
-#define NBITS 64
-#else
-#define NBITS 32
-#endif /* CONFIG_64BIT */
 #define _priq_run_init		z_priq_mq_init
 #define _priq_run_add		z_priq_mq_add
 #define _priq_run_remove	z_priq_mq_remove
 #define _priq_run_best		z_priq_mq_best
-static ALWAYS_INLINE void z_priq_mq_add(struct _priq_mq *pq, struct k_thread *thread);
-static ALWAYS_INLINE void z_priq_mq_remove(struct _priq_mq *pq, struct k_thread *thread);
 #endif
 
 /* Scalable Wait Queue */
@@ -59,9 +51,31 @@ static ALWAYS_INLINE void z_priq_mq_remove(struct _priq_mq *pq, struct k_thread 
 #define _priq_wait_best		z_priq_dumb_best
 #endif
 
+#if defined(CONFIG_64BIT)
+#define NBITS          64
+#define TRAILING_ZEROS u64_count_trailing_zeros
+#else
+#define NBITS          32
+#define TRAILING_ZEROS u32_count_trailing_zeros
+#endif /* CONFIG_64BIT */
+
 static ALWAYS_INLINE void z_priq_dumb_init(sys_dlist_t *pq)
 {
 	sys_dlist_init(pq);
+}
+
+static ALWAYS_INLINE void z_priq_dumb_add(sys_dlist_t *pq, struct k_thread *thread)
+{
+	struct k_thread *t;
+
+	SYS_DLIST_FOR_EACH_CONTAINER(pq, t, base.qnode_dlist) {
+		if (z_sched_prio_cmp(thread, t) > 0) {
+			sys_dlist_insert(&t->base.qnode_dlist, &thread->base.qnode_dlist);
+			return;
+		}
+	}
+
+	sys_dlist_append(pq, &thread->base.qnode_dlist);
 }
 
 static ALWAYS_INLINE void z_priq_dumb_remove(sys_dlist_t *pq, struct k_thread *thread)
@@ -81,6 +95,23 @@ static ALWAYS_INLINE struct k_thread *z_priq_dumb_best(sys_dlist_t *pq)
 	}
 	return thread;
 }
+
+#ifdef CONFIG_SCHED_CPU_MASK
+static ALWAYS_INLINE struct k_thread *z_priq_dumb_mask_best(sys_dlist_t *pq)
+{
+	/* With masks enabled we need to be prepared to walk the list
+	 * looking for one we can run
+	 */
+	struct k_thread *thread;
+
+	SYS_DLIST_FOR_EACH_CONTAINER(pq, thread, base.qnode_dlist) {
+		if ((thread->base.cpu_mask & BIT(_current_cpu->id)) != 0) {
+			return thread;
+		}
+	}
+	return NULL;
+}
+#endif /* CONFIG_SCHED_CPU_MASK */
 
 static ALWAYS_INLINE void z_priq_rb_init(struct _priq_rb *pq)
 {
@@ -134,34 +165,6 @@ static ALWAYS_INLINE struct k_thread *z_priq_rb_best(struct _priq_rb *pq)
 	return thread;
 }
 
-static ALWAYS_INLINE struct k_thread *z_priq_mq_best(struct _priq_mq *pq)
-{
-	struct k_thread *thread = NULL;
-
-	for (int i = 0; i < PRIQ_BITMAP_SIZE; ++i) {
-		if (!pq->bitmask[i]) {
-			continue;
-		}
-
-#ifdef CONFIG_64BIT
-		sys_dlist_t *l = &pq->queues[i * 64 + u64_count_trailing_zeros(pq->bitmask[i])];
-#else
-		sys_dlist_t *l = &pq->queues[i * 32 + u32_count_trailing_zeros(pq->bitmask[i])];
-#endif
-		sys_dnode_t *n = sys_dlist_peek_head(l);
-
-		if (n != NULL) {
-			thread = CONTAINER_OF(n, struct k_thread, base.qnode_dlist);
-			break;
-		}
-	}
-
-	return thread;
-}
-
-
-#ifdef CONFIG_SCHED_MULTIQ
-
 struct prio_info {
 	uint8_t offset_prio;
 	uint8_t idx;
@@ -205,44 +208,26 @@ static ALWAYS_INLINE void z_priq_mq_remove(struct _priq_mq *pq,
 		pq->bitmask[pos.idx] &= ~BIT(pos.bit);
 	}
 }
-#endif /* CONFIG_SCHED_MULTIQ */
 
-
-
-#ifdef CONFIG_SCHED_CPU_MASK
-static ALWAYS_INLINE struct k_thread *z_priq_dumb_mask_best(sys_dlist_t *pq)
+static ALWAYS_INLINE struct k_thread *z_priq_mq_best(struct _priq_mq *pq)
 {
-	/* With masks enabled we need to be prepared to walk the list
-	 * looking for one we can run
-	 */
-	struct k_thread *thread;
+	struct k_thread *thread = NULL;
 
-	SYS_DLIST_FOR_EACH_CONTAINER(pq, thread, base.qnode_dlist) {
-		if ((thread->base.cpu_mask & BIT(_current_cpu->id)) != 0) {
-			return thread;
+	for (int i = 0; i < PRIQ_BITMAP_SIZE; ++i) {
+		if (!pq->bitmask[i]) {
+			continue;
 		}
-	}
-	return NULL;
-}
-#endif /* CONFIG_SCHED_CPU_MASK */
 
+		sys_dlist_t *l = &pq->queues[i * NBITS + TRAILING_ZEROS(pq->bitmask[i])];
+		sys_dnode_t *n = sys_dlist_peek_head(l);
 
-#if defined(CONFIG_SCHED_DUMB) || defined(CONFIG_WAITQ_DUMB)
-static ALWAYS_INLINE void z_priq_dumb_add(sys_dlist_t *pq,
-					  struct k_thread *thread)
-{
-	struct k_thread *t;
-
-	SYS_DLIST_FOR_EACH_CONTAINER(pq, t, base.qnode_dlist) {
-		if (z_sched_prio_cmp(thread, t) > 0) {
-			sys_dlist_insert(&t->base.qnode_dlist,
-					 &thread->base.qnode_dlist);
-			return;
+		if (n != NULL) {
+			thread = CONTAINER_OF(n, struct k_thread, base.qnode_dlist);
+			break;
 		}
 	}
 
-	sys_dlist_append(pq, &thread->base.qnode_dlist);
+	return thread;
 }
-#endif /* CONFIG_SCHED_DUMB || CONFIG_WAITQ_DUMB */
 
 #endif /* ZEPHYR_KERNEL_INCLUDE_PRIORITY_Q_H_ */

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -103,7 +103,7 @@ static inline bool should_queue_thread(struct k_thread *thread)
 
 static ALWAYS_INLINE void queue_thread(struct k_thread *thread)
 {
-	thread->base.thread_state |= _THREAD_QUEUED;
+	z_mark_thread_as_queued(thread);
 	if (should_queue_thread(thread)) {
 		runq_add(thread);
 	}
@@ -117,7 +117,7 @@ static ALWAYS_INLINE void queue_thread(struct k_thread *thread)
 
 static ALWAYS_INLINE void dequeue_thread(struct k_thread *thread)
 {
-	thread->base.thread_state &= ~_THREAD_QUEUED;
+	z_mark_thread_as_not_queued(thread);
 	if (should_queue_thread(thread)) {
 		runq_remove(thread);
 	}

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -158,8 +158,10 @@ static inline bool is_halting(struct k_thread *thread)
 /* Clear the halting bits (_THREAD_ABORTING and _THREAD_SUSPENDING) */
 static inline void clear_halting(struct k_thread *thread)
 {
-	barrier_dmem_fence_full(); /* Other cpus spin on this locklessly! */
-	thread->base.thread_state &= ~(_THREAD_ABORTING | _THREAD_SUSPENDING);
+	if (IS_ENABLED(CONFIG_SMP) && (CONFIG_MP_MAX_NUM_CPUS > 1)) {
+		barrier_dmem_fence_full(); /* Other cpus spin on this locklessly! */
+		thread->base.thread_state &= ~(_THREAD_ABORTING | _THREAD_SUSPENDING);
+	}
 }
 
 static ALWAYS_INLINE struct k_thread *next_up(void)

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -88,6 +88,11 @@ static ALWAYS_INLINE void runq_remove(struct k_thread *thread)
 	_priq_run_remove(thread_runq(thread), thread);
 }
 
+static ALWAYS_INLINE void runq_yield(void)
+{
+	_priq_run_yield(curr_cpu_runq());
+}
+
 static ALWAYS_INLINE struct k_thread *runq_best(void)
 {
 	return _priq_run_best(curr_cpu_runq());
@@ -1041,11 +1046,11 @@ void z_impl_k_yield(void)
 
 	k_spinlock_key_t key = k_spin_lock(&_sched_spinlock);
 
-	if (!IS_ENABLED(CONFIG_SMP) ||
-	    z_is_thread_queued(arch_current_thread())) {
-		dequeue_thread(arch_current_thread());
-	}
-	queue_thread(arch_current_thread());
+#ifdef CONFIG_SMP
+	z_mark_thread_as_queued(arch_current_thread());
+#endif
+	runq_yield();
+
 	update_cache(1);
 	z_swap(&_sched_spinlock, key);
 }

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -36,7 +36,7 @@ struct k_spinlock _sched_spinlock;
 __incoherent struct k_thread _thread_dummy;
 
 static ALWAYS_INLINE void update_cache(int preempt_ok);
-static void halt_thread(struct k_thread *thread, uint8_t new_state);
+static ALWAYS_INLINE void halt_thread(struct k_thread *thread, uint8_t new_state);
 static void add_to_waitq_locked(struct k_thread *thread, _wait_q_t *wait_q);
 
 
@@ -411,8 +411,8 @@ static void thread_halt_spin(struct k_thread *thread, k_spinlock_key_t key)
  * (aborting arch_current_thread() will not return, obviously), which may be after
  * a context switch.
  */
-static void z_thread_halt(struct k_thread *thread, k_spinlock_key_t key,
-			  bool terminate)
+static ALWAYS_INLINE void z_thread_halt(struct k_thread *thread, k_spinlock_key_t key,
+					bool terminate)
 {
 	_wait_q_t *wq = &thread->join_queue;
 #ifdef CONFIG_SMP
@@ -1243,7 +1243,7 @@ extern void thread_abort_hook(struct k_thread *thread);
  * @param thread Identify the thread to halt
  * @param new_state New thread state (_THREAD_DEAD or _THREAD_SUSPENDED)
  */
-static void halt_thread(struct k_thread *thread, uint8_t new_state)
+static ALWAYS_INLINE void halt_thread(struct k_thread *thread, uint8_t new_state)
 {
 	bool dummify = false;
 

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -481,7 +481,7 @@ void z_impl_k_thread_suspend(k_tid_t thread)
 
 	k_spinlock_key_t  key = k_spin_lock(&_sched_spinlock);
 
-	if ((thread->base.thread_state & _THREAD_SUSPENDED) != 0U) {
+	if (unlikely(z_is_thread_suspended(thread))) {
 
 		/* The target thread is already suspended. Nothing to do. */
 
@@ -510,7 +510,7 @@ void z_impl_k_thread_resume(k_tid_t thread)
 	k_spinlock_key_t key = k_spin_lock(&_sched_spinlock);
 
 	/* Do not try to resume a thread that was not suspended */
-	if (!z_is_thread_suspended(thread)) {
+	if (unlikely(!z_is_thread_suspended(thread))) {
 		k_spin_unlock(&_sched_spinlock, key);
 		return;
 	}


### PR DESCRIPTION
This set of commits offers improvements to both the cooperative and preemptive results in the the thread_metric benchmark.

The following numbers were obtained with the thread_metric benchmark project on the disco_l475_iot1 board. MQ denotes use of CONFIG_SCHED_MULTIQ and DQ denotes use of CONFIG_SCHED_DUMB.

Before:
Time Period Total:  12436655  (Cooperative, MQ)
Time Period Total:  11268922  (Cooperative, DQ)
Time Period Total:  5730607   (Preemptive, MQ)
Time Period Total:  6404080   (Preemptive, DQ)

After:
Time Period Total:  16001868  (Cooperative, MQ) : +28.7 %
Time Period Total:  11595554  (Cooperative, DQ) : +2.9 %
Time Period Total:  6473166   (Preemptive, MQ) : +12.9 %
Time Period Total:  7018286   (Preemptive, DQ) : +9.6%