### PR TITLE
tests: net: lib: lwm2m: interop: Fix strip-with-multi-characters (B005)

### DIFF
--- a/tests/net/lib/lwm2m/interop/pytest/leshan.py
+++ b/tests/net/lib/lwm2m/interop/pytest/leshan.py
@@ -455,7 +455,7 @@ class LeshanEventsIterator:
                     for line in self._it:
                         if not line.startswith('data: '):
                             continue
-                        data = json.loads(line.lstrip('data: '))
+                        data = json.loads(line.removeprefix('data: '))
                         if event == 'SEND' or (event == 'NOTIFICATION' and data['kind'] == 'composite'):
                             return Leshan.parse_composite(data['val'])
                         if event == 'NOTIFICATION':


### PR DESCRIPTION
All strip functions remove any of the provided characters instead of a prefix/suffix. This is likely a bug.

See https://docs.astral.sh/ruff/rules/strip-with-multi-characters/