### PR TITLE
Bluetooth: Mesh: Fix proxy advertising set sending Mesh messages

### DIFF
--- a/subsys/bluetooth/mesh/adv.c
+++ b/subsys/bluetooth/mesh/adv.c
@@ -233,6 +233,11 @@ struct bt_mesh_adv *bt_mesh_adv_get_by_tag(enum bt_mesh_adv_tag_bit tags, k_time
 		return k_fifo_get(&bt_mesh_relay_queue, timeout);
 	}
 
+	if (IS_ENABLED(CONFIG_BT_MESH_ADV_EXT_GATT_SEPARATE) &&
+	    tags & BT_MESH_ADV_TAG_BIT_PROXY) {
+		return NULL;
+	}
+
 	return bt_mesh_adv_get(timeout);
 }
 


### PR DESCRIPTION
When start to sending proxy advertising, will also process in send_pending_adv, but the bt_mesh_adv_get_by_tag will directly return buffer from bt_mesh_adv_queue or bt_mesh_relay_queue, which case mesh messages sent on different sets, can cause peer replay attack.