### PR TITLE
arch: replace `_current_cpu` with `arch_curr_cpu()`

### DIFF
--- a/arch/arc/core/thread.c
+++ b/arch/arc/core/thread.c
@@ -334,7 +334,7 @@ int arc_vpx_lock(k_timeout_t timeout)
 
 	key = k_spin_lock(&lock);
 
-	id = _current_cpu->id;
+	id = arch_curr_cpu()->id;
 #if (CONFIG_MP_MAX_NUM_CPUS > 1) && defined(CONFIG_SCHED_CPU_MASK)
 	__ASSERT(!arch_is_in_isr() && (_current->base.cpu_mask == BIT(id)), "");
 #endif
@@ -357,7 +357,7 @@ void arc_vpx_unlock(void)
 #if (CONFIG_MP_MAX_NUM_CPUS > 1) && defined(CONFIG_SCHED_CPU_MASK)
 	__ASSERT(!arch_is_in_isr() && (_current->base.cpu_mask == BIT(id)), "");
 #endif
-	id = _current_cpu->id;
+	id = arch_curr_cpu()->id;
 	k_spin_unlock(&lock, key);
 
 	/*

--- a/arch/arm/core/cortex_a_r/fault.c
+++ b/arch/arm/core/cortex_a_r/fault.c
@@ -153,7 +153,7 @@ bool z_arm_fault_undef_instruction_fp(void)
 
 	__set_FPEXC(FPEXC_EN);
 
-	if (_current_cpu->nested > 1) {
+	if (arch_curr_cpu()->nested > 1) {
 		/*
 		 * If the nested count is greater than 1, the undefined
 		 * instruction exception came from an irq/svc context.  (The
@@ -161,13 +161,13 @@ bool z_arm_fault_undef_instruction_fp(void)
 		 * the undef exception would increment it to 2).
 		 */
 		struct __fpu_sf *spill_esf =
-			(struct __fpu_sf *)_current_cpu->fp_ctx;
+			(struct __fpu_sf *)arch_curr_cpu()->fp_ctx;
 
 		if (spill_esf == NULL) {
 			return false;
 		}
 
-		_current_cpu->fp_ctx = NULL;
+		arch_curr_cpu()->fp_ctx = NULL;
 
 		/*
 		 * If the nested count is 2 and the current thread has used the
@@ -177,9 +177,9 @@ bool z_arm_fault_undef_instruction_fp(void)
 		 * saved exception stack frame, then save the floating point
 		 * context because it is about to be overwritten.
 		 */
-		if (((_current_cpu->nested == 2)
+		if (((arch_curr_cpu()->nested == 2)
 				&& (_current->base.user_options & K_FP_REGS))
-			|| ((_current_cpu->nested > 2)
+			|| ((arch_curr_cpu()->nested > 2)
 				&& (spill_esf->undefined & FPEXC_EN))) {
 			/*
 			 * Spill VFP registers to specified exception stack

--- a/arch/arm64/core/isr_wrapper.S
+++ b/arch/arm64/core/isr_wrapper.S
@@ -32,7 +32,7 @@ GDATA(_sw_isr_table)
 GTEXT(_isr_wrapper)
 SECTION_FUNC(TEXT, _isr_wrapper)
 
-	/* ++_current_cpu->nested to be checked by arch_is_in_isr() */
+	/* ++arch_curr_cpu()->nested to be checked by arch_is_in_isr() */
 	get_cpu	x0
 	ldr	w1, [x0, #___cpu_t_nested_OFFSET]
 	add	w2, w1, #1
@@ -113,7 +113,7 @@ spurious_continue:
 
 GTEXT(z_arm64_irq_done)
 z_arm64_irq_done:
-	/* if (--_current_cpu->nested != 0) exit */
+	/* if (--arch_curr_cpu()->nested != 0) exit */
 	get_cpu	x0
 	ldr	w1, [x0, #___cpu_t_nested_OFFSET]
 	subs	w1, w1, #1

--- a/arch/arm64/core/smp.c
+++ b/arch/arm64/core/smp.c
@@ -283,7 +283,7 @@ void arch_spin_relax(void)
 		 * We may not be in IRQ context here hence cannot use
 		 * arch_flush_local_fpu() directly.
 		 */
-		arch_float_disable(_current_cpu->arch.fpu_owner);
+		arch_float_disable(arch_curr_cpu()->arch.fpu_owner);
 	}
 }
 #endif

--- a/arch/arm64/core/switch.S
+++ b/arch/arm64/core/switch.S
@@ -179,7 +179,7 @@ offload:
 	 */
 	ldp	x1, x0, [sp, ___esf_t_x0_x1_OFFSET]
 
-	/* ++_current_cpu->nested to be checked by arch_is_in_isr() */
+	/* ++arch_curr_cpu()->nested to be checked by arch_is_in_isr() */
 	get_cpu	x2
 	ldr	w3, [x2, #___cpu_t_nested_OFFSET]
 	add	w4, w3, #1

--- a/arch/mips/core/irq_manage.c
+++ b/arch/mips/core/irq_manage.c
@@ -62,7 +62,7 @@ int arch_irq_is_enabled(unsigned int irq)
 
 void z_mips_enter_irq(uint32_t ipending)
 {
-	_current_cpu->nested++;
+	arch_curr_cpu()->nested++;
 
 #ifdef CONFIG_IRQ_OFFLOAD
 	z_irq_do_offload();
@@ -88,7 +88,7 @@ void z_mips_enter_irq(uint32_t ipending)
 		}
 	}
 
-	_current_cpu->nested--;
+	arch_curr_cpu()->nested--;
 
 	if (IS_ENABLED(CONFIG_STACK_SENTINEL)) {
 		z_check_stack_sentinel();

--- a/arch/mips/include/kernel_arch_func.h
+++ b/arch/mips/include/kernel_arch_func.h
@@ -39,7 +39,7 @@ FUNC_NORETURN void z_mips_fatal_error(unsigned int reason,
 
 static inline bool arch_is_in_isr(void)
 {
-	return _current_cpu->nested != 0U;
+	return arch_curr_cpu()->nested != 0U;
 }
 
 #ifdef CONFIG_IRQ_OFFLOAD

--- a/arch/riscv/core/isr.S
+++ b/arch/riscv/core/isr.S
@@ -137,7 +137,7 @@ SECTION_FUNC(exception.entry, _isr_wrapper)
 .balign CONFIG_RISCV_TRAP_HANDLER_ALIGNMENT
 
 #ifdef CONFIG_USERSPACE
-	/* retrieve address of _current_cpu preserving s0 */
+	/* retrieve address of arch_curr_cpu() preserving s0 */
 	csrrw s0, mscratch, s0
 
 	/* preserve t0 and t1 temporarily */
@@ -172,7 +172,7 @@ SECTION_FUNC(exception.entry, _isr_wrapper)
 	lr t0, _curr_cpu_arch_user_exc_tmp0(s0)
 	lr t1, _curr_cpu_arch_user_exc_tmp1(s0)
 
-	/* retrieve original s0 and restore _current_cpu in mscratch */
+	/* retrieve original s0 and restore arch_curr_cpu() in mscratch */
 	csrrw s0, mscratch, s0
 #endif
 
@@ -184,7 +184,7 @@ SECTION_FUNC(exception.entry, _isr_wrapper)
 	DO_CALLER_SAVED(sr)		;
 #endif /* CONFIG_RISCV_SOC_HAS_ISR_STACKING */
 
-	/* Save s0 in the esf and load it with &_current_cpu. */
+	/* Save s0 in the esf and load it with &arch_curr_cpu(). */
 	sr s0, __struct_arch_esf_s0_OFFSET(sp)
 	get_current_cpu s0
 
@@ -476,7 +476,7 @@ do_irq_offload:
 	lr a1, __struct_arch_esf_a0_OFFSET(sp)
 	lr a0, __struct_arch_esf_a1_OFFSET(sp)
 
-	/* Increment _current_cpu->nested */
+	/* Increment arch_curr_cpu()->nested */
 	lw t1, ___cpu_t_nested_OFFSET(s0)
 	addi t2, t1, 1
 	sw t2, ___cpu_t_nested_OFFSET(s0)
@@ -592,7 +592,7 @@ is_interrupt:
 2:
 #endif
 
-	/* Increment _current_cpu->nested */
+	/* Increment arch_curr_cpu()->nested */
 	lw t1, ___cpu_t_nested_OFFSET(s0)
 	addi t2, t1, 1
 	sw t2, ___cpu_t_nested_OFFSET(s0)
@@ -654,7 +654,7 @@ on_irq_stack:
 #endif
 
 irq_done:
-	/* Decrement _current_cpu->nested */
+	/* Decrement arch_curr_cpu()->nested */
 	lw t2, ___cpu_t_nested_OFFSET(s0)
 	addi t2, t2, -1
 	sw t2, ___cpu_t_nested_OFFSET(s0)
@@ -698,7 +698,7 @@ reschedule:
 
 z_riscv_thread_start:
 might_have_rescheduled:
-	/* reload s0 with &_current_cpu as it might have changed or be unset */
+	/* reload s0 with &arch_curr_cpu() as it might have changed or be unset */
 	get_current_cpu s0
 
 #endif /* CONFIG_MULTITHREADING */

--- a/arch/riscv/core/pmp.c
+++ b/arch/riscv/core/pmp.c
@@ -376,7 +376,7 @@ void z_riscv_pmp_init(void)
 	 * and lock it too.
 	 */
 	set_pmp_entry(&index, PMP_NONE | PMP_L,
-		      (uintptr_t)z_interrupt_stacks[_current_cpu->id],
+		      (uintptr_t)z_interrupt_stacks[arch_curr_cpu()->id],
 		      Z_RISCV_STACK_GUARD_SIZE,
 		      pmp_addr, pmp_cfg, ARRAY_SIZE(pmp_addr));
 

--- a/arch/sparc/core/irq_manage.c
+++ b/arch/sparc/core/irq_manage.c
@@ -28,7 +28,7 @@ void z_sparc_enter_irq(uint32_t irl)
 {
 	struct _isr_table_entry *ite;
 
-	_current_cpu->nested++;
+	arch_curr_cpu()->nested++;
 
 #ifdef CONFIG_IRQ_OFFLOAD
 	if (irl != 141U) {
@@ -45,7 +45,7 @@ void z_sparc_enter_irq(uint32_t irl)
 	ite->isr(ite->arg);
 #endif
 
-	_current_cpu->nested--;
+	arch_curr_cpu()->nested--;
 #ifdef CONFIG_STACK_SENTINEL
 	z_check_stack_sentinel();
 #endif

--- a/arch/sparc/include/kernel_arch_func.h
+++ b/arch/sparc/include/kernel_arch_func.h
@@ -47,7 +47,7 @@ FUNC_NORETURN void z_sparc_fatal_error(unsigned int reason,
 
 static inline bool arch_is_in_isr(void)
 {
-	return _current_cpu->nested != 0U;
+	return arch_curr_cpu()->nested != 0U;
 }
 
 #ifdef CONFIG_IRQ_OFFLOAD

--- a/arch/x86/core/intel64/irq_offload.c
+++ b/arch/x86/core/intel64/irq_offload.c
@@ -23,7 +23,7 @@ static const void *irq_offload_args[CONFIG_MP_MAX_NUM_CPUS];
 
 static void dispatcher(const void *arg)
 {
-	uint8_t cpu_id = _current_cpu->id;
+	uint8_t cpu_id = arch_curr_cpu()->id;
 
 	if (irq_offload_funcs[cpu_id] != NULL) {
 		irq_offload_funcs[cpu_id](irq_offload_args[cpu_id]);
@@ -33,7 +33,7 @@ static void dispatcher(const void *arg)
 void arch_irq_offload(irq_offload_routine_t routine, const void *parameter)
 {
 	int key = arch_irq_lock();
-	uint8_t cpu_id = _current_cpu->id;
+	uint8_t cpu_id = arch_curr_cpu()->id;
 
 	irq_offload_funcs[cpu_id] = routine;
 	irq_offload_args[cpu_id] = parameter;

--- a/arch/xtensa/core/irq_offload.c
+++ b/arch/xtensa/core/irq_offload.c
@@ -16,7 +16,7 @@ static struct {
 static void irq_offload_isr(const void *param)
 {
 	ARG_UNUSED(param);
-	uint8_t cpu_id = _current_cpu->id;
+	uint8_t cpu_id = arch_curr_cpu()->id;
 
 	offload_params[cpu_id].fn(offload_params[cpu_id].arg);
 }
@@ -26,7 +26,7 @@ void arch_irq_offload(irq_offload_routine_t routine, const void *parameter)
 	IRQ_CONNECT(ZSR_IRQ_OFFLOAD_INT, 0, irq_offload_isr, NULL, 0);
 
 	unsigned int intenable, key = arch_irq_lock();
-	uint8_t cpu_id = _current_cpu->id;
+	uint8_t cpu_id = arch_curr_cpu()->id;
 
 	offload_params[cpu_id].fn = routine;
 	offload_params[cpu_id].arg = parameter;

--- a/arch/xtensa/core/mpu.c
+++ b/arch/xtensa/core/mpu.c
@@ -846,7 +846,7 @@ int arch_mem_domain_partition_remove(struct k_mem_domain *domain,
 	 * Need to update hardware MPU regions if we are removing
 	 * partition from the domain of the current running thread.
 	 */
-	cur_thread = _current_cpu->current;
+	cur_thread = arch_curr_cpu()->current;
 	if (cur_thread->mem_domain_info.mem_domain == domain) {
 		xtensa_mpu_map_write(cur_thread);
 	}
@@ -882,7 +882,7 @@ int arch_mem_domain_partition_add(struct k_mem_domain *domain,
 	 * at boot so we need to avoid writing MPU regions to
 	 * hardware.
 	 */
-	cur_thread = _current_cpu->current;
+	cur_thread = arch_curr_cpu()->current;
 	if (((cur_thread->base.thread_state & _THREAD_DUMMY) != _THREAD_DUMMY) &&
 	    (cur_thread->mem_domain_info.mem_domain == domain)) {
 		xtensa_mpu_map_write(cur_thread);
@@ -956,7 +956,7 @@ int arch_mem_domain_thread_add(struct k_thread *thread)
 	 * Need to switch to new MPU map if this is the current
 	 * running thread.
 	 */
-	if (thread == _current_cpu->current) {
+	if (thread == arch_curr_cpu()->current) {
 		xtensa_mpu_map_write(thread);
 	}
 

--- a/arch/xtensa/core/ptables.c
+++ b/arch/xtensa/core/ptables.c
@@ -322,7 +322,7 @@ void xtensa_mmu_init(void)
 	 */
 	XTENSA_WSR(ZSR_DEPC_SAVE_STR, 0);
 
-	arch_xtensa_mmu_post_init(_current_cpu->id == 0);
+	arch_xtensa_mmu_post_init(arch_curr_cpu()->id == 0);
 }
 
 void xtensa_mmu_reinit(void)
@@ -331,7 +331,7 @@ void xtensa_mmu_reinit(void)
 	xtensa_init_paging(xtensa_kernel_ptables);
 
 #ifdef CONFIG_USERSPACE
-	struct k_thread *thread = _current_cpu->current;
+	struct k_thread *thread = arch_curr_cpu()->current;
 	struct arch_mem_domain *domain =
 			&(thread->mem_domain_info.mem_domain->arch);
 
@@ -340,7 +340,7 @@ void xtensa_mmu_reinit(void)
 	xtensa_set_paging(domain->asid, domain->ptables);
 #endif /* CONFIG_USERSPACE */
 
-	arch_xtensa_mmu_post_init(_current_cpu->id == 0);
+	arch_xtensa_mmu_post_init(arch_curr_cpu()->id == 0);
 }
 
 #ifdef CONFIG_ARCH_HAS_RESERVED_PAGE_FRAMES
@@ -678,7 +678,7 @@ void xtensa_mmu_tlb_shootdown(void)
 	}
 
 #ifdef CONFIG_USERSPACE
-	struct k_thread *thread = _current_cpu->current;
+	struct k_thread *thread = arch_curr_cpu()->current;
 
 	/* If current thread is a user thread, we need to see if it has
 	 * been migrated to another memory domain as the L1 page table
@@ -994,7 +994,7 @@ int arch_mem_domain_thread_add(struct k_thread *thread)
 	/* Need to switch to new page tables if this is
 	 * the current thread running.
 	 */
-	if (thread == _current_cpu->current) {
+	if (thread == arch_curr_cpu()->current) {
 		xtensa_set_paging(domain->arch.asid, thread->arch.ptables);
 	}
 
@@ -1005,7 +1005,7 @@ int arch_mem_domain_thread_add(struct k_thread *thread)
 	 * Note that there is no need to send TLB IPI if this is
 	 * migration as it was sent above during reset_region().
 	 */
-	if ((thread != _current_cpu->current) && !is_migration) {
+	if ((thread != arch_curr_cpu()->current) && !is_migration) {
 		xtensa_mmu_tlb_ipi();
 	}
 #endif

--- a/arch/xtensa/core/vector_handlers.c
+++ b/arch/xtensa/core/vector_handlers.c
@@ -272,7 +272,7 @@ static ALWAYS_INLINE void usage_stop(void)
 static inline void *return_to(void *interrupted)
 {
 #ifdef CONFIG_MULTITHREADING
-	return _current_cpu->nested <= 1 ?
+	return arch_curr_cpu()->nested <= 1 ?
 		z_get_next_switch_handle(interrupted) : interrupted;
 #else
 	return interrupted;
@@ -464,7 +464,7 @@ skip_checks:
 	if (is_dblexc || is_fatal_error) {
 		uint32_t ignore;
 
-		/* We are going to manipulate _current_cpu->nested manually.
+		/* We are going to manipulate arch_curr_cpu()->nested manually.
 		 * Since the error is fatal, for recoverable errors, code
 		 * execution must not return back to the current thread as
 		 * it is being terminated (via above xtensa_fatal_error()).
@@ -487,7 +487,7 @@ skip_checks:
 		__asm__ volatile("rsil %0, %1"
 				: "=r" (ignore) : "i"(XCHAL_EXCM_LEVEL));
 
-		_current_cpu->nested = 1;
+		arch_curr_cpu()->nested = 1;
 	}
 
 #if defined(CONFIG_XTENSA_MMU)

--- a/arch/xtensa/include/kernel_arch_func.h
+++ b/arch/xtensa/include/kernel_arch_func.h
@@ -40,7 +40,7 @@ static ALWAYS_INLINE void arch_cohere_stacks(struct k_thread *old_thread,
 					     void *old_switch_handle,
 					     struct k_thread *new_thread)
 {
-	int32_t curr_cpu = _current_cpu->id;
+	int32_t curr_cpu = arch_curr_cpu()->id;
 
 	size_t ostack = old_thread->stack_info.start;
 	size_t osz    = old_thread->stack_info.size;

--- a/drivers/timer/stm32_lptim_timer.c
+++ b/drivers/timer/stm32_lptim_timer.c
@@ -85,7 +85,7 @@ static struct k_spinlock lock;
 #ifdef CONFIG_STM32_LPTIM_STDBY_TIMER
 
 #define CURRENT_CPU \
-	(COND_CODE_1(CONFIG_SMP, (arch_curr_cpu()->id), (_current_cpu->id)))
+	(COND_CODE_1(CONFIG_SMP, (arch_curr_cpu()->id), (arch_curr_cpu()->id)))
 
 #define cycle_t uint32_t
 

--- a/include/zephyr/arch/arc/arch_inlines.h
+++ b/include/zephyr/arch/arc/arch_inlines.h
@@ -16,6 +16,10 @@
 
 static ALWAYS_INLINE _cpu_t *arch_curr_cpu(void)
 {
+#ifdef CONFIG_VALIDATE_ARCH_CURR_CPU
+	__ASSERT_NO_MSG(!z_smp_cpu_mobile());
+#endif /* CONFIG_VALIDATE_ARCH_CURR_CPU */
+
 #ifdef CONFIG_SMP
 	uint32_t core;
 

--- a/include/zephyr/arch/arm/arch_inlines.h
+++ b/include/zephyr/arch/arm/arch_inlines.h
@@ -14,7 +14,15 @@
 
 static ALWAYS_INLINE _cpu_t *arch_curr_cpu(void)
 {
+#ifdef CONFIG_VALIDATE_ARCH_CURR_CPU
+	__ASSERT_NO_MSG(!z_smp_cpu_mobile());
+#endif /* CONFIG_VALIDATE_ARCH_CURR_CPU */
+
+#ifdef CONFIG_SMP
 	return (_cpu_t *)(read_tpidruro() & TPIDRURO_CURR_CPU);
+#else
+	return &_kernel.cpus[0];
+#endif /* CONFIG_SMP */
 }
 #else
 

--- a/include/zephyr/arch/arm64/arch_inlines.h
+++ b/include/zephyr/arch/arm64/arch_inlines.h
@@ -17,7 +17,15 @@
 /* Note: keep in sync with `get_cpu` in arch/arm64/core/macro_priv.inc */
 static ALWAYS_INLINE _cpu_t *arch_curr_cpu(void)
 {
+#ifdef CONFIG_VALIDATE_ARCH_CURR_CPU
+	__ASSERT_NO_MSG(!z_smp_cpu_mobile());
+#endif /* CONFIG_VALIDATE_ARCH_CURR_CPU */
+
+#ifdef CONFIG_SMP
 	return (_cpu_t *)(read_tpidrro_el0() & TPIDRROEL0_CURR_CPU);
+#else
+	return &_kernel.cpus[0];
+#endif /* CONFIG_SMP */
 }
 
 static ALWAYS_INLINE int arch_exception_depth(void)

--- a/include/zephyr/arch/riscv/arch_inlines.h
+++ b/include/zephyr/arch/riscv/arch_inlines.h
@@ -19,11 +19,15 @@ static ALWAYS_INLINE uint32_t arch_proc_id(void)
 
 static ALWAYS_INLINE _cpu_t *arch_curr_cpu(void)
 {
+#ifdef CONFIG_VALIDATE_ARCH_CURR_CPU
+	__ASSERT_NO_MSG(!z_smp_cpu_mobile());
+#endif /* CONFIG_VALIDATE_ARCH_CURR_CPU */
+
 #if defined(CONFIG_SMP) || defined(CONFIG_USERSPACE)
 	return (_cpu_t *)csr_read(mscratch);
 #else
 	return &_kernel.cpus[0];
-#endif
+#endif /* defined(CONFIG_SMP) || defined(CONFIG_USERSPACE) */
 }
 
 static ALWAYS_INLINE unsigned int arch_num_cpus(void)

--- a/include/zephyr/arch/x86/arch_inlines.h
+++ b/include/zephyr/arch/x86/arch_inlines.h
@@ -19,6 +19,11 @@
 
 static inline struct _cpu *arch_curr_cpu(void)
 {
+#ifdef CONFIG_VALIDATE_ARCH_CURR_CPU
+	__ASSERT_NO_MSG(!z_smp_cpu_mobile());
+#endif /* CONFIG_VALIDATE_ARCH_CURR_CPU */
+
+#ifdef CONFIG_SMP
 	struct _cpu *cpu;
 
 	__asm__ volatile("movq %%gs:(%c1), %0"
@@ -26,6 +31,9 @@ static inline struct _cpu *arch_curr_cpu(void)
 			 : "i" (offsetof(x86_tss64_t, cpu)));
 
 	return cpu;
+#else
+	return &_kernel.cpus[0];
+#endif /* CONFIG_SMP */
 }
 
 static ALWAYS_INLINE uint32_t arch_proc_id(void)

--- a/include/zephyr/arch/xtensa/arch_inlines.h
+++ b/include/zephyr/arch/xtensa/arch_inlines.h
@@ -62,11 +62,19 @@
 /** Implementation of @ref arch_curr_cpu. */
 static ALWAYS_INLINE _cpu_t *arch_curr_cpu(void)
 {
+#ifdef CONFIG_VALIDATE_ARCH_CURR_CPU
+	__ASSERT_NO_MSG(!z_smp_cpu_mobile());
+#endif /* CONFIG_VALIDATE_ARCH_CURR_CPU */
+
+#ifdef CONFIG_SMP
 	_cpu_t *cpu;
 
 	cpu = (_cpu_t *)XTENSA_RSR(ZSR_CPU_STR);
 
 	return cpu;
+#else
+	return &_kernel.cpus[0];
+#endif /* CONFIG_SMP */
 }
 
 /** Implementation of @ref arch_proc_id. */

--- a/include/zephyr/kernel_structs.h
+++ b/include/zephyr/kernel_structs.h
@@ -258,12 +258,9 @@ extern atomic_t _cpus_active;
  */
 bool z_smp_cpu_mobile(void);
 
-#define _current_cpu ({ __ASSERT_NO_MSG(!z_smp_cpu_mobile()); \
-			arch_curr_cpu(); })
 #define _current k_sched_current_thread_query()
 
 #else
-#define _current_cpu (&_kernel.cpus[0])
 #define _current _kernel.cpus[0].current
 #endif
 

--- a/kernel/Kconfig.smp
+++ b/kernel/Kconfig.smp
@@ -126,4 +126,15 @@ config TICKET_SPINLOCKS
 	  which resolves such unfairness issue at the cost of slightly
 	  increased memory footprint.
 
+config VALIDATE_ARCH_CURR_CPU
+	bool "Validate usage of arch_curr_cpu"
+	depends on ASSERT
+	depends on SMP && MP_MAX_NUM_CPUS > 1
+	default y
+	help
+	  The `arch_curr_cpu()` should only ever be used in non-preemptible
+	  contexts when there's more than one CPU enabled in the system.
+
+	  This option guarantees correct usage with runtime checks.
+
 endmenu

--- a/kernel/fatal.c
+++ b/kernel/fatal.c
@@ -96,7 +96,7 @@ void z_fatal_error(unsigned int reason, const struct arch_esf *esf)
 	 * change it without also updating twister
 	 */
 	LOG_ERR(">>> ZEPHYR FATAL ERROR %d: %s on CPU %d", reason,
-		reason_to_str(reason), _current_cpu->id);
+		reason_to_str(reason), arch_curr_cpu()->id);
 
 	/* FIXME: This doesn't seem to work as expected on all arches.
 	 * Need a reliable way to determine whether the fault happened when

--- a/kernel/include/kswap.h
+++ b/kernel/include/kswap.h
@@ -125,7 +125,7 @@ static ALWAYS_INLINE unsigned int do_swap(unsigned int key,
 		z_sched_usage_switch(new_thread);
 
 #ifdef CONFIG_SMP
-		_current_cpu->swap_ok = 0;
+		arch_curr_cpu()->swap_ok = 0;
 		new_thread->base.cpu = arch_curr_cpu()->id;
 
 		if (!is_spinlock) {
@@ -134,7 +134,7 @@ static ALWAYS_INLINE unsigned int do_swap(unsigned int key,
 #endif /* CONFIG_SMP */
 		z_thread_mark_switched_out();
 		z_sched_switch_spin(new_thread);
-		_current_cpu->current = new_thread;
+		arch_curr_cpu()->current = new_thread;
 
 #ifdef CONFIG_TIMESLICING
 		z_reset_time_slice(new_thread);
@@ -260,6 +260,6 @@ static inline void z_dummy_thread_init(struct k_thread *dummy_thread)
 	dummy_thread->base.slice_ticks = 0;
 #endif /* CONFIG_TIMESLICE_PER_THREAD */
 
-	_current_cpu->current = dummy_thread;
+	arch_curr_cpu()->current = dummy_thread;
 }
 #endif /* ZEPHYR_KERNEL_INCLUDE_KSWAP_H_ */

--- a/kernel/include/priority_q.h
+++ b/kernel/include/priority_q.h
@@ -195,7 +195,7 @@ static ALWAYS_INLINE struct k_thread *z_priq_dumb_mask_best(sys_dlist_t *pq)
 	struct k_thread *thread;
 
 	SYS_DLIST_FOR_EACH_CONTAINER(pq, thread, base.qnode_dlist) {
-		if ((thread->base.cpu_mask & BIT(_current_cpu->id)) != 0) {
+		if ((thread->base.cpu_mask & BIT(arch_curr_cpu()->id)) != 0) {
 			return thread;
 		}
 	}

--- a/kernel/ipi.c
+++ b/kernel/ipi.c
@@ -31,7 +31,7 @@ atomic_val_t ipi_mask_create(struct k_thread *thread)
 
 	uint32_t  ipi_mask = 0;
 	uint32_t  num_cpus = (uint32_t)arch_num_cpus();
-	uint32_t  id = _current_cpu->id;
+	uint32_t  id = arch_curr_cpu()->id;
 	struct k_thread *cpu_thread;
 	bool   executable_on_cpu = true;
 

--- a/kernel/mmu.c
+++ b/kernel/mmu.c
@@ -1666,7 +1666,7 @@ static bool do_page_fault(void *addr, bool pin)
 #endif /* CONFIG_DEMAND_PAGING_ALLOW_IRQ */
 
 	key = k_spin_lock(&z_mm_lock);
-	faulting_thread = _current_cpu->current;
+	faulting_thread = arch_curr_cpu()->current;
 
 	status = arch_page_location_get(addr, &page_in_location);
 	if (status == ARCH_PAGE_LOCATION_BAD) {

--- a/kernel/spinlock_validate.c
+++ b/kernel/spinlock_validate.c
@@ -11,7 +11,7 @@ bool z_spin_lock_valid(struct k_spinlock *l)
 	uintptr_t thread_cpu = l->thread_cpu;
 
 	if (thread_cpu != 0U) {
-		if ((thread_cpu & 3U) == _current_cpu->id) {
+		if ((thread_cpu & 3U) == arch_curr_cpu()->id) {
 			return false;
 		}
 	}
@@ -28,7 +28,7 @@ bool z_spin_unlock_valid(struct k_spinlock *l)
 		/* Edge case where an ISR aborted _current */
 		return true;
 	}
-	if (tcpu != (_current_cpu->id | (uintptr_t)_current)) {
+	if (tcpu != (arch_curr_cpu()->id | (uintptr_t)_current)) {
 		return false;
 	}
 	return true;
@@ -36,7 +36,7 @@ bool z_spin_unlock_valid(struct k_spinlock *l)
 
 void z_spin_lock_set_owner(struct k_spinlock *l)
 {
-	l->thread_cpu = _current_cpu->id | (uintptr_t)_current;
+	l->thread_cpu = arch_curr_cpu()->id | (uintptr_t)_current;
 }
 
 #ifdef CONFIG_KERNEL_COHERENCE

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -946,8 +946,8 @@ void z_thread_mark_switched_out(void)
 #ifdef CONFIG_TRACING
 #ifdef CONFIG_THREAD_LOCAL_STORAGE
 	/* Dummy thread won't have TLS set up to run arbitrary code */
-	if (!_current_cpu->current ||
-	    (_current_cpu->current->base.thread_state & _THREAD_DUMMY) != 0)
+	if (!arch_curr_cpu()->current ||
+	    (arch_curr_cpu()->current->base.thread_state & _THREAD_DUMMY) != 0)
 		return;
 #endif /* CONFIG_THREAD_LOCAL_STORAGE */
 	SYS_PORT_TRACING_FUNC(k_thread, switched_out);

--- a/kernel/timeslicing.c
+++ b/kernel/timeslicing.c
@@ -60,14 +60,14 @@ static void slice_timeout(struct _timeout *timeout)
 	/* We need an IPI if we just handled a timeslice expiration
 	 * for a different CPU.
 	 */
-	if (cpu != _current_cpu->id) {
+	if (cpu != arch_curr_cpu()->id) {
 		flag_ipi(IPI_CPU_MASK(cpu));
 	}
 }
 
 void z_reset_time_slice(struct k_thread *thread)
 {
-	int cpu = _current_cpu->id;
+	int cpu = arch_curr_cpu()->id;
 
 	z_abort_timeout(&slice_timeouts[cpu]);
 	slice_expired[cpu] = false;
@@ -114,7 +114,7 @@ void z_time_slice(void)
 	pending_current = NULL;
 #endif
 
-	if (slice_expired[_current_cpu->id] && thread_is_sliceable(curr)) {
+	if (slice_expired[arch_curr_cpu()->id] && thread_is_sliceable(curr)) {
 #ifdef CONFIG_TIMESLICE_PER_THREAD
 		if (curr->base.slice_expired) {
 			k_spin_unlock(&_sched_spinlock, key);

--- a/samples/subsys/tracing/src/tracing_user.c
+++ b/samples/subsys/tracing/src/tracing_user.c
@@ -12,7 +12,7 @@ void sys_trace_thread_switched_in_user(void)
 {
 	unsigned int key = irq_lock();
 
-	__ASSERT_NO_MSG(nested_interrupts[_current_cpu->id] == 0);
+	__ASSERT_NO_MSG(nested_interrupts[arch_curr_cpu()->id] == 0);
 	/* Can't use k_current_get as thread base and z_tls_current might be incorrect */
 	printk("%s: %p\n", __func__, k_sched_current_thread_query());
 
@@ -23,7 +23,7 @@ void sys_trace_thread_switched_out_user(void)
 {
 	unsigned int key = irq_lock();
 
-	__ASSERT_NO_MSG(nested_interrupts[_current_cpu->id] == 0);
+	__ASSERT_NO_MSG(nested_interrupts[arch_curr_cpu()->id] == 0);
 	/* Can't use k_current_get as thread base and z_tls_current might be incorrect */
 	printk("%s: %p\n", __func__, k_sched_current_thread_query());
 
@@ -33,7 +33,7 @@ void sys_trace_thread_switched_out_user(void)
 void sys_trace_isr_enter_user(void)
 {
 	unsigned int key = irq_lock();
-	_cpu_t *curr_cpu = _current_cpu;
+	_cpu_t *curr_cpu = arch_curr_cpu();
 
 	printk("%s: %d\n", __func__, nested_interrupts[curr_cpu->id]);
 	nested_interrupts[curr_cpu->id]++;
@@ -44,7 +44,7 @@ void sys_trace_isr_enter_user(void)
 void sys_trace_isr_exit_user(void)
 {
 	unsigned int key = irq_lock();
-	_cpu_t *curr_cpu = _current_cpu;
+	_cpu_t *curr_cpu = arch_curr_cpu();
 
 	nested_interrupts[curr_cpu->id]--;
 	printk("%s: %d\n", __func__, nested_interrupts[curr_cpu->id]);

--- a/subsys/pm/pm.c
+++ b/subsys/pm/pm.c
@@ -62,7 +62,7 @@ static inline void pm_state_notify(bool entering_state)
 		}
 
 		if (callback) {
-			callback(z_cpus_pm_state[_current_cpu->id].state);
+			callback(z_cpus_pm_state[arch_curr_cpu()->id].state);
 		}
 	}
 	k_spin_unlock(&pm_notifier_lock, pm_notifier_key);
@@ -93,7 +93,7 @@ static inline int32_t ticks_expiring_sooner(int32_t ticks1, int32_t ticks2)
 
 void pm_system_resume(void)
 {
-	uint8_t id = _current_cpu->id;
+	uint8_t id = arch_curr_cpu()->id;
 
 	/*
 	 * This notification is called from the ISR of the event
@@ -142,7 +142,7 @@ bool pm_state_force(uint8_t cpu, const struct pm_state_info *info)
 
 bool pm_system_suspend(int32_t kernel_ticks)
 {
-	uint8_t id = _current_cpu->id;
+	uint8_t id = arch_curr_cpu()->id;
 	k_spinlock_key_t key;
 	int32_t ticks, events_ticks;
 

--- a/subsys/pm/pm_stats.c
+++ b/subsys/pm/pm_stats.c
@@ -53,17 +53,17 @@ SYS_INIT(pm_stats_init, PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
 
 void pm_stats_start(void)
 {
-	time_start[_current_cpu->id] = k_cycle_get_32();
+	time_start[arch_curr_cpu()->id] = k_cycle_get_32();
 }
 
 void pm_stats_stop(void)
 {
-	time_stop[_current_cpu->id] = k_cycle_get_32();
+	time_stop[arch_curr_cpu()->id] = k_cycle_get_32();
 }
 
 void pm_stats_update(enum pm_state state)
 {
-	uint8_t cpu = _current_cpu->id;
+	uint8_t cpu = arch_curr_cpu()->id;
 	uint32_t time_total = time_stop[cpu] - time_start[cpu];
 
 	STATS_INC(stats[cpu][state], state_count);

--- a/subsys/profiling/perf/backends/perf_riscv.c
+++ b/subsys/profiling/perf/backends/perf_riscv.c
@@ -36,13 +36,13 @@ size_t arch_perf_current_stack_trace(uintptr_t *buf, size_t size)
 	 * In riscv (arch/riscv/core/isr.S) ra, ip($mepc) and fp($s0) are saved
 	 * at the beginning of _isr_wrapper in order, specified by z_arch_esf_t.
 	 * Then, before calling interruption handler, core switch $sp to
-	 * _current_cpu->irq_stack and save $sp with offset -16 on irq stack
+	 * arch_curr_cpu()->irq_stack and save $sp with offset -16 on irq stack
 	 *
 	 * The following lines lines do the reverse things to get ra, ip anf fp
 	 * from thread stack
 	 */
 	const struct arch_esf * const esf =
-		*((struct arch_esf **)(((uintptr_t)_current_cpu->irq_stack) - 16));
+		*((struct arch_esf **)(((uintptr_t)arch_curr_cpu()->irq_stack) - 16));
 
 	/*
 	 * $s0 is used as frame pointer.

--- a/subsys/profiling/perf/backends/perf_x86.c
+++ b/subsys/profiling/perf/backends/perf_x86.c
@@ -43,12 +43,12 @@ size_t arch_perf_current_stack_trace(uintptr_t *buf, size_t size)
 	size_t idx = 0;
 
 	const struct isf * const isf =
-		*((struct isf **)(((void **)_current_cpu->irq_stack)-1));
+		*((struct isf **)(((void **)arch_curr_cpu()->irq_stack)-1));
 	/*
 	 * In x86 (arch/x86/core/ia32/intstub.S) %eip and %ebp
 	 * are saved at the beginning of _interrupt_enter in order, that described
 	 * in struct esf. Core switch %esp to
-	 * _current_cpu->irq_stack and push %esp on irq stack
+	 * arch_curr_cpu()->irq_stack and push %esp on irq stack
 	 *
 	 * The following lines lines do the reverse things to get %eip and %ebp
 	 * from thread stack

--- a/subsys/testsuite/ztest/src/ztest.c
+++ b/subsys/testsuite/ztest/src/ztest.c
@@ -235,7 +235,7 @@ static void cpu_hold(void *arg1, void *arg2, void *arg3)
 	 * the FPU preemptively here to prevent any other CPU waiting after
 	 * this CPU forever and deadlock the system.
 	 */
-	k_float_disable(_current_cpu->arch.fpu_owner);
+	k_float_disable(arch_curr_cpu()->arch.fpu_owner);
 #endif
 
 	while (cpuhold_active) {

--- a/tests/arch/arc/arc_vpx_lock/src/main.c
+++ b/tests/arch/arc/arc_vpx_lock/src/main.c
@@ -34,7 +34,7 @@ static int current_cpu_id_get(void)
 	int id;
 
 	key = arch_irq_lock();
-	id = _current_cpu->id;
+	id = arch_curr_cpu()->id;
 	arch_irq_unlock(key);
 
 	return id;

--- a/tests/kernel/ipi_cascade/src/main.c
+++ b/tests/kernel/ipi_cascade/src/main.c
@@ -107,7 +107,7 @@ void thread3_entry(void *p1, void *p2, void *p3)
 	int  key;
 
 	key = arch_irq_lock();
-	id = _current_cpu->id;
+	id = arch_curr_cpu()->id;
 	arch_irq_unlock(key);
 
 	 /* 2.1 - Block on my_event */

--- a/tests/kernel/ipi_optimize/src/main.c
+++ b/tests/kernel/ipi_optimize/src/main.c
@@ -37,7 +37,7 @@ void z_trace_sched_ipi(void)
 	k_spinlock_key_t  key;
 
 	key = k_spin_lock(&ipilock);
-	ipi_count[_current_cpu->id]++;
+	ipi_count[arch_curr_cpu()->id]++;
 	k_spin_unlock(&ipilock, key);
 }
 
@@ -65,7 +65,7 @@ static void busy_thread_entry(void *p1, void *p2, void *p3)
 	uint32_t id;
 
 	key = arch_irq_lock();
-	id = _current_cpu->id;
+	id = arch_curr_cpu()->id;
 	arch_irq_unlock(key);
 
 	atomic_or(&busy_started, BIT(id));
@@ -138,7 +138,7 @@ uint32_t busy_threads_create(int priority)
 
 	k_sleep(K_TICKS(1));
 	key = arch_irq_lock();
-	id = _current_cpu->id;
+	id = arch_curr_cpu()->id;
 	arch_irq_unlock(key);
 
 	/*

--- a/tests/kernel/threads/thread_stack/src/main.c
+++ b/tests/kernel/threads/thread_stack/src/main.c
@@ -501,11 +501,11 @@ ZTEST(userspace_thread_stack, test_idle_stack)
 	int ret;
 #ifdef CONFIG_SMP
 	/* 1cpu test case, so all other CPUs are spinning with co-op
-	 * threads blocking them. _current_cpu triggers an assertion.
+	 * threads blocking them. arch_curr_cpu() triggers an assertion.
 	 */
 	struct k_thread *idle = arch_curr_cpu()->idle_thread;
 #else
-	struct k_thread *idle = _current_cpu->idle_thread;
+	struct k_thread *idle = arch_curr_cpu()->idle_thread;
 #endif
 	size_t unused_bytes;
 

--- a/tests/subsys/pm/power_mgmt_multicore/src/main.c
+++ b/tests/subsys/pm/power_mgmt_multicore/src/main.c
@@ -33,7 +33,7 @@ void pm_state_set(enum pm_state state, uint8_t substate_id)
 {
 	ARG_UNUSED(substate_id);
 
-	switch (state_testing[_current_cpu->id]) {
+	switch (state_testing[arch_curr_cpu()->id]) {
 	case  PM_STATE_RUNTIME_IDLE:
 		zassert_equal(PM_STATE_RUNTIME_IDLE, state);
 		break;
@@ -41,7 +41,7 @@ void pm_state_set(enum pm_state state, uint8_t substate_id)
 		zassert_equal(PM_STATE_SUSPEND_TO_IDLE, state);
 		break;
 	case  PM_STATE_STANDBY:
-		zassert_equal(_current_cpu->id, 1U);
+		zassert_equal(arch_curr_cpu()->id, 1U);
 		zassert_equal(PM_STATE_STANDBY, state);
 		break;
 	default:


### PR DESCRIPTION
Use the `arch_curr_cpu()` directly instead of the `_current_cpu` abstraction.

Guard the `z_smp_cpu_mobile()` usage validation with a new Kconfig `CONFIG_VALIDATE_ARCH_CURR_CPU`, and move it into the `arch_curr_cpu()` function.

- [ ] update docs