### PR TITLE
Fix doc release 4.0

### DIFF
--- a/doc/releases/release-notes-4.0.rst
+++ b/doc/releases/release-notes-4.0.rst
@@ -735,6 +735,8 @@ Drivers and Sensors
   * Added support for more OmniVision OV2640 controls (:dtcompatible:`ovti,ov2640`)
   * Added support for more OmniVision OV5640 controls (:dtcompatible:`ovti,ov5640`)
   * STM32: Implemented :c:func:`video_get_ctrl` and :c:func:`video_set_ctrl` APIs.
+  * Removed an init order circular dependency for the camera pipeline on NXP RT10xx platforms
+    (:github:`80304`)
 
 * W1
 

--- a/doc/releases/release-notes-4.0.rst
+++ b/doc/releases/release-notes-4.0.rst
@@ -728,6 +728,7 @@ Drivers and Sensors
   * Introduced missing :kconfig:option:`CONFIG_VIDEO_LOG_LEVEL`
   * Added a sample for capturing video and displaying it with LVGL
     (:zephyr:code-sample:`video-capture-to-lvgl`)
+  * Added an automatic test to check colorbar pattern correctness
   * Added support for GalaxyCore GC2145 image sensor (:dtcompatible:`gc,gc2145`)
   * Added support for ESP32-S3 LCD-CAM interface (:dtcompatible:`espressif,esp32-lcd-cam`)
   * Added support for NXP MCUX SMARTDMA interface (:dtcompatible:`nxp,smartdma`)

--- a/doc/releases/release-notes-4.0.rst
+++ b/doc/releases/release-notes-4.0.rst
@@ -724,7 +724,8 @@ Drivers and Sensors
   * Introduced API for partial frames transfer with the video buffer field ``line_offset``
   * Introduced API for :ref:`multi-heap<memory_management_shared_multi_heap>` video buffer allocation with
     :kconfig:option:`CONFIG_VIDEO_BUFFER_USE_SHARED_MULTI_HEAP`
-  * Introduced bindings for common video link properties in ``video-interfaces.yaml``
+  * Introduced bindings for common video link properties in ``video-interfaces.yaml``. Migration to the
+    new bindings is tracked in :github:`80514`
   * Introduced missing :kconfig:option:`CONFIG_VIDEO_LOG_LEVEL`
   * Added a sample for capturing video and displaying it with LVGL
     (:zephyr:code-sample:`video-capture-to-lvgl`)


### PR DESCRIPTION
- Add camera colorbar pattern test: this is added via PRs #79337 and #79263 to automatically check if a colorbar pattern generated by a camera pipeline is correct or not which is helpful to detect issue in a camera pipeline.
- Add some fixed issues in video domain: the chicken-egg issue in init orders of the camera pipeline on NXP RT10xx platforms (**a known issue exists more than a year due to technical obstacle, not a bug**) and the floating point logging issue in video capture sample