### PR TITLE
doc: fix typo in multiple directories before v4.0.0 release

### DIFF
--- a/doc/connectivity/networking/network_tracing.rst
+++ b/doc/connectivity/networking/network_tracing.rst
@@ -9,7 +9,7 @@ Network Tracing
 
 User can enable network core stack and socket API calls tracing.
 
-The :kconfig:option:`CONFIG_TRACING_NET_CORE` option contols the core network
+The :kconfig:option:`CONFIG_TRACING_NET_CORE` option controls the core network
 stack tracing. This option is enabled by default if tracing and networking
 are enabled. The system will start to collect the receiving and sending call
 verdicts i.e., whether the network packet was successfully sent or received.

--- a/doc/contribute/documentation/guidelines.rst
+++ b/doc/contribute/documentation/guidelines.rst
@@ -796,7 +796,7 @@ Application build commands
          :board: qemu_x86
          :goals: build
 
-   This wil render as:
+   This will render as:
 
       .. zephyr-app-commands::
          :zephyr-app: samples/hello_world

--- a/doc/develop/toolchains/cadence_xcc.rst
+++ b/doc/develop/toolchains/cadence_xcc.rst
@@ -62,7 +62,7 @@ Cadence Tensilica Xtensa C/C++ Compiler (XCC)
          export XTENSA_CORE=ace10_LX7HiFi4_2022_10
          export TOOLCHAIN_VER=RI-2022.10-linux
 
-   #. Muiltiple SoCs:
+   #. Multiple SoCs:
 
       .. code-block:: console
 

--- a/doc/hardware/arch/arm-scmi.rst
+++ b/doc/hardware/arch/arm-scmi.rst
@@ -142,9 +142,9 @@ Currently, Zephyr has support for the following standard protocols:
 Clock management protocol
 *************************
 
-This protocol is used to perfrom clock management operations. This is done
+This protocol is used to perform clock management operations. This is done
 via a driver (:file:`drivers/clock_control/clock_control_arm_scmi.c`), which
-implements the Zephyr clock control subsytem API. As such, from the user's
+implements the Zephyr clock control subsystem API. As such, from the user's
 perspective, using this driver is no different than using any other clock
 management driver.
 

--- a/doc/releases/migration-guide-4.0.rst
+++ b/doc/releases/migration-guide-4.0.rst
@@ -368,7 +368,7 @@ Bluetooth Audio
   :kconfig:option:`CONFIG_BT_ASCS_MAX_ASE_SNK_COUNT` to reflect that they now serve as a
   compile-time maximum configuration of ASEs to be used.
   :c:func:`bt_bap_unicast_server_register` needs to be called once before using the Unicast Server,
-  and more specfically prior to calling :c:func:`bt_bap_unicast_server_register_cb` for the first
+  and more specifically prior to calling :c:func:`bt_bap_unicast_server_register_cb` for the first
   time. It does not need to be called again until the new function
   :c:func:`bt_bap_unicast_server_unregister` has been called.
   (:github:`76632`)

--- a/doc/releases/release-notes-4.0.rst
+++ b/doc/releases/release-notes-4.0.rst
@@ -509,7 +509,7 @@ Drivers and Sensors
 
 * I3C
 
-  * Added support for SETAASA optmization during initialization. Added a
+  * Added support for SETAASA optimization during initialization. Added a
     ``supports-setaasa`` property to ``i3c-devices.yaml``.
   * Added sending DEFTGTS if any devices that support functioning as a secondary
     controller on the bus.
@@ -1057,7 +1057,7 @@ Libraries / Subsystems
 
     * :c:func:`hawkbit_autohandler` now takes one argument. If the argument is set to true, the
       autohandler will reshedule itself after running. If the argument is set to false, the
-      autohandler will not reshedule itself. Both variants are sheduled independent of each other.
+      autohandler will not reshedule itself. Both variants are scheduled independent of each other.
       The autohandler always runs in the system workqueue.
 
     * Use the :c:func:`hawkbit_autohandler_wait` function to wait for the autohandler to finish.
@@ -1258,7 +1258,7 @@ MCUboot
   * Added zephyr prefix to generated header path.
   * Added optional img mgmt slot info feature.
   * Added bootutil support for maximum image size details for additional images.
-  * Added support for automatically calculcating max sectors.
+  * Added support for automatically calculating max sectors.
   * Added missing ``boot_enc_init()`` function.
   * Added support for keeping image encrypted in scratch area in bootutil.
   * Fixed serial recovery for NXP IMX.RT, LPC55x and MCXNx platforms

--- a/doc/services/smf/index.rst
+++ b/doc/services/smf/index.rst
@@ -335,7 +335,7 @@ Code::
 		/* Child states do not have entry or exit actions */
 		[S0] = SMF_CREATE_STATE(NULL, s0_run, NULL, &demo_states[PARENT], NULL),
 		[S1] = SMF_CREATE_STATE(NULL, s1_run, NULL, &demo_states[PARENT], NULL),
-		/* State S2 do ot have entry or exit actions and no parent */
+		/* State S2 do not have entry or exit actions and no parent */
 		[S2] = SMF_CREATE_STATE(NULL, s2_run, NULL, NULL, NULL),
 	};
 

--- a/doc/services/storage/zms/zms.rst
+++ b/doc/services/storage/zms/zms.rst
@@ -367,7 +367,7 @@ Version1
 - Supports 32-bit IDs to store ID/Value pairs
 - Small sized data ( <= 8 bytes) are stored in the ATE itself
 - Built-in Data CRC32 (included in the ATE)
-- Versionning of ZMS (to handle future evolution)
+- Versioning of ZMS (to handle future evolution)
 - Supports large write-block-size (Only for platforms that need this)
 
 Future features


### PR DESCRIPTION
Utilize a code spell-checking tool to scan for and correct spelling errors in various files within the `doc` directory.
