### PR TITLE
doc: release-notes-4.0: add release notes for firmware subsystem

### DIFF
--- a/doc/releases/release-notes-4.0.rst
+++ b/doc/releases/release-notes-4.0.rst
@@ -1193,6 +1193,14 @@ Libraries / Subsystems
 
     (:github:`79653`)
 
+* Firmware
+
+  * Introduced basic support for ARM's System Control and Management Interface, which includes:
+
+    * Subset of clock management protocol commands
+    * Subset of pin control protocol commands
+    * Shared memory and mailbox-based transport
+
 HALs
 ****
 


### PR DESCRIPTION
Includes notes on SCMI's introduction.