### PR TITLE
boards: st: nucleo_u5a5zj_q: configure PD14 as SPI1 nCS

### DIFF
--- a/boards/st/nucleo_u5a5zj_q/doc/index.rst
+++ b/boards/st/nucleo_u5a5zj_q/doc/index.rst
@@ -236,7 +236,7 @@ Default Zephyr Peripheral Mapping:
 - LD3 : PG2
 - LPUART_1_TX : PG7
 - LPUART_1_RX : PG8
-- SPI_1_NSS : PA4
+- SPI_1 nCS (GPIO) : PD14
 - SPI_1_SCK : PA5
 - SPI_1_MISO : PA6
 - SPI_1_MOSI : PA7

--- a/boards/st/nucleo_u5a5zj_q/nucleo_u5a5zj_q-common.dtsi
+++ b/boards/st/nucleo_u5a5zj_q/nucleo_u5a5zj_q-common.dtsi
@@ -112,9 +112,9 @@
 };
 
 &spi1 {
-	pinctrl-0 = <&spi1_nss_pe12 &spi1_sck_pa5
-		     &spi1_miso_pa6 &spi1_mosi_pa7>;
+	pinctrl-0 = <&spi1_sck_pa5 &spi1_miso_pa6 &spi1_mosi_pa7>;
 	pinctrl-names = "default";
+	cs-gpios = <&gpiod 14 GPIO_ACTIVE_LOW>;
 	status = "okay";
 };
 


### PR DESCRIPTION
ST ZIO connector is Arduino Uno compatible. Arduino SPI pins are placed on
D10-D13 pins, where D10 is SPI nCS pin. This pin is connected with PD14 of
STM32U5A.

According to schematics of this Nucleo board [1]:

> Due to muxing constrainte, the SPI_NSS is not available as an alternate
> on this IO, so this pin is affected with an I/O function to do the Chip
> Select

This means that software control of GPIO is needed to make use of this SPI
interface on regular SPI signals on Arduino connector. Reconfigure
SPI1 (used as Arduino SPI) interface to account for that.

Note that previously configured PE12 is only available on ST ZIO and ST
Morpho connectors, not on Arduino connector.

Update documentation as well, which was referencing PA4 as nCS signal (used
on some other Nucleo boards).

[1] https://www.st.com/resource/en/schematic_pack/mb1549-u5a5ziq-c04-schematic.pdf