### PR TITLE
boards: nxp: fix s26ks512s0 flash write-block-size

### DIFF
--- a/boards/nxp/mimxrt1050_evk/mimxrt1050_evk_mimxrt1052_hyperflash.overlay
+++ b/boards/nxp/mimxrt1050_evk/mimxrt1050_evk_mimxrt1052_hyperflash.overlay
@@ -39,7 +39,7 @@
 		ahb-write-wait-unit = <2>;
 		ahb-write-wait-interval = <20>;
 		status = "okay";
-		erase-block-size = <4096>;
+		erase-block-size = <DT_SIZE_K(256)>;
 		write-block-size = <16>;
 
 		partitions {
@@ -48,22 +48,22 @@
 			#size-cells = <1>;
 			boot_partition: partition@0 {
 				label = "mcuboot";
-				reg = <0x00000000 DT_SIZE_K(128)>;
+				reg = <0x00000000 DT_SIZE_K(256)>;
 			};
-			/* The MCUBoot swap-move algorithm uses the last 11 sectors
+			/* The MCUBoot swap-move algorithm uses the last 2 sectors
 			 * of the primary slot0 for swap status and move.
 			 */
-			slot0_partition: partition@20000 {
+			slot0_partition: partition@40000 {
 				label = "image-0";
-				reg = <0x00020000 (DT_SIZE_M(3) + DT_SIZE_K(44))>;
+				reg = <0x00040000 (DT_SIZE_M(3) + DT_SIZE_K(512))>;
 			};
-			slot1_partition: partition@32B000 {
+			slot1_partition: partition@3C0000 {
 				label = "image-1";
-				reg = <0x0032B000 DT_SIZE_M(3)>;
+				reg = <0x003C0000 DT_SIZE_M(3)>;
 			};
-			storage_partition: partition@62B000 {
+			storage_partition: partition@6C0000 {
 				label = "storage";
-				reg = <0x0062B000 (DT_SIZE_M(58) - DT_SIZE_K(172))>;
+				reg = <0x006C0000 (DT_SIZE_M(58) - DT_SIZE_K(768))>;
 			};
 		};
 	};

--- a/boards/nxp/mimxrt1060_evk/mimxrt1060_evk_mimxrt1062_hyperflash.overlay
+++ b/boards/nxp/mimxrt1060_evk/mimxrt1060_evk_mimxrt1062_hyperflash.overlay
@@ -37,7 +37,7 @@
 		ahb-write-wait-unit = <2>;
 		ahb-write-wait-interval = <20>;
 		status = "okay";
-		erase-block-size = <4096>;
+		erase-block-size = <DT_SIZE_K(256)>;
 		write-block-size = <16>;
 
 		partitions {
@@ -46,22 +46,22 @@
 			#size-cells = <1>;
 			boot_partition: partition@0 {
 				label = "mcuboot";
-				reg = <0x00000000 DT_SIZE_K(128)>;
+				reg = <0x00000000 DT_SIZE_K(256)>;
 			};
-			/* The MCUBoot swap-move algorithm uses the last 11 sectors
+			/* The MCUBoot swap-move algorithm uses the last 2 sectors
 			 * of the primary slot0 for swap status and move.
 			 */
-			slot0_partition: partition@20000 {
+			slot0_partition: partition@40000 {
 				label = "image-0";
-				reg = <0x00020000 (DT_SIZE_M(3) + DT_SIZE_K(44))>;
+				reg = <0x00040000 (DT_SIZE_M(3) + DT_SIZE_K(512))>;
 			};
-			slot1_partition: partition@32B000 {
+			slot1_partition: partition@3C0000 {
 				label = "image-1";
-				reg = <0x0032B000 DT_SIZE_M(3)>;
+				reg = <0x003C0000 DT_SIZE_M(3)>;
 			};
-			storage_partition: partition@62B000 {
+			storage_partition: partition@6C0000 {
 				label = "storage";
-				reg = <0x0062B000 (DT_SIZE_M(58) - DT_SIZE_K(172))>;
+				reg = <0x006C0000 (DT_SIZE_M(58) - DT_SIZE_K(768))>;
 			};
 		};
 	};

--- a/boards/nxp/mimxrt1062_fmurt6/mimxrt1062_fmurt6.dts
+++ b/boards/nxp/mimxrt1062_fmurt6/mimxrt1062_fmurt6.dts
@@ -200,7 +200,7 @@
 		ahb-write-wait-unit = <2>;
 		ahb-write-wait-interval = <20>;
 		status = "okay";
-		erase-block-size = <4096>;
+		erase-block-size = <DT_SIZE_K(256)>;
 		write-block-size = <16>;
 
 		partitions {
@@ -209,22 +209,22 @@
 			#size-cells = <1>;
 			boot_partition: partition@0 {
 				label = "mcuboot";
-				reg = <0x00000000 DT_SIZE_K(128)>;
+				reg = <0x00000000 DT_SIZE_K(256)>;
 			};
-			/* The MCUBoot swap-move algorithm uses the last 11 sectors
+			/* The MCUBoot swap-move algorithm uses the last 2 sectors
 			 * of the primary slot0 for swap status and move.
 			 */
-			slot0_partition: partition@20000 {
+			slot0_partition: partition@40000 {
 				label = "image-0";
-				reg = <0x00020000 (DT_SIZE_M(3) + DT_SIZE_K(44))>;
+				reg = <0x00040000 (DT_SIZE_M(3) + DT_SIZE_K(512))>;
 			};
-			slot1_partition: partition@32B000 {
+			slot1_partition: partition@3C0000 {
 				label = "image-1";
-				reg = <0x0032B000 DT_SIZE_M(3)>;
+				reg = <0x003C0000 DT_SIZE_M(3)>;
 			};
-			storage_partition: partition@62B000 {
+			storage_partition: partition@6C0000 {
 				label = "storage";
-				reg = <0x0062B000 (DT_SIZE_M(58) - DT_SIZE_K(172))>;
+				reg = <0x006C0000 (DT_SIZE_M(58) - DT_SIZE_K(768))>;
 			};
 		};
 	};


### PR DESCRIPTION
- Sets s26ks512s0 flash write-block-size to correct 256KB.
- Optimizes MCUboot partitions to fit the correct write-block-size.

Fixes #80284