### PR TITLE
cmake: dts: Use temporary file for dts.cmake

### DIFF
--- a/cmake/modules/dts.cmake
+++ b/cmake/modules/dts.cmake
@@ -349,17 +349,26 @@ endif()
 #
 # Run GEN_DTS_CMAKE_SCRIPT.
 #
+# A temporary file is copied to the original file if it differs. This prevents issue such as a
+# cycle when sysbuild is used of configuring and building multiple times due to the dts.cmake file
+# of images having a newer modification time than the sysbuild build.ninja file, despite the
+# output having not changed
+#
+set(dts_cmake_tmp ${DTS_CMAKE}.new)
 
 execute_process(
   COMMAND ${PYTHON_EXECUTABLE} ${GEN_DTS_CMAKE_SCRIPT}
   --edt-pickle ${EDT_PICKLE}
-  --cmake-out ${DTS_CMAKE}
+  --cmake-out ${dts_cmake_tmp}
   WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
   RESULT_VARIABLE ret
   )
 if(NOT "${ret}" STREQUAL "0")
   message(FATAL_ERROR "gen_dts_cmake.py failed with return code: ${ret}")
 else()
+  zephyr_file_copy(${dts_cmake_tmp} ${DTS_CMAKE} ONLY_IF_DIFFERENT)
+  file(REMOVE ${dts_cmake_tmp})
+  set(dts_cmake_tmp)
   message(STATUS "Including generated dts.cmake file: ${DTS_CMAKE}")
   include(${DTS_CMAKE})
 endif()


### PR DESCRIPTION
    Uses a temporary file for dts output then uses CMake to copy to the
    correct file if it has changed. This prevents a ping-pong issue when
    sysbuild is used of configuring and building cycle when nothing has
    changed and there is sysbuild code which loads in the devicetree
    data from an image
