### PR TITLE
tests: bluetooth: tester: Fix bluetooth tester for nucleo_wba55cg

### DIFF
--- a/boards/st/nucleo_wba55cg/nucleo_wba55cg.dts
+++ b/boards/st/nucleo_wba55cg/nucleo_wba55cg.dts
@@ -20,6 +20,7 @@
 
 	chosen {
 		zephyr,bt-c2h-uart = &usart1;
+		zephyr,uart-pipe = &usart1;
 		zephyr,console = &usart1;
 		zephyr,shell-uart = &usart1;
 		zephyr,sram = &sram0;

--- a/tests/bluetooth/tester/boards/nucleo_wba55cg.conf
+++ b/tests/bluetooth/tester/boards/nucleo_wba55cg.conf
@@ -1,0 +1,5 @@
+CONFIG_CONSOLE=n
+
+CONFIG_BT_HCI_TX_STACK_SIZE_WITH_PROMPT=y
+# TODO: Investigation to be done to optimize this value
+CONFIG_BT_HCI_TX_STACK_SIZE=4096


### PR DESCRIPTION
Fix compilation error by specifying usart1 to be used for uart-pipe. Add a board-specific configuration file to disable the console, so, the usart1 will be used only for bluetooth and to specify the BT_HCI_TX_STACK_SIZE.