### PR TITLE
drivers: udc_stm32: set address only for standard device requests

### DIFF
--- a/drivers/usb/udc/udc_stm32.c
+++ b/drivers/usb/udc/udc_stm32.c
@@ -168,7 +168,8 @@ void HAL_PCD_SetupStageCallback(PCD_HandleTypeDef *hpcd)
 		return;
 	}
 
-	if (setup->bRequest == USB_SREQ_SET_ADDRESS) {
+	if ((setup->bmRequestType == 0) &&
+	    (setup->bRequest == USB_SREQ_SET_ADDRESS)) {
 		/* HAL requires we set the address before submitting status */
 		HAL_PCD_SetAddress(&priv->pcd, setup->wValue);
 	}


### PR DESCRIPTION
Any request 5 did set the address even if it's a non standard request like vendor specific requests.

This was discovered during testing cannectivity with a NUCLEO-F756ZG board.