### PR TITLE
net: lwm2m: add set_socketoptions cb to pull context LwM2M context

### DIFF
--- a/include/zephyr/net/lwm2m.h
+++ b/include/zephyr/net/lwm2m.h
@@ -182,6 +182,7 @@ enum lwm2m_rd_client_event {
 typedef void (*lwm2m_ctx_event_cb_t)(struct lwm2m_ctx *ctx,
 				     enum lwm2m_rd_client_event event);
 
+typedef int (*lwm2m_set_sockopt_cb_t)(struct lwm2m_ctx *client_ctx);
 
 /**
  * @brief Different traffic states of the LwM2M socket.
@@ -259,7 +260,7 @@ struct lwm2m_ctx {
 	 * a callback that is called after a socket is created and before
 	 * connect.
 	 */
-	int (*set_socketoptions)(struct lwm2m_ctx *client_ctx);
+	lwm2m_set_sockopt_cb_t set_socketoptions;
 
 	/** Flag to indicate if context should use DTLS.
 	 *  Enabled via the use of coaps:// protocol prefix in connection
@@ -1621,6 +1622,17 @@ int lwm2m_security_mode(struct lwm2m_ctx *ctx);
  * @return 0 for success or negative in case of error.
  */
 int lwm2m_set_default_sockopt(struct lwm2m_ctx *ctx);
+
+/**
+ * @brief Set the @ref lwm2m_ctx::set_socketoptions callback for the pull context's client.
+ *
+ * This allows setting specific socket options on the socket that is used to pull
+ * firmware updates. The callback will be called after the pull context socket has been
+ * created and before it will connect.
+ *
+ * @param[in] set_sockopt_cb A callback function to set sockopts for the pull context client.
+ */
+void lwm2m_pull_context_set_sockopt_callback(lwm2m_set_sockopt_cb_t set_sockopt_cb);
 
 #ifdef __cplusplus
 }

--- a/subsys/net/lib/lwm2m/lwm2m_pull_context.c
+++ b/subsys/net/lib/lwm2m/lwm2m_pull_context.c
@@ -446,11 +446,15 @@ int lwm2m_pull_context_start_transfer(char *uri, struct requesting_object req, k
 	context.result_cb = req.result_cb;
 	context.write_cb = req.write_cb;
 
-	(void)memset(&context.firmware_ctx, 0, sizeof(struct lwm2m_ctx));
 	(void)memset(&context.block_ctx, 0, sizeof(struct coap_block_context));
 	context.firmware_ctx.sock_fd = -1;
 
 	firmware_transfer();
 
 	return 0;
+}
+
+void lwm2m_pull_context_set_sockopt_callback(lwm2m_set_sockopt_cb_t set_sockopt_cb)
+{
+	context.firmware_ctx.set_socketoptions = set_sockopt_cb;
 }


### PR DESCRIPTION
The pull context LwM2M client's set_socketoptions callback is currently unused and can't be set by a user. Add a public API to set the pull context's client's set_socketoptions callback.

This fixes an issue I am seeing in our application when pulling a FOTA through LwM2M. My application uses multiple network interfaces and binds a socket to a specific interface with `zsock_setsockopt()` and `SO_BINDTODEVICE` through the `set_socketoptions` callback. When pulling a FOTA, this callback is not set.

I am open to alternative implementations/suggestions that could fix this issue.