### PR TITLE
west.yml: espressif: fix mcuboot assert in hal

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -157,7 +157,7 @@ manifest:
       groups:
         - hal
     - name: hal_espressif
-      revision: 174547ef6a97dafcd6786ecd171cc701f5c0893b
+      revision: 07ff57e8d197765652b7819b297415d859ed7815
       path: modules/hal/espressif
       west-commands: west/west-commands.yml
       groups:


### PR DESCRIPTION
Espressif contains mcuboot calls for loading image. This fixes the way assert call is included in that scenario.

This also includes in HAL a commit addressing an ESP32-C2 Wi-Fi connection issue related to rom functions.

Fixes #81351