### PR TITLE
drivers: spi: Call correct SPI device definition macros

### DIFF
--- a/drivers/spi/spi_ambiq_bleif.c
+++ b/drivers/spi/spi_ambiq_bleif.c
@@ -213,7 +213,8 @@ static int spi_ambiq_init(const struct device *dev)
 		.size = DT_INST_REG_SIZE(n),                                                       \
 		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),                                         \
 		.pwr_func = pwr_on_ambiq_spi_##n};                                                 \
-	DEVICE_DT_INST_DEFINE(n, spi_ambiq_init, NULL, &spi_ambiq_data##n, &spi_ambiq_config##n,   \
-			      POST_KERNEL, CONFIG_SPI_INIT_PRIORITY, &spi_ambiq_driver_api);
+	SPI_DEVICE_DT_INST_DEFINE(n, spi_ambiq_init, NULL, &spi_ambiq_data##n,                     \
+				  &spi_ambiq_config##n, POST_KERNEL, CONFIG_SPI_INIT_PRIORITY,     \
+				  &spi_ambiq_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(AMBIQ_SPI_BLEIF_INIT)

--- a/drivers/spi/spi_ambiq_spic.c
+++ b/drivers/spi/spi_ambiq_spic.c
@@ -517,8 +517,8 @@ static int spi_ambiq_pm_action(const struct device *dev, enum pm_device_action a
 		.irq_config_func = spi_irq_config_func_##n,                                        \
 		.pwr_func = pwr_on_ambiq_spi_##n};                                                 \
 	PM_DEVICE_DT_INST_DEFINE(n, spi_ambiq_pm_action);                                          \
-	DEVICE_DT_INST_DEFINE(n, spi_ambiq_init, PM_DEVICE_DT_INST_GET(n), &spi_ambiq_data##n,     \
-			      &spi_ambiq_config##n, POST_KERNEL, CONFIG_SPI_INIT_PRIORITY,         \
-			      &spi_ambiq_driver_api);
+	SPI_DEVICE_DT_INST_DEFINE(n, spi_ambiq_init, PM_DEVICE_DT_INST_GET(n), &spi_ambiq_data##n, \
+				  &spi_ambiq_config##n, POST_KERNEL, CONFIG_SPI_INIT_PRIORITY,     \
+				  &spi_ambiq_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(AMBIQ_SPI_INIT)

--- a/drivers/spi/spi_ambiq_spid.c
+++ b/drivers/spi/spi_ambiq_spid.c
@@ -423,8 +423,8 @@ static int spi_ambiq_pm_action(const struct device *dev, enum pm_device_action a
 		.irq_config_func = spi_irq_config_func_##n,                                        \
 		.pwr_func = pwr_on_ambiq_spi_##n};                                                 \
 	PM_DEVICE_DT_INST_DEFINE(n, spi_ambiq_pm_action);                                          \
-	DEVICE_DT_INST_DEFINE(n, spi_ambiq_init, PM_DEVICE_DT_INST_GET(n), &spi_ambiq_data##n,     \
-			      &spi_ambiq_config##n, POST_KERNEL, CONFIG_SPI_INIT_PRIORITY,         \
-			      &spi_ambiq_driver_api);
+	SPI_DEVICE_DT_INST_DEFINE(n, spi_ambiq_init, PM_DEVICE_DT_INST_GET(n), &spi_ambiq_data##n, \
+				  &spi_ambiq_config##n, POST_KERNEL, CONFIG_SPI_INIT_PRIORITY,     \
+				  &spi_ambiq_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(AMBIQ_SPID_INIT)

--- a/drivers/spi/spi_andes_atcspi200.c
+++ b/drivers/spi/spi_andes_atcspi200.c
@@ -957,7 +957,7 @@ static void spi_atcspi200_irq_handler(void *arg)
 		.xip = SPI_ROM_CFG_XIP(DT_DRV_INST(n)),			\
 	};								\
 									\
-	DEVICE_DT_INST_DEFINE(n,					\
+	SPI_DEVICE_DT_INST_DEFINE(n,					\
 		spi_atcspi200_init,					\
 		NULL,							\
 		&spi_atcspi200_dev_data_##n,				\

--- a/drivers/spi/spi_b91.c
+++ b/drivers/spi/spi_b91.c
@@ -483,7 +483,7 @@ static DEVICE_API(spi, spi_b91_api) = {
 		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(inst),		  \
 	};								  \
 									  \
-	DEVICE_DT_INST_DEFINE(inst, spi_b91_init,			  \
+	SPI_DEVICE_DT_INST_DEFINE(inst, spi_b91_init,			  \
 			      NULL,					  \
 			      &spi_b91_data_##inst,			  \
 			      &spi_b91_cfg_##inst,			  \

--- a/drivers/spi/spi_b_renesas_ra8.c
+++ b/drivers/spi/spi_b_renesas_ra8.c
@@ -766,8 +766,8 @@ static void ra_spi_eri_isr(const struct device *dev)
 		return 0;                                                                          \
 	}                                                                                          \
                                                                                                    \
-	DEVICE_DT_INST_DEFINE(index, spi_b_ra_init##index, PM_DEVICE_DT_INST_GET(index),           \
-			      &ra_spi_data_##index, &ra_spi_config_##index, POST_KERNEL,           \
-			      CONFIG_SPI_INIT_PRIORITY, &ra_spi_driver_api);
+	SPI_DEVICE_DT_INST_DEFINE(index, spi_b_ra_init##index, PM_DEVICE_DT_INST_GET(index),       \
+				  &ra_spi_data_##index, &ra_spi_config_##index, POST_KERNEL,       \
+				  CONFIG_SPI_INIT_PRIORITY, &ra_spi_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(RA_SPI_INIT)

--- a/drivers/spi/spi_bitbang.c
+++ b/drivers/spi/spi_bitbang.c
@@ -325,7 +325,7 @@ int spi_bitbang_init(const struct device *dev)
 		SPI_CONTEXT_CS_GPIOS_INITIALIZE(DT_DRV_INST(inst), ctx)	\
 	};								\
 									\
-	DEVICE_DT_INST_DEFINE(inst,					\
+	SPI_DEVICE_DT_INST_DEFINE(inst,					\
 			    spi_bitbang_init,				\
 			    NULL,					\
 			    &spi_bitbang_data_##inst,			\

--- a/drivers/spi/spi_cc13xx_cc26xx.c
+++ b/drivers/spi/spi_cc13xx_cc26xx.c
@@ -291,7 +291,7 @@ static DEVICE_API(spi, spi_cc13xx_cc26xx_driver_api) = {
 #define SPI_CC13XX_CC26XX_DEVICE_INIT(n)				    \
 	PM_DEVICE_DT_INST_DEFINE(n, spi_cc13xx_cc26xx_pm_action);	    \
 									    \
-	DEVICE_DT_INST_DEFINE(n,					    \
+	SPI_DEVICE_DT_INST_DEFINE(n,					    \
 		spi_cc13xx_cc26xx_init_##n,				    \
 		PM_DEVICE_DT_INST_GET(n),				    \
 		&spi_cc13xx_cc26xx_data_##n, &spi_cc13xx_cc26xx_config_##n, \

--- a/drivers/spi/spi_dw.c
+++ b/drivers/spi/spi_dw.c
@@ -660,7 +660,7 @@ COND_CODE_1(IS_EQ(DT_NUM_IRQS(DT_DRV_INST(inst)), 1),              \
 			.clear_bit_func = reg_clear_bit,                                    \
 			.test_bit_func = reg_test_bit,))                                    \
 	};                                                                                  \
-	DEVICE_DT_INST_DEFINE(inst,                                                         \
+	SPI_DEVICE_DT_INST_DEFINE(inst,                                                     \
 		spi_dw_init,                                                                \
 		NULL,                                                                       \
 		&spi_dw_data_##inst,                                                        \

--- a/drivers/spi/spi_emul.c
+++ b/drivers/spi/spi_emul.c
@@ -151,7 +151,7 @@ static DEVICE_API(spi, spi_emul_api) = {
 		.num_children = ARRAY_SIZE(emuls_##n),                                             \
 	};                                                                                         \
 	static struct spi_emul_data spi_emul_data_##n;                                             \
-	DEVICE_DT_INST_DEFINE(n, spi_emul_init, NULL, &spi_emul_data_##n, &spi_emul_cfg_##n,       \
-			      POST_KERNEL, CONFIG_SPI_INIT_PRIORITY, &spi_emul_api);
+	SPI_DEVICE_DT_INST_DEFINE(n, spi_emul_init, NULL, &spi_emul_data_##n, &spi_emul_cfg_##n,   \
+				  POST_KERNEL, CONFIG_SPI_INIT_PRIORITY, &spi_emul_api);
 
 DT_INST_FOREACH_STATUS_OKAY(SPI_EMUL_INIT)

--- a/drivers/spi/spi_esp32_spim.c
+++ b/drivers/spi/spi_esp32_spim.c
@@ -559,7 +559,7 @@ static DEVICE_API(spi, spi_api) = {
 		.clock_source = SPI_CLK_SRC_DEFAULT,	\
 	};	\
 		\
-	DEVICE_DT_INST_DEFINE(idx, spi_esp32_init,	\
+	SPI_DEVICE_DT_INST_DEFINE(idx, spi_esp32_init,	\
 			      NULL, &spi_data_##idx,	\
 			      &spi_config_##idx, POST_KERNEL,	\
 			      CONFIG_SPI_INIT_PRIORITY, &spi_api);

--- a/drivers/spi/spi_gd32.c
+++ b/drivers/spi/spi_gd32.c
@@ -683,7 +683,7 @@ int spi_gd32_init(const struct device *dev)
 		IF_ENABLED(CONFIG_SPI_GD32_DMA, (.dma = DMAS_DECL(idx),))      \
 		IF_ENABLED(CONFIG_SPI_GD32_INTERRUPT,			       \
 			   (.irq_configure = spi_gd32_irq_configure_##idx)) }; \
-	DEVICE_DT_INST_DEFINE(idx, spi_gd32_init, NULL,			       \
+	SPI_DEVICE_DT_INST_DEFINE(idx, spi_gd32_init, NULL,			       \
 			      &spi_gd32_data_##idx, &spi_gd32_config_##idx,    \
 			      POST_KERNEL, CONFIG_SPI_INIT_PRIORITY,	       \
 			      &spi_gd32_driver_api);

--- a/drivers/spi/spi_gecko_eusart.c
+++ b/drivers/spi/spi_gecko_eusart.c
@@ -312,7 +312,7 @@ static DEVICE_API(spi, spi_gecko_eusart_api) = {
 		.clock_cfg = SILABS_DT_INST_CLOCK_CFG(n),                                      \
 		.clock_frequency = DT_INST_PROP_OR(n, clock_frequency, 1000000)                \
 	};                                                                                 \
-	DEVICE_DT_INST_DEFINE(n, spi_gecko_eusart_init, NULL, &spi_gecko_eusart_data_##n,  \
+	SPI_DEVICE_DT_INST_DEFINE(n, spi_gecko_eusart_init, NULL, &spi_gecko_eusart_data_##n,  \
 			      &spi_gecko_eusart_cfg_##n, POST_KERNEL, CONFIG_SPI_INIT_PRIORITY,    \
 			      &spi_gecko_eusart_api);
 

--- a/drivers/spi/spi_gecko_usart.c
+++ b/drivers/spi/spi_gecko_usart.c
@@ -443,7 +443,7 @@ static DEVICE_API(spi, spi_gecko_api) = {
 	    GET_GECKO_USART_CLOCK(n) \
 	    .clock_frequency = DT_INST_PROP_OR(n, clock_frequency, 1000000) \
 	}; \
-	DEVICE_DT_INST_DEFINE(n, \
+	SPI_DEVICE_DT_INST_DEFINE(n, \
 			spi_gecko_init, \
 			NULL, \
 			&spi_gecko_data_##n, \
@@ -476,7 +476,7 @@ static DEVICE_API(spi, spi_gecko_api) = {
 	    .loc_tx = DT_INST_PROP_BY_IDX(n, location_tx, 0), \
 	    .loc_clk = DT_INST_PROP_BY_IDX(n, location_clk, 0), \
 	}; \
-	DEVICE_DT_INST_DEFINE(n, \
+	SPI_DEVICE_DT_INST_DEFINE(n, \
 			spi_gecko_init, \
 			NULL, \
 			&spi_gecko_data_##n, \

--- a/drivers/spi/spi_grlib_spimctrl.c
+++ b/drivers/spi/spi_grlib_spimctrl.c
@@ -236,7 +236,7 @@ static DEVICE_API(spi, api) = {
 		SPI_CONTEXT_INIT_LOCK(data_##n, ctx),                   \
 		SPI_CONTEXT_INIT_SYNC(data_##n, ctx),                   \
 	};                                                              \
-	DEVICE_DT_INST_DEFINE(n,                                        \
+	SPI_DEVICE_DT_INST_DEFINE(n,                                        \
 			init,                                           \
 			NULL,                                           \
 			&data_##n,                                      \

--- a/drivers/spi/spi_ifx_cat1.c
+++ b/drivers/spi/spi_ifx_cat1.c
@@ -332,20 +332,21 @@ static int ifx_cat1_spi_init(const struct device *dev)
 		.reg_addr = (CySCB_Type *)DT_INST_REG_ADDR(n),                                     \
 		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),                                         \
 		.scb_spi_config =                                                                  \
-			{.spiMode = CY_SCB_SPI_MASTER,       /* overwrite by cfg  */               \
-			 .sclkMode = CY_SCB_SPI_CPHA0_CPOL0, /* overwrite by cfg  */               \
-			 .rxDataWidth = 8,                   /* overwrite by cfg  */               \
-			 .txDataWidth = 8,                   /* overwrite by cfg  */               \
-			 .enableMsbFirst = true,             /* overwrite by cfg  */               \
-			 .subMode = CY_SCB_SPI_MOTOROLA,                                           \
-			 .oversample = IFX_CAT1_SPI_DEFAULT_OVERSAMPLE,                            \
-			 .enableMisoLateSample = true,                                             \
-			 .ssPolarity = CY_SCB_SPI_ACTIVE_LOW,                                      \
-		},                                                                                 \
+			{                                                                          \
+				.spiMode = CY_SCB_SPI_MASTER,       /* overwrite by cfg  */        \
+				.sclkMode = CY_SCB_SPI_CPHA0_CPOL0, /* overwrite by cfg  */        \
+				.rxDataWidth = 8,                   /* overwrite by cfg  */        \
+				.txDataWidth = 8,                   /* overwrite by cfg  */        \
+				.enableMsbFirst = true,             /* overwrite by cfg  */        \
+				.subMode = CY_SCB_SPI_MOTOROLA,                                    \
+				.oversample = IFX_CAT1_SPI_DEFAULT_OVERSAMPLE,                     \
+				.enableMisoLateSample = true,                                      \
+				.ssPolarity = CY_SCB_SPI_ACTIVE_LOW,                               \
+			},                                                                         \
 		.irq_priority = DT_INST_IRQ(n, priority),                                          \
 	};                                                                                         \
-	DEVICE_DT_INST_DEFINE(n, ifx_cat1_spi_init, NULL, &spi_cat1_data_##n,                      \
-			      &spi_cat1_config_##n, POST_KERNEL,                                   \
-			      CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &ifx_cat1_spi_api);
+	SPI_DEVICE_DT_INST_DEFINE(n, ifx_cat1_spi_init, NULL, &spi_cat1_data_##n,                  \
+				  &spi_cat1_config_##n, POST_KERNEL,                               \
+				  CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &ifx_cat1_spi_api);
 
 DT_INST_FOREACH_STATUS_OKAY(IFX_CAT1_SPI_INIT)

--- a/drivers/spi/spi_litex.c
+++ b/drivers/spi/spi_litex.c
@@ -251,7 +251,7 @@ static DEVICE_API(spi, spi_litex_api) = {
 		.data_width = DT_INST_PROP(n, data_width),                                         \
 		.max_cs = DT_INST_PROP(n, max_cs),                                                 \
 	};                                                                                         \
-	DEVICE_DT_INST_DEFINE(n,                                                                   \
+	SPI_DEVICE_DT_INST_DEFINE(n,                                                               \
 			NULL,                                                                      \
 			NULL,                                                                      \
 			&spi_litex_data_##n,                                                       \

--- a/drivers/spi/spi_litex_litespi.c
+++ b/drivers/spi/spi_litex_litespi.c
@@ -271,7 +271,7 @@ static DEVICE_API(spi, spi_litex_api) = {
 		.phy_clk_divisor_addr = DT_INST_REG_ADDR_BY_NAME_OR(n, phy_clk_divisor, 0)         \
                                                                                                    \
 	};                                                                                         \
-	DEVICE_DT_INST_DEFINE(n, NULL, NULL, &spi_litex_data_##n, &spi_litex_cfg_##n, POST_KERNEL, \
-			      CONFIG_SPI_INIT_PRIORITY, &spi_litex_api);
+	SPI_DEVICE_DT_INST_DEFINE(n, NULL, NULL, &spi_litex_data_##n, &spi_litex_cfg_##n,          \
+				  POST_KERNEL, CONFIG_SPI_INIT_PRIORITY, &spi_litex_api);
 
 DT_INST_FOREACH_STATUS_OKAY(SPI_INIT)

--- a/drivers/spi/spi_ll_stm32.c
+++ b/drivers/spi/spi_ll_stm32.c
@@ -1396,7 +1396,7 @@ static struct spi_stm32_data spi_stm32_dev_data_##id = {		\
 									\
 PM_DEVICE_DT_INST_DEFINE(id, spi_stm32_pm_action);			\
 									\
-DEVICE_DT_INST_DEFINE(id, spi_stm32_init, PM_DEVICE_DT_INST_GET(id),	\
+SPI_DEVICE_DT_INST_DEFINE(id, spi_stm32_init, PM_DEVICE_DT_INST_GET(id),\
 		    &spi_stm32_dev_data_##id, &spi_stm32_cfg_##id,	\
 		    POST_KERNEL, CONFIG_SPI_INIT_PRIORITY,		\
 		    &api_funcs);					\

--- a/drivers/spi/spi_max32.c
+++ b/drivers/spi/spi_max32.c
@@ -965,7 +965,7 @@ static DEVICE_API(spi, spi_max32_api) = {
 		SPI_CONTEXT_INIT_SYNC(max32_spi_data_##_num, ctx),                                 \
 		SPI_CONTEXT_CS_GPIOS_INITIALIZE(DT_DRV_INST(_num), ctx)                            \
 		IF_ENABLED(CONFIG_SPI_RTIO, (.rtio_ctx = &max32_spi_rtio_##_num))};                \
-	DEVICE_DT_INST_DEFINE(_num, spi_max32_init, NULL, &max32_spi_data_##_num,                  \
+	SPI_DEVICE_DT_INST_DEFINE(_num, spi_max32_init, NULL, &max32_spi_data_##_num,              \
 			      &max32_spi_config_##_num, PRE_KERNEL_2, CONFIG_SPI_INIT_PRIORITY,    \
 			      &spi_max32_api);
 

--- a/drivers/spi/spi_mchp_mss.c
+++ b/drivers/spi/spi_mchp_mss.c
@@ -477,8 +477,8 @@ static DEVICE_API(spi, mss_spi_driver_api) = {
 		SPI_CONTEXT_INIT_SYNC(mss_spi_data_##n, ctx),                                      \
 	};                                                                                         \
                                                                                                    \
-	DEVICE_DT_INST_DEFINE(n, mss_spi_init_##n, NULL, &mss_spi_data_##n, &mss_spi_config_##n,   \
-			      POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,                     \
-			      &mss_spi_driver_api);
+	SPI_DEVICE_DT_INST_DEFINE(n, mss_spi_init_##n, NULL, &mss_spi_data_##n,                    \
+				  &mss_spi_config_##n, POST_KERNEL,                                \
+				  CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &mss_spi_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(MSS_SPI_INIT)

--- a/drivers/spi/spi_mchp_mss_qspi.c
+++ b/drivers/spi/spi_mchp_mss_qspi.c
@@ -580,33 +580,29 @@ static DEVICE_API(spi, mss_qspi_driver_api) = {
 	.release = mss_qspi_release,
 };
 
-#define MSS_QSPI_INIT(n)						\
-	static void mss_qspi_config_func_##n(const struct device *dev);	\
-									\
-	static const struct mss_qspi_config mss_qspi_config_##n = { \
-		.base = DT_INST_REG_ADDR(n),				\
-		.irq_config_func = mss_qspi_config_func_##n,	\
-		.clock_freq = DT_INST_PROP(n, clock_frequency),	\
-	};								\
-									\
-	static struct mss_qspi_data mss_qspi_data_##n = {	\
-		SPI_CONTEXT_INIT_LOCK(mss_qspi_data_##n, ctx),	\
-		SPI_CONTEXT_INIT_SYNC(mss_qspi_data_##n, ctx),	\
-	};								\
-									\
-	DEVICE_DT_INST_DEFINE(n, mss_qspi_init,				\
-			    NULL,					\
-			    &mss_qspi_data_##n,			\
-			    &mss_qspi_config_##n, POST_KERNEL,	\
-			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
-			    &mss_qspi_driver_api);			\
-									\
-	static void mss_qspi_config_func_##n(const struct device *dev)	\
-	{								\
-		IRQ_CONNECT(DT_INST_IRQN(n), DT_INST_IRQ(n, priority),	\
-			    mss_qspi_interrupt,				\
-			    DEVICE_DT_INST_GET(n), 0);			\
-		irq_enable(DT_INST_IRQN(n));				\
+#define MSS_QSPI_INIT(n)                                                                           \
+	static void mss_qspi_config_func_##n(const struct device *dev);                            \
+                                                                                                   \
+	static const struct mss_qspi_config mss_qspi_config_##n = {                                \
+		.base = DT_INST_REG_ADDR(n),                                                       \
+		.irq_config_func = mss_qspi_config_func_##n,                                       \
+		.clock_freq = DT_INST_PROP(n, clock_frequency),                                    \
+	};                                                                                         \
+                                                                                                   \
+	static struct mss_qspi_data mss_qspi_data_##n = {                                          \
+		SPI_CONTEXT_INIT_LOCK(mss_qspi_data_##n, ctx),                                     \
+		SPI_CONTEXT_INIT_SYNC(mss_qspi_data_##n, ctx),                                     \
+	};                                                                                         \
+                                                                                                   \
+	SPI_DEVICE_DT_INST_DEFINE(n, mss_qspi_init, NULL, &mss_qspi_data_##n,                      \
+				  &mss_qspi_config_##n, POST_KERNEL,                               \
+				  CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &mss_qspi_driver_api);       \
+                                                                                                   \
+	static void mss_qspi_config_func_##n(const struct device *dev)                             \
+	{                                                                                          \
+		IRQ_CONNECT(DT_INST_IRQN(n), DT_INST_IRQ(n, priority), mss_qspi_interrupt,         \
+			    DEVICE_DT_INST_GET(n), 0);                                             \
+		irq_enable(DT_INST_IRQN(n));                                                       \
 	}
 
 DT_INST_FOREACH_STATUS_OKAY(MSS_QSPI_INIT)

--- a/drivers/spi/spi_mcux_dspi.c
+++ b/drivers/spi/spi_mcux_dspi.c
@@ -906,23 +906,23 @@ static DEVICE_API(spi, spi_mcux_driver_api) = {
 		    DT_INST_PROP_OR(id, ctar, 0),			\
 		.samplePoint =						\
 		    DT_INST_PROP_OR(id, sample_point, 0),		\
-		.enable_continuous_sck =					\
+		.enable_continuous_sck =				\
 		    DT_INST_PROP(id, continuous_sck),			\
 		.enable_rxfifo_overwrite =				\
 		    DT_INST_PROP(id, rx_fifo_overwrite),		\
-		.enable_modified_timing_format =				\
+		.enable_modified_timing_format =			\
 		    DT_INST_PROP(id, modified_timing_format),		\
 		.is_dma_chn_shared =					\
 		    DT_INST_PROP(id, nxp_rx_tx_chn_share),		\
 		.pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(id),		\
 	};								\
-	DEVICE_DT_INST_DEFINE(id,					\
+	SPI_DEVICE_DT_INST_DEFINE(id,					\
 			    spi_mcux_init,				\
 			    NULL,					\
 			    &spi_mcux_data_##id,			\
 			    &spi_mcux_config_##id,			\
 			    POST_KERNEL,				\
-			    CONFIG_SPI_INIT_PRIORITY,		\
+			    CONFIG_SPI_INIT_PRIORITY,			\
 			    &spi_mcux_driver_api);			\
 	static void spi_mcux_config_func_##id(const struct device *dev)	\
 	{								\

--- a/drivers/spi/spi_mcux_ecspi.c
+++ b/drivers/spi/spi_mcux_ecspi.c
@@ -331,7 +331,7 @@ static DEVICE_API(spi, spi_mcux_driver_api) = {
 		SPI_CONTEXT_CS_GPIOS_INITIALIZE(DT_DRV_INST(n), ctx)				\
 	};											\
 												\
-	DEVICE_DT_INST_DEFINE(n, spi_mcux_init, NULL,						\
+	SPI_DEVICE_DT_INST_DEFINE(n, spi_mcux_init, NULL,					\
 			      &spi_mcux_data_##n, &spi_mcux_config_##n,				\
 			      POST_KERNEL, CONFIG_SPI_INIT_PRIORITY,				\
 			      &spi_mcux_driver_api);						\

--- a/drivers/spi/spi_mcux_flexcomm.c
+++ b/drivers/spi/spi_mcux_flexcomm.c
@@ -901,7 +901,7 @@ static void spi_mcux_config_func_##id(const struct device *dev) \
 		SPI_CONTEXT_CS_GPIOS_INITIALIZE(DT_DRV_INST(id), ctx)	\
 		SPI_DMA_CHANNELS(id)		\
 	};								\
-	DEVICE_DT_INST_DEFINE(id,					\
+	SPI_DEVICE_DT_INST_DEFINE(id,					\
 			    spi_mcux_init,				\
 			    NULL,					\
 			    &spi_mcux_data_##id,			\

--- a/drivers/spi/spi_mcux_flexio.c
+++ b/drivers/spi/spi_mcux_flexio.c
@@ -439,7 +439,7 @@ static DEVICE_API(spi, spi_mcux_driver_api) = {
 		SPI_CONTEXT_CS_GPIOS_INITIALIZE(DT_DRV_INST(n), ctx)	\
 	};								\
 									\
-	DEVICE_DT_INST_DEFINE(n, spi_mcux_init, NULL,			\
+	SPI_DEVICE_DT_INST_DEFINE(n, spi_mcux_init, NULL,		\
 				&spi_mcux_flexio_data_##n,		\
 				&spi_mcux_flexio_config_##n, POST_KERNEL, \
 				CONFIG_SPI_INIT_PRIORITY,		\

--- a/drivers/spi/spi_mcux_lpspi.c
+++ b/drivers/spi/spi_mcux_lpspi.c
@@ -850,7 +850,7 @@ static int spi_mcux_init(const struct device *dev)
 			IF_ENABLED(CONFIG_SPI_RTIO, (.rtio_ctx = &spi_mcux_rtio_##n,))             \
 	};                                                                                         \
                                                                                                    \
-	DEVICE_DT_INST_DEFINE(n, spi_mcux_init, NULL, &spi_mcux_data_##n, &spi_mcux_config_##n,    \
+	SPI_DEVICE_DT_INST_DEFINE(n, spi_mcux_init, NULL, &spi_mcux_data_##n, &spi_mcux_config_##n,\
 			      POST_KERNEL, CONFIG_SPI_INIT_PRIORITY, &spi_mcux_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(SPI_MCUX_LPSPI_INIT)

--- a/drivers/spi/spi_npcx_spip.c
+++ b/drivers/spi/spi_npcx_spip.c
@@ -443,7 +443,7 @@ static DEVICE_API(spi, spi_npcx_spip_api) = {
 		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),                                         \
 		NPCX_SPIP_IRQ_HANDLER_FUNC(n)};                                                    \
                                                                                                    \
-	DEVICE_DT_INST_DEFINE(n, spi_npcx_spip_init, NULL, &spi_npcx_spip_data_##n,                \
+	SPI_DEVICE_DT_INST_DEFINE(n, spi_npcx_spip_init, NULL, &spi_npcx_spip_data_##n,            \
 			      &spi_npcx_spip_cfg_##n, POST_KERNEL, CONFIG_SPI_INIT_PRIORITY,       \
 			      &spi_npcx_spip_api);
 

--- a/drivers/spi/spi_nrfx_spi.c
+++ b/drivers/spi/spi_nrfx_spi.c
@@ -456,7 +456,7 @@ static int spi_nrfx_init(const struct device *dev)
 		     !(DT_GPIO_FLAGS(SPI(idx), wake_gpios) & GPIO_ACTIVE_LOW), \
 		     "WAKE line must be configured as active high");	       \
 	PM_DEVICE_DT_DEFINE(SPI(idx), spi_nrfx_pm_action);		       \
-	DEVICE_DT_DEFINE(SPI(idx),					       \
+	SPI_DEVICE_DT_DEFINE(SPI(idx),					       \
 		      spi_nrfx_init,					       \
 		      PM_DEVICE_DT_GET(SPI(idx)),			       \
 		      &spi_##idx##_data,				       \

--- a/drivers/spi/spi_nrfx_spim.c
+++ b/drivers/spi/spi_nrfx_spim.c
@@ -741,7 +741,7 @@ static int spi_nrfx_init(const struct device *dev)
 		     !(DT_GPIO_FLAGS(SPIM(idx), wake_gpios) & GPIO_ACTIVE_LOW),\
 		     "WAKE line must be configured as active high");	       \
 	PM_DEVICE_DT_DEFINE(SPIM(idx), spim_nrfx_pm_action);		       \
-	DEVICE_DT_DEFINE(SPIM(idx),					       \
+	SPI_DEVICE_DT_DEFINE(SPIM(idx),					       \
 		      spi_nrfx_init,					       \
 		      PM_DEVICE_DT_GET(SPIM(idx)),			       \
 		      &spi_##idx##_data,				       \

--- a/drivers/spi/spi_nrfx_spis.c
+++ b/drivers/spi/spi_nrfx_spis.c
@@ -394,7 +394,7 @@ static int spi_nrfx_init(const struct device *dev)
 	BUILD_ASSERT(!DT_NODE_HAS_PROP(SPIS(idx), wake_gpios) ||	       \
 		     !(DT_GPIO_FLAGS(SPIS(idx), wake_gpios) & GPIO_ACTIVE_LOW),\
 		     "WAKE line must be configured as active high");	       \
-	DEVICE_DT_DEFINE(SPIS(idx),					       \
+	SPI_DEVICE_DT_DEFINE(SPIS(idx),					       \
 			    spi_nrfx_init,				       \
 			    NULL,					       \
 			    &spi_##idx##_data,				       \

--- a/drivers/spi/spi_numaker.c
+++ b/drivers/spi/spi_numaker.c
@@ -360,7 +360,7 @@ done:
 		.clk_dev = DEVICE_DT_GET(DT_PARENT(DT_INST_CLOCKS_CTLR(inst))),                    \
 		.pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(inst),                                    \
 	};                                                                                         \
-	DEVICE_DT_INST_DEFINE(inst, spi_numaker_init, NULL, &spi_numaker_data_##inst,              \
+	SPI_DEVICE_DT_INST_DEFINE(inst, spi_numaker_init, NULL, &spi_numaker_data_##inst,          \
 			      &spi_numaker_config_##inst, POST_KERNEL, CONFIG_SPI_INIT_PRIORITY,   \
 			      &spi_numaker_driver_api);
 

--- a/drivers/spi/spi_nxp_s32.c
+++ b/drivers/spi/spi_nxp_s32.c
@@ -703,7 +703,7 @@ static DEVICE_API(spi, spi_nxp_s32_driver_api) = {
 		SPI_CONTEXT_INIT_SYNC(spi_nxp_s32_data_##n, ctx),			\
 		SPI_CONTEXT_CS_GPIOS_INITIALIZE(DT_DRV_INST(n), ctx)			\
 	};										\
-	DEVICE_DT_INST_DEFINE(n,							\
+	SPI_DEVICE_DT_INST_DEFINE(n,							\
 			spi_nxp_s32_init, NULL,						\
 			&spi_nxp_s32_data_##n, &spi_nxp_s32_config_##n,			\
 			POST_KERNEL, CONFIG_SPI_INIT_PRIORITY,				\

--- a/drivers/spi/spi_oc_simple.c
+++ b/drivers/spi/spi_oc_simple.c
@@ -231,7 +231,7 @@ int spi_oc_simple_init(const struct device *dev)
 		SPI_CONTEXT_CS_GPIOS_INITIALIZE(DT_DRV_INST(inst), ctx) \
 	};								\
 									\
-	DEVICE_DT_INST_DEFINE(inst,					\
+	SPI_DEVICE_DT_INST_DEFINE(inst,					\
 			    spi_oc_simple_init,				\
 			    NULL,					\
 			    &spi_oc_simple_data_##inst,			\

--- a/drivers/spi/spi_opentitan.c
+++ b/drivers/spi/spi_opentitan.c
@@ -323,7 +323,7 @@ static DEVICE_API(spi, spi_opentitan_api) = {
 		.base = DT_INST_REG_ADDR(n), \
 		.f_input = DT_INST_PROP(n, clock_frequency), \
 	}; \
-	DEVICE_DT_INST_DEFINE(n, \
+	SPI_DEVICE_DT_INST_DEFINE(n, \
 			spi_opentitan_init, \
 			NULL, \
 			&spi_opentitan_data_##n, \

--- a/drivers/spi/spi_pl022.c
+++ b/drivers/spi/spi_pl022.c
@@ -1031,7 +1031,7 @@ static int spi_pl022_init(const struct device *dev)
 				(.dma_enabled = false,))                                           \
 		IF_ENABLED(CONFIG_SPI_PL022_INTERRUPT,                                             \
 					   (.irq_config = spi_pl022_irq_config_##idx,))};          \
-	DEVICE_DT_INST_DEFINE(idx, spi_pl022_init, NULL, &spi_pl022_data_##idx,                    \
+	SPI_DEVICE_DT_INST_DEFINE(idx, spi_pl022_init, NULL, &spi_pl022_data_##idx,                \
 			      &spi_pl022_cfg_##idx, POST_KERNEL, CONFIG_SPI_INIT_PRIORITY,         \
 			      &spi_pl022_api);
 

--- a/drivers/spi/spi_psoc6.c
+++ b/drivers/spi/spi_psoc6.c
@@ -430,7 +430,7 @@ static DEVICE_API(spi, spi_psoc6_driver_api) = {
 		SPI_CONTEXT_INIT_SYNC(spi_psoc6_dev_data_##n, ctx),	\
 		SPI_CONTEXT_CS_GPIOS_INITIALIZE(DT_DRV_INST(n), ctx)	\
 	};								\
-	DEVICE_DT_INST_DEFINE(n, spi_psoc6_init, NULL,			\
+	SPI_DEVICE_DT_INST_DEFINE(n, spi_psoc6_init, NULL,		\
 			      &spi_psoc6_dev_data_##n,			\
 			      &spi_psoc6_config_##n, POST_KERNEL,	\
 			      CONFIG_SPI_INIT_PRIORITY,			\

--- a/drivers/spi/spi_pw.c
+++ b/drivers/spi/spi_pw.c
@@ -871,7 +871,7 @@ static int spi_pw_init(const struct device *dev)
 		.clock_freq = DT_INST_PROP(n, clock_frequency),	     \
 		INIT_PCIE(n)					     \
 	};							     \
-	DEVICE_DT_INST_DEFINE(n, spi_pw_init, NULL,		     \
+	SPI_DEVICE_DT_INST_DEFINE(n, spi_pw_init, NULL,		     \
 			      &spi_##n##_data, &spi_##n##_config,    \
 			      POST_KERNEL, CONFIG_SPI_INIT_PRIORITY, \
 			      &pw_spi_api);
@@ -891,7 +891,7 @@ static int spi_pw_init(const struct device *dev)
 		.clock_freq = DT_INST_PROP(n, clock_frequency),	     \
 		INIT_PCIE(n)					     \
 	};							     \
-	DEVICE_DT_INST_DEFINE(n, spi_pw_init, NULL,		     \
+	SPI_DEVICE_DT_INST_DEFINE(n, spi_pw_init, NULL,		     \
 			      &spi_##n##_data, &spi_##n##_config,    \
 			      POST_KERNEL, CONFIG_SPI_INIT_PRIORITY, \
 			      &pw_spi_api);

--- a/drivers/spi/spi_rpi_pico_pio.c
+++ b/drivers/spi/spi_rpi_pico_pio.c
@@ -759,7 +759,7 @@ int spi_pico_pio_init(const struct device *dev)
 		SPI_CONTEXT_INIT_LOCK(spi_pico_pio_data_##inst, spi_ctx),                          \
 		SPI_CONTEXT_INIT_SYNC(spi_pico_pio_data_##inst, spi_ctx),                          \
 		SPI_CONTEXT_CS_GPIOS_INITIALIZE(DT_DRV_INST(inst), spi_ctx)};                      \
-	DEVICE_DT_INST_DEFINE(inst, spi_pico_pio_init, NULL, &spi_pico_pio_data_##inst,            \
+	SPI_DEVICE_DT_INST_DEFINE(inst, spi_pico_pio_init, NULL, &spi_pico_pio_data_##inst,        \
 			      &spi_pico_pio_config_##inst, POST_KERNEL, CONFIG_SPI_INIT_PRIORITY,  \
 			      &spi_pico_pio_api);                                                  \
 	BUILD_ASSERT(DT_INST_NODE_HAS_PROP(inst, clk_gpios), "Missing clock GPIO");                \

--- a/drivers/spi/spi_rv32m1_lpspi.c
+++ b/drivers/spi/spi_rv32m1_lpspi.c
@@ -330,7 +330,7 @@ static DEVICE_API(spi, spi_mcux_driver_api) = {
 		SPI_CONTEXT_CS_GPIOS_INITIALIZE(DT_DRV_INST(n), ctx)	\
 	};								\
 									\
-	DEVICE_DT_INST_DEFINE(n, spi_mcux_init, NULL,			\
+	SPI_DEVICE_DT_INST_DEFINE(n, spi_mcux_init, NULL,		\
 			    &spi_mcux_data_##n,				\
 			    &spi_mcux_config_##n,			\
 			    POST_KERNEL,				\

--- a/drivers/spi/spi_sam.c
+++ b/drivers/spi/spi_sam.c
@@ -890,7 +890,7 @@ static DEVICE_API(spi, spi_sam_driver_api) = {
 		SPI_CONTEXT_CS_GPIOS_INITIALIZE(DT_DRV_INST(n), ctx)				\
 		IF_ENABLED(CONFIG_SPI_RTIO, (.rtio_ctx = &spi_sam_rtio_##n))			\
 	};											\
-	DEVICE_DT_INST_DEFINE(n, &spi_sam_init, NULL,						\
+	SPI_DEVICE_DT_INST_DEFINE(n, &spi_sam_init, NULL,					\
 			    &spi_sam_dev_data_##n,						\
 			    &spi_sam_config_##n, POST_KERNEL,					\
 			    CONFIG_SPI_INIT_PRIORITY, &spi_sam_driver_api);

--- a/drivers/spi/spi_sam0.c
+++ b/drivers/spi/spi_sam0.c
@@ -748,7 +748,7 @@ static const struct spi_sam0_config spi_sam0_config_##n = {		\
 		SPI_CONTEXT_INIT_SYNC(spi_sam0_dev_data_##n, ctx),	\
 		SPI_CONTEXT_CS_GPIOS_INITIALIZE(DT_DRV_INST(n), ctx)	\
 	};								\
-	DEVICE_DT_INST_DEFINE(n, spi_sam0_init, NULL,			\
+	SPI_DEVICE_DT_INST_DEFINE(n, spi_sam0_init, NULL,		\
 			    &spi_sam0_dev_data_##n,			\
 			    &spi_sam0_config_##n, POST_KERNEL,		\
 			    CONFIG_SPI_INIT_PRIORITY,			\

--- a/drivers/spi/spi_sedi.c
+++ b/drivers/spi/spi_sedi.c
@@ -407,7 +407,7 @@ static int spi_sedi_device_ctrl(const struct device *dev,
 		.spi_device = num, .irq_config = spi_##num##_irq_init,         \
 	};								       \
 	PM_DEVICE_DEFINE(spi_##num, spi_sedi_device_ctrl);		       \
-	DEVICE_DT_INST_DEFINE(num,					       \
+	SPI_DEVICE_DT_INST_DEFINE(num,					       \
 			      spi_sedi_init,				       \
 			      PM_DEVICE_GET(spi_##num),		               \
 			      &spi_##num##_data,			       \

--- a/drivers/spi/spi_sifive.c
+++ b/drivers/spi/spi_sifive.c
@@ -292,7 +292,7 @@ static DEVICE_API(spi, spi_sifive_api) = {
 		.f_sys = SIFIVE_PERIPHERAL_CLOCK_FREQUENCY, \
 		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n), \
 	}; \
-	DEVICE_DT_INST_DEFINE(n, \
+	SPI_DEVICE_DT_INST_DEFINE(n, \
 			spi_sifive_init, \
 			NULL, \
 			&spi_sifive_data_##n, \

--- a/drivers/spi/spi_smartbond.c
+++ b/drivers/spi/spi_smartbond.c
@@ -1328,7 +1328,7 @@ static int spi_smartbond_init(const struct device *dev)
 		SPI_CONTEXT_INIT_SYNC(spi_smartbond_##id##_data, ctx),                             \
 		SPI_CONTEXT_CS_GPIOS_INITIALIZE(DT_DRV_INST(id), ctx)};                            \
 	PM_DEVICE_DT_INST_DEFINE(id, spi_smartbond_pm_action);                                     \
-	DEVICE_DT_INST_DEFINE(id,                                                                  \
+	SPI_DEVICE_DT_INST_DEFINE(id,                                                              \
 			      spi_smartbond_init,                                                  \
 			      PM_DEVICE_DT_INST_GET(id),                                           \
 			      &spi_smartbond_##id##_data,                                          \

--- a/drivers/spi/spi_test.c
+++ b/drivers/spi/spi_test.c
@@ -52,9 +52,8 @@ static DEVICE_API(spi, vnd_spi_api) = {
 	.release = vnd_spi_release,
 };
 
-#define VND_SPI_INIT(n)							\
-	DEVICE_DT_INST_DEFINE(n, NULL, NULL, NULL, NULL, POST_KERNEL,	\
-			      CONFIG_SPI_INIT_PRIORITY,			\
-			      &vnd_spi_api);
+#define VND_SPI_INIT(n)                                                                            \
+	SPI_DEVICE_DT_INST_DEFINE(n, NULL, NULL, NULL, NULL, POST_KERNEL,                          \
+				  CONFIG_SPI_INIT_PRIORITY, &vnd_spi_api);
 
 DT_INST_FOREACH_STATUS_OKAY(VND_SPI_INIT)

--- a/drivers/spi/spi_xec_qmspi.c
+++ b/drivers/spi/spi_xec_qmspi.c
@@ -703,7 +703,7 @@ static struct spi_qmspi_data spi_qmspi_0_dev_data = {
 	SPI_CONTEXT_CS_GPIOS_INITIALIZE(DT_DRV_INST(0), ctx)
 };
 
-DEVICE_DT_INST_DEFINE(0,
+SPI_DEVICE_DT_INST_DEFINE(0,
 		    qmspi_init, NULL, &spi_qmspi_0_dev_data,
 		    &spi_qmspi_0_config, POST_KERNEL,
 		    CONFIG_SPI_INIT_PRIORITY, &spi_qmspi_driver_api);

--- a/drivers/spi/spi_xec_qmspi_ldma.c
+++ b/drivers/spi/spi_xec_qmspi_ldma.c
@@ -1071,7 +1071,7 @@ static DEVICE_API(spi, spi_qmspi_xec_driver_api) = {
 		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(i),		\
 	};								\
 	PM_DEVICE_DT_INST_DEFINE(i, qmspi_xec_pm_action);		\
-	DEVICE_DT_INST_DEFINE(i, qmspi_xec_init,			\
+	SPI_DEVICE_DT_INST_DEFINE(i, qmspi_xec_init,			\
 		PM_DEVICE_DT_INST_GET(i),				\
 		&qmspi_xec_data_##i, &qmspi_xec_config_##i,		\
 		POST_KERNEL, CONFIG_SPI_INIT_PRIORITY,			\

--- a/drivers/spi/spi_xlnx_axi_quadspi.c
+++ b/drivers/spi/spi_xlnx_axi_quadspi.c
@@ -601,38 +601,31 @@ static DEVICE_API(spi, xlnx_quadspi_driver_api) = {
 #define STARTUP_BLOCK_INIT(n)
 #endif
 
-#define XLNX_QUADSPI_INIT(n)						\
-	static void xlnx_quadspi_config_func_##n(const struct device *dev);	\
-									\
-	static const struct xlnx_quadspi_config xlnx_quadspi_config_##n = { \
-		.base = DT_INST_REG_ADDR(n),				\
-		.irq_config_func = xlnx_quadspi_config_func_##n,	\
-		.num_ss_bits = DT_INST_PROP(n, xlnx_num_ss_bits),	\
-		.num_xfer_bytes =					\
-			DT_INST_PROP(n, xlnx_num_transfer_bits) / 8,	\
-		.fifo_size = DT_INST_PROP_OR(n, fifo_size, 0),		\
-		STARTUP_BLOCK_INIT(n)					\
-	};								\
-									\
-	static struct xlnx_quadspi_data xlnx_quadspi_data_##n = {	\
-		SPI_CONTEXT_INIT_LOCK(xlnx_quadspi_data_##n, ctx),	\
-		SPI_CONTEXT_INIT_SYNC(xlnx_quadspi_data_##n, ctx),	\
-		SPI_CONTEXT_CS_GPIOS_INITIALIZE(DT_DRV_INST(n), ctx)	\
-	};								\
-									\
-	DEVICE_DT_INST_DEFINE(n, &xlnx_quadspi_init,			\
-			    NULL,					\
-			    &xlnx_quadspi_data_##n,			\
-			    &xlnx_quadspi_config_##n, POST_KERNEL,	\
-			    CONFIG_SPI_INIT_PRIORITY,			\
-			    &xlnx_quadspi_driver_api);			\
-									\
-	static void xlnx_quadspi_config_func_##n(const struct device *dev)	\
-	{								\
-		IRQ_CONNECT(DT_INST_IRQN(n), DT_INST_IRQ(n, priority),	\
-			    xlnx_quadspi_isr,				\
-			    DEVICE_DT_INST_GET(n), 0);			\
-		irq_enable(DT_INST_IRQN(n));				\
+#define XLNX_QUADSPI_INIT(n)                                                                       \
+	static void xlnx_quadspi_config_func_##n(const struct device *dev);                        \
+                                                                                                   \
+	static const struct xlnx_quadspi_config xlnx_quadspi_config_##n = {                        \
+		.base = DT_INST_REG_ADDR(n),                                                       \
+		.irq_config_func = xlnx_quadspi_config_func_##n,                                   \
+		.num_ss_bits = DT_INST_PROP(n, xlnx_num_ss_bits),                                  \
+		.num_xfer_bytes = DT_INST_PROP(n, xlnx_num_transfer_bits) / 8,                     \
+		.fifo_size = DT_INST_PROP_OR(n, fifo_size, 0),                                     \
+		STARTUP_BLOCK_INIT(n)};                                                            \
+                                                                                                   \
+	static struct xlnx_quadspi_data xlnx_quadspi_data_##n = {                                  \
+		SPI_CONTEXT_INIT_LOCK(xlnx_quadspi_data_##n, ctx),                                 \
+		SPI_CONTEXT_INIT_SYNC(xlnx_quadspi_data_##n, ctx),                                 \
+		SPI_CONTEXT_CS_GPIOS_INITIALIZE(DT_DRV_INST(n), ctx)};                             \
+                                                                                                   \
+	SPI_DEVICE_DT_INST_DEFINE(n, &xlnx_quadspi_init, NULL, &xlnx_quadspi_data_##n,             \
+				  &xlnx_quadspi_config_##n, POST_KERNEL, CONFIG_SPI_INIT_PRIORITY, \
+				  &xlnx_quadspi_driver_api);                                       \
+                                                                                                   \
+	static void xlnx_quadspi_config_func_##n(const struct device *dev)                         \
+	{                                                                                          \
+		IRQ_CONNECT(DT_INST_IRQN(n), DT_INST_IRQ(n, priority), xlnx_quadspi_isr,           \
+			    DEVICE_DT_INST_GET(n), 0);                                             \
+		irq_enable(DT_INST_IRQN(n));                                                       \
 	}
 
 DT_INST_FOREACH_STATUS_OKAY(XLNX_QUADSPI_INIT)

--- a/drivers/spi/spi_xmc4xxx.c
+++ b/drivers/spi/spi_xmc4xxx.c
@@ -679,17 +679,16 @@ static DEVICE_API(spi, spi_xmc4xxx_driver_api) = {
 			SPI_CONTEXT_INIT_LOCK(xmc4xxx_data_##index, ctx),                          \
 		SPI_CONTEXT_INIT_SYNC(xmc4xxx_data_##index, ctx),                                  \
 		SPI_DMA_CHANNEL(index, tx, MEMORY_TO_PERIPHERAL, 8, 1)                             \
-		SPI_DMA_CHANNEL(index, rx, PERIPHERAL_TO_MEMORY, 1, 8)};                           \
+			SPI_DMA_CHANNEL(index, rx, PERIPHERAL_TO_MEMORY, 1, 8)};                   \
                                                                                                    \
 	static const struct spi_xmc4xxx_config xmc4xxx_config_##index = {                          \
 		.spi = (XMC_USIC_CH_t *)DT_INST_REG_ADDR(index),                                   \
 		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(index),                                     \
 		.miso_src = DT_INST_ENUM_IDX(index, miso_src),                                     \
-		XMC4XXX_IRQ_HANDLER_STRUCT_INIT(index)                                             \
-		XMC4XXX_IRQ_DMA_STRUCT_INIT(index)};                                               \
+		XMC4XXX_IRQ_HANDLER_STRUCT_INIT(index) XMC4XXX_IRQ_DMA_STRUCT_INIT(index)};        \
                                                                                                    \
-	DEVICE_DT_INST_DEFINE(index, spi_xmc4xxx_init, NULL, &xmc4xxx_data_##index,                \
-			      &xmc4xxx_config_##index, POST_KERNEL,                                \
-			      CONFIG_SPI_INIT_PRIORITY, &spi_xmc4xxx_driver_api);
+	SPI_DEVICE_DT_INST_DEFINE(index, spi_xmc4xxx_init, NULL, &xmc4xxx_data_##index,            \
+				  &xmc4xxx_config_##index, POST_KERNEL, CONFIG_SPI_INIT_PRIORITY,  \
+				  &spi_xmc4xxx_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(XMC4XXX_INIT)

--- a/include/zephyr/drivers/spi.h
+++ b/include/zephyr/drivers/spi.h
@@ -628,6 +628,17 @@ static inline void spi_transceive_stats(const struct device *dev, int error,
 #endif /*CONFIG_SPI_STATS*/
 
 /**
+ * @brief Like SPI_DEVICE_DT_DEFINE(), but uses an instance of a `DT_DRV_COMPAT`
+ * compatible instead of a node identifier.
+ *
+ * @param inst Instance number. The `node_id` argument to SPI_DEVICE_DT_DEFINE() is
+ * set to `DT_DRV_INST(inst)`.
+ * @param ... Other parameters as expected by SPI_DEVICE_DT_DEFINE().
+ */
+#define SPI_DEVICE_DT_INST_DEFINE(inst, ...)                                       \
+	SPI_DEVICE_DT_DEFINE(DT_DRV_INST(inst), __VA_ARGS__)
+
+/**
  * @typedef spi_api_io
  * @brief Callback API for I/O
  * See spi_transceive() for argument descriptions


### PR DESCRIPTION
If CONFIG_SPI_STATS is enabled, the device state for all SPI controller drivers must contain the SPI stats. This space is allocated by calling Z_SPI_INIT_FN as part of the device definition; this is done automatically when using SPI_DEVICE_DT_DEFINE instead of DEVICE_DT_DEFINE. If space for statistics is not properly allocated but CONFIG_SPI_STATS is enabled, an unexpected write to memory outside of the stats region may occur on a SPI transfer. This commit uses SPI_DEVICE_DT_DEFINE or SPI_DEVICE_DT_INST_DEFINE for all in-tree SPI controller drivers.