### PR TITLE
drivers: i2c: Call correct I2C device definition macros

### DIFF
--- a/drivers/i2c/gpio_i2c_switch.c
+++ b/drivers/i2c/gpio_i2c_switch.c
@@ -91,7 +91,7 @@ static int gpio_i2c_switch_init(const struct device *dev)
 		.gpio = GPIO_DT_SPEC_GET(DT_DRV_INST(inst), gpios),                                \
 	};                                                                                         \
                                                                                                    \
-	DEVICE_DT_INST_DEFINE(inst, gpio_i2c_switch_init, device_pm_control_nop,                   \
+	I2C_DEVICE_DT_INST_DEFINE(inst, gpio_i2c_switch_init, device_pm_control_nop,               \
 			      &gpio_i2c_switch_dev_data_##inst, &gpio_i2c_switch_dev_cfg_##inst,   \
 			      POST_KERNEL, CONFIG_I2C_INIT_PRIORITY, &gpio_i2c_switch_api_funcs);
 

--- a/drivers/i2c/i2c_ene_kb1200.c
+++ b/drivers/i2c/i2c_ene_kb1200.c
@@ -352,7 +352,7 @@ static int i2c_kb1200_init(const struct device *dev)
 		.fsmbm = (struct fsmbm_regs *)DT_INST_REG_ADDR(inst),                              \
 		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(inst),                                      \
 	};                                                                                         \
-	DEVICE_DT_INST_DEFINE(inst, &i2c_kb1200_init, NULL, &i2c_kb1200_data_##inst,               \
+	I2C_DEVICE_DT_INST_DEFINE(inst, &i2c_kb1200_init, NULL, &i2c_kb1200_data_##inst,           \
 			      &i2c_kb1200_config_##inst, PRE_KERNEL_1,                             \
 			      CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &i2c_kb1200_api);
 

--- a/drivers/i2c/i2c_mchp_mss.c
+++ b/drivers/i2c/i2c_mchp_mss.c
@@ -382,7 +382,8 @@ static void mss_i2c_irq_handler(const struct device *dev)
 		.clock_freq = DT_INST_PROP(n, clock_frequency),                                    \
 	};                                                                                         \
                                                                                                    \
-	DEVICE_DT_INST_DEFINE(n, mss_i2c_init_##n, NULL, &mss_i2c_data_##n, &mss_i2c_config_##n,   \
-			      PRE_KERNEL_1, CONFIG_I2C_INIT_PRIORITY, &mss_i2c_driver_api);
+	I2C_DEVICE_DT_INST_DEFINE(n, mss_i2c_init_##n, NULL, &mss_i2c_data_##n,                    \
+			&mss_i2c_config_##n, PRE_KERNEL_1, CONFIG_I2C_INIT_PRIORITY,               \
+			&mss_i2c_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(MSS_I2C_INIT)

--- a/drivers/i2c/i2c_sc18im704.c
+++ b/drivers/i2c/i2c_sc18im704.c
@@ -340,7 +340,7 @@ static const struct i2c_driver_api i2c_sc18im_driver_api = {
 		.i2c_config = I2C_MODE_CONTROLLER | (I2C_SPEED_STANDARD << I2C_SPEED_SHIFT),	\
 	};											\
 												\
-	DEVICE_DT_INST_DEFINE(n, i2c_sc18im_init, NULL,						\
+	I2C_DEVICE_DT_INST_DEFINE(n, i2c_sc18im_init, NULL,					\
 			      &i2c_sc18im_data_##n, &i2c_sc18im_config_##n,			\
 			      POST_KERNEL, CONFIG_I2C_SC18IM704_INIT_PRIORITY,			\
 			      &i2c_sc18im_driver_api);


### PR DESCRIPTION
If CONFIG_I2C_STATS is enabled, the device state for all I2C controller drivers must contain the I2C stats. This space is allocated by calling Z_I2C_INIT_FN as part of the device definition; this is done automatically when using I2C_DEVICE_DT_DEFINE instead of DEVICE_DT_DEFINE. If space for statistics is not properly allocated but CONFIG_I2C_STATS is enabled, an unexpected write to memory outside of the stats region may occur on an I2C transfer. This commit uses I2C_DEVICE_DT_DEFINE or I2C_DEVICE_DT_INST_DEFINE for all in-tree I2C controller drivers that do not already.