### PR TITLE
drivers: spi: smbus: allow NULL init function

### DIFF
--- a/include/zephyr/drivers/smbus.h
+++ b/include/zephyr/drivers/smbus.h
@@ -449,7 +449,10 @@ struct smbus_device_state {
 		stats_init(&state->stats.s_hdr, STATS_SIZE_32, 4,	\
 			   STATS_NAME_INIT_PARMS(smbus));		\
 		stats_register(dev->name, &(state->stats.s_hdr));	\
-		return init_fn(dev);					\
+		if (!is_null_no_warn(init_fn)) {			\
+			return init_fn(dev);				\
+		}							\
+		return 0;						\
 	}
 
 /** @endcond */

--- a/include/zephyr/drivers/spi.h
+++ b/include/zephyr/drivers/spi.h
@@ -549,7 +549,10 @@ struct spi_device_state {
 		stats_init(&state->stats.s_hdr, STATS_SIZE_32, 3,	\
 			   STATS_NAME_INIT_PARMS(spi));			\
 		stats_register(dev->name, &(state->stats.s_hdr));	\
-		return init_fn(dev);					\
+		if (!is_null_no_warn(init_fn)) {			\
+			return init_fn(dev);				\
+		}							\
+		return 0;						\
 	}
 
 /**


### PR DESCRIPTION
Generic device API allows for NULL init function, do the same for SPI and SMBUS.