### PR TITLE
scripts: west_commands: core: run netcat with check_call()

### DIFF
--- a/scripts/west_commands/runners/core.py
+++ b/scripts/west_commands/runners/core.py
@@ -923,7 +923,8 @@ class ZephyrBinaryRunner(abc.ABC):
         # CONFIG_SHELL_VT100_COMMANDS etc.
         if shutil.which('nc') is not None:
             client_cmd = ['nc', host, str(port)]
-            self.run_client(client_cmd)
+            # Note: netcat (nc) does not handle sigint, so cannot use run_client()
+            self.check_call(client_cmd)
             return
 
         # Otherwise, use a pure python implementation. This will work well for logging,


### PR DESCRIPTION
Netcat (nc) does not handle SIGINT. It silently ignores it. This is problematic, because several orphaned processes can be left behind, preventing subsequent invocations of `twister` or `west` from succeeding, until orphaned processes are manually killed.

We cannot use `run_client()`, given that the pydoc for `run_client()` specifically contains "Run a client that handles SIGINT".

Instead, use `check_call()`, which correctly handles `Ctrl+C`.

Fixes #81194