### PR TITLE
drivers: uart: clarification of poll_out blocking duration

### DIFF
--- a/include/zephyr/drivers/uart.h
+++ b/include/zephyr/drivers/uart.h
@@ -561,10 +561,11 @@ static inline int z_impl_uart_poll_in_u16(const struct device *dev,
 /**
  * @brief Write a character to the device for output.
  *
- * This routine checks if the transmitter is full.  When the
+ * This routine checks if the transmitter is full. When the
  * transmitter is not full, it writes a character to the data
- * register. It waits and blocks the calling thread, otherwise. This
- * function is a blocking call.
+ * register. It waits and blocks the calling thread otherwise. This
+ * function is a blocking call. It blocks the calling thread until the
+ * character is sent.
  *
  * To send a character when hardware flow control is enabled, the handshake
  * signal CTS must be asserted.


### PR DESCRIPTION
The API docs state that the uart_poll_out is a blocking call, but it does not specify how long a call to this function should block the calling thread. This is described in the UART driver documentation.

This patch clarifies the API docs and aligns it with the driver documentation.

ref https://github.com/zephyrproject-rtos/zephyr/blob/1a5ae376a3f93312fd85016464a8b6221c554c14/doc/hardware/peripherals/uart.rst?plain=1#L18-L20