### PR TITLE
logging: Add a log flush operation

### DIFF
--- a/include/zephyr/logging/log_ctrl.h
+++ b/include/zephyr/logging/log_ctrl.h
@@ -96,6 +96,17 @@ __syscall void log_panic(void);
 __syscall bool log_process(void);
 
 /**
+ * @brief Process all pending log messages
+ */
+#ifdef CONFIG_LOG_MODE_DEFERRED
+void log_flush(void);
+#else
+static inline void log_flush(void)
+{
+}
+#endif
+
+/**
  * @brief Return number of buffered log messages.
  *
  * @return Number of currently buffered log messages.

--- a/subsys/logging/log_core.c
+++ b/subsys/logging/log_core.c
@@ -992,4 +992,19 @@ static int enable_logger(void)
 	return 0;
 }
 
+#ifdef CONFIG_LOG_MODE_DEFERRED
+void log_flush(void)
+{
+	if (IS_ENABLED(CONFIG_LOG_PROCESS_THREAD)) {
+		while (log_data_pending()) {
+			k_sleep(K_MSEC(10));
+		}
+		k_sleep(K_MSEC(10));
+	} else {
+		while (LOG_PROCESS()) {
+		}
+	}
+}
+#endif
+
 SYS_INIT(enable_logger, POST_KERNEL, CONFIG_LOG_CORE_INIT_PRIORITY);

--- a/subsys/testsuite/ztest/src/ztest.c
+++ b/subsys/testsuite/ztest/src/ztest.c
@@ -934,19 +934,6 @@ static void __ztest_init_unit_test_result_for_suite(struct ztest_suite_node *sui
 	}
 }
 
-static void flush_log(void)
-{
-	if (IS_ENABLED(CONFIG_LOG_PROCESS_THREAD)) {
-		while (log_data_pending()) {
-			k_sleep(K_MSEC(10));
-		}
-		k_sleep(K_MSEC(10));
-	} else {
-		while (LOG_PROCESS()) {
-		}
-	}
-}
-
 /* Show one line summary for a test suite.
  */
 static void __ztest_show_suite_summary_oneline(struct ztest_suite_node *suite)
@@ -994,7 +981,7 @@ static void __ztest_show_suite_summary_oneline(struct ztest_suite_node *suite)
 			 TC_RESULT_TO_STR(suite_result), passrate_major, passrate_minor,
 			 suite->name, distinct_pass, distinct_fail, distinct_skip, distinct_total,
 			 suite_duration_worst_ms / 1000, suite_duration_worst_ms % 1000);
-	flush_log();
+	log_flush();
 }
 
 static void __ztest_show_suite_summary_verbose(struct ztest_suite_node *suite)
@@ -1035,12 +1022,12 @@ static void __ztest_show_suite_summary_verbose(struct ztest_suite_node *suite)
 
 		if (flush_frequency % 3 == 0) {
 			/** Reduce the flush frequency a bit to speed up the output */
-			flush_log();
+			log_flush();
 		}
 		flush_frequency++;
 	}
 	TC_SUMMARY_PRINT("\n");
-	flush_log();
+	log_flush();
 }
 
 static void __ztest_show_suite_summary(void)
@@ -1051,9 +1038,9 @@ static void __ztest_show_suite_summary(void)
 	/* Flush the log a lot to ensure that no summary content
 	 * is dropped if it goes through the logging subsystem.
 	 */
-	flush_log();
+	log_flush();
 	TC_SUMMARY_PRINT("\n------ TESTSUITE SUMMARY START ------\n\n");
-	flush_log();
+	log_flush();
 	for (struct ztest_suite_node *ptr = _ztest_suite_node_list_start;
 	     ptr < _ztest_suite_node_list_end; ++ptr) {
 
@@ -1061,7 +1048,7 @@ static void __ztest_show_suite_summary(void)
 		__ztest_show_suite_summary_verbose(ptr);
 	}
 	TC_SUMMARY_PRINT("------ TESTSUITE SUMMARY END ------\n\n");
-	flush_log();
+	log_flush();
 }
 
 static int __ztest_run_test_suite(struct ztest_suite_node *ptr, const void *state, bool shuffle,
@@ -1474,7 +1461,7 @@ int main(void)
 #ifndef CONFIG_ZTEST_SHELL
 	test_main();
 	end_report();
-	flush_log();
+	log_flush();
 	LOG_PANIC();
 	if (IS_ENABLED(CONFIG_ZTEST_RETEST_IF_PASSED)) {
 		static __noinit struct {


### PR DESCRIPTION
Ensure all pending log messages are processed by the log processing thread when log_flush is called, blocking the caller until done.

#81350 might be fixed by this, need @lyakh to confirm