### PR TITLE
demand_paging: eviction: add kconfig CONFIG_EVICTION_TRACKING

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -55,6 +55,8 @@ config ARM64
 	select ARCH_HAS_DIRECTED_IPIS
 	select ARCH_HAS_DEMAND_PAGING
 	select ARCH_HAS_DEMAND_MAPPING
+	select ARCH_SUPPORTS_EVICTION_TRACKING
+	select EVICTION_TRACKING if DEMAND_PAGING
 	help
 	  ARM64 (AArch64) architecture
 
@@ -693,6 +695,12 @@ config ARCH_SUPPORTS_ROM_START
 
 config ARCH_SUPPORTS_EMPTY_IRQ_SPURIOUS
 	bool
+
+config ARCH_SUPPORTS_EVICTION_TRACKING
+	bool
+	help
+	  Architecture code supports page tracking for eviction algorithms
+	  when demand paging is enabled.
 
 config ARCH_HAS_EXTRA_EXCEPTION_INFO
 	bool

--- a/doc/kernel/memory_management/demand_paging.rst
+++ b/doc/kernel/memory_management/demand_paging.rst
@@ -156,8 +156,12 @@ Two eviction algorithms are currently available:
   to the NRU code but also considerably more efficient. This is recommended for
   production use.
 
-To implement a new eviction algorithm, the five functions mentioned
-above must be implemented.
+To implement a new eviction algorithm, :c:func:`k_mem_paging_eviction_init()`
+and :c:func:`k_mem_paging_eviction_select()` must be implemented.
+If :kconfig:option:`CONFIG_EVICTION_TRACKING` is enabled for an algorithm,
+these additional functions must also be implemented,
+:c:func:`k_mem_paging_eviction_add()`, :c:func:`k_mem_paging_eviction_remove()`,
+:c:func:`k_mem_paging_eviction_accessed()`.
 
 Backing Store
 *************

--- a/include/zephyr/kernel/mm/demand_paging.h
+++ b/include/zephyr/kernel/mm/demand_paging.h
@@ -217,6 +217,8 @@ __syscall void k_mem_paging_histogram_backing_store_page_out_get(
  * @{
  */
 
+#if defined(CONFIG_EVICTION_TRACKING) || defined(__DOXYGEN__)
+
 /**
  * Submit a page frame for eviction candidate tracking
  *
@@ -260,6 +262,25 @@ void k_mem_paging_eviction_remove(struct k_mem_page_frame *pf);
  * @param [in] phys The physical address being accessed
  */
 void k_mem_paging_eviction_accessed(uintptr_t phys);
+
+#else /* CONFIG_EVICTION_TRACKING || __DOXYGEN__ */
+
+static inline void k_mem_paging_eviction_add(struct k_mem_page_frame *pf)
+{
+	ARG_UNUSED(pf);
+}
+
+static inline void k_mem_paging_eviction_remove(struct k_mem_page_frame *pf)
+{
+	ARG_UNUSED(pf);
+}
+
+static inline void k_mem_paging_eviction_accessed(uintptr_t phys)
+{
+	ARG_UNUSED(phys);
+}
+
+#endif /* CONFIG_EVICTION_TRACKING || __DOXYGEN__ */
 
 /**
  * Select a page frame for eviction

--- a/subsys/demand_paging/eviction/Kconfig
+++ b/subsys/demand_paging/eviction/Kconfig
@@ -11,6 +11,7 @@ choice EVICTION_CHOICE
 
 config EVICTION_CUSTOM
 	bool "Custom eviction algorithm"
+	imply EVICTION_TRACKING
 	help
 	  This option is chosen when the eviction algorithm will be implemented
 	  by the application, instead of using one included in Zephyr.
@@ -30,6 +31,7 @@ config EVICTION_NRU
 
 config EVICTION_LRU
 	bool "Least Recently Used (LRU) page eviction algorithm"
+	select EVICTION_TRACKING
 	help
 	  This implements a Least Recently Used page eviction algorithm.
 	  Usage is tracked based on MMU protection making pages unaccessible
@@ -49,3 +51,11 @@ config EVICTION_NRU_PERIOD
 	  pages that are capable of being paged out. At eviction time, if a page
 	  still has the accessed property, it will be considered as recently used.
 endif # EVICTION_NRU
+
+config EVICTION_TRACKING
+	bool
+	depends on ARCH_SUPPORTS_EVICTION_TRACKING
+	help
+	  Selected by eviction algorithms which needs page tracking and need to
+	  implement the following functions: k_mem_paging_eviction_add(),
+	  k_mem_paging_eviction_remove() and k_mem_paging_eviction_accessed().

--- a/subsys/demand_paging/eviction/nru.c
+++ b/subsys/demand_paging/eviction/nru.c
@@ -111,8 +111,11 @@ void k_mem_paging_eviction_init(void)
 		      K_MSEC(CONFIG_EVICTION_NRU_PERIOD));
 }
 
+#ifdef CONFIG_EVICTION_TRACKING
 /*
- * unused interfaces
+ * Empty functions defined here so that architectures unconditionally
+ * implement eviction tracking can still use this algorithm for
+ * testing.
  */
 
 void k_mem_paging_eviction_add(struct k_mem_page_frame *pf)
@@ -129,3 +132,5 @@ void k_mem_paging_eviction_accessed(uintptr_t phys)
 {
 	ARG_UNUSED(phys);
 }
+
+#endif /* CONFIG_EVICTION_TRACKING */


### PR DESCRIPTION
This adds a new kconfig for eviction algorithm which needs page tracking. When enabled, k_mem_paging_eviction_add()/_remove() and k_mem_paging_eviction_accessed() must be implemented. If an algorithm does not do page tracking, there is no need to implement these functions, and no need for the kernel MMU code to call into empty functions. This should save a few function calls and some CPU cycles.

Note that arm64 unconditionally calls those functions so forces CONFIG_EVICTION_TRACKING to be enabled there.