### PR TITLE
tests: drivers: build_all: eeprom: fix label name conflict

### DIFF
--- a/tests/drivers/build_all/eeprom/app.overlay
+++ b/tests/drivers/build_all/eeprom/app.overlay
@@ -59,7 +59,7 @@
 				#address-cells = <1>;
 				#size-cells = <0>;
 
-				eeprom: ti_tmp116_eeprom@0 {
+				test_tmp116_eeprom: ti_tmp116_eeprom@0 {
 					compatible = "ti,tmp116-eeprom";
 					reg = <0x0>;
 					read-only;


### PR DESCRIPTION
Some boards build fail with tests/drivers/build_all/eeprom because the label name `eeprom` already exists in their devicetree (adp_xc7k/ae350, bytesensi_l, same54_xpro), conflicting with the test case's overlay.

Rename the eeprom node label in the test case as the noted in [tests/drivers/build_all/eeprom/app.overlay](https://github.com/zephyrproject-rtos/zephyr/blob/40cd35e56d43716bdbdeafafa6c356407121ca2e/tests/drivers/build_all/eeprom/app.overlay#L8).
```
 * Names in this file should be chosen in a way that won't conflict
 * with real-world devicetree nodes, to allow these tests to run on
 * (and be extended to test) real hardware.
```