### PR TITLE
drivers: intc: plic: remove incorrect arch_proc_id() usage

### DIFF
--- a/drivers/interrupt_controller/intc_plic.c
+++ b/drivers/interrupt_controller/intc_plic.c
@@ -388,7 +388,7 @@ void riscv_plic_irq_set_pending(uint32_t irq)
  */
 unsigned int riscv_plic_get_irq(void)
 {
-	return save_irq[arch_proc_id()];
+	return save_irq[arch_curr_cpu()->id];
 }
 
 /**
@@ -400,7 +400,7 @@ unsigned int riscv_plic_get_irq(void)
  */
 const struct device *riscv_plic_get_dev(void)
 {
-	return save_dev[arch_proc_id()];
+	return save_dev[arch_curr_cpu()->id];
 }
 
 #ifdef CONFIG_PLIC_IRQ_AFFINITY
@@ -485,7 +485,7 @@ static void plic_irq_handler(const struct device *dev)
 	const struct plic_config *config = dev->config;
 	mem_addr_t claim_complete_addr = get_claim_complete_addr(dev);
 	struct _isr_table_entry *ite;
-	uint32_t cpu_id = arch_proc_id();
+	uint32_t cpu_id = arch_curr_cpu()->id;
 	/* Get the IRQ number generating the interrupt */
 	const uint32_t local_irq = sys_read32(claim_complete_addr);
 

--- a/include/zephyr/drivers/interrupt_controller/riscv_plic.h
+++ b/include/zephyr/drivers/interrupt_controller/riscv_plic.h
@@ -64,12 +64,16 @@ void riscv_plic_irq_set_pending(uint32_t irq);
 /**
  * @brief Get active interrupt ID
  *
+ * @note Should be called with interrupt locked
+ *
  * @return Returns the ID of an active interrupt
  */
 unsigned int riscv_plic_get_irq(void);
 
 /**
  * @brief Get active interrupt controller device
+ *
+ * @note Should be called with interrupt locked
  *
  * @return Returns device pointer of the active interrupt device
  */


### PR DESCRIPTION
The `arch_proc_id()` returns the hartid of a CPU, which may not start from zero. The way that it's used as an index to access `save_irq[]` array is wrong, use `arch_curr_cpu()->id` instead.