### PR TITLE
tests: drivers: build_all: eeprom: fix build error

### DIFF
--- a/tests/drivers/build_all/eeprom/app.overlay
+++ b/tests/drivers/build_all/eeprom/app.overlay
@@ -59,7 +59,7 @@
 				#address-cells = <1>;
 				#size-cells = <0>;
 
-				eeprom: ti_tmp116_eeprom@0 {
+				test_eeprom: ti_tmp116_eeprom@0 {
 					compatible = "ti,tmp116-eeprom";
 					reg = <0x0>;
 					read-only;


### PR DESCRIPTION
Rename the `eeprom` to `test_eeprom` to avoid namespace collision with boards that have existing `eeprom` defined in the devicetree, such as the `adp_xc7k/ae350`

To repro on `main`:

```
west build -p -b adp_xc7k/ae350 tests/drivers/build_all/eeprom -T drivers.eeprom.emul.build
```

and expect the following error:

```
-- Found devicetree overlay: /home/ycsin/zephyrproject/zephyr/tests/drivers/build_all/eeprom/app.overlay
devicetree error: Label 'eeprom' appears on /soc/i2c@f0a00000/eeprom@50 and on /test/i2c@11112222/tmp116@2/ti_tmp116_eeprom@0
```

This is failing in the CI of #81260