### PR TITLE
soc: sensry: sy1xx: fix CI issue with LLEXT build

### DIFF
--- a/soc/sensry/ganymed/sy1xx/common/linker.ld
+++ b/soc/sensry/ganymed/sy1xx/common/linker.ld
@@ -78,6 +78,9 @@ SECTIONS
 
         #include <zephyr/linker/rel-sections.ld>
 
+        #ifdef CONFIG_LLEXT
+        #include <zephyr/linker/llext-sections.ld>
+        #endif
 
         SECTION_PROLOGUE(.plt,,)
         {


### PR DESCRIPTION
The linker script for this SoC was not including the LLEXT section definitions when `CONFIG_LLEXT` was enabled. This patch adds the necessary include directive to the linker script and fixes the [build issue identified by CI](https://github.com/zephyrproject-rtos/zephyr/actions/runs/11761688794/job/32763760105).