### PR TITLE
Flexible ETR buffer location

### DIFF
--- a/dts/bindings/arm/nordic,nrf-tddconf.yaml
+++ b/dts/bindings/arm/nordic,nrf-tddconf.yaml
@@ -38,3 +38,7 @@ properties:
       - 1
       - 2
       - 3
+
+  etrbuffer:
+    description: phandle to the memory region used for the ETR buffer
+    type: phandle

--- a/snippets/nordic-log-stm-dict/boards/nrf54h20_cpuapp.overlay
+++ b/snippets/nordic-log-stm-dict/boards/nrf54h20_cpuapp.overlay
@@ -12,4 +12,5 @@
 	etrsources = <(NRF_TDDCONF_SOURCE_STMMAINCORE | NRF_TDDCONF_SOURCE_STMPPR |
 		NRF_TDDCONF_SOURCE_STMFLPR)>;
 	portconfig = <0>;
+	etrbuffer = <&etr_buffer>;
 };

--- a/snippets/nordic-log-stm/boards/nrf54h20_cpuapp.overlay
+++ b/snippets/nordic-log-stm/boards/nrf54h20_cpuapp.overlay
@@ -12,4 +12,5 @@
 	etrsources = <(NRF_TDDCONF_SOURCE_STMMAINCORE | NRF_TDDCONF_SOURCE_STMPPR |
 		NRF_TDDCONF_SOURCE_STMFLPR)>;
 	portconfig = <0>;
+	etrbuffer = <&etr_buffer>;
 };


### PR DESCRIPTION
Introduce etr-buffer into the tddconf binding to support flexible placement of the etr buffer in the memory map. The location will then be stored into the user information configuration registers and loaded on power on