### PR TITLE
twister: add instance name as default parameter

### DIFF
--- a/doc/develop/test/twister.rst
+++ b/doc/develop/test/twister.rst
@@ -1315,6 +1315,38 @@ Using Single Board For Multiple Variants
       runner: nrfjprog
       serial: /dev/ttyACM1
 
+Scripts Usage for platform
+++++++++++++++++++++++++++
+
+Below scripts are supported
+
+* pre_script: <path to pre script>
+
+* post_script: <path to pre script>
+
+* post_flash_script: <path to pre script>
+
+each of above scripts can have timeout defined as below in hardwar map file by script_param
+
+.. code-block:: yaml
+
+    - connected: false
+      id: 0229000005d9ebc600000000000000000000000097969905
+      platform: mimxrt1060_evk
+      probe_id: 000609301751
+      product: DAPLink CMSIS-DAP
+      runner: jlink
+      serial: null
+      pre_script: pre_scripts.sh
+      post_script: post_scripts.sh
+      post_flash_script: post_flash_scripts.sh
+      script_param:
+        "pre_script_timeout":  100
+        "post_script_timeout": 100
+        "post_flash_timeout":  100
+
+also a default patameter <testinstance.name> will be pass as fist parameter for scripts
+
 Quarantine
 ++++++++++
 

--- a/scripts/pylib/twister/twisterlib/environment.py
+++ b/scripts/pylib/twister/twisterlib/environment.py
@@ -640,7 +640,8 @@ structure in the main Zephyr tree: boards/<vendor>/<board_name>/""")
 
     parser.add_argument("--pre-script",
                         help="""specify a pre script. This will be executed
-                        before device handler open serial port and invoke runner.
+                        before device handler open serial port and invoke runner,
+                        and testinstance name will be its first parameter.
                         """)
 
     parser.add_argument(

--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -714,7 +714,10 @@ class DeviceHandler(Handler):
             timeout = 30
             if script_param:
                 timeout = script_param.get("pre_script_timeout", timeout)
-            self.run_custom_script(pre_script, timeout)
+            pre_script_cmd = ([pre_script] +
+                              [self.instance.name]
+                             )
+            self.run_custom_script(pre_script_cmd, timeout)
 
         flash_timeout = hardware.flash_timeout
         if hardware.flash_with_test:
@@ -782,7 +785,10 @@ class DeviceHandler(Handler):
             timeout = 30
             if script_param:
                 timeout = script_param.get("post_flash_timeout", timeout)
-            self.run_custom_script(post_flash_script, timeout)
+            post_flash_script_cmd = ([post_flash_script] +
+                                     [self.instance.name]
+                                    )
+            self.run_custom_script(post_flash_script_cmd, timeout)
 
         # Connect to device after flashing it
         if hardware.flash_before:
@@ -824,7 +830,10 @@ class DeviceHandler(Handler):
             timeout = 30
             if script_param:
                 timeout = script_param.get("post_script_timeout", timeout)
-            self.run_custom_script(post_script, timeout)
+            post_script_cmd = ([post_script] +
+                               [self.instance.name]
+                              )
+            self.run_custom_script(post_script_cmd, timeout)
 
         self.make_dut_available(hardware)
 

--- a/scripts/tests/twister/test_handlers.py
+++ b/scripts/tests/twister/test_handlers.py
@@ -1479,16 +1479,16 @@ def test_devicehandler_handle(
         return
 
     handler.run_custom_script.assert_has_calls([
-        mock.call('dummy pre script', mock.ANY)
+        mock.call(['dummy pre script', mock.ANY], mock.ANY)
     ])
 
     if raise_create_serial:
         return
 
     handler.run_custom_script.assert_has_calls([
-        mock.call('dummy pre script', mock.ANY),
-        mock.call('dummy post flash script', mock.ANY),
-        mock.call('dummy post script', mock.ANY)
+        mock.call(['dummy pre script', mock.ANY], mock.ANY),
+        mock.call(['dummy post flash script', mock.ANY], mock.ANY),
+        mock.call(['dummy post script', mock.ANY], mock.ANY)
     ])
 
     if expected_reason:


### PR DESCRIPTION
add testinstance name as default parameter to
customer scripts