### PR TITLE
drivers: serial: gecko: Fix build error on Series 0

### DIFF
--- a/drivers/serial/uart_gecko.c
+++ b/drivers/serial/uart_gecko.c
@@ -492,13 +492,15 @@ static int uart_gecko_init(const struct device *dev)
 #ifdef CONFIG_PM_DEVICE
 static int uart_gecko_pm_action(const struct device *dev, enum pm_device_action action)
 {
-	const struct uart_gecko_config *config = dev->config;
+	__maybe_unused const struct uart_gecko_config *config = dev->config;
 
 	switch (action) {
 	case PM_DEVICE_ACTION_SUSPEND:
+#ifdef USART_STATUS_TXIDLE
 		/* Wait for TX FIFO to flush before suspending */
 		while (!(USART_StatusGet(config->base) & USART_STATUS_TXIDLE)) {
 		}
+#endif
 		break;
 
 	case PM_DEVICE_ACTION_RESUME:


### PR DESCRIPTION
Series 0 does not have the TXIDLE status flag. The closest equivalent is TXC, but it isn't set until the first transmission completes, and is therefore not safe to use in PM suspend without also separately keeping track of whether the driver has ever initiated a transmission. For now, disable the TXIDLE check on devices that don't support it as a minimal fix for the observed build error. This is effectively equivalent to reverting the addition of PM support for these devices only. Since these devices don't have a low-power system timer implementation anyway, the lack of PM handling does not hurt anything.

Fixes #81390 .