### PR TITLE
soc: mediatek: mt8195_adsp: add support for LLEXT build

### DIFF
--- a/soc/mediatek/mtk_adsp/mt8195_adsp/linker.ld
+++ b/soc/mediatek/mtk_adsp/mt8195_adsp/linker.ld
@@ -136,4 +136,7 @@ SECTIONS {
  */
 #include <zephyr/linker/intlist.ld>
 
+#ifdef CONFIG_LLEXT
+#include <zephyr/linker/llext-sections.ld>
+#endif
 } /* SECTIONS */


### PR DESCRIPTION
The linker script for this SoC was not including the LLEXT section definitions when `CONFIG_LLEXT` was enabled. This patch adds the missing include directive to the linker script, fixing the same issue as #81378 for the `mt8195_adsp` target.