### PR TITLE
boards: nxp: imx8mp_evk: add GPIO to M7

### DIFF
--- a/boards/nxp/imx8mp_evk/doc/index.rst
+++ b/boards/nxp/imx8mp_evk/doc/index.rst
@@ -30,6 +30,7 @@ Zephyr OS is ported to run on the Cortex®-A53 core.
   - LEDs:
 
     - 1x Power status LED
+    - 1x User LED (yellow)
     - 1x UART LED
   - Debug
 
@@ -79,6 +80,9 @@ features:
 +-----------+------------+-------------------------------------+
 | UART      | on-chip    | serial port-polling;                |
 |           |            | serial port-interrupt               |
++-----------+------------+-------------------------------------+
+| GPIO      | on-chip    | GPIO input;                         |
+|           |            | GPIO output                         |
 +-----------+------------+-------------------------------------+
 
 Devices

--- a/boards/nxp/imx8mp_evk/imx8mp_evk_mimx8ml8_m7.dts
+++ b/boards/nxp/imx8mp_evk/imx8mp_evk_mimx8ml8_m7.dts
@@ -6,6 +6,7 @@
 
 /dts-v1/;
 
+#include <zephyr/dt-bindings/gpio/gpio.h>
 #include <nxp/nxp_imx8ml_m7.dtsi>
 #include "imx8mp_evk-pinctrl.dtsi"
 
@@ -20,6 +21,18 @@
 
 		zephyr,console = &uart4;
 		zephyr,shell-uart = &uart4;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		yellow_led: led_0 {
+			gpios = <&gpio3 16 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	aliases {
+		led0 = &yellow_led;
 	};
 };
 

--- a/boards/nxp/imx8mp_evk/imx8mp_evk_mimx8ml8_m7_ddr.dts
+++ b/boards/nxp/imx8mp_evk/imx8mp_evk_mimx8ml8_m7_ddr.dts
@@ -6,6 +6,7 @@
 
 /dts-v1/;
 
+#include <zephyr/dt-bindings/gpio/gpio.h>
 #include <nxp/nxp_imx8ml_m7.dtsi>
 #include "imx8mp_evk-pinctrl.dtsi"
 
@@ -20,6 +21,18 @@
 
 		zephyr,console = &uart4;
 		zephyr,shell-uart = &uart4;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		yellow_led: led_0 {
+			gpios = <&gpio3 16 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	aliases {
+		led0 = &yellow_led;
 	};
 };
 


### PR DESCRIPTION
In addition also the led0 has been configured to run samples using it.