### PR TITLE
github: west_cmds: add missing anytree package

### DIFF
--- a/.github/workflows/west_cmds.yml
+++ b/.github/workflows/west_cmds.yml
@@ -66,7 +66,7 @@ jobs:
     - name: install pytest
       run: |
         pip3 install wheel
-        pip3 install pytest west pyelftools canopen natsort progress mypy intelhex psutil ply pyserial
+        pip3 install pytest west pyelftools canopen natsort progress mypy intelhex psutil ply pyserial anytree
     - name: run pytest-win
       if: runner.os == 'Windows'
       run: |


### PR DESCRIPTION
Add missing anytree package, runners started to fail on it:

```
../pylib/twister/twisterlib/runner.py:60: in <module>
    from anytree import Node, RenderTree
E   ModuleNotFoundError: No module named 'anytree'
```