### PR TITLE
dts: x86: intel: alder_lake: Add second core

### DIFF
--- a/dts/x86/intel/alder_lake.dtsi
+++ b/dts/x86/intel/alder_lake.dtsi
@@ -23,6 +23,13 @@
 			reg = <0>;
 		};
 
+		cpu@1 {
+			device_type = "cpu";
+			compatible = "intel,alder-lake";
+			d-cache-line-size = <64>;
+			reg = <1>;
+		};
+
 	};
 
 	dram0: memory@0 {


### PR DESCRIPTION
Alder Lake have at least 2 cores. Both boards using this SoC (`up_squared_pro_7000` and `adl`) are configured with
`MP_MAX_NUM_CPUS=2`, so `dts` should contain at least one more core.