### PR TITLE
ci: west_commands: fix missing anytree module error

### DIFF
--- a/.github/workflows/west_cmds.yml
+++ b/.github/workflows/west_cmds.yml
@@ -66,7 +66,7 @@ jobs:
     - name: install pytest
       run: |
         pip3 install wheel
-        pip3 install pytest west pyelftools canopen natsort progress mypy intelhex psutil ply pyserial
+        pip3 install pytest west pyelftools canopen natsort progress mypy intelhex psutil ply pyserial anytree
     - name: run pytest-win
       if: runner.os == 'Windows'
       run: |


### PR DESCRIPTION
CI has been failing for a few days because the anytree module is not installed.

Install it.