### PR TITLE
lib: libc: Kconfig: Correct dependencies for MINIMAL_LIBC_SUPPORTED

### DIFF
--- a/lib/libc/Kconfig
+++ b/lib/libc/Kconfig
@@ -28,6 +28,7 @@ config FULL_LIBC_SUPPORTED
 config MINIMAL_LIBC_SUPPORTED
 	bool
 	depends on !NATIVE_APPLICATION
+	depends on !REQUIRES_FULL_LIBC
 	default y
 	help
 	  Selected when the target has support for the minimal C library
@@ -68,7 +69,6 @@ choice LIBC_IMPLEMENTATION
 
 config MINIMAL_LIBC
 	bool "Minimal C library"
-	depends on !REQUIRES_FULL_LIBC
 	depends on MINIMAL_LIBC_SUPPORTED
 	imply COMPILER_FREESTANDING
 	select COMMON_LIBC_ABORT


### PR DESCRIPTION
The MINIMAL_LIBC_SUPPORTED option is supposed to indicate that the minimal C library implementation can be chosen and many tests use this option as a filter for scenarios where the MINIMAL_LIBC option is enabled.

On the other hand, the REQUIRES_FULL_LIBC option tells that the minimal C library is insufficient and it prevents the MINIMAL_LIBC option from being enabled. But it should also cause that MINIMAL_LIBC_SUPPORTED is no longer enabled, otherwise for targets requiring a complete C library implementation, tests using the filtering mentioned above will not be actually performed with the minimal C library.

This commit removes the above discrepancy by moving the dependency on !REQUIRES_FULL_LIBC from MINIMAL_LIBC to MINIMAL_LIBC_SUPPORTED.