### PR TITLE
boards: lilygo: adopt new zephyr:board directive and role

### DIFF
--- a/boards/lilygo/ttgo_lora32/doc/index.rst
+++ b/boards/lilygo/ttgo_lora32/doc/index.rst
@@ -1,7 +1,4 @@
-.. _ttgo_lora32:
-
-Lilygo TTGO LoRa32
-##################
+.. zephyr:board:: ttgo_lora32
 
 Overview
 ********
@@ -17,13 +14,6 @@ It's available in two versions supporting two different frequency ranges and fea
 - TF card slot
 
 Some of the ESP32 I/O pins are accessible on the board's pin headers.
-
-.. figure:: img/ttgo_lora32.webp
-        :align: center
-        :alt: Lilygo TTGO LoRa32 module
-        :width: 400 px
-
-        Lilygo TTGO LoRa32 module
 
 Functional Description
 **********************

--- a/boards/lilygo/ttgo_t8c3/doc/index.rst
+++ b/boards/lilygo/ttgo_t8c3/doc/index.rst
@@ -1,7 +1,4 @@
-.. _ttgo_t8c3:
-
-Lilygo TTGO T8-C3
-#################
+.. zephyr:board:: ttgo_t8c3
 
 Overview
 ********
@@ -16,12 +13,6 @@ It features the following integrated components:
 - USB-C connector for power and communication
 - JST GH 2-pin battery connector
 - LED
-
-.. figure:: img/ttgo_t8c3.webp
-   :align: center
-   :alt: TTGO T8-C3
-
-   Lilygo TTGO T8-C3
 
 Functional Description
 **********************


### PR DESCRIPTION
This updates the documentation of all the LilyGO boards to use the new `zephyr:board::` directive.
https://builds.zephyrproject.io/zephyr/pr/81411/docs/boards/lilygo/ttgo_lora32/doc/index.html
https://builds.zephyrproject.io/zephyr/pr/81411/docs/boards/lilygo/ttgo_t8c3/doc/index.html
