### PR TITLE
boards nrf52_bsim: Fix sample used as example

### DIFF
--- a/boards/native/nrf_bsim/doc/nrf52_bsim.rst
+++ b/boards/native/nrf_bsim/doc/nrf52_bsim.rst
@@ -120,10 +120,10 @@ most Zephyr samples and tests.
 When you want to run a simulation with radio activity you need to run also the
 BableSim 2G4 (2.4GHz) physical layer simulation (phy).
 
-For example, if you would like to run a simple case with 1 BLE ``central_hr``
-sample application connecting to a BLE ``peripheral`` sample application:
-Build the ``central_hr`` application targeting this board and copy the resulting
-executable to the simulator bin folder with a sensible name:
+For example, if you would like to run a simple case with a BLE :zephyr:code-sample:`ble_central_hr`
+sample application connecting to a BLE :zephyr:code-sample:`ble_peripheral_hr` sample application:
+Build the :zephyr:code-sample:`ble_central_hr` application targeting this board and copy the
+resulting executable to the simulator bin folder with a sensible name:
 
 .. zephyr-app-commands::
    :zephyr-app: samples/bluetooth/central_hr
@@ -137,10 +137,10 @@ executable to the simulator bin folder with a sensible name:
    $ cp build/zephyr/zephyr.exe \
      ${BSIM_OUT_PATH}/bin/bs_nrf52_bsim_samples_bluetooth_central_hr
 
-Do the same for the ``peripheral`` sample app:
+Do the same for the :zephyr:code-sample:`ble_peripheral_hr` sample app:
 
 .. zephyr-app-commands::
-   :zephyr-app: samples/bluetooth/peripheral
+   :zephyr-app: samples/bluetooth/peripheral_hr
    :host-os: unix
    :board: nrf52_bsim
    :goals: build
@@ -149,7 +149,7 @@ Do the same for the ``peripheral`` sample app:
 .. code-block:: console
 
    $ cp build/zephyr/zephyr.exe \
-     ${BSIM_OUT_PATH}/bin/bs_nrf52_bsim_samples_bluetooth_peripheral
+     ${BSIM_OUT_PATH}/bin/bs_nrf52_bsim_samples_bluetooth_peripheral_hr
 
 And then run them together with BabbleSim's 2G4 physical layer simulation:
 


### PR DESCRIPTION
Let's fix the sample used in the example. The peripheral_hr and central_hr are meant to be run with each other. Let's also use the :zephyr:code-sample: directive to refer to the samples so we get a link.

Fixes #81412