### PR TITLE
kernel: make z_is_idle_thread_entry take code ptr

### DIFF
--- a/kernel/include/kthread.h
+++ b/kernel/include/kthread.h
@@ -225,7 +225,7 @@ static ALWAYS_INLINE bool should_preempt(struct k_thread *thread,
 }
 
 
-static inline bool z_is_idle_thread_entry(void *entry_point)
+static inline bool z_is_idle_thread_entry(k_thread_entry_t entry_point)
 {
 	return entry_point == idle;
 }


### PR DESCRIPTION
This is causing errors on IAR toolchain.

Talking to the C standard and compiler folks, they don't like this, since it is not guaranteed that code and data pointers are the same size. However if we do the cast it goes through fine.

 ```
        return entry_point == idle;
                              ^
"/workdir/zephyr/kernel/include/kthread.h",230  Warning[Pa131]: this is a function pointer constant. Did you intend a function call?

        return entry_point == idle;
                           ^
"/workdir/zephyr/kernel/include/kthread.h",230  Error[Pe042]: operand types are incompatible ("void *" and "void (*)(void *, void *, void *)")
```