### PR TITLE
bluetooth: CTS: Fix includes to avoid build error with some libCs

### DIFF
--- a/include/zephyr/bluetooth/services/cts.h
+++ b/include/zephyr/bluetooth/services/cts.h
@@ -16,7 +16,6 @@
  */
 
 #include <stdint.h>
-#include <zephyr/posix/time.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/subsys/bluetooth/services/cts.c
+++ b/subsys/bluetooth/services/cts.c
@@ -7,9 +7,17 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+#undef _POSIX_C_SOURCE
+#define _POSIX_C_SOURCE 200809L /* To get gmtime_r()'s prototype */
+
+#ifdef CONFIG_BT_CTS_HELPER_API
+#include <time.h>
+#include <zephyr/sys/timeutil.h>
+#endif
+
 #include <stdbool.h>
 #include <zephyr/sys/byteorder.h>
-#include <zephyr/posix/time.h>
 
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/gatt.h>
@@ -25,9 +33,6 @@ LOG_MODULE_REGISTER(cts, CONFIG_BT_CTS_LOG_LEVEL);
 static const struct bt_cts_cb *cts_cb;
 
 #ifdef CONFIG_BT_CTS_HELPER_API
-
-#include <time.h>
-#include <zephyr/sys/timeutil.h>
 
 int bt_cts_time_to_unix_ms(const struct bt_cts_time_format *ct_time, int64_t *unix_ms)
 {


### PR DESCRIPTION
Remove unnecessary include in header and source file which causes conflicting type definitions with some libCs.

gmtime_r() is an extension to the C library, and therefore one needs to explicitly ask for its prototype to have it exposed. This is done by defining _POSIX_C_SOURCE so let's do so.

These two changes fix build errors with some libCs. Tested with pico, newlib, minimal and the host glibc with CONFIG_BT_CTS_HELPER_API set to `n` and `y`

Related to #81412
Fixes #81416