### PR TITLE
boards: snps: nsim: align ICCM/DCCM configuration

### DIFF
--- a/boards/snps/nsim/arc_classic/nsim_nsim_em7d_v22.dts
+++ b/boards/snps/nsim/arc_classic/nsim_nsim_em7d_v22.dts
@@ -6,6 +6,9 @@
 
 /dts-v1/;
 
+#define ICCM_SIZE DT_SIZE_K(256)
+#define DCCM_SIZE DT_SIZE_K(128)
+
 #include "nsim_em.dtsi"
 
 / {

--- a/boards/snps/nsim/arc_classic/nsim_nsim_sem.dts
+++ b/boards/snps/nsim/arc_classic/nsim_nsim_sem.dts
@@ -4,27 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 /dts-v1/;
+
+#define ICCM_SIZE DT_SIZE_K(256)
+#define DCCM_SIZE DT_SIZE_K(256)
 
 #include "nsim_em-sec.dtsi"
 
 / {
-
-	model = "nsim_sem";
+	model = "snps,nsim_sem";
 	compatible = "snps,nsim_sem";
-
-	iccm0: iccm@0 {
-		compatible = "arc,iccm";
-		reg = <0x0 0x40000>;
-	};
-
-	dccm0: dccm@80000000 {
-		compatible = "arc,dccm";
-		reg = <0x80000000 0x40000>;
-	};
-
-	chosen {
-		zephyr,sram = &dccm0;
-	};
 };

--- a/boards/snps/nsim/arc_classic/nsim_nsim_sem.yaml
+++ b/boards/snps/nsim/arc_classic/nsim_nsim_sem.yaml
@@ -1,5 +1,5 @@
 identifier: nsim/nsim_sem
-name: SEM Nsim simulator
+name: SEM nSIM simulator
 type: sim
 arch: arc
 simulation:

--- a/boards/snps/nsim/arc_classic/nsim_nsim_sem_mpu_stack_guard.dts
+++ b/boards/snps/nsim/arc_classic/nsim_nsim_sem_mpu_stack_guard.dts
@@ -6,9 +6,12 @@
 
 /dts-v1/;
 
+#define ICCM_SIZE DT_SIZE_K(512)
+#define DCCM_SIZE DT_SIZE_K(512)
+
 #include "nsim_em-sec.dtsi"
 
 / {
-	model = "snps,nsim_sem_mpu_stack_guard";
-	compatible = "snps,nsim_sem_mpu_stack_guard.dts";
+	model = "snps,nsim_sem";
+	compatible = "snps,nsim_sem";
 };

--- a/boards/snps/nsim/arc_classic/support/mdb_em7d_v22.args
+++ b/boards/snps/nsim/arc_classic/support/mdb_em7d_v22.args
@@ -38,10 +38,10 @@
 	-dcache_feature=2
 	-icache=16384,32,2,a
 	-icache_feature=2
-	-dccm_size=0x80000
+	-dccm_size=0x20000
 	-dccm_base=0x80000000
 	-dccm_interleave
-	-iccm0_size=0x80000
+	-iccm0_size=0x40000
 	-iccm0_base=0x00000000
 	-Xpct_counters=8
 	-dmac

--- a/boards/snps/nsim/arc_classic/support/mdb_hs.args
+++ b/boards/snps/nsim/arc_classic/support/mdb_hs.args
@@ -34,11 +34,11 @@
 	-dcache_mem_cycles=2
 	-icache=65536,64,4,a
 	-icache_feature=2
-	-dccm_size=0x40000
+	-dccm_size=0x100000
 	-dccm_base=0x80000000
 	-dccm_mem_cycles=2
-	-iccm0_size=0x40000
-	-iccm0_base=0x70000000
+	-iccm0_size=0x100000
+	-iccm0_base=0x00000000
 	-mpuv3
 	-mpu_regions=16
 	-prop=nsim_mem-dev=uart0,kind=dwuart,base=0xf0000000,irq=24

--- a/boards/snps/nsim/arc_classic/support/mdb_hs_hostlink.args
+++ b/boards/snps/nsim/arc_classic/support/mdb_hs_hostlink.args
@@ -34,11 +34,11 @@
 	-dcache_mem_cycles=2
 	-icache=65536,64,4,a
 	-icache_feature=2
-	-dccm_size=0x40000
+	-dccm_size=0x100000
 	-dccm_base=0x80000000
 	-dccm_mem_cycles=2
-	-iccm0_size=0x40000
-	-iccm0_base=0x70000000
+	-iccm0_size=0x100000
+	-iccm0_base=0x00000000
 	-mpuv3
 	-mpu_regions=16
 	-noprofile

--- a/boards/snps/nsim/arc_classic/support/mdb_hs_mpuv6.args
+++ b/boards/snps/nsim/arc_classic/support/mdb_hs_mpuv6.args
@@ -39,7 +39,7 @@
 	-dccm_size=0x100000
 	-dccm_base=0x80000000
 	-dccm_mem_cycles=2
-	-iccm0_size=0x40000
-	-iccm0_base=0x70000000
+	-iccm0_size=0x100000
+	-iccm0_base=0x00000000
 	-prop=nsim_mem-dev=uart0,kind=dwuart,base=0xf0000000,irq=24
 	-noprofile

--- a/boards/snps/nsim/arc_classic/support/nsim_hs.props
+++ b/boards/snps/nsim/arc_classic/support/nsim_hs.props
@@ -41,8 +41,8 @@
 	dccm_size=0x100000
 	dccm_base=0x80000000
 	nsim_isa_dccm_mem_cycles=2
-	iccm0_size=0x40000
-	iccm0_base=0x70000000
+	iccm0_size=0x100000
+	iccm0_base=0x00000000
 	mpu_regions=16
 	mpu_version=3
 	nsim_mem-dev=uart0,kind=dwuart,base=0xf0000000,irq=24

--- a/boards/snps/nsim/arc_classic/support/nsim_hs_hostlink.props
+++ b/boards/snps/nsim/arc_classic/support/nsim_hs_hostlink.props
@@ -41,7 +41,7 @@
 	dccm_size=0x100000
 	dccm_base=0x80000000
 	nsim_isa_dccm_mem_cycles=2
-	iccm0_size=0x40000
-	iccm0_base=0x70000000
+	iccm0_size=0x100000
+	iccm0_base=0x00000000
 	mpu_regions=16
 	mpu_version=3

--- a/boards/snps/nsim/arc_classic/support/nsim_hs_mpuv6.props
+++ b/boards/snps/nsim/arc_classic/support/nsim_hs_mpuv6.props
@@ -43,6 +43,6 @@
 	dccm_size=0x100000
 	dccm_base=0x80000000
 	nsim_isa_dccm_mem_cycles=2
-	iccm0_size=0x40000
-	iccm0_base=0x70000000
+	iccm0_size=0x100000
+	iccm0_base=0x00000000
 	nsim_mem-dev=uart0,kind=dwuart,base=0xf0000000,irq=24


### PR DESCRIPTION
Some of the boards are completely simulated and do not represent any real hardware configurations. Others are diverged from the original intentions. Treat them on a case-by-case basis, separately for EM, SEM and HS.

Original description:
> As these boards are completely simulated and do not represent any real hardware configurations, provide all of them with 1M of both ICCM and DCCM to avoid out-of-memory test failures and fix all discovered inconsistencies in their ICCM/DCCM configuration.