### PR TITLE
docs: contribute: documentation: generation: fix missing doc

### DIFF
--- a/doc/contribute/documentation/generation.rst
+++ b/doc/contribute/documentation/generation.rst
@@ -255,7 +255,7 @@ To enable this mode, set the following option when invoking cmake::
 
 or invoke make with the following target::
 
-   cd ~/zephyr
+   cd ~/zephyr/doc
 
    # To generate HTML output without detailed Kconfig
    make html-fast


### PR DESCRIPTION
fix the path where the user has to be in order to execute make html-fast