### PR TITLE
west.yml: segger: RTT control block init mode Kconfigs

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -317,7 +317,7 @@ manifest:
       path: modules/lib/picolibc
       revision: d492d5fa7c96918e37653f303028346bb0dd51a2
     - name: segger
-      revision: 798f95ea9304e5ed8165a661081443051f210733
+      revision: 1a607e8718171cfbc1ee6b2a5ec00f619d1cc7fc
       path: modules/debug/segger
       groups:
         - debug


### PR DESCRIPTION
Kconfig options for RTT control block initialization and linker section were added in #53569, however the Zephyr west.yml was not updated to incorporate the Segger repository changes (https://github.com/zephyrproject-rtos/segger/pull/17) required to make use of the new Kconfig options.

This fixes that by updating west.yml.

Segger repository changes by @giansta 