### PR TITLE
tests: subsys: canbus: isotp: remove rt1180_evk platforms

### DIFF
--- a/tests/subsys/canbus/isotp/conformance/testcase.yaml
+++ b/tests/subsys/canbus/isotp/conformance/testcase.yaml
@@ -12,6 +12,10 @@
 # CAN FD independent of CONFIG_CAN_FD_MODE configuration.
 #
 
+common:
+  platform_exclude:
+    - mimxrt1180_evk/mimxrt1189/cm33
+    - mimxrt1180_evk/mimxrt1189/cm7
 tests:
   # cases 1, 3
   canbus.isotp.conformance:


### PR DESCRIPTION
fix issue: #81371
remove rt1180_evk platforms on canbus/isotp/conformance case, this case has not yet been adapted