### PR TITLE
doc: services: debugging: Remove unwanted reference link

### DIFF
--- a/doc/services/debugging/coredump.rst
+++ b/doc/services/debugging/coredump.rst
@@ -45,7 +45,7 @@ Usage
 
 When the core dump module is enabled, during a fatal error, CPU registers
 and memory content are printed or stored according to which backends
-are enabled. This core dump data can fed into a custom-made GDB server as
+are enabled. This core dump data can be fed into a custom-made GDB server as
 a remote target for GDB (and other GDB compatible debuggers). CPU registers,
 memory content and stack can be examined in the debugger.
 

--- a/doc/services/debugging/cs_trace_defmt.rst
+++ b/doc/services/debugging/cs_trace_defmt.rst
@@ -11,7 +11,7 @@ decoded offline by the host but deformatter can be used on-chip to decode the da
 application runtime.
 
 Usage
-#####
+*****
 
 Deformatter is initialized with a user callback. Data is decoded using
 :c:func:`cs_trace_defmt_process` in 16 bytes chunks. Callback is called whenever stream changes or


### PR DESCRIPTION
Remove unwanted reference link to the section (Usage) in ARM Coresight Trace Deformatter that shows up in the main Debugging documentation page, by lowering the level of (Usage) heading from ##### to *****

The commit also has a typo fix.