### PR TITLE
bluetooth: gatt: add `err` param to discover cb

### DIFF
--- a/include/zephyr/bluetooth/gatt.h
+++ b/include/zephyr/bluetooth/gatt.h
@@ -1558,6 +1558,7 @@ struct bt_gatt_discover_params;
  *  @param conn Connection object.
  *  @param attr Attribute found, or NULL if not found.
  *  @param params Discovery parameters given.
+ *  @param err 0 on success, -ECONNRESET on connection lost, -EPROTO on invalid data
  *
  *  If discovery procedure has completed this callback will be called with
  *  attr set to NULL. This will not happen if procedure was stopped by returning
@@ -1598,7 +1599,8 @@ struct bt_gatt_discover_params;
  */
 typedef uint8_t (*bt_gatt_discover_func_t)(struct bt_conn *conn,
 					const struct bt_gatt_attr *attr,
-					struct bt_gatt_discover_params *params);
+					struct bt_gatt_discover_params *params,
+					int err);
 
 /** GATT Discover types */
 enum {

--- a/samples/bluetooth/central_hr/src/main.c
+++ b/samples/bluetooth/central_hr/src/main.c
@@ -48,10 +48,9 @@ static uint8_t notify_func(struct bt_conn *conn,
 
 static uint8_t discover_func(struct bt_conn *conn,
 			     const struct bt_gatt_attr *attr,
-			     struct bt_gatt_discover_params *params)
+			     struct bt_gatt_discover_params *params,
+			     int err)
 {
-	int err;
-
 	if (!attr) {
 		printk("Discover complete\n");
 		(void)memset(params, 0, sizeof(*params));

--- a/samples/bluetooth/central_ht/src/main.c
+++ b/samples/bluetooth/central_ht/src/main.c
@@ -71,10 +71,9 @@ static uint8_t notify_func(struct bt_conn *conn,
 
 static uint8_t discover_func(struct bt_conn *conn,
 			     const struct bt_gatt_attr *attr,
-			     struct bt_gatt_discover_params *params)
+			     struct bt_gatt_discover_params *params,
+			     int err)
 {
-	int err;
-
 	if (!attr) {
 		printk("Discover complete\n");
 		(void)memset(params, 0, sizeof(*params));

--- a/samples/bluetooth/central_otc/src/main.c
+++ b/samples/bluetooth/central_otc/src/main.c
@@ -358,10 +358,8 @@ static bool is_discovery_complete(void)
 }
 
 static uint8_t discover_func(struct bt_conn *conn, const struct bt_gatt_attr *attr,
-			     struct bt_gatt_discover_params *params)
+			     struct bt_gatt_discover_params *params, int err)
 {
-	int err;
-
 	if (!attr) {
 		printk("Discover complete\n");
 		(void)memset(params, 0, sizeof(*params));

--- a/samples/bluetooth/encrypted_advertising/central/src/central_ead.c
+++ b/samples/bluetooth/encrypted_advertising/central/src/central_ead.c
@@ -260,7 +260,7 @@ static int gatt_read(struct bt_conn *conn, const struct bt_uuid *uuid, size_t re
 }
 
 static uint8_t gatt_discover_cb(struct bt_conn *conn, const struct bt_gatt_attr *attr,
-				struct bt_gatt_discover_params *params)
+				struct bt_gatt_discover_params *params, int err)
 {
 	gatt_disc_err = attr ? 0 : BT_ATT_ERR_ATTRIBUTE_NOT_FOUND;
 

--- a/samples/bluetooth/mtu_update/central/src/central_mtu_update.c
+++ b/samples/bluetooth/mtu_update/central/src/central_mtu_update.c
@@ -61,10 +61,8 @@ static uint8_t notify_func(struct bt_conn *conn,
 }
 
 static uint8_t discover_func(struct bt_conn *conn, const struct bt_gatt_attr *attr,
-			     struct bt_gatt_discover_params *params)
+			     struct bt_gatt_discover_params *params, int err)
 {
-	int err;
-
 	if (!attr) {
 		printk("Discover complete\n");
 		(void)memset(params, 0, sizeof(*params));

--- a/samples/bluetooth/periodic_adv_rsp/src/main.c
+++ b/samples/bluetooth/periodic_adv_rsp/src/main.c
@@ -190,7 +190,7 @@ static void device_found(const bt_addr_le_t *addr, int8_t rssi, uint8_t type,
 }
 
 static uint8_t discover_func(struct bt_conn *conn, const struct bt_gatt_attr *attr,
-			     struct bt_gatt_discover_params *params)
+			     struct bt_gatt_discover_params *params, int err)
 {
 	struct bt_gatt_chrc *chrc;
 	char str[BT_UUID_STR_LEN];

--- a/samples/boards/bbc/microbit/pong/src/ble.c
+++ b/samples/boards/bbc/microbit/pong/src/ble.c
@@ -169,10 +169,9 @@ static uint8_t notify_func(struct bt_conn *conn,
 
 static uint8_t discover_func(struct bt_conn *conn,
 			  const struct bt_gatt_attr *attr,
-			  struct bt_gatt_discover_params *param)
+			  struct bt_gatt_discover_params *param,
+			  int err)
 {
-	int err;
-
 	if (!attr) {
 		printk("Discover complete\n");
 		(void)memset(&discov_param, 0, sizeof(discov_param));

--- a/subsys/bluetooth/audio/aics_client.c
+++ b/subsys/bluetooth/audio/aics_client.c
@@ -551,7 +551,7 @@ static bool valid_inst_discovered(struct bt_aics *inst)
 }
 
 static uint8_t aics_discover_func(struct bt_conn *conn, const struct bt_gatt_attr *attr,
-				  struct bt_gatt_discover_params *params)
+				  struct bt_gatt_discover_params *params, int err)
 {
 	struct bt_aics_client *client_inst = CONTAINER_OF(params,
 							  struct bt_aics_client,
@@ -566,7 +566,7 @@ static uint8_t aics_discover_func(struct bt_conn *conn, const struct bt_gatt_att
 		atomic_clear_bit(inst->cli.flags, BT_AICS_CLIENT_FLAG_BUSY);
 
 		if (inst->cli.cb && inst->cli.cb->discover) {
-			int err = valid_inst_discovered(inst) ? 0 : -ENOENT;
+			err = valid_inst_discovered(inst) ? 0 : -ENOENT;
 
 			inst->cli.cb->discover(inst, err);
 		}
@@ -616,8 +616,6 @@ static uint8_t aics_discover_func(struct bt_conn *conn, const struct bt_gatt_att
 		}
 
 		if (sub_params) {
-			int err;
-
 			sub_params->value = BT_GATT_CCC_NOTIFY;
 			sub_params->value_handle = chrc->value_handle;
 			/*

--- a/subsys/bluetooth/audio/bap_broadcast_assistant.c
+++ b/subsys/bluetooth/audio/bap_broadcast_assistant.c
@@ -656,10 +656,10 @@ static void discover_init(struct bap_broadcast_assistant_instance *inst)
  */
 static uint8_t char_discover_func(struct bt_conn *conn,
 				  const struct bt_gatt_attr *attr,
-				  struct bt_gatt_discover_params *params)
+				  struct bt_gatt_discover_params *params,
+				  int err)
 {
 	struct bt_gatt_subscribe_params *sub_params = NULL;
-	int err;
 	struct bap_broadcast_assistant_instance *inst = inst_by_conn(conn);
 
 	if (inst == NULL) {
@@ -725,9 +725,9 @@ static uint8_t char_discover_func(struct bt_conn *conn,
 
 static uint8_t service_discover_func(struct bt_conn *conn,
 				     const struct bt_gatt_attr *attr,
-				     struct bt_gatt_discover_params *params)
+				     struct bt_gatt_discover_params *params,
+				     int err)
 {
-	int err;
 	struct bt_gatt_service_val *prim_service;
 	struct bap_broadcast_assistant_instance *inst = inst_by_conn(conn);
 

--- a/subsys/bluetooth/audio/bap_unicast_client.c
+++ b/subsys/bluetooth/audio/bap_unicast_client.c
@@ -3606,7 +3606,8 @@ int bt_bap_unicast_client_release(struct bt_bap_stream *stream)
 
 static uint8_t unicast_client_cp_discover_func(struct bt_conn *conn,
 					       const struct bt_gatt_attr *attr,
-					       struct bt_gatt_discover_params *discover)
+					       struct bt_gatt_discover_params *discover,
+					       int err)
 {
 	struct bt_gatt_chrc *chrc;
 	uint16_t value_handle;
@@ -3751,12 +3752,12 @@ static bool any_ases_found(const struct unicast_client *client)
 
 static uint8_t unicast_client_ase_discover_cb(struct bt_conn *conn,
 					      const struct bt_gatt_attr *attr,
-					      struct bt_gatt_discover_params *discover)
+					      struct bt_gatt_discover_params *discover,
+					      int err)
 {
 	struct unicast_client *client;
 	struct bt_gatt_chrc *chrc;
 	uint16_t value_handle;
-	int err;
 
 	client = &uni_cli_insts[bt_conn_index(conn)];
 
@@ -3911,13 +3912,13 @@ static int unicast_client_pacs_avail_ctx_read(struct bt_conn *conn, uint16_t han
 
 static uint8_t unicast_client_pacs_avail_ctx_discover_cb(struct bt_conn *conn,
 							 const struct bt_gatt_attr *attr,
-							 struct bt_gatt_discover_params *discover)
+							 struct bt_gatt_discover_params *discover,
+							 int err)
 {
 	uint8_t index = bt_conn_index(conn);
 	const struct bt_gatt_chrc *chrc;
 	uint8_t chrc_properties;
 	uint16_t value_handle;
-	int err;
 
 	if (!attr) {
 		/* If available_ctx is not found, we terminate the discovery as
@@ -4096,12 +4097,12 @@ static int unicast_client_pacs_location_read(struct bt_conn *conn, uint16_t hand
 
 static uint8_t unicast_client_pacs_location_discover_cb(struct bt_conn *conn,
 							const struct bt_gatt_attr *attr,
-							struct bt_gatt_discover_params *discover)
+							struct bt_gatt_discover_params *discover,
+							int err)
 {
 	uint8_t index = bt_conn_index(conn);
 	const struct bt_gatt_chrc *chrc;
 	uint16_t value_handle;
-	int err;
 
 	if (!attr) {
 		/* If location is not found, we just continue reading the
@@ -4212,12 +4213,12 @@ discover_loc:
 
 static uint8_t unicast_client_pacs_context_discover_cb(struct bt_conn *conn,
 						       const struct bt_gatt_attr *attr,
-						       struct bt_gatt_discover_params *discover)
+						       struct bt_gatt_discover_params *discover,
+						       int err)
 {
 	struct unicast_client *client = &uni_cli_insts[bt_conn_index(conn)];
 	struct bt_gatt_chrc *chrc;
 	uint16_t value_handle;
-	int err;
 
 	if (attr == NULL) {
 		LOG_ERR("Unable to find %s PAC context", bt_audio_dir_str(client->dir));
@@ -4404,12 +4405,12 @@ fail:
 
 static uint8_t unicast_client_pac_discover_cb(struct bt_conn *conn,
 					      const struct bt_gatt_attr *attr,
-					      struct bt_gatt_discover_params *discover)
+					      struct bt_gatt_discover_params *discover,
+					      int err)
 {
 	struct unicast_client *client = &uni_cli_insts[bt_conn_index(conn)];
 	struct bt_gatt_chrc *chrc;
 	uint16_t value_handle;
-	int err;
 
 	if (attr == NULL) {
 		LOG_DBG("Unable to find %s PAC", bt_audio_dir_str(client->dir));

--- a/subsys/bluetooth/audio/cap_common.c
+++ b/subsys/bluetooth/audio/cap_common.c
@@ -306,7 +306,8 @@ static void csis_client_discover_cb(struct bt_conn *conn,
 
 static uint8_t bt_cap_common_discover_included_cb(struct bt_conn *conn,
 						  const struct bt_gatt_attr *attr,
-						  struct bt_gatt_discover_params *params)
+						  struct bt_gatt_discover_params *params,
+						  int err)
 {
 	if (attr == NULL) {
 		LOG_DBG("CAS CSIS include not found");
@@ -330,7 +331,6 @@ static uint8_t bt_cap_common_discover_included_cb(struct bt_conn *conn,
 				.discover = csis_client_discover_cb,
 			};
 			static bool csis_cbs_registered;
-			int err;
 
 			LOG_DBG("CAS CSIS not known, discovering");
 
@@ -358,7 +358,7 @@ static uint8_t bt_cap_common_discover_included_cb(struct bt_conn *conn,
 }
 
 static uint8_t bt_cap_common_discover_cas_cb(struct bt_conn *conn, const struct bt_gatt_attr *attr,
-					     struct bt_gatt_discover_params *params)
+					     struct bt_gatt_discover_params *params, int err)
 {
 	if (attr == NULL) {
 		cap_common_discover_complete(conn, -ENODATA, NULL, NULL);
@@ -366,7 +366,6 @@ static uint8_t bt_cap_common_discover_cas_cb(struct bt_conn *conn, const struct 
 		const struct bt_gatt_service_val *prim_service = attr->user_data;
 		struct bt_cap_common_client *client =
 			CONTAINER_OF(params, struct bt_cap_common_client, param);
-		int err;
 
 		client->conn = bt_conn_ref(conn);
 

--- a/subsys/bluetooth/audio/csip_set_coordinator.c
+++ b/subsys/bluetooth/audio/csip_set_coordinator.c
@@ -678,7 +678,8 @@ static int csip_set_coordinator_discover_sets(struct bt_csip_set_coordinator_ins
 
 static uint8_t discover_func(struct bt_conn *conn,
 			     const struct bt_gatt_attr *attr,
-			     struct bt_gatt_discover_params *params)
+			     struct bt_gatt_discover_params *params,
+			     int err)
 {
 	struct bt_gatt_chrc *chrc;
 	struct bt_csip_set_coordinator_inst *client = &client_insts[bt_conn_index(conn)];
@@ -692,8 +693,6 @@ static uint8_t discover_func(struct bt_conn *conn,
 
 		if (CONFIG_BT_CSIP_SET_COORDINATOR_MAX_CSIS_INSTANCES > 1 &&
 		    (client->cur_inst->idx + 1) < client->inst_count) {
-			int err;
-
 			client->cur_inst = &client->svc_insts[client->cur_inst->idx + 1];
 			client->discover_params.uuid = NULL;
 			client->discover_params.start_handle = client->cur_inst->start_handle;
@@ -708,8 +707,6 @@ static uint8_t discover_func(struct bt_conn *conn,
 			}
 
 		} else {
-			int err;
-
 			client->cur_inst = NULL;
 			err = csip_set_coordinator_discover_sets(client);
 			if (err != 0) {
@@ -762,8 +759,6 @@ static uint8_t discover_func(struct bt_conn *conn,
 			}
 
 			if (sub_params->value != 0) {
-				int err;
-
 				sub_params->ccc_handle = BT_GATT_AUTO_DISCOVER_CCC_HANDLE;
 				sub_params->end_handle = client->cur_inst->end_handle;
 				sub_params->value_handle = chrc->value_handle;
@@ -786,7 +781,8 @@ static uint8_t discover_func(struct bt_conn *conn,
 
 static uint8_t primary_discover_func(struct bt_conn *conn,
 				     const struct bt_gatt_attr *attr,
-				     struct bt_gatt_discover_params *params)
+				     struct bt_gatt_discover_params *params,
+				     int err)
 {
 	struct bt_gatt_service_val *prim_service;
 	struct bt_csip_set_coordinator_inst *client = &client_insts[bt_conn_index(conn)];
@@ -797,8 +793,6 @@ static uint8_t primary_discover_func(struct bt_conn *conn,
 		(void)memset(params, 0, sizeof(*params));
 
 		if (client->inst_count != 0) {
-			int err;
-
 			client->cur_inst = &client->svc_insts[0];
 			client->discover_params.uuid = NULL;
 			client->discover_params.start_handle = client->cur_inst->start_handle;

--- a/subsys/bluetooth/audio/gmap_client.c
+++ b/subsys/bluetooth/audio/gmap_client.c
@@ -164,11 +164,10 @@ static int gmap_read_bgr_feat(struct bt_gmap_client *gmap_cli, uint16_t handle)
 }
 
 static uint8_t bgr_feat_discover_func(struct bt_conn *conn, const struct bt_gatt_attr *attr,
-				      struct bt_gatt_discover_params *params)
+				      struct bt_gatt_discover_params *params, int err)
 {
 	struct bt_gmap_client *gmap_cli = client_by_conn(conn);
 	const struct bt_gatt_chrc *chrc;
-	int err;
 
 	__ASSERT(gmap_cli != NULL, "no instance for conn %p", (void *)conn);
 
@@ -263,11 +262,10 @@ static int gmap_read_bgs_feat(struct bt_gmap_client *gmap_cli, uint16_t handle)
 }
 
 static uint8_t bgs_feat_discover_func(struct bt_conn *conn, const struct bt_gatt_attr *attr,
-				      struct bt_gatt_discover_params *params)
+				      struct bt_gatt_discover_params *params, int err)
 {
 	struct bt_gmap_client *gmap_cli = client_by_conn(conn);
 	const struct bt_gatt_chrc *chrc;
-	int err;
 
 	__ASSERT(gmap_cli != NULL, "no instance for conn %p", (void *)conn);
 
@@ -364,11 +362,10 @@ static int gmap_read_ugt_feat(struct bt_gmap_client *gmap_cli, uint16_t handle)
 }
 
 static uint8_t ugt_feat_discover_func(struct bt_conn *conn, const struct bt_gatt_attr *attr,
-				      struct bt_gatt_discover_params *params)
+				      struct bt_gatt_discover_params *params, int err)
 {
 	struct bt_gmap_client *gmap_cli = client_by_conn(conn);
 	const struct bt_gatt_chrc *chrc;
-	int err;
 
 	__ASSERT(gmap_cli != NULL, "no instance for conn %p", (void *)conn);
 
@@ -467,11 +464,10 @@ static int gmap_read_ugg_feat(struct bt_gmap_client *gmap_cli, uint16_t handle)
 }
 
 static uint8_t ugg_feat_discover_func(struct bt_conn *conn, const struct bt_gatt_attr *attr,
-				      struct bt_gatt_discover_params *params)
+				      struct bt_gatt_discover_params *params, int err)
 {
 	struct bt_gmap_client *gmap_cli = client_by_conn(conn);
 	const struct bt_gatt_chrc *chrc;
-	int err;
 
 	__ASSERT(gmap_cli != NULL, "no instance for conn %p", (void *)conn);
 
@@ -571,11 +567,10 @@ static int gmap_read_role(struct bt_gmap_client *gmap_cli, uint16_t handle)
 }
 
 static uint8_t role_discover_func(struct bt_conn *conn, const struct bt_gatt_attr *attr,
-				  struct bt_gatt_discover_params *params)
+				  struct bt_gatt_discover_params *params, int err)
 {
 	struct bt_gmap_client *gmap_cli = client_by_conn(conn);
 	const struct bt_gatt_chrc *chrc;
-	int err;
 
 	__ASSERT(gmap_cli != NULL, "no instance for conn %p", (void *)conn);
 
@@ -614,11 +609,10 @@ static int gmap_discover_role(struct bt_gmap_client *gmap_cli)
 }
 
 static uint8_t gmas_discover_func(struct bt_conn *conn, const struct bt_gatt_attr *attr,
-				  struct bt_gatt_discover_params *params)
+				  struct bt_gatt_discover_params *params, int err)
 {
 	struct bt_gmap_client *gmap_cli = client_by_conn(conn);
 	const struct bt_gatt_service_val *svc;
-	int err;
 
 	__ASSERT(gmap_cli != NULL, "no instance for conn %p", (void *)conn);
 

--- a/subsys/bluetooth/audio/has_client.c
+++ b/subsys/bluetooth/audio/has_client.c
@@ -563,11 +563,10 @@ static int control_point_subscribe(struct bt_has_client *inst, uint16_t value_ha
 }
 
 static uint8_t control_point_discover_cb(struct bt_conn *conn, const struct bt_gatt_attr *attr,
-					 struct bt_gatt_discover_params *params)
+					 struct bt_gatt_discover_params *params, int err)
 {
 	struct bt_has_client *inst = CONTAINER_OF(params, struct bt_has_client, params.discover);
 	const struct bt_gatt_chrc *chrc;
-	int err;
 
 	LOG_DBG("conn %p attr %p params %p", (void *)conn, attr, params);
 
@@ -754,11 +753,10 @@ static int features_subscribe(struct bt_has_client *inst, uint16_t value_handle)
 }
 
 static uint8_t features_discover_cb(struct bt_conn *conn, const struct bt_gatt_attr *attr,
-				    struct bt_gatt_discover_params *params)
+				    struct bt_gatt_discover_params *params, int err)
 {
 	struct bt_has_client *inst = CONTAINER_OF(params, struct bt_has_client, params.discover);
 	const struct bt_gatt_chrc *chrc;
-	int err;
 
 	LOG_DBG("conn %p attr %p params %p", (void *)conn, attr, params);
 

--- a/subsys/bluetooth/audio/mcc.c
+++ b/subsys/bluetooth/audio/mcc.c
@@ -1387,12 +1387,12 @@ static void discovery_complete(struct bt_conn *conn, int err)
 #ifdef CONFIG_BT_MCC_OTS
 static uint8_t discover_otc_char_func(struct bt_conn *conn,
 				      const struct bt_gatt_attr *attr,
-				      struct bt_gatt_discover_params *params)
+				      struct bt_gatt_discover_params *params,
+				      int err)
 {
 	struct mcs_instance_t *mcs_inst = CONTAINER_OF(params,
 						       struct mcs_instance_t,
 						       discover_params);
-	int err = 0;
 	struct bt_gatt_chrc *chrc;
 	struct bt_gatt_subscribe_params *sub_params = NULL;
 
@@ -1480,10 +1480,10 @@ static uint8_t discover_otc_char_func(struct bt_conn *conn,
 
 static uint8_t discover_include_func(struct bt_conn *conn,
 				     const struct bt_gatt_attr *attr,
-				     struct bt_gatt_discover_params *params)
+				     struct bt_gatt_discover_params *params,
+				     int err)
 {
 	struct bt_gatt_include *include;
-	int err = 0;
 
 	if (attr) {
 		struct mcs_instance_t *mcs_inst = CONTAINER_OF(params,
@@ -1765,7 +1765,8 @@ static bool subscribe_next_mcs_char(struct mcs_instance_t *mcs_inst,
  */
 static uint8_t discover_mcs_char_func(struct bt_conn *conn,
 				      const struct bt_gatt_attr *attr,
-				      struct bt_gatt_discover_params *params)
+				      struct bt_gatt_discover_params *params,
+				      int err)
 {
 	struct mcs_instance_t *mcs_inst = CONTAINER_OF(params,
 						       struct mcs_instance_t,
@@ -2005,7 +2006,8 @@ static uint8_t discover_mcs_char_func(struct bt_conn *conn,
  */
 static uint8_t discover_primary_func(struct bt_conn *conn,
 				     const struct bt_gatt_attr *attr,
-				     struct bt_gatt_discover_params *params)
+				     struct bt_gatt_discover_params *params,
+				     int err)
 {
 	struct bt_gatt_service_val *prim_service;
 
@@ -2013,7 +2015,6 @@ static uint8_t discover_primary_func(struct bt_conn *conn,
 		struct mcs_instance_t *mcs_inst = CONTAINER_OF(params,
 							       struct mcs_instance_t,
 							       discover_params);
-		int err;
 		/* Found an attribute */
 		LOG_DBG("[ATTRIBUTE] handle 0x%04X", attr->handle);
 

--- a/subsys/bluetooth/audio/micp_mic_ctlr.c
+++ b/subsys/bluetooth/audio/micp_mic_ctlr.c
@@ -321,7 +321,8 @@ static void micp_mic_ctlr_aics_set_auto_mode_cb(struct bt_aics *inst, int err)
 
 static uint8_t micp_discover_include_func(
 	struct bt_conn *conn, const struct bt_gatt_attr *attr,
-	struct bt_gatt_discover_params *params)
+	struct bt_gatt_discover_params *params,
+	int err)
 {
 	struct bt_micp_mic_ctlr *mic_ctlr = mic_ctlr_get_by_conn(conn);
 
@@ -344,7 +345,6 @@ static uint8_t micp_discover_include_func(
 		if (bt_uuid_cmp(include->uuid, BT_UUID_AICS) == 0 &&
 		    mic_ctlr->aics_inst_cnt < CONFIG_BT_MICP_MIC_CTLR_MAX_AICS_INST) {
 			uint8_t inst_idx;
-			int err;
 			struct bt_aics_discover_param param = {
 				.start_handle = include->start_handle,
 				.end_handle = include->end_handle,
@@ -378,13 +378,12 @@ static uint8_t micp_discover_include_func(
  */
 static uint8_t micp_discover_func(struct bt_conn *conn,
 				  const struct bt_gatt_attr *attr,
-				  struct bt_gatt_discover_params *params)
+				  struct bt_gatt_discover_params *params,
+				  int err)
 {
 	struct bt_micp_mic_ctlr *mic_ctlr = mic_ctlr_get_by_conn(conn);
 
 	if (attr == NULL) {
-		int err = 0;
-
 		LOG_DBG("Discovery complete");
 		(void)memset(params, 0, sizeof(*params));
 
@@ -421,8 +420,6 @@ static uint8_t micp_discover_func(struct bt_conn *conn,
 		}
 
 		if (sub_params != NULL) {
-			int err;
-
 			sub_params->ccc_handle = BT_GATT_AUTO_DISCOVER_CCC_HANDLE;
 			sub_params->end_handle = mic_ctlr->end_handle;
 			sub_params->value = BT_GATT_CCC_NOTIFY;
@@ -449,7 +446,8 @@ static uint8_t micp_discover_func(struct bt_conn *conn,
 
 static uint8_t primary_discover_func(struct bt_conn *conn,
 				     const struct bt_gatt_attr *attr,
-				     struct bt_gatt_discover_params *params)
+				     struct bt_gatt_discover_params *params,
+				     int err)
 {
 	struct bt_micp_mic_ctlr *mic_ctlr = mic_ctlr_get_by_conn(conn);
 
@@ -465,7 +463,6 @@ static uint8_t primary_discover_func(struct bt_conn *conn,
 	if (params->type == BT_GATT_DISCOVER_PRIMARY) {
 		struct bt_gatt_service_val *prim_service =
 			(struct bt_gatt_service_val *)attr->user_data;
-		int err;
 
 		LOG_DBG("Primary discover complete");
 		mic_ctlr->start_handle = attr->handle + 1;

--- a/subsys/bluetooth/audio/tbs_client.c
+++ b/subsys/bluetooth/audio/tbs_client.c
@@ -1553,7 +1553,8 @@ static void tbs_client_disc_read_ccid(struct bt_conn *conn)
  */
 static uint8_t discover_func(struct bt_conn *conn,
 			     const struct bt_gatt_attr *attr,
-			     struct bt_gatt_discover_params *params)
+			     struct bt_gatt_discover_params *params,
+			     int err)
 {
 	const uint8_t conn_index = bt_conn_index(conn);
 	struct bt_tbs_server_inst *srv_inst = &srv_insts[conn_index];
@@ -1690,8 +1691,6 @@ static uint8_t discover_func(struct bt_conn *conn,
 			}
 
 			if (sub_params->value != 0) {
-				int err;
-
 				sub_params->ccc_handle = BT_GATT_AUTO_DISCOVER_CCC_HANDLE;
 				sub_params->end_handle = current_inst->end_handle;
 				sub_params->notify = notify_handler;
@@ -1793,7 +1792,8 @@ static void primary_discover_complete(struct bt_tbs_server_inst *server, struct 
 static const struct bt_uuid *tbs_uuid = BT_UUID_TBS;
 
 static uint8_t primary_discover_tbs_cb(struct bt_conn *conn, const struct bt_gatt_attr *attr,
-				       struct bt_gatt_discover_params *params)
+				       struct bt_gatt_discover_params *params,
+				       int err)
 {
 	const uint8_t conn_index = bt_conn_index(conn);
 	struct bt_tbs_server_inst *srv_inst = &srv_insts[conn_index];
@@ -1843,7 +1843,8 @@ static int primary_discover_tbs(struct bt_conn *conn)
 static const struct bt_uuid *gtbs_uuid = BT_UUID_GTBS;
 
 static uint8_t primary_discover_gtbs_cb(struct bt_conn *conn, const struct bt_gatt_attr *attr,
-					struct bt_gatt_discover_params *params)
+					struct bt_gatt_discover_params *params,
+					int err)
 {
 	const uint8_t conn_index = bt_conn_index(conn);
 	struct bt_tbs_server_inst *srv_inst = &srv_insts[conn_index];
@@ -1863,8 +1864,6 @@ static uint8_t primary_discover_gtbs_cb(struct bt_conn *conn, const struct bt_ga
 	}
 
 #if defined(CONFIG_BT_TBS_CLIENT_TBS)
-	int err;
-
 	err = primary_discover_tbs(conn);
 	if (err == 0) {
 		return BT_GATT_ITER_STOP;

--- a/subsys/bluetooth/audio/tmap.c
+++ b/subsys/bluetooth/audio/tmap.c
@@ -80,9 +80,8 @@ uint8_t tmap_char_read(struct bt_conn *conn, uint8_t err,
 }
 
 static uint8_t discover_func(struct bt_conn *conn, const struct bt_gatt_attr *attr,
-			     struct bt_gatt_discover_params *params)
+			     struct bt_gatt_discover_params *params, int err)
 {
-	int err;
 	uint8_t conn_id = bt_conn_index(conn);
 
 	if (!attr) {

--- a/subsys/bluetooth/audio/vcp_vol_ctlr.c
+++ b/subsys/bluetooth/audio/vcp_vol_ctlr.c
@@ -329,11 +329,11 @@ static void vcp_vol_ctlr_write_vcs_cp_cb(struct bt_conn *conn, uint8_t err,
 #if defined(CONFIG_BT_VCP_VOL_CTLR_VOCS) || defined(CONFIG_BT_VCP_VOL_CTLR_AICS)
 static uint8_t vcs_discover_include_func(struct bt_conn *conn,
 					 const struct bt_gatt_attr *attr,
-					 struct bt_gatt_discover_params *params)
+					 struct bt_gatt_discover_params *params,
+					 int err)
 {
 	struct bt_gatt_include *include;
 	uint8_t inst_idx;
-	int err;
 	struct bt_vcp_vol_ctlr *vol_ctlr = vol_ctlr_get_by_conn(conn);
 
 	if (attr == NULL) {
@@ -428,9 +428,9 @@ static uint8_t vcs_discover_include_func(struct bt_conn *conn,
  */
 static uint8_t vcs_discover_func(struct bt_conn *conn,
 				 const struct bt_gatt_attr *attr,
-				 struct bt_gatt_discover_params *params)
+				 struct bt_gatt_discover_params *params,
+				 int err)
 {
-	int err = 0;
 	struct bt_gatt_chrc *chrc;
 	struct bt_gatt_subscribe_params *sub_params = NULL;
 	struct bt_vcp_vol_ctlr *vol_ctlr = vol_ctlr_get_by_conn(conn);
@@ -509,7 +509,8 @@ static uint8_t vcs_discover_func(struct bt_conn *conn,
  */
 static uint8_t primary_discover_func(struct bt_conn *conn,
 				     const struct bt_gatt_attr *attr,
-				     struct bt_gatt_discover_params *params)
+				     struct bt_gatt_discover_params *params,
+				     int err)
 {
 	struct bt_gatt_service_val *prim_service;
 	struct bt_vcp_vol_ctlr *vol_ctlr = vol_ctlr_get_by_conn(conn);
@@ -524,8 +525,6 @@ static uint8_t primary_discover_func(struct bt_conn *conn,
 	LOG_DBG("[ATTRIBUTE] handle 0x%04X", attr->handle);
 
 	if (params->type == BT_GATT_DISCOVER_PRIMARY) {
-		int err;
-
 		LOG_DBG("Primary discover complete");
 		prim_service = (struct bt_gatt_service_val *)attr->user_data;
 

--- a/subsys/bluetooth/audio/vocs_client.c
+++ b/subsys/bluetooth/audio/vocs_client.c
@@ -353,7 +353,7 @@ static bool valid_inst_discovered(struct bt_vocs_client *inst)
 }
 
 static uint8_t vocs_discover_func(struct bt_conn *conn, const struct bt_gatt_attr *attr,
-				  struct bt_gatt_discover_params *params)
+				  struct bt_gatt_discover_params *params, int err)
 {
 	struct bt_vocs_client *inst = CONTAINER_OF(params, struct bt_vocs_client, discover_params);
 
@@ -363,7 +363,7 @@ static uint8_t vocs_discover_func(struct bt_conn *conn, const struct bt_gatt_att
 		(void)memset(params, 0, sizeof(*params));
 
 		if (inst->cb && inst->cb->discover) {
-			int err = valid_inst_discovered(inst) ? 0 : -ENOENT;
+			err = valid_inst_discovered(inst) ? 0 : -ENOENT;
 
 			inst->cb->discover(&inst->vocs, err);
 		}
@@ -411,8 +411,6 @@ static uint8_t vocs_discover_func(struct bt_conn *conn, const struct bt_gatt_att
 		}
 
 		if (sub_params) {
-			int err;
-
 			sub_params->value = BT_GATT_CCC_NOTIFY;
 			sub_params->value_handle = chrc->value_handle;
 			/*

--- a/subsys/bluetooth/host/shell/gatt.c
+++ b/subsys/bluetooth/host/shell/gatt.c
@@ -180,7 +180,8 @@ static void print_chrc_props(const struct shell *sh, uint8_t properties)
 
 static uint8_t discover_func(struct bt_conn *conn,
 			     const struct bt_gatt_attr *attr,
-			     struct bt_gatt_discover_params *params)
+			     struct bt_gatt_discover_params *params,
+			     int err)
 {
 	struct bt_gatt_service_val *gatt_service;
 	struct bt_gatt_chrc *gatt_chrc;

--- a/subsys/bluetooth/mesh/gatt_cli.c
+++ b/subsys/bluetooth/mesh/gatt_cli.c
@@ -92,9 +92,9 @@ static void notify_enabled(struct bt_conn *conn, uint8_t err,
 
 static uint8_t discover_func(struct bt_conn *conn,
 			     const struct bt_gatt_attr *attr,
-			     struct bt_gatt_discover_params *params)
+			     struct bt_gatt_discover_params *params,
+			     int err)
 {
-	int err;
 	struct bt_mesh_gatt_server *server = get_server(conn);
 
 	if (!attr) {

--- a/subsys/bluetooth/services/ias/ias_client.c
+++ b/subsys/bluetooth/services/ias/ias_client.c
@@ -96,7 +96,8 @@ int bt_ias_client_alert_write(struct bt_conn *conn, enum bt_ias_alert_lvl lvl)
 
 static uint8_t bt_ias_alert_lvl_disc_cb(struct bt_conn *conn,
 					const struct bt_gatt_attr *attr,
-					struct bt_gatt_discover_params *discover)
+					struct bt_gatt_discover_params *discover,
+					int err)
 {
 	const struct bt_gatt_chrc *chrc;
 
@@ -118,9 +119,9 @@ static uint8_t bt_ias_alert_lvl_disc_cb(struct bt_conn *conn,
 
 static uint8_t bt_ias_prim_disc_cb(struct bt_conn *conn,
 				   const struct bt_gatt_attr *attr,
-				   struct bt_gatt_discover_params *discover)
+				   struct bt_gatt_discover_params *discover,
+				   int err)
 {
-	int err;
 	const struct bt_gatt_service_val *data;
 	struct bt_ias_client *client = client_by_conn(conn);
 

--- a/tests/bluetooth/audio/ascs/src/main.c
+++ b/tests/bluetooth/audio/ascs/src/main.c
@@ -65,11 +65,10 @@ static void ascs_test_suite_fixture_init(struct ascs_test_suite_fixture *fixture
 		CONFIG_BT_ASCS_MAX_ASE_SNK_COUNT,
 		CONFIG_BT_ASCS_MAX_ASE_SRC_COUNT
 	};
-	int err;
 
 	memset(fixture, 0, sizeof(*fixture));
 
-	err = bt_bap_unicast_server_register(&param);
+	(void)bt_bap_unicast_server_register(&param);
 
 	fixture->ase_cp = test_ase_control_point_get();
 
@@ -268,11 +267,9 @@ ZTEST_F(ascs_test_suite, test_ascs_unregister_without_register)
 
 ZTEST_F(ascs_test_suite, test_ascs_unregister_with_ases_in_config_state)
 {
-	const struct test_ase_chrc_value_hdr *hdr;
 	const struct bt_gatt_attr *ase;
 	struct bt_bap_stream *stream = &fixture->stream;
 	struct bt_conn *conn = &fixture->conn;
-	struct bt_gatt_notify_params *notify_params;
 	uint8_t ase_id;
 	int err;
 

--- a/tests/bluetooth/audio/mocks/src/gatt.c
+++ b/tests/bluetooth/audio/mocks/src/gatt.c
@@ -532,7 +532,7 @@ int bt_gatt_discover(struct bt_conn *conn, struct bt_gatt_discover_params *param
 		.handle = start_handle,
 	};
 
-	params->func(conn, &attr, params);
+	params->func(conn, &attr, params, 0);
 
 	return 0;
 }

--- a/tests/bluetooth/common/testlib/src/att_read.c
+++ b/tests/bluetooth/common/testlib/src/att_read.c
@@ -208,7 +208,7 @@ struct bt_testlib_gatt_discover_service_closure {
 };
 
 static uint8_t gatt_discover_service_cb(struct bt_conn *conn, const struct bt_gatt_attr *attr,
-					struct bt_gatt_discover_params *params)
+					struct bt_gatt_discover_params *params, int err)
 {
 	struct bt_testlib_gatt_discover_service_closure *ctx =
 		CONTAINER_OF(params, struct bt_testlib_gatt_discover_service_closure, params);
@@ -297,7 +297,7 @@ struct bt_testlib_gatt_discover_char_closure {
 };
 
 static uint8_t gatt_discover_char_cb(struct bt_conn *conn, const struct bt_gatt_attr *attr,
-				     struct bt_gatt_discover_params *params)
+				     struct bt_gatt_discover_params *params, int err)
 {
 	struct bt_testlib_gatt_discover_char_closure *ctx =
 		CONTAINER_OF(params, struct bt_testlib_gatt_discover_char_closure, params);

--- a/tests/bluetooth/tester/src/btp_gatt.c
+++ b/tests/bluetooth/tester/src/btp_gatt.c
@@ -1033,7 +1033,8 @@ static void discover_destroy(struct bt_gatt_discover_params *params)
 
 static uint8_t disc_prim_cb(struct bt_conn *conn,
 			 const struct bt_gatt_attr *attr,
-			 struct bt_gatt_discover_params *params)
+			 struct bt_gatt_discover_params *params,
+			 int err)
 {
 	struct bt_gatt_service_val *data;
 	struct btp_gatt_disc_prim_rp *rp = (void *) gatt_buf.buf;
@@ -1160,7 +1161,8 @@ static uint8_t disc_prim_uuid(const void *cmd, uint16_t cmd_len,
 
 static uint8_t find_included_cb(struct bt_conn *conn,
 				const struct bt_gatt_attr *attr,
-				struct bt_gatt_discover_params *params)
+				struct bt_gatt_discover_params *params,
+				int err)
 {
 	struct bt_gatt_include *data;
 	struct btp_gatt_find_included_rp *rp = (void *) gatt_buf.buf;
@@ -1239,7 +1241,8 @@ static uint8_t find_included(const void *cmd, uint16_t cmd_len,
 
 static uint8_t disc_chrc_cb(struct bt_conn *conn,
 			    const struct bt_gatt_attr *attr,
-			    struct bt_gatt_discover_params *params)
+			    struct bt_gatt_discover_params *params,
+			    int err)
 {
 	struct bt_gatt_chrc *data;
 	struct btp_gatt_disc_chrc_rp *rp = (void *) gatt_buf.buf;
@@ -1367,7 +1370,8 @@ static uint8_t disc_chrc_uuid(const void *cmd, uint16_t cmd_len,
 
 static uint8_t disc_all_desc_cb(struct bt_conn *conn,
 				const struct bt_gatt_attr *attr,
-				struct bt_gatt_discover_params *params)
+				struct bt_gatt_discover_params *params,
+				int err)
 {
 	struct btp_gatt_disc_all_desc_rp *rp = (void *) gatt_buf.buf;
 	struct btp_gatt_descriptor *descriptor;
@@ -1955,7 +1959,8 @@ fail:
 
 static uint8_t discover_func(struct bt_conn *conn,
 			     const struct bt_gatt_attr *attr,
-			     struct bt_gatt_discover_params *params)
+			     struct bt_gatt_discover_params *params,
+			     int err)
 {
 	struct bt_gatt_subscribe_params *subscription;
 

--- a/tests/bsim/bluetooth/audio/src/has_client_test.c
+++ b/tests/bsim/bluetooth/audio/src/has_client_test.c
@@ -430,10 +430,9 @@ static void subscribe_cb(struct bt_conn *conn, uint8_t err, struct bt_gatt_subsc
 }
 
 static uint8_t discover_features_cb(struct bt_conn *conn, const struct bt_gatt_attr *attr,
-				    struct bt_gatt_discover_params *params)
+				    struct bt_gatt_discover_params *params, int err)
 {
 	struct bt_gatt_subscribe_params *subscribe_params;
-	int err;
 
 	if (!attr) {
 		LOG_DBG("Discover complete");
@@ -496,10 +495,9 @@ static void discover_and_subscribe_features(void)
 
 static uint8_t discover_active_preset_index_cb(struct bt_conn *conn,
 					       const struct bt_gatt_attr *attr,
-					       struct bt_gatt_discover_params *params)
+					       struct bt_gatt_discover_params *params, int err)
 {
 	struct bt_gatt_subscribe_params *subscribe_params;
-	int err;
 
 	if (!attr) {
 		LOG_DBG("Discover complete");
@@ -561,10 +559,9 @@ static void discover_and_subscribe_active_preset_index(void)
 }
 
 static uint8_t discover_control_point_cb(struct bt_conn *conn, const struct bt_gatt_attr *attr,
-					 struct bt_gatt_discover_params *params)
+					 struct bt_gatt_discover_params *params, int err)
 {
 	struct bt_gatt_subscribe_params *subscribe_params;
-	int err;
 
 	if (!attr) {
 		LOG_DBG("Discover complete");

--- a/tests/bsim/bluetooth/audio/src/pacs_notify_client_test.c
+++ b/tests/bsim/bluetooth/audio/src/pacs_notify_client_test.c
@@ -94,10 +94,9 @@ static uint8_t pacs_notify_handler(struct bt_conn *conn,
 }
 
 static uint8_t discover_supported_contexts(struct bt_conn *conn, const struct bt_gatt_attr *attr,
-			     struct bt_gatt_discover_params *params)
+			     struct bt_gatt_discover_params *params, int err)
 {
 	struct bt_gatt_subscribe_params *subscribe_params;
-	int err;
 
 	if (!attr) {
 		LOG_DBG("Discover complete");
@@ -161,10 +160,9 @@ static void discover_and_subscribe_supported_contexts(void)
 }
 
 static uint8_t discover_available_contexts(struct bt_conn *conn, const struct bt_gatt_attr *attr,
-			     struct bt_gatt_discover_params *params)
+			     struct bt_gatt_discover_params *params, int err)
 {
 	struct bt_gatt_subscribe_params *subscribe_params;
-	int err;
 
 	if (!attr) {
 		LOG_DBG("Discover complete");
@@ -228,10 +226,9 @@ static void discover_and_subscribe_available_contexts(void)
 }
 
 static uint8_t discover_src_loc(struct bt_conn *conn, const struct bt_gatt_attr *attr,
-			     struct bt_gatt_discover_params *params)
+			     struct bt_gatt_discover_params *params, int err)
 {
 	struct bt_gatt_subscribe_params *subscribe_params;
-	int err;
 
 	if (!attr) {
 		LOG_DBG("Discover complete");
@@ -295,10 +292,9 @@ static void discover_and_subscribe_src_loc(void)
 }
 
 static uint8_t discover_snk_loc(struct bt_conn *conn, const struct bt_gatt_attr *attr,
-			     struct bt_gatt_discover_params *params)
+			     struct bt_gatt_discover_params *params, int err)
 {
 	struct bt_gatt_subscribe_params *subscribe_params;
-	int err;
 
 	if (!attr) {
 		LOG_DBG("Discover complete");
@@ -362,10 +358,9 @@ static void discover_and_subscribe_snk_loc(void)
 }
 
 static uint8_t discover_pacs_src(struct bt_conn *conn, const struct bt_gatt_attr *attr,
-			     struct bt_gatt_discover_params *params)
+			     struct bt_gatt_discover_params *params, int err)
 {
 	struct bt_gatt_subscribe_params *subscribe_params;
-	int err;
 
 	if (!attr) {
 		LOG_DBG("Discover complete");
@@ -429,10 +424,9 @@ static void discover_and_subscribe_src_pacs(void)
 }
 
 static uint8_t discover_pacs_snk(struct bt_conn *conn, const struct bt_gatt_attr *attr,
-			     struct bt_gatt_discover_params *params)
+			     struct bt_gatt_discover_params *params, int err)
 {
 	struct bt_gatt_subscribe_params *subscribe_params;
-	int err;
 
 	if (!attr) {
 		LOG_DBG("Discover complete");

--- a/tests/bsim/bluetooth/host/att/eatt_notif/src/client_test.c
+++ b/tests/bsim/bluetooth/host/att/eatt_notif/src/client_test.c
@@ -133,7 +133,8 @@ void send_notification(void)
 
 static uint8_t discover_func(struct bt_conn *conn,
 		const struct bt_gatt_attr *attr,
-		struct bt_gatt_discover_params *params)
+		struct bt_gatt_discover_params *params,
+		int err)
 {
 	SET_FLAG(flag_discover_complete);
 	printk("Discover complete\n");

--- a/tests/bsim/bluetooth/host/att/eatt_notif/src/server_test.c
+++ b/tests/bsim/bluetooth/host/att/eatt_notif/src/server_test.c
@@ -59,10 +59,9 @@ static uint16_t chrc_handle;
 
 static uint8_t discover_func(struct bt_conn *conn,
 			     const struct bt_gatt_attr *attr,
-			     struct bt_gatt_discover_params *params)
+			     struct bt_gatt_discover_params *params,
+			     int err)
 {
-	int err;
-
 	if (attr == NULL) {
 		if (chrc_handle == 0) {
 			FAIL("Did not discover chrc (%x)", chrc_handle);

--- a/tests/bsim/bluetooth/host/gatt/authorization/src/gatt_client_test.c
+++ b/tests/bsim/bluetooth/host/gatt/authorization/src/gatt_client_test.c
@@ -99,10 +99,9 @@ void device_found(const bt_addr_le_t *addr, int8_t rssi, uint8_t type,
 
 static uint8_t discover_func(struct bt_conn *conn,
 		const struct bt_gatt_attr *attr,
-		struct bt_gatt_discover_params *params)
+		struct bt_gatt_discover_params *params,
+		int err)
 {
-	int err;
-
 	if (attr == NULL) {
 		if (unhandled_chrc_handle == 0 ||
 		    unauthorized_chrc_handle == 0 ||

--- a/tests/bsim/bluetooth/host/gatt/caching/src/gatt_client_test.c
+++ b/tests/bsim/bluetooth/host/gatt/caching/src/gatt_client_test.c
@@ -106,10 +106,8 @@ void device_found(const bt_addr_le_t *addr, int8_t rssi, uint8_t type, struct ne
 }
 
 static uint8_t discover_func(struct bt_conn *conn, const struct bt_gatt_attr *attr,
-			     struct bt_gatt_discover_params *params)
+			     struct bt_gatt_discover_params *params, int err)
 {
-	int err;
-
 	if (attr == NULL) {
 		if (chrc_handle == 0) {
 			FAIL("Did not discover chrc (%x)\n", chrc_handle);

--- a/tests/bsim/bluetooth/host/gatt/general/src/gatt_client_test.c
+++ b/tests/bsim/bluetooth/host/gatt/general/src/gatt_client_test.c
@@ -114,10 +114,9 @@ void device_found(const bt_addr_le_t *addr, int8_t rssi, uint8_t type,
 
 static uint8_t discover_func(struct bt_conn *conn,
 		const struct bt_gatt_attr *attr,
-		struct bt_gatt_discover_params *params)
+		struct bt_gatt_discover_params *params,
+		int err)
 {
-	int err;
-
 	if (attr == NULL) {
 		if (chrc_handle == 0 || long_chrc_handle == 0) {
 			FAIL("Did not discover chrc (%x) or long_chrc (%x)\n", chrc_handle,

--- a/tests/bsim/bluetooth/host/gatt/notify/src/gatt_client_test.c
+++ b/tests/bsim/bluetooth/host/gatt/notify/src/gatt_client_test.c
@@ -102,10 +102,8 @@ void device_found(const bt_addr_le_t *addr, int8_t rssi, uint8_t type, struct ne
 }
 
 static uint8_t discover_func(struct bt_conn *conn, const struct bt_gatt_attr *attr,
-			     struct bt_gatt_discover_params *params)
+			     struct bt_gatt_discover_params *params, int err)
 {
-	int err;
-
 	if (attr == NULL) {
 		if (chrc_handle == 0 || long_chrc_handle == 0) {
 			FAIL("Did not discover chrc (%x) or long_chrc (%x)", chrc_handle,

--- a/tests/bsim/bluetooth/host/gatt/notify_multiple/src/gatt_client_test.c
+++ b/tests/bsim/bluetooth/host/gatt/notify_multiple/src/gatt_client_test.c
@@ -120,10 +120,8 @@ void device_found(const bt_addr_le_t *addr, int8_t rssi, uint8_t type, struct ne
 }
 
 static uint8_t discover_func(struct bt_conn *conn, const struct bt_gatt_attr *attr,
-			     struct bt_gatt_discover_params *params)
+			     struct bt_gatt_discover_params *params, int err)
 {
-	int err;
-
 	if (attr == NULL) {
 		if (chrc_handle == 0 || long_chrc_handle == 0) {
 			FAIL("Did not discover chrc (%x) or long_chrc (%x)", chrc_handle,

--- a/tests/bsim/bluetooth/host/gatt/sc_indicate/src/central.c
+++ b/tests/bsim/bluetooth/host/gatt/sc_indicate/src/central.c
@@ -73,7 +73,8 @@ static void subscribe(void)
 
 static uint8_t discover_func(struct bt_conn *conn,
 			     const struct bt_gatt_attr *attr,
-			     struct bt_gatt_discover_params *params)
+			     struct bt_gatt_discover_params *params,
+			     int err)
 {
 	if (attr == NULL) {
 		for (size_t i = 0U; i < ARRAY_SIZE(gatt_handles); i++) {

--- a/tests/bsim/bluetooth/host/gatt/settings/src/gatt_utils.c
+++ b/tests/bsim/bluetooth/host/gatt/settings/src/gatt_utils.c
@@ -123,7 +123,7 @@ uint16_t gatt_handles[NUM_HANDLES] = {0};
 DEFINE_FLAG(flag_discovered);
 
 static uint8_t discover_func(struct bt_conn *conn, const struct bt_gatt_attr *attr,
-			     struct bt_gatt_discover_params *params)
+			     struct bt_gatt_discover_params *params, int err)
 {
 	if (attr == NULL) {
 		for (int i = 0; i < ARRAY_SIZE(gatt_handles); i++) {

--- a/tests/bsim/bluetooth/host/misc/conn_stress/central/src/main.c
+++ b/tests/bsim/bluetooth/host/misc/conn_stress/central/src/main.c
@@ -209,9 +209,8 @@ static uint8_t notify_func(struct bt_conn *conn, struct bt_gatt_subscribe_params
 }
 
 static uint8_t discover_func(struct bt_conn *conn, const struct bt_gatt_attr *attr,
-			     struct bt_gatt_discover_params *params)
+			     struct bt_gatt_discover_params *params, int err)
 {
-	int err;
 	char uuid_str[BT_UUID_STR_LEN];
 	struct conn_info *conn_info_ref;
 

--- a/tests/bsim/bluetooth/host/misc/conn_stress/peripheral/src/main.c
+++ b/tests/bsim/bluetooth/host/misc/conn_stress/peripheral/src/main.c
@@ -247,9 +247,8 @@ static uint8_t rx_notification(struct bt_conn *conn, struct bt_gatt_subscribe_pa
 }
 
 static uint8_t discover_func(struct bt_conn *conn, const struct bt_gatt_attr *attr,
-			     struct bt_gatt_discover_params *params)
+			     struct bt_gatt_discover_params *params, int err)
 {
-	int err;
 	char uuid_str[BT_UUID_STR_LEN];
 
 	if (!attr) {

--- a/tests/bsim/bluetooth/host/misc/disable/src/gatt_client_test.c
+++ b/tests/bsim/bluetooth/host/misc/disable/src/gatt_client_test.c
@@ -99,10 +99,9 @@ void device_found(const bt_addr_le_t *addr, int8_t rssi, uint8_t type,
 
 static uint8_t discover_func(struct bt_conn *conn,
 		const struct bt_gatt_attr *attr,
-		struct bt_gatt_discover_params *params)
+		struct bt_gatt_discover_params *params,
+		int err)
 {
-	int err;
-
 	if (attr == NULL) {
 		if (chrc_handle == 0 || long_chrc_handle == 0) {
 			FAIL("Did not discover chrc (%x) or long_chrc (%x)",

--- a/tests/bsim/bluetooth/ll/conn/src/test_connect1.c
+++ b/tests/bsim/bluetooth/ll/conn/src/test_connect1.c
@@ -180,10 +180,9 @@ static uint8_t notify_func(struct bt_conn *conn,
 
 static uint8_t discover_func(struct bt_conn *conn,
 		const struct bt_gatt_attr *attr,
-		struct bt_gatt_discover_params *params)
+		struct bt_gatt_discover_params *params,
+		int err)
 {
-	int err;
-
 	if (!attr) {
 		printk("Discover complete\n");
 		memset(params, 0, sizeof(*params));

--- a/tests/bsim/bluetooth/samples/battery_service/src/central_test.c
+++ b/tests/bsim/bluetooth/samples/battery_service/src/central_test.c
@@ -504,10 +504,8 @@ static void subscribe_battery_level_status(const struct bt_gatt_attr *attr)
 }
 
 static uint8_t discover_func(struct bt_conn *conn, const struct bt_gatt_attr *attr,
-			     struct bt_gatt_discover_params *params)
+			     struct bt_gatt_discover_params *params, int err)
 {
-	int err;
-
 	if (!attr) {
 		LOG_DBG("Discover complete\n");
 		memset(params, 0, sizeof(*params));


### PR DESCRIPTION
Add an error parameter to the discovery callback so that users can differentiate between an error occurring in the discovery process and the attribute simply not existing.

Currently both situations are provided to the user as `attr == NULL`.