### PR TITLE
Bluetooth: host: Fix bug in disconnected handling

### DIFF
--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -933,6 +933,8 @@ static void conn_handle_disconnected(uint16_t handle, uint8_t disconnect_reason)
 			 */
 			disconnected_handles[i] = ~BT_ACL_HANDLE_MASK | handle;
 			disconnected_handles_reason[i] = disconnect_reason;
+
+			return;
 		}
 	}
 }


### PR DESCRIPTION
When disconnected only the first empty slot in the disconnected_handles array should be updated.