### PR TITLE
doc: releases: add more release highlights for 4.0

### DIFF
--- a/doc/releases/migration-guide-4.0.rst
+++ b/doc/releases/migration-guide-4.0.rst
@@ -196,9 +196,6 @@ Crypto
 * Following the deprecation of the TinyCrypt library (:github:`79566`), the
   TinyCrypt-based shim driver was marked as deprecated (:github:`79653`).
 
-Display
-=======
-
 Disk
 ====
 
@@ -238,12 +235,6 @@ Input
 
 * The :dtcompatible:`analog-axis` ``invert`` property has been renamed to
   ``invert-input`` (there's now an ``invert-output`` available as well).
-
-Interrupt Controller
-====================
-
-LED Strip
-=========
 
 PWM
 ===
@@ -348,9 +339,6 @@ Bluetooth HCI
 * The Kconfig option :kconfig:option:`BT_SPI` is now automatically selected based on devicetree
   compatibles and can be removed from board ``.defconfig`` files.
 
-Bluetooth Mesh
-==============
-
 Bluetooth Audio
 ===============
 
@@ -412,9 +400,6 @@ Bluetooth Audio
 
 * ``BT_AUDIO_BROADCAST_CODE_SIZE`` has been removed and ``BT_ISO_BROADCAST_CODE_SIZE`` should be
   used instead. (:github:`80217`)
-
-Bluetooth Classic
-=================
 
 Bluetooth Host
 ==============
@@ -491,9 +476,6 @@ Refer to the extended advertising sample for an example
 implementation of advertiser restarting. The same technique can
 be used for legacy advertising.
 
-Bluetooth Crypto
-================
-
 Networking
 **********
 
@@ -565,9 +547,6 @@ MCUmgr
   The requirement for Bluetooth authentication is now indicated by the :kconfig:option:`CONFIG_MCUMGR_TRANSPORT_BT_PERM_RW_AUTHEN` Kconfig option.
   To remove the default requirement for Bluetooth authentication it is necessary to enable the :kconfig:option:`CONFIG_MCUMGR_TRANSPORT_BT_PERM_RW` Kconfig option in the project configuration.
 
-Modem
-=====
-
 Random
 ======
 
@@ -600,6 +579,3 @@ JWT (JSON Web Token)
 
   They replace the previously-existing Kconfigs ``CONFIG_JWT_SIGN_RSA`` and
   ``CONFIG_JWT_SIGN_ECDSA``. (:github:`79653`)
-
-Architectures
-*************

--- a/doc/releases/release-notes-4.0.rst
+++ b/doc/releases/release-notes-4.0.rst
@@ -1215,8 +1215,6 @@ Libraries / Subsystems
 
   * Made demand paging SMP compatible.
 
-* Formatted output
-
 * Management
 
   * MCUmgr
@@ -1254,10 +1252,6 @@ Libraries / Subsystems
       ``<zephyr/mgmt/hawkbit/autohandler.h>`` and the configuration header file is now
       ``<zephyr/mgmt/hawkbit/config.h>``.
 
-* Logging
-
-* Modem modules
-
 * Power management
 
   * Added initial ESP32-C6 power management interface to allow light and deep-sleep features.
@@ -1287,12 +1281,6 @@ Libraries / Subsystems
     * :kconfig:option:`CONFIG_MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_EPHEMERAL_ENABLED`
       for TLS 1.3 PSK ephemeral key exchange mode.
 
-* CMSIS-NN
-
-* FPGA
-
-* Random
-
 * SD
 
   * No significant changes in this release
@@ -1311,8 +1299,6 @@ Libraries / Subsystems
     runtime, do ``kernel thread -h`` for more info.
   * ``kernel reboot`` shell command without any additional arguments will now do a cold reboot
     instead of requiring you to type ``kernel reboot cold``.
-
-* State Machine Framework
 
 * Storage
 

--- a/doc/releases/release-notes-4.0.rst
+++ b/doc/releases/release-notes-4.0.rst
@@ -425,16 +425,12 @@ Drivers and Sensors
   * Added driver for Analog Devices MAX32 SoC series (:dtcompatible:`adi,max32-adc`).
   * Added support for NXP S32 SAR_ADC (:dtcompatible:`nxp,s32-adc-sar`)
 
-* Battery
-
 * CAN
 
   * Added initial support for Renesas RA CANFD (:dtcompatible:`renesas,ra-canfd-global`,
     :dtcompatible:`renesas,ra-canfd`)
   * Added Flexcan support for S32Z27x (:dtcompatible:`nxp,flexcan`, :dtcompatible:`nxp,flexcan-fd`)
   * Improved NXP S32 CANXL error reporting (:dtcompatible:`nxp,s32-canxl`)
-
-* Charger
 
 * Clock control
 
@@ -604,16 +600,12 @@ Drivers and Sensors
   * Added support for W25Q512JV and W25Q512NW-IQ/IN to NXP's MCUX Flexspi driver
   * Renamed the binding :dtcompatible:`nxp,iap-msf1` to :dtcompatible:`nxp,msf1` for accuracy
 
-* GNSS
-
 * GPIO
 
   * tle9104: Add support for the parallel output mode via setting the properties ``parallel-out12`` and
     ``parallel-out34``.
   * Converted the NXP S32 SIUL2 drivers to native Zephyr code
   * Converted the NXP wake-up drivers to native Zephyr code
-
-* Hardware info
 
 * Haptics
 
@@ -691,8 +683,6 @@ Drivers and Sensors
 
   * Updated ws2812 GPIO driver to support dynamic bus timings
 
-* LoRa
-
 * Mailbox
 
   * Added driver support for ESP32 and ESP32-S3 SoCs.
@@ -728,8 +718,6 @@ Drivers and Sensors
 
   * Improve NXP CSI and MIPI_CSI2Rx drivers to support varibale frame rates
 
-* MSPI
-
 * Pin control
 
   * Added support for Microchip MEC5
@@ -750,8 +738,6 @@ Drivers and Sensors
 
   * Upgraded CP9314 driver to B1 silicon revision
   * Added basic driver for MPS MPM54304
-
-* Reset
 
 * RTC
 

--- a/doc/releases/release-notes-4.0.rst
+++ b/doc/releases/release-notes-4.0.rst
@@ -73,6 +73,17 @@ https://docs.zephyrproject.org/latest/security/vulnerabilities.html
 API Changes
 ***********
 
+Removed APIs in this release
+============================
+
+* Macro ``K_THREAD_STACK_MEMBER``, deprecated since v3.5.0, has been removed.
+  Use :c:macro:`K_KERNEL_STACK_MEMBER` instead.
+
+* ``CBPRINTF_PACKAGE_COPY_*`` macros, deprecated since Zephyr 3.5.0, have been removed.
+
+* ``_ENUM_TOKEN`` and ``_ENUM_UPPER_TOKEN`` macros, deprecated since Zephyr 2.7.0,
+  are no longer generated.
+
 * Removed deprecated arch-level CMSIS header files
   ``include/zephyr/arch/arm/cortex_a_r/cmsis.h`` and
   ``include/zephyr/arch/arm/cortex_m/cmsis.h``. ``cmsis_core.h`` needs to be
@@ -81,20 +92,11 @@ API Changes
 * Removed deprecated ``ceiling_fraction`` macro. :c:macro:`DIV_ROUND_UP` needs
   to be used now.
 
-* Deprecated ``EARLY``, ``APPLICATION`` and ``SMP`` init levels can no longer be
-  used for devices.
-
 * Removed deprecated header file
   ``include/zephyr/random/rand32.h``. ``random.h`` needs to be included now.
 
-Removed APIs in this release
-============================
-
-* Macro ``K_THREAD_STACK_MEMBER``, deprecated since v3.5.0, has been removed.
-  Use :c:macro:`K_KERNEL_STACK_MEMBER` instead.
-* ``CBPRINTF_PACKAGE_COPY_*`` macros, deprecated since Zephyr 3.5.0, have been removed.
-* ``_ENUM_TOKEN`` and ``_ENUM_UPPER_TOKEN`` macros, deprecated since Zephyr 2.7.0,
-  are no longer generated.
+* Deprecated ``EARLY``, ``APPLICATION`` and ``SMP`` init levels can no longer be
+  used for devices.
 
 Deprecated in this release
 ==========================

--- a/doc/releases/release-notes-4.0.rst
+++ b/doc/releases/release-notes-4.0.rst
@@ -9,20 +9,51 @@ We are pleased to announce the release of Zephyr version 4.0.0.
 
 Major enhancements with this release include:
 
-* The introduction of the :ref:`secure storage<secure_storage>` subsystem. It allows the use of the
-  PSA Secure Storage API and of persistent keys in the PSA Crypto API on all board targets. It
+* **Secure Storage Subsystem**:
+  A newly introduced :ref:`secure storage<secure_storage>` subsystem allows the use of the
+  PSA Secure Storage API and of persistent keys in the PSA Crypto API on *all* board targets. It
   is now the standard way to provide device-specific protection to data at rest. (:github:`76222`)
 
-* The introduction of the :ref:`comparator<comparator_api>` device driver subsystem for analog
-  comparators, complete with shell support. It supports initial configuration through devicetree
-  and runtime configuration through vendor specific APIs. Initially the
-  :dtcompatible:`nordic,nrf-comp`, :dtcompatible:`nordic,nrf-lpcomp` and
-  :dtcompatible:`nxp,kinetis-acmp` are supported.
+* **ZMS (Zephyr Memory Storage) Subsystem**:
+  :ref:`ZMS <zms_api>` is a new key-value storage subsystem compatible with all non-volatile storage
+  types, including traditional NOR flash and advanced technologies like RRAM and MRAM that support
+  write without erasure.
 
-* The introduction of the :ref:`stepper<stepper_api>` device driver subsystem for stepper motors,
-  complete with shell support. Initially implemented drivers include a simple
-  :dtcompatible:`zephyr,gpio-stepper` and a complex sensor-less stall-detection capable with
-  integrated ramp-controller :dtcompatible:`adi,tmc5041`.
+* **Analog Comparators**:
+  A new :ref:`comparator<comparator_api>` device driver subsystem for analog comparators has been
+  added, complete with shell support. It supports initial configuration through Devicetree and
+  runtime configuration through vendor specific APIs. Initially the :dtcompatible:`nordic,nrf-comp`,
+  :dtcompatible:`nordic,nrf-lpcomp` and :dtcompatible:`nxp,kinetis-acmp` are supported.
+
+* **Stepper Motors**:
+  It is now possible to interact with stepper motors using a standard API thanks to the new
+  :ref:`stepper<stepper_api>` device driver subsystem, which also comes with shell support.
+  Initially implemented drivers include a simple :dtcompatible:`zephyr,gpio-steppers` and a complex
+  sensor-less stall-detection capable with integrated ramp-controller :dtcompatible:`adi,tmc5041`.
+
+* **Haptics**:
+  A new :ref:`haptics_api` device driver subsystem allows unified access to haptic controllers,
+  enabling users to add haptic feedback to their applications.
+
+* **Multimedia Capabilities**
+  Zephyr's audio and video capabilities have been expanded with support for new image sensors, video
+  interfaces, audio interfaces, and codecs being supported.
+
+* **Prometheus Library**:
+  A `Prometheus`_ metrics library has been added to the networking stack. It provides a way to
+  expose metrics to Prometheus clients over HTTP, facilitating the consolidated remote monitoring of
+  Zephyr devices alongside other systems typically monitored using Prometheus.
+
+* **Documentation Improvements**:
+  Several enhancements were made to the online documentation to improve content discovery and
+  navigation. These include a new :ref:`interactive board catalog <boards>` and an interactive
+  directory for :zephyr:code-sample-category:`code samples <samples>`.
+
+* **Expanded Board Support**:
+  Over 60 :ref:`new boards <boards_added_in_zephyr_4_0>` and
+  :ref:`shields <shields_added_in_zephyr_4_0>` are supported in Zephyr 4.0.
+
+.. _`Prometheus`: https://prometheus.io/
 
 An overview of the changes required or recommended when migrating your application from Zephyr
 v3.7.0 to Zephyr v4.0.0 can be found in the separate :ref:`migration guide<migration_4.0>`.
@@ -221,6 +252,8 @@ Boards & SoC Support
   * NXP mimxrt685: fixed clocks to enable DMIC
   * NXP MCX N Series: Fixed NXP LPSPI native chip select when using synchronous API with DMA bug
 
+.. _boards_added_in_zephyr_4_0:
+
 * Added support for these boards:
 
    * :zephyr:board:`01space ESP32C3 0.42 OLED <esp32c3_042_oled>` (``esp32c3_042_oled``)
@@ -317,6 +350,9 @@ Boards & SoC Support
   * Enabled DSPI and EDMA3 on NXP ``s32z270dc2``
   * Enabled ENET ethernet on NXP ``imx8mm`` and ``imx8mn``
   * Added support for the NXP ``imx8qm`` and ``imx8qxp`` DSP core to enable the openAMP sample
+
+
+.. _shields_added_in_zephyr_4_0:
 
 * Added support for the following shields:
 

--- a/doc/releases/release-notes-4.0.rst
+++ b/doc/releases/release-notes-4.0.rst
@@ -841,7 +841,7 @@ Drivers and Sensors
   * Introduced stepper shell commands for controlling and configuring
     stepper motors with :kconfig:option:`CONFIG_STEPPER_SHELL`
   * Added support for ADI TMC5041 (:dtcompatible:`adi,tmc5041`)
-  * Added support for gpio-stepper-controller (:dtcompatible:`gpio-stepper-controller`)
+  * Added support for gpio-stepper-controller (:dtcompatible:`zephyr,gpio-steppers`)
   * Added stepper api test-suite
   * Added stepper shell test-suite
 

--- a/doc/releases/release-notes-4.0.rst
+++ b/doc/releases/release-notes-4.0.rst
@@ -326,7 +326,7 @@ Boards & SoC Support
   * The nrf54l15bsim target now includes models of the AAR, CCM and ECB peripherals, and many
     other improvements.
   * Support for Google Kukui EC board (``google_kukui``) has been dropped.
-  * STM32: Deprecated MCO configuration via Kconfig in favour of setting it through devicetree.
+  * STM32: Deprecated MCO configuration via Kconfig in favour of setting it through Devicetree.
     See ``samples/boards/stm32/mco`` sample.
   * STM32: STM32CubeProgrammer is now the default runner on all STMicroelectronics STM32 boards.
   * Removed the ``nrf54l15pdk`` board, use :ref:`nrf54l15dk_nrf54l15` instead.
@@ -571,7 +571,7 @@ Drivers and Sensors
     * Added DP83825 phy driver.
     * PHY_MII
 
-      * Fixed generic phy_mii driver not using the value of the ``no-reset`` property from devicetree.
+      * Fixed generic phy_mii driver not using the value of the ``no-reset`` property from Devicetree.
       * Removed excess newlines from log output of phy_mii driver.
     * KSZ8081
 

--- a/doc/releases/release-notes-4.0.rst
+++ b/doc/releases/release-notes-4.0.rst
@@ -1454,8 +1454,8 @@ MCUboot
   * Added SHA512 support to MCUboot code and support for calculating SHA512 hash in imgtool.
   * Added fallback to USB DFU option.
   * Added better mode selection checks to bootutil.
-  * Added bootuil protected TLV size to image size check.
-  * Added functionaliy to remove images with conflicting flags or where features are required
+  * Added bootutil protected TLV size to image size check.
+  * Added functionality to remove images with conflicting flags or where features are required
     that are not supported.
   * Added compressed image flags and TLVs to MCUboot, Kconfig options and support for generating
     compressed LZMA2 images with ARM thumb filter to imgtool.
@@ -1478,7 +1478,7 @@ MCUboot
   * Fixed slot info for directXIP/RAM load in bootutil.
   * Fixed bootutil issue with not zeroing AES and SHA-256 contexts with mbedTLS.
   * Fixed boot_serial ``format`` and ``incompatible-pointer-types`` warnings.
-  * Fixed booltuil wrong definition of ``find_swap_count``.
+  * Fixed bootutil wrong definition of ``find_swap_count``.
   * Fixed bootutil swap move max app size calculation.
   * Fixed imgtool issue where getpub failed for ed25519 key.
   * Fixed issue with sysbuild if something else is named mcuboot.

--- a/doc/releases/release-notes-4.0.rst
+++ b/doc/releases/release-notes-4.0.rst
@@ -869,7 +869,7 @@ Drivers and Sensors
   * Added a sample for capturing video and displaying it with LVGL
     (:zephyr:code-sample:`video-capture-to-lvgl`)
   * Added an automatic test to check colorbar pattern correctness
-  * Added support for GalaxyCore GC2145 image sensor (:dtcompatible:`gc,gc2145`)
+  * Added support for GalaxyCore GC2145 image sensor (:dtcompatible:`galaxycore,gc2145`)
   * Added support for ESP32-S3 LCD-CAM interface (:dtcompatible:`espressif,esp32-lcd-cam`)
   * Added support for NXP MCUX SMARTDMA interface (:dtcompatible:`nxp,smartdma`)
   * Added support for more OmniVision OV2640 controls (:dtcompatible:`ovti,ov2640`)


### PR DESCRIPTION
This adds a few more entries to hopefully complete the list of
4.0 highlights + other cleanups (spelling/typos and removing empty sections)

https://builds.zephyrproject.io/zephyr/pr/81434/docs/releases/release-notes-4.0.html
