### PR TITLE
west.yml: MCUboot synchronization from upstream

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -285,7 +285,7 @@ manifest:
       groups:
         - crypto
     - name: mcuboot
-      revision: f74b77cf7808919837c0ed14c2ead3918c546349
+      revision: eb942067989569f9cf319b087d0bb16b16effd86
       path: bootloader/mcuboot
       groups:
         - bootloader


### PR DESCRIPTION
Update Zephyr fork of MCUboot to revision:
  eb942067989569f9cf319b087d0bb16b16effd86

Brings following Zephyr relevant fixes:
  - eb942067 Allow bootstrapping for multiple images
  - d59ae346 boot_serial: Support sha256, sha384 and sha512
  - bcffc62c boot: bootutil: boot_record: Fix issue with saving image data
  - 099f4284 boot: zephyr: Add fallback for overhead calculation when auto fails
  - ab014436 boards: mcxn947_qspi: fix mcuboot partition allocation
  - bd7423d1 boot: zephyr: Add warning on default key file usage
  - a03c95f6 doc: remove repetition
  - 040fc42a boot/zephyr: Load image to RAM on single loader
  - 84c68ace boot/zephyr: Add CONFIG_SINGLE_APPLICATION_SLOT_RAM_LOAD
  - 77d911f4 boot/bootutil: Add MCUBOOT_SINGLE_APPLICATION_SLOT_RAM_LOAD mode
  - 0c721da7 boot/bootutil: Split RAM load code to its own file

Notes on process:
 1) The MCUboot update from [mcu-tools/mcuboot/main](https://github.com/mcu-tools/mcuboot/tree/main) with the SHA used in west.yaml is already synchronized to [zephyrproject-rtos/mcuboot/upstream-sync](https://github.com/zephyrproject-rtos/mcuboot/tree/upstream-sync) branch, and is available in the Zephyr fork of MCUboot.
 2) The [DNM] on this PR should be kept until the PR passes all tests and is accepted.
 3) Once the PR passes all tests and gets accepted, the upstream-sync branch should be fast-forward merged to [zephyrproject-rtos/mcuboot/main](https://github.com/zephyrproject-rtos/mcuboot/tree/main) branch and [DNM] should be removed.
 4) After the main branch gets updated, this PR does not require further changes and should be merged as is.