### PR TITLE
soc: nordic: handle -include for IAR

### DIFF
--- a/cmake/compiler/compiler_flags_template.cmake
+++ b/cmake/compiler/compiler_flags_template.cmake
@@ -143,3 +143,6 @@ set_compiler_property(PROPERTY no_builtin_malloc)
 # Compiler flag for defining specs. Used only by gcc, other compilers may keep
 # this undefined.
 set_compiler_property(PROPERTY specs)
+
+# Compiler flag for defining preinclude files.
+set_compiler_property(PROPERTY include_file)

--- a/cmake/compiler/gcc/compiler_flags.cmake
+++ b/cmake/compiler/gcc/compiler_flags.cmake
@@ -244,3 +244,5 @@ set_compiler_property(PROPERTY no_builtin -fno-builtin)
 set_compiler_property(PROPERTY no_builtin_malloc -fno-builtin-malloc)
 
 set_compiler_property(PROPERTY specs -specs=)
+
+set_compiler_property(PROPERTY include_file -include)

--- a/soc/nordic/CMakeLists.txt
+++ b/soc/nordic/CMakeLists.txt
@@ -17,11 +17,13 @@ zephyr_library_sources(
 # headers for different SoCs.
 set(dt_binding_includes ${DTS_INCLUDE_FILES})
 list(FILTER dt_binding_includes INCLUDE REGEX "/dt-bindings/.*\.h$")
-list(TRANSFORM dt_binding_includes PREPEND "-include;")
+
+set(include_flag $<TARGET_PROPERTY:compiler,include_file>$<SEMICOLON>)
+
 set_source_files_properties(
   validate_binding_headers.c
   DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
-  PROPERTIES COMPILE_OPTIONS "${dt_binding_includes}"
+  PROPERTIES COMPILE_OPTIONS "${include_flag}$<JOIN:${dt_binding_includes},;${include_flag}>"
 )
 
 if(CONFIG_SOC_HAS_TIMING_FUNCTIONS AND NOT CONFIG_BOARD_HAS_TIMING_FUNCTIONS)


### PR DESCRIPTION
CMakeLists.txt uses the C compiler parameter -include, for IAR this is --preinclude.