### PR TITLE
drivers: misc: coresight: Enable log colors for STMESP logging

### DIFF
--- a/drivers/misc/coresight/Kconfig
+++ b/drivers/misc/coresight/Kconfig
@@ -23,6 +23,7 @@ config NRF_ETR_DECODE
 	select CS_TRACE_DEFMT
 	select LOG_FRONTEND_STMESP_DEMUX
 	select LOG_OUTPUT
+	imply LOG_BACKEND_SHOW_COLOR
 	imply CBPRINTF_FP_SUPPORT
 	help
 	  In this mode, log messages stored by Coresight STM logging frontends are

--- a/subsys/logging/Kconfig.formatting
+++ b/subsys/logging/Kconfig.formatting
@@ -134,9 +134,8 @@ config LOG_IMMEDIATE_CLEAN_OUTPUT
 
 config LOG_BACKEND_SHOW_COLOR
 	bool "Colors in the backend"
-	depends on LOG_BACKEND_UART || LOG_BACKEND_NATIVE_POSIX || LOG_BACKEND_RTT \
+	default y if LOG_BACKEND_UART || LOG_BACKEND_NATIVE_POSIX || LOG_BACKEND_RTT \
 	           || LOG_BACKEND_SWO || LOG_BACKEND_XTENSA_SIM || SHELL_LOG_BACKEND
-	default y
 	help
 	  When enabled selected backend prints errors in red and warning in yellow.
 


### PR DESCRIPTION
LOG_BACKEND_SHOW_COLOR could not be set because it was depending on selected backends. Setting this option should not be blocked and for those backends it should have `default y` to have coloring there out of the box.
After changing `depends on` to `default y` it can be set by the ETR handler which decodes STMESP logging.