### PR TITLE
pm: device_runtime: Optimize pm_device_runtime_usage

### DIFF
--- a/subsys/pm/device_runtime.c
+++ b/subsys/pm/device_runtime.c
@@ -563,25 +563,9 @@ bool pm_device_runtime_is_enabled(const struct device *dev)
 
 int pm_device_runtime_usage(const struct device *dev)
 {
-	struct pm_device *pm = dev->pm;
-	uint32_t usage;
-
 	if (!pm_device_runtime_is_enabled(dev)) {
 		return -ENOTSUP;
 	}
 
-	if (atomic_test_bit(&dev->pm_base->flags, PM_DEVICE_FLAG_ISR_SAFE)) {
-		struct pm_device_isr *pm_sync = dev->pm_isr;
-		k_spinlock_key_t k = k_spin_lock(&pm_sync->lock);
-
-		usage = pm_sync->base.usage;
-
-		k_spin_unlock(&pm_sync->lock, k);
-	} else {
-		(void)k_sem_take(&pm->lock, K_FOREVER);
-		usage = pm->base.usage;
-		k_sem_give(&pm->lock);
-	}
-
-	return usage;
+	return dev->pm_base->usage;
 }


### PR DESCRIPTION
There is no point in using lock or semaphore to read current usage counter as it may change after unlocking or giving back the semaphore. Value can only be trusted in the controlled environment (e.g. test).