### PR TITLE
modules: hal_nordic: nrfs: Optimize communication

### DIFF
--- a/modules/hal_nordic/nrfs/backends/nrfs_backend_ipc_service.c
+++ b/modules/hal_nordic/nrfs/backends/nrfs_backend_ipc_service.c
@@ -176,7 +176,10 @@ nrfs_err_t nrfs_backend_send(void *message, size_t size)
 
 nrfs_err_t nrfs_backend_send_ex(void *message, size_t size, k_timeout_t timeout, bool high_prio)
 {
-	if (size <= MAX_PACKET_DATA_SIZE) {
+	if (!k_is_in_isr() && nrfs_backend_connected()) {
+		return ipc_service_send(&ipc_cpusys_channel_config.ipc_ept, message, size) ?
+			NRFS_SUCCESS : NRFS_ERR_IPC;
+	} else if (size <= MAX_PACKET_DATA_SIZE) {
 		int err;
 		struct ipc_data_packet tx_data;
 


### PR DESCRIPTION
It is not needed to use always the system work queue to send a message over IPC. In thread context IPC service can be called directly. It speeds up the communication and allows to use nrfs from the system work queue. Legacy approach could easily lead to the deadlock if user would call nrfs from work queue and pend on semaphore until response is received.