### PR TITLE
test: arm: irq: Add overlays files for Infineon boards

### DIFF
--- a/boards/infineon/cy8cproto_062_4343w/cy8cproto_062_4343w_defconfig
+++ b/boards/infineon/cy8cproto_062_4343w/cy8cproto_062_4343w_defconfig
@@ -17,6 +17,9 @@ CONFIG_UART_CONSOLE=y
 # Enable UART driver
 CONFIG_SERIAL=y
 
+# Enable GPIO driver
+CONFIG_GPIO=y
+
 # Enable clock controller
 CONFIG_CLOCK_CONTROL=y
 

--- a/boards/infineon/cy8cproto_063_ble/cy8cproto_063_ble_defconfig
+++ b/boards/infineon/cy8cproto_063_ble/cy8cproto_063_ble_defconfig
@@ -18,6 +18,9 @@ CONFIG_UART_CONSOLE=y
 # Enable UART driver
 CONFIG_SERIAL=y
 
+# Enable GPIO
+CONFIG_GPIO=y
+
 # Enable clock controller
 CONFIG_CLOCK_CONTROL=y
 

--- a/boards/infineon/cyw920829m2evk_02/cyw920829m2evk_02_defconfig
+++ b/boards/infineon/cyw920829m2evk_02/cyw920829m2evk_02_defconfig
@@ -18,6 +18,9 @@ CONFIG_UART_CONSOLE=y
 # Enable UART driver
 CONFIG_SERIAL=y
 
+# Enable GPIO driver
+CONFIG_GPIO=y
+
 # Enable clock controller
 CONFIG_CLOCK_CONTROL=y
 

--- a/tests/arch/arm/arm_irq_advanced_features/boards/cy8cproto_062_4343w.overlay
+++ b/tests/arch/arm/arm_irq_advanced_features/boards/cy8cproto_062_4343w.overlay
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2024 Cypress Semiconductor Corporation.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Changed default interrupts priority for GPIO to 4 */
+&gpio_prt0 {
+	interrupts = <0 4>;
+};
+
+&gpio_prt2 {
+	interrupts = <2 4>;
+};
+
+&gpio_prt3 {
+	interrupts = <3 4>;
+};
+
+&gpio_prt5 {
+	interrupts = <5 4>;
+};
+
+&gpio_prt6 {
+	interrupts = <6 4>;
+};
+
+&gpio_prt9 {
+	interrupts = <9 4>;
+};
+
+&gpio_prt12 {
+	interrupts = <12 4>;
+};
+
+&gpio_prt13 {
+	interrupts = <13 4>;
+};

--- a/tests/arch/arm/arm_irq_advanced_features/boards/cy8cproto_063_ble.overlay
+++ b/tests/arch/arm/arm_irq_advanced_features/boards/cy8cproto_063_ble.overlay
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2024 Cypress Semiconductor Corporation.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Changed default interrupts priority for GPIO to 4 */
+&gpio_prt0 {
+	interrupts = <0 4>;
+};
+
+&gpio_prt5 {
+	interrupts = <5 4>;
+};
+
+&gpio_prt6 {
+	interrupts = <6 4>;
+};
+
+&gpio_prt7 {
+	interrupts = <7 4>;
+};
+
+&gpio_prt9 {
+	interrupts = <9 4>;
+};
+
+&gpio_prt10 {
+	interrupts = <10 4>;
+};
+
+&gpio_prt12 {
+	interrupts = <12 4>;
+};

--- a/tests/arch/arm/arm_irq_advanced_features/boards/cyw920829m2evk_02.overlay
+++ b/tests/arch/arm/arm_irq_advanced_features/boards/cyw920829m2evk_02.overlay
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2024 Cypress Semiconductor Corporation.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Changed default interrupts priority for GPIO to 4 */
+&gpio_prt0 {
+	interrupts = <0 4>;
+};
+
+&gpio_prt1 {
+	interrupts = <1 4>;
+};
+
+&gpio_prt3 {
+	interrupts = <3 4>;
+};
+
+&gpio_prt5 {
+	interrupts = <5 4>;
+};

--- a/tests/arch/arm/arm_irq_zero_latency_levels/boards/cy8cproto_062_4343w.overlay
+++ b/tests/arch/arm/arm_irq_zero_latency_levels/boards/cy8cproto_062_4343w.overlay
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2024 Cypress Semiconductor Corporation.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Changed default interrupts priority for GPIO to 4 */
+&gpio_prt0 {
+	interrupts = <0 4>;
+};
+
+&gpio_prt2 {
+	interrupts = <2 4>;
+};
+
+&gpio_prt3 {
+	interrupts = <3 4>;
+};
+
+&gpio_prt5 {
+	interrupts = <5 4>;
+};
+
+&gpio_prt6 {
+	interrupts = <6 4>;
+};
+
+&gpio_prt9 {
+	interrupts = <9 4>;
+};
+
+&gpio_prt12 {
+	interrupts = <12 4>;
+};
+
+&gpio_prt13 {
+	interrupts = <13 4>;
+};

--- a/tests/arch/arm/arm_irq_zero_latency_levels/boards/cy8cproto_063_ble.overlay
+++ b/tests/arch/arm/arm_irq_zero_latency_levels/boards/cy8cproto_063_ble.overlay
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2024 Cypress Semiconductor Corporation.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Changed default interrupts priority for GPIO to 4 */
+&gpio_prt0 {
+	interrupts = <0 4>;
+};
+
+&gpio_prt5 {
+	interrupts = <5 4>;
+};
+
+&gpio_prt6 {
+	interrupts = <6 4>;
+};
+
+&gpio_prt7 {
+	interrupts = <7 4>;
+};
+
+&gpio_prt9 {
+	interrupts = <9 4>;
+};
+
+&gpio_prt10 {
+	interrupts = <10 4>;
+};
+
+&gpio_prt12 {
+	interrupts = <12 4>;
+};

--- a/tests/arch/arm/arm_irq_zero_latency_levels/boards/cyw920829m2evk_02.overlay
+++ b/tests/arch/arm/arm_irq_zero_latency_levels/boards/cyw920829m2evk_02.overlay
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2024 Cypress Semiconductor Corporation.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Changed default interrupts priority for GPIO to 4 */
+&gpio_prt0 {
+	interrupts = <0 4>;
+};
+
+&gpio_prt1 {
+	interrupts = <1 4>;
+};
+
+&gpio_prt3 {
+	interrupts = <3 4>;
+};
+
+&gpio_prt5 {
+	interrupts = <5 4>;
+};


### PR DESCRIPTION
[Infineon: board: Add CONFIG_GPIO to defconfigs](https://github.com/zephyrproject-rtos/zephyr/commit/b94bb41cfef3f588bdb2a9857427aa13a8acc7c8) 

Add CONFIG_GPIO from defconfigs for Infineon boards.

Revert pull/81377, which affect some ble samples which
used GPIO.

Signed-off-by: Nazar Palamar <nazar.palamar@infineon.com>


[test: arm: irq: Add overlays files for Infineon boards](https://github.com/zephyrproject-rtos/zephyr/commit/86139976baf96c3fb88455a448e862b371f3e599) 

Changed interrupt priority for GPIO, default 6 is not suitable for
for the ZERO_LATENCY_IRQS function used in this test.
used in this test.


FIX CI: https://github.com/zephyrproject-rtos/zephyr/actions/runs/11524969451/job/32695832470?pr=80025
Signed-off-by: Nazar Palamar <nazar.palamar@infineon.com>