### PR TITLE
twister: Allow sharing hardware platform between variants

### DIFF
--- a/doc/develop/test/twister.rst
+++ b/doc/develop/test/twister.rst
@@ -1278,6 +1278,25 @@ using an external J-Link probe.  The ``probe_id`` keyword overrides the
       runner: jlink
       serial: null
 
+Using Single Board For Multiple Variants
+++++++++++++++++++++++++++++++++++++++++
+
+  The ``platform`` attribute can be a list of names or a string
+  with names separated by spaces. This allows to run tests for
+  different platform variants on the same physical board, without
+  re-configuring the hardware map file for each variant. For example:
+
+.. code-block:: yaml
+
+    - connected: true
+      id: '001234567890'
+      platform:
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf5340dk/nrf5340/cpuapp/ns
+      product: J-Link
+      runner: nrfjprog
+      serial: /dev/ttyACM1
+
 Quarantine
 ++++++++++
 

--- a/scripts/pylib/twister/twisterlib/hardwaremap.py
+++ b/scripts/pylib/twister/twisterlib/hardwaremap.py
@@ -262,7 +262,13 @@ class HardwareMap:
             flash_before = dut.get('flash_before')
             if flash_before is None:
                 flash_before = self.options.flash_before and (not (flash_with_test or serial_pty))
-            platform  = dut.get('platform')
+            platform = dut.get('platform')
+            if isinstance(platform, str):
+                platforms = platform.split()
+            elif isinstance(platform, list):
+                platforms = platform
+            else:
+                raise ValueError(f"Invalid platform value: {platform}")
             id = dut.get('id')
             runner = dut.get('runner')
             runner_params = dut.get('runner_params')
@@ -270,28 +276,29 @@ class HardwareMap:
             baud = dut.get('baud', None)
             product = dut.get('product')
             fixtures = dut.get('fixtures', [])
-            connected= dut.get('connected') and ((serial or serial_pty) is not None)
+            connected = dut.get('connected') and ((serial or serial_pty) is not None)
             if not connected:
                 continue
-            new_dut = DUT(platform=platform,
-                          product=product,
-                          runner=runner,
-                          runner_params=runner_params,
-                          id=id,
-                          serial_pty=serial_pty,
-                          serial=serial,
-                          serial_baud=baud,
-                          connected=connected,
-                          pre_script=pre_script,
-                          flash_before=flash_before,
-                          post_script=post_script,
-                          post_flash_script=post_flash_script,
-                          script_param=script_param,
-                          flash_timeout=flash_timeout,
-                          flash_with_test=flash_with_test)
-            new_dut.fixtures = fixtures
-            new_dut.counter = 0
-            self.duts.append(new_dut)
+            for plat in platforms:
+                new_dut = DUT(platform=plat,
+                              product=product,
+                              runner=runner,
+                              runner_params=runner_params,
+                              id=id,
+                              serial_pty=serial_pty,
+                              serial=serial,
+                              serial_baud=baud,
+                              connected=connected,
+                              pre_script=pre_script,
+                              flash_before=flash_before,
+                              post_script=post_script,
+                              post_flash_script=post_flash_script,
+                              script_param=script_param,
+                              flash_timeout=flash_timeout,
+                              flash_with_test=flash_with_test)
+                new_dut.fixtures = fixtures
+                new_dut.counter = 0
+                self.duts.append(new_dut)
 
     def scan(self, persistent=False):
         from serial.tools import list_ports

--- a/scripts/schemas/twister/hwmap-schema.yaml
+++ b/scripts/schemas/twister/hwmap-schema.yaml
@@ -16,7 +16,7 @@ sequence:
         type: str
         required: false
       "platform":
-        type: str
+        type: any
         required: true
       "probe_id":
         type: str

--- a/scripts/tests/twister/test_handlers.py
+++ b/scripts/tests/twister/test_handlers.py
@@ -1275,6 +1275,7 @@ def test_devicehandler_create_serial_connection(
     dut = DUT()
     dut.available = 0
     dut.failures = 0
+    handler.duts = [dut]
 
     hardware_baud = 14400
     flash_timeout = 60


### PR DESCRIPTION
Extended hardware map to share a single board between variants. To run tests for different variants on the same board without re-configuring the hardware map file for each variant, one can extend the `platform` attribute with board names separated by spaces or use `platform` as a list.

Generate hardware map:
`${ZEPHYR_BASE}/scripts/twister --generate-hardware-map hardware_map.yml`

Update platform with two variants you want to use:
```
- connected: true
  id: '001050076605'
  platform: nrf5340dk/nrf5340/cpuapp nrf5340dk/nrf5340/cpuapp/ns
  product: J-Link
  runner: nrfjprog
  serial: /dev/ttyACM1
```

Run tests:
`./scripts/twister -T samples/hello_world --device-testing --hardware-map hardware_map.yml --west-flash=--recover -vv --no-clean -ll debug`

```
DEBUG   - platform filter: ['nrf5340dk/nrf5340/cpuapp', 'nrf5340dk/nrf5340/cpuapp/ns']
...
| Board                       |           ID |   Counter |   Failures |
|-----------------------------|--------------|-----------|------------|
| nrf5340dk/nrf5340/cpuapp    | 001050076605 |         1 |          0 |
| nrf5340dk/nrf5340/cpuapp/ns | 001050076605 |         1 |          0 |
```

When test is run on a selected board, then all DUTs with same `id` are locked.




