### PR TITLE
tests: thread_error_case and ztest/base: fix incorrect userspace filtering

### DIFF
--- a/tests/kernel/threads/thread_error_case/testcase.yaml
+++ b/tests/kernel/threads/thread_error_case/testcase.yaml
@@ -4,7 +4,7 @@ tests:
       - kernel
       - threads
       - userspace
-    filter: CONFIG_USERSPACE
+    filter: CONFIG_ARCH_HAS_USERSPACE
     ignore_faults: true
     integration_platforms:
       - qemu_x86

--- a/tests/ztest/base/testcase.yaml
+++ b/tests/ztest/base/testcase.yaml
@@ -16,7 +16,7 @@ tests:
     integration_platforms:
       - native_sim
   testing.ztest.base.verbose_0_userspace:
-    filter: CONFIG_USERSPACE
+    filter: CONFIG_ARCH_HAS_USERSPACE
     extra_args: CONF_FILE=prj_verbose_0.conf
     tags:
       - userspace


### PR DESCRIPTION
The filter here should be used to filter for capability: whether the platform configuration supports userspace. And if it does support userspace, we then enable CONFIG_TEST_USERSPACE (and thus CONFIG_USERSPACE) for testing. We should not be filtering for whether userspace is enabled, but should really be filtering for whether userspace is supported.