### PR TITLE
manifest: hal_nxp: update to include subset pin control files

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -198,7 +198,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: 3c64cd63125c86870802a561ce79dc33697b005c
+      revision: pull/468/head
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
Update NXP HAL manifest to include pin control files for subset parts, which typically do not have a board target defined within Zephyr but are still supported by NXP's HAL.