### PR TITLE
ARCMWDT: continue RISC-V enablement

### DIFF
--- a/cmake/compiler/arcmwdt/compiler_flags.cmake
+++ b/cmake/compiler/arcmwdt/compiler_flags.cmake
@@ -115,7 +115,7 @@ set_compiler_property(PROPERTY warning_error_misra_sane -Werror=vla)
 
 set_compiler_property(PROPERTY cstd -std=)
 
-if (NOT CONFIG_ARCMWDT_LIBC)
+if (NOT CONFIG_ARCMWDT_LIBC AND NOT CONFIG_PICOLIBC_USE_TOOLCHAIN)
   set_compiler_property(PROPERTY nostdinc -Hno_default_include -Hnoarcexlib -U__STDC_LIB_EXT1__)
   set_compiler_property(APPEND PROPERTY nostdinc_include ${NOSTDINC})
 endif()
@@ -196,7 +196,7 @@ set_compiler_property(PROPERTY no_global_merge "")
 # Required ASM flags when using mwdt
 set_property(TARGET asm PROPERTY required "-Hasmcpp")
 
-if(CONFIG_ARCMWDT_LIBC)
+if(CONFIG_ARCMWDT_LIBC OR CONFIG_PICOLIBC_USE_TOOLCHAIN)
   # We rely on the default C/C++ include locations which are provided by MWDT if we do build with
   # MW C / C++ libraries. However, for that case we still need to explicitly set header directory
   # to ASM builds (which may use 'stdbool.h').

--- a/cmake/compiler/arcmwdt/compiler_flags.cmake
+++ b/cmake/compiler/arcmwdt/compiler_flags.cmake
@@ -124,12 +124,10 @@ endif()
 set_property(TARGET compiler-cpp PROPERTY dialect_cpp98 "-std=c++98")
 set_property(TARGET compiler-cpp PROPERTY dialect_cpp11 "-std=c++11")
 set_property(TARGET compiler-cpp PROPERTY dialect_cpp14 "-std=c++14")
-set_property(TARGET compiler-cpp PROPERTY dialect_cpp17 "-std=c++17")
-
-#no support of C++2a, C++20, C++2b
-set_property(TARGET compiler-cpp PROPERTY dialect_cpp2a "")
-set_property(TARGET compiler-cpp PROPERTY dialect_cpp20 "")
-set_property(TARGET compiler-cpp PROPERTY dialect_cpp2b "")
+set_property(TARGET compiler-cpp PROPERTY dialect_cpp17 "-std=c++17" "-Wno-register")
+set_property(TARGET compiler-cpp PROPERTY dialect_cpp2a "-std=c++2a" "-Wno-register")
+set_property(TARGET compiler-cpp PROPERTY dialect_cpp20 "-std=c++20" "-Wno-register")
+set_property(TARGET compiler-cpp PROPERTY dialect_cpp2b "-std=c++2b" "-Wno-register")
 
 # Flag for disabling strict aliasing rule in C and C++
 set_compiler_property(PROPERTY no_strict_aliasing -fno-strict-aliasing)

--- a/cmake/compiler/arcmwdt/generic.cmake
+++ b/cmake/compiler/arcmwdt/generic.cmake
@@ -25,7 +25,7 @@ if(ret)
   ${full_version_output}"
   )
 else()
-  set(ARCMWDT_MIN_REQUIRED_VERS "2022.09")
+  set(ARCMWDT_MIN_REQUIRED_VERS "2024.06")
 #
 # Regular version has format: "T-2022.06"
 # Engineering builds: "ENG-2022.06-001"

--- a/cmake/compiler/arcmwdt/target.cmake
+++ b/cmake/compiler/arcmwdt/target.cmake
@@ -43,9 +43,3 @@ endif()
 if(NOT CONFIG_ARCMWDT_LIBC)
   list(APPEND TOOLCHAIN_C_FLAGS -fno-builtin)
 endif()
-
-# The MWDT compiler requires different macro definitions for ARC and RISC-V
-# architectures. __MW_ASM_RV_MACRO__ allows to select appropriate compilation branch.
-if(CONFIG_RISCV)
-  list(APPEND TOOLCHAIN_C_FLAGS -D__MW_ASM_RV_MACRO__)
-endif()

--- a/cmake/compiler/arcmwdt/target.cmake
+++ b/cmake/compiler/arcmwdt/target.cmake
@@ -40,6 +40,13 @@ endif()
 # We can't rely on these functions presence if we don't use MWDT libc.
 # NOTE: the option name '-fno-builtin' is misleading a bit - we still can
 # manually call __builtin_** functions even if we specify it.
-if(NOT CONFIG_ARCMWDT_LIBC)
+if(NOT CONFIG_ARCMWDT_LIBC AND NOT CONFIG_PICOLIBC_USE_TOOLCHAIN)
   list(APPEND TOOLCHAIN_C_FLAGS -fno-builtin)
+endif()
+
+# Set the default include path depending on the C library we're going to use
+if(CONFIG_ARCMWDT_LIBC)
+  list(APPEND TOOLCHAIN_C_FLAGS -Hlibc=mw)
+elseif(CONFIG_PICOLIBC_USE_TOOLCHAIN)
+  list(APPEND TOOLCHAIN_C_FLAGS -Hlibc=pico)
 endif()

--- a/cmake/linker/arcmwdt/linker_flags.cmake
+++ b/cmake/linker/arcmwdt/linker_flags.cmake
@@ -16,12 +16,21 @@ check_set_linker_property(TARGET linker PROPERTY baremetal
                           -Hnocrt
 )
 
-# There are two options:
-# - We have full MWDT libc support and we link MWDT libc - this is default
-#   behavior and we don't need to do something for that.
-# - We use minimal libc provided by Zephyr itself. In that case we must not
-#   link MWDT libc, but we still need to link libmw
-if(CONFIG_MINIMAL_LIBC)
+# There are three options:
+# - We have full MWDT libc support in the toolchain and we link MWDT libc
+# - We have full Picolibc support in the toolchain and we link Picolibc
+# - We use some libc provided by Zephyr itself (minimal or Picolibc).
+#   In that case we must not link our MWDT libc or Picolibc,
+#   but we still need to link libmw
+if(CONFIG_ARCMWDT_LIBC)
+  check_set_linker_property(TARGET linker APPEND PROPERTY baremetal
+                            -Hlibc=mw
+  )
+elseif(CONFIG_PICOLIBC_USE_TOOLCHAIN)
+  check_set_linker_property(TARGET linker APPEND PROPERTY baremetal
+                            -Hlibc=pico
+  )
+else()
   check_set_linker_property(TARGET linker APPEND PROPERTY baremetal
                             -Hnolib
                             -Hldopt=-lmw

--- a/cmake/toolchain/arcmwdt/Kconfig.defconfig
+++ b/cmake/toolchain/arcmwdt/Kconfig.defconfig
@@ -2,4 +2,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config PICOLIBC_SUPPORTED
-	default n
+	default n if ARC

--- a/cmake/toolchain/arcmwdt/generic.cmake
+++ b/cmake/toolchain/arcmwdt/generic.cmake
@@ -51,3 +51,4 @@ set(CROSS_COMPILE ${TOOLCHAIN_HOME}/arc/bin/)
 set(SYSROOT_DIR ${TOOLCHAIN_HOME}/${SYSROOT_TARGET})
 
 set(TOOLCHAIN_HAS_NEWLIB OFF CACHE BOOL "True if toolchain supports newlib")
+set(TOOLCHAIN_HAS_PICOLIBC ON CACHE BOOL "True if toolchain supports picolibc")

--- a/include/zephyr/toolchain/mwdt.h
+++ b/include/zephyr/toolchain/mwdt.h
@@ -20,14 +20,14 @@
 #define FUNC_CODE()
 #define FUNC_INSTR(a)
 
-#ifdef __MW_ASM_RV_MACRO__
+#ifdef CONFIG_RISCV
 .macro section_var_mwdt, section, symbol
-	.section \section().\symbol, "aw"
+	.section .\section\().\symbol, "aw"
 	\symbol :
 .endm
 
 .macro section_func_mwdt, section, symbol
-	.section \section().\symbol, "ax"
+	.section .\section\().\symbol, "ax"
 	FUNC_CODE()
 	PERFOPT_ALIGN
 	\symbol :
@@ -35,11 +35,11 @@
 .endm
 
 .macro section_subsec_func_mwdt, section, subsection, symbol
-	.section \section().\subsection, "ax"
+	.section .\section\().\subsection, "ax"
 	PERFOPT_ALIGN
 	\symbol :
 .endm
-#else
+#else  /* CONFIG_RISCV */
 .macro section_var_mwdt, section, symbol
 	.section .\&section\&.\&symbol, "aw"
 	symbol :
@@ -58,14 +58,14 @@
 	PERFOPT_ALIGN
 	symbol :
 .endm
-#endif /* __MW_ASM_RV_MACRO__ */
+#endif /* CONFIG_RISCV */
 
 #define SECTION_VAR(sect, sym) section_var_mwdt sect, sym
 #define SECTION_FUNC(sect, sym) section_func_mwdt sect, sym
 #define SECTION_SUBSEC_FUNC(sect, subsec, sym) \
 	section_subsec_func_mwdt sect, subsec, sym
 
-#ifdef __MW_ASM_RV_MACRO__
+#ifdef CONFIG_RISCV
 .macro glbl_text_mwdt, symbol
 	.globl \symbol
 	.type \symbol, @function
@@ -76,16 +76,16 @@
 	.type \symbol, @object
 .endm
 
-.macro weak_data_mwdt, symbol
-	.weak \symbol
-	.type \symbol, @object
-.endm
-
 .macro weak_text_mwdt, symbol
 	.weak \symbol
 	.type \symbol, @function
 .endm
-#else
+
+.macro weak_data_mwdt, symbol
+	.weak \symbol
+	.type \symbol, @object
+.endm
+#else  /* CONFIG_RISCV */
 .macro glbl_text_mwdt, symbol
 	.globl symbol
 	.type symbol, @function
@@ -96,32 +96,31 @@
 	.type symbol, @object
 .endm
 
-.macro weak_data_mwdt, symbol
-	.weak symbol
-	.type symbol, @object
-.endm
-
 .macro weak_text_mwdt, symbol
 	.weak symbol
 	.type symbol, @function
 .endm
-#endif /* __MW_ASM_RV_MACRO__ */
+
+.macro weak_data_mwdt, symbol
+	.weak symbol
+	.type symbol, @object
+.endm
+#endif /* CONFIG_RISCV */
 
 #define GTEXT(sym) glbl_text_mwdt sym
 #define GDATA(sym) glbl_data_mwdt sym
-#define WDATA(sym) weak_data_mwdt sym
 #define WTEXT(sym) weak_text_mwdt sym
+#define WDATA(sym) weak_data_mwdt sym
 
 #else /* defined(_ASMLANGUAGE) */
 
 #ifdef CONFIG_NEWLIB_LIBC
-  #error "ARC MWDT doesn't support building with CONFIG_NEWLIB_LIBC as it doesn't have newlib"
+#error "ARC MWDT doesn't support building with CONFIG_NEWLIB_LIBC as it doesn't have newlib"
 #endif /* CONFIG_NEWLIB_LIBC */
 
 #ifdef CONFIG_NATIVE_APPLICATION
-  #error "ARC MWDT doesn't support building Zephyr as an native application"
+#error "ARC MWDT doesn't support building Zephyr as a native application"
 #endif /* CONFIG_NATIVE_APPLICATION */
-
 
 #define __no_optimization __attribute__((optnone))
 #define __fallthrough     __attribute__((fallthrough))

--- a/lib/libc/Kconfig
+++ b/lib/libc/Kconfig
@@ -115,6 +115,7 @@ config ARCMWDT_LIBC
 	bool "ARC MWDT C library"
 	depends on !NATIVE_APPLICATION
 	depends on "$(ZEPHYR_TOOLCHAIN_VARIANT)" = "arcmwdt"
+	select LIBC_ERRNO if RISCV
 	help
 	  C library provided by ARC MWDT toolchain.
 

--- a/lib/libc/arcmwdt/libc-hooks.c
+++ b/lib/libc/arcmwdt/libc-hooks.c
@@ -91,10 +91,12 @@ int _isatty(int file)
 	return 0;
 }
 
+#ifndef CONFIG_LIBC_ERRNO
 int *___errno(void)
 {
 	return z_errno();
 }
+#endif
 
 __weak void _exit(int status)
 {

--- a/tests/lib/cpp/libcxx/testcase.yaml
+++ b/tests/lib/cpp/libcxx/testcase.yaml
@@ -24,7 +24,7 @@ tests:
     integration_platforms:
       - mps2/an385
   cpp.libcxx.glibcxx.picolibc:
-    filter: TOOLCHAIN_HAS_PICOLIBC == 1
+    filter: TOOLCHAIN_HAS_PICOLIBC == 1 and CONFIG_PICOLIBC_SUPPORTED
     toolchain_exclude: xcc
     tags: cpp
     timeout: 60

--- a/tests/lib/cpp/libcxx/testcase.yaml
+++ b/tests/lib/cpp/libcxx/testcase.yaml
@@ -25,7 +25,7 @@ tests:
       - mps2/an385
   cpp.libcxx.glibcxx.picolibc:
     filter: TOOLCHAIN_HAS_PICOLIBC == 1 and CONFIG_PICOLIBC_SUPPORTED
-    toolchain_exclude: xcc
+    toolchain_exclude: xcc arcmwdt
     tags: cpp
     timeout: 60
     extra_configs:


### PR DESCRIPTION
The current state of ARC MWDT toolchain support doesn't really allow building Zephyr for our ARC-V cores.