### PR TITLE
west: runner: add support for ecpprog

### DIFF
--- a/boards/common/ecpprog.board.cmake
+++ b/boards/common/ecpprog.board.cmake
@@ -1,0 +1,5 @@
+# Copyright (c) 2024 tinyVision.ai Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+board_set_flasher_ifnset(ecpprog)
+board_finalize_runner_args(ecpprog)

--- a/scripts/west_commands/runners/__init__.py
+++ b/scripts/west_commands/runners/__init__.py
@@ -31,6 +31,7 @@ _names = [
     'canopen_program',
     'dediprog',
     'dfu',
+    'ecpprog',
     'esp32',
     'ezflashcli',
     'gd32isp',

--- a/scripts/west_commands/runners/ecpprog.py
+++ b/scripts/west_commands/runners/ecpprog.py
@@ -1,0 +1,41 @@
+# Copyright (c) 2024 tinyVision.ai Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Runner for the ecpprog programming tool for Lattice FPGAs."""
+# https://github.com/gregdavill/ecpprog
+
+from runners.core import BuildConfiguration, RunnerCaps, ZephyrBinaryRunner
+
+
+class EcpprogBinaryRunner(ZephyrBinaryRunner):
+    """Runner front-end for programming the FPGA flash at some offset."""
+
+    def __init__(self, cfg, device=None):
+        super().__init__(cfg)
+        self.device = device
+
+    @classmethod
+    def name(cls):
+        return "ecpprog"
+
+    @classmethod
+    def capabilities(cls):
+        return RunnerCaps(commands={"flash"})
+
+    @classmethod
+    def do_add_parser(cls, parser):
+        parser.add_argument(
+            "--device", dest="device", help="Device identifier such as i:<vid>:<pid>"
+        )
+
+    @classmethod
+    def do_create(cls, cfg, args):
+        return EcpprogBinaryRunner(cfg, device=args.device)
+
+    def do_run(self, command, **kwargs):
+        build_conf = BuildConfiguration(self.cfg.build_dir)
+        load_offset = build_conf.get("CONFIG_FLASH_LOAD_OFFSET", 0)
+        command = ("ecpprog", "-o", hex(load_offset), self.cfg.bin_file)
+        self.logger.debug(" ".join(command))
+        self.check_call(command)

--- a/scripts/west_commands/tests/test_imports.py
+++ b/scripts/west_commands/tests/test_imports.py
@@ -21,6 +21,7 @@ def test_runner_imports():
         'canopen',
         'dediprog',
         'dfu-util',
+        'ecpprog',
         'esp32',
         'ezflashcli',
         'gd32isp',


### PR DESCRIPTION
This adds the `ecpprog` utility to flash FPGA boards on Zephyr.

There is currently no board upstream configured to use it, but 3rd-party module soon will, and later be submitted to Zephyr.

Example `board.cmake`:

```
include(${ZEPHYR_BASE}/boards/common/ecpprog.board.cmake)
```

Optional `Kconfig.defconfig` for [`CONFIG_FLASH_LOAD_OFFSET`](https://docs.zephyrproject.org/latest/kconfig.html#CONFIG_FLASH_LOAD_OFFSET) support:

```
# Workaround for not being able to have commas in macro arguments
DT_CHOSEN_Z_CODE_PARTITION := zephyr,code-partition

config FLASH_LOAD_OFFSET
        default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_CODE_PARTITION))
        # or directly some number
```

Sample output:

```
$ west flash
-- west flash: rebuilding
ninja: no work to do.
-- west flash: using runner ecpprog
ecpprog -o 0x100000 /home/tinyvision/zephyrproject/tinyclunx33_zephyr_example/build/zephyr/zephyr.bin
init..
IDCODE: 0x010fb043 (LIFCL-33U)
NX Status Register: 0x0000110100000000
reset..
flash ID: 0xEF 0x80 0x18
file size: 157096
erase 64kB sector at 0x100000..
erase 64kB sector at 0x110000..
erase 64kB sector at 0x120000..
programming..  157096/157096
verify..       157096/157096  VERIFY OK
Bye.
$
```