### PR TITLE
drivers: led: lp5569: implement write_channels api

### DIFF
--- a/doc/releases/release-notes-4.1.rst
+++ b/doc/releases/release-notes-4.1.rst
@@ -119,6 +119,7 @@ Drivers and Sensors
 * LED
 
   * Added a new set of devicetree based LED APIs, see :c:struct:`led_dt_spec`.
+  * lp5569: added use of auto-increment functionality.
 
 * LED Strip
 

--- a/doc/releases/release-notes-4.1.rst
+++ b/doc/releases/release-notes-4.1.rst
@@ -121,6 +121,7 @@ Drivers and Sensors
   * Added a new set of devicetree based LED APIs, see :c:struct:`led_dt_spec`.
   * lp5569: added use of auto-increment functionality.
   * lp5569: implemented ``write_channels`` api.
+  * lp5569: demonstrate ``led_write_channels`` in the sample.
 
 * LED Strip
 

--- a/doc/releases/release-notes-4.1.rst
+++ b/doc/releases/release-notes-4.1.rst
@@ -120,6 +120,7 @@ Drivers and Sensors
 
   * Added a new set of devicetree based LED APIs, see :c:struct:`led_dt_spec`.
   * lp5569: added use of auto-increment functionality.
+  * lp5569: implemented ``write_channels`` api.
 
 * LED Strip
 

--- a/drivers/led/lp5569.c
+++ b/drivers/led/lp5569.c
@@ -31,6 +31,7 @@ LOG_MODULE_REGISTER(lp5569, CONFIG_LED_LOG_LEVEL);
 
 #define LP5569_MISC          0x2F
 #define LP5569_POWERSAVE_EN  BIT(5)
+#define LP5569_EN_AUTO_INCR  BIT(6)
 #define LP5569_CP_MODE_SHIFT 3
 
 /* PWM base Register for controlling the duty-cycle */
@@ -110,7 +111,7 @@ static int lp5569_enable(const struct device *dev)
 	}
 
 	ret = i2c_reg_write_byte_dt(&config->bus, LP5569_MISC,
-				    LP5569_POWERSAVE_EN |
+				    LP5569_POWERSAVE_EN | LP5569_EN_AUTO_INCR |
 					    (config->cp_mode << LP5569_CP_MODE_SHIFT));
 	if (ret < 0) {
 		LOG_ERR("LED reg update failed");

--- a/drivers/led/lp5569.c
+++ b/drivers/led/lp5569.c
@@ -77,6 +77,23 @@ static inline int lp5569_led_off(const struct device *dev, uint32_t led)
 	return lp5569_led_set_brightness(dev, led, 0);
 }
 
+static int lp5569_write_channels(const struct device *dev, uint32_t start_channel,
+				 uint32_t num_channels, const uint8_t *buf)
+{
+	const struct lp5569_config *config = dev->config;
+	uint32_t i2c_len = num_channels + 1;
+	uint8_t i2c_msg[LP5569_NUM_LEDS + 1];
+
+	if ((uint64_t)start_channel + num_channels > LP5569_NUM_LEDS) {
+		return -EINVAL;
+	}
+
+	i2c_msg[0] = LP5569_LED0_PWM + start_channel;
+	memcpy(&i2c_msg[1], buf, num_channels);
+
+	return i2c_write_dt(&config->bus, i2c_msg, i2c_len);
+}
+
 static int lp5569_enable(const struct device *dev)
 {
 	const struct lp5569_config *config = dev->config;
@@ -170,6 +187,7 @@ static const struct led_driver_api lp5569_led_api = {
 	.set_brightness = lp5569_led_set_brightness,
 	.on = lp5569_led_on,
 	.off = lp5569_led_off,
+	.write_channels = lp5569_write_channels,
 };
 
 #define LP5569_DEFINE(id)                                                                          \

--- a/samples/drivers/led/lp5569/README.rst
+++ b/samples/drivers/led/lp5569/README.rst
@@ -8,7 +8,10 @@ Overview
 ********
 
 This sample controls 9 LEDs connected to an LP5569 driver. The sample turns
-all LEDs on and switches all LEDs off again within a one second interval.
+all LEDs on one by one with a 1 second delay between each. Then it fades all
+LEDs until they are off again. Afterwards, it turns them all on at once, waits
+a second, and turns them all back off.
+This pattern then repeats indefinitely.
 
 Building and Running
 ********************

--- a/samples/drivers/led/lp5569/src/main.c
+++ b/samples/drivers/led/lp5569/src/main.c
@@ -18,6 +18,7 @@ LOG_MODULE_REGISTER(app, CONFIG_LED_LOG_LEVEL);
 int main(void)
 {
 	const struct device *const led_dev = DEVICE_DT_GET_ANY(ti_lp5569);
+	uint8_t ch_buf[9] = {0};
 	int i, ret;
 
 	if (!led_dev) {
@@ -32,7 +33,8 @@ int main(void)
 
 	/*
 	 * Display a continuous pattern that turns on 9 LEDs at 1 s one by
-	 * one until it reaches the end and turns off LEDs in reverse order.
+	 * one until it reaches the end and fades off all LEDs.
+	 * Afterwards, all LEDs get blinked once at the same time.
 	 */
 
 	LOG_INF("Testing 9 LEDs ..");
@@ -59,6 +61,26 @@ int main(void)
 
 			k_sleep(DELAY_TIME_BREATHING);
 		}
+
+		k_sleep(DELAY_TIME_ON);
+
+		/* Turn on all LEDs at once to demonstrate write_channels */
+		memset(ch_buf, 255, ARRAY_SIZE(ch_buf));
+		ret = led_write_channels(led_dev, 0, ARRAY_SIZE(ch_buf), ch_buf);
+		if (ret) {
+			return ret;
+		}
+
+		k_sleep(DELAY_TIME_ON);
+
+		/* Turn off all LEDs at once to demonstrate write_channels */
+		memset(ch_buf, 0, ARRAY_SIZE(ch_buf));
+		ret = led_write_channels(led_dev, 0, ARRAY_SIZE(ch_buf), ch_buf);
+		if (ret) {
+			return ret;
+		}
+
+		k_sleep(DELAY_TIME_ON);
 	}
 	return 0;
 }


### PR DESCRIPTION
[drivers: led: lp5569: enable auto-increment](https://github.com/zephyrproject-rtos/zephyr/commit/574c4a5491b4e6e93c7c93c0242b50184de102fd)

The lp5569 controller supports auto-increment for its registers. This is by
default enabled in the chip, but the driver actively disabled it.

Since auto-increment is useful for writing multiple consecutive registers,
enable the feature. The driver, however, doesn't perform such consecutive
writes and thus the existing behavior is not altered.

Signed-off-by: Emil Dahl Juhl <emdj@bang-olufsen.dk>

[drivers: led: lp5569: implement write_channels api](https://github.com/zephyrproject-rtos/zephyr/commit/cff92077db2e05b0aa30ff60c8ccef68beeaa525)

The lp5569 has multiple pwm outputs, and thus implementing the
write_channels api to set multiple values in a single call makes sense.

Implement the write_channels function with a basic range check on the
channel range.
Since the lp5569 supports auto-increment, all of the channels can be
written in one i2c transfer, starting from the pwm register of the
start_channel.

Signed-off-by: Emil Dahl Juhl <emdj@bang-olufsen.dk>