### PR TITLE
boards: m5stack/m5stack_cores3: disable in twister

### DIFF
--- a/boards/m5stack/m5stack_cores3/m5stack_cores3_appcpu.yaml
+++ b/boards/m5stack/m5stack_cores3/m5stack_cores3_appcpu.yaml
@@ -1,6 +1,7 @@
 identifier: m5stack_cores3/esp32s3/appcpu
 name: M5Stack CoreS3 APPCPU
 type: mcu
+twister: false
 arch: xtensa
 toolchain:
   - zephyr

--- a/boards/m5stack/m5stack_cores3/m5stack_cores3_procpu.yaml
+++ b/boards/m5stack/m5stack_cores3/m5stack_cores3_procpu.yaml
@@ -1,6 +1,7 @@
 identifier: m5stack_cores3/esp32s3/procpu
 name: M5Stack CoreS3 PROCPU
 type: mcu
+twister: false
 arch: xtensa
 toolchain:
   - zephyr


### PR DESCRIPTION
Do not run this board with twister. Temporary fix while we wait for a
fix.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
