### PR TITLE
tests: posix: common: mitigate warning for qemu_arc_em

### DIFF
--- a/tests/posix/common/prj.conf
+++ b/tests/posix/common/prj.conf
@@ -24,7 +24,3 @@ CONFIG_XSI_SYSTEM_LOGGING=y
 
 # for sched_get_priority_min(), sched_get_priority_max()
 CONFIG_POSIX_PRIORITY_SCHEDULING=y
-
-# for networking
-CONFIG_NET_TEST=y
-CONFIG_TEST_RANDOM_GENERATOR=y


### PR DESCRIPTION
Previously, twister would fail due to a warning being escalated to an error because `CONFIG_NET_TEST` was set. It's not necessary for `tests/posix/common` though.

Testing Done:
```shell
west twister -p qemu_arc/qemu_arc_em -s tests/posix/common/portability.posix.common.userspace
Renaming output directory to /home/cfriedt/zephyrproject/zephyr/twister-out.7
INFO    - Using Ninja..
INFO    - Zephyr version: v4.0.0-294-g0402fb35ab22
INFO    - Using 'zephyr' toolchain.
INFO    - Building initial testsuite list...
INFO    - Writing JSON report /home/cfriedt/zephyrproject/zephyr/twister-out/testplan.json
INFO    - JOBS: 32
INFO    - Adding tasks to the queue...
INFO    - Added initial list of jobs to queue
INFO    - Total complete:    1/   1  100%  built (not run):    0, filtered:    0, failed:    0, error:    0
INFO    - 1 test scenarios (1 configurations) selected, 0 configurations filtered (0 by static filter, 0 at runtime).
INFO    - 1 of 1 executed test configurations passed (100.00%), 0 built (not run), 0 failed, 0 errored, with no warnings in 24.56 seconds.
INFO    - 98 of 98 executed test cases passed (100.00%) on 1 out of total 857 platforms (0.12%).
INFO    - 2 selected test cases not executed: 2 skipped.
INFO    - 1 test configurations executed on platforms, 0 test configurations were only built.
INFO    - Saving reports...
INFO    - Writing JSON report /home/cfriedt/zephyrproject/zephyr/twister-out/twister.json
INFO    - Writing xunit report /home/cfriedt/zephyrproject/zephyr/twister-out/twister.xml...
INFO    - Writing xunit report /home/cfriedt/zephyrproject/zephyr/twister-out/twister_report.xml...
INFO    - Run completed
```

```shell
twister -T tests/posix/common/
Renaming output directory to /home/cfriedt/zephyrproject/zephyr/twister-out.6
INFO    - Using Ninja..
INFO    - Zephyr version: v4.0.0-294-g0402fb35ab22
INFO    - Using 'zephyr' toolchain.
INFO    - Selecting default platforms per test case
INFO    - Building initial testsuite list...
INFO    - Writing JSON report /home/cfriedt/zephyrproject/zephyr/twister-out/testplan.json
INFO    - JOBS: 32
INFO    - Adding tasks to the queue...
INFO    - Added initial list of jobs to queue
INFO    - Total complete:  108/ 108  100%  built (not run):    0, filtered:  531, failed:    0, error:    0
INFO    - 14 test scenarios (630 configurations) selected, 531 configurations filtered (522 by static filter, 9 at runtime).
INFO    - 99 of 99 executed test configurations passed (100.00%), 0 built (not run), 0 failed, 0 errored, with no warnings in 156.60 seconds.
INFO    - 9297 of 9297 executed test cases passed (100.00%) on 9 out of total 857 platforms (1.05%).
INFO    - 603 selected test cases not executed: 603 skipped.
INFO    - 99 test configurations executed on platforms, 0 test configurations were only built.
INFO    - Saving reports...
INFO    - Writing JSON report /home/cfriedt/zephyrproject/zephyr/twister-out/twister.json
INFO    - Writing xunit report /home/cfriedt/zephyrproject/zephyr/twister-out/twister.xml...
INFO    - Writing xunit report /home/cfriedt/zephyrproject/zephyr/twister-out/twister_report.xml...
INFO    - Run completed
```