### PR TITLE
riscv: coredump: dump `sp`, remove `tp`

### DIFF
--- a/arch/riscv/core/coredump.c
+++ b/arch/riscv/core/coredump.c
@@ -14,6 +14,8 @@
 #define ARCH_HDR_VER 2
 #endif
 
+uintptr_t z_riscv_get_sp_before_exc(const struct arch_esf *esf);
+
 struct riscv_arch_block {
 #ifdef CONFIG_64BIT
 	struct {
@@ -35,6 +37,7 @@ struct riscv_arch_block {
 		uint64_t t5;
 		uint64_t t6;
 		uint64_t pc;
+		uint64_t sp;
 	} r;
 #else /* !CONFIG_64BIT */
 	struct {
@@ -58,6 +61,7 @@ struct riscv_arch_block {
 		uint32_t t6;
 #endif /* !CONFIG_RISCV_ISA_RV32E */
 		uint32_t pc;
+		uint32_t sp;
 	} r;
 #endif /* CONFIG_64BIT */
 } __packed;
@@ -107,6 +111,7 @@ void arch_coredump_info_dump(const struct arch_esf *esf)
 	arch_blk.r.a7 = esf->a7;
 #endif /* !CONFIG_RISCV_ISA_RV32E */
 	arch_blk.r.pc = esf->mepc;
+	arch_blk.r.sp = z_riscv_get_sp_before_exc(esf);
 
 	/* Send for output */
 	coredump_buffer_output((uint8_t *)&hdr, sizeof(hdr));

--- a/scripts/coredump/gdbstubs/arch/risc_v.py
+++ b/scripts/coredump/gdbstubs/arch/risc_v.py
@@ -76,7 +76,6 @@ class GdbStub_RISC_V(GdbStub):
         self.registers = dict()
 
         self.registers[RegNum.RA] = tu[0]
-        self.registers[RegNum.TP] = tu[1]
         self.registers[RegNum.T0] = tu[2]
         self.registers[RegNum.T1] = tu[3]
         self.registers[RegNum.T2] = tu[4]

--- a/scripts/coredump/gdbstubs/arch/risc_v.py
+++ b/scripts/coredump/gdbstubs/arch/risc_v.py
@@ -50,8 +50,8 @@ class RegNum():
 
 
 class GdbStub_RISC_V(GdbStub):
-    ARCH_DATA_BLK_STRUCT    = "<IIIIIIIIIIIIIIIIII"
-    ARCH_DATA_BLK_STRUCT_2  = "<QQQQQQQQQQQQQQQQQQ"
+    ARCH_DATA_BLK_STRUCT    = "<IIIIIIIIIIIIIIIIIII"
+    ARCH_DATA_BLK_STRUCT_2  = "<QQQQQQQQQQQQQQQQQQQ"
 
     GDB_SIGNAL_DEFAULT = 7
 
@@ -93,6 +93,7 @@ class GdbStub_RISC_V(GdbStub):
         self.registers[RegNum.T5] = tu[15]
         self.registers[RegNum.T6] = tu[16]
         self.registers[RegNum.PC] = tu[17]
+        self.registers[RegNum.SP] = tu[18]
 
     def handle_register_group_read_packet(self):
         reg_fmt = "<I" if self.arch_data_ver == 1 else "<Q"


### PR DESCRIPTION
Derive the `sp` register from the `*esf` and dump it.
While there, remove `tp` from the parser as it isn't available in the coredump.

```
*** Booting Zephyr OS build v4.0.0-rc3-398-gf537cf311d7a ***
Coredump: qemu_riscv64
E: 
E:  mcause: 7, Store/AMO access fault
E:   mtval: 0
E:      a0: 0000000000000000    t0: 0000000000000009
E:      a1: 000000008000913d    t1: 000000000000004c
E:      a2: 0000000000000010    t2: 0000000000000053
E:      a3: 000000008000c080    t3: 000000000000002a
E:      a4: 0000000000000000    t4: 000000000000002e
E:      a5: 0000000000000000    t5: 000000000000007f
E:      a6: 0000000000000068    t6: 0000000000000010
E:      a7: 000000000000006a
E:      sp: 000000008000dc00
E:      ra: 000000008000073e
E:    mepc: 00000000800003fa
E: mstatus: 0000000a00021880
E: 
E: call trace:
E:       0: sp: 000000008000dc00 ra: 00000000800003fa [func_3+0xe]
E: 
E: >>> ZEPHYR FATAL ERROR 0: CPU exception on CPU 0
E: Current thread: 0x8000c080 (unknown)
E: #CD:BEGIN#
E: #CD:5a4502000400060000000000
E: #CD:4102009800
```

```
(gdb) info registers 
ra             0x8000073e       0x8000073e <z_thread_entry+34>
sp             0x8000dc00       0x8000dc00 <crash_stack+5184>
gp             <unavailable>
tp             <unavailable>
t0             0x9      9
t1             0x4c     76
t2             0x53     83
fp             <unavailable>
s1             <unavailable>
a0             0x0      0
a1             0x8000913d       2147520829
a2             0x10     16
a3             0x8000c080       2147532928
a4             0x0      0
a5             0x0      0
a6             0x68     104
a7             0x6a     106
s2             <unavailable>
s3             <unavailable>
s4             <unavailable>
s5             <unavailable>
s6             <unavailable>
s7             <unavailable>
s8             <unavailable>
s9             <unavailable>
s10            <unavailable>
s11            <unavailable>
t3             0x2a     42
t4             0x2e     46
t5             0x7f     127
t6             0x10     16
pc             0x800003fa       0x800003fa <func_3+14>
```