### PR TITLE
boards: others: add candleLightFD USB to CAN FD adapter board

### DIFF
--- a/boards/others/candlelightfd/Kconfig.candlelightfd
+++ b/boards/others/candlelightfd/Kconfig.candlelightfd
@@ -1,0 +1,5 @@
+# Copyright (c) 2024 Sean Nyekjaer <sean@geanix.com>
+# SPDX-License-Identifier: Apache-2.0
+
+config BOARD_CANDLELIGHTFD
+	select SOC_STM32G0B1XX

--- a/boards/others/candlelightfd/board.cmake
+++ b/boards/others/candlelightfd/board.cmake
@@ -1,0 +1,8 @@
+# Copyright (c) 2024 Sean Nyekjaer <sean@geanix.com>
+# SPDX-License-Identifier: Apache-2.0
+
+board_runner_args(dfu-util "--pid=0483:df11" "--alt=0" "--dfuse")
+board_runner_args(jlink "--device=STM32G0B1CB")
+
+include(${ZEPHYR_BASE}/boards/common/dfu-util.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/others/candlelightfd/board.yml
+++ b/boards/others/candlelightfd/board.yml
@@ -1,0 +1,8 @@
+board:
+  name: candlelightfd
+  full_name: candleLightFD
+  vendor: others
+  socs:
+    - name: stm32g0b1xx
+      variants:
+        - name: 'dual'

--- a/boards/others/candlelightfd/candlelightfd.dtsi
+++ b/boards/others/candlelightfd/candlelightfd.dtsi
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2024 Sean Nyekjaer <sean@geanix.com>
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <st/g0/stm32g0b1Xb.dtsi>
+#include <st/g0/stm32g0b1r(b-c-e)tx-pinctrl.dtsi>
+
+/ {
+	chosen {
+		zephyr,sram = &sram0;
+		zephyr,flash = &flash0;
+		zephyr,code-partition = &slot0_partition;
+		zephyr,canbus = &fdcan1;
+	};
+
+	aliases {
+		led0 = &led_rx;
+		led1 = &led_tx;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		led_rx: led_rx {
+			gpios = <&gpioa 3 GPIO_ACTIVE_LOW>;
+			label = "LED RX";
+		};
+		led_tx: led_tx {
+			gpios = <&gpioa 4 GPIO_ACTIVE_LOW>;
+			label = "LED TX";
+		};
+	};
+
+	transceiver0: can-phy0 {
+		compatible = "nxp,tja1051", "can-transceiver-gpio";
+		enable-gpios = <&gpioa 15 GPIO_ACTIVE_LOW>;
+		max-bitrate = <5000000>;
+		#phy-cells = <0>;
+	};
+};
+
+&clk_hse {
+	status = "okay";
+	clock-frequency = <DT_FREQ_M(8)>;
+};
+
+&clk_hsi48 {
+	status = "okay";
+	crs-usb-sof;
+};
+
+&pll {
+	div-m = <1>;
+	mul-n = <30>;
+	div-p = <2>;
+	div-q = <3>;
+	div-r = <4>;
+	clocks = <&clk_hse>;
+	status = "okay";
+};
+
+&rcc {
+	clocks = <&pll>;
+	clock-frequency = <DT_FREQ_M(60)>;
+	ahb-prescaler = <1>;
+	apb1-prescaler = <1>;
+};
+
+zephyr_udc0: &usb {
+	pinctrl-0 = <&usb_dm_pa11 &usb_dp_pa12>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
+&fdcan1 {
+	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00001000>,
+		 <&rcc STM32_SRC_PLL_Q FDCAN_SEL(1)>;
+	pinctrl-0 = <&fdcan1_rx_pd0 &fdcan1_tx_pd1>;
+	pinctrl-names = "default";
+	phys = <&transceiver0>;
+	status = "okay";
+};
+
+&flash0 {
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		boot_partition: partition@0 {
+			label = "mcuboot";
+			reg = <0x00000000 DT_SIZE_K(48)>;
+			read-only;
+		};
+		slot0_partition: partition@c000 {
+			label = "image-0";
+			reg = <0x0000c000 DT_SIZE_K(80)>;
+		};
+	};
+};

--- a/boards/others/candlelightfd/candlelightfd_stm32g0b1xx.dts
+++ b/boards/others/candlelightfd/candlelightfd_stm32g0b1xx.dts
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2024 Sean Nyekjaer <sean@geanix.com>
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+/dts-v1/;
+
+#include "candlelightfd.dtsi"
+
+/ {
+	model = "candleLight FD";
+	compatible = "candlelightfd";
+};

--- a/boards/others/candlelightfd/candlelightfd_stm32g0b1xx.yaml
+++ b/boards/others/candlelightfd/candlelightfd_stm32g0b1xx.yaml
@@ -1,0 +1,10 @@
+identifier: candlelightfd/stm32g0b1xx
+name: candleLightFD
+type: mcu
+arch: arm
+toolchain:
+  - zephyr
+  - gnuarmemb
+ram: 144
+flash: 128
+vendor: others

--- a/boards/others/candlelightfd/candlelightfd_stm32g0b1xx_defconfig
+++ b/boards/others/candlelightfd/candlelightfd_stm32g0b1xx_defconfig
@@ -1,0 +1,8 @@
+# Enable MPU
+CONFIG_ARM_MPU=y
+
+# Enable HW stack protection
+CONFIG_HW_STACK_PROTECTION=y
+
+# Enable GPIO
+CONFIG_GPIO=y

--- a/boards/others/candlelightfd/candlelightfd_stm32g0b1xx_dual.dts
+++ b/boards/others/candlelightfd/candlelightfd_stm32g0b1xx_dual.dts
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2024 Sean Nyekjaer <sean@geanix.com>
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+/dts-v1/;
+
+#include "candlelightfd.dtsi"
+
+/ {
+	model = "candleLight FD Dual";
+	compatible = "candlelightfd";
+
+	transceiver1: can-phy1 {
+		compatible = "nxp,tja1051", "can-transceiver-gpio";
+		enable-gpios = <&gpiob 2 GPIO_ACTIVE_LOW>;
+		max-bitrate = <5000000>;
+		#phy-cells = <0>;
+	};
+};
+
+&fdcan2 {
+	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00001000>,
+		 <&rcc STM32_SRC_PLL_Q FDCAN_SEL(1)>;
+	pinctrl-0 = <&fdcan2_rx_pb0 &fdcan2_tx_pb1>;
+	pinctrl-names = "default";
+	phys = <&transceiver1>;
+	status = "okay";
+};

--- a/boards/others/candlelightfd/candlelightfd_stm32g0b1xx_dual.yaml
+++ b/boards/others/candlelightfd/candlelightfd_stm32g0b1xx_dual.yaml
@@ -1,0 +1,10 @@
+identifier: candlelightfd/stm32g0b1xx/dual
+name: candleLightFD Dual
+type: mcu
+arch: arm
+toolchain:
+  - zephyr
+  - gnuarmemb
+ram: 144
+flash: 128
+vendor: others

--- a/boards/others/candlelightfd/candlelightfd_stm32g0b1xx_dual_defconfig
+++ b/boards/others/candlelightfd/candlelightfd_stm32g0b1xx_dual_defconfig
@@ -1,0 +1,8 @@
+# Enable MPU
+CONFIG_ARM_MPU=y
+
+# Enable HW stack protection
+CONFIG_HW_STACK_PROTECTION=y
+
+# Enable GPIO
+CONFIG_GPIO=y

--- a/boards/others/candlelightfd/doc/index.rst
+++ b/boards/others/candlelightfd/doc/index.rst
@@ -1,0 +1,77 @@
+.. zephyr:board:: candlelightfd
+
+Overview
+********
+
+The candleLight FD is an open-hardware USB to CAN FD adapter board available from Linux Automation GmBH.
+Find more information about the board at the `Linux Automation website`_.
+
+Hardware
+********
+
+The candleLight FD board is equipped with a STM32G0B1CBT6 microcontroller and features an USB-C connector,
+a DB-9M connector for the CAN bus, and two user LEDs. Schematics and component placement drawings
+are available in the `candleLight FD GitHub repository`_.
+
+Supported Features
+==================
+
+The ``candlelightfd/stm32g0b1xx`` board target supports the following hardware features:
+
++-----------+------------+-------------------------------------+
+| Interface | Controller | Driver/Component                    |
++===========+============+=====================================+
+| NVIC      | on-chip    | nested vector interrupt controller  |
++-----------+------------+-------------------------------------+
+| PINMUX    | on-chip    | pinmux                              |
++-----------+------------+-------------------------------------+
+| FLASH     | on-chip    | flash memory                        |
++-----------+------------+-------------------------------------+
+| GPIO      | on-chip    | gpio                                |
++-----------+------------+-------------------------------------+
+| USB       | on-chip    | USB                                 |
++-----------+------------+-------------------------------------+
+| CAN1      | on-chip    | CAN controller                      |
++-----------+------------+-------------------------------------+
+| CAN2      | on-chip    | CAN controller                      |
++-----------+------------+-------------------------------------+
+
+The default configuration can be found in the defconfig file:
+:zephyr_file:`boards/others/candlelightfd/candlelightfd_stm32g0b1xx_defconfig`.
+
+System Clock
+============
+
+The STM32G0B1CBT6 PLL is driven by an external crystal oscillator (HSE) running at 8 MHz and
+configured to provide a system clock of 60 MHz. This allows generating a FDCAN1 and FDCAN2 core
+clock of 80 MHz.
+
+Programming and Debugging
+*************************
+
+Build and flash applications as usual (see :ref:`build_an_application` and
+:ref:`application_run` for more details).
+
+If flashing via USB DFU, short jumper ``BOOT`` when applying power to the candleLight FD in order to
+enter the built-in DFU mode.
+
+Variants
+========
+
+The candleLight FD is can be retrofitted with a second transceiver, making it a dual CAN FD device:
+
+- ``candlelightfd``: The default variant.
+- ``candlelightfd_stm32g0b1xx_dual``: Variant for the dual CAN FD.
+
+Here is an example for the :zephyr:code-sample:`blinky` application.
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/basic/blinky
+   :board: candlelightfd
+   :goals: flash
+
+.. _Linux Automation website:
+   https://linux-automation.com/en/products/candlelight-fd.html
+
+.. _candleLight FD GitHub repository:
+   https://github.com/linux-automation/candleLightFD


### PR DESCRIPTION
Add support for the open-hardware candleLight FD USB to CAN FD board.