### PR TITLE
tests: Bluetooth: Audio: Use same recv_cb for all tests

### DIFF
--- a/subsys/bluetooth/audio/bap_stream.c
+++ b/subsys/bluetooth/audio/bap_stream.c
@@ -362,7 +362,13 @@ static int bap_stream_send(struct bt_bap_stream *stream, struct net_buf *buf, ui
 	struct bt_bap_ep *ep;
 	int ret;
 
-	if (stream == NULL || stream->ep == NULL) {
+	if (stream == NULL) {
+		LOG_DBG("stream is NULL");
+		return -EINVAL;
+	}
+
+	if (stream->ep == NULL) {
+		LOG_DBG("stream->ep %p is NULL", stream);
 		return -EINVAL;
 	}
 

--- a/tests/bsim/bluetooth/audio/src/bap_broadcast_sink_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_broadcast_sink_test.c
@@ -32,6 +32,7 @@
 #include <zephyr/toolchain.h>
 
 #include "bap_common.h"
+#include "bap_stream_rx.h"
 #include "bstests.h"
 #include "common.h"
 
@@ -44,7 +45,6 @@ CREATE_FLAG(flag_base_metadata_updated);
 CREATE_FLAG(flag_pa_synced);
 CREATE_FLAG(flag_syncable);
 CREATE_FLAG(flag_pa_sync_lost);
-CREATE_FLAG(flag_received);
 CREATE_FLAG(flag_pa_request);
 CREATE_FLAG(flag_bis_sync_requested);
 CREATE_FLAG(flag_big_sync_mic_failure);
@@ -528,8 +528,12 @@ static void validate_stream_codec_cfg(const struct bt_bap_stream *stream)
 
 static void started_cb(struct bt_bap_stream *stream)
 {
+	struct audio_test_stream *test_stream = audio_test_stream_from_bap_stream(stream);
 	struct bt_bap_ep_info info;
 	int err;
+
+	memset(&test_stream->last_info, 0, sizeof(test_stream->last_info));
+	test_stream->rx_cnt = 0U;
 
 	err = bt_bap_ep_get_info(stream->ep, &info);
 	if (err != 0) {
@@ -578,57 +582,10 @@ static void stopped_cb(struct bt_bap_stream *stream, uint8_t reason)
 	}
 }
 
-static void recv_cb(struct bt_bap_stream *stream,
-		    const struct bt_iso_recv_info *info,
-		    struct net_buf *buf)
-{
-	struct audio_test_stream *test_stream = audio_test_stream_from_bap_stream(stream);
-
-	if ((test_stream->rx_cnt % 100U) == 0U) {
-		printk("[%zu]: Incoming audio on stream %p len %u and ts %u\n", test_stream->rx_cnt,
-		       stream, buf->len, info->ts);
-	}
-
-	if (test_stream->rx_cnt > 0U && info->ts == test_stream->last_info.ts) {
-		FAIL("Duplicated timestamp received: %u\n", test_stream->last_info.ts);
-		return;
-	}
-
-	if (test_stream->rx_cnt > 0U && info->seq_num == test_stream->last_info.seq_num) {
-		FAIL("Duplicated PSN received: %u\n", test_stream->last_info.seq_num);
-		return;
-	}
-
-	if (info->flags & BT_ISO_FLAGS_ERROR) {
-		/* Fail the test if we have not received what we expected */
-		if (!TEST_FLAG(flag_received)) {
-			FAIL("ISO receive error\n");
-		}
-
-		return;
-	}
-
-	if (info->flags & BT_ISO_FLAGS_LOST) {
-		FAIL("ISO receive lost\n");
-		return;
-	}
-
-	if (memcmp(buf->data, mock_iso_data, buf->len) == 0) {
-		test_stream->rx_cnt++;
-
-		if (test_stream->rx_cnt >= MIN_SEND_COUNT) {
-			/* We set the flag is just one stream has received the expected */
-			SET_FLAG(flag_received);
-		}
-	} else {
-		FAIL("Unexpected data received\n");
-	}
-}
-
 static struct bt_bap_stream_ops stream_ops = {
 	.started = started_cb,
 	.stopped = stopped_cb,
-	.recv = recv_cb
+	.recv = bap_stream_rx_recv_cb,
 };
 
 static int init(void)
@@ -964,7 +921,7 @@ static void test_common(void)
 	}
 
 	printk("Waiting for data\n");
-	WAIT_FOR_FLAG(flag_received);
+	WAIT_FOR_FLAG(flag_audio_received);
 	backchannel_sync_send_all(); /* let other devices know we have received what we wanted */
 
 	/* Ensure that we also see the metadata update */
@@ -1051,7 +1008,7 @@ static void test_sink_encrypted(void)
 	}
 
 	printk("Waiting for data\n");
-	WAIT_FOR_FLAG(flag_received);
+	WAIT_FOR_FLAG(flag_audio_received);
 
 	backchannel_sync_send_all(); /* let other devices know we have received data */
 
@@ -1140,7 +1097,7 @@ static void broadcast_sink_with_assistant(void)
 	}
 
 	printk("Waiting for data\n");
-	WAIT_FOR_FLAG(flag_received);
+	WAIT_FOR_FLAG(flag_audio_received);
 	backchannel_sync_send_all(); /* let other devices know we have received what we wanted */
 
 	/* Ensure that we also see the metadata update */

--- a/tests/bsim/bluetooth/audio/src/bap_broadcast_source_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_broadcast_source_test.c
@@ -176,8 +176,12 @@ static void validate_stream_codec_cfg(const struct bt_bap_stream *stream)
 
 static void started_cb(struct bt_bap_stream *stream)
 {
+	struct audio_test_stream *test_stream = audio_test_stream_from_bap_stream(stream);
 	struct bt_bap_ep_info info;
 	int err;
+
+	test_stream->seq_num = 0U;
+	test_stream->tx_cnt = 0U;
 
 	err = bt_bap_ep_get_info(stream->ep, &info);
 	if (err != 0) {

--- a/tests/bsim/bluetooth/audio/src/bap_stream_rx.c
+++ b/tests/bsim/bluetooth/audio/src/bap_stream_rx.c
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/bluetooth/audio/bap.h>
+#include <zephyr/bluetooth/iso.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/logging/log_core.h>
+#include <zephyr/net_buf.h>
+
+#include "common.h"
+#include <string.h>
+
+LOG_MODULE_REGISTER(stream_tx, LOG_LEVEL_INF);
+
+static void log_stream_rx(struct bt_bap_stream *stream, const struct bt_iso_recv_info *info,
+			  struct net_buf *buf)
+{
+	struct audio_test_stream *test_stream = audio_test_stream_from_bap_stream(stream);
+
+	LOG_INF("[%zu]: Incoming audio on stream %p len %u, flags 0x%02X, seq_num %u and ts %u\n",
+		test_stream->rx_cnt, stream, buf->len, info->flags, info->seq_num, info->ts);
+}
+
+void bap_stream_rx_recv_cb(struct bt_bap_stream *stream, const struct bt_iso_recv_info *info,
+			   struct net_buf *buf)
+{
+	struct audio_test_stream *test_stream = audio_test_stream_from_bap_stream(stream);
+
+	if ((test_stream->rx_cnt % 50U) == 0U) {
+		log_stream_rx(stream, info, buf);
+	}
+
+	if (test_stream->rx_cnt > 0U && info->ts == test_stream->last_info.ts) {
+		log_stream_rx(stream, info, buf);
+		FAIL("Duplicated timestamp received: %u\n", test_stream->last_info.ts);
+		return;
+	}
+
+	if (test_stream->rx_cnt > 0U && info->seq_num == test_stream->last_info.seq_num) {
+		log_stream_rx(stream, info, buf);
+		FAIL("Duplicated PSN received: %u\n", test_stream->last_info.seq_num);
+		return;
+	}
+
+	if (info->flags & BT_ISO_FLAGS_ERROR) {
+		/* Fail the test if we have not received what we expected */
+		if (!TEST_FLAG(flag_audio_received)) {
+			log_stream_rx(stream, info, buf);
+			FAIL("ISO receive error\n");
+		}
+
+		return;
+	}
+
+	if (info->flags & BT_ISO_FLAGS_LOST) {
+		log_stream_rx(stream, info, buf);
+		FAIL("ISO receive lost\n");
+		return;
+	}
+
+	if (memcmp(buf->data, mock_iso_data, buf->len) == 0) {
+		test_stream->rx_cnt++;
+
+		if (test_stream->rx_cnt >= MIN_SEND_COUNT) {
+			/* We set the flag is just one stream has received the expected */
+			SET_FLAG(flag_audio_received);
+		}
+	} else {
+		log_stream_rx(stream, info, buf);
+		FAIL("Unexpected data received\n");
+	}
+}

--- a/tests/bsim/bluetooth/audio/src/bap_stream_rx.h
+++ b/tests/bsim/bluetooth/audio/src/bap_stream_rx.h
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/bluetooth/audio/bap.h>
+#include <zephyr/bluetooth/iso.h>
+#include <zephyr/net_buf.h>
+
+void bap_stream_rx_recv_cb(struct bt_bap_stream *stream, const struct bt_iso_recv_info *info,
+			   struct net_buf *buf);

--- a/tests/bsim/bluetooth/audio/src/bap_unicast_client_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_unicast_client_test.c
@@ -29,6 +29,7 @@
 #include <zephyr/sys/printk.h>
 #include <zephyr/sys/util.h>
 
+#include "bap_stream_rx.h"
 #include "bstests.h"
 #include "common.h"
 #include "bap_common.h"
@@ -154,43 +155,6 @@ static void stream_released(struct bt_bap_stream *stream)
 	SET_FLAG(flag_stream_released);
 }
 
-static void stream_recv_cb(struct bt_bap_stream *stream, const struct bt_iso_recv_info *info,
-			   struct net_buf *buf)
-{
-	struct audio_test_stream *test_stream = audio_test_stream_from_bap_stream(stream);
-
-	if ((test_stream->rx_cnt % 100U) == 0U) {
-		printk("[%zu]: Incoming audio on stream %p len %u and ts %u\n", test_stream->rx_cnt,
-		       stream, buf->len, info->ts);
-	}
-
-	if (test_stream->rx_cnt > 0U && info->ts == test_stream->last_info.ts) {
-		FAIL("Duplicated timestamp received: %u\n", test_stream->last_info.ts);
-		return;
-	}
-
-	if (test_stream->rx_cnt > 0U && info->seq_num == test_stream->last_info.seq_num) {
-		FAIL("Duplicated PSN received: %u\n", test_stream->last_info.seq_num);
-		return;
-	}
-
-	if (info->flags & BT_ISO_FLAGS_ERROR) {
-		FAIL("ISO receive error\n");
-		return;
-	}
-
-	if (info->flags & BT_ISO_FLAGS_LOST) {
-		FAIL("ISO receive lost\n");
-		return;
-	}
-
-	if (memcmp(buf->data, mock_iso_data, buf->len) == 0) {
-		test_stream->rx_cnt++;
-	} else {
-		FAIL("Unexpected data received\n");
-	}
-}
-
 static void stream_sent_cb(struct bt_bap_stream *stream)
 {
 	struct audio_test_stream *test_stream = audio_test_stream_from_bap_stream(stream);
@@ -234,7 +198,7 @@ static struct bt_bap_stream_ops stream_ops = {
 	.disabled = stream_disabled,
 	.stopped = stream_stopped,
 	.released = stream_released,
-	.recv = stream_recv_cb,
+	.recv = bap_stream_rx_recv_cb,
 	.sent = stream_sent_cb,
 	.connected = stream_connected,
 	.disconnected = stream_disconnected,
@@ -894,13 +858,8 @@ static void transceive_streams(void)
 	}
 
 	if (source_stream != NULL) {
-		const struct audio_test_stream *test_stream =
-			audio_test_stream_from_bap_stream(source_stream);
-
-		/* Keep receiving until we reach the minimum expected */
-		while (test_stream->rx_cnt < MIN_SEND_COUNT) {
-			k_sleep(K_MSEC(100));
-		}
+		printk("Waiting for data\n");
+		WAIT_FOR_FLAG(flag_audio_received);
 	}
 }
 

--- a/tests/bsim/bluetooth/audio/src/cap_acceptor_test.c
+++ b/tests/bsim/bluetooth/audio/src/cap_acceptor_test.c
@@ -33,6 +33,7 @@
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
 
+#include "bap_stream_rx.h"
 #include "bstests.h"
 #include "common.h"
 #include "bap_common.h"
@@ -50,7 +51,6 @@ CREATE_FLAG(flag_broadcast_code);
 CREATE_FLAG(flag_base_received);
 CREATE_FLAG(flag_pa_synced);
 CREATE_FLAG(flag_syncable);
-CREATE_FLAG(flag_received);
 CREATE_FLAG(flag_pa_sync_lost);
 CREATE_FLAG(flag_pa_request);
 CREATE_FLAG(flag_bis_sync_requested);
@@ -275,6 +275,13 @@ static struct bt_le_per_adv_sync_cb bap_pa_sync_cb = {
 
 static void started_cb(struct bt_bap_stream *stream)
 {
+	struct audio_test_stream *test_stream = audio_test_stream_from_bap_stream(stream);
+
+	memset(&test_stream->last_info, 0, sizeof(test_stream->last_info));
+	test_stream->rx_cnt = 0U;
+	test_stream->seq_num = 0U;
+	test_stream->tx_cnt = 0U;
+
 	printk("Stream %p started\n", stream);
 	k_sem_give(&sem_broadcast_started);
 }
@@ -285,54 +292,11 @@ static void stopped_cb(struct bt_bap_stream *stream, uint8_t reason)
 	k_sem_give(&sem_broadcast_stopped);
 }
 
-static void recv_cb(struct bt_bap_stream *stream, const struct bt_iso_recv_info *info,
-		    struct net_buf *buf)
-{
-	struct audio_test_stream *test_stream = audio_test_stream_from_bap_stream(stream);
-
-	if ((test_stream->rx_cnt % 50U) == 0U) {
-		printk("[%zu]: Incoming audio on stream %p len %u and ts %u\n", test_stream->rx_cnt,
-		       stream, buf->len, info->ts);
-	}
-
-	if (test_stream->rx_cnt > 0U && info->ts == test_stream->last_info.ts) {
-		FAIL("Duplicated timestamp received: %u\n", test_stream->last_info.ts);
-		return;
-	}
-
-	if (test_stream->rx_cnt > 0U && info->seq_num == test_stream->last_info.seq_num) {
-		FAIL("Duplicated PSN received: %u\n", test_stream->last_info.seq_num);
-		return;
-	}
-
-	if (info->flags & BT_ISO_FLAGS_ERROR) {
-		/* Fail the test if we have not received what we expected */
-		if (!TEST_FLAG(flag_received)) {
-			FAIL("ISO receive error\n");
-		}
-
-		return;
-	}
-
-	if (info->flags & BT_ISO_FLAGS_LOST) {
-		FAIL("ISO receive lost\n");
-		return;
-	}
-
-	if (memcmp(buf->data, mock_iso_data, buf->len) == 0) {
-		test_stream->rx_cnt++;
-
-		if (test_stream->rx_cnt >= MIN_SEND_COUNT) {
-			/* We set the flag is just one stream has received the expected */
-			SET_FLAG(flag_received);
-		}
-	} else {
-		FAIL("Unexpected data received\n");
-	}
-}
-
 static struct bt_bap_stream_ops broadcast_stream_ops = {
-	.started = started_cb, .stopped = stopped_cb, .recv = recv_cb};
+	.started = started_cb,
+	.stopped = stopped_cb,
+	.recv = bap_stream_rx_recv_cb,
+};
 
 static void unicast_stream_enabled_cb(struct bt_bap_stream *stream)
 {
@@ -796,7 +760,7 @@ static void init(void)
 		UNSET_FLAG(flag_base_received);
 		UNSET_FLAG(flag_pa_synced);
 		UNSET_FLAG(flag_pa_request);
-		UNSET_FLAG(flag_received);
+		UNSET_FLAG(flag_audio_received);
 		UNSET_FLAG(flag_base_metadata_updated);
 		UNSET_FLAG(flag_bis_sync_requested);
 
@@ -998,7 +962,7 @@ static void create_and_sync_sink(struct bt_bap_stream *bap_streams[], size_t *st
 static void sink_wait_for_data(void)
 {
 	printk("Waiting for data\n");
-	WAIT_FOR_FLAG(flag_received);
+	WAIT_FOR_FLAG(flag_audio_received);
 	backchannel_sync_send_all(); /* let other devices know we have received what we wanted */
 }
 

--- a/tests/bsim/bluetooth/audio/src/cap_initiator_broadcast_test.c
+++ b/tests/bsim/bluetooth/audio/src/cap_initiator_broadcast_test.c
@@ -116,6 +116,11 @@ static const struct named_lc3_preset lc3_broadcast_presets[] = {
 
 static void broadcast_started_cb(struct bt_bap_stream *stream)
 {
+	struct audio_test_stream *test_stream = audio_test_stream_from_bap_stream(stream);
+
+	test_stream->seq_num = 0U;
+	test_stream->tx_cnt = 0U;
+
 	printk("Stream %p started\n", stream);
 	k_sem_give(&sem_broadcast_started);
 }

--- a/tests/bsim/bluetooth/audio/src/common.c
+++ b/tests/bsim/bluetooth/audio/src/common.c
@@ -35,6 +35,7 @@ struct bt_conn *default_conn;
 atomic_t flag_connected;
 atomic_t flag_disconnected;
 atomic_t flag_conn_updated;
+atomic_t flag_audio_received;
 volatile bt_security_t security_level;
 
 const struct bt_data ad[AD_SIZE] = {

--- a/tests/bsim/bluetooth/audio/src/common.h
+++ b/tests/bsim/bluetooth/audio/src/common.h
@@ -29,6 +29,7 @@
 #include <zephyr/sys_clock.h>
 #include <zephyr/types.h>
 
+#include "bstests.h"
 #include "bs_types.h"
 #include "bs_tracing.h"
 
@@ -88,7 +89,7 @@ static const uint8_t mock_iso_data[] = {
 		(void)k_sleep(K_MSEC(1)); \
 	}
 
-
+extern enum bst_result_t bst_result;
 #define FAIL(...) \
 	do { \
 		bst_result = Failed; \
@@ -114,6 +115,7 @@ extern struct bt_conn *default_conn;
 extern atomic_t flag_connected;
 extern atomic_t flag_disconnected;
 extern atomic_t flag_conn_updated;
+extern atomic_t flag_audio_received;
 extern volatile bt_security_t security_level;
 
 void disconnected(struct bt_conn *conn, uint8_t reason);


### PR DESCRIPTION
This commit changes the BSIM tests to use the same recv callback for all tests. The purpose of this is to reduce code duplication and make it easier to maintain the tests.

This also changes the recv_cb so that in case of any error we log the most recently received SDU, which should provide more information about why a test failed in case of RX error.