### PR TITLE
SCA: Get eclair options file value for sysbuild invokation

### DIFF
--- a/cmake/sca/eclair/sca.cmake
+++ b/cmake/sca/eclair/sca.cmake
@@ -8,6 +8,9 @@ message(STATUS "Found eclair_env: ${ECLAIR_ENV}")
 find_program(ECLAIR_REPORT eclair_report REQUIRED)
 message(STATUS "Found eclair_report: ${ECLAIR_REPORT}")
 
+# Get eclair specific option file variables, also needed if invoked with sysbuild
+zephyr_get(ECLAIR_OPTIONS_FILE)
+
 if(ECLAIR_OPTIONS_FILE)
   if(IS_ABSOLUTE ${ECLAIR_OPTIONS_FILE})
     set(ECLAIR_OPTIONS ${ECLAIR_OPTIONS_FILE})


### PR DESCRIPTION
Get eclair specific option file variable via zephyr_get. This is also needed if the sca is invoked with sysbuild so it uses the intended file.

This is a follow-up to PR: #68324 and fixes the non blocking comment: https://github.com/zephyrproject-rtos/zephyr/pull/68324#discussion_r1836872932
