### PR TITLE
manifest: Update nrf_wifi

### DIFF
--- a/drivers/wifi/nrf_wifi/src/wifi_mgmt_scan.c
+++ b/drivers/wifi/nrf_wifi/src/wifi_mgmt_scan.c
@@ -297,6 +297,8 @@ static inline enum wifi_security_type drv_to_wifi_mgmt(int drv_security_type)
 		return WIFI_SECURITY_TYPE_WAPI;
 	case NRF_WIFI_EAP:
 		return WIFI_SECURITY_TYPE_EAP;
+	case NRF_WIFI_EAP_TLS_SHA256:
+		return WIFI_SECURITY_TYPE_EAP_TLS_SHA256;
 	default:
 		return WIFI_SECURITY_TYPE_UNKNOWN;
 	}

--- a/drivers/wifi/nrf_wifi/src/wifi_mgmt_scan.c
+++ b/drivers/wifi/nrf_wifi/src/wifi_mgmt_scan.c
@@ -278,6 +278,34 @@ static inline enum wifi_mfp_options drv_to_wifi_mgmt_mfp(unsigned char mfp_flag)
 
 	return WIFI_MFP_UNKNOWN;
 }
+
+static inline enum wifi_cipher_suite_b drv_to_wifi_mgmt_suiteb(int drv_security_type)
+{
+	switch (drv_security_type) {
+	case NRF_WIFI_OPEN:
+	case NRF_WIFI_WEP:
+	case NRF_WIFI_WPA:
+	case NRF_WIFI_WPA2:
+	case NRF_WIFI_WPA2_256:
+	case NRF_WIFI_WPA3:
+	case NRF_WIFI_WAPI:
+	case NRF_WIFI_FT_EAP_SHA384:
+	case NRF_WIFI_FT_PSK_SHA384:
+	case NRF_WIFI_PSK_SHA384:
+		return WIFI_CIPHER_SUITE_B_NA;
+	case NRF_WIFI_EAP:
+	case NRF_WIFI_EAP_TLS_SHA256:
+	case NRF_WIFI_FT_EAP:
+		return WIFI_CIPHER_SUITE_B_NONE;
+	case NRF_WIFI_EAP_SUITEB_SHA256:
+		return WIFI_CIPHER_SUITE_B;
+	case NRF_WIFI_EAP_SUITEB_SHA384:
+		return WIFI_CIPHER_SUITE_B_192;
+	default:
+		return WIFI_CIPHER_SUITE_B_NA;
+	}
+}
+
 static inline enum wifi_security_type drv_to_wifi_mgmt(int drv_security_type)
 {
 	switch (drv_security_type) {
@@ -299,6 +327,18 @@ static inline enum wifi_security_type drv_to_wifi_mgmt(int drv_security_type)
 		return WIFI_SECURITY_TYPE_EAP;
 	case NRF_WIFI_EAP_TLS_SHA256:
 		return WIFI_SECURITY_TYPE_EAP_TLS_SHA256;
+	case NRF_WIFI_FT_EAP:
+		return WIFI_SECURITY_TYPE_FT_EAP;
+	case NRF_WIFI_EAP_SUITEB_SHA256:
+		return WIFI_SECURITY_TYPE_EAP;
+	case NRF_WIFI_EAP_SUITEB_SHA384:
+		return WIFI_SECURITY_TYPE_EAP;
+	case NRF_WIFI_FT_EAP_SHA384:
+		return WIFI_SECURITY_TYPE_FT_EAP_SHA384;
+	case NRF_WIFI_FT_PSK_SHA384:
+		return WIFI_SECURITY_TYPE_FT_PSK;
+	case NRF_WIFI_PSK_SHA384:
+		return WIFI_SECURITY_TYPE_PSK_SHA384;
 	default:
 		return WIFI_SECURITY_TYPE_UNKNOWN;
 	}
@@ -346,6 +386,8 @@ void nrf_wifi_event_proc_disp_scan_res_zep(void *vif_ctx,
 		res.channel = r->nwk_channel;
 
 		res.security = drv_to_wifi_mgmt(r->security_type);
+
+		res.suite_b_type = drv_to_wifi_mgmt_suiteb(r->security_type);
 
 		res.mfp = drv_to_wifi_mgmt_mfp(r->mfp_flag);
 

--- a/include/zephyr/net/wifi.h
+++ b/include/zephyr/net/wifi.h
@@ -38,6 +38,18 @@
 extern "C" {
 #endif
 
+/** @brief IEEE 802.11 SUITE-B */
+enum wifi_cipher_suite_b {
+	/** Not Applicable for Personal mode security */
+	WIFI_CIPHER_SUITE_B_NA,
+	/** Not enable for Enterprise mode security */
+	WIFI_CIPHER_SUITE_B_NONE,
+	/** SUITE-B */
+	WIFI_CIPHER_SUITE_B,
+	/** SUITE-B-192 */
+	WIFI_CIPHER_SUITE_B_192,
+};
+
 /** @brief IEEE 802.11 security types. */
 enum wifi_security_type {
 	/** No security. */
@@ -86,6 +98,8 @@ enum wifi_security_type {
 	WIFI_SECURITY_TYPE_FT_EAP,
 	/** FT-EAP-SHA384 security */
 	WIFI_SECURITY_TYPE_FT_EAP_SHA384,
+	/** WPA2-PSK-SHA384 security. */
+	WIFI_SECURITY_TYPE_PSK_SHA384,
 
 	/** @cond INTERNAL_HIDDEN */
 	__WIFI_SECURITY_TYPE_AFTER_LAST,
@@ -178,6 +192,9 @@ struct wifi_eap_config {
 	/** Phase2 setting string. */
 	char *phase2;
 };
+
+/** Helper function to get user-friendly Suite_B type name. */
+const char *wifi_suiteb_txt(enum wifi_cipher_suite_b suite_b);
 
 /** Helper function to get user-friendly security type name. */
 const char *wifi_security_txt(enum wifi_security_type security);

--- a/include/zephyr/net/wifi_mgmt.h
+++ b/include/zephyr/net/wifi_mgmt.h
@@ -490,6 +490,8 @@ struct wifi_scan_result {
 	uint8_t channel;
 	/** Security type */
 	enum wifi_security_type security;
+	/** Cipher SuiteB */
+	enum wifi_cipher_suite_b suite_b_type;
 	/** MFP options */
 	enum wifi_mfp_options mfp;
 	/** RSSI */

--- a/subsys/net/l2/wifi/wifi_mgmt.c
+++ b/subsys/net/l2/wifi/wifi_mgmt.c
@@ -48,8 +48,42 @@ struct wifi_roaming_params {
 static struct wifi_roaming_params roaming_params;
 #endif
 
+const bool is_enterprise_security(enum wifi_security_type security)
+{
+	switch (security) {
+	case WIFI_SECURITY_TYPE_EAP_TLS:
+	case WIFI_SECURITY_TYPE_EAP_TLS_SHA256:
+	case WIFI_SECURITY_TYPE_EAP_PEAP_MSCHAPV2:
+	case WIFI_SECURITY_TYPE_EAP_PEAP_GTC:
+	case WIFI_SECURITY_TYPE_EAP_TTLS_MSCHAPV2:
+	case WIFI_SECURITY_TYPE_EAP_PEAP_TLS:
+		return true;
+	default:
+		return false;
+	}
+}
+
+const char *wifi_suiteb_txt(enum wifi_cipher_suite_b suiteb)
+{
+	switch (suiteb) {
+	case WIFI_CIPHER_SUITE_B_NA:
+		return "Not Applicable";
+	case WIFI_CIPHER_SUITE_B_NONE:
+		return "Not Enabled";
+	case WIFI_CIPHER_SUITE_B:
+		return "SUITE-B";
+	case WIFI_CIPHER_SUITE_B_192:
+		return "SUITE-B-192";
+	default:
+		return "UNKNOWN";
+	}
+}
 const char *wifi_security_txt(enum wifi_security_type security)
 {
+	if (is_enterprise_security(security)) {
+		return "IEEE_8021_x";
+	}
+
 	switch (security) {
 	case WIFI_SECURITY_TYPE_NONE:
 		return "OPEN";
@@ -65,8 +99,6 @@ const char *wifi_security_txt(enum wifi_security_type security)
 		return "WPA3-SAE-AUTO";
 	case WIFI_SECURITY_TYPE_WAPI:
 		return "WAPI";
-	case WIFI_SECURITY_TYPE_EAP_TLS:
-		return "EAP-TLS";
 	case WIFI_SECURITY_TYPE_WEP:
 		return "WEP";
 	case WIFI_SECURITY_TYPE_WPA_PSK:
@@ -75,16 +107,6 @@ const char *wifi_security_txt(enum wifi_security_type security)
 		return "WPA/WPA2/WPA3 PSK";
 	case WIFI_SECURITY_TYPE_DPP:
 		return "DPP";
-	case WIFI_SECURITY_TYPE_EAP_PEAP_MSCHAPV2:
-		return "EAP-PEAP-MSCHAPV2";
-	case WIFI_SECURITY_TYPE_EAP_PEAP_GTC:
-		return "EAP-PEAP-GTC";
-	case WIFI_SECURITY_TYPE_EAP_TTLS_MSCHAPV2:
-		return "EAP-TTLS-MSCHAPV2";
-	case WIFI_SECURITY_TYPE_EAP_PEAP_TLS:
-		return "EAP-PEAP-TLS";
-	case WIFI_SECURITY_TYPE_EAP_TLS_SHA256:
-		return "EAP-TLS-SHA256";
 	case WIFI_SECURITY_TYPE_FT_PSK:
 		return "FT-PSK";
 	case WIFI_SECURITY_TYPE_FT_SAE:

--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -190,18 +190,19 @@ static void handle_wifi_scan_result(struct net_mgmt_event_callback *cb)
 	context.scan_result++;
 
 	if (context.scan_result == 1U) {
-		PR("\n%-4s | %-32s %-5s | %-13s | %-4s | %-15s | %-17s | %-8s\n",
-		   "Num", "SSID", "(len)", "Chan (Band)", "RSSI", "Security", "BSSID", "MFP");
+		PR("\n%-4s | %-32s %-5s | %-13s | %-4s | %-30s | %-17s | %-8s\n",
+		   "Num", "SSID", "(len)", "Chan (Band)", "RSSI", "Security (Suite-B)",
+		   "BSSID", "MFP");
 	}
 
 	strncpy(ssid_print, entry->ssid, sizeof(ssid_print) - 1);
 	ssid_print[sizeof(ssid_print) - 1] = '\0';
 
-	PR("%-4d | %-32s %-5u | %-4u (%-6s) | %-4d | %-15s | %-17s | %-8s\n",
+	PR("%-4d | %-32s %-5u | %-4u (%-6s) | %-4d | %-18s (%-12s) | %-17s | %-8s\n",
 	   context.scan_result, ssid_print, entry->ssid_length, entry->channel,
 	   wifi_band_txt(entry->band),
 	   entry->rssi,
-	   wifi_security_txt(entry->security),
+	   wifi_security_txt(entry->security), wifi_suiteb_txt(entry->suite_b_type),
 	   ((entry->mac_length) ?
 		   net_sprint_ll_addr_buf(entry->mac, WIFI_MAC_ADDR_LEN,
 					  mac_string_buf,

--- a/west.yml
+++ b/west.yml
@@ -309,7 +309,7 @@ manifest:
       revision: fbc6e614686b69dfa56f9694350b9488cf83d3f7
       path: modules/bsim_hw_models/nrf_hw_models
     - name: nrf_wifi
-      revision: 71261e2b719b98500b7741c3398a74a5fb631596
+      revision: f6b950a3b5c0187fe499b0e518426d5bf88b7e68
       path: modules/lib/nrf_wifi
     - name: open-amp
       revision: b735edbc739ad59156eb55bb8ce2583d74537719


### PR DESCRIPTION
Updated manifest to include separate security type for EAP TLS SHA256 in display of scan results when APs have EAP and PMF enabled.