### PR TITLE
tests: Bluetooth: ASCS: Fix various issues in ASCS unit tests

### DIFF
--- a/subsys/bluetooth/audio/ascs.c
+++ b/subsys/bluetooth/audio/ascs.c
@@ -3283,6 +3283,8 @@ int bt_ascs_unregister(void)
 
 	for (size_t i = 0; i < ARRAY_SIZE(ascs.ase_pool); i++) {
 		if (ascs.ase_pool[i].ep.status.state != BT_BAP_EP_STATE_IDLE) {
+			LOG_DBG("[%zu] ase %p not in idle state: %s", i, &ascs.ase_pool[i].ep,
+				bt_bap_ep_state_str(ascs.ase_pool[i].ep.status.state));
 			return -EBUSY;
 		}
 	}

--- a/tests/bluetooth/audio/ascs/CMakeLists.txt
+++ b/tests/bluetooth/audio/ascs/CMakeLists.txt
@@ -16,6 +16,7 @@ target_sources(testbinary
   PRIVATE
     src/main.c
     src/test_ase_control_params.c
+    src/test_ase_register.c
     src/test_ase_state_transition_invalid.c
     src/test_ase_state_transition.c
     src/test_common.c

--- a/tests/bluetooth/audio/ascs/src/test_ase_control_params.c
+++ b/tests/bluetooth/audio/ascs/src/test_ase_control_params.c
@@ -9,6 +9,7 @@
 
 #include <stdint.h>
 #include <stdlib.h>
+#include <zephyr/kernel.h>
 #include <zephyr/types.h>
 #include <zephyr/bluetooth/audio/audio.h>
 #include <zephyr/bluetooth/audio/bap.h>
@@ -80,12 +81,11 @@ static void test_ase_control_params_after(void *f)
 	err = bt_bap_unicast_server_unregister_cb(&mock_bap_unicast_server_cb);
 	zassert_equal(err, 0, "unexpected err response %d", err);
 
+	/* Sleep to trigger any pending state changes from unregister_cb */
+	k_sleep(K_SECONDS(1));
+
 	err = bt_bap_unicast_server_unregister();
-	while (err != 0) {
-		zassert_equal(err, -EBUSY, "unexpected err response %d", err);
-		k_sleep(K_MSEC(10));
-		err = bt_bap_unicast_server_unregister();
-	}
+	zassert_equal(err, 0, "Unexpected err response %d", err);
 }
 
 static void test_ase_control_params_teardown(void *f)

--- a/tests/bluetooth/audio/ascs/src/test_ase_register.c
+++ b/tests/bluetooth/audio/ascs/src/test_ase_register.c
@@ -1,0 +1,163 @@
+/* main.c - Application main entry point */
+
+/*
+ * Copyright (c) 2024 Demant A/S
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <errno.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+
+#include <zephyr/autoconf.h>
+#include <zephyr/fff.h>
+#include <zephyr/kernel.h>
+#include <zephyr/bluetooth/audio/audio.h>
+#include <zephyr/bluetooth/audio/bap.h>
+#include <zephyr/bluetooth/audio/pacs.h>
+#include <zephyr/bluetooth/conn.h>
+#include <zephyr/bluetooth/hci_types.h>
+#include <zephyr/bluetooth/gatt.h>
+#include <zephyr/bluetooth/uuid.h>
+#include <zephyr/sys/util_macro.h>
+#include <zephyr/ztest_assert.h>
+#include <zephyr/ztest_test.h>
+
+#include "assert.h"
+#include "bap_unicast_server.h"
+#include "bap_unicast_server_expects.h"
+#include "bap_stream.h"
+#include "bap_stream_expects.h"
+#include "conn.h"
+
+#include "test_common.h"
+
+static void ascs_register_test_suite_after(void *f)
+{
+	/* Attempt to clean up failing tests */
+	(void)bt_bap_unicast_server_unregister_cb(&mock_bap_unicast_server_cb);
+
+	/* Sleep to trigger any pending state changes */
+	k_sleep(K_SECONDS(1));
+
+	(void)bt_bap_unicast_server_unregister();
+}
+
+ZTEST_SUITE(ascs_register_test_suite, NULL, NULL, NULL, ascs_register_test_suite_after, NULL);
+
+static ZTEST(ascs_register_test_suite, test_cb_register_without_ascs_registered)
+{
+	int err;
+
+	err = bt_bap_unicast_server_register_cb(&mock_bap_unicast_server_cb);
+	zassert_equal(err, -ENOTSUP, "Unexpected err response %d", err);
+}
+
+static ZTEST(ascs_register_test_suite, test_ascs_register_with_null_param)
+{
+	int err;
+
+	err = bt_bap_unicast_server_register(NULL);
+	zassert_equal(err, -EINVAL, "Unexpected err response %d", err);
+}
+
+static ZTEST(ascs_register_test_suite, test_ascs_register_twice)
+{
+	int err;
+	struct bt_bap_unicast_server_register_param param = {
+		CONFIG_BT_ASCS_MAX_ASE_SNK_COUNT,
+		CONFIG_BT_ASCS_MAX_ASE_SRC_COUNT,
+	};
+
+	/* Setup already registered once, so calling once here should be sufficient */
+	err = bt_bap_unicast_server_register(&param);
+	zassert_equal(err, 0, "Unexpected err response %d", err);
+
+	/* Setup already registered once, so calling once here should be sufficient */
+	err = bt_bap_unicast_server_register(&param);
+	zassert_equal(err, -EALREADY, "Unexpected err response %d", err);
+
+	err = bt_bap_unicast_server_unregister();
+	zassert_equal(err, 0, "Unexpected err response %d", err);
+}
+
+static ZTEST(ascs_register_test_suite, test_ascs_register_too_many_sinks)
+{
+	int err;
+	struct bt_bap_unicast_server_register_param param = {
+		CONFIG_BT_ASCS_MAX_ASE_SNK_COUNT + 1,
+		CONFIG_BT_ASCS_MAX_ASE_SRC_COUNT,
+	};
+
+	err = bt_bap_unicast_server_register(&param);
+	zassert_equal(err, -EINVAL, "Unexpected err response %d", err);
+}
+
+static ZTEST(ascs_register_test_suite, test_ascs_register_too_many_sources)
+{
+	int err;
+	struct bt_bap_unicast_server_register_param param = {
+		CONFIG_BT_ASCS_MAX_ASE_SNK_COUNT,
+		CONFIG_BT_ASCS_MAX_ASE_SRC_COUNT + 1,
+	};
+
+	err = bt_bap_unicast_server_register(&param);
+	zassert_equal(err, -EINVAL, "Unexpected err response %d", err);
+}
+
+static ZTEST(ascs_register_test_suite, test_ascs_register_zero_ases)
+{
+	int err;
+	struct bt_bap_unicast_server_register_param param = {0, 0};
+
+	err = bt_bap_unicast_server_register(&param);
+	zassert_equal(err, -EINVAL, "Unexpected err response %d", err);
+}
+
+static ZTEST(ascs_register_test_suite, test_ascs_register_fewer_than_max_ases)
+{
+	int err;
+	struct bt_bap_unicast_server_register_param param = {
+		CONFIG_BT_ASCS_MAX_ASE_SNK_COUNT > 0 ? CONFIG_BT_ASCS_MAX_ASE_SNK_COUNT - 1 : 0,
+		CONFIG_BT_ASCS_MAX_ASE_SRC_COUNT > 0 ? CONFIG_BT_ASCS_MAX_ASE_SRC_COUNT - 1 : 0,
+	};
+
+	err = bt_bap_unicast_server_register(&param);
+	zassert_equal(err, 0, "Unexpected err response %d", err);
+}
+
+static ZTEST(ascs_register_test_suite, test_ascs_unregister_without_register)
+{
+	int err;
+
+	err = bt_bap_unicast_server_unregister();
+	zassert_equal(err, -EALREADY, "Unexpected err response %d", err);
+}
+
+static ZTEST(ascs_register_test_suite, test_ascs_unregister_with_cbs_registered)
+{
+	struct bt_bap_unicast_server_register_param param = {
+		CONFIG_BT_ASCS_MAX_ASE_SNK_COUNT,
+		CONFIG_BT_ASCS_MAX_ASE_SRC_COUNT,
+	};
+	int err;
+
+	err = bt_bap_unicast_server_register(&param);
+	zassert_equal(err, 0, "Unexpected err response %d", err);
+
+	err = bt_bap_unicast_server_register_cb(&mock_bap_unicast_server_cb);
+	zassert_equal(err, 0, "Unexpected err response %d", err);
+
+	/* Not valid to unregister while callbacks are still registered */
+	err = bt_bap_unicast_server_unregister();
+	zassert_equal(err, -EAGAIN, "Unexpected err response %d", err);
+
+	err = bt_bap_unicast_server_unregister_cb(&mock_bap_unicast_server_cb);
+	zassert_equal(err, 0, "Unexpected err response %d", err);
+
+	err = bt_bap_unicast_server_unregister();
+	zassert_equal(err, 0, "Unexpected err response %d", err);
+}

--- a/tests/bluetooth/audio/ascs/src/test_ase_state_transition.c
+++ b/tests/bluetooth/audio/ascs/src/test_ase_state_transition.c
@@ -8,12 +8,14 @@
  */
 
 #include <stdlib.h>
+#include <zephyr/kernel.h>
 #include <zephyr/types.h>
 #include <zephyr/bluetooth/audio/audio.h>
 #include <zephyr/bluetooth/audio/bap.h>
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/gatt.h>
 #include <zephyr/sys/util_macro.h>
+#include <zephyr/ztest_assert.h>
 
 #include "bap_unicast_server.h"
 #include "bap_unicast_server_expects.h"
@@ -110,12 +112,11 @@ static void test_ase_state_transition_after(void *f)
 	err = bt_bap_unicast_server_unregister_cb(&mock_bap_unicast_server_cb);
 	zassert_equal(err, 0, "unexpected err response %d", err);
 
+	/* Sleep to trigger any pending state changes from unregister_cb */
+	k_sleep(K_SECONDS(1));
+
 	err = bt_bap_unicast_server_unregister();
-	while (err != 0) {
-		zassert_equal(err, -EBUSY, "unexpected err response %d", err);
-		k_sleep(K_MSEC(10));
-		err = bt_bap_unicast_server_unregister();
-	}
+	zassert_equal(err, 0, "Unexpected err response %d", err);
 }
 
 static void test_ase_state_transition_teardown(void *f)

--- a/tests/bluetooth/audio/ascs/src/test_ase_state_transition_invalid.c
+++ b/tests/bluetooth/audio/ascs/src/test_ase_state_transition_invalid.c
@@ -8,6 +8,7 @@
  */
 
 #include <stdlib.h>
+#include <zephyr/kernel.h>
 #include <zephyr/types.h>
 #include <zephyr/bluetooth/audio/audio.h>
 #include <zephyr/bluetooth/audio/bap.h>
@@ -75,12 +76,11 @@ static void test_ase_state_transition_invalid_after(void *f)
 	err = bt_bap_unicast_server_unregister_cb(&mock_bap_unicast_server_cb);
 	zassert_equal(err, 0, "unexpected err response %d", err);
 
+	/* Sleep to trigger any pending state changes from unregister_cb */
+	k_sleep(K_SECONDS(1));
+
 	err = bt_bap_unicast_server_unregister();
-	while (err != 0) {
-		zassert_equal(err, -EBUSY, "unexpected err response %d", err);
-		k_sleep(K_MSEC(10));
-		err = bt_bap_unicast_server_unregister();
-	}
+	zassert_equal(err, 0, "Unexpected err response %d", err);
 }
 
 static void test_ase_state_transition_invalid_teardown(void *f)

--- a/tests/bluetooth/audio/ascs/testcase.yaml
+++ b/tests/bluetooth/audio/ascs/testcase.yaml
@@ -16,6 +16,8 @@ tests:
   bluetooth.audio.ascs.test_unicast_client_enabled:
     type: unit
     extra_configs:
+      - CONFIG_BT_CENTRAL=y
+      - CONFIG_BT_ISO_CENTRAL=y
       - CONFIG_BT_BAP_UNICAST_CLIENT=y
       - CONFIG_BT_GATT_CLIENT=y
       - CONFIG_BT_GATT_AUTO_DISCOVER_CCC=y


### PR DESCRIPTION
    The ASCS unit tests had various errors after adding support for
    dynamic registration.
    Several tests did not properly clean up after failure, causing other
    tests to fail when they shouldn't.
    
    Moved the register tests to their own file as they should not
    do the register in the "before" function.
    
    The test_ascs_unregister_with_ases_in_config_state test was also
    removed, as it had both issues and the state that it wants to test
    cannot be reached with the current API - It is not possible to
    put an ASE in the configured state without callbacks,
    and registered callbacks prevents us from calling
    bt_bap_unicast_server_unregister to trigger the case as that can
    only be done if callbacks are unregistered. Since unregistering
    callbacks also puts all ASEs to the idle state, it is not possible
    to call bt_bap_unicast_server_unregister for a non-idle ASE.
    
    The testcase.yaml was also missing some Kconfig options to
    properly enable the client tests.