### PR TITLE
tests: mgmt: mcumgr: os_mgmt_info: Fix return type

### DIFF
--- a/tests/subsys/mgmt/mcumgr/os_mgmt_info/src/main.c
+++ b/tests/subsys/mgmt/mcumgr/os_mgmt_info/src/main.c
@@ -212,7 +212,7 @@ static enum mgmt_cb_return os_mgmt_info_custom_cmd_callback(uint32_t event,
 		}
 	}
 
-	return MGMT_ERR_EOK;
+	return MGMT_CB_OK;
 }
 
 static struct mgmt_callback custom_cmd_check_callback = {


### PR DESCRIPTION
Fixes returning a define from a different enum which throws an error with clang