### PR TITLE
soc: espressif: esp32c6 split cached area

### DIFF
--- a/soc/espressif/esp32c6/default.ld
+++ b/soc/espressif/esp32c6/default.ld
@@ -25,7 +25,8 @@ user_sram_org = HPSRAM_START;
 user_sram_size = (user_sram_end - user_sram_org);
 
 /* Aliases */
-#define CACHED_REGION      mmap0_0_seg
+#define FLASH_CODE_REGION  irom0_0_seg
+#define RODATA_REGION      drom0_0_seg
 #define RAMABLE_REGION     sram0_0_seg
 #define ROMABLE_REGION     FLASH
 
@@ -38,7 +39,7 @@ user_sram_size = (user_sram_end - user_sram_org);
 /* Flash segments (rodata and text) should be mapped in the virtual address spaces.
  * Executing directly from LMA is not possible. */
 #undef GROUP_ROM_LINK_IN
-#define GROUP_ROM_LINK_IN(vregion, lregion) > CACHED_REGION AT > lregion
+#define GROUP_ROM_LINK_IN(vregion, lregion) > RODATA_REGION AT > lregion
 
 /* Make sure new sections have consistent alignment between input and output sections */
 #undef SECTION_DATA_PROLOGUE
@@ -65,7 +66,8 @@ MEMORY
 
   sram0_0_seg(RW): org = user_sram_org, len = user_sram_size
 
-  mmap0_0_seg (R): org = CACHED_ORG, len = CACHED_SIZE
+  irom0_0_seg(RX): org = IROM_SEG_ORG, len = IROM_SEG_LEN
+  drom0_0_seg(R):  org = DROM_SEG_ORG, len = DROM_SEG_LEN
 
   lp_ram_seg(RW):    org = LPSRAM_IRAM_START,
                      len = 0x2000 - RESERVE_RTC_MEM
@@ -769,7 +771,7 @@ SECTIONS
     __rom_region_end = ABSOLUTE(.);
     _etext = .;
 
-  } GROUP_DATA_LINK_IN(CACHED_REGION, ROMABLE_REGION)
+  } GROUP_DATA_LINK_IN(FLASH_CODE_REGION, ROMABLE_REGION)
 
   /* --- END OF .flash.text --- */
 
@@ -780,12 +782,6 @@ SECTIONS
   {
     . = ALIGN(CACHE_ALIGN);
   } GROUP_LINK_IN(ROMABLE_REGION)
-
-  .flash.align_rodata (NOLOAD) :
-  {
-    /* Subsequent segment lma and vma align */
-    . = ALIGN(CACHE_ALIGN);
-  } GROUP_LINK_IN(CACHED_REGION)
 
   /* Symbols used during the application memory mapping */
   _image_drom_start = LOADADDR(.flash.rodata);
@@ -843,7 +839,7 @@ SECTIONS
     *(.rodata_wlog)
     *(.rodata_wlog*)
     . = ALIGN(4);
-  } GROUP_DATA_LINK_IN(CACHED_REGION, ROMABLE_REGION)
+  } GROUP_DATA_LINK_IN(RODATA_REGION, ROMABLE_REGION)
 
   #include <zephyr/linker/cplusplus-rom.ld>
   #include <zephyr/linker/common-rom/common-rom-init.ld>
@@ -863,7 +859,7 @@ SECTIONS
     . = ALIGN(4);
     _rodata_reserved_end = ABSOLUTE(.);
     _image_rodata_end = ABSOLUTE(.);
-  } GROUP_DATA_LINK_IN(CACHED_REGION, ROMABLE_REGION)
+  } GROUP_DATA_LINK_IN(RODATA_REGION, ROMABLE_REGION)
 
   /* --- END OF .rodata --- */
 

--- a/soc/espressif/esp32c6/memory.h
+++ b/soc/espressif/esp32c6/memory.h
@@ -60,6 +60,8 @@
 #endif
 
 /* Cached memory */
-#define CACHE_ALIGN        CONFIG_MMU_PAGE_SIZE
-#define CACHED_ORG         0x42000000
-#define CACHED_SIZE        FLASH_SIZE
+#define CACHE_ALIGN  CONFIG_MMU_PAGE_SIZE
+#define IROM_SEG_ORG 0x42000000
+#define IROM_SEG_LEN FLASH_SIZE
+#define DROM_SEG_ORG 0x42800000
+#define DROM_SEG_LEN FLASH_SIZE


### PR DESCRIPTION
Split the cached area and assign both parts IROM and DROM meaning. This is necessary to overcome the esptool section merging issues.