### PR TITLE
stm32: Fix wrong binding target for RTC_SEL in stm32u0

### DIFF
--- a/include/zephyr/dt-bindings/clock/stm32u0_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32u0_clock.h
@@ -87,6 +87,6 @@
 #define CLK48_SEL(val)		STM32_DOMAIN_CLOCK(val, 3, 26, CCIPR_REG)
 #define ADC_SEL(val)		STM32_DOMAIN_CLOCK(val, 3, 28, CCIPR_REG)
 /** BDCR devices */
-#define RTC_SEL(val)		STM32_DOMAIN_CLOCK(val, 3, 8, CSR_REG)
+#define RTC_SEL(val)		STM32_DOMAIN_CLOCK(val, 3, 8, BDCR_REG)
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32U0_CLOCK_H_ */


### PR DESCRIPTION
Change the stm32u0 clock from CSR_REG to BDCR_REG.

fixes https://github.com/zephyrproject-rtos/zephyr/issues/81493