### PR TITLE
tests: cpp: remove non-existing target

### DIFF
--- a/tests/lib/cpp/cxx/testcase.yaml
+++ b/tests/lib/cpp/cxx/testcase.yaml
@@ -42,7 +42,6 @@ tests:
       - nrf54h20dk/nrf54h20/cpuapp
       - nrf54h20dk/nrf54h20/cpurad
       - nrf54h20dk@0.8.0/nrf54h20/cpuapp
-      - nrf54h20dk@0.8.0/nrf54h20/cpurad
       - nrf9280pdk/nrf9280/cpuapp
       - nrf9280pdk/nrf9280/cpurad
     filter: not CONFIG_HAS_RENESAS_RA_FSP


### PR DESCRIPTION
nrf54h20dk@0.8.0/nrf54h20/cpurad was recently removed.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
