### PR TITLE
drivers: pwm: mcux_tpm: allow configuring the clock prescaler

### DIFF
--- a/drivers/pwm/pwm_mcux_tpm.c
+++ b/drivers/pwm/pwm_mcux_tpm.c
@@ -195,6 +195,8 @@ static const struct pwm_driver_api mcux_tpm_driver_api = {
 	.get_cycles_per_sec = mcux_tpm_get_cycles_per_sec,
 };
 
+#define TO_TPM_PRESCALE_DIVIDE(val) _DO_CONCAT(kTPM_Prescale_Divide_, val)
+
 #define TPM_DEVICE(n) \
 	PINCTRL_DT_INST_DEFINE(n); \
 	static const struct mcux_tpm_config mcux_tpm_config_##n = { \
@@ -204,7 +206,7 @@ static const struct pwm_driver_api mcux_tpm_driver_api = {
 		.clock_subsys = (clock_control_subsys_t) \
 			DT_INST_CLOCKS_CELL(n, name), \
 		.tpm_clock_source = kTPM_SystemClock, \
-		.prescale = kTPM_Prescale_Divide_16, \
+		.prescale = TO_TPM_PRESCALE_DIVIDE(DT_INST_PROP(n, prescaler)), \
 		.channel_count = FSL_FEATURE_TPM_CHANNEL_COUNTn((TPM_Type *) \
 			DT_INST_REG_ADDR(n)), \
 		.mode = kTPM_EdgeAlignedPwm, \

--- a/dts/arm/nxp/nxp_imx95_m7.dtsi
+++ b/dts/arm/nxp/nxp_imx95_m7.dtsi
@@ -91,6 +91,7 @@
 			reg = <0x424e0000 0x88>;
 			interrupts = <73 0>;
 			clocks = <&scmi_clk IMX95_CLK_BUSWAKEUP>;
+			prescaler = <16>;
 			status = "disabled";
 			#pwm-cells = <3>;
 		};
@@ -100,6 +101,7 @@
 			reg = <0x424f0000 0x88>;
 			interrupts = <74 0>;
 			clocks = <&scmi_clk IMX95_CLK_TPM4>;
+			prescaler = <16>;
 			status = "disabled";
 			#pwm-cells = <3>;
 		};
@@ -109,6 +111,7 @@
 			reg = <0x42500000 0x88>;
 			interrupts = <75 0>;
 			clocks = <&scmi_clk IMX95_CLK_TPM5>;
+			prescaler = <16>;
 			status = "disabled";
 			#pwm-cells = <3>;
 		};
@@ -118,6 +121,7 @@
 			reg = <0x42510000 0x88>;
 			interrupts = <76 0>;
 			clocks = <&scmi_clk IMX95_CLK_TPM6>;
+			prescaler = <16>;
 			status = "disabled";
 			#pwm-cells = <3>;
 		};
@@ -254,6 +258,7 @@
 			reg = <0x44310000 0x88>;
 			interrupts = <29 0>;
 			clocks = <&scmi_clk IMX95_CLK_BUSAON>;
+			prescaler = <16>;
 			status = "disabled";
 			#pwm-cells = <3>;
 		};
@@ -263,6 +268,7 @@
 			reg = <0x44320000 0x88>;
 			interrupts = <30 0>;
 			clocks = <&scmi_clk IMX95_CLK_TPM2>;
+			prescaler = <16>;
 			status = "disabled";
 			#pwm-cells = <3>;
 		};

--- a/dts/arm/nxp/nxp_kw41z.dtsi
+++ b/dts/arm/nxp/nxp_kw41z.dtsi
@@ -204,6 +204,7 @@
 			interrupts = <0x84 0>;
 			/* channel information needed - fixme */
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x103C 24>;
+			prescaler = <16>;
 			status = "disabled";
 			#pwm-cells = <3>;
 		};
@@ -214,6 +215,7 @@
 			interrupts = <0x88 0>;
 			/* channel information needed - fixme */
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x103C 25>;
+			prescaler = <16>;
 			status = "disabled";
 			#pwm-cells = <3>;
 		};
@@ -224,6 +226,7 @@
 			interrupts = <0x8C 0>;
 			/* channel information needed - fixme */
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x103C 26>;
+			prescaler = <16>;
 			status = "disabled";
 			#pwm-cells = <3>;
 		};

--- a/dts/arm/nxp/nxp_mcxc_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxc_common.dtsi
@@ -252,6 +252,7 @@
 			reg = <0x40038000 0x88>;
 			interrupts = <17 0>;
 			clocks = <&sim KINETIS_SIM_MCGPCLK 0x103C 24>;
+			prescaler = <16>;
 			status = "disabled";
 			#pwm-cells = <3>;
 		};
@@ -261,6 +262,7 @@
 			reg = <0x40039000 0x88>;
 			interrupts = <18 0>;
 			clocks = <&sim KINETIS_SIM_MCGPCLK 0x103C 25>;
+			prescaler = <16>;
 			status = "disabled";
 			#pwm-cells = <3>;
 		};
@@ -270,6 +272,7 @@
 			reg = <0x4003a000 0x88>;
 			interrupts = <19 0>;
 			clocks = <&sim KINETIS_SIM_MCGPCLK 0x103C 26>;
+			prescaler = <16>;
 			status = "disabled";
 			#pwm-cells = <3>;
 		};

--- a/dts/arm/nxp/nxp_mcxw71.dtsi
+++ b/dts/arm/nxp/nxp_mcxw71.dtsi
@@ -248,6 +248,7 @@
 		reg = <0x31000 0x100>;
 		interrupts = <37 0>;
 		clocks = <&scg SCG_K4_FIRC_CLK 0xc4>;
+		prescaler = <16>;
 		status = "disabled";
 		#pwm-cells = <3>;
 	};
@@ -257,6 +258,7 @@
 		reg = <0x32000 0x100>;
 		interrupts = <38 0>;
 		clocks = <&scg SCG_K4_FIRC_CLK 0xc8>;
+		prescaler = <16>;
 		status = "disabled";
 		#pwm-cells = <3>;
 	};

--- a/dts/bindings/pwm/nxp,kinetis-tpm.yaml
+++ b/dts/bindings/pwm/nxp,kinetis-tpm.yaml
@@ -17,6 +17,20 @@ properties:
   pinctrl-0:
     required: true
 
+  prescaler:
+    type: int
+    required: true
+    enum:
+      - 1
+      - 2
+      - 4
+      - 8
+      - 16
+      - 32
+      - 64
+      - 128
+    description: Input clock prescaler
+
   "#pwm-cells":
     const: 3
 


### PR DESCRIPTION
Allow configuring the clock prescaler divider for the NXP Kinetis Timer/PWM Module (TPM). Setting the prescaler to a lower value allows for higher resolution for the generated PWM waveforms. This change is inspired from the pwm_mcux_ftm driver:

Link: https://github.com/zephyrproject-rtos/zephyr/pull/25396