### PR TITLE
boards: st: nucleo_h533re: configure SPI on Arduino headers

### DIFF
--- a/boards/st/nucleo_h533re/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_h533re/arduino_r3_connector.dtsi
@@ -36,3 +36,4 @@
 };
 
 arduino_serial: &usart1 {};
+arduino_spi: &spi1 {};

--- a/boards/st/nucleo_h533re/doc/index.rst
+++ b/boards/st/nucleo_h533re/doc/index.rst
@@ -169,6 +169,8 @@ The Zephyr nucleo_h533re board configuration supports the following hardware fea
 +-----------+------------+-------------------------------------+
 | USB       | on-chip    | USB full-speed host/device bus      |
 +-----------+------------+-------------------------------------+
+| SPI       | on-chip    | spi                                 |
++-----------+------------+-------------------------------------+
 
 Other hardware features are not yet supported on this Zephyr port.
 
@@ -206,7 +208,7 @@ Default Zephyr Peripheral Mapping:
 
 - ADC1 channel 0 input: PA0
 - USART1 TX/RX : PB14/PB15 (Arduino USART1)
-- SPI1 SCK/MISO/MOSI/NSS: PA5/PA6/PA7/PA4
+- SPI1 SCK/MISO/MOSI/NSS: PA5/PA6/PA7/PC9
 - UART2 TX/RX : PA2/PA3 (VCP)
 - USER_PB : PC13
 

--- a/boards/st/nucleo_h533re/nucleo_h533re.dts
+++ b/boards/st/nucleo_h533re/nucleo_h533re.dts
@@ -105,6 +105,13 @@
 	status = "okay";
 };
 
+&spi1 {
+	pinctrl-0 = <&spi1_sck_pa5 &spi1_miso_pa6 &spi1_mosi_pa7>;
+	pinctrl-names = "default";
+	cs-gpios = <&gpioc 9 GPIO_ACTIVE_LOW>;
+	status = "okay";
+};
+
 &iwdg {
 	status = "okay";
 };

--- a/boards/st/nucleo_h533re/nucleo_h533re.yaml
+++ b/boards/st/nucleo_h533re/nucleo_h533re.yaml
@@ -12,7 +12,9 @@ flash: 512
 supported:
   - arduino_gpio
   - arduino_serial
+  - arduino_spi
   - gpio
+  - spi
   - watchdog
   - pwm
   - rtc


### PR DESCRIPTION
This allows to use the board right away with samples and shields depending
on Arduino SPI.