### PR TITLE
linker: add ARC-specific debug sections

### DIFF
--- a/include/zephyr/arch/arc/v2/linker.ld
+++ b/include/zephyr/arch/arc/v2/linker.ld
@@ -291,9 +291,15 @@ SECTIONS {
 
 #include <zephyr/linker/ram-end.ld>
 
-    GROUP_END(RAMABLE_REGION)
+	GROUP_END(RAMABLE_REGION)
 
 #include <zephyr/linker/debug-sections.ld>
+
+	SECTION_PROLOGUE(.arcextmap, 0,) {
+		*(.arcextmap)
+		*(.arcextmap.*)
+		*(.gnu.linkonce.arcextmap.*)
+	}
 
 	SECTION_PROLOGUE(.ARC.attributes, 0,) {
 		KEEP(*(.ARC.attributes))


### PR DESCRIPTION
ARC architecture has some additional .arcextmap debug sections used by debuggers to understand extension-specific instructions. These sections could safely be ignored, but doing this causes warnings at least with ARC MWDT toolchain.