### PR TITLE
drivers: serial: nrfx_uarte: Fix device runtime PM in the interrupt driven API

### DIFF
--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -353,16 +353,16 @@ static void uarte_nrfx_isr_int(const void *arg)
 	if (txstopped && (IS_ENABLED(CONFIG_PM_DEVICE_RUNTIME) || LOW_POWER_ENABLED(config))) {
 		unsigned int key = irq_lock();
 
-		if (IS_ENABLED(CONFIG_PM_DEVICE_RUNTIME) &&
-		    (data->flags & UARTE_FLAG_POLL_OUT)) {
-			data->flags &= ~UARTE_FLAG_POLL_OUT;
-			pm_device_runtime_put(dev);
+		if (IS_ENABLED(CONFIG_PM_DEVICE_RUNTIME)) {
+			if (data->flags & UARTE_FLAG_POLL_OUT) {
+				data->flags &= ~UARTE_FLAG_POLL_OUT;
+				pm_device_runtime_put_async(dev, K_NO_WAIT);
+			}
 		} else {
 			nrf_uarte_disable(uarte);
 		}
-
 #ifdef UARTE_INTERRUPT_DRIVEN
-		if (!data->int_driven || data->int_driven->fifo_fill_lock == 0)
+		if (!data->int_driven)
 #endif
 		{
 			nrf_uarte_int_disable(uarte, NRF_UARTE_INT_TXSTOPPED_MASK);
@@ -378,15 +378,19 @@ static void uarte_nrfx_isr_int(const void *arg)
 
 	if (txstopped) {
 		data->int_driven->fifo_fill_lock = 0;
-		if (data->int_driven->disable_tx_irq) {
-			nrf_uarte_int_disable(uarte,
-					      NRF_UARTE_INT_TXSTOPPED_MASK);
-			data->int_driven->disable_tx_irq = false;
-			return;
+		if (!data->int_driven->tx_irq_enabled) {
+
+			nrf_uarte_int_disable(uarte, NRF_UARTE_INT_TXSTOPPED_MASK);
 		}
 
+		if (data->int_driven->disable_tx_irq) {
+			data->int_driven->disable_tx_irq = false;
+			if (IS_ENABLED(CONFIG_PM_DEVICE_RUNTIME)) {
+				pm_device_runtime_put_async(dev, K_NO_WAIT);
+			}
+			return;
+		}
 	}
-
 
 	if (nrf_uarte_event_check(uarte, NRF_UARTE_EVENT_ERROR)) {
 		nrf_uarte_event_clear(uarte, NRF_UARTE_EVENT_ERROR);
@@ -1892,6 +1896,11 @@ static void uarte_nrfx_irq_tx_enable(const struct device *dev)
 {
 	NRF_UARTE_Type *uarte = get_uarte_instance(dev);
 	struct uarte_nrfx_data *data = dev->data;
+
+	if (IS_ENABLED(CONFIG_PM_DEVICE_RUNTIME)) {
+		pm_device_runtime_get(dev);
+	}
+
 	unsigned int key = irq_lock();
 
 	data->int_driven->disable_tx_irq = false;

--- a/tests/drivers/uart/uart_elementary/boards/nrf54h20dk_nrf54h20_cpuapp_dual_uart.overlay
+++ b/tests/drivers/uart/uart_elementary/boards/nrf54h20dk_nrf54h20_cpuapp_dual_uart.overlay
@@ -30,6 +30,7 @@ dut: &uart135 {
 	pinctrl-1 = <&uart135_sleep_alt>;
 	pinctrl-names = "default", "sleep";
 	current-speed = <115200>;
+	zephyr,pm-device-runtime-auto;
 };
 
 &pinctrl {
@@ -59,4 +60,5 @@ dut_aux: &uart137 {
 	pinctrl-1 = <&uart137_sleep_alt>;
 	pinctrl-names = "default", "sleep";
 	current-speed = <115200>;
+	zephyr,pm-device-runtime-auto;
 };

--- a/tests/drivers/uart/uart_elementary/testcase.yaml
+++ b/tests/drivers/uart/uart_elementary/testcase.yaml
@@ -19,6 +19,15 @@ tests:
     extra_args: DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_dual_uart.overlay"
     extra_configs:
       - CONFIG_DUAL_UART_TEST=y
+  drivers.uart.uart_elementary_dual_nrf54h.pm:
+    filter: CONFIG_SERIAL_SUPPORT_INTERRUPT
+    platform_allow:
+      - nrf54h20dk/nrf54h20/cpuapp
+    extra_args: DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_dual_uart.overlay"
+    extra_configs:
+      - CONFIG_DUAL_UART_TEST=y
+      - CONFIG_PM_DEVICE=y
+      - CONFIG_PM_DEVICE_RUNTIME=y
   drivers.uart.uart_elementary_dual_setup_mismatch_nrf54h:
     filter: CONFIG_SERIAL_SUPPORT_INTERRUPT
     platform_allow:


### PR DESCRIPTION
Runtime PM was not correctly handled in the interrupt driven API.
Added tests configuration to `tests/drivers/uart/uart_elementary` test.