### PR TITLE
lvgl: Allow flush thread to have preemptive priority

### DIFF
--- a/doc/releases/migration-guide-4.1.rst
+++ b/doc/releases/migration-guide-4.1.rst
@@ -36,6 +36,10 @@ Trusted Firmware-M
 LVGL
 ====
 
+* The config option :kconfig:option:`CONFIG_LV_Z_FLUSH_THREAD_PRIO` is now called
+  :kconfig:option:`CONFIG_LV_Z_FLUSH_THREAD_PRIORITY` and its value is now interpreted as an
+  absolute priority instead of a cooperative one.
+
 Device Drivers and Devicetree
 *****************************
 

--- a/modules/lvgl/Kconfig
+++ b/modules/lvgl/Kconfig
@@ -103,11 +103,11 @@ config LV_Z_FLUSH_THREAD_STACK_SIZE
 	help
 	  Stack size for LVGL flush thread, which will call display_write
 
-config LV_Z_FLUSH_THREAD_PRIO
+config LV_Z_FLUSH_THREAD_PRIORITY
 	int "LVGL flush thread priority"
-	default 0
+	default -1
 	help
-	  Cooperative priority of LVGL flush thread.
+	  Priority of LVGL flush thread.
 
 endif # LV_Z_FLUSH_THREAD
 

--- a/modules/lvgl/lvgl_display.c
+++ b/modules/lvgl/lvgl_display.c
@@ -34,9 +34,8 @@ void lvgl_flush_thread_entry(void *arg1, void *arg2, void *arg3)
 	}
 }
 
-K_THREAD_DEFINE(lvgl_flush_thread, CONFIG_LV_Z_FLUSH_THREAD_STACK_SIZE,
-		lvgl_flush_thread_entry, NULL, NULL, NULL,
-		K_PRIO_COOP(CONFIG_LV_Z_FLUSH_THREAD_PRIO), 0, 0);
+K_THREAD_DEFINE(lvgl_flush_thread, CONFIG_LV_Z_FLUSH_THREAD_STACK_SIZE, lvgl_flush_thread_entry,
+		NULL, NULL, NULL, CONFIG_LV_Z_FLUSH_THREAD_PRIORITY, 0, 0);
 
 
 void lvgl_wait_cb(lv_disp_drv_t *disp_drv)


### PR DESCRIPTION
The LVGL flush thread was hard-coded to be cooperative. For long-running actions like data transfer to the display, this is problematic as it might block high-frequency actions like USB or input events.

Hence, make it configurable to be preemptive, and rename it to match the similar Kconfig values like CONFIG_SDL_THREAD_PRIORITY.

The renaming change was added on purpose so it causes an error for all people that use it; this is a breaking change otherwise.