### PR TITLE
nrfbsim: Enable and test UARTE for 54L15

### DIFF
--- a/boards/native/nrf_bsim/doc/nrf54l15bsim.rst
+++ b/boards/native/nrf_bsim/doc/nrf54l15bsim.rst
@@ -52,6 +52,7 @@ This boards include models of some of the nRF54L15 SOC peripherals:
 * RTC (Real Time Counter)
 * TEMP (Temperature sensor)
 * TIMER
+* UARTE (UART with Easy DMA)
 * UICR (User Information Configuration Registers)
 
 and will use the same drivers as the nrf54l15dk targets for these.

--- a/boards/native/nrf_bsim/nrf54l15bsim_nrf54l15_cpuapp.dts
+++ b/boards/native/nrf_bsim/nrf54l15bsim_nrf54l15_cpuapp.dts
@@ -8,6 +8,7 @@
 
 #include <mem.h>
 #include <arm/nordic/nrf54l15_cpuapp.dtsi>
+#include <../boards/nordic/nrf54l15dk/nrf54l15dk_nrf54l_05_10_15-pinctrl.dtsi>
 
 / {
 	model = "Nordic NRF54L15 BSIM NRF54L15 Application";
@@ -15,6 +16,7 @@
 
 	chosen {
 		zephyr,entropy = &rng;
+		zephyr,bt-c2h-uart = &uart20;
 		zephyr,flash-controller = &rram_controller;
 		zephyr,flash = &cpuapp_rram;
 	};
@@ -28,19 +30,15 @@
 		/delete-node/ memory@2002f000;
 		peripheral@50000000 {
 			/delete-node/ spi@4a000;
-			/delete-node/ uart@4a000;
 			/delete-node/ vpr@4c000;
 			/delete-node/ mailbox@0;
 			/delete-node/ interrupt-controller@f0000000;
 			/delete-node/ i2c@c6000;
 			/delete-node/ spi@c6000;
-			/delete-node/ uart@c6000;
 			/delete-node/ i2c@c7000;
 			/delete-node/ spi@c7000;
-			/delete-node/ uart@c7000;
 			/delete-node/ i2c@c8000;
 			/delete-node/ spi@c8000;
-			/delete-node/ uart@c8000;
 			/delete-node/ pwm@d2000;
 			/delete-node/ pwm@d3000;
 			/delete-node/ pwm@d4000;
@@ -51,7 +49,6 @@
 			/delete-node/ qdec@e1000;
 			/delete-node/ i2c@104000;
 			/delete-node/ spi@104000;
-			/delete-node/ uart@104000;
 			/delete-node/ watchdog@108000;
 			/delete-node/ watchdog@109000;
 		};
@@ -86,6 +83,20 @@
 	};
 };
 
+&uart20 {
+	status = "okay";
+	current-speed = <115200>;
+	pinctrl-0 = <&uart20_default>;
+	pinctrl-1 = <&uart20_sleep>;
+	pinctrl-names = "default", "sleep";
+};
+
+&uart30 {
+	current-speed = <115200>;
+	pinctrl-0 = <&uart30_default>;
+	pinctrl-1 = <&uart30_sleep>;
+	pinctrl-names = "default", "sleep";
+};
 
 &gpio0 {
 	status = "okay";

--- a/boards/native/nrf_bsim/nrf54l15bsim_nrf54l15_cpuapp.yaml
+++ b/boards/native/nrf_bsim/nrf54l15bsim_nrf54l15_cpuapp.yaml
@@ -13,5 +13,4 @@ supported:
 testing:
   ignore_tags:
     - modem
-    - uart
     - bsim_skip_CI

--- a/tests/bsim/ci.uart.sh
+++ b/tests/bsim/ci.uart.sh
@@ -12,9 +12,15 @@ cd ${ZEPHYR_BASE}
 set -uex
 
 echo "UART: Single device tests"
+echo " nRF52833 & 5340:"
 ${ZEPHYR_BASE}/scripts/twister -T tests/drivers/uart/ --force-color --inline-logs -v -M \
   -p nrf52_bsim -p nrf5340bsim/nrf5340/cpuapp --fixture gpio_loopback \
   -- -uart0_loopback -uart1_loopback
+
+echo " nRF54L15:"
+${ZEPHYR_BASE}/scripts/twister -T tests/drivers/uart/ --force-color --inline-logs -v -M \
+  -p nrf54l15bsim/nrf54l15/cpuapp --fixture gpio_loopback \
+  -- -uart2_loopback
 
 echo "UART: Multi device tests"
 WORK_DIR=${ZEPHYR_BASE}/bsim_uart nice tests/bsim/drivers/uart/compile.sh

--- a/tests/drivers/uart/uart_async_api/boards/nrf54l15bsim_nrf54l15_cpuapp.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/nrf54l15bsim_nrf54l15_cpuapp.overlay
@@ -1,0 +1,3 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include "nrf54l15dk_nrf54l15_cpuapp.overlay"

--- a/tests/drivers/uart/uart_async_api/testcase.yaml
+++ b/tests/drivers/uart/uart_async_api/testcase.yaml
@@ -30,6 +30,7 @@ tests:
       - nrf52840dk/nrf52840
       - nrf52_bsim
       - nrf5340bsim/nrf5340/cpuapp
+      - nrf54l15bsim/nrf54l15/cpuapp
     filter: CONFIG_SERIAL_SUPPORT_ASYNC
     harness: ztest
     harness_config:

--- a/tests/drivers/uart/uart_mix_fifo_poll/boards/nrf54l15bsim_nrf54l15_cpuapp.overlay
+++ b/tests/drivers/uart/uart_mix_fifo_poll/boards/nrf54l15bsim_nrf54l15_cpuapp.overlay
@@ -1,0 +1,3 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include "nrf54l15dk_nrf54l15_cpuapp.overlay"

--- a/tests/drivers/uart/uart_mix_fifo_poll/testcase.yaml
+++ b/tests/drivers/uart/uart_mix_fifo_poll/testcase.yaml
@@ -10,6 +10,7 @@ common:
     - nrf5340dk/nrf5340/cpuapp
     - nrf5340bsim/nrf5340/cpuapp
     - nrf54l15dk/nrf54l15/cpuapp
+    - nrf54l15bsim/nrf54l15/cpuapp
     - nrf54h20dk/nrf54h20/cpuapp
     - nrf54h20dk/nrf54h20/cpurad
     - nrf52_bsim

--- a/tests/drivers/uart/uart_pm/boards/nrf54l15bsim_nrf54l15_cpuapp.overlay
+++ b/tests/drivers/uart/uart_pm/boards/nrf54l15bsim_nrf54l15_cpuapp.overlay
@@ -1,0 +1,3 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include "nrf54l15dk_nrf54l15_cpuapp.overlay"

--- a/tests/drivers/uart/uart_pm/testcase.yaml
+++ b/tests/drivers/uart/uart_pm/testcase.yaml
@@ -6,6 +6,7 @@ common:
   platform_allow:
     - nrf52840dk/nrf52840
     - nrf54l15dk/nrf54l15/cpuapp
+    - nrf54l15bsim/nrf54l15/cpuapp
     - nrf54h20dk/nrf54h20/cpuapp
     - nrf52_bsim
     - nrf5340bsim/nrf5340/cpuapp
@@ -29,6 +30,7 @@ tests:
     extra_args: DTC_OVERLAY_FILE="boards/nrf52840dk_nrf52840.overlay;nrf_rx_disable.overlay"
     platform_exclude:
       - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54l15bsim/nrf54l15/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
 
   drivers.uart.pm.enhanced_poll:


### PR DESCRIPTION
Update nRF hw models to latest which include models of the UARTE for the nrf54l15,
and enable the uart tests in this simulated platform.

Also for the ci runtime uart tests we run in the babblesim job, enable the nrf54l15.

Note: The UARTE models do not yet have all new 54 functionality (4-9 bit frames, address logic, and DMA match logic is missing)