### PR TITLE
boards: renesas: da14695_dk_usb: added mikrobus node labels

### DIFF
--- a/boards/renesas/da14695_dk_usb/da14695_dk_usb-pinctrl.dtsi
+++ b/boards/renesas/da14695_dk_usb/da14695_dk_usb-pinctrl.dtsi
@@ -18,20 +18,20 @@
 
 	uart2_default: uart2_default {
 		group1 {
-			pinmux = <SMARTBOND_PINMUX(UART_TX, 0, 17)>;
+			pinmux = <SMARTBOND_PINMUX(UART2_TX, 0, 17)>;
 		};
 		group2 {
-			pinmux = <SMARTBOND_PINMUX(UART_RX, 1, 8)>;
+			pinmux = <SMARTBOND_PINMUX(UART2_RX, 1, 8)>;
 			bias-pull-up;
 		};
 	};
 
 	uart3_default: uart3_default {
 		group1 {
-			pinmux = <SMARTBOND_PINMUX(UART_TX, 0, 29)>;
+			pinmux = <SMARTBOND_PINMUX(UART3_TX, 0, 29)>;
 		};
 		group2 {
-			pinmux = <SMARTBOND_PINMUX(UART_RX, 0, 28)>;
+			pinmux = <SMARTBOND_PINMUX(UART3_RX, 0, 28)>;
 			bias-pull-up;
 		};
 	};
@@ -63,8 +63,8 @@
 
 	/omit-if-no-ref/ i2c2_sleep: i2c2_sleep {
 		group1 {
-			pinmux = <SMARTBOND_PINMUX(GPIO, 0, 28)>,
-				<SMARTBOND_PINMUX(GPIO, 0, 29)>;
+			pinmux = <SMARTBOND_PINMUX(GPIO, 0, 19)>,
+				<SMARTBOND_PINMUX(GPIO, 0, 18)>;
 			bias-pull-up;
 		};
 	};

--- a/boards/renesas/da14695_dk_usb/da14695_dk_usb.dts
+++ b/boards/renesas/da14695_dk_usb/da14695_dk_usb.dts
@@ -38,51 +38,50 @@
 		};
 	};
 
-	mikrobus_header{
-		mikrobus-connector-1 {
-			compatible = "mikro-bus";
-			#gpio-cells = <2>;
-			gpio-map-mask = <0xffffffff 0xffffffc0>;
-			gpio-map-pass-thru = <0 0x3f>;
-			gpio-map =	<0 0 &gpio0 25 0>,	/* AN  */
-					/* Not a GPIO*/		/* RST */
-					<2 0 &gpio1 2 0>,	/* CS   */
-					<3 0 &gpio1 3 0>,	/* SCK  */
-					<4 0 &gpio1 4 0>,	/* MISO */
-					<5 0 &gpio1 5 0>,	/* MOSI */
-								/* +3.3V */
-								/* GND */
-					<6 0 &gpio1 6 0>,	/* PWM  */
-					<7 0 &gpio1 7 0>,	/* INT  */
-					<8 0 &gpio1 8 0>,	/* RX   */
-					<9 0 &gpio0 17 0>,	/* TX   */
-					<10 0 &gpio0 18 0>,	/* SCL  */
-					<11 0 &gpio0 19 0>;	/* SDA  */
-								/* +5V */
-								/* GND */
-		};
-		mikrobus-connector-2 {
-			compatible = "mikro-bus";
-			#gpio-cells = <2>;
-			gpio-map-mask = <0xffffffff 0xffffffc0>;
-			gpio-map-pass-thru = <0 0x3f>;
-			gpio-map =	<0 0 &gpio1 9 0>,	/* AN  */
-					/* Not a GPIO*/		/* RST */
-					<2 0 &gpio0 20 0>,	/* CS   */
-					<3 0 &gpio0 21 0>,	/* SCK  */
-					<4 0 &gpio0 24 0>,	/* MISO */
-					<5 0 &gpio0 26 0>,	/* MOSI */
-								/* +3.3V */
-								/* GND */
-					<6 0 &gpio1 1 0>,	/* PWM  */
-					<7 0 &gpio0 27 0>,	/* INT  */
-					<8 0 &gpio0 28 0>,	/* RX   */
-					<9 0 &gpio0 29 0>,	/* TX   */
-					<10 0 &gpio0 30 0>,	/* SCL  */
-					<11 0 &gpio0 31 0>;	/* SDA  */
-								/* +5V */
-								/* GND */
-		};
+	mikrobus_1_header: mikrobus-connector-1 {
+		compatible = "mikro-bus";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map =	<0 0 &gpio1 9 0>,	/* AN  */
+				<1 0 &gpio0 12 0>,	/* RST */
+				<2 0 &gpio0 20 0>,	/* CS   */
+				<3 0 &gpio0 21 0>,	/* SCK  */
+				<4 0 &gpio0 24 0>,	/* MISO */
+				<5 0 &gpio0 26 0>,	/* MOSI */
+							/* +3.3V */
+							/* GND */
+				<6 0 &gpio1 1 0>,	/* PWM  */
+				<7 0 &gpio0 27 0>,	/* INT  */
+				<8 0 &gpio0 28 0>,	/* RX   */
+				<9 0 &gpio0 29 0>,	/* TX   */
+				<10 0 &gpio0 30 0>,	/* SCL  */
+				<11 0 &gpio0 31 0>;	/* SDA  */
+							/* +5V */
+							/* GND */
+	};
+
+	mikrobus_2_header: mikrobus-connector-2 {
+		compatible = "mikro-bus";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map =	<0 0 &gpio0 25 0>,	/* AN  */
+				<1 0 &gpio0 12 0>,	/* RST */
+				<2 0 &gpio1 2 0>,	/* CS   */
+				<3 0 &gpio1 3 0>,	/* SCK  */
+				<4 0 &gpio1 4 0>,	/* MISO */
+				<5 0 &gpio1 5 0>,	/* MOSI */
+							/* +3.3V */
+							/* GND */
+				<6 0 &gpio1 6 0>,	/* PWM  */
+				<7 0 &gpio1 7 0>,	/* INT  */
+				<8 0 &gpio1 8 0>,	/* RX   */
+				<9 0 &gpio0 17 0>,	/* TX   */
+				<10 0 &gpio0 18 0>,	/* SCL  */
+				<11 0 &gpio0 19 0>;	/* SDA  */
+							/* +5V */
+							/* GND */
 	};
 
 	aliases {
@@ -186,6 +185,7 @@ zephyr_udc0: &usbd {
 &pll {
 	status = "okay";
 };
+
 &i2c {
 	status = "okay";
 	pinctrl-0 = <&i2c_default>;
@@ -218,10 +218,18 @@ mikrobus_1_i2c: &i2c {};
 
 mikrobus_1_spi: &spi {};
 
-mikrobus_1_uart: &uart2 {};
+mikrobus_1_uart: &uart3 {};
 
 mikrobus_2_i2c: &i2c2 {};
 
 mikrobus_2_spi: &spi2 {};
 
-mikrobus_2_uart: &uart3 {};
+mikrobus_2_uart: &uart2 {};
+
+mikrobus_i2c: &mikrobus_1_i2c {};
+
+mikrobus_spi: &mikrobus_1_spi {};
+
+mikrobus_serial: &mikrobus_1_uart {};
+
+mikrobus_header: &mikrobus_1_header {};


### PR DESCRIPTION
Added mikrobus_header, mikrobus_i2c, mikrobus_spi and mikrobus_serial node labels to da14695_dk_usb device tree board definition, allowing compatible shield boards to be used. Also fixed minor issues with pin assignment and header labelling.