### PR TITLE
x86: remove CONFIG_DISABLE_SSBD and CONFIG_ENABLE_EXTENDED_IBRS

### DIFF
--- a/arch/x86/Kconfig
+++ b/arch/x86/Kconfig
@@ -417,15 +417,6 @@ config X86_DISABLE_SSBD
 	  Even if enabled, will have no effect on CPUs that do not
 	  require this feature.
 
-config DISABLE_SSBD
-	bool "Disable Speculative Store Bypass [DEPRECATED]"
-	depends on USERSPACE
-	default y if !X86_NO_SPECTRE_V4
-	select X86_DISABLE_SSBD
-	select DEPRECATED
-	help
-	  Deprecated. Use CONFIG_X86_DISABLE_SSBD instead.
-
 config X86_ENABLE_EXTENDED_IBRS
 	bool "Extended IBRS"
 	depends on USERSPACE
@@ -434,15 +425,6 @@ config X86_ENABLE_EXTENDED_IBRS
 	  This option will enable the Extended Indirect Branch Restricted
 	  Speculation 'always on' feature. This mitigates Indirect Branch
 	  Control vulnerabilities (aka Spectre V2).
-
-config ENABLE_EXTENDED_IBRS
-	bool "Extended IBRS [DEPRECATED]"
-	depends on USERSPACE
-	default y if !X86_NO_SPECTRE_V2
-	select X86_ENABLE_EXTENDED_IBRS
-	select DEPRECATED
-	help
-	  Deprecated. Use CONFIG_X86_ENABLE_EXTENDED_IBRS instead.
 
 config X86_BOUNDS_CHECK_BYPASS_MITIGATION
 	bool

--- a/doc/releases/migration-guide-4.1.rst
+++ b/doc/releases/migration-guide-4.1.rst
@@ -124,3 +124,9 @@ Architectures
   * For the native_sim target :kconfig:option:`CONFIG_NATIVE_SIM_NATIVE_POSIX_COMPAT` has been
     switched to ``n`` by default, and this option has been deprecated. Ensure your code does not
     use the :kconfig:option:`CONFIG_BOARD_NATIVE_POSIX` option anymore (:github:`81232`).
+
+* x86
+
+  * Kconfigs ``CONFIG_DISABLE_SSBD`` and ``CONFIG_ENABLE_EXTENDED_IBRS`` have been deprecated
+    since v3.7. These were removed.  Use :kconfig:option:`CONFIG_X86_DISABLE_SSBD` and
+    :kconfig:option:`CONFIG_X86_ENABLE_EXTENDED_IBRS` instead.


### PR DESCRIPTION
These two kconfigs have been deprecated since v3.7. So remove them now.