### PR TITLE
Update index.rst

### DIFF
--- a/doc/develop/getting_started/index.rst
+++ b/doc/develop/getting_started/index.rst
@@ -208,7 +208,13 @@ Get Zephyr and install Python dependencies
 
 Next, clone Zephyr and its :ref:`modules <modules>` into a new :ref:`west
 <west>` workspace named :file:`zephyrproject`. You'll also install Zephyr's
-additional Python dependencies in a `Python virtual environment`_.
+additional Python dependencies in a `Python virtual environment`_. It's
+worth noting that the Zephyr source is not the same as the Zephyr SDK and
+they have different versions, which need to be compatible with each other.
+If you are following this guide, that's taken care of. But if you need a
+specific version of either in future, make sure the other one is compatible
+by checking against 
+https://github.com/zephyrproject-rtos/sdk-ng/wiki/Zephyr-SDK-Version-Compatibility-Matrix
 
 .. _Python virtual environment: https://docs.python.org/3/library/venv.html
 
@@ -390,6 +396,8 @@ Zephyr applications.
 For Linux, it also contains additional host tools, such as custom QEMU and OpenOCD builds
 that are used to emulate, flash and debug Zephyr applications.
 
+Note that the SDK is different from the Zephyr source and has separate version control.
+See the "Get Zephyr" step above for version compatibility implications.
 
 .. tabs::
 

--- a/doc/develop/getting_started/index.rst
+++ b/doc/develop/getting_started/index.rst
@@ -213,7 +213,7 @@ worth noting that the Zephyr source is not the same as the Zephyr SDK and
 they have different versions, which need to be compatible with each other.
 If you are following this guide, that's taken care of. But if you need a
 specific version of either in future, make sure the other one is compatible
-by checking against 
+by checking against
 https://github.com/zephyrproject-rtos/sdk-ng/wiki/Zephyr-SDK-Version-Compatibility-Matrix
 
 .. _Python virtual environment: https://docs.python.org/3/library/venv.html


### PR DESCRIPTION
Documentation: add text about SDK and main source being different

Improved clarity that there's a difference between Zephyr and Zephyr SDK, and the version compatibility requirement, after being invited to contribute at https://discord.com/channels/720317445772017664/720317445772017667/1307307941103140894

Signed-off-by: SimonMerrett <26767525+SimonMerrett@users.noreply.github.com>