### PR TITLE
doc: Add a link to the Build and Configuration Documentation

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -54,6 +54,20 @@ documentation for a specific version of Zephyr.
 	   <p>Explore samples and demos for various boards</p>
        </li>
        <li class="grid-item">
+	   <a href="build/index.html">
+               <span class="grid-icon fa fa-cubes"></span>
+	       <h2>Build and Configuration Systems</h2>
+	   </a>
+	   <p>Explore CMake, Kconfig, devicetrees and more</p>
+       </li>
+       <li class="grid-item">
+	   <a href="kernel/index.html">
+               <span class="grid-icon fa fa-microchip"></span>
+	       <h2>Kernel</h2>
+	   </a>
+	   <p>Learn about kernel services, driver models and more</p>
+       </li>
+       <li class="grid-item">
 	   <a href="hardware/index.html">
                <span class="grid-icon fa fa-sign-in"></span>
 	       <h2>Hardware Support</h2>


### PR DESCRIPTION
Build and Configuration Documentation already
exists, but there is no link to it in the main
documentation page. The same applies to kernel
documentation. Links are added in this commit.

Covers [Issue#81545](https://github.com/zephyrproject-rtos/zephyr/issues/81545)