### PR TITLE
ci: testplan: resolve board files when testing with targets

### DIFF
--- a/scripts/ci/test_plan.py
+++ b/scripts/ci/test_plan.py
@@ -125,6 +125,11 @@ class Filters:
         if not self.platforms:
             self.find_archs()
             self.find_boards()
+        else:
+            for file in self.modified_files:
+                if file.startswith(("boards/", "dts/")):
+                    self.resolved_files.append(file)
+
         self.find_excludes()
 
     def get_plan(self, options, integration=False, use_testsuite_root=True):


### PR DESCRIPTION
When using the -p option, changes to boards are irrelevant. This is true
in the clang workflow.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
