### PR TITLE
docs: kernel: iterable_section: add #include to linker example

### DIFF
--- a/doc/kernel/iterable_sections/index.rst
+++ b/doc/kernel/iterable_sections/index.rst
@@ -47,6 +47,7 @@ identifier, ``DATA_SECTIONS`` for RAM structures and ``SECTIONS`` for ROM ones.
 .. code-block:: c
 
    # iterables.ld
+   #include <zephyr/linker/iterable_sections.h>
    ITERABLE_SECTION_RAM(my_data, 4)
 
 The data can then be accessed using :c:macro:`STRUCT_SECTION_FOREACH`.


### PR DESCRIPTION
if you do not include #include <zephyr/linker/iterable_sections.h> 
you will get a build error