### PR TITLE
dts: xtensa: Fix gpio-reserved-ranges of esp32_wroom_32ue_n4

### DIFF
--- a/dts/xtensa/espressif/esp32/esp32_wroom_32ue_n16.dtsi
+++ b/dts/xtensa/espressif/esp32/esp32_wroom_32ue_n16.dtsi
@@ -13,7 +13,7 @@
 };
 
 &gpio1 {
-	gpio-reserved-ranges = <6 2>; // GPIO37-38 NC
+	gpio-reserved-ranges = <5 2>; // GPIO37-38 NC
 };
 
 /* 16MB flash */

--- a/dts/xtensa/espressif/esp32/esp32_wroom_32ue_n4.dtsi
+++ b/dts/xtensa/espressif/esp32/esp32_wroom_32ue_n4.dtsi
@@ -13,7 +13,7 @@
 };
 
 &gpio1 {
-	gpio-reserved-ranges = <6 2>; // GPIO37-38 NC
+	gpio-reserved-ranges = <5 2>; // GPIO37-38 NC
 };
 
 /* 4MB flash */

--- a/dts/xtensa/espressif/esp32/esp32_wroom_32ue_n8.dtsi
+++ b/dts/xtensa/espressif/esp32/esp32_wroom_32ue_n8.dtsi
@@ -13,7 +13,7 @@
 };
 
 &gpio1 {
-	gpio-reserved-ranges = <6 2>; // GPIO37-38 NC
+	gpio-reserved-ranges = <5 2>; // GPIO37-38 NC
 };
 
 /* 8MB flash */

--- a/dts/xtensa/espressif/esp32/esp32_wroom_da_n16.dtsi
+++ b/dts/xtensa/espressif/esp32/esp32_wroom_da_n16.dtsi
@@ -14,7 +14,7 @@
 };
 
 &gpio1 {
-	gpio-reserved-ranges = <6 2>; // GPIO37-38 NC
+	gpio-reserved-ranges = <5 2>; // GPIO37-38 NC
 };
 
 /* 16MB flash */

--- a/dts/xtensa/espressif/esp32/esp32_wroom_da_n4.dtsi
+++ b/dts/xtensa/espressif/esp32/esp32_wroom_da_n4.dtsi
@@ -14,7 +14,7 @@
 };
 
 &gpio1 {
-	gpio-reserved-ranges = <6 2>; // GPIO37-38 NC
+	gpio-reserved-ranges = <5 2>; // GPIO37-38 NC
 };
 
 /* 4MB flash */

--- a/dts/xtensa/espressif/esp32/esp32_wroom_da_n8.dtsi
+++ b/dts/xtensa/espressif/esp32/esp32_wroom_da_n8.dtsi
@@ -14,7 +14,7 @@
 };
 
 &gpio1 {
-	gpio-reserved-ranges = <6 2>; // GPIO37-38 NC
+	gpio-reserved-ranges = <5 2>; // GPIO37-38 NC
 };
 
 /* 8MB flash */

--- a/dts/xtensa/espressif/esp32/esp32_wrover_e_n16r2.dtsi
+++ b/dts/xtensa/espressif/esp32/esp32_wrover_e_n16r2.dtsi
@@ -13,7 +13,7 @@
 };
 
 &gpio1 {
-	gpio-reserved-ranges = <6 2>; // GPIO37-38 NC
+	gpio-reserved-ranges = <5 2>; // GPIO37-38 NC
 };
 
 /* 16MB flash */

--- a/dts/xtensa/espressif/esp32/esp32_wrover_e_n16r4.dtsi
+++ b/dts/xtensa/espressif/esp32/esp32_wrover_e_n16r4.dtsi
@@ -13,7 +13,7 @@
 };
 
 &gpio1 {
-	gpio-reserved-ranges = <6 2>; // GPIO37-38 NC
+	gpio-reserved-ranges = <5 2>; // GPIO37-38 NC
 };
 
 /* 16MB flash */

--- a/dts/xtensa/espressif/esp32/esp32_wrover_e_n16r8.dtsi
+++ b/dts/xtensa/espressif/esp32/esp32_wrover_e_n16r8.dtsi
@@ -13,7 +13,7 @@
 };
 
 &gpio1 {
-	gpio-reserved-ranges = <6 2>; // GPIO37-38 NC
+	gpio-reserved-ranges = <5 2>; // GPIO37-38 NC
 };
 
 /* 16MB flash */

--- a/dts/xtensa/espressif/esp32/esp32_wrover_e_n4r2.dtsi
+++ b/dts/xtensa/espressif/esp32/esp32_wrover_e_n4r2.dtsi
@@ -13,7 +13,7 @@
 };
 
 &gpio1 {
-	gpio-reserved-ranges = <6 1>, <7 1>; // GPIO37-38 NC
+	gpio-reserved-ranges = <5 2>; // GPIO37-38 NC
 };
 
 /* 4MB flash */

--- a/dts/xtensa/espressif/esp32/esp32_wrover_e_n4r8.dtsi
+++ b/dts/xtensa/espressif/esp32/esp32_wrover_e_n4r8.dtsi
@@ -13,7 +13,7 @@
 };
 
 &gpio1 {
-	gpio-reserved-ranges = <6 1>, <7 1>; // GPIO37-38 NC
+	gpio-reserved-ranges = <5 2>; // GPIO37-38 NC
 };
 
 /* 4MB flash */

--- a/dts/xtensa/espressif/esp32/esp32_wrover_e_n8r2.dtsi
+++ b/dts/xtensa/espressif/esp32/esp32_wrover_e_n8r2.dtsi
@@ -13,7 +13,7 @@
 };
 
 &gpio1 {
-	gpio-reserved-ranges = <6 2>; // GPIO37-38 NC
+	gpio-reserved-ranges = <5 2>; // GPIO37-38 NC
 };
 
 /* 8MB flash */

--- a/dts/xtensa/espressif/esp32/esp32_wrover_e_n8r8.dtsi
+++ b/dts/xtensa/espressif/esp32/esp32_wrover_e_n8r8.dtsi
@@ -14,7 +14,7 @@
 };
 
 &gpio1 {
-	gpio-reserved-ranges = <6 2>; // GPIO37-38 NC
+	gpio-reserved-ranges = <5 2>; // GPIO37-38 NC
 };
 
 /* 8MB flash */


### PR DESCRIPTION
The range of GPIO37-38 is <5 2>

Signed-off-by: Peth-typark <typark0422@pethcare.com>