### PR TITLE
doc: posix: option_groups: add section for POSIX_FILE_SYSTEM_R

### DIFF
--- a/doc/services/portability/posix/option_groups/index.rst
+++ b/doc/services/portability/posix/option_groups/index.rst
@@ -258,6 +258,19 @@ Enable this option group with :kconfig:option:`CONFIG_POSIX_FILE_SYSTEM`.
     unlink(), yes
     utime(),
 
+.. _posix_option_group_file_system_r:
+
+POSIX_FILE_SYSTEM_R
++++++++++++++++++++
+
+Enable this option with :kconfig:option:`CONFIG_POSIX_FILE_SYSTEM_R`.
+
+.. csv-table:: POSIX_FILE_SYSTEM_R
+   :header: API, Supported
+   :widths: 50,10
+
+    readdir_r(), yes
+
 .. _posix_option_group_mapped_files:
 
 POSIX_MAPPED_FILES


### PR DESCRIPTION
Add section for POSIX_FILE_SYSTEM_R which contains only `readdir_r()`.