### PR TITLE
doc: i2c: Update I2C specification link

### DIFF
--- a/drivers/i2c/i2c_bitbang.c
+++ b/drivers/i2c/i2c_bitbang.c
@@ -13,8 +13,8 @@
  * the Standard-mode and Fast-mode speeds and doesn't support optional
  * protocol feature like 10-bit addresses or clock stretching.
  *
- * Timings and protocol are based Rev. 6 of the I2C specification:
- * http://www.nxp.com/documents/user_manual/UM10204.pdf
+ * Timings and protocol are based Rev. 7 of the I2C specification:
+ * https://www.nxp.com/docs/en/user-guide/UM10204.pdf
  */
 
 #include <errno.h>


### PR DESCRIPTION
The prior link to the I2C specification was broken and no longer accessible. 
Updated the link to a valid and current URL.

This PR is based against #81269 