### PR TITLE
manifest: Pull rssi callback API fix for promiscuous mode

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -188,7 +188,7 @@ manifest:
       groups:
         - hal
     - name: hal_nordic
-      revision: 5c8d109371ebb740fbef1f440a3b59e488a36717
+      revision: pull/256/head
       path: modules/hal/nordic
       groups:
         - hal


### PR DESCRIPTION
This pulls in fix for rssi callback API when promiscuous mode is enabled. This fixes SHEL-3255