### PR TITLE
Use defaults in iCE40 binding

### DIFF
--- a/drivers/fpga/fpga_ice40.c
+++ b/drivers/fpga/fpga_ice40.c
@@ -550,17 +550,13 @@ static int fpga_ice40_init(const struct device *dev)
 
 #define FPGA_ICE40_BUS_FREQ(inst) DT_INST_PROP(inst, spi_max_frequency)
 
-#define FPGA_ICE40_CONFIG_DELAY_US(inst)                                                           \
-	DT_INST_PROP_OR(inst, config_delay_us, FPGA_ICE40_CONFIG_DELAY_US_MIN)
+#define FPGA_ICE40_CONFIG_DELAY_US(inst) DT_INST_PROP(inst, config_delay_us)
 
-#define FPGA_ICE40_CRESET_DELAY_US(inst)                                                           \
-	DT_INST_PROP_OR(inst, creset_delay_us, FPGA_ICE40_CRESET_DELAY_US_MIN)
+#define FPGA_ICE40_CRESET_DELAY_US(inst) DT_INST_PROP(inst, creset_delay_us)
 
-#define FPGA_ICE40_LEADING_CLOCKS(inst)                                                            \
-	DT_INST_PROP_OR(inst, leading_clocks, FPGA_ICE40_LEADING_CLOCKS_MIN)
+#define FPGA_ICE40_LEADING_CLOCKS(inst) DT_INST_PROP(inst, leading_clocks)
 
-#define FPGA_ICE40_TRAILING_CLOCKS(inst)                                                           \
-	DT_INST_PROP_OR(inst, trailing_clocks, FPGA_ICE40_TRAILING_CLOCKS_MIN)
+#define FPGA_ICE40_TRAILING_CLOCKS(inst) DT_INST_PROP(inst, trailing_clocks)
 
 #define FPGA_ICE40_MHZ_DELAY_COUNT(inst) DT_INST_PROP_OR(inst, mhz_delay_count, 0)
 

--- a/dts/bindings/fpga/lattice,ice40-fpga.yaml
+++ b/dts/bindings/fpga/lattice,ice40-fpga.yaml
@@ -69,25 +69,26 @@ properties:
       mhz-delay-count = <0>;
   creset-delay-us:
     type: int
+    default: 1
     description: |
       Delay (in microseconds) between asserting CRESET_B and releasing CRESET_B.
-      Example usage / default:
-      creset-delay-us = <1>;
+      The datasheet specifies a minimum of 200ns, therefore the default is set
+      to 1us.
   config-delay-us:
     type: int
+    default: 1200
     description: |
       Delay (in microseconds) after releasing CRESET_B to clear internal configuration memory.
-      Example usage / default:
-      config-delay-us = <1200>;
+      The datasheet specifies a minimum of 1200us, which is the default.
   leading-clocks:
     type: int
+    default: 8
     description: |
       Prior to sending the bitstream, issue this number of leading clocks with SPI_CS pulled high.
-      Example usage / default:
-      leading-clocks = <8>;
+      The datasheet specifies 8 dummy cycles, which is the default.
   trailing-clocks:
     type: int
+    default: 49
     description: |
       After sending the bitstream, issue this number of trailing clocks with SPI_CS pulled high.
-      Example usage / default:
-      trailing-clocks = <49>;
+      The datasheet specifies 49 dummy cycles, which is the default.


### PR DESCRIPTION
Replace the DT_INST_PROP_OR statements with defaults in the devicetree binding of the iCE40.