### PR TITLE
lib: shell: replace strtol with strtoul in cmd_load for address parsing

### DIFF
--- a/subsys/shell/modules/devmem_service.c
+++ b/subsys/shell/modules/devmem_service.c
@@ -247,8 +247,8 @@ static int cmd_load(const struct shell *sh, size_t argc, char **argv)
 		argc--;
 	}
 
-	bytes = (unsigned char *)strtol(argv[1], NULL, 0);
-	data = (uint32_t *)strtol(argv[1], NULL, 0);
+	bytes = (unsigned char *)strtoul(argv[1], NULL, 0);
+	data = (uint32_t *)strtoul(argv[1], NULL, 0);
 
 	set_bypass(sh, bypass_cb);
 	return 0;


### PR DESCRIPTION
Addresses in cmd_load() should always be unsigned. Previously, strtol() was used, which is limited to signed long values, causing issues with addresses >= 0x80000000. This commit replaces strtol() with strtoul(), ensuring proper handling of the full 32-bit address space.

Fixes #81343