### PR TITLE
drivers: fpga: fixup for renesas slg471X5

### DIFF
--- a/drivers/fpga/Kconfig.slg471x5
+++ b/drivers/fpga/Kconfig.slg471x5
@@ -5,6 +5,6 @@ config SLG471X5_FPGA
 	bool "Renesas SLG47105/SLG47115 GreenPAK Configurable Mixed-Signal IC"
 	default y
 	depends on DT_HAS_RENESAS_SLG47105_ENABLED || DT_HAS_RENESAS_SLG47115_ENABLED
-	select SPI
+	select I2C
 	help
 	  Enable Renesas SLG47105/SLG47115 driver support.

--- a/drivers/fpga/fpga_slg471x5.c
+++ b/drivers/fpga/fpga_slg471x5.c
@@ -71,9 +71,12 @@ static int fpga_slg471x5_verify(const struct device *dev, uint8_t *img, uint32_t
 {
 	const struct fpga_slg471x5_config *config = dev->config;
 	uint8_t buf[SLG471X5_NREG] = {0}, addr, len;
-	int i;
+	int i, ret;
 
-	i2c_read_dt(&config->bus, buf, SLG471X5_NREG);
+	ret = i2c_read_dt(&config->bus, buf, SLG471X5_NREG);
+	if (ret < 0) {
+		return ret;
+	}
 
 	for (i = 0; i < config->verify_list_len; i++) {
 		addr = config->verify_list[i].addr;


### PR DESCRIPTION
Correct Kconfig and evaluate return value of i2c read during verification.