### PR TITLE
cmake: Remove deprecated global CSTD property

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1039,14 +1039,6 @@ if(CONFIG_USERSPACE)
   set(PROCESS_GPERF ${ZEPHYR_BASE}/scripts/build/process_gperf.py)
 endif()
 
-get_property(GLOBAL_CSTD GLOBAL PROPERTY CSTD)
-if(DEFINED GLOBAL_CSTD)
-  message(DEPRECATION
-    "Global CSTD property is deprecated, see Kconfig.zephyr for C Standard options.")
-  set(CSTD ${GLOBAL_CSTD})
-  list(APPEND CMAKE_C_COMPILE_FEATURES ${compile_features_${CSTD}})
-endif()
-
 # @Intent: Obtain compiler specific flag for specifying the c standard
 zephyr_compile_options(
   $<$<COMPILE_LANGUAGE:C>:$<TARGET_PROPERTY:compiler,cstd>${CSTD}>

--- a/tests/subsys/bindesc/reading/testcase.yaml
+++ b/tests/subsys/bindesc/reading/testcase.yaml
@@ -10,14 +10,23 @@ tests:
       - native_posix
       - native_sim
   bindesc.read.c99:
-    extra_args: CSTD="c99"
+    extra_configs:
+      - CONFIG_STD_C99=y
   bindesc.read.c11:
-    extra_args: CSTD="c11"
+    extra_configs:
+      - CONFIG_STD_C11=y
   bindesc.read.c17:
-    extra_args: CSTD="c17"
+    extra_configs:
+      - CONFIG_STD_C17=y
   bindesc.read.gnu99:
-    extra_args: CSTD="gnu99"
+    extra_configs:
+      - CONFIG_STD_C99=y
+      - CONFIG_GNU_C_EXTENSIONS=y
   bindesc.read.gnu11:
-    extra_args: CSTD="gnu11"
+    extra_configs:
+      - CONFIG_STD_C11=y
+      - CONFIG_GNU_C_EXTENSIONS=y
   bindesc.read.gnu17:
-    extra_args: CSTD="gnu17"
+    extra_configs:
+      - CONFIG_STD_C17=y
+      - CONFIG_GNU_C_EXTENSIONS=y


### PR DESCRIPTION
Remove the global CSTD property as it has been deprecated for 2 releases.

Ref: #77069