### PR TITLE
tests: Thread-Metric: Filter properly native targets

### DIFF
--- a/tests/benchmarks/thread_metric/testcase.yaml
+++ b/tests/benchmarks/thread_metric/testcase.yaml
@@ -4,9 +4,9 @@ common:
     - benchmark
   # Native platforms excluded as timer interrupts may not be detected
   # qemu_nios2 excluded as it is slow
+  arch_exclude:
+    - posix
   platform_exclude:
-    - native_posix
-    - native_sim
     - qemu_nios2
   integration_platforms:
     - qemu_x86


### PR DESCRIPTION
There is more native targets than native_sim and native_posix. Let's exclude them all by architecture.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/81590