### PR TITLE
lib: os: poweroff: Extend power off functionality

### DIFF
--- a/include/zephyr/sys/poweroff.h
+++ b/include/zephyr/sys/poweroff.h
@@ -43,6 +43,19 @@ FUNC_NORETURN void z_sys_poweroff(void);
  */
 FUNC_NORETURN void sys_poweroff(void);
 
+/**
+ * @brief Prepare the power off.
+ *
+ * Platform specific code which can be executed before interrupts are locked and
+ * power off function is called. Called when @kconfig{CONFIG_POWEROFF_PREPARE} is
+ * enabled.
+ *
+ * @retval 0 if preparation was successful.
+ * @retval negative if error occurred. Note that @ref sys_poweroff cannot return so error
+ * does not stop powering off.
+ */
+int z_sys_poweroff_prepare(void);
+
 /** @} */
 
 #ifdef __cplusplus

--- a/include/zephyr/sys/poweroff.h
+++ b/include/zephyr/sys/poweroff.h
@@ -29,6 +29,15 @@ extern "C" {
  */
 FUNC_NORETURN void z_sys_poweroff(void);
 
+/**
+ * @brief System power off ready hook.
+ *
+ * This function needs to be implemented in the platform code. It must put the core
+ * in the state which may lead to the power off of the system but it can return
+ * if powering off is interrupted.
+ */
+void z_sys_poweroff_ready(void);
+
 /** @endcond */
 
 /**
@@ -44,6 +53,19 @@ FUNC_NORETURN void z_sys_poweroff(void);
 FUNC_NORETURN void sys_poweroff(void);
 
 /**
+ * @brief Put core in "ready for power off" state.
+ *
+ * Function can be used in multi-core platforms to put a core into a state which
+ * may result in power off (if all other cores goes to the power off state) but
+ * it may also return if system is waken up before power off is reached.
+ *
+ * @retval 0 if the core was waken up from power off ready state.
+ * @retval negative if @ref z_sys_poweroff_prepare or @ref z_sys_poweroff_unprepare
+ * returned error.
+ */
+int sys_poweroff_ready(void);
+
+/**
  * @brief Prepare the power off.
  *
  * Platform specific code which can be executed before interrupts are locked and
@@ -52,9 +74,20 @@ FUNC_NORETURN void sys_poweroff(void);
  *
  * @retval 0 if preparation was successful.
  * @retval negative if error occurred. Note that @ref sys_poweroff cannot return so error
- * does not stop powering off.
+ * can only interrupt powering off when @ref sys_poweroff_ready is used.
  */
 int z_sys_poweroff_prepare(void);
+
+/**
+ * @brief Revert preparation to the power off.
+ *
+ * Platform specific code which can be executed if the core returns from @ref z_sys_poweroff_ready.
+ * Called by @ref sys_poweroff_ready when @kconfig{CONFIG_POWEROFF_PREPARE} is enabled.
+ *
+ * @retval 0 if reverting was successful.
+ * @retval negative if error occurred.
+ */
+int z_sys_poweroff_unprepare(void);
 
 /** @} */
 

--- a/lib/os/Kconfig
+++ b/lib/os/Kconfig
@@ -124,6 +124,12 @@ config POWEROFF
 	help
 	  Enable support for system power off.
 
+config POWEROFF_PREPARE
+	bool "Prepare before the power off"
+	depends on POWEROFF
+	help
+	  When enabled platform code can be executed before the power off.
+
 rsource "Kconfig.cbprintf"
 rsource "zvfs/Kconfig"
 

--- a/lib/os/poweroff.c
+++ b/lib/os/poweroff.c
@@ -16,3 +16,31 @@ void sys_poweroff(void)
 
 	z_sys_poweroff();
 }
+
+int sys_poweroff_ready(void)
+{
+	uint32_t key;
+
+	if (IS_ENABLED(CONFIG_POWEROFF_PREPARE)) {
+		int err = z_sys_poweroff_prepare();
+
+		if (err < 0) {
+			return err;
+		}
+	}
+
+	key = irq_lock();
+
+	z_sys_poweroff_ready();
+	irq_unlock(key);
+
+	if (IS_ENABLED(CONFIG_POWEROFF_PREPARE)) {
+		int err = z_sys_poweroff_unprepare();
+
+		if (err < 0) {
+			return err;
+		}
+	}
+
+	return 0;
+}

--- a/lib/os/poweroff.c
+++ b/lib/os/poweroff.c
@@ -8,6 +8,10 @@
 
 void sys_poweroff(void)
 {
+	if (IS_ENABLED(CONFIG_POWEROFF_PREPARE)) {
+		(void)z_sys_poweroff_prepare();
+	}
+
 	(void)irq_lock();
 
 	z_sys_poweroff();


### PR DESCRIPTION
Extend poweroff functionality:
- Add option to call prepare function (`z_sys_poweroff_prepare()`) before interrupts are locked.
- Add `sys_poweroff_ready()` which can be used on multi-core targets. Compared to `sys_poweroff()` it may return. `sys_poweroff_ready()` is calling `z_sys_poweroff_unprepare()` is `z_sys_poweroff_ready()` returns.