### PR TITLE
drivers: display: gc9x01x: fix correct mipi buffer size

### DIFF
--- a/drivers/display/display_gc9x01x.c
+++ b/drivers/display/display_gc9x01x.c
@@ -530,7 +530,7 @@ static int gc9x01x_write(const struct device *dev, const uint16_t x, const uint1
 		write_h = 1U;
 		nbr_of_writes = desc->height;
 		mipi_desc.height = 1;
-		mipi_desc.buf_size = desc->pitch * data->bytes_per_pixel;
+		mipi_desc.buf_size = desc->width * data->bytes_per_pixel;
 	} else {
 		write_h = desc->height;
 		mipi_desc.height = desc->height;


### PR DESCRIPTION
Since the mipi api only supports buffers where pitch is equal to width the driver spilts buffers with width smaller than pitch into multiple mipi transmissions. In that case the mipi buffer size was not set correctly.

fixes https://github.com/zephyrproject-rtos/zephyr/issues/81572