### PR TITLE
tests: cpp: remove obsolete target

### DIFF
--- a/tests/lib/cpp/cxx/testcase.yaml
+++ b/tests/lib/cpp/cxx/testcase.yaml
@@ -41,7 +41,6 @@ tests:
       - nrf54l20pdk/nrf54l20/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
       - nrf54h20dk/nrf54h20/cpurad
-      - nrf54h20dk@0.8.0/nrf54h20/cpuapp
       - nrf9280pdk/nrf9280/cpuapp
       - nrf9280pdk/nrf9280/cpurad
     filter: not CONFIG_HAS_RENESAS_RA_FSP


### PR DESCRIPTION
nrf54h20dk@0.8.0/nrf54h20/cpuapp was dropped.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
