### PR TITLE
net: if: Do not report error if we are already in promisc mode

### DIFF
--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -5667,7 +5667,7 @@ int net_if_set_promisc(struct net_if *iface)
 	net_if_lock(iface);
 
 	ret = promisc_mode_set(iface, true);
-	if (ret < 0) {
+	if (ret < 0 && ret != -EALREADY) {
 		goto out;
 	}
 


### PR DESCRIPTION
If we are already in promiscuous mode, then do not report error in that case.

Fixes #81605