### PR TITLE
doc: doxygen: improve formatting for kconfig alias

### DIFF
--- a/doc/zephyr.doxyfile.in
+++ b/doc/zephyr.doxyfile.in
@@ -279,7 +279,7 @@ TAB_SIZE               = 8
 # with the commands \{ and \} for these it is advised to use the version @{ and
 # @} or use a double escape (\\{ and \\})
 
-ALIASES                = "kconfig{1}=\verbatim \1 \endverbatim" \
+ALIASES                = "kconfig{1}=\c \1" \
                          "req{1}=\ref ZEPH_\1 \"ZEPH-\1\"" \
                          "satisfy{1}=\xrefitem satisfy \"Satisfies requirement\" \"Requirement Implementation\" \1" \
                          "verify{1}=\xrefitem verify \"Verifies requirement\" \"Requirement Verification\" \1" \


### PR DESCRIPTION
\verbatim is not giving the right output as we need an inline literal. Switch to \c instead.

Fixes #81595.