### PR TITLE
github: Update security page for v4.0.0 release

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -8,9 +8,10 @@ updates:
   - The most recent release, and the release prior to that.
   - Active LTS releases.
 
-At this time, with the latest release of v3.6, the supported
+At this time, with the latest release of v4.0, the supported
 versions are:
 
+  - v4.0: Current release
   - v3.7: Current LTS
   - v3.6: Prior release
   - v2.7: Prior LTS


### PR DESCRIPTION
Updates the GitHub security page with the current supported versions after the v4.0.0 release.