### PR TITLE
doc: notes for sdk installation in shared environments

### DIFF
--- a/doc/develop/getting_started/index.rst
+++ b/doc/develop/getting_started/index.rst
@@ -393,6 +393,8 @@ chosen. You'll also install Zephyr's additional Python dependencies in a
 
             west packages pip --install
 
+.. _gs_install_zephyr_sdk:
+
 Install the Zephyr SDK
 **********************
 

--- a/doc/develop/toolchains/zephyr_sdk.rst
+++ b/doc/develop/toolchains/zephyr_sdk.rst
@@ -300,7 +300,7 @@ Depending on the topology of build infrastructure, it may be preferable to simpl
 the ``/opt/zephyr/sdk/$SDK_VERSION`` directory to other build machines. Alternatively, use
 ``/opt/zephyr/sdk/$SDK_VERSION`` to create packages using the package manager of choice.
 
-.. _gs_package_managers:
+.. _toolchain_zephyr_sdk_package_manager:
 
 Guidelines for Package Managers
 *******************************


### PR DESCRIPTION
* doc: getting_started: add anchor for installing the zephyr sdk
* doc: zephyr_sdk: install notes for sdk, venv in shared env
* doc: zephyr_sdk: notes for sdk package managers

[Doc Preview](https://builds.zephyrproject.io/zephyr/pr/81615/docs/develop/toolchains/zephyr_sdk.html)

