### PR TITLE
ci: testplan: do not deal with arch changes

### DIFF
--- a/scripts/ci/test_plan.py
+++ b/scripts/ci/test_plan.py
@@ -123,7 +123,9 @@ class Filters:
         self.find_tags()
         self.find_tests()
         if not self.platforms:
-            self.find_archs()
+            # disable for now, this is generating lots of churn when changing
+            # architectures that is otherwise covered elsewhere.
+            #self.find_archs()
             self.find_boards()
         else:
             for file in self.modified_files:


### PR DESCRIPTION
This is generating lots of duplication and unnecessary builds when
multiple arches are being changed. Let's stick to basic coverage which
should be enough for PRs.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
