### PR TITLE
Add missing properties for SPI node on Renesas RA8 devices

### DIFF
--- a/boards/renesas/ek_ra8m1/ek_ra8m1.dts
+++ b/boards/renesas/ek_ra8m1/ek_ra8m1.dts
@@ -246,6 +246,8 @@ mikrobus_serial: &uart3 {};
 
 &spi1 {
 	pinctrl-0 = <&spi1_default>;
+	pinctrl-names = "default";
+	status = "okay";
 };
 
 &pwm7 {

--- a/drivers/spi/spi_b_renesas_ra8.c
+++ b/drivers/spi/spi_b_renesas_ra8.c
@@ -92,7 +92,9 @@ static int ra_spi_b_configure(const struct device *dev, const struct spi_config 
 		return 0;
 	}
 
-	fsp_err = R_SPI_B_Close(&data->spi);
+	if (data->spi.open != 0) {
+		R_SPI_B_Close(&data->spi);
+	}
 
 	if ((config->operation & SPI_FRAME_FORMAT_TI) == SPI_FRAME_FORMAT_TI) {
 		return -ENOTSUP;


### PR DESCRIPTION
- Add missing `pinctrl-names` and `status` properties for the spi1 node in ek_ra8m1.dts to be able to test spi_loopback on ek_ra8m1
- Add condition in source driver to check for close before opening to prevent invalid pointer access