### PR TITLE
Fix warning of `size_t` formatting with `%.*s`

### DIFF
--- a/samples/subsys/ipc/openamp_rsc_table/src/main_remote.c
+++ b/samples/subsys/ipc/openamp_rsc_table/src/main_remote.c
@@ -299,7 +299,7 @@ void app_rpmsg_tty(void *arg1, void *arg2, void *arg3)
 		k_sem_take(&data_tty_sem,  K_FOREVER);
 		if (tty_msg.len) {
 			LOG_INF("[Linux TTY] incoming msg: %.*s",
-				tty_msg.len, (char *)tty_msg.data);
+				(int)tty_msg.len, (char *)tty_msg.data);
 			snprintf(tx_buff, 13, "TTY 0x%04x: ", tty_ept.addr);
 			memcpy(&tx_buff[12], tty_msg.data, tty_msg.len);
 			rpmsg_send(&tty_ept, tx_buff, tty_msg.len + 12);

--- a/subsys/net/lib/dns/resolve.c
+++ b/subsys/net/lib/dns/resolve.c
@@ -424,7 +424,7 @@ static int dns_resolve_init_locked(struct dns_resolve_context *ctx,
 			if (!ret) {
 				if (servers[i] != NULL && servers[i][0] != '\0') {
 					NET_DBG("Invalid server address %.*s",
-						server_len, servers[i]);
+						(int)server_len, servers[i]);
 				}
 
 				continue;
@@ -432,7 +432,7 @@ static int dns_resolve_init_locked(struct dns_resolve_context *ctx,
 
 			dns_postprocess_server(ctx, idx);
 
-			NET_DBG("[%d] %.*s%s%s%s%s", i, server_len, servers[i],
+			NET_DBG("[%d] %.*s%s%s%s%s", i, (int)server_len, servers[i],
 				IS_ENABLED(CONFIG_MDNS_RESOLVER) ?
 				(ctx->servers[i].is_mdns ? " mDNS" : "") : "",
 				IS_ENABLED(CONFIG_LLMNR_RESOLVER) ?

--- a/subsys/net/lib/wifi_credentials/wifi_credentials_shell.c
+++ b/subsys/net/lib/wifi_credentials/wifi_credentials_shell.c
@@ -34,20 +34,20 @@ static void print_network_info(void *cb_arg, const char *ssid, size_t ssid_len)
 		shell_error(sh,
 			    "An error occurred when trying to load credentials for network \"%.*s\""
 			    ". err: %d",
-			    ssid_len, ssid, ret);
+			    (int)ssid_len, ssid, ret);
 		return;
 	}
 
 	shell_fprintf(sh, SHELL_VT100_COLOR_DEFAULT,
-		      "  network ssid: \"%.*s\", ssid_len: %d, type: %s", ssid_len, ssid, ssid_len,
-		      wifi_security_txt(creds.header.type));
+		      "  network ssid: \"%.*s\", ssid_len: %d, type: %s", (int)ssid_len, ssid,
+		      ssid_len, wifi_security_txt(creds.header.type));
 
 	if (creds.header.type == WIFI_SECURITY_TYPE_PSK ||
 	    creds.header.type == WIFI_SECURITY_TYPE_PSK_SHA256 ||
 	    creds.header.type == WIFI_SECURITY_TYPE_SAE ||
 	    creds.header.type == WIFI_SECURITY_TYPE_WPA_PSK) {
 		shell_fprintf(sh, SHELL_VT100_COLOR_DEFAULT,
-			      ", password: \"%.*s\", password_len: %d", creds.password_len,
+			      ", password: \"%.*s\", password_len: %d", (int)creds.password_len,
 			      creds.password, creds.password_len);
 	}
 

--- a/tests/subsys/mgmt/mcumgr/zcbor_bulk/src/main.c
+++ b/tests/subsys/mgmt/mcumgr/zcbor_bulk/src/main.c
@@ -71,7 +71,7 @@ ZTEST(zcbor_bulk, test_correct)
 	zassert_equal(sizeof("world") - 1, world.len, "Expected length %d",
 		sizeof("world") - 1);
 	zassert_equal(0, memcmp(world.value, "world", world.len),
-		"Expected \"world\", got %.*s", world.len, world.value);
+		"Expected \"world\", got %.*s", (int)world.len, world.value);
 	zassert_true(bool_val, "Expected bool val == true");
 }
 
@@ -112,7 +112,7 @@ ZTEST(zcbor_bulk, test_correct_out_of_order)
 	zassert_equal(sizeof("world") - 1, world.len, "Expected length %d",
 		sizeof("world") - 1);
 	zassert_equal(0, memcmp(world.value, "world", world.len),
-		"Expected \"world\", got %.*s", world.len, world.value);
+		"Expected \"world\", got %.*s", (int)world.len, world.value);
 	zassert_true(bool_val, "Expected bool val == true");
 }
 
@@ -222,7 +222,7 @@ ZTEST(zcbor_bulk, test_bad_type_2)
 	zassert_equal(sizeof("world") - 1, world.len, "Expected length %d",
 		sizeof("world") - 1);
 	zassert_equal(0, memcmp(world.value, "world", world.len),
-		"Expected \"world\", got %.*s", world.len, world.value);
+		"Expected \"world\", got %.*s", (int)world.len, world.value);
 	zassert_false(bool_val, "Expected bool val unmodified");
 }
 
@@ -298,7 +298,7 @@ ZTEST(zcbor_bulk, test_duplicate)
 	zassert_equal(sizeof("world") - 1, world.len, "Expected length %d",
 		sizeof("world") - 1);
 	zassert_equal(0, memcmp(world.value, "world", world.len),
-		"Expected \"world\", got %.*s", world.len, world.value);
+		"Expected \"world\", got %.*s", (int)world.len, world.value);
 	zassert_false(bool_val, "Expected bool val unmodified");
 }
 
@@ -377,7 +377,7 @@ ZTEST(zcbor_bulk, test_map_in_map_correct)
 	zassert_equal(sizeof("world") - 1, world.len, "Expected length %d",
 		sizeof("world") - 1);
 	zassert_equal(0, memcmp(world.value, "world", world.len),
-		"Expected \"world\", got %.*s", world.len, world.value);
+		"Expected \"world\", got %.*s", (int)world.len, world.value);
 	zassert_true(bool_val, "Expected bool_val == true");
 
 	/* Map within map */


### PR DESCRIPTION
On 64-bit platforms, the actual type of `size_t` is `long unsigned int`, while `%.*s` expects an argument of type `int`. This mismatch causes build warnings, which are treated as errors by the CI, resulting in PRs targeting 64-bit boards failing.

This PR resolves these warnings by explicitly casting `size_t` to `int` where necessary.

The issue can be reproduced on 64-bit boards such as `rpi_4b` with the following command:

```
$ west build -s samples/posix/gettimeofday -p -b rpi_4b

[...]

[170/214] Building C object zephyr/subsys/net/lib/dns/CMakeFiles/subsys__net__lib__dns.dir/resolve.c.obj
In file included from [...]/zephyr/include/zephyr/logging/log.h:11,
                 from [...]/zephyr/subsys/net/lib/dns/resolve.c:14:
[...]/zephyr/subsys/net/lib/dns/resolve.c: In function 'dns_resolve_init_locked':
[...]/zephyr/include/zephyr/net/net_core.h:56:35: warning: field precision specifier '.*' expects argument of type 'int', but argument 3 has type 'size_t' {aka 'long unsigned int'} [-Wformat=]
   56 | #define NET_DBG(fmt, ...) LOG_DBG("(%p): " fmt, k_current_get(),        \
      |                                   ^~~~~~~~
[...]/zephyr/include/zephyr/logging/log_core.h:315:50: note: in definition of macro 'Z_LOG2'
  315 |                         z_log_printf_arg_checker(__VA_ARGS__);                                     \
      |                                                  ^~~~~~~~~~~
/Users/XiNGRZ/Projects/zephyrproject/zephyr/include/zephyr/logging/log.h:75:25: note: in expansion of macro 'Z_LOG'
   75 | #define LOG_DBG(...)    Z_LOG(LOG_LEVEL_DBG, __VA_ARGS__)
      |                         ^~~~~
[...]/zephyr/include/zephyr/net/net_core.h:56:27: note: in expansion of macro 'LOG_DBG'
   56 | #define NET_DBG(fmt, ...) LOG_DBG("(%p): " fmt, k_current_get(),        \
      |                           ^~~~~~~
[...]/zephyr/subsys/net/lib/dns/resolve.c:426:41: note: in expansion of macro 'NET_DBG'
  426 |                                         NET_DBG("Invalid server address %.*s",
      |                                         ^~~~~~~
[...]/zephyr/include/zephyr/net/net_core.h:56:35: warning: field precision specifier '.*' expects argument of type 'int', but argument 4 has type 'size_t' {aka 'long unsigned int'} [-Wformat=]
   56 | #define NET_DBG(fmt, ...) LOG_DBG("(%p): " fmt, k_current_get(),        \
      |                                   ^~~~~~~~
[...]/zephyr/include/zephyr/logging/log_core.h:315:50: note: in definition of macro 'Z_LOG2'
  315 |                         z_log_printf_arg_checker(__VA_ARGS__);                                     \
      |                                                  ^~~~~~~~~~~
[...]/zephyr/include/zephyr/logging/log.h:75:25: note: in expansion of macro 'Z_LOG'
   75 | #define LOG_DBG(...)    Z_LOG(LOG_LEVEL_DBG, __VA_ARGS__)
      |                         ^~~~~
[...]/zephyr/include/zephyr/net/net_core.h:56:27: note: in expansion of macro 'LOG_DBG'
   56 | #define NET_DBG(fmt, ...) LOG_DBG("(%p): " fmt, k_current_get(),        \
      |                           ^~~~~~~
[...]/zephyr/subsys/net/lib/dns/resolve.c:435:25: note: in expansion of macro 'NET_DBG'
  435 |                         NET_DBG("[%d] %.*s%s%s%s%s", i, server_len, servers[i],
      |                         ^~~~~~~
```