### PR TITLE
subsystem: bluetooth: Fix uninitialized variable

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_filter.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_filter.c
@@ -1164,7 +1164,7 @@ static void rpa_adv_refresh(struct ll_adv_set *adv)
 	uint8_t pri_idx;
 
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
-	uint8_t sec_idx;
+	uint8_t sec_idx = UINT8_MAX;
 #endif /* CONFIG_BT_CTLR_ADV_EXT */
 
 	if (adv->own_addr_type != BT_HCI_OWN_ADDR_RPA_OR_PUBLIC &&


### PR DESCRIPTION
Fix uninitialized sec_idx variables scanned by Coverity.

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/74718