### PR TITLE
tests: net: socket: tcp: Exclude nrf5340dk/nrf5340/cpuapp/ns

### DIFF
--- a/tests/net/socket/tcp/testcase.yaml
+++ b/tests/net/socket/tcp/testcase.yaml
@@ -1,6 +1,7 @@
 common:
   depends_on: netif
   min_ram: 32
+  min_flash: 194
   tags:
     - net
     - socket


### PR DESCRIPTION
Do not build for nrf5340dk/nrf5340/cpuapp/ns as it does not have enough flash for the application.

Fixes #81608