### PR TITLE
arch: riscv: reg: include required header

### DIFF
--- a/include/zephyr/arch/riscv/reg.h
+++ b/include/zephyr/arch/riscv/reg.h
@@ -7,6 +7,8 @@
 #ifndef ZEPHYR_INCLUDE_ZEPHYR_ARCH_RISCV_REG_H_
 #define ZEPHYR_INCLUDE_ZEPHYR_ARCH_RISCV_REG_H_
 
+#include <zephyr/sys/util.h>
+
 #define reg_read(reg)                                                                              \
 	({                                                                                         \
 		register unsigned long __rv;                                                       \


### PR DESCRIPTION
Include `zephyr/sys/util.h` for the `STRINGIFY()` macro.

Fixes #81647