### PR TITLE
Bluetooth: Controller & nordic HW models: Support MDK 8.68

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
@@ -1724,11 +1724,15 @@ uint32_t radio_tmr_start_get(void)
 void radio_tmr_stop(void)
 {
 	nrf_timer_task_trigger(EVENT_TIMER, NRF_TIMER_TASK_STOP);
+#if defined(TIMER_TASKS_SHUTDOWN_TASKS_SHUTDOWN_Msk)
 	nrf_timer_task_trigger(EVENT_TIMER, NRF_TIMER_TASK_SHUTDOWN);
+#endif
 
 #if !defined(CONFIG_BT_CTLR_TIFS_HW)
 	nrf_timer_task_trigger(SW_SWITCH_TIMER, NRF_TIMER_TASK_STOP);
+#if defined(TIMER_TASKS_SHUTDOWN_TASKS_SHUTDOWN_Msk)
 	nrf_timer_task_trigger(SW_SWITCH_TIMER, NRF_TIMER_TASK_SHUTDOWN);
+#endif
 #endif /* !CONFIG_BT_CTLR_TIFS_HW */
 
 #if defined(CONFIG_SOC_COMPATIBLE_NRF54LX)

--- a/west.yml
+++ b/west.yml
@@ -300,7 +300,7 @@ manifest:
       groups:
         - tools
     - name: nrf_hw_models
-      revision: aeef3db9fa9e4b9d12b3bbec44f9cedc8fcb7d9c
+      revision: 42737c8ec8485987c7c9b0262b136de623e1ded2
       path: modules/bsim_hw_models/nrf_hw_models
     - name: open-amp
       revision: b735edbc739ad59156eb55bb8ce2583d74537719


### PR DESCRIPTION
These 2 commits avoid build issues with the latest nrfx HAL & its MDK:

TASK_SHUTDOWN was deprecated in newer SOCs and now removed in MDK 8.68 (nrfx 3.9.0)
(Note a SHUTDOWN should be equivalent to a TASK_STOP + TASK_CLEAR in new devices.)

& 

    manifest: Update nRF hw models to latest
    
    Update the HW models module to:
    42737c8ec8485987c7c9b0262b136de623e1ded2
    
    Including the following:
    42737c8 TIMER: Support devices without TASK_SHUTDOWN nrfx3.9 MDK 8.68
    5fe6873 54 UARTE: Add frametimeout functionality
    dc086d7 UARTE: Add basic 54 support
    b046745 UARTE: Support better not having UART functionality
    1c5f58c README: Mention the nRF54L15 models cover the L10 and L05
    597c7d0 TEMP: Also build hal replacement for 54 and define NRF_TEMP_NS/S
    fb2ca83 Makefile: Let's build libraries (specially HAL) as pic
    200a1e3 Makefiles: move some common options to common snippet
    
