### PR TITLE
bluetooth: buf: Add a callback for freed buffer in rx pool 

### DIFF
--- a/include/zephyr/bluetooth/buf.h
+++ b/include/zephyr/bluetooth/buf.h
@@ -138,6 +138,27 @@ BUILD_ASSERT(BT_BUF_ACL_RX_COUNT <= BT_BUF_ACL_RX_COUNT_MAX,
  */
 struct net_buf *bt_buf_get_rx(enum bt_buf_type type, k_timeout_t timeout);
 
+/** A callback to notify about freed buffer in the incoming data pool.
+ *
+ * This callback is called when a buffer of a given type is freed and can be requested through the
+ * @ref bt_buf_get_rx function. However, this callback is called from the context of the buffer
+ * freeing operation and must not attempt to allocate a new buffer from the same pool.
+ *
+ * @warning When this callback is called, the scheduler is locked and the callee must not perform
+ * any action that makes the current thread unready. This callback must only be used for very
+ * short non-blocking operation (e.g. submitting a work item).
+ *
+ * @param type_mask A bit mask of buffer types that have been freed.
+ */
+typedef void (*bt_buf_rx_freed_cb_t)(enum bt_buf_type type_mask);
+
+/** Set the callback to notify about freed buffer in the incoming data pool.
+ *
+ * @param cb Callback to notify about freed buffer in the incoming data pool. If NULL, the callback
+ *           is disabled.
+ */
+void bt_buf_rx_freed_cb_set(bt_buf_rx_freed_cb_t cb);
+
 /** Allocate a buffer for outgoing data
  *
  *  This will set the buffer type so bt_buf_set_type() does not need to

--- a/include/zephyr/bluetooth/buf.h
+++ b/include/zephyr/bluetooth/buf.h
@@ -28,22 +28,22 @@
 extern "C" {
 #endif
 
-/** Possible types of buffers passed around the Bluetooth stack */
+/** Possible types of buffers passed around the Bluetooth stack in a form of bitmask. */
 enum bt_buf_type {
 	/** HCI command */
-	BT_BUF_CMD,
+	BT_BUF_CMD = BIT(0),
 	/** HCI event */
-	BT_BUF_EVT,
+	BT_BUF_EVT = BIT(1),
 	/** Outgoing ACL data */
-	BT_BUF_ACL_OUT,
+	BT_BUF_ACL_OUT = BIT(2),
 	/** Incoming ACL data */
-	BT_BUF_ACL_IN,
+	BT_BUF_ACL_IN = BIT(3),
 	/** Outgoing ISO data */
-	BT_BUF_ISO_OUT,
+	BT_BUF_ISO_OUT = BIT(4),
 	/** Incoming ISO data */
-	BT_BUF_ISO_IN,
+	BT_BUF_ISO_IN = BIT(5),
 	/** H:4 data */
-	BT_BUF_H4,
+	BT_BUF_H4 = BIT(6),
 };
 
 /** @brief This is a base type for bt_buf user data. */

--- a/subsys/bluetooth/host/iso_internal.h
+++ b/subsys/bluetooth/host/iso_internal.h
@@ -87,6 +87,16 @@ void hci_iso(struct net_buf *buf);
 /* Allocates RX buffer */
 struct net_buf *bt_iso_get_rx(k_timeout_t timeout);
 
+/** A callback used to notify about freed buffer in the iso rx pool. */
+typedef void (*bt_iso_buf_rx_freed_cb_t)(void);
+
+/** Set a callback to notify about freed buffer in the iso rx pool.
+ *
+ * @param cb Callback to notify about freed buffer in the iso rx pool. If NULL, the callback is
+ *           disabled.
+ */
+void bt_iso_buf_rx_freed_cb_set(bt_iso_buf_rx_freed_cb_t cb);
+
 /* Process CIS Established event */
 void hci_le_cis_established(struct net_buf *buf);
 

--- a/tests/bluetooth/buf/CMakeLists.txt
+++ b/tests/bluetooth/buf/CMakeLists.txt
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(buf)
+
+target_sources(app PRIVATE src/main.c)

--- a/tests/bluetooth/buf/prj.conf
+++ b/tests/bluetooth/buf/prj.conf
@@ -1,0 +1,10 @@
+CONFIG_TEST=y
+CONFIG_ZTEST=y
+
+CONFIG_BT=y
+CONFIG_BT_CTLR=n
+CONFIG_BT_H4=n
+
+# Needed to enable and test the iso rx pool
+CONFIG_BT_OBSERVER=y
+CONFIG_BT_ISO_SYNC_RECEIVER=y

--- a/tests/bluetooth/buf/src/main.c
+++ b/tests/bluetooth/buf/src/main.c
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+
+#include <errno.h>
+#include <zephyr/tc_util.h>
+#include <zephyr/ztest.h>
+
+#include <zephyr/bluetooth/hci.h>
+#include <zephyr/bluetooth/buf.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/drivers/bluetooth.h>
+#include <zephyr/sys/byteorder.h>
+
+static enum bt_buf_type freed_buf_type;
+static K_SEM_DEFINE(rx_sem, 0, 1);
+
+void bt_buf_rx_freed_cb(enum bt_buf_type type)
+{
+	freed_buf_type = type;
+	k_sem_give(&rx_sem);
+}
+
+ZTEST_SUITE(test_buf_data_api, NULL, NULL, NULL, NULL, NULL);
+
+ZTEST(test_buf_data_api, test_buf_freed_cb)
+{
+	struct net_buf *buf;
+	int err;
+
+	bt_buf_rx_freed_cb_set(bt_buf_rx_freed_cb);
+
+	/* Test that the callback is called for the BT_BUF_EVT type */
+	buf = bt_buf_get_rx(BT_BUF_EVT, K_NO_WAIT);
+	zassert_not_null(buf, "Failed to get event buffer");
+
+	net_buf_unref(buf);
+	/* The freed buf cb is called from net_buf_unref, therefore the semaphore should
+	 * already by given.
+	 */
+	err = k_sem_take(&rx_sem, K_NO_WAIT);
+	zassert_equal(err, 0, "Timeout while waiting for event buffer to be freed");
+	zassert_equal(BT_BUF_EVT, BT_BUF_EVT & freed_buf_type, "Event buffer wasn't freed");
+
+	/* Test that the callback is called for the BT_BUF_ACL_IN type */
+	buf = bt_buf_get_rx(BT_BUF_ACL_IN, K_NO_WAIT);
+	zassert_not_null(buf, "Failed to get ACL buffer");
+
+	net_buf_unref(buf);
+	/* The freed buf cb is called from net_buf_unref, therefore the semaphore should
+	 * already by given.
+	 */
+	err = k_sem_take(&rx_sem, K_NO_WAIT);
+	zassert_equal(err, 0, "Timeout while waiting for ACL buffer to be freed");
+	zassert_equal(BT_BUF_ACL_IN, BT_BUF_ACL_IN & freed_buf_type, "ACL buffer wasn't freed");
+
+	/* Test that the callback is called for the BT_BUF_ISO_IN type */
+	buf = bt_buf_get_rx(BT_BUF_ISO_IN, K_NO_WAIT);
+	zassert_not_null(buf, "Failed to get ISO buffer");
+
+	net_buf_unref(buf);
+	/* The freed buf cb is called from net_buf_unref, therefore the semaphore should
+	 * already by given.
+	 */
+	err = k_sem_take(&rx_sem, K_NO_WAIT);
+	zassert_equal(err, 0, "Timeout while waiting for ISO buffer to be freed");
+	zassert_equal(BT_BUF_ISO_IN, BT_BUF_ISO_IN & freed_buf_type, "ISO buffer wasn't freed");
+}

--- a/tests/bluetooth/buf/testcase.yaml
+++ b/tests/bluetooth/buf/testcase.yaml
@@ -1,0 +1,30 @@
+common:
+  tags:
+    - bluetooth
+    - host
+
+tests:
+  bluetooth.buf:
+    platform_allow:
+      - native_sim
+      - native_sim/native/64
+    integration_platforms:
+      - native_sim
+    extra_configs:
+      - CONFIG_BT_HCI_ACL_FLOW_CONTROL=y
+  bluetooth.buf.no_acl_flow_control:
+    platform_allow:
+      - native_sim
+      - native_sim/native/64
+    integration_platforms:
+      - native_sim
+    extra_configs:
+      - CONFIG_BT_HCI_ACL_FLOW_CONTROL=n
+  bluetooth.buf.hci_raw:
+    platform_allow:
+      - native_sim
+      - native_sim/native/64
+    integration_platforms:
+      - native_sim
+    extra_configs:
+      - CONFIG_BT_HCI_RAW=y


### PR DESCRIPTION
The Bluetooth data buffer API currently lacks a mechanism to notify when
a buffer is freed in the RX pool. This limitation forces HCI drivers to
adopt inefficient workarounds to manage buffer allocation.

HCI drivers face two suboptimal options:

- Blocking calls: Use bt_buf_get_rx with K_FOREVER, which blocks the
  execution context until a buffer becomes available.
- Polling: Repeatedly call bt_buf_get_rx with K_NO_WAIT, which increases
  CPU load and reduces efficiency.

This commit introduces a callback mechanism that is triggered each time
a buffer is freed in the RX pool. With this feature, HCI drivers can:

- Call bt_buf_get_rx with K_NO_WAIT.
- Wait for the callback notification if a NULL buffer is returned,
  avoiding unnecessary polling.

The new callback improves efficiency by enabling event-driven behavior
for buffer management, reducing CPU overhead while maintaining
responsiveness.