### PR TITLE
tests: math: interpolation: disable floating point contraction

### DIFF
--- a/tests/lib/math/interpolation/src/main.c
+++ b/tests/lib/math/interpolation/src/main.c
@@ -6,6 +6,18 @@
 #include <math.h>
 
 #include <zephyr/ztest.h>
+
+#ifdef __clang__
+/*
+ * Floating-point contraction merges an operation of the form (a*b + c) from
+ * two operations (fmul, fadd) into a single operation (fmadd). This can change
+ * the value of the resulting LSB, causing problems when the expected value is
+ * some multiple of 0.5f and the rounding functions are used. Disable
+ * contraction for the tests to ensure this doesn't occur.
+ */
+#pragma STDC FP_CONTRACT OFF
+#endif
+
 #include <zephyr/math/interpolation.h>
 
 ZTEST(interpolation, test_interpolation_oob)


### PR DESCRIPTION
This test cannot tolerate any loss of precision, including the one caused by the compiler contracting floating points operations together, like in fused multiply-add (FMA). Some toolchains enable FP contraction by default, so disable it for the specific test and let the user decide themselves whether precision or performance is needed for their specific application.

One alternative is to include the pragma into the interpolation function itself and make its behaviour more deterministic. Still, I think I should start with the less intrusive approach.

Another alternative would be to rework the interpolation function to remove the contraction site. For that we basically need to split the FMA expression into two.