### PR TITLE
dtsi: espressif: fix dts build warnings

### DIFF
--- a/boards/m5stack/m5stack_core2/m5stack_core2_procpu.dts
+++ b/boards/m5stack/m5stack_core2/m5stack_core2_procpu.dts
@@ -73,6 +73,12 @@
 			rotation = <0>;
 		};
 	};
+
+	bus_5v: bus_5v {
+		compatible = "regulator-fixed";
+		regulator-name = "bus_5v";
+		enable-gpios = <&axp192_gpio 5 GPIO_ACTIVE_HIGH>;
+	};
 };
 
 &psram0 {
@@ -175,12 +181,6 @@
 				line-name = "bus_pwr_en";
 			};
 		};
-	};
-
-	bus_5v: bus_5v {
-		compatible = "regulator-fixed";
-		regulator-name = "bus_5v";
-		enable-gpios = <&axp192_gpio 5 GPIO_ACTIVE_HIGH>;
 	};
 
 	ft5336_touch: ft5336@38 {

--- a/dts/xtensa/espressif/esp32/esp32_common.dtsi
+++ b/dts/xtensa/espressif/esp32/esp32_common.dtsi
@@ -111,6 +111,7 @@
 
 		intc: interrupt-controller@3ff00104 {
 			#interrupt-cells = <3>;
+			#address-cells = <0>;
 			compatible = "espressif,esp32-intc";
 			interrupt-controller;
 			reg = <0x3ff00104 0x114>;

--- a/dts/xtensa/espressif/esp32s2/esp32s2_common.dtsi
+++ b/dts/xtensa/espressif/esp32s2/esp32s2_common.dtsi
@@ -86,6 +86,7 @@
 
 		intc: interrupt-controller@3f4c2000 {
 			#interrupt-cells = <3>;
+			#address-cells = <0>;
 			compatible = "espressif,esp32-intc";
 			interrupt-controller;
 			reg = <0x3f4c2000 0x114>;

--- a/dts/xtensa/espressif/esp32s3/esp32s3_common.dtsi
+++ b/dts/xtensa/espressif/esp32s3/esp32s3_common.dtsi
@@ -128,6 +128,7 @@
 
 		intc: interrupt-controller@600c2000 {
 			#interrupt-cells = <3>;
+			#address-cells = <0>;
 			compatible = "espressif,esp32-intc";
 			interrupt-controller;
 			reg = <0x600c2000 0x1000>;


### PR DESCRIPTION
1) Add address-cell field into interrupt allocator entry to overcome build warnings.
2) Fix `m5stack_core2` regulator region entry.