### PR TITLE
boards: mps3_corstone300_fvp_ns: disable twister

### DIFF
--- a/boards/arm/mps3/mps3_corstone300_fvp_ns.yaml
+++ b/boards/arm/mps3/mps3_corstone300_fvp_ns.yaml
@@ -7,6 +7,8 @@ type: mcu
 arch: arm
 ram: 2048
 flash: 512
+# Related issue #81656
+twister: false
 toolchain:
   - gnuarmemb
   - zephyr


### PR DESCRIPTION
Disable board temporarily as it fetches code from external repositories.

Related issue #81656

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
