### PR TITLE
SOC: Remove config PINCTRL from xmc4xxx soc

### DIFF
--- a/drivers/adc/Kconfig.xmc4xxx
+++ b/drivers/adc/Kconfig.xmc4xxx
@@ -7,5 +7,6 @@ config ADC_XMC4XXX
 	bool "XMC4XXX ADC"
 	default y
 	depends on DT_HAS_INFINEON_XMC4XXX_ADC_ENABLED
+	select PINCTRL
 	help
 	  Enable XMC4XXX adc driver.

--- a/drivers/can/Kconfig.xmc4xxx
+++ b/drivers/can/Kconfig.xmc4xxx
@@ -6,6 +6,7 @@ config CAN_XMC4XXX
 	bool "Infineon XMC4xxx CAN Driver"
 	default y
 	depends on DT_HAS_INFINEON_XMC4XXX_CAN_NODE_ENABLED
+	select PINCTRL
 	help
 	  Enable Infineon XMC4xxx CAN Driver
 

--- a/drivers/ethernet/Kconfig.xmc4xxx
+++ b/drivers/ethernet/Kconfig.xmc4xxx
@@ -7,6 +7,7 @@ menuconfig ETH_XMC4XXX
 	bool "XMC4XXX Ethernet driver"
 	default y
 	depends on DT_HAS_INFINEON_XMC4XXX_ETHERNET_ENABLED
+	select PINCTRL
 	help
 	  Enable XMC4XXX Ethernet driver.
 

--- a/drivers/pwm/Kconfig.xmc4xxx_ccu4
+++ b/drivers/pwm/Kconfig.xmc4xxx_ccu4
@@ -5,5 +5,6 @@ config PWM_XMC4XXX_CCU4
 	bool "Infineon XMC4XXX CCU4 driver"
 	default y
 	depends on DT_HAS_INFINEON_XMC4XXX_CCU4_PWM_ENABLED
+	select PINCTRL
 	help
 	  Enables Infineon XMC4XXX CCU4 PWM driver.

--- a/drivers/pwm/Kconfig.xmc4xxx_ccu8
+++ b/drivers/pwm/Kconfig.xmc4xxx_ccu8
@@ -5,5 +5,6 @@ config PWM_XMC4XXX_CCU8
 	bool "Infineon XMC4XXX CCU4 driver"
 	default y
 	depends on DT_HAS_INFINEON_XMC4XXX_CCU8_PWM_ENABLED
+	select PINCTRL
 	help
 	  Enables Infineon XMC4XXX CCU8 PWM driver.

--- a/drivers/serial/Kconfig.xmc4xxx
+++ b/drivers/serial/Kconfig.xmc4xxx
@@ -11,6 +11,7 @@ config UART_XMC4XXX
 	select SERIAL_SUPPORT_INTERRUPT
 	select SERIAL_SUPPORT_ASYNC if DT_HAS_INFINEON_XMC4XXX_DMA_ENABLED
 	select DMA if UART_ASYNC_API
+	select PINCTRL
 	help
 	  This option enables the XMC4XX UART driver.
 

--- a/drivers/spi/Kconfig.xmc4xxx
+++ b/drivers/spi/Kconfig.xmc4xxx
@@ -6,6 +6,7 @@ menuconfig SPI_XMC4XXX
 	default y
 	depends on DT_HAS_INFINEON_XMC4XXX_SPI_ENABLED
 	select GPIO
+	select PINCTRL
 	help
 	  Enable XMC4XXX SPI driver.
 

--- a/soc/infineon/cat3/Kconfig.defconfig
+++ b/soc/infineon/cat3/Kconfig.defconfig
@@ -7,7 +7,4 @@ if SOC_FAMILY_INFINEON_XMC
 
 rsource "*/Kconfig.defconfig"
 
-config PINCTRL
-	default y
-
 endif # SOC_FAMILY_INFINEON_XMC


### PR DESCRIPTION
	- Move selection of CONFIG_PINCTRL from soc to individual drivers
	- in accordance with issue #78619

Signed-off-by:McAtee Maxwell <maxwell.mcatee@infineon.com>