### PR TITLE
soc: intel_adsp/ace30: do not map 0x0

### DIFF
--- a/soc/intel/intel_adsp/ace/mmu_ace30.c
+++ b/soc/intel/intel_adsp/ace/mmu_ace30.c
@@ -126,7 +126,7 @@ const struct xtensa_mmu_range xtensa_soc_mmu_ranges[] = {
 	},
 	{
 		/* FIXME: definitely need more refinements... */
-		.start = (uint32_t)0x0,
+		.start = (uint32_t)0x1000,
 		.end   = (uint32_t)0x100000,
 		.attrs = XTENSA_MMU_PERM_W,
 		.name = "hwreg0",


### PR DESCRIPTION
The MMU mapping in SoC covers 0x0 which prevents catching NULL pointer accesses. Since there are no hardware registers at the very first page of memory, we move the starting point one page later.