### PR TITLE
kernel: Add _THREAD_SLEEPING thread state

### DIFF
--- a/include/zephyr/kernel_structs.h
+++ b/include/zephyr/kernel_structs.h
@@ -54,6 +54,9 @@ extern "C" {
 /* Thread is waiting on an object */
 #define _THREAD_PENDING (BIT(1))
 
+/* Thread is sleeping */
+#define _THREAD_SLEEPING (BIT(2))
+
 /* Thread has terminated */
 #define _THREAD_DEAD (BIT(3))
 

--- a/kernel/include/kthread.h
+++ b/kernel/include/kthread.h
@@ -15,6 +15,7 @@
 
 #define Z_STATE_STR_DUMMY       "dummy"
 #define Z_STATE_STR_PENDING     "pending"
+#define Z_STATE_STR_SLEEPING    "sleeping"
 #define Z_STATE_STR_DEAD        "dead"
 #define Z_STATE_STR_SUSPENDED   "suspended"
 #define Z_STATE_STR_ABORTING    "aborting"
@@ -96,9 +97,8 @@ static inline bool z_is_thread_prevented_from_running(struct k_thread *thread)
 {
 	uint8_t state = thread->base.thread_state;
 
-	return (state & (_THREAD_PENDING | _THREAD_DEAD |
+	return (state & (_THREAD_PENDING | _THREAD_SLEEPING | _THREAD_DEAD |
 			 _THREAD_DUMMY | _THREAD_SUSPENDED)) != 0U;
-
 }
 
 static inline bool z_is_thread_timeout_active(struct k_thread *thread)
@@ -144,6 +144,16 @@ static inline void z_mark_thread_as_pending(struct k_thread *thread)
 static inline void z_mark_thread_as_not_pending(struct k_thread *thread)
 {
 	thread->base.thread_state &= ~_THREAD_PENDING;
+}
+
+static inline void z_mark_thread_as_sleeping(struct k_thread *thread)
+{
+	thread->base.thread_state |= _THREAD_SLEEPING;
+}
+
+static inline void z_mark_thread_as_not_sleeping(struct k_thread *thread)
+{
+	thread->base.thread_state &= ~_THREAD_SLEEPING;
 }
 
 /*

--- a/kernel/include/kthread.h
+++ b/kernel/include/kthread.h
@@ -146,6 +146,11 @@ static inline void z_mark_thread_as_not_pending(struct k_thread *thread)
 	thread->base.thread_state &= ~_THREAD_PENDING;
 }
 
+static inline bool z_is_thread_sleeping(struct k_thread *thread)
+{
+	return (thread->base.thread_state & _THREAD_SLEEPING) != 0U;
+}
+
 static inline void z_mark_thread_as_sleeping(struct k_thread *thread)
 {
 	thread->base.thread_state |= _THREAD_SLEEPING;

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -598,7 +598,7 @@ static void init_idle_thread(int i)
 			  stack_size, idle, &_kernel.cpus[i],
 			  NULL, NULL, K_IDLE_PRIO, K_ESSENTIAL,
 			  tname);
-	z_mark_thread_as_not_suspended(thread);
+	z_mark_thread_as_not_sleeping(thread);
 
 #ifdef CONFIG_SMP
 	thread->base.is_idle = 1U;
@@ -675,7 +675,7 @@ static char *prepare_multithreading(void)
 				       NULL, NULL, NULL,
 				       CONFIG_MAIN_THREAD_PRIORITY,
 				       K_ESSENTIAL, "main");
-	z_mark_thread_as_not_suspended(&z_main_thread);
+	z_mark_thread_as_not_sleeping(&z_main_thread);
 	z_ready_thread(&z_main_thread);
 
 	z_init_cpu(0);

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -498,8 +498,6 @@ void z_impl_k_thread_suspend(k_tid_t thread)
 		return;
 	}
 
-	(void)z_abort_thread_timeout(thread);
-
 	k_spinlock_key_t  key = k_spin_lock(&_sched_spinlock);
 
 	if ((thread->base.thread_state & _THREAD_SUSPENDED) != 0U) {
@@ -631,7 +629,7 @@ void z_sched_wake_thread(struct k_thread *thread, bool is_timeout)
 			if (thread->base.pended_on != NULL) {
 				unpend_thread_no_timeout(thread);
 			}
-			z_mark_thread_as_not_suspended(thread);
+			z_mark_thread_as_not_sleeping(thread);
 			ready_thread(thread);
 		}
 	}
@@ -1111,11 +1109,9 @@ static int32_t z_tick_sleep(k_ticks_t ticks)
 #endif /* CONFIG_TIMESLICING && CONFIG_SWAP_NONATOMIC */
 	unready_thread(arch_current_thread());
 	z_add_thread_timeout(arch_current_thread(), timeout);
-	z_mark_thread_as_suspended(arch_current_thread());
+	z_mark_thread_as_sleeping(arch_current_thread());
 
 	(void)z_swap(&_sched_spinlock, key);
-
-	__ASSERT(!z_is_thread_state_set(arch_current_thread(), _THREAD_SUSPENDED), "");
 
 	/* We require a 32 bit unsigned subtraction to care a wraparound */
 	uint32_t left_ticks = expected_wakeup_ticks - sys_clock_tick_get_32();
@@ -1137,20 +1133,12 @@ int32_t z_impl_k_sleep(k_timeout_t timeout)
 
 	SYS_PORT_TRACING_FUNC_ENTER(k_thread, sleep, timeout);
 
-	/* in case of K_FOREVER, we suspend */
-	if (K_TIMEOUT_EQ(timeout, K_FOREVER)) {
-
-		k_thread_suspend(arch_current_thread());
-		SYS_PORT_TRACING_FUNC_EXIT(k_thread, sleep, timeout, (int32_t) K_TICKS_FOREVER);
-
-		return (int32_t) K_TICKS_FOREVER;
-	}
-
 	ticks = timeout.ticks;
 
 	ticks = z_tick_sleep(ticks);
 
-	int32_t ret = k_ticks_to_ms_ceil64(ticks);
+	int32_t ret = K_TIMEOUT_EQ(timeout, K_FOREVER) ? K_TICKS_FOREVER :
+		      k_ticks_to_ms_ceil64(ticks);
 
 	SYS_PORT_TRACING_FUNC_EXIT(k_thread, sleep, timeout, ret);
 
@@ -1193,24 +1181,18 @@ void z_impl_k_wakeup(k_tid_t thread)
 {
 	SYS_PORT_TRACING_OBJ_FUNC(k_thread, wakeup, thread);
 
-	if (z_is_thread_pending(thread)) {
-		return;
-	}
-
-	if (z_abort_thread_timeout(thread) < 0) {
-		/* Might have just been sleeping forever */
-		if (thread->base.thread_state != _THREAD_SUSPENDED) {
-			return;
-		}
-	}
+	(void)z_abort_thread_timeout(thread);
 
 	k_spinlock_key_t  key = k_spin_lock(&_sched_spinlock);
 
-	z_mark_thread_as_not_suspended(thread);
-
-	if (thread_active_elsewhere(thread) == NULL) {
-		ready_thread(thread);
+	if (!z_is_thread_sleeping(thread)) {
+		k_spin_unlock(&_sched_spinlock, key);
+		return;
 	}
+
+	z_mark_thread_as_not_sleeping(thread);
+
+	ready_thread(thread);
 
 	if (arch_is_in_isr()) {
 		k_spin_unlock(&_sched_spinlock, key);

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -543,7 +543,7 @@ char *z_setup_new_thread(struct k_thread *new_thread,
 	z_waitq_init(&new_thread->join_queue);
 
 	/* Initialize various struct k_thread members */
-	z_init_thread_base(&new_thread->base, prio, _THREAD_SUSPENDED, options);
+	z_init_thread_base(&new_thread->base, prio, _THREAD_SLEEPING, options);
 	stack_ptr = setup_thread_stack(new_thread, stack, stack_size);
 
 #ifdef CONFIG_KERNEL_COHERENCE

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -236,6 +236,7 @@ const char *k_thread_state_str(k_tid_t thread_id, char *buf, size_t buf_size)
 	} state_string[] = {
 		SS_ENT(DUMMY),
 		SS_ENT(PENDING),
+		SS_ENT(SLEEPING),
 		SS_ENT(DEAD),
 		SS_ENT(SUSPENDED),
 		SS_ENT(ABORTING),

--- a/modules/hal_infineon/abstraction-rtos/source/COMPONENT_ZEPHYR/cyabs_rtos_zephyr.c
+++ b/modules/hal_infineon/abstraction-rtos/source/COMPONENT_ZEPHYR/cyabs_rtos_zephyr.c
@@ -232,6 +232,7 @@ cy_rslt_t cy_rtos_get_thread_state(cy_thread_t *thread, cy_thread_state_t *state
 				break;
 
 			case _THREAD_SUSPENDED:
+			case _THREAD_SLEEPING:
 			case _THREAD_PENDING:
 				*state = CY_THREAD_STATE_BLOCKED;
 				break;

--- a/subsys/portability/cmsis_rtos_v2/thread.c
+++ b/subsys/portability/cmsis_rtos_v2/thread.c
@@ -312,6 +312,7 @@ osThreadState_t osThreadGetState(osThreadId_t thread_id)
 		state = osThreadTerminated;
 		break;
 	case _THREAD_SUSPENDED:
+	case _THREAD_SLEEPING:
 	case _THREAD_PENDING:
 		state = osThreadBlocked;
 		break;

--- a/tests/benchmarks/thread_metric/src/tm_porting_layer_zephyr.c
+++ b/tests/benchmarks/thread_metric/src/tm_porting_layer_zephyr.c
@@ -69,6 +69,11 @@ int tm_thread_create(int thread_id, int priority, void (*entry_function)(void *,
 			      TM_TEST_STACK_SIZE, entry_function,
 			      NULL, NULL, NULL, priority, 0, K_FOREVER);
 
+	/* Thread started in sleeping state. Switch to suspended state */
+
+	k_thread_suspend(&test_thread[thread_id]);
+	k_wakeup(&test_thread[thread_id]);
+
 	return (tid == &test_thread[thread_id]) ? TM_SUCCESS : TM_ERROR;
 }
 

--- a/tests/kernel/threads/thread_apis/src/test_kthread_for_each.c
+++ b/tests/kernel/threads/thread_apis/src/test_kthread_for_each.c
@@ -249,6 +249,10 @@ ZTEST(threads_lifecycle_1cpu, test_k_thread_state_str)
 	str = k_thread_state_str(tid, state_str, sizeof(state_str));
 	zassert_str_equal(str, "dead");
 
+	tid->base.thread_state = _THREAD_SLEEPING;
+	str = k_thread_state_str(tid, state_str, sizeof(state_str));
+	zassert_str_equal(str, "sleeping");
+
 	tid->base.thread_state = _THREAD_SUSPENDED;
 	str = k_thread_state_str(tid, state_str, sizeof(state_str));
 	zassert_str_equal(str, "suspended");


### PR DESCRIPTION
As has been previously noted elsewhere, Zephyr's performance on the thread_metric _preemptive_ benchmark had been observed to be significantly behind that of some other RTOSes such as ThreadX. One of the contributing factors of this has been the call to z_abort_thread() in k_thread_suspend(). Suspending a thread really should be orthogonal to timeouts and sleeps. This set of commits aims to both correct that and improve Zephyr's _preemptive_ benchmark performance. When applied atop of the other performance related PRs, this patch set gives us numbers that are about 9% better.

To decouple the two, a new thread state has been introduced--_THREAD_SLEEPING. As all the existing bits in the thread_state field are used, the size of this field must be increased from an 8-bit field. Should this field be increased on its own, this will introduce padding gaps in the layout of the _thread_base structure. To counteract the padding two other fields have also had their sizes modified.
    user_options has been increased to 16 bits (it was getting closer to being full).
    cpu_mask has been made to always be 16-bits.
 These changes can be expected to have an impact on 3rd party tools.

This decoupling also results in some behavior changes.
 
1. A thread that has gone to sleep forever will no longer be resumed by k_thread_resume(). Such a thread is awakened with k_wakeup().
2. Suspending a thread does not cancel any timeouts, thereby allowing a thread to be both sleeping and suspended, or pending with a timeout and suspended.

Below are some performance numbers using the thread_metric's preemptive benchmark with multiq on the disco_l475_iot1 (higher is better)

Main branch: 5731301
This commit atop main: 5854334
PR #81311 and #81677 together: 6501273
This commit atop both #81311 and #81677: 7034780

======================

EDIT:

The numbers reported above are for the previous version of this patch set. There has since been other changes to  k_thread_suspend() that render the performance boost moot. Furthermore, the size and placement of the thread_state, cpu_mask and user_options fields are no longer changing with this patch set.

What this set of patches does it introduce the _THREAD_SLEEPING bit (in place of the now gone _THREAD_PRESTART) bit. This helps decouple sleeping states from suspended states allowing a thread to be both sleeping and suspended. As part of this decoupling, threads are no longer created in the suspended state, but rather in the sleeping state. This seems a more intuitive state for threads that have a delay (whether finite or forever)--it is as if the first thing that they do is sleep.

One of the motivations for this stems from a model that k_thread_suspend() should not be messing with a thread's timeout.