### PR TITLE
github: workflows: fix clang and twister workflows to unblock CI

### DIFF
--- a/.github/workflows/clang.yaml
+++ b/.github/workflows/clang.yaml
@@ -8,7 +8,7 @@ concurrency:
 
 jobs:
   clang-build:
-    runs-on: zephyr-runner-linux-x64-4xlarge
+    runs-on: zephyr-runner-v2-linux-x64-4xlarge
     container:
       image: zephyrprojectrtos/ci:v0.18.4
       options: '--entrypoint /bin/bash'

--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   twister-build-prep:
-    runs-on: zephyr-runner-linux-x64-4xlarge
+    runs-on: zephyr-runner-v2-linux-x64-4xlarge
     container:
       image: zephyrprojectrtos/ci:v0.18.4
       options: '--entrypoint /bin/bash'


### PR DESCRIPTION
For quite some time, clang-build and twister jobs have failed in CI on v2.7-branch.

Update the runs-on group to use the same runners in the main branch.

Fixes #81687