### PR TITLE
arch: riscv: streamline fatal handling code

### DIFF
--- a/arch/riscv/Kconfig
+++ b/arch/riscv/Kconfig
@@ -274,14 +274,6 @@ config RISCV_HART_MASK
 	  i.e. 128, 129, ..(0x80, 8x81, ..), this can be configured to 63 (0x7f)
 	  such that we can extract the bits that start from 0.
 
-config EXTRA_EXCEPTION_INFO
-	bool "Collect extra exception info"
-	depends on EXCEPTION_DEBUG
-	help
-	  This option enables the collection of extra information, such as
-	  register state, when a fault occurs. This information can be useful
-	  to collect for post-mortem analysis and debug of issues.
-
 config RISCV_PMP
 	bool "RISC-V PMP Support"
 	select THREAD_STACK_INFO

--- a/arch/riscv/core/fatal.c
+++ b/arch/riscv/core/fatal.c
@@ -80,12 +80,7 @@ const char *z_riscv_mcause_str(unsigned long cause)
 FUNC_NORETURN void z_riscv_fatal_error(unsigned int reason,
 				       const struct arch_esf *esf)
 {
-	z_riscv_fatal_error_csf(reason, esf, NULL);
-}
-
-FUNC_NORETURN void z_riscv_fatal_error_csf(unsigned int reason, const struct arch_esf *esf,
-					   const _callee_saved_t *csf)
-{
+	__maybe_unused _callee_saved_t *csf = NULL;
 	unsigned long mcause;
 
 	__asm__ volatile("csrr %0, mcause" : "=r" (mcause));
@@ -122,6 +117,8 @@ FUNC_NORETURN void z_riscv_fatal_error_csf(unsigned int reason, const struct arc
 		LOG_ERR("   mepc: " PR_REG, esf->mepc);
 		LOG_ERR("mstatus: " PR_REG, esf->mstatus);
 		LOG_ERR("");
+
+		csf = esf->csf;
 	}
 
 	if (csf != NULL) {
@@ -247,6 +244,12 @@ FUNC_NORETURN void arch_syscall_oops(void *ssf_ptr)
 void z_impl_user_fault(unsigned int reason)
 {
 	struct arch_esf *oops_esf = arch_current_thread()->syscall_frame;
+
+#ifdef CONFIG_EXCEPTION_DEBUG
+	if (oops_esf != NULL) {
+		oops_esf->csf = NULL;
+	}
+#endif /* CONFIG_EXCEPTION_DEBUG */
 
 	if (((arch_current_thread()->base.user_options & K_USER) != 0) &&
 		reason != K_ERR_STACK_CHK_FAIL) {

--- a/arch/riscv/core/isr.S
+++ b/arch/riscv/core/isr.S
@@ -56,6 +56,20 @@
 	RV_I(	sr s9, ___callee_saved_t_s9_OFFSET(sp)		);\
 	RV_I(	sr s10, ___callee_saved_t_s10_OFFSET(sp)	);\
 	RV_I(	sr s11, ___callee_saved_t_s11_OFFSET(sp)	)
+
+/**
+ * Convenience macro to store the caller-saved registers (CSF) on stack,
+ * and link it to the `struct arch_esf`.
+ *  1. Restore the `s0` we saved early in ISR entry so it shows up properly in the CSF.
+ *  2. Allocate space for CSF on current thread stack
+ *  3. Save CSF to the allocated stack
+ *  4. Link the saved CSF to the `struct arch_esf`
+ */
+#define STORE_CSF_IN_ESF(_esf)                                                                     \
+	lr s0, __struct_arch_esf_s0_OFFSET(sp)		;                                          \
+	addi sp, sp, -__callee_saved_t_SIZEOF		;                                          \
+	STORE_CALLEE_SAVED()				;                                          \
+	sr sp __struct_arch_esf_csf_OFFSET(_esf)
 #endif /* CONFIG_EXCEPTION_DEBUG */
 
 	.macro get_current_cpu dst
@@ -375,8 +389,18 @@ no_fp:	/* increment arch_current_thread()->arch.exception_depth */
 	 * no_reschedule to restore stack.
 	 */
 	mv a0, sp
+#ifdef CONFIG_EXCEPTION_DEBUG
+	STORE_CSF_IN_ESF(a0)		;
+
+	call _Fault
+	/* Restore SP if _Fault returns before jumping to no_reschedule */
+	addi sp, sp, __callee_saved_t_SIZEOF
+
+	j no_reschedule
+#else
 	la ra, no_reschedule
 	tail _Fault
+#endif /* CONFIG_EXCEPTION_DEBUG */
 
 is_kernel_syscall:
 	/*
@@ -446,20 +470,7 @@ do_fault:
 1:	mv a1, sp
 
 #ifdef CONFIG_EXCEPTION_DEBUG
-	/*
-	 * Restore the s0 we saved early in ISR entry
-	 * so it shows up properly in the CSF.
-	 */
-	lr s0, __struct_arch_esf_s0_OFFSET(sp)
-
-	/* Allocate space for caller-saved registers on current thread stack */
-	addi sp, sp, -__callee_saved_t_SIZEOF
-
-	/* Save callee-saved registers */
-	STORE_CALLEE_SAVED()		;
-
-	/* Store csf's addr into esf (a1 still holds the pointer to the esf at this point) */
-	sr sp __struct_arch_esf_csf_OFFSET(a1)
+	STORE_CSF_IN_ESF(a1)		;
 #endif /* CONFIG_EXCEPTION_DEBUG */
 	tail z_riscv_fatal_error
 

--- a/arch/riscv/core/isr.S
+++ b/arch/riscv/core/isr.S
@@ -78,12 +78,7 @@ GTEXT(__soc_save_context)
 GTEXT(__soc_restore_context)
 #endif /* CONFIG_RISCV_SOC_CONTEXT_SAVE */
 
-#ifdef CONFIG_EXCEPTION_DEBUG
-GTEXT(z_riscv_fatal_error_csf)
-#else
 GTEXT(z_riscv_fatal_error)
-#endif /* CONFIG_EXCEPTION_DEBUG */
-
 GTEXT(z_get_next_switch_handle)
 GTEXT(z_riscv_switch)
 GTEXT(z_riscv_thread_start)
@@ -460,19 +455,13 @@ do_fault:
 	/* Allocate space for caller-saved registers on current thread stack */
 	addi sp, sp, -__callee_saved_t_SIZEOF
 
-	/* Save callee-saved registers to be passed as 3rd arg */
+	/* Save callee-saved registers */
 	STORE_CALLEE_SAVED()		;
-	mv a2, sp
 
-#ifdef CONFIG_EXTRA_EXCEPTION_INFO
 	/* Store csf's addr into esf (a1 still holds the pointer to the esf at this point) */
-	sr a2 __struct_arch_esf_csf_OFFSET(a1)
-#endif /* CONFIG_EXTRA_EXCEPTION_INFO */
-
-	tail z_riscv_fatal_error_csf
-#else
-	tail z_riscv_fatal_error
+	sr sp __struct_arch_esf_csf_OFFSET(a1)
 #endif /* CONFIG_EXCEPTION_DEBUG */
+	tail z_riscv_fatal_error
 
 #if defined(CONFIG_IRQ_OFFLOAD)
 do_irq_offload:

--- a/arch/riscv/core/offsets/offsets.c
+++ b/arch/riscv/core/offsets/offsets.c
@@ -118,10 +118,6 @@ GEN_OFFSET_STRUCT(arch_esf, s0);
 GEN_OFFSET_STRUCT(arch_esf, sp);
 #endif
 
-#ifdef CONFIG_EXTRA_EXCEPTION_INFO
-GEN_OFFSET_STRUCT(arch_esf, csf);
-#endif /* CONFIG_EXTRA_EXCEPTION_INFO */
-
 #if defined(CONFIG_RISCV_SOC_CONTEXT_SAVE)
 GEN_OFFSET_STRUCT(arch_esf, soc_context);
 #endif
@@ -132,6 +128,7 @@ GEN_SOC_OFFSET_SYMS();
 GEN_ABSOLUTE_SYM(__struct_arch_esf_SIZEOF, sizeof(struct arch_esf));
 
 #ifdef CONFIG_EXCEPTION_DEBUG
+GEN_OFFSET_STRUCT(arch_esf, csf);
 GEN_ABSOLUTE_SYM(__callee_saved_t_SIZEOF, ROUND_UP(sizeof(_callee_saved_t), ARCH_STACK_PTR_ALIGN));
 #endif /* CONFIG_EXCEPTION_DEBUG */
 

--- a/arch/riscv/include/kernel_arch_func.h
+++ b/arch/riscv/include/kernel_arch_func.h
@@ -74,12 +74,8 @@ arch_switch(void *switch_to, void **switched_from)
 #endif
 }
 
-/* Thin wrapper around z_riscv_fatal_error_csf */
 FUNC_NORETURN void z_riscv_fatal_error(unsigned int reason,
 				       const struct arch_esf *esf);
-
-FUNC_NORETURN void z_riscv_fatal_error_csf(unsigned int reason, const struct arch_esf *esf,
-					   const _callee_saved_t *csf);
 
 static inline bool arch_is_in_isr(void)
 {

--- a/doc/releases/migration-guide-4.1.rst
+++ b/doc/releases/migration-guide-4.1.rst
@@ -180,3 +180,9 @@ Architectures
   * For the native_sim target :kconfig:option:`CONFIG_NATIVE_SIM_NATIVE_POSIX_COMPAT` has been
     switched to ``n`` by default, and this option has been deprecated. Ensure your code does not
     use the :kconfig:option:`CONFIG_BOARD_NATIVE_POSIX` option anymore (:github:`81232`).
+
+* RISCV
+
+  * :kconfig:option:`CONFIG_EXTRA_EXCEPTION_INFO` has been removed, the ``*csf`` pointer will be
+    available in the ``struct arch_esf`` as long as :kconfig:option:`CONFIG_EXCEPTION_DEBUG` is
+    enabled.

--- a/include/zephyr/arch/riscv/exception.h
+++ b/include/zephyr/arch/riscv/exception.h
@@ -45,11 +45,11 @@ struct soc_esf {
 };
 #endif
 
-#ifdef CONFIG_EXTRA_EXCEPTION_INFO
+#ifdef CONFIG_EXCEPTION_DEBUG
 /* Forward declaration */
 struct _callee_saved;
 typedef struct _callee_saved _callee_saved_t;
-#endif /* CONFIG_EXTRA_EXCEPTION_INFO */
+#endif /* CONFIG_EXCEPTION_DEBUG */
 
 #if defined(CONFIG_RISCV_SOC_HAS_ISR_STACKING)
 	SOC_ISR_STACKING_ESF_DECLARE;
@@ -87,9 +87,9 @@ struct arch_esf {
 	unsigned long sp;		/* preserved (user or kernel) stack pointer */
 #endif
 
-#ifdef CONFIG_EXTRA_EXCEPTION_INFO
+#ifdef CONFIG_EXCEPTION_DEBUG
 	_callee_saved_t *csf;		/* pointer to callee-saved-registers */
-#endif /* CONFIG_EXTRA_EXCEPTION_INFO */
+#endif /* CONFIG_EXCEPTION_DEBUG */
 
 #ifdef CONFIG_RISCV_SOC_CONTEXT_SAVE
 	struct soc_esf soc_context;

--- a/soc/nordic/common/vpr/soc_isr_stacking.h
+++ b/soc/nordic/common/vpr/soc_isr_stacking.h
@@ -14,6 +14,12 @@
 
 #define VPR_CPU DT_INST(0, nordic_vpr)
 
+#ifdef CONFIG_EXCEPTION_DEBUG
+#define ESF_CSF _callee_saved_t *csf
+#else
+#define ESF_CSF
+#endif /* CONFIG_EXCEPTION_DEBUG */
+
 #if DT_PROP(VPR_CPU, nordic_bus_width) == 64
 
 #define SOC_ISR_STACKING_ESF_DECLARE                                                               \
@@ -22,6 +28,7 @@
 		unsigned long mstatus;                                                             \
 		unsigned long tp;                                                                  \
 		struct soc_esf soc_context;                                                        \
+		ESF_CSF;                                                                           \
                                                                                                    \
 		unsigned long t2;                                                                  \
 		unsigned long ra;                                                                  \
@@ -45,6 +52,7 @@
 		unsigned long mstatus;                                                             \
 		unsigned long tp;                                                                  \
 		struct soc_esf soc_context;                                                        \
+		ESF_CSF;                                                                           \
                                                                                                    \
 		unsigned long ra;                                                                  \
 		unsigned long t2;                                                                  \

--- a/tests/arch/riscv/fatal/Kconfig
+++ b/tests/arch/riscv/fatal/Kconfig
@@ -1,0 +1,20 @@
+# Copyright (c) 2024 Meta Platforms
+# SPDX-License-Identifier: Apache-2.0
+
+choice
+	prompt "Fatal type"
+	default TEST_RISCV_FATAL_PANIC
+
+config TEST_RISCV_FATAL_PANIC
+	bool "Panic induced fault"
+	help
+	  Tests the error handling via `z_riscv_fatal_error()`
+
+config TEST_RISCV_FATAL_ILLEGAL_INSTRUCTION
+	bool "Illegal instruction induced fault"
+	help
+	  Tests the error handling via `_Fault()`
+
+endchoice
+
+source "Kconfig.zephyr"

--- a/tests/arch/riscv/fatal/src/main.c
+++ b/tests/arch/riscv/fatal/src/main.c
@@ -4,59 +4,84 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/sys/util.h>
+
+#define reg_load(reg, imm)  __asm__("li " STRINGIFY(reg) ", " STRINGIFY(imm))
+
+/**
+ * Load up a bunch of known values into registers
+ * and expect them to show up in the core dump.
+ * Value is register ABI name kinda spelled out,
+ * followed by zeros to pad to 32 bits,
+ * followed by FF00, followed by hex number of the register,
+ * follwed by the "hex-coded-decimal" number of the register.
+ */
 int main(void)
 {
+	reg_load(ra, 0xDADA0000FF000101);
+
+	/* reg_load(sp, 0x0000000000000000); skipped because it can mess stuff up */
+
+#ifndef CONFIG_RISCV_GP
+	reg_load(gp, 0xE1E10000FF000303);
+#endif /* CONFIG_RISCV_GP */
+
+#ifndef CONFIG_THREAD_LOCAL_STORAGE
+	reg_load(tp, 0xE2E20000FF000404);
+#endif /* CONFIG_THREAD_LOCAL_STORAGE */
+
+	reg_load(t0, 0xD0FF0000FF000505);
+	reg_load(t1, 0xD1FF0000FF000606);
+	reg_load(t2, 0xD2FF0000FF000707);
+
+#ifndef CONFIG_FRAME_POINTER
+	reg_load(s0, 0xC0FF0000FF000808);
+#endif /* CONFIG_FRAME_POINTER */
+
+	reg_load(s1, 0xC1FF0000FF000909);
+
+	reg_load(a0, 0xA0FF0000FF000A10);
+	reg_load(a1, 0xA1FF0000FF000B11);
+	reg_load(a2, 0xA2FF0000FF000C12);
+	reg_load(a3, 0xA3FF0000FF000D13);
+	reg_load(a4, 0xA4FF0000FF000E14);
+	reg_load(a5, 0xA5FF0000FF000F15);
+
+#ifndef CONFIG_RISCV_ISA_RV32E
+	reg_load(a6, 0xA6FF0000FF001016);
+	reg_load(a7, 0xA7FF0000FF001117);
+
+	reg_load(s2, 0xC2FF0000FF001218);
+	reg_load(s3, 0xC3FF0000FF001319);
+	reg_load(s4, 0xC4FF0000FF001420);
+	reg_load(s5, 0xC5FF0000FF001521);
+	reg_load(s6, 0xC6FF0000FF001622);
+	reg_load(s7, 0xC7FF0000FF001723);
+	reg_load(s8, 0xC8FF0000FF001824);
+	reg_load(s9, 0xC9FF0000FF001925);
+	reg_load(s10, 0xC10FF000FF001A26);
+	reg_load(s11, 0xC11FF000FF001B27);
+
+	reg_load(t3, 0xD3FF0000FF001C28);
+	reg_load(t4, 0xD4FF0000FF001D29);
+	reg_load(t5, 0xD5FF0000FF001E30);
+	reg_load(t6, 0xD6FF0000FF001F31);
+#endif /* CONFIG_RISCV_ISA_RV32E */
+
+#ifdef CONFIG_TEST_RISCV_FATAL_PANIC
+	reg_load(a0, 4); /* K_ERR_KERNEL_PANIC */
+	reg_load(t0, 0); /* RV_ECALL_RUNTIME_EXCEPT */
+	__asm__("ecall");
+#else /* CONFIG_TEST_RISCV_FATAL_ILLEGAL_INSTRUCTION */
 	__asm__(
 		/**
-		 * Load up a bunch of known values into registers
-		 * and expect them to show up in the core dump.
-		 * Value is register ABI name kinda spelled out,
-		 * followed by zeros to pad to 32 bits,
-		 * followed by FF00, followed by hex number of the register,
-		 * follwed by the "hex-coded-decismal" number of the register.
+		 * 0 is an illegal instruction,
+		 * put 2 copies to make it 4 bytes wide just in case.
 		 */
-
-		/* "RA" -> "DA".  Kind of a stretch, but okay. */
-		"li x1, 0xDADA0000FF000101\n\t"
-
-		/* Skip stack pointer because it can mess stuff up. */
-		/* "li x2, 0\n\t" */
-
-		/* T0 -> D0.  Kinda close in pronunciation. */
-		"li x5, 0xD0FF0000FF000505\n\t"
-		"li x6, 0xD1FF0000FF000606\n\t"
-		"li x7, 0xD2FF0000FF000707\n\t"
-		/* S0 -> C0.  Kinda close in pronunciation. */
-		"li x8, 0xC0FF0000FF000808\n\t"
-		"li x9, 0xC1FF0000FF000909\n\t"
-		/* A0 -> A0.  Actual match! */
-		"li x10, 0xA0FF0000FF000A10\n\t"
-		"li x11, 0xA1FF0000FF000B11\n\t"
-		"li x12, 0xA2FF0000FF000C12\n\t"
-		"li x13, 0xA3FF0000FF000D13\n\t"
-		"li x14, 0xA4FF0000FF000E14\n\t"
-		"li x15, 0xA5FF0000FF000F15\n\t"
-		"li x16, 0xA6FF0000FF001016\n\t"
-		"li x17, 0xA7FF0000FF001117\n\t"
-		"li x18, 0xC2FF0000FF001218\n\t"
-		"li x19, 0xC3FF0000FF001319\n\t"
-		"li x20, 0xC4FF0000FF001420\n\t"
-		"li x21, 0xC5FF0000FF001521\n\t"
-		"li x22, 0xC6FF0000FF001622\n\t"
-		"li x23, 0xC7FF0000FF001723\n\t"
-		"li x24, 0xC8FF0000FF001824\n\t"
-		"li x25, 0xC9FF0000FF001925\n\t"
-		"li x26, 0xC10FF000FF001A26\n\t"
-		"li x27, 0xC11FF000FF001B27\n\t"
-		"li x28, 0xD3FF0000FF001C28\n\t"
-		"li x29, 0xD4FF0000FF001D29\n\t"
-		"li x30, 0xD5FF0000FF001E30\n\t"
-		"li x31, 0xD6FF0000FF001F31\n\t"
-		/* K_ERR_KERNEL_PANIC */
-		"li a0, 4\n\t"
-		/* RV_ECALL_RUNTIME_EXCEPT */
-		"li t0, 0\n\t"
-		"ecall\n");
+		".insn 2, 0\n\t"
+		".insn 2, 0\n\t"
+		"");
+#endif /* CONFIG_TEST_RISCV_FATAL_PANIC */
 
 	return 0;
 }

--- a/tests/arch/riscv/fatal/testcase.yaml
+++ b/tests/arch/riscv/fatal/testcase.yaml
@@ -6,7 +6,10 @@ common:
   platform_allow:
     - qemu_riscv64
 tests:
-  arch.riscv64.fatal:
+  arch.riscv64.fatal.panic_sp:
+    extra_configs:
+      - CONFIG_FRAME_POINTER=n
+      - CONFIG_TEST_RISCV_FATAL_PANIC=y
     harness_config:
       type: multi_line
       regex:
@@ -20,6 +23,72 @@ tests:
         - "E:      a7: a7ff0000ff001117"
         - "E:      ra: dada0000ff000101"
         - "E:      s0: c0ff0000ff000808    s6: c6ff0000ff001622"
+        - "E:      s1: c1ff0000ff000909    s7: c7ff0000ff001723"
+        - "E:      s2: c2ff0000ff001218    s8: c8ff0000ff001824"
+        - "E:      s3: c3ff0000ff001319    s9: c9ff0000ff001925"
+        - "E:      s4: c4ff0000ff001420   s10: c10ff000ff001a26"
+        - "E:      s5: c5ff0000ff001521   s11: c11ff000ff001b27"
+  arch.riscv64.fatal.fault_sp:
+    extra_configs:
+      - CONFIG_FRAME_POINTER=n
+      - CONFIG_TEST_RISCV_FATAL_ILLEGAL_INSTRUCTION=y
+    harness_config:
+      type: multi_line
+      regex:
+        - "E:      a0: a0ff0000ff000a10    t0: d0ff0000ff000505"
+        - "E:      a1: a1ff0000ff000b11    t1: d1ff0000ff000606"
+        - "E:      a2: a2ff0000ff000c12    t2: d2ff0000ff000707"
+        - "E:      a3: a3ff0000ff000d13    t3: d3ff0000ff001c28"
+        - "E:      a4: a4ff0000ff000e14    t4: d4ff0000ff001d29"
+        - "E:      a5: a5ff0000ff000f15    t5: d5ff0000ff001e30"
+        - "E:      a6: a6ff0000ff001016    t6: d6ff0000ff001f31"
+        - "E:      a7: a7ff0000ff001117"
+        - "E:      ra: dada0000ff000101"
+        - "E:      s0: c0ff0000ff000808    s6: c6ff0000ff001622"
+        - "E:      s1: c1ff0000ff000909    s7: c7ff0000ff001723"
+        - "E:      s2: c2ff0000ff001218    s8: c8ff0000ff001824"
+        - "E:      s3: c3ff0000ff001319    s9: c9ff0000ff001925"
+        - "E:      s4: c4ff0000ff001420   s10: c10ff000ff001a26"
+        - "E:      s5: c5ff0000ff001521   s11: c11ff000ff001b27"
+  arch.riscv64.fatal.panic_fp:
+    extra_configs:
+      - CONFIG_FRAME_POINTER=y
+      - CONFIG_TEST_RISCV_FATAL_PANIC=y
+    harness_config:
+      type: multi_line
+      regex:
+        - "E:      a0: 0000000000000004    t0: 0000000000000000"
+        - "E:      a1: a1ff0000ff000b11    t1: d1ff0000ff000606"
+        - "E:      a2: a2ff0000ff000c12    t2: d2ff0000ff000707"
+        - "E:      a3: a3ff0000ff000d13    t3: d3ff0000ff001c28"
+        - "E:      a4: a4ff0000ff000e14    t4: d4ff0000ff001d29"
+        - "E:      a5: a5ff0000ff000f15    t5: d5ff0000ff001e30"
+        - "E:      a6: a6ff0000ff001016    t6: d6ff0000ff001f31"
+        - "E:      a7: a7ff0000ff001117"
+        - "E:      ra: dada0000ff000101"
+        - "E:      s0: \\w+    s6: c6ff0000ff001622"
+        - "E:      s1: c1ff0000ff000909    s7: c7ff0000ff001723"
+        - "E:      s2: c2ff0000ff001218    s8: c8ff0000ff001824"
+        - "E:      s3: c3ff0000ff001319    s9: c9ff0000ff001925"
+        - "E:      s4: c4ff0000ff001420   s10: c10ff000ff001a26"
+        - "E:      s5: c5ff0000ff001521   s11: c11ff000ff001b27"
+  arch.riscv64.fatal.fault_fp:
+    extra_configs:
+      - CONFIG_FRAME_POINTER=y
+      - CONFIG_TEST_RISCV_FATAL_ILLEGAL_INSTRUCTION=y
+    harness_config:
+      type: multi_line
+      regex:
+        - "E:      a0: a0ff0000ff000a10    t0: d0ff0000ff000505"
+        - "E:      a1: a1ff0000ff000b11    t1: d1ff0000ff000606"
+        - "E:      a2: a2ff0000ff000c12    t2: d2ff0000ff000707"
+        - "E:      a3: a3ff0000ff000d13    t3: d3ff0000ff001c28"
+        - "E:      a4: a4ff0000ff000e14    t4: d4ff0000ff001d29"
+        - "E:      a5: a5ff0000ff000f15    t5: d5ff0000ff001e30"
+        - "E:      a6: a6ff0000ff001016    t6: d6ff0000ff001f31"
+        - "E:      a7: a7ff0000ff001117"
+        - "E:      ra: dada0000ff000101"
+        - "E:      s0: \\w+    s6: c6ff0000ff001622"
         - "E:      s1: c1ff0000ff000909    s7: c7ff0000ff001723"
         - "E:      s2: c2ff0000ff001218    s8: c8ff0000ff001824"
         - "E:      s3: c3ff0000ff001319    s9: c9ff0000ff001925"


### PR DESCRIPTION
**arch: riscv: streamline fatal handling code**

`CONFIG_EXTRA_EXCEPTION_INFO` that was added in https://github.com/zephyrproject-rtos/zephyr/pull/78065 doesn't
seem necessary, as we were already storing and printing the
callee-saved-registers before that. All `CONFIG_EXTRA_EXCEPTION_INFO`
does in RISCV is to add an additional `_callee_saved_t *csf` in the
`struct arch_esf`, which overhead is negligible to what's being enabled
by `CONFIG_EXCEPTION_DEBUG`.

Let's remove `CONFIG_EXTRA_EXCEPTION_INFO`, and have that extra
`_callee_saved_t *csf` in the `struct arch_esf` as long as
`CONFIG_EXCEPTION_DEBUG` is enabled.

Then, since `*csf` is always available in the `struct arch_esf` when
`CONFIG_EXCEPTION_DEBUG=y`, we can simply rely on that pointer in
`z_riscv_fatal_error()` instead of an additional argument in
`z_riscv_fatal_error_csf()`, rendering it redundant and thus can be
removed.

**arch: riscv: fatal: print csf in `_Fault()`**

Refactor the csf saving code into a macro and calls it before jumping
to `_Fault()`, so that callee-saved-registers are printed on generic
CPU exception as well.

**tests: arch: riscv: fatal: test _Fault() path**

- Updated the testcase to test `_Fault()` error handling path.
- While there, update the testcase to test with/without frame pointer
  enabled.
- Also, create a `reg_load` macro so that the test looks more 'C'
  than 'asm'.
