### PR TITLE
soc/it8xxx2: disable USB debug path at default

### DIFF
--- a/soc/ite/ec/common/chip_chipregs.h
+++ b/soc/ite/ec/common/chip_chipregs.h
@@ -1662,6 +1662,7 @@ struct gctrl_it8xxx2_regs {
 /* 0x20: Memory Controller Configuration 3 */
 #define IT8XXX2_GCTRL_SPISLVPFE		BIT(6)
 /* 0x30: Memory Controller Configuration */
+#define IT8XXX2_GCTRL_USB_DEBUG_EN      BIT(7)
 #define IT8XXX2_GCTRL_ICACHE_RESET	BIT(4)
 /* 0x37: Eflash Protect Lock */
 #define IT8XXX2_GCTRL_EPLR_ENABLE	BIT(0)

--- a/soc/ite/ec/it8xxx2/soc.c
+++ b/soc/ite/ec/it8xxx2/soc.c
@@ -388,6 +388,12 @@ static int ite_it8xxx2_init(void)
 	gctrl_regs->GCTRL_WMCR |= BIT(7);
 
 	/*
+	 * Disable USB debug at default, in order to prevent SoC
+	 * from entering debug mode when there is signal toggling on GPH5/GPH6.
+	 */
+	gctrl_regs->GCTRL_MCCR &= ~IT8XXX2_GCTRL_USB_DEBUG_EN;
+
+	/*
 	 * Disable this feature that can detect pre-define hardware
 	 * target A through I2C0. This is for debugging use, so it
 	 * can be disabled to avoid illegal access.


### PR DESCRIPTION
This change disables USB debug path at default, in order to prevent SoC from entering debug mode when there is signal toggling on GPH5/GPH6.