### PR TITLE
hostap: distinguish suppliant AP and hostapd AP

### DIFF
--- a/drivers/wifi/nxp/Kconfig.nxp
+++ b/drivers/wifi/nxp/Kconfig.nxp
@@ -486,7 +486,7 @@ config NXP_WIFI_MAX_PRIO
 config NXP_WIFI_SOFTAP_SUPPORT
 	bool "Wi-Fi SoftAP Support"
 	select NET_DHCPV4_SERVER
-	select WIFI_NM_WPA_SUPPLICANT_AP if WIFI_NM_WPA_SUPPLICANT
+	select WIFI_NM_HOSTAPD_AP if WIFI_NM_WPA_SUPPLICANT
 	default y
 	help
 	  Option to enable Wi-Fi SoftAP functions in the Wi-Fi driver.

--- a/modules/hostap/CMakeLists.txt
+++ b/modules/hostap/CMakeLists.txt
@@ -166,7 +166,8 @@ zephyr_library_sources_ifdef(CONFIG_IEEE80211R
 	${HOSTAP_SRC_BASE}/ap/wpa_auth_ft.c
 )
 
-zephyr_library_sources_ifdef(CONFIG_WIFI_NM_WPA_SUPPLICANT_AP
+if(CONFIG_WIFI_NM_WPA_SUPPLICANT_AP OR CONFIG_WIFI_NM_HOSTAPD_AP)
+zephyr_library_sources(
 	${WIFI_NM_WPA_SUPPLICANT_BASE}/ap.c
 	${HOSTAP_SRC_BASE}/ap/ap_config.c
 	${HOSTAP_SRC_BASE}/ap/ap_drv_ops.c
@@ -217,7 +218,7 @@ zephyr_library_sources_ifdef(CONFIG_WIFI_NM_WPA_SUPPLICANT_11AX
 	${HOSTAP_SRC_BASE}/ap/ieee802_11_he.c
 )
 
-zephyr_library_compile_definitions_ifdef(CONFIG_WIFI_NM_WPA_SUPPLICANT_AP
+zephyr_library_compile_definitions(
 	CONFIG_AP
 	CONFIG_NO_RADIUS
 	CONFIG_NO_VLAN
@@ -231,6 +232,7 @@ zephyr_library_compile_definitions_ifdef(CONFIG_WIFI_NM_WPA_SUPPLICANT_AP
 zephyr_library_compile_definitions_ifdef(CONFIG_WIFI_NM_WPA_SUPPLICANT_11AX
 	CONFIG_IEEE80211AX
 )
+endif()
 
 zephyr_include_directories_ifdef(CONFIG_WIFI_NM_HOSTAPD_AP
 	${WIFI_NM_HOSTAPD_BASE}/

--- a/modules/hostap/Kconfig
+++ b/modules/hostap/Kconfig
@@ -25,7 +25,7 @@ if WIFI_NM_WPA_SUPPLICANT
 
 config HEAP_MEM_POOL_ADD_SIZE_HOSTAP
 	def_int 85000 if WIFI_NM_WPA_SUPPLICANT_CRYPTO_ENTERPRISE && !MBEDTLS_ENABLE_HEAP
-	def_int 40000 if WIFI_NM_WPA_SUPPLICANT_AP
+	def_int 40000 if WIFI_NM_WPA_SUPPLICANT_AP || WIFI_NM_HOSTAPD_AP
 	# 8192 for MbedTLS heap
 	def_int 21808 if MBEDTLS_ENABLE_HEAP
 	# 30K is mandatory, but might need more for long duration use cases
@@ -375,8 +375,8 @@ config TESTING_OPTIONS
 
 config AP
 	bool
-	depends on WIFI_NM_WPA_SUPPLICANT_AP
-	default y if WIFI_NM_WPA_SUPPLICANT_AP
+	depends on WIFI_NM_WPA_SUPPLICANT_AP || WIFI_NM_HOSTAPD_AP
+	default y if WIFI_NM_WPA_SUPPLICANT_AP || WIFI_NM_HOSTAPD_AP
 
 config NO_RADIUS
 	bool


### PR DESCRIPTION
hostap: distinguish suppliant AP and hostapd AP
drivers: wifi: nxp: default use hostapd AP