### PR TITLE
drivers: ethernet: phy_mii: add link down log

### DIFF
--- a/drivers/ethernet/phy/phy_mii.c
+++ b/drivers/ethernet/phy/phy_mii.c
@@ -168,6 +168,7 @@ static int update_link_state(const struct device *dev)
 
 	/* If link is down, there is nothing more to be done */
 	if (data->state.is_up == false) {
+		LOG_INF("PHY (%d) is down", cfg->phy_addr);
 		return 0;
 	}
 


### PR DESCRIPTION
It's expected there is log info for both link up and link down.