### PR TITLE
drivers serial nrfx: Apply workaround also for bsim targets

### DIFF
--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -30,9 +30,7 @@
 
 LOG_MODULE_REGISTER(uart_nrfx_uarte, CONFIG_UART_LOG_LEVEL);
 
-#if !defined(CONFIG_ARCH_POSIX)
 #define RX_FLUSH_WORKAROUND 1
-#endif
 
 #define UARTE(idx)                DT_NODELABEL(uart##idx)
 #define UARTE_HAS_PROP(idx, prop) DT_NODE_HAS_PROP(UARTE(idx), prop)

--- a/west.yml
+++ b/west.yml
@@ -188,7 +188,7 @@ manifest:
       groups:
         - hal
     - name: hal_nordic
-      revision: ce87268bb5610b7e90acce3efa5c511e95aeeeae
+      revision: 5fbccc3fa8341d0cd5a128bc94f23ee03b763239
       path: modules/hal/nordic
       groups:
         - hal


### PR DESCRIPTION
Or more precisely, do not remove the workaround for them.
The current HW models are accurate enough in this area for the workaround to work properly.