### PR TITLE
tests: driver: uart: uart_mix_fifo_poll: Extend test to support running on multiple UART instances

### DIFF
--- a/tests/drivers/uart/uart_mix_fifo_poll/boards/nrf54h20dk_nrf54h20_common.dtsi
+++ b/tests/drivers/uart/uart_mix_fifo_poll/boards/nrf54h20dk_nrf54h20_common.dtsi
@@ -19,6 +19,27 @@
 			low-power-enable;
 		};
 	};
+	uart120_default_alt: uart120_default_alt {
+		group1 {
+			psels = <NRF_PSEL(UART_TX, 7, 7)>,
+				<NRF_PSEL(UART_RTS, 7, 5)>;
+		};
+		group2 {
+			psels = <NRF_PSEL(UART_RX, 7, 4)>,
+				<NRF_PSEL(UART_CTS, 7, 6)>;
+			bias-pull-up;
+		};
+	};
+
+	uart120_sleep_alt: uart120_sleep_alt {
+		group1 {
+			psels = <NRF_PSEL(UART_TX, 7, 7)>,
+				<NRF_PSEL(UART_RX, 7, 4)>,
+				<NRF_PSEL(UART_RTS, 7, 5)>,
+				<NRF_PSEL(UART_CTS, 7, 6)>;
+			low-power-enable;
+		};
+	};
 };
 
 dut: &uart137 {
@@ -30,7 +51,14 @@ dut: &uart137 {
 	hw-flow-control;
 };
 
-/* Use timer137 as only this one can generate interrupts on cpusys. */
+dut2: &uart120 {
+	pinctrl-0 = <&uart120_default_alt>;
+	pinctrl-1 = <&uart120_sleep_alt>;
+	pinctrl-names = "default", "sleep";
+	current-speed = <115200>;
+	hw-flow-control;
+};
+
 counter_dev: &timer137 {
 	status = "okay";
 };

--- a/tests/drivers/uart/uart_mix_fifo_poll/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/tests/drivers/uart/uart_mix_fifo_poll/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -6,6 +6,15 @@
 	memory-regions = <&cpuapp_dma_region>;
 };
 
+&dma_fast_region {
+	status = "okay";
+};
+
+&dut2 {
+	status = "okay";
+	memory-regions = <&dma_fast_region>;
+};
+
 &grtc {
 	interrupts = <109 2>;
 };

--- a/tests/drivers/uart/uart_mix_fifo_poll/boards/nrf54h20dk_nrf54h20_cpurad.overlay
+++ b/tests/drivers/uart/uart_mix_fifo_poll/boards/nrf54h20dk_nrf54h20_cpurad.overlay
@@ -6,6 +6,14 @@
 	memory-regions = <&cpurad_dma_region>;
 };
 
+&dma_fast_region {
+	status = "okay";
+};
+
+&dut2 {
+	memory-regions = <&dma_fast_region>;
+};
+
 &grtc {
 	interrupts = <109 2>;
 };

--- a/tests/drivers/uart/uart_mix_fifo_poll/src/main.c
+++ b/tests/drivers/uart/uart_mix_fifo_poll/src/main.c
@@ -40,6 +40,24 @@ struct rx_source {
 	uint8_t prev;
 };
 
+struct dut_data {
+	const struct device *dev;
+	const char *name;
+};
+
+static struct dut_data duts[] = {
+	{
+		.dev = DEVICE_DT_GET(UART_NODE),
+		.name = DT_NODE_FULL_NAME(UART_NODE),
+	},
+#if DT_NODE_EXISTS(DT_NODELABEL(dut2))
+	{
+		.dev = DEVICE_DT_GET(DT_NODELABEL(dut2)),
+		.name = DT_NODE_FULL_NAME(DT_NODELABEL(dut2)),
+	},
+#endif
+};
+
 #define BUF_SIZE 16
 
 /* Buffer used for polling. */
@@ -66,8 +84,7 @@ static struct test_data int_async_data;
 
 static const struct device *const counter_dev =
 	DEVICE_DT_GET(COUNTER_NODE);
-static const struct device *const uart_dev =
-	DEVICE_DT_GET(UART_NODE);
+static const struct device *uart_dev;
 
 static bool async;
 static bool int_driven;
@@ -128,7 +145,7 @@ static void counter_top_handler(const struct device *dev, void *user_data)
 	}
 }
 
-static void init_test(void)
+static void init_test(int idx)
 {
 	int err;
 	struct counter_top_cfg top_cfg = {
@@ -136,6 +153,11 @@ static void init_test(void)
 		.user_data = NULL,
 		.flags = 0
 	};
+
+	memset(source, 0, sizeof(source));
+	async_rx_enabled = false;
+	uart_dev = duts[idx].dev;
+	TC_PRINT("UART instance:%s\n", duts[idx].name);
 
 	zassert_true(device_is_ready(uart_dev), "uart device is not ready");
 
@@ -369,10 +391,21 @@ ZTEST(uart_mix_fifo_poll, test_mixed_uart_access)
 
 void *uart_mix_setup(void)
 {
-	init_test();
+	static int idx;
+
+	init_test(idx++);
 
 	return NULL;
 }
 
 ZTEST_SUITE(uart_mix_fifo_poll, NULL, uart_mix_setup,
 		NULL, NULL, NULL);
+
+void test_main(void)
+{
+	/* Run all suites for each dut UART. Setup function for each suite is picking
+	 * next UART from the array.
+	 */
+	ztest_run_all(NULL, false, ARRAY_SIZE(duts), 1);
+	ztest_verify_all_test_suites_ran();
+}

--- a/tests/drivers/uart/uart_mix_fifo_poll/testcase.yaml
+++ b/tests/drivers/uart/uart_mix_fifo_poll/testcase.yaml
@@ -25,14 +25,12 @@ tests:
       - CONFIG_UART_INTERRUPT_DRIVEN=n
       - CONFIG_UART_ASYNC_API=n
       - CONFIG_UART_0_ENHANCED_POLL_OUT=n
-      - CONFIG_UART_NRFX_UARTE_LEGACY_SHIM=n
 
   drivers.uart.uart_mix_poll_fifo:
     extra_configs:
       - CONFIG_UART_INTERRUPT_DRIVEN=y
       - CONFIG_UART_0_INTERRUPT_DRIVEN=y
       - CONFIG_UART_0_ENHANCED_POLL_OUT=n
-      - CONFIG_UART_NRFX_UARTE_LEGACY_SHIM=n
 
   drivers.uart.uart_mix_poll_async_api:
     extra_configs:
@@ -40,7 +38,6 @@ tests:
       - CONFIG_UART_0_INTERRUPT_DRIVEN=n
       - CONFIG_UART_0_ASYNC=y
       - CONFIG_UART_0_ENHANCED_POLL_OUT=n
-      - CONFIG_UART_NRFX_UARTE_LEGACY_SHIM=n
 
   drivers.uart.uart_mix_poll_async_api_const:
     extra_args: TEST_CONST_BUFFER=1
@@ -50,7 +47,6 @@ tests:
       - CONFIG_UART_0_ASYNC=y
       - CONFIG_UART_0_ENHANCED_POLL_OUT=n
       - CONFIG_UART_0_TX_CACHE_SIZE=2
-      - CONFIG_UART_NRFX_UARTE_LEGACY_SHIM=n
     tags: bsim_skip_CI # We skip a few tests to save CI time, as they give little extra coverage
 
   drivers.uart.uart_mix_poll_with_ppi:
@@ -58,16 +54,20 @@ tests:
       - CONFIG_UART_INTERRUPT_DRIVEN=n
       - CONFIG_UART_ASYNC_API=n
       - CONFIG_UART_0_ENHANCED_POLL_OUT=y
-      - CONFIG_UART_NRFX_UARTE_LEGACY_SHIM=n
-    tags: bsim_skip_CI
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf9160dk/nrf9160
 
   drivers.uart.uart_mix_poll_fifo_with_ppi:
     extra_configs:
       - CONFIG_UART_INTERRUPT_DRIVEN=y
       - CONFIG_UART_0_INTERRUPT_DRIVEN=y
       - CONFIG_UART_0_ENHANCED_POLL_OUT=y
-      - CONFIG_UART_NRFX_UARTE_LEGACY_SHIM=n
-    tags: bsim_skip_CI
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf9160dk/nrf9160
 
   drivers.uart.uart_mix_poll_async_api_with_ppi:
     extra_configs:
@@ -75,42 +75,7 @@ tests:
       - CONFIG_UART_0_INTERRUPT_DRIVEN=n
       - CONFIG_UART_0_ASYNC=y
       - CONFIG_UART_0_ENHANCED_POLL_OUT=y
-      - CONFIG_UART_NRFX_UARTE_LEGACY_SHIM=n
-    tags: bsim_skip_CI
-
-  drivers.uart.legacy.uart_mix_poll:
-    extra_configs:
-      - CONFIG_UART_INTERRUPT_DRIVEN=n
-      - CONFIG_UART_ASYNC_API=n
-      - CONFIG_UART_0_ENHANCED_POLL_OUT=n
-      - CONFIG_UART_NRFX_UARTE_LEGACY_SHIM=y
-    platform_exclude:
-      - nrf54l15dk/nrf54l15/cpuapp
-      - nrf54l20pdk/nrf54l20/cpuapp
-      - nrf54h20dk/nrf54h20/cpuapp
-      - nrf54h20dk/nrf54h20/cpurad
-
-  drivers.uart.legacy.uart_mix_poll_fifo:
-    extra_configs:
-      - CONFIG_UART_INTERRUPT_DRIVEN=y
-      - CONFIG_UART_0_INTERRUPT_DRIVEN=y
-      - CONFIG_UART_0_ENHANCED_POLL_OUT=n
-      - CONFIG_UART_NRFX_UARTE_LEGACY_SHIM=y
-    platform_exclude:
-      - nrf54l15dk/nrf54l15/cpuapp
-      - nrf54l20pdk/nrf54l20/cpuapp
-      - nrf54h20dk/nrf54h20/cpuapp
-      - nrf54h20dk/nrf54h20/cpurad
-
-  drivers.uart.legacy.uart_mix_poll_async_api:
-    extra_configs:
-      - CONFIG_UART_ASYNC_API=y
-      - CONFIG_UART_0_INTERRUPT_DRIVEN=n
-      - CONFIG_UART_0_ASYNC=y
-      - CONFIG_UART_0_ENHANCED_POLL_OUT=n
-      - CONFIG_UART_NRFX_UARTE_LEGACY_SHIM=y
-    platform_exclude:
-      - nrf54l15dk/nrf54l15/cpuapp
-      - nrf54l20pdk/nrf54l20/cpuapp
-      - nrf54h20dk/nrf54h20/cpuapp
-      - nrf54h20dk/nrf54h20/cpurad
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf9160dk/nrf9160

--- a/tests/drivers/uart/uart_mix_fifo_poll/testcase.yaml
+++ b/tests/drivers/uart/uart_mix_fifo_poll/testcase.yaml
@@ -18,7 +18,7 @@ common:
   integration_platforms:
     - nrf52840dk/nrf52840
   harness_config:
-    fixture: gpio_loopback
+    fixture: uart_loopback
 tests:
   drivers.uart.uart_mix_poll:
     extra_configs:


### PR DESCRIPTION
Rework test to support running on multiple UART instances.
Extend configuration for nrf54h20dk/nrf54h20/cpuapp to use also uart120 instance.
It contains commit from #81273 as without this uart120 does not work with device runtime PM.