### PR TITLE
boards: silabs: add default uart-pipe options

### DIFF
--- a/boards/silabs/dev_kits/sim3u1xx_dk/sim3u1xx_dk.dts
+++ b/boards/silabs/dev_kits/sim3u1xx_dk/sim3u1xx_dk.dts
@@ -24,6 +24,7 @@
 		zephyr,console = &usart0;
 		zephyr,flash = &flash0;
 		zephyr,shell-uart = &usart0;
+		zephyr,uart-pipe = &usart0;
 		zephyr,sram = &sram0;
 	};
 

--- a/boards/silabs/dev_kits/sltb004a/sltb004a.dts
+++ b/boards/silabs/dev_kits/sltb004a/sltb004a.dts
@@ -27,6 +27,7 @@
 	chosen {
 		zephyr,console = &usart0;
 		zephyr,shell-uart = &usart0;
+		zephyr,uart-pipe = &usart0;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 	};

--- a/boards/silabs/dev_kits/sltb009a/sltb009a.dts
+++ b/boards/silabs/dev_kits/sltb009a/sltb009a.dts
@@ -16,6 +16,7 @@
 	chosen {
 		zephyr,console = &usart0;
 		zephyr,shell-uart = &usart0;
+		zephyr,uart-pipe = &usart0;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 	};

--- a/boards/silabs/dev_kits/sltb010a/Kconfig.defconfig
+++ b/boards/silabs/dev_kits/sltb010a/Kconfig.defconfig
@@ -26,6 +26,9 @@ config MAIN_STACK_SIZE
 	default 3072 if PM
 	default 2304
 
+config BT_SEND_ECC_EMULATION
+	default y
+
 endif # BT
 
 config REGULATOR

--- a/boards/silabs/dev_kits/sltb010a/thunderboard.dtsi
+++ b/boards/silabs/dev_kits/sltb010a/thunderboard.dtsi
@@ -11,6 +11,7 @@
 		zephyr,bt-c2h-uart = &usart1;
 		zephyr,console = &usart1;
 		zephyr,shell-uart = &usart1;
+		zephyr,uart-pipe = &usart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 	};

--- a/boards/silabs/dev_kits/xg24_dk2601b/Kconfig.defconfig
+++ b/boards/silabs/dev_kits/xg24_dk2601b/Kconfig.defconfig
@@ -31,6 +31,9 @@ config COMMON_LIBC_MALLOC_ARENA_SIZE
 config MAIN_STACK_SIZE
 	default 2304
 
+config BT_SEND_ECC_EMULATION
+	default y
+
 if SHELL
 
 config SHELL_STACK_SIZE

--- a/boards/silabs/dev_kits/xg24_dk2601b/xg24_dk2601b.dts
+++ b/boards/silabs/dev_kits/xg24_dk2601b/xg24_dk2601b.dts
@@ -17,6 +17,7 @@
 	chosen {
 		zephyr,console = &usart0;
 		zephyr,shell-uart = &usart0;
+		zephyr,uart-pipe = &usart0;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_partition;

--- a/boards/silabs/dev_kits/xg27_dk2602a/Kconfig.defconfig
+++ b/boards/silabs/dev_kits/xg27_dk2602a/Kconfig.defconfig
@@ -26,6 +26,9 @@ config MAIN_STACK_SIZE
 	default 3072 if PM
 	default 2304
 
+config BT_SEND_ECC_EMULATION
+	default y
+
 endif # BT
 
 config REGULATOR

--- a/boards/silabs/dev_kits/xg27_dk2602a/thunderboard.dtsi
+++ b/boards/silabs/dev_kits/xg27_dk2602a/thunderboard.dtsi
@@ -11,6 +11,7 @@
 		zephyr,bt-c2h-uart = &usart1;
 		zephyr,console = &usart1;
 		zephyr,shell-uart = &usart1;
+		zephyr,uart-pipe = &usart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 	};

--- a/boards/silabs/radio_boards/common/efr32-series1-common.dtsi
+++ b/boards/silabs/radio_boards/common/efr32-series1-common.dtsi
@@ -11,6 +11,7 @@
 	chosen {
 		zephyr,console = &usart0;
 		zephyr,shell-uart = &usart0;
+		zephyr,uart-pipe = &usart0;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_partition;

--- a/boards/silabs/radio_boards/slwrb4104a/Kconfig.defconfig
+++ b/boards/silabs/radio_boards/slwrb4104a/Kconfig.defconfig
@@ -37,6 +37,9 @@ config MAIN_STACK_SIZE
 	default 3072 if PM
 	default 2304
 
+config BT_SEND_ECC_EMULATION
+	default y
+
 endif # BT
 
 endif # BOARD_SLWRB4104A

--- a/boards/silabs/radio_boards/slwrb4161a/Kconfig.defconfig
+++ b/boards/silabs/radio_boards/slwrb4161a/Kconfig.defconfig
@@ -37,6 +37,9 @@ config MAIN_STACK_SIZE
 	default 3072 if PM
 	default 2304
 
+config BT_SEND_ECC_EMULATION
+	default y
+
 endif # BT
 
 endif # BOARD_SLWRB4161A

--- a/boards/silabs/radio_boards/slwrb4170a/Kconfig.defconfig
+++ b/boards/silabs/radio_boards/slwrb4170a/Kconfig.defconfig
@@ -37,6 +37,9 @@ config MAIN_STACK_SIZE
 	default 3072 if PM
 	default 2304
 
+config BT_SEND_ECC_EMULATION
+	default y
+
 endif # BT
 
 endif # BOARD_SLWRB4170A

--- a/boards/silabs/radio_boards/slwrb4180a/Kconfig.defconfig
+++ b/boards/silabs/radio_boards/slwrb4180a/Kconfig.defconfig
@@ -37,6 +37,9 @@ config MAIN_STACK_SIZE
 	default 3072 if PM
 	default 2304
 
+config BT_SEND_ECC_EMULATION
+	default y
+
 endif # BT
 
 endif # BOARD_SLWRB4180A

--- a/boards/silabs/radio_boards/slwrb4180a/slwrb4180a.dts
+++ b/boards/silabs/radio_boards/slwrb4180a/slwrb4180a.dts
@@ -16,6 +16,7 @@
 	chosen {
 		zephyr,console = &usart0;
 		zephyr,shell-uart = &usart0;
+		zephyr,uart-pipe = &usart0;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_partition;

--- a/boards/silabs/radio_boards/slwrb4250b/Kconfig.defconfig
+++ b/boards/silabs/radio_boards/slwrb4250b/Kconfig.defconfig
@@ -37,6 +37,9 @@ config MAIN_STACK_SIZE
 	default 3072 if PM
 	default 2304
 
+config BT_SEND_ECC_EMULATION
+	default y
+
 endif # BT
 
 endif # BOARD_SLWRB4250B

--- a/boards/silabs/radio_boards/slwrb4255a/Kconfig.defconfig
+++ b/boards/silabs/radio_boards/slwrb4255a/Kconfig.defconfig
@@ -37,6 +37,9 @@ config MAIN_STACK_SIZE
 	default 3072 if PM
 	default 2304
 
+config BT_SEND_ECC_EMULATION
+	default y
+
 endif # BT
 
 endif # BOARD_SLWRB4255A

--- a/boards/silabs/radio_boards/slwrb4321a/slwrb4321a.dts
+++ b/boards/silabs/radio_boards/slwrb4321a/slwrb4321a.dts
@@ -18,6 +18,7 @@
 	chosen {
 		zephyr,console = &usart0;
 		zephyr,shell-uart = &usart0;
+		zephyr,uart-pipe = &usart0;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 	};

--- a/boards/silabs/radio_boards/xg24_rb4187c/Kconfig.defconfig
+++ b/boards/silabs/radio_boards/xg24_rb4187c/Kconfig.defconfig
@@ -37,6 +37,9 @@ config MAIN_STACK_SIZE
 	default 3072 if PM
 	default 2304
 
+config BT_SEND_ECC_EMULATION
+	default y
+
 endif # BT
 
 endif # BOARD_XG24_RB4187C

--- a/boards/silabs/radio_boards/xg24_rb4187c/xg24_rb4187c.dts
+++ b/boards/silabs/radio_boards/xg24_rb4187c/xg24_rb4187c.dts
@@ -17,6 +17,7 @@
 	chosen {
 		zephyr,console = &usart0;
 		zephyr,shell-uart = &usart0;
+		zephyr,uart-pipe = &usart0;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_partition;


### PR DESCRIPTION
~~Adds overlay and config files to tester app for xg24_rb4187c silabs board. Overlay enables uart for BTP communication and config file enables RTT logging.~~

Reworked the PR to enable for all silabs boards a default option for uart-pipe driver.
Added a Kconfig for tinycrypt ecc to be able to use SM features with xg24_rb4187c. There is an ongoing work that will provide a proper way to enable it for all boards #81776 