### PR TITLE
dts: espressif: Add flash size options to partition tables

### DIFF
--- a/dts/common/espressif/partitions_0x0_amp_16M.dtsi
+++ b/dts/common/espressif/partitions_0x0_amp_16M.dtsi
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2024 Espressif Systems (Shanghai) Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+ /* 16MB flash partition table */
+&flash0 {
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		boot_partition: partition@0 {
+			label = "mcuboot";
+			reg = <0x0 DT_SIZE_K(64)>;
+		};
+
+		slot0_partition: partition@20000 {
+			label = "image-0";
+			reg = <0x20000 DT_SIZE_K(6080)>;
+		};
+
+		slot0_appcpu_partition: partition@610000 {
+			label = "image-0-appcpu";
+			reg = <0x610000 DT_SIZE_K(1920)>;
+		};
+
+		slot1_partition: partition@7F0000 {
+			label = "image-1";
+			reg = <0x7F0000 DT_SIZE_K(6080)>;
+		};
+
+		slot1_appcpu_partition: partition@DE0000 {
+			label = "image-1-appcpu";
+			reg = <0xDE0000 DT_SIZE_K(1920)>;
+		};
+
+		storage_partition: partition@FC0000 {
+			label = "storage";
+			reg = <0xFC0000 DT_SIZE_K(128)>;
+		};
+
+		scratch_partition: partition@FE0000 {
+			   label = "image-scratch";
+			   reg = <0xFE0000 DT_SIZE_K(64)>;
+		};
+
+		coredump_partition: partition@FF0000 {
+			label = "coredump-partition";
+			reg = <0xFF0000 DT_SIZE_K(4)>;
+		};
+	};
+};

--- a/dts/common/espressif/partitions_0x0_amp_32M.dtsi
+++ b/dts/common/espressif/partitions_0x0_amp_32M.dtsi
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2024 Espressif Systems (Shanghai) Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+ /* 32MB flash partition table */
+&flash0 {
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		boot_partition: partition@0 {
+			label = "mcuboot";
+			reg = <0x0 DT_SIZE_K(64)>;
+		};
+
+		slot0_partition: partition@20000 {
+			label = "image-0";
+			reg = <0x20000 DT_SIZE_K(12352)>;
+		};
+
+		slot0_appcpu_partition: partition@C30000 {
+			label = "image-0-appcpu";
+			reg = <0xC30000 DT_SIZE_K(3840)>;
+		};
+
+		slot1_partition: partition@FF0000 {
+			label = "image-1";
+			reg = <0xFF0000 DT_SIZE_K(12352)>;
+		};
+
+		slot1_appcpu_partition: partition@1C00000 {
+			label = "image-1-appcpu";
+			reg = <0x1C00000 DT_SIZE_K(3840)>;
+		};
+
+		storage_partition: partition@1FC0000 {
+			label = "storage";
+			reg = <0x1FC0000 DT_SIZE_K(128)>;
+		};
+
+		scratch_partition: partition@1FE0000 {
+			   label = "image-scratch";
+			   reg = <0x1FE0000 DT_SIZE_K(64)>;
+		};
+
+		coredump_partition: partition@1FF0000 {
+			label = "coredump-partition";
+			reg = <0x1FF0000 DT_SIZE_K(4)>;
+		};
+	};
+};

--- a/dts/common/espressif/partitions_0x0_default_16M.dtsi
+++ b/dts/common/espressif/partitions_0x0_default_16M.dtsi
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2024 Espressif Systems (Shanghai) Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+ /* 16MB flash partition table */
+&flash0 {
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		boot_partition: partition@0 {
+			label = "mcuboot";
+			reg = <0x0 DT_SIZE_K(64)>;
+		};
+
+		slot0_partition: partition@20000 {
+			label = "image-0";
+			reg = <0x20000 DT_SIZE_K(8000)>;
+		};
+
+		slot1_partition: partition@7F0000 {
+			label = "image-1";
+			reg = <0x7F0000 DT_SIZE_K(8000)>;
+		};
+
+		storage_partition: partition@FC0000 {
+			label = "storage";
+			reg = <0xFC0000 DT_SIZE_K(128)>;
+		};
+
+		scratch_partition: partition@FE0000 {
+			   label = "image-scratch";
+			   reg = <0xFE0000 DT_SIZE_K(64)>;
+		};
+
+		coredump_partition: partition@FF0000 {
+			label = "coredump-partition";
+			reg = <0xFF0000 DT_SIZE_K(4)>;
+		};
+	};
+};

--- a/dts/common/espressif/partitions_0x0_default_32M.dtsi
+++ b/dts/common/espressif/partitions_0x0_default_32M.dtsi
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2024 Espressif Systems (Shanghai) Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+ /* 32MB flash partition table */
+&flash0 {
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		boot_partition: partition@0 {
+			label = "mcuboot";
+			reg = <0x0 DT_SIZE_K(64)>;
+		};
+
+		slot0_partition: partition@20000 {
+			label = "image-0";
+			reg = <0x20000 DT_SIZE_K(16192)>;
+		};
+
+		slot1_partition: partition@FF0000 {
+			label = "image-1";
+			reg = <0xFF0000 DT_SIZE_K(16192)>;
+		};
+
+		storage_partition: partition@1FC0000 {
+			label = "storage";
+			reg = <0x1FC0000 DT_SIZE_K(128)>;
+		};
+
+		scratch_partition: partition@1FE0000 {
+			   label = "image-scratch";
+			   reg = <0x1FE0000 DT_SIZE_K(64)>;
+		};
+
+		coredump_partition: partition@1FF0000 {
+			label = "coredump-partition";
+			reg = <0x1FF0000 DT_SIZE_K(4)>;
+		};
+	};
+};

--- a/dts/common/espressif/partitions_0x1000_amp_16M.dtsi
+++ b/dts/common/espressif/partitions_0x1000_amp_16M.dtsi
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2024 Espressif Systems (Shanghai) Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+ /* 16MB flash partition table */
+&flash0 {
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		boot_partition: partition@1000 {
+			label = "mcuboot";
+			reg = <0x1000 DT_SIZE_K(60)>;
+		};
+
+		slot0_partition: partition@20000 {
+			label = "image-0";
+			reg = <0x20000 DT_SIZE_K(6080)>;
+		};
+
+		slot0_appcpu_partition: partition@610000 {
+			label = "image-0-appcpu";
+			reg = <0x610000 DT_SIZE_K(1920)>;
+		};
+
+		slot1_partition: partition@7F0000 {
+			label = "image-1";
+			reg = <0x7F0000 DT_SIZE_K(6080)>;
+		};
+
+		slot1_appcpu_partition: partition@DE0000 {
+			label = "image-1-appcpu";
+			reg = <0xDE0000 DT_SIZE_K(1920)>;
+		};
+
+		storage_partition: partition@FC0000 {
+			label = "storage";
+			reg = <0xFC0000 DT_SIZE_K(128)>;
+		};
+
+		scratch_partition: partition@FE0000 {
+			   label = "image-scratch";
+			   reg = <0xFE0000 DT_SIZE_K(64)>;
+		};
+
+		coredump_partition: partition@FF0000 {
+			label = "coredump-partition";
+			reg = <0xFF0000 DT_SIZE_K(4)>;
+		};
+	};
+};

--- a/dts/common/espressif/partitions_0x1000_amp_32M.dtsi
+++ b/dts/common/espressif/partitions_0x1000_amp_32M.dtsi
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2024 Espressif Systems (Shanghai) Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+ /* 32MB flash partition table */
+&flash0 {
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		boot_partition: partition@1000 {
+			label = "mcuboot";
+			reg = <0x1000 DT_SIZE_K(60)>;
+		};
+
+		slot0_partition: partition@20000 {
+			label = "image-0";
+			reg = <0x20000 DT_SIZE_K(12352)>;
+		};
+
+		slot0_appcpu_partition: partition@C30000 {
+			label = "image-0-appcpu";
+			reg = <0xC24000 DT_SIZE_K(3840)>;
+		};
+
+		slot1_partition: partition@FF0000 {
+			label = "image-1";
+			reg = <0xFF0000 DT_SIZE_K(12352)>;
+		};
+
+		slot1_appcpu_partition: partition@1C00000 {
+			label = "image-1-appcpu";
+			reg = <0x1C00000 DT_SIZE_K(3840)>;
+		};
+
+		storage_partition: partition@1FC0000 {
+			label = "storage";
+			reg = <0x1FC0000 DT_SIZE_K(128)>;
+		};
+
+		scratch_partition: partition@1FE0000 {
+			   label = "image-scratch";
+			   reg = <0x1FE0000 DT_SIZE_K(64)>;
+		};
+
+		coredump_partition: partition@1FF0000 {
+			label = "coredump-partition";
+			reg = <0x1FF0000 DT_SIZE_K(4)>;
+		};
+	};
+};

--- a/dts/common/espressif/partitions_0x1000_default_16M.dtsi
+++ b/dts/common/espressif/partitions_0x1000_default_16M.dtsi
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2024 Espressif Systems (Shanghai) Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+ /* 16MB flash partition table */
+&flash0 {
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		boot_partition: partition@1000 {
+			label = "mcuboot";
+			reg = <0x1000 DT_SIZE_K(60)>;
+		};
+
+		slot0_partition: partition@20000 {
+			label = "image-0";
+			reg = <0x20000 DT_SIZE_K(8000)>;
+		};
+
+		slot1_partition: partition@7F0000 {
+			label = "image-1";
+			reg = <0x7F0000 DT_SIZE_K(8000)>;
+		};
+
+		storage_partition: partition@FC0000 {
+			label = "storage";
+			reg = <0xFC0000 DT_SIZE_K(128)>;
+		};
+
+		scratch_partition: partition@FE0000 {
+			   label = "image-scratch";
+			   reg = <0xFE0000 DT_SIZE_K(64)>;
+		};
+
+		coredump_partition: partition@FF0000 {
+			label = "coredump-partition";
+			reg = <0xFF0000 DT_SIZE_K(4)>;
+		};
+	};
+};

--- a/dts/common/espressif/partitions_0x1000_default_32M.dtsi
+++ b/dts/common/espressif/partitions_0x1000_default_32M.dtsi
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2024 Espressif Systems (Shanghai) Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+ /* 32MB flash partition table */
+&flash0 {
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		boot_partition: partition@1000 {
+			label = "mcuboot";
+			reg = <0x1000 DT_SIZE_K(60)>;
+		};
+
+		slot0_partition: partition@20000 {
+			label = "image-0";
+			reg = <0x20000 DT_SIZE_K(16192)>;
+		};
+
+		slot1_partition: partition@FF0000 {
+			label = "image-1";
+			reg = <0xFF0000 DT_SIZE_K(16192)>;
+		};
+
+		storage_partition: partition@1FC0000 {
+			label = "storage";
+			reg = <0x1FC0000 DT_SIZE_K(128)>;
+		};
+
+		scratch_partition: partition@1FE0000 {
+			   label = "image-scratch";
+			   reg = <0x1FE0000 DT_SIZE_K(64)>;
+		};
+
+		coredump_partition: partition@1FF0000 {
+			label = "coredump-partition";
+			reg = <0x1FF0000 DT_SIZE_K(4)>;
+		};
+	};
+};


### PR DESCRIPTION
Update the list of available partition tables with more size options.