### PR TITLE
python: Format and sort imports

### DIFF
--- a/.ruff-excludes.toml
+++ b/.ruff-excludes.toml
@@ -231,12 +231,6 @@
     "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
     "UP010",    # https://docs.astral.sh/ruff/rules/unnecessary-future-import
 ]
-"./samples/modules/thrift/hello/client/hello_client.py" = [
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
-]
-"./samples/net/cellular_modem/server/te.py" = [
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
-]
 "./samples/net/cellular_modem/server/te_udp_echo.py" = [
     "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
     "UP039",    # https://docs.astral.sh/ruff/rules/unnecessary-class-parentheses
@@ -245,27 +239,12 @@
     "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
     "UP039",    # https://docs.astral.sh/ruff/rules/unnecessary-class-parentheses
 ]
-"./samples/net/cloud/aws_iot_mqtt/src/creds/convert_keys.py" = [
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
-]
 "./samples/sensor/sensor_shell/pytest/test_sensor_shell.py" = [
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
-]
-"./samples/subsys/profiling/perf/pytest/test_perf.py" = [
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
-]
-"./samples/subsys/testsuite/pytest/basic/pytest/conftest.py" = [
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
 ]
 "./samples/subsys/testsuite/pytest/basic/pytest/test_sample.py" = [
     "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
     "SIM112",   # https://docs.astral.sh/ruff/rules/uncapitalized-environment-variables
-]
-"./samples/subsys/zbus/remote_mock/remote_mock.py" = [
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
-]
-"./samples/subsys/zbus/uart_bridge/decoder.py" = [
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
 ]
 "./scripts/build/check_init_priorities.py" = [
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
@@ -278,9 +257,6 @@
 "./scripts/build/check_init_priorities_test.py" = [
     "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
     "UP026",    # https://docs.astral.sh/ruff/rules/deprecated-mock-import
-]
-"./scripts/build/dir_is_writeable.py" = [
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
 ]
 "./scripts/build/elf_parser.py" = [
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
@@ -400,9 +376,6 @@
     "SIM115",   # https://docs.astral.sh/ruff/rules/open-file-with-context-handler
     "UP039",    # https://docs.astral.sh/ruff/rules/unnecessary-class-parentheses
 ]
-"./scripts/build/llext_slidlib.py" = [
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
-]
 "./scripts/build/mergehex.py" = [
     "B904",     # https://docs.astral.sh/ruff/rules/raise-without-from-inside-except
     "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
@@ -434,12 +407,6 @@
     "UP015",    # https://docs.astral.sh/ruff/rules/redundant-open-modes
     "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
     "UP032",    # https://docs.astral.sh/ruff/rules/f-string
-]
-"./scripts/build/user_wordsize.py" = [
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
-]
-"./scripts/check_maintainers.py" = [
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
 ]
 "./scripts/ci/check_compliance.py" = [
     "B904",     # https://docs.astral.sh/ruff/rules/raise-without-from-inside-except
@@ -509,9 +476,6 @@
     "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
     "SIM115",   # https://docs.astral.sh/ruff/rules/open-file-with-context-handler
     "UP015",    # https://docs.astral.sh/ruff/rules/redundant-open-modes
-]
-"./scripts/coredump/gdbstubs/__init__.py" = [
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
 ]
 "./scripts/coredump/gdbstubs/arch/arm64.py" = [
     "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
@@ -646,9 +610,6 @@
     "UP015",    # https://docs.astral.sh/ruff/rules/redundant-open-modes
     "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
 ]
-"./scripts/generate_usb_vif/constants/xml_constants.py" = [
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
-]
 "./scripts/generate_usb_vif/generate_vif.py" = [
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
     "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
@@ -687,9 +648,6 @@
 "./scripts/kconfig/hardenconfig.py" = [
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
     "UP032",    # https://docs.astral.sh/ruff/rules/f-string
-]
-"./scripts/kconfig/kconfig.py" = [
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
 ]
 "./scripts/kconfig/kconfigfunctions.py" = [
     "B011",     # https://docs.astral.sh/ruff/rules/assert-false
@@ -785,12 +743,6 @@
     "SIM115",   # https://docs.astral.sh/ruff/rules/open-file-with-context-handler
     "UP015",    # https://docs.astral.sh/ruff/rules/redundant-open-modes
 ]
-"./scripts/logging/dictionary/log_parser_uart.py" = [
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
-]
-"./scripts/logging/dictionary/parserlib.py" = [
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
-]
 "./scripts/make_bugs_pickle.py" = [
     "UP006",    # https://docs.astral.sh/ruff/rules/non-pep585-annotation
     "UP035",    # https://docs.astral.sh/ruff/rules/deprecated-import
@@ -850,9 +802,6 @@
     "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
     "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
 ]
-"./scripts/pylib/pytest-twister-harness/src/twister_harness/helpers/mcumgr.py" = [
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
-]
 "./scripts/pylib/pytest-twister-harness/src/twister_harness/helpers/shell.py" = [
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
     "E741",     # https://docs.astral.sh/ruff/rules/ambiguous-variable-name
@@ -888,12 +837,6 @@
     "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
     "UP015",    # https://docs.astral.sh/ruff/rules/redundant-open-modes
     "UP035",    # https://docs.astral.sh/ruff/rules/deprecated-import
-]
-"./scripts/pylib/pytest-twister-harness/tests/fixtures/mcumgr_fixture_test.py" = [
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
-]
-"./scripts/pylib/pytest-twister-harness/tests/helpers/shell_mcuboot_command_parser_test.py" = [
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
 ]
 "./scripts/pylib/pytest-twister-harness/tests/helpers/shell_test.py" = [
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
@@ -1206,9 +1149,6 @@
     "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
     "UP026",    # https://docs.astral.sh/ruff/rules/deprecated-mock-import
 ]
-"./scripts/tests/twister/test_mixins.py" = [
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
-]
 "./scripts/tests/twister/test_platform.py" = [
     "B011",     # https://docs.astral.sh/ruff/rules/assert-false
     "E402",     # https://docs.astral.sh/ruff/rules/module-import-not-at-top-of-file
@@ -1283,9 +1223,6 @@
     "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
     "UP015",    # https://docs.astral.sh/ruff/rules/redundant-open-modes
     "UP026",    # https://docs.astral.sh/ruff/rules/deprecated-mock-import
-]
-"./scripts/tests/twister_blackbox/test_data/tests/pytest/pytest/conftest.py" = [
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
 ]
 "./scripts/tests/twister_blackbox/test_data/tests/pytest/pytest/test_sample.py" = [
     "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
@@ -1422,17 +1359,8 @@
     "F541",     # https://docs.astral.sh/ruff/rules/f-string-missing-placeholders
     "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
 ]
-"./scripts/utils/migrate_includes.py" = [
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
-]
 "./scripts/utils/migrate_mcumgr_kconfigs.py" = [
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
-]
-"./scripts/utils/migrate_posix_kconfigs.py" = [
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
-]
-"./scripts/utils/migrate_sys_init.py" = [
     "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
 ]
 "./scripts/utils/ntc_thermistor_table.py" = [
@@ -1447,9 +1375,6 @@
     "UP007",    # https://docs.astral.sh/ruff/rules/non-pep604-annotation
     "UP035",    # https://docs.astral.sh/ruff/rules/deprecated-import
 ]
-"./scripts/utils/twister_to_list.py" = [
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
-]
 "./scripts/west_commands/bindesc.py" = [
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
     "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
@@ -1457,9 +1382,6 @@
 ]
 "./scripts/west_commands/blobs.py" = [
     "F541",     # https://docs.astral.sh/ruff/rules/f-string-missing-placeholders
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
-]
-"./scripts/west_commands/boards.py" = [
     "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
 ]
 "./scripts/west_commands/build.py" = [
@@ -1725,9 +1647,6 @@
     "SIM115",   # https://docs.astral.sh/ruff/rules/open-file-with-context-handler
     "SIM300",   # https://docs.astral.sh/ruff/rules/yoda-conditions
 ]
-"./scripts/west_commands/shields.py" = [
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
-]
 "./scripts/west_commands/sign.py" = [
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
     "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
@@ -1773,9 +1692,6 @@
 "./scripts/west_commands/tests/test_gd32isp.py" = [
     "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
 ]
-"./scripts/west_commands/tests/test_imports.py" = [
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
-]
 "./scripts/west_commands/tests/test_mdb.py" = [
     "F541",     # https://docs.astral.sh/ruff/rules/f-string-missing-placeholders
     "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
@@ -1799,9 +1715,6 @@
 "./scripts/west_commands/tests/test_stm32flash.py" = [
     "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
     "SIM117",   # https://docs.astral.sh/ruff/rules/multiple-with-statements
-]
-"./scripts/west_commands/tests/test_twister.py" = [
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
 ]
 "./scripts/west_commands/tests/test_xsdb.py" = [
     "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
@@ -1856,12 +1769,6 @@
     "UP008",    # https://docs.astral.sh/ruff/rules/super-call-with-parameters
     "UP015",    # https://docs.astral.sh/ruff/rules/redundant-open-modes
 ]
-"./scripts/west_commands/zspdx/spdxids.py" = [
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
-]
-"./scripts/west_commands/zspdx/util.py" = [
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
-]
 "./scripts/west_commands/zspdx/walker.py" = [
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
     "F541",     # https://docs.astral.sh/ruff/rules/f-string-missing-placeholders
@@ -1877,9 +1784,6 @@
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
     "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
     "UP032",    # https://docs.astral.sh/ruff/rules/f-string
-]
-"./soc/intel/intel_adsp/tools/acetool.py" = [
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
 ]
 "./soc/intel/intel_adsp/tools/cavstool.py" = [
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
@@ -1942,15 +1846,6 @@
 "./soc/silabs/silabs_sim3/sim3u/gen_crossbar_config.py" = [
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
 ]
-"./tests/boot/with_mcumgr/pytest/test_downgrade_prevention.py" = [
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
-]
-"./tests/boot/with_mcumgr/pytest/test_upgrade.py" = [
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
-]
-"./tests/boot/with_mcumgr/pytest/utils.py" = [
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
-]
 "./tests/boot/with_mcumgr/pytest/west_sign_wrapper.py" = [
     "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
     "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
@@ -1962,15 +1857,9 @@
     "UP007",    # https://docs.astral.sh/ruff/rules/non-pep604-annotation
     "UP035",    # https://docs.astral.sh/ruff/rules/deprecated-import
 ]
-"./tests/drivers/can/host/pytest/conftest.py" = [
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
-]
 "./tests/drivers/can/host/pytest/test_can.py" = [
     "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
     "UP039",    # https://docs.astral.sh/ruff/rules/unnecessary-class-parentheses
-]
-"./tests/kernel/timer/timer_behavior/pytest/conftest.py" = [
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
 ]
 "./tests/kernel/timer/timer_behavior/pytest/saleae_logic2.py" = [
     "B905",     # https://docs.astral.sh/ruff/rules/zip-without-explicit-strict
@@ -1984,9 +1873,6 @@
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
     "UP015",    # https://docs.astral.sh/ruff/rules/redundant-open-modes
 ]
-"./tests/misc/llext-edk/pytest/test_edk.py" = [
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
-]
 "./tests/net/lib/lwm2m/interop/pytest/conftest.py" = [
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
     "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
@@ -1994,9 +1880,6 @@
 "./tests/net/lib/lwm2m/interop/pytest/leshan.py" = [
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
     "F541",     # https://docs.astral.sh/ruff/rules/f-string-missing-placeholders
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
-]
-"./tests/net/lib/lwm2m/interop/pytest/test_blockwise.py" = [
     "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
 ]
 "./tests/net/lib/lwm2m/interop/pytest/test_bootstrap.py" = [
@@ -2018,29 +1901,14 @@
     "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
     "SIM118",   # https://docs.astral.sh/ruff/rules/in-dict-keys
 ]
-"./tests/net/socket/tls_configurations/pytest/conftest.py" = [
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
-]
 "./tests/net/socket/tls_configurations/pytest/test_app_vs_openssl.py" = [
     "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
     "UP032",    # https://docs.astral.sh/ruff/rules/f-string
-]
-"./tests/net/socket/udp/generate-c-string.py" = [
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
-]
-"./tests/subsys/debug/gdbstub/pytest/conftest.py" = [
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
 ]
 "./tests/subsys/debug/gdbstub/pytest/test_gdbstub.py" = [
     "E402",     # https://docs.astral.sh/ruff/rules/module-import-not-at-top-of-file
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
     "F541",     # https://docs.astral.sh/ruff/rules/f-string-missing-placeholders
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
-]
-"./tests/subsys/logging/dictionary/pytest/conftest.py" = [
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
-]
-"./tests/subsys/logging/dictionary/pytest/test_logging_dictionary.py" = [
     "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
 ]
 "./tests/ztest/ztest_param/pytest/test_parameters.py" = [

--- a/samples/modules/thrift/hello/client/hello_client.py
+++ b/samples/modules/thrift/hello/client/hello_client.py
@@ -14,12 +14,12 @@ Usage:
 
 import argparse
 import sys
+
 sys.path.append('gen-py')
 
-from thrift.protocol import TBinaryProtocol
-from thrift.transport import TTransport
-from thrift.transport import TSocket
 from hello import Hello
+from thrift.protocol import TBinaryProtocol
+from thrift.transport import TSocket, TTransport
 
 
 def parse_args():

--- a/samples/net/cellular_modem/server/te.py
+++ b/samples/net/cellular_modem/server/te.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import signal
+
 from te_udp_echo import TEUDPEcho
 from te_udp_receive import TEUDPReceive
 

--- a/samples/net/cloud/aws_iot_mqtt/src/creds/convert_keys.py
+++ b/samples/net/cloud/aws_iot_mqtt/src/creds/convert_keys.py
@@ -1,8 +1,9 @@
 # Copyright (c) 2023 Lucas Dietrich <ld.adecy@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
 
-import os
 import glob
+import os
+
 
 def bin2array(name, fin, fout):
     with open(fin, 'rb') as f:

--- a/samples/subsys/profiling/perf/pytest/test_perf.py
+++ b/samples/subsys/profiling/perf/pytest/test_perf.py
@@ -7,8 +7,7 @@
 import logging
 import re
 
-from twister_harness import Shell
-from twister_harness import DeviceAdapter
+from twister_harness import DeviceAdapter, Shell
 
 logger = logging.getLogger(__name__)
 

--- a/samples/subsys/testsuite/pytest/basic/pytest/conftest.py
+++ b/samples/subsys/testsuite/pytest/basic/pytest/conftest.py
@@ -4,6 +4,7 @@
 
 import pytest
 
+
 # add option "--cmdopt" to pytest, or it will report "unknown option"
 # this option is passed from twister.
 def pytest_addoption(parser):

--- a/samples/subsys/zbus/remote_mock/remote_mock.py
+++ b/samples/subsys/zbus/remote_mock/remote_mock.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
 # Copyright (c) 2022 Rodrigo Peixoto <rodrigopex@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
-import serial
+import argparse
 import json
 from time import sleep
-import argparse
+
+import serial
 
 j = """
 [

--- a/samples/subsys/zbus/uart_bridge/decoder.py
+++ b/samples/subsys/zbus/uart_bridge/decoder.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 # Copyright (c) 2022 Rodrigo Peixoto <rodrigopex@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
-import serial
-import json
 import argparse
+import json
+
+import serial
 
 j = """
 [

--- a/scripts/check_maintainers.py
+++ b/scripts/check_maintainers.py
@@ -7,9 +7,10 @@
 import argparse
 import sys
 
-from github_helpers import get_github_object
 from get_maintainer import Maintainers
 from github.GithubException import UnknownObjectException
+from github_helpers import get_github_object
+
 
 def parse_args():
     parser = argparse.ArgumentParser(

--- a/scripts/coredump/gdbstubs/__init__.py
+++ b/scripts/coredump/gdbstubs/__init__.py
@@ -4,12 +4,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from gdbstubs.arch.x86 import GdbStub_x86
-from gdbstubs.arch.x86_64 import GdbStub_x86_64
+from gdbstubs.arch.arm64 import GdbStub_ARM64
 from gdbstubs.arch.arm_cortex_m import GdbStub_ARM_CortexM
 from gdbstubs.arch.risc_v import GdbStub_RISC_V
+from gdbstubs.arch.x86 import GdbStub_x86
+from gdbstubs.arch.x86_64 import GdbStub_x86_64
 from gdbstubs.arch.xtensa import GdbStub_Xtensa
-from gdbstubs.arch.arm64 import GdbStub_ARM64
 
 
 class TgtCode:

--- a/scripts/generate_usb_vif/constants/xml_constants.py
+++ b/scripts/generate_usb_vif/constants/xml_constants.py
@@ -5,8 +5,7 @@
 
 """This file contains XML constants defined to be used by generate_vif.py"""
 
-from constants import other_constants
-from constants import vif_element_constants
+from constants import other_constants, vif_element_constants
 
 XML_ENCODING = "utf-8"
 XML_ELEMENT_NAME_PREFIX = "vif"

--- a/scripts/kconfig/kconfig.py
+++ b/scripts/kconfig/kconfig.py
@@ -23,8 +23,17 @@ import textwrap
 
 # Zephyr doesn't use tristate symbols. They're supported here just to make the
 # script a bit more generic.
-from kconfiglib import Kconfig, split_expr, expr_value, expr_str, BOOL, \
-                       TRISTATE, TRI_TO_STR, AND, OR
+from kconfiglib import (
+    AND,
+    BOOL,
+    OR,
+    TRI_TO_STR,
+    TRISTATE,
+    Kconfig,
+    expr_str,
+    expr_value,
+    split_expr,
+)
 
 
 def main():

--- a/scripts/logging/dictionary/log_parser_uart.py
+++ b/scripts/logging/dictionary/log_parser_uart.py
@@ -12,13 +12,13 @@ log data taken directly from input serialport and print
 the log messages.
 """
 
-import serial
-import time
 import argparse
 import logging
 import sys
+import time
 
 import parserlib
+import serial
 
 LOGGER_FORMAT = "%(message)s"
 logger = logging.getLogger("parser")

--- a/scripts/logging/dictionary/parserlib.py
+++ b/scripts/logging/dictionary/parserlib.py
@@ -12,8 +12,8 @@ This library along with dictionary_parser converts the
 input binary data to the log using log database.
 """
 
-import sys
 import logging
+import sys
 
 import dictionary_parser
 from dictionary_parser.log_database import LogDatabase

--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/helpers/mcumgr.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/helpers/mcumgr.py
@@ -6,10 +6,9 @@ from __future__ import annotations
 import logging
 import re
 import shlex
-
-from subprocess import check_output, getstatusoutput
-from pathlib import Path
 from dataclasses import dataclass
+from pathlib import Path
+from subprocess import check_output, getstatusoutput
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/pylib/pytest-twister-harness/tests/fixtures/mcumgr_fixture_test.py
+++ b/scripts/pylib/pytest-twister-harness/tests/fixtures/mcumgr_fixture_test.py
@@ -2,10 +2,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import pytest
 import textwrap
-
 from unittest import mock
+
+import pytest
 from twister_harness.helpers.mcumgr import MCUmgr, MCUmgrException
 
 

--- a/scripts/pylib/pytest-twister-harness/tests/helpers/shell_mcuboot_command_parser_test.py
+++ b/scripts/pylib/pytest-twister-harness/tests/helpers/shell_mcuboot_command_parser_test.py
@@ -4,7 +4,7 @@
 
 import textwrap
 
-from twister_harness.helpers.shell import ShellMCUbootCommandParsed, ShellMCUbootArea
+from twister_harness.helpers.shell import ShellMCUbootArea, ShellMCUbootCommandParsed
 
 
 def test_if_mcuboot_command_output_is_parsed_two_areas() -> None:

--- a/scripts/tests/twister/test_mixins.py
+++ b/scripts/tests/twister/test_mixins.py
@@ -7,6 +7,7 @@ Tests for the mixins class
 """
 
 import os
+
 import pytest
 
 

--- a/scripts/tests/twister_blackbox/test_data/tests/pytest/pytest/conftest.py
+++ b/scripts/tests/twister_blackbox/test_data/tests/pytest/pytest/conftest.py
@@ -4,6 +4,7 @@
 
 import pytest
 
+
 # add option "--cmdopt" to pytest, or it will report "unknown option"
 # this option is passed from twister.
 def pytest_addoption(parser):

--- a/scripts/utils/migrate_includes.py
+++ b/scripts/utils/migrate_includes.py
@@ -16,10 +16,9 @@ SPDX-License-Identifier: Apache-2.0
 """
 
 import argparse
-from pathlib import Path
 import re
 import sys
-
+from pathlib import Path
 
 ZEPHYR_BASE = Path(__file__).parents[2]
 

--- a/scripts/utils/migrate_posix_kconfigs.py
+++ b/scripts/utils/migrate_posix_kconfigs.py
@@ -18,10 +18,9 @@ SPDX-License-Identifier: Apache-2.0
 """
 
 import argparse
-from pathlib import Path
 import re
 import sys
-
+from pathlib import Path
 
 ZEPHYR_BASE = Path(__file__).parents[2]
 

--- a/scripts/utils/migrate_sys_init.py
+++ b/scripts/utils/migrate_sys_init.py
@@ -15,8 +15,8 @@ SPDX-License-Identifier: Apache-2.0
 """
 
 import argparse
-from pathlib import Path
 import re
+from pathlib import Path
 
 
 def update_sys_init(project, dry_run):

--- a/scripts/utils/twister_to_list.py
+++ b/scripts/utils/twister_to_list.py
@@ -16,7 +16,6 @@ from pathlib import Path
 
 from ruamel.yaml import YAML
 
-
 FIELDS = (
     "arch_exclude",
     "arch_allow",

--- a/scripts/west_commands/boards.py
+++ b/scripts/west_commands/boards.py
@@ -4,18 +4,18 @@
 
 import argparse
 import os
-from pathlib import Path
 import re
 import sys
 import textwrap
+from pathlib import Path
 
 from west.commands import WestCommand
-
 from zephyr_ext_common import ZEPHYR_BASE
 
 sys.path.append(os.fspath(Path(__file__).parent.parent))
 import list_boards
 import zephyr_module
+
 
 class Boards(WestCommand):
 

--- a/scripts/west_commands/shields.py
+++ b/scripts/west_commands/shields.py
@@ -5,18 +5,18 @@
 
 import argparse
 import os
-from pathlib import Path
 import re
 import sys
 import textwrap
+from pathlib import Path
 
 from west.commands import WestCommand
-
 from zephyr_ext_common import ZEPHYR_BASE
 
 sys.path.append(os.fspath(Path(__file__).parent.parent))
 import list_shields
 import zephyr_module
+
 
 class Shields(WestCommand):
 

--- a/scripts/west_commands/tests/test_imports.py
+++ b/scripts/west_commands/tests/test_imports.py
@@ -4,6 +4,7 @@
 
 from runners.core import ZephyrBinaryRunner
 
+
 def test_runner_imports():
     # Ensure that all runner modules are imported and returned by
     # get_runners().

--- a/scripts/west_commands/tests/test_twister.py
+++ b/scripts/west_commands/tests/test_twister.py
@@ -2,11 +2,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import argparse
 from argparse import Namespace
 
-from twister_cmd import Twister
 import pytest
-import argparse
+from twister_cmd import Twister
 
 TEST_CASES = [
     {

--- a/soc/intel/intel_adsp/tools/acetool.py
+++ b/soc/intel/intel_adsp/tools/acetool.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import asyncio
+
 import cavstool
 
 if __name__ == "__main__":

--- a/tests/boot/with_mcumgr/pytest/test_downgrade_prevention.py
+++ b/tests/boot/with_mcumgr/pytest/test_downgrade_prevention.py
@@ -4,17 +4,12 @@
 from __future__ import annotations
 
 import logging
-
 from pathlib import Path
-from twister_harness import DeviceAdapter, Shell, MCUmgr
-from twister_harness.helpers.utils import (
-    find_in_config,
-    match_lines,
-    match_no_lines
-)
-from utils import check_with_shell_command, check_with_mcumgr_command
-from test_upgrade import create_signed_image
 
+from test_upgrade import create_signed_image
+from twister_harness import DeviceAdapter, MCUmgr, Shell
+from twister_harness.helpers.utils import find_in_config, match_lines, match_no_lines
+from utils import check_with_mcumgr_command, check_with_shell_command
 
 logger = logging.getLogger(__name__)
 

--- a/tests/boot/with_mcumgr/pytest/test_upgrade.py
+++ b/tests/boot/with_mcumgr/pytest/test_upgrade.py
@@ -3,17 +3,13 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-import pytest
 import logging
-
 from pathlib import Path
-from twister_harness import DeviceAdapter, Shell, MCUmgr
-from twister_harness.helpers.utils import (
-    find_in_config,
-    match_lines,
-    match_no_lines
-)
-from utils import check_with_shell_command, check_with_mcumgr_command
+
+import pytest
+from twister_harness import DeviceAdapter, MCUmgr, Shell
+from twister_harness.helpers.utils import find_in_config, match_lines, match_no_lines
+from utils import check_with_mcumgr_command, check_with_shell_command
 from west_sign_wrapper import west_sign_with_imgtool
 
 logger = logging.getLogger(__name__)

--- a/tests/boot/with_mcumgr/pytest/utils.py
+++ b/tests/boot/with_mcumgr/pytest/utils.py
@@ -5,9 +5,8 @@ from __future__ import annotations
 
 import logging
 
-from twister_harness import Shell, MCUmgr
+from twister_harness import MCUmgr, Shell
 from twister_harness.helpers.shell import ShellMCUbootCommandParsed
-
 
 logger = logging.getLogger(__name__)
 

--- a/tests/drivers/can/host/pytest/conftest.py
+++ b/tests/drivers/can/host/pytest/conftest.py
@@ -6,14 +6,13 @@
 Configuration of Zephyr CAN <=> host CAN test suite.
 """
 
-import re
 import logging
+import re
+
 import pytest
-
-from twister_harness import DeviceAdapter, Shell
-
 from can import Bus, BusABC
 from can_shell import CanShellBus
+from twister_harness import DeviceAdapter, Shell
 
 logger = logging.getLogger(__name__)
 

--- a/tests/kernel/timer/timer_behavior/pytest/conftest.py
+++ b/tests/kernel/timer/timer_behavior/pytest/conftest.py
@@ -2,9 +2,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import pytest
-
 from pathlib import Path
+
+import pytest
 
 
 def pytest_addoption(parser):

--- a/tests/misc/llext-edk/pytest/test_edk.py
+++ b/tests/misc/llext-edk/pytest/test_edk.py
@@ -4,12 +4,12 @@
 
 import logging
 import os
-import pytest
 import shutil
 import tempfile
-
 from pathlib import Path
 from subprocess import check_output
+
+import pytest
 from twister_harness import DeviceAdapter
 
 logger = logging.getLogger(__name__)

--- a/tests/net/lib/lwm2m/interop/pytest/test_blockwise.py
+++ b/tests/net/lib/lwm2m/interop/pytest/test_blockwise.py
@@ -9,17 +9,16 @@ SPDX-License-Identifier: Apache-2.0
 
 """
 
-import time
-import logging
-import zlib
-import re
-import random
-import string
 import binascii
-from leshan import Leshan
+import logging
+import random
+import re
+import string
+import time
+import zlib
 
-from twister_harness import Shell
-from twister_harness import DeviceAdapter
+from leshan import Leshan
+from twister_harness import DeviceAdapter, Shell
 
 logger = logging.getLogger(__name__)
 

--- a/tests/net/socket/udp/generate-c-string.py
+++ b/tests/net/socket/udp/generate-c-string.py
@@ -7,7 +7,6 @@
 from argparse import ArgumentParser
 from math import ceil
 
-
 CHUNK = "This is a fragment of generated C string. "
 
 

--- a/tests/subsys/logging/dictionary/pytest/test_logging_dictionary.py
+++ b/tests/subsys/logging/dictionary/pytest/test_logging_dictionary.py
@@ -10,9 +10,9 @@ Pytest harness to test the output of the dictionary logging.
 
 import logging
 import os
+import re
 import shlex
 import subprocess
-import re
 
 from twister_harness import DeviceAdapter
 


### PR DESCRIPTION
`ruff check --select I001 --fix` applied to python files that had this as only issue.