### PR TITLE
Bluetooth: ISO: Removed unused pool and funcs/macros

### DIFF
--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -58,13 +58,6 @@ static struct bt_iso_recv_info iso_info_data[CONFIG_BT_ISO_RX_BUF_COUNT];
 #define iso_info(buf) (&iso_info_data[net_buf_id(buf)])
 #endif /* CONFIG_BT_ISO_RX */
 
-#if defined(CONFIG_BT_ISO_UNICAST) || defined(CONFIG_BT_ISO_BROADCAST)
-NET_BUF_POOL_FIXED_DEFINE(iso_tx_pool, CONFIG_BT_ISO_TX_BUF_COUNT,
-			  BT_ISO_SDU_BUF_SIZE(CONFIG_BT_ISO_TX_MTU),
-			  CONFIG_BT_CONN_TX_USER_DATA_SIZE, NULL);
-
-#endif /* CONFIG_BT_ISO_UNICAST || CONFIG_BT_ISO_BROADCAST */
-
 struct bt_conn iso_conns[CONFIG_BT_ISO_MAX_CHAN];
 
 /* TODO: Allow more than one server? */
@@ -181,27 +174,6 @@ static struct bt_conn *iso_new(void)
 	}
 
 	return iso;
-}
-
-#if defined(CONFIG_NET_BUF_LOG)
-struct net_buf *bt_iso_create_pdu_timeout_debug(struct net_buf_pool *pool, size_t reserve,
-						k_timeout_t timeout, const char *func, int line)
-#else
-struct net_buf *bt_iso_create_pdu_timeout(struct net_buf_pool *pool, size_t reserve,
-					  k_timeout_t timeout)
-#endif
-{
-	if (!pool) {
-		pool = &iso_tx_pool;
-	}
-
-	reserve += sizeof(struct bt_hci_iso_sdu_hdr);
-
-#if defined(CONFIG_NET_BUF_LOG)
-	return bt_conn_create_pdu_timeout_debug(pool, reserve, timeout, func, line);
-#else
-	return bt_conn_create_pdu_timeout(pool, reserve, timeout);
-#endif
 }
 
 static int hci_le_setup_iso_data_path(const struct bt_conn *iso, uint8_t dir,

--- a/subsys/bluetooth/host/iso_internal.h
+++ b/subsys/bluetooth/host/iso_internal.h
@@ -114,47 +114,6 @@ void bt_iso_disconnected(struct bt_conn *iso);
 /* Notify ISO connected channels of security changed */
 void bt_iso_security_changed(struct bt_conn *acl, uint8_t hci_status);
 
-/* Allocate ISO PDU */
-#if defined(CONFIG_NET_BUF_LOG)
-struct net_buf *bt_iso_create_pdu_timeout_debug(struct net_buf_pool *pool,
-						size_t reserve,
-						k_timeout_t timeout,
-						const char *func, int line);
-#define bt_iso_create_pdu_timeout(_pool, _reserve, _timeout) \
-	bt_iso_create_pdu_timeout_debug(_pool, _reserve, _timeout, \
-					__func__, __LINE__)
-
-#define bt_iso_create_pdu(_pool, _reserve) \
-	bt_iso_create_pdu_timeout_debug(_pool, _reserve, K_FOREVER, \
-					__func__, __LINE__)
-#else
-struct net_buf *bt_iso_create_pdu_timeout(struct net_buf_pool *pool,
-					  size_t reserve, k_timeout_t timeout);
-
-#define bt_iso_create_pdu(_pool, _reserve) \
-	bt_iso_create_pdu_timeout(_pool, _reserve, K_FOREVER)
-#endif
-
-/* Allocate ISO Fragment */
-#if defined(CONFIG_NET_BUF_LOG)
-struct net_buf *bt_iso_create_frag_timeout_debug(size_t reserve,
-						 k_timeout_t timeout,
-						 const char *func, int line);
-
-#define bt_iso_create_frag_timeout(_reserve, _timeout) \
-	bt_iso_create_frag_timeout_debug(_reserve, _timeout, \
-					 __func__, __LINE__)
-
-#define bt_iso_create_frag(_reserve) \
-	bt_iso_create_frag_timeout_debug(_reserve, K_FOREVER, \
-					 __func__, __LINE__)
-#else
-struct net_buf *bt_iso_create_frag_timeout(size_t reserve, k_timeout_t timeout);
-
-#define bt_iso_create_frag(_reserve) \
-	bt_iso_create_frag_timeout(_reserve, K_FOREVER)
-#endif
-
 #if defined(CONFIG_BT_ISO_LOG_LEVEL_DBG)
 void bt_iso_chan_set_state_debug(struct bt_iso_chan *chan,
 				 enum bt_iso_state state,


### PR DESCRIPTION
The iso_tx_pool was unused because all the functions and macros that used it were unused.