### PR TITLE
scripts: nrf_common: Move MPI to sysbuild Kconfig

### DIFF
--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -1026,9 +1026,6 @@ flagged.
         "SRAM2",  # Referenced in a comment in samples/application_development
         "STACK_SIZE",  # Used as an example in the Kconfig docs
         "STD_CPP",  # Referenced in CMake comment
-        "SUIT_MPI_APP_AREA_PATH", # Used by nRF runners to program provisioning data, based on build configuration
-        "SUIT_MPI_GENERATE", # Used by nRF runners to program provisioning data, based on build configuration
-        "SUIT_MPI_RAD_AREA_PATH", # Used by nRF runners to program provisioning data, based on build configuration
         "TEST1",
         "TOOLCHAIN_ARCMWDT_SUPPORTS_THREAD_LOCAL_STORAGE", # The symbol is defined in the toolchain
                                                     # Kconfig which is sourced based on Zephyr

--- a/scripts/west_commands/runners/nrf_common.py
+++ b/scripts/west_commands/runners/nrf_common.py
@@ -342,26 +342,28 @@ class NrfBinaryRunner(ZephyrBinaryRunner):
                 mpi_hex_dir = Path(os.path.join(self.cfg.build_dir, 'zephyr'))
 
                 # Handle Manifest Provisioning Information
-                if self.build_conf.getboolean('CONFIG_SUIT_MPI_GENERATE'):
+                if self.sysbuild_conf.getboolean('SB_CONFIG_SUIT_MPI_GENERATE'):
                     app_mpi_hex_file = os.fspath(
-                        mpi_hex_dir / self.build_conf.get('CONFIG_SUIT_MPI_APP_AREA_PATH'))
+                        mpi_hex_dir / self.sysbuild_conf.get('SB_CONFIG_SUIT_MPI_APP_AREA_PATH'))
                     rad_mpi_hex_file = os.fspath(
-                        mpi_hex_dir / self.build_conf.get('CONFIG_SUIT_MPI_RAD_AREA_PATH')
+                        mpi_hex_dir / self.sysbuild_conf.get('SB_CONFIG_SUIT_MPI_RAD_AREA_PATH')
                     )
-                    self.op_program(
-                        app_mpi_hex_file,
-                        'ERASE_NONE',
-                        None,
-                        defer=True,
-                        core='NRFDL_DEVICE_CORE_APPLICATION',
-                    )
-                    self.op_program(
-                        rad_mpi_hex_file,
-                        'ERASE_NONE',
-                        None,
-                        defer=True,
-                        core='NRFDL_DEVICE_CORE_NETWORK',
-                    )
+                    if os.path.exists(app_mpi_hex_file):
+                        self.op_program(
+                            app_mpi_hex_file,
+                            'ERASE_NONE',
+                            None,
+                            defer=True,
+                            core='NRFDL_DEVICE_CORE_APPLICATION',
+                        )
+                    if os.path.exists(rad_mpi_hex_file):
+                        self.op_program(
+                            rad_mpi_hex_file,
+                            'ERASE_NONE',
+                            None,
+                            defer=True,
+                            core='NRFDL_DEVICE_CORE_NETWORK',
+                        )
 
                 # Handle SUIT root manifest if application manifests are not used.
                 # If an application firmware is built, the root envelope is merged
@@ -370,13 +372,14 @@ class NrfBinaryRunner(ZephyrBinaryRunner):
                     app_root_envelope_hex_file = os.fspath(
                         mpi_hex_dir / 'suit_installed_envelopes_application_merged.hex'
                     )
-                    self.op_program(
-                        app_root_envelope_hex_file,
-                        'ERASE_NONE',
-                        None,
-                        defer=True,
-                        core='NRFDL_DEVICE_CORE_APPLICATION',
-                    )
+                    if os.path.exists(app_root_envelope_hex_file):
+                        self.op_program(
+                            app_root_envelope_hex_file,
+                            'ERASE_NONE',
+                            None,
+                            defer=True,
+                            core='NRFDL_DEVICE_CORE_APPLICATION',
+                        )
 
             if not self.erase and generated_uicr:
                 self.exec_op('erase', core=core, option={'chip_erase_mode': 'ERASE_UICR',


### PR DESCRIPTION
Use sysbuild to build and configure SUIT Manifest Provisioning Information.