### PR TITLE
samples: net: cellular_modem: Add additional overlay for nrf7002dk

### DIFF
--- a/samples/net/cellular_modem/boards/nrf7002dk_nrf5340_cpuapp_ns.overlay
+++ b/samples/net/cellular_modem/boards/nrf7002dk_nrf5340_cpuapp_ns.overlay
@@ -1,0 +1,41 @@
+/ {
+        aliases {
+                modem = &modem;
+        };
+};
+
+&pinctrl {
+        uart1_alt_default: uart1_alt_default {
+                group1 {
+                        psels = <NRF_PSEL(UART_TX, 0, 25)>;
+                };
+                group2 {
+                        psels = <NRF_PSEL(UART_RX, 0, 26)>;
+                        bias-pull-up;
+                };
+        };
+
+        uart1_alt_sleep: uart1_alt_sleep {
+                group1 {
+                        psels = <NRF_PSEL(UART_TX, 0, 25)>,
+                                <NRF_PSEL(UART_RX, 0, 26)>;
+                        low-power-enable;
+                };
+        };
+};
+
+&uart1 {
+        pinctrl-0 = <&uart1_alt_default>;
+        pinctrl-1 = <&uart1_alt_sleep>;
+        pinctrl-names = "default", "sleep";
+        current-speed = <115200>;
+        status = "okay";
+
+        modem: modem {
+                compatible = "telit,me910g1";
+                mdm-power-gpios = <&gpio1 6 GPIO_ACTIVE_HIGH>;
+                mdm-reset-gpios = <&gpio1 7 GPIO_ACTIVE_LOW>;
+                status = "okay";
+        };
+};
+


### PR DESCRIPTION
This overlay is for the nrf7002dk. The modem tested was the Telit ME310G1-WW, but should work for any of the supported modems provided that the UART lines are defined and hooked up correctly.