### PR TITLE
drivers: video: Disable the driver if real camera presents

### DIFF
--- a/drivers/video/Kconfig.sw_generator
+++ b/drivers/video/Kconfig.sw_generator
@@ -3,7 +3,10 @@
 # Copyright (c) 2016 Linaro Limited
 # SPDX-License-Identifier: Apache-2.0
 
+DT_CHOSEN_ZEPHYR_CAMERA := zephyr,camera
+
 config VIDEO_SW_GENERATOR
 	bool "Video Software Generator"
+	depends on !$(dt_chosen_enabled,$(DT_CHOSEN_ZEPHYR_CAMERA))
 	help
 	  Enable video pattern generator (for testing purposes).


### PR DESCRIPTION
Do not enable the video sw generator if a real camera is present. This helps to save some spaces and to avoid unrelated code going into the built image.

If the real camera presents, there will be a warning which cannot be avoided:
`warning: VIDEO_SW_GENERATOR (defined at drivers/video/Kconfig.sw_generator:8) was assigned the value 'y' but got the value 'n' 