### PR TITLE
samples: boards: Add support for nucleo_wba55cg board

### DIFF
--- a/dts/arm/st/wba/stm32wba.dtsi
+++ b/dts/arm/st/wba/stm32wba.dtsi
@@ -118,6 +118,13 @@
 		};
 	};
 
+	mcos {
+		mco1: mco1 {
+			compatible = "st,stm32-clock-mco";
+			status = "disabled";
+		};
+	};
+
 	soc {
 		flash: flash-controller@40022000 {
 			compatible = "st,stm32-flash-controller", "st,stm32wba-flash-controller";

--- a/include/zephyr/dt-bindings/clock/stm32wba_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32wba_clock.h
@@ -100,5 +100,29 @@
 #define ADC_SEL(val)		STM32_DOMAIN_CLOCK(val, 7, 12, CCIPR3_REG)
 /** BCDR1 devices */
 #define RTC_SEL(val)		STM32_DOMAIN_CLOCK(val, 3, 8, BCDR1_REG)
+/** @brief RCC_CFGRx register offset */
+#define CFGR1_REG               0x1C
+/** CFGR1 devices */
+#define MCO1_SEL(val)           STM32_MCO_CFGR(val, 0xF, 24, CFGR1_REG)
+#define MCO1_PRE(val)           STM32_MCO_CFGR(val, 0x7, 28, CFGR1_REG)
+
+/* MCO prescaler : division factor */
+#define MCO_PRE_DIV_1 0
+#define MCO_PRE_DIV_2 1
+#define MCO_PRE_DIV_4 2
+#define MCO_PRE_DIV_8 3
+#define MCO_PRE_DIV_16 4
+
+/* MCO clock output */
+#define MCO_SEL_SYSCLKPRE 1
+#define MCO_SEL_HSI16 3
+#define MCO_SEL_HSE32 4
+#define MCO_SEL_PLL1RCLK 5
+#define MCO_SEL_LSI 6
+#define MCO_SEL_LSE 7
+#define MCO_SEL_PLL1PCLK 8
+#define MCO_SEL_PLL1QCLK 9
+#define MCO_SEL_HCLK5 10
+
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32WBA_CLOCK_H_ */

--- a/samples/boards/st/mco/boards/nucleo_wba55cg.overlay
+++ b/samples/boards/st/mco/boards/nucleo_wba55cg.overlay
@@ -1,0 +1,30 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2025 STMicroelectronics
+ */
+
+/* The clock that is output must be enabled. */
+&clk_lse {
+	status = "okay";
+};
+/* MCO use same pin like usart1 RX - disable usart */
+/ {
+	chosen {
+		zephyr,bt-c2h-uart = &lpuart1;
+		zephyr,uart-pipe = &lpuart1;
+		zephyr,console = &lpuart1;
+		zephyr,shell-uart = &lpuart1;
+	};
+};
+&usart1 {
+	status = "disabled";
+};
+
+&mco1 {
+	status = "okay";
+	clocks = <&rcc STM32_SRC_LSE MCO1_SEL(MCO_SEL_LSE)>;
+	prescaler = <MCO1_PRE(MCO1_PRE_DIV_2)>;
+	pinctrl-0 = <&rcc_mco_pa8>;
+	pinctrl-names = "default";
+};

--- a/samples/boards/st/mco/sample.yaml
+++ b/samples/boards/st/mco/sample.yaml
@@ -7,6 +7,7 @@ tests:
       - nucleo_f446ze
       - stm32f746g_disco
       - nucleo_u5a5zj_q
+      - nucleo_wba55cg
     integration_platforms:
       - stm32f746g_disco
     tags: board


### PR DESCRIPTION
run mco example also with nucleo_wba55cg board
due to gpio conflict uart print out not functional

Signed-off-by:Lubos Koudelka <lubos.koudelka@st.com>