### PR TITLE
boards: frdm_mcxn947: Delete enable of GPIO5 clock

### DIFF
--- a/boards/nxp/frdm_mcxn947/board.c
+++ b/boards/nxp/frdm_mcxn947/board.c
@@ -190,10 +190,6 @@ static int frdm_mcxn947_init(void)
 	CLOCK_EnableClock(kCLOCK_Gpio4);
 #endif
 
-#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(gpio5))
-	CLOCK_EnableClock(kCLOCK_Gpio5);
-#endif
-
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(dac0))
 	SPC_EnableActiveModeAnalogModules(SPC0, kSPC_controlDac0);
 	CLOCK_SetClkDiv(kCLOCK_DivDac0Clk, 1u);


### PR DESCRIPTION
There is no bit to enable GPIO5 clock in the clock control register.
Fixes https://github.com/zephyrproject-rtos/zephyr/discussions/81554