### PR TITLE
MAINTAINERS: fix area Networking issue assignment

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -2991,7 +2991,7 @@ Networking:
     - subsys/net/lib/ptp/
     - samples/net/ptp/
   labels:
-    - "area: Networking"
+    - "area: PTP"
   tests:
     - sample.net.ptp
 


### PR DESCRIPTION
Replacing "area: Networking" with "area: PTP" to prevent from including myself in issues and PRs that are related to every piece of Networking code. Insted I'll be included only in PTP related issued/PRs.