### PR TITLE
twister: filters: add ability to filter by vendor

### DIFF
--- a/doc/develop/test/twister.rst
+++ b/doc/develop/test/twister.rst
@@ -438,6 +438,17 @@ arch_allow: <list of arches, such as x86, arm, arc>
 arch_exclude: <list of arches, such as x86, arm, arc>
     Set of architectures that this test scenario should not run on.
 
+vendor_allow: <list of vendors>
+    Set of platform vendors that this test scenario should only be run for.  The
+    vendor is defined as part of the board definition. Boards associated with
+    this vendors will be included. Other boards, including those without a
+    vendor will be excluded.
+
+vendor_exclude: <list of vendors>
+    Set of platform vendors that this test scenario should not run on.
+    The vendor is defined as part of the board. Boards associated with this
+    vendors will be excluded.
+
 platform_allow: <list of platforms>
     Set of platforms that this test scenario should only be run for. Do not use
     this option to limit testing or building in CI due to time or resource

--- a/scripts/pylib/twister/twisterlib/config_parser.py
+++ b/scripts/pylib/twister/twisterlib/config_parser.py
@@ -61,6 +61,8 @@ class TwisterConfigParser:
                        "min_flash": {"type": "int", "default": 32},
                        "arch_allow": {"type": "set"},
                        "arch_exclude": {"type": "set"},
+                       "vendor_allow": {"type": "set"},
+                       "vendor_exclude": {"type": "set"},
                        "extra_sections": {"type": "list", "default": []},
                        "integration_platforms": {"type": "list", "default": []},
                        "ignore_faults": {"type": "bool", "default": False },

--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -895,6 +895,12 @@ class TestPlan:
                     if ts.arch_exclude and plat.arch in ts.arch_exclude:
                         instance.add_filter("In test case arch exclude", Filters.TESTSUITE)
 
+                    if ts.vendor_allow and plat.vendor not in ts.vendor_allow:
+                        instance.add_filter("Not in test suite vendor allow list", Filters.TESTSUITE)
+
+                    if ts.vendor_exclude and plat.vendor in ts.vendor_exclude:
+                        instance.add_filter("In test suite vendor exclude", Filters.TESTSUITE)
+
                     if ts.platform_exclude and plat.name in ts.platform_exclude:
                         # works only when we have all platforms parsed, -p limits parsing...
                         if not platform_filter:

--- a/scripts/schemas/twister/testsuite-schema.yaml
+++ b/scripts/schemas/twister/testsuite-schema.yaml
@@ -20,6 +20,16 @@ schema;scenario-schema:
     "arch_allow":
       type: any
       required: false
+    "vendor_exclude":
+      type: seq
+      required: false
+      sequence:
+        - type: str
+    "vendor_allow":
+      type: seq
+      required: false
+      sequence:
+        - type: str
     "testcases":
       type: seq
       required: false


### PR DESCRIPTION
add vendor_allow and vendor_exclude to the list of filters. The vendor
data is maintained in the board.yml files.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
