### PR TITLE
ci: twister: add --no-detailed-test-id

### DIFF
--- a/.github/workflows/clang.yaml
+++ b/.github/workflows/clang.yaml
@@ -107,13 +107,13 @@ jobs:
           export ZEPHYR_TOOLCHAIN_VARIANT=llvm
 
           # check if we need to run a full twister or not based on files changed
-          python3 ./scripts/ci/test_plan.py --platform ${{ matrix.platform }} -c origin/${BASE_REF}..
+          python3 ./scripts/ci/test_plan.py --no-detailed-test-id --platform ${{ matrix.platform }} -c origin/${BASE_REF}..
 
           # We can limit scope to just what has changed
           if [ -s testplan.json ]; then
             echo "report_needed=1" >> $GITHUB_OUTPUT
             # Full twister but with options based on changes
-            ./scripts/twister --force-color --inline-logs -M -N -v --load-tests testplan.json --retry-failed 2
+            ./scripts/twister --no-detailed-test-id --force-color --inline-logs -M -N -v --load-tests testplan.json --retry-failed 2
           else
             # if nothing is run, skip reporting step
             echo "report_needed=0" >> $GITHUB_OUTPUT

--- a/.github/workflows/twister-prep.yaml
+++ b/.github/workflows/twister-prep.yaml
@@ -83,7 +83,7 @@ jobs:
         run: |
           export ZEPHYR_BASE=${PWD}
           export ZEPHYR_TOOLCHAIN_VARIANT=zephyr
-          python3 ./scripts/ci/test_plan.py -c origin/${BASE_REF}.. --pull-request -t $TESTS_PER_BUILDER
+          python3 ./scripts/ci/test_plan.py -c origin/${BASE_REF}.. --no-detailed-test-id --pull-request -t $TESTS_PER_BUILDER
           if [ -s .testplan ]; then
             cat .testplan >> $GITHUB_ENV
           else

--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -44,7 +44,7 @@ jobs:
       CCACHE_IGNOREOPTIONS: '-specs=* --specs=*'
       BSIM_OUT_PATH: /opt/bsim/
       BSIM_COMPONENTS_PATH: /opt/bsim/components
-      TWISTER_COMMON: ' --force-color --inline-logs -v -N -M --retry-failed 3 --timeout-multiplier 2 '
+      TWISTER_COMMON: '--no-detailed-test-id --force-color --inline-logs -v -N -M --retry-failed 3 --timeout-multiplier 2 '
       DAILY_OPTIONS: ' -M --build-only --all --show-footprint'
       PR_OPTIONS: ' --clobber-output --integration'
       PUSH_OPTIONS: ' --clobber-output -M --show-footprint --report-filtered'


### PR DESCRIPTION
Switch to short test identifier in reporting.
Part of a series of changes to improve reporting and remove duplication
and clutter when running twister.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
