### PR TITLE
soc: intel_adsp/ace: put syscall helpers in vector code section

### DIFF
--- a/soc/intel/intel_adsp/ace/ace-link.ld
+++ b/soc/intel/intel_adsp/ace/ace-link.ld
@@ -285,6 +285,10 @@ SECTIONS {
     *libarch__xtensa__core.a:userspace.S.obj(.literal.xtensa_do_syscall)
     *libarch__xtensa__core.a:userspace.S.obj(.text.xtensa_do_syscall)
 
+#ifdef CONFIG_XTENSA_SYSCALL_USE_HELPER
+    *libarch__xtensa__core.a:syscall_helper.c.obj(.text.xtensa_syscall_helper*)
+#endif /* CONFIG_XTENSA_SYSCALL_USE_HELPER */
+
   } > xtensa_vector_code
 #endif /* CONFIG_XTENSA_MMU */
 


### PR DESCRIPTION
This puts the syscall helpers into the vector code section, and is a tiny TLB optimization. Before this, worst case scenario is that there would 2 instruction TLB misses when both the syscall helpers and the vector code pages are not in TLB cache. With this change, there would be at most 1 instruction TLB miss as now the syscall helper and the vector code (which includes exception handling code and xtensa_do_syscall()) are now in the same page, and the same TLB entry.