### PR TITLE
tests: add integration_platforms and misc optimizations

### DIFF
--- a/samples/basic/minimal/sample.yaml
+++ b/samples/basic/minimal/sample.yaml
@@ -13,7 +13,6 @@ tests:
     extra_args: CONF_FILE='common.conf;mt.conf;arm.conf'
     build_only: true
     platform_allow:
-      - reel_board
       - frdm_k64f
       - mps2/an385
       - nrf51dk/nrf51822
@@ -25,42 +24,46 @@ tests:
     extra_args: CONF_FILE='common.conf;mt.conf;no-preempt.conf;arm.conf'
     build_only: true
     platform_allow:
-      - reel_board
       - frdm_k64f
       - mps2/an385
       - nrf51dk/nrf51822
       - nucleo_f429zi
       - disco_l475_iot1
+    integration_platforms:
+      - frdm_k64f
   sample.minimal.mt-no-preempt-no-timers.arm:
     extra_args: CONF_FILE='common.conf;mt.conf;no-preempt.conf;no-timers.conf;arm.conf'
     build_only: true
     platform_allow:
-      - reel_board
       - frdm_k64f
       - mps2/an385
       - nrf51dk/nrf51822
       - nucleo_f429zi
       - disco_l475_iot1
+    integration_platforms:
+      - frdm_k64f
   sample.minimal.no-mt.arm:
     extra_args: CONF_FILE='common.conf;no-mt.conf;arm.conf'
     build_only: true
     platform_allow:
-      - reel_board
       - frdm_k64f
       - mps2/an385
       - nrf51dk/nrf51822
       - nucleo_f429zi
       - disco_l475_iot1
+    integration_platforms:
+      - frdm_k64f
   sample.minimal.no-mt-no-timers.arm:
     extra_args: CONF_FILE='common.conf;no-mt.conf;no-timers.conf;arm.conf'
     build_only: true
     platform_allow:
-      - reel_board
       - frdm_k64f
       - mps2/an385
       - nrf51dk/nrf51822
       - nucleo_f429zi
       - disco_l475_iot1
+    integration_platforms:
+      - frdm_k64f
   sample.minimal.mt.x86:
     extra_args: CONF_FILE='common.conf;mt.conf;x86.conf'
     build_only: true

--- a/samples/boards/st/power_mgmt/wkup_pins/sample.yaml
+++ b/samples/boards/st/power_mgmt/wkup_pins/sample.yaml
@@ -10,3 +10,5 @@ tests:
       - nucleo_u575zi_q
       - nucleo_u5a5zj_q
       - nucleo_wl55jc
+    integration_platforms:
+      - nucleo_l4r5zi

--- a/samples/drivers/display/sample.yaml
+++ b/samples/drivers/display/sample.yaml
@@ -52,6 +52,8 @@ tests:
       - mimxrt1060_evk
       - mimxrt1050_evk
       - mimxrt1040_evk
+    integration_platforms:
+      - mimxrt1040_evk
     tags: display
     harness: console
     extra_args: SHIELD=rk043fn02h_ct

--- a/samples/drivers/watchdog/sample.yaml
+++ b/samples/drivers/watchdog/sample.yaml
@@ -112,3 +112,5 @@ tests:
       - s32z2xxdc2/s32z270/rtu1
       - s32z2xxdc2@D/s32z270/rtu0
       - s32z2xxdc2@D/s32z270/rtu1
+    integration_platforms:
+      - s32z2xxdc2/s32z270/rtu0

--- a/samples/net/zperf/sample.yaml
+++ b/samples/net/zperf/sample.yaml
@@ -27,6 +27,8 @@ tests:
       - nucleo_f429zi
       - nucleo_f746zg
       - stm32h573i_dk
+    integration_platforms:
+      - stm32h573i_dk
   sample.net.zperf_no_shell:
     harness: net
     extra_configs:

--- a/samples/subsys/canbus/isotp/sample.yaml
+++ b/samples/subsys/canbus/isotp/sample.yaml
@@ -23,8 +23,6 @@ tests:
       - CONFIG_SAMPLE_LOOPBACK_MODE=y
       - CONFIG_SAMPLE_CAN_FD_MODE=y
     platform_allow:
-      - native_posix
-      - native_posix/native/64
       - native_sim
       - native_sim/native/64
     harness: console

--- a/samples/subsys/display/lvgl/sample.yaml
+++ b/samples/subsys/display/lvgl/sample.yaml
@@ -76,6 +76,8 @@ tests:
       - mimxrt1060_evk
       - mimxrt1050_evk
       - mimxrt1040_evk
+    integration_platforms:
+      - mimxrt1040_evk
     tags: display
     harness: console
     extra_args: SHIELD=rk043fn66hs_ctg
@@ -86,6 +88,8 @@ tests:
       - mimxrt1064_evk
       - mimxrt1060_evk
       - mimxrt1050_evk
+      - mimxrt1040_evk
+    integration_platforms:
       - mimxrt1040_evk
     tags: display
     harness: console

--- a/samples/tfm_integration/config_build/sample.yaml
+++ b/samples/tfm_integration/config_build/sample.yaml
@@ -5,11 +5,12 @@ common:
   tags:
     - trusted-firmware-m
   platform_allow:
-    - mps2/an521/cpu0/ns
     - v2m_musca_s1/musca_s1/ns
     - nrf5340dk/nrf5340/cpuapp/ns
     - nrf9160dk/nrf9160/ns
     - bl5340_dvk/nrf5340/cpuapp/ns
+  integration_platforms:
+    - nrf5340dk/nrf5340/cpuapp/ns
   harness: console
   harness_config:
     type: one_line

--- a/samples/tfm_integration/psa_crypto/sample.yaml
+++ b/samples/tfm_integration/psa_crypto/sample.yaml
@@ -20,6 +20,8 @@ tests:
       - nrf9160dk/nrf9160/ns
       - stm32l562e_dk/stm32l562xx/ns
       - bl5340_dvk/nrf5340/cpuapp/ns
+    integration_platforms:
+      - mps2/an521/cpu0/ns
     harness: console
     harness_config:
       type: multi_line

--- a/tests/bluetooth/init/testcase.yaml
+++ b/tests/bluetooth/init/testcase.yaml
@@ -143,8 +143,6 @@ tests:
       - nrf52dk/nrf52832
     integration_platforms:
       - nrf5340dk/nrf5340/cpunet
-      - nrf52840dk/nrf52840
-      - nrf52dk/nrf52832
   bluetooth.init.test_ctlr_ticker:
     extra_args:
       - CONF_FILE=prj_ctlr_ticker.conf
@@ -152,7 +150,6 @@ tests:
       - nrf52840dk/nrf52840
       - nrf52dk/nrf52832
     integration_platforms:
-      - nrf52840dk/nrf52840
       - nrf52dk/nrf52832
   bluetooth.init.test_ctlr_broadcaster:
     extra_args: CONF_FILE=prj_ctlr_broadcaster.conf
@@ -161,6 +158,8 @@ tests:
       - nrf52dk/nrf52832
       - nrf51dk/nrf51822
       - rv32m1_vega/openisa_rv32m1/ri5cy
+    integration_platforms:
+      - nrf52dk/nrf52832
   bluetooth.init.test_ctlr_peripheral:
     extra_args: CONF_FILE=prj_ctlr_peripheral.conf
     platform_allow:
@@ -168,6 +167,8 @@ tests:
       - nrf52dk/nrf52832
       - nrf51dk/nrf51822
       - rv32m1_vega/openisa_rv32m1/ri5cy
+    integration_platforms:
+      - nrf52dk/nrf52832
   bluetooth.init.test_ctlr_peripheral_priv:
     extra_args: CONF_FILE=prj_ctlr_peripheral_priv.conf
     platform_allow:
@@ -175,6 +176,8 @@ tests:
       - nrf52dk/nrf52832
       - nrf51dk/nrf51822
       - rv32m1_vega/openisa_rv32m1/ri5cy
+    integration_platforms:
+      - nrf52840dk/nrf52840
   bluetooth.init.test_ctlr_observer:
     extra_args: CONF_FILE=prj_ctlr_observer.conf
     platform_allow:
@@ -184,8 +187,6 @@ tests:
       - rv32m1_vega/openisa_rv32m1/ri5cy
     integration_platforms:
       - nrf52dk/nrf52832
-      - nrf51dk/nrf51822
-      - rv32m1_vega/openisa_rv32m1/ri5cy
   bluetooth.init.test_ctlr_central:
     extra_args: CONF_FILE=prj_ctlr_central.conf
     platform_allow:
@@ -195,7 +196,6 @@ tests:
       - rv32m1_vega/openisa_rv32m1/ri5cy
     integration_platforms:
       - nrf52dk/nrf52832
-      - nrf51dk/nrf51822
       - rv32m1_vega/openisa_rv32m1/ri5cy
   bluetooth.init.test_ctlr_central_priv:
     extra_args: CONF_FILE=prj_ctlr_central_priv.conf
@@ -206,7 +206,6 @@ tests:
       - rv32m1_vega/openisa_rv32m1/ri5cy
     integration_platforms:
       - nrf52dk/nrf52832
-      - nrf51dk/nrf51822
       - rv32m1_vega/openisa_rv32m1/ri5cy
   bluetooth.init.test_ctlr_broadcaster_ext:
     extra_args: CONF_FILE=prj_ctlr_broadcaster_ext.conf
@@ -343,7 +342,6 @@ tests:
       - rv32m1_vega/openisa_rv32m1/ri5cy
     integration_platforms:
       - nrf52840dk/nrf52840
-      - nrf52dk/nrf52832
       - rv32m1_vega/openisa_rv32m1/ri5cy
   bluetooth.init.test_config_bt_recv_workq_bt:
     extra_args:

--- a/tests/boards/espressif/rtc_clk/testcase.yaml
+++ b/tests/boards/espressif/rtc_clk/testcase.yaml
@@ -1,3 +1,6 @@
+common:
+  integration_platforms:
+    - esp32c6_devkitc
 tests:
   boards.esp32.rtc_clk:
     platform_allow:

--- a/tests/boards/espressif/wifi/testcase.yaml
+++ b/tests/boards/espressif/wifi/testcase.yaml
@@ -1,3 +1,6 @@
+common:
+  integration_platforms:
+    - esp32c3_devkitm
 tests:
   esp.wifi.sec.none:
     tags: wifi

--- a/tests/drivers/adc/adc_accuracy_test/testcase.yaml
+++ b/tests/drivers/adc/adc_accuracy_test/testcase.yaml
@@ -23,3 +23,5 @@ tests:
       - nrf52840dk/nrf52840
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
+    integration_platforms:
+      - frdm_kl25z

--- a/tests/drivers/adc/adc_api/testcase.yaml
+++ b/tests/drivers/adc/adc_api/testcase.yaml
@@ -43,6 +43,9 @@ tests:
       - stm32f3_disco
       - stm32h573i_dk
       - stm32u083c_dk
+    integration_platforms:
+      - disco_l475_iot1
+      - nucleo_l476rg
   drivers.adc.dma_nxp_kinetis:
     extra_args:
       - EXTRA_CONF_FILE="overlay-dma-kinetis.conf"

--- a/tests/drivers/build_all/can/testcase.yaml
+++ b/tests/drivers/build_all/can/testcase.yaml
@@ -21,7 +21,5 @@ tests:
     platform_allow: lpcxpresso55s28
   drivers.can.build_all.native_linux:
     platform_allow:
-      - native_posix
-      - native_posix/native/64
       - native_sim
       - native_sim/native/64

--- a/tests/drivers/build_all/comparator/testcase.yaml
+++ b/tests/drivers/build_all/comparator/testcase.yaml
@@ -18,6 +18,9 @@ tests:
       - nrf54h20dk/nrf54h20/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf9280pdk/nrf9280/cpuapp
+    integration_platforms:
+      - nrf52dk/nrf52810
+      - nrf5340dk/nrf5340/cpuapp
   drivers.build_all.comparator.nrf_comp.se_aref:
     extra_args:
       - DTC_OVERLAY_FILE="nrf_comp/se_aref.overlay"
@@ -32,6 +35,9 @@ tests:
       - nrf54h20dk/nrf54h20/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf9280pdk/nrf9280/cpuapp
+    integration_platforms:
+      - nrf52dk/nrf52810
+      - nrf5340dk/nrf5340/cpuapp
   drivers.build_all.comparator.nrf_comp.se:
     extra_args:
       - DTC_OVERLAY_FILE="nrf_comp/se.overlay"
@@ -46,6 +52,9 @@ tests:
       - nrf54h20dk/nrf54h20/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf9280pdk/nrf9280/cpuapp
+    integration_platforms:
+      - nrf52dk/nrf52810
+      - nrf5340dk/nrf5340/cpuapp
   drivers.build_all.comparator.nrf_lpcomp.ext_ref:
     extra_args:
       - DTC_OVERLAY_FILE="nrf_lpcomp/ext_ref.overlay"
@@ -56,6 +65,9 @@ tests:
       - nrf54h20dk/nrf54h20/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf9280pdk/nrf9280/cpuapp
+    integration_platforms:
+      - nrf51dk/nrf51822
+      - nrf54l15dk/nrf54l15/cpuapp
   drivers.build_all.comparator.nrf_lpcomp.int_ref:
     extra_args:
       - DTC_OVERLAY_FILE="nrf_lpcomp/int_ref.overlay"
@@ -66,6 +78,9 @@ tests:
       - nrf54h20dk/nrf54h20/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf9280pdk/nrf9280/cpuapp
+    integration_platforms:
+      - nrf51dk/nrf51822
+      - nrf54h20dk/nrf54h20/cpuapp
   drivers.build_all.comparator.mcux_acmp.mimxrt1176_mux_dac:
     extra_args:
       - DTC_OVERLAY_FILE="mcux_acmp/mimxrt1176_mux_dac.dts"

--- a/tests/drivers/build_all/counter/testcase.yaml
+++ b/tests/drivers/build_all/counter/testcase.yaml
@@ -13,7 +13,5 @@ tests:
     extra_configs:
       - CONFIG_I2C=y
     platform_allow:
-      - native_posix
-      - native_posix/native/64
       - native_sim
       - native_sim/native/64

--- a/tests/drivers/build_all/gpio/testcase.yaml
+++ b/tests/drivers/build_all/gpio/testcase.yaml
@@ -31,6 +31,8 @@ tests:
       - nrf52840dk/nrf52840
       - native_sim
       - native_sim/native/64
+    integration_platforms:
+      - native_sim
     depends_on:
       - gpio
       - adc

--- a/tests/drivers/build_all/interrupt_controller/intc_plic/testcase.yaml
+++ b/tests/drivers/build_all/interrupt_controller/intc_plic/testcase.yaml
@@ -6,6 +6,9 @@ common:
     - qemu_riscv32/qemu_virt_riscv32/smp
     - qemu_riscv64
     - qemu_riscv64/qemu_virt_riscv64/smp
+  integration_platforms:
+    - qemu_riscv32
+    - qemu_riscv64
   tags:
     - drivers
     - interrupt

--- a/tests/drivers/build_all/modem/testcase.yaml
+++ b/tests/drivers/build_all/modem/testcase.yaml
@@ -5,6 +5,8 @@ common:
     - native_sim/native/64
     - qemu_x86
     - qemu_x86_64
+  integration_platforms:
+    - qemu_x86
 
 tests:
   drivers.modem.modem_hl7800.interrupt_driven.build:

--- a/tests/drivers/can/api/testcase.yaml
+++ b/tests/drivers/can/api/testcase.yaml
@@ -14,12 +14,7 @@ tests:
       - CONFIG_CAN_ACCEPT_RTR=y
   drivers.can.api.twai:
     extra_args: DTC_OVERLAY_FILE=twai-enable.overlay
-    filter: dt_compat_enabled("espressif,esp32-twai")
     platform_allow:
-      - esp32_devkitc_wroom/esp32/procpu
-      - esp32_devkitc_wrover/esp32/procpu
-      - esp32c3_devkitm
-      - esp32s2_saola
       - esp32s3_devkitm/esp32s3/procpu
       - xiao_esp32s3/esp32s3/procpu
   drivers.can.api.nxp_s32_canxl.non_rx_fifo:

--- a/tests/drivers/charger/sbs_charger/testcase.yaml
+++ b/tests/drivers/charger/sbs_charger/testcase.yaml
@@ -31,6 +31,8 @@ tests:
       - qemu_kvm_arm64
       - xenvm
       - xenvm/xenvm/gicv3
+    integration_platforms:
+      - qemu_cortex_a53
     extra_args:
       CONF_FILE="prj.conf;boards/qemu_cortex_a53.conf"
       DTC_OVERLAY_FILE="boards/qemu_cortex_a53.overlay"

--- a/tests/drivers/clock_control/clock_control_api/testcase.yaml
+++ b/tests/drivers/clock_control/clock_control_api/testcase.yaml
@@ -13,6 +13,8 @@ tests:
       - sltb010a@0
       - xg24_dk2601b
       - xg27_dk2602a
+    integration_platforms:
+      - esp32_devkitc_wroom/esp32/procpu
   drivers.clock.clock_control_nrf5:
     platform_allow:
       - nrf51dk/nrf51822

--- a/tests/drivers/counter/counter_nrf_rtc/fixed_top/testcase.yaml
+++ b/tests/drivers/counter/counter_nrf_rtc/fixed_top/testcase.yaml
@@ -10,3 +10,5 @@ tests:
       - nrf54h20dk/nrf54h20/cpuapp
       - nrf54h20dk/nrf54h20/cpurad
       - nrf54h20dk/nrf54h20/cpuppr
+    integration_platforms:
+      - nrf52840dk/nrf52840

--- a/tests/drivers/flash/erase_blocks/testcase.yaml
+++ b/tests/drivers/flash/erase_blocks/testcase.yaml
@@ -15,3 +15,5 @@ tests:
       - b_u585i_iot02a
       - nrf9160dk/nrf9160
       - nrf5340dk/nrf5340/cpuapp
+    integration_platforms:
+      - nrf9160dk/nrf9160

--- a/tests/drivers/gpio/gpio_basic_api/testcase.yaml
+++ b/tests/drivers/gpio/gpio_basic_api/testcase.yaml
@@ -19,6 +19,8 @@ tests:
       - nrf5340bsim/nrf5340/cpuapp
       - nrf5340bsim/nrf5340/cpunet
       - nrf54l15bsim/nrf54l15/cpuapp
+    integration_platforms:
+      - nrf52840dk/nrf52840
     extra_args: "DTC_OVERLAY_FILE=boards/nrf52840dk_nrf52840.overlay;\
                  boards/nrf52840dk_nrf52840_sense_edge.overlay"
 
@@ -75,6 +77,8 @@ tests:
       - nucleo_wb09ke
       - nucleo_wb05kz
       - nucleo_wba55cg
+    integration_platforms:
+      - mimxrt595_evk/mimxrt595s/cm33
   drivers.gpio.st_2pin_arduino:
     min_flash: 34
     depends_on:

--- a/tests/drivers/i2c/i2c_target_api/testcase.yaml
+++ b/tests/drivers/i2c/i2c_target_api/testcase.yaml
@@ -53,3 +53,5 @@ tests:
       - max32675evkit
       - max32680evkit/max32680/m4
       - max32690evkit/max32690/m4
+    integration_platforms:
+      - max32690evkit/max32690/m4

--- a/tests/drivers/retained_mem/api/testcase.yaml
+++ b/tests/drivers/retained_mem/api/testcase.yaml
@@ -10,6 +10,8 @@ tests:
       - nrf54h20dk/nrf54h20/cpuapp
       - nrf54h20dk/nrf54h20/cpurad
       - nrf54l15dk/nrf54l15/cpuapp
+    integration_platforms:
+      - qemu_cortex_m3
     tags:
       - drivers
       - retained_mem

--- a/tests/drivers/spi/spi_controller_peripheral/testcase.yaml
+++ b/tests/drivers/spi/spi_controller_peripheral/testcase.yaml
@@ -4,9 +4,12 @@ common:
   harness: ztest
   harness_config:
     fixture: gpio_spi_loopback
-  platform_allow: |
-    nrf52840dk/nrf52840 nrf54l15dk/nrf54l15/cpuapp nrf54h20dk/nrf54h20/cpuapp
-    nrf54h20dk/nrf54h20/cpurad nrf54h20dk/nrf54h20/cpuppr
+  platform_allow:
+    - nrf52840dk/nrf52840
+    - nrf54l15dk/nrf54l15/cpuapp
+    - nrf54h20dk/nrf54h20/cpuapp
+    - nrf54h20dk/nrf54h20/cpurad
+    - nrf54h20dk/nrf54h20/cpuppr
 
 tests:
   drivers.spi.spi_mode0:

--- a/tests/drivers/spi/spi_loopback/testcase.yaml
+++ b/tests/drivers/spi/spi_loopback/testcase.yaml
@@ -33,6 +33,8 @@ tests:
     platform_allow:
       - robokit1
       - mimxrt1170_evk/mimxrt1176/cm7
+    integration_platforms:
+      - robokit1
   drivers.spi.mcux_dspi_dma.loopback:
     extra_args:
       - EXTRA_CONF_FILE="overlay-mcux-dspi-dma.conf"
@@ -52,15 +54,15 @@ tests:
     extra_args:
       - EXTRA_CONF_FILE="overlay-stm32-spi-16bits.conf"
       - DTC_OVERLAY_FILE="overlay-stm32-spi-16bits.overlay"
-    filter: CONFIG_SOC_FAMILY_STM32
     platform_allow:
       - nucleo_h743zi
       - nucleo_h753zi
       - nucleo_h745zi_q/stm32h745xx/m4
       - nucleo_h745zi_q/stm32h745xx/m7
+    integration_platforms:
+      - nucleo_h743zi
   drivers.spi.stm32_spi_dma.loopback:
     extra_args: EXTRA_CONF_FILE="overlay-stm32-spi-dma.conf"
-    filter: CONFIG_SOC_FAMILY_STM32
     platform_allow:
       - b_u585i_iot02a
       - nucleo_g474re
@@ -83,35 +85,39 @@ tests:
     # using `zephyr,memory-attr = < DT_MEM_ARM_MPU_RAM_NOCACHE)>`
     extra_args:
       - EXTRA_CONF_FILE="overlay-stm32-spi-dma-dt-nocache-mem.conf"
-    filter: CONFIG_SOC_FAMILY_STM32 and CONFIG_CPU_HAS_DCACHE
+    filter: CONFIG_CPU_HAS_DCACHE
     platform_allow:
       - nucleo_h743zi
       - nucleo_h753zi
       - nucleo_h745zi_q/stm32h745xx/m4
       - nucleo_h745zi_q/stm32h745xx/m7
+    integration_platforms:
+      - nucleo_h743zi
   drivers.spi.stm32_spi_16bits_frames_dma.loopback:
     extra_args:
       - EXTRA_CONF_FILE="overlay-stm32-spi-16bits-dma.conf"
       - DTC_OVERLAY_FILE="overlay-stm32-spi-16bits.overlay"
-    filter: CONFIG_SOC_FAMILY_STM32
     platform_allow:
       - nucleo_h743zi
       - nucleo_h753zi
       - nucleo_h745zi_q/stm32h745xx/m4
       - nucleo_h745zi_q/stm32h745xx/m7
+    integration_platforms:
+      - nucleo_h743zi
   drivers.spi.stm32_spi_16bits_frames_dma_dt_nocache_mem.loopback:
     extra_args:
       - EXTRA_CONF_FILE="overlay-stm32-spi-16bits-dma-dt-nocache-mem.conf"
       - DTC_OVERLAY_FILE="overlay-stm32-spi-16bits.overlay"
-    filter: CONFIG_SOC_FAMILY_STM32 and CONFIG_CPU_HAS_DCACHE
+    filter: CONFIG_CPU_HAS_DCACHE
     platform_allow:
       - nucleo_h743zi
       - nucleo_h753zi
       - nucleo_h745zi_q/stm32h745xx/m4
       - nucleo_h745zi_q/stm32h745xx/m7
+    integration_platforms:
+      - nucleo_h743zi
   drivers.spi.stm32_spi_interrupt.loopback:
     extra_args: EXTRA_CONF_FILE="overlay-stm32-spi-interrupt.conf"
-    filter: CONFIG_SOC_FAMILY_STM32
     platform_allow:
       - b_u585i_iot02a
       - nucleo_f207zg
@@ -128,6 +134,8 @@ tests:
       - nucleo_wl55jc
       - stm32f3_disco
       - stm32h573i_dk
+    integration_platforms:
+      - stm32h573i_dk
   drivers.spi.gd32_spi_interrupt.loopback:
     extra_args: EXTRA_CONF_FILE="overlay-gd32-spi-interrupt.conf"
     platform_allow:
@@ -141,6 +149,8 @@ tests:
       - gd32vf103v_eval
       - longan_nano
       - longan_nano/gd32vf103/lite
+    integration_platforms:
+      - gd32f403z_eval
   drivers.spi.gd32_spi_dma.loopback:
     extra_args: EXTRA_CONF_FILE="overlay-gd32-spi-dma.conf"
     platform_allow:
@@ -154,6 +164,8 @@ tests:
       - gd32vf103v_eval
       - longan_nano
       - longan_nano/gd32vf103/lite
+    integration_platforms:
+      - gd32f403z_eval
   drivers.spi.pl022_spi_interrupt.loopback:
     extra_configs:
       - CONFIG_SPI_PL022_INTERRUPT=y

--- a/tests/drivers/timer/nrf_grtc_timer/testcase.yaml
+++ b/tests/drivers/timer/nrf_grtc_timer/testcase.yaml
@@ -9,3 +9,5 @@ tests:
       - nrf54h20dk/nrf54h20/cpurad
       - nrf54h20dk/nrf54h20/cpuppr
       - nrf54l20pdk/nrf54l20/cpuapp
+    integration_platforms:
+      - nrf54l20pdk/nrf54l20/cpuapp

--- a/tests/drivers/uart/uart_async_api/testcase.yaml
+++ b/tests/drivers/uart/uart_async_api/testcase.yaml
@@ -85,6 +85,8 @@ tests:
       - CONFIG_UART_SAM0_ASYNC=y
       - CONFIG_DMA=y
     build_only: true
+    integration_platforms:
+      - samc21n_xpro
   drivers.uart.async_api.nocache_mem:
     # nocache memory region is defined by the linker
     filter: CONFIG_SERIAL_SUPPORT_ASYNC and CONFIG_CPU_HAS_DCACHE

--- a/tests/drivers/uart/uart_elementary/testcase.yaml
+++ b/tests/drivers/uart/uart_elementary/testcase.yaml
@@ -12,6 +12,8 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l15dk/nrf54l15/cpuflpr
       - nrf5340dk/nrf5340/cpuapp
+    integration_platforms:
+      - nrf54h20dk/nrf54h20/cpuapp
   drivers.uart.uart_elementary_dual_nrf54h:
     filter: CONFIG_SERIAL_SUPPORT_INTERRUPT
     platform_allow:

--- a/tests/drivers/uart/uart_pm/testcase.yaml
+++ b/tests/drivers/uart/uart_pm/testcase.yaml
@@ -12,6 +12,8 @@ common:
   harness_config:
     fixture: gpio_loopback
   depends_on: gpio
+  integration_platforms:
+    - nrf52840dk/nrf52840
 tests:
   drivers.uart.pm:
     extra_configs:

--- a/tests/drivers/w1/w1_api/testcase.yaml
+++ b/tests/drivers/w1/w1_api/testcase.yaml
@@ -47,3 +47,5 @@ tests:
       - max32680evkit/max32680/m4
       - max32690evkit/max32690/m4
       - max78002evkit/max78002/m4
+    integration_platforms:
+      - apard32690/max32690/m4

--- a/tests/drivers/watchdog/wdt_basic_api/testcase.yaml
+++ b/tests/drivers/watchdog/wdt_basic_api/testcase.yaml
@@ -122,6 +122,8 @@ tests:
       - s32z2xxdc2@D/s32z270/rtu0
       - s32z2xxdc2@D/s32z270/rtu1
       - mr_canhubk3
+    integration_platforms:
+      - s32z2xxdc2/s32z270/rtu0
   drivers.watchdog.mimxrt1050_evk_ti_tps382x:
     filter: dt_compat_enabled("ti,tps382x")
     platform_allow: mimxrt1050_evk

--- a/tests/drivers/watchdog/wdt_basic_reset_none/testcase.yaml
+++ b/tests/drivers/watchdog/wdt_basic_reset_none/testcase.yaml
@@ -9,6 +9,8 @@ tests:
       - s32z2xxdc2@D/s32z270/rtu0
       - s32z2xxdc2@D/s32z270/rtu1
       - mr_canhubk3
+    integration_platforms:
+      - s32z2xxdc2/s32z270/rtu0
     tags:
       - drivers
       - watchdog

--- a/tests/modules/thrift/ThriftTest/testcase.yaml
+++ b/tests/modules/thrift/ThriftTest/testcase.yaml
@@ -14,6 +14,8 @@ common:
     - qemu_riscv32
     - qemu_riscv64
     - qemu_x86_64
+  integration_platforms:
+    - qemu_riscv64
 tests:
   thrift.ThriftTest.binaryProtocol: {}
   thrift.ThriftTest.compactProtocol:

--- a/tests/subsys/fs/ext2/testcase.yaml
+++ b/tests/subsys/fs/ext2/testcase.yaml
@@ -8,6 +8,8 @@ tests:
       - hifive_unmatched/fu740/s7
       - hifive_unmatched/fu740/u74
       - bl5340_dvk/nrf5340/cpuapp
+    integration_platforms:
+      - native_sim
     extra_args:
       - EXTRA_DTC_OVERLAY_FILE="ramdisk_small.overlay"
 

--- a/tests/subsys/mgmt/mcumgr/cb_notifications/testcase.yaml
+++ b/tests/subsys/mgmt/mcumgr/cb_notifications/testcase.yaml
@@ -11,6 +11,8 @@ tests:
       - native_sim/native/64
       - qemu_riscv32/qemu_virt_riscv32/smp
       - qemu_riscv64
+    integration_platforms:
+      - native_sim
     tags:
       - cb_notifications
       - mcumgr

--- a/tests/subsys/mgmt/mcumgr/os_mgmt_datetime/testcase.yaml
+++ b/tests/subsys/mgmt/mcumgr/os_mgmt_datetime/testcase.yaml
@@ -15,5 +15,7 @@ common:
     - qemu_malta
     - qemu_arc/qemu_arc_hs6x
     - qemu_leon3
+  integration_platforms:
+    - native_sim
 tests:
   mgmt.mcumgr.os.datetime: {}

--- a/tests/subsys/settings/file/testcase.yaml
+++ b/tests/subsys/settings/file/testcase.yaml
@@ -8,6 +8,8 @@ tests:
       - native_sim
       - native_sim/native/64
       - mr_canhubk3
+    integration_platforms:
+      - nrf52840dk/nrf52840
     tags:
       - settings
       - file


### PR DESCRIPTION
Add integration_platforms to many tests that use platform_allow to
manage scope of pull_request CI.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
