### PR TITLE
soc: esp32c3: update soc type list and referenced boards

### DIFF
--- a/boards/01space/esp32c3_042_oled/Kconfig.esp32c3_042_oled
+++ b/boards/01space/esp32c3_042_oled/Kconfig.esp32c3_042_oled
@@ -2,4 +2,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config BOARD_ESP32C3_042_OLED
-	select SOC_ESP32C3_FX4
+	select SOC_ESP32C3_FH4

--- a/boards/lilygo/ttgo_t8c3/Kconfig.ttgo_t8c3
+++ b/boards/lilygo/ttgo_t8c3/Kconfig.ttgo_t8c3
@@ -2,4 +2,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config BOARD_TTGO_T8C3
-	select SOC_ESP32C3_FX4
+	select SOC_ESP32C3_FN4

--- a/boards/m5stack/stamp_c3/Kconfig.stamp_c3
+++ b/boards/m5stack/stamp_c3/Kconfig.stamp_c3
@@ -4,4 +4,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config BOARD_STAMP_C3
-	select SOC_ESP32C3_FX4
+	select SOC_ESP32C3_FN4

--- a/boards/seeed/xiao_esp32c3/Kconfig.xiao_esp32c3
+++ b/boards/seeed/xiao_esp32c3/Kconfig.xiao_esp32c3
@@ -2,4 +2,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config BOARD_XIAO_ESP32C3
-	select SOC_ESP32C3_FX4
+	select SOC_ESP32C3_FN4

--- a/soc/espressif/esp32c3/Kconfig.soc
+++ b/soc/espressif/esp32c3/Kconfig.soc
@@ -7,11 +7,17 @@ config SOC_SERIES_ESP32C3
 	help
 	  ESP32C3
 
-config SOC_ESP32C3_FX4
+config SOC_ESP32C3_FN4
 	bool
 	select SOC_ESP32C3
 	help
-	  ESP32C3_FX4
+	  ESP32C3_FN4
+
+config SOC_ESP32C3_FH4
+	bool
+	select SOC_ESP32C3
+	help
+	  ESP32C3_FH4
 
 config SOC_ESP32C3_MINI_N4
 	bool
@@ -44,7 +50,8 @@ config SOC
 	default "esp32c3" if SOC_SERIES_ESP32C3
 
 config SOC_PART_NUMBER
-	default "ESP32C3_FX4" if SOC_ESP32C3_FX4
+	default "ESP32C3_FN4" if SOC_ESP32C3_FN4
+	default "ESP32C3_FH4" if SOC_ESP32C3_FH4
 	default "ESP32C3_MINI_N4" if SOC_ESP32C3_MINI_N4
 	default "ESP32C3_WROOM_02_N4" if SOC_ESP32C3_WROOM_02_N4
 	default "ESP32C3_WROOM_02_N8" if SOC_ESP32C3_WROOM_02_N8

--- a/soc/espressif/esp32c3/Kconfig.soc
+++ b/soc/espressif/esp32c3/Kconfig.soc
@@ -19,6 +19,13 @@ config SOC_ESP32C3_FH4
 	help
 	  ESP32C3_FH4
 
+config SOC_ESP32C3_FH4X
+	bool
+	select SOC_ESP32C3
+	select SOC_ESP32C3_REV_1_1
+	help
+	  ESP32C3_FH4X
+
 config SOC_ESP32C3_MINI_N4
 	bool
 	select SOC_ESP32C3
@@ -43,6 +50,12 @@ config SOC_ESP32C3
 	help
 	  ESP32C3
 
+config SOC_ESP32C3_REV_1_1
+	bool "SOC is revision v1.1"
+	help
+	  ESP32-C3 revision v1.1 has updated ROM functions for Wi-Fi and BLE that
+	  can free up to 35kB of RAM.
+
 config SOC_SERIES
 	default "esp32c3" if SOC_SERIES_ESP32C3
 
@@ -52,6 +65,7 @@ config SOC
 config SOC_PART_NUMBER
 	default "ESP32C3_FN4" if SOC_ESP32C3_FN4
 	default "ESP32C3_FH4" if SOC_ESP32C3_FH4
+	default "ESP32C3_FH4X" if SOC_ESP32C3_FH4X
 	default "ESP32C3_MINI_N4" if SOC_ESP32C3_MINI_N4
 	default "ESP32C3_WROOM_02_N4" if SOC_ESP32C3_WROOM_02_N4
 	default "ESP32C3_WROOM_02_N8" if SOC_ESP32C3_WROOM_02_N8

--- a/west.yml
+++ b/west.yml
@@ -157,7 +157,7 @@ manifest:
       groups:
         - hal
     - name: hal_espressif
-      revision: 6605f649d151f255011c7dfdd35cd568caa871a4
+      revision: 980d61c1d3d3e801ed7c5ccb57ec84c5dd9e9360
       path: modules/hal/espressif
       west-commands: west/west-commands.yml
       groups:


### PR DESCRIPTION
This PR updates some of esp32c3-based board to use proper SOC part number.
This also adds FH4X model, which has improved ROM code and can free up to 35kB of memory usage depending on the application (specially for Wi-Fi/BLE usage).

In case of Wi-Fi shell sample code, the diff is:

Non FH4X type:
```Memory region         Used Size  Region Size  %age Used
           FLASH:      611968 B    4194048 B     14.59%
     iram0_0_seg:      138272 B     306688 B     45.09%
     dram0_0_seg:      219648 B     306688 B     71.62%
     irom0_0_seg:      310056 B         4 MB      7.39%
     drom0_0_seg:      415360 B         4 MB      9.90%
    rtc_iram_seg:          0 GB         8 KB      0.00%
        IDT_LIST:          0 GB         8 KB      0.00%
```
FH4X type:
```
Memory region         Used Size  Region Size  %age Used
           FLASH:      612312 B    4194048 B     14.60%
     iram0_0_seg:      141040 B     306688 B     45.99%
     dram0_0_seg:      222416 B     306688 B     72.52%
     irom0_0_seg:      315098 B         4 MB      7.51%
     drom0_0_seg:      415704 B         4 MB      9.91%
    rtc_iram_seg:          0 GB         8 KB      0.00%
        IDT_LIST:          0 GB         8 KB      0.00%
```