### PR TITLE
devicetree: Get interrupt flags through binding-API

### DIFF
--- a/include/zephyr/devicetree/interrupt_controller.h
+++ b/include/zephyr/devicetree/interrupt_controller.h
@@ -50,6 +50,49 @@ extern "C" {
 #define DT_INST_INTC_GET_AGGREGATOR_LEVEL(inst) DT_INTC_GET_AGGREGATOR_LEVEL(DT_DRV_INST(inst))
 
 /**
+ * @brief Get a interrupt controller specifier's flags cell
+ *
+ * This macro expects interrupt specifiers with cells named "sense" | "priority".
+ * If there is no "sense" or "priority" cell in the interrupt specifier, zero is returned.
+ * Refer to the node's binding to check specifier cell names if necessary.
+ *
+ * Example devicetree fragment:
+ *
+ *     intc1: interrupt-controller@... {
+ *             compatible = "vnd,interrupt";
+ *             #interrupt-cells = <2>;
+ *     };
+ *
+ *     intc2: interrupt-controller@... {
+ *             compatible = "vnd,interrupt";
+ *             #interrupt-cells = <2>;
+ *     };
+ *
+ *     n: node {
+ *             interrupts-extended = <&intc1 3 2 15>,
+ *                                   <&intc2 4 3 16>;
+ *     };
+ *
+ * Bindings fragment for the vnd,interrupt compatible:
+ *
+ *     interrupt-cells:
+ *       - irq
+ *       - sense
+ *       - priority
+ *
+ * Example usage:
+ *
+ *     DT_INTC_FLAGS_BY_IDX(DT_NODELABEL(n), 0) // ((2 << 8) | (15 << 0))
+ *     DT_INTC_FLAGS_BY_IDX(DT_NODELABEL(n), 1) // ((3 << 8) | (16 << 0))
+ *
+ * @param inst instance of an interrupt controller
+ * @return the flags cell value at index "idx", or zero if there is none
+ */
+#define DT_INTC_FLAGS_BY_IDX(inst, idx) \
+	((DT_INST_IRQ_BY_IDX(inst, idx, sense) << 8) \
+	| (DT_INST_IRQ_BY_IDX(inst, idx, priority)) << 0)
+
+/**
  * @}
  */
 

--- a/include/zephyr/devicetree/interrupt_controller.h
+++ b/include/zephyr/devicetree/interrupt_controller.h
@@ -93,6 +93,14 @@ extern "C" {
 	| (DT_INST_IRQ_BY_IDX(inst, idx, priority)) << 0)
 
 /**
+ * @brief Equivalent to DT_INTC_FLAGS_BY_IDX(inst, 0)
+ * @param inst instance of an interrupt controller
+ * @return the flags cell value at index 0, or zero if there is none
+ * @see DT_INTC_FLAGS_BY_IDX()
+ */
+#define DT_INTC_FLAGS(inst) DT_INTC_FLAGS_BY_IDX(inst, 0)
+
+/**
  * @}
  */
 

--- a/tests/lib/devicetree/api/src/main.c
+++ b/tests/lib/devicetree/api/src/main.c
@@ -6,6 +6,7 @@
 
 #include <zephyr/ztest.h>
 #include <zephyr/devicetree.h>
+#include <zephyr/devicetree/interrupt_controller.h>
 #include <zephyr/device.h>
 #include <zephyr/drivers/adc.h>
 #include <zephyr/drivers/gpio.h>
@@ -3536,6 +3537,13 @@ ZTEST(devicetree_api, test_reset)
 #define DT_DRV_COMPAT vnd_interrupt_holder_extended
 ZTEST(devicetree_api, test_interrupt_controller)
 {
+	/* DT_INTC_FLAGS_BY_IDX */
+	zassert_equal(DT_INTC_FLAGS_BY_IDX(TEST_IRQ_EXT, 0), 0x4607, "");
+	zassert_equal(DT_INTC_FLAGS_BY_IDX(TEST_IRQ_EXT, 2), 0x2A07, "");
+
+	/* DT_INTC_FLAGS */
+	zassert_equal(DT_INTC_FLAGS(TEST_IRQ_EXT), 0x4607, "");
+
 	/* DT_IRQ_INTC_BY_IDX */
 	zassert_true(DT_SAME_NODE(DT_IRQ_INTC_BY_IDX(TEST_IRQ_EXT, 0), TEST_INTC), "");
 	zassert_true(DT_SAME_NODE(DT_IRQ_INTC_BY_IDX(TEST_IRQ_EXT, 1), TEST_GPIO_4), "");


### PR DESCRIPTION
It can be used to obtain the cell in interrupts-extended in the interrupt devicetree(but the value it gets is the result of combining the attributes.)

I'm not sure if this is what @bjarki-andreasen expects. I feel that the usage scenario of this API is not much different from the definition in the binding-rule and device tree in the binding-api test environment.