### PR TITLE
drivers: hwinfo: Support for reset reasons in nRF54H20

### DIFF
--- a/drivers/hwinfo/hwinfo_nrf.c
+++ b/drivers/hwinfo/hwinfo_nrf.c
@@ -8,8 +8,13 @@
 #include <zephyr/drivers/hwinfo.h>
 #include <string.h>
 #include <zephyr/sys/byteorder.h>
-#if !defined(CONFIG_SOC_SERIES_NRF54HX) && !defined(CONFIG_BOARD_QEMU_CORTEX_M0)
+#if defined(CONFIG_BOARD_QEMU_CORTEX_M0) || \
+	(defined(CONFIG_NRF_PLATFORM_HALTIUM) && \
+	 defined(CONFIG_RISCV_CORE_NORDIC_VPR))
+#define RESET_CAUSE_AVAILABLE 0
+#else
 #include <helpers/nrfx_reset_reason.h>
+#define RESET_CAUSE_AVAILABLE 1
 #endif
 
 #if defined(CONFIG_TRUSTED_EXECUTION_NONSECURE) && defined(NRF_FICR_S)
@@ -63,7 +68,30 @@ ssize_t z_impl_hwinfo_get_device_id(uint8_t *buffer, size_t length)
 	return length;
 }
 
-#if !defined(CONFIG_SOC_SERIES_NRF54HX) && !defined(CONFIG_BOARD_QEMU_CORTEX_M0)
+#if RESET_CAUSE_AVAILABLE
+
+#if defined(NRF_RESETINFO)
+
+#define REASON_LOCKUP (NRFX_RESET_REASON_LOCKUP_MASK | NRFX_RESET_REASON_LOCAL_LOCKUP_MASK)
+#define REASON_SOFTWARE (NRFX_RESET_REASON_SREQ_MASK | NRFX_RESET_REASON_LOCAL_SREQ_MASK)
+#define REASON_WATCHDOG	\
+	(NRFX_RESET_REASON_DOG_MASK | \
+	 NRFX_RESET_REASON_LOCAL_DOG1_MASK | \
+	 NRFX_RESET_REASON_LOCAL_DOG0_MASK)
+
+#else /* NRF_RESETINFO */
+
+#define REASON_LOCKUP NRFX_RESET_REASON_LOCKUP_MASK
+#define REASON_SOFTWARE NRFX_RESET_REASON_SREQ_MASK
+
+#if NRF_POWER_HAS_RESETREAS
+#define REASON_WATCHDOG NRFX_RESET_REASON_DOG_MASK
+#else
+#define REASON_WATCHDOG	(NRFX_RESET_REASON_DOG0_MASK | NRFX_RESET_REASON_DOG1_MASK)
+#endif /* NRF_POWER_HAS_RESETREAS */
+
+#endif /* NRF_RESETINFO */
+
 int z_impl_hwinfo_get_reset_cause(uint32_t *cause)
 {
 	uint32_t flags = 0;
@@ -73,19 +101,21 @@ int z_impl_hwinfo_get_reset_cause(uint32_t *cause)
 	if (reason & NRFX_RESET_REASON_RESETPIN_MASK) {
 		flags |= RESET_PIN;
 	}
-	if (reason & NRFX_RESET_REASON_DOG_MASK) {
+	if (reason & REASON_WATCHDOG) {
 		flags |= RESET_WATCHDOG;
 	}
-	if (reason & NRFX_RESET_REASON_LOCKUP_MASK) {
+
+	if (reason & REASON_LOCKUP) {
 		flags |= RESET_CPU_LOCKUP;
 	}
+
 	if (reason & NRFX_RESET_REASON_OFF_MASK) {
 		flags |= RESET_LOW_POWER_WAKE;
 	}
 	if (reason & NRFX_RESET_REASON_DIF_MASK) {
 		flags |= RESET_DEBUG;
 	}
-	if (reason & NRFX_RESET_REASON_SREQ_MASK) {
+	if (reason & REASON_SOFTWARE) {
 		flags |= RESET_SOFTWARE;
 	}
 
@@ -124,11 +154,7 @@ int z_impl_hwinfo_get_reset_cause(uint32_t *cause)
 		flags |= RESET_DEBUG;
 	}
 #endif
-#if !NRF_POWER_HAS_RESETREAS
-	if (reason & NRFX_RESET_REASON_DOG1_MASK) {
-		flags |= RESET_WATCHDOG;
-	}
-#endif
+
 #if NRFX_RESET_REASON_HAS_GRTC
 	if (reason & NRFX_RESET_REASON_GRTC_MASK) {
 		flags |= RESET_CLOCK;
@@ -147,6 +173,7 @@ int z_impl_hwinfo_get_reset_cause(uint32_t *cause)
 	if (reason & NRFX_RESET_REASON_LCTRLAP_MASK) {
 		flags |= RESET_DEBUG;
 	}
+
 #endif
 #if defined(NRFX_RESET_REASON_TAMPC_MASK)
 	if (reason & NRFX_RESET_REASON_TAMPC_MASK) {
@@ -184,4 +211,4 @@ int z_impl_hwinfo_get_supported_reset_cause(uint32_t *supported)
 
 	return 0;
 }
-#endif
+#endif /* RESET_CAUSE_AVAILABLE */


### PR DESCRIPTION
Adding support for reset reasons in the nRF54H20 SoC.