### PR TITLE
Bluetooth: Host: deprecate bt_le_set_auto_conn()

### DIFF
--- a/doc/connectivity/bluetooth/bluetooth-le-host.rst
+++ b/doc/connectivity/bluetooth/bluetooth-le-host.rst
@@ -73,9 +73,7 @@ To initially discover a device to connect to the application will likely
 use the :c:func:`bt_le_scan_start` API, wait for an appropriate device
 to be found (using the scan callback), stop scanning using
 :c:func:`bt_le_scan_stop` and then connect to the device using
-:c:func:`bt_conn_le_create`. If the central wants to keep
-automatically reconnecting to the peripheral it should use the
-:c:func:`bt_le_set_auto_conn` API.
+:c:func:`bt_conn_le_create`.
 
 There are some sample applications for the central role available in the
 tree, such as :zephyr_file:`samples/bluetooth/central_hr`.

--- a/doc/releases/release-notes-4.1.rst
+++ b/doc/releases/release-notes-4.1.rst
@@ -30,6 +30,10 @@ Removed APIs in this release
 Deprecated in this release
 ==========================
 
+* Deprecated the :c:func:`bt_le_set_auto_conn` API function. Application developers can achieve
+  the same functionality in their application code by reconnecting to the peer when the
+  :c:member:`bt_conn_cb.disconnected` callback is invoked.
+
 Architectures
 *************
 

--- a/include/zephyr/bluetooth/conn.h
+++ b/include/zephyr/bluetooth/conn.h
@@ -1432,8 +1432,8 @@ int bt_conn_create_auto_stop(void);
  *
  *  @return Zero on success or error code otherwise.
  */
-int bt_le_set_auto_conn(const bt_addr_le_t *addr,
-			const struct bt_le_conn_param *param);
+__deprecated int bt_le_set_auto_conn(const bt_addr_le_t *addr,
+				     const struct bt_le_conn_param *param);
 
 /** @brief Set security level for a connection.
  *

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -1851,18 +1851,6 @@ static int conn_disconnect(struct bt_conn *conn, uint8_t reason)
 
 int bt_conn_disconnect(struct bt_conn *conn, uint8_t reason)
 {
-	/* Disconnection is initiated by us, so auto connection shall
-	 * be disabled. Otherwise the passive scan would be enabled
-	 * and we could send LE Create Connection as soon as the remote
-	 * starts advertising.
-	 */
-#if !defined(CONFIG_BT_FILTER_ACCEPT_LIST)
-	if (IS_ENABLED(CONFIG_BT_CENTRAL) &&
-	    conn->type == BT_CONN_TYPE_LE) {
-		bt_le_set_auto_conn(&conn->le.dst, NULL);
-	}
-#endif /* !defined(CONFIG_BT_FILTER_ACCEPT_LIST) */
-
 	switch (conn->state) {
 	case BT_CONN_SCAN_BEFORE_INITIATING:
 		conn->err = reason;

--- a/subsys/bluetooth/host/conn_internal.h
+++ b/subsys/bluetooth/host/conn_internal.h
@@ -49,7 +49,7 @@ typedef enum __packed {
 enum {
 	/** The connection context is used for automatic connection establishment
 	 *
-	 * That is, with @ref bt_conn_le_create_auto() or bt_le_set_auto_conn().
+	 * That is, with @ref bt_conn_le_create_auto().
 	 * This flag is set even after the connection has been established so
 	 * that the connection can be reestablished once disconnected.
 	 * The connection establishment may be performed with or without the filter

--- a/subsys/bluetooth/host/shell/bt.c
+++ b/subsys/bluetooth/host/shell/bt.c
@@ -3321,33 +3321,6 @@ static int cmd_connect_le(const struct shell *sh, size_t argc, char *argv[])
 	return 0;
 }
 
-#if !defined(CONFIG_BT_FILTER_ACCEPT_LIST)
-static int cmd_auto_conn(const struct shell *sh, size_t argc, char *argv[])
-{
-	bt_addr_le_t addr;
-	int err;
-
-	err = bt_addr_le_from_str(argv[1], argv[2], &addr);
-	if (err) {
-		shell_error(sh, "Invalid peer address (err %d)", err);
-		return err;
-	}
-
-	if (argc < 4) {
-		return bt_le_set_auto_conn(&addr, BT_LE_CONN_PARAM_DEFAULT);
-	} else if (!strcmp(argv[3], "on")) {
-		return bt_le_set_auto_conn(&addr, BT_LE_CONN_PARAM_DEFAULT);
-	} else if (!strcmp(argv[3], "off")) {
-		return bt_le_set_auto_conn(&addr, NULL);
-	} else {
-		shell_help(sh);
-		return SHELL_CMD_HELP_PRINTED;
-	}
-
-	return 0;
-}
-#endif /* !defined(CONFIG_BT_FILTER_ACCEPT_LIST) */
-
 static int cmd_connect_le_name(const struct shell *sh, size_t argc, char *argv[])
 {
 	const struct bt_le_scan_param param = {
@@ -5076,9 +5049,6 @@ SHELL_STATIC_SUBCMD_SET_CREATE(bt_cmds,
 #if defined(CONFIG_BT_CENTRAL)
 	SHELL_CMD_ARG(connect, NULL, HELP_ADDR_LE EXT_ADV_SCAN_OPT,
 		      cmd_connect_le, 1, 3),
-#if !defined(CONFIG_BT_FILTER_ACCEPT_LIST)
-	SHELL_CMD_ARG(auto-conn, NULL, HELP_ADDR_LE, cmd_auto_conn, 3, 0),
-#endif /* !defined(CONFIG_BT_FILTER_ACCEPT_LIST) */
 	SHELL_CMD_ARG(connect-name, NULL, "<name filter>",
 		      cmd_connect_le_name, 2, 0),
 #endif /* CONFIG_BT_CENTRAL */


### PR DESCRIPTION
bt_le_set_auto_conn() function is not working as
expected. Also, it doesn't have any test coverage
and any usage in sample applications.
The function is deprecated
Fixes #81597