### PR TITLE
doc: boards: exensions: add board name to side box

### DIFF
--- a/doc/_extensions/zephyr/domain/__init__.py
+++ b/doc/_extensions/zephyr/domain/__init__.py
@@ -253,6 +253,7 @@ class ConvertBoardNode(SphinxTransform):
             sidebar += field_list
 
             details = [
+                ("Name", nodes.literal(text=node["id"])),
                 ("Vendor", node["vendor"]),
                 ("Architecture", ", ".join(node["archs"])),
                 ("SoC", ", ".join(node["socs"])),
@@ -262,7 +263,10 @@ class ConvertBoardNode(SphinxTransform):
                 field = nodes.field()
                 field_name = nodes.field_name(text=property_name)
                 field_body = nodes.field_body()
-                field_body += nodes.paragraph(text=value)
+                if isinstance(value, nodes.Node):
+                    field_body += value
+                else:
+                    field_body += nodes.paragraph(text=value)
                 field += field_name
                 field += field_body
                 field_list += field

--- a/doc/_static/css/custom.css
+++ b/doc/_static/css/custom.css
@@ -1159,8 +1159,15 @@ li>a.code-sample-link.reference.internal.current {
     margin-top: 12px !important;
     margin-bottom: 12px !important;
     grid-template-columns: auto 1fr !important;
+    padding-right: 1em;
 }
 
 .sidebar.board-overview dl.field-list > dt {
     background: transparent !important;
+}
+
+.sidebar.board-overview dl.field-list>dd {
+    margin-left: 1em;
+    text-overflow: ellipsis;
+    overflow: hidden;
 }


### PR DESCRIPTION
This adds the board name (displayed as a code literal) to the "Wikipedia card" for quick reference.

https://builds.zephyrproject.io/zephyr/pr/81760/docs/boards/st/nucleo_g0b1re/doc/index.html

Fixes #81652.