### PR TITLE
General fix for MSPI drivers and Apollo3p mspi feature update

### DIFF
--- a/drivers/flash/flash_mspi_atxp032.c
+++ b/drivers/flash/flash_mspi_atxp032.c
@@ -124,6 +124,7 @@ static int flash_mspi_atxp032_command_write(const struct device *flash, uint8_t 
 	data->trans.async             = false;
 	data->trans.xfer_mode         = MSPI_PIO;
 	data->trans.tx_dummy          = tx_dummy;
+	data->trans.rx_dummy          = data->dev_cfg.rx_dummy;
 	data->trans.cmd_length        = 1;
 	data->trans.addr_length       = addr_len;
 	data->trans.hold_ce           = false;
@@ -155,6 +156,7 @@ static int flash_mspi_atxp032_command_read(const struct device *flash, uint8_t c
 
 	data->trans.async             = false;
 	data->trans.xfer_mode         = MSPI_PIO;
+	data->trans.tx_dummy          = data->dev_cfg.tx_dummy;
 	data->trans.rx_dummy          = rx_dummy;
 	data->trans.cmd_length        = 1;
 	data->trans.addr_length       = addr_len;
@@ -261,7 +263,7 @@ static int flash_mspi_atxp032_get_vendor_id(const struct device *flash, uint8_t 
 	ret = flash_mspi_atxp032_command_read(flash, SPI_NOR_CMD_RDID, 0, 0, 0, buffer, 11);
 	*vendor_id = buffer[7];
 
-	data->jedec_id = (buffer[7] << 16) | (buffer[8] << 8) | buffer[9];
+	memcpy(&data->jedec_id, buffer + 7, 3);
 
 	return ret;
 }
@@ -326,10 +328,11 @@ static int flash_mspi_atxp032_page_program(const struct device *flash, off_t off
 	data->trans.async             = false;
 	data->trans.xfer_mode         = MSPI_DMA;
 	data->trans.tx_dummy          = data->dev_cfg.tx_dummy;
+	data->trans.rx_dummy          = data->dev_cfg.rx_dummy;
 	data->trans.cmd_length        = data->dev_cfg.cmd_length;
 	data->trans.addr_length       = data->dev_cfg.addr_length;
 	data->trans.hold_ce           = false;
-	data->trans.priority          = 1;
+	data->trans.priority          = MSPI_XFER_PRIORITY_MEDIUM;
 	data->trans.packets           = &data->packet;
 	data->trans.num_packet        = 1;
 	data->trans.timeout           = CONFIG_MSPI_COMPLETION_TIMEOUT_TOLERANCE;
@@ -375,6 +378,7 @@ static int flash_mspi_atxp032_busy_wait(const struct device *flash)
 			return ret;
 		}
 		LOG_DBG("status: 0x%x", status);
+		k_sleep(K_MSEC(1));
 	} while (status & SPI_NOR_WIP_BIT);
 
 	if (data->dev_cfg.io_mode != MSPI_IO_MODE_SINGLE) {
@@ -407,11 +411,12 @@ static int flash_mspi_atxp032_read(const struct device *flash, off_t offset, voi
 
 	data->trans.async             = false;
 	data->trans.xfer_mode         = MSPI_DMA;
+	data->trans.tx_dummy          = data->dev_cfg.tx_dummy;
 	data->trans.rx_dummy          = data->dev_cfg.rx_dummy;
 	data->trans.cmd_length        = data->dev_cfg.cmd_length;
 	data->trans.addr_length       = data->dev_cfg.addr_length;
 	data->trans.hold_ce           = false;
-	data->trans.priority          = 1;
+	data->trans.priority          = MSPI_XFER_PRIORITY_MEDIUM;
 	data->trans.packets           = &data->packet;
 	data->trans.num_packet        = 1;
 	data->trans.timeout           = CONFIG_MSPI_COMPLETION_TIMEOUT_TOLERANCE;
@@ -681,6 +686,7 @@ static int flash_mspi_atxp032_init(const struct device *flash)
 	}
 	data->timing_cfg = cfg->tar_timing_cfg;
 
+#if CONFIG_MSPI_XIP
 	if (cfg->tar_xip_cfg.enable) {
 		if (mspi_xip_config(cfg->bus, &cfg->dev_id, &cfg->tar_xip_cfg)) {
 			LOG_ERR("Failed to enable XIP/%u", __LINE__);
@@ -688,7 +694,9 @@ static int flash_mspi_atxp032_init(const struct device *flash)
 		}
 		data->xip_cfg = cfg->tar_xip_cfg;
 	}
+#endif /* CONFIG_MSPI_XIP */
 
+#if CONFIG_MSPI_SCRAMBLE
 	if (cfg->tar_scramble_cfg.enable) {
 		if (mspi_scramble_config(cfg->bus, &cfg->dev_id, &cfg->tar_scramble_cfg)) {
 			LOG_ERR("Failed to enable scrambling/%u", __LINE__);
@@ -696,6 +704,7 @@ static int flash_mspi_atxp032_init(const struct device *flash)
 		}
 		data->scramble_cfg = cfg->tar_scramble_cfg;
 	}
+#endif /* MSPI_SCRAMBLE */
 
 	release(flash);
 
@@ -720,11 +729,12 @@ static int flash_mspi_atxp032_read_sfdp(const struct device *flash, off_t addr, 
 
 	data->trans.async             = false;
 	data->trans.xfer_mode         = MSPI_DMA;
+	data->trans.tx_dummy          = data->dev_cfg.tx_dummy;
 	data->trans.rx_dummy          = 8;
 	data->trans.cmd_length        = 1;
 	data->trans.addr_length       = 3;
 	data->trans.hold_ce           = false;
-	data->trans.priority          = 1;
+	data->trans.priority          = MSPI_XFER_PRIORITY_MEDIUM;
 	data->trans.packets           = &data->packet;
 	data->trans.num_packet        = 1;
 	data->trans.timeout           = CONFIG_MSPI_COMPLETION_TIMEOUT_TOLERANCE;
@@ -745,7 +755,7 @@ static int flash_mspi_atxp032_read_jedec_id(const struct device *flash, uint8_t 
 {
 	struct flash_mspi_atxp032_data *data = flash->data;
 
-	id = &data->jedec_id;
+	memcpy(id, &data->jedec_id, 3);
 	return 0;
 }
 #endif /* CONFIG_FLASH_JESD216_API */
@@ -808,23 +818,17 @@ static const struct flash_driver_api flash_mspi_atxp032_api = {
 		.time_to_break      = 0,                                                          \
 	}
 
-#if CONFIG_SOC_FAMILY_AMBIQ
 #define MSPI_TIMING_CONFIG(n)                                                                     \
-	{                                                                                         \
-		.ui8WriteLatency    = DT_INST_PROP_BY_IDX(n, ambiq_timing_config, 0),             \
-		.ui8TurnAround      = DT_INST_PROP_BY_IDX(n, ambiq_timing_config, 1),             \
-		.bTxNeg             = DT_INST_PROP_BY_IDX(n, ambiq_timing_config, 2),             \
-		.bRxNeg             = DT_INST_PROP_BY_IDX(n, ambiq_timing_config, 3),             \
-		.bRxCap             = DT_INST_PROP_BY_IDX(n, ambiq_timing_config, 4),             \
-		.ui32TxDQSDelay     = DT_INST_PROP_BY_IDX(n, ambiq_timing_config, 5),             \
-		.ui32RxDQSDelay     = DT_INST_PROP_BY_IDX(n, ambiq_timing_config, 6),             \
-		.ui32RXDQSDelayEXT  = DT_INST_PROP_BY_IDX(n, ambiq_timing_config, 7),             \
-	}
-#define MSPI_TIMING_CONFIG_MASK(n) DT_INST_PROP(n, ambiq_timing_config_mask)
-#else
-#define MSPI_TIMING_CONFIG(n)
-#define MSPI_TIMING_CONFIG_MASK(n)
-#endif
+	COND_CODE_1(CONFIG_SOC_FAMILY_AMBIQ,                                                      \
+		(MSPI_AMBIQ_TIMING_CONFIG(n)), ({}))                                              \
+
+#define MSPI_TIMING_CONFIG_MASK(n)                                                                \
+	COND_CODE_1(CONFIG_SOC_FAMILY_AMBIQ,                                                      \
+		(MSPI_AMBIQ_TIMING_CONFIG_MASK(n)), (MSPI_TIMING_PARAM_DUMMY))                    \
+
+#define MSPI_PORT(n)                                                                              \
+	COND_CODE_1(CONFIG_SOC_FAMILY_AMBIQ,                                                      \
+		(MSPI_AMBIQ_PORT(n)), (0))                                                        \
 
 #define FLASH_MSPI_ATXP032(n)                                                                     \
 	static const struct flash_mspi_atxp032_config flash_mspi_atxp032_config_##n = {           \

--- a/drivers/flash/flash_mspi_emul_device.c
+++ b/drivers/flash/flash_mspi_emul_device.c
@@ -215,7 +215,7 @@ static int flash_mspi_emul_write(const struct device *flash, off_t offset,
 	data->xfer.cmd_length          = data->dev_cfg.cmd_length;
 	data->xfer.addr_length         = data->dev_cfg.addr_length;
 	data->xfer.hold_ce             = false;
-	data->xfer.priority            = 1;
+	data->xfer.priority            = MSPI_XFER_PRIORITY_MEDIUM;
 	data->xfer.packets             = &data->packet;
 	data->xfer.num_packet          = 1;
 	data->xfer.timeout             = CONFIG_MSPI_COMPLETION_TIMEOUT_TOLERANCE;
@@ -288,7 +288,7 @@ static int flash_mspi_emul_read(const struct device *flash, off_t offset,
 	data->xfer.cmd_length          = data->dev_cfg.cmd_length;
 	data->xfer.addr_length         = data->dev_cfg.addr_length;
 	data->xfer.hold_ce             = false;
-	data->xfer.priority            = 1;
+	data->xfer.priority            = MSPI_XFER_PRIORITY_MEDIUM;
 	data->xfer.packets             = &data->packet;
 	data->xfer.num_packet          = 1;
 	data->xfer.timeout             = CONFIG_MSPI_COMPLETION_TIMEOUT_TOLERANCE;

--- a/drivers/mspi/mspi_ambiq.h
+++ b/drivers/mspi/mspi_ambiq.h
@@ -25,6 +25,38 @@
 			},                                                                        \
 	}
 
+#define MSPI_CQ_MAX_ENTRY MSPI0_CQCURIDX_CQCURIDX_Msk
+
+#define TIMING_CFG_GET_RX_DUMMY(cfg)                                                              \
+	{                                                                                         \
+		mspi_timing_cfg *timing = (mspi_timing_cfg *)cfg;                                 \
+		timing->ui8TurnAround;                                                            \
+	}
+
+#define TIMING_CFG_SET_RX_DUMMY(cfg, num)                                                         \
+	{                                                                                         \
+		mspi_timing_cfg *timing = (mspi_timing_cfg *)cfg;                                 \
+		timing->ui8TurnAround = num;                                                      \
+	}
+
+#define MSPI_AMBIQ_TIMING_CONFIG(n)                                                               \
+	{                                                                                         \
+		.ui8WriteLatency    = DT_INST_PROP_BY_IDX(n, ambiq_timing_config, 0),             \
+		.ui8TurnAround      = DT_INST_PROP_BY_IDX(n, ambiq_timing_config, 1),             \
+		.bTxNeg             = DT_INST_PROP_BY_IDX(n, ambiq_timing_config, 2),             \
+		.bRxNeg             = DT_INST_PROP_BY_IDX(n, ambiq_timing_config, 3),             \
+		.bRxCap             = DT_INST_PROP_BY_IDX(n, ambiq_timing_config, 4),             \
+		.ui32TxDQSDelay     = DT_INST_PROP_BY_IDX(n, ambiq_timing_config, 5),             \
+		.ui32RxDQSDelay     = DT_INST_PROP_BY_IDX(n, ambiq_timing_config, 6),             \
+		.ui32RXDQSDelayEXT  = DT_INST_PROP_BY_IDX(n, ambiq_timing_config, 7),             \
+	}
+
+#define MSPI_AMBIQ_TIMING_CONFIG_MASK(n) DT_INST_PROP(n, ambiq_timing_config_mask)
+
+#define MSPI_AMBIQ_PORT(n)                                                                        \
+		((DT_REG_ADDR(DT_INST_BUS(n)) - MSPI0_BASE) / (DT_REG_SIZE(DT_INST_BUS(n)) * 4))
+
+
 struct mspi_ambiq_timing_cfg {
 	uint8_t ui8WriteLatency;
 	uint8_t ui8TurnAround;
@@ -46,20 +78,5 @@ enum mspi_ambiq_timing_param {
 	MSPI_AMBIQ_SET_RXDQSDLY       = BIT(6),
 	MSPI_AMBIQ_SET_RXDQSDLYEXT    = BIT(7),
 };
-
-#define MSPI_PORT(n)    ((DT_REG_ADDR(DT_INST_BUS(n)) - MSPI0_BASE) /                             \
-			(DT_REG_SIZE(DT_INST_BUS(n)) * 4))
-
-#define TIMING_CFG_GET_RX_DUMMY(cfg)                                                              \
-	{                                                                                         \
-		mspi_timing_cfg *timing = (mspi_timing_cfg *)cfg;                                 \
-		timing->ui8TurnAround;                                                            \
-	}
-
-#define TIMING_CFG_SET_RX_DUMMY(cfg, num)                                                         \
-	{                                                                                         \
-		mspi_timing_cfg *timing = (mspi_timing_cfg *)cfg;                                 \
-		timing->ui8TurnAround = num;                                                      \
-	}
 
 #endif

--- a/include/zephyr/drivers/mspi.h
+++ b/include/zephyr/drivers/mspi.h
@@ -129,7 +129,7 @@ enum mspi_bus_event {
 
 /**
  * @brief MSPI bus event callback mask
- * This is a  preliminary list same as mspi_bus_event. I encourage the
+ * This is a preliminary list same as mspi_bus_event. I encourage the
  * community to fill it up.
  */
 enum mspi_bus_event_cb_mask {
@@ -145,6 +145,16 @@ enum mspi_bus_event_cb_mask {
 enum mspi_xfer_mode {
 	MSPI_PIO,
 	MSPI_DMA,
+};
+
+/**
+ * @brief MSPI transfer priority
+ * This is a preliminary list of priorities that are typically used with DMA
+ */
+enum mspi_xfer_priority {
+	MSPI_XFER_PRIORITY_LOW,
+	MSPI_XFER_PRIORITY_MEDIUM,
+	MSPI_XFER_PRIORITY_HIGH,
 };
 
 /**
@@ -401,10 +411,8 @@ struct mspi_xfer {
 	bool                        hold_ce;
 	/** @brief  Software CE control          */
 	struct mspi_ce_control      ce_sw_ctrl;
-	/** @brief  Priority 0 = Low (best effort)
-	 *                   1 = High (service immediately)
-	 */
-	uint8_t                     priority;
+	/** @brief  MSPI transfer priority       */
+	enum mspi_xfer_priority     priority;
 	/** @brief  Transfer packets             */
 	const struct mspi_xfer_packet *packets;
 	/** @brief  Number of transfer packets   */

--- a/samples/drivers/jesd216/boards/apollo3p_evb.conf
+++ b/samples/drivers/jesd216/boards/apollo3p_evb.conf
@@ -1,0 +1,9 @@
+# Copyright (c) 2024 Ambiq Micro Inc. <www.ambiq.com>
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_FLASH_MSPI_ATXP032=y
+CONFIG_MSPI_INIT_PRIORITY=40
+CONFIG_FLASH_INIT_PRIORITY=50
+CONFIG_PM_DEVICE=y
+CONFIG_SPI=n
+CONFIG_SPI_NOR=n

--- a/samples/drivers/jesd216/boards/apollo3p_evb.overlay
+++ b/samples/drivers/jesd216/boards/apollo3p_evb.overlay
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2024 Ambiq Micro Inc. <www.ambiq.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		mspi0 = &mspi1;
+	};
+};
+
+&gpio32_63 {
+	status = "okay";
+};
+
+&mspi1 {
+
+	compatible = "ambiq,mspi-controller";
+	pinctrl-0 = <&mspi1_default>;
+	pinctrl-1 = <&mspi1_sleep>;
+	pinctrl-2 = <&mspi1_flash>;
+	pinctrl-names = "default","sleep","flash";
+	status = "okay";
+
+	ce-gpios = <&gpio32_63 18 GPIO_ACTIVE_LOW>;
+
+	cmdq-buffer-location = ".mspi_buff";
+	cmdq-buffer-size = <256>;
+
+	atxp032: atxp032@0 {
+		compatible = "ambiq,mspi-device", "mspi-atxp032";
+		size = <DT_SIZE_M(32)>;
+		reg = <0>;
+		status = "okay";
+		mspi-max-frequency = <48000000>;
+		mspi-io-mode = "MSPI_IO_MODE_OCTAL";
+		mspi-data-rate = "MSPI_DATA_RATE_SINGLE";
+		mspi-hardware-ce-num = <0>;
+		read-command = <0x0B>;
+		write-command = <0x02>;
+		command-length = "INSTR_1_BYTE";
+		address-length = "ADDR_4_BYTE";
+		rx-dummy = <8>;
+		tx-dummy = <0>;
+		xip-config = <1 0 0 0>;
+		ce-break-config = <0 0>;
+		ambiq,timing-config-mask = <3>;
+		ambiq,timing-config = <0 8 0 0 0 0 0 0>;
+	};
+
+};
+
+&pinctrl {
+
+	mspi1_sleep: mspi1_sleep{
+		group1 {
+			pinmux = <GPIO_P51>,
+				 <GPIO_P52>,
+				 <GPIO_P53>,
+				 <GPIO_P54>,
+				 <GPIO_P55>,
+				 <GPIO_P56>,
+				 <GPIO_P57>,
+				 <GPIO_P58>,
+				 <GPIO_P59>,
+				 <GPIO_P69>,
+				 <GPIO_P50>;
+		};
+	};
+
+	mspi1_flash: mspi1_flash{
+
+		group1 {
+			pinmux = <MSPI1_0_P51>,
+				 <MSPI1_1_P52>,
+				 <MSPI1_2_P53>,
+				 <MSPI1_3_P54>,
+				 <MSPI1_4_P55>,
+				 <MSPI1_5_P56>,
+				 <MSPI1_6_P57>,
+				 <MSPI1_7_P58>;
+			drive-strength = "0.75";
+			ambiq,iom-mspi = <0>;
+			ambiq,iom-num = <1>;
+		};
+
+		group2 {
+			pinmux = <MSPI1_8_P59>;
+			drive-strength = "0.75";
+			ambiq,iom-mspi = <0>;
+			ambiq,iom-num = <2>;
+		};
+
+		group3 {
+			pinmux = <NCE50_P50>;
+			drive-strength = "1.0";
+			ambiq,iom-mspi = <0>;
+			ambiq,iom-num = <1>;
+		};
+
+		group4 {
+			pinmux = <GPIO_P69>;
+		};
+
+	};
+
+};

--- a/samples/drivers/jesd216/sample.yaml
+++ b/samples/drivers/jesd216/sample.yaml
@@ -35,3 +35,12 @@ tests:
       or dt_compat_enabled("st,stm32-ospi-nor")
       or dt_compat_enabled("st,stm32-qspi-nor")
     depends_on: spi
+  sample.drivers.jesd216.atxp032:
+    tags:
+      - mspi
+    filter: dt_compat_enabled("mspi-atxp032")
+    platform_allow:
+      - apollo3p_evb
+    integration_platforms:
+      - apollo3p_evb
+    depends_on: mspi

--- a/samples/drivers/jesd216/src/main.c
+++ b/samples/drivers/jesd216/src/main.c
@@ -26,6 +26,8 @@
 #define FLASH_NODE DT_COMPAT_GET_ANY_STATUS_OKAY(nxp_s32_qspi_nor)
 #elif DT_HAS_COMPAT_STATUS_OKAY(nxp_imx_flexspi_nor)
 #define FLASH_NODE DT_COMPAT_GET_ANY_STATUS_OKAY(nxp_imx_flexspi_nor)
+#elif DT_HAS_COMPAT_STATUS_OKAY(mspi_atxp032)
+#define FLASH_NODE DT_COMPAT_GET_ANY_STATUS_OKAY(mspi_atxp032)
 #else
 #error Unsupported flash driver
 #define FLASH_NODE DT_INVALID_NODE

--- a/samples/drivers/mspi/mspi_async/README.rst
+++ b/samples/drivers/mspi/mspi_async/README.rst
@@ -32,5 +32,8 @@ Sample Output
 .. code-block:: console
 
    *** Booting Zephyr OS build zephyr-v3.5.0-8581-gc80b243c7598 ***
-   w:3,r:3
+
+   Starting the mspi async example..
+   Waiting for complete..., xfer1 completed:3, xfer2 completed:2
+   xfer1 completed:4, xfer2 completed:4
    Read data matches written data

--- a/samples/drivers/mspi/mspi_async/src/main.c
+++ b/samples/drivers/mspi/mspi_async/src/main.c
@@ -14,13 +14,15 @@
 
 #define MSPI_BUS                  DT_BUS(DT_ALIAS(dev0))
 #define MSPI_TARGET               DT_ALIAS(dev0)
+/* This size is arbitrary and should be modified based on how fast the controller is */
+#define BUF_SIZE 16*1024
 
-#define BUF_SIZE 1024
-
-#if CONFIG_MEMC_MSPI_APS6404L
-#define DEVICE_MEM_WRITE_INSTR    0x38
-#define DEVICE_MEM_READ_INSTR     0xEB
-#endif
+#define DEVICE_MEM_WRITE_INSTR    DT_PROP(DT_ALIAS(dev0), write_command)
+#define DEVICE_MEM_READ_INSTR     DT_PROP(DT_ALIAS(dev0), read_command)
+#define DEVICE_MEM_TX_DUMMY       DT_PROP(DT_ALIAS(dev0), tx_dummy)
+#define DEVICE_MEM_RX_DUMMY       DT_PROP(DT_ALIAS(dev0), rx_dummy)
+#define DEVICE_MEM_CMD_LENGTH     DT_ENUM_IDX(DT_ALIAS(dev0), command_length)
+#define DEVICE_MEM_ADDR_LENGTH    DT_ENUM_IDX(DT_ALIAS(dev0), address_length)
 
 uint8_t memc_write_buffer[BUF_SIZE];
 uint8_t memc_read_buffer[BUF_SIZE];
@@ -30,82 +32,82 @@ struct user_context {
 	uint32_t total_packets;
 };
 
-void async_cb(struct mspi_callback_context *mspi_cb_ctx, uint32_t status)
+void async_cb(struct mspi_callback_context *mspi_cb_ctx)
 {
-	volatile struct user_context *usr_ctx = mspi_cb_ctx->ctx;
+	struct user_context *usr_ctx = mspi_cb_ctx->ctx;
+	struct mspi_event *evt = &mspi_cb_ctx->mspi_evt;
 
-	mspi_cb_ctx->mspi_evt.evt_data.status = status;
-	if (mspi_cb_ctx->mspi_evt.evt_data.packet_idx == usr_ctx->total_packets - 1) {
+	if (evt->evt_data.packet_idx == usr_ctx->total_packets - 1) {
 		usr_ctx->status = 0;
 	}
 }
-
+/* The packets doesn't have to have equal size or consecutive address or same transfer direction */
 struct mspi_xfer_packet packet1[] = {
 	{
 		.dir                = MSPI_TX,
 		.cmd                = DEVICE_MEM_WRITE_INSTR,
 		.address            = 0,
-		.num_bytes          = 256,
+		.num_bytes          = BUF_SIZE / 4,
 		.data_buf           = memc_write_buffer,
 		.cb_mask            = MSPI_BUS_NO_CB,
 	},
 	{
-		.dir                = MSPI_TX,
-		.cmd                = DEVICE_MEM_WRITE_INSTR,
-		.address            = 256,
-		.num_bytes          = 256,
-		.data_buf           = memc_write_buffer + 256,
+		.dir                = MSPI_RX,
+		.cmd                = DEVICE_MEM_READ_INSTR,
+		.address            = 0,
+		.num_bytes          = BUF_SIZE / 4,
+		.data_buf           = memc_read_buffer,
 		.cb_mask            = MSPI_BUS_NO_CB,
 	},
 	{
 		.dir                = MSPI_TX,
 		.cmd                = DEVICE_MEM_WRITE_INSTR,
-		.address            = 512,
-		.num_bytes          = 256,
-		.data_buf           = memc_write_buffer + 512,
+		.address            = BUF_SIZE / 4,
+		.num_bytes          = BUF_SIZE / 4,
+		.data_buf           = memc_write_buffer + BUF_SIZE / 4,
 		.cb_mask            = MSPI_BUS_NO_CB,
 	},
 	{
-		.dir                = MSPI_TX,
-		.cmd                = DEVICE_MEM_WRITE_INSTR,
-		.address            = 512 + 256,
-		.num_bytes          = 256,
-		.data_buf           = memc_write_buffer + 512 + 256,
+		.dir                = MSPI_RX,
+		.cmd                = DEVICE_MEM_READ_INSTR,
+		.address            = BUF_SIZE / 4,
+		.num_bytes          = BUF_SIZE / 4,
+		.data_buf           = memc_read_buffer + BUF_SIZE / 4,
 		.cb_mask            = MSPI_BUS_XFER_COMPLETE_CB,
 	},
 };
 
 struct mspi_xfer_packet packet2[] = {
 	{
-		.dir                = MSPI_RX,
-		.cmd                = DEVICE_MEM_READ_INSTR,
-		.address            = 0,
-		.num_bytes          = 256,
-		.data_buf           = memc_read_buffer,
+		.dir                = MSPI_TX,
+		.cmd                = DEVICE_MEM_WRITE_INSTR,
+		.address            = BUF_SIZE / 2,
+		.num_bytes          = BUF_SIZE / 4,
+		.data_buf           = memc_write_buffer + BUF_SIZE / 2,
+		.cb_mask            = MSPI_BUS_NO_CB,
+	},
+	{
+		.dir                = MSPI_TX,
+		.cmd                = DEVICE_MEM_WRITE_INSTR,
+		.address            = BUF_SIZE / 2 + BUF_SIZE / 4,
+		.num_bytes          = BUF_SIZE / 4,
+		.data_buf           = memc_write_buffer + BUF_SIZE / 2 + BUF_SIZE / 4,
 		.cb_mask            = MSPI_BUS_NO_CB,
 	},
 	{
 		.dir                = MSPI_RX,
 		.cmd                = DEVICE_MEM_READ_INSTR,
-		.address            = 256,
-		.num_bytes          = 256,
-		.data_buf           = memc_read_buffer + 256,
+		.address            = BUF_SIZE / 2 + BUF_SIZE / 4,
+		.num_bytes          = BUF_SIZE / 4,
+		.data_buf           = memc_read_buffer + BUF_SIZE / 2 + BUF_SIZE / 4,
 		.cb_mask            = MSPI_BUS_NO_CB,
 	},
 	{
 		.dir                = MSPI_RX,
 		.cmd                = DEVICE_MEM_READ_INSTR,
-		.address            = 512,
-		.num_bytes          = 256,
-		.data_buf           = memc_read_buffer + 512,
-		.cb_mask            = MSPI_BUS_NO_CB,
-	},
-	{
-		.dir                = MSPI_RX,
-		.cmd                = DEVICE_MEM_READ_INSTR,
-		.address            = 512 + 256,
-		.num_bytes          = 256,
-		.data_buf           = memc_read_buffer + 512 + 256,
+		.address            = BUF_SIZE / 2,
+		.num_bytes          = BUF_SIZE / 4,
+		.data_buf           = memc_read_buffer + BUF_SIZE / 2,
 		.cb_mask            = MSPI_BUS_XFER_COMPLETE_CB,
 	},
 };
@@ -113,38 +115,47 @@ struct mspi_xfer_packet packet2[] = {
 struct mspi_xfer xfer1 = {
 	.async                      = true,
 	.xfer_mode                  = MSPI_DMA,
-	.tx_dummy                   = 0,
-	.cmd_length                 = 1,
-	.addr_length                = 3,
-	.priority                   = 1,
+	.tx_dummy                   = DEVICE_MEM_TX_DUMMY,
+	.rx_dummy                   = DEVICE_MEM_RX_DUMMY,
+	.cmd_length                 = DEVICE_MEM_CMD_LENGTH,
+	.addr_length                = DEVICE_MEM_ADDR_LENGTH,
+	.priority                   = MSPI_XFER_PRIORITY_MEDIUM,
 	.packets                    = (struct mspi_xfer_packet *)&packet1,
 	.num_packet                 = sizeof(packet1) / sizeof(struct mspi_xfer_packet),
+	.timeout                    = CONFIG_MSPI_COMPLETION_TIMEOUT_TOLERANCE,
 };
 
 struct mspi_xfer xfer2 = {
 	.async                      = true,
 	.xfer_mode                  = MSPI_DMA,
-	.rx_dummy                   = 6,
-	.cmd_length                 = 1,
-	.addr_length                = 3,
-	.priority                   = 1,
+	.tx_dummy                   = DEVICE_MEM_TX_DUMMY,
+	.rx_dummy                   = DEVICE_MEM_RX_DUMMY,
+	.cmd_length                 = DEVICE_MEM_CMD_LENGTH,
+	.addr_length                = DEVICE_MEM_ADDR_LENGTH,
+	.priority                   = MSPI_XFER_PRIORITY_MEDIUM,
 	.packets                    = (struct mspi_xfer_packet *)&packet2,
 	.num_packet                 = sizeof(packet2) / sizeof(struct mspi_xfer_packet),
+	.timeout                    = CONFIG_MSPI_COMPLETION_TIMEOUT_TOLERANCE,
 };
 
 int main(void)
 {
 	const struct device *controller = DEVICE_DT_GET(MSPI_BUS);
 	struct mspi_dev_id dev_id = MSPI_DEVICE_ID_DT(MSPI_TARGET);
-	struct mspi_callback_context cb_ctx1, cb_ctx2;
-	volatile struct user_context write_ctx, read_ctx;
+	volatile struct mspi_callback_context cb_ctx1, cb_ctx2;
+	volatile struct user_context usr_ctx1, usr_ctx2;
 	int i, j;
 	int ret;
+
+	printk("\nStarting the mspi async example..\n");
 
 	/* Initialize write buffer */
 	for (i = 0; i < BUF_SIZE; i++) {
 		memc_write_buffer[i] = (uint8_t)i;
 	}
+
+	memset((void *)&cb_ctx1.mspi_evt, 0, sizeof(struct mspi_event));
+	memset((void *)&cb_ctx2.mspi_evt, 0, sizeof(struct mspi_event));
 
 	ret = mspi_dev_config(controller, &dev_id, MSPI_DEVICE_CONFIG_NONE, NULL);
 	if (ret) {
@@ -152,27 +163,29 @@ int main(void)
 		return 1;
 	}
 
-	write_ctx.total_packets = xfer1.num_packet;
-	write_ctx.status        = ~0;
-	cb_ctx1.ctx             = (void *)&write_ctx;
+	usr_ctx1.total_packets = xfer1.num_packet;
+	usr_ctx1.status        = ~0;
+	cb_ctx1.ctx            = (void *)&usr_ctx1;
 	ret = mspi_register_callback(controller, &dev_id, MSPI_BUS_XFER_COMPLETE,
-					(mspi_callback_handler_t)async_cb, &cb_ctx1);
+				     (mspi_callback_handler_t)async_cb,
+				     (struct mspi_callback_context *)&cb_ctx1);
 	if (ret) {
-		printk("Failed to register callback\n");
+		printk("Failed to register callback and context for xfer1\n");
 		return 1;
 	}
 
 	ret = mspi_transceive(controller, &dev_id, &xfer1);
 	if (ret) {
-		printk("Failed to send transceive\n");
+		printk("Failed to send transceive xfer1\n");
 		return 1;
 	}
 
-	read_ctx.total_packets  = xfer2.num_packet;
-	read_ctx.status         = ~0;
-	cb_ctx2.ctx             = (void *)&read_ctx;
+	usr_ctx2.total_packets  = xfer2.num_packet;
+	usr_ctx2.status         = ~0;
+	cb_ctx2.ctx             = (void *)&usr_ctx2;
 	ret = mspi_register_callback(controller, &dev_id, MSPI_BUS_XFER_COMPLETE,
-					(mspi_callback_handler_t)async_cb, &cb_ctx2);
+				     (mspi_callback_handler_t)async_cb,
+				     (struct mspi_callback_context *)&cb_ctx2);
 	if (ret) {
 		printk("Failed to register callback\n");
 		return 1;
@@ -180,16 +193,20 @@ int main(void)
 
 	ret = mspi_transceive(controller, &dev_id, &xfer2);
 	if (ret) {
-		printk("Failed to send transceive\n");
+		printk("Failed to register callback and context for xfer2\n");
 		return 1;
 	}
 
-	while (write_ctx.status != 0 || read_ctx.status != 0) {
-		printk("Waiting for complete..., write completed:%d, read completed:%d\n",
+	while (usr_ctx1.status != 0 || usr_ctx2.status != 0) {
+		printk("Waiting for complete..., xfer1 completed:%d, xfer2 completed:%d\n",
 			cb_ctx1.mspi_evt.evt_data.packet_idx,
 			cb_ctx2.mspi_evt.evt_data.packet_idx);
 		k_busy_wait(100000);
 	}
+
+	printk("xfer1 completed:%d, xfer2 completed:%d\n",
+		cb_ctx1.mspi_evt.evt_data.packet_idx,
+		cb_ctx2.mspi_evt.evt_data.packet_idx);
 
 	for (j = 0; j < BUF_SIZE; j++) {
 		if (memc_write_buffer[j] != memc_read_buffer[j]) {

--- a/west.yml
+++ b/west.yml
@@ -147,7 +147,7 @@ manifest:
       groups:
         - hal
     - name: hal_ambiq
-      revision: 87a188b91aca22ce3ce7deb4a1cbf7780d784673
+      revision: 1f1c8f72d686cbc626b9b82e75dc32d3148c2e2e
       path: modules/hal/ambiq
       groups:
         - hal


### PR DESCRIPTION
Updates for the common files
1. Standarlized transfer priority and add a medium level.
2. Improve the mspi_async example.
3. Moved ambiq specific macro to mspi_ambiq header from shared drivers.
4. Add the CONFIG_MSPI_* macro for optional features in shared drivers
5. Add atxp032 driver to jesd216 example.

Ambiq specific update:
Introduce the `am_hal_mspi_cq_scatter_xfer` api with three modes(STREAM, NORMAL, LOOP) that can dynamically set transfer related settings in command queue.


Tests:
\zephyr\tests\drivers\mspi\api
\zephyr\tests\drivers\mspi\flash
\zephyr\samples\drivers\jesd216
\zephyr\samples\drivers\memc
\zephyr\samples\drivers\mspi\mspi_async
\zephyr\samples\drivers\mspi\mspi_flash
