### PR TITLE
dts: nordic: Add SUIT storage partition for nRF9280 SiP

### DIFF
--- a/dts/common/nordic/nrf9280.dtsi
+++ b/dts/common/nordic/nrf9280.dtsi
@@ -74,6 +74,10 @@
 	reserved-memory {
 		#address-cells = <1>;
 		#size-cells = <1>;
+
+		suit_storage_partition: memory@e6b7000 {
+			reg = <0xe6b7000 DT_SIZE_K(40)>;
+		};
 	};
 
 	clocks {


### PR DESCRIPTION
Add definition of the SUIT storage partition for the nRF9280 SiP.