### PR TITLE
tests: posix: single_process: correct typo and filter

### DIFF
--- a/tests/posix/single_process/testcase.yaml
+++ b/tests/posix/single_process/testcase.yaml
@@ -7,10 +7,10 @@ common:
   platform_key:
     - arch
     - simulation
+  min_flash: 64
+  min_ram: 32
 tests:
-  portability.single_process.rwlocks:
-    min_flash: 64
-    min_ram: 32
+  portability.single_process: {}
   portability.posix.single_process.minimal:
     extra_configs:
       - CONFIG_MINIMAL_LIBC=y


### PR DESCRIPTION
What looks to be a copy-paste typo was not caught in code review.

Change .rwlocks to nothing and move the filter to the common area.

Testing Done:
```shell
$ twister -T tests/posix/single_process/
INFO    - Using Ninja..
INFO    - Zephyr version: v4.0.0-623-g5d018d3fba65
INFO    - Using 'zephyr' toolchain.
INFO    - Selecting default platforms per test case
INFO    - Building initial testsuite list...
INFO    - Writing JSON report /home/cfriedt/zephyrproject/zephyr/twister-out/testplan.json
INFO    - JOBS: 32
INFO    - Adding tasks to the queue...
INFO    - Added initial list of jobs to queue
INFO    - Total complete:   40/  40  100%  built (not run):    0, filtered:  225, failed:    0, error:    0
INFO    - 6 test scenarios (264 configurations) selected, 225 configurations filtered (224 by static filter, 1 at runtime).
INFO    - 39 of 39 executed test configurations passed (100.00%), 0 built (not run), 0 failed, 0 errored, with no warnings in 48.67 seconds.
INFO    - 312 of 312 executed test cases passed (100.00%) on 10 out of total 865 platforms (1.16%).
INFO    - 39 test configurations executed on platforms, 0 test configurations were only built.
INFO    - Saving reports...
INFO    - Writing JSON report /home/cfriedt/zephyrproject/zephyr/twister-out/twister.json
INFO    - Writing xunit report /home/cfriedt/zephyrproject/zephyr/twister-out/twister.xml...
INFO    - Writing xunit report /home/cfriedt/zephyrproject/zephyr/twister-out/twister_report.xml...
INFO    - Run completed
```