### PR TITLE
boards: frdm_mcxn947: fix MCUBoot USB Serial Recovery build

### DIFF
--- a/boards/nxp/frdm_mcxn947/frdm_mcxn947.dtsi
+++ b/boards/nxp/frdm_mcxn947/frdm_mcxn947.dtsi
@@ -140,18 +140,18 @@ nxp_8080_touch_panel_i2c: &flexcomm2_lpi2c2 {
 
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x00000000 DT_SIZE_K(64)>;
+			reg = <0x00000000 DT_SIZE_K(80)>;
 		};
 		/* For the MCUBoot "upgrade only" method,
 		 * the slot sizes must be equal.
 		 */
-		slot0_partition: partition@10000 {
+		slot0_partition: partition@14000 {
 			label = "image-0";
-			reg = <0x00010000 DT_SIZE_K(992)>;
+			reg = <0x00014000 DT_SIZE_K(984)>;
 		};
-		slot1_partition: partition@108000 {
+		slot1_partition: partition@10A000 {
 			label = "image-1";
-			reg = <0x00108000 DT_SIZE_K(992)>;
+			reg = <0x0010A000 DT_SIZE_K(984)>;
 		};
 		/* storage_partition is placed in WINBOND flash memory*/
 	};


### PR DESCRIPTION
- Fixes MCUBoot build error when enabled Serial Recovery via USB CDC ACM.
- Increases MCUBoot partition size.