### PR TITLE
 posix: add missing defines in poll.h

### DIFF
--- a/include/zephyr/posix/poll.h
+++ b/include/zephyr/posix/poll.h
@@ -12,6 +12,8 @@
 extern "C" {
 #endif
 
+typedef	unsigned int nfds_t;
+
 #define pollfd zsock_pollfd
 
 #define POLLIN ZSOCK_POLLIN

--- a/include/zephyr/posix/poll.h
+++ b/include/zephyr/posix/poll.h
@@ -17,6 +17,7 @@ typedef	unsigned int nfds_t;
 #define pollfd zsock_pollfd
 
 #define POLLIN ZSOCK_POLLIN
+#define POLLPRI ZSOCK_POLLPRI
 #define POLLOUT ZSOCK_POLLOUT
 #define POLLERR ZSOCK_POLLERR
 #define POLLHUP ZSOCK_POLLHUP

--- a/tests/posix/headers/src/poll_h.c
+++ b/tests/posix/headers/src/poll_h.c
@@ -23,7 +23,7 @@ ZTEST(posix_headers, test_poll_h)
 	zassert_not_equal(-1, offsetof(struct pollfd, events));
 	zassert_not_equal(-1, offsetof(struct pollfd, revents));
 
-	/* zassert_true(sizeof(nfds_t) <= sizeof(long)); */ /* not implemented */
+	zassert_true(sizeof(nfds_t) <= sizeof(long));
 
 	zassert_not_equal(-1, POLLIN);
 	/* zassert_not_equal(-1, POLLRDNORM); */ /* not implemented */

--- a/tests/posix/headers/src/poll_h.c
+++ b/tests/posix/headers/src/poll_h.c
@@ -28,7 +28,7 @@ ZTEST(posix_headers, test_poll_h)
 	zassert_not_equal(-1, POLLIN);
 	/* zassert_not_equal(-1, POLLRDNORM); */ /* not implemented */
 	/* zassert_not_equal(-1, POLLRDBAND); */ /* not implemented */
-	/* zassert_not_equal(-1, POLLPRI); */ /* not implemented */
+	zassert_not_equal(-1, POLLPRI);
 	zassert_not_equal(-1, POLLOUT);
 	/* zassert_not_equal(-1, POLLWRNORM); */ /* not implemented */
 	/* zassert_not_equal(-1, POLLWRBAND); */ /* not implemented */


### PR DESCRIPTION
This PR adds a couple of missing POSIX defines in `poll.h`.