### PR TITLE
samples: smp_svr: Add frdm_mcxn947 to allow list for USB and UDP

### DIFF
--- a/samples/subsys/mgmt/mcumgr/smp_svr/sample.yaml
+++ b/samples/subsys/mgmt/mcumgr/smp_svr/sample.yaml
@@ -30,7 +30,9 @@ tests:
       - nrf52840dk/nrf52840
   sample.mcumgr.smp_svr.udp:
     extra_args: EXTRA_CONF_FILE="overlay-udp.conf"
-    platform_allow: frdm_k64f
+    platform_allow:
+      - frdm_mcxn947/mcxn947/cpu0
+      - frdm_k64f
     integration_platforms:
       - frdm_k64f
   sample.mcumgr.smp_svr.cdc:
@@ -38,6 +40,7 @@ tests:
       - EXTRA_CONF_FILE="overlay-cdc.conf"
       - DTC_OVERLAY_FILE="usb.overlay"
     platform_allow:
+      - frdm_mcxn947/mcxn947/cpu0
       - nrf52833dk/nrf52820
       - nrf52833dk/nrf52833
       - nrf52840dk/nrf52840


### PR DESCRIPTION
Adds frdm_mcxn947 to the smp_svr sample allow list, for overlay-udp.conf and usb.overlay.