### PR TITLE
Bluetooth: Controller: Fix bt_ctrl to bt_ctlr abbreviation

### DIFF
--- a/doc/releases/migration-guide-4.3.rst
+++ b/doc/releases/migration-guide-4.3.rst
@@ -69,6 +69,14 @@ Bluetooth
 * :c:struct:`bt_conn_le_cs_main_mode` and :c:struct:`bt_conn_le_cs_sub_mode` have been replaced
   with :c:struct:`bt_conn_le_cs_mode`.
 
+Bluetooth Controller
+====================
+
+* The following Kconfig option have been renamed:
+
+    * :kconfig:option:`CONFIG_BT_CTRL_ADV_ADI_IN_SCAN_RSP` to
+      :kconfig:option:`CONFIG_BT_CTLR_ADV_ADI_IN_SCAN_RSP`
+
 .. zephyr-keep-sorted-start re(^\w)
 
 Bluetooth Audio

--- a/doc/releases/release-notes-3.4.rst
+++ b/doc/releases/release-notes-3.4.rst
@@ -489,7 +489,7 @@ Bluetooth
     ``ticks_slot_window``. Implement continuous scanning with it.
   * Added support for considering the SDU interval, along with the packet
     sequence number and time stamps, in SDU fragmentation.
-  * Added a new ``BT_CTRL_TX_PWR_DBM`` option to set the TX power directly in
+  * Added a new ``BT_CTLR_TX_PWR_DBM`` option to set the TX power directly in
     dBm.
   * Optimized the RX path with support for piggy-backing notifications on
     already-allocated RX nodes.

--- a/subsys/bluetooth/controller/Kconfig.ll_sw_split
+++ b/subsys/bluetooth/controller/Kconfig.ll_sw_split
@@ -524,10 +524,20 @@ config BT_CTLR_ADV_EXT_PDU_EXTRA_DATA_MEMORY
 	  that is part of PDU data.
 
 config BT_CTRL_ADV_ADI_IN_SCAN_RSP
+	bool "Include ADI in AUX_SCAN_RSP PDU [DEPRECATED]"
+	depends on BT_BROADCASTER && BT_CTLR_ADV_EXT
+	select BT_CTLR_ADV_ADI_IN_SCAN_RSP
+	select DEPRECATED
+	help
+	  DEPRECATED: Renamed as BT_CTLR_ADV_ADI_IN_SCAN_RSP.
+
+	  Enable ADI field in AUX_SCAN_RSP PDU.
+
+config BT_CTLR_ADV_ADI_IN_SCAN_RSP
 	bool "Include ADI in AUX_SCAN_RSP PDU"
 	depends on BT_BROADCASTER && BT_CTLR_ADV_EXT
 	help
-	  Enable ADI field in AUX_SCAN_RSP PDU
+	  Enable ADI field in AUX_SCAN_RSP PDU.
 
 config BT_CTLR_SCAN_AUX_USE_CHAINS
 	bool "Use new chains based implementation for following advertising chains"

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
@@ -856,7 +856,7 @@ uint8_t ll_adv_aux_sr_data_set(uint8_t handle, uint8_t op, uint8_t frag_pref,
 		hdr_add_fields = 0U;
 
 		/* Add ADI if support enabled */
-		if (IS_ENABLED(CONFIG_BT_CTRL_ADV_ADI_IN_SCAN_RSP)) {
+		if (IS_ENABLED(CONFIG_BT_CTLR_ADV_ADI_IN_SCAN_RSP)) {
 			/* We need to get reference to ADI in auxiliary PDU */
 			hdr_add_fields |= ULL_ADV_PDU_HDR_FIELD_ADI;
 
@@ -886,7 +886,7 @@ uint8_t ll_adv_aux_sr_data_set(uint8_t handle, uint8_t op, uint8_t frag_pref,
 			goto sr_data_set_did_update;
 		}
 
-		if (IS_ENABLED(CONFIG_BT_CTRL_ADV_ADI_IN_SCAN_RSP)) {
+		if (IS_ENABLED(CONFIG_BT_CTLR_ADV_ADI_IN_SCAN_RSP)) {
 			(void)memcpy(&adi,
 				     &hdr_data[ULL_ADV_HDR_DATA_ADI_PTR_OFFSET],
 				     sizeof(struct pdu_adv_adi *));

--- a/tests/bluetooth/controller/ctrl_hci/testcase.yaml
+++ b/tests/bluetooth/controller/ctrl_hci/testcase.yaml
@@ -1,7 +1,7 @@
 common:
   tags:
     - bluetooth
-    - bt_ctrl_hci
+    - bt_ctlr_hci
     - bt_ull_llcp
 tests:
   bluetooth.controller.ctrl_hci.test:

--- a/tests/bluetooth/shell/testcase.yaml
+++ b/tests/bluetooth/shell/testcase.yaml
@@ -72,7 +72,7 @@ tests:
     build_only: true
     extra_args: CONF_FILE="log.conf"
     tags: bluetooth
-  bluetooth.shell.bt_ctrl_dtm:
+  bluetooth.shell.bt_ctlr_dtm:
     build_only: true
     extra_args:
       - CONFIG_BT_CTLR_DTM_HCI=y

--- a/tests/bsim/bluetooth/ll/edtt/gatt_test_app/prj_llcp.conf
+++ b/tests/bsim/bluetooth/ll/edtt/gatt_test_app/prj_llcp.conf
@@ -17,7 +17,7 @@ CONFIG_BT_L2CAP_TX_MTU=512
 CONFIG_LOG=y
 
 # NOTE: In order to get ACL_FLOW_CONTROL to work it is imperative that
-# BT_CTRL_RX_BUFFERS is increased from its default value of 1.
+# BT_CTLR_RX_BUFFERS is increased from its default value of 1.
 CONFIG_BT_CTLR_RX_BUFFERS=3
 
 # To make DEVICE Name writable...


### PR DESCRIPTION
The Controller is abbreviated as CTLR in contrast to CTRL
which is used in the context of Link Layer Control
Procedures.

Fix to rename BT_CTRL_ADV_ADI_IN_SCAN_RSP to
BT_CTLR_ADV_ADI_IN_SCAN_RSP.