### PR TITLE
boards: st: nucleo_u5a5zj_q: enable USB HS

### DIFF
--- a/boards/st/nucleo_u5a5zj_q/Kconfig.defconfig
+++ b/boards/st/nucleo_u5a5zj_q/Kconfig.defconfig
@@ -1,0 +1,5 @@
+# Copyright (c) 2024 Marcin Niestroj
+# SPDX-License-Identifier: Apache-2.0
+
+configdefault USB_DC_STM32_CLOCK_CHECK
+	default n

--- a/boards/st/nucleo_u5a5zj_q/doc/index.rst
+++ b/boards/st/nucleo_u5a5zj_q/doc/index.rst
@@ -204,6 +204,8 @@ The Zephyr nucleo_u5a5zj_q board configuration supports the following hardware f
 +-----------+------------+-------------------------------------+
 | RTC       | on-chip    | rtc                                 |
 +-----------+------------+-------------------------------------+
+| USB       | on-chip    | USB high-speed host/device bus      |
++-----------+------------+-------------------------------------+
 
 
 Other hardware features are not yet supported on this Zephyr port.

--- a/boards/st/nucleo_u5a5zj_q/nucleo_u5a5zj_q-common.dtsi
+++ b/boards/st/nucleo_u5a5zj_q/nucleo_u5a5zj_q-common.dtsi
@@ -59,18 +59,17 @@
 	status = "okay";
 };
 
-&clk_msis {
+&clk_hse {
 	status = "okay";
-	msi-range = <4>;
-	msi-pll-mode;
+	clock-frequency = <DT_FREQ_M(16)>;
 };
 
 &pll1 {
 	div-m = <1>;
-	mul-n = <80>;
+	mul-n = <20>;
 	div-q = <2>;
 	div-r = <2>;
-	clocks = <&clk_msis>;
+	clocks = <&clk_hse>;
 	status = "okay";
 };
 

--- a/boards/st/nucleo_u5a5zj_q/nucleo_u5a5zj_q.dts
+++ b/boards/st/nucleo_u5a5zj_q/nucleo_u5a5zj_q.dts
@@ -32,6 +32,14 @@
 		volt-sensor0 = &vref1;
 		volt-sensor1 = &vbat4;
 	};
+
+	soc {
+		usbphyc: usbphyc@40017c00 {
+			compatible = "st,stm32-usbphyc";
+			reg = <0x40017c00 0x400>;
+			#phy-cells = <0>;
+		};
+	};
 };
 
 &flash0 {
@@ -72,5 +80,14 @@
 };
 
 &gpdma1 {
+	status = "okay";
+};
+
+zephyr_udc0: &usbotg_hs {
+	pinctrl-0 = <&usb_otg_hs_dm_pa11 &usb_otg_hs_dp_pa12>;
+	pinctrl-names = "default";
+	clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x0000c000>,
+		 <&rcc STM32_SRC_HSE USBPHYC_SEL(0)>;
+	phys = <&usbphyc>;
 	status = "okay";
 };

--- a/boards/st/nucleo_u5a5zj_q/nucleo_u5a5zj_q.yaml
+++ b/boards/st/nucleo_u5a5zj_q/nucleo_u5a5zj_q.yaml
@@ -21,5 +21,6 @@ supported:
   - backup_sram
   - dma
   - rtc
+  - usb_device
 ram: 2450
 flash: 4096

--- a/drivers/usb/device/usb_dc_stm32.c
+++ b/drivers/usb/device/usb_dc_stm32.c
@@ -317,7 +317,7 @@ static int usb_dc_stm32_clock_enable(void)
 	LL_AHB1_GRP1_DisableClockLowPower(LL_AHB1_GRP1_PERIPH_OTGHSULPI);
 #endif
 
-#if USB_OTG_HS_EMB_PHY
+#if USB_OTG_HS_EMB_PHY && defined(CONFIG_SOC_SERIES_STM32F7X)
 	LL_APB2_GRP1_EnableClock(LL_APB2_GRP1_PERIPH_OTGPHYC);
 #endif
 #endif /* USB_OTG_HS_ULPI_PHY */

--- a/drivers/usb/udc/udc_stm32.c
+++ b/drivers/usb/udc/udc_stm32.c
@@ -1076,7 +1076,7 @@ static int priv_clock_enable(void)
 	LL_AHB1_GRP1_DisableClockLowPower(LL_AHB1_GRP1_PERIPH_OTGHSULPI);
 #endif /* defined(CONFIG_SOC_SERIES_STM32H7X) */
 
-#if USB_OTG_HS_EMB_PHY
+#if USB_OTG_HS_EMB_PHY && defined(CONFIG_SOC_SERIES_STM32F7X)
 	LL_APB2_GRP1_EnableClock(LL_APB2_GRP1_PERIPH_OTGPHYC);
 #endif
 #elif defined(CONFIG_SOC_SERIES_STM32H7X) && DT_HAS_COMPAT_STATUS_OKAY(st_stm32_otgfs)


### PR DESCRIPTION
Use HSE as PLL input source, to achieve clock increased accuracy. This allows to drive USB HS
peripheral clock, which is not possible with MSIS.

Provide configuration for USB HS with embedded USB HS PHY.

Tested with `west build -b nucleo_u5a5zj_q zephyr/samples/subsys/usb/cdc_acm`:

```
[27617.468275] usb 1-2.3.2: new high-speed USB device number 51 using xhci_hcd
[27617.583341] usb 1-2.3.2: New USB device found, idVendor=2fe3, idProduct=0001, bcdDevice= 4.00
[27617.583346] usb 1-2.3.2: New USB device strings: Mfr=1, Product=2, SerialNumber=3
[27617.583348] usb 1-2.3.2: Product: Zephyr CDC ACM sample
[27617.583350] usb 1-2.3.2: Manufacturer: ZEPHYR
[27617.583351] usb 1-2.3.2: SerialNumber: 39365007001B001B
```