### PR TITLE
Bluetooth: Host: Log when connecting while scanning may give bad params

### DIFF
--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -3747,6 +3747,12 @@ int bt_conn_le_create(const bt_addr_le_t *peer, const struct bt_conn_le_create_p
 		return -ENOMEM;
 	}
 
+	if (BT_LE_STATES_SCAN_INIT(bt_dev.le.states) &&
+	    bt_le_explicit_scanner_running() &&
+	    !bt_le_explicit_scanner_uses_same_params(create_param)) {
+		LOG_WRN("Use same scan and connection create params to obtain best performance");
+	}
+
 	create_param_setup(create_param);
 
 #if defined(CONFIG_BT_SMP)

--- a/subsys/bluetooth/host/scan.c
+++ b/subsys/bluetooth/host/scan.c
@@ -2414,3 +2414,20 @@ bool bt_le_explicit_scanner_running(void)
 {
 	return atomic_test_bit(scan_state.scan_flags, BT_LE_SCAN_USER_EXPLICIT_SCAN);
 }
+
+bool bt_le_explicit_scanner_uses_same_params(const struct bt_conn_le_create_param *create_param)
+{
+	if (scan_state.explicit_scan_param.window != create_param->window ||
+	    scan_state.explicit_scan_param.interval != create_param->interval){
+		return false;
+	}
+
+	if (scan_state.explicit_scan_param.options & BT_LE_SCAN_OPT_CODED) {
+		if (scan_state.explicit_scan_param.window_coded != create_param->window_coded ||
+		    scan_state.explicit_scan_param.interval_coded != create_param->interval_coded){
+			return false;
+		}
+	}
+
+	return true;
+}

--- a/subsys/bluetooth/host/scan.h
+++ b/subsys/bluetooth/host/scan.h
@@ -121,4 +121,14 @@ int bt_le_scan_user_remove(enum bt_le_scan_user flag);
  * Check if the explicit scanner was enabled.
  */
 bool bt_le_explicit_scanner_running(void);
+
+/**
+ * Check if an explicit scanner uses the same parameters
+ *
+ * @param create_param Parameters used for connection establishment.
+ *
+ * @return true If explicit scanner uses the same parameters
+ * @return false If explicit scanner uses different parameters
+ */
+bool bt_le_explicit_scanner_uses_same_params(const struct bt_conn_le_create_param *create_param);
 #endif /* defined SUBSYS_BLUETOOTH_HOST_SCAN_H_ */


### PR DESCRIPTION
The API documentation already states that the controller may require the scan interval and window used for scanning and 
connection establishment to be equal to obtain the best performance.

This commit prints out a warning when this is not the case. The code size is unchanged when `CONFIG_BT_SCAN_AND_INITIATE_IN_PARALLEL=n`.

This makes application developers aware that using the parameters `BT_LE_SCAN_ACTIVE_CONTINUOUS` with `BT_CONN_LE_CREATE_CONN` may not give the best performance.