### PR TITLE
boards: xenvm: remove incorrect condition for Kconfig heap values

### DIFF
--- a/boards/xen/xenvm/Kconfig.defconfig
+++ b/boards/xen/xenvm/Kconfig.defconfig
@@ -7,6 +7,6 @@ config BUILD_OUTPUT_BIN
 	default y
 
 config HEAP_MEM_POOL_SIZE
-	default 16384 if BOARD_XENVM_XENVM
+	default 16384
 
 endif # BOARD_XENVM

--- a/tests/kernel/device/testcase.yaml
+++ b/tests/kernel/device/testcase.yaml
@@ -7,7 +7,9 @@ tests:
   kernel.device:
     integration_platforms:
       - native_sim
-    platform_exclude: xenvm
+    platform_exclude:
+      - xenvm
+      - xenvm/xenvm/gicv3
   kernel.device.metadata:
     platform_allow:
       - qemu_x86
@@ -21,13 +23,16 @@ tests:
       - libc
     extra_configs:
       - CONFIG_MINIMAL_LIBC=y
-    platform_exclude: xenvm
+    platform_exclude:
+      - xenvm
+      - xenvm/xenvm/gicv3
   kernel.device.pm:
     integration_platforms:
       - native_sim
     platform_exclude:
       - mec15xxevb_assy6853
       - xenvm
+      - xenvm/xenvm/gicv3
     extra_configs:
       - CONFIG_PM_DEVICE=y
   kernel.device.linker_generator:


### PR DESCRIPTION
xenvm Kconfig contained incorrect name for board parameter. It led to build issues - heap size was set incorrectly. Since whole file is already placed under right Kconfig condition ("if BOARD_XENVM"), remove incorret parameter at all.

This issue was introduced by commit 8dc3f856229c during migration to hwmv2 due to typo.