### PR TITLE
pm: device: Add power domain get function

### DIFF
--- a/include/zephyr/pm/device.h
+++ b/include/zephyr/pm/device.h
@@ -578,6 +578,16 @@ bool pm_device_wakeup_is_capable(const struct device *dev);
 bool pm_device_on_power_domain(const struct device *dev);
 
 /**
+ * @brief Get the device's power domain.
+ *
+ * @param dev Device instance.
+ *
+ * @retval Device's power domain if on a power domain
+ * @retval NULL if not on a power domain
+ */
+const struct device *pm_device_get_power_domain(const struct device *dev);
+
+/**
  * @brief Add a device to a power domain.
  *
  * This function adds a device to a given power domain.

--- a/subsys/pm/device.c
+++ b/subsys/pm/device.c
@@ -338,6 +338,19 @@ bool pm_device_on_power_domain(const struct device *dev)
 #endif
 }
 
+const struct device *pm_device_get_power_domain(const struct device *dev)
+{
+#ifdef CONFIG_PM_DEVICE_POWER_DOMAIN
+	if (pm_device_on_power_domain(dev) == false) {
+		return NULL;
+	}
+	return dev->pm_base->domain;
+#else
+	ARG_UNUSED(dev);
+	return NULL;
+#endif
+}
+
 bool pm_device_is_powered(const struct device *dev)
 {
 #ifdef CONFIG_PM_DEVICE_POWER_DOMAIN


### PR DESCRIPTION
Add a function to get power domain device from a pm device.

This change was prompted by needing to use runtime usage checks on power domains.

Signed-off-by: Jacob McClellan <mcclellanjacob@meta.com>