### PR TITLE
scripts: ci: check_compliance: ruff: avoid mixing stdout and stderr

### DIFF
--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -1657,7 +1657,7 @@ class Ruff(ComplianceTest):
                     f"ruff check --force-exclude --output-format=json {file}",
                     check=True,
                     stdout=subprocess.PIPE,
-                    stderr=subprocess.STDOUT,
+                    stderr=subprocess.DEVNULL,
                     shell=True,
                     cwd=GIT_TOP,
                 )


### PR DESCRIPTION
The python subprocess call had a `stdout=subprocess.PIPE` parameter that redirects standard output to a pipe,
and a `stderr=subprocess.STDOUT` parameter that redirected stderr to the pipe.
This mixed JSON and non-JSON output together, and issued an exception.
Fixing with `stderr=subprocess.DEVNULL` to ignore standard error and only keep the JSON output.

For short: we had this:

```json
warning: The following rules have been removed and ignoring them has no effect:
    - UP027

[
  {
    "cell": null,
    "code": "I001",
    "end_location": {
      "column": 1,
      "row": 11
    },
    "filename": "/home/tinyvision/zephyrproject/zephyr/scripts/west_commands/runners/ecpprog.py",
    "fix": {
      "applicability": "safe",
      "edits": [
        {
          "content": "from runners.core import BuildConfiguration, RunnerCaps, ZephyrBinaryRunner\n\n\n",
          "end_location": {
            "column": 1,
            "row": 11
          },
          "location": {
            "column": 1,
            "row": 8
          }
        }
      ],
      "message": "Organize imports"
    },
    "location": {
      "column": 1,
      "row": 8
    },
    "message": "Import block is un-sorted or un-formatted",
    "noqa_row": 8,
    "url": "https://docs.astral.sh/ruff/rules/unsorted-imports"
  }
]
```

We want this:

```json
[
  {
    "cell": null,
    "code": "I001",
    "end_location": {
      "column": 1,
      "row": 11
    },
    "filename": "/home/tinyvision/zephyrproject/zephyr/scripts/west_commands/runners/ecpprog.py",
    "fix": {
      "applicability": "safe",
      "edits": [
        {
          "content": "from runners.core import BuildConfiguration, RunnerCaps, ZephyrBinaryRunner\n\n\n",
          "end_location": {
            "column": 1,
            "row": 11
          },
          "location": {
            "column": 1,
            "row": 8
          }
        }
      ],
      "message": "Organize imports"
    },
    "location": {
      "column": 1,
      "row": 8
    },
    "message": "Import block is un-sorted or un-formatted",
    "noqa_row": 8,
    "url": "https://docs.astral.sh/ruff/rules/unsorted-imports"
  }
]
```