### PR TITLE
net: mqtt: Fix error of `size_t` formatting with `PRIu16`

### DIFF
--- a/subsys/net/lib/mqtt_sn/mqtt_sn.c
+++ b/subsys/net/lib/mqtt_sn/mqtt_sn.c
@@ -184,7 +184,7 @@ static struct mqtt_sn_publish *mqtt_sn_publish_create(struct mqtt_sn_data *data)
 
 	if (data && data->data && data->size) {
 		if (data->size > sizeof(pub->pubdata)) {
-			LOG_ERR("Can't create PUB: Too much data (%" PRIu16 ")", data->size);
+			LOG_ERR("Can't create PUB: Too much data (%zu)", data->size);
 			return NULL;
 		}
 
@@ -242,7 +242,7 @@ static struct mqtt_sn_topic *mqtt_sn_topic_create(struct mqtt_sn_data *name)
 	}
 
 	if (name->size > sizeof(topic->name)) {
-		LOG_ERR("Can't create topic: name too long (%" PRIu16 ")", name->size);
+		LOG_ERR("Can't create topic: name too long (%zu)", name->size);
 		return NULL;
 	}
 


### PR DESCRIPTION
Similar to #81626, `size_t` is defined as `long unsigned int` on 64-bit platforms, which makes it incompatible with `PRIu16`. This results in PRs targeting 64-bit platforms failing.

This issue can be reproduced on 64-bit boards such as `rpi_4b` using the following command:

```
$ west build -s tests/net/lib/mqtt_sn_packet -p -b rpi_4b

[...]

[112/150] Building C object zephyr/subsys/net/lib/mqtt_sn/CMakeFiles/subsys__net__lib__mqtt_sn.dir/mqtt_sn.c.obj
In file included from [...]/zephyr/include/zephyr/logging/log.h:11,
                 from [...]/zephyr/subsys/net/lib/mqtt_sn/mqtt_sn.c:14:
[...]/zephyr/subsys/net/lib/mqtt_sn/mqtt_sn.c: In function 'mqtt_sn_publish_create':
[...]/zephyr/subsys/net/lib/mqtt_sn/mqtt_sn.c:187:33: warning: format '%hu' expects argument of type 'int', but argument 2 has type 'size_t' {aka 'long unsigned int'} [-Wformat=]
  187 |                         LOG_ERR("Can't create PUB: Too much data (%" PRIu16 ")", data->size);
      |                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~             ~~~~~~~~~~
      |                                                                                      |
      |                                                                                      size_t {aka long unsigned int}
[...]/zephyr/include/zephyr/logging/log_core.h:315:50: note: in definition of macro 'Z_LOG2'
  315 |                         z_log_printf_arg_checker(__VA_ARGS__);                                     \
      |                                                  ^~~~~~~~~~~
[...]/zephyr/include/zephyr/logging/log.h:44:25: note: in expansion of macro 'Z_LOG'
   44 | #define LOG_ERR(...)    Z_LOG(LOG_LEVEL_ERR, __VA_ARGS__)
      |                         ^~~~~
[...]/zephyr/subsys/net/lib/mqtt_sn/mqtt_sn.c:187:25: note: in expansion of macro 'LOG_ERR'
  187 |                         LOG_ERR("Can't create PUB: Too much data (%" PRIu16 ")", data->size);
      |                         ^~~~~~~
[...]/zephyr/subsys/net/lib/mqtt_sn/mqtt_sn.c: In function 'mqtt_sn_topic_create':
[...]/zephyr/subsys/net/lib/mqtt_sn/mqtt_sn.c:245:25: warning: format '%hu' expects argument of type 'int', but argument 2 has type 'size_t' {aka 'long unsigned int'} [-Wformat=]
  245 |                 LOG_ERR("Can't create topic: name too long (%" PRIu16 ")", name->size);
      |                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~             ~~~~~~~~~~
      |                                                                                |
      |                                                                                size_t {aka long unsigned int}
[...]/zephyr/include/zephyr/logging/log_core.h:315:50: note: in definition of macro 'Z_LOG2'
  315 |                         z_log_printf_arg_checker(__VA_ARGS__);                                     \
      |                                                  ^~~~~~~~~~~
[...]/zephyr/include/zephyr/logging/log.h:44:25: note: in expansion of macro 'Z_LOG'
   44 | #define LOG_ERR(...)    Z_LOG(LOG_LEVEL_ERR, __VA_ARGS__)
      |                         ^~~~~
[...]/zephyr/subsys/net/lib/mqtt_sn/mqtt_sn.c:245:17: note: in expansion of macro 'LOG_ERR'
  245 |                 LOG_ERR("Can't create topic: name too long (%" PRIu16 ")", name->size);
      |                 ^~~~~~~
```