### PR TITLE
modbus: serial: remove redundant `cfg->dev` usage in `uart_cb_handler`

### DIFF
--- a/subsys/modbus/modbus_serial.c
+++ b/subsys/modbus/modbus_serial.c
@@ -386,22 +386,19 @@ static void cb_handler_tx(struct modbus_context *ctx)
 static void uart_cb_handler(const struct device *dev, void *app_data)
 {
 	struct modbus_context *ctx = (struct modbus_context *)app_data;
-	struct modbus_serial_config *cfg;
 
 	if (ctx == NULL) {
 		LOG_ERR("Modbus hardware is not properly initialized");
 		return;
 	}
 
-	cfg = ctx->cfg;
+	if (uart_irq_update(dev) && uart_irq_is_pending(dev)) {
 
-	if (uart_irq_update(cfg->dev) && uart_irq_is_pending(cfg->dev)) {
-
-		if (uart_irq_rx_ready(cfg->dev)) {
+		if (uart_irq_rx_ready(dev)) {
 			cb_handler_rx(ctx);
 		}
 
-		if (uart_irq_tx_ready(cfg->dev)) {
+		if (uart_irq_tx_ready(dev)) {
 			cb_handler_tx(ctx);
 		}
 	}


### PR DESCRIPTION
Simplify `uart_cb_handler` by directly using `dev` instead of `cfg->dev`, as both hold the same value.