### PR TITLE
drivers/wifi/esp_at: Fix system crash caused by null pointer

### DIFF
--- a/drivers/wifi/esp_at/esp.c
+++ b/drivers/wifi/esp_at/esp.c
@@ -866,9 +866,9 @@ MODEM_CMD_DIRECT_DEFINE(on_cmd_ipd)
 {
 	struct esp_data *dev = CONTAINER_OF(data, struct esp_data,
 					    cmd_handler_data);
-	struct esp_socket *sock;
-	int data_offset;
-	long data_len;
+	struct esp_socket *sock = NULL;
+	int data_offset = 0;
+	long data_len = 0;
 	int err;
 	int ret;
 

--- a/drivers/wifi/esp_at/esp.c
+++ b/drivers/wifi/esp_at/esp.c
@@ -811,7 +811,7 @@ static int cmd_ipd_parse_hdr(struct esp_data *dev,
 	}
 
 	*sock = esp_socket_ref_from_link_id(dev, link_id);
-	if (!sock) {
+	if (*sock == NULL) {
 		LOG_ERR("No socket for link %ld", link_id);
 		return str - ipd_buf;
 	}


### PR DESCRIPTION
The code for checking the null pointer is incorrect, 
with ESP_AT_CIPDINFO_USE turned on, after a soft
reboot of the host and before a reboot of ESP32, the
host may receive an incorrect IPD message causing 
a system crash.

Fixes #81804