### PR TITLE
sensor: tmp108: fix `sample_fetch` API conformance

### DIFF
--- a/drivers/sensor/ti/tmp108/CMakeLists.txt
+++ b/drivers/sensor/ti/tmp108/CMakeLists.txt
@@ -2,4 +2,5 @@
 
 zephyr_library()
 
-zephyr_library_sources(tmp108.c tmp108_trigger.c)
+zephyr_library_sources(tmp108.c)
+zephyr_library_sources_ifdef(CONFIG_TMP108_ALERT_INTERRUPTS tmp108_trigger.c)

--- a/drivers/sensor/ti/tmp108/tmp108.c
+++ b/drivers/sensor/ti/tmp108/tmp108.c
@@ -153,10 +153,7 @@ static int tmp108_channel_get(const struct device *dev,
 	}
 
 	uval = ((int32_t)drv_data->sample * TMP108_TEMP_MULTIPLIER(dev)) / TMP108_TEMP_DIVISOR(dev);
-	val->val1 = uval / 1000000;
-	val->val2 = uval % 1000000;
-
-	return 0;
+	return sensor_value_from_micro(val, uval);
 }
 
 static int tmp108_attr_get(const struct device *dev,
@@ -236,7 +233,7 @@ static int tmp108_attr_set(const struct device *dev,
 		break;
 
 	case SENSOR_ATTR_LOWER_THRESH:
-		uval = val->val1 * 1000000 + val->val2;
+		uval = sensor_value_to_micro(val);
 		reg_value = (uval * TMP108_TEMP_DIVISOR(dev)) / TMP108_TEMP_MULTIPLIER(dev);
 		result = tmp108_reg_write(dev,
 					  TI_TMP108_REG_LOW_LIMIT,
@@ -244,7 +241,7 @@ static int tmp108_attr_set(const struct device *dev,
 		break;
 
 	case SENSOR_ATTR_UPPER_THRESH:
-		uval = val->val1 * 1000000 + val->val2;
+		uval = sensor_value_to_micro(val);
 		reg_value = (uval * TMP108_TEMP_DIVISOR(dev)) / TMP108_TEMP_MULTIPLIER(dev);
 		result = tmp108_reg_write(dev,
 					  TI_TMP108_REG_HIGH_LIMIT,

--- a/drivers/sensor/ti/tmp108/tmp108.c
+++ b/drivers/sensor/ti/tmp108/tmp108.c
@@ -100,45 +100,57 @@ static int tmp108_sample_fetch(const struct device *dev,
 			       enum sensor_channel chan)
 {
 	struct tmp108_data *drv_data = dev->data;
+	uint16_t config, converting_mask;
 	int result;
 
 	if (chan != SENSOR_CHAN_ALL && chan != SENSOR_CHAN_AMBIENT_TEMP) {
 		return -ENOTSUP;
 	}
 
-	/* If one shot mode is set, query chip for reading
-	 * should be finished 30 ms later
-	 */
-	if (drv_data->one_shot_mode == true) {
-
-		result = tmp108_write_config(dev,
-					     TI_TMP108_MODE_MASK(dev),
-					     TI_TMP108_MODE_ONE_SHOT(dev));
-
-		if (result < 0) {
-			return result;
-		}
-
-		/* Schedule read to start in 30 ms if mode change was successful
-		 * the typical wakeup time given in the data sheet is 27
-		 */
-		result = k_work_schedule(&drv_data->scheduled_work,
-					 K_MSEC(TMP108_WAKEUP_TIME_IN_MS(dev)));
-
-		if (result < 0) {
-			return result;
-		}
-
-		return 0;
+	if (!drv_data->one_shot_mode) {
+		/* Read the latest temperature result */
+		return ti_tmp108_read_temp(dev);
 	}
 
-	result =  ti_tmp108_read_temp(dev);
-
+	/* Trigger the conversion */
+	result = tmp108_write_config(dev,
+					TI_TMP108_MODE_MASK(dev),
+					TI_TMP108_MODE_ONE_SHOT(dev));
 	if (result < 0) {
 		return result;
 	}
 
-	return 0;
+	/* Typical conversion time:
+	 *   TMP108: 27ms
+	 *   AS6212: 36ms
+	 * Maximum conversion time:
+	 *   TMP108: 35ms
+	 *   AS6212: 51ms
+	 */
+	const uint32_t conv_time_min = 25;
+	const uint32_t conv_time_max = 100;
+	const uint32_t poll_period = 5;
+
+	k_sleep(K_MSEC(conv_time_min));
+	converting_mask = TI_TMP108_CONF_M1(dev) | TI_TMP108_CONF_M0(dev);
+
+	for (int i = conv_time_min; i < conv_time_max; i += poll_period) {
+		/* Read the config register */
+		result = tmp108_reg_read(dev, TI_TMP108_REG_CONF, &config);
+		if (result < 0) {
+			return result;
+		}
+		if ((config & converting_mask) == 0) {
+			/* Conversion has finished */
+			LOG_DBG("Conversion complete after %d ms", i);
+			return ti_tmp108_read_temp(dev);
+		}
+		/* Wait before reading again */
+		k_sleep(K_MSEC(poll_period));
+	}
+
+	/* Conversion timed out */
+	return -EAGAIN;
 }
 
 static int tmp108_channel_get(const struct device *dev,
@@ -366,8 +378,6 @@ static int tmp108_init(const struct device *dev)
 		LOG_ERR("I2C dev %s not ready", cfg->i2c_spec.bus->name);
 		return -ENODEV;
 	}
-
-	drv_data->scheduled_work.work.handler = tmp108_trigger_handle_one_shot;
 
 	/* save this driver instance for passing to other functions */
 	drv_data->tmp108_dev = dev;

--- a/drivers/sensor/ti/tmp108/tmp108.c
+++ b/drivers/sensor/ti/tmp108/tmp108.c
@@ -201,16 +201,17 @@ static int tmp108_attr_set(const struct device *dev,
 			   const struct sensor_value *val)
 {
 	struct tmp108_data *drv_data = dev->data;
-	uint16_t mode = 0;
-	uint16_t reg_value = 0;
+	__maybe_unused uint16_t reg_value;
+	__maybe_unused int32_t uval;
+	uint16_t mode;
 	int result = 0;
-	int32_t uval;
 
 	if (chan != SENSOR_CHAN_AMBIENT_TEMP && chan != SENSOR_CHAN_ALL) {
 		return -ENOTSUP;
 	}
 
 	switch ((int) attr) {
+#ifdef CONFIG_TMP108_ALERT_INTERRUPTS
 	case SENSOR_ATTR_HYSTERESIS:
 		if (TI_TMP108_HYSTER_0_C(dev) == TI_TMP108_CONF_NA) {
 			LOG_WRN("AS621x Series lacks Hysterisis setttings");
@@ -260,6 +261,18 @@ static int tmp108_attr_set(const struct device *dev,
 					  reg_value);
 		break;
 
+	case SENSOR_ATTR_TMP108_ALERT_POLARITY:
+		if (val->val1 == 1) {
+			mode = TI_TMP108_CONF_POL_HIGH(dev);
+		} else {
+			mode = TI_TMP108_CONF_POL_LOW(dev);
+		}
+		result = tmp108_write_config(dev,
+					     TI_TMP108_CONF_POL_MASK(dev),
+					     mode);
+		break;
+#endif /* CONFIG_TMP108_ALERT_INTERRUPTS */
+
 	case SENSOR_ATTR_SAMPLING_FREQUENCY:
 		if (val->val1 < 1) {
 			mode = TI_TMP108_FREQ_4_SECS(dev);
@@ -296,17 +309,6 @@ static int tmp108_attr_set(const struct device *dev,
 		drv_data->one_shot_mode = true;
 		break;
 
-	case SENSOR_ATTR_TMP108_ALERT_POLARITY:
-		if (val->val1 == 1) {
-			mode = TI_TMP108_CONF_POL_HIGH(dev);
-		} else {
-			mode = TI_TMP108_CONF_POL_LOW(dev);
-		}
-		result = tmp108_write_config(dev,
-					     TI_TMP108_CONF_POL_MASK(dev),
-					     mode);
-		break;
-
 	default:
 		return -ENOTSUP;
 	}
@@ -323,7 +325,9 @@ static const struct sensor_driver_api tmp108_driver_api = {
 	.attr_get = tmp108_attr_get,
 	.sample_fetch = tmp108_sample_fetch,
 	.channel_get = tmp108_channel_get,
+#ifdef CONFIG_TMP108_ALERT_INTERRUPTS
 	.trigger_set = tmp_108_trigger_set,
+#endif
 };
 
 #ifdef CONFIG_TMP108_ALERT_INTERRUPTS
@@ -371,7 +375,6 @@ static int setup_interrupts(const struct device *dev)
 static int tmp108_init(const struct device *dev)
 {
 	const struct tmp108_config *cfg = dev->config;
-	struct tmp108_data *drv_data = dev->data;
 	int result = 0;
 
 	if (!device_is_ready(cfg->i2c_spec.bus)) {
@@ -379,10 +382,12 @@ static int tmp108_init(const struct device *dev)
 		return -ENODEV;
 	}
 
+#ifdef CONFIG_TMP108_ALERT_INTERRUPTS
+	struct tmp108_data *drv_data = dev->data;
+
 	/* save this driver instance for passing to other functions */
 	drv_data->tmp108_dev = dev;
 
-#ifdef CONFIG_TMP108_ALERT_INTERRUPTS
 	result = setup_interrupts(dev);
 
 	if (result < 0) {
@@ -396,22 +401,16 @@ static int tmp108_init(const struct device *dev)
 	return result;
 }
 
-#define TMP108_DEFINE(inst, t)						   \
-	static struct tmp108_data tmp108_prv_data_##inst##t;		   \
-	static const struct tmp108_config tmp108_config_##inst##t = {	   \
-		.i2c_spec = I2C_DT_SPEC_INST_GET(inst),			   \
-		.alert_gpio = GPIO_DT_SPEC_INST_GET_OR(inst,		   \
-						       alert_gpios, { 0 }),\
-		.reg_def = t##_CONF					   \
-	};								   \
-	SENSOR_DEVICE_DT_INST_DEFINE(inst,				   \
-			      &tmp108_init,				   \
-			      NULL,					   \
-			      &tmp108_prv_data_##inst##t,		   \
-			      &tmp108_config_##inst##t,			   \
-			      POST_KERNEL,				   \
-			      CONFIG_SENSOR_INIT_PRIORITY,		   \
-			      &tmp108_driver_api);
+#define TMP108_DEFINE(inst, t)                                                                     \
+	static struct tmp108_data tmp108_prv_data_##inst##t;                                       \
+	static const struct tmp108_config tmp108_config_##inst##t = {                              \
+		.i2c_spec = I2C_DT_SPEC_INST_GET(inst),                                            \
+		IF_ENABLED(CONFIG_TMP108_ALERT_INTERRUPTS,                                         \
+			   (.alert_gpio = GPIO_DT_SPEC_INST_GET(inst, alert_gpios),))              \
+		.reg_def = t##_CONF};                                                              \
+	SENSOR_DEVICE_DT_INST_DEFINE(inst, &tmp108_init, NULL, &tmp108_prv_data_##inst##t,         \
+				     &tmp108_config_##inst##t, POST_KERNEL,                        \
+				     CONFIG_SENSOR_INIT_PRIORITY, &tmp108_driver_api);
 
 #define TMP108_INIT(n) TMP108_DEFINE(n, TI_TMP108)
 #undef DT_DRV_COMPAT

--- a/drivers/sensor/ti/tmp108/tmp108.h
+++ b/drivers/sensor/ti/tmp108/tmp108.h
@@ -24,6 +24,7 @@
 			 .CONF_HYS0 = TI_TMP108_CONF_NA,\
 			 .CONF_CR0  = 0x0040,	\
 			 .CONF_CR1  = 0x0080,	\
+			 .CONF_SLEEP = 0x0100,  \
 			 .CONF_M1   = 0x0000,	\
 			 .CONF_TM   = 0x0200,	\
 			 .CONF_POL  = 0x0400,	\
@@ -47,9 +48,11 @@
 			 .WAKEUP_TIME_IN_MS = 30 }
 
 #define TI_TMP108_MODE_SHUTDOWN(x) 0
-#define TI_TMP108_MODE_ONE_SHOT(x) TI_TMP108_CONF_M0(x)
+#define TI_TMP108_MODE_ONE_SHOT(x) (TI_TMP108_CONF_M0(x) | TI_TMP108_CONF_SLEEP(x))
 #define TI_TMP108_MODE_CONTINUOUS(x) TI_TMP108_CONF_M1(x)
-#define TI_TMP108_MODE_MASK(x)	~(TI_TMP108_CONF_M0(x) | TI_TMP108_CONF_M1(x))
+#define TI_TMP108_MODE_MASK(x)	~(TI_TMP108_CONF_M0(x) | \
+				  TI_TMP108_CONF_M1(x) | \
+				  TI_TMP108_CONF_SLEEP(x))
 
 #define TI_TMP108_FREQ_4_SECS(x) 0
 #define TI_TMP108_FREQ_1_HZ(x) TI_TMP108_GET_CONF(x, CONF_CR0)
@@ -77,6 +80,7 @@
 
 #define TI_TMP108_CONF_M1(x) TI_TMP108_GET_CONF(x, CONF_M1)
 #define TI_TMP108_CONF_M0(x) TI_TMP108_GET_CONF(x, CONF_M0)
+#define TI_TMP108_CONF_SLEEP(x) TI_TMP108_GET_CONF(x, CONF_SLEEP)
 
 #define TMP108_TEMP_MULTIPLIER(x)	TI_TMP108_GET_CONF(x, TEMP_MULT)
 #define TMP108_TEMP_DIVISOR(x)	TI_TMP108_GET_CONF(x, TEMP_DIV)
@@ -88,6 +92,7 @@
 struct tmp_108_reg_def {
 	uint16_t CONF_M0;	/** Mode 1 configuration bit */
 	uint16_t CONF_M1;	/** Mode 2 configuration bit */
+	uint16_t CONF_SLEEP;    /** Sleep mode configuration bit */
 	uint16_t CONF_CR0;	/** Conversion rate 1 configuration bit */
 	uint16_t CONF_CR1;	/** Conversion rate 2 configuration bit */
 	uint16_t CONF_POL;	/** Alert pin Polarity configuration bit */

--- a/drivers/sensor/ti/tmp108/tmp108.h
+++ b/drivers/sensor/ti/tmp108/tmp108.h
@@ -31,8 +31,7 @@
 			 .CONF_M0   = 0x8000,	\
 			 .CONF_RST  = 0x0080,	\
 			 .TEMP_MULT = 15625,	\
-			 .TEMP_DIV  = 2,        \
-			 .WAKEUP_TIME_IN_MS = 120 }
+			 .TEMP_DIV  = 2 }
 
 #define TI_TMP108_CONF	{.CONF_HYS0  = 0x0010,	\
 			 .CONF_HYS1  = 0x0020,	\
@@ -44,8 +43,7 @@
 			 .CONF_CR1   = 0x4000,	\
 			 .CONF_RST   = 0x0022,	\
 			 .TEMP_MULT  = 15625,	\
-			 .TEMP_DIV   = 4,       \
-			 .WAKEUP_TIME_IN_MS = 30 }
+			 .TEMP_DIV   = 4 }
 
 #define TI_TMP108_MODE_SHUTDOWN(x) 0
 #define TI_TMP108_MODE_ONE_SHOT(x) (TI_TMP108_CONF_M0(x) | TI_TMP108_CONF_SLEEP(x))
@@ -84,7 +82,6 @@
 
 #define TMP108_TEMP_MULTIPLIER(x)	TI_TMP108_GET_CONF(x, TEMP_MULT)
 #define TMP108_TEMP_DIVISOR(x)	TI_TMP108_GET_CONF(x, TEMP_DIV)
-#define TMP108_WAKEUP_TIME_IN_MS(x)	TI_TMP108_GET_CONF(x, WAKEUP_TIME_IN_MS)
 #define TMP108_CONF_RST(x)	TI_TMP108_GET_CONF(x, CONF_RST)
 
 #define TI_TMP108_CONF_NA 0x0000
@@ -101,7 +98,6 @@ struct tmp_108_reg_def {
 	uint16_t CONF_HYS0;	/** Temperature hysteresis config 2 bit */
 	int32_t TEMP_MULT;	/** Temperature multiplier */
 	int32_t TEMP_DIV;	/** Temperature divisor */
-	uint16_t WAKEUP_TIME_IN_MS; /** Wake up and conversion time from one shot */
 	uint16_t CONF_RST;	/** default reset values on init */
 };
 
@@ -120,13 +116,8 @@ struct tmp108_data {
 
 	bool one_shot_mode;
 
-	struct k_work_delayable scheduled_work;
-
 	const struct sensor_trigger *temp_alert_trigger;
 	sensor_trigger_handler_t temp_alert_handler;
-
-	sensor_trigger_handler_t data_ready_handler;
-	const struct sensor_trigger *data_ready_trigger;
 
 	struct gpio_callback temp_alert_gpio_cb;
 };

--- a/drivers/sensor/ti/tmp108/tmp108.h
+++ b/drivers/sensor/ti/tmp108/tmp108.h
@@ -20,30 +20,29 @@
 #define TI_TMP108_REG_LOW_LIMIT		0x02   /** Low alert set register */
 #define TI_TMP108_REG_HIGH_LIMIT	0x03   /** High alert set register */
 
-#define AMS_AS6212_CONF	{.CONF_HYS1 = TI_TMP108_CONF_NA,\
-			 .CONF_HYS0 = TI_TMP108_CONF_NA,\
-			 .CONF_CR0  = 0x0040,	\
-			 .CONF_CR1  = 0x0080,	\
-			 .CONF_SLEEP = 0x0100,  \
-			 .CONF_M1   = 0x0000,	\
-			 .CONF_TM   = 0x0200,	\
-			 .CONF_POL  = 0x0400,	\
-			 .CONF_M0   = 0x8000,	\
-			 .CONF_RST  = 0x0080,	\
-			 .TEMP_MULT = 15625,	\
-			 .TEMP_DIV  = 2 }
+#define AMS_AS6212_CONF                                                                            \
+	{.CONF_CR0 = 0x0040,                                                                       \
+	 .CONF_CR1 = 0x0080,                                                                       \
+	 .CONF_SLEEP = 0x0100,                                                                     \
+	 .CONF_M1 = 0x0000,                                                                        \
+	 .CONF_TM = 0x0200,                                                                        \
+	 .CONF_M0 = 0x8000,                                                                        \
+	 .CONF_RST = 0x0080,                                                                       \
+	 .TEMP_MULT = 15625,                                                                       \
+	 .TEMP_DIV = 2,                                                                            \
+	 IF_ENABLED(CONFIG_TMP108_ALERT_INTERRUPTS, (.CONF_POL = 0x0400))}
 
-#define TI_TMP108_CONF	{.CONF_HYS0  = 0x0010,	\
-			 .CONF_HYS1  = 0x0020,	\
-			 .CONF_POL   = 0x0080,	\
-			 .CONF_M0    = 0x0100,	\
-			 .CONF_M1    = 0x0200,	\
-			 .CONF_TM    = 0x0400,	\
-			 .CONF_CR0   = 0x2000,	\
-			 .CONF_CR1   = 0x4000,	\
-			 .CONF_RST   = 0x0022,	\
-			 .TEMP_MULT  = 15625,	\
-			 .TEMP_DIV   = 4 }
+#define TI_TMP108_CONF                                                                             \
+	{.CONF_M0 = 0x0100,                                                                        \
+	 .CONF_M1 = 0x0200,                                                                        \
+	 .CONF_TM = 0x0400,                                                                        \
+	 .CONF_CR0 = 0x2000,                                                                       \
+	 .CONF_CR1 = 0x4000,                                                                       \
+	 .CONF_RST = 0x0022,                                                                       \
+	 .TEMP_MULT = 15625,                                                                       \
+	 .TEMP_DIV = 4,                                                                            \
+	 IF_ENABLED(CONFIG_TMP108_ALERT_INTERRUPTS,                                                \
+		    (.CONF_HYS0 = 0x0010, .CONF_HYS1 = 0x0020, .CONF_POL = 0x0080))}
 
 #define TI_TMP108_MODE_SHUTDOWN(x) 0
 #define TI_TMP108_MODE_ONE_SHOT(x) (TI_TMP108_CONF_M0(x) | TI_TMP108_CONF_SLEEP(x))
@@ -87,39 +86,45 @@
 #define TI_TMP108_CONF_NA 0x0000
 
 struct tmp_108_reg_def {
-	uint16_t CONF_M0;	/** Mode 1 configuration bit */
-	uint16_t CONF_M1;	/** Mode 2 configuration bit */
-	uint16_t CONF_SLEEP;    /** Sleep mode configuration bit */
-	uint16_t CONF_CR0;	/** Conversion rate 1 configuration bit */
-	uint16_t CONF_CR1;	/** Conversion rate 2 configuration bit */
-	uint16_t CONF_POL;	/** Alert pin Polarity configuration bit */
-	uint16_t CONF_TM;	/** Thermostat mode setting bit */
-	uint16_t CONF_HYS1;	/** Temperature hysteresis config 1 bit  */
-	uint16_t CONF_HYS0;	/** Temperature hysteresis config 2 bit */
-	int32_t TEMP_MULT;	/** Temperature multiplier */
-	int32_t TEMP_DIV;	/** Temperature divisor */
-	uint16_t CONF_RST;	/** default reset values on init */
+	uint16_t CONF_M0;    /** Mode 1 configuration bit */
+	uint16_t CONF_M1;    /** Mode 2 configuration bit */
+	uint16_t CONF_SLEEP; /** Sleep mode configuration bit */
+	uint16_t CONF_CR0;   /** Conversion rate 1 configuration bit */
+	uint16_t CONF_CR1;   /** Conversion rate 2 configuration bit */
+	uint16_t CONF_TM;    /** Thermostat mode setting bit */
+	int32_t TEMP_MULT;   /** Temperature multiplier */
+	int32_t TEMP_DIV;    /** Temperature divisor */
+	uint16_t CONF_RST;   /** default reset values on init */
+#ifdef CONFIG_TMP108_ALERT_INTERRUPTS
+	uint16_t CONF_POL;  /** Alert pin Polarity configuration bit */
+	uint16_t CONF_HYS1; /** Temperature hysteresis config 1 bit  */
+	uint16_t CONF_HYS0; /** Temperature hysteresis config 2 bit */
+#endif
 };
 
 #define TI_TMP108_GET_CONF(x, cfg) ((struct tmp108_config *)(x->config))->reg_def.cfg
 
 struct tmp108_config {
 	const struct i2c_dt_spec i2c_spec;
-	const struct gpio_dt_spec alert_gpio;
 	struct tmp_108_reg_def reg_def;
+#ifdef CONFIG_TMP108_ALERT_INTERRUPTS
+	const struct gpio_dt_spec alert_gpio;
+#endif /* CONFIG_TMP108_ALERT_INTERRUPTS */
 };
 
 struct tmp108_data {
-	const struct device *tmp108_dev;
-
 	int16_t sample;
 
 	bool one_shot_mode;
+
+#ifdef CONFIG_TMP108_ALERT_INTERRUPTS
+	const struct device *tmp108_dev;
 
 	const struct sensor_trigger *temp_alert_trigger;
 	sensor_trigger_handler_t temp_alert_handler;
 
 	struct gpio_callback temp_alert_gpio_cb;
+#endif /* CONFIG_TMP108_ALERT_INTERRUPTS */
 };
 
 int tmp_108_trigger_set(const struct device *dev,

--- a/drivers/sensor/ti/tmp108/tmp108_trigger.c
+++ b/drivers/sensor/ti/tmp108/tmp108_trigger.c
@@ -10,45 +10,7 @@
 
 #include "tmp108.h"
 
-#define TMP108_ONE_SHOT_RETRY_TIME_IN_MS 10
-
 LOG_MODULE_DECLARE(TMP108, CONFIG_SENSOR_LOG_LEVEL);
-
-void tmp108_trigger_handle_one_shot(struct k_work *work)
-{
-	struct k_work_delayable *delayable_work = k_work_delayable_from_work(work);
-	struct tmp108_data *drv_data = CONTAINER_OF(delayable_work,
-						    struct tmp108_data,
-						    scheduled_work);
-
-	uint16_t config = 0;
-	bool shutdown_mode = false;
-
-	tmp108_reg_read(drv_data->tmp108_dev, TI_TMP108_REG_CONF, &config);
-
-	/* check shutdown mode which indicates a one shot read was successful */
-	shutdown_mode = (config & (TI_TMP108_CONF_M1(drv_data->tmp108_dev) |
-				   TI_TMP108_CONF_M0(drv_data->tmp108_dev))) == 0;
-
-	if (shutdown_mode == true) {
-		ti_tmp108_read_temp(drv_data->tmp108_dev);
-	} else {
-		LOG_ERR("Temperature one shot mode read failed, retrying");
-		/* Wait for typical wake up time, retry if the read fails
-		 * assuming the chip should wake up and take a reading after the typical
-		 * wake up time and call of this thread plus 10 ms time has passed
-		 */
-		k_work_reschedule(&drv_data->scheduled_work,
-				  K_MSEC(TMP108_ONE_SHOT_RETRY_TIME_IN_MS));
-		return;
-	}
-
-	/* Successful read, call set callbacks */
-	if (drv_data->data_ready_handler) {
-		drv_data->data_ready_handler(drv_data->tmp108_dev,
-					     drv_data->data_ready_trigger);
-	}
-}
 
 void tmp108_trigger_handle_alert(const struct device *gpio,
 				 struct gpio_callback *cb,
@@ -71,12 +33,6 @@ int tmp_108_trigger_set(const struct device *dev,
 			sensor_trigger_handler_t handler)
 {
 	struct tmp108_data *drv_data = dev->data;
-
-	if (trig->type == SENSOR_TRIG_DATA_READY) {
-		drv_data->data_ready_handler = handler;
-		drv_data->data_ready_trigger = trig;
-		return 0;
-	}
 
 	if (trig->type == SENSOR_TRIG_THRESHOLD) {
 		drv_data->temp_alert_handler = handler;


### PR DESCRIPTION
`sensor_sample_fetch` is documented as blocking until the fetch operation is complete. Update the implementation so that this is true.

Optimize the resource usage of the driver for the case where `CONFIG_TMP108_ALERT_INTERRUPTS=n`.