### PR TITLE
scripts: west_commands: Fix MissingProgram import

### DIFF
--- a/scripts/west_commands/runners/__init__.py
+++ b/scripts/west_commands/runners/__init__.py
@@ -5,7 +5,7 @@
 import importlib
 import logging
 
-from runners.core import ZephyrBinaryRunner
+from runners.core import MissingProgram, ZephyrBinaryRunner
 
 _logger = logging.getLogger('runners')
 
@@ -75,4 +75,4 @@ def get_runner_cls(runner):
             return cls
     raise ValueError(f'unknown runner "{runner}"')
 
-__all__ = ['ZephyrBinaryRunner', 'get_runner_cls']
+__all__ = ['ZephyrBinaryRunner', 'MissingProgram', 'get_runner_cls']


### PR DESCRIPTION
`MissingProgram` should be exported in `__all__`
Fixes #81797