### PR TITLE
ci: compliance: Install python packages from requirements

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -38,7 +38,7 @@ jobs:
       run: |
         pip3 install setuptools
         pip3 install wheel
-        pip3 install python-magic lxml junitparser gitlint pylint pykwalify yamllint clang-format unidiff sphinx-lint ruff
+        pip3 install -r scripts/requirements-compliance.txt
         pip3 install west
 
     - name: west setup

--- a/scripts/requirements-compliance.txt
+++ b/scripts/requirements-compliance.txt
@@ -1,13 +1,17 @@
 # COMPLIANCE: required by the compliance scripts
 
 # used by ci/check_compliance
+# zephyr-keep-sorted-start
 clang-format>=15.0.0
+gitlint
+junitparser>=2
+lxml
+pykwalify
+pylint>=3
 python-magic
 python-magic-bin; sys_platform == "win32"
-lxml
-junitparser>=2
-pylint>=3
+ruff
+sphinx-lint
 unidiff
 yamllint
-sphinx-lint
-ruff
+# zephyr-keep-sorted-stop


### PR DESCRIPTION
Instead of maintaining two lists, use the requirements file for installing compliance dependencies.