### PR TITLE
github: Add dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "ci: github: "
+    labels: []
+    groups:
+      actions-deps:
+        patterns:
+          - "*"


### PR DESCRIPTION
Add a GH dependabot configuration to check for updates for github actions ~~and pip dependencies~~ once a week.