### PR TITLE
net: wifi: shell: enhance consistency in `__wifi_args_to_params`

### DIFF
--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -726,7 +726,7 @@ static int __wifi_args_to_params(const struct shell *sh, size_t argc, char *argv
 			}
 			break;
 		case 'a':
-			params->anon_id = optarg;
+			params->anon_id = state->optarg;
 			params->aid_length = strlen(params->anon_id);
 			if (params->aid_length > WIFI_ENT_IDENTITY_MAX_LEN) {
 				PR_WARNING("anon_id too long (max %d characters)\n",
@@ -741,7 +741,7 @@ static int __wifi_args_to_params(const struct shell *sh, size_t argc, char *argv
 			}
 
 			if (key_passwd_cnt == 0) {
-				params->key_passwd = optarg;
+				params->key_passwd = state->optarg;
 				params->key_passwd_length = strlen(params->key_passwd);
 				if (params->key_passwd_length > WIFI_ENT_PSWD_MAX_LEN) {
 					PR_WARNING("key_passwd too long (max %d characters)\n",
@@ -749,7 +749,7 @@ static int __wifi_args_to_params(const struct shell *sh, size_t argc, char *argv
 					return -EINVAL;
 				}
 			} else if (key_passwd_cnt == 1) {
-				params->key2_passwd = optarg;
+				params->key2_passwd = state->optarg;
 				params->key2_passwd_length = strlen(params->key2_passwd);
 				if (params->key2_passwd_length > WIFI_ENT_PSWD_MAX_LEN) {
 					PR_WARNING("key2_passwd too long (max %d characters)\n",
@@ -760,10 +760,10 @@ static int __wifi_args_to_params(const struct shell *sh, size_t argc, char *argv
 			key_passwd_cnt++;
 			break;
 		case 'S':
-			params->suiteb_type = atoi(optarg);
+			params->suiteb_type = atoi(state->optarg);
 			break;
 		case 'V':
-			params->eap_ver = atoi(optarg);
+			params->eap_ver = atoi(state->optarg);
 			if (params->eap_ver != 0U && params->eap_ver != 1U) {
 				PR_WARNING("eap_ver error %d\n", params->eap_ver);
 				return -EINVAL;
@@ -776,10 +776,10 @@ static int __wifi_args_to_params(const struct shell *sh, size_t argc, char *argv
 				return -EINVAL;
 			}
 
-			params->eap_identity = optarg;
+			params->eap_identity = state->optarg;
 			params->eap_id_length = strlen(params->eap_identity);
 
-			params->identities[params->nusers] = optarg;
+			params->identities[params->nusers] = state->optarg;
 			params->nusers++;
 			if (params->eap_id_length > WIFI_ENT_IDENTITY_MAX_LEN) {
 				PR_WARNING("eap identity too long (max %d characters)\n",
@@ -794,10 +794,10 @@ static int __wifi_args_to_params(const struct shell *sh, size_t argc, char *argv
 				return -EINVAL;
 			}
 
-			params->eap_password = optarg;
+			params->eap_password = state->optarg;
 			params->eap_passwd_length = strlen(params->eap_password);
 
-			params->passwords[params->passwds] = optarg;
+			params->passwords[params->passwds] = state->optarg;
 			params->passwds++;
 			if (params->eap_passwd_length > WIFI_ENT_PSWD_MAX_LEN) {
 				PR_WARNING("eap password length too long (max %d characters)\n",


### PR DESCRIPTION
Several arguments were added but have not yet been aligned with others in the same function.
Hence, use `getopt_state` to access `optarg`, offering a better alternative to direct global access.