### PR TITLE
tests: rtio: rtio_api: test `cq_count` overflow

### DIFF
--- a/tests/subsys/rtio/rtio_api/src/test_rtio_api.c
+++ b/tests/subsys/rtio/rtio_api/src/test_rtio_api.c
@@ -616,6 +616,25 @@ ZTEST(rtio_api, test_rtio_transaction)
 	}
 }
 
+ZTEST(rtio_api, test_rtio_cqe_count_overflow)
+{
+	/* atomic_t is signed, but RTIO uses cq_count as `uintptr_t` */
+	const atomic_t max_val = (1ULL << (ATOMIC_BITS)) - 1;
+
+	TC_PRINT("initializing iodev test devices\n");
+
+	for (int i = 0; i < 2; i++) {
+		rtio_iodev_test_init(iodev_test_transaction[i]);
+	}
+
+	TC_PRINT("rtio transaction CQE overflow\n");
+	atomic_set(&r_transaction.cq_count, max_val - 3);
+	for (int i = 0; i < TEST_REPEATS; i++) {
+		test_rtio_transaction_(&r_transaction);
+	}
+}
+
+
 #define THROUGHPUT_ITERS 100000
 RTIO_DEFINE(r_throughput, SQE_POOL_SIZE, CQE_POOL_SIZE);
 

--- a/tests/subsys/rtio/rtio_api/testcase.yaml
+++ b/tests/subsys/rtio/rtio_api/testcase.yaml
@@ -12,6 +12,8 @@ tests:
   rtio.api:
     filter: not CONFIG_ARCH_HAS_USERSPACE
     tags: rtio
+    extra_configs:
+      - CONFIG_RTIO_SUBMIT_SEM=n
     integration_platforms:
       - native_sim
   rtio.api.submit_sem:
@@ -25,6 +27,7 @@ tests:
     filter: CONFIG_ARCH_HAS_USERSPACE
     extra_configs:
       - CONFIG_USERSPACE=y
+      - CONFIG_RTIO_SUBMIT_SEM=n
     arch_exclude:
       - posix
     tags:


### PR DESCRIPTION
Add a test for the behaviour of `rtio_submit` with `CONFIG_RTIO_SUBMIT_SEM=n` when the `cq_count` variable overflows.

Note CI is currently expected to fail, this is a POC of the behaviour.