### PR TITLE
tests: rtio: rtio_api: explicit `RTIO_SUBMIT_SEM=n`

### DIFF
--- a/tests/subsys/rtio/rtio_api/testcase.yaml
+++ b/tests/subsys/rtio/rtio_api/testcase.yaml
@@ -12,6 +12,8 @@ tests:
   rtio.api:
     filter: not CONFIG_ARCH_HAS_USERSPACE
     tags: rtio
+    extra_configs:
+      - CONFIG_RTIO_SUBMIT_SEM=n
     integration_platforms:
       - native_sim
   rtio.api.submit_sem:
@@ -25,6 +27,7 @@ tests:
     filter: CONFIG_ARCH_HAS_USERSPACE
     extra_configs:
       - CONFIG_USERSPACE=y
+      - CONFIG_RTIO_SUBMIT_SEM=n
     arch_exclude:
       - posix
     tags:


### PR DESCRIPTION
Now that `CONFIG_RTIO_SUBMIT_SEM` is the default option, testing the alternate code path requires explicitly disabling it.

Default changed in #76562.