### PR TITLE
tests: posix: rwlocks + getopt: move filter to testcase.yml common area

### DIFF
--- a/tests/posix/getopt/testcase.yaml
+++ b/tests/posix/getopt/testcase.yaml
@@ -7,10 +7,10 @@ common:
   platform_key:
     - arch
     - simulation
+  min_flash: 64
+  min_ram: 32
 tests:
-  portability.posix.getopt:
-    min_flash: 64
-    min_ram: 32
+  portability.posix.getopt: {}
   portability.posix.getopt.minimal:
     extra_configs:
       - CONFIG_MINIMAL_LIBC=y

--- a/tests/posix/rwlocks/testcase.yaml
+++ b/tests/posix/rwlocks/testcase.yaml
@@ -7,10 +7,10 @@ common:
   platform_key:
     - arch
     - simulation
+  min_flash: 64
+  min_ram: 32
 tests:
-  portability.posix.rwlocks:
-    min_flash: 64
-    min_ram: 32
+  portability.posix.rwlocks: {}
   portability.posix.rwlocks.minimal:
     extra_configs:
       - CONFIG_MINIMAL_LIBC=y


### PR DESCRIPTION
Similar to #81766, move the filter to the common area.

This fixes an issue in CI.

https://github.com/zephyrproject-rtos/zephyr/actions/runs/11991907071/job/33431123881