### PR TITLE
boards: st: dts: fix slot0_partition address error

### DIFF
--- a/boards/st/b_l4s5i_iot01a/b_l4s5i_iot01a.dts
+++ b/boards/st/b_l4s5i_iot01a/b_l4s5i_iot01a.dts
@@ -185,9 +185,9 @@
 			read-only;
 		};
 
-		slot0_partition: partition@1000 {
+		slot0_partition: partition@10000 {
 			label = "image-0";
-			reg = <0x1000 DT_SIZE_K(976)>;
+			reg = <0x10000 DT_SIZE_K(976)>;
 		};
 
 		slot1_partition: partition@104000 {


### PR DESCRIPTION
The B_L4S5I_IOT01A Discovery kit does not boot up when using --sysbuild. The error is caused by slot0_partition which is assigned an address of 0x1000 which overlaps with the boot_partition. Setting the address to 0x10000 fixed it.