### PR TITLE
samples: bluetooth: Add build asserts for VS-using samples

### DIFF
--- a/samples/bluetooth/hci_pwr_ctrl/boards/qemu_cortex_m3.overlay
+++ b/samples/bluetooth/hci_pwr_ctrl/boards/qemu_cortex_m3.overlay
@@ -1,0 +1,3 @@
+&bt_hci_uart {
+	bt-hci-vs-ext;
+};

--- a/samples/bluetooth/hci_pwr_ctrl/boards/qemu_x86.overlay
+++ b/samples/bluetooth/hci_pwr_ctrl/boards/qemu_x86.overlay
@@ -1,0 +1,3 @@
+&bt_hci_uart {
+	bt-hci-vs-ext;
+};

--- a/samples/bluetooth/hci_pwr_ctrl/src/main.c
+++ b/samples/bluetooth/hci_pwr_ctrl/src/main.c
@@ -22,6 +22,9 @@
 #include <zephyr/bluetooth/gatt.h>
 #include <zephyr/bluetooth/services/hrs.h>
 
+BUILD_ASSERT(IS_ENABLED(CONFIG_BT_HAS_HCI_VS),
+	     "This app requires Zephyr-specific HCI vendor extensions");
+
 static struct bt_conn *default_conn;
 static uint16_t default_conn_handle;
 

--- a/samples/bluetooth/hci_vs_scan_req/src/main.c
+++ b/samples/bluetooth/hci_vs_scan_req/src/main.c
@@ -10,6 +10,9 @@
 #include <zephyr/bluetooth/hci_vs.h>
 #include <zephyr/bluetooth/addr.h>
 
+BUILD_ASSERT(IS_ENABLED(CONFIG_BT_HAS_HCI_VS),
+	     "This app requires Zephyr-specific HCI vendor extensions");
+
 #define DEVICE_NAME CONFIG_BT_DEVICE_NAME
 #define DEVICE_NAME_LENGTH (sizeof(DEVICE_NAME) - 1)
 


### PR DESCRIPTION
The README files of these samples already indicate that they use the Zephyr-specific HCI vendor extensions, but this may still not be clear enough to some users, as evidenced in #81779. Add build asserts to make sure the samples only build when Zephyr VS extensions have been enabled.