### PR TITLE
MAINTAINERS: make tagunil an ARC collaborator

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -133,6 +133,7 @@ ARC arch:
     - evgeniy-paltsev
   collaborators:
     - abrodkin
+    - tagunil
   files:
     - arch/arc/
     - include/zephyr/arch/arc/


### PR DESCRIPTION
Add myself to the ARC collaborators list, as I'm currently employed by Synopsys to work on improving ARC support in Zephyr.