### PR TITLE
device: Optimize device_get_binding search efficiency

### DIFF
--- a/kernel/device.c
+++ b/kernel/device.c
@@ -35,20 +35,10 @@ const struct device *z_impl_device_get_binding(const char *name)
 		return NULL;
 	}
 
-	/* Split the search into two loops: in the common scenario, where
-	 * device names are stored in ROM (and are referenced by the user
-	 * with CONFIG_* macros), only cheap pointer comparisons will be
-	 * performed. Reserve string comparisons for a fallback.
-	 */
+	/* Return NULL if the device matching 'name' is not ready. */
 	STRUCT_SECTION_FOREACH(device, dev) {
-		if (z_impl_device_is_ready(dev) && (dev->name == name)) {
-			return dev;
-		}
-	}
-
-	STRUCT_SECTION_FOREACH(device, dev) {
-		if (z_impl_device_is_ready(dev) && (strcmp(name, dev->name) == 0)) {
-			return dev;
+		if ((dev->name == name) || (strcmp(name, dev->name) == 0)) {
+			return z_impl_device_is_ready(dev) ? dev : NULL;
 		}
 	}
 


### PR DESCRIPTION
Optimize 'device_get_binding' function search so that when a matching device is found, it returns NULL if it is not ready.

Another solution.
```
	STRUCT_SECTION_FOREACH(device, dev) {
		if (dev->name == name ||strcmp(name, dev->name) == 0) {
			return z_impl_device_is_ready(dev) ? dev : NULL;
		}
	}
```
But. This simplifies it to a single loop and preserves the original requirement (I'm not sure if this solution will be unusual in large-scale deployments)