### PR TITLE
drivers: sensor: ti: ina230: Fix dts warning if INA230_TRIGGER enabled

### DIFF
--- a/drivers/sensor/ti/ina23x/Kconfig
+++ b/drivers/sensor/ti/ina23x/Kconfig
@@ -44,7 +44,7 @@ config INA230_TRIGGER
 	bool "INA230 trigger mode"
 	depends on INA230
 	depends on GPIO
-	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_TI_INA230),alert-gpios)
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_TI_INA230),alert-gpios) || $(dt_compat_any_has_prop,$(DT_COMPAT_TI_INA236),alert-gpios)
 	help
 	  Set to enable trigger mode using gpio interrupt, where
 	  interrupts are configured to line ALERT PIN.


### PR DESCRIPTION
Updates the Kconfig condition to support trigger functionality for INA236. This will get rid of `warning: INA230_TRIGGER (defined at drivers/sensor/ti/ina23x/Kconfig:43) was assigned the value 'y' but got the value 'n'.` if INA230_TRIGGER is enabled.