### PR TITLE
usb: device_next: enable CDC ACM automatically

### DIFF
--- a/subsys/usb/device_next/class/Kconfig.cdc_acm
+++ b/subsys/usb/device_next/class/Kconfig.cdc_acm
@@ -4,6 +4,7 @@
 
 config USBD_CDC_ACM_CLASS
 	bool "USB CDC ACM implementation [EXPERIMENTAL]"
+	default y
 	depends on SERIAL
 	depends on DT_HAS_ZEPHYR_CDC_ACM_UART_ENABLED
 	select SERIAL_HAS_DRIVER


### PR DESCRIPTION
This behavior is consistent with CDC ACM on the old USB stack, as well as with other classes under the new USB stack.