### PR TITLE
twister: support segger real-time-transfer (rtt) for serial_pty via west

### DIFF
--- a/scripts/pylib/twister/twisterlib/environment.py
+++ b/scripts/pylib/twister/twisterlib/environment.py
@@ -873,6 +873,18 @@ def parse_arguments(
         logger.error("west-flash requires device-testing to be enabled")
         sys.exit(1)
 
+    if options.device_serial_pty and options.device_serial_pty == "rtt":
+        if options.west_flash is None:
+            logger.error("--device-serial-pty rtt requires --west-flash")
+            sys.exit(1)
+
+        # add the following options
+        options.extra_args += ['CONFIG_USE_SEGGER_RTT=y',
+                               'CONFIG_RTT_CONSOLE=y', 'CONFIG_CONSOLE=y',
+                               # This option is needed to ensure the uart console is not selected
+                               # when CONFIG_RTT_CONSOLE is enabled due to #81798
+                               'CONFIG_UART_CONSOLE=n']
+
     if not options.testsuite_root:
         # if we specify a test scenario which is part of a suite directly, do
         # not set testsuite root to default, just point to the test directory

--- a/scripts/pylib/twister/twisterlib/environment.py
+++ b/scripts/pylib/twister/twisterlib/environment.py
@@ -939,10 +939,6 @@ def parse_arguments(
         logger.error("--device-flash-with-test does not apply when --flash-before is used")
         sys.exit(1)
 
-    if options.flash_before and options.device_serial_pty:
-        logger.error("--device-serial-pty cannot be used when --flash-before is set (for now)")
-        sys.exit(1)
-
     if options.shuffle_tests and options.subset is None:
         logger.error("--shuffle-tests requires --subset")
         sys.exit(1)

--- a/scripts/pylib/twister/twisterlib/hardwaremap.py
+++ b/scripts/pylib/twister/twisterlib/hardwaremap.py
@@ -213,7 +213,7 @@ class HardwareMap:
                                 True,
                                 flash_timeout=self.options.device_flash_timeout,
                                 flash_with_test=self.options.device_flash_with_test,
-                                flash_before=False,
+                                flash_before=self.options.flash_before
                                 )
 
             # the fixtures given by twister command explicitly should be assigned to each DUT

--- a/scripts/west_commands/runners/jlink.py
+++ b/scripts/west_commands/runners/jlink.py
@@ -89,6 +89,7 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
                  gdb_host='',
                  gdb_port=DEFAULT_JLINK_GDB_PORT,
                  rtt_port=DEFAULT_JLINK_RTT_PORT,
+                 rtt_quiet=False,
                  tui=False, tool_opt=None):
         super().__init__(cfg)
         self.file = cfg.file
@@ -112,6 +113,7 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
         self.tui_arg = ['-tui'] if tui else []
         self.loader = loader
         self.rtt_port = rtt_port
+        self.rtt_quiet = rtt_quiet
 
         self.tool_opt = []
         if tool_opt is not None:
@@ -174,6 +176,8 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
                             help='RTT client, default is JLinkRTTClient')
         parser.add_argument('--rtt-port', default=DEFAULT_JLINK_RTT_PORT,
                             help=f'jlink rtt port, defaults to {DEFAULT_JLINK_RTT_PORT}')
+        parser.add_argument('--rtt-quiet', action='store_true',
+                            help='only output rtt to stdout, not that of subprocesses')
 
         parser.set_defaults(reset=False)
 
@@ -192,9 +196,13 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
                                  gdb_host=args.gdb_host,
                                  gdb_port=args.gdb_port,
                                  rtt_port=args.rtt_port,
+                                 rtt_quiet=args.rtt_quiet,
                                  tui=args.tui, tool_opt=args.tool_opt)
 
     def print_gdbserver_message(self):
+        if self.rtt_quiet:
+            return
+
         if not self.thread_info_enabled:
             thread_msg = '; no thread info available'
         elif self.supports_thread_info:
@@ -205,6 +213,9 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
                          f'{self.gdb_port}{thread_msg}')
 
     def print_rttserver_message(self):
+        if self.rtt_quiet:
+            return
+
         self.logger.info(f'J-Link RTT server running on port {self.rtt_port}')
 
     @property
@@ -317,10 +328,13 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
             self.print_gdbserver_message()
             self.check_call(server_cmd)
         elif command == 'rtt':
+            rtt_quiet_kwargs = {'stdout': subprocess.DEVNULL,
+                                'stderr': subprocess.DEVNULL} if self.rtt_quiet else {}
+
             self.print_gdbserver_message()
             self.print_rttserver_message()
             server_cmd += ['-nohalt']
-            server_proc = self.popen_ignore_int(server_cmd)
+            server_proc = self.popen_ignore_int(server_cmd, **rtt_quiet_kwargs)
             try:
                 sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
                 # wait for the port to be open


### PR DESCRIPTION
Add initial support for RTT (Segger Real-time Transfer) for reading console messages with `twister` via `west` when testing with hardware.

> [!NOTE] 
> This support should be considered experimental as transfer speed, buffering, buffer size, and buffer count are all tuneable parameters that can vary per-platform and debug adapter. Physical UARTs or other higher-speed I/O interfaces are certainly still the primary means of capturing test output from twister when connected to hardware.

Tested with:
```shell
twister -p nucleo_l496zg --device-testing --flash-before --west-runner openocd --west-flash --device-serial-pty rtt -T samples/hello_world
```

```shell
cat twister-out/nucleo_l496zg_stm32l496xx/samples/hello_world/sample.basic.helloworld/handler.log
*** Booting Zephyr OS build v4.0.0-749-gc9e567da3747 ***
Hello World! nucleo_l496zg/stm32l496xx
```

This change set also includes updates to `jlink` and `openocd` west runners to add an `--rtt-quiet` option. The new option suppresses the `stdout` and `stderr` of subprocesses (e.g. `JLinkRTTLogger` or `openocd`), which is the expectation for `--device-serial-pty` scripts. By suppressing unnecessary output, we can leverage `west rtt` in an automatically generated shell script (as opposed to importing or duplicating more python code in `twister`).

Currently, the only other RTT-capable west runner is `pyocd`.

Additionally, the `DeviceHandler.handle()` method of `handler.py` is a bit tricky to work with; I was unsuccessful in making separate methods for `_do_flash()` and `_do_serial()` portions of the operation. That would have simplified the `--flash-before` logic. Python was throwing exceptions claiming that code was attempting to adjust objects shared between processes without synchronization. At some point, the `handle()` method should probably be refactored, but it was considered beyond what was necessary for the first draft of this PR.