### PR TITLE
twister: testplan: Detect duplicates on --no-detailed-test-id

### DIFF
--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -185,6 +185,8 @@ class TestPlan:
         num = self.add_testsuites(testsuite_filter=self.run_individual_testsuite)
         if num == 0:
             raise TwisterRuntimeError("No test cases found at the specified location...")
+        if self.load_errors:
+            raise TwisterRuntimeError(f"Found {self.load_errors} errors loading {num} test configurations.")
 
         self.find_subtests()
         # get list of scenarios we have parsed into one list
@@ -193,9 +195,6 @@ class TestPlan:
 
         self.report_duplicates()
         self.parse_configuration(config_file=self.env.test_config)
-
-        if self.load_errors:
-            raise TwisterRuntimeError("Errors while loading configurations")
 
         # handle quarantine
         ql = self.options.quarantine_list
@@ -602,10 +601,18 @@ class TestPlan:
                             suite.add_subcases(suite_dict, subcases, ztest_suite_names)
                         else:
                             suite.add_subcases(suite_dict)
+
                         if testsuite_filter:
                             scenario = os.path.basename(suite.name)
                             if suite.name and (suite.name in testsuite_filter or scenario in testsuite_filter):
                                 self.testsuites[suite.name] = suite
+                        elif suite.name in self.testsuites:
+                            msg = f"test suite '{suite.name}' in '{suite.yamlfile}' is already added"
+                            if suite.yamlfile == self.testsuites[suite.name].yamlfile:
+                                logger.debug(f"Skip - {msg}")
+                            else:
+                                msg = f"Duplicate {msg} from '{self.testsuites[suite.name].yamlfile}'"
+                                raise TwisterRuntimeError(msg)
                         else:
                             self.testsuites[suite.name] = suite
 

--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -165,7 +165,7 @@ class TestPlan:
         sub_tests = self.options.sub_test
         if sub_tests:
             for subtest in sub_tests:
-                _subtests = self.get_testsuite(subtest)
+                _subtests = self.get_testcase(subtest)
                 for _subtest in _subtests:
                     self.run_individual_testsuite.append(_subtest.name)
 
@@ -1084,6 +1084,13 @@ class TestPlan:
 
 
     def get_testsuite(self, identifier):
+        results = []
+        for _, ts in self.testsuites.items():
+            if ts.id == identifier:
+                results.append(ts)
+        return results
+
+    def get_testcase(self, identifier):
         results = []
         for _, ts in self.testsuites.items():
             for case in ts.testcases:

--- a/scripts/tests/twister/test_testplan.py
+++ b/scripts/tests/twister/test_testplan.py
@@ -1699,27 +1699,31 @@ def test_testplan_add_instances():
     }
 
 
-def test_testplan_get_testsuite():
+def test_testplan_get_testcase():
     testplan = TestPlan(env=mock.Mock())
     testplan.testsuites = {
-        'testsuite0': mock.Mock(testcases=[mock.Mock(), mock.Mock()]),
-        'testsuite1': mock.Mock(testcases=[mock.Mock()]),
-        'testsuite2': mock.Mock(testcases=[mock.Mock(), mock.Mock()]),
-        'testsuite3': mock.Mock(testcases=[])
+        'test1.suite0': mock.Mock(testcases=[mock.Mock(), mock.Mock()]),
+        'test1.suite1': mock.Mock(testcases=[mock.Mock(), mock.Mock()]),
+        'test1.suite2': mock.Mock(testcases=[mock.Mock(), mock.Mock()]),
+        'test1.suite3': mock.Mock(testcases=[])
     }
-    testplan.testsuites['testsuite0'].testcases[0].name = 'testcase name 0'
-    testplan.testsuites['testsuite0'].testcases[1].name = 'testcase name 1'
-    testplan.testsuites['testsuite1'].testcases[0].name = 'sample id'
-    testplan.testsuites['testsuite2'].testcases[0].name = 'dummy id'
-    testplan.testsuites['testsuite2'].testcases[1].name = 'sample id'
 
-    id = 'sample id'
+    testplan.testsuites['test1.suite0'].testcases[0].name = 'test1.suite0.case0'
+    testplan.testsuites['test1.suite0'].testcases[1].name = 'test1.suite0.case1'
+    #
+    testplan.testsuites['test1.suite1'].testcases[0].name = 'test1.suite1.case0'
+    testplan.testsuites['test1.suite1'].testcases[1].name = 'test1.suite1.case0'  # in suite duplicate
+    #
+    testplan.testsuites['test1.suite2'].testcases[0].name = 'test1.suite2.case0'
+    testplan.testsuites['test1.suite2'].testcases[1].name = 'test1.suite1.case0'  # out suite duplicate
 
-    res = testplan.get_testsuite(id)
+    id = 'test1.suite1.case0'
 
-    assert len(res) == 2
-    assert testplan.testsuites['testsuite1'] in res
-    assert testplan.testsuites['testsuite2'] in res
+    res = testplan.get_testcase(id)
+
+    assert len(res) == 3
+    assert testplan.testsuites['test1.suite1'] in res
+    assert testplan.testsuites['test1.suite2'] in res
 
 
 def test_testplan_verify_platforms_existence(caplog):


### PR DESCRIPTION
Detect duplicate TestSuites on load, and raise error when it happens with `--no-detailed-test-id` option which shortens TestSuite name excluding the test project path prefix, thus increasing chances for duplicates. Without this check, only the last duplicated test configuration was selected while others silently ignored.

Fix duplicate test scenario error reporting to show paths to all twister.yaml configuration files where these duplicates were found.

This duplication check should prevent unexpected hidden test scope distortions, for example mistakenly duplicated test configurations selected to the CI scope (#81736), or out of the tree duplicated test names, etc.

Example:
1) introduce a test configuration duplicate:
```
--- a/tests/ztest/error_hook/testcase.yaml
+++ b/tests/ztest/error_hook/testcase.yaml
@@ -9,6 +9,6 @@ tests:
     tags:
       - userspace
     ignore_faults: true
-  testing.ztest.error_hook.no_userspace:
+  testing.ztest.summary.shared_unit_test:
     extra_args: CONF_FILE=prj_no_userspace.conf
     ignore_faults: true
```
2) `./scripts/twister -p native_sim -vv -ll DEBUG -j 1 -T tests/ztest`
```
twisterlib.error.TwisterRuntimeError: Duplicated test scenarios found:                                                     
- testing.ztest.summary.shared_unit_test found in:  
```
with the fix:
```
twisterlib.error.TwisterRuntimeError: Duplicated test scenarios found:                                                     
- testing.ztest.summary.shared_unit_test found in:                                                                         
  - /zephyr/tests/ztest/summary                                                                
  - /zephyr/tests/ztest/error_hook     
```
3) `./scripts/twister -p native_sim -vv -ll DEBUG -j 1 -T tests/ztest --no-detailed-test-id`
```
ERROR   - /zephyr/tests/ztest/error_hook: can't load (skipping): TwisterRuntimeError("Duplicate test 
suite 'testing.ztest.summary.shared_unit_test' in '/zephyr/tests/ztest/error_hook' is already added from '/zephyr/tests/ztest/summary'")                                                                  
...
twisterlib.error.TwisterRuntimeError: Found 1 errors loading 29 test configurations
```