### PR TITLE
boards: nxp: imx8m/n/p, imx93/5, fix ram dts node name

### DIFF
--- a/boards/nxp/imx8mm_evk/imx8mm_evk_mimx8mm6_a53.dts
+++ b/boards/nxp/imx8mm_evk/imx8mm_evk_mimx8mm6_a53.dts
@@ -16,7 +16,8 @@
 	chosen {
 		zephyr,console = &uart4;
 		zephyr,shell-uart = &uart4;
-		zephyr,sram = &sram0;
+		/* sram node actually locates at DDR DRAM */
+		zephyr,sram = &dram;
 	};
 
 	cpus {
@@ -31,7 +32,7 @@
 		};
 	};
 
-	sram0: memory@93c00000 {
+	dram: memory@93c00000 {
 		reg = <0x93c00000 DT_SIZE_M(1)>;
 	};
 };

--- a/boards/nxp/imx8mm_evk/imx8mm_evk_mimx8mm6_a53_smp.dts
+++ b/boards/nxp/imx8mm_evk/imx8mm_evk_mimx8mm6_a53_smp.dts
@@ -16,7 +16,8 @@
 	chosen {
 		zephyr,console = &uart4;
 		zephyr,shell-uart = &uart4;
-		zephyr,sram = &sram0;
+		/* sram node actually locates at DDR DRAM */
+		zephyr,sram = &dram;
 	};
 
 	cpus {
@@ -33,7 +34,7 @@
 		method = "smc";
 	};
 
-	sram0: memory@93c00000 {
+	dram: memory@93c00000 {
 		reg = <0x93c00000 DT_SIZE_M(1)>;
 	};
 };

--- a/boards/nxp/imx8mn_evk/imx8mn_evk_mimx8mn6_a53.dts
+++ b/boards/nxp/imx8mn_evk/imx8mn_evk_mimx8mn6_a53.dts
@@ -16,7 +16,8 @@
 	chosen {
 		zephyr,console = &uart4;
 		zephyr,shell-uart = &uart4;
-		zephyr,sram = &sram0;
+		/* sram node actually locates at DDR DRAM */
+		zephyr,sram = &dram;
 	};
 
 	cpus {
@@ -31,7 +32,7 @@
 		};
 	};
 
-	sram0: memory@93c00000 {
+	dram: memory@93c00000 {
 		reg = <0x93c00000 DT_SIZE_M(1)>;
 	};
 };

--- a/boards/nxp/imx8mn_evk/imx8mn_evk_mimx8mn6_a53_smp.dts
+++ b/boards/nxp/imx8mn_evk/imx8mn_evk_mimx8mn6_a53_smp.dts
@@ -16,7 +16,8 @@
 	chosen {
 		zephyr,console = &uart4;
 		zephyr,shell-uart = &uart4;
-		zephyr,sram = &sram0;
+		/* sram node actually locates at DDR DRAM */
+		zephyr,sram = &dram;
 	};
 
 	cpus {
@@ -33,7 +34,7 @@
 		method = "smc";
 	};
 
-	sram0: memory@93c00000 {
+	dram: memory@93c00000 {
 		reg = <0x93c00000 DT_SIZE_M(1)>;
 	};
 };

--- a/boards/nxp/imx8mp_evk/imx8mp_evk_mimx8ml8_a53.dts
+++ b/boards/nxp/imx8mp_evk/imx8mp_evk_mimx8ml8_a53.dts
@@ -16,7 +16,8 @@
 	chosen {
 		zephyr,console = &uart4;
 		zephyr,shell-uart = &uart4;
-		zephyr,sram = &sram0;
+		/* sram node actually locates at DDR DRAM */
+		zephyr,sram = &dram;
 	};
 
 	cpus {
@@ -31,7 +32,7 @@
 		};
 	};
 
-	sram0: memory@c0000000 {
+	dram: memory@c0000000 {
 		reg = <0xc0000000 DT_SIZE_M(1)>;
 	};
 

--- a/boards/nxp/imx8mp_evk/imx8mp_evk_mimx8ml8_a53_smp.dts
+++ b/boards/nxp/imx8mp_evk/imx8mp_evk_mimx8ml8_a53_smp.dts
@@ -16,7 +16,8 @@
 	chosen {
 		zephyr,console = &uart4;
 		zephyr,shell-uart = &uart4;
-		zephyr,sram = &sram0;
+		/* sram node actually locates at DDR DRAM */
+		zephyr,sram = &dram;
 	};
 
 	cpus {
@@ -33,7 +34,7 @@
 		method = "smc";
 	};
 
-	sram0: memory@c0000000 {
+	dram: memory@c0000000 {
 		reg = <0xc0000000 DT_SIZE_M(1)>;
 	};
 

--- a/boards/nxp/imx93_evk/imx93_evk_mimx9352_a55.dts
+++ b/boards/nxp/imx93_evk/imx93_evk_mimx9352_a55.dts
@@ -16,7 +16,8 @@
 	chosen {
 		zephyr,console = &lpuart2;
 		zephyr,shell-uart = &lpuart2;
-		zephyr,sram = &sram0;
+		/* sram node actually locates at DDR DRAM */
+		zephyr,sram = &dram;
 		zephyr,canbus = &flexcan2;
 	};
 
@@ -26,7 +27,7 @@
 		};
 	};
 
-	sram0: memory@d0000000 {
+	dram: memory@d0000000 {
 		reg = <0xd0000000 DT_SIZE_M(1)>;
 	};
 

--- a/boards/nxp/imx95_evk/imx95_evk_mimx9596_a55.dts
+++ b/boards/nxp/imx95_evk/imx95_evk_mimx9596_a55.dts
@@ -16,7 +16,8 @@
 	chosen {
 		zephyr,console = &lpuart1;
 		zephyr,shell-uart = &lpuart1;
-		zephyr,sram = &sram0;
+		/* sram node actually locates at DDR DRAM */
+		zephyr,sram = &dram;
 	};
 
 	cpus {
@@ -41,7 +42,7 @@
 		};
 	};
 
-	sram0: memory@d0000000 {
+	dram: memory@d0000000 {
 		reg = <0xd0000000 DT_SIZE_M(1)>;
 	};
 };

--- a/boards/nxp/imx95_evk/imx95_evk_mimx9596_a55_smp.dts
+++ b/boards/nxp/imx95_evk/imx95_evk_mimx9596_a55_smp.dts
@@ -16,7 +16,7 @@
 	chosen {
 		zephyr,console = &lpuart1;
 		zephyr,shell-uart = &lpuart1;
-		zephyr,sram = &sram0;
+		zephyr,sram = &dram;
 	};
 
 	psci {
@@ -24,7 +24,7 @@
 		method = "smc";
 	};
 
-	sram0: memory@d0000000 {
+	dram: memory@d0000000 {
 		reg = <0xd0000000 DT_SIZE_M(1)>;
 	};
 };


### PR DESCRIPTION
For Zephyr Cortex-A Core supports on NXP boards imx8mm, imx8mn, imx8mp, imx93 and imx95, currently use DDR DRAM memory as Zephyr memory, so change RAM dts nodes name to be "dram" in order to reduce confusion.