### PR TITLE
bluetooth: ssp: support pairing_accept for ssp

### DIFF
--- a/include/zephyr/bluetooth/conn.h
+++ b/include/zephyr/bluetooth/conn.h
@@ -2195,7 +2195,8 @@ struct bt_conn_auth_cb {
 	 *  This callback may be unregistered in which case pairing continues
 	 *  as if the Kconfig flag was not set.
 	 *
-	 *  This callback is not called for BR/EDR Secure Simple Pairing (SSP).
+	 *  For BR/EDR Secure Simple Pairing (SSP), this callback is called
+	 *  when receiving the BT_HCI_EVT_IO_CAPA_REQ hci event.
 	 *
 	 *  @param conn Connection where pairing is initiated.
 	 *  @param feat Pairing req/resp info.

--- a/subsys/bluetooth/host/classic/ssp.c
+++ b/subsys/bluetooth/host/classic/ssp.c
@@ -650,6 +650,19 @@ void bt_hci_io_capa_req(struct net_buf *buf)
 		return;
 	}
 
+#if defined(CONFIG_BT_SMP_APP_PAIRING_ACCEPT)
+	if (bt_auth && bt_auth->pairing_accept) {
+		enum bt_security_err err;
+
+		err = bt_auth->pairing_accept(conn, NULL);
+		if (err != BT_SECURITY_ERR_SUCCESS) {
+			io_capa_neg_reply(&evt->bdaddr,
+					  BT_HCI_ERR_PAIRING_NOT_ALLOWED);
+			return;
+		}
+	}
+#endif
+
 	resp_buf = bt_hci_cmd_create(BT_HCI_OP_IO_CAPABILITY_REPLY,
 				     sizeof(*cp));
 	if (!resp_buf) {


### PR DESCRIPTION
when receiving the io cap request from controller, call pairing_accept to check whether application accept the pairing. If no, reply BT_HCI_OP_IO_CAPABILITY_NEG_REPLY.

It is tested with the handsfree sample by adding the following codes, and enable `CONFIG_BT_SMP_APP_PAIRING_ACCEPT`
```
enum bt_security_err pairing_accept(struct bt_conn *conn,
			const struct bt_conn_pairing_feat *const feat)
{
	return BT_SECURITY_ERR_PAIR_NOT_ALLOWED;
}

struct bt_conn_auth_cb auth_cb = {
	.pairing_accept = pairing_accept,
};

static void bt_ready(int err)
{
	bt_conn_auth_cb_register(&auth_cb);
}
```