### PR TITLE
Bluetooth: Shell: Set conn to NULL before bt_conn_le_create

### DIFF
--- a/subsys/bluetooth/host/shell/bt.c
+++ b/subsys/bluetooth/host/shell/bt.c
@@ -3264,7 +3264,7 @@ static int cmd_connect_le(const struct shell *sh, size_t argc, char *argv[])
 {
 	int err;
 	bt_addr_le_t addr;
-	struct bt_conn *conn;
+	struct bt_conn *conn = NULL;
 	uint32_t options = 0;
 
 	/* When no arguments are specified, connect to the last scanned device. */


### PR DESCRIPTION
bt_conn_le_create logs a warning if the provided conn is non-NULL which was the case here. Simply set it to NULL as it is a local variable.