### PR TITLE
tests: net: socket: udp: Add min_flash to the test config

### DIFF
--- a/tests/net/socket/udp/testcase.yaml
+++ b/tests/net/socket/udp/testcase.yaml
@@ -5,6 +5,7 @@ common:
     - socket
     - udp
   min_ram: 21
+  min_flash: 194
   filter: CONFIG_FULL_LIBC_SUPPORTED
 tests:
   net.socket.udp:


### PR DESCRIPTION
Add minimum flash requirement to the tests. This will effectively exclude nrf5340dk/nrf5340/cpuapp/ns as it does not have enough flash for the application.

Fixes #81862