### PR TITLE
boards: nrfbsim: Add minimal model of SCB.SCR SEVONPEND bit

### DIFF
--- a/boards/native/nrf_bsim/board_irq.h
+++ b/boards/native/nrf_bsim/board_irq.h
@@ -16,6 +16,7 @@ extern "C" {
 
 void nrfbsim_WFE_model(void);
 void nrfbsim_SEV_model(void);
+int nrfbsim_set_SEVONPEND(int new_value);
 
 #define IRQ_ZERO_LATENCY	BIT(1) /* Unused in this board*/
 #define IRQ_PRIO_LOWEST		UINT8_MAX

--- a/west.yml
+++ b/west.yml
@@ -300,7 +300,7 @@ manifest:
       groups:
         - tools
     - name: nrf_hw_models
-      revision: 3cfca0192ff84da919e9bc7978bcc2239cd6a395
+      revision: bceda1bab72971823effeb1c1151d9a093480d2c
       path: modules/bsim_hw_models/nrf_hw_models
     - name: open-amp
       revision: b735edbc739ad59156eb55bb8ce2583d74537719


### PR DESCRIPTION
To allow code which uses this functionality to work.
(And while at it, clarify a comment in the same file) 