### PR TITLE
storage/stream_flash: Initialize settings at point of use

### DIFF
--- a/subsys/storage/stream/stream_flash.c
+++ b/subsys/storage/stream/stream_flash.c
@@ -272,15 +272,6 @@ int stream_flash_init(struct stream_flash_ctx *ctx, const struct device *fdev,
 		return -EFAULT;
 	}
 
-#ifdef CONFIG_STREAM_FLASH_PROGRESS
-	int rc = settings_subsys_init();
-
-	if (rc != 0) {
-		LOG_ERR("Error %d initializing settings subsystem", rc);
-		return rc;
-	}
-#endif
-
 	struct _inspect_flash inspect_flash_ctx = {
 		.buf_len = buf_len,
 		.total_size = 0
@@ -328,6 +319,15 @@ int stream_flash_init(struct stream_flash_ctx *ctx, const struct device *fdev,
 }
 
 #ifdef CONFIG_STREAM_FLASH_PROGRESS
+static int stream_flash_settings_init(void)
+{
+	int rc = settings_subsys_init();
+
+	if (rc != 0) {
+		LOG_ERR("Error %d initializing settings subsystem", rc);
+	}
+	return rc;
+}
 
 int stream_flash_progress_load(struct stream_flash_ctx *ctx,
 			       const char *settings_key)
@@ -336,9 +336,12 @@ int stream_flash_progress_load(struct stream_flash_ctx *ctx,
 		return -EFAULT;
 	}
 
-	int rc = settings_load_subtree_direct(settings_key,
-					      settings_direct_loader,
-					      (void *) ctx);
+	int rc = stream_flash_settings_init();
+
+	if (rc == 0) {
+		rc = settings_load_subtree_direct(settings_key, settings_direct_loader,
+						  (void *)ctx);
+	}
 
 	if (rc != 0) {
 		LOG_ERR("Error %d while loading progress for \"%s\"",
@@ -355,9 +358,12 @@ int stream_flash_progress_save(const struct stream_flash_ctx *ctx,
 		return -EFAULT;
 	}
 
-	int rc = settings_save_one(settings_key,
-				   &ctx->bytes_written,
-				   sizeof(ctx->bytes_written));
+	int rc = stream_flash_settings_init();
+
+	if (rc == 0) {
+		rc = settings_save_one(settings_key, &ctx->bytes_written,
+				       sizeof(ctx->bytes_written));
+	}
 
 	if (rc != 0) {
 		LOG_ERR("Error %d while storing progress for \"%s\"",
@@ -374,7 +380,11 @@ int stream_flash_progress_clear(const struct stream_flash_ctx *ctx,
 		return -EFAULT;
 	}
 
-	int rc = settings_delete(settings_key);
+	int rc = stream_flash_settings_init();
+
+	if (rc == 0) {
+		rc = settings_delete(settings_key);
+	}
 
 	if (rc != 0) {
 		LOG_ERR("Error %d while deleting progress for \"%s\"",


### PR DESCRIPTION
The commit moves Settigns initialization out of stream_flash initialization function into: stream_flash_progress_clear
 stream_flash_progress_load and stream_flash_progress_save.

This slightly increases code size (~56 bytes on Arm) but allows to initialize Stream Flash even if Settings subsystem fails to initialize and continue providing its basic functionality.