### PR TITLE
TF-M: increase default Mbed TLS heap size in TF-M

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -341,7 +341,7 @@ manifest:
       groups:
         - tee
     - name: trusted-firmware-m
-      revision: bceac6cdfccb41ef4e289b9dca17daad48cda270
+      revision: fa020a8b001843bb5a115bc4692eaf6787e3d1de
       path: modules/tee/tf-m/trusted-firmware-m
       groups:
         - tee


### PR DESCRIPTION
This PR updates the TF-M reference in to include a couple of commits which are useful to properly size the heap memory allocated in TF-M for the crypto partition. This is necessary in order to allow Mbed TLS to handle RSA signatures with 2048-bits (previously only 1024-bits were possible).

Resolves #79864