### PR TITLE
stm32 flash read out protection rdp in a common file

### DIFF
--- a/drivers/flash/flash_stm32.c
+++ b/drivers/flash/flash_stm32.c
@@ -42,8 +42,6 @@ static const struct flash_parameters flash_stm32_parameters = {
 #endif
 };
 
-static int flash_stm32_cr_lock(const struct device *dev, bool enable);
-
 bool __weak flash_stm32_valid_range(const struct device *dev, off_t offset,
 				    uint32_t len, bool write)
 {
@@ -228,7 +226,7 @@ static int flash_stm32_write(const struct device *dev, off_t offset,
 	return rc;
 }
 
-static int flash_stm32_cr_lock(const struct device *dev, bool enable)
+int flash_stm32_cr_lock(const struct device *dev, bool enable)
 {
 	FLASH_TypeDef *regs = FLASH_STM32_REGS(dev);
 
@@ -286,81 +284,6 @@ static int flash_stm32_cr_lock(const struct device *dev, bool enable)
 	}
 
 	return rc;
-}
-
-int flash_stm32_option_bytes_lock(const struct device *dev, bool enable)
-{
-	FLASH_TypeDef *regs = FLASH_STM32_REGS(dev);
-
-#if defined(FLASH_OPTCR_OPTLOCK) /* F2, F4, F7 */
-	if (enable) {
-		regs->OPTCR |= FLASH_OPTCR_OPTLOCK;
-	} else if (regs->OPTCR & FLASH_OPTCR_OPTLOCK) {
-		regs->OPTKEYR = FLASH_OPT_KEY1;
-		regs->OPTKEYR = FLASH_OPT_KEY2;
-	}
-#else
-	int rc;
-
-	/* Unlock CR/PECR/NSCR register if needed. */
-	if (!enable) {
-		rc = flash_stm32_cr_lock(dev, false);
-		if (rc) {
-			return rc;
-		}
-	}
-#if defined(FLASH_CR_OPTWRE)	  /* F0, F1 and F3 */
-	if (enable) {
-		regs->CR &= ~FLASH_CR_OPTWRE;
-	} else if (!(regs->CR & FLASH_CR_OPTWRE)) {
-		regs->OPTKEYR = FLASH_OPTKEY1;
-		regs->OPTKEYR = FLASH_OPTKEY2;
-	}
-#elif defined(FLASH_CR_OPTLOCK)	  /* G0, G4, L4, WB and WL */
-	if (enable) {
-		regs->CR |= FLASH_CR_OPTLOCK;
-	} else if (regs->CR & FLASH_CR_OPTLOCK) {
-		regs->OPTKEYR = FLASH_OPTKEY1;
-		regs->OPTKEYR = FLASH_OPTKEY2;
-	}
-#elif defined(FLASH_PECR_OPTLOCK) /* L0 and L1 */
-	if (enable) {
-		regs->PECR |= FLASH_PECR_OPTLOCK;
-	} else if (regs->PECR & FLASH_PECR_OPTLOCK) {
-		regs->OPTKEYR = FLASH_OPTKEY1;
-		regs->OPTKEYR = FLASH_OPTKEY2;
-	}
-#elif defined(FLASH_NSCR_OPTLOCK) /* L5 and U5 */
-	if (enable) {
-		regs->NSCR |= FLASH_NSCR_OPTLOCK;
-	} else if (regs->NSCR & FLASH_NSCR_OPTLOCK) {
-		regs->OPTKEYR = FLASH_OPTKEY1;
-		regs->OPTKEYR = FLASH_OPTKEY2;
-	}
-#elif defined(FLASH_NSCR1_OPTLOCK) /* WBA */
-	if (enable) {
-		regs->NSCR1 |= FLASH_NSCR1_OPTLOCK;
-	} else if (regs->NSCR1 & FLASH_NSCR1_OPTLOCK) {
-		regs->OPTKEYR = FLASH_OPTKEY1;
-		regs->OPTKEYR = FLASH_OPTKEY2;
-	}
-#endif
-	/* Lock CR/PECR/NSCR register if needed. */
-	if (enable) {
-		rc = flash_stm32_cr_lock(dev, true);
-		if (rc) {
-			return rc;
-		}
-	}
-#endif
-
-	if (enable) {
-		LOG_DBG("Option bytes locked");
-	} else {
-		LOG_DBG("Option bytes unlocked");
-	}
-
-	return 0;
 }
 
 #if defined(CONFIG_FLASH_EX_OP_ENABLED) && defined(CONFIG_FLASH_STM32_BLOCK_REGISTERS)

--- a/drivers/flash/flash_stm32.h
+++ b/drivers/flash/flash_stm32.h
@@ -55,6 +55,8 @@ struct flash_stm32_priv {
 #define FLASH_CR_SNB FLASH_CR_SSN
 #define FLASH_CR_SNB_Pos FLASH_CR_SSN_Pos
 #define KEYR1 KEYR
+#define FLASH_OPT_KEY1 FLASH_OPTKEY1
+#define FLASH_OPT_KEY2 FLASH_OPTKEY2
 #endif /* CONFIG_SOC_SERIES_STM32H7RSX */
 
 /* Differentiate between arm trust-zone non-secure/secure, and others. */
@@ -71,10 +73,8 @@ struct flash_stm32_priv {
 #define FLASH_STM32_SR		SR
 #endif
 
-
 #define FLASH_STM32_PRIV(dev) ((struct flash_stm32_priv *)((dev)->data))
 #define FLASH_STM32_REGS(dev) (FLASH_STM32_PRIV(dev)->regs)
-
 
 /* Redefinitions of flags and masks to harmonize stm32 series: */
 #if defined(CONFIG_SOC_SERIES_STM32U5X)
@@ -329,12 +329,12 @@ int flash_stm32_block_erase_loop(const struct device *dev,
 
 int flash_stm32_wait_flash_idle(const struct device *dev);
 
-int flash_stm32_option_bytes_lock(const struct device *dev, bool enable);
-
 uint32_t flash_stm32_option_bytes_read(const struct device *dev);
 
 int flash_stm32_option_bytes_write(const struct device *dev, uint32_t mask,
 				   uint32_t value);
+
+int flash_stm32_cr_lock(const struct device *dev, bool enable);
 
 #ifdef CONFIG_SOC_SERIES_STM32WBX
 int flash_stm32_check_status(const struct device *dev);

--- a/drivers/flash/flash_stm32h7x.c
+++ b/drivers/flash/flash_stm32h7x.c
@@ -309,31 +309,6 @@ int flash_stm32_option_bytes_disable(const struct device *dev)
 }
 #endif /* CONFIG_FLASH_STM32_BLOCK_REGISTERS */
 
-int flash_stm32_option_bytes_lock(const struct device *dev, bool enable)
-{
-	FLASH_TypeDef *regs = FLASH_STM32_REGS(dev);
-
-	if (enable) {
-		regs->OPTCR |= FLASH_OPTCR_OPTLOCK;
-	} else if (regs->OPTCR & FLASH_OPTCR_OPTLOCK) {
-#ifdef CONFIG_SOC_SERIES_STM32H7RSX
-		regs->OPTKEYR = FLASH_OPTKEY1;
-		regs->OPTKEYR = FLASH_OPTKEY2;
-#else
-		regs->OPTKEYR = FLASH_OPT_KEY1;
-		regs->OPTKEYR = FLASH_OPT_KEY2;
-#endif /* CONFIG_SOC_SERIES_STM32H7RSX */
-	}
-
-	if (enable) {
-		LOG_DBG("Option bytes locked");
-	} else {
-		LOG_DBG("Option bytes unlocked");
-	}
-
-	return 0;
-}
-
 bool flash_stm32_valid_range(const struct device *dev, off_t offset, uint32_t len, bool write)
 {
 #if defined(DUAL_BANK)


### PR DESCRIPTION
Following the PR "Implement readout protection for STM32H7" #76640, it appears that 
" Function flash_stm32_option_bytes_lock() seems to be the obvious candidate to be moved to" a common file to stm32h7 anr other stm32 series.
This common file could be the existing drivers/flash/flash_stm32_ex_op.c 
The flash_stm32_option_bytes_lock() is moved there and the flash_stm32_write_protection is made external to that file