### PR TITLE
modules: nanopb: Move pip dependencies to optional module

### DIFF
--- a/doc/services/serialization/nanopb.rst
+++ b/doc/services/serialization/nanopb.rst
@@ -45,6 +45,7 @@ Additionally, Nanopb is an optional module and needs to be added explicitly to t
 
    west config manifest.project-filter -- +nanopb
    west update
+   west packages pip --install
 
 Configuration
 *************

--- a/scripts/requirements-extras.txt
+++ b/scripts/requirements-extras.txt
@@ -21,10 +21,6 @@ Pillow>=10.0
 # can be used to sign a Zephyr application binary for consumption by a bootloader
 imgtool>=2.1.0
 
-# used by nanopb module to generate sources from .proto files
-grpcio-tools>=1.47.0
-protobuf>=3.20.3
-
 # used by scripts/release/bug_bash.py for generating top ten bug squashers
 PyGithub
 

--- a/submanifests/optional.yaml
+++ b/submanifests/optional.yaml
@@ -22,7 +22,7 @@ manifest:
       groups:
         - optional
     - name: nanopb
-      revision: 98bf4db69897b53434f3d0ba72e0a3ab1a902824
+      revision: 0a3b5050a28faeca3cfa2f566e043807431c8d7f
       path: modules/lib/nanopb
       remote: upstream
       groups:


### PR DESCRIPTION
The west packages extension can be used to install module dependencies.

Upstream nanopb has added the pip package dependencies to the zephyr/module.yml file. Remove in-tree pip package dependencies.

Ref #80782 