### PR TITLE
soc: nordic: Default enable Power Management on nRF54H20 radio core

### DIFF
--- a/soc/nordic/nrf54h/Kconfig.defconfig.nrf54h20_cpurad
+++ b/soc/nordic/nrf54h/Kconfig.defconfig.nrf54h20_cpurad
@@ -11,4 +11,7 @@ config NUM_IRQS
 config NRF_REGTOOL_GENERATE_UICR
 	default y
 
+config PM
+	default y
+
 endif # SOC_NRF54H20_CPURAD


### PR DESCRIPTION
Adds CONFIG_PM=y to Radio core in the nRF54H20 SoC on the nRF54H20 DK
soc defconf.