### PR TITLE
boards: nordic: nrf54h20dk: VPRs board runner config

### DIFF
--- a/boards/nordic/nrf54h20dk/board.cmake
+++ b/boards/nordic/nrf54h20dk/board.cmake
@@ -12,3 +12,14 @@ if(CONFIG_BOARD_NRF54H20DK_NRF54H20_CPUAPP OR CONFIG_BOARD_NRF54H20DK_NRF54H20_C
   board_runner_args(jlink "--device=CORTEX-M33" "--speed=4000" "--tool-opt=-jlinkscriptfile ${JLINKSCRIPTFILE}")
   include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
 endif()
+
+if(CONFIG_BOARD_NRF54H20DK_NRF54H20_CPUPPR OR CONFIG_BOARD_NRF54H20DK_NRF54H20_CPUFLPR)
+  if(CONFIG_BOARD_NRF54H20DK_NRF54H20_CPUPPR)
+    set(JLINKSCRIPTFILE ${CMAKE_CURRENT_LIST_DIR}/support/nrf54h20_cpuppr.JLinkScript)
+  else()
+    set(JLINKSCRIPTFILE ${CMAKE_CURRENT_LIST_DIR}/support/nrf54h20_cpuflpr.JLinkScript)
+  endif()
+
+  board_runner_args(jlink "--device=RISC-V" "--speed=4000" "-if SW" "--tool-opt=-jlinkscriptfile ${JLINKSCRIPTFILE}")
+  include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
+endif()

--- a/boards/nordic/nrf54h20dk/support/nrf54h20_cpuflpr.JLinkScript
+++ b/boards/nordic/nrf54h20dk/support/nrf54h20_cpuflpr.JLinkScript
@@ -1,0 +1,9 @@
+int InitTarget(void) {
+  // Base address where DMI registers can be found in the APB address space
+  JLINK_ExecCommand("CORESIGHT_SetCoreBaseAddr = 0x5F8D4400");
+
+  // Use AP[x] to communicate with the RISC-V, flpr = APP
+  JLINK_ExecCommand("CORESIGHT_SetIndexAHBAPToUse = 0");
+
+  return 0;
+}

--- a/boards/nordic/nrf54h20dk/support/nrf54h20_cpuppr.JLinkScript
+++ b/boards/nordic/nrf54h20dk/support/nrf54h20_cpuppr.JLinkScript
@@ -1,0 +1,9 @@
+int InitTarget(void) {
+  // Base address where DMI registers can be found in the APB address space
+  JLINK_ExecCommand("CORESIGHT_SetCoreBaseAddr = 0x5F908400");
+
+  // Use AP[x] to communicate with the RISC-V, ppr = APP
+  JLINK_ExecCommand("CORESIGHT_SetIndexAHBAPToUse = 0");
+
+  return 0;
+}


### PR DESCRIPTION
Added basic support for west debug for nrf54h20
RISC-V cpus: nrf54h20_cpuppr and nrf54h20_cpuppr.
Note external jlink probe needs to be used.