### PR TITLE
west: runners: bossac: Honor --erase flag

### DIFF
--- a/doc/develop/flash_debug/host-tools.rst
+++ b/doc/develop/flash_debug/host-tools.rst
@@ -28,7 +28,14 @@ The typical command to flash the board is:
 
 .. code-block:: console
 
-	west flash [ -r bossac ] [ -p /dev/ttyX ]
+	west flash [ -r bossac ] [ -p /dev/ttyX ] [ --erase ]
+
+.. note::
+
+    By default, flashing with bossac will only erase the flash pages containing
+    the flashed application, leaving other pages untouched. Should you wish to
+    erase the entire flash of the target when flashing, pass the ``--erase``
+    parameter when flashing.
 
 Flash configuration for devices:
 

--- a/doc/releases/migration-guide-4.1.rst
+++ b/doc/releases/migration-guide-4.1.rst
@@ -18,6 +18,12 @@ the :ref:`release notes<zephyr_4.1>`.
 Build System
 ************
 
+BOSSA Runner
+============
+
+The ``bossac`` runner has been changed to no longer do a full erase by default when flashing. To
+perform a full erase, pass the ``--erase`` option when executing ``west flash``.
+
 Kernel
 ******
 

--- a/scripts/west_commands/runners/bossac.py
+++ b/scripts/west_commands/runners/bossac.py
@@ -25,12 +25,13 @@ class BossacBinaryRunner(ZephyrBinaryRunner):
     '''Runner front-end for bossac.'''
 
     def __init__(self, cfg, bossac='bossac', port=DEFAULT_BOSSAC_PORT,
-                 speed=DEFAULT_BOSSAC_SPEED, boot_delay=0):
+                 speed=DEFAULT_BOSSAC_SPEED, boot_delay=0, erase=False):
         super().__init__(cfg)
         self.bossac = bossac
         self.port = port
         self.speed = speed
         self.boot_delay = boot_delay
+        self.erase = erase
 
     @classmethod
     def name(cls):
@@ -38,7 +39,7 @@ class BossacBinaryRunner(ZephyrBinaryRunner):
 
     @classmethod
     def capabilities(cls):
-        return RunnerCaps(commands={'flash'})
+        return RunnerCaps(commands={'flash'}, erase=True)
 
     @classmethod
     def do_add_parser(cls, parser):
@@ -60,7 +61,7 @@ class BossacBinaryRunner(ZephyrBinaryRunner):
     def do_create(cls, cfg, args):
         return BossacBinaryRunner(cfg, bossac=args.bossac,
                                   port=args.bossac_port, speed=args.speed,
-                                  boot_delay=args.delay)
+                                  boot_delay=args.delay, erase=args.erase)
 
     def read_help(self):
         """Run bossac --help and return the output as a list of lines"""
@@ -180,8 +181,11 @@ class BossacBinaryRunner(ZephyrBinaryRunner):
 
     def make_bossac_cmd(self):
         self.ensure_output('bin')
-        cmd_flash = [self.bossac, '-p', self.port, '-R', '-e', '-w', '-v',
+        cmd_flash = [self.bossac, '-p', self.port, '-R', '-w', '-v',
                      '-b', self.cfg.bin_file]
+
+        if self.erase:
+            cmd_flash += ['-e']
 
         dt_chosen_code_partition_nd = self.get_chosen_code_partition_node()
 


### PR DESCRIPTION
Instead of unconditionally erasing the whole target, add support for using the common --erase flag.

This tweak is needed to avoid the bossac runner from erasing the whole chip every time it's run, helping preserve things like settings stored to flash when using them on samd21, for example.