### PR TITLE
vla: Use proper C99 flexible array

### DIFF
--- a/include/zephyr/bluetooth/hci_types.h
+++ b/include/zephyr/bluetooth/hci_types.h
@@ -755,7 +755,7 @@ struct bt_hci_handle_count {
 #define BT_HCI_OP_HOST_NUM_COMPLETED_PACKETS    BT_OP(BT_OGF_BASEBAND, 0x0035) /* 0x0c35 */
 struct bt_hci_cp_host_num_completed_packets {
 	uint8_t  num_handles;
-	struct bt_hci_handle_count h[0];
+	struct bt_hci_handle_count h[];
 } __packed;
 
 #define BT_HCI_OP_WRITE_INQUIRY_MODE            BT_OP(BT_OGF_BASEBAND, 0x0045) /* 0x0c45 */
@@ -811,7 +811,7 @@ struct bt_hci_cp_configure_data_path {
 	uint8_t  data_path_dir;
 	uint8_t  data_path_id;
 	uint8_t  vs_config_len;
-	uint8_t  vs_config[0];
+	uint8_t  vs_config[];
 } __packed;
 
 struct bt_hci_rp_configure_data_path {
@@ -922,7 +922,7 @@ struct bt_hci_std_codec_info {
 } __packed;
 struct bt_hci_std_codecs {
 	uint8_t num_codecs;
-	struct bt_hci_std_codec_info codec_info[0];
+	struct bt_hci_std_codec_info codec_info[];
 } __packed;
 struct bt_hci_vs_codec_info {
 	uint16_t company_id;
@@ -930,12 +930,12 @@ struct bt_hci_vs_codec_info {
 } __packed;
 struct bt_hci_vs_codecs {
 	uint8_t num_codecs;
-	struct bt_hci_vs_codec_info codec_info[0];
+	struct bt_hci_vs_codec_info codec_info[];
 } __packed;
 struct bt_hci_rp_read_codecs {
 	uint8_t status;
 	/* other fields filled in dynamically */
-	uint8_t codecs[0];
+	uint8_t codecs[];
 } __packed;
 
 #define BT_HCI_OP_READ_CODECS_V2                BT_OP(BT_OGF_INFO, 0x000d) /* 0x100d */
@@ -945,7 +945,7 @@ struct bt_hci_std_codec_info_v2 {
 } __packed;
 struct bt_hci_std_codecs_v2 {
 	uint8_t num_codecs;
-	struct bt_hci_std_codec_info_v2 codec_info[0];
+	struct bt_hci_std_codec_info_v2 codec_info[];
 } __packed;
 struct bt_hci_vs_codec_info_v2 {
 	uint16_t company_id;
@@ -954,12 +954,12 @@ struct bt_hci_vs_codec_info_v2 {
 } __packed;
 struct bt_hci_vs_codecs_v2 {
 	uint8_t num_codecs;
-	struct bt_hci_vs_codec_info_v2 codec_info[0];
+	struct bt_hci_vs_codec_info_v2 codec_info[];
 } __packed;
 struct bt_hci_rp_read_codecs_v2 {
 	uint8_t status;
 	/* other fields filled in dynamically */
-	uint8_t codecs[0];
+	uint8_t codecs[];
 } __packed;
 
 struct bt_hci_cp_codec_id {
@@ -976,13 +976,13 @@ struct bt_hci_cp_read_codec_capabilities {
 } __packed;
 struct bt_hci_codec_capability_info {
 	uint8_t length;
-	uint8_t data[0];
+	uint8_t data[];
 } __packed;
 struct bt_hci_rp_read_codec_capabilities {
 	uint8_t status;
 	uint8_t num_capabilities;
 	/* other fields filled in dynamically */
-	uint8_t capabilities[0];
+	uint8_t capabilities[];
 } __packed;
 
 #define BT_HCI_OP_READ_CTLR_DELAY               BT_OP(BT_OGF_INFO, 0x000f) /* 0x100f */
@@ -991,7 +991,7 @@ struct bt_hci_cp_read_ctlr_delay {
 	uint8_t transport;
 	uint8_t direction;
 	uint8_t codec_config_len;
-	uint8_t codec_config[0];
+	uint8_t codec_config[];
 } __packed;
 struct bt_hci_rp_read_ctlr_delay {
 	uint8_t status;
@@ -1555,7 +1555,7 @@ struct bt_hci_cp_le_set_ext_adv_data {
 	uint8_t  op;
 	uint8_t  frag_pref;
 	uint8_t  len;
-	uint8_t  data[0];
+	uint8_t  data[];
 } __packed;
 
 #define BT_HCI_OP_LE_SET_EXT_SCAN_RSP_DATA      BT_OP(BT_OGF_LE, 0x0038) /* 0x2038 */
@@ -1564,7 +1564,7 @@ struct bt_hci_cp_le_set_ext_scan_rsp_data {
 	uint8_t  op;
 	uint8_t  frag_pref;
 	uint8_t  len;
-	uint8_t  data[0];
+	uint8_t  data[];
 } __packed;
 
 #define BT_HCI_OP_LE_SET_EXT_ADV_ENABLE         BT_OP(BT_OGF_LE, 0x0039) /* 0x2039 */
@@ -1577,7 +1577,7 @@ struct bt_hci_ext_adv_set {
 struct bt_hci_cp_le_set_ext_adv_enable {
 	uint8_t  enable;
 	uint8_t  set_num;
-	struct bt_hci_ext_adv_set s[0];
+	struct bt_hci_ext_adv_set s[];
 } __packed;
 
 #define BT_HCI_OP_LE_READ_MAX_ADV_DATA_LEN      BT_OP(BT_OGF_LE, 0x003a) /* 0x203a */
@@ -1622,7 +1622,7 @@ struct bt_hci_cp_le_set_per_adv_data {
 	uint8_t  handle;
 	uint8_t  op;
 	uint8_t  len;
-	uint8_t  data[0];
+	uint8_t  data[];
 } __packed;
 
 #define BT_HCI_LE_SET_PER_ADV_ENABLE_ENABLE     BIT(0)
@@ -1649,7 +1649,7 @@ struct bt_hci_cp_le_set_ext_scan_param {
 	uint8_t  own_addr_type;
 	uint8_t  filter_policy;
 	uint8_t  phys;
-	struct bt_hci_ext_scan_phy p[0];
+	struct bt_hci_ext_scan_phy p[];
 } __packed;
 
 /* Extends BT_HCI_LE_SCAN_FILTER_DUP */
@@ -1681,7 +1681,7 @@ struct bt_hci_cp_le_ext_create_conn {
 	uint8_t      own_addr_type;
 	bt_addr_le_t peer_addr;
 	uint8_t      phys;
-	struct bt_hci_ext_conn_phy p[0];
+	struct bt_hci_ext_conn_phy p[];
 } __packed;
 
 struct bt_hci_cp_le_ext_create_conn_v2 {
@@ -1691,7 +1691,7 @@ struct bt_hci_cp_le_ext_create_conn_v2 {
 	uint8_t      own_addr_type;
 	bt_addr_le_t peer_addr;
 	uint8_t      phys;
-	struct bt_hci_ext_conn_phy p[0];
+	struct bt_hci_ext_conn_phy p[];
 } __packed;
 
 #define BT_HCI_OP_LE_SET_PER_ADV_SUBEVENT_DATA  BT_OP(BT_OGF_LE, 0x0082) /* 0x2082 */
@@ -1700,13 +1700,13 @@ struct bt_hci_cp_le_set_pawr_subevent_data_element {
 	uint8_t response_slot_start;
 	uint8_t response_slot_count;
 	uint8_t subevent_data_length;
-	uint8_t subevent_data[0];
+	uint8_t subevent_data[];
 } __packed;
 
 struct bt_hci_cp_le_set_pawr_subevent_data {
 	uint8_t adv_handle;
 	uint8_t num_subevents;
-	struct bt_hci_cp_le_set_pawr_subevent_data_element subevents[0];
+	struct bt_hci_cp_le_set_pawr_subevent_data_element subevents[];
 } __packed;
 
 
@@ -1718,7 +1718,7 @@ struct bt_hci_cp_le_set_pawr_response_data {
 	uint8_t response_subevent;
 	uint8_t response_slot;
 	uint8_t response_data_length;
-	uint8_t response_data[0];
+	uint8_t response_data[];
 } __packed;
 
 #define BT_HCI_OP_LE_SET_PER_ADV_SYNC_SUBEVENT  BT_OP(BT_OGF_LE, 0x0084) /* 0x2084 */
@@ -1726,7 +1726,7 @@ struct bt_hci_cp_le_set_pawr_sync_subevent {
 	uint16_t sync_handle;
 	uint16_t periodic_adv_properties;
 	uint8_t num_subevents;
-	uint8_t subevents[0];
+	uint8_t subevents[];
 } __packed;
 
 
@@ -1839,7 +1839,7 @@ struct bt_hci_cp_le_rx_test_v3 {
 	uint8_t  expected_cte_type;
 	uint8_t  slot_durations;
 	uint8_t  switch_pattern_len;
-	uint8_t  ant_ids[0];
+	uint8_t  ant_ids[];
 } __packed;
 
 #define BT_HCI_OP_LE_TX_TEST_V3                 BT_OP(BT_OGF_LE, 0x0050) /* 0x2050 */
@@ -1852,7 +1852,7 @@ struct bt_hci_cp_le_tx_test_v3 {
 	uint8_t  cte_len;
 	uint8_t  cte_type;
 	uint8_t  switch_pattern_len;
-	uint8_t  ant_ids[0];
+	uint8_t  ant_ids[];
 } __packed;
 
 /* Min and max Constant Tone Extension length in 8us units */
@@ -1874,7 +1874,7 @@ struct bt_hci_cp_le_set_cl_cte_tx_params {
 	uint8_t cte_type;
 	uint8_t cte_count;
 	uint8_t switch_pattern_len;
-	uint8_t ant_ids[0];
+	uint8_t ant_ids[];
 } __packed;
 
 #define BT_HCI_OP_LE_SET_CL_CTE_TX_ENABLE      BT_OP(BT_OGF_LE, 0x0052) /* 0x2052 */
@@ -1897,7 +1897,7 @@ struct bt_hci_cp_le_set_cl_cte_sampling_enable {
 	uint8_t  slot_durations;
 	uint8_t  max_sampled_cte;
 	uint8_t  switch_pattern_len;
-	uint8_t  ant_ids[0];
+	uint8_t  ant_ids[];
 } __packed;
 
 struct bt_hci_rp_le_set_cl_cte_sampling_enable {
@@ -1911,7 +1911,7 @@ struct bt_hci_cp_le_set_conn_cte_rx_params {
 	uint8_t  sampling_enable;
 	uint8_t  slot_durations;
 	uint8_t  switch_pattern_len;
-	uint8_t  ant_ids[0];
+	uint8_t  ant_ids[];
 } __packed;
 
 struct bt_hci_rp_le_set_conn_cte_rx_params {
@@ -1931,7 +1931,7 @@ struct bt_hci_cp_le_set_conn_cte_tx_params {
 	uint16_t handle;
 	uint8_t  cte_types;
 	uint8_t  switch_pattern_len;
-	uint8_t  ant_ids[0];
+	uint8_t  ant_ids[];
 } __packed;
 
 struct bt_hci_rp_le_set_conn_cte_tx_params {
@@ -2119,14 +2119,14 @@ struct bt_hci_cp_le_set_cig_params {
 	uint16_t c_latency;
 	uint16_t p_latency;
 	uint8_t  num_cis;
-	struct bt_hci_cis_params cis[0];
+	struct bt_hci_cis_params cis[];
 } __packed;
 
 struct bt_hci_rp_le_set_cig_params {
 	uint8_t  status;
 	uint8_t  cig_id;
 	uint8_t  num_handles;
-	uint16_t handle[0];
+	uint16_t handle[];
 } __packed;
 
 #define BT_HCI_OP_LE_SET_CIG_PARAMS_TEST        BT_OP(BT_OGF_LE, 0x0063) /* 0x2063 */
@@ -2154,14 +2154,14 @@ struct bt_hci_cp_le_set_cig_params_test {
 	uint8_t  packing;
 	uint8_t  framing;
 	uint8_t  num_cis;
-	struct bt_hci_cis_params_test cis[0];
+	struct bt_hci_cis_params_test cis[];
 } __packed;
 
 struct bt_hci_rp_le_set_cig_params_test {
 	uint8_t  status;
 	uint8_t  cig_id;
 	uint8_t  num_handles;
-	uint16_t handle[0];
+	uint16_t handle[];
 } __packed;
 
 #define BT_HCI_OP_LE_CREATE_CIS                 BT_OP(BT_OGF_LE, 0x0064) /* 0x2064 */
@@ -2172,7 +2172,7 @@ struct bt_hci_cis {
 
 struct bt_hci_cp_le_create_cis {
 	uint8_t  num_cis;
-	struct bt_hci_cis cis[0];
+	struct bt_hci_cis cis[];
 } __packed;
 
 #define BT_HCI_OP_LE_REMOVE_CIG                 BT_OP(BT_OGF_LE, 0x0065) /* 0x2065 */
@@ -2252,7 +2252,7 @@ struct bt_hci_cp_le_big_create_sync {
 	uint8_t  mse;
 	uint16_t sync_timeout;
 	uint8_t  num_bis;
-	uint8_t  bis[0];
+	uint8_t  bis[];
 } __packed;
 
 #define BT_HCI_OP_LE_BIG_TERMINATE_SYNC         BT_OP(BT_OGF_LE, 0x006c) /* 0x206c */
@@ -2278,7 +2278,7 @@ struct bt_hci_cp_le_setup_iso_path {
 	struct bt_hci_cp_codec_id codec_id;
 	uint8_t  controller_delay[3];
 	uint8_t  codec_config_len;
-	uint8_t  codec_config[0];
+	uint8_t  codec_config[];
 } __packed;
 
 struct bt_hci_rp_le_setup_iso_path {
@@ -2386,7 +2386,7 @@ struct bt_hci_cp_le_tx_test_v4 {
 	uint8_t  cte_len;
 	uint8_t  cte_type;
 	uint8_t  switch_pattern_len;
-	uint8_t  ant_ids[0];
+	uint8_t  ant_ids[];
 } __packed;
 
 #define BT_HCI_TX_TEST_POWER_MIN -0x7F
@@ -2811,7 +2811,7 @@ struct bt_hci_evt_role_change {
 #define BT_HCI_EVT_NUM_COMPLETED_PACKETS        0x13
 struct bt_hci_evt_num_completed_packets {
 	uint8_t  num_handles;
-	struct bt_hci_handle_count h[0];
+	struct bt_hci_handle_count h[];
 } __packed;
 
 #define BT_HCI_EVT_PIN_CODE_REQ                 0x16
@@ -2896,7 +2896,7 @@ struct bt_hci_evt_le_per_advertising_report_v2 {
 	uint8_t subevent;
 	uint8_t data_status;
 	uint8_t length;
-	uint8_t data[0];
+	uint8_t data[];
 } __packed;
 
 #define BT_HCI_EVT_LE_PAST_RECEIVED_V2 0x26
@@ -2932,7 +2932,7 @@ struct bt_hci_evt_le_per_adv_response {
 	uint8_t response_slot;
 	uint8_t data_status;
 	uint8_t data_length;
-	uint8_t data[0];
+	uint8_t data[];
 } __packed;
 
 struct bt_hci_evt_le_per_adv_response_report {
@@ -2940,7 +2940,7 @@ struct bt_hci_evt_le_per_adv_response_report {
 	uint8_t subevent;
 	uint8_t tx_status;
 	uint8_t num_responses;
-	struct bt_hci_evt_le_per_adv_response responses[0];
+	struct bt_hci_evt_le_per_adv_response responses[];
 } __packed;
 
 #define BT_HCI_EVT_LE_ENH_CONN_COMPLETE_V2 0x29
@@ -3058,11 +3058,11 @@ struct bt_hci_evt_le_advertising_info {
 	uint8_t      evt_type;
 	bt_addr_le_t addr;
 	uint8_t      length;
-	uint8_t      data[0];
+	uint8_t      data[];
 } __packed;
 struct bt_hci_evt_le_advertising_report {
 	uint8_t num_reports;
-	struct bt_hci_evt_le_advertising_info adv_info[0];
+	struct bt_hci_evt_le_advertising_info adv_info[];
 } __packed;
 
 /** All limits according to BT Core Spec v5.4 [Vol 4, Part E]. */
@@ -3148,7 +3148,7 @@ struct bt_hci_evt_le_direct_adv_info {
 } __packed;
 struct bt_hci_evt_le_direct_adv_report {
 	uint8_t num_reports;
-	struct bt_hci_evt_le_direct_adv_info direct_adv_info[0];
+	struct bt_hci_evt_le_direct_adv_info direct_adv_info[];
 } __packed;
 
 #define BT_HCI_EVT_LE_PHY_UPDATE_COMPLETE       0x0c
@@ -3184,11 +3184,11 @@ struct bt_hci_evt_le_ext_advertising_info {
 	uint16_t     interval;
 	bt_addr_le_t direct_addr;
 	uint8_t      length;
-	uint8_t      data[0];
+	uint8_t      data[];
 } __packed;
 struct bt_hci_evt_le_ext_advertising_report {
 	uint8_t num_reports;
-	struct bt_hci_evt_le_ext_advertising_info adv_info[0];
+	struct bt_hci_evt_le_ext_advertising_info adv_info[];
 } __packed;
 
 #define BT_HCI_EVT_LE_PER_ADV_SYNC_ESTABLISHED  0x0e
@@ -3210,7 +3210,7 @@ struct bt_hci_evt_le_per_advertising_report {
 	uint8_t  cte_type;
 	uint8_t  data_status;
 	uint8_t  length;
-	uint8_t  data[0];
+	uint8_t  data[];
 } __packed;
 
 #define BT_HCI_EVT_LE_PER_ADV_SYNC_LOST         0x10
@@ -3269,7 +3269,7 @@ struct bt_hci_evt_le_connectionless_iq_report {
 	uint8_t  packet_status;
 	uint16_t per_evt_counter;
 	uint8_t  sample_count;
-	struct bt_hci_le_iq_sample sample[0];
+	struct bt_hci_le_iq_sample sample[];
 } __packed;
 
 #define BT_HCI_EVT_LE_CONNECTION_IQ_REPORT      0x16
@@ -3284,7 +3284,7 @@ struct bt_hci_evt_le_connection_iq_report {
 	uint8_t  packet_status;
 	uint16_t conn_evt_counter;
 	uint8_t  sample_count;
-	struct bt_hci_le_iq_sample sample[0];
+	struct bt_hci_le_iq_sample sample[];
 } __packed;
 
 #define BT_HCI_CTE_REQ_STATUS_RSP_WITHOUT_CTE  0x0
@@ -3355,7 +3355,7 @@ struct bt_hci_evt_le_big_complete {
 	uint16_t max_pdu;
 	uint16_t iso_interval;
 	uint8_t  num_bis;
-	uint16_t handle[0];
+	uint16_t handle[];
 } __packed;
 
 #define BT_HCI_EVT_LE_BIG_TERMINATE             0x1c
@@ -3376,7 +3376,7 @@ struct bt_hci_evt_le_big_sync_established {
 	uint16_t max_pdu;
 	uint16_t iso_interval;
 	uint8_t  num_bis;
-	uint16_t handle[0];
+	uint16_t handle[];
 } __packed;
 
 #define BT_HCI_EVT_LE_BIG_SYNC_LOST             0x1e

--- a/include/zephyr/drivers/sensor.h
+++ b/include/zephyr/drivers/sensor.h
@@ -926,7 +926,7 @@ struct __attribute__((__packed__)) sensor_data_generic_header {
 	int8_t _padding[sizeof(struct sensor_chan_spec) - 1];
 
 	/* Channels present in the frame */
-	struct sensor_chan_spec channels[0];
+	struct sensor_chan_spec channels[];
 };
 
 /**

--- a/include/zephyr/logging/log_multidomain_helper.h
+++ b/include/zephyr/logging/log_multidomain_helper.h
@@ -70,7 +70,7 @@
 
 /** @brief Content of the logging message. */
 struct log_multidomain_log_msg {
-	uint8_t data[0];
+	FLEXIBLE_ARRAY_DECLARE(uint8_t, data);
 } __packed;
 
 /** @brief Content of the domain count message. */
@@ -87,14 +87,14 @@ struct log_multidomain_source_cnt {
 /** @brief Content of the domain name message. */
 struct log_multidomain_domain_name {
 	uint8_t domain_id;
-	char name[0];
+	char name[];
 } __packed;
 
 /** @brief Content of the source name message. */
 struct log_multidomain_source_name {
 	uint8_t domain_id;
 	uint16_t source_id;
-	char name[0];
+	char name[];
 } __packed;
 
 /** @brief Content of the message for getting logging levels. */

--- a/include/zephyr/net/net_ip.h
+++ b/include/zephyr/net/net_ip.h
@@ -600,7 +600,7 @@ struct net_tcp_hdr {
 	uint8_t wnd[2];
 	uint16_t chksum;
 	uint8_t urg[2];
-	uint8_t optdata[0];
+	uint8_t optdata[];
 } __packed;
 
 static inline const char *net_addr_type2str(enum net_addr_type type)

--- a/subsys/bluetooth/audio/ascs_internal.h
+++ b/subsys/bluetooth/audio/ascs_internal.h
@@ -34,13 +34,13 @@
 struct bt_ascs_ase_status {
 	uint8_t  id;
 	uint8_t  state;
-	uint8_t  params[0];
+	uint8_t  params[];
 } __packed;
 
 struct bt_ascs_codec_config {
 	uint8_t len;
 	uint8_t type;
-	uint8_t data[0];
+	uint8_t data[];
 } __packed;
 
 struct bt_ascs_codec {
@@ -86,7 +86,7 @@ struct bt_ascs_ase_status_enable {
 	uint8_t  cig_id;
 	uint8_t  cis_id;
 	uint8_t  metadata_len;
-	uint8_t  metadata[0];
+	uint8_t  metadata[];
 } __packed;
 
 /* ASE_Status =  0x04 (Streaming) defined in Table 4.5.
@@ -95,7 +95,7 @@ struct bt_ascs_ase_status_stream {
 	uint8_t  cig_id;
 	uint8_t  cis_id;
 	uint8_t  metadata_len;
-	uint8_t  metadata[0];
+	uint8_t  metadata[];
 } __packed;
 
 /* ASE_Status = 0x05 (Disabling) as defined in Table 4.5.
@@ -104,14 +104,14 @@ struct bt_ascs_ase_status_disable {
 	uint8_t  cig_id;
 	uint8_t  cis_id;
 	uint8_t  metadata_len;
-	uint8_t  metadata[0];
+	uint8_t  metadata[];
 } __packed;
 
 /* ASE Control Point Protocol */
 struct bt_ascs_ase_cp {
 	/* Request/Notification opcode */
 	uint8_t  op;
-	uint8_t  pdu[0];
+	uint8_t  pdu[];
 } __packed;
 
 /* Opcodes */
@@ -137,14 +137,14 @@ struct bt_ascs_config {
 	/* Codec Specific Config Length */
 	uint8_t  cc_len;
 	/* LTV-formatted Codec-Specific Configuration */
-	struct bt_ascs_codec_config cc[0];
+	struct bt_ascs_codec_config cc[];
 } __packed;
 
 struct bt_ascs_config_op {
 	/* Number of ASEs */
 	uint8_t  num_ases;
 	/* Config Parameters */
-	struct bt_ascs_config cfg[0];
+	struct bt_ascs_config cfg[];
 } __packed;
 
 #define BT_ASCS_QOS_OP                   0x02
@@ -175,7 +175,7 @@ struct bt_ascs_qos_op {
 	/* Number of ASEs */
 	uint8_t  num_ases;
 	/* QoS Parameters */
-	struct bt_ascs_qos qos[0];
+	struct bt_ascs_qos qos[];
 } __packed;
 
 #define BT_ASCS_ENABLE_OP                0x03
@@ -185,14 +185,14 @@ struct bt_ascs_metadata {
 	/* Metadata length */
 	uint8_t  len;
 	/* LTV-formatted Metadata */
-	uint8_t  data[0];
+	uint8_t  data[];
 } __packed;
 
 struct bt_ascs_enable_op {
 	/* Number of ASEs */
 	uint8_t  num_ases;
 	/* Metadata */
-	struct bt_ascs_metadata metadata[0];
+	struct bt_ascs_metadata metadata[];
 } __packed;
 
 #define BT_ASCS_START_OP                 0x04
@@ -200,7 +200,7 @@ struct bt_ascs_start_op {
 	/* Number of ASEs */
 	uint8_t  num_ases;
 	/* ASE IDs */
-	uint8_t  ase[0];
+	uint8_t  ase[];
 } __packed;
 
 #define BT_ASCS_DISABLE_OP               0x05
@@ -208,7 +208,7 @@ struct bt_ascs_disable_op {
 	/* Number of ASEs */
 	uint8_t  num_ases;
 	/* ASE IDs */
-	uint8_t  ase[0];
+	uint8_t  ase[];
 } __packed;
 
 #define BT_ASCS_STOP_OP                  0x06
@@ -216,7 +216,7 @@ struct bt_ascs_stop_op {
 	/* Number of ASEs */
 	uint8_t  num_ases;
 	/* ASE IDs */
-	uint8_t  ase[0];
+	uint8_t  ase[];
 } __packed;
 
 #define BT_ASCS_METADATA_OP              0x07
@@ -224,7 +224,7 @@ struct bt_ascs_metadata_op {
 	/* Number of ASEs */
 	uint8_t  num_ases;
 	/* Metadata */
-	struct bt_ascs_metadata metadata[0];
+	struct bt_ascs_metadata metadata[];
 } __packed;
 
 #define BT_ASCS_RELEASE_OP              0x08
@@ -232,7 +232,7 @@ struct bt_ascs_release_op {
 	/* Number of ASEs */
 	uint8_t  num_ases;
 	/* Ase IDs */
-	uint8_t  ase[0];
+	uint8_t  ase[];
 } __packed;
 
 struct bt_ascs_cp_ase_rsp {
@@ -250,7 +250,7 @@ struct bt_ascs_cp_rsp {
 	/* Number of ASEs */
 	uint8_t  num_ase;
 	/* ASE response */
-	struct bt_ascs_cp_ase_rsp ase_rsp[0];
+	struct bt_ascs_cp_ase_rsp ase_rsp[];
 } __packed;
 
 static inline const char *bt_ascs_op_str(uint8_t op)

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_df_types.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_df_types.h
@@ -109,8 +109,8 @@ struct node_rx_iq_report {
 	uint8_t chan_idx;
 	uint16_t event_counter;
 	union {
-		uint8_t pdu[0] __aligned(4);
-		struct iq_sample sample[0];
+		FLEXIBLE_ARRAY_DECLARE(uint8_t, pdu) __aligned(4);
+		FLEXIBLE_ARRAY_DECLARE(struct iq_sample, sample);
 	};
 };
 
@@ -167,8 +167,8 @@ struct cte_conn_iq_report {
 	uint8_t sample_count;
 	uint8_t rssi_ant_id;
 	union {
-		uint8_t pdu[0] __aligned(4);
-		struct iq_sample sample[0];
+		FLEXIBLE_ARRAY_DECLARE(uint8_t, pdu) __aligned(4);
+		FLEXIBLE_ARRAY_DECLARE(struct iq_sample, sample);
 	};
 };
 

--- a/subsys/bluetooth/controller/ll_sw/openisa/lll/pdu_vendor.h
+++ b/subsys/bluetooth/controller/ll_sw/openisa/lll/pdu_vendor.h
@@ -7,27 +7,27 @@
 /* No vendor Data PDU struct octet3 */
 struct pdu_data_vnd_octet3 {
 	union {
-		uint8_t resv[0];
+		FLEXIBLE_ARRAY_DECLARE(uint8_t, resv);
 	} __packed;
 } __packed;
 
 /* No vendor BIS PDU struct octet3 */
 struct pdu_bis_vnd_octet3 {
 	union {
-		uint8_t resv[0];
+		FLEXIBLE_ARRAY_DECLARE(uint8_t, resv);
 	} __packed;
 } __packed;
 
 /* No vendor CIS PDU struct octet3 */
 struct pdu_cis_vnd_octet3 {
 	union {
-		uint8_t resv[0];
+		FLEXIBLE_ARRAY_DECLARE(uint8_t, resv);
 	} __packed;
 } __packed;
 
 /* No ISOAL helper vendor ISO PDU struct octet3 */
 struct pdu_iso_vnd_octet3 {
 	union {
-		uint8_t resv[0];
+		FLEXIBLE_ARRAY_DECLARE(uint8_t, resv);
 	} __packed;
 } __packed;

--- a/subsys/bluetooth/controller/ll_sw/pdu.h
+++ b/subsys/bluetooth/controller/ll_sw/pdu.h
@@ -436,7 +436,7 @@ struct pdu_adv_ext_hdr {
 	uint8_t tgt_addr:1;
 	uint8_t adv_addr:1;
 #endif /* CONFIG_LITTLE_ENDIAN */
-	uint8_t data[0];
+	FLEXIBLE_ARRAY_DECLARE(uint8_t, data);
 } __packed;
 
 struct pdu_adv_com_ext_adv {
@@ -449,7 +449,7 @@ struct pdu_adv_com_ext_adv {
 #endif /* CONFIG_LITTLE_ENDIAN */
 	union {
 		struct pdu_adv_ext_hdr ext_hdr;
-		uint8_t ext_hdr_adv_data[0];
+		FLEXIBLE_ARRAY_DECLARE(uint8_t, ext_hdr_adv_data);
 	};
 } __packed;
 
@@ -567,7 +567,7 @@ struct pdu_adv {
 	uint8_t len;
 
 	union {
-		uint8_t   payload[0];
+		FLEXIBLE_ARRAY_DECLARE(uint8_t, payload);
 		struct pdu_adv_adv_ind adv_ind;
 		struct pdu_adv_direct_ind direct_ind;
 		struct pdu_adv_scan_req scan_req;
@@ -1004,7 +1004,7 @@ struct pdu_data {
 
 	union {
 		struct pdu_data_llctrl llctrl;
-		uint8_t                   lldata[0];
+		FLEXIBLE_ARRAY_DECLARE(uint8_t, lldata);
 
 #if defined(CONFIG_BT_CTLR_CONN_RSSI)
 		uint8_t                   rssi;
@@ -1032,7 +1032,7 @@ struct pdu_iso {
 
 	struct pdu_iso_vnd_octet3 octet3;
 
-	uint8_t payload[0];
+	uint8_t payload[];
 } __packed;
 
 /* ISO SDU segmentation header */
@@ -1094,7 +1094,7 @@ struct pdu_cis {
 
 	struct pdu_cis_vnd_octet3 octet3;
 
-	uint8_t payload[0];
+	uint8_t payload[];
 } __packed;
 
 enum pdu_big_ctrl_type {
@@ -1116,7 +1116,7 @@ struct pdu_big_ctrl_term_ind {
 struct pdu_big_ctrl {
 	uint8_t opcode;
 	union {
-		uint8_t ctrl_data[0];
+		FLEXIBLE_ARRAY_DECLARE(uint8_t, ctrl_data);
 		struct pdu_big_ctrl_chan_map_ind chan_map_ind;
 		struct pdu_big_ctrl_term_ind term_ind;
 	} __packed;
@@ -1151,7 +1151,7 @@ struct pdu_bis {
 	struct pdu_bis_vnd_octet3 octet3;
 
 	union {
-		uint8_t payload[0];
+		FLEXIBLE_ARRAY_DECLARE(uint8_t, payload);
 		struct pdu_big_ctrl ctrl;
 	} __packed;
 } __packed;
@@ -1275,7 +1275,7 @@ struct pdu_dtm {
 
 	struct pdu_data_vnd_octet3 octet3;
 
-	uint8_t payload[0];
+	uint8_t payload[];
 } __packed;
 
 /* Direct Test Mode maximum payload size */

--- a/subsys/bluetooth/controller/util/dbuf.h
+++ b/subsys/bluetooth/controller/util/dbuf.h
@@ -18,7 +18,7 @@ struct dbuf_hdr {
 	/* Size in a bytes of a single element stored in double buffer. */
 	uint8_t elem_size;
 	/* Pointer for actual buffer memory. Its size should be 2 times @p elem_size. */
-	uint8_t data[0];
+	uint8_t data[];
 };
 
 /**

--- a/subsys/bluetooth/host/att_internal.h
+++ b/subsys/bluetooth/host/att_internal.h
@@ -1,6 +1,7 @@
 /* att_internal.h - Attribute protocol handling */
 
 #include <zephyr/bluetooth/l2cap.h>
+#include <zephyr/sys/util.h>
 
 /*
  * Copyright (c) 2015-2016 Intel Corporation
@@ -75,7 +76,7 @@ struct bt_att_info_128 {
 #define BT_ATT_OP_FIND_INFO_RSP			0x05
 struct bt_att_find_info_rsp {
 	uint8_t  format;
-	uint8_t  info[0];
+	uint8_t  info[];
 } __packed;
 
 /* Find By Type Value Request */
@@ -84,7 +85,7 @@ struct bt_att_find_type_req {
 	uint16_t start_handle;
 	uint16_t end_handle;
 	uint16_t type;
-	uint8_t  value[0];
+	uint8_t  value[];
 } __packed;
 
 struct bt_att_handle_group {
@@ -95,7 +96,7 @@ struct bt_att_handle_group {
 /* Find By Type Value Response */
 #define BT_ATT_OP_FIND_TYPE_RSP			0x07
 struct bt_att_find_type_rsp {
-	struct bt_att_handle_group list[0];
+	FLEXIBLE_ARRAY_DECLARE(struct bt_att_handle_group, list);
 } __packed;
 
 /* Read By Type Request */
@@ -103,19 +104,19 @@ struct bt_att_find_type_rsp {
 struct bt_att_read_type_req {
 	uint16_t start_handle;
 	uint16_t end_handle;
-	uint8_t  uuid[0];
+	uint8_t  uuid[];
 } __packed;
 
 struct bt_att_data {
 	uint16_t handle;
-	uint8_t  value[0];
+	uint8_t  value[];
 } __packed;
 
 /* Read By Type Response */
 #define BT_ATT_OP_READ_TYPE_RSP			0x09
 struct bt_att_read_type_rsp {
 	uint8_t  len;
-	struct bt_att_data data[0];
+	struct bt_att_data data[];
 } __packed;
 
 /* Read Request */
@@ -127,7 +128,7 @@ struct bt_att_read_req {
 /* Read Response */
 #define BT_ATT_OP_READ_RSP			0x0b
 struct bt_att_read_rsp {
-	uint8_t  value[0];
+	FLEXIBLE_ARRAY_DECLARE(uint8_t, value);
 } __packed;
 
 /* Read Blob Request */
@@ -140,7 +141,7 @@ struct bt_att_read_blob_req {
 /* Read Blob Response */
 #define BT_ATT_OP_READ_BLOB_RSP			0x0d
 struct bt_att_read_blob_rsp {
-	uint8_t  value[0];
+	FLEXIBLE_ARRAY_DECLARE(uint8_t, value);
 } __packed;
 
 /* Read Multiple Request */
@@ -148,13 +149,13 @@ struct bt_att_read_blob_rsp {
 
 #define BT_ATT_OP_READ_MULT_REQ			0x0e
 struct bt_att_read_mult_req {
-	uint16_t handles[0];
+	FLEXIBLE_ARRAY_DECLARE(uint16_t, value);
 } __packed;
 
 /* Read Multiple Response */
 #define BT_ATT_OP_READ_MULT_RSP			0x0f
 struct bt_att_read_mult_rsp {
-	uint8_t  value[0];
+	FLEXIBLE_ARRAY_DECLARE(uint8_t, value);
 } __packed;
 
 /* Read by Group Type Request */
@@ -162,27 +163,27 @@ struct bt_att_read_mult_rsp {
 struct bt_att_read_group_req {
 	uint16_t start_handle;
 	uint16_t end_handle;
-	uint8_t  uuid[0];
+	uint8_t  uuid[];
 } __packed;
 
 struct bt_att_group_data {
 	uint16_t start_handle;
 	uint16_t end_handle;
-	uint8_t  value[0];
+	uint8_t  value[];
 } __packed;
 
 /* Read by Group Type Response */
 #define BT_ATT_OP_READ_GROUP_RSP		0x11
 struct bt_att_read_group_rsp {
 	uint8_t  len;
-	struct bt_att_group_data data[0];
+	struct bt_att_group_data data[];
 } __packed;
 
 /* Write Request */
 #define BT_ATT_OP_WRITE_REQ			0x12
 struct bt_att_write_req {
 	uint16_t handle;
-	uint8_t  value[0];
+	uint8_t  value[];
 } __packed;
 
 /* Write Response */
@@ -193,7 +194,7 @@ struct bt_att_write_req {
 struct bt_att_prepare_write_req {
 	uint16_t handle;
 	uint16_t offset;
-	uint8_t  value[0];
+	uint8_t  value[];
 } __packed;
 
 /* Prepare Write Respond */
@@ -201,7 +202,7 @@ struct bt_att_prepare_write_req {
 struct bt_att_prepare_write_rsp {
 	uint16_t handle;
 	uint16_t offset;
-	uint8_t  value[0];
+	uint8_t  value[];
 } __packed;
 
 /* Execute Write Request */
@@ -220,14 +221,14 @@ struct bt_att_exec_write_req {
 #define BT_ATT_OP_NOTIFY			0x1b
 struct bt_att_notify {
 	uint16_t handle;
-	uint8_t  value[0];
+	uint8_t  value[];
 } __packed;
 
 /* Handle Value Indication */
 #define BT_ATT_OP_INDICATE			0x1d
 struct bt_att_indicate {
 	uint16_t handle;
-	uint8_t  value[0];
+	uint8_t  value[];
 } __packed;
 
 /* Handle Value Confirm */
@@ -239,14 +240,14 @@ struct bt_att_signature {
 
 #define BT_ATT_OP_READ_MULT_VL_REQ		0x20
 struct bt_att_read_mult_vl_req {
-	uint16_t handles[0];
+	FLEXIBLE_ARRAY_DECLARE(uint16_t, handles);
 } __packed;
 
 /* Read Multiple Response */
 #define BT_ATT_OP_READ_MULT_VL_RSP		0x21
 struct bt_att_read_mult_vl_rsp {
 	uint16_t len;
-	uint8_t  value[0];
+	uint8_t  value[];
 } __packed;
 
 /* Handle Multiple Value Notification */
@@ -254,21 +255,21 @@ struct bt_att_read_mult_vl_rsp {
 struct bt_att_notify_mult {
 	uint16_t handle;
 	uint16_t len;
-	uint8_t  value[0];
+	uint8_t  value[];
 } __packed;
 
 /* Write Command */
 #define BT_ATT_OP_WRITE_CMD			0x52
 struct bt_att_write_cmd {
 	uint16_t handle;
-	uint8_t  value[0];
+	uint8_t  value[];
 } __packed;
 
 /* Signed Write Command */
 #define BT_ATT_OP_SIGNED_WRITE_CMD		0xd2
 struct bt_att_signed_write_cmd {
 	uint16_t handle;
-	uint8_t  value[0];
+	uint8_t  value[];
 } __packed;
 
 typedef void (*bt_att_func_t)(struct bt_conn *conn, int err,

--- a/subsys/bluetooth/host/classic/avrcp_internal.h
+++ b/subsys/bluetooth/host/classic/avrcp_internal.h
@@ -99,7 +99,7 @@ struct bt_avrcp_header {
 
 struct bt_avrcp_unit_info_cmd {
 	struct bt_avrcp_header hdr;
-	uint8_t data[0];
+	uint8_t data[];
 } __packed;
 
 int bt_avrcp_init(void);

--- a/subsys/bluetooth/host/classic/l2cap_br_internal.h
+++ b/subsys/bluetooth/host/classic/l2cap_br_internal.h
@@ -34,7 +34,7 @@ struct bt_l2cap_sig_hdr {
 #define BT_L2CAP_CMD_REJECT             0x01
 struct bt_l2cap_cmd_reject {
 	uint16_t reason;
-	uint8_t  data[0];
+	uint8_t  data[];
 } __packed;
 
 struct bt_l2cap_cmd_reject_cid_data {
@@ -83,7 +83,7 @@ struct bt_l2cap_conn_rsp {
 struct bt_l2cap_conf_req {
 	uint16_t dcid;
 	uint16_t flags;
-	uint8_t  data[0];
+	uint8_t  data[];
 } __packed;
 
 #define BT_L2CAP_CONF_RSP               0x05
@@ -91,7 +91,7 @@ struct bt_l2cap_conf_rsp {
 	uint16_t scid;
 	uint16_t flags;
 	uint16_t result;
-	uint8_t  data[0];
+	uint8_t  data[];
 } __packed;
 
 /* Option type used by MTU config request data */
@@ -110,7 +110,7 @@ struct bt_l2cap_conf_rsp {
 struct bt_l2cap_conf_opt {
 	uint8_t type;
 	uint8_t len;
-	uint8_t data[0];
+	uint8_t data[];
 } __packed;
 
 struct bt_l2cap_conf_opt_mtu {
@@ -182,7 +182,7 @@ struct bt_l2cap_info_req {
 struct bt_l2cap_info_rsp {
 	uint16_t type;
 	uint16_t result;
-	uint8_t  data[0];
+	uint8_t  data[];
 } __packed;
 
 #define BR_CHAN(_ch) CONTAINER_OF(_ch, struct bt_l2cap_br_chan, chan)

--- a/subsys/bluetooth/host/l2cap_internal.h
+++ b/subsys/bluetooth/host/l2cap_internal.h
@@ -43,7 +43,7 @@ struct bt_l2cap_sig_hdr {
 #define BT_L2CAP_CMD_REJECT             0x01
 struct bt_l2cap_cmd_reject {
 	uint16_t reason;
-	uint8_t  data[0];
+	uint8_t  data[];
 } __packed;
 
 struct bt_l2cap_cmd_reject_cid_data {
@@ -122,7 +122,7 @@ struct bt_l2cap_ecred_conn_req {
 	uint16_t mtu;
 	uint16_t mps;
 	uint16_t credits;
-	uint16_t scid[0];
+	uint16_t scid[];
 } __packed;
 
 #define BT_L2CAP_ECRED_CONN_RSP         0x18
@@ -131,14 +131,14 @@ struct bt_l2cap_ecred_conn_rsp {
 	uint16_t mps;
 	uint16_t credits;
 	uint16_t result;
-	uint16_t dcid[0];
+	uint16_t dcid[];
 } __packed;
 
 #define BT_L2CAP_ECRED_RECONF_REQ       0x19
 struct bt_l2cap_ecred_reconf_req {
 	uint16_t mtu;
 	uint16_t mps;
-	uint16_t scid[0];
+	uint16_t scid[];
 } __packed;
 
 #define BT_L2CAP_RECONF_SUCCESS         0x0000

--- a/subsys/logging/frontends/log_frontend_dict_uart.c
+++ b/subsys/logging/frontends/log_frontend_dict_uart.c
@@ -23,7 +23,7 @@ BUILD_ASSERT(sizeof(struct log_frontend_uart_pkt_hdr) == sizeof(uint16_t));
 
 struct log_frontend_uart_generic_pkt {
 	struct log_frontend_uart_pkt_hdr hdr;
-	uint8_t data[0];
+	FLEXIBLE_ARRAY_DECLARE(uint8_t, data);
 } __packed;
 
 struct log_frontend_uart_dropped_pkt {
@@ -34,7 +34,7 @@ struct log_frontend_uart_dropped_pkt {
 struct log_frontend_uart_pkt {
 	struct log_frontend_uart_pkt_hdr hdr;
 	struct log_dict_output_normal_msg_hdr_t data_hdr;
-	uint8_t data[0];
+	FLEXIBLE_ARRAY_DECLARE(uint8_t, data);
 } __packed;
 
 /* Union needed to avoid warning when casting to packed structure. */

--- a/subsys/net/ip/nbr.h
+++ b/subsys/net/ip/nbr.h
@@ -68,7 +68,7 @@ struct net_nbr {
 	/** Start of the data storage. Not to be accessed directly
 	 *  (the data pointer should be used instead).
 	 */
-	uint8_t __nbr[0] __net_nbr_align;
+	uint8_t __nbr[] __net_nbr_align;
 };
 
 /* This is an array of struct net_nbr + some additional data */

--- a/subsys/shell/shell_history.c
+++ b/subsys/shell/shell_history.c
@@ -42,7 +42,7 @@ struct shell_history_item {
 	sys_dnode_t dnode;
 	uint16_t len;
 	uint16_t padding;
-	char data[0];
+	char data[];
 };
 
 void z_shell_history_mode_exit(struct shell_history *history)


### PR DESCRIPTION
As part of upcoming hardening buffer checks on Zephyr we need to sanitize the usage of flexible array. This pr properly declare flexible arrays according to C99 standard, not relying on non-portable GNU extension.

Fixes #63845