### PR TITLE
net: lib: mqtt_sn: change log messages to use correct format specifier

### DIFF
--- a/subsys/net/lib/mqtt_sn/mqtt_sn.c
+++ b/subsys/net/lib/mqtt_sn/mqtt_sn.c
@@ -184,7 +184,7 @@ static struct mqtt_sn_publish *mqtt_sn_publish_create(struct mqtt_sn_data *data)
 
 	if (data && data->data && data->size) {
 		if (data->size > sizeof(pub->pubdata)) {
-			LOG_ERR("Can't create PUB: Too much data (%" PRIu16 ")", data->size);
+			LOG_ERR("Can't create PUB: Too much data (%zu)", data->size);
 			return NULL;
 		}
 
@@ -242,7 +242,7 @@ static struct mqtt_sn_topic *mqtt_sn_topic_create(struct mqtt_sn_data *name)
 	}
 
 	if (name->size > sizeof(topic->name)) {
-		LOG_ERR("Can't create topic: name too long (%" PRIu16 ")", name->size);
+		LOG_ERR("Can't create topic: name too long (%zu)", name->size);
 		return NULL;
 	}
 


### PR DESCRIPTION
Commit aa9c9228d48 (net: mqtt-sn: Add Gateway Advertisement and Discovery process support) changed the `size` field to a `size_t`. Update the log messages to use the correct format specifier for this new field.

Fixes #81897