### PR TITLE
bluetooth: mesh: Use bt_get_name to get device name

### DIFF
--- a/subsys/bluetooth/mesh/gatt.h
+++ b/subsys/bluetooth/mesh/gatt.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define ADV_SLOW_INT                                                           \
+	.interval_min = BT_GAP_ADV_SLOW_INT_MIN,                               \
+	.interval_max = BT_GAP_ADV_SLOW_INT_MAX
+
+#define ADV_FAST_INT                                                           \
+	.interval_min = BT_GAP_ADV_FAST_INT_MIN_2,                             \
+	.interval_max = BT_GAP_ADV_FAST_INT_MAX_2
+
+#define BT_DEVICE_NAME (IS_ENABLED(CONFIG_BT_DEVICE_NAME_DYNAMIC) ? \
+			(const uint8_t *)bt_get_name() : \
+			(const uint8_t *)CONFIG_BT_DEVICE_NAME)
+#define BT_DEVICE_NAME_LEN (IS_ENABLED(CONFIG_BT_DEVICE_NAME_DYNAMIC) ? strlen(bt_get_name()) : \
+			    (sizeof(CONFIG_BT_DEVICE_NAME) - 1))

--- a/subsys/bluetooth/mesh/pb_gatt_srv.c
+++ b/subsys/bluetooth/mesh/pb_gatt_srv.c
@@ -26,6 +26,7 @@
 #include "foundation.h"
 #include "access.h"
 #include "proxy.h"
+#include "gatt.h"
 #include "proxy_msg.h"
 #include "pb_gatt_srv.h"
 

--- a/subsys/bluetooth/mesh/pb_gatt_srv.c
+++ b/subsys/bluetooth/mesh/pb_gatt_srv.c
@@ -242,13 +242,12 @@ static size_t gatt_prov_adv_create(struct bt_data prov_sd[2])
 	prov_sd_len += 1;
 
 dev_name:
-#if defined(CONFIG_BT_MESH_PB_GATT_USE_DEVICE_NAME)
-	prov_sd[prov_sd_len].type = BT_DATA_NAME_COMPLETE;
-	prov_sd[prov_sd_len].data_len = sizeof(CONFIG_BT_DEVICE_NAME) - 1;
-	prov_sd[prov_sd_len].data = CONFIG_BT_DEVICE_NAME;
-
-	prov_sd_len += 1;
-#endif
+	if (IS_ENABLED(CONFIG_BT_MESH_PB_GATT_USE_DEVICE_NAME)) {
+		prov_sd[prov_sd_len].type = BT_DATA_NAME_COMPLETE;
+		prov_sd[prov_sd_len].data_len = BT_DEVICE_NAME_LEN;
+		prov_sd[prov_sd_len].data = BT_DEVICE_NAME;
+		prov_sd_len += 1;
+	}
 
 	return prov_sd_len;
 }

--- a/subsys/bluetooth/mesh/proxy.h
+++ b/subsys/bluetooth/mesh/proxy.h
@@ -10,20 +10,6 @@
 #define ADV_OPT_USE_IDENTITY 0
 #endif
 
-#define ADV_SLOW_INT                                                           \
-	.interval_min = BT_GAP_ADV_SLOW_INT_MIN,                               \
-	.interval_max = BT_GAP_ADV_SLOW_INT_MAX
-
-#define ADV_FAST_INT                                                           \
-	.interval_min = BT_GAP_ADV_FAST_INT_MIN_2,                             \
-	.interval_max = BT_GAP_ADV_FAST_INT_MAX_2
-
-#define BT_DEVICE_NAME (IS_ENABLED(CONFIG_BT_DEVICE_NAME_DYNAMIC) ? \
-			(const uint8_t *)bt_get_name() : \
-			(const uint8_t *)CONFIG_BT_DEVICE_NAME)
-#define BT_DEVICE_NAME_LEN (IS_ENABLED(CONFIG_BT_DEVICE_NAME_DYNAMIC) ? strlen(bt_get_name()) : \
-			    (sizeof(CONFIG_BT_DEVICE_NAME) - 1))
-
 #define BT_MESH_ID_TYPE_NET	  0x00
 #define BT_MESH_ID_TYPE_NODE	  0x01
 #define BT_MESH_ID_TYPE_PRIV_NET  0x02

--- a/subsys/bluetooth/mesh/proxy.h
+++ b/subsys/bluetooth/mesh/proxy.h
@@ -18,6 +18,12 @@
 	.interval_min = BT_GAP_ADV_FAST_INT_MIN_2,                             \
 	.interval_max = BT_GAP_ADV_FAST_INT_MAX_2
 
+#define BT_DEVICE_NAME (IS_ENABLED(CONFIG_BT_DEVICE_NAME_DYNAMIC) ? \
+			(const uint8_t *)bt_get_name() : \
+			(const uint8_t *)CONFIG_BT_DEVICE_NAME)
+#define BT_DEVICE_NAME_LEN (IS_ENABLED(CONFIG_BT_DEVICE_NAME_DYNAMIC) ? strlen(bt_get_name()) : \
+			    (sizeof(CONFIG_BT_DEVICE_NAME) - 1))
+
 #define BT_MESH_ID_TYPE_NET	  0x00
 #define BT_MESH_ID_TYPE_NODE	  0x01
 #define BT_MESH_ID_TYPE_PRIV_NET  0x02

--- a/subsys/bluetooth/mesh/proxy_srv.c
+++ b/subsys/bluetooth/mesh/proxy_srv.c
@@ -28,6 +28,7 @@
 #include "foundation.h"
 #include "access.h"
 #include "proxy.h"
+#include "gatt.h"
 #include "proxy_msg.h"
 #include "crypto.h"
 

--- a/subsys/bluetooth/mesh/proxy_srv.c
+++ b/subsys/bluetooth/mesh/proxy_srv.c
@@ -482,12 +482,6 @@ static const struct bt_data net_id_ad[] = {
 	BT_DATA(BT_DATA_SVC_DATA16, proxy_svc_data, NET_ID_LEN),
 };
 
-static const struct bt_data sd[] = {
-#if defined(CONFIG_BT_MESH_PROXY_USE_DEVICE_NAME)
-	BT_DATA(BT_DATA_NAME_COMPLETE, CONFIG_BT_DEVICE_NAME, sizeof(CONFIG_BT_DEVICE_NAME) - 1),
-#endif
-};
-
 static int randomize_bt_addr(void)
 {
 	/* TODO: There appears to be no way to force an RPA/NRPA refresh. */
@@ -509,6 +503,7 @@ static int enc_id_adv(struct bt_mesh_subnet *sub, uint8_t type,
 					 type == BT_MESH_ID_TYPE_PRIV_NODE),
 		ADV_FAST_INT,
 	};
+	struct bt_data sd[1];
 	int err;
 
 	err = bt_mesh_encrypt(&sub->keys[SUBNET_KEY_TX_IDX(sub)].identity, hash, hash);
@@ -528,9 +523,17 @@ static int enc_id_adv(struct bt_mesh_subnet *sub, uint8_t type,
 	proxy_svc_data[2] = type;
 	memcpy(&proxy_svc_data[3], &hash[8], 8);
 
+	if (IS_ENABLED(CONFIG_BT_MESH_PROXY_USE_DEVICE_NAME)) {
+		sd[0].type = BT_DATA_NAME_COMPLETE;
+		sd[0].data_len = BT_DEVICE_NAME_LEN;
+		sd[0].data = BT_DEVICE_NAME;
+	}
+
 	err = bt_mesh_adv_gatt_start(
 		type == BT_MESH_ID_TYPE_PRIV_NET ? &slow_adv_param : &fast_adv_param,
-		duration, enc_id_ad, ARRAY_SIZE(enc_id_ad), sd, ARRAY_SIZE(sd));
+		duration, enc_id_ad, ARRAY_SIZE(enc_id_ad),
+		IS_ENABLED(CONFIG_BT_MESH_PROXY_USE_DEVICE_NAME) ? sd : NULL,
+		IS_ENABLED(CONFIG_BT_MESH_PROXY_USE_DEVICE_NAME) ? ARRAY_SIZE(sd) : 0);
 	if (err) {
 		LOG_WRN("Failed to advertise using type 0x%02x (err %d)", type, err);
 		return err;
@@ -606,6 +609,7 @@ static int net_id_adv(struct bt_mesh_subnet *sub, int32_t duration)
 		.options = ADV_OPT_PROXY(false),
 		ADV_SLOW_INT,
 	};
+	struct bt_data sd[1];
 	int err;
 
 	proxy_svc_data[2] = BT_MESH_ID_TYPE_NET;
@@ -614,8 +618,17 @@ static int net_id_adv(struct bt_mesh_subnet *sub, int32_t duration)
 
 	memcpy(proxy_svc_data + 3, sub->keys[SUBNET_KEY_TX_IDX(sub)].net_id, 8);
 
+	if (IS_ENABLED(CONFIG_BT_MESH_PROXY_USE_DEVICE_NAME)) {
+		sd[0].type = BT_DATA_NAME_COMPLETE;
+		sd[0].data_len = BT_DEVICE_NAME_LEN;
+		sd[0].data = BT_DEVICE_NAME;
+	}
+
 	err = bt_mesh_adv_gatt_start(&slow_adv_param, duration, net_id_ad,
-				     ARRAY_SIZE(net_id_ad), sd, ARRAY_SIZE(sd));
+				     ARRAY_SIZE(net_id_ad),
+				     IS_ENABLED(CONFIG_BT_MESH_PROXY_USE_DEVICE_NAME) ? sd : NULL,
+				     IS_ENABLED(CONFIG_BT_MESH_PROXY_USE_DEVICE_NAME) ?
+					ARRAY_SIZE(sd) : 0);
 	if (err) {
 		LOG_WRN("Failed to advertise using Network ID (err %d)", err);
 		return err;


### PR DESCRIPTION
By default if CONFIG_BT_MESH_PROXY_USE_DEVICE_NAME or CONFIG_BT_MESH_PB_GATT_USE_DEVICE_NAME is enabled, the mesh stack will add BT_DATA_NAME_COMPLETE AD Type along with the Mesh Proxy Service or Mesh Provisioning Service advertisements accordingly.

When BT_LE_ADV_OPT_USE_NAME was present and
CONFIG_BT_DEVICE_NAME_DYNAMIC is enabled, the advertised name was automatically updated by the host. This turned out to be a side-effect rather than expected behavior and after #71700 this behavior waa changed.

But customers use dynamic name feature.

This commit makes the mesh stack use bt_get_name to get the device name, which returns runtime name if CONFIG_BT_DEVICE_NAME_DYNAMIC is enabled.