### PR TITLE
kernel: sched: use arch_current_thread instead of _current

### DIFF
--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -502,7 +502,7 @@ void z_impl_k_thread_suspend(k_tid_t thread)
 	/* Special case "suspend the current thread" as it doesn't
 	 * need the async complexity below.
 	 */
-	if (thread == _current && !arch_is_in_isr() && !IS_ENABLED(CONFIG_SMP)) {
+	if (thread == arch_current_thread() && !arch_is_in_isr() && !IS_ENABLED(CONFIG_SMP)) {
 		k_spinlock_key_t key = k_spin_lock(&_sched_spinlock);
 
 		z_mark_thread_as_suspended(thread);


### PR DESCRIPTION
_current is deprecated, use arch_current_thread()
Signed-off-by: Anas Nashif <anas.nashif@intel.com>
