### PR TITLE
samples:drivers:led:led_strip:  esp32s3_devkitc uses GPIO38, not GPIO39 for RGB led.

### DIFF
--- a/samples/drivers/led/led_strip/boards/esp32s3_devkitc_procpu.overlay
+++ b/samples/drivers/led/led_strip/boards/esp32s3_devkitc_procpu.overlay
@@ -39,7 +39,7 @@ i2s_led: &i2s0 {
 &pinctrl {
 	i2s0_pinconf: i2s0_pinconf {
 		group1 {
-			pinmux = <I2S0_O_SD_GPIO39>;
+			pinmux = <I2S0_O_SD_GPIO38>;
 			output-enable;
 		};
 	};


### PR DESCRIPTION
# Fix for Issue 81893

[Issue 81893](https://github.com/zephyrproject-rtos/zephyr/issues/81893) pertains to the wrong GPIO being selected in the esp32s3_devkitc overlay for the `samples/drivers/led/led_strip` sample.

Changed
```
pinmux = <I2S0_O_SD_GPIO39>;
```
to
```
pinmux = <I2S0_O_SD_GPIO38>;
```
For links to the device documentation, take a look at the original issue provided above.