### PR TITLE
drivers:stepper: fake: fix cid issues

### DIFF
--- a/drivers/stepper/fake_stepper_controller.c
+++ b/drivers/stepper/fake_stepper_controller.c
@@ -19,28 +19,28 @@ struct fake_stepper_data {
 	int32_t actual_position;
 };
 
-DEFINE_FAKE_VALUE_FUNC(int, fake_stepper_enable, const struct device *, const bool);
+DEFINE_FAKE_VALUE_FUNC(int, fake_stepper_enable, const struct device *, bool);
 
 DEFINE_FAKE_VALUE_FUNC(int, fake_stepper_is_moving, const struct device *, bool *);
 
-DEFINE_FAKE_VALUE_FUNC(int, fake_stepper_move, const struct device *, const int32_t);
+DEFINE_FAKE_VALUE_FUNC(int, fake_stepper_move, const struct device *, int32_t);
 
-DEFINE_FAKE_VALUE_FUNC(int, fake_stepper_set_max_velocity, const struct device *, const uint32_t);
+DEFINE_FAKE_VALUE_FUNC(int, fake_stepper_set_max_velocity, const struct device *, uint32_t);
 
 DEFINE_FAKE_VALUE_FUNC(int, fake_stepper_set_micro_step_res, const struct device *,
-		       const enum stepper_micro_step_resolution);
+		       enum stepper_micro_step_resolution);
 
 DEFINE_FAKE_VALUE_FUNC(int, fake_stepper_get_micro_step_res, const struct device *,
 		       enum stepper_micro_step_resolution *);
 
-DEFINE_FAKE_VALUE_FUNC(int, fake_stepper_set_actual_position, const struct device *, const int32_t);
+DEFINE_FAKE_VALUE_FUNC(int, fake_stepper_set_actual_position, const struct device *, int32_t);
 
 DEFINE_FAKE_VALUE_FUNC(int, fake_stepper_get_actual_position, const struct device *, int32_t *);
 
-DEFINE_FAKE_VALUE_FUNC(int, fake_stepper_set_target_position, const struct device *, const int32_t);
+DEFINE_FAKE_VALUE_FUNC(int, fake_stepper_set_target_position, const struct device *, int32_t);
 
 DEFINE_FAKE_VALUE_FUNC(int, fake_stepper_enable_constant_velocity_mode, const struct device *,
-		       const enum stepper_direction, const uint32_t);
+		       enum stepper_direction, uint32_t);
 
 DEFINE_FAKE_VALUE_FUNC(int, fake_stepper_set_event_callback, const struct device *,
 		       stepper_event_callback_t, void *);

--- a/include/zephyr/drivers/stepper/stepper_fake.h
+++ b/include/zephyr/drivers/stepper/stepper_fake.h
@@ -14,30 +14,28 @@
 extern "C" {
 #endif
 
-DECLARE_FAKE_VALUE_FUNC(int, fake_stepper_enable, const struct device *, const bool);
+DECLARE_FAKE_VALUE_FUNC(int, fake_stepper_enable, const struct device *, bool);
 
-DECLARE_FAKE_VALUE_FUNC(int, fake_stepper_move, const struct device *, const int32_t);
+DECLARE_FAKE_VALUE_FUNC(int, fake_stepper_move, const struct device *, int32_t);
 
-DECLARE_FAKE_VALUE_FUNC(int, fake_stepper_set_max_velocity, const struct device *, const uint32_t);
+DECLARE_FAKE_VALUE_FUNC(int, fake_stepper_set_max_velocity, const struct device *, uint32_t);
 
 DECLARE_FAKE_VALUE_FUNC(int, fake_stepper_set_micro_step_res, const struct device *,
-			const enum stepper_micro_step_resolution);
+			enum stepper_micro_step_resolution);
 
 DECLARE_FAKE_VALUE_FUNC(int, fake_stepper_get_micro_step_res, const struct device *,
 			enum stepper_micro_step_resolution *);
 
-DECLARE_FAKE_VALUE_FUNC(int, fake_stepper_set_actual_position, const struct device *,
-			const int32_t);
+DECLARE_FAKE_VALUE_FUNC(int, fake_stepper_set_actual_position, const struct device *, int32_t);
 
 DECLARE_FAKE_VALUE_FUNC(int, fake_stepper_get_actual_position, const struct device *, int32_t *);
 
-DECLARE_FAKE_VALUE_FUNC(int, fake_stepper_set_target_position, const struct device *,
-			const int32_t);
+DECLARE_FAKE_VALUE_FUNC(int, fake_stepper_set_target_position, const struct device *, int32_t);
 
 DECLARE_FAKE_VALUE_FUNC(int, fake_stepper_is_moving, const struct device *, bool *);
 
 DECLARE_FAKE_VALUE_FUNC(int, fake_stepper_enable_constant_velocity_mode, const struct device *,
-			const enum stepper_direction, const uint32_t);
+			enum stepper_direction, uint32_t);
 
 DECLARE_FAKE_VALUE_FUNC(int, fake_stepper_set_event_callback, const struct device *,
 			stepper_event_callback_t, void *);


### PR DESCRIPTION
Fix: Write to const-qualified field. (WRITE_CONST_FIELD)

- https://github.com/zephyrproject-rtos/zephyr/issues/81915, https://github.com/zephyrproject-rtos/zephyr/issues/81920, https://github.com/zephyrproject-rtos/zephyr/issues/81922, https://github.com/zephyrproject-rtos/zephyr/issues/81924, https://github.com/zephyrproject-rtos/zephyr/issues/81932, https://github.com/zephyrproject-rtos/zephyr/issues/81940, https://github.com/zephyrproject-rtos/zephyr/issues/81941
https://github.com/zephyrproject-rtos/zephyr/issues/81946, https://github.com/zephyrproject-rtos/zephyr/issues/81947, https://github.com/zephyrproject-rtos/zephyr/issues/81959, https://github.com/zephyrproject-rtos/zephyr/issues/81961, https://github.com/zephyrproject-rtos/zephyr/issues/81970, https://github.com/zephyrproject-rtos/zephyr/issues/81973, https://github.com/zephyrproject-rtos/zephyr/issues/81977