### PR TITLE
soc: atmel: sam0: Add bossac boot mode support.

### DIFF
--- a/soc/atmel/sam0/common/bossa.c
+++ b/soc/atmel/sam0/common/bossa.c
@@ -9,6 +9,8 @@
 #include <zephyr/drivers/usb/usb_dc.h>
 #include <zephyr/init.h>
 #include <zephyr/usb/class/usb_cdc.h>
+#include <zephyr/retention/retention.h>
+#include <zephyr/retention/bootmode.h>
 
 /*
  * Magic value that causes the bootloader to stay in bootloader mode instead of
@@ -22,12 +24,35 @@
 #error Unsupported BOSSA bootloader variant
 #endif
 
+#if CONFIG_RETENTION_BOOT_MODE
+
+static FUNC_NORETURN void bossa_jump_to_bootloader(void)
+{
+	const struct device *dbl_tap_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_bossac_double_tap_magic));
+	uint32_t val = DOUBLE_TAP_MAGIC;
+
+	retention_write(dbl_tap_dev, 0, (uint8_t *)&val, sizeof(val));
+	NVIC_SystemReset();
+}
+
+#else
+
+static FUNC_NORETURN void bossa_jump_to_bootloader(void)
+{
+	uint32_t *top;
+
+	top = (uint32_t *)(DT_REG_ADDR(DT_NODELABEL(sram0)) + DT_REG_SIZE(DT_NODELABEL(sram0)));
+
+	top[-1] = DOUBLE_TAP_MAGIC;
+	NVIC_SystemReset();
+}
+
+#endif
+
 #if defined(CONFIG_BOOTLOADER_BOSSA_DEVICE_NAME)
 
 static void bossa_reset(const struct device *dev, uint32_t rate)
 {
-	uint32_t *top;
-
 	if (rate != 1200) {
 		return;
 	}
@@ -37,17 +62,12 @@ static void bossa_reset(const struct device *dev, uint32_t rate)
 	 */
 	usb_dc_detach();
 
-	top = (uint32_t *)(DT_REG_ADDR(DT_NODELABEL(sram0)) +
-			   DT_REG_SIZE(DT_NODELABEL(sram0)));
-	top[-1] = DOUBLE_TAP_MAGIC;
-
-	NVIC_SystemReset();
+	bossa_jump_to_bootloader();
 }
 
-static int bossa_init(void)
+static int bossa_init_cdc(void)
 {
-	const struct device *dev =
-		device_get_binding(CONFIG_BOOTLOADER_BOSSA_DEVICE_NAME);
+	const struct device *dev = device_get_binding(CONFIG_BOOTLOADER_BOSSA_DEVICE_NAME);
 
 	if (dev == NULL) {
 		return -ENODEV;
@@ -56,6 +76,22 @@ static int bossa_init(void)
 	return cdc_acm_dte_rate_callback_set(dev, bossa_reset);
 }
 
-SYS_INIT(bossa_init, APPLICATION, 0);
+SYS_INIT(bossa_init_cdc, APPLICATION, 0);
 
 #endif /* CONFIG_BOOTLOADER_BOSSA_DEVICE_NAME */
+
+#if CONFIG_RETENTION_BOOT_MODE
+
+static int bossa_check_boot_init(void)
+{
+	if (bootmode_check(BOOT_MODE_TYPE_BOOTLOADER) > 0) {
+		bootmode_clear();
+		bossa_jump_to_bootloader();
+	}
+
+	return 0;
+}
+
+SYS_INIT(bossa_check_boot_init, PRE_KERNEL_1, 0);
+
+#endif /* CONFIG_RETENTION_BOOT_MODE */


### PR DESCRIPTION
Support loading the boot mode from retained memory and triggering a jump to the bossac bootloader when requested.

This implemented the bare minimum to support bootloader boot mode on SAM0 devices using the BOSSAC bootloader. In particular, this was tested on a small samd21e18 based device of mine with the following added to the devicetree:

```dts
/ {
        sram@20007FFB {
                compatible = "zephyr,memory-region", "mmio-sram";
                reg = <0x20007FFB 0x5>;
                zephyr,memory-region = "RetainedMem";
                status = "okay";

                retainedmem {
                        compatible = "zephyr,retained-ram";
                        status = "okay";
                        #address-cells = <1>;
                        #size-cells = <1>;

                        retention0: retention@0 {
                                compatible = "zephyr,retention";
                                status = "okay";
                                reg = <0x0 0x1>;
                        };
                        retention1: retention@1 {
                                compatible = "zephyr,retention";
                                status = "okay";
                                reg = <0x1 0x4>;
                        };
                };
        };

        chosen {
                zephyr,boot-mode = &retention0;
		zephyr,bossac-double-tap-magic = &retention1;
        };
};

/* Reduce SRAM0 usage by 1 byte to account for non-init area */
&sram0 {
        reg = <0x20000000 0x7FFB>;
};
```

Note: The reserved 4-bytes at the end of the SRAM is used by the bootloader, and in particular, is *cleared* by the bootloader on start (see https://github.com/adafruit/uf2-samdx1/blob/master/src/main.c#L138) so we need to place our boot mode just *before* this so it's not wiped away by the bootloader.

Since we're doing this on top of the retained API *anyways*, I updated the code that needs to assign the "magic value" to use the retained API to do so and leverages the second entry. I picked a chosen value of `zephyr,bossac-double-tap-magic` but I'm definitely open to better naming ideas. If folks would rather I note do that here, I will need *some* sort of logic to determine the right memory address for where to place this. My initial version was hardcoding a `+ 5` to the SRAM calculation that exists already, but this felt like a hack.

I'm also not sure the "correct" way to document this, so please do let me know.

Thanks as always, looking forward to feedback.