### PR TITLE
drivers: stepper: Add step direction stepper common binding

### DIFF
--- a/drivers/stepper/CMakeLists.txt
+++ b/drivers/stepper/CMakeLists.txt
@@ -12,4 +12,5 @@ zephyr_library_property(ALLOW_EMPTY TRUE)
 
 zephyr_library_sources_ifdef(CONFIG_FAKE_STEPPER fake_stepper_controller.c)
 zephyr_library_sources_ifdef(CONFIG_GPIO_STEPPER gpio_stepper_controller.c)
+zephyr_library_sources_ifdef(CONFIG_STEP_DIR_STEPPER step_dir_stepper_common.c)
 zephyr_library_sources_ifdef(CONFIG_STEPPER_SHELL stepper_shell.c)

--- a/drivers/stepper/Kconfig
+++ b/drivers/stepper/Kconfig
@@ -24,10 +24,17 @@ config STEPPER_SHELL
 	help
 	  Enable stepper shell for testing.
 
+config STEP_DIR_STEPPER
+	bool
+	help
+	  Enable library used for step direction stepper drivers.
+
 comment "Stepper Drivers"
 
-rsource "adi_tmc/Kconfig"
+# zephyr-keep-sorted-start
 rsource "Kconfig.fake"
 rsource "Kconfig.gpio"
+rsource "adi_tmc/Kconfig"
+# zephyr-keep-sorted-stop
 
 endif

--- a/drivers/stepper/adi_tmc/CMakeLists.txt
+++ b/drivers/stepper/adi_tmc/CMakeLists.txt
@@ -5,4 +5,5 @@ zephyr_library()
 zephyr_library_property(ALLOW_EMPTY TRUE)
 
 zephyr_library_sources_ifdef(CONFIG_STEPPER_ADI_TMC_SPI adi_tmc_spi.c)
+zephyr_library_sources_ifdef(CONFIG_STEPPER_ADI_TMC2209 adi_tmc22xx_stepper_controller.c)
 zephyr_library_sources_ifdef(CONFIG_STEPPER_ADI_TMC5041 adi_tmc5041_stepper_controller.c)

--- a/drivers/stepper/adi_tmc/Kconfig
+++ b/drivers/stepper/adi_tmc/Kconfig
@@ -26,30 +26,7 @@ config STEPPER_ADI_TMC_SPI
 
 comment "Trinamic Stepper Drivers"
 
-config STEPPER_ADI_TMC5041
-	bool "Activate trinamic tmc5041 stepper driver"
-	depends on DT_HAS_ADI_TMC5041_ENABLED && STEPPER_ADI_TMC
-	select STEPPER_ADI_TMC_SPI
-	default y
-	help
-	  Stepper driver for TMC5041.
-
-config STEPPER_ADI_TMC5041_RAMPSTAT_POLL
-	bool "TMC5041 poll ramp status"
-	depends on STEPPER_ADI_TMC5041
-	default y
-	help
-	  When enabled, the ramp status will be polled on TMC5041, to check for events:
-	  - TMC5041_POS_REACHED_EVENT
-	  - TMC5041_STOP_SG_EVENT
-	  - TMC5041_STOP_LEFT_EVENT
-	  - TMC5041_STOP_RIGHT_EVENT
-
-config STEPPER_ADI_TMC5041_RAMPSTAT_POLL_INTERVAL_IN_MSEC
-	int "TMC5041 poll ramp status interval in ms"
-	depends on STEPPER_ADI_TMC5041_RAMPSTAT_POLL
-	default 100
-	help
-	  The interval in ms to poll the ramp status on TMC5041.
+rsource "Kconfig.tmc22xx"
+rsource "Kconfig.tmc5041"
 
 endif # STEPPER_ADI_TMC

--- a/drivers/stepper/adi_tmc/Kconfig.tmc22xx
+++ b/drivers/stepper/adi_tmc/Kconfig.tmc22xx
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 Fabian Blatz <fabianblatz@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+config STEPPER_ADI_TMC2209
+	bool "Activate trinamic tmc2209 stepper driver"
+	depends on DT_HAS_ADI_TMC2209_ENABLED
+	select STEP_DIR_STEPPER
+	default y
+	help
+	  Stepper driver for TMC2209.

--- a/drivers/stepper/adi_tmc/Kconfig.tmc5041
+++ b/drivers/stepper/adi_tmc/Kconfig.tmc5041
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 Fabian Blatz <fabianblatz@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+config STEPPER_ADI_TMC5041
+	bool "Activate trinamic tmc5041 stepper driver"
+	depends on DT_HAS_ADI_TMC5041_ENABLED && STEPPER_ADI_TMC
+	select STEPPER_ADI_TMC_SPI
+	default y
+	help
+	  Stepper driver for TMC5041.
+
+config STEPPER_ADI_TMC5041_RAMPSTAT_POLL
+	bool "TMC5041 poll ramp status"
+	depends on STEPPER_ADI_TMC5041
+	default y
+	help
+	  When enabled, the ramp status will be polled on TMC5041, to check for events:
+	  - TMC5041_POS_REACHED_EVENT
+	  - TMC5041_STOP_SG_EVENT
+	  - TMC5041_STOP_LEFT_EVENT
+	  - TMC5041_STOP_RIGHT_EVENT
+
+config STEPPER_ADI_TMC5041_RAMPSTAT_POLL_INTERVAL_IN_MSEC
+	int "TMC5041 poll ramp status interval in ms"
+	depends on STEPPER_ADI_TMC5041_RAMPSTAT_POLL
+	default 100
+	help
+	  The interval in ms to poll the ramp status on TMC5041.

--- a/drivers/stepper/adi_tmc/adi_tmc22xx_stepper_controller.c
+++ b/drivers/stepper/adi_tmc/adi_tmc22xx_stepper_controller.c
@@ -1,0 +1,196 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Fabian Blatz <fabianblatz@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "../step_dir_stepper_common.h"
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(tmc22xx, CONFIG_STEPPER_LOG_LEVEL);
+
+#define MSX_PIN_COUNT       2
+#define MSX_PIN_STATE_COUNT 4
+
+struct tmc22xx_config {
+	struct step_dir_stepper_common_config common;
+	const struct gpio_dt_spec enable_pin;
+	const struct gpio_dt_spec *msx_pins;
+	enum stepper_micro_step_resolution *msx_resolutions;
+};
+
+struct tmc22xx_data {
+	struct step_dir_stepper_common_data common;
+	enum stepper_micro_step_resolution resolution;
+};
+
+STEP_DIR_STEPPER_STRUCT_CHECK(struct tmc22xx_config, struct tmc22xx_data);
+
+static int tmc22xx_stepper_enable(const struct device *dev, const bool enable)
+{
+	const struct tmc22xx_config *config = dev->config;
+
+	LOG_DBG("Stepper motor controller %s %s", dev->name, enable ? "enabled" : "disabled");
+	if (enable) {
+		return gpio_pin_set_dt(&config->enable_pin, 1);
+	} else {
+		return gpio_pin_set_dt(&config->enable_pin, 0);
+	}
+}
+
+static int tmc22xx_stepper_set_micro_step_res(const struct device *dev,
+					      enum stepper_micro_step_resolution micro_step_res)
+{
+	struct tmc22xx_data *data = dev->data;
+	const struct tmc22xx_config *config = dev->config;
+	int ret;
+
+	if (!config->msx_pins) {
+		LOG_ERR("Microstep resolution pins are not configured");
+		return -ENODEV;
+	}
+
+	for (uint8_t i = 0; i < MSX_PIN_STATE_COUNT; i++) {
+		if (micro_step_res != config->msx_resolutions[i]) {
+			continue;
+		}
+
+		ret = gpio_pin_set_dt(&config->msx_pins[0], i & 0x01);
+		if (ret < 0) {
+			LOG_ERR("Failed to set MS1 pin: %d", ret);
+			return ret;
+		}
+
+		ret = gpio_pin_set_dt(&config->msx_pins[1], (i & 0x02) >> 1);
+		if (ret < 0) {
+			LOG_ERR("Failed to set MS2 pin: %d", ret);
+			return ret;
+		}
+
+		data->resolution = micro_step_res;
+		return 0;
+	}
+
+	LOG_ERR("Unsupported microstep resolution: %d", micro_step_res);
+	return -EINVAL;
+}
+
+static int tmc22xx_stepper_get_micro_step_res(const struct device *dev,
+					      enum stepper_micro_step_resolution *micro_step_res)
+{
+	struct tmc22xx_data *data = dev->data;
+
+	*micro_step_res = data->resolution;
+	return 0;
+}
+
+static int tmc22xx_stepper_configure_msx_pins(const struct device *dev)
+{
+	const struct tmc22xx_config *config = dev->config;
+	int ret;
+
+	for (uint8_t i = 0; i < MSX_PIN_COUNT; i++) {
+		if (!gpio_is_ready_dt(&config->msx_pins[i])) {
+			LOG_ERR("MSX pin %u are not ready", i);
+			return -ENODEV;
+		}
+
+		ret = gpio_pin_configure_dt(&config->msx_pins[i], GPIO_OUTPUT);
+		if (ret < 0) {
+			LOG_ERR("Failed to configure msx pin %u", i);
+			return ret;
+		}
+	}
+	return 0;
+}
+
+static int tmc22xx_stepper_init(const struct device *dev)
+{
+	const struct tmc22xx_config *config = dev->config;
+	struct tmc22xx_data *data = dev->data;
+	int ret;
+
+	if (!gpio_is_ready_dt(&config->enable_pin)) {
+		LOG_ERR("GPIO pins are not ready");
+		return -ENODEV;
+	}
+
+	ret = gpio_pin_configure_dt(&config->enable_pin, GPIO_OUTPUT);
+	if (ret < 0) {
+		LOG_ERR("Failed to configure enable pin: %d", ret);
+		return ret;
+	}
+
+	if (config->msx_pins) {
+		ret = tmc22xx_stepper_configure_msx_pins(dev);
+		if (ret < 0) {
+			LOG_ERR("Failed to configure MSX pins: %d", ret);
+			return ret;
+		}
+
+		ret = tmc22xx_stepper_set_micro_step_res(dev, data->resolution);
+		if (ret < 0) {
+			LOG_ERR("Failed to set microstep resolution: %d", ret);
+			return ret;
+		}
+	}
+
+	ret = step_dir_stepper_common_init(dev);
+	if (ret < 0) {
+		LOG_ERR("Failed to init step dir common stepper: %d", ret);
+		return ret;
+	}
+
+	return 0;
+}
+
+static DEVICE_API(stepper, tmc22xx_stepper_api) = {
+	.enable = tmc22xx_stepper_enable,
+	.move_by = step_dir_stepper_common_move_by,
+	.is_moving = step_dir_stepper_common_is_moving,
+	.set_reference_position = step_dir_stepper_common_set_reference_position,
+	.get_actual_position = step_dir_stepper_common_get_actual_position,
+	.move_to = step_dir_stepper_common_move_to,
+	.set_max_velocity = step_dir_stepper_common_set_max_velocity,
+	.run = step_dir_stepper_common_run,
+	.set_event_callback = step_dir_stepper_common_set_event_callback,
+	.set_micro_step_res = tmc22xx_stepper_set_micro_step_res,
+	.get_micro_step_res = tmc22xx_stepper_get_micro_step_res,
+};
+
+#define TMC22XX_STEPPER_DEFINE(inst, msx_table)                                                    \
+	IF_ENABLED(DT_INST_NODE_HAS_PROP(inst, msx_gpios), (                                       \
+	static const struct gpio_dt_spec tmc22xx_stepper_msx_pins_##inst[] = {                     \
+		DT_INST_FOREACH_PROP_ELEM_SEP(                                                     \
+			inst, msx_gpios, GPIO_DT_SPEC_GET_BY_IDX, (,)                              \
+		),                                                                                 \
+	};                                                                                         \
+	BUILD_ASSERT(                                                                              \
+		ARRAY_SIZE(tmc22xx_stepper_msx_pins_##inst) == MSX_PIN_COUNT,                      \
+		"Two microstep config pins needed");                                               \
+	))                                                                                         \
+                                                                                                   \
+	static const struct tmc22xx_config tmc22xx_config_##inst = {                               \
+		.common = STEP_DIR_STEPPER_DT_INST_COMMON_CONFIG_INIT(inst),                       \
+		.enable_pin = GPIO_DT_SPEC_INST_GET(inst, enable_gpios),                           \
+		.msx_pins = DT_INST_NODE_HAS_PROP(inst, msx_gpios)                                 \
+				    ? tmc22xx_stepper_msx_pins_##inst                              \
+				    : NULL,                                                        \
+		.msx_resolutions = msx_table,                                                      \
+	};                                                                                         \
+	static struct tmc22xx_data tmc22xx_data_##inst = {                                         \
+		.common = STEP_DIR_STEPPER_DT_INST_COMMON_DATA_INIT(inst),                         \
+		.resolution = DT_INST_PROP(inst, micro_step_res),                                  \
+	};                                                                                         \
+	DEVICE_DT_INST_DEFINE(inst, tmc22xx_stepper_init, NULL, &tmc22xx_data_##inst,              \
+			      &tmc22xx_config_##inst, POST_KERNEL, CONFIG_STEPPER_INIT_PRIORITY,   \
+			      &tmc22xx_stepper_api);
+
+#define DT_DRV_COMPAT adi_tmc2209
+static enum stepper_micro_step_resolution tmc2209_msx_resolutions[MSX_PIN_STATE_COUNT] = {
+	STEPPER_MICRO_STEP_8,
+	STEPPER_MICRO_STEP_32,
+	STEPPER_MICRO_STEP_64,
+	STEPPER_MICRO_STEP_16,
+};
+DT_INST_FOREACH_STATUS_OKAY_VARGS(TMC22XX_STEPPER_DEFINE, tmc2209_msx_resolutions)
+#undef DT_DRV_COMPAT

--- a/drivers/stepper/step_dir_stepper_common.c
+++ b/drivers/stepper/step_dir_stepper_common.c
@@ -241,7 +241,7 @@ int step_dir_stepper_common_run(const struct device *dev, const enum stepper_dir
 	K_SPINLOCK(&data->lock) {
 		data->run_mode = STEPPER_RUN_MODE_VELOCITY;
 		data->direction = direction;
-		if (value != 0) {
+		if (velocity != 0) {
 			data->delay_in_us = USEC_PER_SEC / velocity;
 			(void)k_work_reschedule(&data->stepper_dwork, K_NO_WAIT);
 		} else {

--- a/drivers/stepper/step_dir_stepper_common.c
+++ b/drivers/stepper/step_dir_stepper_common.c
@@ -1,0 +1,263 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Fabian Blatz <fabianblatz@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "step_dir_stepper_common.h"
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(step_dir_stepper, CONFIG_STEPPER_LOG_LEVEL);
+
+static inline int step_dir_stepper_perform_step(const struct device *dev)
+{
+	const struct step_dir_stepper_common_config *config = dev->config;
+	struct step_dir_stepper_common_data *data = dev->data;
+	int ret;
+
+	switch (data->direction) {
+	case STEPPER_DIRECTION_POSITIVE:
+		ret = gpio_pin_set_dt(&config->dir_pin, 1);
+		break;
+	case STEPPER_DIRECTION_NEGATIVE:
+		ret = gpio_pin_set_dt(&config->dir_pin, 0);
+		break;
+	default:
+		LOG_ERR("Unsupported direction: %d", data->direction);
+		return -ENOTSUP;
+	}
+	if (ret < 0) {
+		LOG_ERR("Failed to set direction: %d", ret);
+		return ret;
+	}
+
+	ret = gpio_pin_toggle_dt(&config->step_pin);
+	if (ret < 0) {
+		LOG_ERR("Failed to toggle step pin: %d", ret);
+		return ret;
+	}
+
+	if (!config->dual_edge) {
+		ret = gpio_pin_toggle_dt(&config->step_pin);
+		if (ret < 0) {
+			LOG_ERR("Failed to toggle step pin: %d", ret);
+			return ret;
+		}
+	}
+
+	return 0;
+}
+
+static void update_remaining_steps(struct step_dir_stepper_common_data *data)
+{
+	if (data->step_count > 0) {
+		data->step_count--;
+		(void)k_work_reschedule(&data->stepper_dwork, K_USEC(data->delay_in_us));
+	} else if (data->step_count < 0) {
+		data->step_count++;
+		(void)k_work_reschedule(&data->stepper_dwork, K_USEC(data->delay_in_us));
+	} else {
+		if (!data->callback) {
+			LOG_WRN_ONCE("No callback set");
+			return;
+		}
+		data->callback(data->dev, STEPPER_EVENT_STEPS_COMPLETED, data->event_cb_user_data);
+	}
+}
+
+static void update_direction_from_step_count(const struct device *dev)
+{
+	struct step_dir_stepper_common_data *data = dev->data;
+
+	if (data->step_count > 0) {
+		data->direction = STEPPER_DIRECTION_POSITIVE;
+	} else if (data->step_count < 0) {
+		data->direction = STEPPER_DIRECTION_NEGATIVE;
+	} else {
+		LOG_ERR("Step count is zero");
+	}
+}
+
+static void position_mode_task(const struct device *dev)
+{
+	struct step_dir_stepper_common_data *data = dev->data;
+
+	if (data->step_count) {
+		(void)step_dir_stepper_perform_step(dev);
+	}
+	update_remaining_steps(dev->data);
+}
+
+static void velocity_mode_task(const struct device *dev)
+{
+	struct step_dir_stepper_common_data *data = dev->data;
+
+	(void)step_dir_stepper_perform_step(dev);
+	(void)k_work_reschedule(&data->stepper_dwork, K_USEC(data->delay_in_us));
+}
+
+static void stepper_work_step_handler(struct k_work *work)
+{
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
+	struct step_dir_stepper_common_data *data =
+		CONTAINER_OF(dwork, struct step_dir_stepper_common_data, stepper_dwork);
+
+	K_SPINLOCK(&data->lock) {
+		switch (data->run_mode) {
+		case STEPPER_RUN_MODE_POSITION:
+			position_mode_task(data->dev);
+			break;
+		case STEPPER_RUN_MODE_VELOCITY:
+			velocity_mode_task(data->dev);
+			break;
+		default:
+			LOG_WRN("Unsupported run mode: %d", data->run_mode);
+			break;
+		}
+	}
+}
+
+int step_dir_stepper_common_init(const struct device *dev)
+{
+	const struct step_dir_stepper_common_config *config = dev->config;
+	struct step_dir_stepper_common_data *data = dev->data;
+	int ret;
+
+	if (!gpio_is_ready_dt(&config->step_pin) || !gpio_is_ready_dt(&config->dir_pin)) {
+		LOG_ERR("GPIO pins are not ready");
+		return -ENODEV;
+	}
+
+	ret = gpio_pin_configure_dt(&config->step_pin, GPIO_OUTPUT);
+	if (ret < 0) {
+		LOG_ERR("Failed to configure step pin: %d", ret);
+		return ret;
+	}
+
+	ret = gpio_pin_configure_dt(&config->dir_pin, GPIO_OUTPUT);
+	if (ret < 0) {
+		LOG_ERR("Failed to configure dir pin: %d", ret);
+		return ret;
+	}
+
+	k_work_init_delayable(&data->stepper_dwork, stepper_work_step_handler);
+
+	return 0;
+}
+
+int step_dir_stepper_common_move_by(const struct device *dev, const int32_t micro_steps)
+{
+	struct step_dir_stepper_common_data *data = dev->data;
+
+	if (data->delay_in_us == 0) {
+		LOG_ERR("Velocity not set or invalid velocity set");
+		return -EINVAL;
+	}
+
+	K_SPINLOCK(&data->lock) {
+		data->run_mode = STEPPER_RUN_MODE_POSITION;
+		data->step_count = micro_steps;
+		update_direction_from_step_count(dev);
+		(void)k_work_reschedule(&data->stepper_dwork, K_NO_WAIT);
+	}
+
+	return 0;
+}
+
+int step_dir_stepper_common_set_max_velocity(const struct device *dev, const uint32_t velocity)
+{
+	struct step_dir_stepper_common_data *data = dev->data;
+
+	if (velocity == 0) {
+		LOG_ERR("Velocity cannot be zero");
+		return -EINVAL;
+	}
+
+	if (velocity > USEC_PER_SEC) {
+		LOG_ERR("Velocity cannot be greater than %d micro steps per second", USEC_PER_SEC);
+		return -EINVAL;
+	}
+
+	K_SPINLOCK(&data->lock) {
+		data->delay_in_us = USEC_PER_SEC / velocity;
+	}
+
+	return 0;
+}
+
+int step_dir_stepper_common_set_reference_position(const struct device *dev, const int32_t value)
+{
+	struct step_dir_stepper_common_data *data = dev->data;
+
+	K_SPINLOCK(&data->lock) {
+		data->actual_position = value;
+	}
+
+	return 0;
+}
+
+int step_dir_stepper_common_get_actual_position(const struct device *dev, int32_t *value)
+{
+	struct step_dir_stepper_common_data *data = dev->data;
+
+	K_SPINLOCK(&data->lock) {
+		*value = data->actual_position;
+	}
+
+	return 0;
+}
+
+int step_dir_stepper_common_move_to(const struct device *dev, const int32_t value)
+{
+	struct step_dir_stepper_common_data *data = dev->data;
+
+	if (data->delay_in_us == 0) {
+		LOG_ERR("Velocity not set or invalid velocity set");
+		return -EINVAL;
+	}
+
+	K_SPINLOCK(&data->lock) {
+		data->run_mode = STEPPER_RUN_MODE_POSITION;
+		data->step_count = value - data->actual_position;
+		update_direction_from_step_count(dev);
+		(void)k_work_reschedule(&data->stepper_dwork, K_NO_WAIT);
+	}
+
+	return 0;
+}
+
+int step_dir_stepper_common_is_moving(const struct device *dev, bool *is_moving)
+{
+	struct step_dir_stepper_common_data *data = dev->data;
+
+	*is_moving = k_work_delayable_is_pending(&data->stepper_dwork);
+	return 0;
+}
+
+int step_dir_stepper_common_run(const struct device *dev, const enum stepper_direction direction,
+				const uint32_t velocity)
+{
+	struct step_dir_stepper_common_data *data = dev->data;
+
+	K_SPINLOCK(&data->lock) {
+		data->run_mode = STEPPER_RUN_MODE_VELOCITY;
+		data->direction = direction;
+		if (value != 0) {
+			data->delay_in_us = USEC_PER_SEC / velocity;
+			(void)k_work_reschedule(&data->stepper_dwork, K_NO_WAIT);
+		} else {
+			(void)k_work_cancel_delayable(&data->stepper_dwork);
+		}
+	}
+
+	return 0;
+}
+
+int step_dir_stepper_common_set_event_callback(const struct device *dev,
+					       stepper_event_callback_t callback, void *user_data)
+{
+	struct step_dir_stepper_common_data *data = dev->data;
+
+	data->callback = callback;
+	data->event_cb_user_data = user_data;
+	return 0;
+}

--- a/drivers/stepper/step_dir_stepper_common.h
+++ b/drivers/stepper/step_dir_stepper_common.h
@@ -1,0 +1,191 @@
+/*
+ * Copyright 2024 Fabian Blatz <fabianblatz@gmail.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_DRIVER_STEPPER_STEP_DIR_STEPPER_COMMON_H_
+#define ZEPHYR_DRIVER_STEPPER_STEP_DIR_STEPPER_COMMON_H_
+
+/**
+ * @brief Stepper Driver APIs
+ * @defgroup step_dir_stepper Stepper Driver APIs
+ * @ingroup io_interfaces
+ * @{
+ */
+
+#include <zephyr/device.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/drivers/stepper.h>
+
+/**
+ * @brief Common step direction stepper config.
+ *
+ * This structure **must** be placed first in the driver's config structure.
+ */
+struct step_dir_stepper_common_config {
+	const struct gpio_dt_spec step_pin;
+	const struct gpio_dt_spec dir_pin;
+	bool dual_edge;
+};
+
+/**
+ * @brief Initialize common step direction stepper config from devicetree instance.
+ *
+ * @param node_id The devicetree node identifier.
+ */
+#define STEP_DIR_STEPPER_DT_COMMON_CONFIG_INIT(node_id)                                            \
+	{                                                                                          \
+		.step_pin = GPIO_DT_SPEC_GET(node_id, step_gpios),                                 \
+		.dir_pin = GPIO_DT_SPEC_GET(node_id, direction_gpios),                             \
+		.dual_edge = DT_PROP_OR(node_id, dual_edge_step, false),                           \
+	}
+
+/**
+ * @brief Initialize common step direction stepper config from devicetree instance.
+ * @param inst Instance.
+ */
+#define STEP_DIR_STEPPER_DT_INST_COMMON_CONFIG_INIT(inst)                                          \
+	STEP_DIR_STEPPER_DT_COMMON_CONFIG_INIT(DT_DRV_INST(inst))
+
+/**
+ * @brief Common step direction stepper data.
+ *
+ * This structure **must** be placed first in the driver's data structure.
+ */
+struct step_dir_stepper_common_data {
+	const struct device *dev;
+	struct k_spinlock lock;
+	enum stepper_direction direction;
+	enum stepper_run_mode run_mode;
+	struct k_work_delayable stepper_dwork;
+	int32_t actual_position;
+	uint32_t delay_in_us;
+	int32_t step_count;
+	stepper_event_callback_t callback;
+	void *event_cb_user_data;
+};
+
+/**
+ * @brief Initialize common step direction stepper data from devicetree instance.
+ *
+ * @param node_id The devicetree node identifier.
+ */
+#define STEP_DIR_STEPPER_DT_COMMON_DATA_INIT(node_id)                                              \
+	{                                                                                          \
+		.dev = DEVICE_DT_GET(node_id),                                                     \
+	}
+
+/**
+ * @brief Initialize common step direction stepper data from devicetree instance.
+ * @param inst Instance.
+ */
+#define STEP_DIR_STEPPER_DT_INST_COMMON_DATA_INIT(inst)                                            \
+	STEP_DIR_STEPPER_DT_COMMON_DATA_INIT(DT_DRV_INST(inst))
+
+/**
+ * @brief Validate the offset of the common data structures.
+ *
+ * @param config Name of the config structure.
+ * @param data Name of the data structure.
+ */
+#define STEP_DIR_STEPPER_STRUCT_CHECK(config, data)                                                \
+	BUILD_ASSERT(offsetof(config, common) == 0,                                                \
+		     "struct step_dir_stepper_common_config must be placed first");                \
+	BUILD_ASSERT(offsetof(data, common) == 0,                                                  \
+		     "struct step_dir_stepper_common_data must be placed first");
+
+/**
+ * @brief Common function to initialize a step direction stepper device at init time.
+ *
+ * This function must be called at the end of the device init function.
+ *
+ * @param dev Step direction stepper device instance.
+ *
+ * @retval 0 If initialized successfully.
+ * @retval -errno Negative errno in case of failure.
+ */
+int step_dir_stepper_common_init(const struct device *dev);
+
+/**
+ * @brief Move the stepper motor by a given number of micro_steps.
+ *
+ * @param dev Pointer to the device structure.
+ * @param micro_steps Number of micro_steps to move. Can be positive or negative.
+ * @return 0 on success, or a negative error code on failure.
+ */
+int step_dir_stepper_common_move_by(const struct device *dev, const int32_t micro_steps);
+
+/**
+ * @brief Set the maximum velocity in micro_steps per second.
+ *
+ * @param dev Pointer to the device structure.
+ * @param velocity Maximum velocity in micro_steps per second.
+ * @return 0 on success, or a negative error code on failure.
+ */
+int step_dir_stepper_common_set_max_velocity(const struct device *dev, const uint32_t velocity);
+
+/**
+ * @brief Set the reference position of the stepper motor.
+ *
+ * @param dev Pointer to the device structure.
+ * @param value The reference position value to set.
+ * @return 0 on success, or a negative error code on failure.
+ */
+int step_dir_stepper_common_set_reference_position(const struct device *dev, const int32_t value);
+
+/**
+ * @brief Get the actual (reference) position of the stepper motor.
+ *
+ * @param dev Pointer to the device structure.
+ * @param value Pointer to a variable where the position value will be stored.
+ * @return 0 on success, or a negative error code on failure.
+ */
+int step_dir_stepper_common_get_actual_position(const struct device *dev, int32_t *value);
+
+/**
+ * @brief Set the absolute target position of the stepper motor.
+ *
+ * @param dev Pointer to the device structure.
+ * @param value The target position to set.
+ * @return 0 on success, or a negative error code on failure.
+ */
+int step_dir_stepper_common_move_to(const struct device *dev, const int32_t value);
+
+/**
+ * @brief Check if the stepper motor is still moving.
+ *
+ * @param dev Pointer to the device structure.
+ * @param is_moving Pointer to a boolean where the movement status will be stored.
+ * @return 0 on success, or a negative error code on failure.
+ */
+int step_dir_stepper_common_is_moving(const struct device *dev, bool *is_moving);
+
+/**
+ * @brief Run the stepper with a given velocity in a given direction.
+ *
+ * @param dev Pointer to the device structure.
+ * @param direction The direction of movement (positive or negative).
+ * @param velocity The velocity in micro_steps per second.
+ * @return 0 on success, or a negative error code on failure.
+ */
+int step_dir_stepper_common_run(const struct device *dev, const enum stepper_direction direction,
+				const uint32_t velocity);
+
+/**
+ * @brief Set a callback function for stepper motor events.
+ *
+ * This function sets a user-defined callback that will be invoked when a stepper motor event
+ * occurs.
+ *
+ * @param dev Pointer to the device structure.
+ * @param callback The callback function to set.
+ * @param user_data Pointer to user-defined data that will be passed to the callback.
+ * @return 0 on success, or a negative error code on failure.
+ */
+int step_dir_stepper_common_set_event_callback(const struct device *dev,
+					       stepper_event_callback_t callback, void *user_data);
+
+/** @} */
+
+#endif /* ZEPHYR_DRIVER_STEPPER_STEP_DIR_STEPPER_COMMON_H_ */

--- a/dts/bindings/stepper/adi/adi,tmc2209.yaml
+++ b/dts/bindings/stepper/adi/adi,tmc2209.yaml
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 Fabian Blatz <fabianblatz@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  Analog Devices TMC2209 stepper motor driver.
+
+  Example:
+  tmc2209: tmc2209 {
+      compatible = "adi,tmc2209";
+      enable-gpios = <&gpio0 0 GPIO_ACTIVE_HIGH>;
+      msx-gpios = <&gpio0 1 GPIO_ACTIVE_HIGH>,
+                  <&gpio0 2 GPIO_ACTIVE_HIGH>;
+      step-gpios = <&gpio0 3 GPIO_ACTIVE_HIGH>;
+      direction-gpios = <&gpio0 4 GPIO_ACTIVE_HIGH>;
+      dual-edge-step;
+  }
+
+compatible: "adi,tmc2209"
+
+include:
+  - name: stepper-controller.yaml
+    property-allowlist:
+      - micro-step-res
+      - step-gpios
+      - direction-gpios
+
+properties:
+  enable-gpios:
+    type: phandle-array
+    description: |
+      GPIO pins used to control the enable signal of the motor driver.
+
+  msx-gpios:
+    type: phandle-array
+    description: |
+      An array of GPIO pins for configuring the microstep resolution of the driver.
+      The pins should be listed in the following order:
+      - MS1
+      - MS2
+
+  dual-edge-step:
+    type: boolean
+    description: |
+      If present, the stepper motor controller supports dual edge step signals.
+      This means that the step signal can be toggled on both the rising and falling edge.

--- a/dts/bindings/stepper/stepper-controller.yaml
+++ b/dts/bindings/stepper/stepper-controller.yaml
@@ -24,3 +24,14 @@ properties:
       - 256
     description: |
       micro-step resolution to be set while initializing the device driver.
+
+  step-gpios:
+    type: phandle-array
+    description: |
+      The GPIO pins used to send step signals to the stepper motor.
+
+  direction-gpios:
+    type: phandle-array
+    description: |
+      The GPIO pins used to send direction signals to the stepper motor.
+      Pin will be driven high for forward direction and low for reverse direction.

--- a/tests/drivers/build_all/stepper/gpio.dtsi
+++ b/tests/drivers/build_all/stepper/gpio.dtsi
@@ -12,3 +12,14 @@ test_gpio_stepper: test_gpio_stepper {
 		<&test_gpio 0 0>,
 		<&test_gpio 0 0>;
 };
+
+test_tmc2209: tmc2209_motor {
+	compatible = "adi,tmc2209";
+	status = "okay";
+	micro-step-res = <1>;
+	msx-gpios = <&test_gpio 0 0>,
+		    <&test_gpio 0 0>;
+	enable-gpios = <&test_gpio 0 0>;
+	step-gpios = <&test_gpio 0 0>;
+	direction-gpios = <&test_gpio 0 0>;
+};


### PR DESCRIPTION
Adds a step direction binding that can be used with any stepper that implements said control interface to cut down on boilerplate code.

Will also add a driver that makes use of this :^)

EDIT:// Added the TMC2209 driver using the step dir interface. Usage of the one wire interface and DIAG pin will be added in a later commit. This just serves as a example usage of the common step dir interface.