### PR TITLE
ci: compliance: Exclude ClangFormat

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -79,7 +79,7 @@ jobs:
         git log  --pretty=oneline | head -n 10
         # Increase rename limit to allow for large PRs
         git config diff.renameLimit 10000
-        ./scripts/ci/check_compliance.py --annotate -e KconfigBasic \
+        ./scripts/ci/check_compliance.py --annotate -e KconfigBasic -e ClangFormat \
         -c origin/${BASE_REF}..
 
     - name: upload-results


### PR DESCRIPTION
Stop running ClangFormat in CI as it confuses (first time) contributors more than it helps.