### PR TITLE
llext: fix minor Coverity issue #434586

### DIFF
--- a/subsys/llext/llext_link.c
+++ b/subsys/llext/llext_link.c
@@ -168,7 +168,7 @@ static void llext_link_plt(struct llext_loader *ldr, struct llext *ext, elf_shdr
 			ret = llext_read(ldr, &rela, sizeof(rela));
 		}
 
-		if (ret < 0) {
+		if (ret != 0) {
 			LOG_ERR("PLT: failed to read RELA #%u, trying to continue", i);
 			continue;
 		}


### PR DESCRIPTION
The check combination of "is zero" and then "less than zero" leaves open the theoretical possibility of  `llext_seek()` returning a positive value, which would cause the function to continue on with an uinitialized `rela`.

Checking for "not zero" has the same effect and covers all situations.

Fixes #81964.