### PR TITLE
tests: benchmarks: optimize filters and use platform_key.

### DIFF
--- a/tests/benchmarks/app_kernel/testcase.yaml
+++ b/tests/benchmarks/app_kernel/testcase.yaml
@@ -1,4 +1,6 @@
 common:
+  platform_key:
+    - arch
   tags:
     - benchmark
     - kernel

--- a/tests/benchmarks/data_structure_perf/dlist_perf/testcase.yaml
+++ b/tests/benchmarks/data_structure_perf/dlist_perf/testcase.yaml
@@ -1,5 +1,7 @@
 tests:
   benchmark.data_structure_perf.dlist:
+    platform_key:
+      - arch
     tags:
       - benchmark
       - dlist

--- a/tests/benchmarks/data_structure_perf/rbtree_perf/testcase.yaml
+++ b/tests/benchmarks/data_structure_perf/rbtree_perf/testcase.yaml
@@ -1,5 +1,7 @@
 tests:
   benchmark.data_structure_perf.rbtree:
+    platform_key:
+      - arch
     tags:
       - benchmark
       - rbtree

--- a/tests/benchmarks/latency_measure/testcase.yaml
+++ b/tests/benchmarks/latency_measure/testcase.yaml
@@ -1,4 +1,6 @@
 common:
+  platform_key:
+    - arch
   tags:
     - kernel
     - benchmark

--- a/tests/benchmarks/sched/testcase.yaml
+++ b/tests/benchmarks/sched/testcase.yaml
@@ -1,5 +1,7 @@
 tests:
   benchmark.kernel.scheduler:
+    platform_key:
+      - arch
     tags:
       - benchmark
       - kernel

--- a/tests/benchmarks/sched_queues/testcase.yaml
+++ b/tests/benchmarks/sched_queues/testcase.yaml
@@ -1,4 +1,7 @@
 common:
+  platform_key:
+    - arch
+  min_ram: 32
   tags:
     - kernel
     - benchmark

--- a/tests/benchmarks/sched_userspace/testcase.yaml
+++ b/tests/benchmarks/sched_userspace/testcase.yaml
@@ -5,7 +5,6 @@ tests:
       - kernel
       - benchmark
       - userspace
-    slow: true
     filter: CONFIG_ARCH_HAS_USERSPACE
     arch_exclude:
       - posix

--- a/tests/benchmarks/sys_kernel/testcase.yaml
+++ b/tests/benchmarks/sys_kernel/testcase.yaml
@@ -1,5 +1,7 @@
 tests:
   benchmark.kernel.core:
+    platform_key:
+      - arch
     tags:
       - kernel
       - benchmark

--- a/tests/benchmarks/thread_metric/testcase.yaml
+++ b/tests/benchmarks/thread_metric/testcase.yaml
@@ -1,4 +1,6 @@
 common:
+  platform_key:
+    - arch
   tags:
     - kernel
     - benchmark

--- a/tests/benchmarks/wait_queues/testcase.yaml
+++ b/tests/benchmarks/wait_queues/testcase.yaml
@@ -1,4 +1,6 @@
 common:
+  platform_key:
+    - arch
   tags:
     - kernel
     - benchmark


### PR DESCRIPTION
Benchmarks are not tests, we run them to verify they still work and do
not bitrot. Running them on each architecture should be sufficient.

This reduces amount of churn in CI and still allows them to be run
individually on platforms.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
