### PR TITLE
scripts: ci: tags: Add zephyr-keep-sorted check

### DIFF
--- a/scripts/ci/tags.yaml
+++ b/scripts/ci/tags.yaml
@@ -40,11 +40,31 @@
 #    to get test coverage as broad as possible.
 # 2. Keep tag entries sorted alphabetically
 
+# zephyr-keep-sorted-start
 bluetooth:
   files:
     - drivers/bluetooth/
     - subsys/bluetooth/
     - subsys/net/l2/bluetooth/
+
+cmsis_dsp:
+  files:
+    - modules/Kconfig.cmsis_dsp
+    # we have no means of telling file changes in a module, so for assume any
+    # change to west.yml is updating something we need to re-test for.
+    - west.yml
+
+kernel:
+  files:
+    - kernel/
+    - arch/
+
+mcumgr:
+  files:
+    - subsys/mgmt/mcumgr/
+    - tests/subsys/mgmt/mcumgr/
+    - samples/subsys/mgmt/mcumgr/
+    - include/zephyr/mgmt/mcumgr/
 
 net:
   files:
@@ -56,6 +76,17 @@ net:
     - drivers/ieee802154/
     - drivers/ptp_clock/
 
+posix:
+  files:
+    - lib/posix/
+
+test_framework:
+  files:
+    - subsys/testsuite/
+    - samples/subsys/testsuite/
+    - tests/subsys/testsuite/
+    - tests/ztest/
+
 wifi:
   files:
     - modules/hostap/
@@ -65,35 +96,7 @@ wifi:
     - include/zephyr/net/wifi_mgmt.h
     - include/zephyr/net/wifi_nm.h
     - include/zephyr/net/wifi_utils.h
-
-test_framework:
-  files:
-    - subsys/testsuite/
-    - samples/subsys/testsuite/
-    - tests/subsys/testsuite/
-    - tests/ztest/
-
-cmsis_dsp:
-  files:
-    - modules/Kconfig.cmsis_dsp
-    # we have no means of telling file changes in a module, so for assume any
-    # change to west.yml is updating something we need to re-test for.
-    - west.yml
-
-mcumgr:
-  files:
-    - subsys/mgmt/mcumgr/
-    - tests/subsys/mgmt/mcumgr/
-    - samples/subsys/mgmt/mcumgr/
-    - include/zephyr/mgmt/mcumgr/
-kernel:
-  files:
-    - kernel/
-    - arch/
-
-posix:
-  files:
-    - lib/posix/
+# zephyr-keep-sorted-stop
 
 # cbprintf:
 #    files:


### PR DESCRIPTION
The tag entries should be sorted, add zephyr-keep-sorted check and sort accordingly.