### PR TITLE
samples: drivers: rtc application runs on stm32 target

### DIFF
--- a/samples/drivers/rtc/README.rst
+++ b/samples/drivers/rtc/README.rst
@@ -27,8 +27,7 @@ Sample Output
 
 .. code-block:: console
 
-   RTC date and time: 2024-11-17 04:21:47
-   RTC date and time: 2024-11-17 04:21:48
-   RTC date and time: 2024-11-17 04:21:49
+   RTC date and time: 2024-11-17 04:19:00
+   RTC date and time: 2024-11-17 04:19:01
 
    <repeats endlessly>

--- a/samples/drivers/rtc/sample.yaml
+++ b/samples/drivers/rtc/sample.yaml
@@ -4,9 +4,16 @@ tests:
   sample.drivers.rtc:
     platform_allow:
       - stm32f3_disco
+    integration_platforms:
+      - stm32f3_disco
     tags:
       - samples
       - rtc
       - api
     depends_on:
       - rtc
+    harness: console
+    harness_config:
+      type: one_line
+      regex:
+        - "RTC date and time: 2024-11-17 04:19:01"


### PR DESCRIPTION
Check that rtc has, at least, incremented second counter one time to validated the sample.

Run the samples/drivers/rtc/ on the stm32f3_disco to demonstrate how o use rtc api get time/ set time
```
*** Booting Zephyr OS build v4.0.0-856-g94add84a331f ***                        
RTC date and time: 2024-11-17 04:19:00                                          
RTC date and time: 2024-11-17 04:19:01                                          
RTC date and time: 2024-11-17 04:19:02
...     
```

It can run on any stm32 target  board with rtc aliased _and_ enabled.