### PR TITLE
boards: nordic: Fix cpuapp_ram0x_region reg value.

### DIFF
--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20-memory_map.dtsi
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20-memory_map.dtsi
@@ -27,7 +27,7 @@
 
 		cpuapp_ram0x_region: memory@2f011000 {
 			compatible = "nordic,owned-memory";
-			reg = <0x2f010000 DT_SIZE_K(260)>;
+			reg = <0x2f011000 DT_SIZE_K(260)>;
 			status = "disabled";
 			nordic,access = <NRF_OWNER_ID_APPLICATION NRF_PERM_RWS>;
 			#address-cells = <1>;


### PR DESCRIPTION
There is a mistake and the cpuapp_ram0x_region "reg" value should start from 0x2f011000 to be consistent with declared ranges.