### PR TITLE
scripts: Fix twisterlib for ruff

### DIFF
--- a/.ruff-excludes.toml
+++ b/.ruff-excludes.toml
@@ -876,7 +876,6 @@
     "E402",     # https://docs.astral.sh/ruff/rules/module-import-not-at-top-of-file
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
     "E713",     # https://docs.astral.sh/ruff/rules/not-in-test
-    "E741",     # https://docs.astral.sh/ruff/rules/ambiguous-variable-name
     "F401",     # https://docs.astral.sh/ruff/rules/unused-import
     "F541",     # https://docs.astral.sh/ruff/rules/f-string-missing-placeholders
     "SIM102",   # https://docs.astral.sh/ruff/rules/collapsible-if

--- a/.ruff-excludes.toml
+++ b/.ruff-excludes.toml
@@ -766,7 +766,6 @@
 ]
 "./scripts/pylib/twister/twisterlib/coverage.py" = [
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
-    "F541",     # https://docs.astral.sh/ruff/rules/f-string-missing-placeholders
     "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
     "UP032",    # https://docs.astral.sh/ruff/rules/f-string
 ]
@@ -776,7 +775,6 @@
 ]
 "./scripts/pylib/twister/twisterlib/handlers.py" = [
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
-    "F541",     # https://docs.astral.sh/ruff/rules/f-string-missing-placeholders
     "UP007",    # https://docs.astral.sh/ruff/rules/non-pep604-annotation
     "UP030",    # https://docs.astral.sh/ruff/rules/format-literals
     "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
@@ -788,7 +786,6 @@
 ]
 "./scripts/pylib/twister/twisterlib/harness.py" = [
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
-    "F541",     # https://docs.astral.sh/ruff/rules/f-string-missing-placeholders
     "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
     "UP032",    # https://docs.astral.sh/ruff/rules/f-string
 ]
@@ -802,13 +799,11 @@
 ]
 "./scripts/pylib/twister/twisterlib/reports.py" = [
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
-    "F541",     # https://docs.astral.sh/ruff/rules/f-string-missing-placeholders
     "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
     "UP032",    # https://docs.astral.sh/ruff/rules/f-string
 ]
 "./scripts/pylib/twister/twisterlib/runner.py" = [
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
-    "F541",     # https://docs.astral.sh/ruff/rules/f-string-missing-placeholders
     "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
     "UP032",    # https://docs.astral.sh/ruff/rules/f-string
 ]
@@ -824,7 +819,6 @@
     "E402",     # https://docs.astral.sh/ruff/rules/module-import-not-at-top-of-file
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
     "F401",     # https://docs.astral.sh/ruff/rules/unused-import
-    "F541",     # https://docs.astral.sh/ruff/rules/f-string-missing-placeholders
     "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
     "UP032",    # https://docs.astral.sh/ruff/rules/f-string
 ]

--- a/.ruff-excludes.toml
+++ b/.ruff-excludes.toml
@@ -769,7 +769,6 @@
     "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
 ]
 "./scripts/pylib/twister/twisterlib/coverage.py" = [
-    "B905",     # https://docs.astral.sh/ruff/rules/zip-without-explicit-strict
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
     "F541",     # https://docs.astral.sh/ruff/rules/f-string-missing-placeholders
     "SIM105",   # https://docs.astral.sh/ruff/rules/suppressible-exception

--- a/.ruff-excludes.toml
+++ b/.ruff-excludes.toml
@@ -782,7 +782,6 @@
 "./scripts/pylib/twister/twisterlib/environment.py" = [
     "B006",     # https://docs.astral.sh/ruff/rules/mutable-argument-default
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
-    "UP006",    # https://docs.astral.sh/ruff/rules/non-pep585-annotation
     "UP021",    # https://docs.astral.sh/ruff/rules/replace-universal-newlines
     "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
 ]
@@ -847,7 +846,6 @@
     "SIM102",   # https://docs.astral.sh/ruff/rules/collapsible-if
     "SIM115",   # https://docs.astral.sh/ruff/rules/open-file-with-context-handler
     "UP004",    # https://docs.astral.sh/ruff/rules/useless-object-inheritance
-    "UP006",    # https://docs.astral.sh/ruff/rules/non-pep585-annotation
     "UP015",    # https://docs.astral.sh/ruff/rules/redundant-open-modes
     "UP022",    # https://docs.astral.sh/ruff/rules/replace-stdout-stderr
     "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
@@ -855,7 +853,6 @@
 ]
 "./scripts/pylib/twister/twisterlib/size_calc.py" = [
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
-    "UP006",    # https://docs.astral.sh/ruff/rules/non-pep585-annotation
     "UP015",    # https://docs.astral.sh/ruff/rules/redundant-open-modes
     "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
 ]
@@ -884,7 +881,6 @@
     "B006",     # https://docs.astral.sh/ruff/rules/mutable-argument-default
     "B904",     # https://docs.astral.sh/ruff/rules/raise-without-from-inside-except
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
-    "UP006",    # https://docs.astral.sh/ruff/rules/non-pep585-annotation
     "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
     "UP032",    # https://docs.astral.sh/ruff/rules/f-string
 ]

--- a/.ruff-excludes.toml
+++ b/.ruff-excludes.toml
@@ -768,7 +768,6 @@
 "./scripts/pylib/twister/twisterlib/config_parser.py" = [
     "B028",     # https://docs.astral.sh/ruff/rules/no-explicit-stacklevel
     "B904",     # https://docs.astral.sh/ruff/rules/raise-without-from-inside-except
-    "SIM401",   # https://docs.astral.sh/ruff/rules/if-else-block-instead-of-dict-get
     "UP007",    # https://docs.astral.sh/ruff/rules/non-pep604-annotation
     "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
 ]
@@ -871,9 +870,6 @@
     "UP006",    # https://docs.astral.sh/ruff/rules/non-pep585-annotation
     "UP015",    # https://docs.astral.sh/ruff/rules/redundant-open-modes
     "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
-]
-"./scripts/pylib/twister/twisterlib/statuses.py" = [
-    "SIM401",   # https://docs.astral.sh/ruff/rules/if-else-block-instead-of-dict-get
 ]
 "./scripts/pylib/twister/twisterlib/testinstance.py" = [
     "B006",     # https://docs.astral.sh/ruff/rules/mutable-argument-default

--- a/.ruff-excludes.toml
+++ b/.ruff-excludes.toml
@@ -787,8 +787,8 @@
 ]
 "./scripts/pylib/twister/twisterlib/environment.py" = [
     "B006",     # https://docs.astral.sh/ruff/rules/mutable-argument-default
-    "E402",     # https://docs.astral.sh/ruff/rules/module-import-not-at-top-of-file
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
+    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
     "SIM118",   # https://docs.astral.sh/ruff/rules/in-dict-keys
     "UP006",    # https://docs.astral.sh/ruff/rules/non-pep585-annotation
     "UP021",    # https://docs.astral.sh/ruff/rules/replace-universal-newlines
@@ -867,7 +867,6 @@
 ]
 "./scripts/pylib/twister/twisterlib/runner.py" = [
     "B006",     # https://docs.astral.sh/ruff/rules/mutable-argument-default
-    "E402",     # https://docs.astral.sh/ruff/rules/module-import-not-at-top-of-file
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
     "E713",     # https://docs.astral.sh/ruff/rules/not-in-test
     "F541",     # https://docs.astral.sh/ruff/rules/f-string-missing-placeholders
@@ -964,7 +963,6 @@
     "UP032",    # https://docs.astral.sh/ruff/rules/f-string
 ]
 "./scripts/release/list_devicetree_bindings_changes.py" = [
-    "E402",     # https://docs.astral.sh/ruff/rules/module-import-not-at-top-of-file
     "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
     "SIM117",   # https://docs.astral.sh/ruff/rules/multiple-with-statements
     "UP006",    # https://docs.astral.sh/ruff/rules/non-pep585-annotation

--- a/.ruff-excludes.toml
+++ b/.ruff-excludes.toml
@@ -793,7 +793,6 @@
     "UP006",    # https://docs.astral.sh/ruff/rules/non-pep585-annotation
     "UP021",    # https://docs.astral.sh/ruff/rules/replace-universal-newlines
     "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
-    "UP035",    # https://docs.astral.sh/ruff/rules/deprecated-import
 ]
 "./scripts/pylib/twister/twisterlib/handlers.py" = [
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
@@ -880,7 +879,6 @@
     "UP022",    # https://docs.astral.sh/ruff/rules/replace-stdout-stderr
     "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
     "UP032",    # https://docs.astral.sh/ruff/rules/f-string
-    "UP035",    # https://docs.astral.sh/ruff/rules/deprecated-import
 ]
 "./scripts/pylib/twister/twisterlib/size_calc.py" = [
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
@@ -929,7 +927,6 @@
     "UP006",    # https://docs.astral.sh/ruff/rules/non-pep585-annotation
     "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
     "UP032",    # https://docs.astral.sh/ruff/rules/f-string
-    "UP035",    # https://docs.astral.sh/ruff/rules/deprecated-import
 ]
 "./scripts/pylib/twister/twisterlib/twister_main.py" = [
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long

--- a/.ruff-excludes.toml
+++ b/.ruff-excludes.toml
@@ -756,52 +756,9 @@
     "UP015",    # https://docs.astral.sh/ruff/rules/redundant-open-modes
     "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
 ]
-"./scripts/pylib/twister/twisterlib/cmakecache.py" = [
-    "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
-]
-"./scripts/pylib/twister/twisterlib/coverage.py" = [
-    "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
-]
-"./scripts/pylib/twister/twisterlib/environment.py" = [
-    "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
-]
-"./scripts/pylib/twister/twisterlib/handlers.py" = [
-    "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
-]
-"./scripts/pylib/twister/twisterlib/hardwaremap.py" = [
-    "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
-]
-"./scripts/pylib/twister/twisterlib/harness.py" = [
-    "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
-]
-"./scripts/pylib/twister/twisterlib/platform.py" = [
-    "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
-]
-"./scripts/pylib/twister/twisterlib/quarantine.py" = [
-    "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
-]
-"./scripts/pylib/twister/twisterlib/reports.py" = [
-    "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
-]
-"./scripts/pylib/twister/twisterlib/runner.py" = [
-    "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
-]
-"./scripts/pylib/twister/twisterlib/size_calc.py" = [
-    "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
-]
-"./scripts/pylib/twister/twisterlib/testinstance.py" = [
-    "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
-]
 "./scripts/pylib/twister/twisterlib/testplan.py" = [
     "E402",     # https://docs.astral.sh/ruff/rules/module-import-not-at-top-of-file
-    "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
     "F401",     # https://docs.astral.sh/ruff/rules/unused-import
-]
-"./scripts/pylib/twister/twisterlib/testsuite.py" = [
-    "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
-]
-"./scripts/pylib/twister/twisterlib/twister_main.py" = [
-    "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
 ]
 "./scripts/pylint/checkers/argparse-checker.py" = [
     "F821",     # https://docs.astral.sh/ruff/rules/undefined-name

--- a/.ruff-excludes.toml
+++ b/.ruff-excludes.toml
@@ -809,7 +809,6 @@
     "B009",     # https://docs.astral.sh/ruff/rules/get-attr-with-constant
     "B904",     # https://docs.astral.sh/ruff/rules/raise-without-from-inside-except
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
-    "E713",     # https://docs.astral.sh/ruff/rules/not-in-test
     "F541",     # https://docs.astral.sh/ruff/rules/f-string-missing-placeholders
     "F811",     # https://docs.astral.sh/ruff/rules/redefined-while-unused
     "SIM102",   # https://docs.astral.sh/ruff/rules/collapsible-if
@@ -844,7 +843,6 @@
 "./scripts/pylib/twister/twisterlib/runner.py" = [
     "B006",     # https://docs.astral.sh/ruff/rules/mutable-argument-default
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
-    "E713",     # https://docs.astral.sh/ruff/rules/not-in-test
     "F541",     # https://docs.astral.sh/ruff/rules/f-string-missing-placeholders
     "SIM102",   # https://docs.astral.sh/ruff/rules/collapsible-if
     "SIM115",   # https://docs.astral.sh/ruff/rules/open-file-with-context-handler
@@ -875,7 +873,6 @@
     "B904",     # https://docs.astral.sh/ruff/rules/raise-without-from-inside-except
     "E402",     # https://docs.astral.sh/ruff/rules/module-import-not-at-top-of-file
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
-    "E713",     # https://docs.astral.sh/ruff/rules/not-in-test
     "F401",     # https://docs.astral.sh/ruff/rules/unused-import
     "F541",     # https://docs.astral.sh/ruff/rules/f-string-missing-placeholders
     "SIM102",   # https://docs.astral.sh/ruff/rules/collapsible-if

--- a/.ruff-excludes.toml
+++ b/.ruff-excludes.toml
@@ -847,7 +847,6 @@
 ]
 "./scripts/pylib/twister/twisterlib/testplan.py" = [
     "B006",     # https://docs.astral.sh/ruff/rules/mutable-argument-default
-    "B023",     # https://docs.astral.sh/ruff/rules/function-uses-loop-variable
     "E402",     # https://docs.astral.sh/ruff/rules/module-import-not-at-top-of-file
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
     "F401",     # https://docs.astral.sh/ruff/rules/unused-import

--- a/.ruff-excludes.toml
+++ b/.ruff-excludes.toml
@@ -759,7 +759,6 @@
 ]
 "./scripts/pylib/twister/twisterlib/cmakecache.py" = [
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
-    "SIM102",   # https://docs.astral.sh/ruff/rules/collapsible-if
     "UP015",    # https://docs.astral.sh/ruff/rules/redundant-open-modes
     "UP032",    # https://docs.astral.sh/ruff/rules/f-string
 ]
@@ -786,7 +785,6 @@
 "./scripts/pylib/twister/twisterlib/handlers.py" = [
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
     "F541",     # https://docs.astral.sh/ruff/rules/f-string-missing-placeholders
-    "SIM102",   # https://docs.astral.sh/ruff/rules/collapsible-if
     "SIM105",   # https://docs.astral.sh/ruff/rules/suppressible-exception
     "SIM115",   # https://docs.astral.sh/ruff/rules/open-file-with-context-handler
     "UP007",    # https://docs.astral.sh/ruff/rules/non-pep604-annotation
@@ -807,7 +805,6 @@
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
     "F541",     # https://docs.astral.sh/ruff/rules/f-string-missing-placeholders
     "F811",     # https://docs.astral.sh/ruff/rules/redefined-while-unused
-    "SIM102",   # https://docs.astral.sh/ruff/rules/collapsible-if
     "UP015",    # https://docs.astral.sh/ruff/rules/redundant-open-modes
     "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
     "UP032",    # https://docs.astral.sh/ruff/rules/f-string
@@ -836,7 +833,6 @@
     "B006",     # https://docs.astral.sh/ruff/rules/mutable-argument-default
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
     "F541",     # https://docs.astral.sh/ruff/rules/f-string-missing-placeholders
-    "SIM102",   # https://docs.astral.sh/ruff/rules/collapsible-if
     "SIM115",   # https://docs.astral.sh/ruff/rules/open-file-with-context-handler
     "UP015",    # https://docs.astral.sh/ruff/rules/redundant-open-modes
     "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
@@ -851,7 +847,6 @@
     "B006",     # https://docs.astral.sh/ruff/rules/mutable-argument-default
     "B904",     # https://docs.astral.sh/ruff/rules/raise-without-from-inside-except
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
-    "SIM102",   # https://docs.astral.sh/ruff/rules/collapsible-if
     "UP015",    # https://docs.astral.sh/ruff/rules/redundant-open-modes
     "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
 ]
@@ -863,7 +858,6 @@
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
     "F401",     # https://docs.astral.sh/ruff/rules/unused-import
     "F541",     # https://docs.astral.sh/ruff/rules/f-string-missing-placeholders
-    "SIM102",   # https://docs.astral.sh/ruff/rules/collapsible-if
     "UP015",    # https://docs.astral.sh/ruff/rules/redundant-open-modes
     "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
     "UP032",    # https://docs.astral.sh/ruff/rules/f-string

--- a/.ruff-excludes.toml
+++ b/.ruff-excludes.toml
@@ -761,7 +761,6 @@
 "./scripts/pylib/twister/twisterlib/cmakecache.py" = [
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
     "SIM102",   # https://docs.astral.sh/ruff/rules/collapsible-if
-    "SIM114",   # https://docs.astral.sh/ruff/rules/if-with-same-arms
     "UP015",    # https://docs.astral.sh/ruff/rules/redundant-open-modes
     "UP032",    # https://docs.astral.sh/ruff/rules/f-string
 ]
@@ -793,7 +792,6 @@
     "F541",     # https://docs.astral.sh/ruff/rules/f-string-missing-placeholders
     "SIM102",   # https://docs.astral.sh/ruff/rules/collapsible-if
     "SIM105",   # https://docs.astral.sh/ruff/rules/suppressible-exception
-    "SIM114",   # https://docs.astral.sh/ruff/rules/if-with-same-arms
     "SIM115",   # https://docs.astral.sh/ruff/rules/open-file-with-context-handler
     "UP007",    # https://docs.astral.sh/ruff/rules/non-pep604-annotation
     "UP015",    # https://docs.astral.sh/ruff/rules/redundant-open-modes

--- a/.ruff-excludes.toml
+++ b/.ruff-excludes.toml
@@ -800,7 +800,6 @@
     "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
 ]
 "./scripts/pylib/twister/twisterlib/harness.py" = [
-    "B009",     # https://docs.astral.sh/ruff/rules/get-attr-with-constant
     "B904",     # https://docs.astral.sh/ruff/rules/raise-without-from-inside-except
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
     "F541",     # https://docs.astral.sh/ruff/rules/f-string-missing-placeholders

--- a/.ruff-excludes.toml
+++ b/.ruff-excludes.toml
@@ -759,6 +759,7 @@
     "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
 ]
 "./scripts/pylib/twister/twisterlib/cmakecache.py" = [
+    "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
     "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
     "SIM102",   # https://docs.astral.sh/ruff/rules/collapsible-if
     "SIM114",   # https://docs.astral.sh/ruff/rules/if-with-same-arms
@@ -877,6 +878,7 @@
     "UP004",    # https://docs.astral.sh/ruff/rules/useless-object-inheritance
     "UP006",    # https://docs.astral.sh/ruff/rules/non-pep585-annotation
     "UP015",    # https://docs.astral.sh/ruff/rules/redundant-open-modes
+    "UP022",    # https://docs.astral.sh/ruff/rules/replace-stdout-stderr
     "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
     "UP032",    # https://docs.astral.sh/ruff/rules/f-string
     "UP035",    # https://docs.astral.sh/ruff/rules/deprecated-import

--- a/.ruff-excludes.toml
+++ b/.ruff-excludes.toml
@@ -758,78 +758,54 @@
 ]
 "./scripts/pylib/twister/twisterlib/cmakecache.py" = [
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
-    "UP032",    # https://docs.astral.sh/ruff/rules/f-string
 ]
 "./scripts/pylib/twister/twisterlib/config_parser.py" = [
     "UP007",    # https://docs.astral.sh/ruff/rules/non-pep604-annotation
-    "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
 ]
 "./scripts/pylib/twister/twisterlib/coverage.py" = [
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
-    "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
-    "UP032",    # https://docs.astral.sh/ruff/rules/f-string
 ]
 "./scripts/pylib/twister/twisterlib/environment.py" = [
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
-    "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
 ]
 "./scripts/pylib/twister/twisterlib/handlers.py" = [
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
     "UP007",    # https://docs.astral.sh/ruff/rules/non-pep604-annotation
-    "UP030",    # https://docs.astral.sh/ruff/rules/format-literals
-    "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
-    "UP032",    # https://docs.astral.sh/ruff/rules/f-string
 ]
 "./scripts/pylib/twister/twisterlib/hardwaremap.py" = [
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
-    "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
 ]
 "./scripts/pylib/twister/twisterlib/harness.py" = [
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
-    "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
-    "UP032",    # https://docs.astral.sh/ruff/rules/f-string
 ]
 "./scripts/pylib/twister/twisterlib/platform.py" = [
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
-    "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
 ]
 "./scripts/pylib/twister/twisterlib/quarantine.py" = [
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
-    "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
 ]
 "./scripts/pylib/twister/twisterlib/reports.py" = [
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
-    "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
-    "UP032",    # https://docs.astral.sh/ruff/rules/f-string
 ]
 "./scripts/pylib/twister/twisterlib/runner.py" = [
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
-    "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
-    "UP032",    # https://docs.astral.sh/ruff/rules/f-string
 ]
 "./scripts/pylib/twister/twisterlib/size_calc.py" = [
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
-    "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
 ]
 "./scripts/pylib/twister/twisterlib/testinstance.py" = [
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
-    "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
 ]
 "./scripts/pylib/twister/twisterlib/testplan.py" = [
     "E402",     # https://docs.astral.sh/ruff/rules/module-import-not-at-top-of-file
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
     "F401",     # https://docs.astral.sh/ruff/rules/unused-import
-    "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
-    "UP032",    # https://docs.astral.sh/ruff/rules/f-string
 ]
 "./scripts/pylib/twister/twisterlib/testsuite.py" = [
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
-    "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
-    "UP032",    # https://docs.astral.sh/ruff/rules/f-string
 ]
 "./scripts/pylib/twister/twisterlib/twister_main.py" = [
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
-    "UP032",    # https://docs.astral.sh/ruff/rules/f-string
 ]
 "./scripts/pylint/checkers/argparse-checker.py" = [
     "F821",     # https://docs.astral.sh/ruff/rules/undefined-name

--- a/.ruff-excludes.toml
+++ b/.ruff-excludes.toml
@@ -775,14 +775,12 @@
     "F541",     # https://docs.astral.sh/ruff/rules/f-string-missing-placeholders
     "SIM105",   # https://docs.astral.sh/ruff/rules/suppressible-exception
     "UP015",    # https://docs.astral.sh/ruff/rules/redundant-open-modes
-    "UP022",    # https://docs.astral.sh/ruff/rules/replace-stdout-stderr
     "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
     "UP032",    # https://docs.astral.sh/ruff/rules/f-string
 ]
 "./scripts/pylib/twister/twisterlib/environment.py" = [
     "B006",     # https://docs.astral.sh/ruff/rules/mutable-argument-default
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
-    "UP021",    # https://docs.astral.sh/ruff/rules/replace-universal-newlines
     "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
 ]
 "./scripts/pylib/twister/twisterlib/handlers.py" = [
@@ -842,7 +840,6 @@
     "SIM102",   # https://docs.astral.sh/ruff/rules/collapsible-if
     "SIM115",   # https://docs.astral.sh/ruff/rules/open-file-with-context-handler
     "UP015",    # https://docs.astral.sh/ruff/rules/redundant-open-modes
-    "UP022",    # https://docs.astral.sh/ruff/rules/replace-stdout-stderr
     "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
     "UP032",    # https://docs.astral.sh/ruff/rules/f-string
 ]

--- a/.ruff-excludes.toml
+++ b/.ruff-excludes.toml
@@ -817,7 +817,6 @@
     "F541",     # https://docs.astral.sh/ruff/rules/f-string-missing-placeholders
     "F811",     # https://docs.astral.sh/ruff/rules/redefined-while-unused
     "SIM102",   # https://docs.astral.sh/ruff/rules/collapsible-if
-    "SIM300",   # https://docs.astral.sh/ruff/rules/yoda-conditions
     "UP008",    # https://docs.astral.sh/ruff/rules/super-call-with-parameters
     "UP015",    # https://docs.astral.sh/ruff/rules/redundant-open-modes
     "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting

--- a/.ruff-excludes.toml
+++ b/.ruff-excludes.toml
@@ -785,7 +785,6 @@
 "./scripts/pylib/twister/twisterlib/environment.py" = [
     "B006",     # https://docs.astral.sh/ruff/rules/mutable-argument-default
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
-    "SIM118",   # https://docs.astral.sh/ruff/rules/in-dict-keys
     "UP006",    # https://docs.astral.sh/ruff/rules/non-pep585-annotation
     "UP021",    # https://docs.astral.sh/ruff/rules/replace-universal-newlines
     "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
@@ -807,7 +806,6 @@
 "./scripts/pylib/twister/twisterlib/hardwaremap.py" = [
     "B006",     # https://docs.astral.sh/ruff/rules/mutable-argument-default
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
-    "SIM118",   # https://docs.astral.sh/ruff/rules/in-dict-keys
     "UP004",    # https://docs.astral.sh/ruff/rules/useless-object-inheritance
     "UP015",    # https://docs.astral.sh/ruff/rules/redundant-open-modes
     "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
@@ -897,7 +895,6 @@
     "F541",     # https://docs.astral.sh/ruff/rules/f-string-missing-placeholders
     "SIM102",   # https://docs.astral.sh/ruff/rules/collapsible-if
     "SIM110",   # https://docs.astral.sh/ruff/rules/reimplemented-builtin
-    "SIM118",   # https://docs.astral.sh/ruff/rules/in-dict-keys
     "SIM202",   # https://docs.astral.sh/ruff/rules/negate-not-equal-op
     "UP015",    # https://docs.astral.sh/ruff/rules/redundant-open-modes
     "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting

--- a/.ruff-excludes.toml
+++ b/.ruff-excludes.toml
@@ -759,9 +759,6 @@
 "./scripts/pylib/twister/twisterlib/cmakecache.py" = [
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
 ]
-"./scripts/pylib/twister/twisterlib/config_parser.py" = [
-    "UP007",    # https://docs.astral.sh/ruff/rules/non-pep604-annotation
-]
 "./scripts/pylib/twister/twisterlib/coverage.py" = [
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
 ]
@@ -770,7 +767,6 @@
 ]
 "./scripts/pylib/twister/twisterlib/handlers.py" = [
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
-    "UP007",    # https://docs.astral.sh/ruff/rules/non-pep604-annotation
 ]
 "./scripts/pylib/twister/twisterlib/hardwaremap.py" = [
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long

--- a/.ruff-excludes.toml
+++ b/.ruff-excludes.toml
@@ -776,7 +776,6 @@
     "UP032",    # https://docs.astral.sh/ruff/rules/f-string
 ]
 "./scripts/pylib/twister/twisterlib/environment.py" = [
-    "B006",     # https://docs.astral.sh/ruff/rules/mutable-argument-default
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
     "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
 ]
@@ -792,7 +791,6 @@
     "UP032",    # https://docs.astral.sh/ruff/rules/f-string
 ]
 "./scripts/pylib/twister/twisterlib/hardwaremap.py" = [
-    "B006",     # https://docs.astral.sh/ruff/rules/mutable-argument-default
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
     "UP015",    # https://docs.astral.sh/ruff/rules/redundant-open-modes
     "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
@@ -813,7 +811,6 @@
     "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
 ]
 "./scripts/pylib/twister/twisterlib/quarantine.py" = [
-    "B006",     # https://docs.astral.sh/ruff/rules/mutable-argument-default
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
     "UP015",    # https://docs.astral.sh/ruff/rules/redundant-open-modes
     "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
@@ -826,7 +823,6 @@
     "UP032",    # https://docs.astral.sh/ruff/rules/f-string
 ]
 "./scripts/pylib/twister/twisterlib/runner.py" = [
-    "B006",     # https://docs.astral.sh/ruff/rules/mutable-argument-default
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
     "F541",     # https://docs.astral.sh/ruff/rules/f-string-missing-placeholders
     "SIM115",   # https://docs.astral.sh/ruff/rules/open-file-with-context-handler
@@ -840,13 +836,11 @@
     "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
 ]
 "./scripts/pylib/twister/twisterlib/testinstance.py" = [
-    "B006",     # https://docs.astral.sh/ruff/rules/mutable-argument-default
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
     "UP015",    # https://docs.astral.sh/ruff/rules/redundant-open-modes
     "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
 ]
 "./scripts/pylib/twister/twisterlib/testplan.py" = [
-    "B006",     # https://docs.astral.sh/ruff/rules/mutable-argument-default
     "E402",     # https://docs.astral.sh/ruff/rules/module-import-not-at-top-of-file
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
     "F401",     # https://docs.astral.sh/ruff/rules/unused-import
@@ -856,7 +850,6 @@
     "UP032",    # https://docs.astral.sh/ruff/rules/f-string
 ]
 "./scripts/pylib/twister/twisterlib/testsuite.py" = [
-    "B006",     # https://docs.astral.sh/ruff/rules/mutable-argument-default
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
     "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
     "UP032",    # https://docs.astral.sh/ruff/rules/f-string

--- a/.ruff-excludes.toml
+++ b/.ruff-excludes.toml
@@ -800,7 +800,6 @@
 "./scripts/pylib/twister/twisterlib/hardwaremap.py" = [
     "B006",     # https://docs.astral.sh/ruff/rules/mutable-argument-default
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
-    "UP004",    # https://docs.astral.sh/ruff/rules/useless-object-inheritance
     "UP015",    # https://docs.astral.sh/ruff/rules/redundant-open-modes
     "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
 ]
@@ -815,9 +814,6 @@
     "UP015",    # https://docs.astral.sh/ruff/rules/redundant-open-modes
     "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
     "UP032",    # https://docs.astral.sh/ruff/rules/f-string
-]
-"./scripts/pylib/twister/twisterlib/mixins.py" = [
-    "UP004",    # https://docs.astral.sh/ruff/rules/useless-object-inheritance
 ]
 "./scripts/pylib/twister/twisterlib/package.py" = [
     "UP015",    # https://docs.astral.sh/ruff/rules/redundant-open-modes
@@ -845,7 +841,6 @@
     "F541",     # https://docs.astral.sh/ruff/rules/f-string-missing-placeholders
     "SIM102",   # https://docs.astral.sh/ruff/rules/collapsible-if
     "SIM115",   # https://docs.astral.sh/ruff/rules/open-file-with-context-handler
-    "UP004",    # https://docs.astral.sh/ruff/rules/useless-object-inheritance
     "UP015",    # https://docs.astral.sh/ruff/rules/redundant-open-modes
     "UP022",    # https://docs.astral.sh/ruff/rules/replace-stdout-stderr
     "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting

--- a/.ruff-excludes.toml
+++ b/.ruff-excludes.toml
@@ -748,7 +748,6 @@
 ]
 "./scripts/pylib/twister/expr_parser.py" = [
     "SIM103",   # https://docs.astral.sh/ruff/rules/needless-bool
-    "SIM110",   # https://docs.astral.sh/ruff/rules/reimplemented-builtin
     "SIM115",   # https://docs.astral.sh/ruff/rules/open-file-with-context-handler
     "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
 ]
@@ -832,7 +831,6 @@
 "./scripts/pylib/twister/twisterlib/quarantine.py" = [
     "B006",     # https://docs.astral.sh/ruff/rules/mutable-argument-default
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
-    "SIM110",   # https://docs.astral.sh/ruff/rules/reimplemented-builtin
     "UP015",    # https://docs.astral.sh/ruff/rules/redundant-open-modes
     "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
 ]
@@ -882,7 +880,6 @@
     "F401",     # https://docs.astral.sh/ruff/rules/unused-import
     "F541",     # https://docs.astral.sh/ruff/rules/f-string-missing-placeholders
     "SIM102",   # https://docs.astral.sh/ruff/rules/collapsible-if
-    "SIM110",   # https://docs.astral.sh/ruff/rules/reimplemented-builtin
     "UP015",    # https://docs.astral.sh/ruff/rules/redundant-open-modes
     "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
     "UP032",    # https://docs.astral.sh/ruff/rules/f-string

--- a/.ruff-excludes.toml
+++ b/.ruff-excludes.toml
@@ -795,7 +795,6 @@
     "SIM105",   # https://docs.astral.sh/ruff/rules/suppressible-exception
     "SIM114",   # https://docs.astral.sh/ruff/rules/if-with-same-arms
     "SIM115",   # https://docs.astral.sh/ruff/rules/open-file-with-context-handler
-    "SIM201",   # https://docs.astral.sh/ruff/rules/negate-equal-op
     "UP007",    # https://docs.astral.sh/ruff/rules/non-pep604-annotation
     "UP015",    # https://docs.astral.sh/ruff/rules/redundant-open-modes
     "UP030",    # https://docs.astral.sh/ruff/rules/format-literals
@@ -821,9 +820,6 @@
     "UP015",    # https://docs.astral.sh/ruff/rules/redundant-open-modes
     "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
     "UP032",    # https://docs.astral.sh/ruff/rules/f-string
-]
-"./scripts/pylib/twister/twisterlib/jobserver.py" = [
-    "SIM201",   # https://docs.astral.sh/ruff/rules/negate-equal-op
 ]
 "./scripts/pylib/twister/twisterlib/mixins.py" = [
     "UP004",    # https://docs.astral.sh/ruff/rules/useless-object-inheritance
@@ -856,7 +852,6 @@
     "F541",     # https://docs.astral.sh/ruff/rules/f-string-missing-placeholders
     "SIM102",   # https://docs.astral.sh/ruff/rules/collapsible-if
     "SIM115",   # https://docs.astral.sh/ruff/rules/open-file-with-context-handler
-    "SIM201",   # https://docs.astral.sh/ruff/rules/negate-equal-op
     "UP004",    # https://docs.astral.sh/ruff/rules/useless-object-inheritance
     "UP006",    # https://docs.astral.sh/ruff/rules/non-pep585-annotation
     "UP015",    # https://docs.astral.sh/ruff/rules/redundant-open-modes
@@ -890,7 +885,6 @@
     "F541",     # https://docs.astral.sh/ruff/rules/f-string-missing-placeholders
     "SIM102",   # https://docs.astral.sh/ruff/rules/collapsible-if
     "SIM110",   # https://docs.astral.sh/ruff/rules/reimplemented-builtin
-    "SIM202",   # https://docs.astral.sh/ruff/rules/negate-not-equal-op
     "UP015",    # https://docs.astral.sh/ruff/rules/redundant-open-modes
     "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
     "UP032",    # https://docs.astral.sh/ruff/rules/f-string

--- a/.ruff-excludes.toml
+++ b/.ruff-excludes.toml
@@ -759,7 +759,6 @@
 ]
 "./scripts/pylib/twister/twisterlib/cmakecache.py" = [
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
-    "UP015",    # https://docs.astral.sh/ruff/rules/redundant-open-modes
     "UP032",    # https://docs.astral.sh/ruff/rules/f-string
 ]
 "./scripts/pylib/twister/twisterlib/config_parser.py" = [
@@ -769,7 +768,6 @@
 "./scripts/pylib/twister/twisterlib/coverage.py" = [
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
     "F541",     # https://docs.astral.sh/ruff/rules/f-string-missing-placeholders
-    "UP015",    # https://docs.astral.sh/ruff/rules/redundant-open-modes
     "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
     "UP032",    # https://docs.astral.sh/ruff/rules/f-string
 ]
@@ -782,26 +780,20 @@
     "F541",     # https://docs.astral.sh/ruff/rules/f-string-missing-placeholders
     "SIM115",   # https://docs.astral.sh/ruff/rules/open-file-with-context-handler
     "UP007",    # https://docs.astral.sh/ruff/rules/non-pep604-annotation
-    "UP015",    # https://docs.astral.sh/ruff/rules/redundant-open-modes
     "UP030",    # https://docs.astral.sh/ruff/rules/format-literals
     "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
     "UP032",    # https://docs.astral.sh/ruff/rules/f-string
 ]
 "./scripts/pylib/twister/twisterlib/hardwaremap.py" = [
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
-    "UP015",    # https://docs.astral.sh/ruff/rules/redundant-open-modes
     "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
 ]
 "./scripts/pylib/twister/twisterlib/harness.py" = [
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
     "F541",     # https://docs.astral.sh/ruff/rules/f-string-missing-placeholders
     "F811",     # https://docs.astral.sh/ruff/rules/redefined-while-unused
-    "UP015",    # https://docs.astral.sh/ruff/rules/redundant-open-modes
     "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
     "UP032",    # https://docs.astral.sh/ruff/rules/f-string
-]
-"./scripts/pylib/twister/twisterlib/package.py" = [
-    "UP015",    # https://docs.astral.sh/ruff/rules/redundant-open-modes
 ]
 "./scripts/pylib/twister/twisterlib/platform.py" = [
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
@@ -809,13 +801,11 @@
 ]
 "./scripts/pylib/twister/twisterlib/quarantine.py" = [
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
-    "UP015",    # https://docs.astral.sh/ruff/rules/redundant-open-modes
     "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
 ]
 "./scripts/pylib/twister/twisterlib/reports.py" = [
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
     "F541",     # https://docs.astral.sh/ruff/rules/f-string-missing-placeholders
-    "UP015",    # https://docs.astral.sh/ruff/rules/redundant-open-modes
     "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
     "UP032",    # https://docs.astral.sh/ruff/rules/f-string
 ]
@@ -823,18 +813,15 @@
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
     "F541",     # https://docs.astral.sh/ruff/rules/f-string-missing-placeholders
     "SIM115",   # https://docs.astral.sh/ruff/rules/open-file-with-context-handler
-    "UP015",    # https://docs.astral.sh/ruff/rules/redundant-open-modes
     "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
     "UP032",    # https://docs.astral.sh/ruff/rules/f-string
 ]
 "./scripts/pylib/twister/twisterlib/size_calc.py" = [
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
-    "UP015",    # https://docs.astral.sh/ruff/rules/redundant-open-modes
     "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
 ]
 "./scripts/pylib/twister/twisterlib/testinstance.py" = [
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
-    "UP015",    # https://docs.astral.sh/ruff/rules/redundant-open-modes
     "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
 ]
 "./scripts/pylib/twister/twisterlib/testplan.py" = [
@@ -842,7 +829,6 @@
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
     "F401",     # https://docs.astral.sh/ruff/rules/unused-import
     "F541",     # https://docs.astral.sh/ruff/rules/f-string-missing-placeholders
-    "UP015",    # https://docs.astral.sh/ruff/rules/redundant-open-modes
     "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
     "UP032",    # https://docs.astral.sh/ruff/rules/f-string
 ]
@@ -853,7 +839,6 @@
 ]
 "./scripts/pylib/twister/twisterlib/twister_main.py" = [
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
-    "UP015",    # https://docs.astral.sh/ruff/rules/redundant-open-modes
     "UP032",    # https://docs.astral.sh/ruff/rules/f-string
 ]
 "./scripts/pylint/checkers/argparse-checker.py" = [

--- a/.ruff-excludes.toml
+++ b/.ruff-excludes.toml
@@ -808,7 +808,6 @@
     "F541",     # https://docs.astral.sh/ruff/rules/f-string-missing-placeholders
     "F811",     # https://docs.astral.sh/ruff/rules/redefined-while-unused
     "SIM102",   # https://docs.astral.sh/ruff/rules/collapsible-if
-    "UP008",    # https://docs.astral.sh/ruff/rules/super-call-with-parameters
     "UP015",    # https://docs.astral.sh/ruff/rules/redundant-open-modes
     "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
     "UP032",    # https://docs.astral.sh/ruff/rules/f-string

--- a/.ruff-excludes.toml
+++ b/.ruff-excludes.toml
@@ -760,7 +760,6 @@
 ]
 "./scripts/pylib/twister/twisterlib/cmakecache.py" = [
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
     "SIM102",   # https://docs.astral.sh/ruff/rules/collapsible-if
     "SIM114",   # https://docs.astral.sh/ruff/rules/if-with-same-arms
     "UP015",    # https://docs.astral.sh/ruff/rules/redundant-open-modes
@@ -769,7 +768,6 @@
 "./scripts/pylib/twister/twisterlib/config_parser.py" = [
     "B028",     # https://docs.astral.sh/ruff/rules/no-explicit-stacklevel
     "B904",     # https://docs.astral.sh/ruff/rules/raise-without-from-inside-except
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
     "SIM401",   # https://docs.astral.sh/ruff/rules/if-else-block-instead-of-dict-get
     "UP007",    # https://docs.astral.sh/ruff/rules/non-pep604-annotation
     "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
@@ -778,7 +776,6 @@
     "B905",     # https://docs.astral.sh/ruff/rules/zip-without-explicit-strict
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
     "F541",     # https://docs.astral.sh/ruff/rules/f-string-missing-placeholders
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
     "SIM105",   # https://docs.astral.sh/ruff/rules/suppressible-exception
     "UP015",    # https://docs.astral.sh/ruff/rules/redundant-open-modes
     "UP022",    # https://docs.astral.sh/ruff/rules/replace-stdout-stderr
@@ -788,7 +785,6 @@
 "./scripts/pylib/twister/twisterlib/environment.py" = [
     "B006",     # https://docs.astral.sh/ruff/rules/mutable-argument-default
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
     "SIM118",   # https://docs.astral.sh/ruff/rules/in-dict-keys
     "UP006",    # https://docs.astral.sh/ruff/rules/non-pep585-annotation
     "UP021",    # https://docs.astral.sh/ruff/rules/replace-universal-newlines
@@ -797,7 +793,6 @@
 "./scripts/pylib/twister/twisterlib/handlers.py" = [
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
     "F541",     # https://docs.astral.sh/ruff/rules/f-string-missing-placeholders
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
     "SIM102",   # https://docs.astral.sh/ruff/rules/collapsible-if
     "SIM105",   # https://docs.astral.sh/ruff/rules/suppressible-exception
     "SIM114",   # https://docs.astral.sh/ruff/rules/if-with-same-arms
@@ -812,7 +807,6 @@
 "./scripts/pylib/twister/twisterlib/hardwaremap.py" = [
     "B006",     # https://docs.astral.sh/ruff/rules/mutable-argument-default
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
     "SIM118",   # https://docs.astral.sh/ruff/rules/in-dict-keys
     "UP004",    # https://docs.astral.sh/ruff/rules/useless-object-inheritance
     "UP015",    # https://docs.astral.sh/ruff/rules/redundant-open-modes
@@ -825,7 +819,6 @@
     "E713",     # https://docs.astral.sh/ruff/rules/not-in-test
     "F541",     # https://docs.astral.sh/ruff/rules/f-string-missing-placeholders
     "F811",     # https://docs.astral.sh/ruff/rules/redefined-while-unused
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
     "SIM102",   # https://docs.astral.sh/ruff/rules/collapsible-if
     "SIM300",   # https://docs.astral.sh/ruff/rules/yoda-conditions
     "UP008",    # https://docs.astral.sh/ruff/rules/super-call-with-parameters
@@ -840,18 +833,15 @@
     "UP004",    # https://docs.astral.sh/ruff/rules/useless-object-inheritance
 ]
 "./scripts/pylib/twister/twisterlib/package.py" = [
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
     "UP015",    # https://docs.astral.sh/ruff/rules/redundant-open-modes
 ]
 "./scripts/pylib/twister/twisterlib/platform.py" = [
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
     "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
 ]
 "./scripts/pylib/twister/twisterlib/quarantine.py" = [
     "B006",     # https://docs.astral.sh/ruff/rules/mutable-argument-default
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
     "SIM110",   # https://docs.astral.sh/ruff/rules/reimplemented-builtin
     "UP015",    # https://docs.astral.sh/ruff/rules/redundant-open-modes
     "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
@@ -859,7 +849,6 @@
 "./scripts/pylib/twister/twisterlib/reports.py" = [
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
     "F541",     # https://docs.astral.sh/ruff/rules/f-string-missing-placeholders
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
     "UP015",    # https://docs.astral.sh/ruff/rules/redundant-open-modes
     "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
     "UP032",    # https://docs.astral.sh/ruff/rules/f-string
@@ -869,7 +858,6 @@
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
     "E713",     # https://docs.astral.sh/ruff/rules/not-in-test
     "F541",     # https://docs.astral.sh/ruff/rules/f-string-missing-placeholders
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
     "SIM102",   # https://docs.astral.sh/ruff/rules/collapsible-if
     "SIM115",   # https://docs.astral.sh/ruff/rules/open-file-with-context-handler
     "SIM201",   # https://docs.astral.sh/ruff/rules/negate-equal-op
@@ -882,20 +870,17 @@
 ]
 "./scripts/pylib/twister/twisterlib/size_calc.py" = [
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
     "UP006",    # https://docs.astral.sh/ruff/rules/non-pep585-annotation
     "UP015",    # https://docs.astral.sh/ruff/rules/redundant-open-modes
     "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
 ]
 "./scripts/pylib/twister/twisterlib/statuses.py" = [
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
     "SIM401",   # https://docs.astral.sh/ruff/rules/if-else-block-instead-of-dict-get
 ]
 "./scripts/pylib/twister/twisterlib/testinstance.py" = [
     "B006",     # https://docs.astral.sh/ruff/rules/mutable-argument-default
     "B904",     # https://docs.astral.sh/ruff/rules/raise-without-from-inside-except
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
     "SIM102",   # https://docs.astral.sh/ruff/rules/collapsible-if
     "UP015",    # https://docs.astral.sh/ruff/rules/redundant-open-modes
     "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
@@ -910,7 +895,6 @@
     "E741",     # https://docs.astral.sh/ruff/rules/ambiguous-variable-name
     "F401",     # https://docs.astral.sh/ruff/rules/unused-import
     "F541",     # https://docs.astral.sh/ruff/rules/f-string-missing-placeholders
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
     "SIM102",   # https://docs.astral.sh/ruff/rules/collapsible-if
     "SIM110",   # https://docs.astral.sh/ruff/rules/reimplemented-builtin
     "SIM118",   # https://docs.astral.sh/ruff/rules/in-dict-keys
@@ -923,14 +907,12 @@
     "B006",     # https://docs.astral.sh/ruff/rules/mutable-argument-default
     "B904",     # https://docs.astral.sh/ruff/rules/raise-without-from-inside-except
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
     "UP006",    # https://docs.astral.sh/ruff/rules/non-pep585-annotation
     "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
     "UP032",    # https://docs.astral.sh/ruff/rules/f-string
 ]
 "./scripts/pylib/twister/twisterlib/twister_main.py" = [
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
     "UP015",    # https://docs.astral.sh/ruff/rules/redundant-open-modes
     "UP032",    # https://docs.astral.sh/ruff/rules/f-string
 ]

--- a/.ruff-excludes.toml
+++ b/.ruff-excludes.toml
@@ -763,7 +763,6 @@
     "UP032",    # https://docs.astral.sh/ruff/rules/f-string
 ]
 "./scripts/pylib/twister/twisterlib/config_parser.py" = [
-    "B028",     # https://docs.astral.sh/ruff/rules/no-explicit-stacklevel
     "UP007",    # https://docs.astral.sh/ruff/rules/non-pep604-annotation
     "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
 ]

--- a/.ruff-excludes.toml
+++ b/.ruff-excludes.toml
@@ -770,7 +770,6 @@
 "./scripts/pylib/twister/twisterlib/coverage.py" = [
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
     "F541",     # https://docs.astral.sh/ruff/rules/f-string-missing-placeholders
-    "SIM105",   # https://docs.astral.sh/ruff/rules/suppressible-exception
     "UP015",    # https://docs.astral.sh/ruff/rules/redundant-open-modes
     "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
     "UP032",    # https://docs.astral.sh/ruff/rules/f-string
@@ -782,7 +781,6 @@
 "./scripts/pylib/twister/twisterlib/handlers.py" = [
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
     "F541",     # https://docs.astral.sh/ruff/rules/f-string-missing-placeholders
-    "SIM105",   # https://docs.astral.sh/ruff/rules/suppressible-exception
     "SIM115",   # https://docs.astral.sh/ruff/rules/open-file-with-context-handler
     "UP007",    # https://docs.astral.sh/ruff/rules/non-pep604-annotation
     "UP015",    # https://docs.astral.sh/ruff/rules/redundant-open-modes

--- a/.ruff-excludes.toml
+++ b/.ruff-excludes.toml
@@ -764,7 +764,6 @@
 ]
 "./scripts/pylib/twister/twisterlib/config_parser.py" = [
     "B028",     # https://docs.astral.sh/ruff/rules/no-explicit-stacklevel
-    "B904",     # https://docs.astral.sh/ruff/rules/raise-without-from-inside-except
     "UP007",    # https://docs.astral.sh/ruff/rules/non-pep604-annotation
     "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
 ]
@@ -799,7 +798,6 @@
     "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
 ]
 "./scripts/pylib/twister/twisterlib/harness.py" = [
-    "B904",     # https://docs.astral.sh/ruff/rules/raise-without-from-inside-except
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
     "F541",     # https://docs.astral.sh/ruff/rules/f-string-missing-placeholders
     "F811",     # https://docs.astral.sh/ruff/rules/redefined-while-unused
@@ -843,7 +841,6 @@
 ]
 "./scripts/pylib/twister/twisterlib/testinstance.py" = [
     "B006",     # https://docs.astral.sh/ruff/rules/mutable-argument-default
-    "B904",     # https://docs.astral.sh/ruff/rules/raise-without-from-inside-except
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
     "UP015",    # https://docs.astral.sh/ruff/rules/redundant-open-modes
     "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
@@ -851,7 +848,6 @@
 "./scripts/pylib/twister/twisterlib/testplan.py" = [
     "B006",     # https://docs.astral.sh/ruff/rules/mutable-argument-default
     "B023",     # https://docs.astral.sh/ruff/rules/function-uses-loop-variable
-    "B904",     # https://docs.astral.sh/ruff/rules/raise-without-from-inside-except
     "E402",     # https://docs.astral.sh/ruff/rules/module-import-not-at-top-of-file
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
     "F401",     # https://docs.astral.sh/ruff/rules/unused-import
@@ -862,7 +858,6 @@
 ]
 "./scripts/pylib/twister/twisterlib/testsuite.py" = [
     "B006",     # https://docs.astral.sh/ruff/rules/mutable-argument-default
-    "B904",     # https://docs.astral.sh/ruff/rules/raise-without-from-inside-except
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
     "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
     "UP032",    # https://docs.astral.sh/ruff/rules/f-string

--- a/.ruff-excludes.toml
+++ b/.ruff-excludes.toml
@@ -789,7 +789,6 @@
 "./scripts/pylib/twister/twisterlib/harness.py" = [
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
     "F541",     # https://docs.astral.sh/ruff/rules/f-string-missing-placeholders
-    "F811",     # https://docs.astral.sh/ruff/rules/redefined-while-unused
     "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
     "UP032",    # https://docs.astral.sh/ruff/rules/f-string
 ]

--- a/.ruff-excludes.toml
+++ b/.ruff-excludes.toml
@@ -748,7 +748,6 @@
 ]
 "./scripts/pylib/twister/expr_parser.py" = [
     "SIM103",   # https://docs.astral.sh/ruff/rules/needless-bool
-    "SIM115",   # https://docs.astral.sh/ruff/rules/open-file-with-context-handler
     "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
 ]
 "./scripts/pylib/twister/scl.py" = [
@@ -778,7 +777,6 @@
 "./scripts/pylib/twister/twisterlib/handlers.py" = [
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
     "F541",     # https://docs.astral.sh/ruff/rules/f-string-missing-placeholders
-    "SIM115",   # https://docs.astral.sh/ruff/rules/open-file-with-context-handler
     "UP007",    # https://docs.astral.sh/ruff/rules/non-pep604-annotation
     "UP030",    # https://docs.astral.sh/ruff/rules/format-literals
     "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
@@ -812,7 +810,6 @@
 "./scripts/pylib/twister/twisterlib/runner.py" = [
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
     "F541",     # https://docs.astral.sh/ruff/rules/f-string-missing-placeholders
-    "SIM115",   # https://docs.astral.sh/ruff/rules/open-file-with-context-handler
     "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
     "UP032",    # https://docs.astral.sh/ruff/rules/f-string
 ]

--- a/scripts/pylib/twister/twisterlib/cmakecache.py
+++ b/scripts/pylib/twister/twisterlib/cmakecache.py
@@ -7,6 +7,7 @@
 import re
 from collections import OrderedDict
 
+
 class CMakeCacheEntry:
     '''Represents a CMake cache entry.
 

--- a/scripts/pylib/twister/twisterlib/cmakecache.py
+++ b/scripts/pylib/twister/twisterlib/cmakecache.py
@@ -52,7 +52,10 @@ class CMakeCacheEntry:
         val = val.upper()
         if val in ('ON', 'YES', 'TRUE', 'Y'):
             return 1
-        elif val in ('OFF', 'NO', 'FALSE', 'N', 'IGNORE', 'NOTFOUND', '') or val.endswith('-NOTFOUND'):
+        elif (
+            val in ('OFF', 'NO', 'FALSE', 'N', 'IGNORE', 'NOTFOUND', '')
+            or val.endswith('-NOTFOUND')
+        ):
             return 0
         else:
             try:

--- a/scripts/pylib/twister/twisterlib/cmakecache.py
+++ b/scripts/pylib/twister/twisterlib/cmakecache.py
@@ -59,7 +59,7 @@ class CMakeCacheEntry:
                 v = int(val)
                 return v != 0
             except ValueError as exc:
-                raise ValueError('invalid bool {}'.format(val)) from exc
+                raise ValueError(f'invalid bool {val}') from exc
 
     @classmethod
     def from_line(cls, line, line_no):
@@ -81,7 +81,7 @@ class CMakeCacheEntry:
             try:
                 value = cls._to_bool(value)
             except ValueError as exc:
-                args = exc.args + ('on line {}: {}'.format(line_no, line),)
+                args = exc.args + (f'on line {line_no}: {line}',)
                 raise ValueError(args) from exc
         # If the value is a CMake list (i.e. is a string which contains a ';'),
         # convert to a Python list.

--- a/scripts/pylib/twister/twisterlib/cmakecache.py
+++ b/scripts/pylib/twister/twisterlib/cmakecache.py
@@ -52,9 +52,7 @@ class CMakeCacheEntry:
         val = val.upper()
         if val in ('ON', 'YES', 'TRUE', 'Y'):
             return 1
-        elif val in ('OFF', 'NO', 'FALSE', 'N', 'IGNORE', 'NOTFOUND', ''):
-            return 0
-        elif val.endswith('-NOTFOUND'):
+        elif val in ('OFF', 'NO', 'FALSE', 'N', 'IGNORE', 'NOTFOUND', '') or val.endswith('-NOTFOUND'):
             return 0
         else:
             try:

--- a/scripts/pylib/twister/twisterlib/cmakecache.py
+++ b/scripts/pylib/twister/twisterlib/cmakecache.py
@@ -83,11 +83,10 @@ class CMakeCacheEntry:
             except ValueError as exc:
                 args = exc.args + ('on line {}: {}'.format(line_no, line),)
                 raise ValueError(args) from exc
-        elif type_ in ['STRING', 'INTERNAL']:
-            # If the value is a CMake list (i.e. is a string which
-            # contains a ';'), convert to a Python list.
-            if ';' in value:
-                value = value.split(';')
+        # If the value is a CMake list (i.e. is a string which contains a ';'),
+        # convert to a Python list.
+        elif type_ in ['STRING', 'INTERNAL'] and ';' in value:
+            value = value.split(';')
 
         return CMakeCacheEntry(name, value)
 

--- a/scripts/pylib/twister/twisterlib/cmakecache.py
+++ b/scripts/pylib/twister/twisterlib/cmakecache.py
@@ -112,7 +112,7 @@ class CMakeCache:
 
     def load(self, cache_file):
         entries = []
-        with open(cache_file, 'r') as cache:
+        with open(cache_file) as cache:
             for line_no, line in enumerate(cache):
                 entry = CMakeCacheEntry.from_line(line, line_no)
                 if entry:

--- a/scripts/pylib/twister/twisterlib/config_parser.py
+++ b/scripts/pylib/twister/twisterlib/config_parser.py
@@ -248,10 +248,7 @@ class TwisterConfigParser:
 
         for k, kinfo in self.testsuite_valid_keys.items():
             if k not in d:
-                if "required" in kinfo:
-                    required = kinfo["required"]
-                else:
-                    required = False
+                required = kinfo.get("required", False)
 
                 if required:
                     raise ConfigurationError(

--- a/scripts/pylib/twister/twisterlib/config_parser.py
+++ b/scripts/pylib/twister/twisterlib/config_parser.py
@@ -267,6 +267,7 @@ class TwisterConfigParser:
                 except ValueError:
                     raise ConfigurationError(
                         self.filename, "bad %s value '%s' for key '%s' in name '%s'" %
-                                       (kinfo["type"], d[k], k, name))
+                                       (kinfo["type"], d[k], k, name)
+                    ) from None
 
         return d

--- a/scripts/pylib/twister/twisterlib/config_parser.py
+++ b/scripts/pylib/twister/twisterlib/config_parser.py
@@ -4,10 +4,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import copy
-import scl
 import warnings
 from typing import Union
+
+import scl
 from twisterlib.error import ConfigurationError
+
 
 def extract_fields_from_arg_list(target_fields: set, arg_list: Union[str, list]):
     """

--- a/scripts/pylib/twister/twisterlib/config_parser.py
+++ b/scripts/pylib/twister/twisterlib/config_parser.py
@@ -130,7 +130,9 @@ class TwisterConfigParser:
                 if len(vs) > 1:
                     warnings.warn(
                         "Space-separated lists are deprecated, use YAML lists instead",
-                        DeprecationWarning)
+                        DeprecationWarning,
+                        stacklevel=2
+                    )
 
                 if len(typestr) > 4 and typestr[4] == ":":
                     return [self._cast_value(vsi, typestr[5:]) for vsi in vs]
@@ -148,7 +150,9 @@ class TwisterConfigParser:
                 if len(vs) > 1:
                     warnings.warn(
                         "Space-separated lists are deprecated, use YAML lists instead",
-                        DeprecationWarning)
+                        DeprecationWarning,
+                        stacklevel=2
+                    )
 
                 if len(typestr) > 3 and typestr[3] == ":":
                     return {self._cast_value(vsi, typestr[4:]) for vsi in vs}
@@ -243,7 +247,8 @@ class TwisterConfigParser:
                 "in extra_args. This feature is deprecated and will soon "
                 "result in an error. Use extra_conf_files, extra_overlay_confs "
                 "or extra_dtc_overlay_files YAML fields instead",
-                DeprecationWarning
+                DeprecationWarning,
+                stacklevel=2
             )
 
         for k, kinfo in self.testsuite_valid_keys.items():

--- a/scripts/pylib/twister/twisterlib/config_parser.py
+++ b/scripts/pylib/twister/twisterlib/config_parser.py
@@ -164,8 +164,7 @@ class TwisterConfigParser:
         elif typestr.startswith("map"):
             return value
         else:
-            raise ConfigurationError(
-                self.filename, "unknown type '%s'" % value)
+            raise ConfigurationError(self.filename, f"unknown type '{value}'")
 
     def get_scenario(self, name):
         """Get a dictionary representing the keys/values within a scenario
@@ -199,7 +198,7 @@ class TwisterConfigParser:
                 )
             if k in d:
                 if k == "filter":
-                    d[k] = "(%s) and (%s)" % (d[k], v)
+                    d[k] = f"({d[k]}) and ({v})"
                 elif k not in ("extra_conf_files", "extra_overlay_confs",
                                "extra_dtc_overlay_files"):
                     if isinstance(d[k], str) and isinstance(v, list):
@@ -258,8 +257,8 @@ class TwisterConfigParser:
                 if required:
                     raise ConfigurationError(
                         self.filename,
-                        "missing required value for '%s' in test '%s'" %
-                        (k, name))
+                        f"missing required value for '{k}' in test '{name}'"
+                    )
                 else:
                     if "default" in kinfo:
                         default = kinfo["default"]
@@ -271,8 +270,8 @@ class TwisterConfigParser:
                     d[k] = self._cast_value(d[k], kinfo["type"])
                 except ValueError:
                     raise ConfigurationError(
-                        self.filename, "bad %s value '%s' for key '%s' in name '%s'" %
-                                       (kinfo["type"], d[k], k, name)
+                        self.filename,
+                        f"bad {kinfo['type']} value '{d[k]}' for key '{k}' in name '{name}'"
                     ) from None
 
         return d

--- a/scripts/pylib/twister/twisterlib/config_parser.py
+++ b/scripts/pylib/twister/twisterlib/config_parser.py
@@ -5,13 +5,12 @@
 
 import copy
 import warnings
-from typing import Union
 
 import scl
 from twisterlib.error import ConfigurationError
 
 
-def extract_fields_from_arg_list(target_fields: set, arg_list: Union[str, list]):
+def extract_fields_from_arg_list(target_fields: set, arg_list: str | list):
     """
     Given a list of "FIELD=VALUE" args, extract values of args with a
     given field name and return the remaining args separately.

--- a/scripts/pylib/twister/twisterlib/coverage.py
+++ b/scripts/pylib/twister/twisterlib/coverage.py
@@ -182,10 +182,12 @@ class Lcov(CoverageTool):
 
     def get_version(self):
         try:
-            result = subprocess.run(['lcov', '--version'],
-                                    stdout=subprocess.PIPE,
-                                    stderr=subprocess.PIPE,
-                                    text=True, check=True)
+            result = subprocess.run(
+                ['lcov', '--version'],
+                capture_output=True,
+                text=True,
+                check=True
+            )
             version_output = result.stdout.strip().replace('lcov: LCOV version ', '')
             return version_output
         except subprocess.CalledProcessError as e:
@@ -293,10 +295,12 @@ class Gcovr(CoverageTool):
 
     def get_version(self):
         try:
-            result = subprocess.run(['gcovr', '--version'],
-                                    stdout=subprocess.PIPE,
-                                    stderr=subprocess.PIPE,
-                                    text=True, check=True)
+            result = subprocess.run(
+                ['gcovr', '--version'],
+                capture_output=True,
+                text=True,
+                check=True
+            )
             version_lines = result.stdout.strip().split('\n')
             if version_lines:
                 version_output = version_lines[0].replace('gcovr ', '')

--- a/scripts/pylib/twister/twisterlib/coverage.py
+++ b/scripts/pylib/twister/twisterlib/coverage.py
@@ -39,7 +39,7 @@ class CoverageTool:
         elif tool == 'gcovr':
             t =  Gcovr()
         else:
-            logger.error("Unsupported coverage tool specified: {}".format(tool))
+            logger.error(f"Unsupported coverage tool specified: {tool}")
             return None
 
         logger.debug(f"Select {tool} as the coverage tool...")
@@ -47,7 +47,7 @@ class CoverageTool:
 
     @staticmethod
     def retrieve_gcov_data(input_file):
-        logger.debug("Working on %s" % input_file)
+        logger.debug(f"Working on {input_file}")
         extracted_coverage_info = {}
         capture_data = False
         capture_complete = False
@@ -125,47 +125,61 @@ class CoverageTool:
                 with open(filename, 'wb') as fp:
                     fp.write(hex_bytes)
             except ValueError:
-                logger.exception("Unable to convert hex data for file: {}".format(filename))
+                logger.exception(f"Unable to convert hex data for file: {filename}")
                 gcda_created = False
             except FileNotFoundError:
-                logger.exception("Unable to create gcda file: {}".format(filename))
+                logger.exception(f"Unable to create gcda file: {filename}")
                 gcda_created = False
         return gcda_created
 
     def generate(self, outdir):
         coverage_completed = True
-        for filename in glob.glob("%s/**/handler.log" % outdir, recursive=True):
+        for filename in glob.glob(f"{outdir}/**/handler.log", recursive=True):
             gcov_data = self.__class__.retrieve_gcov_data(filename)
             capture_complete = gcov_data['complete']
             extracted_coverage_info = gcov_data['data']
             if capture_complete:
                 gcda_created = self.create_gcda_files(extracted_coverage_info)
                 if gcda_created:
-                    logger.debug("Gcov data captured: {}".format(filename))
+                    logger.debug(f"Gcov data captured: {filename}")
                 else:
-                    logger.error("Gcov data invalid for: {}".format(filename))
+                    logger.error(f"Gcov data invalid for: {filename}")
                     coverage_completed = False
             else:
-                logger.error("Gcov data capture incomplete: {}".format(filename))
+                logger.error(f"Gcov data capture incomplete: {filename}")
                 coverage_completed = False
 
         with open(os.path.join(outdir, "coverage.log"), "a") as coveragelog:
             ret = self._generate(outdir, coveragelog)
             if ret == 0:
                 report_log = {
-                    "html": "HTML report generated: {}".format(os.path.join(outdir, "coverage", "index.html")),
-                    "lcov": "LCOV report generated: {}".format(os.path.join(outdir, "coverage.info")),
-                    "xml": "XML report generated: {}".format(os.path.join(outdir, "coverage", "coverage.xml")),
-                    "csv": "CSV report generated: {}".format(os.path.join(outdir, "coverage", "coverage.csv")),
-                    "txt": "TXT report generated: {}".format(os.path.join(outdir, "coverage", "coverage.txt")),
-                    "coveralls": "Coveralls report generated: {}".format(os.path.join(outdir, "coverage", "coverage.coveralls.json")),
-                    "sonarqube": "Sonarqube report generated: {}".format(os.path.join(outdir, "coverage", "coverage.sonarqube.xml"))
+                    "html": "HTML report generated: {}".format(
+                        os.path.join(outdir, "coverage", "index.html")
+                    ),
+                    "lcov": "LCOV report generated: {}".format(
+                        os.path.join(outdir, "coverage.info")
+                    ),
+                    "xml": "XML report generated: {}".format(
+                        os.path.join(outdir, "coverage", "coverage.xml")
+                    ),
+                    "csv": "CSV report generated: {}".format(
+                        os.path.join(outdir, "coverage", "coverage.csv")
+                    ),
+                    "txt": "TXT report generated: {}".format(
+                        os.path.join(outdir, "coverage", "coverage.txt")
+                    ),
+                    "coveralls": "Coveralls report generated: {}".format(
+                        os.path.join(outdir, "coverage", "coverage.coveralls.json")
+                    ),
+                    "sonarqube": "Sonarqube report generated: {}".format(
+                        os.path.join(outdir, "coverage", "coverage.sonarqube.xml")
+                    )
                 }
                 for r in self.output_formats.split(','):
                     logger.info(report_log[r])
             else:
                 coverage_completed = False
-        logger.debug("All coverage data processed: {}".format(coverage_completed))
+        logger.debug(f"All coverage data processed: {coverage_completed}")
         return coverage_completed
 
 

--- a/scripts/pylib/twister/twisterlib/coverage.py
+++ b/scripts/pylib/twister/twisterlib/coverage.py
@@ -51,7 +51,7 @@ class CoverageTool:
         extracted_coverage_info = {}
         capture_data = False
         capture_complete = False
-        with open(input_file, 'r') as fp:
+        with open(input_file) as fp:
             for line in fp.readlines():
                 if re.search("GCOV_COVERAGE_DUMP_START", line):
                     capture_data = True

--- a/scripts/pylib/twister/twisterlib/coverage.py
+++ b/scripts/pylib/twister/twisterlib/coverage.py
@@ -388,13 +388,18 @@ class Gcovr(CoverageTool):
             "xml": ["--xml", os.path.join(subdir, "coverage.xml"), "--xml-pretty"],
             "csv": ["--csv", os.path.join(subdir, "coverage.csv")],
             "txt": ["--txt", os.path.join(subdir, "coverage.txt")],
-            "coveralls": ["--coveralls", os.path.join(subdir, "coverage.coveralls.json"), "--coveralls-pretty"],
+            "coveralls": ["--coveralls", os.path.join(subdir, "coverage.coveralls.json"),
+                          "--coveralls-pretty"],
             "sonarqube": ["--sonarqube", os.path.join(subdir, "coverage.sonarqube.xml")]
         }
-        gcovr_options = self._flatten_list([report_options[r] for r in self.output_formats.split(',')])
+        gcovr_options = self._flatten_list(
+            [report_options[r] for r in self.output_formats.split(',')]
+        )
 
-        return subprocess.call(["gcovr", "-r", self.base_dir] + mode_options + gcovr_options + tracefiles,
-                               stdout=coveragelog)
+        return subprocess.call(
+            ["gcovr", "-r", self.base_dir] \
+                + mode_options + gcovr_options + tracefiles, stdout=coveragelog
+        )
 
 
 
@@ -427,7 +432,9 @@ def run_coverage(testplan, options):
         elif os.path.exists(zephyr_sdk_gcov_tool):
             gcov_tool = zephyr_sdk_gcov_tool
         else:
-            logger.error("Can't find a suitable gcov tool. Use --gcov-tool or set ZEPHYR_SDK_INSTALL_DIR.")
+            logger.error(
+                "Can't find a suitable gcov tool. Use --gcov-tool or set ZEPHYR_SDK_INSTALL_DIR."
+            )
             sys.exit(1)
     else:
         gcov_tool = str(options.gcov_tool)

--- a/scripts/pylib/twister/twisterlib/coverage.py
+++ b/scripts/pylib/twister/twisterlib/coverage.py
@@ -3,6 +3,7 @@
 # Copyright (c) 2018-2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
+import contextlib
 import glob
 import logging
 import os
@@ -114,10 +115,8 @@ class CoverageTool:
             # hence skipping it problem only in gcovr v4.1
             if "kobject_hash" in filename:
                 filename = (filename[:-4]) + "gcno"
-                try:
+                with contextlib.suppress(Exception):
                     os.remove(filename)
-                except Exception:
-                    pass
                 continue
 
             try:

--- a/scripts/pylib/twister/twisterlib/coverage.py
+++ b/scripts/pylib/twister/twisterlib/coverage.py
@@ -3,14 +3,14 @@
 # Copyright (c) 2018-2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-import sys
-import os
+import glob
 import logging
+import os
 import pathlib
+import re
 import shutil
 import subprocess
-import glob
-import re
+import sys
 import tempfile
 
 logger = logging.getLogger('twister')

--- a/scripts/pylib/twister/twisterlib/coverage.py
+++ b/scripts/pylib/twister/twisterlib/coverage.py
@@ -413,7 +413,7 @@ def run_coverage(testplan, options):
         elif os.path.exists(zephyr_sdk_gcov_tool):
             gcov_tool = zephyr_sdk_gcov_tool
         else:
-            logger.error(f"Can't find a suitable gcov tool. Use --gcov-tool or set ZEPHYR_SDK_INSTALL_DIR.")
+            logger.error("Can't find a suitable gcov tool. Use --gcov-tool or set ZEPHYR_SDK_INSTALL_DIR.")
             sys.exit(1)
     else:
         gcov_tool = str(options.gcov_tool)

--- a/scripts/pylib/twister/twisterlib/coverage.py
+++ b/scripts/pylib/twister/twisterlib/coverage.py
@@ -98,7 +98,7 @@ class CoverageTool:
 
             # Iteratively call gcov-tool (not gcov) to merge the files
             merge_tool = self.gcov_tool + '-tool'
-            for d1, d2 in zip(dirs[:-1], dirs[1:]):
+            for d1, d2 in zip(dirs[:-1], dirs[1:], strict=False):
                 cmd = [merge_tool, 'merge', d1, d2, '--output', d2]
                 subprocess.call(cmd)
 

--- a/scripts/pylib/twister/twisterlib/environment.py
+++ b/scripts/pylib/twister/twisterlib/environment.py
@@ -1022,7 +1022,7 @@ class TwisterEnv:
             return diff
         dict_options = vars(self.options)
         dict_default = vars(self.default_options)
-        for k in dict_options.keys():
+        for k in dict_options:
             if k not in dict_default or dict_options[k] != dict_default[k]:
                 diff[k] = dict_options[k]
         return diff

--- a/scripts/pylib/twister/twisterlib/environment.py
+++ b/scripts/pylib/twister/twisterlib/environment.py
@@ -1036,7 +1036,7 @@ class TwisterEnv:
         try:
             subproc = subprocess.run(["git", "describe", "--abbrev=12", "--always"],
                                      stdout=subprocess.PIPE,
-                                     universal_newlines=True,
+                                     text=True,
                                      cwd=ZEPHYR_BASE)
             if subproc.returncode == 0:
                 _version = subproc.stdout.strip()
@@ -1052,7 +1052,7 @@ class TwisterEnv:
         try:
             subproc = subprocess.run(["git", "show", "-s", "--format=%cI", "HEAD"],
                                         stdout=subprocess.PIPE,
-                                        universal_newlines=True,
+                                        text=True,
                                         cwd=ZEPHYR_BASE)
             if subproc.returncode == 0:
                 self.commit_date = subproc.stdout.strip()

--- a/scripts/pylib/twister/twisterlib/environment.py
+++ b/scripts/pylib/twister/twisterlib/environment.py
@@ -119,15 +119,18 @@ Artificially long but functional example:
         "--save-tests",
         metavar="FILENAME",
         action="store",
-        help="Write a list of tests and platforms to be run to %(metavar)s file and stop execution. "
-             "The resulting file will have the same content as 'testplan.json'.")
+        help="Write a list of tests and platforms to be run to %(metavar)s file and stop execution."
+             " The resulting file will have the same content as 'testplan.json'."
+    )
 
     case_select.add_argument(
         "-F",
         "--load-tests",
         metavar="FILENAME",
         action="store",
-        help="Load a list of tests and platforms to be run from a JSON file ('testplan.json' schema).")
+        help="Load a list of tests and platforms to be run"
+             "from a JSON file ('testplan.json' schema)."
+    )
 
     case_select.add_argument(
         "-T", "--testsuite-root", action="append", default=[], type = norm_path,
@@ -219,8 +222,12 @@ Artificially long but functional example:
                         """)
 
     test_or_build.add_argument(
-        "-b", "--build-only", action="store_true", default="--prep-artifacts-for-testing" in sys.argv,
-        help="Only build the code, do not attempt to run the code on targets.")
+        "-b",
+        "--build-only",
+        action="store_true",
+        default="--prep-artifacts-for-testing" in sys.argv,
+        help="Only build the code, do not attempt to run the code on targets."
+    )
 
     test_or_build.add_argument(
         "--prep-artifacts-for-testing", action="store_true",
@@ -353,15 +360,23 @@ structure in the main Zephyr tree: boards/<vendor>/<board_name>/""")
     parser.add_argument("--coverage-tool", choices=['lcov', 'gcovr'], default='gcovr',
                         help="Tool to use to generate coverage report.")
 
-    parser.add_argument("--coverage-formats", action="store", default=None, # default behavior is set in run_coverage
-                        help="Output formats to use for generated coverage reports, as a comma-separated list. " +
-                             "Valid options for 'gcovr' tool are: " +
-                             ','.join(supported_coverage_formats['gcovr']) + " (html - default)." +
-                             " Valid options for 'lcov' tool are: " +
-                             ','.join(supported_coverage_formats['lcov']) + " (html,lcov - default).")
+    parser.add_argument(
+        "--coverage-formats",
+        action="store",
+        default=None, # default behavior is set in run_coverage
+        help="Output formats to use for generated coverage reports, as a comma-separated list. " +
+             "Valid options for 'gcovr' tool are: " +
+             ','.join(supported_coverage_formats['gcovr']) + " (html - default)." +
+             " Valid options for 'lcov' tool are: " +
+             ','.join(supported_coverage_formats['lcov']) + " (html,lcov - default)."
+        )
 
-    parser.add_argument("--test-config", action="store", default=os.path.join(ZEPHYR_BASE, "tests", "test_config.yaml"),
-        help="Path to file with plans and test configurations.")
+    parser.add_argument(
+        "--test-config",
+        action="store",
+        default=os.path.join(ZEPHYR_BASE, "tests", "test_config.yaml"),
+        help="Path to file with plans and test configurations."
+    )
 
     parser.add_argument("--level", action="store",
         help="Test level to be used. By default, no levels are used for filtering"
@@ -814,7 +829,12 @@ structure in the main Zephyr tree: boards/<vendor>/<board_name>/""")
     return parser
 
 
-def parse_arguments(parser: argparse.ArgumentParser, args, options = None, on_init=True) -> argparse.Namespace:
+def parse_arguments(
+    parser: argparse.ArgumentParser,
+    args,
+    options = None,
+    on_init=True
+) -> argparse.Namespace:
     if options is None:
         options = parser.parse_args(args)
 
@@ -875,11 +895,19 @@ def parse_arguments(parser: argparse.ArgumentParser, args, options = None, on_in
         logger.error("valgrind enabled but valgrind executable not found")
         sys.exit(1)
 
-    if (not options.device_testing) and (options.device_serial or options.device_serial_pty or options.hardware_map):
-        logger.error("Use --device-testing with --device-serial, or --device-serial-pty, or --hardware-map.")
+    if (
+        (not options.device_testing)
+        and (options.device_serial or options.device_serial_pty or options.hardware_map)
+    ):
+        logger.error(
+            "Use --device-testing with --device-serial, or --device-serial-pty, or --hardware-map."
+        )
         sys.exit(1)
 
-    if options.device_testing and (options.device_serial or options.device_serial_pty) and len(options.platform) != 1:
+    if (
+        options.device_testing
+        and (options.device_serial or options.device_serial_pty) and len(options.platform) != 1
+    ):
         logger.error("When --device-testing is used with --device-serial "
                      "or --device-serial-pty, exactly one platform must "
                      "be specified")

--- a/scripts/pylib/twister/twisterlib/environment.py
+++ b/scripts/pylib/twister/twisterlib/environment.py
@@ -286,8 +286,7 @@ Artificially long but functional example:
 
     # Start of individual args place them in alpha-beta order
 
-    board_root_list = ["%s/boards" % ZEPHYR_BASE,
-                       "%s/subsys/testsuite/boards" % ZEPHYR_BASE]
+    board_root_list = [f"{ZEPHYR_BASE}/boards", f"{ZEPHYR_BASE}/subsys/testsuite/boards"]
 
     modules = zephyr_module.parse_modules(ZEPHYR_BASE)
     for module in modules:
@@ -934,10 +933,10 @@ def parse_arguments(parser: argparse.ArgumentParser, args, options = None, on_in
                 double_dash = len(options.extra_test_args)
             unrecognized = " ".join(options.extra_test_args[0:double_dash])
 
-            logger.error("Unrecognized arguments found: '%s'. Use -- to "
-                         "delineate extra arguments for test binary or pass "
-                         "-h for help.",
-                         unrecognized)
+            logger.error(
+                f"Unrecognized arguments found: '{unrecognized}'."
+                " Use -- to delineate extra arguments for test binary or pass -h for help."
+            )
 
             sys.exit(1)
 
@@ -1065,7 +1064,7 @@ class TwisterEnv:
             args = []
         script = os.fspath(args[0])
 
-        logger.debug("Running cmake script %s", script)
+        logger.debug(f"Running cmake script {script}")
 
         cmake_args = ["-D{}".format(a.replace('"', '')) for a in args[1:]]
         cmake_args.extend(['-P', script])
@@ -1093,12 +1092,12 @@ class TwisterEnv:
         out = strip_ansi_sequences(out.decode())
 
         if p.returncode == 0:
-            msg = "Finished running %s" % (args[0])
+            msg = f"Finished running {args[0]}"
             logger.debug(msg)
             results = {"returncode": p.returncode, "msg": msg, "stdout": out}
 
         else:
-            logger.error("CMake script failure: %s" % (args[0]))
+            logger.error(f"CMake script failure: {args[0]}")
             results = {"returncode": p.returncode, "returnmsg": out}
 
         return results

--- a/scripts/pylib/twister/twisterlib/environment.py
+++ b/scripts/pylib/twister/twisterlib/environment.py
@@ -1060,7 +1060,9 @@ class TwisterEnv:
             logger.exception("Failure while reading head commit date.")
 
     @staticmethod
-    def run_cmake_script(args=[]):
+    def run_cmake_script(args=None):
+        if args is None:
+            args = []
         script = os.fspath(args[0])
 
         logger.debug("Running cmake script %s", script)

--- a/scripts/pylib/twister/twisterlib/environment.py
+++ b/scripts/pylib/twister/twisterlib/environment.py
@@ -18,7 +18,7 @@ import sys
 from datetime import datetime, timezone
 from importlib import metadata
 from pathlib import Path
-from typing import Generator, List
+from collections.abc import Generator
 
 from twisterlib.constants import SUPPORTED_SIMS
 from twisterlib.coverage import supported_coverage_formats
@@ -59,7 +59,7 @@ def python_version_guard():
         sys.exit(1)
 
 
-installed_packages: List[str] = list(_get_installed_packages())
+installed_packages: list[str] = list(_get_installed_packages())
 PYTEST_PLUGIN_INSTALLED = 'pytest-twister-harness' in installed_packages
 
 

--- a/scripts/pylib/twister/twisterlib/environment.py
+++ b/scripts/pylib/twister/twisterlib/environment.py
@@ -22,20 +22,16 @@ from typing import Generator, List
 
 from twisterlib.constants import SUPPORTED_SIMS
 from twisterlib.coverage import supported_coverage_formats
+from twisterlib.error import TwisterRuntimeError
+from twisterlib.log_helper import log_command
+import zephyr_module
 
 logger = logging.getLogger('twister')
 logger.setLevel(logging.DEBUG)
 
-from twisterlib.error import TwisterRuntimeError
-from twisterlib.log_helper import log_command
-
 ZEPHYR_BASE = os.getenv("ZEPHYR_BASE")
 if not ZEPHYR_BASE:
     sys.exit("$ZEPHYR_BASE environment variable undefined")
-
-sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts/"))
-
-import zephyr_module
 
 # Use this for internal comparisons; that's what canonicalization is
 # for. Don't use it when invoking other components of the build system

--- a/scripts/pylib/twister/twisterlib/environment.py
+++ b/scripts/pylib/twister/twisterlib/environment.py
@@ -15,16 +15,16 @@ import re
 import shutil
 import subprocess
 import sys
+from collections.abc import Generator
 from datetime import datetime, timezone
 from importlib import metadata
 from pathlib import Path
-from collections.abc import Generator
 
+import zephyr_module
 from twisterlib.constants import SUPPORTED_SIMS
 from twisterlib.coverage import supported_coverage_formats
 from twisterlib.error import TwisterRuntimeError
 from twisterlib.log_helper import log_command
-import zephyr_module
 
 logger = logging.getLogger('twister')
 logger.setLevel(logging.DEBUG)

--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -137,7 +137,7 @@ class Handler:
         self.instance.execution_time = handler_time
         for tc in self.instance.testcases:
             tc.status = TwisterStatus.FAIL
-        self.instance.reason = f"Testsuite mismatch"
+        self.instance.reason = "Testsuite mismatch"
         logger.debug("Test suite names were not printed or some of them in " \
                      "output do not correspond with expected: %s",
                      str(expected_suite_names))

--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -123,8 +123,10 @@ class Handler:
             return
         # compare the expect and detect from end one by one without order
         _d_suite = detected_suite_names[-len(expected_suite_names):]
-        if set(_d_suite) != set(expected_suite_names):
-            if not set(_d_suite).issubset(set(expected_suite_names)):
+        if (
+            set(_d_suite) != set(expected_suite_names)
+            and not set(_d_suite).issubset(set(expected_suite_names))
+        ):
                 self._missing_suite_name(expected_suite_names, handler_time)
 
     def _missing_suite_name(self, expected_suite_names, handler_time):
@@ -221,13 +223,16 @@ class BinaryHandler(Handler):
                     log_out_fp.write(strip_ansi_sequences(line_decoded))
                     log_out_fp.flush()
                     harness.handle(stripped_line)
-                    if harness.status != TwisterStatus.NONE:
-                        if not timeout_extended or harness.capture_coverage:
-                            timeout_extended = True
-                            if harness.capture_coverage:
-                                timeout_time = time.time() + 30
-                            else:
-                                timeout_time = time.time() + 2
+                    if (
+                        harness.status != TwisterStatus.NONE
+                        and not timeout_extended
+                        or harness.capture_coverage
+                    ):
+                        timeout_extended = True
+                        if harness.capture_coverage:
+                            timeout_time = time.time() + 30
+                        else:
+                            timeout_time = time.time() + 2
                 else:
                     reader_t.join(0)
                     break
@@ -455,10 +460,9 @@ class DeviceHandler(Handler):
                         logger.debug("DEVICE: {0}".format(sl))
                         harness.handle(sl)
 
-            if harness.status != TwisterStatus.NONE:
-                if not harness.capture_coverage:
-                    ser.close()
-                    break
+            if harness.status != TwisterStatus.NONE and not harness.capture_coverage:
+                ser.close()
+                break
 
         log_out_fp.close()
 

--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -554,10 +554,7 @@ class DeviceHandler(Handler):
                     if runner in ("pyocd", "nrfjprog", "nrfutil"):
                         command_extra_args.append("--dev-id")
                         command_extra_args.append(board_id)
-                    elif runner == "openocd" and product == "STM32 STLink":
-                        command_extra_args.append("--cmd-pre-init")
-                        command_extra_args.append("hla_serial %s" % board_id)
-                    elif runner == "openocd" and product == "STLINK-V3":
+                    elif runner == "openocd" and product == "STM32 STLink" or runner == "openocd" and product == "STLINK-V3":
                         command_extra_args.append("--cmd-pre-init")
                         command_extra_args.append("hla_serial %s" % board_id)
                     elif runner == "openocd" and product == "EDBG CMSIS-DAP":

--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -116,7 +116,7 @@ class Handler:
         logger.debug(f"Expected suite names:{expected_suite_names}")
         logger.debug(f"Detected suite names:{detected_suite_names}")
         if not expected_suite_names or \
-                not harness_status == TwisterStatus.PASS:
+                harness_status != TwisterStatus.PASS:
             return
         if not detected_suite_names:
             self._missing_suite_name(expected_suite_names, handler_time)

--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -11,7 +11,6 @@ import argparse
 import logging
 import math
 import os
-import psutil
 import re
 import select
 import shlex
@@ -20,15 +19,16 @@ import subprocess
 import sys
 import threading
 import time
-
 from contextlib import contextmanager
 from pathlib import Path
-from queue import Queue, Empty
+from queue import Empty, Queue
+from typing import Optional
+
+import psutil
 from twisterlib.environment import ZEPHYR_BASE, strip_ansi_sequences
 from twisterlib.error import TwisterException
 from twisterlib.platform import Platform
 from twisterlib.statuses import TwisterStatus
-from typing import Optional
 
 sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts/pylib/build_helpers"))
 from domains import Domains

--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -138,9 +138,10 @@ class Handler:
         for tc in self.instance.testcases:
             tc.status = TwisterStatus.FAIL
         self.instance.reason = "Testsuite mismatch"
-        logger.debug("Test suite names were not printed or some of them in " \
-                     "output do not correspond with expected: %s",
-                     str(expected_suite_names))
+        logger.debug(
+            "Test suite names were not printed or some of them in output"
+            f" do not correspond with expected: {str(expected_suite_names)}",
+        )
 
     def _final_handle_actions(self, harness, handler_time):
 
@@ -166,7 +167,7 @@ class Handler:
             # have added any additional images to the run target manually
             domain_path = os.path.join(self.build_dir, "domains.yaml")
             domains = Domains.from_file(domain_path)
-            logger.debug("Loaded sysbuild domain data from %s" % domain_path)
+            logger.debug(f"Loaded sysbuild domain data from {domain_path}")
             build_dir = domains.get_default_domain().build_dir
         else:
             build_dir = self.build_dir
@@ -217,7 +218,7 @@ class BinaryHandler(Handler):
                     stripped_line = line_decoded.rstrip()
                     if stripped_line.endswith(suffix):
                         stripped_line = stripped_line[:-len(suffix)].rstrip()
-                    logger.debug("OUTPUT: %s", stripped_line)
+                    logger.debug(f"OUTPUT: {stripped_line}")
                     log_out_fp.write(strip_ansi_sequences(line_decoded))
                     log_out_fp.flush()
                     harness.handle(stripped_line)
@@ -343,10 +344,10 @@ class BinaryHandler(Handler):
             harness.run_robot_test(command, self)
             return
 
-        stderr_log = "{}/handler_stderr.log".format(self.instance.build_dir)
+        stderr_log = f"{self.instance.build_dir}/handler_stderr.log"
         with open(stderr_log, "w+") as stderr_log_fp, subprocess.Popen(command, stdout=subprocess.PIPE,
                               stderr=stderr_log_fp, cwd=self.build_dir, env=env) as proc:
-            logger.debug("Spawning BinaryHandler Thread for %s" % self.name)
+            logger.debug(f"Spawning BinaryHandler Thread for {self.name}")
             t = threading.Thread(target=self._output_handler, args=(proc, harness,), daemon=True)
             t.start()
             t.join()
@@ -357,7 +358,7 @@ class BinaryHandler(Handler):
             self.returncode = proc.returncode
             if proc.returncode != 0:
                 self.instance.status = TwisterStatus.ERROR
-                self.instance.reason = "BinaryHandler returned {}".format(proc.returncode)
+                self.instance.reason = f"BinaryHandler returned {proc.returncode}"
             self.try_kill_process_by_pid()
 
         handler_time = time.time() - start_time
@@ -521,7 +522,7 @@ class DeviceHandler(Handler):
             except subprocess.TimeoutExpired:
                 proc.kill()
                 proc.communicate()
-                logger.error("{} timed out".format(script))
+                logger.error(f"{script} timed out")
 
     def _create_command(self, runner, hardware):
         if (self.options.west_flash is not None) or runner:
@@ -550,13 +551,13 @@ class DeviceHandler(Handler):
                         command_extra_args.append(board_id)
                     elif runner == "openocd" and product == "STM32 STLink" or runner == "openocd" and product == "STLINK-V3":
                         command_extra_args.append("--cmd-pre-init")
-                        command_extra_args.append("hla_serial %s" % board_id)
+                        command_extra_args.append(f"hla_serial {board_id}")
                     elif runner == "openocd" and product == "EDBG CMSIS-DAP":
                         command_extra_args.append("--cmd-pre-init")
-                        command_extra_args.append("cmsis_dap_serial %s" % board_id)
+                        command_extra_args.append(f"cmsis_dap_serial {board_id}")
                     elif runner == "openocd" and product == "LPC-LINK2 CMSIS-DAP":
                         command_extra_args.append("--cmd-pre-init")
-                        command_extra_args.append("adapter serial %s" % board_id)
+                        command_extra_args.append(f"adapter serial {board_id}")
                     elif runner == "jlink":
                         command.append("--dev-id")
                         command.append(board_id)
@@ -564,9 +565,9 @@ class DeviceHandler(Handler):
                         # for linkserver
                         # --probe=#<number> select by probe index
                         # --probe=<serial number> select by probe serial number
-                        command.append("--probe=%s" % board_id)
+                        command.append(f"--probe={board_id}")
                     elif runner == "stm32cubeprogrammer":
-                        command.append("--tool-opt=sn=%s" % board_id)
+                        command.append(f"--tool-opt=sn={board_id}")
 
                     # Receive parameters from runner_params field.
                     if hardware.runner_params:
@@ -627,7 +628,7 @@ class DeviceHandler(Handler):
     def _handle_serial_exception(self, exception, dut, serial_pty, ser_pty_process):
         self.instance.status = TwisterStatus.FAIL
         self.instance.reason = "Serial Device Error"
-        logger.error("Serial device error: %s" % (str(exception)))
+        logger.error(f"Serial device error: {exception!s}")
 
         self.instance.add_missing_case_status(TwisterStatus.BLOCK, "Serial Device Error")
         if serial_pty and ser_pty_process:
@@ -666,10 +667,7 @@ class DeviceHandler(Handler):
                 )
             except subprocess.CalledProcessError as error:
                 logger.error(
-                    "Failed to run subprocess {}, error {}".format(
-                        serial_pty,
-                        error.output
-                    )
+                    f"Failed to run subprocess {serial_pty}, error {error.output}"
                 )
                 return
 
@@ -734,8 +732,8 @@ class DeviceHandler(Handler):
         start_time = time.time()
         t.start()
 
-        d_log = "{}/device.log".format(self.instance.build_dir)
-        logger.debug('Flash command: %s', command)
+        d_log = f"{self.instance.build_dir}/device.log"
+        logger.debug(f'Flash command: {command}', )
         flash_error = False
         try:
             stdout = stderr = None
@@ -797,7 +795,7 @@ class DeviceHandler(Handler):
             t.join(0.1)
 
         if t.is_alive():
-            logger.debug("Timed out while monitoring serial output on {}".format(self.instance.platform.name))
+            logger.debug(f"Timed out while monitoring serial output on {self.instance.platform.name}")
 
         if ser.isOpen():
             ser.close()
@@ -1036,7 +1034,7 @@ class QEMUHandler(Handler):
                 self.instance.reason = "Timeout"
             else:
                 if not self.instance.reason:
-                    self.instance.reason = "Exited with {}".format(self.returncode)
+                    self.instance.reason = f"Exited with {self.returncode}"
             self.instance.add_missing_case_status(TwisterStatus.BLOCK)
 
     def handle(self, harness):
@@ -1055,19 +1053,19 @@ class QEMUHandler(Handler):
                                              self.ignore_unexpected_eof))
 
         self.thread.daemon = True
-        logger.debug("Spawning QEMUHandler Thread for %s" % self.name)
+        logger.debug(f"Spawning QEMUHandler Thread for {self.name}")
         self.thread.start()
         thread_max_time = time.time() + self.get_test_timeout()
         if sys.stdout.isatty():
             subprocess.call(["stty", "sane"], stdin=sys.stdout)
 
-        logger.debug("Running %s (%s)" % (self.name, self.type_str))
+        logger.debug(f"Running {self.name} ({self.type_str})")
 
         is_timeout = False
         qemu_pid = None
 
         with subprocess.Popen(command, stdout=open(self.stdout_fn, "w"), stderr=open(self.stderr_fn, "w"), cwd=self.build_dir) as proc:
-            logger.debug("Spawning QEMUHandler Thread for %s" % self.name)
+            logger.debug(f"Spawning QEMUHandler Thread for {self.name}")
 
             try:
                 proc.wait(self.get_test_timeout())
@@ -1205,7 +1203,7 @@ class QEMUWinHandler(Handler):
                 self.instance.reason = "Timeout"
             else:
                 if not self.instance.reason:
-                    self.instance.reason = "Exited with {}".format(self.returncode)
+                    self.instance.reason = f"Exited with {self.returncode}"
             self.instance.add_missing_case_status(TwisterStatus.BLOCK)
 
     def _enqueue_char(self, queue):
@@ -1333,14 +1331,14 @@ class QEMUWinHandler(Handler):
         command = self._create_command(domain_build_dir)
         self._set_qemu_filenames(domain_build_dir)
 
-        logger.debug("Running %s (%s)" % (self.name, self.type_str))
+        logger.debug(f"Running {self.name} ({self.type_str})")
         is_timeout = False
         self.stop_thread = False
         queue = Queue()
 
         with subprocess.Popen(command, stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT,
                               cwd=self.build_dir) as proc:
-            logger.debug("Spawning QEMUHandler Thread for %s" % self.name)
+            logger.debug(f"Spawning QEMUHandler Thread for {self.name}")
 
             self.thread = threading.Thread(target=self._enqueue_char, args=(queue,))
             self.thread.daemon = True

--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -201,7 +201,7 @@ class BinaryHandler(Handler):
     def _output_handler(self, proc, harness):
         suffix = '\\r\\n'
 
-        with open(self.log, "wt") as log_out_fp:
+        with open(self.log, "w") as log_out_fp:
             timeout_extended = False
             timeout_time = time.time() + self.get_test_timeout()
             while True:
@@ -894,7 +894,7 @@ class QEMUHandler(Handler):
         # Disable internal buffering, we don't
         # want read() or poll() to ever block if there is data in there
         in_fp = open(fifo_out, "rb", buffering=0)
-        log_out_fp = open(logfile, "wt")
+        log_out_fp = open(logfile, "w")
 
         return out_fp, in_fp, log_out_fp
 
@@ -1087,7 +1087,7 @@ class QEMUHandler(Handler):
         is_timeout = False
         qemu_pid = None
 
-        with subprocess.Popen(command, stdout=open(self.stdout_fn, "wt"), stderr=open(self.stderr_fn, "wt"), cwd=self.build_dir) as proc:
+        with subprocess.Popen(command, stdout=open(self.stdout_fn, "w"), stderr=open(self.stderr_fn, "w"), cwd=self.build_dir) as proc:
             logger.debug("Spawning QEMUHandler Thread for %s" % self.name)
 
             try:
@@ -1174,7 +1174,7 @@ class QEMUWinHandler(Handler):
 
     @staticmethod
     def _open_log_file(logfile):
-        return open(logfile, "wt")
+        return open(logfile, "w")
 
     @staticmethod
     def _close_log_file(log_file):

--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -23,7 +23,6 @@ import time
 from contextlib import contextmanager
 from pathlib import Path
 from queue import Empty, Queue
-from typing import Optional
 
 import psutil
 from twisterlib.environment import ZEPHYR_BASE, strip_ansi_sequences
@@ -71,7 +70,7 @@ def terminate_process(proc):
 
 class Handler:
     def __init__(self, instance, type_str: str, options: argparse.Namespace,
-                 generator_cmd: Optional[str] = None, suite_name_check: bool = True):
+                 generator_cmd: str | None = None, suite_name_check: bool = True):
         """Constructor
 
         """
@@ -175,7 +174,7 @@ class Handler:
 
 
 class BinaryHandler(Handler):
-    def __init__(self, instance, type_str: str, options: argparse.Namespace, generator_cmd: Optional[str] = None,
+    def __init__(self, instance, type_str: str, options: argparse.Namespace, generator_cmd: str | None = None,
                  suite_name_check: bool = True):
         """Constructor
 
@@ -186,7 +185,7 @@ class BinaryHandler(Handler):
         self.seed = None
         self.extra_test_args = None
         self.line = b""
-        self.binary: Optional[str] = None
+        self.binary: str | None = None
 
     def try_kill_process_by_pid(self):
         if self.pid_fn:
@@ -374,7 +373,7 @@ class BinaryHandler(Handler):
 
 
 class SimulationHandler(BinaryHandler):
-    def __init__(self, instance, type_str: str, options: argparse.Namespace, generator_cmd: Optional[str] = None,
+    def __init__(self, instance, type_str: str, options: argparse.Namespace, generator_cmd: str | None = None,
                  suite_name_check: bool = True):
         """Constructor
 
@@ -827,7 +826,7 @@ class QEMUHandler(Handler):
     for these to collect whether the test passed or failed.
     """
 
-    def __init__(self, instance, type_str: str, options: argparse.Namespace, generator_cmd: Optional[str] = None,
+    def __init__(self, instance, type_str: str, options: argparse.Namespace, generator_cmd: str | None = None,
                  suite_name_check: bool = True):
         """Constructor
 
@@ -1117,7 +1116,7 @@ class QEMUWinHandler(Handler):
      for these to collect whether the test passed or failed.
      """
 
-    def __init__(self, instance, type_str: str, options: argparse.Namespace, generator_cmd: Optional[str] = None,
+    def __init__(self, instance, type_str: str, options: argparse.Namespace, generator_cmd: str | None = None,
                  suite_name_check: bool = True):
         """Constructor
 

--- a/scripts/pylib/twister/twisterlib/hardwaremap.py
+++ b/scripts/pylib/twister/twisterlib/hardwaremap.py
@@ -33,7 +33,7 @@ logger = logging.getLogger('twister')
 logger.setLevel(logging.DEBUG)
 
 
-class DUT(object):
+class DUT:
     def __init__(self,
                  id=None,
                  serial=None,

--- a/scripts/pylib/twister/twisterlib/hardwaremap.py
+++ b/scripts/pylib/twister/twisterlib/hardwaremap.py
@@ -120,7 +120,7 @@ class DUT(object):
         d = {}
         exclude = ['_available', '_counter', '_failures', 'match']
         v = vars(self)
-        for k in v.keys():
+        for k in v:
             if k not in exclude and v[k]:
                 d[k] = v[k]
         return d

--- a/scripts/pylib/twister/twisterlib/hardwaremap.py
+++ b/scripts/pylib/twister/twisterlib/hardwaremap.py
@@ -234,10 +234,26 @@ class HardwareMap:
         print(tabulate(table, headers=header, tablefmt="github"))
 
 
-    def add_device(self, serial, platform, pre_script, is_pty, baud=None, flash_timeout=60, flash_with_test=False, flash_before=False):
-        device = DUT(platform=platform, connected=True, pre_script=pre_script, serial_baud=baud,
-                     flash_timeout=flash_timeout, flash_with_test=flash_with_test, flash_before=flash_before
-                    )
+    def add_device(
+        self,
+        serial,
+        platform,
+        pre_script,
+        is_pty,
+        baud=None,
+        flash_timeout=60,
+        flash_with_test=False,
+        flash_before=False
+    ):
+        device = DUT(
+            platform=platform,
+            connected=True,
+            pre_script=pre_script,
+            serial_baud=baud,
+            flash_timeout=flash_timeout,
+            flash_with_test=flash_with_test,
+            flash_before=flash_before
+        )
         if is_pty:
             device.serial_pty = serial
         else:
@@ -330,7 +346,10 @@ class HardwareMap:
         serial_devices = list_ports.comports()
         logger.info("Scanning connected hardware...")
         for d in serial_devices:
-            if d.manufacturer and d.manufacturer.casefold() in [m.casefold() for m in self.manufacturer]:
+            if (
+                d.manufacturer
+                and d.manufacturer.casefold() in [m.casefold() for m in self.manufacturer]
+            ):
 
                 # TI XDS110 can have multiple serial devices for a single board
                 # assume endpoint 0 is the serial, skip all others

--- a/scripts/pylib/twister/twisterlib/hardwaremap.py
+++ b/scripts/pylib/twister/twisterlib/hardwaremap.py
@@ -4,26 +4,25 @@
 # Copyright (c) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-import os
-from multiprocessing import Lock, Value
-import re
-
-import platform
-import yaml
-import scl
 import logging
+import os
+import platform
+import re
+from multiprocessing import Lock, Value
 from pathlib import Path
-from natsort import natsorted
 
+import scl
+import yaml
+from natsort import natsorted
 from twisterlib.environment import ZEPHYR_BASE
 
 try:
     # Use the C LibYAML parser if available, rather than the Python parser.
     # It's much faster.
-    from yaml import CSafeLoader as SafeLoader
     from yaml import CDumper as Dumper
+    from yaml import CSafeLoader as SafeLoader
 except ImportError:
-    from yaml import SafeLoader, Dumper
+    from yaml import Dumper, SafeLoader
 
 try:
     from tabulate import tabulate

--- a/scripts/pylib/twister/twisterlib/hardwaremap.py
+++ b/scripts/pylib/twister/twisterlib/hardwaremap.py
@@ -430,7 +430,11 @@ class HardwareMap:
             logger.info("Detected devices:")
             self.dump(detected=True)
 
-    def dump(self, filtered=[], header=[], connected_only=False, detected=False):
+    def dump(self, filtered=None, header=None, connected_only=False, detected=False):
+        if filtered is None:
+            filtered = []
+        if header is None:
+            header = []
         print("")
         table = []
         if detected:

--- a/scripts/pylib/twister/twisterlib/hardwaremap.py
+++ b/scripts/pylib/twister/twisterlib/hardwaremap.py
@@ -361,7 +361,7 @@ class HardwareMap:
                 s_dev.lock = None
                 self.detected.append(s_dev)
             else:
-                logger.warning("Unsupported device (%s): %s" % (d.manufacturer, d))
+                logger.warning(f"Unsupported device ({d.manufacturer}): {d}")
 
     def save(self, hwm_file):
         # use existing map

--- a/scripts/pylib/twister/twisterlib/hardwaremap.py
+++ b/scripts/pylib/twister/twisterlib/hardwaremap.py
@@ -367,7 +367,7 @@ class HardwareMap:
         # use existing map
         self.detected = natsorted(self.detected, key=lambda x: x.serial or '')
         if os.path.exists(hwm_file):
-            with open(hwm_file, 'r') as yaml_file:
+            with open(hwm_file) as yaml_file:
                 hwm = yaml.load(yaml_file, Loader=SafeLoader)
                 if hwm:
                     hwm.sort(key=lambda x: x.get('id', ''))

--- a/scripts/pylib/twister/twisterlib/harness.py
+++ b/scripts/pylib/twister/twisterlib/harness.py
@@ -114,7 +114,7 @@ class Harness:
     def translate_record(self, record: dict) -> dict:
         if self.record_as_json:
             for k in self.record_as_json:
-                if not k in record:
+                if k not in record:
                     continue
                 try:
                     record[k] = json.loads(record[k]) if record[k] else {}
@@ -296,7 +296,7 @@ class Console(Harness):
         elif self.type == "multi_line" and not self.ordered:
             for i, pattern in enumerate(self.patterns):
                 r = self.regex[i]
-                if pattern.search(line) and not r in self.matches:
+                if pattern.search(line) and r not in self.matches:
                     self.matches[r] = line
                     logger.debug(f"HARNESS:{self.__class__.__name__}:EXPECTED("
                                  f"{len(self.matches)}/{self.patterns_expected}):"

--- a/scripts/pylib/twister/twisterlib/harness.py
+++ b/scripts/pylib/twister/twisterlib/harness.py
@@ -157,9 +157,8 @@ class Harness:
             self.status = TwisterStatus.FAIL
             self.reason = "Testsuite failed"
 
-        if self.fail_on_fault:
-            if line == self.FAULT:
-                self.fault = True
+        if self.fail_on_fault and line == self.FAULT:
+            self.fault = True
 
         if self.GCOV_START in line:
             self.capture_coverage = True
@@ -306,9 +305,8 @@ class Console(Harness):
         else:
             logger.error("Unknown harness_config type")
 
-        if self.fail_on_fault:
-            if self.FAULT in line:
-                self.fault = True
+        if self.fail_on_fault and self.FAULT in line:
+            self.fault = True
 
         if self.GCOV_START in line:
             self.capture_coverage = True

--- a/scripts/pylib/twister/twisterlib/harness.py
+++ b/scripts/pylib/twister/twisterlib/harness.py
@@ -13,7 +13,6 @@ import sys
 import threading
 import time
 import xml.etree.ElementTree as ET
-from asyncio.log import logger
 from collections import OrderedDict
 from enum import Enum
 

--- a/scripts/pylib/twister/twisterlib/harness.py
+++ b/scripts/pylib/twister/twisterlib/harness.py
@@ -171,7 +171,7 @@ class Robot(Harness):
     is_robot_test = True
 
     def configure(self, instance):
-        super(Robot, self).configure(instance)
+        super().configure(instance)
         self.instance = instance
 
         config = instance.testsuite.harness_config
@@ -247,10 +247,10 @@ class Console(Harness):
         '''
         if self.instance and len(self.instance.testcases) == 1:
             return self.instance.testcases[0].name
-        return super(Console, self).get_testcase_name()
+        return super().get_testcase_name()
 
     def configure(self, instance):
-        super(Console, self).configure(instance)
+        super().configure(instance)
         if self.regex is None or len(self.regex) == 0:
             self.status = TwisterStatus.FAIL
             tc = self.instance.set_case_status_by_name(
@@ -354,7 +354,7 @@ class PytestHarnessException(Exception):
 class Pytest(Harness):
 
     def configure(self, instance: TestInstance):
-        super(Pytest, self).configure(instance)
+        super().configure(instance)
         self.running_dir = instance.build_dir
         self.source_dir = instance.testsuite.source_dir
         self.report_file = os.path.join(self.running_dir, 'report.xml')

--- a/scripts/pylib/twister/twisterlib/harness.py
+++ b/scripts/pylib/twister/twisterlib/harness.py
@@ -1,29 +1,30 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-from asyncio.log import logger
-from enum import Enum
+
+import json
+import logging
+import os
 import platform
 import re
-import os
-import sys
-import subprocess
 import shlex
-from collections import OrderedDict
-import xml.etree.ElementTree as ET
-import logging
+import shutil
+import subprocess
+import sys
 import threading
 import time
-import shutil
-import json
+import xml.etree.ElementTree as ET
+from asyncio.log import logger
+from collections import OrderedDict
+from enum import Enum
 
 from pytest import ExitCode
-from twisterlib.reports import ReportStatus
+from twisterlib.constants import SUPPORTED_SIMS_IN_PYTEST
+from twisterlib.environment import PYTEST_PLUGIN_INSTALLED, ZEPHYR_BASE
 from twisterlib.error import ConfigurationError, StatusAttributeError
-from twisterlib.environment import ZEPHYR_BASE, PYTEST_PLUGIN_INSTALLED
 from twisterlib.handlers import Handler, terminate_process
+from twisterlib.reports import ReportStatus
 from twisterlib.statuses import TwisterStatus
 from twisterlib.testinstance import TestInstance
-from twisterlib.constants import SUPPORTED_SIMS_IN_PYTEST
 
 logger = logging.getLogger('twister')
 logger.setLevel(logging.DEBUG)

--- a/scripts/pylib/twister/twisterlib/harness.py
+++ b/scripts/pylib/twister/twisterlib/harness.py
@@ -222,8 +222,9 @@ class Robot(Harness):
                 # please note that there should be only one testcase in testcases list
                 self.instance.testcases[0].status = TwisterStatus.PASS
             else:
-                logger.error("Robot test failure: %s for %s" %
-                             (handler.sourcedir, self.instance.platform.name))
+                logger.error(
+                    f"Robot test failure: {handler.sourcedir} for {self.instance.platform.name}"
+                )
                 self.instance.status = TwisterStatus.FAIL
                 self.instance.testcases[0].status = TwisterStatus.FAIL
 
@@ -530,7 +531,7 @@ class Pytest(Harness):
         else:
             cmd_append_python_path = ''
         cmd_to_print = cmd_append_python_path + shlex.join(cmd)
-        logger.debug('Running pytest command: %s', cmd_to_print)
+        logger.debug(f'Running pytest command: {cmd_to_print}')
 
         return cmd, env
 
@@ -541,7 +542,7 @@ class Pytest(Harness):
             if not line:
                 continue
             self._output.append(line)
-            logger.debug('PYTEST: %s', line)
+            logger.debug(f'PYTEST: {line}')
             self.parse_record(line)
         proc.communicate()
 
@@ -639,11 +640,11 @@ class Gtest(Harness):
             # Assert that we don't already have a running test
             assert (
                 self.tc is None
-            ), "gTest error, {} didn't finish".format(self.tc)
+            ), f"gTest error, {self.tc} didn't finish"
 
             # Check that the instance doesn't exist yet (prevents re-running)
             tc = self.instance.get_case_by_name(name)
-            assert tc is None, "gTest error, {} running twice".format(tc)
+            assert tc is None, f"gTest error, {tc} running twice"
 
             # Create the test instance and set the context
             tc = self.instance.get_case_or_create(name)
@@ -674,7 +675,7 @@ class Gtest(Harness):
         tc = self.instance.get_case_by_name(name)
         assert (
             tc is not None and tc == self.tc
-        ), "gTest error, mismatched tests. Expected {} but got {}".format(self.tc, tc)
+        ), f"gTest error, mismatched tests. Expected {self.tc} but got {tc}"
 
         # Test finished, clear the context
         self.tc = None
@@ -743,13 +744,13 @@ class Test(Harness):
         for ts_name_ in ts_names:
             if self.started_suites[ts_name_]['count'] < (0 if phase == 'TS_SUM' else 1):
                 continue
-            tc_fq_id = "{}.{}.{}".format(self.id, ts_name_, tc_name)
+            tc_fq_id = f"{self.id}.{ts_name_}.{tc_name}"
             if tc := self.instance.get_case_by_name(tc_fq_id):
                 if self.trace:
                     logger.debug(f"On {phase}: Ztest case '{tc_name}' matched to '{tc_fq_id}")
                 return tc
         logger.debug(f"On {phase}: Ztest case '{tc_name}' is not known in {self.started_suites} running suite(s).")
-        tc_id = "{}.{}".format(self.id, tc_name)
+        tc_id = f"{self.id}.{tc_name}"
         return self.instance.get_case_or_create(tc_id)
 
     def start_suite(self, suite_name):

--- a/scripts/pylib/twister/twisterlib/harness.py
+++ b/scripts/pylib/twister/twisterlib/harness.py
@@ -158,7 +158,7 @@ class Harness:
             self.reason = "Testsuite failed"
 
         if self.fail_on_fault:
-            if self.FAULT == line:
+            if line == self.FAULT:
                 self.fault = True
 
         if self.GCOV_START in line:

--- a/scripts/pylib/twister/twisterlib/harness.py
+++ b/scripts/pylib/twister/twisterlib/harness.py
@@ -129,7 +129,9 @@ class Harness:
         if self.record_pattern:
             match = self.record_pattern.search(line)
             if match:
-                rec = self.translate_record({ k:v.strip() for k,v in match.groupdict(default="").items() })
+                rec = self.translate_record(
+                    { k:v.strip() for k,v in match.groupdict(default="").items() }
+                )
                 self.recording.append(rec)
         return match
     #
@@ -416,7 +418,9 @@ class Pytest(Harness):
         elif handler.type_str == 'build':
             command.append('--device-type=custom')
         else:
-            raise PytestHarnessException(f'Support for handler {handler.type_str} not implemented yet')
+            raise PytestHarnessException(
+                f'Support for handler {handler.type_str} not implemented yet'
+            )
 
         if handler.type_str != 'device':
             for fixture in handler.options.fixture:
@@ -522,12 +526,20 @@ class Pytest(Harness):
         env = os.environ.copy()
         if not PYTEST_PLUGIN_INSTALLED:
             cmd.extend(['-p', 'twister_harness.plugin'])
-            pytest_plugin_path = os.path.join(ZEPHYR_BASE, 'scripts', 'pylib', 'pytest-twister-harness', 'src')
+            pytest_plugin_path = os.path.join(
+                ZEPHYR_BASE,
+                'scripts',
+                'pylib',
+                'pytest-twister-harness',
+                'src'
+            )
             env['PYTHONPATH'] = pytest_plugin_path + os.pathsep + env.get('PYTHONPATH', '')
             if _WINDOWS:
                 cmd_append_python_path = f'set PYTHONPATH={pytest_plugin_path};%PYTHONPATH% && '
             else:
-                cmd_append_python_path = f'export PYTHONPATH={pytest_plugin_path}:${{PYTHONPATH}} && '
+                cmd_append_python_path = (
+                    f'export PYTHONPATH={pytest_plugin_path}:${{PYTHONPATH}} && '
+                )
         else:
             cmd_append_python_path = ''
         cmd_to_print = cmd_append_python_path + shlex.join(cmd)
@@ -571,7 +583,9 @@ class Pytest(Harness):
         if (elem_ts := root.find('testsuite')) is not None:
             if elem_ts.get('failures') != '0':
                 self.status = TwisterStatus.FAIL
-                self.instance.reason = f"{elem_ts.get('failures')}/{elem_ts.get('tests')} pytest scenario(s) failed"
+                self.instance.reason = (
+                    f"{elem_ts.get('failures')}/{elem_ts.get('tests')} pytest scenario(s) failed"
+                )
             elif elem_ts.get('errors') != '0':
                 self.status = TwisterStatus.ERROR
                 self.instance.reason = 'Error during pytest execution'
@@ -717,11 +731,20 @@ class Test(Harness):
     __test__ = False  # for pytest to skip this class when collects tests
 
     test_suite_start_pattern = re.compile(r"Running TESTSUITE (?P<suite_name>\S*)")
-    test_suite_end_pattern = re.compile(r"TESTSUITE (?P<suite_name>\S*)\s+(?P<suite_status>succeeded|failed)")
+    test_suite_end_pattern = re.compile(
+        r"TESTSUITE (?P<suite_name>\S*)\s+(?P<suite_status>succeeded|failed)"
+    )
     test_case_start_pattern = re.compile(r"START - (test_)?([a-zA-Z0-9_-]+)")
-    test_case_end_pattern = re.compile(r".*(PASS|FAIL|SKIP) - (test_)?(\S*) in (\d*[.,]?\d*) seconds")
-    test_suite_summary_pattern = re.compile(r"SUITE (?P<suite_status>\S*) - .* \[(?P<suite_name>\S*)\]: .* duration = (\d*[.,]?\d*) seconds")
-    test_case_summary_pattern = re.compile(r" - (PASS|FAIL|SKIP) - \[([^\.]*).(test_)?(\S*)\] duration = (\d*[.,]?\d*) seconds")
+    test_case_end_pattern = re.compile(
+        r".*(PASS|FAIL|SKIP) - (test_)?(\S*) in (\d*[.,]?\d*) seconds"
+    )
+    test_suite_summary_pattern = re.compile(
+        r"SUITE (?P<suite_status>\S*) - .* \[(?P<suite_name>\S*)\]:"
+        r" .* duration = (\d*[.,]?\d*) seconds"
+    )
+    test_case_summary_pattern = re.compile(
+        r" - (PASS|FAIL|SKIP) - \[([^\.]*).(test_)?(\S*)\] duration = (\d*[.,]?\d*) seconds"
+    )
 
 
     def get_testcase(self, tc_name, phase, ts_name=None):
@@ -740,7 +763,7 @@ class Test(Harness):
                 self.detected_suite_names.append(ts_name)
             ts_names = [ ts_name ] if ts_name in ts_names else []
 
-        # Firstly try to match the test case ID to the first running Ztest suite with this test name.
+        # First, try to match the test case ID to the first running Ztest suite with this test name.
         for ts_name_ in ts_names:
             if self.started_suites[ts_name_]['count'] < (0 if phase == 'TS_SUM' else 1):
                 continue
@@ -749,7 +772,10 @@ class Test(Harness):
                 if self.trace:
                     logger.debug(f"On {phase}: Ztest case '{tc_name}' matched to '{tc_fq_id}")
                 return tc
-        logger.debug(f"On {phase}: Ztest case '{tc_name}' is not known in {self.started_suites} running suite(s).")
+        logger.debug(
+            f"On {phase}: Ztest case '{tc_name}' is not known"
+            f" in {self.started_suites} running suite(s)."
+        )
         tc_id = f"{self.id}.{tc_name}"
         return self.instance.get_case_or_create(tc_id)
 
@@ -773,7 +799,9 @@ class Test(Harness):
             if phase == 'TS_SUM' and self.started_suites[suite_name]['count'] == 0:
                 return
             if self.started_suites[suite_name]['count'] < 1:
-                logger.error(f"Already ENDED {phase} suite '{suite_name}':{self.started_suites[suite_name]}")
+                logger.error(
+                    f"Already ENDED {phase} suite '{suite_name}':{self.started_suites[suite_name]}"
+                )
             elif self.trace:
                 logger.debug(f"END {phase} suite '{suite_name}':{self.started_suites[suite_name]}")
             self.started_suites[suite_name]['count'] -= 1
@@ -796,7 +824,9 @@ class Test(Harness):
             if phase == 'TS_SUM' and self.started_cases[tc_name]['count'] == 0:
                 return
             if self.started_cases[tc_name]['count'] < 1:
-                logger.error(f"Already ENDED {phase} case '{tc_name}':{self.started_cases[tc_name]}")
+                logger.error(
+                    f"Already ENDED {phase} case '{tc_name}':{self.started_cases[tc_name]}"
+                )
             elif self.trace:
                 logger.debug(f"END {phase} case '{tc_name}':{self.started_cases[tc_name]}")
             self.started_cases[tc_name]['count'] -= 1

--- a/scripts/pylib/twister/twisterlib/harness.py
+++ b/scripts/pylib/twister/twisterlib/harness.py
@@ -924,7 +924,7 @@ class HarnessImporter:
             if harness_name:
                 harness_class = getattr(thismodule, harness_name)
             else:
-                harness_class = getattr(thismodule, 'Test')
+                harness_class = thismodule.Test
             return harness_class()
         except AttributeError as e:
             logger.debug(f"harness {harness_name} not implemented: {e}")

--- a/scripts/pylib/twister/twisterlib/harness.py
+++ b/scripts/pylib/twister/twisterlib/harness.py
@@ -82,8 +82,8 @@ class Harness:
         try:
             key = value.name if isinstance(value, Enum) else value
             self._status = TwisterStatus[key]
-        except KeyError:
-            raise StatusAttributeError(self.__class__, value)
+        except KeyError as err:
+            raise StatusAttributeError(self.__class__, value) from err
 
     def configure(self, instance):
         self.instance = instance

--- a/scripts/pylib/twister/twisterlib/harness.py
+++ b/scripts/pylib/twister/twisterlib/harness.py
@@ -229,7 +229,7 @@ class Robot(Harness):
                 self.instance.testcases[0].status = TwisterStatus.FAIL
 
             if out:
-                with open(os.path.join(self.instance.build_dir, handler.log), "wt") as log:
+                with open(os.path.join(self.instance.build_dir, handler.log), 'w') as log:
                     log_msg = out.decode(sys.getdefaultencoding())
                     log.write(log_msg)
 

--- a/scripts/pylib/twister/twisterlib/harness.py
+++ b/scripts/pylib/twister/twisterlib/harness.py
@@ -201,7 +201,7 @@ class Robot(Harness):
                     command.append(f'{v}')
 
         if self.path is None:
-            raise PytestHarnessException(f'The parameter robot_testsuite is mandatory')
+            raise PytestHarnessException('The parameter robot_testsuite is mandatory')
 
         if isinstance(self.path, list):
             for suite in self.path:

--- a/scripts/pylib/twister/twisterlib/jobserver.py
+++ b/scripts/pylib/twister/twisterlib/jobserver.py
@@ -152,15 +152,17 @@ class GNUMakeJobClient(JobClient):
                         rc = fcntl.fcntl(pipe[0], fcntl.F_GETFL)
                         if rc & os.O_ACCMODE != os.O_RDONLY:
                             logger.warning(
-                                "FD %s is not readable (flags=%x); "
-                                "ignoring GNU make jobserver", pipe[0], rc)
+                                f"FD {pipe[0]} is not readable (flags={rc:x});"
+                                " ignoring GNU make jobserver"
+                            )
                             pipe = None
                     if pipe:
                         rc = fcntl.fcntl(pipe[1], fcntl.F_GETFL)
                         if rc & os.O_ACCMODE != os.O_WRONLY:
                             logger.warning(
-                                "FD %s is not writable (flags=%x); "
-                                "ignoring GNU make jobserver", pipe[1], rc)
+                                f"FD {pipe[1]} is not writable (flags={rc:x});"
+                                " ignoring GNU make jobserver"
+                            )
                             pipe = None
                     if pipe:
                         logger.info("using GNU make jobserver")

--- a/scripts/pylib/twister/twisterlib/jobserver.py
+++ b/scripts/pylib/twister/twisterlib/jobserver.py
@@ -62,9 +62,7 @@ class JobClient:
         kwargs["env"].update(self.env())
         kwargs["pass_fds"] += self.pass_fds()
 
-        return subprocess.Popen(  # pylint:disable=consider-using-with
-            argv, **kwargs
-        )
+        return subprocess.Popen(argv, **kwargs)
 
 
 class GNUMakeJobClient(JobClient):

--- a/scripts/pylib/twister/twisterlib/jobserver.py
+++ b/scripts/pylib/twister/twisterlib/jobserver.py
@@ -150,14 +150,14 @@ class GNUMakeJobClient(JobClient):
                     # Use F_GETFL to see if file descriptors are valid
                     if pipe:
                         rc = fcntl.fcntl(pipe[0], fcntl.F_GETFL)
-                        if not rc & os.O_ACCMODE == os.O_RDONLY:
+                        if rc & os.O_ACCMODE != os.O_RDONLY:
                             logger.warning(
                                 "FD %s is not readable (flags=%x); "
                                 "ignoring GNU make jobserver", pipe[0], rc)
                             pipe = None
                     if pipe:
                         rc = fcntl.fcntl(pipe[1], fcntl.F_GETFL)
-                        if not rc & os.O_ACCMODE == os.O_WRONLY:
+                        if rc & os.O_ACCMODE != os.O_WRONLY:
                             logger.warning(
                                 "FD %s is not writable (flags=%x); "
                                 "ignoring GNU make jobserver", pipe[1], rc)

--- a/scripts/pylib/twister/twisterlib/mixins.py
+++ b/scripts/pylib/twister/twisterlib/mixins.py
@@ -4,5 +4,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-class DisablePyTestCollectionMixin(object):
+class DisablePyTestCollectionMixin:
     __test__ = False

--- a/scripts/pylib/twister/twisterlib/package.py
+++ b/scripts/pylib/twister/twisterlib/package.py
@@ -25,7 +25,7 @@ class Artifacts:
 
     def package(self):
         dirs = []
-        with open(os.path.join(self.options.outdir, "twister.json"), "r") as json_test_plan:
+        with open(os.path.join(self.options.outdir, "twister.json")) as json_test_plan:
             jtp = json.load(json_test_plan)
             for t in jtp['testsuites']:
                 if t['status'] != TwisterStatus.FILTER:

--- a/scripts/pylib/twister/twisterlib/package.py
+++ b/scripts/pylib/twister/twisterlib/package.py
@@ -3,11 +3,12 @@
 # Copyright (c) 2020 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-import tarfile
 import json
 import os
+import tarfile
 
 from twisterlib.statuses import TwisterStatus
+
 
 class Artifacts:
 

--- a/scripts/pylib/twister/twisterlib/platform.py
+++ b/scripts/pylib/twister/twisterlib/platform.py
@@ -177,4 +177,4 @@ class Platform:
             return next(iter(self.simulators), None)
 
     def __repr__(self):
-        return "<%s on %s>" % (self.name, self.arch)
+        return f"<{self.name} on {self.arch}>"

--- a/scripts/pylib/twister/twisterlib/platform.py
+++ b/scripts/pylib/twister/twisterlib/platform.py
@@ -45,8 +45,9 @@ class Platform:
 
     Maps directly to BOARD when building"""
 
-    platform_schema = scl.yaml_load(os.path.join(ZEPHYR_BASE,
-                                                 "scripts", "schemas", "twister", "platform-schema.yaml"))
+    platform_schema = scl.yaml_load(
+        os.path.join(ZEPHYR_BASE, "scripts", "schemas", "twister", "platform-schema.yaml")
+    )
 
     def __init__(self):
         """Constructor.
@@ -132,7 +133,12 @@ class Platform:
         self.tier = variant_data.get("tier", data.get("tier", self.tier))
         self.type = variant_data.get('type', data.get('type', self.type))
 
-        self.simulators = [Simulator(data) for data in variant_data.get('simulation', data.get('simulation', self.simulators))]
+        self.simulators = [
+            Simulator(data) for data in variant_data.get(
+                'simulation',
+                data.get('simulation', self.simulators)
+            )
+        ]
         default_sim = self.simulator_by_name(None)
         if default_sim:
             self.simulation = default_sim.name

--- a/scripts/pylib/twister/twisterlib/platform.py
+++ b/scripts/pylib/twister/twisterlib/platform.py
@@ -6,12 +6,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import logging
 import os
 import shutil
+
 import scl
-from twisterlib.environment import ZEPHYR_BASE
 from twisterlib.constants import SUPPORTED_SIMS
-import logging
+from twisterlib.environment import ZEPHYR_BASE
 
 logger = logging.getLogger('twister')
 logger.setLevel(logging.DEBUG)

--- a/scripts/pylib/twister/twisterlib/quarantine.py
+++ b/scripts/pylib/twister/twisterlib/quarantine.py
@@ -137,7 +137,4 @@ class QuarantineData:
 
 def _is_element_matched(element: str, list_of_elements: list[re.Pattern]) -> bool:
     """Return True if given element is matching to any of elements from the list"""
-    for pattern in list_of_elements:
-        if pattern.fullmatch(element):
-            return True
-    return False
+    return any(pattern.fullmatch(element) for pattern in list_of_elements)

--- a/scripts/pylib/twister/twisterlib/quarantine.py
+++ b/scripts/pylib/twister/twisterlib/quarantine.py
@@ -7,10 +7,10 @@ from __future__ import annotations
 
 import logging
 import re
-import yaml
-
-from pathlib import Path
 from dataclasses import dataclass, field
+from pathlib import Path
+
+import yaml
 
 try:
     from yaml import CSafeLoader as SafeLoader

--- a/scripts/pylib/twister/twisterlib/quarantine.py
+++ b/scripts/pylib/twister/twisterlib/quarantine.py
@@ -38,7 +38,7 @@ class Quarantine:
     def get_matched_quarantine(self, testname, platform, architecture, simulator):
         qelem = self.quarantine.get_matched_quarantine(testname, platform, architecture, simulator)
         if qelem:
-            logger.debug('%s quarantined with reason: %s' % (testname, qelem.comment))
+            logger.debug(f'{testname} quarantined with reason: {qelem.comment}')
             return qelem.comment
         return None
 

--- a/scripts/pylib/twister/twisterlib/quarantine.py
+++ b/scripts/pylib/twister/twisterlib/quarantine.py
@@ -96,7 +96,7 @@ class QuarantineData:
     @classmethod
     def load_data_from_yaml(cls, filename: str | Path) -> QuarantineData:
         """Load quarantine from yaml file."""
-        with open(filename, 'r', encoding='UTF-8') as yaml_fd:
+        with open(filename, encoding='UTF-8') as yaml_fd:
             qlist_raw_data: list[dict] = yaml.load(yaml_fd, Loader=SafeLoader)
         try:
             if not qlist_raw_data:

--- a/scripts/pylib/twister/twisterlib/quarantine.py
+++ b/scripts/pylib/twister/twisterlib/quarantine.py
@@ -28,7 +28,9 @@ class QuarantineException(Exception):
 class Quarantine:
     """Handle tests under quarantine."""
 
-    def __init__(self, quarantine_list=[]) -> None:
+    def __init__(self, quarantine_list=None) -> None:
+        if quarantine_list is None:
+            quarantine_list = []
         self.quarantine = QuarantineData()
         for quarantine_file in quarantine_list:
             self.quarantine.extend(QuarantineData.load_data_from_yaml(quarantine_file))

--- a/scripts/pylib/twister/twisterlib/quarantine.py
+++ b/scripts/pylib/twister/twisterlib/quarantine.py
@@ -125,11 +125,15 @@ class QuarantineData:
             if (qelem.platforms
                     and (matched := _is_element_matched(platform, qelem.re_platforms)) is False):
                 continue
-            if (qelem.architectures
-                    and (matched := _is_element_matched(architecture, qelem.re_architectures)) is False):
+            if (
+                qelem.architectures
+                and (matched := _is_element_matched(architecture, qelem.re_architectures)) is False
+            ):
                 continue
-            if (qelem.simulations
-                    and (matched := _is_element_matched(simulator_name, qelem.re_simulations)) is False):
+            if (
+                qelem.simulations
+                and (matched := _is_element_matched(simulator_name, qelem.re_simulations)) is False
+            ):
                 continue
 
             if matched:

--- a/scripts/pylib/twister/twisterlib/reports.py
+++ b/scripts/pylib/twister/twisterlib/reports.py
@@ -4,16 +4,16 @@
 # Copyright (c) 2018 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from enum import Enum
-import os
 import json
 import logging
-from colorama import Fore
-import xml.etree.ElementTree as ET
+import os
 import string
+import xml.etree.ElementTree as ET
 from datetime import datetime
+from enum import Enum
 from pathlib import PosixPath
 
+from colorama import Fore
 from twisterlib.statuses import TwisterStatus
 
 logger = logging.getLogger('twister')

--- a/scripts/pylib/twister/twisterlib/reports.py
+++ b/scripts/pylib/twister/twisterlib/reports.py
@@ -65,7 +65,19 @@ class Reporting:
 
 
     @staticmethod
-    def xunit_testcase(eleTestsuite, name, classname, status: TwisterStatus, ts_status: TwisterStatus, reason, duration, runnable, stats, log, build_only_as_skip):
+    def xunit_testcase(
+        eleTestsuite,
+        name,
+        classname,
+        status: TwisterStatus,
+        ts_status: TwisterStatus,
+        reason,
+        duration,
+        runnable,
+        stats,
+        log,
+        build_only_as_skip
+    ):
         fails, passes, errors, skips = stats
 
         if status in [TwisterStatus.SKIP, TwisterStatus.FILTER]:
@@ -106,7 +118,12 @@ class Reporting:
         else:
             if status == TwisterStatus.NONE:
                 logger.debug(f"{name}: No status")
-                ET.SubElement(eleTestcase, ReportStatus.SKIP, type="untested", message="No results captured, testsuite misconfiguration?")
+                ET.SubElement(
+                    eleTestcase,
+                    ReportStatus.SKIP,
+                    type="untested",
+                    message="No results captured, testsuite misconfiguration?"
+                )
             else:
                 logger.error(f"{name}: Unknown status '{status}'")
 
@@ -129,7 +146,9 @@ class Reporting:
         suites_to_report = all_suites
             # do not create entry if everything is filtered out
         if not self.env.options.detailed_skipped_report:
-            suites_to_report = list(filter(lambda d: TwisterStatus(d.get('status')) != TwisterStatus.FILTER, all_suites))
+            suites_to_report = list(
+                filter(lambda d: TwisterStatus(d.get('status')) != TwisterStatus.FILTER, all_suites)
+            )
 
         for suite in suites_to_report:
             duration = 0
@@ -199,7 +218,9 @@ class Reporting:
             suites = list(filter(lambda d: d['platform'] == platform, all_suites))
             # do not create entry if everything is filtered out
             if not self.env.options.detailed_skipped_report:
-                non_filtered = list(filter(lambda d: TwisterStatus(d.get('status')) != TwisterStatus.FILTER, suites))
+                non_filtered = list(
+                    filter(lambda d: TwisterStatus(d.get('status')) != TwisterStatus.FILTER, suites)
+                )
                 if not non_filtered:
                     continue
 
@@ -225,7 +246,10 @@ class Reporting:
 
                 ts_status = TwisterStatus(ts.get('status'))
                 # Do not report filtered testcases
-                if ts_status == TwisterStatus.FILTER and not self.env.options.detailed_skipped_report:
+                if (
+                    ts_status == TwisterStatus.FILTER
+                    and not self.env.options.detailed_skipped_report
+                ):
                     continue
                 if full_report:
                     for tc in ts.get("testcases", []):
@@ -289,13 +313,17 @@ class Reporting:
                 continue
             if (filters and 'allow_status' in filters and \
                 instance.status not in [TwisterStatus[s] for s in filters['allow_status']]):
-                logger.debug(f"Skip test suite '{instance.testsuite.name}' status '{instance.status}' "
-                             f"not allowed for {filename}")
+                logger.debug(
+                    f"Skip test suite '{instance.testsuite.name}'"
+                    f" status '{instance.status}' not allowed for {filename}"
+                )
                 continue
             if (filters and 'deny_status' in filters and \
                 instance.status in [TwisterStatus[s] for s in filters['deny_status']]):
-                logger.debug(f"Skip test suite '{instance.testsuite.name}' status '{instance.status}' "
-                             f"denied for {filename}")
+                logger.debug(
+                    f"Skip test suite '{instance.testsuite.name}'"
+                    f" status '{instance.status}' denied for {filename}"
+                )
                 continue
             suite = {}
             handler_log = os.path.join(instance.build_dir, "handler.log")
@@ -377,7 +405,11 @@ class Reporting:
                 # if we discover those at runtime, the fallback testcase wont be
                 # needed anymore and can be removed from the output, it does
                 # not have a status and would otherwise be reported as skipped.
-                if case.freeform and case.status == TwisterStatus.NONE and len(instance.testcases) > 1:
+                if (
+                    case.freeform
+                    and case.status == TwisterStatus.NONE
+                    and len(instance.testcases) > 1
+                ):
                     continue
                 testcase = {}
                 testcase['identifier'] = case.name
@@ -408,9 +440,15 @@ class Reporting:
             if instance.recording is not None:
                 suite['recording'] = instance.recording
 
-            if (instance.status not in [TwisterStatus.NONE, TwisterStatus.ERROR, TwisterStatus.FILTER]
-                    and self.env.options.create_rom_ram_report
-                    and self.env.options.footprint_report is not None):
+            if (
+                instance.status not in [
+                    TwisterStatus.NONE,
+                    TwisterStatus.ERROR,
+                    TwisterStatus.FILTER
+                ]
+                and self.env.options.create_rom_ram_report
+                and self.env.options.footprint_report is not None
+            ):
                 # Init as empty data preparing for filtering properties.
                 suite['footprint'] = {}
 
@@ -506,7 +544,9 @@ class Reporting:
                 if show_footprint:
                     logger.log(
                         logging.INFO if all_deltas else logging.WARNING,
-                        f"{i.platform.name:<25} {i.testsuite.name:<60} {metric} {delta:<+4}, is now {value:6} {percentage:+.2%}")
+                        f"{i.platform.name:<25} {i.testsuite.name:<60} {metric} {delta:<+4},"
+                        f" is now {value:6} {percentage:+.2%}"
+                    )
 
                 warnings += 1
 
@@ -523,7 +563,9 @@ class Reporting:
             count = self.env.options.report_summary
             log_txt = "The following issues were found "
             if count > self.instance_fail_count:
-                log_txt += f"(presenting {self.instance_fail_count} out of the {count} items requested):"
+                log_txt += (
+                    f"(presenting {self.instance_fail_count} out of the {count} items requested):"
+                )
             else:
                 log_txt += f"(showing the {count} of {self.instance_fail_count} items):"
         else:
@@ -533,7 +575,12 @@ class Reporting:
         example_instance = None
         detailed_test_id = self.env.options.detailed_test_id
         for instance in self.instances.values():
-            if instance.status not in [TwisterStatus.PASS, TwisterStatus.FILTER, TwisterStatus.SKIP, TwisterStatus.NOTRUN]:
+            if instance.status not in [
+                TwisterStatus.PASS,
+                TwisterStatus.FILTER,
+                TwisterStatus.SKIP,
+                TwisterStatus.NOTRUN
+            ]:
                 cnt += 1
                 if cnt == 1:
                     logger.info("-+" * 40)
@@ -543,7 +590,10 @@ class Reporting:
                 if self.env.options.report_summary is not None and \
                    status in [TwisterStatus.ERROR, TwisterStatus.FAIL]:
                     status = Fore.RED + status.upper() + Fore.RESET
-                logger.info(f"{cnt}) {instance.testsuite.name} on {instance.platform.name} {status} ({instance.reason})")
+                logger.info(
+                    f"{cnt}) {instance.testsuite.name} on {instance.platform.name}"
+                    f" {status} ({instance.reason})"
+                )
                 example_instance = instance
             if cnt == count:
                 break
@@ -559,10 +609,16 @@ class Reporting:
             extra_parameters = '' if detailed_test_id else ' --no-detailed-test-id'
             logger.info(f"west twister -p <PLATFORM> -s <TEST ID>{extra_parameters}, for example:")
             logger.info("")
-            logger.info(f"west twister -p {example_instance.platform.name} -s {example_instance.testsuite.name}"
-                        f"{extra_parameters}")
+            logger.info(
+                f"west twister -p {example_instance.platform.name}"
+                f" -s {example_instance.testsuite.name}"
+                f"{extra_parameters}"
+            )
             logger.info("or with west:")
-            logger.info(f"west build -p -b {example_instance.platform.name} {cwd_rel_path} -T {example_instance.testsuite.id}")
+            logger.info(
+                f"west build -p -b {example_instance.platform.name} {cwd_rel_path}"
+                f" -T {example_instance.testsuite.id}"
+            )
             logger.info("-+" * 40)
 
     def summary(self, results, ignore_unrecognized_sections, duration):
@@ -589,45 +645,97 @@ class Reporting:
         else:
             pass_rate = 0
 
+        passed_color = (
+            TwisterStatus.get_color(TwisterStatus.FAIL)
+            if failed
+            else TwisterStatus.get_color(TwisterStatus.PASS)
+        )
+        unfiltered_configs = results.total - results.filtered_configs
+        notrun_number_section = (
+            f'{TwisterStatus.get_color(TwisterStatus.NOTRUN)}{results.notrun}{Fore.RESET}'
+            if results.notrun
+            else f'{results.notrun}'
+        )
+        failed_number_section = (
+            f'{TwisterStatus.get_color(TwisterStatus.FAIL)}{results.failed}{Fore.RESET}'
+            if results.failed
+            else f'{results.failed}'
+        )
+        error_number_section = (
+            f'{TwisterStatus.get_color(TwisterStatus.ERROR)}{results.error}{Fore.RESET}'
+            if results.error
+            else f'{results.error}'
+        )
+        warnings_number_section = (
+            f'{Fore.YELLOW}{self.plan.warnings + results.warnings}{Fore.RESET}'
+            if (self.plan.warnings + results.warnings)
+            else 'no'
+        )
         logger.info(
-            f"{TwisterStatus.get_color(TwisterStatus.FAIL) if failed else TwisterStatus.get_color(TwisterStatus.PASS)}{results.passed}"
-            f" of {results.total - results.filtered_configs}{Fore.RESET}"
+            f"{passed_color}{results.passed} of {unfiltered_configs}{Fore.RESET}"
             f" executed test configurations passed ({pass_rate:.2%}),"
-            f" {f'{TwisterStatus.get_color(TwisterStatus.NOTRUN)}{results.notrun}{Fore.RESET}' if results.notrun else f'{results.notrun}'} built (not run),"
-            f" {f'{TwisterStatus.get_color(TwisterStatus.FAIL)}{results.failed}{Fore.RESET}' if results.failed else f'{results.failed}'} failed,"
-            f" {f'{TwisterStatus.get_color(TwisterStatus.ERROR)}{results.error}{Fore.RESET}' if results.error else f'{results.error}'} errored,"
-            f" with {f'{Fore.YELLOW}{self.plan.warnings + results.warnings}{Fore.RESET}' if (self.plan.warnings + results.warnings) else 'no'} warnings"
+            f" {notrun_number_section} built (not run),"
+            f" {failed_number_section} failed,"
+            f" {error_number_section} errored,"
+            f" with {warnings_number_section} warnings"
             f" in {duration:.2f} seconds."
         )
 
         total_platforms = len(self.platforms)
-        filtered_platforms = set(instance.platform.name for instance in self.instances.values()
-                                  if instance.status not in[TwisterStatus.FILTER, TwisterStatus.NOTRUN, TwisterStatus.SKIP])
+        filtered_platforms = set(
+            instance.platform.name for instance in self.instances.values()
+            if instance.status not in [
+                TwisterStatus.FILTER,
+                TwisterStatus.NOTRUN,
+                TwisterStatus.SKIP
+            ]
+        )
         # if we are only building, do not report about tests being executed.
         if self.platforms and not self.env.options.build_only:
-            executed_cases = results.cases - results.filtered_cases - results.skipped_cases - results.notrun_cases
+            executed_cases = (
+                results.cases
+                - results.filtered_cases
+                - results.skipped_cases
+                - results.notrun_cases
+            )
             pass_rate = 100 * (float(results.passed_cases) / float(executed_cases)) \
                 if executed_cases != 0 else 0
             platform_rate = (100 * len(filtered_platforms) / len(self.platforms))
+            blocked_after_comma = ", " + str(results.blocked_cases) + " blocked"
+            failed_after_comma = ", " + str(results.failed_cases) + " failed"
+            error_after_comma = ", " + str(results.error_cases) + " errored"
+            none_after_comma = ", " + str(results.none_cases) + " without a status"
             logger.info(
-                f'{results.passed_cases} of {executed_cases} executed test cases passed ({pass_rate:02.2f}%)'
-                f'{", " + str(results.blocked_cases) + " blocked" if results.blocked_cases else ""}'
-                f'{", " + str(results.failed_cases) + " failed" if results.failed_cases else ""}'
-                f'{", " + str(results.error_cases) + " errored" if results.error_cases else ""}'
-                f'{", " + str(results.none_cases) + " without a status" if results.none_cases else ""}'
-                f' on {len(filtered_platforms)} out of total {total_platforms} platforms ({platform_rate:02.2f}%).'
+                f'{results.passed_cases} of {executed_cases} executed test cases passed'
+                f' ({pass_rate:02.2f}%)'
+                f'{blocked_after_comma if results.blocked_cases else ""}'
+                f'{failed_after_comma if results.failed_cases else ""}'
+                f'{error_after_comma if results.error_cases else ""}'
+                f'{none_after_comma if results.none_cases else ""}'
+                f' on {len(filtered_platforms)} out of total {total_platforms} platforms'
+                f' ({platform_rate:02.2f}%).'
             )
             if results.skipped_cases or results.notrun_cases:
+                not_executed = results.skipped_cases + results.notrun_cases
+                skipped_after_colon = " " + str(results.skipped_cases) + " skipped"
+                notrun_after_comma = (
+                    (", " if results.skipped_cases else " ")
+                    + str(results.notrun_cases)
+                    + " not run (built only)"
+                )
                 logger.info(
-                    f'{results.skipped_cases + results.notrun_cases} selected test cases not executed:' \
-                    f'{" " + str(results.skipped_cases) + " skipped" if results.skipped_cases else ""}' \
-                    f'{(", " if results.skipped_cases else " ") + str(results.notrun_cases) + " not run (built only)" if results.notrun_cases else ""}' \
+                    f'{not_executed} selected test cases not executed:' \
+                    f'{skipped_after_colon if results.skipped_cases else ""}' \
+                    f'{notrun_after_comma if results.notrun_cases else ""}' \
                     f'.'
                 )
 
         built_only = results.total - run - results.filtered_configs
-        logger.info(f"{Fore.GREEN}{run}{Fore.RESET} test configurations executed on platforms, \
-{TwisterStatus.get_color(TwisterStatus.NOTRUN)}{built_only}{Fore.RESET} test configurations were only built.")
+        logger.info(
+            f"{Fore.GREEN}{run}{Fore.RESET} test configurations executed on platforms,"
+            f" {TwisterStatus.get_color(TwisterStatus.NOTRUN)}{built_only}{Fore.RESET}"
+            " test configurations were only built."
+        )
 
     def save_reports(self, name, suffix, report_dir, no_update, platform_reports):
         if not self.instances:

--- a/scripts/pylib/twister/twisterlib/reports.py
+++ b/scripts/pylib/twister/twisterlib/reports.py
@@ -450,7 +450,7 @@ class Reporting:
                                ("used_rom", int, True)]
 
         if not os.path.exists(filename):
-            logger.error("Cannot compare metrics, %s not found" % filename)
+            logger.error(f"Cannot compare metrics, {filename} not found")
             return []
 
         results = []
@@ -506,9 +506,7 @@ class Reporting:
                 if show_footprint:
                     logger.log(
                         logging.INFO if all_deltas else logging.WARNING,
-                        "{:<25} {:<60} {} {:<+4}, is now {:6} {:+.2%}".format(
-                        i.platform.name, i.testsuite.name,
-                        metric, delta, value, percentage))
+                        f"{i.platform.name:<25} {i.testsuite.name:<60} {metric} {delta:<+4}, is now {value:6} {percentage:+.2%}")
 
                 warnings += 1
 
@@ -574,9 +572,11 @@ class Reporting:
             if instance.status == TwisterStatus.FAIL:
                 failed += 1
             elif not ignore_unrecognized_sections and instance.metrics.get("unrecognized"):
-                logger.error("%sFAILED%s: %s has unrecognized binary sections: %s" %
-                             (Fore.RED, Fore.RESET, instance.name,
-                              str(instance.metrics.get("unrecognized", []))))
+                logger.error(
+                    f"{Fore.RED}FAILED{Fore.RESET}:"
+                    f" {instance.name} has unrecognized binary sections:"
+                    f" {instance.metrics.get('unrecognized', [])!s}"
+                )
                 failed += 1
 
             # FIXME: need a better way to identify executed tests
@@ -648,7 +648,7 @@ class Reporting:
             filename = os.path.join(outdir, report_name)
 
         if suffix:
-            filename = "{}_{}".format(filename, suffix)
+            filename = f"{filename}_{suffix}"
 
         if not no_update:
             json_file = filename + ".json"
@@ -669,10 +669,10 @@ class Reporting:
         platforms = {repr(inst.platform):inst.platform for _, inst in self.instances.items()}
         for platform in platforms.values():
             if suffix:
-                filename = os.path.join(outdir,"{}_{}.xml".format(platform.normalized_name, suffix))
-                json_platform_file = os.path.join(outdir,"{}_{}".format(platform.normalized_name, suffix))
+                filename = os.path.join(outdir,f"{platform.normalized_name}_{suffix}.xml")
+                json_platform_file = os.path.join(outdir,f"{platform.normalized_name}_{suffix}")
             else:
-                filename = os.path.join(outdir,"{}.xml".format(platform.normalized_name))
+                filename = os.path.join(outdir,f"{platform.normalized_name}.xml")
                 json_platform_file = os.path.join(outdir, platform.normalized_name)
             self.xunit_report(json_file, filename, platform.name, full_report=True)
             self.json_report(json_platform_file + ".json",

--- a/scripts/pylib/twister/twisterlib/reports.py
+++ b/scripts/pylib/twister/twisterlib/reports.py
@@ -116,7 +116,7 @@ class Reporting:
     def xunit_report_suites(self, json_file, filename):
 
         json_data = {}
-        with open(json_file, "r") as json_results:
+        with open(json_file) as json_results:
             json_data = json.load(json_results)
 
 
@@ -185,7 +185,7 @@ class Reporting:
             selected = self.selected_platforms
 
         json_data = {}
-        with open(json_file, "r") as json_results:
+        with open(json_file) as json_results:
             json_data = json.load(json_results)
 
 
@@ -429,7 +429,7 @@ class Reporting:
                     if do_all or k in self.env.options.footprint_report:
                         footprint_fname = os.path.join(instance.build_dir, v)
                         try:
-                            with open(footprint_fname, "rt") as footprint_json:
+                            with open(footprint_fname) as footprint_json:
                                 logger.debug(f"Collect footprint.{k} for '{instance.name}'")
                                 suite['footprint'][k] = json.load(footprint_json)
                         except FileNotFoundError:
@@ -440,7 +440,7 @@ class Reporting:
             suites.append(suite)
 
         report["testsuites"] = suites
-        with open(filename, "wt") as json_file:
+        with open(filename, 'w') as json_file:
             json.dump(report, json_file, indent=4, separators=(',',':'))
 
 

--- a/scripts/pylib/twister/twisterlib/reports.py
+++ b/scripts/pylib/twister/twisterlib/reports.py
@@ -106,7 +106,7 @@ class Reporting:
         else:
             if status == TwisterStatus.NONE:
                 logger.debug(f"{name}: No status")
-                ET.SubElement(eleTestcase, ReportStatus.SKIP, type=f"untested", message="No results captured, testsuite misconfiguration?")
+                ET.SubElement(eleTestcase, ReportStatus.SKIP, type="untested", message="No results captured, testsuite misconfiguration?")
             else:
                 logger.error(f"{name}: Unknown status '{status}'")
 
@@ -523,7 +523,7 @@ class Reporting:
             log_txt = f"The following issues were found (showing the all {count} items):"
         elif self.env.options.report_summary:
             count = self.env.options.report_summary
-            log_txt = f"The following issues were found "
+            log_txt = "The following issues were found "
             if count > self.instance_fail_count:
                 log_txt += f"(presenting {self.instance_fail_count} out of the {count} items requested):"
             else:
@@ -551,7 +551,7 @@ class Reporting:
                 break
         if cnt == 0 and self.env.options.report_summary is not None:
             logger.info("-+" * 40)
-            logger.info(f"No errors/fails found")
+            logger.info("No errors/fails found")
 
         if cnt and example_instance:
             cwd_rel_path = os.path.relpath(example_instance.testsuite.source_dir, start=os.getcwd())
@@ -563,7 +563,7 @@ class Reporting:
             logger.info("")
             logger.info(f"west twister -p {example_instance.platform.name} -s {example_instance.testsuite.name}"
                         f"{extra_parameters}")
-            logger.info(f"or with west:")
+            logger.info("or with west:")
             logger.info(f"west build -p -b {example_instance.platform.name} {cwd_rel_path} -T {example_instance.testsuite.id}")
             logger.info("-+" * 40)
 

--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -769,14 +769,16 @@ class FilterBuilder(CMake):
             filter_data.update(self.defconfig)
         filter_data.update(self.cmake_cache)
 
-        if self.instance.sysbuild and self.env.options.device_testing:
-            # Verify that twister's arguments support sysbuild.
-            # Twister sysbuild flashing currently only works with west, so
-            # --west-flash must be passed.
-            if self.env.options.west_flash is None:
-                logger.warning("Sysbuild test will be skipped. " +
-                    "West must be used for flashing.")
-                return {os.path.join(self.platform.name, self.testsuite.name): True}
+        # Verify that twister's arguments support sysbuild.
+        # Twister sysbuild flashing currently only works with west,
+        # so --west-flash must be passed.
+        if (
+            self.instance.sysbuild
+            and self.env.options.device_testing
+            and self.env.options.west_flash is None
+        ):
+            logger.warning("Sysbuild test will be skipped. West must be used for flashing.")
+            return {os.path.join(self.platform.name, self.testsuite.name): True}
 
         if self.testsuite and self.testsuite.filter:
             try:

--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -1093,8 +1093,13 @@ class ProjectBuilder(FilterBuilder):
     def demangle(self, symbol_name):
         if symbol_name[:2] == '_Z':
             try:
-                cpp_filt = subprocess.run('c++filt', input=symbol_name, text=True, check=True,
-                                          stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                cpp_filt = subprocess.run(
+                    'c++filt',
+                    input=symbol_name,
+                    text=True,
+                    check=True,
+                    capture_output=True
+                )
                 if self.trace:
                     logger.debug(f"Demangle: '{symbol_name}'==>'{cpp_filt.stdout}'")
                 return cpp_filt.stdout.strip()

--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -5,9 +5,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
-from math import log10
 import multiprocessing
 import os
+import pathlib
 import pickle
 import queue
 import re
@@ -16,22 +16,21 @@ import subprocess
 import sys
 import time
 import traceback
-import yaml
+from math import log10
 from multiprocessing import Lock, Process, Value
 from multiprocessing.managers import BaseManager
-from packaging import version
-import pathlib
 
+import elftools
+import yaml
 from colorama import Fore
 from domains import Domains
+from elftools.elf.elffile import ELFFile
+from elftools.elf.sections import SymbolTableSection
+from packaging import version
 from twisterlib.cmakecache import CMakeCache
 from twisterlib.environment import canonical_zephyr_base
 from twisterlib.error import BuildError, ConfigurationError, StatusAttributeError
 from twisterlib.statuses import TwisterStatus
-
-import elftools
-from elftools.elf.elffile import ELFFile
-from elftools.elf.sections import SymbolTableSection
 
 if version.parse(elftools.__version__) < version.parse('0.24'):
     sys.exit("pyelftools is out of date, need version 0.24 or later")
@@ -40,13 +39,13 @@ if version.parse(elftools.__version__) < version.parse('0.24'):
 if sys.platform == 'linux':
     from twisterlib.jobserver import GNUMakeJobClient, GNUMakeJobServer, JobClient
 
-from twisterlib.log_helper import log_command
-from twisterlib.testinstance import TestInstance
 from twisterlib.environment import TwisterEnv
-from twisterlib.testsuite import TestSuite
-from twisterlib.platform import Platform
-from twisterlib.testplan import change_skip_to_error_if_integration
 from twisterlib.harness import HarnessImporter, Pytest
+from twisterlib.log_helper import log_command
+from twisterlib.platform import Platform
+from twisterlib.testinstance import TestInstance
+from twisterlib.testplan import change_skip_to_error_if_integration
+from twisterlib.testsuite import TestSuite
 
 try:
     from yaml import CSafeLoader as SafeLoader

--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -1730,7 +1730,7 @@ class TwisterRunner:
         the static filter stats. So need to prepare them before pipline starts.
         '''
         for instance in self.instances.values():
-            if instance.status == TwisterStatus.FILTER and not instance.reason == 'runtime filter':
+            if instance.status == TwisterStatus.FILTER and instance.reason != 'runtime filter':
                 self.results.filtered_static_increment()
                 self.results.filtered_configs_increment()
                 self.results.filtered_cases_increment(len(instance.testsuite.testcases))

--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -59,7 +59,7 @@ logger = logging.getLogger('twister')
 logger.setLevel(logging.DEBUG)
 
 
-class ExecutionCounter(object):
+class ExecutionCounter:
     def __init__(self, total=0):
         '''
         Most of the stats are at test instance level

--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -1619,7 +1619,7 @@ class ProjectBuilder(FilterBuilder):
     @staticmethod
     def calc_size(instance: TestInstance, from_buildlog: bool):
         if instance.status not in [TwisterStatus.ERROR, TwisterStatus.FAIL, TwisterStatus.SKIP]:
-            if not instance.platform.type in ["native", "qemu", "unit"]:
+            if instance.platform.type not in ["native", "qemu", "unit"]:
                 generate_warning = bool(instance.platform.type == "mcu")
                 size_calc = instance.calculate_sizes(from_buildlog=from_buildlog, generate_warning=generate_warning)
                 instance.metrics["used_ram"] = size_calc.get_used_ram()

--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -513,11 +513,13 @@ class CMake:
         self.default_encoding = sys.getdefaultencoding()
         self.jobserver = jobserver
 
-    def parse_generated(self, filter_stages=[]):
+    def parse_generated(self, filter_stages=None):
         self.defconfig = {}
         return {}
 
-    def run_build(self, args=[]):
+    def run_build(self, args=None):
+        if args is None:
+            args = []
 
         logger.debug("Building %s for %s" % (self.source_dir, self.platform.name))
 
@@ -594,7 +596,9 @@ class CMake:
 
         return ret
 
-    def run_cmake(self, args="", filter_stages=[]):
+    def run_cmake(self, args="", filter_stages=None):
+        if filter_stages is None:
+            filter_stages = []
 
         if not self.options.disable_warnings_as_errors:
             warnings_as_errors = 'y'
@@ -711,7 +715,9 @@ class FilterBuilder(CMake):
 
         self.log = "config-twister.log"
 
-    def parse_generated(self, filter_stages=[]):
+    def parse_generated(self, filter_stages=None):
+        if filter_stages is None:
+            filter_stages = []
 
         if self.platform.name == "unit_testing":
             return {}
@@ -877,7 +883,9 @@ class ProjectBuilder(FilterBuilder):
             self.log_info("{}".format(b_log), inline_logs)
 
 
-    def _add_to_pipeline(self, pipeline, op: str, additionals: dict={}):
+    def _add_to_pipeline(self, pipeline, op: str, additionals: dict=None):
+        if additionals is None:
+            additionals = {}
         try:
             if op:
                 task = dict({'op': op, 'test': self.instance}, **additionals)
@@ -1161,7 +1169,9 @@ class ProjectBuilder(FilterBuilder):
                 testcase.reason = tc_info.get('reason')
 
 
-    def cleanup_artifacts(self, additional_keep: list[str] = []):
+    def cleanup_artifacts(self, additional_keep: list[str] = None):
+        if additional_keep is None:
+            additional_keep = []
         logger.debug("Cleaning up {}".format(self.instance.build_dir))
         allow = [
             os.path.join('zephyr', '.config'),
@@ -1529,7 +1539,9 @@ class ProjectBuilder(FilterBuilder):
 
         return args_expanded
 
-    def cmake(self, filter_stages=[]):
+    def cmake(self, filter_stages=None):
+        if filter_stages is None:
+            filter_stages = []
         args = []
         for va in self.testsuite.extra_args.copy():
             cond_args = va.split(":")

--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -743,7 +743,7 @@ class FilterBuilder(CMake):
 
 
         if not filter_stages or "kconfig" in filter_stages:
-            with open(defconfig_path, "r") as fp:
+            with open(defconfig_path) as fp:
                 defconfig = {}
                 for line in fp.readlines():
                     m = self.config_re.match(line)
@@ -1281,7 +1281,7 @@ class ProjectBuilder(FilterBuilder):
         if not os.path.exists(runners_file_path):
             return []
 
-        with open(runners_file_path, 'r') as file:
+        with open(runners_file_path) as file:
             runners_content: dict = yaml.load(file, Loader=SafeLoader)
 
         if 'config' not in runners_content:
@@ -1320,7 +1320,7 @@ class ProjectBuilder(FilterBuilder):
         if not os.path.exists(runners_file_path):
             return
 
-        with open(runners_file_path, 'rt') as file:
+        with open(runners_file_path) as file:
             runners_content_text = file.read()
             runners_content_yaml: dict = yaml.load(runners_content_text, Loader=SafeLoader)
 
@@ -1338,7 +1338,7 @@ class ProjectBuilder(FilterBuilder):
             binary_path_relative = os.path.relpath(binary_path, start=runners_dir_path)
             runners_content_text = runners_content_text.replace(binary_path, binary_path_relative)
 
-        with open(runners_file_path, 'wt') as file:
+        with open(runners_file_path, 'w') as file:
             file.write(runners_content_text)
 
     def _sanitize_zephyr_base_from_files(self):
@@ -1354,14 +1354,14 @@ class ProjectBuilder(FilterBuilder):
             if not os.path.exists(file_path):
                 continue
 
-            with open(file_path, "rt") as file:
+            with open(file_path) as file:
                 data = file.read()
 
             # add trailing slash at the end of canonical_zephyr_base if it does not exist:
             path_to_remove = os.path.join(canonical_zephyr_base, "")
             data = data.replace(path_to_remove, "")
 
-            with open(file_path, "wt") as file:
+            with open(file_path, 'w') as file:
                 file.write(data)
 
     @staticmethod

--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -153,7 +153,10 @@ class ExecutionCounter:
 
         Node(f"Total test suites: {self.total}", parent=root)
         processed_suites = Node(f"Processed test suites: {self.done}", parent=root)
-        filtered_suites = Node(f"Filtered test suites: {self.filtered_configs}", parent=processed_suites)
+        filtered_suites = Node(
+            f"Filtered test suites: {self.filtered_configs}",
+            parent=processed_suites
+        )
         Node(f"Filtered test suites (static): {self.filtered_static}", parent=filtered_suites)
         Node(f"Filtered test suites (at runtime): {self.filtered_runtime}", parent=filtered_suites)
         selected_suites = Node(f"Selected test suites: {selected_configs}", parent=processed_suites)
@@ -171,10 +174,16 @@ class ExecutionCounter:
         Node(f"Built only test cases: {self.notrun_cases}", parent=selected_cases_node)
         Node(f"Blocked test cases: {self.blocked_cases}", parent=selected_cases_node)
         Node(f"Failed test cases: {self.failed_cases}", parent=selected_cases_node)
-        error_cases_node = Node(f"Errors in test cases: {self.error_cases}", parent=selected_cases_node)
+        error_cases_node = Node(
+            f"Errors in test cases: {self.error_cases}",
+            parent=selected_cases_node
+        )
 
         if self.none_cases or self.started_cases:
-            Node("The following test case statuses should not appear in a proper execution", parent=error_cases_node)
+            Node(
+                "The following test case statuses should not appear in a proper execution",
+                parent=error_cases_node
+            )
         if self.none_cases:
             Node(f"Statusless test cases: {self.none_cases}", parent=error_cases_node)
         if self.started_cases:
@@ -550,7 +559,10 @@ class CMake:
         duration = time.time() - start_time
         self.instance.build_time += duration
         if p.returncode == 0:
-            msg = f"Finished building {self.source_dir} for {self.platform.name} in {duration:.2f} seconds"
+            msg = (
+                f"Finished building {self.source_dir} for {self.platform.name}"
+                f" in {duration:.2f} seconds"
+            )
             logger.debug(msg)
 
             if not self.instance.run:
@@ -562,7 +574,11 @@ class CMake:
 
             if out:
                 log_msg = out.decode(self.default_encoding)
-                with open(os.path.join(self.build_dir, self.log), "a", encoding=self.default_encoding) as log:
+                with open(
+                    os.path.join(self.build_dir, self.log),
+                    "a",
+                    encoding=self.default_encoding
+                ) as log:
                     log.write(log_msg)
             else:
                 return None
@@ -571,12 +587,22 @@ class CMake:
             log_msg = ""
             if out:
                 log_msg = out.decode(self.default_encoding)
-                with open(os.path.join(self.build_dir, self.log), "a", encoding=self.default_encoding) as log:
+                with open(
+                    os.path.join(self.build_dir, self.log),
+                    "a",
+                    encoding=self.default_encoding
+                ) as log:
                     log.write(log_msg)
 
             if log_msg:
-                overflow_found = re.findall("region `(FLASH|ROM|RAM|ICCM|DCCM|SRAM|dram\\d_\\d_seg)' overflowed by", log_msg)
-                imgtool_overflow_found = re.findall(r"Error: Image size \(.*\) \+ trailer \(.*\) exceeds requested size", log_msg)
+                overflow_found = re.findall(
+                    "region `(FLASH|ROM|RAM|ICCM|DCCM|SRAM|dram\\d_\\d_seg)' overflowed by",
+                    log_msg
+                )
+                imgtool_overflow_found = re.findall(
+                    r"Error: Image size \(.*\) \+ trailer \(.*\) exceeds requested size",
+                    log_msg
+                )
                 if overflow_found and not self.options.overflow_as_errors:
                     logger.debug(f"Test skipped due to {overflow_found[0]} Overflow")
                     self.instance.status = TwisterStatus.SKIP
@@ -650,7 +676,9 @@ class CMake:
         cmake_args.extend(cmake_opts)
 
         if self.instance.testsuite.required_snippets:
-            cmake_opts = ['-DSNIPPET={}'.format(';'.join(self.instance.testsuite.required_snippets))]
+            cmake_opts = [
+                '-DSNIPPET={}'.format(';'.join(self.instance.testsuite.required_snippets))
+            ]
             cmake_args.extend(cmake_opts)
 
         cmake = shutil.which('cmake')
@@ -683,7 +711,10 @@ class CMake:
 
         if p.returncode == 0:
             filter_results = self.parse_generated(filter_stages)
-            msg = f"Finished running cmake {self.source_dir} for {self.platform.name} in {duration:.2f} seconds"
+            msg = (
+                f"Finished running cmake {self.source_dir} for {self.platform.name}"
+                f" in {duration:.2f} seconds"
+            )
             logger.debug(msg)
             ret = {
                     'returncode': p.returncode,
@@ -701,7 +732,11 @@ class CMake:
 
         if out:
             os.makedirs(self.build_dir, exist_ok=True)
-            with open(os.path.join(self.build_dir, self.log), "a", encoding=self.default_encoding) as log:
+            with open(
+                os.path.join(self.build_dir, self.log),
+                "a",
+                encoding=self.default_encoding
+            ) as log:
                 log_msg = out.decode(self.default_encoding)
                 log.write(log_msg)
 
@@ -734,11 +769,12 @@ class FilterBuilder(CMake):
             edt_pickle = os.path.join(domain_build, "zephyr", "edt.pickle")
         else:
             cmake_cache_path = os.path.join(self.build_dir, "CMakeCache.txt")
-            # .config is only available after kconfig stage in cmake. If only dt based filtration is required
-            # package helper call won't produce .config
+            # .config is only available after kconfig stage in cmake.
+            # If only dt based filtration is required package helper call won't produce .config
             if not filter_stages or "kconfig" in filter_stages:
                 defconfig_path = os.path.join(self.build_dir, "zephyr", ".config")
-            # dt is compiled before kconfig, so edt_pickle is available regardless of choice of filter stages
+            # dt is compiled before kconfig,
+            # so edt_pickle is available regardless of choice of filter stages
             edt_pickle = os.path.join(self.build_dir, "zephyr", "edt.pickle")
 
 
@@ -811,7 +847,13 @@ class FilterBuilder(CMake):
 class ProjectBuilder(FilterBuilder):
 
     def __init__(self, instance: TestInstance, env: TwisterEnv, jobserver, **kwargs):
-        super().__init__(instance.testsuite, instance.platform, instance.testsuite.source_dir, instance.build_dir, jobserver)
+        super().__init__(
+            instance.testsuite,
+            instance.platform,
+            instance.testsuite.source_dir,
+            instance.build_dir,
+            jobserver
+        )
 
         self.log = "build.log"
         self.instance = instance
@@ -976,14 +1018,22 @@ class ProjectBuilder(FilterBuilder):
                     # due to ram/rom overflow.
                     if  self.instance.status == TwisterStatus.SKIP:
                         results.skipped_increment()
-                        self.instance.add_missing_case_status(TwisterStatus.SKIP, self.instance.reason)
+                        self.instance.add_missing_case_status(
+                            TwisterStatus.SKIP,
+                            self.instance.reason
+                        )
 
                     if ret.get('returncode', 1) > 0:
-                        self.instance.add_missing_case_status(TwisterStatus.BLOCK, self.instance.reason)
+                        self.instance.add_missing_case_status(
+                            TwisterStatus.BLOCK,
+                            self.instance.reason
+                        )
                         next_op = 'report'
                     else:
                         if self.instance.testsuite.harness in ['ztest', 'test']:
-                            logger.debug(f"Determine test cases for test instance: {self.instance.name}")
+                            logger.debug(
+                                f"Determine test cases for test instance: {self.instance.name}"
+                            )
                             try:
                                 self.determine_testcases(results)
                                 next_op = 'gather_metrics'
@@ -1015,9 +1065,15 @@ class ProjectBuilder(FilterBuilder):
                     next_op = 'run'
                 else:
                     if self.instance.status == TwisterStatus.NOTRUN:
-                        run_conditions =  f"(run:{self.instance.run}, handler.ready:{self.instance.handler.ready})"
+                        run_conditions =  (
+                            f"(run:{self.instance.run},"
+                            f" handler.ready:{self.instance.handler.ready})"
+                        )
                         logger.debug(f"Instance {self.instance.name} can't run {run_conditions}")
-                        self.instance.add_missing_case_status(TwisterStatus.NOTRUN, "Nowhere to run")
+                        self.instance.add_missing_case_status(
+                            TwisterStatus.NOTRUN,
+                            "Nowhere to run"
+                        )
                     next_op = 'report'
             except StatusAttributeError as sae:
                 logger.error(str(sae))
@@ -1090,7 +1146,10 @@ class ProjectBuilder(FilterBuilder):
                 mode = message.get("mode")
                 if mode == "device":
                     self.cleanup_device_testing_artifacts()
-                elif mode == "passed" or (mode == "all" and self.instance.reason != "CMake build failure"):
+                elif (
+                    mode == "passed"
+                    or (mode == "all" and self.instance.reason != "CMake build failure")
+                ):
                     self.cleanup_artifacts()
             except StatusAttributeError as sae:
                 logger.error(str(sae))
@@ -1120,7 +1179,9 @@ class ProjectBuilder(FilterBuilder):
         yaml_testsuite_name = self.instance.testsuite.id
         logger.debug(f"Determine test cases for test suite: {yaml_testsuite_name}")
 
-        logger.debug(f"Test instance {self.instance.name} already has {len(self.instance.testcases)} cases.")
+        logger.debug(
+            f"Test instance {self.instance.name} already has {len(self.instance.testcases)} cases."
+        )
         new_ztest_unit_test_regex = re.compile(r"z_ztest_unit_test__([^\s]+?)__([^\s]*)")
         detected_cases = []
 
@@ -1154,7 +1215,10 @@ class ProjectBuilder(FilterBuilder):
 
         if detected_cases:
             logger.debug(f"Detected Ztest cases: [{', '.join(detected_cases)}] in {elf_file}")
-            tc_keeper = {tc.name: {'status': tc.status, 'reason': tc.reason} for tc in self.instance.testcases}
+            tc_keeper = {
+                tc.name: {'status': tc.status, 'reason': tc.reason}
+                for tc in self.instance.testcases
+            }
             self.instance.testcases.clear()
             self.instance.testsuite.testcases.clear()
 
@@ -1400,8 +1464,10 @@ class ProjectBuilder(FilterBuilder):
                                  f' test case {tc.name}.')
                     results.warnings_increment(1)
                 case _:
-                    logger.warning(f'An unknown status "{tc.status}" detected in instance {instance.name},'
-                                 f' test case {tc.name}.')
+                    logger.warning(
+                        f'An unknown status "{tc.status}" detected in instance {instance.name},'
+                        f' test case {tc.name}.'
+                    )
                     results.warnings_increment(1)
 
 
@@ -1415,7 +1481,9 @@ class ProjectBuilder(FilterBuilder):
 
         self._add_instance_testcases_to_status_counts(instance, results)
 
-        status = f'{TwisterStatus.get_color(instance.status)}{str.upper(instance.status)}{Fore.RESET}'
+        status = (
+            f'{TwisterStatus.get_color(instance.status)}{str.upper(instance.status)}{Fore.RESET}'
+        )
 
         if instance.status in [TwisterStatus.ERROR, TwisterStatus.FAIL]:
             if instance.status == TwisterStatus.ERROR:
@@ -1426,7 +1494,9 @@ class ProjectBuilder(FilterBuilder):
                 status += " " + instance.reason
             else:
                 logger.error(
-                    f"{instance.platform.name:<25} {instance.testsuite.name:<50} {status}: {instance.reason}")
+                    f"{instance.platform.name:<25} {instance.testsuite.name:<50}"
+                    f" {status}: {instance.reason}"
+                )
             if not self.options.verbose:
                 self.log_info_file(self.options.inline_logs)
         elif instance.status == TwisterStatus.SKIP:
@@ -1479,35 +1549,46 @@ class ProjectBuilder(FilterBuilder):
         else:
             completed_perc = 0
             if total_to_do > 0:
-                completed_perc = int((float(results.done - results.filtered_static) / total_to_do) * 100)
+                completed_perc = int(
+                    (float(results.done - results.filtered_static) / total_to_do) * 100
+                )
 
             unfiltered = results.done - results.filtered_static
+            complete_section = (
+                f"{TwisterStatus.get_color(TwisterStatus.PASS)}"
+                f"{unfiltered:>4}/{total_to_do:>4}"
+                f"{Fore.RESET}  {completed_perc:>2}%"
+            )
+            notrun_section = (
+                f"{TwisterStatus.get_color(TwisterStatus.NOTRUN)}{results.notrun:>4}{Fore.RESET}"
+            )
             filtered_section_color = (
                 TwisterStatus.get_color(TwisterStatus.SKIP)
                 if results.filtered_configs > 0
                 else Fore.RESET
             )
+            filtered_section = (
+                f"{filtered_section_color}{results.filtered_configs:>4}{Fore.RESET}"
+            )
             failed_section_color = (
                 TwisterStatus.get_color(TwisterStatus.FAIL) if results.failed > 0 else Fore.RESET
+            )
+            failed_section = (
+                f"{failed_section_color}{results.failed:>4}{Fore.RESET}"
             )
             error_section_color = (
                 TwisterStatus.get_color(TwisterStatus.ERROR) if results.error > 0 else Fore.RESET
             )
-            sys.stdout.write(
-                f"INFO    - Total complete: "
-                f"{TwisterStatus.get_color(TwisterStatus.PASS)}"
-                f"{unfiltered:>4}/{total_to_do:>4}"
-                f"{Fore.RESET}  {completed_perc:>2}%"
-                "  built (not run):"
-                f" {TwisterStatus.get_color(TwisterStatus.NOTRUN)}{results.notrun:>4}{Fore.RESET},"
-                " filtered:"
-                f" {filtered_section_color}{results.filtered_configs:>4}{Fore.RESET},"
-                " failed:"
-                f" {failed_section_color}{results.failed:>4}{Fore.RESET},"
-                " error:"
-                f" {error_section_color}{results.error:>4}{Fore.RESET}\r"
+            error_section = (
+                f"{error_section_color}{results.error:>4}{Fore.RESET}"
             )
-
+            sys.stdout.write(
+                f"INFO    - Total complete: {complete_section}"
+                f"  built (not run): {notrun_section},"
+                f" filtered: {filtered_section},"
+                f" failed: {failed_section},"
+                f" error: {error_section}\r"
+            )
         sys.stdout.flush()
 
     @staticmethod
@@ -1648,7 +1729,10 @@ class ProjectBuilder(FilterBuilder):
         if instance.status not in [TwisterStatus.ERROR, TwisterStatus.FAIL, TwisterStatus.SKIP]:
             if instance.platform.type not in ["native", "qemu", "unit"]:
                 generate_warning = bool(instance.platform.type == "mcu")
-                size_calc = instance.calculate_sizes(from_buildlog=from_buildlog, generate_warning=generate_warning)
+                size_calc = instance.calculate_sizes(
+                    from_buildlog=from_buildlog,
+                    generate_warning=generate_warning
+                )
                 instance.metrics["used_ram"] = size_calc.get_used_ram()
                 instance.metrics["used_rom"] = size_calc.get_used_rom()
                 instance.metrics["available_rom"] = size_calc.get_available_rom()
@@ -1773,12 +1857,23 @@ class TwisterRunner:
             f" {self.results.filtered_configs - self.results.filtered_static} at runtime)."
         )
 
-    def add_tasks_to_queue(self, pipeline, build_only=False, test_only=False, retry_build_errors=False):
+    def add_tasks_to_queue(
+        self,
+        pipeline,
+        build_only=False,
+        test_only=False,
+        retry_build_errors=False
+    ):
         for instance in self.instances.values():
             if build_only:
                 instance.run = False
 
-            no_retry_statuses = [TwisterStatus.PASS, TwisterStatus.SKIP, TwisterStatus.FILTER, TwisterStatus.NOTRUN]
+            no_retry_statuses = [
+                TwisterStatus.PASS,
+                TwisterStatus.SKIP,
+                TwisterStatus.FILTER,
+                TwisterStatus.NOTRUN
+            ]
             if not retry_build_errors:
                 no_retry_statuses.append(TwisterStatus.ERROR)
 
@@ -1789,12 +1884,19 @@ class TwisterRunner:
                 instance.status = TwisterStatus.NONE
                 # Previous states should be removed from the stats
                 if self.results.iteration > 1:
-                    ProjectBuilder._add_instance_testcases_to_status_counts(instance, self.results, decrement=True)
+                    ProjectBuilder._add_instance_testcases_to_status_counts(
+                        instance,
+                        self.results,
+                        decrement=True
+                    )
 
                 # Check if cmake package_helper script can be run in advance.
                 instance.filter_stages = []
                 if instance.testsuite.filter:
-                    instance.filter_stages = self.get_cmake_filter_stages(instance.testsuite.filter, expr_parser.reserved.keys())
+                    instance.filter_stages = self.get_cmake_filter_stages(
+                        instance.testsuite.filter,
+                        expr_parser.reserved.keys()
+                    )
 
                 if test_only and instance.run:
                     pipeline.put({"op": "run", "test": instance})
@@ -1870,13 +1972,16 @@ class TwisterRunner:
 
     @staticmethod
     def get_cmake_filter_stages(filt, logic_keys):
-        """ Analyze filter expressions from test yaml and decide if dts and/or kconfig based filtering will be needed."""
+        """Analyze filter expressions from test yaml
+        and decide if dts and/or kconfig based filtering will be needed.
+        """
         dts_required = False
         kconfig_required = False
         full_required = False
         filter_stages = []
 
-        # Compress args in expressions like "function('x', 'y')" so they are not split when splitting by whitespaces
+        # Compress args in expressions like "function('x', 'y')"
+        # so they are not split when splitting by whitespaces
         filt = filt.replace(", ", ",")
         # Remove logic words
         for k in logic_keys:

--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -1018,7 +1018,7 @@ class ProjectBuilder(FilterBuilder):
                     if self.instance.status == TwisterStatus.NOTRUN:
                         run_conditions =  f"(run:{self.instance.run}, handler.ready:{self.instance.handler.ready})"
                         logger.debug(f"Instance {self.instance.name} can't run {run_conditions}")
-                        self.instance.add_missing_case_status(TwisterStatus.NOTRUN, f"Nowhere to run")
+                        self.instance.add_missing_case_status(TwisterStatus.NOTRUN, "Nowhere to run")
                     next_op = 'report'
             except StatusAttributeError as sae:
                 logger.error(str(sae))

--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -54,10 +54,11 @@ try:
 except ImportError:
     from yaml import SafeLoader
 
-logger = logging.getLogger('twister')
-logger.setLevel(logging.DEBUG)
 import expr_parser
 from anytree import Node, RenderTree
+
+logger = logging.getLogger('twister')
+logger.setLevel(logging.DEBUG)
 
 
 class ExecutionCounter(object):

--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -19,7 +19,6 @@ import traceback
 import yaml
 from multiprocessing import Lock, Process, Value
 from multiprocessing.managers import BaseManager
-from typing import List
 from packaging import version
 import pathlib
 
@@ -1156,7 +1155,7 @@ class ProjectBuilder(FilterBuilder):
                 testcase.reason = tc_info.get('reason')
 
 
-    def cleanup_artifacts(self, additional_keep: List[str] = []):
+    def cleanup_artifacts(self, additional_keep: list[str] = []):
         logger.debug("Cleaning up {}".format(self.instance.build_dir))
         allow = [
             os.path.join('zephyr', '.config'),
@@ -1209,7 +1208,7 @@ class ProjectBuilder(FilterBuilder):
 
         self._sanitize_files()
 
-    def _get_artifact_allow_list_for_domain(self, domain: str) -> List[str]:
+    def _get_artifact_allow_list_for_domain(self, domain: str) -> list[str]:
         """
         Return a list of files needed to test a given domain.
         """
@@ -1223,14 +1222,14 @@ class ProjectBuilder(FilterBuilder):
             ]
         return allow
 
-    def _get_binaries(self) -> List[str]:
+    def _get_binaries(self) -> list[str]:
         """
         Get list of binaries paths (absolute or relative to the
         self.instance.build_dir), basing on information from platform.binaries
         or runners.yaml. If they are not found take default binaries like
         "zephyr/zephyr.hex" etc.
         """
-        binaries: List[str] = []
+        binaries: list[str] = []
 
         platform = self.instance.platform
         if platform.binaries:
@@ -1254,7 +1253,7 @@ class ProjectBuilder(FilterBuilder):
             ]
         return binaries
 
-    def _get_binaries_from_runners(self, domain='') -> List[str]:
+    def _get_binaries_from_runners(self, domain='') -> list[str]:
         """
         Get list of binaries paths (absolute or relative to the
         self.instance.build_dir) from runners.yaml file. May be used for
@@ -1273,9 +1272,9 @@ class ProjectBuilder(FilterBuilder):
             return []
 
         runners_config: dict = runners_content['config']
-        binary_keys: List[str] = ['elf_file', 'hex_file', 'bin_file']
+        binary_keys: list[str] = ['elf_file', 'hex_file', 'bin_file']
 
-        binaries: List[str] = []
+        binaries: list[str] = []
         for binary_key in binary_keys:
             binary_path = runners_config.get(binary_key)
             if binary_path is None:
@@ -1313,7 +1312,7 @@ class ProjectBuilder(FilterBuilder):
             return
 
         runners_config: dict = runners_content_yaml['config']
-        binary_keys: List[str] = ['elf_file', 'hex_file', 'bin_file']
+        binary_keys: list[str] = ['elf_file', 'hex_file', 'bin_file']
 
         for binary_key in binary_keys:
             binary_path = runners_config.get(binary_key)

--- a/scripts/pylib/twister/twisterlib/size_calc.py
+++ b/scripts/pylib/twister/twisterlib/size_calc.py
@@ -132,12 +132,12 @@ class SizeCalculator:
         print(self.elf_filename)
         print("SECTION NAME             VMA        LMA     SIZE  HEX SZ TYPE")
         for v in self.sections:
-            print("%-17s 0x%08x 0x%08x %8d 0x%05x %-7s" %
-                        (v["name"], v["virt_addr"], v["load_addr"], v["size"], v["size"],
-                        v["type"]))
+            print(
+                f'{v["name"]:<17} {v["virt_addr"]:#010x} {v["load_addr"]:#010x}'
+                f' {v["size"]:>8} {v["size"]:#07x} {v["type"]:<7}'
+            )
 
-        print("Totals: %d bytes (ROM), %d bytes (RAM)" %
-                    (self.used_rom, self.used_ram))
+        print(f"Totals: {self.used_rom} bytes (ROM), {self.used_ram} bytes (RAM)")
         print("")
 
     def get_used_ram(self):
@@ -196,7 +196,7 @@ class SizeCalculator:
 
         try:
             if magic != b'\x7fELF':
-                raise TwisterRuntimeError("%s is not an ELF binary" % self.elf_filename)
+                raise TwisterRuntimeError(f"{self.elf_filename} is not an ELF binary")
         except Exception as e:
             print(str(e))
             sys.exit(2)
@@ -212,7 +212,7 @@ class SizeCalculator:
             "utf-8").strip()
         try:
             if is_xip_output.endswith("no symbols"):
-                raise TwisterRuntimeError("%s has no symbol information" % self.elf_filename)
+                raise TwisterRuntimeError(f"{self.elf_filename} has no symbol information")
         except Exception as e:
             print(str(e))
             sys.exit(2)

--- a/scripts/pylib/twister/twisterlib/size_calc.py
+++ b/scripts/pylib/twister/twisterlib/size_calc.py
@@ -297,7 +297,7 @@ class SizeCalculator:
         @return Content of the build.log file (list[str])
         """
         if os.path.exists(path=self.buildlog_filename):
-            with open(file=self.buildlog_filename, mode='r') as file:
+            with open(file=self.buildlog_filename) as file:
                 file_content = file.readlines()
         else:
             if self.generate_warning:

--- a/scripts/pylib/twister/twisterlib/size_calc.py
+++ b/scripts/pylib/twister/twisterlib/size_calc.py
@@ -301,7 +301,10 @@ class SizeCalculator:
                 file_content = file.readlines()
         else:
             if self.generate_warning:
-                logger.error(msg=f"Incorrect path to build.log file to analyze footprints. Please check the path {self.buildlog_filename}.")
+                logger.error(
+                    msg="Incorrect path to build.log file to analyze footprints."
+                       f" Please check the path {self.buildlog_filename}."
+                )
             file_content = []
         return file_content
 
@@ -325,13 +328,16 @@ class SizeCalculator:
                     break
         # If the file does not contain information about memory footprint, the warning is raised.
         if result == -1:
-            logger.warning(msg=f"Information about memory footprint for this test configuration is not found. Please check file {self.buildlog_filename}.")
+            logger.warning(
+                msg="Information about memory footprint for this test configuration is not found."
+                   f" Please check file {self.buildlog_filename}."
+            )
         return result
 
     def _get_lines_with_footprint(self, start_offset: int, file_content: list[str]) -> list[str]:
         """Get lines from the file with a memory footprint.
 
-        @param start_offset (int) Offset with the first line of the information about memory footprint.
+        @param start_offset (int) Offset with the memory footprint's first line.
         @param file_content (list[str]) Content of the build.log file.
         @return Lines with information about memory footprint (list[str])
         """
@@ -368,7 +374,12 @@ class SizeCalculator:
             result = []
             PATTERN_SPLIT_COLUMNS = "  +"
             for line in text_lines:
-                line = [column.rstrip(":") for column in re.split(pattern=PATTERN_SPLIT_COLUMNS, string=line)]
+                line = [
+                    column.rstrip(":") for column in re.split(
+                        pattern=PATTERN_SPLIT_COLUMNS,
+                        string=line
+                    )
+                ]
                 result.append(list(filter(None, line)))
         else:
             result = [[]]
@@ -384,7 +395,10 @@ class SizeCalculator:
         if len(data_lines) != self.USEFUL_LINES_AMOUNT:
             data_lines = [[]]
             if self.generate_warning:
-                logger.warning(msg=f"Incomplete information about memory footprint. Please check file {self.buildlog_filename}")
+                logger.warning(
+                    msg="Incomplete information about memory footprint."
+                       f" Please check file {self.buildlog_filename}"
+                )
         else:
             for idx, line in enumerate(data_lines):
                 # Line with description of the columns
@@ -423,13 +437,18 @@ class SizeCalculator:
         @return Table with information about memory usage (list[list[str]])
         """
         file_content = self._get_buildlog_file_content()
-        data_line_start_idx = self._find_offset_of_last_pattern_occurrence(file_content=file_content)
+        data_line_start_idx = self._find_offset_of_last_pattern_occurrence(
+            file_content=file_content
+        )
 
         if data_line_start_idx < 0:
             data_from_content = [[]]
         else:
             # Clean lines and separate information to columns
-            information_lines = self._get_lines_with_footprint(start_offset=data_line_start_idx, file_content=file_content)
+            information_lines = self._get_lines_with_footprint(
+                start_offset=data_line_start_idx,
+                file_content=file_content
+            )
             information_lines = self._clear_whitespaces_from_lines(text_lines=information_lines)
             data_from_content = self._divide_text_lines_into_columns(text_lines=information_lines)
             data_from_content = self._unify_prefixes_on_all_values(data_lines=data_from_content)
@@ -446,7 +465,10 @@ class SizeCalculator:
             self.available_ram = 0
             self.available_rom = 0
             if self.generate_warning:
-                logger.warning(msg=f"Missing information about memory footprint. Check file {self.buildlog_filename}.")
+                logger.warning(
+                    msg="Missing information about memory footprint."
+                       f" Check file {self.buildlog_filename}."
+                )
         else:
             ROW_RAM_IDX = 2
             ROW_ROM_IDX = 1

--- a/scripts/pylib/twister/twisterlib/size_calc.py
+++ b/scripts/pylib/twister/twisterlib/size_calc.py
@@ -9,7 +9,6 @@ import os
 import re
 import subprocess
 import sys
-import typing
 
 from twisterlib.error import TwisterRuntimeError
 
@@ -99,7 +98,7 @@ class SizeCalculator:
     USEFUL_LINES_AMOUNT = 4
 
     def __init__(self, elf_filename: str,\
-        extra_sections: typing.List[str],\
+        extra_sections: list[str],\
         buildlog_filepath: str = '',\
         generate_warning: bool = True):
         """Constructor
@@ -292,7 +291,7 @@ class SizeCalculator:
         self._check_is_xip()
         self._get_info_elf_sections()
 
-    def _get_buildlog_file_content(self) -> typing.List[str]:
+    def _get_buildlog_file_content(self) -> list[str]:
         """Get content of the build.log file.
 
         @return Content of the build.log file (list[str])
@@ -306,7 +305,7 @@ class SizeCalculator:
             file_content = []
         return file_content
 
-    def _find_offset_of_last_pattern_occurrence(self, file_content: typing.List[str]) -> int:
+    def _find_offset_of_last_pattern_occurrence(self, file_content: list[str]) -> int:
         """Find the offset from which the information about the memory footprint is read.
 
         @param file_content (list[str]) Content of build.log.
@@ -329,7 +328,7 @@ class SizeCalculator:
             logger.warning(msg=f"Information about memory footprint for this test configuration is not found. Please check file {self.buildlog_filename}.")
         return result
 
-    def _get_lines_with_footprint(self, start_offset: int, file_content: typing.List[str]) -> typing.List[str]:
+    def _get_lines_with_footprint(self, start_offset: int, file_content: list[str]) -> list[str]:
         """Get lines from the file with a memory footprint.
 
         @param start_offset (int) Offset with the first line of the information about memory footprint.
@@ -351,7 +350,7 @@ class SizeCalculator:
             result = file_content[info_line_idx_start:info_line_idx_stop]
         return result
 
-    def _clear_whitespaces_from_lines(self, text_lines: typing.List[str]) -> typing.List[str]:
+    def _clear_whitespaces_from_lines(self, text_lines: list[str]) -> list[str]:
         """Clear text lines from whitespaces.
 
         @param text_lines (list[str]) Lines with useful information.
@@ -359,7 +358,7 @@ class SizeCalculator:
         """
         return [line.strip("\n").rstrip("%") for line in text_lines] if text_lines else []
 
-    def _divide_text_lines_into_columns(self, text_lines: typing.List[str]) -> typing.List[typing.List[str]]:
+    def _divide_text_lines_into_columns(self, text_lines: list[str]) -> list[list[str]]:
         """Divide lines of text into columns.
 
         @param lines (list[list[str]]) Lines with information about memory footprint.
@@ -376,7 +375,7 @@ class SizeCalculator:
 
         return result
 
-    def _unify_prefixes_on_all_values(self, data_lines: typing.List[typing.List[str]]) -> typing.List[typing.List[str]]:
+    def _unify_prefixes_on_all_values(self, data_lines: list[list[str]]) -> list[list[str]]:
         """Convert all values in the table to unified order of magnitude.
 
         @param data_lines (list[list[str]]) Lines with information about memory footprint.
@@ -418,7 +417,7 @@ class SizeCalculator:
             converted_value = str(numeric_value * unit_predictor)
         return converted_value
 
-    def _create_data_table(self) -> typing.List[typing.List[str]]:
+    def _create_data_table(self) -> list[list[str]]:
         """Create table with information about memory footprint.
 
         @return Table with information about memory usage (list[list[str]])

--- a/scripts/pylib/twister/twisterlib/size_calc.py
+++ b/scripts/pylib/twister/twisterlib/size_calc.py
@@ -4,12 +4,13 @@
 # Copyright (c) 2018 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-import subprocess
-import sys
+import logging
 import os
 import re
+import subprocess
+import sys
 import typing
-import logging
+
 from twisterlib.error import TwisterRuntimeError
 
 logger = logging.getLogger('twister')

--- a/scripts/pylib/twister/twisterlib/statuses.py
+++ b/scripts/pylib/twister/twisterlib/statuses.py
@@ -35,7 +35,7 @@ class TwisterStatus(str, Enum):
             TwisterStatus.STARTED: Fore.MAGENTA,
             TwisterStatus.NONE: Fore.MAGENTA
         }
-        return status2color[status] if status in status2color else Fore.RESET
+        return status2color.get(status, Fore.RESET)
 
     # All statuses below this comment can be used for TestCase
     BLOCK = 'blocked'

--- a/scripts/pylib/twister/twisterlib/statuses.py
+++ b/scripts/pylib/twister/twisterlib/statuses.py
@@ -7,8 +7,9 @@ Status classes to be used instead of str statuses.
 """
 from __future__ import annotations
 
-from colorama import Fore
 from enum import Enum
+
+from colorama import Fore
 
 
 class TwisterStatus(str, Enum):

--- a/scripts/pylib/twister/twisterlib/testinstance.py
+++ b/scripts/pylib/twister/twisterlib/testinstance.py
@@ -110,8 +110,8 @@ class TestInstance:
         try:
             key = value.name if isinstance(value, Enum) else value
             self._status = TwisterStatus[key]
-        except KeyError:
-            raise StatusAttributeError(self.__class__, value)
+        except KeyError as err:
+            raise StatusAttributeError(self.__class__, value) from err
 
     def add_filter(self, reason, filter_type):
         self.filters.append({'type': filter_type, 'reason': reason })

--- a/scripts/pylib/twister/twisterlib/testinstance.py
+++ b/scripts/pylib/twister/twisterlib/testinstance.py
@@ -397,4 +397,4 @@ class TestInstance:
         return buildlog_paths[0]
 
     def __repr__(self):
-        return "<TestSuite %s on %s>" % (self.testsuite.name, self.platform.name)
+        return f"<TestSuite {self.testsuite.name} on {self.platform.name}>"

--- a/scripts/pylib/twister/twisterlib/testinstance.py
+++ b/scripts/pylib/twister/twisterlib/testinstance.py
@@ -300,7 +300,9 @@ class TestInstance:
 
         return testsuite_runnable and target_ready
 
-    def create_overlay(self, platform, enable_asan=False, enable_ubsan=False, enable_coverage=False, coverage_platform=[]):
+    def create_overlay(self, platform, enable_asan=False, enable_ubsan=False, enable_coverage=False, coverage_platform=None):
+        if coverage_platform is None:
+            coverage_platform = []
         # Create this in a "twister/" subdirectory otherwise this
         # will pass this overlay to kconfig.py *twice* and kconfig.cmake
         # will silently give that second time precedence over any

--- a/scripts/pylib/twister/twisterlib/testinstance.py
+++ b/scripts/pylib/twister/twisterlib/testinstance.py
@@ -333,12 +333,10 @@ class TestInstance:
                     content = content + "\nCONFIG_COVERAGE=y"
                     content = content + "\nCONFIG_COVERAGE_DUMP=y"
 
-        if enable_asan:
-            if platform.type == "native":
+        if platform.type == "native":
+            if enable_asan:
                 content = content + "\nCONFIG_ASAN=y"
-
-        if enable_ubsan:
-            if platform.type == "native":
+            if enable_ubsan:
                 content = content + "\nCONFIG_UBSAN=y"
 
         if content:

--- a/scripts/pylib/twister/twisterlib/testinstance.py
+++ b/scripts/pylib/twister/twisterlib/testinstance.py
@@ -92,7 +92,7 @@ class TestInstance:
                 self.recording.extend(recording)
 
             filename = os.path.join(self.build_dir, fname_csv)
-            with open(filename, "wt") as csvfile:
+            with open(filename, 'w') as csvfile:
                 cw = csv.DictWriter(csvfile,
                                     fieldnames = self.recording[0].keys(),
                                     lineterminator = os.linesep,
@@ -131,7 +131,7 @@ class TestInstance:
         run_id = ""
         run_id_file = os.path.join(self.build_dir, "run_id.txt")
         if os.path.exists(run_id_file):
-            with open(run_id_file, "r") as fp:
+            with open(run_id_file) as fp:
                 run_id = fp.read()
         else:
             hash_object = hashlib.md5(self.name.encode())

--- a/scripts/pylib/twister/twisterlib/testinstance.py
+++ b/scripts/pylib/twister/twisterlib/testinstance.py
@@ -6,33 +6,34 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-from enum import Enum
-import os
-import hashlib
-import random
-import logging
-import glob
-import csv
 
-from twisterlib.environment import TwisterEnv
-from twisterlib.testsuite import TestCase, TestSuite
-from twisterlib.platform import Platform
-from twisterlib.error import BuildError, StatusAttributeError
-from twisterlib.size_calc import SizeCalculator
-from twisterlib.statuses import TwisterStatus
-from twisterlib.handlers import (
-    Handler,
-    SimulationHandler,
-    BinaryHandler,
-    QEMUHandler,
-    QEMUWinHandler,
-    DeviceHandler,
-)
+import csv
+import glob
+import hashlib
+import logging
+import os
+import random
+from enum import Enum
+
 from twisterlib.constants import (
     SUPPORTED_SIMS,
     SUPPORTED_SIMS_IN_PYTEST,
     SUPPORTED_SIMS_WITH_EXEC,
 )
+from twisterlib.environment import TwisterEnv
+from twisterlib.error import BuildError, StatusAttributeError
+from twisterlib.handlers import (
+    BinaryHandler,
+    DeviceHandler,
+    Handler,
+    QEMUHandler,
+    QEMUWinHandler,
+    SimulationHandler,
+)
+from twisterlib.platform import Platform
+from twisterlib.size_calc import SizeCalculator
+from twisterlib.statuses import TwisterStatus
+from twisterlib.testsuite import TestCase, TestSuite
 
 logger = logging.getLogger('twister')
 logger.setLevel(logging.DEBUG)

--- a/scripts/pylib/twister/twisterlib/testinstance.py
+++ b/scripts/pylib/twister/twisterlib/testinstance.py
@@ -70,9 +70,15 @@ class TestInstance:
         if testsuite.detailed_test_id:
             self.build_dir = os.path.join(outdir, platform.normalized_name, testsuite.name)
         else:
-            # if suite is not in zephyr, keep only the part after ".." in reconstructed dir structure
+            # if suite is not in zephyr,
+            # keep only the part after ".." in reconstructed dir structure
             source_dir_rel = testsuite.source_dir_rel.rsplit(os.pardir+os.path.sep, 1)[-1]
-            self.build_dir = os.path.join(outdir, platform.normalized_name, source_dir_rel, testsuite.name)
+            self.build_dir = os.path.join(
+                outdir,
+                platform.normalized_name,
+                source_dir_rel,
+                testsuite.name
+            )
         self.run_id = self._get_run_id()
         self.domains = None
         # Instance need to use sysbuild if a given suite or a platform requires it
@@ -281,7 +287,9 @@ class TestInstance:
 
         # check if test is runnable in pytest
         if self.testsuite.harness == 'pytest':
-            target_ready = bool(filter == 'runnable' or simulator and simulator.name in SUPPORTED_SIMS_IN_PYTEST)
+            target_ready = bool(
+                filter == 'runnable' or simulator and simulator.name in SUPPORTED_SIMS_IN_PYTEST
+            )
 
         if filter != 'runnable' and \
                 simulator and \
@@ -300,7 +308,14 @@ class TestInstance:
 
         return testsuite_runnable and target_ready
 
-    def create_overlay(self, platform, enable_asan=False, enable_ubsan=False, enable_coverage=False, coverage_platform=None):
+    def create_overlay(
+        self,
+        platform,
+        enable_asan=False,
+        enable_ubsan=False,
+        enable_coverage=False,
+        coverage_platform=None
+    ):
         if coverage_platform is None:
             coverage_platform = []
         # Create this in a "twister/" subdirectory otherwise this
@@ -349,7 +364,11 @@ class TestInstance:
 
         return content
 
-    def calculate_sizes(self, from_buildlog: bool = False, generate_warning: bool = True) -> SizeCalculator:
+    def calculate_sizes(
+        self,
+        from_buildlog: bool = False,
+        generate_warning: bool = True
+    ) -> SizeCalculator:
         """Get the RAM/ROM sizes of a test case.
 
         This can only be run after the instance has been executed by

--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -175,7 +175,7 @@ class TestPlan:
             if self.run_individual_testsuite:
                 logger.info("Running the following tests:")
                 for test in self.run_individual_testsuite:
-                    print(" - {}".format(test))
+                    print(f" - {test}")
             else:
                 raise TwisterRuntimeError("Tests not found")
 
@@ -217,7 +217,7 @@ class TestPlan:
     def load(self):
 
         if self.options.report_suffix:
-            last_run = os.path.join(self.options.outdir, "twister_{}.json".format(self.options.report_suffix))
+            last_run = os.path.join(self.options.outdir, f"twister_{self.options.report_suffix}.json")
         else:
             last_run = os.path.join(self.options.outdir, "twister.json")
 
@@ -262,7 +262,7 @@ class TestPlan:
                 raise TwisterRuntimeError("subset should not exceed the total number of sets")
 
             if int(subset) > 0 and int(sets) >= int(subset):
-                logger.info("Running only a subset: %s/%s" % (subset, sets))
+                logger.info(f"Running only a subset: {subset}/{sets}")
             else:
                 raise TwisterRuntimeError(f"You have provided a wrong subset value: {self.options.subset}.")
 
@@ -347,9 +347,9 @@ class TestPlan:
         if dupes:
             msg = "Duplicated test scenarios found:\n"
             for dupe in dupes:
-                msg += ("- {} found in:\n".format(dupe))
+                msg += (f"- {dupe} found in:\n")
                 for dc in self.get_testsuite(dupe):
-                    msg += ("  - {}\n".format(dc.yamlfile))
+                    msg += (f"  - {dc.yamlfile}\n")
             raise TwisterRuntimeError(msg)
         else:
             logger.debug("No duplicates found.")
@@ -360,7 +360,7 @@ class TestPlan:
             tags = tags.union(tc.tags)
 
         for t in tags:
-            print("- {}".format(t))
+            print(f"- {t}")
 
     def report_test_tree(self):
         tests_list = self.get_tests_list()
@@ -399,7 +399,7 @@ class TestPlan:
                     Node(test, parent=subarea)
 
         for pre, _, node in RenderTree(testsuite):
-            print("%s%s" % (pre, node.name))
+            print(f"{pre}{node.name}")
 
     def report_test_list(self):
         tests_list = self.get_tests_list()
@@ -407,8 +407,8 @@ class TestPlan:
         cnt = 0
         for test in sorted(tests_list):
             cnt = cnt + 1
-            print(" - {}".format(test))
-        print("{} total.".format(cnt))
+            print(f" - {test}")
+        print(f"{cnt} total.")
 
 
     # Debug Functions
@@ -550,7 +550,7 @@ class TestPlan:
         for root in self.env.test_roots:
             root = os.path.abspath(root)
 
-            logger.debug("Reading test case configuration files under %s..." % root)
+            logger.debug(f"Reading test case configuration files under {root}...")
 
             for dirpath, _, filenames in os.walk(root, topdown=True):
                 if self.SAMPLE_FILENAME in filenames:
@@ -570,8 +570,9 @@ class TestPlan:
                                               os.path.relpath(suite_path, root),
                                               filename)
                     if os.path.exists(alt_config):
-                        logger.info("Using alternative configuration from %s" %
-                                    os.path.normpath(alt_config))
+                        logger.info(
+                            f"Using alternative configuration from {os.path.normpath(alt_config)}"
+                        )
                         suite_yaml_path = alt_config
                         break
 
@@ -981,7 +982,9 @@ class TestPlan:
                     # Search and check that all required snippet files are found
                     for this_snippet in snippet_args['snippets']:
                         if this_snippet not in found_snippets:
-                            logger.error("Can't find snippet '%s' for test '%s'", this_snippet, ts.name)
+                            logger.error(
+                                f"Can't find snippet '{this_snippet}' for test '{ts.name}'"
+                            )
                             instance.status = TwisterStatus.ERROR
                             instance.reason = f"Snippet {this_snippet} not found"
                             missing_snippet = True

--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -372,19 +372,28 @@ class TestPlan:
         for test in sorted(tests_list):
             if test.startswith("sample."):
                 sec = test.split(".")
-                area = find(samples, lambda node: node.name == sec[1] and node.parent == samples)
+                area = find(
+                    samples,
+                    lambda node, sname=sec[1]: node.name == sname and node.parent == samples
+                )
                 if not area:
                     area = Node(sec[1], parent=samples)
 
                 Node(test, parent=area)
             else:
                 sec = test.split(".")
-                area = find(tests, lambda node: node.name == sec[0] and node.parent == tests)
+                area = find(
+                    tests,
+                    lambda node, sname=sec[0]: node.name == sname and node.parent == tests
+                )
                 if not area:
                     area = Node(sec[0], parent=tests)
 
                 if area and len(sec) > 2:
-                    subarea = find(area, lambda node: node.name == sec[1] and node.parent == area)
+                    subarea = find(
+                        area, lambda node, sname=sec[1], sparent=area: node.name == sname
+                        and node.parent == sparent
+                    )
                     if not subarea:
                         subarea = Node(sec[1], parent=area)
                     Node(test, parent=subarea)

--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -726,10 +726,7 @@ class TestPlan:
             return 1
 
     def check_platform(self, platform, platform_list):
-        for p in platform_list:
-            if p in platform.aliases:
-                return True
-        return False
+        return any(p in platform.aliases for p in platform_list)
 
     def apply_filters(self, **kwargs):
 

--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -786,7 +786,7 @@ class TestPlan:
         if platform_filter:
             logger.debug(f"Checking platform filter: {platform_filter}")
             # find in aliases and rename
-            self.verify_platforms_existence(platform_filter, f"platform_filter")
+            self.verify_platforms_existence(platform_filter, "platform_filter")
             for pf in platform_filter:
                 logger.debug(f"Checking platform in filter: {pf}")
                 if pf in self.platform_names:
@@ -981,7 +981,7 @@ class TestPlan:
                     # Search and check that all required snippet files are found
                     for this_snippet in snippet_args['snippets']:
                         if this_snippet not in found_snippets:
-                            logger.error(f"Can't find snippet '%s' for test '%s'", this_snippet, ts.name)
+                            logger.error("Can't find snippet '%s' for test '%s'", this_snippet, ts.name)
                             instance.status = TwisterStatus.ERROR
                             instance.reason = f"Snippet {this_snippet} not found"
                             missing_snippet = True

--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -5,37 +5,37 @@
 # Copyright (c) 2024 Arm Limited (or its affiliates). All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
-import os
-import sys
-import re
-import subprocess
+import collections
+import copy
 import glob
 import json
-import collections
+import logging
+import os
+import random
+import re
+import subprocess
+import sys
+from argparse import Namespace
 from collections import OrderedDict
 from itertools import islice
-import logging
-import copy
-import random
-import snippets
 from pathlib import Path
-from argparse import Namespace
+
+import snippets
 
 try:
-    from anytree import RenderTree, Node, find
+    from anytree import Node, RenderTree, find
 except ImportError:
     print("Install the anytree module to use the --test-tree option")
 
-from twisterlib.testsuite import TestSuite, scan_testsuite_path
+import list_boards
+import scl
+from twisterlib.config_parser import TwisterConfigParser
 from twisterlib.error import TwisterRuntimeError
 from twisterlib.platform import Platform
-from twisterlib.config_parser import TwisterConfigParser
+from twisterlib.quarantine import Quarantine
 from twisterlib.statuses import TwisterStatus
 from twisterlib.testinstance import TestInstance
-from twisterlib.quarantine import Quarantine
-
-import scl
-import list_boards
+from twisterlib.testsuite import TestSuite, scan_testsuite_path
 from zephyr_module import parse_modules
 
 logger = logging.getLogger('twister')

--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -544,7 +544,9 @@ class TestPlan:
                             testcases.remove(case.name)
         return testcases
 
-    def add_testsuites(self, testsuite_filter=[]):
+    def add_testsuites(self, testsuite_filter=None):
+        if testsuite_filter is None:
+            testsuite_filter = []
         for root in self.env.test_roots:
             root = os.path.abspath(root)
 
@@ -656,7 +658,9 @@ class TestPlan:
             if not matched_quarantine and self.options.quarantine_verify:
                 instance.add_filter("Not under quarantine", Filters.QUARANTINE)
 
-    def load_from_file(self, file, filter_platform=[]):
+    def load_from_file(self, file, filter_platform=None):
+        if filter_platform is None:
+            filter_platform = []
         try:
             with open(file, "r") as json_test_plan:
                 jtp = json.load(json_test_plan)

--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -570,7 +570,7 @@ class TestPlan:
                     subcases = None
                     ztest_suite_names = None
 
-                    for name in parsed_data.scenarios.keys():
+                    for name in parsed_data.scenarios:
                         suite_dict = parsed_data.get_scenario(name)
                         suite = TestSuite(root, suite_path, name, data=suite_dict, detailed_test_id=self.options.detailed_test_id)
 

--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -91,7 +91,13 @@ class TestPlan:
         os.path.join(ZEPHYR_BASE,
                      "scripts", "schemas", "twister", "quarantine-schema.yaml"))
 
-    tc_schema_path = os.path.join(ZEPHYR_BASE, "scripts", "schemas", "twister", "test-config-schema.yaml")
+    tc_schema_path = os.path.join(
+        ZEPHYR_BASE,
+        "scripts",
+        "schemas",
+        "twister",
+        "test-config-schema.yaml"
+    )
 
     SAMPLE_FILENAME = 'sample.yaml'
     TESTSUITE_FILENAME = 'testcase.yaml'
@@ -189,7 +195,9 @@ class TestPlan:
         if num == 0:
             raise TwisterRuntimeError("No test cases found at the specified location...")
         if self.load_errors:
-            raise TwisterRuntimeError(f"Found {self.load_errors} errors loading {num} test configurations.")
+            raise TwisterRuntimeError(
+                f"Found {self.load_errors} errors loading {num} test configurations."
+            )
 
         self.find_subtests()
         # get list of scenarios we have parsed into one list
@@ -217,7 +225,10 @@ class TestPlan:
     def load(self):
 
         if self.options.report_suffix:
-            last_run = os.path.join(self.options.outdir, f"twister_{self.options.report_suffix}.json")
+            last_run = os.path.join(
+                self.options.outdir,
+                f"twister_{self.options.report_suffix}.json"
+            )
         else:
             last_run = os.path.join(self.options.outdir, "twister.json")
 
@@ -264,7 +275,9 @@ class TestPlan:
             if int(subset) > 0 and int(sets) >= int(subset):
                 logger.info(f"Running only a subset: {subset}/{sets}")
             else:
-                raise TwisterRuntimeError(f"You have provided a wrong subset value: {self.options.subset}.")
+                raise TwisterRuntimeError(
+                    f"You have provided a wrong subset value: {self.options.subset}."
+                )
 
             self.generate_subset(subset, int(sets))
 
@@ -584,7 +597,13 @@ class TestPlan:
 
                     for name in parsed_data.scenarios:
                         suite_dict = parsed_data.get_scenario(name)
-                        suite = TestSuite(root, suite_path, name, data=suite_dict, detailed_test_id=self.options.detailed_test_id)
+                        suite = TestSuite(
+                            root,
+                            suite_path,
+                            name,
+                            data=suite_dict,
+                            detailed_test_id=self.options.detailed_test_id
+                        )
 
                         # convert to fully qualified names
                         _integration = []
@@ -619,14 +638,21 @@ class TestPlan:
 
                         if testsuite_filter:
                             scenario = os.path.basename(suite.name)
-                            if suite.name and (suite.name in testsuite_filter or scenario in testsuite_filter):
+                            if (
+                                suite.name
+                                and (suite.name in testsuite_filter or scenario in testsuite_filter)
+                            ):
                                 self.testsuites[suite.name] = suite
                         elif suite.name in self.testsuites:
-                            msg = f"test suite '{suite.name}' in '{suite.yamlfile}' is already added"
+                            msg = (
+                                f"test suite '{suite.name}' in '{suite.yamlfile}' is already added"
+                            )
                             if suite.yamlfile == self.testsuites[suite.name].yamlfile:
                                 logger.debug(f"Skip - {msg}")
                             else:
-                                msg = f"Duplicate {msg} from '{self.testsuites[suite.name].yamlfile}'"
+                                msg = (
+                                    f"Duplicate {msg} from '{self.testsuites[suite.name].yamlfile}'"
+                                )
                                 raise TwisterRuntimeError(msg)
                         else:
                             self.testsuites[suite.name] = suite
@@ -651,7 +677,10 @@ class TestPlan:
         if self.quarantine:
             simulator = plat.simulator_by_name(self.options)
             matched_quarantine = self.quarantine.get_matched_quarantine(
-                instance.testsuite.id, plat.name, plat.arch, simulator.name if simulator is not None else 'na'
+                instance.testsuite.id,
+                plat.name,
+                plat.arch,
+                simulator.name if simulator is not None else 'na'
             )
             if matched_quarantine and not self.options.quarantine_verify:
                 instance.add_filter("Quarantine: " + matched_quarantine, Filters.QUARANTINE)
@@ -722,7 +751,11 @@ class TestPlan:
                         if instance.status != TwisterStatus.NONE:
                             tc_reason = tc.get('reason')
                         if tc_status != TwisterStatus.NONE:
-                            case = instance.set_case_status_by_name(identifier, tc_status, tc_reason)
+                            case = instance.set_case_status_by_name(
+                                identifier,
+                                tc_status,
+                                tc_reason
+                            )
                             case.duration = tc.get('execution_time', 0)
                             if tc.get('log'):
                                 case.output = tc.get('log')
@@ -795,7 +828,9 @@ class TestPlan:
             platform_filter = _platforms
             platforms = list(filter(lambda p: p.name in platform_filter, self.platforms))
         elif emu_filter:
-            platforms = list(filter(lambda p: bool(p.simulator_by_name(self.options.sim_name)), self.platforms))
+            platforms = list(
+                filter(lambda p: bool(p.simulator_by_name(self.options.sim_name)), self.platforms)
+            )
         elif vendor_filter:
             platforms = list(filter(lambda p: p.vendor in vendor_filter, self.platforms))
             logger.info(f"Selecting platforms by vendors: {','.join(vendor_filter)}")
@@ -820,11 +855,16 @@ class TestPlan:
         keyed_tests = {}
 
         for ts_name, ts in self.testsuites.items():
-            if ts.build_on_all and not platform_filter and platform_config.get('increased_platform_scope', True):
+            if (
+                ts.build_on_all
+                and not platform_filter
+                and platform_config.get('increased_platform_scope', True)
+            ):
                 platform_scope = self.platforms
             elif ts.integration_platforms:
-                integration_platforms = list(filter(lambda item: item.name in ts.integration_platforms,
-                                                    self.platforms))
+                integration_platforms = list(
+                    filter(lambda item: item.name in ts.integration_platforms, self.platforms)
+                )
                 if self.options.integration:
                     self.verify_platforms_existence(
                         ts.integration_platforms, f"{ts_name} - integration_platforms")
@@ -844,14 +884,20 @@ class TestPlan:
 
             # If there isn't any overlap between the platform_allow list and the platform_scope
             # we set the scope to the platform_allow list
-            if ts.platform_allow and not platform_filter and not integration and platform_config.get('increased_platform_scope', True):
+            if (
+                ts.platform_allow
+                and not platform_filter
+                and not integration
+                and platform_config.get('increased_platform_scope', True)
+            ):
                 self.verify_platforms_existence(ts.platform_allow, f"{ts_name} - platform_allow")
                 a = set(platform_scope)
                 b = set(filter(lambda item: item.name in ts.platform_allow, self.platforms))
                 c = a.intersection(b)
                 if not c:
-                    platform_scope = list(filter(lambda item: item.name in ts.platform_allow, \
-                                             self.platforms))
+                    platform_scope = list(
+                        filter(lambda item: item.name in ts.platform_allow, self.platforms)
+                    )
             # list of instances per testsuite, aka configurations.
             instance_list = []
             for plat in platform_scope:
@@ -869,21 +915,34 @@ class TestPlan:
                     continue
 
                 if ts.modules and self.modules and not set(ts.modules).issubset(set(self.modules)):
-                    instance.add_filter(f"one or more required modules not available: {','.join(ts.modules)}", Filters.MODULE)
+                    instance.add_filter(
+                        f"one or more required modules not available: {','.join(ts.modules)}",
+                        Filters.MODULE
+                    )
 
                 if self.options.level:
                     tl = self.get_level(self.options.level)
                     if tl is None:
-                        instance.add_filter(f"Unknown test level '{self.options.level}'", Filters.TESTPLAN)
+                        instance.add_filter(
+                            f"Unknown test level '{self.options.level}'",
+                            Filters.TESTPLAN
+                        )
                     else:
                         planned_scenarios = tl.scenarios
-                        if ts.id not in planned_scenarios and not set(ts.levels).intersection(set(tl.levels)):
+                        if (
+                            ts.id not in planned_scenarios
+                            and not set(ts.levels).intersection(set(tl.levels))
+                        ):
                             instance.add_filter("Not part of requested test plan", Filters.TESTPLAN)
 
                 if runnable and not instance.run:
                     instance.add_filter("Not runnable on device", Filters.CMD_LINE)
 
-                if self.options.integration and ts.integration_platforms and plat.name not in ts.integration_platforms:
+                if (
+                    self.options.integration
+                    and ts.integration_platforms
+                    and plat.name not in ts.integration_platforms
+                ):
                     instance.add_filter("Not part of integration platforms", Filters.TESTSUITE)
 
                 if ts.skip:
@@ -915,7 +974,10 @@ class TestPlan:
                         instance.add_filter("In test case arch exclude", Filters.TESTSUITE)
 
                     if ts.vendor_allow and plat.vendor not in ts.vendor_allow:
-                        instance.add_filter("Not in test suite vendor allow list", Filters.TESTSUITE)
+                        instance.add_filter(
+                            "Not in test suite vendor allow list",
+                            Filters.TESTSUITE
+                        )
 
                     if ts.vendor_exclude and plat.vendor in ts.vendor_exclude:
                         instance.add_filter("In test suite vendor exclude", Filters.TESTSUITE)
@@ -923,7 +985,10 @@ class TestPlan:
                     if ts.platform_exclude and plat.name in ts.platform_exclude:
                         # works only when we have all platforms parsed, -p limits parsing...
                         if not platform_filter:
-                            self.verify_platforms_existence(ts.platform_exclude, f"{ts_name} - platform_exclude")
+                            self.verify_platforms_existence(
+                                ts.platform_exclude,
+                                f"{ts_name} - platform_exclude"
+                            )
                         instance.add_filter("In test case platform exclude", Filters.TESTSUITE)
 
                 if ts.toolchain_exclude and toolchain in ts.toolchain_exclude:
@@ -944,7 +1009,10 @@ class TestPlan:
                     instance.add_filter("Not in testsuite toolchain allow list", Filters.TOOLCHAIN)
 
                 if not plat.env_satisfied:
-                    instance.add_filter("Environment ({}) not satisfied".format(", ".join(plat.env)), Filters.PLATFORM)
+                    instance.add_filter(
+                        "Environment ({}) not satisfied".format(", ".join(plat.env)),
+                        Filters.PLATFORM
+                    )
 
                 if not force_toolchain \
                         and toolchain and (toolchain not in plat.supported_toolchains) \
@@ -958,7 +1026,10 @@ class TestPlan:
                 if ts.harness:
                     sim = plat.simulator_by_name(self.options.sim_name)
                     if ts.harness == 'robot' and not (sim and sim.name == 'renode'):
-                        instance.add_filter("No robot support for the selected platform", Filters.SKIP)
+                        instance.add_filter(
+                            "No robot support for the selected platform",
+                            Filters.SKIP
+                        )
 
                 if ts.depends_on:
                     dep_intersection = ts.depends_on.intersection(set(plat.supported))
@@ -969,7 +1040,10 @@ class TestPlan:
                     instance.add_filter("Not enough FLASH", Filters.PLATFORM)
 
                 if set(plat.ignore_tags) & ts.tags:
-                    instance.add_filter("Excluded tags per platform (exclude_tags)", Filters.PLATFORM)
+                    instance.add_filter(
+                        "Excluded tags per platform (exclude_tags)",
+                        Filters.PLATFORM
+                    )
 
                 if plat.only_tags and not set(plat.only_tags) & ts.tags:
                     instance.add_filter("Excluded tags per platform (only_tags)", Filters.PLATFORM)
@@ -977,7 +1051,10 @@ class TestPlan:
                 if ts.required_snippets:
                     missing_snippet = False
                     snippet_args = {"snippets": ts.required_snippets}
-                    found_snippets = snippets.find_snippets_in_roots(snippet_args, [*self.env.snippet_roots, Path(ts.source_dir)])
+                    found_snippets = snippets.find_snippets_in_roots(
+                        snippet_args,
+                        [*self.env.snippet_roots, Path(ts.source_dir)]
+                    )
 
                     # Search and check that all required snippet files are found
                     for this_snippet in snippet_args['snippets']:
@@ -1019,19 +1096,25 @@ class TestPlan:
                 # handle quarantined tests
                 self.handle_quarantined_tests(instance, plat)
 
-                # platform_key is a list of unique platform attributes that form a unique key a test
-                # will match against to determine if it should be scheduled to run. A key containing a
-                # field name that the platform does not have will filter the platform.
+                # platform_key is a list of unique platform attributes that form a unique key
+                # a test will match against to determine if it should be scheduled to run.
+                # A key containing a field name that the platform does not have
+                # will filter the platform.
                 #
                 # A simple example is keying on arch and simulation
                 # to run a test once per unique (arch, simulation) platform.
-                if not ignore_platform_key and hasattr(ts, 'platform_key') and len(ts.platform_key) > 0:
+                if (
+                    not ignore_platform_key
+                    and hasattr(ts, 'platform_key')
+                    and len(ts.platform_key) > 0
+                ):
                     key_fields = sorted(set(ts.platform_key))
                     keys = [getattr(plat, key_field, None) for key_field in key_fields]
                     for key in keys:
                         if key is None or key == 'na':
                             instance.add_filter(
-                                f"Excluded platform missing key fields demanded by test {key_fields}",
+                                "Excluded platform missing key fields"
+                                f" demanded by test {key_fields}",
                                 Filters.PLATFORM
                             )
                             break
@@ -1041,8 +1124,17 @@ class TestPlan:
                         test_keys = tuple(test_keys)
                         keyed_test = keyed_tests.get(test_keys)
                         if keyed_test is not None:
-                            plat_key = {key_field: getattr(keyed_test['plat'], key_field) for key_field in key_fields}
-                            instance.add_filter(f"Already covered for key {key} by platform {keyed_test['plat'].name} having key {plat_key}", Filters.PLATFORM_KEY)
+                            plat_key = {
+                                key_field: getattr(
+                                    keyed_test['plat'],
+                                    key_field
+                                ) for key_field in key_fields
+                            }
+                            instance.add_filter(
+                                f"Already covered for key {key}"
+                                f" by platform {keyed_test['plat'].name} having key {plat_key}",
+                                Filters.PLATFORM_KEY
+                            )
                         else:
                             # do not add a platform to keyed tests if previously
                             # filtered
@@ -1066,7 +1158,12 @@ class TestPlan:
                     _platform_allow = set(ts.platform_allow)
                     _intersection = _default_p.intersection(_platform_allow)
                     if _intersection:
-                        aa = list(filter(lambda _scenario: _scenario.platform.name in _intersection, instance_list))
+                        aa = list(
+                            filter(
+                                lambda _scenario: _scenario.platform.name in _intersection,
+                                instance_list
+                            )
+                        )
                         self.add_instances(aa)
                     else:
                         self.add_instances(instance_list)
@@ -1074,20 +1171,36 @@ class TestPlan:
                     # add integration platforms to the list of default
                     # platforms, even if we are not in integration mode
                     _platforms = self.default_platforms + ts.integration_platforms
-                    instances = list(filter(lambda ts: ts.platform.name in _platforms, instance_list))
+                    instances = list(
+                        filter(lambda ts: ts.platform.name in _platforms, instance_list)
+                    )
                     self.add_instances(instances)
             elif integration:
-                instances = list(filter(lambda item:  item.platform.name in ts.integration_platforms, instance_list))
+                instances = list(
+                    filter(
+                        lambda item:  item.platform.name in ts.integration_platforms,
+                        instance_list
+                    )
+                )
                 self.add_instances(instances)
 
             elif emulation_platforms:
                 self.add_instances(instance_list)
-                for instance in list(filter(lambda inst: not
-                                            inst.platform.simulator_by_name(self.options.sim_name), instance_list)):
+                for instance in list(
+                    filter(
+                        lambda inst: not inst.platform.simulator_by_name(self.options.sim_name),
+                        instance_list
+                    )
+                ):
                     instance.add_filter("Not an emulated platform", Filters.CMD_LINE)
             elif vendor_platforms:
                 self.add_instances(instance_list)
-                for instance in list(filter(lambda inst: inst.platform.vendor not in vendor_filter, instance_list)):
+                for instance in list(
+                    filter(
+                        lambda inst: inst.platform.vendor not in vendor_filter,
+                        instance_list
+                    )
+                ):
                     instance.add_filter("Not a selected vendor platform", Filters.CMD_LINE)
             else:
                 self.add_instances(instance_list)
@@ -1101,7 +1214,9 @@ class TestPlan:
 
         self.selected_platforms = set(p.platform.name for p in self.instances.values())
 
-        filtered_instances = list(filter(lambda item:  item.status == TwisterStatus.FILTER, self.instances.values()))
+        filtered_instances = list(
+            filter(lambda item:  item.status == TwisterStatus.FILTER, self.instances.values())
+        )
         for filtered_instance in filtered_instances:
             change_skip_to_error_if_integration(self.options, filtered_instance)
 
@@ -1195,4 +1310,6 @@ def change_skip_to_error_if_integration(options, instance):
             return
         instance.status = TwisterStatus.ERROR
         instance.reason += " but is one of the integration platforms"
-        logger.debug(f"Changing status of {instance.name} to ERROR because it is an integration platform")
+        logger.debug(
+            f"Changing status of {instance.name} to ERROR because it is an integration platform"
+        )

--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -854,9 +854,8 @@ class TestPlan:
                     # Discard silently
                     continue
 
-                if ts.modules and self.modules:
-                    if not set(ts.modules).issubset(set(self.modules)):
-                        instance.add_filter(f"one or more required modules not available: {','.join(ts.modules)}", Filters.MODULE)
+                if ts.modules and self.modules and not set(ts.modules).issubset(set(self.modules)):
+                    instance.add_filter(f"one or more required modules not available: {','.join(ts.modules)}", Filters.MODULE)
 
                 if self.options.level:
                     tl = self.get_level(self.options.level)

--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -1072,7 +1072,7 @@ class TestPlan:
                     instance.add_filter("Not an emulated platform", Filters.CMD_LINE)
             elif vendor_platforms:
                 self.add_instances(instance_list)
-                for instance in list(filter(lambda inst: not inst.platform.vendor in vendor_filter, instance_list)):
+                for instance in list(filter(lambda inst: inst.platform.vendor not in vendor_filter, instance_list)):
                     instance.add_filter("Not a selected vendor platform", Filters.CMD_LINE)
             else:
                 self.add_instances(instance_list)

--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -127,7 +127,7 @@ class TestPlan:
         self.name = "unnamed"
 
     def get_level(self, name):
-        level = next((l for l in self.levels if l.name == name), None)
+        level = next((lvl for lvl in self.levels if lvl.name == name), None)
         return level
 
     def parse_configuration(self, config_file):

--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -255,8 +255,8 @@ class TestPlan:
             s =  self.options.subset
             try:
                 subset, sets = (int(x) for x in s.split("/"))
-            except ValueError:
-                raise TwisterRuntimeError("Bad subset value.")
+            except ValueError as err:
+                raise TwisterRuntimeError("Bad subset value.") from err
 
             if subset > sets:
                 raise TwisterRuntimeError("subset should not exceed the total number of sets")

--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -662,7 +662,7 @@ class TestPlan:
         if filter_platform is None:
             filter_platform = []
         try:
-            with open(file, "r") as json_test_plan:
+            with open(file) as json_test_plan:
                 jtp = json.load(json_test_plan)
                 instance_list = []
                 for ts in jtp.get("testsuites", []):

--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -21,9 +21,6 @@ import snippets
 from pathlib import Path
 from argparse import Namespace
 
-logger = logging.getLogger('twister')
-logger.setLevel(logging.DEBUG)
-
 try:
     from anytree import RenderTree, Node, find
 except ImportError:
@@ -37,8 +34,12 @@ from twisterlib.statuses import TwisterStatus
 from twisterlib.testinstance import TestInstance
 from twisterlib.quarantine import Quarantine
 
+import scl
 import list_boards
 from zephyr_module import parse_modules
+
+logger = logging.getLogger('twister')
+logger.setLevel(logging.DEBUG)
 
 ZEPHYR_BASE = os.getenv("ZEPHYR_BASE")
 if not ZEPHYR_BASE:
@@ -51,7 +52,6 @@ from devicetree import edtlib  # pylint: disable=unused-import
 
 sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts/"))
 
-import scl
 class Filters:
     # platform keys
     PLATFORM_KEY = 'platform key filter'

--- a/scripts/pylib/twister/twisterlib/testsuite.py
+++ b/scripts/pylib/twister/twisterlib/testsuite.py
@@ -11,7 +11,6 @@ import logging
 import contextlib
 import mmap
 import glob
-from typing import List
 
 from twisterlib.mixins import DisablePyTestCollectionMixin
 from twisterlib.environment import canonical_zephyr_base
@@ -39,12 +38,12 @@ class ScanPathResult:
         ztest_suite_names                Names of found ztest suites
     """
     def __init__(self,
-                 matches: List[str] = None,
+                 matches: list[str] = None,
                  warnings: str = None,
                  has_registered_test_suites: bool = False,
                  has_run_registered_test_suites: bool = False,
                  has_test_main: bool = False,
-                 ztest_suite_names: List[str] = []):
+                 ztest_suite_names: list[str] = []):
         self.matches = matches
         self.warnings = warnings
         self.has_registered_test_suites = has_registered_test_suites

--- a/scripts/pylib/twister/twisterlib/testsuite.py
+++ b/scripts/pylib/twister/twisterlib/testsuite.py
@@ -377,8 +377,8 @@ class TestCase(DisablePyTestCollectionMixin):
         try:
             key = value.name if isinstance(value, Enum) else value
             self._status = TwisterStatus[key]
-        except KeyError:
-            raise StatusAttributeError(self.__class__, value)
+        except KeyError as err:
+            raise StatusAttributeError(self.__class__, value) from err
 
     def __lt__(self, other):
         return self.name < other.name
@@ -443,8 +443,8 @@ class TestSuite(DisablePyTestCollectionMixin):
         try:
             key = value.name if isinstance(value, Enum) else value
             self._status = TwisterStatus[key]
-        except KeyError:
-            raise StatusAttributeError(self.__class__, value)
+        except KeyError as err:
+            raise StatusAttributeError(self.__class__, value) from err
 
     def load(self, data):
         for k, v in data.items():

--- a/scripts/pylib/twister/twisterlib/testsuite.py
+++ b/scripts/pylib/twister/twisterlib/testsuite.py
@@ -107,8 +107,13 @@ def scan_file(inf_name):
         if os.name == 'nt':
             mmap_args = {'fileno': inf.fileno(), 'length': 0, 'access': mmap.ACCESS_READ}
         else:
-            mmap_args = {'fileno': inf.fileno(), 'length': 0, 'flags': mmap.MAP_PRIVATE, 'prot': mmap.PROT_READ,
-                            'offset': 0}
+            mmap_args = {
+                'fileno': inf.fileno(),
+                'length': 0,
+                'flags': mmap.MAP_PRIVATE,
+                'prot': mmap.PROT_READ,
+                'offset': 0
+            }
 
         with contextlib.closing(mmap.mmap(**mmap_args)) as main_c:
             regular_suite_regex_matches = \
@@ -130,13 +135,19 @@ def scan_file(inf_name):
             if regular_suite_regex_matches:
                 ztest_suite_names = \
                     _extract_ztest_suite_names(regular_suite_regex_matches)
-                testcase_names, warnings = \
-                    _find_regular_ztest_testcases(main_c, regular_suite_regex_matches, has_registered_test_suites)
+                testcase_names, warnings = _find_regular_ztest_testcases(
+                    main_c,
+                    regular_suite_regex_matches,
+                    has_registered_test_suites
+                )
             elif registered_suite_regex_matches:
                 ztest_suite_names = \
                     _extract_ztest_suite_names(registered_suite_regex_matches)
-                testcase_names, warnings = \
-                    _find_regular_ztest_testcases(main_c, registered_suite_regex_matches, has_registered_test_suites)
+                testcase_names, warnings = _find_regular_ztest_testcases(
+                    main_c,
+                    registered_suite_regex_matches,
+                    has_registered_test_suites
+                )
             elif new_suite_regex_matches or new_suite_testcase_regex_matches:
                 ztest_suite_names = \
                     _extract_ztest_suite_names(new_suite_regex_matches)
@@ -248,10 +259,15 @@ def _find_ztest_testcases(search_area, testcase_regex):
     """
     testcase_regex_matches = \
         [m for m in testcase_regex.finditer(search_area)]
-    testcase_names = \
-        [(m.group("suite_name") if m.groupdict().get("suite_name") else b'', m.group("testcase_name")) \
-         for m in testcase_regex_matches]
-    testcase_names = [(ts_name.decode("UTF-8"), tc_name.decode("UTF-8")) for ts_name, tc_name in testcase_names]
+    testcase_names = [
+        (
+            m.group("suite_name") if m.groupdict().get("suite_name") else b'',
+            m.group("testcase_name")
+        ) for m in testcase_regex_matches
+    ]
+    testcase_names = [
+        (ts_name.decode("UTF-8"), tc_name.decode("UTF-8")) for ts_name, tc_name in testcase_names
+    ]
     warnings = None
     for testcase_name in testcase_names:
         if not testcase_name[1].startswith("test_"):
@@ -424,7 +440,9 @@ class TestSuite(DisablePyTestCollectionMixin):
         self.id = name
 
         self.source_dir = suite_path
-        self.source_dir_rel = os.path.relpath(os.path.realpath(suite_path), start=canonical_zephyr_base)
+        self.source_dir_rel = os.path.relpath(
+            os.path.realpath(suite_path), start=canonical_zephyr_base
+        )
         self.yamlfile = suite_path
         self.testcases = []
         self.integration_platforms = []
@@ -455,7 +473,9 @@ class TestSuite(DisablePyTestCollectionMixin):
                 setattr(self, k, v)
 
         if self.harness == 'console' and not self.harness_config:
-            raise Exception('Harness config error: console harness defined without a configuration.')
+            raise Exception(
+                'Harness config error: console harness defined without a configuration.'
+            )
 
     def add_subcases(self, data, parsed_subcases=None, suite_names=None):
         testcases = data.get("testcases", [])
@@ -492,7 +512,9 @@ class TestSuite(DisablePyTestCollectionMixin):
             relative_ts_root = ""
 
         # workdir can be "."
-        unique = os.path.normpath(os.path.join(relative_ts_root, workdir, name)).replace(os.sep, '/')
+        unique = os.path.normpath(
+            os.path.join(relative_ts_root, workdir, name)
+        ).replace(os.sep, '/')
         return unique
 
     @staticmethod

--- a/scripts/pylib/twister/twisterlib/testsuite.py
+++ b/scripts/pylib/twister/twisterlib/testsuite.py
@@ -43,7 +43,9 @@ class ScanPathResult:
                  has_registered_test_suites: bool = False,
                  has_run_registered_test_suites: bool = False,
                  has_test_main: bool = False,
-                 ztest_suite_names: list[str] = []):
+                 ztest_suite_names: list[str] = None):
+        if ztest_suite_names is None:
+            ztest_suite_names = []
         self.matches = matches
         self.warnings = warnings
         self.has_registered_test_suites = has_registered_test_suites
@@ -260,10 +262,12 @@ def _find_ztest_testcases(search_area, testcase_regex):
 
     return testcase_names, warnings
 
-def find_c_files_in(path: str, extensions: list = ['c', 'cpp', 'cxx', 'cc']) -> list:
+def find_c_files_in(path: str, extensions: list = None) -> list:
     """
     Find C or C++ sources in the directory specified by "path"
     """
+    if extensions is None:
+        extensions = ['c', 'cpp', 'cxx', 'cc']
     if not os.path.isdir(path):
         return []
 

--- a/scripts/pylib/twister/twisterlib/testsuite.py
+++ b/scripts/pylib/twister/twisterlib/testsuite.py
@@ -3,18 +3,18 @@
 # Copyright (c) 2018-2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from enum import Enum
-import os
-from pathlib import Path
-import re
-import logging
 import contextlib
-import mmap
 import glob
+import logging
+import mmap
+import os
+import re
+from enum import Enum
+from pathlib import Path
 
-from twisterlib.mixins import DisablePyTestCollectionMixin
 from twisterlib.environment import canonical_zephyr_base
 from twisterlib.error import StatusAttributeError, TwisterException, TwisterRuntimeError
+from twisterlib.mixins import DisablePyTestCollectionMixin
 from twisterlib.statuses import TwisterStatus
 
 logger = logging.getLogger('twister')

--- a/scripts/pylib/twister/twisterlib/testsuite.py
+++ b/scripts/pylib/twister/twisterlib/testsuite.py
@@ -301,9 +301,8 @@ def scan_testsuite_path(testsuite_path):
         try:
             result: ScanPathResult = scan_file(filename)
             if result.warnings:
-                logger.error("%s: %s" % (filename, result.warnings))
-                raise TwisterRuntimeError(
-                    "%s: %s" % (filename, result.warnings))
+                logger.error(f"{filename}: {result.warnings}")
+                raise TwisterRuntimeError(f"{filename}: {result.warnings}")
             if result.matches:
                 subcases += result.matches
             if result.has_registered_test_suites:
@@ -316,7 +315,7 @@ def scan_testsuite_path(testsuite_path):
                 ztest_suite_names += result.ztest_suite_names
 
         except ValueError as e:
-            logger.error("%s: error parsing source file: %s" % (filename, e))
+            logger.error(f"{filename}: error parsing source file: {e}")
 
     src_dir_pathlib_path = Path(src_dir_path)
     for filename in find_c_files_in(testsuite_path):
@@ -328,13 +327,13 @@ def scan_testsuite_path(testsuite_path):
         try:
             result: ScanPathResult = scan_file(filename)
             if result.warnings:
-                logger.error("%s: %s" % (filename, result.warnings))
+                logger.error(f"{filename}: {result.warnings}")
             if result.matches:
                 subcases += result.matches
             if result.ztest_suite_names:
                 ztest_suite_names += result.ztest_suite_names
         except ValueError as e:
-            logger.error("%s: can't find: %s" % (filename, e))
+            logger.error(f"{filename}: can't find: {e}")
 
     if (has_registered_test_suites and has_test_main and
             not has_run_registered_test_suites):
@@ -388,7 +387,7 @@ class TestCase(DisablePyTestCollectionMixin):
         return self.name < other.name
 
     def __repr__(self):
-        return "<TestCase %s with %s>" % (self.name, self.status)
+        return f"<TestCase {self.name} with {self.status}>"
 
     def __str__(self):
         return self.name
@@ -469,7 +468,7 @@ class TestSuite(DisablePyTestCollectionMixin):
             else:
                 # only add each testcase once
                 for sub in set(parsed_subcases):
-                    name = "{}.{}".format(self.id, sub)
+                    name = f"{self.id}.{sub}"
                     self.add_testcase(name)
 
         if suite_names:

--- a/scripts/pylib/twister/twisterlib/twister_main.py
+++ b/scripts/pylib/twister/twisterlib/twister_main.py
@@ -76,7 +76,7 @@ def main(options: argparse.Namespace, default_options: argparse.Namespace):
     elif options.last_metrics:
         ls = os.path.join(options.outdir, "twister.json")
         if os.path.exists(ls):
-            with open(ls, "r") as fp:
+            with open(ls) as fp:
                 previous_results = fp.read()
         else:
             sys.exit(f"Can't compare metrics with non existing file {ls}")

--- a/scripts/pylib/twister/twisterlib/twister_main.py
+++ b/scripts/pylib/twister/twisterlib/twister_main.py
@@ -4,23 +4,22 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse
-import colorama
 import logging
 import os
 import shutil
 import sys
 import time
 
+import colorama
 from colorama import Fore
-
+from twisterlib.coverage import run_coverage
+from twisterlib.environment import TwisterEnv
+from twisterlib.hardwaremap import HardwareMap
+from twisterlib.package import Artifacts
+from twisterlib.reports import Reporting
+from twisterlib.runner import TwisterRunner
 from twisterlib.statuses import TwisterStatus
 from twisterlib.testplan import TestPlan
-from twisterlib.reports import Reporting
-from twisterlib.hardwaremap import HardwareMap
-from twisterlib.coverage import run_coverage
-from twisterlib.runner import TwisterRunner
-from twisterlib.environment import TwisterEnv
-from twisterlib.package import Artifacts
 
 logger = logging.getLogger("twister")
 logger.setLevel(logging.DEBUG)

--- a/scripts/pylib/twister/twisterlib/twister_main.py
+++ b/scripts/pylib/twister/twisterlib/twister_main.py
@@ -82,13 +82,13 @@ def main(options: argparse.Namespace, default_options: argparse.Namespace):
             sys.exit(f"Can't compare metrics with non existing file {ls}")
     elif os.path.exists(options.outdir):
         if options.clobber_output:
-            print("Deleting output directory {}".format(options.outdir))
+            print(f"Deleting output directory {options.outdir}")
             shutil.rmtree(options.outdir)
         else:
             for i in range(1, 100):
-                new_out = options.outdir + ".{}".format(i)
+                new_out = options.outdir + f".{i}"
                 if not os.path.exists(new_out):
-                    print("Renaming output directory to {}".format(new_out))
+                    print(f"Renaming output directory to {new_out}")
                     shutil.move(options.outdir, new_out)
                     break
             else:
@@ -141,13 +141,7 @@ def main(options: argparse.Namespace, default_options: argparse.Namespace):
                 if options.platform and not tplan.check_platform(i.platform, options.platform):
                     continue
                 logger.debug(
-                    "{:<25} {:<50} {}SKIPPED{}: {}".format(
-                        i.platform.name,
-                        i.testsuite.name,
-                        Fore.YELLOW,
-                        Fore.RESET,
-                        i.reason,
-                    )
+                    f"{i.platform.name:<25} {i.testsuite.name:<50} {Fore.YELLOW}SKIPPED{Fore.RESET}: {i.reason}"
                 )
 
     report = Reporting(tplan, env)
@@ -173,7 +167,7 @@ def main(options: argparse.Namespace, default_options: argparse.Namespace):
 
     if options.dry_run:
         duration = time.time() - start_time
-        logger.info("Completed in %d seconds" % (duration))
+        logger.info(f"Completed in {duration} seconds")
         return 0
 
     if options.short_build_path:

--- a/scripts/pylib/twister/twisterlib/twister_main.py
+++ b/scripts/pylib/twister/twisterlib/twister_main.py
@@ -70,7 +70,12 @@ def main(options: argparse.Namespace, default_options: argparse.Namespace):
 
     previous_results = None
     # Cleanup
-    if options.no_clean or options.only_failed or options.test_only or options.report_summary is not None:
+    if (
+        options.no_clean
+        or options.only_failed
+        or options.test_only
+        or options.report_summary is not None
+    ):
         if os.path.exists(options.outdir):
             print("Keeping artifacts untouched")
     elif options.last_metrics:
@@ -141,7 +146,8 @@ def main(options: argparse.Namespace, default_options: argparse.Namespace):
                 if options.platform and not tplan.check_platform(i.platform, options.platform):
                     continue
                 logger.debug(
-                    f"{i.platform.name:<25} {i.testsuite.name:<50} {Fore.YELLOW}SKIPPED{Fore.RESET}: {i.reason}"
+                    f"{i.platform.name:<25} {i.testsuite.name:<50}"
+                    f" {Fore.YELLOW}SKIPPED{Fore.RESET}: {i.reason}"
                 )
 
     report = Reporting(tplan, env)

--- a/scripts/tests/twister/test_config_parser.py
+++ b/scripts/tests/twister/test_config_parser.py
@@ -160,7 +160,7 @@ def test_cast_value(zephyr_base, value, typestr, expected, expected_warning):
             result = parser._cast_value(value, typestr)
             assert result == expected
             if expected_warning:
-                warn_mock.assert_called_once_with(*expected_warning)
+                warn_mock.assert_called_once_with(*expected_warning, stacklevel=mock.ANY)
             else:
                 warn_mock.assert_not_called()
 

--- a/scripts/tests/twister/test_handlers.py
+++ b/scripts/tests/twister/test_handlers.py
@@ -1740,98 +1740,6 @@ def test_qemuhandler_thread_get_fifo_names():
     assert fifo_in ==  'dummy.in'
     assert fifo_out ==  'dummy.out'
 
-TESTDATA_22 = [
-    (False, False),
-    (False, True),
-    (True, False),
-    (True, True),
-]
-
-@pytest.mark.parametrize(
-    'fifo_in_exists, fifo_out_exists',
-    TESTDATA_22,
-    ids=['both missing', 'out exists', 'in exists', 'both exist']
-)
-def test_qemuhandler_thread_open_files(fifo_in_exists, fifo_out_exists):
-    def mock_exists(path):
-        if path == 'fifo.in':
-            return fifo_in_exists
-        elif path == 'fifo.out':
-            return fifo_out_exists
-        else:
-            raise ValueError('Unexpected path in mock of os.path.exists')
-
-    unlink_mock = mock.Mock()
-    exists_mock = mock.Mock(side_effect=mock_exists)
-    mkfifo_mock = mock.Mock()
-
-    fifo_in = 'fifo.in'
-    fifo_out = 'fifo.out'
-    logfile = 'log.file'
-
-    with mock.patch('os.unlink', unlink_mock), \
-         mock.patch('os.mkfifo', mkfifo_mock), \
-         mock.patch('os.path.exists', exists_mock), \
-         mock.patch('builtins.open', mock.mock_open()) as open_mock:
-        _, _, _ = QEMUHandler._thread_open_files(fifo_in, fifo_out, logfile)
-
-    open_mock.assert_has_calls([
-        mock.call('fifo.in', 'wb'),
-        mock.call('fifo.out', 'rb', buffering=0),
-        mock.call('log.file', 'w'),
-    ])
-
-    if fifo_in_exists:
-        unlink_mock.assert_any_call('fifo.in')
-
-    if fifo_out_exists:
-        unlink_mock.assert_any_call('fifo.out')
-
-
-TESTDATA_23 = [
-    (False, False),
-    (True, True),
-    (True, False)
-]
-
-@pytest.mark.parametrize(
-    'is_pid, is_lookup_error',
-    TESTDATA_23,
-    ids=['pid missing', 'pid lookup error', 'pid ok']
-)
-def test_qemuhandler_thread_close_files(is_pid, is_lookup_error):
-    is_process_killed = {}
-
-    def mock_kill(pid, sig):
-        if is_lookup_error:
-            raise ProcessLookupError(f'Couldn\'t find pid: {pid}.')
-        elif sig == signal.SIGTERM:
-            is_process_killed[pid] = True
-
-    unlink_mock = mock.Mock()
-    kill_mock = mock.Mock(side_effect=mock_kill)
-
-    fifo_in = 'fifo.in'
-    fifo_out = 'fifo.out'
-    pid = 12345 if is_pid else None
-    out_fp = mock.Mock()
-    in_fp = mock.Mock()
-    log_out_fp = mock.Mock()
-
-    with mock.patch('os.unlink', unlink_mock), \
-         mock.patch('os.kill', kill_mock):
-        QEMUHandler._thread_close_files(fifo_in, fifo_out, pid, out_fp,
-                                        in_fp, log_out_fp)
-
-    out_fp.close.assert_called_once()
-    in_fp.close.assert_called_once()
-    log_out_fp.close.assert_called_once()
-
-    unlink_mock.assert_has_calls([mock.call('fifo.in'), mock.call('fifo.out')])
-
-    if is_pid and not is_lookup_error:
-        assert is_process_killed[pid]
-
 
 TESTDATA_24 = [
     (TwisterStatus.FAIL, 'timeout', TwisterStatus.FAIL, 'timeout'),
@@ -1983,6 +1891,8 @@ def test_qemuhandler_thread(
     handler.pid_fn = 'pid_fn'
     handler.fifo_fn = 'fifo_fn'
 
+    file_objs = {}
+
     def mocked_open(filename, *args, **kwargs):
         if filename == handler.pid_fn:
             contents = str(pid).encode('utf-8')
@@ -1993,6 +1903,9 @@ def test_qemuhandler_thread(
 
         file_object = mock.mock_open(read_data=contents).return_value
         file_object.__iter__.return_value = contents.splitlines(True)
+        if file_object not in file_objs:
+            file_objs[filename] = file_object
+
         return file_object
 
     harness = mock.Mock(capture_coverage=capture_coverage, handle=print)
@@ -2006,27 +1919,19 @@ def test_qemuhandler_thread(
     mock_thread_get_fifo_names = mock.Mock(
         return_value=('fifo_fn.in', 'fifo_fn.out')
     )
-    log_fp_mock = mock.Mock()
-    in_fp_mock = mocked_open('fifo_fn.out')
-    out_fp_mock = mock.Mock()
-    mock_thread_open_files = mock.Mock(
-        return_value=(out_fp_mock, in_fp_mock, log_fp_mock)
-    )
-    mock_thread_close_files = mock.Mock()
     mock_thread_update_instance_info = mock.Mock()
 
     with mock.patch('time.time', side_effect=faux_timer.time), \
          mock.patch('builtins.open', new=mocked_open), \
          mock.patch('select.poll', return_value=p), \
          mock.patch('os.path.exists', return_value=True), \
+         mock.patch('os.unlink', mock.Mock()), \
+         mock.patch('os.mkfifo', mock.Mock()), \
+         mock.patch('os.kill', mock.Mock()), \
          mock.patch('twisterlib.handlers.QEMUHandler._get_cpu_time',
                     mock_cputime), \
          mock.patch('twisterlib.handlers.QEMUHandler._thread_get_fifo_names',
                     mock_thread_get_fifo_names), \
-         mock.patch('twisterlib.handlers.QEMUHandler._thread_open_files',
-                    mock_thread_open_files), \
-         mock.patch('twisterlib.handlers.QEMUHandler._thread_close_files',
-                    mock_thread_close_files), \
          mock.patch('twisterlib.handlers.QEMUHandler.' \
                     '_thread_update_instance_info',
                     mock_thread_update_instance_info):
@@ -2041,8 +1946,6 @@ def test_qemuhandler_thread(
             handler.ignore_unexpected_eof
         )
 
-    print(mock_thread_update_instance_info.call_args_list)
-
     mock_thread_update_instance_info.assert_called_once_with(
         handler,
         mock.ANY,
@@ -2050,7 +1953,7 @@ def test_qemuhandler_thread(
         mock.ANY
     )
 
-    log_fp_mock.write.assert_has_calls(expected_log_calls)
+    file_objs[handler.log].write.assert_has_calls(expected_log_calls)
 
 
 TESTDATA_26 = [

--- a/scripts/tests/twister/test_handlers.py
+++ b/scripts/tests/twister/test_handlers.py
@@ -400,7 +400,7 @@ def test_binaryhandler_output_handler(
          mock.patch('time.time', side_effect=faux_timer.time):
         handler._output_handler(proc, harness)
 
-        mock_file.assert_called_with(handler.log, 'wt')
+        mock_file.assert_called_with(handler.log, 'w')
 
     if expected_handler_calls:
         mock_file.return_value.write.assert_has_calls(expected_handler_calls)
@@ -1778,7 +1778,7 @@ def test_qemuhandler_thread_open_files(fifo_in_exists, fifo_out_exists):
     open_mock.assert_has_calls([
         mock.call('fifo.in', 'wb'),
         mock.call('fifo.out', 'rb', buffering=0),
-        mock.call('log.file', 'wt'),
+        mock.call('log.file', 'w'),
     ])
 
     if fifo_in_exists:

--- a/scripts/tests/twister/test_hardwaremap.py
+++ b/scripts/tests/twister/test_hardwaremap.py
@@ -657,7 +657,7 @@ def test_hardwaremap_save(mocked_hm, hwm, expected_dump):
     read_mock = mock.mock_open(read_data=hwm)
     write_mock = mock.mock_open()
 
-    def mock_open(filename, mode):
+    def mock_open(filename, mode='r'):
         if mode == 'r':
             return read_mock()
         elif mode == 'w':

--- a/scripts/tests/twister/test_runner.py
+++ b/scripts/tests/twister/test_runner.py
@@ -688,7 +688,7 @@ def test_filterbuilder_parse_generated(
         cache = [cache_elem]
         return cache
 
-    def mock_open(filepath, type, *args, **kwargs):
+    def mock_open(filepath, *args, **kwargs):
         if filepath == expected_defconfig_path:
             rd = 'I am not a proper line\n' \
                  'CONFIG_FOO="no"'

--- a/scripts/tests/twister/test_testinstance.py
+++ b/scripts/tests/twister/test_testinstance.py
@@ -260,7 +260,7 @@ def test_testinstance_record(testinstance):
 
     mock_file.assert_called_with(
         os.path.join(testinstance.build_dir, 'recording.csv'),
-        'wt'
+        'w'
     )
 
     mock_writeheader.assert_has_calls([mock.call({ k:k for k in recording[0]})])

--- a/scripts/tests/twister/test_twister.py
+++ b/scripts/tests/twister/test_twister.py
@@ -65,11 +65,14 @@ def test_testsuite_config_files():
 
         # CONF_FILE, DTC_OVERLAY_FILE, OVERLAY_CONFIG fields should be stripped out
         # of extra_args. Other fields should remain untouched.
-        warn_mock.assert_called_once_with("Do not specify CONF_FILE, OVERLAY_CONFIG, or "
-                                          "DTC_OVERLAY_FILE in extra_args. This feature is "
-                                          "deprecated and will soon result in an error. Use "
-                                          "extra_conf_files, extra_overlay_confs or "
-                                          "extra_dtc_overlay_files YAML fields instead", DeprecationWarning)
+        warn_mock.assert_called_once_with(
+            "Do not specify CONF_FILE, OVERLAY_CONFIG, or DTC_OVERLAY_FILE in extra_args."
+            " This feature is deprecated and will soon result in an error."
+            " Use extra_conf_files, extra_overlay_confs"
+            " or extra_dtc_overlay_files YAML fields instead",
+            DeprecationWarning,
+            stacklevel=2
+        )
 
     assert scenario["extra_args"] == ["UNRELATED1=abc", "UNRELATED2=xyz"]
 


### PR DESCRIPTION
Twisterlib files are often changed and having them under ruff's linting would be useful.
This brings them up to ruff's standards and updates relevant tests.
