### PR TITLE
posix: clock: fix integer overflow in __z_clock_nanosleep

### DIFF
--- a/lib/posix/options/clock.c
+++ b/lib/posix/options/clock.c
@@ -216,11 +216,9 @@ static int __z_clock_nanosleep(clockid_t clock_id, int flags, const struct times
 		return -1;
 	}
 
-	if ((flags & TIMER_ABSTIME) == 0 &&
-	    unlikely(rqtp->tv_sec >= ULLONG_MAX / NSEC_PER_SEC)) {
-
-		ns = rqtp->tv_nsec + NSEC_PER_SEC
-			+ (uint64_t)k_sleep(K_SECONDS(rqtp->tv_sec - 1)) * NSEC_PER_MSEC;
+	if ((flags & TIMER_ABSTIME) == 0 && unlikely(rqtp->tv_sec >= ULLONG_MAX / NSEC_PER_SEC)) {
+		ns = rqtp->tv_nsec + NSEC_PER_SEC +
+		     (uint64_t)k_sleep(K_SECONDS(rqtp->tv_sec - 1)) * NSEC_PER_MSEC;
 	} else {
 		ns = (uint64_t)rqtp->tv_sec * NSEC_PER_SEC + rqtp->tv_nsec;
 	}

--- a/lib/posix/options/clock.c
+++ b/lib/posix/options/clock.c
@@ -222,7 +222,7 @@ static int __z_clock_nanosleep(clockid_t clock_id, int flags, const struct times
 		ns = rqtp->tv_nsec + NSEC_PER_SEC
 			+ k_sleep(K_SECONDS(rqtp->tv_sec - 1)) * NSEC_PER_MSEC;
 	} else {
-		ns = rqtp->tv_sec * NSEC_PER_SEC + rqtp->tv_nsec;
+		ns = (uint64_t)rqtp->tv_sec * NSEC_PER_SEC + rqtp->tv_nsec;
 	}
 
 	uptime_ns = k_ticks_to_ns_ceil64(sys_clock_tick_get());

--- a/lib/posix/options/clock.c
+++ b/lib/posix/options/clock.c
@@ -220,7 +220,7 @@ static int __z_clock_nanosleep(clockid_t clock_id, int flags, const struct times
 	    unlikely(rqtp->tv_sec >= ULLONG_MAX / NSEC_PER_SEC)) {
 
 		ns = rqtp->tv_nsec + NSEC_PER_SEC
-			+ k_sleep(K_SECONDS(rqtp->tv_sec - 1)) * NSEC_PER_MSEC;
+			+ (uint64_t)k_sleep(K_SECONDS(rqtp->tv_sec - 1)) * NSEC_PER_MSEC;
 	} else {
 		ns = (uint64_t)rqtp->tv_sec * NSEC_PER_SEC + rqtp->tv_nsec;
 	}


### PR DESCRIPTION
Nanosecond time calculation overflows if the libc has 32-bit time_t. One such libc is the classic ARC MWDT one, but there might be others.