### PR TITLE
net: ipv6_pe: Check return value from mbedtls_md_setup

### DIFF
--- a/subsys/net/ip/ipv6.c
+++ b/subsys/net/ip/ipv6.c
@@ -903,7 +903,12 @@ static int gen_stable_iid(uint8_t if_index,
 	}
 
 	mbedtls_md_init(&ctx);
-	mbedtls_md_setup(&ctx, md_info, true);
+	ret = mbedtls_md_setup(&ctx, md_info, true);
+	if (ret != 0) {
+		NET_DBG("Cannot %s hmac (%d)", "setup", ret);
+		goto err;
+	}
+
 	ret = mbedtls_md_hmac_starts(&ctx, secret_key, sizeof(secret_key));
 	if (ret != 0) {
 		NET_DBG("Cannot %s hmac (%d)", "start", ret);

--- a/subsys/net/ip/ipv6_pe.c
+++ b/subsys/net/ip/ipv6_pe.c
@@ -256,7 +256,12 @@ static int gen_temporary_iid(struct net_if *iface,
 	}
 
 	mbedtls_md_init(&ctx);
-	mbedtls_md_setup(&ctx, md_info, true);
+	ret = mbedtls_md_setup(&ctx, md_info, true);
+	if (ret != 0) {
+		NET_DBG("Cannot %s hmac (%d)", "setup", ret);
+		goto err;
+	}
+
 	ret = mbedtls_md_hmac_starts(&ctx, secret_key, sizeof(secret_key));
 	if (ret != 0) {
 		NET_DBG("Cannot %s hmac (%d)", "start", ret);


### PR DESCRIPTION
Bail out if mbedtls_md_setup() returns an error.

Fixes #81950
Coverify-CID: 434626

Fixed also similar issue in `ipv6.c` in second commit.