### PR TITLE
net: dns: mdns_responder: Interface name might miss terminating null

### DIFF
--- a/subsys/net/lib/dns/mdns_responder.c
+++ b/subsys/net/lib/dns/mdns_responder.c
@@ -873,7 +873,7 @@ static int init_listener(void)
 				ifindex, ret);
 		} else {
 			memset(&if_req, 0, sizeof(if_req));
-			strncpy(if_req.ifr_name, name, sizeof(if_req.ifr_name));
+			strncpy(if_req.ifr_name, name, sizeof(if_req.ifr_name) - 1);
 
 			ret = zsock_setsockopt(v4, SOL_SOCKET, SO_BINDTODEVICE,
 					       &if_req, sizeof(if_req));


### PR DESCRIPTION
The network interface name that is copied to if_req struct might be missing terminating null for IPv4.

This is fixing the IPv4 issue which was missed in previous fix attempt.

Fixes #74795
Coverity-CID: 368797