### PR TITLE
net: lwm2m: Reset server timestamps after bootstrap

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_rd_client.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rd_client.c
@@ -849,6 +849,9 @@ static int sm_bootstrap_trans_done(void)
 	client.ctx->sec_obj_inst = -1;
 	client.use_bootstrap = false;
 
+	/* reset server timestamps */
+	lwm2m_server_reset_timestamps();
+
 	set_sm_state(ENGINE_DO_REGISTRATION);
 
 	return 0;


### PR DESCRIPTION
Reset the server timestamps after bootstrap to handle a case where a new server instance has replaced the bootstrap server instance.