### PR TITLE
dts: bindings: i2s: Adds properties for power supply control

### DIFF
--- a/dts/bindings/i2s/i2s-device.yaml
+++ b/dts/bindings/i2s/i2s-device.yaml
@@ -3,7 +3,7 @@
 
 # Common fields for I2S devices
 
-include: base.yaml
+include: [base.yaml, power.yaml]
 
 on-bus: i2s
 


### PR DESCRIPTION
Adds a dependency to `power.yaml`, as already exists for SPI and I2C devices.