### PR TITLE
net: lib: http_server: Verify fs_read result for filesystem resources

### DIFF
--- a/subsys/net/lib/http/http_server_http1.c
+++ b/subsys/net/lib/http/http_server_http1.c
@@ -450,6 +450,11 @@ int handle_http1_static_fs_resource(struct http_resource_detail_static_fs *stati
 	remaining = file_size;
 	while (remaining > 0) {
 		len = fs_read(&file, http_response, sizeof(http_response));
+		if (len < 0) {
+			LOG_ERR("Filesystem read error (%d)", len);
+			goto close;
+		}
+
 		ret = http_server_sendall(client, http_response, len);
 		if (ret < 0) {
 			goto close;

--- a/subsys/net/lib/http/http_server_http2.c
+++ b/subsys/net/lib/http/http_server_http2.c
@@ -470,6 +470,10 @@ static int handle_http2_static_fs_resource(struct http_resource_detail_static_fs
 	remaining = client->data_len;
 	while (remaining > 0) {
 		len = fs_read(&file, tmp, sizeof(tmp));
+		if (len < 0) {
+			LOG_ERR("Filesystem read error (%d)", len);
+			goto out;
+		}
 
 		remaining -= len;
 		ret = send_data_frame(client, tmp, len, frame->stream_identifier,


### PR DESCRIPTION
Verify the result of the fs_read() operation when handling filesystem resources, and abort processing the resource in case of errors.

Fixes #81995