### PR TITLE
twister: testplan: fix robot filter when there is no simulator

### DIFF
--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -934,7 +934,7 @@ class TestPlan:
 
                 if ts.harness:
                     sim = plat.simulator_by_name(self.options.sim_name)
-                    if ts.harness == 'robot' and sim and sim.name != 'renode':
+                    if ts.harness == 'robot' and not (sim and sim.name == 'renode'):
                         instance.add_filter("No robot support for the selected platform", Filters.SKIP)
 
                 if ts.depends_on:


### PR DESCRIPTION
#79174 incorectly interpreted the condition. If no simulator is found if cannot be "renode" and therefore robot should be considered unsupported.