### PR TITLE
bluetooth: fix GATT service reregistering

### DIFF
--- a/include/zephyr/bluetooth/gatt.h
+++ b/include/zephyr/bluetooth/gatt.h
@@ -297,7 +297,18 @@ struct bt_gatt_attr {
 	 *
 	 *  @sa bt_gatt_discover_func_t about this field.
 	 */
-	uint16_t perm;
+	uint16_t perm: 15;
+
+	/** @cond INTERNAL_HIDDEN
+	 *  Indicates if the attribute handle was assigned automatically.
+	 *
+	 *  This flag is set to 1 if the attribute handle was assigned by the stack,
+	 *  and 0 if it was manually set by the application.
+	 *
+	 *  @note Applications must not modify this field.
+	 */
+	bool _auto_assigned_handle: 1;
+	/** @endcond */
 };
 
 /** @brief GATT Service structure */

--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -1307,9 +1307,11 @@ static int gatt_register(struct bt_gatt_service *svc)
 populate:
 	/* Populate the handles and append them to the list */
 	for (; attrs && count; attrs++, count--) {
+		attrs->_auto_assigned_handle = 0;
 		if (!attrs->handle) {
 			/* Allocate handle if not set already */
 			attrs->handle = ++handle;
+			attrs->_auto_assigned_handle = 1;
 		} else if (attrs->handle > handle) {
 			/* Use existing handle if valid */
 			handle = attrs->handle;
@@ -1726,6 +1728,12 @@ static int gatt_unregister(struct bt_gatt_service *svc)
 
 		if (is_host_managed_ccc(attr)) {
 			gatt_unregister_ccc(attr->user_data);
+		}
+
+		/* The stack should not clear any handles set by the user. */
+		if (attr->_auto_assigned_handle) {
+			attr->handle = 0;
+			attr->_auto_assigned_handle = 0;
 		}
 	}
 


### PR DESCRIPTION
* Fixed issue with reregistering of a GATT services.
* Added unit tests covering the GATT reregistering scenario.

Fixes #67377