### PR TITLE
drivers: led_strip: ws2812_i2s: Adds dependency to `i2s-device`

### DIFF
--- a/drivers/led_strip/ws2812_i2s.c
+++ b/drivers/led_strip/ws2812_i2s.c
@@ -230,7 +230,7 @@ static DEVICE_API(led_strip, ws2812_i2s_api) = {
 		DT_INST_PROP(idx, color_mapping);                                                  \
                                                                                                    \
 	static const struct ws2812_i2s_cfg ws2812_i2s_##idx##_cfg = {                              \
-		.dev = DEVICE_DT_GET(DT_INST_PROP(idx, i2s_dev)),                                  \
+		.dev = DEVICE_DT_GET(DT_INST_BUS(idx)),                                            \
 		.tx_buf_bytes = WS2812_I2S_BUFSIZE(idx),                                           \
 		.mem_slab = &ws2812_i2s_##idx##_slab,                                              \
 		.num_colors = WS2812_NUM_COLORS(idx),                                              \

--- a/dts/bindings/led_strip/worldsemi,ws2812-i2s.yaml
+++ b/dts/bindings/led_strip/worldsemi,ws2812-i2s.yaml
@@ -9,14 +9,9 @@ description: |
 
 compatible: "worldsemi,ws2812-i2s"
 
-include: [base.yaml, ws2812.yaml]
+include: [i2s-device.yaml, ws2812.yaml]
 
 properties:
-
-  i2s-dev:
-    type: phandle
-    required: true
-    description: Pointer to the I2S instance.
 
   out-active-low:
     type: boolean

--- a/samples/drivers/led/led_strip/boards/esp32s3_devkitc_procpu.overlay
+++ b/samples/drivers/led/led_strip/boards/esp32s3_devkitc_procpu.overlay
@@ -20,10 +20,10 @@ i2s_led: &i2s0 {
 	dmas = <&dma 3>;
 	dma-names = "tx";
 
-	led_strip: ws2812 {
+	led_strip: ws2812@0 {
 		compatible = "worldsemi,ws2812-i2s";
 
-		i2s-dev = <&i2s_led>;
+		reg = <0>;
 		chain-length = <46>;
 		color-mapping = <LED_COLOR_ID_GREEN
 				 LED_COLOR_ID_RED

--- a/samples/drivers/led/led_strip/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/samples/drivers/led/led_strip/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -17,10 +17,10 @@ i2s_led: &i2s0 {
 	pinctrl-0 = <&i2s0_default_alt>;
 	pinctrl-names = "default";
 
-	led_strip: ws2812 {
+	led_strip: ws2812@0 {
 		compatible = "worldsemi,ws2812-i2s";
 
-		i2s-dev = <&i2s_led>;
+		reg = <0>;
 		chain-length = <42>; /* arbitrary; change at will */
 		color-mapping = <LED_COLOR_ID_GREEN
 					LED_COLOR_ID_RED

--- a/samples/drivers/led/led_strip/boards/thingy52_nrf52832.overlay
+++ b/samples/drivers/led/led_strip/boards/thingy52_nrf52832.overlay
@@ -22,10 +22,10 @@ i2s_led: &i2s0 {
 	pinctrl-0 = <&i2s0_default_alt>;
 	pinctrl-names = "default";
 
-	led_strip: ws2812 {
+	led_strip: ws2812@0 {
 		compatible = "worldsemi,ws2812-i2s";
 
-		i2s-dev = < &i2s_led >;
+		reg = <0>;
 		chain-length = <10>; /* arbitrary; change at will */
 		color-mapping = <LED_COLOR_ID_GREEN
 					LED_COLOR_ID_RED


### PR DESCRIPTION
Removes the ugly `i2s-dev` property and uses its parent I2S bus device.