### PR TITLE
tests: posix: common: userspace: temporarily disable qemu_arc_em

### DIFF
--- a/tests/posix/common/testcase.yaml
+++ b/tests/posix/common/testcase.yaml
@@ -75,6 +75,9 @@ tests:
       - CONFIG_THREAD_STACK_INFO=n
   portability.posix.common.userspace:
     filter: CONFIG_ARCH_HAS_USERSPACE
+    # Temporarily disabled due to #82059
+    platform_exclude:
+      - qemu_arc/qemu_arc_em
     tags:
       - userspace
     extra_configs:


### PR DESCRIPTION
This build would fail in CI for reasons that are not obvious.

```
west twister -i -p qemu_arc/qemu_arc_em \
  -s tests/posix/common/portability.posix.common.userspace

scripts/build/gen_kobject_placeholders.py did not reserve \
  enough space for kobject rodata.
```

It's the only platform that fails this way.

Exclude it from this test temporarily until #82059 is fixed.

Testing Done
```shell
$ twister -T tests/posix/common
INFO    - Using 'zephyr' toolchain.
INFO    - Selecting default platforms per test case
INFO    - Building initial testsuite list...
INFO    - Writing JSON report /home/cfriedt/zephyrproject/zephyr/twister-out/testplan.json
INFO    - JOBS: 32
INFO    - Adding tasks to the queue...
INFO    - Added initial list of jobs to queue
INFO    - Total complete:  108/ 108  100%  built (not run):    0, filtered:  517, failed:    0, error:    0
INFO    - 14 test scenarios (616 configurations) selected, 517 configurations filtered (508 by static filter, 9 at runtime).
INFO    - 99 of 99 executed test configurations passed (100.00%), 0 built (not run), 0 failed, 0 errored, with no warnings in 241.91 seconds.
INFO    - 8694 of 8694 executed test cases passed (100.00%) on 10 out of total 869 platforms (1.15%).
INFO    - 612 selected test cases not executed: 612 skipped.
INFO    - 99 test configurations executed on platforms, 0 test configurations were only built.
INFO    - Saving reports...
INFO    - Writing JSON report /home/cfriedt/zephyrproject/zephyr/twister-out/twister.json
INFO    - Writing xunit report /home/cfriedt/zephyrproject/zephyr/twister-out/twister.xml...
INFO    - Writing xunit report /home/cfriedt/zephyrproject/zephyr/twister-out/twister_report.xml...
INFO    - Run completed
```