### PR TITLE
 drivers: sensor: st: Fix uninitialized variable in lsm6dsv16x

### DIFF
--- a/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x_trigger.c
+++ b/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x_trigger.c
@@ -37,7 +37,7 @@ static int lsm6dsv16x_enable_xl_int(const struct device *dev, int enable)
 
 	/* set interrupt */
 	if (cfg->drdy_pin == 1) {
-		lsm6dsv16x_pin_int_route_t val;
+		lsm6dsv16x_pin_int_route_t val = {};
 
 		ret = lsm6dsv16x_pin_int1_route_get(ctx, &val);
 		if (ret < 0) {
@@ -49,7 +49,7 @@ static int lsm6dsv16x_enable_xl_int(const struct device *dev, int enable)
 
 		ret = lsm6dsv16x_pin_int1_route_set(ctx, &val);
 	} else {
-		lsm6dsv16x_pin_int_route_t val;
+		lsm6dsv16x_pin_int_route_t val = {};
 
 		ret = lsm6dsv16x_pin_int2_route_get(ctx, &val);
 		if (ret < 0) {
@@ -83,7 +83,7 @@ static int lsm6dsv16x_enable_g_int(const struct device *dev, int enable)
 
 	/* set interrupt */
 	if (cfg->drdy_pin == 1) {
-		lsm6dsv16x_pin_int_route_t val;
+		lsm6dsv16x_pin_int_route_t val = {};
 
 		ret = lsm6dsv16x_pin_int1_route_get(ctx, &val);
 		if (ret < 0) {
@@ -95,7 +95,7 @@ static int lsm6dsv16x_enable_g_int(const struct device *dev, int enable)
 
 		ret = lsm6dsv16x_pin_int1_route_set(ctx, &val);
 	} else {
-		lsm6dsv16x_pin_int_route_t val;
+		lsm6dsv16x_pin_int_route_t val = {};
 
 		ret = lsm6dsv16x_pin_int2_route_get(ctx, &val);
 		if (ret < 0) {


### PR DESCRIPTION
Fix uninitialized ret variables scanned by Coverity.

from:
https://github.com/zephyrproject-rtos/zephyr/issues/81956