### PR TITLE
maintainers: Update nRF Wi-Fi entries

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -4745,11 +4745,6 @@ West:
   collaborators:
     - hubertmis
     - nordic-krch
-    - krish2718
-    - sachinthegreen
-    - udaynordic
-    - rajb9
-    - srkanordic
   files:
     - modules/hal_nordic/
   labels:
@@ -5070,6 +5065,10 @@ West:
   maintainers:
     - krish2718
     - sachinthegreen
+  collaborators:
+    - udaynordic
+    - rajb9
+    - srkanordic
   files:
     - modules/nrf_wifi/
   labels:


### PR DESCRIPTION
Now that OSAL code is moved form hal_nordic to nrf_wifi, update the entries to reflect the same.