### PR TITLE
drivers: input: gpio_keys: select GPIO

### DIFF
--- a/drivers/input/Kconfig.gpio_keys
+++ b/drivers/input/Kconfig.gpio_keys
@@ -5,6 +5,6 @@ config INPUT_GPIO_KEYS
 	bool "GPIO Keys input driver"
 	default y
 	depends on DT_HAS_GPIO_KEYS_ENABLED
-	depends on GPIO
+	select GPIO
 	help
 	  Enable support for GPIO Keys input driver.


### PR DESCRIPTION
Instead of depending on GPIO. This allows to just enable CONFIG_INPUT=y + DT node in the application layer. The same pattern is nowadays followed by most drivers.