### PR TITLE
scripts: process_gperf: upgrade the asso_values type to unsigned short

### DIFF
--- a/scripts/build/process_gperf.py
+++ b/scripts/build/process_gperf.py
@@ -126,6 +126,9 @@ def process_line(line, fp):
     # and just turn them into pointers
     line = re.sub(r'["].*["]', reformat_str, line)
 
+    # Use a bigger data type for the asso_values table to provide some margin
+    line = re.sub(r'char asso_values', r'short asso_values', line)
+
     fp.write(line)
 
 

--- a/tests/posix/common/testcase.yaml
+++ b/tests/posix/common/testcase.yaml
@@ -75,9 +75,6 @@ tests:
       - CONFIG_THREAD_STACK_INFO=n
   portability.posix.common.userspace:
     filter: CONFIG_ARCH_HAS_USERSPACE
-    # Temporarily disabled due to #82059
-    platform_exclude:
-      - qemu_arc/qemu_arc_em
     tags:
       - userspace
     extra_configs:


### PR DESCRIPTION
The gperf tool automatically selects the optimal data type for the asso_value table, depending on the MAX_HASH_VALUE. However, there is a corner case when the tables generated on different stages of the build process have different data types, causing a link-time error. Upgrade the data type for the table from unsigned char to unsigned short to at least exclude this 8-bit to 16-bit transition. There is another potential issue with the 16-bit to 32-bit transition, but it seems not very likely to have 65k kernel objects anytime soon.

Fixes: #82059
