### PR TITLE
style: Improve readability of DT_xxx_M macro

### DIFF
--- a/dts/common/freq.h
+++ b/dts/common/freq.h
@@ -8,6 +8,6 @@
 #define __DT_FREQ_H
 
 #define DT_FREQ_K(x) ((x) * 1000)
-#define DT_FREQ_M(x) ((x) * 1000 * 1000)
+#define DT_FREQ_M(x) (DT_FREQ_K(x) * 1000)
 
 #endif /* __DT_FREQ_H */

--- a/dts/common/freq.h
+++ b/dts/common/freq.h
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef __DT_FREQ_H
-#define __DT_FREQ_H
+#ifndef ZEPHYR_DTS_COMMON_FREQ_H_
+#define ZEPHYR_DTS_COMMON_FREQ_H_
 
 #define DT_FREQ_K(x) ((x) * 1000)
 #define DT_FREQ_M(x) (DT_FREQ_K(x) * 1000)
 
-#endif /* __DT_FREQ_H */
+#endif /* ZEPHYR_DTS_COMMON_FREQ_H_ */

--- a/dts/common/mem.h
+++ b/dts/common/mem.h
@@ -8,7 +8,7 @@
 #define __DT_MEM_H
 
 #define DT_SIZE_K(x) ((x) * 1024)
-#define DT_SIZE_M(x) ((x) * 1024 * 1024)
+#define DT_SIZE_M(x) (DT_SIZE_K(x) * 1024)
 
 /* concatenate the values of the arguments into one */
 #define _DT_DO_CONCAT(x, y) x ## y

--- a/dts/common/mem.h
+++ b/dts/common/mem.h
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef __DT_MEM_H
-#define __DT_MEM_H
+#ifndef ZEPHYR_DTS_COMMON_MEM_H_
+#define ZEPHYR_DTS_COMMON_MEM_H_
 
 #define DT_SIZE_K(x) ((x) * 1024)
 #define DT_SIZE_M(x) (DT_SIZE_K(x) * 1024)
@@ -15,4 +15,4 @@
 
 #define DT_ADDR(a) _DT_DO_CONCAT(0x, a)
 
-#endif /* __DT_MEM_H */
+#endif /* ZEPHYR_DTS_COMMON_MEM_H_ */


### PR DESCRIPTION
This makes the preprocessor macros in `dts/common` more beautiful, in line with the `ZEPHYR_INCLUDE` macro style, and it reuses the existing `DT_xxx_K` instead of hard coding.