### PR TITLE
doc: css: boards: fix font size for board name

### DIFF
--- a/doc/_static/css/custom.css
+++ b/doc/_static/css/custom.css
@@ -1171,3 +1171,7 @@ li>a.code-sample-link.reference.internal.current {
     text-overflow: ellipsis;
     overflow: hidden;
 }
+
+.sidebar.board-overview dl.field-list>dd code {
+    font-size: 0.9em;
+}


### PR DESCRIPTION
The board name should have the same size as all the other attributes in the board's "Wikipedia card".

BEFORE

![image](https://github.com/user-attachments/assets/8b2a18d1-c938-4be6-9142-86de5f0706f9)


AFTER

![image](https://github.com/user-attachments/assets/cf72ab90-cbff-44ad-b115-bd68ab4db9c4)
