### PR TITLE
Bluetooth: host: Improve error reporting on gatt subscribe

### DIFF
--- a/doc/releases/migration-guide-4.1.rst
+++ b/doc/releases/migration-guide-4.1.rst
@@ -521,6 +521,12 @@ Bluetooth Classic
 Bluetooth Host
 ==============
 
+* :c:func:`bt_gatt_subscribe` behavior has changed to if a different user/application has already
+  subscribed to the same handle. If user/application A subscribed to notifications and user/application
+  B subscribed to indications, both users/applications will receive the notify callback for notifications
+  and indications. The notify callback does not inform if it was a notification or indication. This is a
+  corner case since most applications will only subscribe once and for either notification or indication.
+
 * :kconfig:option:`CONFIG_BT_BUF_ACL_RX_COUNT` has been deprecated. The number of ACL RX buffers is
   now computed internally and is equal to :kconfig:option:`CONFIG_BT_MAX_CONN` + 1. If an application
   needs more buffers, it can use the new :kconfig:option:`CONFIG_BT_BUF_ACL_RX_COUNT_EXTRA` to add

--- a/include/zephyr/bluetooth/gatt.h
+++ b/include/zephyr/bluetooth/gatt.h
@@ -2088,6 +2088,12 @@ struct bt_gatt_subscribe_params {
  *  notified value. One may then decide whether to unsubscribe directly from
  *  this callback. Notification callback with NULL data will not be called if
  *  subscription was removed by this method.
+ *  If user/application A subscribed to notifications and user/application
+ *  B subscribed to indications, both users/applications will receive the notify
+ *  callback for notifications and indications. The notify callback does not
+ *  inform if it was a notification or indication. This is a corner case since
+ *  most applications will only subscribe once and for either notification
+ *  or indication.
  *
  *  The Response comes in callback @p params->subscribe. The callback is run from
  *  the context specified by 'config BT_RECV_CONTEXT'.
@@ -2106,6 +2112,8 @@ struct bt_gatt_subscribe_params {
  *
  *  @retval 0 Successfully queued request. Will call @p params->write on
  *  resolution.
+ *
+ *  @retval -EINVAL if the @p params->value is out of range
  *
  *  @retval -ENOMEM ATT request queue is full and blocking would cause deadlock.
  *  Allow a pending request to resolve before retrying, or call this function


### PR DESCRIPTION
* Return EALREADY when the subscription already exists but it is a different entry. This indicates to the application to not wait on subscribe callback. This is needed because the callback is called from the ccc_write which does not happen when another subscription exists