### PR TITLE
net: Remove useless asserts

### DIFF
--- a/include/zephyr/net/net_if.h
+++ b/include/zephyr/net/net_if.h
@@ -786,8 +786,9 @@ static inline void net_if_tx_unlock(struct net_if *iface)
 static inline void net_if_flag_set(struct net_if *iface,
 				   enum net_if_flag value)
 {
-	NET_ASSERT(iface);
-	NET_ASSERT(iface->if_dev);
+	if (iface == NULL || iface->if_dev == NULL) {
+		return;
+	}
 
 	atomic_set_bit(iface->if_dev->flags, value);
 }
@@ -803,8 +804,9 @@ static inline void net_if_flag_set(struct net_if *iface,
 static inline bool net_if_flag_test_and_set(struct net_if *iface,
 					    enum net_if_flag value)
 {
-	NET_ASSERT(iface);
-	NET_ASSERT(iface->if_dev);
+	if (iface == NULL || iface->if_dev == NULL) {
+		return false;
+	}
 
 	return atomic_test_and_set_bit(iface->if_dev->flags, value);
 }
@@ -818,8 +820,9 @@ static inline bool net_if_flag_test_and_set(struct net_if *iface,
 static inline void net_if_flag_clear(struct net_if *iface,
 				     enum net_if_flag value)
 {
-	NET_ASSERT(iface);
-	NET_ASSERT(iface->if_dev);
+	if (iface == NULL || iface->if_dev == NULL) {
+		return;
+	}
 
 	atomic_clear_bit(iface->if_dev->flags, value);
 }
@@ -835,8 +838,9 @@ static inline void net_if_flag_clear(struct net_if *iface,
 static inline bool net_if_flag_test_and_clear(struct net_if *iface,
 					      enum net_if_flag value)
 {
-	NET_ASSERT(iface);
-	NET_ASSERT(iface->if_dev);
+	if (iface == NULL || iface->if_dev == NULL) {
+		return false;
+	}
 
 	return atomic_test_and_clear_bit(iface->if_dev->flags, value);
 }
@@ -852,10 +856,7 @@ static inline bool net_if_flag_test_and_clear(struct net_if *iface,
 static inline bool net_if_flag_is_set(struct net_if *iface,
 				      enum net_if_flag value)
 {
-	NET_ASSERT(iface);
-	NET_ASSERT(iface->if_dev);
-
-	if (iface == NULL) {
+	if (iface == NULL || iface->if_dev == NULL) {
 		return false;
 	}
 
@@ -873,8 +874,9 @@ static inline bool net_if_flag_is_set(struct net_if *iface,
 static inline enum net_if_oper_state net_if_oper_state_set(
 	struct net_if *iface, enum net_if_oper_state oper_state)
 {
-	NET_ASSERT(iface);
-	NET_ASSERT(iface->if_dev);
+	if (iface == NULL || iface->if_dev == NULL) {
+		return NET_IF_OPER_UNKNOWN;
+	}
 
 	BUILD_ASSERT((enum net_if_oper_state)(-1) > 0 && NET_IF_OPER_UNKNOWN == 0);
 	if (oper_state <= NET_IF_OPER_UP) {
@@ -893,8 +895,9 @@ static inline enum net_if_oper_state net_if_oper_state_set(
  */
 static inline enum net_if_oper_state net_if_oper_state(struct net_if *iface)
 {
-	NET_ASSERT(iface);
-	NET_ASSERT(iface->if_dev);
+	if (iface == NULL || iface->if_dev == NULL) {
+		return NET_IF_OPER_UNKNOWN;
+	}
 
 	return iface->if_dev->oper_state;
 }
@@ -918,7 +921,7 @@ enum net_verdict net_if_send_data(struct net_if *iface, struct net_pkt *pkt);
  */
 static inline const struct net_l2 *net_if_l2(struct net_if *iface)
 {
-	if (!iface || !iface->if_dev) {
+	if (iface == NULL || iface->if_dev == NULL) {
 		return NULL;
 	}
 
@@ -944,8 +947,9 @@ enum net_verdict net_if_recv_data(struct net_if *iface, struct net_pkt *pkt);
  */
 static inline void *net_if_l2_data(struct net_if *iface)
 {
-	NET_ASSERT(iface);
-	NET_ASSERT(iface->if_dev);
+	if (iface == NULL || iface->if_dev == NULL) {
+		return NULL;
+	}
 
 	return iface->if_dev->l2_data;
 }
@@ -959,8 +963,9 @@ static inline void *net_if_l2_data(struct net_if *iface)
  */
 static inline const struct device *net_if_get_device(struct net_if *iface)
 {
-	NET_ASSERT(iface);
-	NET_ASSERT(iface->if_dev);
+	if (iface == NULL || iface->if_dev == NULL) {
+		return NULL;
+	}
 
 	return iface->if_dev->dev;
 }
@@ -1011,8 +1016,9 @@ bool net_if_is_offloaded(struct net_if *iface);
 static inline struct net_offload *net_if_offload(struct net_if *iface)
 {
 #if defined(CONFIG_NET_OFFLOAD)
-	NET_ASSERT(iface);
-	NET_ASSERT(iface->if_dev);
+	if (iface == NULL || iface->if_dev == NULL) {
+		return NULL;
+	}
 
 	return iface->if_dev->offload;
 #else
@@ -1032,8 +1038,9 @@ static inline struct net_offload *net_if_offload(struct net_if *iface)
 static inline bool net_if_is_socket_offloaded(struct net_if *iface)
 {
 #if defined(CONFIG_NET_SOCKETS_OFFLOAD)
-	NET_ASSERT(iface);
-	NET_ASSERT(iface->if_dev);
+	if (iface == NULL || iface->if_dev == NULL) {
+		return false;
+	}
 
 	return (iface->if_dev->socket_offload != NULL);
 #else
@@ -1053,8 +1060,9 @@ static inline void net_if_socket_offload_set(
 		struct net_if *iface, net_socket_create_t socket_offload)
 {
 #if defined(CONFIG_NET_SOCKETS_OFFLOAD)
-	NET_ASSERT(iface);
-	NET_ASSERT(iface->if_dev);
+	if (iface == NULL || iface->if_dev == NULL) {
+		return;
+	}
 
 	iface->if_dev->socket_offload = socket_offload;
 #else
@@ -1073,8 +1081,9 @@ static inline void net_if_socket_offload_set(
 static inline net_socket_create_t net_if_socket_offload(struct net_if *iface)
 {
 #if defined(CONFIG_NET_SOCKETS_OFFLOAD)
-	NET_ASSERT(iface);
-	NET_ASSERT(iface->if_dev);
+	if (iface == NULL || iface->if_dev == NULL) {
+		return NULL;
+	}
 
 	return iface->if_dev->socket_offload;
 #else
@@ -1093,8 +1102,9 @@ static inline net_socket_create_t net_if_socket_offload(struct net_if *iface)
  */
 static inline struct net_linkaddr *net_if_get_link_addr(struct net_if *iface)
 {
-	NET_ASSERT(iface);
-	NET_ASSERT(iface->if_dev);
+	if (iface == NULL || iface->if_dev == NULL) {
+		return NULL;
+	}
 
 	return &iface->if_dev->link_addr;
 }
@@ -1108,7 +1118,9 @@ static inline struct net_linkaddr *net_if_get_link_addr(struct net_if *iface)
  */
 static inline struct net_if_config *net_if_get_config(struct net_if *iface)
 {
-	NET_ASSERT(iface);
+	if (iface == NULL) {
+		return NULL;
+	}
 
 	return &iface->config;
 }
@@ -1252,11 +1264,9 @@ static inline int net_if_set_link_addr(struct net_if *iface,
  */
 static inline uint16_t net_if_get_mtu(struct net_if *iface)
 {
-	if (iface == NULL) {
+	if (iface == NULL || iface->if_dev == NULL) {
 		return 0U;
 	}
-
-	NET_ASSERT(iface->if_dev);
 
 	return iface->if_dev->mtu;
 }
@@ -1270,11 +1280,9 @@ static inline uint16_t net_if_get_mtu(struct net_if *iface)
 static inline void net_if_set_mtu(struct net_if *iface,
 				  uint16_t mtu)
 {
-	if (iface == NULL) {
+	if (iface == NULL || iface->if_dev == NULL) {
 		return;
 	}
-
-	NET_ASSERT(iface->if_dev);
 
 	iface->if_dev->mtu = mtu;
 }
@@ -1288,7 +1296,9 @@ static inline void net_if_set_mtu(struct net_if *iface,
 static inline void net_if_addr_set_lf(struct net_if_addr *ifaddr,
 				      bool is_infinite)
 {
-	NET_ASSERT(ifaddr);
+	if (ifaddr == NULL) {
+		return;
+	}
 
 	ifaddr->is_infinite = is_infinite;
 }
@@ -1320,7 +1330,9 @@ struct net_if *net_if_lookup_by_dev(const struct device *dev);
  */
 static inline struct net_if_config *net_if_config_get(struct net_if *iface)
 {
-	NET_ASSERT(iface);
+	if (iface == NULL) {
+		return NULL;
+	}
 
 	return &iface->config;
 }
@@ -1651,7 +1663,9 @@ void net_if_ipv6_maddr_join(struct net_if *iface,
  */
 static inline bool net_if_ipv6_maddr_is_joined(struct net_if_mcast_addr *addr)
 {
-	NET_ASSERT(addr);
+	if (addr == NULL) {
+		return false;
+	}
 
 	return addr->is_joined;
 }
@@ -1765,7 +1779,9 @@ bool net_if_ipv6_addr_onlink(struct net_if **iface, struct in6_addr *addr);
 #if defined(CONFIG_NET_NATIVE_IPV6)
 static inline struct in6_addr *net_if_router_ipv6(struct net_if_router *router)
 {
-	NET_ASSERT(router);
+	if (router == NULL) {
+		return NULL;
+	}
 
 	return &router->address.in6_addr;
 }
@@ -1932,7 +1948,9 @@ static inline void net_if_ipv6_set_base_reachable_time(struct net_if *iface,
 						       uint32_t reachable_time)
 {
 #if defined(CONFIG_NET_NATIVE_IPV6)
-	NET_ASSERT(iface);
+	if (iface == NULL) {
+		return;
+	}
 
 	if (!iface->config.ip.ipv6) {
 		return;
@@ -1956,7 +1974,9 @@ static inline void net_if_ipv6_set_base_reachable_time(struct net_if *iface,
 static inline uint32_t net_if_ipv6_get_reachable_time(struct net_if *iface)
 {
 #if defined(CONFIG_NET_NATIVE_IPV6)
-	NET_ASSERT(iface);
+	if (iface == NULL) {
+		return 0;
+	}
 
 	if (!iface->config.ip.ipv6) {
 		return 0;
@@ -2007,7 +2027,9 @@ static inline void net_if_ipv6_set_retrans_timer(struct net_if *iface,
 						 uint32_t retrans_timer)
 {
 #if defined(CONFIG_NET_NATIVE_IPV6)
-	NET_ASSERT(iface);
+	if (iface == NULL) {
+		return;
+	}
 
 	if (!iface->config.ip.ipv6) {
 		return;
@@ -2030,7 +2052,9 @@ static inline void net_if_ipv6_set_retrans_timer(struct net_if *iface,
 static inline uint32_t net_if_ipv6_get_retrans_timer(struct net_if *iface)
 {
 #if defined(CONFIG_NET_NATIVE_IPV6)
-	NET_ASSERT(iface);
+	if (iface == NULL) {
+		return 0;
+	}
 
 	if (!iface->config.ip.ipv6) {
 		return 0;
@@ -2367,7 +2391,9 @@ void net_if_ipv4_maddr_join(struct net_if *iface,
  */
 static inline bool net_if_ipv4_maddr_is_joined(struct net_if_mcast_addr *addr)
 {
-	NET_ASSERT(addr);
+	if (addr == NULL) {
+		return false;
+	}
 
 	return addr->is_joined;
 }
@@ -2390,7 +2416,9 @@ void net_if_ipv4_maddr_leave(struct net_if *iface,
 #if defined(CONFIG_NET_NATIVE_IPV4)
 static inline struct in_addr *net_if_router_ipv4(struct net_if_router *router)
 {
-	NET_ASSERT(router);
+	if (router == NULL) {
+		return NULL;
+	}
 
 	return &router->address.in_addr;
 }
@@ -2837,7 +2865,9 @@ int net_if_up(struct net_if *iface);
  */
 static inline bool net_if_is_up(struct net_if *iface)
 {
-	NET_ASSERT(iface);
+	if (iface == NULL) {
+		return false;
+	}
 
 	return net_if_flag_is_set(iface, NET_IF_UP) &&
 	       net_if_flag_is_set(iface, NET_IF_RUNNING);
@@ -2861,7 +2891,9 @@ int net_if_down(struct net_if *iface);
  */
 static inline bool net_if_is_admin_up(struct net_if *iface)
 {
-	NET_ASSERT(iface);
+	if (iface == NULL) {
+		return false;
+	}
 
 	return net_if_flag_is_set(iface, NET_IF_UP);
 }
@@ -2895,7 +2927,9 @@ void net_if_carrier_off(struct net_if *iface);
  */
 static inline bool net_if_is_carrier_ok(struct net_if *iface)
 {
-	NET_ASSERT(iface);
+	if (iface == NULL) {
+		return false;
+	}
 
 	return net_if_flag_is_set(iface, NET_IF_LOWER_UP);
 }
@@ -2931,7 +2965,9 @@ void net_if_dormant_off(struct net_if *iface);
  */
 static inline bool net_if_is_dormant(struct net_if *iface)
 {
-	NET_ASSERT(iface);
+	if (iface == NULL) {
+		return false;
+	}
 
 	return net_if_flag_is_set(iface, NET_IF_DORMANT);
 }

--- a/include/zephyr/net/trickle.h
+++ b/include/zephyr/net/trickle.h
@@ -136,7 +136,9 @@ void net_trickle_inconsistency(struct net_trickle *trickle);
  */
 static inline bool net_trickle_is_running(struct net_trickle *trickle)
 {
-	NET_ASSERT(trickle);
+	if (trickle == NULL) {
+		return false;
+	}
 
 	return trickle->I != 0U;
 }

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -2023,7 +2023,9 @@ bool net_if_ipv6_addr_rm(struct net_if *iface, const struct in6_addr *addr)
 	bool result = true;
 	int ret;
 
-	NET_ASSERT(addr);
+	if (iface == NULL || addr == NULL) {
+		return false;
+	}
 
 	net_if_lock(iface);
 
@@ -2254,8 +2256,9 @@ void net_if_ipv6_maddr_foreach(struct net_if *iface, net_if_ip_maddr_cb_t cb,
 {
 	struct net_if_ipv6 *ipv6;
 
-	NET_ASSERT(iface);
-	NET_ASSERT(cb);
+	if (iface == NULL || cb == NULL) {
+		return;
+	}
 
 	net_if_lock(iface);
 
@@ -2325,8 +2328,9 @@ out:
 
 void net_if_ipv6_maddr_leave(struct net_if *iface, struct net_if_mcast_addr *addr)
 {
-	NET_ASSERT(iface);
-	NET_ASSERT(addr);
+	if (iface == NULL || addr == NULL) {
+		return;
+	}
 
 	net_if_lock(iface);
 	addr->is_joined = false;
@@ -2335,8 +2339,9 @@ void net_if_ipv6_maddr_leave(struct net_if *iface, struct net_if_mcast_addr *add
 
 void net_if_ipv6_maddr_join(struct net_if *iface, struct net_if_mcast_addr *addr)
 {
-	NET_ASSERT(iface);
-	NET_ASSERT(addr);
+	if (iface == NULL || addr == NULL) {
+		return;
+	}
 
 	net_if_lock(iface);
 	addr->is_joined = true;
@@ -3140,7 +3145,9 @@ const struct in6_addr *net_if_ipv6_select_src_addr_hint(struct net_if *dst_iface
 	const struct in6_addr *src = NULL;
 	uint8_t best_match = 0U;
 
-	NET_ASSERT(dst);
+	if (dst == NULL) {
+		return NULL;
+	}
 
 	if (!net_ipv6_is_ll_addr(dst) && !net_ipv6_is_addr_mcast_link(dst)) {
 		struct net_if_ipv6_prefix *prefix;
@@ -3665,7 +3672,9 @@ const struct in_addr *net_if_ipv4_select_src_addr(struct net_if *dst_iface,
 	const struct in_addr *src = NULL;
 	uint8_t best_match = 0U;
 
-	NET_ASSERT(dst);
+	if (dst == NULL) {
+		return NULL;
+	}
 
 	if (!net_ipv4_is_ll_addr(dst)) {
 
@@ -4358,7 +4367,9 @@ bool net_if_ipv4_addr_rm(struct net_if *iface, const struct in_addr *addr)
 	bool result = true;
 	int ret;
 
-	NET_ASSERT(addr);
+	if (iface == NULL || addr == NULL) {
+		return false;
+	}
 
 	net_if_lock(iface);
 
@@ -4590,8 +4601,9 @@ void net_if_ipv4_maddr_foreach(struct net_if *iface, net_if_ip_maddr_cb_t cb,
 {
 	struct net_if_ipv4 *ipv4;
 
-	NET_ASSERT(iface);
-	NET_ASSERT(cb);
+	if (iface == NULL || cb == NULL) {
+		return;
+	}
 
 	net_if_lock(iface);
 
@@ -4643,8 +4655,9 @@ out:
 
 void net_if_ipv4_maddr_leave(struct net_if *iface, struct net_if_mcast_addr *addr)
 {
-	NET_ASSERT(iface);
-	NET_ASSERT(addr);
+	if (iface == NULL || addr == NULL) {
+		return;
+	}
 
 	net_if_lock(iface);
 	addr->is_joined = false;
@@ -4653,8 +4666,9 @@ void net_if_ipv4_maddr_leave(struct net_if *iface, struct net_if_mcast_addr *add
 
 void net_if_ipv4_maddr_join(struct net_if *iface, struct net_if_mcast_addr *addr)
 {
-	NET_ASSERT(iface);
-	NET_ASSERT(addr);
+	if (iface == NULL || addr == NULL) {
+		return;
+	}
 
 	net_if_lock(iface);
 	addr->is_joined = true;
@@ -5581,7 +5595,9 @@ out:
 
 void net_if_carrier_on(struct net_if *iface)
 {
-	NET_ASSERT(iface);
+	if (iface == NULL) {
+		return;
+	}
 
 	net_if_lock(iface);
 
@@ -5594,7 +5610,9 @@ void net_if_carrier_on(struct net_if *iface)
 
 void net_if_carrier_off(struct net_if *iface)
 {
-	NET_ASSERT(iface);
+	if (iface == NULL) {
+		return;
+	}
 
 	net_if_lock(iface);
 
@@ -5607,7 +5625,9 @@ void net_if_carrier_off(struct net_if *iface)
 
 void net_if_dormant_on(struct net_if *iface)
 {
-	NET_ASSERT(iface);
+	if (iface == NULL) {
+		return;
+	}
 
 	net_if_lock(iface);
 
@@ -5620,7 +5640,9 @@ void net_if_dormant_on(struct net_if *iface)
 
 void net_if_dormant_off(struct net_if *iface)
 {
-	NET_ASSERT(iface);
+	if (iface == NULL) {
+		return;
+	}
 
 	net_if_lock(iface);
 
@@ -5636,7 +5658,9 @@ static int promisc_mode_set(struct net_if *iface, bool enable)
 {
 	enum net_l2_flags l2_flags = 0;
 
-	NET_ASSERT(iface);
+	if (iface == NULL) {
+		return -EINVAL;
+	}
 
 	l2_flags = l2_flags_get(iface);
 	if (!(l2_flags & NET_L2_PROMISC_MODE)) {
@@ -5702,7 +5726,9 @@ out:
 
 bool net_if_is_promisc(struct net_if *iface)
 {
-	NET_ASSERT(iface);
+	if (iface == NULL) {
+		return false;
+	}
 
 	return net_if_flag_is_set(iface, NET_IF_PROMISC);
 }

--- a/subsys/net/l2/ethernet/vlan.c
+++ b/subsys/net/l2/ethernet/vlan.c
@@ -136,7 +136,6 @@ static struct vlan_context *get_vlan_ctx(struct net_if *main_iface,
 		}
 
 		ctx = net_if_get_device(vctx->virtual_iface)->data;
-		NET_ASSERT(vctx != NULL);
 
 		if (any_tag) {
 			if (ctx->tag != NET_VLAN_TAG_UNSPEC) {

--- a/subsys/net/lib/trickle/trickle.c
+++ b/subsys/net/lib/trickle/trickle.c
@@ -161,7 +161,9 @@ int net_trickle_create(struct net_trickle *trickle,
 		       uint8_t Imax,
 		       uint8_t k)
 {
-	NET_ASSERT(trickle && Imax > 0 && k > 0 && !CHECK_IMIN(Imin));
+	if (!(trickle && Imax > 0 && k > 0 && !CHECK_IMIN(Imin))) {
+		return -EINVAL;
+	}
 
 	(void)memset(trickle, 0, sizeof(struct net_trickle));
 
@@ -170,7 +172,9 @@ int net_trickle_create(struct net_trickle *trickle,
 	trickle->Imax_abs = Imin << Imax;
 	trickle->k = k;
 
-	NET_ASSERT(trickle->Imax_abs);
+	if (!trickle->Imax_abs) {
+		return -EINVAL;
+	}
 
 	NET_DBG("Imin %d Imax %u k %u Imax_abs %u",
 		trickle->Imin, trickle->Imax, trickle->k,
@@ -185,7 +189,9 @@ int net_trickle_start(struct net_trickle *trickle,
 		      net_trickle_cb_t cb,
 		      void *user_data)
 {
-	NET_ASSERT(trickle && cb);
+	if (!(trickle && cb)) {
+		return -EINVAL;
+	}
 
 	trickle->cb = cb;
 	trickle->user_data = user_data;
@@ -206,7 +212,9 @@ int net_trickle_start(struct net_trickle *trickle,
 
 int net_trickle_stop(struct net_trickle *trickle)
 {
-	NET_ASSERT(trickle);
+	if (trickle == NULL) {
+		return -EINVAL;
+	}
 
 	k_work_cancel_delayable(&trickle->timer);
 
@@ -217,7 +225,9 @@ int net_trickle_stop(struct net_trickle *trickle)
 
 void net_trickle_consistency(struct net_trickle *trickle)
 {
-	NET_ASSERT(trickle);
+	if (trickle == NULL) {
+		return;
+	}
 
 	if (trickle->c < 0xFF) {
 		trickle->c++;
@@ -228,7 +238,9 @@ void net_trickle_consistency(struct net_trickle *trickle)
 
 void net_trickle_inconsistency(struct net_trickle *trickle)
 {
-	NET_ASSERT(trickle);
+	if (trickle == NULL) {
+		return;
+	}
 
 	if (trickle->I != trickle->Imin) {
 		NET_DBG("inconsistency");

--- a/subsys/net/lib/websocket/websocket.c
+++ b/subsys/net/lib/websocket/websocket.c
@@ -99,8 +99,6 @@ static int websocket_context_unref(struct websocket_context *ctx)
 
 static inline bool websocket_context_is_used(struct websocket_context *ctx)
 {
-	NET_ASSERT(ctx);
-
 	return !!atomic_get(&ctx->refcount);
 }
 


### PR DESCRIPTION
Remove assert calls from networking code where the asserts were used incorrect to try to check something at runtime. As asserts are normally disabled, the checks were pointless. Replace the asserts with proper runtime checks where applicable.