### PR TITLE
ci: compliance: Rebase on the target branch before running compliance

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -23,6 +23,21 @@ jobs:
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 0
 
+    - name: Rebase onto the target branch
+      env:
+        BASE_REF: ${{ github.base_ref }}
+      run: |
+        git config --global user.email "you@example.com"
+        git config --global user.name "Your Name"
+        git remote -v
+        # Ensure there's no merge commits in the PR
+        [[ "$(git rev-list --merges --count origin/${BASE_REF}..)" == "0" ]] || \
+        (echo "::error ::Merge commits not allowed, rebase instead";false)
+        git rebase origin/${BASE_REF}
+        git clean -f -d
+        # debug
+        git log  --pretty=oneline | head -n 10
+
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
@@ -42,19 +57,7 @@ jobs:
         pip3 install west
 
     - name: west setup
-      env:
-        BASE_REF: ${{ github.base_ref }}
       run: |
-        git config --global user.email "you@example.com"
-        git config --global user.name "Your Name"
-        git remote -v
-        # Ensure there's no merge commits in the PR
-        [[ "$(git rev-list --merges --count origin/${BASE_REF}..)" == "0" ]] || \
-        (echo "::error ::Merge commits not allowed, rebase instead";false)
-        git rebase origin/${BASE_REF}
-        git clean -f -d
-        # debug
-        git log  --pretty=oneline | head -n 10
         west init -l . || true
         west config manifest.group-filter -- +ci,-optional
         west update -o=--depth=1 -n 2>&1 1> west.update.log || west update -o=--depth=1 -n 2>&1 1> west.update2.log


### PR DESCRIPTION
Prior to running the compliance checks, we rebase the PR onto the target branch to check the compliance state as if we were merged.