### PR TITLE
dts: common: nordic: nrf54l: Add hfpll clock source

### DIFF
--- a/boards/native/nrf_bsim/nrf54l15bsim_nrf54l15_cpuapp.dts
+++ b/boards/native/nrf_bsim/nrf54l15bsim_nrf54l15_cpuapp.dts
@@ -83,6 +83,10 @@
 	};
 };
 
+&uart00 {
+	/delete-property/ clocks;
+};
+
 &uart20 {
 	status = "okay";
 	current-speed = <115200>;

--- a/dts/common/nordic/nrf54l20.dtsi
+++ b/dts/common/nordic/nrf54l20.dtsi
@@ -46,6 +46,12 @@
 			#clock-cells = <0>;
 			clock-frequency = <DT_FREQ_M(32)>;
 		};
+
+		hfpll: hfpll {
+			compatible = "fixed-clock";
+			#clock-cells = <0>;
+			clock-frequency = <DT_FREQ_M(128)>;
+		};
 	};
 
 	soc {
@@ -117,6 +123,7 @@
 				compatible = "nordic,nrf-uarte";
 				reg = <0x4d000 0x1000>;
 				interrupts = <77 NRF_DEFAULT_IRQ_PRIORITY>;
+				clocks = <&hfpll>;
 				status = "disabled";
 				endtx-stoptx-supported;
 				frame-timeout-supported;

--- a/dts/common/nordic/nrf54l_05_10_15.dtsi
+++ b/dts/common/nordic/nrf54l_05_10_15.dtsi
@@ -59,6 +59,12 @@
 			#clock-cells = <0>;
 			clock-frequency = <DT_FREQ_M(32)>;
 		};
+
+		hfpll: hfpll {
+			compatible = "fixed-clock";
+			#clock-cells = <0>;
+			clock-frequency = <DT_FREQ_M(128)>;
+		};
 	};
 
 	soc {
@@ -138,6 +144,7 @@
 				compatible = "nordic,nrf-uarte";
 				reg = <0x4a000 0x1000>;
 				interrupts = <74 NRF_DEFAULT_IRQ_PRIORITY>;
+				clocks = <&hfpll>;
 				status = "disabled";
 				endtx-stoptx-supported;
 				frame-timeout-supported;


### PR DESCRIPTION
Add 128 MHz clock source and use it for uart00. Baudrate setting must be adjusted based on uart clock source so without this change there is wrong baudrate on uart00.