### PR TITLE
hostap: fix VHT channel center segment0

### DIFF
--- a/include/zephyr/net/wifi.h
+++ b/include/zephyr/net/wifi.h
@@ -223,6 +223,27 @@ enum wifi_frequency_bands {
 /** Helper function to get user-friendly frequency band name. */
 const char *wifi_band_txt(enum wifi_frequency_bands band);
 
+/**
+ * @brief IEEE 802.11 operational frequency bandwidths (not exhaustive).
+ */
+enum wifi_frequency_bandwidths {
+	/** 20 MHz. */
+	WIFI_FREQ_BANDWIDTH_20MHZ = 1,
+	/** 40 MHz. */
+	WIFI_FREQ_BANDWIDTH_40MHZ,
+	/** 80 MHz. */
+	WIFI_FREQ_BANDWIDTH_80MHZ,
+
+	/** Number of frequency bandwidths available. */
+	__WIFI_FREQ_BANDWIDTH_AFTER_LAST,
+	/** Highest frequency bandwidth available. */
+	WIFI_FREQ_BANDWIDTH_MAX = __WIFI_FREQ_BANDWIDTH_AFTER_LAST - 1,
+	/** Invalid frequency bandwidth */
+	WIFI_FREQ_BANDWIDTH_UNKNOWN
+};
+
+const char *const wifi_bandwidth_txt(enum wifi_frequency_bandwidths bandwidth);
+
 /** Max SSID length */
 #define WIFI_SSID_MAX_LEN 32
 /** Minimum PSK length */
@@ -655,6 +676,12 @@ enum wifi_ap_config_param {
 	WIFI_AP_CONFIG_PARAM_MAX_INACTIVITY = BIT(0),
 	/** Used for AP mode configuration parameter max_num_sta */
 	WIFI_AP_CONFIG_PARAM_MAX_NUM_STA = BIT(1),
+	/** Used for AP mode configuration parameter bandwidth */
+	WIFI_AP_CONFIG_PARAM_BANDWIDTH = BIT(2),
+	/** Used for AP mode configuration parameter ht_capab */
+	WIFI_AP_CONFIG_PARAM_HT_CAPAB = BIT(3),
+	/** Used for AP mode configuration parameter vht_capab */
+	WIFI_AP_CONFIG_PARAM_VHT_CAPAB = BIT(4),
 };
 
 #ifdef __cplusplus

--- a/include/zephyr/net/wifi_mgmt.h
+++ b/include/zephyr/net/wifi_mgmt.h
@@ -566,6 +566,8 @@ struct wifi_connect_req_params {
 	 * 2: clear SSID, but keep the original length and ignore probe request for broadcast SSID
 	 */
 	uint8_t ignore_broadcast_ssid;
+	/** Parameter used for frequency band */
+	enum wifi_frequency_bandwidths bandwidth;
 };
 
 /** @brief Wi-Fi connect result codes. To be overlaid on top of \ref wifi_status
@@ -976,6 +978,7 @@ struct wifi_channel_info {
 
 /** @cond INTERNAL_HIDDEN */
 #define WIFI_AP_STA_MAX_INACTIVITY (LONG_MAX - 1)
+#define WIFI_AP_IEEE_80211_CAPAB_MAX_LEN 64
 /** @endcond */
 
 /** @brief Wi-Fi AP configuration parameter */
@@ -986,6 +989,14 @@ struct wifi_ap_config_params {
 	uint32_t max_inactivity;
 	/** Parameter used for setting maximum number of stations */
 	uint32_t max_num_sta;
+	/** Parameter used for frequency band */
+	enum wifi_frequency_bandwidths bandwidth;
+#if defined(CONFIG_WIFI_NM_HOSTAPD_AP)
+	/** Parameter used for setting HT capabilities */
+	char ht_capab[WIFI_AP_IEEE_80211_CAPAB_MAX_LEN + 1];
+	/** Parameter used for setting VHT capabilities */
+	char vht_capab[WIFI_AP_IEEE_80211_CAPAB_MAX_LEN + 1];
+#endif
 };
 
 #ifdef CONFIG_WIFI_NM_WPA_SUPPLICANT_DPP

--- a/modules/hostap/src/supp_api.c
+++ b/modules/hostap/src/supp_api.c
@@ -2075,6 +2075,72 @@ out:
 	return ret;
 }
 
+static int hapd_config_chan_center_seg0(struct wifi_connect_req_params *params)
+{
+	int ret = 0;
+	uint8_t center_freq_seg0_idx = 0;
+	uint8_t oper_chwidth = CHANWIDTH_USE_HT;
+	const uint8_t *center_freq = NULL;
+	static const uint8_t center_freq_40MHz[] = {38,  46,  54,  62,  102, 110,
+						    118, 126, 134, 142, 151, 159};
+	static const uint8_t center_freq_80MHz[] = {42, 58, 106, 122, 138, 155};
+	uint8_t index, index_max, chan_idx, ch_offset = 0;
+
+	/* Unless ACS is being used, both "channel" and "vht_oper_centr_freq_seg0_idx"
+	 * parameters must be set.
+	 */
+	switch (params->bandwidth) {
+	case WIFI_FREQ_BANDWIDTH_20MHZ:
+		oper_chwidth = CHANWIDTH_USE_HT;
+		center_freq_seg0_idx = params->channel;
+		break;
+	case WIFI_FREQ_BANDWIDTH_40MHZ:
+		oper_chwidth = CHANWIDTH_USE_HT;
+		center_freq = center_freq_40MHz;
+		index_max = ARRAY_SIZE(center_freq_40MHz);
+		ch_offset = 2;
+		break;
+	case WIFI_FREQ_BANDWIDTH_80MHZ:
+		oper_chwidth = CHANWIDTH_80MHZ;
+		center_freq = center_freq_80MHz;
+		index_max = ARRAY_SIZE(center_freq_80MHz);
+		ch_offset = 6;
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	if (params->bandwidth != WIFI_FREQ_BANDWIDTH_20MHZ) {
+		chan_idx = params->channel;
+		for (index = 0; index < index_max; index++) {
+			if ((chan_idx >= (center_freq[index] - ch_offset)) &&
+			    (chan_idx <= (center_freq[index] + ch_offset))) {
+				center_freq_seg0_idx = center_freq[index];
+				break;
+			}
+		}
+	}
+
+	if (!hostapd_cli_cmd_v("set vht_oper_chwidth %d", oper_chwidth)) {
+		goto out;
+	}
+	if (!hostapd_cli_cmd_v("set vht_oper_centr_freq_seg0_idx %d", center_freq_seg0_idx)) {
+		goto out;
+	}
+#ifdef CONFIG_WIFI_NM_WPA_SUPPLICANT_11AX
+	if (!hostapd_cli_cmd_v("set he_oper_chwidth %d", oper_chwidth)) {
+		goto out;
+	}
+	if (!hostapd_cli_cmd_v("set he_oper_centr_freq_seg0_idx %d", center_freq_seg0_idx)) {
+		goto out;
+	}
+#endif
+
+	return ret;
+out:
+	return -EINVAL;
+}
+
 int hapd_config_network(struct hostapd_iface *iface,
 			struct wifi_connect_req_params *params)
 {
@@ -2108,6 +2174,11 @@ int hapd_config_network(struct hostapd_iface *iface,
 	}
 
 	if (!hostapd_cli_cmd_v("set channel %d", params->channel)) {
+		goto out;
+	}
+
+	ret = hapd_config_chan_center_seg0(params);
+	if (ret) {
 		goto out;
 	}
 
@@ -2241,53 +2312,72 @@ out:
 	return -1;
 }
 
+static int set_ap_config_params(const struct device *dev, struct wifi_ap_config_params *params)
+{
+	const struct wifi_mgmt_ops *const wifi_mgmt_api = get_wifi_mgmt_api(dev);
+
+	if (wifi_mgmt_api == NULL || wifi_mgmt_api->ap_config_params == NULL) {
+		return -ENOTSUP;
+	}
+
+	return wifi_mgmt_api->ap_config_params(dev, params);
+}
+
 int supplicant_ap_config_params(const struct device *dev, struct wifi_ap_config_params *params)
 {
 	struct hostapd_iface *iface;
-	const struct wifi_mgmt_ops *const wifi_mgmt_api = get_wifi_mgmt_api(dev);
 	int ret = 0;
 
-	if (params->type & WIFI_AP_CONFIG_PARAM_MAX_INACTIVITY) {
-		if (!wifi_mgmt_api || !wifi_mgmt_api->ap_config_params) {
-			wpa_printf(MSG_ERROR, "ap_config_params not supported");
-			return -ENOTSUP;
-		}
-
-		ret = wifi_mgmt_api->ap_config_params(dev, params);
-		if (ret) {
-			wpa_printf(MSG_ERROR,
-				   "Failed to set maximum inactivity duration for stations");
-		} else {
-			wpa_printf(MSG_INFO, "Set maximum inactivity duration for stations: %d (s)",
-				   params->max_inactivity);
-		}
+	ret = set_ap_config_params(dev, params);
+	if (ret && (ret != -ENOTSUP)) {
+		wpa_printf(MSG_ERROR, "Failed to set ap config params");
+		return -EINVAL;
 	}
+
+	k_mutex_lock(&wpa_supplicant_mutex, K_FOREVER);
+
+	iface = get_hostapd_handle(dev);
+	if (iface == NULL) {
+		ret = -ENOENT;
+		wpa_printf(MSG_ERROR, "Interface %s not found", dev->name);
+		goto out;
+	}
+
+	if (iface->state > HAPD_IFACE_DISABLED) {
+		ret = -EBUSY;
+		wpa_printf(MSG_ERROR, "Interface %s is not in disable state", dev->name);
+		goto out;
+	}
+
 	if (params->type & WIFI_AP_CONFIG_PARAM_MAX_NUM_STA) {
-		k_mutex_lock(&wpa_supplicant_mutex, K_FOREVER);
-
-		iface = get_hostapd_handle(dev);
-		if (!iface) {
-			ret = -ENOENT;
-			wpa_printf(MSG_ERROR, "Interface %s not found", dev->name);
-			goto out;
-		}
-
-		if (iface->state > HAPD_IFACE_DISABLED) {
-			ret = -EBUSY;
-			wpa_printf(MSG_ERROR, "Interface %s is not in disable state", dev->name);
-			goto out;
-		}
-
 		if (!hostapd_cli_cmd_v("set max_num_sta %d", params->max_num_sta)) {
 			ret = -EINVAL;
 			wpa_printf(MSG_ERROR, "Failed to set maximum number of stations");
 			goto out;
 		}
 		wpa_printf(MSG_INFO, "Set maximum number of stations: %d", params->max_num_sta);
+	}
+
+	if (params->type & WIFI_AP_CONFIG_PARAM_HT_CAPAB) {
+		if (!hostapd_cli_cmd_v("set ht_capab %s", params->ht_capab)) {
+			ret = -EINVAL;
+			wpa_printf(MSG_ERROR, "Failed to set HT capabilities");
+			goto out;
+		}
+		wpa_printf(MSG_INFO, "Set HT capabilities: %s", params->ht_capab);
+	}
+
+	if (params->type & WIFI_AP_CONFIG_PARAM_VHT_CAPAB) {
+		if (!hostapd_cli_cmd_v("set vht_capab %s", params->vht_capab)) {
+			ret = -EINVAL;
+			wpa_printf(MSG_ERROR, "Failed to set VHT capabilities");
+			goto out;
+		}
+		wpa_printf(MSG_INFO, "Set VHT capabilities: %s", params->vht_capab);
+	}
 
 out:
 		k_mutex_unlock(&wpa_supplicant_mutex);
-	}
 
 	return ret;
 }
@@ -2467,6 +2557,20 @@ int supplicant_ap_wps_config(const struct device *dev, struct wifi_wps_config_pa
 }
 #endif
 
+static int set_ap_bandwidth(const struct device *dev, enum wifi_frequency_bandwidths bandwidth)
+{
+	const struct wifi_mgmt_ops *const wifi_mgmt_api = get_wifi_mgmt_api(dev);
+	struct wifi_ap_config_params params = {0};
+
+	if (wifi_mgmt_api == NULL || wifi_mgmt_api->ap_config_params == NULL) {
+		return -ENOTSUP;
+	}
+
+	params.bandwidth = bandwidth;
+	params.type = WIFI_AP_CONFIG_PARAM_BANDWIDTH;
+	return wifi_mgmt_api->ap_config_params(dev, &params);
+}
+
 int supplicant_ap_enable(const struct device *dev,
 			 struct wifi_connect_req_params *params)
 {
@@ -2484,6 +2588,12 @@ int supplicant_ap_enable(const struct device *dev,
 			   "Interface %s is down, dropping connect",
 			   dev->name);
 		return -1;
+	}
+
+	ret = set_ap_bandwidth(dev, params->bandwidth);
+	if (ret && (ret != -ENOTSUP)) {
+		wpa_printf(MSG_ERROR, "Failed to set ap bandwidth");
+		return -EINVAL;
 	}
 
 	k_mutex_lock(&wpa_supplicant_mutex, K_FOREVER);

--- a/subsys/net/l2/wifi/wifi_mgmt.c
+++ b/subsys/net/l2/wifi/wifi_mgmt.c
@@ -129,6 +129,21 @@ const char *wifi_band_txt(enum wifi_frequency_bands band)
 	}
 }
 
+const char *const wifi_bandwidth_txt(enum wifi_frequency_bandwidths bandwidth)
+{
+	switch (bandwidth) {
+	case WIFI_FREQ_BANDWIDTH_20MHZ:
+		return "20 MHz";
+	case WIFI_FREQ_BANDWIDTH_40MHZ:
+		return "40 MHz";
+	case WIFI_FREQ_BANDWIDTH_80MHZ:
+		return "80 MHz";
+	case WIFI_FREQ_BANDWIDTH_UNKNOWN:
+	default:
+		return "UNKNOWN";
+	}
+}
+
 const char *wifi_state_txt(enum wifi_iface_state state)
 {
 	switch (state) {


### PR DESCRIPTION
hostap: fix VHT channel center segment0

1) Unless ACS is being used, both "channel" and
    "vht_oper_centr_freq_seg0_idx" parameters must be set.
    Fixed "channel center segment 0" not being set in VHT Operation IE.
2) Set HT capabilities and VHT capabilities via the wifi ap config command.
3) Set AP bandwidth to wifi driver via the wifi_mgmt_api->ap_config_params.