### PR TITLE
drivers: intel_adsp: Refactor Power Management Initialization for DMIC, SSP, and GPDMA Drivers

### DIFF
--- a/drivers/dai/intel/dmic/dmic.c
+++ b/drivers/dai/intel/dmic/dmic.c
@@ -895,13 +895,8 @@ static int dai_dmic_initialize_device(const struct device *dev)
 		dai_dmic_irq_handler,
 		DEVICE_DT_INST_GET(0),
 		0);
-	if (pm_device_on_power_domain(dev)) {
-		pm_device_init_off(dev);
-	} else {
-		pm_device_init_suspended(dev);
-	}
 
-	return pm_device_runtime_enable(dev);
+	return pm_device_driver_init(dev, dmic_pm_action);
 };
 
 

--- a/drivers/dai/intel/ssp/ssp.c
+++ b/drivers/dai/intel/ssp/ssp.c
@@ -2663,14 +2663,7 @@ static int dai_intel_ssp_init_device(const struct device *dev)
 static int ssp_init(const struct device *dev)
 {
 	dai_intel_ssp_init_device(dev);
-
-	if (pm_device_on_power_domain(dev)) {
-		pm_device_init_off(dev);
-	} else {
-		pm_device_init_suspended(dev);
-	}
-
-	return pm_device_runtime_enable(dev);
+	return pm_device_driver_init(dev, ssp_pm_action);
 }
 
 static int dai_ssp_dma_control_set(const struct device *dev,

--- a/drivers/dma/dma_intel_adsp_gpdma.c
+++ b/drivers/dma/dma_intel_adsp_gpdma.c
@@ -440,38 +440,15 @@ static inline void ace_gpdma_intc_unmask(void)
 static inline void ace_gpdma_intc_unmask(void) {}
 #endif
 
-
-int intel_adsp_gpdma_init(const struct device *dev)
-{
-	struct dw_dma_dev_data *const dev_data = dev->data;
-
-	/* Setup context and atomics for channels */
-	dev_data->dma_ctx.magic = DMA_MAGIC;
-	dev_data->dma_ctx.dma_channels = DW_MAX_CHAN;
-	dev_data->dma_ctx.atomic = dev_data->channels_atomic;
-
-	ace_gpdma_intc_unmask();
-
-#if CONFIG_PM_DEVICE && CONFIG_SOC_SERIES_INTEL_ADSP_ACE
-	if (pm_device_on_power_domain(dev)) {
-		pm_device_init_off(dev);
-	} else {
-		pm_device_init_suspended(dev);
-	}
-
-	return 0;
-#else
-	return intel_adsp_gpdma_power_on(dev);
-#endif
-}
-#ifdef CONFIG_PM_DEVICE
 static int gpdma_pm_action(const struct device *dev, enum pm_device_action action)
 {
 	switch (action) {
 	case PM_DEVICE_ACTION_RESUME:
 		return intel_adsp_gpdma_power_on(dev);
 	case PM_DEVICE_ACTION_SUSPEND:
+#ifdef CONFIG_PM_DEVICE
 		return intel_adsp_gpdma_power_off(dev);
+#endif
 	/* ON and OFF actions are used only by the power domain to change internal power status of
 	 * the device. OFF state mean that device and its power domain are disabled, SUSPEND mean
 	 * that device is power off but domain is already power on.
@@ -485,7 +462,19 @@ static int gpdma_pm_action(const struct device *dev, enum pm_device_action actio
 
 	return 0;
 }
-#endif
+
+int intel_adsp_gpdma_init(const struct device *dev)
+{
+	struct dw_dma_dev_data *const dev_data = dev->data;
+
+	/* Setup context and atomics for channels */
+	dev_data->dma_ctx.magic = DMA_MAGIC;
+	dev_data->dma_ctx.dma_channels = DW_MAX_CHAN;
+	dev_data->dma_ctx.atomic = dev_data->channels_atomic;
+
+	ace_gpdma_intc_unmask();
+	return pm_device_driver_init(dev, gpdma_pm_action);
+}
 
 static const struct dma_driver_api intel_adsp_gpdma_driver_api = {
 	.config = intel_adsp_gpdma_config,

--- a/dts/xtensa/intel/intel_adsp_ace15_mtpm.dtsi
+++ b/dts/xtensa/intel/intel_adsp_ace15_mtpm.dtsi
@@ -292,12 +292,13 @@
 			dmas = <&lpgpdma0 2
 					&lpgpdma0 3>;
 			dma-names = "tx", "rx";
-			power-domains = <&io0_domain>;
 			ssp-index = <0>;
 			status = "okay";
 
 			ssp00: ssp@0 {
 				compatible = "intel,ssp-dai";
+				power-domains = <&io0_domain>;
+				zephyr,pm-device-runtime-auto;
 				status = "okay";
 				reg = <0x0>;
 			};
@@ -314,12 +315,13 @@
 			dmas = <&lpgpdma0 4
 					&lpgpdma0 5>;
 			dma-names = "tx", "rx";
-			power-domains = <&io0_domain>;
 			ssp-index = <1>;
 			status = "okay";
 
 			ssp10: ssp@10 {
 				compatible = "intel,ssp-dai";
+				power-domains = <&io0_domain>;
+				zephyr,pm-device-runtime-auto;
 				status = "okay";
 				reg = <0x10>;
 			};
@@ -336,12 +338,13 @@
 			dmas = <&lpgpdma0 6
 					&lpgpdma0 7>;
 			dma-names = "tx", "rx";
-			power-domains = <&io0_domain>;
 			ssp-index = <2>;
 			status = "okay";
 
 			ssp20: ssp@20 {
 				compatible = "intel,ssp-dai";
+				power-domains = <&io0_domain>;
+				zephyr,pm-device-runtime-auto;
 				status = "okay";
 				reg = <0x20>;
 			};

--- a/dts/xtensa/intel/intel_adsp_ace15_mtpm.dtsi
+++ b/dts/xtensa/intel/intel_adsp_ace15_mtpm.dtsi
@@ -156,6 +156,7 @@
 			interrupts = <0x08 0 0>;
 			interrupt-parent = <&ace_intc>;
 			power-domains = <&hub_ulp_domain>;
+			zephyr,pm-device-runtime-auto;
 		};
 
 		dmic1: dmic1@10000 {
@@ -166,6 +167,7 @@
 			interrupts = <0x09 0 0>;
 			interrupt-parent = <&ace_intc>;
 			power-domains = <&hub_ulp_domain>;
+			zephyr,pm-device-runtime-auto;
 		};
 
 		/*

--- a/dts/xtensa/intel/intel_adsp_ace20_lnl.dtsi
+++ b/dts/xtensa/intel/intel_adsp_ace20_lnl.dtsi
@@ -180,6 +180,7 @@
 			fifo = <0x0008>;
 			interrupts = <0x08 0 0>;
 			interrupt-parent = <&ace_intc>;
+			zephyr,pm-device-runtime-auto;
 		};
 
 		dmic1: dai-dmic1@10100 {
@@ -189,6 +190,7 @@
 			fifo = <0x0108>;
 			interrupts = <0x08 0 0>;
 			interrupt-parent = <&ace_intc>;
+			zephyr,pm-device-runtime-auto;
 		};
 
 		dmicvss: dmicvss@16000 {

--- a/dts/xtensa/intel/intel_adsp_ace20_lnl.dtsi
+++ b/dts/xtensa/intel/intel_adsp_ace20_lnl.dtsi
@@ -222,12 +222,13 @@
 			dmas = <&hda_link_out 1
 				&hda_link_in 1>;
 			dma-names = "tx", "rx";
-			power-domains = <&io0_domain>;
 			ssp-index = <0>;
 			status = "okay";
 
 			ssp00: ssp@0 {
 				compatible = "intel,ssp-dai";
+				power-domains = <&io0_domain>;
+				zephyr,pm-device-runtime-auto;
 				status = "okay";
 				reg = <0x0>;
 			};
@@ -245,12 +246,13 @@
 			dmas = <&hda_link_out 2
 				&hda_link_in 2>;
 			dma-names = "tx", "rx";
-			power-domains = <&io0_domain>;
 			ssp-index = <1>;
 			status = "okay";
 
 			ssp10: ssp@10 {
 				compatible = "intel,ssp-dai";
+				power-domains = <&io0_domain>;
+				zephyr,pm-device-runtime-auto;
 				status = "okay";
 				reg = <0x10>;
 			};
@@ -268,12 +270,13 @@
 			dmas = <&hda_link_out 3
 				&hda_link_in 3>;
 			dma-names = "tx", "rx";
-			power-domains = <&io0_domain>;
 			ssp-index = <2>;
 			status = "okay";
 
 			ssp20: ssp@20 {
 				compatible = "intel,ssp-dai";
+				power-domains = <&io0_domain>;
+				zephyr,pm-device-runtime-auto;
 				status = "okay";
 				reg = <0x20>;
 			};

--- a/dts/xtensa/intel/intel_adsp_ace30.dtsi
+++ b/dts/xtensa/intel/intel_adsp_ace30.dtsi
@@ -170,6 +170,7 @@
 			interrupts = <0x08 0 0>;
 			interrupt-parent = <&ace_intc>;
 			power-domains = <&hub_ulp_domain>;
+			zephyr,pm-device-runtime-auto;
 		};
 
 		dmic1: dai-dmic1@10100 {
@@ -180,6 +181,7 @@
 			interrupts = <0x08 0 0>;
 			interrupt-parent = <&ace_intc>;
 			power-domains = <&hub_ulp_domain>;
+			zephyr,pm-device-runtime-auto;
 		};
 
 		dmicvss: dmicvss@16000 {

--- a/dts/xtensa/intel/intel_adsp_ace30.dtsi
+++ b/dts/xtensa/intel/intel_adsp_ace30.dtsi
@@ -214,53 +214,68 @@
 				&hda_link_in 1>;
 			dma-names = "tx", "rx";
 			ssp-index = <0>;
-			power-domains = <&io0_domain>;
 			status = "okay";
 
 			ssp00: ssp@0 {
 				compatible = "intel,ssp-dai";
+				power-domains = <&io0_domain>;
+				zephyr,pm-device-runtime-auto;
 				reg = <0x0>;
 				status = "okay";
 			};
 
 			ssp01: ssp@1 {
 				compatible = "intel,ssp-dai";
+				power-domains = <&io0_domain>;
+				zephyr,pm-device-runtime-auto;
 				reg = <0x1>;
 				status = "okay";
 			};
 
 			ssp02: ssp@2 {
 				compatible = "intel,ssp-dai";
+				power-domains = <&io0_domain>;
+				zephyr,pm-device-runtime-auto;
 				reg = <0x2>;
 				status = "okay";
 			};
 
 			ssp03: ssp@3 {
 				compatible = "intel,ssp-dai";
+				power-domains = <&io0_domain>;
+				zephyr,pm-device-runtime-auto;
 				reg = <0x3>;
 				status = "okay";
 			};
 
 			ssp04: ssp@4 {
 				compatible = "intel,ssp-dai";
+				power-domains = <&io0_domain>;
+				zephyr,pm-device-runtime-auto;
 				reg = <0x4>;
 				status = "okay";
 			};
 
 			ssp05: ssp@5 {
 				compatible = "intel,ssp-dai";
+				power-domains = <&io0_domain>;
+				zephyr,pm-device-runtime-auto;
 				reg = <0x5>;
 				status = "okay";
 			};
 
 			ssp06: ssp@6 {
 				compatible = "intel,ssp-dai";
+				power-domains = <&io0_domain>;
+				zephyr,pm-device-runtime-auto;
 				reg = <0x6>;
 				status = "okay";
 			};
 
 			ssp07: ssp@7 {
 				compatible = "intel,ssp-dai";
+				power-domains = <&io0_domain>;
+				zephyr,pm-device-runtime-auto;
 				reg = <0x7>;
 				status = "okay";
 			};
@@ -279,53 +294,68 @@
 				&hda_link_in 2>;
 			dma-names = "tx", "rx";
 			ssp-index = <1>;
-			power-domains = <&io0_domain>;
 			status = "okay";
 
 			ssp10: ssp@10 {
 				compatible = "intel,ssp-dai";
+				power-domains = <&io0_domain>;
+				zephyr,pm-device-runtime-auto;
 				reg = <0x10>;
 				status = "okay";
 			};
 
 			ssp11: ssp@11 {
 				compatible = "intel,ssp-dai";
+				power-domains = <&io0_domain>;
+				zephyr,pm-device-runtime-auto;
 				reg = <0x11>;
 				status = "okay";
 			};
 
 			ssp12: ssp@12 {
 				compatible = "intel,ssp-dai";
+				power-domains = <&io0_domain>;
+				zephyr,pm-device-runtime-auto;
 				reg = <0x12>;
 				status = "okay";
 			};
 
 			ssp13: ssp@13 {
 				compatible = "intel,ssp-dai";
+				power-domains = <&io0_domain>;
+				zephyr,pm-device-runtime-auto;
 				reg = <0x13>;
 				status = "okay";
 			};
 
 			ssp14: ssp@14 {
 				compatible = "intel,ssp-dai";
+				power-domains = <&io0_domain>;
+				zephyr,pm-device-runtime-auto;
 				reg = <0x14>;
 				status = "okay";
 			};
 
 			ssp15: ssp@15 {
 				compatible = "intel,ssp-dai";
+				power-domains = <&io0_domain>;
+				zephyr,pm-device-runtime-auto;
 				reg = <0x15>;
 				status = "okay";
 			};
 
 			ssp16: ssp@16 {
 				compatible = "intel,ssp-dai";
+				power-domains = <&io0_domain>;
+				zephyr,pm-device-runtime-auto;
 				reg = <0x16>;
 				status = "okay";
 			};
 
 			ssp17: ssp@17 {
 				compatible = "intel,ssp-dai";
+				power-domains = <&io0_domain>;
+				zephyr,pm-device-runtime-auto;
 				reg = <0x17>;
 				status = "okay";
 			};
@@ -344,53 +374,68 @@
 				&hda_link_in 3>;
 			dma-names = "tx", "rx";
 			ssp-index = <2>;
-			power-domains = <&io0_domain>;
 			status = "okay";
 
 			ssp20: ssp@20 {
 				compatible = "intel,ssp-dai";
+				power-domains = <&io0_domain>;
+				zephyr,pm-device-runtime-auto;
 				reg = <0x20>;
 				status = "okay";
 			};
 
 			ssp21: ssp@21 {
 				compatible = "intel,ssp-dai";
+				power-domains = <&io0_domain>;
+				zephyr,pm-device-runtime-auto;
 				reg = <0x21>;
 				status = "okay";
 			};
 
 			ssp22: ssp@22 {
 				compatible = "intel,ssp-dai";
+				power-domains = <&io0_domain>;
+				zephyr,pm-device-runtime-auto;
 				reg = <0x22>;
 				status = "okay";
 			};
 
 			ssp23: ssp@23 {
 				compatible = "intel,ssp-dai";
+				power-domains = <&io0_domain>;
+				zephyr,pm-device-runtime-auto;
 				reg = <0x23>;
 				status = "okay";
 			};
 
 			ssp24: ssp@24 {
 				compatible = "intel,ssp-dai";
+				power-domains = <&io0_domain>;
+				zephyr,pm-device-runtime-auto;
 				reg = <0x24>;
 				status = "okay";
 			};
 
 			ssp25: ssp@25 {
 				compatible = "intel,ssp-dai";
+				power-domains = <&io0_domain>;
+				zephyr,pm-device-runtime-auto;
 				reg = <0x25>;
 				status = "okay";
 			};
 
 			ssp26: ssp@26 {
 				compatible = "intel,ssp-dai";
+				power-domains = <&io0_domain>;
+				zephyr,pm-device-runtime-auto;
 				reg = <0x26>;
 				status = "okay";
 			};
 
 			ssp27: ssp@27 {
 				compatible = "intel,ssp-dai";
+				power-domains = <&io0_domain>;
+				zephyr,pm-device-runtime-auto;
 				reg = <0x27>;
 				status = "okay";
 			};

--- a/dts/xtensa/intel/intel_adsp_ace30_ptl.dtsi
+++ b/dts/xtensa/intel/intel_adsp_ace30_ptl.dtsi
@@ -219,53 +219,68 @@
 				&hda_link_in 1>;
 			dma-names = "tx", "rx";
 			ssp-index = <0>;
-			power-domains = <&io0_domain>;
 			status = "okay";
 
 			ssp00: ssp@0 {
 				compatible = "intel,ssp-dai";
+				power-domains = <&io0_domain>;
+				zephyr,pm-device-runtime-auto;
 				reg = <0x0>;
 				status = "okay";
 			};
 
 			ssp01: ssp@1 {
 				compatible = "intel,ssp-dai";
+				power-domains = <&io0_domain>;
+				zephyr,pm-device-runtime-auto;
 				reg = <0x1>;
 				status = "okay";
 			};
 
 			ssp02: ssp@2 {
 				compatible = "intel,ssp-dai";
+				power-domains = <&io0_domain>;
+				zephyr,pm-device-runtime-auto;
 				reg = <0x2>;
 				status = "okay";
 			};
 
 			ssp03: ssp@3 {
 				compatible = "intel,ssp-dai";
+				power-domains = <&io0_domain>;
+				zephyr,pm-device-runtime-auto;
 				reg = <0x3>;
 				status = "okay";
 			};
 
 			ssp04: ssp@4 {
 				compatible = "intel,ssp-dai";
+				power-domains = <&io0_domain>;
+				zephyr,pm-device-runtime-auto;
 				reg = <0x4>;
 				status = "okay";
 			};
 
 			ssp05: ssp@5 {
 				compatible = "intel,ssp-dai";
+				power-domains = <&io0_domain>;
+				zephyr,pm-device-runtime-auto;
 				reg = <0x5>;
 				status = "okay";
 			};
 
 			ssp06: ssp@6 {
 				compatible = "intel,ssp-dai";
+				power-domains = <&io0_domain>;
+				zephyr,pm-device-runtime-auto;
 				reg = <0x6>;
 				status = "okay";
 			};
 
 			ssp07: ssp@7 {
 				compatible = "intel,ssp-dai";
+				power-domains = <&io0_domain>;
+				zephyr,pm-device-runtime-auto;
 				reg = <0x7>;
 				status = "okay";
 			};
@@ -284,53 +299,68 @@
 				&hda_link_in 2>;
 			dma-names = "tx", "rx";
 			ssp-index = <1>;
-			power-domains = <&io0_domain>;
 			status = "okay";
 
 			ssp10: ssp@10 {
 				compatible = "intel,ssp-dai";
+				power-domains = <&io0_domain>;
+				zephyr,pm-device-runtime-auto;
 				reg = <0x10>;
 				status = "okay";
 			};
 
 			ssp11: ssp@11 {
 				compatible = "intel,ssp-dai";
+				power-domains = <&io0_domain>;
+				zephyr,pm-device-runtime-auto;
 				reg = <0x11>;
 				status = "okay";
 			};
 
 			ssp12: ssp@12 {
 				compatible = "intel,ssp-dai";
+				power-domains = <&io0_domain>;
+				zephyr,pm-device-runtime-auto;
 				reg = <0x12>;
 				status = "okay";
 			};
 
 			ssp13: ssp@13 {
 				compatible = "intel,ssp-dai";
+				power-domains = <&io0_domain>;
+				zephyr,pm-device-runtime-auto;
 				reg = <0x13>;
 				status = "okay";
 			};
 
 			ssp14: ssp@14 {
 				compatible = "intel,ssp-dai";
+				power-domains = <&io0_domain>;
+				zephyr,pm-device-runtime-auto;
 				reg = <0x14>;
 				status = "okay";
 			};
 
 			ssp15: ssp@15 {
 				compatible = "intel,ssp-dai";
+				power-domains = <&io0_domain>;
+				zephyr,pm-device-runtime-auto;
 				reg = <0x15>;
 				status = "okay";
 			};
 
 			ssp16: ssp@16 {
 				compatible = "intel,ssp-dai";
+				power-domains = <&io0_domain>;
+				zephyr,pm-device-runtime-auto;
 				reg = <0x16>;
 				status = "okay";
 			};
 
 			ssp17: ssp@17 {
 				compatible = "intel,ssp-dai";
+				power-domains = <&io0_domain>;
+				zephyr,pm-device-runtime-auto;
 				reg = <0x17>;
 				status = "okay";
 			};
@@ -349,53 +379,68 @@
 				&hda_link_in 3>;
 			dma-names = "tx", "rx";
 			ssp-index = <2>;
-			power-domains = <&io0_domain>;
 			status = "okay";
 
 			ssp20: ssp@20 {
 				compatible = "intel,ssp-dai";
+				power-domains = <&io0_domain>;
+				zephyr,pm-device-runtime-auto;
 				reg = <0x20>;
 				status = "okay";
 			};
 
 			ssp21: ssp@21 {
 				compatible = "intel,ssp-dai";
+				power-domains = <&io0_domain>;
+				zephyr,pm-device-runtime-auto;
 				reg = <0x21>;
 				status = "okay";
 			};
 
 			ssp22: ssp@22 {
 				compatible = "intel,ssp-dai";
+				power-domains = <&io0_domain>;
+				zephyr,pm-device-runtime-auto;
 				reg = <0x22>;
 				status = "okay";
 			};
 
 			ssp23: ssp@23 {
 				compatible = "intel,ssp-dai";
+				power-domains = <&io0_domain>;
+				zephyr,pm-device-runtime-auto;
 				reg = <0x23>;
 				status = "okay";
 			};
 
 			ssp24: ssp@24 {
 				compatible = "intel,ssp-dai";
+				power-domains = <&io0_domain>;
+				zephyr,pm-device-runtime-auto;
 				reg = <0x24>;
 				status = "okay";
 			};
 
 			ssp25: ssp@25 {
 				compatible = "intel,ssp-dai";
+				power-domains = <&io0_domain>;
+				zephyr,pm-device-runtime-auto;
 				reg = <0x25>;
 				status = "okay";
 			};
 
 			ssp26: ssp@26 {
 				compatible = "intel,ssp-dai";
+				power-domains = <&io0_domain>;
+				zephyr,pm-device-runtime-auto;
 				reg = <0x26>;
 				status = "okay";
 			};
 
 			ssp27: ssp@27 {
 				compatible = "intel,ssp-dai";
+				power-domains = <&io0_domain>;
+				zephyr,pm-device-runtime-auto;
 				reg = <0x27>;
 				status = "okay";
 			};

--- a/dts/xtensa/intel/intel_adsp_ace30_ptl.dtsi
+++ b/dts/xtensa/intel/intel_adsp_ace30_ptl.dtsi
@@ -175,6 +175,7 @@
 			interrupts = <0x08 0 0>;
 			interrupt-parent = <&ace_intc>;
 			power-domains = <&hub_ulp_domain>;
+			zephyr,pm-device-runtime-auto;
 		};
 
 		dmic1: dai-dmic1@10100 {
@@ -185,6 +186,7 @@
 			interrupts = <0x08 0 0>;
 			interrupt-parent = <&ace_intc>;
 			power-domains = <&hub_ulp_domain>;
+			zephyr,pm-device-runtime-auto;
 		};
 
 		dmicvss: dmicvss@16000 {


### PR DESCRIPTION
This pull request refactors the power management initialization for the DMIC, SSP, and GPDMA drivers across ACE15, ACE20, and ACE30 generations.

The current implementation of power management initialization for these drivers does not fully comply with the recommended practices outlined in the documentation. This refactor addresses these issues, ensuring that the drivers are initialized correctly and consistently. The functionality of the power management state remains unchanged, ensuring consistent behavior across all three generations.

Changes:
1. DMIC Driver:
    - Replaced the conditional initialization of power management state with a call to pm_device_driver_init in the dai_dmic_initialize_device function.
    - Added the zephyr,pm-device-runtime-auto property to the DMIC nodes in the device tree files for ACE15, ACE20, and ACE30.
2. SSP Driver:
    - Replaced the conditional initialization of power management state with a call to pm_device_driver_init in the ssp_init function.
    - Added the zephyr,pm-device-runtime-auto property to the SSP nodes in the device tree files for ACE15, ACE20, and ACE30.
    - Moved the power domain assignment for the SSP device in the device tree. The previous configuration resulted in the device not being under any power domain and being initialized as always ON.
3. GPDMA Driver:
    - Replaced the conditional initialization of power management state with a call to pm_device_driver_init in the intel_adsp_gpdma_init function.
    - Ensured that the GPDMA driver is initialized with the appropriate power management state and that runtime power management is automatically enabled based on the device tree configuration.