### PR TITLE
doc: doxygen: add doxygen aliases to allow description of driver ops (backend) API in a common way

### DIFF
--- a/doc/_doxygen/doxygen-awesome-zephyr.css
+++ b/doc/_doxygen/doxygen-awesome-zephyr.css
@@ -109,3 +109,23 @@ dl.section dd, dl.bug dd, dl.deprecated dd {
     padding-top: 25px;
     text-align: center;
 }
+
+/* Driver ops "badges" */
+.op-badge {
+    font-size: 12px;
+    font-weight: bold;
+    padding: 2px 4px ;
+    border-radius: 6px;
+    vertical-align: top;
+    border: 1px solid rgba(0,0,0,0.1);
+}
+
+.op-req {
+    background-color: #e74c3c;
+    color: white;
+}
+
+.op-opt {
+    background-color: #3498db;
+    color: white;
+}

--- a/doc/zephyr.doxyfile.in
+++ b/doc/zephyr.doxyfile.in
@@ -302,6 +302,23 @@ ALIASES                = "kconfig{1}=\c \1" \
                          "atomic_api=As for all atomic APIs, includes a full/sequentially-consistent memory barrier (where applicable)." \
                          "supervisor=\qualifier supervisor"
 
+# Aliases to help structure the API documentation for "driver ops"
+ALIASES               += "def_driverbackendgroup{2}=\defgroup \2_backend \1 Driver Backend API ^^\
+                                                    \brief This group contains the API type definitions, callback signatures, and other helpers required to implement a \1 driver. ^^\
+                                                    \ingroup \2"
+ALIASES               += "driver_ops{1}=\brief \htmlonly <span class=\"mlabel\">Driver Operations</span> \endhtmlonly \1 driver operations \
+                                        \details This is the driver API structure any \1 driver needs to define. \
+                                                 It contains function pointers to the operations the driver implements, \
+                                                 as well as any other driver-specific constant data. ^^\
+                                                 ^^ \
+                                                 Members marked with \driver_ops_mandatory MUST be set by the driver, \
+                                                 whereas those marked with \driver_ops_optional are optional. \
+                                        \see DEVICE_DT_INST_DEFINE() \
+                                        \see DEVICE_DT_DEFINE() \
+                                        \see DEVICE_API()"
+ALIASES               += "driver_ops_mandatory=\htmlonly<span class=\"op-badge op-req\" title=\"This operation MUST be implemented by the driver.\">REQ</span>\endhtmlonly"
+ALIASES               += "driver_ops_optional=\htmlonly<span class=\"op-badge op-opt\" title=\"This operation MAY optionally be implemented by the driver.\">OPT</span>\endhtmlonly"
+
 # Set the OPTIMIZE_OUTPUT_FOR_C tag to YES if your project consists of C sources
 # only. Doxygen will then generate output that is more tailored for C. For
 # instance, some of the names that are used will be different. The list of all

--- a/include/zephyr/drivers/can.h
+++ b/include/zephyr/drivers/can.h
@@ -312,9 +312,8 @@ typedef void (*can_state_change_callback_t)(const struct device *dev,
 					    void *user_data);
 
 /**
- * @cond INTERNAL_HIDDEN
- *
- * For internal driver use only, skip these in public documentation.
+ * @def_driverbackendgroup{CAN Controller,can_controller}
+ * @{
  */
 
 /**
@@ -506,36 +505,88 @@ typedef int (*can_get_core_clock_t)(const struct device *dev, uint32_t *rate);
  */
 typedef int (*can_get_max_filters_t)(const struct device *dev, bool ide);
 
+/**
+ * @driver_ops{CAN Controller}
+ */
 __subsystem struct can_driver_api {
+	/**
+	 * @driver_ops_mandatory @copybrief can_get_capabilities
+	 */
 	can_get_capabilities_t get_capabilities;
+	/**
+	 * @driver_ops_mandatory @copybrief can_start
+	 */
 	can_start_t start;
+	/**
+	 * @driver_ops_mandatory @copybrief can_stop
+	 */
 	can_stop_t stop;
+	/**
+	 * @driver_ops_mandatory @copybrief can_set_mode
+	 */
 	can_set_mode_t set_mode;
+	/**
+	 * @driver_ops_mandatory @copybrief can_set_timing
+	 */
 	can_set_timing_t set_timing;
+	/**
+	 * @driver_ops_mandatory @copybrief can_send
+	 */
 	can_send_t send;
+	/**
+	 * @driver_ops_mandatory @copybrief can_add_rx_filter
+	 */
 	can_add_rx_filter_t add_rx_filter;
+	/**
+	 * @driver_ops_mandatory @copybrief can_remove_rx_filter
+	 */
 	can_remove_rx_filter_t remove_rx_filter;
 #if defined(CONFIG_CAN_MANUAL_RECOVERY_MODE) || defined(__DOXYGEN__)
+	/**
+	 * @driver_ops_optional @copybrief can_recover
+	 * @kconfig_dep{CONFIG_CAN_MANUAL_RECOVERY_MODE}
+	 */
 	can_recover_t recover;
 #endif /* CONFIG_CAN_MANUAL_RECOVERY_MODE */
+	/**
+	 * @driver_ops_mandatory @copybrief can_get_state
+	 */
 	can_get_state_t get_state;
+	/**
+	 * @driver_ops_mandatory @copybrief can_set_state_change_callback
+	 */
 	can_set_state_change_callback_t set_state_change_callback;
+	/**
+	 * @driver_ops_mandatory @copybrief can_get_core_clock
+	 */
 	can_get_core_clock_t get_core_clock;
+	/**
+	 * @driver_ops_optional @copybrief can_get_max_filters
+	 */
 	can_get_max_filters_t get_max_filters;
-	/* Min values for the timing registers */
+	/** @driver_ops_mandatory Min values for the timing registers */
 	struct can_timing timing_min;
-	/* Max values for the timing registers */
+	/** @driver_ops_mandatory Max values for the timing registers */
 	struct can_timing timing_max;
 #if defined(CONFIG_CAN_FD_MODE) || defined(__DOXYGEN__)
+	/**
+	 * @driver_ops_optional @copybrief can_set_timing_data
+	 * @kconfig_dep{CONFIG_CAN_FD_MODE}
+	 */
 	can_set_timing_data_t set_timing_data;
-	/* Min values for the timing registers during the data phase */
+	/** Min values for the timing registers during the data phase.
+	 * @driver_ops_mandatory if @ref set_timing_data is implemented
+	 */
 	struct can_timing timing_data_min;
-	/* Max values for the timing registers during the data phase */
+	/** Max values for the timing registers during the data phase.
+	 * @driver_ops_mandatory if @ref set_timing_data is implemented
+	 */
 	struct can_timing timing_data_max;
 #endif /* CONFIG_CAN_FD_MODE */
 };
-
-/** @endcond */
+/**
+ * @}
+ */
 
 #if defined(CONFIG_CAN_STATS) || defined(__DOXYGEN__)
 

--- a/include/zephyr/drivers/gnss.h
+++ b/include/zephyr/drivers/gnss.h
@@ -44,11 +44,7 @@ enum gnss_pps_mode {
 	GNSS_PPS_MODE_ENABLED_WHILE_LOCKED = 3
 };
 
-/** API for setting fix rate */
-typedef int (*gnss_set_fix_rate_t)(const struct device *dev, uint32_t fix_interval_ms);
 
-/** API for getting fix rate */
-typedef int (*gnss_get_fix_rate_t)(const struct device *dev, uint32_t *fix_interval_ms);
 
 /** GNSS navigation modes */
 enum gnss_navigation_mode {
@@ -62,13 +58,7 @@ enum gnss_navigation_mode {
 	GNSS_NAVIGATION_MODE_HIGH_DYNAMICS = 3
 };
 
-/** API for setting navigation mode */
-typedef int (*gnss_set_navigation_mode_t)(const struct device *dev,
-					  enum gnss_navigation_mode mode);
 
-/** API for getting navigation mode */
-typedef int (*gnss_get_navigation_mode_t)(const struct device *dev,
-					  enum gnss_navigation_mode *mode);
 
 /** Systems contained in gnss_systems_t */
 enum gnss_system {
@@ -93,17 +83,7 @@ enum gnss_system {
 /** Type storing bitmask of GNSS systems */
 typedef uint32_t gnss_systems_t;
 
-/** API for enabling systems */
-typedef int (*gnss_set_enabled_systems_t)(const struct device *dev, gnss_systems_t systems);
 
-/** API for getting enabled systems */
-typedef int (*gnss_get_enabled_systems_t)(const struct device *dev, gnss_systems_t *systems);
-
-/** API for getting enabled systems */
-typedef int (*gnss_get_supported_systems_t)(const struct device *dev, gnss_systems_t *systems);
-
-/** API for getting timestamp of last PPS pulse */
-typedef int (*gnss_get_latest_timepulse_t)(const struct device *dev, k_ticks_t *timestamp);
 
 /** GNSS fix status */
 enum gnss_fix_status {
@@ -165,17 +145,77 @@ struct gnss_time {
 	uint8_t century_year;
 };
 
-/** GNSS API structure */
+/**
+ * @def_driverbackendgroup{GNSS,gnss_interface}
+ * @{
+ */
+
+/** API for setting fix rate */
+typedef int (*gnss_set_fix_rate_t)(const struct device *dev, uint32_t fix_interval_ms);
+
+/** API for getting fix rate */
+typedef int (*gnss_get_fix_rate_t)(const struct device *dev, uint32_t *fix_interval_ms);
+
+/** API for setting navigation mode */
+typedef int (*gnss_set_navigation_mode_t)(const struct device *dev,
+					  enum gnss_navigation_mode mode);
+
+/** API for getting navigation mode */
+typedef int (*gnss_get_navigation_mode_t)(const struct device *dev,
+					  enum gnss_navigation_mode *mode);
+
+/** API for enabling systems */
+typedef int (*gnss_set_enabled_systems_t)(const struct device *dev, gnss_systems_t systems);
+
+/** API for getting enabled systems */
+typedef int (*gnss_get_enabled_systems_t)(const struct device *dev, gnss_systems_t *systems);
+
+/** API for getting enabled systems */
+typedef int (*gnss_get_supported_systems_t)(const struct device *dev, gnss_systems_t *systems);
+
+/** API for getting timestamp of last PPS pulse */
+typedef int (*gnss_get_latest_timepulse_t)(const struct device *dev, k_ticks_t *timestamp);
+
+/**
+ * @driver_ops{GNSS}
+ */
 __subsystem struct gnss_driver_api {
+	/**
+	 * @driver_ops_optional @copybrief gnss_set_fix_rate
+	 */
 	gnss_set_fix_rate_t set_fix_rate;
+	/**
+	 * @driver_ops_optional @copybrief gnss_get_fix_rate
+	 */
 	gnss_get_fix_rate_t get_fix_rate;
+	/**
+	 * @driver_ops_optional @copybrief gnss_set_navigation_mode
+	 */
 	gnss_set_navigation_mode_t set_navigation_mode;
+	/**
+	 * @driver_ops_optional @copybrief gnss_get_navigation_mode
+	 */
 	gnss_get_navigation_mode_t get_navigation_mode;
+	/**
+	 * @driver_ops_optional @copybrief gnss_set_enabled_systems
+	 */
 	gnss_set_enabled_systems_t set_enabled_systems;
+	/**
+	 * @driver_ops_optional @copybrief gnss_get_enabled_systems
+	 */
 	gnss_get_enabled_systems_t get_enabled_systems;
+	/**
+	 * @driver_ops_optional @copybrief gnss_get_supported_systems
+	 */
 	gnss_get_supported_systems_t get_supported_systems;
+	/**
+	 * @driver_ops_optional @copybrief gnss_get_latest_timepulse
+	 */
 	gnss_get_latest_timepulse_t get_latest_timepulse;
 };
+/**
+ * @}
+ */
 
 /** GNSS data structure */
 struct gnss_data {

--- a/include/zephyr/drivers/spi.h
+++ b/include/zephyr/drivers/spi.h
@@ -859,8 +859,14 @@ static inline void spi_transceive_stats(const struct device *dev, int error,
 	SPI_DEVICE_DT_DEFINE(DT_DRV_INST(inst), __VA_ARGS__)
 
 /**
+ * @def_driverbackendgroup{SPI,spi_interface}
+ * @{
+ */
+
+/**
  * @typedef spi_api_io
- * @brief Callback API for I/O
+ * @brief Callback API for I/O.
+ *
  * See spi_transceive() for argument descriptions
  */
 typedef int (*spi_api_io)(const struct device *dev,
@@ -878,8 +884,9 @@ typedef int (*spi_api_io)(const struct device *dev,
 typedef void (*spi_callback_t)(const struct device *dev, int result, void *data);
 
 /**
- * @typedef spi_api_io
- * @brief Callback API for asynchronous I/O
+ * @typedef spi_api_io_async
+ * @brief Callback API for asynchronous I/O.
+ *
  * See spi_transceive_signal() for argument descriptions
  */
 typedef int (*spi_api_io_async)(const struct device *dev,
@@ -889,7 +896,7 @@ typedef int (*spi_api_io_async)(const struct device *dev,
 				spi_callback_t cb,
 				void *userdata);
 
-#if defined(CONFIG_SPI_RTIO) || defined(DOXYGEN)
+#if defined(CONFIG_SPI_RTIO) || defined(__DOXYGEN__)
 
 /**
  * @typedef spi_api_iodev_submit
@@ -909,19 +916,35 @@ typedef int (*spi_api_release)(const struct device *dev,
 
 
 /**
- * @brief SPI driver API
- * This is the mandatory API any SPI driver needs to expose.
+ * @driver_ops{SPI}
  */
 __subsystem struct spi_driver_api {
+	/**
+	 * @driver_ops_mandatory @copybrief spi_transceive
+	 */
 	spi_api_io transceive;
-#ifdef CONFIG_SPI_ASYNC
+#if defined(CONFIG_SPI_ASYNC) || defined(__DOXYGEN__)
+	/**
+	 * @driver_ops_optional @copybrief spi_transceive_cb
+	 * @kconfig_dep{CONFIG_SPI_ASYNC}
+	 */
 	spi_api_io_async transceive_async;
 #endif /* CONFIG_SPI_ASYNC */
-#ifdef CONFIG_SPI_RTIO
+#if defined(CONFIG_SPI_RTIO) || defined(__DOXYGEN__)
+	/**
+	 * @driver_ops_optional @copybrief spi_iodev_submit
+	 * @kconfig_dep{CONFIG_SPI_RTIO}
+	 */
 	spi_api_iodev_submit iodev_submit;
 #endif /* CONFIG_SPI_RTIO */
+	/**
+	 * @driver_ops_mandatory @copybrief spi_release
+	 */
 	spi_api_release release;
 };
+/**
+ * @}
+ */
 
 /**
  * @brief Check if SPI CS is controlled using a GPIO.
@@ -1153,9 +1176,7 @@ static inline int spi_write_dt(const struct spi_dt_spec *spec,
  */
 
 /**
- * @brief Read/write the specified amount of data from the SPI driver.
- *
- * @note This function is asynchronous.
+ * @brief Read/write the specified amount of data from the SPI driver asynchronously.
  *
  * @note This function is available only if @kconfig{CONFIG_SPI_ASYNC}
  * is selected.


### PR DESCRIPTION
A new attempt at trying to provide public documentation for the driver API that device driver developers need to implement. This introduces new Doxygen aliases to standardize the documentation of driver backend APIs (operations).
    
This adds:
- `def_driverbackendgroup`: To define the backend API doxygen group in a consistent way. The group typically contains the driver API struct but may contain other "driver implementor only" elements.
- `driver_ops`: To describe the main driver structure.
- `driver_ops_mandatory` / `driver_ops_optional`: To add visual "REQ" (Required) and "OPT" (Optional) badges to struct members.
    
These visual cues help device driver developers quickly identify which API pointers must be implemented vs. those that are optional.

PR implements the usage of the new aliases for documenting CAN, GNSS, and SPI API.

https://builds.zephyrproject.io/zephyr/pr/82117/docs/doxygen/html/structcan__driver__api.html

This is probably worth bringing up to the Architecture WG for awareness/discussion and to ensure we agree on approach and terminology used. Or maybe not, it shouldn't really be that controversial, I would hope :)

Maybe the only thing where I'd love to hear people's thoughts terminology-wise is that this work allowed me to uncover that we have many places where the driver operations and their typedefs are referred to as "Callback API" ("Callback API for/to/upon..."). Which... I... don't get? I can't for the life of me get my head around what is "callback" about them? I would typically expect callback to express some kind of async behavior or something but here it is just _very_ confusing IMO -- can we agree to instead have something like:

```diff
 /**
  * @typedef led_api_update_rgb
- * @brief Callback API for updating an RGB LED strip
+ * @brief Driver operation for updating an RGB LED strip
  *
  * @see led_strip_update_rgb() for argument descriptions.
  */
 typedef int (*led_api_update_rgb)(const struct device *dev,
 				  struct led_rgb *pixels,
 				  size_t num_pixels);

```