### PR TITLE
ci: testsplan: skip module handling with no west changes

### DIFF
--- a/scripts/ci/test_plan.py
+++ b/scripts/ci/test_plan.py
@@ -188,6 +188,8 @@ class Filters:
             logging.info(f'aprojs: {aprojs}')
             logging.info(f'project: {projs_names}')
 
+            if not projs_names:
+                return
             _options = []
             for p in projs_names:
                 _options.extend(["-t", p ])


### PR DESCRIPTION
In cases were west modules did not change, skip. This happens when
manifest layout changes, but without SHA changes.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
