### PR TITLE
drivers: auxdisplay: Place API into iterable section

### DIFF
--- a/drivers/auxdisplay/auxdisplay_hd44780.c
+++ b/drivers/auxdisplay/auxdisplay_hd44780.c
@@ -523,7 +523,7 @@ static int auxdisplay_hd44780_write(const struct device *dev, const uint8_t *tex
 	return 0;
 }
 
-static const struct auxdisplay_driver_api auxdisplay_hd44780_auxdisplay_api = {
+static DEVICE_API(auxdisplay, auxdisplay_hd44780_auxdisplay_api) = {
 	.display_on = auxdisplay_hd44780_display_on,
 	.display_off = auxdisplay_hd44780_display_off,
 	.cursor_set_enabled = auxdisplay_hd44780_cursor_set_enabled,

--- a/drivers/auxdisplay/auxdisplay_itron.c
+++ b/drivers/auxdisplay/auxdisplay_itron.c
@@ -406,7 +406,7 @@ static int auxdisplay_itron_write(const struct device *dev, const uint8_t *data,
 	return send_cmd(dev, data, len, false, true);
 }
 
-static const struct auxdisplay_driver_api auxdisplay_itron_auxdisplay_api = {
+static DEVICE_API(auxdisplay, auxdisplay_itron_auxdisplay_api) = {
 	.display_on = auxdisplay_itron_display_on,
 	.display_off = auxdisplay_itron_display_off,
 	.cursor_set_enabled = auxdisplay_itron_cursor_set_enabled,

--- a/drivers/auxdisplay/auxdisplay_jhd1313.c
+++ b/drivers/auxdisplay/auxdisplay_jhd1313.c
@@ -335,7 +335,7 @@ static int auxdisplay_jhd1313_capabilities_get(const struct device *dev,
 	return 0;
 }
 
-static const struct auxdisplay_driver_api auxdisplay_jhd1313_auxdisplay_api = {
+static DEVICE_API(auxdisplay, auxdisplay_jhd1313_auxdisplay_api) = {
 	.display_on = auxdisplay_jhd1313_display_on,
 	.display_off = auxdisplay_jhd1313_display_off,
 	.cursor_set_enabled = auxdisplay_jhd1313_cursor_set_enabled,

--- a/drivers/auxdisplay/auxdisplay_pt6314.c
+++ b/drivers/auxdisplay/auxdisplay_pt6314.c
@@ -284,7 +284,7 @@ static int auxdisplay_pt6314_init(const struct device *dev)
 	return 0;
 }
 
-static const struct auxdisplay_driver_api auxdisplay_pt6314_auxdisplay_api = {
+static DEVICE_API(auxdisplay, auxdisplay_pt6314_auxdisplay_api) = {
 	.display_on = auxdisplay_pt6314_display_on,
 	.display_off = auxdisplay_pt6314_display_off,
 	.cursor_set_enabled = auxdisplay_pt6314_cursor_set_enabled,

--- a/drivers/auxdisplay/auxdisplay_serlcd.c
+++ b/drivers/auxdisplay/auxdisplay_serlcd.c
@@ -392,7 +392,7 @@ static int auxdisplay_serlcd_init(const struct device *dev)
 	return 0;
 }
 
-static const struct auxdisplay_driver_api auxdisplay_serlcd_auxdisplay_api = {
+static DEVICE_API(auxdisplay, auxdisplay_serlcd_auxdisplay_api) = {
 	.display_on = auxdisplay_serlcd_display_on,
 	.display_off = auxdisplay_serlcd_display_off,
 	.cursor_set_enabled = auxdisplay_serlcd_cursor_set_enabled,


### PR DESCRIPTION
Add wrapper DEVICE_API macro to all auxdisplay_driver_api instances.