### PR TITLE
drivers: bbram: Place API into iterable section

### DIFF
--- a/drivers/bbram/bbram_emul.c
+++ b/drivers/bbram/bbram_emul.c
@@ -119,7 +119,7 @@ static int bbram_emul_write(const struct device *dev, size_t offset, size_t size
 	return 0;
 }
 
-static const struct bbram_driver_api bbram_emul_driver_api = {
+static DEVICE_API(bbram, bbram_emul_driver_api) = {
 	.check_invalid = bbram_emul_check_invalid,
 	.check_standby_power = bbram_emul_check_standby_power,
 	.check_power = bbram_emul_check_power,

--- a/drivers/bbram/bbram_it8xxx2.c
+++ b/drivers/bbram/bbram_it8xxx2.c
@@ -67,7 +67,7 @@ static int bbram_it8xxx2_size(const struct device *dev, size_t *size)
 	return 0;
 }
 
-static const struct bbram_driver_api bbram_it8xxx2_driver_api = {
+static DEVICE_API(bbram, bbram_it8xxx2_driver_api) = {
 	.read = bbram_it8xxx2_read,
 	.write = bbram_it8xxx2_write,
 	.get_size = bbram_it8xxx2_size,

--- a/drivers/bbram/bbram_microchip_mcp7940n.c
+++ b/drivers/bbram/bbram_microchip_mcp7940n.c
@@ -212,7 +212,7 @@ finish:
 	return rc;
 }
 
-static const struct bbram_driver_api microchip_mcp7940n_bbram_api = {
+static DEVICE_API(bbram, microchip_mcp7940n_bbram_api) = {
 	.get_size = microchip_mcp7940n_bbram_size,
 	.check_invalid = microchip_mcp7940n_bbram_is_invalid,
 	.check_standby_power = microchip_mcp7940n_bbram_check_standby_power,

--- a/drivers/bbram/bbram_npcx.c
+++ b/drivers/bbram/bbram_npcx.c
@@ -90,7 +90,7 @@ static int bbram_npcx_write(const struct device *dev, size_t offset, size_t size
 	return 0;
 }
 
-static const struct bbram_driver_api bbram_npcx_driver_api = {
+static DEVICE_API(bbram, bbram_npcx_driver_api) = {
 	.check_invalid = bbram_npcx_check_invalid,
 	.check_standby_power = bbram_npcx_check_standby_power,
 	.check_power = bbram_npcx_check_power,

--- a/drivers/bbram/bbram_stm32.c
+++ b/drivers/bbram/bbram_stm32.c
@@ -94,7 +94,7 @@ static int bbram_stm32_get_size(const struct device *dev, size_t *size)
 	return 0;
 }
 
-static const struct bbram_driver_api bbram_stm32_driver_api = {
+static DEVICE_API(bbram, bbram_stm32_driver_api) = {
 	.read = bbram_stm32_read,
 	.write = bbram_stm32_write,
 	.get_size = bbram_stm32_get_size,

--- a/drivers/bbram/bbram_xec.c
+++ b/drivers/bbram/bbram_xec.c
@@ -72,7 +72,7 @@ static int bbram_xec_write(const struct device *dev, size_t offset, size_t size,
 	return 0;
 }
 
-static const struct bbram_driver_api bbram_xec_driver_api = {
+static DEVICE_API(bbram, bbram_xec_driver_api) = {
 	.check_invalid = bbram_xec_check_invalid,
 	.get_size = bbram_xec_get_size,
 	.read = bbram_xec_read,


### PR DESCRIPTION
Add wrapper DEVICE_API macro to all bbram_driver_api instances.