### PR TITLE
drivers: can: Place API into iterable section

### DIFF
--- a/drivers/can/can_esp32_twai.c
+++ b/drivers/can/can_esp32_twai.c
@@ -216,7 +216,7 @@ static int can_esp32_twai_init(const struct device *dev)
 	return err;
 }
 
-const struct can_driver_api can_esp32_twai_driver_api = {
+DEVICE_API(can, can_esp32_twai_driver_api) = {
 	.get_capabilities = can_sja1000_get_capabilities,
 	.start = can_sja1000_start,
 	.stop = can_sja1000_stop,

--- a/drivers/can/can_fake.c
+++ b/drivers/can/can_fake.c
@@ -103,7 +103,7 @@ static int fake_can_init(const struct device *dev)
 	return 0;
 }
 
-static const struct can_driver_api fake_can_driver_api = {
+static DEVICE_API(can, fake_can_driver_api) = {
 	.start = fake_can_start,
 	.stop = fake_can_stop,
 	.get_capabilities = fake_can_get_capabilities,

--- a/drivers/can/can_kvaser_pci.c
+++ b/drivers/can/can_kvaser_pci.c
@@ -130,7 +130,7 @@ static int can_kvaser_pci_init(const struct device *dev)
 	return 0;
 }
 
-const struct can_driver_api can_kvaser_pci_driver_api = {
+DEVICE_API(can, can_kvaser_pci_driver_api) = {
 	.get_capabilities = can_sja1000_get_capabilities,
 	.start = can_sja1000_start,
 	.stop = can_sja1000_stop,

--- a/drivers/can/can_loopback.c
+++ b/drivers/can/can_loopback.c
@@ -365,7 +365,7 @@ static int can_loopback_get_max_filters(const struct device *dev, bool ide)
 	return CONFIG_CAN_MAX_FILTER;
 }
 
-static const struct can_driver_api can_loopback_driver_api = {
+static DEVICE_API(can, can_loopback_driver_api) = {
 	.get_capabilities = can_loopback_get_capabilities,
 	.start = can_loopback_start,
 	.stop = can_loopback_stop,

--- a/drivers/can/can_mcp2515.c
+++ b/drivers/can/can_mcp2515.c
@@ -877,7 +877,7 @@ static void mcp2515_int_gpio_callback(const struct device *dev,
 	k_sem_give(&dev_data->int_sem);
 }
 
-static const struct can_driver_api can_api_funcs = {
+static DEVICE_API(can, can_api_funcs) = {
 	.get_capabilities = mcp2515_get_capabilities,
 	.set_timing = mcp2515_set_timing,
 	.start = mcp2515_start,

--- a/drivers/can/can_mcp251xfd.c
+++ b/drivers/can/can_mcp251xfd.c
@@ -1682,7 +1682,7 @@ static int mcp251xfd_init(const struct device *dev)
 	return ret;
 }
 
-static const struct can_driver_api mcp251xfd_api_funcs = {
+static DEVICE_API(can, mcp251xfd_api_funcs) = {
 	.get_capabilities = mcp251xfd_get_capabilities,
 	.set_mode = mcp251xfd_set_mode,
 	.set_timing = mcp251xfd_set_timing,

--- a/drivers/can/can_mcux_flexcan.c
+++ b/drivers/can/can_mcux_flexcan.c
@@ -1257,7 +1257,7 @@ static int mcux_flexcan_init(const struct device *dev)
 	return 0;
 }
 
-__maybe_unused static const struct can_driver_api mcux_flexcan_driver_api = {
+static DEVICE_API(can, mcux_flexcan_driver_api) __maybe_unused = {
 	.get_capabilities = mcux_flexcan_get_capabilities,
 	.start = mcux_flexcan_start,
 	.stop = mcux_flexcan_stop,
@@ -1299,7 +1299,7 @@ __maybe_unused static const struct can_driver_api mcux_flexcan_driver_api = {
 };
 
 #ifdef CONFIG_CAN_MCUX_FLEXCAN_FD
-static const struct can_driver_api mcux_flexcan_fd_driver_api = {
+static DEVICE_API(can, mcux_flexcan_fd_driver_api) = {
 	.get_capabilities = mcux_flexcan_get_capabilities,
 	.start = mcux_flexcan_start,
 	.stop = mcux_flexcan_stop,

--- a/drivers/can/can_mcux_mcan.c
+++ b/drivers/can/can_mcux_mcan.c
@@ -135,7 +135,7 @@ static int mcux_mcan_init(const struct device *dev)
 	return 0;
 }
 
-static const struct can_driver_api mcux_mcan_driver_api = {
+static DEVICE_API(can, mcux_mcan_driver_api) = {
 	.get_capabilities = can_mcan_get_capabilities,
 	.start = can_mcan_start,
 	.stop = can_mcan_stop,

--- a/drivers/can/can_native_linux.c
+++ b/drivers/can/can_native_linux.c
@@ -399,7 +399,7 @@ static int can_native_linux_get_max_filters(const struct device *dev, bool ide)
 	return CONFIG_CAN_MAX_FILTER;
 }
 
-static const struct can_driver_api can_native_linux_driver_api = {
+static DEVICE_API(can, can_native_linux_driver_api) = {
 	.start = can_native_linux_start,
 	.stop = can_native_linux_stop,
 	.get_capabilities = can_native_linux_get_capabilities,

--- a/drivers/can/can_nrf.c
+++ b/drivers/can/can_nrf.c
@@ -57,7 +57,7 @@ static int can_nrf_get_core_clock(const struct device *dev, uint32_t *rate)
 	return clock_control_get_rate(config->clock, NULL, rate);
 }
 
-static const struct can_driver_api can_nrf_api = {
+static DEVICE_API(can, can_nrf_api) = {
 	.get_capabilities = can_mcan_get_capabilities,
 	.start = can_mcan_start,
 	.stop = can_mcan_stop,

--- a/drivers/can/can_numaker.c
+++ b/drivers/can/can_numaker.c
@@ -160,7 +160,7 @@ static int can_numaker_init(const struct device *dev)
 	return rc;
 }
 
-static const struct can_driver_api can_numaker_driver_api = {
+static DEVICE_API(can, can_numaker_driver_api) = {
 	.get_capabilities = can_mcan_get_capabilities,
 	.start = can_mcan_start,
 	.stop = can_mcan_stop,

--- a/drivers/can/can_nxp_s32_canxl.c
+++ b/drivers/can/can_nxp_s32_canxl.c
@@ -1080,7 +1080,7 @@ static void can_nxp_s32_isr_error(const struct device *dev)
 	Canexcel_Ip_ErrIRQHandler(config->instance);
 }
 
-static const struct can_driver_api can_nxp_s32_driver_api = {
+static DEVICE_API(can, can_nxp_s32_driver_api) = {
 	.get_capabilities = can_nxp_s32_get_capabilities,
 	.start = can_nxp_s32_start,
 	.stop = can_nxp_s32_stop,

--- a/drivers/can/can_rcar.c
+++ b/drivers/can/can_rcar.c
@@ -1150,7 +1150,7 @@ static int can_rcar_get_max_filters(const struct device *dev, bool ide)
 	return CONFIG_CAN_RCAR_MAX_FILTER;
 }
 
-static const struct can_driver_api can_rcar_driver_api = {
+static DEVICE_API(can, can_rcar_driver_api) = {
 	.get_capabilities = can_rcar_get_capabilities,
 	.start = can_rcar_start,
 	.stop = can_rcar_stop,

--- a/drivers/can/can_renesas_ra.c
+++ b/drivers/can/can_renesas_ra.c
@@ -969,7 +969,7 @@ static int can_renesas_ra_init(const struct device *dev)
 	return 0;
 }
 
-static const struct can_driver_api can_renesas_ra_driver_api = {
+static DEVICE_API(can, can_renesas_ra_driver_api) = {
 	.get_capabilities = can_renesas_ra_get_capabilities,
 	.start = can_renesas_ra_start,
 	.stop = can_renesas_ra_stop,

--- a/drivers/can/can_sam.c
+++ b/drivers/can/can_sam.c
@@ -123,7 +123,7 @@ static int can_sam_init(const struct device *dev)
 	return ret;
 }
 
-static const struct can_driver_api can_sam_driver_api = {
+static DEVICE_API(can, can_sam_driver_api) = {
 	.get_capabilities = can_mcan_get_capabilities,
 	.start = can_mcan_start,
 	.stop = can_mcan_stop,

--- a/drivers/can/can_sam0.c
+++ b/drivers/can/can_sam0.c
@@ -161,7 +161,7 @@ static int can_sam0_init(const struct device *dev)
 	return ret;
 }
 
-static const struct can_driver_api can_sam0_driver_api = {
+static DEVICE_API(can, can_sam0_driver_api) = {
 	.get_capabilities = can_mcan_get_capabilities,
 	.start = can_mcan_start,
 	.stop = can_mcan_stop,

--- a/drivers/can/can_shell.c
+++ b/drivers/can/can_shell.c
@@ -68,6 +68,11 @@ static struct k_poll_event can_shell_rx_msgq_events[] = {
 static void can_shell_tx_msgq_triggered_work_handler(struct k_work *work);
 static void can_shell_rx_msgq_triggered_work_handler(struct k_work *work);
 
+static bool can_device_check(const struct device *dev)
+{
+	return DEVICE_API_IS(can, dev) && device_is_ready(dev);
+}
+
 #ifdef CONFIG_CAN_SHELL_SCRIPTING_FRIENDLY
 static void can_shell_dummy_bypass_cb(const struct shell *sh, uint8_t *data, size_t len)
 {
@@ -279,7 +284,7 @@ static int cmd_can_start(const struct shell *sh, size_t argc, char **argv)
 	const struct device *dev = device_get_binding(argv[1]);
 	int err;
 
-	if (!device_is_ready(dev)) {
+	if (!can_device_check(dev)) {
 		shell_error(sh, "device %s not ready", argv[1]);
 		return -ENODEV;
 	}
@@ -300,7 +305,7 @@ static int cmd_can_stop(const struct shell *sh, size_t argc, char **argv)
 	const struct device *dev = device_get_binding(argv[1]);
 	int err;
 
-	if (!device_is_ready(dev)) {
+	if (!can_device_check(dev)) {
 		shell_error(sh, "device %s not ready", argv[1]);
 		return -ENODEV;
 	}
@@ -331,7 +336,7 @@ static int cmd_can_show(const struct shell *sh, size_t argc, char **argv)
 	can_mode_t cap;
 	int err;
 
-	if (!device_is_ready(dev)) {
+	if (!can_device_check(dev)) {
 		shell_error(sh, "device %s not ready", argv[1]);
 		return -ENODEV;
 	}
@@ -436,7 +441,7 @@ static int cmd_can_bitrate_set(const struct shell *sh, size_t argc, char **argv)
 	char *endptr;
 	int err;
 
-	if (!device_is_ready(dev)) {
+	if (!can_device_check(dev)) {
 		shell_error(sh, "device %s not ready", argv[1]);
 		return -ENODEV;
 	}
@@ -507,7 +512,7 @@ static int cmd_can_dbitrate_set(const struct shell *sh, size_t argc, char **argv
 	char *endptr;
 	int err;
 
-	if (!device_is_ready(dev)) {
+	if (!can_device_check(dev)) {
 		shell_error(sh, "device %s not ready", argv[1]);
 		return -ENODEV;
 	}
@@ -613,7 +618,7 @@ static int cmd_can_timing_set(const struct shell *sh, size_t argc, char **argv)
 	struct can_timing timing = { 0 };
 	int err;
 
-	if (!device_is_ready(dev)) {
+	if (!can_device_check(dev)) {
 		shell_error(sh, "device %s not ready", argv[1]);
 		return -ENODEV;
 	}
@@ -642,7 +647,7 @@ static int cmd_can_dtiming_set(const struct shell *sh, size_t argc, char **argv)
 	struct can_timing timing = { 0 };
 	int err;
 
-	if (!device_is_ready(dev)) {
+	if (!can_device_check(dev)) {
 		shell_error(sh, "device %s not ready", argv[1]);
 		return -ENODEV;
 	}
@@ -675,7 +680,7 @@ static int cmd_can_mode_set(const struct shell *sh, size_t argc, char **argv)
 	int i;
 	int j;
 
-	if (!device_is_ready(dev)) {
+	if (!can_device_check(dev)) {
 		shell_error(sh, "device %s not ready", argv[1]);
 		return -ENODEV;
 	}
@@ -727,7 +732,7 @@ static int cmd_can_send(const struct shell *sh, size_t argc, char **argv)
 	int err;
 	int i;
 
-	if (!device_is_ready(dev)) {
+	if (!can_device_check(dev)) {
 		shell_error(sh, "device %s not ready", argv[1]);
 		return -ENODEV;
 	}
@@ -844,7 +849,7 @@ static int cmd_can_filter_add(const struct shell *sh, size_t argc, char **argv)
 	char *endptr;
 	int err;
 
-	if (!device_is_ready(dev)) {
+	if (!can_device_check(dev)) {
 		shell_error(sh, "device %s not ready", argv[1]);
 		return -ENODEV;
 	}
@@ -940,7 +945,7 @@ static int cmd_can_filter_remove(const struct shell *sh, size_t argc, char **arg
 	int filter_id;
 	char *endptr;
 
-	if (!device_is_ready(dev)) {
+	if (!can_device_check(dev)) {
 		shell_error(sh, "device %s not ready", argv[1]);
 		return -ENODEV;
 	}
@@ -966,7 +971,7 @@ static int cmd_can_recover(const struct shell *sh, size_t argc, char **argv)
 	char *endptr;
 	int err;
 
-	if (!device_is_ready(dev)) {
+	if (!can_device_check(dev)) {
 		shell_error(sh, "device %s not ready", argv[1]);
 		return -ENODEV;
 	}
@@ -996,7 +1001,7 @@ static int cmd_can_recover(const struct shell *sh, size_t argc, char **argv)
 
 static void cmd_can_device_name(size_t idx, struct shell_static_entry *entry)
 {
-	const struct device *dev = shell_device_lookup(idx, NULL);
+	const struct device *dev = shell_device_filter(idx, can_device_check);
 
 	entry->syntax = (dev != NULL) ? dev->name : NULL;
 	entry->handler = NULL;

--- a/drivers/can/can_stm32_bxcan.c
+++ b/drivers/can/can_stm32_bxcan.c
@@ -1063,7 +1063,7 @@ static void can_stm32_remove_rx_filter(const struct device *dev, int filter_id)
 	k_mutex_unlock(&filter_mutex);
 }
 
-static const struct can_driver_api can_api_funcs = {
+static DEVICE_API(can, can_api_funcs) = {
 	.get_capabilities = can_stm32_get_capabilities,
 	.start = can_stm32_start,
 	.stop = can_stm32_stop,

--- a/drivers/can/can_stm32_fdcan.c
+++ b/drivers/can/can_stm32_fdcan.c
@@ -507,7 +507,7 @@ static int can_stm32fd_init(const struct device *dev)
 	return ret;
 }
 
-static const struct can_driver_api can_stm32fd_driver_api = {
+static DEVICE_API(can, can_stm32fd_driver_api) = {
 	.get_capabilities = can_mcan_get_capabilities,
 	.start = can_mcan_start,
 	.stop = can_mcan_stop,

--- a/drivers/can/can_stm32h7_fdcan.c
+++ b/drivers/can/can_stm32h7_fdcan.c
@@ -194,7 +194,7 @@ static int can_stm32h7_init(const struct device *dev)
 	return 0;
 }
 
-static const struct can_driver_api can_stm32h7_driver_api = {
+static DEVICE_API(can, can_stm32h7_driver_api) = {
 	.get_capabilities = can_mcan_get_capabilities,
 	.start = can_mcan_start,
 	.stop = can_mcan_stop,

--- a/drivers/can/can_tcan4x5x.c
+++ b/drivers/can/can_tcan4x5x.c
@@ -713,7 +713,7 @@ static int tcan4x5x_init(const struct device *dev)
 	return 0;
 }
 
-static const struct can_driver_api tcan4x5x_driver_api = {
+static DEVICE_API(can, tcan4x5x_driver_api) = {
 	.get_capabilities = can_mcan_get_capabilities,
 	.start = can_mcan_start,
 	.stop = can_mcan_stop,

--- a/drivers/can/can_xmc4xxx.c
+++ b/drivers/can/can_xmc4xxx.c
@@ -882,7 +882,7 @@ static int can_xmc4xxx_init(const struct device *dev)
 	return can_set_timing(dev, &timing);
 }
 
-static const struct can_driver_api can_xmc4xxx_api_funcs = {
+static DEVICE_API(can, can_xmc4xxx_api_funcs) = {
 	.get_capabilities = can_xmc4xxx_get_capabilities,
 	.set_mode = can_xmc4xxx_set_mode,
 	.set_timing = can_xmc4xxx_set_timing,


### PR DESCRIPTION
Add wrapper DEVICE_API macro to all can_driver_api instances.