### PR TITLE
usb: device_next: uac2: Double buffering on IN data endpoints

### DIFF
--- a/drivers/usb/udc/udc_dwc2.c
+++ b/drivers/usb/udc/udc_dwc2.c
@@ -1387,11 +1387,12 @@ static void udc_dwc2_ep_disable(const struct device *dev,
 	uint8_t ep_idx = USB_EP_GET_IDX(cfg->addr);
 	mem_addr_t dxepctl_reg;
 	uint32_t dxepctl;
+	const bool is_iso = dwc2_ep_is_iso(cfg);
 
 	dxepctl_reg = dwc2_get_dxepctl_reg(dev, cfg->addr);
 	dxepctl = sys_read32(dxepctl_reg);
 
-	if (dxepctl & USB_DWC2_DEPCTL_NAKSTS) {
+	if (!is_iso && (dxepctl & USB_DWC2_DEPCTL_NAKSTS)) {
 		/* Endpoint already sends forced NAKs. STALL if necessary. */
 		if (stall) {
 			dxepctl |= USB_DWC2_DEPCTL_STALL;

--- a/drivers/usb/udc/udc_dwc2.c
+++ b/drivers/usb/udc/udc_dwc2.c
@@ -2572,7 +2572,11 @@ static void dwc2_handle_incompisoin(const struct device *dev)
 
 				buf = udc_buf_get(dev, cfg->addr);
 				if (buf) {
+					/* Data is no longer relevant */
 					udc_submit_ep_event(dev, buf, 0);
+
+					/* Try to queue next packet before SOF */
+					dwc2_handle_xfer_next(dev, cfg);
 				}
 			}
 		}


### PR DESCRIPTION
Application is expected to call usbd_uac2_send() on each enabled USB Streaming Output Terminal (isochronous IN data endpoint) exactly once every SOF. The class is bookkeeping queued transfers to make it easier to determine component at fault when things go wrong. However, this approach only works fine if the underlying USB device controller buffers
the data to be sent on next SOF and reports the transfer completion immediately after data is buffered (e.g. nRF52 USBD).

While DWC2 otg also requires the SW to arm endpoint with data for the next SOF, unlike nRF52 USBD the transfer is only considered complete after either the IN token for isochronous endpoint is received or after the Periodic Frame Interval elapses without IN token. This design inevitably requires the application to be able to have at least two buffers for isochronous IN endpoints.

Support dual buffering on IN data endpoints to facilitate sending isochronous IN data on every SOF regardless of the underlying USB device controller design.