### PR TITLE
doc: gsg: warn against using Python 3.13 on Windows

### DIFF
--- a/doc/develop/getting_started/index.rst
+++ b/doc/develop/getting_started/index.rst
@@ -190,7 +190,7 @@ The current minimum required version for the main dependencies are:
 
          .. warning::
 
-            As of November 2023, Python 3.12 is not recommended for Zephyr development on Windows,
+            As of November 2024, Python 3.13 is not recommended for Zephyr development on Windows,
             as some required Python dependencies may be difficult to install.
 
       #. Close the terminal window.


### PR DESCRIPTION
History seems to repeat itself and we need to momentarily discourage folks to use Python 3.13 on Windows until windows-curses releases a PyPI package that works with it.
See https://github.com/zephyrproject-rtos/windows-curses/issues/69

Fixes #81543.