### PR TITLE
mgmt: mcumgr: transport: smp: Fix smp_init runlevel.

### DIFF
--- a/subsys/mgmt/mcumgr/transport/src/smp.c
+++ b/subsys/mgmt/mcumgr/transport/src/smp.c
@@ -32,7 +32,7 @@ K_THREAD_STACK_DEFINE(smp_work_queue_stack, CONFIG_MCUMGR_TRANSPORT_WORKQUEUE_ST
 static struct k_work_q smp_work_queue;
 
 #ifdef CONFIG_SMP_CLIENT
-static sys_slist_t smp_transport_clients;
+static sys_slist_t smp_transport_clients = SYS_SLIST_STATIC_INIT(&smp_transport_clients);
 #endif
 
 static const struct k_work_queue_config smp_work_queue_config = {
@@ -266,10 +266,6 @@ void smp_rx_clear(struct smp_transport *zst)
 
 static int smp_init(void)
 {
-#ifdef CONFIG_SMP_CLIENT
-	sys_slist_init(&smp_transport_clients);
-#endif
-
 	k_work_queue_init(&smp_work_queue);
 
 	k_work_queue_start(&smp_work_queue, smp_work_queue_stack,


### PR DESCRIPTION
Move priority to POST_KERNEL to make sure smp_init() is called before smp_init_uart as it initializes the transport list in case CONFIG_SMP_CLIENT is enabled.

The smp_init() routine was called after smp_init_uart(), causing the list to be emptied again after registration of the uart client transport.