### PR TITLE
Revert "soc: intel_adsp/ace30: do not map 0x0"

### DIFF
--- a/soc/intel/intel_adsp/ace/mmu_ace30.c
+++ b/soc/intel/intel_adsp/ace/mmu_ace30.c
@@ -126,7 +126,7 @@ const struct xtensa_mmu_range xtensa_soc_mmu_ranges[] = {
 	},
 	{
 		/* FIXME: definitely need more refinements... */
-		.start = (uint32_t)0x1000,
+		.start = (uint32_t)0x0,
 		.end   = (uint32_t)0x100000,
 		.attrs = XTENSA_MMU_PERM_W,
 		.name = "hwreg0",


### PR DESCRIPTION
The original [pull request](https://github.com/zephyrproject-rtos/zephyr/pull/81682) introduced a regression. I was not aware of it myself and it did not occur to me to verify, but ACE has registers with addresses smaller than **0x1000**.

For example, registers such as this one: https://github.com/zephyrproject-rtos/zephyr/blob/main/dts/xtensa/intel/intel_adsp_ace30_ptl.dtsi#L164-L167

This reverts commit 3d3ffa2c059d3aa2e76c5e76cf19769121d298f4.