### PR TITLE
drivers: can: transceiver: Place API into iterable section

### DIFF
--- a/drivers/can/transceiver/can_transceiver_gpio.c
+++ b/drivers/can/transceiver/can_transceiver_gpio.c
@@ -110,7 +110,7 @@ static int can_transceiver_gpio_init(const struct device *dev)
 	return 0;
 }
 
-static const struct can_transceiver_driver_api can_transceiver_gpio_driver_api = {
+static DEVICE_API(can_transceiver, can_transceiver_gpio_driver_api) = {
 	.enable = can_transceiver_gpio_enable,
 	.disable = can_transceiver_gpio_disable,
 };

--- a/include/zephyr/drivers/can/transceiver.h
+++ b/include/zephyr/drivers/can/transceiver.h
@@ -65,10 +65,7 @@ __subsystem struct can_transceiver_driver_api {
  */
 static inline int can_transceiver_enable(const struct device *dev, can_mode_t mode)
 {
-	const struct can_transceiver_driver_api *api =
-		(const struct can_transceiver_driver_api *)dev->api;
-
-	return api->enable(dev, mode);
+	return DEVICE_API_GET(can_transceiver, dev)->enable(dev, mode);
 }
 
 /**
@@ -87,10 +84,7 @@ static inline int can_transceiver_enable(const struct device *dev, can_mode_t mo
  */
 static inline int can_transceiver_disable(const struct device *dev)
 {
-	const struct can_transceiver_driver_api *api =
-		(const struct can_transceiver_driver_api *)dev->api;
-
-	return api->disable(dev);
+	return DEVICE_API_GET(can_transceiver, dev)->disable(dev);
 }
 
 /**


### PR DESCRIPTION
Add wrapper DEVICE_API macro to all can_transceiver_driver_api instances.