### PR TITLE
drivers: modem: cellular: Place API into iterable section

### DIFF
--- a/drivers/modem/modem_cellular.c
+++ b/drivers/modem/modem_cellular.c
@@ -1668,7 +1668,7 @@ static int modem_cellular_get_registration_status(const struct device *dev,
 	return ret;
 }
 
-const static struct cellular_driver_api modem_cellular_api = {
+static DEVICE_API(cellular, modem_cellular_api) = {
 	.get_signal = modem_cellular_get_signal,
 	.get_modem_info = modem_cellular_get_modem_info,
 	.get_registration_status = modem_cellular_get_registration_status,


### PR DESCRIPTION
Add wrapper DEVICE_API macro to all cellular_driver_api instances.