### PR TITLE
instantiation of flash area objects at point of usage

### DIFF
--- a/include/zephyr/storage/flash_map.h
+++ b/include/zephyr/storage/flash_map.h
@@ -134,6 +134,28 @@ int flash_area_open(uint8_t id, const struct flash_area **fa);
 void flash_area_close(const struct flash_area *fa);
 
 /**
+ * @brief Verify that a device assigned to flash area is ready for use.
+ *
+ * Indicates whether the provided flash area has a device known to be
+ * in a state where it can be used with Flash Map API.
+ *
+ * This can be used with struct flash_area pointers captured from
+ * FIXED_PARTITION().
+ * At minimum this means that the device has been successfully initialized.
+ *
+ * @param dev pointer to flash_area object to check.
+ *
+ * @retval true If the device is ready for use.
+ * @retval false If the device is not ready for use or if a NULL pointer is
+ * passed as flash area pointer or device pointer within flash area object
+ * is NULL.
+ */
+static ALWAYS_INLINE bool flash_area_device_is_ready(const struct flash_area *fa)
+{
+	return (fa != NULL && device_is_ready(fa->fa_dev));
+}
+
+/**
  * @brief Read flash area data
  *
  * Read data from flash area. Area readout boundaries are asserted before read
@@ -375,6 +397,31 @@ uint8_t flash_area_erased_val(const struct flash_area *fa);
  */
 #define FIXED_PARTITION_NODE_DEVICE(node) \
 	DEVICE_DT_GET(DT_MTD_FROM_FIXED_PARTITION(node))
+
+/**
+ * Get pointer to flash_area object by partition label
+ *
+ * @param label DTS node label of a partition
+ *
+ * @return Pointer to flash_area type object representing partition
+ */
+#define FIXED_PARTITION(label)	FIXED_PARTITION_1(DT_NODELABEL(label))
+#define FIXED_PARTITION_1(node)	FIXED_PARTITION_0(DT_DEP_ORD(node))
+#define FIXED_PARTITION_0(ord) (const struct flash_area *)&DT_CAT(global_fixed_partition_ORD_, part)
+
+/** @cond INTERNAL_HIDDEN */
+#define DECLARE_PARTITION(part) DECLARE_PARTITION_0(DT_DEP_ORD(part))
+#define DECLARE_PARTITION_0(part)						\
+	extern const struct flash_area DT_CAT(global_fixed_partition_ORD_, part);
+#define FOR_EACH_PARTITION_TABLE(table) DT_FOREACH_CHILD(table, DECLARE_PARTITION)
+
+/* Generate declarations */
+DT_FOREACH_STATUS_OKAY(fixed_partitions, FOR_EACH_PARTITION_TABLE)
+
+#undef DECLARE_PARTITION
+#undef DECLARE_PARTITION_0
+#undef FOR_EACH_PARTITION_TABLE
+/** @endcond */
 
 #ifdef __cplusplus
 }

--- a/include/zephyr/storage/flash_map.h
+++ b/include/zephyr/storage/flash_map.h
@@ -139,11 +139,10 @@ void flash_area_close(const struct flash_area *fa);
  * Indicates whether the provided flash area has a device known to be
  * in a state where it can be used with Flash Map API.
  *
- * This can be used with struct flash_area pointers captured from
- * FIXED_PARTITION().
+ * This can be used with struct flash_area pointers captured from FIXED_PARTITION().
  * At minimum this means that the device has been successfully initialized.
  *
- * @param dev pointer to flash_area object to check.
+ * @param fa pointer to flash_area object to check.
  *
  * @retval true If the device is ready for use.
  * @retval false If the device is not ready for use or if a NULL pointer is
@@ -253,6 +252,20 @@ uint32_t flash_area_align(const struct flash_area *fa);
  */
 int flash_area_get_sectors(int fa_id, uint32_t *count,
 			   struct flash_sector *sectors);
+
+/**
+ * Retrieve info about sectors within the area.
+ *
+ * @param[in]  fa       pointer to flash area object.
+ * @param[out] sectors  buffer for sectors data
+ * @param[in,out] count On input Capacity of @p sectors, on output number of
+ * sectors retrieved.
+ *
+ * @return  0 on success, negative errno code on fail. Especially returns
+ * -ENOMEM if There are too many flash pages on the flash_area to fit in the
+ * array.
+ */
+int flash_area_sectors(const struct flash_area *fa, uint32_t *count, struct flash_sector *sectors);
 
 /**
  * Flash map iteration callback
@@ -407,12 +420,13 @@ uint8_t flash_area_erased_val(const struct flash_area *fa);
  */
 #define FIXED_PARTITION(label)	FIXED_PARTITION_1(DT_NODELABEL(label))
 #define FIXED_PARTITION_1(node)	FIXED_PARTITION_0(DT_DEP_ORD(node))
-#define FIXED_PARTITION_0(ord) (const struct flash_area *)&DT_CAT(global_fixed_partition_ORD_, part)
+#define FIXED_PARTITION_0(ord)							\
+	((const struct flash_area *)&DT_CAT(global_fixed_partition_ORD_, ord))
 
 /** @cond INTERNAL_HIDDEN */
-#define DECLARE_PARTITION(part) DECLARE_PARTITION_0(DT_DEP_ORD(part))
-#define DECLARE_PARTITION_0(part)						\
-	extern const struct flash_area DT_CAT(global_fixed_partition_ORD_, part);
+#define DECLARE_PARTITION(node) DECLARE_PARTITION_0(DT_DEP_ORD(node))
+#define DECLARE_PARTITION_0(ord)						\
+	extern const struct flash_area DT_CAT(global_fixed_partition_ORD_, ord);
 #define FOR_EACH_PARTITION_TABLE(table) DT_FOREACH_CHILD(table, DECLARE_PARTITION)
 
 /* Generate declarations */

--- a/subsys/storage/flash_map/flash_map_layout.c
+++ b/subsys/storage/flash_map/flash_map_layout.c
@@ -78,8 +78,6 @@ static bool get_sectors_cb(const struct flash_pages_info *info, void *datav)
 
 int flash_area_get_sectors(int idx, uint32_t *cnt, struct flash_sector *ret)
 {
-	struct layout_data data;
-	const struct device *flash_dev;
 	const struct flash_area *fa;
 	int rc = flash_area_open(idx, &fa);
 
@@ -87,7 +85,17 @@ int flash_area_get_sectors(int idx, uint32_t *cnt, struct flash_sector *ret)
 		return -EINVAL;
 	}
 
-	data.area_idx = idx;
+	rc = flash_area_sectors(fa, cnt, ret);
+	flash_area_close(fa);
+
+	return rc;
+}
+
+int flash_area_sectors(const struct flash_area *fa, uint32_t *cnt, struct flash_sector *ret)
+{
+	struct layout_data data;
+	const struct device *flash_dev;
+
 	data.area_off = fa->fa_off;
 	data.area_len = fa->fa_size;
 
@@ -97,10 +105,6 @@ int flash_area_get_sectors(int idx, uint32_t *cnt, struct flash_sector *ret)
 	data.status = 0;
 
 	flash_dev = fa->fa_dev;
-	flash_area_close(fa);
-	if (flash_dev == NULL) {
-		return -ENODEV;
-	}
 
 	flash_page_foreach(flash_dev, get_sectors_cb, &data);
 

--- a/tests/subsys/storage/flash_map/src/main.c
+++ b/tests/subsys/storage/flash_map/src/main.c
@@ -32,51 +32,90 @@ ZTEST(flash_map, test_flash_area_disabled_device)
 	zassert_equal(rc, -ENOENT, "Open did not fail");
 }
 
+ZTEST(flash_map, test_flash_area_device_is_ready)
+{
+	const struct flash_area no_dev = {
+		.fa_dev = NULL,
+	};
+
+	zassert_false(flash_area_device_is_ready(NULL));
+	zassert_false(flash_area_device_is_ready(&no_dev));
+	/* The below just assumes that tests are executed so late that
+	 * all devices are already initialized and ready.
+	 */
+	zassert_true(flash_area_device_is_ready(
+			FIXED_PARTITION(SLOT1_PARTITION)));
+}
+
+static void layout_match(const struct device *flash_dev, uint32_t sec_cnt)
+{
+	off_t off = 0;
+	int i;
+
+	/* For each reported sector, check if it corresponds to real page on device */
+	for (i = 0; i < sec_cnt; ++i) {
+		struct flash_pages_info fpi;
+
+		zassert_ok(
+			flash_get_page_info_by_offs(flash_dev, SLOT1_PARTITION_OFFSET + off, &fpi));
+		/* Offset of page taken directly from device corresponds to offset
+		 * within flash area
+		 */
+		zassert_equal(fpi.start_offset, fs_sectors[i].fs_off + SLOT1_PARTITION_OFFSET);
+		zassert_equal(fpi.size, fs_sectors[i].fs_size);
+		off += fs_sectors[i].fs_size;
+	}
+}
+
 /**
  * @brief Test flash_area_get_sectors()
  */
 ZTEST(flash_map, test_flash_area_get_sectors)
 {
 	const struct flash_area *fa;
-	uint32_t sec_cnt;
-	int i;
-	int rc;
-	off_t off;
-	const struct device *flash_dev;
 	const struct device *flash_dev_a = SLOT1_PARTITION_DEV;
+	uint32_t sec_cnt;
+	int rc;
 
-	rc = flash_area_open(SLOT1_PARTITION_ID, &fa);
-	zassert_true(rc == 0, "flash_area_open() fail");
+	fa = FIXED_PARTITION(SLOT1_PARTITION);
 
-	/* First erase the area so it's ready for use. */
-	flash_dev = flash_area_get_device(fa);
+	zassert_true(flash_area_device_is_ready(fa));
+
+	zassert_true(device_is_ready(flash_dev_a));
 
 	/* Device obtained by label should match the one from fa object */
-	zassert_equal(flash_dev, flash_dev_a, "Device for slot1_partition do not match");
+	zassert_equal(fa->fa_dev, flash_dev_a, "Device for slot1_partition do not match");
+
+	memset(&fs_sectors[0], 0, sizeof(fs_sectors));
 
 	sec_cnt = ARRAY_SIZE(fs_sectors);
 	rc = flash_area_get_sectors(SLOT1_PARTITION_ID, &sec_cnt, fs_sectors);
 	zassert_true(rc == 0, "flash_area_get_sectors failed");
 
-	off = 0;
+	layout_match(flash_dev_a, sec_cnt);
+}
 
-	/* For each reported sector, check if it corresponds to real page on device */
-	for (i = 0; i < sec_cnt; ++i) {
-		struct flash_pages_info fpi;
+ZTEST(flash_map, test_flash_area_sectors)
+{
+	const struct flash_area *fa;
+	uint32_t sec_cnt;
+	int rc;
+	const struct device *flash_dev_a = SLOT1_PARTITION_DEV;
 
-		zassert_ok(flash_get_page_info_by_offs(flash_dev,
-						       SLOT1_PARTITION_OFFSET + off,
-						       &fpi));
-		/* Offset of page taken directly from device corresponds to offset
-		 * within flash area
-		 */
-		zassert_equal(fpi.start_offset,
-			      fs_sectors[i].fs_off + SLOT1_PARTITION_OFFSET);
-		zassert_equal(fpi.size, fs_sectors[i].fs_size);
-		off += fs_sectors[i].fs_size;
-	}
+	fa = FIXED_PARTITION(SLOT1_PARTITION);
 
-	flash_area_close(fa);
+	zassert_true(flash_area_device_is_ready(fa));
+
+	zassert_true(device_is_ready(flash_dev_a));
+
+	/* Device obtained by label should match the one from fa object */
+	zassert_equal(fa->fa_dev, flash_dev_a, "Device for slot1_partition do not match");
+
+	sec_cnt = ARRAY_SIZE(fs_sectors);
+	rc = flash_area_sectors(fa, &sec_cnt, fs_sectors);
+	zassert_true(rc == 0, "flash_area_get_sectors failed");
+
+	layout_match(flash_dev_a, sec_cnt);
 }
 
 ZTEST(flash_map, test_flash_area_erased_val)
@@ -84,10 +123,8 @@ ZTEST(flash_map, test_flash_area_erased_val)
 	const struct flash_parameters *param;
 	const struct flash_area *fa;
 	uint8_t val;
-	int rc;
 
-	rc = flash_area_open(SLOT1_PARTITION_ID, &fa);
-	zassert_true(rc == 0, "flash_area_open() fail");
+	fa = FIXED_PARTITION(SLOT1_PARTITION);
 
 	val = flash_area_erased_val(fa);
 
@@ -95,8 +132,6 @@ ZTEST(flash_map, test_flash_area_erased_val)
 
 	zassert_equal(param->erase_value, val,
 		      "value different than the flash erase value");
-
-	flash_area_close(fa);
 }
 
 ZTEST(flash_map, test_fixed_partition_node_macros)
@@ -118,8 +153,7 @@ ZTEST(flash_map, test_flash_area_erase_and_flatten)
 	const struct flash_area *fa;
 	const struct device *flash_dev;
 
-	rc = flash_area_open(SLOT1_PARTITION_ID, &fa);
-	zassert_true(rc == 0, "flash_area_open() fail");
+	fa = FIXED_PARTITION(SLOT1_PARTITION);
 
 	/* First erase the area so it's ready for use. */
 	flash_dev = flash_area_get_device(fa);


### PR DESCRIPTION
Once again, because I have managed to break CI  previously (https://discord.com/channels/720317445772017664/1014241011989487716/1311329358043942943)

The PR consists of  commits adding: 
 -  `FIXED_PARTITION(label)` macro that allows to directly access flash_area object instead of using flash_area_open to search it in map; this should reduce size of rom usage by applications since only the directly referenced by code partitions will be linked in instead of entire flash map that flash_area_open has to iterate on; the commit also adds supporting code that generates the object and proper declarations.
 - `flash_area_device_is_ready` to be used instead of `flash_area_open` to check if object obtained by invocation of `FIXED_PARTITION` is pointing to device ready for operation.
 -  `flash_area_sectors` which is equivalent to `flash_are_get_sectors` except it takes flash_area object pointer instead of flash area index, and does not use flash_area_open internally; this change is needed as replacement for `flash_area_get_sectors` so that generating of default flash_map could be removed;
 - Changes for flash map tests, where `flash_area_open/flash_area_close` is no longer used in tests.
