### PR TITLE
drivers: clock_control: Place API into iterable section

### DIFF
--- a/drivers/clock_control/beetle_clock_control.c
+++ b/drivers/clock_control/beetle_clock_control.c
@@ -148,7 +148,7 @@ static int beetle_clock_control_get_subsys_rate(const struct device *clock,
 	return 0;
 }
 
-static const struct clock_control_driver_api beetle_clock_control_api = {
+static DEVICE_API(clock_control, beetle_clock_control_api) = {
 	.on = beetle_clock_control_on,
 	.off = beetle_clock_control_off,
 	.get_rate = beetle_clock_control_get_subsys_rate,

--- a/drivers/clock_control/clock_agilex.c
+++ b/drivers/clock_control/clock_agilex.c
@@ -35,7 +35,7 @@ static int clk_get_rate(const struct device *dev,
 	return 0;
 }
 
-static const struct clock_control_driver_api clk_api = {
+static DEVICE_API(clock_control, clk_api) = {
 	.get_rate = clk_get_rate
 };
 

--- a/drivers/clock_control/clock_control_adsp.c
+++ b/drivers/clock_control/clock_control_adsp.c
@@ -24,7 +24,7 @@ static int cavs_clock_ctrl_init(const struct device *dev)
 	return 0;
 }
 
-static const struct clock_control_driver_api cavs_clock_api = {
+static DEVICE_API(clock_control, cavs_clock_api) = {
 	.set_rate = cavs_clock_ctrl_set_rate
 };
 

--- a/drivers/clock_control/clock_control_agilex5.c
+++ b/drivers/clock_control/clock_control_agilex5.c
@@ -69,7 +69,9 @@ static int clock_get_rate(const struct device *dev, clock_control_subsys_t sub_s
 	return 0;
 }
 
-static const struct clock_control_driver_api clock_api = {.get_rate = clock_get_rate};
+static DEVICE_API(clock_control, clock_api) = {
+	.get_rate = clock_get_rate,
+};
 
 #define CLOCK_CONTROL_DEVICE(_inst)                                                                \
                                                                                                    \

--- a/drivers/clock_control/clock_control_ambiq.c
+++ b/drivers/clock_control/clock_control_ambiq.c
@@ -119,7 +119,7 @@ static int ambiq_clock_init(const struct device *dev)
 	return 0;
 }
 
-static const struct clock_control_driver_api ambiq_clock_driver_api = {
+static DEVICE_API(clock_control, ambiq_clock_driver_api) = {
 	.on = ambiq_clock_on,
 	.off = ambiq_clock_off,
 	.get_rate = ambiq_clock_get_rate,

--- a/drivers/clock_control/clock_control_arm_scmi.c
+++ b/drivers/clock_control/clock_control_arm_scmi.c
@@ -68,7 +68,7 @@ static int scmi_clock_get_rate(const struct device *dev,
 	return scmi_clock_rate_get(proto, clk_id, rate);
 }
 
-static struct clock_control_driver_api scmi_clock_api = {
+static DEVICE_API(clock_control, scmi_clock_api) = {
 	.on = scmi_clock_on,
 	.off = scmi_clock_off,
 	.get_rate = scmi_clock_get_rate,

--- a/drivers/clock_control/clock_control_ast10x0.c
+++ b/drivers/clock_control/clock_control_ast10x0.c
@@ -146,7 +146,7 @@ static int aspeed_clock_control_get_rate(const struct device *dev,
 	return 0;
 }
 
-static const struct clock_control_driver_api aspeed_clk_api = {
+static DEVICE_API(clock_control, aspeed_clk_api) = {
 	.on = aspeed_clock_control_on,
 	.off = aspeed_clock_control_off,
 	.get_rate = aspeed_clock_control_get_rate,

--- a/drivers/clock_control/clock_control_esp32.c
+++ b/drivers/clock_control/clock_control_esp32.c
@@ -795,7 +795,7 @@ static int clock_control_esp32_init(const struct device *dev)
 	return 0;
 }
 
-static const struct clock_control_driver_api clock_control_esp32_api = {
+static DEVICE_API(clock_control, clock_control_esp32_api) = {
 	.on = clock_control_esp32_on,
 	.off = clock_control_esp32_off,
 	.get_rate = clock_control_esp32_get_rate,

--- a/drivers/clock_control/clock_control_fixed_rate.c
+++ b/drivers/clock_control/clock_control_fixed_rate.c
@@ -49,7 +49,7 @@ static int fixed_rate_clk_get_rate(const struct device *dev,
 	return 0;
 }
 
-static const struct clock_control_driver_api fixed_rate_clk_api = {
+static DEVICE_API(clock_control, fixed_rate_clk_api) = {
 	.on = fixed_rate_clk_on,
 	.off = fixed_rate_clk_off,
 	.get_status = fixed_rate_clk_get_status,

--- a/drivers/clock_control/clock_control_gd32.c
+++ b/drivers/clock_control/clock_control_gd32.c
@@ -198,7 +198,7 @@ clock_control_gd32_get_status(const struct device *dev,
 	return CLOCK_CONTROL_STATUS_OFF;
 }
 
-static const struct clock_control_driver_api clock_control_gd32_api = {
+static DEVICE_API(clock_control, clock_control_gd32_api) = {
 	.on = clock_control_gd32_on,
 	.off = clock_control_gd32_off,
 	.get_rate = clock_control_gd32_get_rate,

--- a/drivers/clock_control/clock_control_ifx_cat1.c
+++ b/drivers/clock_control/clock_control_ifx_cat1.c
@@ -708,7 +708,7 @@ static int clock_control_infineon_cat_on_off(const struct device *dev,
 	return -ENOSYS;
 }
 
-static const struct clock_control_driver_api clock_control_infineon_cat1_api = {
+static DEVICE_API(clock_control, clock_control_infineon_cat1_api) = {
 	.on = clock_control_infineon_cat_on_off,
 	.off = clock_control_infineon_cat_on_off
 };

--- a/drivers/clock_control/clock_control_litex.c
+++ b/drivers/clock_control/clock_control_litex.c
@@ -1605,7 +1605,7 @@ static inline int litex_clk_off(const struct device *dev,
 	return litex_clk_change_value(ZERO_REG, ZERO_REG, POWER_REG);
 }
 
-static const struct clock_control_driver_api litex_clk_api = {
+static DEVICE_API(clock_control, litex_clk_api) = {
 	.on = litex_clk_on,
 	.off = litex_clk_off,
 	.get_rate = litex_clk_get_subsys_rate,

--- a/drivers/clock_control/clock_control_lpc11u6x.c
+++ b/drivers/clock_control/clock_control_lpc11u6x.c
@@ -338,7 +338,7 @@ static int lpc11u6x_syscon_init(const struct device *dev)
 	return 0;
 }
 
-static const struct clock_control_driver_api lpc11u6x_clock_control_api = {
+static DEVICE_API(clock_control, lpc11u6x_clock_control_api) = {
 	.on = lpc11u6x_clock_control_on,
 	.off = lpc11u6x_clock_control_off,
 	.get_rate = lpc11u6x_clock_control_get_rate,

--- a/drivers/clock_control/clock_control_max32.c
+++ b/drivers/clock_control/clock_control_max32.c
@@ -94,7 +94,7 @@ static int api_get_rate(const struct device *dev, clock_control_subsys_t clkcfg,
 	return 0;
 }
 
-static const struct clock_control_driver_api max32_clkctrl_api = {
+static DEVICE_API(clock_control, max32_clkctrl_api) = {
 	.on = api_on,
 	.off = api_off,
 	.get_rate = api_get_rate,

--- a/drivers/clock_control/clock_control_mchp_xec.c
+++ b/drivers/clock_control/clock_control_mchp_xec.c
@@ -1014,7 +1014,7 @@ void mchp_xec_clk_ctrl_sys_sleep_disable(void)
 #endif
 
 /* Clock controller driver registration */
-static const struct clock_control_driver_api xec_clock_control_api = {
+static DEVICE_API(clock_control, xec_clock_control_api) = {
 	.on = xec_clock_control_on,
 	.off = xec_clock_control_off,
 	.get_rate = xec_clock_control_get_subsys_rate,

--- a/drivers/clock_control/clock_control_mcux_ccm.c
+++ b/drivers/clock_control/clock_control_mcux_ccm.c
@@ -489,7 +489,7 @@ static int CCM_SET_FUNC_ATTR mcux_ccm_set_subsys_rate(const struct device *dev,
 
 
 
-static const struct clock_control_driver_api mcux_ccm_driver_api = {
+static DEVICE_API(clock_control, mcux_ccm_driver_api) = {
 	.on = mcux_ccm_on,
 	.off = mcux_ccm_off,
 	.get_rate = mcux_ccm_get_subsys_rate,

--- a/drivers/clock_control/clock_control_mcux_ccm_rev2.c
+++ b/drivers/clock_control/clock_control_mcux_ccm_rev2.c
@@ -301,7 +301,7 @@ static int CCM_SET_FUNC_ATTR mcux_ccm_set_subsys_rate(const struct device *dev,
 	}
 }
 
-static const struct clock_control_driver_api mcux_ccm_driver_api = {
+static DEVICE_API(clock_control, mcux_ccm_driver_api) = {
 	.on = mcux_ccm_on,
 	.off = mcux_ccm_off,
 	.get_rate = mcux_ccm_get_subsys_rate,

--- a/drivers/clock_control/clock_control_mcux_mcg.c
+++ b/drivers/clock_control/clock_control_mcux_mcg.c
@@ -55,7 +55,7 @@ static int mcux_mcg_get_rate(const struct device *dev,
 	return 0;
 }
 
-static const struct clock_control_driver_api mcux_mcg_driver_api = {
+static DEVICE_API(clock_control, mcux_mcg_driver_api) = {
 	.on = mcux_mcg_on,
 	.off = mcux_mcg_off,
 	.get_rate = mcux_mcg_get_rate,

--- a/drivers/clock_control/clock_control_mcux_pcc.c
+++ b/drivers/clock_control/clock_control_mcux_pcc.c
@@ -103,7 +103,7 @@ static int mcux_pcc_get_rate(const struct device *dev,
 	return 0;
 }
 
-static const struct clock_control_driver_api mcux_pcc_api = {
+static DEVICE_API(clock_control, mcux_pcc_api) = {
 	.on = mcux_pcc_on,
 	.off = mcux_pcc_off,
 	.get_rate = mcux_pcc_get_rate,

--- a/drivers/clock_control/clock_control_mcux_scg.c
+++ b/drivers/clock_control/clock_control_mcux_scg.c
@@ -144,7 +144,7 @@ static int mcux_scg_init(const struct device *dev)
 	return 0;
 }
 
-static const struct clock_control_driver_api mcux_scg_driver_api = {
+static DEVICE_API(clock_control, mcux_scg_driver_api) = {
 	.on = mcux_scg_on,
 	.off = mcux_scg_off,
 	.get_rate = mcux_scg_get_rate,

--- a/drivers/clock_control/clock_control_mcux_scg_k4.c
+++ b/drivers/clock_control/clock_control_mcux_scg_k4.c
@@ -73,7 +73,7 @@ static int mcux_scg_k4_get_rate(const struct device *dev, clock_control_subsys_t
 	return 0;
 }
 
-static const struct clock_control_driver_api mcux_scg_driver_api = {
+static DEVICE_API(clock_control, mcux_scg_driver_api) = {
 	.on = mcux_scg_k4_on,
 	.off = mcux_scg_k4_off,
 	.get_rate = mcux_scg_k4_get_rate,

--- a/drivers/clock_control/clock_control_mcux_sim.c
+++ b/drivers/clock_control/clock_control_mcux_sim.c
@@ -103,7 +103,7 @@ static int mcux_sim_init(const struct device *dev)
 	return 0;
 }
 
-static const struct clock_control_driver_api mcux_sim_driver_api = {
+static DEVICE_API(clock_control, mcux_sim_driver_api) = {
 	.on = mcux_sim_on,
 	.off = mcux_sim_off,
 	.get_rate = mcux_sim_get_subsys_rate,

--- a/drivers/clock_control/clock_control_mcux_syscon.c
+++ b/drivers/clock_control/clock_control_mcux_syscon.c
@@ -486,7 +486,7 @@ static int SYSCON_SET_FUNC_ATTR mcux_lpc_syscon_clock_control_set_subsys_rate(
 	}
 }
 
-static const struct clock_control_driver_api mcux_lpc_syscon_api = {
+static DEVICE_API(clock_control, mcux_lpc_syscon_api) = {
 	.on = mcux_lpc_syscon_clock_control_on,
 	.off = mcux_lpc_syscon_clock_control_off,
 	.get_rate = mcux_lpc_syscon_clock_control_get_subsys_rate,

--- a/drivers/clock_control/clock_control_npcm.c
+++ b/drivers/clock_control/clock_control_npcm.c
@@ -301,7 +301,7 @@ static int npcm_clock_control_get_subsys_rate(const struct device *dev,
 }
 
 /* Clock controller driver registration */
-static struct clock_control_driver_api npcm_clock_control_api = {
+static DEVICE_API(clock_control, npcm_clock_control_api) = {
 	.on = npcm_clock_control_on,
 	.off = npcm_clock_control_off,
 	.get_rate = npcm_clock_control_get_subsys_rate,

--- a/drivers/clock_control/clock_control_npcx.c
+++ b/drivers/clock_control/clock_control_npcx.c
@@ -148,7 +148,7 @@ void npcx_clock_control_turn_off_system_sleep(void)
 #endif /* CONFIG_PM */
 
 /* Clock controller driver registration */
-static const struct clock_control_driver_api npcx_clock_control_api = {
+static DEVICE_API(clock_control, npcx_clock_control_api) = {
 	.on = npcx_clock_control_on,
 	.off = npcx_clock_control_off,
 	.get_rate = npcx_clock_control_get_subsys_rate,

--- a/drivers/clock_control/clock_control_nrf.c
+++ b/drivers/clock_control/clock_control_nrf.c
@@ -692,7 +692,7 @@ static int clk_init(const struct device *dev)
 	return 0;
 }
 
-static const struct clock_control_driver_api clock_control_api = {
+static DEVICE_API(clock_control, clock_control_api) = {
 	.on = api_blocking_start,
 	.off = api_stop,
 	.async_on = api_start,

--- a/drivers/clock_control/clock_control_nrf_auxpll.c
+++ b/drivers/clock_control/clock_control_nrf_auxpll.c
@@ -99,7 +99,7 @@ static enum clock_control_status clock_control_nrf_auxpll_get_status(const struc
 	return CLOCK_CONTROL_STATUS_OFF;
 }
 
-static const struct clock_control_driver_api clock_control_nrf_auxpll_api = {
+static DEVICE_API(clock_control, clock_control_nrf_auxpll_api) = {
 	.on = clock_control_nrf_auxpll_on,
 	.off = clock_control_nrf_auxpll_off,
 	.get_rate = clock_control_nrf_auxpll_get_rate,

--- a/drivers/clock_control/clock_control_numaker_scc.c
+++ b/drivers/clock_control/clock_control_numaker_scc.c
@@ -95,7 +95,7 @@ static inline int numaker_scc_configure(const struct device *dev, clock_control_
 }
 
 /* System clock controller driver registration */
-static const struct clock_control_driver_api numaker_scc_api = {
+static DEVICE_API(clock_control, numaker_scc_api) = {
 	.on = numaker_scc_on,
 	.off = numaker_scc_off,
 	.get_rate = numaker_scc_get_rate,

--- a/drivers/clock_control/clock_control_nxp_s32.c
+++ b/drivers/clock_control/clock_control_nxp_s32.c
@@ -67,7 +67,7 @@ static int nxp_s32_clock_init(const struct device *dev)
 	return (status == CLOCK_IP_SUCCESS ? 0 : -EIO);
 }
 
-static const struct clock_control_driver_api nxp_s32_clock_driver_api = {
+static DEVICE_API(clock_control, nxp_s32_clock_driver_api) = {
 	.on = nxp_s32_clock_on,
 	.off = nxp_s32_clock_off,
 	.get_rate = nxp_s32_clock_get_rate,

--- a/drivers/clock_control/clock_control_pwm.c
+++ b/drivers/clock_control/clock_control_pwm.c
@@ -129,7 +129,7 @@ static int clock_control_pwm_init(const struct device *dev)
 	return 0;
 }
 
-static const struct clock_control_driver_api clock_control_pwm_api = {
+static DEVICE_API(clock_control, clock_control_pwm_api) = {
 	.on = clock_control_pwm_on,
 	.get_rate = clock_control_pwm_get_rate,
 	.set_rate = clock_control_pwm_set_rate,

--- a/drivers/clock_control/clock_control_r8a7795_cpg_mssr.c
+++ b/drivers/clock_control/clock_control_r8a7795_cpg_mssr.c
@@ -263,7 +263,7 @@ static int r8a7795_cpg_mssr_init(const struct device *dev)
 	return 0;
 }
 
-static const struct clock_control_driver_api r8a7795_cpg_mssr_api = {
+static DEVICE_API(clock_control, r8a7795_cpg_mssr_api) = {
 	.on = r8a7795_cpg_mssr_start,
 	.off = r8a7795_cpg_mssr_stop,
 	.get_rate = rcar_cpg_get_rate,

--- a/drivers/clock_control/clock_control_r8a779f0_cpg_mssr.c
+++ b/drivers/clock_control/clock_control_r8a779f0_cpg_mssr.c
@@ -254,7 +254,7 @@ static int r8a779f0_cpg_mssr_init(const struct device *dev)
 	return 0;
 }
 
-static const struct clock_control_driver_api r8a779f0_cpg_mssr_api = {
+static DEVICE_API(clock_control, r8a779f0_cpg_mssr_api) = {
 	.on = r8a779f0_cpg_mssr_start,
 	.off = r8a779f0_cpg_mssr_stop,
 	.get_rate = rcar_cpg_get_rate,

--- a/drivers/clock_control/clock_control_renesas_ra_cgc.c
+++ b/drivers/clock_control/clock_control_renesas_ra_cgc.c
@@ -81,7 +81,7 @@ static int clock_control_ra_init(const struct device *dev)
 	return 0;
 }
 
-static const struct clock_control_driver_api clock_control_reneas_ra_api = {
+static DEVICE_API(clock_control, clock_control_reneas_ra_api) = {
 	.on = clock_control_renesas_ra_on,
 	.off = clock_control_renesas_ra_off,
 	.get_rate = clock_control_renesas_ra_get_rate,

--- a/drivers/clock_control/clock_control_rpi_pico.c
+++ b/drivers/clock_control/clock_control_rpi_pico.c
@@ -721,7 +721,7 @@ static int clock_control_rpi_pico_init(const struct device *dev)
 	return 0;
 }
 
-static const struct clock_control_driver_api clock_control_rpi_pico_api = {
+static DEVICE_API(clock_control, clock_control_rpi_pico_api) = {
 	.on = clock_control_rpi_pico_on,
 	.off = clock_control_rpi_pico_off,
 	.get_rate = clock_control_rpi_pico_get_rate,

--- a/drivers/clock_control/clock_control_rv32m1_pcc.c
+++ b/drivers/clock_control/clock_control_rv32m1_pcc.c
@@ -51,7 +51,7 @@ static int rv32m1_pcc_get_rate(const struct device *dev,
 	return 0;
 }
 
-static const struct clock_control_driver_api rv32m1_pcc_api = {
+static DEVICE_API(clock_control, rv32m1_pcc_api) = {
 	.on = rv32m1_pcc_on,
 	.off = rv32m1_pcc_off,
 	.get_rate = rv32m1_pcc_get_rate,

--- a/drivers/clock_control/clock_control_sam_pmc.c
+++ b/drivers/clock_control/clock_control_sam_pmc.c
@@ -129,7 +129,7 @@ atmel_sam_clock_control_get_status(const struct device *dev,
 	return status;
 }
 
-static const struct clock_control_driver_api atmel_sam_clock_control_api = {
+static DEVICE_API(clock_control, atmel_sam_clock_control_api) = {
 	.on = atmel_sam_clock_control_on,
 	.off = atmel_sam_clock_control_off,
 	.get_rate = atmel_sam_clock_control_get_rate,

--- a/drivers/clock_control/clock_control_si32_ahb.c
+++ b/drivers/clock_control/clock_control_si32_ahb.c
@@ -44,7 +44,7 @@ static int clock_control_si32_ahb_get_rate(const struct device *dev, clock_contr
 	return 0;
 }
 
-static struct clock_control_driver_api clock_control_si32_ahb_api = {
+static DEVICE_API(clock_control, clock_control_si32_ahb_api) = {
 	.on = clock_control_si32_ahb_on,
 	.off = clock_control_si32_ahb_off,
 	.get_rate = clock_control_si32_ahb_get_rate,

--- a/drivers/clock_control/clock_control_si32_apb.c
+++ b/drivers/clock_control/clock_control_si32_apb.c
@@ -46,7 +46,7 @@ static int clock_control_si32_apb_get_rate(const struct device *dev, clock_contr
 	return 0;
 }
 
-static struct clock_control_driver_api clock_control_si32_apb_api = {
+static DEVICE_API(clock_control, clock_control_si32_apb_api) = {
 	.on = clock_control_si32_apb_on,
 	.off = clock_control_si32_apb_off,
 	.get_rate = clock_control_si32_apb_get_rate,

--- a/drivers/clock_control/clock_control_si32_pll.c
+++ b/drivers/clock_control/clock_control_si32_pll.c
@@ -113,7 +113,7 @@ static int clock_control_si32_pll_set_rate(const struct device *dev, clock_contr
 	return 0;
 }
 
-static struct clock_control_driver_api clock_control_si32_pll_api = {
+static DEVICE_API(clock_control, clock_control_si32_pll_api) = {
 	.on = clock_control_si32_pll_on,
 	.off = clock_control_si32_pll_off,
 	.get_rate = clock_control_si32_pll_get_rate,

--- a/drivers/clock_control/clock_control_silabs_series.c
+++ b/drivers/clock_control/clock_control_silabs_series.c
@@ -112,7 +112,7 @@ static int silabs_clock_control_init(const struct device *dev)
 	return 0;
 }
 
-static const struct clock_control_driver_api silabs_clock_control_api = {
+static DEVICE_API(clock_control, silabs_clock_control_api) = {
 	.on = silabs_clock_control_on,
 	.off = silabs_clock_control_off,
 	.get_rate = silabs_clock_control_get_rate,

--- a/drivers/clock_control/clock_control_smartbond.c
+++ b/drivers/clock_control/clock_control_smartbond.c
@@ -603,7 +603,7 @@ int smartbond_clocks_init(const struct device *dev)
 	return 0;
 }
 
-static const struct clock_control_driver_api smartbond_clock_control_api = {
+static DEVICE_API(clock_control, smartbond_clock_control_api) = {
 	.on = smartbond_clock_control_on,
 	.off = smartbond_clock_control_off,
 	.get_rate = smartbond_clock_control_get_rate,

--- a/drivers/clock_control/clock_control_wch_rcc.c
+++ b/drivers/clock_control/clock_control_wch_rcc.c
@@ -84,7 +84,7 @@ static int clock_control_wch_rcc_get_rate(const struct device *dev, clock_contro
 	return 0;
 }
 
-static struct clock_control_driver_api clock_control_wch_rcc_api = {
+static DEVICE_API(clock_control, clock_control_wch_rcc_api) = {
 	.on = clock_control_wch_rcc_on,
 	.get_rate = clock_control_wch_rcc_get_rate,
 };

--- a/drivers/clock_control/clock_stm32_ll_common.c
+++ b/drivers/clock_control/clock_stm32_ll_common.c
@@ -498,7 +498,7 @@ static enum clock_control_status stm32_clock_control_get_status(const struct dev
 	}
 }
 
-static const struct clock_control_driver_api stm32_clock_control_api = {
+static DEVICE_API(clock_control, stm32_clock_control_api) = {
 	.on = stm32_clock_control_on,
 	.off = stm32_clock_control_off,
 	.get_rate = stm32_clock_control_get_subsys_rate,

--- a/drivers/clock_control/clock_stm32_ll_h5.c
+++ b/drivers/clock_control/clock_stm32_ll_h5.c
@@ -346,7 +346,7 @@ static int stm32_clock_control_get_subsys_rate(const struct device *dev,
 	return 0;
 }
 
-static const struct clock_control_driver_api stm32_clock_control_api = {
+static DEVICE_API(clock_control, stm32_clock_control_api) = {
 	.on = stm32_clock_control_on,
 	.off = stm32_clock_control_off,
 	.get_rate = stm32_clock_control_get_subsys_rate,

--- a/drivers/clock_control/clock_stm32_ll_h7.c
+++ b/drivers/clock_control/clock_stm32_ll_h7.c
@@ -645,7 +645,7 @@ static int stm32_clock_control_get_subsys_rate(const struct device *clock,
 	return 0;
 }
 
-static const struct clock_control_driver_api stm32_clock_control_api = {
+static DEVICE_API(clock_control, stm32_clock_control_api) = {
 	.on = stm32_clock_control_on,
 	.off = stm32_clock_control_off,
 	.get_rate = stm32_clock_control_get_subsys_rate,

--- a/drivers/clock_control/clock_stm32_ll_mp1.c
+++ b/drivers/clock_control/clock_stm32_ll_mp1.c
@@ -393,7 +393,7 @@ static int stm32_clock_control_get_subsys_rate(const struct device *clock,
 	return 0;
 }
 
-static const struct clock_control_driver_api stm32_clock_control_api = {
+static DEVICE_API(clock_control, stm32_clock_control_api) = {
 	.on = stm32_clock_control_on,
 	.off = stm32_clock_control_off,
 	.get_rate = stm32_clock_control_get_subsys_rate,

--- a/drivers/clock_control/clock_stm32_ll_u5.c
+++ b/drivers/clock_control/clock_stm32_ll_u5.c
@@ -385,7 +385,7 @@ static enum clock_control_status stm32_clock_control_get_status(const struct dev
 	}
 }
 
-static const struct clock_control_driver_api stm32_clock_control_api = {
+static DEVICE_API(clock_control, stm32_clock_control_api) = {
 	.on = stm32_clock_control_on,
 	.off = stm32_clock_control_off,
 	.get_rate = stm32_clock_control_get_subsys_rate,

--- a/drivers/clock_control/clock_stm32_ll_wb0.c
+++ b/drivers/clock_control/clock_stm32_ll_wb0.c
@@ -521,7 +521,7 @@ static enum clock_control_status stm32_clock_control_get_status(const struct dev
 	}
 }
 
-static struct clock_control_driver_api stm32_clock_control_api = {
+static DEVICE_API(clock_control, stm32_clock_control_api) = {
 	.on = stm32_clock_control_on,
 	.off = stm32_clock_control_off,
 	.get_rate = stm32_clock_control_get_subsys_rate,

--- a/drivers/clock_control/clock_stm32_ll_wba.c
+++ b/drivers/clock_control/clock_stm32_ll_wba.c
@@ -299,7 +299,7 @@ static enum clock_control_status stm32_clock_control_get_status(const struct dev
 	}
 }
 
-static const struct clock_control_driver_api stm32_clock_control_api = {
+static DEVICE_API(clock_control, stm32_clock_control_api) = {
 	.on = stm32_clock_control_on,
 	.off = stm32_clock_control_off,
 	.get_rate = stm32_clock_control_get_subsys_rate,


### PR DESCRIPTION
Add wrapper DEVICE_API macro to all clock_control_driver_api instances.