### PR TITLE
Boards: Infineon: XMC47 Relax kit: Added buttons to device tree

### DIFF
--- a/boards/infineon/xmc47_relax_kit/xmc47_relax_kit.dts
+++ b/boards/infineon/xmc47_relax_kit/xmc47_relax_kit.dts
@@ -19,6 +19,7 @@
 
 	aliases {
 		led0 = &led1;
+		sw0 = &button1;
 		die-temp0 = &die_temp;
 		pwm-led0 = &pwm_led1;
 		watchdog0 = &wdt0;
@@ -35,6 +36,16 @@
 			gpios = <&gpio5 8 GPIO_ACTIVE_HIGH>;
 		};
 	};
+
+	buttons {
+		compatible = "gpio-keys";
+		button1: button1 {
+			gpios = < &gpio15 12 GPIO_ACTIVE_LOW >;
+		};
+		button2: button2 {
+			gpios = < &gpio15 13 GPIO_ACTIVE_LOW >;
+		};
+	};	
 
 	pwmleds {
 		compatible = "pwm-leds";
@@ -159,6 +170,10 @@
 };
 
 &gpio5 {
+	status = "okay";
+};
+
+&gpio15 {
 	status = "okay";
 };
 

--- a/boards/infineon/xmc47_relax_kit/xmc47_relax_kit.dts
+++ b/boards/infineon/xmc47_relax_kit/xmc47_relax_kit.dts
@@ -45,7 +45,7 @@
 		button2: button2 {
 			gpios = < &gpio15 13 GPIO_ACTIVE_LOW >;
 		};
-	};	
+	};
 
 	pwmleds {
 		compatible = "pwm-leds";


### PR DESCRIPTION
[The XMC47 Relax kit](https://www.infineon.com/cms/de/product/evaluation-boards/kit_xmc47_relax_v1/) is equipped with two buttons. 
This pull request adds the two buttons to the devicetree file of the board. 

