### PR TITLE
drivers: stepper: api: rename enable_constant_velocity_mode to run

### DIFF
--- a/doc/hardware/peripherals/stepper.rst
+++ b/doc/hardware/peripherals/stepper.rst
@@ -22,7 +22,7 @@ Control Stepper
 - **Move to** a specific position also known as **absolute movement**
   using :c:func:`stepper_set_target_position`.
 - Run continuously with a **constant velocity** in a specific direction until
-  a stop is detected using :c:func:`stepper_enable_constant_velocity_mode`.
+  a stop is detected using :c:func:`stepper_run`.
 - Check if the stepper is **moving** using :c:func:`stepper_is_moving`.
 - Register an **event callback** using :c:func:`stepper_set_event_callback`.
 

--- a/doc/releases/migration-guide-4.1.rst
+++ b/doc/releases/migration-guide-4.1.rst
@@ -158,6 +158,7 @@ Stepper
 
   * Renamed the ``compatible`` from ``zephyr,gpio-steppers`` to :dtcompatible:`zephyr,gpio-stepper`.
   * Renamed the ``stepper_set_actual_position`` function to :c:func:`stepper_set_reference_position`.
+  * Renamed the ``stepper_enable_constant_velocity_mode`` function to :c:func:`stepper_run`.
 
 SPI
 ===

--- a/drivers/stepper/adi_tmc/adi_tmc5041_stepper_controller.c
+++ b/drivers/stepper/adi_tmc/adi_tmc5041_stepper_controller.c
@@ -477,11 +477,10 @@ static int tmc5041_stepper_set_target_position(const struct device *dev, const i
 	return 0;
 }
 
-static int tmc5041_stepper_enable_constant_velocity_mode(const struct device *dev,
-							 const enum stepper_direction direction,
-							 const uint32_t velocity)
+static int tmc5041_stepper_run(const struct device *dev, const enum stepper_direction direction,
+			       const uint32_t velocity)
 {
-	LOG_DBG("Stepper motor controller %s enable constant velocity mode", dev->name);
+	LOG_DBG("Stepper motor controller %s run with velocity %d", dev->name, velocity);
 	const struct tmc5041_stepper_config *config = dev->config;
 	const struct tmc5041_config *tmc5041_config = config->controller->config;
 	struct tmc5041_stepper_data *data = dev->data;
@@ -731,7 +730,7 @@ static int tmc5041_stepper_init(const struct device *dev)
 		.set_reference_position = tmc5041_stepper_set_reference_position,		\
 		.get_actual_position = tmc5041_stepper_get_actual_position,			\
 		.set_target_position = tmc5041_stepper_set_target_position,			\
-		.enable_constant_velocity_mode = tmc5041_stepper_enable_constant_velocity_mode,	\
+		.run = tmc5041_stepper_run,							\
 		.set_event_callback = tmc5041_stepper_set_event_callback, };
 
 #define TMC5041_STEPPER_DEFINE(child)								\

--- a/drivers/stepper/fake_stepper_controller.c
+++ b/drivers/stepper/fake_stepper_controller.c
@@ -39,8 +39,8 @@ DEFINE_FAKE_VALUE_FUNC(int, fake_stepper_get_actual_position, const struct devic
 
 DEFINE_FAKE_VALUE_FUNC(int, fake_stepper_set_target_position, const struct device *, int32_t);
 
-DEFINE_FAKE_VALUE_FUNC(int, fake_stepper_enable_constant_velocity_mode, const struct device *,
-		       enum stepper_direction, uint32_t);
+DEFINE_FAKE_VALUE_FUNC(int, fake_stepper_run, const struct device *, enum stepper_direction,
+		       uint32_t);
 
 DEFINE_FAKE_VALUE_FUNC(int, fake_stepper_set_event_callback, const struct device *,
 		       stepper_event_callback_t, void *);
@@ -98,7 +98,7 @@ static void fake_stepper_reset_rule_before(const struct ztest_unit_test *test, v
 	RESET_FAKE(fake_stepper_set_reference_position);
 	RESET_FAKE(fake_stepper_get_actual_position);
 	RESET_FAKE(fake_stepper_set_target_position);
-	RESET_FAKE(fake_stepper_enable_constant_velocity_mode);
+	RESET_FAKE(fake_stepper_run);
 
 	/* Install custom fakes for the setter and getter functions */
 	fake_stepper_set_micro_step_res_fake.custom_fake = fake_stepper_set_micro_step_res_delegate;
@@ -134,7 +134,7 @@ static DEVICE_API(stepper, fake_stepper_driver_api) = {
 	.set_reference_position = fake_stepper_set_reference_position,
 	.get_actual_position = fake_stepper_get_actual_position,
 	.set_target_position = fake_stepper_set_target_position,
-	.enable_constant_velocity_mode = fake_stepper_enable_constant_velocity_mode,
+	.run = fake_stepper_run,
 	.set_event_callback = fake_stepper_set_event_callback,
 };
 

--- a/drivers/stepper/gpio_stepper_controller.c
+++ b/drivers/stepper/gpio_stepper_controller.c
@@ -261,17 +261,16 @@ static int gpio_stepper_set_max_velocity(const struct device *dev, uint32_t velo
 	return 0;
 }
 
-static int gpio_stepper_enable_constant_velocity_mode(const struct device *dev,
-						      const enum stepper_direction direction,
-						      const uint32_t value)
+static int gpio_stepper_run(const struct device *dev, const enum stepper_direction direction,
+			    const uint32_t velocity)
 {
 	struct gpio_stepper_data *data = dev->data;
 
 	K_SPINLOCK(&data->lock) {
 		data->run_mode = STEPPER_RUN_MODE_VELOCITY;
 		data->direction = direction;
-		if (value != 0) {
-			data->delay_in_us = USEC_PER_SEC / value;
+		if (velocity != 0) {
+			data->delay_in_us = USEC_PER_SEC / velocity;
 			(void)k_work_reschedule(&data->stepper_dwork, K_NO_WAIT);
 		} else {
 			(void)k_work_cancel_delayable(&data->stepper_dwork);
@@ -360,7 +359,7 @@ static DEVICE_API(stepper, gpio_stepper_api) = {
 	.get_actual_position = gpio_stepper_get_actual_position,
 	.set_target_position = gpio_stepper_set_target_position,
 	.set_max_velocity = gpio_stepper_set_max_velocity,
-	.enable_constant_velocity_mode = gpio_stepper_enable_constant_velocity_mode,
+	.run = gpio_stepper_run,
 	.set_micro_step_res = gpio_stepper_set_micro_step_res,
 	.get_micro_step_res = gpio_stepper_get_micro_step_res,
 	.set_event_callback = gpio_stepper_set_event_callback,

--- a/drivers/stepper/stepper_shell.c
+++ b/drivers/stepper/stepper_shell.c
@@ -366,8 +366,7 @@ static int cmd_stepper_set_target_position(const struct shell *sh, size_t argc, 
 	return err;
 }
 
-static int cmd_stepper_enable_constant_velocity_mode(const struct shell *sh, size_t argc,
-						     char **argv)
+static int cmd_stepper_run(const struct shell *sh, size_t argc, char **argv)
 {
 	const struct device *dev;
 	int err = -EINVAL;
@@ -401,7 +400,7 @@ static int cmd_stepper_enable_constant_velocity_mode(const struct shell *sh, siz
 		shell_error(sh, "Failed to set callback: %d", err);
 	}
 
-	err = stepper_enable_constant_velocity_mode(dev, direction, velocity);
+	err = stepper_run(dev, direction, velocity);
 	if (err) {
 		shell_error(sh, "Error: %d", err);
 		return err;
@@ -468,9 +467,8 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 		      cmd_stepper_get_actual_position, 2, 0),
 	SHELL_CMD_ARG(set_target_position, &dsub_pos_stepper_motor_name, "<device> <micro_steps>",
 		      cmd_stepper_set_target_position, 3, 0),
-	SHELL_CMD_ARG(enable_constant_velocity_mode, &dsub_pos_stepper_motor_name_dir,
-		      "<device> <direction> <velocity>", cmd_stepper_enable_constant_velocity_mode,
-		      4, 0),
+	SHELL_CMD_ARG(run, &dsub_pos_stepper_motor_name_dir, "<device> <direction> <velocity>",
+		      cmd_stepper_run, 4, 0),
 	SHELL_CMD_ARG(info, &dsub_pos_stepper_motor_name, "<device>", cmd_stepper_info, 2, 0),
 	SHELL_SUBCMD_SET_END);
 

--- a/include/zephyr/drivers/stepper/stepper_fake.h
+++ b/include/zephyr/drivers/stepper/stepper_fake.h
@@ -34,8 +34,8 @@ DECLARE_FAKE_VALUE_FUNC(int, fake_stepper_set_target_position, const struct devi
 
 DECLARE_FAKE_VALUE_FUNC(int, fake_stepper_is_moving, const struct device *, bool *);
 
-DECLARE_FAKE_VALUE_FUNC(int, fake_stepper_enable_constant_velocity_mode, const struct device *,
-			enum stepper_direction, uint32_t);
+DECLARE_FAKE_VALUE_FUNC(int, fake_stepper_run, const struct device *, enum stepper_direction,
+			uint32_t);
 
 DECLARE_FAKE_VALUE_FUNC(int, fake_stepper_set_event_callback, const struct device *,
 			stepper_event_callback_t, void *);

--- a/tests/drivers/stepper/shell/src/main.c
+++ b/tests/drivers/stepper/shell/src/main.c
@@ -127,27 +127,23 @@ ZTEST(stepper_shell, test_stepper_set_target_position)
 		      "wrong target position value");
 }
 
-ZTEST(stepper_shell, test_stepper_enable_constant_velocity_mode)
+ZTEST(stepper_shell, test_stepper_run)
 {
 	const struct shell *sh = shell_backend_dummy_get_ptr();
-	int err = shell_execute_cmd(sh, "stepper enable_constant_velocity_mode " FAKE_STEPPER_NAME
-					" positive 200");
+	int err = shell_execute_cmd(sh, "stepper run " FAKE_STEPPER_NAME " positive 200");
 
-	ASSERT_STEPPER_FUNC_CALLED(fake_stepper_enable_constant_velocity_mode_fake, err);
-	zassert_equal(fake_stepper_enable_constant_velocity_mode_fake.arg1_val,
-		      STEPPER_DIRECTION_POSITIVE, "wrong direction value");
-	zassert_equal(fake_stepper_enable_constant_velocity_mode_fake.arg2_val, 200,
-		      "wrong velocity value");
+	ASSERT_STEPPER_FUNC_CALLED(fake_stepper_run_fake, err);
+	zassert_equal(fake_stepper_run_fake.arg1_val, STEPPER_DIRECTION_POSITIVE,
+		      "wrong direction value");
+	zassert_equal(fake_stepper_run_fake.arg2_val, 200, "wrong velocity value");
 }
 
-ZTEST(stepper_shell, test_stepper_enable_constant_velocity_mode_invalid_direction)
+ZTEST(stepper_shell, test_stepper_run_invalid_direction)
 {
 	const struct shell *sh = shell_backend_dummy_get_ptr();
-	int err = shell_execute_cmd(sh, "stepper enable_constant_velocity_mode " FAKE_STEPPER_NAME
-					" foo 200");
+	int err = shell_execute_cmd(sh, "stepper run " FAKE_STEPPER_NAME " foo 200");
 
-	zassert_not_equal(err, 0,
-			  " executed enable_constant_velocity_mode with invalid direction value");
+	zassert_not_equal(err, 0, " executed run with invalid direction value");
 }
 
 ZTEST(stepper_shell, test_stepper_info)


### PR DESCRIPTION
rename enable_constant_velocity_mode to run in following files:
- include/zephyr/drivers/stepper.h
- include/zephyr/drivers/stepper/stepper_fake.h
- doc/hardware/peripherals/stepper.rst
- doc/releases/migration-guide-4.1.rst
- drivers/stepper/adi_tmc/adi_tmc5041_stepper_controller.c
- drivers/stepper/fake_stepper_controller.c
- drivers/stepper/gpio_stepper_controller.c
- drivers/stepper/stepper_shell.c
- tests/drivers/stepper/shell/src/main.c