### PR TITLE
dts: arm: renesas: smartbond: add dma configuration to spi node

### DIFF
--- a/drivers/spi/Kconfig.smartbond
+++ b/drivers/spi/Kconfig.smartbond
@@ -11,10 +11,9 @@ config SPI_SMARTBOND
 
 config SPI_SMARTBOND_DMA
 	bool "Renesas Smartbond(tm) SPI with DMA acceleration"
-	default y
 	depends on SPI_SMARTBOND
 	select DMA
 	help
 	  Enables using the DMA engine instead of interrupt-driven
 	  approach. This acceleration is available only for
-	  asynchronous transfers.
+	  synchronous transfers.


### PR DESCRIPTION
The Smartbond SPI driver uses DMA acceleration by default. However no DMA configuration is provided in the SPI node, resulting in run time errors when the SPI interface is used.