### PR TITLE
drivers: coredump: Place API into iterable section

### DIFF
--- a/drivers/coredump/coredump_impl.c
+++ b/drivers/coredump/coredump_impl.c
@@ -126,7 +126,7 @@ static int coredump_init(const struct device *dev)
 	return 0;
 }
 
-static const struct coredump_driver_api coredump_api = {
+static DEVICE_API(coredump, coredump_api) = {
 	.dump = coredump_impl_dump,
 	.register_memory = coredump_impl_register_memory,
 	.unregister_memory = coredump_impl_unregister_memory,

--- a/subsys/debug/coredump/coredump_core.c
+++ b/subsys/debug/coredump/coredump_core.c
@@ -101,9 +101,7 @@ static void dump_thread(struct k_thread *thread)
 #if defined(CONFIG_COREDUMP_DEVICE)
 static void process_coredump_dev_memory(const struct device *dev)
 {
-	struct coredump_driver_api *api = (struct coredump_driver_api *)dev->api;
-
-	api->dump(dev);
+	DEVICE_API_GET(coredump, dev)->dump(dev);
 }
 #endif
 


### PR DESCRIPTION
Add wrapper DEVICE_API macro to all coredump_driver_api instances.