### PR TITLE
drivers: counter: Place API into iterable section

### DIFF
--- a/drivers/counter/counter_ace_v1x_art.c
+++ b/drivers/counter/counter_ace_v1x_art.c
@@ -102,7 +102,7 @@ int counter_ace_v1x_art_get_value(const struct device *dev, uint64_t *value)
 	return 0;
 }
 
-static const struct counter_driver_api ace_v1x_art_counter_apis = {
+static DEVICE_API(counter, ace_v1x_art_counter_apis) = {
 	.get_value_64 = counter_ace_v1x_art_get_value
 };
 

--- a/drivers/counter/counter_ace_v1x_rtc.c
+++ b/drivers/counter/counter_ace_v1x_rtc.c
@@ -35,7 +35,7 @@ int counter_ace_v1x_rtc_init(const struct device *dev)
 	return 0;
 }
 
-static const struct counter_driver_api ace_v1x_rtc_counter_apis = {
+static DEVICE_API(counter, ace_v1x_rtc_counter_apis) = {
 	.get_value_64 = counter_ace_v1x_rtc_get_value
 };
 

--- a/drivers/counter/counter_ambiq_timer.c
+++ b/drivers/counter/counter_ambiq_timer.c
@@ -229,7 +229,7 @@ static uint32_t counter_ambiq_get_top_value(const struct device *dev)
 	return config->counter_info.max_top_value;
 }
 
-static const struct counter_driver_api counter_api = {
+static DEVICE_API(counter, counter_api) = {
 	.start = counter_ambiq_start,
 	.stop = counter_ambiq_stop,
 	.get_value = counter_ambiq_get_value,

--- a/drivers/counter/counter_andes_atcpit100.c
+++ b/drivers/counter/counter_andes_atcpit100.c
@@ -462,7 +462,7 @@ static int atcpit100_set_guard_period(const struct device *dev,
 	return 0;
 }
 
-static const struct counter_driver_api atcpit100_driver_api = {
+static DEVICE_API(counter, atcpit100_driver_api) = {
 	.start = atcpit100_start,
 	.stop = atcpit100_stop,
 	.get_value = atcpit100_get_value,

--- a/drivers/counter/counter_cmos.c
+++ b/drivers/counter/counter_cmos.c
@@ -199,7 +199,7 @@ static const struct counter_config_info info = {
 	.freq = 1
 };
 
-static const struct counter_driver_api api = {
+static DEVICE_API(counter, api) = {
 	.get_value = get_value
 };
 

--- a/drivers/counter/counter_dw_timer.c
+++ b/drivers/counter/counter_dw_timer.c
@@ -297,7 +297,7 @@ uint32_t counter_dw_timer_get_freq(const struct device *timer_dev)
 #endif
 }
 
-static const struct counter_driver_api dw_timer_driver_api = {
+static DEVICE_API(counter, dw_timer_driver_api) = {
 	.start = counter_dw_timer_start,
 	.stop = counter_dw_timer_disable,
 	.get_value = counter_dw_timer_get_value,

--- a/drivers/counter/counter_esp32_rtc.c
+++ b/drivers/counter/counter_esp32_rtc.c
@@ -210,7 +210,7 @@ static const struct counter_esp32_config counter_config = {
 	.irq_flags = DT_INST_IRQ_BY_IDX(0, 0, flags)
 };
 
-static const struct counter_driver_api rtc_timer_esp32_api = {
+static DEVICE_API(counter, rtc_timer_esp32_api) = {
 	.start = counter_esp32_start,
 	.stop = counter_esp32_stop,
 	.get_value = counter_esp32_get_value,

--- a/drivers/counter/counter_esp32_tmr.c
+++ b/drivers/counter/counter_esp32_tmr.c
@@ -227,7 +227,7 @@ static uint32_t counter_esp32_get_top_value(const struct device *dev)
 	return config->counter_info.max_top_value;
 }
 
-static const struct counter_driver_api counter_api = {
+static DEVICE_API(counter, counter_api) = {
 	.start = counter_esp32_start,
 	.stop = counter_esp32_stop,
 	.get_value = counter_esp32_get_value,

--- a/drivers/counter/counter_gd32_timer.c
+++ b/drivers/counter/counter_gd32_timer.c
@@ -448,7 +448,7 @@ static int counter_gd32_timer_init(const struct device *dev)
 	return 0;
 }
 
-static const struct counter_driver_api counter_api = {
+static DEVICE_API(counter, counter_api) = {
 	.start = counter_gd32_timer_start,
 	.stop = counter_gd32_timer_stop,
 	.get_value = counter_gd32_timer_get_value,

--- a/drivers/counter/counter_gecko_rtcc.c
+++ b/drivers/counter/counter_gecko_rtcc.c
@@ -305,7 +305,7 @@ static int counter_gecko_init(const struct device *dev)
 	return 0;
 }
 
-static const struct counter_driver_api counter_gecko_driver_api = {
+static DEVICE_API(counter, counter_gecko_driver_api) = {
 	.start = counter_gecko_start,
 	.stop = counter_gecko_stop,
 	.get_value = counter_gecko_get_value,

--- a/drivers/counter/counter_gecko_stimer.c
+++ b/drivers/counter/counter_gecko_stimer.c
@@ -266,7 +266,7 @@ static int counter_gecko_init(const struct device *dev)
 	return 0;
 }
 
-static const struct counter_driver_api counter_gecko_driver_api = {
+static DEVICE_API(counter, counter_gecko_driver_api) = {
 	.start = counter_gecko_start,
 	.stop = counter_gecko_stop,
 	.get_value = counter_gecko_get_value,

--- a/drivers/counter/counter_ifx_cat1.c
+++ b/drivers/counter/counter_ifx_cat1.c
@@ -485,7 +485,7 @@ static int ifx_cat1_counter_set_guard_period(const struct device *dev, uint32_t 
 	return 0;
 }
 
-static const struct counter_driver_api counter_api = {
+static DEVICE_API(counter, counter_api) = {
 	.start = ifx_cat1_counter_start,
 	.stop = ifx_cat1_counter_stop,
 	.get_value = ifx_cat1_counter_get_value,

--- a/drivers/counter/counter_imx_epit.c
+++ b/drivers/counter/counter_imx_epit.c
@@ -135,7 +135,7 @@ static uint32_t imx_epit_get_top_value(const struct device *dev)
 	return EPIT_GetCounterLoadValue(base);
 }
 
-static const struct counter_driver_api imx_epit_driver_api = {
+static DEVICE_API(counter, imx_epit_driver_api) = {
 	.start = imx_epit_start,
 	.stop = imx_epit_stop,
 	.get_value = imx_epit_get_value,

--- a/drivers/counter/counter_ll_stm32_rtc.c
+++ b/drivers/counter/counter_ll_stm32_rtc.c
@@ -672,7 +672,7 @@ static int rtc_stm32_pm_action(const struct device *dev,
 }
 #endif /* CONFIG_PM_DEVICE */
 
-static const struct counter_driver_api rtc_stm32_driver_api = {
+static DEVICE_API(counter, rtc_stm32_driver_api) = {
 	.start = rtc_stm32_start,
 	.stop = rtc_stm32_stop,
 	.get_value = rtc_stm32_get_value,

--- a/drivers/counter/counter_ll_stm32_timer.c
+++ b/drivers/counter/counter_ll_stm32_timer.c
@@ -570,7 +570,7 @@ static void counter_stm32_alarm_irq_handle(const struct device *dev, uint32_t id
 	}
 }
 
-static const struct counter_driver_api counter_stm32_driver_api = {
+static DEVICE_API(counter, counter_stm32_driver_api) = {
 	.start = counter_stm32_start,
 	.stop = counter_stm32_stop,
 	.get_value = counter_stm32_get_value,

--- a/drivers/counter/counter_max32_rtc.c
+++ b/drivers/counter/counter_max32_rtc.c
@@ -225,7 +225,7 @@ static int rtc_max32_init(const struct device *dev)
 	return 0;
 }
 
-static const struct counter_driver_api counter_rtc_max32_driver_api = {
+static DEVICE_API(counter, counter_rtc_max32_driver_api) = {
 	.start = api_start,
 	.stop = api_stop,
 	.get_value = api_get_value,

--- a/drivers/counter/counter_max32_timer.c
+++ b/drivers/counter/counter_max32_timer.c
@@ -290,7 +290,7 @@ static int max32_counter_init(const struct device *dev)
 	return 0;
 }
 
-static const struct counter_driver_api counter_max32_driver_api = {
+static DEVICE_API(counter, counter_max32_driver_api) = {
 	.start = api_start,
 	.stop = api_stop,
 	.get_value = api_get_value,

--- a/drivers/counter/counter_mchp_xec.c
+++ b/drivers/counter/counter_mchp_xec.c
@@ -274,7 +274,7 @@ static void counter_xec_isr(const struct device *dev)
 	}
 }
 
-static const struct counter_driver_api counter_xec_api = {
+static DEVICE_API(counter, counter_xec_api) = {
 		.start = counter_xec_start,
 		.stop = counter_xec_stop,
 		.get_value = counter_xec_get_value,

--- a/drivers/counter/counter_mcux_ctimer.c
+++ b/drivers/counter/counter_mcux_ctimer.c
@@ -277,7 +277,7 @@ static int mcux_lpc_ctimer_init(const struct device *dev)
 	return 0;
 }
 
-static const struct counter_driver_api mcux_ctimer_driver_api = {
+static DEVICE_API(counter, mcux_ctimer_driver_api) = {
 	.start = mcux_lpc_ctimer_start,
 	.stop = mcux_lpc_ctimer_stop,
 	.get_value = mcux_lpc_ctimer_get_value,

--- a/drivers/counter/counter_mcux_gpt.c
+++ b/drivers/counter/counter_mcux_gpt.c
@@ -213,7 +213,7 @@ static int mcux_gpt_init(const struct device *dev)
 	return 0;
 }
 
-static const struct counter_driver_api mcux_gpt_driver_api = {
+static DEVICE_API(counter, mcux_gpt_driver_api) = {
 	.start = mcux_gpt_start,
 	.stop = mcux_gpt_stop,
 	.get_value = mcux_gpt_get_value,

--- a/drivers/counter/counter_mcux_lpc_rtc.c
+++ b/drivers/counter/counter_mcux_lpc_rtc.c
@@ -219,7 +219,7 @@ static int mcux_lpc_rtc_init(const struct device *dev)
 	return 0;
 }
 
-static const struct counter_driver_api mcux_rtc_driver_api = {
+static DEVICE_API(counter, mcux_rtc_driver_api) = {
 	.start = mcux_lpc_rtc_start,
 	.stop = mcux_lpc_rtc_stop,
 	.get_value = mcux_lpc_rtc_get_value,
@@ -413,7 +413,7 @@ static int mcux_lpc_rtc_highres_init(const struct device *dev)
 	return 0;
 }
 
-static const struct counter_driver_api mcux_rtc_highres_driver_api = {
+static DEVICE_API(counter, mcux_rtc_highres_driver_api) = {
 	.start = mcux_lpc_rtc_highres_start,
 	.stop = mcux_lpc_rtc_highres_stop,
 	.get_value = mcux_lpc_rtc_highres_get_value,

--- a/drivers/counter/counter_mcux_lptmr.c
+++ b/drivers/counter/counter_mcux_lptmr.c
@@ -150,7 +150,7 @@ static int mcux_lptmr_init(const struct device *dev)
 	return 0;
 }
 
-static const struct counter_driver_api mcux_lptmr_driver_api = {
+static DEVICE_API(counter, mcux_lptmr_driver_api) = {
 	.start = mcux_lptmr_start,
 	.stop = mcux_lptmr_stop,
 	.get_value = mcux_lptmr_get_value,

--- a/drivers/counter/counter_mcux_qtmr.c
+++ b/drivers/counter/counter_mcux_qtmr.c
@@ -289,7 +289,7 @@ static int mcux_qtmr_init(const struct device *dev)
 	return 0;
 }
 
-static const struct counter_driver_api mcux_qtmr_driver_api = {
+static DEVICE_API(counter, mcux_qtmr_driver_api) = {
 	.start = mcux_qtmr_start,
 	.stop = mcux_qtmr_stop,
 	.get_value = mcux_qtmr_get_value,

--- a/drivers/counter/counter_mcux_rtc.c
+++ b/drivers/counter/counter_mcux_rtc.c
@@ -262,7 +262,7 @@ static int mcux_rtc_init(const struct device *dev)
 	return 0;
 }
 
-static const struct counter_driver_api mcux_rtc_driver_api = {
+static DEVICE_API(counter, mcux_rtc_driver_api) = {
 	.start = mcux_rtc_start,
 	.stop = mcux_rtc_stop,
 	.get_value = mcux_rtc_get_value,

--- a/drivers/counter/counter_mcux_snvs.c
+++ b/drivers/counter/counter_mcux_snvs.c
@@ -293,7 +293,7 @@ static int mcux_snvs_init(const struct device *dev)
 	return 0;
 }
 
-static const struct counter_driver_api mcux_snvs_driver_api = {
+static DEVICE_API(counter, mcux_snvs_driver_api) = {
 	.start = mcux_snvs_start,
 	.stop = mcux_snvs_stop,
 	.get_value = mcux_snvs_get_value,

--- a/drivers/counter/counter_mcux_tpm.c
+++ b/drivers/counter/counter_mcux_tpm.c
@@ -251,7 +251,7 @@ static int mcux_tpm_init(const struct device *dev)
 	return 0;
 }
 
-static const struct counter_driver_api mcux_tpm_driver_api = {
+static DEVICE_API(counter, mcux_tpm_driver_api) = {
 	.start = mcux_tpm_start,
 	.stop = mcux_tpm_stop,
 	.get_value = mcux_tpm_get_value,

--- a/drivers/counter/counter_native_posix.c
+++ b/drivers/counter/counter_native_posix.c
@@ -227,7 +227,7 @@ static int ctr_cancel_alarm(const struct device *dev, uint8_t chan_id)
 	return 0;
 }
 
-static const struct counter_driver_api ctr_api = {
+static DEVICE_API(counter, ctr_api) = {
 	.start = ctr_start,
 	.stop = ctr_stop,
 	.get_value = ctr_get_value,

--- a/drivers/counter/counter_nrfx_rtc.c
+++ b/drivers/counter/counter_nrfx_rtc.c
@@ -674,7 +674,7 @@ static void irq_handler(const void *arg)
 	}
 }
 
-static const struct counter_driver_api counter_nrfx_driver_api = {
+static DEVICE_API(counter, counter_nrfx_driver_api) = {
 	.start = start,
 	.stop = stop,
 	.get_value = get_value,

--- a/drivers/counter/counter_nrfx_timer.c
+++ b/drivers/counter/counter_nrfx_timer.c
@@ -390,7 +390,7 @@ static void irq_handler(const void *arg)
 	}
 }
 
-static const struct counter_driver_api counter_nrfx_driver_api = {
+static DEVICE_API(counter, counter_nrfx_driver_api) = {
 	.start = start,
 	.stop = stop,
 	.get_value = get_value,

--- a/drivers/counter/counter_nxp_mrt.c
+++ b/drivers/counter/counter_nxp_mrt.c
@@ -264,7 +264,7 @@ static void nxp_mrt_isr(const struct device *dev)
 	}
 }
 
-struct counter_driver_api nxp_mrt_api = {
+DEVICE_API(counter, nxp_mrt_api) = {
 	.get_value = nxp_mrt_get_value,
 	.start = nxp_mrt_start,
 	.stop = nxp_mrt_stop,

--- a/drivers/counter/counter_nxp_pit.c
+++ b/drivers/counter/counter_nxp_pit.c
@@ -234,7 +234,7 @@ static int nxp_pit_init(const struct device *dev)
 	return 0;
 }
 
-static const struct counter_driver_api nxp_pit_driver_api = {
+static DEVICE_API(counter, nxp_pit_driver_api) = {
 	.start = nxp_pit_start,
 	.stop = nxp_pit_stop,
 	.get_value = nxp_pit_get_value,

--- a/drivers/counter/counter_nxp_s32_sys_timer.c
+++ b/drivers/counter/counter_nxp_s32_sys_timer.c
@@ -370,7 +370,7 @@ static int nxp_s32_sys_timer_init(const struct device *dev)
 	return 0;
 }
 
-static const struct counter_driver_api nxp_s32_sys_timer_driver_api = {
+static DEVICE_API(counter, nxp_s32_sys_timer_driver_api) = {
 	.start = nxp_s32_sys_timer_start,
 	.stop = nxp_s32_sys_timer_stop,
 	.get_value = nxp_s32_sys_timer_get_value,

--- a/drivers/counter/counter_renesas_ra_agt.c
+++ b/drivers/counter/counter_renesas_ra_agt.c
@@ -519,7 +519,7 @@ static uint32_t r_agt_ticks_sub(uint32_t val, uint32_t old, uint32_t top)
 	return (val >= old) ? (val - old) : val + top + 1 - old;
 }
 
-static const struct counter_driver_api ra_agt_driver_api = {
+static DEVICE_API(counter, ra_agt_driver_api) = {
 	.start = counter_ra_agt_start,
 	.stop = counter_ra_agt_stop,
 	.get_value = counter_ra_agt_get_value,

--- a/drivers/counter/counter_rpi_pico_timer.c
+++ b/drivers/counter/counter_rpi_pico_timer.c
@@ -188,7 +188,7 @@ static int counter_rpi_pico_timer_init(const struct device *dev)
 	return 0;
 }
 
-static const struct counter_driver_api counter_rpi_pico_driver_api = {
+static DEVICE_API(counter, counter_rpi_pico_driver_api) = {
 	.start = counter_rpi_pico_timer_start,
 	.stop = counter_rpi_pico_timer_stop,
 	.get_value = counter_rpi_pico_timer_get_value,

--- a/drivers/counter/counter_sam0_tc32.c
+++ b/drivers/counter/counter_sam0_tc32.c
@@ -391,7 +391,7 @@ static int counter_sam0_tc32_initialize(const struct device *dev)
 	return 0;
 }
 
-static const struct counter_driver_api counter_sam0_tc32_driver_api = {
+static DEVICE_API(counter, counter_sam0_tc32_driver_api) = {
 	.start = counter_sam0_tc32_start,
 	.stop = counter_sam0_tc32_stop,
 	.get_value = counter_sam0_tc32_get_value,

--- a/drivers/counter/counter_sam_tc.c
+++ b/drivers/counter/counter_sam_tc.c
@@ -343,7 +343,7 @@ static int counter_sam_initialize(const struct device *dev)
 	return 0;
 }
 
-static const struct counter_driver_api counter_sam_driver_api = {
+static DEVICE_API(counter, counter_sam_driver_api) = {
 	.start = counter_sam_tc_start,
 	.stop = counter_sam_tc_stop,
 	.get_value = counter_sam_tc_get_value,

--- a/drivers/counter/counter_smartbond_timer.c
+++ b/drivers/counter/counter_smartbond_timer.c
@@ -453,7 +453,7 @@ static int counter_smartbond_pm_action(const struct device *dev, enum pm_device_
 }
 #endif
 
-static const struct counter_driver_api counter_smartbond_driver_api = {
+static DEVICE_API(counter, counter_smartbond_driver_api) = {
 	.start = counter_smartbond_start,
 	.stop = counter_smartbond_stop,
 	.get_value = counter_smartbond_get_value,

--- a/drivers/counter/counter_xlnx_axi_timer.c
+++ b/drivers/counter/counter_xlnx_axi_timer.c
@@ -309,7 +309,7 @@ static int xlnx_axi_timer_init(const struct device *dev)
 	return 0;
 }
 
-static const struct counter_driver_api xlnx_axi_timer_driver_api = {
+static DEVICE_API(counter, xlnx_axi_timer_driver_api) = {
 	.start = xlnx_axi_timer_start,
 	.stop = xlnx_axi_timer_stop,
 	.get_value = xlnx_axi_timer_get_value,

--- a/drivers/counter/maxim_ds3231.c
+++ b/drivers/counter/maxim_ds3231.c
@@ -1270,7 +1270,7 @@ static int ds3231_counter_set_top_value(const struct device *dev,
 	return -ENOTSUP;
 }
 
-static const struct counter_driver_api ds3231_api = {
+static DEVICE_API(counter, ds3231_api) = {
 	.start = ds3231_counter_start,
 	.stop = ds3231_counter_stop,
 	.get_value = ds3231_counter_get_value,

--- a/drivers/counter/rtc_mcp7940n.c
+++ b/drivers/counter/rtc_mcp7940n.c
@@ -733,7 +733,7 @@ out:
 	return rc;
 }
 
-static const struct counter_driver_api mcp7940n_api = {
+static DEVICE_API(counter, mcp7940n_api) = {
 	.start = mcp7940n_counter_start,
 	.stop = mcp7940n_counter_stop,
 	.get_value = mcp7940n_counter_get_value,

--- a/drivers/counter/timer_dtmr_cmsdk_apb.c
+++ b/drivers/counter/timer_dtmr_cmsdk_apb.c
@@ -122,7 +122,7 @@ static uint32_t dtmr_cmsdk_apb_get_pending_int(const struct device *dev)
 	return cfg->dtimer->timer1ris;
 }
 
-static const struct counter_driver_api dtmr_cmsdk_apb_api = {
+static DEVICE_API(counter, dtmr_cmsdk_apb_api) = {
 	.start = dtmr_cmsdk_apb_start,
 	.stop = dtmr_cmsdk_apb_stop,
 	.get_value = dtmr_cmsdk_apb_get_value,

--- a/drivers/counter/timer_tmr_cmsdk_apb.c
+++ b/drivers/counter/timer_tmr_cmsdk_apb.c
@@ -119,7 +119,7 @@ static uint32_t tmr_cmsdk_apb_get_pending_int(const struct device *dev)
 	return cfg->timer->intstatus;
 }
 
-static const struct counter_driver_api tmr_cmsdk_apb_api = {
+static DEVICE_API(counter, tmr_cmsdk_apb_api) = {
 	.start = tmr_cmsdk_apb_start,
 	.stop = tmr_cmsdk_apb_stop,
 	.get_value = tmr_cmsdk_apb_get_value,


### PR DESCRIPTION
Add wrapper DEVICE_API macro to all counter_driver_api instances.