### PR TITLE
drivers: dac: Place API into iterable section

### DIFF
--- a/drivers/dac/dac_ad559x.c
+++ b/drivers/dac/dac_ad559x.c
@@ -80,7 +80,7 @@ static int dac_ad559x_write_value(const struct device *dev, uint8_t channel, uin
 	}
 }
 
-static const struct dac_driver_api dac_ad559x_api = {
+static DEVICE_API(dac, dac_ad559x_api) = {
 	.channel_setup = dac_ad559x_channel_setup,
 	.write_value = dac_ad559x_write_value,
 };

--- a/drivers/dac/dac_ad569x.c
+++ b/drivers/dac/dac_ad569x.c
@@ -160,7 +160,7 @@ static int ad569x_init(const struct device *dev)
 	return 0;
 }
 
-static const struct dac_driver_api ad569x_driver_api = {
+static DEVICE_API(dac, ad569x_driver_api) = {
 	.channel_setup = ad569x_channel_setup,
 	.write_value = ad569x_write_value,
 };

--- a/drivers/dac/dac_ad56xx.c
+++ b/drivers/dac/dac_ad56xx.c
@@ -159,7 +159,7 @@ static int ad56xx_init(const struct device *dev)
 	return 0;
 }
 
-static const struct dac_driver_api ad56xx_driver_api = {
+static DEVICE_API(dac, ad56xx_driver_api) = {
 	.channel_setup = ad56xx_channel_setup,
 	.write_value = ad56xx_write_value,
 };

--- a/drivers/dac/dac_dacx0501.c
+++ b/drivers/dac/dac_dacx0501.c
@@ -174,7 +174,7 @@ static int dacx0501_init(const struct device *dev)
 	return 0;
 }
 
-static const struct dac_driver_api dacx0501_driver_api = {
+static DEVICE_API(dac, dacx0501_driver_api) = {
 	.channel_setup = dacx0501_channel_setup,
 	.write_value = dacx0501_write_value,
 };

--- a/drivers/dac/dac_dacx0508.c
+++ b/drivers/dac/dac_dacx0508.c
@@ -361,7 +361,7 @@ static int dacx0508_init(const struct device *dev)
 	return 0;
 }
 
-static const struct dac_driver_api dacx0508_driver_api = {
+static DEVICE_API(dac, dacx0508_driver_api) = {
 	.channel_setup = dacx0508_channel_setup,
 	.write_value = dacx0508_write_value,
 };

--- a/drivers/dac/dac_dacx3608.c
+++ b/drivers/dac/dac_dacx3608.c
@@ -246,7 +246,7 @@ static int dacx3608_init(const struct device *dev)
 	return 0;
 }
 
-static const struct dac_driver_api dacx3608_driver_api = {
+static DEVICE_API(dac, dacx3608_driver_api) = {
 	.channel_setup = dacx3608_channel_setup,
 	.write_value = dacx3608_write_value,
 };

--- a/drivers/dac/dac_esp32.c
+++ b/drivers/dac/dac_esp32.c
@@ -76,7 +76,7 @@ static int dac_esp32_init(const struct device *dev)
 	return 0;
 }
 
-static const struct dac_driver_api dac_esp32_driver_api = {
+static DEVICE_API(dac, dac_esp32_driver_api) = {
 	.channel_setup = dac_esp32_channel_setup,
 	.write_value = dac_esp32_write_value
 };

--- a/drivers/dac/dac_gd32.c
+++ b/drivers/dac/dac_gd32.c
@@ -144,7 +144,7 @@ static int dac_gd32_write_value(const struct device *dev,
 	return 0;
 }
 
-struct dac_driver_api dac_gd32_driver_api = {
+DEVICE_API(dac, dac_gd32_driver_api) = {
 	.channel_setup = dac_gd32_channel_setup,
 	.write_value = dac_gd32_write_value
 };

--- a/drivers/dac/dac_ltc166x.c
+++ b/drivers/dac/dac_ltc166x.c
@@ -103,7 +103,7 @@ static int ltc166x_init(const struct device *dev)
 	return 0;
 }
 
-static const struct dac_driver_api ltc166x_driver_api = {
+static DEVICE_API(dac, ltc166x_driver_api) = {
 	.channel_setup = ltc166x_channel_setup,
 	.write_value = ltc166x_write_value,
 };

--- a/drivers/dac/dac_mcp4725.c
+++ b/drivers/dac/dac_mcp4725.c
@@ -129,7 +129,7 @@ static int dac_mcp4725_init(const struct device *dev)
 	return 0;
 }
 
-static const struct dac_driver_api mcp4725_driver_api = {
+static DEVICE_API(dac, mcp4725_driver_api) = {
 	.channel_setup = mcp4725_channel_setup,
 	.write_value = mcp4725_write_value,
 };

--- a/drivers/dac/dac_mcp4728.c
+++ b/drivers/dac/dac_mcp4728.c
@@ -92,7 +92,7 @@ static int dac_mcp4728_init(const struct device *dev)
 	return 0;
 }
 
-static const struct dac_driver_api mcp4728_driver_api = {
+static DEVICE_API(dac, mcp4728_driver_api) = {
 	.channel_setup = mcp4728_channel_setup,
 	.write_value = mcp4728_write_value,
 };

--- a/drivers/dac/dac_mcux_dac.c
+++ b/drivers/dac/dac_mcux_dac.c
@@ -87,7 +87,7 @@ static int mcux_dac_write_value(const struct device *dev, uint8_t channel,
 	return 0;
 }
 
-static const struct dac_driver_api mcux_dac_driver_api = {
+static DEVICE_API(dac, mcux_dac_driver_api) = {
 	.channel_setup = mcux_dac_channel_setup,
 	.write_value = mcux_dac_write_value,
 };

--- a/drivers/dac/dac_mcux_dac32.c
+++ b/drivers/dac/dac_mcux_dac32.c
@@ -101,7 +101,7 @@ static int mcux_dac32_init(const struct device *dev)
 	return pinctrl_apply_state(config->pincfg, PINCTRL_STATE_DEFAULT);
 }
 
-static const struct dac_driver_api mcux_dac32_driver_api = {
+static DEVICE_API(dac, mcux_dac32_driver_api) = {
 	.channel_setup = mcux_dac32_channel_setup,
 	.write_value = mcux_dac32_write_value,
 };

--- a/drivers/dac/dac_mcux_gau.c
+++ b/drivers/dac/dac_mcux_gau.c
@@ -80,7 +80,7 @@ static int nxp_gau_dac_write_value(const struct device *dev,
 	return 0;
 };
 
-static const struct dac_driver_api nxp_gau_dac_driver_api = {
+static DEVICE_API(dac, nxp_gau_dac_driver_api) = {
 	.channel_setup = nxp_gau_dac_channel_setup,
 	.write_value = nxp_gau_dac_write_value,
 };

--- a/drivers/dac/dac_mcux_lpdac.c
+++ b/drivers/dac/dac_mcux_lpdac.c
@@ -91,7 +91,7 @@ static int mcux_lpdac_init(const struct device *dev)
 	return 0;
 }
 
-static const struct dac_driver_api mcux_lpdac_driver_api = {
+static DEVICE_API(dac, mcux_lpdac_driver_api) = {
 	.channel_setup = mcux_lpdac_channel_setup,
 	.write_value = mcux_lpdac_write_value,
 };

--- a/drivers/dac/dac_sam.c
+++ b/drivers/dac/dac_sam.c
@@ -162,7 +162,7 @@ static int dac_sam_init(const struct device *dev)
 	return 0;
 }
 
-static const struct dac_driver_api dac_sam_driver_api = {
+static DEVICE_API(dac, dac_sam_driver_api) = {
 	.channel_setup = dac_sam_channel_setup,
 	.write_value = dac_sam_write_value,
 };

--- a/drivers/dac/dac_sam0.c
+++ b/drivers/dac/dac_sam0.c
@@ -105,7 +105,7 @@ static int dac_sam0_init(const struct device *dev)
 	return 0;
 }
 
-static const struct dac_driver_api api_sam0_driver_api = {
+static DEVICE_API(dac, api_sam0_driver_api) = {
 	.channel_setup = dac_sam0_channel_setup,
 	.write_value = dac_sam0_write_value
 };

--- a/drivers/dac/dac_stm32.c
+++ b/drivers/dac/dac_stm32.c
@@ -167,7 +167,7 @@ static int dac_stm32_init(const struct device *dev)
 	return 0;
 }
 
-static const struct dac_driver_api api_stm32_driver_api = {
+static DEVICE_API(dac, api_stm32_driver_api) = {
 	.channel_setup = dac_stm32_channel_setup,
 	.write_value = dac_stm32_write_value
 };

--- a/drivers/dac/dac_test.c
+++ b/drivers/dac/dac_test.c
@@ -26,7 +26,7 @@ int vnd_dac_write_value(const struct device *dev, uint8_t channel, uint32_t valu
 	return -ENOTSUP;
 }
 
-static const struct dac_driver_api vnd_dac_driver_api = {
+static DEVICE_API(dac, vnd_dac_driver_api) = {
 	.channel_setup = vnd_dac_channel_setup,
 	.write_value = vnd_dac_write_value,
 };


### PR DESCRIPTION
Add wrapper DEVICE_API macro to all dac_driver_api instances.