### PR TITLE
Boards: Infineon: XMC45 Relax kit: Added buttons to device tree

### DIFF
--- a/boards/infineon/xmc45_relax_kit/xmc45_relax_kit.dts
+++ b/boards/infineon/xmc45_relax_kit/xmc45_relax_kit.dts
@@ -20,6 +20,7 @@
 
 	aliases {
 		led0 = &led1;
+		sw0 = &button1;
 		die-temp0 = &die_temp;
 		pwm-led0 = &pwm_led1;
 		watchdog0 = &wdt0;
@@ -36,6 +37,16 @@
 			gpios = <&gpio1 0 GPIO_ACTIVE_HIGH>;
 		};
 	};
+	
+	buttons {
+		compatible = "gpio-keys";
+		button1: button1 {
+			gpios = < &gpio1 14 GPIO_ACTIVE_LOW >;
+		};
+		button2: button2 {
+			gpios = < &gpio1 15 GPIO_ACTIVE_LOW >;
+		};
+ 	};
 
 	pwmleds {
 		compatible = "pwm-leds";

--- a/boards/infineon/xmc45_relax_kit/xmc45_relax_kit.dts
+++ b/boards/infineon/xmc45_relax_kit/xmc45_relax_kit.dts
@@ -37,7 +37,7 @@
 			gpios = <&gpio1 0 GPIO_ACTIVE_HIGH>;
 		};
 	};
-	
+
 	buttons {
 		compatible = "gpio-keys";
 		button1: button1 {
@@ -46,7 +46,7 @@
 		button2: button2 {
 			gpios = < &gpio1 15 GPIO_ACTIVE_LOW >;
 		};
- 	};
+	};
 
 	pwmleds {
 		compatible = "pwm-leds";


### PR DESCRIPTION
[The XMC45 Relax kit](https://www.infineon.com/cms/de/product/evaluation-boards/kit_xmc47_relax_v1/) is equipped with two buttons.
This pull request adds the two buttons to the devicetree file of the board.