### PR TITLE
drivers: edac: Place API into iterable section

### DIFF
--- a/drivers/edac/edac_ibecc.c
+++ b/drivers/edac/edac_ibecc.c
@@ -257,7 +257,7 @@ static int notify_callback_set(const struct device *dev,
 	return 0;
 }
 
-static const struct edac_driver_api api = {
+static DEVICE_API(edac, api) = {
 #if defined(CONFIG_EDAC_ERROR_INJECT)
 	/* Error Injection functions */
 	.inject_set_param1 = inject_set_param1,

--- a/tests/subsys/edac/ibecc/src/dummy.c
+++ b/tests/subsys/edac/ibecc/src/dummy.c
@@ -14,7 +14,7 @@
  * EDAC dummy is used for coverage tests for -ENOSYS returns
  */
 
-static const struct edac_driver_api edac_dummy_api = { 0 };
+static DEVICE_API(edac, edac_dummy_api) = { 0 };
 
 DEVICE_DEFINE(dummy_edac, "dummy_edac", NULL, NULL,
 	      NULL, NULL,


### PR DESCRIPTION
Add wrapper DEVICE_API macro to all edac_driver_api instances.