### PR TITLE
drivers: eeprom: Place API into iterable section

### DIFF
--- a/drivers/eeprom/eeprom_at2x.c
+++ b/drivers/eeprom/eeprom_at2x.c
@@ -593,7 +593,7 @@ static int eeprom_at2x_init(const struct device *dev)
 	return 0;
 }
 
-static const struct eeprom_driver_api eeprom_at2x_api = {
+static DEVICE_API(eeprom, eeprom_at2x_api) = {
 	.read = eeprom_at2x_read,
 	.write = eeprom_at2x_write,
 	.size = eeprom_at2x_size,

--- a/drivers/eeprom/eeprom_emulator.c
+++ b/drivers/eeprom/eeprom_emulator.c
@@ -720,7 +720,7 @@ static int eeprom_emu_init(const struct device *dev)
 	return rc;
 }
 
-static const struct eeprom_driver_api eeprom_emu_api = {
+static DEVICE_API(eeprom, eeprom_emu_api) = {
 	.read = eeprom_emu_read,
 	.write = eeprom_emu_write,
 	.size = eeprom_emu_size,

--- a/drivers/eeprom/eeprom_fake.c
+++ b/drivers/eeprom/eeprom_fake.c
@@ -49,7 +49,7 @@ static void fake_eeprom_reset_rule_before(const struct ztest_unit_test *test, vo
 ZTEST_RULE(fake_eeprom_reset_rule, fake_eeprom_reset_rule_before, NULL);
 #endif /* CONFIG_ZTEST */
 
-static const struct eeprom_driver_api fake_eeprom_driver_api = {
+static DEVICE_API(eeprom, fake_eeprom_driver_api) = {
 	.read = fake_eeprom_read,
 	.write = fake_eeprom_write,
 	.size = fake_eeprom_size,

--- a/drivers/eeprom/eeprom_lpc11u6x.c
+++ b/drivers/eeprom/eeprom_lpc11u6x.c
@@ -101,7 +101,7 @@ static size_t eeprom_lpc11u6x_size(const struct device *dev)
 	return config->size;
 }
 
-static const struct eeprom_driver_api eeprom_lpc11u6x_api = {
+static DEVICE_API(eeprom, eeprom_lpc11u6x_api) = {
 	.read = eeprom_lpc11u6x_read,
 	.write = eeprom_lpc11u6x_write,
 	.size = eeprom_lpc11u6x_size,

--- a/drivers/eeprom/eeprom_mb85rcxx.c
+++ b/drivers/eeprom/eeprom_mb85rcxx.c
@@ -206,7 +206,7 @@ static size_t mb85rcxx_get_size(const struct device *dev)
 	return cfg->size;
 }
 
-static const struct eeprom_driver_api mb85rcxx_driver_api = {
+static DEVICE_API(eeprom, mb85rcxx_driver_api) = {
 	.read = &mb85rcxx_read,
 	.write = &mb85rcxx_write,
 	.size = &mb85rcxx_get_size,

--- a/drivers/eeprom/eeprom_mb85rsxx.c
+++ b/drivers/eeprom/eeprom_mb85rsxx.c
@@ -295,7 +295,7 @@ static int eeprom_mb85rsxx_init(const struct device *dev)
 	return 0;
 }
 
-static const struct eeprom_driver_api mb85rsxx_driver_api = {
+static DEVICE_API(eeprom, mb85rsxx_driver_api) = {
 	.read = &eeprom_mb85rsxx_read,
 	.write = &eeprom_mb85rsxx_write,
 	.size = &eeprom_mb85rsxx_size,

--- a/drivers/eeprom/eeprom_mchp_xec.c
+++ b/drivers/eeprom/eeprom_mchp_xec.c
@@ -354,7 +354,7 @@ static int eeprom_xec_init(const struct device *dev)
 	return 0;
 }
 
-static const struct eeprom_driver_api eeprom_xec_api = {
+static DEVICE_API(eeprom, eeprom_xec_api) = {
 	.read = eeprom_xec_read,
 	.write = eeprom_xec_write,
 	.size = eeprom_xec_size,

--- a/drivers/eeprom/eeprom_simulator.c
+++ b/drivers/eeprom/eeprom_simulator.c
@@ -198,7 +198,7 @@ static size_t eeprom_sim_size(const struct device *dev)
 	return config->size;
 }
 
-static const struct eeprom_driver_api eeprom_sim_api = {
+static DEVICE_API(eeprom, eeprom_sim_api) = {
 	.read = eeprom_sim_read,
 	.write = eeprom_sim_write,
 	.size = eeprom_sim_size,

--- a/drivers/eeprom/eeprom_stm32.c
+++ b/drivers/eeprom/eeprom_stm32.c
@@ -107,7 +107,7 @@ static size_t eeprom_stm32_size(const struct device *dev)
 	return config->size;
 }
 
-static const struct eeprom_driver_api eeprom_stm32_api = {
+static DEVICE_API(eeprom, eeprom_stm32_api) = {
 	.read = eeprom_stm32_read,
 	.write = eeprom_stm32_write,
 	.size = eeprom_stm32_size,

--- a/drivers/eeprom/eeprom_tmp116.c
+++ b/drivers/eeprom/eeprom_tmp116.c
@@ -53,7 +53,7 @@ static int eeprom_tmp116_init(const struct device *dev)
 	return 0;
 }
 
-static const struct eeprom_driver_api eeprom_tmp116_api = {
+static DEVICE_API(eeprom, eeprom_tmp116_api) = {
 	.read = eeprom_tmp116_read,
 	.write = eeprom_tmp116_write,
 	.size = eeprom_tmp116_size,


### PR DESCRIPTION
Add wrapper DEVICE_API macro to all eeprom_driver_api instances.