### PR TITLE
drivers: entropy: Place API into iterable section

### DIFF
--- a/drivers/entropy/entropy_b91_trng.c
+++ b/drivers/entropy/entropy_b91_trng.c
@@ -59,7 +59,7 @@ static int entropy_b91_trng_get_entropy_isr(const struct device *dev,
 }
 
 /* Entropy driver APIs structure */
-static const struct entropy_driver_api entropy_b91_trng_api = {
+static DEVICE_API(entropy, entropy_b91_trng_api) = {
 	.get_entropy = entropy_b91_trng_get_entropy,
 	.get_entropy_isr = entropy_b91_trng_get_entropy_isr
 };

--- a/drivers/entropy/entropy_bt_hci.c
+++ b/drivers/entropy/entropy_bt_hci.c
@@ -28,7 +28,7 @@ static int entropy_bt_get_entropy(const struct device *dev,
 }
 
 /* HCI commands cannot be run from an interrupt context */
-static const struct entropy_driver_api entropy_bt_api = {
+static DEVICE_API(entropy, entropy_bt_api) = {
 	.get_entropy = entropy_bt_get_entropy,
 	.get_entropy_isr = NULL
 };

--- a/drivers/entropy/entropy_cc13xx_cc26xx.c
+++ b/drivers/entropy/entropy_cc13xx_cc26xx.c
@@ -334,7 +334,7 @@ static int entropy_cc13xx_cc26xx_init(const struct device *dev)
 	return 0;
 }
 
-static const struct entropy_driver_api entropy_cc13xx_cc26xx_driver_api = {
+static DEVICE_API(entropy, entropy_cc13xx_cc26xx_driver_api) = {
 	.get_entropy = entropy_cc13xx_cc26xx_get_entropy,
 	.get_entropy_isr = entropy_cc13xx_cc26xx_get_entropy_isr,
 };

--- a/drivers/entropy/entropy_esp32.c
+++ b/drivers/entropy/entropy_esp32.c
@@ -88,7 +88,7 @@ static int entropy_esp32_init(const struct device *dev)
 	return ret;
 }
 
-static const struct entropy_driver_api entropy_esp32_api_funcs = {
+static DEVICE_API(entropy, entropy_esp32_api_funcs) = {
 	.get_entropy = entropy_esp32_get_entropy
 };
 

--- a/drivers/entropy/entropy_gecko_se.c
+++ b/drivers/entropy/entropy_gecko_se.c
@@ -49,7 +49,7 @@ static int entropy_gecko_se_init(const struct device *dev)
 	return 0;
 }
 
-static const struct entropy_driver_api entropy_gecko_se_api_funcs = {
+static DEVICE_API(entropy, entropy_gecko_se_api_funcs) = {
 	.get_entropy = entropy_gecko_se_get_entropy,
 };
 

--- a/drivers/entropy/entropy_gecko_trng.c
+++ b/drivers/entropy/entropy_gecko_trng.c
@@ -148,7 +148,7 @@ static int entropy_gecko_trng_init(const struct device *dev)
 	return 0;
 }
 
-static struct entropy_driver_api entropy_gecko_trng_api_funcs = {
+static DEVICE_API(entropy, entropy_gecko_trng_api_funcs) = {
 	.get_entropy = entropy_gecko_trng_get_entropy,
 	.get_entropy_isr = entropy_gecko_trng_get_entropy_isr
 };

--- a/drivers/entropy/entropy_litex.c
+++ b/drivers/entropy/entropy_litex.c
@@ -34,7 +34,7 @@ static int entropy_prbs_get_entropy(const struct device *dev, uint8_t *buffer,
 	return 0;
 }
 
-static const struct entropy_driver_api entropy_prbs_api = {
+static DEVICE_API(entropy, entropy_prbs_api) = {
 	.get_entropy = entropy_prbs_get_entropy
 };
 

--- a/drivers/entropy/entropy_max32.c
+++ b/drivers/entropy/entropy_max32.c
@@ -65,7 +65,7 @@ static int api_get_entropy_isr(const struct device *dev, uint8_t *buf, uint16_t 
 	return ret;
 }
 
-static const struct entropy_driver_api entropy_max32_api = {.get_entropy = api_get_entropy,
+static DEVICE_API(entropy, entropy_max32_api) = {.get_entropy = api_get_entropy,
 							    .get_entropy_isr = api_get_entropy_isr};
 
 static int entropy_max32_init(const struct device *dev)

--- a/drivers/entropy/entropy_mcux_caam.c
+++ b/drivers/entropy/entropy_mcux_caam.c
@@ -66,7 +66,7 @@ static int entropy_mcux_caam_get_entropy(const struct device *dev,
 	return 0;
 }
 
-static const struct entropy_driver_api entropy_mcux_caam_api_funcs = {
+static DEVICE_API(entropy, entropy_mcux_caam_api_funcs) = {
 	.get_entropy = entropy_mcux_caam_get_entropy
 };
 

--- a/drivers/entropy/entropy_mcux_rng.c
+++ b/drivers/entropy/entropy_mcux_rng.c
@@ -30,7 +30,7 @@ static int entropy_mcux_rng_get_entropy(const struct device *dev,
 	return 0;
 }
 
-static const struct entropy_driver_api entropy_mcux_rng_api_funcs = {
+static DEVICE_API(entropy, entropy_mcux_rng_api_funcs) = {
 	.get_entropy = entropy_mcux_rng_get_entropy
 };
 

--- a/drivers/entropy/entropy_mcux_rnga.c
+++ b/drivers/entropy/entropy_mcux_rnga.c
@@ -53,7 +53,7 @@ static int entropy_mcux_rnga_get_entropy(const struct device *dev,
 	return 0;
 }
 
-static const struct entropy_driver_api entropy_mcux_rnga_api_funcs = {
+static DEVICE_API(entropy, entropy_mcux_rnga_api_funcs) = {
 	.get_entropy = entropy_mcux_rnga_get_entropy
 };
 

--- a/drivers/entropy/entropy_mcux_trng.c
+++ b/drivers/entropy/entropy_mcux_trng.c
@@ -30,7 +30,7 @@ static int entropy_mcux_trng_get_entropy(const struct device *dev,
 	return 0;
 }
 
-static const struct entropy_driver_api entropy_mcux_trng_api_funcs = {
+static DEVICE_API(entropy, entropy_mcux_trng_api_funcs) = {
 	.get_entropy = entropy_mcux_trng_get_entropy
 };
 

--- a/drivers/entropy/entropy_neorv32_trng.c
+++ b/drivers/entropy/entropy_neorv32_trng.c
@@ -127,7 +127,7 @@ static int neorv32_trng_pm_action(const struct device *dev, enum pm_device_actio
 }
 #endif /* CONFIG_PM_DEVICE */
 
-static const struct entropy_driver_api neorv32_trng_driver_api = {
+static DEVICE_API(entropy, neorv32_trng_driver_api) = {
 	.get_entropy = neorv32_trng_get_entropy,
 	.get_entropy_isr = neorv32_trng_get_entropy_isr,
 };

--- a/drivers/entropy/entropy_npcx_drbg.c
+++ b/drivers/entropy/entropy_npcx_drbg.c
@@ -222,7 +222,7 @@ static int entropy_npcx_drbg_pm_action(const struct device *dev, enum pm_device_
 }
 #endif /* CONFIG_PM_DEVICE */
 
-static const struct entropy_driver_api entropy_npcx_drbg_api = {
+static DEVICE_API(entropy, entropy_npcx_drbg_api) = {
 	.get_entropy = entropy_npcx_drbg_get_entropy,
 };
 

--- a/drivers/entropy/entropy_nrf5.c
+++ b/drivers/entropy/entropy_nrf5.c
@@ -310,7 +310,7 @@ static int entropy_nrf5_get_entropy_isr(const struct device *dev,
 
 static int entropy_nrf5_init(const struct device *dev);
 
-static const struct entropy_driver_api entropy_nrf5_api_funcs = {
+static DEVICE_API(entropy, entropy_nrf5_api_funcs) = {
 	.get_entropy = entropy_nrf5_get_entropy,
 	.get_entropy_isr = entropy_nrf5_get_entropy_isr
 };

--- a/drivers/entropy/entropy_psa_crypto.c
+++ b/drivers/entropy/entropy_psa_crypto.c
@@ -41,7 +41,7 @@ static int entropy_psa_crypto_rng_get_entropy(const struct device *dev,
 }
 
 /* Entropy driver APIs structure */
-static const struct entropy_driver_api entropy_psa_crypto_rng_api = {
+static DEVICE_API(entropy, entropy_psa_crypto_rng_api) = {
 	.get_entropy = entropy_psa_crypto_rng_get_entropy,
 };
 

--- a/drivers/entropy/entropy_renesas_ra.c
+++ b/drivers/entropy/entropy_renesas_ra.c
@@ -35,7 +35,7 @@ static int entropy_ra_rsip_trng_get_entropy(const struct device *dev, uint8_t *b
 	return 0;
 }
 
-static const struct entropy_driver_api entropy_ra_rsip_trng_api = {
+static DEVICE_API(entropy, entropy_ra_rsip_trng_api) = {
 	.get_entropy = entropy_ra_rsip_trng_get_entropy,
 };
 

--- a/drivers/entropy/entropy_rv32m1_trng.c
+++ b/drivers/entropy/entropy_rv32m1_trng.c
@@ -32,7 +32,7 @@ static int entropy_rv32m1_trng_get_entropy(const struct device *dev,
 	return 0;
 }
 
-static const struct entropy_driver_api entropy_rv32m1_trng_api_funcs = {
+static DEVICE_API(entropy, entropy_rv32m1_trng_api_funcs) = {
 	.get_entropy = entropy_rv32m1_trng_get_entropy
 };
 

--- a/drivers/entropy/entropy_sam.c
+++ b/drivers/entropy/entropy_sam.c
@@ -167,7 +167,7 @@ static int entropy_sam_init(const struct device *dev)
 	return 0;
 }
 
-static const struct entropy_driver_api entropy_sam_api = {
+static DEVICE_API(entropy, entropy_sam_api) = {
 	.get_entropy = entropy_sam_get_entropy,
 	.get_entropy_isr = entropy_sam_get_entropy_isr
 };

--- a/drivers/entropy/entropy_smartbond.c
+++ b/drivers/entropy/entropy_smartbond.c
@@ -395,7 +395,7 @@ static int entropy_smartbond_pm_action(const struct device *dev, enum pm_device_
 }
 #endif
 
-static const struct entropy_driver_api entropy_smartbond_api_funcs = {
+static DEVICE_API(entropy, entropy_smartbond_api_funcs) = {
 	.get_entropy = entropy_smartbond_get_entropy,
 	.get_entropy_isr = entropy_smartbond_get_entropy_isr};
 

--- a/drivers/entropy/entropy_stm32.c
+++ b/drivers/entropy/entropy_stm32.c
@@ -763,7 +763,7 @@ static int entropy_stm32_rng_pm_action(const struct device *dev,
 }
 #endif /* CONFIG_PM_DEVICE */
 
-static const struct entropy_driver_api entropy_stm32_rng_api = {
+static DEVICE_API(entropy, entropy_stm32_rng_api) = {
 	.get_entropy = entropy_stm32_rng_get_entropy,
 	.get_entropy_isr = entropy_stm32_rng_get_entropy_isr
 };

--- a/drivers/entropy/fake_entropy_native_posix.c
+++ b/drivers/entropy/fake_entropy_native_posix.c
@@ -79,7 +79,7 @@ static int entropy_native_posix_init(const struct device *dev)
 	return 0;
 }
 
-static const struct entropy_driver_api entropy_native_posix_api_funcs = {
+static DEVICE_API(entropy, entropy_native_posix_api_funcs) = {
 	.get_entropy     = entropy_native_posix_get_entropy,
 	.get_entropy_isr = entropy_native_posix_get_entropy_isr
 };


### PR DESCRIPTION
Add wrapper DEVICE_API macro to all entropy_driver_api instances.