### PR TITLE
drivers: ethphy: Place API into iterable section

### DIFF
--- a/drivers/ethernet/phy/phy_adin2111.c
+++ b/drivers/ethernet/phy/phy_adin2111.c
@@ -628,7 +628,7 @@ static int phy_adin2111_link_cb_set(const struct device *dev, phy_callback_t cb,
 	return 0;
 }
 
-static const struct ethphy_driver_api phy_adin2111_api = {
+static DEVICE_API(ethphy, phy_adin2111_api) = {
 	.get_link = phy_adin2111_get_link_state,
 	.cfg_link = phy_adin2111_cfg_link,
 	.link_cb_set = phy_adin2111_link_cb_set,

--- a/drivers/ethernet/phy/phy_microchip_ksz8081.c
+++ b/drivers/ethernet/phy/phy_microchip_ksz8081.c
@@ -505,7 +505,7 @@ skip_int_gpio:
 	return 0;
 }
 
-static const struct ethphy_driver_api mc_ksz8081_phy_api = {
+static DEVICE_API(ethphy, mc_ksz8081_phy_api) = {
 	.get_link = phy_mc_ksz8081_get_link,
 	.cfg_link = phy_mc_ksz8081_cfg_link,
 	.link_cb_set = phy_mc_ksz8081_link_cb_set,

--- a/drivers/ethernet/phy/phy_mii.c
+++ b/drivers/ethernet/phy/phy_mii.c
@@ -480,7 +480,7 @@ static int phy_mii_initialize(const struct device *dev)
 
 #define IS_FIXED_LINK(n)	DT_INST_NODE_HAS_PROP(n, fixed_link)
 
-static const struct ethphy_driver_api phy_mii_driver_api = {
+static DEVICE_API(ethphy, phy_mii_driver_api) = {
 	.get_link = phy_mii_get_link_state,
 	.cfg_link = phy_mii_cfg_link,
 	.link_cb_set = phy_mii_link_cb_set,

--- a/drivers/ethernet/phy/phy_qualcomm_ar8031.c
+++ b/drivers/ethernet/phy/phy_qualcomm_ar8031.c
@@ -483,7 +483,7 @@ static int qc_ar8031_init(const struct device *dev)
 	return 0;
 }
 
-static const struct ethphy_driver_api ar8031_driver_api = {
+static DEVICE_API(ethphy, ar8031_driver_api) = {
 	.get_link = qc_ar8031_get_link_state,
 	.cfg_link = qc_ar8031_cfg_link,
 	.link_cb_set = qc_ar8031_link_cb_set,

--- a/drivers/ethernet/phy/phy_realtek_rtl8211f.c
+++ b/drivers/ethernet/phy/phy_realtek_rtl8211f.c
@@ -642,7 +642,7 @@ skip_int_gpio:
 	return 0;
 }
 
-static const struct ethphy_driver_api rt_rtl8211f_phy_api = {
+static DEVICE_API(ethphy, rt_rtl8211f_phy_api) = {
 	.get_link = phy_rt_rtl8211f_get_link,
 	.cfg_link = phy_rt_rtl8211f_cfg_link,
 	.link_cb_set = phy_rt_rtl8211f_link_cb_set,

--- a/drivers/ethernet/phy/phy_ti_dp83825.c
+++ b/drivers/ethernet/phy/phy_ti_dp83825.c
@@ -566,7 +566,7 @@ skip_int_gpio:
 	return 0;
 }
 
-static const struct ethphy_driver_api ti_dp83825_phy_api = {
+static DEVICE_API(ethphy, ti_dp83825_phy_api) = {
 	.get_link = phy_ti_dp83825_get_link,
 	.cfg_link = phy_ti_dp83825_cfg_link,
 	.link_cb_set = phy_ti_dp83825_link_cb_set,

--- a/drivers/ethernet/phy/phy_tja1103.c
+++ b/drivers/ethernet/phy/phy_tja1103.c
@@ -435,7 +435,7 @@ static int phy_tja1103_link_cb_set(const struct device *dev, phy_callback_t cb, 
 	return 0;
 }
 
-static const struct ethphy_driver_api phy_tja1103_api = {
+static DEVICE_API(ethphy, phy_tja1103_api) = {
 	.get_link = phy_tja1103_get_link_state,
 	.cfg_link = phy_tja1103_cfg_link,
 	.link_cb_set = phy_tja1103_link_cb_set,


### PR DESCRIPTION
Add wrapper DEVICE_API macro to all ethphy_driver_api instances.