### PR TITLE
drivers: fuel_gauge: Place API into iterable section

### DIFF
--- a/drivers/fuel_gauge/bq27z746/bq27z746.c
+++ b/drivers/fuel_gauge/bq27z746/bq27z746.c
@@ -270,7 +270,7 @@ static int bq27z746_init(const struct device *dev)
 	return 0;
 }
 
-static const struct fuel_gauge_driver_api bq27z746_driver_api = {
+static DEVICE_API(fuel_gauge, bq27z746_driver_api) = {
 	.get_property = &bq27z746_get_prop,
 	.set_property = &bq27z746_set_prop,
 	.get_buffer_property = &bq27z746_get_buffer_prop,

--- a/drivers/fuel_gauge/composite/fuel_gauge_composite.c
+++ b/drivers/fuel_gauge/composite/fuel_gauge_composite.c
@@ -92,7 +92,7 @@ static int composite_get_prop(const struct device *dev, fuel_gauge_prop_t prop,
 	return 0;
 }
 
-static const struct fuel_gauge_driver_api composite_api = {
+static DEVICE_API(fuel_gauge, composite_api) = {
 	.get_property = composite_get_prop,
 };
 

--- a/drivers/fuel_gauge/max17048/max17048.c
+++ b/drivers/fuel_gauge/max17048/max17048.c
@@ -279,7 +279,7 @@ static int max17048_get_prop(const struct device *dev, fuel_gauge_prop_t prop,
 	return ret;
 }
 
-static const struct fuel_gauge_driver_api max17048_driver_api = {
+static DEVICE_API(fuel_gauge, max17048_driver_api) = {
 	.get_property = &max17048_get_prop,
 };
 

--- a/drivers/fuel_gauge/sbs_gauge/sbs_gauge.c
+++ b/drivers/fuel_gauge/sbs_gauge/sbs_gauge.c
@@ -290,7 +290,7 @@ static int sbs_gauge_init(const struct device *dev)
 	return 0;
 }
 
-static const struct fuel_gauge_driver_api sbs_gauge_driver_api = {
+static DEVICE_API(fuel_gauge, sbs_gauge_driver_api) = {
 	.get_property = &sbs_gauge_get_prop,
 	.set_property = &sbs_gauge_set_prop,
 	.get_buffer_property = &sbs_gauge_get_buffer_prop,


### PR DESCRIPTION
Add wrapper DEVICE_API macro to all fuel_gauge_driver_api instances.