### PR TITLE
drivers: gnss: Place API into iterable section

### DIFF
--- a/drivers/gnss/gnss_emul.c
+++ b/drivers/gnss/gnss_emul.c
@@ -336,7 +336,7 @@ static int gnss_emul_api_get_supported_systems(const struct device *dev, gnss_sy
 	return 0;
 }
 
-static const struct gnss_driver_api api = {
+static DEVICE_API(gnss, api) = {
 	.set_fix_rate = gnss_emul_api_set_fix_rate,
 	.get_fix_rate = gnss_emul_api_get_fix_rate,
 	.set_navigation_mode = gnss_emul_api_set_navigation_mode,

--- a/drivers/gnss/gnss_luatos_air530z.c
+++ b/drivers/gnss/gnss_luatos_air530z.c
@@ -336,7 +336,7 @@ static int luatos_air530z_get_supported_systems(const struct device *dev, gnss_s
 	return 0;
 }
 
-static const struct gnss_driver_api gnss_api = {
+static DEVICE_API(gnss, gnss_api) = {
 	.set_fix_rate = luatos_air530z_set_fix_rate,
 	.set_enabled_systems = luatos_air530z_set_enabled_systems,
 	.get_supported_systems = luatos_air530z_get_supported_systems,

--- a/drivers/gnss/gnss_nmea_generic.c
+++ b/drivers/gnss/gnss_nmea_generic.c
@@ -81,7 +81,7 @@ static int gnss_nmea_generic_resume(const struct device *dev)
 	return ret;
 }
 
-static const struct gnss_driver_api gnss_api = {
+static DEVICE_API(gnss, gnss_api) = {
 };
 
 static int gnss_nmea_generic_init_nmea0183_match(const struct device *dev)

--- a/drivers/gnss/gnss_quectel_lcx6g.c
+++ b/drivers/gnss/gnss_quectel_lcx6g.c
@@ -717,7 +717,7 @@ static int quectel_lcx6g_get_supported_systems(const struct device *dev, gnss_sy
 	return 0;
 }
 
-static const struct gnss_driver_api gnss_api = {
+static DEVICE_API(gnss, gnss_api) = {
 	.set_fix_rate = quectel_lcx6g_set_fix_rate,
 	.get_fix_rate = quectel_lcx6g_get_fix_rate,
 	.set_navigation_mode = quectel_lcx6g_set_navigation_mode,

--- a/drivers/gnss/gnss_u_blox_m8.c
+++ b/drivers/gnss/gnss_u_blox_m8.c
@@ -913,7 +913,7 @@ unlock:
 	return ret;
 }
 
-static const struct gnss_driver_api gnss_api = {
+static DEVICE_API(gnss, gnss_api) = {
 	.set_fix_rate = ubx_m8_set_fix_rate,
 	.get_fix_rate = ubx_m8_get_fix_rate,
 	.set_navigation_mode = ubx_m8_set_navigation_mode,


### PR DESCRIPTION
Add wrapper DEVICE_API macro to all gnss_driver_api instances.