### PR TITLE
drivers: gpio: Place API into iterable section

### DIFF
--- a/drivers/gpio/gpio_ad559x.c
+++ b/drivers/gpio/gpio_ad559x.c
@@ -196,7 +196,7 @@ static int gpio_ad559x_pin_interrupt_configure(const struct device *dev,
 	return -ENOTSUP;
 }
 
-static const struct gpio_driver_api gpio_ad559x_api = {
+static DEVICE_API(gpio, gpio_ad559x_api) = {
 	.pin_configure = gpio_ad559x_configure,
 	.port_get_raw = gpio_ad559x_port_get_raw,
 	.port_set_masked_raw = gpio_ad559x_port_set_masked_raw,

--- a/drivers/gpio/gpio_adp5585.c
+++ b/drivers/gpio/gpio_adp5585.c
@@ -441,7 +441,7 @@ out:
 	return ret;
 }
 
-static const struct gpio_driver_api api_table = {
+static DEVICE_API(gpio, api_table) = {
 	.pin_configure = gpio_adp5585_config,
 	.port_get_raw = gpio_adp5585_port_read,
 	.port_set_masked_raw = gpio_adp5585_port_set_masked,

--- a/drivers/gpio/gpio_ads114s0x.c
+++ b/drivers/gpio/gpio_ads114s0x.c
@@ -118,7 +118,7 @@ static int gpio_ads114s0x_init(const struct device *dev)
 	return 0;
 }
 
-static const struct gpio_driver_api gpio_ads114s0x_api = {
+static DEVICE_API(gpio, gpio_ads114s0x_api) = {
 	.pin_configure = gpio_ads114s0x_config,
 	.port_set_masked_raw = gpio_ads114s0x_port_set_masked_raw,
 	.port_set_bits_raw = gpio_ads114s0x_port_set_bits_raw,

--- a/drivers/gpio/gpio_altera_pio.c
+++ b/drivers/gpio/gpio_altera_pio.c
@@ -278,7 +278,7 @@ static void gpio_altera_irq_handler(const struct device *dev)
 	gpio_fire_callbacks(&data->cb, dev, port_value);
 }
 
-static const struct gpio_driver_api gpio_altera_driver_api = {
+static DEVICE_API(gpio, gpio_altera_driver_api) = {
 	.pin_configure		 = gpio_altera_configure,
 	.port_get_raw		 = gpio_altera_port_get_raw,
 	.port_set_masked_raw	 = NULL,

--- a/drivers/gpio/gpio_ambiq.c
+++ b/drivers/gpio/gpio_ambiq.c
@@ -550,7 +550,7 @@ static int ambiq_gpio_init(const struct device *port)
 	return 0;
 }
 
-static const struct gpio_driver_api ambiq_gpio_drv_api = {
+static DEVICE_API(gpio, ambiq_gpio_drv_api) = {
 	.pin_configure = ambiq_gpio_pin_configure,
 #ifdef CONFIG_GPIO_GET_CONFIG
 	.pin_get_config = ambiq_gpio_get_config,

--- a/drivers/gpio/gpio_andes_atcgpio100.c
+++ b/drivers/gpio/gpio_andes_atcgpio100.c
@@ -319,7 +319,7 @@ static void gpio_atcgpio100_irq_handler(const struct device *port)
 
 }
 
-static const struct gpio_driver_api gpio_atcgpio100_api = {
+static DEVICE_API(gpio, gpio_atcgpio100_api) = {
 	.pin_configure           = gpio_atcgpio100_config,
 	.port_get_raw            = gpio_atcgpio100_port_get_raw,
 	.port_set_masked_raw     = gpio_atcgpio100_set_masked_raw,

--- a/drivers/gpio/gpio_axp192.c
+++ b/drivers/gpio/gpio_axp192.c
@@ -268,7 +268,7 @@ static int gpio_axp192_manage_callback(const struct device *dev, struct gpio_cal
 	return gpio_manage_callback(&data->cb_list_gpio, callback, set);
 }
 
-static const struct gpio_driver_api gpio_axp192_api = {
+static DEVICE_API(gpio, gpio_axp192_api) = {
 	.pin_configure = gpio_axp192_configure,
 	.port_get_raw = gpio_axp192_port_get_raw,
 	.port_set_masked_raw = gpio_axp192_port_set_masked_raw,

--- a/drivers/gpio/gpio_b91.c
+++ b/drivers/gpio/gpio_b91.c
@@ -467,7 +467,7 @@ static int gpio_b91_manage_callback(const struct device *dev,
 }
 
 /* GPIO driver APIs structure */
-static const struct gpio_driver_api gpio_b91_driver_api = {
+static DEVICE_API(gpio, gpio_b91_driver_api) = {
 	.pin_configure = gpio_b91_pin_configure,
 	.port_get_raw = gpio_b91_port_get_raw,
 	.port_set_masked_raw = gpio_b91_port_set_masked_raw,

--- a/drivers/gpio/gpio_bcm2711.c
+++ b/drivers/gpio/gpio_bcm2711.c
@@ -319,7 +319,7 @@ int gpio_bcm2711_init(const struct device *port)
 	return 0;
 }
 
-static const struct gpio_driver_api gpio_bcm2711_api = {
+static DEVICE_API(gpio, gpio_bcm2711_api) = {
 	.pin_configure = gpio_bcm2711_pin_configure,
 	.port_get_raw = gpio_bcm2711_port_get_raw,
 	.port_set_masked_raw = gpio_bcm2711_port_set_masked_raw,

--- a/drivers/gpio/gpio_bd8lb600fs.c
+++ b/drivers/gpio/gpio_bd8lb600fs.c
@@ -154,7 +154,7 @@ static int bd8lb600fs_gpio_port_toggle_bits(const struct device *dev, uint32_t m
 	return result;
 }
 
-static const struct gpio_driver_api api_table = {
+static DEVICE_API(gpio, api_table) = {
 	.pin_configure = bd8lb600fs_gpio_pin_configure,
 	.port_get_raw = bd8lb600fs_gpio_port_get_raw,
 	.port_set_masked_raw = bd8lb600fs_gpio_port_set_masked_raw,

--- a/drivers/gpio/gpio_brcmstb.c
+++ b/drivers/gpio/gpio_brcmstb.c
@@ -105,7 +105,7 @@ static int gpio_brcmstb_port_toggle_bits(const struct device *port, gpio_port_pi
 	return 0;
 }
 
-static const struct gpio_driver_api gpio_brcmstb_api = {
+static DEVICE_API(gpio, gpio_brcmstb_api) = {
 	.pin_configure = gpio_brcmstb_pin_configure,
 	.port_get_raw = gpio_brcmstb_port_get_raw,
 	.port_set_masked_raw = gpio_brcmstb_port_set_masked_raw,

--- a/drivers/gpio/gpio_cc13xx_cc26xx.c
+++ b/drivers/gpio/gpio_cc13xx_cc26xx.c
@@ -297,7 +297,7 @@ static int gpio_cc13xx_cc26xx_port_get_direction(const struct device *port, gpio
 }
 #endif /* CONFIG_GPIO_GET_DIRECTION */
 
-static const struct gpio_driver_api gpio_cc13xx_cc26xx_driver_api = {
+static DEVICE_API(gpio, gpio_cc13xx_cc26xx_driver_api) = {
 	.pin_configure = gpio_cc13xx_cc26xx_config,
 	.port_get_raw = gpio_cc13xx_cc26xx_port_get_raw,
 	.port_set_masked_raw = gpio_cc13xx_cc26xx_port_set_masked_raw,

--- a/drivers/gpio/gpio_cc32xx.c
+++ b/drivers/gpio/gpio_cc32xx.c
@@ -229,7 +229,7 @@ static void gpio_cc32xx_port_isr(const struct device *dev)
 	gpio_fire_callbacks(&data->callbacks, dev, int_status);
 }
 
-static const struct gpio_driver_api api_funcs = {
+static DEVICE_API(gpio, api_funcs) = {
 	.pin_configure = gpio_cc32xx_config,
 	.port_get_raw = gpio_cc32xx_port_get_raw,
 	.port_set_masked_raw = gpio_cc32xx_port_set_masked_raw,

--- a/drivers/gpio/gpio_cmsdk_ahb.c
+++ b/drivers/gpio/gpio_cmsdk_ahb.c
@@ -216,7 +216,7 @@ static int gpio_cmsdk_ahb_manage_callback(const struct device *dev,
 	return gpio_manage_callback(&data->gpio_cb, callback, set);
 }
 
-static const struct gpio_driver_api gpio_cmsdk_ahb_drv_api_funcs = {
+static DEVICE_API(gpio, gpio_cmsdk_ahb_drv_api_funcs) = {
 	.pin_configure = gpio_cmsdk_ahb_config,
 	.port_get_raw = gpio_cmsdk_ahb_port_get_raw,
 	.port_set_masked_raw = gpio_cmsdk_ahb_port_set_masked_raw,

--- a/drivers/gpio/gpio_creg_gpio.c
+++ b/drivers/gpio/gpio_creg_gpio.c
@@ -148,7 +148,7 @@ static int pin_config(const struct device *dev,
 	return -ENOTSUP;
 }
 
-static const struct gpio_driver_api api_table = {
+static DEVICE_API(gpio, api_table) = {
 	.pin_configure = pin_config,
 	.port_get_raw = port_get,
 	.port_set_masked_raw = port_set_masked,

--- a/drivers/gpio/gpio_cy8c95xx.c
+++ b/drivers/gpio/gpio_cy8c95xx.c
@@ -262,7 +262,7 @@ out:
 	return rc;
 }
 
-static const struct gpio_driver_api api_table = {
+static DEVICE_API(gpio, api_table) = {
 	.pin_configure = cy8c95xx_config,
 	.port_get_raw = port_get,
 	.port_set_masked_raw = port_set_masked,

--- a/drivers/gpio/gpio_davinci.c
+++ b/drivers/gpio/gpio_davinci.c
@@ -139,7 +139,7 @@ static int gpio_davinci_port_toggle_bits(const struct device *dev,
 	return 0;
 }
 
-static const struct gpio_driver_api gpio_davinci_driver_api = {
+static DEVICE_API(gpio, gpio_davinci_driver_api) = {
 	.pin_configure = gpio_davinci_configure,
 	.port_get_raw = gpio_davinci_port_get_raw,
 	.port_set_masked_raw = gpio_davinci_port_set_masked_raw,

--- a/drivers/gpio/gpio_dw.c
+++ b/drivers/gpio/gpio_dw.c
@@ -399,7 +399,7 @@ static void gpio_dw_isr(const struct device *port)
 }
 #endif /* DT_ANY_INST_HAS_PROP_STATUS_OKAY(interrupts) */
 
-static const struct gpio_driver_api api_funcs = {
+static DEVICE_API(gpio, api_funcs) = {
 	.pin_configure = gpio_dw_config,
 	.port_get_raw = gpio_dw_port_get_raw,
 	.port_set_masked_raw = gpio_dw_port_set_masked_raw,

--- a/drivers/gpio/gpio_efinix_sapphire.c
+++ b/drivers/gpio/gpio_efinix_sapphire.c
@@ -206,7 +206,7 @@ static int gpio_efinix_sapphire_init(const struct device *dev)
 }
 
 /* API map */
-static const struct gpio_driver_api gpio_efinix_sapphire_api = {
+static DEVICE_API(gpio, gpio_efinix_sapphire_api) = {
 	.pin_configure = gpio_efinix_sapphire_config,
 	.port_get_raw = gpio_efinix_sapphire_port_get_raw,
 	.port_set_masked_raw = gpio_efinix_sapphire_port_set_masked_raw,

--- a/drivers/gpio/gpio_emul.c
+++ b/drivers/gpio/gpio_emul.c
@@ -804,7 +804,7 @@ static int gpio_emul_port_get_direction(const struct device *port, gpio_port_pin
 }
 #endif /* CONFIG_GPIO_GET_DIRECTION */
 
-static const struct gpio_driver_api gpio_emul_driver = {
+static DEVICE_API(gpio, gpio_emul_driver) = {
 	.pin_configure = gpio_emul_pin_configure,
 #ifdef CONFIG_GPIO_GET_CONFIG
 	.pin_get_config = gpio_emul_pin_get_config,

--- a/drivers/gpio/gpio_ene_kb1200.c
+++ b/drivers/gpio/gpio_ene_kb1200.c
@@ -174,7 +174,7 @@ static uint32_t kb1200_gpio_get_pending_int(const struct device *dev)
 	return config->gptd_regs->GPTDPF;
 }
 
-static const struct gpio_driver_api kb1200_gpio_api = {
+static DEVICE_API(gpio, kb1200_gpio_api) = {
 	.pin_configure = kb1200_gpio_pin_configure,
 	.port_get_raw = kb1200_gpio_port_get_raw,
 	.port_set_masked_raw = kb1200_gpio_port_set_masked_raw,

--- a/drivers/gpio/gpio_eos_s3.c
+++ b/drivers/gpio/gpio_eos_s3.c
@@ -394,7 +394,7 @@ static int gpio_eos_s3_port_get_direction(const struct device *port, gpio_port_p
 }
 #endif /* CONFIG_GPIO_GET_DIRECTION */
 
-static const struct gpio_driver_api gpio_eos_s3_driver_api = {
+static DEVICE_API(gpio, gpio_eos_s3_driver_api) = {
 	.pin_configure = gpio_eos_s3_configure,
 	.port_get_raw = gpio_eos_s3_port_get_raw,
 	.port_set_masked_raw = gpio_eos_s3_port_set_masked_raw,

--- a/drivers/gpio/gpio_esp32.c
+++ b/drivers/gpio/gpio_esp32.c
@@ -498,7 +498,7 @@ static int gpio_esp32_init(const struct device *dev)
 	return 0;
 }
 
-static const struct gpio_driver_api gpio_esp32_driver_api = {
+static DEVICE_API(gpio, gpio_esp32_driver_api) = {
 	.pin_configure = gpio_esp32_config,
 	.port_get_raw = gpio_esp32_port_get_raw,
 	.port_set_masked_raw = gpio_esp32_port_set_masked_raw,

--- a/drivers/gpio/gpio_fxl6408.c
+++ b/drivers/gpio/gpio_fxl6408.c
@@ -393,7 +393,7 @@ int gpio_fxl6408_init(const struct device *dev)
 	return 0;
 }
 
-static const struct gpio_driver_api gpio_fxl_driver = {
+static DEVICE_API(gpio, gpio_fxl_driver) = {
 	.pin_configure = gpio_fxl6408_pin_config,
 	.port_get_raw = gpio_fxl6408_port_get_raw,
 	.port_set_masked_raw = gpio_fxl6408_port_set_masked_raw,

--- a/drivers/gpio/gpio_gd32.c
+++ b/drivers/gpio/gpio_gd32.c
@@ -333,7 +333,7 @@ static int gpio_gd32_manage_callback(const struct device *dev,
 	return gpio_manage_callback(&data->callbacks, callback, set);
 }
 
-static const struct gpio_driver_api gpio_gd32_api = {
+static DEVICE_API(gpio, gpio_gd32_api) = {
 	.pin_configure = gpio_gd32_configure,
 	.port_get_raw = gpio_gd32_port_get_raw,
 	.port_set_masked_raw = gpio_gd32_port_set_masked_raw,

--- a/drivers/gpio/gpio_gecko.c
+++ b/drivers/gpio/gpio_gecko.c
@@ -358,7 +358,7 @@ static void gpio_gecko_common_isr(const struct device *dev)
 	}
 }
 
-static const struct gpio_driver_api gpio_gecko_driver_api = {
+static DEVICE_API(gpio, gpio_gecko_driver_api) = {
 	.pin_configure = gpio_gecko_configure,
 #ifdef CONFIG_GPIO_GET_CONFIG
 	.pin_get_config = gpio_gecko_get_config,
@@ -372,7 +372,7 @@ static const struct gpio_driver_api gpio_gecko_driver_api = {
 	.manage_callback = gpio_gecko_manage_callback,
 };
 
-static const struct gpio_driver_api gpio_gecko_common_driver_api = {
+static DEVICE_API(gpio, gpio_gecko_common_driver_api) = {
 	.manage_callback = gpio_gecko_manage_callback,
 };
 

--- a/drivers/gpio/gpio_grgpio2.c
+++ b/drivers/gpio/gpio_grgpio2.c
@@ -269,7 +269,7 @@ static int grgpio_init(const struct device *dev)
 	return 0;
 }
 
-static const struct gpio_driver_api driver_api = {
+static DEVICE_API(gpio, driver_api) = {
 	.pin_configure                  = pin_configure,
 	.port_get_raw                   = port_get_raw,
 	.port_set_masked_raw            = port_set_masked_raw,

--- a/drivers/gpio/gpio_ifx_cat1.c
+++ b/drivers/gpio/gpio_ifx_cat1.c
@@ -221,7 +221,7 @@ static int gpio_cat1_manage_callback(const struct device *port,
 				    callback, set);
 }
 
-static const struct gpio_driver_api gpio_cat1_api = {
+static DEVICE_API(gpio, gpio_cat1_api) = {
 	.pin_configure = gpio_cat1_configure,
 	.port_get_raw = gpio_cat1_port_get_raw,
 	.port_set_masked_raw = gpio_cat1_port_set_masked_raw,

--- a/drivers/gpio/gpio_imx.c
+++ b/drivers/gpio/gpio_imx.c
@@ -253,7 +253,7 @@ static void imx_gpio_port_isr(const struct device *port)
 	gpio_fire_callbacks(&data->callbacks, port, int_status);
 }
 
-static const struct gpio_driver_api imx_gpio_driver_api = {
+static DEVICE_API(gpio, imx_gpio_driver_api) = {
 	.pin_configure = imx_gpio_configure,
 	.port_get_raw = imx_gpio_port_get_raw,
 	.port_set_masked_raw = imx_gpio_port_set_masked_raw,

--- a/drivers/gpio/gpio_intel.c
+++ b/drivers/gpio/gpio_intel.c
@@ -550,7 +550,7 @@ static int gpio_intel_port_get_raw(const struct device *dev,
 	return port_get_raw(dev, 0xFFFFFFFF, value, false);
 }
 
-static const struct gpio_driver_api gpio_intel_api = {
+static DEVICE_API(gpio, gpio_intel_api) = {
 	.pin_configure = gpio_intel_config,
 	.manage_callback = gpio_intel_manage_callback,
 	.port_get_raw = gpio_intel_port_get_raw,

--- a/drivers/gpio/gpio_iproc.c
+++ b/drivers/gpio/gpio_iproc.c
@@ -179,7 +179,7 @@ static int gpio_iproc_manage_callback(const struct device *port, struct gpio_cal
 	return gpio_manage_callback(&context->cb, callback, set);
 }
 
-static const struct gpio_driver_api gpio_iproc_api = {
+static DEVICE_API(gpio, gpio_iproc_api) = {
 	.pin_configure = gpio_iproc_configure,
 	.port_get_raw = gpio_iproc_port_get_raw,
 	.port_set_masked_raw = gpio_iproc_port_set_masked_raw,

--- a/drivers/gpio/gpio_ite_it8xxx2.c
+++ b/drivers/gpio/gpio_ite_it8xxx2.c
@@ -673,7 +673,7 @@ static int gpio_ite_pin_interrupt_configure(const struct device *dev,
 	return 0;
 }
 
-static const struct gpio_driver_api gpio_ite_driver_api = {
+static DEVICE_API(gpio, gpio_ite_driver_api) = {
 	.pin_configure = gpio_ite_configure,
 #ifdef CONFIG_GPIO_GET_CONFIG
 	.pin_get_config = gpio_ite_get_config,

--- a/drivers/gpio/gpio_ite_it8xxx2_v2.c
+++ b/drivers/gpio/gpio_ite_it8xxx2_v2.c
@@ -502,7 +502,7 @@ static int gpio_ite_pin_interrupt_configure(const struct device *dev,
 	return 0;
 }
 
-static const struct gpio_driver_api gpio_ite_driver_api = {
+static DEVICE_API(gpio, gpio_ite_driver_api) = {
 	.pin_configure = gpio_ite_configure,
 #ifdef CONFIG_GPIO_GET_CONFIG
 	.pin_get_config = gpio_ite_get_config,

--- a/drivers/gpio/gpio_kscan_ite_it8xxx2.c
+++ b/drivers/gpio/gpio_kscan_ite_it8xxx2.c
@@ -217,7 +217,7 @@ static int gpio_kscan_it8xxx2_port_toggle_bits(const struct device *dev,
 	return 0;
 }
 
-static const struct gpio_driver_api gpio_kscan_it8xxx2_driver_api = {
+static DEVICE_API(gpio, gpio_kscan_it8xxx2_driver_api) = {
 	.pin_configure = gpio_kscan_it8xxx2_configure,
 #ifdef CONFIG_GPIO_GET_CONFIG
 	.pin_get_config = gpio_kscan_it8xxx2_get_config,

--- a/drivers/gpio/gpio_litex.c
+++ b/drivers/gpio/gpio_litex.c
@@ -288,7 +288,7 @@ static int gpio_litex_port_get_direction(const struct device *dev, gpio_port_pin
 }
 #endif /* CONFIG_GPIO_GET_DIRECTION */
 
-static const struct gpio_driver_api gpio_litex_driver_api = {
+static DEVICE_API(gpio, gpio_litex_driver_api) = {
 	.pin_configure = gpio_litex_configure,
 	.port_get_raw = gpio_litex_port_get_raw,
 	.port_set_masked_raw = gpio_litex_port_set_masked_raw,

--- a/drivers/gpio/gpio_lmp90xxx.c
+++ b/drivers/gpio/gpio_lmp90xxx.c
@@ -135,7 +135,7 @@ static int gpio_lmp90xxx_init(const struct device *dev)
 	return 0;
 }
 
-static const struct gpio_driver_api gpio_lmp90xxx_api = {
+static DEVICE_API(gpio, gpio_lmp90xxx_api) = {
 	.pin_configure = gpio_lmp90xxx_config,
 	.port_set_masked_raw = gpio_lmp90xxx_port_set_masked_raw,
 	.port_set_bits_raw = gpio_lmp90xxx_port_set_bits_raw,

--- a/drivers/gpio/gpio_lpc11u6x.c
+++ b/drivers/gpio/gpio_lpc11u6x.c
@@ -482,7 +482,7 @@ static void gpio_lpc11u6x_isr(const void *arg)
 #endif
 }
 
-static const struct gpio_driver_api gpio_lpc11u6x_driver_api = {
+static DEVICE_API(gpio, gpio_lpc11u6x_driver_api) = {
 	.pin_configure = gpio_lpc11u6x_pin_configure,
 	.port_get_raw = gpio_lpc11u6x_port_get_raw,
 	.port_set_masked_raw = gpio_lpc11u6x_port_set_masked_raw,

--- a/drivers/gpio/gpio_max14906.c
+++ b/drivers/gpio/gpio_max14906.c
@@ -431,7 +431,7 @@ static int gpio_max14906_init(const struct device *dev)
 	return ret;
 }
 
-static const struct gpio_driver_api gpio_max14906_api = {
+static DEVICE_API(gpio, gpio_max14906_api) = {
 	.pin_configure = gpio_max14906_config,
 	.port_get_raw = gpio_max14906_port_get_raw,
 	.port_set_bits_raw = gpio_max14906_port_set_bits_raw,

--- a/drivers/gpio/gpio_max14916.c
+++ b/drivers/gpio/gpio_max14916.c
@@ -359,7 +359,7 @@ static int gpio_max14916_init(const struct device *dev)
 	return ret;
 }
 
-static const struct gpio_driver_api gpio_max14916_api = {
+static DEVICE_API(gpio, gpio_max14916_api) = {
 	.pin_configure = gpio_max14916_config,
 	.port_get_raw = gpio_max14916_port_get_raw,
 	.port_set_bits_raw = gpio_max14916_port_set_bits_raw,

--- a/drivers/gpio/gpio_max32.c
+++ b/drivers/gpio/gpio_max32.c
@@ -201,7 +201,7 @@ static int api_manage_callback(const struct device *dev, struct gpio_callback *c
 	return gpio_manage_callback(&(data->cb_list), callback, set);
 }
 
-static const struct gpio_driver_api gpio_max32_driver = {
+static DEVICE_API(gpio, gpio_max32_driver) = {
 	.pin_configure = api_pin_configure,
 	.port_get_raw = api_port_get_raw,
 	.port_set_masked_raw = api_port_set_masked_raw,

--- a/drivers/gpio/gpio_mchp_mss.c
+++ b/drivers/gpio/gpio_mchp_mss.c
@@ -194,7 +194,7 @@ static int mss_gpio_manage_callback(const struct device *dev,
 
 	return gpio_manage_callback(&data->cb, callback, set);
 }
-static const struct gpio_driver_api mss_gpio_driver = {
+static DEVICE_API(gpio, mss_gpio_driver) = {
 	.pin_configure           = mss_gpio_config,
 	.port_toggle_bits        = mss_gpio_port_toggle_bits,
 	.port_get_raw            = mss_gpio_port_get_raw,

--- a/drivers/gpio/gpio_mchp_xec.c
+++ b/drivers/gpio/gpio_mchp_xec.c
@@ -330,7 +330,7 @@ static void gpio_gpio_xec_port_isr(const struct device *dev)
 	gpio_fire_callbacks(&data->callbacks, dev, girq_result);
 }
 
-static const struct gpio_driver_api gpio_xec_driver_api = {
+static DEVICE_API(gpio, gpio_xec_driver_api) = {
 	.pin_configure = gpio_xec_configure,
 	.port_get_raw = gpio_xec_port_get_raw,
 	.port_set_masked_raw = gpio_xec_port_set_masked_raw,

--- a/drivers/gpio/gpio_mchp_xec_v2.c
+++ b/drivers/gpio/gpio_mchp_xec_v2.c
@@ -488,7 +488,7 @@ static void gpio_gpio_xec_port_isr(const struct device *dev)
 }
 
 /* GPIO driver official API table */
-static const struct gpio_driver_api gpio_xec_driver_api = {
+static DEVICE_API(gpio, gpio_xec_driver_api) = {
 	.pin_configure = gpio_xec_configure,
 	.port_get_raw = gpio_xec_port_get_raw,
 	.port_set_masked_raw = gpio_xec_port_set_masked_raw,

--- a/drivers/gpio/gpio_mcp23xxx.c
+++ b/drivers/gpio/gpio_mcp23xxx.c
@@ -464,7 +464,7 @@ static void mcp23xxx_int_gpio_handler(const struct device *port, struct gpio_cal
 	k_work_submit(&drv_data->work);
 }
 
-const struct gpio_driver_api gpio_mcp23xxx_api_table = {
+DEVICE_API(gpio, gpio_mcp23xxx_api_table) = {
 	.pin_configure = mcp23xxx_pin_cfg,
 	.port_get_raw = mcp23xxx_port_get_raw,
 	.port_set_masked_raw = mcp23xxx_port_set_masked_raw,

--- a/drivers/gpio/gpio_mcux.c
+++ b/drivers/gpio/gpio_mcux.c
@@ -390,7 +390,7 @@ static int gpio_mcux_port_get_direction(const struct device *dev, gpio_port_pins
 }
 #endif /* CONFIG_GPIO_GET_DIRECTION */
 
-static const struct gpio_driver_api gpio_mcux_driver_api = {
+static DEVICE_API(gpio, gpio_mcux_driver_api) = {
 	.pin_configure = gpio_mcux_configure,
 	.port_get_raw = gpio_mcux_port_get_raw,
 	.port_set_masked_raw = gpio_mcux_port_set_masked_raw,

--- a/drivers/gpio/gpio_mcux_igpio.c
+++ b/drivers/gpio/gpio_mcux_igpio.c
@@ -338,7 +338,7 @@ static void mcux_igpio_port_isr(const struct device *dev)
 	gpio_fire_callbacks(&data->callbacks, dev, int_flags);
 }
 
-static const struct gpio_driver_api mcux_igpio_driver_api = {
+static DEVICE_API(gpio, mcux_igpio_driver_api) = {
 	.pin_configure = mcux_igpio_configure,
 	.port_get_raw = mcux_igpio_port_get_raw,
 	.port_set_masked_raw = mcux_igpio_port_set_masked_raw,

--- a/drivers/gpio/gpio_mcux_lpc.c
+++ b/drivers/gpio/gpio_mcux_lpc.c
@@ -414,7 +414,7 @@ static int gpio_mcux_lpc_init(const struct device *dev)
 	return 0;
 }
 
-static const struct gpio_driver_api gpio_mcux_lpc_driver_api = {
+static DEVICE_API(gpio, gpio_mcux_lpc_driver_api) = {
 	.pin_configure = gpio_mcux_lpc_configure,
 	.port_get_raw = gpio_mcux_lpc_port_get_raw,
 	.port_set_masked_raw = gpio_mcux_lpc_port_set_masked_raw,

--- a/drivers/gpio/gpio_mcux_rgpio.c
+++ b/drivers/gpio/gpio_mcux_rgpio.c
@@ -267,7 +267,7 @@ static void mcux_rgpio_port_isr(const struct device *dev)
 	gpio_fire_callbacks(&data->callbacks, dev, int_flags);
 }
 
-static const struct gpio_driver_api mcux_rgpio_driver_api = {
+static DEVICE_API(gpio, mcux_rgpio_driver_api) = {
 	.pin_configure = mcux_rgpio_configure,
 	.port_get_raw = mcux_rgpio_port_get_raw,
 	.port_set_masked_raw = mcux_rgpio_port_set_masked_raw,

--- a/drivers/gpio/gpio_mmio32.c
+++ b/drivers/gpio/gpio_mmio32.c
@@ -147,7 +147,7 @@ static int gpio_mmio32_port_toggle_bits(const struct device *dev,
 	return 0;
 }
 
-const struct gpio_driver_api gpio_mmio32_api = {
+DEVICE_API(gpio, gpio_mmio32_api) = {
 	.pin_configure = gpio_mmio32_config,
 	.port_get_raw = gpio_mmio32_port_get_raw,
 	.port_set_masked_raw = gpio_mmio32_port_set_masked_raw,

--- a/drivers/gpio/gpio_nct38xx_port.c
+++ b/drivers/gpio/gpio_nct38xx_port.c
@@ -476,7 +476,7 @@ int gpio_nct38xx_dispatch_port_isr(const struct device *dev)
 	return 0;
 }
 
-static const struct gpio_driver_api gpio_nct38xx_driver = {
+static DEVICE_API(gpio, gpio_nct38xx_driver) = {
 	.pin_configure = gpio_nct38xx_pin_config,
 #ifdef CONFIG_GPIO_GET_CONFIG
 	.pin_get_config = gpio_nct38xx_pin_get_config,

--- a/drivers/gpio/gpio_neorv32.c
+++ b/drivers/gpio/gpio_neorv32.c
@@ -195,7 +195,7 @@ static int neorv32_gpio_init(const struct device *dev)
 	return 0;
 }
 
-static const struct gpio_driver_api neorv32_gpio_driver_api = {
+static DEVICE_API(gpio, neorv32_gpio_driver_api) = {
 	.pin_configure = neorv32_gpio_pin_configure,
 	.port_get_raw = neorv32_gpio_port_get_raw,
 	.port_set_masked_raw = neorv32_gpio_port_set_masked_raw,

--- a/drivers/gpio/gpio_npcx.c
+++ b/drivers/gpio/gpio_npcx.c
@@ -380,7 +380,7 @@ static int gpio_npcx_manage_callback(const struct device *dev,
 }
 
 /* GPIO driver registration */
-static const struct gpio_driver_api gpio_npcx_driver = {
+static DEVICE_API(gpio, gpio_npcx_driver) = {
 	.pin_configure = gpio_npcx_config,
 #ifdef CONFIG_GPIO_GET_CONFIG
 	.pin_get_config = gpio_npcx_pin_get_config,

--- a/drivers/gpio/gpio_npm1300.c
+++ b/drivers/gpio/gpio_npm1300.c
@@ -192,7 +192,7 @@ static int gpio_npm1300_port_toggle_bits(const struct device *dev, gpio_port_pin
 	return gpio_npm1300_port_set_masked_raw(dev, pins, ~value);
 }
 
-static const struct gpio_driver_api gpio_npm1300_api = {
+static DEVICE_API(gpio, gpio_npm1300_api) = {
 	.pin_configure = gpio_npm1300_configure,
 	.port_get_raw = gpio_npm1300_port_get_raw,
 	.port_set_masked_raw = gpio_npm1300_port_set_masked_raw,

--- a/drivers/gpio/gpio_npm6001.c
+++ b/drivers/gpio/gpio_npm6001.c
@@ -192,7 +192,7 @@ static int gpio_npm6001_port_toggle_bits(const struct device *dev,
 						~val & NPM6001_PIN_MSK);
 }
 
-static const struct gpio_driver_api gpio_npm6001_api = {
+static DEVICE_API(gpio, gpio_npm6001_api) = {
 	.pin_configure = gpio_npm6001_configure,
 	.port_get_raw = gpio_npm6001_port_get_raw,
 	.port_set_masked_raw = gpio_npm6001_port_set_masked_raw,

--- a/drivers/gpio/gpio_nrfx.c
+++ b/drivers/gpio/gpio_nrfx.c
@@ -506,7 +506,7 @@ static int gpio_nrfx_init(const struct device *port)
 	return 0;
 }
 
-static const struct gpio_driver_api gpio_nrfx_drv_api_funcs = {
+static DEVICE_API(gpio, gpio_nrfx_drv_api_funcs) = {
 	.pin_configure = gpio_nrfx_pin_configure,
 	.port_get_raw = gpio_nrfx_port_get_raw,
 	.port_set_masked_raw = gpio_nrfx_port_set_masked_raw,

--- a/drivers/gpio/gpio_numaker.c
+++ b/drivers/gpio/gpio_numaker.c
@@ -198,7 +198,7 @@ static int gpio_numaker_manage_callback(const struct device *dev, struct gpio_ca
 	return gpio_manage_callback(&data->callbacks, callback, set);
 }
 
-static const struct gpio_driver_api gpio_numaker_api = {
+static DEVICE_API(gpio, gpio_numaker_api) = {
 	.pin_configure = gpio_numaker_configure,
 	.port_get_raw = gpio_numaker_port_get_raw,
 	.port_set_masked_raw = gpio_numaker_port_set_masked_raw,

--- a/drivers/gpio/gpio_numicro.c
+++ b/drivers/gpio/gpio_numicro.c
@@ -237,7 +237,7 @@ static void gpio_numicro_isr(const struct device *dev)
 	gpio_fire_callbacks(&data->callbacks, dev, int_status);
 }
 
-static const struct gpio_driver_api gpio_numicro_driver_api = {
+static DEVICE_API(gpio, gpio_numicro_driver_api) = {
 	.pin_configure = gpio_numicro_configure,
 	.port_get_raw = gpio_numicro_port_get_raw,
 	.port_set_masked_raw = gpio_numicro_port_set_masked_raw,

--- a/drivers/gpio/gpio_nxp_s32.c
+++ b/drivers/gpio/gpio_nxp_s32.c
@@ -462,7 +462,7 @@ static int nxp_s32_gpio_port_get_direction(const struct device *dev,
 }
 #endif /* CONFIG_GPIO_GET_DIRECTION */
 
-static const struct gpio_driver_api gpio_nxp_s32_driver_api = {
+static DEVICE_API(gpio, gpio_nxp_s32_driver_api) = {
 	.pin_configure = nxp_s32_gpio_configure,
 	.port_get_raw = nxp_s32_gpio_port_get_raw,
 	.port_set_masked_raw = nxp_s32_gpio_port_set_masked_raw,

--- a/drivers/gpio/gpio_pca953x.c
+++ b/drivers/gpio/gpio_pca953x.c
@@ -467,7 +467,7 @@ out:
 	return rc;
 }
 
-static const struct gpio_driver_api api_table = {
+static DEVICE_API(gpio, api_table) = {
 	.pin_configure = gpio_pca953x_config,
 	.port_get_raw = gpio_pca953x_port_read,
 	.port_set_masked_raw = gpio_pca953x_port_set_masked,

--- a/drivers/gpio/gpio_pca95xx.c
+++ b/drivers/gpio/gpio_pca95xx.c
@@ -759,7 +759,7 @@ static int gpio_pca95xx_manage_callback(const struct device *dev,
 }
 #endif /* CONFIG_GPIO_PCA95XX_INTERRUPT */
 
-static const struct gpio_driver_api gpio_pca95xx_drv_api_funcs = {
+static DEVICE_API(gpio, gpio_pca95xx_drv_api_funcs) = {
 	.pin_configure = gpio_pca95xx_config,
 	.port_get_raw = gpio_pca95xx_port_get_raw,
 	.port_set_masked_raw = gpio_pca95xx_port_set_masked_raw,

--- a/drivers/gpio/gpio_pca_series.c
+++ b/drivers/gpio/gpio_pca_series.c
@@ -1639,7 +1639,7 @@ static void gpio_pca_series_gpio_int_handler(const struct device *dev,
  * gpio_pca_zephyr_gpio_api
  */
 
-static const struct gpio_driver_api gpio_pca_series_api_funcs_standard = {
+static DEVICE_API(gpio, gpio_pca_series_api_funcs_standard) = {
 	.pin_configure = gpio_pca_series_pin_configure,
 	.port_get_raw = gpio_pca_series_port_read_standard,
 	.port_set_masked_raw = gpio_pca_series_port_set_masked,
@@ -1652,7 +1652,7 @@ static const struct gpio_driver_api gpio_pca_series_api_funcs_standard = {
 #endif
 };
 
-static const struct gpio_driver_api gpio_pca_series_api_funcs_extended = {
+static DEVICE_API(gpio, gpio_pca_series_api_funcs_extended) = {
 	.pin_configure = gpio_pca_series_pin_configure,
 	.port_get_raw = gpio_pca_series_port_read_extended, /* special version used */
 	.port_set_masked_raw = gpio_pca_series_port_set_masked,

--- a/drivers/gpio/gpio_pcal64xxa.c
+++ b/drivers/gpio/gpio_pcal64xxa.c
@@ -1099,7 +1099,7 @@ int pcal64xxa_init(const struct device *dev)
 #define PCAL64XXA_AUTOMATIC_RESET(idx) !(DT_INST_PROP(idx, no_auto_reset))
 
 #define GPIO_PCAL6408A_INST(idx)                                                                   \
-	static const struct gpio_driver_api pcal6408a_drv_api##idx = {                             \
+	static DEVICE_API(gpio, pcal6408a_drv_api##idx) = {                             \
 		.pin_configure = pcal64xxa_pin_configure,                                          \
 		.port_get_raw = pcal64xxa_port_get_raw,                                            \
 		.port_set_masked_raw = pcal64xxa_port_set_masked_raw,                              \
@@ -1133,7 +1133,7 @@ int pcal64xxa_init(const struct device *dev)
 DT_INST_FOREACH_STATUS_OKAY(GPIO_PCAL6408A_INST)
 
 #define GPIO_PCAL6416A_INST(idx)                                                                   \
-	static const struct gpio_driver_api pcal6416a_drv_api##idx = {                             \
+	static DEVICE_API(gpio, pcal6416a_drv_api##idx) = {                             \
 		.pin_configure = pcal64xxa_pin_configure,                                          \
 		.port_get_raw = pcal64xxa_port_get_raw,                                            \
 		.port_set_masked_raw = pcal64xxa_port_set_masked_raw,                              \

--- a/drivers/gpio/gpio_pcf857x.c
+++ b/drivers/gpio/gpio_pcf857x.c
@@ -376,7 +376,7 @@ static int pcf857x_init(const struct device *dev)
 }
 
 /** Realizes the functions of gpio.h for pcf857x*/
-static const struct gpio_driver_api pcf857x_drv_api = {
+static DEVICE_API(gpio, pcf857x_drv_api) = {
 	.pin_configure = pcf857x_pin_configure,
 	.port_get_raw = pcf857x_port_get_raw,
 	.port_set_masked_raw = pcf857x_port_set_masked_raw,

--- a/drivers/gpio/gpio_psoc6.c
+++ b/drivers/gpio/gpio_psoc6.c
@@ -229,7 +229,7 @@ static uint32_t gpio_psoc6_get_pending_int(const struct device *dev)
 	return GPIO_PRT_INTR_MASKED(port);
 }
 
-static const struct gpio_driver_api gpio_psoc6_api = {
+static DEVICE_API(gpio, gpio_psoc6_api) = {
 	.pin_configure = gpio_psoc6_config,
 	.port_get_raw = gpio_psoc6_port_get_raw,
 	.port_set_masked_raw = gpio_psoc6_port_set_masked_raw,

--- a/drivers/gpio/gpio_rcar.c
+++ b/drivers/gpio/gpio_rcar.c
@@ -276,7 +276,7 @@ static int gpio_rcar_manage_callback(const struct device *dev,
 	return gpio_manage_callback(&data->cb, callback, set);
 }
 
-static const struct gpio_driver_api gpio_rcar_driver_api = {
+static DEVICE_API(gpio, gpio_rcar_driver_api) = {
 	.pin_configure = gpio_rcar_configure,
 	.port_get_raw = gpio_rcar_port_get_raw,
 	.port_set_masked_raw = gpio_rcar_port_set_masked_raw,

--- a/drivers/gpio/gpio_renesas_ra.c
+++ b/drivers/gpio/gpio_renesas_ra.c
@@ -358,7 +358,7 @@ static int gpio_ra_pin_interrupt_configure(const struct device *dev, gpio_pin_t 
 	return gpio_ra_pin_configure(dev, pin, pincfg | mode | trig);
 }
 
-static const struct gpio_driver_api gpio_ra_driver_api = {
+static DEVICE_API(gpio, gpio_ra_driver_api) = {
 	.pin_configure = gpio_ra_pin_configure,
 #ifdef CONFIG_GPIO_GET_CONFIG
 	.pin_get_config = gpio_ra_pin_get_config,

--- a/drivers/gpio/gpio_renesas_ra_ioport.c
+++ b/drivers/gpio/gpio_renesas_ra_ioport.c
@@ -145,7 +145,7 @@ static int gpio_ra_port_toggle_bits(const struct device *dev, gpio_port_pins_t p
 	return 0;
 }
 
-static const struct gpio_driver_api gpio_ra_drv_api_funcs = {
+static DEVICE_API(gpio, gpio_ra_drv_api_funcs) = {
 	.pin_configure = gpio_ra_pin_configure,
 	.port_get_raw = gpio_ra_port_get_raw,
 	.port_set_masked_raw = gpio_ra_port_set_masked_raw,

--- a/drivers/gpio/gpio_rpi_pico.c
+++ b/drivers/gpio/gpio_rpi_pico.c
@@ -178,7 +178,7 @@ static int gpio_rpi_manage_callback(const struct device *dev,
 	return gpio_manage_callback(&data->callbacks, callback, set);
 }
 
-static const struct gpio_driver_api gpio_rpi_driver_api = {
+static DEVICE_API(gpio, gpio_rpi_driver_api) = {
 	.pin_configure = gpio_rpi_configure,
 	.port_get_raw = gpio_rpi_port_get_raw,
 	.port_set_masked_raw = gpio_rpi_port_set_masked_raw,

--- a/drivers/gpio/gpio_rt1718s_port.c
+++ b/drivers/gpio/gpio_rt1718s_port.c
@@ -338,7 +338,7 @@ void rt1718s_gpio_alert_handler(const struct device *dev)
 	}
 }
 
-static const struct gpio_driver_api gpio_rt1718s_driver = {
+static DEVICE_API(gpio, gpio_rt1718s_driver) = {
 	.pin_configure = gpio_rt1718s_pin_config,
 	.port_get_raw = gpio_rt1718s_port_get_raw,
 	.port_set_masked_raw = gpio_rt1718s_port_set_masked_raw,

--- a/drivers/gpio/gpio_rv32m1.c
+++ b/drivers/gpio/gpio_rv32m1.c
@@ -286,7 +286,7 @@ static int gpio_rv32m1_init(const struct device *dev)
 	return config->irq_config_func(dev);
 }
 
-static const struct gpio_driver_api gpio_rv32m1_driver_api = {
+static DEVICE_API(gpio, gpio_rv32m1_driver_api) = {
 	.pin_configure = gpio_rv32m1_configure,
 	.port_get_raw = gpio_rv32m1_port_get_raw,
 	.port_set_masked_raw = gpio_rv32m1_port_set_masked_raw,

--- a/drivers/gpio/gpio_rzt2m.c
+++ b/drivers/gpio/gpio_rzt2m.c
@@ -393,7 +393,7 @@ static int rzt2m_gpio_manage_callback(const struct device *dev, struct gpio_call
 	return gpio_manage_callback(&data->cb, cb, set);
 }
 
-static const struct gpio_driver_api rzt2m_gpio_driver_api = {
+static DEVICE_API(gpio, rzt2m_gpio_driver_api) = {
 	.pin_configure = rzt2m_gpio_configure,
 	.port_get_raw = rzt2m_gpio_get_raw,
 	.port_set_masked_raw = rzt2m_port_set_masked_raw,

--- a/drivers/gpio/gpio_sam.c
+++ b/drivers/gpio/gpio_sam.c
@@ -293,7 +293,7 @@ static int gpio_sam_manage_callback(const struct device *port,
 	return gpio_manage_callback(&context->cb, callback, set);
 }
 
-static const struct gpio_driver_api gpio_sam_api = {
+static DEVICE_API(gpio, gpio_sam_api) = {
 	.pin_configure = gpio_sam_config,
 	.port_get_raw = gpio_sam_port_get_raw,
 	.port_set_masked_raw = gpio_sam_port_set_masked_raw,

--- a/drivers/gpio/gpio_sam0.c
+++ b/drivers/gpio/gpio_sam0.c
@@ -269,7 +269,7 @@ static uint32_t gpio_sam0_get_pending_int(const struct device *dev)
 
 #endif
 
-static const struct gpio_driver_api gpio_sam0_api = {
+static DEVICE_API(gpio, gpio_sam0_api) = {
 	.pin_configure = gpio_sam0_config,
 	.port_get_raw = gpio_sam0_port_get_raw,
 	.port_set_masked_raw = gpio_sam0_port_set_masked_raw,

--- a/drivers/gpio/gpio_sam4l.c
+++ b/drivers/gpio/gpio_sam4l.c
@@ -217,7 +217,7 @@ static int gpio_sam_manage_callback(const struct device *port,
 	return gpio_manage_callback(&context->cb, callback, set);
 }
 
-static const struct gpio_driver_api gpio_sam_api = {
+static DEVICE_API(gpio, gpio_sam_api) = {
 	.pin_configure = gpio_sam_config,
 	.port_get_raw = gpio_sam_port_get_raw,
 	.port_set_masked_raw = gpio_sam_port_set_masked_raw,

--- a/drivers/gpio/gpio_sc18im704.c
+++ b/drivers/gpio/gpio_sc18im704.c
@@ -251,7 +251,7 @@ static int gpio_sc18im_init(const struct device *dev)
 	return 0;
 }
 
-static const struct gpio_driver_api gpio_sc18im_driver_api = {
+static DEVICE_API(gpio, gpio_sc18im_driver_api) = {
 	.pin_configure = gpio_sc18im_pin_configure,
 #ifdef CONFIG_GPIO_GET_CONFIG
 	.pin_get_config = gpio_sc18im_pin_get_config,

--- a/drivers/gpio/gpio_sedi.c
+++ b/drivers/gpio/gpio_sedi.c
@@ -273,7 +273,7 @@ static uint32_t gpio_sedi_get_pending(const struct device *dev)
 	return sedi_gpio_get_gisr(gpio_dev, 0);
 }
 
-static const struct gpio_driver_api gpio_sedi_driver_api = {
+static DEVICE_API(gpio, gpio_sedi_driver_api) = {
 	.pin_configure = gpio_sedi_configure,
 	.port_get_raw = gpio_sedi_get_raw,
 	.port_set_masked_raw = gpio_sedi_set_masked_raw,

--- a/drivers/gpio/gpio_si32.c
+++ b/drivers/gpio/gpio_si32.c
@@ -159,7 +159,7 @@ static int gpio_si32_manage_callback(const struct device *dev, struct gpio_callb
 	return gpio_manage_callback(&data->cb, callback, set);
 }
 
-static const struct gpio_driver_api gpio_si32_driver = {
+static DEVICE_API(gpio, gpio_si32_driver) = {
 	.pin_configure = gpio_si32_configure,
 	.port_get_raw = gpio_si32_port_get_raw,
 	.port_set_masked_raw = gpio_si32_port_set_masked_raw,

--- a/drivers/gpio/gpio_sifive.c
+++ b/drivers/gpio/gpio_sifive.c
@@ -306,7 +306,7 @@ static int gpio_sifive_port_get_dir(const struct device *dev, gpio_port_pins_t m
 }
 #endif /* CONFIG_GPIO_GET_DIRECTION */
 
-static const struct gpio_driver_api gpio_sifive_driver = {
+static DEVICE_API(gpio, gpio_sifive_driver) = {
 	.pin_configure           = gpio_sifive_config,
 	.port_get_raw            = gpio_sifive_port_get_raw,
 	.port_set_masked_raw     = gpio_sifive_port_set_masked_raw,

--- a/drivers/gpio/gpio_smartbond.c
+++ b/drivers/gpio/gpio_smartbond.c
@@ -379,7 +379,7 @@ static int gpio_smartbond_pm_action(const struct device *dev,
 #endif /* CONFIG_PM_DEVICE */
 
 /* GPIO driver registration */
-static const struct gpio_driver_api gpio_smartbond_drv_api_funcs = {
+static DEVICE_API(gpio, gpio_smartbond_drv_api_funcs) = {
 	.pin_configure = gpio_smartbond_pin_configure,
 	.port_get_raw = gpio_smartbond_port_get_raw,
 	.port_set_masked_raw = gpio_smartbond_port_set_masked_raw,

--- a/drivers/gpio/gpio_sn74hc595.c
+++ b/drivers/gpio/gpio_sn74hc595.c
@@ -134,7 +134,7 @@ unlock:
 	return ret;
 }
 
-static const struct gpio_driver_api gpio_sn74hc595_drv_api_funcs = {
+static DEVICE_API(gpio, gpio_sn74hc595_drv_api_funcs) = {
 	.pin_configure = gpio_sn74hc595_config,
 	.port_get_raw = gpio_sn74hc595_port_get_raw,
 	.port_set_masked_raw = gpio_sn74hc595_port_set_masked_raw,

--- a/drivers/gpio/gpio_stellaris.c
+++ b/drivers/gpio/gpio_stellaris.c
@@ -247,7 +247,7 @@ static int gpio_stellaris_manage_callback(const struct device *dev,
 	return 0;
 }
 
-static const struct gpio_driver_api gpio_stellaris_driver_api = {
+static DEVICE_API(gpio, gpio_stellaris_driver_api) = {
 	.pin_configure = gpio_stellaris_configure,
 #ifdef CONFIG_GPIO_GET_CONFIG
 	.pin_get_config = gpio_stellaris_get_config,

--- a/drivers/gpio/gpio_stm32.c
+++ b/drivers/gpio/gpio_stm32.c
@@ -648,7 +648,7 @@ static int gpio_stm32_manage_callback(const struct device *dev,
 	return gpio_manage_callback(&data->cb, callback, set);
 }
 
-static const struct gpio_driver_api gpio_stm32_driver = {
+static DEVICE_API(gpio, gpio_stm32_driver) = {
 	.pin_configure = gpio_stm32_config,
 #if defined(CONFIG_GPIO_GET_CONFIG) && !defined(CONFIG_SOC_SERIES_STM32F1X)
 	.pin_get_config = gpio_stm32_get_config,

--- a/drivers/gpio/gpio_stmpe1600.c
+++ b/drivers/gpio/gpio_stmpe1600.c
@@ -285,7 +285,7 @@ static int stmpe1600_init(const struct device *dev)
 	return ret;
 }
 
-static const struct gpio_driver_api stmpe1600_drv_api = {
+static DEVICE_API(gpio, stmpe1600_drv_api) = {
 	.pin_configure = stmpe1600_configure,
 	.port_get_raw = stmpe1600_port_get_raw,
 	.port_set_masked_raw = stmpe1600_port_set_masked_raw,

--- a/drivers/gpio/gpio_sx1509b.c
+++ b/drivers/gpio/gpio_sx1509b.c
@@ -635,7 +635,7 @@ static int gpio_sx1509b_manage_callback(const struct device *dev,
 }
 #endif
 
-static const struct gpio_driver_api api_table = {
+static DEVICE_API(gpio, api_table) = {
 	.pin_configure = sx1509b_config,
 	.port_get_raw = port_get,
 	.port_set_masked_raw = port_set_masked,

--- a/drivers/gpio/gpio_tca6424a.c
+++ b/drivers/gpio/gpio_tca6424a.c
@@ -437,7 +437,7 @@ static int tca6424a_manage_callback(const struct device *dev, struct gpio_callba
 	return gpio_manage_callback(&drv_data->callbacks, callback, set);
 }
 
-static const struct gpio_driver_api tca6424a_drv_api = {
+static DEVICE_API(gpio, tca6424a_drv_api) = {
 	.pin_configure = tca6424a_pin_config,
 	.port_get_raw = tca6424a_port_get_raw,
 	.port_set_masked_raw = tca6424a_port_set_masked_raw,

--- a/drivers/gpio/gpio_test.c
+++ b/drivers/gpio/gpio_test.c
@@ -63,7 +63,7 @@ static int vnd_gpio_port_toggle_bits(const struct device *port,
 	return -ENOTSUP;
 }
 
-static const struct gpio_driver_api vnd_gpio_api = {
+static DEVICE_API(gpio, vnd_gpio_api) = {
 	.pin_configure = vnd_gpio_pin_configure,
 	.port_get_raw = vnd_gpio_port_get_raw,
 	.port_set_masked_raw = vnd_gpio_port_set_masked_raw,

--- a/drivers/gpio/gpio_tle9104.c
+++ b/drivers/gpio/gpio_tle9104.c
@@ -194,7 +194,7 @@ static int tle9104_gpio_pin_interrupt_configure(const struct device *dev, gpio_p
 	return -ENOTSUP;
 }
 
-static const struct gpio_driver_api api_table = {
+static DEVICE_API(gpio, api_table) = {
 	.pin_configure = tle9104_gpio_pin_configure,
 	.port_get_raw = tle9104_gpio_port_get_raw,
 	.port_set_masked_raw = tle9104_gpio_port_set_masked_raw,

--- a/drivers/gpio/gpio_xlnx_axi.c
+++ b/drivers/gpio/gpio_xlnx_axi.c
@@ -366,7 +366,7 @@ static int gpio_xlnx_axi_init(const struct device *dev)
 	return 0;
 }
 
-static const struct gpio_driver_api gpio_xlnx_axi_driver_api = {
+static DEVICE_API(gpio, gpio_xlnx_axi_driver_api) = {
 	.pin_configure = gpio_xlnx_axi_pin_configure,
 	.port_get_raw = gpio_xlnx_axi_port_get_raw,
 	.port_set_masked_raw = gpio_xlnx_axi_port_set_masked_raw,

--- a/drivers/gpio/gpio_xlnx_ps.c
+++ b/drivers/gpio/gpio_xlnx_ps.c
@@ -24,7 +24,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
  * An API is required for this driver, but as no pin access is provided at
  * this level, use the default API contents provided by the driver subsystem.
  */
-static const struct gpio_driver_api gpio_xlnx_ps_default_apis;
+static DEVICE_API(gpio, gpio_xlnx_ps_default_apis);
 
 /**
  * @brief Initialize a Xilinx PS GPIO controller parent device

--- a/drivers/gpio/gpio_xlnx_ps_bank.c
+++ b/drivers/gpio/gpio_xlnx_ps_bank.c
@@ -393,7 +393,7 @@ static int gpio_xlnx_ps_bank_manage_callback(const struct device *dev,
 }
 
 /* GPIO bank device driver API */
-static const struct gpio_driver_api gpio_xlnx_ps_bank_apis = {
+static DEVICE_API(gpio, gpio_xlnx_ps_bank_apis) = {
 	.pin_configure = gpio_xlnx_ps_pin_configure,
 	.port_get_raw = gpio_xlnx_ps_bank_get,
 	.port_set_masked_raw = gpio_xlnx_ps_bank_set_masked,

--- a/drivers/gpio/gpio_xmc4xxx.c
+++ b/drivers/gpio/gpio_xmc4xxx.c
@@ -201,7 +201,7 @@ static int gpio_xmc4xxx_toggle_bits(const struct device *dev, gpio_port_pins_t p
 
 static int gpio_xmc4xxx_init(const struct device *dev) { return 0; }
 
-static const struct gpio_driver_api gpio_xmc4xxx_driver_api = {
+static DEVICE_API(gpio, gpio_xmc4xxx_driver_api) = {
 	.pin_configure = gpio_xmc4xxx_pin_configure,
 	.port_get_raw = gpio_xmc4xxx_get_raw,
 	.port_set_masked_raw = gpio_xmc4xxx_set_masked_raw,

--- a/drivers/gpio/wch_gpio_ch32v00x.c
+++ b/drivers/gpio/wch_gpio_ch32v00x.c
@@ -106,7 +106,7 @@ static int gpio_ch32v00x_port_toggle_bits(const struct device *dev, uint32_t pin
 	return 0;
 }
 
-static const struct gpio_driver_api gpio_ch32v00x_driver_api = {
+static DEVICE_API(gpio, gpio_ch32v00x_driver_api) = {
 	.pin_configure = gpio_ch32v00x_configure,
 	.port_get_raw = gpio_ch32v00x_port_get_raw,
 	.port_set_masked_raw = gpio_ch32v00x_port_set_masked_raw,

--- a/tests/kernel/device/src/main.c
+++ b/tests/kernel/device/src/main.c
@@ -30,7 +30,7 @@ DEVICE_DEFINE(dummy_noinit, DUMMY_NOINIT, NULL, NULL, NULL, NULL,
 	      POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, NULL);
 
 /* To access from userspace, the device needs an API. Use a dummy GPIO one */
-static const struct gpio_driver_api fakedeferdriverapi;
+static DEVICE_API(gpio, fakedeferdriverapi);
 
 /* Fake deferred devices */
 DEVICE_DT_DEFINE(DT_INST(0, fakedeferdriver), NULL, NULL, NULL, NULL,

--- a/tests/lib/devicetree/api/src/main.c
+++ b/tests/lib/devicetree/api/src/main.c
@@ -1919,7 +1919,7 @@ static int test_gpio_init(const struct device *dev)
 #undef DT_DRV_COMPAT
 #define DT_DRV_COMPAT vnd_gpio_device
 
-static const struct gpio_driver_api test_api;
+static DEVICE_API(gpio, test_api);
 
 #define TEST_GPIO_INIT(num)					\
 	static struct test_gpio_data gpio_data_##num = {	\


### PR DESCRIPTION
Add wrapper DEVICE_API macro to all gpio_driver_api instances.