### PR TITLE
drivers: haptics: Place API into iterable section

### DIFF
--- a/drivers/haptics/drv2605.c
+++ b/drivers/haptics/drv2605.c
@@ -612,7 +612,7 @@ static int drv2605_init(const struct device *dev)
 	return 0;
 }
 
-static const struct haptics_driver_api drv2605_driver_api = {
+static DEVICE_API(haptics, drv2605_driver_api) = {
 	.start_output = &drv2605_start_output,
 	.stop_output = &drv2605_stop_output,
 };


### PR DESCRIPTION
Add wrapper DEVICE_API macro to all haptics_driver_api instances.