### PR TITLE
manifest: nrf_wifi: Pull fix for RSSI in promiscuous mode

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -309,7 +309,7 @@ manifest:
       revision: 3cfca0192ff84da919e9bc7978bcc2239cd6a395
       path: modules/bsim_hw_models/nrf_hw_models
     - name: nrf_wifi
-      revision: f9e2abdb70761003912b1b929a37b536f68a91da
+      revision: 675e15c88cceaf6166e9132b3d2aad1c86b6bd25
       path: modules/lib/nrf_wifi
     - name: open-amp
       revision: b735edbc739ad59156eb55bb8ce2583d74537719


### PR DESCRIPTION
This pulls in fix for rssi callback API when promiscuous mode is enabled. 