### PR TITLE
dts: bindings: rename nxp,kinetis-lpuart compatible

### DIFF
--- a/doc/releases/migration-guide-4.1.rst
+++ b/doc/releases/migration-guide-4.1.rst
@@ -181,6 +181,8 @@ Sensors
 Serial
 ======
 
+* Renamed the ``compatible`` from ``nxp,kinetis-lpuart`` to :dtcompatible:`nxp,lpuart`.
+
 Stepper
 =======
 

--- a/drivers/serial/Kconfig.mcux_lpuart
+++ b/drivers/serial/Kconfig.mcux_lpuart
@@ -6,7 +6,7 @@
 config UART_MCUX_LPUART
 	bool "MCUX LPUART driver"
 	default y
-	depends on DT_HAS_NXP_KINETIS_LPUART_ENABLED
+	depends on DT_HAS_NXP_LPUART_ENABLED
 	depends on CLOCK_CONTROL
 	select SERIAL_HAS_DRIVER
 	select SERIAL_SUPPORT_INTERRUPT

--- a/drivers/serial/uart_mcux_lpuart.c
+++ b/drivers/serial/uart_mcux_lpuart.c
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#define DT_DRV_COMPAT nxp_kinetis_lpuart
+#define DT_DRV_COMPAT nxp_lpuart
 
 #include <errno.h>
 #include <zephyr/device.h>

--- a/dts/arm/nxp/nxp_imx93_m33.dtsi
+++ b/dts/arm/nxp/nxp_imx93_m33.dtsi
@@ -89,7 +89,7 @@
 		};
 
 		lpuart2: serial@44390000 {
-			compatible = "nxp,imx-lpuart", "nxp,kinetis-lpuart";
+			compatible = "nxp,imx-lpuart", "nxp,lpuart";
 			reg = <0x44390000 DT_SIZE_K(64)>;
 			interrupts = <20 3>;
 			clocks = <&ccm IMX_CCM_LPUART2_CLK 0x6c 24>;

--- a/dts/arm/nxp/nxp_imx95_m7.dtsi
+++ b/dts/arm/nxp/nxp_imx95_m7.dtsi
@@ -149,7 +149,7 @@
 		};
 
 		lpuart3: serial@42570000 {
-			compatible = "nxp,imx-lpuart", "nxp,kinetis-lpuart";
+			compatible = "nxp,imx-lpuart", "nxp,lpuart";
 			reg = <0x42570000 DT_SIZE_K(64)>;
 			interrupts = <64 3>;
 			clocks = <&scmi_clk IMX95_CLK_LPUART3>;
@@ -157,7 +157,7 @@
 		};
 
 		lpuart4: serial@42580000 {
-			compatible = "nxp,imx-lpuart", "nxp,kinetis-lpuart";
+			compatible = "nxp,imx-lpuart", "nxp,lpuart";
 			reg = <0x42580000 DT_SIZE_K(64)>;
 			interrupts = <65 3>;
 			clocks = <&scmi_clk IMX95_CLK_LPUART4>;
@@ -165,7 +165,7 @@
 		};
 
 		lpuart5: serial@42590000 {
-			compatible = "nxp,imx-lpuart", "nxp,kinetis-lpuart";
+			compatible = "nxp,imx-lpuart", "nxp,lpuart";
 			reg = <0x42590000 DT_SIZE_K(64)>;
 			interrupts = <66 3>;
 			clocks = <&scmi_clk IMX95_CLK_LPUART5>;
@@ -173,7 +173,7 @@
 		};
 
 		lpuart6: serial@425a0000 {
-			compatible = "nxp,imx-lpuart", "nxp,kinetis-lpuart";
+			compatible = "nxp,imx-lpuart", "nxp,lpuart";
 			reg = <0x425a0000 DT_SIZE_K(64)>;
 			interrupts = <67 3>;
 			clocks = <&scmi_clk IMX95_CLK_LPUART6>;
@@ -194,7 +194,7 @@
 		};
 
 		lpuart7: serial@42690000 {
-			compatible = "nxp,imx-lpuart", "nxp,kinetis-lpuart";
+			compatible = "nxp,imx-lpuart", "nxp,lpuart";
 			reg = <0x42690000 DT_SIZE_K(64)>;
 			interrupts = <68 3>;
 			clocks = <&scmi_clk IMX95_CLK_LPUART7>;
@@ -202,7 +202,7 @@
 		};
 
 		lpuart8: serial@426a0000 {
-			compatible = "nxp,imx-lpuart", "nxp,kinetis-lpuart";
+			compatible = "nxp,imx-lpuart", "nxp,lpuart";
 			reg = <0x426a0000 DT_SIZE_K(64)>;
 			interrupts = <69 3>;
 			clocks = <&scmi_clk IMX95_CLK_LPUART8>;
@@ -296,7 +296,7 @@
 		};
 
 		lpuart1: serial@44380000 {
-			compatible = "nxp,imx-lpuart", "nxp,kinetis-lpuart";
+			compatible = "nxp,imx-lpuart", "nxp,lpuart";
 			reg = <0x44380000 DT_SIZE_K(64)>;
 			interrupts = <19 3>;
 			clocks = <&scmi_clk IMX95_CLK_LPUART1>;
@@ -304,7 +304,7 @@
 		};
 
 		lpuart2: serial@44390000 {
-			compatible = "nxp,imx-lpuart", "nxp,kinetis-lpuart";
+			compatible = "nxp,imx-lpuart", "nxp,lpuart";
 			reg = <0x44390000 DT_SIZE_K(64)>;
 			interrupts = <20 3>;
 			clocks = <&scmi_clk IMX95_CLK_LPUART2>;

--- a/dts/arm/nxp/nxp_k66.dtsi
+++ b/dts/arm/nxp/nxp_k66.dtsi
@@ -14,7 +14,7 @@
 / {
 	soc {
 		lpuart0: lpuart@400c4000 {
-			compatible = "nxp,kinetis-lpuart";
+			compatible = "nxp,lpuart";
 			reg = <0x400c4000 0x14>;
 			interrupts = <86 0>;
 			clocks = <&sim KINETIS_SIM_CORESYS_CLK 0x1038 20>;

--- a/dts/arm/nxp/nxp_k8x.dtsi
+++ b/dts/arm/nxp/nxp_k8x.dtsi
@@ -210,7 +210,7 @@
 		};
 
 		lpuart0: lpuart@400c4000 {
-			compatible = "nxp,kinetis-lpuart";
+			compatible = "nxp,lpuart";
 			reg = <0x400c4000 0x1000>;
 			interrupts = <30 0>;
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x102c 4>;
@@ -220,7 +220,7 @@
 		};
 
 		lpuart1: lpuart@400c5000 {
-			compatible = "nxp,kinetis-lpuart";
+			compatible = "nxp,lpuart";
 			reg = <0x400c5000 0x1000>;
 			interrupts = <31 0>;
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x102c 5>;
@@ -230,7 +230,7 @@
 		};
 
 		lpuart2: lpuart@400c6000 {
-			compatible = "nxp,kinetis-lpuart";
+			compatible = "nxp,lpuart";
 			reg = <0x400c6000 0x1000>;
 			interrupts = <32 0>;
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x102c 6>;
@@ -240,7 +240,7 @@
 		};
 
 		lpuart3: lpuart@400c7000 {
-			compatible = "nxp,kinetis-lpuart";
+			compatible = "nxp,lpuart";
 			reg = <0x400c7000 0x1000>;
 			interrupts = <33 0>;
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x102c 7>;
@@ -250,7 +250,7 @@
 		};
 
 		lpuart4: lpuart@400d6000 {
-			compatible = "nxp,kinetis-lpuart";
+			compatible = "nxp,lpuart";
 			reg = <0x400d6000 0x1000>;
 			interrupts = <34 0>;
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x102c 22>;

--- a/dts/arm/nxp/nxp_ke1xf.dtsi
+++ b/dts/arm/nxp/nxp_ke1xf.dtsi
@@ -325,7 +325,7 @@
 		};
 
 		lpuart0: uart@4006a000 {
-			compatible = "nxp,kinetis-lpuart";
+			compatible = "nxp,lpuart";
 			reg = <0x4006a000 0x1000>;
 			interrupts = <31 0>, <32 0>;
 			interrupt-names = "transmit", "receive";
@@ -336,7 +336,7 @@
 		};
 
 		lpuart1: uart@4006b000 {
-			compatible = "nxp,kinetis-lpuart";
+			compatible = "nxp,lpuart";
 			reg = <0x4006b000 0x1000>;
 			interrupts = <33 0>, <34 0>;
 			interrupt-names = "transmit", "receive";
@@ -347,7 +347,7 @@
 		};
 
 		lpuart2: uart@4006c000 {
-			compatible = "nxp,kinetis-lpuart";
+			compatible = "nxp,lpuart";
 			reg = <0x4006c000 0x1000>;
 			interrupts = <35 0>, <36 0>;
 			interrupt-names = "transmit", "receive";

--- a/dts/arm/nxp/nxp_ke1xz.dtsi
+++ b/dts/arm/nxp/nxp_ke1xz.dtsi
@@ -153,7 +153,7 @@
 		};
 
 		lpuart0: uart@4006a000 {
-			compatible = "nxp,kinetis-lpuart";
+			compatible = "nxp,lpuart";
 			reg = <0x4006a000 0x1000>;
 			interrupts = <12 0>;
 			clocks = <&pcc 0x1a8 KINETIS_PCC_SRC_FIRC_ASYNC>;
@@ -161,7 +161,7 @@
 		};
 
 		lpuart1: uart@4006b000 {
-			compatible = "nxp,kinetis-lpuart";
+			compatible = "nxp,lpuart";
 			reg = <0x4006b000 0x1000>;
 			interrupts = <13 0>;
 			clocks = <&pcc 0x1ac KINETIS_PCC_SRC_FIRC_ASYNC>;
@@ -169,7 +169,7 @@
 		};
 
 		lpuart2: uart@4006c000 {
-			compatible = "nxp,kinetis-lpuart";
+			compatible = "nxp,lpuart";
 			reg = <0x4006c000 0x1000>;
 			interrupts = <14 0>;
 			clocks = <&pcc 0x1b0 KINETIS_PCC_SRC_FIRC_ASYNC>;

--- a/dts/arm/nxp/nxp_kw40z.dtsi
+++ b/dts/arm/nxp/nxp_kw40z.dtsi
@@ -115,7 +115,7 @@
 		};
 
 		lpuart0: lpuart@40054000 {
-			compatible = "nxp,kinetis-lpuart";
+			compatible = "nxp,lpuart";
 			reg = <0x40054000 0x18>;
 			interrupts = <12 0>;
 			clocks = <&sim KINETIS_SIM_CORESYS_CLK 0x1038 20>;

--- a/dts/arm/nxp/nxp_kw41z.dtsi
+++ b/dts/arm/nxp/nxp_kw41z.dtsi
@@ -122,7 +122,7 @@
 		};
 
 		lpuart0: lpuart@40054000 {
-			compatible = "nxp,kinetis-lpuart";
+			compatible = "nxp,lpuart";
 			reg = <0x40054000 0x18>;
 			interrupts = <12 0>;
 			clocks = <&sim KINETIS_SIM_CORESYS_CLK 0x1038 20>;

--- a/dts/arm/nxp/nxp_mcxa156.dtsi
+++ b/dts/arm/nxp/nxp_mcxa156.dtsi
@@ -129,7 +129,7 @@
 		};
 
 		lpuart0: lpuart@4009f000 {
-			compatible = "nxp,kinetis-lpuart";
+			compatible = "nxp,lpuart";
 			reg = <0x4009f000 0x1000>;
 			interrupts = <31 0>;
 			clocks = <&syscon MCUX_LPUART0_CLK>;

--- a/dts/arm/nxp/nxp_mcxc_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxc_common.dtsi
@@ -223,7 +223,7 @@
 		};
 
 		lpuart0: uart@40054000 {
-			compatible = "nxp,kinetis-lpuart";
+			compatible = "nxp,lpuart";
 			reg = <0x40054000 0x1000>;
 			interrupts = <12 0>;
 			clocks = <&sim KINETIS_SIM_MCGPCLK 0x1038 20>;
@@ -231,7 +231,7 @@
 		};
 
 		lpuart1: uart@40055000 {
-			compatible = "nxp,kinetis-lpuart";
+			compatible = "nxp,lpuart";
 			reg = <0x40055000 0x1000>;
 			interrupts = <13 0>;
 			clocks = <&sim KINETIS_SIM_MCGPCLK 0x1038 21>;

--- a/dts/arm/nxp/nxp_mcxn23x_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxn23x_common.dtsi
@@ -180,7 +180,7 @@
 		#size-cells = <1>;
 
 		flexcomm0_lpuart0: lpuart@92000 {
-			compatible = "nxp,kinetis-lpuart";
+			compatible = "nxp,lpuart";
 			reg = <0x92000 0x1000>;
 			clocks = <&syscon MCUX_FLEXCOMM0_CLK>;
 			status = "disabled";
@@ -214,7 +214,7 @@
 		#size-cells = <1>;
 
 		flexcomm1_lpuart1: lpuart@93000 {
-			compatible = "nxp,kinetis-lpuart";
+			compatible = "nxp,lpuart";
 			reg = <0x93000 0x1000>;
 			clocks = <&syscon MCUX_FLEXCOMM1_CLK>;
 			/* DMA channels 0 and 1, muxed to LPUART1 RX and TX */
@@ -254,7 +254,7 @@
 		#size-cells = <1>;
 
 		flexcomm2_lpuart2: lpuart@94000 {
-			compatible = "nxp,kinetis-lpuart";
+			compatible = "nxp,lpuart";
 			reg = <0x94000 0x1000>;
 			clocks = <&syscon MCUX_FLEXCOMM2_CLK>;
 			/* DMA channels 4 and 5, muxed to LPUART2 RX and TX */
@@ -294,7 +294,7 @@
 		#size-cells = <1>;
 
 		flexcomm3_lpuart3: lpuart@95000 {
-			compatible = "nxp,kinetis-lpuart";
+			compatible = "nxp,lpuart";
 			reg = <0x95000 0x1000>;
 			clocks = <&syscon MCUX_FLEXCOMM3_CLK>;
 			status = "disabled";
@@ -328,7 +328,7 @@
 		#size-cells = <1>;
 
 		flexcomm4_lpuart4: lpuart@b4000 {
-			compatible = "nxp,kinetis-lpuart";
+			compatible = "nxp,lpuart";
 			reg = <0xb4000 0x1000>;
 			clocks = <&syscon MCUX_FLEXCOMM4_CLK>;
 			/* DMA channels 2 and 3, muxed to LPUART4 RX and TX */
@@ -368,7 +368,7 @@
 		#size-cells = <1>;
 
 		flexcomm5_lpuart5: lpuart@b5000 {
-			compatible = "nxp,kinetis-lpuart";
+			compatible = "nxp,lpuart";
 			reg = <0xb5000 0x1000>;
 			clocks = <&syscon MCUX_FLEXCOMM5_CLK>;
 			status = "disabled";
@@ -402,7 +402,7 @@
 		#size-cells = <1>;
 
 		flexcomm6_lpuart6: lpuart@b6000 {
-			compatible = "nxp,kinetis-lpuart";
+			compatible = "nxp,lpuart";
 			reg = <0xb6000 0x1000>;
 			clocks = <&syscon MCUX_FLEXCOMM6_CLK>;
 			status = "disabled";
@@ -436,7 +436,7 @@
 		#size-cells = <1>;
 
 		flexcomm7_lpuart7: lpuart@b7000 {
-			compatible = "nxp,kinetis-lpuart";
+			compatible = "nxp,lpuart";
 			reg = <0xb7000 0x1000>;
 			clocks = <&syscon MCUX_FLEXCOMM7_CLK>;
 			status = "disabled";

--- a/dts/arm/nxp/nxp_mcxn94x_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxn94x_common.dtsi
@@ -187,7 +187,7 @@
 		#size-cells = <1>;
 
 		flexcomm0_lpuart0: lpuart@92000 {
-			compatible = "nxp,kinetis-lpuart";
+			compatible = "nxp,lpuart";
 			reg = <0x92000 0x1000>;
 			clocks = <&syscon MCUX_FLEXCOMM0_CLK>;
 			status = "disabled";
@@ -221,7 +221,7 @@
 		#size-cells = <1>;
 
 		flexcomm1_lpuart1: lpuart@93000 {
-			compatible = "nxp,kinetis-lpuart";
+			compatible = "nxp,lpuart";
 			reg = <0x93000 0x1000>;
 			clocks = <&syscon MCUX_FLEXCOMM1_CLK>;
 			/* DMA channels 0 and 1, muxed to LPUART1 RX and TX */
@@ -261,7 +261,7 @@
 		#size-cells = <1>;
 
 		flexcomm2_lpuart2: lpuart@94000 {
-			compatible = "nxp,kinetis-lpuart";
+			compatible = "nxp,lpuart";
 			reg = <0x94000 0x1000>;
 			clocks = <&syscon MCUX_FLEXCOMM2_CLK>;
 			/* DMA channels 4 and 5, muxed to LPUART2 RX and TX */
@@ -301,7 +301,7 @@
 		#size-cells = <1>;
 
 		flexcomm3_lpuart3: lpuart@95000 {
-			compatible = "nxp,kinetis-lpuart";
+			compatible = "nxp,lpuart";
 			reg = <0x95000 0x1000>;
 			clocks = <&syscon MCUX_FLEXCOMM3_CLK>;
 			status = "disabled";
@@ -335,7 +335,7 @@
 		#size-cells = <1>;
 
 		flexcomm4_lpuart4: lpuart@b4000 {
-			compatible = "nxp,kinetis-lpuart";
+			compatible = "nxp,lpuart";
 			reg = <0xb4000 0x1000>;
 			clocks = <&syscon MCUX_FLEXCOMM4_CLK>;
 			/* DMA channels 2 and 3, muxed to LPUART4 RX and TX */
@@ -375,7 +375,7 @@
 		#size-cells = <1>;
 
 		flexcomm5_lpuart5: lpuart@b5000 {
-			compatible = "nxp,kinetis-lpuart";
+			compatible = "nxp,lpuart";
 			reg = <0xb5000 0x1000>;
 			clocks = <&syscon MCUX_FLEXCOMM5_CLK>;
 			status = "disabled";
@@ -409,7 +409,7 @@
 		#size-cells = <1>;
 
 		flexcomm6_lpuart6: lpuart@b6000 {
-			compatible = "nxp,kinetis-lpuart";
+			compatible = "nxp,lpuart";
 			reg = <0xb6000 0x1000>;
 			clocks = <&syscon MCUX_FLEXCOMM6_CLK>;
 			status = "disabled";
@@ -443,7 +443,7 @@
 		#size-cells = <1>;
 
 		flexcomm7_lpuart7: lpuart@b7000 {
-			compatible = "nxp,kinetis-lpuart";
+			compatible = "nxp,lpuart";
 			reg = <0xb7000 0x1000>;
 			clocks = <&syscon MCUX_FLEXCOMM7_CLK>;
 			status = "disabled";
@@ -477,7 +477,7 @@
 		#size-cells = <1>;
 
 		flexcomm8_lpuart8: lpuart@b8000 {
-			compatible = "nxp,kinetis-lpuart";
+			compatible = "nxp,lpuart";
 			reg = <0xb8000 0x1000>;
 			clocks = <&syscon MCUX_FLEXCOMM8_CLK>;
 			status = "disabled";
@@ -511,7 +511,7 @@
 		#size-cells = <1>;
 
 		flexcomm9_lpuart9: lpuart@b9000 {
-			compatible = "nxp,kinetis-lpuart";
+			compatible = "nxp,lpuart";
 			reg = <0xb9000 0x1000>;
 			clocks = <&syscon MCUX_FLEXCOMM9_CLK>;
 			status = "disabled";

--- a/dts/arm/nxp/nxp_mcxw71.dtsi
+++ b/dts/arm/nxp/nxp_mcxw71.dtsi
@@ -171,7 +171,7 @@
 	};
 
 	lpuart0: serial@38000 {
-		compatible = "nxp,kinetis-lpuart";
+		compatible = "nxp,lpuart";
 		reg = <0x38000 0x34>;
 		interrupts = <44 0>;
 		clocks = <&scg SCG_K4_FIRC_CLK 0xe0>;
@@ -179,7 +179,7 @@
 	};
 
 	lpuart1: serial@39000 {
-		compatible = "nxp,kinetis-lpuart";
+		compatible = "nxp,lpuart";
 		reg = <0x39000 0x34>;
 		interrupts = <45 0>;
 		clocks = <&scg SCG_K4_FIRC_CLK 0xe4>;

--- a/dts/arm/nxp/nxp_rt10xx.dtsi
+++ b/dts/arm/nxp/nxp_rt10xx.dtsi
@@ -493,7 +493,7 @@
 		};
 
 		lpuart1: uart@40184000 {
-			compatible = "nxp,kinetis-lpuart";
+			compatible = "nxp,lpuart";
 			reg = <0x40184000 0x4000>;
 			interrupts = <20 0>;
 			clocks = <&ccm IMX_CCM_LPUART_CLK 0x7c 24>;
@@ -503,7 +503,7 @@
 		};
 
 		lpuart2: uart@40188000 {
-			compatible = "nxp,kinetis-lpuart";
+			compatible = "nxp,lpuart";
 			reg = <0x40188000 0x4000>;
 			interrupts = <21 0>;
 			clocks = <&ccm IMX_CCM_LPUART_CLK 0x68 28>;
@@ -513,7 +513,7 @@
 		};
 
 		lpuart3: uart@4018c000 {
-			compatible = "nxp,kinetis-lpuart";
+			compatible = "nxp,lpuart";
 			reg = <0x4018c000 0x4000>;
 			interrupts = <22 0>;
 			clocks = <&ccm IMX_CCM_LPUART_CLK 0x68 12>;
@@ -523,7 +523,7 @@
 		};
 
 		lpuart4: uart@40190000 {
-			compatible = "nxp,kinetis-lpuart";
+			compatible = "nxp,lpuart";
 			reg = <0x40190000 0x4000>;
 			interrupts = <23 0>;
 			clocks = <&ccm IMX_CCM_LPUART_CLK 0x6c 24>;
@@ -533,7 +533,7 @@
 		};
 
 		lpuart5: uart@40194000 {
-			compatible = "nxp,kinetis-lpuart";
+			compatible = "nxp,lpuart";
 			reg = <0x40194000 0x4000>;
 			interrupts = <24 0>;
 			clocks = <&ccm IMX_CCM_LPUART_CLK 0x74 2>;
@@ -543,7 +543,7 @@
 		};
 
 		lpuart6: uart@40198000 {
-			compatible = "nxp,kinetis-lpuart";
+			compatible = "nxp,lpuart";
 			reg = <0x40198000 0x4000>;
 			interrupts = <25 0>;
 			clocks = <&ccm IMX_CCM_LPUART_CLK 0x74 6>;
@@ -553,7 +553,7 @@
 		};
 
 		lpuart7: uart@4019c000 {
-			compatible = "nxp,kinetis-lpuart";
+			compatible = "nxp,lpuart";
 			reg = <0x4019c000 0x4000>;
 			interrupts = <26 0>;
 			clocks = <&ccm IMX_CCM_LPUART_CLK 0x7c 26>;
@@ -563,7 +563,7 @@
 		};
 
 		lpuart8: uart@401a0000 {
-			compatible = "nxp,kinetis-lpuart";
+			compatible = "nxp,lpuart";
 			reg = <0x401a0000 0x4000>;
 			interrupts = <27 0>;
 			clocks = <&ccm IMX_CCM_LPUART_CLK 0x80 14>;

--- a/dts/arm/nxp/nxp_rt118x.dtsi
+++ b/dts/arm/nxp/nxp_rt118x.dtsi
@@ -70,7 +70,7 @@
 	};
 
 	lpuart1: uart@4380000 {
-		compatible = "nxp,kinetis-lpuart";
+		compatible = "nxp,lpuart";
 		reg = <0x4380000 0x4000>;
 		interrupts = <19 0>;
 		clocks = <&ccm IMX_CCM_LPUART0102_CLK 0x7c 24>;
@@ -78,7 +78,7 @@
 	};
 
 	lpuart2: uart@4390000 {
-		compatible = "nxp,kinetis-lpuart";
+		compatible = "nxp,lpuart";
 		reg = <0x4390000 0x4000>;
 		interrupts = <20 0>;
 		clocks = <&ccm IMX_CCM_LPUART0102_CLK 0x68 28>;
@@ -86,7 +86,7 @@
 	};
 
 	lpuart3: uart@2570000 {
-		compatible = "nxp,kinetis-lpuart";
+		compatible = "nxp,lpuart";
 		reg = <0x2570000 0x4000>;
 		interrupts = <68 0>;
 		clocks = <&ccm IMX_CCM_LPUART0304_CLK 0x68 12>;
@@ -94,7 +94,7 @@
 	};
 
 	lpuart4: uart@2580000 {
-		compatible = "nxp,kinetis-lpuart";
+		compatible = "nxp,lpuart";
 		reg = <0x2580000 0x4000>;
 		interrupts = <69 0>;
 		clocks = <&ccm IMX_CCM_LPUART0304_CLK 0x6c 24>;
@@ -102,7 +102,7 @@
 	};
 
 	lpuart5: uart@2590000 {
-		compatible = "nxp,kinetis-lpuart";
+		compatible = "nxp,lpuart";
 		reg = <0x2590000 0x4000>;
 		interrupts = <70 0>;
 		clocks = <&ccm IMX_CCM_LPUART0506_CLK 0x74 2>;
@@ -110,7 +110,7 @@
 	};
 
 	lpuart6: uart@25A0000 {
-		compatible = "nxp,kinetis-lpuart";
+		compatible = "nxp,lpuart";
 		reg = <0x25A0000 0x4000>;
 		interrupts = <71 0>;
 		clocks = <&ccm IMX_CCM_LPUART0506_CLK 0x74 6>;
@@ -118,7 +118,7 @@
 	};
 
 	lpuart7: uart@4570000 {
-		compatible = "nxp,kinetis-lpuart";
+		compatible = "nxp,lpuart";
 		reg = <0x4570000 0x4000>;
 		interrupts = <196 0>;
 		clocks = <&ccm IMX_CCM_LPUART0708_CLK 0x7c 26>;
@@ -126,7 +126,7 @@
 	};
 
 	lpuart8: uart@2DA0000 {
-		compatible = "nxp,kinetis-lpuart";
+		compatible = "nxp,lpuart";
 		reg = <0x2DA0000 0x4000>;
 		interrupts = <197 0>;
 		clocks = <&ccm IMX_CCM_LPUART0708_CLK 0x80 14>;
@@ -134,7 +134,7 @@
 	};
 
 	lpuart9: uart@2D70000 {
-		compatible = "nxp,kinetis-lpuart";
+		compatible = "nxp,lpuart";
 		reg = <0x2D70000 0x4000>;
 		interrupts = <156 0>;
 		clocks = <&ccm IMX_CCM_LPUART0910_CLK 0x80 14>;
@@ -142,7 +142,7 @@
 	};
 
 	lpuart10: uart@2D80000 {
-		compatible = "nxp,kinetis-lpuart";
+		compatible = "nxp,lpuart";
 		reg = <0x2D80000 0x4000>;
 		interrupts = <157 0>;
 		clocks = <&ccm IMX_CCM_LPUART0910_CLK 0x80 14>;
@@ -150,7 +150,7 @@
 	};
 
 	lpuart11: uart@2D90000 {
-		compatible = "nxp,kinetis-lpuart";
+		compatible = "nxp,lpuart";
 		reg = <0x2D90000 0x4000>;
 		interrupts = <158 0>;
 		clocks = <&ccm IMX_CCM_LPUART1112_CLK 0x80 14>;
@@ -158,7 +158,7 @@
 	};
 
 	lpuart12: uart@4580000 {
-		compatible = "nxp,kinetis-lpuart";
+		compatible = "nxp,lpuart";
 		reg = <0x4580000 0x4000>;
 		interrupts = <159 0>;
 		clocks = <&ccm IMX_CCM_LPUART1112_CLK 0x80 14>;

--- a/dts/arm/nxp/nxp_rt11xx.dtsi
+++ b/dts/arm/nxp/nxp_rt11xx.dtsi
@@ -471,7 +471,7 @@
 		};
 
 		lpuart1: uart@4007c000 {
-			compatible = "nxp,kinetis-lpuart";
+			compatible = "nxp,lpuart";
 			reg = <0x4007c000 0x4000>;
 			interrupts = <20 0>;
 			clocks = <&ccm IMX_CCM_LPUART1_CLK 0x7c 24>;
@@ -479,7 +479,7 @@
 		};
 
 		lpuart2: uart@40080000 {
-			compatible = "nxp,kinetis-lpuart";
+			compatible = "nxp,lpuart";
 			reg = <0x40080000 0x4000>;
 			interrupts = <21 0>;
 			clocks = <&ccm IMX_CCM_LPUART2_CLK 0x68 28>;
@@ -487,7 +487,7 @@
 		};
 
 		lpuart3: uart@40084000 {
-			compatible = "nxp,kinetis-lpuart";
+			compatible = "nxp,lpuart";
 			reg = <0x40084000 0x4000>;
 			interrupts = <22 0>;
 			clocks = <&ccm IMX_CCM_LPUART3_CLK 0x68 12>;
@@ -495,7 +495,7 @@
 		};
 
 		lpuart4: uart@40088000 {
-			compatible = "nxp,kinetis-lpuart";
+			compatible = "nxp,lpuart";
 			reg = <0x40088000 0x4000>;
 			interrupts = <23 0>;
 			clocks = <&ccm IMX_CCM_LPUART4_CLK 0x6c 24>;
@@ -503,7 +503,7 @@
 		};
 
 		lpuart5: uart@4008c000 {
-			compatible = "nxp,kinetis-lpuart";
+			compatible = "nxp,lpuart";
 			reg = <0x4008c000 0x4000>;
 			interrupts = <24 0>;
 			clocks = <&ccm IMX_CCM_LPUART5_CLK 0x74 2>;
@@ -511,7 +511,7 @@
 		};
 
 		lpuart6: uart@40090000 {
-			compatible = "nxp,kinetis-lpuart";
+			compatible = "nxp,lpuart";
 			reg = <0x40090000 0x4000>;
 			interrupts = <25 0>;
 			clocks = <&ccm IMX_CCM_LPUART6_CLK 0x74 6>;
@@ -519,7 +519,7 @@
 		};
 
 		lpuart7: uart@40094000 {
-			compatible = "nxp,kinetis-lpuart";
+			compatible = "nxp,lpuart";
 			reg = <0x40094000 0x4000>;
 			interrupts = <26 0>;
 			clocks = <&ccm IMX_CCM_LPUART7_CLK 0x7c 26>;
@@ -527,7 +527,7 @@
 		};
 
 		lpuart8: uart@40098000 {
-			compatible = "nxp,kinetis-lpuart";
+			compatible = "nxp,lpuart";
 			reg = <0x40098000 0x4000>;
 			interrupts = <27 0>;
 			clocks = <&ccm IMX_CCM_LPUART8_CLK 0x80 14>;
@@ -535,7 +535,7 @@
 		};
 
 		lpuart9: uart@4009c000 {
-			compatible = "nxp,kinetis-lpuart";
+			compatible = "nxp,lpuart";
 			reg = <0x4009c000 0x4000>;
 			interrupts = <28 0>;
 			clocks = <&ccm IMX_CCM_LPUART9_CLK 0x80 14>;
@@ -543,7 +543,7 @@
 		};
 
 		lpuart10: uart@400a0000 {
-			compatible = "nxp,kinetis-lpuart";
+			compatible = "nxp,lpuart";
 			reg = <0x400a0000 0x4000>;
 			interrupts = <29 0>;
 			clocks = <&ccm IMX_CCM_LPUART10_CLK 0x80 14>;
@@ -551,7 +551,7 @@
 		};
 
 		lpuart11: uart@40c24000 {
-			compatible = "nxp,kinetis-lpuart";
+			compatible = "nxp,lpuart";
 			reg = <0x40c24000 0x4000>;
 			interrupts = <30 0>;
 			clocks = <&ccm IMX_CCM_LPUART11_CLK 0x80 14>;
@@ -559,7 +559,7 @@
 		};
 
 		lpuart12: uart@40c28000 {
-			compatible = "nxp,kinetis-lpuart";
+			compatible = "nxp,lpuart";
 			reg = <0x40c28000 0x4000>;
 			interrupts = <31 0>;
 			clocks = <&ccm IMX_CCM_LPUART12_CLK 0x80 14>;

--- a/dts/arm/nxp/nxp_s32k1xx.dtsi
+++ b/dts/arm/nxp/nxp_s32k1xx.dtsi
@@ -166,7 +166,7 @@
 		};
 
 		lpuart0: uart@4006a000 {
-			compatible = "nxp,kinetis-lpuart";
+			compatible = "nxp,lpuart";
 			reg = <0x4006a000 0x1000>;
 			interrupts = <31 0>;
 			clocks = <&clock NXP_S32_LPUART0_CLK>;
@@ -174,7 +174,7 @@
 		};
 
 		lpuart1: uart@4006b000 {
-			compatible = "nxp,kinetis-lpuart";
+			compatible = "nxp,lpuart";
 			reg = <0x4006b000 0x1000>;
 			interrupts = <33 0>;
 			clocks = <&clock NXP_S32_LPUART1_CLK>;
@@ -182,7 +182,7 @@
 		};
 
 		lpuart2: uart@4006c000 {
-			compatible = "nxp,kinetis-lpuart";
+			compatible = "nxp,lpuart";
 			reg = <0x4006c000 0x1000>;
 			interrupts = <35 0>;
 			status = "disabled";

--- a/dts/arm/nxp/nxp_s32k344_m7.dtsi
+++ b/dts/arm/nxp/nxp_s32k344_m7.dtsi
@@ -323,7 +323,7 @@
 		};
 
 		lpuart0: uart@40328000 {
-			compatible = "nxp,kinetis-lpuart";
+			compatible = "nxp,lpuart";
 			reg = <0x40328000 0x4000>;
 			interrupts = <141 0>;
 			clocks = <&clock NXP_S32_LPUART0_CLK>;
@@ -331,7 +331,7 @@
 		};
 
 		lpuart1: uart@4032c000 {
-			compatible = "nxp,kinetis-lpuart";
+			compatible = "nxp,lpuart";
 			reg = <0x4032c000 0x4000>;
 			interrupts = <142 0>;
 			clocks = <&clock NXP_S32_LPUART1_CLK>;
@@ -339,7 +339,7 @@
 		};
 
 		lpuart2: uart@40330000 {
-			compatible = "nxp,kinetis-lpuart";
+			compatible = "nxp,lpuart";
 			reg = <0x40330000 0x4000>;
 			interrupts = <143 0>;
 			clocks = <&clock NXP_S32_LPUART2_CLK>;
@@ -347,7 +347,7 @@
 		};
 
 		lpuart3: uart@40334000 {
-			compatible = "nxp,kinetis-lpuart";
+			compatible = "nxp,lpuart";
 			reg = <0x40334000 0x4000>;
 			interrupts = <144 0>;
 			clocks = <&clock NXP_S32_LPUART3_CLK>;
@@ -355,7 +355,7 @@
 		};
 
 		lpuart4: uart@40338000 {
-			compatible = "nxp,kinetis-lpuart";
+			compatible = "nxp,lpuart";
 			reg = <0x40338000 0x4000>;
 			interrupts = <145 0>;
 			clocks = <&clock NXP_S32_LPUART4_CLK>;
@@ -363,7 +363,7 @@
 		};
 
 		lpuart5: uart@4033c000 {
-			compatible = "nxp,kinetis-lpuart";
+			compatible = "nxp,lpuart";
 			reg = <0x4033c000 0x4000>;
 			interrupts = <146 0>;
 			clocks = <&clock NXP_S32_LPUART5_CLK>;
@@ -371,7 +371,7 @@
 		};
 
 		lpuart6: uart@40340000 {
-			compatible = "nxp,kinetis-lpuart";
+			compatible = "nxp,lpuart";
 			reg = <0x40340000 0x4000>;
 			interrupts = <147 0>;
 			clocks = <&clock NXP_S32_LPUART6_CLK>;
@@ -379,7 +379,7 @@
 		};
 
 		lpuart7: uart@40344000 {
-			compatible = "nxp,kinetis-lpuart";
+			compatible = "nxp,lpuart";
 			reg = <0x40344000 0x4000>;
 			interrupts = <148 0>;
 			clocks = <&clock NXP_S32_LPUART7_CLK>;
@@ -387,7 +387,7 @@
 		};
 
 		lpuart8: uart@4048c000 {
-			compatible = "nxp,kinetis-lpuart";
+			compatible = "nxp,lpuart";
 			reg = <0x4048c000 0x4000>;
 			interrupts = <149 0>;
 			clocks = <&clock NXP_S32_LPUART8_CLK>;
@@ -395,7 +395,7 @@
 		};
 
 		lpuart9: uart@40490000 {
-			compatible = "nxp,kinetis-lpuart";
+			compatible = "nxp,lpuart";
 			reg = <0x40490000 0x4000>;
 			interrupts = <150 0>;
 			clocks = <&clock NXP_S32_LPUART9_CLK>;
@@ -403,7 +403,7 @@
 		};
 
 		lpuart10: uart@40494000 {
-			compatible = "nxp,kinetis-lpuart";
+			compatible = "nxp,lpuart";
 			reg = <0x40494000 0x4000>;
 			interrupts = <151 0>;
 			clocks = <&clock NXP_S32_LPUART10_CLK>;
@@ -411,7 +411,7 @@
 		};
 
 		lpuart11: uart@40498000 {
-			compatible = "nxp,kinetis-lpuart";
+			compatible = "nxp,lpuart";
 			reg = <0x40498000 0x4000>;
 			interrupts = <152 0>;
 			clocks = <&clock NXP_S32_LPUART11_CLK>;
@@ -419,7 +419,7 @@
 		};
 
 		lpuart12: uart@4049c000 {
-			compatible = "nxp,kinetis-lpuart";
+			compatible = "nxp,lpuart";
 			reg = <0x4049c000 0x4000>;
 			interrupts = <153 0>;
 			clocks = <&clock NXP_S32_LPUART12_CLK>;
@@ -427,7 +427,7 @@
 		};
 
 		lpuart13: uart@404a0000 {
-			compatible = "nxp,kinetis-lpuart";
+			compatible = "nxp,lpuart";
 			reg = <0x404a0000 0x4000>;
 			interrupts = <154 0>;
 			clocks = <&clock NXP_S32_LPUART13_CLK>;
@@ -435,7 +435,7 @@
 		};
 
 		lpuart14: uart@404a4000 {
-			compatible = "nxp,kinetis-lpuart";
+			compatible = "nxp,lpuart";
 			reg = <0x404a4000 0x4000>;
 			interrupts = <155 0>;
 			clocks = <&clock NXP_S32_LPUART14_CLK>;
@@ -443,7 +443,7 @@
 		};
 
 		lpuart15: uart@404a8000 {
-			compatible = "nxp,kinetis-lpuart";
+			compatible = "nxp,lpuart";
 			reg = <0x404a8000 0x4000>;
 			interrupts = <156 0>;
 			clocks = <&clock NXP_S32_LPUART15_CLK>;

--- a/dts/arm64/nxp/nxp_mimx93_a55.dtsi
+++ b/dts/arm64/nxp/nxp_mimx93_a55.dtsi
@@ -124,7 +124,7 @@
 	};
 
 	lpuart1: serial@44380000 {
-		compatible = "nxp,imx-lpuart", "nxp,kinetis-lpuart";
+		compatible = "nxp,imx-lpuart", "nxp,lpuart";
 		reg = <0x44380000 DT_SIZE_K(64)>;
 		interrupts = <GIC_SPI 19 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
 		interrupt-names = "irq_0";
@@ -134,7 +134,7 @@
 	};
 
 	lpuart2: serial@44390000 {
-		compatible = "nxp,imx-lpuart", "nxp,kinetis-lpuart";
+		compatible = "nxp,imx-lpuart", "nxp,lpuart";
 		reg = <0x44390000 DT_SIZE_K(64)>;
 		interrupts = <GIC_SPI 20 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
 		interrupt-names = "irq_0";

--- a/dts/arm64/nxp/nxp_mimx95_a55.dtsi
+++ b/dts/arm64/nxp/nxp_mimx95_a55.dtsi
@@ -116,7 +116,7 @@
 	};
 
 	lpuart3: serial@42570000 {
-		compatible = "nxp,imx-lpuart", "nxp,kinetis-lpuart";
+		compatible = "nxp,imx-lpuart", "nxp,lpuart";
 		reg = <0x42570000 DT_SIZE_K(64)>;
 		interrupts = <GIC_SPI 64 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
 		interrupt-names = "irq_0";
@@ -125,7 +125,7 @@
 	};
 
 	lpuart4: serial@42580000 {
-		compatible = "nxp,imx-lpuart", "nxp,kinetis-lpuart";
+		compatible = "nxp,imx-lpuart", "nxp,lpuart";
 		reg = <0x42580000 DT_SIZE_K(64)>;
 		interrupts = <GIC_SPI 65 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
 		interrupt-names = "irq_0";
@@ -134,7 +134,7 @@
 	};
 
 	lpuart5: serial@42590000 {
-		compatible = "nxp,imx-lpuart", "nxp,kinetis-lpuart";
+		compatible = "nxp,imx-lpuart", "nxp,lpuart";
 		reg = <0x42590000 DT_SIZE_K(64)>;
 		interrupts = <GIC_SPI 66 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
 		interrupt-names = "irq_0";
@@ -143,7 +143,7 @@
 	};
 
 	lpuart6: serial@425a0000 {
-		compatible = "nxp,imx-lpuart", "nxp,kinetis-lpuart";
+		compatible = "nxp,imx-lpuart", "nxp,lpuart";
 		reg = <0x425a0000 DT_SIZE_K(64)>;
 		interrupts = <GIC_SPI 67 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
 		interrupt-names = "irq_0";
@@ -152,7 +152,7 @@
 	};
 
 	lpuart7: serial@42690000 {
-		compatible = "nxp,imx-lpuart", "nxp,kinetis-lpuart";
+		compatible = "nxp,imx-lpuart", "nxp,lpuart";
 		reg = <0x42690000 DT_SIZE_K(64)>;
 		interrupts = <GIC_SPI 68 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
 		interrupt-names = "irq_0";
@@ -161,7 +161,7 @@
 	};
 
 	lpuart8: serial@426a0000 {
-		compatible = "nxp,imx-lpuart", "nxp,kinetis-lpuart";
+		compatible = "nxp,imx-lpuart", "nxp,lpuart";
 		reg = <0x426a0000 DT_SIZE_K(64)>;
 		interrupts = <GIC_SPI 69 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
 		interrupt-names = "irq_0";
@@ -179,7 +179,7 @@
 	};
 
 	lpuart1: serial@44380000 {
-		compatible = "nxp,imx-lpuart", "nxp,kinetis-lpuart";
+		compatible = "nxp,imx-lpuart", "nxp,lpuart";
 		reg = <0x44380000 DT_SIZE_K(64)>;
 		interrupts = <GIC_SPI 19 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
 		interrupt-names = "irq_0";
@@ -188,7 +188,7 @@
 	};
 
 	lpuart2: serial@44390000 {
-		compatible = "nxp,imx-lpuart", "nxp,kinetis-lpuart";
+		compatible = "nxp,imx-lpuart", "nxp,lpuart";
 		reg = <0x44390000 DT_SIZE_K(64)>;
 		interrupts = <GIC_SPI 20 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
 		interrupt-names = "irq_0";

--- a/dts/bindings/serial/nxp,lpuart.yaml
+++ b/dts/bindings/serial/nxp,lpuart.yaml
@@ -1,6 +1,6 @@
-description: Kinetis LPUART
+description: NXP LPUART
 
-compatible: "nxp,kinetis-lpuart"
+compatible: "nxp,lpuart"
 
 include: [uart-controller.yaml, uart-controller-pin-inversion.yaml, pinctrl-device.yaml]
 

--- a/dts/xtensa/nxp/nxp_imx8.dtsi
+++ b/dts/xtensa/nxp/nxp_imx8.dtsi
@@ -186,7 +186,7 @@
 	};
 
 	lpuart2: serial@5a080000 {
-		compatible = "nxp,imx-lpuart", "nxp,kinetis-lpuart";
+		compatible = "nxp,imx-lpuart", "nxp,lpuart";
 		reg = <0x5a080000 DT_SIZE_K(4)>;
 		interrupt-parent = <&master4>;
 		interrupts = <3>;

--- a/dts/xtensa/nxp/nxp_imx8ulp.dtsi
+++ b/dts/xtensa/nxp/nxp_imx8ulp.dtsi
@@ -61,7 +61,7 @@
 	 * from LPUART7.
 	 */
 	lpuart7: serial@29870000 {
-		compatible = "nxp,kinetis-lpuart";
+		compatible = "nxp,lpuart";
 		reg = <0x29870000 DT_SIZE_K(4)>;
 		clocks = <&pcc4 IMX8ULP_CLOCK_LPUART7 0x0>;
 		status = "disabled";

--- a/soc/nxp/imx/imx9/imx93/a55/mmu_regions.c
+++ b/soc/nxp/imx/imx9/imx93/a55/mmu_regions.c
@@ -29,7 +29,7 @@ static const struct arm_mmu_region mmu_regions[] = {
 			      DT_REG_SIZE(DT_NODELABEL(iomuxc)),
 			      MT_DEVICE_nGnRnE | MT_P_RW_U_NA | MT_NS),
 
-	MMU_REGION_DT_COMPAT_FOREACH_FLAT_ENTRY(nxp_kinetis_lpuart,
+	MMU_REGION_DT_COMPAT_FOREACH_FLAT_ENTRY(nxp_lpuart,
 						(MT_DEVICE_nGnRnE | MT_P_RW_U_NA | MT_NS))
 
 	MMU_REGION_DT_COMPAT_FOREACH_FLAT_ENTRY(nxp_flexcan,

--- a/soc/nxp/imx/imx9/imx95/a55/mmu_regions.c
+++ b/soc/nxp/imx/imx9/imx95/a55/mmu_regions.c
@@ -21,7 +21,7 @@ static const struct arm_mmu_region mmu_regions[] = {
 	MMU_REGION_DT_COMPAT_FOREACH_FLAT_ENTRY(nxp_mbox_imx_mu,
 						(MT_DEVICE_nGnRnE | MT_P_RW_U_NA | MT_NS))
 
-	MMU_REGION_DT_COMPAT_FOREACH_FLAT_ENTRY(nxp_kinetis_lpuart,
+	MMU_REGION_DT_COMPAT_FOREACH_FLAT_ENTRY(nxp_lpuart,
 						(MT_DEVICE_nGnRnE | MT_P_RW_U_NA | MT_NS))
 
 };

--- a/soc/nxp/mcx/mcxn/soc.c
+++ b/soc/nxp/mcx/mcxn/soc.c
@@ -27,7 +27,7 @@ void soc_reset_hook(void)
 #endif
 
 #define FLEXCOMM_CHECK_2(n)	\
-	BUILD_ASSERT((DT_NODE_HAS_COMPAT(n, nxp_kinetis_lpuart) == 0) &&	\
+	BUILD_ASSERT((DT_NODE_HAS_COMPAT(n, nxp_lpuart) == 0) &&		\
 		     (DT_NODE_HAS_COMPAT(n, nxp_lpi2c) == 0),			\
 		     "Do not enable SPI and UART/I2C on the same Flexcomm node");
 


### PR DESCRIPTION
Rename "nxp,kinetis-lpuart" compatible to "nxp,lpuart" to remove the device family from its name because this hardware block is used in multiple NXP devices from different families.