### PR TITLE
dts: bindings: rename nxp,imx-lpspi compatible

### DIFF
--- a/doc/releases/migration-guide-4.1.rst
+++ b/doc/releases/migration-guide-4.1.rst
@@ -128,6 +128,11 @@ Stepper
   * Renamed the ``compatible`` from ``zephyr,gpio-steppers`` to :dtcompatible:`zephyr,gpio-stepper`.
   * Renamed the ``stepper_set_actual_position`` function to :c:func:`stepper_set_reference_position`.
 
+SPI
+===
+
+* Renamed the ``compatible`` from ``nxp,imx-lpspi`` to :dtcompatible:`nxp,lpspi`.
+
 Regulator
 =========
 

--- a/drivers/spi/Kconfig.mcux_lpspi
+++ b/drivers/spi/Kconfig.mcux_lpspi
@@ -4,13 +4,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config SPI_MCUX_LPSPI
-	bool "MCUX SPI driver"
+	bool "MCUX LPSPI driver"
 	default y
-	depends on DT_HAS_NXP_IMX_LPSPI_ENABLED
+	depends on DT_HAS_NXP_LPSPI_ENABLED
 	depends on CLOCK_CONTROL
 	select PINCTRL
 	help
-	  Enable support for mcux spi driver.
+	  Enable support for MCUX LPSPI driver.
 
 if SPI_MCUX_LPSPI
 config SPI_MCUX_LPSPI_DMA

--- a/drivers/spi/spi_mcux_lpspi.c
+++ b/drivers/spi/spi_mcux_lpspi.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#define DT_DRV_COMPAT nxp_imx_lpspi
+#define DT_DRV_COMPAT nxp_lpspi
 
 #include <errno.h>
 #include <zephyr/drivers/spi.h>

--- a/dts/arm/nxp/nxp_ke1xf.dtsi
+++ b/dts/arm/nxp/nxp_ke1xf.dtsi
@@ -380,7 +380,7 @@
 		};
 
 		lpspi0: spi@4002c000 {
-			compatible = "nxp,imx-lpspi";
+			compatible = "nxp,lpspi";
 			reg = <0x4002c000 0x1000>;
 			interrupts = <26 0>;
 			clocks = <&pcc 0xb0 KINETIS_PCC_SRC_FIRC_ASYNC>;
@@ -390,7 +390,7 @@
 		};
 
 		lpspi1: spi@4002d000 {
-			compatible = "nxp,imx-lpspi";
+			compatible = "nxp,lpspi";
 			reg = <0x4002d000 0x1000>;
 			interrupts = <27 0>;
 			clocks = <&pcc 0xb4 KINETIS_PCC_SRC_FIRC_ASYNC>;

--- a/dts/arm/nxp/nxp_ke1xz.dtsi
+++ b/dts/arm/nxp/nxp_ke1xz.dtsi
@@ -422,7 +422,7 @@
 		};
 
 		lpspi0: spi@4002c000 {
-			compatible = "nxp,imx-lpspi";
+			compatible = "nxp,lpspi";
 			reg = <0x4002c000 0x1000>;
 			interrupts = <10 0>;
 			clocks = <&pcc 0xb0 KINETIS_PCC_SRC_FIRC_ASYNC>;
@@ -432,7 +432,7 @@
 		};
 
 		lpspi1: spi@4002d000 {
-			compatible = "nxp,imx-lpspi";
+			compatible = "nxp,lpspi";
 			reg = <0x4002d000 0x1000>;
 			interrupts = <11 0>;
 			clocks = <&pcc 0xb4 KINETIS_PCC_SRC_FIRC_ASYNC>;

--- a/dts/arm/nxp/nxp_mcxn23x_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxn23x_common.dtsi
@@ -186,7 +186,7 @@
 			status = "disabled";
 		};
 		flexcomm0_lpspi0: spi@92000 {
-			compatible = "nxp,imx-lpspi";
+			compatible = "nxp,lpspi";
 			reg = <0x92000 0x1000>;
 			clocks = <&syscon MCUX_FLEXCOMM0_CLK>;
 			#address-cells = <1>;
@@ -223,7 +223,7 @@
 			status = "disabled";
 		};
 		flexcomm1_lpspi1: spi@93000 {
-			compatible = "nxp,imx-lpspi";
+			compatible = "nxp,lpspi";
 			reg = <0x93000 0x1000>;
 			clocks = <&syscon MCUX_FLEXCOMM1_CLK>;
 			#address-cells = <1>;
@@ -263,7 +263,7 @@
 			status = "disabled";
 		};
 		flexcomm2_lpspi2: spi@94000 {
-			compatible = "nxp,imx-lpspi";
+			compatible = "nxp,lpspi";
 			reg = <0x94000 0x1000>;
 			clocks = <&syscon MCUX_FLEXCOMM2_CLK>;
 			#address-cells = <1>;
@@ -300,7 +300,7 @@
 			status = "disabled";
 		};
 		flexcomm3_lpspi3: spi@95000 {
-			compatible = "nxp,imx-lpspi";
+			compatible = "nxp,lpspi";
 			reg = <0x95000 0x1000>;
 			clocks = <&syscon MCUX_FLEXCOMM3_CLK>;
 			#address-cells = <1>;
@@ -337,7 +337,7 @@
 			status = "disabled";
 		};
 		flexcomm4_lpspi4: spi@b4000 {
-			compatible = "nxp,imx-lpspi";
+			compatible = "nxp,lpspi";
 			reg = <0xb4000 0x1000>;
 			clocks = <&syscon MCUX_FLEXCOMM4_CLK>;
 			#address-cells = <1>;
@@ -374,7 +374,7 @@
 			status = "disabled";
 		};
 		flexcomm5_lpspi5: spi@b5000 {
-			compatible = "nxp,imx-lpspi";
+			compatible = "nxp,lpspi";
 			reg = <0xb5000 0x1000>;
 			clocks = <&syscon MCUX_FLEXCOMM5_CLK>;
 			#address-cells = <1>;
@@ -408,7 +408,7 @@
 			status = "disabled";
 		};
 		flexcomm6_lpspi6: spi@b6000 {
-			compatible = "nxp,imx-lpspi";
+			compatible = "nxp,lpspi";
 			reg = <0xb6000 0x1000>;
 			clocks = <&syscon MCUX_FLEXCOMM6_CLK>;
 			#address-cells = <1>;
@@ -442,7 +442,7 @@
 			status = "disabled";
 		};
 		flexcomm7_lpspi7: spi@b7000 {
-			compatible = "nxp,imx-lpspi";
+			compatible = "nxp,lpspi";
 			reg = <0xb7000 0x1000>;
 			clocks = <&syscon MCUX_FLEXCOMM7_CLK>;
 			#address-cells = <1>;

--- a/dts/arm/nxp/nxp_mcxn94x_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxn94x_common.dtsi
@@ -193,7 +193,7 @@
 			status = "disabled";
 		};
 		flexcomm0_lpspi0: spi@92000 {
-			compatible = "nxp,imx-lpspi";
+			compatible = "nxp,lpspi";
 			reg = <0x92000 0x1000>;
 			clocks = <&syscon MCUX_FLEXCOMM0_CLK>;
 			#address-cells = <1>;
@@ -230,7 +230,7 @@
 			status = "disabled";
 		};
 		flexcomm1_lpspi1: spi@93000 {
-			compatible = "nxp,imx-lpspi";
+			compatible = "nxp,lpspi";
 			reg = <0x93000 0x1000>;
 			clocks = <&syscon MCUX_FLEXCOMM1_CLK>;
 			#address-cells = <1>;
@@ -270,7 +270,7 @@
 			status = "disabled";
 		};
 		flexcomm2_lpspi2: spi@94000 {
-			compatible = "nxp,imx-lpspi";
+			compatible = "nxp,lpspi";
 			reg = <0x94000 0x1000>;
 			clocks = <&syscon MCUX_FLEXCOMM2_CLK>;
 			#address-cells = <1>;
@@ -307,7 +307,7 @@
 			status = "disabled";
 		};
 		flexcomm3_lpspi3: spi@95000 {
-			compatible = "nxp,imx-lpspi";
+			compatible = "nxp,lpspi";
 			reg = <0x95000 0x1000>;
 			clocks = <&syscon MCUX_FLEXCOMM3_CLK>;
 			#address-cells = <1>;
@@ -344,7 +344,7 @@
 			status = "disabled";
 		};
 		flexcomm4_lpspi4: spi@b4000 {
-			compatible = "nxp,imx-lpspi";
+			compatible = "nxp,lpspi";
 			reg = <0xb4000 0x1000>;
 			clocks = <&syscon MCUX_FLEXCOMM4_CLK>;
 			#address-cells = <1>;
@@ -381,7 +381,7 @@
 			status = "disabled";
 		};
 		flexcomm5_lpspi5: spi@b5000 {
-			compatible = "nxp,imx-lpspi";
+			compatible = "nxp,lpspi";
 			reg = <0xb5000 0x1000>;
 			clocks = <&syscon MCUX_FLEXCOMM5_CLK>;
 			#address-cells = <1>;
@@ -415,7 +415,7 @@
 			status = "disabled";
 		};
 		flexcomm6_lpspi6: spi@b6000 {
-			compatible = "nxp,imx-lpspi";
+			compatible = "nxp,lpspi";
 			reg = <0xb6000 0x1000>;
 			clocks = <&syscon MCUX_FLEXCOMM6_CLK>;
 			#address-cells = <1>;
@@ -449,7 +449,7 @@
 			status = "disabled";
 		};
 		flexcomm7_lpspi7: spi@b7000 {
-			compatible = "nxp,imx-lpspi";
+			compatible = "nxp,lpspi";
 			reg = <0xb7000 0x1000>;
 			clocks = <&syscon MCUX_FLEXCOMM7_CLK>;
 			#address-cells = <1>;
@@ -483,7 +483,7 @@
 			status = "disabled";
 		};
 		flexcomm8_lpspi8: spi@b8000 {
-			compatible = "nxp,imx-lpspi";
+			compatible = "nxp,lpspi";
 			reg = <0xb8000 0x1000>;
 			clocks = <&syscon MCUX_FLEXCOMM8_CLK>;
 			#address-cells = <1>;
@@ -517,7 +517,7 @@
 			status = "disabled";
 		};
 		flexcomm9_lpspi9: spi@b9000 {
-			compatible = "nxp,imx-lpspi";
+			compatible = "nxp,lpspi";
 			reg = <0xb9000 0x1000>;
 			clocks = <&syscon MCUX_FLEXCOMM9_CLK>;
 			#address-cells = <1>;

--- a/dts/arm/nxp/nxp_mcxw71.dtsi
+++ b/dts/arm/nxp/nxp_mcxw71.dtsi
@@ -209,7 +209,7 @@
 	};
 
 	lpspi0: spi@36000 {
-		compatible = "nxp,imx-lpspi";
+		compatible = "nxp,lpspi";
 		reg = <0x36000 0x800>;
 		interrupts = <42 0>;
 		clocks = <&scg SCG_K4_FIRC_CLK 0xd8>;
@@ -219,7 +219,7 @@
 	};
 
 	lpspi1: spi@37000 {
-		compatible = "nxp,imx-lpspi";
+		compatible = "nxp,lpspi";
 		reg = <0x37000 0x800>;
 		interrupts = <43 0>;
 		clocks = <&scg SCG_K4_FIRC_CLK 0xdc>;

--- a/dts/arm/nxp/nxp_rt1010.dtsi
+++ b/dts/arm/nxp/nxp_rt1010.dtsi
@@ -157,7 +157,7 @@
 		/delete-node/ spi@40394000;
 		/delete-node/ spi@40398000;
 		lpspi1: spi@40194000 {
-			compatible = "nxp,imx-lpspi";
+			compatible = "nxp,lpspi";
 			reg = <0x40194000 0x4000>;
 			interrupts = <32 3>;
 			status = "disabled";
@@ -167,7 +167,7 @@
 		};
 
 		lpspi2: spi@40198000 {
-			compatible = "nxp,imx-lpspi";
+			compatible = "nxp,lpspi";
 			reg = <0x40198000 0x4000>;
 			interrupts = <33 3>;
 			status = "disabled";

--- a/dts/arm/nxp/nxp_rt10xx.dtsi
+++ b/dts/arm/nxp/nxp_rt10xx.dtsi
@@ -453,7 +453,7 @@
 		};
 
 		lpspi1: spi@40394000 {
-			compatible = "nxp,imx-lpspi";
+			compatible = "nxp,lpspi";
 			reg = <0x40394000 0x4000>;
 			interrupts = <32 3>;
 			status = "disabled";
@@ -463,7 +463,7 @@
 		};
 
 		lpspi2: spi@40398000 {
-			compatible = "nxp,imx-lpspi";
+			compatible = "nxp,lpspi";
 			reg = <0x40398000 0x4000>;
 			interrupts = <33 3>;
 			status = "disabled";
@@ -473,7 +473,7 @@
 		};
 
 		lpspi3: spi@4039c000 {
-			compatible = "nxp,imx-lpspi";
+			compatible = "nxp,lpspi";
 			reg = <0x4039c000 0x4000>;
 			interrupts = <34 3>;
 			status = "disabled";
@@ -483,7 +483,7 @@
 		};
 
 		lpspi4: spi@403a0000 {
-			compatible = "nxp,imx-lpspi";
+			compatible = "nxp,lpspi";
 			reg = <0x403a0000 0x4000>;
 			interrupts = <35 3>;
 			status = "disabled";

--- a/dts/arm/nxp/nxp_rt11xx.dtsi
+++ b/dts/arm/nxp/nxp_rt11xx.dtsi
@@ -411,7 +411,7 @@
 		};
 
 		lpspi1: spi@40114000 {
-			compatible = "nxp,imx-lpspi";
+			compatible = "nxp,lpspi";
 			reg = <0x40114000 0x4000>;
 			interrupts = <38 3>;
 			status = "disabled";
@@ -421,7 +421,7 @@
 		};
 
 		lpspi2: spi@40118000 {
-			compatible = "nxp,imx-lpspi";
+			compatible = "nxp,lpspi";
 			reg = <0x40118000 0x4000>;
 			interrupts = <39 3>;
 			status = "disabled";
@@ -431,7 +431,7 @@
 		};
 
 		lpspi3: spi@4011c000 {
-			compatible = "nxp,imx-lpspi";
+			compatible = "nxp,lpspi";
 			reg = <0x4011c000 0x4000>;
 			interrupts = <40 3>;
 			status = "disabled";
@@ -441,7 +441,7 @@
 		};
 
 		lpspi4: spi@40120000 {
-			compatible = "nxp,imx-lpspi";
+			compatible = "nxp,lpspi";
 			reg = <0x40120000 0x4000>;
 			interrupts = <41 3>;
 			status = "disabled";
@@ -451,7 +451,7 @@
 		};
 
 		lpspi5: spi@40c2c000 {
-			compatible = "nxp,imx-lpspi";
+			compatible = "nxp,lpspi";
 			reg = <0x40c2c000 0x4000>;
 			interrupts = <42 3>;
 			status = "disabled";
@@ -461,7 +461,7 @@
 		};
 
 		lpspi6: spi@40c30000 {
-			compatible = "nxp,imx-lpspi";
+			compatible = "nxp,lpspi";
 			reg = <0x40c30000 0x4000>;
 			interrupts = <43 3>;
 			status = "disabled";

--- a/dts/arm/nxp/nxp_s32k1xx.dtsi
+++ b/dts/arm/nxp/nxp_s32k1xx.dtsi
@@ -71,7 +71,7 @@
 		};
 
 		lpspi0: spi@4002c000 {
-			compatible = "nxp,imx-lpspi";
+			compatible = "nxp,lpspi";
 			reg = <0x4002c000 0x1000>;
 			interrupts = <26 0>;
 			clocks = <&clock NXP_S32_LPSPI0_CLK>;
@@ -81,7 +81,7 @@
 		};
 
 		lpspi1: spi@4002d000 {
-			compatible = "nxp,imx-lpspi";
+			compatible = "nxp,lpspi";
 			reg = <0x4002d000 0x1000>;
 			interrupts = <27 0>;
 			#address-cells = <1>;
@@ -90,7 +90,7 @@
 		};
 
 		lpspi2: spi@4002e000 {
-			compatible = "nxp,imx-lpspi";
+			compatible = "nxp,lpspi";
 			reg = <0x4002e000 0x1000>;
 			interrupts = <28 0>;
 			#address-cells = <1>;

--- a/dts/arm/nxp/nxp_s32k344_m7.dtsi
+++ b/dts/arm/nxp/nxp_s32k344_m7.dtsi
@@ -564,7 +564,7 @@
 		};
 
 		lpspi0: spi@40358000 {
-			compatible = "nxp,imx-lpspi";
+			compatible = "nxp,lpspi";
 			reg = <0x40358000 0x4000>;
 			interrupts = <165 0>;
 			clocks = <&clock NXP_S32_LPSPI0_CLK>;
@@ -574,7 +574,7 @@
 		};
 
 		lpspi1: spi@4035c000 {
-			compatible = "nxp,imx-lpspi";
+			compatible = "nxp,lpspi";
 			reg = <0x4035c000 0x4000>;
 			interrupts = <166 0>;
 			clocks = <&clock NXP_S32_LPSPI1_CLK>;
@@ -584,7 +584,7 @@
 		};
 
 		lpspi2: spi@40360000 {
-			compatible = "nxp,imx-lpspi";
+			compatible = "nxp,lpspi";
 			reg = <0x40360000 0x4000>;
 			interrupts = <167 0>;
 			clocks = <&clock NXP_S32_LPSPI2_CLK>;
@@ -594,7 +594,7 @@
 		};
 
 		lpspi3: spi@40364000 {
-			compatible = "nxp,imx-lpspi";
+			compatible = "nxp,lpspi";
 			reg = <0x40364000 0x4000>;
 			interrupts = <168 0>;
 			clocks = <&clock NXP_S32_LPSPI3_CLK>;
@@ -604,7 +604,7 @@
 		};
 
 		lpspi4: spi@404bc000 {
-			compatible = "nxp,imx-lpspi";
+			compatible = "nxp,lpspi";
 			reg = <0x404bc000 0x4000>;
 			interrupts = <169 0>;
 			clocks = <&clock NXP_S32_LPSPI4_CLK>;
@@ -614,7 +614,7 @@
 		};
 
 		lpspi5: spi@404c0000 {
-			compatible = "nxp,imx-lpspi";
+			compatible = "nxp,lpspi";
 			reg = <0x404c0000 0x4000>;
 			interrupts = <170 0>;
 			clocks = <&clock NXP_S32_LPSPI5_CLK>;

--- a/dts/arm64/nxp/nxp_mimx93_a55.dtsi
+++ b/dts/arm64/nxp/nxp_mimx93_a55.dtsi
@@ -240,7 +240,7 @@
 	};
 
 	lpspi1: spi@44360000 {
-		compatible = "nxp,imx-lpspi";
+		compatible = "nxp,lpspi";
 		reg = <0x44360000 0x4000>;
 		interrupts = <GIC_SPI 16 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
 		interrupt-parent = <&gic>;
@@ -251,7 +251,7 @@
 	};
 
 	lpspi2: spi@44370000 {
-		compatible = "nxp,imx-lpspi";
+		compatible = "nxp,lpspi";
 		reg = <0x44370000 0x4000>;
 		interrupts = <GIC_SPI 17 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
 		interrupt-parent = <&gic>;
@@ -262,7 +262,7 @@
 	};
 
 	lpspi3: spi@42550000 {
-		compatible = "nxp,imx-lpspi";
+		compatible = "nxp,lpspi";
 		reg = <0x42550000 0x4000>;
 		interrupts = <GIC_SPI 65 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
 		interrupt-parent = <&gic>;
@@ -273,7 +273,7 @@
 	};
 
 	lpspi4: spi@42560000 {
-		compatible = "nxp,imx-lpspi";
+		compatible = "nxp,lpspi";
 		reg = <0x42560000 0x4000>;
 		interrupts = <GIC_SPI 66 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
 		interrupt-parent = <&gic>;
@@ -284,7 +284,7 @@
 	};
 
 	lpspi5: spi@426f0000 {
-		compatible = "nxp,imx-lpspi";
+		compatible = "nxp,lpspi";
 		reg = <0x426f0000 0x4000>;
 		interrupts = <GIC_SPI 191 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
 		interrupt-parent = <&gic>;
@@ -295,7 +295,7 @@
 	};
 
 	lpspi6: spi@42700000 {
-		compatible = "nxp,imx-lpspi";
+		compatible = "nxp,lpspi";
 		reg = <0x42700000 0x4000>;
 		interrupts = <GIC_SPI 192 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
 		interrupt-parent = <&gic>;
@@ -306,7 +306,7 @@
 	};
 
 	lpspi7: spi@42710000 {
-		compatible = "nxp,imx-lpspi";
+		compatible = "nxp,lpspi";
 		reg = <0x42710000 0x4000>;
 		interrupts = <GIC_SPI 193 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
 		interrupt-parent = <&gic>;
@@ -317,7 +317,7 @@
 	};
 
 	lpspi8: spi@42720000 {
-		compatible = "nxp,imx-lpspi";
+		compatible = "nxp,lpspi";
 		reg = <0x42720000 0x4000>;
 		interrupts = <GIC_SPI 194 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
 		interrupt-parent = <&gic>;

--- a/dts/bindings/spi/nxp,lpspi.yaml
+++ b/dts/bindings/spi/nxp,lpspi.yaml
@@ -1,9 +1,9 @@
 # Copyright (c) 2018,2023 NXP
 # SPDX-License-Identifier: Apache-2.0
 
-description: NXP i.MX LPSPI controller
+description: NXP LPSPI controller
 
-compatible: "nxp,imx-lpspi"
+compatible: "nxp,lpspi"
 
 include: ["spi-controller.yaml", "pinctrl-device.yaml"]
 

--- a/soc/nxp/mcx/mcxn/soc.c
+++ b/soc/nxp/mcx/mcxn/soc.c
@@ -37,4 +37,4 @@ void soc_reset_hook(void)
 /* SPI cannot be exist with UART or I2C on the same FlexComm Interface
  * Throw a build error if user is enabling SPI and UART/I2C on a Flexcomm node.
  */
-DT_FOREACH_STATUS_OKAY(nxp_imx_lpspi, FLEXCOMM_CHECK)
+DT_FOREACH_STATUS_OKAY(nxp_lpspi, FLEXCOMM_CHECK)

--- a/soc/nxp/mcx/mcxw/soc.c
+++ b/soc/nxp/mcx/mcxw/soc.c
@@ -149,11 +149,11 @@ static ALWAYS_INLINE void clock_init(void)
 		CLOCK_EnableClock(kCLOCK_Lpi2c1);
 	}
 
-	if (DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(lpspi0), nxp_imx_lpspi, okay)) {
+	if (DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(lpspi0), nxp_lpspi, okay)) {
 		CLOCK_EnableClock(kCLOCK_Lpspi0);
 	}
 
-	if (DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(lpspi1), nxp_imx_lpspi, okay)) {
+	if (DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(lpspi1), nxp_lpspi, okay)) {
 		CLOCK_EnableClock(kCLOCK_Lpspi1);
 	}
 

--- a/tests/drivers/spi/spi_loopback/testcase.yaml
+++ b/tests/drivers/spi/spi_loopback/testcase.yaml
@@ -14,16 +14,16 @@ tests:
   drivers.spi.loopback.internal:
     filter: CONFIG_SPI_LOOPBACK_MODE_LOOP
   drivers.spi.loopback.lpspi.dma:
-    filter: DT_HAS_NXP_IMX_LPSPI_ENABLED and DT_HAS_NXP_MCUX_EDMA_ENABLED
+    filter: DT_HAS_NXP_LPSPI_ENABLED and DT_HAS_NXP_MCUX_EDMA_ENABLED
     extra_configs:
       - CONFIG_SPI_MCUX_LPSPI_DMA=y
   drivers.spi.loopback.lpspi.async.unset:
-    filter: DT_HAS_NXP_IMX_LPSPI_ENABLED and DT_HAS_NXP_MCUX_EDMA_ENABLED
+    filter: DT_HAS_NXP_LPSPI_ENABLED and DT_HAS_NXP_MCUX_EDMA_ENABLED
     extra_configs:
       - CONFIG_SPI_MCUX_LPSPI_DMA=n
       - CONFIG_SPI_ASYNC=n
   drivers.spi.loopback.lpspi.dma.async.unset:
-    filter: DT_HAS_NXP_IMX_LPSPI_ENABLED and DT_HAS_NXP_MCUX_EDMA_ENABLED
+    filter: DT_HAS_NXP_LPSPI_ENABLED and DT_HAS_NXP_MCUX_EDMA_ENABLED
     extra_configs:
       - CONFIG_SPI_MCUX_LPSPI_DMA=y
       - CONFIG_SPI_ASYNC=n


### PR DESCRIPTION
Rename "nxp,imx-lpspi" compatible to "nxp,lpspi" to remove the device family from its name because this hardware block is used in multiple NXP devices from different families.