### PR TITLE
dts: bindings: remove device family name from NXP GPIO bindings 

### DIFF
--- a/doc/releases/migration-guide-4.1.rst
+++ b/doc/releases/migration-guide-4.1.rst
@@ -101,6 +101,18 @@ Entropy
 GNSS
 ====
 
+GPIO
+====
+
+* Renamed the ``compatible`` from ``nxp,kinetis-gpio`` to :dtcompatible:`nxp,gpio`.
+* The :dtcompatible:`nxp,gpio` ``nxp,kinetis-port`` property has been renamed to ``nxp,port``.
+* The devicetree binding header ``include/zephyr/dt-bindings/gpio/nxp-kinetis-gpio.h`` has been
+  renamed to :zephyr_file:`include/zephyr/dt-bindings/gpio/nxp-gpio.h` and the following defines
+  have changed:
+
+    * :c:macro:`KINETIS_GPIO_DS_DFLT` renamed to :c:macro:`NXP_GPIO_DS_DFLT`.
+    * :c:macro:`KINETIS_GPIO_DS_ALT` renamed to :c:macro:`NXP_GPIO_DS_ALT`.
+
 Input
 =====
 

--- a/drivers/gpio/Kconfig.mcux
+++ b/drivers/gpio/Kconfig.mcux
@@ -7,6 +7,6 @@
 config GPIO_MCUX
 	bool "MCUX GPIO driver"
 	default y
-	depends on DT_HAS_NXP_KINETIS_GPIO_ENABLED
+	depends on DT_HAS_NXP_GPIO_ENABLED
 	help
-	  Enable the MCUX pinmux driver.
+	  Enable the MCUX GPIO driver.

--- a/drivers/gpio/gpio_mcux.c
+++ b/drivers/gpio/gpio_mcux.c
@@ -414,7 +414,7 @@ static const struct gpio_driver_api gpio_mcux_driver_api = {
 		irq_enable(DT_INST_IRQN(n));				\
 	} while (false)
 
-#define GPIO_PORT_BASE_ADDR(n) DT_REG_ADDR(DT_INST_PHANDLE(n, nxp_kinetis_port))
+#define GPIO_PORT_BASE_ADDR(n) DT_REG_ADDR(DT_INST_PHANDLE(n, nxp_port))
 
 #define GPIO_DEVICE_INIT_MCUX(n)					\
 	static int gpio_mcux_port## n ## _init(const struct device *dev); \

--- a/drivers/gpio/gpio_mcux.c
+++ b/drivers/gpio/gpio_mcux.c
@@ -10,7 +10,7 @@
 #include <errno.h>
 #include <zephyr/device.h>
 #include <zephyr/drivers/gpio.h>
-#include <zephyr/dt-bindings/gpio/nxp-kinetis-gpio.h>
+#include <zephyr/dt-bindings/gpio/nxp-gpio.h>
 #include <zephyr/irq.h>
 #include <soc.h>
 #include <fsl_common.h>
@@ -104,12 +104,12 @@ static int gpio_mcux_configure(const struct device *dev,
 
 #if defined(FSL_FEATURE_PORT_HAS_DRIVE_STRENGTH) && FSL_FEATURE_PORT_HAS_DRIVE_STRENGTH
 	/* Determine the drive strength */
-	switch (flags & KINETIS_GPIO_DS_MASK) {
-	case KINETIS_GPIO_DS_DFLT:
+	switch (flags & NXP_GPIO_DS_MASK) {
+	case NXP_GPIO_DS_DFLT:
 		/* Default is low drive strength */
 		mask |= PORT_PCR_DSE_MASK;
 		break;
-	case KINETIS_GPIO_DS_ALT:
+	case NXP_GPIO_DS_ALT:
 		/* Alternate is high drive strength */
 		pcr |= PORT_PCR_DSE_MASK;
 		break;

--- a/drivers/gpio/gpio_mcux.c
+++ b/drivers/gpio/gpio_mcux.c
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#define DT_DRV_COMPAT nxp_kinetis_gpio
+#define DT_DRV_COMPAT nxp_gpio
 
 #include <errno.h>
 #include <zephyr/device.h>

--- a/dts/arm/nxp/nxp_k2x.dtsi
+++ b/dts/arm/nxp/nxp_k2x.dtsi
@@ -230,7 +230,7 @@
 			interrupts = <59 2>;
 			gpio-controller;
 			#gpio-cells = <2>;
-			nxp,kinetis-port = <&porta>;
+			nxp,port = <&porta>;
 		};
 
 		gpiob: gpio@400ff040 {
@@ -240,7 +240,7 @@
 			interrupts = <60 2>;
 			gpio-controller;
 			#gpio-cells = <2>;
-			nxp,kinetis-port = <&portb>;
+			nxp,port = <&portb>;
 		};
 
 		gpioc: gpio@400ff080 {
@@ -250,7 +250,7 @@
 			interrupts = <61 2>;
 			gpio-controller;
 			#gpio-cells = <2>;
-			nxp,kinetis-port = <&portc>;
+			nxp,port = <&portc>;
 		};
 
 		gpiod: gpio@400ff0c0 {
@@ -260,7 +260,7 @@
 			interrupts = <62 2>;
 			gpio-controller;
 			#gpio-cells = <2>;
-			nxp,kinetis-port = <&portd>;
+			nxp,port = <&portd>;
 		};
 
 		gpioe: gpio@400ff100 {
@@ -270,7 +270,7 @@
 			interrupts = <63 2>;
 			gpio-controller;
 			#gpio-cells = <2>;
-			nxp,kinetis-port = <&porte>;
+			nxp,port = <&porte>;
 		};
 
 		spi0: spi@4002c000 {

--- a/dts/arm/nxp/nxp_k2x.dtsi
+++ b/dts/arm/nxp/nxp_k2x.dtsi
@@ -224,7 +224,7 @@
 		};
 
 		gpioa: gpio@400ff000 {
-			compatible = "nxp,kinetis-gpio";
+			compatible = "nxp,gpio";
 			status = "disabled";
 			reg = <0x400ff000 0x40>;
 			interrupts = <59 2>;
@@ -234,7 +234,7 @@
 		};
 
 		gpiob: gpio@400ff040 {
-			compatible = "nxp,kinetis-gpio";
+			compatible = "nxp,gpio";
 			status = "disabled";
 			reg = <0x400ff040 0x40>;
 			interrupts = <60 2>;
@@ -244,7 +244,7 @@
 		};
 
 		gpioc: gpio@400ff080 {
-			compatible = "nxp,kinetis-gpio";
+			compatible = "nxp,gpio";
 			status = "disabled";
 			reg = <0x400ff080 0x40>;
 			interrupts = <61 2>;
@@ -254,7 +254,7 @@
 		};
 
 		gpiod: gpio@400ff0c0 {
-			compatible = "nxp,kinetis-gpio";
+			compatible = "nxp,gpio";
 			status = "disabled";
 			reg = <0x400ff0c0 0x40>;
 			interrupts = <62 2>;
@@ -264,7 +264,7 @@
 		};
 
 		gpioe: gpio@400ff100 {
-			compatible = "nxp,kinetis-gpio";
+			compatible = "nxp,gpio";
 			status = "disabled";
 			reg = <0x400ff100 0x40>;
 			interrupts = <63 2>;

--- a/dts/arm/nxp/nxp_k6x.dtsi
+++ b/dts/arm/nxp/nxp_k6x.dtsi
@@ -291,7 +291,7 @@
 			interrupts = <59 2>;
 			gpio-controller;
 			#gpio-cells = <2>;
-			nxp,kinetis-port = <&porta>;
+			nxp,port = <&porta>;
 		};
 
 		gpiob: gpio@400ff040 {
@@ -301,7 +301,7 @@
 			interrupts = <60 2>;
 			gpio-controller;
 			#gpio-cells = <2>;
-			nxp,kinetis-port = <&portb>;
+			nxp,port = <&portb>;
 		};
 
 		gpioc: gpio@400ff080 {
@@ -311,7 +311,7 @@
 			interrupts = <61 2>;
 			gpio-controller;
 			#gpio-cells = <2>;
-			nxp,kinetis-port = <&portc>;
+			nxp,port = <&portc>;
 		};
 
 		gpiod: gpio@400ff0c0 {
@@ -321,7 +321,7 @@
 			interrupts = <62 2>;
 			gpio-controller;
 			#gpio-cells = <2>;
-			nxp,kinetis-port = <&portd>;
+			nxp,port = <&portd>;
 		};
 
 		gpioe: gpio@400ff100 {
@@ -331,7 +331,7 @@
 			interrupts = <63 2>;
 			gpio-controller;
 			#gpio-cells = <2>;
-			nxp,kinetis-port = <&porte>;
+			nxp,port = <&porte>;
 		};
 
 		spi0: spi@4002c000 {

--- a/dts/arm/nxp/nxp_k6x.dtsi
+++ b/dts/arm/nxp/nxp_k6x.dtsi
@@ -285,7 +285,7 @@
 		};
 
 		gpioa: gpio@400ff000 {
-			compatible = "nxp,kinetis-gpio";
+			compatible = "nxp,gpio";
 			status = "disabled";
 			reg = <0x400ff000 0x40>;
 			interrupts = <59 2>;
@@ -295,7 +295,7 @@
 		};
 
 		gpiob: gpio@400ff040 {
-			compatible = "nxp,kinetis-gpio";
+			compatible = "nxp,gpio";
 			status = "disabled";
 			reg = <0x400ff040 0x40>;
 			interrupts = <60 2>;
@@ -305,7 +305,7 @@
 		};
 
 		gpioc: gpio@400ff080 {
-			compatible = "nxp,kinetis-gpio";
+			compatible = "nxp,gpio";
 			status = "disabled";
 			reg = <0x400ff080 0x40>;
 			interrupts = <61 2>;
@@ -315,7 +315,7 @@
 		};
 
 		gpiod: gpio@400ff0c0 {
-			compatible = "nxp,kinetis-gpio";
+			compatible = "nxp,gpio";
 			status = "disabled";
 			reg = <0x400ff0c0 0x40>;
 			interrupts = <62 2>;
@@ -325,7 +325,7 @@
 		};
 
 		gpioe: gpio@400ff100 {
-			compatible = "nxp,kinetis-gpio";
+			compatible = "nxp,gpio";
 			status = "disabled";
 			reg = <0x400ff100 0x40>;
 			interrupts = <63 2>;

--- a/dts/arm/nxp/nxp_k8x.dtsi
+++ b/dts/arm/nxp/nxp_k8x.dtsi
@@ -116,7 +116,7 @@
 		};
 
 		gpioa: gpio@400ff000 {
-			compatible = "nxp,kinetis-gpio";
+			compatible = "nxp,gpio";
 			status = "disabled";
 			reg = <0x400ff000 0x40>;
 			interrupts = <59 2>;
@@ -126,7 +126,7 @@
 		};
 
 		gpiob: gpio@400ff040 {
-			compatible = "nxp,kinetis-gpio";
+			compatible = "nxp,gpio";
 			status = "disabled";
 			reg = <0x400ff040 0x40>;
 			interrupts = <60 2>;
@@ -136,7 +136,7 @@
 		};
 
 		gpioc: gpio@400ff080 {
-			compatible = "nxp,kinetis-gpio";
+			compatible = "nxp,gpio";
 			status = "disabled";
 			reg = <0x400ff080 0x40>;
 			interrupts = <61 2>;
@@ -146,7 +146,7 @@
 		};
 
 		gpiod: gpio@400ff0c0 {
-			compatible = "nxp,kinetis-gpio";
+			compatible = "nxp,gpio";
 			status = "disabled";
 			reg = <0x400ff0c0 0x40>;
 			interrupts = <62 2>;
@@ -156,7 +156,7 @@
 		};
 
 		gpioe: gpio@400ff100 {
-			compatible = "nxp,kinetis-gpio";
+			compatible = "nxp,gpio";
 			status = "disabled";
 			reg = <0x400ff100 0x40>;
 			interrupts = <63 2>;

--- a/dts/arm/nxp/nxp_k8x.dtsi
+++ b/dts/arm/nxp/nxp_k8x.dtsi
@@ -122,7 +122,7 @@
 			interrupts = <59 2>;
 			gpio-controller;
 			#gpio-cells = <2>;
-			nxp,kinetis-port = <&porta>;
+			nxp,port = <&porta>;
 		};
 
 		gpiob: gpio@400ff040 {
@@ -132,7 +132,7 @@
 			interrupts = <60 2>;
 			gpio-controller;
 			#gpio-cells = <2>;
-			nxp,kinetis-port = <&portb>;
+			nxp,port = <&portb>;
 		};
 
 		gpioc: gpio@400ff080 {
@@ -142,7 +142,7 @@
 			interrupts = <61 2>;
 			gpio-controller;
 			#gpio-cells = <2>;
-			nxp,kinetis-port = <&portc>;
+			nxp,port = <&portc>;
 		};
 
 		gpiod: gpio@400ff0c0 {
@@ -152,7 +152,7 @@
 			interrupts = <62 2>;
 			gpio-controller;
 			#gpio-cells = <2>;
-			nxp,kinetis-port = <&portd>;
+			nxp,port = <&portd>;
 		};
 
 		gpioe: gpio@400ff100 {
@@ -162,7 +162,7 @@
 			interrupts = <63 2>;
 			gpio-controller;
 			#gpio-cells = <2>;
-			nxp,kinetis-port = <&porte>;
+			nxp,port = <&porte>;
 		};
 
 		i2c0: i2c@40066000 {

--- a/dts/arm/nxp/nxp_ke1xf.dtsi
+++ b/dts/arm/nxp/nxp_ke1xf.dtsi
@@ -452,7 +452,7 @@
 		};
 
 		gpioa: gpio@400ff000 {
-			compatible = "nxp,kinetis-gpio";
+			compatible = "nxp,gpio";
 			status = "disabled";
 			reg = <0x400ff000 0x40>;
 			interrupts = <59 2>;
@@ -462,7 +462,7 @@
 		};
 
 		gpiob: gpio@400ff040 {
-			compatible = "nxp,kinetis-gpio";
+			compatible = "nxp,gpio";
 			status = "disabled";
 			reg = <0x400ff040 0x40>;
 			interrupts = <60 2>;
@@ -472,7 +472,7 @@
 		};
 
 		gpioc: gpio@400ff080 {
-			compatible = "nxp,kinetis-gpio";
+			compatible = "nxp,gpio";
 			status = "disabled";
 			reg = <0x400ff080 0x40>;
 			interrupts = <61 2>;
@@ -482,7 +482,7 @@
 		};
 
 		gpiod: gpio@400ff0c0 {
-			compatible = "nxp,kinetis-gpio";
+			compatible = "nxp,gpio";
 			status = "disabled";
 			reg = <0x400ff0c0 0x40>;
 			interrupts = <62 2>;
@@ -492,7 +492,7 @@
 		};
 
 		gpioe: gpio@400ff100 {
-			compatible = "nxp,kinetis-gpio";
+			compatible = "nxp,gpio";
 			status = "disabled";
 			reg = <0x400ff100 0x40>;
 			interrupts = <63 2>;

--- a/dts/arm/nxp/nxp_ke1xf.dtsi
+++ b/dts/arm/nxp/nxp_ke1xf.dtsi
@@ -458,7 +458,7 @@
 			interrupts = <59 2>;
 			gpio-controller;
 			#gpio-cells = <2>;
-			nxp,kinetis-port = <&porta>;
+			nxp,port = <&porta>;
 		};
 
 		gpiob: gpio@400ff040 {
@@ -468,7 +468,7 @@
 			interrupts = <60 2>;
 			gpio-controller;
 			#gpio-cells = <2>;
-			nxp,kinetis-port = <&portb>;
+			nxp,port = <&portb>;
 		};
 
 		gpioc: gpio@400ff080 {
@@ -478,7 +478,7 @@
 			interrupts = <61 2>;
 			gpio-controller;
 			#gpio-cells = <2>;
-			nxp,kinetis-port = <&portc>;
+			nxp,port = <&portc>;
 		};
 
 		gpiod: gpio@400ff0c0 {
@@ -488,7 +488,7 @@
 			interrupts = <62 2>;
 			gpio-controller;
 			#gpio-cells = <2>;
-			nxp,kinetis-port = <&portd>;
+			nxp,port = <&portd>;
 		};
 
 		gpioe: gpio@400ff100 {
@@ -498,7 +498,7 @@
 			interrupts = <63 2>;
 			gpio-controller;
 			#gpio-cells = <2>;
-			nxp,kinetis-port = <&porte>;
+			nxp,port = <&porte>;
 		};
 
 		adc0: adc@4003b000 {

--- a/dts/arm/nxp/nxp_ke1xz.dtsi
+++ b/dts/arm/nxp/nxp_ke1xz.dtsi
@@ -245,7 +245,7 @@
 			#size-cells = <1>;
 
 			gpioa: gpio@400ff000 {
-				compatible = "nxp,kinetis-gpio";
+				compatible = "nxp,gpio";
 				status = "disabled";
 				reg = <0x0 0x40>;
 				gpio-controller;
@@ -254,7 +254,7 @@
 			};
 
 			gpioe: gpio@400ff100 {
-				compatible = "nxp,kinetis-gpio";
+				compatible = "nxp,gpio";
 				status = "disabled";
 				reg = <0x100 0x40>;
 				gpio-controller;
@@ -263,7 +263,7 @@
 			};
 
 			fgpioa: gpio@f8000000 {
-				compatible = "nxp,kinetis-gpio";
+				compatible = "nxp,gpio";
 				status = "disabled";
 				reg = <0xf8000000 0x40>;
 				gpio-controller;
@@ -272,7 +272,7 @@
 			};
 
 			fgpioe: gpio@f8000100 {
-				compatible = "nxp,kinetis-gpio";
+				compatible = "nxp,gpio";
 				status = "disabled";
 				reg = <0xf8000100 0x40>;
 				gpio-controller;
@@ -290,7 +290,7 @@
 			#size-cells = <1>;
 
 			gpiob: gpio@400ff040 {
-				compatible = "nxp,kinetis-gpio";
+				compatible = "nxp,gpio";
 				status = "disabled";
 				reg = <0x40 0x40>;
 				gpio-controller;
@@ -299,7 +299,7 @@
 			};
 
 			gpioc: gpio@400ff080 {
-				compatible = "nxp,kinetis-gpio";
+				compatible = "nxp,gpio";
 				status = "disabled";
 				reg = <0x80 0x40>;
 				gpio-controller;
@@ -308,7 +308,7 @@
 			};
 
 			gpiod: gpio@400ff0c0 {
-				compatible = "nxp,kinetis-gpio";
+				compatible = "nxp,gpio";
 				status = "disabled";
 				reg = <0xc0 0x40>;
 				gpio-controller;
@@ -317,7 +317,7 @@
 			};
 
 			fgpiob: gpio@f8000040 {
-				compatible = "nxp,kinetis-gpio";
+				compatible = "nxp,gpio";
 				status = "disabled";
 				reg = <0xf8000040 0x40>;
 				gpio-controller;
@@ -326,7 +326,7 @@
 			};
 
 			fgpioc: gpio@f8000080 {
-				compatible = "nxp,kinetis-gpio";
+				compatible = "nxp,gpio";
 				status = "disabled";
 				reg = <0xf8000080 0x40>;
 				gpio-controller;
@@ -335,7 +335,7 @@
 			};
 
 			fgpiod: gpio@f80000c0 {
-				compatible = "nxp,kinetis-gpio";
+				compatible = "nxp,gpio";
 				status = "disabled";
 				reg = <0xf80000c0 0x40>;
 				gpio-controller;

--- a/dts/arm/nxp/nxp_ke1xz.dtsi
+++ b/dts/arm/nxp/nxp_ke1xz.dtsi
@@ -250,7 +250,7 @@
 				reg = <0x0 0x40>;
 				gpio-controller;
 				#gpio-cells = <2>;
-				nxp,kinetis-port = <&porta>;
+				nxp,port = <&porta>;
 			};
 
 			gpioe: gpio@400ff100 {
@@ -259,7 +259,7 @@
 				reg = <0x100 0x40>;
 				gpio-controller;
 				#gpio-cells = <2>;
-				nxp,kinetis-port = <&porte>;
+				nxp,port = <&porte>;
 			};
 
 			fgpioa: gpio@f8000000 {
@@ -268,7 +268,7 @@
 				reg = <0xf8000000 0x40>;
 				gpio-controller;
 				#gpio-cells = <2>;
-				nxp,kinetis-port = <&porta>;
+				nxp,port = <&porta>;
 			};
 
 			fgpioe: gpio@f8000100 {
@@ -277,7 +277,7 @@
 				reg = <0xf8000100 0x40>;
 				gpio-controller;
 				#gpio-cells = <2>;
-				nxp,kinetis-port = <&porte>;
+				nxp,port = <&porte>;
 			};
 		};
 
@@ -295,7 +295,7 @@
 				reg = <0x40 0x40>;
 				gpio-controller;
 				#gpio-cells = <2>;
-				nxp,kinetis-port = <&portb>;
+				nxp,port = <&portb>;
 			};
 
 			gpioc: gpio@400ff080 {
@@ -304,7 +304,7 @@
 				reg = <0x80 0x40>;
 				gpio-controller;
 				#gpio-cells = <2>;
-				nxp,kinetis-port = <&portc>;
+				nxp,port = <&portc>;
 			};
 
 			gpiod: gpio@400ff0c0 {
@@ -313,7 +313,7 @@
 				reg = <0xc0 0x40>;
 				gpio-controller;
 				#gpio-cells = <2>;
-				nxp,kinetis-port = <&portd>;
+				nxp,port = <&portd>;
 			};
 
 			fgpiob: gpio@f8000040 {
@@ -322,7 +322,7 @@
 				reg = <0xf8000040 0x40>;
 				gpio-controller;
 				#gpio-cells = <2>;
-				nxp,kinetis-port = <&portb>;
+				nxp,port = <&portb>;
 			};
 
 			fgpioc: gpio@f8000080 {
@@ -331,7 +331,7 @@
 				reg = <0xf8000080 0x40>;
 				gpio-controller;
 				#gpio-cells = <2>;
-				nxp,kinetis-port = <&portc>;
+				nxp,port = <&portc>;
 			};
 
 			fgpiod: gpio@f80000c0 {
@@ -340,7 +340,7 @@
 				reg = <0xf80000c0 0x40>;
 				gpio-controller;
 				#gpio-cells = <2>;
-				nxp,kinetis-port = <&portd>;
+				nxp,port = <&portd>;
 			};
 		};
 

--- a/dts/arm/nxp/nxp_kl25z.dtsi
+++ b/dts/arm/nxp/nxp_kl25z.dtsi
@@ -155,7 +155,7 @@
 			interrupts = <30 2>;
 			gpio-controller;
 			#gpio-cells = <2>;
-			nxp,kinetis-port = <&porta>;
+			nxp,port = <&porta>;
 		};
 
 		gpiob: gpio@400ff040 {
@@ -164,7 +164,7 @@
 			reg = <0x400ff040 0x40>;
 			gpio-controller;
 			#gpio-cells = <2>;
-			nxp,kinetis-port = <&portb>;
+			nxp,port = <&portb>;
 		};
 
 		gpioc: gpio@400ff080 {
@@ -173,7 +173,7 @@
 			reg = <0x400ff080 0x40>;
 			gpio-controller;
 			#gpio-cells = <2>;
-			nxp,kinetis-port = <&portc>;
+			nxp,port = <&portc>;
 		};
 
 		gpiod: gpio@400ff0c0 {
@@ -183,7 +183,7 @@
 			interrupts = <31 2>;
 			gpio-controller;
 			#gpio-cells = <2>;
-			nxp,kinetis-port = <&portd>;
+			nxp,port = <&portd>;
 		};
 
 		gpioe: gpio@400ff100 {
@@ -192,7 +192,7 @@
 			reg = <0x400ff100 0x40>;
 			gpio-controller;
 			#gpio-cells = <2>;
-			nxp,kinetis-port = <&porte>;
+			nxp,port = <&porte>;
 		};
 
 		usbotg: usbd@40072000 {

--- a/dts/arm/nxp/nxp_kl25z.dtsi
+++ b/dts/arm/nxp/nxp_kl25z.dtsi
@@ -149,7 +149,7 @@
 		};
 
 		gpioa: gpio@400ff000 {
-			compatible = "nxp,kinetis-gpio";
+			compatible = "nxp,gpio";
 			status = "disabled";
 			reg = <0x400ff000 0x40>;
 			interrupts = <30 2>;
@@ -159,7 +159,7 @@
 		};
 
 		gpiob: gpio@400ff040 {
-			compatible = "nxp,kinetis-gpio";
+			compatible = "nxp,gpio";
 			status = "disabled";
 			reg = <0x400ff040 0x40>;
 			gpio-controller;
@@ -168,7 +168,7 @@
 		};
 
 		gpioc: gpio@400ff080 {
-			compatible = "nxp,kinetis-gpio";
+			compatible = "nxp,gpio";
 			status = "disabled";
 			reg = <0x400ff080 0x40>;
 			gpio-controller;
@@ -177,7 +177,7 @@
 		};
 
 		gpiod: gpio@400ff0c0 {
-			compatible = "nxp,kinetis-gpio";
+			compatible = "nxp,gpio";
 			status = "disabled";
 			reg = <0x400ff0c0 0x40>;
 			interrupts = <31 2>;
@@ -187,7 +187,7 @@
 		};
 
 		gpioe: gpio@400ff100 {
-			compatible = "nxp,kinetis-gpio";
+			compatible = "nxp,gpio";
 			status = "disabled";
 			reg = <0x400ff100 0x40>;
 			gpio-controller;

--- a/dts/arm/nxp/nxp_kv5x.dtsi
+++ b/dts/arm/nxp/nxp_kv5x.dtsi
@@ -105,7 +105,7 @@
 		};
 
 		gpioa: gpio@400ff000 {
-			compatible = "nxp,kinetis-gpio";
+			compatible = "nxp,gpio";
 			status = "disabled";
 			reg = <0x400ff000 0x40>;
 			interrupts = <59 2>;
@@ -115,7 +115,7 @@
 		};
 
 		gpiob: gpio@400ff040 {
-			compatible = "nxp,kinetis-gpio";
+			compatible = "nxp,gpio";
 			status = "disabled";
 			reg = <0x400ff040 0x40>;
 			interrupts = <60 2>;
@@ -125,7 +125,7 @@
 		};
 
 		gpioc: gpio@400ff080 {
-			compatible = "nxp,kinetis-gpio";
+			compatible = "nxp,gpio";
 			status = "disabled";
 			reg = <0x400ff080 0x40>;
 			interrupts = <61 2>;
@@ -135,7 +135,7 @@
 		};
 
 		gpiod: gpio@400ff0c0 {
-			compatible = "nxp,kinetis-gpio";
+			compatible = "nxp,gpio";
 			status = "disabled";
 			reg = <0x400ff0c0 0x40>;
 			interrupts = <62 2>;
@@ -145,7 +145,7 @@
 		};
 
 		gpioe: gpio@400ff100 {
-			compatible = "nxp,kinetis-gpio";
+			compatible = "nxp,gpio";
 			status = "disabled";
 			reg = <0x400ff100 0x40>;
 			interrupts = <63 2>;

--- a/dts/arm/nxp/nxp_kv5x.dtsi
+++ b/dts/arm/nxp/nxp_kv5x.dtsi
@@ -111,7 +111,7 @@
 			interrupts = <59 2>;
 			gpio-controller;
 			#gpio-cells = <2>;
-			nxp,kinetis-port = <&porta>;
+			nxp,port = <&porta>;
 		};
 
 		gpiob: gpio@400ff040 {
@@ -121,7 +121,7 @@
 			interrupts = <60 2>;
 			gpio-controller;
 			#gpio-cells = <2>;
-			nxp,kinetis-port = <&portb>;
+			nxp,port = <&portb>;
 		};
 
 		gpioc: gpio@400ff080 {
@@ -131,7 +131,7 @@
 			interrupts = <61 2>;
 			gpio-controller;
 			#gpio-cells = <2>;
-			nxp,kinetis-port = <&portc>;
+			nxp,port = <&portc>;
 		};
 
 		gpiod: gpio@400ff0c0 {
@@ -141,7 +141,7 @@
 			interrupts = <62 2>;
 			gpio-controller;
 			#gpio-cells = <2>;
-			nxp,kinetis-port = <&portd>;
+			nxp,port = <&portd>;
 		};
 
 		gpioe: gpio@400ff100 {
@@ -151,7 +151,7 @@
 			interrupts = <63 2>;
 			gpio-controller;
 			#gpio-cells = <2>;
-			nxp,kinetis-port = <&porte>;
+			nxp,port = <&porte>;
 		};
 
 		i2c0: i2c@40066000 {

--- a/dts/arm/nxp/nxp_kw2xd.dtsi
+++ b/dts/arm/nxp/nxp_kw2xd.dtsi
@@ -212,7 +212,7 @@
 			interrupts = <59 2>;
 			gpio-controller;
 			#gpio-cells = <2>;
-			nxp,kinetis-port = <&porta>;
+			nxp,port = <&porta>;
 		};
 
 		gpiob: gpio@400ff040 {
@@ -222,7 +222,7 @@
 			interrupts = <60 2>;
 			gpio-controller;
 			#gpio-cells = <2>;
-			nxp,kinetis-port = <&portb>;
+			nxp,port = <&portb>;
 		};
 
 		gpioc: gpio@400ff080 {
@@ -232,7 +232,7 @@
 			interrupts = <61 2>;
 			gpio-controller;
 			#gpio-cells = <2>;
-			nxp,kinetis-port = <&portc>;
+			nxp,port = <&portc>;
 		};
 
 		gpiod: gpio@400ff0c0 {
@@ -242,7 +242,7 @@
 			interrupts = <62 2>;
 			gpio-controller;
 			#gpio-cells = <2>;
-			nxp,kinetis-port = <&portd>;
+			nxp,port = <&portd>;
 		};
 
 		gpioe: gpio@400ff100 {
@@ -252,7 +252,7 @@
 			interrupts = <63 2>;
 			gpio-controller;
 			#gpio-cells = <2>;
-			nxp,kinetis-port = <&porte>;
+			nxp,port = <&porte>;
 		};
 
 		spi0: spi@4002c000 {

--- a/dts/arm/nxp/nxp_kw2xd.dtsi
+++ b/dts/arm/nxp/nxp_kw2xd.dtsi
@@ -206,7 +206,7 @@
 		};
 
 		gpioa: gpio@400ff000 {
-			compatible = "nxp,kinetis-gpio";
+			compatible = "nxp,gpio";
 			status = "disabled";
 			reg = <0x400ff000 0x40>;
 			interrupts = <59 2>;
@@ -216,7 +216,7 @@
 		};
 
 		gpiob: gpio@400ff040 {
-			compatible = "nxp,kinetis-gpio";
+			compatible = "nxp,gpio";
 			status = "disabled";
 			reg = <0x400ff040 0x40>;
 			interrupts = <60 2>;
@@ -226,7 +226,7 @@
 		};
 
 		gpioc: gpio@400ff080 {
-			compatible = "nxp,kinetis-gpio";
+			compatible = "nxp,gpio";
 			status = "disabled";
 			reg = <0x400ff080 0x40>;
 			interrupts = <61 2>;
@@ -236,7 +236,7 @@
 		};
 
 		gpiod: gpio@400ff0c0 {
-			compatible = "nxp,kinetis-gpio";
+			compatible = "nxp,gpio";
 			status = "disabled";
 			reg = <0x400ff0c0 0x40>;
 			interrupts = <62 2>;
@@ -246,7 +246,7 @@
 		};
 
 		gpioe: gpio@400ff100 {
-			compatible = "nxp,kinetis-gpio";
+			compatible = "nxp,gpio";
 			status = "disabled";
 			reg = <0x400ff100 0x40>;
 			interrupts = <63 2>;

--- a/dts/arm/nxp/nxp_kw40z.dtsi
+++ b/dts/arm/nxp/nxp_kw40z.dtsi
@@ -142,7 +142,7 @@
 		};
 
 		gpioa: gpio@400ff000 {
-			compatible = "nxp,kinetis-gpio";
+			compatible = "nxp,gpio";
 			status = "disabled";
 			reg = <0x400ff000 0x40>;
 			interrupts = <30 2>;
@@ -152,7 +152,7 @@
 		};
 
 		gpiob: gpio@400ff040 {
-			compatible = "nxp,kinetis-gpio";
+			compatible = "nxp,gpio";
 			status = "disabled";
 			reg = <0x400ff040 0x40>;
 			gpio-controller;
@@ -161,7 +161,7 @@
 		};
 
 		gpioc: gpio@400ff080 {
-			compatible = "nxp,kinetis-gpio";
+			compatible = "nxp,gpio";
 			status = "disabled";
 			reg = <0x400ff080 0x40>;
 			interrupts = <31 2>;

--- a/dts/arm/nxp/nxp_kw40z.dtsi
+++ b/dts/arm/nxp/nxp_kw40z.dtsi
@@ -148,7 +148,7 @@
 			interrupts = <30 2>;
 			gpio-controller;
 			#gpio-cells = <2>;
-			nxp,kinetis-port = <&porta>;
+			nxp,port = <&porta>;
 		};
 
 		gpiob: gpio@400ff040 {
@@ -157,7 +157,7 @@
 			reg = <0x400ff040 0x40>;
 			gpio-controller;
 			#gpio-cells = <2>;
-			nxp,kinetis-port = <&portb>;
+			nxp,port = <&portb>;
 		};
 
 		gpioc: gpio@400ff080 {
@@ -167,7 +167,7 @@
 			interrupts = <31 2>;
 			gpio-controller;
 			#gpio-cells = <2>;
-			nxp,kinetis-port = <&portc>;
+			nxp,port = <&portc>;
 		};
 
 		spi0: spi@4002c000 {

--- a/dts/arm/nxp/nxp_kw41z.dtsi
+++ b/dts/arm/nxp/nxp_kw41z.dtsi
@@ -155,7 +155,7 @@
 			interrupts = <30 2>;
 			gpio-controller;
 			#gpio-cells = <2>;
-			nxp,kinetis-port = <&porta>;
+			nxp,port = <&porta>;
 		};
 
 		gpiob: gpio@400ff040 {
@@ -164,7 +164,7 @@
 			reg = <0x400ff040 0x40>;
 			gpio-controller;
 			#gpio-cells = <2>;
-			nxp,kinetis-port = <&portb>;
+			nxp,port = <&portb>;
 		};
 
 		gpioc: gpio@400ff080 {
@@ -174,7 +174,7 @@
 			interrupts = <31 2>;
 			gpio-controller;
 			#gpio-cells = <2>;
-			nxp,kinetis-port = <&portc>;
+			nxp,port = <&portc>;
 		};
 
 		spi0: spi@4002c000 {

--- a/dts/arm/nxp/nxp_kw41z.dtsi
+++ b/dts/arm/nxp/nxp_kw41z.dtsi
@@ -149,7 +149,7 @@
 		};
 
 		gpioa: gpio@400ff000 {
-			compatible = "nxp,kinetis-gpio";
+			compatible = "nxp,gpio";
 			status = "disabled";
 			reg = <0x400ff000 0x40>;
 			interrupts = <30 2>;
@@ -159,7 +159,7 @@
 		};
 
 		gpiob: gpio@400ff040 {
-			compatible = "nxp,kinetis-gpio";
+			compatible = "nxp,gpio";
 			status = "disabled";
 			reg = <0x400ff040 0x40>;
 			gpio-controller;
@@ -168,7 +168,7 @@
 		};
 
 		gpioc: gpio@400ff080 {
-			compatible = "nxp,kinetis-gpio";
+			compatible = "nxp,gpio";
 			status = "disabled";
 			reg = <0x400ff080 0x40>;
 			interrupts = <31 2>;

--- a/dts/arm/nxp/nxp_mcxa156.dtsi
+++ b/dts/arm/nxp/nxp_mcxa156.dtsi
@@ -80,7 +80,7 @@
 		};
 
 		gpio0: gpio@40102000 {
-			compatible = "nxp,kinetis-gpio";
+			compatible = "nxp,gpio";
 			reg = <0x40102000 0x1000>;
 			interrupts = <71 0>;
 			gpio-controller;
@@ -89,7 +89,7 @@
 		};
 
 		gpio1: gpio@40103000 {
-			compatible = "nxp,kinetis-gpio";
+			compatible = "nxp,gpio";
 			status = "disabled";
 			reg = <0x40103000 0x1000>;
 			interrupts = <72 0>;
@@ -99,7 +99,7 @@
 		};
 
 		gpio2: gpio@40104000 {
-			compatible = "nxp,kinetis-gpio";
+			compatible = "nxp,gpio";
 			status = "disabled";
 			reg = <0x40104000 0x1000>;
 			interrupts = <73 0>;
@@ -109,7 +109,7 @@
 		};
 
 		gpio3: gpio@40105000 {
-			compatible = "nxp,kinetis-gpio";
+			compatible = "nxp,gpio";
 			status = "disabled";
 			reg = <0x40105000 0x1000>;
 			interrupts = <74 0>;
@@ -119,7 +119,7 @@
 		};
 
 		gpio4: gpio@40106000 {
-			compatible = "nxp,kinetis-gpio";
+			compatible = "nxp,gpio";
 			status = "disabled";
 			reg = <0x40106000 0x1000>;
 			interrupts = <75 0>;

--- a/dts/arm/nxp/nxp_mcxa156.dtsi
+++ b/dts/arm/nxp/nxp_mcxa156.dtsi
@@ -85,7 +85,7 @@
 			interrupts = <71 0>;
 			gpio-controller;
 			#gpio-cells = <2>;
-			nxp,kinetis-port = <&porta>;
+			nxp,port = <&porta>;
 		};
 
 		gpio1: gpio@40103000 {
@@ -95,7 +95,7 @@
 			interrupts = <72 0>;
 			gpio-controller;
 			#gpio-cells = <2>;
-			nxp,kinetis-port = <&portb>;
+			nxp,port = <&portb>;
 		};
 
 		gpio2: gpio@40104000 {
@@ -105,7 +105,7 @@
 			interrupts = <73 0>;
 			gpio-controller;
 			#gpio-cells = <2>;
-			nxp,kinetis-port = <&portc>;
+			nxp,port = <&portc>;
 		};
 
 		gpio3: gpio@40105000 {
@@ -115,7 +115,7 @@
 			interrupts = <74 0>;
 			gpio-controller;
 			#gpio-cells = <2>;
-			nxp,kinetis-port = <&portd>;
+			nxp,port = <&portd>;
 		};
 
 		gpio4: gpio@40106000 {
@@ -125,7 +125,7 @@
 			interrupts = <75 0>;
 			gpio-controller;
 			#gpio-cells = <2>;
-			nxp,kinetis-port = <&porte>;
+			nxp,port = <&porte>;
 		};
 
 		lpuart0: lpuart@4009f000 {

--- a/dts/arm/nxp/nxp_mcxc_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxc_common.dtsi
@@ -137,7 +137,7 @@
 		};
 
 		gpioa: gpio@400ff000 {
-			compatible = "nxp,kinetis-gpio";
+			compatible = "nxp,gpio";
 			status = "disabled";
 			reg = <0x400ff000 0x40>;
 			interrupts = <30 2>;
@@ -147,7 +147,7 @@
 		};
 
 		gpiob: gpio@400ff040 {
-			compatible = "nxp,kinetis-gpio";
+			compatible = "nxp,gpio";
 			status = "disabled";
 			reg = <0x400ff040 0x40>;
 			gpio-controller;
@@ -156,7 +156,7 @@
 		};
 
 		gpioc: gpio@400ff080 {
-			compatible = "nxp,kinetis-gpio";
+			compatible = "nxp,gpio";
 			status = "disabled";
 			reg = <0x400ff080 0x40>;
 			interrupts = <31 2>;
@@ -166,7 +166,7 @@
 		};
 
 		gpiod: gpio@400ff0c0 {
-			compatible = "nxp,kinetis-gpio";
+			compatible = "nxp,gpio";
 			status = "disabled";
 			reg = <0x400ff0c0 0x40>;
 			gpio-controller;
@@ -175,7 +175,7 @@
 		};
 
 		gpioe: gpio@400ff100 {
-			compatible = "nxp,kinetis-gpio";
+			compatible = "nxp,gpio";
 			status = "disabled";
 			reg = <0x400ff100 0x40>;
 			gpio-controller;

--- a/dts/arm/nxp/nxp_mcxc_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxc_common.dtsi
@@ -143,7 +143,7 @@
 			interrupts = <30 2>;
 			gpio-controller;
 			#gpio-cells = <2>;
-			nxp,kinetis-port = <&porta>;
+			nxp,port = <&porta>;
 		};
 
 		gpiob: gpio@400ff040 {
@@ -152,7 +152,7 @@
 			reg = <0x400ff040 0x40>;
 			gpio-controller;
 			#gpio-cells = <2>;
-			nxp,kinetis-port = <&portb>;
+			nxp,port = <&portb>;
 		};
 
 		gpioc: gpio@400ff080 {
@@ -162,7 +162,7 @@
 			interrupts = <31 2>;
 			gpio-controller;
 			#gpio-cells = <2>;
-			nxp,kinetis-port = <&portc>;
+			nxp,port = <&portc>;
 		};
 
 		gpiod: gpio@400ff0c0 {
@@ -171,7 +171,7 @@
 			reg = <0x400ff0c0 0x40>;
 			gpio-controller;
 			#gpio-cells = <2>;
-			nxp,kinetis-port = <&portd>;
+			nxp,port = <&portd>;
 		};
 
 		gpioe: gpio@400ff100 {
@@ -180,7 +180,7 @@
 			reg = <0x400ff100 0x40>;
 			gpio-controller;
 			#gpio-cells = <2>;
-			nxp,kinetis-port = <&porte>;
+			nxp,port = <&porte>;
 		};
 
 		adc0: adc@4003b000{

--- a/dts/arm/nxp/nxp_mcxn23x_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxn23x_common.dtsi
@@ -110,7 +110,7 @@
 	};
 
 	gpio0: gpio@96000 {
-		compatible = "nxp,kinetis-gpio";
+		compatible = "nxp,gpio";
 		status = "disabled";
 		reg = <0x96000 0x1000>;
 		interrupts = <17 0>,<18 0>;
@@ -120,7 +120,7 @@
 	};
 
 	gpio1: gpio@98000 {
-		compatible = "nxp,kinetis-gpio";
+		compatible = "nxp,gpio";
 		status = "disabled";
 		reg = <0x98000 0x1000>;
 		interrupts = <19 0>,<20 0>;
@@ -130,7 +130,7 @@
 	};
 
 	gpio2: gpio@9a000 {
-		compatible = "nxp,kinetis-gpio";
+		compatible = "nxp,gpio";
 		status = "disabled";
 		reg = <0x9a000 0x1000>;
 		interrupts = <21 0>,<22 0>;
@@ -140,7 +140,7 @@
 	};
 
 	gpio3: gpio@9c000 {
-		compatible = "nxp,kinetis-gpio";
+		compatible = "nxp,gpio";
 		status = "disabled";
 		reg = <0x9c000 0x1000>;
 		interrupts = <23 0>,<24 0>;
@@ -150,7 +150,7 @@
 	};
 
 	gpio4: gpio@9e000 {
-		compatible = "nxp,kinetis-gpio";
+		compatible = "nxp,gpio";
 		status = "disabled";
 		reg = <0x9e000 0x1000>;
 		interrupts = <25 0>,<26 0>;
@@ -160,7 +160,7 @@
 	};
 
 	gpio5: gpio@40000 {
-		compatible = "nxp,kinetis-gpio";
+		compatible = "nxp,gpio";
 		status = "disabled";
 		reg = <0x40000 0x1000>;
 		interrupts = <27 0>,<28 0>;

--- a/dts/arm/nxp/nxp_mcxn23x_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxn23x_common.dtsi
@@ -116,7 +116,7 @@
 		interrupts = <17 0>,<18 0>;
 		gpio-controller;
 		#gpio-cells = <2>;
-		nxp,kinetis-port = <&porta>;
+		nxp,port = <&porta>;
 	};
 
 	gpio1: gpio@98000 {
@@ -126,7 +126,7 @@
 		interrupts = <19 0>,<20 0>;
 		gpio-controller;
 		#gpio-cells = <2>;
-		nxp,kinetis-port = <&portb>;
+		nxp,port = <&portb>;
 	};
 
 	gpio2: gpio@9a000 {
@@ -136,7 +136,7 @@
 		interrupts = <21 0>,<22 0>;
 		gpio-controller;
 		#gpio-cells = <2>;
-		nxp,kinetis-port = <&portc>;
+		nxp,port = <&portc>;
 	};
 
 	gpio3: gpio@9c000 {
@@ -146,7 +146,7 @@
 		interrupts = <23 0>,<24 0>;
 		gpio-controller;
 		#gpio-cells = <2>;
-		nxp,kinetis-port = <&portd>;
+		nxp,port = <&portd>;
 	};
 
 	gpio4: gpio@9e000 {
@@ -156,7 +156,7 @@
 		interrupts = <25 0>,<26 0>;
 		gpio-controller;
 		#gpio-cells = <2>;
-		nxp,kinetis-port = <&porte>;
+		nxp,port = <&porte>;
 	};
 
 	gpio5: gpio@40000 {
@@ -166,7 +166,7 @@
 		interrupts = <27 0>,<28 0>;
 		gpio-controller;
 		#gpio-cells = <2>;
-		nxp,kinetis-port = <&portf>;
+		nxp,port = <&portf>;
 	};
 
 	flexcomm0: flexcomm@92000 {

--- a/dts/arm/nxp/nxp_mcxn94x_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxn94x_common.dtsi
@@ -122,7 +122,7 @@
 		interrupts = <17 0>,<18 0>;
 		gpio-controller;
 		#gpio-cells = <2>;
-		nxp,kinetis-port = <&porta>;
+		nxp,port = <&porta>;
 	};
 
 	gpio1: gpio@98000 {
@@ -132,7 +132,7 @@
 		interrupts = <19 0>,<20 0>;
 		gpio-controller;
 		#gpio-cells = <2>;
-		nxp,kinetis-port = <&portb>;
+		nxp,port = <&portb>;
 	};
 
 	gpio2: gpio@9a000 {
@@ -142,7 +142,7 @@
 		interrupts = <21 0>,<22 0>;
 		gpio-controller;
 		#gpio-cells = <2>;
-		nxp,kinetis-port = <&portc>;
+		nxp,port = <&portc>;
 	};
 
 	gpio3: gpio@9c000 {
@@ -152,7 +152,7 @@
 		interrupts = <23 0>,<24 0>;
 		gpio-controller;
 		#gpio-cells = <2>;
-		nxp,kinetis-port = <&portd>;
+		nxp,port = <&portd>;
 	};
 
 	gpio4: gpio@9e000 {
@@ -162,7 +162,7 @@
 		interrupts = <25 0>,<26 0>;
 		gpio-controller;
 		#gpio-cells = <2>;
-		nxp,kinetis-port = <&porte>;
+		nxp,port = <&porte>;
 	};
 
 	gpio5: gpio@40000 {
@@ -172,7 +172,7 @@
 		interrupts = <27 0>,<28 0>;
 		gpio-controller;
 		#gpio-cells = <2>;
-		nxp,kinetis-port = <&portf>;
+		nxp,port = <&portf>;
 	};
 
 	flexcomm0: flexcomm@92000 {

--- a/dts/arm/nxp/nxp_mcxn94x_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxn94x_common.dtsi
@@ -116,7 +116,7 @@
 	};
 
 	gpio0: gpio@96000 {
-		compatible = "nxp,kinetis-gpio";
+		compatible = "nxp,gpio";
 		status = "disabled";
 		reg = <0x96000 0x1000>;
 		interrupts = <17 0>,<18 0>;
@@ -126,7 +126,7 @@
 	};
 
 	gpio1: gpio@98000 {
-		compatible = "nxp,kinetis-gpio";
+		compatible = "nxp,gpio";
 		status = "disabled";
 		reg = <0x98000 0x1000>;
 		interrupts = <19 0>,<20 0>;
@@ -136,7 +136,7 @@
 	};
 
 	gpio2: gpio@9a000 {
-		compatible = "nxp,kinetis-gpio";
+		compatible = "nxp,gpio";
 		status = "disabled";
 		reg = <0x9a000 0x1000>;
 		interrupts = <21 0>,<22 0>;
@@ -146,7 +146,7 @@
 	};
 
 	gpio3: gpio@9c000 {
-		compatible = "nxp,kinetis-gpio";
+		compatible = "nxp,gpio";
 		status = "disabled";
 		reg = <0x9c000 0x1000>;
 		interrupts = <23 0>,<24 0>;
@@ -156,7 +156,7 @@
 	};
 
 	gpio4: gpio@9e000 {
-		compatible = "nxp,kinetis-gpio";
+		compatible = "nxp,gpio";
 		status = "disabled";
 		reg = <0x9e000 0x1000>;
 		interrupts = <25 0>,<26 0>;
@@ -166,7 +166,7 @@
 	};
 
 	gpio5: gpio@40000 {
-		compatible = "nxp,kinetis-gpio";
+		compatible = "nxp,gpio";
 		status = "disabled";
 		reg = <0x40000 0x1000>;
 		interrupts = <27 0>,<28 0>;

--- a/dts/arm/nxp/nxp_mcxw71.dtsi
+++ b/dts/arm/nxp/nxp_mcxw71.dtsi
@@ -229,7 +229,7 @@
 	};
 
 	gpiod: gpio@46000{
-		compatible = "nxp,kinetis-gpio";
+		compatible = "nxp,gpio";
 		status = "disabled";
 		gpio-controller;
 		#gpio-cells = <2>;
@@ -351,7 +351,7 @@
 
 &fast_peripheral0 {
 	gpioa: gpio@10000{
-		compatible = "nxp,kinetis-gpio";
+		compatible = "nxp,gpio";
 		status = "disabled";
 		gpio-controller;
 		#gpio-cells = <2>;
@@ -361,7 +361,7 @@
 	};
 
 	gpiob: gpio@20000{
-		compatible = "nxp,kinetis-gpio";
+		compatible = "nxp,gpio";
 		status = "disabled";
 		gpio-controller;
 		#gpio-cells = <2>;
@@ -371,7 +371,7 @@
 	};
 
 	gpioc: gpio@30000{
-		compatible = "nxp,kinetis-gpio";
+		compatible = "nxp,gpio";
 		status = "disabled";
 		gpio-controller;
 		#gpio-cells = <2>;

--- a/dts/arm/nxp/nxp_mcxw71.dtsi
+++ b/dts/arm/nxp/nxp_mcxw71.dtsi
@@ -233,7 +233,7 @@
 		status = "disabled";
 		gpio-controller;
 		#gpio-cells = <2>;
-		nxp,kinetis-port = <&portd>;
+		nxp,port = <&portd>;
 		reg = <0x46000 0x128>;
 		interrupts = <65 0>, <66 0>;
 	};
@@ -355,7 +355,7 @@
 		status = "disabled";
 		gpio-controller;
 		#gpio-cells = <2>;
-		nxp,kinetis-port = <&porta>;
+		nxp,port = <&porta>;
 		reg = <0x10000 0x128>;
 		interrupts = <59 0>, <60 0>;
 	};
@@ -365,7 +365,7 @@
 		status = "disabled";
 		gpio-controller;
 		#gpio-cells = <2>;
-		nxp,kinetis-port = <&portb>;
+		nxp,port = <&portb>;
 		reg = <0x20000 0x128>;
 		interrupts = <61 0>, <62 0>;
 	};
@@ -375,7 +375,7 @@
 		status = "disabled";
 		gpio-controller;
 		#gpio-cells = <2>;
-		nxp,kinetis-port = <&portc>;
+		nxp,port = <&portc>;
 		reg = <0x30000 0x128>;
 		interrupts = <63 0>, <64 0>;
 	};

--- a/dts/arm/nxp/nxp_s32k1xx.dtsi
+++ b/dts/arm/nxp/nxp_s32k1xx.dtsi
@@ -189,7 +189,7 @@
 		};
 
 		gpioa: gpio@400ff000 {
-			compatible = "nxp,kinetis-gpio";
+			compatible = "nxp,gpio";
 			reg = <0x400ff000 0x40>;
 			interrupts = <59 2>;
 			gpio-controller;
@@ -199,7 +199,7 @@
 		};
 
 		gpiob: gpio@400ff040 {
-			compatible = "nxp,kinetis-gpio";
+			compatible = "nxp,gpio";
 			reg = <0x400ff040 0x40>;
 			interrupts = <60 2>;
 			gpio-controller;
@@ -209,7 +209,7 @@
 		};
 
 		gpioc: gpio@400ff080 {
-			compatible = "nxp,kinetis-gpio";
+			compatible = "nxp,gpio";
 			reg = <0x400ff080 0x40>;
 			interrupts = <61 2>;
 			gpio-controller;
@@ -219,7 +219,7 @@
 		};
 
 		gpiod: gpio@400ff0c0 {
-			compatible = "nxp,kinetis-gpio";
+			compatible = "nxp,gpio";
 			reg = <0x400ff0c0 0x40>;
 			interrupts = <62 2>;
 			gpio-controller;
@@ -229,7 +229,7 @@
 		};
 
 		gpioe: gpio@400ff100 {
-			compatible = "nxp,kinetis-gpio";
+			compatible = "nxp,gpio";
 			reg = <0x400ff100 0x40>;
 			interrupts = <63 2>;
 			gpio-controller;

--- a/dts/arm/nxp/nxp_s32k1xx.dtsi
+++ b/dts/arm/nxp/nxp_s32k1xx.dtsi
@@ -194,7 +194,7 @@
 			interrupts = <59 2>;
 			gpio-controller;
 			#gpio-cells = <2>;
-			nxp,kinetis-port = <&porta>;
+			nxp,port = <&porta>;
 			status = "disabled";
 		};
 
@@ -204,7 +204,7 @@
 			interrupts = <60 2>;
 			gpio-controller;
 			#gpio-cells = <2>;
-			nxp,kinetis-port = <&portb>;
+			nxp,port = <&portb>;
 			status = "disabled";
 		};
 
@@ -214,7 +214,7 @@
 			interrupts = <61 2>;
 			gpio-controller;
 			#gpio-cells = <2>;
-			nxp,kinetis-port = <&portc>;
+			nxp,port = <&portc>;
 			status = "disabled";
 		};
 
@@ -224,7 +224,7 @@
 			interrupts = <62 2>;
 			gpio-controller;
 			#gpio-cells = <2>;
-			nxp,kinetis-port = <&portd>;
+			nxp,port = <&portd>;
 			status = "disabled";
 		};
 
@@ -234,7 +234,7 @@
 			interrupts = <63 2>;
 			gpio-controller;
 			#gpio-cells = <2>;
-			nxp,kinetis-port = <&porte>;
+			nxp,port = <&porte>;
 			status = "disabled";
 		};
 

--- a/dts/bindings/gpio/nxp,gpio.yaml
+++ b/dts/bindings/gpio/nxp,gpio.yaml
@@ -1,6 +1,6 @@
-description: Kinetis GPIO node
+description: NXP GPIO controller
 
-compatible: "nxp,kinetis-gpio"
+compatible: "nxp,gpio"
 
 include: [gpio-controller.yaml, base.yaml]
 

--- a/dts/bindings/gpio/nxp,gpio.yaml
+++ b/dts/bindings/gpio/nxp,gpio.yaml
@@ -11,7 +11,7 @@ properties:
   "#gpio-cells":
     const: 2
 
-  nxp,kinetis-port:
+  nxp,port:
     required: true
     type: phandle
     description: |

--- a/include/zephyr/dt-bindings/gpio/nxp-gpio.h
+++ b/include/zephyr/dt-bindings/gpio/nxp-gpio.h
@@ -3,15 +3,14 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#ifndef ZEPHYR_INCLUDE_DT_BINDINGS_GPIO_NXP_KINETIS_GPIO_H_
-#define ZEPHYR_INCLUDE_DT_BINDINGS_GPIO_NXP_KINETIS_GPIO_H_
+#ifndef ZEPHYR_INCLUDE_DT_BINDINGS_GPIO_NXP_GPIO_H_
+#define ZEPHYR_INCLUDE_DT_BINDINGS_GPIO_NXP_GPIO_H_
 
 /**
  * @name GPIO drive strength flags
  *
  * The drive strength flags are a Zephyr specific extension of the standard GPIO
- * flags specified by the Linux GPIO binding. Only applicable for NXP Kinetis
- * SoCs.
+ * flags specified by the Linux GPIO binding.
  *
  * The interface supports two different drive strengths:
  * `DFLT` - The lowest drive strength supported by the HW
@@ -20,16 +19,16 @@
  * @{
  */
 /** @cond INTERNAL_HIDDEN */
-#define KINETIS_GPIO_DS_POS 9
-#define KINETIS_GPIO_DS_MASK (0x3U << KINETIS_GPIO_DS_POS)
+#define NXP_GPIO_DS_POS 9
+#define NXP_GPIO_DS_MASK (0x3U << NXP_GPIO_DS_POS)
 /** @endcond */
 
 /** Default drive strength. */
-#define KINETIS_GPIO_DS_DFLT (0x0U << KINETIS_GPIO_DS_POS)
+#define NXP_GPIO_DS_DFLT (0x0U << NXP_GPIO_DS_POS)
 
 /** Alternative drive strength. */
-#define KINETIS_GPIO_DS_ALT (0x3U << KINETIS_GPIO_DS_POS)
+#define NXP_GPIO_DS_ALT (0x3U << NXP_GPIO_DS_POS)
 
 /** @} */
 
-#endif /* ZEPHYR_INCLUDE_DT_BINDINGS_GPIO_NXP_KINETIS_GPIO_H_ */
+#endif /* ZEPHYR_INCLUDE_DT_BINDINGS_GPIO_NXP_GPIO_H_ */


### PR DESCRIPTION
Remove device family name from NXP GPIO binding compat, property and defines because this hardware block is used in multiple NXP devices from different families.