### PR TITLE
dts: bindings: rename nxp,imx-lpi2c compatible

### DIFF
--- a/doc/releases/migration-guide-4.1.rst
+++ b/doc/releases/migration-guide-4.1.rst
@@ -101,6 +101,11 @@ Entropy
 GNSS
 ====
 
+I2C
+===
+
+* Renamed the ``compatible`` from ``nxp,imx-lpi2c`` to :dtcompatible:`nxp,lpi2c`.
+
 Input
 =====
 

--- a/drivers/i2c/Kconfig
+++ b/drivers/i2c/Kconfig
@@ -201,7 +201,7 @@ config I2C_MCUX
 config I2C_MCUX_LPI2C
 	bool "MCUX LPI2C driver"
 	default y
-	depends on DT_HAS_NXP_IMX_LPI2C_ENABLED
+	depends on DT_HAS_NXP_LPI2C_ENABLED
 	depends on CLOCK_CONTROL
 	select PINCTRL
 	help

--- a/drivers/i2c/i2c_mcux_lpi2c.c
+++ b/drivers/i2c/i2c_mcux_lpi2c.c
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#define DT_DRV_COMPAT nxp_imx_lpi2c
+#define DT_DRV_COMPAT nxp_lpi2c
 
 #include <errno.h>
 #include <zephyr/drivers/i2c.h>

--- a/drivers/i2c/i2c_mcux_lpi2c_rtio.c
+++ b/drivers/i2c/i2c_mcux_lpi2c_rtio.c
@@ -7,7 +7,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#define DT_DRV_COMPAT nxp_imx_lpi2c
+#define DT_DRV_COMPAT nxp_lpi2c
 
 #include <errno.h>
 #include <zephyr/drivers/i2c.h>

--- a/dts/arm/nxp/nxp_imx95_m7.dtsi
+++ b/dts/arm/nxp/nxp_imx95_m7.dtsi
@@ -123,7 +123,7 @@
 		};
 
 		lpi2c3: i2c@42530000 {
-			compatible = "nxp,imx-lpi2c";
+			compatible = "nxp,lpi2c";
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -134,7 +134,7 @@
 		};
 
 		lpi2c4: i2c@42540000 {
-			compatible = "nxp,imx-lpi2c";
+			compatible = "nxp,lpi2c";
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -206,7 +206,7 @@
 		};
 
 		lpi2c5: i2c@426b0000 {
-			compatible = "nxp,imx-lpi2c";
+			compatible = "nxp,lpi2c";
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -217,7 +217,7 @@
 		};
 
 		lpi2c6: i2c@426c0000 {
-			compatible = "nxp,imx-lpi2c";
+			compatible = "nxp,lpi2c";
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -228,7 +228,7 @@
 		};
 
 		lpi2c7: i2c@426d0000 {
-			compatible = "nxp,imx-lpi2c";
+			compatible = "nxp,lpi2c";
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -239,7 +239,7 @@
 		};
 
 		lpi2c8: i2c@426e0000 {
-			compatible = "nxp,imx-lpi2c";
+			compatible = "nxp,lpi2c";
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -268,7 +268,7 @@
 		};
 
 		lpi2c1: i2c@44340000 {
-			compatible = "nxp,imx-lpi2c";
+			compatible = "nxp,lpi2c";
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -279,7 +279,7 @@
 		};
 
 		lpi2c2: i2c@44350000 {
-			compatible = "nxp,imx-lpi2c";
+			compatible = "nxp,lpi2c";
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			#address-cells = <1>;
 			#size-cells = <0>;

--- a/dts/arm/nxp/nxp_ke1xf.dtsi
+++ b/dts/arm/nxp/nxp_ke1xf.dtsi
@@ -358,7 +358,7 @@
 		};
 
 		lpi2c0: i2c@40066000 {
-			compatible = "nxp,imx-lpi2c";
+			compatible = "nxp,lpi2c";
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -369,7 +369,7 @@
 		};
 
 		lpi2c1: i2c@40067000 {
-			compatible = "nxp,imx-lpi2c";
+			compatible = "nxp,lpi2c";
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			#address-cells = <1>;
 			#size-cells = <0>;

--- a/dts/arm/nxp/nxp_ke1xz.dtsi
+++ b/dts/arm/nxp/nxp_ke1xz.dtsi
@@ -383,7 +383,7 @@
 		};
 
 		lpi2c0: i2c@40066000 {
-			compatible = "nxp,imx-lpi2c";
+			compatible = "nxp,lpi2c";
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -394,7 +394,7 @@
 		};
 
 		lpi2c1: i2c@40067000 {
-			compatible = "nxp,imx-lpi2c";
+			compatible = "nxp,lpi2c";
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			#address-cells = <1>;
 			#size-cells = <0>;

--- a/dts/arm/nxp/nxp_mcxn23x_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxn23x_common.dtsi
@@ -194,7 +194,7 @@
 			status = "disabled";
 		};
 		flexcomm0_lpi2c0: lpi2c@92800 {
-			compatible = "nxp,imx-lpi2c";
+			compatible = "nxp,lpi2c";
 			reg = <0x92800 0x1000>;
 			clocks = <&syscon MCUX_FLEXCOMM0_CLK>;
 			#address-cells = <1>;
@@ -234,7 +234,7 @@
 			status = "disabled";
 		};
 		flexcomm1_lpi2c1: lpi2c@93800 {
-			compatible = "nxp,imx-lpi2c";
+			compatible = "nxp,lpi2c";
 			reg = <0x93800 0x1000>;
 			clocks = <&syscon MCUX_FLEXCOMM1_CLK>;
 			#address-cells = <1>;
@@ -274,7 +274,7 @@
 			status = "disabled";
 		};
 		flexcomm2_lpi2c2: lpi2c@94800 {
-			compatible = "nxp,imx-lpi2c";
+			compatible = "nxp,lpi2c";
 			reg = <0x94800 0x1000>;
 			clocks = <&syscon MCUX_FLEXCOMM2_CLK>;
 			#address-cells = <1>;
@@ -308,7 +308,7 @@
 			status = "disabled";
 		};
 		flexcomm3_lpi2c3: lpi2c@95800 {
-			compatible = "nxp,imx-lpi2c";
+			compatible = "nxp,lpi2c";
 			reg = <0x95800 0x1000>;
 			clocks = <&syscon MCUX_FLEXCOMM3_CLK>;
 			#address-cells = <1>;
@@ -348,7 +348,7 @@
 			status = "disabled";
 		};
 		flexcomm4_lpi2c4: lpi2c@b4800 {
-			compatible = "nxp,imx-lpi2c";
+			compatible = "nxp,lpi2c";
 			reg = <0xb4800 0x1000>;
 			clocks = <&syscon MCUX_FLEXCOMM4_CLK>;
 			#address-cells = <1>;
@@ -382,7 +382,7 @@
 			status = "disabled";
 		};
 		flexcomm5_lpi2c5: lpi2c@b5800 {
-			compatible = "nxp,imx-lpi2c";
+			compatible = "nxp,lpi2c";
 			reg = <0xb5800 0x1000>;
 			clocks = <&syscon MCUX_FLEXCOMM5_CLK>;
 			#address-cells = <1>;
@@ -416,7 +416,7 @@
 			status = "disabled";
 		};
 		flexcomm6_lpi2c6: lpi2c@b6800 {
-			compatible = "nxp,imx-lpi2c";
+			compatible = "nxp,lpi2c";
 			reg = <0xb6800 0x1000>;
 			clocks = <&syscon MCUX_FLEXCOMM6_CLK>;
 			#address-cells = <1>;
@@ -450,7 +450,7 @@
 			status = "disabled";
 		};
 		flexcomm7_lpi2c7: lpi2c@b7800 {
-			compatible = "nxp,imx-lpi2c";
+			compatible = "nxp,lpi2c";
 			reg = <0xb7800 0x1000>;
 			clocks = <&syscon MCUX_FLEXCOMM7_CLK>;
 			#address-cells = <1>;

--- a/dts/arm/nxp/nxp_mcxn94x_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxn94x_common.dtsi
@@ -201,7 +201,7 @@
 			status = "disabled";
 		};
 		flexcomm0_lpi2c0: lpi2c@92800 {
-			compatible = "nxp,imx-lpi2c";
+			compatible = "nxp,lpi2c";
 			reg = <0x92800 0x1000>;
 			clocks = <&syscon MCUX_FLEXCOMM0_CLK>;
 			#address-cells = <1>;
@@ -241,7 +241,7 @@
 			status = "disabled";
 		};
 		flexcomm1_lpi2c1: lpi2c@93800 {
-			compatible = "nxp,imx-lpi2c";
+			compatible = "nxp,lpi2c";
 			reg = <0x93800 0x1000>;
 			clocks = <&syscon MCUX_FLEXCOMM1_CLK>;
 			#address-cells = <1>;
@@ -281,7 +281,7 @@
 			status = "disabled";
 		};
 		flexcomm2_lpi2c2: lpi2c@94800 {
-			compatible = "nxp,imx-lpi2c";
+			compatible = "nxp,lpi2c";
 			reg = <0x94800 0x1000>;
 			clocks = <&syscon MCUX_FLEXCOMM2_CLK>;
 			#address-cells = <1>;
@@ -315,7 +315,7 @@
 			status = "disabled";
 		};
 		flexcomm3_lpi2c3: lpi2c@95800 {
-			compatible = "nxp,imx-lpi2c";
+			compatible = "nxp,lpi2c";
 			reg = <0x95800 0x1000>;
 			clocks = <&syscon MCUX_FLEXCOMM3_CLK>;
 			#address-cells = <1>;
@@ -355,7 +355,7 @@
 			status = "disabled";
 		};
 		flexcomm4_lpi2c4: lpi2c@b4800 {
-			compatible = "nxp,imx-lpi2c";
+			compatible = "nxp,lpi2c";
 			reg = <0xb4800 0x1000>;
 			clocks = <&syscon MCUX_FLEXCOMM4_CLK>;
 			#address-cells = <1>;
@@ -389,7 +389,7 @@
 			status = "disabled";
 		};
 		flexcomm5_lpi2c5: lpi2c@b5800 {
-			compatible = "nxp,imx-lpi2c";
+			compatible = "nxp,lpi2c";
 			reg = <0xb5800 0x1000>;
 			clocks = <&syscon MCUX_FLEXCOMM5_CLK>;
 			#address-cells = <1>;
@@ -423,7 +423,7 @@
 			status = "disabled";
 		};
 		flexcomm6_lpi2c6: lpi2c@b6800 {
-			compatible = "nxp,imx-lpi2c";
+			compatible = "nxp,lpi2c";
 			reg = <0xb6800 0x1000>;
 			clocks = <&syscon MCUX_FLEXCOMM6_CLK>;
 			#address-cells = <1>;
@@ -457,7 +457,7 @@
 			status = "disabled";
 		};
 		flexcomm7_lpi2c7: lpi2c@b7800 {
-			compatible = "nxp,imx-lpi2c";
+			compatible = "nxp,lpi2c";
 			reg = <0xb7800 0x1000>;
 			clocks = <&syscon MCUX_FLEXCOMM7_CLK>;
 			#address-cells = <1>;
@@ -491,7 +491,7 @@
 			status = "disabled";
 		};
 		flexcomm8_lpi2c8: lpi2c@b8800 {
-			compatible = "nxp,imx-lpi2c";
+			compatible = "nxp,lpi2c";
 			reg = <0xb8800 0x1000>;
 			clocks = <&syscon MCUX_FLEXCOMM8_CLK>;
 			#address-cells = <1>;
@@ -525,7 +525,7 @@
 			status = "disabled";
 		};
 		flexcomm9_lpi2c9: lpi2c@b9800 {
-			compatible = "nxp,imx-lpi2c";
+			compatible = "nxp,lpi2c";
 			reg = <0xb9800 0x1000>;
 			clocks = <&syscon MCUX_FLEXCOMM9_CLK>;
 			#address-cells = <1>;

--- a/dts/arm/nxp/nxp_mcxw71.dtsi
+++ b/dts/arm/nxp/nxp_mcxw71.dtsi
@@ -187,7 +187,7 @@
 	};
 
 	lpi2c0: i2c@33000 {
-		compatible = "nxp,imx-lpi2c";
+		compatible = "nxp,lpi2c";
 		clock-frequency = <I2C_BITRATE_STANDARD>;
 		#address-cells = <1>;
 		#size-cells = <0>;
@@ -198,7 +198,7 @@
 	};
 
 	lpi2c1: i2c@34000 {
-		compatible = "nxp,imx-lpi2c";
+		compatible = "nxp,lpi2c";
 		clock-frequency = <I2C_BITRATE_STANDARD>;
 		#address-cells = <1>;
 		#size-cells = <0>;

--- a/dts/arm/nxp/nxp_rt1010.dtsi
+++ b/dts/arm/nxp/nxp_rt1010.dtsi
@@ -125,7 +125,7 @@
 		/delete-node/ i2c@403f4000;
 
 		lpi2c1: i2c@401a4000 {
-			compatible = "nxp,imx-lpi2c";
+			compatible = "nxp,lpi2c";
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -136,7 +136,7 @@
 		};
 
 		lpi2c2: i2c@401a8000 {
-			compatible = "nxp,imx-lpi2c";
+			compatible = "nxp,lpi2c";
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			#address-cells = <1>;
 			#size-cells = <0>;

--- a/dts/arm/nxp/nxp_rt10xx.dtsi
+++ b/dts/arm/nxp/nxp_rt10xx.dtsi
@@ -391,7 +391,7 @@
 		};
 
 		lpi2c1: i2c@403f0000 {
-			compatible = "nxp,imx-lpi2c";
+			compatible = "nxp,lpi2c";
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -402,7 +402,7 @@
 		};
 
 		lpi2c2: i2c@403f4000 {
-			compatible = "nxp,imx-lpi2c";
+			compatible = "nxp,lpi2c";
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -413,7 +413,7 @@
 		};
 
 		lpi2c3: i2c@403f8000 {
-			compatible = "nxp,imx-lpi2c";
+			compatible = "nxp,lpi2c";
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -424,7 +424,7 @@
 		};
 
 		lpi2c4: i2c@403fc000 {
-			compatible = "nxp,imx-lpi2c";
+			compatible = "nxp,lpi2c";
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			#address-cells = <1>;
 			#size-cells = <0>;

--- a/dts/arm/nxp/nxp_rt118x.dtsi
+++ b/dts/arm/nxp/nxp_rt118x.dtsi
@@ -214,7 +214,7 @@
 	};
 
 	lpi2c1: i2c@4340000 {
-		compatible = "nxp,imx-lpi2c";
+		compatible = "nxp,lpi2c";
 		clock-frequency = <I2C_BITRATE_STANDARD>;
 		#address-cells = <1>;
 		#size-cells = <0>;
@@ -225,7 +225,7 @@
 	};
 
 	lpi2c2: i2c@4350000 {
-		compatible = "nxp,imx-lpi2c";
+		compatible = "nxp,lpi2c";
 		clock-frequency = <I2C_BITRATE_STANDARD>;
 		#address-cells = <1>;
 		#size-cells = <0>;
@@ -236,7 +236,7 @@
 	};
 
 	lpi2c3: i2c@2530000 {
-		compatible = "nxp,imx-lpi2c";
+		compatible = "nxp,lpi2c";
 		clock-frequency = <I2C_BITRATE_STANDARD>;
 		#address-cells = <1>;
 		#size-cells = <0>;
@@ -247,7 +247,7 @@
 	};
 
 	lpi2c4: i2c@2540000 {
-		compatible = "nxp,imx-lpi2c";
+		compatible = "nxp,lpi2c";
 		clock-frequency = <I2C_BITRATE_STANDARD>;
 		#address-cells = <1>;
 		#size-cells = <0>;
@@ -258,7 +258,7 @@
 	};
 
 	lpi2c5: i2c@2d30000 {
-		compatible = "nxp,imx-lpi2c";
+		compatible = "nxp,lpi2c";
 		clock-frequency = <I2C_BITRATE_STANDARD>;
 		#address-cells = <1>;
 		#size-cells = <0>;
@@ -269,7 +269,7 @@
 	};
 
 	lpi2c6: i2c@2d40000 {
-		compatible = "nxp,imx-lpi2c";
+		compatible = "nxp,lpi2c";
 		clock-frequency = <I2C_BITRATE_STANDARD>;
 		#address-cells = <1>;
 		#size-cells = <0>;

--- a/dts/arm/nxp/nxp_rt11xx.dtsi
+++ b/dts/arm/nxp/nxp_rt11xx.dtsi
@@ -303,7 +303,7 @@
 		};
 
 		lpi2c1: i2c@40104000 {
-			compatible = "nxp,imx-lpi2c";
+			compatible = "nxp,lpi2c";
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -314,7 +314,7 @@
 		};
 
 		lpi2c2: i2c@40108000 {
-			compatible = "nxp,imx-lpi2c";
+			compatible = "nxp,lpi2c";
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -325,7 +325,7 @@
 		};
 
 		lpi2c3: i2c@4010c000 {
-			compatible = "nxp,imx-lpi2c";
+			compatible = "nxp,lpi2c";
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -336,7 +336,7 @@
 		};
 
 		lpi2c4: i2c@40110000 {
-			compatible = "nxp,imx-lpi2c";
+			compatible = "nxp,lpi2c";
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -347,7 +347,7 @@
 		};
 
 		lpi2c5: i2c@40c34000 {
-			compatible = "nxp,imx-lpi2c";
+			compatible = "nxp,lpi2c";
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -358,7 +358,7 @@
 		};
 
 		lpi2c6: i2c@40c38000 {
-			compatible = "nxp,imx-lpi2c";
+			compatible = "nxp,lpi2c";
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			#address-cells = <1>;
 			#size-cells = <0>;

--- a/dts/arm/nxp/nxp_s32k1xx.dtsi
+++ b/dts/arm/nxp/nxp_s32k1xx.dtsi
@@ -145,7 +145,7 @@
 		};
 
 		lpi2c0: i2c@40066000 {
-			compatible = "nxp,imx-lpi2c";
+			compatible = "nxp,lpi2c";
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -156,7 +156,7 @@
 		};
 
 		lpi2c1: i2c@40067000 {
-			compatible = "nxp,imx-lpi2c";
+			compatible = "nxp,lpi2c";
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			#address-cells = <1>;
 			#size-cells = <0>;

--- a/dts/arm/nxp/nxp_s32k344_m7.dtsi
+++ b/dts/arm/nxp/nxp_s32k344_m7.dtsi
@@ -520,7 +520,7 @@
 		};
 
 		lpi2c0: i2c@40350000 {
-			compatible = "nxp,imx-lpi2c";
+			compatible = "nxp,lpi2c";
 			reg = <0x40350000 0x10000>;
 			clocks = <&clock NXP_S32_LPI2C0_CLK>;
 			#address-cells = <1>;
@@ -530,7 +530,7 @@
 		};
 
 		lpi2c1: i2c@40354000 {
-			compatible = "nxp,imx-lpi2c";
+			compatible = "nxp,lpi2c";
 			reg = <0x40354000 0x10000>;
 			clocks = <&clock NXP_S32_LPI2C1_CLK>;
 			#address-cells = <1>;

--- a/dts/arm/nxp/nxp_s32z27x_r52.dtsi
+++ b/dts/arm/nxp/nxp_s32z27x_r52.dtsi
@@ -1106,7 +1106,7 @@
 		};
 
 		lpi2c1: i2c@409d0000 {
-			compatible = "nxp,imx-lpi2c";
+			compatible = "nxp,lpi2c";
 			reg = <0x409d0000 0x10000>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -1117,7 +1117,7 @@
 		};
 
 		lpi2c2: i2c@421d0000 {
-			compatible = "nxp,imx-lpi2c";
+			compatible = "nxp,lpi2c";
 			reg = <0x421d0000 0x10000>;
 			#address-cells = <1>;
 			#size-cells = <0>;

--- a/dts/arm64/nxp/nxp_mimx93_a55.dtsi
+++ b/dts/arm64/nxp/nxp_mimx93_a55.dtsi
@@ -144,7 +144,7 @@
 	};
 
 	lpi2c1: i2c@44340000 {
-		compatible = "nxp,imx-lpi2c";
+		compatible = "nxp,lpi2c";
 		clock-frequency = <I2C_BITRATE_STANDARD>;
 		#address-cells = <1>;
 		#size-cells = <0>;
@@ -156,7 +156,7 @@
 	};
 
 	lpi2c2: i2c@44350000 {
-		compatible = "nxp,imx-lpi2c";
+		compatible = "nxp,lpi2c";
 		clock-frequency = <I2C_BITRATE_STANDARD>;
 		#address-cells = <1>;
 		#size-cells = <0>;
@@ -168,7 +168,7 @@
 	};
 
 	lpi2c3: i2c@42530000 {
-		compatible = "nxp,imx-lpi2c";
+		compatible = "nxp,lpi2c";
 		clock-frequency = <I2C_BITRATE_STANDARD>;
 		#address-cells = <1>;
 		#size-cells = <0>;
@@ -180,7 +180,7 @@
 	};
 
 	lpi2c4: i2c@42540000 {
-		compatible = "nxp,imx-lpi2c";
+		compatible = "nxp,lpi2c";
 		clock-frequency = <I2C_BITRATE_STANDARD>;
 		#address-cells = <1>;
 		#size-cells = <0>;
@@ -192,7 +192,7 @@
 	};
 
 	lpi2c5: i2c@426b0000 {
-		compatible = "nxp,imx-lpi2c";
+		compatible = "nxp,lpi2c";
 		clock-frequency = <I2C_BITRATE_STANDARD>;
 		#address-cells = <1>;
 		#size-cells = <0>;
@@ -204,7 +204,7 @@
 	};
 
 	lpi2c6: i2c@426c0000 {
-		compatible = "nxp,imx-lpi2c";
+		compatible = "nxp,lpi2c";
 		clock-frequency = <I2C_BITRATE_STANDARD>;
 		#address-cells = <1>;
 		#size-cells = <0>;
@@ -216,7 +216,7 @@
 	};
 
 	lpi2c7: i2c@426d0000 {
-		compatible = "nxp,imx-lpi2c";
+		compatible = "nxp,lpi2c";
 		clock-frequency = <I2C_BITRATE_STANDARD>;
 		#address-cells = <1>;
 		#size-cells = <0>;
@@ -228,7 +228,7 @@
 	};
 
 	lpi2c8: i2c@426e0000 {
-		compatible = "nxp,imx-lpi2c";
+		compatible = "nxp,lpi2c";
 		clock-frequency = <I2C_BITRATE_STANDARD>;
 		#address-cells = <1>;
 		#size-cells = <0>;

--- a/dts/bindings/i2c/nxp,lpi2c.yaml
+++ b/dts/bindings/i2c/nxp,lpi2c.yaml
@@ -1,9 +1,9 @@
 # Copyright (c) 2019, NXP
 # SPDX-License-Identifier: Apache-2.0
 
-description: NXP i.MX LPI2C controller
+description: NXP LPI2C controller
 
-compatible: "nxp,imx-lpi2c"
+compatible: "nxp,lpi2c"
 
 include: [i2c-controller.yaml, pinctrl-device.yaml]
 

--- a/soc/nxp/mcx/mcxn/soc.c
+++ b/soc/nxp/mcx/mcxn/soc.c
@@ -28,7 +28,7 @@ void soc_reset_hook(void)
 
 #define FLEXCOMM_CHECK_2(n)	\
 	BUILD_ASSERT((DT_NODE_HAS_COMPAT(n, nxp_kinetis_lpuart) == 0) &&	\
-		     (DT_NODE_HAS_COMPAT(n, nxp_imx_lpi2c) == 0),		\
+		     (DT_NODE_HAS_COMPAT(n, nxp_lpi2c) == 0),			\
 		     "Do not enable SPI and UART/I2C on the same Flexcomm node");
 
 /* For SPI node enabled, check if UART or I2C is also enabled on the same parent Flexcomm node */

--- a/soc/nxp/mcx/mcxw/soc.c
+++ b/soc/nxp/mcx/mcxw/soc.c
@@ -141,11 +141,11 @@ static ALWAYS_INLINE void clock_init(void)
 		CLOCK_EnableClock(kCLOCK_Tpm1);
 	}
 
-	if (DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(lpi2c0), nxp_imx_lpi2c, okay)) {
+	if (DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(lpi2c0), nxp_lpi2c, okay)) {
 		CLOCK_EnableClock(kCLOCK_Lpi2c0);
 	}
 
-	if (DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(lpi2c1), nxp_imx_lpi2c, okay)) {
+	if (DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(lpi2c1), nxp_lpi2c, okay)) {
 		CLOCK_EnableClock(kCLOCK_Lpi2c1);
 	}
 


### PR DESCRIPTION
Rename "nxp,imx-lpi2c" compatible to "nxp,lpi2c" to remove the device family from its name because this hardware block is used in multiple NXP devices from different families.