### PR TITLE
dts: bindings: rename nxp,kinetis-dspi compatible

### DIFF
--- a/doc/releases/migration-guide-4.1.rst
+++ b/doc/releases/migration-guide-4.1.rst
@@ -163,6 +163,7 @@ SPI
 ===
 
 * Renamed the ``compatible`` from ``nxp,imx-lpspi`` to :dtcompatible:`nxp,lpspi`.
+* Renamed the ``compatible`` from ``nxp,kinetis-dspi`` to :dtcompatible:`nxp,dspi`.
 
 Regulator
 =========

--- a/drivers/spi/Kconfig.mcux_dspi
+++ b/drivers/spi/Kconfig.mcux_dspi
@@ -5,13 +5,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config SPI_MCUX_DSPI
-	bool "MCUX SPI driver"
+	bool "MCUX DSPI driver"
 	default y
-	depends on DT_HAS_NXP_KINETIS_DSPI_ENABLED
+	depends on DT_HAS_NXP_DSPI_ENABLED
 	depends on CLOCK_CONTROL
 	select PINCTRL
 	help
-	  Enable support for mcux spi driver.
+	  Enable the MCUX DSPI driver.
 
 if SPI_MCUX_DSPI
 
@@ -19,7 +19,7 @@ config DSPI_MCUX_EDMA
 	bool "ENABLE EDMA for DSPI driver"
 	depends on HAS_MCUX && HAS_MCUX_EDMA
 	help
-	  Enable the MCUX DSPI driver.
+	  Enable DMA support for the MCUX DSPI driver.
 
 if DSPI_MCUX_EDMA
 

--- a/drivers/spi/spi_mcux_dspi.c
+++ b/drivers/spi/spi_mcux_dspi.c
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#define DT_DRV_COMPAT	nxp_kinetis_dspi
+#define DT_DRV_COMPAT	nxp_dspi
 
 #include <errno.h>
 #include <zephyr/drivers/spi.h>

--- a/dts/arm/nxp/nxp_k2x.dtsi
+++ b/dts/arm/nxp/nxp_k2x.dtsi
@@ -274,7 +274,7 @@
 		};
 
 		spi0: spi@4002c000 {
-			compatible = "nxp,kinetis-dspi";
+			compatible = "nxp,dspi";
 			reg = <0x4002c000 0x88>;
 			interrupts = <26 3>;
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x103C 12>;
@@ -284,7 +284,7 @@
 		};
 
 		spi1: spi@4002d000 {
-			compatible = "nxp,kinetis-dspi";
+			compatible = "nxp,dspi";
 			reg = <0x4002d000 0x88>;
 			interrupts = <27 3>;
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x103C 13>;

--- a/dts/arm/nxp/nxp_k6x.dtsi
+++ b/dts/arm/nxp/nxp_k6x.dtsi
@@ -335,7 +335,7 @@
 		};
 
 		spi0: spi@4002c000 {
-			compatible = "nxp,kinetis-dspi";
+			compatible = "nxp,dspi";
 			reg = <0x4002c000 0x88>;
 			interrupts = <26 3>;
 			dmas = <&edma0 0 14>, <&edma0 0 15>;
@@ -349,7 +349,7 @@
 		};
 
 		spi1: spi@4002d000 {
-			compatible = "nxp,kinetis-dspi";
+			compatible = "nxp,dspi";
 			reg = <0x4002d000 0x88>;
 			interrupts = <27 3>;
 			dmas = <&edma0 0 16>, <&edma0 0 16>;
@@ -364,7 +364,7 @@
 		};
 
 		spi2: spi@400ac000 {
-			compatible = "nxp,kinetis-dspi";
+			compatible = "nxp,dspi";
 			reg = <0x400ac000 0x88>;
 			interrupts = <65 3>;
 			dmas = <&edma0 0 38>, <&edma0 0 39>;

--- a/dts/arm/nxp/nxp_k8x.dtsi
+++ b/dts/arm/nxp/nxp_k8x.dtsi
@@ -335,7 +335,7 @@
 		};
 
 		spi0: spi@4002c000 {
-			compatible = "nxp,kinetis-dspi";
+			compatible = "nxp,dspi";
 			reg = <0x4002c000 0x1000>;
 			interrupts = <26 3>;
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x103c 12>;
@@ -345,7 +345,7 @@
 		};
 
 		spi1: spi@4002d000 {
-			compatible = "nxp,kinetis-dspi";
+			compatible = "nxp,dspi";
 			reg = <0x4002d000 0x1000>;
 			interrupts = <27 3>;
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x103c 13>;
@@ -355,7 +355,7 @@
 		};
 
 		spi2: spi@400ac000 {
-			compatible = "nxp,kinetis-dspi";
+			compatible = "nxp,dspi";
 			reg = <0x400ac000 0x1000>;
 			interrupts = <65 3>;
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1030 12>;

--- a/dts/arm/nxp/nxp_kv5x.dtsi
+++ b/dts/arm/nxp/nxp_kv5x.dtsi
@@ -239,7 +239,7 @@
 		};
 
 		spi0: spi@4002c000 {
-			compatible = "nxp,kinetis-dspi";
+			compatible = "nxp,dspi";
 			reg = <0x4002c000 0x1000>;
 			interrupts = <26 3>;
 			status = "disabled";
@@ -249,7 +249,7 @@
 		};
 
 		spi1: spi@4002d000 {
-			compatible = "nxp,kinetis-dspi";
+			compatible = "nxp,dspi";
 			reg = <0x4002d000 0x1000>;
 			interrupts = <27 3>;
 			status = "disabled";
@@ -259,7 +259,7 @@
 		};
 
 		spi2: spi@400ac000 {
-			compatible = "nxp,kinetis-dspi";
+			compatible = "nxp,dspi";
 			reg = <0x400ac000 0x1000>;
 			interrupts = <65 3>;
 			status = "disabled";

--- a/dts/arm/nxp/nxp_kw2xd.dtsi
+++ b/dts/arm/nxp/nxp_kw2xd.dtsi
@@ -256,7 +256,7 @@
 		};
 
 		spi0: spi@4002c000 {
-			compatible = "nxp,kinetis-dspi";
+			compatible = "nxp,dspi";
 			reg = <0x4002c000 0x88>;
 			interrupts = <26 3>;
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x103C 12>;
@@ -266,7 +266,7 @@
 		};
 
 		spi1: spi@4002d000 {
-			compatible = "nxp,kinetis-dspi";
+			compatible = "nxp,dspi";
 			reg = <0x4002d000 0x88>;
 			interrupts = <27 3>;
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x103C 13>;

--- a/dts/arm/nxp/nxp_kw40z.dtsi
+++ b/dts/arm/nxp/nxp_kw40z.dtsi
@@ -171,7 +171,7 @@
 		};
 
 		spi0: spi@4002c000 {
-			compatible = "nxp,kinetis-dspi";
+			compatible = "nxp,dspi";
 			reg = <0x4002c000 0x9C>;
 			interrupts = <10 3>;
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x103C 12>;
@@ -182,7 +182,7 @@
 		};
 
 		spi1: spi@4002d000 {
-			compatible = "nxp,kinetis-dspi";
+			compatible = "nxp,dspi";
 			reg = <0x4002d000 0x9C>;
 			interrupts = <29 3>;
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x103C 13>;

--- a/dts/arm/nxp/nxp_kw41z.dtsi
+++ b/dts/arm/nxp/nxp_kw41z.dtsi
@@ -178,7 +178,7 @@
 		};
 
 		spi0: spi@4002c000 {
-			compatible = "nxp,kinetis-dspi";
+			compatible = "nxp,dspi";
 			reg = <0x4002c000 0x9C>;
 			interrupts = <10 3>;
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x103C 12>;
@@ -189,7 +189,7 @@
 		};
 
 		spi1: spi@4002d000 {
-			compatible = "nxp,kinetis-dspi";
+			compatible = "nxp,dspi";
 			reg = <0x4002d000 0x9C>;
 			interrupts = <29 3>;
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x103C 13>;

--- a/dts/arm/nxp/nxp_s32z27x_r52.dtsi
+++ b/dts/arm/nxp/nxp_s32z27x_r52.dtsi
@@ -561,7 +561,7 @@
 		};
 
 		dspi0: spi@40340000 {
-			compatible = "nxp,kinetis-dspi";
+			compatible = "nxp,dspi";
 			reg = <0x40340000 0x10000>;
 			interrupts = <GIC_SPI 204 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
 			clocks = <&clock NXP_S32_MSCDSPI_CLK>;

--- a/dts/bindings/spi/nxp,dspi.yaml
+++ b/dts/bindings/spi/nxp,dspi.yaml
@@ -1,9 +1,9 @@
 # Copyright (c) 2018, NXP
 # SPDX-License-Identifier: Apache-2.0
 
-description: NXP Kinetis DSPI controller
+description: NXP DSPI controller
 
-compatible: "nxp,kinetis-dspi"
+compatible: "nxp,dspi"
 
 include: ["spi-controller.yaml", "pinctrl-device.yaml"]
 


### PR DESCRIPTION
Rename "nxp,kinetis-dspi" compatible to "nxp,dspi" to remove the device family from its name because this hardware block is used in multiple NXP devices from different families.