### PR TITLE
drivers: bluetooth: esp32:  enable entropy generator by default

### DIFF
--- a/drivers/bluetooth/hci/Kconfig
+++ b/drivers/bluetooth/hci/Kconfig
@@ -147,6 +147,7 @@ config BT_ESP32
 	default y
 	depends on DT_HAS_ESPRESSIF_ESP32_BT_HCI_ENABLED
 	depends on ZEPHYR_HAL_ESPRESSIF_MODULE_BLOBS
+	select ENTROPY_GENERATOR
 	help
 	  Espressif HCI bluetooth interface
 


### PR DESCRIPTION
As BT now uses PSA crypto API instead of TinyCrypt, entropy generator is now needed for a proper bluetooth operation.

This is an extension of changes added by #79931.