### PR TITLE
tests: drivers: gpio: gpio_basic_api: restore support for nrf54l15 flpr

### DIFF
--- a/tests/drivers/gpio/gpio_basic_api/boards/nrf54l15dk_nrf54l15_cpuflpr.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/nrf54l15dk_nrf54l15_cpuflpr.overlay
@@ -1,0 +1,1 @@
+#include "nrf54l15dk_nrf54l15_cpuapp.overlay"

--- a/tests/drivers/gpio/gpio_basic_api/boards/nrf54l15dk_nrf54l15_cpuflpr_xip.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/nrf54l15dk_nrf54l15_cpuflpr_xip.overlay
@@ -1,0 +1,1 @@
+#include "nrf54l15dk_nrf54l15_cpuapp.overlay"


### PR DESCRIPTION
Missing after PDK->DK.