### PR TITLE
drivers: i2c+i3c: Place API into iterable section

### DIFF
--- a/drivers/i2c/gpio_i2c_switch.c
+++ b/drivers/i2c/gpio_i2c_switch.c
@@ -64,7 +64,7 @@ static int gpio_i2c_switch_transfer(const struct device *dev, struct i2c_msg *ms
 	return res;
 }
 
-static const struct i2c_driver_api gpio_i2c_switch_api_funcs = {
+static DEVICE_API(i2c, gpio_i2c_switch_api_funcs) = {
 	.configure = gpio_i2c_switch_configure,
 	.transfer = gpio_i2c_switch_transfer,
 #ifdef CONFIG_I2C_RTIO

--- a/drivers/i2c/i2c_ambiq.c
+++ b/drivers/i2c/i2c_ambiq.c
@@ -381,7 +381,7 @@ end:
 	return ret;
 }
 
-static const struct i2c_driver_api i2c_ambiq_driver_api = {
+static DEVICE_API(i2c, i2c_ambiq_driver_api) = {
 	.configure = i2c_ambiq_configure,
 	.transfer = i2c_ambiq_transfer,
 #if CONFIG_I2C_AMBIQ_BUS_RECOVERY

--- a/drivers/i2c/i2c_andes_atciic100.c
+++ b/drivers/i2c/i2c_andes_atciic100.c
@@ -732,7 +732,7 @@ static void i2c_atciic100_irq_handler(void *arg)
 	}
 }
 
-static const struct i2c_driver_api i2c_atciic100_driver = {
+static DEVICE_API(i2c, i2c_atciic100_driver) = {
 	.configure = (i2c_api_configure_t)i2c_atciic100_configure,
 	.transfer = (i2c_api_full_io_t)i2c_atciic100_transfer,
 #if defined(CONFIG_I2C_TARGET)

--- a/drivers/i2c/i2c_b91.c
+++ b/drivers/i2c/i2c_b91.c
@@ -147,7 +147,7 @@ static int i2c_b91_init(const struct device *dev)
 }
 
 /* I2C driver APIs structure */
-static const struct i2c_driver_api i2c_b91_api = {
+static DEVICE_API(i2c, i2c_b91_api) = {
 	.configure = i2c_b91_configure,
 	.transfer = i2c_b91_transfer,
 #ifdef CONFIG_I2C_RTIO

--- a/drivers/i2c/i2c_bcm_iproc.c
+++ b/drivers/i2c/i2c_bcm_iproc.c
@@ -916,7 +916,7 @@ static int iproc_i2c_init(const struct device *dev)
 	return 0;
 }
 
-static const struct i2c_driver_api iproc_i2c_driver_api = {
+static DEVICE_API(i2c, iproc_i2c_driver_api) = {
 	.configure = iproc_i2c_configure,
 	.transfer = iproc_i2c_transfer_multi,
 #ifdef CONFIG_I2C_TARGET

--- a/drivers/i2c/i2c_cc13xx_cc26xx.c
+++ b/drivers/i2c/i2c_cc13xx_cc26xx.c
@@ -419,7 +419,7 @@ static int i2c_cc13xx_cc26xx_init(const struct device *dev)
 	return 0;
 }
 
-static const struct i2c_driver_api i2c_cc13xx_cc26xx_driver_api = {
+static DEVICE_API(i2c, i2c_cc13xx_cc26xx_driver_api) = {
 	.configure = i2c_cc13xx_cc26xx_configure,
 	.transfer = i2c_cc13xx_cc26xx_transfer,
 #ifdef CONFIG_I2C_RTIO

--- a/drivers/i2c/i2c_cc32xx.c
+++ b/drivers/i2c/i2c_cc32xx.c
@@ -379,7 +379,7 @@ static int i2c_cc32xx_init(const struct device *dev)
 	return 0;
 }
 
-static const struct i2c_driver_api i2c_cc32xx_driver_api = {
+static DEVICE_API(i2c, i2c_cc32xx_driver_api) = {
 	.configure = i2c_cc32xx_configure,
 	.transfer = i2c_cc32xx_transfer,
 #ifdef CONFIG_I2C_RTIO

--- a/drivers/i2c/i2c_dw.c
+++ b/drivers/i2c/i2c_dw.c
@@ -1023,7 +1023,7 @@ static void i2c_dw_slave_read_clear_intr_bits(const struct device *dev)
 }
 #endif /* CONFIG_I2C_TARGET */
 
-static const struct i2c_driver_api funcs = {
+static DEVICE_API(i2c, funcs) = {
 	.configure = i2c_dw_runtime_configure,
 	.transfer = i2c_dw_transfer,
 #ifdef CONFIG_I2C_TARGET

--- a/drivers/i2c/i2c_emul.c
+++ b/drivers/i2c/i2c_emul.c
@@ -292,7 +292,7 @@ static int i2c_emul_target_unregister(const struct device *dev, struct i2c_targe
 
 /* Device instantiation */
 
-static const struct i2c_driver_api i2c_emul_api = {
+static DEVICE_API(i2c, i2c_emul_api) = {
 	.configure = i2c_emul_configure,
 	.get_config = i2c_emul_get_config,
 	.transfer = i2c_emul_transfer,

--- a/drivers/i2c/i2c_ene_kb1200.c
+++ b/drivers/i2c/i2c_ene_kb1200.c
@@ -293,7 +293,7 @@ static int i2c_kb1200_transfer(const struct device *dev, struct i2c_msg *msgs, u
 }
 
 /* I2C Master driver registration */
-static const struct i2c_driver_api i2c_kb1200_api = {
+static DEVICE_API(i2c, i2c_kb1200_api) = {
 	.configure = i2c_kb1200_configure,
 	.get_config = i2c_kb1200_get_config,
 	.transfer = i2c_kb1200_transfer,

--- a/drivers/i2c/i2c_esp32.c
+++ b/drivers/i2c/i2c_esp32.c
@@ -722,7 +722,7 @@ static void IRAM_ATTR i2c_esp32_isr(void *arg)
 	k_sem_give(&data->cmd_sem);
 }
 
-static const struct i2c_driver_api i2c_esp32_driver_api = {
+static DEVICE_API(i2c, i2c_esp32_driver_api) = {
 	.configure = i2c_esp32_configure,
 	.get_config = i2c_esp32_get_config,
 	.transfer = i2c_esp32_transfer,

--- a/drivers/i2c/i2c_gd32.c
+++ b/drivers/i2c/i2c_gd32.c
@@ -641,7 +641,7 @@ error:
 	return err;
 }
 
-static const struct i2c_driver_api i2c_gd32_driver_api = {
+static DEVICE_API(i2c, i2c_gd32_driver_api) = {
 	.configure = i2c_gd32_configure,
 	.transfer = i2c_gd32_transfer,
 #ifdef CONFIG_I2C_RTIO

--- a/drivers/i2c/i2c_gecko.c
+++ b/drivers/i2c/i2c_gecko.c
@@ -216,7 +216,7 @@ static int i2c_gecko_target_unregister(const struct device *dev, struct i2c_targ
 }
 #endif
 
-static const struct i2c_driver_api i2c_gecko_driver_api = {
+static DEVICE_API(i2c, i2c_gecko_driver_api) = {
 	.configure = i2c_gecko_configure,
 	.transfer = i2c_gecko_transfer,
 #if defined(CONFIG_I2C_TARGET)

--- a/drivers/i2c/i2c_gpio.c
+++ b/drivers/i2c/i2c_gpio.c
@@ -140,7 +140,7 @@ static int i2c_gpio_recover_bus(const struct device *dev)
 	return rc;
 }
 
-static const struct i2c_driver_api api = {
+static DEVICE_API(i2c, api) = {
 	.configure = i2c_gpio_configure,
 	.get_config = i2c_gpio_get_config,
 	.transfer = i2c_gpio_transfer,

--- a/drivers/i2c/i2c_ifx_cat1.c
+++ b/drivers/i2c/i2c_ifx_cat1.c
@@ -492,7 +492,7 @@ static int ifx_cat1_i2c_target_unregister(const struct device *dev, struct i2c_t
 }
 
 /* I2C API structure */
-static const struct i2c_driver_api i2c_cat1_driver_api = {
+static DEVICE_API(i2c, i2c_cat1_driver_api) = {
 	.configure = ifx_cat1_i2c_configure,
 	.transfer = ifx_cat1_i2c_transfer,
 	.get_config = ifx_cat1_i2c_get_config,

--- a/drivers/i2c/i2c_ifx_xmc4.c
+++ b/drivers/i2c/i2c_ifx_xmc4.c
@@ -425,7 +425,7 @@ static void i2c_xmc4_isr(const struct device *dev)
 
 
 /* I2C API structure */
-static const struct i2c_driver_api i2c_xmc4_driver_api = {
+static DEVICE_API(i2c, i2c_xmc4_driver_api) = {
 	.configure = ifx_xmc4_i2c_configure,
 	.transfer = ifx_xmc4_i2c_transfer,
 	.get_config = ifx_xmc4_i2c_get_config,

--- a/drivers/i2c/i2c_imx.c
+++ b/drivers/i2c/i2c_imx.c
@@ -360,7 +360,7 @@ static int i2c_imx_init(const struct device *dev)
 	return 0;
 }
 
-static const struct i2c_driver_api i2c_imx_driver_api = {
+static DEVICE_API(i2c, i2c_imx_driver_api) = {
 	.configure = i2c_imx_configure,
 	.transfer = i2c_imx_transfer,
 #ifdef CONFIG_I2C_RTIO

--- a/drivers/i2c/i2c_ite_enhance.c
+++ b/drivers/i2c/i2c_ite_enhance.c
@@ -1452,7 +1452,7 @@ static int i2c_enhance_target_unregister(const struct device *dev,
 }
 #endif
 
-static const struct i2c_driver_api i2c_enhance_driver_api = {
+static DEVICE_API(i2c, i2c_enhance_driver_api) = {
 	.configure = i2c_enhance_configure,
 	.get_config = i2c_enhance_get_config,
 	.transfer = i2c_enhance_transfer,

--- a/drivers/i2c/i2c_ite_it8xxx2.c
+++ b/drivers/i2c/i2c_ite_it8xxx2.c
@@ -1250,7 +1250,7 @@ static int i2c_it8xxx2_recover_bus(const struct device *dev)
 	return 0;
 }
 
-static const struct i2c_driver_api i2c_it8xxx2_driver_api = {
+static DEVICE_API(i2c, i2c_it8xxx2_driver_api) = {
 	.configure = i2c_it8xxx2_configure,
 	.get_config = i2c_it8xxx2_get_config,
 	.transfer = i2c_it8xxx2_transfer,

--- a/drivers/i2c/i2c_litex.c
+++ b/drivers/i2c/i2c_litex.c
@@ -136,7 +136,7 @@ static int i2c_litex_recover_bus(const struct device *dev)
 	return i2c_bitbang_recover_bus(bitbang);
 }
 
-static const struct i2c_driver_api i2c_litex_driver_api = {
+static DEVICE_API(i2c, i2c_litex_driver_api) = {
 	.configure = i2c_litex_configure,
 	.get_config = i2c_litex_get_config,
 	.transfer = i2c_litex_transfer,

--- a/drivers/i2c/i2c_ll_stm32.c
+++ b/drivers/i2c/i2c_ll_stm32.c
@@ -310,7 +310,7 @@ restore:
 }
 #endif /* CONFIG_I2C_STM32_BUS_RECOVERY */
 
-static const struct i2c_driver_api api_funcs = {
+static DEVICE_API(i2c, api_funcs) = {
 	.configure = i2c_stm32_runtime_configure,
 	.transfer = i2c_stm32_transfer,
 	.get_config = i2c_stm32_get_config,

--- a/drivers/i2c/i2c_lpc11u6x.c
+++ b/drivers/i2c/i2c_lpc11u6x.c
@@ -340,7 +340,7 @@ static int lpc11u6x_i2c_init(const struct device *dev)
 	return 0;
 }
 
-static const struct i2c_driver_api i2c_api = {
+static DEVICE_API(i2c, i2c_api) = {
 	.configure = lpc11u6x_i2c_configure,
 	.transfer = lpc11u6x_i2c_transfer,
 	.target_register = lpc11u6x_i2c_slave_register,

--- a/drivers/i2c/i2c_max32.c
+++ b/drivers/i2c/i2c_max32.c
@@ -832,7 +832,7 @@ static void i2c_max32_isr(const struct device *dev)
 }
 #endif /* CONFIG_I2C_TARGET || CONFIG_I2C_MAX32_INTERRUPT */
 
-static const struct i2c_driver_api api = {
+static DEVICE_API(i2c, api) = {
 	.configure = api_configure,
 	.transfer = api_transfer,
 #ifdef CONFIG_I2C_TARGET

--- a/drivers/i2c/i2c_mchp_mss.c
+++ b/drivers/i2c/i2c_mchp_mss.c
@@ -232,7 +232,7 @@ static int mss_i2c_transfer(const struct device *dev, struct i2c_msg *msgs, uint
 	return 0;
 }
 
-static const struct i2c_driver_api mss_i2c_driver_api = {
+static DEVICE_API(i2c, mss_i2c_driver_api) = {
 	.configure = mss_i2c_configure,
 	.transfer = mss_i2c_transfer,
 #ifdef CONFIG_I2C_RTIO

--- a/drivers/i2c/i2c_mchp_xec.c
+++ b/drivers/i2c/i2c_mchp_xec.c
@@ -829,7 +829,7 @@ static int i2c_xec_target_unregister(const struct device *dev,
 }
 #endif
 
-static const struct i2c_driver_api i2c_xec_driver_api = {
+static DEVICE_API(i2c, i2c_xec_driver_api) = {
 	.configure = i2c_xec_configure,
 	.transfer = i2c_xec_transfer,
 #ifdef CONFIG_I2C_TARGET

--- a/drivers/i2c/i2c_mchp_xec_v2.c
+++ b/drivers/i2c/i2c_mchp_xec_v2.c
@@ -1033,7 +1033,7 @@ static int i2c_xec_target_unregister(const struct device *dev,
 }
 #endif
 
-static const struct i2c_driver_api i2c_xec_driver_api = {
+static DEVICE_API(i2c, i2c_xec_driver_api) = {
 	.configure = i2c_xec_configure,
 	.transfer = i2c_xec_transfer,
 #ifdef CONFIG_I2C_TARGET

--- a/drivers/i2c/i2c_mcux.c
+++ b/drivers/i2c/i2c_mcux.c
@@ -342,7 +342,7 @@ static int i2c_mcux_init(const struct device *dev)
 	return 0;
 }
 
-static const struct i2c_driver_api i2c_mcux_driver_api = {
+static DEVICE_API(i2c, i2c_mcux_driver_api) = {
 	.configure = i2c_mcux_configure,
 	.transfer = i2c_mcux_transfer,
 #ifdef CONFIG_I2C_CALLBACK

--- a/drivers/i2c/i2c_mcux_flexcomm.c
+++ b/drivers/i2c/i2c_mcux_flexcomm.c
@@ -519,7 +519,7 @@ static int mcux_flexcomm_init(const struct device *dev)
 	return 0;
 }
 
-static const struct i2c_driver_api mcux_flexcomm_driver_api = {
+static DEVICE_API(i2c, mcux_flexcomm_driver_api) = {
 	.configure = mcux_flexcomm_configure,
 	.transfer = mcux_flexcomm_transfer,
 #if defined(CONFIG_I2C_TARGET)

--- a/drivers/i2c/i2c_mcux_lpi2c.c
+++ b/drivers/i2c/i2c_mcux_lpi2c.c
@@ -550,7 +550,7 @@ static int mcux_lpi2c_init(const struct device *dev)
 	return 0;
 }
 
-static const struct i2c_driver_api mcux_lpi2c_driver_api = {
+static DEVICE_API(i2c, mcux_lpi2c_driver_api) = {
 	.configure = mcux_lpi2c_configure,
 	.transfer = mcux_lpi2c_transfer,
 #if CONFIG_I2C_MCUX_LPI2C_BUS_RECOVERY

--- a/drivers/i2c/i2c_mcux_lpi2c_rtio.c
+++ b/drivers/i2c/i2c_mcux_lpi2c_rtio.c
@@ -332,7 +332,7 @@ static int mcux_lpi2c_init(const struct device *dev)
 	return 0;
 }
 
-static const struct i2c_driver_api mcux_lpi2c_driver_api = {
+static DEVICE_API(i2c, mcux_lpi2c_driver_api) = {
 	.configure = mcux_lpi2c_configure,
 	.transfer = mcux_lpi2c_transfer,
 	.iodev_submit = mcux_lpi2c_submit,

--- a/drivers/i2c/i2c_nios2.c
+++ b/drivers/i2c/i2c_nios2.c
@@ -152,7 +152,7 @@ static void i2c_nios2_isr(const struct device *dev)
 
 static int i2c_nios2_init(const struct device *dev);
 
-static const struct i2c_driver_api i2c_nios2_driver_api = {
+static DEVICE_API(i2c, i2c_nios2_driver_api) = {
 	.configure = i2c_nios2_configure,
 	.transfer = i2c_nios2_transfer,
 #ifdef CONFIG_I2C_RTIO

--- a/drivers/i2c/i2c_npcx_port.c
+++ b/drivers/i2c/i2c_npcx_port.c
@@ -200,7 +200,7 @@ static int i2c_npcx_port_init(const struct device *dev)
 	return 0;
 }
 
-static const struct i2c_driver_api i2c_port_npcx_driver_api = {
+static DEVICE_API(i2c, i2c_port_npcx_driver_api) = {
 	.configure = i2c_npcx_port_configure,
 	.get_config = i2c_npcx_port_get_config,
 	.transfer = i2c_npcx_port_transfer,

--- a/drivers/i2c/i2c_nrfx_twi.c
+++ b/drivers/i2c/i2c_nrfx_twi.c
@@ -125,7 +125,7 @@ static void event_handler(nrfx_twi_evt_t const *p_event, void *p_context)
 	k_sem_give(&dev_data->completion_sync);
 }
 
-static const struct i2c_driver_api i2c_nrfx_twi_driver_api = {
+static DEVICE_API(i2c, i2c_nrfx_twi_driver_api) = {
 	.configure   = i2c_nrfx_twi_configure,
 	.transfer    = i2c_nrfx_twi_transfer,
 	.recover_bus = i2c_nrfx_twi_recover_bus,

--- a/drivers/i2c/i2c_nrfx_twi_rtio.c
+++ b/drivers/i2c/i2c_nrfx_twi_rtio.c
@@ -152,7 +152,7 @@ static void i2c_nrfx_twi_rtio_submit(const struct device *dev, struct rtio_iodev
 	}
 }
 
-static const struct i2c_driver_api i2c_nrfx_twi_rtio_driver_api = {
+static DEVICE_API(i2c, i2c_nrfx_twi_rtio_driver_api) = {
 	.configure   = i2c_nrfx_twi_rtio_configure,
 	.transfer    = i2c_nrfx_twi_rtio_transfer,
 	.recover_bus = i2c_nrfx_twi_rtio_recover_bus,

--- a/drivers/i2c/i2c_nrfx_twim.c
+++ b/drivers/i2c/i2c_nrfx_twim.c
@@ -204,7 +204,7 @@ static int i2c_nrfx_twim_init(const struct device *dev)
 	return i2c_nrfx_twim_common_init(dev);
 }
 
-static const struct i2c_driver_api i2c_nrfx_twim_driver_api = {
+static DEVICE_API(i2c, i2c_nrfx_twim_driver_api) = {
 	.configure = i2c_nrfx_twim_configure,
 	.transfer = i2c_nrfx_twim_transfer,
 #ifdef CONFIG_I2C_RTIO

--- a/drivers/i2c/i2c_nrfx_twim_rtio.c
+++ b/drivers/i2c/i2c_nrfx_twim_rtio.c
@@ -148,7 +148,7 @@ static void event_handler(nrfx_twim_evt_t const *p_event, void *p_context)
 	i2c_nrfx_twim_rtio_complete(dev, status);
 }
 
-static const struct i2c_driver_api i2c_nrfx_twim_driver_api = {
+static DEVICE_API(i2c, i2c_nrfx_twim_driver_api) = {
 	.configure = i2c_nrfx_twim_rtio_configure,
 	.transfer = i2c_nrfx_twim_rtio_transfer,
 	.recover_bus = i2c_nrfx_twim_rtio_recover_bus,

--- a/drivers/i2c/i2c_numaker.c
+++ b/drivers/i2c/i2c_numaker.c
@@ -732,7 +732,7 @@ cleanup:
 	return err;
 }
 
-static const struct i2c_driver_api i2c_numaker_driver_api = {
+static DEVICE_API(i2c, i2c_numaker_driver_api) = {
 	.configure = i2c_numaker_configure,
 	.get_config = i2c_numaker_get_config,
 	.transfer = i2c_numaker_transfer,

--- a/drivers/i2c/i2c_rcar.c
+++ b/drivers/i2c/i2c_rcar.c
@@ -344,7 +344,7 @@ static int i2c_rcar_init(const struct device *dev)
 	return 0;
 }
 
-static const struct i2c_driver_api i2c_rcar_driver_api = {
+static DEVICE_API(i2c, i2c_rcar_driver_api) = {
 	.configure = i2c_rcar_configure,
 	.transfer = i2c_rcar_transfer,
 #ifdef CONFIG_I2C_RTIO

--- a/drivers/i2c/i2c_renesas_ra_iic.c
+++ b/drivers/i2c/i2c_renesas_ra_iic.c
@@ -473,7 +473,7 @@ static void calc_iic_master_clock_setting(const struct device *dev, const uint32
 		clk_cfg->brl_value, clk_cfg->brh_value, clk_cfg->cks_value);
 }
 
-static const struct i2c_driver_api i2c_ra_iic_driver_api = {
+static DEVICE_API(i2c, i2c_ra_iic_driver_api) = {
 	.configure = i2c_ra_iic_configure,
 	.get_config = i2c_ra_iic_get_config,
 	.transfer = i2c_ra_iic_transfer,

--- a/drivers/i2c/i2c_rv32m1_lpi2c.c
+++ b/drivers/i2c/i2c_rv32m1_lpi2c.c
@@ -255,7 +255,7 @@ static int rv32m1_lpi2c_init(const struct device *dev)
 	return 0;
 }
 
-static const struct i2c_driver_api rv32m1_lpi2c_driver_api = {
+static DEVICE_API(i2c, rv32m1_lpi2c_driver_api) = {
 	.configure = rv32m1_lpi2c_configure,
 	.transfer = rv32m1_lpi2c_transfer,
 #ifdef CONFIG_I2C_RTIO

--- a/drivers/i2c/i2c_sam0.c
+++ b/drivers/i2c/i2c_sam0.c
@@ -772,7 +772,7 @@ static int i2c_sam0_initialize(const struct device *dev)
 	return 0;
 }
 
-static const struct i2c_driver_api i2c_sam0_driver_api = {
+static DEVICE_API(i2c, i2c_sam0_driver_api) = {
 	.configure = i2c_sam0_configure,
 	.transfer = i2c_sam0_transfer,
 #ifdef CONFIG_I2C_RTIO

--- a/drivers/i2c/i2c_sam4l_twim.c
+++ b/drivers/i2c/i2c_sam4l_twim.c
@@ -588,7 +588,7 @@ static int i2c_sam_twim_initialize(const struct device *dev)
 	return 0;
 }
 
-static const struct i2c_driver_api i2c_sam_twim_driver_api = {
+static DEVICE_API(i2c, i2c_sam_twim_driver_api) = {
 	.configure = i2c_sam_twim_configure,
 	.transfer = i2c_sam_twim_transfer,
 #ifdef CONFIG_I2C_RTIO

--- a/drivers/i2c/i2c_sam_twi.c
+++ b/drivers/i2c/i2c_sam_twi.c
@@ -350,7 +350,7 @@ static int i2c_sam_twi_initialize(const struct device *dev)
 	return 0;
 }
 
-static const struct i2c_driver_api i2c_sam_twi_driver_api = {
+static DEVICE_API(i2c, i2c_sam_twi_driver_api) = {
 	.configure = i2c_sam_twi_configure,
 	.transfer = i2c_sam_twi_transfer,
 #ifdef CONFIG_I2C_RTIO

--- a/drivers/i2c/i2c_sam_twihs.c
+++ b/drivers/i2c/i2c_sam_twihs.c
@@ -321,7 +321,7 @@ static int i2c_sam_twihs_initialize(const struct device *dev)
 	return 0;
 }
 
-static const struct i2c_driver_api i2c_sam_twihs_driver_api = {
+static DEVICE_API(i2c, i2c_sam_twihs_driver_api) = {
 	.configure = i2c_sam_twihs_configure,
 	.transfer = i2c_sam_twihs_transfer,
 };

--- a/drivers/i2c/i2c_sam_twihs_rtio.c
+++ b/drivers/i2c/i2c_sam_twihs_rtio.c
@@ -327,7 +327,7 @@ static int i2c_sam_twihs_initialize(const struct device *dev)
 	return 0;
 }
 
-static const struct i2c_driver_api i2c_sam_twihs_driver_api = {
+static DEVICE_API(i2c, i2c_sam_twihs_driver_api) = {
 	.configure = i2c_sam_twihs_configure,
 	.transfer = i2c_sam_twihs_transfer,
 	.iodev_submit = i2c_sam_twihs_submit,

--- a/drivers/i2c/i2c_sbcon.c
+++ b/drivers/i2c/i2c_sbcon.c
@@ -113,7 +113,7 @@ static int i2c_sbcon_recover_bus(const struct device *dev)
 	return i2c_bitbang_recover_bus(&context->bitbang);
 }
 
-static const struct i2c_driver_api api = {
+static DEVICE_API(i2c, api) = {
 	.configure = i2c_sbcon_configure,
 	.get_config = i2c_sbcon_get_config,
 	.transfer = i2c_sbcon_transfer,

--- a/drivers/i2c/i2c_sc18im704.c
+++ b/drivers/i2c/i2c_sc18im704.c
@@ -320,7 +320,7 @@ static int i2c_sc18im_init(const struct device *dev)
 	return 0;
 }
 
-static const struct i2c_driver_api i2c_sc18im_driver_api = {
+static DEVICE_API(i2c, i2c_sc18im_driver_api) = {
 	.configure = i2c_sc18im_configure,
 	.get_config = i2c_sc18im_get_config,
 	.transfer = i2c_sc18im_transfer,

--- a/drivers/i2c/i2c_sedi.c
+++ b/drivers/i2c/i2c_sedi.c
@@ -112,7 +112,7 @@ static int i2c_sedi_api_full_io(const struct device *dev, struct i2c_msg *msgs, 
 	return ret;
 }
 
-static const struct i2c_driver_api i2c_sedi_apis = {
+static DEVICE_API(i2c, i2c_sedi_apis) = {
 	.configure = i2c_sedi_api_configure,
 	.transfer = i2c_sedi_api_full_io,
 #ifdef CONFIG_I2C_RTIO

--- a/drivers/i2c/i2c_sifive.c
+++ b/drivers/i2c/i2c_sifive.c
@@ -316,7 +316,7 @@ static int i2c_sifive_init(const struct device *dev)
 	return 0;
 }
 
-static const struct i2c_driver_api i2c_sifive_api = {
+static DEVICE_API(i2c, i2c_sifive_api) = {
 	.configure = i2c_sifive_configure,
 	.transfer = i2c_sifive_transfer,
 #ifdef CONFIG_I2C_RTIO

--- a/drivers/i2c/i2c_smartbond.c
+++ b/drivers/i2c/i2c_smartbond.c
@@ -548,7 +548,7 @@ static void i2c_smartbond_isr(const struct device *dev)
 #define I2C_SMARTBOND_CONFIGURE(id)
 #endif
 
-static const struct i2c_driver_api i2c_smartbond_driver_api = {
+static DEVICE_API(i2c, i2c_smartbond_driver_api) = {
 	.configure = i2c_smartbond_configure,
 	.get_config = i2c_smartbond_get_config,
 	.transfer = i2c_smartbond_transfer,

--- a/drivers/i2c/i2c_tca954x.c
+++ b/drivers/i2c/i2c_tca954x.c
@@ -153,7 +153,7 @@ static int tca954x_channel_init(const struct device *dev)
 	return 0;
 }
 
-static const struct i2c_driver_api tca954x_api_funcs = {
+static DEVICE_API(i2c, tca954x_api_funcs) = {
 	.configure = tca954x_configure,
 	.transfer = tca954x_transfer,
 #ifdef CONFIG_I2C_RTIO

--- a/drivers/i2c/i2c_test.c
+++ b/drivers/i2c/i2c_test.c
@@ -27,7 +27,7 @@ static int vnd_i2c_transfer(const struct device *dev,
 	return -ENOTSUP;
 }
 
-static const struct i2c_driver_api vnd_i2c_api = {
+static DEVICE_API(i2c, vnd_i2c_api) = {
 	.configure = vnd_i2c_configure,
 	.transfer  = vnd_i2c_transfer,
 };

--- a/drivers/i2c/i2c_xilinx_axi.c
+++ b/drivers/i2c/i2c_xilinx_axi.c
@@ -620,7 +620,7 @@ static int i2c_xilinx_axi_init(const struct device *dev)
 	return 0;
 }
 
-static const struct i2c_driver_api i2c_xilinx_axi_driver_api = {
+static DEVICE_API(i2c, i2c_xilinx_axi_driver_api) = {
 	.configure = i2c_xilinx_axi_configure,
 	.transfer = i2c_xilinx_axi_transfer,
 #if defined(CONFIG_I2C_TARGET)

--- a/drivers/i3c/i3c_cdns.c
+++ b/drivers/i3c/i3c_cdns.c
@@ -3281,7 +3281,7 @@ static int cdns_i3c_bus_init(const struct device *dev)
 	return 0;
 }
 
-static struct i3c_driver_api api = {
+static DEVICE_API(i3c, api) = {
 	.i2c_api.configure = cdns_i3c_i2c_api_configure,
 	.i2c_api.transfer = cdns_i3c_i2c_api_transfer,
 

--- a/drivers/i3c/i3c_mcux.c
+++ b/drivers/i3c/i3c_mcux.c
@@ -2090,7 +2090,7 @@ out_xfer_i2c_stop_unlock:
 	return ret;
 }
 
-static const struct i3c_driver_api mcux_i3c_driver_api = {
+static DEVICE_API(i3c, mcux_i3c_driver_api) = {
 	.i2c_api.configure = mcux_i3c_i2c_api_configure,
 	.i2c_api.transfer = mcux_i3c_i2c_api_transfer,
 	.i2c_api.recover_bus = mcux_i3c_recover_bus,

--- a/drivers/i3c/i3c_npcx.c
+++ b/drivers/i3c/i3c_npcx.c
@@ -2963,7 +2963,7 @@ static int npcx_i3c_init(const struct device *dev)
 	return 0;
 }
 
-static const struct i3c_driver_api npcx_i3c_driver_api = {
+static DEVICE_API(i3c, npcx_i3c_driver_api) = {
 	.configure = npcx_i3c_configure,
 	.config_get = npcx_i3c_config_get,
 

--- a/drivers/i3c/i3c_test.c
+++ b/drivers/i3c/i3c_test.c
@@ -32,7 +32,7 @@ static int vnd_i3c_recover_bus(const struct device *dev)
 	return -ENOTSUP;
 }
 
-static const struct i3c_driver_api vnd_i3c_api = {
+static DEVICE_API(i3c, vnd_i3c_api) = {
 	.configure = vnd_i3c_configure,
 	.config_get = vnd_i3c_config_get,
 	.recover_bus = vnd_i3c_recover_bus,

--- a/tests/drivers/i2c/i2c_target_api/common/i2c_virtual.c
+++ b/tests/drivers/i2c/i2c_target_api/common/i2c_virtual.c
@@ -204,7 +204,7 @@ static int i2c_virtual_transfer(const struct device *dev, struct i2c_msg *msg,
 	return ret;
 }
 
-static const struct i2c_driver_api api_funcs = {
+static DEVICE_API(i2c, api_funcs) = {
 	.configure = i2c_virtual_runtime_configure,
 	.transfer = i2c_virtual_transfer,
 	.target_register = i2c_virtual_target_register,


### PR DESCRIPTION
Add wrapper DEVICE_API macro to all i2c_driver_api & i3c_driver_api instances.