### PR TITLE
drivers: ethernet: Optimize RxBD buffer configuration

### DIFF
--- a/drivers/ethernet/nxp_enet/eth_nxp_enet.c
+++ b/drivers/ethernet/nxp_enet/eth_nxp_enet.c
@@ -893,9 +893,9 @@ static const struct ethernet_api api_funcs = {
 #define driver_cache_maintain	false
 #elif defined(CONFIG_NOCACHE_MEMORY)
 #define _nxp_enet_dma_desc_section __nocache
-#define _nxp_enet_dma_buffer_section __nocache
+#define _nxp_enet_dma_buffer_section
 #define _nxp_enet_driver_buffer_section
-#define driver_cache_maintain	false
+#define driver_cache_maintain	true
 #else
 #define _nxp_enet_dma_desc_section
 #define _nxp_enet_dma_buffer_section


### PR DESCRIPTION
On IMX93_EVK A-core, the _nxp_enet_dma_buffer_section is configured to __nocache area. That makes the RxPkt performance very low (<= 50Mbps). By defining it to the cacheable area, the RxPkt performance is >10x better.

Example with Zperf:
build: ```west build -p always -b imx93_evk/mimx9352/a55 samples/net/zperf/```
DUT command: ```zperf udp download 5001```
PC command: ```iperf -u -c 192.0.2.1 -p 5001 -b 800M```
Result before optimization:
<img width="266" alt="image" src="https://github.com/user-attachments/assets/4115744b-f151-4ba6-b04c-9c1a574d02c7">

Result after optimization:
<img width="244" alt="image" src="https://github.com/user-attachments/assets/c3110a61-f62b-4415-b88d-1e06f3bddfa6">
