### PR TITLE
devicetree: add `DT_ANY_INST_HAS_BOOL_STATUS_OKAY`

### DIFF
--- a/doc/releases/release-notes-4.1.rst
+++ b/doc/releases/release-notes-4.1.rst
@@ -263,6 +263,8 @@ USB
 Devicetree
 **********
 
+* Added :c:macro:`DT_ANY_INST_HAS_BOOL_STATUS_OKAY`.
+
 Kconfig
 *******
 

--- a/dts/bindings/test/vnd,device-with-props.yaml
+++ b/dts/bindings/test/vnd,device-with-props.yaml
@@ -14,3 +14,12 @@ properties:
 
   baz:
     type: int
+
+  bool-foo:
+    type: boolean
+
+  bool-bar:
+    type: boolean
+
+  bool-baz:
+    type: boolean

--- a/include/zephyr/devicetree.h
+++ b/include/zephyr/devicetree.h
@@ -4768,6 +4768,56 @@
 	(DT_COMPAT_FOREACH_STATUS_OKAY_VARGS(compat, DT_COMPAT_NODE_HAS_PROP_AND_OR, prop) 0)
 
 /**
+ * @brief Check if any `DT_DRV_COMPAT` node with status `okay` has a given
+ *        boolean property that exists.
+ *
+ * This differs from @ref DT_ANY_INST_HAS_PROP_STATUS_OKAY because even when not present
+ * on a node, the boolean property is generated with a value of 0 and therefore exists.
+ *
+ * @param prop lowercase-and-underscores property name
+ *
+ * Example devicetree overlay:
+ *
+ * @code{.dts}
+ *     &i2c0 {
+ *         sensor0: sensor@0 {
+ *             compatible = "vnd,some-sensor";
+ *             status = "okay";
+ *             reg = <0>;
+ *             foo;
+ *             bar;
+ *         };
+ *
+ *         sensor1: sensor@1 {
+ *             compatible = "vnd,some-sensor";
+ *             status = "okay";
+ *             reg = <1>;
+ *             foo;
+ *         };
+ *
+ *         sensor2: sensor@2 {
+ *             compatible = "vnd,some-sensor";
+ *             status = "disabled";
+ *             reg = <2>;
+ *             baz;
+ *         };
+ *     };
+ * @endcode
+ *
+ * Example usage:
+ *
+ * @code{.c}
+ *     #define DT_DRV_COMPAT vnd_some_sensor
+ *
+ *     DT_ANY_INST_HAS_BOOL_STATUS_OKAY(foo) // 1
+ *     DT_ANY_INST_HAS_BOOL_STATUS_OKAY(bar) // 1
+ *     DT_ANY_INST_HAS_BOOL_STATUS_OKAY(baz) // 0
+ * @endcode
+ */
+#define DT_ANY_INST_HAS_BOOL_STATUS_OKAY(prop) \
+	COND_CODE_1(IS_EMPTY(DT_ANY_INST_HAS_BOOL_STATUS_OKAY_(prop)), (0), (1))
+
+/**
  * @brief Call @p fn on all nodes with compatible `DT_DRV_COMPAT`
  *        and status `okay`
  *
@@ -5063,6 +5113,35 @@
  */
 #define DT_ANY_INST_HAS_PROP_STATUS_OKAY_(prop)	\
 	DT_INST_FOREACH_STATUS_OKAY_VARGS(DT_ANY_INST_HAS_PROP_STATUS_OKAY__, prop)
+
+/** @brief Helper for DT_ANY_INST_HAS_BOOL_STATUS_OKAY_
+ *
+ * This macro generates token "1," for instance of a device,
+ * identified by index @p idx, if instance has boolean property
+ * @p prop with value 1.
+ *
+ * @param idx instance number
+ * @param prop property to check for
+ *
+ * @return Macro evaluates to `1,` if instance property value is 1,
+ * otherwise it evaluates to literal nothing.
+ */
+#define DT_ANY_INST_HAS_BOOL_STATUS_OKAY__(idx, prop)	\
+	COND_CODE_1(DT_INST_PROP(idx, prop), (1,), ())
+/** @brief Helper for DT_ANY_INST_HAS_BOOL_STATUS_OKAY
+ *
+ * This macro uses DT_ANY_INST_HAS_BOOL_STATUS_OKAY_ with
+ * DT_INST_FOREACH_STATUS_OKAY_VARG to generate comma separated list of 1,
+ * where each 1 on the list represents instance that has a property
+ * @p prop of value 1; the list may be empty, and the upper bound on number of
+ * list elements is number of device instances.
+ *
+ * @param prop property to check
+ *
+ * @return Evaluates to list of 1s (e.g: 1,1,1,) or nothing.
+ */
+#define DT_ANY_INST_HAS_BOOL_STATUS_OKAY_(prop)	\
+	DT_INST_FOREACH_STATUS_OKAY_VARGS(DT_ANY_INST_HAS_BOOL_STATUS_OKAY__, prop)
 
 #define DT_PATH_INTERNAL(...) \
 	UTIL_CAT(DT_ROOT, MACRO_MAP_CAT(DT_S_PREFIX, __VA_ARGS__))

--- a/tests/lib/devicetree/api/app.overlay
+++ b/tests/lib/devicetree/api/app.overlay
@@ -638,18 +638,22 @@
 			status = "okay";
 			foo = <1>;
 			bar = <2>;
+			bool-foo;
+			bool-bar;
 		};
 
 		device-with-props-1 {
 			compatible = "vnd,device-with-props";
 			status = "okay";
 			foo = <2>;
+			bool-foo;
 		};
 
 		device-with-props-2 {
 			compatible = "vnd,device-with-props";
 			status = "disabled";
 			baz = <1>;
+			bool-baz;
 		};
 
 		test_string_token_0: string-token-0 {

--- a/tests/lib/devicetree/api/src/main.c
+++ b/tests/lib/devicetree/api/src/main.c
@@ -223,6 +223,35 @@ ZTEST(devicetree_api, test_any_compat_inst_prop)
 		      0, "");
 }
 
+#undef DT_DRV_COMPAT
+#define DT_DRV_COMPAT vnd_device_with_props
+ZTEST(devicetree_api, test_any_inst_bool)
+{
+	zassert_equal(DT_ANY_INST_HAS_BOOL_STATUS_OKAY(bool_foo), 1, "");
+	zassert_equal(DT_ANY_INST_HAS_BOOL_STATUS_OKAY(bool_bar), 1, "");
+	zassert_equal(DT_ANY_INST_HAS_BOOL_STATUS_OKAY(bool_baz), 0, "");
+	zassert_equal(DT_ANY_INST_HAS_BOOL_STATUS_OKAY(does_not_exist), 0, "");
+
+	zassert_equal(COND_CODE_1(DT_ANY_INST_HAS_BOOL_STATUS_OKAY(bool_foo),
+				  (5), (6)),
+		      5, "");
+	zassert_equal(COND_CODE_0(DT_ANY_INST_HAS_BOOL_STATUS_OKAY(bool_foo),
+				  (5), (6)),
+		      6, "");
+	zassert_equal(COND_CODE_1(DT_ANY_INST_HAS_BOOL_STATUS_OKAY(bool_baz),
+				  (5), (6)),
+		      6, "");
+	zassert_equal(COND_CODE_0(DT_ANY_INST_HAS_BOOL_STATUS_OKAY(bool_baz),
+				  (5), (6)),
+		      5, "");
+	zassert_true(IS_ENABLED(DT_ANY_INST_HAS_BOOL_STATUS_OKAY(bool_foo)), "");
+	zassert_true(!IS_ENABLED(DT_ANY_INST_HAS_BOOL_STATUS_OKAY(bool_baz)), "");
+	zassert_equal(IF_ENABLED(DT_ANY_INST_HAS_BOOL_STATUS_OKAY(bool_foo), (1)) + 1,
+		      2, "");
+	zassert_equal(IF_ENABLED(DT_ANY_INST_HAS_BOOL_STATUS_OKAY(bool_baz), (1)) + 1,
+		      1, "");
+}
+
 ZTEST(devicetree_api, test_default_prop_access)
 {
 	/*


### PR DESCRIPTION
Add `DT_ANY_INST_HAS_BOOL_STATUS_OKAY` as a complement to
`DT_ANY_INST_HAS_PROP_STATUS_OKAY`. This macro exists because boolean
properties not present on a node are still generated with a value of 0,
and therefore cannot be used with `DT_ANY_INST_HAS_PROP_STATUS_OKAY`.
