### PR TITLE
rtc: shell: support node labels and allow only rtc devices

### DIFF
--- a/drivers/rtc/Kconfig
+++ b/drivers/rtc/Kconfig
@@ -38,6 +38,7 @@ config RTC_CALIBRATION
 config RTC_SHELL
 	bool "RTC Shell commands"
 	depends on SHELL
+	imply DEVICE_DT_METADATA
 	help
 	  RTC Shell commands
 


### PR DESCRIPTION
Added support for using node labels instead of only full node name and added a verification that the given device is an rtc device.