### PR TITLE
can: shell: support device node labels

### DIFF
--- a/drivers/can/Kconfig
+++ b/drivers/can/Kconfig
@@ -41,6 +41,7 @@ config CAN_DEFAULT_BITRATE_DATA
 config CAN_SHELL
 	bool "CAN shell"
 	depends on SHELL
+	imply DEVICE_DT_METADATA
 	select POLL
 	help
 	  Enable CAN Shell for testing.

--- a/drivers/can/can_shell.c
+++ b/drivers/can/can_shell.c
@@ -274,9 +274,27 @@ static void can_shell_print_extended_modes(const struct shell *sh, can_mode_t ca
 	}
 }
 
+static const struct device *get_can_controller(char *id)
+{
+	const struct device *dev = device_get_binding(id);
+
+	if (dev != NULL) {
+		return dev;
+	}
+
+#ifdef CONFIG_DEVICE_DT_METADATA
+	dev = device_get_by_dt_nodelabel(id);
+	if (dev != NULL) {
+		return dev;
+	}
+#endif /* CONFIG_DEVICE_DT_METADATA */
+
+	return NULL;
+}
+
 static int cmd_can_start(const struct shell *sh, size_t argc, char **argv)
 {
-	const struct device *dev = device_get_binding(argv[1]);
+	const struct device *dev = get_can_controller(argv[1]);
 	int err;
 
 	if (!device_is_ready(dev)) {
@@ -297,7 +315,7 @@ static int cmd_can_start(const struct shell *sh, size_t argc, char **argv)
 
 static int cmd_can_stop(const struct shell *sh, size_t argc, char **argv)
 {
-	const struct device *dev = device_get_binding(argv[1]);
+	const struct device *dev = get_can_controller(argv[1]);
 	int err;
 
 	if (!device_is_ready(dev)) {
@@ -318,7 +336,7 @@ static int cmd_can_stop(const struct shell *sh, size_t argc, char **argv)
 
 static int cmd_can_show(const struct shell *sh, size_t argc, char **argv)
 {
-	const struct device *dev = device_get_binding(argv[1]);
+	const struct device *dev = get_can_controller(argv[1]);
 	const struct device *phy;
 	const struct can_timing *timing_min;
 	const struct can_timing *timing_max;
@@ -429,7 +447,7 @@ static int cmd_can_show(const struct shell *sh, size_t argc, char **argv)
 
 static int cmd_can_bitrate_set(const struct shell *sh, size_t argc, char **argv)
 {
-	const struct device *dev = device_get_binding(argv[1]);
+	const struct device *dev = get_can_controller(argv[1]);
 	struct can_timing timing = { 0 };
 	uint16_t sample_pnt;
 	uint32_t bitrate;
@@ -500,7 +518,7 @@ static int cmd_can_bitrate_set(const struct shell *sh, size_t argc, char **argv)
 
 static int cmd_can_dbitrate_set(const struct shell *sh, size_t argc, char **argv)
 {
-	const struct device *dev = device_get_binding(argv[1]);
+	const struct device *dev = get_can_controller(argv[1]);
 	struct can_timing timing = { 0 };
 	uint16_t sample_pnt;
 	uint32_t bitrate;
@@ -609,7 +627,7 @@ static int can_shell_parse_timing(const struct shell *sh, size_t argc, char **ar
 
 static int cmd_can_timing_set(const struct shell *sh, size_t argc, char **argv)
 {
-	const struct device *dev = device_get_binding(argv[1]);
+	const struct device *dev = get_can_controller(argv[1]);
 	struct can_timing timing = { 0 };
 	int err;
 
@@ -638,7 +656,7 @@ static int cmd_can_timing_set(const struct shell *sh, size_t argc, char **argv)
 
 static int cmd_can_dtiming_set(const struct shell *sh, size_t argc, char **argv)
 {
-	const struct device *dev = device_get_binding(argv[1]);
+	const struct device *dev = get_can_controller(argv[1]);
 	struct can_timing timing = { 0 };
 	int err;
 
@@ -667,7 +685,7 @@ static int cmd_can_dtiming_set(const struct shell *sh, size_t argc, char **argv)
 
 static int cmd_can_mode_set(const struct shell *sh, size_t argc, char **argv)
 {
-	const struct device *dev = device_get_binding(argv[1]);
+	const struct device *dev = get_can_controller(argv[1]);
 	can_mode_t mode = CAN_MODE_NORMAL;
 	can_mode_t raw;
 	char *endptr;
@@ -715,7 +733,7 @@ static int cmd_can_mode_set(const struct shell *sh, size_t argc, char **argv)
 
 static int cmd_can_send(const struct shell *sh, size_t argc, char **argv)
 {
-	const struct device *dev = device_get_binding(argv[1]);
+	const struct device *dev = get_can_controller(argv[1]);
 	static unsigned int frame_counter;
 	unsigned int frame_no;
 	struct can_frame frame = { 0 };
@@ -836,7 +854,7 @@ static int cmd_can_send(const struct shell *sh, size_t argc, char **argv)
 
 static int cmd_can_filter_add(const struct shell *sh, size_t argc, char **argv)
 {
-	const struct device *dev = device_get_binding(argv[1]);
+	const struct device *dev = get_can_controller(argv[1]);
 	struct can_filter filter;
 	uint32_t id_mask;
 	int argidx = 2;
@@ -936,7 +954,7 @@ static int cmd_can_filter_add(const struct shell *sh, size_t argc, char **argv)
 
 static int cmd_can_filter_remove(const struct shell *sh, size_t argc, char **argv)
 {
-	const struct device *dev = device_get_binding(argv[1]);
+	const struct device *dev = get_can_controller(argv[1]);
 	int filter_id;
 	char *endptr;
 
@@ -960,7 +978,7 @@ static int cmd_can_filter_remove(const struct shell *sh, size_t argc, char **arg
 
 static int cmd_can_recover(const struct shell *sh, size_t argc, char **argv)
 {
-	const struct device *dev = device_get_binding(argv[1]);
+	const struct device *dev = get_can_controller(argv[1]);
 	k_timeout_t timeout = K_FOREVER;
 	int millisec;
 	char *endptr;


### PR DESCRIPTION
Add support for using device node labels instead of node full name.