### PR TITLE
tests/storage/stream_flash: add nrf52840dk/nrf52840 to platform_allow

### DIFF
--- a/tests/subsys/storage/stream/stream_flash/testcase.yaml
+++ b/tests/subsys/storage/stream/stream_flash/testcase.yaml
@@ -7,6 +7,8 @@ common:
 tests:
   storage.stream_flash:
     tags: stream_flash
+    platform_allow:
+      - nrf52840dk/nrf52840
     integration_platforms:
       - nrf52840dk/nrf52840
   storage.stream_flash.simulator.no_explicit_erase:


### PR DESCRIPTION
If nrf52840dk/nrf52840 is an integration platform, it should also be an allowed platform, otherwise the test run breaks down.

This is a hotfix for the CI breakage introduced by #81868, an example of a failed run is https://github.com/zephyrproject-rtos/zephyr/actions/runs/12066063251/job/33646115201?pr=81532
