### PR TITLE
wifi: nrf_wifi: Remove duplicate Kconfig option

### DIFF
--- a/drivers/wifi/nrf_wifi/Kconfig.nrfwifi
+++ b/drivers/wifi/nrf_wifi/Kconfig.nrfwifi
@@ -676,15 +676,6 @@ config NET_MGMT_EVENT_QUEUE_SIZE
 	# Doing interface down and up even with delay puts a lot of events in the queue
 	default 16
 
-config NRF_WIFI_RPU_RECOVERY_PROPAGATION_DELAY_MS
-	int "RPU recovery propagation delay in milliseconds"
-	default 10
-	help
-	  Propagation delay in milliseconds to wait after the RPU is powered down
-	  before powering it up. This delay is required to ensure that the recovery
-	  is propagated to all the applications and stack, and has enough time to
-	  clean up the resources.
-
 config NRF_WIFI_RPU_RECOVERY_PS_ACTIVE_TIMEOUT_MS
 	int "RPU recovery power save active timeout in milliseconds"
 	default 50000


### PR DESCRIPTION
Remove NRF_WIFI_RPU_RECOVERY_PROPAGATION_DELAY_MS Kconfig which was defined twice with different values.