### PR TITLE
Add support for ADXL366

### DIFF
--- a/drivers/sensor/adi/adxl367/Kconfig
+++ b/drivers/sensor/adi/adxl367/Kconfig
@@ -6,9 +6,11 @@
 menuconfig ADXL367
 	bool "ADXL367 Three Axis High-g I2C/SPI accelerometer"
 	default y
-	depends on DT_HAS_ADI_ADXL367_ENABLED
-	select I2C if $(dt_compat_on_bus,$(DT_COMPAT_ADI_ADXL367),i2c)
-	select SPI if $(dt_compat_on_bus,$(DT_COMPAT_ADI_ADXL367),spi)
+	depends on DT_HAS_ADI_ADXL367_ENABLED || DT_HAS_ADI_ADXL366_ENABLED
+	select I2C if $(dt_compat_on_bus,$(DT_COMPAT_ADI_ADXL367),i2c) || \
+				$(dt_compat_on_bus,$(DT_COMPAT_ADI_ADXL366),i2c)
+	select SPI if $(dt_compat_on_bus,$(DT_COMPAT_ADI_ADXL367),spi) || \
+				$(dt_compat_on_bus,$(DT_COMPAT_ADI_ADXL366),spi)
 	help
 	  Enable driver for ADXL367 Three-Axis Digital Accelerometers.
 

--- a/drivers/sensor/adi/adxl367/adxl367.c
+++ b/drivers/sensor/adi/adxl367/adxl367.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#define DT_DRV_COMPAT adi_adxl367
-
 #include <zephyr/drivers/sensor.h>
 #include <zephyr/kernel.h>
 #include <zephyr/device.h>
@@ -17,6 +15,8 @@
 #include <zephyr/logging/log.h>
 
 #include "adxl367.h"
+
+#define DT_DRV_COMPAT adi_adxl367
 
 LOG_MODULE_REGISTER(ADXL367, CONFIG_SENSOR_LOG_LEVEL);
 
@@ -1075,21 +1075,17 @@ static int adxl367_init(const struct device *dev)
 	return adxl367_probe(dev);
 }
 
-#if DT_NUM_INST_STATUS_OKAY(DT_DRV_COMPAT) == 0
-#warning "ADXL367 driver enabled without any devices"
-#endif
-
 /*
  * Device creation macro, shared by ADXL367_DEFINE_SPI() and
  * ADXL367_DEFINE_I2C().
  */
 
-#define ADXL367_DEVICE_INIT(inst)					\
+#define ADXL367_DEVICE_INIT(inst, chipid)					\
 	SENSOR_DEVICE_DT_INST_DEFINE(inst,				\
 			      adxl367_init,				\
 			      NULL,					\
-			      &adxl367_data_##inst,			\
-			      &adxl367_config_##inst,			\
+			      &adxl367_data_##inst##chipid,			\
+			      &adxl367_config_##inst##chipid,			\
 			      POST_KERNEL,				\
 			      CONFIG_SENSOR_INIT_PRIORITY,		\
 			      &adxl367_api_funcs);
@@ -1101,7 +1097,7 @@ static int adxl367_init(const struct device *dev)
 #define ADXL367_CFG_IRQ(inst)
 #endif /* CONFIG_ADXL367_TRIGGER */
 
-#define ADXL367_CONFIG(inst)								\
+#define ADXL367_CONFIG(inst, chipid)								\
 		.odr = DT_INST_PROP(inst, odr),						\
 		.autosleep = false,							\
 		.low_noise = false,							\
@@ -1123,63 +1119,69 @@ static int adxl367_init(const struct device *dev)
 		.fifo_config.fifo_format = ADXL367_FIFO_FORMAT_XYZ,			\
 		.fifo_config.fifo_samples = 128,					\
 		.fifo_config.fifo_read_mode = ADXL367_14B_CHID,				\
-		.op_mode = ADXL367_MEASURE,
+		.op_mode = ADXL367_MEASURE,						\
+		.chip_id = chipid,
 
 /*
  * Instantiation macros used when a device is on a SPI bus.
  */
 #define ADXL367_SPI_CFG SPI_WORD_SET(8) | SPI_TRANSFER_MSB
 
-#define ADXL367_RTIO_DEFINE(inst)                                    \
-	SPI_DT_IODEV_DEFINE(adxl367_iodev_##inst, DT_DRV_INST(inst),     \
+#define ADXL367_RTIO_DEFINE(inst, chipid)                                    \
+	SPI_DT_IODEV_DEFINE(adxl367_iodev_##inst##chipid, DT_DRV_INST(inst),     \
 						ADXL367_SPI_CFG, 0U);                        \
-	RTIO_DEFINE(adxl367_rtio_ctx_##inst, 8, 8);
+	RTIO_DEFINE(adxl367_rtio_ctx_##inst##chipid, 8, 8);
 
-#define ADXL367_CONFIG_SPI(inst)					\
+#define ADXL367_CONFIG_SPI(inst, chipid)					\
 	{								\
 		.bus_init = adxl367_spi_init,				\
 		.spi = SPI_DT_SPEC_INST_GET(inst, ADXL367_SPI_CFG, 0),		\
-		ADXL367_CONFIG(inst)					\
+		ADXL367_CONFIG(inst, chipid)					\
 		COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, int1_gpios),	\
 		(ADXL367_CFG_IRQ(inst)), ())				\
 	}
 
-#define ADXL367_DEFINE_SPI(inst)					\
-	IF_ENABLED(CONFIG_ADXL367_STREAM, (ADXL367_RTIO_DEFINE(inst)));                          \
-	static struct adxl367_data adxl367_data_##inst = {			\
-	IF_ENABLED(CONFIG_ADXL367_STREAM, (.rtio_ctx = &adxl367_rtio_ctx_##inst,                  \
-				.iodev = &adxl367_iodev_##inst,)) \
+#define ADXL367_DEFINE_SPI(inst, chipid)					\
+	IF_ENABLED(CONFIG_ADXL367_STREAM, (ADXL367_RTIO_DEFINE(inst, chipid)));                  \
+	static struct adxl367_data adxl367_data_##inst##chipid = {			\
+	IF_ENABLED(CONFIG_ADXL367_STREAM, (.rtio_ctx = &adxl367_rtio_ctx_##inst##chipid,         \
+				.iodev = &adxl367_iodev_##inst##chipid,)) \
 	};	\
-	static const struct adxl367_dev_config adxl367_config_##inst =	\
-		ADXL367_CONFIG_SPI(inst);				\
-	ADXL367_DEVICE_INIT(inst)
+	static const struct adxl367_dev_config adxl367_config_##inst##chipid =	\
+		ADXL367_CONFIG_SPI(inst, chipid);				\
+	ADXL367_DEVICE_INIT(inst, chipid)
 
 /*
  * Instantiation macros used when a device is on an I2C bus.
  */
 
-#define ADXL367_CONFIG_I2C(inst)					\
+#define ADXL367_CONFIG_I2C(inst, chipid)					\
 	{								\
 		.bus_init = adxl367_i2c_init,				\
 		.i2c = I2C_DT_SPEC_INST_GET(inst),			\
-		ADXL367_CONFIG(inst)					\
+		ADXL367_CONFIG(inst, chipid)					\
 		COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, int1_gpios),	\
 		(ADXL367_CFG_IRQ(inst)), ())				\
 	}
 
-#define ADXL367_DEFINE_I2C(inst)					\
-	static struct adxl367_data adxl367_data_##inst;			\
-	static const struct adxl367_dev_config adxl367_config_##inst =	\
-		ADXL367_CONFIG_I2C(inst);				\
-	ADXL367_DEVICE_INIT(inst)
+#define ADXL367_DEFINE_I2C(inst, chipid)					\
+	static struct adxl367_data adxl367_data_##inst##chipid;			\
+	static const struct adxl367_dev_config adxl367_config_##inst##chipid =	\
+		ADXL367_CONFIG_I2C(inst, chipid);				\
+	ADXL367_DEVICE_INIT(inst, chipid)
 /*
  * Main instantiation macro. Use of COND_CODE_1() selects the right
  * bus-specific macro at preprocessor time.
  */
 
-#define ADXL367_DEFINE(inst)						\
+#define ADXL367_DEFINE(inst, chipid)						\
 	COND_CODE_1(DT_INST_ON_BUS(inst, spi),				\
-		    (ADXL367_DEFINE_SPI(inst)),				\
-		    (ADXL367_DEFINE_I2C(inst)))
+		    (ADXL367_DEFINE_SPI(inst, chipid)),				\
+		    (ADXL367_DEFINE_I2C(inst, chipid)))
 
-DT_INST_FOREACH_STATUS_OKAY(ADXL367_DEFINE)
+DT_INST_FOREACH_STATUS_OKAY_VARGS(ADXL367_DEFINE, ADXL367_CHIP_ID)
+
+#undef DT_DRV_COMPAT
+#define DT_DRV_COMPAT adi_adxl366
+DT_INST_FOREACH_STATUS_OKAY_VARGS(ADXL367_DEFINE, ADXL366_CHIP_ID)
+#undef DT_DRV_COMPAT

--- a/drivers/sensor/adi/adxl367/adxl367.h
+++ b/drivers/sensor/adi/adxl367/adxl367.h
@@ -14,15 +14,34 @@
 #include <zephyr/kernel.h>
 #include <zephyr/sys/util.h>
 
-#define DT_DRV_COMPAT adi_adxl367
-
+#define DT_DRV_COMPAT  adi_adxl367
 #if DT_ANY_INST_ON_BUS_STATUS_OKAY(spi)
-#include <zephyr/drivers/spi.h>
+#define ADXL367_BUS_SPI
 #endif /* DT_ANY_INST_ON_BUS_STATUS_OKAY(spi) */
-
 #if DT_ANY_INST_ON_BUS_STATUS_OKAY(i2c)
-#include <zephyr/drivers/i2c.h>
+#define ADXL367_BUS_I2C
 #endif /* DT_ANY_INST_ON_BUS_STATUS_OKAY(i2c) */
+#undef DT_DRV_COMPAT
+
+#define DT_DRV_COMPAT  adi_adxl366
+#if DT_ANY_INST_ON_BUS_STATUS_OKAY(spi)
+#define ADXL367_BUS_SPI
+#endif /* DT_ANY_INST_ON_BUS_STATUS_OKAY(spi) */
+#if DT_ANY_INST_ON_BUS_STATUS_OKAY(i2c)
+#define ADXL367_BUS_I2C
+#endif /* DT_ANY_INST_ON_BUS_STATUS_OKAY(i2c) */
+#undef DT_DRV_COMPAT
+
+#ifdef ADXL367_BUS_SPI
+#include <zephyr/drivers/spi.h>
+#endif /* ADXL367_BUS_SPI */
+
+#ifdef ADXL367_BUS_I2C
+#include <zephyr/drivers/i2c.h>
+#endif /* ADXL367_BUS_I2C */
+
+#define ADXL367_CHIP_ID		0
+#define ADXL366_CHIP_ID		1
 
 /*
  * ADXL367 registers definition
@@ -355,12 +374,12 @@ struct adxl367_data {
 };
 
 struct adxl367_dev_config {
-#if DT_ANY_INST_ON_BUS_STATUS_OKAY(i2c)
+#ifdef ADXL367_BUS_I2C
 	struct i2c_dt_spec i2c;
-#endif
-#if DT_ANY_INST_ON_BUS_STATUS_OKAY(spi)
+#endif /* ADXL367_BUS_I2C */
+#ifdef ADXL367_BUS_SPI
 	struct spi_dt_spec spi;
-#endif
+#endif /* ADXL367_BUS_SPI */
 	int (*bus_init)(const struct device *dev);
 
 #ifdef CONFIG_ADXL367_TRIGGER
@@ -383,6 +402,7 @@ struct adxl367_dev_config {
 
 	uint16_t inactivity_time;
 	uint8_t activity_time;
+	uint8_t chip_id;
 };
 
 struct adxl367_fifo_data {

--- a/drivers/sensor/adi/adxl367/adxl367_i2c.c
+++ b/drivers/sensor/adi/adxl367/adxl367_i2c.c
@@ -7,14 +7,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#define DT_DRV_COMPAT adi_adxl367
-
 #include <string.h>
 #include <zephyr/logging/log.h>
 
 #include "adxl367.h"
 
-#if DT_ANY_INST_ON_BUS_STATUS_OKAY(i2c)
+#ifdef ADXL367_BUS_I2C
 
 LOG_MODULE_DECLARE(ADXL367, CONFIG_SENSOR_LOG_LEVEL);
 
@@ -101,4 +99,4 @@ int adxl367_i2c_init(const struct device *dev)
 
 	return 0;
 }
-#endif /* DT_ANY_INST_ON_BUS_STATUS_OKAY(i2c) */
+#endif /* ADXL367_BUS_I2C */

--- a/drivers/sensor/adi/adxl367/adxl367_spi.c
+++ b/drivers/sensor/adi/adxl367/adxl367_spi.c
@@ -7,14 +7,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#define DT_DRV_COMPAT adi_adxl367
-
 #include <string.h>
 #include <zephyr/logging/log.h>
 
 #include "adxl367.h"
 
-#if DT_ANY_INST_ON_BUS_STATUS_OKAY(spi)
+#ifdef ADXL367_BUS_SPI
 
 LOG_MODULE_DECLARE(ADXL367, CONFIG_SENSOR_LOG_LEVEL);
 
@@ -127,4 +125,4 @@ int adxl367_spi_init(const struct device *dev)
 	return 0;
 }
 
-#endif /* DT_ANY_INST_ON_BUS_STATUS_OKAY(spi) */
+#endif /* ADXL367_BUS_SPI */

--- a/drivers/sensor/adi/adxl367/adxl367_trigger.c
+++ b/drivers/sensor/adi/adxl367/adxl367_trigger.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#define DT_DRV_COMPAT adi_adxl367
-
 #include <zephyr/device.h>
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/sys/util.h>

--- a/dts/bindings/sensor/adi,adxl366-i2c.yaml
+++ b/dts/bindings/sensor/adi,adxl366-i2c.yaml
@@ -1,0 +1,8 @@
+# Copyright (c) 2023 Analog Devices Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+description: ADXL366 3-axis nanopower accelerometer, accessed through I2C bus
+
+compatible: "adi,adxl366"
+
+include: ["i2c-device.yaml", "adi,adxl367-common.yaml"]

--- a/dts/bindings/sensor/adi,adxl366-spi.yaml
+++ b/dts/bindings/sensor/adi,adxl366-spi.yaml
@@ -1,0 +1,8 @@
+# Copyright (c) 2023 Analog Devices Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+description: ADXL366 3-axis nanopower accelerometer, accessed through SPI bus
+
+compatible: "adi,adxl366"
+
+include: ["spi-device.yaml", "adi,adxl367-common.yaml"]


### PR DESCRIPTION
Add support for ADXL366 accelerometer by modifying existing ADXL367 driver to support both ADXL367 and ADXL366.

Signed-off-by: Vladislav Pejic [vladislav.pejic@orioninc.com](mailto:vladislav.pejic@orioninc.com)