### PR TITLE
soc: nordic: nrf54h: Switch guards for nRF54H20 radiodore

### DIFF
--- a/soc/nordic/nrf54h/power.c
+++ b/soc/nordic/nrf54h/power.c
@@ -62,7 +62,7 @@ void nrf_poweroff(void)
 	nrf_resetinfo_resetreas_local_set(NRF_RESETINFO, 0);
 	nrf_resetinfo_restore_valid_set(NRF_RESETINFO, false);
 
-#if !defined(CONFIG_SOC_NRF54H20_CPURAD)
+#if !defined(NRF_RADIOCORE)
 	/* Disable retention */
 	nrf_lrcconf_retain_set(NRF_LRCCONF010, NRF_LRCCONF_POWER_MAIN, false);
 	nrf_lrcconf_retain_set(NRF_LRCCONF010, NRF_LRCCONF_POWER_DOMAIN_0, false);
@@ -88,7 +88,7 @@ static void s2idle_enter(uint8_t substate_id)
 	case 1: /* Substate for idle with cache retained - not implemented yet. */
 		break;
 	case 2: /* Substate for idle with cache disabled. */
-#if !defined(CONFIG_SOC_NRF54H20_CPURAD)
+#if !defined(NRF_RADIOCORE)
 		soc_lrcconf_poweron_request(&soc_node, NRF_LRCCONF_POWER_MAIN);
 #endif
 		common_suspend();
@@ -113,7 +113,7 @@ static void s2idle_exit(uint8_t substate_id)
 		break;
 	case 2: /* Substate for idle with cache disabled. */
 		common_resume();
-#if !defined(CONFIG_SOC_NRF54H20_CPURAD)
+#if !defined(NRF_RADIOCORE)
 		soc_lrcconf_poweron_release(&soc_node, NRF_LRCCONF_POWER_MAIN);
 #endif
 	default: /* Unknown substate. */
@@ -126,7 +126,7 @@ static void s2idle_exit(uint8_t substate_id)
 static void s2ram_exit(void)
 {
 	common_resume();
-#if !defined(CONFIG_SOC_NRF54H20_CPURAD)
+#if !defined(NRF_RADIOCORE)
 	/* Re-enable domain retention. */
 	nrf_lrcconf_retain_set(NRF_LRCCONF010, NRF_LRCCONF_POWER_DOMAIN_0, true);
 #endif
@@ -142,7 +142,7 @@ static int sys_suspend_to_ram(void)
 					  NRF_RESETINFO_RESETREAS_LOCAL_UNRETAINED_MASK);
 	nrf_resetinfo_restore_valid_set(NRF_RESETINFO, true);
 
-#if !defined(CONFIG_SOC_NRF54H20_CPURAD)
+#if !defined(NRF_RADIOCORE)
 	/* Disable retention */
 	nrf_lrcconf_retain_set(NRF_LRCCONF010, NRF_LRCCONF_POWER_DOMAIN_0, false);
 #endif


### PR DESCRIPTION

Replace the symbol `CONFIG_SOC_NRF54H20_CPURAD` with the generic
`NRF_RADIOCORE`.