### PR TITLE
drivers: display: stm32_ltdc: Use local device variable

### DIFF
--- a/drivers/display/display_stm32_ltdc.c
+++ b/drivers/display/display_stm32_ltdc.c
@@ -286,7 +286,7 @@ static int stm32_ltdc_display_blanking_on(const struct device *dev)
 		return -ENOSYS;
 	}
 
-	if (!device_is_ready(config->display_controller)) {
+	if (!device_is_ready(display_dev)) {
 		LOG_ERR("Display device %s not ready", display_dev->name);
 		return -ENODEV;
 	}


### PR DESCRIPTION
Similar to `stm32_ltdc_display_blanking_off()`, use local device variable instead of accessing the config's structure member again.