### PR TITLE
ci: workflows: remove rebase-merge folder before rebase

### DIFF
--- a/.github/workflows/bsim-tests.yaml
+++ b/.github/workflows/bsim-tests.yaml
@@ -77,6 +77,7 @@ jobs:
           git config --global user.email "bot@zephyrproject.org"
           git config --global user.name "Zephyr Bot"
           rm -fr ".git/rebase-apply"
+          rm -fr ".git/rebase-merge"
           git rebase origin/${BASE_REF}
           git clean -f -d
           git log  --pretty=oneline | head -n 10

--- a/.github/workflows/clang.yaml
+++ b/.github/workflows/clang.yaml
@@ -61,6 +61,7 @@ jobs:
           git config --global user.email "bot@zephyrproject.org"
           git config --global user.name "Zephyr Bot"
           rm -fr ".git/rebase-apply"
+          rm -fr ".git/rebase-merge"
           git rebase origin/${BASE_REF}
           git clean -f -d
           git log  --pretty=oneline | head -n 10

--- a/.github/workflows/coding_guidelines.yml
+++ b/.github/workflows/coding_guidelines.yml
@@ -40,6 +40,8 @@ jobs:
         git config --global user.email "actions@zephyrproject.org"
         git config --global user.name "Github Actions"
         git remote -v
+        rm -fr ".git/rebase-apply"
+        rm -fr ".git/rebase-merge"
         git rebase origin/${BASE_REF}
         git clean -f -d
         source zephyr-env.sh

--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -33,6 +33,8 @@ jobs:
         # Ensure there's no merge commits in the PR
         [[ "$(git rev-list --merges --count origin/${BASE_REF}..)" == "0" ]] || \
         (echo "::error ::Merge commits not allowed, rebase instead";false)
+        rm -fr ".git/rebase-apply"
+        rm -fr ".git/rebase-merge"
         git rebase origin/${BASE_REF}
         git clean -f -d
         # debug

--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -94,6 +94,8 @@ jobs:
       run: |
         git config --global user.email "actions@zephyrproject.org"
         git config --global user.name "Github Actions"
+        rm -fr ".git/rebase-apply"
+        rm -fr ".git/rebase-merge"
         git rebase origin/${BASE_REF}
         git clean -f -d
         git log --graph --oneline HEAD...${PR_HEAD}

--- a/.github/workflows/hello_world_multiplatform.yaml
+++ b/.github/workflows/hello_world_multiplatform.yaml
@@ -45,6 +45,8 @@ jobs:
         run: |
           git config --global user.email "actions@zephyrproject.org"
           git config --global user.name "Github Actions"
+          rm -fr ".git/rebase-apply"
+          rm -fr ".git/rebase-merge"
           git rebase origin/${BASE_REF}
           git clean -f -d
           git log --graph --oneline HEAD...${PR_HEAD}

--- a/.github/workflows/scripts_tests.yml
+++ b/.github/workflows/scripts_tests.yml
@@ -42,6 +42,8 @@ jobs:
         run: |
           git config --global user.email "actions@zephyrproject.org"
           git config --global user.name "Github Actions"
+          rm -fr ".git/rebase-apply"
+          rm -fr ".git/rebase-merge"
           git rebase origin/${BASE_REF}
           git clean -f -d
           git log --graph --oneline HEAD...${PR_HEAD}

--- a/.github/workflows/twister-prep.yaml
+++ b/.github/workflows/twister-prep.yaml
@@ -67,6 +67,7 @@ jobs:
           git config --global user.email "bot@zephyrproject.org"
           git config --global user.name "Zephyr Bot"
           rm -fr ".git/rebase-apply"
+          rm -fr ".git/rebase-merge"
           git rebase origin/${BASE_REF}
           git clean -f -d
           git log  --pretty=oneline | head -n 10

--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -84,6 +84,7 @@ jobs:
             git config --global user.email "bot@zephyrproject.org"
             git config --global user.name "Zephyr Builder"
             rm -fr ".git/rebase-apply"
+            rm -fr ".git/rebase-merge"
             git rebase origin/${BASE_REF}
             git clean -f -d
             git log  --pretty=oneline | head -n 10


### PR DESCRIPTION
We've seen that some workflows can create phantom rebase-merge folder that doesn't get cleaned. This commit removes possible rebase-merge folder pre-rebase. This is from ADI self hosted-runner:

![image](https://github.com/user-attachments/assets/fdd212fb-d9b0-4610-ac5a-b185f632e888)

We've seen that with this commit deletes the folder pre-rebase

More info:
with git v2.26, there's a change that : "Previously git rebase used the “apply” backend. In 2.26, both git rebase and git rebase -i now both use the “merge” backend. " from: https://github.blog/open-source/git/highlights-from-git-2-26/
Runners use newer git versions (v2.30+). In these versions, rebase conflicts create "rebase-merge" folder to fix option, not "rebase-apply".

