### PR TITLE
drivers: udc_dwc2: Wait for USBHS clock start

### DIFF
--- a/drivers/usb/udc/udc_dwc2_vendor_quirks.h
+++ b/drivers/usb/udc/udc_dwc2_vendor_quirks.h
@@ -201,6 +201,9 @@ static inline int usbhs_enable_core(const struct device *dev)
 	wrapper->ENABLE = USBHS_ENABLE_PHY_Msk | USBHS_ENABLE_CORE_Msk;
 	wrapper->TASKS_START = 1UL;
 
+	/* Wait for clock to start to avoid hang on too early register read */
+	k_busy_wait(1);
+
 	/* Enable interrupts */
 	wrapper->INTENSET = 1UL;
 


### PR DESCRIPTION
Accessing DWC2 otg core registers before the clock starts results in complete system hang. Add a 1 us busy wait to make sure that software won't access registers before the clock is started.