### PR TITLE
net: lib: lwm2m: Fix missing mutex unlock

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_registry.c
+++ b/subsys/net/lib/lwm2m/lwm2m_registry.c
@@ -648,6 +648,7 @@ static int lwm2m_engine_set(const struct lwm2m_obj_path *path, const void *value
 		if (!lwm2m_validate_time_resource_lenghts(max_data_len, len)) {
 			LOG_ERR("Time Set: buffer length %u  max data len %zu not supported", len,
 				max_data_len);
+			k_mutex_unlock(&registry_lock);
 			return -EINVAL;
 		}
 
@@ -924,6 +925,7 @@ static int lwm2m_engine_get(const struct lwm2m_obj_path *path, void *buf, uint16
 			if (!lwm2m_validate_time_resource_lenghts(data_len, buflen)) {
 				LOG_ERR("Time get buffer length %u  data len %zu not supported",
 					buflen, data_len);
+				k_mutex_unlock(&registry_lock);
 				return -EINVAL;
 			}
 


### PR DESCRIPTION
lwm2m_engine_set() and lwm2m_engine_get() locks
the registry_lock mutex, but this is not unlocked
when setting or getting a time resource where the buffer lengths are invalid resulting in an early return without unlocking the mutex. This results in a deadlock when attempting to lock the registry in another thread.