### PR TITLE
drivers: i2s: Place API into iterable section

### DIFF
--- a/drivers/i2s/i2s_esp32.c
+++ b/drivers/i2s/i2s_esp32.c
@@ -887,7 +887,7 @@ static int i2s_esp32_write(const struct device *dev, void *mem_block, size_t siz
 	return 0;
 }
 
-static const struct i2s_driver_api i2s_esp32_driver_api = {
+static DEVICE_API(i2s, i2s_esp32_driver_api) = {
 	.configure = i2s_esp32_configure,
 	.config_get = i2s_esp32_config_get,
 	.trigger = i2s_esp32_trigger,

--- a/drivers/i2s/i2s_litex.c
+++ b/drivers/i2s/i2s_litex.c
@@ -591,7 +591,7 @@ static void i2s_litex_isr_tx(void *arg)
 	k_mem_slab_free(stream->cfg.mem_slab, stream->mem_block);
 }
 
-static const struct i2s_driver_api i2s_litex_driver_api = {
+static DEVICE_API(i2s, i2s_litex_driver_api) = {
 	.configure = i2s_litex_configure,
 	.read = i2s_litex_read,
 	.write = i2s_litex_write,

--- a/drivers/i2s/i2s_ll_stm32.c
+++ b/drivers/i2s/i2s_ll_stm32.c
@@ -483,7 +483,7 @@ static int i2s_stm32_write(const struct device *dev, void *mem_block,
 	return queue_put(&dev_data->tx.mem_block_queue, mem_block, size);
 }
 
-static const struct i2s_driver_api i2s_stm32_driver_api = {
+static DEVICE_API(i2s, i2s_stm32_driver_api) = {
 	.configure = i2s_stm32_configure,
 	.read = i2s_stm32_read,
 	.write = i2s_stm32_write,

--- a/drivers/i2s/i2s_mcux_flexcomm.c
+++ b/drivers/i2s/i2s_mcux_flexcomm.c
@@ -851,7 +851,7 @@ static int i2s_mcux_write(const struct device *dev, void *mem_block,
 	return ret;
 }
 
-static const struct i2s_driver_api i2s_mcux_driver_api = {
+static DEVICE_API(i2s, i2s_mcux_driver_api) = {
 	.configure = i2s_mcux_configure,
 	.config_get = i2s_mcux_config_get,
 	.read = i2s_mcux_read,

--- a/drivers/i2s/i2s_mcux_sai.c
+++ b/drivers/i2s/i2s_mcux_sai.c
@@ -1159,7 +1159,7 @@ static int i2s_mcux_initialize(const struct device *dev)
 	return 0;
 }
 
-static const struct i2s_driver_api i2s_mcux_driver_api = {
+static DEVICE_API(i2s, i2s_mcux_driver_api) = {
 	.configure = i2s_mcux_config,
 	.read = i2s_mcux_read,
 	.write = i2s_mcux_write,

--- a/drivers/i2s/i2s_nrfx.c
+++ b/drivers/i2s/i2s_nrfx.c
@@ -914,7 +914,7 @@ static void init_clock_manager(const struct device *dev)
 	__ASSERT_NO_MSG(drv_data->clk_mgr != NULL);
 }
 
-static const struct i2s_driver_api i2s_nrf_drv_api = {
+static DEVICE_API(i2s, i2s_nrf_drv_api) = {
 	.configure = i2s_nrfx_configure,
 	.config_get = i2s_nrfx_config_get,
 	.read = i2s_nrfx_read,

--- a/drivers/i2s/i2s_sam_ssc.c
+++ b/drivers/i2s/i2s_sam_ssc.c
@@ -990,7 +990,7 @@ static int i2s_sam_initialize(const struct device *dev)
 	return 0;
 }
 
-static const struct i2s_driver_api i2s_sam_driver_api = {
+static DEVICE_API(i2s, i2s_sam_driver_api) = {
 	.configure = i2s_sam_configure,
 	.config_get = i2s_sam_config_get,
 	.read = i2s_sam_read,

--- a/drivers/i2s/i2s_test.c
+++ b/drivers/i2s/i2s_test.c
@@ -35,7 +35,7 @@ static int vnd_i2s_write(const struct device *dev, void *mem_block, size_t size)
 	return -ENOTSUP;
 }
 
-static const struct i2s_driver_api vnd_i2s_driver_api = {
+static DEVICE_API(i2s, vnd_i2s_driver_api) = {
 	.configure = vnd_i2s_configure,
 	.config_get = vnd_i2s_config_get,
 	.trigger = vnd_i2s_trigger,


### PR DESCRIPTION
Add wrapper DEVICE_API macro to all i2s_driver_api instances.