### PR TITLE
drivers: ipm: Place API into iterable section

### DIFF
--- a/drivers/ipm/ipm_cavs_host.c
+++ b/drivers/ipm/ipm_cavs_host.c
@@ -197,7 +197,7 @@ static int init(const struct device *dev)
 	return 0;
 }
 
-static const struct ipm_driver_api api = {
+static DEVICE_API(ipm, api) = {
 	.send = send,
 	.max_data_size_get = max_data_size_get,
 	.max_id_val_get = max_id_val_get,

--- a/drivers/ipm/ipm_esp32.c
+++ b/drivers/ipm/ipm_esp32.c
@@ -268,7 +268,7 @@ static int esp32_ipm_init(const struct device *dev)
 	return 0;
 }
 
-static const struct ipm_driver_api esp32_ipm_driver_api = {
+static DEVICE_API(ipm, esp32_ipm_driver_api) = {
 	.send = esp32_ipm_send,
 	.register_callback = esp32_ipm_register_callback,
 	.max_data_size_get = esp32_ipm_max_data_size_get,

--- a/drivers/ipm/ipm_imx.c
+++ b/drivers/ipm/ipm_imx.c
@@ -341,7 +341,7 @@ static int imx_mu_init(const struct device *dev)
 	return 0;
 }
 
-static const struct ipm_driver_api imx_mu_driver_api = {
+static DEVICE_API(ipm, imx_mu_driver_api) = {
 	.send = imx_mu_ipm_send,
 	.register_callback = imx_mu_ipm_register_callback,
 	.max_data_size_get = imx_mu_ipm_max_data_size_get,

--- a/drivers/ipm/ipm_ivshmem.c
+++ b/drivers/ipm/ipm_ivshmem.c
@@ -111,7 +111,7 @@ static int ivshmem_ipm_init(const struct device *dev)
 	return 0;
 }
 
-static const struct ipm_driver_api ivshmem_ipm_driver_api = {
+static DEVICE_API(ipm, ivshmem_ipm_driver_api) = {
 	.send = ivshmem_ipm_send,
 	.register_callback = ivshmem_ipm_register_callback,
 	.set_enabled = ivshmem_ipm_set_enabled

--- a/drivers/ipm/ipm_mbox.c
+++ b/drivers/ipm/ipm_mbox.c
@@ -89,7 +89,7 @@ static int ipm_mbox_init(const struct device *ipmdev)
 	return 0;
 }
 
-static const struct ipm_driver_api ipm_mbox_funcs = {
+static DEVICE_API(ipm, ipm_mbox_funcs) = {
 	.send = ipm_mbox_send,
 	.register_callback = ipm_mbox_register_callback,
 	.max_data_size_get = ipm_mbox_get_max_data_size,

--- a/drivers/ipm/ipm_mcux.c
+++ b/drivers/ipm/ipm_mcux.c
@@ -182,7 +182,7 @@ static int mcux_mailbox_init(const struct device *dev)
 	return 0;
 }
 
-static const struct ipm_driver_api mcux_mailbox_driver_api = {
+static DEVICE_API(ipm, mcux_mailbox_driver_api) = {
 	.send = mcux_mailbox_ipm_send,
 	.register_callback = mcux_mailbox_ipm_register_callback,
 	.max_data_size_get = mcux_mailbox_ipm_max_data_size_get,

--- a/drivers/ipm/ipm_mhu.c
+++ b/drivers/ipm/ipm_mhu.c
@@ -163,7 +163,7 @@ static void ipm_mhu_register_cb(const struct device *d,
 	driver_data->user_data = user_data;
 }
 
-static const struct ipm_driver_api ipm_mhu_driver_api = {
+static DEVICE_API(ipm, ipm_mhu_driver_api) = {
 	.send = ipm_mhu_send,
 	.register_callback = ipm_mhu_register_cb,
 	.max_data_size_get = ipm_mhu_max_data_size_get,

--- a/drivers/ipm/ipm_nrfx_ipc.c
+++ b/drivers/ipm/ipm_nrfx_ipc.c
@@ -96,7 +96,7 @@ static int ipm_nrf_init(const struct device *dev)
 	return 0;
 }
 
-static const struct ipm_driver_api ipm_nrf_driver_api = {
+static DEVICE_API(ipm, ipm_nrf_driver_api) = {
 	.send = ipm_nrf_send,
 	.register_callback = ipm_nrf_register_callback,
 	.max_data_size_get = ipm_nrf_max_data_size_get,
@@ -208,7 +208,7 @@ static int vipm_nrf_##_idx##_set_enabled(const struct device *dev, int enable)\
 	return 0;							\
 }									\
 									\
-static const struct ipm_driver_api vipm_nrf_##_idx##_driver_api = {	\
+static DEVICE_API(ipm, vipm_nrf_##_idx##_driver_api) = {	\
 	.send = vipm_nrf_##_idx##_send,					\
 	.register_callback = vipm_nrf_##_idx##_register_callback,	\
 	.max_data_size_get = vipm_nrf_max_data_size_get,		\

--- a/drivers/ipm/ipm_sedi.c
+++ b/drivers/ipm/ipm_sedi.c
@@ -260,7 +260,7 @@ static int ipm_power_ctrl(const struct device *dev,
 }
 #endif
 
-static const struct ipm_driver_api ipm_funcs = {
+static DEVICE_API(ipm, ipm_funcs) = {
 	.send = ipm_sedi_send,
 	.register_callback = ipm_sedi_register_callback,
 	.max_data_size_get = ipm_sedi_get_max_data_size,

--- a/drivers/ipm/ipm_stm32_hsem.c
+++ b/drivers/ipm/ipm_stm32_hsem.c
@@ -184,7 +184,7 @@ static int stm32_hsem_mailbox_init(const struct device *dev)
 	return 0;
 }
 
-static const struct ipm_driver_api stm32_hsem_mailbox_ipm_dirver_api = {
+static DEVICE_API(ipm, stm32_hsem_mailbox_ipm_dirver_api) = {
 	.send = stm32_hsem_mailbox_ipm_send,
 	.register_callback = stm32_hsem_mailbox_ipm_register_callback,
 	.max_data_size_get = stm32_hsem_mailbox_ipm_max_data_size_get,

--- a/drivers/ipm/ipm_stm32_ipcc.c
+++ b/drivers/ipm/ipm_stm32_ipcc.c
@@ -276,7 +276,7 @@ static int stm32_ipcc_mailbox_init(const struct device *dev)
 	return 0;
 }
 
-static const struct ipm_driver_api stm32_ipcc_mailbox_driver_api = {
+static DEVICE_API(ipm, stm32_ipcc_mailbox_driver_api) = {
 	.send = stm32_ipcc_mailbox_ipm_send,
 	.register_callback = stm32_ipcc_mailbox_ipm_register_callback,
 	.max_data_size_get = stm32_ipcc_mailbox_ipm_max_data_size_get,

--- a/drivers/ipm/ipm_xlnx_ipi.c
+++ b/drivers/ipm/ipm_xlnx_ipi.c
@@ -198,7 +198,7 @@ static int xlnx_ipi_init(const struct device *dev)
 	return 0;
 }
 
-static struct ipm_driver_api xlnx_ipi_api = {
+static DEVICE_API(ipm, xlnx_ipi_api) = {
 	.send = xlnx_ipi_send,
 	.register_callback = xlnx_ipi_register_callback,
 	.max_data_size_get = xlnx_ipi_max_data_size_get,

--- a/tests/drivers/ipm/src/ipm_dummy.c
+++ b/tests/drivers/ipm/src/ipm_dummy.c
@@ -113,7 +113,7 @@ static int ipm_dummy_max_data_size_get(const struct device *d)
 	return DUMMY_IPM_DATA_WORDS * sizeof(uint32_t);
 }
 
-struct ipm_driver_api ipm_dummy_api = {
+DEVICE_API(ipm, ipm_dummy_api) = {
 	.send = ipm_dummy_send,
 	.register_callback = ipm_dummy_register_callback,
 	.max_data_size_get = ipm_dummy_max_data_size_get,


### PR DESCRIPTION
Add wrapper DEVICE_API macro to all ipm_driver_api instances.