### PR TITLE
Can driver api

### DIFF
--- a/drivers/can/can_common.c
+++ b/drivers/can/can_common.c
@@ -35,7 +35,8 @@ int z_impl_can_send(const struct device *dev, const struct can_frame *frame,
 		    k_timeout_t timeout, can_tx_callback_t callback,
 		    void *user_data)
 {
-	const struct can_driver_api *api = (const struct can_driver_api *)dev->api;
+	__ASSERT_NO_MSG(DEVICE_API_IS(can, dev));
+
 	uint32_t id_mask;
 
 	CHECKIF(frame == NULL) {
@@ -62,7 +63,7 @@ int z_impl_can_send(const struct device *dev, const struct can_frame *frame,
 
 		k_sem_init(&ctx.done, 0, 1);
 
-		err = api->send(dev, frame, timeout, can_tx_default_cb, &ctx);
+		err = DEVICE_API_GET(can, dev)->send(dev, frame, timeout, can_tx_default_cb, &ctx);
 		if (err != 0) {
 			return err;
 		}
@@ -72,13 +73,14 @@ int z_impl_can_send(const struct device *dev, const struct can_frame *frame,
 		return ctx.status;
 	}
 
-	return api->send(dev, frame, timeout, callback, user_data);
+	return DEVICE_API_GET(can, dev)->send(dev, frame, timeout, callback, user_data);
 }
 
 int can_add_rx_filter(const struct device *dev, can_rx_callback_t callback,
 		      void *user_data, const struct can_filter *filter)
 {
-	const struct can_driver_api *api = (const struct can_driver_api *)dev->api;
+	__ASSERT_NO_MSG(DEVICE_API_IS(can, dev));
+
 	uint32_t id_mask;
 
 	CHECKIF(callback == NULL || filter == NULL) {
@@ -100,7 +102,7 @@ int can_add_rx_filter(const struct device *dev, can_rx_callback_t callback,
 		return -EINVAL;
 	}
 
-	return api->add_rx_filter(dev, callback, user_data, filter);
+	return DEVICE_API_GET(can, dev)->add_rx_filter(dev, callback, user_data, filter);
 }
 
 static void can_msgq_put(const struct device *dev, struct can_frame *frame, void *user_data)
@@ -121,9 +123,9 @@ static void can_msgq_put(const struct device *dev, struct can_frame *frame, void
 int z_impl_can_add_rx_filter_msgq(const struct device *dev, struct k_msgq *msgq,
 				  const struct can_filter *filter)
 {
-	const struct can_driver_api *api = dev->api;
+	__ASSERT_NO_MSG(DEVICE_API_IS(can, dev));
 
-	return api->add_rx_filter(dev, can_msgq_put, msgq, filter);
+	return DEVICE_API_GET(can, dev)->add_rx_filter(dev, can_msgq_put, msgq, filter);
 }
 
 /**
@@ -383,7 +385,8 @@ static int check_timing_in_range(const struct can_timing *timing,
 int z_impl_can_set_timing(const struct device *dev,
 			  const struct can_timing *timing)
 {
-	const struct can_driver_api *api = (const struct can_driver_api *)dev->api;
+	__ASSERT_NO_MSG(DEVICE_API_IS(can, dev));
+
 	const struct can_timing *min = can_get_timing_min(dev);
 	const struct can_timing *max = can_get_timing_max(dev);
 	int err;
@@ -393,7 +396,7 @@ int z_impl_can_set_timing(const struct device *dev,
 		return err;
 	}
 
-	return api->set_timing(dev, timing);
+	return DEVICE_API_GET(can, dev)->set_timing(dev, timing);
 }
 
 int z_impl_can_set_bitrate(const struct device *dev, uint32_t bitrate)
@@ -425,12 +428,13 @@ int z_impl_can_set_bitrate(const struct device *dev, uint32_t bitrate)
 int z_impl_can_set_timing_data(const struct device *dev,
 			       const struct can_timing *timing_data)
 {
-	const struct can_driver_api *api = (const struct can_driver_api *)dev->api;
+	__ASSERT_NO_MSG(DEVICE_API_IS(can, dev));
+
 	const struct can_timing *min = can_get_timing_data_min(dev);
 	const struct can_timing *max = can_get_timing_data_max(dev);
 	int err;
 
-	if (api->set_timing_data == NULL) {
+	if (DEVICE_API_GET(can, dev)->set_timing_data == NULL) {
 		return -ENOSYS;
 	}
 
@@ -439,7 +443,7 @@ int z_impl_can_set_timing_data(const struct device *dev,
 		return err;
 	}
 
-	return api->set_timing_data(dev, timing_data);
+	return DEVICE_API_GET(can, dev)->set_timing_data(dev, timing_data);
 }
 
 int z_impl_can_set_bitrate_data(const struct device *dev, uint32_t bitrate_data)

--- a/drivers/can/can_esp32_twai.c
+++ b/drivers/can/can_esp32_twai.c
@@ -216,7 +216,7 @@ static int can_esp32_twai_init(const struct device *dev)
 	return err;
 }
 
-const struct can_driver_api can_esp32_twai_driver_api = {
+static DEVICE_API(can, can_esp32_twai_driver_api) = {
 	.get_capabilities = can_sja1000_get_capabilities,
 	.start = can_sja1000_start,
 	.stop = can_sja1000_stop,

--- a/drivers/can/can_fake.c
+++ b/drivers/can/can_fake.c
@@ -103,7 +103,7 @@ static int fake_can_init(const struct device *dev)
 	return 0;
 }
 
-static const struct can_driver_api fake_can_driver_api = {
+static DEVICE_API(can, fake_can_driver_api) = {
 	.start = fake_can_start,
 	.stop = fake_can_stop,
 	.get_capabilities = fake_can_get_capabilities,

--- a/drivers/can/can_kvaser_pci.c
+++ b/drivers/can/can_kvaser_pci.c
@@ -130,7 +130,7 @@ static int can_kvaser_pci_init(const struct device *dev)
 	return 0;
 }
 
-const struct can_driver_api can_kvaser_pci_driver_api = {
+DEVICE_API(can, can_kvaser_pci_driver_api) = {
 	.get_capabilities = can_sja1000_get_capabilities,
 	.start = can_sja1000_start,
 	.stop = can_sja1000_stop,

--- a/drivers/can/can_loopback.c
+++ b/drivers/can/can_loopback.c
@@ -365,7 +365,7 @@ static int can_loopback_get_max_filters(const struct device *dev, bool ide)
 	return CONFIG_CAN_MAX_FILTER;
 }
 
-static const struct can_driver_api can_loopback_driver_api = {
+static DEVICE_API(can, can_loopback_driver_api) = {
 	.get_capabilities = can_loopback_get_capabilities,
 	.start = can_loopback_start,
 	.stop = can_loopback_stop,

--- a/drivers/can/can_mcp2515.c
+++ b/drivers/can/can_mcp2515.c
@@ -877,7 +877,7 @@ static void mcp2515_int_gpio_callback(const struct device *dev,
 	k_sem_give(&dev_data->int_sem);
 }
 
-static const struct can_driver_api can_api_funcs = {
+static DEVICE_API(can, can_api_funcs) = {
 	.get_capabilities = mcp2515_get_capabilities,
 	.set_timing = mcp2515_set_timing,
 	.start = mcp2515_start,

--- a/drivers/can/can_mcp251xfd.c
+++ b/drivers/can/can_mcp251xfd.c
@@ -1682,7 +1682,7 @@ static int mcp251xfd_init(const struct device *dev)
 	return ret;
 }
 
-static const struct can_driver_api mcp251xfd_api_funcs = {
+static DEVICE_API(can, mcp251xfd_api_funcs) = {
 	.get_capabilities = mcp251xfd_get_capabilities,
 	.set_mode = mcp251xfd_set_mode,
 	.set_timing = mcp251xfd_set_timing,

--- a/drivers/can/can_mcux_flexcan.c
+++ b/drivers/can/can_mcux_flexcan.c
@@ -1257,7 +1257,7 @@ static int mcux_flexcan_init(const struct device *dev)
 	return 0;
 }
 
-__maybe_unused static const struct can_driver_api mcux_flexcan_driver_api = {
+static __maybe_unused DEVICE_API(can, mcux_flexcan_driver_api) = {
 	.get_capabilities = mcux_flexcan_get_capabilities,
 	.start = mcux_flexcan_start,
 	.stop = mcux_flexcan_stop,
@@ -1299,7 +1299,7 @@ __maybe_unused static const struct can_driver_api mcux_flexcan_driver_api = {
 };
 
 #ifdef CONFIG_CAN_MCUX_FLEXCAN_FD
-static const struct can_driver_api mcux_flexcan_fd_driver_api = {
+static DEVICE_API(can, mcux_flexcan_fd_driver_api) = {
 	.get_capabilities = mcux_flexcan_get_capabilities,
 	.start = mcux_flexcan_start,
 	.stop = mcux_flexcan_stop,

--- a/drivers/can/can_mcux_mcan.c
+++ b/drivers/can/can_mcux_mcan.c
@@ -135,7 +135,7 @@ static int mcux_mcan_init(const struct device *dev)
 	return 0;
 }
 
-static const struct can_driver_api mcux_mcan_driver_api = {
+static DEVICE_API(can, mcux_mcan_driver_api) = {
 	.get_capabilities = can_mcan_get_capabilities,
 	.start = can_mcan_start,
 	.stop = can_mcan_stop,

--- a/drivers/can/can_native_linux.c
+++ b/drivers/can/can_native_linux.c
@@ -399,7 +399,7 @@ static int can_native_linux_get_max_filters(const struct device *dev, bool ide)
 	return CONFIG_CAN_MAX_FILTER;
 }
 
-static const struct can_driver_api can_native_linux_driver_api = {
+static DEVICE_API(can, can_native_linux_driver_api) = {
 	.start = can_native_linux_start,
 	.stop = can_native_linux_stop,
 	.get_capabilities = can_native_linux_get_capabilities,

--- a/drivers/can/can_nrf.c
+++ b/drivers/can/can_nrf.c
@@ -57,7 +57,7 @@ static int can_nrf_get_core_clock(const struct device *dev, uint32_t *rate)
 	return clock_control_get_rate(config->clock, NULL, rate);
 }
 
-static const struct can_driver_api can_nrf_api = {
+static DEVICE_API(can, can_nrf_api) = {
 	.get_capabilities = can_mcan_get_capabilities,
 	.start = can_mcan_start,
 	.stop = can_mcan_stop,

--- a/drivers/can/can_numaker.c
+++ b/drivers/can/can_numaker.c
@@ -160,7 +160,7 @@ static int can_numaker_init(const struct device *dev)
 	return rc;
 }
 
-static const struct can_driver_api can_numaker_driver_api = {
+static DEVICE_API(can, can_numaker_driver_api) = {
 	.get_capabilities = can_mcan_get_capabilities,
 	.start = can_mcan_start,
 	.stop = can_mcan_stop,

--- a/drivers/can/can_nxp_s32_canxl.c
+++ b/drivers/can/can_nxp_s32_canxl.c
@@ -1080,7 +1080,7 @@ static void can_nxp_s32_isr_error(const struct device *dev)
 	Canexcel_Ip_ErrIRQHandler(config->instance);
 }
 
-static const struct can_driver_api can_nxp_s32_driver_api = {
+static DEVICE_API(can, can_nxp_s32_driver_api) = {
 	.get_capabilities = can_nxp_s32_get_capabilities,
 	.start = can_nxp_s32_start,
 	.stop = can_nxp_s32_stop,

--- a/drivers/can/can_rcar.c
+++ b/drivers/can/can_rcar.c
@@ -1150,7 +1150,7 @@ static int can_rcar_get_max_filters(const struct device *dev, bool ide)
 	return CONFIG_CAN_RCAR_MAX_FILTER;
 }
 
-static const struct can_driver_api can_rcar_driver_api = {
+static DEVICE_API(can, can_rcar_driver_api) = {
 	.get_capabilities = can_rcar_get_capabilities,
 	.start = can_rcar_start,
 	.stop = can_rcar_stop,

--- a/drivers/can/can_renesas_ra.c
+++ b/drivers/can/can_renesas_ra.c
@@ -969,7 +969,7 @@ static int can_renesas_ra_init(const struct device *dev)
 	return 0;
 }
 
-static const struct can_driver_api can_renesas_ra_driver_api = {
+static DEVICE_API(can, can_renesas_ra_driver_api) = {
 	.get_capabilities = can_renesas_ra_get_capabilities,
 	.start = can_renesas_ra_start,
 	.stop = can_renesas_ra_stop,

--- a/drivers/can/can_sam.c
+++ b/drivers/can/can_sam.c
@@ -123,7 +123,7 @@ static int can_sam_init(const struct device *dev)
 	return ret;
 }
 
-static const struct can_driver_api can_sam_driver_api = {
+static DEVICE_API(can, can_sam_driver_api) = {
 	.get_capabilities = can_mcan_get_capabilities,
 	.start = can_mcan_start,
 	.stop = can_mcan_stop,

--- a/drivers/can/can_sam0.c
+++ b/drivers/can/can_sam0.c
@@ -161,7 +161,7 @@ static int can_sam0_init(const struct device *dev)
 	return ret;
 }
 
-static const struct can_driver_api can_sam0_driver_api = {
+static DEVICE_API(can, can_sam0_driver_api) = {
 	.get_capabilities = can_mcan_get_capabilities,
 	.start = can_mcan_start,
 	.stop = can_mcan_stop,

--- a/drivers/can/can_shell.c
+++ b/drivers/can/can_shell.c
@@ -68,6 +68,11 @@ static struct k_poll_event can_shell_rx_msgq_events[] = {
 static void can_shell_tx_msgq_triggered_work_handler(struct k_work *work);
 static void can_shell_rx_msgq_triggered_work_handler(struct k_work *work);
 
+static bool device_is_can_and_ready(const struct device *dev)
+{
+	return device_is_ready(dev) && DEVICE_API_IS(can, dev);
+}
+
 #ifdef CONFIG_CAN_SHELL_SCRIPTING_FRIENDLY
 static void can_shell_dummy_bypass_cb(const struct shell *sh, uint8_t *data, size_t len)
 {
@@ -996,7 +1001,7 @@ static int cmd_can_recover(const struct shell *sh, size_t argc, char **argv)
 
 static void cmd_can_device_name(size_t idx, struct shell_static_entry *entry)
 {
-	const struct device *dev = shell_device_lookup(idx, NULL);
+	const struct device *dev = shell_device_filter(idx, device_is_can_and_ready);
 
 	entry->syntax = (dev != NULL) ? dev->name : NULL;
 	entry->handler = NULL;
@@ -1026,7 +1031,7 @@ static void cmd_can_mode(size_t idx, struct shell_static_entry *entry)
 
 static void cmd_can_device_name_mode(size_t idx, struct shell_static_entry *entry)
 {
-	const struct device *dev = shell_device_lookup(idx, NULL);
+	const struct device *dev = shell_device_filter(idx, device_is_can_and_ready);
 
 	entry->syntax = (dev != NULL) ? dev->name : NULL;
 	entry->handler = NULL;

--- a/drivers/can/can_stm32_bxcan.c
+++ b/drivers/can/can_stm32_bxcan.c
@@ -1063,7 +1063,7 @@ static void can_stm32_remove_rx_filter(const struct device *dev, int filter_id)
 	k_mutex_unlock(&filter_mutex);
 }
 
-static const struct can_driver_api can_api_funcs = {
+static DEVICE_API(can, can_api_funcs) = {
 	.get_capabilities = can_stm32_get_capabilities,
 	.start = can_stm32_start,
 	.stop = can_stm32_stop,

--- a/drivers/can/can_stm32_fdcan.c
+++ b/drivers/can/can_stm32_fdcan.c
@@ -507,7 +507,7 @@ static int can_stm32fd_init(const struct device *dev)
 	return ret;
 }
 
-static const struct can_driver_api can_stm32fd_driver_api = {
+static DEVICE_API(can, can_stm32fd_driver_api) = {
 	.get_capabilities = can_mcan_get_capabilities,
 	.start = can_mcan_start,
 	.stop = can_mcan_stop,

--- a/drivers/can/can_stm32h7_fdcan.c
+++ b/drivers/can/can_stm32h7_fdcan.c
@@ -194,7 +194,7 @@ static int can_stm32h7_init(const struct device *dev)
 	return 0;
 }
 
-static const struct can_driver_api can_stm32h7_driver_api = {
+static DEVICE_API(can, can_stm32h7_driver_api) = {
 	.get_capabilities = can_mcan_get_capabilities,
 	.start = can_mcan_start,
 	.stop = can_mcan_stop,

--- a/drivers/can/can_tcan4x5x.c
+++ b/drivers/can/can_tcan4x5x.c
@@ -713,7 +713,7 @@ static int tcan4x5x_init(const struct device *dev)
 	return 0;
 }
 
-static const struct can_driver_api tcan4x5x_driver_api = {
+static DEVICE_API(can, tcan4x5x_driver_api) = {
 	.get_capabilities = can_mcan_get_capabilities,
 	.start = can_mcan_start,
 	.stop = can_mcan_stop,

--- a/drivers/can/can_xmc4xxx.c
+++ b/drivers/can/can_xmc4xxx.c
@@ -882,7 +882,7 @@ static int can_xmc4xxx_init(const struct device *dev)
 	return can_set_timing(dev, &timing);
 }
 
-static const struct can_driver_api can_xmc4xxx_api_funcs = {
+static DEVICE_API(can, can_xmc4xxx_api_funcs) = {
 	.get_capabilities = can_xmc4xxx_get_capabilities,
 	.set_mode = can_xmc4xxx_set_mode,
 	.set_timing = can_xmc4xxx_set_timing,

--- a/include/zephyr/drivers/can.h
+++ b/include/zephyr/drivers/can.h
@@ -825,9 +825,9 @@ __syscall int can_get_core_clock(const struct device *dev, uint32_t *rate);
 
 static inline int z_impl_can_get_core_clock(const struct device *dev, uint32_t *rate)
 {
-	const struct can_driver_api *api = (const struct can_driver_api *)dev->api;
+	__ASSERT_NO_MSG(DEVICE_API_IS(can, dev));
 
-	return api->get_core_clock(dev, rate);
+	return DEVICE_API_GET(can, dev)->get_core_clock(dev, rate);
 }
 
 /**
@@ -949,9 +949,9 @@ __syscall const struct can_timing *can_get_timing_min(const struct device *dev);
 
 static inline const struct can_timing *z_impl_can_get_timing_min(const struct device *dev)
 {
-	const struct can_driver_api *api = (const struct can_driver_api *)dev->api;
+	__ASSERT_NO_MSG(DEVICE_API_IS(can, dev));
 
-	return &api->timing_min;
+	return &DEVICE_API_GET(can, dev)->timing_min;
 }
 
 /**
@@ -965,9 +965,9 @@ __syscall const struct can_timing *can_get_timing_max(const struct device *dev);
 
 static inline const struct can_timing *z_impl_can_get_timing_max(const struct device *dev)
 {
-	const struct can_driver_api *api = (const struct can_driver_api *)dev->api;
+	__ASSERT_NO_MSG(DEVICE_API_IS(can, dev));
 
-	return &api->timing_max;
+	return &DEVICE_API_GET(can, dev)->timing_max;
 }
 
 /**
@@ -1017,9 +1017,9 @@ __syscall const struct can_timing *can_get_timing_data_min(const struct device *
 #ifdef CONFIG_CAN_FD_MODE
 static inline const struct can_timing *z_impl_can_get_timing_data_min(const struct device *dev)
 {
-	const struct can_driver_api *api = (const struct can_driver_api *)dev->api;
+	__ASSERT_NO_MSG(DEVICE_API_IS(can, dev));
 
-	return &api->timing_data_min;
+	return &DEVICE_API_GET(can, dev)->timing_data_min;
 }
 #endif /* CONFIG_CAN_FD_MODE */
 
@@ -1041,9 +1041,9 @@ __syscall const struct can_timing *can_get_timing_data_max(const struct device *
 #ifdef CONFIG_CAN_FD_MODE
 static inline const struct can_timing *z_impl_can_get_timing_data_max(const struct device *dev)
 {
-	const struct can_driver_api *api = (const struct can_driver_api *)dev->api;
+	__ASSERT_NO_MSG(DEVICE_API_IS(can, dev));
 
-	return &api->timing_data_max;
+	return &DEVICE_API_GET(can, dev)->timing_data_max;
 }
 #endif /* CONFIG_CAN_FD_MODE */
 
@@ -1176,9 +1176,9 @@ __syscall int can_get_capabilities(const struct device *dev, can_mode_t *cap);
 
 static inline int z_impl_can_get_capabilities(const struct device *dev, can_mode_t *cap)
 {
-	const struct can_driver_api *api = (const struct can_driver_api *)dev->api;
+	__ASSERT_NO_MSG(DEVICE_API_IS(can, dev));
 
-	return api->get_capabilities(dev, cap);
+	return DEVICE_API_GET(can, dev)->get_capabilities(dev, cap);
 }
 
 /**
@@ -1220,9 +1220,9 @@ __syscall int can_start(const struct device *dev);
 
 static inline int z_impl_can_start(const struct device *dev)
 {
-	const struct can_driver_api *api = (const struct can_driver_api *)dev->api;
+	__ASSERT_NO_MSG(DEVICE_API_IS(can, dev));
 
-	return api->start(dev);
+	return DEVICE_API_GET(can, dev)->start(dev);
 }
 
 /**
@@ -1244,9 +1244,9 @@ __syscall int can_stop(const struct device *dev);
 
 static inline int z_impl_can_stop(const struct device *dev)
 {
-	const struct can_driver_api *api = (const struct can_driver_api *)dev->api;
+	__ASSERT_NO_MSG(DEVICE_API_IS(can, dev));
 
-	return api->stop(dev);
+	return DEVICE_API_GET(can, dev)->stop(dev);
 }
 
 /**
@@ -1263,9 +1263,9 @@ __syscall int can_set_mode(const struct device *dev, can_mode_t mode);
 
 static inline int z_impl_can_set_mode(const struct device *dev, can_mode_t mode)
 {
-	const struct can_driver_api *api = (const struct can_driver_api *)dev->api;
+	__ASSERT_NO_MSG(DEVICE_API_IS(can, dev));
 
-	return api->set_mode(dev, mode);
+	return DEVICE_API_GET(can, dev)->set_mode(dev, mode);
 }
 
 /**
@@ -1456,9 +1456,9 @@ __syscall void can_remove_rx_filter(const struct device *dev, int filter_id);
 
 static inline void z_impl_can_remove_rx_filter(const struct device *dev, int filter_id)
 {
-	const struct can_driver_api *api = (const struct can_driver_api *)dev->api;
+	__ASSERT_NO_MSG(DEVICE_API_IS(can, dev));
 
-	api->remove_rx_filter(dev, filter_id);
+	DEVICE_API_GET(can, dev)->remove_rx_filter(dev, filter_id);
 }
 
 /**
@@ -1478,13 +1478,13 @@ __syscall int can_get_max_filters(const struct device *dev, bool ide);
 
 static inline int z_impl_can_get_max_filters(const struct device *dev, bool ide)
 {
-	const struct can_driver_api *api = (const struct can_driver_api *)dev->api;
+	__ASSERT_NO_MSG(DEVICE_API_IS(can, dev));
 
-	if (api->get_max_filters == NULL) {
+	if (DEVICE_API_GET(can, dev)->get_max_filters == NULL) {
 		return -ENOSYS;
 	}
 
-	return api->get_max_filters(dev, ide);
+	return DEVICE_API_GET(can, dev)->get_max_filters(dev, ide);
 }
 
 /** @} */
@@ -1514,9 +1514,9 @@ __syscall int can_get_state(const struct device *dev, enum can_state *state,
 static inline int z_impl_can_get_state(const struct device *dev, enum can_state *state,
 				       struct can_bus_err_cnt *err_cnt)
 {
-	const struct can_driver_api *api = (const struct can_driver_api *)dev->api;
+	__ASSERT_NO_MSG(DEVICE_API_IS(can, dev));
 
-	return api->get_state(dev, state, err_cnt);
+	return DEVICE_API_GET(can, dev)->get_state(dev, state, err_cnt);
 }
 
 /**
@@ -1541,13 +1541,13 @@ __syscall int can_recover(const struct device *dev, k_timeout_t timeout);
 #ifdef CONFIG_CAN_MANUAL_RECOVERY_MODE
 static inline int z_impl_can_recover(const struct device *dev, k_timeout_t timeout)
 {
-	const struct can_driver_api *api = (const struct can_driver_api *)dev->api;
+	__ASSERT_NO_MSG(DEVICE_API_IS(can, dev));
 
-	if (api->recover == NULL) {
+	if (DEVICE_API_GET(can, dev)->recover == NULL) {
 		return -ENOSYS;
 	}
 
-	return api->recover(dev, timeout);
+	return DEVICE_API_GET(can, dev)->recover(dev, timeout);
 }
 #endif /* CONFIG_CAN_MANUAL_RECOVERY_MODE */
 
@@ -1568,9 +1568,9 @@ static inline void can_set_state_change_callback(const struct device *dev,
 						 can_state_change_callback_t callback,
 						 void *user_data)
 {
-	const struct can_driver_api *api = (const struct can_driver_api *)dev->api;
+	__ASSERT_NO_MSG(DEVICE_API_IS(can, dev));
 
-	api->set_state_change_callback(dev, callback, user_data);
+	DEVICE_API_GET(can, dev)->set_state_change_callback(dev, callback, user_data);
 }
 
 /** @} */


### PR DESCRIPTION
Add wrapper DEVICE_API macro to all can_driver_api instances.

Also, check that device passed to CAN shell is a can device.