### PR TITLE
manifest: Update nRF hw models to latest

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -305,7 +305,7 @@ manifest:
       groups:
         - tools
     - name: nrf_hw_models
-      revision: 3cfca0192ff84da919e9bc7978bcc2239cd6a395
+      revision: fbc6e614686b69dfa56f9694350b9488cf83d3f7
       path: modules/bsim_hw_models/nrf_hw_models
     - name: nrf_wifi
       revision: f9e2abdb70761003912b1b929a37b536f68a91da


### PR DESCRIPTION
Update the HW models module to:
fbc6e614686b69dfa56f9694350b9488cf83d3f7

Including the following:

- fbc6e61 HW models: Fix a few Wextra warnings
- b164f15 nrfx replacements: Fix a few Wextra warnings
- 1f02d3b UART 54: Correct UART22 name
- 3172fdb UART(E): Add new pty backend
- 3015405 UARTE FIFO backend: Fix comment and typos
- c29727a doc: UARTE is now implemented for 54L
- 64d9cdf 54 UARTE: Add support for Address bit and configurable data size
- 3745647 UART: FIFO backend ignore irrelevant CONFIG bits 
- 3a20c98 54 UARTE: Add MATCH functionality
- bceda1b Int controller: Provide logic similar to SEVONPEND bit 
- e66584f Makefile: Add variable to pass arbitrary build options