### PR TITLE
drivers: interrupt_controller: Place API into iterable section

### DIFF
--- a/drivers/interrupt_controller/intc_gicv3_its.c
+++ b/drivers/interrupt_controller/intc_gicv3_its.c
@@ -655,7 +655,7 @@ static int gicv3_its_init(const struct device *dev)
 	return 0;
 }
 
-struct its_driver_api gicv3_its_api = {
+DEVICE_API(its, gicv3_its_api) = {
 	.alloc_intid = gicv3_its_alloc_intid,
 	.setup_deviceid = gicv3_its_init_device_id,
 	.map_intid = gicv3_its_map_intid,


### PR DESCRIPTION
Commit https://github.com/zephyrproject-rtos/zephyr/commit/e63c6cd5349aafb03e2cc47f874e5e3380a7140b introduced device API
macros to be used by driver implementations. The DEVICE_API macro
ensures the passed API instance is placed in the corresponding iterable
section to allow for runtime checks.

Add wrapper DEVICE_API macro to all its_driver_api instances.