### PR TITLE
samples: dumb_http_server: Fix dead "Zephyr About page" href

### DIFF
--- a/samples/net/sockets/dumb_http_server/src/response_big.html.bin
+++ b/samples/net/sockets/dumb_http_server/src/response_big.html.bin
@@ -15,7 +15,7 @@ body {
 
 <p style="color: red">
 Warning: this is a content sample. Proceed to
-<a href="https://www.zephyrproject.org/about/what-is-zephyr-project">Zephyr About page</a>
+<a href="https://www.zephyrproject.org/learn-about">Zephyr About page</a>
 for up to date information.
 </p>
 

--- a/samples/net/sockets/dumb_http_server_mt/src/response_100k.html.bin
+++ b/samples/net/sockets/dumb_http_server_mt/src/response_100k.html.bin
@@ -15,7 +15,7 @@ body {
 
 <p style="color: red">
 Warning: this is a content sample. Proceed to
-<a href="https://www.zephyrproject.org/about/what-is-zephyr-project">Zephyr About page</a>
+<a href="https://www.zephyrproject.org/learn-about">Zephyr About page</a>
 for up to date information.
 </p>
 

--- a/samples/net/sockets/dumb_http_server_mt/src/response_big.html.bin
+++ b/samples/net/sockets/dumb_http_server_mt/src/response_big.html.bin
@@ -15,7 +15,7 @@ body {
 
 <p style="color: red">
 Warning: this is a content sample. Proceed to
-<a href="https://www.zephyrproject.org/about/what-is-zephyr-project">Zephyr About page</a>
+<a href="https://www.zephyrproject.org/learn-about">Zephyr About page</a>
 for up to date information.
 </p>
 


### PR DESCRIPTION
Update href for 'Zephyr About page' in the `dumb_http_server` sample to the correct URL.