### PR TITLE
drivers: led: Place API into iterable section

### DIFF
--- a/drivers/led/ht16k33.c
+++ b/drivers/led/ht16k33.c
@@ -415,7 +415,7 @@ static int ht16k33_init(const struct device *dev)
 	return 0;
 }
 
-static const struct led_driver_api ht16k33_leds_api = {
+static DEVICE_API(led, ht16k33_leds_api) = {
 	.blink = ht16k33_led_blink,
 	.set_brightness = ht16k33_led_set_brightness,
 	.on = ht16k33_led_on,

--- a/drivers/led/is31fl3194.c
+++ b/drivers/led/is31fl3194.c
@@ -313,7 +313,7 @@ static int is31fl3194_init(const struct device *dev)
 	return i2c_reg_write_byte_dt(&config->bus, IS31FL3194_CONF_REG, IS31FL3194_CONF_ENABLE);
 }
 
-static const struct led_driver_api is31fl3194_led_api = {
+static DEVICE_API(led, is31fl3194_led_api) = {
 	.set_brightness = is31fl3194_set_brightness,
 	.on = is31fl3194_led_on,
 	.off = is31fl3194_led_off,

--- a/drivers/led/is31fl3216a.c
+++ b/drivers/led/is31fl3216a.c
@@ -222,7 +222,7 @@ static int is31fl3216a_init(const struct device *dev)
 	return is31fl3216a_init_registers(&config->i2c);
 }
 
-static const struct led_driver_api is31fl3216a_led_api = {
+static DEVICE_API(led, is31fl3216a_led_api) = {
 	.set_brightness = is31fl3216a_led_set_brightness,
 	.on = is31fl3216a_led_on,
 	.off = is31fl3216a_led_off,

--- a/drivers/led/is31fl3733.c
+++ b/drivers/led/is31fl3733.c
@@ -275,7 +275,7 @@ int is31fl3733_current_limit(const struct device *dev, uint8_t limit)
 	return i2c_reg_write_byte_dt(&config->bus, GLOBAL_CURRENT_CTRL_REG, limit);
 }
 
-static const struct led_driver_api is31fl3733_api = {
+static DEVICE_API(led, is31fl3733_api) = {
 	.on = is31fl3733_led_on,
 	.off = is31fl3733_led_off,
 	.set_brightness = is31fl3733_led_set_brightness,

--- a/drivers/led/led_gpio.c
+++ b/drivers/led/led_gpio.c
@@ -77,7 +77,7 @@ static int led_gpio_init(const struct device *dev)
 	return err;
 }
 
-static const struct led_driver_api led_gpio_api = {
+static DEVICE_API(led, led_gpio_api) = {
 	.on		= led_gpio_on,
 	.off		= led_gpio_off,
 	.set_brightness	= led_gpio_set_brightness,

--- a/drivers/led/led_mchp_xec.c
+++ b/drivers/led/led_mchp_xec.c
@@ -258,7 +258,7 @@ static int xec_bbled_init(const struct device *dev)
 	return ret;
 }
 
-static const struct led_driver_api xec_bbled_api = {
+static DEVICE_API(led, xec_bbled_api) = {
 	.on		= xec_bbled_on,
 	.off		= xec_bbled_off,
 	.blink		= xec_bbled_blink,

--- a/drivers/led/led_npm1300.c
+++ b/drivers/led/led_npm1300.c
@@ -62,7 +62,7 @@ static int led_npm1300_off(const struct device *dev, uint32_t led)
 				     1U);
 }
 
-static const struct led_driver_api led_npm1300_api = {
+static DEVICE_API(led, led_npm1300_api) = {
 	.on = led_npm1300_on,
 	.off = led_npm1300_off,
 };

--- a/drivers/led/led_pwm.c
+++ b/drivers/led/led_pwm.c
@@ -124,7 +124,7 @@ static int led_pwm_pm_action(const struct device *dev,
 }
 #endif /* CONFIG_PM_DEVICE */
 
-static const struct led_driver_api led_pwm_api = {
+static DEVICE_API(led, led_pwm_api) = {
 	.on		= led_pwm_on,
 	.off		= led_pwm_off,
 	.blink		= led_pwm_blink,

--- a/drivers/led/led_shell.c
+++ b/drivers/led/led_shell.c
@@ -330,9 +330,14 @@ cmd_write_channels(const struct shell *sh, size_t argc, char **argv)
 	return err;
 }
 
+static bool device_is_led_and_ready(const struct device *dev)
+{
+	return device_is_ready(dev) && DEVICE_API_IS(led, dev);
+}
+
 static void device_name_get(size_t idx, struct shell_static_entry *entry)
 {
-	const struct device *dev = shell_device_lookup(idx, NULL);
+	const struct device *dev = shell_device_filter(idx, device_is_led_and_ready);
 
 	entry->syntax = (dev != NULL) ? dev->name : NULL;
 	entry->handler = NULL;

--- a/drivers/led/lp3943.c
+++ b/drivers/led/lp3943.c
@@ -275,7 +275,7 @@ static const struct lp3943_config lp3943_led_config = {
 	.bus = I2C_DT_SPEC_INST_GET(0),
 };
 
-static const struct led_driver_api lp3943_led_api = {
+static DEVICE_API(led, lp3943_led_api) = {
 	.blink = lp3943_led_blink,
 	.set_brightness = lp3943_led_set_brightness,
 	.on = lp3943_led_on,

--- a/drivers/led/lp50xx.c
+++ b/drivers/led/lp50xx.c
@@ -338,7 +338,7 @@ static int lp50xx_pm_action(const struct device *dev,
 }
 #endif /* CONFIG_PM_DEVICE */
 
-static const struct led_driver_api lp50xx_led_api = {
+static DEVICE_API(led, lp50xx_led_api) = {
 	.on		= lp50xx_on,
 	.off		= lp50xx_off,
 	.get_info	= lp50xx_get_info,

--- a/drivers/led/lp5562.c
+++ b/drivers/led/lp5562.c
@@ -1068,7 +1068,7 @@ static int lp5562_led_init(const struct device *dev)
 	return 0;
 }
 
-static const struct led_driver_api lp5562_led_api = {
+static DEVICE_API(led, lp5562_led_api) = {
 	.blink = lp5562_led_blink,
 	.set_brightness = lp5562_led_set_brightness,
 	.on = lp5562_led_on,

--- a/drivers/led/lp5569.c
+++ b/drivers/led/lp5569.c
@@ -183,7 +183,7 @@ static int lp5569_pm_action(const struct device *dev, enum pm_device_action acti
 }
 #endif /* CONFIG_PM_DEVICE */
 
-static const struct led_driver_api lp5569_led_api = {
+static DEVICE_API(led, lp5569_led_api) = {
 	.set_brightness = lp5569_led_set_brightness,
 	.on = lp5569_led_on,
 	.off = lp5569_led_off,

--- a/drivers/led/ncp5623.c
+++ b/drivers/led/ncp5623.c
@@ -184,7 +184,7 @@ static int ncp5623_led_init(const struct device *dev)
 	return 0;
 }
 
-static const struct led_driver_api ncp5623_led_api = {
+static DEVICE_API(led, ncp5623_led_api) = {
 	.set_brightness = ncp5623_set_brightness,
 	.on = ncp5623_led_on,
 	.off = ncp5623_led_off,

--- a/drivers/led/pca9633.c
+++ b/drivers/led/pca9633.c
@@ -216,7 +216,7 @@ static int pca9633_led_init(const struct device *dev)
 	return 0;
 }
 
-static const struct led_driver_api pca9633_led_api = {
+static DEVICE_API(led, pca9633_led_api) = {
 	.blink = pca9633_led_blink,
 	.set_brightness = pca9633_led_set_brightness,
 	.on = pca9633_led_on,

--- a/drivers/led/tlc59108.c
+++ b/drivers/led/tlc59108.c
@@ -208,7 +208,7 @@ static int tlc59108_led_init(const struct device *dev)
 	return 0;
 }
 
-static const struct led_driver_api tlc59108_led_api = {
+static DEVICE_API(led, tlc59108_led_api) = {
 	.blink = tlc59108_led_blink,
 	.set_brightness = tlc59108_led_set_brightness,
 	.on = tlc59108_led_on,

--- a/drivers/sensor/grow_r502a/grow_r502a.c
+++ b/drivers/sensor/grow_r502a/grow_r502a.c
@@ -1218,7 +1218,7 @@ static int grow_r502a_led_off(const struct device *dev, uint32_t led)
 	return fps_led_control(dev, &led_ctrl);
 }
 
-static const struct led_driver_api grow_r502a_leds_api = {
+static DEVICE_API(led, grow_r502a_leds_api) = {
 	.set_color = grow_r502a_led_set_color,
 	.on = grow_r502a_led_on,
 	.off = grow_r502a_led_off,


### PR DESCRIPTION
Add wrapper DEVICE_API macro to all led_driver_api instances.