### PR TITLE
drivers: led_strip: Place API into iterable section

### DIFF
--- a/drivers/led_strip/apa102.c
+++ b/drivers/led_strip/apa102.c
@@ -92,7 +92,7 @@ static int apa102_init(const struct device *dev)
 	return 0;
 }
 
-static const struct led_strip_driver_api apa102_api = {
+static DEVICE_API(led_strip, apa102_api) = {
 	.update_rgb = apa102_update_rgb,
 	.length = apa102_length,
 };

--- a/drivers/led_strip/lpd880x.c
+++ b/drivers/led_strip/lpd880x.c
@@ -150,7 +150,7 @@ static const struct lpd880x_config lpd880x_config = {
 	.length = DT_INST_PROP(0, chain_length),
 };
 
-static const struct led_strip_driver_api lpd880x_strip_api = {
+static DEVICE_API(led_strip, lpd880x_strip_api) = {
 	.update_rgb = lpd880x_strip_update_rgb,
 	.update_channels = lpd880x_strip_update_channels,
 	.length = lpd880x_strip_length,

--- a/drivers/led_strip/tlc5971.c
+++ b/drivers/led_strip/tlc5971.c
@@ -322,7 +322,7 @@ static int tlc5971_init(const struct device *dev)
 	return 0;
 }
 
-static const struct led_strip_driver_api tlc5971_api = {
+static DEVICE_API(led_strip, tlc5971_api) = {
 	.update_rgb = tlc5971_update_rgb,
 	.length = tlc5971_length,
 };

--- a/drivers/led_strip/tlc59731.c
+++ b/drivers/led_strip/tlc59731.c
@@ -139,7 +139,7 @@ static size_t tlc59731_length(const struct device *dev)
 	return config->length;
 }
 
-static const struct led_strip_driver_api tlc59731_gpio_api = {
+static DEVICE_API(led_strip, tlc59731_gpio_api) = {
 	.update_rgb = tlc59731_gpio_update_rgb,
 	.length = tlc59731_length,
 };

--- a/drivers/led_strip/ws2812_gpio.c
+++ b/drivers/led_strip/ws2812_gpio.c
@@ -172,7 +172,7 @@ static size_t ws2812_gpio_length(const struct device *dev)
 	return config->length;
 }
 
-static const struct led_strip_driver_api ws2812_gpio_api = {
+static DEVICE_API(led_strip, ws2812_gpio_api) = {
 	.update_rgb = ws2812_gpio_update_rgb,
 	.length = ws2812_gpio_length,
 };

--- a/drivers/led_strip/ws2812_i2s.c
+++ b/drivers/led_strip/ws2812_i2s.c
@@ -216,7 +216,7 @@ static int ws2812_i2s_init(const struct device *dev)
 	return 0;
 }
 
-static const struct led_strip_driver_api ws2812_i2s_api = {
+static DEVICE_API(led_strip, ws2812_i2s_api) = {
 	.update_rgb = ws2812_strip_update_rgb,
 	.length = ws2812_strip_length,
 };

--- a/drivers/led_strip/ws2812_rpi_pico_pio.c
+++ b/drivers/led_strip/ws2812_rpi_pico_pio.c
@@ -116,7 +116,7 @@ static size_t ws2812_led_strip_length(const struct device *dev)
 	return config->length;
 }
 
-static const struct led_strip_driver_api ws2812_led_strip_api = {
+static DEVICE_API(led_strip, ws2812_led_strip_api) = {
 	.update_rgb = ws2812_led_strip_update_rgb,
 	.length = ws2812_led_strip_length,
 };

--- a/drivers/led_strip/ws2812_spi.c
+++ b/drivers/led_strip/ws2812_spi.c
@@ -169,7 +169,7 @@ static int ws2812_spi_init(const struct device *dev)
 	return 0;
 }
 
-static const struct led_strip_driver_api ws2812_spi_api = {
+static DEVICE_API(led_strip, ws2812_spi_api) = {
 	.update_rgb = ws2812_strip_update_rgb,
 	.length = ws2812_strip_length,
 };


### PR DESCRIPTION
Add wrapper DEVICE_API macro to all led_strip_driver_api instances.