### PR TITLE
soc: nordic: enable DPPI and PPIB nodes by default

### DIFF
--- a/drivers/serial/Kconfig.nrfx_uart_instance
+++ b/drivers/serial/Kconfig.nrfx_uart_instance
@@ -20,7 +20,7 @@ config UART_$(nrfx_uart_num)_ASYNC
 
 config UART_$(nrfx_uart_num)_ENHANCED_POLL_OUT
 	bool "Efficient poll out on port $(nrfx_uart_num)"
-	depends on !$(dt_nodelabel_has_prop,uart$(nrfx_uart_num),short-endtx-stoptx)
+	depends on !$(dt_nodelabel_has_prop,uart$(nrfx_uart_num),endtx-stoptx-supported)
 	default y
 	depends on HAS_HW_NRF_UARTE$(nrfx_uart_num)
 	depends on HAS_HW_NRF_PPI || HAS_HW_NRF_DPPIC

--- a/dts/arm/nordic/nrf54l20_enga_cpuapp.dtsi
+++ b/dts/arm/nordic/nrf54l20_enga_cpuapp.dtsi
@@ -40,3 +40,51 @@ nvic: &cpuapp_nvic {};
 &gpiote30 {
 	interrupts = <269 NRF_DEFAULT_IRQ_PRIORITY>;
 };
+
+&dppic00 {
+	status = "okay";
+};
+
+&dppic10 {
+	status = "okay";
+};
+
+&dppic20 {
+	status = "okay";
+};
+
+&dppic30 {
+	status = "okay";
+};
+
+&ppib00 {
+	status = "okay";
+};
+
+&ppib01 {
+	status = "okay";
+};
+
+&ppib10 {
+	status = "okay";
+};
+
+&ppib11 {
+	status = "okay";
+};
+
+&ppib20 {
+	status = "okay";
+};
+
+&ppib21 {
+	status = "okay";
+};
+
+&ppib22 {
+	status = "okay";
+};
+
+&ppib30 {
+	status = "okay";
+};

--- a/dts/arm/nordic/nrf54l_05_10_15_cpuapp.dtsi
+++ b/dts/arm/nordic/nrf54l_05_10_15_cpuapp.dtsi
@@ -84,3 +84,51 @@ nvic: &cpuapp_nvic {};
 	interrupts = <269 NRF_DEFAULT_IRQ_PRIORITY>;
 #endif
 };
+
+&dppic00 {
+	status = "okay";
+};
+
+&dppic10 {
+	status = "okay";
+};
+
+&dppic20 {
+	status = "okay";
+};
+
+&dppic30 {
+	status = "okay";
+};
+
+&ppib00 {
+	status = "okay";
+};
+
+&ppib01 {
+	status = "okay";
+};
+
+&ppib10 {
+	status = "okay";
+};
+
+&ppib11 {
+	status = "okay";
+};
+
+&ppib20 {
+	status = "okay";
+};
+
+&ppib21 {
+	status = "okay";
+};
+
+&ppib22 {
+	status = "okay";
+};
+
+&ppib30 {
+	status = "okay";
+};


### PR DESCRIPTION
The DPPI and PPIB peripheral nodes must be enabled to allow the CONFIG_HAS_HW_NRF_DPPIC to be set. This change is consistent with what was done on nRF5340 and does not introduce any additional memory overhead, because there is no Zephyr driver behind the nrf-dppic and nrf-ppib bindings.