### PR TITLE
include: zephyr: sys: util: Add type check for macro DIV_ROUND_CLOSEST

### DIFF
--- a/include/zephyr/sys/util.h
+++ b/include/zephyr/sys/util.h
@@ -366,9 +366,10 @@ extern "C" {
  *
  * @return The result of @p n / @p d, rounded to the nearest integer.
  */
-#define DIV_ROUND_CLOSEST(n, d)	\
-	((((n) < 0) ^ ((d) < 0)) ? ((n) - ((d) / 2)) / (d) : \
-	((n) + ((d) / 2)) / (d))
+#define DIV_ROUND_CLOSEST(n, d)                                                                    \
+	(((((__typeof__(n))-1) < 0) && (((__typeof__(d))-1) < 0) && ((n) < 0) ^ ((d) < 0))         \
+		 ? ((n) - ((d) / 2)) / (d)                                                         \
+		 : ((n) + ((d) / 2)) / (d))
 
 #ifndef MAX
 /**


### PR DESCRIPTION
Add type check to avoid comparing unsigned values with 0 which is always true or false and can cause coverity issue.

Fix #81936 