### PR TITLE
drivers: spi: Place API into iterable section

### DIFF
--- a/drivers/spi/spi_ambiq_bleif.c
+++ b/drivers/spi/spi_ambiq_bleif.c
@@ -159,7 +159,7 @@ static int spi_ambiq_release(const struct device *dev, const struct spi_config *
 	return 0;
 }
 
-static struct spi_driver_api spi_ambiq_driver_api = {
+static DEVICE_API(spi, spi_ambiq_driver_api) = {
 	.transceive = spi_ambiq_transceive,
 #ifdef CONFIG_SPI_RTIO
 	.iodev_submit = spi_rtio_iodev_default_submit,

--- a/drivers/spi/spi_ambiq_spic.c
+++ b/drivers/spi/spi_ambiq_spic.c
@@ -417,7 +417,7 @@ static int spi_ambiq_release(const struct device *dev, const struct spi_config *
 	return 0;
 }
 
-static const struct spi_driver_api spi_ambiq_driver_api = {
+static DEVICE_API(spi, spi_ambiq_driver_api) = {
 	.transceive = spi_ambiq_transceive,
 #ifdef CONFIG_SPI_RTIO
 	.iodev_submit = spi_rtio_iodev_default_submit,

--- a/drivers/spi/spi_ambiq_spid.c
+++ b/drivers/spi/spi_ambiq_spid.c
@@ -325,7 +325,7 @@ static int spi_ambiq_release(const struct device *dev, const struct spi_config *
 	return 0;
 }
 
-static const struct spi_driver_api spi_ambiq_driver_api = {
+static DEVICE_API(spi, spi_ambiq_driver_api) = {
 	.transceive = spi_ambiq_transceive,
 	.release = spi_ambiq_release,
 };

--- a/drivers/spi/spi_andes_atcspi200.c
+++ b/drivers/spi/spi_andes_atcspi200.c
@@ -739,7 +739,7 @@ int spi_atcspi200_init(const struct device *dev)
 	return 0;
 }
 
-static const struct spi_driver_api spi_atcspi200_api = {
+static DEVICE_API(spi, spi_atcspi200_api) = {
 	.transceive = spi_atcspi200_transceive,
 #ifdef CONFIG_SPI_ASYNC
 	.transceive_async = spi_atcspi200_transceive_async,

--- a/drivers/spi/spi_b91.c
+++ b/drivers/spi/spi_b91.c
@@ -453,7 +453,7 @@ static int spi_b91_release(const struct device *dev,
 }
 
 /* SPI driver APIs structure */
-static const struct spi_driver_api spi_b91_api = {
+static DEVICE_API(spi, spi_b91_api) = {
 	.transceive = spi_b91_transceive,
 	.release = spi_b91_release,
 #ifdef CONFIG_SPI_ASYNC

--- a/drivers/spi/spi_b_renesas_ra8.c
+++ b/drivers/spi/spi_b_renesas_ra8.c
@@ -400,7 +400,7 @@ static int ra_spi_b_release(const struct device *dev, const struct spi_config *c
 	return 0;
 }
 
-static const struct spi_driver_api ra_spi_driver_api = {.transceive = ra_spi_b_transceive,
+static DEVICE_API(spi, ra_spi_driver_api) = {.transceive = ra_spi_b_transceive,
 #ifdef CONFIG_SPI_ASYNC
 							.transceive_async =
 								ra_spi_b_transceive_async,

--- a/drivers/spi/spi_bitbang.c
+++ b/drivers/spi/spi_bitbang.c
@@ -249,7 +249,7 @@ int spi_bitbang_release(const struct device *dev,
 	return 0;
 }
 
-static const struct spi_driver_api spi_bitbang_api = {
+static DEVICE_API(spi, spi_bitbang_api) = {
 	.transceive = spi_bitbang_transceive,
 	.release = spi_bitbang_release,
 #ifdef CONFIG_SPI_ASYNC

--- a/drivers/spi/spi_cc13xx_cc26xx.c
+++ b/drivers/spi/spi_cc13xx_cc26xx.c
@@ -235,7 +235,7 @@ static int spi_cc13xx_cc26xx_pm_action(const struct device *dev,
 #endif /* CONFIG_PM_DEVICE */
 
 
-static const struct spi_driver_api spi_cc13xx_cc26xx_driver_api = {
+static DEVICE_API(spi, spi_cc13xx_cc26xx_driver_api) = {
 	.transceive = spi_cc13xx_cc26xx_transceive,
 	.release = spi_cc13xx_cc26xx_release,
 #ifdef CONFIG_SPI_RTIO

--- a/drivers/spi/spi_dw.c
+++ b/drivers/spi/spi_dw.c
@@ -525,7 +525,7 @@ out:
 	completed(dev, error);
 }
 
-static const struct spi_driver_api dw_spi_api = {
+static DEVICE_API(spi, dw_spi_api) = {
 	.transceive = spi_dw_transceive,
 #ifdef CONFIG_SPI_ASYNC
 	.transceive_async = spi_dw_transceive_async,

--- a/drivers/spi/spi_emul.c
+++ b/drivers/spi/spi_emul.c
@@ -130,7 +130,7 @@ int spi_emul_register(const struct device *dev, struct spi_emul *emul)
 
 /* Device instantiation */
 
-static const struct spi_driver_api spi_emul_api = {
+static DEVICE_API(spi, spi_emul_api) = {
 	.transceive = spi_emul_io,
 #ifdef CONFIG_SPI_RTIO
 	.iodev_submit = spi_rtio_iodev_default_submit,

--- a/drivers/spi/spi_esp32_spim.c
+++ b/drivers/spi/spi_esp32_spim.c
@@ -500,7 +500,7 @@ static int spi_esp32_release(const struct device *dev,
 	return 0;
 }
 
-static const struct spi_driver_api spi_api = {
+static DEVICE_API(spi, spi_api) = {
 	.transceive = spi_esp32_transceive,
 #ifdef CONFIG_SPI_ASYNC
 	.transceive_async = spi_esp32_transceive_async,

--- a/drivers/spi/spi_gd32.c
+++ b/drivers/spi/spi_gd32.c
@@ -570,7 +570,7 @@ static int spi_gd32_release(const struct device *dev,
 	return 0;
 }
 
-static const struct spi_driver_api spi_gd32_driver_api = {
+static DEVICE_API(spi, spi_gd32_driver_api) = {
 	.transceive = spi_gd32_transceive,
 #ifdef CONFIG_SPI_ASYNC
 	.transceive_async = spi_gd32_transceive_async,

--- a/drivers/spi/spi_gecko_eusart.c
+++ b/drivers/spi/spi_gecko_eusart.c
@@ -291,7 +291,7 @@ static int spi_gecko_eusart_release(const struct device *dev, const struct spi_c
 }
 
 /* Device Instantiation */
-static const struct spi_driver_api spi_gecko_eusart_api = {
+static DEVICE_API(spi, spi_gecko_eusart_api) = {
 	.transceive = spi_gecko_eusart_transceive,
 #ifdef CONFIG_SPI_ASYNC
 	.transceive_async = spi_gecko_eusart_transceive_async,

--- a/drivers/spi/spi_gecko_usart.c
+++ b/drivers/spi/spi_gecko_usart.c
@@ -417,7 +417,7 @@ static int spi_gecko_release(const struct device *dev,
 }
 
 /* Device Instantiation */
-static const struct spi_driver_api spi_gecko_api = {
+static DEVICE_API(spi, spi_gecko_api) = {
 	.transceive = spi_gecko_transceive,
 #ifdef CONFIG_SPI_ASYNC
 	.transceive_async = spi_gecko_transceive_async,

--- a/drivers/spi/spi_grlib_spimctrl.c
+++ b/drivers/spi/spi_grlib_spimctrl.c
@@ -215,7 +215,7 @@ static int init(const struct device *dev)
 	return 0;
 }
 
-static struct spi_driver_api api = {
+static DEVICE_API(spi, api) = {
 	.transceive             = transceive,
 #ifdef CONFIG_SPI_ASYNC
 	.transceive_async       = transceive_async,

--- a/drivers/spi/spi_ifx_cat1.c
+++ b/drivers/spi/spi_ifx_cat1.c
@@ -287,7 +287,7 @@ static int ifx_cat1_spi_release(const struct device *dev, const struct spi_confi
 	return 0;
 }
 
-static const struct spi_driver_api ifx_cat1_spi_api = {
+static DEVICE_API(spi, ifx_cat1_spi_api) = {
 	.transceive = ifx_cat1_spi_transceive_sync,
 #if defined(CONFIG_SPI_ASYNC)
 	.transceive_async = ifx_cat1_spi_transceive_async,

--- a/drivers/spi/spi_it8xxx2.c
+++ b/drivers/spi/spi_it8xxx2.c
@@ -502,7 +502,7 @@ static int spi_it8xxx2_init(const struct device *dev)
 	return 0;
 }
 
-static const struct spi_driver_api spi_it8xxx2_driver_api = {
+static DEVICE_API(spi, spi_it8xxx2_driver_api) = {
 	.transceive = it8xxx2_transceive,
 	.release = it8xxx2_release,
 

--- a/drivers/spi/spi_litex.c
+++ b/drivers/spi/spi_litex.c
@@ -223,7 +223,7 @@ static int spi_litex_release(const struct device *dev, const struct spi_config *
 }
 
 /* Device Instantiation */
-static const struct spi_driver_api spi_litex_api = {
+static DEVICE_API(spi, spi_litex_api) = {
 	.transceive = spi_litex_transceive,
 #ifdef CONFIG_SPI_ASYNC
 	.transceive_async = spi_litex_transceive_async,

--- a/drivers/spi/spi_litex_litespi.c
+++ b/drivers/spi/spi_litex_litespi.c
@@ -245,7 +245,7 @@ static int spi_litex_release(const struct device *dev, const struct spi_config *
 }
 
 /* Device Instantiation */
-static const struct spi_driver_api spi_litex_api = {
+static DEVICE_API(spi, spi_litex_api) = {
 	.transceive = spi_litex_transceive,
 #ifdef CONFIG_SPI_ASYNC
 	.transceive_async = spi_litex_transceive_async,

--- a/drivers/spi/spi_ll_stm32.c
+++ b/drivers/spi/spi_ll_stm32.c
@@ -1146,7 +1146,7 @@ static int spi_stm32_transceive_async(const struct device *dev,
 }
 #endif /* CONFIG_SPI_ASYNC */
 
-static const struct spi_driver_api api_funcs = {
+static DEVICE_API(spi, api_funcs) = {
 	.transceive = spi_stm32_transceive,
 #ifdef CONFIG_SPI_ASYNC
 	.transceive_async = spi_stm32_transceive_async,

--- a/drivers/spi/spi_max32.c
+++ b/drivers/spi/spi_max32.c
@@ -898,7 +898,7 @@ static int spi_max32_init(const struct device *dev)
 }
 
 /* SPI driver APIs structure */
-static const struct spi_driver_api spi_max32_api = {
+static DEVICE_API(spi, spi_max32_api) = {
 	.transceive = api_transceive,
 #ifdef CONFIG_SPI_ASYNC
 	.transceive_async = api_transceive_async,

--- a/drivers/spi/spi_mchp_mss.c
+++ b/drivers/spi/spi_mchp_mss.c
@@ -443,7 +443,7 @@ static int mss_spi_init(const struct device *dev)
 
 #define MICROCHIP_SPI_PM_OPS (NULL)
 
-static const struct spi_driver_api mss_spi_driver_api = {
+static DEVICE_API(spi, mss_spi_driver_api) = {
 	.transceive = mss_spi_transceive_blocking,
 #ifdef CONFIG_SPI_ASYNC
 	.transceive_async = mss_spi_transceive_async,

--- a/drivers/spi/spi_mchp_mss_qspi.c
+++ b/drivers/spi/spi_mchp_mss_qspi.c
@@ -569,7 +569,7 @@ static int mss_qspi_init(const struct device *dev)
 	return ret;
 }
 
-static const struct spi_driver_api mss_qspi_driver_api = {
+static DEVICE_API(spi, mss_qspi_driver_api) = {
 	.transceive = mss_qspi_transceive_blocking,
 #ifdef CONFIG_SPI_ASYNC
 	.transceive_async = mss_qspi_transceive_async,

--- a/drivers/spi/spi_mcux_dspi.c
+++ b/drivers/spi/spi_mcux_dspi.c
@@ -795,7 +795,7 @@ static int spi_mcux_init(const struct device *dev)
 	return 0;
 }
 
-static const struct spi_driver_api spi_mcux_driver_api = {
+static DEVICE_API(spi, spi_mcux_driver_api) = {
 	.transceive = spi_mcux_transceive,
 #ifdef CONFIG_SPI_ASYNC
 	.transceive_async = spi_mcux_transceive_async,

--- a/drivers/spi/spi_mcux_ecspi.c
+++ b/drivers/spi/spi_mcux_ecspi.c
@@ -302,7 +302,7 @@ static int spi_mcux_init(const struct device *dev)
 	return 0;
 }
 
-static const struct spi_driver_api spi_mcux_driver_api = {
+static DEVICE_API(spi, spi_mcux_driver_api) = {
 	.transceive = spi_mcux_transceive,
 #ifdef CONFIG_SPI_ASYNC
 	.transceive_async = spi_mcux_transceive_async,

--- a/drivers/spi/spi_mcux_flexcomm.c
+++ b/drivers/spi/spi_mcux_flexcomm.c
@@ -824,7 +824,7 @@ static int spi_mcux_init(const struct device *dev)
 	return 0;
 }
 
-static const struct spi_driver_api spi_mcux_driver_api = {
+static DEVICE_API(spi, spi_mcux_driver_api) = {
 	.transceive = spi_mcux_transceive,
 #ifdef CONFIG_SPI_ASYNC
 	.transceive_async = spi_mcux_transceive_async,

--- a/drivers/spi/spi_mcux_flexio.c
+++ b/drivers/spi/spi_mcux_flexio.c
@@ -394,7 +394,7 @@ static int spi_mcux_init(const struct device *dev)
 	return 0;
 }
 
-static const struct spi_driver_api spi_mcux_driver_api = {
+static DEVICE_API(spi, spi_mcux_driver_api) = {
 	.transceive = spi_mcux_transceive,
 #ifdef CONFIG_SPI_ASYNC
 	.transceive_async = spi_mcux_transceive_async,

--- a/drivers/spi/spi_mcux_lpspi.c
+++ b/drivers/spi/spi_mcux_lpspi.c
@@ -710,7 +710,7 @@ static int spi_mcux_release(const struct device *dev, const struct spi_config *s
 	return 0;
 }
 
-static const struct spi_driver_api spi_mcux_driver_api = {
+static DEVICE_API(spi, spi_mcux_driver_api) = {
 	.transceive = spi_mcux_transceive_sync,
 #ifdef CONFIG_SPI_ASYNC
 	.transceive_async = spi_mcux_transceive_async,

--- a/drivers/spi/spi_npcx_spip.c
+++ b/drivers/spi/spi_npcx_spip.c
@@ -402,7 +402,7 @@ static int spi_npcx_spip_init(const struct device *dev)
 	return 0;
 }
 
-static struct spi_driver_api spi_npcx_spip_api = {
+static DEVICE_API(spi, spi_npcx_spip_api) = {
 	.transceive = spi_npcx_spip_transceive,
 	.release = spi_npcx_spip_release,
 #ifdef CONFIG_SPI_ASYNC

--- a/drivers/spi/spi_nrfx_spi.c
+++ b/drivers/spi/spi_nrfx_spi.c
@@ -323,7 +323,7 @@ static int spi_nrfx_release(const struct device *dev,
 	return 0;
 }
 
-static const struct spi_driver_api spi_nrfx_driver_api = {
+static DEVICE_API(spi, spi_nrfx_driver_api) = {
 	.transceive = spi_nrfx_transceive,
 #ifdef CONFIG_SPI_ASYNC
 	.transceive_async = spi_nrfx_transceive_async,

--- a/drivers/spi/spi_nrfx_spim.c
+++ b/drivers/spi/spi_nrfx_spim.c
@@ -560,7 +560,7 @@ static int spi_nrfx_release(const struct device *dev,
 	return 0;
 }
 
-static const struct spi_driver_api spi_nrfx_driver_api = {
+static DEVICE_API(spi, spi_nrfx_driver_api) = {
 	.transceive = spi_nrfx_transceive,
 #ifdef CONFIG_SPI_ASYNC
 	.transceive_async = spi_nrfx_transceive_async,

--- a/drivers/spi/spi_nrfx_spis.c
+++ b/drivers/spi/spi_nrfx_spis.c
@@ -264,7 +264,7 @@ static int spi_nrfx_release(const struct device *dev,
 	return 0;
 }
 
-static const struct spi_driver_api spi_nrfx_driver_api = {
+static DEVICE_API(spi, spi_nrfx_driver_api) = {
 	.transceive = spi_nrfx_transceive,
 #ifdef CONFIG_SPI_ASYNC
 	.transceive_async = spi_nrfx_transceive_async,

--- a/drivers/spi/spi_numaker.c
+++ b/drivers/spi/spi_numaker.c
@@ -281,7 +281,7 @@ static int spi_numaker_release(const struct device *dev, const struct spi_config
 	return 0;
 }
 
-static const struct spi_driver_api spi_numaker_driver_api = {
+static DEVICE_API(spi, spi_numaker_driver_api) = {
 	.transceive = spi_numaker_transceive,
 #ifdef CONFIG_SPI_RTIO
 	.iodev_submit = spi_rtio_iodev_default_submit,

--- a/drivers/spi/spi_nxp_s32.c
+++ b/drivers/spi/spi_nxp_s32.c
@@ -599,7 +599,7 @@ static void spi_nxp_s32_transfer_callback(const struct device *dev, Spi_Ip_Event
 }
 #endif /*CONFIG_NXP_S32_SPI_INTERRUPT*/
 
-static const struct spi_driver_api spi_nxp_s32_driver_api = {
+static DEVICE_API(spi, spi_nxp_s32_driver_api) = {
 	.transceive = spi_nxp_s32_transceive,
 #ifdef CONFIG_SPI_ASYNC
 	.transceive_async = spi_nxp_s32_transceive_async,

--- a/drivers/spi/spi_oc_simple.c
+++ b/drivers/spi/spi_oc_simple.c
@@ -180,7 +180,7 @@ int spi_oc_simple_release(const struct device *dev,
 	return 0;
 }
 
-static const struct spi_driver_api spi_oc_simple_api = {
+static DEVICE_API(spi, spi_oc_simple_api) = {
 	.transceive = spi_oc_simple_transceive,
 	.release = spi_oc_simple_release,
 #ifdef CONFIG_SPI_ASYNC

--- a/drivers/spi/spi_opentitan.c
+++ b/drivers/spi/spi_opentitan.c
@@ -302,7 +302,7 @@ static int spi_opentitan_release(const struct device *dev,
 
 /* Device Instantiation */
 
-static const struct spi_driver_api spi_opentitan_api = {
+static DEVICE_API(spi, spi_opentitan_api) = {
 	.transceive = spi_opentitan_transceive,
 #ifdef CONFIG_SPI_ASYNC
 	.transceive_async = spi_opentitan_transceive_async,

--- a/drivers/spi/spi_pl022.c
+++ b/drivers/spi/spi_pl022.c
@@ -892,7 +892,7 @@ static int spi_pl022_release(const struct device *dev,
 	return 0;
 }
 
-static const struct spi_driver_api spi_pl022_api = {
+static DEVICE_API(spi, spi_pl022_api) = {
 	.transceive = spi_pl022_transceive,
 #if defined(CONFIG_SPI_ASYNC)
 	.transceive_async = spi_pl022_transceive_async,

--- a/drivers/spi/spi_psoc6.c
+++ b/drivers/spi/spi_psoc6.c
@@ -405,7 +405,7 @@ static int spi_psoc6_init(const struct device *dev)
 	return spi_psoc6_release(dev, NULL);
 }
 
-static const struct spi_driver_api spi_psoc6_driver_api = {
+static DEVICE_API(spi, spi_psoc6_driver_api) = {
 	.transceive = spi_psoc6_transceive_sync,
 #ifdef CONFIG_SPI_ASYNC
 	.transceive_async = spi_psoc6_transceive_async,

--- a/drivers/spi/spi_pw.c
+++ b/drivers/spi/spi_pw.c
@@ -734,7 +734,7 @@ static void spi_pw_isr(const void *arg)
 }
 #endif
 
-static const struct spi_driver_api pw_spi_api = {
+static DEVICE_API(spi, pw_spi_api) = {
 	.transceive = spi_pw_transceive,
 	.release = spi_pw_release,
 #ifdef CONFIG_SPI_ASYNC

--- a/drivers/spi/spi_renesas_ra.c
+++ b/drivers/spi/spi_renesas_ra.c
@@ -460,7 +460,7 @@ static int ra_spi_release(const struct device *dev, const struct spi_config *con
 	return 0;
 }
 
-static const struct spi_driver_api ra_spi_driver_api = {.transceive = ra_spi_transceive,
+static DEVICE_API(spi, ra_spi_driver_api) = {.transceive = ra_spi_transceive,
 #ifdef CONFIG_SPI_ASYNC
 							.transceive_async = ra_spi_transceive_async,
 #endif /* CONFIG_SPI_ASYNC */

--- a/drivers/spi/spi_rpi_pico_pio.c
+++ b/drivers/spi/spi_rpi_pico_pio.c
@@ -678,7 +678,7 @@ int spi_pico_pio_release(const struct device *dev, const struct spi_config *spi_
 	return 0;
 }
 
-static const struct spi_driver_api spi_pico_pio_api = {
+static DEVICE_API(spi, spi_pico_pio_api) = {
 	.transceive = spi_pico_pio_transceive,
 	.release = spi_pico_pio_release,
 };

--- a/drivers/spi/spi_rv32m1_lpspi.c
+++ b/drivers/spi/spi_rv32m1_lpspi.c
@@ -297,7 +297,7 @@ static int spi_mcux_init(const struct device *dev)
 	return 0;
 }
 
-static const struct spi_driver_api spi_mcux_driver_api = {
+static DEVICE_API(spi, spi_mcux_driver_api) = {
 	.transceive = spi_mcux_transceive,
 #ifdef CONFIG_SPI_ASYNC
 	.transceive_async = spi_mcux_transceive_async,

--- a/drivers/spi/spi_sam.c
+++ b/drivers/spi/spi_sam.c
@@ -843,7 +843,7 @@ static int spi_sam_init(const struct device *dev)
 	return 0;
 }
 
-static const struct spi_driver_api spi_sam_driver_api = {
+static DEVICE_API(spi, spi_sam_driver_api) = {
 	.transceive = spi_sam_transceive_sync,
 #ifdef CONFIG_SPI_ASYNC
 	.transceive_async = spi_sam_transceive_async,

--- a/drivers/spi/spi_sam0.c
+++ b/drivers/spi/spi_sam0.c
@@ -691,7 +691,7 @@ static int spi_sam0_init(const struct device *dev)
 	return 0;
 }
 
-static const struct spi_driver_api spi_sam0_driver_api = {
+static DEVICE_API(spi, spi_sam0_driver_api) = {
 	.transceive = spi_sam0_transceive_sync,
 #ifdef CONFIG_SPI_ASYNC
 	.transceive_async = spi_sam0_transceive_async,

--- a/drivers/spi/spi_sedi.c
+++ b/drivers/spi/spi_sedi.c
@@ -297,7 +297,7 @@ void spi_sedi_callback(uint32_t event, void *param)
 	}
 }
 
-static const struct spi_driver_api sedi_spi_api = {
+static DEVICE_API(spi, sedi_spi_api) = {
 	.transceive = spi_sedi_transceive,
 #ifdef CONFIG_SPI_ASYNC
 	.transceive_async = spi_sedi_transceive_async,

--- a/drivers/spi/spi_sifive.c
+++ b/drivers/spi/spi_sifive.c
@@ -272,7 +272,7 @@ static int spi_sifive_release(const struct device *dev,
 
 /* Device Instantiation */
 
-static const struct spi_driver_api spi_sifive_api = {
+static DEVICE_API(spi, spi_sifive_api) = {
 	.transceive = spi_sifive_transceive,
 #ifdef CONFIG_SPI_RTIO
 	.iodev_submit = spi_rtio_iodev_default_submit,

--- a/drivers/spi/spi_smartbond.c
+++ b/drivers/spi/spi_smartbond.c
@@ -1118,7 +1118,7 @@ static int spi_smartbond_release(const struct device *dev, const struct spi_conf
 	return 0;
 }
 
-static const struct spi_driver_api spi_smartbond_driver_api = {
+static DEVICE_API(spi, spi_smartbond_driver_api) = {
 	.transceive = spi_smartbond_transceive,
 #ifdef CONFIG_SPI_ASYNC
 	.transceive_async = spi_smartbond_transceive_async,

--- a/drivers/spi/spi_test.c
+++ b/drivers/spi/spi_test.c
@@ -41,7 +41,7 @@ static int vnd_spi_release(const struct device *dev,
 	return -ENOTSUP;
 }
 
-static const struct spi_driver_api vnd_spi_api = {
+static DEVICE_API(spi, vnd_spi_api) = {
 	.transceive = vnd_spi_transceive,
 #ifdef CONFIG_SPI_ASYNC
 	.transceive_async = vnd_spi_transceive_async,

--- a/drivers/spi/spi_xec_qmspi.c
+++ b/drivers/spi/spi_xec_qmspi.c
@@ -657,7 +657,7 @@ static int qmspi_init(const struct device *dev)
 	return 0;
 }
 
-static const struct spi_driver_api spi_qmspi_driver_api = {
+static DEVICE_API(spi, spi_qmspi_driver_api) = {
 	.transceive = qmspi_transceive_sync,
 #ifdef CONFIG_SPI_ASYNC
 	.transceive_async = qmspi_transceive_async,

--- a/drivers/spi/spi_xec_qmspi_ldma.c
+++ b/drivers/spi/spi_xec_qmspi_ldma.c
@@ -986,7 +986,7 @@ static int qmspi_xec_init(const struct device *dev)
 	return 0;
 }
 
-static const struct spi_driver_api spi_qmspi_xec_driver_api = {
+static DEVICE_API(spi, spi_qmspi_xec_driver_api) = {
 	.transceive = qmspi_transceive_sync,
 #ifdef CONFIG_SPI_ASYNC
 	.transceive_async = qmspi_transceive_async,

--- a/drivers/spi/spi_xlnx_axi_quadspi.c
+++ b/drivers/spi/spi_xlnx_axi_quadspi.c
@@ -585,7 +585,7 @@ static int xlnx_quadspi_init(const struct device *dev)
 	return 0;
 }
 
-static const struct spi_driver_api xlnx_quadspi_driver_api = {
+static DEVICE_API(spi, xlnx_quadspi_driver_api) = {
 	.transceive = xlnx_quadspi_transceive_blocking,
 #ifdef CONFIG_SPI_ASYNC
 	.transceive_async = xlnx_quadspi_transceive_async,

--- a/drivers/spi/spi_xmc4xxx.c
+++ b/drivers/spi/spi_xmc4xxx.c
@@ -592,7 +592,7 @@ static int spi_xmc4xxx_init(const struct device *dev)
 	return 0;
 }
 
-static const struct spi_driver_api spi_xmc4xxx_driver_api = {
+static DEVICE_API(spi, spi_xmc4xxx_driver_api) = {
 	.transceive = spi_xmc4xxx_transceive_sync,
 #if defined(CONFIG_SPI_ASYNC)
 	.transceive_async = spi_xmc4xxx_transceive_async,


### PR DESCRIPTION
Add wrapper DEVICE_API macro to all spi_driver_api instances.