### PR TITLE
drivers: lora: Place API into iterable section

### DIFF
--- a/drivers/lora/rylrxxx.c
+++ b/drivers/lora/rylrxxx.c
@@ -664,7 +664,7 @@ static int rylr_init(const struct device *dev)
 	return err;
 }
 
-static const struct lora_driver_api rylr_lora_api = {
+static DEVICE_API(lora, rylr_lora_api) = {
 	.config = rylr_config,
 	.send = rylr_send,
 	.send_async = rylr_send_async,

--- a/drivers/lora/sx126x.c
+++ b/drivers/lora/sx126x.c
@@ -463,7 +463,7 @@ static int sx126x_lora_init(const struct device *dev)
 	return 0;
 }
 
-static const struct lora_driver_api sx126x_lora_api = {
+static DEVICE_API(lora, sx126x_lora_api) = {
 	.config = sx12xx_lora_config,
 	.send = sx12xx_lora_send,
 	.send_async = sx12xx_lora_send_async,

--- a/drivers/lora/sx127x.c
+++ b/drivers/lora/sx127x.c
@@ -625,7 +625,7 @@ static int sx127x_lora_init(const struct device *dev)
 	return 0;
 }
 
-static const struct lora_driver_api sx127x_lora_api = {
+static DEVICE_API(lora, sx127x_lora_api) = {
 	.config = sx12xx_lora_config,
 	.send = sx12xx_lora_send,
 	.send_async = sx12xx_lora_send_async,


### PR DESCRIPTION
Add wrapper DEVICE_API macro to all lora_driver_api instances.