### PR TITLE
drivers: mbox: Place API into iterable section

### DIFF
--- a/drivers/mbox/mbox_andes_plic_sw.c
+++ b/drivers/mbox/mbox_andes_plic_sw.c
@@ -104,7 +104,7 @@ static int mbox_plic_set_enabled(const struct device *dev, uint32_t ch, bool ena
 	return 0;
 }
 
-static const struct mbox_driver_api mbox_plic_driver_api = {
+static DEVICE_API(mbox, mbox_plic_driver_api) = {
 	.send = mbox_plic_send,
 	.register_callback = mbox_plic_register_callback,
 	.mtu_get = mbox_plic_mtu_get,

--- a/drivers/mbox/mbox_esp32.c
+++ b/drivers/mbox/mbox_esp32.c
@@ -235,7 +235,7 @@ static int esp32_mbox_init(const struct device *dev)
 	return ret;
 }
 
-static const struct mbox_driver_api esp32_mbox_driver_api = {
+static DEVICE_API(mbox, esp32_mbox_driver_api) = {
 	.send = esp32_mbox_send,
 	.register_callback = esp32_mbox_register_callback,
 	.mtu_get = esp32_mbox_mtu_get,

--- a/drivers/mbox/mbox_ivshmem.c
+++ b/drivers/mbox/mbox_ivshmem.c
@@ -132,7 +132,7 @@ static int ivshmem_mbox_init(const struct device *dev)
 	return 0;
 }
 
-static const struct mbox_driver_api ivshmem_mbox_driver_api = {
+static DEVICE_API(mbox, ivshmem_mbox_driver_api) = {
 	.send = ivshmem_mbox_send,
 	.register_callback = ivshmem_mbox_register_callback,
 	.mtu_get = ivshmem_mbox_mtu_get,

--- a/drivers/mbox/mbox_nrf_bellboard_rx.c
+++ b/drivers/mbox/mbox_nrf_bellboard_rx.c
@@ -135,7 +135,7 @@ static int bellboard_rx_set_enabled(const struct device *dev, uint32_t id, bool 
 	return 0;
 }
 
-static const struct mbox_driver_api bellboard_rx_driver_api = {
+static DEVICE_API(mbox, bellboard_rx_driver_api) = {
 	.max_channels_get = bellboard_rx_max_channels_get,
 	.register_callback = bellboard_rx_register_callback,
 	.set_enabled = bellboard_rx_set_enabled,

--- a/drivers/mbox/mbox_nrf_bellboard_tx.c
+++ b/drivers/mbox/mbox_nrf_bellboard_tx.c
@@ -45,7 +45,7 @@ static uint32_t bellboard_tx_max_channels_get(const struct device *dev)
 	return BELLBOARD_TASKS_TRIGGER_MaxCount;
 }
 
-static const struct mbox_driver_api bellboard_tx_driver_api = {
+static DEVICE_API(mbox, bellboard_tx_driver_api) = {
 	.send = bellboard_tx_send,
 	.mtu_get = bellboard_tx_mtu_get,
 	.max_channels_get = bellboard_tx_max_channels_get,

--- a/drivers/mbox/mbox_nrf_vevif_event_rx.c
+++ b/drivers/mbox/mbox_nrf_vevif_event_rx.c
@@ -104,7 +104,7 @@ static int vevif_event_rx_set_enabled(const struct device *dev, uint32_t id, boo
 	return 0;
 }
 
-static const struct mbox_driver_api vevif_event_rx_driver_api = {
+static DEVICE_API(mbox, vevif_event_rx_driver_api) = {
 	.max_channels_get = vevif_event_rx_max_channels_get,
 	.register_callback = vevif_event_rx_register_callback,
 	.set_enabled = vevif_event_rx_set_enabled,

--- a/drivers/mbox/mbox_nrf_vevif_event_tx.c
+++ b/drivers/mbox/mbox_nrf_vevif_event_tx.c
@@ -56,7 +56,7 @@ static uint32_t vevif_event_tx_max_channels_get(const struct device *dev)
 	return VEVIF_EVENTS_NUM;
 }
 
-static const struct mbox_driver_api vevif_event_tx_driver_api = {
+static DEVICE_API(mbox, vevif_event_tx_driver_api) = {
 	.send = vevif_event_tx_send,
 	.mtu_get = vevif_event_tx_mtu_get,
 	.max_channels_get = vevif_event_tx_max_channels_get,

--- a/drivers/mbox/mbox_nrf_vevif_task_rx.c
+++ b/drivers/mbox/mbox_nrf_vevif_task_rx.c
@@ -105,7 +105,7 @@ static int vevif_task_rx_set_enabled(const struct device *dev, uint32_t id, bool
 	return 0;
 }
 
-static const struct mbox_driver_api vevif_task_rx_driver_api = {
+static DEVICE_API(mbox, vevif_task_rx_driver_api) = {
 	.max_channels_get = vevif_task_rx_max_channels_get,
 	.register_callback = vevif_task_rx_register_callback,
 	.set_enabled = vevif_task_rx_set_enabled,

--- a/drivers/mbox/mbox_nrf_vevif_task_tx.c
+++ b/drivers/mbox/mbox_nrf_vevif_task_tx.c
@@ -56,7 +56,7 @@ static uint32_t vevif_task_tx_max_channels_get(const struct device *dev)
 	return config->tasks;
 }
 
-static const struct mbox_driver_api vevif_task_tx_driver_api = {
+static DEVICE_API(mbox, vevif_task_tx_driver_api) = {
 	.send = vevif_task_tx_send,
 	.mtu_get = vevif_task_tx_mtu_get,
 	.max_channels_get = vevif_task_tx_max_channels_get,

--- a/drivers/mbox/mbox_nrfx_ipc.c
+++ b/drivers/mbox/mbox_nrfx_ipc.c
@@ -190,7 +190,7 @@ static int mbox_nrf_init(const struct device *dev)
 	return 0;
 }
 
-static const struct mbox_driver_api mbox_nrf_driver_api = {
+static DEVICE_API(mbox, mbox_nrf_driver_api) = {
 	.send = mbox_nrf_send,
 	.register_callback = mbox_nrf_register_callback,
 	.mtu_get = mbox_nrf_mtu_get,

--- a/drivers/mbox/mbox_nxp_imx_mu.c
+++ b/drivers/mbox/mbox_nxp_imx_mu.c
@@ -113,7 +113,7 @@ static int nxp_imx_mu_set_enabled(const struct device *dev, uint32_t channel, bo
 	return 0;
 }
 
-static const struct mbox_driver_api nxp_imx_mu_driver_api = {
+static DEVICE_API(mbox, nxp_imx_mu_driver_api) = {
 	.send = nxp_imx_mu_send,
 	.register_callback = nxp_imx_mu_register_callback,
 	.mtu_get = nxp_imx_mu_mtu_get,

--- a/drivers/mbox/mbox_nxp_mailbox.c
+++ b/drivers/mbox/mbox_nxp_mailbox.c
@@ -180,7 +180,7 @@ static int nxp_mailbox_set_enabled(const struct device *dev, uint32_t channel, b
 	return 0;
 }
 
-static const struct mbox_driver_api nxp_mailbox_driver_api = {
+static DEVICE_API(mbox, nxp_mailbox_driver_api) = {
 	.send = nxp_mailbox_send,
 	.register_callback = nxp_mailbox_register_callback,
 	.mtu_get = nxp_mailbox_mtu_get,

--- a/drivers/mbox/mbox_nxp_s32_mru.c
+++ b/drivers/mbox/mbox_nxp_s32_mru.c
@@ -177,7 +177,7 @@ void nxp_s32_mru_isr(const struct device *dev)
 	Mru_Ip_IrqHandler(config->hw_cfg.InstanceId, config->irq_group);
 }
 
-static const struct mbox_driver_api nxp_s32_mru_driver_api = {
+static DEVICE_API(mbox, nxp_s32_mru_driver_api) = {
 	.send = nxp_s32_mru_send,
 	.register_callback = nxp_s32_mru_register_callback,
 	.mtu_get = nxp_s32_mru_mtu_get,

--- a/drivers/mbox/mbox_stm32_hsem.c
+++ b/drivers/mbox/mbox_stm32_hsem.c
@@ -241,7 +241,7 @@ static int mbox_stm32_hsem_init(const struct device *dev)
 	return ret;
 }
 
-static const struct mbox_driver_api mbox_stm32_hsem_driver_api = {
+static DEVICE_API(mbox, mbox_stm32_hsem_driver_api) = {
 	.send = mbox_stm32_hsem_send,
 	.register_callback = mbox_stm32_hsem_register_callback,
 	.mtu_get = mbox_stm32_hsem_mtu_get,


### PR DESCRIPTION
Add wrapper DEVICE_API macro to all mbox_driver_api instances.