### PR TITLE
drivers: mdio: Place API into iterable section

### DIFF
--- a/drivers/ethernet/eth_smsc91x.c
+++ b/drivers/ethernet/eth_smsc91x.c
@@ -880,7 +880,7 @@ static int mdio_smsc_write(const struct device *dev, uint8_t prtad, uint8_t deva
 	return 0;
 }
 
-static const struct mdio_driver_api mdio_smsc_api = {
+static DEVICE_API(mdio, mdio_smsc_api) = {
 	.bus_disable = mdio_smsc_bus_disable,
 	.bus_enable = mdio_smsc_bus_enable,
 	.read = mdio_smsc_read,

--- a/drivers/mdio/mdio_adin2111.c
+++ b/drivers/mdio/mdio_adin2111.c
@@ -187,7 +187,7 @@ static void mdio_adin2111_bus_disable(const struct device *dev)
 	eth_adin2111_unlock(cfg->adin);
 }
 
-static const struct mdio_driver_api mdio_adin2111_api = {
+static DEVICE_API(mdio, mdio_adin2111_api) = {
 	.read = mdio_adin2111_read,
 	.write = mdio_adin2111_write,
 	.read_c45 = mdio_adin2111_read_c45,

--- a/drivers/mdio/mdio_dwcxgmac.c
+++ b/drivers/mdio/mdio_dwcxgmac.c
@@ -203,7 +203,7 @@ static int mdio_dwcxgmac_initialize(const struct device *dev)
 	return 0;
 }
 
-static const struct mdio_driver_api mdio_dwcxgmac_driver_api = {
+static DEVICE_API(mdio, mdio_dwcxgmac_driver_api) = {
 	.read = mdio_dwcxgmac_read,
 	.write = mdio_dwcxgmac_write,
 	.bus_enable = mdio_dwcxgmac_bus_enable,

--- a/drivers/mdio/mdio_esp32.c
+++ b/drivers/mdio/mdio_esp32.c
@@ -122,7 +122,7 @@ err:
 	return res;
 }
 
-static const struct mdio_driver_api mdio_esp32_driver_api = {
+static DEVICE_API(mdio, mdio_esp32_driver_api) = {
 	.read = mdio_esp32_read,
 	.write = mdio_esp32_write,
 };

--- a/drivers/mdio/mdio_gpio.c
+++ b/drivers/mdio/mdio_gpio.c
@@ -157,7 +157,7 @@ static int mdio_gpio_initialize(const struct device *dev)
 	return 0;
 }
 
-static const struct mdio_driver_api mdio_gpio_driver_api = {
+static DEVICE_API(mdio, mdio_gpio_driver_api) = {
 	.read = mdio_gpio_read_mmi,
 	.write = mdio_gpio_write_mmi,
 };

--- a/drivers/mdio/mdio_litex_liteeth.c
+++ b/drivers/mdio/mdio_litex_liteeth.c
@@ -152,7 +152,7 @@ static int mdio_litex_initialize(const struct device *dev)
 	return 0;
 }
 
-static const struct mdio_driver_api mdio_litex_driver_api = {
+static DEVICE_API(mdio, mdio_litex_driver_api) = {
 	.read = mdio_litex_read_mmi,
 	.write = mdio_litex_write_mmi,
 };

--- a/drivers/mdio/mdio_nxp_enet.c
+++ b/drivers/mdio/mdio_nxp_enet.c
@@ -157,7 +157,7 @@ static int nxp_enet_mdio_write(const struct device *dev,
 	return ret;
 }
 
-static const struct mdio_driver_api nxp_enet_mdio_api = {
+static DEVICE_API(mdio, nxp_enet_mdio_api) = {
 	.read = nxp_enet_mdio_read,
 	.write = nxp_enet_mdio_write,
 };

--- a/drivers/mdio/mdio_nxp_enet_qos.c
+++ b/drivers/mdio/mdio_nxp_enet_qos.c
@@ -144,7 +144,7 @@ static int nxp_enet_qos_mdio_write(const struct device *dev,
 	return do_transaction(&mdio_write);
 }
 
-static const struct mdio_driver_api nxp_enet_qos_mdio_api = {
+static DEVICE_API(mdio, nxp_enet_qos_mdio_api) = {
 	.read = nxp_enet_qos_mdio_read,
 	.write = nxp_enet_qos_mdio_write,
 };

--- a/drivers/mdio/mdio_nxp_imx_netc.c
+++ b/drivers/mdio/mdio_nxp_imx_netc.c
@@ -80,7 +80,7 @@ static int nxp_imx_netc_mdio_initialize(const struct device *dev)
 	return 0;
 }
 
-static const struct mdio_driver_api nxp_imx_netc_mdio_api = {
+static DEVICE_API(mdio, nxp_imx_netc_mdio_api) = {
 	.read = nxp_imx_netc_mdio_read,
 	.write = nxp_imx_netc_mdio_write,
 };

--- a/drivers/mdio/mdio_nxp_s32_gmac.c
+++ b/drivers/mdio/mdio_nxp_s32_gmac.c
@@ -141,7 +141,7 @@ static int mdio_nxp_s32_init(const struct device *dev)
 	return 0;
 }
 
-static const struct mdio_driver_api mdio_nxp_s32_driver_api = {
+static DEVICE_API(mdio, mdio_nxp_s32_driver_api) = {
 	.read = mdio_nxp_s32_read_c22,
 	.write = mdio_nxp_s32_write_c22,
 	.read_c45 = mdio_nxp_s32_read_c45,

--- a/drivers/mdio/mdio_nxp_s32_netc.c
+++ b/drivers/mdio/mdio_nxp_s32_netc.c
@@ -67,7 +67,7 @@ static int nxp_s32_mdio_initialize(const struct device *dev)
 	return 0;
 }
 
-static const struct mdio_driver_api nxp_s32_mdio_api = {
+static DEVICE_API(mdio, nxp_s32_mdio_api) = {
 	.read = nxp_s32_mdio_read,
 	.write = nxp_s32_mdio_write,
 };

--- a/drivers/mdio/mdio_sam.c
+++ b/drivers/mdio/mdio_sam.c
@@ -158,7 +158,7 @@ static int mdio_sam_initialize(const struct device *dev)
 	return retval;
 }
 
-static const struct mdio_driver_api mdio_sam_driver_api = {
+static DEVICE_API(mdio, mdio_sam_driver_api) = {
 	.read = mdio_sam_read,
 	.write = mdio_sam_write,
 	.read_c45 = mdio_sam_read_c45,

--- a/drivers/mdio/mdio_stm32_hal.c
+++ b/drivers/mdio/mdio_stm32_hal.c
@@ -99,7 +99,7 @@ static int mdio_stm32_init(const struct device *dev)
 	return 0;
 }
 
-static const struct mdio_driver_api mdio_stm32_api = {
+static DEVICE_API(mdio, mdio_stm32_api) = {
 	.read = mdio_stm32_read,
 	.write = mdio_stm32_write,
 	.bus_enable = mdio_stm32_bus_enable,

--- a/drivers/mdio/mdio_xmc4xxx.c
+++ b/drivers/mdio/mdio_xmc4xxx.c
@@ -164,7 +164,7 @@ static int mdio_xmc4xxx_initialize(const struct device *dev)
 	return ret;
 }
 
-static const struct mdio_driver_api mdio_xmc4xxx_driver_api = {
+static DEVICE_API(mdio, mdio_xmc4xxx_driver_api) = {
 	.read = mdio_xmc4xxx_read,
 	.write = mdio_xmc4xxx_write,
 	.bus_enable = mdio_xmc4xxx_bus_enable,


### PR DESCRIPTION
Add wrapper DEVICE_API macro to all mdio_driver_api instances.