### PR TITLE
drivers: mipi_dbi: Place API into iterable section

### DIFF
--- a/drivers/mipi_dbi/mipi_dbi_bitbang.c
+++ b/drivers/mipi_dbi/mipi_dbi_bitbang.c
@@ -275,7 +275,7 @@ fail:
 	return ret;
 }
 
-static const struct mipi_dbi_driver_api mipi_dbi_bitbang_driver_api = {
+static DEVICE_API(mipi_dbi, mipi_dbi_bitbang_driver_api) = {
 	.reset = mipi_dbi_bitbang_reset,
 	.command_write = mipi_dbi_bitbang_command_write,
 	.write_display = mipi_dbi_bitbang_write_display

--- a/drivers/mipi_dbi/mipi_dbi_nxp_flexio_lcdif.c
+++ b/drivers/mipi_dbi/mipi_dbi_nxp_flexio_lcdif.c
@@ -417,7 +417,7 @@ static int flexio_lcdif_init(const struct device *dev)
 	return 0;
 }
 
-static struct mipi_dbi_driver_api mipi_dbi_lcdif_driver_api = {
+static DEVICE_API(mipi_dbi, mipi_dbi_lcdif_driver_api) = {
 	.reset = mipi_dbi_flexio_lcdif_reset,
 	.command_write = mipi_dbi_flexio_lcdif_command_write,
 	.write_display = mipi_dbi_flexio_ldcif_write_display,

--- a/drivers/mipi_dbi/mipi_dbi_nxp_lcdic.c
+++ b/drivers/mipi_dbi/mipi_dbi_nxp_lcdic.c
@@ -684,7 +684,7 @@ static int mipi_dbi_lcdic_init(const struct device *dev)
 	return 0;
 }
 
-static const struct mipi_dbi_driver_api mipi_dbi_lcdic_driver_api = {
+static DEVICE_API(mipi_dbi, mipi_dbi_lcdic_driver_api) = {
 	.command_write = mipi_dbi_lcdic_write_cmd,
 	.write_display = mipi_dbi_lcdic_write_display,
 	.reset = mipi_dbi_lcdic_reset,

--- a/drivers/mipi_dbi/mipi_dbi_smartbond.c
+++ b/drivers/mipi_dbi/mipi_dbi_smartbond.c
@@ -536,7 +536,7 @@ static int mipi_dbi_smartbond_init(const struct device *dev)
 	return ret;
 }
 
-static const struct mipi_dbi_driver_api mipi_dbi_smartbond_driver_api = {
+static DEVICE_API(mipi_dbi, mipi_dbi_smartbond_driver_api) = {
 #if MIPI_DBI_SMARTBOND_IS_RESET_AVAILABLE
 	.reset = mipi_dbi_smartbond_reset,
 #endif

--- a/drivers/mipi_dbi/mipi_dbi_spi.c
+++ b/drivers/mipi_dbi/mipi_dbi_spi.c
@@ -314,7 +314,7 @@ static int mipi_dbi_spi_init(const struct device *dev)
 	return 0;
 }
 
-static const struct mipi_dbi_driver_api mipi_dbi_spi_driver_api = {
+static DEVICE_API(mipi_dbi, mipi_dbi_spi_driver_api) = {
 	.reset = mipi_dbi_spi_reset,
 	.command_write = mipi_dbi_spi_command_write,
 	.write_display = mipi_dbi_spi_write_display,

--- a/drivers/mipi_dbi/mipi_dbi_stm32_fmc.c
+++ b/drivers/mipi_dbi/mipi_dbi_stm32_fmc.c
@@ -172,7 +172,7 @@ static int mipi_dbi_stm32_fmc_init(const struct device *dev)
 	return 0;
 }
 
-static struct mipi_dbi_driver_api mipi_dbi_stm32_fmc_driver_api = {
+static DEVICE_API(mipi_dbi, mipi_dbi_stm32_fmc_driver_api) = {
 	.reset = mipi_dbi_stm32_fmc_reset,
 	.command_write = mipi_dbi_stm32_fmc_command_write,
 	.write_display = mipi_dbi_stm32_fmc_write_display,


### PR DESCRIPTION
Add wrapper DEVICE_API macro to all mipi_dbi_driver_api instances.