### PR TITLE
drivers: mipi_dsi: Place API into iterable section

### DIFF
--- a/drivers/mipi_dsi/dsi_mcux.c
+++ b/drivers/mipi_dsi/dsi_mcux.c
@@ -300,7 +300,7 @@ static ssize_t dsi_mcux_transfer(const struct device *dev, uint8_t channel,
 
 }
 
-static struct mipi_dsi_driver_api dsi_mcux_api = {
+static DEVICE_API(mipi_dsi, dsi_mcux_api) = {
 	.attach = dsi_mcux_attach,
 	.transfer = dsi_mcux_transfer,
 };

--- a/drivers/mipi_dsi/dsi_mcux_2l.c
+++ b/drivers/mipi_dsi/dsi_mcux_2l.c
@@ -464,7 +464,7 @@ static ssize_t dsi_mcux_transfer(const struct device *dev, uint8_t channel,
 
 }
 
-static struct mipi_dsi_driver_api dsi_mcux_api = {
+static DEVICE_API(mipi_dsi, dsi_mcux_api) = {
 	.attach = dsi_mcux_attach,
 	.detach = dsi_mcux_detach,
 	.transfer = dsi_mcux_transfer,

--- a/drivers/mipi_dsi/dsi_stm32.c
+++ b/drivers/mipi_dsi/dsi_stm32.c
@@ -387,7 +387,7 @@ static ssize_t mipi_dsi_stm32_transfer(const struct device *dev, uint8_t channel
 	return len;
 }
 
-static struct mipi_dsi_driver_api dsi_stm32_api = {
+static DEVICE_API(mipi_dsi, dsi_stm32_api) = {
 	.attach = mipi_dsi_stm32_attach,
 	.transfer = mipi_dsi_stm32_transfer,
 };

--- a/drivers/mipi_dsi/dsi_test.c
+++ b/drivers/mipi_dsi/dsi_test.c
@@ -43,7 +43,7 @@ static int vnd_mipi_dsi_detach(const struct device *dev, uint8_t channel,
 	return -ENOTSUP;
 }
 
-static struct mipi_dsi_driver_api vnd_mipi_dsi_api = {
+static DEVICE_API(mipi_dsi, vnd_mipi_dsi_api) = {
 	.attach = vnd_mipi_dsi_attach,
 	.transfer = vnd_mipi_dsi_transfer,
 	.detach = vnd_mipi_dsi_detach,


### PR DESCRIPTION
Add wrapper DEVICE_API macro to all mipi_dsi_driver_api instances.