### PR TITLE
kernel/sched: Correct k_sleep() return value when a 32-bit tick wraparound occurs

### DIFF
--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -1117,7 +1117,11 @@ static int32_t z_tick_sleep(k_ticks_t ticks)
 
 	__ASSERT(!z_is_thread_state_set(arch_current_thread(), _THREAD_SUSPENDED), "");
 
-	ticks = (k_ticks_t)expected_wakeup_ticks - sys_clock_tick_get_32();
+	/* We require a 32 bit unsigned subtraction to care a wraparound */
+	uint32_t left_ticks = expected_wakeup_ticks - sys_clock_tick_get_32();
+
+	/* To handle a negative value correctly, once type-cast it to signed 32 bit */
+	ticks = (k_ticks_t)(int32_t)left_ticks;
 	if (ticks > 0) {
 		return ticks;
 	}

--- a/tests/kernel/sched/wraparound/CMakeLists.txt
+++ b/tests/kernel/sched/wraparound/CMakeLists.txt
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(sleep)
+
+FILE(GLOB app_sources src/*.c)
+target_sources(app PRIVATE ${app_sources})

--- a/tests/kernel/sched/wraparound/prj.conf
+++ b/tests/kernel/sched/wraparound/prj.conf
@@ -1,0 +1,1 @@
+CONFIG_ZTEST=y

--- a/tests/kernel/sched/wraparound/src/main.c
+++ b/tests/kernel/sched/wraparound/src/main.c
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2024 Akaiwa Wataru <akaiwa@sonas.co.jp>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <zephyr/kernel.h>
+#include <zephyr/ztest.h>
+
+static k_tid_t thread_id;
+
+static void alarm_callback(struct k_timer *timer)
+{
+	k_wakeup(thread_id);
+}
+
+K_TIMER_DEFINE(alarm, alarm_callback, NULL);
+
+/**
+ * @brief Test 32-bit tick wraparound during k_sleep() execution
+ */
+ZTEST(wraparound, test_tick_wraparound_in_sleep)
+{
+	static const uint32_t start_ticks = 0xffffff00; /* It wraps around after 256 ticks! */
+	static const uint32_t timeout_ticks = 300;      /* 3 seconds @ 100Hz tick */
+	static const uint32_t wakeup_ticks = 10;        /* 100 ms @ 100Hz tick */
+
+	sys_clock_tick_set(start_ticks);
+
+	/* Wake up myself by alarm */
+	thread_id = k_current_get();
+	k_timer_start(&alarm, K_TICKS(wakeup_ticks), K_FOREVER);
+
+	/* Waiting alarm's k_wakeup() call */
+	int32_t left_ms = k_sleep(K_TICKS(timeout_ticks));
+
+	zassert(left_ms > 0, "k_sleep() timed out");
+
+	k_timer_stop(&alarm);
+}
+
+ZTEST_SUITE(wraparound, NULL, NULL, NULL, NULL, NULL);

--- a/tests/kernel/sched/wraparound/testcase.yaml
+++ b/tests/kernel/sched/wraparound/testcase.yaml
@@ -1,0 +1,3 @@
+tests:
+  kernel.scheduler.wraparound:
+    tags: kernel


### PR DESCRIPTION
Fixes #79863

The `expected_wakeup_ticks` and `sys_clock_tick_get_32()` are uint32_t values, and may wrap around individually.
If the `expected_wakeup_ticks` has a wraparound and `sys_clock_tick_get_32()` doesn't, so `expected_wakeup_ticks < sys_clock_tick_get_32()`, the API return value will be corrupted.

**Example: try to sleep 1000 ticks, but wakeup occurs in 10 ticks**

| `sys_clock_tick_get_32()` before sleep | `expected_wakeup_ticks` | `sys_clock_tick_get_32()` after wakeup | return value (remaining ticks) |
| -- | -- | -- | -- |
| 10000 | 11000 | 10010 | 990 (OK) |
| 0xffffffff (4,294,967,295) | 0x000003e7 (999) ↩️  | 0x00000009 (9) ↩️ | 990 (OK) |
| 0xffffff00 (4,294,967,040) | 0x000002eb (744) ↩️ | 0xFFFFFF0A (4,294,967,050) | -4,294,966,300 😱 (returns 0) |

The API return value should be calculated in 32bit-unsigned-integer manner, and any wraparound will be treated properly.

| `sys_clock_tick_get_32()` before sleep | `expected_wakeup_ticks` | `sys_clock_tick_get_32()` after wakeup | return value (remaining ticks) |
| -- | -- | -- | -- |
| 10000 | 11000 | 10010 | 990 (OK) |
| 0xffffffff (4,294,967,295) | 0x000003e7 (999) ↩️  | 0x00000009 (9) ↩️ | 990 (OK) |
| 0xffffff00 (4,294,967,040) | 0x000002eb (744) ↩️ | 0xFFFFFF0A (4,294,967,050) | 990 (OK) ↩️ |

### Review Request

- I add a test to reproduce the issue (it failed first), and the fixed code passed the test. The test is very very slow. May I commit the test to the repository?