### PR TITLE
drivers: clock_control: nrf: Place API into iterable section

### DIFF
--- a/drivers/clock_control/clock_control_nrf2_fll16m.c
+++ b/drivers/clock_control/clock_control_nrf2_fll16m.c
@@ -239,7 +239,7 @@ static int fll16m_init(const struct device *dev)
 				 fll16m_work_handler);
 }
 
-static struct nrf_clock_control_driver_api fll16m_drv_api = {
+static DEVICE_API(nrf_clock_control, fll16m_drv_api) = {
 	.std_api = {
 		.on = api_nosys_on_off,
 		.off = api_nosys_on_off,

--- a/drivers/clock_control/clock_control_nrf2_hfxo.c
+++ b/drivers/clock_control/clock_control_nrf2_hfxo.c
@@ -171,7 +171,7 @@ static int init_hfxo(const struct device *dev)
 	return 0;
 }
 
-static struct nrf_clock_control_driver_api drv_api_hfxo = {
+static DEVICE_API(nrf_clock_control, drv_api_hfxo) = {
 	.std_api = {
 		.on = api_nosys_on_off,
 		.off = api_nosys_on_off,

--- a/drivers/clock_control/clock_control_nrf2_hsfll.c
+++ b/drivers/clock_control/clock_control_nrf2_hsfll.c
@@ -217,7 +217,7 @@ static int hsfll_init(const struct device *dev)
 	return 0;
 }
 
-static struct nrf_clock_control_driver_api hsfll_drv_api = {
+static DEVICE_API(nrf_clock_control, hsfll_drv_api) = {
 	.std_api = {
 		.on = api_nosys_on_off,
 		.off = api_nosys_on_off,

--- a/drivers/clock_control/clock_control_nrf2_lfclk.c
+++ b/drivers/clock_control/clock_control_nrf2_lfclk.c
@@ -241,7 +241,7 @@ static int lfclk_init(const struct device *dev)
 				 lfclk_work_handler);
 }
 
-static struct nrf_clock_control_driver_api lfclk_drv_api = {
+static DEVICE_API(nrf_clock_control, lfclk_drv_api) = {
 	.std_api = {
 		.on = api_nosys_on_off,
 		.off = api_nosys_on_off,


### PR DESCRIPTION
Add wrapper DEVICE_API macro to all nrf_clock_control_driver_api instances.