### PR TITLE
drivers: Place API into iterable section for trivial drivers

### DIFF
--- a/drivers/interrupt_controller/intc_intel_vtd.c
+++ b/drivers/interrupt_controller/intc_intel_vtd.c
@@ -523,7 +523,7 @@ out:
 	return ret;
 }
 
-static const struct vtd_driver_api vtd_api = {
+static DEVICE_API(vtd, vtd_api) = {
 	.allocate_entries = vtd_ictl_allocate_entries,
 	.remap_msi = vtd_ictl_remap_msi,
 	.remap = vtd_ictl_remap,

--- a/drivers/interrupt_controller/intc_shared_irq.c
+++ b/drivers/interrupt_controller/intc_shared_irq.c
@@ -130,7 +130,7 @@ static void shared_irq_isr(const struct device *dev)
 	}
 }
 
-static const struct shared_irq_driver_api api_funcs = {
+static DEVICE_API(shared_irq, api_funcs) = {
 	.isr_register = isr_register,
 	.enable = enable,
 	.disable = disable,

--- a/drivers/misc/timeaware_gpio/timeaware_gpio_intel.c
+++ b/drivers/misc/timeaware_gpio/timeaware_gpio_intel.c
@@ -188,7 +188,7 @@ static int tgpio_intel_read_ts_ec(const struct device *dev,
 	return 0;
 }
 
-static const struct tgpio_driver_api api_funcs = {
+static DEVICE_API(tgpio, api_funcs) = {
 	.pin_disable = tgpio_intel_pin_disable,
 	.get_time = tgpio_intel_get_time,
 	.set_perout = tgpio_intel_periodic_output,

--- a/drivers/peci/peci_ite_it8xxx2.c
+++ b/drivers/peci/peci_ite_it8xxx2.c
@@ -301,7 +301,7 @@ static void peci_it8xxx2_isr(const struct device *dev)
 	k_sem_give(&data->device_sync_sem);
 }
 
-static const struct peci_driver_api peci_it8xxx2_driver_api = {
+static DEVICE_API(peci, peci_it8xxx2_driver_api) = {
 	.config = peci_it8xxx2_configure,
 	.enable = peci_it8xxx2_enable,
 	.disable = peci_it8xxx2_disable,

--- a/drivers/peci/peci_mchp_xec.c
+++ b/drivers/peci/peci_mchp_xec.c
@@ -508,7 +508,7 @@ static void peci_xec_isr(const void *arg)
 }
 #endif
 
-static const struct peci_driver_api peci_xec_driver_api = {
+static DEVICE_API(peci, peci_xec_driver_api) = {
 	.config = peci_xec_configure,
 	.enable = peci_xec_enable,
 	.disable = peci_xec_disable,

--- a/drivers/peci/peci_npcx.c
+++ b/drivers/peci/peci_npcx.c
@@ -225,7 +225,7 @@ static void peci_npcx_isr(const struct device *dev)
 	k_sem_give(&data->trans_sync_sem);
 }
 
-static const struct peci_driver_api peci_npcx_driver_api = {
+static DEVICE_API(peci, peci_npcx_driver_api) = {
 	.config = peci_npcx_configure,
 	.enable = peci_npcx_enable,
 	.disable = peci_npcx_disable,

--- a/drivers/ps2/ps2_mchp_xec.c
+++ b/drivers/ps2/ps2_mchp_xec.c
@@ -337,7 +337,7 @@ static void ps2_xec_isr(const struct device *dev)
 	regs->CTRL = MCHP_PS2_CTRL_EN;
 }
 
-static const struct ps2_driver_api ps2_xec_driver_api = {
+static DEVICE_API(ps2, ps2_xec_driver_api) = {
 	.config = ps2_xec_configure,
 	.read = NULL,
 	.write = ps2_xec_write,

--- a/drivers/ps2/ps2_npcx_channel.c
+++ b/drivers/ps2/ps2_npcx_channel.c
@@ -96,7 +96,7 @@ static int ps2_npcx_channel_init(const struct device *dev)
 	return 0;
 }
 
-static const struct ps2_driver_api ps2_channel_npcx_driver_api = {
+static DEVICE_API(ps2, ps2_channel_npcx_driver_api) = {
 	.config = ps2_npcx_ch_configure,
 	.read = NULL,
 	.write = ps2_npcx_ch_write,

--- a/drivers/reset/reset_ast10x0.c
+++ b/drivers/reset/reset_ast10x0.c
@@ -91,7 +91,7 @@ static int aspeed_reset_line_toggle(const struct device *dev, uint32_t id)
 	return ret;
 }
 
-static const struct reset_driver_api aspeed_reset_api = {
+static DEVICE_API(reset, aspeed_reset_api) = {
 	.status = aspeed_reset_status,
 	.line_assert = aspeed_reset_line_assert,
 	.line_deassert = aspeed_reset_line_deassert,

--- a/drivers/reset/reset_gd32.c
+++ b/drivers/reset/reset_gd32.c
@@ -59,7 +59,7 @@ static int reset_gd32_line_toggle(const struct device *dev, uint32_t id)
 	return 0;
 }
 
-static const struct reset_driver_api reset_gd32_driver_api = {
+static DEVICE_API(reset, reset_gd32_driver_api) = {
 	.status = reset_gd32_status,
 	.line_assert = reset_gd32_line_assert,
 	.line_deassert = reset_gd32_line_deassert,

--- a/drivers/reset/reset_intel_socfpga.c
+++ b/drivers/reset/reset_intel_socfpga.c
@@ -89,7 +89,7 @@ static int32_t reset_intel_soc_init(const struct device *dev)
 	return 0;
 }
 
-static const struct reset_driver_api reset_intel_soc_driver_api = {
+static DEVICE_API(reset, reset_intel_soc_driver_api) = {
 	.status = reset_intel_soc_status,
 	.line_assert = reset_intel_soc_line_assert,
 	.line_deassert = reset_intel_soc_line_deassert,

--- a/drivers/reset/reset_lpc_syscon.c
+++ b/drivers/reset/reset_lpc_syscon.c
@@ -52,7 +52,7 @@ static int reset_nxp_syscon_line_toggle(const struct device *dev, uint32_t id)
 	return 0;
 }
 
-static const struct reset_driver_api reset_nxp_syscon_driver_api = {
+static DEVICE_API(reset, reset_nxp_syscon_driver_api) = {
 	.status = reset_nxp_syscon_status,
 	.line_assert = reset_nxp_syscon_line_assert,
 	.line_deassert = reset_nxp_syscon_line_deassert,

--- a/drivers/reset/reset_npcx.c
+++ b/drivers/reset/reset_npcx.c
@@ -66,7 +66,7 @@ static int reset_npcx_line_toggle(const struct device *dev, uint32_t id)
 	return ret;
 }
 
-static const struct reset_driver_api reset_npcx_driver_api = {
+static DEVICE_API(reset, reset_npcx_driver_api) = {
 	.line_toggle = reset_npcx_line_toggle,
 };
 

--- a/drivers/reset/reset_numaker.c
+++ b/drivers/reset/reset_numaker.c
@@ -59,7 +59,7 @@ static int reset_numaker_line_toggle(const struct device *dev, uint32_t id)
 	return 0;
 }
 
-static const struct reset_driver_api reset_numaker_driver_api = {
+static DEVICE_API(reset, reset_numaker_driver_api) = {
 	.status = reset_numaker_status,
 	.line_assert = reset_numaker_line_assert,
 	.line_deassert = reset_numaker_line_deassert,

--- a/drivers/reset/reset_nxp_rstctl.c
+++ b/drivers/reset/reset_nxp_rstctl.c
@@ -64,7 +64,7 @@ static int reset_nxp_rstctl_line_toggle(const struct device *dev, uint32_t id)
 	return 0;
 }
 
-static const struct reset_driver_api reset_nxp_rstctl_driver_api = {
+static DEVICE_API(reset, reset_nxp_rstctl_driver_api) = {
 	.status = reset_nxp_rstctl_status,
 	.line_assert = reset_nxp_rstctl_line_assert,
 	.line_deassert = reset_nxp_rstctl_line_deassert,

--- a/drivers/reset/reset_rpi_pico.c
+++ b/drivers/reset/reset_rpi_pico.c
@@ -138,7 +138,7 @@ static int reset_rpi_init(const struct device *dev)
 	return 0;
 }
 
-static const struct reset_driver_api reset_rpi_driver_api = {
+static DEVICE_API(reset, reset_rpi_driver_api) = {
 	.status = reset_rpi_status,
 	.line_assert = reset_rpi_line_assert,
 	.line_deassert = reset_rpi_line_deassert,

--- a/drivers/reset/reset_stm32.c
+++ b/drivers/reset/reset_stm32.c
@@ -63,7 +63,7 @@ static int reset_stm32_line_toggle(const struct device *dev, uint32_t id)
 	return 0;
 }
 
-static const struct reset_driver_api reset_stm32_driver_api = {
+static DEVICE_API(reset, reset_stm32_driver_api) = {
 	.status = reset_stm32_status,
 	.line_assert = reset_stm32_line_assert,
 	.line_deassert = reset_stm32_line_deassert,

--- a/drivers/sip_svc/sip_smc_intel_socfpga.c
+++ b/drivers/sip_svc/sip_smc_intel_socfpga.c
@@ -211,7 +211,7 @@ static int arm_sip_smc_init(const struct device *dev)
 	return 0;
 }
 
-static const struct svc_driver_api api = {
+static DEVICE_API(svc, api) = {
 	.sip_supervisory_call = intel_sip_secure_monitor_call,
 	.sip_svc_plat_get_trans_idx = intel_sip_smc_plat_get_trans_idx,
 	.sip_svc_plat_format_trans_id = intel_sip_smc_plat_format_trans_id,

--- a/drivers/smbus/intel_pch_smbus.c
+++ b/drivers/smbus/intel_pch_smbus.c
@@ -886,7 +886,7 @@ unlock:
 	return ret;
 }
 
-static const struct smbus_driver_api funcs = {
+static DEVICE_API(smbus, funcs) = {
 	.configure = pch_configure,
 	.get_config = pch_get_config,
 	.smbus_quick = pch_smbus_quick,

--- a/drivers/smbus/smbus_stm32.c
+++ b/drivers/smbus/smbus_stm32.c
@@ -247,7 +247,7 @@ static int smbus_stm32_block_write(const struct device *dev, uint16_t periph_add
 	return i2c_transfer(config->i2c_dev, messages, ARRAY_SIZE(messages), periph_addr);
 }
 
-static const struct smbus_driver_api smbus_stm32_api = {
+static DEVICE_API(smbus, smbus_stm32_api) = {
 	.configure = smbus_stm32_configure,
 	.get_config = smbus_stm32_get_config,
 	.smbus_quick = smbus_stm32_quick,

--- a/drivers/stepper/adi_tmc/adi_tmc5041_stepper_controller.c
+++ b/drivers/stepper/adi_tmc/adi_tmc5041_stepper_controller.c
@@ -721,7 +721,7 @@ static int tmc5041_stepper_init(const struct device *dev)
 		.stepper = DEVICE_DT_GET(child),};
 
 #define TMC5041_STEPPER_API_DEFINE(child)							\
-	static const struct stepper_driver_api tmc5041_stepper_api_##child = {			\
+	static DEVICE_API(stepper, tmc5041_stepper_api_##child) = {				\
 		.enable = tmc5041_stepper_enable,						\
 		.is_moving = tmc5041_stepper_is_moving,						\
 		.move = tmc5041_stepper_move,							\

--- a/drivers/stepper/fake_stepper_controller.c
+++ b/drivers/stepper/fake_stepper_controller.c
@@ -124,7 +124,7 @@ static int fake_stepper_init(const struct device *dev)
 	return 0;
 }
 
-static const struct stepper_driver_api fake_stepper_driver_api = {
+static DEVICE_API(stepper, fake_stepper_driver_api) = {
 	.enable = fake_stepper_enable,
 	.move = fake_stepper_move,
 	.is_moving = fake_stepper_is_moving,

--- a/drivers/stepper/gpio_stepper_controller.c
+++ b/drivers/stepper/gpio_stepper_controller.c
@@ -352,7 +352,7 @@ static int gpio_stepper_init(const struct device *dev)
 	return 0;
 }
 
-static const struct stepper_driver_api gpio_stepper_api = {
+static DEVICE_API(stepper, gpio_stepper_api) = {
 	.enable = gpio_stepper_enable,
 	.move = gpio_stepper_move,
 	.is_moving = gpio_stepper_is_moving,

--- a/drivers/syscon/syscon.c
+++ b/drivers/syscon/syscon.c
@@ -121,7 +121,7 @@ static int syscon_generic_get_size(const struct device *dev, size_t *size)
 	return 0;
 }
 
-static const struct syscon_driver_api syscon_generic_driver_api = {
+static DEVICE_API(syscon, syscon_generic_driver_api) = {
 	.read = syscon_generic_read_reg,
 	.write = syscon_generic_write_reg,
 	.get_base = syscon_generic_get_base,

--- a/drivers/tee/optee/optee.c
+++ b/drivers/tee/optee/optee.c
@@ -1259,7 +1259,7 @@ static int optee_init(const struct device *dev)
 	return 0;
 }
 
-static const struct tee_driver_api optee_driver_api = {
+static DEVICE_API(tee, optee_driver_api) = {
 	.get_version = optee_get_version,
 	.open_session = optee_open_session,
 	.close_session = optee_close_session,


### PR DESCRIPTION
Add wrapper DEVICE_API macro to all <class>_driver_api instances.