### PR TITLE
drivers: flash: Place API into iterable section

### DIFF
--- a/drivers/flash/flash_ambiq.c
+++ b/drivers/flash/flash_ambiq.c
@@ -211,7 +211,7 @@ static void flash_ambiq_pages_layout(const struct device *dev,
 }
 #endif /* CONFIG_FLASH_PAGE_LAYOUT */
 
-static const struct flash_driver_api flash_ambiq_driver_api = {
+static DEVICE_API(flash, flash_ambiq_driver_api) = {
 	.read = flash_ambiq_read,
 	.write = flash_ambiq_write,
 	.erase = flash_ambiq_erase,

--- a/drivers/flash/flash_andes_qspi.c
+++ b/drivers/flash/flash_andes_qspi.c
@@ -880,7 +880,7 @@ flash_andes_qspi_get_parameters(const struct device *dev)
 	return &config->parameters;
 }
 
-static const struct flash_driver_api flash_andes_qspi_api = {
+static DEVICE_API(flash, flash_andes_qspi_api) = {
 	.read = flash_andes_qspi_read,
 	.write = flash_andes_qspi_write,
 	.erase = flash_andes_qspi_erase,

--- a/drivers/flash/flash_cadence_nand.c
+++ b/drivers/flash/flash_cadence_nand.c
@@ -143,7 +143,7 @@ static const struct flash_parameters *flash_cdns_get_parameters(const struct dev
 
 	return &flash_cdns_parameters;
 }
-static const struct flash_driver_api flash_cdns_nand_api = {
+static DEVICE_API(flash, flash_cdns_nand_api) = {
 	.erase = flash_cdns_nand_erase,
 	.write = flash_cdns_nand_write,
 	.read = flash_cdns_nand_read,

--- a/drivers/flash/flash_cadence_qspi_nor.c
+++ b/drivers/flash/flash_cadence_qspi_nor.c
@@ -109,7 +109,7 @@ flash_cad_get_parameters(const struct device *dev)
 	return &flash_cad_parameters;
 }
 
-static const struct flash_driver_api flash_cad_api = {
+static DEVICE_API(flash, flash_cad_api) = {
 	.erase = flash_cad_erase,
 	.write = flash_cad_write,
 	.read = flash_cad_read,

--- a/drivers/flash/flash_esp32.c
+++ b/drivers/flash/flash_esp32.c
@@ -161,7 +161,7 @@ static int flash_esp32_init(const struct device *dev)
 	return 0;
 }
 
-static const struct flash_driver_api flash_esp32_driver_api = {
+static DEVICE_API(flash, flash_esp32_driver_api) = {
 	.read = flash_esp32_read,
 	.write = flash_esp32_write,
 	.erase = flash_esp32_erase,

--- a/drivers/flash/flash_gd32.c
+++ b/drivers/flash/flash_gd32.c
@@ -98,7 +98,7 @@ flash_gd32_get_parameters(const struct device *dev)
 	return &flash_gd32_parameters;
 }
 
-static const struct flash_driver_api flash_gd32_driver_api = {
+static DEVICE_API(flash, flash_gd32_driver_api) = {
 	.read = flash_gd32_read,
 	.write = flash_gd32_write,
 	.erase = flash_gd32_erase,

--- a/drivers/flash/flash_gecko.c
+++ b/drivers/flash/flash_gecko.c
@@ -216,7 +216,7 @@ static int flash_gecko_init(const struct device *dev)
 	return 0;
 }
 
-static const struct flash_driver_api flash_gecko_driver_api = {
+static DEVICE_API(flash, flash_gecko_driver_api) = {
 	.read = flash_gecko_read,
 	.write = flash_gecko_write,
 	.erase = flash_gecko_erase,

--- a/drivers/flash/flash_hp_ra.c
+++ b/drivers/flash/flash_hp_ra.c
@@ -51,7 +51,7 @@ void flash_ra_page_layout(const struct device *dev, const struct flash_pages_lay
 static int flash_ra_ex_op(const struct device *dev, uint16_t code, const uintptr_t in, void *out);
 #endif
 
-static const struct flash_driver_api flash_ra_api = {
+static DEVICE_API(flash, flash_ra_api) = {
 	.erase = flash_ra_erase,
 	.write = flash_ra_write,
 	.read = flash_ra_read,

--- a/drivers/flash/flash_ifx_cat1.c
+++ b/drivers/flash/flash_ifx_cat1.c
@@ -184,7 +184,7 @@ static int ifx_cat1_flash_init(const struct device *dev)
 	return 0;
 }
 
-static const struct flash_driver_api ifx_cat1_flash_driver_api = {
+static DEVICE_API(flash, ifx_cat1_flash_driver_api) = {
 	.read = ifx_cat1_flash_read,
 	.write = ifx_cat1_flash_write,
 	.erase = ifx_cat1_flash_erase,

--- a/drivers/flash/flash_ifx_cat1_qspi.c
+++ b/drivers/flash/flash_ifx_cat1_qspi.c
@@ -326,7 +326,7 @@ static int ifx_cat1_flash_init(const struct device *dev)
 	return 0;
 }
 
-static const struct flash_driver_api ifx_cat1_flash_driver_api = {
+static DEVICE_API(flash, ifx_cat1_flash_driver_api) = {
 	.read = ifx_cat1_flash_read,
 	.write = ifx_cat1_flash_write,
 	.erase = ifx_cat1_flash_erase,

--- a/drivers/flash/flash_ite_it8xxx2.c
+++ b/drivers/flash/flash_ite_it8xxx2.c
@@ -499,7 +499,7 @@ static void flash_it8xxx2_pages_layout(const struct device *dev,
 }
 #endif /* CONFIG_FLASH_PAGE_LAYOUT */
 
-static const struct flash_driver_api flash_it8xxx2_api = {
+static DEVICE_API(flash, flash_it8xxx2_api) = {
 	.erase = flash_it8xxx2_erase,
 	.write = flash_it8xxx2_write,
 	.read = flash_it8xxx2_read,

--- a/drivers/flash/flash_max32.c
+++ b/drivers/flash/flash_max32.c
@@ -132,7 +132,7 @@ static int flash_max32_init(const struct device *dev)
 	return ret != 0 ? -EIO : 0;
 }
 
-static const struct flash_driver_api flash_max32_driver_api = {
+static DEVICE_API(flash, flash_max32_driver_api) = {
 	.read = api_read,
 	.write = api_write,
 	.erase = api_erase,

--- a/drivers/flash/flash_mcux_flexspi_hyperflash.c
+++ b/drivers/flash/flash_mcux_flexspi_hyperflash.c
@@ -633,7 +633,7 @@ static int flash_flexspi_hyperflash_init(const struct device *dev)
 	return 0;
 }
 
-static const struct flash_driver_api flash_flexspi_hyperflash_api = {
+static DEVICE_API(flash, flash_flexspi_hyperflash_api) = {
 	.read = flash_flexspi_hyperflash_read,
 	.write = flash_flexspi_hyperflash_write,
 	.erase = flash_flexspi_hyperflash_erase,

--- a/drivers/flash/flash_mcux_flexspi_mx25um51345g.c
+++ b/drivers/flash/flash_mcux_flexspi_mx25um51345g.c
@@ -557,7 +557,7 @@ static int flash_flexspi_nor_init(const struct device *dev)
 	return 0;
 }
 
-static const struct flash_driver_api flash_flexspi_nor_api = {
+static DEVICE_API(flash, flash_flexspi_nor_api) = {
 	.erase = flash_flexspi_nor_erase,
 	.write = flash_flexspi_nor_write,
 	.read = flash_flexspi_nor_read,

--- a/drivers/flash/flash_mcux_flexspi_nor.c
+++ b/drivers/flash/flash_mcux_flexspi_nor.c
@@ -1264,7 +1264,7 @@ static int flash_flexspi_nor_init(const struct device *dev)
 	return 0;
 }
 
-static const struct flash_driver_api flash_flexspi_nor_api = {
+static DEVICE_API(flash, flash_flexspi_nor_api) = {
 	.erase = flash_flexspi_nor_erase,
 	.write = flash_flexspi_nor_write,
 	.read = flash_flexspi_nor_read,

--- a/drivers/flash/flash_mspi_atxp032.c
+++ b/drivers/flash/flash_mspi_atxp032.c
@@ -774,7 +774,7 @@ static int flash_mspi_atxp032_pm_action(const struct device *flash, enum pm_devi
 }
 #endif /** IS_ENABLED(CONFIG_PM_DEVICE) */
 
-static const struct flash_driver_api flash_mspi_atxp032_api = {
+static DEVICE_API(flash, flash_mspi_atxp032_api) = {
 	.erase = flash_mspi_atxp032_erase,
 	.write = flash_mspi_atxp032_write,
 	.read = flash_mspi_atxp032_read,

--- a/drivers/flash/flash_mspi_emul_device.c
+++ b/drivers/flash/flash_mspi_emul_device.c
@@ -339,7 +339,7 @@ static void flash_mspi_emul_pages_layout(const struct device *flash,
 }
 #endif /* CONFIG_FLASH_PAGE_LAYOUT */
 
-static const struct flash_driver_api flash_mspi_emul_device_api = {
+static DEVICE_API(flash, flash_mspi_emul_device_api) = {
 	.erase = flash_mspi_emul_erase,
 	.write = flash_mspi_emul_write,
 	.read = flash_mspi_emul_read,

--- a/drivers/flash/flash_npcx_fiu_nor.c
+++ b/drivers/flash/flash_npcx_fiu_nor.c
@@ -509,7 +509,7 @@ static int flash_npcx_nor_ex_op(const struct device *dev, uint16_t code,
 }
 #endif
 
-static const struct flash_driver_api flash_npcx_nor_driver_api = {
+static DEVICE_API(flash, flash_npcx_nor_driver_api) = {
 	.read = flash_npcx_nor_read,
 	.write = flash_npcx_nor_write,
 	.erase = flash_npcx_nor_erase,

--- a/drivers/flash/flash_nxp_s32_qspi_nor.c
+++ b/drivers/flash/flash_nxp_s32_qspi_nor.c
@@ -935,7 +935,7 @@ static int nxp_s32_qspi_init(const struct device *dev)
 	return ret;
 }
 
-static const struct flash_driver_api nxp_s32_qspi_api = {
+static DEVICE_API(flash, nxp_s32_qspi_api) = {
 	.erase = nxp_s32_qspi_erase,
 	.write = nxp_s32_qspi_write,
 	.read = nxp_s32_qspi_read,

--- a/drivers/flash/flash_rpi_pico.c
+++ b/drivers/flash/flash_rpi_pico.c
@@ -306,7 +306,7 @@ void flash_rpi_page_layout(const struct device *dev, const struct flash_pages_la
 
 #endif /* CONFIG_FLASH_PAGE_LAYOUT */
 
-static const struct flash_driver_api flash_rpi_driver_api = {
+static DEVICE_API(flash, flash_rpi_driver_api) = {
 	.read = flash_rpi_read,
 	.write = flash_rpi_write,
 	.erase = flash_rpi_erase,

--- a/drivers/flash/flash_sam.c
+++ b/drivers/flash/flash_sam.c
@@ -464,7 +464,7 @@ static void sam_flash_api_pages_layout(const struct device *dev,
 	*layout_size = config->pages_layouts_size;
 }
 
-static struct flash_driver_api sam_flash_api = {
+static DEVICE_API(flash, sam_flash_api) = {
 	.read = sam_flash_read,
 	.write = sam_flash_write,
 	.erase = sam_flash_erase,

--- a/drivers/flash/flash_sam0.c
+++ b/drivers/flash/flash_sam0.c
@@ -487,7 +487,7 @@ static int flash_sam0_init(const struct device *dev)
 	return flash_sam0_write_protection(dev, false);
 }
 
-static const struct flash_driver_api flash_sam0_api = {
+static DEVICE_API(flash, flash_sam0_api) = {
 	.erase = flash_sam0_erase,
 	.write = flash_sam0_write,
 	.read = flash_sam0_read,

--- a/drivers/flash/flash_si32.c
+++ b/drivers/flash/flash_si32.c
@@ -197,7 +197,7 @@ static int flash_si32_init(const struct device *dev)
 	return 0;
 }
 
-static const struct flash_driver_api flash_si32_driver_api = {
+static DEVICE_API(flash, flash_si32_driver_api) = {
 	.read = flash_si32_read,
 	.write = flash_si32_write,
 	.erase = flash_si32_erase,

--- a/drivers/flash/flash_simulator.c
+++ b/drivers/flash/flash_simulator.c
@@ -158,7 +158,7 @@ static uint8_t mock_flash[FLASH_SIMULATOR_FLASH_SIZE];
 #endif
 #endif /* CONFIG_ARCH_POSIX */
 
-static const struct flash_driver_api flash_sim_api;
+static DEVICE_API(flash, flash_sim_api);
 
 static const struct flash_parameters flash_sim_parameters = {
 	.write_block_size = FLASH_SIMULATOR_PROG_UNIT,
@@ -380,7 +380,7 @@ flash_sim_get_parameters(const struct device *dev)
 	return &flash_sim_parameters;
 }
 
-static const struct flash_driver_api flash_sim_api = {
+static DEVICE_API(flash, flash_sim_api) = {
 	.read = flash_sim_read,
 	.write = flash_sim_write,
 	.erase = flash_sim_erase,

--- a/drivers/flash/flash_smartbond.c
+++ b/drivers/flash/flash_smartbond.c
@@ -270,7 +270,7 @@ void flash_smartbond_page_layout(const struct device *dev,
 }
 #endif /* CONFIG_FLASH_PAGE_LAYOUT */
 
-static const struct flash_driver_api flash_smartbond_driver_api = {
+static DEVICE_API(flash, flash_smartbond_driver_api) = {
 	.read = flash_smartbond_read,
 	.write = flash_smartbond_write,
 	.erase = flash_smartbond_erase,

--- a/drivers/flash/flash_stm32.c
+++ b/drivers/flash/flash_stm32.c
@@ -507,7 +507,7 @@ static struct flash_stm32_priv flash_data = {
 #endif
 };
 
-static const struct flash_driver_api flash_stm32_api = {
+static DEVICE_API(flash, flash_stm32_api) = {
 	.erase = flash_stm32_erase,
 	.write = flash_stm32_write,
 	.read = flash_stm32_read,

--- a/drivers/flash/flash_stm32_ospi.c
+++ b/drivers/flash/flash_stm32_ospi.c
@@ -1702,7 +1702,7 @@ static void flash_stm32_ospi_pages_layout(const struct device *dev,
 }
 #endif
 
-static const struct flash_driver_api flash_stm32_ospi_driver_api = {
+static DEVICE_API(flash, flash_stm32_ospi_driver_api) = {
 	.read = flash_stm32_ospi_read,
 	.write = flash_stm32_ospi_write,
 	.erase = flash_stm32_ospi_erase,

--- a/drivers/flash/flash_stm32_qspi.c
+++ b/drivers/flash/flash_stm32_qspi.c
@@ -885,7 +885,7 @@ static void flash_stm32_qspi_pages_layout(const struct device *dev,
 }
 #endif
 
-static const struct flash_driver_api flash_stm32_qspi_driver_api = {
+static DEVICE_API(flash, flash_stm32_qspi_driver_api) = {
 	.read = flash_stm32_qspi_read,
 	.write = flash_stm32_qspi_write,
 	.erase = flash_stm32_qspi_erase,

--- a/drivers/flash/flash_stm32_xspi.c
+++ b/drivers/flash/flash_stm32_xspi.c
@@ -1539,7 +1539,7 @@ static void flash_stm32_xspi_pages_layout(const struct device *dev,
 }
 #endif
 
-static const struct flash_driver_api flash_stm32_xspi_driver_api = {
+static DEVICE_API(flash, flash_stm32_xspi_driver_api) = {
 	.read = flash_stm32_xspi_read,
 	.write = flash_stm32_xspi_write,
 	.erase = flash_stm32_xspi_erase,

--- a/drivers/flash/flash_stm32h7x.c
+++ b/drivers/flash/flash_stm32h7x.c
@@ -668,7 +668,7 @@ static struct flash_stm32_priv flash_data = {
 #endif
 };
 
-static const struct flash_driver_api flash_stm32h7_api = {
+static DEVICE_API(flash, flash_stm32h7_api) = {
 	.erase = flash_stm32h7_erase,
 	.write = flash_stm32h7_write,
 	.read = flash_stm32h7_read,

--- a/drivers/flash/flash_stm32wb0x.c
+++ b/drivers/flash/flash_stm32wb0x.c
@@ -427,7 +427,7 @@ void flash_wb0x_pages_layout(const struct device *dev,
 }
 #endif /* CONFIG_FLASH_PAGE_LAYOUT */
 
-static const struct flash_driver_api flash_wb0x_api = {
+static DEVICE_API(flash, flash_wb0x_api) = {
 	.erase = flash_wb0x_erase,
 	.write = flash_wb0x_write,
 	.read = flash_wb0x_read,

--- a/drivers/flash/flash_stm32wba_fm.c
+++ b/drivers/flash/flash_stm32wba_fm.c
@@ -198,7 +198,7 @@ void flash_stm32wba_page_layout(const struct device *dev,
 	*layout_size = 1;
 }
 
-static const struct flash_driver_api flash_stm32_api = {
+static DEVICE_API(flash, flash_stm32_api) = {
 	.erase = flash_stm32_erase,
 	.write = flash_stm32_write,
 	.read = flash_stm32_read,

--- a/drivers/flash/nrf_qspi_nor.c
+++ b/drivers/flash/nrf_qspi_nor.c
@@ -1185,7 +1185,7 @@ int qspi_nor_get_size(const struct device *dev, uint64_t *size)
 	return 0;
 }
 
-static const struct flash_driver_api qspi_nor_api = {
+static DEVICE_API(flash, qspi_nor_api) = {
 	.read = qspi_nor_read,
 	.write = qspi_nor_write,
 	.erase = qspi_nor_erase,

--- a/drivers/flash/soc_flash_b91.c
+++ b/drivers/flash/soc_flash_b91.c
@@ -220,7 +220,7 @@ static void flash_b91_pages_layout(const struct device *dev,
 
 static struct flash_b91_data flash_data;
 
-static const struct flash_driver_api flash_b91_api = {
+static DEVICE_API(flash, flash_b91_api) = {
 	.erase = flash_b91_erase,
 	.write = flash_b91_write,
 	.read = flash_b91_read,

--- a/drivers/flash/soc_flash_cc13xx_cc26xx.c
+++ b/drivers/flash/soc_flash_cc13xx_cc26xx.c
@@ -288,7 +288,7 @@ static void flash_cc13xx_cc26xx_layout(const struct device *dev,
 }
 #endif /* CONFIG_FLASH_PAGE_LAYOUT */
 
-static const struct flash_driver_api flash_cc13xx_cc26xx_api = {
+static DEVICE_API(flash, flash_cc13xx_cc26xx_api) = {
 	.erase = flash_cc13xx_cc26xx_erase,
 	.write = flash_cc13xx_cc26xx_write,
 	.read = flash_cc13xx_cc26xx_read,

--- a/drivers/flash/soc_flash_lpc.c
+++ b/drivers/flash/soc_flash_lpc.c
@@ -145,7 +145,7 @@ flash_lpc_get_parameters(const struct device *dev)
 
 static struct flash_priv flash_data;
 
-static const struct flash_driver_api flash_lpc_api = {
+static DEVICE_API(flash, flash_lpc_api) = {
 	.erase = flash_lpc_erase,
 	.write = flash_lpc_write,
 	.read = flash_lpc_read,

--- a/drivers/flash/soc_flash_mcux.c
+++ b/drivers/flash/soc_flash_mcux.c
@@ -346,7 +346,7 @@ flash_mcux_get_parameters(const struct device *dev)
 
 static struct flash_priv flash_data;
 
-static const struct flash_driver_api flash_mcux_api = {
+static DEVICE_API(flash, flash_mcux_api) = {
 	.erase = flash_mcux_erase,
 	.write = flash_mcux_write,
 	.read = flash_mcux_read,

--- a/drivers/flash/soc_flash_nios2_qspi.c
+++ b/drivers/flash/soc_flash_nios2_qspi.c
@@ -490,7 +490,7 @@ flash_nios2_qspi_get_parameters(const struct device *dev)
 	return &flash_nios2_qspi_parameters;
 }
 
-static const struct flash_driver_api flash_nios2_qspi_api = {
+static DEVICE_API(flash, flash_nios2_qspi_api) = {
 	.erase = flash_nios2_qspi_erase,
 	.write = flash_nios2_qspi_write,
 	.read = flash_nios2_qspi_read,

--- a/drivers/flash/soc_flash_nrf.c
+++ b/drivers/flash/soc_flash_nrf.c
@@ -290,7 +290,7 @@ flash_nrf_get_parameters(const struct device *dev)
 	return &flash_nrf_parameters;
 }
 
-static const struct flash_driver_api flash_nrf_api = {
+static DEVICE_API(flash, flash_nrf_api) = {
 	.read = flash_nrf_read,
 	.write = flash_nrf_write,
 	.erase = flash_nrf_erase,

--- a/drivers/flash/soc_flash_nrf_mram.c
+++ b/drivers/flash/soc_flash_nrf_mram.c
@@ -175,7 +175,7 @@ static void nrf_mram_page_layout(const struct device *dev, const struct flash_pa
 }
 #endif
 
-static const struct flash_driver_api nrf_mram_api = {
+static DEVICE_API(flash, nrf_mram_api) = {
 	.read = nrf_mram_read,
 	.write = nrf_mram_write,
 	.erase = nrf_mram_erase,

--- a/drivers/flash/soc_flash_nrf_rram.c
+++ b/drivers/flash/soc_flash_nrf_rram.c
@@ -342,7 +342,7 @@ static void nrf_rram_page_layout(const struct device *dev, const struct flash_pa
 }
 #endif
 
-static const struct flash_driver_api nrf_rram_api = {
+static DEVICE_API(flash, nrf_rram_api) = {
 	.read = nrf_rram_read,
 	.write = nrf_rram_write,
 	.erase = nrf_rram_erase,

--- a/drivers/flash/soc_flash_numaker.c
+++ b/drivers/flash/soc_flash_numaker.c
@@ -252,7 +252,7 @@ static const struct flash_parameters *flash_numaker_get_parameters(const struct 
 
 static struct flash_numaker_data flash_data;
 
-static const struct flash_driver_api flash_numaker_api = {
+static DEVICE_API(flash, flash_numaker_api) = {
 	.erase = flash_numaker_erase,
 	.write = flash_numaker_write,
 	.read = flash_numaker_read,

--- a/drivers/flash/soc_flash_numaker_rmc.c
+++ b/drivers/flash/soc_flash_numaker_rmc.c
@@ -246,7 +246,7 @@ static const struct flash_parameters *flash_numaker_get_parameters(const struct 
 
 static struct flash_numaker_data flash_data;
 
-static const struct flash_driver_api flash_numaker_api = {
+static DEVICE_API(flash, flash_numaker_api) = {
 	.erase = flash_numaker_erase,
 	.write = flash_numaker_write,
 	.read = flash_numaker_read,

--- a/drivers/flash/soc_flash_rv32m1.c
+++ b/drivers/flash/soc_flash_rv32m1.c
@@ -132,7 +132,7 @@ flash_mcux_get_parameters(const struct device *dev)
 
 static struct flash_priv flash_data;
 
-static const struct flash_driver_api flash_mcux_api = {
+static DEVICE_API(flash, flash_mcux_api) = {
 	.erase = flash_mcux_erase,
 	.write = flash_mcux_write,
 	.read = flash_mcux_read,

--- a/drivers/flash/soc_flash_xmc4xxx.c
+++ b/drivers/flash/soc_flash_xmc4xxx.c
@@ -180,14 +180,15 @@ static const struct flash_parameters *flash_xmc4xxx_get_parameters(const struct 
 	return &dev_config->parameters;
 }
 
-static const struct flash_driver_api flash_xmc4xxx_api = {.erase = flash_xmc4xxx_erase,
-							  .write = flash_xmc4xxx_write,
-							  .read = flash_xmc4xxx_read,
+static DEVICE_API(flash, flash_xmc4xxx_api) = {
+	.erase = flash_xmc4xxx_erase,
+	.write = flash_xmc4xxx_write,
+	.read = flash_xmc4xxx_read,
 #ifdef CONFIG_FLASH_PAGE_LAYOUT
-							  .page_layout = flash_xmc4xxx_page_layout,
+	.page_layout = flash_xmc4xxx_page_layout,
 #endif
-							  .get_parameters =
-								  flash_xmc4xxx_get_parameters};
+	.get_parameters = flash_xmc4xxx_get_parameters,
+};
 
 static struct flash_xmc4xxx_data flash_xmc4xxx_data_0;
 static struct flash_xmc4xxx_config flash_xmc4xxx_cfg_0 = {

--- a/drivers/flash/spi_flash_at45.c
+++ b/drivers/flash/spi_flash_at45.c
@@ -655,7 +655,7 @@ static int spi_flash_at45_get_size(const struct device *dev, uint64_t *size)
 	return 0;
 }
 
-static const struct flash_driver_api spi_flash_at45_api = {
+static DEVICE_API(flash, spi_flash_at45_api) = {
 	.read = spi_flash_at45_read,
 	.write = spi_flash_at45_write,
 	.erase = spi_flash_at45_erase,

--- a/drivers/flash/spi_nor.c
+++ b/drivers/flash/spi_nor.c
@@ -1683,7 +1683,7 @@ static int flash_nor_get_size(const struct device *dev, uint64_t *size)
 	return 0;
 }
 
-static const struct flash_driver_api spi_nor_api = {
+static DEVICE_API(flash, spi_nor_api) = {
 	.read = spi_nor_read,
 	.write = spi_nor_write,
 	.erase = spi_nor_erase,

--- a/tests/drivers/flash_api/src/main.c
+++ b/tests/drivers/flash_api/src/main.c
@@ -50,7 +50,7 @@ static struct device_state some_dev_state = {
 };
 
 /* Device with get_size */
-const static struct flash_driver_api size_fun_api = {
+static DEVICE_API(flash, size_fun_api) = {
 	.get_size = some_get_size,
 };
 const static struct device size_fun_dev = {
@@ -61,7 +61,7 @@ const static struct device size_fun_dev = {
 };
 
 /* No functions device */
-const static struct flash_driver_api no_fun_api = {0};
+static DEVICE_API(flash, no_fun_api) = {0};
 const static struct device no_fun_dev = {
 	"no_fun",
 	NULL,
@@ -70,7 +70,7 @@ const static struct device no_fun_dev = {
 };
 
 /* Device with get_size implemented but returning -ENOTSUP */
-static struct flash_driver_api enotsup_fun_api = {
+static DEVICE_API(flash, enotsup_fun_api) = {
 	.get_size = enotsup_get_size,
 };
 static struct device enotsup_fun_dev = {

--- a/tests/subsys/fs/multi-fs/src/test_ram_backend.c
+++ b/tests/subsys/fs/multi-fs/src/test_ram_backend.c
@@ -77,7 +77,7 @@ static void test_flash_ram_pages_layout(const struct device *dev,
 	*layout_size = ARRAY_SIZE(dev_layout);
 }
 
-static const struct flash_driver_api flash_ram_api = {
+static DEVICE_API(flash, flash_ram_api) = {
 	.erase = test_flash_ram_erase,
 	.write = test_flash_ram_write,
 	.read = test_flash_ram_read,


### PR DESCRIPTION
Add wrapper DEVICE_API macro to all flash_driver_api instances.