### PR TITLE
storage/stream_flash: Make write callback optional

### DIFF
--- a/include/zephyr/storage/stream_flash.h
+++ b/include/zephyr/storage/stream_flash.h
@@ -61,7 +61,9 @@ struct stream_flash_ctx {
 	size_t bytes_written; /* Number of bytes written to flash */
 	size_t offset; /* Offset from base of flash device to write area */
 	size_t available; /* Available bytes in write area */
+#ifdef CONFIG_STREAM_FLASH_POST_WRITE_CALLBACK
 	stream_flash_callback_t callback; /* Callback invoked after write op */
+#endif
 #ifdef CONFIG_STREAM_FLASH_ERASE
 	off_t last_erased_page_start_offset; /* Last erased offset */
 #endif
@@ -82,6 +84,8 @@ struct stream_flash_ctx {
  *             If this is '0', the size will be set to the total size
  *             of the flash device minus the offset.
  * @param cb Callback to be invoked on completed flash write operations.
+ *           Callback is supported when CONFIG_STREAM_FLASH_POST_WRITE_CALLBACK
+ *           is enabled.
  *
  * @return non-negative on success, negative errno code on fail
  */

--- a/subsys/storage/stream/Kconfig
+++ b/subsys/storage/stream/Kconfig
@@ -12,6 +12,14 @@ menuconfig STREAM_FLASH
 
 if STREAM_FLASH
 
+config STREAM_FLASH_POST_WRITE_CALLBACK
+	bool "Write complete callback"
+	default y
+	help
+	  Enable callback that will be invoked once data is synchronized from
+	  stream to device. When callback is not used, disabling the option
+	  allows to save some code storage and RAM.
+
 config STREAM_FLASH_ERASE
 	bool "Perform erase operations"
 	depends on FLASH_HAS_EXPLICIT_ERASE

--- a/subsys/storage/stream/stream_flash.c
+++ b/subsys/storage/stream/stream_flash.c
@@ -165,6 +165,8 @@ static int flash_sync(struct stream_flash_ctx *ctx)
 		return rc;
 	}
 
+#if defined(CONFIG_STREAM_FLASH_POST_WRITE_CALLBACK)
+
 	if (ctx->callback) {
 		/* Invert to ensure that caller is able to discover a faulty
 		 * flash_read() even if no error code is returned.
@@ -186,6 +188,8 @@ static int flash_sync(struct stream_flash_ctx *ctx)
 			return rc;
 		}
 	}
+
+#endif
 
 	ctx->bytes_written += ctx->buf_bytes;
 	ctx->buf_bytes = 0U;
@@ -317,7 +321,12 @@ int stream_flash_init(struct stream_flash_ctx *ctx, const struct device *fdev,
 	ctx->offset = offset;
 	ctx->available = (size == 0 ? inspect_flash_ctx.total_size - offset :
 				      size);
+
+#if !defined(CONFIG_STREAM_FLASH_POST_WRITE_CALLBACK)
+	ARG_UNUSED(cb);
+#else
 	ctx->callback = cb;
+#endif
 
 #ifdef CONFIG_STREAM_FLASH_ERASE
 	ctx->last_erased_page_start_offset = -1;

--- a/tests/subsys/storage/stream/stream_flash/prj.conf
+++ b/tests/subsys/storage/stream/stream_flash/prj.conf
@@ -13,3 +13,6 @@ CONFIG_SETTINGS=y
 CONFIG_STREAM_FLASH=y
 CONFIG_STREAM_FLASH_ERASE=y
 CONFIG_STREAM_FLASH_PROGRESS=y
+# It case if this is no longer y by default in Kconfig as
+# the tests are not ready to not test the feature.
+CONFIG_STREAM_FLASH_POST_WRITE_CALLBACK=y


### PR DESCRIPTION
The commit adds Kconfig option CONFIG_STREAM_FLASH_POST_WRITE_CALLBACK that allows to turn off support for callback invoked after data is written to storage device.
If the feature is not used disabling it allows to save some storage.

For example allows to shave off ~140 bytes from smp_svr built for nrf52840.