### PR TITLE
scripts: build: gen_app_partitions: enquote archive name wildcards

### DIFF
--- a/scripts/build/gen_app_partitions.py
+++ b/scripts/build/gen_app_partitions.py
@@ -58,7 +58,7 @@ data_template = """
 """
 
 library_data_template = """
-		*{0}:*(.data .data.* .sdata .sdata.*)
+		\"*{0}:*\"(.data .data.* .sdata .sdata.*)
 """
 
 bss_template = """
@@ -67,7 +67,7 @@ bss_template = """
 """
 
 library_bss_template = """
-		*{0}:*(.bss .bss.* .sbss .sbss.* COMMON COMMON.*)
+		\"*{0}:*\"(.bss .bss.* .sbss .sbss.* COMMON COMMON.*)
 """
 
 footer_template = """


### PR DESCRIPTION
Some linkers (e.g. the ARC MWDT one) don't recognize wildcards in file names if they are not enclosed in quotes. Looks like the quotes have no negative effect on the GNU ld linker, so just do it unconditionally.