### PR TITLE
drivers: espi: Place API into iterable section

### DIFF
--- a/drivers/espi/espi_it8xxx2.c
+++ b/drivers/espi/espi_it8xxx2.c
@@ -1336,7 +1336,7 @@ static void espi_it8xxx2_flash_init(const struct device *dev)
 /* eSPI driver registration */
 static int espi_it8xxx2_init(const struct device *dev);
 
-static const struct espi_driver_api espi_it8xxx2_driver_api = {
+static DEVICE_API(espi, espi_it8xxx2_driver_api) = {
 	.config = espi_it8xxx2_configure,
 	.get_channel_status = espi_it8xxx2_channel_ready,
 	.send_vwire = espi_it8xxx2_send_vwire,

--- a/drivers/espi/espi_mchp_xec.c
+++ b/drivers/espi/espi_mchp_xec.c
@@ -1430,7 +1430,7 @@ static void espi_xec_periph_isr(const struct device *dev)
 
 static int espi_xec_init(const struct device *dev);
 
-static const struct espi_driver_api espi_xec_driver_api = {
+static DEVICE_API(espi, espi_xec_driver_api) = {
 	.config = espi_xec_configure,
 	.get_channel_status = espi_xec_channel_ready,
 	.send_vwire = espi_xec_send_vwire,

--- a/drivers/espi/espi_mchp_xec_v2.c
+++ b/drivers/espi/espi_mchp_xec_v2.c
@@ -1250,7 +1250,7 @@ const struct espi_vw_isr m2s_vwires_isr[] = {
 
 static int espi_xec_init(const struct device *dev);
 
-static const struct espi_driver_api espi_xec_driver_api = {
+static DEVICE_API(espi, espi_xec_driver_api) = {
 	.config = espi_xec_configure,
 	.get_channel_status = espi_xec_channel_ready,
 	.send_vwire = espi_xec_send_vwire,

--- a/drivers/espi/espi_npcx.c
+++ b/drivers/espi/espi_npcx.c
@@ -1347,7 +1347,7 @@ void npcx_espi_disable_interrupts(const struct device *dev)
 /* eSPI driver registration */
 static int espi_npcx_init(const struct device *dev);
 
-static const struct espi_driver_api espi_npcx_driver_api = {
+static DEVICE_API(espi, espi_npcx_driver_api) = {
 	.config = espi_npcx_configure,
 	.get_channel_status = espi_npcx_channel_ready,
 	.send_vwire = espi_npcx_send_vwire,

--- a/drivers/espi/espi_saf_mchp_xec.c
+++ b/drivers/espi/espi_saf_mchp_xec.c
@@ -818,7 +818,7 @@ static int espi_saf_xec_activate(const struct device *dev)
 
 static int espi_saf_xec_init(const struct device *dev);
 
-static const struct espi_saf_driver_api espi_saf_xec_driver_api = {
+static DEVICE_API(espi_saf, espi_saf_xec_driver_api) = {
 	.config = espi_saf_xec_configuration,
 	.set_protection_regions = espi_saf_xec_set_pr,
 	.activate = espi_saf_xec_activate,

--- a/drivers/espi/espi_saf_mchp_xec_v2.c
+++ b/drivers/espi/espi_saf_mchp_xec_v2.c
@@ -1062,7 +1062,7 @@ static void espi_saf_err_isr(const struct device *dev)
 	espi_send_callbacks(&data->callbacks, dev, evt);
 }
 
-static const struct espi_saf_driver_api espi_saf_xec_driver_api = {
+static DEVICE_API(espi_saf, espi_saf_xec_driver_api) = {
 	.config = espi_saf_xec_configuration,
 	.set_protection_regions = espi_saf_xec_set_pr,
 	.activate = espi_saf_xec_activate,

--- a/drivers/espi/espi_taf_npcx.c
+++ b/drivers/espi/espi_taf_npcx.c
@@ -638,7 +638,7 @@ static int espi_taf_npcx_init(const struct device *dev)
 	return 0;
 }
 
-static const struct espi_saf_driver_api espi_taf_npcx_driver_api = {
+static DEVICE_API(espi_saf, espi_taf_npcx_driver_api) = {
 	.config = espi_taf_npcx_configure,
 	.set_protection_regions = espi_taf_npcx_set_pr,
 	.activate = espi_taf_npcx_activate,

--- a/drivers/mspi/mspi_ambiq_ap3.c
+++ b/drivers/mspi/mspi_ambiq_ap3.c
@@ -1320,7 +1320,7 @@ static int mspi_ambiq_init(const struct device *controller)
 	return mspi_ambiq_config(&spec);
 }
 
-static struct mspi_driver_api mspi_ambiq_driver_api = {
+static DEVICE_API(mspi, mspi_ambiq_driver_api) = {
 	.config                = mspi_ambiq_config,
 	.dev_config            = mspi_ambiq_dev_config,
 	.xip_config            = mspi_ambiq_xip_config,


### PR DESCRIPTION
Add wrapper DEVICE_API macro to all espi/mspi driver_api instances.