### PR TITLE
drivers: watchdog: Place API into iterable section

### DIFF
--- a/drivers/watchdog/wdt_ambiq.c
+++ b/drivers/watchdog/wdt_ambiq.c
@@ -166,7 +166,7 @@ static int wdt_ambiq_init(const struct device *dev)
 	return 0;
 }
 
-static const struct wdt_driver_api wdt_ambiq_driver_api = {
+static DEVICE_API(wdt, wdt_ambiq_driver_api) = {
 	.setup = wdt_ambiq_setup,
 	.disable = wdt_ambiq_disable,
 	.install_timeout = wdt_ambiq_install_timeout,

--- a/drivers/watchdog/wdt_andes_atcwdt200.c
+++ b/drivers/watchdog/wdt_andes_atcwdt200.c
@@ -299,7 +299,7 @@ static int wdt_atcwdt200_feed(const struct device *dev, int channel_id)
 	return 0;
 }
 
-static const struct wdt_driver_api wdt_atcwdt200_api = {
+static DEVICE_API(wdt, wdt_atcwdt200_api) = {
 	.setup = wdt_atcwdt200_setup,
 	.disable = wdt_atcwdt200_disable,
 	.install_timeout = wdt_atcwdt200_install_timeout,

--- a/drivers/watchdog/wdt_cc13xx_cc26xx.c
+++ b/drivers/watchdog/wdt_cc13xx_cc26xx.c
@@ -213,7 +213,7 @@ static int wdt_cc13xx_cc26xx_init(const struct device *dev)
 	return wdt_cc13xx_cc26xx_setup(dev, options);
 }
 
-static const struct wdt_driver_api wdt_cc13xx_cc26xx_api = {
+static DEVICE_API(wdt, wdt_cc13xx_cc26xx_api) = {
 	.setup = wdt_cc13xx_cc26xx_setup,
 	.disable = wdt_cc13xx_cc26xx_disable,
 	.install_timeout = wdt_cc13xx_cc26xx_install_timeout,

--- a/drivers/watchdog/wdt_cc32xx.c
+++ b/drivers/watchdog/wdt_cc32xx.c
@@ -161,7 +161,7 @@ static int wdt_cc32xx_init(const struct device *dev)
 	return rv;
 }
 
-static const struct wdt_driver_api wdt_cc32xx_api = {
+static DEVICE_API(wdt, wdt_cc32xx_api) = {
 	.setup = wdt_cc32xx_setup,
 	.disable = wdt_cc32xx_disable,
 	.install_timeout = wdt_cc32xx_install_timeout,

--- a/drivers/watchdog/wdt_cmsdk_apb.c
+++ b/drivers/watchdog/wdt_cmsdk_apb.c
@@ -152,7 +152,7 @@ static int wdog_cmsdk_apb_feed(const struct device *dev, int channel_id)
 	return 0;
 }
 
-static const struct wdt_driver_api wdog_cmsdk_apb_api = {
+static DEVICE_API(wdt, wdog_cmsdk_apb_api) = {
 	.setup = wdog_cmsdk_apb_setup,
 	.disable = wdog_cmsdk_apb_disable,
 	.install_timeout = wdog_cmsdk_apb_install_timeout,

--- a/drivers/watchdog/wdt_counter.c
+++ b/drivers/watchdog/wdt_counter.c
@@ -149,7 +149,7 @@ static int wdt_counter_feed(const struct device *dev, int chan_id)
 	return timeout_set(dev, chan_id, true);
 }
 
-static const struct wdt_driver_api wdt_counter_driver_api = {
+static DEVICE_API(wdt, wdt_counter_driver_api) = {
 	.setup = wdt_counter_setup,
 	.disable = wdt_counter_disable,
 	.install_timeout = wdt_counter_install_timeout,

--- a/drivers/watchdog/wdt_dw.c
+++ b/drivers/watchdog/wdt_dw.c
@@ -148,7 +148,7 @@ int dw_wdt_disable(const struct device *dev)
 	return ret;
 }
 
-static const struct wdt_driver_api dw_wdt_api = {
+static DEVICE_API(wdt, dw_wdt_api) = {
 	.setup = dw_wdt_setup,
 	.disable = dw_wdt_disable,
 	.install_timeout = dw_wdt_install_timeout,

--- a/drivers/watchdog/wdt_ene_kb1200.c
+++ b/drivers/watchdog/wdt_ene_kb1200.c
@@ -143,7 +143,7 @@ static void wdt_kb1200_isr(const struct device *dev)
 	}
 }
 
-static const struct wdt_driver_api wdt_kb1200_api = {
+static DEVICE_API(wdt, wdt_kb1200_api) = {
 	.setup = wdt_kb1200_setup,
 	.disable = wdt_kb1200_disable,
 	.install_timeout = wdt_kb1200_install_timeout,

--- a/drivers/watchdog/wdt_esp32.c
+++ b/drivers/watchdog/wdt_esp32.c
@@ -185,7 +185,7 @@ static int wdt_esp32_init(const struct device *dev)
 	return 0;
 }
 
-static const struct wdt_driver_api wdt_api = {
+static DEVICE_API(wdt, wdt_api) = {
 	.setup = wdt_esp32_set_config,
 	.disable = wdt_esp32_disable,
 	.install_timeout = wdt_esp32_install_timeout,

--- a/drivers/watchdog/wdt_fwdgt_gd32.c
+++ b/drivers/watchdog/wdt_fwdgt_gd32.c
@@ -146,7 +146,7 @@ static int gd32_fwdgt_feed(const struct device *dev, int channel_id)
 	return 0;
 }
 
-static const struct wdt_driver_api fwdgt_gd32_api = {
+static DEVICE_API(wdt, fwdgt_gd32_api) = {
 	.setup = gd32_fwdgt_setup,
 	.disable = gd32_fwdgt_disable,
 	.install_timeout = gd32_fwdgt_install_timeout,

--- a/drivers/watchdog/wdt_gecko.c
+++ b/drivers/watchdog/wdt_gecko.c
@@ -271,7 +271,7 @@ static int wdt_gecko_init(const struct device *dev)
 	return 0;
 }
 
-static const struct wdt_driver_api wdt_gecko_driver_api = {
+static DEVICE_API(wdt, wdt_gecko_driver_api) = {
 	.setup = wdt_gecko_setup,
 	.disable = wdt_gecko_disable,
 	.install_timeout = wdt_gecko_install_timeout,

--- a/drivers/watchdog/wdt_ifx_cat1.c
+++ b/drivers/watchdog/wdt_ifx_cat1.c
@@ -132,7 +132,7 @@ static int ifx_cat1_wdt_init(const struct device *dev)
 	return 0;
 }
 
-static const struct wdt_driver_api ifx_cat1_wdt_api = {
+static DEVICE_API(wdt, ifx_cat1_wdt_api) = {
 	.setup = ifx_cat1_wdt_setup,
 	.disable = ifx_cat1_wdt_disable,
 	.install_timeout = ifx_cat1_wdt_install_timeout,

--- a/drivers/watchdog/wdt_intel_adsp.c
+++ b/drivers/watchdog/wdt_intel_adsp.c
@@ -216,7 +216,7 @@ int dw_wdt_disable(const struct device *dev)
 	return -ENOTSUP;
 }
 
-static const struct wdt_driver_api intel_adsp_wdt_api = {
+static DEVICE_API(wdt, intel_adsp_wdt_api) = {
 	.setup = intel_adsp_wdt_setup,
 	.disable = dw_wdt_disable,
 	.install_timeout = intel_adsp_wdt_install_timeout,

--- a/drivers/watchdog/wdt_ite_it8xxx2.c
+++ b/drivers/watchdog/wdt_ite_it8xxx2.c
@@ -236,7 +236,7 @@ static void wdt_it8xxx2_isr(const struct device *dev)
 	LOG_DBG("WDT ISR");
 }
 
-static const struct wdt_driver_api wdt_it8xxx2_api = {
+static DEVICE_API(wdt, wdt_it8xxx2_api) = {
 	.setup = wdt_it8xxx2_setup,
 	.disable = wdt_it8xxx2_disable,
 	.install_timeout = wdt_it8xxx2_install_timeout,

--- a/drivers/watchdog/wdt_iwdg_stm32.c
+++ b/drivers/watchdog/wdt_iwdg_stm32.c
@@ -179,7 +179,7 @@ static int iwdg_stm32_feed(const struct device *dev, int channel_id)
 	return 0;
 }
 
-static const struct wdt_driver_api iwdg_stm32_api = {
+static DEVICE_API(wdt, iwdg_stm32_api) = {
 	.setup = iwdg_stm32_setup,
 	.disable = iwdg_stm32_disable,
 	.install_timeout = iwdg_stm32_install_timeout,

--- a/drivers/watchdog/wdt_litex.c
+++ b/drivers/watchdog/wdt_litex.c
@@ -203,7 +203,7 @@ static int wdt_litex_init(const struct device *dev)
 	return 0;
 }
 
-static const struct wdt_driver_api wdt_api = {
+static DEVICE_API(wdt, wdt_api) = {
 	.setup = wdt_litex_setup,
 	.disable = wdt_litex_disable,
 	.install_timeout = wdt_litex_install_timeout,

--- a/drivers/watchdog/wdt_max32.c
+++ b/drivers/watchdog/wdt_max32.c
@@ -242,10 +242,12 @@ static int wdt_max32_init(const struct device *dev)
 	return 0;
 }
 
-static const struct wdt_driver_api max32_wdt_api = {.setup = wdt_max32_setup,
-						    .disable = wdt_max32_disable,
-						    .install_timeout = wdt_max32_install_timeout,
-						    .feed = wdt_max32_feed};
+static DEVICE_API(wdt, max32_wdt_api) = {
+	.setup = wdt_max32_setup,
+	.disable = wdt_max32_disable,
+	.install_timeout = wdt_max32_install_timeout,
+	.feed = wdt_max32_feed,
+};
 
 #define MAX32_WDT_INIT(_num)                                                                       \
 	static void wdt_max32_irq_init_##_num(void)                                                \

--- a/drivers/watchdog/wdt_mchp_xec.c
+++ b/drivers/watchdog/wdt_mchp_xec.c
@@ -166,7 +166,7 @@ static void wdt_xec_isr(const struct device *dev)
 	regs->IEN &= ~MCHP_WDT_IEN_EVENT_IRQ_EN;
 }
 
-static const struct wdt_driver_api wdt_xec_api = {
+static DEVICE_API(wdt, wdt_xec_api) = {
 	.setup = wdt_xec_setup,
 	.disable = wdt_xec_disable,
 	.install_timeout = wdt_xec_install_timeout,

--- a/drivers/watchdog/wdt_mcux_imx_wdog.c
+++ b/drivers/watchdog/wdt_mcux_imx_wdog.c
@@ -149,7 +149,7 @@ static int mcux_wdog_init(const struct device *dev)
 	return 0;
 }
 
-static const struct wdt_driver_api mcux_wdog_api = {
+static DEVICE_API(wdt, mcux_wdog_api) = {
 	.setup = mcux_wdog_setup,
 	.disable = mcux_wdog_disable,
 	.install_timeout = mcux_wdog_install_timeout,

--- a/drivers/watchdog/wdt_mcux_wdog.c
+++ b/drivers/watchdog/wdt_mcux_wdog.c
@@ -156,7 +156,7 @@ static int mcux_wdog_init(const struct device *dev)
 	return 0;
 }
 
-static const struct wdt_driver_api mcux_wdog_api = {
+static DEVICE_API(wdt, mcux_wdog_api) = {
 	.setup = mcux_wdog_setup,
 	.disable = mcux_wdog_disable,
 	.install_timeout = mcux_wdog_install_timeout,

--- a/drivers/watchdog/wdt_mcux_wdog32.c
+++ b/drivers/watchdog/wdt_mcux_wdog32.c
@@ -178,7 +178,7 @@ static int mcux_wdog32_init(const struct device *dev)
 	return 0;
 }
 
-static const struct wdt_driver_api mcux_wdog32_api = {
+static DEVICE_API(wdt, mcux_wdog32_api) = {
 	.setup = mcux_wdog32_setup,
 	.disable = mcux_wdog32_disable,
 	.install_timeout = mcux_wdog32_install_timeout,

--- a/drivers/watchdog/wdt_mcux_wwdt.c
+++ b/drivers/watchdog/wdt_mcux_wwdt.c
@@ -173,7 +173,7 @@ static int mcux_wwdt_init(const struct device *dev)
 	return 0;
 }
 
-static const struct wdt_driver_api mcux_wwdt_api = {
+static DEVICE_API(wdt, mcux_wwdt_api) = {
 	.setup = mcux_wwdt_setup,
 	.disable = mcux_wwdt_disable,
 	.install_timeout = mcux_wwdt_install_timeout,

--- a/drivers/watchdog/wdt_npcx.c
+++ b/drivers/watchdog/wdt_npcx.c
@@ -328,7 +328,7 @@ static int wdt_npcx_feed(const struct device *dev, int channel_id)
 }
 
 /* WDT driver registration */
-static const struct wdt_driver_api wdt_npcx_driver_api = {
+static DEVICE_API(wdt, wdt_npcx_driver_api) = {
 	.setup = wdt_npcx_setup,
 	.disable = wdt_npcx_disable,
 	.install_timeout = wdt_npcx_install_timeout,

--- a/drivers/watchdog/wdt_npm1300.c
+++ b/drivers/watchdog/wdt_npm1300.c
@@ -124,7 +124,7 @@ static int wdt_npm1300_feed(const struct device *dev, int channel_id)
 	return mfd_npm1300_reg_write(config->mfd, TIME_BASE, TIME_OFFSET_WDOG_KICK, 1U);
 }
 
-static const struct wdt_driver_api wdt_npm1300_api = {
+static DEVICE_API(wdt, wdt_npm1300_api) = {
 	.setup = wdt_npm1300_setup,
 	.disable = wdt_npm1300_disable,
 	.install_timeout = wdt_npm1300_install_timeout,

--- a/drivers/watchdog/wdt_npm6001.c
+++ b/drivers/watchdog/wdt_npm6001.c
@@ -157,7 +157,7 @@ static int wdt_npm6001_feed(const struct device *dev, int channel_id)
 	return i2c_write_dt(&config->bus, buf, sizeof(buf));
 }
 
-static const struct wdt_driver_api wdt_npm6001_api = {
+static DEVICE_API(wdt, wdt_npm6001_api) = {
 	.setup = wdt_npm6001_setup,
 	.disable = wdt_npm6001_disable,
 	.install_timeout = wdt_npm6001_install_timeout,

--- a/drivers/watchdog/wdt_nrfx.c
+++ b/drivers/watchdog/wdt_nrfx.c
@@ -160,7 +160,7 @@ static int wdt_nrf_feed(const struct device *dev, int channel_id)
 	return 0;
 }
 
-static const struct wdt_driver_api wdt_nrfx_driver_api = {
+static DEVICE_API(wdt, wdt_nrfx_driver_api) = {
 	.setup = wdt_nrf_setup,
 	.disable = wdt_nrf_disable,
 	.install_timeout = wdt_nrf_install_timeout,

--- a/drivers/watchdog/wdt_nxp_fs26.c
+++ b/drivers/watchdog/wdt_nxp_fs26.c
@@ -804,7 +804,7 @@ static int wdt_nxp_fs26_init(const struct device *dev)
 	return 0;
 }
 
-static const struct wdt_driver_api wdt_nxp_fs26_api = {
+static DEVICE_API(wdt, wdt_nxp_fs26_api) = {
 	.setup = wdt_nxp_fs26_setup,
 	.disable = wdt_nxp_fs26_disable,
 	.install_timeout = wdt_nxp_fs26_install_timeout,

--- a/drivers/watchdog/wdt_nxp_s32.c
+++ b/drivers/watchdog/wdt_nxp_s32.c
@@ -363,7 +363,7 @@ static int swt_nxp_s32_init(const struct device *dev)
 	return 0;
 }
 
-static const struct wdt_driver_api swt_nxp_s32_driver_api = {
+static DEVICE_API(wdt, swt_nxp_s32_driver_api) = {
 	.setup = swt_nxp_s32_setup,
 	.disable = swt_nxp_s32_disable,
 	.install_timeout = swt_nxp_s32_install_timeout,

--- a/drivers/watchdog/wdt_opentitan.c
+++ b/drivers/watchdog/wdt_opentitan.c
@@ -205,7 +205,7 @@ static struct wdt_ot_aontimer_cfg ot_aontimer_cfg = {
 	.wdog_lock = DT_INST_PROP(0, wdog_lock),
 };
 
-static const struct wdt_driver_api ot_aontimer_api = {
+static DEVICE_API(wdt, ot_aontimer_api) = {
 	.setup = ot_aontimer_setup,
 	.disable = ot_aontimer_disable,
 	.install_timeout = ot_aontimer_install_timeout,

--- a/drivers/watchdog/wdt_rpi_pico.c
+++ b/drivers/watchdog/wdt_rpi_pico.c
@@ -162,7 +162,7 @@ static int wdt_rpi_pico_init(const struct device *dev)
 	return 0;
 }
 
-static const struct wdt_driver_api wdt_rpi_pico_driver_api = {
+static DEVICE_API(wdt, wdt_rpi_pico_driver_api) = {
 	.setup = wdt_rpi_pico_setup,
 	.disable = wdt_rpi_pico_disable,
 	.install_timeout = wdt_rpi_pico_install_timeout,

--- a/drivers/watchdog/wdt_sam.c
+++ b/drivers/watchdog/wdt_sam.c
@@ -224,7 +224,7 @@ static int wdt_sam_feed(const struct device *dev, int channel_id)
 	return 0;
 }
 
-static const struct wdt_driver_api wdt_sam_api = {
+static DEVICE_API(wdt, wdt_sam_api) = {
 	.setup = wdt_sam_setup,
 	.disable = wdt_sam_disable,
 	.install_timeout = wdt_sam_install_timeout,

--- a/drivers/watchdog/wdt_sam0.c
+++ b/drivers/watchdog/wdt_sam0.c
@@ -242,7 +242,7 @@ static int wdt_sam0_feed(const struct device *dev, int channel_id)
 	return 0;
 }
 
-static const struct wdt_driver_api wdt_sam0_api = {
+static DEVICE_API(wdt, wdt_sam0_api) = {
 	.setup = wdt_sam0_setup,
 	.disable = wdt_sam0_disable,
 	.install_timeout = wdt_sam0_install_timeout,

--- a/drivers/watchdog/wdt_sifive.c
+++ b/drivers/watchdog/wdt_sifive.c
@@ -251,7 +251,7 @@ static int wdt_sifive_feed(const struct device *dev, int channel_id)
 	return 0;
 }
 
-static const struct wdt_driver_api wdt_sifive_api = {
+static DEVICE_API(wdt, wdt_sifive_api) = {
 	.setup = wdt_sifive_setup,
 	.disable = wdt_sifive_disable,
 	.install_timeout = wdt_sifive_install_timeout,

--- a/drivers/watchdog/wdt_smartbond.c
+++ b/drivers/watchdog/wdt_smartbond.c
@@ -114,7 +114,7 @@ static int wdg_smartbond_feed(const struct device *dev, int channel_id)
 	return 0;
 }
 
-static const struct wdt_driver_api wdg_smartbond_api = {
+static DEVICE_API(wdt, wdg_smartbond_api) = {
 	.setup = wdg_smartbond_setup,
 	.disable = wdg_smartbond_disable,
 	.install_timeout = wdg_smartbond_install_timeout,

--- a/drivers/watchdog/wdt_tco.c
+++ b/drivers/watchdog/wdt_tco.c
@@ -230,7 +230,7 @@ static int tco_feed(const struct device *dev, int channel_id)
 	return 0;
 }
 
-static const struct wdt_driver_api tco_driver_api = {
+static DEVICE_API(wdt, tco_driver_api) = {
 	.setup = tco_setup,
 	.disable = tco_disable,
 	.install_timeout = tco_install_timeout,

--- a/drivers/watchdog/wdt_ti_tps382x.c
+++ b/drivers/watchdog/wdt_ti_tps382x.c
@@ -74,7 +74,7 @@ static int ti_tps382x_feed(const struct device *dev, int channel_id)
 	return gpio_pin_toggle_dt(&config->wdi_gpio);
 }
 
-static const struct wdt_driver_api ti_tps382x_api = {
+static DEVICE_API(wdt, ti_tps382x_api) = {
 	.setup = ti_tps382x_setup,
 	.disable = ti_tps382x_disable,
 	.install_timeout = ti_tps382x_install_timeout,

--- a/drivers/watchdog/wdt_wwdg_stm32.c
+++ b/drivers/watchdog/wdt_wwdg_stm32.c
@@ -270,7 +270,7 @@ void wwdg_stm32_isr(const struct device *dev)
 	}
 }
 
-static const struct wdt_driver_api wwdg_stm32_api = {
+static DEVICE_API(wdt, wwdg_stm32_api) = {
 	.setup = wwdg_stm32_setup,
 	.disable = wwdg_stm32_disable,
 	.install_timeout = wwdg_stm32_install_timeout,

--- a/drivers/watchdog/wdt_wwdgt_gd32.c
+++ b/drivers/watchdog/wdt_wwdgt_gd32.c
@@ -192,7 +192,7 @@ static void gd32_wwdgt_irq_config(const struct device *dev)
 	irq_enable(DT_INST_IRQN(0));
 }
 
-static const struct wdt_driver_api wwdgt_gd32_api = {
+static DEVICE_API(wdt, wwdgt_gd32_api) = {
 	.setup = gd32_wwdgt_setup,
 	.disable = gd32_wwdgt_disable,
 	.install_timeout = gd32_wwdgt_install_timeout,

--- a/drivers/watchdog/wdt_wwdt_numaker.c
+++ b/drivers/watchdog/wdt_wwdt_numaker.c
@@ -238,7 +238,7 @@ static void wwdt_numaker_isr(const struct device *dev)
 	}
 }
 
-static const struct wdt_driver_api wwdt_numaker_api = {
+static DEVICE_API(wdt, wwdt_numaker_api) = {
 	.setup = wwdt_numaker_setup,
 	.disable = wwdt_numaker_disable,
 	.install_timeout = wwdt_numaker_install_timeout,

--- a/drivers/watchdog/wdt_xilinx_axi.c
+++ b/drivers/watchdog/wdt_xilinx_axi.c
@@ -263,7 +263,7 @@ int z_impl_hwinfo_get_supported_reset_cause(uint32_t *supported)
 
 #endif
 
-static const struct wdt_driver_api wdt_xilinx_api = {
+static DEVICE_API(wdt, wdt_xilinx_api) = {
 	.setup = wdt_xilinx_axi_setup,
 	.disable = wdt_xilinx_axi_disable,
 	.install_timeout = wdt_xilinx_axi_install_timeout,

--- a/drivers/watchdog/wdt_xmc4xxx.c
+++ b/drivers/watchdog/wdt_xmc4xxx.c
@@ -145,7 +145,7 @@ static int wdt_xmc4xxx_feed(const struct device *dev, int channel_id)
 	return 0;
 }
 
-static const struct wdt_driver_api wdt_xmc4xxx_api = {
+static DEVICE_API(wdt, wdt_xmc4xxx_api) = {
 	.setup = wdt_xmc4xxx_setup,
 	.disable = wdt_xmc4xxx_disable,
 	.install_timeout = wdt_xmc4xxx_install_timeout,

--- a/drivers/watchdog/xt_wdt_esp32.c
+++ b/drivers/watchdog/xt_wdt_esp32.c
@@ -147,7 +147,7 @@ static int esp32_xt_wdt_init(const struct device *dev)
 	return 0;
 }
 
-static const struct wdt_driver_api esp32_xt_wdt_api = {
+static DEVICE_API(wdt, esp32_xt_wdt_api) = {
 	.setup = esp32_xt_wdt_setup,
 	.disable = esp32_xt_wdt_disable,
 	.install_timeout = esp32_xt_wdt_install_timeout,


### PR DESCRIPTION
Add wrapper DEVICE_API macro to all wdt_driver_api instances.