### PR TITLE
drivers: Place API in iterable section for remaining drivers

### DIFF
--- a/drivers/ethernet/eth_e1000.c
+++ b/drivers/ethernet/eth_e1000.c
@@ -411,7 +411,7 @@ static int ptp_clock_e1000_rate_adjust(const struct device *dev, double ratio)
 	return 0;
 }
 
-static const struct ptp_clock_driver_api api = {
+static DEVICE_API(ptp_clock, api) = {
 	.set = ptp_clock_e1000_set,
 	.get = ptp_clock_e1000_get,
 	.adjust = ptp_clock_e1000_adjust,

--- a/drivers/ethernet/eth_native_posix.c
+++ b/drivers/ethernet/eth_native_posix.c
@@ -560,7 +560,7 @@ static int ptp_clock_rate_adjust_native_posix(const struct device *clk,
 	return 0;
 }
 
-static const struct ptp_clock_driver_api api = {
+static DEVICE_API(ptp_clock, api) = {
 	.set = ptp_clock_set_native_posix,
 	.get = ptp_clock_get_native_posix,
 	.adjust = ptp_clock_adjust_native_posix,

--- a/drivers/ethernet/eth_sam_gmac.c
+++ b/drivers/ethernet/eth_sam_gmac.c
@@ -2398,7 +2398,7 @@ static int ptp_clock_sam_gmac_rate_adjust(const struct device *dev,
 	return -ENOTSUP;
 }
 
-static const struct ptp_clock_driver_api ptp_api = {
+static DEVICE_API(ptp_clock, ptp_api) = {
 	.set = ptp_clock_sam_gmac_set,
 	.get = ptp_clock_sam_gmac_get,
 	.adjust = ptp_clock_sam_gmac_adjust,

--- a/drivers/ethernet/eth_stm32_hal.c
+++ b/drivers/ethernet/eth_stm32_hal.c
@@ -1509,7 +1509,7 @@ error:
 	return ret;
 }
 
-static const struct ptp_clock_driver_api api = {
+static DEVICE_API(ptp_clock, api) = {
 	.set = ptp_clock_stm32_set,
 	.get = ptp_clock_stm32_get,
 	.adjust = ptp_clock_stm32_adjust,

--- a/drivers/ethernet/eth_xmc4xxx.c
+++ b/drivers/ethernet/eth_xmc4xxx.c
@@ -1113,7 +1113,7 @@ static int eth_xmc4xxx_ptp_clock_rate_adjust(const struct device *dev, double ra
 	return 0;
 }
 
-static const struct ptp_clock_driver_api ptp_api_xmc4xxx = {
+static DEVICE_API(ptp_clock, ptp_api_xmc4xxx) = {
 	.set = eth_xmc4xxx_ptp_clock_set,
 	.get = eth_xmc4xxx_ptp_clock_get,
 	.adjust = eth_xmc4xxx_ptp_clock_adjust,

--- a/drivers/ethernet/nxp_enet/eth_mcux.c
+++ b/drivers/ethernet/nxp_enet/eth_mcux.c
@@ -1711,7 +1711,7 @@ static int ptp_clock_mcux_rate_adjust(const struct device *dev, double ratio)
 	return 0;
 }
 
-static const struct ptp_clock_driver_api api = {
+static DEVICE_API(ptp_clock, api) = {
 	.set = ptp_clock_mcux_set,
 	.get = ptp_clock_mcux_get,
 	.adjust = ptp_clock_mcux_adjust,

--- a/drivers/ptp_clock/ptp_clock_nxp_enet.c
+++ b/drivers/ptp_clock/ptp_clock_nxp_enet.c
@@ -225,7 +225,7 @@ static void ptp_clock_nxp_enet_isr(const struct device *dev)
 	irq_unlock(irq_lock_key);
 }
 
-static const struct ptp_clock_driver_api ptp_clock_nxp_enet_api = {
+static DEVICE_API(ptp_clock, ptp_clock_nxp_enet_api) = {
 	.set = ptp_clock_nxp_enet_set,
 	.get = ptp_clock_nxp_enet_get,
 	.adjust = ptp_clock_nxp_enet_adjust,

--- a/drivers/retained_mem/retained_mem_nrf_gpregret.c
+++ b/drivers/retained_mem/retained_mem_nrf_gpregret.c
@@ -107,7 +107,7 @@ static int nrf_gpregret_clear(const struct device *dev)
 	return 0;
 }
 
-static const struct retained_mem_driver_api nrf_gpregret_api = {
+static DEVICE_API(retained_mem, nrf_gpregret_api) = {
 	.size = nrf_gpregret_size,
 	.read = nrf_gpregret_read,
 	.write = nrf_gpregret_write,

--- a/drivers/retained_mem/retained_mem_zephyr_ram.c
+++ b/drivers/retained_mem/retained_mem_zephyr_ram.c
@@ -108,7 +108,7 @@ static int zephyr_retained_mem_ram_clear(const struct device *dev)
 	return 0;
 }
 
-static const struct retained_mem_driver_api zephyr_retained_mem_ram_api = {
+static DEVICE_API(retained_mem, zephyr_retained_mem_ram_api) = {
 	.size = zephyr_retained_mem_ram_size,
 	.read = zephyr_retained_mem_ram_read,
 	.write = zephyr_retained_mem_ram_write,

--- a/drivers/retained_mem/retained_mem_zephyr_reg.c
+++ b/drivers/retained_mem/retained_mem_zephyr_reg.c
@@ -109,7 +109,7 @@ static int zephyr_retained_mem_reg_clear(const struct device *dev)
 	return 0;
 }
 
-static const struct retained_mem_driver_api zephyr_retained_mem_reg_api = {
+static DEVICE_API(retained_mem, zephyr_retained_mem_reg_api) = {
 	.size = zephyr_retained_mem_reg_size,
 	.read = zephyr_retained_mem_reg_read,
 	.write = zephyr_retained_mem_reg_write,

--- a/drivers/sdhc/ifx_cat1_sdio.c
+++ b/drivers/sdhc/ifx_cat1_sdio.c
@@ -303,7 +303,7 @@ static int ifx_cat1_sdio_init(const struct device *dev)
 	return 0;
 }
 
-static const struct sdhc_driver_api ifx_cat1_sdio_api = {
+static DEVICE_API(sdhc, ifx_cat1_sdio_api) = {
 	.reset = ifx_cat1_sdio_reset,
 	.request = ifx_cat1_sdio_request,
 	.set_io = ifx_cat1_sdio_set_io,

--- a/drivers/sdhc/imx_usdhc.c
+++ b/drivers/sdhc/imx_usdhc.c
@@ -1046,7 +1046,7 @@ static int imx_usdhc_init(const struct device *dev)
 	return k_sem_init(&data->transfer_sem, 0, 1);
 }
 
-static const struct sdhc_driver_api usdhc_api = {
+static DEVICE_API(sdhc, usdhc_api) = {
 	.reset = imx_usdhc_reset,
 	.request = imx_usdhc_request,
 	.set_io = imx_usdhc_set_io,

--- a/drivers/sdhc/intel_emmc_host.c
+++ b/drivers/sdhc/intel_emmc_host.c
@@ -1267,7 +1267,7 @@ static int emmc_init(const struct device *dev)
 	return emmc_reset(dev);
 }
 
-static const struct sdhc_driver_api emmc_api = {
+static DEVICE_API(sdhc, emmc_api) = {
 	.reset = emmc_reset,
 	.request = emmc_request,
 	.set_io = emmc_set_io,

--- a/drivers/sdhc/mcux_sdif.c
+++ b/drivers/sdhc/mcux_sdif.c
@@ -401,7 +401,7 @@ static int mcux_sdif_request(const struct device *dev,
 	return ret;
 }
 
-static const struct sdhc_driver_api sdif_api = {
+static DEVICE_API(sdhc, sdif_api) = {
 	.reset = mcux_sdif_reset,
 	.get_host_props = mcux_sdif_get_host_props,
 	.set_io = mcux_sdif_set_io,

--- a/drivers/sdhc/rcar_mmc.c
+++ b/drivers/sdhc/rcar_mmc.c
@@ -1877,7 +1877,7 @@ static int rcar_mmc_get_host_props(const struct device *dev, struct sdhc_host_pr
 	return 0;
 }
 
-static const struct sdhc_driver_api rcar_sdhc_api = {
+static DEVICE_API(sdhc, rcar_sdhc_api) = {
 	.card_busy = rcar_mmc_card_busy,
 #ifdef CONFIG_RCAR_MMC_SCC_SUPPORT
 	.execute_tuning = rcar_mmc_execute_tuning,

--- a/drivers/sdhc/sam_hsmci.c
+++ b/drivers/sdhc/sam_hsmci.c
@@ -660,7 +660,7 @@ static int sam_hsmci_request(const struct device *dev, struct sdhc_command *cmd,
 	return ret;
 }
 
-static const struct sdhc_driver_api hsmci_api = {
+static DEVICE_API(sdhc, hsmci_api) = {
 	.reset = sam_hsmci_reset,
 	.get_host_props = sam_hsmci_get_host_props,
 	.set_io = sam_hsmci_set_io,

--- a/drivers/sdhc/sdhc_cdns.c
+++ b/drivers/sdhc/sdhc_cdns.c
@@ -235,7 +235,7 @@ static int sdhc_cdns_set_io(const struct device *dev, struct sdhc_io *ios)
 	return 0;
 }
 
-static const struct sdhc_driver_api sdhc_cdns_api = {
+static DEVICE_API(sdhc, sdhc_cdns_api) = {
 	.request = sdhc_cdns_request,
 	.set_io = sdhc_cdns_set_io,
 	.get_host_props = sdhc_cdns_get_host_props,

--- a/drivers/sdhc/sdhc_esp32.c
+++ b/drivers/sdhc/sdhc_esp32.c
@@ -1395,12 +1395,14 @@ static int sdhc_esp32_init(const struct device *dev)
 	return 0;
 }
 
-static const struct sdhc_driver_api sdhc_api = {.reset = sdhc_esp32_reset,
-						.request = sdhc_esp32_request,
-						.set_io = sdhc_esp32_set_io,
-						.get_card_present = sdhc_esp32_get_card_present,
-						.card_busy = sdhc_esp32_card_busy,
-						.get_host_props = sdhc_esp32_get_host_props};
+static DEVICE_API(sdhc, sdhc_api) = {
+	.reset = sdhc_esp32_reset,
+	.request = sdhc_esp32_request,
+	.set_io = sdhc_esp32_set_io,
+	.get_card_present = sdhc_esp32_get_card_present,
+	.card_busy = sdhc_esp32_card_busy,
+	.get_host_props = sdhc_esp32_get_host_props,
+};
 
 #define SDHC_ESP32_INIT(n)                                                                         \
                                                                                                    \

--- a/drivers/sdhc/sdhc_spi.c
+++ b/drivers/sdhc/sdhc_spi.c
@@ -810,7 +810,7 @@ static int sdhc_spi_init(const struct device *dev)
 	return ret;
 }
 
-static const struct sdhc_driver_api sdhc_spi_api = {
+static DEVICE_API(sdhc, sdhc_spi_api) = {
 	.request = sdhc_spi_request,
 	.set_io = sdhc_spi_set_io,
 	.get_host_props = sdhc_spi_get_host_props,

--- a/drivers/video/gc2145.c
+++ b/drivers/video/gc2145.c
@@ -1113,7 +1113,7 @@ static int gc2145_set_ctrl(const struct device *dev, unsigned int cid, void *val
 	}
 }
 
-static const struct video_driver_api gc2145_driver_api = {
+static DEVICE_API(video, gc2145_driver_api) = {
 	.set_format = gc2145_set_fmt,
 	.get_format = gc2145_get_fmt,
 	.get_caps = gc2145_get_caps,

--- a/drivers/video/mt9m114.c
+++ b/drivers/video/mt9m114.c
@@ -461,7 +461,7 @@ static int mt9m114_get_caps(const struct device *dev, enum video_endpoint_id ep,
 	return 0;
 }
 
-static const struct video_driver_api mt9m114_driver_api = {
+static DEVICE_API(video, mt9m114_driver_api) = {
 	.set_format = mt9m114_set_fmt,
 	.get_format = mt9m114_get_fmt,
 	.get_caps = mt9m114_get_caps,

--- a/drivers/video/ov2640.c
+++ b/drivers/video/ov2640.c
@@ -971,7 +971,7 @@ static int ov2640_set_ctrl(const struct device *dev,
 	return ret;
 }
 
-static const struct video_driver_api ov2640_driver_api = {
+static DEVICE_API(video, ov2640_driver_api) = {
 	.set_format = ov2640_set_fmt,
 	.get_format = ov2640_get_fmt,
 	.get_caps = ov2640_get_caps,

--- a/drivers/video/ov5640.c
+++ b/drivers/video/ov5640.c
@@ -916,7 +916,7 @@ static int ov5640_enum_frmival(const struct device *dev, enum video_endpoint_id 
 	return 0;
 }
 
-static const struct video_driver_api ov5640_driver_api = {
+static DEVICE_API(video, ov5640_driver_api) = {
 	.set_format = ov5640_set_fmt,
 	.get_format = ov5640_get_fmt,
 	.get_caps = ov5640_get_caps,

--- a/drivers/video/ov7670.c
+++ b/drivers/video/ov7670.c
@@ -547,7 +547,7 @@ static int ov7670_init(const struct device *dev)
 	return 0;
 }
 
-static const struct video_driver_api ov7670_api = {
+static DEVICE_API(video, ov7670_api) = {
 	.set_format = ov7670_set_fmt,
 	.get_format = ov7670_get_fmt,
 	.get_caps = ov7670_get_caps,

--- a/drivers/video/ov7725.c
+++ b/drivers/video/ov7725.c
@@ -548,7 +548,7 @@ static int ov7725_get_caps(const struct device *dev,
 	return 0;
 }
 
-static const struct video_driver_api ov7725_driver_api = {
+static DEVICE_API(video, ov7725_driver_api) = {
 	.set_format = ov7725_set_fmt,
 	.get_format = ov7725_get_fmt,
 	.get_caps = ov7725_get_caps,

--- a/drivers/video/video_esp32_dvp.c
+++ b/drivers/video/video_esp32_dvp.c
@@ -396,7 +396,7 @@ static int video_esp32_init(const struct device *dev)
 	return 0;
 }
 
-static const struct video_driver_api esp32_driver_api = {
+static DEVICE_API(video, esp32_driver_api) = {
 	/* mandatory callbacks */
 	.set_format = video_esp32_set_fmt,
 	.get_format = video_esp32_get_fmt,

--- a/drivers/video/video_mcux_csi.c
+++ b/drivers/video/video_mcux_csi.c
@@ -478,7 +478,7 @@ static int video_mcux_csi_enum_frmival(const struct device *dev, enum video_endp
 	return ret;
 }
 
-static const struct video_driver_api video_mcux_csi_driver_api = {
+static DEVICE_API(video, video_mcux_csi_driver_api) = {
 	.set_format = video_mcux_csi_set_fmt,
 	.get_format = video_mcux_csi_get_fmt,
 	.stream_start = video_mcux_csi_stream_start,

--- a/drivers/video/video_mcux_mipi_csi2rx.c
+++ b/drivers/video/video_mcux_mipi_csi2rx.c
@@ -311,7 +311,7 @@ static int mipi_csi2rx_enum_frmival(const struct device *dev, enum video_endpoin
 	return 0;
 }
 
-static const struct video_driver_api mipi_csi2rx_driver_api = {
+static DEVICE_API(video, mipi_csi2rx_driver_api) = {
 	.get_caps = mipi_csi2rx_get_caps,
 	.get_format = mipi_csi2rx_get_fmt,
 	.set_format = mipi_csi2rx_set_fmt,

--- a/drivers/video/video_mcux_smartdma.c
+++ b/drivers/video/video_mcux_smartdma.c
@@ -357,7 +357,7 @@ static int nxp_video_sdma_init(const struct device *dev)
 	return 0;
 }
 
-static const struct video_driver_api nxp_video_sdma_api = {
+static DEVICE_API(video, nxp_video_sdma_api) = {
 	.get_format = nxp_video_sdma_get_format,
 	.set_format = nxp_video_sdma_set_format,
 	.get_caps = nxp_video_sdma_get_caps,

--- a/drivers/video/video_stm32_dcmi.c
+++ b/drivers/video/video_stm32_dcmi.c
@@ -372,7 +372,7 @@ static inline int video_stm32_dcmi_get_ctrl(const struct device *dev, unsigned i
 	return ret;
 }
 
-static const struct video_driver_api video_stm32_dcmi_driver_api = {
+static DEVICE_API(video, video_stm32_dcmi_driver_api) = {
 	.set_format = video_stm32_dcmi_set_fmt,
 	.get_format = video_stm32_dcmi_get_fmt,
 	.stream_start = video_stm32_dcmi_stream_start,

--- a/drivers/video/video_sw_generator.c
+++ b/drivers/video/video_sw_generator.c
@@ -337,7 +337,7 @@ static int video_sw_generator_enum_frmival(const struct device *dev, enum video_
 	return 0;
 }
 
-static const struct video_driver_api video_sw_generator_driver_api = {
+static DEVICE_API(video, video_sw_generator_driver_api) = {
 	.set_format = video_sw_generator_set_fmt,
 	.get_format = video_sw_generator_get_fmt,
 	.stream_start = video_sw_generator_stream_start,

--- a/tests/net/ptp/clock/src/main.c
+++ b/tests/net/ptp/clock/src/main.c
@@ -226,7 +226,7 @@ static int my_ptp_clock_rate_adjust(const struct device *dev, double ratio)
 static struct ptp_context ptp_test_1_context;
 static struct ptp_context ptp_test_2_context;
 
-static const struct ptp_clock_driver_api api = {
+static DEVICE_API(ptp_clock, api) = {
 	.set = my_ptp_clock_set,
 	.get = my_ptp_clock_get,
 	.adjust = my_ptp_clock_adjust,


### PR DESCRIPTION
Add wrapper DEVICE_API macro to all retained_mem/sdhc/video driver_api instances.