### PR TITLE
sysbuild: Functionality to pass variables from sysbuild directly to p…

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -96,7 +96,6 @@ Peter Bigot <peter.bigot@nordicsemi.no> <pab@pabigot.com>
 Peter Johanson <peter@peterjohanson.com>
 Piyush Itankar <piyush.t.itankar@intel.com>
 Radosław Koppel <radoslaw.koppel@nordicsemi.no>
-Radosław Koppel <radoslaw.koppel@nordicsemi.no> <r.koppel@k-el.com>
 Raja D. Singh <rdsingh@iotwizards.com>
 Ricardo Salveti <ricardo@opensourcefoundries.com>
 Ricardo Salveti <ricardo@opensourcefoundries.com> <ricardo.salveti@linaro.org>

--- a/samples/sysbuild/shared_vars/CMakeLists.txt
+++ b/samples/sysbuild/shared_vars/CMakeLists.txt
@@ -1,0 +1,26 @@
+# Copyright (c) 2024 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+# We are expecing shared variables to be present BEFORE Zephyr package is added
+if(DEFINED SHARE_ME_APP1)
+	message(STATUS "SHARE_ME_APP1=${SHARE_ME_APP1}")
+else()
+	message(FATAL_ERROR "No SHARE_ME_APP1 variable")
+endif()
+if(DEFINED SHARE_ME_APP2)
+	message(STATUS "SHARE_ME_APP2=${SHARE_ME_APP2}")
+else()
+	message(FATAL_ERROR "No SHARE_ME_APP2 variable")
+endif()
+if(DEFINED SHARE_ME_REMOTE1)
+	message(FATAL_ERROR "Unexpected SHARE_ME_REMOTE1 variable set")
+endif()
+if(DEFINED SHARE_ME_REMOTE2)
+	message(FATAL_ERROR "Unexpected SHARE_ME_REMOTE2 variable set")
+endif()
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+
+project(shared_vars)
+target_sources(app PRIVATE src/main.c)

--- a/samples/sysbuild/shared_vars/prj.conf
+++ b/samples/sysbuild/shared_vars/prj.conf
@@ -1,0 +1,1 @@
+# no additional configuration is required

--- a/samples/sysbuild/shared_vars/remote/CMakeLists.txt
+++ b/samples/sysbuild/shared_vars/remote/CMakeLists.txt
@@ -1,0 +1,26 @@
+# Copyright (c) 2024 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+# We are expecing shared variables to be present BEFORE Zephyr package is added
+if(DEFINED SHARE_ME_REMOTE1)
+	message(STATUS "SHARE_ME_REMOTE1=${SHARE_ME_REMOTE1}")
+else()
+	message(FATAL_ERROR "No SHARE_ME_REMOTE1 variable")
+endif()
+if(DEFINED SHARE_ME_REMOTE2)
+	message(STATUS "SHARE_ME_REMOTE2=${SHARE_ME_REMOTE2}")
+else()
+	message(FATAL_ERROR "No SHARE_ME_REMOTE2 variable")
+endif()
+if(DEFINED SHARE_ME_APP1)
+	message(FATAL_ERROR "Unexpected SHARE_ME_APP1 variable set")
+endif()
+if(DEFINED SHARE_ME_APP2)
+	message(FATAL_ERROR "Unexpected SHARE_ME_APP2 variable set")
+endif()
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+
+project(shared_vars)
+target_sources(app PRIVATE ../src/main.c)

--- a/samples/sysbuild/shared_vars/remote/prj.conf
+++ b/samples/sysbuild/shared_vars/remote/prj.conf
@@ -1,0 +1,1 @@
+# no additional configuration is required

--- a/samples/sysbuild/shared_vars/sample.yaml
+++ b/samples/sysbuild/shared_vars/sample.yaml
@@ -1,0 +1,18 @@
+sample:
+  name: Passing variables from sysbuild.cmake to application cmake
+  description: |
+    Not even an application - just a cmake sample how to pass variables directly to cmake call
+    of the external project.
+
+common:
+  sysbuild: true
+  build_only: true
+
+tests:
+  sample.sysbuild.shared_vars:
+    platform_allow: native_posix
+    extra_args: >-
+      SHARE_ME_APP1=101
+      SHARE_ME_APP2=102
+      SHARE_ME_REMOTE1=201
+      SHARE_ME_REMOTE2=202

--- a/samples/sysbuild/shared_vars/src/main.c
+++ b/samples/sysbuild/shared_vars/src/main.c
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+int main(void)
+{
+	/* Nothing to do - it is build system test */
+	return 0;
+}

--- a/samples/sysbuild/shared_vars/sysbuild.cmake
+++ b/samples/sysbuild/shared_vars/sysbuild.cmake
@@ -1,0 +1,8 @@
+# Copyright (c) 2024 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+ExternalZephyrProject_Add(
+  APPLICATION remote
+  SOURCE_DIR ${APP_DIR}/remote
+  BOARD ${BOARD}
+)

--- a/samples/sysbuild/shared_vars/sysbuild/CMakeLists.txt
+++ b/samples/sysbuild/shared_vars/sysbuild/CMakeLists.txt
@@ -1,0 +1,11 @@
+# Copyright (c) 2024 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+# Configure user shared variables.
+# The variables with this name would be passed from sysbuild directly to the cmake call
+# of the application and external projects.
+list(APPEND shared_vars_USER_SHARED_VARS SHARE_ME_APP1 SHARE_ME_APP2)
+list(APPEND remote_USER_SHARED_VARS SHARE_ME_REMOTE1 SHARE_ME_REMOTE2)
+
+find_package(Sysbuild REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(sysbuild LANGUAGES)

--- a/share/sysbuild/cmake/modules/sysbuild_extensions.cmake
+++ b/share/sysbuild/cmake/modules/sysbuild_extensions.cmake
@@ -309,6 +309,7 @@ function(ExternalZephyrProject_Add)
     shared_cmake_variables_list
     CMAKE_BUILD_TYPE
     CMAKE_VERBOSE_MAKEFILE
+    ${${ZBUILD_APPLICATION}_USER_SHARED_VARS}
   )
 
   set(sysbuild_cache_file ${CMAKE_BINARY_DIR}/${ZBUILD_APPLICATION}_sysbuild_cache.txt)


### PR DESCRIPTION
Small change that gives a possibility to create list of variables that should be passed directly to projects cmakes. Such variables would be available before Zephyr project inclusion inside the project itself.
The list needs to have a form `<namespace>_USER_SHARED_VARS` and needs to be defined before ExternalZephyrProject_Add.
When it is used to pass variables to main application it needs to defined before Sysbuild package (in sysbuild/CmakeLists.txt).

This is proof of concept that solves the issue presented in #76592.

It might require some discussion and polishing - but before that I wish to know what community thinks about it.