### PR TITLE
dts: bindings: rename nxp,kinetis-rtc compatible

### DIFF
--- a/doc/releases/migration-guide-4.1.rst
+++ b/doc/releases/migration-guide-4.1.rst
@@ -131,6 +131,11 @@ Stepper
 Regulator
 =========
 
+RTC
+===
+
+* Renamed the ``compatible`` from ``nxp,kinetis-rtc`` to :dtcompatible:`nxp,rtc`.
+
 Video
 =====
 

--- a/drivers/counter/Kconfig.mcux_rtc
+++ b/drivers/counter/Kconfig.mcux_rtc
@@ -6,6 +6,6 @@
 config COUNTER_MCUX_RTC
 	bool "MCUX RTC driver"
 	default y
-	depends on DT_HAS_NXP_KINETIS_RTC_ENABLED
+	depends on DT_HAS_NXP_RTC_ENABLED
 	help
-	  Enable support for mcux rtc driver.
+	  Enable support for MCU RTC driver.

--- a/drivers/counter/counter_mcux_rtc.c
+++ b/drivers/counter/counter_mcux_rtc.c
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#define DT_DRV_COMPAT nxp_kinetis_rtc
+#define DT_DRV_COMPAT nxp_rtc
 
 #include <zephyr/drivers/counter.h>
 #include <zephyr/irq.h>

--- a/dts/arm/nxp/nxp_k6x.dtsi
+++ b/dts/arm/nxp/nxp_k6x.dtsi
@@ -101,7 +101,7 @@
 		};
 
 		rtc: rtc@4003d000 {
-			compatible = "nxp,kinetis-rtc";
+			compatible = "nxp,rtc";
 			reg = <0x4003d000 0x1000>;
 			interrupts = <46 0>, <47 0>;
 			interrupt-names = "alarm", "seconds";

--- a/dts/arm/nxp/nxp_k8x.dtsi
+++ b/dts/arm/nxp/nxp_k8x.dtsi
@@ -326,7 +326,7 @@
 		};
 
 		rtc: rtc@4003d000 {
-			compatible = "nxp,kinetis-rtc";
+			compatible = "nxp,rtc";
 			reg = <0x4003d000 0x1000>;
 			interrupts = <46 0>, <47 0>;
 			interrupt-names = "alarm", "seconds";

--- a/dts/arm/nxp/nxp_ke1xf.dtsi
+++ b/dts/arm/nxp/nxp_ke1xf.dtsi
@@ -265,7 +265,7 @@
 		};
 
 		rtc: rtc@4003d000 {
-			compatible = "nxp,kinetis-rtc";
+			compatible = "nxp,rtc";
 			reg = <0x4003d000 0x1000>;
 			interrupts = <46 0>, <47 0>;
 			interrupt-names = "alarm", "seconds";

--- a/dts/arm/nxp/nxp_ke1xz.dtsi
+++ b/dts/arm/nxp/nxp_ke1xz.dtsi
@@ -405,7 +405,7 @@
 		};
 
 		rtc: rtc@4003d000 {
-			compatible = "nxp,kinetis-rtc";
+			compatible = "nxp,rtc";
 			reg = <0x4003d000 0x1000>;
 			interrupts = <20 0>;
 			clock-frequency = <32768>;

--- a/dts/arm/nxp/nxp_kw41z.dtsi
+++ b/dts/arm/nxp/nxp_kw41z.dtsi
@@ -55,7 +55,7 @@
 		};
 
 		rtc: rtc@4003d000 {
-			compatible = "nxp,kinetis-rtc";
+			compatible = "nxp,rtc";
 			reg = <0x4003d000 0x20>;
 			interrupts = <20 0>;
 			clock-frequency = <32768>;

--- a/dts/arm/nxp/nxp_mcxc_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxc_common.dtsi
@@ -287,7 +287,7 @@
 		};
 
 		rtc: rtc@4003d000 {
-			compatible = "nxp,kinetis-rtc";
+			compatible = "nxp,rtc";
 			reg = <0x4003d000 0x1000>;
 			interrupts = <20 0>, <21 0>;
 			interrupt-names = "alarm", "seconds";

--- a/dts/arm/nxp/nxp_s32k1xx.dtsi
+++ b/dts/arm/nxp/nxp_s32k1xx.dtsi
@@ -319,7 +319,7 @@
 		};
 
 		rtc: rtc@4003d000 {
-			compatible = "nxp,kinetis-rtc";
+			compatible = "nxp,rtc";
 			reg = <0x4003d000 0x1000>;
 			interrupts = <46 0>, <47 0>;
 			interrupt-names = "alarm", "seconds";

--- a/dts/bindings/rtc/nxp,rtc.yaml
+++ b/dts/bindings/rtc/nxp,rtc.yaml
@@ -2,9 +2,9 @@
 # Copyright 2024 NXP
 # SPDX-License-Identifier: Apache-2.0
 
-description: Kinetis RTC
+description: NXP Real Time Clock (RTC)
 
-compatible: "nxp,kinetis-rtc"
+compatible: "nxp,rtc"
 
 include: rtc.yaml
 

--- a/tests/drivers/counter/counter_basic_api/src/test_counter.c
+++ b/tests/drivers/counter/counter_basic_api/src/test_counter.c
@@ -73,7 +73,7 @@ static const struct device *const devices[] = {
 	DEVS_FOR_DT_COMPAT(nxp_lpc_ctimer)
 #endif
 #ifdef CONFIG_COUNTER_MCUX_RTC
-	DEVS_FOR_DT_COMPAT(nxp_kinetis_rtc)
+	DEVS_FOR_DT_COMPAT(nxp_rtc)
 #endif
 #ifdef CONFIG_COUNTER_MCUX_QTMR
 	DEVS_FOR_DT_COMPAT(nxp_imx_tmr)
@@ -130,7 +130,7 @@ static const struct device *const devices[] = {
 
 static const struct device *const period_devs[] = {
 #ifdef CONFIG_COUNTER_MCUX_RTC
-	DEVS_FOR_DT_COMPAT(nxp_kinetis_rtc)
+	DEVS_FOR_DT_COMPAT(nxp_rtc)
 #endif
 #ifdef CONFIG_COUNTER_MCUX_LPC_RTC
 	DEVS_FOR_DT_COMPAT(nxp_lpc_rtc)


### PR DESCRIPTION
Rename "nxp,kinetis-rtc" compatible to "nxp,rtc" to remove the device family from its name because this hardware block is used in multiple NXP devices from different families.