### PR TITLE
Driver: hci_nxp_setup: Support HCI baudrate update

### DIFF
--- a/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm7_B.overlay
+++ b/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm7_B.overlay
@@ -89,7 +89,7 @@ m2_hci_uart: &lpuart2 {
 			compatible = "nxp,bt-hci-uart";
 			sdio-reset-gpios = <&gpio9 15 GPIO_ACTIVE_HIGH>;
 			w-disable-gpios = <&gpio9 30 GPIO_ACTIVE_HIGH>;
-			hci-operation-speed = <115200>;
+			hci-operation-speed = <3000000>;
 			hw-flow-control;
 			fw-download-primary-speed = <115200>;
 			fw-download-secondary-speed = <3000000>;

--- a/drivers/bluetooth/hci/Kconfig
+++ b/drivers/bluetooth/hci/Kconfig
@@ -294,6 +294,7 @@ config BT_H4_NXP_CTLR
 	select GPIO
 	depends on BT_H4
 	select CRC
+	select BT_HCI_SETUP
 	default y
 	depends on DT_HAS_NXP_BT_HCI_UART_ENABLED
 	help
@@ -316,5 +317,12 @@ config BT_H4_NXP_CTLR_WAIT_TIME_AFTER_UPLOAD
 	default 1000
 	help
 	  Waiting time after firmware is uploaded. Unit is millisecond.
+
+config BT_H4_NXP_CTLR_WAIT_TIME_AFTER_BAUDRATE_UPDATE
+	int "Waiting time after controller baudrate is updated"
+	range 500 5000
+	default 500
+	help
+	  Waiting time after controller baudrate is updated. Unit is millisecond.
 
 endif #BT_H4_NXP_CTLR


### PR DESCRIPTION
Change running baudrate from `115200` from `3000000`.

Implement the function `bt_h4_vnd_setup` to update the HCI bandrate.

Add Kconfig `BT_H4_NXP_CTLR_WAIT_TIME_AFTER_BAUDRATE_UPDATE` to set the waiting time after the controller bandrate HCI vendor specific command sent. It is used to ensure the controller is ready to update HCI bandrate.

Select `BT_HCI_SETUP` if `BT_H4_NXP_CTLR` is enabled.