### PR TITLE
net: wifi: Fix CONFIG_EAP_TTLS not enabling all dependencies

### DIFF
--- a/modules/hostap/CMakeLists.txt
+++ b/modules/hostap/CMakeLists.txt
@@ -432,12 +432,15 @@ zephyr_library_compile_definitions_ifdef(CONFIG_EAP_GTC
 zephyr_library_sources_ifdef(CONFIG_EAP_MSCHAPV2
   ${HOSTAP_SRC_BASE}/eap_peer/eap_mschapv2.c
   ${HOSTAP_SRC_BASE}/eap_peer/mschapv2.c
-  ${HOSTAP_SRC_BASE}/eap_common/chap.c
 )
 
 zephyr_library_compile_definitions_ifdef(CONFIG_EAP_MSCHAPV2
   EAP_MSCHAPv2
 )
+
+if(CONFIG_EAP_TTLS OR CONFIG_EAP_MSCHAPV2)
+  zephyr_library_sources(${HOSTAP_SRC_BASE}/eap_common/chap.c)
+endif()
 
 zephyr_library_sources_ifdef(CONFIG_EAP_LEAP
   ${HOSTAP_SRC_BASE}/eap_peer/eap_leap.c


### PR DESCRIPTION
CONFIG_EAP_TTLS now correctly adds all .c files it requires from hostap.

Related: #82098