### PR TITLE
modules: hostap: Fix incorrect link mode of AP

### DIFF
--- a/modules/hostap/src/supp_events.c
+++ b/modules/hostap/src/supp_events.c
@@ -264,14 +264,17 @@ static enum wifi_link_mode get_sta_link_mode(struct wpa_supplicant *wpa_s, struc
 		return WIFI_5;
 	} else if (sta->flags & WLAN_STA_HT) {
 		return WIFI_4;
+#ifndef CONFIG_WIFI_NM_HOSTAPD_AP
 	} else if (sta->flags & WLAN_STA_NONERP) {
 		return WIFI_1;
-#ifndef CONFIG_WIFI_NM_HOSTAPD_AP
 	} else if (wpa_s->assoc_freq > 4000) {
 		return WIFI_2;
 	} else if (wpa_s->assoc_freq > 2000) {
 		return WIFI_3;
 #else
+	} else if ((sta->flags & WLAN_STA_NONERP) ||
+		   (iface->current_mode->mode == HOSTAPD_MODE_IEEE80211B)) {
+		return WIFI_1;
 	} else if (iface->freq > 4000) {
 		return WIFI_2;
 	} else if (iface->freq > 2000) {


### PR DESCRIPTION
Added hw_mode check of AP with hostapd when getting link mode of current station. If the hw_mode of AP is 11b, then the link mode of current station will show 11b.