### PR TITLE
samples: mgmt: mcumgr: smp_svr: Make build only

### DIFF
--- a/samples/subsys/mgmt/mcumgr/smp_svr/sample.yaml
+++ b/samples/subsys/mgmt/mcumgr/smp_svr/sample.yaml
@@ -3,6 +3,7 @@ sample:
   name: smp svr
 common:
   sysbuild: true
+  build_only: true
 tests:
   sample.mcumgr.smp_svr.bt:
     harness: bluetooth


### PR DESCRIPTION
This is a sample, not a test, it should not run on devices and expect output with twister

Fixes #82251