### PR TITLE
API Change: Stream Flash: Deprecating stream_flash_erase_page

### DIFF
--- a/doc/releases/release-notes-4.1.rst
+++ b/doc/releases/release-notes-4.1.rst
@@ -88,6 +88,15 @@ Deprecated APIs and options
 
 * :kconfig:option:`CONFIG_NATIVE_APPLICATION` has been deprecated.
 
+* Deprecated the :c:func:`stream_flash_erase_page` from Stream Flash API. The same functionality
+  can be achieved using :c:func:`flash_area_erase` or :c:func:`flash_erase`. Nevertheless
+  erasing of a device, while stream flash is supposed to do so, as configured, will result in
+  data lost from stream flash. There are only two situations where device should be erased
+  directly:
+
+  1. when Stream Flash is not configured to do erase on its own
+  2. when erase is used for removal of a data prior or after Stream Flash uses the designated area.
+
 * For the native_sim target :kconfig:option:`CONFIG_NATIVE_SIM_NATIVE_POSIX_COMPAT` has been
   switched to ``n`` by default, and this option has been deprecated.
 

--- a/include/zephyr/storage/stream_flash.h
+++ b/include/zephyr/storage/stream_flash.h
@@ -130,6 +130,9 @@ int stream_flash_buffered_write(struct stream_flash_ctx *ctx, const uint8_t *dat
 /**
  * @brief Erase the flash page to which a given offset belongs.
  *
+ * @deprecated Use @a flash_area_erase() or flash_erase(). Note that there
+ * is no Stream Flash API equivalent for that.
+ *
  * This function erases a flash page to which an offset belongs if this page
  * is not the page previously erased by the provided ctx
  * (ctx->last_erased_page_start_offset).
@@ -139,7 +142,7 @@ int stream_flash_buffered_write(struct stream_flash_ctx *ctx, const uint8_t *dat
  *
  * @return non-negative on success, negative errno code on fail
  */
-int stream_flash_erase_page(struct stream_flash_ctx *ctx, off_t off);
+__deprecated int stream_flash_erase_page(struct stream_flash_ctx *ctx, off_t off);
 
 /**
  * @brief Load persistent stream write progress stored with key

--- a/include/zephyr/storage/stream_flash.h
+++ b/include/zephyr/storage/stream_flash.h
@@ -65,7 +65,9 @@ struct stream_flash_ctx {
 	stream_flash_callback_t callback; /* Callback invoked after write op */
 #endif
 #ifdef CONFIG_STREAM_FLASH_ERASE
-	off_t last_erased_page_start_offset; /* Last erased offset */
+	size_t erased_up_to;		/* Offset of last erased byte, relative to
+					 * offset in this context.
+					 */
 #endif
 	size_t write_block_size;	/* Offset/size device write alignment */
 	uint8_t erase_value;

--- a/subsys/storage/stream/Kconfig
+++ b/subsys/storage/stream/Kconfig
@@ -35,6 +35,20 @@ config STREAM_FLASH_ERASE
 	help
 	  If disabled an external actor must erase the flash area being written
 	  to.
+	  Option available only if there is at least one device in, a configuration,
+	  that requires erase prior to write.
+
+config STREAM_FLASH_ERASE_ONLY_WHEN_SUPPORTED
+	bool "Check if device supports erase prior to attempting one"
+	depends on STREAM_FLASH_ERASE
+	depends on FLASH_HAS_NO_EXPLICIT_ERASE
+	help
+	  This is used in stream flash code to exclude invocation of erase on devices that do not
+	  have such requirement prior to write nor support rase as a way to increase write speed.
+	  Option is available only if there is a mix of devices, in a configuration, where some
+	  support erase and some do not. If user is sure to not use Stream Flash with devices that
+	  have no support for erase, this option may be disabled to discard small amount of code
+	  from final application.
 
 config STREAM_FLASH_PROGRESS
 	bool "Persistent stream write progress"

--- a/subsys/storage/stream/stream_flash.c
+++ b/subsys/storage/stream/stream_flash.c
@@ -60,9 +60,9 @@ static int settings_direct_loader(const char *key, size_t len,
 				LOG_ERR("Error %d while getting page info", rc);
 				return rc;
 			}
-			ctx->last_erased_page_start_offset = page.start_offset;
+			ctx->erased_up_to = page.start_offset + page.size - ctx->offset;
 		} else {
-			ctx->last_erased_page_start_offset = -1;
+			ctx->erased_up_to = 0;
 		}
 #endif /* CONFIG_STREAM_FLASH_ERASE */
 	}
@@ -72,7 +72,64 @@ static int settings_direct_loader(const char *key, size_t len,
 
 #endif /* CONFIG_STREAM_FLASH_PROGRESS */
 
-#ifdef CONFIG_STREAM_FLASH_ERASE
+/* Will erase at most what is required to append given size, If already
+ * erased space can accommodate requested size, then no new page will
+ * be erased.
+ * Note that this function is supposed to fulfill hardware requirements
+ * for erase prior to write or allow faster writes when hardware supports
+ * erase as means to speed up writes, and will do nothing on devices that
+ * that not require erase before write.
+ */
+static int stream_flash_erase_to_append(struct stream_flash_ctx *ctx, size_t size)
+{
+	int rc = 0;
+#if defined(CONFIG_STREAM_FLASH_ERASE)
+	struct flash_pages_info page;
+#if defined(CONFIG_STREAM_FLASH_ERASE_ONLY_WHEN_SUPPORTED)
+	const struct flash_parameters *fparams = flash_get_parameters(ctx->fdev);
+#endif
+
+	/* ctx->erased_up_to points to first offset that has not yet been erased,
+	 * relative to ctx->offset.
+	 */
+	if (ctx->bytes_written + size <= ctx->erased_up_to) {
+		return 0;
+	}
+
+	/* Trying to append beyond available range? */
+	if (ctx->bytes_written + size > ctx->available) {
+		return -ERANGE;
+	}
+
+#if defined(CONFIG_STREAM_FLASH_ERASE_ONLY_WHEN_SUPPORTED)
+	/* Stream flash does not rely on erase, it does it when device needs it */
+	if (!(flash_params_get_erase_cap(fparams) & FLASH_ERASE_C_EXPLICIT)) {
+		return 0;
+	}
+#endif
+	/* Note that ctx->erased_up_to is offset relative to ctx->offset that
+	 * points to first byte not yet erased.
+	 */
+	rc = flash_get_page_info_by_offs(ctx->fdev, ctx->offset + ctx->erased_up_to, &page);
+	if (rc != 0) {
+		LOG_ERR("Error %d while getting page info", rc);
+		return rc;
+	}
+
+	LOG_DBG("Erasing page at offset 0x%08lx", (long)page.start_offset);
+
+	rc = flash_erase(ctx->fdev, page.start_offset, page.size);
+
+	if (rc != 0) {
+		LOG_ERR("Error %d while erasing page", rc);
+	} else {
+		ctx->erased_up_to += page.size;
+	}
+#endif
+	return rc;
+}
+
+#if defined(CONFIG_STREAM_FLASH_ERASE)
 
 int stream_flash_erase_page(struct stream_flash_ctx *ctx, off_t off)
 {
@@ -83,6 +140,11 @@ int stream_flash_erase_page(struct stream_flash_ctx *ctx, off_t off)
 	if (off < ctx->offset || (off - ctx->offset) >= ctx->available) {
 		LOG_ERR("Offset out of designated range");
 		return -ERANGE;
+	}
+
+	/* Do not allow pages that have already been erased */
+	if ((off - ctx->offset) < ctx->erased_up_to) {
+		return -EINVAL;
 	}
 
 #if defined(CONFIG_FLASH_HAS_NO_EXPLICIT_ERASE)
@@ -100,7 +162,7 @@ int stream_flash_erase_page(struct stream_flash_ctx *ctx, off_t off)
 		return rc;
 	}
 
-	if (ctx->last_erased_page_start_offset == page.start_offset) {
+	if (ctx->erased_up_to >= page.start_offset + page.size) {
 		return 0;
 	}
 
@@ -111,7 +173,7 @@ int stream_flash_erase_page(struct stream_flash_ctx *ctx, off_t off)
 	if (rc != 0) {
 		LOG_ERR("Error %d while erasing page", rc);
 	} else {
-		ctx->last_erased_page_start_offset = page.start_offset;
+		ctx->erased_up_to = page.start_offset + page.size;
 	}
 
 	return rc;
@@ -137,11 +199,10 @@ static int flash_sync(struct stream_flash_ctx *ctx)
 
 	if (IS_ENABLED(CONFIG_STREAM_FLASH_ERASE)) {
 
-		rc = stream_flash_erase_page(ctx,
-					     write_addr + ctx->buf_bytes - 1);
+		rc = stream_flash_erase_to_append(ctx, ctx->buf_bytes);
 		if (rc < 0) {
-			LOG_ERR("stream_flash_erase_page err %d offset=0x%08zx",
-				rc, write_addr);
+			LOG_ERR("stream_flash_forward_erase %d range=0x%08zx",
+				rc, ctx->buf_bytes);
 			return rc;
 		}
 	}
@@ -343,7 +404,7 @@ int stream_flash_init(struct stream_flash_ctx *ctx, const struct device *fdev,
 
 
 #ifdef CONFIG_STREAM_FLASH_ERASE
-	ctx->last_erased_page_start_offset = -1;
+	ctx->erased_up_to = 0;
 #endif
 	ctx->erase_value = params->erase_value;
 

--- a/tests/subsys/storage/stream/stream_flash/src/main.c
+++ b/tests/subsys/storage/stream/stream_flash/src/main.c
@@ -424,80 +424,6 @@ ZTEST(lib_stream_flash, test_stream_flash_buffered_write_whole_page)
 	/* Second page should not be erased */
 	VERIFY_WRITTEN(page_size, page_size);
 }
-
-/* Erase that never completes successfully */
-static int bad_erase(const struct device *dev, off_t offset, size_t size)
-{
-	return -EINVAL;
-}
-
-ZTEST(lib_stream_flash, test_stream_flash_erase_page)
-{
-	int rc;
-
-	init_target();
-
-	/* Write something to make page dirty */
-	rc = flash_write(ctx.fdev, FLASH_BASE, write_buf, BUF_LEN);
-	zassert_equal(rc, 0, "expected success");
-
-	rc = stream_flash_erase_page(&ctx, FLASH_BASE);
-	zassert_equal(rc, 0, "expected success");
-
-	VERIFY_ERASED(0, page_size);
-
-	/*
-	 * Test failure in erase does not change context.
-	 * The test is done by replacing erase function of device API with fake
-	 * one that returns with an error, invoking the erase procedure
-	 * and than comparing state of context prior to call to the one after.
-	 */
-	struct device fake_dev = *ctx.fdev;
-	struct flash_driver_api fake_api = *(struct flash_driver_api *)ctx.fdev->api;
-	struct stream_flash_ctx bad_ctx = ctx;
-	struct stream_flash_ctx cmp_ctx;
-
-	fake_api.erase = bad_erase;
-	fake_dev.api = &fake_api;
-	bad_ctx.fdev = &fake_dev;
-	/* Triger erase attempt */
-	bad_ctx.last_erased_page_start_offset = FLASH_BASE - 16;
-	cmp_ctx = bad_ctx;
-
-	rc = stream_flash_erase_page(&bad_ctx, FLASH_BASE);
-	zassert_equal(memcmp(&bad_ctx, &cmp_ctx, sizeof(bad_ctx)), 0,
-		      "Ctx should not get altered");
-	zassert_equal(rc, -EINVAL, "Expected failure");
-
-	/* False dev with erase set to NULL to avoid actual erase */
-	fake_api.erase = NULL;
-	struct stream_flash_ctx range_test_ctx = {
-		.offset = 1024,
-		.available = 2048,
-		.fdev = &fake_dev,
-		.last_erased_page_start_offset = -1,
-	};
-
-	rc = stream_flash_erase_page(&range_test_ctx, 1024);
-	zassert_equal(rc, -ENOSYS, "%d No device attached - expected failure", rc);
-
-	rc = stream_flash_erase_page(&range_test_ctx, 1023);
-	zassert_equal(rc, -ERANGE, "Expected failure - offset before designated area");
-
-	rc = stream_flash_erase_page(&range_test_ctx,
-				     range_test_ctx.offset + range_test_ctx.available + 1);
-	zassert_equal(rc, -ERANGE, "Expected failure - offset after designated area");
-}
-#else
-ZTEST(lib_stream_flash, test_stream_flash_erase_page)
-{
-	ztest_test_skip();
-}
-
-ZTEST(lib_stream_flash, test_stream_flash_buffered_write_whole_page)
-{
-	ztest_test_skip();
-}
 #endif
 
 static size_t write_and_save_progress(size_t bytes, const char *save_key)
@@ -580,8 +506,7 @@ ZTEST(lib_stream_flash, test_stream_flash_progress_resume)
 	size_t bytes_written_old;
 	size_t bytes_written;
 #ifdef CONFIG_STREAM_FLASH_ERASE
-	off_t erase_offset_old;
-	off_t erase_offset;
+	size_t erased_up_to_old;
 #endif
 
 	clear_all_progress();
@@ -589,7 +514,7 @@ ZTEST(lib_stream_flash, test_stream_flash_progress_resume)
 
 	bytes_written_old = stream_flash_bytes_written(&ctx);
 #ifdef CONFIG_STREAM_FLASH_ERASE
-	erase_offset_old = ctx.last_erased_page_start_offset;
+	erased_up_to_old = ctx.erased_up_to;
 #endif
 
 	/* Test load with zero bytes_written */
@@ -603,8 +528,7 @@ ZTEST(lib_stream_flash, test_stream_flash_progress_resume)
 	zassert_equal(bytes_written, bytes_written_old,
 		      "expected bytes_written to be unchanged");
 #ifdef CONFIG_STREAM_FLASH_ERASE
-	erase_offset = ctx.last_erased_page_start_offset;
-	zassert_equal(erase_offset, erase_offset_old,
+	zassert_equal(ctx.erased_up_to, erased_up_to_old,
 		      "expected erase offset to be unchanged");
 #endif
 
@@ -615,8 +539,8 @@ ZTEST(lib_stream_flash, test_stream_flash_progress_resume)
 	bytes_written_old = write_and_save_progress(page_size * 2,
 						    progress_key);
 #ifdef CONFIG_STREAM_FLASH_ERASE
-	erase_offset_old = ctx.last_erased_page_start_offset;
-	zassert_true(erase_offset_old != 0, "expected pages to be erased");
+	zassert_false(ctx.erased_up_to == 0, "expected pages to be erased");
+	erased_up_to_old = ctx.erased_up_to;
 #endif
 
 	init_target();
@@ -626,7 +550,7 @@ ZTEST(lib_stream_flash, test_stream_flash_progress_resume)
 	zassert_equal(bytes_written, bytes_written_old,
 		      "expected bytes_written to be loaded");
 #if defined(CONFIG_STREAM_FLASH_ERASE)
-	zassert_equal(erase_offset_old, ctx.last_erased_page_start_offset,
+	zassert_equal(erased_up_to_old, ctx.erased_up_to,
 		      "expected last erased page offset to be loaded");
 #endif
 
@@ -647,7 +571,6 @@ ZTEST(lib_stream_flash, test_stream_flash_progress_clear)
 	size_t bytes_written;
 #ifdef CONFIG_STREAM_FLASH_ERASE
 	off_t erase_offset_old;
-	off_t erase_offset;
 #endif
 
 	clear_all_progress();
@@ -663,7 +586,7 @@ ZTEST(lib_stream_flash, test_stream_flash_progress_clear)
 
 	bytes_written_old = stream_flash_bytes_written(&ctx);
 #ifdef CONFIG_STREAM_FLASH_ERASE
-	erase_offset_old = ctx.last_erased_page_start_offset;
+	erase_offset_old = ctx.erased_up_to;
 #endif
 
 	rc = stream_flash_progress_load(&ctx, progress_key);
@@ -674,8 +597,7 @@ ZTEST(lib_stream_flash, test_stream_flash_progress_clear)
 		      "expected bytes_written to be unchanged");
 
 #ifdef CONFIG_STREAM_FLASH_ERASE
-	erase_offset = ctx.last_erased_page_start_offset;
-	zassert_equal(erase_offset, erase_offset_old,
+	zassert_equal(ctx.erased_up_to, erase_offset_old,
 		      "expected erase offset to be unchanged");
 #endif
 }


### PR DESCRIPTION
A few commits that
 - move stream flash logic to stop using stream_flash_erase_page
 - fixing tests
 - marking  the stream_flash_erase_page as deprecated

Fixes #67407