### PR TITLE
modules: hal_nordic: nrfs: callback when connected

### DIFF
--- a/modules/hal_nordic/nrfs/backends/nrfs_backend_ipc_service.h
+++ b/modules/hal_nordic/nrfs/backends/nrfs_backend_ipc_service.h
@@ -86,6 +86,21 @@ nrfs_err_t nrfs_backend_send_ex(void *message, size_t size, k_timeout_t timeout,
  */
 void nrfs_backend_fatal_error_handler(enum nrfs_backend_error error_id);
 
+typedef void (*nrfs_backend_bound_info_cb_t)(void);
+struct nrfs_backend_bound_info_subs {
+	sys_snode_t node;
+	nrfs_backend_bound_info_cb_t cb;
+};
+/**
+ * @brief Register callback function to notify when nrfs is connected.
+ * There can be multiple callbacks registered.
+ *
+ * @param subs Subcription instance.
+ * @param cb Callback
+ */
+void nrfs_backend_register_bound_subscribe(struct nrfs_backend_bound_info_subs *subs,
+				    nrfs_backend_bound_info_cb_t cb);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
User can assign callback function to nrfs ip backend to be notified when connection is actually established. Callback register neeeds to be done before nrfs is initialized.