### PR TITLE
boards: nxp: Add 'supported: flash'

### DIFF
--- a/boards/nxp/frdm_k22f/frdm_k22f.yaml
+++ b/boards/nxp/frdm_k22f/frdm_k22f.yaml
@@ -12,6 +12,7 @@ supported:
   - arduino_i2c
   - arduino_spi
   - dac
+  - flash
   - gpio
   - i2c
   - nvs

--- a/boards/nxp/frdm_k64f/frdm_k64f.yaml
+++ b/boards/nxp/frdm_k64f/frdm_k64f.yaml
@@ -18,6 +18,7 @@ supported:
   - counter
   - dac
   - dma
+  - flash
   - gpio
   - i2c
   - netif:eth

--- a/boards/nxp/frdm_k82f/frdm_k82f.yaml
+++ b/boards/nxp/frdm_k82f/frdm_k82f.yaml
@@ -15,6 +15,7 @@ supported:
   - arduino_spi
   - counter
   - dma
+  - flash
   - gpio
   - i2c
   - nvs

--- a/boards/nxp/frdm_ke15z/frdm_ke15z.yaml
+++ b/boards/nxp/frdm_ke15z/frdm_ke15z.yaml
@@ -9,5 +9,6 @@ toolchain:
 flash: 256
 ram: 24
 supported:
+  - flash
   - gpio
   - uart

--- a/boards/nxp/frdm_ke17z/frdm_ke17z.yaml
+++ b/boards/nxp/frdm_ke17z/frdm_ke17z.yaml
@@ -9,13 +9,14 @@ toolchain:
   - gnuarmemb
   - xtools
 supported:
-  - counter
-  - gpio
   - adc
-  - uart
-  - pwm
-  - i2c
-  - spi
+  - counter
   - dma
+  - flash
+  - gpio
+  - i2c
+  - pwm
+  - spi
+  - uart
   - watchdog
 vendor: nxp

--- a/boards/nxp/frdm_ke17z512/frdm_ke17z512.yaml
+++ b/boards/nxp/frdm_ke17z512/frdm_ke17z512.yaml
@@ -18,6 +18,7 @@ supported:
   - counter
   - gpio
   - adc
+  - flash
   - uart
   - pwm
   - i2c

--- a/boards/nxp/frdm_kl25z/frdm_kl25z.yaml
+++ b/boards/nxp/frdm_kl25z/frdm_kl25z.yaml
@@ -16,6 +16,7 @@ supported:
   - adc
   - arduino_gpio
   - gpio
+  - flash
   - i2c
   - usb_device
 vendor: nxp

--- a/boards/nxp/frdm_kw41z/frdm_kw41z.yaml
+++ b/boards/nxp/frdm_kw41z/frdm_kw41z.yaml
@@ -12,6 +12,7 @@ supported:
   - adc
   - arduino_gpio
   - counter
+  - flash
   - gpio
   - i2c
   - spi

--- a/boards/nxp/frdm_mcxa156/frdm_mcxa156.yaml
+++ b/boards/nxp/frdm_mcxa156/frdm_mcxa156.yaml
@@ -15,5 +15,6 @@ toolchain:
   - gnuarmemb
   - xtools
 supported:
+  - flash
   - gpio
 vendor: nxp

--- a/boards/nxp/frdm_mcxc242/frdm_mcxc242.yaml
+++ b/boards/nxp/frdm_mcxc242/frdm_mcxc242.yaml
@@ -15,14 +15,15 @@ toolchain:
   - gnuarmemb
   - xtools
 supported:
-  - gpio
-  - uart
-  - i2c
-  - usb_device
-  - usbd
-  - pwm
   - adc
   - counter
+  - flash
+  - gpio
+  - i2c
+  - pwm
+  - uart
+  - usb_device
+  - usbd
 testing:
   ignore_tags:
     - net

--- a/boards/nxp/frdm_mcxc444/frdm_mcxc444.yaml
+++ b/boards/nxp/frdm_mcxc444/frdm_mcxc444.yaml
@@ -15,9 +15,10 @@ toolchain:
   - gnuarmemb
   - xtools
 supported:
+  - counter
+  - flash
   - gpio
   - uart
-  - counter
 testing:
   ignore_tags:
     - net

--- a/boards/nxp/frdm_mcxn236/frdm_mcxn236.yaml
+++ b/boards/nxp/frdm_mcxn236/frdm_mcxn236.yaml
@@ -15,14 +15,15 @@ toolchain:
   - gnuarmemb
   - xtools
 supported:
-  - can
-  - dma
-  - gpio
-  - spi
-  - i2c
-  - watchdog
-  - pwm
-  - counter
-  - regulator
   - adc
+  - can
+  - counter
+  - dma
+  - flash
+  - gpio
+  - i2c
+  - pwm
+  - regulator
+  - spi
+  - watchdog
 vendor: nxp

--- a/boards/nxp/frdm_mcxn947/frdm_mcxn947_mcxn947_cpu0.yaml
+++ b/boards/nxp/frdm_mcxn947/frdm_mcxn947_mcxn947_cpu0.yaml
@@ -15,18 +15,19 @@ toolchain:
   - gnuarmemb
   - xtools
 supported:
-  - can
-  - dma
-  - gpio
-  - spi
-  - dac
-  - i2c
-  - watchdog
-  - pwm
-  - counter
-  - sdhc
-  - regulator
   - adc
-  - usb_device
+  - can
+  - counter
+  - dac
+  - dma
+  - flash
+  - gpio
+  - i2c
   - i3c
+  - pwm
+  - regulator
+  - sdhc
+  - spi
+  - usb_device
+  - watchdog
 vendor: nxp

--- a/boards/nxp/frdm_mcxn947/frdm_mcxn947_mcxn947_cpu0_qspi.yaml
+++ b/boards/nxp/frdm_mcxn947/frdm_mcxn947_mcxn947_cpu0_qspi.yaml
@@ -15,18 +15,19 @@ toolchain:
   - gnuarmemb
   - xtools
 supported:
-  - can
-  - dma
-  - gpio
-  - spi
-  - dac
-  - i2c
-  - watchdog
-  - pwm
-  - counter
-  - sdhc
-  - regulator
   - adc
-  - usb_device
+  - can
+  - counter
+  - dac
+  - dma
+  - flash
+  - gpio
+  - i2c
   - i3c
+  - pwm
+  - regulator
+  - sdhc
+  - spi
+  - usb_device
+  - watchdog
 vendor: nxp

--- a/boards/nxp/frdm_mcxw71/frdm_mcxw71.yaml
+++ b/boards/nxp/frdm_mcxw71/frdm_mcxw71.yaml
@@ -9,15 +9,15 @@ toolchain:
   - gnuarmemb
   - xtools
 supported:
-  - gpio
-  - uart
-  - counter
-  - pwm
-  - watchdog
-  - pinctrl
-  - flash
-  - spi
-  - i2c
-  - can
-  - regulator
   - adc
+  - can
+  - counter
+  - flash
+  - gpio
+  - i2c
+  - pinctrl
+  - pwm
+  - regulator
+  - spi
+  - uart
+  - watchdog

--- a/boards/nxp/hexiwear/hexiwear_mk64f12.yaml
+++ b/boards/nxp/hexiwear/hexiwear_mk64f12.yaml
@@ -9,6 +9,7 @@ toolchain:
 supported:
   - adc
   - ble
+  - flash
   - gpio
   - i2c
   - pwm

--- a/boards/nxp/lpcxpresso54114/lpcxpresso54114_lpc54114_m4.yaml
+++ b/boards/nxp/lpcxpresso54114/lpcxpresso54114_lpc54114_m4.yaml
@@ -17,6 +17,7 @@ toolchain:
 supported:
   - arduino_i2c
   - arduino_spi
+  - flash
   - gpio
   - i2c
   - spi

--- a/boards/nxp/lpcxpresso55s06/lpcxpresso55s06.yaml
+++ b/boards/nxp/lpcxpresso55s06/lpcxpresso55s06.yaml
@@ -14,6 +14,7 @@ toolchain:
   - gnuarmemb
   - xtools
 supported:
-  - gpio
   - can
+  - flash
+  - gpio
 vendor: nxp

--- a/boards/nxp/lpcxpresso55s16/lpcxpresso55s16.yaml
+++ b/boards/nxp/lpcxpresso55s16/lpcxpresso55s16.yaml
@@ -20,6 +20,7 @@ supported:
   - arduino_spi
   - can
   - counter
+  - flash
   - gpio
   - i2c
   - spi

--- a/boards/nxp/lpcxpresso55s28/lpcxpresso55s28.yaml
+++ b/boards/nxp/lpcxpresso55s28/lpcxpresso55s28.yaml
@@ -19,6 +19,7 @@ supported:
   - arduino_gpio
   - arduino_i2c
   - arduino_spi
+  - flash
   - gpio
   - i2c
   - spi

--- a/boards/nxp/lpcxpresso55s36/lpcxpresso55s36.yaml
+++ b/boards/nxp/lpcxpresso55s36/lpcxpresso55s36.yaml
@@ -15,11 +15,12 @@ toolchain:
   - gnuarmemb
   - xtools
 supported:
+  - arduino_gpio
   - can
+  - dac
+  - flash
   - gpio
   - pwm
-  - dac
   - usb_device
   - usbd
-  - arduino_gpio
 vendor: nxp

--- a/boards/nxp/lpcxpresso55s69/lpcxpresso55s69_lpc55s69_cpu0.yaml
+++ b/boards/nxp/lpcxpresso55s69/lpcxpresso55s69_lpc55s69_cpu0.yaml
@@ -21,6 +21,7 @@ supported:
   - arduino_serial
   - arduino_spi
   - counter
+  - flash
   - gpio
   - i2c
   - i2s

--- a/boards/nxp/mimxrt1010_evk/mimxrt1010_evk.yaml
+++ b/boards/nxp/mimxrt1010_evk/mimxrt1010_evk.yaml
@@ -16,15 +16,16 @@ toolchain:
 ram: 64
 flash: 16384
 supported:
+  - adc
   - arduino_gpio
   - arduino_i2c
   - arduino_serial
   - arduino_spi
-  - i2c
   - counter
   - dma
-  - usb_device
-  - spi
-  - adc
+  - flash
   - gpio
+  - i2c
+  - spi
+  - usb_device
 vendor: nxp

--- a/boards/nxp/mimxrt1015_evk/mimxrt1015_evk.yaml
+++ b/boards/nxp/mimxrt1015_evk/mimxrt1015_evk.yaml
@@ -15,13 +15,14 @@ toolchain:
 ram: 32
 flash: 16384
 supported:
+  - adc
   - arduino_gpio
   - arduino_serial
   - counter
   - dma
+  - flash
   - gpio
   - i2c
-  - usb_device
   - spi
-  - adc
+  - usb_device
 vendor: nxp

--- a/boards/nxp/mimxrt1020_evk/mimxrt1020_evk.yaml
+++ b/boards/nxp/mimxrt1020_evk/mimxrt1020_evk.yaml
@@ -15,15 +15,16 @@ toolchain:
 ram: 32768
 flash: 8192
 supported:
+  - adc
   - arduino_gpio
   - arduino_serial
   - counter
   - dma
+  - flash
   - gpio
   - i2c
   - netif:eth
+  - sdhc
   - spi
   - usb_device
-  - adc
-  - sdhc
 vendor: nxp

--- a/boards/nxp/mimxrt1024_evk/mimxrt1024_evk.yaml
+++ b/boards/nxp/mimxrt1024_evk/mimxrt1024_evk.yaml
@@ -15,17 +15,18 @@ toolchain:
 ram: 32768
 flash: 4096
 supported:
+  - adc
   - arduino_gpio
   - arduino_serial
   - can
   - dma
+  - flash
+  - gpio
   - hwinfo
   - netif:eth
-  - watchdog
-  - spi
-  - sdhc
-  - adc
-  - usb_device
   - pwm
-  - gpio
+  - sdhc
+  - spi
+  - usb_device
+  - watchdog
 vendor: nxp

--- a/boards/nxp/mimxrt1040_evk/mimxrt1040_evk.yaml
+++ b/boards/nxp/mimxrt1040_evk/mimxrt1040_evk.yaml
@@ -15,11 +15,12 @@ toolchain:
 ram: 32768
 flash: 8192
 supported:
-  - arduino_gpio
-  - gpio
-  - pwm
   - adc
-  - spi
-  - i2c
+  - arduino_gpio
   - counter
+  - flash
+  - gpio
+  - i2c
+  - pwm
+  - spi
 vendor: nxp

--- a/boards/nxp/mimxrt1050_evk/mimxrt1050_evk_mimxrt1052_hyperflash.yaml
+++ b/boards/nxp/mimxrt1050_evk/mimxrt1050_evk_mimxrt1052_hyperflash.yaml
@@ -15,11 +15,13 @@ toolchain:
 ram: 32768
 flash: 65536
 supported:
+  - adc
   - arduino_gpio
   - arduino_serial
   - counter
   - display
   - dma
+  - flash
   - gpio
   - i2c
   - netif:eth
@@ -28,5 +30,4 @@ supported:
   - usb_device
   - usbd
   - watchdog
-  - adc
 vendor: nxp

--- a/boards/nxp/mimxrt1050_evk/mimxrt1050_evk_mimxrt1052_qspi.yaml
+++ b/boards/nxp/mimxrt1050_evk/mimxrt1050_evk_mimxrt1052_qspi.yaml
@@ -15,11 +15,13 @@ toolchain:
 ram: 32768
 flash: 8192
 supported:
+  - adc
   - arduino_gpio
   - arduino_serial
   - counter
   - display
   - dma
+  - flash
   - gpio
   - i2c
   - netif:eth
@@ -28,5 +30,4 @@ supported:
   - usb_device
   - usbd
   - watchdog
-  - adc
 vendor: nxp

--- a/boards/nxp/mimxrt1060_evk/mimxrt1060_evk_mimxrt1062_hyperflash.yaml
+++ b/boards/nxp/mimxrt1060_evk/mimxrt1060_evk_mimxrt1062_hyperflash.yaml
@@ -22,6 +22,7 @@ supported:
   - counter
   - display
   - dma
+  - flash
   - gpio
   - i2c
   - netif:eth

--- a/boards/nxp/mimxrt1060_evk/mimxrt1060_evk_mimxrt1062_qspi.yaml
+++ b/boards/nxp/mimxrt1060_evk/mimxrt1060_evk_mimxrt1062_qspi.yaml
@@ -15,15 +15,16 @@ toolchain:
 ram: 32768
 flash: 8192
 supported:
+  - adc
   - arduino_gpio
   - arduino_i2c
   - arduino_serial
   - arduino_spi
-  - adc
   - can
   - counter
   - display
   - dma
+  - flash
   - gpio
   - i2c
   - netif:eth

--- a/boards/nxp/mimxrt1062_fmurt6/mimxrt1062_fmurt6.yaml
+++ b/boards/nxp/mimxrt1062_fmurt6/mimxrt1062_fmurt6.yaml
@@ -15,17 +15,18 @@ toolchain:
 ram: 768
 flash: 65536
 supported:
+  - adc
+  - can
   - counter
-  - uart
   - dma
+  - flash
   - gpio
   - i2c
   - netif:eth
+  - pwm
   - sdhc
   - spi
+  - uart
   - usb_device
-  - can
   - watchdog
-  - adc
-  - pwm
 vendor: nxp

--- a/boards/nxp/mimxrt1064_evk/mimxrt1064_evk.yaml
+++ b/boards/nxp/mimxrt1064_evk/mimxrt1064_evk.yaml
@@ -15,11 +15,14 @@ toolchain:
 ram: 32768
 flash: 4096
 supported:
+  - adc
   - arduino_gpio
   - arduino_serial
+  - can
   - counter
   - display
   - dma
+  - flash
   - gpio
   - hwinfo
   - i2c
@@ -29,7 +32,5 @@ supported:
   - spi
   - usb_device
   - video
-  - can
   - watchdog
-  - adc
 vendor: nxp

--- a/boards/nxp/mimxrt1160_evk/mimxrt1160_evk_mimxrt1166_cm4.yaml
+++ b/boards/nxp/mimxrt1160_evk/mimxrt1160_evk_mimxrt1166_cm4.yaml
@@ -16,8 +16,9 @@ ram: 128
 flash: 128
 supported:
   - dma
-  - i2c
+  - flash
   - gpio
+  - i2c
   - pwm
   - uart
 vendor: nxp

--- a/boards/nxp/mimxrt1160_evk/mimxrt1160_evk_mimxrt1166_cm7.yaml
+++ b/boards/nxp/mimxrt1160_evk/mimxrt1160_evk_mimxrt1166_cm7.yaml
@@ -15,9 +15,10 @@ toolchain:
 ram: 256
 flash: 16384
 supported:
-  - counter
   - can
+  - counter
   - dma
+  - flash
   - gpio
   - hwinfo
   - i2c

--- a/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm4.yaml
+++ b/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm4.yaml
@@ -16,6 +16,7 @@ ram: 128
 flash: 128
 supported:
   - dma
+  - flash
   - gpio
   - i2c
   - pwm

--- a/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm4_B.yaml
+++ b/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm4_B.yaml
@@ -16,8 +16,9 @@ ram: 128
 flash: 128
 supported:
   - dma
+  - flash
   - gpio
   - i2c
-  - spi
   - pwm
+  - spi
 vendor: nxp

--- a/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm7.yaml
+++ b/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm7.yaml
@@ -16,10 +16,11 @@ ram: 256
 flash: 16384
 supported:
   - adc
-  - counter
   - can
+  - counter
   - display
   - dma
+  - flash
   - gpio
   - hwinfo
   - i2c
@@ -28,7 +29,7 @@ supported:
   - pwm
   - spi
   - usb_device
-  - watchdog
-  - video
   - usbd
+  - video
+  - watchdog
 vendor: nxp

--- a/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm7_B.yaml
+++ b/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm7_B.yaml
@@ -16,15 +16,16 @@ ram: 65536
 flash: 65536
 supported:
   - adc
-  - counter
   - can
+  - counter
   - dma
+  - flash
   - gpio
   - hwinfo
   - i2c
   - mipi_dsi
   - spi
   - usb_device
-  - watchdog
   - video
+  - watchdog
 vendor: nxp

--- a/boards/nxp/mimxrt1180_evk/mimxrt1180_evk_mimxrt1189_cm33.yaml
+++ b/boards/nxp/mimxrt1180_evk/mimxrt1180_evk_mimxrt1189_cm33.yaml
@@ -15,12 +15,13 @@ toolchain:
 ram: 128
 flash: 16384
 supported:
-  - gpio
-  - uart
-  - i2c
-  - counter
   - adc
-  - netif:eth
   - can
+  - counter
+  - flash
+  - gpio
+  - i2c
+  - netif:eth
   - pwm
+  - uart
 vendor: nxp

--- a/boards/nxp/mimxrt1180_evk/mimxrt1180_evk_mimxrt1189_cm7.yaml
+++ b/boards/nxp/mimxrt1180_evk/mimxrt1180_evk_mimxrt1189_cm7.yaml
@@ -15,11 +15,12 @@ toolchain:
 ram: 256
 flash: 256
 supported:
-  - gpio
-  - uart
-  - i2c
-  - counter
   - adc
   - can
+  - counter
+  - flash
+  - gpio
+  - i2c
   - pwm
+  - uart
 vendor: nxp

--- a/boards/nxp/mimxrt595_evk/mimxrt595_evk_mimxrt595s_cm33.yaml
+++ b/boards/nxp/mimxrt595_evk/mimxrt595_evk_mimxrt595s_cm33.yaml
@@ -20,13 +20,14 @@ supported:
   - arduino_serial
   - counter
   - dma
+  - dmic
+  - flash
   - gpio
   - i2c
+  - i2s
+  - pwm
+  - sdhc
   - spi
   - usb_device
   - watchdog
-  - sdhc
-  - pwm
-  - i2s
-  - dmic
 vendor: nxp

--- a/boards/nxp/mimxrt685_evk/mimxrt685_evk_mimxrt685s_cm33.yaml
+++ b/boards/nxp/mimxrt685_evk/mimxrt685_evk_mimxrt685s_cm33.yaml
@@ -21,15 +21,16 @@ supported:
   - arduino_spi
   - counter
   - dma
-  - pwm
+  - flash
   - gpio
   - hwinfo
   - i2c
-  - i3c
   - i2s
+  - i3c
+  - pwm
   - sdhc
   - spi
-  - watchdog
   - usb_device
   - usbd
+  - watchdog
 vendor: nxp

--- a/boards/nxp/mr_canhubk3/mr_canhubk3.yaml
+++ b/boards/nxp/mr_canhubk3/mr_canhubk3.yaml
@@ -10,16 +10,17 @@ flash: 1024
 toolchain:
   - zephyr
 supported:
-  - gpio
-  - uart
-  - can
-  - i2c
   - adc
-  - spi
-  - watchdog
+  - can
+  - counter
+  - display
+  - dma
+  - flash
+  - gpio
+  - i2c
   - netif:eth
   - pwm
-  - dma
-  - display
-  - counter
+  - spi
+  - uart
+  - watchdog
 vendor: nxp

--- a/boards/nxp/rd_rw612_bga/rd_rw612_bga.yaml
+++ b/boards/nxp/rd_rw612_bga/rd_rw612_bga.yaml
@@ -15,16 +15,17 @@ toolchain:
 ram: 960
 flash: 65536
 supported:
+  - adc
+  - counter
+  - dac
   - dma
   - dmic
-  - gpio
-  - spi
-  - i2c
   - entropy
+  - flash
+  - gpio
+  - hwinfo
+  - i2c
+  - pwm
+  - spi
   - usb_device
   - watchdog
-  - counter
-  - pwm
-  - hwinfo
-  - adc
-  - dac

--- a/boards/nxp/rddrone_fmuk66/rddrone_fmuk66.yaml
+++ b/boards/nxp/rddrone_fmuk66/rddrone_fmuk66.yaml
@@ -10,6 +10,7 @@ toolchain:
 supported:
   - can
   - counter
+  - flash
   - gpio
   - i2c
   - nvs

--- a/boards/nxp/twr_ke18f/twr_ke18f.yaml
+++ b/boards/nxp/twr_ke18f/twr_ke18f.yaml
@@ -15,6 +15,7 @@ supported:
   - dac
   - dma
   - i2c
+  - flash
   - pwm
   - spi
   - watchdog

--- a/boards/nxp/twr_kv58f220m/twr_kv58f220m.yaml
+++ b/boards/nxp/twr_kv58f220m/twr_kv58f220m.yaml
@@ -9,5 +9,6 @@ toolchain:
 ram: 128
 flash: 1024
 supported:
+  - flash
   - i2c
 vendor: nxp

--- a/boards/nxp/usb_kw24d512/usb_kw24d512.yaml
+++ b/boards/nxp/usb_kw24d512/usb_kw24d512.yaml
@@ -9,6 +9,7 @@ toolchain:
   - gnuarmemb
   - xtools
 supported:
+  - flash
   - usb_device
   - watchdog
 vendor: nxp

--- a/boards/nxp/vmu_rt1170/vmu_rt1170.yaml
+++ b/boards/nxp/vmu_rt1170/vmu_rt1170.yaml
@@ -16,9 +16,10 @@ ram: 256
 flash: 65536
 supported:
   - adc
-  - counter
   - can
+  - counter
   - dma
+  - flash
   - gpio
   - hwinfo
   - i2c


### PR DESCRIPTION
- Adds 'supported: flash' to all NXP board .yaml with enabled flash controller support.
- Sorts supported features alphabetically.