### PR TITLE
drivers: can: nrf: make sure HSFLL frequency >= AUXPLL

### DIFF
--- a/drivers/can/can_nrf.c
+++ b/drivers/can/can_nrf.c
@@ -13,6 +13,7 @@
 #include <zephyr/drivers/can.h>
 #include <zephyr/drivers/can/can_mcan.h>
 #include <zephyr/drivers/clock_control.h>
+#include <zephyr/drivers/clock_control/nrf_clock_control.h>
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/irq.h>
 
@@ -27,7 +28,8 @@ struct can_nrf_config {
 	uint32_t mcan;
 	uint32_t mrba;
 	uint32_t mram;
-	const struct device *clock;
+	const struct device *auxpll;
+	const struct device *hsfll;
 	const struct pinctrl_dev_config *pcfg;
 	void (*irq_configure)(void);
 	uint16_t irq;
@@ -54,7 +56,7 @@ static int can_nrf_get_core_clock(const struct device *dev, uint32_t *rate)
 	const struct can_mcan_config *mcan_config = dev->config;
 	const struct can_nrf_config *config = mcan_config->custom;
 
-	return clock_control_get_rate(config->clock, NULL, rate);
+	return clock_control_get_rate(config->auxpll, NULL, rate);
 }
 
 static DEVICE_API(can, can_nrf_api) = {
@@ -131,17 +133,41 @@ static const struct can_mcan_ops can_mcan_nrf_ops = {
 	.clear_mram = can_nrf_clear_mram,
 };
 
+static int configure_hsfll(const struct device *dev, bool on)
+{
+	const struct can_mcan_config *mcan_config = dev->config;
+	const struct can_nrf_config *config = mcan_config->custom;
+	struct nrf_clock_spec spec = { 0 };
+
+	/* If CAN is on, HSFLL frequency >= AUXPLL frequency */
+	if (on) {
+		int ret;
+
+		ret = clock_control_get_rate(dev, NULL, &spec.frequency);
+		if (ret < 0) {
+			return ret;
+		}
+	}
+
+	return nrf_clock_control_request_sync(config->hsfll, &spec, K_FOREVER);
+}
+
 static int can_nrf_init(const struct device *dev)
 {
 	const struct can_mcan_config *mcan_config = dev->config;
 	const struct can_nrf_config *config = mcan_config->custom;
 	int ret;
 
-	if (!device_is_ready(config->clock)) {
+	if (!device_is_ready(config->auxpll) || !device_is_ready(config->hsfll)) {
 		return -ENODEV;
 	}
 
-	ret = clock_control_on(config->clock, NULL);
+	ret = configure_hsfll(dev, true);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = clock_control_on(config->auxpll, NULL);
 	if (ret < 0) {
 		return ret;
 	}
@@ -186,8 +212,9 @@ static int can_nrf_init(const struct device *dev)
 		.mcan = CAN_MCAN_DT_INST_MCAN_ADDR(n),                                             \
 		.mrba = CAN_MCAN_DT_INST_MRBA(n),                                                  \
 		.mram = CAN_MCAN_DT_INST_MRAM_ADDR(n),                                             \
-		.clock = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(n)),                                    \
+		.auxpll = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR_BY_NAME(n, auxpll)),                   \
 		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),                                         \
+		.hsfll = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR_BY_NAME(n, hsfll)),                     \
 		.irq = DT_INST_IRQN(n),                                                            \
 		.irq_configure = can_nrf_irq_configure##n,                                         \
 	};                                                                                         \

--- a/dts/bindings/can/nordic,nrf-can.yaml
+++ b/dts/bindings/can/nordic,nrf-can.yaml
@@ -17,6 +17,9 @@ properties:
   clocks:
     required: true
 
+  clock-names:
+    required: true
+
   pinctrl-0:
     required: true
 

--- a/dts/common/nordic/nrf54h20.dtsi
+++ b/dts/common/nordic/nrf54h20.dtsi
@@ -602,7 +602,8 @@
 				reg = <0x8d8000 0x400>, <0x2fbef800 0x800>, <0x2fbe8000 0x7800>;
 				reg-names = "wrapper", "m_can", "message_ram";
 				interrupts = <216 NRF_DEFAULT_IRQ_PRIORITY>;
-				clocks = <&canpll>;
+				clocks = <&canpll>, <&hsfll120>;
+				clock-names = "auxpll", "hsfll";
 				power-domains = <&gpd NRF_GPD_FAST_ACTIVE1>;
 				bosch,mram-cfg = <0x0 28 8 3 3 0 1 1>;
 				status = "disabled";

--- a/dts/common/nordic/nrf9280.dtsi
+++ b/dts/common/nordic/nrf9280.dtsi
@@ -92,6 +92,17 @@
 			#clock-cells = <0>;
 			clock-frequency = <DT_FREQ_M(16)>;
 		};
+
+		hsfll120: hsfll120 {
+			compatible = "nordic,nrf-hsfll-global";
+			clocks = <&fll16m>;
+			#clock-cells = <0>;
+			clock-frequency = <320000000>;
+			supported-clock-frequencies = <64000000
+						       128000000
+						       256000000
+						       320000000>;
+		};
 	};
 
 	soc {

--- a/dts/common/nordic/nrf9280.dtsi
+++ b/dts/common/nordic/nrf9280.dtsi
@@ -450,7 +450,8 @@
 				reg = <0x8d8000 0x400>, <0x2fbef800 0x800>, <0x2fbe8000 0x7800>;
 				reg-names = "wrapper", "m_can", "message_ram";
 				interrupts = <216 NRF_DEFAULT_IRQ_PRIORITY>;
-				clocks = <&canpll>;
+				clocks = <&canpll>, <&hsfll120>;
+				clock-names = "auxpll", "hsfll";
 				bosch,mram-cfg = <0x0 28 8 3 3 0 1 1>;
 				status = "disabled";
 			};
@@ -460,7 +461,8 @@
 				reg = <0x8db000 0x400>, <0x2fbf7800 0x800>, <0x2fbf0000 0x7800>;
 				reg-names = "wrapper", "m_can", "message_ram";
 				interrupts = <219 NRF_DEFAULT_IRQ_PRIORITY>;
-				clocks = <&canpll>;
+				clocks = <&canpll>, <&hsfll120>;
+				clock-names = "auxpll", "hsfll";
 				bosch,mram-cfg = <0x0 28 8 3 3 0 1 1>;
 				status = "disabled";
 			};


### PR DESCRIPTION
When CAN is used, HSFLL frequency must >= AUXPLL frequency. Make sure to
send a request to the HSFLL clock instance.

NOTE: not tested, also depends on https://github.com/zephyrproject-rtos/zephyr/pull/81735