### PR TITLE
drivers: RTC: update API to use DEVICE_API macros

### DIFF
--- a/drivers/rtc/rtc_am1805.c
+++ b/drivers/rtc/rtc_am1805.c
@@ -569,7 +569,7 @@ static int am1805_init(const struct device *dev)
 	return 0;
 }
 
-static const struct rtc_driver_api am1805_driver_api = {
+static DEVICE_API(rtc, am1805_driver_api) = {
 	.set_time = am1805_set_time,
 	.get_time = am1805_get_time,
 #ifdef CONFIG_RTC_ALARM

--- a/drivers/rtc/rtc_ambiq.c
+++ b/drivers/rtc/rtc_ambiq.c
@@ -354,7 +354,7 @@ static int ambiq_rtc_init(const struct device *dev)
 	return 0;
 }
 
-static const struct rtc_driver_api ambiq_rtc_driver_api = {
+static DEVICE_API(rtc, ambiq_rtc_driver_api) = {
 	.set_time = ambiq_rtc_set_time,
 	.get_time = ambiq_rtc_get_time,
 	/* RTC_UPDATE not supported */

--- a/drivers/rtc/rtc_ds1307.c
+++ b/drivers/rtc/rtc_ds1307.c
@@ -118,7 +118,7 @@ unlock:
 	return err;
 }
 
-static const struct rtc_driver_api ds1307_driver_api = {
+static DEVICE_API(rtc, ds1307_driver_api) = {
 	.set_time = ds1307_set_time,
 	.get_time = ds1307_get_time,
 };

--- a/drivers/rtc/rtc_emul.c
+++ b/drivers/rtc/rtc_emul.c
@@ -426,7 +426,7 @@ static int rtc_emul_get_calibration(const struct device *dev, int32_t *calibrati
 }
 #endif /* CONFIG_RTC_CALIBRATION */
 
-static const struct rtc_driver_api rtc_emul_driver_api = {
+static DEVICE_API(rtc, rtc_emul_driver_api) = {
 	.set_time = rtc_emul_set_time,
 	.get_time = rtc_emul_get_time,
 #ifdef CONFIG_RTC_ALARM

--- a/drivers/rtc/rtc_fake.c
+++ b/drivers/rtc/rtc_fake.c
@@ -70,7 +70,7 @@ static void fake_rtc_reset_rule_before(const struct ztest_unit_test *test, void 
 ZTEST_RULE(fake_rtc_reset_rule, fake_rtc_reset_rule_before, NULL);
 #endif /* CONFIG_ZTEST */
 
-static const struct rtc_driver_api rtc_fake_driver_api = {
+static DEVICE_API(rtc, rtc_fake_driver_api) = {
 	.set_time = rtc_fake_set_time,
 	.get_time = rtc_fake_get_time,
 #ifdef CONFIG_RTC_ALARM

--- a/drivers/rtc/rtc_ifx_cat1.c
+++ b/drivers/rtc/rtc_ifx_cat1.c
@@ -324,7 +324,7 @@ static int ifx_cat1_get_calibration(const struct device *dev, int32_t *calibrati
 }
 #endif /* CONFIG_RTC_CALIBRATION */
 
-static const struct rtc_driver_api ifx_cat1_rtc_driver_api = {
+static DEVICE_API(rtc, ifx_cat1_rtc_driver_api) = {
 	.set_time = ifx_cat1_rtc_set_time,
 	.get_time = ifx_cat1_rtc_get_time,
 #ifdef CONFIG_RTC_CALIBRATION

--- a/drivers/rtc/rtc_ll_stm32.c
+++ b/drivers/rtc/rtc_ll_stm32.c
@@ -1039,7 +1039,7 @@ static int rtc_stm32_get_calibration(const struct device *dev, int32_t *calibrat
 #endif
 #endif /* CONFIG_RTC_CALIBRATION */
 
-static const struct rtc_driver_api rtc_stm32_driver_api = {
+static DEVICE_API(rtc, rtc_stm32_driver_api) = {
 	.set_time = rtc_stm32_set_time,
 	.get_time = rtc_stm32_get_time,
 #ifdef CONFIG_RTC_ALARM

--- a/drivers/rtc/rtc_mc146818.c
+++ b/drivers/rtc/rtc_mc146818.c
@@ -495,7 +495,7 @@ static void rtc_mc146818_isr(const struct device *dev)
 #endif
 }
 
-static const struct rtc_driver_api rtc_mc146818_driver_api = {
+static DEVICE_API(rtc, rtc_mc146818_driver_api) = {
 	.set_time = rtc_mc146818_set_time,
 	.get_time = rtc_mc146818_get_time,
 #if defined(CONFIG_RTC_ALARM)

--- a/drivers/rtc/rtc_numaker.c
+++ b/drivers/rtc/rtc_numaker.c
@@ -363,7 +363,7 @@ static int rtc_numaker_alarm_set_callback(const struct device *dev, uint16_t id,
 }
 #endif /* CONFIG_RTC_ALARM */
 
-static const struct rtc_driver_api rtc_numaker_driver_api = {
+static DEVICE_API(rtc, rtc_numaker_driver_api) = {
 	.set_time = rtc_numaker_set_time,
 	.get_time = rtc_numaker_get_time,
 #ifdef CONFIG_RTC_ALARM

--- a/drivers/rtc/rtc_nxp_irtc.c
+++ b/drivers/rtc/rtc_nxp_irtc.c
@@ -356,7 +356,7 @@ static void nxp_irtc_isr(const struct device *dev)
 #endif /* CONFIG_RTC_ALARM */
 }
 
-static const struct rtc_driver_api rtc_nxp_irtc_driver_api = {
+static DEVICE_API(rtc, rtc_nxp_irtc_driver_api) = {
 	.set_time = nxp_irtc_set_time,
 	.get_time = nxp_irtc_get_time,
 #if defined(CONFIG_RTC_ALARM)

--- a/drivers/rtc/rtc_pcf8523.c
+++ b/drivers/rtc/rtc_pcf8523.c
@@ -927,7 +927,7 @@ static int pcf8523_pm_action(const struct device *dev, enum pm_device_action act
 }
 #endif /* CONFIG_PM_DEVICE */
 
-static const struct rtc_driver_api pcf8523_driver_api = {
+static DEVICE_API(rtc, pcf8523_driver_api) = {
 	.set_time = pcf8523_set_time,
 	.get_time = pcf8523_get_time,
 #ifdef CONFIG_RTC_ALARM

--- a/drivers/rtc/rtc_pcf8563.c
+++ b/drivers/rtc/rtc_pcf8563.c
@@ -449,7 +449,7 @@ static int pcf8563_alarm_set_callback(const struct device *dev, uint16_t id,
 #endif
 }
 
-static const struct rtc_driver_api pcf8563_driver_api = {
+static DEVICE_API(rtc, pcf8563_driver_api) = {
 	.set_time = pcf8563_set_time,
 	.get_time = pcf8563_get_time,
 #ifdef CONFIG_RTC_ALARM

--- a/drivers/rtc/rtc_rpi_pico.c
+++ b/drivers/rtc/rtc_rpi_pico.c
@@ -307,7 +307,7 @@ static int rtc_rpi_pico_alarm_set_callback(const struct device *dev, uint16_t id
 
 #endif /* CONFIG_RTC_ALARM */
 
-static const struct rtc_driver_api rtc_rpi_pico_driver_api = {
+static DEVICE_API(rtc, rtc_rpi_pico_driver_api) = {
 	.set_time = rtc_rpi_pico_set_time,
 	.get_time = rtc_rpi_pico_get_time,
 #if defined(CONFIG_RTC_ALARM)

--- a/drivers/rtc/rtc_rv3028.c
+++ b/drivers/rtc/rtc_rv3028.c
@@ -886,7 +886,7 @@ static int rv3028_init(const struct device *dev)
 	return 0;
 }
 
-static const struct rtc_driver_api rv3028_driver_api = {
+static DEVICE_API(rtc, rv3028_driver_api) = {
 	.set_time = rv3028_set_time,
 	.get_time = rv3028_get_time,
 #ifdef CONFIG_RTC_ALARM

--- a/drivers/rtc/rtc_rv8263.c
+++ b/drivers/rtc/rtc_rv8263.c
@@ -680,7 +680,7 @@ int rv8263c8_calibration_get(const struct device *dev, int32_t *calibration)
 }
 #endif
 
-static const struct rtc_driver_api rv8263c8_driver_api = {
+static DEVICE_API(rtc, rv8263c8_driver_api) = {
 	.set_time = rv8263c8_time_set,
 	.get_time = rv8263c8_time_get,
 #if CONFIG_RTC_ALARM

--- a/drivers/rtc/rtc_sam.c
+++ b/drivers/rtc/rtc_sam.c
@@ -616,7 +616,7 @@ static int rtc_sam_get_calibration(const struct device *dev, int32_t *calibratio
 }
 #endif /* CONFIG_RTC_CALIBRATION */
 
-static const struct rtc_driver_api rtc_sam_driver_api = {
+static DEVICE_API(rtc, rtc_sam_driver_api) = {
 	.set_time = rtc_sam_set_time,
 	.get_time = rtc_sam_get_time,
 #ifdef CONFIG_RTC_ALARM

--- a/drivers/rtc/rtc_smartbond.c
+++ b/drivers/rtc/rtc_smartbond.c
@@ -583,7 +583,7 @@ static int rtc_smartbond_update_set_callback(const struct device *dev, rtc_updat
 }
 #endif
 
-static const struct rtc_driver_api rtc_smartbond_driver_api = {
+static DEVICE_API(rtc, rtc_smartbond_driver_api) = {
 	.get_time = rtc_smartbond_get_time,
 	.set_time = rtc_smartbond_set_time,
 #if defined(CONFIG_RTC_ALARM)

--- a/drivers/rtc/rtc_xmc4xxx.c
+++ b/drivers/rtc/rtc_xmc4xxx.c
@@ -221,7 +221,7 @@ static int rtc_xmc4xxx_update_set_callback(const struct device *dev, rtc_update_
 }
 #endif /* CONFIG_RTC_UPDATE */
 
-static const struct rtc_driver_api rtc_xmc4xxx_driver_api = {
+static DEVICE_API(rtc, rtc_xmc4xxx_driver_api) = {
 	.set_time = rtc_xmc4xxx_set_time,
 	.get_time = rtc_xmc4xxx_get_time,
 #ifdef CONFIG_RTC_ALARM

--- a/include/zephyr/drivers/rtc.h
+++ b/include/zephyr/drivers/rtc.h
@@ -199,9 +199,7 @@ __syscall int rtc_set_time(const struct device *dev, const struct rtc_time *time
 
 static inline int z_impl_rtc_set_time(const struct device *dev, const struct rtc_time *timeptr)
 {
-	const struct rtc_driver_api *api = (const struct rtc_driver_api *)dev->api;
-
-	return api->set_time(dev, timeptr);
+	return DEVICE_API_GET(rtc, dev)->set_time(dev, timeptr);
 }
 
 /**
@@ -218,9 +216,7 @@ __syscall int rtc_get_time(const struct device *dev, struct rtc_time *timeptr);
 
 static inline int z_impl_rtc_get_time(const struct device *dev, struct rtc_time *timeptr)
 {
-	const struct rtc_driver_api *api = (const struct rtc_driver_api *)dev->api;
-
-	return api->get_time(dev, timeptr);
+	return DEVICE_API_GET(rtc, dev)->get_time(dev, timeptr);
 }
 
 /**
@@ -249,13 +245,11 @@ __syscall int rtc_alarm_get_supported_fields(const struct device *dev, uint16_t 
 static inline int z_impl_rtc_alarm_get_supported_fields(const struct device *dev, uint16_t id,
 							uint16_t *mask)
 {
-	const struct rtc_driver_api *api = (const struct rtc_driver_api *)dev->api;
-
-	if (api->alarm_get_supported_fields == NULL) {
+	if (DEVICE_API_GET(rtc, dev)->alarm_get_supported_fields == NULL) {
 		return -ENOSYS;
 	}
 
-	return api->alarm_get_supported_fields(dev, id, mask);
+	return DEVICE_API_GET(rtc, dev)->alarm_get_supported_fields(dev, id, mask);
 }
 
 /**
@@ -287,13 +281,11 @@ __syscall int rtc_alarm_set_time(const struct device *dev, uint16_t id, uint16_t
 static inline int z_impl_rtc_alarm_set_time(const struct device *dev, uint16_t id, uint16_t mask,
 					    const struct rtc_time *timeptr)
 {
-	const struct rtc_driver_api *api = (const struct rtc_driver_api *)dev->api;
-
-	if (api->alarm_set_time == NULL) {
+	if (DEVICE_API_GET(rtc, dev)->alarm_set_time == NULL) {
 		return -ENOSYS;
 	}
 
-	return api->alarm_set_time(dev, id, mask, timeptr);
+	return DEVICE_API_GET(rtc, dev)->alarm_set_time(dev, id, mask, timeptr);
 }
 
 /**
@@ -317,13 +309,11 @@ __syscall int rtc_alarm_get_time(const struct device *dev, uint16_t id, uint16_t
 static inline int z_impl_rtc_alarm_get_time(const struct device *dev, uint16_t id, uint16_t *mask,
 					    struct rtc_time *timeptr)
 {
-	const struct rtc_driver_api *api = (const struct rtc_driver_api *)dev->api;
-
-	if (api->alarm_get_time == NULL) {
+	if (DEVICE_API_GET(rtc, dev)->alarm_get_time == NULL) {
 		return -ENOSYS;
 	}
 
-	return api->alarm_get_time(dev, id, mask, timeptr);
+	return DEVICE_API_GET(rtc, dev)->alarm_get_time(dev, id, mask, timeptr);
 }
 
 /**
@@ -345,13 +335,11 @@ __syscall int rtc_alarm_is_pending(const struct device *dev, uint16_t id);
 
 static inline int z_impl_rtc_alarm_is_pending(const struct device *dev, uint16_t id)
 {
-	const struct rtc_driver_api *api = (const struct rtc_driver_api *)dev->api;
-
-	if (api->alarm_is_pending == NULL) {
+	if (DEVICE_API_GET(rtc, dev)->alarm_is_pending == NULL) {
 		return -ENOSYS;
 	}
 
-	return api->alarm_is_pending(dev, id);
+	return DEVICE_API_GET(rtc, dev)->alarm_is_pending(dev, id);
 }
 
 /**
@@ -386,13 +374,11 @@ __syscall int rtc_alarm_set_callback(const struct device *dev, uint16_t id,
 static inline int z_impl_rtc_alarm_set_callback(const struct device *dev, uint16_t id,
 						rtc_alarm_callback callback, void *user_data)
 {
-	const struct rtc_driver_api *api = (const struct rtc_driver_api *)dev->api;
-
-	if (api->alarm_set_callback == NULL) {
+	if (DEVICE_API_GET(rtc, dev)->alarm_set_callback == NULL) {
 		return -ENOSYS;
 	}
 
-	return api->alarm_set_callback(dev, id, callback, user_data);
+	return DEVICE_API_GET(rtc, dev)->alarm_set_callback(dev, id, callback, user_data);
 }
 
 #endif /* CONFIG_RTC_ALARM */
@@ -431,13 +417,11 @@ __syscall int rtc_update_set_callback(const struct device *dev, rtc_update_callb
 static inline int z_impl_rtc_update_set_callback(const struct device *dev,
 						 rtc_update_callback callback, void *user_data)
 {
-	const struct rtc_driver_api *api = (const struct rtc_driver_api *)dev->api;
-
-	if (api->update_set_callback == NULL) {
+	if (DEVICE_API_GET(rtc, dev)->update_set_callback == NULL) {
 		return -ENOSYS;
 	}
 
-	return api->update_set_callback(dev, callback, user_data);
+	return DEVICE_API_GET(rtc, dev)->update_set_callback(dev, callback, user_data);
 }
 
 #endif /* CONFIG_RTC_UPDATE */
@@ -473,13 +457,11 @@ __syscall int rtc_set_calibration(const struct device *dev, int32_t calibration)
 
 static inline int z_impl_rtc_set_calibration(const struct device *dev, int32_t calibration)
 {
-	const struct rtc_driver_api *api = (const struct rtc_driver_api *)dev->api;
-
-	if (api->set_calibration == NULL) {
+	if (DEVICE_API_GET(rtc, dev)->set_calibration == NULL) {
 		return -ENOSYS;
 	}
 
-	return api->set_calibration(dev, calibration);
+	return DEVICE_API_GET(rtc, dev)->set_calibration(dev, calibration);
 }
 
 /**
@@ -496,13 +478,11 @@ __syscall int rtc_get_calibration(const struct device *dev, int32_t *calibration
 
 static inline int z_impl_rtc_get_calibration(const struct device *dev, int32_t *calibration)
 {
-	const struct rtc_driver_api *api = (const struct rtc_driver_api *)dev->api;
-
-	if (api->get_calibration == NULL) {
+	if (DEVICE_API_GET(rtc, dev)->get_calibration == NULL) {
 		return -ENOSYS;
 	}
 
-	return api->get_calibration(dev, calibration);
+	return DEVICE_API_GET(rtc, dev)->get_calibration(dev, calibration);
 }
 
 #endif /* CONFIG_RTC_CALIBRATION */


### PR DESCRIPTION
Update RTC API and device drivers to use DEVICE_API macros.