### PR TITLE
cmake: linker_script: add vector_sw_relay

### DIFF
--- a/cmake/linker_script/arm/linker.cmake
+++ b/cmake/linker_script/arm/linker.cmake
@@ -161,6 +161,23 @@ if(CONFIG_CPU_CORTEX_M_HAS_VTOR)
   endif()
 endif()
 
+if(CONFIG_SW_VECTOR_RELAY)
+  if (CONFIG_CPU_CORTEX_M_HAS_VTOR)
+    set(VECTOR_RELAY_PRIO 100)
+  else()
+    set(VECTOR_RELAY_PRIO 0)
+  endif()
+
+  zephyr_linker_section_configure(
+    SECTION .rom_start
+    INPUT ".vector_relay_table*"
+    KEEP FIRST
+    ALIGN ${VECTOR_ALIGN}
+    PRIO ${VECTOR_RELAY_PRIO}
+  )
+
+endif()
+
 zephyr_linker_section_configure(
   SECTION .rom_start
   INPUT ".exc_vector_table*"


### PR DESCRIPTION
Currently the arch/arm/vector_sw_relay test fails due to alignment issues with CONFIG_CMAKE_LINKER_GENERATOR enabled on ek_ra4e2

This attempt passes the test, however I am not 100% convinced the rest of
the functionality is correct. Especially .rom_start ordering

Please review critically :) 