### PR TITLE
boards: cc1352p7_lp: Adds a way to select the board to flash

### DIFF
--- a/boards/ti/cc1352p7_launchpad/support/openocd.cfg
+++ b/boards/ti/cc1352p7_launchpad/support/openocd.cfg
@@ -1,1 +1,7 @@
+# Serial could be found using the following command:
+# lsusb -d 0451:bef3 -v | grep -i iserial
+if { [info exists _ZEPHYR_BOARD_SERIAL] } {
+    adapter serial $_ZEPHYR_BOARD_SERIAL
+}
+
 source [find board/ti_cc26x2x7_launchpad.cfg]


### PR DESCRIPTION
This updates openocd.cfg file to support flashing multiple boards attached to the host computer.