### PR TITLE
tests: arm: remove GNUC ifdef

### DIFF
--- a/tests/arch/arm/arm_thread_swap/src/arm_syscalls.c
+++ b/tests/arch/arm/arm_thread_swap/src/arm_syscalls.c
@@ -12,10 +12,6 @@
 #include <offsets_short_arch.h>
 #include <ksched.h>
 
-#if !defined(__GNUC__)
-#error __FILE__ goes only with Cortex-M GCC
-#endif
-
 #if !defined(CONFIG_ARMV6_M_ARMV8_M_BASELINE) && \
 	!defined(CONFIG_ARMV7_M_ARMV8_M_MAINLINE)
 #error "Unsupported architecture"

--- a/tests/arch/arm/arm_thread_swap/src/arm_thread_arch.c
+++ b/tests/arch/arm/arm_thread_swap/src/arm_thread_arch.c
@@ -12,10 +12,6 @@
 #include <offsets_short_arch.h>
 #include <ksched.h>
 
-#if !defined(__GNUC__)
-#error __FILE__ goes only with Cortex-M GCC
-#endif
-
 #if !defined(CONFIG_ARMV6_M_ARMV8_M_BASELINE) && \
 	!defined(CONFIG_ARMV7_M_ARMV8_M_MAINLINE)
 #error "Unsupported architecture"


### PR DESCRIPTION
Porting zephyr to IAR I stumbled onto this test.
I think these ifdefs are guarding the inline assembly in this test.
But it is better to get compile error rather than #error. (We can handle this inline assembly almost just fine)
Does this actually happen to any other toolchain?
Maybe this test should filter on CONFIG_TOOLCHAIN_HAS_GNU_EXTENSIONS or similar instead? 
