### PR TITLE
Revert "modules: nanopb: Move pip dependencies to optional module"

### DIFF
--- a/doc/services/serialization/nanopb.rst
+++ b/doc/services/serialization/nanopb.rst
@@ -45,7 +45,6 @@ Additionally, Nanopb is an optional module and needs to be added explicitly to t
 
    west config manifest.project-filter -- +nanopb
    west update
-   west packages pip --install
 
 Configuration
 *************

--- a/scripts/requirements-extras.txt
+++ b/scripts/requirements-extras.txt
@@ -21,6 +21,10 @@ Pillow>=10.0
 # can be used to sign a Zephyr application binary for consumption by a bootloader
 imgtool>=2.1.0
 
+# used by nanopb module to generate sources from .proto files
+grpcio-tools>=1.47.0
+protobuf>=3.20.3
+
 # used by scripts/release/bug_bash.py for generating top ten bug squashers
 PyGithub
 

--- a/submanifests/optional.yaml
+++ b/submanifests/optional.yaml
@@ -23,7 +23,7 @@ manifest:
       groups:
         - optional
     - name: nanopb
-      revision: 0a3b5050a28faeca3cfa2f566e043807431c8d7f
+      revision: 98bf4db69897b53434f3d0ba72e0a3ab1a902824
       path: modules/lib/nanopb
       remote: upstream
       groups:


### PR DESCRIPTION
This reverts commit 26614832f20292e482daaf36bd100d68f45ea231.

A bug in upstream nanopb, which this commit was pulling as part of the submanifest update, seems to be causing test failures on big-endian platforms.

Upstream bug: https://github.com/nanopb/nanopb/issues/1039