### PR TITLE
arch: riscv: make arch_current_thread_set() safer

### DIFF
--- a/include/zephyr/arch/riscv/arch_inlines.h
+++ b/include/zephyr/arch/riscv/arch_inlines.h
@@ -32,10 +32,9 @@ register struct k_thread *__arch_current_thread __asm__("gp");
 
 #define arch_current_thread() __arch_current_thread
 #define arch_current_thread_set(thread)                                                            \
-	{                                                                                          \
-		_current_cpu->current = thread;                                                    \
-		__arch_current_thread = (thread);                                                  \
-	}
+	do {                                                                                       \
+		_current_cpu->current = __arch_current_thread = (thread);                          \
+	} while (0)
 #endif /* CONFIG_RISCV_CURRENT_VIA_GP */
 
 static ALWAYS_INLINE unsigned int arch_num_cpus(void)


### PR DESCRIPTION
Use the `do { } while (0)` construct so the macro behaves like an actual
C statement in all cases. Also evaluate the macro argument only once.
