### PR TITLE
twister: config: increase min_ram to 16k

### DIFF
--- a/samples/sensor/jc42/sample.yaml
+++ b/samples/sensor/jc42/sample.yaml
@@ -4,6 +4,7 @@ tests:
   sample.sensor.jc42:
     harness: sensor
     tags: sensors
+    min_ram: 8
     depends_on: i2c
     filter: dt_compat_enabled("jedec,jc-42.4-temp")
     platform_allow: nucleo_l053r8

--- a/scripts/pylib/twister/twisterlib/config_parser.py
+++ b/scripts/pylib/twister/twisterlib/config_parser.py
@@ -56,7 +56,7 @@ class TwisterConfigParser:
                        "skip": {"type": "bool", "default": False},
                        "slow": {"type": "bool", "default": False},
                        "timeout": {"type": "int", "default": 60},
-                       "min_ram": {"type": "int", "default": 8},
+                       "min_ram": {"type": "int", "default": 16},
                        "modules": {"type": "list", "default": []},
                        "depends_on": {"type": "set"},
                        "min_flash": {"type": "int", "default": 32},


### PR DESCRIPTION
Increase default to 16k, this can be overidden in the test configuration
where needed.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
