### PR TITLE
modules: nanopb: Move pip dependencies to optional module

### DIFF
--- a/doc/services/serialization/nanopb.rst
+++ b/doc/services/serialization/nanopb.rst
@@ -45,6 +45,7 @@ Additionally, Nanopb is an optional module and needs to be added explicitly to t
 
    west config manifest.project-filter -- +nanopb
    west update
+   west packages pip --install
 
 Configuration
 *************

--- a/scripts/requirements-extras.txt
+++ b/scripts/requirements-extras.txt
@@ -21,10 +21,6 @@ Pillow>=10.0
 # can be used to sign a Zephyr application binary for consumption by a bootloader
 imgtool>=2.1.0
 
-# used by nanopb module to generate sources from .proto files
-grpcio-tools>=1.47.0
-protobuf>=3.20.3
-
 # used by scripts/release/bug_bash.py for generating top ten bug squashers
 PyGithub
 

--- a/submanifests/optional.yaml
+++ b/submanifests/optional.yaml
@@ -23,7 +23,7 @@ manifest:
       groups:
         - optional
     - name: nanopb
-      revision: 98bf4db69897b53434f3d0ba72e0a3ab1a902824
+      revision: 7307ce399b81ddcb3c3a5dc862c52d4754328d38
       path: modules/lib/nanopb
       remote: upstream
       groups:

--- a/tests/modules/nanopb/testcase.yaml
+++ b/tests/modules/nanopb/testcase.yaml
@@ -7,3 +7,4 @@ tests:
     integration_platforms:
       - native_sim
       - native_sim/native/64
+      - qemu_malta/qemu_malta/be # Test on Big Endian platform


### PR DESCRIPTION
Try #81878 again after being reverted by #82351

Upstream has reverted the breaking change on Big endian platforms.

Add a big endian test platform for validating serialization.