### PR TITLE
twister: do not create overlays/run_id for filtered cases

### DIFF
--- a/scripts/pylib/twister/twisterlib/testinstance.py
+++ b/scripts/pylib/twister/twisterlib/testinstance.py
@@ -79,7 +79,7 @@ class TestInstance:
                 source_dir_rel,
                 testsuite.name
             )
-        self.run_id = self._get_run_id()
+        self.run_id = None
         self.domains = None
         # Instance need to use sysbuild if a given suite or a platform requires it
         self.sysbuild = testsuite.sysbuild or platform.sysbuild
@@ -89,6 +89,9 @@ class TestInstance:
         self.init_cases()
         self.filters = []
         self.filter_type = None
+
+    def setup_run_id(self):
+        self.run_id = self._get_run_id()
 
     def record(self, recording, fname_csv="recording.csv"):
         if recording:

--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -1206,6 +1206,11 @@ class TestPlan:
                 self.add_instances(instance_list)
 
         for _, case in self.instances.items():
+            # Do not create files for filtered instances
+            if case.status == TwisterStatus.FILTER:
+                continue
+            # set run_id for each unfiltered instance
+            case.setup_run_id()
             case.create_overlay(case.platform,
                                 self.options.enable_asan,
                                 self.options.enable_ubsan,

--- a/scripts/tests/twister_blackbox/test_report.py
+++ b/scripts/tests/twister_blackbox/test_report.py
@@ -174,7 +174,7 @@ class TestReport:
                 pytest.fail(f"Unsupported file type: '{path}'")
 
         for f_platform in test_platforms:
-            platform_path = os.path.join(out_path, f_platform.replace("/", "_"))
+            platform_path = os.path.join(out_path, f_platform.replace("/", "_") + ".json", )
             assert os.path.exists(platform_path), f'file not found {f_platform}'
 
         assert str(sys_exit.value) == '0'


### PR DESCRIPTION
Avoid creating directories and files for instances that are filtered.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
