### PR TITLE
Bluetooth: Host: Enable ENTROPY_GENERATOR for BT_HOST_CRYPTO_PRNG

### DIFF
--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -181,9 +181,6 @@ config BT_HOST_CRYPTO
 config BT_HOST_CRYPTO_PRNG
 	bool "Use PSA crypto API library for random number generation"
 	default y
-	select PSA_WANT_ALG_SHA_256
-	select PSA_WANT_KEY_TYPE_HMAC
-	select PSA_WANT_ALG_HMAC
 	depends on BT_HOST_CRYPTO
 	help
 	  When selected, will use PSA Crypto API library for random number generation.

--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -168,6 +168,8 @@ rsource "../audio/Kconfig"
 config BT_HOST_CRYPTO
 	bool "Use crypto functionality implemented in the Bluetooth host"
 	default y if !BT_CTLR_CRYPTO
+	# An implementation of z_impl_sys_rand_get() is required
+	select ENTROPY_GENERATOR
 	select MBEDTLS if !BUILD_WITH_TFM
 	select MBEDTLS_PSA_CRYPTO_C if !BUILD_WITH_TFM
 	select PSA_WANT_KEY_TYPE_AES


### PR DESCRIPTION
With the recent change to PSA crypto, it's important to enable the top-level entropy driver Kconfig option, so that the underlying entropy driver can be enabled when necessary. The one exception to this is if a test (i.e. insecure) random number generator is enabled, since those will also provide the underlying z_impl_sys_rand_get() implementation, which is what's ultimately required by PSA.

Fixes #82344