### PR TITLE
drivers: can: remove deprecated CAN API functions and macros

### DIFF
--- a/doc/releases/release-notes-4.1.rst
+++ b/doc/releases/release-notes-4.1.rst
@@ -29,6 +29,12 @@ Removed APIs in this release
 
  * The deprecated Bluetooth HCI driver API has been removed. It has been replaced by a
    :c:group:`new API<bt_hci_api>` that follows the normal Zephyr driver model.
+ * The deprecated ``CAN_MAX_STD_ID`` (replaced by :c:macro:`CAN_STD_ID_MASK`) and ``CAN_MAX_EXT_ID``
+   (replaced by :c:macro:`CAN_EXT_ID_MASK`) CAN API macros have been removed.
+ * The deprecated ``can_get_min_bitrate()`` (replaced by :c:func:`can_get_bitrate_min`) and
+   ``can_get_max_bitrate()`` (replaced by :c:func:`can_get_bitrate_max`) CAN API functions have been
+   removed.
+ * The deprecated ``can_calc_prescaler()`` CAN API function has been removed.
 
 Deprecated in this release
 ==========================

--- a/drivers/can/can_common.c
+++ b/drivers/can/can_common.c
@@ -343,24 +343,6 @@ int z_impl_can_calc_timing_data(const struct device *dev, struct can_timing *res
 }
 #endif /* CONFIG_CAN_FD_MODE */
 
-int can_calc_prescaler(const struct device *dev, struct can_timing *timing,
-		       uint32_t bitrate)
-{
-	uint32_t ts = timing->prop_seg + timing->phase_seg1 + timing->phase_seg2 +
-		   CAN_SYNC_SEG;
-	uint32_t core_clock;
-	int ret;
-
-	ret = can_get_core_clock(dev, &core_clock);
-	if (ret != 0) {
-		return ret;
-	}
-
-	timing->prescaler = core_clock / (bitrate * ts);
-
-	return core_clock % (ts * timing->prescaler);
-}
-
 static int check_timing_in_range(const struct can_timing *timing,
 				 const struct can_timing *min,
 				 const struct can_timing *max)

--- a/include/zephyr/drivers/can.h
+++ b/include/zephyr/drivers/can.h
@@ -1054,29 +1054,6 @@ __syscall int can_set_timing_data(const struct device *dev,
 __syscall int can_set_bitrate_data(const struct device *dev, uint32_t bitrate_data);
 
 /**
- * @brief Fill in the prescaler value for a given bitrate and timing
- *
- * Fill the prescaler value in the timing struct. The sjw, prop_seg, phase_seg1
- * and phase_seg2 must be given.
- *
- * The returned bitrate error is remainder of the division of the clock rate by
- * the bitrate times the timing segments.
- *
- * @deprecated This function allows for bitrate errors, but bitrate errors between nodes on the same
- *             network leads to them drifting apart after the start-of-frame (SOF) synchronization
- *             has taken place.
- *
- * @param dev     Pointer to the device structure for the driver instance.
- * @param timing  Result is written into the can_timing struct provided.
- * @param bitrate Target bitrate.
- *
- * @retval 0 or positive bitrate error.
- * @retval Negative error code on error.
- */
-__deprecated int can_calc_prescaler(const struct device *dev, struct can_timing *timing,
-				    uint32_t bitrate);
-
-/**
  * @brief Configure the bus timing of a CAN controller.
  *
  * @see can_set_timing_data()

--- a/include/zephyr/drivers/can.h
+++ b/include/zephyr/drivers/can.h
@@ -847,35 +847,6 @@ static inline uint32_t z_impl_can_get_bitrate_min(const struct device *dev)
 }
 
 /**
- * @brief Get minimum supported bitrate
- *
- * Get the minimum supported bitrate for the CAN controller/transceiver combination.
- *
- * @deprecated Use @a can_get_bitrate_min() instead.
- *
- * @note The minimum bitrate represents limitations of the CAN controller/transceiver
- * combination. Whether the CAN controller can achieve this bitrate depends on the CAN core clock
- * rate and the minimum CAN timing limits.
- *
- * @see can_get_core_clock()
- * @see can_get_timing_min()
- * @see can_get_timing_data_min()
- *
- * @param dev Pointer to the device structure for the driver instance.
- * @param[out] min_bitrate Minimum supported bitrate in bits/s. A value of 0 means the lower limit
- *                         is unspecified.
- *
- * @retval -EIO General input/output error.
- * @retval -ENOSYS If this function is not implemented by the driver.
- */
-__deprecated static inline int can_get_min_bitrate(const struct device *dev, uint32_t *min_bitrate)
-{
-	*min_bitrate = can_get_bitrate_min(dev);
-
-	return 0;
-}
-
-/**
  * @brief Get maximum supported bitrate
  *
  * Get the maximum supported bitrate for the CAN controller/transceiver combination.
@@ -898,35 +869,6 @@ static inline uint32_t z_impl_can_get_bitrate_max(const struct device *dev)
 	const struct can_driver_config *common = (const struct can_driver_config *)dev->config;
 
 	return common->max_bitrate;
-}
-
-/**
- * @brief Get maximum supported bitrate
- *
- * Get the maximum supported bitrate for the CAN controller/transceiver combination.
- *
- * @deprecated Use @a can_get_bitrate_max() instead.
- *
- * @note The maximum bitrate represents limitations of the CAN controller/transceiver
- * combination. Whether the CAN controller can achieve this bitrate depends on the CAN core clock
- * rate and the maximum CAN timing limits.
- *
- * @see can_get_core_clock()
- * @see can_get_timing_max()
- * @see can_get_timing_data_max()
- *
- * @param dev Pointer to the device structure for the driver instance.
- * @param[out] max_bitrate Maximum supported bitrate in bits/s
- *
- * @retval 0 If successful.
- * @retval -EIO General input/output error.
- * @retval -ENOSYS If this function is not implemented by the driver.
- */
-__deprecated static inline int can_get_max_bitrate(const struct device *dev, uint32_t *max_bitrate)
-{
-	*max_bitrate = can_get_bitrate_max(dev);
-
-	return 0;
 }
 
 /**

--- a/include/zephyr/drivers/can.h
+++ b/include/zephyr/drivers/can.h
@@ -45,26 +45,17 @@ extern "C" {
  * @brief Bit mask for a standard (11-bit) CAN identifier.
  */
 #define CAN_STD_ID_MASK 0x7FFU
-/**
- * @brief Maximum value for a standard (11-bit) CAN identifier.
- *
- * @deprecated Use ``CAN_STD_ID_MASK`` instead.
- */
-#define CAN_MAX_STD_ID  CAN_STD_ID_MASK __DEPRECATED_MACRO
+
 /**
  * @brief Bit mask for an extended (29-bit) CAN identifier.
  */
 #define CAN_EXT_ID_MASK 0x1FFFFFFFU
-/**
- * @brief Maximum value for an extended (29-bit) CAN identifier.
- *
- * @deprecated Use ``CAN_EXT_ID_MASK`` instead.
- */
-#define CAN_MAX_EXT_ID  CAN_EXT_ID_MASK __DEPRECATED_MACRO
+
 /**
  * @brief Maximum data length code for CAN 2.0A/2.0B.
  */
 #define CAN_MAX_DLC     8U
+
 /**
  * @brief Maximum data length code for CAN FD.
  */


### PR DESCRIPTION
Remove deprecated CAN API functions and macros slated for removal in Zephyr v4.1.0:
- ``CAN_MAX_STD_ID``
- ``CAN_MAX_EXT_ID``
- ``can_get_min_bitrate()``
- ``can_get_max_bitrate()``
- ``can_calc_prescaler()``