### PR TITLE
 Bluetooth: Controller: Fix reschedule for ticker that yield

### DIFF
--- a/tests/bsim/bluetooth/audio/src/cap_acceptor_test.c
+++ b/tests/bsim/bluetooth/audio/src/cap_acceptor_test.c
@@ -23,6 +23,7 @@
 #include <zephyr/bluetooth/audio/micp.h>
 #include <zephyr/bluetooth/audio/vcp.h>
 #include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/byteorder.h>
 #include <zephyr/bluetooth/gap.h>
 #include <zephyr/bluetooth/iso.h>
 #include <zephyr/bluetooth/uuid.h>
@@ -412,7 +413,22 @@ static struct bt_bap_scan_delegator_cb scan_delegator_cbs = {
 /* TODO: Expand with CAP service data */
 static const struct bt_data cap_acceptor_ad[] = {
 	BT_DATA_BYTES(BT_DATA_FLAGS, (BT_LE_AD_GENERAL | BT_LE_AD_NO_BREDR)),
-	BT_DATA_BYTES(BT_DATA_UUID16_ALL, BT_UUID_16_ENCODE(BT_UUID_CAS_VAL)),
+	BT_DATA(BT_DATA_NAME_COMPLETE, CONFIG_BT_DEVICE_NAME, sizeof(CONFIG_BT_DEVICE_NAME) - 1),
+	BT_DATA_BYTES(BT_DATA_UUID16_SOME, BT_UUID_16_ENCODE(BT_UUID_ASCS_VAL),
+		      BT_UUID_16_ENCODE(BT_UUID_CAS_VAL)),
+	BT_DATA_BYTES(BT_DATA_SVC_DATA16, BT_UUID_16_ENCODE(BT_UUID_CAS_VAL),
+		      BT_AUDIO_UNICAST_ANNOUNCEMENT_TARGETED),
+	IF_ENABLED(CONFIG_BT_BAP_UNICAST_SERVER,
+		   (BT_DATA_BYTES(BT_DATA_SVC_DATA16,
+				  BT_UUID_16_ENCODE(BT_UUID_ASCS_VAL),
+				  BT_AUDIO_UNICAST_ANNOUNCEMENT_TARGETED,
+				  BT_BYTES_LIST_LE16(SINK_CONTEXT),
+				  BT_BYTES_LIST_LE16(SOURCE_CONTEXT),
+				  0x00, /* Metadata length */),
+	))
+	IF_ENABLED(CONFIG_BT_BAP_SCAN_DELEGATOR,
+		   (BT_DATA_BYTES(BT_DATA_SVC_DATA16, BT_UUID_16_ENCODE(BT_UUID_BASS_VAL)),
+	))
 };
 
 static struct bt_csip_set_member_svc_inst *csip_set_member;
@@ -733,12 +749,6 @@ static void init(void)
 			bt_cap_stream_ops_register(&unicast_streams[i], &unicast_stream_ops);
 		}
 
-		err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_1, cap_acceptor_ad,
-				      ARRAY_SIZE(cap_acceptor_ad), NULL, 0);
-		if (err != 0) {
-			FAIL("Advertising failed to start (err %d)\n", err);
-			return;
-		}
 		test_start_adv();
 	}
 

--- a/tests/bsim/bluetooth/audio/src/cap_commander_test.c
+++ b/tests/bsim/bluetooth/audio/src/cap_commander_test.c
@@ -507,8 +507,75 @@ static struct bt_bap_broadcast_assistant_cb ba_cbs = {
 	.add_src = bap_broadcast_assistant_add_src_cb,
 };
 
+static bool check_audio_support_and_connect_cb(struct bt_data *data, void *user_data)
+{
+	char addr_str[BT_ADDR_LE_STR_LEN];
+	bt_addr_le_t *addr = user_data;
+	const struct bt_uuid *uuid;
+	uint16_t uuid_val;
+	int err;
+
+	printk("data->type %u\n", data->type);
+
+	if (data->type != BT_DATA_SVC_DATA16) {
+		return true; /* Continue parsing to next AD data type */
+	}
+
+	if (data->data_len < sizeof(uuid_val)) {
+		return true; /* Continue parsing to next AD data type */
+	}
+
+	/* We are looking for the CAS service data */
+	uuid_val = sys_get_le16(data->data);
+	uuid = BT_UUID_DECLARE_16(uuid_val);
+	if (bt_uuid_cmp(uuid, BT_UUID_CAS) != 0) {
+		return true; /* Continue parsing to next AD data type */
+	}
+
+	bt_addr_le_to_str(addr, addr_str, sizeof(addr_str));
+	printk("Device found: %s\n", addr_str);
+
+	printk("Stopping scan\n");
+	if (bt_le_scan_stop()) {
+		FAIL("Could not stop scan");
+		return false;
+	}
+
+	err = bt_conn_le_create(addr, BT_CONN_LE_CREATE_CONN,
+				BT_LE_CONN_PARAM(BT_GAP_INIT_CONN_INT_MIN, BT_GAP_INIT_CONN_INT_MIN,
+						 0, BT_GAP_MS_TO_CONN_TIMEOUT(4000)),
+				&connected_conns[connected_conn_cnt]);
+	if (err != 0) {
+		FAIL("Could not connect to peer: %d", err);
+	}
+
+	return false; /* Stop parsing */
+}
+
+static void scan_recv_cb(const struct bt_le_scan_recv_info *info, struct net_buf_simple *buf)
+{
+	struct bt_conn *conn;
+
+	conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, info->addr);
+	if (conn != NULL) {
+		/* Already connected to this device */
+		bt_conn_unref(conn);
+		return;
+	}
+
+	/* Check for connectable, extended advertising */
+	if (((info->adv_props & BT_GAP_ADV_PROP_EXT_ADV) != 0) &&
+	    ((info->adv_props & BT_GAP_ADV_PROP_CONNECTABLE)) != 0) {
+		/* Check for TMAS support in advertising data */
+		bt_data_parse(buf, check_audio_support_and_connect_cb, (void *)info->addr);
+	}
+}
+
 static void init(size_t acceptor_cnt)
 {
+	static struct bt_le_scan_cb scan_callbacks = {
+		.recv = scan_recv_cb,
+	};
 	static struct bt_conn_cb conn_cb = {
 		.disconnected = cap_disconnected_cb,
 	};
@@ -521,6 +588,12 @@ static void init(size_t acceptor_cnt)
 	}
 
 	bt_gatt_cb_register(&gatt_callbacks);
+	err = bt_le_scan_cb_register(&scan_callbacks);
+	if (err != 0) {
+		FAIL("Failed to register scan callbacks (err %d)\n", err);
+		return;
+	}
+
 	bt_conn_cb_register(&conn_cb);
 
 	err = bt_cap_commander_register_cb(&cap_cb);
@@ -573,56 +646,13 @@ static void init(size_t acceptor_cnt)
 	UNSET_FLAG(flag_syncable);
 }
 
-static void cap_device_found(const bt_addr_le_t *addr, int8_t rssi, uint8_t type,
-			     struct net_buf_simple *ad)
-{
-	char addr_str[BT_ADDR_LE_STR_LEN];
-	struct bt_conn *conn;
-	int err;
-
-	/* We're only interested in connectable events */
-	if (type != BT_HCI_ADV_IND && type != BT_HCI_ADV_DIRECT_IND) {
-		return;
-	}
-
-	conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, addr);
-	if (conn != NULL) {
-		/* Already connected to this device */
-		bt_conn_unref(conn);
-		return;
-	}
-
-	bt_addr_le_to_str(addr, addr_str, sizeof(addr_str));
-	printk("Device found: %s (RSSI %d)\n", addr_str, rssi);
-
-	/* connect only to devices in close proximity */
-	if (rssi < -70) {
-		FAIL("RSSI too low");
-		return;
-	}
-
-	printk("Stopping scan\n");
-	if (bt_le_scan_stop()) {
-		FAIL("Could not stop scan");
-		return;
-	}
-
-	err = bt_conn_le_create(addr, BT_CONN_LE_CREATE_CONN,
-				BT_LE_CONN_PARAM(BT_GAP_INIT_CONN_INT_MIN, BT_GAP_INIT_CONN_INT_MIN,
-						 0, BT_GAP_MS_TO_CONN_TIMEOUT(4000)),
-				&connected_conns[connected_conn_cnt]);
-	if (err) {
-		FAIL("Could not connect to peer: %d", err);
-	}
-}
-
 static void scan_and_connect(void)
 {
 	int err;
 
 	UNSET_FLAG(flag_connected);
 
-	err = bt_le_scan_start(BT_LE_SCAN_PASSIVE, cap_device_found);
+	err = bt_le_scan_start(BT_LE_SCAN_PASSIVE, NULL);
 	if (err != 0) {
 		FAIL("Scanning failed to start (err %d)\n", err);
 		return;

--- a/tests/bsim/bluetooth/audio/src/cap_initiator_unicast_test.c
+++ b/tests/bsim/bluetooth/audio/src/cap_initiator_unicast_test.c
@@ -24,6 +24,7 @@
 #include <zephyr/bluetooth/gatt.h>
 #include <zephyr/bluetooth/hci_types.h>
 #include <zephyr/bluetooth/iso.h>
+#include <zephyr/bluetooth/uuid.h>
 #include <zephyr/kernel.h>
 #include <zephyr/net_buf.h>
 #include <zephyr/sys/atomic.h>
@@ -367,8 +368,75 @@ static struct bt_gatt_cb gatt_callbacks = {
 	.att_mtu_updated = att_mtu_updated,
 };
 
+static bool check_audio_support_and_connect_cb(struct bt_data *data, void *user_data)
+{
+	char addr_str[BT_ADDR_LE_STR_LEN];
+	bt_addr_le_t *addr = user_data;
+	const struct bt_uuid *uuid;
+	uint16_t uuid_val;
+	int err;
+
+	printk("data->type %u\n", data->type);
+
+	if (data->type != BT_DATA_SVC_DATA16) {
+		return true; /* Continue parsing to next AD data type */
+	}
+
+	if (data->data_len < sizeof(uuid_val)) {
+		return true; /* Continue parsing to next AD data type */
+	}
+
+	/* We are looking for the CAS service data */
+	uuid_val = sys_get_le16(data->data);
+	uuid = BT_UUID_DECLARE_16(uuid_val);
+	if (bt_uuid_cmp(uuid, BT_UUID_CAS) != 0) {
+		return true; /* Continue parsing to next AD data type */
+	}
+
+	bt_addr_le_to_str(addr, addr_str, sizeof(addr_str));
+	printk("Device found: %s\n", addr_str);
+
+	printk("Stopping scan\n");
+	if (bt_le_scan_stop()) {
+		FAIL("Could not stop scan");
+		return false;
+	}
+
+	err = bt_conn_le_create(addr, BT_CONN_LE_CREATE_CONN,
+				BT_LE_CONN_PARAM(BT_GAP_INIT_CONN_INT_MIN, BT_GAP_INIT_CONN_INT_MIN,
+						 0, BT_GAP_MS_TO_CONN_TIMEOUT(4000)),
+				&connected_conns[connected_conn_cnt]);
+	if (err != 0) {
+		FAIL("Could not connect to peer: %d", err);
+	}
+
+	return false; /* Stop parsing */
+}
+
+static void scan_recv_cb(const struct bt_le_scan_recv_info *info, struct net_buf_simple *buf)
+{
+	struct bt_conn *conn;
+
+	conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, info->addr);
+	if (conn != NULL) {
+		/* Already connected to this device */
+		bt_conn_unref(conn);
+		return;
+	}
+
+	/* Check for connectable, extended advertising */
+	if (((info->adv_props & BT_GAP_ADV_PROP_EXT_ADV) != 0) &&
+	    ((info->adv_props & BT_GAP_ADV_PROP_CONNECTABLE)) != 0) {
+		/* Check for TMAS support in advertising data */
+		bt_data_parse(buf, check_audio_support_and_connect_cb, (void *)info->addr);
+	}
+}
+
 static void init(void)
 {
+	static struct bt_le_scan_cb scan_callbacks = {
+		.recv = scan_recv_cb,
+	};
 	int err;
 
 	err = bt_enable(NULL);
@@ -378,6 +446,11 @@ static void init(void)
 	}
 
 	bt_gatt_cb_register(&gatt_callbacks);
+	err = bt_le_scan_cb_register(&scan_callbacks);
+	if (err != 0) {
+		FAIL("Failed to register scan callbacks (err %d)\n", err);
+		return;
+	}
 
 	err = bt_bap_unicast_client_register_cb(&unicast_client_cbs);
 	if (err != 0) {
@@ -404,56 +477,13 @@ static void init(void)
 	}
 }
 
-static void cap_device_found(const bt_addr_le_t *addr, int8_t rssi, uint8_t type,
-			     struct net_buf_simple *ad)
-{
-	char addr_str[BT_ADDR_LE_STR_LEN];
-	struct bt_conn *conn;
-	int err;
-
-	/* We're only interested in connectable events */
-	if (type != BT_HCI_ADV_IND && type != BT_HCI_ADV_DIRECT_IND) {
-		return;
-	}
-
-	conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, addr);
-	if (conn != NULL) {
-		/* Already connected to this device */
-		bt_conn_unref(conn);
-		return;
-	}
-
-	bt_addr_le_to_str(addr, addr_str, sizeof(addr_str));
-	printk("Device found: %s (RSSI %d)\n", addr_str, rssi);
-
-	/* connect only to devices in close proximity */
-	if (rssi < -70) {
-		FAIL("RSSI too low");
-		return;
-	}
-
-	printk("Stopping scan\n");
-	if (bt_le_scan_stop()) {
-		FAIL("Could not stop scan");
-		return;
-	}
-
-	err = bt_conn_le_create(addr, BT_CONN_LE_CREATE_CONN,
-				BT_LE_CONN_PARAM(BT_GAP_INIT_CONN_INT_MIN, BT_GAP_INIT_CONN_INT_MIN,
-						 0, BT_GAP_MS_TO_CONN_TIMEOUT(4000)),
-				&connected_conns[connected_conn_cnt]);
-	if (err) {
-		FAIL("Could not connect to peer: %d", err);
-	}
-}
-
 static void scan_and_connect(void)
 {
 	int err;
 
 	UNSET_FLAG(flag_connected);
 
-	err = bt_le_scan_start(BT_LE_SCAN_PASSIVE, cap_device_found);
+	err = bt_le_scan_start(BT_LE_SCAN_PASSIVE, NULL);
 	if (err != 0) {
 		FAIL("Scanning failed to start (err %d)\n", err);
 		return;

--- a/tests/bsim/bluetooth/audio/test_scripts/cap_broadcast_ac_12.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/cap_broadcast_ac_12.sh
@@ -56,14 +56,14 @@ Execute_AC_12 8_2_2
 Execute_AC_12 16_1_2
 Execute_AC_12 16_2_2
 Execute_AC_12 24_1_2
-# Execute_AC_12 24_2_2 # ISO receive error
+Execute_AC_12 24_2_2
 Execute_AC_12 32_1_2
 Execute_AC_12 32_2_2
 # Execute_AC_12 441_1_2 # BT_ISO_FLAGS_LOST
 # Execute_AC_12 441_2_2 # BT_ISO_FLAGS_LOST
 Execute_AC_12 48_1_2
-# Execute_AC_12 48_2_2 # ISO receive error
-# Execute_AC_12 48_3_2 # ISO receive error
-# Execute_AC_12 48_4_2 # ISO receive error
+Execute_AC_12 48_2_2
+Execute_AC_12 48_3_2
+Execute_AC_12 48_4_2
 Execute_AC_12 48_5_2
 Execute_AC_12 48_6_2

--- a/tests/bsim/bluetooth/audio/test_scripts/cap_broadcast_ac_14.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/cap_broadcast_ac_14.sh
@@ -54,18 +54,18 @@ Execute_AC_14 48_6_1
 
 # High reliability
 Execute_AC_14 8_1_2
-# Execute_AC_14 8_2_2 # ISO receive error
+Execute_AC_14 8_2_2
 Execute_AC_14 16_1_2
 Execute_AC_14 16_2_2
-# Execute_AC_14 24_1_2 # ISO receive error
-# Execute_AC_14 24_2_2 # ISO receive error
-# Execute_AC_14 32_1_2 # ISO receive error
+Execute_AC_14 24_1_2
+Execute_AC_14 24_2_2
+Execute_AC_14 32_1_2
 Execute_AC_14 32_2_2
 # Execute_AC_14 441_1_2 # BT_ISO_FLAGS_LOST
 # Execute_AC_14 441_2_2 # BT_ISO_FLAGS_ERROR
 # Execute_AC_14 48_1_2 # ISO receive error
 Execute_AC_14 48_2_2
-# Execute_AC_14 48_3_2 # ISO receive error
-# Execute_AC_14 48_4_2 # ISO receive error
+Execute_AC_14 48_3_2
+Execute_AC_14 48_4_2
 # Execute_AC_14 48_5_2  # BT_ISO_FLAGS_ERROR
 # Execute_AC_14 48_6_2  # BT_ISO_FLAGS_ERROR

--- a/tests/bsim/bluetooth/audio/test_scripts/cap_broadcast_ac_14.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/cap_broadcast_ac_14.sh
@@ -63,7 +63,7 @@ Execute_AC_14 32_1_2
 Execute_AC_14 32_2_2
 # Execute_AC_14 441_1_2 # BT_ISO_FLAGS_LOST
 # Execute_AC_14 441_2_2 # BT_ISO_FLAGS_ERROR
-# Execute_AC_14 48_1_2 # ISO receive error
+Execute_AC_14 48_1_2
 Execute_AC_14 48_2_2
 Execute_AC_14 48_3_2
 Execute_AC_14 48_4_2

--- a/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_ac_6_i.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_ac_6_i.sh
@@ -41,7 +41,7 @@ Execute_AC_6_I 32_2_1
 # Execute_AC_6_I 441_1_1 # ASSERTION FAIL [iso_interval_us >= cig->c_sdu_interval]
 # Execute_AC_6_I 441_2_1 # ASSERTION FAIL [iso_interval_us >= cig->c_sdu_interval]
 Execute_AC_6_I 48_1_1
-# Execute_AC_6_I 48_2_1 # test timeout
+Execute_AC_6_I 48_2_1
 Execute_AC_6_I 48_3_1
 Execute_AC_6_I 48_4_1
 Execute_AC_6_I 48_5_1

--- a/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_ac_6_ii.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_ac_6_ii.sh
@@ -47,7 +47,7 @@ Execute_AC_6_II 32_2_1
 # Execute_AC_6_II 441_1_1 # ASSERTION FAIL [iso_interval_us >= cig->c_sdu_interval]
 # Execute_AC_6_II 441_2_1 # ASSERTION FAIL [iso_interval_us >= cig->c_sdu_interval]
 Execute_AC_6_II 48_1_1
-# Execute_AC_6_II 48_2_1 # Fails at PR 79931
+Execute_AC_6_II 48_2_1
 Execute_AC_6_II 48_3_1
 Execute_AC_6_II 48_4_1
 Execute_AC_6_II 48_5_1

--- a/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_ac_7_ii.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_ac_7_ii.sh
@@ -47,7 +47,7 @@ Execute_AC_7_II 32_2_1 32_2_1
 # Execute_AC_7_II 441_1_1 441_1_1 # ASSERTION FAIL [iso_interval_us >= cig->c_sdu_interval]
 # Execute_AC_7_II 441_2_1 441_2_1 # ASSERTION FAIL [iso_interval_us >= cig->c_sdu_interval]
 Execute_AC_7_II 48_1_1 48_1_1
-# Execute_AC_7_II 48_2_1 48_2_1 # Fails at PR 79931
+Execute_AC_7_II 48_2_1 48_2_1
 Execute_AC_7_II 48_3_1 48_3_1
 Execute_AC_7_II 48_4_1 48_4_1
 Execute_AC_7_II 48_5_1 48_5_1

--- a/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_ac_9_i.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_ac_9_i.sh
@@ -43,7 +43,7 @@ Execute_AC_9_I 32_2_1
 # Execute_AC_9_I 441_1_1 # ASSERTION FAIL [iso_interval_us >= cig->c_sdu_interval]
 # Execute_AC_9_I 441_2_1 # ASSERTION FAIL [iso_interval_us >= cig->c_sdu_interval]
 Execute_AC_9_I 48_1_1
-# Execute_AC_9_I 48_2_1 # test timeout
+Execute_AC_9_I 48_2_1
 Execute_AC_9_I 48_3_1
 Execute_AC_9_I 48_4_1
 Execute_AC_9_I 48_5_1

--- a/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_ac_9_ii.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_ac_9_ii.sh
@@ -47,7 +47,7 @@ Execute_AC_9_II 32_2_1
 # Execute_AC_9_II 441_1_1 # ASSERTION FAIL [iso_interval_us >= cig->c_sdu_interval]
 # Execute_AC_9_II 441_2_1 # ASSERTION FAIL [iso_interval_us >= cig->c_sdu_interval]
 Execute_AC_9_II 48_1_1
-# Execute_AC_9_II 48_2_1
+Execute_AC_9_II 48_2_1
 Execute_AC_9_II 48_3_1
 Execute_AC_9_II 48_4_1
 Execute_AC_9_II 48_5_1


### PR DESCRIPTION
Fix reschedule for ticker that yield such that reduce the
slot window after intersection to include required
ticks_slot, and we do not take the interval of the
colliding ticker provided every expiry increments the
interval by random amount of ticks. This is the case for
primary channel advertising.

Fixes commit e1cd5ba77f59 ("Bluetooth: Controller: Fix to
reschedule after overlap when yielding").
