### PR TITLE
drv: ft8xx: new coprocessor commands

### DIFF
--- a/drivers/misc/ft8xx/Kconfig
+++ b/drivers/misc/ft8xx/Kconfig
@@ -3,7 +3,7 @@
 # Copyright (c) 2020-2021 Hubert Miś <hubert.mis@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
 
-config FT800
+menuconfig FT800
 	bool "FT800 Embedded Video Engine driver"
 	default y
 	depends on DT_HAS_FTDI_FT800_ENABLED
@@ -11,9 +11,17 @@ config FT800
 	help
 	  Enable driver for FT800 controller.
 
+if FT800
+
 config FT800_INIT_PRIORITY
 	int "FT800 init priority"
 	default 90
 	depends on FT800
 	help
 	  FT800 driver initialization priority in POST_KERNEL.
+
+module = FT800
+module-str = FT800
+source "subsys/logging/Kconfig.template.log_config"
+
+endif # FT800

--- a/drivers/misc/ft8xx/ft8xx.c
+++ b/drivers/misc/ft8xx/ft8xx.c
@@ -15,8 +15,8 @@
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 
-#include <zephyr/drivers/misc/ft8xx/ft8xx_copro.h>
 #include <zephyr/drivers/misc/ft8xx/ft8xx_common.h>
+#include <zephyr/drivers/misc/ft8xx/ft8xx_copro.h>
 #include <zephyr/drivers/misc/ft8xx/ft8xx_dl.h>
 #include <zephyr/drivers/misc/ft8xx/ft8xx_memory.h>
 
@@ -176,6 +176,11 @@ int ft8xx_get_touch_tag(void)
 	(void)ft8xx_rd8(FT800_REG_INT_FLAGS);
 
 	return (int)ft8xx_rd8(FT800_REG_TOUCH_TAG);
+}
+
+uint32_t ft8xx_get_tracker_value(void)
+{
+	return ft8xx_rd32(FT800_REG_TRACKER);
 }
 
 void ft8xx_drv_irq_triggered(const struct device *dev, struct gpio_callback *cb,

--- a/drivers/misc/ft8xx/ft8xx.c
+++ b/drivers/misc/ft8xx/ft8xx.c
@@ -23,7 +23,7 @@
 #include "ft8xx_drv.h"
 #include "ft8xx_host_commands.h"
 
-LOG_MODULE_REGISTER(ft8xx, CONFIG_DISPLAY_LOG_LEVEL);
+LOG_MODULE_REGISTER(ft8xx, CONFIG_FT800_LOG_LEVEL);
 
 #define FT8XX_DLSWAP_FRAME 0x02
 

--- a/drivers/misc/ft8xx/ft8xx_copro.c
+++ b/drivers/misc/ft8xx/ft8xx_copro.c
@@ -18,7 +18,12 @@
 enum {
 	CMD_DLSTART   = 0xffffff00,
 	CMD_SWAP      = 0xffffff01,
+	CMD_BGCOLOR   = 0xffffff09,
+	CMD_FGCOLOR   = 0xffffff0a,
 	CMD_TEXT      = 0xffffff0c,
+	CMD_SLIDER    = 0xffffff10,
+	CMD_TOGGLE    = 0xffffff12,
+	CMD_TRACK     = 0xffffff2c,
 	CMD_NUMBER    = 0xffffff2e,
 	CMD_CALIBRATE = 0xffffff15,
 } ft8xx_cmd;
@@ -71,6 +76,183 @@ void ft8xx_copro_cmd_dlstart(void)
 void ft8xx_copro_cmd_swap(void)
 {
 	ft8xx_copro_cmd(CMD_SWAP);
+}
+
+void ft8xx_copro_cmd_fgcolor(uint32_t c)
+{
+	const uint16_t cmd_size = sizeof(CMD_FGCOLOR) +
+				  sizeof(c);
+
+	while (ram_cmd_freespace() < cmd_size) {
+		refresh_reg_cmd_read();
+	}
+
+	ft8xx_wr32(FT800_RAM_CMD + reg_cmd_write, CMD_FGCOLOR);
+	increase_reg_cmd_write(sizeof(CMD_FGCOLOR));
+
+	ft8xx_wr32(FT800_RAM_CMD + reg_cmd_write, c);
+	increase_reg_cmd_write(sizeof(c));
+
+	flush_reg_cmd_write();
+}
+
+void ft8xx_copro_cmd_bgcolor(uint32_t c)
+{
+	const uint16_t cmd_size = sizeof(CMD_BGCOLOR) +
+				  sizeof(c);
+
+	while (ram_cmd_freespace() < cmd_size) {
+		refresh_reg_cmd_read();
+	}
+
+	ft8xx_wr32(FT800_RAM_CMD + reg_cmd_write, CMD_BGCOLOR);
+	increase_reg_cmd_write(sizeof(CMD_BGCOLOR));
+
+	ft8xx_wr32(FT800_RAM_CMD + reg_cmd_write, c);
+	increase_reg_cmd_write(sizeof(c));
+
+	flush_reg_cmd_write();
+}
+
+void ft8xx_copro_cmd_slider(int16_t x,
+			    int16_t y,
+			    int16_t w,
+			    int16_t h,
+			    uint16_t options,
+			    uint16_t val,
+			    uint16_t range)
+{
+	size_t padding_bytes = 2;
+	const uint16_t cmd_size = sizeof(CMD_SLIDER) +
+				  sizeof(x) +
+				  sizeof(y) +
+				  sizeof(w) +
+				  sizeof(h) +
+				  sizeof(options) +
+				  sizeof(val) +
+				  sizeof(range) +
+				  padding_bytes;
+
+	while (ram_cmd_freespace() < cmd_size) {
+		refresh_reg_cmd_read();
+	}
+
+	ft8xx_wr32(FT800_RAM_CMD + reg_cmd_write, CMD_SLIDER);
+	increase_reg_cmd_write(sizeof(CMD_SLIDER));
+
+	ft8xx_wr16(FT800_RAM_CMD + reg_cmd_write, x);
+	increase_reg_cmd_write(sizeof(x));
+
+	ft8xx_wr16(FT800_RAM_CMD + reg_cmd_write, y);
+	increase_reg_cmd_write(sizeof(y));
+
+	ft8xx_wr16(FT800_RAM_CMD + reg_cmd_write, w);
+	increase_reg_cmd_write(sizeof(w));
+
+	ft8xx_wr16(FT800_RAM_CMD + reg_cmd_write, h);
+	increase_reg_cmd_write(sizeof(h));
+
+	ft8xx_wr16(FT800_RAM_CMD + reg_cmd_write, options);
+	increase_reg_cmd_write(sizeof(options));
+
+	ft8xx_wr16(FT800_RAM_CMD + reg_cmd_write, val);
+	increase_reg_cmd_write(sizeof(val));
+
+	ft8xx_wr16(FT800_RAM_CMD + reg_cmd_write, range);
+	increase_reg_cmd_write(sizeof(range) + padding_bytes);
+
+	flush_reg_cmd_write();
+}
+
+void ft8xx_copro_cmd_toggle(int16_t x,
+			    int16_t y,
+			    int16_t w,
+			    int16_t font,
+			    uint16_t options,
+			    uint16_t state,
+			    const char *s)
+{
+	const uint16_t str_bytes = strlen(s) + 1;
+	const uint16_t padding_bytes = (4 - (str_bytes % 4)) % 4;
+	const uint16_t cmd_size = sizeof(CMD_TOGGLE) +
+				  sizeof(x) +
+				  sizeof(y) +
+				  sizeof(w) +
+				  sizeof(font) +
+				  sizeof(options) +
+				  sizeof(state) +
+				  str_bytes +
+				  padding_bytes;
+
+	while (ram_cmd_freespace() < cmd_size) {
+		refresh_reg_cmd_read();
+	}
+
+	ft8xx_wr32(FT800_RAM_CMD + reg_cmd_write, CMD_TOGGLE);
+	increase_reg_cmd_write(sizeof(CMD_TOGGLE));
+
+	ft8xx_wr16(FT800_RAM_CMD + reg_cmd_write, x);
+	increase_reg_cmd_write(sizeof(x));
+
+	ft8xx_wr16(FT800_RAM_CMD + reg_cmd_write, y);
+	increase_reg_cmd_write(sizeof(y));
+
+	ft8xx_wr16(FT800_RAM_CMD + reg_cmd_write, w);
+	increase_reg_cmd_write(sizeof(w));
+
+	ft8xx_wr16(FT800_RAM_CMD + reg_cmd_write, font);
+	increase_reg_cmd_write(sizeof(font));
+
+	ft8xx_wr16(FT800_RAM_CMD + reg_cmd_write, options);
+	increase_reg_cmd_write(sizeof(options));
+
+	ft8xx_wr16(FT800_RAM_CMD + reg_cmd_write, state);
+	increase_reg_cmd_write(sizeof(state));
+
+	(void)ft8xx_drv_write(FT800_RAM_CMD + reg_cmd_write, s, str_bytes);
+	increase_reg_cmd_write(str_bytes + padding_bytes);
+
+	flush_reg_cmd_write();
+}
+
+void ft8xx_copro_cmd_track(int16_t x,
+			   int16_t y,
+			   int16_t w,
+			   int16_t h,
+			   int16_t tag)
+{
+	size_t padding_bytes = 2;
+	const uint16_t cmd_size = sizeof(CMD_TRACK) +
+				  sizeof(x) +
+				  sizeof(y) +
+				  sizeof(w) +
+				  sizeof(h) +
+				  sizeof(tag) +
+				  padding_bytes;
+
+	while (ram_cmd_freespace() < cmd_size) {
+		refresh_reg_cmd_read();
+	}
+
+	ft8xx_wr32(FT800_RAM_CMD + reg_cmd_write, CMD_TRACK);
+	increase_reg_cmd_write(sizeof(CMD_TRACK));
+
+	ft8xx_wr16(FT800_RAM_CMD + reg_cmd_write, x);
+	increase_reg_cmd_write(sizeof(x));
+
+	ft8xx_wr16(FT800_RAM_CMD + reg_cmd_write, y);
+	increase_reg_cmd_write(sizeof(y));
+
+	ft8xx_wr16(FT800_RAM_CMD + reg_cmd_write, w);
+	increase_reg_cmd_write(sizeof(w));
+
+	ft8xx_wr16(FT800_RAM_CMD + reg_cmd_write, h);
+	increase_reg_cmd_write(sizeof(h));
+
+	ft8xx_wr16(FT800_RAM_CMD + reg_cmd_write, tag);
+	increase_reg_cmd_write(sizeof(tag) + padding_bytes);
+
+	flush_reg_cmd_write();
 }
 
 void ft8xx_copro_cmd_text(int16_t x,

--- a/include/zephyr/drivers/misc/ft8xx/ft8xx.h
+++ b/include/zephyr/drivers/misc/ft8xx/ft8xx.h
@@ -82,6 +82,17 @@ void ft8xx_touch_transform_set(const struct ft8xx_touch_transform *data);
 int ft8xx_get_touch_tag(void);
 
 /**
+ * @brief Get the tag and the tracking value of the tracked object.
+ *
+ * The reported tag and the tracking value apply to an object tracked by the
+ * coprocessor with the ft8xx_copro_cmd_track() function.
+ *
+ * @return Track register content where 2 MS bytes (0xffff0000 mask) indicate
+ *         the track value and 2 LS bytes (0x0000ffff mask) indicate the tag.
+ */
+uint32_t ft8xx_get_tracker_value(void);
+
+/**
  * @brief Set callback executed when FT8xx triggers interrupt
  *
  * This function configures FT8xx to trigger interrupt when touch event changes

--- a/include/zephyr/drivers/misc/ft8xx/ft8xx_copro.h
+++ b/include/zephyr/drivers/misc/ft8xx/ft8xx_copro.h
@@ -80,6 +80,129 @@ void ft8xx_copro_cmd_dlstart(void);
 void ft8xx_copro_cmd_swap(void);
 
 /**
+ * @brief Set the foreground color
+ *
+ * New foreground color, as a 24-bit RGB number. Red is the most significant 8
+ * bits, blue is the least. So 0xff0000 is bright red. Foreground color is
+ * applicable for things that the user can move such as handles and buttons
+ * ("affordances").
+ *
+ * @param c Color to set
+ */
+void ft8xx_copro_cmd_fgcolor(uint32_t c);
+
+/**
+ * @brief Set the background color
+ *
+ * New background color, as a 24-bit RGB number. Red is the most significant 8
+ * bits, blue is the least. So 0xff0000 is bright red.
+ * Background color is applicable for things that the user cannot move. Example
+ * behind gauges and sliders etc.
+ *
+ * @param c Color to set
+ */
+void ft8xx_copro_cmd_bgcolor(uint32_t c);
+
+/**
+ * @brief Draw a slider
+ *
+ * If width is greater than height, the scroll bar is drawn horizontally.
+ * If height is greater than width, the scroll bar is drawn vertically.
+ *
+ * By default the slider is drawn with a 3D effect. @ref FT8XX_OPT_FLAT removes
+ * the 3D effect.
+ *
+ * @param x x-coordinate of slider top-left, in pixels
+ * @param y y-coordinate of slider top-left, in pixels
+ * @param w Width of slider, in pixels
+ * @param h Height of slider, in pixels
+ * @param options Options to apply
+ * @param val Displayed value of slider, between 0 and range inclusive
+ * @param range Maximum value
+ */
+void ft8xx_copro_cmd_slider(int16_t x,
+			    int16_t y,
+			    int16_t w,
+			    int16_t h,
+			    uint16_t options,
+			    uint16_t val,
+			    uint16_t range);
+
+/**
+ * @brief Draw a toggle switch
+ *
+ * By default the toggle is drawn with a 3D effect and the value option is zero.
+ * @ref FT8XX_OPT_FLAT removes the 3D effect and its value is 256.
+ *
+ * In @p s, a character value of 255 (it can be written as @c \\xff ) separates
+ * the off and on labels.
+ *
+ * @param x x-coordinate of top-left of toggle, in pixels
+ * @param y y-coordinate of top-left of toggle, in pixels
+ * @param w Width of toggle, in pixels
+ * @param font Font to use for text, 0-31. 16-31 are ROM fonts
+ * @param options Options to apply
+ * @param state State of the toggle: 0 is off, 65535 is on
+ * @param s String label for toggle
+ */
+void ft8xx_copro_cmd_toggle(int16_t x,
+			    int16_t y,
+			    int16_t w,
+			    int16_t font,
+			    uint16_t options,
+			    uint16_t state,
+			    const char *s);
+
+/**
+ * @brief Track touches for a graphics object
+ *
+ * This command will enable co-processor engine to track the touch on the
+ * particular graphics object with one valid tag value assigned. Then,
+ * co-processor engine will update the REG_TRACKER periodically with the frame
+ * rate of LCD display panel.
+ *
+ * Co-processor engine tracks the graphics object in rotary tracker mode and
+ * linear tracker mode:
+ *
+ * - Rotary tracker mode
+ *   Track the angle between the touching point and the center of graphics
+ *   object specified by @p tag value. The value is in units of 1/65536 of a
+ *   circle. 0 means that the angle is straight down, 0x4000 left, 0x8000 up,
+ *   and 0xC000 right from the center.
+ * - Linear tracker mode
+ *   If @p w is greater than @p h, track the relative distance of touching point
+ *   to the width of graphics object specified by @p tag value. If @p w is not
+ *   greater than @p h, Track the relative distance of touching point to the
+ *   height of graphics object specified by @p tag value. The value is in units
+ *   of 1/65536 of the width or height of graphics object. The distance of
+ *   touching point refers to the distance from the top left pixel of graphics
+ *   object to the coordinate of touching point.
+ *
+ * For linear tracker functionality, @p x represents x-coordinate of track area
+ * top-left and @p y represents y-coordinate of track area top-left. Both
+ * parameters are in pixels.
+ *
+ * For rotary tracker functionality, @p x represents x-coordinate of track area
+ * center and @p y represents y-coordinate of track area center. Both
+ * parameters are in pixels.
+ *
+ * @note A @p w and @p h of (1,1) means that the tracker is rotary, and reports
+ *       an angle value in REG_TRACKER. A @p w and @p h of (0,0) disables the
+ *       track functionality of co-processor engine.
+ *
+ * @param x x-coordinate
+ * @param y y-coordinate
+ * @param w Width of track area, in pixels.
+ * @param h Height of track area, in pixels.
+ * @param tag Tag of the graphics object to be tracked, 1-255
+ */
+void ft8xx_copro_cmd_track(int16_t x,
+			   int16_t y,
+			   int16_t w,
+			   int16_t h,
+			   int16_t tag);
+
+/**
  * @brief Draw text
  *
  * By default (@p x, @p y) is the top-left pixel of the text and the value of

--- a/include/zephyr/drivers/misc/ft8xx/ft8xx_reference_api.h
+++ b/include/zephyr/drivers/misc/ft8xx/ft8xx_reference_api.h
@@ -172,6 +172,144 @@ static inline void cmd_swap(void)
 }
 
 /**
+ * @brief Set the foreground color
+ *
+ * New foreground color, as a 24-bit RGB number. Red is the most significant 8
+ * bits, blue is the least. So 0xff0000 is bright red. Foreground color is
+ * applicable for things that the user can move such as handles and buttons
+ * ("affordances").
+ *
+ * @param c Color to set
+ */
+static inline void cmd_fgcolor(uint32_t c)
+{
+	ft8xx_copro_cmd_fgcolor(c);
+}
+
+/**
+ * @brief Set the background color
+ *
+ * New background color, as a 24-bit RGB number. Red is the most significant 8
+ * bits, blue is the least. So 0xff0000 is bright red.
+ * Background color is applicable for things that the user cannot move. Example
+ * behind gauges and sliders etc.
+ *
+ * @param c Color to set
+ */
+static inline void cmd_bgcolor(uint32_t c)
+{
+	ft8xx_copro_cmd_bgcolor(c);
+}
+
+/**
+ * @brief Draw a slider
+ *
+ * If width is greater than height, the scroll bar is drawn horizontally.
+ * If height is greater than width, the scroll bar is drawn vertically.
+ *
+ * By default the slider is drawn with a 3D effect. @ref FT8XX_OPT_FLAT removes
+ * the 3D effect.
+ *
+ * @param x x-coordinate of slider top-left, in pixels
+ * @param y y-coordinate of slider top-left, in pixels
+ * @param w Width of slider, in pixels
+ * @param h Height of slider, in pixels
+ * @param options Options to apply
+ * @param val Displayed value of slider, between 0 and range inclusive
+ * @param range Maximum value
+ */
+static inline void cmd_slider(int16_t x,
+			      int16_t y,
+			      int16_t w,
+			      int16_t h,
+			      uint16_t options,
+			      uint16_t val,
+			      uint16_t range)
+{
+	ft8xx_copro_cmd_slider(x, y, w, h, options, val, range);
+}
+
+/**
+ * @brief Draw a toggle switch
+ *
+ * By default the toggle is drawn with a 3D effect and the value option is zero.
+ * @ref FT8XX_OPT_FLAT removes the 3D effect and its value is 256.
+ *
+ * In @p s, a character value of 255 (it can be written as @c \\xff ) separates
+ * the off and on labels.
+ *
+ * @param x x-coordinate of top-left of toggle, in pixels
+ * @param y y-coordinate of top-left of toggle, in pixels
+ * @param w Width of toggle, in pixels
+ * @param font Font to use for text, 0-31. 16-31 are ROM fonts
+ * @param options Options to apply
+ * @param state State of the toggle: 0 is off, 65535 is on
+ * @param s String label for toggle
+ */
+static inline void cmd_toggle(int16_t x,
+			      int16_t y,
+			      int16_t w,
+			      int16_t font,
+			      uint16_t options,
+			      uint16_t state,
+			      const char *s)
+{
+	ft8xx_copro_cmd_toggle(x, y, w, font, options, state, s);
+}
+
+/**
+ * @brief Track touches for a graphics object
+ *
+ * This command will enable co-processor engine to track the touch on the
+ * particular graphics object with one valid tag value assigned. Then,
+ * co-processor engine will update the REG_TRACKER periodically with the frame
+ * rate of LCD display panel.
+ *
+ * Co-processor engine tracks the graphics object in rotary tracker mode and
+ * linear tracker mode:
+ *
+ * - Rotary tracker mode
+ *   Track the angle between the touching point and the center of graphics
+ *   object specified by @p tag value. The value is in units of 1/65536 of a
+ *   circle. 0 means that the angle is straight down, 0x4000 left, 0x8000 up,
+ *   and 0xC000 right from the center.
+ * - Linear tracker mode
+ *   If @p w is greater than @p h, track the relative distance of touching point
+ *   to the width of graphics object specified by @p tag value. If @p w is not
+ *   greater than @p h, Track the relative distance of touching point to the
+ *   height of graphics object specified by @p tag value. The value is in units
+ *   of 1/65536 of the width or height of graphics object. The distance of
+ *   touching point refers to the distance from the top left pixel of graphics
+ *   object to the coordinate of touching point.
+ *
+ * For linear tracker functionality, @p x represents x-coordinate of track area
+ * top-left and @p y represents y-coordinate of track area top-left. Both
+ * parameters are in pixels.
+ *
+ * For rotary tracker functionality, @p x represents x-coordinate of track area
+ * center and @p y represents y-coordinate of track area center. Both
+ * parameters are in pixels.
+ *
+ * @note A @p w and @p h of (1,1) means that the tracker is rotary, and reports
+ *       an angle value in REG_TRACKER. A @p w and @p h of (0,0) disables the
+ *       track functionality of co-processor engine.
+ *
+ * @param x x-coordinate
+ * @param y y-coordinate
+ * @param w Width of track area, in pixels.
+ * @param h Height of track area, in pixels.
+ * @param tag Tag of the graphics object to be tracked, 1-255
+ */
+static inline void cmd_track(int16_t x,
+			     int16_t y,
+			     int16_t w,
+			     int16_t h,
+			     int16_t tag)
+{
+	ft8xx_copro_cmd_track(x, y, w, h, tag);
+}
+
+/**
  * @brief Draw text
  *
  * By default (x,y) is the top-left pixel of the text and the value of


### PR DESCRIPTION
Implement more co-processor commands in the FT8xx display driver. The list of the new implemented commands consists of:

* CMD_FGCOLOR
* CMD_BGCOLOR
* CMD_SLIDER
* CMD_TOGGLE
* CMD_TRACK