### PR TITLE
soc: espressif: fix missing spinlock definition

### DIFF
--- a/soc/espressif/esp32/esp32-mp.c
+++ b/soc/espressif/esp32/esp32-mp.c
@@ -42,6 +42,7 @@ struct cpustart_rec {
 volatile struct cpustart_rec *start_rec;
 static void *appcpu_top;
 static bool cpus_active[CONFIG_MP_MAX_NUM_CPUS];
+static struct k_spinlock loglock;
 #endif
 
 /* Note that the logging done here is ACTUALLY REQUIRED FOR RELIABLE


### PR DESCRIPTION
This definition is deleted in the follwoing commit; 8233b70ece3264379961cf3337cb627b511c7b77 as a part of "cleanup", however this definition is used by `smp_log` which is few lines below.