### PR TITLE
API Change: Stream Flash: Remove device size autodetection from stream_flash_init

### DIFF
--- a/doc/releases/migration-guide-4.1.rst
+++ b/doc/releases/migration-guide-4.1.rst
@@ -393,6 +393,14 @@ LoRa
   additional ``user_data`` parameter, which is a void pointer. This parameter can be used to reference
   any user-defined data structure. To maintain the current behavior, set this parameter to ``NULL``.
 
+Stream Flash
+============
+
+* The function :c:func:`stream_flash_init` no longer does auto-detection of device size
+  when ``size`` parameter is set to 0 and will return error in such case. User is now
+  required to explicitly provide device size. Issue :github:`71042` provides rationale
+  for the change.
+
 Architectures
 *************
 

--- a/doc/releases/release-notes-4.1.rst
+++ b/doc/releases/release-notes-4.1.rst
@@ -24,6 +24,10 @@ https://docs.zephyrproject.org/latest/security/vulnerabilities.html
 API Changes
 ***********
 
+ * Stream Flash initialization function :c:func:`stream_flash_init` no longer does
+   device size autodetection and instead requires user to explicitly provide size
+   of area available for Stream Flash instance operation.
+
 Removed APIs in this release
 ============================
 

--- a/include/zephyr/storage/stream_flash.h
+++ b/include/zephyr/storage/stream_flash.h
@@ -81,8 +81,6 @@ struct stream_flash_ctx {
  *                Must be multiple of the flash device write-block-size.
  * @param offset Offset within flash device to start writing to
  * @param size Number of bytes available for performing buffered write.
- *             If this is '0', the size will be set to the total size
- *             of the flash device minus the offset.
  * @param cb Callback to be invoked on completed flash write operations.
  *           Callback is supported when CONFIG_STREAM_FLASH_POST_WRITE_CALLBACK
  *           is enabled.

--- a/subsys/storage/stream/Kconfig
+++ b/subsys/storage/stream/Kconfig
@@ -6,11 +6,20 @@
 
 menuconfig STREAM_FLASH
 	bool "Stream to flash"
-	select FLASH_PAGE_LAYOUT
 	help
 	  Enable support of stream to flash API
 
 if STREAM_FLASH
+
+config STREAM_FLASH_INSPECT
+	bool "Check whether device layout is OK with Stream Flash definition"
+	default y
+	select FLASH_PAGE_LAYOUT
+	help
+	  Runs simple check to find whether provided device can be used for
+	  stream flash by verifying that buffer size will fit into page.
+	  Once correct configuration has been established and tested it is
+	  worth to disable the option to cut out some unneeded code.
 
 config STREAM_FLASH_POST_WRITE_CALLBACK
 	bool "Write complete callback"


### PR DESCRIPTION
The commit changes requirements for stream_flash_init, where size can no longer be 0 and has to be explicitly set, to avoid situation where size autodetection, invoked by size == 0, would miss changes in layout and silently allow overflow of Stream Flash into other partitions.

There has also been new Kconfig option CONFIG_STREAM_FLASH_INSPECT, set to y by default to keep legacy behaviour, that can be used to turn off stream_flash_ctx vs device inspection, allowing user to shed inspection code once it is not useful anymore.

Fixes: #71042

Aside from described changes tests have been altered to be compliant with the new stream_flash_init behaviour.