### PR TITLE
Fix coreadump header scramble alignment and improve speed of operation

### DIFF
--- a/subsys/debug/coredump/Kconfig
+++ b/subsys/debug/coredump/Kconfig
@@ -28,6 +28,19 @@ config DEBUG_COREDUMP_BACKEND_FLASH_PARTITION
 	  Core dump is saved to a flash partition with DTS alias
 	  "coredump-partition".
 
+config DEBUG_COREDUMP_BACKEND_DEVICE_WITHOUT_ERASE
+	bool "Device used for coredump does not require erase prior to write"
+	depends on FLASH_HAS_NO_EXPLICIT_ERASE
+	help
+	  Caution: this option is available if ANY device, under Flash API,
+	  in a system has no erase-prior-to-write requirement.
+	  If device where coredump will be done does not require erase,
+	  for example it is EEPROM, RRAM, MRAM with separate erase functions,
+	  disabling this option improves coredump time, as for such devices
+	  the designated area does not have to be erased first.
+	  Instead only coredump header is scrambled, before write happens,
+	  and updated after coredump write completes.
+
 config DEBUG_COREDUMP_BACKEND_INTEL_ADSP_MEM_WINDOW
 	bool "Use memory window for coredump on Intel ADSP"
 	depends on DT_HAS_INTEL_ADSP_MEM_WINDOW_ENABLED

--- a/subsys/debug/coredump/coredump_backend_flash_partition.c
+++ b/subsys/debug/coredump/coredump_backend_flash_partition.c
@@ -415,8 +415,12 @@ static void coredump_flash_backend_start(void)
 
 	if (ret == 0) {
 		/* Erase whole flash partition */
-		ret = flash_area_flatten(backend_ctx.flash_area, 0,
-					 backend_ctx.flash_area->fa_size);
+		if (IS_ENABLED(CONFIG_DEBUG_COREDUMP_BACKEND_DEVICE_WITHOUT_ERASE)) {
+			ret = erase_coredump_header();
+		} else {
+			ret = flash_area_erase(backend_ctx.flash_area, 0,
+					       backend_ctx.flash_area->fa_size);
+		}
 	}
 
 	if (ret == 0) {

--- a/subsys/debug/coredump/coredump_backend_flash_partition.c
+++ b/subsys/debug/coredump/coredump_backend_flash_partition.c
@@ -49,8 +49,8 @@ LOG_MODULE_REGISTER(coredump, CONFIG_KERNEL_LOG_LEVEL);
 #if DT_NODE_HAS_PROP(FLASH_CONTROLLER, erase_block_size)
 #define DEVICE_ERASE_BLOCK_SIZE DT_PROP(FLASH_CONTROLLER, erase_block_size)
 #else
-/* Device has no erase block size */
-#define DEVICE_ERASE_BLOCK_SIZE 1
+/* Device has no erase block size but we are still bound by write block size  */
+#define DEVICE_ERASE_BLOCK_SIZE WRITE_BLOCK_SIZE
 #endif
 
 #define HEADER_SCRAMBLE_SIZE	ROUND_UP(sizeof(struct flash_hdr_t),	\


### PR DESCRIPTION
Two commits:
 - fixing coredump header scramble alignment on devices without erase-block-size
 - improving coredump speed on devices that have no hardware requirement for erase prior to write