### PR TITLE
scripts: Update and lock ruff

### DIFF
--- a/.ruff-excludes.toml
+++ b/.ruff-excludes.toml
@@ -126,6 +126,7 @@
     "SIM113",   # https://docs.astral.sh/ruff/rules/enumerate-for-loop
     "SIM115",   # https://docs.astral.sh/ruff/rules/open-file-with-context-handler
     "UP010",    # https://docs.astral.sh/ruff/rules/unnecessary-future-import
+    "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
     "UP032",    # https://docs.astral.sh/ruff/rules/f-string
 ]
 "./samples/modules/tflite-micro/magic_wand/train/train_test.py" = [
@@ -199,6 +200,7 @@
     "F541",     # https://docs.astral.sh/ruff/rules/f-string-missing-placeholders
     "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
     "UP030",    # https://docs.astral.sh/ruff/rules/format-literals
+    "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
     "UP032",    # https://docs.astral.sh/ruff/rules/f-string
 ]
 "./scripts/build/gen_isr_tables_parser_local.py" = [
@@ -206,6 +208,7 @@
     "F541",     # https://docs.astral.sh/ruff/rules/f-string-missing-placeholders
     "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
     "UP030",    # https://docs.astral.sh/ruff/rules/format-literals
+    "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
     "UP032",    # https://docs.astral.sh/ruff/rules/f-string
 ]
 "./scripts/build/gen_kobject_list.py" = [
@@ -254,6 +257,7 @@
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
     "F541",     # https://docs.astral.sh/ruff/rules/f-string-missing-placeholders
     "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
+    "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
 ]
 "./scripts/build/gen_syscalls.py" = [
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
@@ -365,12 +369,14 @@
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
     "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
     "SIM115",   # https://docs.astral.sh/ruff/rules/open-file-with-context-handler
+    "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
     "UP039",    # https://docs.astral.sh/ruff/rules/unnecessary-class-parentheses
 ]
 "./scripts/coredump/coredump_parser/log_parser.py" = [
     "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
     "SIM115",   # https://docs.astral.sh/ruff/rules/open-file-with-context-handler
     "UP030",    # https://docs.astral.sh/ruff/rules/format-literals
+    "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
     "UP032",    # https://docs.astral.sh/ruff/rules/f-string
 ]
 "./scripts/coredump/coredump_serial_log_parser.py" = [
@@ -748,6 +754,8 @@
 ]
 "./scripts/pylib/twister/expr_parser.py" = [
     "SIM103",   # https://docs.astral.sh/ruff/rules/needless-bool
+    "SIM110",   # https://docs.astral.sh/ruff/rules/reimplemented-builtin
+    "SIM115",   # https://docs.astral.sh/ruff/rules/open-file-with-context-handler
     "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
 ]
 "./scripts/pylib/twister/scl.py" = [
@@ -786,6 +794,7 @@
     "UP032",    # https://docs.astral.sh/ruff/rules/f-string
 ]
 "./scripts/release/list_devicetree_bindings_changes.py" = [
+    "E402",     # https://docs.astral.sh/ruff/rules/module-import-not-at-top-of-file
     "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
     "SIM117",   # https://docs.astral.sh/ruff/rules/multiple-with-statements
     "UP006",    # https://docs.astral.sh/ruff/rules/non-pep585-annotation
@@ -833,7 +842,6 @@
 ]
 "./scripts/tests/twister/test_data/mixins/test_to_ignore.py" = [
     "B011",     # https://docs.astral.sh/ruff/rules/assert-false
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
 ]
 "./scripts/tests/twister/test_environment.py" = [
     "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
@@ -1259,7 +1267,6 @@
     "UP032",    # https://docs.astral.sh/ruff/rules/f-string
 ]
 "./scripts/west_commands/zspdx/cmakecache.py" = [
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
     "UP015",    # https://docs.astral.sh/ruff/rules/redundant-open-modes
 ]
 "./scripts/west_commands/zspdx/cmakefileapi.py" = [
@@ -1275,7 +1282,6 @@
     "UP015",    # https://docs.astral.sh/ruff/rules/redundant-open-modes
 ]
 "./scripts/west_commands/zspdx/datatypes.py" = [
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
     "UP008",    # https://docs.astral.sh/ruff/rules/super-call-with-parameters
 ]
 "./scripts/west_commands/zspdx/getincludes.py" = [
@@ -1290,7 +1296,6 @@
     "UP008",    # https://docs.astral.sh/ruff/rules/super-call-with-parameters
 ]
 "./scripts/west_commands/zspdx/scanner.py" = [
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
     "SIM113",   # https://docs.astral.sh/ruff/rules/enumerate-for-loop
     "UP008",    # https://docs.astral.sh/ruff/rules/super-call-with-parameters
     "UP015",    # https://docs.astral.sh/ruff/rules/redundant-open-modes
@@ -1335,14 +1340,6 @@
 "./soc/intel/intel_ish/utils/build_ish_firmware.py" = [
     "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
     "UP009",    # https://docs.astral.sh/ruff/rules/utf8-encoding-declaration
-]
-"./soc/mediatek/mtk_adsp/gen_img.py" = [
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
-    "SIM115",   # https://docs.astral.sh/ruff/rules/open-file-with-context-handler
-]
-"./soc/mediatek/mtk_adsp/mtk_adsp_load.py" = [
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
-    "SIM115",   # https://docs.astral.sh/ruff/rules/open-file-with-context-handler
 ]
 "./soc/microchip/mec/common/spigen/mec_spi_gen.py" = [
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
@@ -1465,11 +1462,11 @@ exclude = [
     "./doc/_extensions/zephyr/link-roles.py",
     "./doc/_scripts/gen_boards_catalog.py",
     "./doc/_scripts/gen_devicetree_rest.py",
-    "./doc/_scripts/gen_helpers.py",
     "./doc/_scripts/redirects.py",
     "./doc/conf.py",
     "./doc/develop/test/twister/sample_blackbox_test.py",
     "./modules/mbedtls/create_psa_files.py",
+    "./samples/boards/nordic/coresight_stm/pytest/test_stm.py",
     "./samples/modules/tflite-micro/magic_wand/train/data_augmentation.py",
     "./samples/modules/tflite-micro/magic_wand/train/data_augmentation_test.py",
     "./samples/modules/tflite-micro/magic_wand/train/data_load.py",
@@ -1770,8 +1767,6 @@ exclude = [
     "./soc/intel/intel_adsp/tools/cavstool_client.py",
     "./soc/intel/intel_adsp/tools/remote-fw-service.py",
     "./soc/intel/intel_ish/utils/build_ish_firmware.py",
-    "./soc/mediatek/mtk_adsp/gen_img.py",
-    "./soc/mediatek/mtk_adsp/mtk_adsp_load.py",
     "./soc/microchip/mec/common/spigen/mec_spi_gen.py",
     "./soc/nuvoton/npcm/common/esiost/esiost.py",
     "./soc/nuvoton/npcm/common/esiost/esiost_args.py",

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -22,7 +22,6 @@ select = [
 ignore = [
     # zephyr-keep-sorted-start
     "SIM108", # Allow if-else blocks instead of forcing ternary operator
-    "UP027",  # deprecated pyupgrade rule
     # zephyr-keep-sorted-stop
 ]
 

--- a/samples/boards/nordic/coresight_stm/pytest/test_stm.py
+++ b/samples/boards/nordic/coresight_stm/pytest/test_stm.py
@@ -122,11 +122,11 @@ def _nrfutil_dictionary_from_serial(
     BUILD_DIR = str(dut.device_config.build_dir)
     logger.debug(f"{BUILD_DIR=}")
     config_str = f"{STM_M_ID['app']}:{BUILD_DIR}/coresight_stm/zephyr/log_dictionary.json"
-    config_str = config_str + f",{STM_M_ID['rad']}:{BUILD_DIR}/remote_rad/zephyr/log_dictionary.json"
+    config_str += f",{STM_M_ID['rad']}:{BUILD_DIR}/remote_rad/zephyr/log_dictionary.json"
     if SB_CONFIG_APP_CPUPPR_RUN:
-        config_str = config_str + f",{STM_M_ID['ppr']}:{BUILD_DIR}/remote_ppr/zephyr/log_dictionary.json"
+        config_str += f",{STM_M_ID['ppr']}:{BUILD_DIR}/remote_ppr/zephyr/log_dictionary.json"
     if SB_CONFIG_APP_CPUFLPR_RUN:
-        config_str = config_str + f",{STM_M_ID['flpr']}:{BUILD_DIR}/remote_flpr/zephyr/log_dictionary.json"
+        config_str += f",{STM_M_ID['flpr']}:{BUILD_DIR}/remote_flpr/zephyr/log_dictionary.json"
     logger.debug(f"{config_str=}")
 
     cmd = (

--- a/scripts/requirements-compliance.txt
+++ b/scripts/requirements-compliance.txt
@@ -10,7 +10,7 @@ pykwalify
 pylint>=3
 python-magic
 python-magic-bin; sys_platform == "win32"
-ruff
+ruff==0.8.1
 sphinx-lint
 unidiff
 yamllint

--- a/scripts/west_commands/runners/teensy.py
+++ b/scripts/west_commands/runners/teensy.py
@@ -60,4 +60,4 @@ class TeensyBinaryRunner(ZephyrBinaryRunner):
             self.check_output(cmd)
             self.logger.info('Success')
         except subprocess.CalledProcessError as grepexc:
-            self.logger.error("Failure %i" % grepexc.returncode)
+            self.logger.error(f"Failure {grepexc.returncode}")


### PR DESCRIPTION
The ruff linter and formatter should get a locked version to be installed for compliance. This prevents new linter issues because of ruff updates itself.

Ruff version 0.8.0 removed the deprecated UP027 rule so it's removed from the ignore list.

Update the excludes file to match the actual reported issues.