### PR TITLE
Bluetooth: Mesh: Improve logic for serving devices erase capabilities

### DIFF
--- a/subsys/bluetooth/mesh/Kconfig
+++ b/subsys/bluetooth/mesh/Kconfig
@@ -1040,6 +1040,30 @@ config BT_MESH_BLOB_IO_FLASH
 	  Enable the BLOB flash stream for reading and writing BLOBs directly to
 	  and from flash.
 
+if BT_MESH_BLOB_IO_FLASH
+
+config BT_MESH_BLOB_IO_FLASH_WITHOUT_ERASE
+	bool "BLOB flash support for devices without erase"
+	default y if FLASH_HAS_NO_EXPLICIT_ERASE
+	depends on FLASH_HAS_NO_EXPLICIT_ERASE
+	help
+	  Enable path supporting devices without erase. This option appears only
+	  if there are devices without explicit erase requirements in the system
+	  and may be disabled to reduce code size in case when no operations
+	  are intended on such type of devices.
+
+config BT_MESH_BLOB_IO_FLASH_WITH_ERASE
+	bool "BLOB flash support for devices with erase"
+	default y if FLASH_HAS_EXPLICIT_ERASE
+	depends on FLASH_HAS_EXPLICIT_ERASE
+	help
+	  Enable path supporting devices with erase. This option appears only
+	  if there are devices requiring erase,  before write, in the system
+	  and may be disabled to reduce code size in case when no operations
+	  are intended on such type of devices.
+
+endif # BT_MESH_BLOB_IO_FLASH
+
 config BT_MESH_DFU_SRV
 	bool "Support for Firmware Update Server model"
 	depends on BT_MESH_MODEL_EXTENSIONS


### PR DESCRIPTION
The commit fixes issue where flash_area_flatten has been used where code was only supposed to erase devices by hardware requirement prior to write, by replacing the call with flash_area_erase and supporting logic to select proper path.
There have been following Kconfig options added:
 - CONFIG_BT_MESH_BLOB_IO_FLASH_WITHOUT_ERASE
 - CONFIG_BT_MESH_BLOB_IO_FLASH_WITH_ERASE
that are available for user depending on devices in the system and allow to turn off paths that are not used by BLOB IO; for example if user never writes to device with erase CONFIG_BT_MESH_BLOB_IO_FLASH_WITH_ERASE will disable the path.
Both Kconfig options are y by default and enable all paths.