### PR TITLE
hostap: wps: Enable PIN expiry timeout

### DIFF
--- a/modules/hostap/src/supp_api.c
+++ b/modules/hostap/src/supp_api.c
@@ -2405,6 +2405,7 @@ out:
 
 int supplicant_ap_wps_pin(const struct device *dev, struct wifi_wps_config_params *params)
 {
+#define WPS_PIN_EXPIRE_TIME 120
 	struct hostapd_iface *iface;
 	char *get_pin_cmd = "WPS_AP_PIN random";
 	int ret  = 0;
@@ -2433,7 +2434,7 @@ int supplicant_ap_wps_pin(const struct device *dev, struct wifi_wps_config_param
 			goto out;
 		}
 
-		if (!hostapd_cli_cmd_v("wps_pin any %s", params->pin)) {
+		if (!hostapd_cli_cmd_v("wps_pin any %s %d", params->pin, WPS_PIN_EXPIRE_TIME)) {
 			goto out;
 		}
 


### PR DESCRIPTION
Enable WPS PIN expire timeout parameter, this helps us in cleanup of
the Authorized MAC IE in the beacon in case no peer is connected
within the timeout.
Without this parameter the  IE is not removed from the beacon.