### PR TITLE
soc: nxp: imx*: remove redundant pinctrl defconfig

### DIFF
--- a/soc/nxp/imx/imx6sx/Kconfig.defconfig
+++ b/soc/nxp/imx/imx6sx/Kconfig.defconfig
@@ -9,10 +9,6 @@ config NUM_IRQS
 	# must be >= the highest interrupt number used
 	default 128
 
-config PINCTRL_IMX
-	default y if HAS_IMX_IOMUXC
-	depends on PINCTRL
-
 rsource "Kconfig.defconfig.*"
 
 endif # SOC_SERIES_IMX6SX

--- a/soc/nxp/imx/imx7d/Kconfig.defconfig
+++ b/soc/nxp/imx/imx7d/Kconfig.defconfig
@@ -9,10 +9,6 @@ config NUM_IRQS
 	# must be >= the highest interrupt number used
 	default 127
 
-config PINCTRL_IMX
-	default y if HAS_IMX_IOMUXC
-	depends on PINCTRL
-
 rsource "Kconfig.defconfig.*"
 
 endif # SOC_SERIES_IMX7D

--- a/soc/nxp/imx/imx8m/Kconfig.defconfig.mimx8ml8_a53
+++ b/soc/nxp/imx/imx8m/Kconfig.defconfig.mimx8ml8_a53
@@ -18,8 +18,4 @@ config NUM_IRQS
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default 8000000
 
-config PINCTRL_IMX
-	default y if HAS_MCUX_IOMUXC
-	depends on PINCTRL
-
 endif

--- a/soc/nxp/imx/imx8m/Kconfig.defconfig.mimx8ml8_m7
+++ b/soc/nxp/imx/imx8m/Kconfig.defconfig.mimx8ml8_m7
@@ -40,8 +40,4 @@ config NUM_IRQS
 	# must be >= the highest interrupt number used
 	default 159
 
-config PINCTRL_IMX
-	default y if HAS_MCUX_IOMUXC
-	depends on PINCTRL
-
 endif # SOC_MIMX8ML8_M7

--- a/soc/nxp/imx/imx8m/Kconfig.defconfig.mimx8mm6_a53
+++ b/soc/nxp/imx/imx8m/Kconfig.defconfig.mimx8mm6_a53
@@ -18,8 +18,4 @@ config NUM_IRQS
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default 8000000
 
-config PINCTRL_IMX
-	default y if HAS_MCUX_IOMUXC
-	depends on PINCTRL
-
 endif

--- a/soc/nxp/imx/imx8m/Kconfig.defconfig.mimx8mm6_m4
+++ b/soc/nxp/imx/imx8m/Kconfig.defconfig.mimx8mm6_m4
@@ -17,8 +17,4 @@ config NUM_IRQS
 	# must be >= the highest interrupt number used
 	default 127
 
-config PINCTRL_IMX
-	default y if HAS_MCUX_IOMUXC
-	depends on PINCTRL
-
 endif # SOC_MIMX8MM6_M4

--- a/soc/nxp/imx/imx8m/Kconfig.defconfig.mimx8mn6_a53
+++ b/soc/nxp/imx/imx8m/Kconfig.defconfig.mimx8mn6_a53
@@ -18,8 +18,4 @@ config NUM_IRQS
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default 8000000
 
-config PINCTRL_IMX
-	default y if HAS_MCUX_IOMUXC
-	depends on PINCTRL
-
 endif

--- a/soc/nxp/imx/imx8m/Kconfig.defconfig.mimx8mq6_m4
+++ b/soc/nxp/imx/imx8m/Kconfig.defconfig.mimx8mq6_m4
@@ -9,10 +9,6 @@ if SOC_MIMX8MQ6_M4
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default 266000000
 
-config PINCTRL_IMX
-	default y if HAS_MCUX_IOMUXC
-	depends on PINCTRL
-
 config NUM_IRQS
 	# must be >= the highest interrupt number used
 	default 127

--- a/soc/nxp/imx/imx9/imx93/Kconfig.defconfig.mimx93.a55
+++ b/soc/nxp/imx/imx9/imx93/Kconfig.defconfig.mimx93.a55
@@ -18,8 +18,4 @@ config NUM_IRQS
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default 24000000
 
-config PINCTRL_IMX
-	default y if HAS_MCUX_IOMUXC
-	depends on PINCTRL
-
 endif

--- a/soc/nxp/imxrt/Kconfig.defconfig
+++ b/soc/nxp/imxrt/Kconfig.defconfig
@@ -13,10 +13,6 @@ config ROM_START_OFFSET
 	default 0x400 if BOOTLOADER_MCUBOOT
 	default 0x2000 if BOOT_FLEXSPI_NOR || BOOT_SEMC_NOR
 
-config PINCTRL_IMX
-	default y if HAS_MCUX_IOMUXC
-	depends on PINCTRL
-
 config ADC_MCUX_12B1MSPS_SAR
 	default y if HAS_MCUX_12B1MSPS_SAR
 	depends on ADC


### PR DESCRIPTION
Many NXP socs had the following defconfig:

```
config PINCTRL_IMX
	default y if HAS_IMX_IOMUXC
	depends on PINCTRL
```

However, the PINCTRL_IMX option already has:

```
config PINCTRL_IMX
	bool "Pin controller driver for iMX MCUs"
	depends on DT_HAS_NXP_IMX_IOMUXC_ENABLED
	depends on HAS_MCUX_IOMUXC || HAS_IMX_IOMUXC
	default y
	help
	  Enable pin controller driver for NXP iMX series MCUs
```

So the soc level defconfigs are redundant.