### PR TITLE
scripts: twister: drop support for space-separated lists

### DIFF
--- a/doc/releases/release-notes-4.1.rst
+++ b/doc/releases/release-notes-4.1.rst
@@ -107,6 +107,11 @@ Boards & SoC Support
 Build system and Infrastructure
 *******************************
 
+* Space-separated lists support has been removed from Twister configuration
+  files. This feature was deprecated a long time ago. Projects that do still use
+  them can use the :zephyr_file:`scripts/utils/twister_to_list.py` script to
+  automatically migrate Twister configuration files.
+
 Drivers and Sensors
 *******************
 

--- a/samples/bluetooth/hci_usb_h4/sample.yaml
+++ b/samples/bluetooth/hci_usb_h4/sample.yaml
@@ -10,4 +10,6 @@ tests:
       - usb
       - bluetooth
     # FIXME: exclude due to build error
-    platform_exclude: 96b_carbon/stm32f401xe stm32l562e_dk
+    platform_exclude:
+      - 96b_carbon/stm32f401xe
+      - stm32l562e_dk

--- a/samples/boards/st/i2c_timing/sample.yaml
+++ b/samples/boards/st/i2c_timing/sample.yaml
@@ -7,7 +7,9 @@ tests:
       - drivers
       - i2c
     filter: dt_compat_enabled("st,stm32-i2c-v2")
-    platform_allow: nucleo_l476rg nucleo_wb55rg
+    platform_allow:
+      - nucleo_l476rg
+      - nucleo_wb55rg
     harness: console
     harness_config:
       type: one_line

--- a/samples/boards/st/mco/sample.yaml
+++ b/samples/boards/st/mco/sample.yaml
@@ -2,5 +2,7 @@ sample:
   name: STM32 microcontroller clock output (MCO) example
 tests:
   sample.board.stm32.mco:
-    platform_allow: nucleo_u5a5zj_q stm32f746g_disco
+    platform_allow:
+      - nucleo_u5a5zj_q
+      - stm32f746g_disco
     tags: board

--- a/samples/drivers/ethernet/eth_ivshmem/sample.yaml
+++ b/samples/drivers/ethernet/eth_ivshmem/sample.yaml
@@ -3,5 +3,7 @@ sample:
 tests:
   sample.drivers.ethernet.eth_ivshmem:
     platform_allow: qemu_cortex_a53
-    tags: drivers ethernet
+    tags:
+      - drivers
+      - ethernet
     build_only: true

--- a/samples/drivers/mbox/sample.yaml
+++ b/samples/drivers/mbox/sample.yaml
@@ -29,9 +29,9 @@ tests:
     integration_platforms:
       - nrf54h20dk/nrf54h20/cpuapp
     extra_args:
-      mbox_SNIPPET=nordic-ppr
-      mbox_EXTRA_DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_cpuppr.overlay"
-      SB_CONF_FILE=sysbuild/nrf54h20dk_nrf54h20_cpuppr.conf
+      - mbox_SNIPPET=nordic-ppr
+      - mbox_EXTRA_DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_cpuppr.overlay"
+      - SB_CONF_FILE=sysbuild/nrf54h20dk_nrf54h20_cpuppr.conf
     sysbuild: true
     harness: console
     harness_config:
@@ -47,9 +47,9 @@ tests:
     integration_platforms:
       - nrf54h20dk/nrf54h20/cpuapp
     extra_args:
-      mbox_SNIPPET=nordic-flpr
-      mbox_EXTRA_DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_cpuflpr.overlay"
-      SB_CONF_FILE=sysbuild/nrf54h20dk_nrf54h20_cpuflpr.conf
+      - mbox_SNIPPET=nordic-flpr
+      - mbox_EXTRA_DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_cpuflpr.overlay"
+      - SB_CONF_FILE=sysbuild/nrf54h20dk_nrf54h20_cpuflpr.conf
     sysbuild: true
     harness: console
     harness_config:
@@ -89,8 +89,7 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp
-    extra_args:
-      mbox_SNIPPET=nordic-flpr
+    extra_args: mbox_SNIPPET=nordic-flpr
     sysbuild: true
     harness: console
     harness_config:
@@ -106,9 +105,9 @@ tests:
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp
     extra_args:
-      mbox_SNIPPET=nordic-flpr
-      mbox_CONFIG_MULTITHREADING=n
-      remote_CONFIG_MULTITHREADING=n
+      - mbox_SNIPPET=nordic-flpr
+      - mbox_CONFIG_MULTITHREADING=n
+      - remote_CONFIG_MULTITHREADING=n
     sysbuild: true
     harness: console
     harness_config:
@@ -124,8 +123,8 @@ tests:
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp
     extra_args:
-      mbox_SNIPPET=nordic-flpr
-      remote_CONFIG_MULTITHREADING=n
+      - mbox_SNIPPET=nordic-flpr
+      - remote_CONFIG_MULTITHREADING=n
     sysbuild: true
     harness: console
     harness_config:

--- a/samples/drivers/mspi/mspi_async/sample.yaml
+++ b/samples/drivers/mspi/mspi_async/sample.yaml
@@ -5,7 +5,9 @@ tests:
     tags:
       - mspi
     filter: dt_compat_enabled("mspi-aps6404l")
-    platform_exclude: hifive_unmatched/fu740/s7 hifive_unmatched/fu740/u74
+    platform_exclude:
+      - hifive_unmatched/fu740/s7
+      - hifive_unmatched/fu740/u74
     harness: console
     harness_config:
       type: multi_line

--- a/samples/drivers/mspi/mspi_flash/sample.yaml
+++ b/samples/drivers/mspi/mspi_flash/sample.yaml
@@ -6,7 +6,9 @@ tests:
       - mspi
       - flash
     filter: dt_compat_enabled("jedec,spi-nor") or dt_compat_enabled("mspi-atxp032")
-    platform_exclude: hifive_unmatched/fu740/s7 hifive_unmatched/fu740/u74
+    platform_exclude:
+      - hifive_unmatched/fu740/s7
+      - hifive_unmatched/fu740/u74
     harness: console
     harness_config:
       type: multi_line

--- a/samples/drivers/spi_flash/sample.yaml
+++ b/samples/drivers/spi_flash/sample.yaml
@@ -8,7 +8,9 @@ tests:
     filter: dt_compat_enabled("jedec,spi-nor") or dt_compat_enabled("st,stm32-qspi-nor")
       or dt_compat_enabled("st,stm32-ospi-nor") or dt_compat_enabled("st,stm32-xspi-nor")
       or (dt_compat_enabled("nordic,qspi-nor") and CONFIG_NORDIC_QSPI_NOR)
-    platform_exclude: hifive_unmatched/fu740/s7 hifive_unmatched/fu740/u74
+    platform_exclude:
+      - hifive_unmatched/fu740/s7
+      - hifive_unmatched/fu740/u74
     harness: console
     harness_config:
       type: multi_line

--- a/samples/kernel/bootargs/sample.yaml
+++ b/samples/kernel/bootargs/sample.yaml
@@ -3,7 +3,9 @@ sample:
 tests:
   sample.kernel.bootargs.multiboot:
     extra_args: EXTRA_CONF_FILE=prj_multiboot.conf
-    platform_allow: qemu_x86 qemu_x86_64
+    platform_allow:
+      - qemu_x86
+      - qemu_x86_64
     harness: console
     harness_config:
       type: one_line

--- a/samples/modules/canopennode/sample.yaml
+++ b/samples/modules/canopennode/sample.yaml
@@ -25,8 +25,8 @@ tests:
     integration_platforms:
       - frdm_k64f
     extra_args:
-      canopennode_CONF_FILE=prj_img_mgmt.conf
-      SB_CONFIG_BOOTLOADER_MCUBOOT=y
 
+      - canopennode_CONF_FILE=prj_img_mgmt.conf
+      - SB_CONFIG_BOOTLOADER_MCUBOOT=y
   sample.modules.canopennode.no_storage:
     extra_args: CONF_FILE=prj_no_storage.conf

--- a/samples/net/cellular_modem/sample.yaml
+++ b/samples/net/cellular_modem/sample.yaml
@@ -2,10 +2,14 @@ sample:
   description: Sample for cellular modem
   name: Sample for cellular modem using native networking
 common:
-  tags: cellular modem
+  tags:
+    - cellular
+    - modem
 tests:
   sample.net.cellular_modem:
-    tags: cellular modem
+    tags:
+      - cellular
+      - modem
     filter: dt_alias_exists("modem")
     platform_allow:
       - b_u585i_iot02a

--- a/samples/net/cloud/aws_iot_mqtt/sample.yaml
+++ b/samples/net/cloud/aws_iot_mqtt/sample.yaml
@@ -2,13 +2,18 @@ sample:
   description: MQTT sample app to AWS IoT Core
   name: aws_iot_mqtt
 common:
-  tags: net mqtt cloud
+  tags:
+    - net
+    - mqtt
+    - cloud
   harness: net
   filter: CONFIG_FULL_LIBC_SUPPORTED and not CONFIG_NATIVE_LIBC
   extra_args: USE_DUMMY_CREDS=1
 tests:
   sample.net.cloud.aws_iot_mqtt:
     depends_on: netif
-    platform_allow: qemu_x86 nucleo_f429zi
+    platform_allow:
+      - qemu_x86
+      - nucleo_f429zi
     integration_platforms:
       - qemu_x86

--- a/samples/net/wpan_serial/sample.yaml
+++ b/samples/net/wpan_serial/sample.yaml
@@ -4,13 +4,17 @@ sample:
 common:
   depends_on: usb_device
   harness: net
-  tags: usb ieee802154
+  tags:
+    - usb
+    - ieee802154
   platform_exclude: pinnacle_100_dvk
 tests:
   sample.net.wpan.serial:
     filter: dt_chosen_enabled("zephyr,ieee802154")
-    platform_exclude: thingy53/nrf5340/cpuapp/ns raytac_mdbt53_db_40/nrf5340/cpuapp/ns
-                      raytac_mdbt53_db_40/nrf5340/cpuapp
+    platform_exclude:
+      - thingy53/nrf5340/cpuapp/ns
+      - raytac_mdbt53_db_40/nrf5340/cpuapp/ns
+      - raytac_mdbt53_db_40/nrf5340/cpuapp
   sample.net.wpan_serial.frdm_cr20a:
     extra_args: SHIELD=frdm_cr20a
     platform_allow: frdm_k64f

--- a/samples/net/zperf/sample.yaml
+++ b/samples/net/zperf/sample.yaml
@@ -48,17 +48,29 @@ tests:
       - native_sim/native/64
   sample.net.zperf.device_next_ecm:
     harness: net
-    extra_args: EXTRA_CONF_FILE="overlay-usbd_next.conf"
-                DTC_OVERLAY_FILE="usbd_next_ecm.overlay"
-    platform_allow: nrf52840dk/nrf52840 frdm_k64f
-    tags: usb net zperf
+    extra_args:
+      - EXTRA_CONF_FILE="overlay-usbd_next.conf"
+      - DTC_OVERLAY_FILE="usbd_next_ecm.overlay"
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - frdm_k64f
+    tags:
+      - usb
+      - net
+      - zperf
     depends_on: usb_device
   sample.net.zperf.device_next_ncm:
     harness: net
-    extra_args: EXTRA_CONF_FILE="overlay-usbd_next.conf"
-                DTC_OVERLAY_FILE="usbd_next_ncm.overlay"
-    platform_allow: nrf52840dk/nrf52840 frdm_k64f
-    tags: usb net zperf
+    extra_args:
+      - EXTRA_CONF_FILE="overlay-usbd_next.conf"
+      - DTC_OVERLAY_FILE="usbd_next_ncm.overlay"
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - frdm_k64f
+    tags:
+      - usb
+      - net
+      - zperf
     depends_on: usb_device
   sample.net.zperf.netusb_eem:
     harness: net

--- a/samples/posix/env/sample.yaml
+++ b/samples/posix/env/sample.yaml
@@ -2,7 +2,9 @@ sample:
   description: posix env sample
   name: posix env
 common:
-  tags: posix env
+  tags:
+    - posix
+    - env
   platform_exclude:
     - native_posix
     - native_posix/native/64

--- a/samples/sensor/amg88xx/sample.yaml
+++ b/samples/sensor/amg88xx/sample.yaml
@@ -6,8 +6,14 @@ sample:
 tests:
   sample.sensor.amg88xx.amg88xx_grid_eye_eval_shield:
     build_only: true
-    depends_on: arduino_i2c arduino_gpio
-    platform_allow: pan1780_evb pan1770_evb pan1781_evb pan1782_evb
+    depends_on:
+      - arduino_i2c
+      - arduino_gpio
+    platform_allow:
+      - pan1780_evb
+      - pan1770_evb
+      - pan1781_evb
+      - pan1782_evb
     integration_platforms:
       - pan1780_evb
     extra_args: SHIELD=amg88xx_grid_eye_eval_shield

--- a/samples/sensor/co2_polling/sample.yaml
+++ b/samples/sensor/co2_polling/sample.yaml
@@ -5,4 +5,6 @@ tests:
     harness: sensor
     tags: sensors
     filter: dt_alias_exists("co2")
-    depends_on: serial uart_interrupt_driven
+    depends_on:
+      - serial
+      - uart_interrupt_driven

--- a/samples/sensor/veaa_x_3/sample.yaml
+++ b/samples/sensor/veaa_x_3/sample.yaml
@@ -5,4 +5,6 @@ tests:
     harness: sensor
     tags: sensors
     filter: dt_compat_enabled("festo,veaa-x-3")
-    depends_on: adc dac
+    depends_on:
+      - adc
+      - dac

--- a/samples/shields/x_nucleo_iks4a1/sensorhub1/sample.yaml
+++ b/samples/shields/x_nucleo_iks4a1/sensorhub1/sample.yaml
@@ -4,7 +4,9 @@ tests:
   sample.shields.x_nucleo_iks4a1.sensorhub1:
     harness: shield
     tags: shield
-    depends_on: arduino_i2c arduino_gpio
+    depends_on:
+      - arduino_i2c
+      - arduino_gpio
     platform_exclude:
       - disco_l475_iot1
       - lpcxpresso55s16

--- a/samples/shields/x_nucleo_iks4a1/sensorhub2/sample.yaml
+++ b/samples/shields/x_nucleo_iks4a1/sensorhub2/sample.yaml
@@ -4,7 +4,9 @@ tests:
   sample.shields.x_nucleo_iks4a1.sensorhub2:
     harness: shield
     tags: shield
-    depends_on: arduino_i2c arduino_gpio
+    depends_on:
+      - arduino_i2c
+      - arduino_gpio
     platform_exclude:
       - disco_l475_iot1
       - lpcxpresso55s16

--- a/samples/shields/x_nucleo_iks4a1/standard/sample.yaml
+++ b/samples/shields/x_nucleo_iks4a1/standard/sample.yaml
@@ -6,7 +6,9 @@ tests:
   sample.shields.x_nucleo_iks4a1.standard:
     harness: shield
     tags: shield
-    depends_on: arduino_i2c arduino_gpio
+    depends_on:
+      - arduino_i2c
+      - arduino_gpio
     platform_exclude:
       - disco_l475_iot1
       - lpcxpresso55s16

--- a/samples/subsys/dap/sample.yaml
+++ b/samples/subsys/dap/sample.yaml
@@ -3,7 +3,9 @@ sample:
 tests:
   sample.dap.bulk:
     build_only: true
-    depends_on: arduino_gpio usb_device
+    depends_on:
+      - arduino_gpio
+      - usb_device
     platform_allow:
       - nrf52840dk/nrf52840
       - frdm_k64f

--- a/samples/subsys/fs/fs_sample/sample.yaml
+++ b/samples/subsys/fs/fs_sample/sample.yaml
@@ -73,7 +73,9 @@ tests:
     simulation_exclude:
       - renode
     extra_args: CONF_FILE="prj_ext.conf"
-    platform_allow: hifive_unmatched/fu740/s7 bl5340_dvk/nrf5340/cpuapp
+    platform_allow:
+      - hifive_unmatched/fu740/s7
+      - bl5340_dvk/nrf5340/cpuapp
   sample.filesystem.fat_fs.stm32h747i_disco_m7_sdmmc:
     build_only: true
     platform_allow: stm32h747i_disco/stm32h747xx/m7

--- a/samples/subsys/ipc/ipc_service/icmsg/sample.yaml
+++ b/samples/subsys/ipc/ipc_service/icmsg/sample.yaml
@@ -29,8 +29,7 @@ tests:
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp
     tags: ipc
-    extra_args:
-      icmsg_SNIPPET=nordic-flpr
+    extra_args: icmsg_SNIPPET=nordic-flpr
     sysbuild: true
     harness: console
     harness_config:
@@ -50,11 +49,11 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
     tags: ipc
     extra_args:
-      icmsg_SNIPPET=nordic-flpr
-      icmsg_CONFIG_MULTITHREADING=n
-      icmsg_CONFIG_LOG_MODE_MINIMAL=y
-      remote_CONFIG_MULTITHREADING=n
-      remote_CONFIG_LOG_MODE_MINIMAL=y
+      - icmsg_SNIPPET=nordic-flpr
+      - icmsg_CONFIG_MULTITHREADING=n
+      - icmsg_CONFIG_LOG_MODE_MINIMAL=y
+      - remote_CONFIG_MULTITHREADING=n
+      - remote_CONFIG_LOG_MODE_MINIMAL=y
     sysbuild: true
     harness: console
     harness_config:
@@ -74,9 +73,9 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
     tags: ipc
     extra_args:
-      icmsg_SNIPPET=nordic-flpr
-      remote_CONFIG_MULTITHREADING=n
-      remote_CONFIG_LOG_MODE_MINIMAL=y
+      - icmsg_SNIPPET=nordic-flpr
+      - remote_CONFIG_MULTITHREADING=n
+      - remote_CONFIG_LOG_MODE_MINIMAL=y
     sysbuild: true
     harness: console
     harness_config:
@@ -96,11 +95,11 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
     tags: ipc
     extra_args:
-      icmsg_SNIPPET=nordic-flpr
-      icmsg_CONFIG_IPC_SERVICE_BACKEND_ICBMSG_NUM_EP=1
-      icmsg_DTC_OVERLAY_FILE="boards/nrf54l15dk_nrf54l15_cpuapp_icbmsg.overlay"
-      remote_CONFIG_IPC_SERVICE_BACKEND_ICBMSG_NUM_EP=1
-      remote_DTC_OVERLAY_FILE="boards/nrf54l15dk_nrf54l15_cpuflpr_icbmsg.overlay"
+      - icmsg_SNIPPET=nordic-flpr
+      - icmsg_CONFIG_IPC_SERVICE_BACKEND_ICBMSG_NUM_EP=1
+      - icmsg_DTC_OVERLAY_FILE="boards/nrf54l15dk_nrf54l15_cpuapp_icbmsg.overlay"
+      - remote_CONFIG_IPC_SERVICE_BACKEND_ICBMSG_NUM_EP=1
+      - remote_DTC_OVERLAY_FILE="boards/nrf54l15dk_nrf54l15_cpuflpr_icbmsg.overlay"
     sysbuild: true
     harness: console
     harness_config:
@@ -120,15 +119,15 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
     tags: ipc
     extra_args:
-      icmsg_SNIPPET=nordic-flpr
-      icmsg_CONFIG_IPC_SERVICE_BACKEND_ICBMSG_NUM_EP=1
-      icmsg_DTC_OVERLAY_FILE="boards/nrf54l15dk_nrf54l15_cpuapp_icbmsg.overlay"
-      icmsg_CONFIG_MULTITHREADING=n
-      icmsg_CONFIG_LOG_MODE_MINIMAL=y
-      remote_CONFIG_IPC_SERVICE_BACKEND_ICBMSG_NUM_EP=1
-      remote_DTC_OVERLAY_FILE="boards/nrf54l15dk_nrf54l15_cpuflpr_icbmsg.overlay"
-      remote_CONFIG_MULTITHREADING=n
-      remote_CONFIG_LOG_MODE_MINIMAL=y
+      - icmsg_SNIPPET=nordic-flpr
+      - icmsg_CONFIG_IPC_SERVICE_BACKEND_ICBMSG_NUM_EP=1
+      - icmsg_DTC_OVERLAY_FILE="boards/nrf54l15dk_nrf54l15_cpuapp_icbmsg.overlay"
+      - icmsg_CONFIG_MULTITHREADING=n
+      - icmsg_CONFIG_LOG_MODE_MINIMAL=y
+      - remote_CONFIG_IPC_SERVICE_BACKEND_ICBMSG_NUM_EP=1
+      - remote_DTC_OVERLAY_FILE="boards/nrf54l15dk_nrf54l15_cpuflpr_icbmsg.overlay"
+      - remote_CONFIG_MULTITHREADING=n
+      - remote_CONFIG_LOG_MODE_MINIMAL=y
     sysbuild: true
     harness: console
     harness_config:
@@ -148,13 +147,13 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
     tags: ipc
     extra_args:
-      icmsg_SNIPPET=nordic-flpr
-      icmsg_CONFIG_IPC_SERVICE_BACKEND_ICBMSG_NUM_EP=1
-      icmsg_DTC_OVERLAY_FILE="boards/nrf54l15dk_nrf54l15_cpuapp_icbmsg.overlay"
-      remote_CONFIG_IPC_SERVICE_BACKEND_ICBMSG_NUM_EP=1
-      remote_DTC_OVERLAY_FILE="boards/nrf54l15dk_nrf54l15_cpuflpr_icbmsg.overlay"
-      remote_CONFIG_MULTITHREADING=n
-      remote_CONFIG_LOG_MODE_MINIMAL=y
+      - icmsg_SNIPPET=nordic-flpr
+      - icmsg_CONFIG_IPC_SERVICE_BACKEND_ICBMSG_NUM_EP=1
+      - icmsg_DTC_OVERLAY_FILE="boards/nrf54l15dk_nrf54l15_cpuapp_icbmsg.overlay"
+      - remote_CONFIG_IPC_SERVICE_BACKEND_ICBMSG_NUM_EP=1
+      - remote_DTC_OVERLAY_FILE="boards/nrf54l15dk_nrf54l15_cpuflpr_icbmsg.overlay"
+      - remote_CONFIG_MULTITHREADING=n
+      - remote_CONFIG_LOG_MODE_MINIMAL=y
     sysbuild: true
     harness: console
     harness_config:

--- a/samples/subsys/ipc/ipc_service/multi_endpoint/sample.yaml
+++ b/samples/subsys/ipc/ipc_service/multi_endpoint/sample.yaml
@@ -32,5 +32,5 @@ tests:
     tags: ipc
     sysbuild: true
     extra_args:
-      DTC_OVERLAY_FILE=boards/nrf5340dk_nrf5340_cpuapp_icbmsg.overlay
-      remote_DTC_OVERLAY_FILE=boards/nrf5340dk_nrf5340_cpunet_icbmsg.overlay
+      - DTC_OVERLAY_FILE=boards/nrf5340dk_nrf5340_cpuapp_icbmsg.overlay
+      - remote_DTC_OVERLAY_FILE=boards/nrf5340dk_nrf5340_cpunet_icbmsg.overlay

--- a/samples/subsys/llext/edk/app/sample.yaml
+++ b/samples/subsys/llext/edk/app/sample.yaml
@@ -1,5 +1,7 @@
 common:
-  tags: llext edk
+  tags:
+    - llext
+    - edk
   arch_allow:
     - arm
   filter: CONFIG_ARCH_HAS_USERSPACE
@@ -9,4 +11,6 @@ sample:
 tests:
   sample.edk.app:
     build_only: true
-    tags: edk llext
+    tags:
+      - edk
+      - llext

--- a/samples/subsys/llext/shell_loader/sample.yaml
+++ b/samples/subsys/llext/shell_loader/sample.yaml
@@ -1,5 +1,7 @@
 common:
-  tags: shell llext
+  tags:
+    - shell
+    - llext
   arch_allow:
     - arm
     - xtensa

--- a/samples/subsys/mgmt/mcumgr/smp_svr/sample.yaml
+++ b/samples/subsys/mgmt/mcumgr/smp_svr/sample.yaml
@@ -172,15 +172,17 @@ tests:
     integration_platforms:
       - nrf52840dk/nrf52840
   sample.mcumgr.smp_svr.ram_load.serial:
-    extra_args: FILE_SUFFIX="ram_load"
-                EXTRA_CONF_FILE="overlay-serial.conf"
+    extra_args:
+      - FILE_SUFFIX="ram_load"
+      - EXTRA_CONF_FILE="overlay-serial.conf"
     platform_allow:
       - nrf52840dk/nrf52840
     integration_platforms:
       - nrf52840dk/nrf52840
   sample.mcumgr.smp_svr.ram_load.serial.fs.shell:
-    extra_args: FILE_SUFFIX="ram_load"
-                EXTRA_CONF_FILE="overlay-serial.conf;overlay-fs.conf;overlay-shell.conf"
+    extra_args:
+      - FILE_SUFFIX="ram_load"
+      - EXTRA_CONF_FILE="overlay-serial.conf;overlay-fs.conf;overlay-shell.conf"
     platform_allow:
       - nrf52840dk/nrf52840
     integration_platforms:

--- a/samples/subsys/usb/uac2_explicit_feedback/sample.yaml
+++ b/samples/subsys/usb/uac2_explicit_feedback/sample.yaml
@@ -5,6 +5,8 @@ tests:
     depends_on:
       - usbd
       - i2s
-    tags: usb i2s
+    tags:
+      - usb
+      - i2s
     platform_allow: nrf5340dk/nrf5340/cpuapp
     harness: TBD

--- a/samples/subsys/usb/uac2_implicit_feedback/sample.yaml
+++ b/samples/subsys/usb/uac2_implicit_feedback/sample.yaml
@@ -5,6 +5,8 @@ tests:
     depends_on:
       - usbd
       - i2s
-    tags: usb i2s
+    tags:
+      - usb
+      - i2s
     platform_allow: nrf5340dk/nrf5340/cpuapp
     harness: TBD

--- a/samples/sysbuild/hello_world/sample.yaml
+++ b/samples/sysbuild/hello_world/sample.yaml
@@ -18,16 +18,14 @@ tests:
       - nrf5340dk/nrf5340/cpuapp
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp
-    extra_args:
-      SB_CONF_FILE=sysbuild/nrf5340dk_nrf5340_cpunet.conf
+    extra_args: SB_CONF_FILE=sysbuild/nrf5340dk_nrf5340_cpunet.conf
 
   sample.sysbuild.hello_world.nrf54h20dk_cpuapp_cpurad:
     platform_allow:
       - nrf54h20dk/nrf54h20/cpuapp
     integration_platforms:
       - nrf54h20dk/nrf54h20/cpuapp
-    extra_args:
-      SB_CONF_FILE=sysbuild/nrf54h20dk_nrf54h20_cpurad.conf
+    extra_args: SB_CONF_FILE=sysbuild/nrf54h20dk_nrf54h20_cpurad.conf
 
   sample.sysbuild.hello_world.nrf54h20dk_cpuapp_cpuppr:
     platform_allow:
@@ -35,41 +33,41 @@ tests:
     integration_platforms:
       - nrf54h20dk/nrf54h20/cpuapp
     extra_args:
-      SB_CONF_FILE=sysbuild/nrf54h20dk_nrf54h20_cpuppr.conf
-      hello_world_SNIPPET=nordic-ppr
 
+      - SB_CONF_FILE=sysbuild/nrf54h20dk_nrf54h20_cpuppr.conf
+      - hello_world_SNIPPET=nordic-ppr
   sample.sysbuild.hello_world.nrf54h20dk_cpuapp_cpuppr_xip:
     platform_allow:
       - nrf54h20dk/nrf54h20/cpuapp
     integration_platforms:
       - nrf54h20dk/nrf54h20/cpuapp
     extra_args:
-      SB_CONF_FILE=sysbuild/nrf54h20dk_nrf54h20_cpuppr_xip.conf
-      hello_world_SNIPPET=nordic-ppr-xip
 
+      - SB_CONF_FILE=sysbuild/nrf54h20dk_nrf54h20_cpuppr_xip.conf
+      - hello_world_SNIPPET=nordic-ppr-xip
   sample.sysbuild.hello_world.nrf54l15dk_nrf54l15_cpuflpr:
     platform_allow:
       - nrf54l15dk/nrf54l15/cpuapp
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp
     extra_args:
-      SB_CONF_FILE=sysbuild/nrf54l15dk_nrf54l15_cpuflpr.conf
-      hello_world_SNIPPET=nordic-flpr
 
+      - SB_CONF_FILE=sysbuild/nrf54l15dk_nrf54l15_cpuflpr.conf
+      - hello_world_SNIPPET=nordic-flpr
   sample.sysbuild.hello_world.nrf54h20dk_cpuapp_cpuflpr:
     platform_allow:
       - nrf54h20dk/nrf54h20/cpuapp
     integration_platforms:
       - nrf54h20dk/nrf54h20/cpuapp
     extra_args:
-      SB_CONF_FILE=sysbuild/nrf54h20dk_nrf54h20_cpuflpr.conf
-      hello_world_SNIPPET=nordic-flpr
 
+      - SB_CONF_FILE=sysbuild/nrf54h20dk_nrf54h20_cpuflpr.conf
+      - hello_world_SNIPPET=nordic-flpr
   sample.sysbuild.hello_world.nrf54h20dk_cpuapp_cpuflpr_xip:
     platform_allow:
       - nrf54h20dk/nrf54h20/cpuapp
     integration_platforms:
       - nrf54h20dk/nrf54h20/cpuapp
     extra_args:
-      SB_CONF_FILE=sysbuild/nrf54h20dk_nrf54h20_cpuflpr_xip.conf
-      hello_world_SNIPPET=nordic-flpr-xip
+      - SB_CONF_FILE=sysbuild/nrf54h20dk_nrf54h20_cpuflpr_xip.conf
+      - hello_world_SNIPPET=nordic-flpr-xip

--- a/scripts/tests/twister/test_config_parser.py
+++ b/scripts/tests/twister/test_config_parser.py
@@ -141,12 +141,10 @@ def test_default_values(zephyr_base):
         ('key: val', 'map', 'key: val', None),   # do-nothing cast
         ('test', 'int', ValueError, None),
         ('test', 'unknown', ConfigurationError, None),
-        ('1 2 2 3', 'list', ['1', '2', '2','3'], ('Space-separated lists are deprecated, use YAML lists instead', DeprecationWarning)),
-        ('1 2 2 3', 'set', {'1', '2', '3'}, ('Space-separated lists are deprecated, use YAML lists instead', DeprecationWarning)),
         ([ '1', '2', '3' ], 'set', { '1', '2', '2','3' }, None),
     ],
     ids=['str to str', 'str to float', 'str to int', 'str to bool', 'str to map',
-         'invalid', 'to unknown', "str to list", "str to set", "list to set"]
+         'invalid', 'to unknown', "list to set"]
 )
 
 def test_cast_value(zephyr_base, value, typestr, expected, expected_warning):

--- a/tests/arch/riscv/fatal/testcase.yaml
+++ b/tests/arch/riscv/fatal/testcase.yaml
@@ -2,7 +2,9 @@ common:
   ignore_faults: true
   harness: console
   ignore_qemu_crash: true
-  tags: kernel riscv
+  tags:
+    - kernel
+    - riscv
   platform_allow:
     - qemu_riscv64
 tests:

--- a/tests/arch/riscv/userspace/riscv_gp/testcase.yaml
+++ b/tests/arch/riscv/userspace/riscv_gp/testcase.yaml
@@ -1,7 +1,9 @@
 common:
   ignore_faults: true
   ignore_qemu_crash: true
-  tags: kernel riscv
+  tags:
+    - kernel
+    - riscv
   platform_allow:
     - qemu_riscv64/qemu_virt_riscv64/smp
 tests:

--- a/tests/boards/nrf/i2c/i2c_slave/testcase.yaml
+++ b/tests/boards/nrf/i2c/i2c_slave/testcase.yaml
@@ -1,7 +1,9 @@
 tests:
   boards.nrf.i2c.i2c_slave:
     depends_on: i2c
-    tags: drivers i2c
+    tags:
+      - drivers
+      - i2c
     harness: ztest
     harness_config:
       fixture: i2c_loopback

--- a/tests/cmake/zephyr_get/testcase.yaml
+++ b/tests/cmake/zephyr_get/testcase.yaml
@@ -7,5 +7,6 @@ tests:
     sysbuild: false
   buildsystem.extensions.zephyr_get.sysbuild:
     sysbuild: true
-    extra_args: TESTCASE_VARIABLE="sysbuild.main"
-      zephyr_get_2nd_TESTCASE_VARIABLE="sysbuild.2nd"
+    extra_args:
+      - TESTCASE_VARIABLE="sysbuild.main"
+      - zephyr_get_2nd_TESTCASE_VARIABLE="sysbuild.2nd"

--- a/tests/drivers/adc/adc_rescale/testcase.yaml
+++ b/tests/drivers/adc/adc_rescale/testcase.yaml
@@ -1,5 +1,8 @@
 common:
-  tags: adc drivers userspace
+  tags:
+    - adc
+    - drivers
+    - userspace
 tests:
   drivers.adc.rescale:
     depends_on: adc

--- a/tests/drivers/build_all/gpio/testcase.yaml
+++ b/tests/drivers/build_all/gpio/testcase.yaml
@@ -20,7 +20,9 @@ tests:
 
   drivers.gpio.build.altera_pio:
     min_ram: 32
-    platform_allow: niosv_m niosv_g
+    platform_allow:
+      - niosv_m
+      - niosv_g
     depends_on: gpio
     extra_args: DTC_OVERLAY_FILE="altera.overlay"
 

--- a/tests/drivers/charger/sbs_charger/testcase.yaml
+++ b/tests/drivers/charger/sbs_charger/testcase.yaml
@@ -10,8 +10,8 @@ tests:
   drivers.charger.sbs.emulated:
     filter: dt_compat_enabled("sbs,sbs-charger")
     extra_args:
-      CONF_FILE="prj.conf;boards/emulated_board.conf"
-      DTC_OVERLAY_FILE="boards/emulated_board.overlay"
+      - CONF_FILE="prj.conf;boards/emulated_board.conf"
+      - DTC_OVERLAY_FILE="boards/emulated_board.overlay"
     platform_exclude:
       - qemu_cortex_a53
       - qemu_cortex_a53/qemu_cortex_a53/smp
@@ -34,5 +34,5 @@ tests:
     integration_platforms:
       - qemu_cortex_a53
     extra_args:
-      CONF_FILE="prj.conf;boards/qemu_cortex_a53.conf"
-      DTC_OVERLAY_FILE="boards/qemu_cortex_a53.overlay"
+      - CONF_FILE="prj.conf;boards/qemu_cortex_a53.conf"
+      - DTC_OVERLAY_FILE="boards/qemu_cortex_a53.overlay"

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32wba_core/testcase.yaml
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32wba_core/testcase.yaml
@@ -1,6 +1,8 @@
 common:
   timeout: 5
-  platform_allow: nucleo_wba52cg nucleo_wba55cg
+  platform_allow:
+    - nucleo_wba52cg
+    - nucleo_wba55cg
 tests:
   drivers.clock.stm32_clock_configuration.wba.sysclksrc_hsi_16:
     extra_args: DTC_OVERLAY_FILE="boards/clear_clocks.overlay;boards/hsi_16.overlay"

--- a/tests/drivers/console/line_splitting/testcase.yaml
+++ b/tests/drivers/console/line_splitting/testcase.yaml
@@ -2,7 +2,9 @@ common:
   tags:
     - drivers
     - console
-  platform_allow: hifive1 hifive_unleashed/fu540/e51
+  platform_allow:
+    - hifive1
+    - hifive_unleashed/fu540/e51
   harness: robot
 
 tests:

--- a/tests/drivers/flash_api/testcase.yaml
+++ b/tests/drivers/flash_api/testcase.yaml
@@ -9,8 +9,13 @@ common:
     - native_sim
 tests:
   drivers.flash.api:
-    tags: drivers flash
+    tags:
+      - drivers
+      - flash
   drivers.flash.api.userspace:
-    tags: driver flash userspace
+    tags:
+      - driver
+      - flash
+      - userspace
     extra_configs:
       - CONFIG_USERSPACE=y

--- a/tests/drivers/flash_simulator/flash_sim_impl/testcase.yaml
+++ b/tests/drivers/flash_simulator/flash_sim_impl/testcase.yaml
@@ -31,11 +31,15 @@ tests:
       - qemu_x86
   drivers.flash.flash_simulator.native_erase_value_0x00:
     extra_args: DTC_OVERLAY_FILE=boards/native_ev_0x00.overlay
-    platform_allow: native_posix native_sim
+    platform_allow:
+      - native_posix
+      - native_sim
     integration_platforms:
       - native_sim
   drivers.flash.flash_simulator.native_64_erase_value_0x00:
     extra_args: DTC_OVERLAY_FILE=boards/native_64_ev_0x00.overlay
-    platform_allow: native_posix/native/64 native_sim/native/64
+    platform_allow:
+      - native_posix/native/64
+      - native_sim/native/64
     integration_platforms:
       - native_sim/native/64

--- a/tests/drivers/gpio/gpio_nrf/testcase.yaml
+++ b/tests/drivers/gpio/gpio_nrf/testcase.yaml
@@ -1,5 +1,7 @@
 common:
-  tags: drivers gpio
+  tags:
+    - drivers
+    - gpio
   depends_on: gpio
   harness: ztest
 tests:

--- a/tests/drivers/gpio/gpio_reserved_ranges/testcase.yaml
+++ b/tests/drivers/gpio/gpio_reserved_ranges/testcase.yaml
@@ -1,6 +1,8 @@
 tests:
   drivers.gpio.reserved_ranges:
-    tags: drivers gpio
+    tags:
+      - drivers
+      - gpio
     depends_on: gpio
     filter: dt_compat_enabled("test-gpio-reserved-ranges")
     platform_allow:

--- a/tests/drivers/i2c/i2c_bme688/testcase.yaml
+++ b/tests/drivers/i2c/i2c_bme688/testcase.yaml
@@ -1,5 +1,7 @@
 common:
-  tags: drivers i2c
+  tags:
+    - drivers
+    - i2c
   depends_on: i2c
 tests:
   drivers.i2c.bme688:

--- a/tests/drivers/mbox/mbox_error_cases/sample.yaml
+++ b/tests/drivers/mbox/mbox_error_cases/sample.yaml
@@ -1,7 +1,9 @@
 sample:
   name: MBOX IPC negative test cases
 common:
-  tags: drivers mbox
+  tags:
+    - drivers
+    - mbox
   harness: ztest
 tests:
 

--- a/tests/drivers/spi/spi_controller_peripheral/testcase.yaml
+++ b/tests/drivers/spi/spi_controller_peripheral/testcase.yaml
@@ -1,6 +1,8 @@
 common:
   depends_on: spi
-  tags: drivers spi
+  tags:
+    - drivers
+    - spi
   harness: ztest
   harness_config:
     fixture: gpio_spi_loopback

--- a/tests/drivers/spi/spi_error_cases/testcase.yaml
+++ b/tests/drivers/spi/spi_error_cases/testcase.yaml
@@ -1,6 +1,8 @@
 common:
   depends_on: spi
-  tags: drivers spi
+  tags:
+    - drivers
+    - spi
   harness: ztest
   harness_config:
     fixture: gpio_spi_loopback

--- a/tests/drivers/uart/uart_async_rx/testcase.yaml
+++ b/tests/drivers/uart/uart_async_rx/testcase.yaml
@@ -1,11 +1,15 @@
 tests:
   drivers.uart.async_rx:
     filter: CONFIG_SERIAL_HAS_DRIVER
-    tags: drivers uart
+    tags:
+      - drivers
+      - uart
     integration_platforms:
       - native_sim
   drivers.uart.async_rx.ztress:
-    tags: drivers uart
+    tags:
+      - drivers
+      - uart
     platform_allow:
       - qemu_cortex_m3
       - qemu_x86

--- a/tests/drivers/uart/uart_basic_api/testcase.yaml
+++ b/tests/drivers/uart/uart_basic_api/testcase.yaml
@@ -10,7 +10,9 @@ tests:
   drivers.uart.basic_api.wide:
     extra_configs:
       - CONFIG_UART_WIDE_DATA=y
-    tags: drivers uart
+    tags:
+      - drivers
+      - uart
     filter: CONFIG_UART_CONSOLE
     harness: keyboard
     arch_allow: arm

--- a/tests/drivers/uart/uart_elementary/testcase.yaml
+++ b/tests/drivers/uart/uart_elementary/testcase.yaml
@@ -1,5 +1,7 @@
 common:
-  tags: drivers uart
+  tags:
+    - drivers
+    - uart
   depends_on: gpio
   harness: ztest
   harness_config:

--- a/tests/drivers/uart/uart_errors/testcase.yaml
+++ b/tests/drivers/uart/uart_errors/testcase.yaml
@@ -1,5 +1,7 @@
 common:
-  tags: drivers uart
+  tags:
+    - drivers
+    - uart
   depends_on: gpio
   harness: ztest
   harness_config:

--- a/tests/kernel/context/testcase.yaml
+++ b/tests/kernel/context/testcase.yaml
@@ -6,7 +6,9 @@ tests:
     min_ram: 16
   kernel.context.minimallibc:
     filter: CONFIG_MINIMAL_LIBC_SUPPORTED
-    tags: kernel libc
+    tags:
+      - kernel
+      - libc
     extra_configs:
       - CONFIG_TEST_EXTRA_STACK_SIZE=1024
       - CONFIG_MINIMAL_LIBC=y

--- a/tests/kernel/device/testcase.yaml
+++ b/tests/kernel/device/testcase.yaml
@@ -25,7 +25,9 @@ tests:
   kernel.device.pm:
     integration_platforms:
       - native_sim
-    platform_exclude: mec15xxevb_assy6853 xenvm
+    platform_exclude:
+      - mec15xxevb_assy6853
+      - xenvm
     extra_configs:
       - CONFIG_PM_DEVICE=y
   kernel.device.linker_generator:

--- a/tests/kernel/obj_tracking/testcase.yaml
+++ b/tests/kernel/obj_tracking/testcase.yaml
@@ -4,7 +4,9 @@ tests:
     platform_exclude: qemu_x86_tiny
   kernel.objects.tracking.minimallibc:
     filter: CONFIG_MINIMAL_LIBC_SUPPORTED
-    tags: kernel libc
+    tags:
+      - kernel
+      - libc
     platform_exclude: qemu_x86_tiny
     extra_configs:
       - CONFIG_MINIMAL_LIBC=y

--- a/tests/kernel/pending/testcase.yaml
+++ b/tests/kernel/pending/testcase.yaml
@@ -3,6 +3,8 @@ tests:
     tags: kernel
   kernel.objects.minimallibc:
     filter: CONFIG_MINIMAL_LIBC_SUPPORTED
-    tags: kernel libc
+    tags:
+      - kernel
+      - libc
     extra_configs:
       - CONFIG_MINIMAL_LIBC=y

--- a/tests/kernel/smp_boot_delay/testcase.yaml
+++ b/tests/kernel/smp_boot_delay/testcase.yaml
@@ -3,7 +3,9 @@ tests:
     tags:
       - kernel
       - smp
-    platform_allow: intel_adsp/cavs25 qemu_x86_64
+    platform_allow:
+      - intel_adsp/cavs25
+      - qemu_x86_64
     integration_platforms:
       - qemu_x86_64
   kernel.multiprocessing.smp_boot_delay.minimallibc:
@@ -12,7 +14,9 @@ tests:
       - kernel
       - smp
       - libc
-    platform_allow: intel_adsp/cavs25 qemu_x86_64
+    platform_allow:
+      - intel_adsp/cavs25
+      - qemu_x86_64
     integration_platforms:
       - qemu_x86_64
     extra_configs:

--- a/tests/kernel/threads/dynamic_thread_stack/testcase.yaml
+++ b/tests/kernel/threads/dynamic_thread_stack/testcase.yaml
@@ -1,5 +1,7 @@
 common:
-  tags: kernel security
+  tags:
+    - kernel
+    - security
   min_ram: 32
   integration_platforms:
     - qemu_x86

--- a/tests/net/conn_mgr_monitor/testcase.yaml
+++ b/tests/net/conn_mgr_monitor/testcase.yaml
@@ -1,7 +1,9 @@
 common:
   min_ram: 16
   depends_on: netif
-  tags: net iface
+  tags:
+    - net
+    - iface
 tests:
   net.conn_mgr.nodad:
     extra_configs:

--- a/tests/net/dhcpv4/server/testcase.yaml
+++ b/tests/net/dhcpv4/server/testcase.yaml
@@ -1,7 +1,9 @@
 common:
   depends_on: netif
-  tags: net dhcpv4
-  # eventfd API does not work with native_posix so exclude it here
+  tags:
+    # eventfd API does not work with native_posix so exclude it here
+    - net
+    - dhcpv4
   platform_exclude:
     - native_posix
     - native_posix/native/64

--- a/tests/net/dhcpv6/testcase.yaml
+++ b/tests/net/dhcpv6/testcase.yaml
@@ -1,6 +1,8 @@
 common:
   depends_on: netif
-  tags: net dhcpv6
+  tags:
+    - net
+    - dhcpv6
 tests:
   net.dhcpv6:
     extra_configs:

--- a/tests/net/icmp/testcase.yaml
+++ b/tests/net/icmp/testcase.yaml
@@ -1,6 +1,8 @@
 common:
   depends_on: netif
-  tags: net icmp
+  tags:
+    - net
+    - icmp
 tests:
   net.icmp.offloaded:
     extra_configs:

--- a/tests/net/lib/coap_client/testcase.yaml
+++ b/tests/net/lib/coap_client/testcase.yaml
@@ -4,4 +4,6 @@ tests:
   net.coap.client:
     platform_allow:
       - native_sim
-    tags: coap net
+    tags:
+      - coap
+      - net

--- a/tests/net/wifi/wifi_nm/testcase.yaml
+++ b/tests/net/wifi/wifi_nm/testcase.yaml
@@ -6,7 +6,9 @@ tests:
     extra_args:
       # Will be ignored for other platforms
       - CONFIG_NRF_WIFI_BUILD_ONLY_MODE=y
-    tags: wifi net
+    tags:
+      - wifi
+      - net
     platform_exclude:
       - rd_rw612_bga/rw612/ethernet # Requires binary blobs to build
       - frdm_rw612 # Requires binary blobs to build

--- a/tests/subsys/llext/simple/testcase.yaml
+++ b/tests/subsys/llext/simple/testcase.yaml
@@ -31,7 +31,10 @@ tests:
   # most tests include no_mem_protection.conf, which disables memory protection
   # hardware completely.
   llext.simple.readonly:
-    arch_allow: arm riscv arc # Xtensa needs writable storage
+    arch_allow:               # Xtensa needs writable storage
+      - arm
+      - riscv
+      - arc
     filter: not CONFIG_MPU and not CONFIG_MMU
     extra_conf_files: ['no_mem_protection.conf']
     extra_configs:
@@ -44,7 +47,10 @@ tests:
       - CONFIG_USERSPACE=y
       - CONFIG_LLEXT_STORAGE_WRITABLE=n
   llext.simple.readonly_mmu:
-    arch_allow: arm64 arm riscv
+    arch_allow:
+      - arm64
+      - arm
+      - riscv
     filter: CONFIG_MMU or CONFIG_RISCV_PMP
     integration_platforms:
       - qemu_cortex_a53         # ARM Cortex-A53 (ARMv8-A ISA)
@@ -52,7 +58,11 @@ tests:
       - CONFIG_LLEXT_HEAP_SIZE=128 # qemu_cortex_a9 requires larger heap
       - CONFIG_LLEXT_STORAGE_WRITABLE=n
   llext.simple.writable:
-    arch_allow: arm xtensa riscv arc
+    arch_allow:
+      - arm
+      - xtensa
+      - riscv
+      - arc
     integration_platforms:
       - qemu_xtensa/dc233c      # Xtensa ISA
     filter: not CONFIG_MPU and not CONFIG_MMU
@@ -60,7 +70,11 @@ tests:
     extra_configs:
       - CONFIG_LLEXT_STORAGE_WRITABLE=y
   llext.simple.writable_relocatable:
-    arch_allow: arm xtensa riscv arc
+    arch_allow:
+      - arm
+      - xtensa
+      - riscv
+      - arc
     platform_exclude:
       - qemu_arc/qemu_arc_hs5x  # See #80949
     integration_platforms:
@@ -74,7 +88,11 @@ tests:
   # Test the Symbol Link Identifier (SLID) linking feature on writable
   # storage to cover both ARM and Xtensa architectures on the same test.
   llext.simple.writable_slid_linking:
-    arch_allow: arm xtensa riscv arc
+    arch_allow:
+      - arm
+      - xtensa
+      - riscv
+      - arc
     integration_platforms:
       - qemu_xtensa/dc233c      # Xtensa ISA
     filter: not CONFIG_MPU and not CONFIG_MMU
@@ -83,7 +101,11 @@ tests:
       - CONFIG_LLEXT_STORAGE_WRITABLE=y
       - CONFIG_LLEXT_EXPORT_BUILTINS_BY_SLID=y
   llext.simple.writable_relocatable_slid_linking:
-    arch_allow: arm xtensa riscv arc
+    arch_allow:
+      - arm
+      - xtensa
+      - riscv
+      - arc
     platform_exclude:
       - qemu_arc/qemu_arc_hs5x  # See #80949
     integration_platforms:

--- a/tests/subsys/sd/sdio/testcase.yaml
+++ b/tests/subsys/sd/sdio/testcase.yaml
@@ -1,6 +1,8 @@
 common:
   depends_on: sdhc
-  tags: drivers sdhc
+  tags:
+    - drivers
+    - sdhc
 tests:
   sd.sdio:
     harness: ztest

--- a/tests/subsys/sip_svc/testcase.yaml
+++ b/tests/subsys/sip_svc/testcase.yaml
@@ -4,7 +4,9 @@
 tests:
   sip_svc.stress_test.ztest:
     build_only: true
-    platform_allow: intel_socfpga_agilex_socdk  intel_socfpga_agilex5_socdk
+    platform_allow:
+      - intel_socfpga_agilex_socdk
+      - intel_socfpga_agilex5_socdk
     integration_platforms:
       - intel_socfpga_agilex_socdk
       - intel_socfpga_agilex5_socdk


### PR DESCRIPTION
Support for space-separated lists was deprecated a long time ago
https://github.com/zephyrproject-rtos/zephyr/commit/a91620f5bbf2a01c5cdc4b435e8b00cc6020be11 so it is time to remove
support for them.

Any project that has not migrated can still use
`scripts/utils/twister_to_list.py` to automatically migrate twister
files.