### PR TITLE
Segger RTT Console OpenOCD Config

### DIFF
--- a/boards/common/openocd.board.cmake
+++ b/boards/common/openocd.board.cmake
@@ -16,7 +16,13 @@ endif()
 set(OPENOCD_CMD_LOAD_DEFAULT "${OPENOCD_FLASH}")
 set(OPENOCD_CMD_VERIFY_DEFAULT "verify_image")
 
+if(EXTRA_CONF_FILE MATCHES "rtt-console.conf")
+  board_runner_args(openocd
+    "--config=${CMAKE_CURRENT_LIST_DIR}/openocd_segger_rtt.cfg"
+  )
+endif()
+
 board_finalize_runner_args(openocd
   --cmd-load "${OPENOCD_CMD_LOAD_DEFAULT}"
   --cmd-verify "${OPENOCD_CMD_VERIFY_DEFAULT}"
-  )
+)

--- a/boards/common/openocd_segger_rtt.cfg
+++ b/boards/common/openocd_segger_rtt.cfg
@@ -1,0 +1,24 @@
+# Copyright (c) 2024 Alexander Kozhinov <ak.alexander.kozhinov@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+proc version_compare {v1 v2} {
+	foreach n1 [split $v1 .] n2 [split $v2 .] {
+		if {$n1 < $n2} {return -1}
+		if {$n1 > $n2} {return 1}
+	}
+	return 0
+}
+
+set current_version [version]
+regexp {([0-9]+\.[0-9]+\.[0-9]+)} $current_version -> current_version
+
+if {[version_compare $current_version "0.12.0"] >= 0} {
+	# OpenOCD version is 0.12.0 or newer - initialize Segger RTT server
+	init
+	rtt setup 0x20000000 10000 "SEGGER RTT"
+	rtt start
+	rtt server start 9090 0
+} else {
+	# OpenOCD version is older than 0.12.0
+	echo "Warn: OpenOCD $current_version does not support Segger RTT"
+}


### PR DESCRIPTION
Add openocd config to support openocd v0.11.0 and v0.12.0

**Problem Description**

Debugging a Zephyr RTOS project with OpenOCD v0.11.0 and Segger RTT will lead to OpenOCD error.
The OpenOCD used with west comes with ZephyrSDK 0.17.0.

**Steps To Reproduce**

1. Build project with Segger RTT support (west cli argument `-S rtt-console` )
2. Add following lines to `openocd.cfg` to support Segger RTT connection over OpenOCD debugger:
```
init
rtt setup 0x20000000 10000 "SEGGER RTT"
rtt start
rtt server start 9090 0
```
my debug file looks therefore as follows:
```
tcl_port 8234

source [find interface/stlink.cfg]
source [find target/stm32g4x.cfg]

transport select hla_swd

init
rtt setup 0x20000000 10000 "SEGGER RTT"
rtt start
rtt server start 9090 0
```

3. Execute  `west flash`
4. Execute  `west debug`
5. Consider OpenOCD output:
```
Open On-Chip Debugger 0.11.0+dev-00728-gb6f95a16c-dirty (2024-10-20-01:26)
Licensed under GNU GPL v2
For bug reports, read
        http://openocd.org/doc/doxygen/bugs.html
1
Info : auto-selecting first available session transport "hla_swd". To override use 'transport select <transport>'.
Info : The selected transport took over low-level target control. The results might differ compared to plain JTAG/SWD
Info : DEPRECATED target event trace-config; use TPIU events {pre,post}-{enable,disable}
Warn : Transport "hla_swd" was already selected
Info : clock speed 2000 kHz
Info : STLINK V3J15M7 (API v3) VID:PID 0483:3754
Info : Target voltage: 3.289421
GNU gdb (Zephyr SDK 0.17.0) 12.1
Copyright (C) 2022 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
Type "show copying" and "show warranty" for details.
This GDB was configured as "--host=x86_64-build_pc-linux-gnu --target=arm-zephyr-eabi".
Type "show configuration" for configuration details.
For bug reporting instructions, please see:
<https://github.com/zephyrproject-rtos/sdk-ng/issues>.
Find the GDB manual and other documentation resources online at:
    <http://www.gnu.org/software/gdb/documentation/>.

For help, type "help".
Type "apropos word" to search for commands related to "word"...
Reading symbols from<PATH_TO_YOUR_APP_BUILD_FOLDER>/zephyr/zephyr.elf...
Info : [stm32g4x.cpu] Cortex-M4 r0p1 processor detected
Info : [stm32g4x.cpu] target has 6 breakpoints, 4 watchpoints
Info : starting gdb server for stm32g4x.cpu on 3333
Info : Listening on port 3333 for gdb connections
Info : rtt: Searching for control block 'SEGGER RTT'
Info : rtt: Control block found at 0x20000000
Info : Listening on port 9090 for rtt connections
Error: The 'tcl_port' command must be used before 'init'.

:3333: Connection timed out.
You can't do that when your target is `exec'
(gdb) 
```

The error `Error: The 'tcl_port' command must be used before 'init'.` can be observed. Also the connection with `telnet localhost 9090` is refused.

Adding `tcl_port xxxx` will not solve the problem.
More information on usage of Segger RTT with OpenOCD can be found under: https://openocd.org/doc/html/General-Commands.html

Fortunatelly doing same with Open On-Chip Debugger 0.12.0-1build2 solves the problem (on ubuntu: `sudo apt install openocd`).
My installation on Ubuntu looks like:
```
 sudo apt install openocd
[sudo] password for nuke: 
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
openocd is already the newest version (0.12.0-1build2).
0 upgraded, 0 newly installed, 0 to remove and 2 not upgraded.
````

**Solution***

This approach adds the necessary Segger RTT initialization section to OpenOCD configuration if zephyr project used to build with `-S rtt-console` snippet. Additionally the proposed OpenOCD configuration will determin running OpenOCD version and skip Segger RTT initialization for OpenOCD under 0.12.0 version used.
