### PR TITLE
tests/bsim: For nrf52bsim use full board name with qualifiers

### DIFF
--- a/tests/bsim/bluetooth/compile.sh
+++ b/tests/bsim/bluetooth/compile.sh
@@ -21,7 +21,7 @@ ${ZEPHYR_BASE}/tests/bsim/bluetooth/host/compile.sh
 ${ZEPHYR_BASE}/tests/bsim/bluetooth/ll/compile.sh
 ${ZEPHYR_BASE}/tests/bsim/bluetooth/mesh/compile.sh
 ${ZEPHYR_BASE}/tests/bsim/bluetooth/samples/compile.sh
-if [ ${BOARD} == "nrf52_bsim" ]; then
+if [ ${BOARD} == "nrf52_bsim/native" ]; then
 	${ZEPHYR_BASE}/tests/bsim/bluetooth/hci_uart/compile.sh
 fi
 

--- a/tests/bsim/bluetooth/samples/compile.sh
+++ b/tests/bsim/bluetooth/samples/compile.sh
@@ -37,7 +37,7 @@ app=tests/bsim/bluetooth/samples/central_hr_peripheral_hr \
   extra_conf_file=${ZEPHYR_BASE}/samples/bluetooth/central_hr/prj.conf \
   conf_overlay=${ZEPHYR_BASE}/samples/bluetooth/central_hr/overlay-phy_coded.conf \
   compile
-if [ ${BOARD} == "nrf52_bsim" ]; then
+if [ ${BOARD} == "nrf52_bsim/native" ]; then
   app=tests/bsim/bluetooth/samples/battery_service \
     conf_file=prj.conf \
     compile

--- a/tests/bsim/sh_common.source
+++ b/tests/bsim/sh_common.source
@@ -7,7 +7,7 @@ _process_ids="";
 : "${BSIM_OUT_PATH:?BSIM_OUT_PATH must be defined}"
 
 #Give a default value to BOARD if it does not have one yet:
-BOARD="${BOARD:-nrf52_bsim}"
+BOARD="${BOARD:-nrf52_bsim/native}"
 
 #The board target full string (with qualifiers):
 BOARD_TS="${BOARD//\//_}"


### PR DESCRIPTION
So when building with twister we get the same executable name as with compile.sh