### PR TITLE
bsim tests: Fix rot in 3 custom development scripts

### DIFF
--- a/tests/bsim/bluetooth/host/gatt/notify_multiple/test_scripts/_notify-debug.sh
+++ b/tests/bsim/bluetooth/host/gatt/notify_multiple/test_scripts/_notify-debug.sh
@@ -11,13 +11,10 @@
 # GDB can be run on the two devices at the same time without issues, just append
 # `debug` when running the script.
 
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
 simulation_id="notify_multiple"
 verbosity_level=2
-
-: "${BSIM_OUT_PATH:?BSIM_OUT_PATH must be defined}"
-
-#Give a default value to BOARD if it does not have one yet:
-BOARD="${BOARD:-nrf52_bsim}"
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/host/misc/conn_stress/scripts/_conn_stress.sh
+++ b/tests/bsim/bluetooth/host/misc/conn_stress/scripts/_conn_stress.sh
@@ -2,6 +2,8 @@
 # Copyright (c) 2023 Nordic Semiconductor
 # SPDX-License-Identifier: Apache-2.0
 
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
 simulation_id="conn_stress"
 process_ids=""; exit_code=0
 
@@ -20,28 +22,23 @@ function Execute(){
   echo "Running $@"
 }
 
-: "${BSIM_OUT_PATH:?BSIM_OUT_PATH must be defined}"
-
-#Give a default value to BOARD if it does not have one yet:
-BOARD="${BOARD:-nrf52_bsim}"
-
 test_path="bsim_bluetooth_host_misc_conn_stress"
 bsim_central_exe_name="bs_nrf52_${test_path}_central_prj_conf"
 bsim_peripheral_exe_name="bs_nrf52_${test_path}_peripheral_prj_conf"
 
 # terminate running simulations (if any)
-${BSIM_COMPONENTS_PATH}/common/stop_bsim.sh
+${BSIM_COMPONENTS_PATH}/common/stop_bsim.sh $simulation_id
 
 # (re)Build the central & peripheral images. Don't continue if build fails.
 west build -b ${BOARD} -d build_central central && \
     cp build_central/zephyr/zephyr.exe \
     "${BSIM_OUT_PATH}/bin/${bsim_central_exe_name}" \
-    || exit
+    || exit 1
 
 west build -b ${BOARD} -d build_peripheral peripheral && \
     cp build_peripheral/zephyr/zephyr.exe \
     "${BSIM_OUT_PATH}/bin/${bsim_peripheral_exe_name}" \
-    || exit
+    || exit 1
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/ll/_compile_permutate_kconfigs.sh
+++ b/tests/bsim/bluetooth/ll/_compile_permutate_kconfigs.sh
@@ -10,19 +10,14 @@
 # set DEBUG_PERMUTATE to 'true' for extra debug output
 DEBUG_PERMUTATE=false
 
-: "${BSIM_OUT_PATH:?BSIM_OUT_PATH must be defined}"
-: "${BSIM_COMPONENTS_PATH:?BSIM_COMPONENTS_PATH must be defined}"
 : "${ZEPHYR_BASE:?ZEPHYR_BASE must be set to point to the zephyr root\
  directory}"
 
-WORK_DIR="${WORK_DIR:-${ZEPHYR_BASE}/bsim_out}"
-BOARD="${BOARD:-nrf52_bsim}"
+source ${ZEPHYR_BASE}/tests/bsim/compile.source
+
 BOARD_ROOT="${BOARD_ROOT:-${ZEPHYR_BASE}}"
 
 mkdir -p ${WORK_DIR}
-
-source ${ZEPHYR_BASE}/tests/bsim/compile.source
-
 
 declare -a list=(
 "CONFIG_BT_CENTRAL="
@@ -42,7 +37,7 @@ perm_compile() {
     # created by the compile scripts since that may mess up other tests
     # We also delete the executable to avoid having artifacts from
     # a previous run
-    local exe_name="bs_nrf52_bsim_tests_kconfig_perm"
+    local exe_name="bs_${BOARD_TS}_tests_kconfig_perm"
     local executable_name=${exe_name}
     local executable_name=${BSIM_OUT_PATH}/bin/$executable_name
 


### PR DESCRIPTION
These 3 scripts were rotted or rotting out (they are not used in CI but were used to support development).
Let's fix them.

Mostly:
* BOARD should have been replaced with BOARD_TS.
* Let's also remove a few duplicate checks and definitions.

`tests/bsim/bluetooth/host/misc/conn_stress/scripts/_conn_stress.sh` was not even running from bash point of view, now it does. But the test hangs a bit into it. I did not look into why.