### PR TITLE
Fix Host Commands for STM32H7 chips

### DIFF
--- a/include/zephyr/devicetree/dma.h
+++ b/include/zephyr/devicetree/dma.h
@@ -221,6 +221,25 @@ extern "C" {
 	DT_PHA_BY_NAME(node_id, dmas, name, cell)
 
 /**
+ * @brief Like DT_DMAS_CELL_BY_NAME(), but with a fallback to @p default_value
+ *
+ * If the value exists, this expands to DT_DMAS_CELL_BY_NAME(node_id,
+ * name, cell). The @p default_value parameter is not expanded in this case.
+ *
+ * Otherwise, this expands to @p default_value.
+ *
+ * @param node_id node identifier for a node with a dmas property
+ * @param name lowercase-and-underscores name of a dmas element
+ *             as defined by the node's dma-names property
+ * @param cell lowercase-and-underscores cell name
+ * @param default_value a fallback value to expand to
+ * @return the cell's value or @p default_value
+ * @see DT_PHA_BY_NAME_OR()
+ */
+#define DT_DMAS_CELL_BY_NAME_OR(node_id, name, cell, default_value) \
+	DT_PHA_BY_NAME_OR(node_id, dmas, name, cell, default_value)
+
+/**
  * @brief Get a DT_DRV_COMPAT instance's DMA specifier's cell value by name
  * @param inst DT_DRV_COMPAT instance number
  * @param name lowercase-and-underscores name of a dmas element

--- a/subsys/mgmt/ec_host_cmd/Kconfig
+++ b/subsys/mgmt/ec_host_cmd/Kconfig
@@ -76,6 +76,15 @@ config EC_HOST_CMD_HANDLER_RX_BUFFER_DEF
 	help
 	  The handler defines common rx buffer
 
+config EC_HOST_CMD_NOCACHE_BUFFERS
+	bool "Place RX and TX buffers in __nocache section"
+	default y if DCACHE && DMA
+	depends on EC_HOST_CMD_HANDLER_TX_BUFFER_DEF || EC_HOST_CMD_HANDLER_RX_BUFFER_DEF
+	help
+	  DMA is often use for communication, however it usually requires
+	  uncached memory. Add possibility to place the RX and TX buffers in the
+	  __nocache section.
+
 config EC_HOST_CMD_INITIALIZE_AT_BOOT
 	bool "Initialize the host command subsystem automacitlly"
 	default y

--- a/subsys/mgmt/ec_host_cmd/backends/ec_host_cmd_backend_spi_stm32.c
+++ b/subsys/mgmt/ec_host_cmd/backends/ec_host_cmd_backend_spi_stm32.c
@@ -706,10 +706,6 @@ static int ec_host_cmd_spi_init(const struct ec_host_cmd_backend *backend,
 		return -EIO;
 	}
 
-	gpio_init_callback(&hc_spi->cs_callback, gpio_cb_nss, BIT(hc_spi->cs.pin));
-	gpio_add_callback(hc_spi->cs.port, &hc_spi->cs_callback);
-	gpio_pin_interrupt_configure(hc_spi->cs.port, hc_spi->cs.pin, GPIO_INT_EDGE_BOTH);
-
 	hc_spi->rx_ctx = rx_ctx;
 	hc_spi->rx_ctx->len = 0;
 
@@ -745,6 +741,11 @@ static int ec_host_cmd_spi_init(const struct ec_host_cmd_backend *backend,
 
 	tx_status(spi, EC_SPI_RX_READY);
 	hc_spi->state = SPI_HOST_CMD_STATE_READY_TO_RX;
+
+	/* Configure CS interrupt once everything is ready. */
+	gpio_init_callback(&hc_spi->cs_callback, gpio_cb_nss, BIT(hc_spi->cs.pin));
+	gpio_add_callback(hc_spi->cs.port, &hc_spi->cs_callback);
+	gpio_pin_interrupt_configure(hc_spi->cs.port, hc_spi->cs.pin, GPIO_INT_EDGE_BOTH);
 
 	return ret;
 }

--- a/subsys/mgmt/ec_host_cmd/backends/ec_host_cmd_backend_spi_stm32.c
+++ b/subsys/mgmt/ec_host_cmd/backends/ec_host_cmd_backend_spi_stm32.c
@@ -100,6 +100,8 @@ BUILD_ASSERT(DT_NODE_HAS_COMPAT_STATUS(DT_CHOSEN(zephyr_host_cmd_spi_backend),
 #define EC_HOST_CMD_ST_STM32_FIFO
 #endif /* st_stm32_spi_fifo */
 
+#define STM32_DMA_FEATURES_ID(id, dir) DT_DMAS_CELL_BY_NAME_OR(id, dir, features, 0)
+
 /*
  * Max data size for a version 3 request/response packet.  This is big enough
  * to handle a request/response header, flash write offset/size, and 512 bytes
@@ -195,8 +197,7 @@ static int prepare_rx(struct ec_host_cmd_spi_ctx *hc_spi);
 			.dma_callback = dma_callback,                                              \
 			.block_count = 2,                                                          \
 	},                                                                                         \
-	.fifo_threshold =                                                                          \
-		STM32_DMA_FEATURES_FIFO_THRESHOLD(DT_DMAS_CELL_BY_NAME(id, dir, features)),
+	.fifo_threshold = STM32_DMA_FEATURES_FIFO_THRESHOLD(STM32_DMA_FEATURES_ID(id, dir)),
 
 #define STM32_SPI_INIT(id)                                                                         \
 	PINCTRL_DT_DEFINE(id);                                                                     \

--- a/subsys/mgmt/ec_host_cmd/backends/ec_host_cmd_backend_spi_stm32.c
+++ b/subsys/mgmt/ec_host_cmd/backends/ec_host_cmd_backend_spi_stm32.c
@@ -102,6 +102,12 @@ BUILD_ASSERT(DT_NODE_HAS_COMPAT_STATUS(DT_CHOSEN(zephyr_host_cmd_spi_backend),
 
 #define STM32_DMA_FEATURES_ID(id, dir) DT_DMAS_CELL_BY_NAME_OR(id, dir, features, 0)
 
+#if DT_CLOCKS_HAS_IDX(DT_CHOSEN(zephyr_host_cmd_spi_backend), 1)
+#define STM32_EC_HOST_CMD_SPI_DOMAIN_CLOCK_SUPPORT 1
+#else
+#define STM32_EC_HOST_CMD_SPI_DOMAIN_CLOCK_SUPPORT 0
+#endif
+
 /*
  * Max data size for a version 3 request/response packet.  This is big enough
  * to handle a request/response header, flash write offset/size, and 512 bytes
@@ -335,7 +341,8 @@ static int spi_init(const struct ec_host_cmd_spi_ctx *hc_spi)
 		return err;
 	}
 
-	if (IS_ENABLED(STM32_SPI_DOMAIN_CLOCK_SUPPORT) && (hc_spi->spi_config->pclk_len > 1)) {
+	if (IS_ENABLED(STM32_EC_HOST_CMD_SPI_DOMAIN_CLOCK_SUPPORT) &&
+	    hc_spi->spi_config->pclk_len > 1) {
 		err = clock_control_configure(
 			DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
 			(clock_control_subsys_t)&hc_spi->spi_config->pclken[1], NULL);

--- a/subsys/mgmt/ec_host_cmd/backends/ec_host_cmd_backend_spi_stm32.c
+++ b/subsys/mgmt/ec_host_cmd/backends/ec_host_cmd_backend_spi_stm32.c
@@ -547,7 +547,7 @@ static int spi_setup_dma(struct ec_host_cmd_spi_ctx *hc_spi)
 	LL_SPI_EnableDMAReq_TX(spi);
 
 	LL_SPI_Enable(spi);
-#else /* EC_HOST_CMD_ST_STM32H7 */
+#else  /* EC_HOST_CMD_ST_STM32H7 */
 	LL_SPI_Enable(spi);
 #endif /* !EC_HOST_CMD_ST_STM32H7 */
 
@@ -783,8 +783,7 @@ struct ec_host_cmd_backend *ec_host_cmd_backend_get_spi(struct gpio_dt_spec *cs)
 }
 
 #ifdef CONFIG_PM_DEVICE
-static int ec_host_cmd_spi_stm32_pm_action(const struct device *dev,
-					   enum pm_device_action action)
+static int ec_host_cmd_spi_stm32_pm_action(const struct device *dev, enum pm_device_action action)
 {
 	const struct ec_host_cmd_backend *backend = (struct ec_host_cmd_backend *)dev->data;
 	struct ec_host_cmd_spi_ctx *hc_spi = (struct ec_host_cmd_spi_ctx *)backend->ctx;
@@ -848,10 +847,8 @@ static int ec_host_cmd_spi_stm32_pm_action(const struct device *dev,
 
 PM_DEVICE_DT_DEFINE(DT_CHOSEN(zephyr_host_cmd_spi_backend), ec_host_cmd_spi_stm32_pm_action);
 
-DEVICE_DT_DEFINE(DT_CHOSEN(zephyr_host_cmd_spi_backend),
-		 NULL,
-		 PM_DEVICE_DT_GET(DT_CHOSEN(zephyr_host_cmd_spi_backend)),
-		 &ec_host_cmd_spi, NULL,
+DEVICE_DT_DEFINE(DT_CHOSEN(zephyr_host_cmd_spi_backend), NULL,
+		 PM_DEVICE_DT_GET(DT_CHOSEN(zephyr_host_cmd_spi_backend)), &ec_host_cmd_spi, NULL,
 		 PRE_KERNEL_1, CONFIG_EC_HOST_CMD_INIT_PRIORITY, NULL);
 
 #ifdef CONFIG_EC_HOST_CMD_INITIALIZE_AT_BOOT

--- a/subsys/mgmt/ec_host_cmd/backends/ec_host_cmd_backend_spi_stm32.c
+++ b/subsys/mgmt/ec_host_cmd/backends/ec_host_cmd_backend_spi_stm32.c
@@ -257,6 +257,9 @@ static inline void tx_status(SPI_TypeDef *spi, uint8_t status)
 	 * families than need to bypass the DMA threshold.
 	 */
 	LL_SPI_TransmitData8(spi, status);
+#ifdef EC_HOST_CMD_ST_STM32H7
+	LL_SPI_SetUDRPattern(spi, status);
+#endif /* EC_HOST_CMD_ST_STM32H7 */
 }
 
 static int expected_size(const struct ec_host_cmd_request_header *header)
@@ -395,6 +398,11 @@ static int spi_configure(const struct ec_host_cmd_spi_ctx *hc_spi)
 	LL_SPI_SetNSSMode(spi, LL_SPI_NSS_HARD_INPUT);
 	LL_SPI_SetMode(spi, LL_SPI_MODE_SLAVE);
 
+#ifdef EC_HOST_CMD_ST_STM32H7
+	LL_SPI_SetUDRConfiguration(spi, LL_SPI_UDR_CONFIG_REGISTER_PATTERN);
+	LL_SPI_SetUDRDetection(spi, LL_SPI_UDR_DETECT_END_DATA_FRAME);
+#endif /* EC_HOST_CMD_ST_STM32H7 */
+
 #ifdef EC_HOST_CMD_ST_STM32_FIFO
 #ifdef EC_HOST_CMD_ST_STM32H7
 	LL_SPI_SetFIFOThreshold(spi, LL_SPI_FIFO_TH_01DATA);
@@ -424,6 +432,9 @@ static int reload_dma_tx(struct ec_host_cmd_spi_ctx *hc_spi, size_t len)
 	if (ret != 0) {
 		return ret;
 	}
+#ifdef EC_HOST_CMD_ST_STM32H7
+	LL_SPI_ClearFlag_UDR(spi);
+#endif
 
 	return 0;
 }

--- a/subsys/mgmt/ec_host_cmd/ec_host_cmd_handler.c
+++ b/subsys/mgmt/ec_host_cmd/ec_host_cmd_handler.c
@@ -6,6 +6,7 @@
 
 #include <zephyr/devicetree.h>
 #include <zephyr/kernel.h>
+#include <zephyr/linker/section_tags.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/mgmt/ec_host_cmd/ec_host_cmd.h>
 #include <zephyr/mgmt/ec_host_cmd/backend.h>
@@ -32,12 +33,18 @@ BUILD_ASSERT(NUMBER_OF_CHOSEN_BACKENDS < 2, "Number of chosen backends > 1");
 #define RX_HEADER_SIZE (sizeof(struct ec_host_cmd_request_header))
 #define TX_HEADER_SIZE (sizeof(struct ec_host_cmd_response_header))
 
+#ifdef CONFIG_EC_HOST_CMD_NOCACHE_BUFFERS
+#define BUFFERS_CACHE_ATTR __nocache
+#else
+#define BUFFERS_CACHE_ATTR
+#endif
+
 COND_CODE_1(CONFIG_EC_HOST_CMD_HANDLER_RX_BUFFER_DEF,
-	    (static uint8_t hc_rx_buffer[CONFIG_EC_HOST_CMD_HANDLER_RX_BUFFER_SIZE] __aligned(4);),
-	    ())
+	    (static uint8_t hc_rx_buffer[CONFIG_EC_HOST_CMD_HANDLER_RX_BUFFER_SIZE] __aligned(4)
+	    BUFFERS_CACHE_ATTR;), ())
 COND_CODE_1(CONFIG_EC_HOST_CMD_HANDLER_TX_BUFFER_DEF,
-	    (static uint8_t hc_tx_buffer[CONFIG_EC_HOST_CMD_HANDLER_TX_BUFFER_SIZE] __aligned(4);),
-	    ())
+	    (static uint8_t hc_tx_buffer[CONFIG_EC_HOST_CMD_HANDLER_TX_BUFFER_SIZE] __aligned(4)
+	    BUFFERS_CACHE_ATTR;), ())
 
 #ifdef CONFIG_EC_HOST_CMD_DEDICATED_THREAD
 static K_KERNEL_STACK_DEFINE(hc_stack, CONFIG_EC_HOST_CMD_HANDLER_STACK_SIZE);


### PR DESCRIPTION
There are several changes to make Host Commands working on STM32H7 chips:
- fix clock domain support
- fix CS interrupt configuration
- handle underrun event
- restart SPI module after every transaction
- add possibility to place common buffers in nocache section