### PR TITLE
boards: nxp: frdm_mcxw71: Add LinkServer runner support

### DIFF
--- a/boards/nxp/frdm_mcxw71/board.cmake
+++ b/boards/nxp/frdm_mcxw71/board.cmake
@@ -1,6 +1,8 @@
 # Copyright 2024 NXP
 # SPDX-License-Identifier: Apache-2.0
 
+board_runner_args(linkserver "--device=MCXW716CxxxA:FRDM-MCXW71")
 board_runner_args(jlink "--device=mcxw716" "--reset-after-load")
 
+include(${ZEPHYR_BASE}/boards/common/linkserver.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/nxp/frdm_mcxw71/doc/index.rst
+++ b/boards/nxp/frdm_mcxw71/doc/index.rst
@@ -91,6 +91,16 @@ Configuring a Debug Probe
 A debug probe is used for both flashing and debugging the board. This board is
 configured by default to use the MCU-Link CMSIS-DAP Onboard Debug Probe.
 
+Using LinkServer
+----------------
+
+Linkserver is the default runner for this board, and supports the factory
+default MCU-Link firmware. Follow the instructions in
+:ref:`mcu-link-cmsis-onboard-debug-probe` to reprogram the default MCU-Link
+firmware. This only needs to be done if the default onboard debug circuit
+firmware was changed. To put the board in ``DFU mode`` to program the firmware,
+short jumper J5.
+
 Using J-Link
 ------------
 


### PR DESCRIPTION
Adds the LinkServer runner support for the FRDM-MCXW71 board.