### PR TITLE
Transparent error code propagation in CAN MCAN module

### DIFF
--- a/drivers/can/can_mcan.c
+++ b/drivers/can/can_mcan.c
@@ -292,7 +292,7 @@ int can_mcan_start(const struct device *dev)
 {
 	const struct can_mcan_config *config = dev->config;
 	struct can_mcan_data *data = dev->data;
-	int err;
+	int err = 0;
 
 	if (data->common.started) {
 		return -EALREADY;
@@ -311,19 +311,19 @@ int can_mcan_start(const struct device *dev)
 
 	err = can_mcan_leave_init_mode(dev, K_MSEC(CAN_INIT_TIMEOUT_MS));
 	if (err != 0) {
-		LOG_ERR("failed to leave init mode");
+		LOG_ERR("failed to leave init mode (err %d)", err);
 
 		if (config->common.phy != NULL) {
 			/* Attempt to disable the CAN transceiver in case of error */
 			(void)can_transceiver_disable(config->common.phy);
 		}
 
-		return -EIO;
+		return err;
 	}
 
 	data->common.started = true;
 
-	return 0;
+	return err;
 }
 
 int can_mcan_stop(const struct device *dev)


### PR DESCRIPTION
The implementation of can_mcan_start() function hides retun code of underlying function, which makes root-cause search mure difficult.
This change strives fro transparent error code propagation to higher software layers.