### PR TITLE
doc: extensions: doxygen: add support for multiple projects

### DIFF
--- a/doc/_extensions/zephyr/api_overview.py
+++ b/doc/_extensions/zephyr/api_overview.py
@@ -1,32 +1,14 @@
 # Copyright (c) 2023 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
+import os
 from pathlib import Path
 from typing import Any
 
 import doxmlparser
 from docutils import nodes
 from doxmlparser.compound import DoxCompoundKind
-from sphinx.application import Sphinx
 from sphinx.util.docutils import SphinxDirective
-
-
-class ApiOverview(SphinxDirective):
-    """
-    This is a Zephyr directive to generate a table containing an overview
-    of all APIs. This table will show the API name, version and since which
-    version it is present - all information extracted from Doxygen XML output.
-
-    It is exclusively used by the doc/develop/api/overview.rst page.
-
-    Configuration options:
-
-    api_overview_doxygen_xml_dir: Doxygen xml output directory
-    api_overview_doxygen_base_url: Doxygen base html directory
-    """
-
-    def run(self):
-        return [self.env.api_overview_table]
 
 
 def get_group(innergroup, all_groups):
@@ -40,64 +22,6 @@ def get_group(innergroup, all_groups):
         raise Exception(f"Unexpected group {innergroup.get_refid()}") from e
 
 
-def visit_group(app, group, all_groups, rows, indent=0):
-    version = since = ""
-    github_uri = "https://github.com/zephyrproject-rtos/zephyr/releases/tag/"
-    cdef = group.get_compounddef()[0]
-
-    ssects = [
-        s for p in cdef.get_detaileddescription().get_para() for s in p.get_simplesect()
-    ]
-    for sect in ssects:
-        if sect.get_kind() == "since":
-            since = sect.get_para()[0].get_valueOf_()
-        elif sect.get_kind() == "version":
-            version = sect.get_para()[0].get_valueOf_()
-
-    if since:
-        since_url = nodes.inline()
-        reference = nodes.reference(
-            text=f"v{since.strip()}.0", refuri=f"{github_uri}/v{since.strip()}.0"
-        )
-        reference.attributes["internal"] = True
-        since_url += reference
-    else:
-        since_url = nodes.Text("")
-
-    url_base = Path(app.config.api_overview_doxygen_base_url)
-    url = url_base / f"{cdef.get_id()}.html"
-
-    title = cdef.get_title()
-
-    row_node = nodes.row()
-
-    # Next entry will contain the spacer and the link with API name
-    entry = nodes.entry()
-    span = nodes.Text("".join(["\U000000A0"] * indent))
-    entry += span
-
-    # API name with link
-    inline = nodes.inline()
-    reference = nodes.reference(text=title, refuri=str(url))
-    reference.attributes["internal"] = True
-    inline += reference
-    entry += inline
-    row_node += entry
-
-    version_node = nodes.Text(version)
-    # Finally, add version and since
-    for cell in [version_node, since_url]:
-        entry = nodes.entry()
-        entry += cell
-        row_node += entry
-    rows.append(row_node)
-
-    for innergroup in cdef.get_innergroup():
-        visit_group(
-            app, get_group(innergroup, all_groups), all_groups, rows, indent + 6
-        )
-
-
 def parse_xml_dir(dir_name):
     groups = []
     root = doxmlparser.index.parse(Path(dir_name) / "index.xml", True)
@@ -109,67 +33,130 @@ def parse_xml_dir(dir_name):
     return groups
 
 
-def generate_table(app, toplevel, groups):
-    table = nodes.table()
-    tgroup = nodes.tgroup()
+class ApiOverview(SphinxDirective):
+    """
+    This is a Zephyr directive to generate a table containing an overview
+    of all APIs. This table will show the API name, version and since which
+    version it is present - all information extracted from Doxygen XML output.
 
-    thead = nodes.thead()
-    thead_row = nodes.row()
-    for header_name in ["API", "Version", "Available in Zephyr Since"]:
-        colspec = nodes.colspec()
-        tgroup += colspec
+    It is exclusively used by the doc/develop/api/overview.rst page.
 
-        entry = nodes.entry()
-        entry += nodes.Text(header_name)
-        thead_row += entry
-    thead += thead_row
-    tgroup += thead
+    Configuration options:
 
-    rows = []
-    tbody = nodes.tbody()
-    for t in toplevel:
-        visit_group(app, t, groups, rows)
-    tbody.extend(rows)
-    tgroup += tbody
+    api_overview_doxygen_out_dir: Doxygen output directory
+    """
 
-    table += tgroup
+    def run(self):
+        groups = parse_xml_dir(self.config.api_overview_doxygen_out_dir + "/xml")
 
-    return table
-
-
-def sync_contents(app: Sphinx) -> None:
-    if app.config.doxyrunner_outdir:
-        doxygen_out_dir = Path(app.config.doxyrunner_outdir)
-    else:
-        doxygen_out_dir = Path(app.outdir) / "_doxygen"
-
-    if not app.env.doxygen_input_changed:
-        return
-
-    doxygen_xml_dir = doxygen_out_dir / "xml"
-    groups = parse_xml_dir(doxygen_xml_dir)
-
-    toplevel = [
-        g
-        for g in groups
-        if g.get_compounddef()[0].get_id()
-        not in [
-            i.get_refid()
-            for h in [j.get_compounddef()[0].get_innergroup() for j in groups]
-            for i in h
+        toplevel = [
+            g
+            for g in groups
+            if g.get_compounddef()[0].get_id()
+            not in [
+                i.get_refid()
+                for h in [j.get_compounddef()[0].get_innergroup() for j in groups]
+                for i in h
+            ]
         ]
-    ]
 
-    app.builder.env.api_overview_table = generate_table(app, toplevel, groups)
+        return [self.generate_table(toplevel, groups)]
+
+    def generate_table(self, toplevel, groups):
+        table = nodes.table()
+        tgroup = nodes.tgroup()
+
+        thead = nodes.thead()
+        thead_row = nodes.row()
+        for header_name in ["API", "Version", "Available in Zephyr Since"]:
+            colspec = nodes.colspec()
+            tgroup += colspec
+
+            entry = nodes.entry()
+            entry += nodes.Text(header_name)
+            thead_row += entry
+        thead += thead_row
+        tgroup += thead
+
+        rows = []
+        tbody = nodes.tbody()
+        for t in toplevel:
+            self.visit_group(t, groups, rows)
+        tbody.extend(rows)
+        tgroup += tbody
+
+        table += tgroup
+
+        return table
+
+    def visit_group(self, group, all_groups, rows, indent=0):
+        version = since = ""
+        github_uri = "https://github.com/zephyrproject-rtos/zephyr/releases/tag/"
+        cdef = group.get_compounddef()[0]
+
+        ssects = [
+            s for p in cdef.get_detaileddescription().get_para() for s in p.get_simplesect()
+        ]
+        for sect in ssects:
+            if sect.get_kind() == "since":
+                since = sect.get_para()[0].get_valueOf_()
+            elif sect.get_kind() == "version":
+                version = sect.get_para()[0].get_valueOf_()
+
+        if since:
+            since_url = nodes.inline()
+            reference = nodes.reference(
+                text=f"v{since.strip()}.0", refuri=f"{github_uri}/v{since.strip()}.0"
+            )
+            reference.attributes["internal"] = True
+            since_url += reference
+        else:
+            since_url = nodes.Text("")
+
+        url_base = Path(self.config.api_overview_doxygen_out_dir + "/html")
+        abs_url = url_base / f"{cdef.get_id()}.html"
+        doc_dir = os.path.dirname(self.get_source_info()[0])
+        doc_dest = os.path.join(
+            self.env.app.outdir,
+            os.path.relpath(doc_dir, self.env.app.srcdir),
+        )
+        url = os.path.relpath(abs_url, doc_dest)
+
+        title = cdef.get_title()
+
+        row_node = nodes.row()
+
+        # Next entry will contain the spacer and the link with API name
+        entry = nodes.entry()
+        span = nodes.Text("".join(["\U000000A0"] * indent))
+        entry += span
+
+        # API name with link
+        inline = nodes.inline()
+        reference = nodes.reference(text=title, refuri=str(url))
+        reference.attributes["internal"] = True
+        inline += reference
+        entry += inline
+        row_node += entry
+
+        version_node = nodes.Text(version)
+        # Finally, add version and since
+        for cell in [version_node, since_url]:
+            entry = nodes.entry()
+            entry += cell
+            row_node += entry
+        rows.append(row_node)
+
+        for innergroup in cdef.get_innergroup():
+            self.visit_group(
+                get_group(innergroup, all_groups), all_groups, rows, indent + 6
+            )
 
 
 def setup(app) -> dict[str, Any]:
-    app.add_config_value("api_overview_doxygen_xml_dir", "html/doxygen/xml", "env")
-    app.add_config_value("api_overview_doxygen_base_url", "../../doxygen/html", "env")
+    app.add_config_value("api_overview_doxygen_out_dir", "", "env")
 
     app.add_directive("api-overview-table", ApiOverview)
-
-    app.connect("builder-inited", sync_contents)
 
     return {
         "version": "0.1",

--- a/doc/_extensions/zephyr/api_overview.py
+++ b/doc/_extensions/zephyr/api_overview.py
@@ -86,7 +86,7 @@ class ApiOverview(SphinxDirective):
 
     def visit_group(self, group, all_groups, rows, indent=0):
         version = since = ""
-        github_uri = "https://github.com/zephyrproject-rtos/zephyr/releases/tag/"
+        github_uri = self.config.api_overview_base_url + "/releases/tag/"
         cdef = group.get_compounddef()[0]
 
         ssects = [
@@ -150,6 +150,7 @@ class ApiOverview(SphinxDirective):
 
 def setup(app) -> dict[str, Any]:
     app.add_config_value("api_overview_doxygen_out_dir", "", "env")
+    app.add_config_value("api_overview_base_url", "", "env")
 
     app.add_directive("api-overview-table", ApiOverview)
 

--- a/doc/_extensions/zephyr/api_overview.py
+++ b/doc/_extensions/zephyr/api_overview.py
@@ -14,9 +14,9 @@ from sphinx.util.docutils import SphinxDirective
 def get_group(innergroup, all_groups):
     try:
         return [
-            g
-            for g in all_groups
-            if g.get_compounddef()[0].get_id() == innergroup.get_refid()
+            group
+            for group in all_groups
+            if group.get_compounddef()[0].get_id() == innergroup.get_refid()
         ][0]
     except IndexError as e:
         raise Exception(f"Unexpected group {innergroup.get_refid()}") from e
@@ -49,15 +49,10 @@ class ApiOverview(SphinxDirective):
     def run(self):
         groups = parse_xml_dir(self.config.api_overview_doxygen_out_dir + "/xml")
 
+        inners = [group.get_compounddef()[0].get_innergroup() for group in groups]
+        inner_ids = [i.get_refid() for inner in inners for i in inner]
         toplevel = [
-            g
-            for g in groups
-            if g.get_compounddef()[0].get_id()
-            not in [
-                i.get_refid()
-                for h in [j.get_compounddef()[0].get_innergroup() for j in groups]
-                for i in h
-            ]
+            group for group in groups if group.get_compounddef()[0].get_id() not in inner_ids
         ]
 
         return [self.generate_table(toplevel, groups)]

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -246,15 +246,22 @@ latex_engine = "xelatex"
 # -- Options for zephyr.doxyrunner plugin ---------------------------------
 
 doxyrunner_doxygen = os.environ.get("DOXYGEN_EXECUTABLE", "doxygen")
-doxyrunner_doxyfile = ZEPHYR_BASE / "doc" / "zephyr.doxyfile.in"
-doxyrunner_outdir = ZEPHYR_BUILD / "doxygen"
-doxyrunner_fmt = True
-doxyrunner_fmt_vars = {"ZEPHYR_BASE": str(ZEPHYR_BASE), "ZEPHYR_VERSION": version}
-doxyrunner_outdir_var = "DOXY_OUT"
+doxyrunner_projects = {
+    "zephyr": {
+        "doxyfile": ZEPHYR_BASE / "doc" / "zephyr.doxyfile.in",
+        "outdir": ZEPHYR_BUILD / "doxygen",
+        "fmt": True,
+        "fmt_vars": {
+            "ZEPHYR_BASE": str(ZEPHYR_BASE),
+            "ZEPHYR_VERSION": version,
+        },
+        "outdir_var": "DOXY_OUT",
+    },
+}
 
 # -- Options for zephyr.doxybridge plugin ---------------------------------
 
-doxybridge_dir = doxyrunner_outdir
+doxybridge_dir = doxyrunner_projects["zephyr"]["outdir"]
 
 # -- Options for html_redirect plugin -------------------------------------
 
@@ -356,7 +363,7 @@ linkcheck_anchors = False
 
 # -- Options for zephyr.api_overview --------------------------------------
 
-api_overview_doxygen_out_dir = str(doxyrunner_outdir)
+api_overview_doxygen_out_dir = str(doxyrunner_projects["zephyr"]["outdir"])
 
 def setup(app):
     # theme customizations

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -364,6 +364,7 @@ linkcheck_anchors = False
 # -- Options for zephyr.api_overview --------------------------------------
 
 api_overview_doxygen_out_dir = str(doxyrunner_projects["zephyr"]["outdir"])
+api_overview_base_url = "https://github.com/zephyrproject-rtos/zephyr"
 
 def setup(app):
     # theme customizations

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -356,7 +356,7 @@ linkcheck_anchors = False
 
 # -- Options for zephyr.api_overview --------------------------------------
 
-api_overview_doxygen_base_url = "../../doxygen/html"
+api_overview_doxygen_out_dir = str(doxyrunner_outdir)
 
 def setup(app):
     # theme customizations

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -261,7 +261,7 @@ doxyrunner_projects = {
 
 # -- Options for zephyr.doxybridge plugin ---------------------------------
 
-doxybridge_dir = doxyrunner_projects["zephyr"]["outdir"]
+doxybridge_projects = {"zephyr": doxyrunner_projects["zephyr"]["outdir"]}
 
 # -- Options for html_redirect plugin -------------------------------------
 

--- a/doc/contribute/documentation/guidelines.rst
+++ b/doc/contribute/documentation/guidelines.rst
@@ -1006,6 +1006,15 @@ Doxygen API documentation
 
       .. doxygengroup:: can_interface
 
+
+   .. rubric:: Options
+
+   .. rst:directive:option:: project
+      :type: project name (optional)
+
+      Associated Doxygen project. This can be useful when multiple Doxygen
+      projects are configured.
+
 .. rst:role:: c:group
 
    This role is used to reference a Doxygen group in the Zephyr tree. In the HTML documentation,


### PR DESCRIPTION
Add support for multiple Doxygen projects to doxyrunner/doxybridge extensions. While not needed upstream, some other projects may benefit from this option when re-using the extension.

Also refactored the api_overview extension as it had some major flaws (see commit for details)