### PR TITLE
Bluetooth: CAP: Fix log warning for meta pointer

### DIFF
--- a/subsys/bluetooth/audio/cap_initiator.c
+++ b/subsys/bluetooth/audio/cap_initiator.c
@@ -119,7 +119,7 @@ static bool cap_initiator_valid_metadata(const uint8_t meta[], size_t meta_len)
 	};
 	int err;
 
-	LOG_DBG("meta %p len %zu", meta, meta_len);
+	LOG_DBG("meta %p len %zu", (void *)meta, meta_len);
 
 	err = bt_audio_data_parse(meta, meta_len, data_func_cb, &metadata_param);
 	if (err != 0 && err != -ECANCELED) {


### PR DESCRIPTION
Fixes the following warning:
<wrn> cbprintf_package: cbprintf_package_convert:
  (unsigned) char * used for %p argument. It's recommended
  to cast it to void * because it may cause misbehavior in
  certain configurations. String:"%s: meta %p len %zu" argument:1