### PR TITLE
tests: drivers: audio: dmic_api: Enable test execution on nrf54l15

### DIFF
--- a/boards/nordic/nrf54l15dk/nrf54l15dk_nrf54l15_cpuapp.yaml
+++ b/boards/nordic/nrf54l15dk/nrf54l15dk_nrf54l15_cpuapp.yaml
@@ -14,6 +14,7 @@ flash: 324
 supported:
   - adc
   - counter
+  - dmic
   - gpio
   - i2c
   - pwm

--- a/tests/drivers/audio/dmic_api/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/tests/drivers/audio/dmic_api/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		dmic-dev = &pdm20;
+	};
+};
+
+&pinctrl {
+	pdm20_default_alt: pdm20_default_alt {
+		group1 {
+			psels = <NRF_PSEL(PDM_CLK, 1, 12)>,
+				<NRF_PSEL(PDM_DIN, 1, 13)>;
+		};
+	};
+};
+
+dmic_dev: &pdm20 {
+	status = "okay";
+	pinctrl-0 = <&pdm20_default_alt>;
+	pinctrl-names = "default";
+	clock-source = "PCLK32M";
+};


### PR DESCRIPTION
Enable execution of dmic_api test on nrf54l15:
- add 'dmic' to the list of supported peripherals;
- add overlay for nrf54l15;