### PR TITLE
drivers: dac: dacx3608: Fix bad shift operation

### DIFF
--- a/drivers/dac/dac_dacx3608.c
+++ b/drivers/dac/dac_dacx3608.c
@@ -146,7 +146,8 @@ static int dacx3608_write_value(const struct device *dev, uint8_t channel,
 	 * Check if channel is initialized
 	 * If broadcast channel is used, check if any channel is initialized
 	 */
-	if ((brdcast && !data->configured) || (!(data->configured & BIT(channel)))) {
+	if ((brdcast && !data->configured) ||
+	    (channel < DACX3608_MAX_CHANNEL && !(data->configured & BIT(channel)))) {
 		LOG_ERR("Channel %d not initialized", channel);
 		return -EINVAL;
 	}


### PR DESCRIPTION
The parameter provided to the `BIT()` macro must be checked so that the shift operation does not overflow the variable.

Fixes #81990