### PR TITLE
west-sign: rimage: also generate an all-modular configuration

### DIFF
--- a/scripts/west_commands/sign.py
+++ b/scripts/west_commands/sign.py
@@ -442,9 +442,11 @@ class RimageSigner(Signer):
         preproc_cmd += ['-I', str(self.sof_src_dir / 'src')]
         preproc_cmd += ['-imacros',
                         str(pathlib.Path('zephyr') / 'include' / 'generated' / 'zephyr' / 'autoconf.h')]
+        full_preproc_cmd = preproc_cmd + ['-o', str(subdir / 'rimage_config_full.toml'), '-DFORCE_ALL_MODULES']
         preproc_cmd += ['-o', str(subdir / 'rimage_config.toml')]
         self.command.inf(quote_sh_list(preproc_cmd))
         subprocess.run(preproc_cmd, check=True, cwd=self.build_dir)
+        subprocess.run(full_preproc_cmd, check=True, cwd=self.build_dir)
 
     def sign(self, command, build_dir, build_conf, formats):
         self.command = command


### PR DESCRIPTION
Add a TOML preprocessing command to generate a configuration with all module blocks included, even if they aren't configured for monotonic building.