### PR TITLE
drivers: sensor: tdk: fix icm42688 division by zero

### DIFF
--- a/drivers/sensor/tdk/icm42688/icm42688.h
+++ b/drivers/sensor/tdk/icm42688/icm42688.h
@@ -506,7 +506,7 @@ static inline void icm42688_gyro_dps(const struct icm42688_cfg *cfg, int32_t in,
 static inline void icm42688_accel_ms(const struct icm42688_cfg *cfg, int32_t in, int32_t *out_ms,
 				     int32_t *out_ums)
 {
-	int64_t sensitivity = 0; /* value equivalent for 1g */
+	int64_t sensitivity;
 
 	switch (cfg->accel_fs) {
 	case ICM42688_DT_ACCEL_FS_2:
@@ -521,6 +521,8 @@ static inline void icm42688_accel_ms(const struct icm42688_cfg *cfg, int32_t in,
 	case ICM42688_DT_ACCEL_FS_16:
 		sensitivity = 2048;
 		break;
+	default:
+		CODE_UNREACHABLE;
 	}
 
 	/* Convert to micrometers/s^2 */
@@ -544,7 +546,7 @@ static inline void icm42688_accel_ms(const struct icm42688_cfg *cfg, int32_t in,
 static inline void icm42688_gyro_rads(const struct icm42688_cfg *cfg, int32_t in, int32_t *out_rads,
 				      int32_t *out_urads)
 {
-	int64_t sensitivity = 0; /* value equivalent for 10x gyro reading deg/s */
+	int64_t sensitivity;
 
 	switch (cfg->gyro_fs) {
 	case ICM42688_DT_GYRO_FS_2000:
@@ -571,6 +573,8 @@ static inline void icm42688_gyro_rads(const struct icm42688_cfg *cfg, int32_t in
 	case ICM42688_DT_GYRO_FS_15_625:
 		sensitivity = 20972;
 		break;
+	default:
+		CODE_UNREACHABLE;
 	}
 
 	int64_t in10_rads = (int64_t)in * SENSOR_PI * 10LL;


### PR DESCRIPTION
There were code paths that could have lead to divide by zero given an invalid scale setting for accel or gyro. In practice this should be an invalid setup even before getting to these conversion functions. The conversion functions now better show all valid values are accounted for by using CODE_UNREACHABLE in the default case.