### PR TITLE
drivers: sensor: fcx_mldx5 fix string_overflow issue

### DIFF
--- a/drivers/sensor/fcx_mldx5/fcx_mldx5.c
+++ b/drivers/sensor/fcx_mldx5/fcx_mldx5.c
@@ -235,7 +235,8 @@ static void fcx_mldx5_uart_send(const struct device *dev, enum fcx_mldx5_cmd cmd
 
 	buf[FCX_MLDX5_STX_INDEX] = FCX_MLDX5_STX;
 	memcpy(&buf[FCX_MLDX5_CMD_INDEX], fcx_mldx5_cmds[cmd], FCX_MLDX5_CMD_LEN);
-	if (cmd_data_len != 0 && cmd_data_len == fcx_mldx5_cmds_data_len[cmd]) {
+	if (cmd_data_len != 0 && cmd_data_len == fcx_mldx5_cmds_data_len[cmd] &&
+	    cmd_data_len <= (FCX_MLDX5_MAX_FRAME_LEN - FCX_MLDX5_HEADER_LEN)) {
 		memcpy(&buf[FCX_MLDX5_DATA_INDEX], cmd_data, strlen(cmd_data));
 	}
 


### PR DESCRIPTION
This commit fixes Copy into fixed size buffer (STRING_OVERFLOW) by checking the cmd_data_len