### PR TITLE
drivers: flash: flash_mcux_flexspi_nor: check all 3 bytes of JEDEC ID

### DIFF
--- a/drivers/flash/flash_mcux_flexspi_nor.c
+++ b/drivers/flash/flash_mcux_flexspi_nor.c
@@ -954,8 +954,10 @@ static int flash_flexspi_nor_check_jedec(struct flash_flexspi_nor_data *data,
 	}
 
 	/* Switch on manufacturer and vendor ID */
-	switch (vendor_id & 0xFFFF) {
-	case 0x609d: /* IS25LP flash, needs P[4:3] cleared with same method as IS25WP */
+	switch (vendor_id & 0xFFFFFF) {
+	case 0x16609d: /* IS25LP032 flash, needs P[4:3] cleared with same method as IS25WP */
+	case 0x17609d: /* IS25LP064 */
+	case 0x18609d: /* IS25LP128 */
 		read_params = 0xE0U;
 		ret = flash_flexspi_nor_is25_clear_read_param(data, flexspi_lut, &read_params);
 		if (ret < 0) {
@@ -969,7 +971,9 @@ static int flash_flexspi_nor_check_jedec(struct flash_flexspi_nor_data *data,
 		}
 		/* Still return an error- we want the JEDEC configuration to run */
 		return -ENOTSUP;
-	case 0x709d:
+	case 0x16709d: /* IS25WP032 */
+	case 0x17709d: /* IS25WP064 */
+	case 0x18709d: /* IS25WP128 */
 		/*
 		 * IS25WP flash. We can support this flash with the JEDEC probe,
 		 * but we need to insure P[6:3] are at the default value
@@ -987,15 +991,8 @@ static int flash_flexspi_nor_check_jedec(struct flash_flexspi_nor_data *data,
 		}
 		/* Still return an error- we want the JEDEC configuration to run */
 		return -ENOTSUP;
-	case 0x40ef:
-		if ((vendor_id & 0xFFFFFF) != 0x2040ef) {
-			/*
-			 * This is not the correct flash chip, and will not
-			 * support the LUT table. Return here
-			 */
-			return -ENOTSUP;
-		}
-		/* W25Q512JV flash, use 4 byte read/write */
+	case 0x2040ef:
+		/* W25Q512JV-IQ/IN flash, use 4 byte read/write */
 		flexspi_lut[READ][0] = FLEXSPI_LUT_SEQ(
 				kFLEXSPI_Command_SDR, kFLEXSPI_1PAD, SPI_NOR_CMD_4READ_4B,
 				kFLEXSPI_Command_RADDR_SDR, kFLEXSPI_4PAD, 32);
@@ -1025,14 +1022,7 @@ static int flash_flexspi_nor_check_jedec(struct flash_flexspi_nor_data *data,
 		/* Device uses bit 1 of status reg 2 for QE */
 		return flash_flexspi_nor_quad_enable(data, flexspi_lut,
 						     JESD216_DW15_QER_VAL_S2B1v5);
-	case 0x60ef:
-		if ((vendor_id & 0xFFFFFF) != 0x2060ef) {
-			/*
-			 * This is not the correct flash chip, and will not
-			 * support the LUT table. Return here
-			 */
-			return -ENOTSUP;
-		}
+	case 0x2060ef:
 		/* W25Q512NW-IQ/IN flash, use 4 byte read/write */
 		flexspi_lut[READ][0] = FLEXSPI_LUT_SEQ(
 				kFLEXSPI_Command_SDR, kFLEXSPI_1PAD, SPI_NOR_CMD_4READ_4B,
@@ -1063,8 +1053,8 @@ static int flash_flexspi_nor_check_jedec(struct flash_flexspi_nor_data *data,
 		/* Device uses bit 1 of status reg 2 for QE */
 		return flash_flexspi_nor_quad_enable(data, flexspi_lut,
 						     JESD216_DW15_QER_VAL_S2B1v5);
-	case 0x25C2:
-		/* MX25 flash, use 4 byte read/write */
+	case 0x3A25C2:
+		/* MX25U51245G flash, use 4 byte read/write */
 		flexspi_lut[READ][0] = FLEXSPI_LUT_SEQ(
 				kFLEXSPI_Command_SDR, kFLEXSPI_1PAD, SPI_NOR_CMD_4READ_4B,
 				kFLEXSPI_Command_RADDR_SDR, kFLEXSPI_4PAD, 32);


### PR DESCRIPTION
The FlexSPI NOR driver should verify all 3 bytes of the JEDEC ID match the expected value before attempting to use a custom LUT table with a flash chip. This reduces the odds that an incompatible LUT will be used with a flash chip, as some flash chips may share the same first byte of their device ID but not be compatible with the custom LUT table.


This PR has been validated on the following flash chips using `tests/drivers/flash/common`:

- [x] W25Q128JW (RT1180)
- [x] W25Q64JVSSIQ (RT1040)
- [x] W25Q32JVWJ0 (RT1064,RT1024)
- [x] AT25SF128A (RT1010, RT1015)
- [x] IS25WP128 (RT1170,RT1160)
- [x] IS25LP064 (RT1020)
- [x] IS25WP064 (RT1060, RT1060-EVKB, RT1064)
- [x] MX25U51245G (RD RW612)
- [x] W25Q512JVFIQ (FRDM RW612)
- [x] W25Q64JVSSIQ (FRDM MCXN947)
- [x] W25Q512NW (RT1170-EVKB)