### PR TITLE
samples: lora: receive: update SNR unit to dB

### DIFF
--- a/samples/drivers/lora/receive/README.rst
+++ b/samples/drivers/lora/receive/README.rst
@@ -36,20 +36,48 @@ Sample Output
 
 .. code-block:: console
 
-    [00:00:00.235,000] <inf> lora_receive: Synchronous reception
-    [00:00:00.956,000] <inf> lora_receive: Received data: helloworld (RSSI:-60dBm, SNR:7dBm)
-    [00:00:02.249,000] <inf> lora_receive: Received data: helloworld (RSSI:-57dBm, SNR:9dBm)
-    [00:00:03.541,000] <inf> lora_receive: Received data: helloworld (RSSI:-57dBm, SNR:9dBm)
-    [00:00:04.834,000] <inf> lora_receive: Received data: helloworld (RSSI:-55dBm, SNR:9dBm)
-    [00:00:04.834,000] <inf> lora_receive: Asynchronous reception
-    [00:00:06.127,000] <inf> lora_receive: Received data: helloworld (RSSI:-55dBm, SNR:9dBm)
-    [00:00:07.419,000] <inf> lora_receive: Received data: helloworld (RSSI:-55dBm, SNR:9dBm)
-    [00:00:08.712,000] <inf> lora_receive: Received data: helloworld (RSSI:-55dBm, SNR:9dBm)
-    [00:00:10.004,000] <inf> lora_receive: Received data: helloworld (RSSI:-55dBm, SNR:9dBm)
-    [00:00:11.297,000] <inf> lora_receive: Received data: helloworld (RSSI:-55dBm, SNR:9dBm)
-    [00:00:12.590,000] <inf> lora_receive: Received data: helloworld (RSSI:-55dBm, SNR:9dBm)
-    [00:00:13.884,000] <inf> lora_receive: Received data: helloworld (RSSI:-55dBm, SNR:9dBm)
-    [00:00:15.177,000] <inf> lora_receive: Received data: helloworld (RSSI:-55dBm, SNR:9dBm)
-    [00:00:16.470,000] <inf> lora_receive: Received data: helloworld (RSSI:-55dBm, SNR:9dBm)
-    [00:00:17.762,000] <inf> lora_receive: Received data: helloworld (RSSI:-55dBm, SNR:9dBm)
-    [00:00:17.762,000] <inf> lora_receive: Stopping packet receptions
+   [00:00:00.235,000] <inf> lora_receive: Synchronous reception
+   [00:00:00.956,000] <inf> lora_receive: LoRa RX RSSI: -60dBm, SNR: 7dB
+   [00:00:00.956,000] <inf> lora_receive: LoRa RX payload
+                                          68 65 6c 6c 6f 77 6f 72  6c 64                   |hellowor ld
+   [00:00:02.249,000] <inf> lora_receive: LoRa RX RSSI: -57dBm, SNR: 9dB
+   [00:00:02.249,000] <inf> lora_receive: LoRa RX payload
+                                          68 65 6c 6c 6f 77 6f 72  6c 64                   |hellowor ld
+   [00:00:03.541,000] <inf> lora_receive: LoRa RX RSSI: -57dBm, SNR: 9dB
+   [00:00:03.541,000] <inf> lora_receive: LoRa RX payload
+                                          68 65 6c 6c 6f 77 6f 72  6c 64                   |hellowor ld
+   [00:00:04.834,000] <inf> lora_receive: LoRa RX RSSI: -55dBm, SNR: 9dB
+   [00:00:04.834,000] <inf> lora_receive: LoRa RX payload
+                                          68 65 6c 6c 6f 77 6f 72  6c 64                   |hellowor ld
+   [00:00:04.834,000] <inf> lora_receive: Asynchronous reception
+   [00:00:06.127,000] <inf> lora_receive: LoRa RX RSSI: -55dBm, SNR: 9dB
+   [00:00:06.127,000] <inf> lora_receive: LoRa RX payload
+                                          68 65 6c 6c 6f 77 6f 72  6c 64                   |hellowor ld
+   [00:00:07.419,000] <inf> lora_receive: LoRa RX RSSI: -55dBm, SNR: 9dB
+   [00:00:07.419,000] <inf> lora_receive: LoRa RX payload
+                                          68 65 6c 6c 6f 77 6f 72  6c 64                   |hellowor ld
+   [00:00:08.712,000] <inf> lora_receive: LoRa RX RSSI: -55dBm, SNR: 9dB
+   [00:00:08.712,000] <inf> lora_receive: LoRa RX payload
+                                          68 65 6c 6c 6f 77 6f 72  6c 64                   |hellowor ld
+   [00:00:10.004,000] <inf> lora_receive: LoRa RX RSSI: -55dBm, SNR: 9dB
+   [00:00:10.004,000] <inf> lora_receive: LoRa RX payload
+                                          68 65 6c 6c 6f 77 6f 72  6c 64                   |hellowor ld
+   [00:00:11.297,000] <inf> lora_receive: LoRa RX RSSI: -55dBm, SNR: 9dB
+   [00:00:11.297,000] <inf> lora_receive: LoRa RX payload
+                                          68 65 6c 6c 6f 77 6f 72  6c 64                   |hellowor ld
+   [00:00:12.590,000] <inf> lora_receive: LoRa RX RSSI: -55dBm, SNR: 9dB
+   [00:00:12.590,000] <inf> lora_receive: LoRa RX payload
+                                          68 65 6c 6c 6f 77 6f 72  6c 64                   |hellowor ld
+   [00:00:13.884,000] <inf> lora_receive: LoRa RX RSSI: -55dBm, SNR: 9dB
+   [00:00:13.884,000] <inf> lora_receive: LoRa RX payload
+                                          68 65 6c 6c 6f 77 6f 72  6c 64                   |hellowor ld
+   [00:00:15.177,000] <inf> lora_receive: LoRa RX RSSI: -55dBm, SNR: 9dB
+   [00:00:15.177,000] <inf> lora_receive: LoRa RX payload
+                                          68 65 6c 6c 6f 77 6f 72  6c 64                   |hellowor ld
+   [00:00:16.470,000] <inf> lora_receive: LoRa RX RSSI: -55dBm, SNR: 9dB
+   [00:00:16.470,000] <inf> lora_receive: LoRa RX payload
+                                          68 65 6c 6c 6f 77 6f 72  6c 64                   |hellowor ld
+   [00:00:17.762,000] <inf> lora_receive: LoRa RX RSSI: -55dBm, SNR: 9dB
+   [00:00:17.762,000] <inf> lora_receive: LoRa RX payload
+                                          68 65 6c 6c 6f 77 6f 72  6c 64                   |hellowor ld
+   [00:00:17.762,000] <inf> lora_receive: Stopping packet receptions

--- a/samples/drivers/lora/receive/src/main.c
+++ b/samples/drivers/lora/receive/src/main.c
@@ -28,8 +28,8 @@ void lora_receive_cb(const struct device *dev, uint8_t *data, uint16_t size,
 	ARG_UNUSED(dev);
 	ARG_UNUSED(size);
 
-	LOG_INF("Received data: %s (RSSI:%ddBm, SNR:%ddBm)",
-		data, rssi, snr);
+	LOG_INF("LoRa RX RSSI: %d dBm, SNR: %d dB", rssi, snr);
+	LOG_HEXDUMP_INF(data, size, "LoRa RX payload");
 
 	/* Stop receiving after 10 packets */
 	if (++cnt == 10) {
@@ -79,8 +79,8 @@ int main(void)
 			return 0;
 		}
 
-		LOG_INF("Received data: %s (RSSI:%ddBm, SNR:%ddBm)",
-			data, rssi, snr);
+		LOG_INF("LoRa RX RSSI: %d dBm, SNR: %d dB", rssi, snr);
+		LOG_HEXDUMP_INF(data, size, "LoRa RX payload");
 	}
 
 	/* Enable asynchronous reception */


### PR DESCRIPTION
Signal-to-noise ratio is a unitless quantity, so its unit is dB, not dBm (dBm is the power relative to 1 milliwatt). At the same time output the received payload using `LOG_HEXDUMP_INF`, instead of limiting the sample solely to string payloads.

Fixes #82414

Ideally this would also update the README sample output, but I no longer have access to any hardware with a LoRa modem to regenerate it.