### PR TITLE
MAINTAINERS: Update collaborators for Devicetree

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -887,6 +887,7 @@ Devicetree:
   collaborators:
     - decsny
     - galak
+    - rruuaanng
   files-regex:
     - dts/bindings/.*zephyr.*
     - dts/bindings/[^,]+$


### PR DESCRIPTION
Add @rruuaanng to devicetree collaborators.

Devicetree currently lacks active reviewers (the existing ones are busy), and given my contributions to the devicetree subsystem, I think I can join the review of devicetree.