### PR TITLE
soc: nordic: common: mram_latency: Add option to auto request no latency

### DIFF
--- a/soc/nordic/common/Kconfig
+++ b/soc/nordic/common/Kconfig
@@ -22,6 +22,13 @@ config MRAM_LATENCY_SYNC_TIMEOUT
 	help
 	  Timeout is given in milliseconds.
 
+config MRAM_LATENCY_AUTO_REQ
+	bool "Request MRAM without latency at start"
+	help
+	  When enabled then MRAM configuration without latency is requested
+	  during the initialization and is kept enabled until the mram_latency API user
+	  calls mram_no_latency_sync_release().
+
 module = MRAM_LATENCY
 module-str = mram_latency
 source "subsys/logging/Kconfig.template.log_config"

--- a/soc/nordic/common/mram_latency.c
+++ b/soc/nordic/common/mram_latency.c
@@ -168,6 +168,10 @@ static int init_nrfs(void)
 
 	state = MRAM_LATENCY_ON;
 
+	if (IS_ENABLED(CONFIG_MRAM_LATENCY_AUTO_REQ)) {
+		mram_no_latency_sync_request();
+	}
+
 	return rv;
 }
 


### PR DESCRIPTION
Add CONFIG_MRAM_LATENCY_AUTO_REQ. When option is enabled then module requests no latency during the initialization. This option might be useful for cases where we want to achieve maximum performance and want to avoid controlling MRAM in the code.

Extension to #81381.