### PR TITLE
doc: releases: 4.1: Mention "imply NVS" removal in OpenThread.

### DIFF
--- a/doc/releases/migration-guide-4.1.rst
+++ b/doc/releases/migration-guide-4.1.rst
@@ -275,6 +275,10 @@ Networking
   rather than directly in the :c:struct:`http_client_ctx` to correctly handle concurrent requests
   on different HTTP/2 streams.
 
+* The :kconfig:option:`CONFIG_NET_L2_OPENTHREAD` symbol no longer implies the
+  :kconfig:option:`CONFIG_NVS` Kconfig option. Platforms using OpenThread must explicitly enable
+  either the :kconfig:option:`CONFIG_NVS` or :kconfig:option:`CONFIG_ZMS` Kconfig option.
+
 Other Subsystems
 ****************
 

--- a/doc/releases/release-notes-4.1.rst
+++ b/doc/releases/release-notes-4.1.rst
@@ -254,7 +254,9 @@ Networking
 
 * Network Interface:
 
-* OpenThread
+* OpenThread:
+
+  * Removed the implicit enabling of the :kconfig:option:`CONFIG_NVS` Kconfig option by the :kconfig:option:`CONFIG_NET_L2_OPENTHREAD` symbol.
 
 * PPP
 


### PR DESCRIPTION
The NET_L2_OPENTHREAD symbol no longer implies the NVS Kconfig option. Platforms using OpenThread must explicitly enable either NVS or ZMS option.

A release note and migration guide entries were added.