### PR TITLE
clock: stm32_ll_h7: add missing STM32_SRC_HSI_KER entry

### DIFF
--- a/drivers/clock_control/clock_stm32_ll_h7.c
+++ b/drivers/clock_control/clock_stm32_ll_h7.c
@@ -541,6 +541,11 @@ static int stm32_clock_control_get_subsys_rate(const struct device *clock,
 		*rate = STM32_LSI_FREQ;
 		break;
 #endif /* STM32_LSI_ENABLED */
+#if defined(STM32_HSI_ENABLED)
+	case STM32_SRC_HSI_KER:
+		*rate = STM32_HSI_FREQ/STM32_HSI_DIVISOR;
+	break;
+#endif /* STM32_HSI_ENABLED */
 #if defined(STM32_HSI48_ENABLED)
 	case STM32_SRC_HSI48:
 		*rate = STM32_HSI48_FREQ;


### PR DESCRIPTION
Add a missing case for STM32_SRC_HSI_KER in the
stm32_clock_control_get_subsys_rate function.