### PR TITLE
sensors: lsm6dsv16x: Kconfig: Fix trigger mode

### DIFF
--- a/drivers/sensor/st/lsm6dsv16x/Kconfig
+++ b/drivers/sensor/st/lsm6dsv16x/Kconfig
@@ -29,6 +29,8 @@ config LSM6DSV16X_STREAM
 	  Use this config option to enable streaming sensor data via RTIO subsystem.
 
 choice LSM6DSV16X_TRIGGER_MODE
+	default LSM6DSV16X_TRIGGER_GLOBAL_THREAD if LSM6DSV16X_STREAM
+	default LSM6DSV16X_TRIGGER_NONE
 	prompt "Trigger mode"
 	help
 	  Specify the type of triggering to be used by the driver.


### PR DESCRIPTION
Select TRIGGER_GLOBAL_THREAD by default if rtio streaming is enabled, and TRIGGER_NONE otherwise. This change prevents bad trigger configurations like

    CONFIG_LSM6DSV16X_TRIGGER=y
    CONFIG_LSM6DSV16X_TRIGGER_NONE=y

which does not have any sense.


Mentioned here:
https://github.com/zephyrproject-rtos/zephyr/pull/79346#discussion_r1867404374