### PR TITLE
tests: drivers: pwm: pwm_to_gpio_loopback

### DIFF
--- a/tests/drivers/pwm/pwm_to_gpio_loopback/CMakeLists.txt
+++ b/tests/drivers/pwm/pwm_to_gpio_loopback/CMakeLists.txt
@@ -1,0 +1,13 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(pwm_loopback)
+
+FILE(GLOB app_sources src/*.c)
+target_sources(app PRIVATE ${app_sources})

--- a/tests/drivers/pwm/pwm_to_gpio_loopback/Kconfig
+++ b/tests/drivers/pwm/pwm_to_gpio_loopback/Kconfig
@@ -1,0 +1,15 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+config TEST_PWM_PERIOD_USEC
+	int "PWM period in microseconds"
+	default 200000
+	help
+	  Set PWM signal period to TEST_PWM_PERIOD_USEC microseconds.
+	  In the test, PWM pulse width will be set to half of this value.
+	  The maximum allowable PWM period value is limited by the hardware design.
+
+source "Kconfig.zephyr"

--- a/tests/drivers/pwm/pwm_to_gpio_loopback/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/tests/drivers/pwm/pwm_to_gpio_loopback/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/pwm/pwm.h>
+#include <zephyr/dt-bindings/gpio/nordic-nrf-gpio.h>
+
+/ {
+	pwm_to_gpio_loopback: pwm_to_gpio_loopback {
+		compatible = "test-pwm-to-gpio-loopback";
+		pwms = <&pwm130 0 0 PWM_POLARITY_NORMAL>;
+		gpios = <&gpio0 1 GPIO_ACTIVE_HIGH>;
+	};
+};
+
+&pinctrl {
+	pwm_default: pwm_default {
+		group1 {
+			psels = <NRF_PSEL(PWM_OUT0, 0, 0)>;
+		};
+	};
+	pwm_sleep: pwm_sleep {
+		group1 {
+			psels = <NRF_PSEL(PWM_OUT0, 0, 0)>;
+			low-power-enable;
+		};
+	};
+};
+
+&pwm130 {
+	status = "okay";
+	pinctrl-0 = <&pwm_default>;
+	pinctrl-1 = <&pwm_sleep>;
+	pinctrl-names = "default", "sleep";
+	memory-regions = <&cpuapp_dma_region>;
+};

--- a/tests/drivers/pwm/pwm_to_gpio_loopback/boards/nrf54h20dk_nrf54h20_cpuapp_fast_p7_0.overlay
+++ b/tests/drivers/pwm/pwm_to_gpio_loopback/boards/nrf54h20dk_nrf54h20_cpuapp_fast_p7_0.overlay
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/pwm/pwm.h>
+#include <zephyr/dt-bindings/gpio/nordic-nrf-gpio.h>
+
+/* Test requires wire connection between:
+ *  - PWM120 OUT[0] at P7.0
+ *  - GPIO input at P1.09
+ */
+
+/ {
+	pwm_to_gpio_loopback: pwm_to_gpio_loopback {
+		compatible = "test-pwm-to-gpio-loopback";
+		pwms = <&pwm120 0 0 PWM_POLARITY_NORMAL>;
+		gpios = <&gpio1 9 GPIO_ACTIVE_HIGH>;
+	};
+};
+
+&pinctrl {
+	pwm_default: pwm_default {
+		group1 {
+			psels = <NRF_PSEL(PWM_OUT0, 7, 0)>;
+		};
+	};
+	pwm_sleep: pwm_sleep {
+		group1 {
+			psels = <NRF_PSEL(PWM_OUT0, 7, 0)>;
+			low-power-enable;
+		};
+	};
+};
+
+&gpio1 {
+	status = "okay";
+};
+
+&pwm120 {
+	status = "okay";
+	pinctrl-0 = <&pwm_default>;
+	pinctrl-1 = <&pwm_sleep>;
+	pinctrl-names = "default", "sleep";
+	memory-regions = <&dma_fast_region>;
+};
+
+&dma_fast_region {
+	status = "okay";
+};
+
+&pwm130 {
+	status = "disabled";
+};

--- a/tests/drivers/pwm/pwm_to_gpio_loopback/boards/nrf54h20dk_nrf54h20_cpuapp_fast_p7_1.overlay
+++ b/tests/drivers/pwm/pwm_to_gpio_loopback/boards/nrf54h20dk_nrf54h20_cpuapp_fast_p7_1.overlay
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/pwm/pwm.h>
+#include <zephyr/dt-bindings/gpio/nordic-nrf-gpio.h>
+
+/* Test requires wire connection between:
+ *  - PWM120 OUT[1] at P7.1
+ *  - GPIO input at P1.05
+ */
+
+/ {
+	pwm_to_gpio_loopback: pwm_to_gpio_loopback {
+		compatible = "test-pwm-to-gpio-loopback";
+		pwms = <&pwm120 1 0 PWM_POLARITY_NORMAL>;
+		gpios = <&gpio1 5 GPIO_ACTIVE_HIGH>;
+	};
+};
+
+&pinctrl {
+	pwm_default: pwm_default {
+		group1 {
+			psels = <NRF_PSEL(PWM_OUT1, 7, 1)>;
+		};
+	};
+	pwm_sleep: pwm_sleep {
+		group1 {
+			psels = <NRF_PSEL(PWM_OUT1, 7, 1)>;
+			low-power-enable;
+		};
+	};
+};
+
+&gpio1 {
+	status = "okay";
+};
+
+&pwm120 {
+	status = "okay";
+	pinctrl-0 = <&pwm_default>;
+	pinctrl-1 = <&pwm_sleep>;
+	pinctrl-names = "default", "sleep";
+	memory-regions = <&dma_fast_region>;
+};
+
+&dma_fast_region {
+	status = "okay";
+};
+
+&pwm130 {
+	status = "disabled";
+};

--- a/tests/drivers/pwm/pwm_to_gpio_loopback/boards/nrf54h20dk_nrf54h20_cpuapp_fast_p7_6.overlay
+++ b/tests/drivers/pwm/pwm_to_gpio_loopback/boards/nrf54h20dk_nrf54h20_cpuapp_fast_p7_6.overlay
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/pwm/pwm.h>
+#include <zephyr/dt-bindings/gpio/nordic-nrf-gpio.h>
+
+/* Test requires wire connection between:
+ *  - PWM120 OUT[2] at P7.6
+ *  - GPIO input at P1.06
+ */
+
+/ {
+	pwm_to_gpio_loopback: pwm_to_gpio_loopback {
+		compatible = "test-pwm-to-gpio-loopback";
+		pwms = <&pwm120 2 0 PWM_POLARITY_NORMAL>;
+		gpios = <&gpio1 6 GPIO_ACTIVE_HIGH>;
+	};
+};
+
+&pinctrl {
+	pwm_default: pwm_default {
+		group1 {
+			psels = <NRF_PSEL(PWM_OUT2, 7, 6)>;
+		};
+	};
+	pwm_sleep: pwm_sleep {
+		group1 {
+			psels = <NRF_PSEL(PWM_OUT2, 7, 6)>;
+			low-power-enable;
+		};
+	};
+};
+
+&gpio1 {
+	status = "okay";
+};
+
+&pwm120 {
+	status = "okay";
+	pinctrl-0 = <&pwm_default>;
+	pinctrl-1 = <&pwm_sleep>;
+	pinctrl-names = "default", "sleep";
+	memory-regions = <&dma_fast_region>;
+};
+
+&dma_fast_region {
+	status = "okay";
+};
+
+&pwm130 {
+	status = "disabled";
+};

--- a/tests/drivers/pwm/pwm_to_gpio_loopback/boards/nrf54h20dk_nrf54h20_cpuapp_fast_p7_7.overlay
+++ b/tests/drivers/pwm/pwm_to_gpio_loopback/boards/nrf54h20dk_nrf54h20_cpuapp_fast_p7_7.overlay
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/pwm/pwm.h>
+#include <zephyr/dt-bindings/gpio/nordic-nrf-gpio.h>
+
+/* Test requires wire connection between:
+ *  - PWM120 OUT[3] at P7.7
+ *  - GPIO input at P1.08
+ */
+
+/ {
+	pwm_to_gpio_loopback: pwm_to_gpio_loopback {
+		compatible = "test-pwm-to-gpio-loopback";
+		pwms = <&pwm120 3 0 PWM_POLARITY_NORMAL>;
+		gpios = <&gpio1 8 GPIO_ACTIVE_HIGH>;
+	};
+};
+
+&pinctrl {
+	pwm_default: pwm_default {
+		group1 {
+			psels = <NRF_PSEL(PWM_OUT3, 7, 7)>;
+		};
+	};
+	pwm_sleep: pwm_sleep {
+		group1 {
+			psels = <NRF_PSEL(PWM_OUT3, 7, 7)>;
+			low-power-enable;
+		};
+	};
+};
+
+&gpio1 {
+	status = "okay";
+};
+
+&pwm120 {
+	status = "okay";
+	pinctrl-0 = <&pwm_default>;
+	pinctrl-1 = <&pwm_sleep>;
+	pinctrl-names = "default", "sleep";
+	memory-regions = <&dma_fast_region>;
+};
+
+&dma_fast_region {
+	status = "okay";
+};
+
+&pwm130 {
+	status = "disabled";
+};

--- a/tests/drivers/pwm/pwm_to_gpio_loopback/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/tests/drivers/pwm/pwm_to_gpio_loopback/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/pwm/pwm.h>
+#include <zephyr/dt-bindings/gpio/nordic-nrf-gpio.h>
+
+/ {
+	pwm_to_gpio_loopback: pwm_to_gpio_loopback {
+		compatible = "test-pwm-to-gpio-loopback";
+		pwms = <&pwm20 0 0 PWM_POLARITY_NORMAL>;
+		gpios = <&gpio1 11 GPIO_ACTIVE_HIGH>;
+	};
+};

--- a/tests/drivers/pwm/pwm_to_gpio_loopback/dts/bindings/test-pwm-to-gpio-loopback.yaml
+++ b/tests/drivers/pwm/pwm_to_gpio_loopback/dts/bindings/test-pwm-to-gpio-loopback.yaml
@@ -1,0 +1,24 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+description: |
+    This binding provides resources required to build and run the
+    tests/drivers/pwm/pwm_to_gpio_loopback test in Zephyr.
+
+compatible: "test-pwm-to-gpio-loopback"
+
+properties:
+  pwms:
+    type: phandle-array
+    required: true
+    description: |
+      PWM pin that will be used for generating a pulse-width modulated signal.
+  gpios:
+    type: phandle-array
+    required: true
+    description: |
+      GPIO pin will be used for capturing the generated signal. The PWM and GPIO
+      pins must be physically connected to each other.

--- a/tests/drivers/pwm/pwm_to_gpio_loopback/prj.conf
+++ b/tests/drivers/pwm/pwm_to_gpio_loopback/prj.conf
@@ -1,0 +1,12 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+CONFIG_ZTEST=y
+CONFIG_TEST_USERSPACE=y
+
+CONFIG_PWM=y
+CONFIG_GPIO=y
+CONFIG_NRF_REGTOOL_VERBOSITY=1

--- a/tests/drivers/pwm/pwm_to_gpio_loopback/src/main.c
+++ b/tests/drivers/pwm/pwm_to_gpio_loopback/src/main.c
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/ztest.h>
+#include "test_pwm_to_gpio_loopback.h"
+
+static void *pwm_loopback_setup(void)
+{
+	struct pwm_dt_spec out;
+	struct gpio_dt_spec in;
+
+	get_test_devices(&out, &in);
+
+	k_object_access_grant(out.dev, k_current_get());
+	k_object_access_grant(in.port, k_current_get());
+
+	TC_PRINT("Testing PWM device %s, channel %d\n", out.dev->name, out.channel);
+	TC_PRINT("GPIO loopback at %s, pin %d\n", in.port->name, in.pin);
+	TC_PRINT("===================================================================\n");
+
+	return NULL;
+}
+
+ZTEST_SUITE(pwm_loopback, NULL, pwm_loopback_setup, NULL, NULL, NULL);

--- a/tests/drivers/pwm/pwm_to_gpio_loopback/src/test_pwm_to_gpio_loopback.c
+++ b/tests/drivers/pwm/pwm_to_gpio_loopback/src/test_pwm_to_gpio_loopback.c
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/drivers/pwm.h>
+#include <zephyr/ztest.h>
+
+#include "test_pwm_to_gpio_loopback.h"
+
+#define NUMBER_OF_CYCLE_TO_CAPTURE 5
+
+static struct gpio_callback pwm_input_cb_data;
+static volatile uint32_t high, low;
+
+void pwm_input_captured_callback(const struct device *dev, struct gpio_callback *cb, uint32_t pins)
+{
+	uint32_t pin = 0;
+
+	while (pins >>= 1) {
+		pin++;
+	}
+
+	if (gpio_pin_get(dev, pin)) {
+		high++;
+	} else {
+		low++;
+	}
+}
+
+void get_test_devices(struct pwm_dt_spec *out, struct gpio_dt_spec *in)
+{
+	/* PWM generator device */
+	out->dev = DEVICE_DT_GET(PWM_LOOPBACK_OUT_CTLR);
+	out->channel = PWM_LOOPBACK_OUT_CHANNEL;
+	out->period = PWM_LOOPBACK_OUT_PERIOD;
+	out->flags = PWM_LOOPBACK_OUT_FLAGS;
+	zassert_true(pwm_is_ready_dt(out), "pwm loopback output device is not ready");
+
+	in->port = DEVICE_DT_GET(GPIO_LOOPBACK_IN_CTRL);
+	in->pin = GPIO_LOOPBACK_IN_PIN;
+	in->dt_flags = GPIO_LOOPBACK_IN_FLAGS;
+	zassert_true(gpio_is_ready_dt(in), "pwm loopback in device is not ready");
+}
+
+static void test_capture(uint32_t period, uint32_t pulse, pwm_flags_t flags)
+{
+	struct pwm_dt_spec out;
+	struct gpio_dt_spec in;
+
+	int err = 0;
+
+	TC_PRINT("Pulse/period: %u/%u usec\n", pulse, period);
+
+	get_test_devices(&out, &in);
+
+	/* clear edge counters */
+	high = 0;
+	low = 0;
+
+	/* configure and enable PWM */
+	err = pwm_set(out.dev, out.channel, PWM_USEC(period), PWM_USEC(pulse),
+		      out.flags ^= (flags & PWM_POLARITY_MASK));
+	zassert_equal(err, 0, "failed to set pwm output (err %d)", err);
+
+	/* configure and enable GPIOTE */
+	err = gpio_pin_configure_dt(&in, GPIO_INPUT);
+	zassert_equal(err, 0, "failed to configure input pin (err %d)", err);
+
+	err = gpio_pin_interrupt_configure_dt(&in, GPIO_INT_EDGE_BOTH);
+	zassert_equal(err, 0, "failed to configure input pin interrupt (err %d)", err);
+
+	gpio_init_callback(&pwm_input_cb_data, pwm_input_captured_callback, BIT(in.pin));
+	gpio_add_callback(in.port, &pwm_input_cb_data);
+
+	/* NUMBER_OF_CYCLE_TO_CAPTURE periods plus 1/4 of period to catch the last edge */
+	k_usleep((NUMBER_OF_CYCLE_TO_CAPTURE * period) + (period >> 2));
+
+	TC_PRINT("PWM output -high state counter: %d -low state counter: %d\n", high, low);
+	zassert((high >= NUMBER_OF_CYCLE_TO_CAPTURE) && (low >= NUMBER_OF_CYCLE_TO_CAPTURE),
+		"PWM not captured");
+}
+
+ZTEST(pwm_loopback, test_pwm_polarity_normal)
+{
+	test_capture(CONFIG_TEST_PWM_PERIOD_USEC, (CONFIG_TEST_PWM_PERIOD_USEC >> 1),
+		PWM_POLARITY_NORMAL);
+}
+
+ZTEST(pwm_loopback, test_pwm_polarity_inverted)
+{
+	test_capture(CONFIG_TEST_PWM_PERIOD_USEC, (CONFIG_TEST_PWM_PERIOD_USEC >> 1),
+		PWM_POLARITY_INVERTED);
+}

--- a/tests/drivers/pwm/pwm_to_gpio_loopback/src/test_pwm_to_gpio_loopback.h
+++ b/tests/drivers/pwm/pwm_to_gpio_loopback/src/test_pwm_to_gpio_loopback.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef __TEST_PWM_TO_GPIO_LOOPBACK_H__
+#define __TEST_PWM_TO_GPIO_LOOPBACK_H__
+
+#include <zephyr/kernel.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/drivers/pwm.h>
+#include <zephyr/ztest.h>
+
+#define PWM_LOOPBACK_NODE DT_INST(0, test_pwm_to_gpio_loopback)
+
+#define PWM_LOOPBACK_OUT_CTLR	 DT_PWMS_CTLR(PWM_LOOPBACK_NODE)
+#define PWM_LOOPBACK_OUT_CHANNEL DT_PWMS_CHANNEL(PWM_LOOPBACK_NODE)
+#define PWM_LOOPBACK_OUT_PERIOD	 DT_PWMS_PERIOD(PWM_LOOPBACK_NODE)
+#define PWM_LOOPBACK_OUT_FLAGS	 DT_PWMS_FLAGS(PWM_LOOPBACK_NODE)
+
+#define GPIO_LOOPBACK_IN_CTRL  DT_GPIO_CTLR(PWM_LOOPBACK_NODE, gpios)
+#define GPIO_LOOPBACK_IN_PIN   DT_GPIO_PIN(PWM_LOOPBACK_NODE, gpios)
+#define GPIO_LOOPBACK_IN_FLAGS DT_GPIO_FLAGS(PWM_LOOPBACK_NODE, gpios)
+
+void get_test_devices(struct pwm_dt_spec *out, struct gpio_dt_spec *in);
+
+#endif /* __TEST_PWM_TO_GPIO_LOOPBACK_H__ */

--- a/tests/drivers/pwm/pwm_to_gpio_loopback/testcase.yaml
+++ b/tests/drivers/pwm/pwm_to_gpio_loopback/testcase.yaml
@@ -1,0 +1,57 @@
+common:
+  tags:
+    - pwm
+    - drivers
+    - ci_tests_drivers_pwm
+  depends_on: pwm
+  filter: dt_compat_enabled("test-pwm-to-gpio-loopback")
+  harness: ztest
+  harness_config:
+    fixture: gpio_loopback
+
+tests:
+  drivers.pwm.gpio_loopback:
+    platform_allow:
+      - nrf54h20dk/nrf54h20/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp
+    integration_platforms:
+      - nrf54h20dk/nrf54h20/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp
+
+  drivers.pwm.gpio_loopback.fast_p7_0:
+    platform_allow:
+      - nrf54h20dk/nrf54h20/cpuapp
+    integration_platforms:
+      - nrf54h20dk/nrf54h20/cpuapp
+    extra_args:
+      DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_fast_p7_0.overlay"
+      CONFIG_TEST_PWM_PERIOD_USEC=10000
+
+  drivers.pwm.gpio_loopback.fast_p7_1:
+    platform_allow:
+      - nrf54h20dk/nrf54h20/cpuapp
+    integration_platforms:
+      - nrf54h20dk/nrf54h20/cpuapp
+    extra_args:
+      DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_fast_p7_1.overlay"
+      CONFIG_TEST_PWM_PERIOD_USEC=10000
+
+  drivers.pwm.gpio_loopback.fast_p7_6:
+    build_only: true
+    platform_allow:
+      - nrf54h20dk/nrf54h20/cpuapp
+    integration_platforms:
+      - nrf54h20dk/nrf54h20/cpuapp
+    extra_args:
+      DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_fast_p7_6.overlay"
+      CONFIG_TEST_PWM_PERIOD_USEC=10000
+
+  drivers.pwm.gpio_loopback.fast_p7_7:
+    build_only: true
+    platform_allow:
+      - nrf54h20dk/nrf54h20/cpuapp
+    integration_platforms:
+      - nrf54h20dk/nrf54h20/cpuapp
+    extra_args:
+      DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_fast_p7_7.overlay"
+      CONFIG_TEST_PWM_PERIOD_USEC=10000


### PR DESCRIPTION
Add test that verify output signal of pwm driver
when can't use the "pwm capture"