### PR TITLE
scripts: twister: add esp32 runner

### DIFF
--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -566,10 +566,14 @@ class DeviceHandler(Handler):
 
                 board_id = hardware.probe_id or hardware.id
                 product = hardware.product
+                serial_port = hardware.serial
                 if board_id is not None:
                     if runner in ("pyocd", "nrfjprog", "nrfutil"):
                         command_extra_args.append("--dev-id")
                         command_extra_args.append(board_id)
+                    elif runner == "esp32":
+                        command_extra_args.append("--esp-device")
+                        command_extra_args.append(serial_port)
                     elif (
                         runner == "openocd"
                         and product == "STM32 STLink"


### PR DESCRIPTION
This PR introduces support for the esp32 runner when utilizing the hardware-map feature. 

As the esp32 runner cannot currently identify target boards by ID, we use the serial port path from the map.yml file.