### PR TITLE
llext: disable for Harvard ARC variants

### DIFF
--- a/doc/services/llext/index.rst
+++ b/doc/services/llext/index.rst
@@ -22,3 +22,5 @@ and introspected to some degree, as well as unloaded when no longer needed.
 
    The LLEXT subsystem requires architecture-specific support. It is currently
    available only on RISC-V, ARM, ARM64, ARC (experimental) and Xtensa cores.
+   Harvard architecture cores that separate code and data paths and have no
+   common memory are not supported.

--- a/subsys/llext/Kconfig
+++ b/subsys/llext/Kconfig
@@ -5,6 +5,7 @@ menuconfig LLEXT
 	bool "Linkable loadable extensions"
 	select CACHE_MANAGEMENT if DCACHE
 	select KERNEL_WHOLE_ARCHIVE
+	depends on !HARVARD
 	help
 	  Enable the linkable loadable extension subsystem
 

--- a/tests/subsys/llext/simple/testcase.yaml
+++ b/tests/subsys/llext/simple/testcase.yaml
@@ -13,6 +13,7 @@ common:
     - qemu_cortex_r5          # ARM Cortex-R5 (ARMv7-R ISA)
     - mps2/an385              # ARM Cortex-M3 (ARMv7-M ISA)
     - mps2/an521/cpu0         # ARM Cortex-M33 (ARMv8-M ISA)
+  filter: not CONFIG_HARVARD
   extra_configs:
     - arch:arm64:CONFIG_LLEXT_HEAP_SIZE=128
   extra_conf_files:


### PR DESCRIPTION
Some ARC processor configurations have separate memory for code (ICCM) and for data (DCCM). Such configurations are unsuitable for LLEXT, except for some quite special cases. For now, disable LLEXT and its tests for these devices completely.