### PR TITLE
tests: posix: threads_ext: remove stale comment

### DIFF
--- a/tests/posix/threads_ext/src/main.c
+++ b/tests/posix/threads_ext/src/main.c
@@ -132,9 +132,6 @@ static void before(void *arg)
 	ARG_UNUSED(arg);
 
 	zassert_ok(pthread_attr_init(&attr));
-	/* TODO: pthread_attr_init() should be sufficient to initialize a thread by itself */
-	/* zassert_ok(pthread_attr_setstack(&attr, &static_thread_stack, STATIC_THREAD_STACK_SIZE));
-	 */
 	attr_valid = true;
 }
 


### PR DESCRIPTION
For a long time now, it's been possible to call `pthread_attr_init()` and have it just to The Right Thing (TM) without having to statically assign a stack.

Remove the stale comment and commented-out code.