### PR TITLE
tests: threads_ext: move min_flash and min_ram parameters to test level

### DIFF
--- a/tests/posix/threads_ext/testcase.yaml
+++ b/tests/posix/threads_ext/testcase.yaml
@@ -7,10 +7,10 @@ common:
   platform_key:
     - arch
     - simulation
+  min_flash: 64
+  min_ram: 32
 tests:
-  portability.posix.threads_ext:
-    min_flash: 64
-    min_ram: 32
+  portability.posix.threads_ext: {}
   portability.posix.threads_ext.minimal:
     extra_configs:
       - CONFIG_MINIMAL_LIBC=y


### PR DESCRIPTION
tests: threads_ext: move min_flash and min_ram parameters to test level

One of the tests is failing since it was split out in 1a633609a0d triggering an assertion:

ASSERTION FAIL [((((size_t)(16)) << 10) - (((uintptr_t) (&_end)) - 0x20000000)) >= 8192] @ WEST_TOPDIR/zephyr/lib/libc/newlib/libc-hooks.c:139

Fix it by making the min_flash and min_ram parameters up to overall test level.
