### PR TITLE
drivers: display: display_ili9xxx: Allow multiple instances

### DIFF
--- a/drivers/display/display_ili9340.h
+++ b/drivers/display/display_ili9340.h
@@ -50,7 +50,7 @@ struct ili9340_regs {
 
 /* Initializer macro for ILI9340 registers. */
 #define ILI9340_REGS_INIT(n)                                                   \
-	static const struct ili9340_regs ili9xxx_regs_##n = {                  \
+	static const struct ili9340_regs ili9340_regs_##n = {                  \
 		.gamset = DT_PROP(DT_INST(n, ilitek_ili9340), gamset),         \
 		.frmctr1 = DT_PROP(DT_INST(n, ilitek_ili9340), frmctr1),       \
 		.disctrl = DT_PROP(DT_INST(n, ilitek_ili9340), disctrl),       \

--- a/drivers/display/display_ili9341.h
+++ b/drivers/display/display_ili9341.h
@@ -121,7 +121,7 @@ struct ili9341_regs {
 		     "ili9341: Error length frame rate control (IFCTL) register");                 \
 	BUILD_ASSERT(DT_PROP_LEN(DT_INST(n, ilitek_ili9341), etmod) == ILI9341_ETMOD_LEN,          \
 		     "ili9341: Error length entry Mode Set (ETMOD) register");                     \
-	static const struct ili9341_regs ili9xxx_regs_##n = {                                      \
+	static const struct ili9341_regs ili9341_regs_##n = {                                      \
 		.gamset = DT_PROP(DT_INST(n, ilitek_ili9341), gamset),                             \
 		.ifmode = DT_PROP(DT_INST(n, ilitek_ili9341), ifmode),                             \
 		.frmctr1 = DT_PROP(DT_INST(n, ilitek_ili9341), frmctr1),                           \

--- a/drivers/display/display_ili9342c.h
+++ b/drivers/display/display_ili9342c.h
@@ -67,7 +67,7 @@ struct ili9342c_regs {
 
 /* Initializer macro for ILI9342C registers. */
 #define ILI9342c_REGS_INIT(n)                                           \
-	static const struct ili9342c_regs ili9xxx_regs_##n = {		\
+	static const struct ili9342c_regs ili9342c_regs_##n = {		\
 	.gamset = DT_PROP(DT_INST(n, ilitek_ili9342c), gamset),		\
 	.ifmode = DT_PROP(DT_INST(n, ilitek_ili9342c), ifmode),		\
 	.frmctr1 = DT_PROP(DT_INST(n, ilitek_ili9342c), frmctr1),	\

--- a/drivers/display/display_ili9488.h
+++ b/drivers/display/display_ili9488.h
@@ -44,7 +44,7 @@ struct ili9488_regs {
 
 /* Initializer macro for ILI9488 registers. */
 #define ILI9488_REGS_INIT(n)                                                   \
-	static const struct ili9488_regs ili9xxx_regs_##n = {                  \
+	static const struct ili9488_regs ili9488_regs_##n = {                  \
 		.frmctr1 = DT_PROP(DT_INST(n, ilitek_ili9488), frmctr1),       \
 		.disctrl = DT_PROP(DT_INST(n, ilitek_ili9488), disctrl),       \
 		.pwctrl1 = DT_PROP(DT_INST(n, ilitek_ili9488), pwctrl1),       \

--- a/drivers/display/display_ili9xxx.c
+++ b/drivers/display/display_ili9xxx.c
@@ -517,7 +517,7 @@ static const struct ili9xxx_quirks ili9488_quirks = {
 #define ILI9XXX_INIT(n, t)                                                     \
 	ILI##t##_REGS_INIT(n);                                                 \
 									       \
-	static const struct ili9xxx_config ili9xxx_config_##n = {              \
+	static const struct ili9xxx_config ili9##t##_config_##n = {            \
 		.quirks = &ili##t##_quirks,                                    \
 		.mipi_dev = DEVICE_DT_GET(DT_PARENT(INST_DT_ILI9XXX(n, t))),   \
 		.dbi_config = {                                                \
@@ -535,15 +535,15 @@ static const struct ili9xxx_quirks ili9488_quirks = {
 		.x_resolution = ILI##t##_X_RES,                                \
 		.y_resolution = ILI##t##_Y_RES,                                \
 		.inversion = DT_PROP(INST_DT_ILI9XXX(n, t), display_inversion),\
-		.regs = &ili9xxx_regs_##n,                                     \
+		.regs = &ili##t##_regs_##n,                                    \
 		.regs_init_fn = ili##t##_regs_init,                            \
 	};                                                                     \
 									       \
-	static struct ili9xxx_data ili9xxx_data_##n;                           \
+	static struct ili9xxx_data ili9##t##_data_##n;                         \
 									       \
 	DEVICE_DT_DEFINE(INST_DT_ILI9XXX(n, t), ili9xxx_init,                  \
-			    NULL, &ili9xxx_data_##n,                           \
-			    &ili9xxx_config_##n, POST_KERNEL,                  \
+			    NULL, &ili9##t##_data_##n,                         \
+			    &ili9##t##_config_##n, POST_KERNEL,                \
 			    CONFIG_DISPLAY_INIT_PRIORITY, &ili9xxx_api)
 
 #define DT_INST_FOREACH_ILI9XXX_STATUS_OKAY(t)                                 \


### PR DESCRIPTION
The ili9xxx driver is used for multiple variants, but did not support different ones at the same time.
Use unique variable names for each variant.

Fixes #82116