### PR TITLE
storage/flash_map: Fix hiding of internal definitions

### DIFF
--- a/include/zephyr/storage/flash_map.h
+++ b/include/zephyr/storage/flash_map.h
@@ -429,11 +429,11 @@ uint8_t flash_area_erased_val(const struct flash_area *fa);
  */
 #define FIXED_PARTITION_BY_NODE(node)	FIXED_PARTITION_1(node)
 
+/** @cond INTERNAL_HIDDEN */
 #define FIXED_PARTITION_1(node)	FIXED_PARTITION_0(DT_DEP_ORD(node))
 #define FIXED_PARTITION_0(ord)							\
 	((const struct flash_area *)&DT_CAT(global_fixed_partition_ORD_, ord))
 
-/** @cond INTERNAL_HIDDEN */
 #define DECLARE_PARTITION(node) DECLARE_PARTITION_0(DT_DEP_ORD(node))
 #define DECLARE_PARTITION_0(ord)						\
 	extern const struct flash_area DT_CAT(global_fixed_partition_ORD_, ord);


### PR DESCRIPTION
Move /** @cond INTERNAL_HIDDEN */ up to cover additional definitions.