### PR TITLE
samples: boards: nordic: system_off: Add comparator wakeup

### DIFF
--- a/samples/boards/nordic/system_off/Kconfig
+++ b/samples/boards/nordic/system_off/Kconfig
@@ -21,9 +21,20 @@ config APP_USE_RETAINED_MEM
 
 endchoice
 
+config GPIO_WAKEUP_ENABLE
+	bool "Use button to wake up device from system off"
+	default y
+	help
+	  Enable system off wakeup from pressing sw0 button.
+
 config GRTC_WAKEUP_ENABLE
 	bool "Use GRTC to wake up device from system off"
 	help
-	  Switch wake up source from pressing sw0 button to GRTC
+	  Enable system off wakeup from GRTC.
+
+config LPCOMP_WAKEUP_ENABLE
+	bool "Use COMP to wake up device from system off"
+	help
+	  Enable system off wakeup from analog comparator.
 
 source "Kconfig.zephyr"

--- a/samples/boards/nordic/system_off/boards/nrf54l15dk_nrf54l15_cpuapp_comparator.overlay
+++ b/samples/boards/nordic/system_off/boards/nrf54l15dk_nrf54l15_cpuapp_comparator.overlay
@@ -1,0 +1,6 @@
+&comp {
+	compatible = "nordic,nrf-lpcomp";
+	psel = "AIN4";
+	refsel = "VDD_4_8";
+	status = "okay";
+};

--- a/samples/boards/nordic/system_off/sample.yaml
+++ b/samples/boards/nordic/system_off/sample.yaml
@@ -64,6 +64,7 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
     extra_configs:
       - CONFIG_GRTC_WAKEUP_ENABLE=y
+      - CONFIG_GPIO_WAKEUP_ENABLE=n
     harness: console
     harness_config:
       type: multi_line
@@ -85,6 +86,7 @@ tests:
     extra_configs:
       - CONFIG_APP_USE_RETAINED_MEM=y
       - CONFIG_GRTC_WAKEUP_ENABLE=y
+      - CONFIG_GPIO_WAKEUP_ENABLE=n
       - CONFIG_RETAINED_MEM=y
     harness: console
     harness_config:
@@ -103,3 +105,55 @@ tests:
         - "Off count: 1"
         - "Active Ticks:"
         - "Entering system off; wait 2 seconds to restart"
+  sample.boards.nrf.system_off.lpcomp_wakeup:
+    extra_args: DTC_OVERLAY_FILE="boards/nrf54l15dk_nrf54l15_cpuapp_comparator.overlay"
+    platform_allow:
+      - nrf54l15dk/nrf54l15/cpuapp
+    extra_configs:
+      - CONFIG_LPCOMP_WAKEUP_ENABLE=y
+      - CONFIG_GPIO_WAKEUP_ENABLE=n
+      - CONFIG_COMPARATOR=y
+    harness: console
+    harness_config:
+      type: multi_line
+      ordered: true
+      regex:
+        - "system off demo"
+        - "Retained data not supported"
+        - "Entering system off; change signal level at comparator input to restart"
+        - "system off demo"
+        - "Retained data not supported"
+        - "Entering system off; change signal level at comparator input to restart"
+        - "system off demo"
+        - "Retained data not supported"
+        - "Entering system off; change signal level at comparator input to restart"
+  sample.boards.nrf.system_off.retained_mem.lpcomp_wakeup:
+    extra_args:
+      - "DTC_OVERLAY_FILE=
+         boards/nrf54l15dk_nrf54l15_cpuapp_comparator.overlay;
+         boards/nrf54l15dk_nrf54l15_cpuapp_retained_mem.overlay"
+    platform_allow:
+      - nrf54l15dk/nrf54l15/cpuapp
+    extra_configs:
+      - CONFIG_APP_USE_RETAINED_MEM=y
+      - CONFIG_GPIO_WAKEUP_ENABLE=n
+      - CONFIG_LPCOMP_WAKEUP_ENABLE=y
+      - CONFIG_RETAINED_MEM=y
+      - CONFIG_COMPARATOR=y
+    harness: console
+    harness_config:
+      type: multi_line
+      ordered: true
+      regex:
+        - "system off demo"
+        - "Retained data: INVALID"
+        - "Boot count: 1"
+        - "Off count: 0"
+        - "Active Ticks:"
+        - "Entering system off; change signal level at comparator input to restart"
+        - "system off demo"
+        - "Retained data: valid"
+        - "Boot count: 2"
+        - "Off count: 1"
+        - "Active Ticks:"
+        - "Entering system off; change signal level at comparator input to restart"

--- a/samples/boards/nordic/system_off/src/main.c
+++ b/samples/boards/nordic/system_off/src/main.c
@@ -11,6 +11,7 @@
 
 #include <zephyr/device.h>
 #include <zephyr/drivers/gpio.h>
+#include <zephyr/drivers/comparator.h>
 #include <zephyr/kernel.h>
 #include <zephyr/pm/device.h>
 #include <zephyr/sys/poweroff.h>
@@ -19,8 +20,12 @@
 #if defined(CONFIG_GRTC_WAKEUP_ENABLE)
 #include <zephyr/drivers/timer/nrf_grtc_timer.h>
 #define DEEP_SLEEP_TIME_S 2
-#else
+#endif
+#if defined(CONFIG_GPIO_WAKEUP_ENABLE)
 static const struct gpio_dt_spec sw0 = GPIO_DT_SPEC_GET(DT_ALIAS(sw0), gpios);
+#endif
+#if defined(CONFIG_LPCOMP_WAKEUP_ENABLE)
+static const struct device *comp_dev = DEVICE_DT_GET(DT_NODELABEL(comp));
 #endif
 
 int main(void)
@@ -58,7 +63,8 @@ int main(void)
 	} else {
 		printk("Entering system off; wait %u seconds to restart\n", DEEP_SLEEP_TIME_S);
 	}
-#else
+#endif
+#if defined(CONFIG_GPIO_WAKEUP_ENABLE)
 	/* configure sw0 as input, interrupt as level active to allow wake-up */
 	rc = gpio_pin_configure_dt(&sw0, GPIO_INPUT);
 	if (rc < 0) {
@@ -73,6 +79,11 @@ int main(void)
 	}
 
 	printf("Entering system off; press sw0 to restart\n");
+#endif
+#if defined(CONFIG_LPCOMP_WAKEUP_ENABLE)
+	comparator_set_trigger(comp_dev, COMPARATOR_TRIGGER_BOTH_EDGES);
+	comparator_trigger_is_pending(comp_dev);
+	printf("Entering system off; change signal level at comparator input to restart\n");
 #endif
 
 	rc = pm_device_action_run(cons, PM_DEVICE_ACTION_SUSPEND);


### PR DESCRIPTION
Extend sytem_off sample to use analog comparator as wake up source.