### PR TITLE
drivers: display: display_rm67612: fix coverity issues

### DIFF
--- a/drivers/display/display_rm67162.c
+++ b/drivers/display/display_rm67162.c
@@ -522,20 +522,17 @@ static int rm67162_set_pixel_format(const struct device *dev,
 	switch (pixel_format) {
 	case PIXEL_FORMAT_RGB_565:
 		data->pixel_format = MIPI_DSI_PIXFMT_RGB565;
-		return 0;
+		param = MIPI_DCS_PIXEL_FORMAT_16BIT;
+		data->bytes_per_pixel = 2;
+		break;
 	case PIXEL_FORMAT_RGB_888:
 		data->pixel_format = MIPI_DSI_PIXFMT_RGB888;
-		return 0;
+		param = MIPI_DCS_PIXEL_FORMAT_24BIT;
+		data->bytes_per_pixel = 3;
+		break;
 	default:
 		/* Other display formats not implemented */
 		return -ENOTSUP;
-	}
-	if (data->pixel_format == MIPI_DSI_PIXFMT_RGB888) {
-		param = MIPI_DCS_PIXEL_FORMAT_24BIT;
-		data->bytes_per_pixel = 3;
-	} else if (data->pixel_format == MIPI_DSI_PIXFMT_RGB565) {
-		param = MIPI_DCS_PIXEL_FORMAT_16BIT;
-		data->bytes_per_pixel = 2;
 	}
 	return mipi_dsi_dcs_write(config->mipi_dsi, config->channel,
 				MIPI_DCS_SET_PIXEL_FORMAT, &param, 1);

--- a/drivers/display/display_rm67162.c
+++ b/drivers/display/display_rm67162.c
@@ -350,7 +350,7 @@ static int rm67162_write_fb(const struct device *dev, bool first_write,
 			const uint8_t *src, uint32_t len)
 {
 	const struct rm67162_config *config = dev->config;
-	uint32_t wlen = 0;
+	ssize_t wlen;
 	struct mipi_dsi_msg msg = {0};
 
 	/* Note- we need to set custom flags on the DCS message,
@@ -368,7 +368,7 @@ static int rm67162_write_fb(const struct device *dev, bool first_write,
 		msg.tx_buf = src;
 		wlen = mipi_dsi_transfer(config->mipi_dsi, config->channel, &msg);
 		if (wlen < 0) {
-			return wlen;
+			return (int)wlen;
 		}
 		/* Advance source pointer and decrement remaining */
 		src += wlen;

--- a/drivers/display/display_rm67162.c
+++ b/drivers/display/display_rm67162.c
@@ -334,7 +334,11 @@ static int rm67162_init(const struct device *dev)
 		/* Init and install GPIO callback */
 		gpio_init_callback(&data->te_gpio_cb, rm67162_te_isr_handler,
 				BIT(config->te_gpio.pin));
-		gpio_add_callback(config->te_gpio.port, &data->te_gpio_cb);
+		ret = gpio_add_callback(config->te_gpio.port, &data->te_gpio_cb);
+		if (ret < 0) {
+			LOG_ERR("Could not add TE gpio callback");
+			return ret;
+		}
 
 		/* Setup te pin semaphore */
 		k_sem_init(&data->te_sem, 0, 1);


### PR DESCRIPTION
Fix a few Coverity issues discovered by static analysis

This PR was tested with `samples/drivers/display` on the RT1170 EVK, using the G1120B0MIPI shield

Fixes #81921
Fixes #81929 
Fixes #81945 