### PR TITLE
drivers: sensor: max31865: fix compilation warning -Wdouble-promotion

### DIFF
--- a/drivers/sensor/maxim/max31865/max31865.c
+++ b/drivers/sensor/maxim/max31865/max31865.c
@@ -99,9 +99,9 @@ static double calculate_temperature(double resistance, double resistance_0)
 	}
 	resistance /= resistance_0;
 	resistance *= 100.0;
-	temperature = A[0] + A[1] * resistance + A[2] * pow(resistance, 2) -
-		      A[3] * pow(resistance, 3) - A[4] * pow(resistance, 4) +
-		      A[5] * pow(resistance, 5);
+	temperature = RTD_C[0] + RTD_C[1] * resistance + RTD_C[2] * pow(resistance, 2) -
+		      RTD_C[3] * pow(resistance, 3) - RTD_C[4] * pow(resistance, 4) +
+		      RTD_C[5] * pow(resistance, 5);
 	return temperature;
 }
 

--- a/drivers/sensor/maxim/max31865/max31865.h
+++ b/drivers/sensor/maxim/max31865/max31865.h
@@ -71,7 +71,7 @@ LOG_MODULE_REGISTER(MAX31865, CONFIG_SENSOR_LOG_LEVEL);
  * For under zero, taken from
  * https://www.analog.com/media/en/technical-documentation/application-notes/AN709_0.pdf
  */
-static const float A[6] = {-242.02, 2.2228, 2.5859e-3, 4.8260e-6, 2.8183e-8, 1.5243e-10};
+static const double RTD_C[6] = {-242.02, 2.2228, 2.5859e-3, 4.8260e-6, 2.8183e-8, 1.5243e-10};
 
 struct max31865_data {
 	double temperature;


### PR DESCRIPTION
Currently compiling a project with the max31865 RTD amplifier enabled throws errors in `calculate_temperature()`
```shell
/workdir/zephyr/drivers/sensor/maxim/max31865/max31865.c: In function 'calculate_temperature':
/workdir/zephyr/drivers/sensor/maxim/max31865/max31865.c:102:35: warning: implicit conversion from 'float' to 'double' to match other operand of binary expression [-Wdouble-promotion]
  102 |         temperature = A[0] + A[1] * resistance + A[2] * pow(resistance, 2) -
      |                                   ^
/workdir/zephyr/drivers/sensor/maxim/max31865/max31865.c:102:28: warning: implicit conversion from 'float' to 'double' to match other operand of binary expression [-Wdouble-promotion]
  102 |         temperature = A[0] + A[1] * resistance + A[2] * pow(resistance, 2) -
      |                            ^
/workdir/zephyr/drivers/sensor/maxim/max31865/max31865.c:102:55: warning: implicit conversion from 'float' to 'double' to match other operand of binary expression [-Wdouble-promotion]
  102 |         temperature = A[0] + A[1] * resistance + A[2] * pow(resistance, 2) -
      |                                                       ^
/workdir/zephyr/drivers/sensor/maxim/max31865/max31865.c:103:28: warning: implicit conversion from 'float' to 'double' to match other operand of binary expression [-Wdouble-promotion]
  103 |                       A[3] * pow(resistance, 3) - A[4] * pow(resistance, 4) +
      |                            ^
/workdir/zephyr/drivers/sensor/maxim/max31865/max31865.c:103:56: warning: implicit conversion from 'float' to 'double' to match other operand of binary expression [-Wdouble-promotion]
  103 |                       A[3] * pow(resistance, 3) - A[4] * pow(resistance, 4) +
      |                                                        ^
/workdir/zephyr/drivers/sensor/maxim/max31865/max31865.c:104:28: warning: implicit conversion from 'float' to 'double' to match other operand of binary expression [-Wdouble-promotion]
  104 |                       A[5] * pow(resistance, 5);
```

This PR changes `A[]` to a double to fix this and, as a bonus, updates the name for clarity.