### PR TITLE
net: wifi: change the acquisition of wifi interface

### DIFF
--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -1040,7 +1040,7 @@ static int wifi_scan_args_to_params(const struct shell *sh,
 
 static int cmd_wifi_scan(const struct shell *sh, size_t argc, char *argv[])
 {
-	struct net_if *iface = net_if_get_first_wifi();
+	struct net_if *iface = net_if_get_wifi_sta();
 	struct wifi_scan_params params = { 0 };
 	bool do_scan = true;
 	int opt_num;
@@ -1076,7 +1076,7 @@ static int cmd_wifi_scan(const struct shell *sh, size_t argc, char *argv[])
 
 static int cmd_wifi_status(const struct shell *sh, size_t argc, char *argv[])
 {
-	struct net_if *iface = net_if_get_first_wifi();
+	struct net_if *iface = net_if_get_wifi_sta();
 	struct wifi_iface_status status = { 0 };
 
 	context.sh = sh;
@@ -1208,7 +1208,7 @@ static int cmd_wifi_stats(const struct shell *sh, size_t argc, char *argv[])
 {
 #if defined(CONFIG_NET_STATISTICS_WIFI) && \
 					defined(CONFIG_NET_STATISTICS_USER_API)
-	struct net_if *iface = net_if_get_first_wifi();
+	struct net_if *iface = net_if_get_wifi_sta();
 	struct net_stats_wifi stats = { 0 };
 	int ret;
 
@@ -1251,7 +1251,7 @@ static int cmd_wifi_stats(const struct shell *sh, size_t argc, char *argv[])
 
 static int cmd_wifi_11k(const struct shell *sh, size_t argc, char *argv[])
 {
-	struct net_if *iface = net_if_get_first_wifi();
+	struct net_if *iface = net_if_get_wifi_sta();
 	struct wifi_11k_params params = { 0 };
 
 	context.sh = sh;
@@ -1292,7 +1292,7 @@ static int cmd_wifi_11k(const struct shell *sh, size_t argc, char *argv[])
 
 static int cmd_wifi_11k_neighbor_request(const struct shell *sh, size_t argc, char *argv[])
 {
-	struct net_if *iface = net_if_get_first_wifi();
+	struct net_if *iface = net_if_get_wifi_sta();
 	struct wifi_11k_params params = { 0 };
 
 	context.sh = sh;
@@ -1329,7 +1329,7 @@ static int cmd_wifi_11k_neighbor_request(const struct shell *sh, size_t argc, ch
 
 static int cmd_wifi_ps(const struct shell *sh, size_t argc, char *argv[])
 {
-	struct net_if *iface = net_if_get_first_wifi();
+	struct net_if *iface = net_if_get_wifi_sta();
 	struct wifi_ps_params params = { 0 };
 
 	context.sh = sh;
@@ -1417,7 +1417,7 @@ static int cmd_wifi_ps(const struct shell *sh, size_t argc, char *argv[])
 
 static int cmd_wifi_ps_mode(const struct shell *sh, size_t argc, char *argv[])
 {
-	struct net_if *iface = net_if_get_first_wifi();
+	struct net_if *iface = net_if_get_wifi_sta();
 	struct wifi_ps_params params = { 0 };
 
 	context.sh = sh;
@@ -1447,7 +1447,7 @@ static int cmd_wifi_ps_mode(const struct shell *sh, size_t argc, char *argv[])
 
 static int cmd_wifi_ps_timeout(const struct shell *sh, size_t argc, char *argv[])
 {
-	struct net_if *iface = net_if_get_first_wifi();
+	struct net_if *iface = net_if_get_wifi_sta();
 	struct wifi_ps_params params = { 0 };
 	long timeout_ms = 0;
 	int err = 0;
@@ -1482,7 +1482,7 @@ static int cmd_wifi_ps_timeout(const struct shell *sh, size_t argc, char *argv[]
 static int cmd_wifi_twt_setup_quick(const struct shell *sh, size_t argc,
 				    char *argv[])
 {
-	struct net_if *iface = net_if_get_first_wifi();
+	struct net_if *iface = net_if_get_wifi_sta();
 	struct wifi_twt_params params = { 0 };
 	int idx = 1;
 	long value;
@@ -1529,7 +1529,7 @@ static int cmd_wifi_twt_setup_quick(const struct shell *sh, size_t argc,
 static int cmd_wifi_twt_setup(const struct shell *sh, size_t argc,
 			      char *argv[])
 {
-	struct net_if *iface = net_if_get_first_wifi();
+	struct net_if *iface = net_if_get_wifi_sta();
 	struct wifi_twt_params params = { 0 };
 	int idx = 1;
 	long value;
@@ -1614,7 +1614,7 @@ static int cmd_wifi_twt_setup(const struct shell *sh, size_t argc,
 static int cmd_wifi_twt_teardown(const struct shell *sh, size_t argc,
 				 char *argv[])
 {
-	struct net_if *iface = net_if_get_first_wifi();
+	struct net_if *iface = net_if_get_wifi_sta();
 	struct wifi_twt_params params = { 0 };
 	long value;
 
@@ -1664,7 +1664,7 @@ static int cmd_wifi_twt_teardown(const struct shell *sh, size_t argc,
 static int cmd_wifi_twt_teardown_all(const struct shell *sh, size_t argc,
 				     char *argv[])
 {
-	struct net_if *iface = net_if_get_first_wifi();
+	struct net_if *iface = net_if_get_wifi_sta();
 	struct wifi_twt_params params = { 0 };
 
 	context.sh = sh;
@@ -1788,11 +1788,7 @@ static int cmd_wifi_ap_stations(const struct shell *sh, size_t argc,
 static int cmd_wifi_ap_sta_disconnect(const struct shell *sh, size_t argc,
 				      char *argv[])
 {
-#ifdef CONFIG_WIFI_NM_HOSTAPD_AP
 	struct net_if *iface = net_if_get_wifi_sap();
-#else
-	struct net_if *iface = net_if_get_first_wifi();
-#endif
 	uint8_t mac[6];
 	int ret;
 
@@ -1861,11 +1857,7 @@ static int wifi_ap_config_args_to_params(const struct shell *sh, size_t argc, ch
 static int cmd_wifi_ap_config_params(const struct shell *sh, size_t argc,
 				     char *argv[])
 {
-#ifdef CONFIG_WIFI_NM_HOSTAPD_AP
 	struct net_if *iface = net_if_get_wifi_sap();
-#else
-	struct net_if *iface = net_if_get_first_wifi();
-#endif
 	struct wifi_ap_config_params ap_config_params = { 0 };
 	int ret = -1;
 
@@ -1889,7 +1881,7 @@ static int cmd_wifi_ap_config_params(const struct shell *sh, size_t argc,
 static int cmd_wifi_reg_domain(const struct shell *sh, size_t argc,
 			       char *argv[])
 {
-	struct net_if *iface = net_if_get_first_wifi();
+	struct net_if *iface = net_if_get_wifi_sta();
 	struct wifi_reg_domain regd = {0};
 	int ret, chan_idx = 0;
 
@@ -1958,7 +1950,7 @@ static int cmd_wifi_reg_domain(const struct shell *sh, size_t argc,
 
 static int cmd_wifi_listen_interval(const struct shell *sh, size_t argc, char *argv[])
 {
-	struct net_if *iface = net_if_get_first_wifi();
+	struct net_if *iface = net_if_get_wifi_sta();
 	struct wifi_ps_params params = { 0 };
 	long interval;
 
@@ -1993,7 +1985,7 @@ static int cmd_wifi_listen_interval(const struct shell *sh, size_t argc, char *a
 #ifdef CONFIG_WIFI_NM_WPA_SUPPLICANT_WNM
 static int cmd_wifi_btm_query(const struct shell *sh, size_t argc, char *argv[])
 {
-	struct net_if *iface = net_if_get_first_wifi();
+	struct net_if *iface = net_if_get_wifi_sta();
 	uint8_t query_reason = 0;
 	long tmp = 0;
 
@@ -2121,7 +2113,7 @@ static int cmd_wifi_ap_wps_pin(const struct shell *sh, size_t argc, char *argv[]
 
 static int cmd_wifi_ps_wakeup_mode(const struct shell *sh, size_t argc, char *argv[])
 {
-	struct net_if *iface = net_if_get_first_wifi();
+	struct net_if *iface = net_if_get_wifi_sta();
 	struct wifi_ps_params params = { 0 };
 
 	context.sh = sh;
@@ -2152,7 +2144,7 @@ static int cmd_wifi_ps_wakeup_mode(const struct shell *sh, size_t argc, char *ar
 
 static int cmd_wifi_set_rts_threshold(const struct shell *sh, size_t argc, char *argv[])
 {
-	struct net_if *iface = net_if_get_first_wifi();
+	struct net_if *iface = net_if_get_wifi_sta();
 	unsigned int rts_threshold = -1; /* Default value if user supplies "off" argument */
 	int err = 0;
 
@@ -2209,7 +2201,7 @@ static int cmd_wifi_set_rts_threshold(const struct shell *sh, size_t argc, char 
 static int cmd_wifi_ps_exit_strategy(const struct shell *sh, size_t argc,
 			    char *argv[])
 {
-	struct net_if *iface = net_if_get_first_wifi();
+	struct net_if *iface = net_if_get_wifi_sta();
 	struct wifi_ps_params params = { 0 };
 
 	context.sh = sh;
@@ -2310,7 +2302,7 @@ static int cmd_wifi_mode(const struct shell *sh, size_t argc, char *argv[])
 		 * lower layer
 		 */
 		if (mode_info.if_index == 0) {
-			iface = net_if_get_first_wifi();
+			iface = net_if_get_wifi_sta();
 			if (iface == NULL) {
 				PR_ERROR("Cannot find the default wifi interface\n");
 				return -ENOEXEC;
@@ -2399,7 +2391,7 @@ static int cmd_wifi_channel(const struct shell *sh, size_t argc, char *argv[])
 		 */
 
 		if (channel_info.if_index == 0) {
-			iface = net_if_get_first_wifi();
+			iface = net_if_get_wifi_sta();
 			if (iface == NULL) {
 				PR_ERROR("Cannot find the default wifi interface\n");
 				return -ENOEXEC;
@@ -2513,7 +2505,7 @@ static int cmd_wifi_packet_filter(const struct shell *sh, size_t argc, char *arg
 		 * value to be verified by the lower layer.
 		 */
 		if (packet_filter.if_index == 0) {
-			iface = net_if_get_first_wifi();
+			iface = net_if_get_wifi_sta();
 			if (iface == NULL) {
 				PR_ERROR("Cannot find the default wifi interface\n");
 				return -ENOEXEC;
@@ -2550,7 +2542,7 @@ static int cmd_wifi_packet_filter(const struct shell *sh, size_t argc, char *arg
 
 static int cmd_wifi_version(const struct shell *sh, size_t argc, char *argv[])
 {
-	struct net_if *iface = net_if_get_first_wifi();
+	struct net_if *iface = net_if_get_wifi_sta();
 	struct wifi_version version = {0};
 
 	if (argc > 1) {
@@ -2795,7 +2787,7 @@ static int parse_dpp_args_set_config_param(const struct shell *sh, size_t argc, 
 
 static int cmd_wifi_dpp_configurator_add(const struct shell *sh, size_t argc, char *argv[])
 {
-	struct net_if *iface = net_if_get_first_wifi();
+	struct net_if *iface = net_if_get_wifi_sta();
 	struct wifi_dpp_params params = {0};
 
 	params.action = WIFI_DPP_CONFIGURATOR_ADD;
@@ -2810,7 +2802,7 @@ static int cmd_wifi_dpp_configurator_add(const struct shell *sh, size_t argc, ch
 static int cmd_wifi_dpp_auth_init(const struct shell *sh, size_t argc, char *argv[])
 {
 	int ret;
-	struct net_if *iface = net_if_get_first_wifi();
+	struct net_if *iface = net_if_get_wifi_sta();
 	struct wifi_dpp_params params = {0};
 
 	params.action = WIFI_DPP_AUTH_INIT;
@@ -2830,7 +2822,7 @@ static int cmd_wifi_dpp_auth_init(const struct shell *sh, size_t argc, char *arg
 
 static int cmd_wifi_dpp_qr_code(const struct shell *sh, size_t argc, char *argv[])
 {
-	struct net_if *iface = net_if_get_first_wifi();
+	struct net_if *iface = net_if_get_wifi_sta();
 	struct wifi_dpp_params params = {0};
 
 	params.action = WIFI_DPP_QR_CODE;
@@ -2849,7 +2841,7 @@ static int cmd_wifi_dpp_qr_code(const struct shell *sh, size_t argc, char *argv[
 static int cmd_wifi_dpp_chirp(const struct shell *sh, size_t argc, char *argv[])
 {
 	int ret;
-	struct net_if *iface = net_if_get_first_wifi();
+	struct net_if *iface = net_if_get_wifi_sta();
 	struct wifi_dpp_params params = {0};
 
 	params.action = WIFI_DPP_CHIRP;
@@ -2870,7 +2862,7 @@ static int cmd_wifi_dpp_chirp(const struct shell *sh, size_t argc, char *argv[])
 static int cmd_wifi_dpp_listen(const struct shell *sh, size_t argc, char *argv[])
 {
 	int ret;
-	struct net_if *iface = net_if_get_first_wifi();
+	struct net_if *iface = net_if_get_wifi_sta();
 	struct wifi_dpp_params params = {0};
 
 	params.action = WIFI_DPP_LISTEN;
@@ -2891,7 +2883,7 @@ static int cmd_wifi_dpp_listen(const struct shell *sh, size_t argc, char *argv[]
 static int cmd_wifi_dpp_btstrap_gen(const struct shell *sh, size_t argc, char *argv[])
 {
 	int ret;
-	struct net_if *iface = net_if_get_first_wifi();
+	struct net_if *iface = net_if_get_wifi_sta();
 	struct wifi_dpp_params params = {0};
 
 	params.action = WIFI_DPP_BOOTSTRAP_GEN;
@@ -2912,7 +2904,7 @@ static int cmd_wifi_dpp_btstrap_gen(const struct shell *sh, size_t argc, char *a
 static int cmd_wifi_dpp_btstrap_get_uri(const struct shell *sh, size_t argc, char *argv[])
 {
 	int ret = 0;
-	struct net_if *iface = net_if_get_first_wifi();
+	struct net_if *iface = net_if_get_wifi_sta();
 	struct wifi_dpp_params params = {0};
 
 	params.action = WIFI_DPP_BOOTSTRAP_GET_URI;
@@ -2936,7 +2928,7 @@ static int cmd_wifi_dpp_btstrap_get_uri(const struct shell *sh, size_t argc, cha
 static int cmd_wifi_dpp_configurator_set(const struct shell *sh, size_t argc, char *argv[])
 {
 	int ret;
-	struct net_if *iface = net_if_get_first_wifi();
+	struct net_if *iface = net_if_get_wifi_sta();
 	struct wifi_dpp_params params = {0};
 
 	params.action = WIFI_DPP_SET_CONF_PARAM;
@@ -2957,7 +2949,7 @@ static int cmd_wifi_dpp_configurator_set(const struct shell *sh, size_t argc, ch
 static int cmd_wifi_dpp_resp_timeout_set(const struct shell *sh, size_t argc, char *argv[])
 {
 	int ret = 0;
-	struct net_if *iface = net_if_get_first_wifi();
+	struct net_if *iface = net_if_get_wifi_sta();
 	struct wifi_dpp_params params = {0};
 
 	params.action = WIFI_DPP_SET_WAIT_RESP_TIME;


### PR DESCRIPTION
For WiFi interface, uniformly use net_if_get_wifi_sta() and net_if_get_wifi_sap() APIs to replace net_if_get_first_wifi().