### PR TITLE
Bluetooth: Controller: Fix interleaved extended scanning assert

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/lll.h
+++ b/subsys/bluetooth/controller/ll_sw/lll.h
@@ -351,8 +351,18 @@ struct node_rx_ftr {
 				* chaining, to reserve node_rx for CSA#2 event
 				* generation etc.
 				*/
-		void *aux_ptr;
-		uint8_t aux_phy;
+		void *lll_aux; /* LLL scheduled auxiliary context associated to
+				* the scan context when enqueuing the node rx.
+				* This does not overlap the below aux_ptr or
+				* aux_phy which are used before enqueue when
+				* setting up LLL scheduling.
+				*/
+		void *aux_ptr; /* aux pointer stored when LLL scheduling the
+				* auxiliary PDU reception by scan context.
+				*/
+		uint8_t aux_phy; /* aux phy stored when LLL scheduling the
+				  * auxiliary PDU reception by scan context.
+				  */
 		struct cte_conn_iq_report *iq_report;
 	};
 	uint32_t ticks_anchor;
@@ -531,9 +541,9 @@ struct event_done_extra {
 	*/
 				};
 
-#if defined(CONFIG_BT_CTLR_ADV_EXT)
+#if defined(CONFIG_BT_CTLR_SCAN_AUX_USE_CHAINS)
 				void *lll;
-#endif /* CONFIG_BT_CTLR_ADV_EXT */
+#endif /* CONFIG_BT_CTLR_SCAN_AUX_USE_CHAINS */
 			};
 
 #if defined(CONFIG_BT_CTLR_LE_ENC)

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
@@ -676,7 +676,10 @@ static void abort_cb(struct lll_prepare_param *prepare_param, void *param)
 
 	e = ull_done_extra_type_set(EVENT_DONE_EXTRA_TYPE_SCAN_AUX);
 	LL_ASSERT(e);
+
+#if defined(CONFIG_BT_CTLR_SCAN_AUX_USE_CHAINS)
 	e->lll = param;
+#endif /* CONFIG_BT_CTLR_SCAN_AUX_USE_CHAINS */
 
 	lll_done(param);
 }
@@ -716,7 +719,10 @@ static void isr_done(void *param)
 
 		e = ull_done_extra_type_set(EVENT_DONE_EXTRA_TYPE_SCAN_AUX);
 		LL_ASSERT(e);
+
+#if defined(CONFIG_BT_CTLR_SCAN_AUX_USE_CHAINS)
 		e->lll = param;
+#endif /* CONFIG_BT_CTLR_SCAN_AUX_USE_CHAINS */
 	}
 
 	lll_isr_cleanup(param);
@@ -1209,6 +1215,7 @@ static int isr_rx_pdu(struct lll_scan *lll, struct lll_scan_aux *lll_aux,
 			lll_aux->state = 1U;
 		} else {
 			ftr->param = lll;
+			ftr->lll_aux = lll->lll_aux;
 			radio_isr_set(isr_tx_scan_req_lll_schedule,
 				      node_rx);
 			lll->lll_aux->state = 1U;
@@ -1278,6 +1285,7 @@ static int isr_rx_pdu(struct lll_scan *lll, struct lll_scan_aux *lll_aux,
 			 * LLL scheduling in the reception of this current PDU.
 			 */
 			ftr->param = lll;
+			ftr->lll_aux = lll->lll_aux;
 			ftr->scan_rsp = lll->lll_aux->state;
 
 			/* Further auxiliary PDU reception will be chain PDUs */
@@ -1661,7 +1669,10 @@ static void isr_early_abort(void *param)
 
 	e = ull_done_extra_type_set(EVENT_DONE_EXTRA_TYPE_SCAN_AUX);
 	LL_ASSERT(e);
+
+#if defined(CONFIG_BT_CTLR_SCAN_AUX_USE_CHAINS)
 	e->lll = param;
+#endif /* CONFIG_BT_CTLR_SCAN_AUX_USE_CHAINS */
 
 	lll_isr_early_abort(param);
 }

--- a/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
@@ -268,13 +268,17 @@ void ull_scan_aux_setup(memq_link_t *link, struct node_rx_pdu *rx)
 			sync_lll = NULL;
 
 			/* Node that does not have valid aux context but has
-			 * valid scan set was scheduled from LLL. We can
-			 * retrieve aux context from lll_scan as it was stored
-			 * there when superior PDU was handled.
+			 * valid scan set was scheduled from LLL.
 			 */
 			lll = ftr->param;
 
-			lll_aux = lll->lll_aux;
+			/* We can not retrieve aux context that was stored in
+			 * lll_scan when superior PDU was handled, as it may be
+			 * reset to NULL before this node rx is processed here.
+			 * The reset happens when new extended advertising chain
+			 * is being received before we process the node here.
+			 */
+			lll_aux = ftr->lll_aux;
 			LL_ASSERT(lll_aux);
 
 			aux = HDR_LLL2ULL(lll_aux);


### PR DESCRIPTION
Fix interleaved extended scanning assert.

ASSERTION FAIL [lll_aux] @ WEST_TOPDIR/zephyr/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c:278

Platform: nRF52x/nRF53x/nRF54x and others.

Reproduce using sample: samples/bluetooth/observer with extended scanning of extended advertising with/without chains

Possible analysis: lll_aux stored in scan context re-used, fix by using lll_aux in node rx instead.