### PR TITLE
usb: device_next: hid: Pass request buffer in input report done

### DIFF
--- a/include/zephyr/usb/class/usbd_hid.h
+++ b/include/zephyr/usb/class/usbd_hid.h
@@ -25,7 +25,7 @@ extern "C" {
  * @defgroup usbd_hid_device USBD HID device API
  * @ingroup usb
  * @since 3.7
- * @version 0.1.0
+ * @version 0.1.1
  * @{
  */
 
@@ -159,7 +159,8 @@ struct hid_device_ops {
 	 * If the device does not use the callback, hid_device_submit_report()
 	 * will be processed synchronously.
 	 */
-	void (*input_report_done)(const struct device *dev);
+	void (*input_report_done)(const struct device *dev,
+				  const uint8_t *const report);
 
 	/**
 	 * New output report callback. Callback will only be called for reports

--- a/subsys/usb/device_next/class/usbd_hid.c
+++ b/subsys/usb/device_next/class/usbd_hid.c
@@ -122,7 +122,7 @@ static int usbd_hid_request(struct usbd_class_data *const c_data,
 
 	if (bi->ep == hid_get_in_ep(c_data)) {
 		if (ops->input_report_done != NULL) {
-			ops->input_report_done(dev);
+			ops->input_report_done(dev, buf->__buf);
 		} else {
 			k_sem_give(&ddata->in_sem);
 		}

--- a/subsys/usb/device_next/class/usbd_hid_api.c
+++ b/subsys/usb/device_next/class/usbd_hid_api.c
@@ -129,8 +129,11 @@ void wrapper_set_protocol(const struct device *dev, const uint8_t proto)
 	}
 }
 
-void wrapper_input_report_done(const struct device *dev)
+void wrapper_input_report_done(const struct device *dev,
+			       const uint8_t *const report)
 {
+	ARG_UNUSED(report);
+
 	const struct hid_ops *legacy_ops = get_legacy_ops(dev);
 
 	if (legacy_ops != NULL && legacy_ops->int_in_ready != NULL) {


### PR DESCRIPTION
Pass the report buffer originally provided in hid_device_submit_report() as a parameter to input_report_done() callback. Example use case is to enable HID report multi buffering which is easiest achieved by allocating report buffer before submitting it and then releasing the buffer after it has been sent.