### PR TITLE
dts: arm: stm32h7 hsi clock requires hsi-div property

### DIFF
--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -66,6 +66,7 @@
 		clk_hsi: clk-hsi {
 			#clock-cells = <0>;
 			compatible = "st,stm32h7-hsi-clock";
+			hsi-div = <1>;	/* HSI RC: 64MHz, hsi_clk = 64MHz */
 			clock-frequency = <DT_FREQ_M(64)>;
 			status = "disabled";
 		};

--- a/dts/arm/st/h7rs/stm32h7rs.dtsi
+++ b/dts/arm/st/h7rs/stm32h7rs.dtsi
@@ -97,6 +97,7 @@
 		clk_hsi: clk-hsi {
 			#clock-cells = <0>;
 			compatible = "st,stm32h7-hsi-clock";
+			hsi-div = <1>;	/* HSI RC: 64MHz, hsi_clk = 64MHz */
 			clock-frequency = <DT_FREQ_M(64)>;
 			status = "disabled";
 		};


### PR DESCRIPTION
The compatible: "st,stm32h7-hsi-clock"  has HSI clock divider required which is set to 1, by default, delevering 64MHz in the stm32h7.dtsi and stm32h7rs.dtsi
(As done for stm32h5 and other series)

```
		clk_hsi: clk-hsi {
			#clock-cells = <0>;
			compatible = "st,stm32h7-hsi-clock";
			hsi-div = <1>;	/* HSI RC: 64MHz, hsi_clk = 64MHz */
			clock-frequency = <DT_FREQ_M(64)>;
			status = "disabled";
		};
```


Once, a stm32h7 board is enabling the clk_hsi, the build faisl on:
Found BOARD.dts:./boards/st/stm32h750b_dk/stm32h750b_dk.dts
devicetree error: 'hsi-div' is marked as required in 'properties:' in  ./dts/bindings/clock/st,stm32h7-hsi-clock.yaml, but does not appear in <Node /clocks/clk-hsi in './misc/empty_file.c'>

This PR adds the <hsi-div> property directly in the stm32h7.dtsi 
