### PR TITLE
driver: gpio: mcp23xxx: increase reset pin pulse duration

### DIFF
--- a/drivers/gpio/gpio_mcp23xxx.c
+++ b/drivers/gpio/gpio_mcp23xxx.c
@@ -23,7 +23,7 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(gpio_mcp23xxx);
 
-#define MCP23XXX_RESET_TIME_US 1
+#define MCP23XXX_RESET_TIME_US 2
 
 /**
  * @brief Reads given register from mcp23xxx.


### PR DESCRIPTION
The reset pulse is currently fixed at 1 µs, the minimum required for the chip. However, a long reset pin trace can increases rise time, making 1 µs potentially insufficient for reliable detection of a reset signal. Increase the pulse duration to 2 µs