### PR TITLE
samples: watchdog: fix board identifiers

### DIFF
--- a/samples/drivers/watchdog/sample.yaml
+++ b/samples/drivers/watchdog/sample.yaml
@@ -52,15 +52,15 @@ tests:
     # seems to ignore extra_args
     platform_allow:
       - nucleo_h723zg
-      - nucleo_h745zi_q
+      - nucleo_h745zi_q/stm32h745xx/m4
       - nucleo_h743zi
       - stm32h735g_disco
       - nucleo_h753zi
       - stm32h750b_dk
       - stm32h7b3i_dk
-      - stm32h745i_disco
-      - nucleo_h755zi_q
-      - stm32h747i_disco
+      - stm32h745i_disco/stm32h745xx/m4
+      - nucleo_h755zi_q/stm32h755xx/m4
+      - stm32h747i_disco/stm32h747xx/m4
     integration_platforms:
       - nucleo_h743zi
   sample.drivers.watchdog.stm32_iwdg:


### PR DESCRIPTION
Use full board target name in cases with multiple variants or cpu
clusters.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
