### PR TITLE
Bluetooth: Audio: add bt_ prefix when registering logging module

### DIFF
--- a/subsys/bluetooth/audio/media_proxy.c
+++ b/subsys/bluetooth/audio/media_proxy.c
@@ -22,7 +22,7 @@
 #include "media_proxy_internal.h"
 #include "mcs_internal.h"
 
-LOG_MODULE_REGISTER(media_proxy, CONFIG_MCTL_LOG_LEVEL);
+LOG_MODULE_REGISTER(bt_media_proxy, CONFIG_MCTL_LOG_LEVEL);
 
 /* Media player */
 struct media_player {


### PR DESCRIPTION
Add the bt_ prefix when registering the logging for the media_proxy module, to be consistent with what the other modules in bluetooth/audio do
Note that the bap_usb module shall not have the bt_ prefix