### PR TITLE
boards: wch: make minichlink default runner

### DIFF
--- a/boards/wch/ch32v003evt/board.cmake
+++ b/boards/wch/ch32v003evt/board.cmake
@@ -1,8 +1,8 @@
 # Copyright (c) 2024 Michael Hope
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(openocd "--use-elf" "--cmd-reset-halt" "halt")
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
-
 board_runner_args(minichlink)
 include(${ZEPHYR_BASE}/boards/common/minichlink.board.cmake)
+
+board_runner_args(openocd "--use-elf" "--cmd-reset-halt" "halt")
+include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)


### PR DESCRIPTION
This makes minichlink the default runner for the ch32v003evt. This way, `west flash` "just works", as advertised in the README, rather than having to manually set the runner to `minichlink` for it to work.