### PR TITLE
doc: release_notes: skim down the release notes content

### DIFF
--- a/doc/releases/migration-guide-4.1.rst
+++ b/doc/releases/migration-guide-4.1.rst
@@ -1,5 +1,10 @@
 :orphan:
 
+..
+  See
+  https://docs.zephyrproject.org/latest/releases/index.html#migration-guides
+  for details of what is supposed to go into this document.
+
 .. _migration_4.1:
 
 Migration guide to Zephyr v4.1.0 (Working Draft)

--- a/doc/releases/release-notes-4.1.rst
+++ b/doc/releases/release-notes-4.1.rst
@@ -1,5 +1,29 @@
 :orphan:
 
+..
+  What goes here: removed/deprecated apis, new boards, new drivers, notable
+  features. If you feel like something new can be useful to a user, put it
+  under "Other Enhancements" in the first paragraph, if you feel like something
+  is worth mentioning in the project media (release blog post, release
+  livestream) put it under "Major enhancement".
+..
+  If you are describing a feature or functionality, consider adding it to the
+  actual project documentation rather than the release notes, so that the
+  information does not get lost in time.
+..
+  No list of bugfixes, minor changes, those are already in the git log, this is
+  not a changelog.
+..
+  Does the entry have a link that contains the details? Just add the link, if
+  you think it needs more details, put them in the content that shows up on the
+  link.
+..
+  Are you thinking about generating this? Don't put anything at all.
+..
+  Does the thing require the user to change their application? Put it on the
+  migration guide instead. (TODO: move the removed APIs section in the
+  migration guide)
+
 .. _zephyr_4.1:
 
 Zephyr 4.1.0 (Working Draft)
@@ -24,457 +48,568 @@ https://docs.zephyrproject.org/latest/security/vulnerabilities.html
 API Changes
 ***********
 
- * Stream Flash initialization function :c:func:`stream_flash_init` no longer does
-   device size autodetection and instead requires user to explicitly provide size
-   of area available for Stream Flash instance operation.
+Removed APIs and options
+========================
 
-Removed APIs in this release
-============================
+* The legacy Bluetooth HCI driver API has been removed. It has been replaced
+  by a :c:group:`new API<bt_hci_api>` that follows the normal Zephyr driver
+  model.
 
- * The deprecated Bluetooth HCI driver API has been removed. It has been replaced by a
-   :c:group:`new API<bt_hci_api>` that follows the normal Zephyr driver model.
- * The deprecated ``CAN_MAX_STD_ID`` (replaced by :c:macro:`CAN_STD_ID_MASK`) and ``CAN_MAX_EXT_ID``
-   (replaced by :c:macro:`CAN_EXT_ID_MASK`) CAN API macros have been removed.
- * The deprecated ``can_get_min_bitrate()`` (replaced by :c:func:`can_get_bitrate_min`) and
-   ``can_get_max_bitrate()`` (replaced by :c:func:`can_get_bitrate_max`) CAN API functions have been
-   removed.
- * The deprecated ``can_calc_prescaler()`` CAN API function has been removed.
+* The ``CAN_MAX_STD_ID`` (replaced by :c:macro:`CAN_STD_ID_MASK`) and
+  ``CAN_MAX_EXT_ID`` (replaced by :c:macro:`CAN_EXT_ID_MASK`) CAN API macros
+  have been removed.
 
-Deprecated in this release
-==========================
+* The ``can_get_min_bitrate()`` (replaced by :c:func:`can_get_bitrate_min`)
+  and ``can_get_max_bitrate()`` (replaced by :c:func:`can_get_bitrate_max`)
+  CAN API functions have been removed.
 
-* Deprecated the :c:func:`bt_le_set_auto_conn` API function. Application developers can achieve
+* The ``can_calc_prescaler()`` CAN API function has been removed.
+
+* The :kconfig:option:`CONFIG_NET_SOCKETS_POSIX_NAMES` option has been
+  removed.  It was a legacy option and was used to allow user to call BSD
+  socket API while not enabling POSIX API.  This removal means that in order
+  to use POSIX API socket calls, one needs to enable the
+  :kconfig:option:`CONFIG_POSIX_API` option.  If the application does not want
+  or is not able to enable that option, then the socket API calls need to be
+  prefixed by a ``zsock_`` string.
+
+* Removed ``video_pix_fmt_bpp()`` function that was returning a *byte* count
+  and only supported 8-bit depth to :c:func:`video_bits_per_pixel()` returning
+  the *bit* count and supporting any color depth.
+
+* :kconfig:option:`CONFIG_WIFI_NM_WPA_SUPPLICANT_CRYPTO`
+
+Deprecated APIs and options
+===========================
+
+* the :c:func:`bt_le_set_auto_conn` API function. Application developers can achieve
   the same functionality in their application code by reconnecting to the peer when the
   :c:member:`bt_conn_cb.disconnected` callback is invoked.
 
-* Deprecated TinyCrypt library. The reasons for this are (:github:`43712`):
+* :kconfig:option:`CONFIG_NATIVE_APPLICATION` has been deprecated.
 
-  * The upstream version of this library is no longer maintained.
-  * Reducing the number of cryptographic libraries in Zephyr to reduce maintenance overhead.
-  * The PSA Crypto API is the recommended cryptographic library for Zephyr.
+* For the native_sim target :kconfig:option:`CONFIG_NATIVE_SIM_NATIVE_POSIX_COMPAT` has been
+  switched to ``n`` by default, and this option has been deprecated.
 
-Architectures
-*************
+* :kconfig:option:`CONFIG_BT_BUF_ACL_RX_COUNT`
 
-* Common
+* All HWMv1 board name aliases which were added as deprecated in v3.7 are now removed
+  (:github:`82247`).
 
-  * Introduced :kconfig:option:`CONFIG_ARCH_HAS_CUSTOM_CURRENT_IMPL`, which can be selected when
-    an architecture implements :c:func:`arch_current_thread` and
-    :c:func:`arch_current_thread_set` functions for faster retrieval of the current CPU's thread
-    pointer. When enabled, the ``_current`` symbol will be routed to
-    :c:func:`arch_current_thread` (:github:`80716`).
+* The TinyCrypt library has been deprecated as the upstream version is no longer maintained.
+  PSA Crypto API is now the recommended cryptographic library for Zephyr.
 
-* ARC
+New APIs and options
+====================
 
-* ARM
+..
+  Link to new APIs here, in a group if you think it's necessary, no need to get
+  fancy just list the link, that should contain the documentation. If you feel
+  like you need to add more details, add them in the API documentation code
+  instead.
 
-* ARM64
+* Architectures
 
-* RISC-V
+  * :kconfig:option:`CONFIG_ARCH_HAS_CUSTOM_CURRENT_IMPL`
+  * :kconfig:option:`CONFIG_RISCV_CURRENT_VIA_GP`
 
-  * Implements :c:func:`arch_current_thread_set` & :c:func:`arch_current_thread`, which can be enabled
-    by :kconfig:option:`CONFIG_RISCV_CURRENT_VIA_GP` (:github:`80716`).
+* Bluetooth
 
-* Xtensa
+  * Mesh
 
-* native/POSIX
+    * :c:member:`bt_mesh_health_cli::update` callback can be used to periodically update the message
+      published by the Health Client.
 
-  * :kconfig:option:`CONFIG_NATIVE_APPLICATION` has been deprecated.
-  * For the native_sim target :kconfig:option:`CONFIG_NATIVE_SIM_NATIVE_POSIX_COMPAT` has been
-    switched to ``n`` by default, and this option has been deprecated.
+* Crypto
 
-Kernel
-******
+  * :kconfig:option:`CONFIG_MBEDTLS_PSA_STATIC_KEY_SLOTS`
+  * :kconfig:option:`CONFIG_MBEDTLS_PSA_KEY_SLOT_COUNT`
 
-Bluetooth
-*********
+* Other
 
-* Audio
+  * :kconfig:option:`CONFIG_BT_BUF_ACL_RX_COUNT_EXTRA`
+  * :c:macro:`DT_ANY_INST_HAS_BOOL_STATUS_OKAY`
+  * :c:struct:`led_dt_spec`
+  * :kconfig:option:`CONFIG_STEP_DIR_STEPPER`
 
-* Host
+New Boards
+**********
+..
+  You may update this list as you contribute a new board during the release cycle, in order to make
+  is visible to people who might be looking at the working draft of the release notes. However, note
+  that this list will be recomputed at the time of the release, so you don't *have* to update it.
+  In any case, just link the board, further details go in the board description.
 
-  * :kconfig:option:`CONFIG_BT_BUF_ACL_RX_COUNT` has been deprecated and
-    :kconfig:option:`CONFIG_BT_BUF_ACL_RX_COUNT_EXTRA` has been added.
+* Adafruit Industries, LLC
 
-  * The ECDH HCI command/event emulation layer has been removed, meaning the host will now always
-    do direct calls to PSA to perform these operations.
+   * :zephyr:board:`adafruit_feather_m4_express` (``adafruit_feather_m4_express``)
+   * :zephyr:board:`adafruit_qt_py_esp32s3` (``adafruit_qt_py_esp32s3``)
 
-* HCI Drivers
+* Advanced Micro Devices (AMD), Inc.
 
-* Mesh
+   * :zephyr:board:`acp_6_0_adsp` (``acp_6_0_adsp``)
 
-  * Introduced a :c:member:`bt_mesh_health_cli::update` callback which is used to update the message
-    published periodically.
+* Analog Devices, Inc.
 
-Boards & SoC Support
-********************
+   * :zephyr:board:`max78000evkit` (``max78000evkit``)
+   * :zephyr:board:`max78000fthr` (``max78000fthr``)
+   * :zephyr:board:`max78002evkit` (``max78002evkit``)
 
-* Added support for these SoC series:
+* Antmicro
 
-  * Added Raspberry Pi RP2350
+   * :zephyr:board:`myra_sip_baseboard` (``myra_sip_baseboard``)
 
-* Made these changes in other SoC series:
+* BeagleBoard.org Foundation
 
-* Added support for these boards:
+   * :zephyr:board:`beagley_ai` (``beagley_ai``)
 
-   * :zephyr:board:`Raspberry Pi Pico 2 <rpi_pico2>`: ``rpi_pico2``
-   * :zephyr:board:`Adafruit QT Py ESP32-S3 <adafruit_qt_py_esp32s3>`: ``adafruit_qt_py_esp32s3``
+* FANKE Technology Co., Ltd.
 
-* Made these board changes:
+   * :zephyr:board:`fk750m1_vbt6` (``fk750m1_vbt6``)
 
-  * All HWMv1 board name aliases which were added as deprecated in v3.7 are now removed
-    (:github:`82247`).
-  * ``mimxrt1050_evk`` and ``mimxrt1060_evk`` revisions for ``qspi`` and ``hyperflash`` have been
-    converted into variants. ``mimxrt1060_evkb`` has been converted into revision ``B`` of
-    ``mimxrt1060_evk``.
-  * Enabled USB, RTC on NXP ``frdm_mcxn236``
+* Google, Inc.
 
-* Added support for the following shields:
+   * :zephyr:board:`google_icetower` (``google_icetower``)
+   * :zephyr:board:`google_quincy` (``google_quincy``)
 
-Build system and Infrastructure
-*******************************
+* Infineon Technologies
+
+   * :zephyr:board:`cy8ckit_062s2_ai` (``cy8ckit_062s2_ai``)
+
+* Lilygo Shenzhen Xinyuan Electronic Technology Co., Ltd
+
+   * :zephyr:board:`ttgo_t7v1_5` (``ttgo_t7v1_5``)
+   * :zephyr:board:`ttgo_t8s3` (``ttgo_t8s3``)
+
+* M5Stack
+
+   * :zephyr:board:`m5stack_cores3` (``m5stack_cores3``)
+
+* Makerbase Co., Ltd.
+
+   * :zephyr:board:`mks_canable_v20` (``mks_canable_v20``)
+
+* MediaTek Inc.
+
+   * MT8186 (``mt8186``)
+   * MT8188 (``mt8188``)
+   * MT8196 (``mt8196``)
+
+* NXP Semiconductors
+
+   * :zephyr:board:`mimxrt700_evk` (``mimxrt700_evk``)
+
+* Nordic Semiconductor
+
+   * :zephyr:board:`nrf54l09pdk` (``nrf54l09pdk``)
+
+* Norik Systems
+
+   * :zephyr:board:`octopus_io_board` (``octopus_io_board``)
+   * :zephyr:board:`octopus_som` (``octopus_som``)
+
+* Qorvo, Inc.
+
+   * :zephyr:board:`decawave_dwm3001cdk` (``decawave_dwm3001cdk``)
+
+* Raspberry Pi Foundation
+
+   * :zephyr:board:`rpi_pico2` (``rpi_pico2``)
+
+* Realtek Semiconductor Corp.
+
+   * :zephyr:board:`rts5912_evb` (``rts5912_evb``)
+
+* Renesas Electronics Corporation
+
+   * :zephyr:board:`fpb_ra4e1` (``fpb_ra4e1``)
+   * :zephyr:board:`rzg3s_smarc` (``rzg3s_smarc``)
+   * :zephyr:board:`voice_ra4e1` (``voice_ra4e1``)
+
+* STMicroelectronics
+
+   * :zephyr:board:`nucleo_c071rb` (``nucleo_c071rb``)
+   * :zephyr:board:`nucleo_f072rb` (``nucleo_f072rb``)
+   * :zephyr:board:`nucleo_h7s3l8` (``nucleo_h7s3l8``)
+   * :zephyr:board:`nucleo_wb07cc` (``nucleo_wb07cc``)
+   * :zephyr:board:`stm32f413h_disco` (``stm32f413h_disco``)
+
+* Seeed Technology Co., Ltd
+
+   * :zephyr:board:`xiao_esp32c6` (``xiao_esp32c6``)
+
+* Shenzhen Fuyuansheng Electronic Technology Co., Ltd.
+
+   * :zephyr:board:`ucan` (``ucan``)
+
+* Silicon Laboratories
+
+   * :zephyr:board:`xg23_rb4210a` (``xg23_rb4210a``)
+   * :zephyr:board:`xg24_ek2703a` (``xg24_ek2703a``)
+   * :zephyr:board:`xg29_rb4412a` (``xg29_rb4412a``)
+
+* Toradex AG
+
+   * :zephyr:board:`verdin_imx8mm` (``verdin_imx8mm``)
+
+* Waveshare Electronics
+
+   * :zephyr:board:`rp2040_zero` (``rp2040_zero``)
+
+* WeAct Studio
+
+   * :zephyr:board:`mini_stm32h7b0` (``mini_stm32h7b0``)
+
+* WinChipHead
+
+   * :zephyr:board:`ch32v003evt` (``ch32v003evt``)
+
+* Würth Elektronik GmbH.
+
+   * :zephyr:board:`we_oceanus1ev` (``we_oceanus1ev``)
+   * :zephyr:board:`we_orthosie1ev` (``we_orthosie1ev``)
+
+* others
+
+   * :zephyr:board:`canbardo` (``canbardo``)
+   * :zephyr:board:`candlelight` (``candlelight``)
+   * :zephyr:board:`candlelightfd` (``candlelightfd``)
+   * :zephyr:board:`esp32c3_supermini` (``esp32c3_supermini``)
+   * :zephyr:board:`promicro_nrf52840` (``promicro_nrf52840``)
+
+New Drivers
+***********
+..
+  Same as above for boards, this will also be recomputed at the time of the release.
+  Just link the driver, further details go in the binding description
+
+* :abbr:`ADC (Analog to Digital Converter)`
+
+   * :dtcompatible:`adi,ad4114-adc`
+   * :dtcompatible:`ti,ads131m02`
+   * :dtcompatible:`ti,tla2022`
+   * :dtcompatible:`ti,tla2024`
+
+* ARM architecture
+
+   * :dtcompatible:`nxp,nbu`
+
+* Bluetooth
+
+   * :dtcompatible:`renesas,bt-hci-da1453x`
+   * :dtcompatible:`st,hci-stm32wb0`
+
+* Clock control
+
+   * :dtcompatible:`atmel,sam0-gclk`
+   * :dtcompatible:`atmel,sam0-mclk`
+   * :dtcompatible:`atmel,sam0-osc32kctrl`
+   * :dtcompatible:`nordic,nrf-hsfll-global`
+   * :dtcompatible:`nuvoton,npcm-pcc`
+   * :dtcompatible:`realtek,rts5912-sccon`
+   * :dtcompatible:`wch,ch32v00x-hse-clock`
+   * :dtcompatible:`wch,ch32v00x-hsi-clock`
+   * :dtcompatible:`wch,ch32v00x-pll-clock`
+   * :dtcompatible:`wch,rcc`
+
+* Counter
+
+   * :dtcompatible:`adi,max32-rtc-counter`
+
+* CPU
+
+   * :dtcompatible:`wch,qingke-v2`
+
+* :abbr:`DAC (Digital to Analog Converter)`
+
+   * :dtcompatible:`adi,max22017-dac`
+
+* :abbr:`DAI (Digital Audio Interface)`
+
+   * :dtcompatible:`mediatek,afe`
+
+* Display
+
+   * :dtcompatible:`ilitek,ili9806e-dsi`
+   * :dtcompatible:`renesas,ra-glcdc`
+   * :dtcompatible:`solomon,ssd1309fb`
+
+* :abbr:`DMA (Direct Memory Access)`
+
+   * :dtcompatible:`infineon,cat1-dma`
+   * :dtcompatible:`nxp,sdma`
+   * :dtcompatible:`silabs,ldma`
+   * :dtcompatible:`xlnx,axi-dma-1.00.a`
+   * :dtcompatible:`xlnx,eth-dma`
+
+* Ethernet
+
+   * :dtcompatible:`davicom,dm8806-phy`
+   * :dtcompatible:`microchip,lan9250`
+   * :dtcompatible:`microchip,t1s-phy`
+   * :dtcompatible:`microchip,vsc8541`
+   * :dtcompatible:`renesas,ra-ethernet`
+
+* Firmware
+
+   * :dtcompatible:`arm,scmi-power`
+
+* :abbr:`FPGA (Field Programmable Gate Array)`
+
+   * :dtcompatible:`lattice,ice40-fpga-base`
+   * :dtcompatible:`lattice,ice40-fpga-bitbang`
+
+* :abbr:`GPIO (General Purpose Input/Output)`
+
+   * :dtcompatible:`adi,max22017-gpio`
+   * :dtcompatible:`adi,max22190-gpio`
+   * :dtcompatible:`awinic,aw9523b-gpio`
+   * :dtcompatible:`ite,it8801-gpio`
+   * :dtcompatible:`microchip,mec5-gpio`
+   * :dtcompatible:`nordic,npm2100-gpio`
+   * :dtcompatible:`raspberrypi,rp1-gpio`
+   * :dtcompatible:`realtek,rts5912-gpio`
+   * :dtcompatible:`renesas,ra-gpio-mipi-header`
+   * :dtcompatible:`renesas,rz-gpio`
+   * :dtcompatible:`renesas,rz-gpio-int`
+   * :dtcompatible:`sensry,sy1xx-gpio`
+   * :dtcompatible:`st,mfxstm32l152`
+   * :dtcompatible:`stemma-qt-connector`
+   * :dtcompatible:`wch,gpio`
+
+* IEEE 802.15.4 HDLC RCP interface
+
+   * :dtcompatible:`nxp,hdlc-rcp-if`
+   * :dtcompatible:`uart,hdlc-rcp-if`
+
+* :abbr:`I2C (Inter-Integrated Circuit)`
+
+   * :dtcompatible:`nxp,ii2c`
+   * :dtcompatible:`ti,omap-i2c`
+   * :dtcompatible:`ti,tca9544a`
+
+* :abbr:`I3C (Improved Inter-Integrated Circuit)`
+
+   * :dtcompatible:`st,stm32-i3c`
+
+* Input
+
+   * :dtcompatible:`ite,it8801-kbd`
+   * :dtcompatible:`microchip,cap12xx`
+   * :dtcompatible:`nintendo,nunchuk`
+
+* Interrupt controller
+
+   * :dtcompatible:`wch,pfic`
+
+* Mailbox
+
+   * :dtcompatible:`linaro,ivshmem-mbox`
+   * :dtcompatible:`ti,omap-mailbox`
+
+* :abbr:`MDIO (Management Data Input/Output)`
+
+   * :dtcompatible:`microchip,lan865x-mdio`
+   * :dtcompatible:`renesas,ra-mdio`
+
+* Memory controller
+
+   * :dtcompatible:`renesas,ra-sdram`
+
+* :abbr:`MFD (Multi-Function Device)`
+
+   * :dtcompatible:`adi,max22017`
+   * :dtcompatible:`awinic,aw9523b`
+   * :dtcompatible:`ite,it8801-altctrl`
+   * :dtcompatible:`ite,it8801-mfd`
+   * :dtcompatible:`ite,it8801-mfd-map`
+   * :dtcompatible:`maxim,ds3231-mfd`
+   * :dtcompatible:`nordic,npm2100`
+
+* :abbr:`MIPI DSI (Mobile Industry Processor Interface Display Serial Interface)`
+
+   * :dtcompatible:`renesas,ra-mipi-dsi`
+
+* Miscellaneous
+
+   * :dtcompatible:`nordic,nrf-bicr`
+   * :dtcompatible:`nordic,nrf-ppib`
+   * :dtcompatible:`renesas,ra-external-interrupt`
+
+* :abbr:`MMU / MPU (Memory Management Unit / Memory Protection Unit)`
+
+   * :dtcompatible:`nxp,sysmpu`
+
+* :abbr:`MTD (Memory Technology Device)`
+
+   * :dtcompatible:`fujitsu,mb85rsxx`
+   * :dtcompatible:`nxp,s32-qspi-hyperflash`
+   * :dtcompatible:`nxp,xspi-mx25um51345g`
+
+* :abbr:`PCIe (Peripheral Component Interconnect Express)`
+
+   * :dtcompatible:`brcm,brcmstb-pcie`
+
+* PHY
+
+   * :dtcompatible:`renesas,ra-usbphyc`
+   * :dtcompatible:`st,stm32u5-otghs-phy`
+
+* Pin control
+
+   * :dtcompatible:`realtek,rts5912-pinctrl`
+   * :dtcompatible:`renesas,rzg-pinctrl`
+   * :dtcompatible:`sensry,sy1xx-pinctrl`
+   * :dtcompatible:`silabs,dbus-pinctrl`
+   * :dtcompatible:`wch,afio`
+
+* :abbr:`PWM (Pulse Width Modulation)`
+
+   * :dtcompatible:`atmel,sam0-tc-pwm`
+   * :dtcompatible:`ite,it8801-pwm`
+   * :dtcompatible:`zephyr,fake-pwm`
+
+* Quad SPI
+
+   * :dtcompatible:`nxp,s32-qspi-sfp-frad`
+   * :dtcompatible:`nxp,s32-qspi-sfp-mdad`
+
+* Regulator
+
+   * :dtcompatible:`nordic,npm2100-regulator`
+
+* :abbr:`RNG (Random Number Generator)`
+
+   * :dtcompatible:`nordic,nrf-cracen-ctrdrbg`
+   * :dtcompatible:`renesas,ra-sce5-rng`
+   * :dtcompatible:`renesas,ra-sce7-rng`
+   * :dtcompatible:`renesas,ra-sce9-rng`
+   * :dtcompatible:`renesas,ra-trng`
+   * :dtcompatible:`st,stm32-rng-noirq`
+
+* :abbr:`RTC (Real Time Clock)`
+
+   * :dtcompatible:`maxim,ds3231-rtc`
+   * :dtcompatible:`microcrystal,rv8803`
+
+* SDHC
+
+   * :dtcompatible:`renesas,ra-sdhc`
+
+* Sensors
+
+   * :dtcompatible:`adi,adxl366`
+   * :dtcompatible:`hc-sr04`
+   * :dtcompatible:`invensense,icm42670s`
+   * :dtcompatible:`maxim,ds3231-sensor`
+   * :dtcompatible:`melexis,mlx90394`
+   * :dtcompatible:`nordic,npm2100-vbat`
+   * :dtcompatible:`renesas,hs400x`
+   * :dtcompatible:`sensirion,scd40`
+   * :dtcompatible:`sensirion,scd41`
+   * :dtcompatible:`sensirion,sts4x`
+   * :dtcompatible:`st,lis2duxs12`
+   * :dtcompatible:`st,lsm6dsv16x`
+   * :dtcompatible:`ti,tmag3001`
+   * :dtcompatible:`ti,tmp435`
+   * :dtcompatible:`we,wsen-pdus-25131308XXXXX`
+   * :dtcompatible:`we,wsen-tids-2521020222501`
+
+* Serial controller
+
+   * :dtcompatible:`microchip,mec5-uart`
+   * :dtcompatible:`realtek,rts5912-uart`
+   * :dtcompatible:`renesas,rz-scif-uart`
+   * :dtcompatible:`silabs,eusart-uart`
+   * :dtcompatible:`silabs,usart-uart`
+   * :dtcompatible:`wch,usart`
+
+* :abbr:`SPI (Serial Peripheral Interface)`
+
+   * :dtcompatible:`ite,it8xxx2-spi`
+   * :dtcompatible:`nxp,xspi`
+   * :dtcompatible:`renesas,ra-spi`
+
+* Stepper
+
+   * :dtcompatible:`adi,tmc2209`
+   * :dtcompatible:`ti,drv8424`
+
+* :abbr:`TCPC (USB Type-C Port Controller)`
+
+   * :dtcompatible:`richtek,rt1715`
+
+* Timer
+
+   * :dtcompatible:`mediatek,ostimer64`
+   * :dtcompatible:`realtek,rts5912-rtmr`
+   * :dtcompatible:`realtek,rts5912-slwtimer`
+   * :dtcompatible:`riscv,machine-timer`
+   * :dtcompatible:`wch,systick`
+
+* USB
+
+   * :dtcompatible:`ambiq,usb`
+   * :dtcompatible:`renesas,ra-udc`
+   * :dtcompatible:`renesas,ra-usb`
+
+* Video
+
+   * :dtcompatible:`zephyr,video-emul-imager`
+   * :dtcompatible:`zephyr,video-emul-rx`
+
+* Watchdog
+
+   * :dtcompatible:`atmel,sam4l-watchdog`
+   * :dtcompatible:`nordic,npm2100-wdt`
+   * :dtcompatible:`nxp,rtwdog`
+
+* Wi-Fi
+
+   * :dtcompatible:`infineon,airoc-wifi`
+
+New Samples
+***********
+
+..
+  Same as above for boards and drivers, this will also be recomputed at the time of the release.
+ Just link the sample, further details go in the sample documentation itself.
+
+* :zephyr:code-sample:`6dof_motion_drdy`
+* :zephyr:code-sample:`ble_cs`
+* :zephyr:code-sample:`bluetooth_ccp_call_control_client`
+* :zephyr:code-sample:`bluetooth_ccp_call_control_server`
+* :zephyr:code-sample:`coresight_stm_sample`
+* :zephyr:code-sample:`i2c-rtio-loopback`
+* :zephyr:code-sample:`lvgl-screen-transparency`
+* :zephyr:code-sample:`mctp_endpoint_sample`
+* :zephyr:code-sample:`mctp_host_sample`
+* :zephyr:code-sample:`openthread-shell`
+* :zephyr:code-sample:`ot-coap`
+* :zephyr:code-sample:`rtc`
+* :zephyr:code-sample:`sensor_batch_processing`
+* :zephyr:code-sample:`sensor_clock`
+* :zephyr:code-sample:`stream_fifo`
+* :zephyr:code-sample:`tdk_apex`
+* :zephyr:code-sample:`uart`
+* :zephyr:code-sample:`webusb-next`
+
+Other notable changes
+*********************
+
+..
+  Any more descriptive subsystem or driver changes. Do you really want to write
+  a paragraph or is it enough to link to the api/driver/Kconfig/board page above?
 
 * Space-separated lists support has been removed from Twister configuration
   files. This feature was deprecated a long time ago. Projects that do still use
   them can use the :zephyr_file:`scripts/utils/twister_to_list.py` script to
   automatically migrate Twister configuration files.
 
-* Twister
-
-  * Test Case names for Ztest now include Ztest suite name, so the resulting identifier has
-    three sections and looks like: ``<test_scenario_name>.<ztest_suite_name>.<ztest_name>``.
-    These extended identifiers are used in log output, twister.json and testplan.json,
-    as well as for ``--sub-test`` command line parameters (:github:`80088`).
-  * The ``--no-detailed-test-id`` command line option also shortens Ztest Test Case names excluding
-    its Test Scenario name prefix which is the same as the parent Test Suite id (:github:`82302`).
-    Twister XML reports have full testsuite name as ``testcase.classname property`` resolving
-    possible duplicate testcase elements in ``twister_report.xml`` testsuite container.
-
-* West
-
-  * Added support for the ``--erase`` option on the OpenOCD runner for boards which specify ``--cmd-erase``.
-
-Drivers and Sensors
-*******************
-
-* ADC
-
-* Battery
-
-* CAN
-
-* Charger
-
-* Clock control
-
-* Counter
-
-* DAC
-
-* Disk
-
-* Display
-
-  * Added flag ``frame_incomplete`` to ``display_write`` that indicates whether a write is the last
-    write of the frame, allowing display drivers to implement double buffering / tearing enable
-    signal handling (:github:`81250`)
-  * Added ``frame_incomplete`` handling to SDL display driver (:dtcompatible:`zephyr,sdl-dc`)
-    (:github:`81250`)
-  * Added transparency support to SDL display driver (:dtcompatible:`zephyr,sdl-dc`) (:github:`81184`)
-
-* Ethernet
-
-* Flash
-
-  * NXP MCUX FlexSPI: Add support for 4-byte addressing mode of Micron MT25Q flash family (:github:`82532`)
-
-* FPGA
-
-  * Extracted from :dtcompatible:`lattice,ice40-fpga` the compatible and driver for
-    :dtcompatible:`lattice,ice40-fpga-bitbang`. This replaces the original ``load_mode`` property from
-    the binding, which selected either the SPI or GPIO bitbang load mode.
-
-* GNSS
-
-* GPIO
-
-* Hardware info
-
-* I2C
-
-* I2S
-
-* I3C
-
-* Input
-
-* LED
-
-  * Added a new set of devicetree based LED APIs, see :c:struct:`led_dt_spec`.
-  * lp5569: added use of auto-increment functionality.
-  * lp5569: implemented ``write_channels`` api.
-  * lp5569: demonstrate ``led_write_channels`` in the sample.
-
-* LED Strip
-
-* LoRa
-
-* Mailbox
-
-* MDIO
-
-* MFD
-
-* Modem
-
-  * HL7800: Fix socket port byte order. This resolves issues with TLS handshake failures. (:github:`83763`)
-
-* MIPI-DBI
-
-* MSPI
-
-* Pin control
-
-  * Added new driver for Silabs Series 2 (:dtcompatible:`silabs,dbus-pinctrl`).
-
-* PWM
-
-* Regulators
-
-* Reset
-
-* RTC
-
-* RTIO
-
-* SDHC
-
-* Sensors
-
-  * Sensor Clock
-
-    * The asynchronous sensor API now supports external clock sources. To use an external clock source
-      with the asynchronous sensor API, the following configurations are required:
-
-      * Enable one of the Kconfig options:
-        :kconfig:option:`CONFIG_SENSOR_CLOCK_COUNTER`,
-        :kconfig:option:`CONFIG_SENSOR_CLOCK_RTC`, or
-        :kconfig:option:`CONFIG_SENSOR_CLOCK_SYSTEM`.
-
-      * If not using the system clock, define the ``zephyr,sensor-clock`` property in the device tree to specify
-        the external clock source.
-
-        A typical configuration in the device tree structure is as follows:
-
-        .. code-block:: devicetree
-
-          / {
-            chosen {
-              zephyr,sensor-clock = &timer0;
-            };
-          };
-
-          &timer0 {
-            status = "okay";
-          };
-
-  * WE
-
-    * Replaced outdated :dtcompatible:`we,wsen-pdus` differential pressure sensor driver
-      and renamed it to :dtcompatible:`we,wsen-pdus-25131308XXXXX`.
-
-    * Replaced outdated :dtcompatible:`we,wsen-tids` temperature sensor driver
-      and renamed it to :dtcompatible:`we,wsen-tids-2521020222501`.
-
-* Serial
-
-* SPI
-
-* Stepper
-
-  * Added driver for ADI TMC2209. :dtcompatible:`adi,tmc2209`.
-  * Added driver for TI DRV8424. :dtcompatible:`ti,drv8424`.
-  * Added :kconfig:option:`CONFIG_STEP_DIR_STEPPER` to enable common functions for step/dir steppers.
-
-* USB
-
-* Video
-
-  * Changed :file:`include/zephyr/drivers/video-controls.h` to have control IDs (CIDs) matching
-    those present in the Linux kernel.
-
-  * Changed ``video_pix_fmt_bpp()`` returning the byte count and only supports 8-bit depth,
-    into ``video_bits_per_pixel()`` returning the bit count and supports any color depth.
-
-* Watchdog
-
-  * Added :kconfig:option:`CONFIG_HAS_WDT_NO_CALLBACKS` which drivers select when they do not support
-    a callback being provided in :c:struct:`wdt_timeout_cfg`.
-
-* Wi-Fi
-
-Networking
-**********
-
-* ARP:
-
-* CoAP:
-
-* Connection manager:
-
-* DHCPv4:
-
-* DHCPv6:
-
-* DNS/mDNS/LLMNR:
-
-* gPTP/PTP:
-
-* HTTP:
-
-* IPSP:
-
-* IPv4:
-
-* IPv6:
-
-* LwM2M:
-
-* Misc:
-
-* MQTT:
-
-* Network Interface:
-
-* OpenThread:
-
-  * Removed the implicit enabling of the :kconfig:option:`CONFIG_NVS` Kconfig option by the :kconfig:option:`CONFIG_NET_L2_OPENTHREAD` symbol.
-
-* PPP
-
-* Shell:
-
-* Sockets:
-
-  * The deprecated :kconfig:option:`CONFIG_NET_SOCKETS_POSIX_NAMES` option has been removed.
-    It was a legacy option and was used to allow user to call BSD socket API while not enabling POSIX API.
-    This removal means that in order to use POSIX API socket calls, one needs to enable the
-    :kconfig:option:`CONFIG_POSIX_API` option.
-    If the application does not want or is not able to enable that option, then the socket API
-    calls need to be prefixed by a ``zsock_`` string.
-
-* Syslog:
-
-* TCP:
-
-* Websocket:
-
-* Wi-Fi:
-
-  * hostap: Removed the unused default Crypto module :kconfig:option:`CONFIG_WIFI_NM_WPA_SUPPLICANT_CRYPTO` Kconfig option.
-
-* zperf:
-
-USB
-***
-
-Devicetree
-**********
-
-* Added :c:macro:`DT_ANY_INST_HAS_BOOL_STATUS_OKAY`.
-
-Kconfig
-*******
-
-Libraries / Subsystems
-**********************
-
-* Debug
-
-* Demand Paging
-
-* Formatted output
-
-* Management
-
-* Logging
-
-* Modem modules
-
-* Power management
-
-* Crypto
-
-  * The Kconfig symbol :kconfig:option:`CONFIG_MBEDTLS_PSA_STATIC_KEY_SLOTS` was
-    added to allow Mbed TLS to use statically allocated buffers to store key material
-    in its PSA Crypto core instead of heap-allocated ones. This can help reduce
-    (or remove, if no other component makes use of it) heap memory requirements
-    from the final application.
-
-  * The Kconfig symbol :kconfig:option:`CONFIG_MBEDTLS_PSA_KEY_SLOT_COUNT` was
-    added to allow selecting the number of key slots available in the Mbed TLS
-    implementation of the PSA Crypto core. It defaults to 16. Since each
-    slot consumes RAM memory even if unused, this value can be tweaked in order
-    to minimize RAM usage.
-
-* CMSIS-NN
-
-* FPGA
-
-* Random
-
-* SD
-
-* State Machine Framework
-
-* Storage
-
-  * Shell: :kconfig:option:`CONFIG_FILE_SYSTEM_SHELL_MOUNT_COMMAND` was added,
-    allowing the mount subcommand to be optionally disabled. This can reduce
-    flash and RAM usage since it requires the heap to be present.
-
-* Task Watchdog
-
-* POSIX API
-
-* LoRa/LoRaWAN
-
-* ZBus
-
-HALs
-****
-
-* Nordic
-
-* STM32
-
-* ADI
-
-* Espressif
-
-MCUboot
-*******
-
-OSDP
-****
-
-Trusted Firmware-M
-******************
-
-LVGL
-****
-
-* Added ``frame_incomplete`` support to indicate whether a write is the last
-  write of the frame (:github:`81250`)
-
-Tests and Samples
-*****************
-
-* Fixed incorrect alpha values in :zephyr_file:`samples/drivers/display`. (:github:`81184`)
-* Added :zephyr_file:`samples/modules/lvgl/screen_transparency`. (:github:`81184`)
-
-Issue Related Items
-*******************
-
-Known Issues
-============
+* Test case names for Ztest now include the Ztest suite name, meaning the resulting identifier has
+  three sections and looks like: ``<test_scenario_name>.<ztest_suite_name>.<ztest_name>``.
+  These extended identifiers are used in log output, twister.json and testplan.json,
+  as well as for ``--sub-test`` command line parameters.
+
+* The ``--no-detailed-test-id`` command line option can be used to shorten the test case name
+  by excluding the test scenario name prefix which is the same as the parent test suite id.


### PR DESCRIPTION
Skim down the release notes file, clarify what goes there and more importantly what doesn't

---
Demo: https://builds.zephyrproject.io/zephyr/pr/82542/docs/releases/release-notes-4.1.html

This is a proposal to skim down the release notes, main idea:

- keep removed/deprecated APIs, although arguably the removed one should be in the release notes
- list all new driver, samples, boards, APIs
  - just link the thing, all of those should already have a documentation generated from the code, duplicating it here is a waste of time and energy for something that lives and dies in the specific release file, that effort should be put in the corresponding documentation in the code instead, initial idea is to keep these lists generated but then maybe refine them further, group, something like that
  - no bugfixes or minor changes, it's called release notes, not changelog
- leave a space for "notable features" and try to have it for stuff that does not fall in the categories above, especially if it does not have a description somewhere else in the code already

TODO: some of the stuff that is still there needs to go in the migration guide, will move it at a later stage