### PR TITLE
soc: nordic: nrf54l: remove redundant ELV code

### DIFF
--- a/soc/nordic/nrf54l/CMakeLists.txt
+++ b/soc/nordic/nrf54l/CMakeLists.txt
@@ -6,7 +6,3 @@ zephyr_library_sources(
   ../validate_rram_partitions.c
   )
 zephyr_include_directories(.)
-
-if(CONFIG_ELV_GRTC_LFXO_ALLOWED)
-  message(WARNING "WARNING! ELV mode feature is EXPERIMENTAL and may brick your device!")
-endif()

--- a/soc/nordic/nrf54l/Kconfig
+++ b/soc/nordic/nrf54l/Kconfig
@@ -73,18 +73,4 @@ config SOC_NRF_FORCE_CONSTLAT
 	  of base resources on while in sleep. The advantage of having a constant
 	  and predictable latency will be at the cost of having increased power consumption.
 
-if NRF_GRTC_TIMER
-
-config ELV_GRTC_LFXO_ALLOWED
-	bool
-	depends on POWEROFF
-	select EXPERIMENTAL
-	help
-	  This feature allows using ELV mode when GRTC operates with the LFXO as
-	  a low-frequency clock source. The LFXO is automatically activated when
-	  preparing to system-off.
-	  WARNING! This feature is EXPERIMENTAL and may brick your device!
-
-endif # NRF_GRTC_TIMER
-
 endif # SOC_SERIES_NRF54LX

--- a/soc/nordic/nrf54l/soc.c
+++ b/soc/nordic/nrf54l/soc.c
@@ -161,9 +161,6 @@ static int nordicsemi_nrf54l_init(void)
 	nrf_regulators_vreg_enable_set(NRF_REGULATORS, NRF_REGULATORS_VREG_MAIN, true);
 #endif
 
-#if defined(CONFIG_ELV_GRTC_LFXO_ALLOWED)
-	nrf_regulators_elv_mode_allow_set(NRF_REGULATORS, NRF_REGULATORS_ELV_ELVGRTCLFXO_MASK);
-#endif /* CONFIG_ELV_GRTC_LFXO_ALLOWED */
 #endif /* NRF_APPLICATION */
 
 	return 0;


### PR DESCRIPTION
Removed dead ELV code from nRF54L soc.