### PR TITLE
Bluetooth: Audio: unittest fails when BT_MAX_CONN = 1

### DIFF
--- a/tests/bluetooth/audio/cap_commander/src/test_distribute_broadcast_code.c
+++ b/tests/bluetooth/audio/cap_commander/src/test_distribute_broadcast_code.c
@@ -245,6 +245,10 @@ ZTEST_F(cap_commander_test_distribute_broadcast_code,
 {
 	int err;
 
+	if (CONFIG_BT_MAX_CONN == 1) {
+		ztest_test_skip();
+	}
+
 	for (size_t i = 0; i < ARRAY_SIZE(fixture->broadcast_code_member_params); i++) {
 		fixture->broadcast_code_member_params[i].member.member = &fixture->conns[0];
 	}


### PR DESCRIPTION
There is a unittest to verify that the distribute broadcast code procedure is not called with the same peer twice. This test requires a minimum of two connections, so we disable this test when only 1 connection can be made