### PR TITLE
twister: fix issue twister with --device-testing on Windows

### DIFF
--- a/scripts/pylib/twister/twisterlib/testinstance.py
+++ b/scripts/pylib/twister/twisterlib/testinstance.py
@@ -264,9 +264,9 @@ class TestInstance:
         simulation = options.sim_name
 
         simulator = self.platform.simulator_by_name(simulation)
-        if os.name == 'nt':
+        if os.name == 'nt' and simulator:
             # running on simulators is currently supported only for QEMU on Windows
-            if (not simulator) or simulator.name not in ('na', 'qemu'):
+            if simulator.name not in ('na', 'qemu'):
                 return False
 
             # check presence of QEMU on Windows


### PR DESCRIPTION
There is an incorrect logic that causes twister with --device-testing to skip all tests on Windows. Correct the logical condition.

This fixes: https://github.com/zephyrproject-rtos/zephyr/issues/82391