### PR TITLE
lib: os: p4wq: fix K_P4WQ_DELAYED_START mode

### DIFF
--- a/lib/os/p4wq.c
+++ b/lib/os/p4wq.c
@@ -168,10 +168,6 @@ static int static_init(void)
 					  &pp->stacks[ssz * i],
 					  pp->stack_size);
 
-			if (pp->flags & K_P4WQ_DELAYED_START) {
-				z_mark_thread_as_suspended(&pp->threads[i]);
-			}
-
 #ifdef CONFIG_SCHED_CPU_MASK
 			if (pp->flags & K_P4WQ_USER_CPU_MASK) {
 				int ret = k_thread_cpu_mask_clear(&pp->threads[i]);
@@ -206,7 +202,6 @@ void k_p4wq_enable_static_thread(struct k_p4wq *queue, struct k_thread *thread,
 #endif
 
 	if (queue->flags & K_P4WQ_DELAYED_START) {
-		z_mark_thread_as_not_suspended(thread);
 		k_thread_start(thread);
 	}
 }


### PR DESCRIPTION
When the PRESTART thread state was removed, this changed the semantics
of k_thread_start() when thread was created with a K_FOREVER timeout,
suspended and then started with k_thread_start().

This sequence is used in p4wq to implement K_P4WQ_DELAYED_START
(which again is needed by K_P4WQ_USER_CPU_MASK).

With PRESTART removed, the following sequence:
  z_mark_thread_as_not_suspended(thread);
  k_thread_start(thread);

.. no longer starts the thread. As a result, p4wq users like SOF
multicore configurations, hit errors as p4wq threads never start.

Fix the implementation by removing the calls to change thread
suspended state explicitly, but rather rely on the new
k_thread_create() and k_thread_start() semantics.

Fixes: 7cdf40541bfc ("kernel/sched: Eliminate PRESTART thread state")