### PR TITLE
modules: hal_nordic: nrfx_config: Customize NRFX_SPIM_EXTENDED_ENABLED

### DIFF
--- a/modules/hal_nordic/nrfx/nrfx_config.h
+++ b/modules/hal_nordic/nrfx/nrfx_config.h
@@ -489,9 +489,12 @@
 
 #define NRFX_SPIM_DT_HAS_RX_DELAY(node) DT_PROP(node, rx_delay_supported) +
 
+#ifndef NRFX_SPIM_EXTENDED_ENABLED
 #if DT_FOREACH_STATUS_OKAY(nordic_nrf_spim, NRFX_SPIM_DT_HAS_RX_DELAY) 0
 #define NRFX_SPIM_EXTENDED_ENABLED 1
 #endif
+#endif
+
 #ifdef CONFIG_NRFX_SPIM00
 #define NRFX_SPIM00_ENABLED 1
 #endif


### PR DESCRIPTION
nrfx_config is setting NRFX_SPIM_EXTENDED_ENABLED based on presence of a DT property. However, there are test cases when it is expected that extended SPIM features will be disabled on a target that supports extended features. Allow that by not setting the value if it is already defined.