### PR TITLE
maintainers: Adding @wearyzen as collaborator on Arm related sections

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -159,6 +159,7 @@ ARM arch:
     - MaureenHelm
     - stephanosio
     - bbolen
+    - wearyzen
   files:
     - arch/arm/
     - arch/arm/core/offsets/
@@ -195,6 +196,8 @@ ARM Platforms:
   status: maintained
   maintainers:
     - ithinuel
+  collaborators:
+    - wearyzen
   files:
     - boards/arm/mps*/
     - boards/arm/v2m_*/
@@ -4995,6 +4998,7 @@ West:
     - ceolin
   collaborators:
     - ithinuel
+    - wearyzen
     - valeriosetti
     - tomi-font
   files:
@@ -5183,6 +5187,7 @@ West:
   collaborators:
     - Vge0rge
     - ithinuel
+    - wearyzen
     - valeriosetti
     - tomi-font
   files:
@@ -5202,6 +5207,7 @@ West:
   collaborators:
     - Vge0rge
     - ithinuel
+    - wearyzen
   files: []
   labels:
     - "area: TF-M"
@@ -5214,6 +5220,7 @@ West:
   collaborators:
     - carlocaione
     - ithinuel
+    - wearyzen
   files:
     - modules/trusted-firmware-a/
   labels:
@@ -5226,6 +5233,7 @@ West:
   collaborators:
     - Vge0rge
     - ithinuel
+    - wearyzen
   files: []
   labels:
     - "area: TF-M"


### PR DESCRIPTION
This change adds @wearyzen as a collaborator to:
- ARM arch
- ARM Platforms
- West project: mbedtls
- West project: trusted-firmware-m
- West project: tf-m-tests
- West project: trusted-firmware-a
- West project: psa-arch-tests