### PR TITLE
stm32g4 dpow  board with sysclock at max 170MHz freq

### DIFF
--- a/boards/st/b_g474e_dpow1/b_g474e_dpow1.dts
+++ b/boards/st/b_g474e_dpow1/b_g474e_dpow1.dts
@@ -102,10 +102,10 @@ stm32_lp_tick_source: &lptim1 {
 };
 
 &pll {
-	div-m = <1>;
-	mul-n = <16>;
-	div-p = <7>;
-	div-q = <2>;
+	div-m = <4>;
+	mul-n = <85>;
+	div-p = <8>;
+	div-q = <8>;
 	div-r = <2>;
 	clocks = <&clk_hsi>;
 	status = "okay";
@@ -113,7 +113,7 @@ stm32_lp_tick_source: &lptim1 {
 
 &rcc {
 	clocks = <&pll>;
-	clock-frequency = <DT_FREQ_M(128)>;
+	clock-frequency = <DT_FREQ_M(170)>;
 	ahb-prescaler = <1>;
 	apb1-prescaler = <1>;
 	apb2-prescaler = <1>;

--- a/dts/arm/st/g4/stm32g4.dtsi
+++ b/dts/arm/st/g4/stm32g4.dtsi
@@ -656,7 +656,7 @@
 		ucpd1: ucpd@4000a000 {
 			compatible = "st,stm32-ucpd";
 			reg = <0x4000a000 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 4U)>;
+			clocks = <&rcc STM32_CLOCK(APB1_2, 8U)>;
 			interrupts = <63 0>;
 			status = "disabled";
 		};


### PR DESCRIPTION
Set the sysclock at 170MHz for the B-G474E-DPOW1 Discovery kit
    PLL is sourced by the HSI at 16MHz
    Increasing the sysclock makes the disco kit similar to other
    stm32G4 target boards and makes LOG output correct

That will help in fixing https://github.com/zephyrproject-rtos/zephyr/issues/77186
