### PR TITLE
mgmt: smp: Fix race condition by using same work queue

### DIFF
--- a/subsys/mgmt/mcumgr/transport/include/mgmt/mcumgr/transport/smp_internal.h
+++ b/subsys/mgmt/mcumgr/transport/include/mgmt/mcumgr/transport/smp_internal.h
@@ -50,11 +50,11 @@ void smp_rx_req(struct smp_transport *smtp, struct net_buf *nb);
 
 #ifdef CONFIG_SMP_CLIENT
 /**
- * @brief Trig SMP client request packet for transmission.
+ * @brief Get work queue for SMP client.
  *
- * @param work	The transport to use to send the corresponding response(s).
+ * @return SMP work queue object.
  */
-void smp_tx_req(struct k_work *work);
+struct k_work_q *smp_get_wq(void);
 #endif
 
 /**

--- a/subsys/mgmt/mcumgr/transport/src/smp.c
+++ b/subsys/mgmt/mcumgr/transport/src/smp.c
@@ -204,9 +204,9 @@ smp_rx_req(struct smp_transport *smpt, struct net_buf *nb)
 }
 
 #ifdef CONFIG_SMP_CLIENT
-void smp_tx_req(struct k_work *work)
+struct k_work_q *smp_get_wq(void)
 {
-	k_work_submit_to_queue(&smp_work_queue, work);
+	return &smp_work_queue;
 }
 #endif
 


### PR DESCRIPTION
Fix possible race condition where SMP client might release the network buffer before system worker queue has processed it.

In smp_client uses shared resources like worker queue linked list and network buffers without maintaining any thread safety.

For unknown reasons, retry timeout handling is pushed into system worker queue while the actual transmission is handled from SMP work queue.

Fix the issue by using the same SMP work queue
for both delayable timeout handling as well as
transmission handling.