### PR TITLE
tests/stream_flash: Improve platform filtering

### DIFF
--- a/tests/subsys/storage/stream/stream_flash/testcase.yaml
+++ b/tests/subsys/storage/stream/stream_flash/testcase.yaml
@@ -12,14 +12,21 @@ tests:
     integration_platforms:
       - nrf52840dk/nrf52840
   storage.stream_flash.simulator.no_explicit_erase:
-    extra_args:
+    filter: dt_compat_enabled("zephyr,sim-flash")
+    extra_configs:
       - CONFIG_STREAM_FLASH_ERASE=n
       - CONFIG_FLASH_SIMULATOR_EXPLICIT_ERASE=n
     tags: stream_flash
   storage.stream_flash.no_explicit_erase:
+    # Systems with zephyr,sim-flash are tested by simulator scenarios,
+    # common platforms could bring them here too so filter these out.
+    filter: not dt_compat_enabled("zephyr,sim-flash")
     platform_allow:
       - nrf54l15dk/nrf54l15/cpuapp
-    extra_args:
+    extra_configs:
+      # Tests, currently, can only support single device testing
+      # and platform enabling SPI NOR automatically brings in a device with
+      # explicit erase requirement.
       - CONFIG_SPI_NOR=n
   storage.stream_flash.dword_wbs:
     extra_args: DTC_OVERLAY_FILE=unaligned_flush.overlay


### PR DESCRIPTION
Improve platform filtering of common platforms, replace extra_args with extra_configs, where applicable and add little comment on why certain options are used.