### PR TITLE
storage/flash_map: Add FIXED_PARTITION_BY_NODE macro

### DIFF
--- a/include/zephyr/storage/flash_map.h
+++ b/include/zephyr/storage/flash_map.h
@@ -419,6 +419,16 @@ uint8_t flash_area_erased_val(const struct flash_area *fa);
  * @return Pointer to flash_area type object representing partition
  */
 #define FIXED_PARTITION(label)	FIXED_PARTITION_1(DT_NODELABEL(label))
+
+/**
+ * Get pointer to flash_area object by partition node in DTS
+ *
+ * @param node DTS node of a partition
+ *
+ * @return Pointer to flash_area type object representing partition
+ */
+#define FIXED_PARTITION_BY_NODE(node)	FIXED_PARTITION_1(node)
+
 #define FIXED_PARTITION_1(node)	FIXED_PARTITION_0(DT_DEP_ORD(node))
 #define FIXED_PARTITION_0(ord)							\
 	((const struct flash_area *)&DT_CAT(global_fixed_partition_ORD_, ord))

--- a/tests/subsys/storage/flash_map/src/main.c
+++ b/tests/subsys/storage/flash_map/src/main.c
@@ -30,6 +30,11 @@ ZTEST(flash_map, test_flash_area_disabled_device)
 	zassert_equal(rc, -ENOENT, "Open did not fail");
 	rc = flash_area_open(FIXED_PARTITION_ID(disabled_b), &fa);
 	zassert_equal(rc, -ENOENT, "Open did not fail");
+
+	/* Note lack of tests for FIXED_PARTITION(...) instantiation,
+	 * because this macro will fail, at compile time, if node does not
+	 * exist or is disabled.
+	 */
 }
 
 ZTEST(flash_map, test_flash_area_device_is_ready)
@@ -143,6 +148,10 @@ ZTEST(flash_map, test_fixed_partition_node_macros)
 		DT_REG_SIZE(SLOT1_PARTITION_NODE));
 	zassert_equal(FIXED_PARTITION_NODE_DEVICE(SLOT1_PARTITION_NODE),
 		DEVICE_DT_GET(DT_MTD_FROM_FIXED_PARTITION(SLOT1_PARTITION_NODE)));
+
+	/* Taking by node and taking by label should give same device */
+	zassert_equal(FIXED_PARTITION_BY_NODE(DT_NODELABEL(SLOT1_PARTITION)),
+		      FIXED_PARTITION(SLOT1_PARTITION));
 }
 
 ZTEST(flash_map, test_flash_area_erase_and_flatten)


### PR DESCRIPTION
Macro allows to instantiate flash_area object pointer from DTS node.