### PR TITLE
boards: silabs: fix ecc config on silabs bt boards

### DIFF
--- a/boards/silabs/dev_kits/sltb010a/Kconfig.defconfig
+++ b/boards/silabs/dev_kits/sltb010a/Kconfig.defconfig
@@ -26,6 +26,9 @@ config MAIN_STACK_SIZE
 	default 3072 if PM
 	default 2304
 
+config BT_ECC
+	default y
+
 config BT_SEND_ECC_EMULATION
 	default y
 

--- a/boards/silabs/dev_kits/xg24_dk2601b/Kconfig.defconfig
+++ b/boards/silabs/dev_kits/xg24_dk2601b/Kconfig.defconfig
@@ -31,6 +31,9 @@ config COMMON_LIBC_MALLOC_ARENA_SIZE
 config MAIN_STACK_SIZE
 	default 2304
 
+config BT_ECC
+	default y
+
 config BT_SEND_ECC_EMULATION
 	default y
 

--- a/boards/silabs/dev_kits/xg27_dk2602a/Kconfig.defconfig
+++ b/boards/silabs/dev_kits/xg27_dk2602a/Kconfig.defconfig
@@ -26,6 +26,9 @@ config MAIN_STACK_SIZE
 	default 3072 if PM
 	default 2304
 
+config BT_ECC
+	default y
+
 config BT_SEND_ECC_EMULATION
 	default y
 

--- a/boards/silabs/radio_boards/slwrb4104a/Kconfig.defconfig
+++ b/boards/silabs/radio_boards/slwrb4104a/Kconfig.defconfig
@@ -37,6 +37,9 @@ config MAIN_STACK_SIZE
 	default 3072 if PM
 	default 2304
 
+config BT_ECC
+	default y
+
 config BT_SEND_ECC_EMULATION
 	default y
 

--- a/boards/silabs/radio_boards/slwrb4161a/Kconfig.defconfig
+++ b/boards/silabs/radio_boards/slwrb4161a/Kconfig.defconfig
@@ -37,6 +37,9 @@ config MAIN_STACK_SIZE
 	default 3072 if PM
 	default 2304
 
+config BT_ECC
+	default y
+
 config BT_SEND_ECC_EMULATION
 	default y
 

--- a/boards/silabs/radio_boards/slwrb4170a/Kconfig.defconfig
+++ b/boards/silabs/radio_boards/slwrb4170a/Kconfig.defconfig
@@ -37,6 +37,9 @@ config MAIN_STACK_SIZE
 	default 3072 if PM
 	default 2304
 
+config BT_ECC
+	default y
+
 config BT_SEND_ECC_EMULATION
 	default y
 

--- a/boards/silabs/radio_boards/slwrb4180a/Kconfig.defconfig
+++ b/boards/silabs/radio_boards/slwrb4180a/Kconfig.defconfig
@@ -37,6 +37,9 @@ config MAIN_STACK_SIZE
 	default 3072 if PM
 	default 2304
 
+config BT_ECC
+	default y
+
 config BT_SEND_ECC_EMULATION
 	default y
 

--- a/boards/silabs/radio_boards/slwrb4250b/Kconfig.defconfig
+++ b/boards/silabs/radio_boards/slwrb4250b/Kconfig.defconfig
@@ -37,6 +37,9 @@ config MAIN_STACK_SIZE
 	default 3072 if PM
 	default 2304
 
+config BT_ECC
+	default y
+
 config BT_SEND_ECC_EMULATION
 	default y
 

--- a/boards/silabs/radio_boards/slwrb4255a/Kconfig.defconfig
+++ b/boards/silabs/radio_boards/slwrb4255a/Kconfig.defconfig
@@ -37,6 +37,9 @@ config MAIN_STACK_SIZE
 	default 3072 if PM
 	default 2304
 
+config BT_ECC
+	default y
+
 config BT_SEND_ECC_EMULATION
 	default y
 

--- a/boards/silabs/radio_boards/xg24_rb4187c/Kconfig.defconfig
+++ b/boards/silabs/radio_boards/xg24_rb4187c/Kconfig.defconfig
@@ -37,6 +37,9 @@ config MAIN_STACK_SIZE
 	default 3072 if PM
 	default 2304
 
+config BT_ECC
+	default y
+
 config BT_SEND_ECC_EMULATION
 	default y
 


### PR DESCRIPTION
`BT_SEND_ECC_EMULATION` depends on `BT_ECC`. Fixes https://github.com/zephyrproject-rtos/zephyr/issues/82569