### PR TITLE
driver: sensor: tmp116: oversample attribute

### DIFF
--- a/drivers/sensor/ti/tmp116/tmp116.c
+++ b/drivers/sensor/ti/tmp116/tmp116.c
@@ -398,6 +398,11 @@ static int tmp116_init(const struct device *dev)
 	drv_data->id = id;
 
 	rc = tmp116_write_config(dev, TMP116_CFGR_CONV, cfg->odr);
+	if (rc < 0) {
+		return rc;
+	}
+
+	rc = tmp116_write_config(dev, TMP116_CFGR_AVG, cfg->oversampling);
 
 	return rc;
 }
@@ -407,6 +412,7 @@ static int tmp116_init(const struct device *dev)
 	static const struct tmp116_dev_config tmp116_config_##_num = { \
 		.bus = I2C_DT_SPEC_INST_GET(_num), \
 		.odr = DT_INST_PROP(_num, odr), \
+		.oversampling = DT_INST_PROP(_num, oversampling), \
 	}; \
 	SENSOR_DEVICE_DT_INST_DEFINE(_num, tmp116_init, NULL, \
 		&tmp116_data_##_num, &tmp116_config_##_num, POST_KERNEL, \

--- a/drivers/sensor/ti/tmp116/tmp116.h
+++ b/drivers/sensor/ti/tmp116/tmp116.h
@@ -50,6 +50,7 @@ struct tmp116_data {
 struct tmp116_dev_config {
 	struct i2c_dt_spec bus;
 	uint16_t odr;
+	uint16_t oversampling;
 };
 
 #endif /*  ZEPHYR_DRIVERS_SENSOR_TMP116_TMP116_H_ */

--- a/dts/bindings/sensor/ti,tmp116.yaml
+++ b/dts/bindings/sensor/ti,tmp116.yaml
@@ -13,10 +13,11 @@ properties:
   odr:
     type: int
     default: 0x200
+    enum: [0, 0x80, 0x100, 0x180, 0x200, 0x280, 0x300, 0x380]
     description: |
       Specify the default temperature output data rate in milliseconds (ms).
       Default is power-up configuration.
-    enum:
+
       - 0     # TMP116_DT_ODR_15_5_MS
       - 0x80  # TMP116_DT_ODR_125_MS
       - 0x100 # TMP116_DT_ODR_250_MS

--- a/dts/bindings/sensor/ti,tmp116.yaml
+++ b/dts/bindings/sensor/ti,tmp116.yaml
@@ -25,3 +25,15 @@ properties:
       - 0x280 # TMP116_DT_ODR_4000_MS
       - 0x300 # TMP116_DT_ODR_8000_MS
       - 0x380 # TMP116_DT_ODR_16000_MS
+  oversampling:
+    type: int
+    default: 0x20
+    enum: [0, 0x20, 0x40, 0x60]
+    description: |
+      Set number of sample to averaging in one readout.
+      Default is power-up configuration (8 samples).
+
+      - 0    # TMP116_DT_OVERSAMPLING_1
+      - 0x20 # TMP116_DT_OVERSAMPLING_8
+      - 0x40 # TMP116_DT_OVERSAMPLING_32
+      - 0x60 # TMP116_DT_OVERSAMPLING_64

--- a/include/zephyr/dt-bindings/sensor/tmp116.h
+++ b/include/zephyr/dt-bindings/sensor/tmp116.h
@@ -26,6 +26,16 @@
 #define TMP116_DT_ODR_16000_MS 0x380
 /** @} */
 
+/**
+ * @defgroup TMP116_OS Temperature average sample count
+ * @{
+ */
+#define TMP116_DT_OVERSAMPLING_1   0
+#define TMP116_DT_OVERSAMPLING_8   0x20
+#define TMP116_DT_OVERSAMPLING_32  0x40
+#define TMP116_DT_OVERSAMPLING_64  0x60
+/** @} */
+
 /** @} */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_TI_TMP116_H_ */

--- a/tests/drivers/build_all/sensor/i2c.dtsi
+++ b/tests/drivers/build_all/sensor/i2c.dtsi
@@ -480,6 +480,7 @@ test_i2c_tmp116: tmp116@47 {
 	compatible = "ti,tmp116";
 	reg = <0x47>;
 	odr = <TMP116_DT_ODR_125_MS>;
+	oversampling = <TMP116_DT_OVERSAMPLING_32>;
 };
 
 test_i2c_bq274xx: bq27xx@48 {


### PR DESCRIPTION
Add oversample attribute

The usage is similar to tmp114, see #77248