### PR TITLE
drivers: stepper: api: rename positioning functions

### DIFF
--- a/doc/hardware/peripherals/stepper.rst
+++ b/doc/hardware/peripherals/stepper.rst
@@ -19,8 +19,7 @@ Control Stepper
 ===============
 
 - **Move by** +/- micro-steps also known as **relative movement** using :c:func:`stepper_move_by`.
-- **Move to** a specific position also known as **absolute movement**
-  using :c:func:`stepper_set_target_position`.
+- **Move to** a specific position also known as **absolute movement** using :c:func:`stepper_move_to`.
 - Run continuously with a **constant velocity** in a specific direction until
   a stop is detected using :c:func:`stepper_run`.
 - Check if the stepper is **moving** using :c:func:`stepper_is_moving`.

--- a/doc/hardware/peripherals/stepper.rst
+++ b/doc/hardware/peripherals/stepper.rst
@@ -18,7 +18,7 @@ Configure Stepper Driver
 Control Stepper
 ===============
 
-- **Move by** +/- micro-steps also known as **relative movement** using :c:func:`stepper_move`.
+- **Move by** +/- micro-steps also known as **relative movement** using :c:func:`stepper_move_by`.
 - **Move to** a specific position also known as **absolute movement**
   using :c:func:`stepper_set_target_position`.
 - Run continuously with a **constant velocity** in a specific direction until

--- a/doc/releases/migration-guide-4.1.rst
+++ b/doc/releases/migration-guide-4.1.rst
@@ -169,6 +169,7 @@ Stepper
   * Renamed the ``compatible`` from ``zephyr,gpio-steppers`` to :dtcompatible:`zephyr,gpio-stepper`.
   * Renamed the ``stepper_set_actual_position`` function to :c:func:`stepper_set_reference_position`.
   * Renamed the ``stepper_enable_constant_velocity_mode`` function to :c:func:`stepper_run`.
+  * Renamed the ``stepper_move`` function to :c:func:`stepper_move_by`.
 
 SPI
 ===

--- a/doc/releases/migration-guide-4.1.rst
+++ b/doc/releases/migration-guide-4.1.rst
@@ -170,6 +170,7 @@ Stepper
   * Renamed the ``stepper_set_actual_position`` function to :c:func:`stepper_set_reference_position`.
   * Renamed the ``stepper_enable_constant_velocity_mode`` function to :c:func:`stepper_run`.
   * Renamed the ``stepper_move`` function to :c:func:`stepper_move_by`.
+  * Renamed the ``stepper_set_target_position`` function to :c:func:`stepper_move_to`.
 
 SPI
 ===

--- a/drivers/stepper/adi_tmc/adi_tmc5041_stepper_controller.c
+++ b/drivers/stepper/adi_tmc/adi_tmc5041_stepper_controller.c
@@ -442,9 +442,9 @@ static int tmc5041_stepper_get_actual_position(const struct device *dev, int32_t
 	return 0;
 }
 
-static int tmc5041_stepper_set_target_position(const struct device *dev, const int32_t position)
+static int tmc5041_stepper_move_to(const struct device *dev, const int32_t micro_steps)
 {
-	LOG_DBG("Stepper motor controller %s set target position to %d", dev->name, position);
+	LOG_DBG("Stepper motor controller %s set target position to %d", dev->name, micro_steps);
 	const struct tmc5041_stepper_config *config = dev->config;
 	struct tmc5041_stepper_data *data = dev->data;
 	int err;
@@ -458,7 +458,7 @@ static int tmc5041_stepper_set_target_position(const struct device *dev, const i
 	if (err != 0) {
 		return -EIO;
 	}
-	err = tmc5041_write(config->controller, TMC5041_XTARGET(config->index), position);
+	err = tmc5041_write(config->controller, TMC5041_XTARGET(config->index), micro_steps);
 	if (err != 0) {
 		return -EIO;
 	}
@@ -729,7 +729,7 @@ static int tmc5041_stepper_init(const struct device *dev)
 		.get_micro_step_res = tmc5041_stepper_get_micro_step_res,			\
 		.set_reference_position = tmc5041_stepper_set_reference_position,		\
 		.get_actual_position = tmc5041_stepper_get_actual_position,			\
-		.set_target_position = tmc5041_stepper_set_target_position,			\
+		.move_to = tmc5041_stepper_move_to,						\
 		.run = tmc5041_stepper_run,							\
 		.set_event_callback = tmc5041_stepper_set_event_callback, };
 

--- a/drivers/stepper/adi_tmc/adi_tmc5041_stepper_controller.c
+++ b/drivers/stepper/adi_tmc/adi_tmc5041_stepper_controller.c
@@ -301,7 +301,7 @@ static int tmc5041_stepper_is_moving(const struct device *dev, bool *is_moving)
 	return 0;
 }
 
-static int tmc5041_stepper_move(const struct device *dev, const int32_t steps)
+static int tmc5041_stepper_move_by(const struct device *dev, const int32_t micro_steps)
 {
 	const struct tmc5041_stepper_config *config = dev->config;
 	struct tmc5041_stepper_data *data = dev->data;
@@ -320,7 +320,7 @@ static int tmc5041_stepper_move(const struct device *dev, const int32_t steps)
 	if (err != 0) {
 		return -EIO;
 	}
-	int32_t target_position = position + steps;
+	int32_t target_position = position + micro_steps;
 
 	err = tmc5041_write(config->controller, TMC5041_RAMPMODE(config->index),
 			    TMC5XXX_RAMPMODE_POSITIONING_MODE);
@@ -328,7 +328,7 @@ static int tmc5041_stepper_move(const struct device *dev, const int32_t steps)
 		return -EIO;
 	}
 	LOG_DBG("Stepper motor controller %s moved to %d by steps: %d", dev->name, target_position,
-		steps);
+		micro_steps);
 	err = tmc5041_write(config->controller, TMC5041_XTARGET(config->index), target_position);
 	if (err != 0) {
 		return -EIO;
@@ -723,7 +723,7 @@ static int tmc5041_stepper_init(const struct device *dev)
 	static DEVICE_API(stepper, tmc5041_stepper_api_##child) = {				\
 		.enable = tmc5041_stepper_enable,						\
 		.is_moving = tmc5041_stepper_is_moving,						\
-		.move = tmc5041_stepper_move,							\
+		.move_by = tmc5041_stepper_move_by,						\
 		.set_max_velocity = tmc5041_stepper_set_max_velocity,				\
 		.set_micro_step_res = tmc5041_stepper_set_micro_step_res,			\
 		.get_micro_step_res = tmc5041_stepper_get_micro_step_res,			\

--- a/drivers/stepper/fake_stepper_controller.c
+++ b/drivers/stepper/fake_stepper_controller.c
@@ -37,7 +37,7 @@ DEFINE_FAKE_VALUE_FUNC(int, fake_stepper_set_reference_position, const struct de
 
 DEFINE_FAKE_VALUE_FUNC(int, fake_stepper_get_actual_position, const struct device *, int32_t *);
 
-DEFINE_FAKE_VALUE_FUNC(int, fake_stepper_set_target_position, const struct device *, int32_t);
+DEFINE_FAKE_VALUE_FUNC(int, fake_stepper_move_to, const struct device *, int32_t);
 
 DEFINE_FAKE_VALUE_FUNC(int, fake_stepper_run, const struct device *, enum stepper_direction,
 		       uint32_t);
@@ -97,7 +97,7 @@ static void fake_stepper_reset_rule_before(const struct ztest_unit_test *test, v
 	RESET_FAKE(fake_stepper_get_micro_step_res);
 	RESET_FAKE(fake_stepper_set_reference_position);
 	RESET_FAKE(fake_stepper_get_actual_position);
-	RESET_FAKE(fake_stepper_set_target_position);
+	RESET_FAKE(fake_stepper_move_to);
 	RESET_FAKE(fake_stepper_run);
 
 	/* Install custom fakes for the setter and getter functions */
@@ -133,7 +133,7 @@ static DEVICE_API(stepper, fake_stepper_driver_api) = {
 	.get_micro_step_res = fake_stepper_get_micro_step_res,
 	.set_reference_position = fake_stepper_set_reference_position,
 	.get_actual_position = fake_stepper_get_actual_position,
-	.set_target_position = fake_stepper_set_target_position,
+	.move_to = fake_stepper_move_to,
 	.run = fake_stepper_run,
 	.set_event_callback = fake_stepper_set_event_callback,
 };

--- a/drivers/stepper/fake_stepper_controller.c
+++ b/drivers/stepper/fake_stepper_controller.c
@@ -23,7 +23,7 @@ DEFINE_FAKE_VALUE_FUNC(int, fake_stepper_enable, const struct device *, bool);
 
 DEFINE_FAKE_VALUE_FUNC(int, fake_stepper_is_moving, const struct device *, bool *);
 
-DEFINE_FAKE_VALUE_FUNC(int, fake_stepper_move, const struct device *, int32_t);
+DEFINE_FAKE_VALUE_FUNC(int, fake_stepper_move_by, const struct device *, int32_t);
 
 DEFINE_FAKE_VALUE_FUNC(int, fake_stepper_set_max_velocity, const struct device *, uint32_t);
 
@@ -90,7 +90,7 @@ static void fake_stepper_reset_rule_before(const struct ztest_unit_test *test, v
 	ARG_UNUSED(fixture);
 
 	RESET_FAKE(fake_stepper_enable);
-	RESET_FAKE(fake_stepper_move);
+	RESET_FAKE(fake_stepper_move_by);
 	RESET_FAKE(fake_stepper_is_moving);
 	RESET_FAKE(fake_stepper_set_max_velocity);
 	RESET_FAKE(fake_stepper_set_micro_step_res);
@@ -126,7 +126,7 @@ static int fake_stepper_init(const struct device *dev)
 
 static DEVICE_API(stepper, fake_stepper_driver_api) = {
 	.enable = fake_stepper_enable,
-	.move = fake_stepper_move,
+	.move_by = fake_stepper_move_by,
 	.is_moving = fake_stepper_is_moving,
 	.set_max_velocity = fake_stepper_set_max_velocity,
 	.set_micro_step_res = fake_stepper_set_micro_step_res,

--- a/drivers/stepper/gpio_stepper_controller.c
+++ b/drivers/stepper/gpio_stepper_controller.c
@@ -177,7 +177,7 @@ static void stepper_work_step_handler(struct k_work *work)
 	}
 }
 
-static int gpio_stepper_move(const struct device *dev, int32_t micro_steps)
+static int gpio_stepper_move_by(const struct device *dev, int32_t micro_steps)
 {
 	struct gpio_stepper_data *data = dev->data;
 
@@ -353,7 +353,7 @@ static int gpio_stepper_init(const struct device *dev)
 
 static DEVICE_API(stepper, gpio_stepper_api) = {
 	.enable = gpio_stepper_enable,
-	.move = gpio_stepper_move,
+	.move_by = gpio_stepper_move_by,
 	.is_moving = gpio_stepper_is_moving,
 	.set_reference_position = gpio_stepper_set_reference_position,
 	.get_actual_position = gpio_stepper_get_actual_position,

--- a/drivers/stepper/gpio_stepper_controller.c
+++ b/drivers/stepper/gpio_stepper_controller.c
@@ -214,7 +214,7 @@ static int gpio_stepper_get_actual_position(const struct device *dev, int32_t *p
 	return 0;
 }
 
-static int gpio_stepper_set_target_position(const struct device *dev, int32_t position)
+static int gpio_stepper_move_to(const struct device *dev, int32_t micro_steps)
 {
 	struct gpio_stepper_data *data = dev->data;
 
@@ -224,7 +224,7 @@ static int gpio_stepper_set_target_position(const struct device *dev, int32_t po
 	}
 	K_SPINLOCK(&data->lock) {
 		data->run_mode = STEPPER_RUN_MODE_POSITION;
-		data->step_count = position - data->actual_position;
+		data->step_count = micro_steps - data->actual_position;
 		update_direction_from_step_count(dev);
 		(void)k_work_reschedule(&data->stepper_dwork, K_NO_WAIT);
 	}
@@ -357,7 +357,7 @@ static DEVICE_API(stepper, gpio_stepper_api) = {
 	.is_moving = gpio_stepper_is_moving,
 	.set_reference_position = gpio_stepper_set_reference_position,
 	.get_actual_position = gpio_stepper_get_actual_position,
-	.set_target_position = gpio_stepper_set_target_position,
+	.move_to = gpio_stepper_move_to,
 	.set_max_velocity = gpio_stepper_set_max_velocity,
 	.run = gpio_stepper_run,
 	.set_micro_step_res = gpio_stepper_set_micro_step_res,

--- a/drivers/stepper/stepper_shell.c
+++ b/drivers/stepper/stepper_shell.c
@@ -338,7 +338,7 @@ static int cmd_stepper_get_actual_position(const struct shell *sh, size_t argc, 
 	return err;
 }
 
-static int cmd_stepper_set_target_position(const struct shell *sh, size_t argc, char **argv)
+static int cmd_stepper_move_to(const struct shell *sh, size_t argc, char **argv)
 {
 	const struct device *dev;
 	int err = 0;
@@ -358,7 +358,7 @@ static int cmd_stepper_set_target_position(const struct shell *sh, size_t argc, 
 		shell_error(sh, "Failed to set callback: %d", err);
 	}
 
-	err = stepper_set_target_position(dev, position);
+	err = stepper_move_to(dev, position);
 	if (err) {
 		shell_error(sh, "Error: %d", err);
 	}
@@ -465,8 +465,8 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 		      cmd_stepper_set_reference_position, 3, 0),
 	SHELL_CMD_ARG(get_actual_position, &dsub_pos_stepper_motor_name, "<device>",
 		      cmd_stepper_get_actual_position, 2, 0),
-	SHELL_CMD_ARG(set_target_position, &dsub_pos_stepper_motor_name, "<device> <micro_steps>",
-		      cmd_stepper_set_target_position, 3, 0),
+	SHELL_CMD_ARG(move_to, &dsub_pos_stepper_motor_name, "<device> <micro_steps>",
+		      cmd_stepper_move_to, 3, 0),
 	SHELL_CMD_ARG(run, &dsub_pos_stepper_motor_name_dir, "<device> <direction> <velocity>",
 		      cmd_stepper_run, 4, 0),
 	SHELL_CMD_ARG(info, &dsub_pos_stepper_motor_name, "<device>", cmd_stepper_info, 2, 0),

--- a/drivers/stepper/stepper_shell.c
+++ b/drivers/stepper/stepper_shell.c
@@ -190,7 +190,7 @@ static int cmd_stepper_enable(const struct shell *sh, size_t argc, char **argv)
 	return err;
 }
 
-static int cmd_stepper_move(const struct shell *sh, size_t argc, char **argv)
+static int cmd_stepper_move_by(const struct shell *sh, size_t argc, char **argv)
 {
 	const struct device *dev;
 	int err = 0;
@@ -211,7 +211,7 @@ static int cmd_stepper_move(const struct shell *sh, size_t argc, char **argv)
 		shell_error(sh, "Failed to set callback: %d", err);
 	}
 
-	err = stepper_move(dev, micro_steps);
+	err = stepper_move_by(dev, micro_steps);
 	if (err) {
 		shell_error(sh, "Error: %d", err);
 	}
@@ -453,8 +453,8 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 	stepper_cmds,
 	SHELL_CMD_ARG(enable, &dsub_pos_stepper_motor_name, "<device> <on/off>", cmd_stepper_enable,
 		      3, 0),
-	SHELL_CMD_ARG(move, &dsub_pos_stepper_motor_name, "<device> <micro_steps>",
-		      cmd_stepper_move, 3, 0),
+	SHELL_CMD_ARG(move_by, &dsub_pos_stepper_motor_name, "<device> <micro_steps>",
+		      cmd_stepper_move_by, 3, 0),
 	SHELL_CMD_ARG(set_max_velocity, &dsub_pos_stepper_motor_name, "<device> <velocity>",
 		      cmd_stepper_set_max_velocity, 3, 0),
 	SHELL_CMD_ARG(set_micro_step_res, &dsub_pos_stepper_motor_name_microstep,

--- a/include/zephyr/drivers/stepper.h
+++ b/include/zephyr/drivers/stepper.h
@@ -150,11 +150,11 @@ typedef int (*stepper_set_reference_position_t)(const struct device *dev, const 
 typedef int (*stepper_get_actual_position_t)(const struct device *dev, int32_t *value);
 
 /**
- * @brief Set the absolute target position of the stepper
+ * @brief Move the stepper motor absolutely by a given number of micro_steps.
  *
- * @see stepper_set_target_position() for details.
+ * @see stepper_move_to() for details.
  */
-typedef int (*stepper_set_target_position_t)(const struct device *dev, const int32_t value);
+typedef int (*stepper_move_to_t)(const struct device *dev, const int32_t micro_steps);
 
 /**
  * @brief Is the target position fo the stepper reached
@@ -196,7 +196,7 @@ __subsystem struct stepper_driver_api {
 	stepper_get_micro_step_res_t get_micro_step_res;
 	stepper_set_reference_position_t set_reference_position;
 	stepper_get_actual_position_t get_actual_position;
-	stepper_set_target_position_t set_target_position;
+	stepper_move_to_t move_to;
 	stepper_is_moving_t is_moving;
 	stepper_run_t run;
 	stepper_set_event_callback_t set_event_callback;
@@ -368,23 +368,26 @@ static inline int z_impl_stepper_get_actual_position(const struct device *dev, i
 /**
  * @brief Set the absolute target position of the stepper
  *
+ * @details The motor will move to the given micro_steps position from the reference position.
+ * This function is non-blocking.
+ *
  * @param dev pointer to the stepper motor controller instance
- * @param value target position to set in micro_steps
+ * @param micro_steps target position to set in micro_steps
  *
  * @retval -EIO General input / output error
  * @retval -ENOSYS If not implemented by device driver
  * @retval 0 Success
  */
-__syscall int stepper_set_target_position(const struct device *dev, int32_t value);
+__syscall int stepper_move_to(const struct device *dev, int32_t micro_steps);
 
-static inline int z_impl_stepper_set_target_position(const struct device *dev, const int32_t value)
+static inline int z_impl_stepper_move_to(const struct device *dev, const int32_t micro_steps)
 {
 	const struct stepper_driver_api *api = (const struct stepper_driver_api *)dev->api;
 
-	if (api->set_target_position == NULL) {
+	if (api->move_to == NULL) {
 		return -ENOSYS;
 	}
-	return api->set_target_position(dev, value);
+	return api->move_to(dev, micro_steps);
 }
 
 /**

--- a/include/zephyr/drivers/stepper/stepper_fake.h
+++ b/include/zephyr/drivers/stepper/stepper_fake.h
@@ -16,7 +16,7 @@ extern "C" {
 
 DECLARE_FAKE_VALUE_FUNC(int, fake_stepper_enable, const struct device *, bool);
 
-DECLARE_FAKE_VALUE_FUNC(int, fake_stepper_move, const struct device *, int32_t);
+DECLARE_FAKE_VALUE_FUNC(int, fake_stepper_move_by, const struct device *, int32_t);
 
 DECLARE_FAKE_VALUE_FUNC(int, fake_stepper_set_max_velocity, const struct device *, uint32_t);
 

--- a/include/zephyr/drivers/stepper/stepper_fake.h
+++ b/include/zephyr/drivers/stepper/stepper_fake.h
@@ -30,7 +30,7 @@ DECLARE_FAKE_VALUE_FUNC(int, fake_stepper_set_reference_position, const struct d
 
 DECLARE_FAKE_VALUE_FUNC(int, fake_stepper_get_actual_position, const struct device *, int32_t *);
 
-DECLARE_FAKE_VALUE_FUNC(int, fake_stepper_set_target_position, const struct device *, int32_t);
+DECLARE_FAKE_VALUE_FUNC(int, fake_stepper_move_to, const struct device *, int32_t);
 
 DECLARE_FAKE_VALUE_FUNC(int, fake_stepper_is_moving, const struct device *, bool *);
 

--- a/tests/drivers/stepper/shell/src/main.c
+++ b/tests/drivers/stepper/shell/src/main.c
@@ -55,13 +55,13 @@ ZTEST(stepper_shell, test_stepper_enable)
 	zassert_equal(fake_stepper_enable_fake.arg1_val, false, "wrong enable value");
 }
 
-ZTEST(stepper_shell, test_stepper_move)
+ZTEST(stepper_shell, test_stepper_move_by)
 {
 	const struct shell *sh = shell_backend_dummy_get_ptr();
-	int err = shell_execute_cmd(sh, "stepper move " FAKE_STEPPER_NAME " 1000");
+	int err = shell_execute_cmd(sh, "stepper move_by " FAKE_STEPPER_NAME " 1000");
 
-	ASSERT_STEPPER_FUNC_CALLED(fake_stepper_move_fake, err);
-	zassert_equal(fake_stepper_move_fake.arg1_val, 1000, "wrong microsteps value");
+	ASSERT_STEPPER_FUNC_CALLED(fake_stepper_move_by_fake, err);
+	zassert_equal(fake_stepper_move_by_fake.arg1_val, 1000, "wrong microsteps value");
 }
 
 ZTEST(stepper_shell, test_stepper_set_max_velocity)

--- a/tests/drivers/stepper/shell/src/main.c
+++ b/tests/drivers/stepper/shell/src/main.c
@@ -117,13 +117,13 @@ ZTEST(stepper_shell, test_stepper_get_actual_position)
 	ASSERT_STEPPER_FUNC_CALLED(fake_stepper_get_actual_position_fake, err);
 }
 
-ZTEST(stepper_shell, test_stepper_set_target_position)
+ZTEST(stepper_shell, test_stepper_move_to)
 {
 	const struct shell *sh = shell_backend_dummy_get_ptr();
-	int err = shell_execute_cmd(sh, "stepper set_target_position " FAKE_STEPPER_NAME " 200");
+	int err = shell_execute_cmd(sh, "stepper move_to " FAKE_STEPPER_NAME " 200");
 
-	ASSERT_STEPPER_FUNC_CALLED(fake_stepper_set_target_position_fake, err);
-	zassert_equal(fake_stepper_set_target_position_fake.arg1_val, 200,
+	ASSERT_STEPPER_FUNC_CALLED(fake_stepper_move_to_fake, err);
+	zassert_equal(fake_stepper_move_to_fake.arg1_val, 200,
 		      "wrong target position value");
 }
 

--- a/tests/drivers/stepper/stepper_api/src/main.c
+++ b/tests/drivers/stepper/stepper_api/src/main.c
@@ -87,7 +87,7 @@ ZTEST_F(stepper, test_target_position)
 	/* Pass the function name as user data */
 	(void)stepper_set_event_callback(fixture->dev, fixture->callback, &fixture);
 
-	(void)stepper_set_target_position(fixture->dev, pos);
+	(void)stepper_move_to(fixture->dev, pos);
 
 	(void)k_poll(&stepper_event, 1, K_SECONDS(5));
 	unsigned int signaled;


### PR DESCRIPTION
rename stepper_move to stepper_move_by in following files:
- include/zephyr/drivers/stepper.h
- include/zephyr/drivers/stepper/stepper_fake.h
- doc/hardware/peripherals/stepper.rst
- doc/releases/migration-guide-4.1.rst
- drivers/stepper/adi_tmc/adi_tmc5041_stepper_controller.c
- drivers/stepper/fake_stepper_controller.c
- drivers/stepper/gpio_stepper_controller.c
- drivers/stepper/stepper_shell.c
- tests/drivers/stepper/shell/src/main.c

rename stepper_set_target_position to stepper_move_to in following files:
- doc/hardware/peripherals/stepper.rst
- doc/releases/migration-guide-4.1.rst
- drivers/stepper/adi_tmc/adi_tmc5041_stepper_controller.c
- drivers/stepper/fake_stepper_controller.c
- drivers/stepper/gpio_stepper_controller.c
- drivers/stepper/stepper_shell.c
- include/zephyr/drivers/stepper.h
- include/zephyr/drivers/stepper/stepper_fake.h
- tests/drivers/stepper/shell/src/main.c
- tests/drivers/stepper/stepper_api/src/main.c