### PR TITLE
net: ethernet: arp: Fix incorrect adding to the pending queue

### DIFF
--- a/subsys/net/l2/ethernet/arp.c
+++ b/subsys/net/l2/ethernet/arp.c
@@ -291,7 +291,8 @@ static inline struct net_pkt *arp_prepare(struct net_if *iface,
 	 */
 	if (entry) {
 		if (!net_pkt_ipv4_acd(pkt)) {
-			k_fifo_put(&entry->pending_queue, net_pkt_ref(pending));
+			net_pkt_ref(pending);
+			k_fifo_put(&entry->pending_queue, pending);
 		}
 
 		entry->iface = net_pkt_iface(pkt);


### PR DESCRIPTION
k_fifo_put is a macro that expands the call to net_pkt_ref(pending) multiple times when CONFIG_TRACING is enabled thus causing extra reference for the pending packet and a memory leak. Fix by moving the referencing call to a separate line.
Signed-off-by: Rait Rääk <raitraak@gmail.com>