### PR TITLE
drivers: bluetooth: Enable HAS_BT_CTLR for Silabs EFR32 driver

### DIFF
--- a/boards/silabs/dev_kits/sltb010a/Kconfig.defconfig
+++ b/boards/silabs/dev_kits/sltb010a/Kconfig.defconfig
@@ -26,9 +26,6 @@ config MAIN_STACK_SIZE
 	default 3072 if PM
 	default 2304
 
-config BT_SEND_ECC_EMULATION
-	default y
-
 endif # BT
 
 config REGULATOR

--- a/boards/silabs/dev_kits/xg24_dk2601b/Kconfig.defconfig
+++ b/boards/silabs/dev_kits/xg24_dk2601b/Kconfig.defconfig
@@ -31,9 +31,6 @@ config COMMON_LIBC_MALLOC_ARENA_SIZE
 config MAIN_STACK_SIZE
 	default 2304
 
-config BT_SEND_ECC_EMULATION
-	default y
-
 if SHELL
 
 config SHELL_STACK_SIZE

--- a/boards/silabs/dev_kits/xg27_dk2602a/Kconfig.defconfig
+++ b/boards/silabs/dev_kits/xg27_dk2602a/Kconfig.defconfig
@@ -26,9 +26,6 @@ config MAIN_STACK_SIZE
 	default 3072 if PM
 	default 2304
 
-config BT_SEND_ECC_EMULATION
-	default y
-
 endif # BT
 
 config REGULATOR

--- a/boards/silabs/radio_boards/slwrb4104a/Kconfig.defconfig
+++ b/boards/silabs/radio_boards/slwrb4104a/Kconfig.defconfig
@@ -37,9 +37,6 @@ config MAIN_STACK_SIZE
 	default 3072 if PM
 	default 2304
 
-config BT_SEND_ECC_EMULATION
-	default y
-
 endif # BT
 
 endif # BOARD_SLWRB4104A

--- a/boards/silabs/radio_boards/slwrb4161a/Kconfig.defconfig
+++ b/boards/silabs/radio_boards/slwrb4161a/Kconfig.defconfig
@@ -37,9 +37,6 @@ config MAIN_STACK_SIZE
 	default 3072 if PM
 	default 2304
 
-config BT_SEND_ECC_EMULATION
-	default y
-
 endif # BT
 
 endif # BOARD_SLWRB4161A

--- a/boards/silabs/radio_boards/slwrb4170a/Kconfig.defconfig
+++ b/boards/silabs/radio_boards/slwrb4170a/Kconfig.defconfig
@@ -37,9 +37,6 @@ config MAIN_STACK_SIZE
 	default 3072 if PM
 	default 2304
 
-config BT_SEND_ECC_EMULATION
-	default y
-
 endif # BT
 
 endif # BOARD_SLWRB4170A

--- a/boards/silabs/radio_boards/slwrb4180a/Kconfig.defconfig
+++ b/boards/silabs/radio_boards/slwrb4180a/Kconfig.defconfig
@@ -37,9 +37,6 @@ config MAIN_STACK_SIZE
 	default 3072 if PM
 	default 2304
 
-config BT_SEND_ECC_EMULATION
-	default y
-
 endif # BT
 
 endif # BOARD_SLWRB4180A

--- a/boards/silabs/radio_boards/slwrb4250b/Kconfig.defconfig
+++ b/boards/silabs/radio_boards/slwrb4250b/Kconfig.defconfig
@@ -37,9 +37,6 @@ config MAIN_STACK_SIZE
 	default 3072 if PM
 	default 2304
 
-config BT_SEND_ECC_EMULATION
-	default y
-
 endif # BT
 
 endif # BOARD_SLWRB4250B

--- a/boards/silabs/radio_boards/slwrb4255a/Kconfig.defconfig
+++ b/boards/silabs/radio_boards/slwrb4255a/Kconfig.defconfig
@@ -37,9 +37,6 @@ config MAIN_STACK_SIZE
 	default 3072 if PM
 	default 2304
 
-config BT_SEND_ECC_EMULATION
-	default y
-
 endif # BT
 
 endif # BOARD_SLWRB4255A

--- a/boards/silabs/radio_boards/xg24_rb4187c/Kconfig.defconfig
+++ b/boards/silabs/radio_boards/xg24_rb4187c/Kconfig.defconfig
@@ -37,9 +37,6 @@ config MAIN_STACK_SIZE
 	default 3072 if PM
 	default 2304
 
-config BT_SEND_ECC_EMULATION
-	default y
-
 endif # BT
 
 endif # BOARD_XG24_RB4187C

--- a/drivers/bluetooth/hci/Kconfig
+++ b/drivers/bluetooth/hci/Kconfig
@@ -126,6 +126,7 @@ config BT_SILABS_EFR32
 	select MBEDTLS
 	select MBEDTLS_PSA_CRYPTO_C
 	select MBEDTLS_ENTROPY_C
+	select HAS_BT_CTLR
 	help
 	  Use Silicon Labs binary Bluetooth library to connect to the
 	  controller.


### PR DESCRIPTION
The controller behind the EFR32 driver is a local link layer implementation, so it makes sense to select HAS_BT_CTLR.

Fixes #82569