### PR TITLE
drivers: sensor: adltc2990 reduce cyclomatic complexity

### DIFF
--- a/drivers/sensor/adi/adltc2990/adltc2990.c
+++ b/drivers/sensor/adi/adltc2990/adltc2990.c
@@ -97,11 +97,9 @@ static int adltc2990_is_busy(const struct device *dev, bool *is_busy)
 {
 	const struct adltc2990_config *cfg = dev->config;
 	uint8_t status_reg = 0;
-	int ret;
 
-	ret = i2c_reg_read_byte_dt(&cfg->bus, ADLTC2990_REG_STATUS, &status_reg);
-	if (ret) {
-		return ret;
+	if (i2c_reg_read_byte_dt(&cfg->bus, ADLTC2990_REG_STATUS, &status_reg)) {
+		return -EIO;
 	}
 
 	*is_busy = status_reg & BIT(0);
@@ -186,17 +184,15 @@ static int adltc2990_fetch_property_value(const struct device *dev,
 		LOG_ERR("Trying to access illegal register");
 		return -EINVAL;
 	}
-	int ret;
 
-	ret = i2c_reg_read_byte_dt(&cfg->bus, msb_address, &msb_value);
-	if (ret) {
-		return ret;
+	if (i2c_reg_read_byte_dt(&cfg->bus, msb_address, &msb_value)) {
+		return -EIO;
 	}
 
-	ret = i2c_reg_read_byte_dt(&cfg->bus, lsb_address, &lsb_value);
-	if (ret) {
-		return ret;
+	if (i2c_reg_read_byte_dt(&cfg->bus, lsb_address, &lsb_value)) {
+		return -EIO;
 	}
+
 	uint16_t conversion_factor;
 	uint8_t negative_bit_index = 14U, sensor_val_divisor = 100U;
 
@@ -238,10 +234,9 @@ static int adltc2990_init(const struct device *dev)
 					 cfg->measurement_mode[1] << 3 | cfg->measurement_mode[0];
 
 	LOG_DBG("Setting Control Register to: 0x%x", ctrl_reg_setting);
-	err = i2c_reg_write_byte_dt(&cfg->bus, ADLTC2990_REG_CONTROL, ctrl_reg_setting);
-	if (err < 0) {
-		LOG_ERR("configuring for single bus failed: %d", err);
-		return err;
+	if (i2c_reg_write_byte_dt(&cfg->bus, ADLTC2990_REG_CONTROL, ctrl_reg_setting)) {
+		LOG_ERR("configuring for single bus failed.");
+		return -EIO;
 	}
 
 	err = adltc2990_trigger_measurement(dev);

--- a/drivers/sensor/adi/adltc2990/adltc2990.c
+++ b/drivers/sensor/adi/adltc2990/adltc2990.c
@@ -1,9 +1,12 @@
 /*
  * SPDX-FileCopyrightText: Copyright (c) 2023 Carl Zeiss Meditec AG
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Jilay Sandeep Pandya
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #define DT_DRV_COMPAT adi_adltc2990
+
+#include <stdbool.h>
 
 #include <zephyr/sys/util.h>
 #include <zephyr/drivers/i2c.h>
@@ -30,25 +33,24 @@ static enum adltc2990_monitoring_type adltc2990_get_v1_v2_measurement_modes(uint
 
 	switch (mode_2_0) {
 	case ADLTC2990_MODE_V1_V2_TR2:
-	case ADLTC2990_MODE_V1_V2_V3_V4: {
+	case ADLTC2990_MODE_V1_V2_V3_V4:
 		type = VOLTAGE_SINGLEENDED;
 		break;
-	}
+
 	case ADLTC2990_MODE_V1_MINUS_V2_TR2:
 	case ADLTC2990_MODE_V1_MINUS_V2_V3_V4:
-	case ADLTC2990_MODE_V1_MINUS_V2_V3_MINUS_V4: {
+	case ADLTC2990_MODE_V1_MINUS_V2_V3_MINUS_V4:
 		type = VOLTAGE_DIFFERENTIAL;
 		break;
-	}
+
 	case ADLTC2990_MODE_TR1_V3_V4:
-	case ADLTC2990_MODE_TR1_V3_MINUS_V4: {
+	case ADLTC2990_MODE_TR1_V3_MINUS_V4:
 	case ADLTC2990_MODE_TR1_TR2:
 		type = TEMPERATURE;
 		break;
-	}
-	default: {
+
+	default:
 		break;
-	}
 	}
 	return type;
 }
@@ -70,25 +72,23 @@ static enum adltc2990_monitoring_type adltc2990_get_v3_v4_measurement_modes(uint
 	switch (mode_2_0) {
 	case ADLTC2990_MODE_V1_V2_TR2:
 	case ADLTC2990_MODE_V1_MINUS_V2_TR2:
-	case ADLTC2990_MODE_TR1_TR2: {
+	case ADLTC2990_MODE_TR1_TR2:
 		type = TEMPERATURE;
 		break;
-	}
 
 	case ADLTC2990_MODE_V1_MINUS_V2_V3_V4:
 	case ADLTC2990_MODE_TR1_V3_V4:
-	case ADLTC2990_MODE_V1_V2_V3_V4: {
+	case ADLTC2990_MODE_V1_V2_V3_V4:
 		type = VOLTAGE_SINGLEENDED;
 		break;
-	}
+
 	case ADLTC2990_MODE_TR1_V3_MINUS_V4:
-	case ADLTC2990_MODE_V1_MINUS_V2_V3_MINUS_V4: {
+	case ADLTC2990_MODE_V1_MINUS_V2_V3_MINUS_V4:
 		type = VOLTAGE_DIFFERENTIAL;
 		break;
-	}
-	default: {
+
+	default:
 		break;
-	}
 	}
 	return type;
 }
@@ -152,40 +152,39 @@ static int adltc2990_fetch_property_value(const struct device *dev,
 	uint8_t msb_address, lsb_address;
 
 	switch (pin) {
-	case V1: {
+	case V1:
 		msb_address = ADLTC2990_REG_V1_MSB;
 		lsb_address = ADLTC2990_REG_V1_LSB;
 		break;
-	}
-	case V2: {
+
+	case V2:
 		msb_address = ADLTC2990_REG_V2_MSB;
 		lsb_address = ADLTC2990_REG_V2_LSB;
 		break;
-	}
-	case V3: {
+
+	case V3:
 		msb_address = ADLTC2990_REG_V3_MSB;
 		lsb_address = ADLTC2990_REG_V3_LSB;
 		break;
-	}
-	case V4: {
+
+	case V4:
 		msb_address = ADLTC2990_REG_V4_MSB;
 		lsb_address = ADLTC2990_REG_V4_LSB;
 		break;
-	}
-	case INTERNAL_TEMPERATURE: {
+
+	case INTERNAL_TEMPERATURE:
 		msb_address = ADLTC2990_REG_INTERNAL_TEMP_MSB;
 		lsb_address = ADLTC2990_REG_INTERNAL_TEMP_LSB;
 		break;
-	}
-	case SUPPLY_VOLTAGE: {
+
+	case SUPPLY_VOLTAGE:
 		msb_address = ADLTC2990_REG_VCC_MSB;
 		lsb_address = ADLTC2990_REG_VCC_LSB;
 		break;
-	}
-	default: {
+
+	default:
 		LOG_ERR("Trying to access illegal register");
 		return -EINVAL;
-	}
 	}
 	int ret;
 
@@ -268,7 +267,7 @@ static int adltc2990_sample_fetch(const struct device *dev, enum sensor_channel 
 	int32_t value;
 
 	switch (chan) {
-	case SENSOR_CHAN_DIE_TEMP: {
+	case SENSOR_CHAN_DIE_TEMP:
 		ret = adltc2990_fetch_property_value(dev, TEMPERATURE, INTERNAL_TEMPERATURE,
 						     &value);
 		if (ret) {
@@ -276,8 +275,8 @@ static int adltc2990_sample_fetch(const struct device *dev, enum sensor_channel 
 		}
 		data->internal_temperature = value;
 		break;
-	}
-	case SENSOR_CHAN_CURRENT: {
+
+	case SENSOR_CHAN_CURRENT:
 		if (!(mode_v1_v2 == VOLTAGE_DIFFERENTIAL || mode_v3_v4 == VOLTAGE_DIFFERENTIAL)) {
 			LOG_ERR("Sensor is not configured to measure Current");
 			return -EINVAL;
@@ -300,8 +299,8 @@ static int adltc2990_sample_fetch(const struct device *dev, enum sensor_channel 
 				 (float)cfg->pins_v3_v4.pins_current_resistor);
 		}
 		break;
-	}
-	case SENSOR_CHAN_VOLTAGE: {
+
+	case SENSOR_CHAN_VOLTAGE:
 		ret = adltc2990_fetch_property_value(dev, VOLTAGE_SINGLEENDED, SUPPLY_VOLTAGE,
 						     &value);
 		if (ret) {
@@ -370,8 +369,8 @@ static int adltc2990_sample_fetch(const struct device *dev, enum sensor_channel 
 			data->pins_v3_v4_values[1] = value * voltage_divider_ratio;
 		}
 		break;
-	}
-	case SENSOR_CHAN_AMBIENT_TEMP: {
+
+	case SENSOR_CHAN_AMBIENT_TEMP:
 		if (!(mode_v1_v2 == TEMPERATURE || mode_v3_v4 == TEMPERATURE)) {
 			LOG_ERR("Sensor is not configured to measure Ambient Temperature");
 			return -EINVAL;
@@ -391,9 +390,9 @@ static int adltc2990_sample_fetch(const struct device *dev, enum sensor_channel 
 			data->pins_v3_v4_values[0] = value;
 		}
 		break;
-	}
-	case SENSOR_CHAN_ALL: {
-		bool is_busy;
+
+	case SENSOR_CHAN_ALL:
+		bool is_busy = false;
 
 		ret = adltc2990_is_busy(dev, &is_busy);
 		if (ret) {
@@ -406,11 +405,10 @@ static int adltc2990_sample_fetch(const struct device *dev, enum sensor_channel 
 		}
 		adltc2990_trigger_measurement(dev);
 		break;
-	}
-	default: {
+
+	default:
 		LOG_ERR("does not measure channel: %d", chan);
 		return -ENOTSUP;
-	}
 	}
 
 	return 0;
@@ -433,13 +431,13 @@ static int adltc2990_channel_get(const struct device *dev, enum sensor_channel c
 	uint8_t offset_index = 0, num_values_v1_v2 = 0, num_values_v3_v4 = 0;
 
 	switch (chan) {
-	case SENSOR_CHAN_DIE_TEMP: {
+	case SENSOR_CHAN_DIE_TEMP:
 		val->val1 = (data->internal_temperature) / 1000000;
 		val->val2 = (data->internal_temperature) % 1000000;
 		LOG_DBG("Internal Temperature Value is:%d.%d", val->val1, val->val2);
 		break;
-	}
-	case SENSOR_CHAN_VOLTAGE: {
+
+	case SENSOR_CHAN_VOLTAGE:
 		if (mode_v1_v2 == VOLTAGE_SINGLEENDED) {
 			LOG_DBG("Getting V1,V2");
 			num_values_v1_v2 = ADLTC2990_VOLTAGE_SINGLE_ENDED_VALUES;
@@ -458,8 +456,8 @@ static int adltc2990_channel_get(const struct device *dev, enum sensor_channel c
 		val[num_values_v1_v2 + num_values_v3_v4].val1 = data->supply_voltage / 1000000;
 		val[num_values_v1_v2 + num_values_v3_v4].val2 = data->supply_voltage % 1000000;
 		break;
-	}
-	case SENSOR_CHAN_CURRENT: {
+
+	case SENSOR_CHAN_CURRENT:
 		if (!(mode_v1_v2 == VOLTAGE_DIFFERENTIAL || mode_v3_v4 == VOLTAGE_DIFFERENTIAL)) {
 			LOG_ERR("Sensor is not configured to measure Current");
 			return -EINVAL;
@@ -476,8 +474,8 @@ static int adltc2990_channel_get(const struct device *dev, enum sensor_channel c
 			num_values_v3_v4 = ADLTC2990_CURRENT_VALUES;
 		}
 		break;
-	}
-	case SENSOR_CHAN_AMBIENT_TEMP: {
+
+	case SENSOR_CHAN_AMBIENT_TEMP:
 		if (!(mode_v1_v2 == TEMPERATURE || mode_v3_v4 == TEMPERATURE)) {
 			LOG_ERR("Sensor is not configured to measure Ambient Temperature");
 			return -EINVAL;
@@ -494,10 +492,10 @@ static int adltc2990_channel_get(const struct device *dev, enum sensor_channel c
 			num_values_v3_v4 = ADLTC2990_TEMP_VALUES;
 		}
 		break;
-	}
-	default: {
+
+	default:
 		return -ENOTSUP;
-	}
+
 	}
 
 	adltc2990_get_v1_v2_val(dev, val, num_values_v1_v2, &offset_index);

--- a/drivers/sensor/adi/adltc2990/adltc2990_emul.c
+++ b/drivers/sensor/adi/adltc2990/adltc2990_emul.c
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: Copyright (c) 2023 Carl Zeiss Meditec AG
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Jilay Sandeep Pandya
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -13,7 +14,7 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/util.h>
 
-#include "adltc2990.h"
+#include "adltc2990_internal.h"
 #include "adltc2990_reg.h"
 #include "adltc2990_emul.h"
 

--- a/drivers/sensor/adi/adltc2990/adltc2990_internal.h
+++ b/drivers/sensor/adi/adltc2990/adltc2990_internal.h
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: Copyright (c) 2023 Carl Zeiss Meditec AG
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Jilay Sandeep Pandya
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -45,6 +46,7 @@ struct pins_configuration {
 };
 
 struct adltc2990_data {
+	uint8_t acq_format;
 	int32_t internal_temperature;
 	int32_t supply_voltage;
 	int32_t pins_v1_v2_values[2];
@@ -54,7 +56,6 @@ struct adltc2990_data {
 struct adltc2990_config {
 	struct i2c_dt_spec bus;
 	uint8_t temp_format;
-	uint8_t acq_format;
 	uint8_t measurement_mode[2];
 	struct pins_configuration pins_v1_v2;
 	struct pins_configuration pins_v3_v4;

--- a/include/zephyr/drivers/sensor/adltc2990.h
+++ b/include/zephyr/drivers/sensor/adltc2990.h
@@ -1,0 +1,41 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Jilay Sandeep Pandya
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_SENSOR_ADLTC2990_H_
+#define ZEPHYR_INCLUDE_DRIVERS_SENSOR_ADLTC2990_H_
+
+#include <stdbool.h>
+
+#include <zephyr/device.h>
+
+enum adltc2990_acquisition_format {
+	ADLTC2990_REPEATED_ACQUISITION,
+	ADLTC2990_SINGLE_SHOT_ACQUISITION,
+};
+
+/**
+ * @brief check if adtlc2990 is busy doing conversion
+ *
+ * @param dev Pointer to the adltc2990 device
+ * @param is_busy Pointer to the variable to store the busy status
+ *
+ * @retval 0 if successful
+ * @retval -EIO General input / output error.
+ */
+int adltc2990_is_busy(const struct device *dev, bool *is_busy);
+
+/**
+ * @brief Trigger the adltc2990 to start a measurement
+ *
+ * @param dev Pointer to the adltc2990 device
+ * @param format The acquisition format to be used
+ *
+ * @retval 0 if successful
+ * @retval -EIO General input / output error.
+ */
+int adltc2990_trigger_measurement(const struct device *dev,
+				  enum adltc2990_acquisition_format format);
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_SENSOR_ADLTC2990_H_ */

--- a/tests/drivers/sensor/adltc2990/src/main.c
+++ b/tests/drivers/sensor/adltc2990/src/main.c
@@ -7,11 +7,12 @@
 #include <zephyr/drivers/emul.h>
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/sensor.h>
+#include <zephyr/drivers/sensor/adltc2990.h>
 #include <zephyr/ztest.h>
 
-#include "adltc2990.h"
 #include "adltc2990_emul.h"
 #include "adltc2990_reg.h"
+#include "adltc2990_internal.h"
 
 /* Colllection of common assertion macros */
 #define CHECK_SINGLE_ENDED_VOLTAGE(sensor_val, index, pin_voltage, r1, r2)                         \
@@ -385,12 +386,16 @@ ZTEST_F(adltc2990_7_3, test_available_channels)
 ZTEST_F(adltc2990_7_3, test_is_device_busy)
 {
 	uint8_t is_busy = BIT(0);
+	bool result;
 
 	adltc2990_emul_set_reg(fixture->target, ADLTC2990_REG_STATUS, &is_busy);
-	zassert_equal(-EBUSY, sensor_sample_fetch_chan(fixture->dev, SENSOR_CHAN_ALL));
+	adltc2990_is_busy(fixture->dev, &result);
+	zassert_equal(1, result, "expected 1, got %d", result);
+
 	is_busy = 0;
 	adltc2990_emul_set_reg(fixture->target, ADLTC2990_REG_STATUS, &is_busy);
-	zassert_equal(0, sensor_sample_fetch_chan(fixture->dev, SENSOR_CHAN_ALL));
+	adltc2990_is_busy(fixture->dev, &result);
+	zassert_equal(0, result, "expected 0, got %d", result);
 }
 
 ZTEST_F(adltc2990_7_3, test_die_temperature)


### PR DESCRIPTION
Have reworked the driver in order to reduce the cyclomatic complexity. 

This driver has more than [80% coverage](https://app.codecov.io/gh/zephyrproject-rtos/zephyr/blob/main/drivers%2Fsensor%2Fadi%2Fadltc2990%2Fadltc2990.c) which made refactoring quite easy.