### PR TITLE
twister: fix shell prompt detection with VT100 colors disabled

### DIFF
--- a/samples/subsys/testsuite/pytest/shell/testcase.yaml
+++ b/samples/subsys/testsuite/pytest/shell/testcase.yaml
@@ -12,3 +12,17 @@ tests:
       - test_framework
       - pytest
       - shell
+  sample.pytest.shell.vt100_colors_off:
+    filter: CONFIG_SERIAL and dt_chosen_enabled("zephyr,shell-uart")
+    min_ram: 40
+    harness: pytest
+    extra_configs:
+      - arch:posix:CONFIG_NATIVE_UART_0_ON_STDINOUT=y
+      - CONFIG_SHELL_VT100_COLORS=n
+    integration_platforms:
+      - native_sim
+      - qemu_cortex_m3
+    tags:
+      - test_framework
+      - pytest
+      - shell

--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/device/device_adapter.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/device/device_adapter.py
@@ -240,7 +240,7 @@ class DeviceAdapter(abc.ABC):
         with open(self.handler_log_path, 'a+') as log_file:
             while self.is_device_running():
                 if self.is_device_connected():
-                    output = self._read_device_output().decode(errors='replace').strip()
+                    output = self._read_device_output().decode(errors='replace').rstrip("\r\n")
                     if output:
                         self._device_read_queue.put(output)
                         log_file.write(f'{output}\n')


### PR DESCRIPTION
## Description:
The pytest harness fails to detect the shell prompt when `CONFIG_SHELL_VT100_COLORS` is disabled. The issue occurs because [_handle_device_output in device_adapter.py](https://github.com/zephyrproject-rtos/zephyr/blob/e873d503a908ab5a313032bf59c7edfe9096a002/scripts/pylib/pytest-twister-harness/src/twister_harness/device/device_adapter.py#L241) strips all whitespace from device output, including the trailing space in the default shell prompt "uart:~$ ".

The bug is reproducible using the shell pytest sample:

```shell
west twister \
    -p qemu_cortex_m3 \
    -T zephyrbase/samples/subsys \
    -s sample.pytest.shell \
    --extra-args "CONFIG_SHELL_VT100_COLORS=n"
```

## Current behavior:

The [_handle_device_output in device_adapter.py](https://github.com/zephyrproject-rtos/zephyr/blob/e873d503a908ab5a313032bf59c7edfe9096a002/scripts/pylib/pytest-twister-harness/src/twister_harness/device/device_adapter.py#L241) method in device_adapter.py uses Python's .strip() without arguments, which removes all leading and trailing whitespace characters. The behavior differs based on VT100 color configuration:

With `CONFIG_SHELL_VT100_COLORS=y` (default):
- Raw output received: `\[1;32muart:~$ \[m\r\n`
- The ANSI escape sequences `\[1;32m` and `\[m` prevent `.strip()` from removing the space which is a part of the message
- Prompt is detected successfully

With `CONFIG_SHELL_VT100_COLORS=n`:
- Raw output received: `uart:~$ \r\n`
- `.strip()` removes all whitespace including the trailing space
- Resulting string `"uart:~$"` no longer matches the expected prompt pattern (which expects a trailing whitespace)
- Test times out waiting for input prompt

## Expected behavior:

Shell prompt should be detected regardless of VT100 color configuration. Only line ending characters should be stripped. Whitespace in prompt should be preserved

## Proposed Solution:
Replace `.strip()` with `.strip("\r\n")` to only remove line endings while preserving whitespace needed for prompt matching. That keeps overall method untouched.

## Potential Impact:

- Existing tests that rely on stripped whitespace in the device output will need to implement their own stripping if required
