### PR TITLE
soc: nxp: imxrt: fix PDRV field setting for drive strength

### DIFF
--- a/soc/nxp/imxrt/imxrt118x/pinctrl_soc.h
+++ b/soc/nxp/imxrt/imxrt118x/pinctrl_soc.h
@@ -56,7 +56,7 @@ extern "C" {
 	IF_ENABLED(DT_PROP(node_id, bias_pull_up),						\
 		(MCUX_IMX_PULL_PULLUP << MCUX_IMX_PULL_SHIFT) |)				\
 	(MCUX_IMX_NOPULL(node_id) << MCUX_IMX_PULL_SHIFT) |					\
-	(DT_ENUM_IDX_OR(node_id, drive_strength, 0) << MCUX_IMX_PDRV_SHIFT) |			\
+	((!DT_ENUM_IDX_OR(node_id, drive_strength, 0)) << MCUX_IMX_PDRV_SHIFT) |		\
 	(DT_PROP(node_id, drive_open_drain) << MCUX_IMX_ODE_SHIFT) |				\
 	(DT_PROP(node_id, input_enable) << MCUX_IMX_INPUT_ENABLE_SHIFT)
 

--- a/soc/nxp/imxrt/imxrt11xx/pinctrl_soc.h
+++ b/soc/nxp/imxrt/imxrt11xx/pinctrl_soc.h
@@ -58,7 +58,7 @@ extern "C" {
 	IF_ENABLED(DT_PROP(node_id, bias_pull_up),						\
 		(MCUX_IMX_PULL_PULLUP << MCUX_IMX_PULL_SHIFT) |)				\
 	(MCUX_IMX_NOPULL(node_id) << MCUX_IMX_PULL_SHIFT) |					\
-	(DT_ENUM_IDX_OR(node_id, drive_strength, 0) << MCUX_IMX_PDRV_SHIFT) |			\
+	((!DT_ENUM_IDX_OR(node_id, drive_strength, 0)) << MCUX_IMX_PDRV_SHIFT) |		\
 	(DT_PROP(node_id, drive_open_drain) << MCUX_IMX_ODE_SHIFT) |				\
 	(DT_PROP(node_id, input_enable) << MCUX_IMX_INPUT_ENABLE_SHIFT)
 


### PR DESCRIPTION
In the IOMUXC controller, the PDRV field uses 0b0 to set the pin drive to high, and 0b1 to set the pin to normal drive. Fix the pinctrl_soc.h definitions for the iMXRT11xx parts to use the correct setting for this register, based on the documentation for the pin control binding

Note that for PDRV type pins, this commit effectively switches their drive strength setting.