### PR TITLE
Revert "west.yml: Update hal_nxp to pull in PDM and SDMA HAL drivers"

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -199,7 +199,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: d291bdcc4a59bace5ae7453e777e06080ccda8ce
+      revision: c42d70dba969de09c0e43d3b26a3ffcb015f6f33
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
This reverts commit 82fdeecf571f4102d4fbe041f5a91999ea6f10d1.

Causing breakage with Wifi samples in main.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
