### PR TITLE
pm: fix warning for missing initializer

### DIFF
--- a/subsys/pm/pm.c
+++ b/subsys/pm/pm.c
@@ -121,7 +121,7 @@ void pm_system_resume(void)
 #ifdef CONFIG_SYS_CLOCK_EXISTS
 		sys_clock_idle_exit();
 #endif /* CONFIG_SYS_CLOCK_EXISTS */
-		z_cpus_pm_state[id] = (struct pm_state_info){PM_STATE_ACTIVE,
+		z_cpus_pm_state[id] = (struct pm_state_info){PM_STATE_ACTIVE, 0, false,
 			0, 0};
 	}
 }


### PR DESCRIPTION
A warning is giving for missing initializer for field `exit_latency_us` of `struct pm_state_info`. This adds the additional init fields.

The warning was as follows:
```
zephyr/subsys/pm/pm.c: In function 'pm_system_resume':
zephyr/subsys/pm/pm.c:102:25: warning: missing initializer for field 'exit_latency_us' of 'struct pm_state_info' [-Wmissing-field-initializers]
  102 |                         0, 0};
      |                         ^
In file included from zephyr/include/zephyr/device.h:15,
                 from zephyr/subsys/pm/pm.c:7:
zephyr/include/zephyr/pm/state.h:166:18: note: 'exit_latency_us' declared here
  166 |         uint32_t exit_latency_us;
      |                  ^~~~~~~~~~~~~~~
```