### PR TITLE
boards: nxp: imx93_evk: add code property for gpio-keys

### DIFF
--- a/boards/nxp/imx93_evk/dts/imx93_evk_mimx9352_exp_btn.overlay
+++ b/boards/nxp/imx93_evk/dts/imx93_evk_mimx9352_exp_btn.overlay
@@ -23,11 +23,13 @@
 		btn_1: btn_1{
 			label = "BTN1";
 			gpios = <&gpio_exp1 5 GPIO_ACTIVE_LOW>;
+			zephyr,code = <INPUT_KEY_0>;
 		};
 
 		btn_2: btn_2{
 			label = "BTN2";
 			gpios = <&gpio_exp1 6 GPIO_ACTIVE_LOW>;
+			zephyr,code = <INPUT_KEY_1>;
 		};
 	};
 };

--- a/boards/nxp/imx93_evk/imx93_evk_mimx9352_a55.dts
+++ b/boards/nxp/imx93_evk/imx93_evk_mimx9352_a55.dts
@@ -8,6 +8,7 @@
 
 #include <nxp/nxp_mimx93_a55.dtsi>
 #include "imx93_evk-pinctrl.dtsi"
+#include <zephyr/dt-bindings/input/input-event-codes.h>
 
 / {
 	model = "NXP i.MX93 A55";
@@ -59,11 +60,13 @@
 		btn_1: btn_1{
 			label = "BTN1";
 			gpios = <&gpio2 23 GPIO_ACTIVE_LOW>;
+			zephyr,code = <INPUT_KEY_0>;
 		};
 
 		btn_2: btn_2{
 			label = "BTN2";
 			gpios = <&gpio2 24 GPIO_ACTIVE_LOW>;
+			zephyr,code = <INPUT_KEY_1>;
 		};
 	};
 

--- a/boards/nxp/imx93_evk/imx93_evk_mimx9352_m33.dts
+++ b/boards/nxp/imx93_evk/imx93_evk_mimx9352_m33.dts
@@ -8,6 +8,7 @@
 
 #include <nxp/nxp_imx93_m33.dtsi>
 #include "imx93_evk-pinctrl.dtsi"
+#include <zephyr/dt-bindings/input/input-event-codes.h>
 
 / {
 	model = "NXP i.MX93 EVK board";
@@ -50,11 +51,13 @@
 		btn_1: btn_1{
 			label = "BTN1";
 			gpios = <&gpio2 23 GPIO_ACTIVE_LOW>;
+			zephyr,code = <INPUT_KEY_0>;
 		};
 
 		btn_2: btn_2{
 			label = "BTN2";
 			gpios = <&gpio2 24 GPIO_ACTIVE_LOW>;
+			zephyr,code = <INPUT_KEY_1>;
 		};
 	};
 };


### PR DESCRIPTION
drivers/input/input_gpio_keys.c requires property "zephyr,code" must be provides for gpio-keys, so add code property for imx93_evk A55 and M33 boards.

This PR is to fix twister build error reported in https://github.com/zephyrproject-rtos/zephyr/pull/79993, the error log is as follows:

```
[92/152] Building C object zephyr/drivers/input/CMakeFiles/drivers__input.dir/input_gpio_keys.c.obj
FAILED: zephyr/drivers/input/CMakeFiles/drivers__input.dir/input_gpio_keys.c.obj 
ccache /opt/toolchains/zephyr-sdk-0.17.0/aarch64-zephyr-elf/bin/aarch64-zephyr-elf-gcc -DCPU_MIMX9352DVVXM_ca55 -DKERNEL -DK_HEAP_MEM_POOL_SIZE=0 -DPICOLIBC_DOUBLE_PRINTF_SCANF -DTC_RUNID=e2a10ce11bda8fae08d995eaf7dd9bfd -D__LINUX_ERRNO_EXTENSIONS__ -D__ZEPHYR_SUPERVISOR__ -D__ZEPHYR__=1 -I/__w/zephyr/zephyr/twister-out/imx93_evk_mimx9352_a55/tests/subsys/input/api/input.api.synchronous/zephyr/include/generated/zephyr -I/__w/zephyr/zephyr/include -I/__w/zephyr/zephyr/twister-out/imx93_evk_mimx9352_a55/tests/subsys/input/api/input.api.synchronous/zephyr/include/generated -I/__w/zephyr/zephyr/soc/nxp/imx -I/__w/zephyr/zephyr/soc/nxp/imx/imx9/imx93/. -I/__w/zephyr/zephyr/soc/nxp/imx/imx9/imx93/a55 -I/__w/zephyr/zephyr/soc/nxp/imx/. -I/__w/zephyr/zephyr/soc/nxp/imx/imx9 -I/__w/zephyr/zephyr/soc/nxp/imx/imx9/include -I/__w/zephyr/zephyr/subsys/testsuite/include -I/__w/zephyr/zephyr/subsys/testsuite/coverage -I/__w/zephyr/zephyr/subsys/testsuite/ztest/include -I/__w/zephyr/modules/hal/nxp/mcux/mcux-sdk/devices/MIMX9352 -I/__w/zephyr/modules/hal/nxp/mcux/mcux-sdk/devices/MIMX9352/drivers -I/__w/zephyr/modules/hal/nxp/mcux/mcux-sdk/CMSIS/Core_AArch64/Include -I/__w/zephyr/modules/hal/nxp/mcux/mcux-sdk/drivers/common -I/__w/zephyr/modules/hal/nxp/mcux/mcux-sdk/drivers/lpi2c -I/__w/zephyr/modules/hal/nxp/mcux/mcux-sdk/drivers/lpuart -I/__w/zephyr/modules/hal/nxp/mcux/mcux-sdk/drivers/rgpio -I/__w/zephyr/modules/hal/nxp/mcux/mcux-sdk/drivers/cache/armv8-a -I/__w/zephyr/zephyr/modules/hal_nxp/. -isystem /__w/zephyr/zephyr/lib/libc/common/include -Wshadow -fno-strict-aliasing -Werror -Os -imacros /__w/zephyr/zephyr/twister-out/imx93_evk_mimx9352_a55/tests/subsys/input/api/input.api.synchronous/zephyr/include/generated/zephyr/autoconf.h -fno-common -g -gdwarf-4 -fdiagnostics-color=always -mcpu=cortex-a55 -mabi=lp64 --sysroot=/opt/toolchains/zephyr-sdk-0.17.0/aarch64-zephyr-elf/aarch64-zephyr-elf -imacros /__w/zephyr/zephyr/include/zephyr/toolchain/zephyr_stdint.h -Wall -Wformat -Wformat-security -Wno-format-zero-length -Wdouble-promotion -Wno-pointer-sign -Wpointer-arith -Wexpansion-to-defined -Wno-unused-but-set-variable -Werror=implicit-int -fno-pic -fno-pie -fno-asynchronous-unwind-tables -ftls-model=local-exec -fno-reorder-functions --param=min-pagesize=0 -fno-defer-pop -fmacro-prefix-map=/__w/zephyr/zephyr/tests/subsys/input/api=CMAKE_SOURCE_DIR -fmacro-prefix-map=/__w/zephyr/zephyr=ZEPHYR_BASE -fmacro-prefix-map=/__w/zephyr=WEST_TOPDIR -ffunction-sections -fdata-sections -moverride=tune=no_ldp_stp_qregs -specs=picolibc.specs -std=c99 -MD -MT zephyr/drivers/input/CMakeFiles/drivers__input.dir/input_gpio_keys.c.obj -MF zephyr/drivers/input/CMakeFiles/drivers__input.dir/input_gpio_keys.c.obj.d -o zephyr/drivers/input/CMakeFiles/drivers__input.dir/input_gpio_keys.c.obj -c /__w/zephyr/zephyr/drivers/input/input_gpio_keys.c
In file included from /__w/zephyr/zephyr/include/zephyr/sys/util_macro.h:34,
                 from /__w/zephyr/zephyr/include/zephyr/irq_multilevel.h:16,
                 from /__w/zephyr/zephyr/include/zephyr/devicetree.h:20,
                 from /__w/zephyr/zephyr/include/zephyr/device.h:12,
                 from /__w/zephyr/zephyr/drivers/input/input_gpio_keys.c:9:
/__w/zephyr/zephyr/include/zephyr/toolchain/gcc.h:87:36: error: static assertion failed: "zephyr-code must be specified to use the input-gpio-keys driver"
   87 | #define BUILD_ASSERT(EXPR, MSG...) _Static_assert((EXPR), "" MSG)
      |                                    ^~~~~~~~~~~~~~

...
```

Use the following command can reproduce the build issue:
```
INFO    - west twister -p imx93_evk/mimx9352/a55 -s sample.input.input_dump_shell --no-detailed-test-id
INFO    - or with west:
INFO    - west build -p -b imx93_evk/mimx9352/a55 samples/subsys/input/input_dump -T sample.input.input_dump_shell
INFO    - -+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
INFO    - Run completed
```
 Fixes #https://github.com/zephyrproject-rtos/zephyr/issues/82366