### PR TITLE
twister: workaround for CI

### DIFF
--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -137,7 +137,8 @@ jobs:
           if [ "${{matrix.subset}}" = "1" ]; then
             ./scripts/zephyr_module.py --twister-out module_tests.args
             if [ -s module_tests.args ]; then
-              ./scripts/twister +module_tests.args --outdir module_tests ${TWISTER_COMMON} ${PUSH_OPTIONS}
+              # FIXME: workaround for modules with invalid test data
+              ./scripts/twister +module_tests.args --outdir module_tests ${TWISTER_COMMON} ${PUSH_OPTIONS} --integration
             fi
           fi
 


### PR DESCRIPTION
Workaround for mcuboot until https://github.com/mcu-tools/mcuboot/pull/2136 is merged.

Caused by introduction of https://github.com/zephyrproject-rtos/zephyr/pull/82404

- **ci: twister: add workaround until module test data is fixed [REVERTME]**
