### PR TITLE
MAINTAINERS: Add cvinayak to Bluetooth HCI, Host and ISO

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -313,6 +313,7 @@ Bluetooth HCI:
     - sjanc
     - theob-pro
     - HoZHel
+    - cvinayak
   files:
     - include/zephyr/drivers/bluetooth/
     - include/zephyr/drivers/bluetooth.h
@@ -326,7 +327,7 @@ Bluetooth HCI:
   tests:
     - bluetooth
 
-Bluetooth controller:
+Bluetooth Controller:
   status: maintained
   maintainers:
     - cvinayak
@@ -365,6 +366,7 @@ Bluetooth Host:
     - sjanc
     - Thalley
     - theob-pro
+    - cvinayak
   files:
     - doc/connectivity/bluetooth/
     - include/zephyr/bluetooth/
@@ -515,6 +517,7 @@ Bluetooth ISO:
     - jhedberg
     - kruithofa
     - rugeGerritsen
+    - cvinayak
   files:
     - include/zephyr/bluetooth/iso.h
     - doc/connectivity/bluetooth/shell/host/iso.rst


### PR DESCRIPTION
Contributed some of the following to HCI (UART) samples: Vinayak Kariappa Chettimada (20):
 Bluetooth: hci_uart: reduce configured stack sizes
 samples: Bluetooth: Add configuration file for all controller features
 samples: Bluetooth: hci_rpmsg: Fix RAM overflow building for DF feature
 Bluetooth: Controller: Preliminary Central multiple CIS support
 samples: Bluetooth: hci_rpmsg/uart: Fix BT_CTLR_ISO_TX_BUFFER_SIZE
 Bluetooth: Controller: Fix connected ISO dynamic tx power
 Bluetooth: Controller: BT_CTLR_ISO_TX_BUFFER_SIZE from BT_ISO_TX_MTU
 samples: Bluetooth: hci_uart: Add preliminary support for nrf54l15pdk
 samples: Bluetooth: hci_uart: Use lower IRQ priority SoC peripherals
 samples: Bluetooth: hci_uart: Add preliminary DF support for nrf54l15pdk
 samples: Bluetooth: hci_uart/hci_ipc: CI coverage for nRF53+nRF21 FEM
 samples: Bluetooth: hci_uart: CI coverage for nRF5340dk cpuapp
 samples: Bluetooth: hci_uart: CI coverage for nRF52+nRF21 FEM
 samples: Bluetooth: hci_uart: CI coverage for nRF52840
 samples: Bluetooth: hci_uart: CI coverage for nRF52dk
 samples: Bluetooth: hci_uart: CI coverage for nRF52833 DF
 samples: Bluetooth: hci_uart(_3wire)/hci_ipc: Enable PAST feature
 samples: Bluetooth: hci_uart hci_ipc configuration update
 samples: Bluetooth: hci_uart hci_ipc configuration update
 Revert "Bluetooth: controller: remove refs to LLCP_LEGACY after rebase"

Contributed some of the following to Host:
Vinayak Kariappa Chettimada (2409):
 Bluetooth: SMP: Fix unaligned access usage fault.
 soc: Use nrf.h instead of nrf52.h and nrf52_bitfields.h
 Bluetooth: Fix race condition between ecc_send and ecc_task
 ...

Contributed some of the following to Host ISO:
Vinayak Kariappa Chettimada (2):
 Bluetooth: host: iso: Fix typo in hci_le_big_terminate
 Bluetooth: HCI: Rename to bt_hci_iso_sdu_hdr and bt_hci_iso_sdu_ts_hdr

and attends the weekly Bluetooth Zephyr meetings.