### PR TITLE
west.yml: MCUboot synchronization from upstream

### DIFF
--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -137,8 +137,7 @@ jobs:
           if [ "${{matrix.subset}}" = "1" ]; then
             ./scripts/zephyr_module.py --twister-out module_tests.args
             if [ -s module_tests.args ]; then
-              # FIXME: workaround for modules with invalid test data
-              ./scripts/twister +module_tests.args --outdir module_tests ${TWISTER_COMMON} ${PUSH_OPTIONS} --integration
+              ./scripts/twister +module_tests.args --outdir module_tests ${TWISTER_COMMON} ${PUSH_OPTIONS}
             fi
           fi
 

--- a/west.yml
+++ b/west.yml
@@ -291,7 +291,7 @@ manifest:
       groups:
         - crypto
     - name: mcuboot
-      revision: eb942067989569f9cf319b087d0bb16b16effd86
+      revision: 5d6471bac184c8accaeeb0efcfad8dd35225a28d
       path: bootloader/mcuboot
       groups:
         - bootloader


### PR DESCRIPTION
west.yml: MCUboot synchronization from upstream
    
Update Zephyr fork of MCUboot to revision:
  5d6471bac184c8accaeeb0efcfad8dd35225a28d
    
Brings following Zephyr relevant fixes:
  - 5d6471ba zephyr: convert platform_allow to a list
  - 7cc60059 boot: zephyr: boards: nrf54l10 and nrf54l05 configs
  - 742978e7 boot: zephyr: Fix sample.bootloader.mcuboot.usb_cdc_acm_recovery
  - 39aab3d8 zephyr: Add CONFIG_MCUBOOT_CLEANUP_RAM

Notes on process:
 1) The MCUboot update from [mcu-tools/mcuboot/main](https://github.com/mcu-tools/mcuboot/tree/main) with the SHA used in west.yaml is already synchronized to [zephyrproject-rtos/mcuboot/upstream-sync](https://github.com/zephyrproject-rtos/mcuboot/tree/upstream-sync) branch, and is available in the Zephyr fork of MCUboot.
 2) The [DNM] on this PR should be kept until the PR passes all tests and is accepted.
 3) Once the PR passes all tests and gets accepted, the upstream-sync branch should be fast-forward merged to [zephyrproject-rtos/mcuboot/main](https://github.com/zephyrproject-rtos/mcuboot/tree/main) branch and [DNM] should be removed.
 4) After the main branch gets updated, this PR does not require further changes and should be merged as is.