### PR TITLE
drivers: bluetooth: hci: STM32WBA: Fix pub address assignment

### DIFF
--- a/drivers/bluetooth/hci/Kconfig
+++ b/drivers/bluetooth/hci/Kconfig
@@ -97,7 +97,7 @@ config BT_STM32WBA
 	depends on DT_HAS_ST_HCI_STM32WBA_ENABLED
 	depends on ZEPHYR_HAL_STM32_MODULE_BLOBS
 	select HAS_STM32LIB
-	select BT_HCI_SET_PUBLIC_ADDR
+	select BT_HCI_SET_PUBLIC_ADDR if !BT_HCI_RAW
 	help
 	  ST STM32WBA HCI Bluetooth interface
 


### PR DESCRIPTION
BLE public address assignment shall be done only when CONFIG_BT_HCI_RAW is not enabled.