### PR TITLE
net: lib: ptp: Include timestamp in follow up msg and minor fixes

### DIFF
--- a/subsys/net/lib/ptp/btca.c
+++ b/subsys/net/lib/ptp/btca.c
@@ -100,7 +100,7 @@ int ptp_btca_ds_cmp(const struct ptp_dataset *a, const struct ptp_dataset *b)
 	if (a->priority1 > b->priority1) {
 		return B_BETTER;
 	}
-	if (a->clk_quality.class > b->clk_quality.class) {
+	if (a->clk_quality.cls > b->clk_quality.cls) {
 		return B_BETTER;
 	}
 	if (a->clk_quality.accuracy > b->clk_quality.accuracy) {
@@ -129,7 +129,7 @@ enum ptp_port_state ptp_btca_state_decision(struct ptp_port *port)
 		return PTP_PS_LISTENING;
 	}
 
-	if (clk_default->clk_quality.class <= 127) {
+	if (clk_default->clk_quality.cls <= 127) {
 		if (ptp_btca_ds_cmp(clk_default, port_best) > 0) {
 			/* M1 */
 			return PTP_PS_GRAND_MASTER;

--- a/subsys/net/lib/ptp/clock.c
+++ b/subsys/net/lib/ptp/clock.c
@@ -262,7 +262,7 @@ const struct ptp_clock *ptp_clock_init(void)
 	dds->n_ports = 0;
 	dds->time_receiver_only = IS_ENABLED(CONFIG_PTP_TIME_RECEIVER_ONLY) ? true : false;
 
-	dds->clk_quality.class = dds->time_receiver_only ? 255 : 248;
+	dds->clk_quality.cls = dds->time_receiver_only ? 255 : 248;
 	dds->clk_quality.accuracy = CONFIG_PTP_CLOCK_ACCURACY;
 	/* 0xFFFF means that value has not been computed - IEEE 1588-2019 7.6.3.3 */
 	dds->clk_quality.offset_scaled_log_variance = 0xFFFF;

--- a/subsys/net/lib/ptp/clock.c
+++ b/subsys/net/lib/ptp/clock.c
@@ -529,8 +529,8 @@ void ptp_clock_synchronize(uint64_t ingress, uint64_t egress)
 
 		ptp_clock_get(ptp_clk.phc, &current);
 
-		current.second -= (uint64_t)(offset / NSEC_PER_SEC);
-		dest_nsec = (int32_t)(current.nanosecond - (uint32_t)(offset % NSEC_PER_SEC));
+		current.second = (uint64_t)(current.second - (offset / NSEC_PER_SEC));
+		dest_nsec = (int32_t)(current.nanosecond - (offset % NSEC_PER_SEC));
 
 		if (dest_nsec < 0) {
 			current.second--;

--- a/subsys/net/lib/ptp/ddt.h
+++ b/subsys/net/lib/ptp/ddt.h
@@ -79,7 +79,7 @@ struct ptp_port_addr {
  */
 struct ptp_clk_quality {
 	/** PTP Clock's class */
-	uint8_t  class;
+	uint8_t  cls;
 	/** Accuracy of the PTP Clock. */
 	uint8_t  accuracy;
 	/** Value representing stability of the Local PTP Clock. */

--- a/subsys/net/lib/ptp/ds.h
+++ b/subsys/net/lib/ptp/ds.h
@@ -101,10 +101,10 @@ struct ptp_parent_ds {
 	uint8_t		       gm_priority1;
 	/** Value of Grandmaster's priority2 attribute. */
 	uint8_t		       gm_priority2;
-	/** Address of the PTP Port issuing sync messages used to synchronize this PTP Instance. */
-	struct ptp_port_addr   protocol_addr;
 	/** Flag inticating use of sync_uncertain flag in Announce message. */
 	bool		       sync_uncertain;
+	/** Address of the PTP Port issuing sync messages used to synchronize this PTP Instance. */
+	struct ptp_port_addr   protocol_addr;
 };
 
 /**

--- a/subsys/net/lib/ptp/msg.c
+++ b/subsys/net/lib/ptp/msg.c
@@ -328,6 +328,7 @@ void ptp_msg_pre_send(struct ptp_msg *msg)
 		msg_port_id_pre_send(&msg->pdelay_resp.req_port_id);
 		break;
 	case PTP_MSG_FOLLOW_UP:
+		msg_timestamp_pre_send(&msg->follow_up.precise_origin_timestamp);
 		break;
 	case PTP_MSG_DELAY_RESP:
 		msg_timestamp_pre_send(&msg->delay_resp.receive_timestamp);

--- a/subsys/net/lib/ptp/transport.c
+++ b/subsys/net/lib/ptp/transport.c
@@ -266,7 +266,7 @@ int ptp_transport_close(struct ptp_port *port)
 
 int ptp_transport_send(struct ptp_port *port, struct ptp_msg *msg, enum ptp_socket idx)
 {
-	__ASSERT(PTP_SOCKET_CNT <= idx, "Invalid socket index");
+	__ASSERT(PTP_SOCKET_CNT > idx, "Invalid socket index");
 
 	static const int socket_port[] = {PTP_SOCKET_PORT_EVENT, PTP_SOCKET_PORT_GENERAL};
 	int length = ntohs(msg->header.msg_length);
@@ -276,7 +276,7 @@ int ptp_transport_send(struct ptp_port *port, struct ptp_msg *msg, enum ptp_sock
 
 int ptp_transport_sendto(struct ptp_port *port, struct ptp_msg *msg, enum ptp_socket idx)
 {
-	__ASSERT(PTP_SOCKET_CNT <= idx, "Invalid socket index");
+	__ASSERT(PTP_SOCKET_CNT > idx, "Invalid socket index");
 
 	static const int socket_port[] = {PTP_SOCKET_PORT_EVENT, PTP_SOCKET_PORT_GENERAL};
 	int length = ntohs(msg->header.msg_length);
@@ -286,7 +286,7 @@ int ptp_transport_sendto(struct ptp_port *port, struct ptp_msg *msg, enum ptp_so
 
 int ptp_transport_recv(struct ptp_port *port, struct ptp_msg *msg, enum ptp_socket idx)
 {
-	__ASSERT(PTP_SOCKET_CNT <= idx, "Invalid socket index");
+	__ASSERT(PTP_SOCKET_CNT > idx, "Invalid socket index");
 
 	int cnt = 0;
 	uint8_t ctrl[CMSG_SPACE(sizeof(struct net_ptp_time))] = {0};


### PR DESCRIPTION
This PR aims to fix some small issues encountered while implementing ptp on a stm32f767. The fixes are described in the individual commit messages, but below is a brief description:

While in developement, I have asserts enabled, and experienced the asserts in transport.c always failing. It appears the condition is inverted, as PTP_SOCKET_CNT is always larger than the current socket.
The second issue is tied to the ptp_clock_synchronization in clock.c. Casting the adjustment value to a uint64/32 with a compound assignment operator (-=) causes the adjustment to be mono-directional.
The third issue is due to compilation errors occuring due to some reserved variable names are being used.
The fourth and main issue is how the follow up message lacks the timestamp captured at the sync message egress. The timestamp is prepared by the sync message, but not inserted into the follow up.