### PR TITLE
zms: optimize write function by skipping unnecessary reads

### DIFF
--- a/subsys/fs/zms/Kconfig
+++ b/subsys/fs/zms/Kconfig
@@ -50,6 +50,15 @@ config ZMS_CUSTOM_BLOCK_SIZE
 	help
 	  Changes the internal buffer size of ZMS
 
+config ZMS_NO_DOUBLE_WRITE
+	bool "Avoid writing the same data again in the storage"
+	help
+	  For some memory technologies, write cycles for memory cells are limited and any
+	  unncessary writes should be avoided.
+	  Enable this config to avoid rewriting data in the storage if it already exists.
+	  This option will reduce write performance as it will need to do a research of the
+	  data in the whole storage before any write.
+
 module = ZMS
 module-str = zms
 source "subsys/logging/Kconfig.template.log_config"

--- a/tests/subsys/fs/zms/src/main.c
+++ b/tests/subsys/fs/zms/src/main.c
@@ -545,6 +545,7 @@ ZTEST_F(zms, test_delete)
 	ate_wra = fixture->fs.ate_wra;
 	data_wra = fixture->fs.data_wra;
 
+#ifdef CONFIG_ZMS_NO_DOUBLE_WRITE
 	/* delete already deleted entry */
 	err = zms_delete(&fixture->fs, 1);
 	zassert_true(err == 0, "zms_delete call failure: %d", err);
@@ -558,6 +559,7 @@ ZTEST_F(zms, test_delete)
 	zassert_true(ate_wra == fixture->fs.ate_wra && data_wra == fixture->fs.data_wra,
 		     "delete nonexistent entry should not make"
 		     " any footprint in the storage");
+#endif
 }
 
 /*


### PR DESCRIPTION
when performing a write ZMS checks if the data exists in the storage to avoid double writing the same data and save some memory cycle life time. However this downgrades the write performance.
Enable this feature only when CONFIG_ZMS_NO_DOUBLE_WRITE is enabled.