### PR TITLE
twister: handler: open files using with statement

### DIFF
--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -354,12 +354,9 @@ class BinaryHandler(Handler):
             return
 
         stderr_log = f"{self.instance.build_dir}/handler_stderr.log"
-        with (
-            open(stderr_log, "w+") as stderr_log_fp,
-            subprocess.Popen(
-                command, stdout=subprocess.PIPE, stderr=stderr_log_fp, cwd=self.build_dir, env=env
-            ) as proc,
-        ):
+        with open(stderr_log, "w+") as stderr_log_fp, subprocess.Popen(
+            command, stdout=subprocess.PIPE, stderr=stderr_log_fp, cwd=self.build_dir, env=env
+        ) as proc:
             logger.debug(f"Spawning BinaryHandler Thread for {self.name}")
             t = threading.Thread(target=self._output_handler, args=(proc, harness,), daemon=True)
             t.start()
@@ -1098,10 +1095,11 @@ class QEMUHandler(Handler):
         is_timeout = False
         qemu_pid = None
 
-        with subprocess.Popen(
+        with open(self.stdout_fn, "w") as stdout_fp, \
+            open(self.stderr_fn, "w") as stderr_fp, subprocess.Popen(
             command,
-            stdout=open(self.stdout_fn, "w"),
-            stderr=open(self.stderr_fn, "w"),
+            stdout=stdout_fp,
+            stderr=stderr_fp,
             cwd=self.build_dir
         ) as proc:
             logger.debug(f"Spawning QEMUHandler Thread for {self.name}")


### PR DESCRIPTION
Use with statement to open stdout/stderr and resolve current warning
when running twister:

	ResourceWarning: unclosed file....

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
