### PR TITLE
boards: waveshare: adopt new rp2040.dtsi location

### DIFF
--- a/boards/waveshare/rp2040_zero/rp2040_zero.dts
+++ b/boards/waveshare/rp2040_zero/rp2040_zero.dts
@@ -6,7 +6,7 @@
 
 /dts-v1/;
 
-#include <rpi_pico/rp2040.dtsi>
+#include <raspberrypi/rpi_pico/rp2040.dtsi>
 #include "rp2040_zero-pinctrl.dtsi"
 #include <freq.h>
 #include <zephyr/dt-bindings/led/led.h>


### PR DESCRIPTION
This board was merged before rp2040.dtsi changed location. Update the include in its dts file accordingly