### PR TITLE
soc: nxp: mcx: Add flash runner configuration

### DIFF
--- a/soc/nxp/mcx/soc.yml
+++ b/soc/nxp/mcx/soc.yml
@@ -30,6 +30,20 @@ runners:
       - qualifiers:
         - mcxn947/cpu0
         - mcxn947/cpu1
+      - qualifiers:
+        - mcxn236
+      - qualifiers:
+        - mcxc141
+      - qualifiers:
+        - mcxc142
+      - qualifiers:
+        - mcxc242
+      - qualifiers:
+        - mcxc444
+      - qualifiers:
+        - mcxa156
+      - qualifiers:
+        - mcxw716c
     '--reset':
     - run: last
       runners:
@@ -38,3 +52,17 @@ runners:
       - qualifiers:
         - mcxn947/cpu0
         - mcxn947/cpu1
+      - qualifiers:
+        - mcxn236
+      - qualifiers:
+        - mcxc141
+      - qualifiers:
+        - mcxc142
+      - qualifiers:
+        - mcxc242
+      - qualifiers:
+        - mcxc444
+      - qualifiers:
+        - mcxa156
+      - qualifiers:
+        - mcxw716c


### PR DESCRIPTION
- Adds a flash runner configuration for mcxn/c/a/w used for sysbuild multi-image projects.
- Solves sysbuild issue with multiple resets and mass erases.