### PR TITLE
boards: nordic: nRF54L15DK: Add debug configuration for FLPR

### DIFF
--- a/boards/nordic/nrf54l15dk/board.cmake
+++ b/boards/nordic/nrf54l15dk/board.cmake
@@ -6,7 +6,8 @@ if(CONFIG_SOC_NRF54L05_CPUAPP OR CONFIG_SOC_NRF54L10_CPUAPP OR
   board_runner_args(jlink "--device=cortex-m33" "--speed=4000")
 elseif(CONFIG_SOC_NRF54L05_CPUFLPR OR CONFIG_SOC_NRF54L10_CPUFLPR OR
 		CONFIG_SOC_NRF54L15_CPUFLPR)
-  board_runner_args(jlink "--speed=4000")
+  set(JLINKSCRIPTFILE ${CMAKE_CURRENT_LIST_DIR}/support/nrf54l_05_10_15_cpuflpr.JLinkScript)
+  board_runner_args(jlink "--device=RISC-V" "--speed=4000" "-if SW" "--tool-opt=-jlinkscriptfile ${JLINKSCRIPTFILE}")
 endif()
 
 include(${ZEPHYR_BASE}/boards/common/nrfutil.board.cmake)

--- a/boards/nordic/nrf54l15dk/support/nrf54l_05_10_15_cpuflpr.JLinkScript
+++ b/boards/nordic/nrf54l15dk/support/nrf54l_05_10_15_cpuflpr.JLinkScript
@@ -1,0 +1,5 @@
+int InitTarget(void) {
+  // Base address where DMI registers can be found in the APB address space
+  JLINK_ExecCommand("CORESIGHT_SetCoreBaseAddr = 0x5004C400");
+  return 0;
+}


### PR DESCRIPTION
Add the required code for `west debug` to work the FLPR core over JLink in the nRF54L 05, 10 and 15 devices.
Note that this requries an external J-Link probe, it will not work withthe on-board (OB) probe soldered on the DK.
    
