### PR TITLE
Bluetooth: Mesh: Fix gatt advertiser start in bt_mesh_resume

### DIFF
--- a/subsys/bluetooth/mesh/main.c
+++ b/subsys/bluetooth/mesh/main.c
@@ -556,12 +556,7 @@ int bt_mesh_resume(void)
 
 	bt_mesh_model_foreach(model_resume, NULL);
 
-	err = bt_mesh_adv_gatt_send();
-	if (err && (err != -ENOTSUP)) {
-		LOG_WRN("GATT send failed (err %d)", err);
-		return err;
-	}
-
+	bt_mesh_adv_gatt_update();
 	return 0;
 }
 


### PR DESCRIPTION
To signal to the mesh extended advertiser that a proxy advertisement is started, `bt_mesh_adv_gatt_send()` is called in combination with setting the `ADV_FLAG_PROXY` flag in adv_ext.c. This ensures that it won't try to start the advertiser again, which would result in the controller rejecting it.

Setting this flag outside adv_ext.c is not viable, and as such calling `bt_mesh_adv_gatt_send()` should also be limited to the advertising source code.

As it stand now, once we utilize the new commit priority for `h_commit` calls such a recall of `bt_mesh_adv_gatt_send()` with following rejection by the controller will happen.

Within the `bt_mesh_resume()` function we can confidently assume the extended advertiser has already been started. As such we can call `bt_mesh_adv_gatt_update()` instead of `bt_mesh_adv_gatt_send()`.

This change has been tested with both running relevant bsim tests after rearranging in which order the settings of the subsystems are loaded via `h_commit`, as well as a modified light switch sample, adding `bt_mesh_resume/suspend` calls on buttons.