### PR TITLE
twister: Pass extra test args to pytest

### DIFF
--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/device/device_adapter.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/device/device_adapter.py
@@ -67,6 +67,8 @@ class DeviceAdapter(abc.ABC):
 
         if not self.command:
             self.generate_command()
+            if self.device_config.extra_test_args:
+                self.command.extend(self.device_config.extra_test_args.split())
 
         if self.device_config.type != 'hardware':
             self._flash_and_run()

--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/plugin.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/plugin.py
@@ -126,6 +126,10 @@ def pytest_addoption(parser: pytest.Parser):
         '--twister-fixture', action='append', dest='fixtures', metavar='FIXTURE', default=[],
         help='Twister fixture supported by this platform. May be given multiple times.'
     )
+    twister_harness_group.addoption(
+        '--extra-test-args',
+        help='Additional args passed to the test binary'
+    )
 
 
 def pytest_configure(config: pytest.Config):

--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/twister_harness_config.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/twister_harness_config.py
@@ -36,6 +36,7 @@ class DeviceConfig:
     post_flash_script: Path | None = None
     fixtures: list[str] = None
     app_build_dir: Path | None = None
+    extra_test_args: str = ''
 
     def __post_init__(self):
         domains = self.build_dir / 'domains.yaml'
@@ -81,6 +82,7 @@ class TwisterHarnessConfig:
             post_script=_cast_to_path(config.option.post_script),
             post_flash_script=_cast_to_path(config.option.post_flash_script),
             fixtures=config.option.fixtures,
+            extra_test_args=config.option.extra_test_args
         )
 
         devices.append(device_from_cli)

--- a/scripts/pylib/twister/twisterlib/harness.py
+++ b/scripts/pylib/twister/twisterlib/harness.py
@@ -426,6 +426,9 @@ class Pytest(Harness):
             for fixture in handler.options.fixture:
                 command.append(f'--twister-fixture={fixture}')
 
+        if handler.options.extra_test_args and handler.type_str == 'native':
+            command.append(f'--extra-test-args={shlex.join(handler.options.extra_test_args)}')
+
         command.extend(pytest_args_yaml)
 
         if handler.options.pytest_args:

--- a/scripts/tests/twister/pytest_integration/test_harness_pytest.py
+++ b/scripts/tests/twister/pytest_integration/test_harness_pytest.py
@@ -28,6 +28,7 @@ def testinstance() -> TestInstance:
     testinstance.handler.options.verbose = 1
     testinstance.handler.options.fixture = ['fixture1:option1', 'fixture2']
     testinstance.handler.options.pytest_args = None
+    testinstance.handler.options.extra_test_args = []
     testinstance.handler.type_str = 'native'
     return testinstance
 
@@ -70,6 +71,15 @@ def test_pytest_command_extra_args(testinstance: TestInstance):
     command = pytest_harness.generate_command()
     for c in pytest_args:
         assert c in command
+
+
+def test_pytest_command_extra_test_args(testinstance: TestInstance):
+    pytest_harness = Pytest()
+    extra_test_args = ['-stop_at=3', '-no-rt']
+    testinstance.handler.options.extra_test_args = extra_test_args
+    pytest_harness.configure(testinstance)
+    command = pytest_harness.generate_command()
+    assert f'--extra-test-args={extra_test_args[0]} {extra_test_args[1]}' in command
 
 
 def test_pytest_command_extra_args_in_options(testinstance: TestInstance):


### PR DESCRIPTION
Pass additional args to test binary.
Fixes #82463

to test just run command:
`./scripts/twister -vv -p native_sim -T samples/subsys/testsuite/pytest/shell  -ll debug --no-clean --pytest-args='-k test_shell_print_version' -- -stop_at=3 -testargs abc`

in the log you can find, that twister calls:
`pytest --twister-harness -s -v ... --device-type=native '--extra-test-args=-stop_at=3 -testargs abc' '-k test_shell_print_version' -p twister_harness.plugin`
and then pytest calls:
`./twister-out/native_sim_native/samples/subsys/testsuite/pytest/shell/sample.pytest.shell/zephyr/zephyr.exe -stop_at=3 -testargs abc`

Twister passes additional args to pytest subprocess only for native_sim (as it is for normal Twister applications, I mean console harness or ztest).
