### PR TITLE
tests/flash: Correct nrf52840 hi-perf mx25 expected flash size

### DIFF
--- a/tests/drivers/flash/common/src/main.c
+++ b/tests/drivers/flash/common/src/main.c
@@ -331,7 +331,8 @@ ZTEST(flash_driver, test_get_size)
 	uint64_t size;
 
 	zassert_ok(flash_get_size(flash_dev, &size));
-	zassert_equal(size, CONFIG_TEST_DRIVER_FLASH_SIZE, "Unexpected size");
+	zassert_equal(size, (uint64_t)CONFIG_TEST_DRIVER_FLASH_SIZE, "Expected %llu, got %llu\n",
+		      (uint64_t)CONFIG_TEST_DRIVER_FLASH_SIZE, size);
 #else
 	/* The test is sipped only because there is no uniform way to get device size */
 	ztest_test_skip();

--- a/tests/drivers/flash/common/testcase.yaml
+++ b/tests/drivers/flash/common/testcase.yaml
@@ -55,7 +55,7 @@ tests:
   drivers.flash.common.mx25r_high_perf:
     platform_allow: nrf52840dk/nrf52840
     extra_configs:
-      - CONFIG_TEST_DRIVER_FLASH_SIZE=216142092
+      - CONFIG_TEST_DRIVER_FLASH_SIZE=8388608
     extra_args:
       - EXTRA_CONF_FILE=boards/nrf52840dk_flash_spi.conf
       - DTC_OVERLAY_FILE=boards/nrf52840dk_mx25r_high_perf.overlay


### PR DESCRIPTION
Two commits:
 - fix the  incorrect size expected to be reported by flash_get size
 - improve test output on failure

Fixes #82619