### PR TITLE
boards: rp2040: set startup-delay-multiplier for applicable boards

### DIFF
--- a/boards/adafruit/kb2040/adafruit_kb2040.dts
+++ b/boards/adafruit/kb2040/adafruit_kb2040.dts
@@ -122,3 +122,7 @@ zephyr_udc0: &usbd {
 	regulator-always-on;
 	regulator-allowed-modes = <REGULATOR_RPI_PICO_MODE_NORMAL>;
 };
+
+&xosc {
+	startup-delay-multiplier = <64>;
+};

--- a/boards/adafruit/qt_py_rp2040/adafruit_qt_py_rp2040.dts
+++ b/boards/adafruit/qt_py_rp2040/adafruit_qt_py_rp2040.dts
@@ -152,3 +152,7 @@ zephyr_udc0: &usbd {
 	regulator-always-on;
 	regulator-allowed-modes = <REGULATOR_RPI_PICO_MODE_NORMAL>;
 };
+
+&xosc {
+	startup-delay-multiplier = <64>;
+};

--- a/boards/seeed/xiao_rp2040/xiao_rp2040.dts
+++ b/boards/seeed/xiao_rp2040/xiao_rp2040.dts
@@ -167,3 +167,7 @@ zephyr_udc0: &usbd {
 	regulator-always-on;
 	regulator-allowed-modes = <REGULATOR_RPI_PICO_MODE_NORMAL>;
 };
+
+&xosc {
+	startup-delay-multiplier = <64>;
+};

--- a/dts/arm/raspberrypi/rpi_pico/rp2040.dtsi
+++ b/dts/arm/raspberrypi/rpi_pico/rp2040.dtsi
@@ -168,7 +168,6 @@
 		xosc: xosc {
 			compatible = "raspberrypi,pico-xosc";
 			clock-frequency = <12000000>;
-			startup-delay-multiplier = <64>;
 			#clock-cells = <0>;
 		};
 


### PR DESCRIPTION
This is based on discussions from https://github.com/zephyrproject-rtos/zephyr/pull/80707#discussion_r1861305898