### PR TITLE
tests: drivers: pwm: Revert PWM capture change for pulse check

### DIFF
--- a/tests/drivers/pwm/pwm_loopback/src/test_pwm_loopback.c
+++ b/tests/drivers/pwm/pwm_loopback/src/test_pwm_loopback.c
@@ -99,12 +99,9 @@ static void test_capture(uint32_t period, uint32_t pulse, enum test_pwm_unit uni
 			       "period capture off by more than 1%");
 	}
 
-	if (flags & PWM_POLARITY_INVERTED) {
-		zassert_within(pulse_capture, period - pulse, (period - pulse) / 100,
-				"pulse capture off by more than 1%");
-	} else {
+	if (flags & PWM_CAPTURE_TYPE_PULSE) {
 		zassert_within(pulse_capture, pulse, pulse / 100,
-				"pulse capture off by more than 1%");
+			       "pulse capture off by more than 1%");
 	}
 }
 


### PR DESCRIPTION
Reverts a change from #81198 regarding how the test checks the pulse output from a capture event. A pulse capture will produce a value that has the same polarity (and range) as programmed by pwm_capture(). Checking 'pulse_capture' against 'period - pulse' means expecting the driver to return a capture value that is not inverted as well, which would cause test cases to fail.