### PR TITLE
scripts: coredump: Fix issue with loading coredumps when thread info …

### DIFF
--- a/scripts/coredump/coredump_parser/log_parser.py
+++ b/scripts/coredump/coredump_parser/log_parser.py
@@ -62,6 +62,7 @@ class CoredumpLogFile:
         self.log_hdr = None
         self.arch_data = list()
         self.memory_regions = list()
+        self.threads_metadata = {"hdr_ver" : None, "data" : None}
 
     def open(self):
         self.fd = open(self.logfile, "rb")

--- a/scripts/coredump/gdbstubs/gdbstub.py
+++ b/scripts/coredump/gdbstubs/gdbstub.py
@@ -179,6 +179,11 @@ class GdbStub(abc.ABC):
             # For packets qfThreadInfo/qsThreadInfo, obtain a list of all active thread IDs
             if pkt[0:12] == b"qfThreadInfo":
                 threads_metadata_data = self.logfile.get_threads_metadata()["data"]
+
+                if threads_metadata_data is None:
+                    self.put_gdb_packet(b"l")
+                    return
+
                 size_t_size = self.elffile.get_kernel_thread_info_size_t_size()
 
                 # First, find and store the thread that _kernel considers current


### PR DESCRIPTION
…is enabled.

When loading a coredump with an an elf built using 'CONFIG_DEBUG_THREAD_INFO=y', gdbstubs assumes that the thread info memoryblock populated by 'CONFIG_DEBUG_COREDUMP_MEMORY_DUMP_THREADS=y' will be present in the coredump. This is not always true and causes an error, and a failure to load the coredump. Add a default value for the threads_metadata variable in CoredumpLogFile which can be used to detect when the memory block is not present. This allows the coredump to load successfully.