### PR TITLE
TinyCrypt: Deprecate the library

### DIFF
--- a/doc/releases/release-notes-4.1.rst
+++ b/doc/releases/release-notes-4.1.rst
@@ -43,6 +43,12 @@ Deprecated in this release
   the same functionality in their application code by reconnecting to the peer when the
   :c:member:`bt_conn_cb.disconnected` callback is invoked.
 
+* Deprecated TinyCrypt library. The reasons for this are (:github:`43712`):
+
+  * The upstream version of this library is no longer maintained.
+  * Reducing the number of cryptographic libraries in Zephyr to reduce maintenance overhead.
+  * The PSA Crypto API is the recommended cryptographic library for Zephyr.
+
 Architectures
 *************
 

--- a/modules/Kconfig.tinycrypt
+++ b/modules/Kconfig.tinycrypt
@@ -9,6 +9,7 @@ config ZEPHYR_TINYCRYPT_MODULE
 config TINYCRYPT
 	bool "TinyCrypt Support"
 	depends on ZEPHYR_TINYCRYPT_MODULE
+	select DEPRECATED
 	help
 	  This option enables the TinyCrypt cryptography library.
 


### PR DESCRIPTION
Now that PSA is supported on Zephyr and the code base has changed to use that library, TinyCrypt is been deprecated. Reasons for this change can be found in #43712.