### PR TITLE
scripts: twister: Add more Status assignment guards

### DIFF
--- a/scripts/pylib/twister/twisterlib/config_parser.py
+++ b/scripts/pylib/twister/twisterlib/config_parser.py
@@ -7,7 +7,7 @@ import copy
 import warnings
 
 import scl
-from twisterlib.error import ConfigurationError
+from pylib.twister.twisterlib.error import ConfigurationError
 
 
 def extract_fields_from_arg_list(target_fields: set, arg_list: str | list):

--- a/scripts/pylib/twister/twisterlib/environment.py
+++ b/scripts/pylib/twister/twisterlib/environment.py
@@ -21,9 +21,9 @@ from importlib import metadata
 from pathlib import Path
 
 import zephyr_module
+from pylib.twister.twisterlib.error import TwisterRuntimeError
 from twisterlib.constants import SUPPORTED_SIMS
 from twisterlib.coverage import supported_coverage_formats
-from twisterlib.error import TwisterRuntimeError
 from twisterlib.log_helper import log_command
 
 logger = logging.getLogger('twister')

--- a/scripts/pylib/twister/twisterlib/error.py
+++ b/scripts/pylib/twister/twisterlib/error.py
@@ -26,7 +26,33 @@ class BuildError(TwisterException):
 class ExecutionError(TwisterException):
     pass
 
-class StatusAttributeError(TwisterException):
+class StatusAssignmentError(TwisterException):
     def __init__(self, cls : type, value):
-        msg = f'{cls.__name__} assigned status {value}, which could not be cast to a TwisterStatus.'
+        msg = (
+            f'{cls.__name__} assigned status "{value}", which could not be cast to a TwisterStatus.'
+        )
+        super().__init__(msg)
+
+class StatusInitError(TwisterException):
+    def __init__(self, value):
+        msg = (
+            f'Attempted initialisation of status "{value}",'
+            ' which could not be cast to a TwisterStatus.'
+        )
+        super().__init__(msg)
+
+class StatusAttributeError(AttributeError):
+    def __init__(self, name):
+        msg = (
+            f'Attempted access to nonexistent TwisterStatus.{name}.'
+            ' Please verify the status list.'
+        )
+        super().__init__(msg)
+
+class StatusKeyError(KeyError):
+    def __init__(self, name):
+        msg = (
+            f'Attempted access to nonexistent TwisterStatus[{name}].'
+            ' Please verify the status list.'
+        )
         super().__init__(msg)

--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -25,8 +25,8 @@ from pathlib import Path
 from queue import Empty, Queue
 
 import psutil
+from pylib.twister.twisterlib.error import TwisterException
 from twisterlib.environment import ZEPHYR_BASE, strip_ansi_sequences
-from twisterlib.error import TwisterException
 from twisterlib.platform import Platform
 from twisterlib.statuses import TwisterStatus
 

--- a/scripts/pylib/twister/twisterlib/harness.py
+++ b/scripts/pylib/twister/twisterlib/harness.py
@@ -19,7 +19,7 @@ from enum import Enum
 from pytest import ExitCode
 from twisterlib.constants import SUPPORTED_SIMS_IN_PYTEST
 from twisterlib.environment import PYTEST_PLUGIN_INSTALLED, ZEPHYR_BASE
-from twisterlib.error import ConfigurationError, StatusAttributeError
+from twisterlib.error import ConfigurationError, StatusAssignmentError
 from twisterlib.handlers import Handler, terminate_process
 from twisterlib.reports import ReportStatus
 from twisterlib.statuses import TwisterStatus
@@ -82,7 +82,7 @@ class Harness:
             key = value.name if isinstance(value, Enum) else value
             self._status = TwisterStatus[key]
         except KeyError as err:
-            raise StatusAttributeError(self.__class__, value) from err
+            raise StatusAssignmentError(self.__class__, value) from err
 
     def configure(self, instance):
         self.instance = instance

--- a/scripts/pylib/twister/twisterlib/harness.py
+++ b/scripts/pylib/twister/twisterlib/harness.py
@@ -16,10 +16,10 @@ import xml.etree.ElementTree as ET
 from collections import OrderedDict
 from enum import Enum
 
+from pylib.twister.twisterlib.error import ConfigurationError, StatusAssignmentError
 from pytest import ExitCode
 from twisterlib.constants import SUPPORTED_SIMS_IN_PYTEST
 from twisterlib.environment import PYTEST_PLUGIN_INSTALLED, ZEPHYR_BASE
-from twisterlib.error import ConfigurationError, StatusAssignmentError
 from twisterlib.handlers import Handler, terminate_process
 from twisterlib.reports import ReportStatus
 from twisterlib.statuses import TwisterStatus

--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -26,9 +26,7 @@ from colorama import Fore
 from elftools.elf.elffile import ELFFile
 from elftools.elf.sections import SymbolTableSection
 from packaging import version
-from twisterlib.cmakecache import CMakeCache
-from twisterlib.environment import canonical_zephyr_base
-from twisterlib.error import (
+from pylib.twister.twisterlib.error import (
     BuildError,
     ConfigurationError,
     StatusAssignmentError,
@@ -36,6 +34,8 @@ from twisterlib.error import (
     StatusInitError,
     StatusKeyError,
 )
+from twisterlib.cmakecache import CMakeCache
+from twisterlib.environment import canonical_zephyr_base
 from twisterlib.statuses import TwisterStatus
 
 if version.parse(elftools.__version__) < version.parse('0.24'):

--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -28,7 +28,14 @@ from elftools.elf.sections import SymbolTableSection
 from packaging import version
 from twisterlib.cmakecache import CMakeCache
 from twisterlib.environment import canonical_zephyr_base
-from twisterlib.error import BuildError, ConfigurationError, StatusAttributeError
+from twisterlib.error import (
+    BuildError,
+    ConfigurationError,
+    StatusAssignmentError,
+    StatusAttributeError,
+    StatusInitError,
+    StatusKeyError,
+)
 from twisterlib.statuses import TwisterStatus
 
 if version.parse(elftools.__version__) < version.parse('0.24'):
@@ -972,8 +979,13 @@ class ProjectBuilder(FilterBuilder):
                         next_op = 'report'
                     else:
                         next_op = 'cmake'
-            except StatusAttributeError as sae:
-                logger.error(str(sae))
+            except (
+                StatusAssignmentError,
+                StatusAttributeError,
+                StatusInitError,
+                StatusKeyError
+            ) as se:
+                logger.error(str(se))
                 self.instance.status = TwisterStatus.ERROR
                 reason = 'Incorrect status assignment'
                 self.instance.reason = reason
@@ -1005,8 +1017,13 @@ class ProjectBuilder(FilterBuilder):
                         next_op = 'report'
                     else:
                         next_op = 'build'
-            except StatusAttributeError as sae:
-                logger.error(str(sae))
+            except (
+                StatusAssignmentError,
+                StatusAttributeError,
+                StatusInitError,
+                StatusKeyError
+            ) as se:
+                logger.error(str(se))
                 self.instance.status = TwisterStatus.ERROR
                 reason = 'Incorrect status assignment'
                 self.instance.reason = reason
@@ -1054,8 +1071,13 @@ class ProjectBuilder(FilterBuilder):
                                 next_op = 'report'
                         else:
                             next_op = 'gather_metrics'
-            except StatusAttributeError as sae:
-                logger.error(str(sae))
+            except (
+                StatusAssignmentError,
+                StatusAttributeError,
+                StatusInitError,
+                StatusKeyError
+            ) as se:
+                logger.error(str(se))
                 self.instance.status = TwisterStatus.ERROR
                 reason = 'Incorrect status assignment'
                 self.instance.reason = reason
@@ -1085,8 +1107,13 @@ class ProjectBuilder(FilterBuilder):
                             "Nowhere to run"
                         )
                     next_op = 'report'
-            except StatusAttributeError as sae:
-                logger.error(str(sae))
+            except (
+                StatusAssignmentError,
+                StatusAttributeError,
+                StatusInitError,
+                StatusKeyError
+            ) as se:
+                logger.error(str(se))
                 self.instance.status = TwisterStatus.ERROR
                 reason = 'Incorrect status assignment'
                 self.instance.reason = reason
@@ -1111,8 +1138,13 @@ class ProjectBuilder(FilterBuilder):
                     "status": self.instance.status,
                     "reason": self.instance.reason
                 }
-            except StatusAttributeError as sae:
-                logger.error(str(sae))
+            except (
+                StatusAssignmentError,
+                StatusAttributeError,
+                StatusInitError,
+                StatusKeyError
+            ) as se:
+                logger.error(str(se))
                 self.instance.status = TwisterStatus.ERROR
                 reason = 'Incorrect status assignment'
                 self.instance.reason = reason
@@ -1140,8 +1172,13 @@ class ProjectBuilder(FilterBuilder):
                     elif self.options.runtime_artifact_cleanup == "all":
                         next_op = 'cleanup'
                         additionals = {"mode": "all"}
-            except StatusAttributeError as sae:
-                logger.error(str(sae))
+            except (
+                StatusAssignmentError,
+                StatusAttributeError,
+                StatusInitError,
+                StatusKeyError
+            ) as se:
+                logger.error(str(se))
                 self.instance.status = TwisterStatus.ERROR
                 reason = 'Incorrect status assignment'
                 self.instance.reason = reason
@@ -1161,8 +1198,13 @@ class ProjectBuilder(FilterBuilder):
                     or (mode == "all" and self.instance.reason != "CMake build failure")
                 ):
                     self.cleanup_artifacts()
-            except StatusAttributeError as sae:
-                logger.error(str(sae))
+            except (
+                StatusAssignmentError,
+                StatusAttributeError,
+                StatusInitError,
+                StatusKeyError
+            ) as se:
+                logger.error(str(se))
                 self.instance.status = TwisterStatus.ERROR
                 reason = 'Incorrect status assignment'
                 self.instance.reason = reason

--- a/scripts/pylib/twister/twisterlib/size_calc.py
+++ b/scripts/pylib/twister/twisterlib/size_calc.py
@@ -10,7 +10,7 @@ import re
 import subprocess
 import sys
 
-from twisterlib.error import TwisterRuntimeError
+from pylib.twister.twisterlib.error import TwisterRuntimeError
 
 logger = logging.getLogger('twister')
 logger.setLevel(logging.DEBUG)

--- a/scripts/pylib/twister/twisterlib/statuses.py
+++ b/scripts/pylib/twister/twisterlib/statuses.py
@@ -7,12 +7,35 @@ Status classes to be used instead of str statuses.
 """
 from __future__ import annotations
 
-from enum import Enum
+from enum import Enum, EnumMeta
 
 from colorama import Fore
+from twisterlib.error import StatusAttributeError, StatusInitError, StatusKeyError
 
 
-class TwisterStatus(str, Enum):
+class TwisterStatusEnumMeta(EnumMeta):
+    def __getattr__(cls, name):
+        try:
+            obj = super().__getattribute__(name)
+        except AttributeError as ae:
+            # Looks like an Enum key - let's give the user more information.
+            if (
+                name.isupper()
+                and not (name.startswith('_') and name.endswith('_'))
+            ):
+                raise StatusAttributeError(name) from ae
+            else:
+                raise
+        return obj
+
+    def __getitem__(cls, name):
+        try:
+            return super().__getitem__(name)
+        except KeyError as ke:
+            raise StatusKeyError(name) from ke
+
+
+class TwisterStatus(str, Enum, metaclass=TwisterStatusEnumMeta):
     def __str__(self):
         return str(self.value)
 
@@ -21,6 +44,8 @@ class TwisterStatus(str, Enum):
         super()._missing_(value)
         if value is None:
             return TwisterStatus.NONE
+        elif value not in cls._value2member_map_:
+            raise StatusInitError(value)
 
     @staticmethod
     def get_color(status: TwisterStatus) -> str:

--- a/scripts/pylib/twister/twisterlib/statuses.py
+++ b/scripts/pylib/twister/twisterlib/statuses.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from enum import Enum, EnumMeta
 
 from colorama import Fore
-from twisterlib.error import StatusAttributeError, StatusInitError, StatusKeyError
+from pylib.twister.twisterlib.error import StatusAttributeError, StatusInitError, StatusKeyError
 
 
 class TwisterStatusEnumMeta(EnumMeta):

--- a/scripts/pylib/twister/twisterlib/testinstance.py
+++ b/scripts/pylib/twister/twisterlib/testinstance.py
@@ -21,7 +21,7 @@ from twisterlib.constants import (
     SUPPORTED_SIMS_WITH_EXEC,
 )
 from twisterlib.environment import TwisterEnv
-from twisterlib.error import BuildError, StatusAttributeError
+from twisterlib.error import BuildError, StatusAssignmentError
 from twisterlib.handlers import (
     BinaryHandler,
     DeviceHandler,
@@ -120,7 +120,7 @@ class TestInstance:
             key = value.name if isinstance(value, Enum) else value
             self._status = TwisterStatus[key]
         except KeyError as err:
-            raise StatusAttributeError(self.__class__, value) from err
+            raise StatusAssignmentError(self.__class__, value) from err
 
     def add_filter(self, reason, filter_type):
         self.filters.append({'type': filter_type, 'reason': reason })

--- a/scripts/pylib/twister/twisterlib/testinstance.py
+++ b/scripts/pylib/twister/twisterlib/testinstance.py
@@ -15,13 +15,13 @@ import os
 import random
 from enum import Enum
 
+from pylib.twister.twisterlib.error import BuildError, StatusAssignmentError
 from twisterlib.constants import (
     SUPPORTED_SIMS,
     SUPPORTED_SIMS_IN_PYTEST,
     SUPPORTED_SIMS_WITH_EXEC,
 )
 from twisterlib.environment import TwisterEnv
-from twisterlib.error import BuildError, StatusAssignmentError
 from twisterlib.handlers import (
     BinaryHandler,
     DeviceHandler,

--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -29,8 +29,8 @@ except ImportError:
 
 import list_boards
 import scl
+from pylib.twister.twisterlib.error import TwisterRuntimeError
 from twisterlib.config_parser import TwisterConfigParser
-from twisterlib.error import TwisterRuntimeError
 from twisterlib.platform import Platform
 from twisterlib.quarantine import Quarantine
 from twisterlib.statuses import TwisterStatus

--- a/scripts/pylib/twister/twisterlib/testsuite.py
+++ b/scripts/pylib/twister/twisterlib/testsuite.py
@@ -12,8 +12,12 @@ import re
 from enum import Enum
 from pathlib import Path
 
+from pylib.twister.twisterlib.error import (
+    StatusAssignmentError,
+    TwisterException,
+    TwisterRuntimeError,
+)
 from twisterlib.environment import canonical_zephyr_base
-from twisterlib.error import StatusAssignmentError, TwisterException, TwisterRuntimeError
 from twisterlib.mixins import DisablePyTestCollectionMixin
 from twisterlib.statuses import TwisterStatus
 

--- a/scripts/pylib/twister/twisterlib/testsuite.py
+++ b/scripts/pylib/twister/twisterlib/testsuite.py
@@ -13,7 +13,7 @@ from enum import Enum
 from pathlib import Path
 
 from twisterlib.environment import canonical_zephyr_base
-from twisterlib.error import StatusAttributeError, TwisterException, TwisterRuntimeError
+from twisterlib.error import StatusAssignmentError, TwisterException, TwisterRuntimeError
 from twisterlib.mixins import DisablePyTestCollectionMixin
 from twisterlib.statuses import TwisterStatus
 
@@ -401,7 +401,7 @@ class TestCase(DisablePyTestCollectionMixin):
             key = value.name if isinstance(value, Enum) else value
             self._status = TwisterStatus[key]
         except KeyError as err:
-            raise StatusAttributeError(self.__class__, value) from err
+            raise StatusAssignmentError(self.__class__, value) from err
 
     def __lt__(self, other):
         return self.name < other.name
@@ -469,7 +469,7 @@ class TestSuite(DisablePyTestCollectionMixin):
             key = value.name if isinstance(value, Enum) else value
             self._status = TwisterStatus[key]
         except KeyError as err:
-            raise StatusAttributeError(self.__class__, value) from err
+            raise StatusAssignmentError(self.__class__, value) from err
 
     def load(self, data):
         for k, v in data.items():

--- a/scripts/tests/twister/test_errors.py
+++ b/scripts/tests/twister/test_errors.py
@@ -11,7 +11,7 @@ import re
 import pytest
 
 from pathlib import Path
-from twisterlib.error import (
+from pylib.twister.twisterlib.error import (
     StatusAttributeError,
     StatusAssignmentError,
     StatusInitError,

--- a/scripts/tests/twister/test_errors.py
+++ b/scripts/tests/twister/test_errors.py
@@ -7,12 +7,19 @@ Tests for the error classes
 """
 
 import os
+import re
 import pytest
 
 from pathlib import Path
-from twisterlib.error import StatusAttributeError
-from twisterlib.error import ConfigurationError
+from twisterlib.error import (
+    StatusAttributeError,
+    StatusAssignmentError,
+    StatusInitError,
+    StatusKeyError,
+    ConfigurationError
+)
 from twisterlib.harness import Test
+from twisterlib.statuses import TwisterStatus
 
 
 def test_configurationerror():
@@ -25,11 +32,43 @@ def test_configurationerror():
         raise ConfigurationError(cfile, message)
 
 
-def test_status_value_error():
+def test_status_assignment_error():
     harness = Test()
 
-    expected_err = 'Test assigned status OK,' \
-                   ' which could not be cast to a TwisterStatus.'
+    expected_err = 'Test assigned status "OK", which could not be cast to a TwisterStatus.'
+
+    with pytest.raises(StatusAssignmentError, match=expected_err):
+        harness.status = "OK"
+
+
+def test_status_attribute_error():
+    harness = Test()
+
+    expected_err = (
+        'Attempted access to nonexistent TwisterStatus.OK. Please verify the status list.'
+    )
 
     with pytest.raises(StatusAttributeError, match=expected_err):
-        harness.status = "OK"
+        harness.status = TwisterStatus.OK
+
+
+def test_status_init_error():
+    harness = Test()
+
+    expected_err = (
+        'Attempted initialisation of status "OK", which could not be cast to a TwisterStatus.'
+    )
+
+    with pytest.raises(StatusInitError, match=expected_err):
+        harness.status = TwisterStatus("OK")
+
+
+def test_status_key_error():
+    harness = Test()
+
+    expected_err = re.escape(
+        'Attempted access to nonexistent TwisterStatus[OK]. Please verify the status list.'
+    )
+
+    with pytest.raises(StatusKeyError, match=expected_err):
+        harness.status = TwisterStatus["OK"]

--- a/scripts/tests/twister/test_handlers.py
+++ b/scripts/tests/twister/test_handlers.py
@@ -25,7 +25,7 @@ import twisterlib.harness
 
 ZEPHYR_BASE = os.getenv("ZEPHYR_BASE")
 
-from twisterlib.error import TwisterException
+from pylib.twister.twisterlib.error import TwisterException
 from twisterlib.statuses import TwisterStatus
 from twisterlib.handlers import (
     Handler,

--- a/scripts/tests/twister/test_runner.py
+++ b/scripts/tests/twister/test_runner.py
@@ -24,8 +24,8 @@ from typing import List
 ZEPHYR_BASE = os.getenv("ZEPHYR_BASE")
 sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts/pylib/twister"))
 
+from pylib.twister.twisterlib.error import BuildError
 from twisterlib.statuses import TwisterStatus
-from twisterlib.error import BuildError
 from twisterlib.harness import Pytest
 
 from twisterlib.runner import (

--- a/scripts/tests/twister/test_testinstance.py
+++ b/scripts/tests/twister/test_testinstance.py
@@ -16,10 +16,10 @@ import mock
 ZEPHYR_BASE = os.getenv("ZEPHYR_BASE")
 sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts/pylib/twister"))
 
+from pylib.twister.twisterlib.error import BuildError
 from pylib.twister.twisterlib.platform import Simulator
 from twisterlib.statuses import TwisterStatus
 from twisterlib.testinstance import TestInstance
-from twisterlib.error import BuildError
 from twisterlib.runner import TwisterRunner
 from twisterlib.handlers import QEMUHandler
 from expr_parser import reserved

--- a/scripts/tests/twister/test_testplan.py
+++ b/scripts/tests/twister/test_testplan.py
@@ -16,13 +16,13 @@ from contextlib import nullcontext
 ZEPHYR_BASE = os.getenv("ZEPHYR_BASE")
 sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts/pylib/twister"))
 
+from pylib.twister.twisterlib.error import TwisterRuntimeError
 from twisterlib.statuses import TwisterStatus
 from twisterlib.testplan import TestPlan, change_skip_to_error_if_integration
 from twisterlib.testinstance import TestInstance
 from twisterlib.testsuite import TestSuite
 from twisterlib.platform import Platform
 from twisterlib.quarantine import Quarantine
-from twisterlib.error import TwisterRuntimeError
 
 
 def test_testplan_add_testsuites_short(class_testplan):

--- a/scripts/tests/twister/test_testsuite.py
+++ b/scripts/tests/twister/test_testsuite.py
@@ -17,6 +17,7 @@ from contextlib import nullcontext
 ZEPHYR_BASE = os.getenv('ZEPHYR_BASE')
 sys.path.insert(0, os.path.join(ZEPHYR_BASE, 'scripts', 'pylib', 'twister'))
 
+from pylib.twister.twisterlib.error import TwisterException, TwisterRuntimeError
 from twisterlib.statuses import TwisterStatus
 from twisterlib.testsuite import (
     _find_src_dir_path,
@@ -28,7 +29,6 @@ from twisterlib.testsuite import (
     TestCase,
     TestSuite
 )
-from twisterlib.error import TwisterException, TwisterRuntimeError
 
 
 TESTDATA_1 = [

--- a/scripts/tests/twister/test_twister.py
+++ b/scripts/tests/twister/test_twister.py
@@ -17,8 +17,8 @@ from pathlib import Path
 ZEPHYR_BASE = os.getenv("ZEPHYR_BASE")
 sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts/pylib/twister"))
 
+from pylib.twister.twisterlib.error import ConfigurationError
 import scl
-from twisterlib.error import ConfigurationError
 from twisterlib.testplan import TwisterConfigParser
 
 def test_yamlload():

--- a/scripts/tests/twister_blackbox/test_error.py
+++ b/scripts/tests/twister_blackbox/test_error.py
@@ -15,8 +15,8 @@ import re
 
 # pylint: disable=no-name-in-module
 from conftest import ZEPHYR_BASE, TEST_DATA, testsuite_filename_mock
+from pylib.twister.twisterlib.error import TwisterRuntimeError
 from twisterlib.testplan import TestPlan
-from twisterlib.error import TwisterRuntimeError
 
 
 class TestError:

--- a/scripts/tests/twister_blackbox/test_testplan.py
+++ b/scripts/tests/twister_blackbox/test_testplan.py
@@ -15,8 +15,8 @@ import json
 
 # pylint: disable=no-name-in-module
 from conftest import ZEPHYR_BASE, TEST_DATA, testsuite_filename_mock
+from pylib.twister.twisterlib.error import TwisterRuntimeError
 from twisterlib.testplan import TestPlan
-from twisterlib.error import TwisterRuntimeError
 
 
 class TestTestPlan:


### PR DESCRIPTION
TwisterStatus now should not crash on wrong assignments of type: TwisterStatus.NONEXISTENT_STATUS and
TwisterStatus('NONEXISTENT_STATUS') and instead fail the current test and go on.

Two new errors were created in order to give users more information.

Fixes #80866 

## Further comparison:

### Case 1 - `self.instance.status = "PASA"`

Previously:
```
ERROR   - Twister call stack dump:
  <full call stack>
ERROR   - TestInstance assigned status PASA, which could not be cast to a TwisterStatus.
ERROR   - qemu_x86/atom             tests/kernel/mutex/mutex_api/kernel.mutex          ERROR: Incorrect status assignment
ERROR   - see: <ZEPHYR_BASE>/twister-out/qemu_x86_atom/tests/kernel/mutex/mutex_api/kernel.mutex/build.log
```
Now:
The same as above.

### Case 2 - `self.instance.status = TwisterStatus.PASA`

Previously:
```
ERROR   - General exception: PASA
ERROR   - Process 2254707 failed, aborting execution
```

Now:
```
ERROR   - Attempted access to nonexistent TwisterStatus.PASA. Please verify the status list.
ERROR   - qemu_x86/atom             tests/kernel/mutex/mutex_api/kernel.mutex          ERROR: Incorrect status assignment
ERROR   - see: <ZEPHYR_BASE>/twister-out/qemu_x86_atom/tests/kernel/mutex/mutex_api/kernel.mutex/build.log
```

### Case 3 - `self.instance.status = TwisterStatus('pass')`

Previously:
```
ERROR   - General exception: 'pass' is not a valid TwisterStatus
ERROR   - Process 2256571 failed, aborting execution
```

Now:
```
ERROR   - Twister call stack dump:
  <full call stack>
ERROR   - Attempted initialisation of status pass, which could not be cast to a TwisterStatus.
ERROR   - qemu_x86/atom             tests/kernel/mutex/mutex_api/kernel.mutex          ERROR: Incorrect status assignment
ERROR   - see: <ZEPHYR_BASE>/twister-out/qemu_x86_atom/tests/kernel/mutex/mutex_api/kernel.mutex/build.log
```

### Case 4 - `self.instance.status = TwisterStatus['pass']`