### PR TITLE
include: binding defines MCO division factor for stm32U5

### DIFF
--- a/include/zephyr/dt-bindings/clock/stm32u5_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32u5_clock.h
@@ -139,4 +139,11 @@
 #define MCO1_SEL(val)           STM32_MCO_CFGR(val, 0xF, 24, CFGR1_REG)
 #define MCO1_PRE(val)           STM32_MCO_CFGR(val, 0x7, 28, CFGR1_REG)
 
+/* MCO prescaler : division factor */
+#define MCO_PRE_DIV_1  0
+#define MCO_PRE_DIV_2  1
+#define MCO_PRE_DIV_4  2
+#define MCO_PRE_DIV_8  3
+#define MCO_PRE_DIV_16 4
+
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32U5_CLOCK_H_ */


### PR DESCRIPTION
On the stm32U5 serie the MCO prescaler is a value set in the CFGR1 register to divide the MCO output clock. 
See the RefMan for accepted values for this stm32U5 serie


The _#define MCO_PRE_DIV_n_ is not easily put in the stm32_common_clocks.h since it is not really common to all the stm32 series 
