### PR TITLE
boards: st: nucleo_h745zi_q: m7: add missing zephyr,canbus chosen

### DIFF
--- a/boards/st/nucleo_h745zi_q/nucleo_h745zi_q_stm32h745xx_m7.dts
+++ b/boards/st/nucleo_h745zi_q/nucleo_h745zi_q_stm32h745xx_m7.dts
@@ -26,6 +26,7 @@
 		zephyr,dtcm = &dtcm;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
+		zephyr,canbus = &fdcan1;
 	};
 
 	pwmleds {


### PR DESCRIPTION
Add missing zephyr,canbus chosen property.

Fixes: e68c7f2f73a36405ad8d15b57380f53cabcc2fcd