### PR TITLE
Bluetooth: Audio: set correct project name in CMakeList.txt

### DIFF
--- a/tests/bluetooth/audio/bap_broadcast_source/CMakeLists.txt
+++ b/tests/bluetooth/audio/bap_broadcast_source/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.20.0)
 
 find_package(Zephyr COMPONENTS unittest HINTS $ENV{ZEPHYR_BASE})
 
-project(bluetooth_ascs)
+project(bluetooth_bap_broadcast_source)
 
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/audio/bap_broadcast_source/uut uut)
 

--- a/tests/bluetooth/audio/cap_commander/CMakeLists.txt
+++ b/tests/bluetooth/audio/cap_commander/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.20.0)
 
 find_package(Zephyr COMPONENTS unittest HINTS $ENV{ZEPHYR_BASE})
 
-project(bluetooth_ascs)
+project(bluetooth_cap_commander)
 
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/audio/cap_commander/uut uut)
 

--- a/tests/bluetooth/audio/cap_initiator/CMakeLists.txt
+++ b/tests/bluetooth/audio/cap_initiator/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.20.0)
 
 find_package(Zephyr COMPONENTS unittest HINTS $ENV{ZEPHYR_BASE})
 
-project(bluetooth_ascs)
+project(bluetooth_cap_initiator)
 
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/audio/cap_initiator/uut uut)
 


### PR DESCRIPTION
Some of the unittests had an incorrect project name in the CMakeList.txt file This is corrected here