### PR TITLE
MAINTAINERS: NXP: Split some drivers to their own areas, and remove danieldegrasse

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -2219,6 +2219,16 @@ Release Notes:
   labels:
     - "area: Wi-Fi"
 
+"Drivers: Wi-Fi NXP":
+  status: maintained
+  maintainers:
+    - dleach02
+    - MaochenWang1
+  files:
+    - drivers/wifi/nxp/
+  labels:
+    - "platform: NXP Drivers"
+
 "Drivers: Memory Management":
   status: maintained
   maintainers:
@@ -3691,6 +3701,8 @@ NXP Drivers:
     - include/zephyr/drivers/*/*mcux*
     - arch/arm/core/mpu/nxp_mpu.c
     - dts/bindings/*/nxp*
+  files-exclude:
+    - drivers/wifi/nxp/
   files-regex-exclude:
     - .*s32.*
   labels:

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3680,7 +3680,6 @@ NXP Drivers:
     - decsny
     - manuargue
     - dbaluta
-    - MarkWangChinese
   files-regex:
     - ^drivers/.*nxp.*
     - ^drivers/.*mcux.*
@@ -3703,11 +3702,23 @@ NXP Drivers:
     - dts/bindings/*/nxp*
   files-exclude:
     - drivers/wifi/nxp/
+    - drivers/usb/*/*mcux*
   files-regex-exclude:
     - .*s32.*
   labels:
     - "platform: NXP Drivers"
   description: NXP Drivers
+
+NXP MCUX USB:
+  status: maintained
+  maintainers:
+    - mmahadevan108
+    - MarkWangChinese
+  files:
+    - drivers/usb/*/*mcux*
+  labels:
+    - "platform: NXP Drivers"
+  description: NXP MCUX USB shim drivers
 
 NXP Platforms (MCU):
   status: maintained

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3676,7 +3676,6 @@ NXP Drivers:
     - dleach02
     - mmahadevan108
   collaborators:
-    - danieldegrasse
     - decsny
     - manuargue
     - dbaluta
@@ -3726,7 +3725,6 @@ NXP Platforms (MCU):
     - dleach02
     - mmahadevan108
   collaborators:
-    - danieldegrasse
     - DerekSnell
     - yvanderv
     - EmilioCBen
@@ -3788,7 +3786,6 @@ NXP Platforms (MPU):
     - dleach02
     - dbaluta
     - iuliana-prodan
-    - danieldegrasse
     - yvanderv
   files:
     - dts/arm64/nxp/
@@ -4790,7 +4787,7 @@ West:
     - dleach02
     - mmahadevan108
   collaborators:
-    - danieldegrasse
+    - decsny
     - manuargue
     - PetervdPerk-NXP
     - bperseghetti


### PR DESCRIPTION
4 Changes:

1. NXP WIFI driver is primarily maintained by @MaochenWang1 and their colleagues, it falling under the "NXP Drivers" area will only request a lot of people that cannot help review this code.

2. NXP MCUX shim driver is primarily maintained by @MarkWangChinese who contributed the UDC drivers, and @mmahadevan108 being familiar with the legacy drivers for the same IP. Split this also to a new area for the same reason as the wifi.

3. Add myself to the hal_nxp west project area.

4. Remove @danieldegrasse from all NXP maintenance areas.