### PR TITLE
tests: Bluetooth: Tester: More logging and verification for ISO RX

### DIFF
--- a/tests/bluetooth/tester/src/audio/btp_bap_broadcast.c
+++ b/tests/bluetooth/tester/src/audio/btp_bap_broadcast.c
@@ -11,6 +11,7 @@
 #include <errno.h>
 
 #include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/iso.h>
 #include <zephyr/types.h>
 #include <zephyr/kernel.h>
 #include <zephyr/sys/ring_buffer.h>
@@ -175,11 +176,16 @@ static void stream_recv(struct bt_bap_stream *stream,
 		/* For now, send just a first packet, to limit the number
 		 * of logs and not unnecessarily spam through btp.
 		 */
-		LOG_DBG("Incoming audio on stream %p len %u", stream, buf->len);
-		b_stream->already_sent = true;
-		broadcaster = &remote_broadcast_sources[b_stream->source_id];
-		send_bis_stream_received_ev(&broadcaster->address, broadcaster->broadcast_id,
-					    b_stream->bis_id, buf->len, buf->data);
+		LOG_DBG("Incoming audio on stream %p len %u flags 0x%02X seq_num %u and ts %u",
+			stream, buf->len, info->flags, info->seq_num, info->ts);
+
+		if ((info->flags & BT_ISO_FLAGS_VALID) == 0) {
+			b_stream->already_sent = true;
+			broadcaster = &remote_broadcast_sources[b_stream->source_id];
+			send_bis_stream_received_ev(&broadcaster->address,
+						    broadcaster->broadcast_id, b_stream->bis_id,
+						    buf->len, buf->data);
+		}
 	}
 }
 

--- a/tests/bluetooth/tester/src/audio/btp_bap_unicast.c
+++ b/tests/bluetooth/tester/src/audio/btp_bap_unicast.c
@@ -9,6 +9,7 @@
 #include <stddef.h>
 #include <errno.h>
 
+#include <zephyr/bluetooth/iso.h>
 #include <zephyr/types.h>
 #include <zephyr/kernel.h>
 #include <zephyr/sys/ring_buffer.h>
@@ -712,9 +713,13 @@ static void stream_recv(struct bt_bap_stream *stream,
 		/* For now, send just a first packet, to limit the number
 		 * of logs and not unnecessarily spam through btp.
 		 */
-		LOG_DBG("Incoming audio on stream %p len %u", stream, buf->len);
-		u_stream->already_sent = true;
-		send_stream_received_ev(stream->conn, stream->ep, buf->len, buf->data);
+		LOG_DBG("Incoming audio on stream %p len %u flags 0x%02X seq_num %u and ts %u",
+			stream, buf->len, info->flags, info->seq_num, info->ts);
+
+		if ((info->flags & BT_ISO_FLAGS_VALID) == 0) {
+			u_stream->already_sent = true;
+			send_stream_received_ev(stream->conn, stream->ep, buf->len, buf->data);
+		}
 	}
 }
 


### PR DESCRIPTION
Add additional data to the logs and only send the event once we have receive a successful SDU.