### PR TITLE
video: samples: i.MX RT10xx: Do not use PxP to flip images

### DIFF
--- a/samples/drivers/video/capture/Kconfig
+++ b/samples/drivers/video/capture/Kconfig
@@ -22,6 +22,11 @@ config VIDEO_PIXEL_FORMAT
 	help
 	  Pixel format of the video frame. If not set, the default pixel format is used.
 
+config VIDEO_CTRL_HFLIP
+	bool "Mirror the video frame horizontally"
+	help
+	  If set, mirror the video frame horizontally
+
 endmenu
 
 source "Kconfig.zephyr"

--- a/samples/drivers/video/capture/boards/mimxrt1060_evkb.conf
+++ b/samples/drivers/video/capture/boards/mimxrt1060_evkb.conf
@@ -1,4 +1,2 @@
-# Leverage PXP to mirror image by flipping
-CONFIG_DMA=y
-CONFIG_MCUX_ELCDIF_PXP=y
-CONFIG_MCUX_ELCDIF_PXP_FLIP_HORIZONTAL=y
+# Mirror video images horizontally
+CONFIG_VIDEO_CTRL_HFLIP=y

--- a/samples/drivers/video/capture/boards/mimxrt1064_evk.conf
+++ b/samples/drivers/video/capture/boards/mimxrt1064_evk.conf
@@ -1,4 +1,2 @@
-# Leverage PXP to mirror image by flipping
-CONFIG_DMA=y
-CONFIG_MCUX_ELCDIF_PXP=y
-CONFIG_MCUX_ELCDIF_PXP_FLIP_HORIZONTAL=y
+# Mirror video images horizontally
+CONFIG_VIDEO_CTRL_HFLIP=y

--- a/samples/drivers/video/capture/src/main.c
+++ b/samples/drivers/video/capture/src/main.c
@@ -9,13 +9,12 @@
 
 #include <zephyr/drivers/display.h>
 #include <zephyr/drivers/video.h>
+#include <zephyr/drivers/video-controls.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(main);
 
 #ifdef CONFIG_TEST
-#include <zephyr/drivers/video-controls.h>
-
 #include "check_test_pattern.h"
 
 #define LOG_LEVEL LOG_LEVEL_DBG
@@ -177,6 +176,11 @@ int main(void)
 			       fie.stepwise.step.numerator, fie.stepwise.step.denominator);
 		}
 		fie.index++;
+	}
+
+	/* Set controls */
+	if (IS_ENABLED(CONFIG_VIDEO_CTRL_HFLIP)) {
+		video_set_ctrl(video_dev, VIDEO_CID_HFLIP, (void *)1);
 	}
 
 #ifdef CONFIG_TEST


### PR DESCRIPTION
On RT10xx, do horizontal flipping at camera level to avoid using PxP which impacts camera framerates. Moreover, on RT11xx, PxP is already reserved for 90 CCW image rotation for LCD display purpose.

This will **work on mt9m114 only when** https://github.com/zephyrproject-rtos/zephyr/pull/81830 is merged.