### PR TITLE
drivers: led: is31fl3194.c fix uninitialized scalar variable

### DIFF
--- a/drivers/led/is31fl3194.c
+++ b/drivers/led/is31fl3194.c
@@ -109,7 +109,7 @@ static int is31fl3194_set_color(const struct device *dev, uint32_t led, uint8_t 
 			break;
 		default:
 			/* unreachable: mapping already tested in is31fl3194_check_config */
-			continue;
+			return -EINVAL;
 		}
 
 		ret = i2c_reg_write_byte_dt(&config->bus, led_channels[i], value);


### PR DESCRIPTION
in the switch case in the preceeding for loop if default path is taken all the time, then the ret variable will stay uninitialized, the original contributor of this driver has provided a comment that this path shall never be reached, however, it is better to return an error code instead of continuing with an incorrect configuration, hence this commit replaces continue with a proper return errono.