### PR TITLE
drivers: haptics: drv2605 fix unchecked return value

### DIFF
--- a/drivers/haptics/drv2605.c
+++ b/drivers/haptics/drv2605.c
@@ -498,16 +498,18 @@ static int drv2605_reset(const struct device *dev)
 	k_msleep(100);
 
 	while (retries > 0) {
-		i2c_reg_read_byte_dt(&config->i2c, DRV2605_REG_MODE, &value);
+		retries--;
+
+		ret = i2c_reg_read_byte_dt(&config->i2c, DRV2605_REG_MODE, &value);
+		if (ret < 0) {
+			k_usleep(10000);
+			continue;
+		}
 
 		if ((value & DRV2605_DEV_RESET) == 0U) {
 			i2c_reg_update_byte_dt(&config->i2c, DRV2605_REG_MODE, DRV2605_STANDBY, 0);
 			return 0;
 		}
-
-		retries--;
-
-		k_usleep(10000);
 	}
 
 	return -ETIMEDOUT;


### PR DESCRIPTION
return -EIO if i2c_read does not work as expected.