### PR TITLE
tests: drivers: build_all: gpio: Test handling plural "compatible"s

### DIFF
--- a/drivers/gpio/gpio_mcp230xx.c
+++ b/drivers/gpio/gpio_mcp230xx.c
@@ -75,15 +75,15 @@ static int mcp230xx_bus_is_ready(const struct device *dev)
 	return 0;
 }
 
-#define GPIO_MCP230XX_DEVICE(inst, num_gpios, open_drain)                                          \
-	static struct mcp23xxx_drv_data mcp230xx_##inst##_drvdata = {                              \
+#define GPIO_MCP230XX_DEVICE(inst, num_gpios, open_drain, model)                                   \
+	static struct mcp23xxx_drv_data mcp##model##_##inst##_drvdata = {                          \
 		/* Default for registers according to datasheet */                                 \
 		.reg_cache.iodir = 0xFFFF, .reg_cache.ipol = 0x0,   .reg_cache.gpinten = 0x0,      \
 		.reg_cache.defval = 0x0,   .reg_cache.intcon = 0x0, .reg_cache.iocon = 0x0,        \
 		.reg_cache.gppu = 0x0,     .reg_cache.intf = 0x0,   .reg_cache.intcap = 0x0,       \
 		.reg_cache.gpio = 0x0,     .reg_cache.olat = 0x0,                                  \
 	};                                                                                         \
-	static const struct mcp23xxx_config mcp230xx_##inst##_config = {                           \
+	static const struct mcp23xxx_config mcp##model##_##inst##_config = {                       \
 		.config = {                                                                        \
 			.port_pin_mask = GPIO_PORT_PIN_MASK_FROM_DT_INST(inst),                    \
 		},                                                                                 \
@@ -98,22 +98,22 @@ static int mcp230xx_bus_is_ready(const struct device *dev)
 		.write_fn = mcp230xx_write_port_regs,                                              \
 		.bus_fn = mcp230xx_bus_is_ready,                                                   \
 	};                                                                                         \
-	DEVICE_DT_INST_DEFINE(inst, gpio_mcp23xxx_init, NULL, &mcp230xx_##inst##_drvdata,          \
-		&mcp230xx_##inst##_config, POST_KERNEL,                                            \
+	DEVICE_DT_INST_DEFINE(inst, gpio_mcp23xxx_init, NULL, &mcp##model##_##inst##_drvdata,      \
+		&mcp##model##_##inst##_config, POST_KERNEL,                                        \
 		CONFIG_GPIO_MCP230XX_INIT_PRIORITY, &gpio_mcp23xxx_api_table);
 
 #define DT_DRV_COMPAT microchip_mcp23008
-DT_INST_FOREACH_STATUS_OKAY_VARGS(GPIO_MCP230XX_DEVICE, 8, false)
+DT_INST_FOREACH_STATUS_OKAY_VARGS(GPIO_MCP230XX_DEVICE, 8, false, 23008)
 #undef DT_DRV_COMPAT
 #define DT_DRV_COMPAT microchip_mcp23009
-DT_INST_FOREACH_STATUS_OKAY_VARGS(GPIO_MCP230XX_DEVICE, 8, true)
+DT_INST_FOREACH_STATUS_OKAY_VARGS(GPIO_MCP230XX_DEVICE, 8, true, 23009)
 #undef DT_DRV_COMPAT
 #define DT_DRV_COMPAT microchip_mcp23016
-DT_INST_FOREACH_STATUS_OKAY_VARGS(GPIO_MCP230XX_DEVICE, 16, false)
+DT_INST_FOREACH_STATUS_OKAY_VARGS(GPIO_MCP230XX_DEVICE, 16, false, 23016)
 #undef DT_DRV_COMPAT
 #define DT_DRV_COMPAT microchip_mcp23017
-DT_INST_FOREACH_STATUS_OKAY_VARGS(GPIO_MCP230XX_DEVICE, 16, false)
+DT_INST_FOREACH_STATUS_OKAY_VARGS(GPIO_MCP230XX_DEVICE, 16, false, 23017)
 #undef DT_DRV_COMPAT
 #define DT_DRV_COMPAT microchip_mcp23018
-DT_INST_FOREACH_STATUS_OKAY_VARGS(GPIO_MCP230XX_DEVICE, 16, true)
+DT_INST_FOREACH_STATUS_OKAY_VARGS(GPIO_MCP230XX_DEVICE, 16, true, 23018)
 #undef DT_DRV_COMPAT

--- a/drivers/gpio/gpio_mcp23sxx.c
+++ b/drivers/gpio/gpio_mcp23sxx.c
@@ -113,20 +113,20 @@ static int mcp23sxx_bus_is_ready(const struct device *dev)
 	return 0;
 }
 
-#define GPIO_MCP23SXX_DEVICE(inst, num_gpios, open_drain)                                     \
-	static struct mcp23xxx_drv_data mcp23sxx_##inst##_drvdata = {                         \
+#define GPIO_MCP23SXX_DEVICE(inst, num_gpios, open_drain, model)                              \
+	static struct mcp23xxx_drv_data mcp##model##_##inst##_drvdata = {                     \
 		/* Default for registers according to datasheet */                            \
 		.reg_cache.iodir = 0xFFFF, .reg_cache.ipol = 0x0,   .reg_cache.gpinten = 0x0, \
 		.reg_cache.defval = 0x0,   .reg_cache.intcon = 0x0, .reg_cache.iocon = 0x0,   \
 		.reg_cache.gppu = 0x0,	   .reg_cache.intf = 0x0,   .reg_cache.intcap = 0x0,  \
 		.reg_cache.gpio = 0x0,	   .reg_cache.olat = 0x0,                             \
 	};                                                                                    \
-	static struct mcp23xxx_config mcp23sxx_##inst##_config = {                            \
+	static struct mcp23xxx_config mcp##model##_##inst##_config = {                        \
 		.config = {					                              \
-			.port_pin_mask = GPIO_PORT_PIN_MASK_FROM_DT_INST(inst),                  \
+			.port_pin_mask = GPIO_PORT_PIN_MASK_FROM_DT_INST(inst),               \
 		},						                              \
 		.bus = {                                                                      \
-			.spi = SPI_DT_SPEC_INST_GET(inst,                                        \
+			.spi = SPI_DT_SPEC_INST_GET(inst,                                     \
 				SPI_OP_MODE_MASTER | SPI_MODE_CPOL |                          \
 				SPI_MODE_CPHA | SPI_WORD_SET(8), 0)                           \
 		},                                                                            \
@@ -138,20 +138,20 @@ static int mcp23sxx_bus_is_ready(const struct device *dev)
 		.write_fn = mcp23sxx_write_port_regs,                                         \
 		.bus_fn = mcp23sxx_bus_is_ready                                               \
 	};                                                                                    \
-	DEVICE_DT_INST_DEFINE(inst, gpio_mcp23xxx_init, NULL, &mcp23sxx_##inst##_drvdata,        \
-			      &mcp23sxx_##inst##_config, POST_KERNEL,                         \
+	DEVICE_DT_INST_DEFINE(inst, gpio_mcp23xxx_init, NULL, &mcp##model##_##inst##_drvdata, \
+			      &mcp##model##_##inst##_config, POST_KERNEL,                     \
 			      CONFIG_GPIO_MCP23SXX_INIT_PRIORITY, &gpio_mcp23xxx_api_table);
 
 
 #define DT_DRV_COMPAT microchip_mcp23s08
-DT_INST_FOREACH_STATUS_OKAY_VARGS(GPIO_MCP23SXX_DEVICE, 8, false)
+DT_INST_FOREACH_STATUS_OKAY_VARGS(GPIO_MCP23SXX_DEVICE, 8, false, 23s08)
 #undef DT_DRV_COMPAT
 #define DT_DRV_COMPAT microchip_mcp23s09
-DT_INST_FOREACH_STATUS_OKAY_VARGS(GPIO_MCP23SXX_DEVICE, 8, true)
+DT_INST_FOREACH_STATUS_OKAY_VARGS(GPIO_MCP23SXX_DEVICE, 8, true, 23s09)
 #undef DT_DRV_COMPAT
 #define DT_DRV_COMPAT microchip_mcp23s17
-DT_INST_FOREACH_STATUS_OKAY_VARGS(GPIO_MCP23SXX_DEVICE, 16, false)
+DT_INST_FOREACH_STATUS_OKAY_VARGS(GPIO_MCP23SXX_DEVICE, 16, false, 23s17)
 #undef DT_DRV_COMPAT
 #define DT_DRV_COMPAT microchip_mcp23s18
-DT_INST_FOREACH_STATUS_OKAY_VARGS(GPIO_MCP23SXX_DEVICE, 16, true)
+DT_INST_FOREACH_STATUS_OKAY_VARGS(GPIO_MCP23SXX_DEVICE, 16, true, 23s18)
 #undef DT_DRV_COMPAT

--- a/tests/drivers/build_all/gpio/app.overlay
+++ b/tests/drivers/build_all/gpio/app.overlay
@@ -410,6 +410,56 @@
 					reset-gpios = <&test_gpio 0 0>;
 				};
 			};
+
+			test_i2c_mcp23008: mcp23008@17 {
+				compatible = "microchip,mcp23008";
+				reg = <0x17>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				ngpios = <16>;
+			};
+
+			test_i2c_mcp23009: mcp23009@18 {
+				compatible = "microchip,mcp23009";
+				reg = <0x18>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				ngpios = <16>;
+			};
+
+			test_i2c_mcp23016: mcp23016@19 {
+				compatible = "microchip,mcp23016";
+				reg = <0x19>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				ngpios = <16>;
+			};
+
+			test_i2c_mcp23018: mcp23016@1a {
+				compatible = "microchip,mcp23018";
+				reg = <0x1a>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				ngpios = <16>;
+			};
+
+			test_i2c_pca9554: pca9554@1b {
+				compatible = "nxp,pca9554";
+				reg = <0x1b>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				ngpios = <8>;
+				int-gpios = <&test_gpio 0 0>;
+			};
+
+			test_i2c_pca9555: pca9555@1c {
+				compatible = "nxp,pca9555";
+				reg = <0x1c>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				ngpios = <16>;
+				int-gpios = <&test_gpio 0 0>;
+			};
 		};
 
 		nct3807_alert_1 {
@@ -434,6 +484,8 @@
 				    &test_gpio 0 0
 				    &test_gpio 0 0
 				    &test_gpio 0 0
+				    &test_gpio 0 0
+				    &test_gpio 0 0
 				    &test_gpio 0 0>;
 
 			test_spi_mcp23s17: mcp23s17@0 {
@@ -445,8 +497,8 @@
 				ngpios = <16>;
 			};
 
-			test_spi_mcp23sxx: mcp23sxx@1 {
-				compatible = "microchip,mcp23sxx";
+			test_spi_mcp23sxx: mcp23s18@1 {
+				compatible = "microchip,mcp23s18";
 				spi-max-frequency = <0>;
 				reg = <0x01>;
 				gpio-controller;
@@ -553,6 +605,25 @@
 				sync-gpios = <&test_gpio 0 0>;
 				en-gpios = <&test_gpio 0 0>;
 			};
+
+			test_spi_mcp23s08: mcp23s08@8 {
+				compatible = "microchip,mcp23s08";
+				spi-max-frequency = <0>;
+				reg = <0x08>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				ngpios = <16>;
+			};
+
+			test_spi_mcp23s09: mcp23s09@9 {
+				compatible = "microchip,mcp23s09";
+				spi-max-frequency = <0>;
+				reg = <0x09>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				ngpios = <16>;
+			};
+
 		};
 	};
 };


### PR DESCRIPTION
Add device definitions in dt to test drivers that handle
multiple "compatible"s by a single driver.

MCP23xxx failed to compile in such a state.
I fixed this isssue.