### PR TITLE
dts: bindings: memc: stm32: correct the SDRAM base address description

### DIFF
--- a/dts/bindings/memory-controllers/st,stm32-fmc-sdram.yaml
+++ b/dts/bindings/memory-controllers/st,stm32-fmc-sdram.yaml
@@ -58,14 +58,14 @@ description: |
   sdram1: sdram@c0000000 {
       compatible = "zephyr,memory-region", "mmio-sram";
       device_type = "memory";
-      reg = <0xc000000 DT_SIZE_M(X)>;
+      reg = <0xc0000000 DT_SIZE_M(X)>;
       zephyr,memory-region = "SDRAM1";
   };
 
   sdram2: sdram@d0000000 {
       compatible = "zephyr,memory-region", "mmio-sram";
       device_type = "memory";
-      reg = <0xd000000 DT_SIZE_M(X)>;
+      reg = <0xd0000000 DT_SIZE_M(X)>;
       zephyr,memory-region = "SDRAM2";
   };
 


### PR DESCRIPTION
Catch the DTS warning by copying the SDRAM node in description:

unit address and first address in 'reg' (0xc000000) don't match for /sdram@c0000000