### PR TITLE
tests: drivers: build_all: sensors: Test handling plural "compatible"s 

### DIFF
--- a/drivers/sensor/sensirion/scd4x/scd4x.c
+++ b/drivers/sensor/sensirion/scd4x/scd4x.c
@@ -889,14 +889,14 @@ static DEVICE_API(sensor, scd4x_api_funcs) = {
 };
 
 #define SCD4X_INIT(inst, scd4x_model)                                                              \
-	static struct scd4x_data scd4x_data_##inst;                                                \
-	static const struct scd4x_config scd4x_config_##inst = {                                   \
+	static struct scd4x_data scd4x_data_##scd4x_model##_##inst;                                \
+	static const struct scd4x_config scd4x_config_##scd4x_model##_##inst = {                   \
 		.bus = I2C_DT_SPEC_INST_GET(inst),                                                 \
 		.model = scd4x_model,                                                              \
 		.mode = DT_INST_ENUM_IDX_OR(inst, mode, SCD4X_MODE_NORMAL),                        \
 	};                                                                                         \
-	SENSOR_DEVICE_DT_INST_DEFINE(inst, scd4x_init, NULL, &scd4x_data_##inst,                   \
-				     &scd4x_config_##inst, POST_KERNEL,                            \
+	SENSOR_DEVICE_DT_INST_DEFINE(inst, scd4x_init, NULL, &scd4x_data_##scd4x_model##_##inst,   \
+				     &scd4x_config_##scd4x_model##_##inst, POST_KERNEL,            \
 				     CONFIG_SENSOR_INIT_PRIORITY, &scd4x_api_funcs);
 
 #define DT_DRV_COMPAT sensirion_scd40

--- a/drivers/sensor/st/lsm6dso/Kconfig
+++ b/drivers/sensor/st/lsm6dso/Kconfig
@@ -6,10 +6,12 @@
 menuconfig LSM6DSO
 	bool "LSM6DSO I2C/SPI accelerometer and gyroscope Chip"
 	default y
-	depends on DT_HAS_ST_LSM6DSO_ENABLED
+	depends on DT_HAS_ST_LSM6DSO_ENABLED || DT_HAS_ST_LSM6DSO32_ENABLED
 	depends on ZEPHYR_HAL_ST_MODULE
-	select I2C if $(dt_compat_on_bus,$(DT_COMPAT_ST_LSM6DSO),i2c)
-	select SPI if $(dt_compat_on_bus,$(DT_COMPAT_ST_LSM6DSO),spi)
+	select I2C if $(dt_compat_on_bus,$(DT_COMPAT_ST_LSM6DSO),i2c) || \
+		      $(dt_compat_on_bus,$(DT_COMPAT_ST_LSM6DSO32),i2c)
+	select SPI if $(dt_compat_on_bus,$(DT_COMPAT_ST_LSM6DSO),spi) || \
+		      $(dt_compat_on_bus,$(DT_COMPAT_ST_LSM6DSO32),spi)
 	select HAS_STMEMSC
 	select USE_STDC_LSM6DSO
 	help

--- a/drivers/sensor/st/lsm6dso/lsm6dso.h
+++ b/drivers/sensor/st/lsm6dso/lsm6dso.h
@@ -19,13 +19,15 @@
 #include <stmemsc.h>
 #include "lsm6dso_reg.h"
 
-#if DT_ANY_INST_ON_BUS_STATUS_OKAY(spi)
+#if DT_HAS_COMPAT_ON_BUS_STATUS_OKAY(st_lsm6dso, spi) || \
+	DT_HAS_COMPAT_ON_BUS_STATUS_OKAY(st_lsm6dso32, spi)
 #include <zephyr/drivers/spi.h>
-#endif /* DT_ANY_INST_ON_BUS_STATUS_OKAY(spi) */
+#endif
 
-#if DT_ANY_INST_ON_BUS_STATUS_OKAY(i2c)
+#if DT_HAS_COMPAT_ON_BUS_STATUS_OKAY(st_lsm6dso, i2c) || \
+	DT_HAS_COMPAT_ON_BUS_STATUS_OKAY(st_lsm6dso32, i2c)
 #include <zephyr/drivers/i2c.h>
-#endif /* DT_ANY_INST_ON_BUS_STATUS_OKAY(i2c) */
+#endif
 
 #define LSM6DSO_EN_BIT					0x01
 #define LSM6DSO_DIS_BIT					0x00
@@ -39,10 +41,12 @@
 struct lsm6dso_config {
 	stmdev_ctx_t ctx;
 	union {
-#if DT_ANY_INST_ON_BUS_STATUS_OKAY(i2c)
+#if DT_HAS_COMPAT_ON_BUS_STATUS_OKAY(st_lsm6dso, i2c) || \
+	DT_HAS_COMPAT_ON_BUS_STATUS_OKAY(st_lsm6dso32, i2c)
 		const struct i2c_dt_spec i2c;
 #endif
-#if DT_ANY_INST_ON_BUS_STATUS_OKAY(spi)
+#if DT_HAS_COMPAT_ON_BUS_STATUS_OKAY(st_lsm6dso, spi) || \
+	DT_HAS_COMPAT_ON_BUS_STATUS_OKAY(st_lsm6dso32, spi)
 		const struct spi_dt_spec spi;
 #endif
 	} stmemsc_cfg;

--- a/tests/drivers/build_all/sensor/i2c.dtsi
+++ b/tests/drivers/build_all/sensor/i2c.dtsi
@@ -1130,11 +1130,11 @@ test_i2c_ilps22qs: ilps22qs@9c {
 
 test_i2c_sts4x: sts4x@9d {
 	compatible = "sensirion,sts4x";
-	reg = <0x99>;
+	reg = <0x9d>;
 	repeatability = <2>;
 };
 
-test_i2c_scd4x: scd4x@9e {
+test_i2c_scd41: scd41@9e {
 	compatible = "sensirion,scd41";
 	reg = <0x9e>;
 	mode = <0>;
@@ -1147,4 +1147,41 @@ test_i2c_npm2100: npm2100@9f {
 	vbat {
 		compatible = "nordic,npm2100-vbat";
 	};
+};
+
+test_i2c_scd40: scd40@a1 {
+	compatible = "sensirion,scd40";
+	reg = <0xa1>;
+};
+
+test_i2c_ina236: ina236@a2 {
+	compatible = "ti,ina236";
+	reg = <0xa2>;
+	current-lsb-microamps = <1000>;
+	rshunt-micro-ohms = <1000>;
+	mask = <0>;
+	alert-limit = <0>;
+	alert-gpios = <&test_gpio 0 0>;
+};
+
+test_i2c_as6212: as6212@a3 {
+	compatible = "ams,as6212";
+	reg = <0xa3>;
+};
+
+test_i2c_p3t1755: p3t1755@a4 {
+	compatible = "nxp,p3t1755";
+	reg = <0xa4>;
+};
+
+test_i2c_lsm6dso32: lsm6dso32@a5 {
+	compatible = "st,lsm6dso32";
+	reg = <0xa5>;
+	irq-gpios = <&test_gpio 0 0>;
+	accel-pm = <LSM6DSO_DT_XL_ULP_MODE>;
+	accel-range = <LSM6DSO_DT_FS_8G>;
+	accel-odr = <LSM6DSO_DT_ODR_1Hz6>;
+	gyro-pm = <LSM6DSO_DT_GY_NORMAL_MODE>;
+	gyro-range = <LSM6DSO_DT_FS_2000DPS>;
+	gyro-odr = <LSM6DSO_DT_ODR_6667Hz>;
 };


### PR DESCRIPTION
Add device definitions in dt to test drivers that handle
multiple "compatible"s by a single driver.

And fix the scd4x and lsm6dso issues found in adding these tests.

