### PR TITLE
drivers: spi: Explicitly cast void* for C++ compatibility

### DIFF
--- a/include/zephyr/drivers/spi.h
+++ b/include/zephyr/drivers/spi.h
@@ -1056,7 +1056,7 @@ static inline int spi_write_signal(const struct device *dev,
  */
 static inline void spi_iodev_submit(struct rtio_iodev_sqe *iodev_sqe)
 {
-	const struct spi_dt_spec *dt_spec = iodev_sqe->sqe.iodev->data;
+	const struct spi_dt_spec *dt_spec = (const struct spi_dt_spec *)iodev_sqe->sqe.iodev->data;
 	const struct device *dev = dt_spec->bus;
 	const struct spi_driver_api *api = (const struct spi_driver_api *)dev->api;
 
@@ -1091,7 +1091,7 @@ extern const struct rtio_iodev_api spi_iodev_api;
  */
 static inline bool spi_is_ready_iodev(const struct rtio_iodev *spi_iodev)
 {
-	struct spi_dt_spec *spec = spi_iodev->data;
+	struct spi_dt_spec *spec = (struct spi_dt_spec *)spi_iodev->data;
 
 	return spi_is_ready_dt(spec);
 }


### PR DESCRIPTION
Fixes two isolated instances of implicit void pointer casting in spi.h. While this is legal in C, it causes a compiler warning in C++.