### PR TITLE
tests: drivers: build_all: ethernet: Test handling plural "compatible"s 

### DIFF
--- a/tests/drivers/build_all/ethernet/app.overlay
+++ b/tests/drivers/build_all/ethernet/app.overlay
@@ -49,6 +49,36 @@
 					int-gpios = <&test_gpio 0 0>;
 					microchip,interface-type = "rmii";
 				};
+
+				ethernet-phy@3 {
+					reg = <0x3>;
+					compatible = "microchip,ksz8794";
+					status = "okay";
+					reset-gpios = <&test_gpio 0 0>;
+					int-gpios = <&test_gpio 0 0>;
+					microchip,interface-type = "rmii";
+				};
+
+				ethernet-phy@4 {
+					reg = <0x4>;
+					compatible = "microchip,ksz8863";
+					status = "okay";
+					reset-gpios = <&test_gpio 0 0>;
+					int-gpios = <&test_gpio 0 0>;
+					microchip,interface-type = "rmii";
+				};
+
+				ethernet-phy@5 {
+					reg = <0x5>;
+					compatible = "adi,adin1100-phy";
+					status = "okay";
+				};
+
+				ethernet-phy@6 {
+					reg = <0x6>;
+					compatible = "adi,adin2111-phy";
+					status = "okay";
+				};
 			};
 		};
 	};


### PR DESCRIPTION
Add device definitions in dt to test drivers that handle
multiple "compatible"s by a single driver.

phy_adin2111 failed to compile in such a state.
I fixed this isssue.