### PR TITLE
drivers: sensors: ti_hdc20xx: Remove unexists `ti,hdc20xx` compatible

### DIFF
--- a/dts/bindings/sensor/ti,hdc20xx.yaml
+++ b/dts/bindings/sensor/ti,hdc20xx.yaml
@@ -3,8 +3,6 @@
 
 description: Texas Instruments HDC20XX Temperature and Humidity Sensor
 
-compatible: "ti,hdc20xx"
-
 include: [sensor-device.yaml, i2c-device.yaml]
 
 properties:


### PR DESCRIPTION
`hdc20xx` is a common definition for TI HDC20xx series, so the `hdc20xx` device does not exists.
Remove the compatible.