### PR TITLE
logging: increase the maximum value of LOG_BUFFER_SIZE

### DIFF
--- a/subsys/logging/Kconfig.processing
+++ b/subsys/logging/Kconfig.processing
@@ -122,7 +122,7 @@ endif # LOG_PROCESS_THREAD
 config LOG_BUFFER_SIZE
 	int "Number of bytes dedicated for the logger internal buffer"
 	default 1024
-	range 128 65536
+	range 128 1048576
 	help
 	  Number of bytes dedicated for the logger internal buffer.
 


### PR DESCRIPTION
Increase the maximum value of LOG_BUFFER_SIZE from 64 KB to 1 MB to accommodate varying device requirements.