### PR TITLE
shell: add function to get device by name or label

### DIFF
--- a/drivers/gpio/Kconfig
+++ b/drivers/gpio/Kconfig
@@ -17,7 +17,6 @@ source "subsys/logging/Kconfig.template.log_config"
 config GPIO_SHELL
 	bool "GPIO Shell"
 	depends on SHELL
-	imply DEVICE_DT_METADATA
 	help
 	  Enable GPIO Shell for testing.
 

--- a/drivers/gpio/gpio_shell.c
+++ b/drivers/gpio/gpio_shell.c
@@ -134,9 +134,10 @@ DT_FOREACH_STATUS_OKAY_NODE(IS_GPIO_CTRL_PIN_GET)
 
 static const struct gpio_ctrl gpio_list[] = {DT_FOREACH_STATUS_OKAY_NODE(IS_GPIO_CTRL_LIST)};
 
-static const struct gpio_ctrl *get_gpio_ctrl_helper(const struct device *dev)
+static const struct gpio_ctrl *get_gpio_ctrl(const char *name)
 {
 	size_t i;
+	const struct device *dev = shell_device_get_binding(name);
 
 	if (dev == NULL) {
 		return NULL;
@@ -147,29 +148,6 @@ static const struct gpio_ctrl *get_gpio_ctrl_helper(const struct device *dev)
 			return &gpio_list[i];
 		}
 	}
-
-	return NULL;
-}
-
-/* Look up a device by some human-readable string identifier. We
- * always search among device names. If the feature is available, we
- * search by node label as well.
- */
-static const struct gpio_ctrl *get_gpio_ctrl(char *id)
-{
-	const struct gpio_ctrl *ctrl;
-
-	ctrl = get_gpio_ctrl_helper(device_get_binding(id));
-	if (ctrl != NULL) {
-		return ctrl;
-	}
-
-#ifdef CONFIG_DEVICE_DT_METADATA
-	ctrl = get_gpio_ctrl_helper(device_get_by_dt_nodelabel(id));
-	if (ctrl != NULL) {
-		return ctrl;
-	}
-#endif	/* CONFIG_DEVICE_DT_METADATA */
 
 	return NULL;
 }

--- a/include/zephyr/shell/shell.h
+++ b/include/zephyr/shell/shell.h
@@ -160,6 +160,28 @@ const struct device *shell_device_filter(size_t idx,
 					 shell_device_filter_t filter);
 
 /**
+ * @brief Get a @ref device reference from its @ref device.name field or label.
+ *
+ * This function iterates through the devices on the system. If a device with
+ * the given @p name field is found, and that device initialized successfully at
+ * boot time, this function returns a pointer to the device.
+ *
+ * If no device has the given @p name, this function returns `NULL`.
+ *
+ * This function also returns NULL when a device is found, but it failed to
+ * initialize successfully at boot time. (To troubleshoot this case, set a
+ * breakpoint on your device driver's initialization function.)
+ *
+ * @param name device name to search for. A null pointer, or a pointer to an
+ * empty string, will cause NULL to be returned.
+ *
+ * @return pointer to device structure with the given name; `NULL` if the device
+ * is not found or if the device with that name's initialization function
+ * failed.
+ */
+const struct device *shell_device_get_binding(const char *name);
+
+/**
  * @brief Shell command handler prototype.
  *
  * @param sh Shell instance.

--- a/subsys/shell/Kconfig
+++ b/subsys/shell/Kconfig
@@ -25,6 +25,11 @@ config SHELL_MINIMAL
 	  defaults which favor reduced flash or memory requirements over extra
 	  features.
 
+config SHELL_DEVICE_HELPERS
+	bool "Shell device helpers"
+	imply DEVICE_DT_METADATA
+	default y if !SHELL_MINIMAL
+
 config SHELL_THREAD_PRIORITY_OVERRIDE
 	bool "Override default shell thread priority"
 	help

--- a/subsys/shell/shell_utils.c
+++ b/subsys/shell/shell_utils.c
@@ -536,6 +536,17 @@ const struct device *shell_device_lookup(size_t idx,
 	return shell_device_internal(idx, prefix, NULL);
 }
 
+const struct device *shell_device_get_binding(const char *name)
+{
+	const struct device *dev = device_get_binding(name);
+
+	if (IS_ENABLED(CONFIG_DEVICE_DT_METADATA) && dev == NULL) {
+		dev = device_get_by_dt_nodelabel(name);
+	}
+
+	return dev;
+}
+
 long shell_strtol(const char *str, int base, int *err)
 {
 	long val;


### PR DESCRIPTION
Added shell_device_get_binding() that wraps device_get_binding() plus device_get_by_dt_nodelabel() so that a shell can easily get a device by its full name or label.

I changed `gpio_shell.c` to use this function as an example. After this merges we can change it everywhere.