### PR TITLE
Bluetooth: Controller: Fix BT_LLL_VENDOR_NORDIC dependency

### DIFF
--- a/subsys/bluetooth/controller/CMakeLists.txt
+++ b/subsys/bluetooth/controller/CMakeLists.txt
@@ -195,13 +195,11 @@ zephyr_library_include_directories_ifdef(
 zephyr_library_include_directories_ifdef(
   CONFIG_BT_LLL_VENDOR_NORDIC
   ll_sw/nordic
-  ll_sw/nordic/hci
   )
 
 zephyr_library_include_directories_ifdef(
   CONFIG_BT_LLL_VENDOR_OPENISA
   ll_sw/openisa
-  ll_sw/openisa/hci
   )
 
 add_subdirectory_ifdef(

--- a/subsys/bluetooth/controller/Kconfig.ll_sw_split
+++ b/subsys/bluetooth/controller/Kconfig.ll_sw_split
@@ -7,9 +7,12 @@ if BT_LL_SW_SPLIT
 
 config BT_LLL_VENDOR_NORDIC
 	bool "Use Nordic LLL"
-	depends on SOC_COMPATIBLE_NRF
-	depends on !$(dt_nodelabel_enabled,timer0)
-	depends on !$(dt_nodelabel_enabled,rtc0)
+	depends on SOC_COMPATIBLE_NRF && \
+		   !$(dt_nodelabel_enabled,timer0) && \
+		   !$(dt_nodelabel_enabled,timer1) && \
+		   !$(dt_nodelabel_enabled,timer4) && \
+		   !$(dt_nodelabel_enabled,timer10) && \
+		   !$(dt_nodelabel_enabled,rtc0)
 
 	select BT_CTLR_ENTROPY_SUPPORT if !SOC_COMPATIBLE_NRF54LX || BOARD_NRF54L15BSIM
 	select FAKE_ENTROPY_NATIVE_POSIX if BT_CTLR_ENTROPY && BOARD_NRF54L15BSIM

--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -76,7 +76,7 @@
 #include "ll_settings.h"
 
 #include "hci_internal.h"
-#include "hci_vendor.h"
+#include "hci/hci_vendor.h"
 
 #if defined(CONFIG_BT_HCI_MESH_EXT)
 #include "ll_sw/ll_mesh.h"


### PR DESCRIPTION
Fix BT_LLL_VENDOR_NORDIC dependency to check timer 0, 1, 4
10, and rtc0 not used by the application.

Use include hci/hci_vendor.h instead of hci_vendor.h.