### PR TITLE
mks_canable_v20: fix fdcan1 clock select

### DIFF
--- a/boards/makerbase/mks_canable_v20/mks_canable_v20.dts
+++ b/boards/makerbase/mks_canable_v20/mks_canable_v20.dts
@@ -81,7 +81,7 @@ zephyr_udc0: &usb {
 &fdcan1 {
 	pinctrl-0 = <&fdcan1_rx_pb8 &fdcan1_tx_pb9>;
 	pinctrl-names = "default";
-	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00001000>,
+	clocks = <&rcc STM32_CLOCK(APB1, 25U)>,
 		 <&rcc STM32_SRC_PLL_Q FDCAN_SEL(1)>;
 	status = "okay";
 };


### PR DESCRIPTION
Use STM32_CLOCK() clock select macro with bit-25 set.
This change shall set register RCC_CCIPR->FDCANSEL to 0x01.
Previosuly there were bit-12 set, which was wrong. For more information refer to RM0440 Rev. 8 page 323 of 2138.