### PR TITLE
drivers: stepper: adi: tmc2209 minor fixes

### DIFF
--- a/drivers/stepper/adi_tmc/adi_tmc22xx_stepper_controller.c
+++ b/drivers/stepper/adi_tmc/adi_tmc22xx_stepper_controller.c
@@ -172,10 +172,9 @@ static DEVICE_API(stepper, tmc22xx_stepper_api) = {
 	static const struct tmc22xx_config tmc22xx_config_##inst = {                               \
 		.common = STEP_DIR_STEPPER_DT_INST_COMMON_CONFIG_INIT(inst),                       \
 		.enable_pin = GPIO_DT_SPEC_INST_GET(inst, enable_gpios),                           \
-		.msx_pins = DT_INST_NODE_HAS_PROP(inst, msx_gpios)                                 \
-				    ? tmc22xx_stepper_msx_pins_##inst                              \
-				    : NULL,                                                        \
 		.msx_resolutions = msx_table,                                                      \
+		IF_ENABLED(DT_INST_NODE_HAS_PROP(inst, msx_gpios),				   \
+		(.msx_pins = tmc22xx_stepper_msx_pins_##inst))					   \
 	};                                                                                         \
 	static struct tmc22xx_data tmc22xx_data_##inst = {                                         \
 		.common = STEP_DIR_STEPPER_DT_INST_COMMON_DATA_INIT(inst),                         \

--- a/drivers/stepper/step_dir_stepper_common.h
+++ b/drivers/stepper/step_dir_stepper_common.h
@@ -37,7 +37,7 @@ struct step_dir_stepper_common_config {
 #define STEP_DIR_STEPPER_DT_COMMON_CONFIG_INIT(node_id)                                            \
 	{                                                                                          \
 		.step_pin = GPIO_DT_SPEC_GET(node_id, step_gpios),                                 \
-		.dir_pin = GPIO_DT_SPEC_GET(node_id, direction_gpios),                             \
+		.dir_pin = GPIO_DT_SPEC_GET(node_id, dir_gpios),	                           \
 		.dual_edge = DT_PROP_OR(node_id, dual_edge_step, false),                           \
 	}
 

--- a/dts/bindings/stepper/adi/adi,tmc2209.yaml
+++ b/dts/bindings/stepper/adi/adi,tmc2209.yaml
@@ -11,7 +11,7 @@ description: |
       msx-gpios = <&gpio0 1 GPIO_ACTIVE_HIGH>,
                   <&gpio0 2 GPIO_ACTIVE_HIGH>;
       step-gpios = <&gpio0 3 GPIO_ACTIVE_HIGH>;
-      direction-gpios = <&gpio0 4 GPIO_ACTIVE_HIGH>;
+      dir-gpios = <&gpio0 4 GPIO_ACTIVE_HIGH>;
       dual-edge-step;
   }
 
@@ -22,7 +22,7 @@ include:
     property-allowlist:
       - micro-step-res
       - step-gpios
-      - direction-gpios
+      - dir-gpios
 
 properties:
   enable-gpios:

--- a/dts/bindings/stepper/stepper-controller.yaml
+++ b/dts/bindings/stepper/stepper-controller.yaml
@@ -30,7 +30,7 @@ properties:
     description: |
       The GPIO pins used to send step signals to the stepper motor.
 
-  direction-gpios:
+  dir-gpios:
     type: phandle-array
     description: |
       The GPIO pins used to send direction signals to the stepper motor.

--- a/tests/drivers/build_all/stepper/gpio.dtsi
+++ b/tests/drivers/build_all/stepper/gpio.dtsi
@@ -21,5 +21,5 @@ test_tmc2209: tmc2209_motor {
 		    <&test_gpio 0 0>;
 	enable-gpios = <&test_gpio 0 0>;
 	step-gpios = <&test_gpio 0 0>;
-	direction-gpios = <&test_gpio 0 0>;
+	dir-gpios = <&test_gpio 0 0>;
 };


### PR DESCRIPTION
1. The current implementation of tmc2209 driver does not allow instantiation of the driver without configuring msx pins.
   _(Found by removing msx_gpios from overlay and then could not compile the driver)_

2. Second Commit renames direction-gpios to dir-gpios since STEP/DIR is a well established term in context of stepper controllers
