### PR TITLE
drivers: sensor: ti: ina230: Fix shared data between instances

### DIFF
--- a/drivers/sensor/ti/ina23x/ina230.c
+++ b/drivers/sensor/ti/ina23x/ina230.c
@@ -249,7 +249,7 @@ static DEVICE_API(sensor, ina230_driver_api) = {
 #endif /* CONFIG_INA230_TRIGGER */
 
 #define INA230_DRIVER_INIT(inst, type)                                                             \
-	static struct ina230_data drv_data_##inst;                                                 \
+	static struct ina230_data drv_data_##type##inst;                                           \
 	static const struct ina230_config drv_config_##type##inst = {                              \
 		.bus = I2C_DT_SPEC_INST_GET(inst),                                                 \
 		.config = (DT_INST_PROP_OR(inst, high_precision, 0) << 12) |                       \
@@ -266,7 +266,7 @@ static DEVICE_API(sensor, ina230_driver_api) = {
 				  (DT_INST_PROP_OR(inst, high_precision, 0) << 1)),                \
 		COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, alert_gpios), (INA230_CFG_IRQ(inst)),      \
 			    ())};   \
-	SENSOR_DEVICE_DT_INST_DEFINE(inst, &ina230_init, NULL, &drv_data_##inst,                   \
+	SENSOR_DEVICE_DT_INST_DEFINE(inst, &ina230_init, NULL, &drv_data_##type##inst,             \
 				     &drv_config_##type##inst, POST_KERNEL,                        \
 				     CONFIG_SENSOR_INIT_PRIORITY, &ina230_driver_api);
 


### PR DESCRIPTION
This commit fixes a shared context between multiple instances of the INA230 and INA236 driver. The issue is the naming of the instance data in `INA230_DRIVER_INIT` macro when we have one instance of INA230 and one of INA236 the name of the data variable will be `drv_data_0`. This variable will then be passed to both instances.