### PR TITLE
spi: context: update state when already locked

### DIFF
--- a/drivers/spi/spi_context.h
+++ b/drivers/spi/spi_context.h
@@ -96,12 +96,10 @@ static inline void spi_context_lock(struct spi_context *ctx,
 			      (k_sem_count_get(&ctx->lock) == 0) &&
 			      (ctx->owner == spi_cfg);
 
-	if (already_locked) {
-		return;
+	if (!already_locked) {
+		k_sem_take(&ctx->lock, K_FOREVER);
+		ctx->owner = spi_cfg;
 	}
-
-	k_sem_take(&ctx->lock, K_FOREVER);
-	ctx->owner = spi_cfg;
 
 #ifdef CONFIG_SPI_ASYNC
 	ctx->asynchronous = asynchronous;

--- a/drivers/spi/spi_context.h
+++ b/drivers/spi/spi_context.h
@@ -92,10 +92,12 @@ static inline void spi_context_lock(struct spi_context *ctx,
 				    void *callback_data,
 				    const struct spi_config *spi_cfg)
 {
-	if ((spi_cfg->operation & SPI_LOCK_ON) &&
-		(k_sem_count_get(&ctx->lock) == 0) &&
-		(ctx->owner == spi_cfg)) {
-			return;
+	bool already_locked = (spi_cfg->operation & SPI_LOCK_ON) &&
+			      (k_sem_count_get(&ctx->lock) == 0) &&
+			      (ctx->owner == spi_cfg);
+
+	if (already_locked) {
+		return;
 	}
 
 	k_sem_take(&ctx->lock, K_FOREVER);


### PR DESCRIPTION
Update the context state parameters when the context is already locked.
This allows changing the callback information for asynchronous
operations while the context is locked.