### PR TITLE
samples: basic: blinky_pwm: Add support for nucleo_wba55cg

### DIFF
--- a/boards/st/nucleo_wba55cg/nucleo_wba55cg.dts
+++ b/boards/st/nucleo_wba55cg/nucleo_wba55cg.dts
@@ -43,6 +43,14 @@
 		};
 	};
 
+	pwmleds: pwmleds {
+		compatible = "pwm-leds";
+
+		green_pwm_led: green_pwm_led {
+			pwms = <&pwm3 2 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
+		};
+	};
+
 	gpio_keys {
 		compatible = "gpio-keys";
 		user_button_1: button_0 {
@@ -66,6 +74,7 @@
 		led0 = &blue_led_1;
 		led1 = &green_led_2;
 		led2 = &red_led_3;
+		pwm-led0 = &green_pwm_led;
 		sw0 = &user_button_1;
 		sw1 = &user_button_2;
 		sw2 = &user_button_3;
@@ -154,6 +163,17 @@
 
 &die_temp {
 	status = "okay";
+};
+
+&timers3 {
+	st,prescaler = <10000>;
+	status = "okay";
+
+	pwm3: pwm {
+		status = "okay";
+		pinctrl-0 = <&tim3_ch2_pa9>;
+		pinctrl-names = "default";
+	};
 };
 
 stm32_lp_tick_source: &lptim1 {


### PR DESCRIPTION
Added configuration to the nucleo_wba55cg overlay to enable support for the blinky_pwm demo. This includes the configuration of timers3 and pwm3 nodes.