### PR TITLE
Bluetooth: BAP: Fix BIS_Sync value in update_recv_state_base

### DIFF
--- a/subsys/bluetooth/audio/bap_broadcast_sink.c
+++ b/subsys/bluetooth/audio/bap_broadcast_sink.c
@@ -542,10 +542,9 @@ static void update_recv_state_base(const struct bt_bap_broadcast_sink *sink,
 	mod_src_param.num_subgroups = sink->subgroup_count;
 	for (uint8_t i = 0U; i < sink->subgroup_count; i++) {
 		struct bt_bap_bass_subgroup *subgroup_param = &mod_src_param.subgroups[i];
-		const struct bt_bap_broadcast_sink_subgroup *sink_subgroup = &sink->subgroups[i];
 
-		/* Set the bis_sync value to the indexes available per subgroup */
-		subgroup_param->bis_sync = sink_subgroup->bis_indexes & sink->indexes_bitfield;
+		/* Leave the bis_sync unchanged */
+		subgroup_param->bis_sync = recv_state->subgroups[i].bis_sync;
 	}
 
 	err = bt_bap_scan_delegator_mod_src(&mod_src_param);


### PR DESCRIPTION
The BASE doesn't affect the BIS sync value, and should thus not change it.

This fixes a bug where the broadcast sink may prematurely set the BIS sync value to e.g. 1 before actually
syncing to the BIG.