### PR TITLE
wifi: fix warning on wifi_ps_exit_strategy_txt

### DIFF
--- a/include/zephyr/net/wifi.h
+++ b/include/zephyr/net/wifi.h
@@ -586,7 +586,7 @@ enum wifi_ps_exit_strategy {
 };
 
 /** Helper function to get user-friendly ps exit strategy name. */
-const char * const wifi_ps_exit_strategy_txt(enum wifi_ps_exit_strategy ps_exit_strategy);
+const char *wifi_ps_exit_strategy_txt(enum wifi_ps_exit_strategy ps_exit_strategy);
 
 /** @brief Wi-Fi power save error codes. */
 enum wifi_config_ps_param_fail_reason {

--- a/subsys/net/l2/wifi/wifi_mgmt.c
+++ b/subsys/net/l2/wifi/wifi_mgmt.c
@@ -292,7 +292,7 @@ const char *wifi_ps_wakeup_mode_txt(enum wifi_ps_wakeup_mode ps_wakeup_mode)
 	}
 }
 
-const char * const wifi_ps_exit_strategy_txt(enum wifi_ps_exit_strategy ps_exit_strategy)
+const char *wifi_ps_exit_strategy_txt(enum wifi_ps_exit_strategy ps_exit_strategy)
 {
 	switch (ps_exit_strategy) {
 	case WIFI_PS_EXIT_EVERY_TIM:


### PR DESCRIPTION
This commit fixes a warning when including wifi.h: type qualifiers ignored on function return type

I'm not sure about the significance of the removed const. It doesn't make any sense to me, which is perhaps why I get the warning