### PR TITLE
Bluetooth: Host: SMP: Verify public key before usage

### DIFF
--- a/subsys/bluetooth/host/ecc.h
+++ b/subsys/bluetooth/host/ecc.h
@@ -44,6 +44,16 @@ struct bt_pub_key_cb {
  */
 bool bt_pub_key_is_debug(uint8_t *cmp_pub_key);
 
+/*  @brief Check if public key is valid.
+ *
+ *  Verify that the public key is valid, e.g. that its coordinates lie on the eliptic curve.
+ *
+ *  @param key The public key to validate.
+ *
+ *  @return True if the public key is valid.
+ */
+bool bt_pub_key_is_valid(const uint8_t key[BT_PUB_KEY_LEN]);
+
 /*  @brief Generate a new Public Key.
  *
  *  Generate a new ECC Public Key. Provided cb must persists until callback

--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -4311,6 +4311,9 @@ static uint8_t smp_public_key(struct bt_smp *smp, struct net_buf *buf)
 		if (!update_debug_keys_check(smp)) {
 			return BT_SMP_ERR_AUTH_REQUIREMENTS;
 		}
+	} else if (!bt_pub_key_is_valid(smp->pkey)) {
+		LOG_WRN("Received invalid public key");
+		return BT_SMP_ERR_INVALID_PARAMS;
 	}
 
 	if (IS_ENABLED(CONFIG_BT_CENTRAL) &&


### PR DESCRIPTION
Add a separate test for public key validity. This needs to be done synchronously so that we can respond with an early failure message to the peer device.

Fixes #80218