### PR TITLE
subsys: bluetooth: host: enable `CONFIG_TEST_RANDOM_GENERATOR` when `!CONFIG_CSPRNG_ENABLED`

### DIFF
--- a/modules/mbedtls/CMakeLists.txt
+++ b/modules/mbedtls/CMakeLists.txt
@@ -7,8 +7,11 @@ if(CONFIG_MBEDTLS)
 zephyr_interface_library_named(mbedTLS)
 
   if(CONFIG_MBEDTLS_BUILTIN)
-    if(CONFIG_MBEDTLS_ENTROPY_POLL_ZEPHYR AND NOT CONFIG_ENTROPY_HAS_DRIVER)
-      message(WARNING "No entropy device on the system, using fake entropy source!")
+    if(CONFIG_MBEDTLS_ENTROPY_POLL_ZEPHYR AND NOT CONFIG_CSPRNG_ENABLED)
+      message(WARNING "
+        No HW random number generator device enabled, using a fake one!
+        Be aware that this source is extremely insecure when used in cryptographic
+        operations, so don't use this in production.")
     endif()
 
     if(CONFIG_MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG)

--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -179,9 +179,10 @@ config BT_HOST_CRYPTO
 config BT_HOST_CRYPTO_PRNG
 	bool "Use PSA crypto API library for random number generation"
 	default y
-	select PSA_WANT_ALG_SHA_256
-	select PSA_WANT_KEY_TYPE_HMAC
-	select PSA_WANT_ALG_HMAC
+	# Fallback for boards that do not have an HW entropy generator (i.e. CSPRNG_ENABLED).
+	# This is meant to be used for tests only, not in production, because generated
+	# random values might be predictable/extremely weak.
+	imply TEST_RANDOM_GENERATOR if !CSPRNG_ENABLED
 	depends on BT_HOST_CRYPTO
 	help
 	  When selected, will use PSA Crypto API library for random number generation.


### PR DESCRIPTION
On boards that do not have an HW entropy generator (i.e. `!CONFIG_CSPRNG_ENABLED`) enable `CONFIG_TEST_RANDOM_GENERATOR`.
    
Albeit from the randomness point of view this is a really bad idea, it allows all the BT samples/tests to be built on all the platforms. A message will be printed on the console when `CONFIG_TEST_RANDOM_GENERATOR`  is set warning the user that this configuration should be used _only_ for test purposes, not in production.

This PR also improves the warning message that it's printed when `CONFIG_MBEDTLS_ENTROPY_POLL_ZEPHYR && !CONFIG_CSPRNG_ENABLED`).

Resolves #82344 (the part not addressed by #82497).