### PR TITLE
dts: bindings: comparator: fix nrf-comp binding.

### DIFF
--- a/dts/bindings/comparator/nordic,nrf-comp.yaml
+++ b/dts/bindings/comparator/nordic,nrf-comp.yaml
@@ -30,7 +30,7 @@ description: |
             sp-mode = "NORMAL";
             th-up = <36>;
             th-down = <30>;
-            isource = "OFF";
+            isource = "DISABLED";
     };
 
   To select an external reference, select the "AREF"
@@ -52,8 +52,8 @@ description: |
             psel = "AIN0";
             extrefsel = "AIN1";
             sp-mode = "NORMAL";
-            hyst = "50MV";
-            isource = "OFF";
+            enable-hyst;
+            isource = "DISABLED";
     };
 
 compatible: "nordic,nrf-comp"

--- a/dts/bindings/comparator/nordic,nrf-lpcomp.yaml
+++ b/dts/bindings/comparator/nordic,nrf-lpcomp.yaml
@@ -23,7 +23,7 @@ description: |
             status = "okay";
             psel = "AIN0";
             refsel = "VDD_4_8";
-            hyst = "ENABLED";
+            enable-hyst;
     };
 
   To select an external reference, select the "AREF"


### PR DESCRIPTION
Fix binding so that it's description matches property list and it's allowed values.