### PR TITLE
tests: drivers: i2s_speed: port test to MIMXRT1060-EVKB board

### DIFF
--- a/tests/drivers/i2s/i2s_speed/Readme.txt
+++ b/tests/drivers/i2s/i2s_speed/Readme.txt
@@ -25,3 +25,14 @@ signals externally on the EVK.  These are the HW changes required to run this te
         - Short BCLK J1-pin9  (SAI1_RX_BCLK/P3_18) to J3-pin15 (SAI0_TX_BCLK/P2_6)
         - Short SYNC J1-pin13 (SAI1_RX_FS/P3_19)   to J3-pin13 (SAI0_TX_FS/P2_7)
         - Short Data J1-pin15 (SAI1_RXD0/P3_21)    to J3-pin7  (SAI0_TXD0/P2_2)
+
+MIMXRT1060-EVK[B/C]:
+This board uses a single SAI and connects the TX and RX signals by shorting externally on the EVK.
+These are the HW changes required to run this test on MIMXRT1060-EVK[B/C]:
+- Remove jumper J99
+- Short BCLK J23-pin5  (SAI1_RX_BCLK  / GPIO_AD_B1_11) to J23-pin23 (SAI1_TX_BCLK  / GPIO_AD_B1_14)
+- Short SYNC J23-pin9  (SAI1_RX_SYNC  / GPIO_AD_B1_10) to J23-pin16 (SAI1_TX_SYNC  / GPIO_AD_B1_15)
+- Short Data J23-pin11 (SAI1_RX_DATA0 / GPIO_AD_B1_12) to J23-pin17 (SAI1_TX_DATA0 / GPIO_AD_B1_13)
+
+- NOTE: these connections cause contention with the following signals/features:
+	- camera CSI_D[2-7]

--- a/tests/drivers/i2s/i2s_speed/boards/mimxrt1060_evk_mimxrt1062_qspi_B.conf
+++ b/tests/drivers/i2s/i2s_speed/boards/mimxrt1060_evk_mimxrt1062_qspi_B.conf
@@ -1,0 +1,21 @@
+#
+# Copyright (c) 2024, NXP
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+# CONFIG_DMA_TCD_QUEUE_SIZE sets size of queue used to chain DMA blocks (TCDs)
+# together, and should be sized as needed by the application.  If not large
+# enough, the DMA may starve.  Symptoms of this issue include transmit blocks
+# repeated, or RX blocks skipped. For I2S driver, queue size must be at least 3.
+CONFIG_DMA_TCD_QUEUE_SIZE=4
+
+# Repeat test continually to help find intermittent issues
+CONFIG_ZTEST_RETEST_IF_PASSED=y
+
+# I2S and DMA logging can occur in interrupt context, and interfere with I2S
+# stream timing.  If using either logging, set logging to deferred
+# CONFIG_LOG_MODE_DEFERRED=y
+
+CONFIG_DMA_LOG_LEVEL_OFF=y
+CONFIG_I2S_LOG_LEVEL_OFF=y

--- a/tests/drivers/i2s/i2s_speed/boards/mimxrt1060_evk_mimxrt1062_qspi_B.overlay
+++ b/tests/drivers/i2s/i2s_speed/boards/mimxrt1060_evk_mimxrt1062_qspi_B.overlay
@@ -1,0 +1,21 @@
+/ {
+	aliases {
+		i2s-node0 = &sai1;
+	};
+};
+
+&pinctrl {
+	pinmux_sai1: pinmux_sai1 {
+		group0 {
+			pinmux = <&iomuxc_gpio_ad_b1_12_sai1_rx_data0>,
+				<&iomuxc_gpio_ad_b1_11_sai1_rx_bclk>,
+				<&iomuxc_gpio_ad_b1_10_sai1_rx_sync>,
+				<&iomuxc_gpio_ad_b1_15_sai1_tx_sync>,
+				<&iomuxc_gpio_ad_b1_14_sai1_tx_bclk>,
+				<&iomuxc_gpio_ad_b1_13_sai1_tx_data0>;
+			drive-strength = "r0-6";
+			slew-rate = "slow";
+			nxp,speed = "100-mhz";
+		};
+	};
+};


### PR DESCRIPTION
Added board support for MIMXRT1060-EVKB board.  These hardware connections and build also pass the test on the EVKC revision.

Requires HAL update at https://github.com/zephyrproject-rtos/hal_nxp/pull/490 to pass the test.