### PR TITLE
BT central legacy OOB only warnings

### DIFF
--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -3654,8 +3654,8 @@ static bool le_sc_oob_data_rsp_check(struct bt_smp *smp)
 	return ((rsp->oob_flag & BT_SMP_OOB_DATA_MASK) == BT_SMP_OOB_PRESENT);
 }
 
-static void le_sc_oob_config_set(struct bt_smp *smp,
-				 struct bt_conn_oob_info *info)
+__maybe_unused static void le_sc_oob_config_set(struct bt_smp *smp,
+						struct bt_conn_oob_info *info)
 {
 	bool req_oob_present = le_sc_oob_data_req_check(smp);
 	bool rsp_oob_present = le_sc_oob_data_rsp_check(smp);
@@ -4184,7 +4184,7 @@ static uint8_t smp_security_request(struct bt_smp *smp, struct net_buf *buf)
 }
 #endif /* CONFIG_BT_CENTRAL */
 
-static uint8_t generate_dhkey(struct bt_smp *smp)
+__maybe_unused static uint8_t generate_dhkey(struct bt_smp *smp)
 {
 	if (IS_ENABLED(CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY)) {
 		return BT_SMP_ERR_UNSPECIFIED;
@@ -4198,7 +4198,7 @@ static uint8_t generate_dhkey(struct bt_smp *smp)
 	return 0;
 }
 
-static uint8_t display_passkey(struct bt_smp *smp)
+__maybe_unused static uint8_t display_passkey(struct bt_smp *smp)
 {
 	struct bt_conn *conn = smp->chan.chan.conn;
 	const struct bt_conn_auth_cb *smp_auth_cb = latch_auth_cb(smp);

--- a/tests/bluetooth/host_config_variants/testcase.yaml
+++ b/tests/bluetooth/host_config_variants/testcase.yaml
@@ -1,9 +1,27 @@
 tests:
   # Test that the Host builds with BT_SMP_OOB_LEGACY_PAIR_ONLY enabled
-  bluetooth.host_config_variants.config_bt_smp_oob_legacy_pair_only:
+  # and peripheral role
+  bluetooth.host_config_variants.config_peripheral_bt_smp_oob_legacy_pair_only:
     extra_configs:
       - CONFIG_BT_SMP=y
       - CONFIG_BT_PERIPHERAL=y
+      - CONFIG_BT_SMP_SC_PAIR_ONLY=n
+      - CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY=y
+    platform_allow:
+      - native_sim
+      - native_sim/native/64
+    integration_platforms:
+      - native_sim
+    tags:
+      - bluetooth
+    build_only: true
+
+  # Test that the Host builds with BT_SMP_OOB_LEGACY_PAIR_ONLY enabled
+  # and central role
+  bluetooth.host_config_variants.config_central_bt_smp_oob_legacy_pair_only:
+    extra_configs:
+      - CONFIG_BT_SMP=y
+      - CONFIG_BT_CENTRAL=y
       - CONFIG_BT_SMP_SC_PAIR_ONLY=n
       - CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY=y
     platform_allow:


### PR DESCRIPTION
Currently, there are build warnings that are triggered when building for BT central and legacy OOB pairing only:
```
CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY=y
CONFIG_BT_CENTRAL=y
```

There was a PR that handled this issue in the past https://github.com/zephyrproject-rtos/zephyr/pull/74400.
Unfortunately, this PR even though it fixed the warnings it also broke the BT peripheral and legacy OOB pairing only build:
```
CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY=y
CONFIG_BT_PERIPHERAL=y
```

https://github.com/zephyrproject-rtos/zephyr/pull/82552 was merged in order to fix the issue with the peripheral build configuration.
Unfortunately, this PR reintroduced the warnings for BT central and legacy OOB pairing.

This commit brings changes to make sure that both the BT central and peripheral builds with OOB legacy pairing are buildable and warnings free.

Also in this commit, a new build test case is added for the BT central and legacy OOB pairing along the existing BT peripheral test case