### PR TITLE
bluetooth: host: hci_core: fix `num_handles` assignment

### DIFF
--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -248,7 +248,7 @@ void bt_send_one_host_num_completed_packets(uint16_t handle)
 	BT_ASSERT_MSG(buf, "Unable to alloc for Host NCP");
 
 	cp = net_buf_add(buf, sizeof(*cp));
-	cp->num_handles = sys_cpu_to_le16(1);
+	cp->num_handles = 1;
 
 	hc = net_buf_add(buf, sizeof(*hc));
 	hc->handle = sys_cpu_to_le16(handle);


### PR DESCRIPTION
Replaced `sys_cpu_to_le16(1)` with a direct `1` assignment to the `cp->num_handles` (uint8_t) field to avoid truncation to `0x00` on big-endian architectures.