### PR TITLE
subsys: ipc: icbmsg: Add a workqueue name

### DIFF
--- a/subsys/ipc/ipc_service/backends/ipc_icbmsg.c
+++ b/subsys/ipc/ipc_service/backends/ipc_icbmsg.c
@@ -1251,6 +1251,7 @@ static int backend_init(const struct device *instance)
 #ifdef CONFIG_MULTITHREADING
 	static K_THREAD_STACK_DEFINE(ep_bound_work_q_stack, EP_BOUND_WORK_Q_STACK_SIZE);
 	static bool is_work_q_started;
+	struct k_work_queue_config work_q_cfg = { .name = "icbmsg_workq" };
 
 #if defined(CONFIG_ARCH_POSIX)
 	native_emb_addr_remap((void **)&conf->tx.blocks_ptr);
@@ -1261,7 +1262,7 @@ static int backend_init(const struct device *instance)
 		k_work_queue_init(&ep_bound_work_q);
 		k_work_queue_start(&ep_bound_work_q, ep_bound_work_q_stack,
 				   K_THREAD_STACK_SIZEOF(ep_bound_work_q_stack),
-				   EP_BOUND_WORK_Q_PRIORITY, NULL);
+				   EP_BOUND_WORK_Q_PRIORITY, &work_q_cfg);
 
 		is_work_q_started = true;
 	}


### PR DESCRIPTION
This allows to easily identify the workqueue thread when using the kernel shell commands.