### PR TITLE
Bluetooth: HFP_HF: implement bt_hfp_hf_get_peer_indicator_status

### DIFF
--- a/include/zephyr/bluetooth/classic/hfp_hf.h
+++ b/include/zephyr/bluetooth/classic/hfp_hf.h
@@ -179,6 +179,20 @@ int bt_hfp_hf_register(struct bt_hfp_hf_cb *cb);
  */
 int bt_hfp_hf_send_cmd(struct bt_conn *conn, enum bt_hfp_hf_at_cmd cmd);
 
+/** @brief Handsfree Get peer indicators' status
+ *
+ *  Get peer indicators' status to handsfree client profile, send the AT
+ *  command "AT+CIND?" to retrieve the current status of the HFP AG 
+ *  indicators, as well as the indicators listed in the "AT+CIND=?" 
+ *  command, and also call the user-registered callback in application 
+ *  accordingly.
+ *
+ *  @param conn Connection object.
+ *
+ *  @return 0 in case of success or negative value in case of error.
+ */
+int bt_hfp_hf_get_peer_indicator_status(struct bt_conn *conn);
+
 #ifdef __cplusplus
 }
 #endif

--- a/subsys/bluetooth/host/classic/hfp_hf.c
+++ b/subsys/bluetooth/host/classic/hfp_hf.c
@@ -681,6 +681,32 @@ int bt_hfp_hf_send_cmd(struct bt_conn *conn, enum bt_hfp_hf_at_cmd cmd)
 	return 0;
 }
 
+int bt_hfp_hf_get_peer_indicator_status(struct bt_conn *conn)
+{
+    struct bt_hfp_hf *hf;
+    int err;
+
+    if (!conn) {
+        LOG_ERR("Invalid connection");
+        return -ENOTCONN;
+    }
+
+    hf = bt_hfp_hf_lookup_bt_conn(conn);
+    if (!hf) {
+        LOG_ERR("No HF connection found");
+        return -ENOTCONN;
+    }
+
+    err = hfp_hf_send_cmd(hf, cind_status_resp, cmd_complete,
+                         "AT+CIND?");
+    if (err < 0) {
+        LOG_ERR("Failed AT+CIND?");
+        return err;
+    }
+
+    return 0;
+}
+
 static void hfp_hf_connected(struct bt_rfcomm_dlc *dlc)
 {
 	struct bt_hfp_hf *hf = CONTAINER_OF(dlc, struct bt_hfp_hf, rfcomm_dlc);


### PR DESCRIPTION
Implement an API to send the AT command "AT+CIND?" to retrieve the current status of the HFP AG indicators, as well as the indicators listed in the "AT+CIND=?" command, and also call the user-registered callback in application accordingly.