### PR TITLE
pinctrl: Fix usage of PINCTRL_DT_DEFINE with C++

### DIFF
--- a/include/zephyr/drivers/pinctrl.h
+++ b/include/zephyr/drivers/pinctrl.h
@@ -157,10 +157,10 @@ struct pinctrl_dev_config {
 #define Z_PINCTRL_STATE_INIT(state_idx, node_id)			       \
 	COND_CODE_1(Z_PINCTRL_SKIP_STATE(state_idx, node_id), (),	       \
 	({								       \
-		.id = Z_PINCTRL_STATE_ID(state_idx, node_id),		       \
 		.pins = Z_PINCTRL_STATE_PINS_NAME(state_idx, node_id),	       \
 		.pin_cnt = ARRAY_SIZE(Z_PINCTRL_STATE_PINS_NAME(state_idx,     \
-								node_id))      \
+								node_id)),      \
+		.id = Z_PINCTRL_STATE_ID(state_idx, node_id)		       \
 	}))
 
 /**


### PR DESCRIPTION
Using PINCTRL_DT_DEFINE from a C++ file cause a "designator order field" error.
This updates Z_PINCTRL_STATE_INIT to respect the same order as defined in struct pinctrl_state.