### PR TITLE
shell: shell_log_backend: Allow printing the thread ID or name

### DIFF
--- a/subsys/shell/shell_log_backend.c
+++ b/subsys/shell/shell_log_backend.c
@@ -161,10 +161,11 @@ static void process_log_msg(const struct shell *sh,
 			     bool locked, bool colors)
 {
 	unsigned int key = 0;
-	uint32_t flags = LOG_OUTPUT_FLAG_LEVEL |
-		      LOG_OUTPUT_FLAG_TIMESTAMP |
-		      (IS_ENABLED(CONFIG_SHELL_LOG_FORMAT_TIMESTAMP) ?
-			LOG_OUTPUT_FLAG_FORMAT_TIMESTAMP : 0);
+	uint32_t flags = LOG_OUTPUT_FLAG_LEVEL | LOG_OUTPUT_FLAG_TIMESTAMP | LOG_OUTPUT_FLAG_THREAD;
+
+	if (IS_ENABLED(CONFIG_SHELL_LOG_FORMAT_TIMESTAMP)) {
+		flags |= LOG_OUTPUT_FLAG_FORMAT_TIMESTAMP;
+	}
 
 	if (colors) {
 		flags |= LOG_OUTPUT_FLAG_COLORS;


### PR DESCRIPTION
Add the `LOG_OUTPUT_FLAG_THREAD` to the default flags for the shell log backend