### PR TITLE
Bluetooth: Audio: allow for multiple acceptors

### DIFF
--- a/tests/bsim/bluetooth/audio/src/cap_commander_test.c
+++ b/tests/bsim/bluetooth/audio/src/cap_commander_test.c
@@ -727,12 +727,6 @@ static void discover_bass(size_t acceptor_cnt)
 {
 	k_sem_reset(&sem_bass_discovered);
 
-	if (acceptor_cnt > 1) {
-		FAIL("Current implementation does not support multiple connections for the "
-		     "broadcast assistant");
-		return;
-	}
-
 	for (size_t i = 0U; i < acceptor_cnt; i++) {
 		int err;
 
@@ -1133,9 +1127,12 @@ static void test_main_cap_commander_broadcast_reception(void)
 
 	test_broadcast_reception_start(acceptor_count);
 
-	backchannel_sync_wait_any(); /* wait for the acceptor to receive data */
+	for (size_t i = 0; i < acceptor_count; i++) {
+		backchannel_sync_wait_any(); /* wait for the acceptor to receive data */
 
-	backchannel_sync_wait_any(); /* wait for the acceptor to receive a metadata update */
+		backchannel_sync_wait_any(); /* wait for the acceptor to receive a metadata update
+					      */
+	}
 
 	test_broadcast_reception_stop(acceptor_count);
 

--- a/tests/bsim/bluetooth/audio/test_scripts/bap_broadcast_audio_assistant.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/bap_broadcast_audio_assistant.sh
@@ -24,7 +24,7 @@ Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=2 \
-  -testid=broadcast_source -RealEncryption=1 -rs=69 -D=3
+  -testid=broadcast_source_w_asst -RealEncryption=1 -rs=69 -D=3
 
 # Simulation time should be larger than the WAIT_TIME in common.h
 Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -D=3 -sim_length=60e6 $@

--- a/tests/bsim/bluetooth/audio/test_scripts/cap_broadcast_reception.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/cap_broadcast_reception.sh
@@ -6,7 +6,7 @@
 
 SIMULATION_ID="cap_broadcast_reception"
 VERBOSITY_LEVEL=2
-NR_OF_DEVICES=3
+NR_OF_DEVICES=4
 EXECUTE_TIMEOUT=180
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
@@ -20,12 +20,16 @@ Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
   -RealEncryption=1 -rs=46 -D=${NR_OF_DEVICES}
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
-  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=1 -testid=broadcast_source \
+  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=1 -testid=broadcast_source_w_asst \
   -RealEncryption=1 -rs=23 -D=${NR_OF_DEVICES}
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=2 -testid=cap_acceptor_broadcast_reception \
   -RealEncryption=1 -rs=69 -D=${NR_OF_DEVICES}
+
+Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
+  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=3 -testid=cap_acceptor_broadcast_reception \
+  -RealEncryption=1 -rs=99 -D=${NR_OF_DEVICES}
 
 # Simulation time should be larger than the WAIT_TIME in common.h
 Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} \


### PR DESCRIPTION
For the CAP broadcast reception start and stop procedures we'd like to test with at least 2 acceptors. This PR makes this change, and also modifies the broadcast-source, so that it behaves properly in a test with multiple acceptors