### PR TITLE
Revert : enable CONFIG_USB_DC_HAS_HS_SUPPORT

### DIFF
--- a/boards/st/nucleo_h723zg/Kconfig.defconfig
+++ b/boards/st/nucleo_h723zg/Kconfig.defconfig
@@ -12,8 +12,4 @@ config NET_L2_ETHERNET
 
 endif # NETWORKING
 
-config USB_DC_HAS_HS_SUPPORT
-	default y
-	depends on USB_DC_STM32
-
 endif # BOARD_NUCLEO_H723ZG


### PR DESCRIPTION
This reverts commit f6235e03cfc88eafa84b9984c0bc75bf511a782c.

Reason for revert:
The modifications introduced in this commit caused a problem with the WebUSB.
As a result, these modifications are not needed and are being reverted to restore proper operation of the WebUSB sample.

This issue https://github.com/zephyrproject-rtos/zephyr/issues/59828 was fixed by this commit https://github.com/zephyrproject-rtos/zephyr/commit/c7cc58ca771a18faa0a8cb5c7f10a3b8bd429776