### PR TITLE
net: l2: wifi: fix handling of missing 'ap_disable'

### DIFF
--- a/subsys/net/l2/wifi/wifi_mgmt.c
+++ b/subsys/net/l2/wifi/wifi_mgmt.c
@@ -615,7 +615,7 @@ static int wifi_ap_disable(uint32_t mgmt_request, struct net_if *iface,
 	const struct device *dev = net_if_get_device(iface);
 	const struct wifi_mgmt_ops *const wifi_mgmt_api = get_wifi_api(iface);
 
-	if (wifi_mgmt_api == NULL || wifi_mgmt_api->ap_enable == NULL) {
+	if (wifi_mgmt_api == NULL || wifi_mgmt_api->ap_disable == NULL) {
 		return -ENOTSUP;
 	}
 


### PR DESCRIPTION
When calling `wifi_ap_disable()` API specific WiFi driver implementation was
checked whether `ap_enable` was provided, instead of `ap_disable`. Fix
that copy-paste error.