### PR TITLE
drviers: mipi_dbi: mipi_dbi_bitbang: fix 16-bit data_gpios exceed error

### DIFF
--- a/drivers/mipi_dbi/mipi_dbi_bitbang.c
+++ b/drivers/mipi_dbi/mipi_dbi_bitbang.c
@@ -337,7 +337,7 @@ static DEVICE_API(mipi_dbi, mipi_dbi_bitbang_driver_api) = {
 		.reset = GPIO_DT_SPEC_INST_GET_OR(n, reset_gpios, {}),                             \
 		DATA_LUT_OPTIMIZATION(n)                                                           \
 	};                                                                                         \
-	BUILD_ASSERT(DT_INST_PROP_LEN(n, data_gpios) < MIPI_DBI_MAX_DATA_BUS_WIDTH,                \
+	BUILD_ASSERT(DT_INST_PROP_LEN(n, data_gpios) <= MIPI_DBI_MAX_DATA_BUS_WIDTH,               \
 		     "Number of data GPIOs in DT exceeds MIPI_DBI_MAX_DATA_BUS_WIDTH");            \
 	static struct mipi_dbi_bitbang_data mipi_dbi_bitbang_data_##n;                             \
 	DEVICE_DT_INST_DEFINE(n, mipi_dbi_bitbang_init, NULL, &mipi_dbi_bitbang_data_##n,          \


### PR DESCRIPTION
For a 16-bit data bus, "DT_INST_PROP_LEN(n, data_gpios)" returns 16 which is equals "MIPI_DBI_MAX_DATA_BUS_WIDTH(16)". As a result, the assertion will always be triggered.

Use a "<=" condition for the assertion instead.