### PR TITLE
tests: benchmarks: increase timeout for sched_queues tests

### DIFF
--- a/tests/benchmarks/sched_queues/testcase.yaml
+++ b/tests/benchmarks/sched_queues/testcase.yaml
@@ -2,6 +2,7 @@ common:
   platform_key:
     - arch
   min_ram: 32
+  timeout: 120
   tags:
     - kernel
     - benchmark


### PR DESCRIPTION
Some tests can take close to 60 seconds to complete on m2gl025_miv platform (Renode-based, 4 MHz) so increase the timeout to 120 seconds to be on the safe side.

See https://github.com/zephyrproject-rtos/zephyr/actions/runs/12253888590/job/34183617013

For further context: https://github.com/zephyrproject-rtos/zephyr/pull/82521#issuecomment-2517960191