### PR TITLE
Modbus allow to disable standard function codes (FCs)

### DIFF
--- a/subsys/modbus/Kconfig
+++ b/subsys/modbus/Kconfig
@@ -79,6 +79,62 @@ config MODBUS_FC08_DIAGNOSTIC
 	help
 	  Enable function code 08 Diagnostic support
 
+config MODBUS_FC01_COIL_RD
+	bool "FC01 single coil read support"
+	depends on MODBUS_SERVER
+	default y
+	help
+	  Enable function code 01 single coil read support
+
+config MODBUS_FC02_DI_RD
+	bool "FC02 single discrete input read support"
+	depends on MODBUS_SERVER
+	default y
+	help
+	  Enable function code 02 single discrete input read support
+
+config MODBUS_FC03_HOLDING_REG_RD
+	bool "FC03 multiple holding register read support"
+	depends on MODBUS_SERVER
+	default y
+	help
+	  Enable function code 03 multiple holding register read support
+
+config MODBUS_FC04_IN_REG_RD
+	bool "FC04 multiple input register read support"
+	depends on MODBUS_SERVER
+	default y
+	help
+	  Enable function code 04 multiple input register read support
+
+config MODBUS_FC05_COIL_WR
+	bool "FC05 single coil write support"
+	depends on MODBUS_SERVER
+	default y
+	help
+	  Enable function code 05 single coil write support
+
+config MODBUS_FC06_HOLDING_REG_WR
+	bool "FC06 single holding register write support"
+	depends on MODBUS_SERVER
+	default y
+	help
+	  Enable function code 06 single holding register write support
+
+config MODBUS_FC15_COILS_WR
+	bool "FC15 multiple coils write support"
+	depends on MODBUS_SERVER
+	default y
+	help
+	  Enable function code 15 multiple coils write support
+
+config MODBUS_FC16_HOLDING_REGS_WR
+	bool "FC16 multiple holding register write support"
+	depends on MODBUS_SERVER
+	default y
+	help
+	  Enable function code 16 multiple holding register write support
+
 module = MODBUS
 module-str = Modbus Support
 module-help = Sets log level for Modbus support

--- a/subsys/modbus/modbus_core.c
+++ b/subsys/modbus/modbus_core.c
@@ -232,12 +232,6 @@ int modbus_init_server(const int iface, struct modbus_iface_param param)
 		goto init_server_error;
 	}
 
-	if (param.server.user_cb == NULL) {
-		LOG_ERR("User callbacks should be available");
-		rc = -EINVAL;
-		goto init_server_error;
-	}
-
 	ctx = modbus_init_iface(iface);
 	if (ctx == NULL) {
 		rc = -EINVAL;

--- a/subsys/modbus/modbus_server.c
+++ b/subsys/modbus/modbus_server.c
@@ -104,6 +104,7 @@ static void mbs_exception_rsp(struct modbus_context *ctx, uint8_t excep_code)
  *  Byte count            1 Bytes
  *  Coil status           N * 1 Byte
  */
+#ifdef CONFIG_MODBUS_FC01_COIL_RD
 static bool mbs_fc01_coil_read(struct modbus_context *ctx)
 {
 	const uint16_t coils_limit = 2000;
@@ -189,6 +190,7 @@ static bool mbs_fc01_coil_read(struct modbus_context *ctx)
 
 	return true;
 }
+#endif
 
 /*
  * FC 02 (0x02) Read Discrete Inputs
@@ -203,6 +205,7 @@ static bool mbs_fc01_coil_read(struct modbus_context *ctx)
  *  Byte count            1 Bytes
  *  Input status           N * 1 Byte
  */
+#ifdef CONFIG_MODBUS_FC02_DI_RD
 static bool mbs_fc02_di_read(struct modbus_context *ctx)
 {
 	const uint16_t di_limit = 2000;
@@ -290,6 +293,7 @@ static bool mbs_fc02_di_read(struct modbus_context *ctx)
 
 	return true;
 }
+#endif
 
 /*
  * 03 (0x03) Read Holding Registers
@@ -304,6 +308,7 @@ static bool mbs_fc02_di_read(struct modbus_context *ctx)
  *  Byte count            1 Bytes
  *  Register Value        N * 2 Byte
  */
+#ifdef CONFIG_MODBUS_FC03_HOLDING_REG_RD
 static bool mbs_fc03_hreg_read(struct modbus_context *ctx)
 {
 	const uint16_t regs_limit = 125;
@@ -402,6 +407,7 @@ static bool mbs_fc03_hreg_read(struct modbus_context *ctx)
 
 	return true;
 }
+#endif
 
 /*
  * 04 (0x04) Read Input Registers
@@ -416,6 +422,7 @@ static bool mbs_fc03_hreg_read(struct modbus_context *ctx)
  *  Byte count            1 Bytes
  *  Register Value        N * 2 Byte
  */
+#ifdef CONFIG_MODBUS_FC04_IN_REG_RD
 static bool mbs_fc04_inreg_read(struct modbus_context *ctx)
 {
 	const uint16_t regs_limit = 125;
@@ -513,6 +520,7 @@ static bool mbs_fc04_inreg_read(struct modbus_context *ctx)
 
 	return true;
 }
+#endif
 
 /*
  * FC 05 (0x05) Write Single Coil
@@ -527,6 +535,7 @@ static bool mbs_fc04_inreg_read(struct modbus_context *ctx)
  *  Output Address        2 Bytes
  *  Output Value          2 Bytes
  */
+#ifdef CONFIG_MODBUS_FC05_COIL_WR
 static bool mbs_fc05_coil_write(struct modbus_context *ctx)
 {
 	const uint8_t request_len = 4;
@@ -572,6 +581,7 @@ static bool mbs_fc05_coil_write(struct modbus_context *ctx)
 
 	return true;
 }
+#endif
 
 /*
  * 06 (0x06) Write Single Register
@@ -586,6 +596,7 @@ static bool mbs_fc05_coil_write(struct modbus_context *ctx)
  *  Register Address      2 Bytes
  *  Register Value        2 Bytes
  */
+#ifdef CONFIG_MODBUS_FC06_HOLDING_REG_WR
 static bool mbs_fc06_hreg_write(struct modbus_context *ctx)
 {
 	const uint8_t request_len = 4;
@@ -622,6 +633,7 @@ static bool mbs_fc06_hreg_write(struct modbus_context *ctx)
 
 	return true;
 }
+#endif
 
 /*
  * 08 (0x08) Diagnostics
@@ -724,6 +736,7 @@ static bool mbs_fc08_diagnostics(struct modbus_context *ctx)
  *  Starting Address      2 Bytes
  *  Quantity of Outputs   2 Bytes
  */
+#ifdef CONFIG_MODBUS_FC15_COILS_WR
 static bool mbs_fc15_coils_write(struct modbus_context *ctx)
 {
 	const uint16_t coils_limit = 2000;
@@ -805,6 +818,7 @@ static bool mbs_fc15_coils_write(struct modbus_context *ctx)
 
 	return true;
 }
+#endif
 
 /*
  * FC16 (0x10) Write Multiple registers
@@ -826,6 +840,7 @@ static bool mbs_fc15_coils_write(struct modbus_context *ctx)
  * the 'Daniels Flow Meter' extensions.  This means that each register
  * requested is considered as a 32-bit IEEE-754 floating-point format.
  */
+#ifdef CONFIG_MODBUS_FC16_HOLDING_REGS_WR
 static bool mbs_fc16_hregs_write(struct modbus_context *ctx)
 {
 	const uint16_t regs_limit = 125;
@@ -924,6 +939,7 @@ static bool mbs_fc16_hregs_write(struct modbus_context *ctx)
 
 	return true;
 }
+#endif
 
 static bool mbs_try_user_fc(struct modbus_context *ctx, uint8_t fc)
 {
@@ -990,41 +1006,57 @@ bool modbus_server_handler(struct modbus_context *ctx)
 	update_server_msg_ctr(ctx);
 
 	switch (fc) {
+#ifdef CONFIG_MODBUS_FC01_COIL_RD
 	case MODBUS_FC01_COIL_RD:
 		send_reply = mbs_fc01_coil_read(ctx);
 		break;
+#endif
 
+#ifdef CONFIG_MODBUS_FC02_DI_RD
 	case MODBUS_FC02_DI_RD:
 		send_reply = mbs_fc02_di_read(ctx);
 		break;
+#endif
 
+#ifdef CONFIG_MODBUS_FC03_HOLDING_REG_RD
 	case MODBUS_FC03_HOLDING_REG_RD:
 		send_reply = mbs_fc03_hreg_read(ctx);
 		break;
+#endif
 
+#ifdef CONFIG_MODBUS_FC04_IN_REG_RD
 	case MODBUS_FC04_IN_REG_RD:
 		send_reply = mbs_fc04_inreg_read(ctx);
 		break;
+#endif
 
+#ifdef CONFIG_MODBUS_FC05_COIL_WR
 	case MODBUS_FC05_COIL_WR:
 		send_reply = mbs_fc05_coil_write(ctx);
 		break;
+#endif
 
+#ifdef CONFIG_MODBUS_FC06_HOLDING_REG_WR
 	case MODBUS_FC06_HOLDING_REG_WR:
 		send_reply = mbs_fc06_hreg_write(ctx);
 		break;
+#endif
 
 	case MODBUS_FC08_DIAGNOSTICS:
 		send_reply = mbs_fc08_diagnostics(ctx);
 		break;
 
+#ifdef CONFIG_MODBUS_FC15_COILS_WR
 	case MODBUS_FC15_COILS_WR:
 		send_reply = mbs_fc15_coils_write(ctx);
 		break;
+#endif
 
+#ifdef CONFIG_MODBUS_FC16_HOLDING_REGS_WR
 	case MODBUS_FC16_HOLDING_REGS_WR:
 		send_reply = mbs_fc16_hregs_write(ctx);
 		break;
+#endif
 
 	default:
 		send_reply = mbs_try_user_fc(ctx, fc);

--- a/subsys/modbus/modbus_server.c
+++ b/subsys/modbus/modbus_server.c
@@ -20,10 +20,11 @@
  */
 
 #include <string.h>
-#include <zephyr/sys/byteorder.h>
-#include <modbus_internal.h>
 
 #include <zephyr/logging/log.h>
+#include <zephyr/sys/byteorder.h>
+
+#include <modbus_internal.h>
 LOG_MODULE_REGISTER(modbus_s, CONFIG_MODBUS_LOG_LEVEL);
 
 /*
@@ -337,8 +338,7 @@ static bool mbs_fc03_hreg_read(struct modbus_context *ctx)
 	/* Get number of bytes needed for response. */
 	num_bytes = (uint8_t)(reg_qty * sizeof(uint16_t));
 
-	if ((reg_addr < MODBUS_FP_EXTENSIONS_ADDR) ||
-	    !IS_ENABLED(CONFIG_MODBUS_FP_EXTENSIONS)) {
+	if ((reg_addr < MODBUS_FP_EXTENSIONS_ADDR) || !IS_ENABLED(CONFIG_MODBUS_FP_EXTENSIONS)) {
 		/* Read integer register */
 		if (ctx->mbs_user_cb->holding_reg_rd == NULL) {
 			mbs_exception_rsp(ctx, MODBUS_EXC_ILLEGAL_FC);
@@ -451,8 +451,7 @@ static bool mbs_fc04_inreg_read(struct modbus_context *ctx)
 	/* Get number of bytes needed for response. */
 	num_bytes = (uint8_t)(reg_qty * sizeof(uint16_t));
 
-	if ((reg_addr < MODBUS_FP_EXTENSIONS_ADDR) ||
-	    !IS_ENABLED(CONFIG_MODBUS_FP_EXTENSIONS)) {
+	if ((reg_addr < MODBUS_FP_EXTENSIONS_ADDR) || !IS_ENABLED(CONFIG_MODBUS_FP_EXTENSIONS)) {
 		/* Read integer register */
 		if (ctx->mbs_user_cb->input_reg_rd == NULL) {
 			mbs_exception_rsp(ctx, MODBUS_EXC_ILLEGAL_FC);
@@ -773,8 +772,7 @@ static bool mbs_fc15_coils_write(struct modbus_context *ctx)
 	}
 
 	/* Be sure byte count is valid for quantity of coils. */
-	if (((((coil_qty - 1) / 8) + 1) !=  num_bytes) ||
-	    (ctx->rx_adu.length  != (num_bytes + 5))) {
+	if (((((coil_qty - 1) / 8) + 1) != num_bytes) || (ctx->rx_adu.length != (num_bytes + 5))) {
 		LOG_ERR("Mismatch in the number of coils");
 		mbs_exception_rsp(ctx, MODBUS_EXC_ILLEGAL_DATA_VAL);
 		return true;
@@ -796,8 +794,7 @@ static bool mbs_fc15_coils_write(struct modbus_context *ctx)
 			coil_state = false;
 		}
 
-		err = ctx->mbs_user_cb->coil_wr(coil_addr + coil_cntr,
-						coil_state);
+		err = ctx->mbs_user_cb->coil_wr(coil_addr + coil_cntr, coil_state);
 
 		if (err != 0) {
 			LOG_INF("Coil address not supported");
@@ -868,8 +865,7 @@ static bool mbs_fc16_hregs_write(struct modbus_context *ctx)
 		return true;
 	}
 
-	if ((reg_addr < MODBUS_FP_EXTENSIONS_ADDR) ||
-	    !IS_ENABLED(CONFIG_MODBUS_FP_EXTENSIONS)) {
+	if ((reg_addr < MODBUS_FP_EXTENSIONS_ADDR) || !IS_ENABLED(CONFIG_MODBUS_FP_EXTENSIONS)) {
 		/* Write integer register */
 		if (ctx->mbs_user_cb->holding_reg_wr == NULL) {
 			mbs_exception_rsp(ctx, MODBUS_EXC_ILLEGAL_FC);
@@ -956,7 +952,7 @@ static bool mbs_try_user_fc(struct modbus_context *ctx, uint8_t fc)
 
 			p->excep_code = MODBUS_EXC_NONE;
 			rval = p->cb(iface, &ctx->rx_adu, &ctx->tx_adu, &p->excep_code,
-					p->user_data);
+				     p->user_data);
 
 			if (p->excep_code != MODBUS_EXC_NONE) {
 				LOG_INF("Custom handler failed with code %d", p->excep_code);

--- a/subsys/modbus/modbus_server.c
+++ b/subsys/modbus/modbus_server.c
@@ -75,6 +75,9 @@ static void update_noresp_ctr(struct modbus_context *ctx)
 #define update_noresp_ctr(...)
 #endif /* CONFIG_MODBUS_FC08_DIAGNOSTIC */
 
+#define HAS_MBS_USER_CB(_cb_name)                                                                  \
+	((ctx->mbs_user_cb != NULL) && (ctx->mbs_user_cb->_cb_name != NULL))
+
 /*
  * This function sets the indicated error response code into the response frame.
  * Then the routine is called to calculate the error check value.
@@ -124,7 +127,7 @@ static bool mbs_fc01_coil_read(struct modbus_context *ctx)
 		return false;
 	}
 
-	if (ctx->mbs_user_cb->coil_rd == NULL) {
+	if (!HAS_MBS_USER_CB(coil_rd)) {
 		mbs_exception_rsp(ctx, MODBUS_EXC_ILLEGAL_FC);
 		return true;
 	}
@@ -225,7 +228,7 @@ static bool mbs_fc02_di_read(struct modbus_context *ctx)
 		return false;
 	}
 
-	if (ctx->mbs_user_cb->discrete_input_rd == NULL) {
+	if (!HAS_MBS_USER_CB(discrete_input_rd)) {
 		mbs_exception_rsp(ctx, MODBUS_EXC_ILLEGAL_FC);
 		return true;
 	}
@@ -329,8 +332,7 @@ static bool mbs_fc03_hreg_read(struct modbus_context *ctx)
 	reg_qty = sys_get_be16(&ctx->rx_adu.data[2]);
 
 	if (reg_qty == 0 || reg_qty > regs_limit) {
-		LOG_ERR("Wrong register quantity, %u (limit is %u)",
-			reg_qty, regs_limit);
+		LOG_ERR("Wrong register quantity, %u (limit is %u)", reg_qty, regs_limit);
 		mbs_exception_rsp(ctx, MODBUS_EXC_ILLEGAL_DATA_VAL);
 		return true;
 	}
@@ -340,14 +342,14 @@ static bool mbs_fc03_hreg_read(struct modbus_context *ctx)
 
 	if ((reg_addr < MODBUS_FP_EXTENSIONS_ADDR) || !IS_ENABLED(CONFIG_MODBUS_FP_EXTENSIONS)) {
 		/* Read integer register */
-		if (ctx->mbs_user_cb->holding_reg_rd == NULL) {
+		if (!HAS_MBS_USER_CB(holding_reg_rd)) {
 			mbs_exception_rsp(ctx, MODBUS_EXC_ILLEGAL_FC);
 			return true;
 		}
 
 	} else {
 		/* Read floating-point register */
-		if (ctx->mbs_user_cb->holding_reg_rd_fp == NULL) {
+		if (!HAS_MBS_USER_CB(holding_reg_rd_fp)) {
 			mbs_exception_rsp(ctx, MODBUS_EXC_ILLEGAL_FC);
 			return true;
 		}
@@ -402,7 +404,6 @@ static bool mbs_fc03_hreg_read(struct modbus_context *ctx)
 			mbs_exception_rsp(ctx, MODBUS_EXC_ILLEGAL_DATA_ADDR);
 			return true;
 		}
-
 	}
 
 	return true;
@@ -442,8 +443,7 @@ static bool mbs_fc04_inreg_read(struct modbus_context *ctx)
 	reg_qty = sys_get_be16(&ctx->rx_adu.data[2]);
 
 	if (reg_qty == 0 || reg_qty > regs_limit) {
-		LOG_ERR("Wrong register quantity, %u (limit is %u)",
-			reg_qty, regs_limit);
+		LOG_ERR("Wrong register quantity, %u (limit is %u)", reg_qty, regs_limit);
 		mbs_exception_rsp(ctx, MODBUS_EXC_ILLEGAL_DATA_VAL);
 		return true;
 	}
@@ -453,14 +453,14 @@ static bool mbs_fc04_inreg_read(struct modbus_context *ctx)
 
 	if ((reg_addr < MODBUS_FP_EXTENSIONS_ADDR) || !IS_ENABLED(CONFIG_MODBUS_FP_EXTENSIONS)) {
 		/* Read integer register */
-		if (ctx->mbs_user_cb->input_reg_rd == NULL) {
+		if (!HAS_MBS_USER_CB(input_reg_rd)) {
 			mbs_exception_rsp(ctx, MODBUS_EXC_ILLEGAL_FC);
 			return true;
 		}
 
 	} else {
 		/* Read floating-point register */
-		if (ctx->mbs_user_cb->input_reg_rd_fp == NULL) {
+		if (!HAS_MBS_USER_CB(input_reg_rd_fp)) {
 			mbs_exception_rsp(ctx, MODBUS_EXC_ILLEGAL_FC);
 			return true;
 		}
@@ -549,7 +549,7 @@ static bool mbs_fc05_coil_write(struct modbus_context *ctx)
 		return false;
 	}
 
-	if (ctx->mbs_user_cb->coil_wr == NULL) {
+	if (!HAS_MBS_USER_CB(coil_wr)) {
 		mbs_exception_rsp(ctx, MODBUS_EXC_ILLEGAL_FC);
 		return true;
 	}
@@ -609,7 +609,7 @@ static bool mbs_fc06_hreg_write(struct modbus_context *ctx)
 		return false;
 	}
 
-	if (ctx->mbs_user_cb->holding_reg_wr == NULL) {
+	if (!HAS_MBS_USER_CB(holding_reg_wr)) {
 		mbs_exception_rsp(ctx, MODBUS_EXC_ILLEGAL_FC);
 		return true;
 	}
@@ -755,7 +755,7 @@ static bool mbs_fc15_coils_write(struct modbus_context *ctx)
 		return false;
 	}
 
-	if (ctx->mbs_user_cb->coil_wr == NULL) {
+	if (!HAS_MBS_USER_CB(coil_wr)) {
 		mbs_exception_rsp(ctx, MODBUS_EXC_ILLEGAL_FC);
 		return true;
 	}
@@ -867,13 +867,13 @@ static bool mbs_fc16_hregs_write(struct modbus_context *ctx)
 
 	if ((reg_addr < MODBUS_FP_EXTENSIONS_ADDR) || !IS_ENABLED(CONFIG_MODBUS_FP_EXTENSIONS)) {
 		/* Write integer register */
-		if (ctx->mbs_user_cb->holding_reg_wr == NULL) {
+		if (!HAS_MBS_USER_CB(holding_reg_wr)) {
 			mbs_exception_rsp(ctx, MODBUS_EXC_ILLEGAL_FC);
 			return true;
 		}
 	} else {
 		/* Write floating-point register */
-		if (ctx->mbs_user_cb->holding_reg_wr_fp == NULL) {
+		if (!HAS_MBS_USER_CB(holding_reg_wr_fp)) {
 			mbs_exception_rsp(ctx, MODBUS_EXC_ILLEGAL_FC);
 			return true;
 		}


### PR DESCRIPTION
Extend the modbus stack to allow disabling the standard function codes FCs via Kconfig in order
- reduce code size when FC is not used
- to allow custom standard FC implementation when required.

All FCs are enabled in Kconfig by default to guarantee the legacy behavior.

The MR relates to #73237.