### PR TITLE
logging: frontend_stmesp: Fix compilation

### DIFF
--- a/include/zephyr/logging/log_frontend_stmesp.h
+++ b/include/zephyr/logging/log_frontend_stmesp.h
@@ -132,7 +132,7 @@ TYPE_SECTION_START_EXTERN(const char *, log_stmesp_ptr);
 		uint32_t idx =                                                                     \
 			((uintptr_t)&_str_ptr - (uintptr_t)TYPE_SECTION_START(log_stmesp_ptr)) /   \
 			sizeof(void *);                                                            \
-		log_frontend_stmesp_log1(_source, idx, (uintptr_t)GET_ARG_N(2, __VA_ARGS__));      \
+		log_frontend_stmesp_log1(_source, idx, (uintptr_t)(GET_ARG_N(2, __VA_ARGS__)));    \
 	} while (0)
 
 #ifdef __cplusplus


### PR DESCRIPTION
Casting an argument was missing parenthesis so if argument was an expression then casting was applied only to the first element and that could lead to compilation warnings.