### PR TITLE
nrf: GRTC clock outputs

### DIFF
--- a/boards/native/nrf_bsim/nrf54l15bsim_nrf54l15_cpuapp.dts
+++ b/boards/native/nrf_bsim/nrf54l15bsim_nrf54l15_cpuapp.dts
@@ -69,6 +69,8 @@
 	/* Channels 7-11 reserved for Zero Latency IRQs, 3-4 for FLPR */
 	child-owned-channels = <3 4 7 8 9 10 11>;
 	status = "okay";
+	/delete-property/ clocks;
+	/delete-property/ clock-names;
 };
 
 &cpuapp_rram {

--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20-pinctrl.dtsi
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20-pinctrl.dtsi
@@ -98,4 +98,19 @@
 			low-power-enable;
 		};
 	};
+
+	/omit-if-no-ref/ grtc_default: grtc_default {
+		group1 {
+			psels = <NRF_PSEL(GRTC_CLKOUT_FAST, 1, 8)>,
+				<NRF_PSEL(GRTC_CLKOUT_32K, 0, 1)>;
+		};
+	};
+
+	/omit-if-no-ref/ grtc_sleep: grtc_sleep {
+		group1 {
+			psels = <NRF_PSEL(GRTC_CLKOUT_FAST, 1, 8)>,
+				<NRF_PSEL(GRTC_CLKOUT_32K, 0, 1)>;
+			low-power-enable;
+		};
+	};
 };

--- a/boards/nordic/nrf54l15dk/nrf54l15dk_nrf54l_05_10_15-pinctrl.dtsi
+++ b/boards/nordic/nrf54l15dk/nrf54l15dk_nrf54l_05_10_15-pinctrl.dtsi
@@ -77,4 +77,19 @@
 			low-power-enable;
 		};
 	};
+
+	/omit-if-no-ref/ grtc_default: grtc_default {
+		group1 {
+			psels = <NRF_PSEL(GRTC_CLKOUT_FAST, 1, 8)>,
+				<NRF_PSEL(GRTC_CLKOUT_32K, 0, 4)>;
+		};
+	};
+
+	/omit-if-no-ref/ grtc_sleep: grtc_sleep {
+		group1 {
+			psels = <NRF_PSEL(GRTC_CLKOUT_FAST, 1, 8)>,
+				<NRF_PSEL(GRTC_CLKOUT_32K, 0, 4)>;
+			low-power-enable;
+		};
+	};
 };

--- a/drivers/pinctrl/pinctrl_nrf.c
+++ b/drivers/pinctrl/pinctrl_nrf.c
@@ -99,6 +99,15 @@ static const nrf_gpio_pin_drive_t drive_modes[NRF_DRIVE_COUNT] = {
 #define NRF_PSEL_TWIS(reg, line) ((NRF_TWIS_Type *)reg)->PSEL.line
 #endif
 
+#if DT_HAS_COMPAT_STATUS_OKAY(nordic_nrf_grtc) || defined(CONFIG_NRFX_GRTC)
+#if DT_NODE_HAS_PROP(DT_NODELABEL(grtc), clkout_fast_frequency_hz)
+#define NRF_GRTC_CLKOUT_FAST 1
+#endif
+#if DT_NODE_HAS_PROP(DT_NODELABEL(grtc), clkout_32k)
+#define NRF_GRTC_CLKOUT_SLOW 1
+#endif
+#endif
+
 int pinctrl_configure_pins(const pinctrl_soc_pin_t *pins, uint8_t pin_cnt,
 			   uintptr_t reg)
 {
@@ -345,6 +354,24 @@ int pinctrl_configure_pins(const pinctrl_soc_pin_t *pins, uint8_t pin_cnt,
 			input = NRF_GPIO_PIN_INPUT_DISCONNECT;
 			break;
 #endif /* defined(NRF_PSEL_QSPI) */
+#if defined(NRF_GRTC_CLKOUT_FAST)
+		case NRF_FUN_GRTC_CLKOUT_FAST:
+#if NRF_GPIO_HAS_SEL && defined(GPIO_PIN_CNF_CTRLSEL_GRTC)
+			nrf_gpio_pin_control_select(psel, NRF_GPIO_PIN_SEL_GRTC);
+#endif
+			dir = NRF_GPIO_PIN_DIR_OUTPUT;
+			input = NRF_GPIO_PIN_INPUT_DISCONNECT;
+			break;
+#endif /* defined(NRF_GRTC_CLKOUT_FAST) */
+#if defined(NRF_GRTC_CLKOUT_SLOW)
+		case NRF_FUN_GRTC_CLKOUT_32K:
+#if NRF_GPIO_HAS_SEL && defined(GPIO_PIN_CNF_CTRLSEL_GRTC)
+			nrf_gpio_pin_control_select(psel, NRF_GPIO_PIN_SEL_GRTC);
+#endif
+			dir = NRF_GPIO_PIN_DIR_OUTPUT;
+			input = NRF_GPIO_PIN_INPUT_DISCONNECT;
+			break;
+#endif /* defined(NRF_GRTC_CLKOUT_SLOW) */
 #if DT_HAS_COMPAT_STATUS_OKAY(nordic_nrf_can)
 		/* Pin routing is controlled by secure domain, via UICR */
 		case NRF_FUN_CAN_TX:

--- a/drivers/timer/nrf_grtc_timer.c
+++ b/drivers/timer/nrf_grtc_timer.c
@@ -10,12 +10,15 @@
 #if defined(CONFIG_CLOCK_CONTROL_NRF)
 #include <zephyr/drivers/clock_control/nrf_clock_control.h>
 #endif
+#include <zephyr/drivers/pinctrl.h>
 #include <zephyr/drivers/timer/system_timer.h>
 #include <zephyr/drivers/timer/nrf_grtc_timer.h>
 #include <nrfx_grtc.h>
 #include <zephyr/sys/math_extras.h>
 
 #define GRTC_NODE DT_NODELABEL(grtc)
+#define HFCLK_NODE DT_PHANDLE_BY_NAME(GRTC_NODE, clocks, hfclock)
+#define LFCLK_NODE DT_PHANDLE_BY_NAME(GRTC_NODE, clocks, lfclock)
 
 /* Ensure that GRTC properties in devicetree are defined correctly. */
 #if !DT_NODE_HAS_PROP(GRTC_NODE, owned_channels)
@@ -49,7 +52,7 @@
 
 #define MAX_CYCLES (MAX_TICKS * CYC_PER_TICK)
 
-#define LFCLK_FREQUENCY_HZ 32768
+#define LFCLK_FREQUENCY_HZ DT_PROP(LFCLK_NODE, clock_frequency)
 
 #if defined(CONFIG_TEST)
 const int32_t z_sys_timer_irq_for_test = DT_IRQN(GRTC_NODE);
@@ -518,7 +521,35 @@ static int sys_clock_driver_init(void)
 #if defined(CONFIG_NRF_GRTC_ALWAYS_ON)
 	nrfx_grtc_active_request_set(true);
 #endif
+
+#if DT_PROP(GRTC_NODE, clkout_32k)
+	nrfy_grtc_clkout_set(NRF_GRTC, NRF_GRTC_CLKOUT_32K, true);
+#endif
+
+#if DT_NODE_HAS_PROP(GRTC_NODE, clkout_fast_frequency_hz)
+#if !DT_NODE_HAS_PROP(HFCLK_NODE, clock_frequency)
+#error "hfclock reference required when fast clock output is enabled."
+#endif
+
+#if DT_PROP(GRTC_NODE, clkout_fast_frequency_hz) > (DT_PROP(HFCLK_NODE, clock_frequency) / 2)
+#error "Invalid frequency value for fast clock output."
+#endif
+	uint32_t base_frequency = DT_PROP(HFCLK_NODE, clock_frequency);
+	uint32_t requested_frequency = DT_PROP(GRTC_NODE, clkout_fast_frequency_hz);
+	uint32_t grtc_div = base_frequency / (requested_frequency * 2);
+
+	nrfy_grtc_clkout_divider_set(NRF_GRTC, (uint8_t)grtc_div);
+	nrfy_grtc_clkout_set(NRF_GRTC, NRF_GRTC_CLKOUT_FAST, true);
+#endif
+
+#if DT_PROP(GRTC_NODE, clkout_32k) || DT_NODE_HAS_PROP(GRTC_NODE, clkout_fast_frequency_hz)
+	PINCTRL_DT_DEFINE(GRTC_NODE);
+	const struct pinctrl_dev_config *pcfg = PINCTRL_DT_DEV_CONFIG_GET(GRTC_NODE);
+
+	return pinctrl_apply_state(pcfg, PINCTRL_STATE_DEFAULT);
+#else
 	return 0;
+#endif
 }
 
 void sys_clock_set_timeout(int32_t ticks, bool idle)

--- a/dts/bindings/timer/nordic,nrf-grtc.yaml
+++ b/dts/bindings/timer/nordic,nrf-grtc.yaml
@@ -4,17 +4,39 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-description: Nordic GRTC (Global RTC)
+description: |
+  Nordic GRTC (Global RTC)
+
+      Example of using clock outputs:
+        &grtc {
+          pinctrl-0 = <&grtc_default>;
+          pinctrl-1 = <&grtc_sleep>;
+          pinctrl-names = "default", "sleep";
+          clkout-fast-frequency-hz = <8000000>;
+          clkout-32k;
+          /* In case of nRF54H20 devices: */
+          nordic,clockpin-enable = <NRF_FUN_GRTC_CLKOUT_FAST>;
+        };
 
 compatible: "nordic,nrf-grtc"
 
 include:
   - "base.yaml"
   - "nordic,split-channels.yaml"
+  - "pinctrl-device.yaml"
+  - "nordic-clockpin.yaml"
 
 properties:
   reg:
     required: true
+
+  clkout-fast-frequency-hz:
+    type: int
+    description: Fast output clock frequency.
+
+  clkout-32k:
+    type: boolean
+    description: 32768 Hz output clock frequency enable.
 
   interrupts:
     required: true

--- a/dts/common/nordic/nrf54h20.dtsi
+++ b/dts/common/nordic/nrf54h20.dtsi
@@ -943,11 +943,8 @@
 				reg = <0x99c000 0x1000>;
 				status = "disabled";
 				cc-num = <16>;
-				/* GRTC uses both LFCLK and FLL16M, but its accuracy and
-				 * precision are inherited from LFCLK. that's why this
-				 *  one is linked here.
-				 */
-				clocks = <&lfclk>;
+				clocks = <&lfclk>, <&fll16m>;
+				clock-names = "lfclock", "hfclock";
 				power-domains = <&gpd NRF_GPD_SLOW_ACTIVE>;
 			};
 

--- a/dts/common/nordic/nrf54l20.dtsi
+++ b/dts/common/nordic/nrf54l20.dtsi
@@ -36,6 +36,12 @@
 	};
 
 	clocks {
+		pclk: pclk {
+			compatible = "fixed-clock";
+			#clock-cells = <0>;
+			clock-frequency = <DT_FREQ_M(16)>;
+		};
+
 		lfxo: lfxo {
 			compatible = "nordic,nrf-lfxo";
 			#clock-cells = <0>;
@@ -505,6 +511,8 @@
 				compatible = "nordic,nrf-grtc";
 				reg = <0xe2000 0x1000>;
 				cc-num = <12>;
+				clocks = <&lfxo>, <&pclk>;
+				clock-names = "lfclock", "hfclock";
 				status = "disabled";
 			};
 

--- a/dts/common/nordic/nrf54l_05_10_15.dtsi
+++ b/dts/common/nordic/nrf54l_05_10_15.dtsi
@@ -49,6 +49,12 @@
 	};
 
 	clocks {
+		pclk: pclk {
+			compatible = "fixed-clock";
+			#clock-cells = <0>;
+			clock-frequency = <DT_FREQ_M(16)>;
+		};
+
 		lfxo: lfxo {
 			compatible = "nordic,nrf-lfxo";
 			#clock-cells = <0>;
@@ -554,6 +560,8 @@
 				compatible = "nordic,nrf-grtc";
 				reg = <0xe2000 0x1000>;
 				cc-num = <12>;
+				clocks = <&lfxo>, <&pclk>;
+				clock-names = "lfclock", "hfclock";
 				status = "disabled";
 			};
 

--- a/include/zephyr/dt-bindings/pinctrl/nrf-pinctrl.h
+++ b/include/zephyr/dt-bindings/pinctrl/nrf-pinctrl.h
@@ -166,6 +166,10 @@
 #define NRF_FUN_TWIS_SCL 48U
 /** TWIS SDA */
 #define NRF_FUN_TWIS_SDA 49U
+/** GRTC fast clock output */
+#define NRF_FUN_GRTC_CLKOUT_FAST 55U
+/** GRTC slow clock output */
+#define NRF_FUN_GRTC_CLKOUT_32K  56U
 
 /** @} */
 


### PR DESCRIPTION
This PR adds possibility of use GRTC clock outputs.
depends on [85323](https://github.com/zephyrproject-rtos/zephyr/pull/85323)