### PR TITLE
driver: clock_control: Add to nrf clock control calib in progres API

### DIFF
--- a/drivers/clock_control/nrf_clock_calibration.c
+++ b/drivers/clock_control/nrf_clock_calibration.c
@@ -294,3 +294,8 @@ int z_nrf_clock_calibration_skips_count(void)
 
 	return total_skips_cnt;
 }
+
+bool z_nrf_clock_calibration_is_in_progress(void)
+{
+	return cal_process_in_progress ? true : false;
+}

--- a/include/zephyr/drivers/clock_control/nrf_clock_control.h
+++ b/include/zephyr/drivers/clock_control/nrf_clock_control.h
@@ -117,6 +117,13 @@ int z_nrf_clock_calibration_count(void);
  */
 int z_nrf_clock_calibration_skips_count(void);
 
+
+/** @brief Returns information if LF clock calibration is in progress.
+ *
+ * @return True if calibration is in progress, false otherwise.
+ */
+bool z_nrf_clock_calibration_is_in_progress(void);
+
 /** @brief Get onoff service for given clock subsystem.
  *
  * @param sys Subsystem.


### PR DESCRIPTION
It may be required to get information if NRF LF clock control calibration is in progress. Some time sensitive operations could benefit from this information.

The commit adds simple function that provides the information. The function is nRF platform specific.