### PR TITLE
Fix nRF54L05/10/15 VEVIF DT issue

### DIFF
--- a/drivers/mbox/mbox_nrf_vevif_event_rx.c
+++ b/drivers/mbox/mbox_nrf_vevif_event_rx.c
@@ -135,7 +135,7 @@ static int vevif_event_rx_init(const struct device *dev)
 		.enabled_mask = 0,                                                                 \
 	};                                                                                         \
 	static const struct mbox_vevif_event_rx_conf conf##inst = {                                \
-		.vpr = (NRF_VPR_Type *)DT_INST_REG_ADDR(inst),                                     \
+		.vpr = (NRF_VPR_Type *)DT_REG_ADDR(DT_INST_PARENT(inst)),                          \
 		.events = DT_INST_PROP(inst, nordic_events),                                       \
 		.events_mask = DT_INST_PROP(inst, nordic_events_mask),                             \
 		.irq_connect = irq_connect##inst,                                                  \

--- a/dts/arm/nordic/nrf54l_05_10_15_cpuapp.dtsi
+++ b/dts/arm/nordic/nrf54l_05_10_15_cpuapp.dtsi
@@ -37,7 +37,7 @@ nvic: &cpuapp_nvic {};
 &cpuflpr_vpr {
 	cpuapp_vevif_rx: mailbox@1 {
 		compatible = "nordic,nrf-vevif-event-rx";
-		reg = <0x0 0x1000>;
+		reg = <0x1 0x1000>;
 		status = "disabled";
 		interrupts = <76 NRF_DEFAULT_IRQ_PRIORITY>;
 		#mbox-cells = <1>;


### PR DESCRIPTION
- `drivers: mbox: nrf_vevif_event_rx: fix VPR address`: VPR address was obtained from the child instance, however, the child nodes address is purely an index within the VPR node. The VPR address needs to be obtained from the parent.
- `dts: arm: nordic: nrf54l05/10/15: fix cpuapp_vevif_rx reg`: The reg address was not equal to the one in the node name, producing a build warning.

Fixes #78251