### PR TITLE
MAINTAINERS: Devicetree: Exclude test bindings

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -896,8 +896,8 @@ Devicetree:
     - galak
     - rruuaanng
   files-regex:
-    - dts/bindings/.*zephyr.*
-    - dts/bindings/[^,]+$
+    - ^dts/bindings/.*zephyr.*
+    - ^dts/bindings/[^,]+$
   files:
     - scripts/dts/
     - dts/common/


### PR DESCRIPTION
Devicetree maintainers probably do not need to be pulled in for dts/bindings/ folders that are found in various tests and samples directories, the purpose of these lines was only for the top level dts/bindings/ folder. Fix the regex to be more specific.