### PR TITLE
tests: llext: temporarily disable all ARC HS5x platforms

### DIFF
--- a/tests/subsys/llext/simple/testcase.yaml
+++ b/tests/subsys/llext/simple/testcase.yaml
@@ -76,7 +76,10 @@ tests:
       - riscv
       - arc
     platform_exclude:
-      - qemu_arc/qemu_arc_hs5x  # See #80949
+      - qemu_arc/qemu_arc_hs5x     # See #80949
+      - nsim/nsim_hs5x             # See #80949
+      - nsim/nsim_hs5x/smp         # See #80949
+      - nsim/nsim_hs5x/smp/12cores # See #80949
     integration_platforms:
       - qemu_xtensa/dc233c      # Xtensa ISA
     filter: not CONFIG_MPU and not CONFIG_MMU
@@ -107,7 +110,10 @@ tests:
       - riscv
       - arc
     platform_exclude:
-      - qemu_arc/qemu_arc_hs5x  # See #80949
+      - qemu_arc/qemu_arc_hs5x     # See #80949
+      - nsim/nsim_hs5x             # See #80949
+      - nsim/nsim_hs5x/smp         # See #80949
+      - nsim/nsim_hs5x/smp/12cores # See #80949
     integration_platforms:
       - qemu_xtensa/dc233c      # Xtensa ISA
     filter: not CONFIG_MPU and not CONFIG_MMU


### PR DESCRIPTION
Exclude all simulated ARC HS5x platforms from selected LLEXT tests until #80949 is resolved. We already understand the root cause of the issue, but we don't have a good enough fix yet, so we'd like to disable the tests for now to avoid CI failures.