### PR TITLE
llext: Support non-paired RISC-V PCREL Relocation

### DIFF
--- a/arch/arm64/core/elf.c
+++ b/arch/arm64/core/elf.c
@@ -6,6 +6,7 @@
 
 #include <zephyr/llext/elf.h>
 #include <zephyr/llext/llext.h>
+#include <zephyr/llext/llext_internal.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/byteorder.h>
@@ -430,12 +431,32 @@ static int imm_reloc_handler(elf_rela_t *rel, elf_word reloc_type, uintptr_t loc
  * @retval -ENOTSUP Unsupported relocation
  * @retval -ENOEXEC Invalid relocation
  */
-int arch_elf_relocate(elf_rela_t *rel, uintptr_t loc, uintptr_t sym_base_addr, const char *sym_name,
-		      uintptr_t load_bias)
+int arch_elf_relocate(struct llext_loader *ldr, struct llext *ext, elf_rela_t *rel,
+		      const elf_shdr_t *shdr)
 {
 	int ret = 0;
 	bool overflow_check = true;
 	elf_word reloc_type = ELF_R_TYPE(rel->r_info);
+	const uintptr_t loc = llext_get_reloc_instruction_location(ldr, ext, shdr->sh_info, rel);
+	elf_sym_t sym;
+	uintptr_t sym_base_addr;
+	const char *sym_name;
+
+	ret = llext_read_symbol(ldr, ext, rel, &sym);
+
+	if (ret != 0) {
+		LOG_ERR("Could not read symbol from binary!");
+		return ret;
+	}
+
+	sym_name = llext_symbol_name(ldr, ext, &sym);
+
+	ret = llext_lookup_symbol(ldr, ext, &sym_base_addr, rel, &sym, sym_name, shdr);
+
+	if (ret != 0) {
+		LOG_ERR("Could not find symbol %s!", sym_name);
+		return ret;
+	}
 
 	switch (reloc_type) {
 	case R_ARM_NONE:

--- a/arch/riscv/core/elf.c
+++ b/arch/riscv/core/elf.c
@@ -62,7 +62,133 @@ static inline int riscv_relocation_fits(long long jump_target, long long max_dis
 	return 0;
 }
 
-static long long last_u_type_jump_target;
+static size_t riscv_last_rel_idx;
+
+/**
+ * @brief On RISC-V, PC-relative relocations (PCREL_LO12_I, PCREL_LO12_S) do not refer to
+ * the actual symbol. Instead, they refer to the location of a different instruction in the
+ * same section, which has a PCREL_HI20 relocation. The relocation offset is then computed based
+ * on the location and symbol from the HI20 relocation. 20 bits from the offset go into the
+ * instruction that has the HI20 relocation, and 12 bits go into the PCREL_LO12 instruction.
+ *
+ * @param[in] ldr llext loader
+ * @param[in] ext current extension
+ * @param[in] pcrel_lo12 the elf relocation structure for the PCREL_LO12I/S relocation.
+ * @param[in] shdr ELF section header for the relocation
+ * @param[in] sym ELF symbol for PCREL_LO12I
+ * @param[out] link_addr_out computed link address
+ *
+ */
+static int llext_riscv_find_sym_pcrel(struct llext_loader *ldr, struct llext *ext,
+				      const elf_rela_t *pcrel_lo12, const elf_shdr_t *shdr,
+				      const elf_sym_t *sym, intptr_t *link_addr_out)
+{
+	int ret;
+	elf_rela_t candidate;
+	uintptr_t candidate_loc;
+	elf_word reloc_type;
+	elf_sym_t candidate_sym;
+	uintptr_t link_addr;
+	const char *symbol_name;
+	int iteration_start = riscv_last_rel_idx;
+	bool is_first = true;
+	const elf_word rel_cnt = shdr->sh_size / shdr->sh_entsize;
+	const uintptr_t sect_base = (uintptr_t)llext_loaded_sect_ptr(ldr, ext, shdr->sh_info);
+	bool found_candidate = false;
+
+	if (iteration_start >= rel_cnt) {
+		/* value left over from a different section */
+		iteration_start = 0;
+	}
+
+	reloc_type = ELF32_R_TYPE(pcrel_lo12->r_info);
+
+	if (reloc_type != R_RISCV_PCREL_LO12_I && reloc_type != R_RISCV_PCREL_LO12_S) {
+		/* this function does not apply - the symbol is already correct */
+		return 0;
+	}
+
+	for (int i = iteration_start; i != iteration_start || is_first; i++) {
+
+		is_first = false;
+
+		/* get each relocation entry */
+		ret = llext_seek(ldr, shdr->sh_offset + i * shdr->sh_entsize);
+		if (ret != 0) {
+			return ret;
+		}
+
+		ret = llext_read(ldr, &candidate, shdr->sh_entsize);
+		if (ret != 0) {
+			return ret;
+		}
+
+		/* FIXME currently, RISC-V relocations all fit in ELF_32_R_TYPE */
+		reloc_type = ELF32_R_TYPE(candidate.r_info);
+
+		candidate_loc = sect_base + candidate.r_offset;
+
+		/*
+		 * RISC-V ELF specification: "value" of the symbol for the PCREL_LO12 relocation
+		 * is actually the offset of the PCREL_HI20 relocation instruction from section
+		 * start
+		 */
+		if (candidate.r_offset == sym->st_value && reloc_type == R_RISCV_PCREL_HI20) {
+			found_candidate = true;
+
+			/*
+			 * start here in next iteration
+			 * it is fairly likely (albeit not guaranteed) that we require PCREL_HI20
+			 * relocations in order
+			 * we can safely write this even if an error occurs after the loop -
+			 * in that case,we can safely abort the execution anyway
+			 */
+			riscv_last_rel_idx = i;
+
+			break;
+		}
+
+		if (i + 1 >= rel_cnt) {
+			/* wrap around and search in previously processed indices as well */
+			i = -1;
+		}
+	}
+
+	if (!found_candidate) {
+		LOG_ERR("Could not find R_RISCV_PCREL_HI20 relocation for "
+			"R_RISCV_PCREL_LO12 relocation!");
+		return -ENOEXEC;
+	}
+
+	/* we found a match - need to compute the relocation for this instruction */
+	/* lower 12 bits go to the PCREL_LO12 relocation */
+
+	/* get corresponding / "actual" symbol */
+	ret = llext_seek(ldr, ldr->sects[LLEXT_MEM_SYMTAB].sh_offset +
+			 ELF_R_SYM(candidate.r_info) * sizeof(elf_sym_t));
+	if (ret != 0) {
+		return ret;
+	}
+
+	ret = llext_read(ldr, &candidate_sym, sizeof(elf_sym_t));
+	if (ret != 0) {
+		return ret;
+	}
+
+	symbol_name = llext_string(ldr, ext, LLEXT_MEM_STRTAB, candidate_sym.st_name);
+
+	ret = llext_lookup_symbol(ldr, ext, &link_addr, &candidate, &candidate_sym,
+				  symbol_name, shdr);
+
+	if (ret != 0) {
+		return ret;
+	}
+
+	*link_addr_out = (intptr_t)(link_addr + candidate.r_addend - candidate_loc); /* S + A - P */
+
+	/* found the matching entry */
+	return 0;
+}
 
 /**
  * @brief RISC-V specific function for relocating partially linked ELF binaries
@@ -124,6 +250,21 @@ int arch_elf_relocate(struct llext_loader *ldr, struct llext *ext, elf_rela_t *r
 	int16_t compressed_imm8;
 	__typeof__(rel->r_addend) target_alignment = 1;
 	intptr_t sym_base_addr = (intptr_t)sym_base_addr_unsigned;
+
+	/*
+	 * For HI20/LO12 ("PCREL") relocation pairs, we need a helper function to
+	 * determine the address for the LO12 relocation, as it depends on the
+	 * value in the HI20 relocation.
+	 */
+	ret = llext_riscv_find_sym_pcrel(ldr, ext, rel, shdr, &sym, &sym_base_addr);
+
+	if (ret != 0) {
+		LOG_ERR("Failed to resolve RISC-V PCREL relocation for symbol %s at %p "
+			"with base address %p load address %p type %" PRIu64,
+			sym_name, (void *)loc, (void *)sym_base_addr, (void *)load_bias,
+			(uint64_t)reloc_type);
+		return ret;
+	}
 
 	LOG_DBG("Relocating symbol %s at %p with base address %p load address %p type %" PRIu64,
 		sym_name, (void *)loc, (void *)sym_base_addr, (void *)load_bias,
@@ -200,43 +341,32 @@ int arch_elf_relocate(struct llext_loader *ldr, struct llext *ext, elf_rela_t *r
 			UNALIGNED_PUT(modified_operand, loc32);
 		}
 
-		last_u_type_jump_target = jump_target;
-
 		return riscv_relocation_fits(jump_target, RISCV_MAX_JUMP_DISTANCE_U_PLUS_I_TYPE,
 					     reloc_type);
 	case R_RISCV_PCREL_LO12_I:
-		/* need the same jump target as preceding U-type relocation */
-		if (last_u_type_jump_target == 0) {
-			LOG_ERR("R_RISCV_PCREL_LO12_I relocation without preceding U-type "
-				"relocation!");
-			return -ENOEXEC;
-		}
+		/*
+		 * Jump target is resolved in llext_riscv_find_sym_pcrel in llext_link.c
+		 * as it depends on other relocations.
+		 */
 		modified_operand = UNALIGNED_GET(loc32);
-		jump_target = last_u_type_jump_target; /* S - P */
-		last_u_type_jump_target = 0;
-		imm8 = jump_target;
+		imm8 = (int32_t)sym_base_addr; /* already computed */
 		modified_operand = R_RISCV_CLEAR_ITYPE_IMM8(modified_operand);
 		modified_operand = R_RISCV_SET_ITYPE_IMM8(modified_operand, imm8);
 		UNALIGNED_PUT(modified_operand, loc32);
-		return riscv_relocation_fits(jump_target, RISCV_MAX_JUMP_DISTANCE_U_PLUS_I_TYPE,
-					     reloc_type);
+		/* we have checked that this fits with the associated relocation */
 		break;
 	case R_RISCV_PCREL_LO12_S:
-		/* need the same jump target as preceding U-type relocation */
-		if (last_u_type_jump_target == 0) {
-			LOG_ERR("R_RISCV_PCREL_LO12_I relocation without preceding U-type "
-				"relocation!");
-			return -ENOEXEC;
-		}
+		/*
+		 * Jump target is resolved in llext_riscv_find_sym_pcrel in llext_link.c
+		 * as it depends on other relocations.
+		 */
 		modified_operand = UNALIGNED_GET(loc32);
-		jump_target = last_u_type_jump_target; /* S - P */
-		last_u_type_jump_target = 0;
-		imm8 = jump_target;
+		imm8 = (int32_t)sym_base_addr; /* already computed */
 		modified_operand = R_RISCV_CLEAR_STYPE_IMM8(modified_operand);
 		modified_operand = R_RISCV_SET_STYPE_IMM8(modified_operand, imm8);
 		UNALIGNED_PUT(modified_operand, loc32);
-		return riscv_relocation_fits(jump_target, RISCV_MAX_JUMP_DISTANCE_U_PLUS_I_TYPE,
-					     reloc_type);
+		/* we have checked that this fits with the associated relocation */
+		break;
 	case R_RISCV_HI20:
 		jump_target = sym_base_addr + rel->r_addend; /* S + A */
 		modified_operand = UNALIGNED_GET(loc32);

--- a/include/zephyr/llext/llext.h
+++ b/include/zephyr/llext/llext.h
@@ -354,18 +354,19 @@ int llext_add_domain(struct llext *ext, struct k_mem_domain *domain);
  * symbolic data such as a section, function, or object. These relocations
  * are architecture specific and each architecture supporting LLEXT must
  * implement this.
+ * Arguments sym_base_addr, sym_name can be computed from the sym parameter,
+ * but these parameters are provided redundantly to increase efficiency.
  *
+ * @param[in] ldr Extension loader
+ * @param[in] ext Extension being relocated refers to
  * @param[in] rel Relocation data provided by ELF
- * @param[in] loc Address of opcode to rewrite
- * @param[in] sym_base_addr Address of symbol referenced by relocation
- * @param[in] sym_name Name of symbol referenced by relocation
- * @param[in] load_bias `.text` load address
+ * @param[in] shdr Header of the ELF section currently being located
  * @retval 0 Success
  * @retval -ENOTSUP Unsupported relocation
  * @retval -ENOEXEC Invalid relocation
  */
-int arch_elf_relocate(elf_rela_t *rel, uintptr_t loc,
-			     uintptr_t sym_base_addr, const char *sym_name, uintptr_t load_bias);
+int arch_elf_relocate(struct llext_loader *ldr, struct llext *ext, elf_rela_t *rel,
+		      const elf_shdr_t *shdr);
 
 /**
  * @brief Locates an ELF section in the file.

--- a/include/zephyr/llext/llext_internal.h
+++ b/include/zephyr/llext/llext_internal.h
@@ -11,6 +11,8 @@
 extern "C" {
 #endif
 
+#include <zephyr/llext/llext.h>
+
 /**
  * @file
  * @brief Private header for linkable loadable extensions
@@ -18,8 +20,6 @@ extern "C" {
 
 /** @cond ignore */
 
-struct llext_loader;
-struct llext;
 
 struct llext_elf_sect_map {
 	enum llext_mem mem_idx;
@@ -27,6 +27,39 @@ struct llext_elf_sect_map {
 };
 
 const void *llext_loaded_sect_ptr(struct llext_loader *ldr, struct llext *ext, unsigned int sh_ndx);
+
+
+static inline const char *llext_string(const struct llext_loader *ldr, const struct llext *ext,
+	enum llext_mem mem_idx, unsigned int idx)
+{
+	return (const char *)ext->mem[mem_idx] + idx;
+}
+
+static inline uintptr_t llext_get_reloc_instruction_location(struct llext_loader *ldr,
+							     struct llext *ext,
+							     int shndx,
+							     const elf_rela_t *rela)
+{
+	return (uintptr_t) llext_loaded_sect_ptr(ldr, ext, shndx) + rela->r_offset;
+}
+
+static inline const char *llext_symbol_name(struct llext_loader *ldr, struct llext *ext,
+					    const elf_sym_t *sym)
+{
+	return llext_string(ldr, ext, LLEXT_MEM_STRTAB, sym->st_name);
+}
+/*
+ * Determine address of a symbol.
+ */
+int llext_lookup_symbol(struct llext_loader *ldr, struct llext *ext, uintptr_t *link_addr,
+			const elf_rela_t *rel, const elf_sym_t *sym, const char *name,
+			const elf_shdr_t *shdr);
+
+/*
+ * Read the symbol entry corresponding to a relocation from the binary.
+ */
+int llext_read_symbol(struct llext_loader *ldr, struct llext *ext, const elf_rela_t *rel,
+		      elf_sym_t *sym);
 
 /** @endcond */
 

--- a/subsys/llext/llext_link.c
+++ b/subsys/llext/llext_link.c
@@ -142,6 +142,84 @@ static const void *llext_find_extension_sym(const char *sym_name, struct llext *
 	return se.addr;
 }
 
+/**
+ * @brief Determine address of a symbol.
+ *
+ * @param ext llext extension
+ * @param ldr llext loader
+ * @param link_addr (output) resolved address
+ * @param rel relocation entry
+ * @param sym symbol entry
+ * @param name symbol name
+ * @param shdr section header
+ *
+ * @return 0 for OK, negative for error
+ */
+static int llext_lookup_symbol(struct llext *ext, struct llext_loader *ldr, uintptr_t *link_addr,
+			       const elf_rela_t *rel, const elf_sym_t *sym, const char *name,
+			       const elf_shdr_t *shdr)
+{
+	if (ELF_R_SYM(rel->r_info) == 0) {
+		/*
+		 * no symbol
+		 * example:  R_ARM_V4BX relocation, R_ARM_RELATIVE
+		 */
+		*link_addr = 0;
+	} else if (sym->st_shndx == SHN_UNDEF) {
+		/* If symbol is undefined, then we need to look it up */
+		*link_addr = (uintptr_t)llext_find_sym(NULL, SYM_NAME_OR_SLID(name, sym->st_value));
+
+		if (*link_addr == 0) {
+			/* Try loaded tables */
+			struct llext *dep;
+
+			*link_addr = (uintptr_t)llext_find_extension_sym(name, &dep);
+			if (*link_addr) {
+				llext_dependency_add(ext, dep);
+			}
+		}
+
+		if (*link_addr == 0) {
+			LOG_ERR("Undefined symbol with no entry in "
+				"symbol table %s, offset %zd, link section %d",
+				name, (size_t)rel->r_offset, shdr->sh_link);
+			return -ENODATA;
+		}
+
+		LOG_INF("found symbol %s at 0x%lx", name, *link_addr);
+	} else if (sym->st_shndx == SHN_ABS) {
+		/* Absolute symbol */
+		*link_addr = sym->st_value;
+	} else if ((sym->st_shndx < ldr->hdr.e_shnum) &&
+		   !IN_RANGE(sym->st_shndx, SHN_LORESERVE, SHN_HIRESERVE)) {
+		/* This check rejects all relocations whose target symbol has a section index higher
+		 * than the maximum possible in this ELF file, or belongs in the reserved range:
+		 * they will be caught by the `else` below and cause an error to be returned. This
+		 * aborts the LLEXT's loading and prevents execution of improperly relocated code,
+		 * which is dangerous.
+		 *
+		 * Note that the unsupported SHN_COMMON section is rejected as part of this check.
+		 * Also note that SHN_ABS would be rejected as well, but we want to handle it
+		 * properly: for this reason, this check must come AFTER handling the case where the
+		 * symbol's section index is SHN_ABS!
+		 *
+		 *
+		 * For regular symbols, the link address is obtained by adding st_value to the start
+		 * address of the section in which the target symbol resides.
+		 */
+		*link_addr =
+			(uintptr_t)llext_loaded_sect_ptr(ldr, ext, sym->st_shndx) + sym->st_value;
+	} else {
+		LOG_ERR("cannot apply relocation: "
+			"target symbol has unexpected section index %d (0x%X)",
+			sym->st_shndx, sym->st_shndx);
+		return -ENOEXEC;
+	}
+
+	return 0;
+}
+
+
 static void llext_link_plt(struct llext_loader *ldr, struct llext *ext, elf_shdr_t *shdr,
 			   const struct llext_load_param *ldr_parm, elf_shdr_t *tgt)
 {
@@ -407,64 +485,12 @@ int llext_link(struct llext_loader *ldr, struct llext *ext, const struct llext_l
 
 			op_loc = sect_base + rel.r_offset;
 
-			if (ELF_R_SYM(rel.r_info) == 0) {
-				/* no symbol ex: R_ARM_V4BX relocation, R_ARM_RELATIVE  */
-				link_addr = 0;
-			} else if (sym.st_shndx == SHN_UNDEF) {
-				/* If symbol is undefined, then we need to look it up */
-				link_addr = (uintptr_t)llext_find_sym(NULL,
-					SYM_NAME_OR_SLID(name, sym.st_value));
+			ret = llext_lookup_symbol(ext, ldr, &link_addr, &rel, &sym, name, shdr);
 
-				if (link_addr == 0) {
-					/* Try loaded tables */
-					struct llext *dep;
-
-					link_addr = (uintptr_t)llext_find_extension_sym(name, &dep);
-					if (link_addr) {
-						llext_dependency_add(ext, dep);
-					}
-				}
-
-				if (link_addr == 0) {
-					LOG_ERR("Undefined symbol with no entry in "
-						"symbol table %s, offset %zd, link section %d",
-						name, (size_t)rel.r_offset, shdr->sh_link);
-					return -ENODATA;
-				}
-
-				LOG_INF("found symbol %s at 0x%lx", name, link_addr);
-			} else if (sym.st_shndx == SHN_ABS) {
-				/* Absolute symbol */
-				link_addr = sym.st_value;
-			} else if ((sym.st_shndx < ldr->hdr.e_shnum) &&
-				!IN_RANGE(sym.st_shndx, SHN_LORESERVE, SHN_HIRESERVE)) {
-				/* This check rejects all relocations whose target symbol
-				 * has a section index higher than the maximum possible
-				 * in this ELF file, or belongs in the reserved range:
-				 * they will be caught by the `else` below and cause an
-				 * error to be returned. This aborts the LLEXT's loading
-				 * and prevents execution of improperly relocated code,
-				 * which is dangerous.
-				 *
-				 * Note that the unsupported SHN_COMMON section is rejected
-				 * as part of this check. Also note that SHN_ABS would be
-				 * rejected as well, but we want to handle it properly:
-				 * for this reason, this check must come AFTER handling
-				 * the case where the symbol's section index is SHN_ABS!
-				 *
-				 *
-				 * For regular symbols, the link address is obtained by
-				 * adding st_value to the start address of the section
-				 * in which the target symbol resides.
-				 */
-				link_addr = (uintptr_t)llext_loaded_sect_ptr(ldr, ext,
-									     sym.st_shndx)
-					    + sym.st_value;
-			} else {
-				LOG_ERR("rela section %d, entry %d: cannot apply relocation: "
-					"target symbol has unexpected section index %d (0x%X)",
-					i, j, sym.st_shndx, sym.st_shndx);
-				return -ENOEXEC;
+			if (ret != 0) {
+				LOG_ERR("Failed to lookup symbol in rela section %d entry %d!", i,
+					j);
+				return ret;
 			}
 
 			LOG_INF("writing relocation symbol %s type %zd sym %zd at addr 0x%lx "

--- a/subsys/llext/llext_priv.h
+++ b/subsys/llext/llext_priv.h
@@ -49,12 +49,6 @@ static inline void llext_free(void *ptr)
 int do_llext_load(struct llext_loader *ldr, struct llext *ext,
 		  const struct llext_load_param *ldr_parm);
 
-static inline const char *llext_string(const struct llext_loader *ldr, const struct llext *ext,
-				       enum llext_mem mem_idx, unsigned int idx)
-{
-	return (char *)ext->mem[mem_idx] + idx;
-}
-
 /*
  * Relocation (llext_link.c)
  */

--- a/tests/subsys/llext/CMakeLists.txt
+++ b/tests/subsys/llext/CMakeLists.txt
@@ -91,3 +91,13 @@ if(NOT CONFIG_LLEXT_TYPE_ELF_OBJECT AND CONFIG_RISCV AND CONFIG_RISCV_ISA_EXT_C)
     ${ZEPHYR_BINARY_DIR}/include/generated/riscv_edge_case_cb_type.inc
   )
 endif()
+
+if(NOT CONFIG_LLEXT_TYPE_ELF_OBJECT AND CONFIG_RISCV)
+  add_llext_target(riscv_edge_case_non_paired_hi20_lo12_ext
+    OUTPUT  ${PROJECT_BINARY_DIR}/llext/riscv_edge_case_non_paired_hi20_lo12_ext.llext
+    SOURCES ${PROJECT_SOURCE_DIR}/src/riscv_edge_case_non_paired_hi20_lo12.c ${PROJECT_SOURCE_DIR}/src/riscv_edge_case_non_paired_hi20_lo12_trigger.S
+  )
+  generate_inc_file_for_target(app ${PROJECT_BINARY_DIR}/llext/riscv_edge_case_non_paired_hi20_lo12_ext.llext
+    ${ZEPHYR_BINARY_DIR}/include/generated/riscv_edge_case_non_paired_hi20_lo12.inc
+  )
+endif()

--- a/tests/subsys/llext/src/riscv_edge_case_non_paired_hi20_lo12.c
+++ b/tests/subsys/llext/src/riscv_edge_case_non_paired_hi20_lo12.c
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2024 CISPA Helmholtz Center for Information Security
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * This extension tests a relocation edge case in RISC-V:
+ * U-type instructions in conjunction with I-type/S-type instructions can be used to
+ * relocate symbols within a 32-bit range from the PC (medany code model) or 0
+ * (medlow code model).
+ * The compiler usually emits the U-type instructions and I-type/S-type instructions in sequence.
+ * However, this is not guaranteed.
+ * The accompanying assembly listing generates a scenario in which this assumption does NOT hold
+ * and tests that the llext loader can handle it.
+ */
+
+#include <stdbool.h>
+#include <zephyr/llext/symbol.h>
+#include <zephyr/ztest_assert.h>
+
+extern int _riscv_edge_case_non_paired_hi20_lo12(void);
+
+
+#define DATA_SEGMENT_SYMBOL_INITIAL 21
+#define DATA_SEGMENT_SYMBOL_EXPECTED (DATA_SEGMENT_SYMBOL_INITIAL+42)
+
+/* changed from the assembly script */
+volatile int _data_segment_symbol = DATA_SEGMENT_SYMBOL_INITIAL;
+
+
+void test_entry(void)
+{
+	int ret_value;
+
+	ret_value = _riscv_edge_case_non_paired_hi20_lo12();
+
+	zassert_equal(ret_value, DATA_SEGMENT_SYMBOL_INITIAL);
+
+	zassert_equal(_data_segment_symbol, DATA_SEGMENT_SYMBOL_EXPECTED);
+}
+EXPORT_SYMBOL(test_entry);

--- a/tests/subsys/llext/src/riscv_edge_case_non_paired_hi20_lo12_trigger.S
+++ b/tests/subsys/llext/src/riscv_edge_case_non_paired_hi20_lo12_trigger.S
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2025 CISPA Helmholtz Center for Information Security
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/toolchain.h>
+
+/* 32-bit global defined in C */
+GDATA(_data_segment_symbol)
+
+GTEXT(_riscv_edge_case_non_paired_hi20_lo12)
+
+/*
+ * Tests an edge case in the RISC-V PSABI: In the medany and the medlow code models,
+ * the compiler emits auipc/lui (U-type) and ld/sw (I-type/S-type) instruction pairs
+ * for accessing a non-local symbol.
+ * The U-type instruction sets the upper 20 bits, the I/S-type the lower 12.
+ * Thus, any address in a 32-bit range from 0 (medlow) / the PC (medany) can be reached.
+ * Often, the U-type and I-type/S-type instruction pairs are adjacent in code.
+ * However, this need not be the case - compilers can re-use the upper 20 bits set by
+ * the U-type instruction with multiple I/S-type instructions, which is a useful optimization
+ * for multiple loads/stores of or within the same symbol.
+ * The U-type instruction can also appear after the I-type in code, e.g., due to control flow.
+ * When the U-type and I/S-type instructions are not in sequence, this triggers an edge case
+ * in the llext loader.
+ * This test triggers this edge case by loading a global, modifying it and storing it back.
+ */
+SECTION_FUNC(TEXT, _riscv_edge_case_non_paired_hi20_lo12)
+	/* jump beyond the I-type/load instruction initially to break sequence assumption */
+	j _do_utype
+
+_do_load:
+	/* re-use the upper-bit value set by the U-type below for a load */
+        lw    a0, %pcrel_lo(.LUtype)(a1)
+
+	addi t1, a0, 42
+
+	j _do_store
+
+_do_utype:
+	/* this u-type sets the higher 20 bits of the global */
+	.LUtype:  auipc a1, %pcrel_hi(_data_segment_symbol)
+
+	/* backwards jump to test loading */
+	j _do_load
+
+_do_store:
+
+	/* write the modified value back for the C code to check */
+	sw t1, %pcrel_lo(.LUtype)(a1)
+
+	/* return a0, i.e., the value we read, for the C code to check */
+	ret

--- a/tests/subsys/llext/src/test_llext.c
+++ b/tests/subsys/llext/src/test_llext.c
@@ -396,6 +396,13 @@ static LLEXT_CONST uint8_t riscv_edge_case_cb_type_ext[] ELF_ALIGN = {
 LLEXT_LOAD_UNLOAD(riscv_edge_case_cb_type)
 #endif /* CONFIG_RISCV && CONFIG_RISCV_ISA_EXT_C */
 
+#if defined(CONFIG_RISCV)
+static LLEXT_CONST uint8_t riscv_edge_case_non_paired_hi20_lo12_ext[] ELF_ALIGN = {
+	#include "riscv_edge_case_non_paired_hi20_lo12.inc"
+};
+LLEXT_LOAD_UNLOAD(riscv_edge_case_non_paired_hi20_lo12)
+#endif /* CONFIG_RISCV */
+
 #endif /* !CONFIG_LLEXT_TYPE_ELF_OBJECT */
 
 #ifndef CONFIG_USERSPACE


### PR DESCRIPTION
Currently, RISC-V's architecture-specific relocations assume that all relocations of type `R_RISCV_PCREL_LO12_I` and `_S` are processed immediately after the `R_RISCV_PCREL_HI20` relocation that they share a relocation target with. While this is the case most of the time, the RISC-V PSABI specification does not guarantee that. This commit corrects this by determining the `R_RISCV_PCREL_HI20` relocation based on the symbol value of the `R_RISCV_PCREL_LO12` relocation, as specified in the [PSABI](https://github.com/riscv-non-isa/riscv-elf-psabi-doc/blob/master/riscv-elf.adoc#pc-relative-symbol-addresses).