### PR TITLE
west.yml: update hal_nxp to include BLE LL and IEEE 802.15.4 PHY NBU combo firmware

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -203,7 +203,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: d2e2514cbe70babc2dfe6e8eb0e4f9e4c97769b6
+      revision: pull/470/head
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
Update hal_nxp to include BLE LL and IEEE 802.15.4 PHY NBU combo firmware for MCXW71 boards.