### PR TITLE
samples: echo_client: fix rw612_openthread_rcp_host build in CI

### DIFF
--- a/samples/net/sockets/echo_client/sample.yaml
+++ b/samples/net/sockets/echo_client/sample.yaml
@@ -98,7 +98,11 @@ tests:
     platform_allow: frdm_kw41z
     filter: CONFIG_FULL_LIBC_SUPPORTED and not CONFIG_NATIVE_LIBC
   sample.net.sockets.echo_client.rw612_openthread_rcp_host:
-    extra_args: OVERLAY_CONFIG="overlay-ot-rcp-host-nxp.conf"
+    build_only: true
+    extra_args:
+      # Disabling monolithic since CI environment doesn't use blobs
+      - CONFIG_NXP_MONOLITHIC_NBU=n
+      - OVERLAY_CONFIG="overlay-ot-rcp-host-nxp.conf"
     slow: true
     tags:
       - net


### PR DESCRIPTION
MONOLITHIC_NXP_NBU cannot be used in CI as it relies on firmware blobs to be fetched.
Disabling the feature so the CI can pass.
Also tagging this test as build_only.