### PR TITLE
Various enhancements for Xen grant table driver

### DIFF
--- a/drivers/xen/Kconfig
+++ b/drivers/xen/Kconfig
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2022-2023 EPAM Systems
+# Copyright (c) 2022-2024 EPAM Systems
 
 if XEN
 
@@ -19,6 +19,15 @@ config XEN_GRANT_TABLE_INIT_PRIORITY
 	int "Grant table driver init priority"
 	depends on XEN_GRANT_TABLE
 	default 50
+
+config NR_GRANT_FRAMES
+	int "Number of grant frames mapped to Zephyr"
+	depends on XEN_GRANT_TABLE
+	default 1
+	help
+	  This value configures how much grant frames will be supported by Zephyr
+	  grant table driver in runtime. This value should be <= max_grant_frames
+	  configured for domain in Xen hypervisor.
 
 endmenu
 

--- a/drivers/xen/gnttab.c
+++ b/drivers/xen/gnttab.c
@@ -2,7 +2,7 @@
 /*
  ****************************************************************************
  * (C) 2006 - Cambridge University
- * (C) 2021-2022 - EPAM Systems
+ * (C) 2021-2024 - EPAM Systems
  ****************************************************************************
  *
  *        File: gnttab.c
@@ -277,7 +277,7 @@ int gnttab_map_refs(struct gnttab_map_grant_ref *map_ops, unsigned int count)
 	return 0;
 }
 
-int gnttab_unmap_refs(struct gnttab_map_grant_ref *unmap_ops, unsigned int count)
+int gnttab_unmap_refs(struct gnttab_unmap_grant_ref *unmap_ops, unsigned int count)
 {
 	return HYPERVISOR_grant_table_op(GNTTABOP_unmap_grant_ref, unmap_ops, count);
 }

--- a/drivers/xen/gnttab.c
+++ b/drivers/xen/gnttab.c
@@ -320,8 +320,6 @@ static int gnttab_init(void)
 {
 	grant_ref_t gref;
 	struct xen_add_to_physmap xatp;
-	struct gnttab_setup_table setup;
-	xen_pfn_t frames[CONFIG_NR_GRANT_FRAMES];
 	int rc = 0, i;
 	unsigned long xen_max_grant_frames;
 	uintptr_t gnttab_base = DT_REG_ADDR_BY_IDX(DT_INST(0, xen_xen), 0);
@@ -353,13 +351,6 @@ static int gnttab_init(void)
 		rc = HYPERVISOR_memory_op(XENMEM_add_to_physmap, &xatp);
 		__ASSERT(!rc, "add_to_physmap failed; status = %d\n", rc);
 	}
-
-	setup.dom = DOMID_SELF;
-	setup.nr_frames = CONFIG_NR_GRANT_FRAMES;
-	set_xen_guest_handle(setup.frame_list, frames);
-	rc = HYPERVISOR_grant_table_op(GNTTABOP_setup_table, &setup, 1);
-	__ASSERT((!rc) && (!setup.status), "Table setup failed; status = %s\n",
-		gnttabop_error(setup.status));
 
 	/*
 	 * Xen DT region reserved for grant table (first reg in hypervisor node)

--- a/drivers/xen/gnttab.c
+++ b/drivers/xen/gnttab.c
@@ -342,7 +342,7 @@ static int gnttab_init(void)
 		gnttab.gref_list[gref] = gref + 1;
 	}
 
-	for (i = 0; i < CONFIG_NR_GRANT_FRAMES; i++) {
+	for (i = CONFIG_NR_GRANT_FRAMES - 1; i >= 0; i--) {
 		xatp.domid = DOMID_SELF;
 		xatp.size = 0;
 		xatp.space = XENMAPSPACE_grant_table;

--- a/drivers/xen/gnttab.c
+++ b/drivers/xen/gnttab.c
@@ -36,16 +36,12 @@ LOG_MODULE_REGISTER(xen_gnttab);
 #define GOP_RETRY_DELAY 200
 
 #define GNTTAB_GREF_USED	(UINT32_MAX - 1)
-#define GNTTAB_SIZE DT_REG_SIZE_BY_IDX(DT_INST(0, xen_xen), 0)
-BUILD_ASSERT(!(GNTTAB_SIZE % XEN_PAGE_SIZE), "Size of gnttab have to be aligned on XEN_PAGE_SIZE");
+#define GNTTAB_SIZE		(CONFIG_NR_GRANT_FRAMES * XEN_PAGE_SIZE)
+#define NR_GRANT_ENTRIES	(GNTTAB_SIZE / sizeof(grant_entry_v1_t))
 
-/* NR_GRANT_FRAMES must be less than or equal to that configured in Xen */
-#define NR_GRANT_FRAMES (GNTTAB_SIZE / XEN_PAGE_SIZE)
-#define NR_GRANT_ENTRIES \
-	(NR_GRANT_FRAMES * XEN_PAGE_SIZE / sizeof(grant_entry_v1_t))
-
+BUILD_ASSERT(GNTTAB_SIZE <= DT_REG_SIZE_BY_IDX(DT_INST(0, xen_xen), 0),
+	     "Number of grant frames is bigger than grant table DT region!");
 BUILD_ASSERT(GNTTAB_SIZE <= CONFIG_KERNEL_VM_SIZE);
-DEVICE_MMIO_TOPLEVEL_STATIC(grant_tables, DT_INST(0, xen_xen));
 
 static struct gnttab {
 	struct k_sem sem;
@@ -303,13 +299,39 @@ const char *gnttabop_error(int16_t status)
 	}
 }
 
+/* Picked from Linux implementation */
+#define LEGACY_MAX_GNT_FRAMES_SUPPORTED		4
+static unsigned long gnttab_get_max_frames(void)
+{
+	int ret;
+	struct gnttab_query_size q = {
+		.dom = DOMID_SELF,
+	};
+
+	ret = HYPERVISOR_grant_table_op(GNTTABOP_query_size, &q, 1);
+	if ((ret < 0) || (q.status != GNTST_okay)) {
+		return LEGACY_MAX_GNT_FRAMES_SUPPORTED;
+	}
+
+	return q.max_nr_frames;
+}
+
 static int gnttab_init(void)
 {
 	grant_ref_t gref;
 	struct xen_add_to_physmap xatp;
 	struct gnttab_setup_table setup;
-	xen_pfn_t frames[NR_GRANT_FRAMES];
+	xen_pfn_t frames[CONFIG_NR_GRANT_FRAMES];
 	int rc = 0, i;
+	unsigned long xen_max_grant_frames;
+	uintptr_t gnttab_base = DT_REG_ADDR_BY_IDX(DT_INST(0, xen_xen), 0);
+	mm_reg_t gnttab_reg;
+
+	xen_max_grant_frames = gnttab_get_max_frames();
+	if (xen_max_grant_frames < CONFIG_NR_GRANT_FRAMES) {
+		LOG_ERR("Xen max_grant_frames is less than CONFIG_NR_GRANT_FRAMES!");
+		k_panic();
+	}
 
 	/* Will be taken/given during gnt_refs allocation/release */
 	k_sem_init(&gnttab.sem, NR_GRANT_ENTRIES - GNTTAB_NR_RESERVED_ENTRIES,
@@ -322,25 +344,32 @@ static int gnttab_init(void)
 		gnttab.gref_list[gref] = gref + 1;
 	}
 
-	for (i = 0; i < NR_GRANT_FRAMES; i++) {
+	for (i = 0; i < CONFIG_NR_GRANT_FRAMES; i++) {
 		xatp.domid = DOMID_SELF;
 		xatp.size = 0;
 		xatp.space = XENMAPSPACE_grant_table;
 		xatp.idx = i;
-		xatp.gpfn = xen_virt_to_gfn(Z_TOPLEVEL_ROM_NAME(grant_tables).phys_addr) + i;
+		xatp.gpfn = xen_virt_to_gfn(gnttab_base) + i;
 		rc = HYPERVISOR_memory_op(XENMEM_add_to_physmap, &xatp);
 		__ASSERT(!rc, "add_to_physmap failed; status = %d\n", rc);
 	}
 
 	setup.dom = DOMID_SELF;
-	setup.nr_frames = NR_GRANT_FRAMES;
+	setup.nr_frames = CONFIG_NR_GRANT_FRAMES;
 	set_xen_guest_handle(setup.frame_list, frames);
 	rc = HYPERVISOR_grant_table_op(GNTTABOP_setup_table, &setup, 1);
 	__ASSERT((!rc) && (!setup.status), "Table setup failed; status = %s\n",
 		gnttabop_error(setup.status));
 
-	DEVICE_MMIO_TOPLEVEL_MAP(grant_tables, K_MEM_CACHE_WB | K_MEM_PERM_RW);
-	gnttab.table = (grant_entry_v1_t *)DEVICE_MMIO_TOPLEVEL_GET(grant_tables);
+	/*
+	 * Xen DT region reserved for grant table (first reg in hypervisor node)
+	 * may be much bigger than CONFIG_NR_GRANT_FRAMES multiplied by page size.
+	 * Thus, we need to map only part of region, that is limited by config.
+	 * The size of this part is calculated in GNTTAB_SIZE macro and used as
+	 * parameter for device_map()
+	 */
+	device_map(&gnttab_reg, gnttab_base, GNTTAB_SIZE, K_MEM_CACHE_WB | K_MEM_PERM_RW);
+	gnttab.table = (grant_entry_v1_t *)gnttab_reg;
 
 	LOG_DBG("%s: grant table mapped\n", __func__);
 

--- a/include/zephyr/xen/gnttab.h
+++ b/include/zephyr/xen/gnttab.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022 EPAM Systems
+ * Copyright (c) 2021-2024 EPAM Systems
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -76,12 +76,12 @@ int gnttab_map_refs(struct gnttab_map_grant_ref *map_ops, unsigned int count);
  * Unmap foreign grant refs. The gnttab_put_page() should be used after this for
  * each page, that was successfully unmapped.
  *
- * @param unmap_ops - array of prepared gnttab_map_grant_ref's for unmapping
+ * @param unmap_ops - array of prepared gnttab_unmap_grant_ref's for unmapping
  * @param count - number of grefs in unmap_ops array
  * @return - @count on success or negative errno on failure
  *           also per-page status will be set in unmap_ops[i].status (GNTST_*)
  */
-int gnttab_unmap_refs(struct gnttab_map_grant_ref *unmap_ops, unsigned int count);
+int gnttab_unmap_refs(struct gnttab_unmap_grant_ref *unmap_ops, unsigned int count);
 
 /*
  * Convert grant ref status codes (GNTST_*) to text messages.

--- a/include/zephyr/xen/public/grant_table.h
+++ b/include/zephyr/xen/public/grant_table.h
@@ -324,7 +324,23 @@ struct gnttab_setup_table {
 typedef struct gnttab_setup_table gnttab_setup_table_t;
 DEFINE_XEN_GUEST_HANDLE(gnttab_setup_table_t);
 
-
+/*
+ * GNTTABOP_query_size: Query the current and maximum sizes of the shared
+ * grant table.
+ * NOTES:
+ *  1. <dom> may be specified as DOMID_SELF.
+ *  2. Only a sufficiently-privileged domain may specify <dom> != DOMID_SELF.
+ */
+struct gnttab_query_size {
+	/* IN parameters. */
+	domid_t  dom;
+	/* OUT parameters. */
+	uint32_t nr_frames;
+	uint32_t max_nr_frames;
+	int16_t  status;	/* => enum grant_status */
+};
+typedef struct gnttab_query_size gnttab_query_size_t;
+DEFINE_XEN_GUEST_HANDLE(gnttab_query_size_t);
 
 /*
  * Bitfield values for gnttab_map_grant_ref.flags.


### PR DESCRIPTION
This pull request is targeted on fixing few issues in Zephyr driver for Xen grant table:
- unmapping hypercall contained incorrect structure in wrapper function signature;
- some grant table entries may be freed more than one time and break allocator state;
- guests always mapped max available number of grant frames provided by Xen, this led to redundant memory consumption and now can be controlled via config;
- grant table mapping procedure was not correct and do redundant hypercall without checking its results (suggested by @orzelmichal);
- avoid multiple grant table expansion during initialization by processing it from end to start (expand domain gnttab only once during init with config frames amount) - patch is prepared by @GrygiriiS;

Please, find detailed description in commit messages.