### PR TITLE
drivers: pwm_led: esp32: Driver update

### DIFF
--- a/drivers/pwm/pwm_led_esp32.c
+++ b/drivers/pwm/pwm_led_esp32.c
@@ -400,7 +400,7 @@ PINCTRL_DT_INST_DEFINE(0);
 		.timer_num = DT_PROP(node_id, timer),                                              \
 		.speed_mode = DT_REG_ADDR(node_id) < SOC_LEDC_CHANNEL_NUM ? LEDC_LOW_SPEED_MODE    \
 									  : !LEDC_LOW_SPEED_MODE,  \
-		.inverted = DT_PWMS_FLAGS(node_id),                                                \
+		.inverted = DT_PROP(node_id, inverted),                                            \
 	},
 
 static struct pwm_ledc_esp32_channel_config channel_config[] = {

--- a/drivers/pwm/pwm_led_esp32.c
+++ b/drivers/pwm/pwm_led_esp32.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2017 Vitor Massaru Iha <vitor@massaru.org>
- * Copyright (c) 2024 Espressif Systems (Shanghai) Co., Ltd.
+ * Copyright (c) 2025 Espressif Systems (Shanghai) Co., Ltd.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -58,10 +58,9 @@ struct pwm_ledc_esp32_config {
 };
 
 static struct pwm_ledc_esp32_channel_config *get_channel_config(const struct device *dev,
-	int channel_id)
+								int channel_id)
 {
-	struct pwm_ledc_esp32_config *config =
-		(struct pwm_ledc_esp32_config *) dev->config;
+	struct pwm_ledc_esp32_config *config = (struct pwm_ledc_esp32_config *)dev->config;
 
 	for (uint8_t i = 0; i < config->channel_len; i++) {
 		if (config->channel_config[i].idx == channel_id) {
@@ -71,7 +70,8 @@ static struct pwm_ledc_esp32_channel_config *get_channel_config(const struct dev
 	return NULL;
 }
 
-static void pwm_led_esp32_start(struct pwm_ledc_esp32_data *data, struct pwm_ledc_esp32_channel_config *channel)
+static void pwm_led_esp32_start(struct pwm_ledc_esp32_data *data,
+				struct pwm_ledc_esp32_channel_config *channel)
 {
 	ledc_hal_set_sig_out_en(&data->hal, channel->channel_num, true);
 	ledc_hal_set_duty_start(&data->hal, channel->channel_num, true);
@@ -81,7 +81,8 @@ static void pwm_led_esp32_start(struct pwm_ledc_esp32_data *data, struct pwm_led
 	}
 }
 
-static void pwm_led_esp32_stop(struct pwm_ledc_esp32_data *data, struct pwm_ledc_esp32_channel_config *channel, bool idle_level)
+static void pwm_led_esp32_stop(struct pwm_ledc_esp32_data *data,
+			       struct pwm_ledc_esp32_channel_config *channel, bool idle_level)
 {
 	ledc_hal_set_idle_level(&data->hal, channel->channel_num, idle_level);
 	ledc_hal_set_sig_out_en(&data->hal, channel->channel_num, false);
@@ -93,7 +94,7 @@ static void pwm_led_esp32_stop(struct pwm_ledc_esp32_data *data, struct pwm_ledc
 }
 
 static void pwm_led_esp32_duty_set(const struct device *dev,
-	struct pwm_ledc_esp32_channel_config *channel)
+				   struct pwm_ledc_esp32_channel_config *channel)
 {
 	struct pwm_ledc_esp32_data *data = (struct pwm_ledc_esp32_data *const)(dev)->data;
 
@@ -116,7 +117,7 @@ static int pwm_led_esp32_calculate_max_resolution(struct pwm_ledc_esp32_channel_
 	for (uint8_t i = 0; i <= SOC_LEDC_TIMER_BIT_WIDTH; i++) {
 		max_precision_n /= 2;
 		if (!max_precision_n) {
-			channel->resolution =  i;
+			channel->resolution = i;
 			return 0;
 		}
 	}
@@ -150,7 +151,9 @@ static int pwm_led_esp32_timer_config(struct pwm_ledc_esp32_channel_config *chan
 	 */
 	for (int i = 0; i < clock_src_num; i++) {
 		channel->clock_src = clock_src[i];
-		esp_clk_tree_src_get_freq_hz(channel->clock_src, ESP_CLK_TREE_SRC_FREQ_PRECISION_CACHED, &channel->clock_src_hz);
+		esp_clk_tree_src_get_freq_hz(channel->clock_src,
+					     ESP_CLK_TREE_SRC_FREQ_PRECISION_CACHED,
+					     &channel->clock_src_hz);
 		if (!pwm_led_esp32_calculate_max_resolution(channel)) {
 			return 0;
 		}
@@ -167,7 +170,7 @@ static int pwm_led_esp32_timer_config(struct pwm_ledc_esp32_channel_config *chan
 }
 
 static int pwm_led_esp32_timer_set(const struct device *dev,
-	struct pwm_ledc_esp32_channel_config *channel)
+				   struct pwm_ledc_esp32_channel_config *channel)
 {
 	int prescaler = 0;
 	uint32_t precision = (0x1 << channel->resolution);
@@ -241,23 +244,23 @@ static int pwm_led_esp32_channel_update_frequency(const struct device *dev,
 	if (channel->freq == current_freq) {
 		/* No need to reconfigure timer */
 		return 0;
-	} else {
-		/* Check whether another channel is using the same timer.
-		 * Timers can only be shared if the same frequency is used, so
-		 * first set operation will take precedence.
-		 */
-		for (int i = 0; i < config->channel_len; ++i) {
-			struct pwm_ledc_esp32_channel_config *ch = &config->channel_config[i];
+	}
 
-			if (ch->freq && (channel->channel_num != ch->channel_num) &&
-			    (channel->timer_num == ch->timer_num) &&
-			    (channel->speed_mode == ch->speed_mode) &&
-			    (channel->freq != ch->freq)) {
-				LOG_ERR("Timer can't be shared and different frequency be "
-					"requested");
-				channel->freq = 0;
-				return -EINVAL;
-			}
+	/* Check whether another channel is using the same timer.
+	 * Timers can only be shared if the same frequency is used, so
+	 * first set operation will take precedence.
+	 */
+	for (int i = 0; i < config->channel_len; ++i) {
+		struct pwm_ledc_esp32_channel_config *ch = &config->channel_config[i];
+
+		if (ch->freq && (channel->channel_num != ch->channel_num) &&
+			(channel->timer_num == ch->timer_num) &&
+			(channel->speed_mode == ch->speed_mode) &&
+			(channel->freq != ch->freq)) {
+			LOG_ERR("Timer can't be shared and different frequency be "
+				"requested");
+			channel->freq = 0;
+			return -EINVAL;
 		}
 	}
 
@@ -274,8 +277,8 @@ static int pwm_led_esp32_channel_update_frequency(const struct device *dev,
 }
 
 static int pwm_led_esp32_set_cycles(const struct device *dev, uint32_t channel_idx,
-				    uint32_t period_cycles,
-				    uint32_t pulse_cycles, pwm_flags_t flags)
+				    uint32_t period_cycles, uint32_t pulse_cycles,
+				    pwm_flags_t flags)
 {
 	struct pwm_ledc_esp32_data *data = (struct pwm_ledc_esp32_data *const)(dev)->data;
 	struct pwm_ledc_esp32_channel_config *channel = get_channel_config(dev, channel_idx);
@@ -312,7 +315,7 @@ static int pwm_led_esp32_set_cycles(const struct device *dev, uint32_t channel_i
 
 	/* Update PWM duty  */
 
-	double duty_cycle = (double) pulse_cycles / (double) period_cycles;
+	double duty_cycle = (double)pulse_cycles / (double)period_cycles;
 
 	channel->duty_val = (uint32_t)((double)(1 << channel->resolution) * duty_cycle);
 
@@ -344,7 +347,8 @@ int pwm_led_esp32_init(const struct device *dev)
 #if SOC_LEDC_HAS_TIMER_SPECIFIC_MUX
 	/* Combine clock sources to include timer specific sources */
 	memcpy(lowspd_clks, global_clks, sizeof(global_clks));
-	memcpy(&lowspd_clks[ARRAY_SIZE(global_clks)], timer_specific_clks, sizeof(timer_specific_clks));
+	memcpy(&lowspd_clks[ARRAY_SIZE(global_clks)], timer_specific_clks,
+	       sizeof(timer_specific_clks));
 #endif
 
 	for (int i = 0; i < config->channel_len; ++i) {
@@ -363,7 +367,9 @@ int pwm_led_esp32_init(const struct device *dev)
 #endif
 		ledc_hal_set_clock_source(&data->hal, channel->timer_num, channel->clock_src);
 
-		esp_clk_tree_src_get_freq_hz(channel->clock_src, ESP_CLK_TREE_SRC_FREQ_PRECISION_CACHED, &channel->clock_src_hz);
+		esp_clk_tree_src_get_freq_hz(channel->clock_src,
+					     ESP_CLK_TREE_SRC_FREQ_PRECISION_CACHED,
+					     &channel->clock_src_hz);
 
 		ledc_hal_bind_channel_timer(&data->hal, channel->channel_num, channel->timer_num);
 		pwm_led_esp32_stop(data, channel, channel->inverted);
@@ -398,8 +404,7 @@ PINCTRL_DT_INST_DEFINE(0);
 	},
 
 static struct pwm_ledc_esp32_channel_config channel_config[] = {
-	DT_INST_FOREACH_CHILD(0, CHANNEL_CONFIG)
-};
+	DT_INST_FOREACH_CHILD(0, CHANNEL_CONFIG)};
 
 static struct pwm_ledc_esp32_config pwm_ledc_esp32_config = {
 	.pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(0),
@@ -416,9 +421,5 @@ static struct pwm_ledc_esp32_data pwm_ledc_esp32_data = {
 	.cmd_sem = Z_SEM_INITIALIZER(pwm_ledc_esp32_data.cmd_sem, 1, 1),
 };
 
-DEVICE_DT_INST_DEFINE(0, &pwm_led_esp32_init, NULL,
-			&pwm_ledc_esp32_data,
-			&pwm_ledc_esp32_config,
-			POST_KERNEL,
-			CONFIG_PWM_INIT_PRIORITY,
-			&pwm_led_esp32_api);
+DEVICE_DT_INST_DEFINE(0, &pwm_led_esp32_init, NULL, &pwm_ledc_esp32_data, &pwm_ledc_esp32_config,
+		      POST_KERNEL, CONFIG_PWM_INIT_PRIORITY, &pwm_led_esp32_api);

--- a/dts/bindings/pwm/espressif,esp32-ledc.yaml
+++ b/dts/bindings/pwm/espressif,esp32-ledc.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2022 Espressif Systems (Shanghai) Co., Ltd.
+# Copyright (c) 2025 Espressif Systems (Shanghai) Co., Ltd.
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
@@ -64,12 +64,16 @@ description: |
       channel9@9 {
         reg = <0x9>;
         timer = <0>;
+        inverted;
       };
       channel10@a {
         reg = <0xa>;
         timer = <1>;
       };
     };
+
+    For the channel to be initially inverted after the driver's init, the flag 'inverted' can
+    be declared, as shown above for channel 9.
 
     Note: The channel's 'reg' property defines the ID of the channel. It must match the channel used
       in the 'pinmux'.
@@ -129,6 +133,14 @@ child-binding:
         Timer selection.
         For maximum flexibility, the high-speed as well as the low-speed channels can be driven from
         one of four high-speed/low-speed timers.
+
+    inverted:
+      type: boolean
+      description: |
+        Initial channel output level.
+        This flag defines if the channel will remain initially inverted after driver init,
+        as any pwm_set() operation will re-evaluate if the output is inverted or not
+        according to the flag passed as parameter.
 
 pwm-cells:
 - channel

--- a/tests/drivers/pwm/pwm_gpio_loopback/socs/esp32_procpu.overlay
+++ b/tests/drivers/pwm/pwm_gpio_loopback/socs/esp32_procpu.overlay
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright (c) 2024 Espressif Systems (Shanghai) Co., Ltd.
+ * Copyright (c) 2025 Espressif Systems (Shanghai) Co., Ltd.
  */
 
 #include <zephyr/dt-bindings/pwm/pwm.h>
@@ -12,10 +12,14 @@
 	zephyr,user {
 		/* GPIO input pins order must match PWM pinctrl config */
 		gpios = <&gpio0 2 ESP32_GPIO_PIN_OUT_EN>,
-			<&gpio0 3 ESP32_GPIO_PIN_OUT_EN>;
+			<&gpio0 3 ESP32_GPIO_PIN_OUT_EN>,
+			<&gpio0 4 ESP32_GPIO_PIN_OUT_EN>,
+			<&gpio0 5 ESP32_GPIO_PIN_OUT_EN>;
 
 		pwms = <&ledc0 0 160000 PWM_POLARITY_NORMAL>,
-			<&ledc0 5 80000 PWM_POLARITY_INVERTED>;
+			<&ledc0 5 80000 PWM_POLARITY_INVERTED>,
+			<&ledc0 9 1000000 PWM_POLARITY_NORMAL>,
+			<&ledc0 10 1000000 PWM_POLARITY_INVERTED>;
 	};
 };
 
@@ -23,7 +27,9 @@
 	ledc0_default: ledc0_default {
 		group1 {
 			pinmux = <LEDC_CH0_GPIO2>,
-				<LEDC_CH5_GPIO3>;
+				<LEDC_CH5_GPIO3>,
+				<LEDC_CH9_GPIO4>,
+				<LEDC_CH10_GPIO5>;
 			input-enable;
 		};
 	};
@@ -44,5 +50,17 @@
 	channel5@5 {
 		reg = <0x5>;
 		timer = <1>;
+	};
+
+	/* HS channel */
+	channel9@9 {
+		reg = <0x9>;
+		timer = <0>;
+	};
+
+	/* share same timer with ch9 */
+	channel10@a {
+		reg = <0xa>;
+		timer = <0>;
 	};
 };


### PR DESCRIPTION
Update LEDC driver in order to address GH reported issues and improve clock management.

Following behaviors are ensured:

- inverted PWM
- default signal level after driver init, as configured
- PWM is now stopped when 0% or 100% duty is selected, to allow using max timer resolution
- transitions when frequency is updated follows timer overflow (synced transition)
- transition for 0% or 100% duty is immediate
- timer can only be shared by two or more channels if frequency is the same. If new value for frequency is requested, it will be rejected to avoid cross-channel interference.

Note: changes were kept in several commits to facilitate review, but can be squashed if requested.