### PR TITLE
drivers: i2c: Fix SMBus build with stm32f4 family chip

### DIFF
--- a/drivers/i2c/i2c_ll_stm32.c
+++ b/drivers/i2c/i2c_ll_stm32.c
@@ -115,7 +115,7 @@ int i2c_stm32_runtime_configure(const struct device *dev, uint32_t config)
 #endif
 
 	LL_I2C_Disable(i2c);
-#if defined(I2C_CR1_SMBDEN) && defined(I2C_CR1_SMBHEN)
+#if defined(I2C_CR1_SMBUS) || defined(I2C_CR1_SMBDEN) || defined(I2C_CR1_SMBHEN)
 	i2c_stm32_set_smbus_mode(dev, data->mode);
 #endif
 	ret = stm32_i2c_configure_timing(dev, i2c_clock);
@@ -480,7 +480,7 @@ void i2c_stm32_smbalert_set_callback(const struct device *dev, i2c_stm32_smbaler
 }
 #endif /* CONFIG_SMBUS_STM32_SMBALERT */
 
-#if defined(I2C_CR1_SMBDEN) && defined(I2C_CR1_SMBHEN)
+#if defined(I2C_CR1_SMBUS) || defined(I2C_CR1_SMBDEN) || defined(I2C_CR1_SMBHEN)
 void i2c_stm32_set_smbus_mode(const struct device *dev, enum i2c_stm32_mode mode)
 {
 	const struct i2c_stm32_config *cfg = dev->config;


### PR DESCRIPTION
This PR fixes SMBus builds with some STM32 family products, such as the F4 family.

The regression was introduced in https://github.com/zephyrproject-rtos/zephyr/pull/78151/commits/c7dbf8aa9a9e5a838b9a47669df32049245da51f