### PR TITLE
tests: drivers: uart: Support test uart_async_api for Renesas RA8 devices

### DIFF
--- a/tests/drivers/uart/uart_async_api/boards/ek_ra8d1.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/ek_ra8d1.overlay
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2024 Renesas Electronics Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&pinctrl {
+	sci2_default: sci2_default {
+		group1 {
+			/* tx */
+			psels = <RA_PSEL(RA_PSEL_SCI_2, 10, 3)>;
+			drive-strength = "medium";
+		};
+		group2 {
+			/* rx */
+			psels = <RA_PSEL(RA_PSEL_SCI_2, 10, 2)>;
+		};
+	};
+};
+
+&sci2 {
+	pinctrl-0 = <&sci2_default>;
+	pinctrl-names = "default";
+	status = "okay";
+	dut: uart {
+		current-speed = <115200>;
+		status = "okay";
+	};
+};

--- a/tests/drivers/uart/uart_async_api/boards/mck_ra8t1.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/mck_ra8t1.overlay
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2024 Renesas Electronics Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&pinctrl {
+	sci4_default: sci4_default {
+		group1 {
+			/* tx */
+			psels = <RA_PSEL(RA_PSEL_SCI_4, 7, 14)>;
+			drive-strength = "medium";
+		};
+		group2 {
+			/* rx */
+			psels = <RA_PSEL(RA_PSEL_SCI_4, 7, 15)>;
+		};
+	};
+};
+
+&sci4 {
+	pinctrl-0 = <&sci4_default>;
+	pinctrl-names = "default";
+	status = "okay";
+	dut: uart {
+		current-speed = <115200>;
+		status = "okay";
+	};
+};


### PR DESCRIPTION
Add overlay to support test `uart_async_api` for ek_ra8d1, mck_ra8t1