### PR TITLE
soc: rw6xx: Enable NXP_MONOLITHIC_IEEE802154

### DIFF
--- a/modules/Kconfig.mcux
+++ b/modules/Kconfig.mcux
@@ -388,6 +388,12 @@ config NXP_MONOLITHIC_BT
 	   If enabled, the BT firmware used by the device will be linked with the
 	   application directly.
 
+config NXP_MONOLITHIC_IEEE802154
+	bool "IEEE802154 firmware monolithic build"
+	help
+	   If enabled, the IEEE802154 firmware used by the device will be linked
+	   with the application directly.
+
 config NXP_RF_IMU
 	bool "Include RF_IMU adapter for intercore messaging"
 	select EVENTS

--- a/soc/nxp/rw/Kconfig.defconfig
+++ b/soc/nxp/rw/Kconfig.defconfig
@@ -33,10 +33,13 @@ endif # BT
 config NXP_MONOLITHIC_WIFI
 	default y if WIFI
 
+config NXP_MONOLITHIC_IEEE802154
+	default y if IEEE802154
+
 config NXP_FW_LOADER
-	default y if (BT || WIFI)
+	default y if (BT || WIFI || IEEE802154)
 
 config NXP_RF_IMU
-	default y if (BT || WIFI)
+	default y if (BT || WIFI || IEEE802154)
 
 endif # SOC_SERIES_RW6XX

--- a/soc/nxp/rw/firmwares.ld
+++ b/soc/nxp/rw/firmwares.ld
@@ -15,7 +15,10 @@ KEEP(*(.fw_cpu1))
 . += 4;
 #endif
 
-#if defined(CONFIG_NXP_MONOLITHIC_BT)
+#if defined(CONFIG_NXP_MONOLITHIC_IEEE802154)
+. = ALIGN(4);
+KEEP(*(.fw_cpu2_combo))
+#elif defined(CONFIG_NXP_MONOLITHIC_BT)
 . = ALIGN(4);
 KEEP(*(.fw_cpu2_ble))
 #endif


### PR DESCRIPTION
Enable monolithic build for IEEE802154