### PR TITLE
Bluetooth: Shell: BR: Add NULL pointer check for result->resp_buf

### DIFF
--- a/subsys/bluetooth/host/classic/shell/bredr.c
+++ b/subsys/bluetooth/host/classic/shell/bredr.c
@@ -380,7 +380,7 @@ static uint8_t sdp_hfp_ag_user(struct bt_conn *conn,
 
 	conn_addr_str(conn, addr, sizeof(addr));
 
-	if (result) {
+	if (result && result->resp_buf) {
 		shell_print(ctx_shell, "SDP HFPAG data@%p (len %u) hint %u from"
 			    " remote %s", result->resp_buf,
 			    result->resp_buf->len, result->next_record_hint,
@@ -440,7 +440,7 @@ static uint8_t sdp_a2src_user(struct bt_conn *conn,
 
 	conn_addr_str(conn, addr, sizeof(addr));
 
-	if (result) {
+	if (result && result->resp_buf) {
 		shell_print(ctx_shell, "SDP A2SRC data@%p (len %u) hint %u from"
 			    " remote %s", result->resp_buf,
 			    result->resp_buf->len, result->next_record_hint,


### PR DESCRIPTION
In case the peer device has NO SDP record, the result is valid, but the result->resp_buf is NULL, it would introduce a hardfault. Therefore, also add a NULL pointer check for result->resp_buf.