### PR TITLE
Bluetooth: BAP: Remove ISO chan limit on subgroup count

### DIFF
--- a/subsys/bluetooth/audio/Kconfig.bap
+++ b/subsys/bluetooth/audio/Kconfig.bap
@@ -172,7 +172,6 @@ if BT_BAP_BROADCAST_SINK
 config BT_BAP_BROADCAST_SNK_SUBGROUP_COUNT
 	int "Basic Audio Profile Broadcast Sink subgroup count"
 	default 1
-	range 1 BT_ISO_MAX_CHAN if BT_ISO_MAX_CHAN < 31
 	range 1 31
 	help
 	  This option sets the maximum number of subgroups per broadcast sink


### PR DESCRIPTION
Removing BT_ISO_MAX_CHAN limit on BT_BAP_BROADCAST_SNK_SUBGROUP_COUNT as this would put an unnecessary limit on how many subgroups would be supported in a sink, 

e.g. when sync'ing to a mono BIS in subgroup 4 while still only supporting 2 ISO channels (BT_ISO_MAX_CHAN=2).