### PR TITLE
shell: use shell_device_get_binding

### DIFF
--- a/drivers/audio/codec_shell.c
+++ b/drivers/audio/codec_shell.c
@@ -81,7 +81,7 @@ static int cmd_start(const struct shell *sh, size_t argc, char *argv[])
 {
 	const struct device *dev;
 
-	dev = device_get_binding(argv[args_indx.device]);
+	dev = shell_device_get_binding(argv[args_indx.device]);
 	if (!dev) {
 		shell_error(sh, "Audio Codec device not found");
 		return -ENODEV;
@@ -95,7 +95,7 @@ static int cmd_stop(const struct shell *sh, size_t argc, char *argv[])
 {
 	const struct device *dev;
 
-	dev = device_get_binding(argv[args_indx.device]);
+	dev = shell_device_get_binding(argv[args_indx.device]);
 	if (!dev) {
 		shell_error(sh, "Audio Codec device not found");
 		return -ENODEV;
@@ -114,7 +114,7 @@ static int cmd_set_prop(const struct shell *sh, size_t argc, char *argv[])
 	char *endptr;
 	audio_property_value_t property_value;
 
-	dev = device_get_binding(argv[args_indx.device]);
+	dev = shell_device_get_binding(argv[args_indx.device]);
 	if (!dev) {
 		shell_error(sh, "Audio Codec device not found");
 		return -ENODEV;
@@ -159,7 +159,7 @@ static int cmd_apply_prop(const struct shell *sh, size_t argc, char *argv[])
 {
 	const struct device *dev;
 
-	dev = device_get_binding(argv[args_indx.device]);
+	dev = shell_device_get_binding(argv[args_indx.device]);
 	if (!dev) {
 		shell_error(sh, "Audio Codec device not found");
 		return -ENODEV;

--- a/drivers/bbram/bbram_shell.c
+++ b/drivers/bbram/bbram_shell.c
@@ -61,7 +61,7 @@ static inline int parse_device(const struct shell *sh, size_t argc, char *argv[]
 		return -EINVAL;
 	}
 
-	*bbram_dev = device_get_binding(argv[1]);
+	*bbram_dev = shell_device_get_binding(argv[1]);
 	if (!*bbram_dev) {
 		shell_error(sh, "Given BBRAM device was not found");
 		return -ENODEV;

--- a/drivers/can/can_shell.c
+++ b/drivers/can/can_shell.c
@@ -281,7 +281,7 @@ static void can_shell_print_extended_modes(const struct shell *sh, can_mode_t ca
 
 static int cmd_can_start(const struct shell *sh, size_t argc, char **argv)
 {
-	const struct device *dev = device_get_binding(argv[1]);
+	const struct device *dev = shell_device_get_binding(argv[1]);
 	int err;
 
 	if (!can_device_check(dev)) {
@@ -302,7 +302,7 @@ static int cmd_can_start(const struct shell *sh, size_t argc, char **argv)
 
 static int cmd_can_stop(const struct shell *sh, size_t argc, char **argv)
 {
-	const struct device *dev = device_get_binding(argv[1]);
+	const struct device *dev = shell_device_get_binding(argv[1]);
 	int err;
 
 	if (!can_device_check(dev)) {
@@ -323,7 +323,7 @@ static int cmd_can_stop(const struct shell *sh, size_t argc, char **argv)
 
 static int cmd_can_show(const struct shell *sh, size_t argc, char **argv)
 {
-	const struct device *dev = device_get_binding(argv[1]);
+	const struct device *dev = shell_device_get_binding(argv[1]);
 	const struct device *phy;
 	const struct can_timing *timing_min;
 	const struct can_timing *timing_max;
@@ -434,7 +434,7 @@ static int cmd_can_show(const struct shell *sh, size_t argc, char **argv)
 
 static int cmd_can_bitrate_set(const struct shell *sh, size_t argc, char **argv)
 {
-	const struct device *dev = device_get_binding(argv[1]);
+	const struct device *dev = shell_device_get_binding(argv[1]);
 	struct can_timing timing = { 0 };
 	uint16_t sample_pnt;
 	uint32_t bitrate;
@@ -505,7 +505,7 @@ static int cmd_can_bitrate_set(const struct shell *sh, size_t argc, char **argv)
 
 static int cmd_can_dbitrate_set(const struct shell *sh, size_t argc, char **argv)
 {
-	const struct device *dev = device_get_binding(argv[1]);
+	const struct device *dev = shell_device_get_binding(argv[1]);
 	struct can_timing timing = { 0 };
 	uint16_t sample_pnt;
 	uint32_t bitrate;
@@ -614,7 +614,7 @@ static int can_shell_parse_timing(const struct shell *sh, size_t argc, char **ar
 
 static int cmd_can_timing_set(const struct shell *sh, size_t argc, char **argv)
 {
-	const struct device *dev = device_get_binding(argv[1]);
+	const struct device *dev = shell_device_get_binding(argv[1]);
 	struct can_timing timing = { 0 };
 	int err;
 
@@ -643,7 +643,7 @@ static int cmd_can_timing_set(const struct shell *sh, size_t argc, char **argv)
 
 static int cmd_can_dtiming_set(const struct shell *sh, size_t argc, char **argv)
 {
-	const struct device *dev = device_get_binding(argv[1]);
+	const struct device *dev = shell_device_get_binding(argv[1]);
 	struct can_timing timing = { 0 };
 	int err;
 
@@ -672,7 +672,7 @@ static int cmd_can_dtiming_set(const struct shell *sh, size_t argc, char **argv)
 
 static int cmd_can_mode_set(const struct shell *sh, size_t argc, char **argv)
 {
-	const struct device *dev = device_get_binding(argv[1]);
+	const struct device *dev = shell_device_get_binding(argv[1]);
 	can_mode_t mode = CAN_MODE_NORMAL;
 	can_mode_t raw;
 	char *endptr;
@@ -720,7 +720,7 @@ static int cmd_can_mode_set(const struct shell *sh, size_t argc, char **argv)
 
 static int cmd_can_send(const struct shell *sh, size_t argc, char **argv)
 {
-	const struct device *dev = device_get_binding(argv[1]);
+	const struct device *dev = shell_device_get_binding(argv[1]);
 	static unsigned int frame_counter;
 	unsigned int frame_no;
 	struct can_frame frame = { 0 };
@@ -841,7 +841,7 @@ static int cmd_can_send(const struct shell *sh, size_t argc, char **argv)
 
 static int cmd_can_filter_add(const struct shell *sh, size_t argc, char **argv)
 {
-	const struct device *dev = device_get_binding(argv[1]);
+	const struct device *dev = shell_device_get_binding(argv[1]);
 	struct can_filter filter;
 	uint32_t id_mask;
 	int argidx = 2;
@@ -941,7 +941,7 @@ static int cmd_can_filter_add(const struct shell *sh, size_t argc, char **argv)
 
 static int cmd_can_filter_remove(const struct shell *sh, size_t argc, char **argv)
 {
-	const struct device *dev = device_get_binding(argv[1]);
+	const struct device *dev = shell_device_get_binding(argv[1]);
 	int filter_id;
 	char *endptr;
 
@@ -965,7 +965,7 @@ static int cmd_can_filter_remove(const struct shell *sh, size_t argc, char **arg
 
 static int cmd_can_recover(const struct shell *sh, size_t argc, char **argv)
 {
-	const struct device *dev = device_get_binding(argv[1]);
+	const struct device *dev = shell_device_get_binding(argv[1]);
 	k_timeout_t timeout = K_FOREVER;
 	int millisec;
 	char *endptr;

--- a/drivers/comparator/comparator_shell.c
+++ b/drivers/comparator/comparator_shell.c
@@ -30,7 +30,7 @@ static int get_device_from_str(const struct shell *sh,
 			       const char *dev_str,
 			       const struct device **dev)
 {
-	*dev = device_get_binding(dev_str);
+	*dev = shell_device_get_binding(dev_str);
 
 	if (*dev == NULL) {
 		shell_error(sh, "%s not %s", dev_str, "found");

--- a/drivers/counter/counter_timer_shell.c
+++ b/drivers/counter/counter_timer_shell.c
@@ -42,7 +42,7 @@ static inline int parse_device(const struct shell *shctx, size_t argc, char *arg
 {
 	ARG_UNUSED(argc);
 
-	*timer_dev = device_get_binding(argv[ARGV_DEV]);
+	*timer_dev = shell_device_get_binding(argv[ARGV_DEV]);
 	if (*timer_dev == NULL) {
 		shell_error(shctx, "Timer: Device %s not found", argv[ARGV_DEV]);
 		return -ENODEV;

--- a/drivers/dac/dac_shell.c
+++ b/drivers/dac/dac_shell.c
@@ -36,7 +36,7 @@ static int cmd_setup(const struct shell *sh, size_t argc, char **argv)
 	int argidx;
 	int err;
 
-	dac = device_get_binding(argv[args_indx.device]);
+	dac = shell_device_get_binding(argv[args_indx.device]);
 	if (!dac) {
 		shell_error(sh, "DAC device not found");
 		return -EINVAL;
@@ -76,7 +76,7 @@ static int cmd_write_value(const struct shell *sh, size_t argc, char **argv)
 	uint32_t value;
 	int err;
 
-	dac = device_get_binding(argv[args_indx.device]);
+	dac = shell_device_get_binding(argv[args_indx.device]);
 	if (!dac) {
 		shell_error(sh, "DAC device not found");
 		return -EINVAL;

--- a/drivers/eeprom/eeprom_shell.c
+++ b/drivers/eeprom/eeprom_shell.c
@@ -42,7 +42,7 @@ static int cmd_read(const struct shell *sh, size_t argc, char **argv)
 	addr = strtoul(argv[args_indx.offset], NULL, 0);
 	len = strtoul(argv[args_indx.length], NULL, 0);
 
-	eeprom = device_get_binding(argv[args_indx.device]);
+	eeprom = shell_device_get_binding(argv[args_indx.device]);
 	if (!eeprom) {
 		shell_error(sh, "EEPROM device not found");
 		return -EINVAL;
@@ -98,7 +98,7 @@ static int cmd_write(const struct shell *sh, size_t argc, char **argv)
 		wr_buf[i] = byte;
 	}
 
-	eeprom = device_get_binding(argv[args_indx.device]);
+	eeprom = shell_device_get_binding(argv[args_indx.device]);
 	if (!eeprom) {
 		shell_error(sh, "EEPROM device not found");
 		return -EINVAL;
@@ -134,7 +134,7 @@ static int cmd_size(const struct shell *sh, size_t argc, char **argv)
 {
 	const struct device *eeprom;
 
-	eeprom = device_get_binding(argv[args_indx.device]);
+	eeprom = shell_device_get_binding(argv[args_indx.device]);
 	if (!eeprom) {
 		shell_error(sh, "EEPROM device not found");
 		return -EINVAL;
@@ -167,7 +167,7 @@ static int cmd_fill(const struct shell *sh, size_t argc, char **argv)
 	}
 	memset(wr_buf, pattern, MIN(len, CONFIG_EEPROM_SHELL_BUFFER_SIZE));
 
-	eeprom = device_get_binding(argv[args_indx.device]);
+	eeprom = shell_device_get_binding(argv[args_indx.device]);
 	if (!eeprom) {
 		shell_error(sh, "EEPROM device not found");
 		return -EINVAL;

--- a/drivers/flash/flash_shell.c
+++ b/drivers/flash/flash_shell.c
@@ -54,7 +54,7 @@ static int parse_helper(const struct shell *sh, size_t *argc,
 
 	if (*endptr != '\0') {
 		/* flash controller from user input */
-		*flash_dev = device_get_binding((*argv)[1]);
+		*flash_dev = shell_device_get_binding((*argv)[1]);
 		if (!*flash_dev) {
 			shell_error(sh, "Given flash device was not found");
 			return -ENODEV;
@@ -193,8 +193,8 @@ static int cmd_copy(const struct shell *sh, size_t argc, char *argv[])
 		return -EINVAL;
 	}
 
-	src_dev = device_get_binding(argv[1]);
-	dst_dev = device_get_binding(argv[2]);
+	src_dev = shell_device_get_binding(argv[1]);
+	dst_dev = shell_device_get_binding(argv[2]);
 	src_offset = strtoul(argv[3], NULL, 0);
 	dst_offset = strtoul(argv[4], NULL, 0);
 	/* size will be padded to write_size bytes */

--- a/drivers/fpga/fpga_shell.c
+++ b/drivers/fpga/fpga_shell.c
@@ -13,7 +13,7 @@
 static int parse_common_args(const struct shell *sh, char **argv,
 			     const struct device **dev)
 {
-	*dev = device_get_binding(argv[1]);
+	*dev = shell_device_get_binding(argv[1]);
 	if (!*dev) {
 		shell_error(sh, "FPGA device %s not found", argv[1]);
 		return -ENODEV;

--- a/drivers/i2c/i2c_shell.c
+++ b/drivers/i2c/i2c_shell.c
@@ -53,7 +53,7 @@ static int cmd_i2c_scan(const struct shell *shell_ctx,
 	const struct device *dev;
 	uint8_t cnt = 0, first = 0x04, last = 0x77;
 
-	dev = device_get_binding(argv[ARGV_DEV]);
+	dev = shell_device_get_binding(argv[ARGV_DEV]);
 
 	if (!dev) {
 		shell_error(shell_ctx, "I2C: Device driver %s not found.",
@@ -102,7 +102,7 @@ static int cmd_i2c_recover(const struct shell *shell_ctx,
 	const struct device *dev;
 	int err;
 
-	dev = device_get_binding(argv[ARGV_DEV]);
+	dev = shell_device_get_binding(argv[ARGV_DEV]);
 	if (!dev) {
 		shell_error(shell_ctx, "I2C: Device driver %s not found.",
 			    argv[1]);
@@ -135,7 +135,7 @@ static int i2c_write_from_buffer(const struct shell *shell_ctx,
 	int ret;
 	int i;
 
-	dev = device_get_binding(s_dev_name);
+	dev = shell_device_get_binding(s_dev_name);
 	if (!dev) {
 		shell_error(shell_ctx, "I2C: Device driver %s not found.",
 			    s_dev_name);
@@ -198,7 +198,7 @@ static int i2c_read_to_buffer(const struct shell *shell_ctx,
 	int dev_addr;
 	int ret;
 
-	dev = device_get_binding(s_dev_name);
+	dev = shell_device_get_binding(s_dev_name);
 	if (!dev) {
 		shell_error(shell_ctx, "I2C: Device driver %s not found.",
 			    s_dev_name);
@@ -310,7 +310,7 @@ static int cmd_i2c_speed(const struct shell *shell_ctx, size_t argc, char **argv
 	uint32_t speed;
 	int ret;
 
-	dev = device_get_binding(s_dev_name);
+	dev = shell_device_get_binding(s_dev_name);
 	if (!dev) {
 		shell_error(shell_ctx, "I2C: Device driver %s not found.",
 			    s_dev_name);

--- a/drivers/i3c/i3c_shell.c
+++ b/drivers/i3c/i3c_shell.c
@@ -145,12 +145,12 @@ static struct i3c_device_desc *get_i3c_attached_desc_from_dev_name(const struct 
 static int i3c_parse_args(const struct shell *sh, char **argv, const struct device **dev,
 			  const struct device **tdev, struct i3c_device_desc **desc)
 {
-	*dev = device_get_binding(argv[ARGV_DEV]);
+	*dev = shell_device_get_binding(argv[ARGV_DEV]);
 	if (!*dev) {
 		shell_error(sh, "I3C: Device driver %s not found.", argv[ARGV_DEV]);
 		return -ENODEV;
 	}
-	*tdev = device_get_binding(argv[ARGV_TDEV]);
+	*tdev = shell_device_get_binding(argv[ARGV_TDEV]);
 	if (!*tdev) {
 		shell_error(sh, "I3C: Device driver %s not found.", argv[ARGV_TDEV]);
 		return -ENODEV;
@@ -173,7 +173,7 @@ static int cmd_i3c_info(const struct shell *sh, size_t argc, char **argv)
 	struct i3c_i2c_device_desc *i2c_desc;
 	bool found = false;
 
-	dev = device_get_binding(argv[ARGV_DEV]);
+	dev = shell_device_get_binding(argv[ARGV_DEV]);
 
 	if (!dev) {
 		shell_error(sh, "I3C: Device driver %s not found.", argv[ARGV_DEV]);
@@ -182,7 +182,7 @@ static int cmd_i3c_info(const struct shell *sh, size_t argc, char **argv)
 	data = (struct i3c_driver_data *)dev->data;
 
 	if (argc == 3) {
-		tdev = device_get_binding(argv[ARGV_TDEV]);
+		tdev = shell_device_get_binding(argv[ARGV_TDEV]);
 		if (!tdev) {
 			shell_error(sh, "I3C: Target Device driver %s not found.", argv[ARGV_TDEV]);
 			return -ENODEV;
@@ -296,7 +296,7 @@ static int cmd_i3c_speed(const struct shell *sh, size_t argc, char **argv)
 	uint32_t speed;
 	int ret;
 
-	dev = device_get_binding(argv[ARGV_DEV]);
+	dev = shell_device_get_binding(argv[ARGV_DEV]);
 	if (!dev) {
 		shell_error(sh, "I3C: Device driver %s not found.", argv[1]);
 		return -ENODEV;
@@ -327,7 +327,7 @@ static int cmd_i3c_recover(const struct shell *sh, size_t argc, char **argv)
 	const struct device *dev;
 	int err;
 
-	dev = device_get_binding(argv[ARGV_DEV]);
+	dev = shell_device_get_binding(argv[ARGV_DEV]);
 	if (!dev) {
 		shell_error(sh, "I3C: Device driver %s not found.", argv[1]);
 		return -ENODEV;
@@ -357,12 +357,12 @@ static int i3c_write_from_buffer(const struct shell *sh, char *s_dev_name, char 
 	int ret;
 	int i;
 
-	dev = device_get_binding(s_dev_name);
+	dev = shell_device_get_binding(s_dev_name);
 	if (!dev) {
 		shell_error(sh, "I3C: Device driver %s not found.", s_dev_name);
 		return -ENODEV;
 	}
-	tdev = device_get_binding(s_tdev_name);
+	tdev = shell_device_get_binding(s_tdev_name);
 	if (!tdev) {
 		shell_error(sh, "I3C: Device driver %s not found.", s_tdev_name);
 		return -ENODEV;
@@ -422,12 +422,12 @@ static int i3c_read_to_buffer(const struct shell *sh, char *s_dev_name, char *s_
 	int reg_addr;
 	int ret;
 
-	dev = device_get_binding(s_dev_name);
+	dev = shell_device_get_binding(s_dev_name);
 	if (!dev) {
 		shell_error(sh, "I3C: Device driver %s not found.", s_dev_name);
 		return -ENODEV;
 	}
-	tdev = device_get_binding(s_tdev_name);
+	tdev = shell_device_get_binding(s_tdev_name);
 	if (!tdev) {
 		shell_error(sh, "I3C: Device driver %s not found.", s_dev_name);
 		return -ENODEV;
@@ -572,7 +572,7 @@ static int cmd_i3c_ccc_rstdaa(const struct shell *sh, size_t argc, char **argv)
 	struct i3c_device_desc *desc;
 	int ret;
 
-	dev = device_get_binding(argv[ARGV_DEV]);
+	dev = shell_device_get_binding(argv[ARGV_DEV]);
 	if (!dev) {
 		shell_error(sh, "I3C: Device driver %s not found.", argv[ARGV_DEV]);
 		return -ENODEV;
@@ -598,7 +598,7 @@ static int cmd_i3c_ccc_entdaa(const struct shell *sh, size_t argc, char **argv)
 {
 	const struct device *dev;
 
-	dev = device_get_binding(argv[ARGV_DEV]);
+	dev = shell_device_get_binding(argv[ARGV_DEV]);
 	if (!dev) {
 		shell_error(sh, "I3C: Device driver %s not found.", argv[ARGV_DEV]);
 		return -ENODEV;
@@ -614,7 +614,7 @@ static int cmd_i3c_ccc_setaasa(const struct shell *sh, size_t argc, char **argv)
 	struct i3c_device_desc *desc;
 	int ret;
 
-	dev = device_get_binding(argv[ARGV_DEV]);
+	dev = shell_device_get_binding(argv[ARGV_DEV]);
 	if (!dev) {
 		shell_error(sh, "I3C: Device driver %s not found.", argv[ARGV_DEV]);
 		return -ENODEV;
@@ -924,7 +924,7 @@ static int cmd_i3c_ccc_setmrl_bc(const struct shell *sh, size_t argc, char **arg
 	struct i3c_ccc_mrl mrl;
 	int ret;
 
-	dev = device_get_binding(argv[ARGV_DEV]);
+	dev = shell_device_get_binding(argv[ARGV_DEV]);
 	if (!dev) {
 		shell_error(sh, "I3C: Device driver %s not found.", argv[ARGV_DEV]);
 		return -ENODEV;
@@ -959,7 +959,7 @@ static int cmd_i3c_ccc_setmwl_bc(const struct shell *sh, size_t argc, char **arg
 	struct i3c_ccc_mwl mwl;
 	int ret;
 
-	dev = device_get_binding(argv[ARGV_DEV]);
+	dev = shell_device_get_binding(argv[ARGV_DEV]);
 	if (!dev) {
 		shell_error(sh, "I3C: Device driver %s not found.", argv[ARGV_DEV]);
 		return -ENODEV;
@@ -986,7 +986,7 @@ static int cmd_i3c_ccc_deftgts(const struct shell *sh, size_t argc, char **argv)
 	const struct device *dev;
 	int ret;
 
-	dev = device_get_binding(argv[ARGV_DEV]);
+	dev = shell_device_get_binding(argv[ARGV_DEV]);
 	if (!dev) {
 		shell_error(sh, "I3C: Device driver %s not found.", argv[ARGV_DEV]);
 		return -ENODEV;
@@ -1013,7 +1013,7 @@ static int cmd_i3c_ccc_enttm(const struct shell *sh, size_t argc, char **argv)
 	enum i3c_ccc_enttm_defbyte defbyte;
 	int ret;
 
-	dev = device_get_binding(argv[ARGV_DEV]);
+	dev = shell_device_get_binding(argv[ARGV_DEV]);
 	if (!dev) {
 		shell_error(sh, "I3C: Device driver %s not found.", argv[ARGV_DEV]);
 		return -ENODEV;
@@ -1037,7 +1037,7 @@ static int cmd_i3c_ccc_rstact_bc(const struct shell *sh, size_t argc, char **arg
 	enum i3c_ccc_rstact_defining_byte action;
 	int ret;
 
-	dev = device_get_binding(argv[ARGV_DEV]);
+	dev = shell_device_get_binding(argv[ARGV_DEV]);
 	if (!dev) {
 		shell_error(sh, "I3C: Device driver %s not found.", argv[ARGV_DEV]);
 		return -ENODEV;
@@ -1099,7 +1099,7 @@ static int cmd_i3c_ccc_enec_bc(const struct shell *sh, size_t argc, char **argv)
 	struct i3c_ccc_events events;
 	int ret;
 
-	dev = device_get_binding(argv[ARGV_DEV]);
+	dev = shell_device_get_binding(argv[ARGV_DEV]);
 	if (!dev) {
 		shell_error(sh, "I3C: Device driver %s not found.", argv[ARGV_DEV]);
 		return -ENODEV;
@@ -1123,7 +1123,7 @@ static int cmd_i3c_ccc_disec_bc(const struct shell *sh, size_t argc, char **argv
 	struct i3c_ccc_events events;
 	int ret;
 
-	dev = device_get_binding(argv[ARGV_DEV]);
+	dev = shell_device_get_binding(argv[ARGV_DEV]);
 	if (!dev) {
 		shell_error(sh, "I3C: Device driver %s not found.", argv[ARGV_DEV]);
 		return -ENODEV;
@@ -1195,7 +1195,7 @@ static int cmd_i3c_ccc_entas0_bc(const struct shell *sh, size_t argc, char **arg
 	struct i3c_driver_data *data;
 	int ret;
 
-	dev = device_get_binding(argv[ARGV_DEV]);
+	dev = shell_device_get_binding(argv[ARGV_DEV]);
 	if (!dev) {
 		shell_error(sh, "I3C: Device driver %s not found.", argv[ARGV_DEV]);
 		return -ENODEV;
@@ -1218,7 +1218,7 @@ static int cmd_i3c_ccc_entas1_bc(const struct shell *sh, size_t argc, char **arg
 	struct i3c_driver_data *data;
 	int ret;
 
-	dev = device_get_binding(argv[ARGV_DEV]);
+	dev = shell_device_get_binding(argv[ARGV_DEV]);
 	if (!dev) {
 		shell_error(sh, "I3C: Device driver %s not found.", argv[ARGV_DEV]);
 		return -ENODEV;
@@ -1241,7 +1241,7 @@ static int cmd_i3c_ccc_entas2_bc(const struct shell *sh, size_t argc, char **arg
 	struct i3c_driver_data *data;
 	int ret;
 
-	dev = device_get_binding(argv[ARGV_DEV]);
+	dev = shell_device_get_binding(argv[ARGV_DEV]);
 	if (!dev) {
 		shell_error(sh, "I3C: Device driver %s not found.", argv[ARGV_DEV]);
 		return -ENODEV;
@@ -1264,7 +1264,7 @@ static int cmd_i3c_ccc_entas3_bc(const struct shell *sh, size_t argc, char **arg
 	struct i3c_driver_data *data;
 	int ret;
 
-	dev = device_get_binding(argv[ARGV_DEV]);
+	dev = shell_device_get_binding(argv[ARGV_DEV]);
 	if (!dev) {
 		shell_error(sh, "I3C: Device driver %s not found.", argv[ARGV_DEV]);
 		return -ENODEV;
@@ -1480,13 +1480,13 @@ static int cmd_i3c_ccc_getvendor(const struct shell *sh, size_t argc, char **arg
 	int err = 0;
 	int ret;
 
-	dev = device_get_binding(argv[ARGV_DEV]);
+	dev = shell_device_get_binding(argv[ARGV_DEV]);
 	if (!dev) {
 		shell_error(sh, "I3C: Device driver %s not found.", argv[ARGV_DEV]);
 		return -ENODEV;
 	}
 
-	tdev = device_get_binding(argv[ARGV_TDEV]);
+	tdev = shell_device_get_binding(argv[ARGV_TDEV]);
 	if (!tdev) {
 		shell_error(sh, "I3C: Device driver %s not found.", argv[ARGV_TDEV]);
 		return -ENODEV;
@@ -1534,13 +1534,13 @@ static int cmd_i3c_ccc_setvendor(const struct shell *sh, size_t argc, char **arg
 	int ret;
 	int i;
 
-	dev = device_get_binding(argv[ARGV_DEV]);
+	dev = shell_device_get_binding(argv[ARGV_DEV]);
 	if (!dev) {
 		shell_error(sh, "I3C: Device driver %s not found.", argv[ARGV_DEV]);
 		return -ENODEV;
 	}
 
-	tdev = device_get_binding(argv[ARGV_TDEV]);
+	tdev = shell_device_get_binding(argv[ARGV_TDEV]);
 	if (!tdev) {
 		shell_error(sh, "I3C: Device driver %s not found.", argv[ARGV_TDEV]);
 		return -ENODEV;
@@ -1583,7 +1583,7 @@ static int cmd_i3c_ccc_setvendor_bc(const struct shell *sh, size_t argc, char **
 	int ret;
 	int i;
 
-	dev = device_get_binding(argv[ARGV_DEV]);
+	dev = shell_device_get_binding(argv[ARGV_DEV]);
 	if (!dev) {
 		shell_error(sh, "I3C: Device driver %s not found.", argv[ARGV_DEV]);
 		return -ENODEV;
@@ -1618,7 +1618,7 @@ static int cmd_i3c_ccc_setbuscon(const struct shell *sh, size_t argc, char **arg
 	int ret;
 	int i;
 
-	dev = device_get_binding(argv[ARGV_DEV]);
+	dev = shell_device_get_binding(argv[ARGV_DEV]);
 	if (!dev) {
 		shell_error(sh, "I3C: Device driver %s not found.", argv[ARGV_DEV]);
 		return -ENODEV;
@@ -1707,12 +1707,12 @@ static int cmd_i3c_attach(const struct shell *sh, size_t argc, char **argv)
 	struct i3c_device_desc *desc;
 	int ret;
 
-	dev = device_get_binding(argv[ARGV_DEV]);
+	dev = shell_device_get_binding(argv[ARGV_DEV]);
 	if (!dev) {
 		shell_error(sh, "I3C: Device driver %s not found.", argv[ARGV_DEV]);
 		return -ENODEV;
 	}
-	tdev = device_get_binding(argv[ARGV_TDEV]);
+	tdev = shell_device_get_binding(argv[ARGV_TDEV]);
 	if (!tdev) {
 		shell_error(sh, "I3C: Device driver %s not found.", argv[ARGV_TDEV]);
 		return -ENODEV;
@@ -1781,7 +1781,7 @@ static int cmd_i3c_i2c_attach(const struct shell *sh, size_t argc, char **argv)
 	uint16_t addr = 0;
 	int ret;
 
-	dev = device_get_binding(argv[ARGV_DEV]);
+	dev = shell_device_get_binding(argv[ARGV_DEV]);
 	if (!dev) {
 		shell_error(sh, "I3C: Device driver %s not found.", argv[ARGV_DEV]);
 		return -ENODEV;
@@ -1808,7 +1808,7 @@ static int cmd_i3c_i2c_detach(const struct shell *sh, size_t argc, char **argv)
 	uint16_t addr = 0;
 	int ret;
 
-	dev = device_get_binding(argv[ARGV_DEV]);
+	dev = shell_device_get_binding(argv[ARGV_DEV]);
 	if (!dev) {
 		shell_error(sh, "I3C: Device driver %s not found.", argv[ARGV_DEV]);
 		return -ENODEV;
@@ -1857,7 +1857,7 @@ static int cmd_i3c_i2c_scan(const struct shell *sh, size_t argc, char **argv)
 	enum i3c_addr_slot_status slot;
 	uint8_t cnt = 0, first = 0x04, last = 0x77;
 
-	dev = device_get_binding(argv[ARGV_DEV]);
+	dev = shell_device_get_binding(argv[ARGV_DEV]);
 
 	if (!dev) {
 		shell_error(sh, "I3C: Device driver %s not found.", argv[ARGV_DEV]);
@@ -1934,7 +1934,7 @@ static int cmd_i3c_ibi_hj(const struct shell *sh, size_t argc, char **argv)
 	struct i3c_ibi request;
 	int ret;
 
-	dev = device_get_binding(argv[ARGV_DEV]);
+	dev = shell_device_get_binding(argv[ARGV_DEV]);
 	if (!dev) {
 		shell_error(sh, "I3C: Device driver %s not found.", argv[ARGV_DEV]);
 		return -ENODEV;
@@ -1959,7 +1959,7 @@ static int cmd_i3c_ibi_cr(const struct shell *sh, size_t argc, char **argv)
 	struct i3c_ibi request;
 	int ret;
 
-	dev = device_get_binding(argv[ARGV_DEV]);
+	dev = shell_device_get_binding(argv[ARGV_DEV]);
 	if (!dev) {
 		shell_error(sh, "I3C: Device driver %s not found.", argv[ARGV_DEV]);
 		return -ENODEV;
@@ -1987,7 +1987,7 @@ static int cmd_i3c_ibi_tir(const struct shell *sh, size_t argc, char **argv)
 	int ret;
 	uint8_t i;
 
-	dev = device_get_binding(argv[ARGV_DEV]);
+	dev = shell_device_get_binding(argv[ARGV_DEV]);
 	if (!dev) {
 		shell_error(sh, "I3C: Device driver %s not found.", argv[ARGV_DEV]);
 		return -ENODEV;

--- a/drivers/led/led_shell.c
+++ b/drivers/led/led_shell.c
@@ -26,7 +26,7 @@ static int parse_common_args(const struct shell *sh, char **argv,
 {
 	char *end_ptr;
 
-	*dev = device_get_binding(argv[arg_idx_dev]);
+	*dev = shell_device_get_binding(argv[arg_idx_dev]);
 	if (!*dev) {
 		shell_error(sh,
 			    "LED device %s not found", argv[arg_idx_dev]);

--- a/drivers/pwm/pwm_shell.c
+++ b/drivers/pwm/pwm_shell.c
@@ -38,7 +38,7 @@ static int cmd_cycles(const struct shell *sh, size_t argc, char **argv)
 	uint32_t channel;
 	int err;
 
-	dev = device_get_binding(argv[args_indx.device]);
+	dev = shell_device_get_binding(argv[args_indx.device]);
 	if (!dev) {
 		shell_error(sh, "PWM device not found");
 		return -EINVAL;
@@ -71,7 +71,7 @@ static int cmd_usec(const struct shell *sh, size_t argc, char **argv)
 	uint32_t channel;
 	int err;
 
-	dev = device_get_binding(argv[args_indx.device]);
+	dev = shell_device_get_binding(argv[args_indx.device]);
 	if (!dev) {
 		shell_error(sh, "PWM device not found");
 		return -EINVAL;
@@ -103,7 +103,7 @@ static int cmd_nsec(const struct shell *sh, size_t argc, char **argv)
 	uint32_t channel;
 	int err;
 
-	dev = device_get_binding(argv[args_indx.device]);
+	dev = shell_device_get_binding(argv[args_indx.device]);
 	if (!dev) {
 		shell_error(sh, "PWM device not found");
 		return -EINVAL;

--- a/drivers/regulator/regulator_shell.c
+++ b/drivers/regulator/regulator_shell.c
@@ -89,7 +89,7 @@ static int cmd_enable(const struct shell *sh, size_t argc, char **argv)
 
 	ARG_UNUSED(argc);
 
-	dev = device_get_binding(argv[1]);
+	dev = shell_device_get_binding(argv[1]);
 	if (dev == NULL) {
 		shell_error(sh, "Regulator device %s not available", argv[1]);
 		return -ENODEV;
@@ -111,7 +111,7 @@ static int cmd_disable(const struct shell *sh, size_t argc, char **argv)
 
 	ARG_UNUSED(argc);
 
-	dev = device_get_binding(argv[1]);
+	dev = shell_device_get_binding(argv[1]);
 	if (dev == NULL) {
 		shell_error(sh, "Regulator device %s not available", argv[1]);
 		return -ENODEV;
@@ -132,7 +132,7 @@ static int cmd_is_enabled(const struct shell *sh, size_t argc, char **argv)
 
 	ARG_UNUSED(argc);
 
-	dev = device_get_binding(argv[1]);
+	dev = shell_device_get_binding(argv[1]);
 	if (dev == NULL) {
 		shell_error(sh, "Regulator device %s not available", argv[1]);
 		return -ENODEV;
@@ -155,7 +155,7 @@ static int cmd_vlist(const struct shell *sh, size_t argc, char **argv)
 
 	ARG_UNUSED(argc);
 
-	dev = device_get_binding(argv[1]);
+	dev = shell_device_get_binding(argv[1]);
 	if (dev == NULL) {
 		shell_error(sh, "Regulator device %s not available", argv[1]);
 		return -ENODEV;
@@ -185,7 +185,7 @@ static int cmd_vset(const struct shell *sh, size_t argc, char **argv)
 	int32_t min_uv, max_uv;
 	int ret;
 
-	dev = device_get_binding(argv[1]);
+	dev = shell_device_get_binding(argv[1]);
 	if (dev == NULL) {
 		shell_error(sh, "Regulator device %s not available", argv[1]);
 		return -ENODEV;
@@ -224,7 +224,7 @@ static int cmd_vget(const struct shell *sh, size_t argc, char **argv)
 
 	ARG_UNUSED(argc);
 
-	dev = device_get_binding(argv[1]);
+	dev = shell_device_get_binding(argv[1]);
 	if (dev == NULL) {
 		shell_error(sh, "Regulator device %s not available", argv[1]);
 		return -ENODEV;
@@ -249,7 +249,7 @@ static int cmd_clist(const struct shell *sh, size_t argc, char **argv)
 
 	ARG_UNUSED(argc);
 
-	dev = device_get_binding(argv[1]);
+	dev = shell_device_get_binding(argv[1]);
 	if (dev == NULL) {
 		shell_error(sh, "Regulator device %s not available", argv[1]);
 		return -ENODEV;
@@ -279,7 +279,7 @@ static int cmd_iset(const struct shell *sh, size_t argc, char **argv)
 	int32_t min_ua, max_ua;
 	int ret;
 
-	dev = device_get_binding(argv[1]);
+	dev = shell_device_get_binding(argv[1]);
 	if (dev == NULL) {
 		shell_error(sh, "Regulator device %s not available", argv[1]);
 		return -ENODEV;
@@ -317,7 +317,7 @@ static int cmd_iget(const struct shell *sh, size_t argc, char **argv)
 
 	ARG_UNUSED(argc);
 
-	dev = device_get_binding(argv[1]);
+	dev = shell_device_get_binding(argv[1]);
 	if (dev == NULL) {
 		shell_error(sh, "Regulator device %s not available", argv[1]);
 		return -ENODEV;
@@ -342,7 +342,7 @@ static int cmd_modeset(const struct shell *sh, size_t argc, char **argv)
 
 	ARG_UNUSED(argc);
 
-	dev = device_get_binding(argv[1]);
+	dev = shell_device_get_binding(argv[1]);
 	if (dev == NULL) {
 		shell_error(sh, "Regulator device %s not available", argv[1]);
 		return -ENODEV;
@@ -367,7 +367,7 @@ static int cmd_modeget(const struct shell *sh, size_t argc, char **argv)
 
 	ARG_UNUSED(argc);
 
-	dev = device_get_binding(argv[1]);
+	dev = shell_device_get_binding(argv[1]);
 	if (dev == NULL) {
 		shell_error(sh, "Regulator device %s not available", argv[1]);
 		return -ENODEV;
@@ -392,7 +392,7 @@ static int cmd_adset(const struct shell *sh, size_t argc, char **argv)
 
 	ARG_UNUSED(argc);
 
-	dev = device_get_binding(argv[1]);
+	dev = shell_device_get_binding(argv[1]);
 	if (dev == NULL) {
 		shell_error(sh, "Regulator device %s not available", argv[1]);
 		return -ENODEV;
@@ -424,7 +424,7 @@ static int cmd_adget(const struct shell *sh, size_t argc, char **argv)
 
 	ARG_UNUSED(argc);
 
-	dev = device_get_binding(argv[1]);
+	dev = shell_device_get_binding(argv[1]);
 	if (dev == NULL) {
 		shell_error(sh, "Regulator device %s not available", argv[1]);
 		return -ENODEV;
@@ -449,7 +449,7 @@ static int cmd_errors(const struct shell *sh, size_t argc, char **argv)
 
 	ARG_UNUSED(argc);
 
-	dev = device_get_binding(argv[1]);
+	dev = shell_device_get_binding(argv[1]);
 	if (dev == NULL) {
 		shell_error(sh, "Regulator device %s not available", argv[1]);
 		return -ENODEV;
@@ -479,7 +479,7 @@ static int cmd_dvsset(const struct shell *sh, size_t argc, char **argv)
 	int ret = 0;
 	regulator_dvs_state_t state;
 
-	dev = device_get_binding(argv[1]);
+	dev = shell_device_get_binding(argv[1]);
 	if (dev == NULL) {
 		shell_error(sh, "Regulator device %s not available", argv[1]);
 		return -ENODEV;
@@ -507,7 +507,7 @@ static int cmd_shipmode(const struct shell *sh, size_t argc, char **argv)
 
 	ARG_UNUSED(argc);
 
-	dev = device_get_binding(argv[1]);
+	dev = shell_device_get_binding(argv[1]);
 	if (dev == NULL) {
 		shell_error(sh, "Regulator device %s not available", argv[1]);
 		return -ENODEV;

--- a/drivers/rtc/rtc_shell.c
+++ b/drivers/rtc/rtc_shell.c
@@ -148,7 +148,7 @@ static char *strptime(const char *s, const char *format, struct tm *tm_time)
 
 static int cmd_set(const struct shell *sh, size_t argc, char **argv)
 {
-	const struct device *dev = device_get_binding(argv[1]);
+	const struct device *dev = shell_device_get_binding(argv[1]);
 
 	if (!device_is_ready(dev)) {
 		shell_error(sh, "device %s not ready", argv[1]);
@@ -191,7 +191,7 @@ static int cmd_set(const struct shell *sh, size_t argc, char **argv)
 
 static int cmd_get(const struct shell *sh, size_t argc, char **argv)
 {
-	const struct device *dev = device_get_binding(argv[1]);
+	const struct device *dev = shell_device_get_binding(argv[1]);
 
 	if (!device_is_ready(dev)) {
 		shell_error(sh, "device %s not ready", argv[1]);

--- a/drivers/sensor/sensor_shell.c
+++ b/drivers/sensor/sensor_shell.c
@@ -548,7 +548,7 @@ static int cmd_get_sensor(const struct shell *sh, size_t argc, char *argv[])
 		return err;
 	}
 
-	dev = device_get_binding(argv[1]);
+	dev = shell_device_get_binding(argv[1]);
 	if (dev == NULL || !sensor_device_check(dev)) {
 		shell_error(sh, "Sensor device unknown (%s)", argv[1]);
 		k_mutex_unlock(&cmd_get_mutex);
@@ -617,7 +617,7 @@ static int cmd_sensor_attr_set(const struct shell *shell_ptr, size_t argc, char 
 	const struct device *dev;
 	int rc;
 
-	dev = device_get_binding(argv[1]);
+	dev = shell_device_get_binding(argv[1]);
 	if (dev == NULL || !sensor_device_check(dev)) {
 		shell_error(shell_ptr, "Sensor device unknown (%s)", argv[1]);
 		return -ENODEV;
@@ -701,7 +701,7 @@ static int cmd_sensor_attr_get(const struct shell *shell_ptr, size_t argc, char 
 {
 	const struct device *dev;
 
-	dev = device_get_binding(argv[1]);
+	dev = shell_device_get_binding(argv[1]);
 	if (dev == NULL || !sensor_device_check(dev)) {
 		shell_error(shell_ptr, "Sensor device unknown (%s)", argv[1]);
 		return -ENODEV;
@@ -1051,7 +1051,7 @@ static int cmd_trig_sensor(const struct shell *sh, size_t argc, char **argv)
 	}
 
 	/* Parse device name */
-	dev = device_get_binding(argv[1]);
+	dev = shell_device_get_binding(argv[1]);
 	if (dev == NULL || !sensor_device_check(dev)) {
 		shell_error(sh, "Sensor device unknown (%s)", argv[1]);
 		return -ENODEV;

--- a/drivers/smbus/smbus_shell.c
+++ b/drivers/smbus/smbus_shell.c
@@ -48,7 +48,7 @@ static int cmd_smbus_scan(const struct shell *sh, size_t argc, char **argv)
 	const struct device *dev;
 	uint8_t cnt = 0, first = 0x04, last = 0x77;
 
-	dev = device_get_binding(argv[ARGV_DEV]);
+	dev = shell_device_get_binding(argv[ARGV_DEV]);
 	if (!dev) {
 		shell_error(sh, "SMBus: Device %s not found", argv[ARGV_DEV]);
 		return -ENODEV;
@@ -87,7 +87,7 @@ static int cmd_smbus_quick(const struct shell *sh, size_t argc, char **argv)
 	uint8_t addr;
 	int ret;
 
-	dev = device_get_binding(argv[ARGV_DEV]);
+	dev = shell_device_get_binding(argv[ARGV_DEV]);
 	if (!dev) {
 		shell_error(sh, "SMBus: Device %s not found", argv[ARGV_DEV]);
 		return -ENODEV;
@@ -111,7 +111,7 @@ static int cmd_smbus_byte_read(const struct shell *sh, size_t argc, char **argv)
 	uint8_t out;
 	int ret;
 
-	dev = device_get_binding(argv[ARGV_DEV]);
+	dev = shell_device_get_binding(argv[ARGV_DEV]);
 	if (!dev) {
 		shell_error(sh, "SMBus: Device %s not found", argv[ARGV_DEV]);
 		return -ENODEV;
@@ -140,7 +140,7 @@ static int cmd_smbus_byte_write(const struct shell *sh,
 	uint8_t value;
 	int ret;
 
-	dev = device_get_binding(argv[ARGV_DEV]);
+	dev = shell_device_get_binding(argv[ARGV_DEV]);
 	if (!dev) {
 		shell_error(sh, "SMBus: Device %s not found", argv[ARGV_DEV]);
 		return -ENODEV;
@@ -169,7 +169,7 @@ static int cmd_smbus_byte_data_read(const struct shell *sh,
 	uint8_t out;
 	int ret;
 
-	dev = device_get_binding(argv[ARGV_DEV]);
+	dev = shell_device_get_binding(argv[ARGV_DEV]);
 	if (!dev) {
 		shell_error(sh, "SMBus: Device %s not found", argv[ARGV_DEV]);
 		return -ENODEV;
@@ -199,7 +199,7 @@ static int cmd_smbus_byte_data_write(const struct shell *sh,
 	uint8_t value;
 	int ret;
 
-	dev = device_get_binding(argv[ARGV_DEV]);
+	dev = shell_device_get_binding(argv[ARGV_DEV]);
 	if (!dev) {
 		shell_error(sh, "SMBus: Device %s not found", argv[ARGV_DEV]);
 		return -ENODEV;
@@ -228,7 +228,7 @@ static int cmd_smbus_word_data_read(const struct shell *sh,
 	uint16_t out;
 	int ret;
 
-	dev = device_get_binding(argv[ARGV_DEV]);
+	dev = shell_device_get_binding(argv[ARGV_DEV]);
 	if (!dev) {
 		shell_error(sh, "SMBus: Device %s not found", argv[ARGV_DEV]);
 		return -ENODEV;
@@ -258,7 +258,7 @@ static int cmd_smbus_word_data_write(const struct shell *sh,
 	uint16_t value;
 	int ret;
 
-	dev = device_get_binding(argv[ARGV_DEV]);
+	dev = shell_device_get_binding(argv[ARGV_DEV]);
 	if (!dev) {
 		shell_error(sh, "SMBus: Device %s not found", argv[ARGV_DEV]);
 		return -ENODEV;
@@ -293,7 +293,7 @@ static int cmd_smbus_block_write(const struct shell *sh,
 		return -EINVAL;
 	}
 
-	dev = device_get_binding(argv[ARGV_DEV]);
+	dev = shell_device_get_binding(argv[ARGV_DEV]);
 	if (!dev) {
 		shell_error(sh, "SMBus: Device %s not found", argv[ARGV_DEV]);
 		return -ENODEV;
@@ -328,7 +328,7 @@ static int cmd_smbus_block_read(const struct shell *sh,
 	uint8_t count;
 	int ret;
 
-	dev = device_get_binding(argv[ARGV_DEV]);
+	dev = shell_device_get_binding(argv[ARGV_DEV]);
 	if (!dev) {
 		shell_error(sh, "SMBus: Device %s not found", argv[ARGV_DEV]);
 		return -ENODEV;

--- a/drivers/spi/spi_shell.c
+++ b/drivers/spi/spi_shell.c
@@ -80,7 +80,7 @@ static int cmd_spi_conf(const struct shell *ctx, size_t argc, char **argv)
 
 	/* warning: initialization discards 'const' qualifier from pointer */
 	/* target type */
-	struct device *dev = (struct device *)device_get_binding(argv[CONF_ARGV_DEV]);
+	struct device *dev = (struct device *)shell_device_get_binding(argv[CONF_ARGV_DEV]);
 
 	if (dev == NULL) {
 		shell_error(ctx, "device %s not found.", argv[CONF_ARGV_DEV]);

--- a/drivers/stepper/stepper_shell.c
+++ b/drivers/stepper/stepper_shell.c
@@ -159,7 +159,7 @@ SHELL_DYNAMIC_CMD_CREATE(dsub_pos_stepper_motor_name_microstep,
 
 static int parse_device_arg(const struct shell *sh, char **argv, const struct device **dev)
 {
-	*dev = device_get_binding(argv[ARG_IDX_DEV]);
+	*dev = shell_device_get_binding(argv[ARG_IDX_DEV]);
 	if (!*dev) {
 		shell_error(sh, "Stepper device %s not found", argv[ARG_IDX_DEV]);
 		return -ENODEV;

--- a/drivers/usb_c/ppc/shell.c
+++ b/drivers/usb_c/ppc/shell.c
@@ -27,7 +27,7 @@ static int cmd_ppc_dump(const struct shell *sh, size_t argc, char **argv)
 	if (argc <= 1) {
 		DT_FOREACH_STATUS_OKAY_VARGS(usb_c_connector, CALL_IF_HAS_PPC, ppc_dump_regs);
 	} else {
-		const struct device *dev = device_get_binding(argv[1]);
+		const struct device *dev = shell_device_get_binding(argv[1]);
 
 		ret = ppc_dump_regs(dev);
 	}
@@ -66,7 +66,7 @@ static int cmd_ppc_status(const struct shell *sh, size_t argc, char **argv)
 	if (argc <= 1) {
 		DT_FOREACH_STATUS_OKAY_VARGS(usb_c_connector, CALL_IF_HAS_PPC, print_status);
 	} else {
-		const struct device *dev = device_get_binding(argv[1]);
+		const struct device *dev = shell_device_get_binding(argv[1]);
 
 		ret = print_status(dev);
 	}
@@ -90,7 +90,7 @@ static int cmd_ppc_exit_db(const struct shell *sh, size_t argc, char **argv)
 		DT_FOREACH_STATUS_OKAY_VARGS(usb_c_connector, CALL_IF_HAS_PPC,
 					     ppc_exit_dead_battery_mode);
 	} else {
-		const struct device *dev = device_get_binding(argv[1]);
+		const struct device *dev = shell_device_get_binding(argv[1]);
 
 		ret = ppc_exit_dead_battery_mode(dev);
 	}

--- a/drivers/usb_c/tcpc/shell.c
+++ b/drivers/usb_c/tcpc/shell.c
@@ -54,7 +54,7 @@ static int cmd_tcpc_dump(const struct shell *sh, size_t argc, char **argv)
 	if (argc <= 1) {
 		DT_FOREACH_STATUS_OKAY(usb_c_connector, TCPC_DUMP_CONN_NODE);
 	} else {
-		const struct device *dev = device_get_binding(argv[1]);
+		const struct device *dev = shell_device_get_binding(argv[1]);
 
 		if (dev != NULL) {
 			TCPC_DUMP_DEV(dev);
@@ -81,7 +81,7 @@ static int cmd_tcpc_vbus(const struct shell *sh, size_t argc, char **argv)
 	if (argc <= 1) {
 		DT_FOREACH_STATUS_OKAY(usb_c_connector, TCPC_VBUS_CONN_NODE);
 	} else {
-		const struct device *dev = device_get_binding(argv[1]);
+		const struct device *dev = shell_device_get_binding(argv[1]);
 
 		if (dev != NULL) {
 			TCPC_VBUS_DEV(dev);
@@ -109,7 +109,7 @@ static int cmd_tcpc_chip_info(const struct shell *sh, size_t argc, char **argv)
 	if (argc <= 1) {
 		DT_FOREACH_STATUS_OKAY(usb_c_connector, TCPC_GET_CHIP_CONN_NODE);
 	} else {
-		const struct device *dev = device_get_binding(argv[1]);
+		const struct device *dev = shell_device_get_binding(argv[1]);
 
 		if (dev != NULL) {
 			TCPC_GET_CHIP_DEV(dev);

--- a/drivers/w1/w1_shell.c
+++ b/drivers/w1/w1_shell.c
@@ -52,7 +52,7 @@ static int cmd_w1_reset_bus(const struct shell *sh, size_t argc, char **argv)
 	const struct device *dev;
 	int ret;
 
-	dev = device_get_binding(argv[1]);
+	dev = shell_device_get_binding(argv[1]);
 	if (!dev) {
 		shell_error(sh, W1DEV_X_NOT_FOUND, argv[1]);
 		return -EINVAL;
@@ -74,7 +74,7 @@ static int cmd_w1_read_bit(const struct shell *sh, size_t argc, char **argv)
 	const struct device *dev;
 	int ret;
 
-	dev = device_get_binding(argv[1]);
+	dev = shell_device_get_binding(argv[1]);
 	if (!dev) {
 		shell_error(sh, W1DEV_X_NOT_FOUND, argv[1]);
 		return -EINVAL;
@@ -98,7 +98,7 @@ static int cmd_w1_read_byte(const struct shell *sh, size_t argc, char **argv)
 	const struct device *dev;
 	int ret;
 
-	dev = device_get_binding(argv[1]);
+	dev = shell_device_get_binding(argv[1]);
 	if (!dev) {
 		shell_error(sh, W1DEV_X_NOT_FOUND, argv[1]);
 		return -EINVAL;
@@ -124,7 +124,7 @@ static int cmd_w1_read_block(const struct shell *sh, size_t argc, char **argv)
 	size_t read_len;
 	int ret;
 
-	dev = device_get_binding(argv[1]);
+	dev = shell_device_get_binding(argv[1]);
 	if (!dev) {
 		shell_error(sh, W1DEV_X_NOT_FOUND, argv[1]);
 		return -EINVAL;
@@ -165,7 +165,7 @@ static int cmd_w1_write_bit(const struct shell *sh, size_t argc, char **argv)
 	unsigned long input = strtoul(argv[2], NULL, 0);
 	int ret;
 
-	dev = device_get_binding(argv[1]);
+	dev = shell_device_get_binding(argv[1]);
 	if (!dev) {
 		shell_error(sh, W1DEV_X_NOT_FOUND, argv[1]);
 		return -EINVAL;
@@ -194,7 +194,7 @@ static int cmd_w1_write_byte(const struct shell *sh, size_t argc, char **argv)
 	bool reset = false;
 	int ret;
 
-	dev = device_get_binding(argv[pos]);
+	dev = shell_device_get_binding(argv[pos]);
 	if (!dev) {
 		shell_error(sh, W1DEV_X_NOT_FOUND, argv[pos]);
 		return -EINVAL;
@@ -243,7 +243,7 @@ static int cmd_w1_write_block(const struct shell *sh, size_t argc, char **argv)
 	bool reset = false;
 	int ret;
 
-	dev = device_get_binding(argv[pos]);
+	dev = shell_device_get_binding(argv[pos]);
 	if (!dev) {
 		shell_error(sh, W1DEV_X_NOT_FOUND, argv[1]);
 		return -EINVAL;
@@ -297,7 +297,7 @@ static int cmd_w1_configure(const struct shell *sh, size_t argc, char **argv)
 	uint32_t type = strtoul(type_name, &type_endptr, 0);
 	uint32_t value = strtoul(argv[3], NULL, 0);
 
-	dev = device_get_binding(argv[1]);
+	dev = shell_device_get_binding(argv[1]);
 	if (!dev) {
 		shell_error(sh, W1DEV_X_NOT_FOUND, argv[1]);
 		return -EINVAL;
@@ -350,7 +350,7 @@ static int cmd_w1_search(const struct shell *sh, size_t argc, char **argv)
 	const struct device *dev;
 	int ret;
 
-	dev = device_get_binding(argv[1]);
+	dev = shell_device_get_binding(argv[1]);
 	if (!dev) {
 		shell_error(sh, W1DEV_X_NOT_FOUND, argv[1]);
 		return -EINVAL;

--- a/drivers/watchdog/wdt_shell.c
+++ b/drivers/watchdog/wdt_shell.c
@@ -72,7 +72,7 @@ static int cmd_setup(const struct shell *sh, size_t argc, char *argv[])
 {
 	const struct device *dev;
 
-	dev = device_get_binding(argv[args_indx.device]);
+	dev = shell_device_get_binding(argv[args_indx.device]);
 	if (!dev) {
 		shell_error(sh, "WDT device not found");
 		return -ENODEV;
@@ -85,7 +85,7 @@ static int cmd_disable(const struct shell *sh, size_t argc, char *argv[])
 {
 	const struct device *dev;
 
-	dev = device_get_binding(argv[args_indx.device]);
+	dev = shell_device_get_binding(argv[args_indx.device]);
 	if (!dev) {
 		shell_error(sh, "WDT device not found");
 		return -ENODEV;
@@ -103,7 +103,7 @@ static int cmd_timeout(const struct shell *sh, size_t argc, char *argv[])
 	struct wdt_timeout_cfg cfg;
 	int rc;
 
-	dev = device_get_binding(argv[args_indx.device]);
+	dev = shell_device_get_binding(argv[args_indx.device]);
 	if (!dev) {
 		shell_error(sh, "WDT device not found");
 		return -ENODEV;
@@ -145,7 +145,7 @@ static int cmd_feed(const struct shell *sh, size_t argc, char *argv[])
 	const struct device *dev;
 	int channel_id;
 
-	dev = device_get_binding(argv[args_indx.device]);
+	dev = shell_device_get_binding(argv[args_indx.device]);
 	if (!dev) {
 		shell_error(sh, "WDT device not found");
 		return -ENODEV;

--- a/subsys/pm/pm_shell.c
+++ b/subsys/pm/pm_shell.c
@@ -31,7 +31,7 @@ static int pm_cmd_suspend(const struct shell *sh, size_t argc, char *argv[])
 	const struct device *dev;
 	int ret;
 
-	dev = device_get_binding(argv[1]);
+	dev = shell_device_get_binding(argv[1]);
 	if (dev == NULL) {
 		shell_error(sh, "Invalid device: %s", argv[1]);
 		return -ENODEV;
@@ -57,7 +57,7 @@ static int pm_cmd_resume(const struct shell *sh, size_t argc, char *argv[])
 	const struct device *dev;
 	int ret;
 
-	dev = device_get_binding(argv[1]);
+	dev = shell_device_get_binding(argv[1]);
 	if (dev == NULL) {
 		shell_error(sh, "Invalid device: %s", argv[1]);
 		return -ENODEV;
@@ -84,7 +84,7 @@ static int pm_cmd_runtime_get(const struct shell *sh, size_t argc, char *argv[])
 	const struct device *dev;
 	int ret;
 
-	dev = device_get_binding(argv[1]);
+	dev = shell_device_get_binding(argv[1]);
 	if (dev == NULL) {
 		shell_error(sh, "Invalid device: %s", argv[1]);
 		return -ENODEV;
@@ -109,7 +109,7 @@ static int pm_cmd_runtime_put(const struct shell *sh, size_t argc, char *argv[])
 	const struct device *dev;
 	int ret;
 
-	dev = device_get_binding(argv[1]);
+	dev = shell_device_get_binding(argv[1]);
 	if (dev == NULL) {
 		shell_error(sh, "Invalid device: %s", argv[1]);
 		return -ENODEV;
@@ -134,7 +134,7 @@ static int pm_cmd_runtime_put_async(const struct shell *sh, size_t argc, char *a
 	const struct device *dev;
 	int ret;
 
-	dev = device_get_binding(argv[1]);
+	dev = shell_device_get_binding(argv[1]);
 	if (dev == NULL) {
 		shell_error(sh, "Invalid device: %s", argv[1]);
 		return -ENODEV;


### PR DESCRIPTION
Use shell_device_get_binding() instead of device_get_binding() so that we get the device based on its name and in addition by its label.
This can be done now that https://github.com/zephyrproject-rtos/zephyr/pull/82698 is merged