### PR TITLE
manifest: update hal_nordic revision

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -189,7 +189,7 @@ manifest:
       groups:
         - hal
     - name: hal_nordic
-      revision: e0e48c4ec75595767a286389e2fcda72b21363b0
+      revision: dbfe4a14cf0ac7425ef58f1a01576873f5976f4c
       path: modules/hal/nordic
       groups:
         - hal


### PR DESCRIPTION
The nrfx sample applications now enable nrfx_gppi functionality explicitly.