### PR TITLE
Bluetooth: Controller: Fix headroom reservation for ISO

### DIFF
--- a/subsys/bluetooth/controller/hci/hci_driver.c
+++ b/subsys/bluetooth/controller/hci/hci_driver.c
@@ -158,8 +158,8 @@ isoal_status_t sink_sdu_alloc_hci(const struct isoal_sink    *sink_ctx,
 	struct net_buf *buf  = bt_buf_get_rx(BT_BUF_ISO_IN, K_FOREVER);
 
 	if (buf) {
-		/* Reserve space for headers */
-		net_buf_reserve(buf, SDU_HCI_HDR_SIZE);
+		/* Increase reserved space for headers */
+		net_buf_reserve(buf, SDU_HCI_HDR_SIZE + net_buf_headroom(buf));
 
 		sdu_buffer->dbuf = buf;
 		sdu_buffer->size = net_buf_tailroom(buf);

--- a/tests/bsim/bluetooth/audio/sysbuild.cmake
+++ b/tests/bsim/bluetooth/audio/sysbuild.cmake
@@ -20,6 +20,7 @@ if(SB_CONFIG_NET_CORE_IMAGE_HCI_IPC)
 
 	set(${NET_APP}_EXTRA_CONF_FILE
 	 ${APP_DIR}/overlay-nrf5340_cpunet_iso-bt_ll_sw_split.conf
+	 ${NET_APP_SRC_DIR}/debug_overlay.conf
 	 CACHE INTERNAL ""
 	)
 


### PR DESCRIPTION
Calling `net_buf_reserve` removed any previous reservation, which includes the reservation by hci_ipc to hold the H4 type byte. This resulted in a out-of-bounds net_buf_push in hci_ipc.

This commit also enables asserts in hci_ipc in the audio bsim test, which reveal the out-of-bounds write.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/82856