### PR TITLE
tests: logging: log_backend_uart: Fix stack overflow

### DIFF
--- a/tests/subsys/logging/log_backend_uart/src/main.c
+++ b/tests/subsys/logging/log_backend_uart/src/main.c
@@ -55,19 +55,22 @@ static void uart_emul_before(void *f)
 
 ZTEST_F(log_backend_uart, test_log_backend_uart_multi_instance)
 {
+	/* Prevent stack overflow by making it static */
+	static uint8_t tx_content[SAMPLE_DATA_SIZE];
+	size_t tx_len;
+
 	zassert_equal(log_backend_count_get(), EMUL_UART_NUM, "Unexpected number of instance(s)");
 
 	LOG_RAW(TEST_DATA);
 
 	for (size_t i = 0; i < EMUL_UART_NUM; i++) {
-		uint8_t tx_content[SAMPLE_DATA_SIZE] = {0};
-		size_t tx_len;
+		memset(tx_content, 0, sizeof(tx_content));
 
 		tx_len = uart_emul_get_tx_data(fixture->dev[i], tx_content, sizeof(tx_content));
 		zassert_equal(tx_len, strlen(TEST_DATA),
 			      "%d: TX buffer length does not match. Expected %d, got %d",
 			      i, strlen(TEST_DATA), tx_len);
-		zassert_mem_equal(tx_content, TEST_DATA, strlen(tx_content));
+		zassert_mem_equal(tx_content, TEST_DATA, strlen(TEST_DATA));
 	}
 }
 


### PR DESCRIPTION
Put the buffer data in a static buffer to reduce the needed stack size.