### PR TITLE
boards: qemu: cortex_m0: Enable stack canaries in ztest

### DIFF
--- a/boards/qemu/cortex_m0/Kconfig.defconfig
+++ b/boards/qemu/cortex_m0/Kconfig.defconfig
@@ -14,4 +14,7 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 config SYS_CLOCK_TICKS_PER_SEC
 	default 100
 
+config STACK_CANARIES
+	default y if ZTEST
+
 endif # BOARD_QEMU_CORTEX_M0


### PR DESCRIPTION
Running tests on qemu cortex m0 should default check stack canaries.