### PR TITLE
scripts: pytest: log msec with leading zeros

### DIFF
--- a/scripts/pylib/twister/twisterlib/harness.py
+++ b/scripts/pylib/twister/twisterlib/harness.py
@@ -389,7 +389,7 @@ class Pytest(Harness):
             f'--build-dir={self.running_dir}',
             f'--junit-xml={self.report_file}',
             '--log-file-level=DEBUG',
-            '--log-file-format=%(asctime)s.%(msecs)d:%(levelname)s:%(name)s: %(message)s',
+            '--log-file-format=%(asctime)s.%(msecs)03d:%(levelname)s:%(name)s: %(message)s',
             f'--log-file={self.pytest_log_file_path}',
             f'--platform={self.instance.platform.name}'
         ]


### PR DESCRIPTION
Milliseconds are logged as is, without leading zeros. This means that
following log content is produced, which is not aligned by columns:

```
12:54:27.972:INFO:root: Test message
12:54:27.992:INFO:root: Test message
12:54:28.12:INFO:root: Test message
12:54:28.32:INFO:root: Test message
12:54:28.52:INFO:root: Test message
12:54:28.73:INFO:root: Test message
12:54:28.93:INFO:root: Test message
12:54:28.113:INFO:root: Test message
12:54:28.133:INFO:root: Test message
```

Change milliseconds logging to include leading zeroes. This allows to print
nicely aligned log messages:

```
12:54:27.972:INFO:root: Test message
12:54:27.992:INFO:root: Test message
12:54:28.012:INFO:root: Test message
12:54:28.032:INFO:root: Test message
12:54:28.052:INFO:root: Test message
12:54:28.073:INFO:root: Test message
12:54:28.093:INFO:root: Test message
12:54:28.113:INFO:root: Test message
12:54:28.133:INFO:root: Test message
```

Additionally it is much easier to configure programs simplifying
timestamped log browsing (like in logview-mode for Emacs), as it is more
standard and does not require custom regex matching.