### PR TITLE
MAINTAINERS: Add "STM32 Wireless Platforms"

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3998,6 +3998,9 @@ STM32 Wireless Platforms:
   maintainers:
     - erwango
   collaborators:
+    - asm5878
+    - HoZHel
+    - benothmn-st
     - mathieuchopstm
   files:
     - boards/shields/x_nucleo_bnrg2a1/
@@ -4881,6 +4884,9 @@ West:
     - FRASTM
     - gautierg-st
     - marwaiehm-st
+    - asm5878
+    - HoZHel
+    - benothmn-st
   files:
     - modules/Kconfig.stm32
   labels:

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3984,11 +3984,34 @@ STM32 Platforms:
     - dts/bindings/*/*stm32*
     - soc/st/stm32/
     - samples/boards/st/
+  files-exclude:
+    - boards/st/*wb*/
+    - drivers/bluetooth/hci/*stm32*.c
+    - soc/st/stm32/stm32wb*/
   labels:
     - "platform: STM32"
   description: >-
-    STM32 SOCs, dts files and related drivers. ST nucleo, disco and eval
-    boards.
+    STM32 SOCs, dts files and related drivers. ST development boards.
+
+STM32 Wireless Platforms:
+  status: maintained
+  maintainers:
+    - erwango
+  collaborators:
+    - mathieuchopstm
+  files:
+    - boards/shields/x_nucleo_bnrg2a1/
+    - boards/shields/x_nucleo_idb05a1/
+    - boards/shields/x_nucleo_wb05kn1/
+    - boards/st/*wb*/
+    - drivers/bluetooth/hci/*stm32*.c
+    - drivers/bluetooth/hci/hci_spi_st.c
+    - soc/st/stm32/stm32wb*/
+  labels:
+    - "platform: STM32"
+  description: >-
+    STM32WB SOCs, dts files and related drivers. STM32WB development boards
+    and ST bluetooth shields.
 
 Espressif Platforms:
   status: maintained


### PR DESCRIPTION
Split "STM32 Platforms" area and introduce a new "STM32 Wireless Platforms" to better reflect team organisation and facilitate the maintenance of various components.

New "STM32 Wireless Platforms" area includes (removed from "STM32 Platforms" scope)
- WB* boards
- HCI drivers
- WB* soc
- ST BLE shields (new)

@asm5878, @benothmn-st and @HoZHel are added as collaborators to this new area as well as `hal_stm32` one, as they take in charge BLE libs maintainance.