### PR TITLE
drivers: flash: stm32wba flash driver moves sem functions

### DIFF
--- a/drivers/flash/CMakeLists.txt
+++ b/drivers/flash/CMakeLists.txt
@@ -97,7 +97,7 @@ if(CONFIG_SOC_FLASH_STM32)
     zephyr_library_sources_ifdef(CONFIG_DT_HAS_ST_STM32H7_FLASH_CONTROLLER_ENABLED flash_stm32h7x.c)
   elseif(CONFIG_SOC_SERIES_STM32WBAX)
     if(CONFIG_BT_STM32WBA)
-      # BLE is enabled. Use implementation over Flash Manager for coexistence wit RF activities
+      # BLE is enabled. Use implementation over Flash Manager for coexistence with RF activities
       zephyr_library_sources(flash_stm32wba_fm.c)
     else()
       zephyr_library_sources_ifdef(CONFIG_DT_HAS_ST_STM32_FLASH_CONTROLLER_ENABLED flash_stm32.c flash_stm32wbax.c)

--- a/drivers/flash/flash_stm32wba_fm.c
+++ b/drivers/flash/flash_stm32wba_fm.c
@@ -66,17 +66,6 @@ bool flash_stm32_valid_range(const struct device *dev, off_t offset,
 	return flash_stm32_range_exists(dev, offset, len);
 }
 
-
-static inline void flash_stm32_sem_take(const struct device *dev)
-{
-	k_sem_take(&FLASH_STM32_PRIV(dev)->sem, K_FOREVER);
-}
-
-static inline void flash_stm32_sem_give(const struct device *dev)
-{
-	k_sem_give(&FLASH_STM32_PRIV(dev)->sem);
-}
-
 static int flash_stm32_read(const struct device *dev, off_t offset,
 			    void *data,
 			    size_t len)


### PR DESCRIPTION
With the CONFIG_BT_STM32WBA,  the stm32wba_fm flash driver is compiled and must have flash_stm32_sem_take/give functions from the flash_stm32.h header file, like other stm32 series.

Following the PR https://github.com/zephyrproject-rtos/zephyr/pull/76640/  and commit ff0f1e562d77b4e4844ef12699c1674417629ec4, the flash_stm32_sem_take() _flash_stm32_sem_take()  are now in the drivers/flash/flash_stm32.h

This PR will avoid error when building  samples/bluetooth/peripheral/ for example on  nucleo_wba55cg  target 
Since the CONFIG_BT_STM32WBA is defined, the flash_stm32wba_fm.c is used for the stm32 flash driver
failing with a  redefinition  of  _flash_stm32_sem_take()  _flash_stm32_sem_give() functions 
