### PR TITLE
ci: bsim tests: Fix paths for triggers

### DIFF
--- a/.github/workflows/bsim-tests.yaml
+++ b/.github/workflows/bsim-tests.yaml
@@ -12,8 +12,8 @@ on:
       - "dts/*/nordic/**"
       - "tests/bluetooth/common/testlib/**"
       - "samples/bluetooth/**"
-      - "boards/posix/**"
-      - "soc/posix/**"
+      - "boards/native/**"
+      - "soc/native/**"
       - "arch/posix/**"
       - "include/zephyr/arch/posix/**"
       - "scripts/native_simulator/**"
@@ -96,8 +96,8 @@ jobs:
             .github/workflows/bsim-tests.yaml
             .github/workflows/bsim-tests-publish.yaml
             west.yml
-            boards/posix/
-            soc/posix/
+            boards/native/
+            soc/native/
             arch/posix/
             include/zephyr/arch/posix/
             scripts/native_simulator/


### PR DESCRIPTION
These paths were not updated when we transitioned to hwmv2 which led to CI jobs not being triggered in some cases.
Let's fix it.

https://github.com/zephyrproject-rtos/zephyr/issues/82835 got thru due to this