### PR TITLE
tests: drivers: gpio: Add a dependency to the aw9523b tests.

### DIFF
--- a/tests/drivers/gpio/gpio_api_1pin/testcase.yaml
+++ b/tests/drivers/gpio/gpio_api_1pin/testcase.yaml
@@ -19,6 +19,7 @@ tests:
       - gpio
       - arduino_gpio
       - i2c
+      - arduino_i2c
     min_flash: 48
     harness_config:
       fixture: aw9523b_on_arduino_header

--- a/tests/drivers/gpio/gpio_basic_api/testcase.yaml
+++ b/tests/drivers/gpio/gpio_basic_api/testcase.yaml
@@ -100,6 +100,7 @@ tests:
       - gpio
       - arduino_gpio
       - i2c
+      - arduino_i2c
     harness_config:
       fixture: aw9523b_on_arduino_header
     filter: dt_compat_enabled("test-gpio-basic-api") and dt_compat_enabled("arduino-header-r3") and


### PR DESCRIPTION
To avoid compilation on boards that do not have arduino_i2c defined, we will clarify that it is dependent on it.

Fix #82711