### PR TITLE
display: stm32_ltdc: fix double fb, implement rotation & suspend behavior

### DIFF
--- a/drivers/display/Kconfig.stm32_ltdc
+++ b/drivers/display/Kconfig.stm32_ltdc
@@ -75,4 +75,11 @@ config STM32_LTDC_DISABLE_FMC_BANK1
 	  Disable FMC bank1 if not used to prevent speculative read accesses.
 	  Refer to AN4861 "4.6 Special recommendations for Cortex-M7 (STM32F7/H7)".
 
+config STM32_LTDC_INTERMEDIATE_BUF_SIZE
+	int "Size of intermediate buffer used to copy new frame to old frame"
+	default 256
+	help
+	  When frame buffer is placed in SDRAM, an intermediate memory is used
+	  to copy new frame buffer to old, to speed up copying. Set to 0 to disable.
+
 endif # STM32_LTDC


### PR DESCRIPTION
The current implementation of a double frame buffer is flawed,
especially considering that LVGL does multiple small writes, essentially
making double buffering pointless as only part of the frame is rendered
when the buffer is swapped. One workaround has been to use a VDB_SIZE of
100% (e.g. STM32H7B3I_DK) and as such have LVGL perform the double
buffering. However, for instance software rotation doesn't work in this
configuration and the entire frame needs to be refreshed on every write.

This commit checks if the write is partial. If this is the case, just
write the partial buffer and return. If the write is final, the buffers
are swapped and the new buffer is copied to the old one.

In addition, an intermediate buffer is used on copying if the frame
buffer is located in SDRAM, to speed up copying of the frame.