### PR TITLE
boards: st: fix twister test failure for stm32u083c_dk

### DIFF
--- a/boards/st/stm32u083c_dk/arduino_r3_connector.dtsi
+++ b/boards/st/stm32u083c_dk/arduino_r3_connector.dtsi
@@ -36,3 +36,4 @@
 };
 
 arduino_serial: &usart2 {};
+arduino_i2c: &i2c1 {};

--- a/boards/st/stm32u083c_dk/stm32u083c_dk.yaml
+++ b/boards/st/stm32u083c_dk/stm32u083c_dk.yaml
@@ -9,6 +9,8 @@ toolchain:
 supported:
   - adc
   - arduino_gpio
+  - arduino_serial
+  - arduino_i2c
   - dac
   - gpio
   - i2c


### PR DESCRIPTION
Test `drivers.gpio.1pin.aw9523b` fails on `stm32u083c_dk` platform because `arduino_i2c` definition does not exists in the device tree of `stm32u083c_dk` board

For the error see; https://github.com/zephyrproject-rtos/zephyr/actions/runs/12270889177/job/34236994087?pr=81187