### PR TITLE
drivers: sensors: lis2dh: added full high-pass filter capabilities

### DIFF
--- a/drivers/sensor/st/lis2dh/lis2dh.c
+++ b/drivers/sensor/st/lis2dh/lis2dh.c
@@ -271,6 +271,21 @@ static int lis2dh_acc_range_set(const struct device *dev, int32_t range)
 }
 #endif
 
+#ifdef CONFIG_LIS2DH_ACCEL_HP_FILTERS
+static int lis2dh_acc_hp_filter_set(const struct device *dev, int32_t val)
+{
+	struct lis2dh_data *lis2dh = dev->data;
+	int status;
+
+	status = lis2dh->hw_tf->write_reg(dev, LIS2DH_REG_CTRL2, val);
+	if (status < 0) {
+		LOG_ERR("Failed to set high pass filters");
+	}
+
+	return status;
+}
+#endif
+
 static int lis2dh_acc_config(const struct device *dev,
 			     enum sensor_channel chan,
 			     enum sensor_attribute attr,

--- a/drivers/sensor/st/lis2dh/lis2dh.h
+++ b/drivers/sensor/st/lis2dh/lis2dh.h
@@ -87,9 +87,12 @@
 #define LIS2DH_REG_CTRL2		0x21
 #define LIS2DH_HPIS1_EN_BIT		BIT(0)
 #define LIS2DH_HPIS2_EN_BIT		BIT(1)
+#define LIS2DH_HPCLICK_EN_BIT		BIT(2)
 #define LIS2DH_FDS_EN_BIT		BIT(3)
-
-#define LIS2DH_HPIS_EN_MASK		BIT_MASK(2)
+#define LIS2DH_HPCF0_EN_BIT		BIT(4)
+#define LIS2DH_HPCF1_EN_BIT		BIT(5)
+#define LIS2DH_HPM0_EN_BIT		BIT(6)
+#define LIS2DH_HPM1_EN_BIT		BIT(7)
 
 #define LIS2DH_REG_CTRL3		0x22
 #define LIS2DH_EN_CLICK_INT1		BIT(7)
@@ -303,11 +306,6 @@ int lis2dh_init_interrupt(const struct device *dev);
 int lis2dh_acc_slope_config(const struct device *dev,
 			    enum sensor_attribute attr,
 			    const struct sensor_value *val);
-#endif
-
-#ifdef CONFIG_LIS2DH_ACCEL_HP_FILTERS
-int lis2dh_acc_hp_filter_set(const struct device *dev,
-			     int32_t val);
 #endif
 
 int lis2dh_spi_init(const struct device *dev);

--- a/drivers/sensor/st/lis2dh/lis2dh_trigger.c
+++ b/drivers/sensor/st/lis2dh/lis2dh_trigger.c
@@ -361,22 +361,6 @@ int lis2dh_acc_slope_config(const struct device *dev,
 	return status;
 }
 
-#ifdef CONFIG_LIS2DH_ACCEL_HP_FILTERS
-int lis2dh_acc_hp_filter_set(const struct device *dev, int32_t val)
-{
-	struct lis2dh_data *lis2dh = dev->data;
-	int status;
-
-	status = lis2dh->hw_tf->update_reg(dev, LIS2DH_REG_CTRL2,
-					   LIS2DH_HPIS_EN_MASK, val);
-	if (status < 0) {
-		LOG_ERR("Failed to set high pass filters");
-	}
-
-	return status;
-}
-#endif
-
 static void lis2dh_gpio_int1_callback(const struct device *dev,
 				      struct gpio_callback *cb, uint32_t pins)
 {


### PR DESCRIPTION
The lis2dh driver has the ability to enable the high-pass filter. However it was only possible to set the first 2 bits of the high-pass register. These bits indicate wether the high-pass filter is enabled for the interrupts. This commit moves lis2dh_acc_hp_filter_set out of lis2dh_trigger to lis2dh. It also removes the mask so that all bits are able to be set