### PR TITLE
wifi: Miscellaneous fixes when testing SoftAP in nRF70

### DIFF
--- a/drivers/wifi/nrf_wifi/Kconfig.nrfwifi
+++ b/drivers/wifi/nrf_wifi/Kconfig.nrfwifi
@@ -96,6 +96,7 @@ config NRF70_STA_MODE
 config NRF70_AP_MODE
 	bool "Access point mode"
 	depends on WIFI_NM_WPA_SUPPLICANT_AP
+	default y if WIFI_NM_WPA_SUPPLICANT_AP
 
 config NRF70_P2P_MODE
 	bool "P2P support in driver"

--- a/modules/hostap/Kconfig
+++ b/modules/hostap/Kconfig
@@ -67,7 +67,7 @@ config WIFI_NM_WPA_SUPPLICANT_DEBUG_LEVEL
 	default 3 if WIFI_NM_WPA_SUPPLICANT_LOG_LEVEL_INF # MSG_INFO
 	default 4 if WIFI_NM_WPA_SUPPLICANT_LOG_LEVEL_WRN # MSG_WARNING
 	default 5 if WIFI_NM_WPA_SUPPLICANT_LOG_LEVEL_ERR # MSG_ERROR
-	default 6
+	default 5
 	help
 	  Minimum priority level of a debug message emitted by WPA supplicant that
 	  is compiled-in the firmware. See wpa_debug.h file of the supplicant for

--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -1938,16 +1938,21 @@ static int cmd_wifi_reg_domain(const struct shell *sh, size_t argc,
 	int ret, chan_idx = 0;
 	int opt;
 	bool force = false;
+	bool verbose = false;
 	int opt_index = 0;
 	static const struct option long_options[] = {
 		{"force", no_argument, 0, 'f'},
+		{"verbose", no_argument, 0, 'v'},
 		{NULL, 0, NULL, 0}
 	};
 
-	while ((opt = getopt_long(argc, argv, "f", long_options, &opt_index)) != -1) {
+	while ((opt = getopt_long(argc, argv, "fv", long_options, &opt_index)) != -1) {
 		switch (opt) {
 		case 'f':
 			force = true;
+			break;
+		case 'v':
+			verbose = true;
 			break;
 		default:
 			return -ENOEXEC;
@@ -1989,6 +1994,9 @@ static int cmd_wifi_reg_domain(const struct shell *sh, size_t argc,
 	if (regd.oper == WIFI_MGMT_GET) {
 		PR("Wi-Fi Regulatory domain is: %c%c\n",
 		   regd.country_code[0], regd.country_code[1]);
+		if (!verbose) {
+			return 0;
+		}
 		PR("<channel>\t<center frequency>\t<supported(y/n)>\t"
 		   "<max power(dBm)>\t<passive transmission only(y/n)>\t<DFS supported(y/n)>\n");
 		for (chan_idx = 0; chan_idx < regd.num_channels; chan_idx++) {
@@ -3503,9 +3511,10 @@ SHELL_SUBCMD_ADD((wifi), reg_domain, &wifi_commands,
 		 "[ISO/IEC 3166-1 alpha2]: Regulatory domain\n"
 		 "[-f]: Force to use this regulatory hint over any other regulatory hints\n"
 		 "Note1: The behavior of this command is dependent on the Wi-Fi driver/chipset implementation\n"
-		 "Note2: This may cause regulatory compliance issues, use it at your own risk.\n",
+		 "Note2: This may cause regulatory compliance issues, use it at your own risk.\n"
+		 "[-v]: Verbose, display the per-channel regulatory information\n",
 		 cmd_wifi_reg_domain,
-		 1, 2);
+		 1, 3);
 
 SHELL_SUBCMD_ADD((wifi), rts_threshold, &wifi_commands,
 		 "<rts_threshold: rts threshold/off>.\n",

--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -1936,37 +1936,45 @@ static int cmd_wifi_reg_domain(const struct shell *sh, size_t argc,
 	struct net_if *iface = net_if_get_wifi_sta();
 	struct wifi_reg_domain regd = {0};
 	int ret, chan_idx = 0;
+	int opt;
+	bool force = false;
+	int opt_index = 0;
+	static const struct option long_options[] = {
+		{"force", no_argument, 0, 'f'},
+		{NULL, 0, NULL, 0}
+	};
 
-	if (argc == 1) {
+	while ((opt = getopt_long(argc, argv, "f", long_options, &opt_index)) != -1) {
+		switch (opt) {
+		case 'f':
+			force = true;
+			break;
+		default:
+			return -ENOEXEC;
+		}
+	}
+
+	if (optind == argc) {
 		regd.chan_info = &chan_info[0];
 		regd.oper = WIFI_MGMT_GET;
-	} else if (argc >= 2 && argc <= 3) {
-		regd.oper = WIFI_MGMT_SET;
-		if (strlen(argv[1]) != 2) {
+	} else if (optind == argc - 1) {
+		if (strlen(argv[optind]) != 2) {
 			PR_WARNING("Invalid reg domain: Length should be two letters/digits\n");
 			return -ENOEXEC;
 		}
 
 		/* Two letter country code with special case of 00 for WORLD */
-		if (((argv[1][0] < 'A' || argv[1][0] > 'Z') ||
-			(argv[1][1] < 'A' || argv[1][1] > 'Z')) &&
-			(argv[1][0] != '0' || argv[1][1] != '0')) {
-			PR_WARNING("Invalid reg domain %c%c\n", argv[1][0], argv[1][1]);
+		if (((argv[optind][0] < 'A' || argv[optind][0] > 'Z') ||
+			(argv[optind][1] < 'A' || argv[optind][1] > 'Z')) &&
+			(argv[optind][0] != '0' || argv[optind][1] != '0')) {
+			PR_WARNING("Invalid reg domain %c%c\n", argv[optind][0], argv[optind][1]);
 			return -ENOEXEC;
 		}
-		regd.country_code[0] = argv[1][0];
-		regd.country_code[1] = argv[1][1];
-
-		if (argc == 3) {
-			if (strncmp(argv[2], "-f", 2) == 0) {
-				regd.force = true;
-			} else {
-				PR_WARNING("Invalid option %s\n", argv[2]);
-				return -ENOEXEC;
-			}
-		}
+		regd.country_code[0] = argv[optind][0];
+		regd.country_code[1] = argv[optind][1];
+		regd.force = force;
+		regd.oper = WIFI_MGMT_SET;
 	} else {
-		shell_help(sh);
 		return -ENOEXEC;
 	}
 


### PR DESCRIPTION
1. Fix default log level of supplicant
2. Fix AP mode dependency in nRF70 driver
3. Regulatory domain: Introduce a new `-v` option to hide per-channel rules. (after converting to getopt)