### PR TITLE
boards: m5stack: cores3: Add TF-Card slot configuration

### DIFF
--- a/boards/m5stack/m5stack_cores3/m5stack_cores3_procpu_common.dtsi
+++ b/boards/m5stack/m5stack_cores3/m5stack_cores3_procpu_common.dtsi
@@ -29,6 +29,7 @@
 		i2c-1 = &i2c1;
 		watchdog0 = &wdt0;
 		rtc = &bm8563_rtc;
+		sdhc0 = &sd0;
 	};
 };
 
@@ -106,6 +107,22 @@
 	status = "okay";
 	pinctrl-0 = <&spim2_default>;
 	pinctrl-names = "default";
+	clock-frequency = <20000000>;
+	cs-gpios = <&gpio0 3 GPIO_ACTIVE_LOW>, /* LCD     */
+		   <&gpio0 4 GPIO_ACTIVE_LOW>; /* TF-CARD */
+
+	sd0: sd@1 {
+		compatible = "zephyr,sdhc-spi-slot";
+		reg = <1>;
+		status = "okay";
+		spi-max-frequency = <20000000>;
+		mmc {
+			compatible = "zephyr,sdmmc-disk";
+			disk-name = "SD";
+			status = "okay";
+		};
+
+	};
 };
 
 &twai {


### PR DESCRIPTION
Adding TF-Card slot configuration.
Adding SPI CS configurations. Reserving id-0 for TFT.