### PR TITLE
[2.7] ci: use runs-on group

### DIFF
--- a/.github/workflows/clang.yaml
+++ b/.github/workflows/clang.yaml
@@ -8,7 +8,8 @@ concurrency:
 
 jobs:
   clang-build:
-    runs-on: zephyr-runner-v2-linux-x64-4xlarge
+    runs-on:
+      group: zephyr-runner-v2-linux-x64-4xlarge
     container:
       image: zephyrprojectrtos/ci:v0.18.4
       options: '--entrypoint /bin/bash'

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -10,7 +10,8 @@ concurrency:
 
 jobs:
   codecov:
-    runs-on: zephyr-runner-v2-linux-x64-4xlarge
+    runs-on:
+      group: zephyr-runner-v2-linux-x64-4xlarge
     container:
       image: zephyrprojectrtos/ci:v0.18.4
       options: '--entrypoint /bin/bash'

--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -17,7 +17,8 @@ concurrency:
 
 jobs:
   twister-build-prep:
-    runs-on: zephyr-runner-v2-linux-x64-4xlarge
+    runs-on:
+      group: zephyr-runner-v2-linux-x64-4xlarge
     container:
       image: zephyrprojectrtos/ci:v0.18.4
       options: '--entrypoint /bin/bash'
@@ -106,7 +107,8 @@ jobs:
           echo "size=${size}" >> $GITHUB_OUTPUT
 
   twister-build:
-    runs-on: zephyr-runner-v2-linux-x64-4xlarge
+    runs-on:
+      group: zephyr-runner-v2-linux-x64-4xlarge
     needs: twister-build-prep
     if: needs.twister-build-prep.outputs.size != 0
     container:


### PR DESCRIPTION
Use group instead of directly referencing runners.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
