### PR TITLE
drivers: spi_nrfx: Fix NRFX_ASSERT crash when sck pin is set to no-connect

### DIFF
--- a/drivers/spi/spi_nrfx_spi.c
+++ b/drivers/spi/spi_nrfx_spi.c
@@ -92,6 +92,7 @@ static int configure(const struct device *dev,
 	struct spi_context *ctx = &dev_data->ctx;
 	nrfx_spi_config_t config;
 	nrfx_err_t result;
+	uint32_t sck_pin;
 
 	if (dev_data->initialized && spi_context_configured(ctx, spi_cfg)) {
 		/* Already configured. No need to do it again. */
@@ -135,8 +136,11 @@ static int configure(const struct device *dev,
 	config.mode      = get_nrf_spi_mode(spi_cfg->operation);
 	config.bit_order = get_nrf_spi_bit_order(spi_cfg->operation);
 
-	nrf_gpio_pin_write(nrf_spi_sck_pin_get(dev_config->spi.p_reg),
-			   spi_cfg->operation & SPI_MODE_CPOL ? 1 : 0);
+	sck_pin = nrf_spi_sck_pin_get(dev_config->spi.p_reg);
+
+	if (sck_pin != NRF_SPI_PIN_NOT_CONNECTED) {
+		nrf_gpio_pin_write(sck_pin, spi_cfg->operation & SPI_MODE_CPOL ? 1 : 0);
+	}
 
 	if (dev_data->initialized) {
 		nrfx_spi_uninit(&dev_config->spi);

--- a/drivers/spi/spi_nrfx_spim.c
+++ b/drivers/spi/spi_nrfx_spim.c
@@ -152,6 +152,7 @@ static int configure(const struct device *dev,
 	uint32_t max_freq = dev_config->max_freq;
 	nrfx_spim_config_t config;
 	nrfx_err_t result;
+	uint32_t sck_pin;
 
 	if (dev_data->initialized && spi_context_configured(ctx, spi_cfg)) {
 		/* Already configured. No need to do it again. */
@@ -208,8 +209,11 @@ static int configure(const struct device *dev,
 	config.mode      = get_nrf_spim_mode(spi_cfg->operation);
 	config.bit_order = get_nrf_spim_bit_order(spi_cfg->operation);
 
-	nrfy_gpio_pin_write(nrfy_spim_sck_pin_get(dev_config->spim.p_reg),
-			    spi_cfg->operation & SPI_MODE_CPOL ? 1 : 0);
+	sck_pin = nrfy_spim_sck_pin_get(dev_config->spim.p_reg);
+
+	if (sck_pin != NRF_SPIM_PIN_NOT_CONNECTED) {
+		nrfy_gpio_pin_write(sck_pin, spi_cfg->operation & SPI_MODE_CPOL ? 1 : 0);
+	}
 
 	if (dev_data->initialized) {
 		nrfx_spim_uninit(&dev_config->spim);

--- a/samples/boards/nordic/nrfx_prs/src/main.c
+++ b/samples/boards/nordic/nrfx_prs/src/main.c
@@ -122,6 +122,7 @@ static bool switch_to_spim(void)
 {
 	int ret;
 	nrfx_err_t err;
+	uint32_t sck_pin;
 
 	PINCTRL_DT_DEFINE(SPIM_NODE);
 
@@ -155,8 +156,11 @@ static bool switch_to_spim(void)
 	}
 
 	/* Set initial state of SCK according to the SPI mode. */
-	nrfy_gpio_pin_write(nrfy_spim_sck_pin_get(spim.p_reg),
-			    (spim_config.mode <= NRF_SPIM_MODE_1) ? 0 : 1);
+	sck_pin = nrfy_spim_sck_pin_get(spim.p_reg);
+
+	if (sck_pin != NRF_SPIM_PIN_NOT_CONNECTED) {
+		nrfy_gpio_pin_write(sck_pin, (spim_config.mode <= NRF_SPIM_MODE_1) ? 0 : 1);
+	}
 
 	err = nrfx_spim_init(&spim, &spim_config, spim_handler, NULL);
 	if (err != NRFX_SUCCESS) {


### PR DESCRIPTION
Fixes a bug in nrf spi driver when CONFIG_WS2812_STRIP_SPI is used to drive a WS2812 strip NRFX_ASSERT() is triggered.

SPI is used for accurate timings and is widely supported for driving these types of LED's. To save on pin count there is only the need for MOSI to be physically connected to the output buffer.