### PR TITLE
kernel: mem_slab performance enhancements

### DIFF
--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -677,6 +677,13 @@ config POLL
 	  concurrently, which can be either directly triggered or triggered by
 	  the availability of some kernel objects (semaphores and FIFOs).
 
+config MEM_SLAB_POINTER_VALIDATE
+	bool "Validate the memory slab pointer when allocating or freeing"
+	default ASSERT
+	help
+	  This enables additional runtime checks to validate the memory slab
+	  pointer during when allocating or freeing a memory slab.
+
 config MEM_SLAB_TRACE_MAX_UTILIZATION
 	bool "Getting maximum slab utilization"
 	help

--- a/kernel/mem_slab.c
+++ b/kernel/mem_slab.c
@@ -206,6 +206,10 @@ out:
 
 static bool slab_ptr_is_good(struct k_mem_slab *slab, const void *ptr)
 {
+	if (!IS_ENABLED(CONFIG_MEM_SLAB_POINTER_VALIDATE)) {
+		return true;
+	}
+
 	const char *p = ptr;
 	ptrdiff_t offset = p - slab->buffer;
 

--- a/kernel/mem_slab.c
+++ b/kernel/mem_slab.c
@@ -278,7 +278,7 @@ void k_mem_slab_free(struct k_mem_slab *slab, void *mem)
 	k_spinlock_key_t key = k_spin_lock(&slab->lock);
 
 	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_mem_slab, free, slab);
-	if ((slab->free_list == NULL) && IS_ENABLED(CONFIG_MULTITHREADING)) {
+	if (unlikely(slab->free_list == NULL) && IS_ENABLED(CONFIG_MULTITHREADING)) {
 		struct k_thread *pending_thread = z_unpend_first_thread(&slab->wait_q);
 
 		if (unlikely(pending_thread != NULL)) {

--- a/tests/benchmarks/thread_metric/prj.conf
+++ b/tests/benchmarks/thread_metric/prj.conf
@@ -23,3 +23,6 @@ CONFIG_PICOLIBC_USE_MODULE=y
 
 # Disable Thread Local Storage for better context switching times
 CONFIG_THREAD_LOCAL_STORAGE=n
+
+# Disable memory slab pointer validation
+CONFIG_MEM_SLAB_POINTER_VALIDATE=n


### PR DESCRIPTION
These commits center around making the runtime validation of the memory slab pointer used in both allocation and freeing configurable. When applied to the thread_metric memory allocation sub-test, this improves its performance by about 13%.