### PR TITLE
Bluetooth: Shell: BR: Set user data size for rfcomm tx pool

### DIFF
--- a/subsys/bluetooth/host/classic/shell/rfcomm.c
+++ b/subsys/bluetooth/host/classic/shell/rfcomm.c
@@ -33,7 +33,7 @@
 
 #define DATA_MTU 48
 
-NET_BUF_POOL_FIXED_DEFINE(pool, 1, DATA_MTU, 0, NULL);
+NET_BUF_POOL_FIXED_DEFINE(pool, 1, DATA_MTU, CONFIG_BT_CONN_TX_USER_DATA_SIZE, NULL);
 
 static struct bt_sdp_attribute spp_attrs[] = {
 	BT_SDP_NEW_SERVICE,


### PR DESCRIPTION
The user data size of the RFCOMM tx pool is zero.

There is not enough space to put the tx_mate.

Use CONFIG_BT_CONN_TX_USER_DATA_SIZE to set
the data size for the RFCOMM tx pool.