### PR TITLE
wifi NM related change

### DIFF
--- a/drivers/wifi/nxp/Kconfig.nxp
+++ b/drivers/wifi/nxp/Kconfig.nxp
@@ -8,7 +8,7 @@ menuconfig WIFI_NXP
 	select NET_L2_ETHERNET_MGMT if NETWORKING && NET_L2_ETHERNET
 	select SDHC if !SOC_SERIES_RW6XX
 	select SDIO_STACK if !SOC_SERIES_RW6XX
-	select WIFI_NM if WIFI_NM_WPA_SUPPLICANT
+	select WIFI_NM
 	depends on DT_HAS_NXP_WIFI_ENABLED
 	help
 	  Enable NXP SoC Wi-Fi support.

--- a/drivers/wifi/nxp/nxp_wifi_drv.c
+++ b/drivers/wifi/nxp/nxp_wifi_drv.c
@@ -1423,8 +1423,13 @@ static void nxp_wifi_sta_init(struct net_if *iface)
 	eth_ctx->eth_if_type = L2_ETH_IF_TYPE_WIFI;
 	intf->netif = iface;
 #ifdef CONFIG_WIFI_NM
+#ifdef CONFIG_WIFI_NM_WPA_SUPPLICANT
 	wifi_nm_register_mgd_type_iface(wifi_nm_get_instance("wifi_supplicant"),
 			WIFI_TYPE_STA, iface);
+#else
+	wifi_nm_register_mgd_type_iface(wifi_nm_get_instance("wifi_sta"),
+			WIFI_TYPE_STA, iface);
+#endif
 #endif
 	g_mlan.state.interface = WLAN_BSS_TYPE_STA;
 
@@ -1458,9 +1463,15 @@ static void nxp_wifi_uap_init(struct net_if *iface)
 
 	eth_ctx->eth_if_type = L2_ETH_IF_TYPE_WIFI;
 	intf->netif = iface;
+
 #ifdef CONFIG_WIFI_NM
+#ifdef CONFIG_WIFI_NM_HOSTAPD_AP
 	wifi_nm_register_mgd_type_iface(wifi_nm_get_instance("hostapd"),
 			WIFI_TYPE_SAP, iface);
+#else
+	wifi_nm_register_mgd_type_iface(wifi_nm_get_instance("wifi_sap"),
+			WIFI_TYPE_SAP, iface);
+#endif
 #endif
 	g_uap.state.interface = WLAN_BSS_TYPE_UAP;
 
@@ -1705,6 +1716,10 @@ static const struct wifi_mgmt_ops nxp_wifi_sta_mgmt = {
 #endif
 };
 
+#if defined(CONFIG_WIFI_NM) && !defined(CONFIG_WIFI_NM_WPA_SUPPLICANT)
+DEFINE_WIFI_NM_INSTANCE(wifi_sta, &nxp_wifi_sta_mgmt);
+#endif
+
 #if defined(CONFIG_WIFI_NM_WPA_SUPPLICANT)
 static const struct zep_wpa_supp_dev_ops nxp_wifi_drv_ops = {
 	.init = wifi_nxp_wpa_supp_dev_init,
@@ -1775,6 +1790,10 @@ static const struct wifi_mgmt_ops nxp_wifi_uap_mgmt = {
 	.get_power_save_config = nxp_wifi_get_power_save,
 	.ap_config_params = nxp_wifi_ap_config_params,
 };
+
+#if defined(CONFIG_WIFI_NM) && !defined(CONFIG_WIFI_NM_HOSTAPD_AP)
+DEFINE_WIFI_NM_INSTANCE(wifi_sap, &nxp_wifi_uap_mgmt);
+#endif
 
 static const struct net_wifi_mgmt_offload nxp_wifi_uap_apis = {
 	.wifi_iface.iface_api.init = nxp_wifi_uap_init,

--- a/modules/hostap/src/supp_main.c
+++ b/modules/hostap/src/supp_main.c
@@ -1079,12 +1079,6 @@ static void zephyr_hostapd_init(struct supplicant_context *ctx)
 		zephyr_hostapd_ctrl_init((void *)interfaces->iface[i]->bss[0]);
 	}
 
-	ret = wifi_nm_register_mgd_iface(wifi_nm_get_instance("hostapd"), iface);
-	if (ret) {
-		LOG_ERR("Failed to register mgd iface with native stack %s (%d)",
-			ifname, ret);
-		goto out;
-	}
 out:
 	return;
 }

--- a/subsys/net/l2/wifi/wifi_nm.c
+++ b/subsys/net/l2/wifi/wifi_nm.c
@@ -115,6 +115,12 @@ int wifi_nm_register_mgd_type_iface(struct wifi_nm_instance *nm,
 
 	k_mutex_lock(&wifi_nm_lock, K_FOREVER);
 	for (int i = 0; i < CONFIG_WIFI_NM_MAX_MANAGED_INTERFACES; i++) {
+		if ((nm->mgd_ifaces[i].iface == iface)
+			&& (nm->mgd_ifaces[i].type == BIT(type))) {
+			k_mutex_unlock(&wifi_nm_lock);
+			return 0;
+		}
+
 		if (!nm->mgd_ifaces[i].iface) {
 			nm->mgd_ifaces[i].iface = iface;
 			nm->mgd_ifaces[i].type = BIT(type);


### PR DESCRIPTION
drivers: wifi: nxp: Enable WIFI_NM for WIFI_NXP
Default enable WIFI_NM for both supplicant and embedded supplicant case, to distinguish STA and SAP interface when use L2 layer.

net: wifi: avoid adding duplicate mgd_ifaces
Add iface and type check to avoid adding duplicate mgd_ifaces.

hostap: remove unnecessary register of mgd iface in hostapd
In zephyr_hostapd_init, calls net_if_get_wifi_sap to get the SAP iface, it means mgd iface of SAP type is registered before zephyr_hostapd_init. Actually the mgd iface of SAP should be called in iface_api.init phase. Therefore, remove unnecessary register of mgd iface in hostapd init.
