### PR TITLE
boards: nordic: nrf5340dk/nrf9160dk: Use sysbuild for ns twister

### DIFF
--- a/boards/nordic/nrf5340dk/nrf5340dk_nrf5340_cpuapp_ns.yaml
+++ b/boards/nordic/nrf5340dk/nrf5340dk_nrf5340_cpuapp_ns.yaml
@@ -17,3 +17,4 @@ supported:
   - gpio
   - spi
 vendor: nordic
+sysbuild: true

--- a/boards/nordic/nrf9160dk/nrf9160dk_nrf9160_ns_0_14_0.yaml
+++ b/boards/nordic/nrf9160dk/nrf9160dk_nrf9160_ns_0_14_0.yaml
@@ -18,3 +18,4 @@ supported:
   - netif:modem
   - gpio
 vendor: nordic
+sysbuild: true

--- a/boards/nordic/nrf9160dk/nrf9160dk_nrf9160_ns_0_7_0.yaml
+++ b/boards/nordic/nrf9160dk/nrf9160dk_nrf9160_ns_0_7_0.yaml
@@ -18,3 +18,4 @@ supported:
   - netif:modem
   - gpio
 vendor: nordic
+sysbuild: true

--- a/tests/kernel/pipe/deprecated/pipe/CMakeLists.txt
+++ b/tests/kernel/pipe/deprecated/pipe/CMakeLists.txt
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.20.0)
+set(CMAKE_C_FLAGS "-D__deprecated='' -D__DEPRECATED_MACRO=''")
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(pipe)
 

--- a/tests/kernel/pipe/deprecated/pipe/testcase.yaml
+++ b/tests/kernel/pipe/deprecated/pipe/testcase.yaml
@@ -4,4 +4,3 @@ tests:
       - kernel
       - userspace
     ignore_faults: true
-    extra_args: CMAKE_C_FLAGS="-D__deprecated='' -D__DEPRECATED_MACRO=''"

--- a/tests/kernel/pipe/deprecated/pipe_api/CMakeLists.txt
+++ b/tests/kernel/pipe/deprecated/pipe_api/CMakeLists.txt
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.20.0)
+set(CMAKE_C_FLAGS "-D__deprecated='' -D__DEPRECATED_MACRO=''")
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(pipe_api)
 

--- a/tests/kernel/pipe/deprecated/pipe_api/testcase.yaml
+++ b/tests/kernel/pipe/deprecated/pipe_api/testcase.yaml
@@ -3,4 +3,3 @@ tests:
     tags:
       - kernel
       - userspace
-    extra_args: CMAKE_C_FLAGS="-D__deprecated='' -D__DEPRECATED_MACRO=''"


### PR DESCRIPTION
Enables forcing use of sysbuild to build nrf5340dk/nrf9160dk non-secure board targets when using twister

Also fixes #84233