### PR TITLE
drivers/pinctrl.h: Resolve Z_PINCTRL_STATE_INIT Cpp Compatibility

### DIFF
--- a/include/zephyr/drivers/pinctrl.h
+++ b/include/zephyr/drivers/pinctrl.h
@@ -157,10 +157,10 @@ struct pinctrl_dev_config {
 #define Z_PINCTRL_STATE_INIT(state_idx, node_id)			       \
 	COND_CODE_1(Z_PINCTRL_SKIP_STATE(state_idx, node_id), (),	       \
 	({								       \
-		.id = Z_PINCTRL_STATE_ID(state_idx, node_id),		       \
 		.pins = Z_PINCTRL_STATE_PINS_NAME(state_idx, node_id),	       \
 		.pin_cnt = ARRAY_SIZE(Z_PINCTRL_STATE_PINS_NAME(state_idx,     \
-								node_id))      \
+								node_id)),     \
+		.id = Z_PINCTRL_STATE_ID(state_idx, node_id)		       \
 	}))
 
 /**


### PR DESCRIPTION
This commit adds C++20 onwards support for the
Z_PINCTRL_STATE_INIT macro. Previously
the PINCTRL_DT_STATE_INIT macro was fixed,
this commits does the same change to the
Z_PINCTRL_STATE_INIT macro.