### PR TITLE
fs: ext2: Fix ext2 read buffer overflow

### DIFF
--- a/subsys/fs/ext2/ext2_impl.c
+++ b/subsys/fs/ext2/ext2_impl.c
@@ -611,6 +611,7 @@ ssize_t ext2_inode_read(struct ext2_inode *inode, void *buf, uint32_t offset, si
 	int rc = 0;
 	ssize_t read = 0;
 	uint32_t block_size = inode->i_fs->block_size;
+	size_t nbytes_to_read = nbytes;
 
 	while (read < nbytes && offset < inode->i_size) {
 
@@ -624,11 +625,12 @@ ssize_t ext2_inode_read(struct ext2_inode *inode, void *buf, uint32_t offset, si
 
 		uint32_t left_on_blk = block_size - block_off;
 		uint32_t left_in_file = inode->i_size - offset;
-		size_t to_read = MIN(nbytes, MIN(left_on_blk, left_in_file));
+		size_t to_read = MIN(nbytes_to_read, MIN(left_on_blk, left_in_file));
 
 		memcpy((uint8_t *)buf + read, inode_current_block_mem(inode) + block_off, to_read);
 
 		read += to_read;
+		nbytes_to_read -= read;
 		offset += to_read;
 	}
 


### PR DESCRIPTION
The ext2 read function can cause an overflow when the buffer size equals to the nbytes to read. 

The issue occurs when a read is performed at the end of a block making the while loop iterate again causing another read of nbytes even tough left_on_blk was already read in to the buffer thus causing a buffer overflow.

By keeping track of the amount of bytes left to read only the number of bytes requested is read into the buffer.