### PR TITLE
HAL STM32 :  update hal_stm32 to the latest version

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -234,7 +234,7 @@ manifest:
       groups:
         - hal
     - name: hal_stm32
-      revision: 0788d073d76bb4e6c1a4a8ff21e95bb3498da536
+      revision: 37842371f5ef0078ad32f16e5059c1df58b51892
       path: modules/hal/stm32
       groups:
         - hal


### PR DESCRIPTION
This PR will update hal_stm32 to the latest version.

It introduces *-pinctrl.dtsi files for the C071XX STM32 series, which will help to fix a CI problem encountered in this PR https://github.com/zephyrproject-rtos/zephyr/pull/82642  