### PR TITLE
unittest: add COMPILER_WARNINGS_AS_ERRORS handling

### DIFF
--- a/cmake/modules/unittest.cmake
+++ b/cmake/modules/unittest.cmake
@@ -131,6 +131,10 @@ if(CONFIG_COVERAGE)
   target_link_libraries(testbinary PRIVATE $<TARGET_PROPERTY:linker,coverage>)
 endif()
 
+if (CONFIG_COMPILER_WARNINGS_AS_ERRORS)
+  target_compile_options(test_interface INTERFACE $<TARGET_PROPERTY:compiler,warnings_as_errors>)
+endif()
+
 if(LIBS)
   message(FATAL_ERROR "This variable is not supported, see SOURCES instead")
 endif()

--- a/cmake/modules/unittest.cmake
+++ b/cmake/modules/unittest.cmake
@@ -112,6 +112,7 @@ target_compile_options(test_interface INTERFACE
   ${EXTRA_CFLAGS_AS_LIST}
   $<$<COMPILE_LANGUAGE:CXX>:${EXTRA_CXXFLAGS_AS_LIST}>
   $<$<COMPILE_LANGUAGE:ASM>:${EXTRA_AFLAGS_AS_LIST}>
+  -Wno-format-zero-length
   )
 
 target_link_options(testbinary PRIVATE

--- a/include/zephyr/linker/linker-defs.h
+++ b/include/zephyr/linker/linker-defs.h
@@ -28,7 +28,7 @@
 /* We need to dummy out DT_NODE_HAS_STATUS when building the unittests.
  * Including devicetree.h would require generating dummy header files
  * to match what gen_defines creates, so it's easier to just dummy out
- * DT_NODE_HAS_STATUS.
+ * DT_NODE_HAS_STATUS. These are undefined at the end of the file.
  */
 #ifdef ZTEST_UNITTEST
 #define DT_NODE_HAS_STATUS(node, status) 0
@@ -358,5 +358,10 @@ extern char lnkr_ondemand_rodata_size[];
 
 #endif /* CONFIG_LINKER_USE_ONDEMAND_SECTION */
 #endif /* ! _ASMLANGUAGE */
+
+#ifdef ZTEST_UNITTEST
+#undef DT_NODE_HAS_STATUS
+#undef DT_NODE_HAS_STATUS_OKAY
+#endif
 
 #endif /* ZEPHYR_INCLUDE_LINKER_LINKER_DEFS_H_ */

--- a/tests/bluetooth/audio/bap_broadcast_source/src/main.c
+++ b/tests/bluetooth/audio/bap_broadcast_source/src/main.c
@@ -19,7 +19,7 @@
 #include <zephyr/bluetooth/iso.h>
 #include <zephyr/fff.h>
 #include <zephyr/kernel.h>
-#include <zephyr/net/buf.h>
+#include <zephyr/net_buf.h>
 #include <zephyr/sys/printk.h>
 #include <zephyr/sys/util_macro.h>
 

--- a/tests/bluetooth/audio/cap_commander/src/test_broadcast_reception.c
+++ b/tests/bluetooth/audio/cap_commander/src/test_broadcast_reception.c
@@ -104,13 +104,12 @@ static void cap_commander_test_broadcast_reception_before(void *f)
 static void cap_commander_test_broadcast_reception_after(void *f)
 {
 	struct cap_commander_test_broadcast_reception_fixture *fixture = f;
-	int err;
 
 	bt_cap_commander_unregister_cb(&mock_cap_commander_cb);
 	bt_bap_broadcast_assistant_unregister_cb(&fixture->broadcast_assistant_cb);
 
 	/* We need to cleanup since the CAP commander remembers state */
-	err = bt_cap_commander_cancel();
+	(void)bt_cap_commander_cancel();
 
 	for (size_t i = 0; i < ARRAY_SIZE(fixture->conns); i++) {
 		mock_bt_conn_disconnected(&fixture->conns[i], BT_HCI_ERR_REMOTE_USER_TERM_CONN);

--- a/tests/bluetooth/audio/cap_commander/uut/bap_broadcast_assistant.c
+++ b/tests/bluetooth/audio/cap_commander/uut/bap_broadcast_assistant.c
@@ -182,13 +182,10 @@ int bt_bap_broadcast_assistant_set_broadcast_code(
 	struct bt_conn *conn, uint8_t src_id,
 	const uint8_t broadcast_code[BT_ISO_BROADCAST_CODE_SIZE])
 {
-	struct bap_broadcast_assistant_instance *inst;
 	struct bt_bap_broadcast_assistant_cb *listener, *next;
 	int err;
 
 	zassert_not_null(conn, "conn is NULL");
-
-	inst = inst_by_conn(conn);
 
 	zassert_equal(src_id, RANDOM_SRC_ID, "Invalid src_id");
 

--- a/tests/bluetooth/audio/codec/src/main.c
+++ b/tests/bluetooth/audio/codec/src/main.c
@@ -659,7 +659,7 @@ ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_meta_set_lang)
 	struct bt_audio_codec_cfg codec_cfg = BT_AUDIO_CODEC_CFG(
 		BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000, {},
 		{BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_LANG, 'e', 'n', 'g')});
-	char new_expected_data[] = "deu";
+	const uint8_t new_expected_data[] = "deu";
 	char expected_data[] = "eng";
 	const uint8_t *lang;
 	int ret;
@@ -1701,7 +1701,7 @@ ZTEST(audio_codec_test_suite, test_bt_audio_codec_cap_meta_set_lang)
 	struct bt_audio_codec_cap codec_cap = BT_AUDIO_CODEC_CAP(
 		BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000, {},
 		{BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_LANG, 'e', 'n', 'g')});
-	char new_expected_data[] = "deu";
+	const uint8_t new_expected_data[] = "deu";
 	char expected_data[] = "eng";
 	const uint8_t *lang;
 	int ret;

--- a/tests/bluetooth/controller/ctrl_phy_update/src/main.c
+++ b/tests/bluetooth/controller/ctrl_phy_update/src/main.c
@@ -589,12 +589,9 @@ ZTEST(phy_periph, test_phy_update_periph_loc_invalid_central)
 {
 	uint8_t err;
 	struct node_tx *tx;
-	struct node_rx_pdu *ntf;
 	struct pdu_data_llctrl_phy_req req = { .rx_phys = PHY_2M, .tx_phys = PHY_2M };
 	uint16_t instant;
 	struct pdu_data_llctrl_conn_param_req conn_param_req = {  };
-
-	struct node_rx_pu pu = { .status = BT_HCI_ERR_SUCCESS };
 
 	struct pdu_data_llctrl_phy_upd_ind phy_update_ind = { .c_to_p_phy = PHY_2M,
 							      .p_to_c_phy = PHY_2M };

--- a/tests/bluetooth/host/conn/mocks/scan.c
+++ b/tests/bluetooth/host/conn/mocks/scan.c
@@ -5,6 +5,7 @@
  */
 
 #include <zephyr/kernel.h>
+#include <zephyr/bluetooth/conn.h>
 
 #include "scan.h"
 

--- a/tests/unit/pot/nhpot.cpp
+++ b/tests/unit/pot/nhpot.cpp
@@ -39,7 +39,7 @@ ZTEST(pot, test_constexpr_NHPOT)
 	zassert_equal(0, NHPOT(UINT64_MAX));
 
 	zassert_equal(64, val);
-	zassert_equal(64, nhpot(42));
+	zassert_equal(64ULL, nhpot(42ULL));
 	zassert_equal(BIT64(33), val64);
 	zassert_equal(BIT64(33), nhpot(42 + BIT64(32)));
 }


### PR DESCRIPTION
Add a check to set the warnings_as_errors flags in unit tests if CONFIG_COMPILER_WARNINGS_AS_ERRORS is specified, this should catch warnings in unit test twister runs.