### PR TITLE
soc: mcxn94x: Add HWINFO and fix USB_Next support

### DIFF
--- a/boards/nxp/frdm_mcxn947/board.c
+++ b/boards/nxp/frdm_mcxn947/board.c
@@ -16,6 +16,10 @@
 #define BOARD_USB_PHY_D_CAL     (0x04U)
 #define BOARD_USB_PHY_TXCAL45DP (0x07U)
 #define BOARD_USB_PHY_TXCAL45DM (0x07U)
+
+usb_phy_config_struct_t usbPhyConfig = {
+	BOARD_USB_PHY_D_CAL, BOARD_USB_PHY_TXCAL45DP, BOARD_USB_PHY_TXCAL45DM,
+};
 #endif
 
 /* Board xtal frequency in Hz */
@@ -284,11 +288,7 @@ static int frdm_mcxn947_init(void)
 	CLOCK_AttachClk(kFRO_HF_to_ADC0);
 #endif
 
-#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(usb1)) && CONFIG_USB_DC_NXP_EHCI
-	usb_phy_config_struct_t usbPhyConfig = {
-		BOARD_USB_PHY_D_CAL, BOARD_USB_PHY_TXCAL45DP, BOARD_USB_PHY_TXCAL45DM,
-	};
-
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(usb1)) && (CONFIG_USB_DC_NXP_EHCI || CONFIG_UDC_NXP_EHCI)
 	SPC0->ACTIVE_VDELAY = 0x0500;
 	/* Change the power DCDC to 1.8v (By default, DCDC is 1.8V), CORELDO to 1.1v (By default,
 	 * CORELDO is 1.0V)
@@ -323,7 +323,9 @@ static int frdm_mcxn947_init(void)
 	CLOCK_EnableClock(kCLOCK_UsbHsPhy);
 	CLOCK_EnableUsbhsPhyPllClock(kCLOCK_Usbphy480M, BOARD_XTAL0_CLK_HZ);
 	CLOCK_EnableUsbhsClock();
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(usb1)) && CONFIG_USB_DC_NXP_EHCI
 	USB_EhciPhyInit(kUSB_ControllerEhci0, BOARD_XTAL0_CLK_HZ, &usbPhyConfig);
+#endif
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(lpcmp0))

--- a/boards/nxp/frdm_mcxn947/doc/index.rst
+++ b/boards/nxp/frdm_mcxn947/doc/index.rst
@@ -85,6 +85,8 @@ The FRDM-MCXN947 board configuration supports the following hardware features:
 +-----------+------------+-------------------------------------+
 | ADC       | on-chip    | adc                                 |
 +-----------+------------+-------------------------------------+
+| HWINFO    | on-chip    | Unique device serial number         |
++-----------+------------+-------------------------------------+
 | USBHS     | on-chip    | USB device                          |
 +-----------+------------+-------------------------------------+
 | LPCMP     | on-chip    | sensor(comparator)                  |

--- a/boards/nxp/frdm_mcxn947/frdm_mcxn947_mcxn947_cpu0.dtsi
+++ b/boards/nxp/frdm_mcxn947/frdm_mcxn947_mcxn947_cpu0.dtsi
@@ -182,6 +182,14 @@
 
 zephyr_udc0: &usb1 {
 	status = "okay";
+	phy_handle = <&usbphy1>;
+};
+
+&usbphy1 {
+	status = "okay";
+	tx-d-cal = <4>;
+	tx-cal-45-dp-ohms = <7>;
+	tx-cal-45-dm-ohms = <7>;
 };
 
 &lpcmp0 {

--- a/dts/arm/nxp/nxp_mcxn94x_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxn94x_common.dtsi
@@ -880,6 +880,12 @@
 		status = "disabled";
 	};
 
+	usbphy1: usbphy@10a000 {
+		compatible = "nxp,usbphy";
+		reg = <0x10a000 0x1000>;
+		status = "disabled";
+	};
+
 	lpcmp0: lpcmp@51000 {
 		compatible = "nxp,lpcmp";
 		reg = <0x51000 0x1000>;

--- a/dts/arm/nxp/nxp_mcxn94x_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxn94x_common.dtsi
@@ -582,6 +582,11 @@
 			/* MCXN94x ROM Flash API supports writing of 128B pages. */
 			write-block-size = <128>;
 		};
+
+		uuid: uuid@1100000 {
+			compatible = "nxp,lpc-uid";
+			reg = <0x1100000 0x10>;
+		};
 	};
 
 	os_timer: timers@49000 {


### PR DESCRIPTION
1. Add HWINFO support by reading the UUID from
2. Fix USB next support on this FRDM-MCXN947 board

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/82755