### PR TITLE
MAINTAINERS: add uLipe as collaborator to lvgl

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -5021,6 +5021,7 @@ West:
   collaborators:
     - brgl
     - pdgendt
+    - uLipe
   files:
     - modules/lvgl/
     - tests/lib/gui/lvgl/


### PR DESCRIPTION
I recently joined to the LVGL team and one of my responsibility is to help on the Zephyr support, since I'm already a contributor to Zephyr, this PR is a helper to also relay the LVGL stuff to me as well, and facilitate my contributions from LVGL upstream to Zephyr downstream module.