### PR TITLE
doc: contributor: change language around PR review escalation

### DIFF
--- a/doc/contribute/contributor_expectations.rst
+++ b/doc/contribute/contributor_expectations.rst
@@ -163,7 +163,7 @@ Workflow Suggestions That Help Reviewers
 .. |git range-diff| replace:: ``git range-diff``
 .. _`git range-diff`: https://git-scm.com/docs/git-range-diff
 
-PR Review Escalation
+Getting PRs Reviewed
 ====================
 
 The Zephyr community is a diverse group of individuals, with different levels of
@@ -179,8 +179,8 @@ following this process:
 #. For PRs that have otherwise stalled, the Zephyr Dev Meeting pings the
    Assignee and any reviewers that have left comments on the PR.
 
-Contributors may escalate PRs outside of the Zephyr Dev Meeting triage process
-as follows:
+Contributors may request PRs to be reviewed outside of the Zephyr Dev Meeting
+triage process as follows:
 
 - After 1 week of inactivity, ping the Assignee or reviewers on the PR by adding
   a comment to the PR.
@@ -195,7 +195,7 @@ as follows:
   help on Discord or send an email to the `Zephyr devel mailing list`_.
 
 Note that for new PRs, contributors should generally wait for at least one
-Zephyr Dev Meeting before escalating the PR themselves.
+Zephyr Dev Meeting before making a request themselves.
 
 .. _Zephyr devel mailing list: https://lists.zephyrproject.org/g/devel
 


### PR DESCRIPTION
Refrain from using Escalation language when requesting review and
getting awareness from maintainers.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
