### PR TITLE
drivers: i2c: stm32_i2c_v2: fix I2C stability issues

### DIFF
--- a/drivers/i2c/i2c_ll_stm32.c
+++ b/drivers/i2c/i2c_ll_stm32.c
@@ -387,7 +387,7 @@ static int i2c_stm32_init(const struct device *dev)
 	int ret;
 	struct i2c_stm32_data *data = dev->data;
 #ifdef CONFIG_I2C_STM32_INTERRUPT
-	k_sem_init(&data->device_sync_sem, 0, K_SEM_MAX_LIMIT);
+	k_sem_init(&data->device_sync_sem, 0, 1);
 	cfg->irq_config_func(dev);
 #endif
 

--- a/drivers/i2c/i2c_ll_stm32.h
+++ b/drivers/i2c/i2c_ll_stm32.h
@@ -68,6 +68,7 @@ struct i2c_stm32_data {
 		unsigned int is_restart;
 		unsigned int flags;
 #endif
+		bool continue_in_next;
 		unsigned int is_write;
 		unsigned int is_arlo;
 		unsigned int is_nack;

--- a/drivers/i2c/i2c_ll_stm32_v2.c
+++ b/drivers/i2c/i2c_ll_stm32_v2.c
@@ -164,16 +164,12 @@ static void stm32_i2c_disable_transfer_interrupts(const struct device *dev)
 	const struct i2c_stm32_config *cfg = dev->config;
 	struct i2c_stm32_data *data = dev->data;
 	I2C_TypeDef *i2c = cfg->i2c;
-
-	LL_I2C_DisableIT_TX(i2c);
-	LL_I2C_DisableIT_RX(i2c);
-	LL_I2C_DisableIT_STOP(i2c);
-	LL_I2C_DisableIT_NACK(i2c);
-	LL_I2C_DisableIT_TC(i2c);
-
+	uint32_t flags =
+		I2C_CR1_TXIE | I2C_CR1_RXIE | I2C_CR1_STOPIE | I2C_CR1_NACKIE | I2C_CR1_TCIE;
 	if (!data->smbalert_active) {
-		LL_I2C_DisableIT_ERR(i2c);
+		flags |= I2C_CR1_ERRIE;
 	}
+	i2c->CR1 &= ~flags;
 }
 
 static void stm32_i2c_enable_transfer_interrupts(const struct device *dev)


### PR DESCRIPTION
Due to various reported stability issues with the STM32 I2C V2 driver in interrupt mode, the controller part is rewritten in an attempt to closely follow documentation found in reference manualand errata sheets. See #70077
A side effect should also be increased performance