### PR TITLE
Wba single wire uart

### DIFF
--- a/boards/st/nucleo_wba55cg/nucleo_wba55cg.dts
+++ b/boards/st/nucleo_wba55cg/nucleo_wba55cg.dts
@@ -123,6 +123,16 @@
 	status = "okay";
 };
 
+&usart2 {
+	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00020000>,
+		 <&rcc STM32_SRC_HSI16 USART2_SEL(2)>;
+	pinctrl-0 = <&usart2_tx_pa12 &usart2_rx_pb8>;
+	pinctrl-1 = <&analog_pa12 &analog_pb8>;
+	pinctrl-names = "default", "sleep";
+	current-speed = <115200>;
+	status = "okay";
+};
+
 &lpuart1 {
 	pinctrl-0 = <&lpuart1_tx_pb5 &lpuart1_rx_pa10>;
 	pinctrl-names = "default";

--- a/samples/boards/st/uart/single_wire/README.rst
+++ b/samples/boards/st/uart/single_wire/README.rst
@@ -7,13 +7,17 @@
 Overview
 ********
 
-A simple application demonstrating how to use the single wire / half-duplex UART
-functionality of STM32. Without adaptions this example runs on STM32F3 discovery
-board. You need to establish a physical connection between pins PA2 (USART2_TX) and
-PC10 (UART4_TX).
-
+A simple application demonstrating how to use the single-wire/half-duplex
+UART functionality of STM32 devices. The example runs on various STM32
+boards with minimal adaptations.
 Add a ``single_wire_uart_loopback`` fixture to your board in the hardware map to allow
 twister to verify this sample's output automatically.
+
+Hardware Setup
+**************
+
+You need to establish a physical connection between UART pins on the board.
+Refer to the specific board overlay file for the exact pin connections.
 
 Building and Running
 ********************

--- a/samples/boards/st/uart/single_wire/boards/nucleo_wba55cg.overlay
+++ b/samples/boards/st/uart/single_wire/boards/nucleo_wba55cg.overlay
@@ -1,0 +1,36 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2025 STMicroelectronics
+ */
+
+&usart2 {
+	status = "okay";
+	pinctrl-0 = <&usart2_tx_pa12>;
+	current-speed = <115200>;
+	single-wire;
+};
+
+&lpuart1 {
+	status = "okay";
+	pinctrl-0 = <&lpuart1_tx_pa2>;
+	current-speed = <115200>;
+	single-wire;
+};
+
+&usart2_tx_pa12 {
+	bias-pull-up;
+	drive-open-drain;
+};
+
+&lpuart1_tx_pa2 {
+	bias-pull-up;
+	drive-open-drain;
+};
+
+/ {
+	aliases {
+	single-line-uart1 = &usart2;
+	single-line-uart2 = &lpuart1;
+	};
+};

--- a/samples/boards/st/uart/single_wire/sample.yaml
+++ b/samples/boards/st/uart/single_wire/sample.yaml
@@ -2,7 +2,9 @@ sample:
   name: STM32 Single Wire UART sample
 tests:
   sample.boards.stm32.uart.single_wire:
-    platform_allow: stm32f3_disco
+    platform_allow:
+      - stm32f3_disco
+      - nucleo_wba55cg
     tags:
       - drivers
       - uart


### PR DESCRIPTION
This pull request introduces support for the Nucleo WBA55CG board in the single-wire UART example.