### PR TITLE
soc: nxp mcxc: fix LinkServer flashing

### DIFF
--- a/dts/arm/nxp/nxp_mcxc_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxc_common.dtsi
@@ -67,7 +67,7 @@
 			status = "disabled";
 			#address-cells = <1>;
 			#size-cells = <1>;
-			fsec = <0xff>;
+			fsec = <0xfe>;
 			fopt = <0x3d>;
 			config-field-offset = <0x400>;
 

--- a/soc/nxp/mcx/mcxc/flash_configuration.c
+++ b/soc/nxp/mcx/mcxc/flash_configuration.c
@@ -29,7 +29,7 @@ uint8_t __kinetis_flash_config_section __kinetis_flash_config[] = {
 	/* Flash security register (FSEC) enables/disables backdoor key access,
 	 * mass erase, factory access, and flash security
 	 */
-	DT_PROP_OR(DT_NODELABEL(ftfa), fsec, 0xFF),
+	DT_PROP_OR(DT_NODELABEL(ftfa), fsec, 0xFE),
 
 	/* Flash nonvolatile option register (FOPT) enables/disables NMI,
 	 * EzPort, and boot options


### PR DESCRIPTION
LinkServer can flash only the first time, cannot flash again. Fix it by setting default mcu security status as unsecure.