### PR TITLE
twister: handlers: fix none status on test fail

### DIFF
--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -326,11 +326,13 @@ class BinaryHandler(Handler):
             else:
                 # When a process is killed, the default handler returns 128 + SIGTERM
                 # so in that case the return code itself is not meaningful
-                self.instance.reason = "Failed"
+                self.instance.reason = f"Failed (rc={self.returncode})"
+            self.instance.add_missing_case_status(TwisterStatus.BLOCK)
         elif harness_status != TwisterStatus.NONE:
             self.instance.status = harness_status
             if harness_status == TwisterStatus.FAIL:
-                self.instance.reason = "Failed"
+                self.instance.reason = "Failed harness"
+            self.instance.add_missing_case_status(TwisterStatus.BLOCK)
         else:
             self.instance.status = TwisterStatus.FAIL
             self.instance.reason = "Timeout"

--- a/scripts/tests/twister/test_handlers.py
+++ b/scripts/tests/twister/test_handlers.py
@@ -511,7 +511,7 @@ def test_binaryhandler_create_env(
 TESTDATA_6 = [
     (TwisterStatus.NONE, False, 2, True, TwisterStatus.FAIL, 'Valgrind error', False),
     (TwisterStatus.NONE, False, 1, False, TwisterStatus.FAIL, 'Failed (rc=1)', False),
-    (TwisterStatus.FAIL, False, 0, False, TwisterStatus.FAIL, 'Failed harness', False),
+    (TwisterStatus.FAIL, False, 0, False, TwisterStatus.FAIL, "Failed harness:'foobar'", False),
     ('success', False, 0, False, 'success', 'Unknown', False),
     (TwisterStatus.NONE, True, 1, True, TwisterStatus.FAIL, 'Timeout', True),
 ]
@@ -540,8 +540,9 @@ def test_binaryhandler_update_instance_info(
     handler.returncode = returncode
     missing_mock = mock.Mock()
     handler.instance.add_missing_case_status = missing_mock
+    mocked_harness = mock.Mock(status=harness_status, reason="foobar")
 
-    handler._update_instance_info(harness_status, handler_time)
+    handler._update_instance_info(mocked_harness, handler_time)
 
     assert handler.instance.execution_time == handler_time
 
@@ -1189,7 +1190,7 @@ def test_devicehandler_create_command(
 
 TESTDATA_14 = [
     ('success', False, 'success', 'Unknown', False),
-    (TwisterStatus.FAIL, False, TwisterStatus.FAIL, 'Failed', True),
+    (TwisterStatus.FAIL, False, TwisterStatus.FAIL, "Failed harness:'foobar'", True),
     (TwisterStatus.ERROR, False, TwisterStatus.ERROR, 'Unknown', True),
     (TwisterStatus.NONE, True, TwisterStatus.NONE, 'Unknown', False),
     (TwisterStatus.NONE, False, TwisterStatus.FAIL, 'Timeout', True),
@@ -1213,8 +1214,9 @@ def test_devicehandler_update_instance_info(
     handler_time = 59
     missing_mock = mock.Mock()
     handler.instance.add_missing_case_status = missing_mock
+    mocked_harness = mock.Mock(status=harness_status, reason="foobar")
 
-    handler._update_instance_info(harness_status, handler_time, flash_error)
+    handler._update_instance_info(mocked_harness, handler_time, flash_error)
 
     assert handler.instance.execution_time == handler_time
 
@@ -1716,12 +1718,13 @@ def test_qemuhandler_update_instance_info(
 ):
     mocked_instance.add_missing_case_status = mock.Mock()
     mocked_instance.reason = self_instance_reason
+    mocked_harness = mock.Mock(status=harness_status, reason="foobar")
 
     handler = QEMUHandler(mocked_instance, 'build', mock.Mock())
     handler.returncode = self_returncode
     handler.ignore_qemu_crash = self_ignore_qemu_crash
 
-    handler._update_instance_info(harness_status, is_timeout)
+    handler._update_instance_info(mocked_harness, is_timeout)
 
     assert handler.instance.status == expected_status
     assert handler.instance.reason == expected_reason

--- a/scripts/tests/twister/test_handlers.py
+++ b/scripts/tests/twister/test_handlers.py
@@ -510,8 +510,8 @@ def test_binaryhandler_create_env(
 
 TESTDATA_6 = [
     (TwisterStatus.NONE, False, 2, True, TwisterStatus.FAIL, 'Valgrind error', False),
-    (TwisterStatus.NONE, False, 1, False, TwisterStatus.FAIL, 'Failed', False),
-    (TwisterStatus.FAIL, False, 0, False, TwisterStatus.FAIL, 'Failed', False),
+    (TwisterStatus.NONE, False, 1, False, TwisterStatus.FAIL, 'Failed (rc=1)', False),
+    (TwisterStatus.FAIL, False, 0, False, TwisterStatus.FAIL, 'Failed harness', False),
     ('success', False, 0, False, 'success', 'Unknown', False),
     (TwisterStatus.NONE, True, 1, True, TwisterStatus.FAIL, 'Timeout', True),
 ]

--- a/scripts/tests/twister_blackbox/test_device.py
+++ b/scripts/tests/twister_blackbox/test_device.py
@@ -72,5 +72,5 @@ class TestDevice:
 
         assert str(sys_exit.value) == '1'
 
-        expected_line = r'seed_native_sim.dummy FAILED Failed \(native (\d+\.\d+)s/seed: {}\)'.format(seed[0])
+        expected_line = r'seed_native_sim.dummy FAILED Failed \(rc=1\) \(native (\d+\.\d+)s/seed: {}\)'.format(seed[0])
         assert re.search(expected_line, err)


### PR DESCRIPTION
Set missing TestCase statuses when a test under the BinaryHandler failed (crashed), so remaining 'STARTED' and 'NONE' are now 'FAILED' and 'BLOCK' respectively.

Pass a test failure reason from harness to the instance to convey more details on the failure.

#68682 is an example of failed test. Such test has its log/json records like these:
```
twister - WARNING - A started status detected in instance ...
twister - WARNING - A None status detected in instance ...
```
and TestCases with a mix of `passed`, `started` (where crash/assert happens), and `None` (not executed)
```
            "name":"tests/kernel/mem_protect/syscalls/kernel.memory_protection.syscalls",
            "status":"failed",
            "reason":"Failed",
            "testcases":[
                {
                    "identifier":"kernel.memory_protection.syscalls.syscalls.syscall_context",
                    "status":"passed"
                },
                {
                    "identifier":"kernel.memory_protection.syscalls.syscalls.syscall_torture",
                    "status":"started"
                },
...           
                {
                    "identifier":"kernel.memory_protection.syscalls.syscalls.to_copy",
                    "execution_time":"0.00",
                    "status":"None"
                },
                {
                    "identifier":"kernel.memory_protection.syscalls.syscalls.user_string_copy",
                    "execution_time":"0.00",
                    "status":"None"
                },
            ]
        },
```
After the fix, the 'started' and 'None' testcases are set to 'failed' and 'blocked' respectively; and the instance has `"reason":"Failed harness:'Testsuite failed'"` as well as the blocked testcases.