### PR TITLE
dts: xtensa: nxp: imx8ulp: fix sram address

### DIFF
--- a/dts/xtensa/nxp/nxp_imx8ulp.dtsi
+++ b/dts/xtensa/nxp/nxp_imx8ulp.dtsi
@@ -30,16 +30,16 @@
 		};
 	};
 
-	sram0: memory@8e000000 {
+	sram0: memory@1a000000 {
 		device_type = "memory";
 		compatible = "mmio-sram";
-		reg = <0x8e000000 DT_SIZE_K(512)>;
+		reg = <0x1a000000 DT_SIZE_K(512)>;
 	};
 
-	sram1: memory@8e800000 {
+	sram1: memory@1a800000 {
 		device_type = "memory";
 		compatible = "mmio-sram";
-		reg = <0x8e800000 DT_SIZE_K(512)>;
+		reg = <0x1a800000 DT_SIZE_K(512)>;
 	};
 
 	pcc4: clock-controller@29800000 {


### PR DESCRIPTION
Fix addresses for sram0 and sram1.

Fixes: a7b7364c4ef8 ("dts/xtensa/nxp: Add dtsi for imx8ulp")