### PR TITLE
ADC STM32: Various fixes and enhancements

### DIFF
--- a/boards/96boards/aerocore2/96b_aerocore2.dts
+++ b/boards/96boards/aerocore2/96b_aerocore2.dts
@@ -179,7 +179,7 @@ zephyr_udc0: &usbotg_fs {
 	pinctrl-0 = <&adc1_in10_pc0 &adc1_in11_pc1
 		     &adc1_in12_pc2 &adc1_in13_pc3>;
 	pinctrl-names = "default";
-	st,adc-clock-source = <SYNC>;
+	st,adc-clock-source = "SYNC";
 	st,adc-prescaler = <2>;
 	status = "okay";
 };

--- a/boards/arduino/opta/arduino_opta-common.dtsi
+++ b/boards/arduino/opta/arduino_opta-common.dtsi
@@ -107,7 +107,7 @@
 &adc1 {
 	pinctrl-0 = <&adc1_inp0_pa0_c &adc1_inp6_pf12>;
 	pinctrl-names = "default";
-	st,adc-clock-source = <SYNC>;
+	st,adc-clock-source = "SYNC";
 	st,adc-prescaler = <4>;
 	vref-mv = <10000>;
 
@@ -135,7 +135,7 @@
 &adc2 {
 	pinctrl-0 = <&adc2_inp9_pb0>;
 	pinctrl-names = "default";
-	st,adc-clock-source = <SYNC>;
+	st,adc-clock-source = "SYNC";
 	st,adc-prescaler = <4>;
 	vref-mv = <10000>;
 
@@ -154,7 +154,7 @@
 &adc3 {
 	pinctrl-0 = <&adc3_inp6_pf10 &adc3_inp7_pf8 &adc3_inp8_pf6 &adc3_inp9_pf4 &adc3_inp0_pc2_c>;
 	pinctrl-names = "default";
-	st,adc-clock-source = <SYNC>;
+	st,adc-clock-source = "SYNC";
 	st,adc-prescaler = <4>;
 	vref-mv = <10000>;
 

--- a/boards/blues/swan_r5/swan_r5.dts
+++ b/boards/blues/swan_r5/swan_r5.dts
@@ -195,7 +195,7 @@ zephyr_udc0: &usbotg_fs {
 &adc1 {
 	pinctrl-0 = <&adc1_in6_pa1>;
 	pinctrl-names = "default";
-	st,adc-clock-source = <SYNC>;
+	st,adc-clock-source = "SYNC";
 	st,adc-prescaler = <4>;
 	status = "okay";
 };

--- a/boards/google/twinkie_v2/google_twinkie_v2.dts
+++ b/boards/google/twinkie_v2/google_twinkie_v2.dts
@@ -101,7 +101,7 @@
 		     &adc1_in18_pc5	/* CSA_CC2	 */
 		    >;
 	pinctrl-names = "default";
-	st,adc-clock-source = <SYNC>;
+	st,adc-clock-source = "SYNC";
 	st,adc-prescaler = <4>;
 	status = "okay";
 

--- a/boards/mikroe/clicker_2/mikroe_clicker_2.dts
+++ b/boards/mikroe/clicker_2/mikroe_clicker_2.dts
@@ -146,7 +146,7 @@ zephyr_udc0: &usbotg_fs {
 	status ="okay";
 	pinctrl-0 = <&adc1_in2_pa2 &adc1_in3_pa3>;
 	pinctrl-names = "default";
-	st,adc-clock-source = <SYNC>;
+	st,adc-clock-source = "SYNC";
 	st,adc-prescaler = <2>;
 };
 

--- a/boards/others/stm32f401_mini/stm32f401_mini.dts
+++ b/boards/others/stm32f401_mini/stm32f401_mini.dts
@@ -117,7 +117,7 @@ zephyr_udc0: &usbotg_fs {
 &adc1 {
 	pinctrl-0 = <&adc1_in1_pa1>;
 	pinctrl-names = "default";
-	st,adc-clock-source = <SYNC>;
+	st,adc-clock-source = "SYNC";
 	st,adc-prescaler = <2>;
 	status = "okay";
 };

--- a/boards/ronoth/lodev/ronoth_lodev.dts
+++ b/boards/ronoth/lodev/ronoth_lodev.dts
@@ -163,7 +163,7 @@
 &adc1 {
 	pinctrl-0 = <&adc_in0_pa0>;
 	pinctrl-names = "default";
-	st,adc-clock-source = <SYNC>;
+	st,adc-clock-source = "SYNC";
 	st,adc-prescaler = <4>;
 	status = "okay";
 };

--- a/boards/seeed/lora_e5_dev_board/lora_e5_dev_board.dts
+++ b/boards/seeed/lora_e5_dev_board/lora_e5_dev_board.dts
@@ -157,7 +157,7 @@ stm32_lp_tick_source: &lptim1 {
 &adc1 {
 	pinctrl-0 = <&adc_in2_pb3>;
 	pinctrl-names = "default";
-	st,adc-clock-source = <SYNC>;
+	st,adc-clock-source = "SYNC";
 	st,adc-prescaler = <4>;
 	status = "okay";
 };

--- a/boards/st/b_g474e_dpow1/b_g474e_dpow1.dts
+++ b/boards/st/b_g474e_dpow1/b_g474e_dpow1.dts
@@ -134,7 +134,7 @@ stm32_lp_tick_source: &lptim1 {
 &adc2 {
 	pinctrl-0 = <&adc2_in8_pc2>;
 	pinctrl-names = "default";
-	st,adc-clock-source = <SYNC>;
+	st,adc-clock-source = "SYNC";
 	st,adc-prescaler = <4>;
 	status = "okay";
 

--- a/boards/st/b_u585i_iot02a/b_u585i_iot02a-common.dtsi
+++ b/boards/st/b_u585i_iot02a/b_u585i_iot02a-common.dtsi
@@ -223,7 +223,7 @@ zephyr_udc0: &usbotg_fs {
 &adc1 {
 	pinctrl-0 = <&adc1_in15_pb0>;
 	pinctrl-names = "default";
-	st,adc-clock-source = <ASYNC>;
+	st,adc-clock-source = "ASYNC";
 	st,adc-prescaler = <4>;
 	status = "okay";
 };
@@ -231,7 +231,7 @@ zephyr_udc0: &usbotg_fs {
 &adc4 {
 	pinctrl-0 = <&adc4_in19_pb1>;
 	pinctrl-names = "default";
-	st,adc-clock-source = <ASYNC>;
+	st,adc-clock-source = "ASYNC";
 	st,adc-prescaler = <4>;
 	status = "okay";
 };

--- a/boards/st/disco_l475_iot1/disco_l475_iot1.dts
+++ b/boards/st/disco_l475_iot1/disco_l475_iot1.dts
@@ -293,7 +293,7 @@ zephyr_udc0: &usbotg_fs {
 	pinctrl-0 = <&adc1_in3_pc2 &adc1_in4_pc3
 		     &adc1_in13_pc4 &adc1_in14_pc5>;
 	pinctrl-names = "default";
-	st,adc-clock-source = <SYNC>;
+	st,adc-clock-source = "SYNC";
 	st,adc-prescaler = <4>;
 	status = "okay";
 };

--- a/boards/st/nucleo_c031c6/nucleo_c031c6.dts
+++ b/boards/st/nucleo_c031c6/nucleo_c031c6.dts
@@ -117,7 +117,7 @@
 &adc1 {
 	pinctrl-0 = <&adc1_in0_pa0 &adc1_in1_pa1 &adc1_in4_pa4>;
 	pinctrl-names = "default";
-	st,adc-clock-source = <SYNC>;
+	st,adc-clock-source = "SYNC";
 	st,adc-prescaler = <4>;
 	status = "okay";
 };

--- a/boards/st/nucleo_f030r8/nucleo_f030r8.dts
+++ b/boards/st/nucleo_f030r8/nucleo_f030r8.dts
@@ -118,7 +118,7 @@
 &adc1 {
 	pinctrl-0 = <&adc_in0_pa0>;
 	pinctrl-names = "default";
-	st,adc-clock-source = <SYNC>;
+	st,adc-clock-source = "SYNC";
 	st,adc-prescaler = <4>;
 	status = "okay";
 };

--- a/boards/st/nucleo_f031k6/nucleo_f031k6.dts
+++ b/boards/st/nucleo_f031k6/nucleo_f031k6.dts
@@ -103,7 +103,7 @@
 &adc1 {
 	pinctrl-0 = <&adc_in0_pa0>;
 	pinctrl-names = "default";
-	st,adc-clock-source = <SYNC>;
+	st,adc-clock-source = "SYNC";
 	st,adc-prescaler = <4>;
 	status = "okay";
 };

--- a/boards/st/nucleo_f042k6/nucleo_f042k6.dts
+++ b/boards/st/nucleo_f042k6/nucleo_f042k6.dts
@@ -99,7 +99,7 @@
 &adc1 {
 	pinctrl-0 = <&adc_in0_pa0>;
 	pinctrl-names = "default";
-	st,adc-clock-source = <SYNC>;
+	st,adc-clock-source = "SYNC";
 	st,adc-prescaler = <4>;
 	status = "okay";
 };

--- a/boards/st/nucleo_f070rb/nucleo_f070rb.dts
+++ b/boards/st/nucleo_f070rb/nucleo_f070rb.dts
@@ -121,7 +121,7 @@
 &adc1 {
 	pinctrl-0 = <&adc_in0_pa0>;
 	pinctrl-names = "default";
-	st,adc-clock-source = <SYNC>;
+	st,adc-clock-source = "SYNC";
 	st,adc-prescaler = <4>;
 	status = "okay";
 };

--- a/boards/st/nucleo_f091rc/nucleo_f091rc.dts
+++ b/boards/st/nucleo_f091rc/nucleo_f091rc.dts
@@ -159,7 +159,7 @@
 &adc1 {
 	pinctrl-0 = <&adc_in0_pa0>;
 	pinctrl-names = "default";
-	st,adc-clock-source = <SYNC>;
+	st,adc-clock-source = "SYNC";
 	st,adc-prescaler = <4>;
 	status = "okay";
 };

--- a/boards/st/nucleo_f207zg/nucleo_f207zg.dts
+++ b/boards/st/nucleo_f207zg/nucleo_f207zg.dts
@@ -164,7 +164,7 @@ zephyr_udc0: &usbotg_fs {
 &adc1 {
 	pinctrl-0 = <&adc1_in0_pa0>;
 	pinctrl-names = "default";
-	st,adc-clock-source = <SYNC>;
+	st,adc-clock-source = "SYNC";
 	st,adc-prescaler = <2>;
 	status = "okay";
 };

--- a/boards/st/nucleo_f302r8/nucleo_f302r8.dts
+++ b/boards/st/nucleo_f302r8/nucleo_f302r8.dts
@@ -124,7 +124,7 @@
 &adc1 {
 	pinctrl-0 = <&adc1_in1_pa0>;
 	pinctrl-names = "default";
-	st,adc-clock-source = <SYNC>;
+	st,adc-clock-source = "SYNC";
 	st,adc-prescaler = <2>;
 	status = "okay";
 };

--- a/boards/st/nucleo_f303k8/nucleo_f303k8.dts
+++ b/boards/st/nucleo_f303k8/nucleo_f303k8.dts
@@ -100,7 +100,7 @@
 &adc1 {
 	pinctrl-0 = <&adc1_in1_pa0>;
 	pinctrl-names = "default";
-	st,adc-clock-source = <SYNC>;
+	st,adc-clock-source = "SYNC";
 	st,adc-prescaler = <2>;
 	status = "okay";
 };

--- a/boards/st/nucleo_f401re/nucleo_f401re.dts
+++ b/boards/st/nucleo_f401re/nucleo_f401re.dts
@@ -180,7 +180,7 @@
 &adc1 {
 	pinctrl-0 = <&adc1_in0_pa0>;
 	pinctrl-names = "default";
-	st,adc-clock-source = <SYNC>;
+	st,adc-clock-source = "SYNC";
 	st,adc-prescaler = <2>;
 	status = "okay";
 };

--- a/boards/st/nucleo_f429zi/nucleo_f429zi.dts
+++ b/boards/st/nucleo_f429zi/nucleo_f429zi.dts
@@ -90,7 +90,7 @@
 &adc1 {
 	pinctrl-0 = <&adc1_in0_pa0>;
 	pinctrl-names = "default";
-	st,adc-clock-source = <SYNC>;
+	st,adc-clock-source = "SYNC";
 	st,adc-prescaler = <2>;
 	status = "okay";
 };

--- a/boards/st/nucleo_f446ze/nucleo_f446ze.dts
+++ b/boards/st/nucleo_f446ze/nucleo_f446ze.dts
@@ -87,7 +87,7 @@
 &adc1 {
 	pinctrl-0 = <&adc1_in0_pa0>;
 	pinctrl-names = "default";
-	st,adc-clock-source = <SYNC>;
+	st,adc-clock-source = "SYNC";
 	st,adc-prescaler = <2>;
 	status = "okay";
 };

--- a/boards/st/nucleo_f722ze/nucleo_f722ze.dts
+++ b/boards/st/nucleo_f722ze/nucleo_f722ze.dts
@@ -102,7 +102,7 @@
 &adc1 {
 	pinctrl-0 = <&adc1_in3_pa3 &adc1_in10_pc0>;
 	pinctrl-names = "default";
-	st,adc-clock-source = <SYNC>;
+	st,adc-clock-source = "SYNC";
 	st,adc-prescaler = <2>;
 	status = "okay";
 };

--- a/boards/st/nucleo_f746zg/nucleo_f746zg.dts
+++ b/boards/st/nucleo_f746zg/nucleo_f746zg.dts
@@ -176,7 +176,7 @@ zephyr_udc0: &usbotg_fs {
 &adc1 {
 	pinctrl-0 = <&adc1_in0_pa0>;
 	pinctrl-names = "default";
-	st,adc-clock-source = <SYNC>;
+	st,adc-clock-source = "SYNC";
 	st,adc-prescaler = <2>;
 	status = "okay";
 };

--- a/boards/st/nucleo_f767zi/nucleo_f767zi.dts
+++ b/boards/st/nucleo_f767zi/nucleo_f767zi.dts
@@ -171,7 +171,7 @@ zephyr_udc0: &usbotg_fs {
 &adc1 {
 	pinctrl-0 = <&adc1_in0_pa0>;
 	pinctrl-names = "default";
-	st,adc-clock-source = <SYNC>;
+	st,adc-clock-source = "SYNC";
 	st,adc-prescaler = <2>;
 	status = "okay";
 };

--- a/boards/st/nucleo_g070rb/nucleo_g070rb.dts
+++ b/boards/st/nucleo_g070rb/nucleo_g070rb.dts
@@ -139,7 +139,7 @@
 &adc1 {
 	pinctrl-0 = <&adc1_in0_pa0 &adc1_in1_pa1>;
 	pinctrl-names = "default";
-	st,adc-clock-source = <SYNC>;
+	st,adc-clock-source = "SYNC";
 	st,adc-prescaler = <4>;
 	status = "okay";
 	vref-mv = <3300>;

--- a/boards/st/nucleo_g071rb/nucleo_g071rb.dts
+++ b/boards/st/nucleo_g071rb/nucleo_g071rb.dts
@@ -147,7 +147,7 @@
 		 <&rcc STM32_SRC_SYSCLK ADC_SEL(0)>;
 	pinctrl-0 = <&adc1_in0_pa0 &adc1_in1_pa1>;
 	pinctrl-names = "default";
-	st,adc-clock-source = <ASYNC>;
+	st,adc-clock-source = "ASYNC";
 	st,adc-prescaler = <4>;
 	status = "okay";
 	vref-mv = <3300>;

--- a/boards/st/nucleo_g0b1re/nucleo_g0b1re.dts
+++ b/boards/st/nucleo_g0b1re/nucleo_g0b1re.dts
@@ -163,7 +163,7 @@ zephyr_udc0: &usb {
 &adc1 {
 	pinctrl-0 = <&adc1_in0_pa0 &adc1_in1_pa1>;
 	pinctrl-names = "default";
-	st,adc-clock-source = <SYNC>;
+	st,adc-clock-source = "SYNC";
 	st,adc-prescaler = <4>;
 	status = "okay";
 };

--- a/boards/st/nucleo_g474re/nucleo_g474re.dts
+++ b/boards/st/nucleo_g474re/nucleo_g474re.dts
@@ -203,7 +203,7 @@ stm32_lp_tick_source: &lptim1 {
 &adc1 {
 	pinctrl-0 = <&adc1_in1_pa0>;
 	pinctrl-names = "default";
-	st,adc-clock-source = <SYNC>;
+	st,adc-clock-source = "SYNC";
 	st,adc-prescaler = <4>;
 	status = "okay";
 };

--- a/boards/st/nucleo_h533re/nucleo_h533re.dts
+++ b/boards/st/nucleo_h533re/nucleo_h533re.dts
@@ -132,7 +132,7 @@
 		 <&rcc STM32_SRC_HCLK ADCDAC_SEL(0)>;
 	pinctrl-0 = <&adc1_inp0_pa0>; /* Arduino A0 */
 	pinctrl-names = "default";
-	st,adc-clock-source = <ASYNC>;
+	st,adc-clock-source = "ASYNC";
 	st,adc-prescaler = <8>;
 	status = "okay";
 };

--- a/boards/st/nucleo_h563zi/nucleo_h563zi-common.dtsi
+++ b/boards/st/nucleo_h563zi/nucleo_h563zi-common.dtsi
@@ -156,7 +156,7 @@
 		 <&rcc STM32_SRC_HCLK ADCDAC_SEL(0)>;
 	pinctrl-0 = <&adc1_inp3_pa6 &adc1_inp15_pa3>; /* Zio A0, Zio D35 */
 	pinctrl-names = "default";
-	st,adc-clock-source = <ASYNC>;
+	st,adc-clock-source = "ASYNC";
 	st,adc-prescaler = <6>;
 	status = "okay";
 };

--- a/boards/st/nucleo_h743zi/nucleo_h743zi.dts
+++ b/boards/st/nucleo_h743zi/nucleo_h743zi.dts
@@ -150,7 +150,7 @@ zephyr_udc0: &usbotg_fs {
 &adc1 {
 	pinctrl-0 = <&adc1_inp15_pa3>;
 	pinctrl-names = "default";
-	st,adc-clock-source = <SYNC>;
+	st,adc-clock-source = "SYNC";
 	st,adc-prescaler = <4>;
 	status = "okay";
 };
@@ -162,7 +162,7 @@ zephyr_udc0: &usbotg_fs {
 &adc3 {
 	pinctrl-0 = <&adc3_inp5_pf3>;
 	pinctrl-names = "default";
-	st,adc-clock-source = <SYNC>;
+	st,adc-clock-source = "SYNC";
 	st,adc-prescaler = <4>;
 	status = "okay";
 };

--- a/boards/st/nucleo_h753zi/nucleo_h753zi.dts
+++ b/boards/st/nucleo_h753zi/nucleo_h753zi.dts
@@ -147,7 +147,7 @@ zephyr_udc0: &usbotg_fs {
 &adc1 {
 	pinctrl-0 = <&adc1_inp15_pa3>;
 	pinctrl-names = "default";
-	st,adc-clock-source = <SYNC>;
+	st,adc-clock-source = "SYNC";
 	st,adc-prescaler = <4>;
 	status = "okay";
 };

--- a/boards/st/nucleo_h7a3zi_q/nucleo_h7a3zi_q.dts
+++ b/boards/st/nucleo_h7a3zi_q/nucleo_h7a3zi_q.dts
@@ -116,7 +116,7 @@
 &adc1 {
 	pinctrl-0 = <&adc1_inp15_pa3>;
 	pinctrl-names = "default";
-	st,adc-clock-source = <SYNC>;
+	st,adc-clock-source = "SYNC";
 	st,adc-prescaler = <4>;
 	status = "okay";
 };

--- a/boards/st/nucleo_l073rz/nucleo_l073rz.dts
+++ b/boards/st/nucleo_l073rz/nucleo_l073rz.dts
@@ -140,7 +140,7 @@ stm32_lp_tick_source: &lptim1 {
 &adc1 {
 	pinctrl-0 = <&adc_in0_pa0>;
 	pinctrl-names = "default";
-	st,adc-clock-source = <SYNC>;
+	st,adc-clock-source = "SYNC";
 	st,adc-prescaler = <4>;
 	status = "okay";
 };

--- a/boards/st/nucleo_l152re/nucleo_l152re.dts
+++ b/boards/st/nucleo_l152re/nucleo_l152re.dts
@@ -124,7 +124,7 @@
 &adc1 {
 	pinctrl-0 = <&adc_in0_pa0>;
 	pinctrl-names = "default";
-	st,adc-clock-source = <ASYNC>;
+	st,adc-clock-source = "ASYNC";
 	st,adc-prescaler = <4>;
 	status = "okay";
 };

--- a/boards/st/nucleo_l412rb_p/nucleo_l412rb_p.dts
+++ b/boards/st/nucleo_l412rb_p/nucleo_l412rb_p.dts
@@ -117,7 +117,7 @@
 &adc1 {
 	pinctrl-0 = <&adc1_in5_pa0>;
 	pinctrl-names = "default";
-	st,adc-clock-source = <SYNC>;
+	st,adc-clock-source = "SYNC";
 	st,adc-prescaler = <4>;
 	status = "okay";
 };

--- a/boards/st/nucleo_l476rg/nucleo_l476rg.dts
+++ b/boards/st/nucleo_l476rg/nucleo_l476rg.dts
@@ -167,7 +167,7 @@ stm32_lp_tick_source: &lptim1 {
 &adc1 {
 	pinctrl-0 = <&adc1_in1_pc0>;
 	pinctrl-names = "default";
-	st,adc-clock-source = <SYNC>;
+	st,adc-clock-source = "SYNC";
 	st,adc-prescaler = <4>;
 	status = "okay";
 };

--- a/boards/st/nucleo_l4r5zi/nucleo_l4r5zi.dts
+++ b/boards/st/nucleo_l4r5zi/nucleo_l4r5zi.dts
@@ -206,7 +206,7 @@ zephyr_udc0: &usbotg_fs {
 &adc1 {
 	pinctrl-0 = <&adc1_in1_pc0>;
 	pinctrl-names = "default";
-	st,adc-clock-source = <SYNC>;
+	st,adc-clock-source = "SYNC";
 	st,adc-prescaler = <4>;
 	status = "okay";
 };

--- a/boards/st/nucleo_l552ze_q/nucleo_l552ze_q-common.dtsi
+++ b/boards/st/nucleo_l552ze_q/nucleo_l552ze_q-common.dtsi
@@ -82,7 +82,7 @@
 &adc1 {
 	pinctrl-0 = <&adc1_in1_pc0>;
 	pinctrl-names = "default";
-	st,adc-clock-source = <SYNC>;
+	st,adc-clock-source = "SYNC";
 	st,adc-prescaler = <4>;
 	status = "okay";
 };

--- a/boards/st/nucleo_u031r8/nucleo_u031r8.dts
+++ b/boards/st/nucleo_u031r8/nucleo_u031r8.dts
@@ -105,7 +105,7 @@
 &adc1 {
 	pinctrl-0 = <&adc1_in0_pc0 &adc1_in1_pc1>;
 	pinctrl-names = "default";
-	st,adc-clock-source = <SYNC>;
+	st,adc-clock-source = "SYNC";
 	st,adc-prescaler = <4>;
 	status = "okay";
 	vref-mv = <3300>;

--- a/boards/st/nucleo_u083rc/nucleo_u083rc.dts
+++ b/boards/st/nucleo_u083rc/nucleo_u083rc.dts
@@ -105,7 +105,7 @@
 &adc1 {
 	pinctrl-0 = <&adc1_in0_pc0 &adc1_in1_pc1>;
 	pinctrl-names = "default";
-	st,adc-clock-source = <ASYNC>;
+	st,adc-clock-source = "ASYNC";
 	clocks = <&rcc STM32_CLOCK_BUS_APB1_2 0x00100000>,
 		 <&rcc STM32_SRC_HSI ADC_SEL(2)>;
 	st,adc-prescaler = <4>;

--- a/boards/st/nucleo_u575zi_q/nucleo_u575zi_q-common.dtsi
+++ b/boards/st/nucleo_u575zi_q/nucleo_u575zi_q-common.dtsi
@@ -129,7 +129,7 @@
 &adc1 {
 	pinctrl-0 = <&adc1_in1_pc0>;
 	pinctrl-names = "default";
-	st,adc-clock-source = <ASYNC>;
+	st,adc-clock-source = "ASYNC";
 	st,adc-prescaler = <4>;
 	status = "okay";
 };
@@ -137,7 +137,7 @@
 &adc4 {
 	pinctrl-0 = <&adc4_in18_pb0>;
 	pinctrl-names = "default";
-	st,adc-clock-source = <ASYNC>;
+	st,adc-clock-source = "ASYNC";
 	st,adc-prescaler = <4>;
 	status = "okay";
 };

--- a/boards/st/nucleo_u5a5zj_q/nucleo_u5a5zj_q-common.dtsi
+++ b/boards/st/nucleo_u5a5zj_q/nucleo_u5a5zj_q-common.dtsi
@@ -128,7 +128,7 @@
 &adc1 {
 	pinctrl-0 = <&adc1_in1_pc0>;
 	pinctrl-names = "default";
-	st,adc-clock-source = <ASYNC>;
+	st,adc-clock-source = "ASYNC";
 	st,adc-prescaler = <4>;
 	status = "okay";
 };
@@ -136,7 +136,7 @@
 &adc4 {
 	pinctrl-0 = <&adc4_in18_pb0>;
 	pinctrl-names = "default";
-	st,adc-clock-source = <ASYNC>;
+	st,adc-clock-source = "ASYNC";
 	st,adc-prescaler = <4>;
 	status = "okay";
 };

--- a/boards/st/nucleo_wb55rg/nucleo_wb55rg.dts
+++ b/boards/st/nucleo_wb55rg/nucleo_wb55rg.dts
@@ -181,7 +181,7 @@
 &adc1 {
 	pinctrl-0 = <&adc1_in3_pc2 &adc1_in5_pa0>;
 	pinctrl-names = "default";
-	st,adc-clock-source = <SYNC>;
+	st,adc-clock-source = "SYNC";
 	st,adc-prescaler = <4>;
 	status = "okay";
 };

--- a/boards/st/nucleo_wba52cg/nucleo_wba52cg.dts
+++ b/boards/st/nucleo_wba52cg/nucleo_wba52cg.dts
@@ -125,7 +125,7 @@
 &adc4 {
 	pinctrl-0 = <&adc4_in8_pa1>;
 	pinctrl-names = "default";
-	st,adc-clock-source = <ASYNC>;
+	st,adc-clock-source = "ASYNC";
 	st,adc-prescaler = <4>;
 	status = "okay";
 };

--- a/boards/st/nucleo_wba55cg/nucleo_wba55cg.dts
+++ b/boards/st/nucleo_wba55cg/nucleo_wba55cg.dts
@@ -147,7 +147,7 @@
 &adc4 {
 	pinctrl-0 = <&adc4_in8_pa1 &adc4_in9_pa0>;
 	pinctrl-names = "default";
-	st,adc-clock-source = <ASYNC>;
+	st,adc-clock-source = "ASYNC";
 	st,adc-prescaler = <4>;
 	status = "okay";
 };

--- a/boards/st/nucleo_wl55jc/nucleo_wl55jc.dts
+++ b/boards/st/nucleo_wl55jc/nucleo_wl55jc.dts
@@ -149,7 +149,7 @@ stm32_lp_tick_source: &lptim1 {
 &adc1 {
 	pinctrl-0 = <&adc_in5_pb1 &adc_in0_pb13>;
 	pinctrl-names = "default";
-	st,adc-clock-source = <SYNC>;
+	st,adc-clock-source = "SYNC";
 	st,adc-prescaler = <4>;
 	status = "okay";
 };

--- a/boards/st/sensortile_box_pro/sensortile_box_pro.dts
+++ b/boards/st/sensortile_box_pro/sensortile_box_pro.dts
@@ -278,7 +278,7 @@ zephyr_udc0: &usbotg_fs {
 &adc1 {
 	pinctrl-0 = <&adc1_in15_pb0>;
 	pinctrl-names = "default";
-	st,adc-clock-source = <ASYNC>;
+	st,adc-clock-source = "ASYNC";
 	st,adc-prescaler = <4>;
 	status = "okay";
 };
@@ -286,7 +286,7 @@ zephyr_udc0: &usbotg_fs {
 &adc4 {
 	pinctrl-0 = <&adc4_in19_pb1>;
 	pinctrl-names = "default";
-	st,adc-clock-source = <ASYNC>;
+	st,adc-clock-source = "ASYNC";
 	st,adc-prescaler = <4>;
 	status = "okay";
 };

--- a/boards/st/steval_stwinbx1/steval_stwinbx1.dts
+++ b/boards/st/steval_stwinbx1/steval_stwinbx1.dts
@@ -259,7 +259,7 @@ zephyr_udc0: &usbotg_fs {
 &adc1 {
 	pinctrl-0 = <&adc1_in1_pc0>;
 	pinctrl-names = "default";
-	st,adc-clock-source = <ASYNC>;
+	st,adc-clock-source = "ASYNC";
 	st,adc-prescaler = <4>;
 	vref-mv = <2750>;
 	status = "okay";
@@ -268,7 +268,7 @@ zephyr_udc0: &usbotg_fs {
 &adc4 {
 	pinctrl-0 = <&adc4_in3_pc2>;
 	pinctrl-names = "default";
-	st,adc-clock-source = <ASYNC>;
+	st,adc-clock-source = "ASYNC";
 	st,adc-prescaler = <4>;
 	vref-mv = <2750>;
 	status = "okay";

--- a/boards/st/stm32c0116_dk/stm32c0116_dk.dts
+++ b/boards/st/stm32c0116_dk/stm32c0116_dk.dts
@@ -141,7 +141,7 @@
 &adc1 {
 	pinctrl-0 = <&adc1_in8_pa8>;
 	pinctrl-names = "default";
-	st,adc-clock-source = <SYNC>;
+	st,adc-clock-source = "SYNC";
 	st,adc-prescaler = <2>;
 	status = "okay";
 

--- a/boards/st/stm32f3_disco/stm32f3_disco.dts
+++ b/boards/st/stm32f3_disco/stm32f3_disco.dts
@@ -219,7 +219,7 @@ zephyr_udc0: &usb {
 &adc1 {
 	pinctrl-0 = <&adc1_in1_pa0>;
 	pinctrl-names = "default";
-	st,adc-clock-source = <SYNC>;
+	st,adc-clock-source = "SYNC";
 	st,adc-prescaler = <2>;
 	status = "okay";
 };

--- a/boards/st/stm32g081b_eval/stm32g081b_eval.dts
+++ b/boards/st/stm32g081b_eval/stm32g081b_eval.dts
@@ -131,7 +131,7 @@
 &adc1 {
 	pinctrl-0 = <&adc1_in3_pa3 &adc1_in9_pb1>;
 	pinctrl-names = "default";
-	st,adc-clock-source = <SYNC>;
+	st,adc-clock-source = "SYNC";
 	st,adc-prescaler = <4>;
 	status = "okay";
 

--- a/boards/st/stm32h573i_dk/stm32h573i_dk.dts
+++ b/boards/st/stm32h573i_dk/stm32h573i_dk.dts
@@ -241,7 +241,7 @@
 		 <&rcc STM32_SRC_HCLK ADCDAC_SEL(0)>;
 	pinctrl-0 = <&adc1_inp6_pf12>; /* Arduino A5 */
 	pinctrl-names = "default";
-	st,adc-clock-source = <ASYNC>;
+	st,adc-clock-source = "ASYNC";
 	st,adc-prescaler = <6>;
 	status = "okay";
 };

--- a/boards/st/stm32h735g_disco/stm32h735g_disco.dts
+++ b/boards/st/stm32h735g_disco/stm32h735g_disco.dts
@@ -124,7 +124,7 @@
 &adc1 {
 	pinctrl-0 = <&adc1_inp0_pa0_c>;
 	pinctrl-names = "default";
-	st,adc-clock-source = <SYNC>;
+	st,adc-clock-source = "SYNC";
 	st,adc-prescaler = <4>;
 	status = "okay";
 };

--- a/boards/st/stm32h750b_dk/stm32h750b_dk.dts
+++ b/boards/st/stm32h750b_dk/stm32h750b_dk.dts
@@ -239,7 +239,7 @@
 };
 
 &adc3 {
-	st,adc-clock-source = <SYNC>;
+	st,adc-clock-source = "SYNC";
 	st,adc-prescaler = <4>;
 	status = "okay";
 };

--- a/boards/st/stm32h7s78_dk/stm32h7s78_dk.dts
+++ b/boards/st/stm32h7s78_dk/stm32h7s78_dk.dts
@@ -148,7 +148,7 @@
 &adc1 {
 	pinctrl-0 = <&adc1_inp6_pf12>; /* Arduino A3 */
 	pinctrl-names = "default";
-	st,adc-clock-source = <SYNC>;
+	st,adc-clock-source = "SYNC";
 	st,adc-prescaler = <4>;
 	status = "okay";
 };
@@ -156,7 +156,7 @@
 &adc2 {
 	pinctrl-0 = <&adc2_inp2_pf13>; /* Arduino A4 */
 	pinctrl-names = "default";
-	st,adc-clock-source = <SYNC>;
+	st,adc-clock-source = "SYNC";
 	st,adc-prescaler = <4>;
 	status = "okay";
 };

--- a/boards/st/stm32l496g_disco/stm32l496g_disco.dts
+++ b/boards/st/stm32l496g_disco/stm32l496g_disco.dts
@@ -164,7 +164,7 @@
 &adc1 {
 	pinctrl-0 = < &adc1_in2_pc1>;
 	pinctrl-names = "default";
-	st,adc-clock-source = <SYNC>;
+	st,adc-clock-source = "SYNC";
 	st,adc-prescaler = <4>;
 	status = "okay";
 };

--- a/boards/st/stm32l4r9i_disco/stm32l4r9i_disco.dts
+++ b/boards/st/stm32l4r9i_disco/stm32l4r9i_disco.dts
@@ -190,7 +190,7 @@
 	pinctrl-0 = <&adc1_in5_pa0 &adc1_in12_pa7 &adc1_in15_pb0
 			&adc1_in4_pc3 &adc1_in13_pc4>;
 	pinctrl-names = "default";
-	st,adc-clock-source = <SYNC>;
+	st,adc-clock-source = "SYNC";
 	st,adc-prescaler = <1>;
 };
 

--- a/boards/st/stm32l562e_dk/stm32l562e_dk_common.dtsi
+++ b/boards/st/stm32l562e_dk/stm32l562e_dk_common.dtsi
@@ -277,7 +277,7 @@ stm32_lp_tick_source: &lptim1 {
 &adc1 {
 	pinctrl-0 = <&adc1_in13_pc4>;
 	pinctrl-names = "default";
-	st,adc-clock-source = <SYNC>;
+	st,adc-clock-source = "SYNC";
 	st,adc-prescaler = <4>;
 	status = "okay";
 };

--- a/boards/st/stm32u083c_dk/stm32u083c_dk.dts
+++ b/boards/st/stm32u083c_dk/stm32u083c_dk.dts
@@ -75,7 +75,7 @@
 &adc1 {
 	pinctrl-0 = <&adc1_in0_pc0 &adc1_in1_pc1>;
 	pinctrl-names = "default";
-	st,adc-clock-source = <ASYNC>;
+	st,adc-clock-source = "ASYNC";
 	clocks = <&rcc STM32_CLOCK_BUS_APB1_2 0x00100000>,
 		 <&rcc STM32_SRC_HSI ADC_SEL(2)>;
 	st,adc-prescaler = <4>;

--- a/boards/st/stm32u5a9j_dk/stm32u5a9j_dk.dts
+++ b/boards/st/stm32u5a9j_dk/stm32u5a9j_dk.dts
@@ -204,7 +204,7 @@ uart0: &usart3 {
 &adc1 {
 	pinctrl-0 = <&adc1_in5_pa0 &adc1_in14_pc5>;
 	pinctrl-names = "default";
-	st,adc-clock-source = <ASYNC>;
+	st,adc-clock-source = "ASYNC";
 	st,adc-prescaler = <1>;
 	status = "okay";
 
@@ -231,7 +231,7 @@ uart0: &usart3 {
 &adc4 {
 	pinctrl-0 = <&adc4_in5_pf14>;
 	pinctrl-names = "default";
-	st,adc-clock-source = <ASYNC>;
+	st,adc-clock-source = "ASYNC";
 	st,adc-prescaler = <1>;
 	status = "okay";
 

--- a/boards/st/stm32wb5mm_dk/stm32wb5mm_dk.dts
+++ b/boards/st/stm32wb5mm_dk/stm32wb5mm_dk.dts
@@ -111,7 +111,7 @@
 &adc1 {
 	pinctrl-0 = <&adc1_in3_pc2>;
 	pinctrl-names = "default";
-	st,adc-clock-source = <SYNC>;
+	st,adc-clock-source = "SYNC";
 	st,adc-prescaler = <4>;
 	status = "okay";
 };

--- a/boards/st/stm32wb5mmg/stm32wb5mmg.dts
+++ b/boards/st/stm32wb5mmg/stm32wb5mmg.dts
@@ -69,7 +69,7 @@
 &adc1 {
 	pinctrl-0 = <&adc1_in3_pc2>;
 	pinctrl-names = "default";
-	st,adc-clock-source = <SYNC>;
+	st,adc-clock-source = "SYNC";
 	st,adc-prescaler = <4>;
 	status = "okay";
 };

--- a/boards/weact/blackpill_f401cc/blackpill_f401cc.dts
+++ b/boards/weact/blackpill_f401cc/blackpill_f401cc.dts
@@ -125,7 +125,7 @@ zephyr_udc0: &usbotg_fs {
 &adc1 {
 	pinctrl-0 = <&adc1_in1_pa1>;
 	pinctrl-names = "default";
-	st,adc-clock-source = <SYNC>;
+	st,adc-clock-source = "SYNC";
 	st,adc-prescaler = <2>;
 	status = "okay";
 };

--- a/boards/weact/blackpill_f401ce/blackpill_f401ce.dts
+++ b/boards/weact/blackpill_f401ce/blackpill_f401ce.dts
@@ -125,7 +125,7 @@ zephyr_udc0: &usbotg_fs {
 &adc1 {
 	pinctrl-0 = <&adc1_in1_pa1>;
 	pinctrl-names = "default";
-	st,adc-clock-source = <SYNC>;
+	st,adc-clock-source = "SYNC";
 	st,adc-prescaler = <2>;
 	status = "okay";
 };

--- a/boards/weact/blackpill_f411ce/blackpill_f411ce.dts
+++ b/boards/weact/blackpill_f411ce/blackpill_f411ce.dts
@@ -126,7 +126,7 @@ zephyr_udc0: &usbotg_fs {
 &adc1 {
 	pinctrl-0 = <&adc1_in1_pa1>;
 	pinctrl-names = "default";
-	st,adc-clock-source = <SYNC>;
+	st,adc-clock-source = "SYNC";
 	st,adc-prescaler = <2>;
 	status = "okay";
 };

--- a/boards/weact/stm32g431_core/weact_stm32g431_core.dts
+++ b/boards/weact/stm32g431_core/weact_stm32g431_core.dts
@@ -154,7 +154,7 @@ stm32_lp_tick_source: &lptim1 {
 &adc2 {
 	pinctrl-0 = <&adc2_in12_pb2>;
 	pinctrl-names = "default";
-	st,adc-clock-source = <SYNC>;
+	st,adc-clock-source = "SYNC";
 	st,adc-prescaler = <4>;
 
 	#address-cells = <1>;

--- a/boards/witte/linum/linum.dts
+++ b/boards/witte/linum/linum.dts
@@ -203,7 +203,7 @@ zephyr_udc0: &usbotg_fs {
 &adc1 {
 	pinctrl-0 = <&adc1_inp15_pa3>;
 	pinctrl-names = "default";
-	st,adc-clock-source = <SYNC>;
+	st,adc-clock-source = "SYNC";
 	st,adc-prescaler = <4>;
 	status = "okay";
 };

--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -211,7 +211,7 @@ static int adc_stm32_dma_start(const struct device *dev,
 			       void *buffer, size_t channel_count)
 {
 	const struct adc_stm32_cfg *config = dev->config;
-	ADC_TypeDef *adc = (ADC_TypeDef *)config->base;
+	ADC_TypeDef *adc = config->base;
 	struct adc_stm32_data *data = dev->data;
 	struct dma_block_config *blk_cfg;
 	int ret;
@@ -368,7 +368,7 @@ static int adc_stm32_enable(ADC_TypeDef *adc)
 static void adc_stm32_start_conversion(const struct device *dev)
 {
 	const struct adc_stm32_cfg *config = dev->config;
-	ADC_TypeDef *adc = (ADC_TypeDef *)config->base;
+	ADC_TypeDef *adc = config->base;
 
 	LOG_DBG("Starting conversion");
 
@@ -685,7 +685,7 @@ static void adc_stm32_oversampling_ratioshift(ADC_TypeDef *adc, uint32_t ratio, 
 static int adc_stm32_oversampling(const struct device *dev, uint8_t ratio)
 {
 	const struct adc_stm32_cfg *config = dev->config;
-	ADC_TypeDef *adc = (ADC_TypeDef *)config->base;
+	ADC_TypeDef *adc = config->base;
 
 	if (ratio == 0) {
 		adc_stm32_oversampling_scope(adc, LL_ADC_OVS_DISABLE);
@@ -725,7 +725,7 @@ static void dma_callback(const struct device *dev, void *user_data,
 	struct adc_stm32_data *data = user_data;
 #if !DT_HAS_COMPAT_STATUS_OKAY(st_stm32f1_adc) /* Avoid unused variables */
 	const struct adc_stm32_cfg *config = data->dev->config;
-	ADC_TypeDef *adc = (ADC_TypeDef *)config->base;
+	ADC_TypeDef *adc = config->base;
 #endif /* !DT_HAS_COMPAT_STATUS_OKAY(st_stm32f1_adc) */
 
 	LOG_DBG("dma callback");
@@ -774,7 +774,7 @@ static uint8_t get_reg_value(const struct device *dev, uint32_t reg,
 			     uint32_t shift, uint32_t mask)
 {
 	const struct adc_stm32_cfg *config = dev->config;
-	ADC_TypeDef *adc = (ADC_TypeDef *)config->base;
+	ADC_TypeDef *adc = config->base;
 
 	uintptr_t addr = (uintptr_t)adc + reg;
 
@@ -785,7 +785,7 @@ static void set_reg_value(const struct device *dev, uint32_t reg,
 			  uint32_t shift, uint32_t mask, uint32_t value)
 {
 	const struct adc_stm32_cfg *config = dev->config;
-	ADC_TypeDef *adc = (ADC_TypeDef *)config->base;
+	ADC_TypeDef *adc = config->base;
 
 	uintptr_t addr = (uintptr_t)adc + reg;
 
@@ -796,7 +796,7 @@ static int set_resolution(const struct device *dev,
 			  const struct adc_sequence *sequence)
 {
 	const struct adc_stm32_cfg *config = dev->config;
-	ADC_TypeDef *adc = (ADC_TypeDef *)config->base;
+	ADC_TypeDef *adc = config->base;
 	uint8_t res_reg_addr = 0xFF;
 	uint8_t res_shift = 0;
 	uint8_t res_mask = 0;
@@ -848,7 +848,7 @@ static int set_sequencer(const struct device *dev)
 {
 	const struct adc_stm32_cfg *config = dev->config;
 	struct adc_stm32_data *data = dev->data;
-	ADC_TypeDef *adc = (ADC_TypeDef *)config->base;
+	ADC_TypeDef *adc = config->base;
 
 	uint8_t channel_id;
 	uint8_t channel_index = 0;
@@ -913,7 +913,7 @@ static int start_read(const struct device *dev,
 {
 	const struct adc_stm32_cfg *config = dev->config;
 	struct adc_stm32_data *data = dev->data;
-	ADC_TypeDef *adc = (ADC_TypeDef *)config->base;
+	ADC_TypeDef *adc = config->base;
 	int err;
 
 	data->buffer = sequence->buffer;
@@ -1021,7 +1021,7 @@ static void adc_context_start_sampling(struct adc_context *ctx)
 		CONTAINER_OF(ctx, struct adc_stm32_data, ctx);
 	const struct device *dev = data->dev;
 	const struct adc_stm32_cfg *config = dev->config;
-	ADC_TypeDef *adc = (ADC_TypeDef *)config->base;
+	ADC_TypeDef *adc = config->base;
 
 	/* Remove warning for some series */
 	ARG_UNUSED(adc);
@@ -1095,7 +1095,7 @@ static void adc_context_on_complete(struct adc_context *ctx, int status)
 	struct adc_stm32_data *data =
 		CONTAINER_OF(ctx, struct adc_stm32_data, ctx);
 	const struct adc_stm32_cfg *config = data->dev->config;
-	ADC_TypeDef *adc = (ADC_TypeDef *)config->base;
+	ADC_TypeDef *adc = config->base;
 
 	ARG_UNUSED(status);
 
@@ -1432,7 +1432,7 @@ static int adc_stm32_set_clock(const struct device *dev)
 {
 	const struct adc_stm32_cfg *config = dev->config;
 	const struct device *const clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
-	ADC_TypeDef *adc = (ADC_TypeDef *)config->base;
+	ADC_TypeDef *adc = config->base;
 	int ret = 0;
 
 	ARG_UNUSED(adc); /* Necessary to avoid warnings on some series */
@@ -1479,7 +1479,7 @@ static int adc_stm32_init(const struct device *dev)
 	struct adc_stm32_data *data = dev->data;
 	const struct adc_stm32_cfg *config = dev->config;
 	const struct device *const clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
-	ADC_TypeDef *adc = (ADC_TypeDef *)config->base;
+	ADC_TypeDef *adc = config->base;
 	int err;
 
 	ARG_UNUSED(adc); /* Necessary to avoid warnings on some series */
@@ -1595,7 +1595,7 @@ static int adc_stm32_init(const struct device *dev)
 static int adc_stm32_suspend_setup(const struct device *dev)
 {
 	const struct adc_stm32_cfg *config = dev->config;
-	ADC_TypeDef *adc = (ADC_TypeDef *)config->base;
+	ADC_TypeDef *adc = config->base;
 	const struct device *const clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 	int err;
 

--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -93,9 +93,9 @@ LOG_MODULE_REGISTER(adc_stm32);
 					   0, value) 0)
 
 #define ANY_ADC_SEQUENCER_TYPE_IS(value) \
-	(DT_INST_FOREACH_STATUS_OKAY_VARGS(IS_EQ_PROP_OR, \
+	(DT_INST_FOREACH_STATUS_OKAY_VARGS(IS_EQ_STRING_PROP, \
 					   st_adc_sequencer,\
-					   0, value) 0)
+					   value) 0)
 
 #define ANY_ADC_OVERSAMPLER_TYPE_IS(value) \
 	(DT_INST_FOREACH_STATUS_OKAY_VARGS(IS_EQ_STRING_PROP, \
@@ -1735,7 +1735,7 @@ static DEVICE_API(adc, api_stm32_driver_api) = {
 #endif
 
 /* st_prescaler property requires 2 elements : clock ASYNC/SYNC and DIV */
-#define ADC_STM32_CLOCK(x)	DT_INST_PROP(x, st_adc_clock_source)
+#define ADC_STM32_CLOCK(x)	DT_INST_STRING_UPPER_TOKEN(x, st_adc_clock_source)
 #define ADC_STM32_DIV(x)	DT_INST_PROP(x, st_adc_prescaler)
 
 /* Macro to set the prefix depending on the 1st element: check if it is SYNC or ASYNC */
@@ -1914,7 +1914,7 @@ static const struct adc_stm32_cfg adc_stm32_cfg_##index = {		\
 	.pclk_len = DT_INST_NUM_CLOCKS(index),				\
 	.clk_prescaler = ADC_STM32_DT_PRESC(index),			\
 	.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(index),			\
-	.sequencer_type = DT_INST_PROP(index, st_adc_sequencer),	\
+	.sequencer_type = DT_INST_STRING_UPPER_TOKEN(index, st_adc_sequencer),	\
 	.oversampler_type = DT_INST_STRING_UPPER_TOKEN(index, st_adc_oversampler),	\
 	.sampling_time_table = DT_INST_PROP(index, sampling_times),	\
 	.num_sampling_time_common_channels =				\

--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -120,78 +120,26 @@ LOG_MODULE_REGISTER(adc_stm32);
 #define STM32_ADC_VREF_MV DT_INST_PROP(0, vref_mv)
 
 #if ANY_ADC_SEQUENCER_TYPE_IS(FULLY_CONFIGURABLE)
-#define RANK(n)		LL_ADC_REG_RANK_##n
-static const uint32_t table_rank[] = {
-	RANK(1),
-	RANK(2),
-	RANK(3),
-	RANK(4),
-	RANK(5),
-	RANK(6),
-	RANK(7),
-	RANK(8),
-	RANK(9),
-	RANK(10),
-	RANK(11),
-	RANK(12),
-	RANK(13),
-	RANK(14),
-	RANK(15),
-	RANK(16),
-#if defined(LL_ADC_REG_RANK_17)
-	RANK(17),
-	RANK(18),
-	RANK(19),
-	RANK(20),
-	RANK(21),
-	RANK(22),
-	RANK(23),
-	RANK(24),
-	RANK(25),
-	RANK(26),
-	RANK(27),
-#if defined(LL_ADC_REG_RANK_28)
-	RANK(28),
-#endif /* LL_ADC_REG_RANK_28 */
-#endif /* LL_ADC_REG_RANK_17 */
-};
 
-#define SEQ_LEN(n)	LL_ADC_REG_SEQ_SCAN_ENABLE_##n##RANKS
+#if defined(LL_ADC_REG_RANK_28)
+#define MAX_RANK	28
+#elif defined(LL_ADC_REG_RANK_27)
+#define MAX_RANK	27
+#else
+#define MAX_RANK	16
+#endif
+
+#define RANK(i, _)	_CONCAT_1(LL_ADC_REG_RANK_, UTIL_INC(i))
+static const uint32_t table_rank[] = {
+	LISTIFY(MAX_RANK, RANK, (,))};
+
+#define SEQ_LEN(i, _)	_CONCAT_2(LL_ADC_REG_SEQ_SCAN_ENABLE_, UTIL_INC(UTIL_INC(i)), RANKS)
 /* Length of this array signifies the maximum sequence length */
 static const uint32_t table_seq_len[] = {
 	LL_ADC_REG_SEQ_SCAN_DISABLE,
-	SEQ_LEN(2),
-	SEQ_LEN(3),
-	SEQ_LEN(4),
-	SEQ_LEN(5),
-	SEQ_LEN(6),
-	SEQ_LEN(7),
-	SEQ_LEN(8),
-	SEQ_LEN(9),
-	SEQ_LEN(10),
-	SEQ_LEN(11),
-	SEQ_LEN(12),
-	SEQ_LEN(13),
-	SEQ_LEN(14),
-	SEQ_LEN(15),
-	SEQ_LEN(16),
-#if defined(LL_ADC_REG_SEQ_SCAN_ENABLE_17RANKS)
-	SEQ_LEN(17),
-	SEQ_LEN(18),
-	SEQ_LEN(19),
-	SEQ_LEN(20),
-	SEQ_LEN(21),
-	SEQ_LEN(22),
-	SEQ_LEN(23),
-	SEQ_LEN(24),
-	SEQ_LEN(25),
-	SEQ_LEN(26),
-	SEQ_LEN(27),
-#if defined(LL_ADC_REG_SEQ_SCAN_ENABLE_28RANKS)
-	SEQ_LEN(28),
-#endif /* LL_ADC_REG_SEQ_SCAN_ENABLE_28RANKS */
-#endif /* LL_ADC_REG_SEQ_SCAN_ENABLE_17RANKS */
+	LISTIFY(UTIL_DEC(MAX_RANK), SEQ_LEN, (,))
 };
+
 #endif /* ANY_ADC_SEQUENCER_TYPE_IS(FULLY_CONFIGURABLE) */
 
 /* Number of different sampling time values */
@@ -659,21 +607,16 @@ static int adc_stm32_calibrate(const struct device *dev)
 
 #define HAS_OVERSAMPLING
 
-#define OVS_SHIFT(n)		LL_ADC_OVS_SHIFT_RIGHT_##n
+#if defined(LL_ADC_OVS_SHIFT_RIGHT_10)
+#define MAX_OVS_SHIFT	10
+#else
+#define MAX_OVS_SHIFT	8
+#endif
+
+#define OVS_SHIFT(i, _)	_CONCAT_1(LL_ADC_OVS_SHIFT_RIGHT_, UTIL_INC(i))
 static const uint32_t table_oversampling_shift[] = {
 	LL_ADC_OVS_SHIFT_NONE,
-	OVS_SHIFT(1),
-	OVS_SHIFT(2),
-	OVS_SHIFT(3),
-	OVS_SHIFT(4),
-	OVS_SHIFT(5),
-	OVS_SHIFT(6),
-	OVS_SHIFT(7),
-	OVS_SHIFT(8),
-#if defined(LL_ADC_OVS_SHIFT_RIGHT_9)
-	OVS_SHIFT(9),
-	OVS_SHIFT(10),
-#endif
+	LISTIFY(MAX_OVS_SHIFT, OVS_SHIFT, (,))
 };
 
 #if ANY_ADC_OVERSAMPLER_TYPE_IS(OVERSAMPLER_MINIMAL)

--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -82,6 +82,14 @@ LOG_MODULE_REGISTER(adc_stm32);
  * compat st_stm32f4_adc -> STM32F2, F4, F7, L1
  */
 
+/* Clock source values */
+#define SYNC			1
+#define ASYNC			2
+
+/* Sequencer type */
+#define NOT_FULLY_CONFIGURABLE	0
+#define FULLY_CONFIGURABLE	1
+
 /* Oversampler type */
 #define OVERSAMPLER_NONE	0
 #define OVERSAMPLER_MINIMAL	1

--- a/dts/arm/st/c0/stm32c0.dtsi
+++ b/dts/arm/st/c0/stm32c0.dtsi
@@ -325,7 +325,7 @@
 				       STM32_ADC_RES(6, 0x03)>;
 			sampling-times = <2 4 8 13 20 40 80 161>;
 			num-sampling-time-common-channels = <2>;
-			st,adc-sequencer = <NOT_FULLY_CONFIGURABLE>;
+			st,adc-sequencer = "NOT_FULLY_CONFIGURABLE";
 			st,adc-oversampler = "OVERSAMPLER_MINIMAL";
 		};
 

--- a/dts/arm/st/c0/stm32c0.dtsi
+++ b/dts/arm/st/c0/stm32c0.dtsi
@@ -326,6 +326,7 @@
 			sampling-times = <2 4 8 13 20 40 80 161>;
 			num-sampling-time-common-channels = <2>;
 			st,adc-sequencer = <NOT_FULLY_CONFIGURABLE>;
+			st,adc-oversampler = "OVERSAMPLER_MINIMAL";
 		};
 
 		dma1: dma@40020000 {

--- a/dts/arm/st/f0/stm32f0.dtsi
+++ b/dts/arm/st/f0/stm32f0.dtsi
@@ -348,7 +348,7 @@
 				       STM32_ADC_RES(6, 0x03)>;
 			sampling-times = <2 8 14 29 42 56 72 240>;
 			num-sampling-time-common-channels = <1>;
-			st,adc-sequencer = <NOT_FULLY_CONFIGURABLE>;
+			st,adc-sequencer = "NOT_FULLY_CONFIGURABLE";
 			st,adc-oversampler = "OVERSAMPLER_NONE";
 		};
 

--- a/dts/arm/st/f0/stm32f0.dtsi
+++ b/dts/arm/st/f0/stm32f0.dtsi
@@ -349,6 +349,7 @@
 			sampling-times = <2 8 14 29 42 56 72 240>;
 			num-sampling-time-common-channels = <1>;
 			st,adc-sequencer = <NOT_FULLY_CONFIGURABLE>;
+			st,adc-oversampler = "OVERSAMPLER_NONE";
 		};
 
 		dma1: dma@40020000 {

--- a/dts/arm/st/f1/stm32f1.dtsi
+++ b/dts/arm/st/f1/stm32f1.dtsi
@@ -348,7 +348,7 @@
 			#io-channel-cells = <1>;
 			resolutions = <STM32F1_ADC_RES(12)>;
 			sampling-times = <2 8 14 29 42 56 72 240>;
-			st,adc-sequencer = <FULLY_CONFIGURABLE>;
+			st,adc-sequencer = "FULLY_CONFIGURABLE";
 			st,adc-oversampler = "OVERSAMPLER_NONE";
 		};
 

--- a/dts/arm/st/f1/stm32f1.dtsi
+++ b/dts/arm/st/f1/stm32f1.dtsi
@@ -349,6 +349,7 @@
 			resolutions = <STM32F1_ADC_RES(12)>;
 			sampling-times = <2 8 14 29 42 56 72 240>;
 			st,adc-sequencer = <FULLY_CONFIGURABLE>;
+			st,adc-oversampler = "OVERSAMPLER_NONE";
 		};
 
 		dma1: dma@40020000 {

--- a/dts/arm/st/f2/stm32f2.dtsi
+++ b/dts/arm/st/f2/stm32f2.dtsi
@@ -376,6 +376,7 @@
 			sampling-times = <3 15 28 58 84 112 144 480>;
 			st,adc-clock-source = <SYNC>;
 			st,adc-sequencer = <FULLY_CONFIGURABLE>;
+			st,adc-oversampler = "OVERSAMPLER_NONE";
 		};
 
 		dma1: dma@40026000 {

--- a/dts/arm/st/f2/stm32f2.dtsi
+++ b/dts/arm/st/f2/stm32f2.dtsi
@@ -374,8 +374,8 @@
 				       STM32_ADC_RES(8, 0x02)
 				       STM32_ADC_RES(6, 0x03)>;
 			sampling-times = <3 15 28 58 84 112 144 480>;
-			st,adc-clock-source = <SYNC>;
-			st,adc-sequencer = <FULLY_CONFIGURABLE>;
+			st,adc-clock-source = "SYNC";
+			st,adc-sequencer = "FULLY_CONFIGURABLE";
 			st,adc-oversampler = "OVERSAMPLER_NONE";
 		};
 

--- a/dts/arm/st/f3/stm32f302.dtsi
+++ b/dts/arm/st/f3/stm32f302.dtsi
@@ -115,6 +115,7 @@
 				       STM32_ADC_RES(6, 0x03)>;
 			sampling-times = <2 3 5 8 20 62 182 602>;
 			st,adc-sequencer = <FULLY_CONFIGURABLE>;
+			st,adc-oversampler = "OVERSAMPLER_NONE";
 		};
 	};
 

--- a/dts/arm/st/f3/stm32f302.dtsi
+++ b/dts/arm/st/f3/stm32f302.dtsi
@@ -114,7 +114,7 @@
 				       STM32_ADC_RES(8, 0x02)
 				       STM32_ADC_RES(6, 0x03)>;
 			sampling-times = <2 3 5 8 20 62 182 602>;
-			st,adc-sequencer = <FULLY_CONFIGURABLE>;
+			st,adc-sequencer = "FULLY_CONFIGURABLE";
 			st,adc-oversampler = "OVERSAMPLER_NONE";
 		};
 	};

--- a/dts/arm/st/f3/stm32f303.dtsi
+++ b/dts/arm/st/f3/stm32f303.dtsi
@@ -154,6 +154,7 @@
 				       STM32_ADC_RES(6, 0x03)>;
 			sampling-times = <2 3 5 8 20 62 182 602>;
 			st,adc-sequencer = <FULLY_CONFIGURABLE>;
+			st,adc-oversampler = "OVERSAMPLER_NONE";
 		};
 
 		adc2: adc@50000100 {
@@ -170,6 +171,7 @@
 				       STM32_ADC_RES(6, 0x03)>;
 			sampling-times = <2 3 5 8 20 62 182 602>;
 			st,adc-sequencer = <FULLY_CONFIGURABLE>;
+			st,adc-oversampler = "OVERSAMPLER_NONE";
 		};
 	};
 

--- a/dts/arm/st/f3/stm32f303.dtsi
+++ b/dts/arm/st/f3/stm32f303.dtsi
@@ -153,7 +153,7 @@
 				       STM32_ADC_RES(8, 0x02)
 				       STM32_ADC_RES(6, 0x03)>;
 			sampling-times = <2 3 5 8 20 62 182 602>;
-			st,adc-sequencer = <FULLY_CONFIGURABLE>;
+			st,adc-sequencer = "FULLY_CONFIGURABLE";
 			st,adc-oversampler = "OVERSAMPLER_NONE";
 		};
 
@@ -170,7 +170,7 @@
 				       STM32_ADC_RES(8, 0x02)
 				       STM32_ADC_RES(6, 0x03)>;
 			sampling-times = <2 3 5 8 20 62 182 602>;
-			st,adc-sequencer = <FULLY_CONFIGURABLE>;
+			st,adc-sequencer = "FULLY_CONFIGURABLE";
 			st,adc-oversampler = "OVERSAMPLER_NONE";
 		};
 	};

--- a/dts/arm/st/f3/stm32f334.dtsi
+++ b/dts/arm/st/f3/stm32f334.dtsi
@@ -40,7 +40,7 @@
 				       STM32_ADC_RES(8, 0x02)
 				       STM32_ADC_RES(6, 0x03)>;
 			sampling-times = <2 3 5 8 20 62 182 602>;
-			st,adc-sequencer = <FULLY_CONFIGURABLE>;
+			st,adc-sequencer = "FULLY_CONFIGURABLE";
 			st,adc-oversampler = "OVERSAMPLER_NONE";
 		};
 

--- a/dts/arm/st/f3/stm32f334.dtsi
+++ b/dts/arm/st/f3/stm32f334.dtsi
@@ -41,6 +41,7 @@
 				       STM32_ADC_RES(6, 0x03)>;
 			sampling-times = <2 3 5 8 20 62 182 602>;
 			st,adc-sequencer = <FULLY_CONFIGURABLE>;
+			st,adc-oversampler = "OVERSAMPLER_NONE";
 		};
 
 		rtc@40002800 {

--- a/dts/arm/st/f3/stm32f373.dtsi
+++ b/dts/arm/st/f3/stm32f373.dtsi
@@ -193,7 +193,7 @@
 			#io-channel-cells = <1>;
 			resolutions = <STM32F1_ADC_RES(12)>;
 			sampling-times = <2 8 14 29 42 56 72 240>;
-			st,adc-sequencer = <FULLY_CONFIGURABLE>;
+			st,adc-sequencer = "FULLY_CONFIGURABLE";
 			st,adc-oversampler = "OVERSAMPLER_NONE";
 		};
 

--- a/dts/arm/st/f3/stm32f373.dtsi
+++ b/dts/arm/st/f3/stm32f373.dtsi
@@ -194,6 +194,7 @@
 			resolutions = <STM32F1_ADC_RES(12)>;
 			sampling-times = <2 8 14 29 42 56 72 240>;
 			st,adc-sequencer = <FULLY_CONFIGURABLE>;
+			st,adc-oversampler = "OVERSAMPLER_NONE";
 		};
 
 		rtc@40002800 {

--- a/dts/arm/st/f4/stm32f4.dtsi
+++ b/dts/arm/st/f4/stm32f4.dtsi
@@ -553,6 +553,7 @@
 			sampling-times = <3 15 28 56 84 112 144 480>;
 			st,adc-clock-source = <SYNC>;
 			st,adc-sequencer = <FULLY_CONFIGURABLE>;
+			st,adc-oversampler = "OVERSAMPLER_NONE";
 		};
 
 		dma1: dma@40026000 {

--- a/dts/arm/st/f4/stm32f4.dtsi
+++ b/dts/arm/st/f4/stm32f4.dtsi
@@ -551,8 +551,8 @@
 				       STM32_ADC_RES(8, 0x02)
 				       STM32_ADC_RES(6, 0x03)>;
 			sampling-times = <3 15 28 56 84 112 144 480>;
-			st,adc-clock-source = <SYNC>;
-			st,adc-sequencer = <FULLY_CONFIGURABLE>;
+			st,adc-clock-source = "SYNC";
+			st,adc-sequencer = "FULLY_CONFIGURABLE";
 			st,adc-oversampler = "OVERSAMPLER_NONE";
 		};
 

--- a/dts/arm/st/f4/stm32f405.dtsi
+++ b/dts/arm/st/f4/stm32f405.dtsi
@@ -255,6 +255,7 @@
 			sampling-times = <3 15 28 56 84 112 144 480>;
 			st,adc-clock-source = <SYNC>;
 			st,adc-sequencer = <FULLY_CONFIGURABLE>;
+			st,adc-oversampler = "OVERSAMPLER_NONE";
 		};
 
 		adc3: adc@40012200 {
@@ -271,6 +272,7 @@
 			sampling-times = <3 15 28 56 84 112 144 480>;
 			st,adc-clock-source = <SYNC>;
 			st,adc-sequencer = <FULLY_CONFIGURABLE>;
+			st,adc-oversampler = "OVERSAMPLER_NONE";
 		};
 
 		dac1: dac@40007400 {

--- a/dts/arm/st/f4/stm32f405.dtsi
+++ b/dts/arm/st/f4/stm32f405.dtsi
@@ -253,8 +253,8 @@
 				       STM32_ADC_RES(8, 0x02)
 				       STM32_ADC_RES(6, 0x03)>;
 			sampling-times = <3 15 28 56 84 112 144 480>;
-			st,adc-clock-source = <SYNC>;
-			st,adc-sequencer = <FULLY_CONFIGURABLE>;
+			st,adc-clock-source = "SYNC";
+			st,adc-sequencer = "FULLY_CONFIGURABLE";
 			st,adc-oversampler = "OVERSAMPLER_NONE";
 		};
 
@@ -270,8 +270,8 @@
 				       STM32_ADC_RES(8, 0x02)
 				       STM32_ADC_RES(6, 0x03)>;
 			sampling-times = <3 15 28 56 84 112 144 480>;
-			st,adc-clock-source = <SYNC>;
-			st,adc-sequencer = <FULLY_CONFIGURABLE>;
+			st,adc-clock-source = "SYNC";
+			st,adc-sequencer = "FULLY_CONFIGURABLE";
 			st,adc-oversampler = "OVERSAMPLER_NONE";
 		};
 

--- a/dts/arm/st/f4/stm32f446.dtsi
+++ b/dts/arm/st/f4/stm32f446.dtsi
@@ -118,8 +118,8 @@
 				       STM32_ADC_RES(8, 0x02)
 				       STM32_ADC_RES(6, 0x03)>;
 			sampling-times = <3 15 28 56 84 112 144 480>;
-			st,adc-clock-source = <SYNC>;
-			st,adc-sequencer = <FULLY_CONFIGURABLE>;
+			st,adc-clock-source = "SYNC";
+			st,adc-sequencer = "FULLY_CONFIGURABLE";
 			st,adc-oversampler = "OVERSAMPLER_NONE";
 		};
 
@@ -135,8 +135,8 @@
 				       STM32_ADC_RES(8, 0x02)
 				       STM32_ADC_RES(6, 0x03)>;
 			sampling-times = <3 15 28 56 84 112 144 480>;
-			st,adc-clock-source = <SYNC>;
-			st,adc-sequencer = <FULLY_CONFIGURABLE>;
+			st,adc-clock-source = "SYNC";
+			st,adc-sequencer = "FULLY_CONFIGURABLE";
 			st,adc-oversampler = "OVERSAMPLER_NONE";
 		};
 

--- a/dts/arm/st/f4/stm32f446.dtsi
+++ b/dts/arm/st/f4/stm32f446.dtsi
@@ -120,6 +120,7 @@
 			sampling-times = <3 15 28 56 84 112 144 480>;
 			st,adc-clock-source = <SYNC>;
 			st,adc-sequencer = <FULLY_CONFIGURABLE>;
+			st,adc-oversampler = "OVERSAMPLER_NONE";
 		};
 
 		adc3: adc@40012200 {
@@ -136,6 +137,7 @@
 			sampling-times = <3 15 28 56 84 112 144 480>;
 			st,adc-clock-source = <SYNC>;
 			st,adc-sequencer = <FULLY_CONFIGURABLE>;
+			st,adc-oversampler = "OVERSAMPLER_NONE";
 		};
 
 		dac1: dac@40007400 {

--- a/dts/arm/st/f7/stm32f7.dtsi
+++ b/dts/arm/st/f7/stm32f7.dtsi
@@ -761,8 +761,8 @@
 				       STM32_ADC_RES(8, 0x02)
 				       STM32_ADC_RES(6, 0x03)>;
 			sampling-times = <3 15 28 56 84 112 144 480>;
-			st,adc-clock-source = <SYNC>;
-			st,adc-sequencer = <FULLY_CONFIGURABLE>;
+			st,adc-clock-source = "SYNC";
+			st,adc-sequencer = "FULLY_CONFIGURABLE";
 			st,adc-oversampler = "OVERSAMPLER_NONE";
 		};
 
@@ -778,8 +778,8 @@
 				       STM32_ADC_RES(8, 0x02)
 				       STM32_ADC_RES(6, 0x03)>;
 			sampling-times = <3 15 28 56 84 112 144 480>;
-			st,adc-clock-source = <SYNC>;
-			st,adc-sequencer = <FULLY_CONFIGURABLE>;
+			st,adc-clock-source = "SYNC";
+			st,adc-sequencer = "FULLY_CONFIGURABLE";
 			st,adc-oversampler = "OVERSAMPLER_NONE";
 		};
 
@@ -795,8 +795,8 @@
 				       STM32_ADC_RES(8, 0x02)
 				       STM32_ADC_RES(6, 0x03)>;
 			sampling-times = <3 15 28 56 84 112 144 480>;
-			st,adc-clock-source = <SYNC>;
-			st,adc-sequencer = <FULLY_CONFIGURABLE>;
+			st,adc-clock-source = "SYNC";
+			st,adc-sequencer = "FULLY_CONFIGURABLE";
 			st,adc-oversampler = "OVERSAMPLER_NONE";
 		};
 

--- a/dts/arm/st/f7/stm32f7.dtsi
+++ b/dts/arm/st/f7/stm32f7.dtsi
@@ -763,6 +763,7 @@
 			sampling-times = <3 15 28 56 84 112 144 480>;
 			st,adc-clock-source = <SYNC>;
 			st,adc-sequencer = <FULLY_CONFIGURABLE>;
+			st,adc-oversampler = "OVERSAMPLER_NONE";
 		};
 
 		adc2: adc@40012100 {
@@ -779,6 +780,7 @@
 			sampling-times = <3 15 28 56 84 112 144 480>;
 			st,adc-clock-source = <SYNC>;
 			st,adc-sequencer = <FULLY_CONFIGURABLE>;
+			st,adc-oversampler = "OVERSAMPLER_NONE";
 		};
 
 		adc3: adc@40012200 {
@@ -795,6 +797,7 @@
 			sampling-times = <3 15 28 56 84 112 144 480>;
 			st,adc-clock-source = <SYNC>;
 			st,adc-sequencer = <FULLY_CONFIGURABLE>;
+			st,adc-oversampler = "OVERSAMPLER_NONE";
 		};
 
 		dac1: dac@40007400 {

--- a/dts/arm/st/g0/stm32g0.dtsi
+++ b/dts/arm/st/g0/stm32g0.dtsi
@@ -422,7 +422,7 @@
 			 */
 			sampling-times = <3 5 8 13 20 40 80 161>;
 			num-sampling-time-common-channels = <2>;
-			st,adc-sequencer = <NOT_FULLY_CONFIGURABLE>;
+			st,adc-sequencer = "NOT_FULLY_CONFIGURABLE";
 			st,adc-oversampler = "OVERSAMPLER_MINIMAL";
 		};
 

--- a/dts/arm/st/g0/stm32g0.dtsi
+++ b/dts/arm/st/g0/stm32g0.dtsi
@@ -423,6 +423,7 @@
 			sampling-times = <3 5 8 13 20 40 80 161>;
 			num-sampling-time-common-channels = <2>;
 			st,adc-sequencer = <NOT_FULLY_CONFIGURABLE>;
+			st,adc-oversampler = "OVERSAMPLER_MINIMAL";
 		};
 
 		dma1: dma@40020000 {

--- a/dts/arm/st/g4/stm32g4.dtsi
+++ b/dts/arm/st/g4/stm32g4.dtsi
@@ -116,6 +116,7 @@
 				       STM32_ADC_RES(6, 0x03)>;
 			sampling-times = <3 7 13 25 48 93 248 641>;
 			st,adc-sequencer = <FULLY_CONFIGURABLE>;
+			st,adc-oversampler = "OVERSAMPLER_MINIMAL";
 		};
 
 		adc2: adc@50000100 {
@@ -131,6 +132,7 @@
 				       STM32_ADC_RES(6, 0x03)>;
 			sampling-times = <3 7 13 25 48 93 248 641>;
 			st,adc-sequencer = <FULLY_CONFIGURABLE>;
+			st,adc-oversampler = "OVERSAMPLER_MINIMAL";
 		};
 
 		dac1: dac@50000800 {

--- a/dts/arm/st/g4/stm32g4.dtsi
+++ b/dts/arm/st/g4/stm32g4.dtsi
@@ -115,7 +115,7 @@
 				       STM32_ADC_RES(8, 0x02)
 				       STM32_ADC_RES(6, 0x03)>;
 			sampling-times = <3 7 13 25 48 93 248 641>;
-			st,adc-sequencer = <FULLY_CONFIGURABLE>;
+			st,adc-sequencer = "FULLY_CONFIGURABLE";
 			st,adc-oversampler = "OVERSAMPLER_MINIMAL";
 		};
 
@@ -131,7 +131,7 @@
 				       STM32_ADC_RES(8, 0x02)
 				       STM32_ADC_RES(6, 0x03)>;
 			sampling-times = <3 7 13 25 48 93 248 641>;
-			st,adc-sequencer = <FULLY_CONFIGURABLE>;
+			st,adc-sequencer = "FULLY_CONFIGURABLE";
 			st,adc-oversampler = "OVERSAMPLER_MINIMAL";
 		};
 

--- a/dts/arm/st/g4/stm32g473.dtsi
+++ b/dts/arm/st/g4/stm32g473.dtsi
@@ -39,7 +39,7 @@
 				       STM32_ADC_RES(8, 0x02)
 				       STM32_ADC_RES(6, 0x03)>;
 			sampling-times = <3 7 13 25 48 93 248 641>;
-			st,adc-sequencer = <FULLY_CONFIGURABLE>;
+			st,adc-sequencer = "FULLY_CONFIGURABLE";
 			st,adc-oversampler = "OVERSAMPLER_MINIMAL";
 		};
 
@@ -55,7 +55,7 @@
 				       STM32_ADC_RES(8, 0x02)
 				       STM32_ADC_RES(6, 0x03)>;
 			sampling-times = <3 7 13 25 48 93 248 641>;
-			st,adc-sequencer = <FULLY_CONFIGURABLE>;
+			st,adc-sequencer = "FULLY_CONFIGURABLE";
 			st,adc-oversampler = "OVERSAMPLER_MINIMAL";
 		};
 

--- a/dts/arm/st/g4/stm32g473.dtsi
+++ b/dts/arm/st/g4/stm32g473.dtsi
@@ -40,6 +40,7 @@
 				       STM32_ADC_RES(6, 0x03)>;
 			sampling-times = <3 7 13 25 48 93 248 641>;
 			st,adc-sequencer = <FULLY_CONFIGURABLE>;
+			st,adc-oversampler = "OVERSAMPLER_MINIMAL";
 		};
 
 		adc5: adc@50000600 {
@@ -55,6 +56,7 @@
 				       STM32_ADC_RES(6, 0x03)>;
 			sampling-times = <3 7 13 25 48 93 248 641>;
 			st,adc-sequencer = <FULLY_CONFIGURABLE>;
+			st,adc-oversampler = "OVERSAMPLER_MINIMAL";
 		};
 
 		spi4: spi@40013c00 {

--- a/dts/arm/st/g4/stm32g491.dtsi
+++ b/dts/arm/st/g4/stm32g491.dtsi
@@ -66,6 +66,7 @@
 				       STM32_ADC_RES(6, 0x03)>;
 			sampling-times = <3 7 13 25 48 93 248 641>;
 			st,adc-sequencer = <FULLY_CONFIGURABLE>;
+			st,adc-oversampler = "OVERSAMPLER_MINIMAL";
 		};
 
 		uart5: serial@40005000 {

--- a/dts/arm/st/g4/stm32g491.dtsi
+++ b/dts/arm/st/g4/stm32g491.dtsi
@@ -65,7 +65,7 @@
 				       STM32_ADC_RES(8, 0x02)
 				       STM32_ADC_RES(6, 0x03)>;
 			sampling-times = <3 7 13 25 48 93 248 641>;
-			st,adc-sequencer = <FULLY_CONFIGURABLE>;
+			st,adc-sequencer = "FULLY_CONFIGURABLE";
 			st,adc-oversampler = "OVERSAMPLER_MINIMAL";
 		};
 

--- a/dts/arm/st/h5/stm32h5.dtsi
+++ b/dts/arm/st/h5/stm32h5.dtsi
@@ -319,7 +319,7 @@
 				       STM32_ADC_RES(8, 0x02)
 				       STM32_ADC_RES(6, 0x03)>;
 			sampling-times = <3 7 13 25 48 93 248 641>;
-			st,adc-sequencer = <FULLY_CONFIGURABLE>;
+			st,adc-sequencer = "FULLY_CONFIGURABLE";
 			st,adc-oversampler = "OVERSAMPLER_MINIMAL";
 		};
 

--- a/dts/arm/st/h5/stm32h5.dtsi
+++ b/dts/arm/st/h5/stm32h5.dtsi
@@ -320,6 +320,7 @@
 				       STM32_ADC_RES(6, 0x03)>;
 			sampling-times = <3 7 13 25 48 93 248 641>;
 			st,adc-sequencer = <FULLY_CONFIGURABLE>;
+			st,adc-oversampler = "OVERSAMPLER_MINIMAL";
 		};
 
 		rtc: rtc@44007800 {

--- a/dts/arm/st/h5/stm32h562.dtsi
+++ b/dts/arm/st/h5/stm32h562.dtsi
@@ -284,6 +284,7 @@
 					STM32_ADC_RES(6, 0x03)>;
 			sampling-times = <3 7 13 25 48 93 248 641>;
 			st,adc-sequencer = <FULLY_CONFIGURABLE>;
+			st,adc-oversampler = "OVERSAMPLER_MINIMAL";
 		};
 
 		timers4: timers@40000800 {

--- a/dts/arm/st/h5/stm32h562.dtsi
+++ b/dts/arm/st/h5/stm32h562.dtsi
@@ -283,7 +283,7 @@
 					STM32_ADC_RES(8, 0x02)
 					STM32_ADC_RES(6, 0x03)>;
 			sampling-times = <3 7 13 25 48 93 248 641>;
-			st,adc-sequencer = <FULLY_CONFIGURABLE>;
+			st,adc-sequencer = "FULLY_CONFIGURABLE";
 			st,adc-oversampler = "OVERSAMPLER_MINIMAL";
 		};
 

--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -863,6 +863,7 @@
 				       STM32_ADC_RES(8, 0x07)>;
 			sampling-times = <2 3 9 17 33 65 388 811>;
 			st,adc-sequencer = <FULLY_CONFIGURABLE>;
+			st,adc-oversampler = "OVERSAMPLER_EXTENDED";
 		};
 
 		adc2: adc@40022100 {
@@ -879,6 +880,7 @@
 				       STM32_ADC_RES(8, 0x07)>;
 			sampling-times = <2 3 9 17 33 65 388 811>;
 			st,adc-sequencer = <FULLY_CONFIGURABLE>;
+			st,adc-oversampler = "OVERSAMPLER_EXTENDED";
 		};
 
 		/* dual mode: adc1 and adc2 coupled */
@@ -896,6 +898,7 @@
 				       STM32_ADC_RES(8, 0x07)>;
 			sampling-times = <2 3 9 17 33 65 388 811>;
 			st,adc-sequencer = <FULLY_CONFIGURABLE>;
+			st,adc-oversampler = "OVERSAMPLER_EXTENDED";
 		};
 
 		adc3: adc@58026000 {
@@ -912,6 +915,7 @@
 				       STM32_ADC_RES(8, 0x07)>;
 			sampling-times = <2 3 9 17 33 65 388 811>;
 			st,adc-sequencer = <FULLY_CONFIGURABLE>;
+			st,adc-oversampler = "OVERSAMPLER_EXTENDED";
 		};
 
 		dac1: dac@40007400 {

--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -862,7 +862,7 @@
 				       STM32_ADC_RES(10, 0x03)
 				       STM32_ADC_RES(8, 0x07)>;
 			sampling-times = <2 3 9 17 33 65 388 811>;
-			st,adc-sequencer = <FULLY_CONFIGURABLE>;
+			st,adc-sequencer = "FULLY_CONFIGURABLE";
 			st,adc-oversampler = "OVERSAMPLER_EXTENDED";
 		};
 
@@ -879,7 +879,7 @@
 				       STM32_ADC_RES(10, 0x03)
 				       STM32_ADC_RES(8, 0x07)>;
 			sampling-times = <2 3 9 17 33 65 388 811>;
-			st,adc-sequencer = <FULLY_CONFIGURABLE>;
+			st,adc-sequencer = "FULLY_CONFIGURABLE";
 			st,adc-oversampler = "OVERSAMPLER_EXTENDED";
 		};
 
@@ -897,7 +897,7 @@
 				       STM32_ADC_RES(10, 0x03)
 				       STM32_ADC_RES(8, 0x07)>;
 			sampling-times = <2 3 9 17 33 65 388 811>;
-			st,adc-sequencer = <FULLY_CONFIGURABLE>;
+			st,adc-sequencer = "FULLY_CONFIGURABLE";
 			st,adc-oversampler = "OVERSAMPLER_EXTENDED";
 		};
 
@@ -914,7 +914,7 @@
 				       STM32_ADC_RES(10, 0x03)
 				       STM32_ADC_RES(8, 0x07)>;
 			sampling-times = <2 3 9 17 33 65 388 811>;
-			st,adc-sequencer = <FULLY_CONFIGURABLE>;
+			st,adc-sequencer = "FULLY_CONFIGURABLE";
 			st,adc-oversampler = "OVERSAMPLER_EXTENDED";
 		};
 

--- a/dts/arm/st/h7/stm32h723.dtsi
+++ b/dts/arm/st/h7/stm32h723.dtsi
@@ -53,6 +53,7 @@
 				       STM32H72X_ADC3_RES(6, 0x03)>;
 			sampling-times = <3 7 13 25 48 93 248 641>;
 			st,adc-sequencer = <FULLY_CONFIGURABLE>;
+			st,adc-oversampler = "OVERSAMPLER_MINIMAL";
 		};
 
 		dmamux1: dmamux@40020800 {

--- a/dts/arm/st/h7/stm32h723.dtsi
+++ b/dts/arm/st/h7/stm32h723.dtsi
@@ -52,7 +52,7 @@
 				       STM32H72X_ADC3_RES(8, 0x02)
 				       STM32H72X_ADC3_RES(6, 0x03)>;
 			sampling-times = <3 7 13 25 48 93 248 641>;
-			st,adc-sequencer = <FULLY_CONFIGURABLE>;
+			st,adc-sequencer = "FULLY_CONFIGURABLE";
 			st,adc-oversampler = "OVERSAMPLER_MINIMAL";
 		};
 

--- a/dts/arm/st/h7rs/stm32h7rs.dtsi
+++ b/dts/arm/st/h7rs/stm32h7rs.dtsi
@@ -749,7 +749,7 @@
 					STM32_ADC_RES(8, 0x2)
 					STM32_ADC_RES(6, 0x3)>;
 			sampling-times = <3 7 13 25 48 93 248 641>;
-			st,adc-sequencer = <FULLY_CONFIGURABLE>;
+			st,adc-sequencer = "FULLY_CONFIGURABLE";
 			st,adc-oversampler = "OVERSAMPLER_MINIMAL";
 		};
 
@@ -765,7 +765,7 @@
 					STM32_ADC_RES(8, 0x02)
 					STM32_ADC_RES(6, 0x03)>;
 			sampling-times = <3 7 13 25 48 93 248 641>;
-			st,adc-sequencer = <FULLY_CONFIGURABLE>;
+			st,adc-sequencer = "FULLY_CONFIGURABLE";
 			st,adc-oversampler = "OVERSAMPLER_MINIMAL";
 		};
 

--- a/dts/arm/st/h7rs/stm32h7rs.dtsi
+++ b/dts/arm/st/h7rs/stm32h7rs.dtsi
@@ -750,6 +750,7 @@
 					STM32_ADC_RES(6, 0x3)>;
 			sampling-times = <3 7 13 25 48 93 248 641>;
 			st,adc-sequencer = <FULLY_CONFIGURABLE>;
+			st,adc-oversampler = "OVERSAMPLER_MINIMAL";
 		};
 
 		adc2: adc@40022100 {
@@ -765,6 +766,7 @@
 					STM32_ADC_RES(6, 0x03)>;
 			sampling-times = <3 7 13 25 48 93 248 641>;
 			st,adc-sequencer = <FULLY_CONFIGURABLE>;
+			st,adc-oversampler = "OVERSAMPLER_MINIMAL";
 		};
 
 		rng: rng@48020000 {

--- a/dts/arm/st/l0/stm32l0.dtsi
+++ b/dts/arm/st/l0/stm32l0.dtsi
@@ -318,7 +318,7 @@
 				       STM32_ADC_RES(6, 0x03)>;
 			sampling-times = <2 4 8 13 20 40 80 161>;
 			num-sampling-time-common-channels = <1>;
-			st,adc-sequencer = <NOT_FULLY_CONFIGURABLE>;
+			st,adc-sequencer = "NOT_FULLY_CONFIGURABLE";
 			st,adc-oversampler = "OVERSAMPLER_MINIMAL";
 		};
 

--- a/dts/arm/st/l0/stm32l0.dtsi
+++ b/dts/arm/st/l0/stm32l0.dtsi
@@ -319,6 +319,7 @@
 			sampling-times = <2 4 8 13 20 40 80 161>;
 			num-sampling-time-common-channels = <1>;
 			st,adc-sequencer = <NOT_FULLY_CONFIGURABLE>;
+			st,adc-oversampler = "OVERSAMPLER_MINIMAL";
 		};
 
 		dma1: dma@40020000 {

--- a/dts/arm/st/l1/stm32l1.dtsi
+++ b/dts/arm/st/l1/stm32l1.dtsi
@@ -228,6 +228,7 @@
 			sampling-times = <4 9 16 24 48 96 192 384>;
 			st,adc-clock-source = <ASYNC>;
 			st,adc-sequencer = <FULLY_CONFIGURABLE>;
+			st,adc-oversampler = "OVERSAMPLER_NONE";
 		};
 
 		dac1: dac@40007400 {

--- a/dts/arm/st/l1/stm32l1.dtsi
+++ b/dts/arm/st/l1/stm32l1.dtsi
@@ -226,8 +226,8 @@
 				       STM32_ADC_RES(8, 0x02)
 				       STM32_ADC_RES(6, 0x03)>;
 			sampling-times = <4 9 16 24 48 96 192 384>;
-			st,adc-clock-source = <ASYNC>;
-			st,adc-sequencer = <FULLY_CONFIGURABLE>;
+			st,adc-clock-source = "ASYNC";
+			st,adc-sequencer = "FULLY_CONFIGURABLE";
 			st,adc-oversampler = "OVERSAMPLER_NONE";
 		};
 

--- a/dts/arm/st/l4/stm32l4.dtsi
+++ b/dts/arm/st/l4/stm32l4.dtsi
@@ -407,6 +407,7 @@
 				       STM32_ADC_RES(6, 0x03)>;
 			sampling-times = <3 7 13 25 48 93 248 641>;
 			st,adc-sequencer = <FULLY_CONFIGURABLE>;
+			st,adc-oversampler = "OVERSAMPLER_MINIMAL";
 		};
 
 		adc2: adc@50040100 {
@@ -422,6 +423,7 @@
 				       STM32_ADC_RES(6, 0x03)>;
 			sampling-times = <3 7 13 25 48 93 248 641>;
 			st,adc-sequencer = <FULLY_CONFIGURABLE>;
+			st,adc-oversampler = "OVERSAMPLER_MINIMAL";
 		};
 
 		dma1: dma@40020000 {

--- a/dts/arm/st/l4/stm32l4.dtsi
+++ b/dts/arm/st/l4/stm32l4.dtsi
@@ -406,7 +406,7 @@
 				       STM32_ADC_RES(8, 0x02)
 				       STM32_ADC_RES(6, 0x03)>;
 			sampling-times = <3 7 13 25 48 93 248 641>;
-			st,adc-sequencer = <FULLY_CONFIGURABLE>;
+			st,adc-sequencer = "FULLY_CONFIGURABLE";
 			st,adc-oversampler = "OVERSAMPLER_MINIMAL";
 		};
 
@@ -422,7 +422,7 @@
 				       STM32_ADC_RES(8, 0x02)
 				       STM32_ADC_RES(6, 0x03)>;
 			sampling-times = <3 7 13 25 48 93 248 641>;
-			st,adc-sequencer = <FULLY_CONFIGURABLE>;
+			st,adc-sequencer = "FULLY_CONFIGURABLE";
 			st,adc-oversampler = "OVERSAMPLER_MINIMAL";
 		};
 

--- a/dts/arm/st/l5/stm32l5.dtsi
+++ b/dts/arm/st/l5/stm32l5.dtsi
@@ -666,7 +666,7 @@
 				       STM32_ADC_RES(8, 0x02)
 				       STM32_ADC_RES(6, 0x03)>;
 			sampling-times = <3 7 13 25 48 93 248 641>;
-			st,adc-sequencer = <FULLY_CONFIGURABLE>;
+			st,adc-sequencer = "FULLY_CONFIGURABLE";
 			st,adc-oversampler = "OVERSAMPLER_MINIMAL";
 		};
 
@@ -682,7 +682,7 @@
 				       STM32_ADC_RES(8, 0x02)
 				       STM32_ADC_RES(6, 0x03)>;
 			sampling-times = <3 7 13 25 48 93 248 641>;
-			st,adc-sequencer = <FULLY_CONFIGURABLE>;
+			st,adc-sequencer = "FULLY_CONFIGURABLE";
 			st,adc-oversampler = "OVERSAMPLER_MINIMAL";
 		};
 

--- a/dts/arm/st/l5/stm32l5.dtsi
+++ b/dts/arm/st/l5/stm32l5.dtsi
@@ -667,6 +667,7 @@
 				       STM32_ADC_RES(6, 0x03)>;
 			sampling-times = <3 7 13 25 48 93 248 641>;
 			st,adc-sequencer = <FULLY_CONFIGURABLE>;
+			st,adc-oversampler = "OVERSAMPLER_MINIMAL";
 		};
 
 		adc2: adc@42028100 {
@@ -682,6 +683,7 @@
 				       STM32_ADC_RES(6, 0x03)>;
 			sampling-times = <3 7 13 25 48 93 248 641>;
 			st,adc-sequencer = <FULLY_CONFIGURABLE>;
+			st,adc-oversampler = "OVERSAMPLER_MINIMAL";
 		};
 
 		usb: usb@4000d400 {

--- a/dts/arm/st/u0/stm32u0.dtsi
+++ b/dts/arm/st/u0/stm32u0.dtsi
@@ -227,6 +227,7 @@
 			sampling-times = <2 4 8 13 20 40 80 161>;
 			num-sampling-time-common-channels = <2>;
 			st,adc-sequencer = <NOT_FULLY_CONFIGURABLE>;
+			st,adc-oversampler = "OVERSAMPLER_MINIMAL";
 		};
 
 		dac1: dac@40007400 {

--- a/dts/arm/st/u0/stm32u0.dtsi
+++ b/dts/arm/st/u0/stm32u0.dtsi
@@ -226,7 +226,7 @@
 				       STM32_ADC_RES(6, 0x03)>;
 			sampling-times = <2 4 8 13 20 40 80 161>;
 			num-sampling-time-common-channels = <2>;
-			st,adc-sequencer = <NOT_FULLY_CONFIGURABLE>;
+			st,adc-sequencer = "NOT_FULLY_CONFIGURABLE";
 			st,adc-oversampler = "OVERSAMPLER_MINIMAL";
 		};
 

--- a/dts/arm/st/u5/stm32u5.dtsi
+++ b/dts/arm/st/u5/stm32u5.dtsi
@@ -793,6 +793,7 @@
 			sampling-times = <5 6 12 20 36 68 391 814>;
 			st,adc-clock-source = <ASYNC>;
 			st,adc-sequencer = <FULLY_CONFIGURABLE>;
+			st,adc-oversampler = "OVERSAMPLER_EXTENDED";
 		};
 
 		adc4: adc@46021000 {
@@ -811,6 +812,7 @@
 			num-sampling-time-common-channels = <2>;
 			st,adc-clock-source = <ASYNC>;
 			st,adc-sequencer = <NOT_FULLY_CONFIGURABLE>;
+			st,adc-oversampler = "OVERSAMPLER_MINIMAL";
 		};
 
 		fdcan1: can@4000a400 {

--- a/dts/arm/st/u5/stm32u5.dtsi
+++ b/dts/arm/st/u5/stm32u5.dtsi
@@ -791,8 +791,8 @@
 				       STM32_ADC_RES(10, 0x02)
 				       STM32_ADC_RES(8, 0x03)>;
 			sampling-times = <5 6 12 20 36 68 391 814>;
-			st,adc-clock-source = <ASYNC>;
-			st,adc-sequencer = <FULLY_CONFIGURABLE>;
+			st,adc-clock-source = "ASYNC";
+			st,adc-sequencer = "FULLY_CONFIGURABLE";
 			st,adc-oversampler = "OVERSAMPLER_EXTENDED";
 		};
 
@@ -810,8 +810,8 @@
 				       STM32_ADC_RES(6, 0x03)>;
 			sampling-times = <2 4 8 13 20 40 80 815>;
 			num-sampling-time-common-channels = <2>;
-			st,adc-clock-source = <ASYNC>;
-			st,adc-sequencer = <NOT_FULLY_CONFIGURABLE>;
+			st,adc-clock-source = "ASYNC";
+			st,adc-sequencer = "NOT_FULLY_CONFIGURABLE";
 			st,adc-oversampler = "OVERSAMPLER_MINIMAL";
 		};
 

--- a/dts/arm/st/u5/stm32u595.dtsi
+++ b/dts/arm/st/u5/stm32u595.dtsi
@@ -76,6 +76,7 @@
 			sampling-times = <5 6 12 20 36 68 391 814>;
 			st,adc-clock-source = <ASYNC>;
 			st,adc-sequencer = <FULLY_CONFIGURABLE>;
+			st,adc-oversampler = "OVERSAMPLER_EXTENDED";
 		};
 
 		/*
@@ -96,6 +97,7 @@
 			sampling-times = <5 6 12 20 36 68 391 814>;
 			st,adc-clock-source = <ASYNC>;
 			st,adc-sequencer = <FULLY_CONFIGURABLE>;
+			st,adc-oversampler = "OVERSAMPLER_EXTENDED";
 		};
 
 		usbotg_hs: otghs@42040000 {

--- a/dts/arm/st/u5/stm32u595.dtsi
+++ b/dts/arm/st/u5/stm32u595.dtsi
@@ -74,8 +74,8 @@
 				       STM32_ADC_RES(10, 0x02)
 				       STM32_ADC_RES(8, 0x03)>;
 			sampling-times = <5 6 12 20 36 68 391 814>;
-			st,adc-clock-source = <ASYNC>;
-			st,adc-sequencer = <FULLY_CONFIGURABLE>;
+			st,adc-clock-source = "ASYNC";
+			st,adc-sequencer = "FULLY_CONFIGURABLE";
 			st,adc-oversampler = "OVERSAMPLER_EXTENDED";
 		};
 
@@ -95,8 +95,8 @@
 				       STM32_ADC_RES(10, 0x02)
 				       STM32_ADC_RES(8, 0x03)>;
 			sampling-times = <5 6 12 20 36 68 391 814>;
-			st,adc-clock-source = <ASYNC>;
-			st,adc-sequencer = <FULLY_CONFIGURABLE>;
+			st,adc-clock-source = "ASYNC";
+			st,adc-sequencer = "FULLY_CONFIGURABLE";
 			st,adc-oversampler = "OVERSAMPLER_EXTENDED";
 		};
 

--- a/dts/arm/st/wb/stm32wb.dtsi
+++ b/dts/arm/st/wb/stm32wb.dtsi
@@ -425,7 +425,7 @@
 				       STM32_ADC_RES(8, 0x02)
 				       STM32_ADC_RES(6, 0x03)>;
 			sampling-times = <3 7 13 25 48 93 248 641>;
-			st,adc-sequencer = <FULLY_CONFIGURABLE>;
+			st,adc-sequencer = "FULLY_CONFIGURABLE";
 			st,adc-oversampler = "OVERSAMPLER_MINIMAL";
 		};
 

--- a/dts/arm/st/wb/stm32wb.dtsi
+++ b/dts/arm/st/wb/stm32wb.dtsi
@@ -426,6 +426,7 @@
 				       STM32_ADC_RES(6, 0x03)>;
 			sampling-times = <3 7 13 25 48 93 248 641>;
 			st,adc-sequencer = <FULLY_CONFIGURABLE>;
+			st,adc-oversampler = "OVERSAMPLER_MINIMAL";
 		};
 
 		iwdg: watchdog@40003000 {

--- a/dts/arm/st/wba/stm32wba.dtsi
+++ b/dts/arm/st/wba/stm32wba.dtsi
@@ -426,6 +426,7 @@
 			num-sampling-time-common-channels = <2>;
 			st,adc-clock-source = <ASYNC>;
 			st,adc-sequencer = <NOT_FULLY_CONFIGURABLE>;
+			st,adc-oversampler = "OVERSAMPLER_MINIMAL";
 		};
 
 		lptim1: timers@46004400 {

--- a/dts/arm/st/wba/stm32wba.dtsi
+++ b/dts/arm/st/wba/stm32wba.dtsi
@@ -424,8 +424,8 @@
 				       STM32_ADC_RES(6, 0x03)>;
 			sampling-times = <2 4 8 13 20 40 80 815>;
 			num-sampling-time-common-channels = <2>;
-			st,adc-clock-source = <ASYNC>;
-			st,adc-sequencer = <NOT_FULLY_CONFIGURABLE>;
+			st,adc-clock-source = "ASYNC";
+			st,adc-sequencer = "NOT_FULLY_CONFIGURABLE";
 			st,adc-oversampler = "OVERSAMPLER_MINIMAL";
 		};
 

--- a/dts/arm/st/wl/stm32wl.dtsi
+++ b/dts/arm/st/wl/stm32wl.dtsi
@@ -355,6 +355,7 @@
 			sampling-times = <2 4 8 13 20 40 80 161>;
 			num-sampling-time-common-channels = <2>;
 			st,adc-sequencer = <NOT_FULLY_CONFIGURABLE>;
+			st,adc-oversampler = "OVERSAMPLER_MINIMAL";
 		};
 
 		dac1: dac@40007400 {

--- a/dts/arm/st/wl/stm32wl.dtsi
+++ b/dts/arm/st/wl/stm32wl.dtsi
@@ -354,7 +354,7 @@
 				       STM32_ADC_RES(6, 0x03)>;
 			sampling-times = <2 4 8 13 20 40 80 161>;
 			num-sampling-time-common-channels = <2>;
-			st,adc-sequencer = <NOT_FULLY_CONFIGURABLE>;
+			st,adc-sequencer = "NOT_FULLY_CONFIGURABLE";
 			st,adc-oversampler = "OVERSAMPLER_MINIMAL";
 		};
 

--- a/dts/bindings/adc/st,stm32-adc.yaml
+++ b/dts/bindings/adc/st,stm32-adc.yaml
@@ -104,5 +104,18 @@ properties:
       - <NOT_FULLY_CONFIGURABLE>: Not fully configurable sequencer
       - <FULLY_CONFIGURABLE>: Fully configurable sequencer
 
+  st,adc-oversampler:
+    type: string
+    required: true
+    enum:
+      - "OVERSAMPLER_NONE"
+      - "OVERSAMPLER_MINIMAL"
+      - "OVERSAMPLER_EXTENDED"
+    description: |
+      Type of ADC oversampler:
+      - "OVERSAMPLER_NONE": No oversampler
+      - "OVERSAMPLER_MINIMAL": Oversampler with 8 possible oversampling values (2, 4, 8, ..., 256)
+      - "OVERSAMPLER_EXTENDED": Oversampler with 1024 possible oversampling values (1..1024)
+
 io-channel-cells:
   - input

--- a/dts/bindings/adc/st,stm32-adc.yaml
+++ b/dts/bindings/adc/st,stm32-adc.yaml
@@ -22,15 +22,15 @@ properties:
     const: 1
 
   st,adc-clock-source:
-    type: int
+    type: string
     required: true
     enum:
-      - 1 # SYNC for synchronous ADC clock source
-      - 2 # ASYNC for asynchronous ADC clock source
+      - "SYNC"
+      - "ASYNC"
     description: |
       Type of ADC clock source :
-      - <SYNC>: derived from the bus clock.
-      - <ASYNC> : independent and asynchronous with the bus clock
+      - "SYNC": derived from the bus clock.
+      - "ASYNC" : independent and asynchronous with the bus clock
       One of the two values may not apply to some series. Refer to the RefMan.
       If an asynchronous clock is selected, a domain clock in the clock property
       has to be defined explicitly.
@@ -94,15 +94,15 @@ properties:
       Number of sampling time common channels for this ADC instance, if any.
 
   st,adc-sequencer:
-    type: int
+    type: string
     required: true
     enum:
-      - 0 # NOT_FULLY_CONFIGURABLE
-      - 1 # FULLY_CONFIGURABLE
+      - "NOT_FULLY_CONFIGURABLE"
+      - "FULLY_CONFIGURABLE"
     description: |
       Type of ADC sequencer:
-      - <NOT_FULLY_CONFIGURABLE>: Not fully configurable sequencer
-      - <FULLY_CONFIGURABLE>: Fully configurable sequencer
+      - "NOT_FULLY_CONFIGURABLE": Not fully configurable sequencer
+      - "FULLY_CONFIGURABLE": Fully configurable sequencer
 
   st,adc-oversampler:
     type: string

--- a/include/zephyr/dt-bindings/adc/stm32_adc.h
+++ b/include/zephyr/dt-bindings/adc/stm32_adc.h
@@ -64,24 +64,4 @@
 	STM32_ADC(resolution, reg_val, STM32_ADC_RES_MASK, STM32_ADC_RES_SHIFT, \
 		  STM32_ADC_RES_REG)
 
-/**
- * @name STM32 ADC clock source
- * This value is to set <st,adc-clock-source>
- * One or both values may not apply to all series. Refer to the RefMan
- * @{
- */
-#define SYNC  1
-#define ASYNC 2
-/** @} */
-
-/**
- * @name STM32 ADC sequencer type
- * This value is to set <st,adc-sequencer>
- * One or both values may not apply to all series. Refer to the RefMan
- * @{
- */
-#define NOT_FULLY_CONFIGURABLE	0
-#define FULLY_CONFIGURABLE	1
-/** @} */
-
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_STM32_ADC_H_ */

--- a/tests/drivers/adc/adc_api/boards/nucleo_f103rb_dma.overlay
+++ b/tests/drivers/adc/adc_api/boards/nucleo_f103rb_dma.overlay
@@ -1,0 +1,41 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2024 STMicroelectronics
+ */
+
+/ {
+	zephyr,user {
+		/* adjust channel number according to pinmux in board.dts */
+		io-channels = <&adc1 0>, <&adc1 4>;
+	};
+};
+
+&adc1 {
+	dmas = <&dma1 1 (STM32_DMA_PERIPH_RX | STM32_DMA_MEM_16BITS | STM32_DMA_PERIPH_16BITS)>;
+	dma-names = "dma";
+
+	pinctrl-0 = <&adc1_in0_pa0 &adc1_in4_pa4>;
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+	};
+
+	channel@4 {
+		reg = <4>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+	};
+};
+
+&dma1 {
+	status = "okay";
+};

--- a/tests/drivers/adc/adc_api/testcase.yaml
+++ b/tests/drivers/adc/adc_api/testcase.yaml
@@ -14,6 +14,12 @@ tests:
       - DTC_OVERLAY_FILE="boards/b_u585i_iot02a_adc4.overlay"
     platform_allow:
       - b_u585i_iot02a
+  drivers.adc.nucleo_f103rb_dma:
+    extra_args:
+      - DTC_OVERLAY_FILE="boards/nucleo_f103rb_dma.overlay"
+      - EXTRA_CONF_FILE="overlay-dma-stm32.conf"
+    platform_allow:
+      - nucleo_f103rb
   drivers.adc.dma_st_stm32:
     extra_args:
       - EXTRA_CONF_FILE="overlay-dma-stm32.conf"


### PR DESCRIPTION
This PR contains various fixes and enhancements for the STM32 ADC driver:
- Add a log message when an overrun error occurs (with indications how to prevent the error)
- Simplify the oversampling function by adding a new property in device tree
- Simplify the DMA enable function and add support for DMA for STM32H7A/H7B and F1 series

Fixes #79909