### PR TITLE
Update MIPI DSI driver to support ULPS

### DIFF
--- a/dts/bindings/mipi-dsi/nxp,mipi-dsi-2l.yaml
+++ b/dts/bindings/mipi-dsi/nxp,mipi-dsi-2l.yaml
@@ -76,3 +76,8 @@ properties:
     description:
       Enable non-contiuous high speed clock. Saves power but introduces latency
       when transitioning to high speed mode.
+
+  ulps-control:
+    type: boolean
+    description:
+      The IP supports ULPS between transfer.

--- a/include/zephyr/drivers/mipi_dsi/mipi_dsi_mcux_2l.h
+++ b/include/zephyr/drivers/mipi_dsi/mipi_dsi_mcux_2l.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 NXP
+ * Copyright 2023,2025 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -12,5 +12,11 @@
  * byte swap depending on KConfig settings
  */
 #define MCUX_DSI_2L_FB_DATA BIT(0x1)
+
+/*
+ * HW specific flag - user set this bit in message flag and after the
+ * transfer bus will enter ULPS.
+ */
+#define MCUX_DSI_2L_ULPS BIT(0x2)
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_MIPI_DSI_MCUX_2L_ */


### PR DESCRIPTION
Add new item ulps_control in binding. If the MIPI DSI on the SoC support ULPS, and user set the bus to enter ULPS after transfer in mipi_dsi_msg, driver will set the bus to enter ULPS.