### PR TITLE
tests: drivers: watchdog: Run tests on nRF54L20pdk

### DIFF
--- a/boards/nordic/nrf54l20pdk/nrf54l20pdk_nrf54l20_cpuapp.yaml
+++ b/boards/nordic/nrf54l20pdk/nrf54l20pdk_nrf54l20_cpuapp.yaml
@@ -15,3 +15,4 @@ flash: 449
 supported:
   - counter
   - gpio
+  - watchdog

--- a/samples/drivers/watchdog/boards/nrf54l20pdk_nrf54l20_cpuapp.overlay
+++ b/samples/drivers/watchdog/boards/nrf54l20pdk_nrf54l20_cpuapp.overlay
@@ -1,0 +1,8 @@
+/*
+ * Copyright 2024 Nordic Semiconductor ASA
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&wdt31 {
+	status = "okay";
+};

--- a/tests/drivers/watchdog/wdt_error_cases/src/main.c
+++ b/tests/drivers/watchdog/wdt_error_cases/src/main.c
@@ -42,7 +42,8 @@
 #define DEFAULT_WINDOW_MIN (0U)
 
 /* Align tests to the specific target: */
-#if defined(CONFIG_SOC_SERIES_NRF54LX) || defined(CONFIG_SOC_NRF9280)
+#if defined(CONFIG_SOC_SERIES_NRF54LX) || defined(CONFIG_SOC_NRF54H20) || \
+	defined(CONFIG_SOC_NRF9280)
 #define WDT_TEST_FLAGS                                                                             \
 	(WDT_DISABLE_SUPPORTED | WDT_FLAG_RESET_SOC_SUPPORTED |                                    \
 	 WDT_FLAG_ONLY_ONE_TIMEOUT_VALUE_SUPPORTED | WDT_OPT_PAUSE_IN_SLEEP_SUPPORTED |            \


### PR DESCRIPTION
Add overlays and align watchdog tests to be executed on nrf54L20pdk.