### PR TITLE
usb: device_next: remove redundant memset() after net_buf_alloc.*()

### DIFF
--- a/drivers/usb/udc/udc_common.c
+++ b/drivers/usb/udc/udc_common.c
@@ -665,7 +665,6 @@ struct net_buf *udc_ep_buf_alloc(const struct device *dev,
 	}
 
 	bi = udc_get_buf_info(buf);
-	memset(bi, 0, sizeof(struct udc_buf_info));
 	bi->ep = ep;
 	LOG_DBG("Allocate net_buf, ep 0x%02x, size %zd", ep, size);
 

--- a/samples/subsys/usb/webusb-next/src/sfunc.c
+++ b/samples/subsys/usb/webusb-next/src/sfunc.c
@@ -133,7 +133,6 @@ struct net_buf *sfunc_buf_alloc(struct usbd_class_data *const c_data,
 	}
 
 	bi = udc_get_buf_info(buf);
-	memset(bi, 0, sizeof(struct udc_buf_info));
 	bi->ep = ep;
 
 	return buf;

--- a/samples/subsys/usb/webusb-next/src/sfunc.c
+++ b/samples/subsys/usb/webusb-next/src/sfunc.c
@@ -19,7 +19,7 @@ LOG_MODULE_REGISTER(sfunc, LOG_LEVEL_INF);
 NET_BUF_POOL_FIXED_DEFINE(sfunc_pool,
 			  1, 0, sizeof(struct udc_buf_info), NULL);
 
-static uint8_t __aligned(sizeof(void *)) sfunc_buf[512];
+UDC_STATIC_BUF_DEFINE(sfunc_buf, 512);
 
 struct sfunc_desc {
 	struct usb_if_descriptor if0;

--- a/subsys/usb/device_next/class/bt_hci.c
+++ b/subsys/usb/device_next/class/bt_hci.c
@@ -169,7 +169,6 @@ struct net_buf *bt_hci_buf_alloc(const uint8_t ep)
 	}
 
 	bi = udc_get_buf_info(buf);
-	memset(bi, 0, sizeof(struct udc_buf_info));
 	bi->ep = ep;
 
 	return buf;

--- a/subsys/usb/device_next/class/usbd_cdc_acm.c
+++ b/subsys/usb/device_next/class/usbd_cdc_acm.c
@@ -132,7 +132,6 @@ struct net_buf *cdc_acm_buf_alloc(const uint8_t ep)
 	}
 
 	bi = udc_get_buf_info(buf);
-	memset(bi, 0, sizeof(struct udc_buf_info));
 	bi->ep = ep;
 
 	return buf;

--- a/subsys/usb/device_next/class/usbd_cdc_ecm.c
+++ b/subsys/usb/device_next/class/usbd_cdc_ecm.c
@@ -164,7 +164,6 @@ static struct net_buf *cdc_ecm_buf_alloc(const uint8_t ep)
 	}
 
 	bi = udc_get_buf_info(buf);
-	memset(bi, 0, sizeof(struct udc_buf_info));
 	bi->ep = ep;
 
 	return buf;

--- a/subsys/usb/device_next/class/usbd_cdc_ncm.c
+++ b/subsys/usb/device_next/class/usbd_cdc_ncm.c
@@ -307,7 +307,6 @@ static struct net_buf *cdc_ncm_buf_alloc(const uint8_t ep)
 	}
 
 	bi = udc_get_buf_info(buf);
-	memset(bi, 0, sizeof(struct udc_buf_info));
 	bi->ep = ep;
 
 	return buf;

--- a/subsys/usb/device_next/class/usbd_hid.c
+++ b/subsys/usb/device_next/class/usbd_hid.c
@@ -513,7 +513,6 @@ static struct net_buf *hid_buf_alloc_ext(const struct hid_device_config *const d
 	}
 
 	bi = udc_get_buf_info(buf);
-	memset(bi, 0, sizeof(struct udc_buf_info));
 	bi->ep = ep;
 
 	return buf;
@@ -531,7 +530,6 @@ static struct net_buf *hid_buf_alloc(const struct hid_device_config *const dcfg,
 	}
 
 	bi = udc_get_buf_info(buf);
-	memset(bi, 0, sizeof(struct udc_buf_info));
 	bi->ep = ep;
 
 	return buf;

--- a/subsys/usb/device_next/class/usbd_msc.c
+++ b/subsys/usb/device_next/class/usbd_msc.c
@@ -138,7 +138,6 @@ static struct net_buf *msc_buf_alloc(const uint8_t ep)
 	}
 
 	bi = udc_get_buf_info(buf);
-	memset(bi, 0, sizeof(struct udc_buf_info));
 	bi->ep = ep;
 
 	return buf;

--- a/subsys/usb/device_next/class/usbd_uac2.c
+++ b/subsys/usb/device_next/class/usbd_uac2.c
@@ -231,7 +231,6 @@ uac2_buf_alloc(const uint8_t ep, void *data, uint16_t size)
 	}
 
 	bi = udc_get_buf_info(buf);
-	memset(bi, 0, sizeof(struct udc_buf_info));
 	bi->ep = ep;
 
 	if (USB_EP_DIR_IS_OUT(ep)) {
@@ -378,7 +377,6 @@ static void write_explicit_feedback(struct usbd_class_data *const c_data,
 	}
 
 	bi = udc_get_buf_info(buf);
-	memset(bi, 0, sizeof(struct udc_buf_info));
 	bi->ep = ep;
 
 	fb_value = ctx->ops->feedback_cb(dev, terminal, ctx->user_data);


### PR DESCRIPTION
With changes introduced in commit https://github.com/zephyrproject-rtos/zephyr/commit/6a3602a30613bbd23a959200ba120ce28811c11b
("net: buf: Clear `user_data` on allocation")
our memset() calls are redundant.

Fix USB function buffer alignment in webusb-next sample.