### PR TITLE
tests: drivers: uart: Enable test execution on nRF54L20pdk

### DIFF
--- a/tests/drivers/uart/uart_elementary/testcase.yaml
+++ b/tests/drivers/uart/uart_elementary/testcase.yaml
@@ -14,6 +14,7 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l20pdk/nrf54l20/cpuapp
       - nrf54l15dk/nrf54l15/cpuflpr
+      - nrf54l20pdk/nrf54l20/cpuapp
       - nrf5340dk/nrf5340/cpuapp
     integration_platforms:
       - nrf54h20dk/nrf54h20/cpuapp

--- a/tests/drivers/uart/uart_pm/testcase.yaml
+++ b/tests/drivers/uart/uart_pm/testcase.yaml
@@ -8,6 +8,7 @@ common:
     - nrf54l15dk/nrf54l15/cpuapp
     - nrf54l20pdk/nrf54l20/cpuapp
     - nrf54l15bsim/nrf54l15/cpuapp
+    - nrf54l20pdk/nrf54l20/cpuapp
     - nrf54h20dk/nrf54h20/cpuapp
     - nrf52_bsim
     - nrf5340bsim/nrf5340/cpuapp
@@ -35,6 +36,7 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l20pdk/nrf54l20/cpuapp
       - nrf54l15bsim/nrf54l15/cpuapp
+      - nrf54l20pdk/nrf54l20/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
 
   drivers.uart.pm.enhanced_poll:


### PR DESCRIPTION
Add overlays needed to execute uart driver tests on nRF54L20pdk.