### PR TITLE
boards: nordic: nrf54l20pdk: Add i2c to supported peripherals

### DIFF
--- a/boards/nordic/nrf54l20pdk/nrf54l20pdk_nrf54l20_cpuapp.yaml
+++ b/boards/nordic/nrf54l20pdk/nrf54l20pdk_nrf54l20_cpuapp.yaml
@@ -15,4 +15,5 @@ flash: 449
 supported:
   - counter
   - gpio
+  - i2c
   - watchdog


### PR DESCRIPTION
Enable execution of i2c driver tests by adding i2c entry to
the list of supported peripherals.