### PR TITLE
samples: smp_svr: enable support for both small and big heaps

### DIFF
--- a/samples/subsys/mgmt/mcumgr/smp_svr/prj.conf
+++ b/samples/subsys/mgmt/mcumgr/smp_svr/prj.conf
@@ -10,6 +10,9 @@ CONFIG_FLASH_MAP=y
 CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=2304
 CONFIG_MAIN_STACK_SIZE=2048
 
+# Enable support for both small and big heaps.
+CONFIG_SYS_HEAP_AUTO=y
+
 # Ensure an MCUboot-compatible binary is generated.
 CONFIG_BOOTLOADER_MCUBOOT=y
 


### PR DESCRIPTION
- Fix non-functional smp_svr for platforms with RAM < 256KB. By default they have support for small heaps only (CONFIG_SYS_HEAP_SMALL_ONLY).
- Use CONFIG_SYS_HEAP_AUTO=y for the project. It enables support for both small and big heaps.
- Proven on a platform with 128KB RAM.