### PR TITLE
drivers: uart: esp32: reset tx fifo during driver init

### DIFF
--- a/drivers/serial/uart_esp32.c
+++ b/drivers/serial/uart_esp32.c
@@ -276,6 +276,7 @@ static int uart_esp32_configure(const struct device *dev, const struct uart_conf
 	uart_hal_set_rxfifo_full_thr(&data->hal, UART_RX_FIFO_THRESH);
 	uart_hal_set_txfifo_empty_thr(&data->hal, UART_TX_FIFO_THRESH);
 	uart_hal_rxfifo_rst(&data->hal);
+	uart_hal_txfifo_rst(&data->hal);
 
 	switch (cfg->parity) {
 	case UART_CFG_PARITY_NONE:


### PR DESCRIPTION
This PR fix issue regarding unwanted characters being sent by reseting uart tx fifo during driver initialization establishing well defined initial condition

related issue: #82370