### PR TITLE
tests: drivers: counter: Enable test execution on nRF54L20pdk

### DIFF
--- a/tests/drivers/counter/counter_basic_api/boards/nrf54l20pdk_nrf54l20_cpuapp.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/nrf54l20pdk_nrf54l20_cpuapp.overlay
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&timer00 {
+	prescaler = <6>;
+	status = "okay";
+};
+
+&timer10 {
+	prescaler = <4>;
+	status = "okay";
+};
+
+&timer20 {
+	prescaler = <4>;
+	status = "okay";
+};
+
+&timer21 {
+	prescaler = <4>;
+	status = "okay";
+};
+
+&timer22 {
+	prescaler = <4>;
+	status = "okay";
+};
+
+&timer23 {
+	prescaler = <4>;
+	status = "okay";
+};
+
+&timer24 {
+	prescaler = <4>;
+	status = "okay";
+};


### PR DESCRIPTION
Add overlay needed to execute counter tests on nRF54L20pdk.