### PR TITLE
drivers: gpio_pca95xx: add pins initialization to default state

### DIFF
--- a/drivers/gpio/gpio_pca95xx.c
+++ b/drivers/gpio/gpio_pca95xx.c
@@ -301,6 +301,15 @@ static inline int update_direction_reg(const struct device *dev, uint8_t pin,
 			      &drv_data->reg_cache.dir, value);
 }
 
+static inline int update_direction_regs(const struct device *dev, uint16_t value)
+{
+	struct gpio_pca95xx_drv_data * const drv_data =
+		(struct gpio_pca95xx_drv_data * const)dev->data;
+
+	return write_port_regs(dev, REG_CONF_PORT0,
+			      &drv_data->reg_cache.dir, value);
+}
+
 static inline int update_pul_sel_reg(const struct device *dev, uint8_t pin,
 					uint16_t value)
 {
@@ -372,6 +381,18 @@ static int setup_pin_dir(const struct device *dev, uint32_t pin, int flags)
 	ret = update_direction_reg(dev, pin, reg_dir);
 
 	return ret;
+}
+
+/**
+ * @brief Initialize pins to default state
+ *
+ * @param dev Device struct of the PCA95XX
+ *
+ * @return 0 if successful, failed otherwise
+ */
+static int init_pins(const struct device *dev)
+{
+	return update_direction_regs(dev, 0xFFFF);
 }
 
 /**
@@ -783,6 +804,7 @@ static int gpio_pca95xx_init(const struct device *dev)
 	const struct gpio_pca95xx_config * const config = dev->config;
 	struct gpio_pca95xx_drv_data * const drv_data =
 		(struct gpio_pca95xx_drv_data * const)dev->data;
+	int ret;
 
 	if (!device_is_ready(config->bus.bus)) {
 		return -ENODEV;
@@ -790,11 +812,14 @@ static int gpio_pca95xx_init(const struct device *dev)
 
 	k_sem_init(&drv_data->lock, 1, 1);
 
+	ret = init_pins(dev);
+	if (ret != 0) {
+		return ret;
+	}
+
 #ifdef CONFIG_GPIO_PCA95XX_INTERRUPT
 	/* Check if GPIO port supports interrupts */
 	if ((config->capabilities & PCA_HAS_INTERRUPT) != 0) {
-		int ret;
-
 		/* Store self-reference for interrupt handling */
 		drv_data->instance = dev;
 


### PR DESCRIPTION
After a `non-power` reset (wdt) pins may remain in `non-default` state. To ensure that a system initialization is the same after any reset, it is necessary to initialize pins to the default state.