### PR TITLE
drivers: serial: nrfx_uarte: Fix bool endtx-stoptx prop check

### DIFF
--- a/drivers/serial/Kconfig.nrfx_uart_instance
+++ b/drivers/serial/Kconfig.nrfx_uart_instance
@@ -20,7 +20,7 @@ config UART_$(nrfx_uart_num)_ASYNC
 
 config UART_$(nrfx_uart_num)_ENHANCED_POLL_OUT
 	bool "Efficient poll out on port $(nrfx_uart_num)"
-	depends on !$(dt_nodelabel_has_prop,uart$(nrfx_uart_num),endtx-stoptx-supported)
+	depends on !$(dt_nodelabel_bool_prop,uart$(nrfx_uart_num),endtx-stoptx-supported)
 	default y
 	depends on HAS_HW_NRF_UARTE$(nrfx_uart_num)
 	depends on HAS_HW_NRF_PPI || HAS_HW_NRF_DPPIC


### PR DESCRIPTION
The dt_nodelabel_bool_prop must be used to check for a boolean property, not the dt_nodelabel_has_prop. Using the latter caused the UART_X_ENHANCED_POLL_OUT condition to be not fulfilled, despite the fact that the property was not set on nRF52840 and nRF91.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/82736