### PR TITLE
boards: st: Enable RNG for nucleo_l476rg and sensortile_box boards

### DIFF
--- a/boards/st/nucleo_l476rg/nucleo_l476rg.dts
+++ b/boards/st/nucleo_l476rg/nucleo_l476rg.dts
@@ -63,6 +63,7 @@
 	div-m = <1>;
 	mul-n = <20>;
 	div-r = <4>;
+	div-q = <8>;
 	clocks = <&clk_hsi>;
 	status = "okay";
 };
@@ -192,4 +193,11 @@ stm32_lp_tick_source: &lptim1 {
 			reg = <0x000f8000 DT_SIZE_K(32)>;
 		};
 	};
+};
+
+&rng {
+	/* Change clock source to avoid using MSI */
+	clocks = <&rcc STM32_CLOCK(AHB2, 18U)>,
+		 <&rcc STM32_SRC_PLL_Q CLK48_SEL(2)>;
+	status = "okay";
 };

--- a/boards/st/sensortile_box/sensortile_box.dts
+++ b/boards/st/sensortile_box/sensortile_box.dts
@@ -72,7 +72,7 @@
 	div-m = <4>;
 	mul-n = <40>;
 	div-p = <7>;
-	div-q = <2>;
+	div-q = <4>;
 	div-r = <2>;
 	clocks = <&clk_hse>;
 	status = "okay";
@@ -243,4 +243,11 @@ zephyr_udc0: &usbotg_fs {
 			reg = <0x000fc000 DT_SIZE_K(24)>;
 		};
 	};
+};
+
+&rng {
+	/* Change clock source to avoid using MSI */
+	clocks = <&rcc STM32_CLOCK(AHB2, 18U)>,
+		 <&rcc STM32_SRC_PLL_Q CLK48_SEL(2)>;
+	status = "okay";
 };


### PR DESCRIPTION
Enable RNG for nucleo_l476rg and sensortile_box boards as well as changing
the clock source for RNG peripheral to avoid using MSI.
