### PR TITLE
dts: arm: st: h7: add a template for stm32h743Xg

### DIFF
--- a/dts/arm/st/h7/stm32h743Xg.dtsi
+++ b/dts/arm/st/h7/stm32h743Xg.dtsi
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <mem.h>
+#include <st/h7/stm32h743.dtsi>
+
+/ {
+	soc {
+		flash-controller@52002000 {
+			flash0: flash@8000000 {
+				reg = <0x08000000 DT_SIZE_K(1024)>;
+			};
+		};
+	};
+};


### PR DESCRIPTION
Same as stm32h743Xi.dtsi, half the flash.