### PR TITLE
tests: guard variable used only with CONFIG_TRACE_SCHED_IPI

### DIFF
--- a/tests/kernel/smp/src/main.c
+++ b/tests/kernel/smp/src/main.c
@@ -734,7 +734,7 @@ ZTEST(smp, test_smp_ipi)
 {
 #ifndef CONFIG_TRACE_SCHED_IPI
 	ztest_test_skip();
-#endif
+#else
 
 	TC_PRINT("cpu num=%d", arch_num_cpus());
 
@@ -754,6 +754,7 @@ ZTEST(smp, test_smp_ipi)
 				"did not receive IPI.(%d)",
 				sched_ipi_has_called);
 	}
+#endif
 }
 #endif
 


### PR DESCRIPTION
Change to prevent build failure when CONFIG_SCHED_IPI_SUPPORTED is defined and CONFIG_TRACE_SCHED_IPI is not.