### PR TITLE
drivers: i3c: report sdr error in `i3c_ccc_payload` and `i3c_msgs`

### DIFF
--- a/drivers/i3c/i3c_ccc.c
+++ b/drivers/i3c/i3c_ccc.c
@@ -860,14 +860,14 @@ int i3c_ccc_do_getmxds(const struct i3c_device_desc *target,
 		len = ccc_tgt_payload.num_xfer;
 
 		if ((fmt == GETMXDS_FORMAT_1) || (fmt == GETMXDS_FORMAT_2)) {
-			if (len == sizeof(((union i3c_ccc_getmxds *)0)->fmt1)) {
+			if (len == SIZEOF_FIELD(union i3c_ccc_getmxds, fmt1)) {
 				mxds->fmt1.maxwr = data[0];
 				mxds->fmt1.maxrd = data[1];
 				/* It is unknown wither format 1 or format 2 is returned ahead of
 				 * time
 				 */
 				memset(&mxds->fmt2.maxrdturn, 0, sizeof(mxds->fmt2.maxrdturn));
-			} else if (len == sizeof(((union i3c_ccc_getmxds *)0)->fmt2)) {
+			} else if (len == SIZEOF_FIELD(union i3c_ccc_getmxds, fmt2)) {
 				mxds->fmt2.maxwr = data[0];
 				mxds->fmt2.maxrd = data[1];
 				memcpy(&mxds->fmt2.maxrdturn, &data[2],

--- a/drivers/i3c/i3c_cdns.c
+++ b/drivers/i3c/i3c_cdns.c
@@ -537,6 +537,7 @@ struct cdns_i3c_cmd {
 	uint32_t *num_xfer;
 	void *buf;
 	uint32_t error;
+	enum i3c_sdr_controller_error_types *sdr_err;
 	enum i3c_data_rate hdr;
 };
 
@@ -1438,10 +1439,11 @@ static int cdns_i3c_do_ccc(const struct device *dev, struct i3c_ccc_payload *pay
 			}
 			cmd->hdr = I3C_DATA_RATE_SDR;
 			/*
-			 * write the address of num_xfer which is to be updated upon message
-			 * completion
+			 * write the address of num_xfer and err which is to be updated upon
+			 * message completion
 			 */
 			cmd->num_xfer = &(payload->targets.payloads[i].num_xfer);
+			cmd->sdr_err = &(payload->targets.payloads[i].err);
 		}
 	} else {
 		cmd = &data->xfer.cmds[0];
@@ -1464,6 +1466,7 @@ static int cdns_i3c_do_ccc(const struct device *dev, struct i3c_ccc_payload *pay
 			cmd->len = 0;
 			cmd->num_xfer = NULL;
 		}
+		cmd->sdr_err = &(payload->ccc.err);
 	}
 
 	data->xfer.ret = -ETIMEDOUT;
@@ -1740,6 +1743,9 @@ static void cdns_i3c_complete_transfer(const struct device *dev)
 	for (int i = 0; i < data->xfer.num_cmds; i++) {
 		switch (data->xfer.cmds[i].error) {
 		case CMDR_NO_ERROR:
+			if (data->xfer.cmds[i].sdr_err) {
+				*data->xfer.cmds[i].sdr_err = I3C_ERROR_CE_NONE;
+			}
 			break;
 
 		case CMDR_MST_ABORT:
@@ -1761,6 +1767,9 @@ static void cdns_i3c_complete_transfer(const struct device *dev)
 				LOG_DBG("%s: Controller Abort due to buffer length excedded with "
 					"no EoD from target",
 					dev->name);
+			}
+			if (data->xfer.cmds[i].sdr_err) {
+				*data->xfer.cmds[i].sdr_err = I3C_ERROR_CE_NONE;
 			}
 			break;
 
@@ -1793,27 +1802,50 @@ static void cdns_i3c_complete_transfer(const struct device *dev)
 					ret = -EIO;
 				}
 			} else {
+				if (data->xfer.cmds[i].sdr_err) {
+					*data->xfer.cmds[i].sdr_err = I3C_ERROR_CE0;
+				}
 				ret = -EIO;
 			}
 			break;
 		}
 
+		case CMDR_M1_ERROR:
+			if (data->xfer.cmds[i].sdr_err) {
+				*data->xfer.cmds[i].sdr_err = I3C_ERROR_CE1;
+			}
+			ret = -EIO;
+			break;
+		case CMDR_M2_ERROR:
+			if (data->xfer.cmds[i].sdr_err) {
+				*data->xfer.cmds[i].sdr_err = I3C_ERROR_CE2;
+			}
+			ret = -EIO;
+			break;
+
 		case CMDR_DDR_PREAMBLE_ERROR:
 		case CMDR_DDR_PARITY_ERROR:
-		case CMDR_M1_ERROR:
-		case CMDR_M2_ERROR:
 		case CMDR_NACK_RESP:
 		case CMDR_DDR_DROPPED:
+			if (data->xfer.cmds[i].sdr_err) {
+				*data->xfer.cmds[i].sdr_err = I3C_ERROR_CE_UNKNOWN;
+			}
 			ret = -EIO;
 			break;
 
 		case CMDR_DDR_RX_FIFO_OVF:
 		case CMDR_DDR_TX_FIFO_UNF:
+			if (data->xfer.cmds[i].sdr_err) {
+				*data->xfer.cmds[i].sdr_err = I3C_ERROR_CE_UNKNOWN;
+			}
 			ret = -ENOSPC;
 			break;
 
 		case CMDR_INVALID_DA:
 		default:
+			if (data->xfer.cmds[i].sdr_err) {
+				*data->xfer.cmds[i].sdr_err = I3C_ERROR_CE_UNKNOWN;
+			}
 			ret = -EINVAL;
 			break;
 		}
@@ -1910,8 +1942,9 @@ static int cdns_i3c_i2c_transfer(const struct device *dev, struct i3c_i2c_device
 			cmd->cmd0 |= CMD0_FIFO_RNW;
 		}
 
-		/* i2c transfers are a don't care for num_xfer */
+		/* i2c transfers are a don't care for num_xfer and sdr error */
 		cmd->num_xfer = NULL;
+		cmd->sdr_err = NULL;
 	}
 
 	data->xfer.ret = -ETIMEDOUT;
@@ -2237,6 +2270,7 @@ static int cdns_i3c_transfer(const struct device *dev, struct i3c_device_desc *t
 			 * completion
 			 */
 			cmd->num_xfer = &(msgs[i].num_xfer);
+			cmd->sdr_err = &(msgs[i].err);
 			cmd->hdr = I3C_DATA_RATE_SDR;
 		} else if ((data->common.ctrl_config.supported_hdr & I3C_MSG_HDR_DDR) &&
 			   (msgs[i].hdr_mode == I3C_MSG_HDR_DDR) && (msgs[i].flags & I3C_MSG_HDR)) {
@@ -2290,6 +2324,7 @@ static int cdns_i3c_transfer(const struct device *dev, struct i3c_device_desc *t
 			 * completion
 			 */
 			cmd->num_xfer = &(msgs[i].num_xfer);
+			cmd->sdr_err = &(msgs[i].err);
 			cmd->hdr = I3C_DATA_RATE_HDR_DDR;
 		} else {
 			LOG_ERR("%s: Unsupported HDR Mode %d", dev->name, msgs[i].hdr_mode);

--- a/drivers/i3c/i3c_cdns.c
+++ b/drivers/i3c/i3c_cdns.c
@@ -1791,9 +1791,9 @@ static void cdns_i3c_complete_transfer(const struct device *dev)
 				 * time which will be returned.
 				 */
 				if ((*data->xfer.cmds[i].num_xfer !=
-				     sizeof(((union i3c_ccc_getmxds *)0)->fmt1)) &&
+				     SIZEOF_FIELD(union i3c_ccc_getmxds, fmt1)) &&
 				    (*data->xfer.cmds[i].num_xfer !=
-				     sizeof(((union i3c_ccc_getmxds *)0)->fmt2))) {
+				     SIZEOF_FIELD(union i3c_ccc_getmxds, fmt2))) {
 					ret = -EIO;
 				}
 			} else if (ccc == I3C_CCC_GETCAPS) {

--- a/include/zephyr/drivers/i3c.h
+++ b/include/zephyr/drivers/i3c.h
@@ -23,6 +23,7 @@
 
 #include <zephyr/device.h>
 #include <zephyr/drivers/i3c/addresses.h>
+#include <zephyr/drivers/i3c/error_types.h>
 #include <zephyr/drivers/i3c/ccc.h>
 #include <zephyr/drivers/i3c/devicetree.h>
 #include <zephyr/drivers/i3c/ibi.h>
@@ -292,87 +293,6 @@ enum i3c_data_rate {
 };
 
 /**
- * @brief I3C SDR Controller Error Codes
- *
- * These are error codes defined by the I3C specification.
- *
- * #I3C_ERROR_CE_UNKNOWN and #I3C_ERROR_CE_NONE are not
- * official error codes according to the specification.
- * These are there simply to aid in error handling during
- * interactions with the I3C drivers and subsystem.
- */
-enum i3c_sdr_controller_error_codes {
-	/** Transaction after sending CCC */
-	I3C_ERROR_CE0,
-
-	/** Monitoring Error */
-	I3C_ERROR_CE1,
-
-	/** No response to broadcast address (0x7E) */
-	I3C_ERROR_CE2,
-
-	/** Failed Controller Handoff */
-	I3C_ERROR_CE3,
-
-	/** Unknown error (not official error code) */
-	I3C_ERROR_CE_UNKNOWN,
-
-	/** No error (not official error code) */
-	I3C_ERROR_CE_NONE,
-
-	I3C_ERROR_CE_MAX = I3C_ERROR_CE_UNKNOWN,
-	I3C_ERROR_CE_INVALID,
-};
-
-/**
- * @brief I3C SDR Target Error Codes
- *
- * These are error codes defined by the I3C specification.
- *
- * #I3C_ERROR_TE_UNKNOWN and #I3C_ERROR_TE_NONE are not
- * official error codes according to the specification.
- * These are there simply to aid in error handling during
- * interactions with the I3C drivers and subsystem.
- */
-enum i3c_sdr_target_error_codes {
-	/**
-	 * Invalid Broadcast Address or
-	 * Dynamic Address after DA assignment
-	 */
-	I3C_ERROR_TE0,
-
-	/** CCC Code */
-	I3C_ERROR_TE1,
-
-	/** Write Data */
-	I3C_ERROR_TE2,
-
-	/** Assigned Address during Dynamic Address Arbitration */
-	I3C_ERROR_TE3,
-
-	/** 0x7E/R missing after RESTART during Dynamic Address Arbitration */
-	I3C_ERROR_TE4,
-
-	/** Transaction after detecting CCC */
-	I3C_ERROR_TE5,
-
-	/** Monitoring Error */
-	I3C_ERROR_TE6,
-
-	/** Dead Bus Recovery */
-	I3C_ERROR_DBR,
-
-	/** Unknown error (not official error code) */
-	I3C_ERROR_TE_UNKNOWN,
-
-	/** No error (not official error code) */
-	I3C_ERROR_TE_NONE,
-
-	I3C_ERROR_TE_MAX = I3C_ERROR_TE_UNKNOWN,
-	I3C_ERROR_TE_INVALID,
-};
-
-/**
  * @brief I3C Transfer API
  * @defgroup i3c_transfer_api I3C Transfer API
  * @{
@@ -484,6 +404,14 @@ struct i3c_msg {
 	 * write to this after the transfer.
 	 */
 	uint32_t		num_xfer;
+
+	/**
+	 * SDR Error Type
+	 *
+	 * Error from I3C Specification v1.1.1 section 5.1.10.2. It is expected
+	 * for the driver to write to this.
+	 */
+	enum i3c_sdr_controller_error_types err;
 
 	/** Flags for this message */
 	uint8_t			flags;

--- a/include/zephyr/drivers/i3c/ccc.h
+++ b/include/zephyr/drivers/i3c/ccc.h
@@ -259,6 +259,14 @@ struct i3c_ccc_target_payload {
 	 * write to this after the transfer.
 	 */
 	size_t num_xfer;
+
+	/**
+	 * SDR Error Type
+	 *
+	 * Error from I3C Specification v1.1.1 section 5.1.10.2. It is expected
+	 * for the driver to write to this.
+	 */
+	enum i3c_sdr_controller_error_types err;
 };
 
 /**
@@ -289,6 +297,14 @@ struct i3c_ccc_payload {
 		 * It is expected for the driver to write to this after the transfer.
 		 */
 		size_t num_xfer;
+
+		/**
+		 * SDR Error Type
+		 *
+		 * Error from I3C Specification v1.1.1 section 5.1.10.2. It is expected
+		 * for the driver to write to this.
+		 */
+		enum i3c_sdr_controller_error_types err;
 	} ccc;
 
 	struct {

--- a/include/zephyr/drivers/i3c/error_types.h
+++ b/include/zephyr/drivers/i3c/error_types.h
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2024 Meta Platforms, Inc. and its affiliates
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_I3C_ERROR_TYPES_H_
+#define ZEPHYR_INCLUDE_DRIVERS_I3C_ERROR_TYPES_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief I3C SDR Controller Error Types
+ *
+ * These are error types defined by the I3C specification.
+ *
+ * #I3C_ERROR_CE_UNKNOWN and #I3C_ERROR_CE_NONE are not
+ * official error types according to the specification.
+ * These are there simply to aid in error handling during
+ * interactions with the I3C drivers and subsystem.
+ */
+enum i3c_sdr_controller_error_types {
+	/** Transaction after sending CCC */
+	I3C_ERROR_CE0,
+
+	/** Monitoring Error */
+	I3C_ERROR_CE1,
+
+	/** No response to broadcast address (0x7E) */
+	I3C_ERROR_CE2,
+
+	/** Failed Controller Handoff */
+	I3C_ERROR_CE3,
+
+	/** Unknown error (not official error type) */
+	I3C_ERROR_CE_UNKNOWN,
+
+	/** No error (not official error type) */
+	I3C_ERROR_CE_NONE,
+
+	I3C_ERROR_CE_MAX = I3C_ERROR_CE_UNKNOWN,
+	I3C_ERROR_CE_INVALID,
+};
+
+/**
+ * @brief I3C SDR Target Error Types
+ *
+ * These are error types defined by the I3C specification.
+ *
+ * #I3C_ERROR_TE_UNKNOWN and #I3C_ERROR_TE_NONE are not
+ * official error types according to the specification.
+ * These are there simply to aid in error handling during
+ * interactions with the I3C drivers and subsystem.
+ */
+enum i3c_sdr_target_error_types {
+	/**
+	 * Invalid Broadcast Address or
+	 * Dynamic Address after DA assignment
+	 */
+	I3C_ERROR_TE0,
+
+	/** CCC type */
+	I3C_ERROR_TE1,
+
+	/** Write Data */
+	I3C_ERROR_TE2,
+
+	/** Assigned Address during Dynamic Address Arbitration */
+	I3C_ERROR_TE3,
+
+	/** 0x7E/R missing after RESTART during Dynamic Address Arbitration */
+	I3C_ERROR_TE4,
+
+	/** Transaction after detecting CCC */
+	I3C_ERROR_TE5,
+
+	/** Monitoring Error */
+	I3C_ERROR_TE6,
+
+	/** Dead Bus Recovery */
+	I3C_ERROR_DBR,
+
+	/** Unknown error (not official error type) */
+	I3C_ERROR_TE_UNKNOWN,
+
+	/** No error (not official error type) */
+	I3C_ERROR_TE_NONE,
+
+	I3C_ERROR_TE_MAX = I3C_ERROR_TE_UNKNOWN,
+	I3C_ERROR_TE_INVALID,
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_I3C_ERROR_TYPES_H_ */


### PR DESCRIPTION
Report the SDR error within the `i3c_ccc_payload` and `i3c_msgs`. This follows the error types of the I3C Specification v1.1.1 Section  5.1.10.2