### PR TITLE
drivers: spi_nrfx_spim: Add clock requests for fast SPIM instances

### DIFF
--- a/drivers/clock_control/clock_control_nrf2_common.c
+++ b/drivers/clock_control/clock_control_nrf2_common.c
@@ -198,6 +198,7 @@ int nrf_clock_control_request_sync(const struct device *dev,
 
 	err = k_sem_take(&req.sem, timeout);
 	if (err < 0) {
+		nrf_clock_control_cancel_or_release(dev, spec, &req.cli);
 		return err;
 	}
 

--- a/dts/common/nordic/nrf54h20.dtsi
+++ b/dts/common/nordic/nrf54h20.dtsi
@@ -648,6 +648,7 @@
 				power-domains = <&gpd NRF_GPD_FAST_ACTIVE1>;
 				easydma-maxcnt-bits = <15>;
 				interrupts = <230 NRF_DEFAULT_IRQ_PRIORITY>;
+				clocks = <&hsfll120>;
 				max-frequency = <DT_FREQ_M(32)>;
 				#address-cells = <1>;
 				#size-cells = <0>;
@@ -674,6 +675,7 @@
 				status = "disabled";
 				easydma-maxcnt-bits = <15>;
 				interrupts = <231 NRF_DEFAULT_IRQ_PRIORITY>;
+				clocks = <&hsfll120>;
 				power-domains = <&gpd NRF_GPD_FAST_ACTIVE1>;
 				max-frequency = <DT_FREQ_M(32)>;
 				#address-cells = <1>;


### PR DESCRIPTION
~Based on #75715 and #81735. Only the last three commits are actually added by this PR.~

*drivers: clock_control_nrf2: Add missing cancelation of request*

This is a follow-up to commit https://github.com/zephyrproject-rtos/zephyr/commit/fe0e2dbc6044ffa74b27bfcba335980bc5a6ae64.

If `nrf_clock_control_request_sync()` ends up with a timeout, before returning it must cancel the request that was not fulfilled on time. Otherwise, the request may actually finish successfully a bit later, but the caller will not be aware that the clock needs to be released (since the call resulted in an error). And actually even more serious problem is that because the `req` structure is placed on stack, after the function returns, the contents of this structure will be probably overwritten with some other data, so if the request finishes at that point, an attempt to execute the callback function pointed by this structure will most likely cause a crash.

*dts: nrf54h20: Add clocks property in fast SPIM nodes*

Fast SPIM instances in nRF54H20 (SPIM120 and SPIM121) are driven by the global HSFLL (HSFLL120). Add `clocks` property in these nodes to reflect this.

*drivers: spi_nrfx_spim: Add clock requests for fast SPIM instances*

Fast SPIM instances (SPIM120 and SPIM121) for correct operation require the highest frequency from the global HSFLL. This commit adds needed clock controller requests to the driver. When the runtime device power management is enabled, the frequency is requested as long as the SPIM is resumed, otherwise it is requested for the duration of transfers.