### PR TITLE
drivers: clock_control: nrf: hfxo: Remove redundad code

### DIFF
--- a/drivers/clock_control/clock_control_nrf2_hfxo.c
+++ b/drivers/clock_control/clock_control_nrf2_hfxo.c
@@ -37,23 +37,15 @@ static uint32_t full_irq_lock(void)
 {
 	uint32_t mcu_critical_state;
 
-	if (IS_ENABLED(CONFIG_ZERO_LATENCY_IRQS)) {
-		mcu_critical_state = __get_PRIMASK();
-		__disable_irq();
-	} else {
-		mcu_critical_state = irq_lock();
-	}
+	mcu_critical_state = __get_PRIMASK();
+	__disable_irq();
 
 	return mcu_critical_state;
 }
 
 static void full_irq_unlock(uint32_t mcu_critical_state)
 {
-	if (IS_ENABLED(CONFIG_ZERO_LATENCY_IRQS)) {
-		__set_PRIMASK(mcu_critical_state);
-	} else {
-		irq_unlock(mcu_critical_state);
-	}
+	__set_PRIMASK(mcu_critical_state);
 }
 #endif /* CONFIG_ZERO_LATENCY_IRQS */
 


### PR DESCRIPTION
There were redundant code in full_irq_lock(), full_irq_unlock() functions that supposed to be used when ZLI IRQs are disabled. These functions are compiled in only when CONFIG_ZERO_LATENCY_IRQS is set, hence the non-ZLI execution path was never included in final binaries.