### PR TITLE
soc: st: stm32: common: fix wakeup off-by-one

### DIFF
--- a/soc/st/stm32/common/stm32_wkup_pins.c
+++ b/soc/st/stm32/common/stm32_wkup_pins.c
@@ -107,7 +107,7 @@ static const struct gpio_dt_spec empty_gpio = {.port = NULL, .pin = 0, .dt_flags
 /* wkup_pin idx starts from 1 */
 #define WKUP_PIN_CFG_DT_BY_IDX(idx) WKUP_PIN_CFG_DT(WKUP_PIN_NODE_ID_BY_IDX(idx))
 
-#define PWR_STM32_WKUP_PIN_DEF(i, _) LL_PWR_WAKEUP_PIN##i
+#define PWR_STM32_WKUP_PIN_LOOKUP_MEMBER(i, _) CONCAT(LL_PWR_WAKEUP_PIN, UTIL_INC(i))
 
 #define WKUP_PIN_CFG_DT_COMMA(wkup_pin_id) WKUP_PIN_CFG_DT(wkup_pin_id),
 
@@ -133,7 +133,9 @@ struct wkup_pin_cfg_t {
  * @brief LookUp Table to store LL_PWR_WAKEUP_PINx for each wake-up pin.
  */
 static const uint32_t table_wakeup_pins[PWR_STM32_MAX_NB_WKUP_PINS + 1] = {
-	LISTIFY(PWR_STM32_MAX_NB_WKUP_PINS, PWR_STM32_WKUP_PIN_DEF, (,))};
+	0,
+	LISTIFY(PWR_STM32_MAX_NB_WKUP_PINS, PWR_STM32_WKUP_PIN_LOOKUP_MEMBER, (,)),
+};
 
 static struct wkup_pin_dt_cfg_t wkup_pins_cfgs[] = {
 	DT_FOREACH_CHILD(STM32_PWR_NODE, WKUP_PIN_CFG_DT_COMMA)};

--- a/soc/st/stm32/common/stm32_wkup_pins.h
+++ b/soc/st/stm32/common/stm32_wkup_pins.h
@@ -17,7 +17,6 @@ extern "C" {
 #endif
 
 /* Some stm32 devices do not have all the LL_PWR_WAKEUP_PINx */
-#define LL_PWR_WAKEUP_PIN0 0
 #ifndef LL_PWR_WAKEUP_PIN3
 #define LL_PWR_WAKEUP_PIN3 0
 #endif /* LL_PWR_WAKEUP_PIN3 */


### PR DESCRIPTION
Wakeup pin indices are 1-based, but `LISTIFY` is 0-based. Consequently, the last element of the pin-to-register-bit lookup table was never populated.

For example, STM32L4xx MCUs, like the STM32L4R5ZI on the NUCLEO-L4R5ZI board supported by the `samples/boards/st/power_mgmt/wkup_pins` sample, [have five WKUP pins](https://github.com/zephyrproject-rtos/zephyr/blob/v4.0.0/dts/arm/st/l4/stm32l4.dtsi#L486-L511), numbered 1 through 5. However, the `LISTIFY` invocation populating `table_wakeup_pins` ranged over [0, 4], and so the table was actually defined as:

```c
static const uint32_t table_wakeup_pins[6] = {
	LL_PWR_WAKEUP_PIN0, LL_PWR_WAKEUP_PIN1, LL_PWR_WAKEUP_PIN2, LL_PWR_WAKEUP_PIN3, LL_PWR_WAKEUP_PIN4,};
```

I.e., the last member was 0-filled (and the first member – `LL_PWR_WAKEUP_PIN0` – is synthetic, and is defined in the adjacent header only to suppress an error generating this array). Attempts to actually configure WKUP5 would fail silently.

Happy to hear feedback on other ways to accomplish this fix – it is quite verbose.