### PR TITLE
Bluetooth: Controller: Fix BT_CTLR_LOW_LAT_ULL conditional code

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
@@ -749,9 +749,9 @@ void lll_conn_isr_tx(void *param)
 
 	radio_isr_set(lll_conn_isr_rx, param);
 
-#if defined(CONFIG_BT_CTLR_LOW_LAT_ULL)
+#if defined(CONFIG_BT_CTLR_LOW_LAT)
 	ull_conn_lll_tx_demux_sched(lll);
-#endif /* CONFIG_BT_CTLR_LOW_LAT_ULL */
+#endif /* CONFIG_BT_CTLR_LOW_LAT */
 }
 
 void lll_conn_rx_pkt_set(struct lll_conn *lll)

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -82,9 +82,9 @@
 LOG_MODULE_REGISTER(bt_ctlr_ull_conn);
 
 static int init_reset(void);
-#if !defined(CONFIG_BT_CTLR_LOW_LAT_ULL)
+#if !defined(CONFIG_BT_CTLR_LOW_LAT)
 static void tx_demux_sched(struct ll_conn *conn);
-#endif /* CONFIG_BT_CTLR_LOW_LAT_ULL */
+#endif /* CONFIG_BT_CTLR_LOW_LAT */
 static void tx_demux(void *param);
 static struct node_tx *tx_ull_dequeue(struct ll_conn *conn, struct node_tx *tx);
 
@@ -240,7 +240,7 @@ int ll_tx_mem_enqueue(uint16_t handle, void *tx)
 
 	MFIFO_ENQUEUE(conn_tx, idx);
 
-#if !defined(CONFIG_BT_CTLR_LOW_LAT_ULL)
+#if !defined(CONFIG_BT_CTLR_LOW_LAT)
 	if (ull_ref_get(&conn->ull)) {
 #if defined(CONFIG_BT_CTLR_FORCE_MD_AUTO)
 		if (tx_cnt >= CONFIG_BT_BUF_ACL_TX_COUNT) {
@@ -261,7 +261,7 @@ int ll_tx_mem_enqueue(uint16_t handle, void *tx)
 		lll_conn_force_md_cnt_set(0U);
 #endif /* CONFIG_BT_CTLR_FORCE_MD_AUTO */
 	}
-#endif /* !CONFIG_BT_CTLR_LOW_LAT_ULL */
+#endif /* !CONFIG_BT_CTLR_LOW_LAT */
 
 	if (IS_ENABLED(CONFIG_BT_PERIPHERAL) && conn->lll.role) {
 		ull_periph_latency_cancel(conn, handle);
@@ -1389,7 +1389,7 @@ void ull_conn_done(struct node_rx_event_done *done)
 	}
 }
 
-#if defined(CONFIG_BT_CTLR_LOW_LAT_ULL)
+#if defined(CONFIG_BT_CTLR_LOW_LAT)
 void ull_conn_lll_tx_demux_sched(struct lll_conn *lll)
 {
 	static memq_link_t link;
@@ -1399,7 +1399,7 @@ void ull_conn_lll_tx_demux_sched(struct lll_conn *lll)
 
 	mayfly_enqueue(TICKER_USER_ID_LLL, TICKER_USER_ID_ULL_HIGH, 1U, &mfy);
 }
-#endif /* CONFIG_BT_CTLR_LOW_LAT_ULL */
+#endif /* CONFIG_BT_CTLR_LOW_LAT */
 
 void ull_conn_tx_demux(uint8_t count)
 {
@@ -1696,7 +1696,7 @@ static int init_reset(void)
 	return 0;
 }
 
-#if !defined(CONFIG_BT_CTLR_LOW_LAT_ULL)
+#if !defined(CONFIG_BT_CTLR_LOW_LAT)
 static void tx_demux_sched(struct ll_conn *conn)
 {
 	static memq_link_t link;
@@ -1706,7 +1706,7 @@ static void tx_demux_sched(struct ll_conn *conn)
 
 	mayfly_enqueue(TICKER_USER_ID_THREAD, TICKER_USER_ID_ULL_HIGH, 0U, &mfy);
 }
-#endif /* !CONFIG_BT_CTLR_LOW_LAT_ULL */
+#endif /* !CONFIG_BT_CTLR_LOW_LAT */
 
 static void tx_demux(void *param)
 {


### PR DESCRIPTION
Fix BT_CTLR_LOW_LAT_ULL conditional compilation code by decoupling it from BT_CTLR_LOW_LAT code.

BT_CTLR_LOW_LAT_ULL makes ULL execution context to tailchain in comparison to continuously process in a while loop.