### PR TITLE
drivers: espi: npcx: support access 2 SPI flash devices

### DIFF
--- a/drivers/espi/espi_taf_npcx.c
+++ b/drivers/espi/espi_taf_npcx.c
@@ -18,7 +18,15 @@
 
 LOG_MODULE_REGISTER(espi_taf, CONFIG_ESPI_LOG_LEVEL);
 
-static const struct device *const spi_dev = DEVICE_DT_GET(DT_ALIAS(taf_flash));
+#define NPCX_TAF_PRIME_FLASH_NODE DT_ALIAS(taf_flash)
+#define NPCX_TAF_SEC_FLASH_NODE   DT_ALIAS(taf_flash1)
+
+#define NPCX_TAF_ALLOC_SIZE(node) (MB(1) << DT_ENUM_IDX(node, spi_dev_size))
+
+static const struct device *const spi_dev = DEVICE_DT_GET(NPCX_TAF_PRIME_FLASH_NODE);
+#if DT_NODE_HAS_STATUS_OKAY(NPCX_TAF_SEC_FLASH_NODE)
+static const struct device *const spi_dev1 = DEVICE_DT_GET(NPCX_TAF_SEC_FLASH_NODE);
+#endif
 
 enum ESPI_TAF_ERASE_LEN {
 	NPCX_ESPI_TAF_ERASE_LEN_4KB,
@@ -52,6 +60,11 @@ struct espi_taf_npcx_data {
 	uint32_t src[16];
 	uint8_t read_buf[MAX_TX_PAYLOAD_SIZE];
 	struct k_work work;
+#if DT_NODE_HAS_STATUS_OKAY(NPCX_TAF_SEC_FLASH_NODE)
+	const struct device *low_dev_ptr;
+	const struct device *high_dev_ptr;
+	uint32_t low_dev_size;
+#endif
 };
 
 static struct espi_taf_npcx_data npcx_espi_taf_data;
@@ -236,6 +249,11 @@ static bool espi_taf_npcx_channel_ready(const struct device *dev)
 	if (!device_is_ready(spi_dev)) {
 		return false;
 	}
+#if DT_NODE_HAS_STATUS_OKAY(NPCX_TAF_SEC_FLASH_NODE)
+	if (!device_is_ready(spi_dev1)) {
+		return false;
+	}
+#endif
 
 	return true;
 }
@@ -362,7 +380,34 @@ static int espi_taf_npcx_flash_read(const struct device *dev, struct espi_saf_pa
 	}
 
 	do {
+#if DT_NODE_HAS_STATUS_OKAY(NPCX_TAF_SEC_FLASH_NODE)
+		if ((addr + len) <= npcx_espi_taf_data.low_dev_size) {
+			rc = flash_read(npcx_espi_taf_data.low_dev_ptr, addr,
+					npcx_espi_taf_data.read_buf, len);
+		} else if (addr >= npcx_espi_taf_data.low_dev_size) {
+			rc = flash_read(npcx_espi_taf_data.high_dev_ptr,
+					(addr - npcx_espi_taf_data.low_dev_size),
+					npcx_espi_taf_data.read_buf, len);
+		} else {
+			rc = flash_read(npcx_espi_taf_data.low_dev_ptr, addr,
+					npcx_espi_taf_data.read_buf,
+					(npcx_espi_taf_data.low_dev_size.low_dev_size - addr));
+
+			if (rc) {
+				LOG_ERR("flash read fail 0x%x", rc);
+				return -EIO;
+			}
+
+			uint32_t index = low_dev_size - addr;
+
+			rc = flash_read(
+				npcx_espi_taf_data.high_dev_ptr, 0x0,
+				&npcx_espi_taf_data.read_buf[index],
+				(addr + len - npcx_espi_taf_data.low_dev_size.low_dev_size));
+		}
+#else
 		rc = flash_read(spi_dev, addr, npcx_espi_taf_data.read_buf, len);
+#endif
 		if (rc) {
 			LOG_ERR("flash read fail 0x%x", rc);
 			return -EIO;
@@ -394,6 +439,8 @@ static int espi_taf_npcx_flash_write(const struct device *dev, struct espi_saf_p
 {
 	struct espi_taf_npcx_pckt *taf_data_ptr = (struct espi_taf_npcx_pckt *)pckt->buf;
 	uint8_t *data_ptr = (uint8_t *)(taf_data_ptr->data);
+	uint32_t addr = pckt->flash_addr;
+	uint32_t len = pckt->len;
 	int rc;
 
 	if (espi_taf_check_write_protect(dev, pckt->flash_addr,
@@ -402,7 +449,19 @@ static int espi_taf_npcx_flash_write(const struct device *dev, struct espi_saf_p
 		return -EINVAL;
 	}
 
-	rc = flash_write(spi_dev, pckt->flash_addr, data_ptr, pckt->len);
+#if DT_NODE_HAS_STATUS_OKAY(NPCX_TAF_SEC_FLASH_NODE)
+	if ((addr + len) <= npcx_espi_taf_data.low_dev_size) {
+		rc = flash_write(npcx_espi_taf_data.low_dev_ptr, addr, data_ptr, len);
+	} else if (addr >= npcx_espi_taf_data.low_dev_size) {
+		rc = flash_write(npcx_espi_taf_data.high_dev_ptr,
+				 (addr - npcx_espi_taf_data.low_dev_size), data_ptr, len);
+	} else {
+		LOG_ERR("Write across two flashes");
+		return -EINVAL;
+	}
+#else
+	rc = flash_write(spi_dev, addr, data_ptr, len);
+#endif
 	if (rc) {
 		LOG_ERR("flash write fail 0x%x", rc);
 		return -EIO;
@@ -438,7 +497,19 @@ static int espi_taf_npcx_flash_erase(const struct device *dev, struct espi_saf_p
 		return -EINVAL;
 	}
 
+#if DT_NODE_HAS_STATUS_OKAY(NPCX_TAF_SEC_FLASH_NODE)
+	if ((addr + len) <= npcx_espi_taf_data.low_dev_size) {
+		rc = flash_erase(npcx_espi_taf_data.low_dev_ptr, addr, len);
+	} else if (addr >= npcx_espi_taf_data.low_dev_size) {
+		rc = flash_erase(npcx_espi_taf_data.high_dev_ptr,
+				 (addr - npcx_espi_taf_data.low_dev_size), len);
+	} else {
+		LOG_ERR("Erase across two flashes");
+		return -EINVAL;
+	}
+#else
 	rc = flash_erase(spi_dev, addr, len);
+#endif
 	if (rc) {
 		LOG_ERR("flash erase fail");
 		return -EIO;
@@ -619,6 +690,18 @@ static int espi_taf_npcx_init(const struct device *dev)
 	SET_FIELD(inst->FLASHCFG, NPCX_FLASHCFG_FLREQSUP,
 		  config->max_rd_sz);
 	inst->FLASHBASE = config->mapped_addr;
+
+#if DT_NODE_HAS_STATUS_OKAY(NPCX_TAF_SEC_FLASH_NODE)
+	if (IS_ENABLED(CONFIG_FLASH_NPCX_FIU_SUPP_LOW_DEV_SWAP)) {
+		npcx_espi_taf_data.low_dev_ptr = spi_dev1;
+		npcx_espi_taf_data.high_dev_ptr = spi_dev;
+		npcx_espi_taf_data.low_dev_size = NPCX_TAF_ALLOC_SIZE(NPCX_TAF_SEC_FLASH_NODE);
+	} else {
+		npcx_espi_taf_data.low_dev_ptr = spi_dev;
+		npcx_espi_taf_data.high_dev_ptr = spi_dev1;
+		npcx_espi_taf_data.low_dev_size = NPCX_TAF_ALLOC_SIZE(NPCX_TAF_PRIME_FLASH_NODE);
+	}
+#endif
 
 #ifdef CONFIG_ESPI_TAF_NPCX_RPMC_SUPPORT
 	uint8_t count_num = 0;

--- a/drivers/flash/Kconfig.npcx_fiu
+++ b/drivers/flash/Kconfig.npcx_fiu
@@ -65,4 +65,12 @@ config FLASH_NPCX_FIU_SUPP_DRA_2_DEV
 	  Selected if NPCX series supports two external SPI devices in Direct
 	  Read Access (DRA) on QSPI bus.
 
+DT_NPCX_FIU_LOW_DEV_SWAP := $(dt_nodelabel_bool_prop,qspi_fiu1,flash-dev-inv)
+config FLASH_NPCX_FIU_SUPP_LOW_DEV_SWAP
+	bool "Inverse the access of the two external flashes"
+	default y if SOC_SERIES_NPCX4 && FLASH_NPCX_FIU_SUPP_DRA_2_DEV && \
+		     "$(DT_NPCX_FIU_LOW_DEV_SWAP)"
+	help
+	  Select if it needs to swap the access of the two external flashes.
+
 endif #FLASH_NPCX_FIU_QSPI

--- a/drivers/flash/flash_npcx_fiu_qspi.h
+++ b/drivers/flash/flash_npcx_fiu_qspi.h
@@ -25,6 +25,20 @@ extern "C" {
 #define NPCX_DEV_NUM_ADDR_3BYTE 3
 #define NPCX_DEV_NUM_ADDR_4BYTE 4
 
+#define NPCX_SPI_F_CS0 0
+#define NPCX_SPI_F_CS1 1
+
+enum NPCX_SPI_DEV_SIZE {
+	NPCX_SPI_DEV_SIZE_1M,
+	NPCX_SPI_DEV_SIZE_2M,
+	NPCX_SPI_DEV_SIZE_4M,
+	NPCX_SPI_DEV_SIZE_8M,
+	NPCX_SPI_DEV_SIZE_16M,
+	NPCX_SPI_DEV_SIZE_32M,
+	NPCX_SPI_DEV_SIZE_64M,
+	NPCX_SPI_DEV_SIZE_128M,
+};
+
 /* UMA operation configuration for a SPI device */
 struct npcx_uma_cfg {
 	uint8_t opcode;
@@ -48,6 +62,8 @@ struct npcx_qspi_cfg {
 	uint8_t enter_4ba;
 	/* SPI read access type of Direct Read Access mode */
 	uint8_t rd_mode;
+	bool is_logical_low_dev;
+	uint8_t spi_dev_sz;
 	/* Configurations for the Quad-SPI peripherals */
 	int flags;
 };
@@ -80,6 +96,16 @@ void qspi_npcx_fiu_mutex_lock_configure(const struct device *dev,
  * @param dev Pointer to the device structure for qspi bus controller instance.
  */
 void qspi_npcx_fiu_mutex_unlock(const struct device *dev);
+
+#if defined(CONFIG_FLASH_NPCX_FIU_DRA_V2)
+/**
+ * @brief Set the size of the address space allocated for SPI device.
+ *
+ * @param dev Pointer to the device structure for qspi bus controller instance.
+ * @param cfg Pointer to the configuration for the device on qspi bus.
+ */
+void qspi_npcx_fiu_set_spi_size(const struct device *dev, const struct npcx_qspi_cfg *cfg);
+#endif
 
 #ifdef __cplusplus
 }

--- a/dts/bindings/flash_controller/nuvoton,npcx-fiu-nor.yaml
+++ b/dts/bindings/flash_controller/nuvoton,npcx-fiu-nor.yaml
@@ -47,3 +47,17 @@ properties:
       - "NPCX_RD_MODE_NORMAL" # Direct read access by command code 03h
       - "NPCX_RD_MODE_FAST" # Direct read access by command code 0bh
       - "NPCX_RD_MODE_FAST_DUAL" # Direct read access by command code bbh
+  spi-dev-size:
+    type: string
+    description: |
+      Select the size of the address space allocated for SPI device. This affects
+      the address space for any direct flash access.
+    enum:
+      - "NPCX_SPI_DEV_SIZE_1M"
+      - "NPCX_SPI_DEV_SIZE_2M"
+      - "NPCX_SPI_DEV_SIZE_4M"
+      - "NPCX_SPI_DEV_SIZE_8M"
+      - "NPCX_SPI_DEV_SIZE_16M"
+      - "NPCX_SPI_DEV_SIZE_32M"
+      - "NPCX_SPI_DEV_SIZE_64M"
+      - "NPCX_SPI_DEV_SIZE_128M"

--- a/dts/bindings/flash_controller/nuvoton,npcx-fiu-qspi.yaml
+++ b/dts/bindings/flash_controller/nuvoton,npcx-fiu-qspi.yaml
@@ -38,3 +38,7 @@ properties:
     type: boolean
     description: |
       Two external SPI devices are supported for Direct Read Access (DRA) on QSPI bus.
+  flash-dev-inv:
+    type: boolean
+    description: |
+      Inverse the device connected to the base address.

--- a/soc/nuvoton/npcx/npcx4/soc.h
+++ b/soc/nuvoton/npcx/npcx4/soc.h
@@ -38,6 +38,7 @@
 
 /* NPCX4 FIU register fields */
 #define NPCX_FIU_EXT_CFG_SPI1_2DEV	6
+#define NPCX_FIU_EXT_CFG_LOW_DEV_NUM	7
 
 /* NPCX4 supported group mask of DEVALT_LK */
 #define NPCX_DEVALT_LK_GROUP_MASK \


### PR DESCRIPTION
These changes enable eSPI TAF to access two flash devices. Additionally, a new property, "flash-dev-inv," determines whether to swap the flash devices' access order. If the swapping feature needs to be enabled, the flash-dev-inv property must be added at the qspi_fiu layer in the device tree.

Here is an example.
```
&qspi_fiu1 {
status = "okay";
...
flash-dev-inv;
...
};
```