### PR TITLE
sensor: remove PM state checks from API functions

### DIFF
--- a/drivers/sensor/amd_sb_tsi/sb_tsi.c
+++ b/drivers/sensor/amd_sb_tsi/sb_tsi.c
@@ -30,13 +30,7 @@ static int sb_tsi_sample_fetch(const struct device *dev,
 {
 	struct sb_tsi_data *data = dev->data;
 	const struct sb_tsi_config *config = dev->config;
-	enum pm_device_state pm_state;
 	int res;
-
-	(void)pm_device_state_get(dev, &pm_state);
-	if (pm_state != PM_DEVICE_STATE_ACTIVE) {
-		return -EIO;
-	}
 
 	if (chan != SENSOR_CHAN_ALL && chan != SENSOR_CHAN_AMBIENT_TEMP) {
 		return -ENOTSUP;

--- a/drivers/sensor/bosch/bme280/bme280.c
+++ b/drivers/sensor/bosch/bme280/bme280.c
@@ -168,15 +168,6 @@ int bme280_sample_fetch_helper(const struct device *dev,
 
 	__ASSERT_NO_MSG(chan == SENSOR_CHAN_ALL);
 
-#ifdef CONFIG_PM_DEVICE
-	enum pm_device_state state;
-	(void)pm_device_state_get(dev, &state);
-	/* Do not allow sample fetching from suspended state */
-	if (state == PM_DEVICE_STATE_SUSPENDED) {
-		return -EIO;
-	}
-#endif
-
 #ifdef CONFIG_BME280_MODE_FORCED
 	ret = bme280_reg_write(dev, BME280_REG_CTRL_MEAS, BME280_CTRL_MEAS_VAL);
 	if (ret < 0) {

--- a/drivers/sensor/bosch/bmi08x/bmi08x_accel.c
+++ b/drivers/sensor/bosch/bmi08x/bmi08x_accel.c
@@ -341,15 +341,6 @@ static int bmi08x_acc_config(const struct device *dev, enum sensor_channel chan,
 static int bmi08x_attr_set(const struct device *dev, enum sensor_channel chan,
 			   enum sensor_attribute attr, const struct sensor_value *val)
 {
-#ifdef CONFIG_PM_DEVICE
-	enum pm_device_state state;
-
-	(void)pm_device_state_get(dev, &state);
-	if (state != PM_DEVICE_STATE_ACTIVE) {
-		return -EBUSY;
-	}
-#endif
-
 	switch (chan) {
 	case SENSOR_CHAN_ACCEL_X:
 	case SENSOR_CHAN_ACCEL_Y:
@@ -372,15 +363,6 @@ static int bmi08x_sample_fetch(const struct device *dev, enum sensor_channel cha
 		LOG_DBG("Unsupported sensor channel");
 		return -ENOTSUP;
 	}
-
-#ifdef CONFIG_PM_DEVICE
-	enum pm_device_state state;
-
-	(void)pm_device_state_get(dev, &state);
-	if (state != PM_DEVICE_STATE_ACTIVE) {
-		return -EBUSY;
-	}
-#endif
 
 	pm_device_busy_set(dev);
 
@@ -498,15 +480,6 @@ static int bmi08x_temp_channel_get(const struct device *dev, struct sensor_value
 static int bmi08x_channel_get(const struct device *dev, enum sensor_channel chan,
 			      struct sensor_value *val)
 {
-#ifdef CONFIG_PM_DEVICE
-	enum pm_device_state state;
-
-	(void)pm_device_state_get(dev, &state);
-	if (state != PM_DEVICE_STATE_ACTIVE) {
-		return -EBUSY;
-	}
-#endif
-
 	switch ((int16_t)chan) {
 	case SENSOR_CHAN_ACCEL_X:
 	case SENSOR_CHAN_ACCEL_Y:

--- a/drivers/sensor/bosch/bmi08x/bmi08x_accel_trigger.c
+++ b/drivers/sensor/bosch/bmi08x/bmi08x_accel_trigger.c
@@ -20,15 +20,6 @@ static void bmi08x_handle_drdy_acc(const struct device *dev)
 {
 	struct bmi08x_accel_data *data = dev->data;
 
-#ifdef CONFIG_PM_DEVICE
-	enum pm_device_state state;
-
-	(void)pm_device_state_get(dev, &state);
-	if (state != PM_DEVICE_STATE_ACTIVE) {
-		return;
-	}
-#endif
-
 	if (data->handler_drdy_acc) {
 		data->handler_drdy_acc(dev, data->drdy_trig_acc);
 	}

--- a/drivers/sensor/bosch/bmi08x/bmi08x_gyro.c
+++ b/drivers/sensor/bosch/bmi08x/bmi08x_gyro.c
@@ -199,15 +199,6 @@ static int bmi08x_gyr_config(const struct device *dev, enum sensor_channel chan,
 static int bmi08x_attr_set(const struct device *dev, enum sensor_channel chan,
 			   enum sensor_attribute attr, const struct sensor_value *val)
 {
-#ifdef CONFIG_PM_DEVICE
-	enum pm_device_state state;
-
-	(void)pm_device_state_get(dev, &state);
-	if (state != PM_DEVICE_STATE_ACTIVE) {
-		return -EBUSY;
-	}
-#endif
-
 	switch (chan) {
 	case SENSOR_CHAN_GYRO_X:
 	case SENSOR_CHAN_GYRO_Y:
@@ -298,15 +289,6 @@ static inline void bmi08x_gyr_channel_get(const struct device *dev, enum sensor_
 static int bmi08x_channel_get(const struct device *dev, enum sensor_channel chan,
 			      struct sensor_value *val)
 {
-#ifdef CONFIG_PM_DEVICE
-	enum pm_device_state state;
-
-	(void)pm_device_state_get(dev, &state);
-	if (state != PM_DEVICE_STATE_ACTIVE) {
-		return -EBUSY;
-	}
-#endif
-
 	switch ((int16_t)chan) {
 	case SENSOR_CHAN_GYRO_X:
 	case SENSOR_CHAN_GYRO_Y:

--- a/drivers/sensor/bosch/bmi08x/bmi08x_gyro_trigger.c
+++ b/drivers/sensor/bosch/bmi08x/bmi08x_gyro_trigger.c
@@ -20,15 +20,6 @@ static void bmi08x_handle_drdy_gyr(const struct device *dev)
 {
 	struct bmi08x_gyro_data *data = dev->data;
 
-#ifdef CONFIG_PM_DEVICE
-	enum pm_device_state state;
-
-	(void)pm_device_state_get(dev, &state);
-	if (state != PM_DEVICE_STATE_ACTIVE) {
-		return;
-	}
-#endif
-
 	if (data->handler_drdy_gyr) {
 		data->handler_drdy_gyr(dev, data->drdy_trig_gyr);
 	}

--- a/drivers/sensor/bosch/bmi160/bmi160.c
+++ b/drivers/sensor/bosch/bmi160/bmi160.c
@@ -853,14 +853,6 @@ static int bmi160_sample_fetch(const struct device *dev,
 	uint8_t status;
 	size_t i;
 	int ret = 0;
-	enum pm_device_state pm_state;
-
-	(void)pm_device_state_get(dev, &pm_state);
-	if (pm_state != PM_DEVICE_STATE_ACTIVE) {
-		LOG_DBG("Device is suspended, fetch is unavailable");
-		ret = -EIO;
-		goto out;
-	}
 
 	if (chan == SENSOR_CHAN_DIE_TEMP) {
 		/* Die temperature is only valid when at least one measurement is active */

--- a/drivers/sensor/bosch/bmm150/bmm150_trigger.c
+++ b/drivers/sensor/bosch/bmm150/bmm150_trigger.c
@@ -85,15 +85,6 @@ int bmm150_trigger_set(
 	struct bmm150_data *data = dev->data;
 	const struct bmm150_config *cfg = dev->config;
 
-#ifdef CONFIG_PM_DEVICE
-	enum pm_device_state state;
-
-	(void)pm_device_state_get(dev, &state);
-	if (state != PM_DEVICE_STATE_ACTIVE) {
-		return -EBUSY;
-	}
-#endif
-
 	if (trig->type != SENSOR_TRIG_DATA_READY) {
 		return -ENOTSUP;
 	}

--- a/drivers/sensor/bosch/bmm350/bmm350_trigger.c
+++ b/drivers/sensor/bosch/bmm350/bmm350_trigger.c
@@ -72,15 +72,6 @@ int bmm350_trigger_set(const struct device *dev, const struct sensor_trigger *tr
 	struct bmm350_data *data = dev->data;
 	int ret = 0;
 
-#ifdef CONFIG_PM_DEVICE
-	enum pm_device_state state;
-
-	(void)pm_device_state_get(dev, &state);
-	if (state != PM_DEVICE_STATE_ACTIVE) {
-		return -EBUSY;
-	}
-#endif
-
 	if (trig->type != SENSOR_TRIG_DATA_READY) {
 		return -ENOTSUP;
 	}

--- a/drivers/sensor/bosch/bmp180/bmp180.c
+++ b/drivers/sensor/bosch/bmp180/bmp180.c
@@ -105,15 +105,6 @@ static int bmp180_attr_set(const struct device *dev, enum sensor_channel chan,
 {
 	int ret;
 
-#ifdef CONFIG_PM_DEVICE
-	enum pm_device_state state;
-
-	(void)pm_device_state_get(dev, &state);
-	if (state != PM_DEVICE_STATE_ACTIVE) {
-		return -EBUSY;
-	}
-#endif /* CONFIG_PM_DEVICE */
-
 	switch (attr) {
 #ifdef CONFIG_BMP180_OSR_RUNTIME
 	case SENSOR_ATTR_OVERSAMPLING:
@@ -250,15 +241,6 @@ static int bmp180_sample_fetch(const struct device *dev,
 	int ret = 0;
 
 	__ASSERT_NO_MSG(chan == SENSOR_CHAN_ALL);
-
-#ifdef CONFIG_PM_DEVICE
-	enum pm_device_state state;
-
-	(void)pm_device_state_get(dev, &state);
-	if (state != PM_DEVICE_STATE_ACTIVE) {
-		return -EBUSY;
-	}
-#endif /* CONFIG_PM_DEVICE */
 
 	pm_device_busy_set(dev);
 

--- a/drivers/sensor/bosch/bmp388/bmp388.c
+++ b/drivers/sensor/bosch/bmp388/bmp388.c
@@ -195,15 +195,6 @@ static int bmp388_attr_set(const struct device *dev,
 {
 	int ret;
 
-#ifdef CONFIG_PM_DEVICE
-	enum pm_device_state state;
-
-	(void)pm_device_state_get(dev, &state);
-	if (state != PM_DEVICE_STATE_ACTIVE) {
-		return -EBUSY;
-	}
-#endif
-
 	switch (attr) {
 #ifdef CONFIG_BMP388_ODR_RUNTIME
 	case SENSOR_ATTR_SAMPLING_FREQUENCY:
@@ -232,15 +223,6 @@ static int bmp388_sample_fetch(const struct device *dev,
 	int ret = 0;
 
 	__ASSERT_NO_MSG(chan == SENSOR_CHAN_ALL);
-
-#ifdef CONFIG_PM_DEVICE
-	enum pm_device_state state;
-
-	(void)pm_device_state_get(dev, &state);
-	if (state != PM_DEVICE_STATE_ACTIVE) {
-		return -EBUSY;
-	}
-#endif
 
 	pm_device_busy_set(dev);
 

--- a/drivers/sensor/bosch/bmp388/bmp388_trigger.c
+++ b/drivers/sensor/bosch/bmp388/bmp388_trigger.c
@@ -83,15 +83,6 @@ int bmp388_trigger_set(
 {
 	struct bmp388_data *data = dev->data;
 
-#ifdef CONFIG_PM_DEVICE
-	enum pm_device_state state;
-
-	(void)pm_device_state_get(dev, &state);
-	if (state != PM_DEVICE_STATE_ACTIVE) {
-		return -EBUSY;
-	}
-#endif
-
 	if (trig->type != SENSOR_TRIG_DATA_READY) {
 		return -ENOTSUP;
 	}

--- a/drivers/sensor/f75303/f75303.c
+++ b/drivers/sensor/f75303/f75303.c
@@ -79,13 +79,7 @@ static int f75303_fetch_remote2(const struct device *dev)
 static int f75303_sample_fetch(const struct device *dev,
 			       enum sensor_channel chan)
 {
-	enum pm_device_state pm_state;
 	int res;
-
-	(void)pm_device_state_get(dev, &pm_state);
-	if (pm_state != PM_DEVICE_STATE_ACTIVE) {
-		return -EIO;
-	}
 
 	switch ((uint32_t)chan) {
 	case SENSOR_CHAN_ALL:

--- a/drivers/sensor/lm75/lm75.c
+++ b/drivers/sensor/lm75/lm75.c
@@ -270,14 +270,7 @@ static inline int lm75_fetch_temp(const struct device *dev)
 
 static int lm75_sample_fetch(const struct device *dev, enum sensor_channel chan)
 {
-	enum pm_device_state pm_state;
 	int ret;
-
-	(void)pm_device_state_get(dev, &pm_state);
-	if (pm_state != PM_DEVICE_STATE_ACTIVE) {
-		ret = -EIO;
-		return ret;
-	}
 
 	switch (chan) {
 	case SENSOR_CHAN_ALL:

--- a/drivers/sensor/ntc_thermistor/ntc_thermistor.c
+++ b/drivers/sensor/ntc_thermistor/ntc_thermistor.c
@@ -29,7 +29,6 @@ static int ntc_thermistor_sample_fetch(const struct device *dev, enum sensor_cha
 {
 	struct ntc_thermistor_data *data = dev->data;
 	const struct ntc_thermistor_config *cfg = dev->config;
-	enum pm_device_state pm_state;
 	int res;
 	struct adc_sequence sequence = {
 		.options = NULL,
@@ -37,11 +36,6 @@ static int ntc_thermistor_sample_fetch(const struct device *dev, enum sensor_cha
 		.buffer_size = sizeof(data->raw),
 		.calibrate = false,
 	};
-
-	(void)pm_device_state_get(dev, &pm_state);
-	if (pm_state != PM_DEVICE_STATE_ACTIVE) {
-		return -EIO;
-	}
 
 	k_mutex_lock(&data->mutex, K_FOREVER);
 

--- a/drivers/sensor/silabs/si7210/si7210.c
+++ b/drivers/sensor/silabs/si7210/si7210.c
@@ -328,15 +328,6 @@ static int si7210_sample_fetch(const struct device *dev, enum sensor_channel cha
 			chan == SENSOR_CHAN_AMBIENT_TEMP ||
 			chan == SENSOR_CHAN_MAGN_Z);
 
-#ifdef CONFIG_PM_DEVICE
-	enum pm_device_state state;
-	(void)pm_device_state_get(dev, &state);
-	/* Do not allow sample fetching from suspended state */
-	if (state == PM_DEVICE_STATE_SUSPENDED) {
-		return -EIO;
-	}
-#endif
-
 	/* Prevent going into suspend in the middle of the conversion */
 	pm_device_busy_set(dev);
 

--- a/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x.c
+++ b/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x.c
@@ -25,17 +25,6 @@
 
 LOG_MODULE_REGISTER(LSM6DSV16X, CONFIG_SENSOR_LOG_LEVEL);
 
-bool lsm6dsv16x_is_active(const struct device *dev)
-{
-#if defined(CONFIG_PM_DEVICE)
-	enum pm_device_state state;
-	(void)pm_device_state_get(dev, &state);
-	return (state == PM_DEVICE_STATE_ACTIVE);
-#else
-	return true;
-#endif /* CONFIG_PM_DEVICE*/
-}
-
 /*
  * values taken from lsm6dsv16x_data_rate_t in hal/st module. The mode/accuracy
  * should be selected through accel-odr property in DT
@@ -437,10 +426,6 @@ static int lsm6dsv16x_attr_set(const struct device *dev,
 	struct lsm6dsv16x_data *data = dev->data;
 #endif /* CONFIG_LSM6DSV16X_SENSORHUB */
 
-	if (!lsm6dsv16x_is_active(dev)) {
-		return -EBUSY;
-	}
-
 	switch (chan) {
 	case SENSOR_CHAN_ACCEL_XYZ:
 		return lsm6dsv16x_accel_config(dev, chan, attr, val);
@@ -640,10 +625,6 @@ static int lsm6dsv16x_gyro_get_config(const struct device *dev,
 static int lsm6dsv16x_attr_get(const struct device *dev, enum sensor_channel chan,
 			       enum sensor_attribute attr, struct sensor_value *val)
 {
-	if (!lsm6dsv16x_is_active(dev)) {
-		return -EBUSY;
-	}
-
 	switch (chan) {
 	case SENSOR_CHAN_ACCEL_XYZ:
 		return lsm6dsv16x_accel_get_config(dev, chan, attr, val);
@@ -723,10 +704,6 @@ static int lsm6dsv16x_sample_fetch(const struct device *dev,
 #if defined(CONFIG_LSM6DSV16X_SENSORHUB)
 	struct lsm6dsv16x_data *data = dev->data;
 #endif /* CONFIG_LSM6DSV16X_SENSORHUB */
-
-	if (!lsm6dsv16x_is_active(dev)) {
-		return -EBUSY;
-	}
 
 	switch (chan) {
 	case SENSOR_CHAN_ACCEL_XYZ:
@@ -998,10 +975,6 @@ static int lsm6dsv16x_channel_get(const struct device *dev,
 			       struct sensor_value *val)
 {
 	struct lsm6dsv16x_data *data = dev->data;
-
-	if (!lsm6dsv16x_is_active(dev)) {
-		return -EBUSY;
-	}
 
 	switch (chan) {
 	case SENSOR_CHAN_ACCEL_X:

--- a/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x.h
+++ b/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x.h
@@ -37,8 +37,6 @@
 #include <zephyr/drivers/i3c.h>
 #endif /* LSM6DSVXXX_ANY_INST_ON_BUS_STATUS_OKAY(i3c) */
 
-bool lsm6dsv16x_is_active(const struct device *dev);
-
 #if LSM6DSVXXX_ANY_INST_ON_BUS_STATUS_OKAY(i3c)
 #define ON_I3C_BUS(cfg)  (cfg->i3c.bus != NULL)
 #define I3C_INT_PIN(cfg) (cfg->int_en_i3c)

--- a/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x_rtio.c
+++ b/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x_rtio.c
@@ -154,10 +154,6 @@ void lsm6dsv16x_submit_sync(struct rtio_iodev_sqe *iodev_sqe)
 
 void lsm6dsv16x_submit(const struct device *dev, struct rtio_iodev_sqe *iodev_sqe)
 {
-	if (!lsm6dsv16x_is_active(dev)) {
-		return;
-	}
-
 	struct rtio_work_req *req = rtio_work_req_alloc();
 
 	if (req == NULL) {

--- a/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x_trigger.c
+++ b/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x_trigger.c
@@ -178,10 +178,6 @@ int lsm6dsv16x_trigger_set(const struct device *dev,
 		return -EINVAL;
 	}
 
-	if (!lsm6dsv16x_is_active(dev)) {
-		return -EBUSY;
-	}
-
 	switch (trig->type) {
 	case SENSOR_TRIG_DATA_READY:
 		if (trig->chan == SENSOR_CHAN_ACCEL_XYZ) {

--- a/drivers/sensor/ti/bq274xx/bq274xx_trigger.c
+++ b/drivers/sensor/ti/bq274xx/bq274xx_trigger.c
@@ -112,15 +112,6 @@ int bq274xx_trigger_set(const struct device *dev,
 	struct bq274xx_data *data = dev->data;
 	int ret;
 
-#ifdef CONFIG_BQ274XX_PM
-	enum pm_device_state state;
-
-	(void)pm_device_state_get(dev, &state);
-	if (state != PM_DEVICE_STATE_ACTIVE) {
-		return -EBUSY;
-	}
-#endif
-
 	if (trig->type != SENSOR_TRIG_DATA_READY) {
 		return -ENOTSUP;
 	}

--- a/drivers/sensor/ti/fdc2x1x/fdc2x1x.c
+++ b/drivers/sensor/ti/fdc2x1x/fdc2x1x.c
@@ -608,16 +608,6 @@ static int fdc2x1x_get_cap_data(const struct device *dev)
 static int fdc2x1x_sample_fetch(const struct device *dev,
 				enum sensor_channel chan)
 {
-#ifdef CONFIG_PM_DEVICE
-	enum pm_device_state state;
-
-	(void)pm_device_state_get(dev, &state);
-	if (state != PM_DEVICE_STATE_ACTIVE) {
-		LOG_ERR("Sample fetch failed, device is not in active mode");
-		return -ENXIO;
-	}
-#endif
-
 	return fdc2x1x_get_cap_data(dev);
 }
 

--- a/drivers/sensor/ti/fdc2x1x/fdc2x1x_trigger.c
+++ b/drivers/sensor/ti/fdc2x1x/fdc2x1x_trigger.c
@@ -23,16 +23,6 @@ static void fdc2x1x_thread_cb(const struct device *dev)
 	struct fdc2x1x_data *drv_data = dev->data;
 	uint16_t status;
 
-#ifdef CONFIG_PM_DEVICE
-	enum pm_device_state state;
-
-	/* INTB asserts after exiting shutdown mode. Drop this interrupt */
-	(void)pm_device_state_get(dev, &state);
-	if (state == PM_DEVICE_STATE_OFF) {
-		return;
-	}
-#endif
-
 	/* Clear the status */
 	if (fdc2x1x_get_status(dev, &status) < 0) {
 		LOG_ERR("Unable to get status.");

--- a/drivers/sensor/ti/lm95234/lm95234.c
+++ b/drivers/sensor/ti/lm95234/lm95234.c
@@ -135,14 +135,7 @@ static int lm95234_sample_fetch(const struct device *dev,
 {
 	struct lm95234_data *data = dev->data;
 	const struct lm95234_config *cfg = dev->config;
-	enum pm_device_state pm_state;
 	int ret;
-
-	(void)pm_device_state_get(dev, &pm_state);
-	if (pm_state != PM_DEVICE_STATE_ACTIVE) {
-		ret = -EIO;
-		return ret;
-	}
 
 	switch ((uint32_t)chan) {
 	case SENSOR_CHAN_ALL:

--- a/drivers/sensor/ti/tmag5170/tmag5170_trigger.c
+++ b/drivers/sensor/ti/tmag5170/tmag5170_trigger.c
@@ -79,15 +79,6 @@ int tmag5170_trigger_set(
 {
 	struct tmag5170_data *data = dev->data;
 
-#if defined(CONFIG_PM_DEVICE)
-	enum pm_device_state state;
-
-	(void)pm_device_state_get(dev, &state);
-	if (state != PM_DEVICE_STATE_ACTIVE) {
-		return -EBUSY;
-	}
-#endif
-
 	if (trig->type != SENSOR_TRIG_DATA_READY) {
 		return -ENOTSUP;
 	}

--- a/drivers/sensor/vishay/vcnl36825t/vcnl36825t.c
+++ b/drivers/sensor/vishay/vcnl36825t/vcnl36825t.c
@@ -152,15 +152,6 @@ static int vcnl36825t_sample_fetch(const struct device *dev, enum sensor_channel
 	struct vcnl36825t_data *data = dev->data;
 	int rc;
 
-#if CONFIG_PM_DEVICE
-	enum pm_device_state state;
-
-	(void)pm_device_state_get(dev, &state);
-	if (state != PM_DEVICE_STATE_ACTIVE) {
-		return -EBUSY;
-	}
-#endif
-
 	switch (chan) {
 	case SENSOR_CHAN_ALL:
 	case SENSOR_CHAN_PROX:


### PR DESCRIPTION
Calling sensor API functions on devices not in `PM_DEVICE_STATE_ACTIVE` is a violation of the PM API. Adding manual checks inside of drivers complicates the drivers and increases ROM footprint for no additional benefit.