### PR TITLE
i2c: nrfx_twim: mark as `PM_DEVICE_ISR_SAFE`

### DIFF
--- a/drivers/i2c/i2c_nrfx_twim.c
+++ b/drivers/i2c/i2c_nrfx_twim.c
@@ -258,7 +258,8 @@ static const struct i2c_driver_api i2c_nrfx_twim_driver_api = {
 		.max_transfer_size = BIT_MASK(				       \
 				DT_PROP(I2C(idx), easydma_maxcnt_bits)),       \
 	};								       \
-	PM_DEVICE_DT_DEFINE(I2C(idx), twim_nrfx_pm_action);		       \
+	PM_DEVICE_DT_DEFINE(I2C(idx), twim_nrfx_pm_action,                     \
+			PM_DEVICE_ISR_SAFE);                                   \
 	I2C_DEVICE_DT_DEFINE(I2C(idx),					       \
 		      i2c_nrfx_twim_init,				       \
 		      PM_DEVICE_DT_GET(I2C(idx)),			       \

--- a/drivers/i2c/i2c_nrfx_twim_rtio.c
+++ b/drivers/i2c/i2c_nrfx_twim_rtio.c
@@ -210,7 +210,7 @@ int i2c_nrfx_twim_rtio_init(const struct device *dev)
 			},                                                                         \
 		.ctx = &_i2c##idx##_twim_rtio,                                                     \
 	};                                                                                         \
-	PM_DEVICE_DT_DEFINE(I2C(idx), twim_nrfx_pm_action);                                        \
+	PM_DEVICE_DT_DEFINE(I2C(idx), twim_nrfx_pm_action, PM_DEVICE_ISR_SAFE);                    \
 	I2C_DEVICE_DT_DEFINE(I2C(idx), i2c_nrfx_twim_rtio_init, PM_DEVICE_DT_GET(I2C(idx)), NULL,  \
 			     &twim_##idx##z_config, POST_KERNEL, CONFIG_I2C_INIT_PRIORITY,         \
 			     &i2c_nrfx_twim_driver_api)


### PR DESCRIPTION
Mark the I2C instances as `PM_DEVICE_ISR_SAFE`, as the transition operations are short, it saves RAM resources, and the spin-locking fixes the non-atomic behaviour of the PM usage counter.