### PR TITLE
tests: gpio: basic_api: not use pull up if it is not supported

### DIFF
--- a/tests/drivers/gpio/gpio_basic_api/src/test_gpio_port.c
+++ b/tests/drivers/gpio/gpio_basic_api/src/test_gpio_port.c
@@ -116,6 +116,10 @@ static int setup(void)
 
 	/* Test output high */
 	rc = gpio_pin_configure(dev_out, PIN_OUT, GPIO_OUTPUT_HIGH | GPIO_PULL_UP);
+	if (rc == -ENOTSUP) {
+		TC_PRINT("NOTE: pull-up not supported; trying as output high\n");
+		rc = gpio_pin_configure(dev_out, PIN_OUT, GPIO_OUTPUT_HIGH);
+	}
 	zassert_equal(rc, 0,
 		      "pin config output high failed");
 


### PR DESCRIPTION
Don't use pull_up if it is not supported by GPIO controller, so that can make the test is not broken.