### PR TITLE
drivers: npcx: use CONFIG_XXX_LOG_LEVEL to set driver log level

### DIFF
--- a/drivers/clock_control/clock_control_npcx.c
+++ b/drivers/clock_control/clock_control_npcx.c
@@ -11,7 +11,7 @@
 #include <zephyr/dt-bindings/clock/npcx_clock.h>
 
 #include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(clock_control_npcx, LOG_LEVEL_ERR);
+LOG_MODULE_REGISTER(clock_control_npcx, CONFIG_CLOCK_CONTROL_LOG_LEVEL);
 
 /* Driver config */
 struct npcx_pcc_config {

--- a/drivers/espi/host_subs_npcx.c
+++ b/drivers/espi/host_subs_npcx.c
@@ -127,7 +127,7 @@
 
 #include <zephyr/logging/log.h>
 #include <zephyr/irq.h>
-LOG_MODULE_REGISTER(host_sub_npcx, LOG_LEVEL_ERR);
+LOG_MODULE_REGISTER(host_sub_npcx, CONFIG_ESPI_LOG_LEVEL);
 
 struct host_sub_npcx_config {
 	/* host module instances */
@@ -897,9 +897,9 @@ int npcx_host_periph_write_request(enum lpc_peripheral_opcode op,
 			return -ENOTSUP;
 		}
 		if (data) {
-			LOG_INF("%s: op 0x%x data %x", __func__, op, *data);
+			LOG_DBG("op 0x%x data %x", op, *data);
 		} else {
-			LOG_INF("%s: op 0x%x only", __func__, op);
+			LOG_DBG("op 0x%x only", op);
 		}
 
 		switch (op) {

--- a/drivers/flash/flash_npcx_fiu_qspi.c
+++ b/drivers/flash/flash_npcx_fiu_qspi.c
@@ -16,7 +16,7 @@
 #include "flash_npcx_fiu_qspi.h"
 
 #include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(npcx_fiu_qspi, LOG_LEVEL_ERR);
+LOG_MODULE_REGISTER(npcx_fiu_qspi, CONFIG_FLASH_LOG_LEVEL);
 
 /* Driver convenience defines */
 #define HAL_INSTANCE(dev) \

--- a/drivers/gpio/gpio_npcx.c
+++ b/drivers/gpio/gpio_npcx.c
@@ -17,7 +17,7 @@
 #include "soc_miwu.h"
 
 #include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(gpio_npcx, LOG_LEVEL_ERR);
+LOG_MODULE_REGISTER(gpio_npcx, CONFIG_GPIO_LOG_LEVEL);
 
 /* GPIO module instances */
 #define NPCX_GPIO_DEV(inst) DEVICE_DT_INST_GET(inst),

--- a/drivers/i2c/i2c_npcx_controller.c
+++ b/drivers/i2c/i2c_npcx_controller.c
@@ -76,7 +76,7 @@
 
 #include <zephyr/logging/log.h>
 #include <zephyr/irq.h>
-LOG_MODULE_REGISTER(i2c_npcx, LOG_LEVEL_ERR);
+LOG_MODULE_REGISTER(i2c_npcx, CONFIG_I2C_LOG_LEVEL);
 
 /* I2C controller mode */
 #define NPCX_I2C_BANK_NORMAL 0

--- a/drivers/i2c/i2c_npcx_port.c
+++ b/drivers/i2c/i2c_npcx_port.c
@@ -36,7 +36,7 @@
 #include <soc.h>
 
 #include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(i2c_npcx_port, LOG_LEVEL_ERR);
+LOG_MODULE_REGISTER(i2c_npcx_port, CONFIG_I2C_LOG_LEVEL);
 
 #include "i2c_npcx_controller.h"
 #include "i2c-priv.h"

--- a/drivers/pwm/pwm_npcx.c
+++ b/drivers/pwm/pwm_npcx.c
@@ -15,7 +15,7 @@
 
 #include <zephyr/logging/log.h>
 
-LOG_MODULE_REGISTER(pwm_npcx, LOG_LEVEL_ERR);
+LOG_MODULE_REGISTER(pwm_npcx, CONFIG_PWM_LOG_LEVEL);
 
 /* 16-bit period cycles/prescaler in NPCX PWM modules */
 #define NPCX_PWM_MAX_PRESCALER      (1UL << (16))


### PR DESCRIPTION
This PR replaces the hard-coded log level with CONFIG_XXX_LOG_LEVEL to set NPCX driver's log level.