### PR TITLE
boards: nrf7002dk: Fix SR coexistence GPIOs ownership

### DIFF
--- a/boards/nordic/nrf7002dk/nrf5340_cpuapp_common.dtsi
+++ b/boards/nordic/nrf7002dk/nrf5340_cpuapp_common.dtsi
@@ -111,6 +111,15 @@
 		mcuboot-led0 = &led0;
 		watchdog0 = &wdt0;
 	};
+
+	nrf_radio_coex: coex {
+		status = "okay";
+		compatible = "nordic,nrf7002-coex";
+		req-gpios = <&gpio0 28 GPIO_ACTIVE_HIGH>;
+		status0-gpios = <&gpio0 30 GPIO_ACTIVE_HIGH>;
+		grant-gpios = <&gpio0 24 (GPIO_PULL_DOWN | GPIO_ACTIVE_LOW)>;
+		swctrl1-gpios = <&gpio0 29 GPIO_ACTIVE_HIGH>;
+	};
 };
 
 &vregmain {


### PR DESCRIPTION
In nRF53 SoC, the CPUAPP owns all the GPIOs by default. Therefore, even if the GPIOs are exclusively used by CPUNET, we must redefine them for CPUAPP and then set up GPIO forwarding to CPUNET using SoC registers (this is done as part of the MPSL CX initialization).

Previously, these GPIOs were mistakenly removed from CPUAPP and defined only for CPUNET. This caused the GPIOs to be
available for CPUNET but still owned by CPUAPP, breaking SR coexistence.
