### PR TITLE
twister: reports: use Path instead of PosixPath

### DIFF
--- a/scripts/pylib/twister/twisterlib/reports.py
+++ b/scripts/pylib/twister/twisterlib/reports.py
@@ -11,7 +11,7 @@ import string
 import xml.etree.ElementTree as ET
 from datetime import datetime
 from enum import Enum
-from pathlib import PosixPath
+from pathlib import Path, PosixPath
 
 from colorama import Fore
 from twisterlib.statuses import TwisterStatus
@@ -171,7 +171,7 @@ class Reporting:
             runnable = suite.get('runnable', 0)
             duration += float(handler_time)
             ts_status = TwisterStatus(suite.get('status'))
-            classname = PosixPath(suite.get("name","")).name
+            classname = Path(suite.get("name","")).name
             for tc in suite.get("testcases", []):
                 status = TwisterStatus(tc.get('status'))
                 reason = tc.get('reason', suite.get('reason', 'Unknown'))
@@ -253,7 +253,7 @@ class Reporting:
                 ):
                     continue
                 if full_report:
-                    classname = PosixPath(ts.get("name","")).name
+                    classname = Path(ts.get("name","")).name
                     for tc in ts.get("testcases", []):
                         status = TwisterStatus(tc.get('status'))
                         reason = tc.get('reason', ts.get('reason', 'Unknown'))


### PR DESCRIPTION
Directly instantiating a PosixPath is not allowed on Windows, use Path instead.
Fixes bug introduced with https://github.com/zephyrproject-rtos/zephyr/commit/c5c4165f68776519b38e5ac9e30a3b1c824588f3 (PR #82302) that breaks "Hello World" CI on Windows