### PR TITLE
boards: google: add google_icetower board

### DIFF
--- a/boards/google/icetower/Kconfig.google_icetower
+++ b/boards/google/icetower/Kconfig.google_icetower
@@ -1,0 +1,5 @@
+# Copyright (c) 2024 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+config BOARD_GOOGLE_ICETOWER
+	select SOC_STM32H743XX

--- a/boards/google/icetower/board.cmake
+++ b/boards/google/icetower/board.cmake
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# keep first
+board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw")
+board_runner_args(jlink "--device=STM32H743VI" "--speed=4000")
+board_runner_args(openocd --target-handle=_CHIPNAME.cpu0)
+
+# keep first
+include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/google/icetower/board.yml
+++ b/boards/google/icetower/board.yml
@@ -1,0 +1,6 @@
+board:
+  name: google_icetower
+  full_name: Icetower Development Board
+  vendor: google
+  socs:
+    - name: stm32h743xx

--- a/boards/google/icetower/doc/index.rst
+++ b/boards/google/icetower/doc/index.rst
@@ -1,0 +1,47 @@
+.. zephyr:board:: google_icetower
+
+Overview
+********
+
+Google Icetower Development Board is a board created by Google for
+fingerprint-related functionality development.
+
+Board has connectors for fingerprint sensors. Console is exposed over `μServo`_
+connector. MCU can be flashed using μServo or SWD.
+
+Hardware
+********
+
+- STM32H7A3VIT6 LQFP100 package
+
+Pin Mapping
+===========
+
+Default Zephyr Peripheral Mapping:
+----------------------------------
+- USART_1 TX/RX : PA9/PA10
+- SPI_1 CS/CLK/MISO/MOSI : PA4/PA5/PA6/PA7
+- SPI_4 CS/CLK/MISO/MOSI : PE11/PE12/PE13/PE14
+
+Programming and Debugging
+*************************
+
+Build application as usual for the ``google_icetower`` board, and flash
+using μServo or an external J-Link connected to J4. If μServo is used, please
+follow the `Chromium EC Flashing Documentation`_.
+
+Debugging
+=========
+
+Use SWD with a J-Link or ST-Link. Remember that SW2 must be set to CORESIGHT.
+
+References
+**********
+
+.. target-notes::
+
+.. _Chromium EC Flashing Documentation:
+   https://chromium.googlesource.com/chromiumos/platform/ec#Flashing-via-the-servo-debug-board
+
+.. _μServo:
+   https://chromium.googlesource.com/chromiumos/third_party/hdctools/+/master/docs/servo_micro.md

--- a/boards/google/icetower/google_icetower.dts
+++ b/boards/google/icetower/google_icetower.dts
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2024 Google LLC
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/dts-v1/;
+
+#include <st/h7/stm32h743Xi.dtsi>
+#include <st/h7/stm32h743vitx-pinctrl.dtsi>
+
+/ {
+	model = "Google Icetower development board";
+	compatible = "google,icetower-fpmcu";
+
+	chosen {
+		zephyr,console = &usart1;
+		zephyr,shell-uart = &usart1;
+		zephyr,sram = &sram0;
+		zephyr,flash = &flash0;
+	};
+};
+
+&clk_lsi {
+	/* LSI clock frequency is 32kHz */
+	status = "okay";
+};
+
+&clk_hsi {
+	status = "okay";
+	hsi-div = <1>;
+	clock-frequency = <DT_FREQ_M(64)>;
+};
+
+&rcc {
+	clocks = <&clk_hsi>;
+	clock-frequency = <DT_FREQ_M(64)>;
+	d1cpre = <1>;
+	hpre = <1>;
+	d1ppre = <1>;
+	d2ppre1 = <1>;
+	d2ppre2 = <1>;
+	d3ppre = <1>;
+};
+
+/* USART1: Servo UART (console) */
+&usart1 {
+	pinctrl-0 = <&usart1_tx_pa9 &usart1_rx_pa10>;
+	pinctrl-names = "default";
+	current-speed = <115200>;
+	status = "okay";
+};
+
+/* SPI1: communication with the AP */
+&spi1 {
+	pinctrl-0 = <&spi1_nss_pa4 &spi1_sck_pa5
+		     &spi1_miso_pa6 &spi1_mosi_pa7>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
+/* SPI4: communication with the fingerprint sensor */
+&spi4 {
+	pinctrl-0 = <&spi4_nss_pe11 &spi4_sck_pe12
+		     &spi4_miso_pe13 &spi4_mosi_pe14>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
+&rtc {
+	clocks = <&rcc STM32_CLOCK_BUS_APB4 0x00010000>,
+		 <&rcc STM32_SRC_LSI RTC_SEL(2)>;
+	status = "okay";
+
+	backup_regs {
+		status = "okay";
+	};
+};

--- a/boards/google/icetower/google_icetower.yaml
+++ b/boards/google/icetower/google_icetower.yaml
@@ -1,0 +1,19 @@
+identifier: google_icetower
+name: Google Icetower Development Board
+type: mcu
+arch: arm
+toolchain:
+  - zephyr
+  - gnuarmemb
+  - xtools
+ram: 1024
+flash: 2048
+vendor: google
+supported:
+  - counter
+  - dma
+  - gpio
+  - i2c
+  - spi
+  - pwm
+  - rtc

--- a/boards/google/icetower/google_icetower_defconfig
+++ b/boards/google/icetower/google_icetower_defconfig
@@ -1,0 +1,17 @@
+# Copyright (c) 2024 Google Inc
+# SPDX-License-Identifier: Apache-2.0
+
+# Serial Drivers
+CONFIG_SERIAL=y
+CONFIG_UART_INTERRUPT_DRIVEN=y
+
+# Console
+CONFIG_CONSOLE=y
+CONFIG_UART_CONSOLE=y
+
+# GPIO Controller
+CONFIG_GPIO=y
+
+# Enable MPU and HW stack protection
+CONFIG_ARM_MPU=y
+CONFIG_HW_STACK_PROTECTION=y


### PR DESCRIPTION
Introduce Google Icetower Development Board.
Icetower is a board created by Google for fingerprint-related functionality development.