### PR TITLE
twister: add dt_node_prop_enabled support

### DIFF
--- a/samples/boards/nxp/mimxrt1170_evk_cm7/magic_addr/sample.yaml
+++ b/samples/boards/nxp/mimxrt1170_evk_cm7/magic_addr/sample.yaml
@@ -1,5 +1,5 @@
 sample:
-  description: RT1170 FLEXRAM Magic Addr example
+  description: RT11xx FLEXRAM Magic Addr example
   name: magic addr
 common:
   integration_platforms:
@@ -8,6 +8,6 @@ common:
   tags:
     - pytest
 tests:
-  sample.boards.mimxrt1170_evk.magic_addr:
-    filter: CONFIG_MEMC_NXP_FLEXRAM
+  sample.boards.magic_addr:
+    filter: dt_node_prop_enabled("flexram", "flexram,has-magic-addr")
     harness: pytest

--- a/scripts/pylib/twister/expr_parser.py
+++ b/scripts/pylib/twister/expr_parser.py
@@ -273,6 +273,14 @@ def ast_expr(ast, env, edt):
         if node and node.status == "okay":
             return True
         return False
+    elif ast[0] == "dt_node_prop_enabled":
+        label = ast[1][0]
+        node = edt.label2node.get(label)
+        prop = ast[1][1]
+        if node and prop in node.props and node.props[prop].val:
+            return True
+        return False
+
 
 mutex = threading.Lock()
 


### PR DESCRIPTION
using "dt_node_prop_enabled" to filter out supported platforms
1. check node existing.
2. check prop in node.
3. check the prop is True.

fixes: #83036