### PR TITLE
include: drivers: clock_control stm32 bus clock index can exceed 256

### DIFF
--- a/include/zephyr/drivers/clock_control/stm32_clock_control.h
+++ b/include/zephyr/drivers/clock_control/stm32_clock_control.h
@@ -444,7 +444,8 @@ struct stm32_pclken {
 #define STM32_CLOCK_INFO(clk_index, node_id)				\
 	{								\
 	.enr = DT_CLOCKS_CELL_BY_IDX(node_id, clk_index, bits),		\
-	.bus = DT_CLOCKS_CELL_BY_IDX(node_id, clk_index, bus) & 0xff,	\
+	.bus = DT_CLOCKS_CELL_BY_IDX(node_id, clk_index, bus) &         \
+		GENMASK(STM32_CLOCK_DIV_SHIFT - 1, 0),                   \
 	.div = DT_CLOCKS_CELL_BY_IDX(node_id, clk_index, bus) >>	\
 		STM32_CLOCK_DIV_SHIFT,					\
 	}


### PR DESCRIPTION
For some stm32 devices, especially the stm32H7RS serie, the RCC register map is larger that 256 (example  AHB1 is 0x138). The mask is extended to 512 in the .bus of the clock info structure.

