### PR TITLE
dts: bindings: display: gc9x01x: Update example and documentation

### DIFF
--- a/dts/bindings/display/galaxycore,gc9x01x.yaml
+++ b/dts/bindings/display/galaxycore,gc9x01x.yaml
@@ -13,17 +13,26 @@ description: |
 
   Here is an example to define a display interface:
 
-  &spi2 {
-    gc9a01a_lcd: gc9a01a_lcd@0 {
-      compatible = "galaxycore,gc9x01x";
-      reg = <0>;
-      spi-max-frequency = <100000000>;
-      cmd-data-gpios = <&gpio0 4 GPIO_ACTIVE_HIGH>;
-      reset-gpios = <&gpio0 8 GPIO_ACTIVE_LOW>;
-      pixel-format = <PANEL_PIXEL_FORMAT_RGB_565>;
-      width = <240>;
-      height = <240>;
-    };
+  / {
+      my_mipi_dbi {
+          compatible = "zephyr,mipi-dbi-spi";
+          status = "okay";
+          #address-cells = <1>;
+          #size-cells = <0>;
+          spi-dev = <&spi2>;
+          dc-gpios = <&gpio0 4 GPIO_ACTIVE_HIGH>;
+          reset-gpios = <&gpio0 8 GPIO_ACTIVE_LOW>;
+
+          gc9x01x_lcd: gc9x01x_lcd@0 {
+              compatible = "galaxycore,gc9x01x";
+              reg = <0>;
+              mipi-max-frequency = <DT_FREQ_M(100)>;
+              pixel-format = <PANEL_PIXEL_FORMAT_RGB_565>;
+              width = <240>;
+              height = <240>;
+              display-inversion;
+          };
+      };
   };
 
 


### PR DESCRIPTION
Update the GC9X01X display driver binding documentation with the current MIPI DBI SPI binding structure. The old example used direct SPI device binding which is now deprecated in favor of the MIPI DBI API, see zephyrproject-rtos/zephyr@be23e70.