### PR TITLE
cmake: add scope support to script mode

### DIFF
--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -3251,8 +3251,9 @@ function(zephyr_get variable)
       set(sysbuild_global_${var})
     endif()
 
-    if(TARGET snippets_scope)
-      get_property(snippets_${var} TARGET snippets_scope PROPERTY ${var})
+    zephyr_scope_exists(scope_defined snippets)
+    if(scope_defined)
+      zephyr_get_scoped(snippets_${var} snippets ${var})
     endif()
   endforeach()
 
@@ -3317,11 +3318,54 @@ endfunction(zephyr_get variable)
 # <scope>: Name of new scope.
 #
 function(zephyr_create_scope scope)
-  if(TARGET ${scope}_scope)
+  zephyr_scope_exists(scope_defined ${scope})
+  if(scope_defined)
     message(FATAL_ERROR "zephyr_create_scope(${scope}) already exists.")
   endif()
 
-  add_custom_target(${scope}_scope)
+  set_property(GLOBAL PROPERTY scope:${scope} TRUE)
+endfunction()
+
+# Usage:
+#   zephyr_scope_exists(<result> <scope>)
+#
+# Check if <scope> exists.
+#
+# <result>: Variable to set with result.
+#           TRUE if scope exists, FALSE otherwise.
+# <scope> : Name of scope.
+#
+function(zephyr_scope_exists result scope)
+  get_property(scope_defined GLOBAL PROPERTY scope:${scope})
+  if(scope_defined)
+    set(${result} TRUE PARENT_SCOPE)
+  else()
+    set(${result} FALSE PARENT_SCOPE)
+  endif()
+endfunction()
+
+# Usage:
+#   zephyr_get_scoped(<output> <scope> <var>)
+#
+# Get the current value of <var> in a specific <scope>, as defined by a
+# previous zephyr_set() call. The value will be stored in the <output> var.
+#
+# <output> : Variable to store the value in
+# <scope>  : Scope for the variable look up
+# <var>    : Name to look up in the specific scope
+#
+function(zephyr_get_scoped output scope var)
+  zephyr_scope_exists(scope_defined ${scope})
+  if(NOT scope_defined)
+    message(FATAL_ERROR "zephyr_get_scoped(): scope ${scope} doesn't exists.")
+  endif()
+
+  get_property(value GLOBAL PROPERTY ${scope}_scope:${var})
+  if(DEFINED value)
+    set(${output} "${value}" PARENT_SCOPE)
+  else()
+    unset(${output} PARENT_SCOPE)
+  endif()
 endfunction()
 
 # Usage:
@@ -3342,7 +3386,8 @@ function(zephyr_set variable)
 
   zephyr_check_arguments_required_all(zephyr_set SET_VAR SCOPE)
 
-  if(NOT TARGET ${SET_VAR_SCOPE}_scope)
+  zephyr_scope_exists(scope_defined ${SET_VAR_SCOPE})
+  if(NOT scope_defined)
     message(FATAL_ERROR "zephyr_set(... SCOPE ${SET_VAR_SCOPE}) doesn't exists.")
   endif()
 
@@ -3350,8 +3395,8 @@ function(zephyr_set variable)
     set(property_args APPEND)
   endif()
 
-  set_property(TARGET ${SET_VAR_SCOPE}_scope ${property_args}
-               PROPERTY ${variable} ${SET_VAR_UNPARSED_ARGUMENTS}
+  set_property(GLOBAL ${property_args} PROPERTY
+               ${SET_VAR_SCOPE}_scope:${variable} ${SET_VAR_UNPARSED_ARGUMENTS}
   )
 endfunction()
 
@@ -5871,16 +5916,11 @@ if(CMAKE_SCRIPT_MODE_FILE)
     # This silence the error: 'set_target_properties command is not scriptable'
   endfunction()
 
-  function(zephyr_set variable)
-    # This silence the error: zephyr_set(...  SCOPE <scope>) doesn't exists.
-  endfunction()
-
   # Build info creates a custom target for handling of build info.
   # build_info is not needed in script mode but still called by Zephyr CMake
   # modules. Therefore disable build_info(...) in when including
   # extensions.cmake in script mode.
   function(build_info)
-    # This silence the error: 'YAML context 'build_info' does not exist.'
-    #                         'Remember to create a YAML context'
+    # This silence the error: 'Unknown CMake command "yaml_context"'
   endfunction()
 endif()

--- a/cmake/modules/yaml.cmake
+++ b/cmake/modules/yaml.cmake
@@ -93,7 +93,8 @@ function(yaml_context)
     )
   endif()
 
-  if(TARGET ${ARG_YAML_NAME}_scope)
+  zephyr_scope_exists(scope_defined ${ARG_YAML_NAME})
+  if(scope_defined)
     list(POP_FRONT ARG_YAML_UNPARSED_ARGUMENTS out-var)
     set(${out-var} TRUE PARENT_SCOPE)
   else()
@@ -183,7 +184,7 @@ function(yaml_get out_var)
   zephyr_check_arguments_required_all(${CMAKE_CURRENT_FUNCTION} ARG_YAML NAME KEY)
   internal_yaml_context_required(NAME ${ARG_YAML_NAME})
 
-  get_property(json_content TARGET ${ARG_YAML_NAME}_scope PROPERTY JSON)
+  zephyr_get_scoped(json_content ${ARG_YAML_NAME} JSON)
 
   # We specify error variable to avoid a fatal error.
   # If key is not found, then type becomes '-NOTFOUND' and value handling is done below.
@@ -224,7 +225,7 @@ function(yaml_length out_var)
   zephyr_check_arguments_required_all(${CMAKE_CURRENT_FUNCTION} ARG_YAML NAME KEY)
   internal_yaml_context_required(NAME ${ARG_YAML_NAME})
 
-  get_property(json_content TARGET ${ARG_YAML_NAME}_scope PROPERTY JSON)
+  zephyr_get_scoped(json_content ${ARG_YAML_NAME} JSON)
 
   string(JSON type ERROR_VARIABLE error TYPE "${json_content}" ${ARG_YAML_KEY})
   if(type STREQUAL ARRAY)
@@ -262,7 +263,7 @@ function(yaml_set)
   zephyr_check_arguments_exclusive(${CMAKE_CURRENT_FUNCTION} ARG_YAML VALUE LIST)
   internal_yaml_context_required(NAME ${ARG_YAML_NAME})
 
-  get_property(json_content TARGET ${ARG_YAML_NAME}_scope PROPERTY JSON)
+  zephyr_get_scoped(json_content ${ARG_YAML_NAME} JSON)
 
   set(yaml_key_undefined ${ARG_YAML_KEY})
   foreach(k ${yaml_key_undefined})
@@ -335,7 +336,7 @@ function(yaml_remove)
   zephyr_check_arguments_required_all(${CMAKE_CURRENT_FUNCTION} ARG_YAML NAME KEY)
   internal_yaml_context_required(NAME ${ARG_YAML_NAME})
 
-  get_property(json_content TARGET ${ARG_YAML_NAME}_scope PROPERTY JSON)
+  zephyr_get_scoped(json_content ${ARG_YAML_NAME} JSON)
   string(JSON json_content REMOVE "${json_content}" ${ARG_YAML_KEY})
 
   zephyr_set(JSON "${json_content}" SCOPE ${ARG_YAML_NAME})
@@ -359,18 +360,18 @@ function(yaml_save)
   zephyr_check_arguments_required(${CMAKE_CURRENT_FUNCTION} ARG_YAML NAME)
   internal_yaml_context_required(NAME ${ARG_YAML_NAME})
 
-  get_target_property(yaml_file ${ARG_YAML_NAME}_scope FILE)
+  zephyr_get_scoped(yaml_file ${ARG_YAML_NAME} FILE)
   if(NOT yaml_file)
     zephyr_check_arguments_required(${CMAKE_CURRENT_FUNCTION} ARG_YAML FILE)
   endif()
 
-  get_property(json_content TARGET ${ARG_YAML_NAME}_scope PROPERTY JSON)
+  zephyr_get_scoped(json_content ${ARG_YAML_NAME} JSON)
   to_yaml("${json_content}" 0 yaml_out)
 
   if(DEFINED ARG_YAML_FILE)
     set(yaml_file ${ARG_YAML_FILE})
   else()
-    get_property(yaml_file TARGET ${ARG_YAML_NAME}_scope PROPERTY FILE)
+    zephyr_get_scoped(yaml_file ${ARG_YAML_NAME} FILE)
   endif()
   if(EXISTS ${yaml_file})
     FILE(RENAME ${yaml_file} ${yaml_file}.bak)

--- a/tests/cmake/zephyr_get/CMakeLists.txt
+++ b/tests/cmake/zephyr_get/CMakeLists.txt
@@ -490,7 +490,8 @@ endfunction()
 
 
 function(test_snippets_scope)
-  if(NOT TARGET snippets_scope)
+  zephyr_scope_exists(snippets_defined snippets)
+  if(NOT snippets_defined)
     zephyr_create_scope(snippets)
   endif()
 

--- a/tests/cmake/zephyr_get/CMakeLists.txt
+++ b/tests/cmake/zephyr_get/CMakeLists.txt
@@ -2,9 +2,17 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
-project(zephyr_get_test)
-target_sources(app PRIVATE ${ZEPHYR_BASE}/misc/empty_file.c)
+if(CMAKE_SCRIPT_MODE_FILE)
+  # Script mode initialization (re-run)
+  set(ZEPHYR_BASE ${CMAKE_CURRENT_LIST_DIR}/../../../)
+  list(APPEND CMAKE_MODULE_PATH "${ZEPHYR_BASE}/cmake/modules")
+  include(extensions)
+else()
+  # Project mode initialization (main CMake invocation)
+  find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+  project(zephyr_get_test)
+  target_sources(app PRIVATE ${ZEPHYR_BASE}/misc/empty_file.c)
+endif()
 
 if(SYSBUILD)
   get_property(IMAGE_NAME TARGET sysbuild_cache PROPERTY SYSBUILD_NAME)
@@ -73,6 +81,9 @@ function(assert_equal variable expected_value)
   endif()
 
   set(info "${TEST_NAME}: ${variable} == '${actual_value}'")
+  if(CMAKE_SCRIPT_MODE_FILE)
+    string(PREPEND info "script mode ")
+  endif()
   if("${actual_value}" STREQUAL "${expected_value}")
     message("PASS: ${info}")
   else()
@@ -584,3 +595,8 @@ run_suite(
   test_merge_reverse
   test_snippets_scope
 )
+
+if (NOT CMAKE_SCRIPT_MODE_FILE AND NOT SYSBUILD)
+  # Re-run this testsuite in plain script mode
+  execute_process(COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_LIST_FILE})
+endif()


### PR DESCRIPTION
In CMake script mode, "targets" are an undefined concept, therefore no properties can be attached to them; those CMake functions are either silently ignored or result in errors. This means that `zephyr_set()` and any functionality that depends on it (e.g. the `yaml` module) is not usable in script mode.

This PR works around this limitation as #83199 by using `GLOBAL PROPERTY` instead of `TARGET` entities.
Two additional functions are introduced to offer a simplified access to the scope functionality:
* a `zephyr_exists_scope` macro to check if a scope exists; and 
* a `zephyr_get_scoped` function to retrieve scoped property values. 

These utility functions are then used in the current code to replace direct property retrieval and scope checks.

The current test suite for the `zephyr_get` API is modified to also run itself in script mode and detect any future issue.

This, along with #80007, is a prerequisite for the LLEXT EDK refactor in #78727. 