### PR TITLE
west.yml: MCUboot synchronization from upstream

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -295,7 +295,7 @@ manifest:
       groups:
         - crypto
     - name: mcuboot
-      revision: 5d6471bac184c8accaeeb0efcfad8dd35225a28d
+      revision: f5454f16358225f69ff729301c8e56d8a580f81a
       path: bootloader/mcuboot
       groups:
         - bootloader


### PR DESCRIPTION
Update Zephyr fork of MCUboot to revision:
  f5454f16358225f69ff729301c8e56d8a580f81a

Brings following Zephyr relevant fixes:
  - f5454f16 boot: bootutil: loader.c: Add check if has upgrade before pushing state change
  - 0946c7a7 boot: zephyr: boards: add ctcc/nrf52840 and ctcc/nrf9161 targets
  - 7ba0e552 boot: zephyr: nxp: Add NXP platforms to the allow list
  - 4f393563 bootutil: Fix device brick after power failure during swap-move revert
  - 2ac79767 bootutil: Fix the reading of image headers after partial swap completion
  - 84416fd2 boot: zephyr: boards: Add frdm-mcxa156 configuration
  - 15909d60 scripts: imgtool: fix sha512 for compression
  - f2a61462 boot: zephyr: boot_record: Save boot data with single image

Notes on process:
 1) The MCUboot update from [mcu-tools/mcuboot/main](https://github.com/mcu-tools/mcuboot/tree/main) with the SHA used in west.yaml is already synchronized to [zephyrproject-rtos/mcuboot/upstream-sync](https://github.com/zephyrproject-rtos/mcuboot/tree/upstream-sync) branch, and is available in the Zephyr fork of MCUboot.
 2) The [DNM] on this PR should be kept until the PR passes all tests and is accepted.
 3) Once the PR passes all tests and gets accepted, the upstream-sync branch should be fast-forward merged to [zephyrproject-rtos/mcuboot/main](https://github.com/zephyrproject-rtos/mcuboot/tree/main) branch and [DNM] should be removed.
 4) After the main branch gets updated, this PR does not require further changes and should be merged as is.