### PR TITLE
Prepare for i.MX8ULP DSP core support of openamp_rsc_table sample

### DIFF
--- a/dts/xtensa/nxp/nxp_imx8ulp.dtsi
+++ b/dts/xtensa/nxp/nxp_imx8ulp.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 NXP
+ * Copyright 2023-2025 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -17,16 +17,16 @@
 			device_type = "cpu";
 			compatible = "cdns,tensilica-xtensa-lx7";
 			reg = <0>;
-		};
 
-		#address-cells = <1>;
-		#size-cells = <0>;
+			#address-cells = <1>;
+			#size-cells = <0>;
 
-		clic: interrupt-controller@0 {
-			compatible = "cdns,xtensa-core-intc";
-			reg = <0>;
-			interrupt-controller;
-			#interrupt-cells = <3>;
+			clic: interrupt-controller@0 {
+				compatible = "cdns,xtensa-core-intc";
+				reg = <0>;
+				interrupt-controller;
+				#interrupt-cells = <3>;
+			};
 		};
 	};
 

--- a/dts/xtensa/nxp/nxp_imx8ulp.dtsi
+++ b/dts/xtensa/nxp/nxp_imx8ulp.dtsi
@@ -98,4 +98,14 @@
 		dai-index = <6>;
 		status = "disabled";
 	};
+
+	mu3: mbox@2da20000 {
+		compatible = "nxp,mbox-imx-mu";
+		reg = <0x2da20000 DT_SIZE_K(64)>;
+		interrupt-parent = <&clic>;
+		interrupts = <15 0 0>;
+		rx-channels = <4>;
+		#mbox-cells = <1>;
+		status = "disabled";
+	};
 };

--- a/soc/nxp/imx/imx8ulp/adsp/linker.ld
+++ b/soc/nxp/imx/imx8ulp/adsp/linker.ld
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 NXP
+ * Copyright 2023-2025 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -171,6 +171,13 @@ EXTERN(ext_man_fw_ver)
 
 SECTIONS
 {
+
+#ifdef CONFIG_OPENAMP_RSC_TABLE
+    SECTION_PROLOGUE(.resource_table,, SUBALIGN(4))
+    {
+      KEEP(*(.resource_table*))
+    } GROUP_LINK_IN(ROMABLE_REGION)
+#endif
 
 #include <zephyr/linker/rel-sections.ld>
 


### PR DESCRIPTION
Add mailbox and resource table section in linker to prepare for i.MX8ULP DSP core support of `openamp_rsc_table` sample.
While here, fix a compile warning.

This pull request is a heads-up about the `openamp_rsc_table` sample support, which has many dependencies
- address translation from driver to device - https://github.com/zephyrproject-rtos/zephyr/pull/84170;
- add support for vendor specific features - https://github.com/zephyrproject-rtos/zephyr/pull/87296;