### PR TITLE
drivers: gpio: Fix unchecked return value in gpio_pca_series

### DIFF
--- a/drivers/gpio/gpio_pca_series.c
+++ b/drivers/gpio/gpio_pca_series.c
@@ -376,7 +376,7 @@ static inline int gpio_pca_series_reg_write(const struct device *dev,
 
 #ifdef CONFIG_GPIO_PCA_SERIES_CACHE_ALL
 	if (gpio_pca_series_reg_cache_offset(dev, reg_type) != PCA_REG_INVALID) {
-		gpio_pca_series_reg_cache_update(dev, reg_type, buf);
+		(void)gpio_pca_series_reg_cache_update(dev, reg_type, buf);
 	}
 #endif /* CONFIG_GPIO_PCA_SERIES_CACHE_ALL */
 
@@ -853,11 +853,11 @@ void gpio_pca_series_cache_test(const struct device *dev)
 		expected_offset += cache_size;
 
 		LOG_WRN("testing reg %d size %d", reg_type,  cache_size);
-		gpio_pca_series_reg_cache_update(dev, reg_type, reset_value_0);
+		(void)gpio_pca_series_reg_cache_update(dev, reg_type, reset_value_0);
 		*buffer_p = 0;
 		gpio_pca_series_reg_cache_read(dev, reg_type, buffer);
 		LOG_WRN("fill 00, result: 0x%16.16x", *buffer_p);
-		gpio_pca_series_reg_cache_update(dev, reg_type, reset_value_1);
+		(void)gpio_pca_series_reg_cache_update(dev, reg_type, reset_value_1);
 		*buffer_p = 0;
 		gpio_pca_series_reg_cache_read(dev, reg_type, buffer);
 		LOG_WRN("fill ff, result: 0x%16.16x", *buffer_p);


### PR DESCRIPTION
Fix unchecked return value scanned by Coverity.