### PR TITLE
drivers: clock_control: stm32 ll common: fix RCC pll disable

### DIFF
--- a/drivers/clock_control/clock_stm32_ll_common.c
+++ b/drivers/clock_control/clock_stm32_ll_common.c
@@ -569,7 +569,11 @@ static void set_up_plls(void)
 		stm32_clock_switch_to_hsi();
 		LL_RCC_SetAHBPrescaler(ahb_prescaler(1));
 	}
+	/* Disable PLL */
 	LL_RCC_PLL_Disable();
+	while (LL_RCC_PLL_IsReady() != 0U) {
+		/* Wait for PLL to be disabled */
+	}
 
 #endif
 
@@ -580,6 +584,9 @@ static void set_up_plls(void)
 	 * since PLL source can be PLL2.
 	 */
 	LL_RCC_PLL2_Disable();
+	while (LL_RCC_PLL2_IsReady() != 0U) {
+		/* Wait for PLL2 to be disabled */
+	}
 
 	config_pll2();
 


### PR DESCRIPTION
The clock_stm32_ll_common.c function set_up_plls calls LL_RCC_PLL_Disable(); and it was not waiting for the disable to complete before trying to configure the pll sysclock which creates a race condition for pll configuration. The wait for re-enabling the RCC pll is already there, it was just missing the wait for the disable before configuration.