### PR TITLE
drivers: Move device driver APIs into iterable sections

### DIFF
--- a/drivers/gpio/gpio_ite_it8801.c
+++ b/drivers/gpio/gpio_ite_it8801.c
@@ -415,7 +415,7 @@ static int gpio_it8801_pin_interrupt_configure(const struct device *dev, gpio_pi
 	return ret;
 }
 
-static const struct gpio_driver_api gpio_it8801_driver_api = {
+static DEVICE_API(gpio, gpio_it8801_driver_api) = {
 	.pin_configure = gpio_it8801_configure,
 #ifdef CONFIG_GPIO_GET_CONFIG
 	.pin_get_config = gpio_it8801_get_config,

--- a/drivers/gpio/gpio_renesas_rz.c
+++ b/drivers/gpio/gpio_renesas_rz.c
@@ -409,7 +409,7 @@ static int gpio_rz_int_init(const struct device *dev)
 }
 #endif
 
-static const struct gpio_driver_api gpio_rz_driver_api = {
+static DEVICE_API(gpio, gpio_rz_driver_api) = {
 	.pin_configure = gpio_rz_pin_configure,
 #ifdef CONFIG_GPIO_GET_CONFIG
 	.pin_get_config = gpio_rz_pin_get_config,

--- a/drivers/pwm/pwm_ite_it8801.c
+++ b/drivers/pwm/pwm_ite_it8801.c
@@ -148,7 +148,7 @@ static int pwm_it8801_init(const struct device *dev)
 	return 0;
 }
 
-static const struct pwm_driver_api pwm_it8801_api = {
+static DEVICE_API(pwm, pwm_it8801_api) = {
 	.set_cycles = pwm_it8801_set_cycles,
 	.get_cycles_per_sec = pwm_it8801_get_cycles_per_sec,
 };

--- a/drivers/serial/uart_renesas_rz_scif.c
+++ b/drivers/serial/uart_renesas_rz_scif.c
@@ -197,7 +197,7 @@ static int uart_rz_scif_config_get(const struct device *dev, struct uart_config 
 
 #endif /* CONFIG_UART_USE_RUNTIME_CONFIGURE */
 
-static const struct uart_driver_api uart_rz_scif_driver_api = {
+static DEVICE_API(uart, uart_rz_scif_driver_api) = {
 	.poll_in = uart_rz_scif_poll_in,
 	.poll_out = uart_rz_scif_poll_out,
 	.err_check = uart_rz_scif_err_check,


### PR DESCRIPTION
These device driver APIs were merged after the DEVICE_API macro was introduced.
Cleanup these leftover drivers.