### PR TITLE
rtio: remove padding field `_resv0` from `struct rtio_sqe`

### DIFF
--- a/include/zephyr/rtio/rtio.h
+++ b/include/zephyr/rtio/rtio.h
@@ -292,8 +292,6 @@ struct rtio_sqe {
 
 	uint32_t iodev_flags; /**< Op iodev flags */
 
-	uint16_t _resv0;
-
 	const struct rtio_iodev *iodev; /**< Device to operation on */
 
 	/**


### PR DESCRIPTION
The `_resv0` field is no longer needed after increasing the size of `iodev_flags` from `uint16_t` to `uint32_t` by this PR #80177.