### PR TITLE
doc: Update to release notes update scope and purpose

### DIFF
--- a/doc/releases/index.rst
+++ b/doc/releases/index.rst
@@ -76,6 +76,11 @@ Changes that require the user to modify their own application to support the new
 release may be mentioned in the release notes, but the details regarding *what*
 needs to be changed are to be detailed in the release's migration guide.
 
+Updates to the release notes post release cycle is permitted but limited to
+style, typographical fixes and to upmerge the notes from maintenance release
+branches with the sole purpose of keeping the latest documentation consistent
+with the changes in the project.
+
 .. toctree::
    :maxdepth: 1
    :glob:


### PR DESCRIPTION
Update the scope and purpose of release notes to include style, typographical fixes and upmerge from maintainence releases to keep the latest documentation consistent with the changes in the project.