### PR TITLE
hostap: Enable WPA_CLI if WIFI_NM_WPA_SUPPLICANT_CLI is selected

### DIFF
--- a/modules/hostap/Kconfig
+++ b/modules/hostap/Kconfig
@@ -345,6 +345,7 @@ config WIFI_NM_WPA_SUPPLICANT_11AX
 
 config WPA_CLI
 	bool "WPA CLI support"
+	default y if WIFI_NM_WPA_SUPPLICANT_CLI
 	help
 	  Enable WPA CLI support for wpa_supplicant.
 


### PR DESCRIPTION
Use WIFI_NM_WPA_SUPPLICANT_CLI to better control the config of WPA_CLI.