### PR TITLE
net: wifi: hostap: add CA certificate used or skipped support

### DIFF
--- a/include/zephyr/net/wifi_mgmt.h
+++ b/include/zephyr/net/wifi_mgmt.h
@@ -569,6 +569,8 @@ struct wifi_connect_req_params {
 	const uint8_t *eap_password;
 	/** eap passwd length, max 128 */
 	uint8_t eap_passwd_length;
+	/** Whether verify peer with CA or not: false-not verify, true-verify. */
+	bool verify_peer_cert;
 	/** Fast BSS Transition used */
 	bool ft_used;
 	/** Number of EAP users */

--- a/modules/hostap/src/supp_api.c
+++ b/modules/hostap/src/supp_api.c
@@ -1233,15 +1233,19 @@ static int wpas_add_and_config_network(struct wpa_supplicant *wpa_s,
 				goto out;
 			}
 
-			if (wpas_config_process_blob(wpa_s->conf, "ca_cert",
-					   enterprise_creds.ca_cert,
-					   enterprise_creds.ca_cert_len)) {
-				goto out;
-			}
+			if (false == ((params->security == WIFI_SECURITY_TYPE_EAP_PEAP_MSCHAPV2 ||
+			    params->security == WIFI_SECURITY_TYPE_EAP_TTLS_MSCHAPV2) &&
+			    (!params->verify_peer_cert))) {
+				if (wpas_config_process_blob(wpa_s->conf, "ca_cert",
+						   enterprise_creds.ca_cert,
+						   enterprise_creds.ca_cert_len)) {
+					goto out;
+				}
 
-			if (!wpa_cli_cmd_v("set_network %d ca_cert \"blob://ca_cert\"",
-					   resp.network_id)) {
-				goto out;
+				if (!wpa_cli_cmd_v("set_network %d ca_cert \"blob://ca_cert\"",
+						   resp.network_id)) {
+					goto out;
+				}
 			}
 
 			if (wpas_config_process_blob(wpa_s->conf, "client_cert",

--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -599,6 +599,7 @@ static int __wifi_args_to_params(const struct shell *sh, size_t argc, char *argv
 		{"key2-pwd", required_argument, 0, 'K'},
 		{"wpa3-enterprise", required_argument, 0, 'S'},
 		{"TLS-cipher", required_argument, 0, 'T'},
+		{"verify-peer-cert", required_argument, 0, 'A'},
 		{"eap-version", required_argument, 0, 'V'},
 		{"eap-id1", required_argument, 0, 'I'},
 		{"eap-id2", required_argument, 0, 'I'},
@@ -644,8 +645,9 @@ static int __wifi_args_to_params(const struct shell *sh, size_t argc, char *argv
 	params->eap_ver = 1;
 	params->ignore_broadcast_ssid = 0;
 	params->bandwidth = WIFI_FREQ_BANDWIDTH_20MHZ;
+	params->verify_peer_cert = false;
 
-	while ((opt = getopt_long(argc, argv, "s:p:k:e:w:b:c:m:t:a:B:K:S:T:V:I:P:i:Rh",
+	while ((opt = getopt_long(argc, argv, "s:p:k:e:w:b:c:m:t:a:B:K:S:T:A:V:I:P:i:Rh",
 				  long_options, &opt_index)) != -1) {
 		state = getopt_state_get();
 		switch (opt) {
@@ -806,6 +808,11 @@ static int __wifi_args_to_params(const struct shell *sh, size_t argc, char *argv
 			break;
 		case 'T':
 			params->TLS_cipher = atoi(state->optarg);
+			break;
+		case 'A':
+			if (iface_mode == WIFI_MODE_INFRA) {
+				params->verify_peer_cert = !!atoi(state->optarg);
+			}
 			break;
 		case 'V':
 			params->eap_ver = atoi(state->optarg);
@@ -3693,6 +3700,8 @@ SHELL_SUBCMD_ADD((wifi), connect, NULL,
 		  "Default 0: Not WPA3 enterprise mode.\n"
 		  "1:Suite-b mode, 2:Suite-b-192-bit mode, 3:WPA3-enterprise-only mode.\n"
 		  "[-T, --TLS-cipher]: 0:TLS-NONE, 1:TLS-ECC-P384, 2:TLS-RSA-3K.\n"
+		  "[-A, --verify-peer-cert]: apply for EAP-PEAP-MSCHAPv2 and EAP-TTLS-MSCHAPv2\n"
+		  "Default 0. 0:not use CA to verify peer, 1:use CA to verify peer.\n"
 		  "[-V, --eap-version]: 0 or 1. Default 1: eap version 1.\n"
 		  "[-I, --eap-id1]: Client Identity. Default no eap identity.\n"
 		  "[-P, --eap-pwd1]: Client Password.\n"


### PR DESCRIPTION
Added new parameter "A" in wifi connect command to support CA certificate used or CA certificate skipped for
EAP-TTLS-MSCHAPV2 and EAP-PEAP-MSCHAPV2.