### PR TITLE
Bluetooth: New function, bt_le_is_advertising, that checks if BLE advertising is active.

### DIFF
--- a/include/zephyr/bluetooth/bluetooth.h
+++ b/include/zephyr/bluetooth/bluetooth.h
@@ -1278,6 +1278,13 @@ int bt_le_adv_update_data(const struct bt_data *ad, size_t ad_len,
 int bt_le_adv_stop(void);
 
 /**
+ * @brief Check if advertising is active.
+ * 
+ * @return True if advertising is active, false otherwise.
+ */
+bool bt_le_is_advertising();
+
+/**
  * @brief Create advertising set.
  *
  * Create a new advertising set and set advertising parameters.

--- a/subsys/bluetooth/host/adv.c
+++ b/subsys/bluetooth/host/adv.c
@@ -1458,6 +1458,12 @@ int bt_le_adv_stop(void)
 	return 0;
 }
 
+bool bt_le_is_advertising()
+{
+	struct bt_le_ext_adv *adv = bt_le_adv_lookup_legacy();
+	return adv && atomic_test_bit(adv->flags, BT_ADV_ENABLED);
+}
+
 #if defined(CONFIG_BT_PERIPHERAL)
 static uint32_t adv_get_options(const struct bt_le_ext_adv *adv)
 {


### PR DESCRIPTION
bt_le_is_advertising() uses the same logic as other functions in the same module when they check whether advertising is active.
Signed-off by: Olof Stacke <olof.stacke@thule.com>