### PR TITLE
dts: arm: nxp: fix build warning about memory address overlap for RT1180

### DIFF
--- a/dts/arm/nxp/nxp_rt118x.dtsi
+++ b/dts/arm/nxp/nxp_rt118x.dtsi
@@ -931,16 +931,16 @@
 &memory {
 	#address-cells = <1>;
 	#size-cells = <1>;
-	ocram1: ocram@484000 {
+	ocram1: ocram@0 {
 		compatible = "zephyr,memory-region", "mmio-sram";
 		zephyr,memory-region = "OCRAM1";
 		/* OCRAM1 first 16K access is blocked by TRDC */
-		reg = <0x484000 DT_SIZE_K(496)>;
+		reg = <0x0 DT_SIZE_K(496)>;
 	};
 
-	ocram2: ocram@500000 {
+	ocram2: ocram@7c000 {
 		compatible = "zephyr,memory-region", "mmio-sram";
 		zephyr,memory-region = "OCRAM2";
-		reg = <0x500000 DT_SIZE_K(256)>;
+		reg = <0x7c000 DT_SIZE_K(256)>;
 	};
 };

--- a/dts/arm/nxp/nxp_rt118x_cm33.dtsi
+++ b/dts/arm/nxp/nxp_rt118x_cm33.dtsi
@@ -22,8 +22,8 @@
 			zephyr,memory-region = "DTCM";
 		};
 
-		memory: memory@30000000 {
-			ranges = <0x0 0x30000000 0x10000000>;
+		memory: memory@30484000 {
+			ranges = <0x0 0x30484000 0x10000000>;
 		};
 
 		peripheral: peripheral@50000000 {

--- a/dts/arm/nxp/nxp_rt118x_cm33_ns.dtsi
+++ b/dts/arm/nxp/nxp_rt118x_cm33_ns.dtsi
@@ -22,8 +22,8 @@
 			zephyr,memory-region = "DTCM";
 		};
 
-		memory: memory@20000000 {
-			ranges = <0x0 0x20000000 0x10000000>;
+		memory: memory@20484000 {
+			ranges = <0x0 0x20484000 0x10000000>;
 		};
 
 		peripheral: peripheral@40000000 {

--- a/dts/arm/nxp/nxp_rt118x_cm7.dtsi
+++ b/dts/arm/nxp/nxp_rt118x_cm7.dtsi
@@ -19,8 +19,8 @@
 			reg = <0x20000000 DT_SIZE_K(256)>;
 		};
 
-		memory: memory@20000000 {
-			ranges = <0x0 0x20000000 0x10000000>;
+		memory: memory@20484000 {
+			ranges = <0x0 0x20484000 0x10000000>;
 		};
 
 		peripheral: peripheral@40000000 {


### PR DESCRIPTION
Change the start location of the parent node to avoid overlapping with the DTCM address.