### PR TITLE
boards: renesas: add missing input key codes for rzt2m buttons

### DIFF
--- a/boards/renesas/rzt2m_starterkit/rzt2m_starter_kit_renesas_rzt2m.dts
+++ b/boards/renesas/rzt2m_starterkit/rzt2m_starter_kit_renesas_rzt2m.dts
@@ -7,6 +7,7 @@
 /dts-v1/;
 #include <dt-bindings/pinctrl/renesas-rzt2m-pinctrl.h>
 #include <arm/renesas/rz/rzt2m.dtsi>
+#include <zephyr/dt-bindings/input/input-event-codes.h>
 
 / {
 	model = "RZT/2M Starter Kit";
@@ -48,10 +49,12 @@
 		sw1: sw1 {
 			label = "sw1";
 			gpios = <&gpio10 5 0>;
+			zephyr,code = <INPUT_KEY_0>;
 		};
 		sw2: sw2 {
 			label = "sw2";
 			gpios = <&gpio16 3 0>;
+			zephyr,code = <INPUT_KEY_1>;
 		};
 	};
 };


### PR DESCRIPTION
zephyr,code property is required for input subsystem to work