### PR TITLE
drivers: Narrow Band Unit interruption driver creation

### DIFF
--- a/boards/nxp/frdm_mcxw71/frdm_mcxw71.dts
+++ b/boards/nxp/frdm_mcxw71/frdm_mcxw71.dts
@@ -137,3 +137,8 @@
 	pinctrl-names = "default";
 	status = "okay";
 };
+
+&nbu {
+	status = "okay";
+	wakeup-source;
+};

--- a/boards/nxp/frdm_rw612/frdm_rw612_common.dtsi
+++ b/boards/nxp/frdm_rw612/frdm_rw612_common.dtsi
@@ -192,6 +192,11 @@
 	pinctrl-names = "default";
 };
 
+&nbu {
+	status = "okay";
+	wakeup-source;
+};
+
 zephyr_udc0: &usb_otg {
 	status = "okay";
 };

--- a/boards/nxp/rd_rw612_bga/rd_rw612_bga.dtsi
+++ b/boards/nxp/rd_rw612_bga/rd_rw612_bga.dtsi
@@ -294,12 +294,12 @@ nxp_8080_touch_panel_i2c: &arduino_i2c {
 	status = "disabled";
 };
 
-&hci {
-	status = "okay";
-	wakeup-source;
-};
-
 &pin1 {
 	status = "okay";
 	wakeup-level = "low";
+};
+
+&nbu {
+	status = "okay";
+	wakeup-source;
 };

--- a/drivers/bluetooth/hci/hci_nxp.c
+++ b/drivers/bluetooth/hci/hci_nxp.c
@@ -39,12 +39,6 @@ struct hci_data {
 #define LOG_LEVEL CONFIG_BT_HCI_DRIVER_LOG_LEVEL
 LOG_MODULE_REGISTER(bt_driver);
 
-#define HCI_IRQ_N        DT_INST_IRQ_BY_NAME(0, hci_int, irq)
-#define HCI_IRQ_P        DT_INST_IRQ_BY_NAME(0, hci_int, priority)
-#if DT_INST_IRQ_HAS_NAME(0, wakeup_int)
-#define HCI_WAKEUP_IRQ_N DT_INST_IRQ_BY_NAME(0, wakeup_int, irq)
-#define HCI_WAKEUP_IRQ_P DT_INST_IRQ_BY_NAME(0, wakeup_int, priority)
-#endif
 /* Vendor specific commands */
 #define HCI_CMD_STORE_BT_CAL_DATA_OCF                   0x61U
 #define HCI_CMD_STORE_BT_CAL_DATA_PARAM_LENGTH          32U
@@ -80,9 +74,6 @@ LOG_MODULE_REGISTER(bt_driver);
 /* -------------------------------------------------------------------------- */
 /*                              Public prototypes                             */
 /* -------------------------------------------------------------------------- */
-
-extern int32_t ble_hci_handler(void);
-extern int32_t ble_wakeup_done_handler(void);
 
 /* -------------------------------------------------------------------------- */
 /*                             Private functions                              */
@@ -545,18 +536,6 @@ static int bt_nxp_init(const struct device *dev)
 	int ret = 0;
 
 	ARG_UNUSED(dev);
-
-	/* HCI Interrupt */
-	IRQ_CONNECT(HCI_IRQ_N, HCI_IRQ_P, ble_hci_handler, 0, 0);
-	irq_enable(HCI_IRQ_N);
-#if DT_INST_IRQ_HAS_NAME(0, wakeup_int)
-	/* Wake up done interrupt */
-	IRQ_CONNECT(HCI_WAKEUP_IRQ_N, HCI_WAKEUP_IRQ_P, ble_wakeup_done_handler, 0, 0);
-	irq_enable(HCI_WAKEUP_IRQ_N);
-#endif
-#if (DT_INST_PROP(0, wakeup_source)) && CONFIG_PM
-	EnableDeepSleepIRQ(HCI_IRQ_N);
-#endif
 
 	do {
 		status = PLATFORM_InitBle();

--- a/drivers/hdlc_rcp_if/hdlc_rcp_if_nxp.c
+++ b/drivers/hdlc_rcp_if/hdlc_rcp_if_nxp.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NXP
+ * Copyright 2024 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -34,11 +34,6 @@
 #define LOG_LEVEL       CONFIG_HDLC_RCP_IF_DRIVER_LOG_LEVEL
 LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 
-#define HDLC_RCP_IF_IRQ_N        DT_INST_IRQ_BY_NAME(0, hdlc_rcp_if_int, irq)
-#define HDLC_RCP_IF_IRQ_P        DT_INST_IRQ_BY_NAME(0, hdlc_rcp_if_int, priority)
-#define HDLC_RCP_IF_WAKEUP_IRQ_N DT_INST_IRQ_BY_NAME(0, wakeup_int, irq)
-#define HDLC_RCP_IF_WAKEUP_IRQ_P DT_INST_IRQ_BY_NAME(0, wakeup_int, priority)
-
 struct ot_hdlc_rcp_context {
 	struct net_if *iface;
 	struct openthread_context *ot_context;
@@ -47,8 +42,6 @@ struct ot_hdlc_rcp_context {
 /* -------------------------------------------------------------------------- */
 /*                             Private prototypes                             */
 /* -------------------------------------------------------------------------- */
-extern int32_t hdlc_rcp_if_handler(void);
-extern int32_t hdlc_rcp_if_wakeup_done_handler(void);
 
 /* -------------------------------------------------------------------------- */
 /*                             Private functions                              */
@@ -58,15 +51,6 @@ static void hdlc_iface_init(struct net_if *iface)
 {
 	struct ot_hdlc_rcp_context *ctx = net_if_get_device(iface)->data;
 	otExtAddress eui64;
-
-	/* HDLC RCP interface Interrupt */
-	IRQ_CONNECT(HDLC_RCP_IF_IRQ_N, HDLC_RCP_IF_IRQ_P, hdlc_rcp_if_handler, 0, 0);
-	irq_enable(HDLC_RCP_IF_IRQ_N);
-
-	/* Wake up done interrupt */
-	IRQ_CONNECT(HDLC_RCP_IF_WAKEUP_IRQ_N, HDLC_RCP_IF_WAKEUP_IRQ_P,
-		    hdlc_rcp_if_wakeup_done_handler, 0, 0);
-	irq_enable(HDLC_RCP_IF_WAKEUP_IRQ_N);
 
 	ctx->iface = iface;
 

--- a/dts/arm/nxp/nxp_mcxw71.dtsi
+++ b/dts/arm/nxp/nxp_mcxw71.dtsi
@@ -19,6 +19,7 @@
 
 	chosen {
 		zephyr,bt-hci = &hci;
+		zephyr,nbu = &nbu;
 	};
 
 	cpus {
@@ -305,10 +306,14 @@
 		status = "disabled";
 	};
 
+	nbu: nbu {
+		compatible = "nxp,nbu";
+		interrupts = <48 2>;
+		interrupt-names = "nbu_rx_int";
+	};
+
 	hci: hci_ble {
 		compatible = "nxp,hci-ble";
-		interrupts = <48 2>;
-		interrupt-names = "hci_int";
 	};
 
 	flexcan0: can@3b000 {

--- a/dts/arm/nxp/nxp_rw6xx_common.dtsi
+++ b/dts/arm/nxp/nxp_rw6xx_common.dtsi
@@ -16,6 +16,7 @@
 / {
 	chosen {
 		zephyr,entropy = &trng;
+		zephyr,nbu = &nbu;
 		zephyr,bt-hci = &hci;
 		zephyr,hdlc-rcp-if = &hdlc_rcp_if;
 	};
@@ -515,17 +516,18 @@
 		status = "disabled";
 	};
 
+	nbu: nbu {
+		compatible = "nxp,nbu";
+		interrupts = <90 2>, <82 2>;
+		interrupt-names = "nbu_rx_int", "wakeup_int";
+	};
+
 	hci: hci_ble {
 		compatible = "nxp,hci-ble";
-		/* first index is the hci interrupt, the second is the wake up done interrupt */
-		interrupts = <90 2>, <82 2>;
-		interrupt-names = "hci_int", "wakeup_int";
 	};
 
 	hdlc_rcp_if: hdlc_rcp_if {
 		compatible = "nxp,hdlc-rcp-if";
-		/* first index is the hdlc_rcp_if interrupt */
-		/* the second is the wake up done interrupt */
 		interrupts = <90 2>, <82 2>;
 		interrupt-names = "hdlc_rcp_if_int", "wakeup_int";
 	};

--- a/dts/bindings/arm/nxp,nbu.yaml
+++ b/dts/bindings/arm/nxp,nbu.yaml
@@ -1,0 +1,16 @@
+# Copyright 2024 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+description: NXP NBU interruption information
+
+include: base.yaml
+
+compatible: "nxp,nbu"
+
+properties:
+  interrupts:
+    required: true
+  nbu-name:
+    default: "NBU NXP"
+    type: string
+    description: Name of the Narrow Band Unit interruption initialization

--- a/dts/bindings/bluetooth/nxp,hci-ble.yaml
+++ b/dts/bindings/bluetooth/nxp,hci-ble.yaml
@@ -8,8 +8,6 @@ compatible: "nxp,hci-ble"
 include: bt-hci.yaml
 
 properties:
-  interrupts:
-    required: true
   bt-hci-name:
     default: "BT NXP"
   bt-hci-bus:

--- a/soc/nxp/common/Kconfig.nbu
+++ b/soc/nxp/common/Kconfig.nbu
@@ -1,0 +1,9 @@
+# Copyright 2024 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+config NXP_NBU
+	bool
+	default y if BT || IEEE802154
+	depends on DT_HAS_NXP_NBU_ENABLED
+	help
+	  NXP Narrow Band Unit interrupt initialization.

--- a/soc/nxp/common/nxp_nbu.c
+++ b/soc/nxp/common/nxp_nbu.c
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2024 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * Interrupt Narrow Band Unit. This is meant for a RCP radio device.
+ */
+
+/* -------------------------------------------------------------------------- */
+/*                                  Includes                                  */
+/* -------------------------------------------------------------------------- */
+#include <zephyr/irq.h>
+
+/* -------------------------------------------------------------------------- */
+/*                                  Definitions                               */
+/* -------------------------------------------------------------------------- */
+#define DT_DRV_COMPAT nxp_nbu
+
+#define NBU_RX_IRQ_N DT_IRQ_BY_NAME(DT_DRV_INST(0), nbu_rx_int, irq)
+#define NBU_RX_IRQ_P DT_IRQ_BY_NAME(DT_DRV_INST(0), nbu_rx_int, priority)
+#if DT_INST_IRQ_HAS_NAME(0, wakeup_int)
+#define NBU_WAKE_UP_IRQ_N DT_IRQ_BY_NAME(DT_DRV_INST(0), wakeup_int, irq)
+#define NBU_WAKE_UP_IRQ_P DT_IRQ_BY_NAME(DT_DRV_INST(0), wakeup_int, priority)
+#endif
+
+/* -------------------------------------------------------------------------- */
+/*                             Private prototypes                             */
+/* -------------------------------------------------------------------------- */
+extern int32_t nbu_handler(void);
+extern int32_t nbu_wakeup_done_handler(void);
+
+/* -------------------------------------------------------------------------- */
+/*                             Public function                                */
+/* -------------------------------------------------------------------------- */
+
+void nxp_nbu_init(void)
+{
+#if defined(CONFIG_BT) || defined(CONFIG_IEEE802154)
+	/* NBU interface Interrupt */
+	IRQ_CONNECT(NBU_RX_IRQ_N, NBU_RX_IRQ_P, nbu_handler, 0, 0);
+	irq_enable(NBU_RX_IRQ_N);
+
+#if DT_INST_IRQ_HAS_NAME(0, wakeup_int)
+	/* Wake up done interrupt */
+	IRQ_CONNECT(NBU_WAKE_UP_IRQ_N, NBU_WAKE_UP_IRQ_P, nbu_wakeup_done_handler, 0, 0);
+	irq_enable(NBU_WAKE_UP_IRQ_N);
+#endif
+#if (DT_INST_PROP(0, wakeup_source)) && CONFIG_PM
+	EnableDeepSleepIRQ(NBU_RX_IRQ_N);
+#endif
+
+#endif
+}

--- a/soc/nxp/mcx/mcxw/CMakeLists.txt
+++ b/soc/nxp/mcx/mcxw/CMakeLists.txt
@@ -4,6 +4,10 @@
 
 zephyr_sources(soc.c mcxw71_platform_init.S)
 
+zephyr_sources_ifdef(CONFIG_NXP_NBU
+  ../../common/nxp_nbu.c
+  )
+
 zephyr_include_directories(.)
 
 set(SOC_LINKER_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/linker.ld CACHE INTERNAL "")

--- a/soc/nxp/mcx/mcxw/Kconfig
+++ b/soc/nxp/mcx/mcxw/Kconfig
@@ -15,3 +15,5 @@ config SOC_SERIES_MCXW
 	select SOC_RESET_HOOK
 	select SOC_EARLY_INIT_HOOK
 	select CLOCK_CONTROL
+
+	rsource "../../common/Kconfig.nbu"

--- a/soc/nxp/mcx/mcxw/soc.c
+++ b/soc/nxp/mcx/mcxw/soc.c
@@ -17,6 +17,7 @@
 #include <fsl_clock.h>
 
 extern uint32_t SystemCoreClock;
+extern void nxp_nbu_init(void);
 
 static ALWAYS_INLINE void clock_init(void)
 {
@@ -214,4 +215,8 @@ void soc_early_init_hook(void)
 
 	/* restore interrupt state */
 	irq_unlock(oldLevel);
+
+#if defined(CONFIG_BT) || defined(CONFIG_IEEE802154)
+	nxp_nbu_init();
+#endif
 }

--- a/soc/nxp/mcx/mcxw/soc.h
+++ b/soc/nxp/mcx/mcxw/soc.h
@@ -10,6 +10,6 @@
 
 #define PORT_MUX_GPIO kPORT_MuxAsGpio
 
-#define ble_hci_handler RF_IMU0_IRQHandler
+#define nbu_handler RF_IMU0_IRQHandler
 
 #endif /* _SOC__H_ */

--- a/soc/nxp/rw/CMakeLists.txt
+++ b/soc/nxp/rw/CMakeLists.txt
@@ -7,6 +7,10 @@ zephyr_sources(
   flexspi_clock_setup.c
   )
 
+zephyr_sources_ifdef(CONFIG_NXP_NBU
+  ../common/nxp_nbu.c
+  )
+
 zephyr_sources_ifdef(CONFIG_PM
   power.c
   )

--- a/soc/nxp/rw/Kconfig
+++ b/soc/nxp/rw/Kconfig
@@ -52,5 +52,6 @@ config IMAGE_VECTOR_TABLE_OFFSET
 endif # NXP_RW6XX_BOOT_HEADER
 
 rsource "../common/Kconfig.flexspi_xip"
+rsource "../common/Kconfig.nbu"
 
 endif # SOC_SERIES_RW6XX

--- a/soc/nxp/rw/soc.c
+++ b/soc/nxp/rw/soc.c
@@ -36,6 +36,7 @@ extern void z_arm_debug_monitor(void);
 extern void z_arm_pendsv(void);
 extern void sys_clock_isr(void);
 extern void z_arm_exc_spurious(void);
+extern void nxp_nbu_init(void);
 
 __imx_boot_ivt_section void (*const image_vector_table[])(void) = {
 	(void (*)())(z_main_stack + CONFIG_MAIN_STACK_SIZE), /* 0x00 */
@@ -301,11 +302,15 @@ void soc_early_init_hook(void)
 	/* Initialize clock */
 	clock_init();
 
-#if defined(CONFIG_ADC_MCUX_GAU) ||  defined(CONFIG_DAC_MCUX_GAU)
+#if defined(CONFIG_ADC_MCUX_GAU) || defined(CONFIG_DAC_MCUX_GAU)
 	POWER_PowerOnGau();
 #endif
 #if CONFIG_PM
 	nxp_rw6xx_power_init();
+#endif
+
+#if defined(CONFIG_BT) || defined(CONFIG_IEEE802154)
+	nxp_nbu_init();
 #endif
 }
 

--- a/soc/nxp/rw/soc.h
+++ b/soc/nxp/rw/soc.h
@@ -16,11 +16,8 @@
 
 #endif /* !_ASMLANGUAGE */
 
-#define ble_hci_handler         BLE_MCI_WAKEUP0_DriverIRQHandler
-#define ble_wakeup_done_handler BLE_MCI_WAKEUP_DONE0_DriverIRQHandler
-
-#define hdlc_rcp_if_handler             BLE_MCI_WAKEUP0_DriverIRQHandler
-#define hdlc_rcp_if_wakeup_done_handler BLE_MCI_WAKEUP_DONE0_DriverIRQHandler
+#define nbu_handler             BLE_MCI_WAKEUP0_DriverIRQHandler
+#define nbu_wakeup_done_handler BLE_MCI_WAKEUP_DONE0_DriverIRQHandler
 
 /* Wrapper Function to deal with SDK differences in power API */
 static inline void EnableDeepSleepIRQ(IRQn_Type irq)


### PR DESCRIPTION
Creation of the new zephyr\soc\nxp\common\nxp_nbu.c driver which manage the interruption of the Narrow Band Unit. This modification is mandatory to support a coex application which includes Bluetooth and 802.15.4 on the same narrow band path.