### PR TITLE
drivers: wifi: nxp: Fix the compilation error on the MIMXRT1170_EVK board with the NXP_88W8987_MURATA_1ZM_M2 WiFi module

### DIFF
--- a/drivers/wifi/nxp/Kconfig.nxp
+++ b/drivers/wifi/nxp/Kconfig.nxp
@@ -291,7 +291,7 @@ config NXP_88W8801_MURATA_2DS_USD
 	  https://www.murata.com/en-us/products/connectivitymodule/wi-fi-bluetooth/overview/lineup/type2ds
 	  https://www.murata.com/en-us/products/connectivitymodule/wi-fi-bluetooth/overview/lineup/usd-m2-adapter
 
-config NXP_88W8801_MURATA_2DS_USD
+config NXP_88W8801_MURATA_2DS_M2
 	bool "NXP MURATA-2DS-M2"
 	help
 	  Murata Type 2DS is a small high-performance module (integrated PCB antenna)

--- a/dts/bindings/wifi/nxp,wifi.yaml
+++ b/dts/bindings/wifi/nxp,wifi.yaml
@@ -8,3 +8,17 @@ description: |
 compatible: "nxp,wifi"
 
 include: [sd-device.yaml, pinctrl-device.yaml]
+
+properties:
+
+  pdn-gpios:
+    type: phandle-array
+    description: Power Down control GPIO pin.
+
+  wl_rst-gpios:
+    type: phandle-array
+    description: WiFi SDIO reset control GPIO pin.
+
+  bt_rst-gpios:
+    type: phandle-array
+    description: Bluetooth reset control GPIO pin.

--- a/west.yml
+++ b/west.yml
@@ -203,7 +203,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: 49ff7e33f848e4b59da59369a77da63e346fb1a3
+      revision: pull/489/head
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
drivers: wifi: nxp: Fix the compilation error on the MIMXRT1170_EVK board with the NXP_88W8987_MURATA_1ZM_M2 WiFi module

- Fix the compilation error on the MIMXRT1170_EVK board with the NXP_88W8987_MURATA_1ZM_M2 WiFi module