### PR TITLE
drivers: flash: stm32 flash register name for the stm32h7RS serie

### DIFF
--- a/drivers/flash/flash_stm32h7x.c
+++ b/drivers/flash/flash_stm32h7x.c
@@ -85,8 +85,11 @@ static __unused int write_optb(const struct device *dev, uint32_t mask,
 	}
 
 	regs->OPTCR = (regs->OPTCR & ~mask) | value;
+#ifdef CONFIG_SOC_SERIES_STM32H7RSX
+	regs->OPTCR |= FLASH_OPTCR_PG_OPT;
+#else
 	regs->OPTCR |= FLASH_OPTCR_OPTSTART;
-
+#endif /* CONFIG_SOC_SERIES_STM32H7RSX */
 	/* Make sure previous write is completed. */
 	barrier_dsync_fence_full();
 
@@ -121,8 +124,13 @@ int flash_stm32_option_bytes_lock(const struct device *dev, bool enable)
 	if (enable) {
 		regs->OPTCR |= FLASH_OPTCR_OPTLOCK;
 	} else if (regs->OPTCR & FLASH_OPTCR_OPTLOCK) {
+#ifdef CONFIG_SOC_SERIES_STM32H7RSX
+		regs->OPTKEYR = FLASH_OPTKEY1;
+		regs->OPTKEYR = FLASH_OPTKEY2;
+#else
 		regs->OPTKEYR = FLASH_OPT_KEY1;
 		regs->OPTKEYR = FLASH_OPT_KEY2;
+#endif /* CONFIG_SOC_SERIES_STM32H7RSX */
 	}
 
 	if (enable) {


### PR DESCRIPTION
Adapt the stm32 flash driver for the stm32h7rs serie where some bit of the FLASH registers are named differently from stm32h7 serie.

This will fix the  errors when building 
_west build -p -b stm32h7s78_dk/stm32h7s7xx tests/subsys/secure_storage/psa/its -T secure_storage.psa.its.secure_storage.custom.store_ 

```
error: 'FLASH_OPTCR_OPTSTART' undeclared (first use in this function); did you mean 'FLASH_OPTICR_OPTERRF'? 
   88 |         regs->OPTCR |= FLASH_OPTCR_OPTSTART; 
      |                        ^~~~~~~~~~~~~~~~~~~~ 
 
 
error: 'FLASH_OPT_KEY1' undeclared (first use in this function); did you mean 'FLASH_OPTKEY1'? 
  124 |                 regs->OPTKEYR = FLASH_OPT_KEY1; 
      |                                 ^~~~~~~~~~~~~~ 
      |                                 FLASH_OPTKEY1 
~/drivers/flash/flash_stm32h7x.c:125:33: error: 'FLASH_OPT_KEY2' undeclared (first use in this function); did you mean 'FLASH_OPTKEY2'? 
  125 |                 regs->OPTKEYR = FLASH_OPT_KEY2; 
      |       
```                          ^~~~~~~~~~~~~~ 