### PR TITLE
drivers: ssp: start with xtal clock on ssp ver >= 2.0

### DIFF
--- a/drivers/dai/intel/ssp/ssp.c
+++ b/drivers/dai/intel/ssp/ssp.c
@@ -1938,6 +1938,7 @@ static int dai_ssp_parse_tlv(struct dai_intel_ssp *dp, const uint8_t *aux_ptr, s
 	struct ssp_intel_ext_ctl *ext;
 #if SSP_IP_VER >= SSP_IP_VER_1_5
 	struct ssp_intel_link_ctl *link;
+	struct dai_intel_ssp_plat_data *ssp = dai_get_plat_data(dp);
 #endif
 
 	for (i = 0; i < aux_len; i += hop) {
@@ -1991,6 +1992,7 @@ static int dai_ssp_parse_tlv(struct dai_intel_ssp *dp, const uint8_t *aux_ptr, s
 				    I2CLCTL_MLCS(link->clock_source), dai_ip_base(dp) +
 				    I2SLCTL_OFFSET);
 #elif SSP_IP_VER > SSP_IP_VER_1_5
+			ssp->link_clock = link->clock_source;
 			sys_write32((sys_read32(dai_i2svss_base(dp) + I2SLCTL_OFFSET) &
 				    ~I2CLCTL_MLCS(0x7)) |
 				    I2CLCTL_MLCS(link->clock_source),
@@ -2555,6 +2557,14 @@ static void ssp_acquire_ip(struct dai_intel_ssp *dp)
 
 		/* Disable dynamic clock gating before touching any register */
 		dai_ssp_pm_runtime_dis_ssp_clk_gating(dp, ssp->ssp_index);
+
+#if SSP_IP_VER >= SSP_IP_VER_2_0
+		/* Switch to selected clock source */
+		sys_write32((sys_read32(dai_i2svss_base(dp) + I2SLCTL_OFFSET) &
+			    ~I2CLCTL_MLCS(0x7)) |
+			    I2CLCTL_MLCS(ssp->link_clock),
+			    dai_i2svss_base(dp) + I2SLCTL_OFFSET);
+#endif
 	}
 }
 
@@ -2579,6 +2589,14 @@ static void ssp_release_ip(struct dai_intel_ssp *dp)
 		}
 
 		dai_ssp_post_stop(dp);
+
+#if SSP_IP_VER >= SSP_IP_VER_2_0
+		/* Restore default XTAL clock source */
+		sys_write32((sys_read32(dai_i2svss_base(dp) + I2SLCTL_OFFSET) &
+			    ~I2CLCTL_MLCS(0x7)) |
+			    I2CLCTL_MLCS(DAI_INTEL_SSP_CLOCK_XTAL_OSCILLATOR),
+			    dai_i2svss_base(dp) + I2SLCTL_OFFSET);
+#endif
 
 		dai_ssp_pm_runtime_en_ssp_clk_gating(dp, ssp->ssp_index);
 

--- a/drivers/dai/intel/ssp/ssp.h
+++ b/drivers/dai/intel/ssp/ssp.h
@@ -137,6 +137,7 @@ struct dai_intel_ssp_plat_data {
 #if SSP_IP_VER > SSP_IP_VER_1_5
 	uint32_t hdamlssp_base;
 	uint32_t i2svss_base;
+	uint32_t link_clock;
 #endif
 	int irq;
 	const char *irq_name;


### PR DESCRIPTION
This patch will save configured link clock and ensure ssp starts with xtal clock if ssp ver >= 2.0