### PR TITLE
net: openthread: Add openthread tcat multiradio config.

### DIFF
--- a/modules/openthread/Kconfig.thread
+++ b/modules/openthread/Kconfig.thread
@@ -195,6 +195,12 @@ config OPENTHREAD_DEFAULT_TX_POWER
 	help
 	  Set the default TX output power [dBm] in radio driver for OpenThread purpose.
 
+config OPENTHREAD_TCAT_MULTIRADIO_CAPABILITIES
+	bool "Openthread multiradio capability"
+	default y if OPENTHREAD_BLE_TCAT
+	help
+	  Openthread multiradio capability.
+
 config OPENTHREAD_BLE_TCAT_THREAD_STACK_SIZE
 	int "Openthread default TCAT stack size"
 	default 5120 if OPENTHREAD_CRYPTO_PSA

--- a/modules/openthread/platform/ble.c
+++ b/modules/openthread/platform/ble.c
@@ -406,7 +406,7 @@ bool otPlatBleSupportsMultiRadio(otInstance *aInstance)
 {
 	OT_UNUSED_VARIABLE(aInstance);
 
-	return false;
+	return IS_ENABLED(CONFIG_OPENTHREAD_TCAT_MULTIRADIO_CAPABILITIES);
 }
 
 otError otPlatBleGetAdvertisementBuffer(otInstance *aInstance, uint8_t **aAdvertisementBuffer)


### PR DESCRIPTION
As per BHC-750 in TCAT case for now only allowed devices are the ones that have either dual radio or multiplexed radio capabilities. So the 'M' bit in BLE advertisement should be always set to 1. In future specifications devices without multiradio capabilities will be allowed this is the reason why new Kconfig was introduced.