### PR TITLE
cmake: update comments about DWARF v5 support in pyelftools

### DIFF
--- a/cmake/compiler/gcc/compiler_flags.cmake
+++ b/cmake/compiler/gcc/compiler_flags.cmake
@@ -207,6 +207,7 @@ set_compiler_property(PROPERTY no_track_macro_expansion -ftrack-macro-expansion=
 
 # GCC 11 by default emits DWARF version 5 which cannot be parsed by
 # pyelftools. Can be removed once pyelftools supports v5.
+# pyelftools 0.31 still is not able to parse the version 5 output.
 check_set_compiler_property(APPEND PROPERTY debug -gdwarf-4)
 
 set_compiler_property(PROPERTY no_common -fno-common)

--- a/cmake/linker/ld/gcc/linker_flags.cmake
+++ b/cmake/linker/ld/gcc/linker_flags.cmake
@@ -11,6 +11,7 @@ check_set_linker_property(TARGET linker APPEND PROPERTY gprof -pg)
 
 # GCC 11 by default emits DWARF version 5 which cannot be parsed by
 # pyelftools. Can be removed once pyelftools supports v5.
+# pyelftools 0.31 still is not able to parse the version 5 output.
 add_link_options(-gdwarf-4)
 
 # Extra warnings options for twister run


### PR DESCRIPTION
Update the comments which document the necessity to enforce DWARF v4 to be able to parse the outputs with pyelftools.

I actually tried to remove this flag, but the build then still fails:
https://github.com/zephyrproject-rtos/zephyr/actions/runs/12369159520/job/34521122341?pr=83083

Therefore I thought it might at least be a good idea to document the version.