### PR TITLE
silabs: Drop obsolete clock configuration

### DIFF
--- a/boards/silabs/dev_kits/sltb010a/Kconfig.defconfig
+++ b/boards/silabs/dev_kits/sltb010a/Kconfig.defconfig
@@ -1,12 +1,6 @@
 # Copyright (c) 2023 Antmicro <www.antmicro.com>
 # SPDX-License-Identifier: Apache-2.0
 
-config CMU_HFXO_FREQ
-	default 38400000
-
-config CMU_LFXO_FREQ
-	default 32768
-
 if SOC_GECKO_USE_RAIL
 
 config FPU

--- a/boards/silabs/dev_kits/xg24_dk2601b/Kconfig.defconfig
+++ b/boards/silabs/dev_kits/xg24_dk2601b/Kconfig.defconfig
@@ -3,12 +3,6 @@
 
 if BOARD_XG24_DK2601B
 
-config CMU_HFXO_FREQ
-	default 40000000
-
-config CMU_LFXO_FREQ
-	default 32768
-
 if SOC_GECKO_USE_RAIL
 
 config FPU

--- a/boards/silabs/dev_kits/xg27_dk2602a/Kconfig.defconfig
+++ b/boards/silabs/dev_kits/xg27_dk2602a/Kconfig.defconfig
@@ -1,12 +1,6 @@
 # Copyright (c) 2023 Antmicro <www.antmicro.com>
 # SPDX-License-Identifier: Apache-2.0
 
-config CMU_HFXO_FREQ
-	default 38400000
-
-config CMU_LFXO_FREQ
-	default 32768
-
 if SOC_GECKO_USE_RAIL
 
 config FPU

--- a/boards/silabs/radio_boards/slwrb4180a/Kconfig.defconfig
+++ b/boards/silabs/radio_boards/slwrb4180a/Kconfig.defconfig
@@ -4,12 +4,6 @@
 
 if BOARD_SLWRB4180A
 
-config CMU_HFXO_FREQ
-	default 38400000
-
-config CMU_LFXO_FREQ
-	default 32768
-
 config LOG_BACKEND_SWO_FREQ_HZ
 	default 875000
 	depends on LOG_BACKEND_SWO

--- a/boards/silabs/radio_boards/xg23_rb4210a/Kconfig.defconfig
+++ b/boards/silabs/radio_boards/xg23_rb4210a/Kconfig.defconfig
@@ -3,12 +3,6 @@
 
 if BOARD_XG23_RB4210A
 
-config CMU_HFXO_FREQ
-	default 39000000
-
-config CMU_LFXO_FREQ
-	default 32768
-
 config LOG_BACKEND_SWO_FREQ_HZ
 	default 875000
 	depends on LOG_BACKEND_SWO

--- a/boards/silabs/radio_boards/xg24_rb4187c/Kconfig.defconfig
+++ b/boards/silabs/radio_boards/xg24_rb4187c/Kconfig.defconfig
@@ -4,12 +4,6 @@
 
 if BOARD_XG24_RB4187C
 
-config CMU_HFXO_FREQ
-	default 39000000
-
-config CMU_LFXO_FREQ
-	default 32768
-
 config LOG_BACKEND_SWO_FREQ_HZ
 	default 875000
 	depends on LOG_BACKEND_SWO

--- a/soc/silabs/Kconfig
+++ b/soc/silabs/Kconfig
@@ -208,7 +208,7 @@ config SOC_GECKO_CMU
 	help
 	  Set if the clock management unit (CMU) is present in the SoC.
 
-if SOC_GECKO_CMU
+if SOC_GECKO_CMU && (SOC_FAMILY_SILABS_S0 || SOC_FAMILY_SILABS_S1)
 
 config CMU_NEED_LFXO
 	bool


### PR DESCRIPTION
Silabs Series-2 (all the `EFR32xg2x` chips) use the new clock driver
introduced in commit bda8ae8c3f0 ("drivers: clock_control: silabs: Add clock
control driver"). This driver get all the configuration from the Device
Tree.

The CMU (Clock Management Unit) options (`CMU_HFXO_FREQ`, `CMU_HFRCO_FREQ`,
`CMU_NEED_LFXO`, `CMU_HFCLK_HFXO`, etc...) are now only used for Series-0 and
Series-1. It does not make sense to declare them with Series-2.