### PR TITLE
samples: lora: receive: fix incorrect variable name

### DIFF
--- a/samples/drivers/lora/receive/sample.yaml
+++ b/samples/drivers/lora/receive/sample.yaml
@@ -11,3 +11,5 @@ tests:
       type: one_line
       regex:
         - "<inf> lora_receive: Synchronous reception"
+    integration_platforms:
+      - b_l072z_lrwan1

--- a/samples/drivers/lora/receive/src/main.c
+++ b/samples/drivers/lora/receive/src/main.c
@@ -80,7 +80,7 @@ int main(void)
 		}
 
 		LOG_INF("LoRa RX RSSI: %d dBm, SNR: %d dB", rssi, snr);
-		LOG_HEXDUMP_INF(data, size, "LoRa RX payload");
+		LOG_HEXDUMP_INF(data, len, "LoRa RX payload");
 	}
 
 	/* Enable asynchronous reception */

--- a/samples/drivers/lora/send/sample.yaml
+++ b/samples/drivers/lora/send/sample.yaml
@@ -11,3 +11,5 @@ tests:
       type: one_line
       regex:
         - "<inf> lora_send: Data sent!"
+    integration_platforms:
+      - b_l072z_lrwan1


### PR DESCRIPTION
Fix an incorrect variable name from copy-pasting code from the async receive handler.

Add an integration platform to the LoRa samples so that changes to these applications are checked in the PR CI.