### PR TITLE
boards: st: nucleo_wba55cg: change OpenOCD reset option

### DIFF
--- a/boards/st/nucleo_wba55cg/support/openocd.cfg
+++ b/boards/st/nucleo_wba55cg/support/openocd.cfg
@@ -19,7 +19,7 @@ set CLOCK_FREQ 8000
 # Reset configuration
 # use hardware reset, connect under reset
 # connect_assert_srst needed if low power mode application running (WFI...)
-reset_config srst_only srst_nogate
+reset_config srst_nogate
 
 source [find target/stm32wbax.cfg]
 


### PR DESCRIPTION
Fixes #82732

Remove "srst_only" option to avoid reset error after flashing program. 