### PR TITLE
Bluetooth: Controller: Replace Kconfig select with depends

### DIFF
--- a/subsys/bluetooth/controller/Kconfig.ll_sw_split
+++ b/subsys/bluetooth/controller/Kconfig.ll_sw_split
@@ -66,8 +66,18 @@ config BT_LLL_VENDOR_NORDIC
 				   (BT_OBSERVER && BT_CTLR_ADV_EXT)
 	select BT_TICKER_START_REMAINDER if BT_CTLR_CENTRAL_ISO
 	select BT_TICKER_REMAINDER_GET if BT_BROADCASTER && BT_CTLR_ADV_EXT
-	select BT_TICKER_LAZY_GET if BT_CTLR_ADV_PERIODIC || BT_CTLR_CENTRAL_ISO || BT_CTLR_SYNC_TRANSFER_SENDER
-
+	select BT_TICKER_LAZY_GET if BT_CTLR_ADV_PERIODIC || \
+				     BT_CTLR_CENTRAL_ISO || \
+				     BT_CTLR_SYNC_TRANSFER_SENDER
+	select BT_TICKER_NEXT_SLOT_GET if (BT_BROADCASTER && \
+					   BT_CTLR_ADV_EXT) || \
+					  BT_CTLR_ADV_PERIODIC || \
+					  BT_CTLR_CENTRAL_ISO
+	select BT_TICKER_NEXT_SLOT_GET_MATCH if (BT_BROADCASTER && \
+						 BT_CTLR_ADV_EXT) || \
+						BT_CTLR_ADV_PERIODIC || \
+						BT_CTLR_CENTRAL_ISO
+	select BT_TICKER_CNTR_FREE_RUNNING if SOC_COMPATIBLE_NRF54LX
 	select BT_TICKER_PREFER_START_BEFORE_STOP if BT_TICKER_SLOT_AGNOSTIC
 
 	default y
@@ -338,7 +348,6 @@ config BT_CTLR_DATA_LENGTH_CLEAR
 config BT_CTLR_PHY_2M_NRF
 	bool "2Mbps Nordic Semiconductor PHY Support (Cleartext only)"
 	depends on SOC_SERIES_NRF51X
-	select BT_CTLR_PHY_2M
 	help
 	  Enable support for Nordic Semiconductor proprietary 2Mbps PHY in the
 	  Controller. Encrypted connections are not supported.
@@ -379,18 +388,18 @@ config BT_CTLR_ADV_PDU_LINK
 	# Enables extra space in each advertising PDU to allow linking PDUs.
 	# This is required to enable advertising data trains (i.e. transmission
 	# of AUX_CHAIN_IND).
+	depends on BT_CTLR_ADV_EXT && BT_BROADCASTER
 	bool
 
 config BT_CTLR_ADV_AUX_PDU_LINK
 	# Enable chaining in Extended Advertising
-	bool
 	select BT_CTLR_ADV_PDU_LINK
+	bool
 
 config BT_CTLR_ADV_AUX_PDU_BACK2BACK
 	bool "Back-to-back transmission of extended advertising trains"
-	depends on BT_BROADCASTER && BT_CTLR_ADV_EXT
 	select BT_CTLR_ADV_AUX_PDU_LINK
-	default y if BT_CTLR_ADV_DATA_LEN_MAX > 191
+	default y if BT_CTLR_ADV_DATA_CHAIN
 	help
 	  Enables transmission of AUX_CHAIN_IND in extended advertising train by
 	  sending each AUX_CHAIN_IND one after another back-to-back.
@@ -411,8 +420,8 @@ config BT_CTLR_ADV_SYNC_PDU_LINK
 
 config BT_CTLR_ADV_SYNC_PDU_BACK2BACK
 	bool "Back-to-back transmission of periodic advertising trains"
-	depends on BT_CTLR_ADV_PERIODIC
 	select BT_CTLR_ADV_SYNC_PDU_LINK
+	default y if BT_CTLR_ADV_PERIODIC && BT_CTLR_ADV_DATA_CHAIN
 	help
 	  Enables transmission of AUX_CHAIN_IND in periodic advertising train by
 	  sending each AUX_CHAIN_IND one after another back-to-back.
@@ -734,8 +743,8 @@ config BT_CTLR_SCHED_ADVANCED
 	depends on BT_CTLR_SCHED_ADVANCED_SUPPORT && \
 		   (BT_CONN || \
 		    (BT_CTLR_ADV_EXT && (BT_CTLR_ADV_AUX_SET > 0)) || \
-		    BT_CTLR_ADV_ISO)
-	select BT_TICKER_NEXT_SLOT_GET
+		    BT_CTLR_ADV_ISO) && \
+		   BT_TICKER_NEXT_SLOT_GET
 	default y if BT_CENTRAL || (BT_BROADCASTER && BT_CTLR_ADV_EXT) || BT_CTLR_ADV_ISO
 	help
 	  Enable non-overlapping placement of observer, initiator and central
@@ -879,7 +888,7 @@ config BT_CTLR_ULL_LOW_PRIO
 
 config BT_CTLR_LOW_LAT
 	bool "Low latency non-negotiating event preemption"
-	select BT_CTLR_LOW_LAT_ULL_DONE
+	depends on BT_CTLR_LOW_LAT_ULL && BT_CTLR_LOW_LAT_ULL_DONE
 	default y if SOC_SERIES_NRF51X
 	help
 	  Use low latency non-negotiating event preemption. This reduces
@@ -890,8 +899,6 @@ config BT_CTLR_LOW_LAT
 config BT_CTLR_LOW_LAT_ULL
 	prompt "Low latency ULL"
 	bool
-	depends on BT_CTLR_LOW_LAT
-	default y
 	help
 	  Low latency ULL implementation that uses tailchaining instead of while
 	  loop to demux rx messages from LLL.
@@ -915,8 +922,7 @@ config BT_CTLR_RX_PDU_META
 
 config BT_CTLR_NRF_GRTC
 	bool "Use nRF GRTC peripheral"
-	depends on SOC_COMPATIBLE_NRF54LX
-	select BT_TICKER_CNTR_FREE_RUNNING
+	depends on BT_TICKER_CNTR_FREE_RUNNING && SOC_COMPATIBLE_NRF54LX
 	default y
 	help
 	  Enable use of nRF54Lx NRF_GRTC peripheral.
@@ -947,8 +953,9 @@ config BT_CTLR_NRF_GRTC_AUTOEN_DEFAULT
 
 config BT_CTLR_RADIO_ENABLE_FAST
 	bool "Use tTXEN/RXEN,FAST ramp-up"
-	depends on SOC_COMPATIBLE_NRF52X || SOC_COMPATIBLE_NRF53X || SOC_COMPATIBLE_NRF54LX
-	select BT_CTLR_SW_SWITCH_SINGLE_TIMER if SOC_COMPATIBLE_NRF54LX
+	depends on SOC_COMPATIBLE_NRF52X || \
+		   SOC_COMPATIBLE_NRF53X || \
+		   SOC_COMPATIBLE_NRF54LX
 	default y
 	help
 	  Enable use of fast radio ramp-up mode.
@@ -962,15 +969,18 @@ config BT_CTLR_RADIO_TIMER_ISR
 
 config BT_CTLR_TIFS_HW
 	bool "H/w Accelerated tIFS Trx switching"
-	depends on !BT_CTLR_RADIO_ENABLE_FAST && BT_CTLR_TIFS_HW_SUPPORT
+	depends on BT_CTLR_TIFS_HW_SUPPORT && !BT_CTLR_RADIO_ENABLE_FAST
 	default y
 	help
 	  Enable use of hardware accelerated tIFS Trx switching.
 
 config BT_CTLR_SW_SWITCH_SINGLE_TIMER
 	bool "Single TIMER tIFS Trx SW switching"
-	depends on (!BT_CTLR_TIFS_HW) && (SOC_COMPATIBLE_NRF52X || SOC_COMPATIBLE_NRF53X || \
-					  SOC_COMPATIBLE_NRF54LX)
+	depends on BT_CTLR_RADIO_ENABLE_FAST && \
+		   (SOC_COMPATIBLE_NRF52X || \
+		    SOC_COMPATIBLE_NRF53X || \
+		    SOC_COMPATIBLE_NRF54LX)
+	default y if SOC_COMPATIBLE_NRF54LX
 	help
 	  Implement the tIFS Trx SW switch with the same TIMER
 	  instance, as the one used for Bluetooth event timing. Requires
@@ -1075,7 +1085,7 @@ config BT_CTLR_TX_RETRY_DISABLE
 
 config BT_CTLR_TX_DEFER
 	bool "Deferred ACL Tx packet transmission setup"
-	select BT_CTLR_RADIO_TIMER_ISR
+	depends on BT_CTLR_RADIO_TIMER_ISR
 	help
 	  Enable deferred ACL Tx packet transmission setup by radio, so that an
 	  enqueued ACL Data packet by the upper layer can be transmitted with
@@ -1088,7 +1098,7 @@ config BT_CTLR_THROUGHPUT
 
 config BT_CTLR_FORCE_MD_COUNT
 	int "Forced MD bit count" if !BT_CTLR_FORCE_MD_AUTO
-	depends on !BT_CTLR_LOW_LAT_ULL
+	depends on !BT_CTLR_LOW_LAT
 	range 0 $(UINT8_MAX)
 	default 1 if BT_CTLR_FORCE_MD_AUTO
 	default 0
@@ -1102,8 +1112,7 @@ config BT_CTLR_FORCE_MD_COUNT
 
 config BT_CTLR_FORCE_MD_AUTO
 	bool "Forced MD bit automatic calculation"
-	depends on !BT_CTLR_LOW_LAT_ULL
-	select BT_CTLR_THROUGHPUT
+	depends on BT_CTLR_THROUGHPUT && !BT_CTLR_LOW_LAT
 	default y if BT_HCI_RAW
 	help
 	  Force MD bit in transmitted PDU based on runtime incoming transmit
@@ -1241,9 +1250,8 @@ config BT_TICKER_NEXT_SLOT_GET
 
 config BT_TICKER_REMAINDER_GET
 	bool "Ticker Next Slot Get with Remainder"
-	depends on BT_TICKER_REMAINDER_SUPPORT
-	select BT_TICKER_NEXT_SLOT_GET
-	select BT_TICKER_NEXT_SLOT_GET_MATCH
+	depends on BT_TICKER_REMAINDER_SUPPORT && BT_TICKER_NEXT_SLOT_GET && \
+		   BT_TICKER_NEXT_SLOT_GET_MATCH
 	default y
 	help
 	  This option enables ticker interface to iterate through active
@@ -1252,8 +1260,7 @@ config BT_TICKER_REMAINDER_GET
 
 config BT_TICKER_LAZY_GET
 	bool "Ticker Next Slot Get with Lazy"
-	select BT_TICKER_NEXT_SLOT_GET
-	select BT_TICKER_NEXT_SLOT_GET_MATCH
+	depends on BT_TICKER_NEXT_SLOT_GET && BT_TICKER_NEXT_SLOT_GET_MATCH
 	help
 	  This option enables ticker interface to iterate through active
 	  ticker nodes, returning tick to expire and lazy count from a reference
@@ -1289,7 +1296,7 @@ config BT_TICKER_EXT_SLOT_WINDOW_YIELD
 
 config BT_TICKER_EXT_EXPIRE_INFO
 	bool "Ticker timeout with other ticker's expire information"
-	select BT_TICKER_EXT
+	depends on BT_TICKER_EXT
 	help
 	  This option enables ticker to return expiration info. The extended
 	  ticker interface) is used to ask for expiration information for
@@ -1336,7 +1343,7 @@ config BT_TICKER_PREFER_START_BEFORE_STOP
 
 config BT_CTLR_JIT_SCHEDULING
 	bool "Just-in-Time Scheduling"
-	select BT_TICKER_SLOT_AGNOSTIC
+	depends on BT_TICKER_SLOT_AGNOSTIC
 	help
 	  This option enables the experimental 'Next Generation' scheduling
 	  feature, which eliminates priorities and collision resolving in the


### PR DESCRIPTION
Replace use of `select` with `depends on` in the LL_SW_SPLIT Kconfig options.