### PR TITLE
posix: Move POSIX configs out of experimental

### DIFF
--- a/lib/posix/options/Kconfig.aio
+++ b/lib/posix/options/Kconfig.aio
@@ -3,8 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config POSIX_ASYNCHRONOUS_IO
-	bool "POSIX asynchronous I/O [EXPERIMENTAL]"
-	select EXPERIMENTAL
+	bool "POSIX asynchronous I/O"
 	help
 	  Enable this option for asynchronous I/O. This option is present for conformance purposes
 	  only. All functions listed in <aio.h> return -1 and set errno to ENOSYS.

--- a/lib/posix/options/Kconfig.device_io
+++ b/lib/posix/options/Kconfig.device_io
@@ -5,8 +5,7 @@
 menu "POSIX device I/O"
 
 config POSIX_DEVICE_IO
-	bool "POSIX device I/O [EXPERIMENTAL]"
-	select EXPERIMENTAL
+	bool "POSIX device I/O"
 	select REQUIRES_FULL_LIBC
 	select ZVFS
 	select ZVFS_POLL

--- a/lib/posix/options/Kconfig.fd_mgmt
+++ b/lib/posix/options/Kconfig.fd_mgmt
@@ -3,8 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig POSIX_FD_MGMT
-	bool "POSIX file descriptor management [EXPERIMENTAL]"
-	select EXPERIMENTAL
+	bool "POSIX file descriptor management"
 	help
 	  Select 'y' here and Zephyr will provide implementations for the POSIX_FD_MGMT Option Group.
 	  This includes support for dup(), dup2(), fcntl(), fseeko(), ftello(), ftruncate(),

--- a/lib/posix/options/Kconfig.mem
+++ b/lib/posix/options/Kconfig.mem
@@ -13,8 +13,7 @@ config POSIX_PAGE_SIZE
 	  This option is not user-configurable.
 
 config POSIX_SHARED_MEMORY_OBJECTS
-	bool "POSIX shared memory objects [EXPERIMENTAL]"
-	select EXPERIMENTAL
+	bool "POSIX shared memory objects"
 	select SYS_HASH_FUNC32
 	select SYS_HASH_FUNC32_DJB2
 	select FDTABLE
@@ -27,8 +26,7 @@ config POSIX_SHARED_MEMORY_OBJECTS
 	  https://pubs.opengroup.org/onlinepubs/9699919799/xrat/V4_port.html#tag_24_03_04
 
 config POSIX_MAPPED_FILES
-	bool "POSIX memory-mapped files [EXPERIMENTAL]"
-	select EXPERIMENTAL
+	bool "POSIX memory-mapped files"
 	imply MMU
 	help
 	  Select 'y' here and Zephyr will provide support for mmap(), msync(), and munmap().
@@ -40,8 +38,7 @@ config POSIX_MAPPED_FILES
 if POSIX_MAPPED_FILES
 
 config POSIX_MEMLOCK
-	bool "POSIX memory locking [EXPERIMENTAL]"
-	select EXPERIMENTAL
+	bool "POSIX memory locking"
 	help
 	  Select 'y' here and Zephyr will provide support for mlockall() and munlockall().
 
@@ -50,8 +47,7 @@ config POSIX_MEMLOCK
 	  https://pubs.opengroup.org/onlinepubs/9699919799/xrat/V4_port.html#tag_24_03_04
 
 config POSIX_MEMLOCK_RANGE
-	bool "POSIX range memory locking [EXPERIMENTAL]"
-	select EXPERIMENTAL
+	bool "POSIX range memory locking"
 	imply MMU
 	imply DEMAND_PAGING
 	help
@@ -64,8 +60,7 @@ config POSIX_MEMLOCK_RANGE
 endif
 
 config POSIX_MEMORY_PROTECTION
-	bool "POSIX memory protection [EXPERIMENTAL]"
-	select EXPERIMENTAL
+	bool "POSIX memory protection"
 	help
 	  Select 'y' here and Zephyr will provide support for mprotect().
 

--- a/lib/posix/options/Kconfig.procN
+++ b/lib/posix/options/Kconfig.procN
@@ -3,8 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig POSIX_MULTI_PROCESS
-	bool "POSIX multi-process support [EXPERIMENTAL]"
-	select EXPERIMENTAL
+	bool "POSIX multi-process support"
 	help
 	  Support for multi-processing.
 

--- a/lib/posix/options/Kconfig.sched
+++ b/lib/posix/options/Kconfig.sched
@@ -5,8 +5,7 @@
 menu "POSIX scheduler options"
 
 config POSIX_PRIORITY_SCHEDULING
-	bool "POSIX priority-based process scheduling [EXPERIMENTAL]"
-	select EXPERIMENTAL
+	bool "POSIX priority-based process scheduling"
 	help
 	  This enables POSIX scheduling APIs (_POSIX_PRIORITY_SCHEDULING).
 

--- a/lib/posix/options/Kconfig.signal
+++ b/lib/posix/options/Kconfig.signal
@@ -5,8 +5,7 @@
 menu "POSIX signals"
 
 config POSIX_REALTIME_SIGNALS
-	bool "POSIX realtime signals [EXPERIMENTAL]"
-	select EXPERIMENTAL
+	bool "POSIX realtime signals"
 	help
 	  Enable support for POSIX realtime signals.
 
@@ -22,8 +21,7 @@ config POSIX_RTSIG_MAX
 endif # POSIX_REALTIME_SIGNALS
 
 config POSIX_SIGNALS
-	bool "POSIX signals [EXPERIMENTAL]"
-	select EXPERIMENTAL
+	bool "POSIX signals"
 	select POSIX_MULTI_PROCESS
 	help
 	  Enable support for POSIX signals.


### PR DESCRIPTION
Many out of the POSIX subsystem configs are enabled automatically when merely CONFIG_POSIX_API is enabled, which is a prerequisite for many networking samples. This causes a massive experimental warning printout when building with warnings enabled.

Since the new POSIX Kconfig configuration options are already present in Zephyr for 2 release cycles and seem settled, I suggest we move them out of experimental phase.