### PR TITLE
Bluetooth: ISO: Add support for cis_established_v2 in host

### DIFF
--- a/include/zephyr/bluetooth/hci_types.h
+++ b/include/zephyr/bluetooth/hci_types.h
@@ -3456,6 +3456,32 @@ struct bt_hci_evt_le_subrate_change {
 	uint16_t supervision_timeout;
 } __packed;
 
+#define BT_HCI_EVT_LE_CIS_ESTABLISHED_V2 0x2a
+struct bt_hci_evt_le_cis_established_v2 {
+	uint8_t  status;
+	uint16_t conn_handle;
+	uint8_t  cig_sync_delay[3];
+	uint8_t  cis_sync_delay[3];
+	uint8_t  c_latency[3];
+	uint8_t  p_latency[3];
+	uint8_t  c_phy;
+	uint8_t  p_phy;
+	uint8_t  nse;
+	uint8_t  c_bn;
+	uint8_t  p_bn;
+	uint8_t  c_ft;
+	uint8_t  p_ft;
+	uint16_t c_max_pdu;
+	uint16_t p_max_pdu;
+	uint16_t interval;
+	uint8_t  sub_interval[3];
+	uint16_t c_max_sdu;
+	uint16_t p_max_sdu;
+	uint8_t  c_sdu_interval[3];
+	uint8_t  p_sdu_interval[3];
+	uint8_t  framing;
+} __packed;
+
 #define BT_HCI_LE_CS_INITIATOR_ROLE_MASK BIT(0)
 #define BT_HCI_LE_CS_REFLECTOR_ROLE_MASK BIT(1)
 
@@ -3926,6 +3952,7 @@ struct bt_hci_evt_le_cs_procedure_enable_complete {
 #define BT_EVT_MASK_LE_PER_ADV_SUBEVENT_DATA_REQ   BT_EVT_BIT(38)
 #define BT_EVT_MASK_LE_PER_ADV_RESPONSE_REPORT     BT_EVT_BIT(39)
 #define BT_EVT_MASK_LE_ENH_CONN_COMPLETE_V2        BT_EVT_BIT(40)
+#define BT_EVT_MASK_LE_CIS_ESTABLISHED_V2          BT_EVT_BIT(41)
 
 #define BT_EVT_MASK_LE_CS_READ_REMOTE_SUPPORTED_CAPABILITIES_COMPLETE BT_EVT_BIT(43)
 #define BT_EVT_MASK_LE_CS_READ_REMOTE_FAE_TABLE_COMPLETE              BT_EVT_BIT(44)

--- a/include/zephyr/bluetooth/iso.h
+++ b/include/zephyr/bluetooth/iso.h
@@ -68,6 +68,8 @@ extern "C" {
 /** Value to set the ISO data path over HCi. */
 #define BT_ISO_DATA_PATH_HCI        0x00
 
+/** Unknown SDU interval */
+#define BT_ISO_SDU_INTERVAL_UNKNOWN 0x000000U
 /** Minimum interval value in microseconds */
 #define BT_ISO_SDU_INTERVAL_MIN     0x0000FFU
 /** Maximum interval value in microseconds */
@@ -140,6 +142,10 @@ extern "C" {
 #define BT_ISO_PTO_MIN              0x00U
 /** Maximum pre-transmission offset */
 #define BT_ISO_PTO_MAX              0x0FU
+/** No subinterval */
+#define BT_ISO_SUBINTERVAL_NONE         0x00000000U
+/** Unknown subinterval */
+#define BT_ISO_SUBINTERVAL_UNKNOWN      0xFFFFFFFFU
 
 /**
  * @brief Check if ISO BIS bitfield is valid (BT_ISO_BIS_INDEX_BIT(1)|..|BT_ISO_BIS_INDEX_BIT(31))
@@ -967,6 +973,18 @@ struct bt_iso_unicast_tx_info {
 
 	/** The burst number */
 	uint8_t  bn;
+
+	/** The maximum SDU size in octets
+	 *
+	 * May be set to @ref bt_iso_unicast_tx_info.max_pdu for peripherals if unknown
+	 */
+	uint16_t max_sdu;
+
+	/** The SDU interval in microseconds
+	 *
+	 * May be set to  @ref BT_ISO_SDU_INTERVAL_UNKNOWN for if unknown.
+	 */
+	uint32_t sdu_interval;
 };
 
 /** @brief ISO Unicast Info Structure */
@@ -976,6 +994,14 @@ struct bt_iso_unicast_info {
 
 	/** The maximum time in us for all PDUs of this CIS in a CIG event */
 	uint32_t cis_sync_delay;
+
+	/**
+	 * @brief The subinterval in microseconds
+	 *
+	 * Will be @ref BT_ISO_SUBINTERVAL_NONE if there is no subinterval (NSE = 1).
+	 * Will be @ref BT_ISO_SUBINTERVAL_UNKNOWN if unknown.
+	 */
+	uint32_t subinterval;
 
 	/** @brief TX information for the central to peripheral data path */
 	struct bt_iso_unicast_tx_info central;

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -7,6 +7,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/bluetooth/hci_types.h>
 #include <zephyr/kernel.h>
 #include <string.h>
 #include <stdio.h>
@@ -2794,6 +2795,8 @@ static const struct event_handler meta_events[] = {
 #if defined(CONFIG_BT_ISO_UNICAST)
 	EVENT_HANDLER(BT_HCI_EVT_LE_CIS_ESTABLISHED, hci_le_cis_established,
 		      sizeof(struct bt_hci_evt_le_cis_established)),
+	EVENT_HANDLER(BT_HCI_EVT_LE_CIS_ESTABLISHED_V2, hci_le_cis_established_v2,
+		      sizeof(struct bt_hci_evt_le_cis_established_v2)),
 #if defined(CONFIG_BT_ISO_PERIPHERAL)
 	EVENT_HANDLER(BT_HCI_EVT_LE_CIS_REQ, hci_le_cis_req,
 		      sizeof(struct bt_hci_evt_le_cis_req)),
@@ -3417,6 +3420,7 @@ static int le_set_event_mask(void)
 	if (IS_ENABLED(CONFIG_BT_ISO) &&
 	    BT_FEAT_LE_CIS(bt_dev.le.features)) {
 		mask |= BT_EVT_MASK_LE_CIS_ESTABLISHED;
+		mask |= BT_EVT_MASK_LE_CIS_ESTABLISHED_V2;
 		if (BT_FEAT_LE_CIS_PERIPHERAL(bt_dev.le.features)) {
 			mask |= BT_EVT_MASK_LE_CIS_REQ;
 		}

--- a/subsys/bluetooth/host/iso_internal.h
+++ b/subsys/bluetooth/host/iso_internal.h
@@ -99,6 +99,7 @@ void bt_iso_buf_rx_freed_cb_set(bt_iso_buf_rx_freed_cb_t cb);
 
 /* Process CIS Established event */
 void hci_le_cis_established(struct net_buf *buf);
+void hci_le_cis_established_v2(struct net_buf *buf);
 
 /* Process CIS Request event */
 void hci_le_cis_req(struct net_buf *buf);


### PR DESCRIPTION
Add support for the bt_hci_evt_le_cis_established_v2 event in the host.

This provided additional information to the host and application about the CIS paramters. Especially the peripheral gets new an important information such as the SDU size and interval.

fixes https://github.com/zephyrproject-rtos/zephyr/issues/79554