### PR TITLE
doc: fix typo 'date' to 'data' in README documentation

### DIFF
--- a/doc/connectivity/networking/api/coap_server.rst
+++ b/doc/connectivity/networking/api/coap_server.rst
@@ -173,7 +173,7 @@ of CoAP services. An example using a temperature sensor can look like:
         coap_append_option_int(&response, COAP_OPTION_CONTENT_FORMAT,
                                COAP_CONTENT_FORMAT_TEXT_PLAIN);
 
-        /* Get the sensor date */
+        /* Get the sensor data */
         sensor_sample_fetch_chan(dev, SENSOR_CHAN_AMBIENT_TEMP);
         sensor_channel_get(dev, SENSOR_CHAN_AMBIENT_TEMP, &value);
         temp = sensor_value_to_double(&value);

--- a/samples/sensor/lsm6dso/README.rst
+++ b/samples/sensor/lsm6dso/README.rst
@@ -7,7 +7,7 @@
 
 Overview
 ********
-This sample sets the date rate of LSM6DSO accelerometer and gyroscope to
+This sample sets the data rate of the LSM6DSO accelerometer and gyroscope to
 12.5Hz and enables a trigger on data ready. It displays on the console
 the values for accelerometer and gyroscope.
 


### PR DESCRIPTION
PR #82703  resolved date instead of data in this 2 files.
lsm6dso README and coap_server document files.