### PR TITLE
add flash get size API function for the stm32 devices

### DIFF
--- a/drivers/flash/flash_stm32.c
+++ b/drivers/flash/flash_stm32.c
@@ -19,6 +19,7 @@
 #include <soc.h>
 #include <stm32_ll_bus.h>
 #include <stm32_ll_rcc.h>
+#include <stm32_ll_utils.h>
 #include <zephyr/logging/log.h>
 
 #include "flash_stm32.h"
@@ -431,6 +432,16 @@ flash_stm32_get_parameters(const struct device *dev)
 	return &flash_stm32_parameters;
 }
 
+/* Gives the total logical device size in bytes and return 0. */
+static int flash_stm32_get_size(const struct device *dev, uint64_t *size)
+{
+	ARG_UNUSED(dev);
+
+	*size = (uint64_t)LL_GetFlashSize() * 1024U;
+
+	return 0;
+}
+
 static struct flash_stm32_priv flash_data = {
 	.regs = (FLASH_TypeDef *) DT_INST_REG_ADDR(0),
 	/* Getting clocks information from device tree description depending
@@ -449,6 +460,7 @@ static DEVICE_API(flash, flash_stm32_api) = {
 	.write = flash_stm32_write,
 	.read = flash_stm32_read,
 	.get_parameters = flash_stm32_get_parameters,
+	.get_size = flash_stm32_get_size,
 #ifdef CONFIG_FLASH_PAGE_LAYOUT
 	.page_layout = flash_stm32_page_layout,
 #endif

--- a/drivers/flash/flash_stm32.c
+++ b/drivers/flash/flash_stm32.c
@@ -13,6 +13,9 @@
 #define DT_DRV_COMPAT st_stm32_flash_controller
 
 #include <string.h>
+#if defined(CONFIG_SOC_SERIES_STM32H5X)
+#include <zephyr/cache.h>
+#endif /* CONFIG_SOC_SERIES_STM32H5X */
 #include <zephyr/drivers/flash.h>
 #include <zephyr/drivers/flash/stm32_flash_api_extensions.h>
 #include <zephyr/init.h>
@@ -437,7 +440,20 @@ static int flash_stm32_get_size(const struct device *dev, uint64_t *size)
 {
 	ARG_UNUSED(dev);
 
+#if defined(CONFIG_SOC_SERIES_STM32H5X)
+	/* Disable the ICACHE to ensure all memory accesses are non-cacheable.
+	 * This is required on STM32H5, where the manufacturing flash must be
+	 * accessed in non-cacheable mode - otherwise, a bus error occurs.
+	 */
+	cache_instr_disable();
+#endif /* CONFIG_SOC_SERIES_STM32H5X */
+
 	*size = (uint64_t)LL_GetFlashSize() * 1024U;
+
+#if defined(CONFIG_SOC_SERIES_STM32H5X)
+	/* Re-enable the ICACHE (unconditonally - it should always be turned on) */
+	cache_instr_enable();
+#endif /* CONFIG_SOC_SERIES_STM32H5X */
 
 	return 0;
 }

--- a/drivers/flash/flash_stm32h7x.c
+++ b/drivers/flash/flash_stm32h7x.c
@@ -861,6 +861,16 @@ static const struct flash_parameters *flash_stm32h7_get_parameters(const struct 
 	return &flash_stm32h7_parameters;
 }
 
+/* Gives the total logical device size in bytes and return 0. */
+static int flash_stm32h7_get_size(const struct device *dev, uint64_t *size)
+{
+	ARG_UNUSED(dev);
+
+	*size = (uint64_t)LL_GetFlashSize() * 1024U;
+
+	return 0;
+}
+
 void flash_stm32_page_layout(const struct device *dev, const struct flash_pages_layout **layout,
 			     size_t *layout_size)
 {
@@ -918,6 +928,7 @@ static DEVICE_API(flash, flash_stm32h7_api) = {
 	.write = flash_stm32h7_write,
 	.read = flash_stm32h7_read,
 	.get_parameters = flash_stm32h7_get_parameters,
+	.get_size = flash_stm32h7_get_size,
 #ifdef CONFIG_FLASH_PAGE_LAYOUT
 	.page_layout = flash_stm32_page_layout,
 #endif

--- a/drivers/flash/flash_stm32wb0x.c
+++ b/drivers/flash/flash_stm32wb0x.c
@@ -22,6 +22,7 @@
 #include <stm32_ll_bus.h>
 #include <stm32_ll_rcc.h>
 #include <stm32_ll_system.h>
+#include <stm32_ll_utils.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(flash_stm32wb0x, CONFIG_FLASH_LOG_LEVEL);
@@ -400,12 +401,24 @@ int flash_wb0x_erase(const struct device *dev, off_t offset, size_t size)
 const struct flash_parameters *flash_wb0x_get_parameters(
 					const struct device *dev)
 {
+	ARG_UNUSED(dev);
+
 	static const struct flash_parameters fp = {
 		.write_block_size = WRITE_BLOCK_SIZE,
 		.erase_value = 0xff,
 	};
 
 	return &fp;
+}
+
+/* Gives the total logical device size in bytes and return 0. */
+static int flash_wb0x_get_size(const struct device *dev, uint64_t *size)
+{
+	ARG_UNUSED(dev);
+
+	*size = (uint64_t)LL_GetFlashSize() * 1024U;
+
+	return 0;
 }
 
 #if defined(CONFIG_FLASH_PAGE_LAYOUT)
@@ -432,6 +445,7 @@ static DEVICE_API(flash, flash_wb0x_api) = {
 	.write = flash_wb0x_write,
 	.read = flash_wb0x_read,
 	.get_parameters = flash_wb0x_get_parameters,
+	.get_size = flash_wb0x_get_size,
 #ifdef CONFIG_FLASH_PAGE_LAYOUT
 	.page_layout = flash_wb0x_pages_layout,
 #endif

--- a/drivers/flash/flash_stm32wba_fm.c
+++ b/drivers/flash/flash_stm32wba_fm.c
@@ -18,6 +18,8 @@ LOG_MODULE_REGISTER(flash_stm32wba, CONFIG_FLASH_LOG_LEVEL);
 #include "flash_manager.h"
 #include "flash_driver.h"
 
+#include <stm32_ll_utils.h>
+
 /* Let's wait for double the max erase time to be sure that the operation is
  * completed.
  */
@@ -163,6 +165,16 @@ static const struct flash_parameters *
 	return &flash_stm32_parameters;
 }
 
+/* Gives the total logical device size in bytes and return 0. */
+static int flash_stm32h7_get_size(const struct device *dev, uint64_t *size)
+{
+	ARG_UNUSED(dev);
+
+	*size = (uint64_t)LL_GetFlashSize() * 1024U;
+
+	return 0;
+}
+
 static struct flash_stm32_priv flash_data = {
 	.regs = (FLASH_TypeDef *) DT_INST_REG_ADDR(0),
 };
@@ -192,6 +204,7 @@ static DEVICE_API(flash, flash_stm32_api) = {
 	.write = flash_stm32_write,
 	.read = flash_stm32_read,
 	.get_parameters = flash_stm32_get_parameters,
+	.get_size = flash_stm32_get_size,
 #ifdef CONFIG_FLASH_PAGE_LAYOUT
 	.page_layout = flash_stm32wba_page_layout,
 #endif

--- a/tests/drivers/flash/common/Kconfig
+++ b/tests/drivers/flash/common/Kconfig
@@ -4,11 +4,15 @@
 # Device/scenario dependent information that is not available in
 # other ways.
 
+DT_CHOSEN_Z_FLASH := zephyr,flash
+
 config TEST_DRIVER_FLASH_SIZE
 	int "Size of flash device under test"
+	default $(dt_chosen_reg_size_int,$(DT_CHOSEN_Z_FLASH),0) if SOC_FAMILY_STM32
 	default -1
 	help
 	  Expected flash device size the test will validate against. If the flash driver does not
 	  support the get_size() API, leave this set as -1 to skip the test.
+	  For the STM32 devices, the flash size is direclty given by the soc DTSI.
 
 source "Kconfig.zephyr"

--- a/tests/drivers/flash/common/testcase.yaml
+++ b/tests/drivers/flash/common/testcase.yaml
@@ -117,6 +117,14 @@ tests:
     extra_configs:
       - CONFIG_DMA=y
       - CONFIG_SOC_FLASH_SILABS_S2_DMA_READ=y
+  drivers.flash.common.stm32:
+    filter: ((CONFIG_FLASH_HAS_DRIVER_ENABLED and not CONFIG_TRUSTED_EXECUTION_NONSECURE)
+      and CONFIG_SOC_FAMILY_STM32
+      and dt_label_with_parent_compat_enabled("storage_partition", "fixed-partitions"))
+    integration_platforms:
+      - nucleo_g474re
+    platform_exclude:
+      - nucleo_wb55rg
   drivers.flash.common.non_quad_mode:
     extra_args:
       - EXTRA_DTC_OVERLAY_FILE=boards/mx25r64_non_quad.overlay


### PR DESCRIPTION
Add the support of the API function **flash_get_size** for the stm32 mcu devices

According to the [documentation](https://docs.zephyrproject.org/latest/doxygen/html/group__flash__interface.html#ga471edb53a2b1abe3dff0f4e2d216521e
), the size is in expressed in Bytes.
The stm32Cube LL function LL_GetFlashSize  is directly giving the size in Kbytes from the mcu register "FLASHSIZE_BASE" 

The tests/drivers/flash/common/ is modified to accept a testcase for all the stm32 targets when the 
CONFIG_TEST_DRIVER_FLASH_SIZE <> 1

```
TESTSUITE flash_driver succeeded                                                                        
                                                                                                        
------ TESTSUITE SUMMARY START ------                                                                   
                                                                                                        
SUITE PASS - 100.00% [flash_driver]: pass = 7, fail = 0, skip = 0, total = 7 duration = 0.370 seconds
 - PASS - [flash_driver.test_flash_copy] duration = 0.119 seconds
 - PASS - [flash_driver.test_flash_erase] duration = 0.055 seconds
 - PASS - [flash_driver.test_flash_fill] duration = 0.051 seconds
 - PASS - [flash_driver.test_flash_flatten] duration = 0.073 seconds
 - PASS - [flash_driver.test_flash_page_layout] duration = 0.032 seconds
 - PASS - [flash_driver.test_get_size] duration = 0.005 seconds
 - PASS - [flash_driver.test_read_unaligned_address] duration = 0.035 seconds

------ TESTSUITE SUMMARY END ------

===================================================================
PROJECT EXECUTION SUCCESSFUL
```


requires https://github.com/zephyrproject-rtos/zephyr/pull/83144