### PR TITLE
net: icmp: Add a way to send ICMP echo-req from system workqueue

### DIFF
--- a/include/zephyr/net/icmp.h
+++ b/include/zephyr/net/icmp.h
@@ -192,6 +192,30 @@ int net_icmp_send_echo_request(struct net_icmp_ctx *ctx,
 			       void *user_data);
 
 /**
+ * @brief Send ICMP echo request message without waiting during send.
+ *
+ * @details This function can be used to send ICMP Echo-Request from a system
+ *          workqueue handler which should not have any sleeps or waits.
+ *          This variant will do the net_buf allocations with K_NO_WAIT.
+ *          This will avoid a warning message in the log about the timeout.
+ *
+ * @param ctx ICMP context used in this request.
+ * @param iface Network interface, can be set to NULL in which case the
+ *        interface is selected according to destination address.
+ * @param dst IP address of the target host.
+ * @param params Echo-Request specific parameters. May be NULL in which case
+ *        suitable default parameters are used.
+ * @param user_data User supplied opaque data passed to the handler. May be NULL.
+ *
+ * @return Return 0 if the sending succeed, <0 otherwise.
+ */
+int net_icmp_send_echo_request_no_wait(struct net_icmp_ctx *ctx,
+				       struct net_if *iface,
+				       struct sockaddr *dst,
+				       struct net_icmp_ping_params *params,
+				       void *user_data);
+
+/**
  * @brief ICMP offload context structure.
  */
 struct net_icmp_offload {

--- a/subsys/net/lib/shell/ping.c
+++ b/subsys/net/lib/shell/ping.c
@@ -272,11 +272,11 @@ static void ping_work(struct k_work *work)
 	params.data = NULL;
 	params.data_size = ctx->payload_size;
 
-	ret = net_icmp_send_echo_request(&ctx->icmp,
-					 ctx->iface,
-					 &ctx->addr,
-					 &params,
-					 ctx);
+	ret = net_icmp_send_echo_request_no_wait(&ctx->icmp,
+						 ctx->iface,
+						 &ctx->addr,
+						 &params,
+						 ctx);
 	if (ret != 0) {
 		PR_WARNING("Failed to send ping, err: %d", ret);
 		ping_done(ctx);


### PR DESCRIPTION
Create a net_icmp_send_echo_request_from_work() variant that will not wait when allocating net_buf to be sent. This variant will avoid a warning to be printed when sending echo-req from a k_work handler because the function cannot sleep in this case.