### PR TITLE
Bluetooth: Mesh: Add documentation for mesh shell blob flash stream

### DIFF
--- a/doc/connectivity/bluetooth/api/mesh/shell.rst
+++ b/doc/connectivity/bluetooth/api/mesh/shell.rst
@@ -1170,6 +1170,27 @@ receiving any BLOB data, but the implementation in the mesh shell will discard t
 	Get a list of all BLOB Transfer Server model instances on the node.
 
 
+Binary Large Object (BLOB) Transfer flash stream
+------------------------------------------------
+BLOB flash stream configuration can be added to the mesh shell by enabling the
+:kconfig:option:`CONFIG_BT_MESH_SHELL_BLOB_IO_FLASH` option. By default, the shell uses a
+dummy BLOB stream. This option allows the user to specify which area in the flash to use.
+See :ref:`flash_map_api` for information on how to obtain related parameters.
+
+``mesh models blob flash-stream-set <AreaID> [<Offset>]``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+	Set the BLOB stream to a specified area.
+
+	* ``AreaID``: Flash area ID to write/read the BLOB to/from.
+	* ``Offset``: Optional offset into the flash area to place the BLOB at (in bytes).
+
+``mesh models blob flash-stream-unset``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+	Set the BLOB stream back to the dummy stream.
+
+
 Firmware Update Client model
 ----------------------------
 

--- a/doc/connectivity/bluetooth/api/mesh/shell.rst
+++ b/doc/connectivity/bluetooth/api/mesh/shell.rst
@@ -1492,9 +1492,9 @@ commands, a Firmware Distribution Server must be instantiated by the application
 DFU metadata
 ------------
 
-The DFU metadata commands allow generating metadata that can be used by a Target node to check the
-firmware before accepting it. The commands are enabled through the
-:kconfig:option:`CONFIG_BT_MESH_DFU_METADATA` configuration option.
+The DFU metadata shell commands allow generating metadata that can be used by a Target node to
+check the firmware before accepting it. The commands are enabled through the
+:kconfig:option:`CONFIG_BT_MESH_SHELL_DFU_METADATA` configuration option.
 
 ``mesh models dfu metadata comp-clear``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Adds documentation for the mesh shell blob flash stream feature. This feature allows the user to specify the flash area to write the BLOB to.