### PR TITLE
drivers: ethernet: Fix assert on receiving large PDUs

### DIFF
--- a/drivers/ethernet/eth_lan9250.c
+++ b/drivers/ethernet/eth_lan9250.c
@@ -504,7 +504,7 @@ static int lan9250_rx(const struct device *dev)
 
 		lan9250_read_buf(dev, data_ptr, data_len);
 		net_buf_add(pkt_buf, data_len);
-
+		pkt_buf = pkt_buf->frags;
 	} while (pkt_len > 0);
 
 	lan9250_read_sys_reg(dev, LAN9250_RX_DATA_FIFO, &tmp);


### PR DESCRIPTION
This patch fixes an assert in net_buf_simple_add() function when the lan_9250 driver would add previously added data to the net buffer on receiving large (>128 bytes) packat. This fix was to use the frags field of the net_buf structure instead.

Tested with a nRF54L15 DK and eth3 click board (with nordic connect sdk 2.8.0 and this patch).