### PR TITLE
[nRF54l] drivers/flash/Kconfig.nrf_rram: bufferd write by default

### DIFF
--- a/drivers/flash/Kconfig.nrf_rram
+++ b/drivers/flash/Kconfig.nrf_rram
@@ -24,7 +24,7 @@ if SOC_FLASH_NRF_RRAM
 config NRF_RRAM_WRITE_BUFFER_SIZE
 	int "Internal write-buffer size"
 	default 32 if !SOC_FLASH_NRF_RADIO_SYNC_NONE
-	default 0
+	default 1
 	range 0 32
 	help
 	  Number of 128-bit words.


### PR DESCRIPTION
Enable buffered write for nRF54l RRAM flash driver by default. CONFIG_NRF_RRAM_WRITE_BUFFER_SIZE=1 means that write will be buffered by 16 B buffer (native RRAM write-bock-size).
This allows optimal life-endurance of RRAM memory.

For reference" DTS declares 16 write-block-size alredy.