### PR TITLE
ci: do_not_merge: convert to python, pass instead of skip

### DIFF
--- a/.github/workflows/do_not_merge.yml
+++ b/.github/workflows/do_not_merge.yml
@@ -6,15 +6,21 @@ on:
 
 jobs:
   do-not-merge:
-    if: ${{ contains(github.event.*.labels.*.name, 'DNM') ||
-            contains(github.event.*.labels.*.name, 'TSC') ||
-            contains(github.event.*.labels.*.name, 'Architecture Review') ||
-            contains(github.event.*.labels.*.name, 'dev-review') }}
     name: Prevent Merging
     runs-on: ubuntu-22.04
     steps:
-      - name: Check for label
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.11
+
+      - name: Install Python dependencies
         run: |
-          echo "Pull request is labeled as 'DNM', 'TSC', 'Architecture Review' or 'dev-review'."
-          echo "This workflow fails so that the pull request cannot be merged."
-          exit 1
+          pip install PyGithub
+
+      - name: Run the check script
+        run: |
+          ./scripts/ci/do_not_merge.py -p "${{ github.event.pull_request.number }}"

--- a/scripts/ci/do_not_merge.py
+++ b/scripts/ci/do_not_merge.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+
+# Copyright 2024 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import os
+import sys
+
+import github
+
+DNM_LABELS = ["DNM", "TSC", "Architecture Review", "dev-review"]
+
+
+def parse_args(argv):
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        allow_abbrev=False,
+    )
+
+    parser.add_argument("-p", "--pr", required=True, type=int, help="The PR number")
+
+    return parser.parse_args(argv)
+
+
+def main(argv):
+    args = parse_args(argv)
+
+    token = os.environ.get('GITHUB_TOKEN', None)
+    gh = github.Github(token)
+    repo = gh.get_repo("zephyrproject-rtos/zephyr")
+    pr = repo.get_pull(args.pr)
+
+    for label in pr.get_labels():
+        if label.name in DNM_LABELS:
+            print(f"Pull request is labeled as \"{label.name}\".")
+            print("This workflow fails so that the pull request cannot be merged.")
+            sys.exit(1)
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
I've been troubleshooting some PR not showing on the merge list dashboard and I have a vague feeling that one of the issue could be GitHub mishandling workflows that fails and then skip but never succeed.

Try to address this by converting the do not merge run to something that passes instead of skipping, and also rewrite it in python while at it, which is probably unnecessary but kindof nice if we want to add more complex conditions down the road.