### PR TITLE
dts: arm: st: f4: fix die_temp channel

### DIFF
--- a/dts/arm/st/f4/stm32f4.dtsi
+++ b/dts/arm/st/f4/stm32f4.dtsi
@@ -592,7 +592,7 @@
 		ts-cal1-temp = <30>;
 		ts-cal2-temp = <110>;
 		ts-cal-vrefanalog = <3300>;
-		io-channels = <&adc1 18>;
+		io-channels = <&adc1 16>;
 		status = "disabled";
 	};
 

--- a/dts/arm/st/f4/stm32f410.dtsi
+++ b/dts/arm/st/f4/stm32f410.dtsi
@@ -106,8 +106,4 @@
 			status = "disabled";
 		};
 	};
-
-	die_temp: dietemp {
-		io-channels = <&adc1 18>;
-	};
 };

--- a/dts/arm/st/f4/stm32f412.dtsi
+++ b/dts/arm/st/f4/stm32f412.dtsi
@@ -242,4 +242,8 @@
 			status = "disabled";
 		};
 	};
+
+	die_temp: dietemp {
+		io-channels = <&adc1 18>;
+	};
 };


### PR DESCRIPTION
The STM32F4 socs have different channels for the temperature sensor. Some are at channel 16 and some at channel 18. Made changes wherever it was relevant.
In short, the base configuration is to channel 16 and wherever it is supposed to be 18 it is overridden.