### PR TITLE
dts: arm: st: added sensor aliases

### DIFF
--- a/boards/st/nucleo_l4r5zi/nucleo_l4r5zi.dts
+++ b/boards/st/nucleo_l4r5zi/nucleo_l4r5zi.dts
@@ -65,6 +65,7 @@
 		led2 = &red_led_0;
 		sw0 = &user_button;
 		pwm-led0 = &red_pwm_led;
+		die-temp0 = &die_temp;
 		volt-sensor0 = &vref;
 		volt-sensor1 = &vbat;
 	};
@@ -208,6 +209,10 @@ zephyr_udc0: &usbotg_fs {
 	pinctrl-names = "default";
 	st,adc-clock-source = <SYNC>;
 	st,adc-prescaler = <4>;
+	status = "okay";
+};
+
+&die_temp {
 	status = "okay";
 };
 

--- a/boards/st/stm32f411e_disco/stm32f411e_disco.dts
+++ b/boards/st/stm32f411e_disco/stm32f411e_disco.dts
@@ -81,6 +81,9 @@
 		accel0 = &lsm303agr_accel;
 		mcuboot-button0 = &user_button;
 		mcuboot-led0 = &orange_led_3;
+		die-temp0 = &die_temp;
+		volt-sensor0 = &vref;
+		volt-sensor1 = &vbat;
 	};
 };
 
@@ -192,4 +195,21 @@ zephyr_udc0: &usbotg_fs {
 			reg = <0x00060000 DT_SIZE_K(128)>;
 		};
 	};
+};
+
+&adc1 {
+	st,adc-prescaler = <2>;
+	status = "okay";
+};
+
+&die_temp {
+	status = "okay";
+};
+
+&vref {
+	status = "okay";
+};
+
+&vbat {
+	status = "okay";
 };

--- a/boards/st/stm32f4_disco/stm32f4_disco.dts
+++ b/boards/st/stm32f4_disco/stm32f4_disco.dts
@@ -77,6 +77,9 @@
 		led2 = &red_led_5;
 		led3 = &blue_led_6;
 		sw0 = &user_button;
+		die-temp0 = &die_temp;
+		volt-sensor0 = &vref;
+		volt-sensor1 = &vbat;
 	};
 };
 
@@ -165,5 +168,22 @@ zephyr_udc0: &usbotg_fs {
 &can2 {
 	pinctrl-0 = <&can2_rx_pb5 &can2_tx_pb13>;
 	pinctrl-names = "default";
+	status = "okay";
+};
+
+&adc1 {
+	st,adc-prescaler = <2>;
+	status = "okay";
+};
+
+&die_temp {
+	status = "okay";
+};
+
+&vref {
+	status = "okay";
+};
+
+&vbat {
 	status = "okay";
 };


### PR DESCRIPTION
Added aliases to nucleo_l4r5zi/stm32f4_disco/stm32f411e_disco for die_temp die_temp/vref/vbat nodes so that the die_temp_polling and soc_voltage samples work for them.