### PR TITLE
picolibc: Disable LTO while building picolibc bits

### DIFF
--- a/lib/libc/picolibc/CMakeLists.txt
+++ b/lib/libc/picolibc/CMakeLists.txt
@@ -11,6 +11,8 @@ zephyr_library_sources(
   stdio.c
   )
 
+zephyr_library_compile_options(-fno-lto)
+
 # define __LINUX_ERRNO_EXTENSIONS__ so we get errno defines like -ESHUTDOWN
 # used by the network stack
 zephyr_compile_definitions(__LINUX_ERRNO_EXTENSIONS__)

--- a/west.yml
+++ b/west.yml
@@ -328,7 +328,7 @@ manifest:
         - debug
     - name: picolibc
       path: modules/lib/picolibc
-      revision: d492d5fa7c96918e37653f303028346bb0dd51a2
+      revision: 82d62ed1ac55b4e34a12d0390aced2dc9af13fc9
     - name: segger
       revision: cf56b1d9c80f81a26e2ac5727c9cf177116a4692
       path: modules/debug/segger


### PR DESCRIPTION
The compiler requires that much of the C library be built without using LTO so that various symbols are available for use by generated code, including things like memset and memcpy.

Add -fno-lto when building both picolibc itself as well as the Zephyr interface bits.

Closes: #81674 