### PR TITLE
samples: st: power_mgmt: warn if running with debug on sleep enabled

### DIFF
--- a/soc/st/stm32/common/soc_config.c
+++ b/soc/st/stm32/common/soc_config.c
@@ -16,6 +16,15 @@
 #include <stm32_ll_bus.h>
 #include <stm32_ll_pwr.h>
 
+#if CONFIG_PM
+
+#if !defined(CONFIG_DEBUG) && defined(CONFIG_STM32_ENABLE_DEBUG_SLEEP_STOP)
+#warning "Running with PM=y and STM32_ENABLE_DEBUG_SLEEP_STOP=y, \
+this will result in increased power consumption during sleep."
+#endif
+
+#endif /* CONFIG_PM */
+
 /**
  * @brief Perform SoC configuration at boot.
  *


### PR DESCRIPTION
Hey bumped into this over the weekend, custom board, didn't realize RTT was flipping this option, digging it out was quite a miserable experience. :-) Would a warning in the sample make sense?

---

These samples are typically meant to test a device power consumption in sleep mode, running STM32_ENABLE_DEBUG_SLEEP_STOP=y kindof defeats the point and and happen silently is a board is running with RTT setup.

Add a warning on the sample if the option is enabled to notify the user of the situation.