### PR TITLE
drivers: dac mcp4725 Remove value check, and mask to allow power-down

### DIFF
--- a/drivers/dac/dac_mcp4725.c
+++ b/drivers/dac/dac_mcp4725.c
@@ -17,7 +17,6 @@ LOG_MODULE_REGISTER(dac_mcp4725, CONFIG_DAC_LOG_LEVEL);
  */
 
 /* Defines for field values in MCP4725 DAC register */
-#define MCP4725_DAC_MAX_VAL			0xFFF
 
 #define MCP4725_FAST_MODE_POWER_DOWN_POS	4U
 #define MCP4725_FAST_MODE_DAC_UPPER_VAL_POS	8U
@@ -94,18 +93,12 @@ static int mcp4725_write_value(const struct device *dev, uint8_t channel,
 		return -EINVAL;
 	}
 
-	/* Check value isn't over 12 bits */
-	if (value > MCP4725_DAC_MAX_VAL) {
-		return -ENOTSUP;
-	}
-
 	/* WRITE_MODE_FAST message format (2 bytes):
 	 *
 	 * ||     15 14     |        13 12        |    11 10 9 8    || 7 6 5 4 3 2 1 0 ||
 	 * || Fast mode (0) | Power-down bits (0) | DAC value[11:8] || DAC value[7:0]  ||
 	 */
-	tx_data[0] = ((value >> MCP4725_FAST_MODE_DAC_UPPER_VAL_POS) &
-		MCP4725_FAST_MODE_DAC_UPPER_VAL_MASK);
+	tx_data[0] = (value >> MCP4725_FAST_MODE_DAC_UPPER_VAL_POS);
 	tx_data[1] = (value & MCP4725_FAST_MODE_DAC_LOWER_VAL_MASK);
 	ret = i2c_write_dt(&config->i2c, tx_data, sizeof(tx_data));
 


### PR DESCRIPTION
MCP4725 has 2 power-down bits that allow one to put it in one of the 3 low power states. The current driver doesn't allow for setting those bits 

- with a value check that doesn't allow anything more than 12 bits
- a mask which ignores anything that's there in the first 4 bits of relevant byte

I have removed those two parts of the code so that I can write a value to the DAC that puts it in a low power mode.

- [datasheet for quick ref](https://ww1.microchip.com/downloads/en/DeviceDoc/MCP4725-Data-Sheet-20002039E.pdf)