### PR TITLE
doc: Correct semtech_sx1276mb1mas shield name

### DIFF
--- a/boards/shields/semtech_sx1276mb1mas/doc/index.rst
+++ b/boards/shields/semtech_sx1276mb1mas/doc/index.rst
@@ -58,7 +58,7 @@ Arduino connectors and defines node aliases for SPI and GPIO interfaces (see
 Programming
 ***********
 
-Set ``--shield semtech_sx1271mb1mas`` when you invoke ``west build``. For
+Set ``--shield semtech_sx1276mb1mas`` when you invoke ``west build``. For
 example:
 
 .. zephyr-app-commands::


### PR DESCRIPTION
The documentation for using the Semtech shield with the west build command incorrectly stated the shield name as semtech_sx1271mb1mas.
This PR corrects the name to semtech_sx1276mb1mas in the relevant documentation.

Fixes: #82688