### PR TITLE
hostap: fix build error when disable enterprise mode

### DIFF
--- a/modules/hostap/CMakeLists.txt
+++ b/modules/hostap/CMakeLists.txt
@@ -558,10 +558,6 @@ zephyr_library_compile_definitions_ifdef(CONFIG_EAP_FAST
   EAP_FAST
 )
 
-zephyr_library_compile_definitions_ifndef(CONFIG_WIFI_NM_WPA_SUPPLICANT_CRYPTO_ENTERPRISE
-  CONFIG_NO_CONFIG_BLOBS
-)
-
 zephyr_library_sources_ifdef(CONFIG_WIFI_NM_WPA_SUPPLICANT_EAPOL
   ${HOSTAP_SRC_BASE}/eapol_supp/eapol_supp_sm.c
   ${HOSTAP_SRC_BASE}/eap_peer/eap.c

--- a/tests/net/wifi/configs/testcase.yaml
+++ b/tests/net/wifi/configs/testcase.yaml
@@ -52,5 +52,4 @@ tests:
       - CONFIG_WIFI_NM_WPA_SUPPLICANT_INF_MON=n
   wifi.build.dpp:
     extra_configs:
-      - CONFIG_WIFI_NM_WPA_SUPPLICANT_CRYPTO_ENTERPRISE=y
       - CONFIG_WIFI_NM_WPA_SUPPLICANT_DPP=y


### PR DESCRIPTION
In Kconfig, already check both dpp and enterprise mode for enable NO_CONFIG_BLOBS, so remove the wrong one in the cmakelist.