### PR TITLE
drivers: wifi: nxp: remove SAP IPv4 address when stopped

### DIFF
--- a/drivers/wifi/nxp/nxp_wifi_drv.c
+++ b/drivers/wifi/nxp/nxp_wifi_drv.c
@@ -322,6 +322,12 @@ int nxp_wifi_wlan_event_callback(enum wlan_event_reason reason, void *data)
 		net_if_dormant_on(g_uap.netif);
 		LOG_DBG("WLAN: UAP Stopped");
 
+		if (net_addr_pton(AF_INET, CONFIG_NXP_WIFI_SOFTAP_IP_ADDRESS, &dhcps_addr4) < 0) {
+			LOG_ERR("Invalid CONFIG_NXP_WIFI_SOFTAP_IP_ADDRESS");
+		} else {
+			net_if_ipv4_addr_rm(g_uap.netif, &dhcps_addr4);
+		}
+
 		net_dhcpv4_server_stop(g_uap.netif);
 		LOG_DBG("DHCP Server stopped successfully");
 		s_nxp_wifi_UapActivated = false;


### PR DESCRIPTION
Start and stop SAP, the IPv4 address is not removed, if then use STA mode to connect to EXT-AP with same gateway address as the stopped SAP, STA will not get the DHCP IPv4 address, as the DHCP offer packet is dropped due to detect of IPv4 address conflict. Removing SAP IPv4 address when stopped SAP can fix this issue.