### PR TITLE
bluetooth: mesh: health_cli: Add callback to pull msg for periodic pub

### DIFF
--- a/doc/releases/release-notes-4.1.rst
+++ b/doc/releases/release-notes-4.1.rst
@@ -94,6 +94,11 @@ Bluetooth
 
 * HCI Drivers
 
+* Mesh
+
+  * Introduced a :c:member:`bt_mesh_health_cli::update` callback which is used to update the message
+    published periodically.
+
 Boards & SoC Support
 ********************
 

--- a/include/zephyr/bluetooth/mesh/health_cli.h
+++ b/include/zephyr/bluetooth/mesh/health_cli.h
@@ -99,6 +99,22 @@ struct bt_mesh_health_cli {
 			       uint8_t test_id, uint16_t cid, uint8_t *faults,
 			       size_t fault_count);
 
+	/** @brief Optional callback for updating the message to be sent as periodic publication.
+	 *
+	 *  This callback is called before sending the periodic publication message.
+	 *  The callback can be used to update the message to be sent.
+	 *
+	 *  If this callback is not implemented, periodic publication can still be enabled,
+	 *  but no messages will be sent.
+	 *
+	 *  @param cli Health client that is sending the periodic publication message.
+	 *  @param pub_buf Publication message buffer to be updated.
+	 *
+	 *  @return 0 if @p pub_buf is updated successfully, or (negative) error code on failure.
+	 *            The message won't be sent if an error is returned.
+	 */
+	int (*update)(struct bt_mesh_health_cli *cli, struct net_buf_simple *pub_buf);
+
 	/* Internal parameters for tracking message responses. */
 	struct bt_mesh_msg_ack_ctx ack_ctx;
 };

--- a/subsys/bluetooth/mesh/health_cli.c
+++ b/subsys/bluetooth/mesh/health_cli.c
@@ -402,6 +402,17 @@ void bt_mesh_health_cli_timeout_set(int32_t timeout)
 	msg_timeout = timeout;
 }
 
+static int update_callback(const struct bt_mesh_model *model)
+{
+	struct bt_mesh_health_cli *cli = model->rt->user_data;
+
+	if (cli->update) {
+		return cli->update(cli, &cli->pub_buf);
+	}
+
+	return -EINVAL;
+}
+
 static int health_cli_init(const struct bt_mesh_model *model)
 {
 	struct bt_mesh_health_cli *cli = model->rt->user_data;
@@ -417,6 +428,7 @@ static int health_cli_init(const struct bt_mesh_model *model)
 	msg_timeout = CONFIG_BT_MESH_HEALTH_CLI_TIMEOUT;
 
 	cli->pub.msg = &cli->pub_buf;
+	cli->pub.update = update_callback;
 	net_buf_simple_init_with_data(&cli->pub_buf, cli->pub_data, sizeof(cli->pub_data));
 
 	bt_mesh_msg_ack_ctx_init(&cli->ack_ctx);


### PR DESCRIPTION
The Health Client model supports periodic publication and thus requires the update callback to be initialized.

This commit implements a callback inside the health client model and adds a wrapper to it so that the user can fill up the msg buffer. This way, the Config Server will always accept
Config Model Publication Set message with periodic publication parameters. If the users callback returns an error or is not implemented, the periodic publication will be aborted.