### PR TITLE
drivers: dai: ssp: remove unused variables

### DIFF
--- a/drivers/dai/intel/ssp/ssp.c
+++ b/drivers/dai/intel/ssp/ssp.c
@@ -2075,8 +2075,6 @@ static void dai_ssp_set_reg_config(struct dai_intel_ssp *dp, const struct dai_co
 	struct dai_intel_ssp_plat_data *ssp_plat_data = dai_get_plat_data(dp);
 	const struct dai_intel_ipc4_ssp_config_ver_3_0 *regs = spec_config;
 	uint32_t sscr1 = 0;
-	uint32_t sstsa = 0;
-	uint32_t ssrsa = 0;
 	uint32_t ssc0 = regs->ssc0;
 	sscr1 = regs->ssc1 & ~(SSCR1_RSVD21);
 


### PR DESCRIPTION
Fix compiler warnings
/zep_workspace/zephyr/drivers/dai/intel/ssp/ssp.c:2079:18: error: unused variable 'ssrsa' [-Werror=unused-variable]
 2079 |         uint32_t ssrsa = 0;
      |                  ^~~~~
/zep_workspace/zephyr/drivers/dai/intel/ssp/ssp.c:2078:18: error: unused variable 'sstsa' [-Werror=unused-variable]
 2078 |         uint32_t sstsa = 0;
      |                  ^~~~~