### PR TITLE
modules: hal_tdk: Introduce kconfig symbol to prevent cmake warning

### DIFF
--- a/modules/hal_tdk/Kconfig
+++ b/modules/hal_tdk/Kconfig
@@ -2,13 +2,19 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config ZEPHYR_HAL_TDK_MODULE
-	bool "TDK HAL sensor drivers"
-	help
-	  Use the TDK HAL
+	bool
+
+menu "TDK drivers"
+
+config TDK_HAL
+	bool "TDK HAL drivers support"
 
 config USE_EMD_ICM42670
 	bool "ICM42x7x High Performance 6-Axis MotionTracking IMU"
 	default y
+	imply TDK_HAL
 	depends on ZEPHYR_HAL_TDK_MODULE
 	depends on DT_HAS_INVENSENSE_ICM42670P_ENABLED \
 		|| DT_HAS_INVENSENSE_ICM42670S_ENABLED
+
+endmenu

--- a/west.yml
+++ b/west.yml
@@ -243,7 +243,7 @@ manifest:
       groups:
         - hal
     - name: hal_tdk
-      revision: 16eaeeb54138348fb3227323d7d7c4b94e96ac3d
+      revision: bbdb38b789363615784e221f909ce18b791c2451
       path: modules/hal/tdk
       groups:
         - hal


### PR DESCRIPTION
The `CONFIG_ZEPHYR_HAL_TDK_MODULE` is always set if the module is on disk, introduce an implied symbol to prevent a cmake warning if no TDK drivers are needed.