### PR TITLE
boards: silabs: removed FLASH_BASE_ADDRESS

### DIFF
--- a/boards/silabs/dev_kits/xg24_dk2601b/Kconfig.defconfig
+++ b/boards/silabs/dev_kits/xg24_dk2601b/Kconfig.defconfig
@@ -9,10 +9,6 @@ config CMU_HFXO_FREQ
 config CMU_LFXO_FREQ
 	default 32768
 
-config FLASH_BASE_ADDRESS
-	hex
-	default 0x08000000
-
 if SOC_GECKO_USE_RAIL
 
 config FPU

--- a/boards/silabs/radio_boards/slwrb4104a/Kconfig.defconfig
+++ b/boards/silabs/radio_boards/slwrb4104a/Kconfig.defconfig
@@ -10,10 +10,6 @@ config CMU_HFXO_FREQ
 config CMU_LFXO_FREQ
 	default 32768
 
-config FLASH_BASE_ADDRESS
-	hex
-	default 0x0
-
 config LOG_BACKEND_SWO_FREQ_HZ
 	default 875000
 	depends on LOG_BACKEND_SWO

--- a/boards/silabs/radio_boards/slwrb4161a/Kconfig.defconfig
+++ b/boards/silabs/radio_boards/slwrb4161a/Kconfig.defconfig
@@ -10,10 +10,6 @@ config CMU_HFXO_FREQ
 config CMU_LFXO_FREQ
 	default 32768
 
-config FLASH_BASE_ADDRESS
-	hex
-	default 0x0
-
 config LOG_BACKEND_SWO_FREQ_HZ
 	default 875000
 	depends on LOG_BACKEND_SWO

--- a/boards/silabs/radio_boards/slwrb4170a/Kconfig.defconfig
+++ b/boards/silabs/radio_boards/slwrb4170a/Kconfig.defconfig
@@ -10,10 +10,6 @@ config CMU_HFXO_FREQ
 config CMU_LFXO_FREQ
 	default 32768
 
-config FLASH_BASE_ADDRESS
-	hex
-	default 0x0
-
 config LOG_BACKEND_SWO_FREQ_HZ
 	default 875000
 	depends on LOG_BACKEND_SWO

--- a/boards/silabs/radio_boards/slwrb4180a/Kconfig.defconfig
+++ b/boards/silabs/radio_boards/slwrb4180a/Kconfig.defconfig
@@ -10,10 +10,6 @@ config CMU_HFXO_FREQ
 config CMU_LFXO_FREQ
 	default 32768
 
-config FLASH_BASE_ADDRESS
-	hex
-	default 0x0
-
 config LOG_BACKEND_SWO_FREQ_HZ
 	default 875000
 	depends on LOG_BACKEND_SWO

--- a/boards/silabs/radio_boards/slwrb4250b/Kconfig.defconfig
+++ b/boards/silabs/radio_boards/slwrb4250b/Kconfig.defconfig
@@ -10,10 +10,6 @@ config CMU_HFXO_FREQ
 config CMU_LFXO_FREQ
 	default 32768
 
-config FLASH_BASE_ADDRESS
-	hex
-	default 0x0
-
 config LOG_BACKEND_SWO_FREQ_HZ
 	default 875000
 	depends on LOG_BACKEND_SWO

--- a/boards/silabs/radio_boards/slwrb4255a/Kconfig.defconfig
+++ b/boards/silabs/radio_boards/slwrb4255a/Kconfig.defconfig
@@ -10,10 +10,6 @@ config CMU_HFXO_FREQ
 config CMU_LFXO_FREQ
 	default 32768
 
-config FLASH_BASE_ADDRESS
-	hex
-	default 0x0
-
 config LOG_BACKEND_SWO_FREQ_HZ
 	default 875000
 	depends on LOG_BACKEND_SWO

--- a/boards/silabs/radio_boards/xg24_rb4187c/Kconfig.defconfig
+++ b/boards/silabs/radio_boards/xg24_rb4187c/Kconfig.defconfig
@@ -10,10 +10,6 @@ config CMU_HFXO_FREQ
 config CMU_LFXO_FREQ
 	default 32768
 
-config FLASH_BASE_ADDRESS
-	hex
-	default 0x08000000
-
 config LOG_BACKEND_SWO_FREQ_HZ
 	default 875000
 	depends on LOG_BACKEND_SWO

--- a/boards/sparkfun/thing_plus_matter_mgm240p/Kconfig.defconfig
+++ b/boards/sparkfun/thing_plus_matter_mgm240p/Kconfig.defconfig
@@ -12,10 +12,6 @@ config CMU_HFXO_FREQ
 config CMU_LFXO_FREQ
 	default 32768
 
-config FLASH_BASE_ADDRESS
-	hex
-	default 0x08000000
-
 if SOC_GECKO_USE_RAIL
 
 config FPU

--- a/dts/arm/silabs/efr32mg24.dtsi
+++ b/dts/arm/silabs/efr32mg24.dtsi
@@ -268,7 +268,7 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 
-			flash0: flash@0 {
+			flash0: flash@8000000 {
 				compatible = "soc-nv-flash";
 				write-block-size = <4>;
 				erase-block-size = <8192>;

--- a/dts/arm/silabs/efr32mg24b020f1536im40.dtsi
+++ b/dts/arm/silabs/efr32mg24b020f1536im40.dtsi
@@ -16,11 +16,9 @@
 		compatible = "silabs,efr32mg24b020f1536im40",
 					"silabs,efr32mg24", "silabs,efr32",
 					"simple-bus";
-
-		flash-controller@50030000 {
-			flash0: flash@0 {
-				reg = <0 DT_SIZE_K(1536)>;
-			};
-		 };
 	};
+};
+
+&flash0 {
+	reg = <0x08000000 DT_SIZE_K(1536)>;
 };

--- a/dts/arm/silabs/efr32mg24b220f1536im48.dtsi
+++ b/dts/arm/silabs/efr32mg24b220f1536im48.dtsi
@@ -16,11 +16,9 @@
 		compatible = "silabs,efr32mg24b220f1536im48",
 					 "silabs,efr32mg24", "silabs,efr32",
 					 "simple-bus";
-
-		flash-controller@50030000 {
-			flash0: flash@0 {
-				reg = <0 DT_SIZE_K(1536)>;
-			};
-		};
 	};
+};
+
+&flash0 {
+	reg = <0x08000000 DT_SIZE_K(1536)>;
 };

--- a/dts/arm/silabs/efr32mg24b310f1536im48.dtsi
+++ b/dts/arm/silabs/efr32mg24b310f1536im48.dtsi
@@ -16,11 +16,9 @@
 		compatible = "silabs,efr32mg24b310f1536im48",
 					 "silabs,efr32mg24", "silabs,efr32",
 					 "simple-bus";
-
-		flash-controller@50030000 {
-			flash0: flash@0 {
-				reg = <0 DT_SIZE_K(1536)>;
-			};
-		};
 	};
+};
+
+&flash0 {
+	reg = <0x08000000 DT_SIZE_K(1536)>;
 };


### PR DESCRIPTION
Removed FLASH_BASE_ADDRESS configuration from various boards' Kconfig. The only thing needed in order to do this was to update the relevant dtsi files so that the flash0 node has its reg property configured properly.