### PR TITLE
ci: do_not_merge: pass instead of skip on mergeable PRs

### DIFF
--- a/.github/workflows/do_not_merge.yml
+++ b/.github/workflows/do_not_merge.yml
@@ -6,14 +6,14 @@ on:
 
 jobs:
   do-not-merge:
-    if: ${{ contains(github.event.*.labels.*.name, 'DNM') ||
-            contains(github.event.*.labels.*.name, 'TSC') ||
-            contains(github.event.*.labels.*.name, 'Architecture Review') ||
-            contains(github.event.*.labels.*.name, 'dev-review') }}
     name: Prevent Merging
     runs-on: ubuntu-22.04
     steps:
       - name: Check for label
+        if: ${{ contains(github.event.*.labels.*.name, 'DNM') ||
+                contains(github.event.*.labels.*.name, 'TSC') ||
+                contains(github.event.*.labels.*.name, 'Architecture Review') ||
+                contains(github.event.*.labels.*.name, 'dev-review') }}
         run: |
           echo "Pull request is labeled as 'DNM', 'TSC', 'Architecture Review' or 'dev-review'."
           echo "This workflow fails so that the pull request cannot be merged."


### PR DESCRIPTION
Change the workflow to pass instead of skip if the PR is mergeable, just trying to see if it helps with PRs not appearing as mergeable because they do not match status:success when they should.