### PR TITLE
ci: general pip cleanup

### DIFF
--- a/.github/workflows/assigner.yml
+++ b/.github/workflows/assigner.yml
@@ -24,8 +24,7 @@ jobs:
     steps:
     - name: Install Python dependencies
       run: |
-        sudo pip3 install -U setuptools wheel pip
-        pip3 install -U PyGithub>=1.55 west
+        pip install -U PyGithub>=1.55 west
 
     - name: Check out source code
       uses: actions/checkout@v4

--- a/.github/workflows/backport_issue_check.yml
+++ b/.github/workflows/backport_issue_check.yml
@@ -25,8 +25,7 @@ jobs:
 
       - name: Install Python dependencies
         run: |
-          sudo pip3 install -U setuptools wheel pip
-          pip3 install -U pygithub
+          pip install -U pygithub
 
       - name: Run backport issue checker
         env:

--- a/.github/workflows/bsim-tests.yaml
+++ b/.github/workflows/bsim-tests.yaml
@@ -170,7 +170,7 @@ jobs:
 
       - name: Merge Test Results
         run: |
-          pip3 install junitparser junit2html
+          pip install junitparser junit2html
           junitparser merge --glob "./bsim_*/*bsim_results.*.xml" "./twister-out/twister.xml" junit.xml
           junit2html junit.xml junit.html
 

--- a/.github/workflows/bug_snapshot.yaml
+++ b/.github/workflows/bug_snapshot.yaml
@@ -25,8 +25,7 @@ jobs:
 
     - name: Install Python dependencies
       run: |
-        sudo pip3 install -U setuptools wheel pip
-        pip3 install -U pygithub
+        pip install -U pygithub
 
     - name: Snapshot bugs
       env:

--- a/.github/workflows/clang.yaml
+++ b/.github/workflows/clang.yaml
@@ -144,7 +144,7 @@ jobs:
           path: artifacts
       - name: Merge Test Results
         run: |
-          pip3 install junitparser junit2html
+          pip install junitparser junit2html
           junitparser merge artifacts/*/twister.xml junit.xml
           junit2html junit.xml junit-clang.html
 

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -101,7 +101,7 @@ jobs:
           export ZEPHYR_BASE=${PWD}
           export ZEPHYR_TOOLCHAIN_VARIANT=zephyr
           mkdir -p coverage/reports
-          pip3 install gcovr==6.0
+          pip install gcovr==6.0
           ./scripts/twister -E ${{matrix.normalized}}-testplan.json
           ls -la
           ./scripts/twister \
@@ -182,7 +182,7 @@ jobs:
       - name: Merge coverage files
         run: |
           pushd ./coverage/reports
-          pip3 install gcovr==6.0
+          pip install gcovr==6.0
           gcovr ${{ steps.get-coverage-files.outputs.mergefiles }}  --merge-mode-functions=separate --json merged.json
           gcovr ${{ steps.get-coverage-files.outputs.mergefiles }} --merge-mode-functions=separate --cobertura merged.xml
           popd

--- a/.github/workflows/coding_guidelines.yml
+++ b/.github/workflows/coding_guidelines.yml
@@ -21,9 +21,8 @@ jobs:
 
     - name: Install python dependencies
       run: |
-        pip3 install unidiff
-        pip3 install wheel
-        pip3 install sh
+        pip install unidiff
+        pip install sh
 
     - name: Install Packages
       run: |

--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -53,10 +53,8 @@ jobs:
 
     - name: Install python dependencies
       run: |
-        pip3 install setuptools
-        pip3 install wheel
-        pip3 install -r scripts/requirements-compliance.txt
-        pip3 install west
+        pip install -r scripts/requirements-compliance.txt
+        pip install west
 
     - name: west setup
       run: |

--- a/.github/workflows/daily_test_version.yml
+++ b/.github/workflows/daily_test_version.yml
@@ -25,7 +25,7 @@ jobs:
 
     - name: install-pip
       run: |
-        pip3 install gitpython
+        pip install gitpython
 
     - name: checkout
       uses: actions/checkout@v4

--- a/.github/workflows/devicetree_checks.yml
+++ b/.github/workflows/devicetree_checks.yml
@@ -62,8 +62,7 @@ jobs:
           ${{ runner.os }}-pip-${{ matrix.python-version }}
     - name: install python dependencies
       run: |
-        pip3 install wheel
-        pip3 install pytest pyyaml tox
+        pip install pytest pyyaml tox
     - name: run tox
       working-directory: scripts/dts/python-devicetree
       run: |

--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -108,11 +108,10 @@ jobs:
 
     - name: install-pip
       run: |
-        sudo pip3 install -U setuptools wheel pip
-        pip3 install -r doc/requirements.txt
-        pip3 install west==${WEST_VERSION}
-        pip3 install cmake==${CMAKE_VERSION}
-        pip3 install coverxygen
+        pip install -r doc/requirements.txt
+        pip install west==${WEST_VERSION}
+        pip install cmake==${CMAKE_VERSION}
+        pip install coverxygen
 
     - name: west setup
       run: |
@@ -223,10 +222,9 @@ jobs:
 
     - name: install-pip
       run: |
-        pip3 install -U setuptools wheel pip
-        pip3 install -r doc/requirements.txt
-        pip3 install west==${WEST_VERSION}
-        pip3 install cmake==${CMAKE_VERSION}
+        pip install -r doc/requirements.txt
+        pip install west==${WEST_VERSION}
+        pip install cmake==${CMAKE_VERSION}
 
     - name: west setup
       run: |

--- a/.github/workflows/footprint-tracking.yml
+++ b/.github/workflows/footprint-tracking.yml
@@ -58,7 +58,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y python3-venv
-          sudo pip3 install -U setuptools wheel pip gitpython
+          pip install -U gitpython
 
       - name: checkout
         uses: actions/checkout@v4
@@ -94,7 +94,7 @@ jobs:
         run: |
           python3 -m venv .venv
           . .venv/bin/activate
-          pip3 install awscli
+          pip install awscli
           aws s3 sync  --quiet footprint_data/ s3://testing.zephyrproject.org/footprint_data/
 
       - name: Transform Footprint data to Twister JSON reports
@@ -113,7 +113,7 @@ jobs:
           ELASTICSEARCH_INDEX: ${{ vars.FOOTPRINT_TRACKING_INDEX }}
         run: |
           shopt -s globstar
-          pip3 install -U elasticsearch
+          pip install -U elasticsearch
           run_date=`date --iso-8601=minutes`
           python3 ./scripts/ci/upload_test_results_es.py -r ${run_date} \
             --flatten footprint \

--- a/.github/workflows/manifest.yml
+++ b/.github/workflows/manifest.yml
@@ -20,7 +20,7 @@ jobs:
           BASE_REF: ${{ github.base_ref }}
         working-directory: zephyrproject/zephyr
         run: |
-          pip3 install west
+          pip install west
           git config --global user.email "you@example.com"
           git config --global user.name "Your Name"
           west init -l . || true

--- a/.github/workflows/pylib_tests.yml
+++ b/.github/workflows/pylib_tests.yml
@@ -44,7 +44,7 @@ jobs:
           ${{ runner.os }}-pip-${{ matrix.python-version }}
     - name: install-packages
       run: |
-        pip3 install -r scripts/requirements-base.txt -r scripts/requirements-build-test.txt
+        pip install -r scripts/requirements-base.txt -r scripts/requirements-build-test.txt
     - name: Run pytest for build_helpers
       env:
         ZEPHYR_BASE: ./

--- a/.github/workflows/scripts_tests.yml
+++ b/.github/workflows/scripts_tests.yml
@@ -64,7 +64,7 @@ jobs:
 
       - name: install-packages
         run: |
-          pip3 install -r scripts/requirements-base.txt -r scripts/requirements-build-test.txt
+          pip install -r scripts/requirements-base.txt -r scripts/requirements-build-test.txt
 
       - name: Run pytest
         env:

--- a/.github/workflows/stats_merged_prs.yml
+++ b/.github/workflows/stats_merged_prs.yml
@@ -20,5 +20,5 @@ jobs:
           ELASTICSEARCH_SERVER: "https://elasticsearch.zephyrproject.io:443"
           PR_STAT_ES_INDEX: ${{ vars.PR_STAT_ES_INDEX }}
         run: |
-          pip3 install pygithub elasticsearch
+          pip install pygithub elasticsearch
           python3 ./scripts/ci/stats/merged_prs.py --pull-request ${{ github.event.pull_request.number }} --repo ${{ github.repository }}

--- a/.github/workflows/twister-publish.yaml
+++ b/.github/workflows/twister-publish.yaml
@@ -37,7 +37,7 @@ jobs:
       - name: Upload to elasticsearch
         if: steps.download-artifacts.outputs.found_artifact == 'true'
         run: |
-          pip3 install elasticsearch
+          pip install elasticsearch
           # set run date on upload to get consistent and unified data across the matrix.
           run_date=`date --iso-8601=minutes`
           if [ "${{github.event.workflow_run.event}}" = "push" ]; then

--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -197,7 +197,7 @@ jobs:
           timestamp="$(date)"
           version="$(git describe --abbrev=12 --always)"
           echo -e "# Generated at $timestamp ($version)\n" > $FREEZE_FILE
-          pip3 freeze | tee -a $FREEZE_FILE
+          pip freeze | tee -a $FREEZE_FILE
 
       - if: matrix.subset == 1 && github.event_name == 'push'
         name: Upload the list of Python packages
@@ -223,7 +223,7 @@ jobs:
 
       - name: Merge Test Results
         run: |
-          pip3 install junitparser junit2html
+          pip install junitparser junit2html
           junitparser merge artifacts/*/*/twister.xml junit.xml
           junit2html junit.xml junit.html
 

--- a/.github/workflows/twister_tests.yml
+++ b/.github/workflows/twister_tests.yml
@@ -51,7 +51,7 @@ jobs:
           ${{ runner.os }}-pip-${{ matrix.python-version }}
     - name: install-packages
       run: |
-        pip3 install -r scripts/requirements-base.txt -r scripts/requirements-build-test.txt -r scripts/requirements-run-test.txt
+        pip install -r scripts/requirements-base.txt -r scripts/requirements-build-test.txt -r scripts/requirements-run-test.txt
     - name: Run pytest for twisterlib
       env:
         ZEPHYR_BASE: ./

--- a/.github/workflows/west_cmds.yml
+++ b/.github/workflows/west_cmds.yml
@@ -65,8 +65,7 @@ jobs:
           ${{ runner.os }}-pip-${{ matrix.python-version }}
     - name: install pytest
       run: |
-        pip3 install wheel
-        pip3 install pytest west pyelftools canopen natsort progress mypy intelhex psutil ply pyserial anytree
+        pip install pytest west pyelftools canopen natsort progress mypy intelhex psutil ply pyserial anytree
     - name: run pytest-win
       if: runner.os == 'Windows'
       run: |


### PR DESCRIPTION
Cleanup all pip commands in the various workflow
- drop the install/upgrade for setuptool pip and wheel, seems like this was introduced few years back to work around some old bug and it's not needed anymore
- use pip instead of pip3, that's probably been equivalent for quite a long time in the CI image