### PR TITLE
nrf54H: wifi: Fix application core boot

### DIFF
--- a/boards/shields/nrf7002eb/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/boards/shields/nrf7002eb/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Only GPIOs 1..11 are supported for PORT1 in nRF54H20DK board, for now
+ * remove this as Wi-Fi SR co-existence is not yet supported on this board.
+ * The external SR RF switch may not even be present on this board.
+ */
+&nrf70 {
+	/delete-property/ srrf-switch-gpios;
+};

--- a/drivers/wifi/nrf_wifi/Kconfig.nrfwifi
+++ b/drivers/wifi/nrf_wifi/Kconfig.nrfwifi
@@ -202,6 +202,8 @@ config NRF70_SR_COEX
 
 config NRF70_SR_COEX_RF_SWITCH
 	bool "GPIO configuration to control SR side RF switch position"
+	depends on $(dt_node_has_prop,nrf70, srrf-switch-gpios)
+	depends on NRF70_SR_COEX
 	help
 	  Select this option to enable GPIO configuration to control SR side RF switch position.
 	  If this GPIO is asserted (1), the SR side RF switch is connected to the Wi-Fi side (shared antenna).

--- a/drivers/wifi/nrf_wifi/Kconfig.nrfwifi
+++ b/drivers/wifi/nrf_wifi/Kconfig.nrfwifi
@@ -202,6 +202,10 @@ config NRF70_SR_COEX
 
 config NRF70_SR_COEX_RF_SWITCH
 	bool "GPIO configuration to control SR side RF switch position"
+	help
+	  Select this option to enable GPIO configuration to control SR side RF switch position.
+	  If this GPIO is asserted (1), the SR side RF switch is connected to the Wi-Fi side (shared antenna).
+	  If this GPIO is de-asserted (0), the SR side RF switch is connected to the SR side (separate antenna).
 
 config NRF70_WORKQ_STACK_SIZE
 	int "Stack size for workqueue"

--- a/drivers/wifi/nrf_wifi/src/coex.c
+++ b/drivers/wifi/nrf_wifi/src/coex.c
@@ -247,10 +247,8 @@ int nrf_wifi_config_sr_switch(bool separate_antennas)
 
 	if (separate_antennas) {
 		gpio_pin_set_dt(&sr_rf_switch_spec, 0x0);
-		LOG_INF("GPIO P1.10 set to 0");
 	} else {
 		gpio_pin_set_dt(&sr_rf_switch_spec, 0x1);
-		LOG_INF("GPIO P1.10 set to 1");
 	}
 
 	return 0;


### PR DESCRIPTION
Application core fails to boot if Wi-Fi is enabled due to unsupported GPIO.