### PR TITLE
drivers: lora: Add user_data to lora_recv_async

### DIFF
--- a/doc/releases/migration-guide-4.1.rst
+++ b/doc/releases/migration-guide-4.1.rst
@@ -332,6 +332,13 @@ MCUmgr
 Modem
 =====
 
+LoRa
+====
+
+* The function :c:func:`lora_recv_async` and callback ``lora_recv_cb`` now include an
+  additional ``user_data`` parameter, which is a void pointer. This parameter can be used to reference
+  any user-defined data structure. To maintain the current behavior, set this parameter to ``NULL``.
+
 Architectures
 *************
 

--- a/drivers/lora/sx12xx_common.h
+++ b/drivers/lora/sx12xx_common.h
@@ -29,7 +29,7 @@ int sx12xx_lora_send_async(const struct device *dev, uint8_t *data,
 int sx12xx_lora_recv(const struct device *dev, uint8_t *data, uint8_t size,
 		     k_timeout_t timeout, int16_t *rssi, int8_t *snr);
 
-int sx12xx_lora_recv_async(const struct device *dev, lora_recv_cb cb);
+int sx12xx_lora_recv_async(const struct device *dev, lora_recv_cb cb, void *user_data);
 
 int sx12xx_lora_config(const struct device *dev,
 		       struct lora_modem_config *config);

--- a/include/zephyr/drivers/lora.h
+++ b/include/zephyr/drivers/lora.h
@@ -121,7 +121,7 @@ struct lora_modem_config {
  * @see lora_recv() for argument descriptions.
  */
 typedef void (*lora_recv_cb)(const struct device *dev, uint8_t *data, uint16_t size,
-			     int16_t rssi, int8_t snr);
+			     int16_t rssi, int8_t snr, void *user_data);
 
 /**
  * @typedef lora_api_config()
@@ -168,7 +168,8 @@ typedef int (*lora_api_recv)(const struct device *dev, uint8_t *data,
  * @param dev Modem to receive data on.
  * @param cb Callback to run on receiving data.
  */
-typedef int (*lora_api_recv_async)(const struct device *dev, lora_recv_cb cb);
+typedef int (*lora_api_recv_async)(const struct device *dev, lora_recv_cb cb,
+			     void *user_data);
 
 /**
  * @typedef lora_api_test_cw()
@@ -286,14 +287,16 @@ static inline int lora_recv(const struct device *dev, uint8_t *data,
  * @param dev Modem to receive data on.
  * @param cb Callback to run on receiving data. If NULL, any pending
  *	     asynchronous receptions will be cancelled.
+ * @param user_data User data passed to callback
  * @return 0 when reception successfully setup, negative on error
  */
-static inline int lora_recv_async(const struct device *dev, lora_recv_cb cb)
+static inline int lora_recv_async(const struct device *dev, lora_recv_cb cb,
+			       void *user_data)
 {
 	const struct lora_driver_api *api =
 		(const struct lora_driver_api *)dev->api;
 
-	return api->recv_async(dev, cb);
+	return api->recv_async(dev, cb, user_data);
 }
 
 /**

--- a/samples/drivers/lora/receive/src/main.c
+++ b/samples/drivers/lora/receive/src/main.c
@@ -21,12 +21,13 @@ BUILD_ASSERT(DT_NODE_HAS_STATUS_OKAY(DEFAULT_RADIO_NODE),
 LOG_MODULE_REGISTER(lora_receive);
 
 void lora_receive_cb(const struct device *dev, uint8_t *data, uint16_t size,
-		     int16_t rssi, int8_t snr)
+		     int16_t rssi, int8_t snr, void *user_data)
 {
 	static int cnt;
 
 	ARG_UNUSED(dev);
 	ARG_UNUSED(size);
+	ARG_UNUSED(user_data);
 
 	LOG_INF("LoRa RX RSSI: %d dBm, SNR: %d dB", rssi, snr);
 	LOG_HEXDUMP_INF(data, size, "LoRa RX payload");
@@ -34,7 +35,7 @@ void lora_receive_cb(const struct device *dev, uint8_t *data, uint16_t size,
 	/* Stop receiving after 10 packets */
 	if (++cnt == 10) {
 		LOG_INF("Stopping packet receptions");
-		lora_recv_async(dev, NULL);
+		lora_recv_async(dev, NULL, NULL);
 	}
 }
 
@@ -85,7 +86,7 @@ int main(void)
 
 	/* Enable asynchronous reception */
 	LOG_INF("Asynchronous reception");
-	lora_recv_async(lora_dev, lora_receive_cb);
+	lora_recv_async(lora_dev, lora_receive_cb, NULL);
 	k_sleep(K_FOREVER);
 	return 0;
 }


### PR DESCRIPTION
Hi,

Right now, `lora_recv_async` does not allow to pass any user_data to callback. This makes the usage harder for example when wrapping API in c++.

This commit addresses this issue but it breaks the API, so we should discuss it first. Let me know what you think