### PR TITLE
manifest: update percepio

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -323,7 +323,7 @@ manifest:
       path: modules/lib/openthread
     - name: percepio
       path: modules/debug/percepio
-      revision: b68d17993109b9bee6b45dc8c9794e7b7bce236d
+      revision: 0d44033c744978ca2505a06640b4f6964c5411e6
       groups:
         - debug
     - name: picolibc


### PR DESCRIPTION
Update the percepio module to use TraceRecorder v4.10.2

Signed-off-by: Erik Tamlin <erik.tamlin@percepio.com>