### PR TITLE
drivers: wifi: esp_at: fix null pointer dereference issue

### DIFF
--- a/drivers/wifi/esp_at/esp.c
+++ b/drivers/wifi/esp_at/esp.c
@@ -811,9 +811,11 @@ static int cmd_ipd_parse_hdr(struct esp_data *dev,
 	}
 
 	*sock = esp_socket_ref_from_link_id(dev, link_id);
-	if (!sock) {
+
+	if (!*sock) {
 		LOG_ERR("No socket for link %ld", link_id);
-		return str - ipd_buf;
+		*data_offset = (str - ipd_buf);
+		return -ENOTCONN;
 	}
 
 	if (!ESP_PROTO_PASSIVE(esp_socket_ip_proto(*sock)) &&


### PR DESCRIPTION
fix null pointer dereference issue by assigning the return pointer to a temp variable and assign further after NULL check