### PR TITLE
scripts: west_commands: Support out-of-tree runners

### DIFF
--- a/doc/develop/modules.rst
+++ b/doc/develop/modules.rst
@@ -1050,6 +1050,25 @@ requirement files in the ``scripts`` directory of the module.
           - scripts/requirements-build.txt
           - scripts/requirements-doc.txt
 
+
+.. _modules-runners:
+
+External Runners
+================
+
+If a module has out of tree boards that require custom :ref:`runners <west-runner>`,
+then it can add a list to its ``zephyr/module.yml`` file, for example:
+
+
+.. code-block:: yaml
+
+    runners:
+      - file: scripts/my-runner.py
+
+
+Each file entry is imported when executing ``west flash`` or ``west debug`` and
+subclasses of the ``ZephyrBinaryRunner`` are registered for use.
+
 Module Inclusion
 ================
 

--- a/doc/develop/west/build-flash-debug.rst
+++ b/doc/develop/west/build-flash-debug.rst
@@ -779,17 +779,25 @@ To view all available options Renode supports, use::
 
   west simulate --runner=renode --renode-help
 
+Out of tree runners
+*******************
+
+:ref:`Zephyr modules <modules>` can have external runners discovered by adding python
+files in their :ref:`module.yml <modules-runners>`. Create an external runner class by
+inheriting from ``ZephyrBinaryRunner`` and implement all abstract methods.
+
+.. note::
+
+   Support for custom out-of-tree runners makes the ``runners.core`` module part of
+   the public API and backwards incompatible changes need to undergo the
+   :ref:`deprecation process <breaking_api_changes>`.
+
 Hacking
 *******
 
 This section documents the ``runners.core`` module used by the
 flash and debug commands. This is the core abstraction used to implement
 support for these features.
-
-.. warning::
-
-   These APIs are provided for reference, but they are more "shared code" used
-   to implement multiple extension commands than a stable API.
 
 Developers can add support for new ways to flash and debug Zephyr programs by
 implementing additional runners. To get this support into upstream Zephyr, the

--- a/scripts/zephyr_module.py
+++ b/scripts/zephyr_module.py
@@ -174,6 +174,15 @@ mapping:
             type: seq
             sequence:
               - type: str
+  runners:
+    required: false
+    type: seq
+    sequence:
+      - type: map
+        mapping:
+          file:
+            required: true
+            type: str
 '''
 
 MODULE_YML_PATH = PurePath('zephyr/module.yml')


### PR DESCRIPTION
Add runners entry to the module schema and import the file(s) specified.

Every class that inherits from ZephyrBinaryRunner and implements all abstract methods will be discovered and added to runners list.

Add an entry to `zephyr/module.yml` to test:

```yaml
runners:
  - file: scripts/runners.py # relative to the project's root
```

Example added here: https://github.com/zephyrproject-rtos/example-application/pull/78

Fixes #83145