### PR TITLE
drivers: sensor: dht: Fix sensor read issue on esp32_devkitc_wrover

### DIFF
--- a/drivers/sensor/aosong/dht/dht.c
+++ b/drivers/sensor/aosong/dht/dht.c
@@ -82,8 +82,6 @@ static int dht_sample_fetch(const struct device *dev,
 
 	k_busy_wait(DHT_START_SIGNAL_DURATION);
 
-	gpio_pin_set_dt(&cfg->dio_gpio, false);
-
 	/* switch to DIR_IN to read sensor signals */
 	gpio_pin_configure_dt(&cfg->dio_gpio, GPIO_INPUT);
 


### PR DESCRIPTION
The DHT[11/22] sensor driver fails to read data due to an extra
"gpio_pin_set_dt" that occurs before waiting for the sensor active
response. This leads to consistent failed reads on esp32. After
removing this line reads are consistently successful when testing with
both a DHT11 and DHT22 sensor connected to an esp32_devkitc_wrover.

Signed-off-by: Omar Naffaa <omarnaffaa.on@gmail.com>