### PR TITLE
MAINTAINERS: Add djiatsaf-st as STM32 collaborator

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -4027,6 +4027,7 @@ STM32 Platforms:
     - GeorgeCGV
     - marwaiehm-st
     - mathieuchopstm
+    - djiatsaf-st
   files:
     - boards/st/
     - drivers/*/*stm32*.c


### PR DESCRIPTION
Add djiatsaf-st  as STM32 collaborator.

See https://github.com/zephyrproject-rtos/zephyr/pulls?q=is%3Apr+author%3Adjiatsaf-st+ for the list of his contributions so far.
Having him as part of collaborators, will fasten review turn around time.