### PR TITLE
Bluetooth: BAP: Add common capability check

### DIFF
--- a/subsys/bluetooth/audio/pacs.c
+++ b/subsys/bluetooth/audio/pacs.c
@@ -1305,3 +1305,36 @@ enum bt_audio_context bt_pacs_get_available_contexts_for_conn(struct bt_conn *co
 
 	return pacs_get_available_contexts_for_conn(conn, dir);
 }
+
+struct codec_cap_lookup_id_data {
+	const struct bt_pac_codec *codec_id;
+	const struct bt_audio_codec_cap *codec_cap;
+};
+
+static bool codec_lookup_id(const struct bt_pacs_cap *cap, void *user_data)
+{
+	struct codec_cap_lookup_id_data *data = user_data;
+
+	if (cap->codec_cap->id == data->codec_id->id &&
+	    cap->codec_cap->cid == data->codec_id->cid &&
+	    cap->codec_cap->vid == data->codec_id->vid) {
+		data->codec_cap = cap->codec_cap;
+
+		return false;
+	}
+
+	return true;
+}
+
+const struct bt_audio_codec_cap *bt_pacs_get_codec_cap(enum bt_audio_dir dir,
+						       const struct bt_pac_codec *codec_id)
+{
+	struct codec_cap_lookup_id_data lookup_data = {
+		.codec_id = codec_id,
+		.codec_cap = NULL,
+	};
+
+	bt_pacs_cap_foreach(dir, codec_lookup_id, &lookup_data);
+
+	return lookup_data.codec_cap;
+}

--- a/subsys/bluetooth/audio/pacs_internal.h
+++ b/subsys/bluetooth/audio/pacs_internal.h
@@ -9,6 +9,7 @@
 
 #include <stdint.h>
 
+#include <zephyr/bluetooth/audio/audio.h>
 #include <zephyr/sys/util_macro.h>
 
 #define BT_AUDIO_LOCATION_MASK BIT_MASK(28)
@@ -38,3 +39,6 @@ struct bt_pacs_context {
 	uint16_t  snk;
 	uint16_t  src;
 } __packed;
+
+const struct bt_audio_codec_cap *bt_pacs_get_codec_cap(enum bt_audio_dir dir,
+						       const struct bt_pac_codec *codec_id);

--- a/tests/bluetooth/audio/mocks/src/pacs.c
+++ b/tests/bluetooth/audio/mocks/src/pacs.c
@@ -4,10 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/bluetooth/audio/audio.h>
 #include <zephyr/types.h>
 #include <zephyr/bluetooth/audio/pacs.h>
 
 #include "pacs.h"
+#include "pacs_internal.h"
 
 /* List of fakes used by this unit tester */
 #define PACS_FFF_FAKES_LIST(FAKE) \
@@ -48,4 +50,12 @@ void mock_bt_pacs_init(void)
 void mock_bt_pacs_cleanup(void)
 {
 
+}
+
+const struct bt_audio_codec_cap *bt_pacs_get_codec_cap(enum bt_audio_dir dir,
+						       const struct bt_pac_codec *codec_id)
+{
+	static struct bt_audio_codec_cap mock_cap;
+
+	return &mock_cap;
 }


### PR DESCRIPTION
Instead of having 2 separate and non-equal checks for capabilities in ASCS and the Broadcast Sink, there is now a single function in pacs.c that performs the
check.

This reduces code size and makes it easier to maintain.