### PR TITLE
Add Clock Control driver support for Renesas RZ/G3S

### DIFF
--- a/boards/renesas/rzg3s_smarc/doc/index.rst
+++ b/boards/renesas/rzg3s_smarc/doc/index.rst
@@ -73,6 +73,8 @@ and the following hardware features:
 +-----------+------------+-------------------------------------+
 | INTC      | on-chip    | external interrupt controller       |
 +-----------+------------+-------------------------------------+
+| CLOCK     | on-chip    | clock control                       |
++-----------+------------+-------------------------------------+
 
 Other hardware features are currently not supported by the port.
 

--- a/drivers/clock_control/CMakeLists.txt
+++ b/drivers/clock_control/CMakeLists.txt
@@ -35,6 +35,7 @@ zephyr_library_sources_ifdef(CONFIG_CLOCK_CONTROL_SMARTBOND           clock_cont
 zephyr_library_sources_ifdef(CONFIG_CLOCK_CONTROL_NUMAKER_SCC         clock_control_numaker_scc.c)
 zephyr_library_sources_ifdef(CONFIG_CLOCK_CONTROL_NXP_S32             clock_control_nxp_s32.c)
 zephyr_library_sources_ifdef(CONFIG_CLOCK_CONTROL_RENESAS_RA_CGC      clock_control_renesas_ra_cgc.c)
+zephyr_library_sources_ifdef(CONFIG_CLOCK_CONTROL_RENESAS_RZ_CPG      clock_control_renesas_rz_cpg.c)
 zephyr_library_sources_ifdef(CONFIG_CLOCK_CONTROL_AMBIQ               clock_control_ambiq.c)
 zephyr_library_sources_ifdef(CONFIG_CLOCK_CONTROL_PWM                 clock_control_pwm.c)
 zephyr_library_sources_ifdef(CONFIG_CLOCK_CONTROL_RPI_PICO            clock_control_rpi_pico.c)

--- a/drivers/clock_control/Kconfig
+++ b/drivers/clock_control/Kconfig
@@ -88,6 +88,8 @@ source "drivers/clock_control/Kconfig.agilex5"
 
 source "drivers/clock_control/Kconfig.renesas_ra_cgc"
 
+source "drivers/clock_control/Kconfig.renesas_rz_cpg"
+
 source "drivers/clock_control/Kconfig.max32"
 
 source "drivers/clock_control/Kconfig.ambiq"

--- a/drivers/clock_control/Kconfig.renesas_rz_cpg
+++ b/drivers/clock_control/Kconfig.renesas_rz_cpg
@@ -1,0 +1,12 @@
+# Copyright (c) 2024 Renesas Electronics Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+config CLOCK_CONTROL_RENESAS_RZ_CPG
+	bool "Renesas RZ/G Clock Control Driver"
+	default y
+	depends on DT_HAS_RENESAS_RZ_CPG_ENABLED
+	select USE_RZ_FSP_CPG
+	help
+	  Enable support for Renesas RZ CPG Clock Pulse Generator (CPG) driver.
+	  The CPG driver supports only module's clocks.
+	  The PLLs and core clocks are not configured by the CPG driver.

--- a/drivers/clock_control/clock_control_renesas_rz_cpg.c
+++ b/drivers/clock_control/clock_control_renesas_rz_cpg.c
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2024 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/drivers/clock_control.h>
+#include <zephyr/dt-bindings/clock/renesas_rzg_clock.h>
+#include <zephyr/kernel.h>
+
+#define DT_DRV_COMPAT renesas_rz_cpg
+
+static int clock_control_renesas_rz_on(const struct device *dev, clock_control_subsys_t sys)
+{
+	if (!dev || !sys) {
+		return -EINVAL;
+	}
+
+	uint32_t *clock_id = (uint32_t *)sys;
+
+	uint32_t ip = (*clock_id & RZ_IP_MASK) >> RZ_IP_SHIFT;
+	uint32_t ch = (*clock_id & RZ_IP_CH_MASK) >> RZ_IP_CH_SHIFT;
+
+	switch (ip) {
+	case RZ_IP_GTM:
+		R_BSP_MODULE_START(FSP_IP_GTM, ch);
+		break;
+	case RZ_IP_GPT:
+		R_BSP_MODULE_START(FSP_IP_GPT, ch);
+		break;
+	case RZ_IP_SCIF:
+		R_BSP_MODULE_START(FSP_IP_SCIF, ch);
+		break;
+	case RZ_IP_RIIC:
+		R_BSP_MODULE_START(FSP_IP_RIIC, ch);
+		break;
+	case RZ_IP_RSPI:
+		R_BSP_MODULE_START(FSP_IP_RSPI, ch);
+		break;
+	case RZ_IP_MHU:
+		R_BSP_MODULE_START(FSP_IP_MHU, ch);
+		break;
+	case RZ_IP_DMAC:
+		R_BSP_MODULE_START(FSP_IP_DMAC, ch);
+		break;
+	case RZ_IP_CANFD:
+		R_BSP_MODULE_START(FSP_IP_CANFD, ch);
+		break;
+	case RZ_IP_ADC:
+		R_BSP_MODULE_START(FSP_IP_ADC, ch);
+		break;
+	default:
+		return -EINVAL; /* Invalid FSP IP Module */
+	}
+
+	return 0;
+}
+
+static int clock_control_renesas_rz_off(const struct device *dev, clock_control_subsys_t sys)
+{
+	if (!dev || !sys) {
+		return -EINVAL;
+	}
+
+	uint32_t *clock_id = (uint32_t *)sys;
+
+	uint32_t ip = (*clock_id & RZ_IP_MASK) >> RZ_IP_SHIFT;
+	uint32_t ch = (*clock_id & RZ_IP_CH_MASK) >> RZ_IP_CH_SHIFT;
+
+	switch (ip) {
+	case RZ_IP_GTM:
+		R_BSP_MODULE_STOP(FSP_IP_GTM, ch);
+		break;
+	case RZ_IP_GPT:
+		R_BSP_MODULE_STOP(FSP_IP_GPT, ch);
+		break;
+	case RZ_IP_SCIF:
+		R_BSP_MODULE_STOP(FSP_IP_SCIF, ch);
+		break;
+	case RZ_IP_RIIC:
+		R_BSP_MODULE_STOP(FSP_IP_RIIC, ch);
+		break;
+	case RZ_IP_RSPI:
+		R_BSP_MODULE_STOP(FSP_IP_RSPI, ch);
+		break;
+	case RZ_IP_MHU:
+		R_BSP_MODULE_STOP(FSP_IP_MHU, ch);
+		break;
+	case RZ_IP_DMAC:
+		R_BSP_MODULE_STOP(FSP_IP_DMAC, ch);
+		break;
+	case RZ_IP_CANFD:
+		R_BSP_MODULE_STOP(FSP_IP_CANFD, ch);
+		break;
+	case RZ_IP_ADC:
+		R_BSP_MODULE_STOP(FSP_IP_ADC, ch);
+		break;
+	default:
+		return -EINVAL; /* Invalid */
+	}
+	return 0;
+}
+
+static int clock_control_renesas_rz_get_rate(const struct device *dev, clock_control_subsys_t sys,
+					     uint32_t *rate)
+{
+	if (!dev || !sys || !rate) {
+		return -EINVAL;
+	}
+
+	uint32_t *clock_id = (uint32_t *)sys;
+
+	fsp_priv_clock_t clk_src = (*clock_id & RZ_CLOCK_MASK) >> RZ_CLOCK_SHIFT;
+	uint32_t clk_div = (*clock_id & RZ_CLOCK_DIV_MASK) >> RZ_CLOCK_DIV_SHIFT;
+
+	uint32_t clk_hz = R_FSP_SystemClockHzGet(clk_src);
+	*rate = clk_hz / clk_div;
+	return 0;
+}
+
+static DEVICE_API(clock_control, rz_clock_control_driver_api) = {
+	.on = clock_control_renesas_rz_on,
+	.off = clock_control_renesas_rz_off,
+	.get_rate = clock_control_renesas_rz_get_rate,
+};
+
+static int clock_control_rz_init(const struct device *dev)
+{
+	ARG_UNUSED(dev);
+	return 0;
+}
+
+DEVICE_DT_INST_DEFINE(0, clock_control_rz_init, NULL, NULL, NULL, PRE_KERNEL_1,
+		      CONFIG_CLOCK_CONTROL_INIT_PRIORITY, &rz_clock_control_driver_api);

--- a/dts/arm/renesas/rz/rzg/r9a08g045.dtsi
+++ b/dts/arm/renesas/rz/rzg/r9a08g045.dtsi
@@ -6,6 +6,7 @@
 
 #include <arm/armv8-m.dtsi>
 #include <mem.h>
+#include <freq.h>
 
 / {
 	compatible = "renesas,r9a08g045";
@@ -31,7 +32,165 @@
 		};
 	};
 
+	osc: osc {
+		compatible = "fixed-clock";
+		clock-frequency = <DT_FREQ_M(24)>;
+		#clock-cells = <0>;
+	};
+
 	soc {
+		cpg: clock-controller@41010000 {
+			compatible = "renesas,rz-cpg";
+			reg = <0x41010000 0x10000>;
+			clocks = <&osc>;
+			#clock-cells = <1>;
+			status = "okay";
+
+			iclk: iclk {
+				compatible = "fixed-clock";
+				clock-frequency = <DT_FREQ_M(1100)>;
+				#clock-cells = <0>;
+			};
+
+			p0clk: p0clk {
+				compatible = "fixed-clock";
+				clock-frequency = <DT_FREQ_M(100)>;
+				#clock-cells = <0>;
+			};
+
+			p4clk: p4clk {
+				compatible = "fixed-clock";
+				clock-frequency = <DT_FREQ_M(160)>;
+				#clock-cells = <0>;
+			};
+
+			p5clk: p5clk {
+				compatible = "fixed-clock";
+				clock-frequency = <DT_FREQ_M(200)>;
+				#clock-cells = <0>;
+			};
+
+			tsuclk: tsuclk {
+				compatible = "fixed-clock";
+				clock-frequency = <DT_FREQ_M(100)>;
+				#clock-cells = <0>;
+			};
+
+			sd0clk: sd0clk {
+				compatible = "fixed-clock";
+				clock-frequency = <133333333>;
+				#clock-cells = <0>;
+			};
+
+			sd1clk: sd1clk {
+				compatible = "fixed-clock";
+				clock-frequency = <133333333>;
+				#clock-cells = <0>;
+			};
+
+			sd2clk: sd2clk {
+				compatible = "fixed-clock";
+				clock-frequency = <133333333>;
+				#clock-cells = <0>;
+			};
+
+			m0clk: m0clk {
+				compatible = "fixed-clock";
+				clock-frequency = <DT_FREQ_M(200)>;
+				#clock-cells = <0>;
+			};
+
+			p1clk: p1clk {
+				compatible = "fixed-clock";
+				clock-frequency = <DT_FREQ_M(200)>;
+				#clock-cells = <0>;
+			};
+
+			p2clk: p2clk {
+				compatible = "fixed-clock";
+				clock-frequency = <DT_FREQ_M(100)>;
+				#clock-cells = <0>;
+			};
+
+			p3clk: p3clk {
+				compatible = "fixed-clock";
+				clock-frequency = <DT_FREQ_M(200)>;
+				#clock-cells = <0>;
+			};
+
+			atclk: atclk {
+				compatible = "fixed-clock";
+				clock-frequency = <DT_FREQ_M(400)>;
+				#clock-cells = <0>;
+			};
+
+			ztclk: ztclk {
+				compatible = "fixed-clock";
+				clock-frequency = <DT_FREQ_M(100)>;
+				#clock-cells = <0>;
+			};
+
+			oc0clk: oc0clk {
+				compatible = "fixed-clock";
+				clock-frequency = <33333333>;
+				#clock-cells = <0>;
+			};
+
+			oc1clk: oc1clk {
+				compatible = "fixed-clock";
+				clock-frequency = <16666666>;
+				#clock-cells = <0>;
+			};
+
+			spi0clk: spi0clk {
+				compatible = "fixed-clock";
+				clock-frequency = <33333333>;
+				#clock-cells = <0>;
+			};
+
+			spi1clk: spi1clk {
+				compatible = "fixed-clock";
+				clock-frequency = <16666666>;
+				#clock-cells = <0>;
+			};
+
+			s0clk: s0clk {
+				compatible = "fixed-clock";
+				clock-frequency = <DT_FREQ_M(400)>;
+				#clock-cells = <0>;
+			};
+
+			i2clk: i2clk {
+				compatible = "fixed-clock";
+				clock-frequency = <DT_FREQ_M(250)>;
+				#clock-cells = <0>;
+			};
+
+			i3clk: i3clk {
+				compatible = "fixed-clock";
+				clock-frequency = <DT_FREQ_M(250)>;
+				#clock-cells = <0>;
+			};
+
+			hpclk: hpclk {
+				compatible = "fixed-clock";
+				clock-frequency = <DT_FREQ_M(250)>;
+				#clock-cells = <0>;
+			};
+
+			oscclk: oscclk {
+				compatible = "fixed-clock";
+				clock-frequency = <DT_FREQ_M(24)>;
+				#clock-cells = <0>;
+			};
+
+			osc2clk: osc2clk {
+				compatible = "fixed-clock";
+				clock-frequency = <DT_FREQ_M(8)>;
+				#clock-cells = <0>;
+			};
+		};
+
 		pinctrl: pin-controller@41030000 {
 			compatible = "renesas,rzg-pinctrl";
 			reg = <0x41030000 DT_SIZE_K(64)>;

--- a/dts/bindings/clock/renesas,rz-cpg.yml
+++ b/dts/bindings/clock/renesas,rz-cpg.yml
@@ -1,0 +1,15 @@
+# Copyright (c) 2024 Renesas Electronics Corporation24
+# SPDX-License-Identifier: Apache-2.0
+
+description: RZ Clock Pulse Generator
+compatible: "renesas,rz-cpg"
+
+include: [base.yaml, clock-controller.yaml]
+
+properties:
+
+  "#clock-cells":
+    const: 1
+
+clock-cells:
+  - clk-id

--- a/include/zephyr/dt-bindings/clock/renesas_rzg_clock.h
+++ b/include/zephyr/dt-bindings/clock/renesas_rzg_clock.h
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2024 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_RENESAS_RZG_CLOCK_H_
+#define ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_RENESAS_RZG_CLOCK_H_
+
+/** RZ clock configuration values */
+#define RZ_IP_MASK         0xFF000000UL
+#define RZ_IP_SHIFT        24UL
+#define RZ_IP_CH_MASK      0xFF0000UL
+#define RZ_IP_CH_SHIFT     16UL
+#define RZ_CLOCK_MASK      0xFF00UL
+#define RZ_CLOCK_SHIFT     8UL
+#define RZ_CLOCK_DIV_MASK  0xFFUL
+#define RZ_CLOCK_DIV_SHIFT 0UL
+
+#define RZ_IP_GTM   0UL /* General Timer */
+#define RZ_IP_GPT   1UL /* General PWM Timer */
+#define RZ_IP_SCIF  2UL /* Serial Communications Interface with FIFO */
+#define RZ_IP_RIIC  3UL /* I2C Bus Interface */
+#define RZ_IP_RSPI  4UL /* Renesas Serial Peripheral Interface */
+#define RZ_IP_MHU   5UL /* Message Handling Unit */
+#define RZ_IP_DMAC  6UL /* Direct Memory Access Controller */
+#define RZ_IP_CANFD 7UL /* CANFD Interface (RS-CANFD) */
+#define RZ_IP_ADC   8UL /* A/D Converter */
+
+#define RZ_CLOCK_ICLK    0UL  /* Cortex-A55 Clock */
+#define RZ_CLOCK_I2CLK   1UL  /* Cortex-M33 Clock */
+#define RZ_CLOCK_I3CLK   2UL  /* Cortex-M33 FPU Clock */
+#define RZ_CLOCK_S0CLK   3UL  /* DDR-PHY Clock */
+#define RZ_CLOCK_OC0CLK  4UL  /* OCTA0 Clock */
+#define RZ_CLOCK_OC1CLK  5UL  /* OCTA1 Clock */
+#define RZ_CLOCK_SPI0CLK 6UL  /* SPI0 Clock */
+#define RZ_CLOCK_SPI1CLK 7UL  /* SPI1 Clock */
+#define RZ_CLOCK_SD0CLK  8UL  /* SDH0 Clock */
+#define RZ_CLOCK_SD1CLK  9UL  /* SDH1 Clock */
+#define RZ_CLOCK_SD2CLK  10UL /* SDH2 Clock */
+#define RZ_CLOCK_M0CLK   11UL /* VCP LCDC Clock */
+#define RZ_CLOCK_HPCLK   12UL /* Ethernet Clock */
+#define RZ_CLOCK_TSUCLK  13UL /* TSU Clock */
+#define RZ_CLOCK_ZTCLK   14UL /* JAUTH Clock */
+#define RZ_CLOCK_P0CLK   15UL /* APB-BUS Clock */
+#define RZ_CLOCK_P1CLK   16UL /* AXI-BUS Clock */
+#define RZ_CLOCK_P2CLK   17UL /* P2CLK */
+#define RZ_CLOCK_P3CLK   18UL /* P3CLK */
+#define RZ_CLOCK_P4CLK   19UL /* P4CLK */
+#define RZ_CLOCK_P5CLK   20UL /* P5CLK */
+#define RZ_CLOCK_ATCLK   21UL /* ATCLK */
+#define RZ_CLOCK_OSCCLK  22UL /* OSC Clock */
+#define RZ_CLOCK_OSCCLK2 23UL /* OSC2 Clock */
+
+#define RZ_CLOCK(IP, ch, clk, div)                                                                 \
+	((RZ_IP_##IP << RZ_IP_SHIFT) | ((ch) << RZ_IP_CH_SHIFT) | ((clk) << RZ_CLOCK_SHIFT) |      \
+	 ((div) << RZ_CLOCK_DIV_SHIFT))
+
+/**
+ * Pack clock configurations in a 32-bit value
+ * as expected for the Device Tree `clocks` property on Renesas RZ/G.
+ *
+ * @param ch Peripheral channel/unit
+ */
+
+/* SCIF */
+#define RZ_CLOCK_SCIF(ch) RZ_CLOCK(SCIF, ch, RZ_CLOCK_P0CLK, 1)
+
+/* GPT */
+#define RZ_CLOCK_GPT(ch) RZ_CLOCK(GPT, ch, RZ_CLOCK_P0CLK, 1)
+
+/* MHU */
+#define RZ_CLOCK_MHU(ch) RZ_CLOCK(MHU, ch, RZ_CLOCK_P1CLK, 2)
+
+/* ADC */
+#define RZ_CLOCK_ADC(ch) RZ_CLOCK(ADC, ch, RZ_CLOCK_TSUCLK, 1)
+
+/* RIIC */
+#define RZ_CLOCK_RIIC(ch) RZ_CLOCK(RIIC, ch, RZ_CLOCK_P0CLK, 1)
+
+/* GTM */
+#define RZ_CLOCK_GTM(ch) RZ_CLOCK(GTM, ch, RZ_CLOCK_P0CLK, 1)
+
+/* CAN */
+#define RZ_CLOCK_CANFD(ch) RZ_CLOCK(CANFD, ch, RZ_CLOCK_P4CLK, 2)
+
+/* RSPI */
+#define RZ_CLOCK_RSPI(ch) RZ_CLOCK(RSPI, ch, RZ_CLOCK_P0CLK, 1)
+
+/* DMAC */
+#define RZ_CLOCK_DMAC(ch) RZ_CLOCK(DMAC, ch, RZ_CLOCK_P3CLK, 1)
+
+#endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_RENESAS_RZG_CLOCK_H_ */

--- a/modules/Kconfig.renesas_fsp
+++ b/modules/Kconfig.renesas_fsp
@@ -183,4 +183,9 @@ config USE_RZ_FSP_EXT_IRQ
 	help
 	  Enable RZ FSP External IRQ driver
 
+config USE_RZ_FSP_CPG
+	bool
+	help
+	  Enable RZ FSP CLOCK CONTROL driver
+
 endif


### PR DESCRIPTION
The Zephyr is running on Cortex-M33 core, and it's started by Cortex-A55 Core. 
It's expected that PLL configuration is fully done by SW running by Cortex-A55 core before starting Zephyr on Cortex-M33 core.
Therefore, the CPG Clock controller driver does not perform any kind of PLL control and uses static default frequencies for PLL/Core clocks. It just provides Zephyr System Clock Control API to enable HW module clock.

Need: https://github.com/zephyrproject-rtos/hal_renesas/pull/56