### PR TITLE
boards: frdm_mcxa156: enable MCUboot support

### DIFF
--- a/boards/nxp/frdm_mcxa156/Kconfig.defconfig
+++ b/boards/nxp/frdm_mcxa156/Kconfig.defconfig
@@ -1,0 +1,15 @@
+# FRDM-MCXA156 board
+
+# Copyright 2024 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+if BOARD_FRDM_MCXA156
+
+if BOOTLOADER_MCUBOOT
+choice MCUBOOT_BOOTLOADER_MODE
+	# Board only supports MCUBoot via "upgrade only" method:
+	default MCUBOOT_BOOTLOADER_MODE_OVERWRITE_ONLY
+endchoice
+endif #BOOTLOADER_MCUBOOT
+
+endif # BOARD_FRDM_MCXA156

--- a/boards/nxp/frdm_mcxa156/Kconfig.sysbuild
+++ b/boards/nxp/frdm_mcxa156/Kconfig.sysbuild
@@ -1,0 +1,6 @@
+# Copyright 2024 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+choice MCUBOOT_MODE
+	default MCUBOOT_MODE_OVERWRITE_ONLY
+endchoice

--- a/boards/nxp/frdm_mcxa156/frdm_mcxa156.dts
+++ b/boards/nxp/frdm_mcxa156/frdm_mcxa156.dts
@@ -21,14 +21,17 @@
 		sw0 = &user_button_2;
 		sw1 = &user_button_3;
 		pwm-0 = &flexpwm0_pwm0;
+		mcuboot-button0 = &user_button_2;
 	};
 
 	chosen {
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash;
 		zephyr,flash-controller = &fmu;
+		zephyr,code-partition = &slot0_partition;
 		zephyr,console = &lpuart0;
 		zephyr,shell-uart = &lpuart0;
+		zephyr,uart-mcumgr = &lpuart0;
 	};
 
 	leds {
@@ -137,4 +140,30 @@
 zephyr_udc0: &usb {
 	status = "okay";
 	num-bidir-endpoints = <8>;
+};
+
+&flash {
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		boot_partition: partition@0 {
+			label = "mcuboot";
+			reg = <0x00000000 DT_SIZE_K(64)>;
+			read-only;
+		};
+		slot0_partition: partition@10000 {
+			label = "image-0";
+			reg = <0x00010000 DT_SIZE_K(424)>;
+		};
+		slot1_partition: partition@7a000 {
+			label = "image-1";
+			reg = <0x0007a000 DT_SIZE_K(424)>;
+		};
+		storage_partition: partition@e4000 {
+			label = "storage";
+			reg = <0x000e4000 DT_SIZE_K(112)>;
+		};
+	};
 };


### PR DESCRIPTION
- Enables MCUboot support for frdm-mcxa156.
- Enables MCUMgr OTA and MCUBoot recovery for frdm-mcxa156.