### PR TITLE
drivers: fuel_gauge: various non-breaking fixes

### DIFF
--- a/drivers/fuel_gauge/fuel_gauge_syscall_handlers.c
+++ b/drivers/fuel_gauge/fuel_gauge_syscall_handlers.c
@@ -26,7 +26,8 @@ static inline int z_vrfy_fuel_gauge_get_prop(const struct device *dev, fuel_gaug
 
 #include <zephyr/syscalls/fuel_gauge_get_prop_mrsh.c>
 
-static inline int z_vrfy_fuel_gauge_get_props(const struct device *dev, fuel_gauge_prop_t *props,
+static inline int z_vrfy_fuel_gauge_get_props(const struct device *dev,
+					      const fuel_gauge_prop_t *props,
 					      union fuel_gauge_prop_val *vals, size_t len)
 {
 	union fuel_gauge_prop_val k_vals[len];
@@ -58,8 +59,9 @@ static inline int z_vrfy_fuel_gauge_set_prop(const struct device *dev, fuel_gaug
 
 #include <zephyr/syscalls/fuel_gauge_set_prop_mrsh.c>
 
-static inline int z_vrfy_fuel_gauge_set_props(const struct device *dev, fuel_gauge_prop_t *props,
-					      union fuel_gauge_prop_val *vals, size_t len)
+static inline int z_vrfy_fuel_gauge_set_props(const struct device *dev,
+					      const fuel_gauge_prop_t *props,
+					      const union fuel_gauge_prop_val *vals, size_t len)
 {
 	union fuel_gauge_prop_val k_vals[len];
 	fuel_gauge_prop_t k_props[len];
@@ -70,9 +72,6 @@ static inline int z_vrfy_fuel_gauge_set_props(const struct device *dev, fuel_gau
 	K_OOPS(k_usermode_from_copy(k_props, props, len * sizeof(fuel_gauge_prop_t)));
 
 	int ret = z_impl_fuel_gauge_set_props(dev, k_props, k_vals, len);
-
-	/* We only copy back vals because props will never be modified */
-	K_OOPS(k_usermode_to_copy(vals, k_vals, len * sizeof(union fuel_gauge_prop_val)));
 
 	return ret;
 }

--- a/include/zephyr/drivers/fuel_gauge.h
+++ b/include/zephyr/drivers/fuel_gauge.h
@@ -288,10 +288,10 @@ static inline int z_impl_fuel_gauge_get_prop(const struct device *dev, fuel_gaug
  * @return 0 if successful, negative errno code of first failing property
  */
 
-__syscall int fuel_gauge_get_props(const struct device *dev, fuel_gauge_prop_t *props,
+__syscall int fuel_gauge_get_props(const struct device *dev, const fuel_gauge_prop_t *props,
 				   union fuel_gauge_prop_val *vals, size_t len);
 static inline int z_impl_fuel_gauge_get_props(const struct device *dev,
-					      fuel_gauge_prop_t *props,
+					      const fuel_gauge_prop_t *props,
 					      union fuel_gauge_prop_val *vals, size_t len)
 {
 	const struct fuel_gauge_driver_api *api = (const struct fuel_gauge_driver_api *)dev->api;
@@ -342,12 +342,12 @@ static inline int z_impl_fuel_gauge_set_prop(const struct device *dev, fuel_gaug
  *
  * @return return=0 if successful. Otherwise, return array index of failing property.
  */
-__syscall int fuel_gauge_set_props(const struct device *dev, fuel_gauge_prop_t *props,
-				   union fuel_gauge_prop_val *vals, size_t len);
+__syscall int fuel_gauge_set_props(const struct device *dev, const fuel_gauge_prop_t *props,
+				   const union fuel_gauge_prop_val *vals, size_t len);
 
 static inline int z_impl_fuel_gauge_set_props(const struct device *dev,
-					      fuel_gauge_prop_t *props,
-					      union fuel_gauge_prop_val *vals, size_t len)
+					      const fuel_gauge_prop_t *props,
+					      const union fuel_gauge_prop_val *vals, size_t len)
 {
 	for (size_t i = 0; i < len; i++) {
 		int ret = fuel_gauge_set_prop(dev, props[i], vals[i]);

--- a/include/zephyr/drivers/fuel_gauge.h
+++ b/include/zephyr/drivers/fuel_gauge.h
@@ -296,7 +296,7 @@ static inline int z_impl_fuel_gauge_get_props(const struct device *dev,
 {
 	const struct fuel_gauge_driver_api *api = dev->api;
 
-	for (int i = 0; i < len; i++) {
+	for (size_t i = 0; i < len; i++) {
 		int ret = api->get_property(dev, props[i], vals + i);
 
 		if (ret) {
@@ -349,7 +349,7 @@ static inline int z_impl_fuel_gauge_set_props(const struct device *dev,
 					      fuel_gauge_prop_t *props,
 					      union fuel_gauge_prop_val *vals, size_t len)
 {
-	for (int i = 0; i < len; i++) {
+	for (size_t i = 0; i < len; i++) {
 		int ret = fuel_gauge_set_prop(dev, props[i], vals[i]);
 
 		if (ret) {

--- a/include/zephyr/drivers/fuel_gauge.h
+++ b/include/zephyr/drivers/fuel_gauge.h
@@ -294,7 +294,7 @@ static inline int z_impl_fuel_gauge_get_props(const struct device *dev,
 					      fuel_gauge_prop_t *props,
 					      union fuel_gauge_prop_val *vals, size_t len)
 {
-	const struct fuel_gauge_driver_api *api = dev->api;
+	const struct fuel_gauge_driver_api *api = (const struct fuel_gauge_driver_api *)dev->api;
 
 	for (size_t i = 0; i < len; i++) {
 		int ret = api->get_property(dev, props[i], vals + i);
@@ -322,7 +322,7 @@ __syscall int fuel_gauge_set_prop(const struct device *dev, fuel_gauge_prop_t pr
 static inline int z_impl_fuel_gauge_set_prop(const struct device *dev, fuel_gauge_prop_t prop,
 					     union fuel_gauge_prop_val val)
 {
-	const struct fuel_gauge_driver_api *api = dev->api;
+	const struct fuel_gauge_driver_api *api = (const struct fuel_gauge_driver_api *)dev->api;
 
 	if (api->set_property == NULL) {
 		return -ENOSYS;

--- a/tests/drivers/fuel_gauge/sbs_gauge/src/test_sbs_gauge.c
+++ b/tests/drivers/fuel_gauge/sbs_gauge/src/test_sbs_gauge.c
@@ -42,7 +42,7 @@ ZTEST_USER_F(sbs_gauge_new_api, test_get_some_props_failed_returns_bad_status)
 		/* Valid property */
 		FUEL_GAUGE_VOLTAGE,
 	};
-	union fuel_gauge_prop_val props[ARRAY_SIZE(prop_types)];
+	union fuel_gauge_prop_val props[ARRAY_SIZE(prop_types)] = {0};
 
 	int ret = fuel_gauge_get_props(fixture->dev, prop_types, props, ARRAY_SIZE(props));
 
@@ -55,7 +55,7 @@ ZTEST_USER_F(sbs_gauge_new_api, test_set_all_props_failed_returns_err)
 		/* Invalid property */
 		FUEL_GAUGE_PROP_MAX,
 	};
-	union fuel_gauge_prop_val props[ARRAY_SIZE(prop_types)];
+	union fuel_gauge_prop_val props[ARRAY_SIZE(prop_types)] = {0};
 
 	int ret = fuel_gauge_set_props(fixture->dev, prop_types, props, ARRAY_SIZE(props));
 
@@ -166,7 +166,7 @@ ZTEST_USER_F(sbs_gauge_new_api, test_get_props__returns_ok)
 		FUEL_GAUGE_SBS_REMAINING_TIME_ALARM,
 	};
 
-	union fuel_gauge_prop_val props[ARRAY_SIZE(prop_types)];
+	union fuel_gauge_prop_val props[ARRAY_SIZE(prop_types)] = {0};
 
 	zassert_ok(fuel_gauge_get_props(fixture->dev, prop_types, props, ARRAY_SIZE(props)));
 }
@@ -181,7 +181,7 @@ ZTEST_USER_F(sbs_gauge_new_api, test_set_props__returns_ok)
 		FUEL_GAUGE_SBS_REMAINING_CAPACITY_ALARM,
 
 	};
-	union fuel_gauge_prop_val props[ARRAY_SIZE(prop_types)];
+	union fuel_gauge_prop_val props[ARRAY_SIZE(prop_types)] = {0};
 
 	zassert_ok(fuel_gauge_set_props(fixture->dev, prop_types, props, ARRAY_SIZE(props)));
 }


### PR DESCRIPTION
This PR fixes a couple of issues that was seen when compiler with g++.

 * fix integer comparison issue
 * fix missing device struct pointer cast
 * add "missing" const from read-only arrays.

I do not believe either of these changes to be breaking API changes as they should have no impact on downstream drivers or applications. I may be wrong.