### PR TITLE
drivers: video: emul: simplify, avoid mission creep

### DIFF
--- a/drivers/video/Kconfig.emul_imager
+++ b/drivers/video/Kconfig.emul_imager
@@ -6,13 +6,9 @@ config VIDEO_EMUL_IMAGER
 	depends on DT_HAS_ZEPHYR_VIDEO_EMUL_IMAGER_ENABLED
 	default y
 	help
-	  Enable driver for the emulated Imager.
-
-config VIDEO_EMUL_IMAGER_FRAMEBUFFER_SIZE
-	int "Internal framebuffer size used for link emulation purpose"
-	default 4096
-	help
-	  Configure the size of the internal framebuffer the emulated Imager
-	  driver uses to simulate MIPI transfers. This is the first field of
-	  dev->data, and the emulated video MIPI driver will `memcpy()` it
-	  into the video buffer.
+	  Enable driver for the emulated Imager. A line buffer contains
+	  the color pattern within the imager data struct, at the first
+	  field, and the "zephyr,video-emul-rx" driver will memcpy() this
+	  line over a full frame, simulating a MIPI link transmetting
+	  the lines of data from the imager to the memory.  The default
+	  value fits 2 bit-per-pixel, 640 pixel-wide frames.

--- a/drivers/video/video_emul_imager.c
+++ b/drivers/video/video_emul_imager.c
@@ -27,13 +27,14 @@ LOG_MODULE_REGISTER(video_emul_imager, CONFIG_VIDEO_LOG_LEVEL);
 #define EMUL_IMAGER_REG_TIMING1   0x0004
 #define EMUL_IMAGER_REG_TIMING2   0x0005
 #define EMUL_IMAGER_REG_TIMING3   0x0006
-#define EMUL_IMAGER_REG_EXPOSURE  0x0007
-#define EMUL_IMAGER_REG_GAIN      0x0008
-#define EMUL_IMAGER_REG_PATTERN   0x0009
+#define EMUL_IMAGER_REG_CUSTOM    0x0007
 #define EMUL_IMAGER_REG_FORMAT    0x000a
 #define EMUL_IMAGER_PATTERN_OFF   0x00
 #define EMUL_IMAGER_PATTERN_BARS1 0x01
 #define EMUL_IMAGER_PATTERN_BARS2 0x02
+
+/* Custom control that is just an I2C write for example and test purpose */
+#define EMUL_IMAGER_CID_CUSTOM (VIDEO_CID_PRIVATE_BASE + 0x01)
 
 /* Emulated register bank */
 uint8_t emul_imager_fake_regs[10];
@@ -198,12 +199,8 @@ static int emul_imager_write_multi(const struct device *const dev,
 static int emul_imager_set_ctrl(const struct device *dev, unsigned int cid, void *value)
 {
 	switch (cid) {
-	case VIDEO_CID_EXPOSURE:
-		return emul_imager_write_reg(dev, EMUL_IMAGER_REG_EXPOSURE, (int)value);
-	case VIDEO_CID_GAIN:
-		return emul_imager_write_reg(dev, EMUL_IMAGER_REG_GAIN, (int)value);
-	case VIDEO_CID_TEST_PATTERN:
-		return emul_imager_write_reg(dev, EMUL_IMAGER_REG_PATTERN, (int)value);
+	case EMUL_IMAGER_CID_CUSTOM:
+		return emul_imager_write_reg(dev, EMUL_IMAGER_REG_CUSTOM, (int)value);
 	default:
 		return -ENOTSUP;
 	}
@@ -211,18 +208,9 @@ static int emul_imager_set_ctrl(const struct device *dev, unsigned int cid, void
 
 static int emul_imager_get_ctrl(const struct device *dev, unsigned int cid, void *value)
 {
-	struct emul_imager_data *data = dev->data;
-
 	switch (cid) {
-	case VIDEO_CID_EXPOSURE:
-		return emul_imager_read_int(dev, EMUL_IMAGER_REG_EXPOSURE, value);
-	case VIDEO_CID_GAIN:
-		return emul_imager_read_int(dev, EMUL_IMAGER_REG_GAIN, value);
-	case VIDEO_CID_TEST_PATTERN:
-		return emul_imager_read_int(dev, EMUL_IMAGER_REG_PATTERN, value);
-	case VIDEO_CID_PIXEL_RATE:
-		*(int64_t *)value = (int64_t)data->fmt.width * data->fmt.pitch * data->mode->fps;
-		return 0;
+	case EMUL_IMAGER_CID_CUSTOM:
+		return emul_imager_read_int(dev, EMUL_IMAGER_REG_CUSTOM, value);
 	default:
 		return -ENOTSUP;
 	}

--- a/drivers/video/video_emul_imager.c
+++ b/drivers/video/video_emul_imager.c
@@ -157,7 +157,7 @@ static const struct video_format_cap fmts[] = {
 /* Emulated I2C register interface, to replace with actual I2C calls for real hardware */
 static int emul_imager_read_reg(const struct device *const dev, uint8_t reg_addr, uint8_t *value)
 {
-	LOG_DBG("%s placeholder for I2C read from 0x%02x", dev->name, reg_addr);
+	LOG_DBG("Placeholder for I2C read from 0x%02x", reg_addr);
 	switch (reg_addr) {
 	case EMUL_IMAGER_REG_SENSOR_ID:
 		*value = EMUL_IMAGER_SENSOR_ID;
@@ -182,7 +182,7 @@ static int emul_imager_read_int(const struct device *const dev, uint8_t reg_addr
 /* Some sensors will need reg8 or reg16 variants. */
 static int emul_imager_write_reg(const struct device *const dev, uint8_t reg_addr, uint8_t value)
 {
-	LOG_DBG("%s placeholder for I2C write 0x%08x to 0x%02x", dev->name, value, reg_addr);
+	LOG_DBG("Placeholder for I2C write 0x%08x to 0x%02x", value, reg_addr);
 	emul_imager_fake_regs[reg_addr] = value;
 	return 0;
 }
@@ -257,7 +257,7 @@ static int emul_imager_set_mode(const struct device *dev, const struct emul_imag
 	data->mode = mode;
 	return 0;
 err:
-	LOG_ERR("Could not apply %s mode %p (%u FPS)", dev->name, mode, mode->fps);
+	LOG_ERR("Could not apply mode %p (%u FPS)", mode, mode->fps);
 	return ret;
 }
 
@@ -372,8 +372,7 @@ static int emul_imager_set_fmt(const struct device *const dev, enum video_endpoi
 
 	ret = video_format_caps_index(fmts, fmt, &fmt_id);
 	if (ret < 0) {
-		LOG_ERR("Format %x %ux%u not found for %s", fmt->pixelformat, fmt->width,
-			fmt->height, dev->name);
+		LOG_ERR("Format %x %ux%u not found", fmt->pixelformat, fmt->width, fmt->height);
 		return ret;
 	}
 
@@ -444,13 +443,13 @@ int emul_imager_init(const struct device *dev)
 
 	ret = emul_imager_read_reg(dev, EMUL_IMAGER_REG_SENSOR_ID, &sensor_id);
 	if (ret < 0 || sensor_id != EMUL_IMAGER_SENSOR_ID) {
-		LOG_ERR("Failed to get %s correct sensor ID (0x%x", dev->name, sensor_id);
+		LOG_ERR("Failed to get a correct sensor ID 0x%x",  sensor_id);
 		return ret;
 	}
 
 	ret = emul_imager_write_multi(dev, emul_imager_init_regs);
 	if (ret < 0) {
-		LOG_ERR("Could not set %s initial registers", dev->name);
+		LOG_ERR("Could not set initial registers");
 		return ret;
 	}
 
@@ -461,8 +460,8 @@ int emul_imager_init(const struct device *dev)
 
 	ret = emul_imager_set_fmt(dev, VIDEO_EP_OUT, &fmt);
 	if (ret < 0) {
-		LOG_ERR("Failed to set %s to default format %x %ux%u", dev->name, fmt.pixelformat,
-			fmt.width, fmt.height);
+		LOG_ERR("Failed to set to default format %x %ux%u",
+			fmt.pixelformat, fmt.width, fmt.height);
 	}
 
 	return 0;

--- a/tests/drivers/video/api/prj.conf
+++ b/tests/drivers/video/api/prj.conf
@@ -1,5 +1,11 @@
 CONFIG_ZTEST=y
 CONFIG_VIDEO=y
-CONFIG_VIDEO_BUFFER_POOL_SZ_MAX=16384
+
+# Just enough for a single frame in RGB565 format: 320 * 420 * 2 + some margin
+CONFIG_VIDEO_BUFFER_POOL_SZ_MAX=300000
 CONFIG_VIDEO_BUFFER_POOL_NUM_MAX=1
+
+# Required to support larger buffers on native_sim
+CONFIG_SYS_HEAP_BIG_ONLY=y
+
 CONFIG_VIDEO_LOG_LEVEL_DBG=y

--- a/tests/drivers/video/api/src/video_emul.c
+++ b/tests/drivers/video/api/src/video_emul.c
@@ -184,6 +184,9 @@ ZTEST(video_common, test_video_vbuf)
 
 	/* Nothing left in the queue, possible to stop */
 	zexpect_ok(video_stream_stop(rx_dev));
+
+	/* Nothing tested, but this should not crash */
+	video_buffer_release(vbuf);
 }
 
 ZTEST_SUITE(video_emul, NULL, NULL, NULL, NULL, NULL);

--- a/tests/drivers/video/api/src/video_emul.c
+++ b/tests/drivers/video/api/src/video_emul.c
@@ -157,7 +157,7 @@ ZTEST(video_common, test_video_vbuf)
 	zexpect_ok(video_set_format(rx_dev, VIDEO_EP_OUT, &fmt));
 
 	/* Allocate a buffer, assuming prj.conf gives enough memory for it */
-	vbuf = video_buffer_alloc(fmt.pitch * fmt.height, K_FOREVER);
+	vbuf = video_buffer_alloc(fmt.pitch * fmt.height, K_NO_WAIT);
 	zexpect_not_null(vbuf);
 
 	/* Start the virtual hardware */

--- a/tests/drivers/video/api/src/video_emul.c
+++ b/tests/drivers/video/api/src/video_emul.c
@@ -130,13 +130,8 @@ ZTEST(video_common, test_video_ctrl)
 	int value;
 
 	/* Exposure control, expected to be supported by all imagers */
-	zexpect_ok(video_set_ctrl(imager_dev, VIDEO_CID_EXPOSURE, (void *)30));
-	zexpect_ok(video_get_ctrl(imager_dev, VIDEO_CID_EXPOSURE, &value));
-	zexpect_equal(value, 30);
-
-	/* Gain control, expected to be supported by all imagers */
-	zexpect_ok(video_set_ctrl(imager_dev, VIDEO_CID_GAIN, (void *)30));
-	zexpect_ok(video_get_ctrl(imager_dev, VIDEO_CID_GAIN, &value));
+	zexpect_ok(video_set_ctrl(imager_dev, VIDEO_CID_PRIVATE_BASE + 0x01, (void *)30));
+	zexpect_ok(video_get_ctrl(imager_dev, VIDEO_CID_PRIVATE_BASE + 0x01, &value));
 	zexpect_equal(value, 30);
 }
 

--- a/tests/drivers/video/api/testcase.yaml
+++ b/tests/drivers/video/api/testcase.yaml
@@ -1,8 +1,9 @@
-# Copyright (c) 2024 tinyVision.ai Inc.
+# Copyright (c) 2024-2025 tinyVision.ai Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 tests:
   drivers.video.api:
+    min_ram: 32
     tags:
       - drivers
       - video


### PR DESCRIPTION
The general goal is making `video_emul_*` just enough complexity to test the APIs on CI.

- Instead of storing a full frame in the emulated imager, only store one line.
- Drop the test pattern generation, as `VIDEO_SW_GENERATOR` does it and no use in maintaining it twice.
- Other fixes and minor improvements.

[EDIT: updated the PR goals mid-way]