### PR TITLE
Bluetooth: Host: Fix not sending Service Changed indication

### DIFF
--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -1743,9 +1743,17 @@ int bt_gatt_service_register(struct bt_gatt_service *svc)
 
 int bt_gatt_service_unregister(struct bt_gatt_service *svc)
 {
+	uint16_t sc_start_handle;
+	uint16_t sc_end_handle;
 	int err;
 
 	__ASSERT(svc, "invalid parameters\n");
+
+	/* gatt_unregister() clears handles when those were auto-assigned
+	 * by host
+	 */
+	sc_start_handle = svc->attrs[0].handle;
+	sc_end_handle = svc->attrs[svc->attr_count - 1].handle;
 
 	k_sched_lock();
 
@@ -1761,8 +1769,7 @@ int bt_gatt_service_unregister(struct bt_gatt_service *svc)
 		return 0;
 	}
 
-	sc_indicate(svc->attrs[0].handle,
-		    svc->attrs[svc->attr_count - 1].handle);
+	sc_indicate(sc_start_handle, sc_end_handle);
 
 	db_changed();
 


### PR DESCRIPTION
gatt_unregister() clears handles if those were auto-assigned by host. This resulted in Service Changed indication not beding sent since call to sc_indicate() pass already cleared handles.

This was affecting GATT/SR/GAS/BV-01-C and GATT/SR/GAS/BV-07-C test cases.

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/83178