### PR TITLE
tests: drivers: gpio: gpio_basic_api: Enable test on nrf54l20pdk

### DIFF
--- a/tests/drivers/gpio/gpio_basic_api/boards/nrf54l20pdk_nrf54l20_cpuapp.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/nrf54l20pdk_nrf54l20_cpuapp.overlay
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	resources {
+		compatible = "test-gpio-basic-api";
+		out-gpios = <&gpio1 10 0>;
+		in-gpios = <&gpio1 11 0>;
+	};
+};
+
+&gpiote20 {
+	status = "okay";
+};
+
+&gpio1 {
+	status = "okay";
+};


### PR DESCRIPTION
Add overlay required to run gpio_basic_api test on nrf54l20pdk.