### PR TITLE
dts: bindings: stepper: add en-gpios to common stepper-controller.yaml

### DIFF
--- a/drivers/stepper/adi_tmc/adi_tmc22xx_stepper_controller.c
+++ b/drivers/stepper/adi_tmc/adi_tmc22xx_stepper_controller.c
@@ -171,7 +171,7 @@ static DEVICE_API(stepper, tmc22xx_stepper_api) = {
                                                                                                    \
 	static const struct tmc22xx_config tmc22xx_config_##inst = {                               \
 		.common = STEP_DIR_STEPPER_DT_INST_COMMON_CONFIG_INIT(inst),                       \
-		.enable_pin = GPIO_DT_SPEC_INST_GET(inst, enable_gpios),                           \
+		.enable_pin = GPIO_DT_SPEC_INST_GET(inst, en_gpios),	                           \
 		.msx_resolutions = msx_table,                                                      \
 		IF_ENABLED(DT_INST_NODE_HAS_PROP(inst, msx_gpios),				   \
 		(.msx_pins = tmc22xx_stepper_msx_pins_##inst))					   \

--- a/dts/bindings/stepper/adi/adi,tmc2209.yaml
+++ b/dts/bindings/stepper/adi/adi,tmc2209.yaml
@@ -23,13 +23,9 @@ include:
       - micro-step-res
       - step-gpios
       - dir-gpios
+      - en-gpios
 
 properties:
-  enable-gpios:
-    type: phandle-array
-    description: |
-      GPIO pins used to control the enable signal of the motor driver.
-
   msx-gpios:
     type: phandle-array
     description: |

--- a/dts/bindings/stepper/stepper-controller.yaml
+++ b/dts/bindings/stepper/stepper-controller.yaml
@@ -25,6 +25,11 @@ properties:
     description: |
       micro-step resolution to be set while initializing the device driver.
 
+  en-gpios:
+    type: phandle-array
+    description: |
+      GPIO pins used to control the enable signal of the motor driver.
+
   step-gpios:
     type: phandle-array
     description: |

--- a/dts/bindings/stepper/ti/ti,drv8424.yaml
+++ b/dts/bindings/stepper/ti/ti,drv8424.yaml
@@ -33,16 +33,12 @@ include:
       - micro-step-res
       - step-gpios
       - dir-gpios
+      - en-gpios
 
 properties:
-
   fault-gpios:
     type: phandle-array
     description: Fault pin.
-
-  en-gpios:
-    type: phandle-array
-    description: Enable pin.
 
   sleep-gpios:
     type: phandle-array

--- a/tests/drivers/build_all/stepper/gpio.dtsi
+++ b/tests/drivers/build_all/stepper/gpio.dtsi
@@ -19,7 +19,7 @@ test_tmc2209: tmc2209_motor {
 	micro-step-res = <1>;
 	msx-gpios = <&test_gpio 0 0>,
 		    <&test_gpio 0 0>;
-	enable-gpios = <&test_gpio 0 0>;
+	en-gpios = <&test_gpio 0 0>;
 	step-gpios = <&test_gpio 0 0>;
 	dir-gpios = <&test_gpio 0 0>;
 };


### PR DESCRIPTION
- rename enable-gpios to en-gpios in adi,tmc2209
- place en-gpios in common stepper-controller.yaml