### PR TITLE
scripts: Remove zcbor requirement from requirements-extras.txt

### DIFF
--- a/scripts/requirements-extras.txt
+++ b/scripts/requirements-extras.txt
@@ -26,6 +26,3 @@ PyGithub
 
 # used to generate devicetree dependency graphs
 graphviz
-
-# used to generate CBOR encoders and decoders, e.g. lwm2m_senml_cbor.
-zcbor>=0.8.0

--- a/subsys/net/lib/lwm2m/README_lwm2m
+++ b/subsys/net/lib/lwm2m/README_lwm2m
@@ -16,6 +16,7 @@ details please see the chapter 11 - CDDL.
 To generate the encoder and decoder:
 
 ```console
+pip install --upgrade zcbor
 sh lwm2m_senml_cbor_regenerate.sh
 ```
 


### PR DESCRIPTION
Add instructions to install it when needed to the lwm2m README.