### PR TITLE
fix the DTS of boards with a   stm32f411 i2s pll  compatible

### DIFF
--- a/boards/96boards/argonkey/96b_argonkey.dts
+++ b/boards/96boards/argonkey/96b_argonkey.dts
@@ -71,7 +71,9 @@
 	div-m = <8>;
 	mul-n = <192>;
 	div-r = <3>;
-	status = "okay";
+	div-q = <4>;
+	clocks = <&clk_hse>;
+	status = "okay"; /* 48MHz on PLLI2SQ */
 };
 
 &rcc {

--- a/boards/96boards/stm32_sensor_mez/96b_stm32_sensor_mez.dts
+++ b/boards/96boards/stm32_sensor_mez/96b_stm32_sensor_mez.dts
@@ -75,7 +75,9 @@
 	div-m = <8>;
 	mul-n = <192>;
 	div-r = <3>;
-	status = "okay";
+	div-q = <4>;
+	clocks = <&clk_hse>;
+	status = "okay"; /* 48MHz on PLLI2SQ */
 };
 
 &rcc {

--- a/boards/shields/x_nucleo_iks02a1/boards/nucleo_f411re.overlay
+++ b/boards/shields/x_nucleo_iks02a1/boards/nucleo_f411re.overlay
@@ -5,9 +5,12 @@
  */
 
 &plli2s {
+	div-m = <8>;
 	mul-n = <192>;
 	div-r = <3>;
-	status = "okay";
+	div-q = <4>;
+	clocks = <&clk_hse>;
+	status = "okay"; /* 48MHz on PLLI2SQ */
 };
 
 &dma2 {


### PR DESCRIPTION
Some targets where not defining correctly the plli2s node when the compatible: "st,stm32f411-plli2s-clock" applies

Then building fails due to missing `div-m` property
Typically  `west build -p -b nucleo_f411re/stm32f411xe samples/shields/x_nucleo_iks02a1/standard -T sample.shields.x_nucleo_iks02a1.standard`
gives
`devicetree error: 'div-m' is marked as required in 'properties:' in ~/dts/bindings/clock/st,stm32f411-plli2s-clock.yaml, but does not appear in <Node /clocks/plli2s in '.../zephyrproject/zephyr/misc/empty_file.c'>`

