### PR TITLE
drivers: stepper: api: add -ECANCELLED error code for move operations

### DIFF
--- a/drivers/stepper/gpio_stepper_controller.c
+++ b/drivers/stepper/gpio_stepper_controller.c
@@ -39,6 +39,7 @@ struct gpio_stepper_data {
 	int32_t actual_position;
 	uint32_t delay_in_us;
 	int32_t step_count;
+	bool is_enabled;
 	stepper_event_callback_t callback;
 	void *event_cb_user_data;
 };
@@ -181,6 +182,11 @@ static int gpio_stepper_move_by(const struct device *dev, int32_t micro_steps)
 {
 	struct gpio_stepper_data *data = dev->data;
 
+	if (!data->is_enabled) {
+		LOG_ERR("Stepper motor is not enabled");
+		return -ECANCELED;
+	}
+
 	if (data->delay_in_us == 0) {
 		LOG_ERR("Velocity not set or invalid velocity set");
 		return -EINVAL;
@@ -217,6 +223,11 @@ static int gpio_stepper_get_actual_position(const struct device *dev, int32_t *p
 static int gpio_stepper_move_to(const struct device *dev, int32_t micro_steps)
 {
 	struct gpio_stepper_data *data = dev->data;
+
+	if (!data->is_enabled) {
+		LOG_ERR("Stepper motor is not enabled");
+		return -ECANCELED;
+	}
 
 	if (data->delay_in_us == 0) {
 		LOG_ERR("Velocity not set or invalid velocity set");
@@ -265,6 +276,11 @@ static int gpio_stepper_run(const struct device *dev, const enum stepper_directi
 			    const uint32_t velocity)
 {
 	struct gpio_stepper_data *data = dev->data;
+
+	if (!data->is_enabled) {
+		LOG_ERR("Stepper motor is not enabled");
+		return -ECANCELED;
+	}
 
 	K_SPINLOCK(&data->lock) {
 		data->run_mode = STEPPER_RUN_MODE_VELOCITY;
@@ -323,6 +339,9 @@ static int gpio_stepper_enable(const struct device *dev, bool enable)
 	struct gpio_stepper_data *data = dev->data;
 
 	K_SPINLOCK(&data->lock) {
+
+		data->is_enabled = enable;
+
 		if (enable) {
 			(void)k_work_reschedule(&data->stepper_dwork, K_NO_WAIT);
 		} else {

--- a/include/zephyr/drivers/stepper.h
+++ b/include/zephyr/drivers/stepper.h
@@ -233,6 +233,7 @@ static inline int z_impl_stepper_enable(const struct device *dev, const bool ena
  * @param dev pointer to the stepper motor controller instance
  * @param micro_steps target micro_steps to be moved from the current position
  *
+ * @retval -ECANCELED If the stepper is disabled
  * @retval -EIO General input / output error
  * @retval	0 Success
  */
@@ -374,6 +375,7 @@ static inline int z_impl_stepper_get_actual_position(const struct device *dev, i
  * @param dev pointer to the stepper motor controller instance
  * @param micro_steps target position to set in micro_steps
  *
+ * @retval -ECANCELED If the stepper is disabled
  * @retval -EIO General input / output error
  * @retval -ENOSYS If not implemented by device driver
  * @retval 0 Success
@@ -425,6 +427,7 @@ static inline int z_impl_stepper_is_moving(const struct device *dev, bool *is_mo
  *                 - > 0: Run the stepper with the given velocity in a given direction
  *                 - 0: Stop the stepper
  *
+ * @retval -ECANCELED If the stepper is disabled
  * @retval -EIO General input / output error
  * @retval -ENOSYS If not implemented by device driver
  * @retval 0 Success


### PR DESCRIPTION
If the stepper is not enabled, calling any of the move operations shall return -ECANCELLED