### PR TITLE
kernel: sched: z_unpend_all_rc

### DIFF
--- a/kernel/include/ksched.h
+++ b/kernel/include/ksched.h
@@ -60,6 +60,7 @@ void z_reschedule(struct k_spinlock *lock, k_spinlock_key_t key);
 void z_reschedule_irqlock(uint32_t key);
 void z_unpend_thread(struct k_thread *thread);
 int z_unpend_all(_wait_q_t *wait_q);
+int z_unpend_all_rc(_wait_q_t *wait_q, int rc);
 bool z_thread_prio_set(struct k_thread *thread, int prio);
 void *z_get_next_switch_handle(void *interrupted);
 

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -960,6 +960,21 @@ int z_unpend_all(_wait_q_t *wait_q)
 	return need_sched;
 }
 
+int z_unpend_all_rc(_wait_q_t *wait_q, int rc)
+{
+	int need_sched = 0;
+	struct k_thread *thread;
+
+	for (thread = z_waitq_head(wait_q); thread != NULL; thread = z_waitq_head(wait_q)) {
+		z_unpend_thread(thread);
+		arch_thread_return_value_set(thread, rc);
+		z_ready_thread(thread);
+		need_sched = 1;
+	}
+
+	return need_sched;
+}
+
 void init_ready_q(struct _ready_q *ready_q)
 {
 	_priq_run_init(&ready_q->runq);


### PR DESCRIPTION
This function is used to unpend all tasks from a wait queue and have the pend_curr(..) function return a specific return code. This is useful when a task is waiting for a resource and the resource is no longer available. By calling z_unpend_all_rc(..) the caller can convey the reason for the cancelation to the waiting tasks.