### PR TITLE
kernel: Add k_reschedule()

### DIFF
--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -946,6 +946,26 @@ __syscall void k_thread_priority_set(k_tid_t thread, int prio);
 __syscall void k_thread_deadline_set(k_tid_t thread, int deadline);
 #endif
 
+/**
+ * @brief Invoke the scheduler
+ *
+ * This routine invokes the scheduler to force a schedule point on the current
+ * CPU. If invoked from within a thread, the scheduler will be invoked
+ * immediately (provided interrupts were not locked when invoked). If invoked
+ * from within an ISR, the scheduler will be invoked upon exiting the ISR.
+ *
+ * Invoking the scheduler allows the kernel to make an immediate determination
+ * as to what the next thread to execute should be. Unlike yielding, this
+ * routine is not guaranteed to switch to a thread of equal or higher priority
+ * if any are available. For example, if the current thread is cooperative and
+ * there is a still higher priority cooperative thread that is ready, then
+ * yielding will switch to that higher priority thread whereas this routine
+ * will not.
+ *
+ * Most applications will never use this routine.
+ */
+__syscall void k_reschedule(void);
+
 #ifdef CONFIG_SCHED_CPU_MASK
 /**
  * @brief Sets all CPU enable masks to zero

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -1050,6 +1050,24 @@ static inline void z_vrfy_k_thread_deadline_set(k_tid_t tid, int deadline)
 #endif /* CONFIG_USERSPACE */
 #endif /* CONFIG_SCHED_DEADLINE */
 
+void z_impl_k_reschedule(void)
+{
+	k_spinlock_key_t key;
+
+	key = k_spin_lock(&_sched_spinlock);
+
+	update_cache(0);
+
+	z_reschedule(&_sched_spinlock, key);
+}
+
+#ifdef CONFIG_USERSPACE
+static inline void z_vrfy_k_reschedule(void)
+{
+	z_impl_k_reschedule();
+}
+#endif /* CONFIG_USERSPACE */
+
 bool k_can_yield(void)
 {
 	return !(k_is_pre_kernel() || k_is_in_isr() ||

--- a/tests/kernel/sched/deadline/prj.conf
+++ b/tests/kernel/sched/deadline/prj.conf
@@ -7,3 +7,6 @@ CONFIG_BT=n
 # Deadline is not compatible with MULTIQ, so we have to pick something
 # specific instead of using the board-level default.
 CONFIG_SCHED_DUMB=y
+
+CONFIG_IRQ_OFFLOAD=y
+CONFIG_IRQ_OFFLOAD_NESTED=n

--- a/tests/kernel/sched/deadline/src/main.c
+++ b/tests/kernel/sched/deadline/src/main.c
@@ -13,7 +13,12 @@
  */
 #define STACK_SIZE (512 + CONFIG_TEST_EXTRA_STACK_SIZE)
 
+#define MSEC_TO_CYCLES(msec)  (int)(((uint64_t)(msec) * \
+				     (uint64_t)CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC) / \
+				    (uint64_t)MSEC_PER_SEC)
+
 struct k_thread worker_threads[NUM_THREADS];
+volatile struct k_thread *expected_thread;
 k_tid_t worker_tids[NUM_THREADS];
 
 K_THREAD_STACK_ARRAY_DEFINE(worker_stacks, NUM_THREADS, STACK_SIZE);
@@ -214,5 +219,106 @@ ZTEST(suite_deadline, test_unqueued)
 		k_thread_abort(worker_tids[i]);
 	}
 }
+
+#if (CONFIG_MP_MAX_NUM_CPUS == 1)
+static void reschedule_wrapper(const void *param)
+{
+	ARG_UNUSED(param);
+
+	k_reschedule();
+}
+
+static void test_reschedule_helper0(void *p1, void *p2, void *p3)
+{
+	/* 4. Reschedule brings us here */
+
+	zassert_true(expected_thread == arch_current_thread(), "");
+
+	expected_thread = &worker_threads[1];
+}
+
+static void test_reschedule_helper1(void *p1, void *p2, void *p3)
+{
+	void (*offload)(void (*f)(const void *p), const void *param) = p1;
+
+	/* 1. First helper expected to execute */
+
+	zassert_true(expected_thread == arch_current_thread(), "");
+
+	offload(reschedule_wrapper, NULL);
+
+	/* 2. Deadlines have not changed. Expected no changes */
+
+	zassert_true(expected_thread == arch_current_thread(), "");
+
+	k_thread_deadline_set(arch_current_thread(), MSEC_TO_CYCLES(1000));
+
+	/* 3. Deadline changed, but there was no reschedule */
+
+	zassert_true(expected_thread == arch_current_thread(), "");
+
+	expected_thread = &worker_threads[0];
+	offload(reschedule_wrapper, NULL);
+
+	/* 5. test_thread_reschedule_helper0 executed */
+
+	zassert_true(expected_thread == arch_current_thread(), "");
+}
+
+static void thread_offload(void (*f)(const void *p), const void *param)
+{
+	f(param);
+}
+
+ZTEST(suite_deadline, test_thread_reschedule)
+{
+	k_thread_create(&worker_threads[0], worker_stacks[0], STACK_SIZE,
+			test_reschedule_helper0,
+			thread_offload, NULL, NULL,
+			K_LOWEST_APPLICATION_THREAD_PRIO,
+			0, K_NO_WAIT);
+
+	k_thread_create(&worker_threads[1], worker_stacks[1], STACK_SIZE,
+			test_reschedule_helper1,
+			thread_offload, NULL, NULL,
+			K_LOWEST_APPLICATION_THREAD_PRIO,
+			0, K_NO_WAIT);
+
+	k_thread_deadline_set(&worker_threads[0], MSEC_TO_CYCLES(500));
+	k_thread_deadline_set(&worker_threads[1], MSEC_TO_CYCLES(10));
+
+	expected_thread = &worker_threads[1];
+
+	k_thread_join(&worker_threads[1], K_FOREVER);
+	k_thread_join(&worker_threads[0], K_FOREVER);
+
+#ifndef CONFIG_SMP
+	/*
+	 * When SMP is enabled, there is always a reschedule performed
+	 * at the end of the ISR.
+	 */
+	k_thread_create(&worker_threads[0], worker_stacks[0], STACK_SIZE,
+			test_reschedule_helper0,
+			irq_offload, NULL, NULL,
+			K_LOWEST_APPLICATION_THREAD_PRIO,
+			0, K_NO_WAIT);
+
+	k_thread_create(&worker_threads[1], worker_stacks[1], STACK_SIZE,
+			test_reschedule_helper1,
+			irq_offload, NULL, NULL,
+			K_LOWEST_APPLICATION_THREAD_PRIO,
+			0, K_NO_WAIT);
+
+	k_thread_deadline_set(&worker_threads[0], MSEC_TO_CYCLES(500));
+	k_thread_deadline_set(&worker_threads[1], MSEC_TO_CYCLES(10));
+
+	expected_thread = &worker_threads[1];
+
+	k_thread_join(&worker_threads[1], K_FOREVER);
+	k_thread_join(&worker_threads[0], K_FOREVER);
+
+#endif /* !CONFIG_SMP */
+}
+#endif /* CONFIG_MP_MAX_NUM_CPUS == 1 */
 
 ZTEST_SUITE(suite_deadline, NULL, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
Adds the routine k_reschedule() to force a schedule point. It is callable at both thread and ISR level.

Most applications will never use this.

Fixes #79361