### PR TITLE
Bluetooth: tests: shell: br : increase rfcomm dlc stack size

### DIFF
--- a/subsys/bluetooth/host/classic/Kconfig
+++ b/subsys/bluetooth/host/classic/Kconfig
@@ -61,8 +61,7 @@ config BT_RFCOMM_TX_MAX
 
 config BT_RFCOMM_DLC_STACK_SIZE
 	int "Stack size of DLC for RFCOMM"
-	default 512 if BT_HFP_AG
-	default 256
+	default 512
 	help
 	  Stack size of DLC for RFCOMM. This is the context from which
 	  all data of upper layer are sent and disconnect


### PR DESCRIPTION
For the shell RFCOMM case, these is a stack overflow problem when do disconnect, so need to increase the CONFIG_BT_RFCOMM_DLC_STACK_SIZE. After testing, the stack here requires at least 388 bytes. With an additional 10% buffer, so set this size to 420.