### PR TITLE
drivers: i3c: cdns: add fifo threashold write/reads

### DIFF
--- a/dts/bindings/i3c/cdns,i3c.yaml
+++ b/dts/bindings/i3c/cdns,i3c.yaml
@@ -24,3 +24,13 @@ properties:
     type: int
     default: 1
     description: IBI Data Fifo Threashold Value
+
+  tx-thr:
+    type: int
+    default: 1
+    description: TX Fifo Threashold Value
+
+  rx-thr:
+    type: int
+    default: 1
+    description: RX Fifo Threashold Value


### PR DESCRIPTION
If an i3c transaction is larger than the FIFO size, it won't transmit. This utilizes the FIFO watermark interrupts to push or pop the fifos with more data.

Conditions to validate [controller only]

- [x] SDR RX Transactions
- [x] SDR TX Transactions
- [ ] DDR RX Transactions
- [ ] DDR TX Transactions
- [ ] Multi-message Transactions