### PR TITLE
dts: bindings: bluetooth: cyw43xxx: Add bt_hci_uart binding layer to desc

### DIFF
--- a/dts/bindings/bluetooth/infineon,cyw43xxx-bt-hci.yaml
+++ b/dts/bindings/bluetooth/infineon,cyw43xxx-bt-hci.yaml
@@ -21,12 +21,17 @@ description: |
         /* HW Flow control must be enabled for HCI H4 */
         hw-flow-control;
 
-        bt-hci {
+        bt_hci_uart: bt_hci_uart {
+          compatible = "zephyr,bt-hci-uart";
           status = "okay";
-          compatible = "infineon,cyw43xxx-bt-hci";
-          bt-reg-on-gpios = <&gpio_prt3 4 (GPIO_ACTIVE_HIGH)>;
 
-          fw-download-speed = <3000000>;
+          bt-hci {
+            status = "okay";
+            compatible = "infineon,cyw43xxx-bt-hci";
+            bt-reg-on-gpios = <&gpio_prt3 4 (GPIO_ACTIVE_HIGH)>;
+
+            fw-download-speed = <3000000>;
+          };
         };
       };
 


### PR DESCRIPTION
This pull request adds the `zephyr,bt-hci-uart` binding to the CYW43xxx device tree example in its bindings file to keep the documentation current with the latest implementation.
In 3482a3b the relevant boards devicetrees were updated.