### PR TITLE
drivers: flash: stm32h7: do not unlock CR at the end of init

### DIFF
--- a/drivers/flash/flash_stm32h7x.c
+++ b/drivers/flash/flash_stm32h7x.c
@@ -767,7 +767,7 @@ static int stm32h7_flash_init(const struct device *dev)
 	}
 #endif
 
-	return flash_stm32h7_write_protection(dev, false);
+	return 0;
 }
 
 DEVICE_DT_INST_DEFINE(0, stm32h7_flash_init, NULL, &flash_data, NULL, POST_KERNEL,


### PR DESCRIPTION
The lock mechanism is to protect unwanted registers modifications due to
software bugs. There is no point in leaving the registers unlock once
the driver is initialized.
