### PR TITLE
[v3.7-branch] samples: mgmt: mcumgr: smp_svr: Fix re-advertise issue on connection

### DIFF
--- a/samples/subsys/mgmt/mcumgr/smp_svr/src/bluetooth.c
+++ b/samples/subsys/mgmt/mcumgr/smp_svr/src/bluetooth.c
@@ -44,11 +44,10 @@ static void connected(struct bt_conn *conn, uint8_t err)
 {
 	if (err) {
 		LOG_ERR("Connection failed (err 0x%02x)", err);
+		k_work_submit(&advertise_work);
 	} else {
 		LOG_INF("Connected");
 	}
-
-	k_work_submit(&advertise_work);
 }
 
 static void disconnected(struct bt_conn *conn, uint8_t reason)


### PR DESCRIPTION
Fixes an issue introduced with commit
c6ad4a792724ed19e51c0a0d0f010490150d4eff which wrong restarts advertising after a device connects when it should only restart advertising if a device fails to connect

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/83041