### PR TITLE
drivers: flash: stm32: update ex_op API

### DIFF
--- a/drivers/flash/flash_stm32.h
+++ b/drivers/flash/flash_stm32.h
@@ -344,11 +344,11 @@ void flash_stm32_page_layout(const struct device *dev,
 #if defined(CONFIG_FLASH_STM32_WRITE_PROTECT)
 
 int flash_stm32_update_wp_sectors(const struct device *dev,
-				  uint32_t changed_sectors,
-				  uint32_t protected_sectors);
+				  uint64_t changed_sectors,
+				  uint64_t protected_sectors);
 
 int flash_stm32_get_wp_sectors(const struct device *dev,
-			       uint32_t *protected_sectors);
+			       uint64_t *protected_sectors);
 #endif
 #if defined(CONFIG_FLASH_STM32_READOUT_PROTECTION)
 uint8_t flash_stm32_get_rdp_level(const struct device *dev);

--- a/drivers/flash/flash_stm32_ex_op.c
+++ b/drivers/flash/flash_stm32_ex_op.c
@@ -28,7 +28,7 @@ int flash_stm32_ex_op_sector_wp(const struct device *dev, const uintptr_t in,
 		(const struct flash_stm32_ex_op_sector_wp_in *)in;
 	struct flash_stm32_ex_op_sector_wp_out *result =
 		(struct flash_stm32_ex_op_sector_wp_out *)out;
-	uint32_t change_mask;
+	uint64_t change_mask;
 	int rc = 0, rc2 = 0;
 #ifdef CONFIG_USERSPACE
 	bool syscall_trap = z_syscall_trap();

--- a/drivers/flash/flash_stm32f4x.c
+++ b/drivers/flash/flash_stm32f4x.c
@@ -273,8 +273,8 @@ uint32_t flash_stm32_option_bytes_read(const struct device *dev)
 
 #if defined(CONFIG_FLASH_STM32_WRITE_PROTECT)
 int flash_stm32_update_wp_sectors(const struct device *dev,
-				  uint32_t changed_sectors,
-				  uint32_t protected_sectors)
+				  uint64_t changed_sectors,
+				  uint64_t protected_sectors)
 {
 	changed_sectors <<= FLASH_OPTCR_nWRP_Pos;
 	protected_sectors <<= FLASH_OPTCR_nWRP_Pos;
@@ -286,12 +286,12 @@ int flash_stm32_update_wp_sectors(const struct device *dev,
 	/* Sector is protected when bit == 0. Flip protected_sectors bits */
 	protected_sectors = ~protected_sectors & changed_sectors;
 
-	return flash_stm32_option_bytes_write(dev, changed_sectors,
-					      protected_sectors);
+	return flash_stm32_option_bytes_write(dev, (uint32_t)changed_sectors,
+					      (uint32_t)protected_sectors);
 }
 
 int flash_stm32_get_wp_sectors(const struct device *dev,
-			       uint32_t *protected_sectors)
+			       uint64_t *protected_sectors)
 {
 	FLASH_TypeDef *regs = FLASH_STM32_REGS(dev);
 

--- a/include/zephyr/drivers/flash/stm32_flash_api_extensions.h
+++ b/include/zephyr/drivers/flash/stm32_flash_api_extensions.h
@@ -66,12 +66,12 @@ enum stm32_ex_ops {
 
 #if defined(CONFIG_FLASH_STM32_WRITE_PROTECT)
 struct flash_stm32_ex_op_sector_wp_in {
-	uint32_t enable_mask;
-	uint32_t disable_mask;
+	uint64_t enable_mask;
+	uint64_t disable_mask;
 };
 
 struct flash_stm32_ex_op_sector_wp_out {
-	uint32_t protected_mask;
+	uint64_t protected_mask;
 };
 #endif /* CONFIG_FLASH_STM32_WRITE_PROTECT */
 

--- a/tests/drivers/flash/stm32/src/main.c
+++ b/tests/drivers/flash/stm32/src/main.c
@@ -24,11 +24,11 @@ static const struct device *const flash_dev = TEST_AREA_DEVICE;
 
 #if defined(CONFIG_FLASH_STM32_WRITE_PROTECT)
 static const struct flash_parameters *flash_params;
-static uint32_t sector_mask;
+static uint64_t sector_mask;
 static uint8_t __aligned(4) expected[EXPECTED_SIZE];
 
 static int sector_mask_from_offset(const struct device *dev, off_t offset,
-				   size_t size, uint32_t *mask)
+				   size_t size, uint64_t *mask)
 {
 	struct flash_pages_info start_page, end_page;
 
@@ -67,7 +67,7 @@ static void *flash_stm32_setup(void)
 				     &sector_mask);
 	zassert_equal(rc, 0, "Cannot get sector mask");
 
-	TC_PRINT("Sector mask for offset 0x%x size 0x%x is 0x%x\n",
+	TC_PRINT("Sector mask for offset 0x%x size 0x%x is 0x%llx\n",
 	       TEST_AREA_OFFSET, EXPECTED_SIZE, sector_mask);
 
 	/* Check if region is not write protected. */
@@ -75,7 +75,7 @@ static void *flash_stm32_setup(void)
 			 (uintptr_t)NULL, &wp_status);
 	zassert_equal(rc, 0, "Cannot get write protect status");
 
-	TC_PRINT("Protected sectors: 0x%x\n", wp_status.protected_mask);
+	TC_PRINT("Protected sectors: 0x%llx\n", wp_status.protected_mask);
 
 	/* Remove protection if needed. */
 	if (wp_status.protected_mask & sector_mask) {


### PR DESCRIPTION
Use uint64_t instead of uint32_t for the FLASH_STM32_EX_OP_SECTOR_WP extended operation.

Some chips have two banks, more than 16 sectors each e.g. stm32h7a3xx chips, so more than 32 bits are required.