### PR TITLE
Intel ADSP: add support for "cold" code and data

### DIFF
--- a/scripts/west_commands/sign.py
+++ b/scripts/west_commands/sign.py
@@ -12,6 +12,8 @@ import shutil
 import subprocess
 import sys
 
+from elftools.elf.elffile import ELFFile
+
 from west import manifest
 from west.commands import Verbosity
 from west.util import quote_sh_list
@@ -474,6 +476,7 @@ class RimageSigner(Signer):
         kernel_name = build_conf.get('CONFIG_KERNEL_BIN_NAME', 'zephyr')
 
         bootloader = None
+        cold = None
         kernel = str(b / 'zephyr' / f'{kernel_name}.elf')
         out_bin = str(b / 'zephyr' / f'{kernel_name}.ri')
         out_xman = str(b / 'zephyr' / f'{kernel_name}.ri.xman')
@@ -484,6 +487,12 @@ class RimageSigner(Signer):
         # zephyr.elf directly.
         if os.path.exists(str(b / 'zephyr' / 'boot.mod')):
             bootloader = str(b / 'zephyr' / 'boot.mod')
+        if os.path.exists(str(b / 'zephyr' / 'cold.mod')):
+            cold = str(b / 'zephyr' / 'cold.mod')
+            with open(cold, 'rb') as f_cold:
+                elf = ELFFile(f_cold)
+                if elf.get_section_by_name('.cold') is None:
+                    cold = None
         if os.path.exists(str(b / 'zephyr' / 'main.mod')):
             kernel = str(b / 'zephyr' / 'main.mod')
 
@@ -556,7 +565,10 @@ class RimageSigner(Signer):
         if not args.quiet and args.verbose:
             sign_base += ['-v'] * args.verbose
 
+        # Order is important
         components = [ ] if bootloader is None else [ bootloader ]
+        if cold is not None:
+            components += [ cold ]
         components += [ kernel ]
 
         sign_config_extra_args = command.config_get_words('rimage.extra-args', [])

--- a/soc/intel/intel_adsp/ace/ace-link.ld
+++ b/soc/intel/intel_adsp/ace/ace-link.ld
@@ -171,6 +171,16 @@ SECTIONS {
    */
   .imrdata : ALIGN(4096) {
     *(.imrdata .imrdata.*)
+  } >imr
+
+  /* Cold code in IMR memory */
+  .cold : ALIGN(4096) {
+    *(.cold .cold.* )
+  } >imr
+
+  /* Cold data. */
+  .coldrodata : ALIGN(4096) {
+    *(.coldrodata .coldrodata.*)
     _imr_end = .;
   } >imr
 
@@ -553,6 +563,7 @@ SECTIONS {
 
   /* rimage module manifest headers */
   .module.boot : { KEEP(*(.module.boot)) } >noload
+  .module.cold : { KEEP(*(.module.cold)) } >noload
   .module.main : { KEEP(*(.module.main)) } >noload
 
  .static_uuid_entries : {

--- a/soc/intel/intel_adsp/common/CMakeLists.txt
+++ b/soc/intel/intel_adsp/common/CMakeLists.txt
@@ -82,11 +82,22 @@ add_custom_command(
       --rename-section .module.boot=.module
       ${KERNEL_REMAPPED} ${CMAKE_BINARY_DIR}/zephyr/boot.mod 2>${NULL_FILE}
 
+  COMMAND ${CMAKE_OBJCOPY}
+      --only-section .cold
+      --only-section .coldrodata
+      --only-section .module.cold
+      --set-section-flags .module.cold=noload,readonly
+      --rename-section .module.cold=.module
+      ${KERNEL_REMAPPED} ${CMAKE_BINARY_DIR}/zephyr/cold.mod 2>${NULL_FILE}
+
   # Remove .fw_metadata here...
   COMMAND ${CMAKE_OBJCOPY}
       --remove-section .imr
       --remove-section .imrdata
+      --remove-section .cold
+      --remove-section .coldrodata
       --remove-section .module.boot
+      --remove-section .module.cold
       --remove-section .fw_metadata
       --set-section-flags .module.main=noload,readonly
       --set-section-flags .static_uuid_entries=noload,readonly

--- a/soc/intel/intel_adsp/common/boot.c
+++ b/soc/intel/intel_adsp/common/boot.c
@@ -92,7 +92,9 @@ static __imr void parse_module(struct sof_man_fw_header *hdr,
 		switch (mod->segment[i].flags.r.type) {
 		case SOF_MAN_SEGMENT_TEXT:
 		case SOF_MAN_SEGMENT_DATA:
-			if (mod->segment[i].flags.r.load == 0) {
+			if (mod->segment[i].flags.r.load == 0 ||
+			    mod->segment[i].v_base_addr >= L2_SRAM_BASE + L2_SRAM_SIZE ||
+			    mod->segment[i].v_base_addr < L2_SRAM_BASE) {
 				continue;
 			}
 

--- a/soc/intel/intel_adsp/common/rimage_modules.c
+++ b/soc/intel/intel_adsp/common/rimage_modules.c
@@ -42,3 +42,17 @@ const struct sof_man_module_manifest main_manifest = {
 		     .affinity_mask = 3,
 	}
 };
+
+__attribute__((section(".module.cold")))
+const struct sof_man_module_manifest cold_manifest = {
+	.module = {
+		     .name = "COLD",
+		     /* d406d134-c3c1-402c-8aec-6821c0c2b0e6 */
+		     .uuid = {0x34, 0xd1, 0x06, 0xd4, 0xc1, 0xc3, 0x2c, 0x40,
+			      0x8a, 0xec, 0x68, 0x21, 0xc0, 0xc2, 0xb0, 0xe6},
+		     .entry_point = 0,
+		     .type = { .load_type = SOF_MAN_MOD_TYPE_MODULE,
+			       .domain_ll = 1 },
+		     .affinity_mask = 3,
+	}
+};


### PR DESCRIPTION
On Intel ADSP the firmware is first stored in abundant but slower DRAM before being copied to scarce and fast SRAM. This PR adds support for storing and executing data and code directly in DRAM without copying it to SRAM.