### PR TITLE
modules: hal_nordic: nrfx: Compile NRFX_GPPI modules for 54lbsim

### DIFF
--- a/modules/hal_nordic/nrfx/CMakeLists.txt
+++ b/modules/hal_nordic/nrfx/CMakeLists.txt
@@ -196,7 +196,7 @@ if(CONFIG_SOC_NRF54L20_ENGA_CPUAPP)
   zephyr_compile_definitions(NRF_SKIP_TAMPC_SETUP)
 endif()
 
-if(CONFIG_SOC_SERIES_NRF54LX AND CONFIG_NRFX_GPPI)
+if(CONFIG_SOC_COMPATIBLE_NRF54LX AND CONFIG_NRFX_GPPI)
   zephyr_library_sources(${HELPERS_DIR}/nrfx_gppi_dppi_ppib_lumos.c)
   zephyr_library_sources(${NRFX_DIR}/soc/interconnect/dppic_ppib/nrfx_interconnect_dppic_ppib.c)
 endif()


### PR DESCRIPTION
We should use CONFIG_SOC_COMPATIBLE_NRF54L15 whenever possible. With the current bsim model of 54L these files do not yet compile, but that can be added separately.