### PR TITLE
settings: let settings_load fail on the first csi_load() failure

### DIFF
--- a/subsys/settings/src/settings_store.c
+++ b/subsys/settings/src/settings_store.c
@@ -55,7 +55,11 @@ int settings_load_subtree(const char *subtree)
 	 */
 	k_mutex_lock(&settings_lock, K_FOREVER);
 	SYS_SLIST_FOR_EACH_CONTAINER(&settings_load_srcs, cs, cs_next) {
-		cs->cs_itf->csi_load(cs, &arg);
+		rc = cs->cs_itf->csi_load(cs, &arg);
+		if (rc < 0) {
+			k_mutex_unlock(&settings_lock);
+			return rc;
+		}
 	}
 	rc = settings_commit_subtree(subtree);
 	k_mutex_unlock(&settings_lock);


### PR DESCRIPTION
settings: let `settings_load()` fail on the first `csi_load()` failure and return the result.

In its current state, it will just happily return `0` in all cases. (except when a `h_commit()` calls fails).
The way I understand it, this is not according to the documentation (https://docs.zephyrproject.org/latest/services/settings/index.html#loading-data-from-persisted-storage).

If you guys agree with the issue (raised here: https://github.com/zephyrproject-rtos/zephyr/issues/83279),
then this is my proposal to fix it.
