### PR TITLE
Revert "cmake: remove enforcement of DWARF v4"

### DIFF
--- a/cmake/compiler/gcc/compiler_flags.cmake
+++ b/cmake/compiler/gcc/compiler_flags.cmake
@@ -214,6 +214,10 @@ set_compiler_property(PROPERTY linker_script -T)
 # Flags to not track macro expansion
 set_compiler_property(PROPERTY no_track_macro_expansion -ftrack-macro-expansion=0)
 
+# GCC 11 by default emits DWARF version 5 which cannot be parsed by
+# pyelftools. Can be removed once pyelftools supports v5.
+check_set_compiler_property(APPEND PROPERTY debug -gdwarf-4)
+
 set_compiler_property(PROPERTY no_common -fno-common)
 
 # GCC compiler flags for imacros. The specific header must be appended by user.

--- a/cmake/linker/ld/gcc/linker_flags.cmake
+++ b/cmake/linker/ld/gcc/linker_flags.cmake
@@ -9,6 +9,10 @@ endif()
 
 check_set_linker_property(TARGET linker APPEND PROPERTY gprof -pg)
 
+# GCC 11 by default emits DWARF version 5 which cannot be parsed by
+# pyelftools. Can be removed once pyelftools supports v5.
+add_link_options(-gdwarf-4)
+
 # Extra warnings options for twister run
 set_property(TARGET linker PROPERTY warnings_as_errors -Wl,--fatal-warnings)
 

--- a/scripts/requirements-base.txt
+++ b/scripts/requirements-base.txt
@@ -4,7 +4,7 @@
 # part of the recommended workflow
 
 # used by various build scripts
-pyelftools>=0.31
+pyelftools>=0.29
 
 # used by dts generation to parse binding YAMLs, also used by
 # twister to parse YAMLs, by west, zephyr_module,...


### PR DESCRIPTION
This reverts commit 9d849d92bfaf08f62f1c4df441aacff88e1e5af3 that seems to be causing dozens of basic kernel test failures across various platforms.

Repro:

```
west build -p -b qemu_x86 tests/kernel/mem_protect/futex -T kernel.futex && west build -t run
```