### PR TITLE
drivers: usb: Fix pointer reference in the NXP drivers

### DIFF
--- a/drivers/usb/udc/udc_mcux_ehci.c
+++ b/drivers/usb/udc/udc_mcux_ehci.c
@@ -695,8 +695,7 @@ static int udc_mcux_init(const struct device *dev)
 
 #ifdef CONFIG_DT_HAS_NXP_USBPHY_ENABLED
 	if (config->phy_config != NULL) {
-		USB_EhciPhyInit(priv->controller_id, 0u,
-			(usb_phy_config_struct_t *)&config->phy_config);
+		USB_EhciPhyInit(priv->controller_id, 0u, config->phy_config);
 	}
 #endif
 

--- a/drivers/usb/udc/udc_mcux_ip3511.c
+++ b/drivers/usb/udc/udc_mcux_ip3511.c
@@ -695,8 +695,7 @@ static int udc_mcux_init(const struct device *dev)
 
 #ifdef CONFIG_DT_HAS_NXP_USBPHY_ENABLED
 	if (config->phy_config != NULL) {
-		USB_EhciPhyInit(priv->controller_id, 0u,
-			(usb_phy_config_struct_t *)&config->phy_config);
+		USB_EhciPhyInit(priv->controller_id, 0u, config->phy_config);
 	}
 #endif
 


### PR DESCRIPTION
The address passed in to the function was incorrect causing failures when porting to RT1180.