### PR TITLE
soc/mediatek: Add DTS binding and definitions for AFE

### DIFF
--- a/boards/mediatek/mt8186/afe-mt8186.dts
+++ b/boards/mediatek/mt8186/afe-mt8186.dts
@@ -1,0 +1,54 @@
+	afe_dl1: afe_dl1 {
+		compatible = "mediatek,afe";
+		afe_name = "DL1";
+		dai_id = <0>;
+		downlink;
+		base = <0x11210050 0x11210054>;
+		cur = <0x11210058 0x1121005c>;
+		end = <0x11210060 0x11210064>;
+		fs = <0x1121004c 24 4>;
+		mono = <0x1121004c 8 1>;
+		enable = <0x11210010 4 1>;
+		hd = <0x1121004c 0 1>;
+	};
+
+	afe_dl2: afe_dl2 {
+		compatible = "mediatek,afe";
+		afe_name = "DL2";
+		dai_id = <1>;
+		downlink;
+		base = <0x1121006c 0x11210070>;
+		cur = <0x11210074 0x11210078>;
+		end = <0x1121007c 0x11210080>;
+		fs = <0x11210068 24 4>;
+		mono = <0x11210068 8 1>;
+		enable = <0x11210010 5 1>;
+		hd = <0x11210068 0 1>;
+	};
+
+	afe_ul1: afe_ul1 {
+		compatible = "mediatek,afe";
+		afe_name = "UL1";
+		dai_id = <2>;
+		base = <0x11210378 0x1121037c>;
+		cur = <0x11210380 0x11210384>;
+		end = <0x11210388 0x1121038c>;
+		fs = <0x11210374 24 4>;
+		mono = <0x11210374 8 1>;
+		quad_ch = <0x11210374 11 1>;
+		enable = <0x11210010 31 1>;
+		hd = <0x11210374 0 1>;
+	};
+
+	afe_ul2: afe_ul2 {
+		compatible = "mediatek,afe";
+		afe_name = "UL2";
+		dai_id = <3>;
+		base = <0x11210860 0x11210864>;
+		cur = <0x11210868 0x1121086c>;
+		end = <0x11210870 0x11210874>;
+		fs = <0x1121085c 24 4>;
+		mono = <0x1121085c 8 1>;
+		enable = <0x11210010 16 1>;
+		hd = <0x1121085c 0 1>;
+	};

--- a/boards/mediatek/mt8188/afe-mt8188.dts
+++ b/boards/mediatek/mt8188/afe-mt8188.dts
@@ -1,0 +1,67 @@
+	afe_dl2: afe_dl2 {
+		compatible = "mediatek,afe";
+		afe_name = "DL2";
+		dai_id = <0>;
+		downlink;
+		base = <0x00000000 0x10b11250>;
+		cur = <0x00000000 0x10b11254>;
+		end = <0x00000000 0x10b11258>;
+		fs = <0x10b115a0 10 5>;
+		enable = <0x10b11200 18 1>;
+		hd = <0x10b1125c 5 1>;
+		msb = <0x10b1192c 18 1>;
+		msb2 = <0x10b11930 18 1>;
+		agent_disable = <0x10b10014 18 1>;
+		ch_num = <0x10b1125c 0 5>;
+	};
+
+	afe_dl3: afe_dl3 {
+		compatible = "mediatek,afe";
+		afe_name = "DL3";
+		dai_id = <1>;
+		downlink;
+		base = <0x00000000 0x10b11260>;
+		cur = <0x00000000 0x10b11264>;
+		end = <0x00000000 0x10b11268>;
+		fs = <0x10b115a0 15 5>;
+		enable = <0x10b11200 19 1>;
+		hd = <0x10b1126c 5 1>;
+		msb = <0x10b1192c 19 1>;
+		msb2 = <0x10b11930 19 1>;
+		agent_disable = <0x10b10014 19 1>;
+		ch_num = <0x10b1126c 0 5>;
+	};
+
+	afe_ul4: afe_ul4 {
+		compatible = "mediatek,afe";
+		afe_name = "UL4";
+		dai_id = <2>;
+		base = <0x00000000 0x10b11330>;
+		cur = <0x00000000 0x10b11334>;
+		end = <0x00000000 0x10b11338>;
+		fs = <0x10b115a8 15 5>;
+		mono = <0x10b1133c 1 1>;
+		int_odd = <0x10b1133c 0 1>;
+		enable = <0x10b11200 4 1>;
+		hd = <0x10b1133c 5 1>;
+		msb = <0x10b1192c 3 1>;
+		msb2 = <0x10b11930 3 1>;
+		agent_disable = <0x10b10014 3 1>;
+	};
+
+	afe_ul5: afe_ul5 {
+		compatible = "mediatek,afe";
+		afe_name = "UL5";
+		dai_id = <3>;
+		base = <0x00000000 0x10b11340>;
+		cur = <0x00000000 0x10b11344>;
+		end = <0x00000000 0x10b11348>;
+		fs = <0x10b115a8 20 5>;
+		mono = <0x10b1134c 1 1>;
+		int_odd = <0x10b1134c 0 1>;
+		enable = <0x10b11200 5 1>;
+		hd = <0x10b1134c 5 1>;
+		msb = <0x10b1192c 4 1>;
+		msb2 = <0x10b11930 4 1>;
+		agent_disable = <0x10b10014 4 1>;
+	};

--- a/boards/mediatek/mt8195/afe-mt8195.dts
+++ b/boards/mediatek/mt8195/afe-mt8195.dts
@@ -1,0 +1,65 @@
+	afe_dl2: afe_dl2 {
+		compatible = "mediatek,afe";
+		afe_name = "DL2";
+		dai_id = <0>;
+		downlink;
+		base = <0x00000000 0x10891250>;
+		cur = <0x00000000 0x10891254>;
+		end = <0x00000000 0x10891258>;
+		fs = <0x108915a0 10 5>;
+		enable = <0x10891200 18 1>;
+		hd = <0x1089125c 5 1>;
+		msb = <0x1089192c 18 1>;
+		msb2 = <0x10891930 18 1>;
+		agent_disable = <0x10890014 18 1>;
+		ch_num = <0x1089125c 0 5>;
+	};
+
+	afe_dl3: afe_dl3 {
+		compatible = "mediatek,afe";
+		afe_name = "DL3";
+		dai_id = <1>;
+		downlink;
+		base = <0x00000000 0x10891260>;
+		cur = <0x00000000 0x10891264>;
+		end = <0x00000000 0x10891268>;
+		fs = <0x108915a0 15 5>;
+		enable = <0x10891200 19 1>;
+		hd = <0x1089126c 5 1>;
+		msb = <0x1089192c 19 1>;
+		msb2 = <0x10891930 19 1>;
+		agent_disable = <0x10890014 19 1>;
+		ch_num = <0x1089126c 0 5>;
+	};
+
+	afe_ul4: afe_ul4 {
+		compatible = "mediatek,afe";
+		afe_name = "UL4";
+		dai_id = <2>;
+		base = <0x00000000 0x10891330>;
+		cur = <0x00000000 0x10891334>;
+		end = <0x00000000 0x10891338>;
+		fs = <0x108915a8 15 5>;
+		mono = <0x1089133c 1 1>;
+		enable = <0x10891200 4 1>;
+		hd = <0x1089133c 5 1>;
+		msb = <0x1089192c 3 1>;
+		msb2 = <0x10891930 3 1>;
+		agent_disable = <0x10890014 3 1>;
+	};
+
+	afe_ul5: afe_ul5 {
+		compatible = "mediatek,afe";
+		afe_name = "UL5";
+		dai_id = <3>;
+		base = <0x00000000 0x10891340>;
+		cur = <0x00000000 0x10891344>;
+		end = <0x00000000 0x10891348>;
+		fs = <0x108915a8 20 5>;
+		mono = <0x1089134c 1 1>;
+		enable = <0x10891200 5 1>;
+		hd = <0x1089134c 5 1>;
+		msb = <0x1089192c 4 1>;
+		msb2 = <0x10891930 4 1>;
+		agent_disable = <0x10890014 4 1>;
+	};

--- a/boards/mediatek/mt8196/afe-mt8196.dts
+++ b/boards/mediatek/mt8196/afe-mt8196.dts
@@ -1,0 +1,66 @@
+	afe_dl1: afe_dl1 {
+		compatible = "mediatek,afe";
+		afe_name = "DL1";
+		dai_id = <1>;
+		downlink;
+		base = <0x1a114470 0x1a114474>;
+		cur = <0x1a114478 0x1a11447c>;
+		end = <0x1a114480 0x1a114484>;
+		fs = <0x1a114490 8 5>;
+		mono = <0x1a114490 4 1>;
+		enable = <0x1a114490 28 1>;
+		hd = <0x1a114490 0 1>;
+	};
+
+	afe_dl_24ch: afe_dl_24ch {
+		compatible = "mediatek,afe";
+		afe_name = "DL_24CH";
+		dai_id = <0>;
+		downlink;
+		base = <0x1a114620 0x1a114624>;
+		cur = <0x1a114628 0x1a11462c>;
+		end = <0x1a114630 0x1a114634>;
+		fs = <0x1a114640 8 5>;
+		enable = <0x1a114640 31 1>;
+		hd = <0x1a114640 0 1>;
+		ch_num = <0x1a114640 24 6>;
+	};
+
+	afe_ul0: afe_ul0 {
+		compatible = "mediatek,afe";
+		afe_name = "UL0";
+		dai_id = <2>;
+		base = <0x1a114d60 0x1a114d64>;
+		cur = <0x1a114d68 0x1a114d6c>;
+		end = <0x1a114d70 0x1a114d74>;
+		fs = <0x1a114d80 8 5>;
+		mono = <0x1a114d80 4 1>;
+		enable = <0x1a114d80 28 1>;
+		hd = <0x1a114d80 0 1>;
+	};
+
+	afe_ul1: afe_ul1 {
+		compatible = "mediatek,afe";
+		afe_name = "UL1";
+		dai_id = <3>;
+		base = <0x1a114d90 0x1a114d94>;
+		cur = <0x1a114d98 0x1a114d9c>;
+		end = <0x1a114da0 0x1a114da4>;
+		fs = <0x1a114db0 8 5>;
+		mono = <0x1a114db0 4 1>;
+		enable = <0x1a114db0 28 1>;
+		hd = <0x1a114db0 0 1>;
+	};
+
+	afe_ul2: afe_ul2 {
+		compatible = "mediatek,afe";
+		afe_name = "UL2";
+		dai_id = <4>;
+		base = <0x1a114dc0 0x1a114dc4>;
+		cur = <0x1a114dc8 0x1a114dcc>;
+		end = <0x1a114dd0 0x1a114dd4>;
+		fs = <0x1a114de0 8 5>;
+		mono = <0x1a114de0 4 1>;
+		enable = <0x1a114de0 28 1>;
+		hd = <0x1a114de0 0 1>;
+	};

--- a/boards/mediatek/mt8196/mt8196_adsp.dts
+++ b/boards/mediatek/mt8196/mt8196_adsp.dts
@@ -101,6 +101,10 @@
 			interrupt-parent = <&intc_g2>;
 			interrupts = <7 0 0>;
 		};
+
+/* Generated code for AFE devices */
+#include "afe-mt8196.dts"
+
 	}; /* soc */
 
 	chosen { };

--- a/dts/bindings/dai/mediatek,afe.yaml
+++ b/dts/bindings/dai/mediatek,afe.yaml
@@ -1,0 +1,63 @@
+description: Mediatek Audio Front End
+
+compatible: "mediatek,afe"
+
+include: base.yaml
+
+properties:
+  dai_id:
+    type: int
+    required: true
+    description: Host-defined SOF DAI index.  Must match the Linux kernel driver.
+  afe_name:
+    type: string
+    required: true
+  downlink:
+    type: boolean
+    description: True/present for downlink (capture) channels
+
+  # These three are two-register arrays defining the DSP registers
+  # that store the hi and low words of a 64 bit bus/host address.
+  #
+  base:
+    type: array
+  end:
+    type: array
+  cur:
+    type: array
+
+  # The remaining registers below are three-cell arrays describing a
+  # bit field as <addr lshift width>.  Most of them are defaultable by
+  # the driver and can be eliminated from DTS for hardware that does
+  # not support the feature.  See the driver source for details.
+  #
+  enable:
+    type: array
+    description: Channel enable flag
+  agent_disable:
+    type: array
+    description: Channel disable flag
+  fs:
+    type: array
+    description: Sample rate register
+  hd:
+    type: array
+    description: Sample format register
+  ch_num:
+    type: array
+    description: Channel count register
+  mono:
+    type: array
+    description: Mono flag register
+  mono_invert:
+    type: boolean
+    description: Sense/meaning of mono flag
+  quad_ch:
+    type: array
+    description: Quad channel flag register
+  int_odd:
+    type: array
+  msb:
+    type: array
+  msb2:
+    type: array


### PR DESCRIPTION
Add a DTS binding for the MediaTek Audio Front End device, and definitions for the in-tree devices.

These .dts files were auto-generated from pre-existing SOF code (that defined the devices as C structs) using a tool currently being submitted in the SOF tree, thus are included here as separate files. The expectation is that future variants will be authored in this format directly.  Longer term we can move them directly into the core board DTS