### PR TITLE
MediaTek DSP memory layout improvements

### DIFF
--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -303,6 +303,14 @@ config LINKER_LAST_SECTION_ID
 	  last section identifier may cause rom region overflow.
 	  In such cases this setting should be disabled.
 
+config LINKER_USE_STACK_SECTION
+	bool "Place stacks in special section"
+	depends on !KERNEL_COHERENCE && !USERSPACE
+	help
+	  When enabled, stack memory declared with either __stackmem
+	  or __kstackmem will be placed in a special ".stacks" section
+	  for the platform linker to treat specially.
+
 config LINKER_LAST_SECTION_ID_PATTERN
 	hex "Last section identifier pattern"
 	default "0xE015E015"

--- a/include/zephyr/linker/section_tags.h
+++ b/include/zephyr/linker/section_tags.h
@@ -72,6 +72,13 @@
 #define __kstackmem __noinit
 #endif /* CONFIG_KERNEL_COHERENCE */
 
+#ifdef CONFIG_LINKER_USE_STACK_SECTION
+#undef __stackmem
+#undef __kstackmem
+#define __stackmem Z_GENERIC_SECTION(.stacks)
+#define __kstackmem Z_GENERIC_SECTION(.stacks)
+#endif
+
 #if defined(CONFIG_LINKER_USE_BOOT_SECTION)
 #define __boot_func	Z_GENERIC_DOT_SECTION(BOOT_TEXT_SECTION_NAME)
 #define __boot_data	Z_GENERIC_DOT_SECTION(BOOT_DATA_SECTION_NAME)

--- a/soc/mediatek/mt8xxx/Kconfig.defconfig
+++ b/soc/mediatek/mt8xxx/Kconfig.defconfig
@@ -36,6 +36,9 @@ config MTK_ADSP_TIMER
 config XTENSA_TIMER
 	default n
 
+config LINKER_USE_STACK_SECTION
+	default y
+
 config XTENSA_CCOUNT_HZ
 	default 720000000 if SOC_MT8195
 	default 400000000 if SOC_MT8186

--- a/soc/mediatek/mt8xxx/linker.ld
+++ b/soc/mediatek/mt8xxx/linker.ld
@@ -42,6 +42,24 @@ SECTIONS {
     *(.stacks .stacks.*)
   } > sram
 
+  .data : {
+    __data_start = .;
+    *(.data .data.*)
+    _trace_ctx_start = ABSOLUTE(.);
+    *(.trace_ctx)
+    _trace_ctx_end = ABSOLUTE(.);
+    __data_end = .;
+  } > sram
+
+  .bss (NOLOAD) :
+  {
+    _bss_start = .;
+    *(.bss .bss.*)
+    *(.gnu.linkonce.b.*)
+    *(COMMON)
+    _bss_end = .;
+  } > sram
+
   _mtk_adsp_sram_end = .;
 
   .text : {
@@ -74,30 +92,9 @@ SECTIONS {
 
   __rodata_region_end = .;
 
-    . = ALIGN(4096); /* Switching MPU permissions, align by 4k */
-
-  _image_ram_start = .;
-
-  .data : {
-    __data_start = .;
-    *(.data .data.*)
-    _trace_ctx_start = ABSOLUTE(.);
-    *(.trace_ctx)
-    _trace_ctx_end = ABSOLUTE(.);
-    __data_end = .;
-  } > dram
+  . = ALIGN(4096); /* Switching MPU permissions, align by 4k */
 
 #include <zephyr/linker/common-ram.ld>
-
-  .bss (NOLOAD) :
-  {
-    _bss_start = .;
-    *(.bss .bss.*)
-    *(.gnu.linkonce.b.*)
-    *(COMMON)
-    _bss_end = .;
-  } > dram
-
 #include <zephyr/linker/common-noinit.ld>
 #include <snippets-sections.ld>
 

--- a/soc/mediatek/mt8xxx/linker.ld
+++ b/soc/mediatek/mt8xxx/linker.ld
@@ -38,6 +38,10 @@ SECTIONS {
     *(.literal.iram .iram.*)
   } > sram
 
+  .stacks : {
+    *(.stacks .stacks.*)
+  } > sram
+
   _mtk_adsp_sram_end = .;
 
   .text : {


### PR DESCRIPTION
Move stacks, .data and .bss from DRAM to SRAM.  The SRAM on these devices is limited; we can't put the entire firmware in it.  But it shows 5x faster latency from the DSP, so try to prioritize default linkage to put mutable data there.

Actually in point of fact even the SRAM is pretty slow (~40 cycle read latency).  Thankfully these devices have monster caches, so in practice things usually work out.