### PR TITLE
Fixes a sysbuild failure for M5Stack CoreS3

### DIFF
--- a/boards/m5stack/m5stack_cores3/m5stack_cores3_procpu_common.dtsi
+++ b/boards/m5stack/m5stack_cores3/m5stack_cores3_procpu_common.dtsi
@@ -84,7 +84,7 @@
 		status = "okay";
 	};
 
-	aw9523b@58 {
+	aw9523b: aw9523b@58 {
 		compatible = "awinic,aw9523b";
 		reg = <0x58>;
 		status = "okay";

--- a/west.yml
+++ b/west.yml
@@ -303,7 +303,7 @@ manifest:
       groups:
         - crypto
     - name: mcuboot
-      revision: a2bc982b3379d51fefda3e17a6a067342dce1a8b
+      revision: 06747985eee7c27d891f2529c58e18f4a84ea6a3
       path: bootloader/mcuboot
       groups:
         - bootloader


### PR DESCRIPTION
This is caused by a driver whose dependencies cannot be resolved being included during sysbuild.

mfd_aw9523b, gpi_aw9523b: Replace 'select I2C' with 'depends on I2C' in Kconfig to follow the specified build settings.

ft5336: Enables INPUT under stricter conditions (when LVGL or DISPLAY is enabled).