### PR TITLE
Deprecate mimxrt1050_evk and mimxrt1060_evk boards properly and update mcuboot

### DIFF
--- a/boards/deprecated.cmake
+++ b/boards/deprecated.cmake
@@ -25,3 +25,15 @@ set(mimx8mp_phyboard_pollux/mimx8ml8/m7_DEPRECATED
 set(mimx8mm_phyboard_polis/mimx8mm6/m4_DEPRECATED
     phyboard_polis/mimx8mm6/m4
 )
+set(mimxrt1050_evk_DEPRECATED
+    mimxrt1050_evk/mimxrt1052/hyperflash
+)
+set(mimxrt1060_evk_DEPRECATED
+    mimxrt1060_evk/mimxrt1064/hyperflash
+)
+set(mimxrt1060_evk_DEPRECATED
+     mimxrt1060_evk/mimxrt1062/qspi
+)
+set(mimxrt1060_evkb_DEPRECATED
+    mimxrt1060_evk@B/mimxrt1062/qspi
+)

--- a/west.yml
+++ b/west.yml
@@ -300,7 +300,7 @@ manifest:
       groups:
         - crypto
     - name: mcuboot
-      revision: f5454f16358225f69ff729301c8e56d8a580f81a
+      revision: a2bc982b3379d51fefda3e17a6a067342dce1a8b
       path: bootloader/mcuboot
       groups:
         - bootloader


### PR DESCRIPTION
- add proper deprecation for mimxrt1050_evk, mimxrt1060_evk and mimxrt1060_evkb
- pull new version of mcuboot that drops old name references in sample.yaml file (twister doesn't seem to know about deprecated names so this change is actually required)

The changes to the deprecated.cmake are not strictly required as part of the hotfix but since I'd already done it when realizing twister didn't really use that file, I thought it was worthwhile to keep since it's needed anyway to not break users downstream.

Reference for the renames that happened to help reviewers ensure no mistakes were made

- https://github.com/zephyrproject-rtos/zephyr/commit/0cdb35d97814c0e4a7c91fb2c0471651f9ce8d2d#diff-915de96b9323b5ac4aa81b6f9c267e56320c276a28372f9a6800073622c0db36
- https://github.com/zephyrproject-rtos/zephyr/commit/8ed80ddb370ad3df8d8687a8f7e95d688bc04377#diff-31d444683827e7b8a80bd4214fe1e2ce2b5b057c114e46e35f3e6de91a5b6c30