### PR TITLE
Revert "soc: st: warn if running with debug on sleep enabled"

### DIFF
--- a/soc/st/stm32/common/soc_config.c
+++ b/soc/st/stm32/common/soc_config.c
@@ -16,15 +16,6 @@
 #include <stm32_ll_bus.h>
 #include <stm32_ll_pwr.h>
 
-#if CONFIG_PM
-
-#if !defined(CONFIG_DEBUG) && defined(CONFIG_STM32_ENABLE_DEBUG_SLEEP_STOP)
-#warning "Running with PM=y and STM32_ENABLE_DEBUG_SLEEP_STOP=y, \
-this will result in increased power consumption during sleep."
-#endif
-
-#endif /* CONFIG_PM */
-
 /**
  * @brief Perform SoC configuration at boot.
  *


### PR DESCRIPTION
This reverts commit b33b3b17f7f52ad7ad58ddf6b4baa9c9d4458745, turns out it's causing issues in CI all over the place, the condition needs more thinking.