### PR TITLE
doc: _scripts: gen_devicetree_rest: add individual files

### DIFF
--- a/doc/_scripts/gen_devicetree_rest.py
+++ b/doc/_scripts/gen_devicetree_rest.py
@@ -162,7 +162,7 @@ class VndLookup:
 def main():
     args = parse_args()
     setup_logging(args.verbose)
-    bindings = load_bindings(args.dts_roots, args.dts_folders)
+    bindings = load_bindings(args.dts_roots, args.dts_folders, args.dts_files)
     base_binding = load_base_binding()
     driver_sources = load_driver_sources()
     vnd_lookup = VndLookup(args.vendor_prefixes, bindings)
@@ -182,6 +182,8 @@ def parse_args():
                         be set in DTS_ROOTS''')
     parser.add_argument('--dts-folder', dest='dts_folders', action='append', default=[],
                         help='additional DTS folders containing binding files')
+    parser.add_argument('--dts-file', dest='dts_files', action='append', default=[],
+                        help='additional individual DTS binding files')
     parser.add_argument('--turbo-mode', action='store_true',
                         help='Enable turbo mode (dummy references)')
     parser.add_argument('out_dir', help='output files are generated here')
@@ -198,7 +200,7 @@ def setup_logging(verbose):
     logging.basicConfig(format='%(filename)s:%(levelname)s: %(message)s',
                         level=log_level)
 
-def load_bindings(dts_roots, dts_folders):
+def load_bindings(dts_roots, dts_folders, dts_files):
     # Get a list of edtlib.Binding objects from searching 'dts_roots'.
 
     if not dts_roots:
@@ -213,6 +215,7 @@ def load_bindings(dts_roots, dts_folders):
     for folders in dts_folders:
         binding_files.extend(glob.glob(f'{folders}/*.yml', recursive=False))
         binding_files.extend(glob.glob(f'{folders}/*.yaml', recursive=False))
+    binding_files.extend(dts_files)
 
     bindings = edtlib.bindings_from_paths(binding_files, ignore_errors=True)
 


### PR DESCRIPTION
Add a CLI argument for specifying individual files to be added to the parsing. This is useful for downstream users that wish to import files such as `bindings/spi/spi-device.yaml`, without also pulling in all the associated SPI controllers.