### PR TITLE
manifest: update hal_nordic revision

### DIFF
--- a/modules/hal_nordic/nrf_802154/CMakeLists.txt
+++ b/modules/hal_nordic/nrf_802154/CMakeLists.txt
@@ -33,9 +33,6 @@ endif ()
 
 target_compile_definitions(zephyr-802154-interface
   INTERFACE
-    # Radio driver shim layer uses raw api
-    NRF_802154_USE_RAW_API=1
-
     # Number of slots containing short addresses of nodes for which
     # pending data is stored.
     NRF_802154_PENDING_SHORT_ADDRESSES=${CONFIG_NRF_802154_PENDING_SHORT_ADDRESSES}

--- a/west.yml
+++ b/west.yml
@@ -193,7 +193,7 @@ manifest:
       groups:
         - hal
     - name: hal_nordic
-      revision: fae15426c6b5a1f67362d508cf51b691ae5ab4b4
+      revision: c563b0e56dfa7e3915637b12b3428e6de36012be
       path: modules/hal/nordic
       groups:
         - hal


### PR DESCRIPTION
This commit updates revision of hal_nordic to bring the latest changes in the nRF IEEE 802.15.4 driver.