### PR TITLE
arch: arm: make tz_wrap more portable

### DIFF
--- a/arch/arm/include/cortex_m/tz_ns.h
+++ b/arch/arm/include/cortex_m/tz_ns.h
@@ -48,12 +48,6 @@
  */
 #define __TZ_WRAP_FUNC_RAW(preface, name, postface, store_lr, load_lr) \
 		__asm__ volatile( \
-			".global "#preface"; .type "#preface", %function"); \
-		__asm__ volatile( \
-			".global "#name"; .type "#name", %function"); \
-		__asm__ volatile( \
-			".global "#postface"; .type "#postface", %function"); \
-		__asm__ volatile( \
 			store_lr "\n\t" \
 			"push {r0-r3}\n\t" \
 			"bl " #preface "\n\t" \


### PR DESCRIPTION
Currently the inline assembler use is creating problems with IAR. (the ".global" parts)
This seems to improve the situation.

The `__TZ_WRAP_FUNC` was introduced in [this MR](https://github.com/zephyrproject-rtos/zephyr/pull/27831)
There is discussions about writing it in C. Which is what would be most portable. But this seems to be avoided
for unclear reasons.

There is a suggestion by anangl in [this discussion](https://github.com/zephyrproject-rtos/zephyr/pull/27831#discussion_r483517530) which I think also looks good. But "g" is not supported in IAR and in GCC it caused other issues.


This change makes tests pass both on IAR and GCC, but it could be causing some issue I am not understanding (clang?), since the ".global" doesn't seem needed. So I am open to other solutions to this.
I don't see any consumers of this API, so not sure what to test, but maybe they are out-of-tree?
I am just starting to look at TrustZone for IAR and this seemed like an easy start.

@carlescufi @anangl
