### PR TITLE
manifest: Update nRF hw models to latest

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -315,7 +315,7 @@ manifest:
       groups:
         - tools
     - name: nrf_hw_models
-      revision: fbc6e614686b69dfa56f9694350b9488cf83d3f7
+      revision: 71bcaa88c97977647d387217dab99f7d6f026815
       path: modules/bsim_hw_models/nrf_hw_models
     - name: nrf_wifi
       revision: 9612cd0f90946aa5c737530c57de2e894e16088f


### PR DESCRIPTION
Update the HW models module to:
71bcaa88c97977647d387217dab99f7d6f026815

Including the following:
- 71bcaa8 hal/nrf_cracen_rng.c: Disable until released
- 69e9037 hal cracen_rng: Add replacements for proposed cracen_rng hal 
- 71c2507 CRACEN RNG: Corrected one comment
- dfbc93a 54 ECB: Corrected behaviour with premature end of input joblist 
- a46101f 54 AAR, ECB, CCM: Correct a few notes and ECB ERRORSTATUS 
- 74aa2de 54L15: Correct IRQ 261 name
- e12ab9c Add CRACEN RNG model
- 91066e7 docs: UART add PTY backend to shortlist of backends