### PR TITLE
drivers: wifi: nxp: raise connect result event when failed

### DIFF
--- a/drivers/wifi/nxp/nxp_wifi_drv.c
+++ b/drivers/wifi/nxp/nxp_wifi_drv.c
@@ -196,10 +196,12 @@ int nxp_wifi_wlan_event_callback(enum wlan_event_reason reason, void *data)
 	case WLAN_REASON_CONNECT_FAILED:
 		net_if_dormant_on(g_mlan.netif);
 		LOG_WRN("WLAN: connect failed");
+		wifi_mgmt_raise_connect_result_event(g_mlan.netif, WIFI_STATUS_CONN_FAIL);
 		break;
 	case WLAN_REASON_NETWORK_NOT_FOUND:
 		net_if_dormant_on(g_mlan.netif);
 		LOG_WRN("WLAN: nxp_wlan_network not found");
+		wifi_mgmt_raise_connect_result_event(g_mlan.netif, WIFI_STATUS_CONN_AP_NOT_FOUND);
 		break;
 	case WLAN_REASON_NETWORK_AUTH_FAILED:
 		LOG_WRN("WLAN: nxp_wlan_network authentication failed");
@@ -210,6 +212,7 @@ int nxp_wifi_wlan_event_callback(enum wlan_event_reason reason, void *data)
 			auth_fail = 0;
 		}
 		net_if_dormant_on(g_mlan.netif);
+		wifi_mgmt_raise_connect_result_event(g_mlan.netif, WIFI_STATUS_CONN_WRONG_PASSWORD);
 		break;
 	case WLAN_REASON_ADDRESS_SUCCESS:
 		LOG_DBG("wlan_network mgr: DHCP new lease");


### PR DESCRIPTION
In case connection fails, the driver should raise a connect result event to notify the user.