### PR TITLE
drivers: stepper: Add timing source API

### DIFF
--- a/drivers/stepper/CMakeLists.txt
+++ b/drivers/stepper/CMakeLists.txt
@@ -6,6 +6,7 @@ zephyr_syscall_header(${ZEPHYR_BASE}/include/zephyr/drivers/stepper.h)
 # zephyr-keep-sorted-start
 add_subdirectory_ifdef(CONFIG_STEPPER_ADI_TMC adi_tmc)
 add_subdirectory_ifdef(CONFIG_STEPPER_TI ti)
+add_subdirectory_ifdef(CONFIG_STEP_DIR_STEPPER step_dir)
 # zephyr-keep-sorted-stop
 
 zephyr_library()
@@ -13,5 +14,4 @@ zephyr_library_property(ALLOW_EMPTY TRUE)
 
 zephyr_library_sources_ifdef(CONFIG_FAKE_STEPPER fake_stepper_controller.c)
 zephyr_library_sources_ifdef(CONFIG_GPIO_STEPPER gpio_stepper_controller.c)
-zephyr_library_sources_ifdef(CONFIG_STEP_DIR_STEPPER step_dir_stepper_common.c)
 zephyr_library_sources_ifdef(CONFIG_STEPPER_SHELL stepper_shell.c)

--- a/drivers/stepper/Kconfig
+++ b/drivers/stepper/Kconfig
@@ -24,10 +24,9 @@ config STEPPER_SHELL
 	help
 	  Enable stepper shell for testing.
 
-config STEP_DIR_STEPPER
-	bool
-	help
-	  Enable library used for step direction stepper drivers.
+comment "Stepper Driver Common"
+
+rsource "step_dir/Kconfig"
 
 comment "Stepper Drivers"
 

--- a/drivers/stepper/Kconfig.stepper_event_template
+++ b/drivers/stepper/Kconfig.stepper_event_template
@@ -1,0 +1,18 @@
+# Copyright (c) 2024 Fabian Blatz <fabianblatz@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+config STEPPER_$(module)_GENERATE_ISR_SAFE_EVENTS
+	bool "$(module-str) guarantee non ISR callbacks upon stepper events"
+	help
+	  Enable the dispatch of stepper generated events via
+	  a message queue to guarantee that the event handler
+	  code is not run inside of an ISR. Can be disabled, but
+	  then registered stepper event callback must be ISR safe.
+
+config STEPPER_$(module)_EVENT_QUEUE_LEN
+	int "$(module-str) maximum number of pending stepper events"
+	default 4
+	depends on STEPPER_$(module)_GENERATE_ISR_SAFE_EVENTS
+	help
+	  The maximum number of stepper events that can be pending before new events
+	  are dropped.

--- a/drivers/stepper/adi_tmc/adi_tmc22xx_stepper_controller.c
+++ b/drivers/stepper/adi_tmc/adi_tmc22xx_stepper_controller.c
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "../step_dir_stepper_common.h"
+#include "../step_dir/step_dir_stepper_common.h"
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(tmc22xx, CONFIG_STEPPER_LOG_LEVEL);

--- a/drivers/stepper/step_dir/CMakeLists.txt
+++ b/drivers/stepper/step_dir/CMakeLists.txt
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 Fabian Blatz
+# SPDX-License-Identifier: Apache-2.0
+
+zephyr_library()
+
+zephyr_library_sources(step_dir_stepper_common.c)
+zephyr_library_sources(step_dir_stepper_work_timing.c)
+zephyr_library_sources_ifdef(CONFIG_STEP_DIR_STEPPER_COUNTER_TIMING step_dir_stepper_counter_timing.c)

--- a/drivers/stepper/step_dir/Kconfig
+++ b/drivers/stepper/step_dir/Kconfig
@@ -1,0 +1,22 @@
+# Copyright (c) 2024 Fabian Blatz <fabianblatz@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+config STEP_DIR_STEPPER
+	bool
+	help
+	  Enable library used for step direction stepper drivers.
+
+if STEP_DIR_STEPPER
+
+config STEP_DIR_STEPPER_COUNTER_TIMING
+	bool "Counter use for stepping"
+	select COUNTER
+	default y
+	help
+	  Enable usage of a counter device for accurate stepping.
+
+module = STEP_DIR
+module-str = step_dir
+rsource "../Kconfig.stepper_event_template"
+
+endif # STEP_DIR_STEPPER

--- a/drivers/stepper/step_dir/step_dir_stepper_counter_timing.c
+++ b/drivers/stepper/step_dir/step_dir_stepper_counter_timing.c
@@ -1,0 +1,120 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Fabian Blatz <fabianblatz@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/drivers/counter.h>
+#include "step_dir_stepper_common.h"
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_DECLARE(step_dir_stepper);
+
+static void step_counter_top_interrupt(const struct device *dev, void *user_data)
+{
+	ARG_UNUSED(dev);
+	struct step_dir_stepper_common_data *data = user_data;
+
+	stepper_handle_timing_signal(data->dev);
+}
+
+int step_counter_timing_source_update(const struct device *dev, const uint32_t velocity)
+{
+	const struct step_dir_stepper_common_config *config = dev->config;
+	struct step_dir_stepper_common_data *data = dev->data;
+	int ret;
+
+	if (velocity == 0) {
+		return -EINVAL;
+	}
+
+	data->counter_top_cfg.ticks =
+		DIV_ROUND_UP(counter_us_to_ticks(config->counter, USEC_PER_SEC), velocity);
+
+	/* Lock interrupts while modifying counter settings */
+	int key = irq_lock();
+
+	ret = counter_set_top_value(config->counter, &data->counter_top_cfg);
+
+	irq_unlock(key);
+
+	if (ret != 0) {
+		LOG_ERR("%s: Failed to set counter top value (error: %d)", dev->name, ret);
+		return ret;
+	}
+
+	return 0;
+}
+
+int step_counter_timing_source_start(const struct device *dev)
+{
+	const struct step_dir_stepper_common_config *config = dev->config;
+	struct step_dir_stepper_common_data *data = dev->data;
+	int ret;
+
+	ret = counter_start(config->counter);
+	if (ret < 0 && ret != -EALREADY) {
+		LOG_ERR("Failed to start counter: %d", ret);
+		return ret;
+	}
+
+	data->counter_running = true;
+
+	return 0;
+}
+
+int step_counter_timing_source_stop(const struct device *dev)
+{
+	const struct step_dir_stepper_common_config *config = dev->config;
+	struct step_dir_stepper_common_data *data = dev->data;
+	int ret;
+
+	ret = counter_stop(config->counter);
+	if (ret < 0 && ret != -EALREADY) {
+		LOG_ERR("Failed to stop counter: %d", ret);
+		return ret;
+	}
+
+	data->counter_running = false;
+
+	return 0;
+}
+
+bool step_counter_timing_source_needs_reschedule(const struct device *dev)
+{
+	ARG_UNUSED(dev);
+	return false;
+}
+
+bool step_counter_timing_source_is_running(const struct device *dev)
+{
+	struct step_dir_stepper_common_data *data = dev->data;
+
+	return data->counter_running;
+}
+
+int step_counter_timing_source_init(const struct device *dev)
+{
+	const struct step_dir_stepper_common_config *config = dev->config;
+	struct step_dir_stepper_common_data *data = dev->data;
+
+	if (!device_is_ready(config->counter)) {
+		LOG_ERR("Counter device is not ready");
+		return -ENODEV;
+	}
+
+	data->counter_top_cfg.callback = step_counter_top_interrupt;
+	data->counter_top_cfg.user_data = data;
+	data->counter_top_cfg.flags = 0;
+	data->counter_top_cfg.ticks = counter_us_to_ticks(config->counter, 1000000);
+
+	return 0;
+}
+
+const struct stepper_timing_source_api step_counter_timing_source_api = {
+	.init = step_counter_timing_source_init,
+	.update = step_counter_timing_source_update,
+	.start = step_counter_timing_source_start,
+	.needs_reschedule = step_counter_timing_source_needs_reschedule,
+	.stop = step_counter_timing_source_stop,
+	.is_running = step_counter_timing_source_is_running,
+};

--- a/drivers/stepper/step_dir/step_dir_stepper_timing_source.h
+++ b/drivers/stepper/step_dir/step_dir_stepper_timing_source.h
@@ -1,0 +1,78 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Fabian Blatz <fabianblatz@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_DRIVER_STEPPER_STEP_DIR_STEPPER_TIMING_SOURCE_H_
+#define ZEPHYR_DRIVER_STEPPER_STEP_DIR_STEPPER_TIMING_SOURCE_H_
+
+#include <zephyr/device.h>
+
+/**
+ * @brief Initialize the stepper timing source.
+ *
+ * @param dev Pointer to the device structure.
+ * @return 0 on success, or a negative error code on failure.
+ */
+typedef int (*stepper_timing_source_init)(const struct device *dev);
+
+/**
+ * @brief Update the stepper timing source.
+ *
+ * @param dev Pointer to the device structure.
+ * @param velocity Velocity in microsteps per second.
+ * @return 0 on success, or a negative error code on failure.
+ */
+typedef int (*stepper_timing_source_update)(const struct device *dev, uint32_t velocity);
+
+/**
+ * @brief Start the stepper timing source.
+ *
+ * @param dev Pointer to the device structure.
+ * @return 0 on success, or a negative error code on failure.
+ */
+typedef int (*stepper_timing_source_start)(const struct device *dev);
+
+/**
+ * @brief Whether the stepper timing source requires rescheduling (keeps running
+ *        after the initial start).
+ *
+ * @param dev Pointer to the device structure.
+ * @return true if the timing source requires rescheduling, false otherwise.
+ */
+typedef bool (*stepper_timing_sources_requires_reschedule)(const struct device *dev);
+
+/**
+ * @brief Stop the stepper timing source.
+ *
+ * @param dev Pointer to the device structure.
+ * @return 0 on success, or a negative error code on failure.
+ */
+typedef int (*stepper_timing_source_stop)(const struct device *dev);
+
+/**
+ * @brief Check if the stepper timing source is running.
+ *
+ * @param dev Pointer to the device structure.
+ * @return true if the timing source is running, false otherwise.
+ */
+typedef bool (*stepper_timing_source_is_running)(const struct device *dev);
+
+/**
+ * @brief Stepper timing source API.
+ */
+struct stepper_timing_source_api {
+	stepper_timing_source_init init;
+	stepper_timing_source_update update;
+	stepper_timing_source_start start;
+	stepper_timing_sources_requires_reschedule needs_reschedule;
+	stepper_timing_source_stop stop;
+	stepper_timing_source_is_running is_running;
+};
+
+extern const struct stepper_timing_source_api step_work_timing_source_api;
+#ifdef CONFIG_STEP_DIR_STEPPER_COUNTER_TIMING
+extern const struct stepper_timing_source_api step_counter_timing_source_api;
+#endif /* CONFIG_STEP_DIR_STEPPER_COUNTER_TIMING */
+
+#endif /* ZEPHYR_DRIVER_STEPPER_STEP_DIR_STEPPER_TIMING_SOURCE_H_ */

--- a/drivers/stepper/step_dir/step_dir_stepper_work_timing.c
+++ b/drivers/stepper/step_dir/step_dir_stepper_work_timing.c
@@ -1,0 +1,79 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Fabian Blatz <fabianblatz@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "step_dir_stepper_timing_source.h"
+#include "step_dir_stepper_common.h"
+
+static k_timeout_t stepper_movement_delay(const struct device *dev)
+{
+	const struct step_dir_stepper_common_data *data = dev->data;
+
+	if (data->max_velocity == 0) {
+		return K_FOREVER;
+	}
+
+	return K_USEC(USEC_PER_SEC / data->max_velocity);
+}
+
+static void stepper_work_step_handler(struct k_work *work)
+{
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
+	struct step_dir_stepper_common_data *data =
+		CONTAINER_OF(dwork, struct step_dir_stepper_common_data, stepper_dwork);
+
+	stepper_handle_timing_signal(data->dev);
+}
+
+int step_work_timing_source_init(const struct device *dev)
+{
+	struct step_dir_stepper_common_data *data = dev->data;
+
+	k_work_init_delayable(&data->stepper_dwork, stepper_work_step_handler);
+
+	return 0;
+}
+
+int step_work_timing_source_update(const struct device *dev, const uint32_t velocity)
+{
+	ARG_UNUSED(dev);
+	ARG_UNUSED(velocity);
+	return 0;
+}
+
+int step_work_timing_source_start(const struct device *dev)
+{
+	struct step_dir_stepper_common_data *data = dev->data;
+
+	return k_work_reschedule(&data->stepper_dwork, stepper_movement_delay(dev));
+}
+
+int step_work_timing_source_stop(const struct device *dev)
+{
+	struct step_dir_stepper_common_data *data = dev->data;
+
+	return k_work_cancel_delayable(&data->stepper_dwork);
+}
+
+bool step_work_timing_source_needs_reschedule(const struct device *dev)
+{
+	ARG_UNUSED(dev);
+	return true;
+}
+
+bool step_work_timing_source_is_running(const struct device *dev)
+{
+	struct step_dir_stepper_common_data *data = dev->data;
+
+	return k_work_delayable_is_pending(&data->stepper_dwork);
+}
+
+const struct stepper_timing_source_api step_work_timing_source_api = {
+	.init = step_work_timing_source_init,
+	.update = step_work_timing_source_update,
+	.start = step_work_timing_source_start,
+	.needs_reschedule = step_work_timing_source_needs_reschedule,
+	.stop = step_work_timing_source_stop,
+	.is_running = step_work_timing_source_is_running,
+};

--- a/dts/bindings/stepper/adi/adi,tmc2209.yaml
+++ b/dts/bindings/stepper/adi/adi,tmc2209.yaml
@@ -24,6 +24,7 @@ include:
       - step-gpios
       - dir-gpios
       - en-gpios
+      - counter
 
 properties:
   msx-gpios:

--- a/dts/bindings/stepper/stepper-controller.yaml
+++ b/dts/bindings/stepper/stepper-controller.yaml
@@ -40,3 +40,7 @@ properties:
     description: |
       The GPIO pins used to send direction signals to the stepper motor.
       Pin will be driven high for forward direction and low for reverse direction.
+
+  counter:
+    type: phandle
+    description: Counter used for generating step-accurate pulse signals.

--- a/tests/drivers/build_all/stepper/gpio.dtsi
+++ b/tests/drivers/build_all/stepper/gpio.dtsi
@@ -22,6 +22,7 @@ test_tmc2209: tmc2209_motor {
 	en-gpios = <&test_gpio 0 0>;
 	step-gpios = <&test_gpio 0 0>;
 	dir-gpios = <&test_gpio 0 0>;
+	counter = <&counter0>;
 };
 
 drv8424: drv8424 {


### PR DESCRIPTION
Adds a timing source API for the common step dir stepper code. This can also be used to simplify the ti drv8424 driver.