### PR TITLE
kernel/swap: remove redundant ARG_UNUSED from do_swap()

### DIFF
--- a/kernel/include/kswap.h
+++ b/kernel/include/kswap.h
@@ -78,7 +78,6 @@ static ALWAYS_INLINE unsigned int do_swap(unsigned int key,
 					  struct k_spinlock *lock,
 					  bool is_spinlock)
 {
-	ARG_UNUSED(lock);
 	struct k_thread *new_thread, *old_thread;
 
 #ifdef CONFIG_SPIN_VALIDATE


### PR DESCRIPTION
The `lock` arg is used multiple times in the function, making the `ARG_UNUSED(lock);` redundant, remove it.