### PR TITLE
lib: os: mpsc_pbuf: do not wait when spinlock is held

### DIFF
--- a/lib/os/mpsc_pbuf.c
+++ b/lib/os/mpsc_pbuf.c
@@ -373,7 +373,7 @@ union mpsc_pbuf_generic *mpsc_pbuf_alloc(struct mpsc_pbuf_buffer *buffer,
 			add_skip_item(buffer, free_wlen);
 			cont = true;
 		} else if (IS_ENABLED(CONFIG_MULTITHREADING) && !K_TIMEOUT_EQ(timeout, K_NO_WAIT) &&
-			   !k_is_in_isr()) {
+			   !k_is_in_isr() && arch_irq_unlocked(key.key)) {
 			int err;
 
 			k_spin_unlock(&buffer->lock, key);


### PR DESCRIPTION
Check if the spinlock is held before attempting to wait by
taking the semaphore, as that would cause a context switch which
isn't allowed and will trigger an assertion error when
`CONFIG_SPIN_VALIDATE` is enabled.

Logging in spinlock-held context when the log buffer is full can lead
to an infinite assertion error loop, as the logging subsys attempts to
allocate buffer when there's none available, it will try to wait for
one and thus triggers the assertion error, the error message will be
printed through the logging sybsys but there's no buffer available,
so it will try to wait for one and triggers another assertion error..
This loop just goes on and on forever, and nothing gets printed to
the terminal.

Added a test to validate the fix.

___

### Without the fix

```
$ west build -b qemu_riscv64 -p auto -t run zephyr/tests/lib/mpsc_pbuf -- -DCONFIG_SYMTAB=y
*** Booting Zephyr OS build v4.0.0-2697-gad71b19ecf51 ***
Running TESTSUITE log_buffer
===================================================================
START - test_alloc_in_spinlock
ASSERTION FAIL [arch_irq_unlocked(key) || arch_current_thread()->base.thread_state & (((1UL << (0))) | ((1UL << (3))))] @ WEST_TOPDIR/ze9
        Context switching while holding lock!
E: 
E:  mcause: 11, Environment call from M-mode
E:   mtval: 0
E:      a0: 0000000000000004    t0: 0000000000000000
E:      a1: 0000000000000063    t1: 000000000000004c
E:      a2: 000000008001a018    t2: 0000000000000044
E:      a3: 0000000080017380    t3: 000000000000002a
E:      a4: 0000000000000000    t4: 000000000000002e
E:      a5: 0000000080017fd0    t5: 000000000000007f
E:      a6: 0000000000000009    t6: 0000000000000010
E:      a7: 0000000000000009
E:      sp: 000000008001a050
E:      ra: 00000000800080a6
E:    mepc: 0000000080003b6a
E: mstatus: 0000000a00021800
E: 
E:      s0: 00000000800160b0    s6: 0000000000000000
E:      s1: 0000000080017fd0    s7: 000000008001a148
E:      s2: 0000000000000000    s8: 0000000000000020
E:      s3: 0000000080017380    s9: 0000000000020080
E:      s4: 0000000000000020   s10: 0000000000000000
E:      s5: 0000000000000001   s11: 0000000000000000
E: 
E: call trace:
E:       0: sp: 000000008001a050 ra: 0000000080003b6a [assert_post_action+0x8]
E:       1: sp: 000000008001a080 ra: 000000008000418c [mpsc_pbuf_alloc+0x18e]
E:       2: sp: 000000008001a100 ra: 0000000080001234 [_log_buffer_test_alloc_in_spinlock_wrapper+0xa8]
E:       3: sp: 000000008001a130 ra: 0000000080001744 [drop+0x0]
E:       4: sp: 000000008001a138 ra: 0000000080000c2e [get_wlen+0x0]
E:       5: sp: 000000008001a170 ra: 0000000080005596 [test_cb+0x46]
E:       6: sp: 000000008001a190 ra: 0000000080005550 [test_cb+0x0]
E:       7: sp: 000000008001a1a0 ra: 0000000080003b5a [z_thread_entry+0x22]
E: 
E: >>> ZEPHYR FATAL ERROR 4: Kernel panic on CPU 0
E: Current thread: 0x80017380 (test_alloc_in_spinlock)
E: Halting system
```