### PR TITLE
doc: release-notes 4.1: Adding Adafruit QT Py ESP32-S3

### DIFF
--- a/doc/releases/release-notes-4.1.rst
+++ b/doc/releases/release-notes-4.1.rst
@@ -111,6 +111,7 @@ Boards & SoC Support
 * Added support for these boards:
 
    * :zephyr:board:`Raspberry Pi Pico 2 <rpi_pico2>`: ``rpi_pico2``
+   * :zephyr:board:`Adafruit QT Py ESP32-S3 <adafruit_qt_py_esp32s3>`: ``adafruit_qt_py_esp32s3``
 
 * Made these board changes:
 


### PR DESCRIPTION
Updating release notes to include the recently added Adafruit QT Py ESP32-S3 both with and without its PSRAM version.