### PR TITLE
dts: bindings: serial: pl011: Make included `reset-device.yaml`

### DIFF
--- a/dts/bindings/serial/arm,pl011.yaml
+++ b/dts/bindings/serial/arm,pl011.yaml
@@ -2,7 +2,7 @@ description: ARM PL011 UART
 
 compatible: "arm,pl011"
 
-include: [uart-controller.yaml, pinctrl-device.yaml]
+include: [uart-controller.yaml, pinctrl-device.yaml, reset-device.yaml]
 
 properties:
   reg:

--- a/dts/bindings/serial/raspberrypi,pico-uart.yaml
+++ b/dts/bindings/serial/raspberrypi,pico-uart.yaml
@@ -2,11 +2,4 @@ description: Raspberry Pi Pico UART
 
 compatible: "raspberrypi,pico-uart"
 
-include: [uart-controller.yaml, pinctrl-device.yaml, reset-device.yaml]
-
-properties:
-  reg:
-    required: true
-
-  interrupts:
-    required: true
+include: "arm,pl011.yaml"


### PR DESCRIPTION
The PL011 driver has already implemented supporting reset device
behavior.
However, the support is incomplete because the `arm,pl011.yaml`,
does not contain a `reset-device.yaml`.

Add include directive to `arm,pl011.yaml` to including
`reset-device.yaml` to complete the support for reset device.