### PR TITLE
dts: bindings: i2c: dw: Make included `reset-device.yaml`

### DIFF
--- a/dts/bindings/i2c/raspberrypi,pico-i2c.yaml
+++ b/dts/bindings/i2c/raspberrypi,pico-i2c.yaml
@@ -2,4 +2,4 @@ description: Raspberry Pi Pico I2C
 
 compatible: "raspberrypi,pico-i2c"
 
-include: ["snps,designware-i2c.yaml", "reset-device.yaml"]
+include: "snps,designware-i2c.yaml"

--- a/dts/bindings/i2c/snps,designware-i2c.yaml
+++ b/dts/bindings/i2c/snps,designware-i2c.yaml
@@ -5,7 +5,7 @@ description: Synopsys DesignWare I2C node
 
 compatible: "snps,designware-i2c"
 
-include: [i2c-controller.yaml, pinctrl-device.yaml, pcie-device.yaml]
+include: [i2c-controller.yaml, pinctrl-device.yaml, pcie-device.yaml, reset-device.yaml]
 
 properties:
   interrupts:


### PR DESCRIPTION
The DesignWare I2C driver has already implemented supporting reset device
behavior.
However, the support is incomplete because the `snps,designware-i2c.yaml`,
does not contain a `reset-device.yaml`.

Add include directive to `snps,designware-i2c.yaml` to including
`reset-device.yaml` to complete the support for reset device.