### PR TITLE
drivers: spi: pl022: Enable PINCTRL conjuction with dt prop 'pinctrl-0'

### DIFF
--- a/drivers/spi/Kconfig.pl022
+++ b/drivers/spi/Kconfig.pl022
@@ -4,7 +4,7 @@
 config SPI_PL022
 	default y
 	depends on DT_HAS_ARM_PL022_ENABLED
-	select PINCTRL if DT_HAS_RASPBERRYPI_PICO_SPI_ENABLED
+	select PINCTRL if $(dt_compat_any_has_prop,$(DT_COMPAT_ARM_PL022),pinctrl-0)
 	bool "ARM PL022 SPI driver"
 
 if SPI_PL022


### PR DESCRIPTION
If there is a pinctrl-0 property, PINCTRL will be enabled in conjunction with it.