### PR TITLE
scripts: checkpatch.pl: Add exception to SPACING rule for macros

### DIFF
--- a/scripts/checkpatch.pl
+++ b/scripts/checkpatch.pl
@@ -4870,8 +4870,11 @@ sub process {
 				    s/\(\s+/\(/;
 			}
 		}
+		# exception: COND_CODE_1(DT_INST_PROP_OR(n, io_mapped, 0), (.port = DT_INST_REG_ADDR(n), ),
+		#                                                              clang-format do this way ^
 		if ($line =~ /(\s+)\)/ && $line !~ /^.\s*\)/ &&
 		    $line !~ /for\s*\(.*;\s+\)/ &&
+		    $line !~ /,\s\)/ &&
 		    $line !~ /:\s+\)/) {
 			if (ERROR("SPACING",
 				  "space prohibited before that close parenthesis ')'\n" . $herecurr) &&


### PR DESCRIPTION
The checkpatch rules have conflict with clang-format rules. The change includes the ecample that triggered the need for this change.