### PR TITLE
Feature/optimize a2dp avdtp

### DIFF
--- a/include/zephyr/bluetooth/classic/a2dp.h
+++ b/include/zephyr/bluetooth/classic/a2dp.h
@@ -341,7 +341,7 @@ struct bt_a2dp_ep_info {
 	/** Codec capabilities, if SBC, use function of a2dp_codec_sbc.h to parse it */
 	struct bt_a2dp_codec_ie codec_cap;
 	/** Stream End Point Information */
-	struct bt_avdtp_sep_info sep_info;
+	struct bt_avdtp_sep_info *sep_info;
 };
 
 /** @brief Helper enum to be used as return value of bt_a2dp_discover_ep_cb.

--- a/subsys/bluetooth/host/classic/a2dp.c
+++ b/subsys/bluetooth/host/classic/a2dp.c
@@ -497,6 +497,8 @@ static int bt_a2dp_get_sep_caps(struct bt_a2dp *a2dp)
 	for (; a2dp->get_cap_index < a2dp->peer_seps_count; a2dp->get_cap_index++) {
 		if (a2dp->discover_cb_param->seps_info[a2dp->get_cap_index].media_type ==
 		    BT_AVDTP_AUDIO) {
+			memset(&a2dp->get_capabilities_param, 0U,
+			       sizeof(a2dp->get_capabilities_param));
 			a2dp->get_capabilities_param.req.func = bt_a2dp_get_capabilities_cb;
 			a2dp->get_capabilities_param.buf = NULL;
 			a2dp->get_capabilities_param.stream_endpoint_id =
@@ -580,6 +582,7 @@ int bt_a2dp_discover(struct bt_a2dp *a2dp, struct bt_a2dp_discover_param *param)
 		return -EBUSY;
 	}
 
+	memset(&a2dp->discover_cb_param, 0U, sizeof(a2dp->discover_cb_param));
 	a2dp->discover_cb_param = param;
 	a2dp->discover_param.req.func = bt_a2dp_discover_cb;
 	a2dp->discover_param.buf = NULL;
@@ -606,6 +609,7 @@ static inline void bt_a2dp_stream_config_set_param(struct bt_a2dp *a2dp,
 						   uint8_t int_id, uint8_t codec_type,
 						   struct bt_avdtp_sep *sep)
 {
+	memset(&a2dp->set_config_param, 0U, sizeof(a2dp->set_config_param));
 	a2dp->set_config_param.req.func = cb;
 	a2dp->set_config_param.acp_stream_ep_id = remote_id;
 	a2dp->set_config_param.int_stream_endpoint_id = int_id;
@@ -733,6 +737,7 @@ static int bt_a2dp_stream_ctrl_pre(struct bt_a2dp_stream *stream, bt_avdtp_func_
 	}
 
 	a2dp = stream->a2dp;
+	memset(&a2dp->ctrl_param, 0U, sizeof(a2dp->ctrl_param));
 	a2dp->ctrl_param.req.func = cb;
 	a2dp->ctrl_param.acp_stream_ep_id = stream->remote_ep != NULL
 						    ? stream->remote_ep->sep.sep_info.id

--- a/subsys/bluetooth/host/classic/a2dp.c
+++ b/subsys/bluetooth/host/classic/a2dp.c
@@ -456,13 +456,13 @@ static int bt_a2dp_get_capabilities_cb(struct bt_avdtp_req *req)
 		struct bt_a2dp_ep_info *info = &a2dp->discover_cb_param->info;
 
 		info->codec_type = codec_type;
-		info->sep_info = a2dp->discover_cb_param->seps_info[a2dp->get_cap_index];
+		info->sep_info = &a2dp->discover_cb_param->seps_info[a2dp->get_cap_index];
 		memcpy(&info->codec_cap.codec_ie, codec_info_element, codec_info_element_len);
 		info->codec_cap.len = codec_info_element_len;
 		user_ret = a2dp->discover_cb_param->cb(a2dp, info, &ep);
 		if (ep != NULL) {
 			ep->codec_type = info->codec_type;
-			ep->sep.sep_info = info->sep_info;
+			ep->sep.sep_info = *info->sep_info;
 			*ep->codec_cap = info->codec_cap;
 			ep->stream = NULL;
 		}

--- a/subsys/bluetooth/host/classic/a2dp.c
+++ b/subsys/bluetooth/host/classic/a2dp.c
@@ -505,7 +505,6 @@ static int bt_a2dp_get_sep_caps(struct bt_a2dp *a2dp)
 			memset(&a2dp->get_capabilities_param, 0U,
 			       sizeof(a2dp->get_capabilities_param));
 			a2dp->get_capabilities_param.req.func = bt_a2dp_get_capabilities_cb;
-			a2dp->get_capabilities_param.buf = NULL;
 			a2dp->get_capabilities_param.stream_endpoint_id =
 				a2dp->discover_cb_param->seps_info[a2dp->get_cap_index].id;
 			err = bt_avdtp_get_capabilities(&a2dp->session,
@@ -597,7 +596,6 @@ int bt_a2dp_discover(struct bt_a2dp *a2dp, struct bt_a2dp_discover_param *param)
 	memset(&a2dp->discover_cb_param, 0U, sizeof(a2dp->discover_cb_param));
 	a2dp->discover_cb_param = param;
 	a2dp->discover_param.req.func = bt_a2dp_discover_cb;
-	a2dp->discover_param.buf = NULL;
 
 	err = bt_avdtp_discover(&a2dp->session, &a2dp->discover_param);
 	if (err) {

--- a/subsys/bluetooth/host/classic/a2dp.c
+++ b/subsys/bluetooth/host/classic/a2dp.c
@@ -392,7 +392,7 @@ static int a2dp_abort_ind(struct bt_avdtp *session, struct bt_avdtp_sep *sep, ui
 	return a2dp_ctrl_ind(session, sep, errcode, req_cb, done_cb, true);
 }
 
-static int bt_a2dp_set_config_cb(struct bt_avdtp_req *req)
+static int bt_a2dp_set_config_cb(struct bt_avdtp_req *req, struct net_buf *buf)
 {
 	struct bt_a2dp *a2dp = SET_CONF_PARAM(SET_CONF_REQ(req));
 	struct bt_a2dp_ep *ep;
@@ -422,7 +422,7 @@ static int bt_a2dp_set_config_cb(struct bt_avdtp_req *req)
 	return 0;
 }
 
-static int bt_a2dp_get_capabilities_cb(struct bt_avdtp_req *req)
+static int bt_a2dp_get_capabilities_cb(struct bt_avdtp_req *req, struct net_buf *buf)
 {
 	int err;
 	uint8_t *codec_info_element;
@@ -431,7 +431,7 @@ static int bt_a2dp_get_capabilities_cb(struct bt_avdtp_req *req)
 	uint8_t codec_type;
 	uint8_t user_ret;
 
-	if (GET_CAP_REQ(req) != &a2dp->get_capabilities_param) {
+	if (GET_CAP_REQ(req) != &a2dp->get_capabilities_param || buf == NULL) {
 		return -EINVAL;
 	}
 
@@ -444,7 +444,7 @@ static int bt_a2dp_get_capabilities_cb(struct bt_avdtp_req *req)
 		return 0;
 	}
 
-	err = bt_avdtp_parse_capability_codec(a2dp->get_capabilities_param.buf, &codec_type,
+	err = bt_avdtp_parse_capability_codec(buf, &codec_type,
 					      &codec_info_element, &codec_info_element_len);
 	if (err) {
 		LOG_DBG("codec capability parsing fail");
@@ -522,14 +522,14 @@ static int bt_a2dp_get_sep_caps(struct bt_a2dp *a2dp)
 	return -EINVAL;
 }
 
-static int bt_a2dp_discover_cb(struct bt_avdtp_req *req)
+static int bt_a2dp_discover_cb(struct bt_avdtp_req *req, struct net_buf *buf)
 {
 	struct bt_a2dp *a2dp = DISCOVER_PARAM(DISCOVER_REQ(req));
 	struct bt_avdtp_sep_info *sep_info;
 	int err;
 
 	LOG_DBG("DISCOVER result:%d", req->status);
-	if (a2dp->discover_cb_param == NULL) {
+	if (a2dp->discover_cb_param == NULL || buf == NULL) {
 		return -EINVAL;
 	}
 
@@ -547,7 +547,7 @@ static int bt_a2dp_discover_cb(struct bt_avdtp_req *req)
 
 		do {
 			sep_info = &a2dp->discover_cb_param->seps_info[a2dp->peer_seps_count];
-			err = bt_avdtp_parse_sep(DISCOVER_REQ(req)->buf, sep_info);
+			err = bt_avdtp_parse_sep(buf, sep_info);
 
 			if (err) {
 				break;
@@ -692,7 +692,7 @@ static int bt_a2dp_ctrl_cb(struct bt_avdtp_req *req, bt_a2dp_rsp_cb rsp_cb, bt_a
 	return 0;
 }
 
-static int bt_a2dp_open_cb(struct bt_avdtp_req *req)
+static int bt_a2dp_open_cb(struct bt_avdtp_req *req, struct net_buf *buf)
 {
 	struct bt_a2dp_ep *ep = CONTAINER_OF(CTRL_REQ(req)->sep, struct bt_a2dp_ep, sep);
 	bt_a2dp_rsp_cb rsp_cb = a2dp_cb != NULL ? a2dp_cb->establish_rsp : NULL;
@@ -703,7 +703,7 @@ static int bt_a2dp_open_cb(struct bt_avdtp_req *req)
 	return bt_a2dp_ctrl_cb(req, rsp_cb, done_cb, false);
 }
 
-static int bt_a2dp_start_cb(struct bt_avdtp_req *req)
+static int bt_a2dp_start_cb(struct bt_avdtp_req *req, struct net_buf *buf)
 {
 	struct bt_a2dp_ep *ep = CONTAINER_OF(CTRL_REQ(req)->sep, struct bt_a2dp_ep, sep);
 	bt_a2dp_rsp_cb rsp_cb = a2dp_cb != NULL ? a2dp_cb->start_rsp : NULL;
@@ -713,7 +713,7 @@ static int bt_a2dp_start_cb(struct bt_avdtp_req *req)
 	return bt_a2dp_ctrl_cb(req, rsp_cb, done_cb, false);
 }
 
-static int bt_a2dp_suspend_cb(struct bt_avdtp_req *req)
+static int bt_a2dp_suspend_cb(struct bt_avdtp_req *req, struct net_buf *buf)
 {
 	struct bt_a2dp_ep *ep = CONTAINER_OF(CTRL_REQ(req)->sep, struct bt_a2dp_ep, sep);
 	bt_a2dp_rsp_cb rsp_cb = a2dp_cb != NULL ? a2dp_cb->suspend_rsp : NULL;
@@ -723,7 +723,7 @@ static int bt_a2dp_suspend_cb(struct bt_avdtp_req *req)
 	return bt_a2dp_ctrl_cb(req, rsp_cb, done_cb, false);
 }
 
-static int bt_a2dp_close_cb(struct bt_avdtp_req *req)
+static int bt_a2dp_close_cb(struct bt_avdtp_req *req, struct net_buf *buf)
 {
 	struct bt_a2dp_ep *ep = CONTAINER_OF(CTRL_REQ(req)->sep, struct bt_a2dp_ep, sep);
 	bt_a2dp_rsp_cb rsp_cb = a2dp_cb != NULL ? a2dp_cb->release_rsp : NULL;
@@ -733,7 +733,7 @@ static int bt_a2dp_close_cb(struct bt_avdtp_req *req)
 	return bt_a2dp_ctrl_cb(req, rsp_cb, done_cb, true);
 }
 
-static int bt_a2dp_abort_cb(struct bt_avdtp_req *req)
+static int bt_a2dp_abort_cb(struct bt_avdtp_req *req, struct net_buf *buf)
 {
 	struct bt_a2dp_ep *ep = CONTAINER_OF(CTRL_REQ(req)->sep, struct bt_a2dp_ep, sep);
 	bt_a2dp_rsp_cb rsp_cb = a2dp_cb != NULL ? a2dp_cb->abort_rsp : NULL;

--- a/subsys/bluetooth/host/classic/avdtp.c
+++ b/subsys/bluetooth/host/classic/avdtp.c
@@ -640,7 +640,7 @@ static void avdtp_open_rsp(struct bt_avdtp *session, struct net_buf *buf, uint8_
 	k_work_cancel_delayable(&session->timeout_work);
 	avdtp_set_status(req, buf, msg_type);
 
-	if (msg_type == BT_AVDTP_ACCEPT && req->status == BT_AVDTP_SUCCESS) {
+	if (req->status == BT_AVDTP_SUCCESS) {
 		bt_avdtp_set_state_lock(CTRL_REQ(req)->sep, AVDTP_OPENING);
 
 		/* wait the media l2cap is established */
@@ -815,7 +815,7 @@ static void avdtp_close_rsp(struct bt_avdtp *session, struct net_buf *buf, uint8
 	k_work_cancel_delayable(&session->timeout_work);
 	avdtp_set_status(req, buf, msg_type);
 
-	if (msg_type == BT_AVDTP_ACCEPT && req->status == BT_AVDTP_SUCCESS) {
+	if (req->status == BT_AVDTP_SUCCESS) {
 		bt_avdtp_set_state_lock(CTRL_REQ(req)->sep, AVDTP_CLOSING);
 
 		if (!avdtp_media_disconnect(CTRL_REQ(req)->sep)) {

--- a/subsys/bluetooth/host/classic/avdtp.c
+++ b/subsys/bluetooth/host/classic/avdtp.c
@@ -141,7 +141,7 @@ void bt_avdtp_media_l2cap_connected(struct bt_l2cap_chan *chan)
 		bt_avdtp_clear_req(session);
 
 		if (req->func != NULL) {
-			req->func(req);
+			req->func(req, NULL);
 		}
 	}
 }
@@ -171,7 +171,7 @@ void bt_avdtp_media_l2cap_disconnected(struct bt_l2cap_chan *chan)
 		bt_avdtp_clear_req(session);
 
 		if (req->func != NULL) {
-			req->func(req);
+			req->func(req, NULL);
 		}
 	} else if (sep->state > AVDTP_OPENING) {
 		bt_avdtp_set_state(sep, AVDTP_IDLE);
@@ -321,18 +321,11 @@ static void avdtp_discover_rsp(struct bt_avdtp *session, struct net_buf *buf, ui
 	}
 
 	k_work_cancel_delayable(&session->timeout_work);
-
-	if (msg_type == BT_AVDTP_ACCEPT) {
-		DISCOVER_REQ(req)->buf = buf;
-	} else {
-		DISCOVER_REQ(req)->buf = NULL;
-	}
-
 	avdtp_set_status(req, buf, msg_type);
 	bt_avdtp_clear_req(session);
 
 	if (req->func != NULL) {
-		req->func(req);
+		req->func(req, buf);
 	}
 }
 
@@ -420,17 +413,11 @@ static void avdtp_get_capabilities_rsp(struct bt_avdtp *session, struct net_buf 
 	}
 
 	k_work_cancel_delayable(&session->timeout_work);
-	GET_CAP_REQ(session->req)->buf = NULL;
-
-	if (msg_type == BT_AVDTP_ACCEPT) {
-		GET_CAP_REQ(req)->buf = buf;
-	}
-
 	avdtp_set_status(req, buf, msg_type);
 	bt_avdtp_clear_req(session);
 
 	if (req->func != NULL) {
-		req->func(req);
+		req->func(req, buf);
 	}
 }
 
@@ -551,7 +538,7 @@ static void avdtp_process_configuration_rsp(struct bt_avdtp *session, struct net
 	bt_avdtp_clear_req(session);
 
 	if (req->func != NULL) {
-		req->func(req);
+		req->func(req, NULL);
 	}
 }
 
@@ -653,7 +640,7 @@ static void avdtp_open_rsp(struct bt_avdtp *session, struct net_buf *buf, uint8_
 		bt_avdtp_clear_req(session);
 
 		if (req->func != NULL) {
-			req->func(req);
+			req->func(req, NULL);
 		}
 	}
 }
@@ -747,7 +734,7 @@ static void avdtp_start_rsp(struct bt_avdtp *session, struct net_buf *buf, uint8
 	bt_avdtp_clear_req(session);
 
 	if (req->func != NULL) {
-		req->func(req);
+		req->func(req, NULL);
 	}
 }
 
@@ -826,7 +813,7 @@ static void avdtp_close_rsp(struct bt_avdtp *session, struct net_buf *buf, uint8
 	bt_avdtp_clear_req(session);
 
 	if (req->func != NULL) {
-		req->func(req);
+		req->func(req, NULL);
 	}
 }
 
@@ -904,7 +891,7 @@ static void avdtp_suspend_rsp(struct bt_avdtp *session, struct net_buf *buf, uin
 	bt_avdtp_clear_req(session);
 
 	if (req->func != NULL) {
-		req->func(req);
+		req->func(req, NULL);
 	}
 }
 
@@ -995,7 +982,7 @@ static void avdtp_abort_rsp(struct bt_avdtp *session, struct net_buf *buf, uint8
 	bt_avdtp_clear_req(session);
 
 	if (req->func != NULL) {
-		req->func(req);
+		req->func(req, NULL);
 	}
 }
 
@@ -1019,7 +1006,7 @@ static void avdtp_timeout(struct k_work *work)
 		case BT_AVDTP_START:
 		case BT_AVDTP_SUSPEND:
 			req->status = BT_AVDTP_TIME_OUT;
-			req->func(req);
+			req->func(req, NULL);
 			break;
 		default:
 			break;
@@ -1116,7 +1103,7 @@ void bt_avdtp_l2cap_disconnected(struct bt_l2cap_chan *chan)
 		bt_avdtp_clear_req(session);
 
 		if (req->func != NULL) {
-			req->func(req);
+			req->func(req, NULL);
 		}
 	}
 

--- a/subsys/bluetooth/host/classic/avdtp_internal.h
+++ b/subsys/bluetooth/host/classic/avdtp_internal.h
@@ -111,7 +111,7 @@ struct bt_avdtp_sep_data {
 #endif
 } __packed;
 
-typedef int (*bt_avdtp_func_t)(struct bt_avdtp_req *req);
+typedef int (*bt_avdtp_func_t)(struct bt_avdtp_req *req, struct net_buf *buf);
 
 struct bt_avdtp_req {
 	uint8_t sig;
@@ -148,13 +148,11 @@ struct bt_avdtp_media_hdr {
 
 struct bt_avdtp_discover_params {
 	struct bt_avdtp_req req;
-	struct net_buf *buf;
 };
 
 struct bt_avdtp_get_capabilities_params {
 	struct bt_avdtp_req req;
 	uint8_t stream_endpoint_id;
-	struct net_buf *buf;
 };
 
 struct bt_avdtp_set_configuration_params {

--- a/subsys/bluetooth/host/classic/shell/a2dp.c
+++ b/subsys/bluetooth/host/classic/shell/a2dp.c
@@ -208,9 +208,9 @@ static void shell_a2dp_print_capabilities(struct bt_a2dp_ep_info *ep_info)
 	codec_type = ep_info->codec_type;
 	codec_ie = ep_info->codec_cap.codec_ie;
 	codec_ie_len = ep_info->codec_cap.len;
-	bt_shell_print("endpoint id: %d, %s, %s:", ep_info->sep_info.id,
-		       (ep_info->sep_info.tsep == BT_AVDTP_SINK) ? "(sink)" : "(source)",
-		       (ep_info->sep_info.inuse) ? "(in use)" : "(idle)");
+	bt_shell_print("endpoint id: %d, %s, %s:", ep_info->sep_info->id,
+		       (ep_info->sep_info->tsep == BT_AVDTP_SINK) ? "(sink)" : "(source)",
+		       (ep_info->sep_info->inuse) ? "(in use)" : "(idle)");
 	if (BT_A2DP_SBC == codec_type) {
 		bt_shell_print("  codec type: SBC");
 


### PR DESCRIPTION
- When the cmd packet is invalid (buf->len is not enough), reply with reject.
- Split the packet handler to cmd_handler and rsp_handler, and optimize the handler array to be function pointer array.
- If receiving the unsupported cmd (signal identifier), send reject or discard it.
- Optimize `bt_a2dp_ep_info`'s field `struct bt_avdtp_sep_info sep_info` as `struct bt_avdtp_sep_info *sep_info`, see the explain in the commit.