### PR TITLE
arch: nios2: timing: Fix timing cycles rollover

### DIFF
--- a/arch/nios2/core/timing.c
+++ b/arch/nios2/core/timing.c
@@ -41,7 +41,13 @@ timing_t arch_timing_counter_get(void)
 uint64_t arch_timing_cycles_get(volatile timing_t *const start,
 				volatile timing_t *const end)
 {
-	return (*end - *start);
+	timing_t start_ = *start;
+	timing_t end_ = *end;
+
+	if (end_ >= start_) {
+		return (end_ - start_);
+	}
+	return (end_ + NIOS2_SUBTRACT_CLOCK_CYCLES(start_));
 }
 
 uint64_t arch_timing_freq_get(void)


### PR DESCRIPTION
Fix arch_timing_cycles_get() to prevent overflow on the clock rollover.

The issue is observable on tests/benchmarks/wait_queues and tests/benchmarks/sched_queues with BENCHMARK_NUM_ITERATIONS value large enough, e.g. default 1000.

Fixes #83377 