### PR TITLE
boards: st: fix partition size for nucleo_l452re

### DIFF
--- a/boards/st/nucleo_l452re/nucleo_l452re_common.dtsi
+++ b/boards/st/nucleo_l452re/nucleo_l452re_common.dtsi
@@ -121,7 +121,7 @@
 		 */
 		storage_partition: partition@7c000 {
 			label = "storage";
-			reg = <0x0007c000 0x00008000>;
+			reg = <0x0007c000 0x00004000>;
 		};
 	};
 };


### PR DESCRIPTION
Fixed wrong partitions size as described in #83329

Fixes #83329
