### PR TITLE
zvfs: improve libc FILE to integer fd abstraction

### DIFF
--- a/lib/libc/newlib/CMakeLists.txt
+++ b/lib/libc/newlib/CMakeLists.txt
@@ -1,7 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 zephyr_library()
-zephyr_library_sources(libc-hooks.c)
+zephyr_library_sources(
+  libc-hooks.c
+  z_libc.c
+)
 
 # Do not allow LTO when compiling libc-hooks.c file
 set_source_files_properties(libc-hooks.c PROPERTIES COMPILE_OPTIONS $<TARGET_PROPERTY:compiler,prohibit_lto>)

--- a/lib/libc/newlib/libc-hooks.c
+++ b/lib/libc/newlib/libc-hooks.c
@@ -243,7 +243,7 @@ int _open(const char *name, int flags, ...)
 {
 	return -1;
 }
-__weak FUNC_ALIAS(_open, open, int);
+__weak int open(const char *name, int mode, ...) ALIAS_OF(_open);
 
 int _close(int file)
 {

--- a/lib/libc/newlib/z_libc.c
+++ b/lib/libc/newlib/z_libc.c
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2024 Tenstorrent AI ULC
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <zephyr/sys/fdtable.h>
+
+static int z_libc_sflags(const char *mode)
+{
+	int ret = 0;
+
+	switch (mode[0]) {
+	case 'r':
+		ret = ZVFS_O_RDONLY;
+		break;
+
+	case 'w':
+		ret = ZVFS_O_WRONLY | ZVFS_O_CREAT | ZVFS_O_TRUNC;
+		break;
+
+	case 'a':
+		ret = ZVFS_O_WRONLY | ZVFS_O_CREAT | ZVFS_O_APPEND;
+		break;
+	default:
+		return 0;
+	}
+
+	while (*++mode) {
+		switch (*mode) {
+		case '+':
+			ret |= ZVFS_O_RDWR;
+			break;
+		case 'x':
+			ret |= ZVFS_O_EXCL;
+			break;
+		default:
+			break;
+		}
+	}
+
+	return ret;
+}
+
+FILE *z_libc_file_alloc(int fd, const char *mode)
+{
+	FILE *fp;
+	/*
+	 * These symbols have conflicting declarations in upstream headers.
+	 * Use uintptr_t and a cast to assign cleanly.
+	 */
+	extern uintptr_t _close_r;
+	extern uintptr_t _lseek_r;
+	extern uintptr_t _read_r;
+	extern uintptr_t _write_r;
+
+	fp = calloc(1, sizeof(*fp));
+	if (fp == NULL) {
+		return NULL;
+	}
+
+	fp->_flags = z_libc_sflags(mode);
+	fp->_file = fd;
+	fp->_cookie = (void *)fp;
+
+	*(uintptr_t *)fp->_read = _read_r;
+	*(uintptr_t *)fp->_write = _write_r;
+	*(uintptr_t *)fp->_seek = _lseek_r;
+	*(uintptr_t *)fp->_close = _close_r;
+
+	return fp;
+}
+
+int z_libc_file_get_fd(FILE *fp)
+{
+	return fp->_file;
+}

--- a/lib/libc/picolibc/CMakeLists.txt
+++ b/lib/libc/picolibc/CMakeLists.txt
@@ -9,6 +9,7 @@ zephyr_library_sources(
   exit.c
   locks.c
   stdio.c
+  z_libc.c
   )
 
 zephyr_library_compile_options($<TARGET_PROPERTY:compiler,prohibit_lto>)

--- a/lib/libc/picolibc/z_libc.c
+++ b/lib/libc/picolibc/z_libc.c
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2024 Tenstorrent AI ULC
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "stdio-bufio.h"
+
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <zephyr/sys/fdtable.h>
+
+#define FDEV_SETUP_ZVFS(fd, buf, size, rwflags, bflags)                                            \
+	FDEV_SETUP_BUFIO(fd, buf, size, zvfs_read_wrap, zvfs_write_wrap, zvfs_lseek, zvfs_close,   \
+			 rwflags, bflags)
+
+int __posix_sflags(const char *mode, int *optr);
+
+/* FIXME: do not use ssize_t or off_t */
+ssize_t zvfs_read(int fd, void *buf, size_t sz, const size_t *from_offset);
+ssize_t zvfs_write(int fd, const void *buf, size_t sz, const size_t *from_offset);
+off_t zvfs_lseek(int fd, off_t offset, int whence);
+int zvfs_close(int fd);
+
+static ssize_t zvfs_read_wrap(int fd, void *buf, size_t sz)
+{
+	return zvfs_read(fd, buf, sz, NULL);
+}
+
+static ssize_t zvfs_write_wrap(int fd, const void *buf, size_t sz)
+{
+	return zvfs_write(fd, buf, sz, NULL);
+}
+
+FILE *z_libc_file_alloc(int fd, const char *mode)
+{
+	struct __file_bufio *bf;
+	int __maybe_unused unused;
+
+	bf = calloc(1, sizeof(struct __file_bufio) + BUFSIZ);
+	if (bf == NULL) {
+		return NULL;
+	}
+
+	*bf = (struct __file_bufio)FDEV_SETUP_ZVFS(fd, (char *)(bf + 1), BUFSIZ,
+						   __posix_sflags(mode, &unused), __BFALL);
+
+	__bufio_lock_init(&(bf->xfile.cfile.file));
+
+	return &(bf->xfile.cfile.file);
+}
+
+int z_libc_file_get_fd(const FILE *fp)
+{
+	const struct __file_bufio *const bf = (const struct __file_bufio *)fp;
+
+	return POINTER_TO_INT(bf->ptr);
+}


### PR DESCRIPTION
Previously, there was an implicit assumption that Zephyr's internal `struct fd_entry *` was synonymous with `FILE *` from the C library.

This is generally not the case and aliasing these two distinct types was preventing a fair bit of functionality from Just Working - namely stdio function calls like `fgets()` and `fopen()` (which of course have historically lacked any kind of test coverage or official support in Zephyr).

The problem can be seen directly when trying to use a function like `zvfs_fdopen()`.

Instead of aliasing the two types, require that all Zephyr C libraries provide

1. `FILE *z_libc_file_alloc(int fd, const char *mode)`, to allocate and populate the required fields of a `FILE` object

2. `int z_libc_file_get_fd(FILE *fp)`, to convert a `FILE*` object to an integer file descriptor.

For Picolibc and Newlib-based C libraries, these functions set and get the integer file descriptor from a field of the internal `FILE` object representation.

For the minimal C library, these functions convert between array index and `struct fd_entry *`.

Fixes #85013