### PR TITLE
tests: bsim: bluetooth: audio fixes build failure

### DIFF
--- a/tests/bsim/bluetooth/audio/src/bap_broadcast_sink_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_broadcast_sink_test.c
@@ -1087,7 +1087,7 @@ static void test_sink_encrypted_incorrect_code(void)
 	/* Wait for all to be started */
 	printk("Waiting for streams to be started\n");
 	for (size_t i = 0U; i < ARRAY_SIZE(streams); i++) {
-		k_sem_take(&sem_started, K_FOREVER);
+		k_sem_take(&sem_stream_started, K_FOREVER);
 	}
 
 	printk("Waiting for data\n");


### PR DESCRIPTION
Fixes build failure, correct the variable is using for `k_sem_take` in function `test_sink_encrypted_incorrect_code`

Fixes #83388