### PR TITLE
Enable NETC PSI0 on i.MXRT1180 M7

### DIFF
--- a/boards/nxp/mimxrt1180_evk/mimxrt1180_evk_mimxrt1189_cm7.dts
+++ b/boards/nxp/mimxrt1180_evk/mimxrt1180_evk_mimxrt1189_cm7.dts
@@ -14,12 +14,20 @@
 	compatible = "nxp,mimxrt1189";
 
 	chosen {
-		zephyr,sram = &dtcm;
+		zephyr,sram = &hyperram0;
+		zephyr,dtcm = &dtcm;
+		zephyr,itcm = &itcm;
 		zephyr,flash-controller = &w25q128jw;
-		zephyr,flash = &itcm;
+		zephyr,flash = &w25q128jw;
 		zephyr,console = &lpuart1;
 		zephyr,shell-uart = &lpuart1;
 		zephyr,canbus = &flexcan3;
+	};
+
+	hyperram0: memory@04000000 {
+		/* Winbond W957A8MFYA5K */
+		device_type = "memory";
+		reg = <0x04000000 DT_SIZE_M(8)>;
 	};
 };
 

--- a/boards/nxp/mimxrt1180_evk/mimxrt1180_evk_mimxrt1189_cm7.dts
+++ b/boards/nxp/mimxrt1180_evk/mimxrt1180_evk_mimxrt1189_cm7.dts
@@ -31,10 +31,6 @@
 	};
 };
 
-&enetc_psi0 {
-	status = "disabled";
-};
-
 &lpuart1 {
 	status = "okay";
 	current-speed = <115200>;

--- a/dts/arm/nxp/nxp_rt118x_cm7.dtsi
+++ b/dts/arm/nxp/nxp_rt118x_cm7.dtsi
@@ -10,13 +10,15 @@
 / {
 	soc {
 		itcm: itcm@0{
-			compatible = "nxp,imx-itcm";
+			compatible = "zephyr,memory-region", "nxp,imx-itcm";
 			reg = <0x00000000 DT_SIZE_K(256)>;
+			zephyr,memory-region = "ITCM";
 		};
 
 		dtcm: dtcm@20000000 {
-			compatible = "nxp,imx-dtcm";
+			compatible = "zephyr,memory-region", "nxp,imx-dtcm";
 			reg = <0x20000000 DT_SIZE_K(256)>;
+			zephyr,memory-region = "DTCM";
 		};
 
 		memory: memory@20484000 {


### PR DESCRIPTION
This PR is to enable NETC PSI0 on i.MXRT1180 M7.
The FLASH/SRAM using M7 ITCM/DTCM is too small for net samples.
SO, also convert to use hyperram and flash on board.

Thanks.