### PR TITLE
modules: lvgl: Rename the VDB custom section Kconfig name

### DIFF
--- a/boards/nxp/mimxrt595_evk/CMakeLists.txt
+++ b/boards/nxp/mimxrt595_evk/CMakeLists.txt
@@ -28,5 +28,5 @@ if(CONFIG_NXP_IMXRT_BOOT_HEADER)
 endif()
 
 # Add custom linker section to relocate framebuffers to PSRAM
-zephyr_linker_sources_ifdef(CONFIG_LV_Z_VBD_CUSTOM_SECTION
+zephyr_linker_sources_ifdef(CONFIG_LV_Z_VDB_CUSTOM_SECTION
   SECTIONS dc_ram.ld)

--- a/boards/nxp/mimxrt595_evk/board.c
+++ b/boards/nxp/mimxrt595_evk/board.c
@@ -344,7 +344,7 @@ static int mimxrt595_evk_init(void)
 }
 
 
-#ifdef CONFIG_LV_Z_VBD_CUSTOM_SECTION
+#ifdef CONFIG_LV_Z_VDB_CUSTOM_SECTION
 extern char __flexspi2_start[];
 extern char __flexspi2_end[];
 
@@ -358,14 +358,14 @@ static int init_psram_framebufs(void)
 	return 0;
 }
 
-#endif /* CONFIG_LV_Z_VBD_CUSTOM_SECTION */
+#endif /* CONFIG_LV_Z_VDB_CUSTOM_SECTION */
 
 #if CONFIG_REGULATOR
 /* PMIC setup is dependent on the regulator API */
 SYS_INIT(board_config_pmic, POST_KERNEL, CONFIG_APPLICATION_INIT_PRIORITY);
 #endif
 
-#ifdef CONFIG_LV_Z_VBD_CUSTOM_SECTION
+#ifdef CONFIG_LV_Z_VDB_CUSTOM_SECTION
 /* Framebuffers should be setup after PSRAM is initialized but before
  * Graphics framework init
  */

--- a/boards/renesas/ek_ra8d1/Kconfig.defconfig
+++ b/boards/renesas/ek_ra8d1/Kconfig.defconfig
@@ -17,7 +17,7 @@ config MEMC
 
 if LVGL
 
-config LV_Z_VBD_CUSTOM_SECTION
+config LV_Z_VDB_CUSTOM_SECTION
 	default y
 
 endif # LVGL

--- a/boards/shields/rk055hdmipi4m/boards/mimxrt595_evk_mimxrt595s_cm33.conf
+++ b/boards/shields/rk055hdmipi4m/boards/mimxrt595_evk_mimxrt595s_cm33.conf
@@ -6,7 +6,7 @@
 
 # Use external framebuffer memory
 CONFIG_MCUX_DCNANO_LCDIF_EXTERNAL_FB_MEM=y
-CONFIG_LV_Z_VBD_CUSTOM_SECTION=y
+CONFIG_LV_Z_VDB_CUSTOM_SECTION=y
 # Use FlexSPI2 for framebuffer (pSRAM is present on this bus)
 CONFIG_MCUX_DCNANO_LCDIF_EXTERNAL_FB_ADDR=0x38400000
 # M33 core and LCDIF both access FlexSPI2 through the same cache,

--- a/boards/shields/rk055hdmipi4ma0/boards/mimxrt595_evk_mimxrt595s_cm33.conf
+++ b/boards/shields/rk055hdmipi4ma0/boards/mimxrt595_evk_mimxrt595s_cm33.conf
@@ -6,7 +6,7 @@
 
 # Use external framebuffer memory
 CONFIG_MCUX_DCNANO_LCDIF_EXTERNAL_FB_MEM=y
-CONFIG_LV_Z_VBD_CUSTOM_SECTION=y
+CONFIG_LV_Z_VDB_CUSTOM_SECTION=y
 # Use FlexSPI2 for framebuffer (pSRAM is present on this bus)
 CONFIG_MCUX_DCNANO_LCDIF_EXTERNAL_FB_ADDR=0x38400000
 # M33 core and LCDIF both access FlexSPI2 through the same cache,

--- a/boards/shields/st_b_lcd40_dsi1_mb1166/boards/stm32h747i_disco_stm32h747xx_m7.defconfig
+++ b/boards/shields/st_b_lcd40_dsi1_mb1166/boards/stm32h747i_disco_stm32h747xx_m7.defconfig
@@ -11,7 +11,7 @@ config STM32_LTDC_FB_NUM
 config LV_Z_DOUBLE_VDB
 	default y
 
-config LV_Z_VBD_CUSTOM_SECTION
+config LV_Z_VDB_CUSTOM_SECTION
 	default y
 
 config LV_Z_FULL_REFRESH

--- a/boards/st/stm32h747i_disco/CMakeLists.txt
+++ b/boards/st/stm32h747i_disco/CMakeLists.txt
@@ -5,5 +5,5 @@
 #
 
 # Add custom linker section to relocate framebuffers to PSRAM
-zephyr_linker_sources_ifdef(CONFIG_LV_Z_VBD_CUSTOM_SECTION
+zephyr_linker_sources_ifdef(CONFIG_LV_Z_VDB_CUSTOM_SECTION
   SECTIONS dc_ram.ld)

--- a/boards/st/stm32h7b3i_dk/CMakeLists.txt
+++ b/boards/st/stm32h7b3i_dk/CMakeLists.txt
@@ -5,5 +5,5 @@
 #
 
 # Add custom linker section to relocate framebuffers to PSRAM
-zephyr_linker_sources_ifdef(CONFIG_LV_Z_VBD_CUSTOM_SECTION
+zephyr_linker_sources_ifdef(CONFIG_LV_Z_VDB_CUSTOM_SECTION
   SECTIONS dc_ram.ld)

--- a/boards/st/stm32h7b3i_dk/Kconfig.defconfig
+++ b/boards/st/stm32h7b3i_dk/Kconfig.defconfig
@@ -40,7 +40,7 @@ config LV_Z_DOUBLE_VDB
 config LV_Z_FULL_REFRESH
 	default y
 
-config LV_Z_VBD_CUSTOM_SECTION
+config LV_Z_VDB_CUSTOM_SECTION
 	default y
 
 config LV_Z_FLUSH_THREAD

--- a/doc/releases/migration-guide-4.1.rst
+++ b/doc/releases/migration-guide-4.1.rst
@@ -99,6 +99,9 @@ LVGL
   :kconfig:option:`CONFIG_LV_Z_FLUSH_THREAD_PRIORITY` and its value is now interpreted as an
   absolute priority instead of a cooperative one.
 
+* The config option :kconfig:option:`CONFIG_LV_Z_VBD_CUSTOM_SECTION` is now called
+  :kconfig:option:`CONFIG_LV_Z_VDB_CUSTOM_SECTION`.
+
 Device Drivers and Devicetree
 *****************************
 

--- a/modules/lvgl/Kconfig.memory
+++ b/modules/lvgl/Kconfig.memory
@@ -83,7 +83,7 @@ config LV_Z_VDB_ALIGN
 	  buffer may be accessed as a uint8_t *, uint16_t *, or uint32_t *,
 	  so buffer must be aligned to prevent unaligned memory access
 
-config LV_Z_VBD_CUSTOM_SECTION
+config LV_Z_VDB_CUSTOM_SECTION
 	bool "Link rendering buffers to custom section"
 	depends on LV_Z_BUFFER_ALLOC_STATIC
 	help

--- a/modules/lvgl/lvgl.c
+++ b/modules/lvgl/lvgl.c
@@ -53,14 +53,14 @@ struct lvgl_disp_data disp_data = {
  * prevent unaligned memory accesses.
  */
 static uint8_t buf0[BUFFER_SIZE]
-#ifdef CONFIG_LV_Z_VBD_CUSTOM_SECTION
+#ifdef CONFIG_LV_Z_VDB_CUSTOM_SECTION
 	Z_GENERIC_SECTION(.lvgl_buf)
 #endif
 		__aligned(CONFIG_LV_Z_VDB_ALIGN);
 
 #ifdef CONFIG_LV_Z_DOUBLE_VDB
 static uint8_t buf1[BUFFER_SIZE]
-#ifdef CONFIG_LV_Z_VBD_CUSTOM_SECTION
+#ifdef CONFIG_LV_Z_VDB_CUSTOM_SECTION
 	Z_GENERIC_SECTION(.lvgl_buf)
 #endif
 		__aligned(CONFIG_LV_Z_VDB_ALIGN);
@@ -68,7 +68,7 @@ static uint8_t buf1[BUFFER_SIZE]
 
 #if ALLOC_MONOCHROME_CONV_BUFFER
 static uint8_t mono_vtile_buf[BUFFER_SIZE]
-#ifdef CONFIG_LV_Z_VBD_CUSTOM_SECTION
+#ifdef CONFIG_LV_Z_VDB_CUSTOM_SECTION
 	Z_GENERIC_SECTION(.lvgl_buf)
 #endif
 		__aligned(CONFIG_LV_Z_VDB_ALIGN);


### PR DESCRIPTION
There are 4 Kconfig names about the "Draw Buffer". Rename the 'VBD' to 'VDB' in Kconfig option 'LV_Z_VBD_CUSTOM_SECTION' to make name consistent.

config LV_Z_VDB_ALIGN
	int "Rending buffer alignment"

config LV_Z_VBD_CUSTOM_SECTION
	bool "Link rendering buffers to custom section"

config LV_Z_DOUBLE_VDB
	bool "Use two rendering buffers"

config LV_Z_VDB_SIZE
	int "Rendering buffer size"
	default 100 if LV_Z_FULL_REFRESH

And the draw buffer definition is now:

	static uint8_t buf0[BUFFER_SIZE]
	#ifdef CONFIG_LV_Z_VDB_CUSTOM_SECTION
		Z_GENERIC_SECTION(.lvgl_buf)
	#endif
			__aligned(CONFIG_LV_Z_VDB_ALIGN);