### PR TITLE
drivers: gpio_cc13xx_cc26xx: Update for latest sdk

### DIFF
--- a/samples/boards/ti/cc13x2_cc26x2/system_off/src/main.c
+++ b/samples/boards/ti/cc13x2_cc26x2/system_off/src/main.c
@@ -14,6 +14,9 @@
 
 #include <driverlib/ioc.h>
 
+/* GPIO all DIOs mask */
+#define GPIO_DIO_ALL_MASK 0xFFFFFFFF
+
 static const struct gpio_dt_spec sw0_gpio = GPIO_DT_SPEC_GET(DT_ALIAS(sw0), gpios);
 
 #define BUSY_WAIT_S 5U
@@ -56,8 +59,8 @@ int main(void)
 	printk("Powering off; press BUTTON1 to restart\n");
 
 	/* Clear GPIO interrupt */
-	status = GPIO_getEventMultiDio(GPIO_DIO_ALL_MASK);
-	GPIO_clearEventMultiDio(status);
+	status = HWREG(GPIO_BASE + GPIO_O_EVFLAGS31_0) & GPIO_DIO_ALL_MASK;
+	HWREG(GPIO_BASE + GPIO_O_EVFLAGS31_0) = status;
 
 	sys_poweroff();
 

--- a/west.yml
+++ b/west.yml
@@ -253,7 +253,7 @@ manifest:
       groups:
         - hal
     - name: hal_ti
-      revision: 258652a3ac5d7df68ba8df20e4705c3bd98ede38
+      revision: 46407c76196ca250c3f955376d52dc3ea25ba381
       path: modules/hal/ti
       groups:
         - hal


### PR DESCRIPTION
- It seems that the mask variants of GPIO functions are not present in the latest sdk, so replace those with direct register access.