### PR TITLE
style: Add parens to the disp expr

### DIFF
--- a/include/zephyr/dt-bindings/pinctrl/rpi-pico-pinctrl-common.h
+++ b/include/zephyr/dt-bindings/pinctrl/rpi-pico-pinctrl-common.h
@@ -19,7 +19,8 @@
 #define RP2_GPIO_OVERRIDE_LOW    2
 #define RP2_GPIO_OVERRIDE_HIGH   3
 
-#define RP2XXX_PINMUX(pin_num, alt_func) (pin_num << RP2_PIN_NUM_POS | alt_func << RP2_ALT_FUNC_POS)
+#define RP2XXX_PINMUX(pin_num, alt_func) \
+	(((pin_num) << RP2_PIN_NUM_POS) | ((alt_func) << RP2_ALT_FUNC_POS))
 
 /* These function are common. SoC-specific functions are defined in their
  * respective header file. Refer to table 279 and 642 in the RP2040 and RP2350


### PR DESCRIPTION
Add parentheses to the displacement expression
to prevent priority issues after macro expansion.