### PR TITLE
ipc: pbuf: fix idx_occupied comment

### DIFF
--- a/subsys/ipc/ipc_service/lib/pbuf.c
+++ b/subsys/ipc/ipc_service/lib/pbuf.c
@@ -15,7 +15,7 @@
 #include <soc.h>
 #endif
 
-/* Helper funciton for getting numer of bytes being written to the bufer. */
+/* Helper function for getting number of bytes being written to the buffer. */
 static uint32_t idx_occupied(uint32_t len, uint32_t wr_idx, uint32_t rd_idx)
 {
 	/* It is implicitly assumed wr_idx and rd_idx cannot differ by more then len. */


### PR DESCRIPTION
Fix typos in the comment on the idx_occupied function