### PR TITLE
boards: sparkfun: pro_micro_rp2040: fix pinctrl definitions for spi

### DIFF
--- a/boards/sparkfun/pro_micro_rp2040/doc/index.rst
+++ b/boards/sparkfun/pro_micro_rp2040/doc/index.rst
@@ -103,8 +103,8 @@ Default Zephyr Peripheral Mapping:
 - I2C1_SDA : P2
 - I2C1_SCL : P3
 - SPI0_RX : P20
-- SPI0_SCK : P18
-- SPI0_TX : P19
+- SPI0_SCK : P22
+- SPI0_TX : P23
 
 Programming and Debugging
 *************************

--- a/boards/sparkfun/pro_micro_rp2040/sparkfun_pro_micro_rp2040-pinctrl.dtsi
+++ b/boards/sparkfun/pro_micro_rp2040/sparkfun_pro_micro_rp2040-pinctrl.dtsi
@@ -29,14 +29,14 @@
 
 	spi0_default: spi0_default {
 		group1 {
-			pinmux = <SPI0_TX_P19>;
+			pinmux = <SPI0_TX_P23>;
 		};
 		group2 {
 			pinmux = <SPI0_RX_P20>;
 			input-enable;
 		};
 		group3 {
-			pinmux = <SPI0_SCK_P18>;
+			pinmux = <SPI0_SCK_P22>;
 		};
 	};
 


### PR DESCRIPTION
The default SCK and COPI/MOSI pins on the Sparkfun Pro Micro RP2040 board correspond to `GPIO22` and `GPIO23` respectively[^1]. The existing pinctrl definitions in the `spi0_default` don't reflect this (rather, they match the pinout of the Adafruit KB2040 MCU[^2]).

Update the board's respective pinctrl definitions to match the pinout.

[^1]: https://cdn.sparkfun.com/assets/e/2/7/6/b/ProMicroRP2040_Graphical_Datasheet.pdf
[^2]: https://learn.adafruit.com/assets/106984