### PR TITLE
checkpatch: Adapt the braces check to Zephyr

### DIFF
--- a/.checkpatch.conf
+++ b/.checkpatch.conf
@@ -5,7 +5,6 @@
 --min-conf-desc-length=1
 --typedefsfile=scripts/checkpatch/typedefsfile
 
---ignore BRACES
 --ignore PRINTK_WITHOUT_KERN_LEVEL
 --ignore SPLIT_STRING
 --ignore VOLATILE

--- a/doc/contribute/guidelines.rst
+++ b/doc/contribute/guidelines.rst
@@ -545,8 +545,7 @@ exceptions:
 * The line length is 100 columns or fewer. In the documentation, longer lines
   for URL references are an allowed exception.
 * Add braces to every ``if``, ``else``, ``do``, ``while``, ``for`` and
-  ``switch`` body, even for single-line code blocks. Use the ``--ignore BRACES``
-  flag to make *checkpatch* stop complaining.
+  ``switch`` body, even for single-line code blocks.
 * Use spaces instead of tabs to align comments after declarations, as needed.
 * Use C89-style single line comments, ``/*  */``. The C99-style single line
   comment, ``//``, is not allowed.


### PR DESCRIPTION
scripts/checkpatch.pl was written originally for the Linux kernel, and its code reflects the kernel's coding style. In particular, it has checks for unneeded braces around single-statement if/else/for/while conditions. In Zephyr however, braces are always required, and so the checks needed modifying to verify the opposite condition.

In order to enable the now-compatible checks, we also remove the --ignore BRACES statement in .checkpatch.conf.

Limitations: the current code works well if there are not conditional statements (e.g. #if, #ifdef or #endif) next to the if/else/for/while conditions. This is rarely the case, but triggers with the Bluetooth controller in code like this:

```
 #if defined(CONFIG_BT_PERIPHERAL)
        if (!lll->is_hdcd)
 #endif /* CONFIG_BT_PERIPHERAL */
        {
```

```
        } else
 #endif /* CONFIG_BT_CTLR_PRIVACY */
        {

```

```
 #if defined(CONFIG_BT_CTLR_DF_ADV_CTE_TX)
        if (lll->cte_started) {
                radio_switch_complete(phy_s, 0, phy_s, 0);
        } else
 #endif /* CONFIG_BT_CTLR_DF_ADV_CTE_TX */
        {
```

```
 #ifdef DUAL_BANK
        while ((FLASH_STM32_REGS(dev)->SR1 & FLASH_SR_QW) ||
               (FLASH_STM32_REGS(dev)->SR2 & FLASH_SR_QW))
 #else
        while (FLASH_STM32_REGS(dev)->SR1 & FLASH_SR_QW)
 #endif
        {
```