### PR TITLE
drivers: cc13xx_cc26xx: pwm: Fix pm bug

### DIFF
--- a/drivers/pwm/pwm_cc13xx_cc26xx_timer.c
+++ b/drivers/pwm/pwm_cc13xx_cc26xx_timer.c
@@ -34,6 +34,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME, CONFIG_PWM_LOG_LEVEL);
 #define PWM_INITIAL_DUTY   0U /* initially off */
 
 struct pwm_cc13xx_cc26xx_data {
+	bool standby_disabled;
 };
 
 struct pwm_cc13xx_cc26xx_config {
@@ -56,14 +57,17 @@ static void write_value(const struct pwm_cc13xx_cc26xx_config *config, uint32_t 
 }
 
 static int set_period_and_pulse(const struct pwm_cc13xx_cc26xx_config *config, uint32_t period,
-				uint32_t pulse)
+				uint32_t pulse, struct pwm_cc13xx_cc26xx_data *data)
 {
 	uint32_t match_value = pulse;
 
 	if (pulse == 0U) {
 		TimerDisable(config->gpt_base, TIMER_B);
 #ifdef CONFIG_PM
-		Power_releaseConstraint(PowerCC26XX_DISALLOW_STANDBY);
+		if (data->standby_disabled) {
+			Power_releaseConstraint(PowerCC26XX_DISALLOW_STANDBY);
+			data->standby_disabled = false;
+		}
 #endif
 		match_value = period + 1;
 	}
@@ -86,7 +90,10 @@ static int set_period_and_pulse(const struct pwm_cc13xx_cc26xx_config *config, u
 
 	if (pulse > 0U) {
 #ifdef CONFIG_PM
-		Power_setConstraint(PowerCC26XX_DISALLOW_STANDBY);
+		if (!data->standby_disabled) {
+			Power_setConstraint(PowerCC26XX_DISALLOW_STANDBY);
+			data->standby_disabled = true;
+		}
 #endif
 		TimerEnable(config->gpt_base, TIMER_B);
 	}
@@ -110,7 +117,7 @@ static int set_cycles(const struct device *dev, uint32_t channel, uint32_t perio
 		HWREG(config->gpt_base + GPT_O_CTL) |= GPT_CTL_TBPWML_NORMAL;
 	}
 
-	set_period_and_pulse(config, period, pulse);
+	set_period_and_pulse(config, period, pulse, dev->data);
 
 	return 0;
 }
@@ -223,7 +230,7 @@ static int init_pwm(const struct device *dev)
 	HWREG(config->gpt_base + GPT_O_TBMR) = GPT_TBMR_TBAMS_PWM | GPT_TBMR_TBMRSU_TOUPDATE |
 					       GPT_TBMR_TBPWMIE_EN | GPT_TBMR_TBMR_PERIODIC;
 
-	set_period_and_pulse(config, PWM_INITIAL_PERIOD, PWM_INITIAL_DUTY);
+	set_period_and_pulse(config, PWM_INITIAL_PERIOD, PWM_INITIAL_DUTY, dev->data);
 
 	return 0;
 }


### PR DESCRIPTION
- The current code will cause stall if some other subsystem (like subg) also needs to manage pm states.
- So add a check to only re-enable suspend if it was disabled by PWM.
- Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/80252
- Tested on beagleconnect freedom