### PR TITLE
drivers: stepper: shell: Use shell_device_filter

### DIFF
--- a/drivers/stepper/stepper_shell.c
+++ b/drivers/stepper/stepper_shell.c
@@ -67,6 +67,11 @@ static void print_callback(const struct device *dev, const enum stepper_event ev
 	}
 }
 
+static bool stepper_device_check(const struct device *dev)
+{
+	return DEVICE_API_IS(stepper, dev) && device_is_ready(dev);
+}
+
 static const struct stepper_direction_map stepper_direction_map[] = {
 	STEPPER_DIRECTION_MAP_ENTRY("positive", STEPPER_DIRECTION_POSITIVE),
 	STEPPER_DIRECTION_MAP_ENTRY("negative", STEPPER_DIRECTION_NEGATIVE),
@@ -114,7 +119,7 @@ SHELL_DYNAMIC_CMD_CREATE(dsub_stepper_microstep, cmd_stepper_microstep);
 
 static void cmd_pos_stepper_motor_name(size_t idx, struct shell_static_entry *entry)
 {
-	const struct device *dev = shell_device_lookup(idx, NULL);
+	const struct device *dev = shell_device_filter(idx, stepper_device_check);
 
 	entry->syntax = (dev != NULL) ? dev->name : NULL;
 	entry->handler = NULL;
@@ -126,7 +131,7 @@ SHELL_DYNAMIC_CMD_CREATE(dsub_pos_stepper_motor_name, cmd_pos_stepper_motor_name
 
 static void cmd_pos_stepper_motor_name_dir(size_t idx, struct shell_static_entry *entry)
 {
-	const struct device *dev = shell_device_lookup(idx, NULL);
+	const struct device *dev = shell_device_filter(idx, stepper_device_check);
 
 	if (dev != NULL) {
 		entry->syntax = dev->name;
@@ -142,7 +147,7 @@ SHELL_DYNAMIC_CMD_CREATE(dsub_pos_stepper_motor_name_dir, cmd_pos_stepper_motor_
 
 static void cmd_pos_stepper_motor_name_microstep(size_t idx, struct shell_static_entry *entry)
 {
-	const struct device *dev = shell_device_lookup(idx, NULL);
+	const struct device *dev = shell_device_filter(idx, stepper_device_check);
 
 	if (dev != NULL) {
 		entry->syntax = dev->name;


### PR DESCRIPTION
Use the shell_device_filter utils method and leverage the new api classing to only suggest stepper devices via tab-complete within the shell.