### PR TITLE
drivers: display: Fix typos in multiple display drivers

### DIFF
--- a/drivers/display/display_dummy.c
+++ b/drivers/display/display_dummy.c
@@ -38,7 +38,7 @@ static int dummy_display_write(const struct device *dev, const uint16_t x,
 {
 	const struct dummy_display_config *config = dev->config;
 
-	__ASSERT(desc->width <= desc->pitch, "Pitch is smaller then width");
+	__ASSERT(desc->width <= desc->pitch, "Pitch is smaller than width");
 	__ASSERT(desc->pitch <= config->width,
 		"Pitch in descriptor is larger than screen size");
 	__ASSERT(desc->height <= config->height,

--- a/drivers/display/display_gc9x01x.c
+++ b/drivers/display/display_gc9x01x.c
@@ -518,7 +518,7 @@ static int gc9x01x_write(const struct device *dev, const uint16_t x, const uint1
 
 	__ASSERT(desc->width <= desc->pitch, "Pitch is smaller than width");
 	__ASSERT((desc->pitch * data->bytes_per_pixel * desc->height) <= desc->buf_size,
-		 "Input buffer to small");
+		 "Input buffer too small");
 
 	LOG_DBG("Writing %dx%d (w,h) @ %dx%d (x,y)", desc->width, desc->height, x, y);
 	ret = gc9x01x_set_mem_area(dev, x, y, desc->width, desc->height);

--- a/drivers/display/display_ili9xxx.c
+++ b/drivers/display/display_ili9xxx.c
@@ -139,7 +139,7 @@ static int ili9xxx_write(const struct device *dev, const uint16_t x,
 	__ASSERT(desc->width <= desc->pitch, "Pitch is smaller than width");
 	__ASSERT((desc->pitch * data->bytes_per_pixel * desc->height) <=
 			 desc->buf_size,
-		 "Input buffer to small");
+		 "Input buffer too small");
 
 	LOG_DBG("Writing %dx%d (w,h) @ %dx%d (x,y)", desc->width, desc->height,
 		x, y);
@@ -207,7 +207,7 @@ static int ili9xxx_read(const struct device *dev, const uint16_t x,
 	__ASSERT(desc->width <= desc->pitch, "Pitch is smaller than width");
 	__ASSERT((desc->pitch * data->bytes_per_pixel * desc->height) <=
 			 desc->buf_size,
-		 "Output buffer to small");
+		 "Output buffer too small");
 
 	LOG_DBG("Reading %dx%d (w,h) @ %dx%d (x,y)", desc->width, desc->height,
 		x, y);

--- a/drivers/display/display_led_strip_matrix.c
+++ b/drivers/display/display_led_strip_matrix.c
@@ -88,7 +88,7 @@ static struct led_rgb *pixel_address(const struct led_strip_matrix_config *confi
 static inline int check_descriptor(const struct led_strip_matrix_config *config, const uint16_t x,
 				   const uint16_t y, const struct display_buffer_descriptor *desc)
 {
-	__ASSERT(desc->width <= desc->pitch, "Pitch is smaller then width");
+	__ASSERT(desc->width <= desc->pitch, "Pitch is smaller than width");
 	__ASSERT(desc->pitch <= config->width, "Pitch in descriptor is larger than screen size");
 	__ASSERT(desc->height <= config->height, "Height in descriptor is larger than screen size");
 	__ASSERT(x + desc->pitch <= config->width,

--- a/drivers/display/display_max7219.c
+++ b/drivers/display/display_max7219.c
@@ -151,8 +151,8 @@ static int max7219_write(const struct device *dev, const uint16_t x, const uint1
 	/*
 	 * MAX7219 only supports PIXEL_FORMAT_MONO01. 1 bit stands for 1 pixel.
 	 */
-	__ASSERT((desc->pitch * desc->height) <= (desc->buf_size * 8U), "Input buffer to small");
-	__ASSERT(desc->width <= desc->pitch, "Pitch is smaller then width");
+	__ASSERT((desc->pitch * desc->height) <= (desc->buf_size * 8U), "Input buffer too small");
+	__ASSERT(desc->width <= desc->pitch, "Pitch is smaller than width");
 	__ASSERT(desc->pitch <= max_width, "Pitch in descriptor is larger than screen size");
 	__ASSERT(desc->height <= max_height, "Height in descriptor is larger than screen size");
 	__ASSERT(x + desc->pitch <= max_width,

--- a/drivers/display/display_sdl.c
+++ b/drivers/display/display_sdl.c
@@ -100,7 +100,7 @@ static void sdl_display_write_argb8888(void *disp_buf,
 		const struct display_buffer_descriptor *desc, const void *buf)
 {
 	__ASSERT((desc->pitch * 4U * desc->height) <= desc->buf_size,
-			"Input buffer to small");
+			"Input buffer too small");
 
 	memcpy(disp_buf, buf, desc->pitch * 4U * desc->height);
 }
@@ -114,7 +114,7 @@ static void sdl_display_write_rgb888(uint8_t *disp_buf,
 	const uint8_t *byte_ptr;
 
 	__ASSERT((desc->pitch * 3U * desc->height) <= desc->buf_size,
-			"Input buffer to small");
+			"Input buffer too small");
 
 	for (h_idx = 0U; h_idx < desc->height; ++h_idx) {
 		for (w_idx = 0U; w_idx < desc->width; ++w_idx) {
@@ -139,7 +139,7 @@ static void sdl_display_write_rgb565(uint8_t *disp_buf,
 	uint16_t rgb565;
 
 	__ASSERT((desc->pitch * 2U * desc->height) <= desc->buf_size,
-			"Input buffer to small");
+			"Input buffer too small");
 
 	for (h_idx = 0U; h_idx < desc->height; ++h_idx) {
 		for (w_idx = 0U; w_idx < desc->width; ++w_idx) {
@@ -164,7 +164,7 @@ static void sdl_display_write_bgr565(uint8_t *disp_buf,
 	const uint16_t *pix_ptr;
 
 	__ASSERT((desc->pitch * 2U * desc->height) <= desc->buf_size,
-			"Input buffer to small");
+			"Input buffer too small");
 
 	for (h_idx = 0U; h_idx < desc->height; ++h_idx) {
 		for (w_idx = 0U; w_idx < desc->width; ++w_idx) {
@@ -192,7 +192,7 @@ static void sdl_display_write_mono(uint8_t *disp_buf,
 	uint8_t *disp_buf_start;
 
 	__ASSERT((desc->pitch * desc->height) <= (desc->buf_size * 8U),
-			"Input buffer to small");
+			"Input buffer too small");
 	__ASSERT((desc->height % 8) == 0U,
 			"Input buffer height not aligned per 8 pixels");
 
@@ -234,7 +234,7 @@ static int sdl_display_write(const struct device *dev, const uint16_t x,
 	LOG_DBG("Writing %dx%d (w,h) bitmap @ %dx%d (x,y)", desc->width,
 			desc->height, x, y);
 
-	__ASSERT(desc->width <= desc->pitch, "Pitch is smaller then width");
+	__ASSERT(desc->width <= desc->pitch, "Pitch is smaller than width");
 	__ASSERT(desc->pitch <= config->width,
 		"Pitch in descriptor is larger than screen size");
 	__ASSERT(desc->height <= config->height,

--- a/drivers/display/display_st7789v.c
+++ b/drivers/display/display_st7789v.c
@@ -143,9 +143,9 @@ static int st7789v_write(const struct device *dev,
 	uint16_t write_h;
 	enum display_pixel_format pixfmt;
 
-	__ASSERT(desc->width <= desc->pitch, "Pitch is smaller then width");
+	__ASSERT(desc->width <= desc->pitch, "Pitch is smaller than width");
 	__ASSERT((desc->pitch * ST7789V_PIXEL_SIZE * desc->height) <= desc->buf_size,
-			"Input buffer to small");
+			"Input buffer too small");
 
 	LOG_DBG("Writing %dx%d (w,h) @ %dx%d (x,y)",
 		desc->width, desc->height, x, y);

--- a/drivers/display/ssd1306.c
+++ b/drivers/display/ssd1306.c
@@ -306,7 +306,7 @@ static int ssd1306_write(const struct device *dev, const uint16_t x, const uint1
 	size_t buf_len;
 
 	if (desc->pitch < desc->width) {
-		LOG_ERR("Pitch is smaller then width");
+		LOG_ERR("Pitch is smaller than width");
 		return -1;
 	}
 

--- a/drivers/display/uc81xx.c
+++ b/drivers/display/uc81xx.c
@@ -383,7 +383,7 @@ static int uc81xx_write(const struct device *dev, const uint16_t x, const uint16
 
 	buf_len = MIN(desc->buf_size,
 		      desc->height * desc->width / UC81XX_PIXELS_PER_BYTE);
-	__ASSERT(desc->width <= desc->pitch, "Pitch is smaller then width");
+	__ASSERT(desc->width <= desc->pitch, "Pitch is smaller than width");
 	__ASSERT(buf != NULL, "Buffer is not available");
 	__ASSERT(buf_len != 0U, "Buffer of length zero");
 	__ASSERT(!(desc->width % UC81XX_PIXELS_PER_BYTE),


### PR DESCRIPTION
Found multiple similar typos in various display drivers - fixed them.

Typos were [reported](https://discord.com/channels/720317445772017664/720317445772017667/1321877994339434497) on Discord in ST7789V display driver. Found that similar typos were present in many other display drivers as well.