### PR TITLE
CAN termination GPIO support

### DIFF
--- a/dts/bindings/phy/can-transceiver-gpio.yaml
+++ b/dts/bindings/phy/can-transceiver-gpio.yaml
@@ -21,3 +21,9 @@ properties:
       GPIO to use to put the CAN transceiver into standby. This GPIO is driven
       inactive when the CAN transceiver is enabled and active when the CAN
       transceiver is disabled.
+
+  termination-gpios:
+    type: phandle-array
+    description: |
+      GPIO to use to enable/disable the CAN transceiver termination resistor.
+      This GPIO will be not changed during CAN transceiver initialzation phase.

--- a/include/zephyr/drivers/can/transceiver.h
+++ b/include/zephyr/drivers/can/transceiver.h
@@ -41,9 +41,23 @@ typedef int (*can_transceiver_enable_t)(const struct device *dev, can_mode_t mod
  */
 typedef int (*can_transceiver_disable_t)(const struct device *dev);
 
+/**
+ * @brief Callback API upon enabling CAN transceiver termination
+ * See @a can_transceiver_termination_enable() for argument description
+ */
+typedef int (*can_transceiver_termination_enable_t)(const struct device *dev);
+
+/**
+ * @brief Callback API upon disabling CAN transceiver termination
+ * See @a can_transceiver_termination_disable() for argument description
+ */
+typedef int (*can_transceiver_termination_disable_t)(const struct device *dev);
+
 __subsystem struct can_transceiver_driver_api {
 	can_transceiver_enable_t enable;
 	can_transceiver_disable_t disable;
+	can_transceiver_termination_enable_t termination_enable;
+	can_transceiver_termination_disable_t termination_disable;
 };
 
 /** @endcond */
@@ -85,6 +99,40 @@ static inline int can_transceiver_enable(const struct device *dev, can_mode_t mo
 static inline int can_transceiver_disable(const struct device *dev)
 {
 	return DEVICE_API_GET(can_transceiver, dev)->disable(dev);
+}
+
+/**
+ * @brief Enable CAN transceiver termination
+ *
+ * Enable CAN transceiver termination by puttig 120ohm between CAN_H and CAN_L.
+ *
+ * @note The CAN transceiver is controlled by the CAN controller driver and
+ *       should not normally be controlled by the application.
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @retval 0 If successful.
+ * @retval -EIO General input/output error, failed to enable device.
+ */
+static inline int can_transceiver_termination_enable(const struct device *dev)
+{
+	return DEVICE_API_GET(can_transceiver, dev)->termination_enable(dev);
+}
+
+/**
+ * @brief Disable CAN transceiver termination
+ *
+ * Disable CAN transceiver termination by puttig 120ohm between CAN_H and CAN_L.
+ *
+ * @note The CAN transceiver is controlled by the CAN controller driver and
+ *       should not normally be controlled by the application.
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @retval 0 If successful.
+ * @retval -EIO General input/output error, failed to enable device.
+ */
+static inline int can_transceiver_termination_disable(const struct device *dev)
+{
+	return DEVICE_API_GET(can_transceiver, dev)->termination_disable(dev);
 }
 
 /**


### PR DESCRIPTION
The functionality for termination gpio is used on
some boards like ST's b-g431b-esc1 motor controller board. This feature is also supported by SocketCAN in linux.

UPD:
There is only one open question regarding implementation: Would be can_mcan API the best way to propagate this functionality to the application?