### PR TITLE
dts: ite: refactor the it8801 template hierarchy

### DIFF
--- a/dts/bindings/mfd/ite,it8801-mfd.yaml
+++ b/dts/bindings/mfd/ite,it8801-mfd.yaml
@@ -5,15 +5,9 @@ description: |
   ITE IT8801 ioexpander multi-function device drivers.
   This ioexpander provides a GPIO/PWM/Keyboard function via I2C bus.
 
-  An example configuration:
+  An example configuration using the it8801-common-cfg.dtsi template:
 
   &i2c4 {
-      status = "okay";
-      clock-frequency = <I2C_BITRATE_STANDARD>;
-      pinctrl-0 = <&i2c4_clk_gpe0_default
-                   &i2c4_data_gpe7_default>;
-      pinctrl-names = "default";
-
       it8801_mfd: it8801@38 {
           compatible = "ite,it8801-mfd";
           /*
@@ -23,74 +17,27 @@ description: |
            */
           reg = <0x38>;
           irq-gpios = <&gpioa 1 0>; /* SMB_INT# */
-          #address-cells = <1>;
-          #size-cells = <1>;
+      }
 
-          ioex_it8801_port0: it8801_port@0  {
-              compatible = "ite,it8801-gpio";
-              reg = <0x00 1   /* GPIPSR */
-                     0x05 1   /* GPSOVR */
-                     0x0a 8   /* GPCR */
-                     0x32 1   /* GPISR */
-                     0x37 1>; /* GPIER */
-              gpio-controller;
-              #gpio-cells = <2>;
-              ngpios = <8>;
-              pin-mask = <0xdb>;
-          };
+      #include <ite/it8801-common-cfg.dtsi>
 
-          ioex_it8801_port1: it8801_port@1 {
-              compatible = "ite,it8801-gpio";
-              reg = <0x01 1   /* GPIPSR */
-                     0x06 1   /* GPSOVR */
-                     0x12 8   /* GPCR */
-                     0x33 1   /* GPISR */
-                     0x38 1>; /* GPIER */
-              gpio-controller;
-              #gpio-cells = <2>;
-              ngpios = <8>;
-              pin-mask = <0x3f>;
-          };
+      /* sub-devices available at nodelabels:
+       * - ioex_it8801_port0
+       * - ioex_it8801_port1
+       * - ioex_it8801_port2
+       * - ioex_it8801_kbd
+       * - ioex_it8801_pwm
+       */
 
-          ioex_it8801_port2: it8801_port@2 {
-              compatible = "ite,it8801-gpio";
-              reg = <0x02 1   /* GPIPSR */
-                     0x07 1   /* GPSOVR */
-                     0x1a 8   /* GPCR */
-                     0x34 1   /* GPISR */
-                     0x39 1>; /* GPIER */
-              gpio-controller;
-              #gpio-cells = <2>;
-              ngpios = <8>;
-              pin-mask = <0x0f>;
-          };
+      &ioex_it8801_kbd {
+          kso-mapping = <0 1 20 3 4 5 6 17 18 16 15 11 12>;
+          mfdctrl = <&kso18_gp01_default &kso20_gp23_default>;
+          row-size = <8>;
+          col-size = <13>;
+      };
 
-          ioex_it8801_kbd: it8801_kbd@40 {
-              compatible = "ite,it8801-kbd";
-              reg = <0x40 1   /* KSOMCR */
-                     0x41 1   /* KSIDR */
-                     0x42 1   /* KSIEER */
-                     0x43 1>; /* KSIIER */
-              kso-mapping = <0 1 20 3 4 5 6
-                             17 18 16 15 11 12>;
-              mfdctrl = <&kso18_gp01_default
-                         &kso20_gp23_default>;
-              row-size = <8>;
-              col-size = <13>;
-
-              kscan_input: kscan-input {
-                  compatible = "zephyr,kscan-input";
-              };
-          };
-
-          ioex_it8801_pwm: it8801_pwm@90 {
-              compatible = "ite,it8801-pwm";
-              mfdctrl = <&pwm7_gp20_default>;
-              reg = <0x90 1   /* PWMMCR */
-                     0x94 1>; /* PWMDCR */
-              channel = <7>;
-              #pwm-cells = <3>;
-          };
+      &ioex_it8801_pwm {
+          status = "okay";
       };
   };
 

--- a/dts/riscv/ite/it8801-common-cfg.dtsi
+++ b/dts/riscv/ite/it8801-common-cfg.dtsi
@@ -6,149 +6,145 @@
 
 #include <ite/it8801-mfd-map.dtsi>
 
-&it8801_i2c {
-	it8801_mfd: it8801@38 {
-		compatible = "ite,it8801-mfd";
-		reg = <0x38>;
-		#address-cells = <1>;
-		#size-cells = <1>;
+&it8801_mfd {
+	#address-cells = <1>;
+	#size-cells = <1>;
 
-		/* GPIO */
-		ioex_it8801_port0: it8801_port@0 {
-			compatible = "ite,it8801-gpio";
-			reg = <0x00 1   /* GPIPSR */
-			       0x05 1   /* GPSOVR */
-			       0x0a 8   /* GPCR */
-			       0x32 1   /* GPISR */
-			       0x37 1>; /* GPIER */
-			gpio-controller;
-			#gpio-cells = <2>;
-			ngpios = <8>;
-			pin-mask = <0xdb>;
-		};
+	/* GPIO */
+	ioex_it8801_port0: it8801_port@0 {
+		compatible = "ite,it8801-gpio";
+		reg = <0x00 1   /* GPIPSR */
+		       0x05 1   /* GPSOVR */
+		       0x0a 8   /* GPCR */
+		       0x32 1   /* GPISR */
+		       0x37 1>; /* GPIER */
+		gpio-controller;
+		#gpio-cells = <2>;
+		ngpios = <8>;
+		pin-mask = <0xdb>;
+	};
 
-		ioex_it8801_port1: it8801_port@1 {
-			compatible = "ite,it8801-gpio";
-			reg = <0x01 1   /* GPIPSR */
-			       0x06 1   /* GPSOVR */
-			       0x12 6   /* GPCR */
-			       0x33 1   /* GPISR */
-			       0x38 1>; /* GPIER */
-			gpio-controller;
-			#gpio-cells = <2>;
-			ngpios = <6>;
-			pin-mask = <0x3f>;
-		};
+	ioex_it8801_port1: it8801_port@1 {
+		compatible = "ite,it8801-gpio";
+		reg = <0x01 1   /* GPIPSR */
+		       0x06 1   /* GPSOVR */
+		       0x12 6   /* GPCR */
+		       0x33 1   /* GPISR */
+		       0x38 1>; /* GPIER */
+		gpio-controller;
+		#gpio-cells = <2>;
+		ngpios = <6>;
+		pin-mask = <0x3f>;
+	};
 
-		ioex_it8801_port2: it8801_port@2 {
-			compatible = "ite,it8801-gpio";
-			reg = <0x02 1   /* GPIPSR */
-			       0x07 1   /* GPSOVR */
-			       0x1a 4   /* GPCR */
-			       0x34 1   /* GPISR */
-			       0x39 1>; /* GPIER */
-			gpio-controller;
-			#gpio-cells = <2>;
-			ngpios = <4>;
-			pin-mask = <0x0f>;
-		};
+	ioex_it8801_port2: it8801_port@2 {
+		compatible = "ite,it8801-gpio";
+		reg = <0x02 1   /* GPIPSR */
+		       0x07 1   /* GPSOVR */
+		       0x1a 4   /* GPCR */
+		       0x34 1   /* GPISR */
+		       0x39 1>; /* GPIER */
+		gpio-controller;
+		#gpio-cells = <2>;
+		ngpios = <4>;
+		pin-mask = <0x0f>;
+	};
 
-		/* KBD */
-		ioex_it8801_kbd: it8801_kbd@40 {
-			compatible = "ite,it8801-kbd";
-			status = "disabled";
-			reg = <0x40 1
-			       0x41 1
-			       0x42 1
-			       0x43 1>;
-			row-size = <8>;
-			col-size = <13>;
-		};
+	/* KBD */
+	ioex_it8801_kbd: it8801_kbd@40 {
+		compatible = "ite,it8801-kbd";
+		status = "disabled";
+		reg = <0x40 1
+		       0x41 1
+		       0x42 1
+		       0x43 1>;
+		row-size = <8>;
+		col-size = <13>;
+	};
 
-		/* PWM */
-		ioex_it8801_pwm1: it8801_pwm@60 {
-			compatible = "ite,it8801-pwm";
-			status = "disabled";
-			reg = <0x60 1   /* PWMMCR */
-			       0x64 1   /* PWMDCR */
-			       0x66 1   /* PWMPRSL */
-			       0x67 1>; /* PWMPRSM */
-			mfdctrl = <&pwm1_gp12_default>;
-			channel = <1>;
-			#pwm-cells = <3>;
-		};
+	/* PWM */
+	ioex_it8801_pwm1: it8801_pwm@60 {
+		compatible = "ite,it8801-pwm";
+		status = "disabled";
+		reg = <0x60 1   /* PWMMCR */
+		       0x64 1   /* PWMDCR */
+		       0x66 1   /* PWMPRSL */
+		       0x67 1>; /* PWMPRSM */
+		mfdctrl = <&pwm1_gp12_default>;
+		channel = <1>;
+		#pwm-cells = <3>;
+	};
 
-		ioex_it8801_pwm2: it8801_pwm@68 {
-			compatible = "ite,it8801-pwm";
-			status = "disabled";
-			reg = <0x68 1   /* PWMMCR */
-			       0x6c 1   /* PWMDCR */
-			       0x6e 1   /* PWMPRSL */
-			       0x6f 1>; /* PWMPRSM */
-			mfdctrl = <&pwm2_gp13_default>;
-			channel = <2>;
-			#pwm-cells = <3>;
-		};
+	ioex_it8801_pwm2: it8801_pwm@68 {
+		compatible = "ite,it8801-pwm";
+		status = "disabled";
+		reg = <0x68 1   /* PWMMCR */
+		       0x6c 1   /* PWMDCR */
+		       0x6e 1   /* PWMPRSL */
+		       0x6f 1>; /* PWMPRSM */
+		mfdctrl = <&pwm2_gp13_default>;
+		channel = <2>;
+		#pwm-cells = <3>;
+	};
 
-		ioex_it8801_pwm3: it8801_pwm@70 {
-			compatible = "ite,it8801-pwm";
-			status = "disabled";
-			reg = <0x70 1   /* PWMMCR */
-			       0x74 1   /* PWMDCR */
-			       0x76 1   /* PWMPRSL */
-			       0x77 1>; /* PWMPRSM */
-			mfdctrl = <&pwm3_gp14_default>;
-			channel = <3>;
-			#pwm-cells = <3>;
-		};
+	ioex_it8801_pwm3: it8801_pwm@70 {
+		compatible = "ite,it8801-pwm";
+		status = "disabled";
+		reg = <0x70 1   /* PWMMCR */
+		       0x74 1   /* PWMDCR */
+		       0x76 1   /* PWMPRSL */
+		       0x77 1>; /* PWMPRSM */
+		mfdctrl = <&pwm3_gp14_default>;
+		channel = <3>;
+		#pwm-cells = <3>;
+	};
 
-		ioex_it8801_pwm4: it8801_pwm@78 {
-			compatible = "ite,it8801-pwm";
-			status = "disabled";
-			reg = <0x78 1   /* PWMMCR */
-			       0x7c 1   /* PWMDCR */
-			       0x7e 1   /* PWMPRSL */
-			       0x7f 1>; /* PWMPRSM */
-			mfdctrl = <&pwm4_gp15_default>;
-			channel = <4>;
-			#pwm-cells = <3>;
-		};
+	ioex_it8801_pwm4: it8801_pwm@78 {
+		compatible = "ite,it8801-pwm";
+		status = "disabled";
+		reg = <0x78 1   /* PWMMCR */
+		       0x7c 1   /* PWMDCR */
+		       0x7e 1   /* PWMPRSL */
+		       0x7f 1>; /* PWMPRSM */
+		mfdctrl = <&pwm4_gp15_default>;
+		channel = <4>;
+		#pwm-cells = <3>;
+	};
 
-		ioex_it8801_pwm7: it8801_pwm@90 {
-			compatible = "ite,it8801-pwm";
-			status = "disabled";
-			reg = <0x90 1   /* PWMMCR */
-			       0x94 1   /* PWMDCR */
-			       0x96 1   /* PWMPRSL */
-			       0x97 1>; /* PWMPRSM */
-			mfdctrl = <&pwm7_gp20_default>;
-			channel = <7>;
-			#pwm-cells = <3>;
+	ioex_it8801_pwm7: it8801_pwm@90 {
+		compatible = "ite,it8801-pwm";
+		status = "disabled";
+		reg = <0x90 1   /* PWMMCR */
+		       0x94 1   /* PWMDCR */
+		       0x96 1   /* PWMPRSL */
+		       0x97 1>; /* PWMPRSM */
+		mfdctrl = <&pwm7_gp20_default>;
+		channel = <7>;
+		#pwm-cells = <3>;
 
-		};
+	};
 
-		ioex_it8801_pwm8: it8801_pwm@98 {
-			compatible = "ite,it8801-pwm";
-			status = "disabled";
-			reg = <0x98 1   /* PWMMCR */
-			       0x9c 1   /* PWMDCR */
-			       0x9e 1   /* PWMPRSL */
-			       0x9f 1>; /* PWMPRSM */
-			mfdctrl = <&pwm8_gp23_default>;
-			channel = <8>;
-			#pwm-cells = <3>;
-		};
+	ioex_it8801_pwm8: it8801_pwm@98 {
+		compatible = "ite,it8801-pwm";
+		status = "disabled";
+		reg = <0x98 1   /* PWMMCR */
+		       0x9c 1   /* PWMDCR */
+		       0x9e 1   /* PWMPRSL */
+		       0x9f 1>; /* PWMPRSM */
+		mfdctrl = <&pwm8_gp23_default>;
+		channel = <8>;
+		#pwm-cells = <3>;
+	};
 
-		ioex_it8801_pwm9: it8801_pwm@a0 {
-			compatible = "ite,it8801-pwm";
-			status = "disabled";
-			reg = <0xa0 1   /* PWMMCR */
-			       0xa4 1   /* PWMDCR */
-			       0xa6 1   /* PWMPRSL */
-			       0xa7 1>; /* PWMPRSM */
-			mfdctrl = <&pwm9_gp22_default>;
-			channel = <9>;
-			#pwm-cells = <3>;
-		};
+	ioex_it8801_pwm9: it8801_pwm@a0 {
+		compatible = "ite,it8801-pwm";
+		status = "disabled";
+		reg = <0xa0 1   /* PWMMCR */
+		       0xa4 1   /* PWMDCR */
+		       0xa6 1   /* PWMPRSL */
+		       0xa7 1>; /* PWMPRSM */
+		mfdctrl = <&pwm9_gp22_default>;
+		channel = <9>;
+		#pwm-cells = <3>;
 	};
 };

--- a/tests/drivers/build_all/gpio/it82xx2_evb.overlay
+++ b/tests/drivers/build_all/gpio/it82xx2_evb.overlay
@@ -4,12 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-it8801_i2c: &i2c4 {
+&i2c4 {
 	status = "okay";
+
+	it8801_mfd: it8801@38 {
+		compatible = "ite,it8801-mfd";
+		reg = <0x38>;
+		irq-gpios = <&gpioa 1 0>;
+	};
 };
 
 #include <ite/it8801-common-cfg.dtsi>
-
-&it8801_mfd {
-	irq-gpios = <&gpioa 1 0>;
-};

--- a/tests/drivers/build_all/input/it82xx2_evb.overlay
+++ b/tests/drivers/build_all/input/it82xx2_evb.overlay
@@ -6,25 +6,27 @@
 
 /delete-node/ &kbd;
 
-it8801_i2c: &i2c4 {
+&i2c4 {
 	status = "okay";
+
+	it8801_mfd: it8801@38 {
+		compatible = "ite,it8801-mfd";
+		reg = <0x38>;
+		irq-gpios = <&gpioa 1 0>;
+	};
 };
 
 #include <ite/it8801-common-cfg.dtsi>
 
-&it8801_mfd {
-	irq-gpios = <&gpioa 1 0>;
+&ioex_it8801_kbd {
+	status = "okay";
+	/* GP00, GP01, GP21, GP22, GP23 can be configured as alternate KSO pins */
+	mfdctrl = <&kso18_gp01_default &kso20_gp23_default>;
+	kso-mapping = <0 1 20 3 4 5 6 17 18 16 15 11 12>;
+	row-size = <8>;
+	col-size = <13>;
 
-	ioex_it8801_kbd: it8801_kbd@40  {
-		status = "okay";
-		/* GP00, GP01, GP21, GP22, GP23 can be configured as alternate KSO pins */
-		mfdctrl = <&kso18_gp01_default &kso20_gp23_default>;
-		kso-mapping = <0 1 20 3 4 5 6 17 18 16 15 11 12>;
-		row-size = <8>;
-		col-size = <13>;
-
-		kscan_input: kscan-input {
-			compatible = "zephyr,kscan-input";
-		};
+	kscan_input: kscan-input {
+		compatible = "zephyr,kscan-input";
 	};
 };

--- a/tests/drivers/build_all/pwm/boards/it82xx2_evb.overlay
+++ b/tests/drivers/build_all/pwm/boards/it82xx2_evb.overlay
@@ -10,16 +10,18 @@
 	};
 };
 
-it8801_i2c: &i2c4 {
+&i2c4 {
 	status = "okay";
+
+	it8801_mfd: it8801@38 {
+		compatible = "ite,it8801-mfd";
+		reg = <0x38>;
+		irq-gpios = <&gpioa 1 0>;
+	};
 };
 
 #include <ite/it8801-common-cfg.dtsi>
 
-&it8801_mfd {
-	irq-gpios = <&gpioa 1 0>;
-
-	ioex_it8801_pwm7: it8801_pwm@90 {
-		status = "okay";
-	};
+&ioex_it8801_pwm7 {
+	status = "okay";
 };


### PR DESCRIPTION
The it8801 template is helpful but in the current state it does not allow changing the device address as that is in the template itself. Fix that by moving the template content down a level in the hierarchy, so that it extends the mfd device itself rather than than instantiate it, then the base instance can have any address, now the only limitation is that only one instance is possible, but that is probably alright for now.

Alternatives would be to use a define for the address, or even a template per address, but this feels like a better compromise for now. This may also use
https://github.com/zephyrproject-rtos/zephyr/pull/82825 in the future if that ever becomes a thing.