### PR TITLE
native_simulator: ensure nsi_host_random() returns 64 bits of randomness

### DIFF
--- a/scripts/native_simulator/common/src/nsi_host_trampolines.c
+++ b/scripts/native_simulator/common/src/nsi_host_trampolines.c
@@ -48,7 +48,14 @@ int nsi_host_open(const char *pathname, int flags)
 
 long nsi_host_random(void)
 {
-	return random();
+	long ret = 0;
+	size_t bits = 8 * sizeof(ret);
+
+	/* Each call to random() returns 31 bits of randomness. */
+	for (size_t shift = 0; shift < bits; shift += 31) {
+		ret |= random() << shift;
+	}
+	return ret;
 }
 
 long nsi_host_read(int fd, void *buffer, unsigned long size)


### PR DESCRIPTION
With native_sim/native/64, nsi_host_random() was only populating 31 of the 64 bits due to the 31-bit limit of the random() function.

To reproduce issue:

```
CONFIG_LOG=y
CONFIG_ENTROPY_GENERATOR=y
CONFIG_FAKE_ENTROPY_NATIVE_POSIX=y
```

```
#include <zephyr/logging/log.h>
#include <zephyr/random/random.h>

LOG_MODULE_REGISTER(hello);

int main(void) {
	uint8_t test[128];
	sys_csrand_get(test, sizeof(test));
	LOG_HEXDUMP_INF(test, sizeof(test), "test");
	return 0;
}
```

Output:

```
[00:00:00.000,000] <inf> hello: test
                                3b db 31 0f 00 00 00 00  cc b6 d5 47 00 00 00 00 |;.1..... ...G....
                                08 aa d2 15 00 00 00 00  e1 be 87 53 00 00 00 00 |........ ...S....
                                e4 7b 88 04 00 00 00 00  ae b1 9d 5f 00 00 00 00 |.{...... ..._....
                                e6 88 9e 4d 00 00 00 00  fb 2d 97 15 00 00 00 00 |...M.... .-......
                                50 16 f7 13 00 00 00 00  28 31 2f 70 00 00 00 00 |P....... (1/p....
                                c0 e6 44 39 00 00 00 00  e9 be 5f 25 00 00 00 00 |..D9.... .._%....
                                36 dc af 46 00 00 00 00  ef 48 d1 72 00 00 00 00 |6..F.... .H.r....
                                ed 48 03 3a 00 00 00 00  6d aa 0f 7e 00 00 00 00 |.H.:.... m..~....
```