### PR TITLE
tests: Bluetooth: BAP: Fix test wrt stream args to broadcast_source

### DIFF
--- a/tests/bsim/bluetooth/audio/src/bap_broadcast_sink_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_broadcast_sink_test.c
@@ -1088,8 +1088,8 @@ static void test_sink_encrypted_incorrect_code(void)
 	test_broadcast_sync(BROADCAST_CODE);
 
 	/* Wait for all to be started */
-	printk("Waiting for streams to be started\n");
-	for (size_t i = 0U; i < ARRAY_SIZE(streams); i++) {
+	printk("Waiting for %zu streams to be started\n", stream_sync_cnt);
+	for (size_t i = 0U; i < stream_sync_cnt; i++) {
 		k_sem_take(&sem_stream_started, K_FOREVER);
 	}
 


### PR DESCRIPTION
Due to adding subgroup count and streams per subgroup arguments to the broadcast_source test, fix the sink test that was not ported due t being merged for change in a different PR.

Relates to commit 01e8d0e3e08d ("tests: Bluetooth: BAP: Add subgroup and stream args to broadcast_source").

Fixes commit 303d0b786f49 ("tests: Bluetooth: BAP: Add test to test invalid bcode").

Fixes build failure in main branch causes PRs to fail CI, example: https://github.com/zephyrproject-rtos/zephyr/actions/runs/12524543984/job/34935185858?pr=78741