### PR TITLE
dts: risc-v: nordic: nrf54h20_cpuppr: fix cpuflpr_vevif label assignment

### DIFF
--- a/dts/riscv/nordic/nrf54h20_cpuppr.dtsi
+++ b/dts/riscv/nordic/nrf54h20_cpuppr.dtsi
@@ -9,7 +9,7 @@
 cpu: &cpuppr {};
 clic: &cpuppr_clic {};
 cpuppr_vevif: &cpuppr_vevif_rx {};
-cpuflpr_vevif: &cpuppr_vevif_tx {};
+cpuflpr_vevif: &cpuflpr_vevif_tx {};
 cpusys_vevif: &cpusys_vevif_tx {};
 
 /delete-node/ &cpuapp;


### PR DESCRIPTION
Fixes misassignment of cpuflpr_vevif label to cpuppr_vevif_tx node by
instead assigning to cpuflpr_vevif_tx node.