### PR TITLE
doc: build: dts: Fix incorrect foreach documentation descriptions

### DIFF
--- a/doc/build/dts/api/api.rst
+++ b/doc/build/dts/api/api.rst
@@ -104,12 +104,10 @@ does not apply to macros which take cell names as arguments.
 For-each macros
 ===============
 
-The :c:macro:`DT_FOREACH_CHILD` macro allows iterating over the ancestor node
+The :c:macro:`DT_FOREACH_ANCESTOR` macro allows iterating over the ancestor node
 of a devicetree node.
-
-There is currently only one "generic" for-each macro,
-:c:macro:`DT_FOREACH_CHILD`, which allows iterating over the children of a
-devicetree node.
+Additionally, the :c:macro:`DT_FOREACH_CHILD` macro allows iterating over the
+children of a devicetree node.
 
 There are special-purpose for-each macros, like
 :c:macro:`DT_INST_FOREACH_STATUS_OKAY`, but these require ``DT_DRV_COMPAT`` to


### PR DESCRIPTION
Replaced incorrect rst link references in the description of traversing ancestor nodes, along with some conflicting descriptions.