### PR TITLE
boards: nxp: imx8mm/n/p imx93/95: enable GIC safe config

### DIFF
--- a/soc/nxp/imx/imx8m/Kconfig.defconfig.mimx8ml8_a53
+++ b/soc/nxp/imx/imx8m/Kconfig.defconfig.mimx8ml8_a53
@@ -12,6 +12,10 @@ config FLASH_SIZE
 config FLASH_BASE_ADDRESS
 	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_FLASH))
 
+# Enable GIC Safe Configuration to run multiple OSes on Cortex-A Cores
+config GIC_SAFE_CONFIG
+	default y
+
 config NUM_IRQS
 	default 240
 

--- a/soc/nxp/imx/imx8m/Kconfig.defconfig.mimx8mm6_a53
+++ b/soc/nxp/imx/imx8m/Kconfig.defconfig.mimx8mm6_a53
@@ -12,6 +12,10 @@ config FLASH_SIZE
 config FLASH_BASE_ADDRESS
 	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_FLASH))
 
+# Enable GIC Safe Configuration to run multiple OSes on Cortex-A Cores
+config GIC_SAFE_CONFIG
+	default y
+
 config NUM_IRQS
 	default 240
 

--- a/soc/nxp/imx/imx8m/Kconfig.defconfig.mimx8mn6_a53
+++ b/soc/nxp/imx/imx8m/Kconfig.defconfig.mimx8mn6_a53
@@ -12,6 +12,10 @@ config FLASH_SIZE
 config FLASH_BASE_ADDRESS
 	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_FLASH))
 
+# Enable GIC Safe Configuration to run multiple OSes on Cortex-A Cores
+config GIC_SAFE_CONFIG
+	default y
+
 config NUM_IRQS
 	default 240
 

--- a/soc/nxp/imx/imx9/imx93/Kconfig.defconfig.mimx93.a55
+++ b/soc/nxp/imx/imx9/imx93/Kconfig.defconfig.mimx93.a55
@@ -12,6 +12,10 @@ config FLASH_SIZE
 config FLASH_BASE_ADDRESS
 	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_FLASH))
 
+# Enable GIC Safe Configuration to run multiple OSes on Cortex-A Cores
+config GIC_SAFE_CONFIG
+	default y
+
 config NUM_IRQS
 	default 240
 

--- a/soc/nxp/imx/imx9/imx95/Kconfig.defconfig.mimx95.a55
+++ b/soc/nxp/imx/imx9/imx95/Kconfig.defconfig.mimx95.a55
@@ -12,6 +12,10 @@ config FLASH_SIZE
 config FLASH_BASE_ADDRESS
 	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_FLASH))
 
+# Enable GIC Safe Configuration to run multiple OSes on Cortex-A Cores
+config GIC_SAFE_CONFIG
+	default y
+
 config NUM_IRQS
 	default 320
 


### PR DESCRIPTION
Enable CONFIG_GIC_SAFE_CONFIG by default for Cortex-A Core platforms by default as the most target is to run multiple OSes together with Zephyr.