### PR TITLE
Siliconlabs HCI driver improvements

### DIFF
--- a/drivers/bluetooth/hci/Kconfig
+++ b/drivers/bluetooth/hci/Kconfig
@@ -116,7 +116,7 @@ config BT_STM32WB0
 	  ST STM32WB0 HCI Bluetooth interface
 
 config BT_SILABS_EFR32
-	bool
+	bool "Silabs EFR32 HCI driver"
 	default y
 	depends on DT_HAS_SILABS_BT_HCI_EFR32_ENABLED
 	depends on ZEPHYR_HAL_SILABS_MODULE_BLOBS || BUILD_ONLY_NO_BLOBS
@@ -136,6 +136,7 @@ config BT_SILABS_EFR32
 	help
 	  Use Silicon Labs binary Bluetooth library to connect to the
 	  controller.
+source "drivers/bluetooth/hci/Kconfig.silabs"
 
 config BT_USERCHAN
 	bool
@@ -296,14 +297,6 @@ config BT_DRV_RX_STACK_SIZE
 	default 256
 	help
 	  Stack size for the HCI driver's RX thread.
-
-config BT_SILABS_EFR32_BUFFER_MEMORY
-	int "Silicon Labs Bluetooth Library memory buffer size"
-	depends on BT_SILABS_EFR32
-	default 6144
-	help
-	  Select the size of allocated memory buffer for the Silicon Labs
-	  Bluetooth Library.
 
 config BT_H4_NXP_CTLR
 	bool "NXP Bluetooth Controller"

--- a/drivers/bluetooth/hci/Kconfig.silabs
+++ b/drivers/bluetooth/hci/Kconfig.silabs
@@ -14,7 +14,7 @@ config BT_SILABS_EFR32_BUFFER_MEMORY
 
 config BT_SILABS_EFR32_USER_ADVERTISERS
 	int "User advertisement sets"
-	default 0
+	default 1
 	help
 	  Amount of advertisement sets reserved for application.
 

--- a/drivers/bluetooth/hci/Kconfig.silabs
+++ b/drivers/bluetooth/hci/Kconfig.silabs
@@ -1,0 +1,44 @@
+# Copyright (c) 2025 Silicon Laboratories Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+menu "EFR32 Bluetooth Controller Configuration"
+	depends on BT_SILABS_EFR32
+
+config BT_SILABS_EFR32_BUFFER_MEMORY
+	int "Memory buffer size"
+	default 6144
+	help
+	  Select the size of allocated memory buffer for the Silicon Labs
+	  Bluetooth Library. If set too low the capacity of the link layer may
+	  suffer.
+
+config BT_SILABS_EFR32_USER_ADVERTISERS
+	int "User advertisement sets"
+	default 0
+	help
+	  Amount of advertisement sets reserved for application.
+
+config BT_SILABS_EFR32_ACCEPT_LIST_SIZE
+	int "Accept list size"
+	default 1
+	help
+	  Accept list size.
+
+config BT_SILABS_EFR32_COMPLETED_PACKETS_THRESHOLD
+	int "Completed packet reporting threshold"
+	default 1
+	help
+	  Completed packet reporting threshold value.
+
+config BT_SILABS_EFR32_COMPLETED_PACKETS_TIMEOUT
+	int "Completed packet report event timeout"
+	default 3
+	help
+	  Completed packet report event timeout.
+
+config BT_SILABS_EFR32_ACCEPT_LINK_LAYER_STACK_SIZE
+	int "Link layer stack size"
+	default 1024
+	help
+	  Link layer stack size.
+endmenu

--- a/drivers/bluetooth/hci/hci_silabs_efr32.c
+++ b/drivers/bluetooth/hci/hci_silabs_efr32.c
@@ -32,9 +32,6 @@ struct hci_data {
 #else
 #define CTLR_RL_SIZE 0
 #endif
-#if !defined(CONFIG_BT_CTLR_RL_SIZE)
-#define CONFIG_BT_CTLR_RL_SIZE 0
-#endif
 
 static K_KERNEL_STACK_DEFINE(slz_ll_stack, CONFIG_BT_SILABS_EFR32_ACCEPT_LINK_LAYER_STACK_SIZE);
 static struct k_thread slz_ll_thread;
@@ -197,47 +194,31 @@ static int slz_bt_open(const struct device *dev, bt_hci_recv_t recv)
 		goto deinit;
 	}
 
-	if (IS_ENABLED(CONFIG_BT_BROADCASTER) || IS_ENABLED(CONFIG_BT_PERIPHERAL)) {
-		sl_btctrl_init_adv();
-	}
-	if (IS_ENABLED(CONFIG_BT_CENTRAL) || IS_ENABLED(CONFIG_BT_OBSERVER)) {
-		sl_btctrl_init_scan();
-	}
-	if (IS_ENABLED(CONFIG_BT_CONN)) {
-		sl_btctrl_init_conn();
-	}
+	sl_btctrl_init_adv();
+	sl_btctrl_init_scan();
+	sl_btctrl_init_conn();
 	sl_btctrl_init_phy();
 
 	if (IS_ENABLED(CONFIG_BT_EXT_ADV)) {
-		if (IS_ENABLED(CONFIG_BT_BROADCASTER) || IS_ENABLED(CONFIG_BT_PERIPHERAL)) {
-			sl_btctrl_init_adv_ext();
-		}
-		if (IS_ENABLED(CONFIG_BT_CENTRAL) || IS_ENABLED(CONFIG_BT_OBSERVER)) {
-			sl_btctrl_init_scan_ext();
-		}
+		sl_btctrl_init_adv_ext();
+		sl_btctrl_init_scan_ext();
 	}
 
-	ret = sl_btctrl_init_basic(MAX_CONN, CONFIG_BT_SILABS_EFR32_USER_ADVERTISERS,
+	ret = sl_btctrl_init_basic(MAX_CONN, CONFIG_BT_SILABS_EFR32_USER_ADVERTISERS + MAX_CONN,
 				   CONFIG_BT_SILABS_EFR32_ACCEPT_LIST_SIZE);
 	if (ret) {
 		LOG_ERR("Failed to initialize the controller %d", ret);
 		goto deinit;
 	}
 
-	if (IS_ENABLED(CONFIG_BT_CONN)) {
-		sl_btctrl_configure_completed_packets_reporting(
-			CONFIG_BT_SILABS_EFR32_COMPLETED_PACKETS_THRESHOLD,
-			CONFIG_BT_SILABS_EFR32_COMPLETED_PACKETS_TIMEOUT);
-	}
+	sl_btctrl_configure_completed_packets_reporting(
+		CONFIG_BT_SILABS_EFR32_COMPLETED_PACKETS_THRESHOLD,
+		CONFIG_BT_SILABS_EFR32_COMPLETED_PACKETS_TIMEOUT);
 
 	sl_bthci_init_upper();
 	sl_btctrl_hci_parser_init_default();
-	if (IS_ENABLED(CONFIG_BT_CONN)) {
-		sl_btctrl_hci_parser_init_conn();
-	}
-	if (IS_ENABLED(CONFIG_BT_BROADCASTER) || IS_ENABLED(CONFIG_BT_PERIPHERAL)) {
-		sl_btctrl_hci_parser_init_adv();
-	}
+	sl_btctrl_hci_parser_init_conn();
+	sl_btctrl_hci_parser_init_adv();
 	sl_btctrl_hci_parser_init_phy();
 
 	if (IS_ENABLED(CONFIG_PM)) {

--- a/drivers/bluetooth/hci/hci_silabs_efr32.c
+++ b/drivers/bluetooth/hci/hci_silabs_efr32.c
@@ -32,6 +32,9 @@ struct hci_data {
 #else
 #define CTLR_RL_SIZE 0
 #endif
+#if !defined(CONFIG_BT_CTLR_RL_SIZE)
+#define CONFIG_BT_CTLR_RL_SIZE 0
+#endif
 
 static K_KERNEL_STACK_DEFINE(slz_ll_stack, CONFIG_BT_SILABS_EFR32_ACCEPT_LINK_LAYER_STACK_SIZE);
 static struct k_thread slz_ll_thread;
@@ -247,6 +250,10 @@ static int slz_bt_open(const struct device *dev, bt_hci_recv_t recv)
 			ret = -EIO;
 			goto deinit;
 		}
+	}
+
+	if (IS_ENABLED(CONFIG_BT_CTLR_PRIVACY)) {
+		sl_btctrl_hci_parser_init_privacy();
 	}
 
 	hci->recv = recv;


### PR DESCRIPTION
- Move Siliconlabs specific HCI Kconfigs to own file.
- use proper macros for enabling features
- add support for controller privacy to enable PTS test runs