### PR TITLE
mgmt: mcumgr: grp: os_mgmt: Add error code for invalid responses

### DIFF
--- a/include/zephyr/mgmt/mcumgr/grp/os_mgmt/os_mgmt.h
+++ b/include/zephyr/mgmt/mcumgr/grp/os_mgmt/os_mgmt.h
@@ -47,6 +47,9 @@ enum os_mgmt_err_code_t {
 
 	/** RTC command failed */
 	OS_MGMT_ERR_RTC_COMMAND_FAILED,
+
+	/** Query was recognized but there is no valid value for the response. */
+	OS_MGMT_ERR_QUERY_RESPONSE_VALUE_NOT_VALID,
 };
 
 /* Bitmask values used by the os info command handler. Note that the width of this variable is

--- a/subsys/mgmt/mcumgr/grp/os_mgmt/src/os_mgmt.c
+++ b/subsys/mgmt/mcumgr/grp/os_mgmt/src/os_mgmt.c
@@ -1053,6 +1053,7 @@ static int os_mgmt_translate_error_code(uint16_t err)
 
 	case OS_MGMT_ERR_QUERY_YIELDS_NO_ANSWER:
 	case OS_MGMT_ERR_RTC_NOT_SET:
+	case OS_MGMT_ERR_QUERY_RESPONSE_VALUE_NOT_VALID:
 		rc = MGMT_ERR_ENOENT;
 		break;
 


### PR DESCRIPTION
Adds a new error code that can be used to signify that a query was valid but the response was not valid