### PR TITLE
drivers: entropy: fix native_posix driver for more than 3 byte requests

### DIFF
--- a/drivers/entropy/fake_entropy_native_posix.c
+++ b/drivers/entropy/fake_entropy_native_posix.c
@@ -42,7 +42,10 @@ static int entropy_native_posix_get_entropy(const struct device *dev,
 		 */
 		long value = nsi_host_random();
 
-		size_t to_copy = MIN(length, sizeof(long int));
+		/* The host random() provides a number between 0 and 2**31-1. Bit 32 is always 0.
+		 * So let's just use the lower 3 bytes discarding the upper 7 bits
+		 */
+		size_t to_copy = MIN(length, 3);
 
 		memcpy(buffer, &value, to_copy);
 		buffer += to_copy;

--- a/tests/subsys/lorawan/frag_decoder/testcase.yaml
+++ b/tests/subsys/lorawan/frag_decoder/testcase.yaml
@@ -7,6 +7,7 @@ tests:
       - native_sim
     extra_configs:
       - CONFIG_LORAWAN_FRAG_TRANSPORT_DECODER_SEMTECH=y
+      - CONFIG_NATIVE_EXTRA_CMDLINE_ARGS="seed=1"
   lorawan.frag_decoder.lowmem.high_redundancy:
     platform_allow:
       - native_sim
@@ -19,3 +20,4 @@ tests:
     extra_configs:
       - CONFIG_LORAWAN_FRAG_TRANSPORT_DECODER_LOWMEM=y
       - CONFIG_LORAWAN_FRAG_TRANSPORT_MAX_REDUNDANCY=10
+      - CONFIG_NATIVE_EXTRA_CMDLINE_ARGS="seed=1"


### PR DESCRIPTION
Fix the native_posix fake entropy driver for more than 3 byte requests, and specially for native_sim//64 builds.

The host random() provides a number between 0 and 2**31-1 (INT_MAX), so bit 32 was always 0.
So when filling a buffer with more than 3 bytes we would be filling each 4th byte with a byte which always had its MSbit as 0.

For LP64 native_sim//64 builds, this was even worse, as the driver had another bug where we assumed random() returned the whole long filled, and therefore all 4 upper bytes would be 0.

Fixes #83447