### PR TITLE
drivers: ieee802154: unify FCS configuration in L2 packet

### DIFF
--- a/drivers/ieee802154/Kconfig
+++ b/drivers/ieee802154/Kconfig
@@ -60,6 +60,14 @@ config IEEE802154_VENDOR_OUI
 
 endif # IEEE802154_VENDOR_OUI_ENABLE
 
+config IEEE802154_L2_PKT_INCL_FCS
+	bool "Include FCS field in the L2 packet"
+	default y if IEEE802154_RAW_MODE || NET_L2_OPENTHREAD
+	help
+	  Some 802.15.4 L2 implementations expect FCS to be included in the
+	  packet, while others do not. Allow to configure this behavior based
+	  on the upper layer selected.
+
 source "drivers/ieee802154/Kconfig.b91"
 
 source "drivers/ieee802154/Kconfig.cc2520"

--- a/drivers/ieee802154/Kconfig.nrf5
+++ b/drivers/ieee802154/Kconfig.nrf5
@@ -62,14 +62,6 @@ config IEEE802154_NRF5_UICR_EUI64_REG
 
 endif # IEEE802154_NRF5_UICR_EUI64_ENABLE
 
-config IEEE802154_NRF5_FCS_IN_LENGTH
-	bool "Include FCS field in the overall packet length"
-	default y if IEEE802154_RAW_MODE || NET_L2_OPENTHREAD
-	help
-	  Some 802.15.4 L2 implementations expect that FCS length is included in
-	  the overall packet length while others not. Allow to configure this
-	  behavior, based on the selected upper layer.
-
 config IEEE802154_NRF5_DELAY_TRX_ACC
 	int "Clock accuracy for delayed operations"
 	default CLOCK_CONTROL_NRF_ACCURACY if (CLOCK_CONTROL_NRF && (CLOCK_CONTROL_NRF_ACCURACY < $(UINT8_MAX)))

--- a/drivers/ieee802154/ieee802154_b91.c
+++ b/drivers/ieee802154/ieee802154_b91.c
@@ -272,8 +272,7 @@ static void b91_rf_rx_isr(void)
 	/* check CRC */
 	if (rf_zigbee_packet_crc_ok(data.rx_buffer)) {
 		/* get payload length */
-		if (IS_ENABLED(CONFIG_IEEE802154_RAW_MODE) ||
-		    IS_ENABLED(CONFIG_NET_L2_OPENTHREAD)) {
+		if (IS_ENABLED(CONFIG_IEEE802154_L2_PKT_INCL_FCS)) {
 			length = data.rx_buffer[B91_LENGTH_OFFSET];
 		} else {
 			length = data.rx_buffer[B91_LENGTH_OFFSET] - B91_FCS_LENGTH;

--- a/drivers/ieee802154/ieee802154_cc13xx_cc26xx.c
+++ b/drivers/ieee802154/ieee802154_cc13xx_cc26xx.c
@@ -413,10 +413,7 @@ static void ieee802154_cc13xx_cc26xx_rx_done(
 			corr = drv_data->rx_data[i][len--] & 0x3F;
 			rssi = drv_data->rx_data[i][len--];
 
-			/* remove fcs as it is not expected by L2
-			 * But keep it for RAW mode
-			 */
-			if (IS_ENABLED(CONFIG_NET_L2_IEEE802154)) {
+			if (!IS_ENABLED(CONFIG_IEEE802154_L2_PKT_INCL_FCS)) {
 				len -= 2;
 			}
 

--- a/drivers/ieee802154/ieee802154_cc13xx_cc26xx_subg.c
+++ b/drivers/ieee802154/ieee802154_cc13xx_cc26xx_subg.c
@@ -340,8 +340,7 @@ static void drv_rx_done(struct ieee802154_cc13xx_cc26xx_subg_data *drv_data)
 			status = drv_data->rx_data[i][len--];
 			rssi = drv_data->rx_data[i][len--];
 
-			/* TODO: Configure firmware to include CRC in raw mode. */
-			if (IS_ENABLED(CONFIG_IEEE802154_RAW_MODE) && len > 0) {
+			if (IS_ENABLED(CONFIG_IEEE802154_L2_PKT_INCL_FCS) && len > 0) {
 				/* append CRC-16/CCITT */
 				uint16_t crc = 0;
 

--- a/drivers/ieee802154/ieee802154_cc2520.c
+++ b/drivers/ieee802154/ieee802154_cc2520.c
@@ -624,7 +624,7 @@ static void cc2520_rx(void *p1, void *p2, void *p3)
 			goto flush;
 		}
 
-		if (!IS_ENABLED(CONFIG_IEEE802154_RAW_MODE)) {
+		if (!IS_ENABLED(CONFIG_IEEE802154_L2_PKT_INCL_FCS)) {
 			pkt_len -= 2U;
 		}
 

--- a/drivers/ieee802154/ieee802154_dw1000.c
+++ b/drivers/ieee802154/ieee802154_dw1000.c
@@ -416,7 +416,7 @@ static inline void dwt_irq_handle_rx(const struct device *dev, uint32_t sys_stat
 	rx_pacc = (rx_finfo & DWT_RX_FINFO_RXPACC_MASK) >>
 		   DWT_RX_FINFO_RXPACC_SHIFT;
 
-	if (!(IS_ENABLED(CONFIG_IEEE802154_RAW_MODE))) {
+	if (!IS_ENABLED(CONFIG_IEEE802154_L2_PKT_INCL_FCS)) {
 		pkt_len -= DWT_FCS_LENGTH;
 	}
 

--- a/drivers/ieee802154/ieee802154_nrf5.c
+++ b/drivers/ieee802154/ieee802154_nrf5.c
@@ -172,7 +172,7 @@ static void nrf5_rx_thread(void *arg1, void *arg2, void *arg3)
 		 * The last 2 bytes contain LQI or FCS, depending if
 		 * automatic CRC handling is enabled or not, respectively.
 		 */
-		if (IS_ENABLED(CONFIG_IEEE802154_NRF5_FCS_IN_LENGTH)) {
+		if (IS_ENABLED(CONFIG_IEEE802154_L2_PKT_INCL_FCS)) {
 			pkt_len = rx_frame->psdu[0];
 		} else {
 			pkt_len = rx_frame->psdu[0] -  IEEE802154_FCS_LENGTH;
@@ -419,7 +419,7 @@ static int handle_ack(struct nrf5_802154_data *nrf5_radio)
 	}
 #endif
 
-	if (IS_ENABLED(CONFIG_IEEE802154_NRF5_FCS_IN_LENGTH)) {
+	if (IS_ENABLED(CONFIG_IEEE802154_L2_PKT_INCL_FCS)) {
 		ack_len = nrf5_radio->ack_frame.psdu[0];
 	} else {
 		ack_len = nrf5_radio->ack_frame.psdu[0] - IEEE802154_FCS_LENGTH;

--- a/drivers/ieee802154/ieee802154_rf2xx.c
+++ b/drivers/ieee802154/ieee802154_rf2xx.c
@@ -208,9 +208,7 @@ static void rf2xx_trx_rx(const struct device *dev)
 		return;
 	}
 
-	if (!IS_ENABLED(CONFIG_IEEE802154_RAW_MODE) &&
-	    !IS_ENABLED(CONFIG_NET_L2_OPENTHREAD) &&
-	    pkt_len >= RX2XX_FRAME_FCS_LENGTH) {
+	if (!IS_ENABLED(CONFIG_IEEE802154_L2_PKT_INCL_FCS) && pkt_len >= RX2XX_FRAME_FCS_LENGTH) {
 		pkt_len -= RX2XX_FRAME_FCS_LENGTH;
 	}
 


### PR DESCRIPTION
Use the same Kconfig for all drivers to configure if the FCS bytes (checksum) should be included in the packets passed to L2.

The description is slightly reworded to make clear that it does not only affect the length, but the packet content itself.