### PR TITLE
drivers: ieee802154: b91: fix status variable type in RX ISR

### DIFF
--- a/drivers/ieee802154/ieee802154_b91.c
+++ b/drivers/ieee802154/ieee802154_b91.c
@@ -260,7 +260,7 @@ static void b91_send_ack(uint8_t seq_num)
 /* RX IRQ handler */
 static void b91_rf_rx_isr(void)
 {
-	uint8_t status;
+	int status;
 	uint8_t length;
 	uint8_t *payload;
 	struct net_pkt *pkt;


### PR DESCRIPTION
The status variable stores the return value of `net_recv_data`, which is an `int` and may be negative.