### PR TITLE
bluetooth: tester: Add TBS btp command

### DIFF
--- a/tests/bluetooth/tester/src/audio/btp/btp_tbs.h
+++ b/tests/bluetooth/tester/src/audio/btp/btp_tbs.h
@@ -71,3 +71,8 @@ struct btp_tbs_set_signal_strength_cmd {
 	uint8_t index;
 	uint8_t strength;
 } __packed;
+
+#define BTP_TBS_TERMINATE_CALL			0x0b
+struct btp_tbs_terminate_call_cmd {
+	uint8_t index;
+} __packed;


### PR DESCRIPTION
Adding TBS Terminate Call command - for some reason this was used in auto-pts but wasn't implemented here. This is needed for TMAP tests.