### PR TITLE
edtlib: amend PropertySpec.path API documentation

### DIFF
--- a/scripts/dts/python-devicetree/src/devicetree/edtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/edtlib.py
@@ -485,7 +485,9 @@ class PropertySpec:
 
     path:
       The file where this property was defined. In case a binding includes
-      other bindings, this is the file where the property was last modified.
+      other bindings, this is the including binding file.
+      Generally this means that this will be the binding file specifying
+      the devicetree node of which this is a property.
 
     type:
       The type of the property as a string, as given in the binding.

--- a/scripts/dts/python-devicetree/src/devicetree/edtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/edtlib.py
@@ -948,8 +948,9 @@ class Node:
 
     props:
       A dict that maps property names to Property objects.
-      Property objects are created for all devicetree properties on the node
-      that are mentioned in 'properties:' in the binding.
+      Property objects are created for the devicetree properties
+      defined by the node's binding and that have a default value
+      or for which a value is set in the DTS.
 
     aliases:
       A list of aliases for the node. This is fetched from the /aliases node.


### PR DESCRIPTION
`PropertySpec.path` does not tell "the file where the property was last modified", but instead the binding file specifying the devicetree node of which this is a property.

This is a known issue (#65135), which we thought was fixed (#65221). The solution turned out to be incorrect, and we reverted the patch (#80030). 

This PR aims to definitively close #65135 by simply amending the API documentation: `edtlib: amend PropertySpec.path API documentation`.

While writing this PR, I came across another wording that I found confusing (class `edtlib.Node`):
```
    props:
      A dict that maps property names to Property objects.
      Property objects are created for all devicetree properties on the node
      that are mentioned in 'properties:' in the binding.
```

AFAICT, assuming that "mentioned in 'properties:' in the binding" refers to properties whose specification we find in `Node._binding.prop2specs`, node properties are created only for those that actually have a value (a default value from the binding, or an explicit value from the DTS).
And usually a node has fewer properties than its binding defines (*supports*), literally `len(node._binding.prop2specs) > len(node.props)`.
If the above reasoning is correct, then the API documentation seems confusing to me: the additional commit, `edtlib: amend Node.props API documentation`, is about that.

Thanks

Fixes #65135.