### PR TITLE
NXP mimxrt595_evk: configure DMA requests in INPUTMUX 

### DIFF
--- a/boards/nxp/mimxrt595_evk/board.c
+++ b/boards/nxp/mimxrt595_evk/board.c
@@ -5,6 +5,7 @@
 
 #include <zephyr/init.h>
 #include "fsl_power.h"
+#include "fsl_inputmux.h"
 #include <zephyr/pm/policy.h>
 #include "board.h"
 
@@ -306,6 +307,52 @@ static int mimxrt595_evk_init(void)
 #endif /* CONFIG_I2S_TEST_SEPARATE_DEVICES */
 #endif /* CONFIG_I2S */
 
+	/* Configure the DMA requests in the INPUTMUX */
+	INPUTMUX_Init(INPUTMUX);
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(dma0))
+	/* Enable the DMA requests with only 1 mux option.  The other request
+	 * choices should be configured for the application
+	 */
+	INPUTMUX_EnableSignal(INPUTMUX,
+			kINPUTMUX_Flexcomm11RxToDmac0Ch32RequestEna, true);
+	INPUTMUX_EnableSignal(INPUTMUX,
+			kINPUTMUX_Flexcomm11TxToDmac0Ch33RequestEna, true);
+	INPUTMUX_EnableSignal(INPUTMUX,
+			kINPUTMUX_Flexcomm12RxToDmac0Ch34RequestEna, true);
+	INPUTMUX_EnableSignal(INPUTMUX,
+			kINPUTMUX_Flexcomm12TxToDmac0Ch35RequestEna, true);
+	INPUTMUX_EnableSignal(INPUTMUX,
+			kINPUTMUX_Flexcomm16RxToDmac0Ch28RequestEna, true);
+	INPUTMUX_EnableSignal(INPUTMUX,
+			kINPUTMUX_Flexcomm16TxToDmac0Ch29RequestEna, true);
+	INPUTMUX_EnableSignal(INPUTMUX,
+			kINPUTMUX_I3c1RxToDmac0Ch30RequestEna, true);
+	INPUTMUX_EnableSignal(INPUTMUX,
+			kINPUTMUX_I3c1TxToDmac0Ch31RequestEna, true);
+#endif /* dma0 */
+
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(dma1))
+	/* Enable the DMA requests with only 1 mux option.  The other request
+	 * choices should be configured for the application
+	 */
+	INPUTMUX_EnableSignal(INPUTMUX,
+			kINPUTMUX_Flexcomm11RxToDmac1Ch32RequestEna, true);
+	INPUTMUX_EnableSignal(INPUTMUX,
+			kINPUTMUX_Flexcomm11TxToDmac1Ch33RequestEna, true);
+	INPUTMUX_EnableSignal(INPUTMUX,
+			kINPUTMUX_Flexcomm12RxToDmac1Ch34RequestEna, true);
+	INPUTMUX_EnableSignal(INPUTMUX,
+			kINPUTMUX_Flexcomm12TxToDmac1Ch35RequestEna, true);
+	INPUTMUX_EnableSignal(INPUTMUX,
+			kINPUTMUX_Flexcomm16RxToDmac1Ch28RequestEna, true);
+	INPUTMUX_EnableSignal(INPUTMUX,
+			kINPUTMUX_Flexcomm16TxToDmac1Ch29RequestEna, true);
+	INPUTMUX_EnableSignal(INPUTMUX,
+			kINPUTMUX_I3c1RxToDmac1Ch30RequestEna, true);
+	INPUTMUX_EnableSignal(INPUTMUX,
+			kINPUTMUX_I3c1TxToDmac1Ch31RequestEna, true);
+#endif /* dma1 */
+	INPUTMUX_Deinit(INPUTMUX);
 
 #ifdef CONFIG_REBOOT
 	/*

--- a/soc/nxp/imxrt/imxrt5xx/cm33/soc.c
+++ b/soc/nxp/imxrt/imxrt5xx/cm33/soc.c
@@ -321,6 +321,10 @@ void __weak rt5xx_clock_init(void)
 	/* Switch FLEXCOMM12 to FRG */
 	CLOCK_AttachClk(kFRG_to_FLEXCOMM12);
 #endif
+#if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(flexcomm12), nxp_lpc_spi, okay)
+	/* Switch FLEXCOMM12 to FRG */
+	CLOCK_AttachClk(kFRG_to_FLEXCOMM12);
+#endif
 #if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(pmic_i2c), nxp_lpc_i2c, okay)
 	CLOCK_AttachClk(kFRO_DIV4_to_FLEXCOMM15);
 #endif


### PR DESCRIPTION
Configure the DMA requests that have only 1 mux option.

Resolves #77751 .  Tested with the `spi_loopback` test using Flexcomm12 with the devicetree changes in https://github.com/zephyrproject-rtos/zephyr/issues/77751.