### PR TITLE
Add support for WPA3 enterprise only mode

### DIFF
--- a/include/zephyr/net/wifi.h
+++ b/include/zephyr/net/wifi.h
@@ -76,8 +76,6 @@ enum wifi_security_type {
 	WIFI_SECURITY_TYPE_EAP_TTLS_MSCHAPV2,
 	/** EAP PEAP security - Enterprise. */
 	WIFI_SECURITY_TYPE_EAP_PEAP_TLS,
-	/** EAP TLS SHA256 security - Enterprise. */
-	WIFI_SECURITY_TYPE_EAP_TLS_SHA256,
 	/** FT-PSK security */
 	WIFI_SECURITY_TYPE_FT_PSK,
 	/** FT-SAE security */

--- a/include/zephyr/net/wifi.h
+++ b/include/zephyr/net/wifi.h
@@ -189,12 +189,12 @@ struct wifi_eap_cipher_config {
 
 struct wifi_eap_config {
 	/**  Security type. */
-	unsigned int type;
-	/** EPA method type of phase1. */
+	enum wifi_security_type type;
+	/** EAP method type of phase1. */
 	enum wifi_eap_type eap_type_phase1;
-	/** EPA method type of phase2. */
+	/** EAP method type of phase2. */
 	enum wifi_eap_type eap_type_phase2;
-	/** EPA method string. */
+	/** EAP method string. */
 	char *method;
 	/** Phase2 setting string. */
 	char *phase2;

--- a/include/zephyr/net/wifi.h
+++ b/include/zephyr/net/wifi.h
@@ -203,6 +203,9 @@ struct wifi_eap_config {
 /** Helper function to get user-friendly security type name. */
 const char *wifi_security_txt(enum wifi_security_type security);
 
+/** Helper function to get user-friendly wpa3 enterprise security type name. */
+const char *wifi_wpa3_enterprise_txt(enum wifi_wpa3_enterprise_type wpa3_ent);
+
 /** @brief IEEE 802.11w - Management frame protection. */
 enum wifi_mfp_options {
 	/** MFP disabled. */

--- a/include/zephyr/net/wifi.h
+++ b/include/zephyr/net/wifi.h
@@ -108,12 +108,26 @@ enum wifi_eap_type {
 	WIFI_EAP_TYPE_MSCHAPV2 = 26,
 };
 
-/** @brief Enterprise security WPA3 suiteb types. */
-enum wifi_suiteb_type {
-	/** suiteb. */
-	WIFI_SUITEB = 1,
-	/** suiteb-192. */
-	WIFI_SUITEB_192,
+/** @brief WPA3 Enterprise security types.
+ *
+ * See Section#3 in WFA WPA3 specification v3.4:
+ * https://www.wi-fi.org/file/wpa3-specification for details.
+ */
+enum wifi_wpa3_enterprise_type {
+	/** No WPA3 enterprise, either WPA2 Enterprise or personal mode */
+	WIFI_WPA3_ENTERPRISE_NA = 0,
+	/** WPA3 enterprise Suite-B (PMFR + WPA3-Suite-B). */
+	WIFI_WPA3_ENTERPRISE_SUITEB = 1,
+	/** WPA3 enterprise Suite-B-192 (PMFR + WPA3-Suite-B-192). */
+	WIFI_WPA3_ENTERPRISE_SUITEB_192,
+	/** WPA3 enterprise only (PMFR + WPA2-ENT disabled). */
+	WIFI_WPA3_ENTERPRISE_ONLY,
+
+	/** @cond INTERNAL_HIDDEN */
+	__WIFI_WPA3_ENTERPRISE_AFTER_LAST,
+	WIFI_WPA3_ENTERPRISE_MAX = __WIFI_WPA3_ENTERPRISE_AFTER_LAST - 1,
+	WIFI_WPA3_ENTERPRISE_UNKNOWN
+	/** @endcond */
 };
 
 enum wifi_eap_tls_cipher_type {

--- a/include/zephyr/net/wifi_mgmt.h
+++ b/include/zephyr/net/wifi_mgmt.h
@@ -553,8 +553,8 @@ struct wifi_connect_req_params {
 	const uint8_t *key2_passwd;
 	/** key2 passwd length, max 128 */
 	uint8_t key2_passwd_length;
-	/** suiteb or suiteb-192 */
-	uint8_t suiteb_type;
+	/** wpa3 enterprise mode */
+	enum wifi_wpa3_enterprise_type wpa3_ent_mode;
 	/** TLS cipher */
 	uint8_t TLS_cipher;
 	/** eap version */

--- a/include/zephyr/net/wifi_mgmt.h
+++ b/include/zephyr/net/wifi_mgmt.h
@@ -505,6 +505,8 @@ struct wifi_scan_result {
 	uint8_t channel;
 	/** Security type */
 	enum wifi_security_type security;
+	/** WPA3 enterprise type */
+	enum wifi_wpa3_enterprise_type wpa3_ent_type;
 	/** MFP options */
 	enum wifi_mfp_options mfp;
 	/** RSSI */

--- a/include/zephyr/net/wifi_mgmt.h
+++ b/include/zephyr/net/wifi_mgmt.h
@@ -684,6 +684,8 @@ struct wifi_iface_status {
 	enum wifi_iface_mode iface_mode;
 	/** Link mode, see enum wifi_link_mode */
 	enum wifi_link_mode link_mode;
+	/** WPA3 enterprise type */
+	enum wifi_wpa3_enterprise_type wpa3_ent_type;
 	/** Security type, see enum wifi_security_type */
 	enum wifi_security_type security;
 	/** MFP options, see enum wifi_mfp_options */

--- a/modules/hostap/src/supp_api.c
+++ b/modules/hostap/src/supp_api.c
@@ -481,7 +481,6 @@ static struct wifi_eap_config eap_config[] = {
 	 "auth=MSCHAPV2"},
 	{WIFI_SECURITY_TYPE_EAP_PEAP_TLS, WIFI_EAP_TYPE_PEAP, WIFI_EAP_TYPE_TLS, "PEAP",
 	 "auth=TLS"},
-	{WIFI_SECURITY_TYPE_EAP_TLS_SHA256, WIFI_EAP_TYPE_TLS, WIFI_EAP_TYPE_NONE, "TLS", NULL},
 };
 
 int process_cipher_config(struct wifi_connect_req_params *params,
@@ -515,10 +514,6 @@ int process_cipher_config(struct wifi_connect_req_params *params,
 		} else {
 			cipher_config->key_mgmt = "WPA-EAP";
 		}
-	}
-
-	if (params->security == WIFI_SECURITY_TYPE_EAP_TLS_SHA256) {
-		cipher_config->key_mgmt = "WPA-EAP-SHA256";
 	}
 
 	for (index = 0; index < ARRAY_SIZE(ciphers); index++) {
@@ -557,8 +552,7 @@ static int is_eap_valid_security(int security)
 		    security == WIFI_SECURITY_TYPE_EAP_PEAP_MSCHAPV2 ||
 		    security == WIFI_SECURITY_TYPE_EAP_PEAP_GTC ||
 		    security == WIFI_SECURITY_TYPE_EAP_TTLS_MSCHAPV2 ||
-		    security == WIFI_SECURITY_TYPE_EAP_PEAP_TLS ||
-		    security == WIFI_SECURITY_TYPE_EAP_TLS_SHA256);
+		    security == WIFI_SECURITY_TYPE_EAP_PEAP_TLS);
 }
 #endif
 

--- a/modules/hostap/src/supp_api.c
+++ b/modules/hostap/src/supp_api.c
@@ -490,13 +490,13 @@ int process_cipher_config(struct wifi_connect_req_params *params,
 	unsigned int gropu_mgmt_cipher_capa;
 	unsigned int index;
 
-	if (params->suiteb_type == WIFI_SUITEB) {
+	if (params->wpa3_ent_mode == WIFI_WPA3_ENTERPRISE_SUITEB) {
 		cipher_capa = WPA_CAPA_ENC_GCMP;
 		gropu_mgmt_cipher_capa = WPA_CAPA_ENC_BIP_GMAC_128;
 		cipher_config->key_mgmt = "WPA-EAP-SUITE-B";
 		cipher_config->openssl_ciphers = "SUITEB128";
 		cipher_config->tls_flags = "[SUITEB]";
-	} else if (params->suiteb_type == WIFI_SUITEB_192) {
+	} else if (params->wpa3_ent_mode == WIFI_WPA3_ENTERPRISE_SUITEB_192) {
 		cipher_capa = WPA_CAPA_ENC_GCMP_256;
 		gropu_mgmt_cipher_capa = WPA_CAPA_ENC_BIP_GMAC_256;
 		if (params->ft_used) {
@@ -506,6 +506,10 @@ int process_cipher_config(struct wifi_connect_req_params *params,
 		}
 		cipher_config->openssl_ciphers = "SUITEB192";
 		cipher_config->tls_flags = "[SUITEB]";
+	} else if (params->wpa3_ent_mode == WIFI_WPA3_ENTERPRISE_ONLY) {
+		cipher_capa = WPA_CAPA_ENC_CCMP;
+		gropu_mgmt_cipher_capa = WPA_CAPA_ENC_BIP;
+		cipher_config->key_mgmt = "WPA-EAP-SHA256";
 	} else {
 		cipher_capa = WPA_CAPA_ENC_CCMP;
 		gropu_mgmt_cipher_capa = WPA_CAPA_ENC_BIP;
@@ -1062,7 +1066,7 @@ static int wpas_add_and_config_network(struct wpa_supplicant *wpa_s,
 				goto out;
 			}
 
-			if (params->suiteb_type == WIFI_SUITEB_192) {
+			if (params->wpa3_ent_mode == WIFI_WPA3_ENTERPRISE_SUITEB_192) {
 				if (params->TLS_cipher == WIFI_EAP_TLS_ECC_P384) {
 					if (!wpa_cli_cmd_v("set_network %d openssl_ciphers \"%s\"",
 							resp.network_id,

--- a/modules/hostap/src/supp_api.c
+++ b/modules/hostap/src/supp_api.c
@@ -27,6 +27,9 @@
 #include "hostapd_cli_zephyr.h"
 #include "ap_drv_ops.h"
 #endif
+#ifdef CONFIG_WIFI_NM_WPA_SUPPLICANT_CRYPTO_ENTERPRISE
+#include "eap_peer/eap.h"
+#endif
 #include "supp_events.h"
 #include "wpa_supplicant/bss.h"
 
@@ -362,13 +365,77 @@ static inline enum wifi_frequency_bands wpas_band_to_zephyr(enum wpa_radio_work_
 	}
 }
 
-static inline enum wifi_security_type wpas_key_mgmt_to_zephyr(int key_mgmt, int proto, int pwe)
+static inline enum wifi_wpa3_enterprise_type wpas_key_mgmt_to_zephyr_wpa3_ent(int key_mgmt)
 {
 	switch (key_mgmt) {
+	case WPA_KEY_MGMT_IEEE8021X_SUITE_B:
+		return WIFI_WPA3_ENTERPRISE_SUITEB;
+	case WPA_KEY_MGMT_IEEE8021X_SUITE_B_192:
+		return WIFI_WPA3_ENTERPRISE_SUITEB_192;
+	case WPA_KEY_MGMT_IEEE8021X_SHA256:
+		return WIFI_WPA3_ENTERPRISE_ONLY;
+	default:
+		return WIFI_WPA3_ENTERPRISE_NA;
+	}
+}
+
+static inline enum wifi_security_type wpas_key_mgmt_to_zephyr(bool is_hapd,
+				void *config, int key_mgmt, int proto, int pwe)
+{
+	switch (key_mgmt) {
+#ifdef CONFIG_WIFI_NM_WPA_SUPPLICANT_CRYPTO_ENTERPRISE
 	case WPA_KEY_MGMT_IEEE8021X:
 	case WPA_KEY_MGMT_IEEE8021X_SUITE_B:
 	case WPA_KEY_MGMT_IEEE8021X_SUITE_B_192:
+	case WPA_KEY_MGMT_IEEE8021X_SHA256:
+		if (is_hapd) {
+#ifdef CONFIG_WIFI_NM_HOSTAPD_CRYPTO_ENTERPRISE
+			struct hostapd_bss_config *conf = (struct hostapd_bss_config *)config;
+
+			switch (conf->eap_user->methods[0].method) {
+			case WIFI_EAP_TYPE_PEAP:
+				if (conf->eap_user->next && conf->eap_user->next->phase2) {
+					switch (conf->eap_user->next->methods[0].method) {
+					case WIFI_EAP_TYPE_MSCHAPV2:
+						return WIFI_SECURITY_TYPE_EAP_PEAP_MSCHAPV2;
+					case WIFI_EAP_TYPE_GTC:
+						return WIFI_SECURITY_TYPE_EAP_PEAP_GTC;
+					case WIFI_EAP_TYPE_TLS:
+						return WIFI_SECURITY_TYPE_EAP_PEAP_TLS;
+					}
+				}
+			case WIFI_EAP_TYPE_TTLS:
+				if (conf->eap_user->next && conf->eap_user->next->phase2) {
+					if (conf->eap_user->next->ttls_auth & 0x1E) {
+						return WIFI_SECURITY_TYPE_EAP_TTLS_MSCHAPV2;
+					}
+				}
+			}
+#endif
+		} else {
+			struct wpa_ssid *ssid = (struct wpa_ssid *)config;
+
+			switch (ssid->eap.eap_methods->method) {
+			case WIFI_EAP_TYPE_TTLS:
+				if (!os_memcmp(ssid->eap.phase2, "auth=MSCHAPV2",
+							   os_strlen(ssid->eap.phase2))) {
+					return WIFI_SECURITY_TYPE_EAP_TTLS_MSCHAPV2;
+				}
+			case WIFI_EAP_TYPE_PEAP:
+				if (!os_memcmp(ssid->eap.phase2, "auth=MSCHAPV2",
+							   os_strlen(ssid->eap.phase2))) {
+					return WIFI_SECURITY_TYPE_EAP_PEAP_MSCHAPV2;
+				} else if (!os_memcmp(ssid->eap.phase2, "auth=GTC",
+							os_strlen(ssid->eap.phase2))) {
+					return WIFI_SECURITY_TYPE_EAP_PEAP_GTC;
+				} else if (!os_memcmp(ssid->eap.phase2, "auth=TLS",
+							os_strlen(ssid->eap.phase2))) {
+					return WIFI_SECURITY_TYPE_EAP_PEAP_TLS;
+				}
+			}
+		}
 		return WIFI_SECURITY_TYPE_EAP_TLS;
+#endif
 	case WPA_KEY_MGMT_NONE:
 		return WIFI_SECURITY_TYPE_NONE;
 	case WPA_KEY_MGMT_PSK:
@@ -1538,7 +1605,8 @@ int supplicant_status(const struct device *dev, struct wifi_iface_status *status
 		sae_pwe = wpa_s->conf->sae_pwe;
 		os_memcpy(status->bssid, wpa_s->bssid, WIFI_MAC_ADDR_LEN);
 		status->band = wpas_band_to_zephyr(wpas_freq_to_band(wpa_s->assoc_freq));
-		status->security = wpas_key_mgmt_to_zephyr(key_mgmt, proto, sae_pwe);
+		status->wpa3_ent_type = wpas_key_mgmt_to_zephyr_wpa3_ent(key_mgmt);
+		status->security = wpas_key_mgmt_to_zephyr(0, ssid, key_mgmt, proto, sae_pwe);
 		status->mfp = get_mfp(ssid->ieee80211w);
 		ieee80211_freq_to_chan(wpa_s->assoc_freq, &channel);
 		status->channel = channel;
@@ -2527,7 +2595,8 @@ int supplicant_ap_status(const struct device *dev, struct wifi_iface_status *sta
 	key_mgmt = bss->wpa_key_mgmt;
 	proto = bss->wpa;
 	sae_pwe = bss->sae_pwe;
-	status->security = wpas_key_mgmt_to_zephyr(key_mgmt, proto, sae_pwe);
+	status->wpa3_ent_type = wpas_key_mgmt_to_zephyr_wpa3_ent(key_mgmt);
+	status->security = wpas_key_mgmt_to_zephyr(1, hapd->conf, key_mgmt, proto, sae_pwe);
 	status->mfp = get_mfp(bss->ieee80211w);
 	status->channel = conf->channel;
 	os_memcpy(status->ssid, ssid->ssid, ssid->ssid_len);

--- a/subsys/net/l2/wifi/wifi_mgmt.c
+++ b/subsys/net/l2/wifi/wifi_mgmt.c
@@ -83,8 +83,6 @@ const char *wifi_security_txt(enum wifi_security_type security)
 		return "EAP-TTLS-MSCHAPV2";
 	case WIFI_SECURITY_TYPE_EAP_PEAP_TLS:
 		return "EAP-PEAP-TLS";
-	case WIFI_SECURITY_TYPE_EAP_TLS_SHA256:
-		return "EAP-TLS-SHA256";
 	case WIFI_SECURITY_TYPE_FT_PSK:
 		return "FT-PSK";
 	case WIFI_SECURITY_TYPE_FT_SAE:

--- a/subsys/net/l2/wifi/wifi_mgmt.c
+++ b/subsys/net/l2/wifi/wifi_mgmt.c
@@ -97,6 +97,20 @@ const char *wifi_security_txt(enum wifi_security_type security)
 	}
 }
 
+const char *wifi_wpa3_enterprise_txt(enum wifi_wpa3_enterprise_type wpa3_ent)
+{
+	switch (wpa3_ent) {
+	case WIFI_WPA3_ENTERPRISE_SUITEB:
+		return "WPA3-SuiteB";
+	case WIFI_WPA3_ENTERPRISE_SUITEB_192:
+		return "WPA3-SuiteB-192";
+	case WIFI_WPA3_ENTERPRISE_ONLY:
+		return "WPA3-Enterprise-Only";
+	default:
+		return "";
+	}
+}
+
 const char *wifi_mfp_txt(enum wifi_mfp_options mfp)
 {
 	switch (mfp) {

--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -863,6 +863,16 @@ static int __wifi_args_to_params(const struct shell *sh, size_t argc, char *argv
 		return -EINVAL;
 	}
 
+	if (params->security == WIFI_SECURITY_TYPE_SAE_HNP
+		|| params->security == WIFI_SECURITY_TYPE_SAE_H2E
+		|| params->security == WIFI_SECURITY_TYPE_SAE_AUTO
+		|| params->wpa3_ent_mode != WIFI_WPA3_ENTERPRISE_NA) {
+		if (params->mfp != WIFI_MFP_REQUIRED) {
+			PR_ERROR("MFP is required for WPA3 mode\n");
+			return -EINVAL;
+		}
+	}
+
 	if (iface_mode == WIFI_MODE_AP && params->channel == WIFI_CHANNEL_ANY) {
 		PR_ERROR("Channel not provided\n");
 		return -EINVAL;

--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -191,18 +191,20 @@ static void handle_wifi_scan_result(struct net_mgmt_event_callback *cb)
 	context.scan_result++;
 
 	if (context.scan_result == 1U) {
-		PR("\n%-4s | %-32s %-5s | %-13s | %-4s | %-15s | %-17s | %-8s\n",
+		PR("\n%-4s | %-32s %-5s | %-13s | %-4s | %-20s | %-17s | %-8s\n",
 		   "Num", "SSID", "(len)", "Chan (Band)", "RSSI", "Security", "BSSID", "MFP");
 	}
 
 	strncpy(ssid_print, entry->ssid, sizeof(ssid_print) - 1);
 	ssid_print[sizeof(ssid_print) - 1] = '\0';
 
-	PR("%-4d | %-32s %-5u | %-4u (%-6s) | %-4d | %-15s | %-17s | %-8s\n",
+	PR("%-4d | %-32s %-5u | %-4u (%-6s) | %-4d | %-20s | %-17s | %-8s\n",
 	   context.scan_result, ssid_print, entry->ssid_length, entry->channel,
 	   wifi_band_txt(entry->band),
 	   entry->rssi,
-	   wifi_security_txt(entry->security),
+	   ((entry->wpa3_ent_type) ?
+		wifi_wpa3_enterprise_txt(entry->wpa3_ent_type)
+		 : wifi_security_txt(entry->security)),
 	   ((entry->mac_length) ?
 		   net_sprint_ll_addr_buf(entry->mac, WIFI_MAC_ADDR_LEN,
 					  mac_string_buf,

--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -580,7 +580,7 @@ static int __wifi_args_to_params(const struct shell *sh, size_t argc, char *argv
 		{"bandwidth", required_argument, 0, 'B'},
 		{"key1-pwd", required_argument, 0, 'K'},
 		{"key2-pwd", required_argument, 0, 'K'},
-		{"suiteb-type", required_argument, 0, 'S'},
+		{"wpa3-enterprise", required_argument, 0, 'S'},
 		{"TLS-cipher", required_argument, 0, 'T'},
 		{"eap-version", required_argument, 0, 'V'},
 		{"eap-id1", required_argument, 0, 'I'},
@@ -785,7 +785,7 @@ static int __wifi_args_to_params(const struct shell *sh, size_t argc, char *argv
 			key_passwd_cnt++;
 			break;
 		case 'S':
-			params->suiteb_type = atoi(state->optarg);
+			params->wpa3_ent_mode = atoi(state->optarg);
 			break;
 		case 'T':
 			params->TLS_cipher = atoi(state->optarg);
@@ -3421,7 +3421,9 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 		      "[-B, --bandwidth=<bandwidth>]: 1:20MHz, 2:40MHz, 3:80MHz\n"
 		      "[-K, --key1-pwd for eap phase1 or --key2-pwd for eap phase2]:\n"
 		      "Private key passwd for enterprise mode. Default no password for private key.\n"
-		      "[-S, --suiteb-type]: 1:suiteb, 2:suiteb-192. Default 0: not suiteb mode.\n"
+		      "[-S, --wpa3-enterprise]: WPA3 enterprise mode:\n"
+		      "Default 0: Not WPA3 enterprise mode.\n"
+		      "1:Suite-b mode, 2:Suite-b-192-bit mode, 3:WPA3-enterprise-only mode.\n"
 		      "[-V, --eap-version]: 0 or 1. Default 1: eap version 1.\n"
 		      "[-I, --eap-id1...--eap-id8]: Client Identity. Default no eap identity.\n"
 		      "[-P, --eap-pwd1...--eap-pwd8]: Client Password.\n"
@@ -3658,7 +3660,9 @@ SHELL_SUBCMD_ADD((wifi), connect, NULL,
 		  "[-a, --anon-id]: Anonymous identity for enterprise mode.\n"
 		  "[-K, --key1-pwd for eap phase1 or --key2-pwd for eap phase2]:\n"
 		  "Private key passwd for enterprise mode. Default no password for private key.\n"
-		  "[-S, --suiteb-type]: 1:suiteb, 2:suiteb-192. Default 0: not suiteb mode.\n"
+		  "[-S, --wpa3-enterprise]: WPA3 enterprise mode:\n"
+		  "Default 0: Not WPA3 enterprise mode.\n"
+		  "1:Suite-b mode, 2:Suite-b-192-bit mode, 3:WPA3-enterprise-only mode.\n"
 		  "[-T, --TLS-cipher]: 0:TLS-NONE, 1:TLS-ECC-P384, 2:TLS-RSA-3K.\n"
 		  "[-V, --eap-version]: 0 or 1. Default 1: eap version 1.\n"
 		  "[-I, --eap-id1]: Client Identity. Default no eap identity.\n"

--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -3685,7 +3685,7 @@ SHELL_SUBCMD_ADD((wifi), connect, NULL,
 		  "[-R, --ieee-80211r]: Use IEEE80211R fast BSS transition connect."
 		  "[-h, --help]: Print out the help for the connect command.\n",
 		  cmd_wifi_connect,
-		 2, 19);
+		 2, 40);
 
 SHELL_SUBCMD_ADD((wifi), disconnect, NULL,
 		 "Disconnect from the Wi-Fi AP.\n",

--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -1144,7 +1144,8 @@ static int cmd_wifi_status(const struct shell *sh, size_t argc, char *argv[])
 					  sizeof(mac_string_buf)));
 		PR("Band: %s\n", wifi_band_txt(status.band));
 		PR("Channel: %d\n", status.channel);
-		PR("Security: %s\n", wifi_security_txt(status.security));
+		PR("Security: %s %s\n", wifi_wpa3_enterprise_txt(status.wpa3_ent_type),
+								wifi_security_txt(status.security));
 		PR("MFP: %s\n", wifi_mfp_txt(status.mfp));
 		if (status.iface_mode == WIFI_MODE_INFRA) {
 			PR("RSSI: %d\n", status.rssi);
@@ -1212,7 +1213,8 @@ static int cmd_wifi_ap_status(const struct shell *sh, size_t argc, char *argv[])
 						 sizeof(mac_string_buf)));
 	PR("Band: %s\n", wifi_band_txt(status.band));
 	PR("Channel: %d\n", status.channel);
-	PR("Security: %s\n", wifi_security_txt(status.security));
+	PR("Security: %s %s\n", wifi_wpa3_enterprise_txt(status.wpa3_ent_type),
+							wifi_security_txt(status.security));
 	PR("MFP: %s\n", wifi_mfp_txt(status.mfp));
 	if (status.iface_mode == WIFI_MODE_INFRA) {
 		PR("RSSI: %d\n", status.rssi);

--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -915,8 +915,7 @@ static int cmd_wifi_connect(const struct shell *sh, size_t argc,
 	    cnx_params.security == WIFI_SECURITY_TYPE_EAP_PEAP_MSCHAPV2 ||
 	    cnx_params.security == WIFI_SECURITY_TYPE_EAP_PEAP_GTC ||
 	    cnx_params.security == WIFI_SECURITY_TYPE_EAP_TTLS_MSCHAPV2 ||
-	    cnx_params.security == WIFI_SECURITY_TYPE_EAP_PEAP_TLS ||
-	    cnx_params.security == WIFI_SECURITY_TYPE_EAP_TLS_SHA256) {
+	    cnx_params.security == WIFI_SECURITY_TYPE_EAP_PEAP_TLS) {
 		cmd_wifi_set_enterprise_creds(sh, iface);
 	}
 #endif
@@ -1926,8 +1925,7 @@ static int cmd_wifi_ap_enable(const struct shell *sh, size_t argc,
 	    cnx_params.security == WIFI_SECURITY_TYPE_EAP_PEAP_MSCHAPV2 ||
 	    cnx_params.security == WIFI_SECURITY_TYPE_EAP_PEAP_GTC ||
 	    cnx_params.security == WIFI_SECURITY_TYPE_EAP_TTLS_MSCHAPV2 ||
-	    cnx_params.security == WIFI_SECURITY_TYPE_EAP_PEAP_TLS ||
-	    cnx_params.security == WIFI_SECURITY_TYPE_EAP_TLS_SHA256) {
+	    cnx_params.security == WIFI_SECURITY_TYPE_EAP_PEAP_TLS) {
 		cmd_wifi_set_enterprise_creds(sh, iface);
 	}
 #endif
@@ -3409,7 +3407,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 		      "0:None, 1:WPA2-PSK, 2:WPA2-PSK-256, 3:SAE-HNP, 4:SAE-H2E, 5:SAE-AUTO, 6:WAPI,"
 		      "7:EAP-TLS, 8:WEP, 9: WPA-PSK, 10: WPA-Auto-Personal, 11: DPP\n"
 		      "12: EAP-PEAP-MSCHAPv2, 13: EAP-PEAP-GTC, 14: EAP-TTLS-MSCHAPv2,\n"
-		      "15: EAP-PEAP-TLS, 16:EAP_TLS_SHA256\n"
+		      "15: EAP-PEAP-TLS\n"
 		      "-w --ieee-80211w=<MFP> (optional: needs security type to be specified)\n"
 		      "0:Disable, 1:Optional, 2:Required\n"
 		      "-b --band=<band> (2 -2.6GHz, 5 - 5Ghz, 6 - 6GHz)\n"
@@ -3652,7 +3650,7 @@ SHELL_SUBCMD_ADD((wifi), connect, NULL,
 		  "0:None, 1:WPA2-PSK, 2:WPA2-PSK-256, 3:SAE-HNP, 4:SAE-H2E, 5:SAE-AUTO, 6:WAPI,"
 		  "7:EAP-TLS, 8:WEP, 9: WPA-PSK, 10: WPA-Auto-Personal, 11: DPP\n"
 		  "12: EAP-PEAP-MSCHAPv2, 13: EAP-PEAP-GTC, 14: EAP-TTLS-MSCHAPv2,\n"
-		  "15: EAP-PEAP-TLS, 16:EAP_TLS_SHA256\n"
+		  "15: EAP-PEAP-TLS\n"
 		  "[-w, --ieee-80211w]: MFP (optional: needs security type to be specified)\n"
 		  ": 0:Disable, 1:Optional, 2:Required.\n"
 		  "[-m, --bssid]: MAC address of the AP (BSSID).\n"


### PR DESCRIPTION
net: wifi: fix wifi connect parameter count error
Fix wrong parameter count error when input 'wifi connect' in enterprise mode.

net: wifi: should enable MFP when connect to WPA3 network
Add check that should enable MFP when connect to WPA3 network.

net: wifi: support printing WPA3 enterprise in scan result
Support printing WPA3 enterprise type in scan result, including the suiteb, suiteb-192 and WPA3 enterprise only.

hostap: support getting enterprise type by status cmd
For 'wifi status' and 'wifi ap status' cmd, support getting the specific enterprise mode, including the WPA3 enterprise mode and the EAP method type.

net: wifi: fix typo of EAP method

hostap: add WPA3 enterprise security type
Change Wi-Fi suiteb type into WPA3 enterprise security type. Support setting WPA3 enterprise only mode, which should use cipher_config->key_mgmt as WPA-EAP-SHA256, and the AKM in RSN IE will show 00-0F-AC:5.

net: l2: wifi: remove EAP TLS SHA256 security
Remove EAP TLS SHA256 security, as it should be replaced by WPA3 enterprise only mode.
