### PR TITLE
drivers: led: lp50xx add pm for turn on/off

### DIFF
--- a/drivers/led/lp50xx.c
+++ b/drivers/led/lp50xx.c
@@ -330,6 +330,12 @@ static int lp50xx_pm_action(const struct device *dev,
 		return lp50xx_enable(dev, false);
 	case PM_DEVICE_ACTION_RESUME:
 		return lp50xx_enable(dev, true);
+    case PM_DEVICE_ACTION_TURN_ON:
+        return lp50xx_init(dev);
+        break;
+    case PM_DEVICE_ACTION_TURN_OFF:
+        return lp50xx_hw_enable(dev, false);
+        break;
 	default:
 		return -ENOTSUP;
 	}


### PR DESCRIPTION
Add PM on and off for lp50xx. Turning of the lp50xx through the enable pin, reduces current consumption significantly 

Signed-off-by: Shahin Haque <ShahinHaque97@outlook.com>