### PR TITLE
net: http_server: serve resources only for the specific services they are registered to

### DIFF
--- a/include/zephyr/net/http/server.h
+++ b/include/zephyr/net/http/server.h
@@ -399,6 +399,9 @@ struct http_client_ctx {
 	/** Socket descriptor associated with the server. */
 	int fd;
 
+	/** HTTP service on which the client is connected */
+	const struct http_service_desc *service;
+
 	/** Client data buffer.  */
 	unsigned char buffer[HTTP_SERVER_CLIENT_BUFFER_SIZE];
 

--- a/include/zephyr/net/http/service.h
+++ b/include/zephyr/net/http/service.h
@@ -67,6 +67,7 @@ struct http_resource_desc {
 struct http_service_desc {
 	const char *host;
 	uint16_t *port;
+	int *fd;
 	void *detail;
 	size_t concurrent;
 	size_t backlog;
@@ -80,9 +81,11 @@ struct http_service_desc {
 
 #define __z_http_service_define(_name, _host, _port, _concurrent, _backlog, _detail, _res_begin,   \
 				_res_end, ...)                                                     \
-	const STRUCT_SECTION_ITERABLE(http_service_desc, _name) = {				   \
+	static int _name##_fd = -1;                                                                \
+	const STRUCT_SECTION_ITERABLE(http_service_desc, _name) = {                                \
 		.host = _host,                                                                     \
 		.port = (uint16_t *)(_port),                                                       \
+		.fd = &_name##_fd,                                                                 \
 		.detail = (void *)(_detail),                                                       \
 		.concurrent = (_concurrent),                                                       \
 		.backlog = (_backlog),                                                             \

--- a/subsys/net/lib/http/headers/server_internal.h
+++ b/subsys/net/lib/http/headers/server_internal.h
@@ -37,7 +37,8 @@ int enter_http2_request(struct http_client_ctx *client);
 int enter_http_done_state(struct http_client_ctx *client);
 
 /* Others */
-struct http_resource_detail *get_resource_detail(const char *path, int *len, bool is_ws);
+struct http_resource_detail *get_resource_detail(const struct http_service_desc *service,
+						 const char *path, int *len, bool is_ws);
 int http_server_sendall(struct http_client_ctx *client, const void *buf, size_t len);
 void http_server_get_content_type_from_extension(char *url, char *content_type,
 						 size_t content_type_size);

--- a/subsys/net/lib/http/http_server_core.c
+++ b/subsys/net/lib/http/http_server_core.c
@@ -237,6 +237,7 @@ int http_server_init(struct http_server_ctx *ctx)
 		LOG_DBG("Initialized HTTP Service %s:%u",
 			svc->host ? svc->host : "<any>", *svc->port);
 
+		*svc->fd = fd;
 		ctx->fds[count].fd = fd;
 		ctx->fds[count].events = ZSOCK_POLLIN;
 		count++;
@@ -298,6 +299,10 @@ static void close_all_sockets(struct http_server_ctx *ctx)
 		}
 
 		ctx->fds[i].fd = -1;
+	}
+
+	HTTP_SERVICE_FOREACH(svc) {
+		*svc->fd = -1;
 	}
 }
 
@@ -393,9 +398,22 @@ void http_client_timer_restart(struct http_client_ctx *client)
 	k_work_reschedule(&client->inactivity_timer, INACTIVITY_TIMEOUT);
 }
 
-static void init_client_ctx(struct http_client_ctx *client, int new_socket)
+static const struct http_service_desc *lookup_service(int server_fd)
+{
+	HTTP_SERVICE_FOREACH(svc) {
+		if (*svc->fd == server_fd) {
+			return svc;
+		}
+	}
+
+	return NULL;
+}
+
+static void init_client_ctx(struct http_client_ctx *client, const struct http_service_desc *svc,
+			    int new_socket)
 {
 	client->fd = new_socket;
+	client->service = svc;
 	client->data_len = 0;
 	client->server_state = HTTP_SERVER_PREFACE_STATE;
 	client->has_upgrade_header = false;
@@ -523,6 +541,7 @@ static int handle_http_request(struct http_client_ctx *client)
 static int http_server_run(struct http_server_ctx *ctx)
 {
 	struct http_client_ctx *client;
+	const struct http_service_desc *service;
 	eventfd_t value;
 	bool found_slot;
 	int new_socket;
@@ -600,6 +619,9 @@ static int http_server_run(struct http_server_ctx *ctx)
 					continue;
 				}
 
+				service = lookup_service(ctx->fds[i].fd);
+				__ASSERT(NULL != service, "fd not associated with a service");
+
 				found_slot = false;
 
 				for (j = ctx->listen_fds; j < ARRAY_SIZE(ctx->fds); j++) {
@@ -615,7 +637,7 @@ static int http_server_run(struct http_server_ctx *ctx)
 
 					LOG_DBG("Init client #%d", j - ctx->listen_fds);
 
-					init_client_ctx(&ctx->clients[j - ctx->listen_fds],
+					init_client_ctx(&ctx->clients[j - ctx->listen_fds], service,
 							new_socket);
 					found_slot = true;
 					break;
@@ -713,33 +735,29 @@ static bool skip_this(struct http_resource_desc *resource, bool is_websocket)
 	return false;
 }
 
-struct http_resource_detail *get_resource_detail(const char *path,
-						 int *path_len,
-						 bool is_websocket)
+struct http_resource_detail *get_resource_detail(const struct http_service_desc *service,
+						 const char *path, int *path_len, bool is_websocket)
 {
-	HTTP_SERVICE_FOREACH(service) {
-		HTTP_SERVICE_FOREACH_RESOURCE(service, resource) {
-			if (skip_this(resource, is_websocket)) {
-				continue;
-			}
+	HTTP_SERVICE_FOREACH_RESOURCE(service, resource) {
+		if (skip_this(resource, is_websocket)) {
+			continue;
+		}
 
-			if (IS_ENABLED(CONFIG_HTTP_SERVER_RESOURCE_WILDCARD)) {
-				int ret;
+		if (IS_ENABLED(CONFIG_HTTP_SERVER_RESOURCE_WILDCARD)) {
+			int ret;
 
-				ret = fnmatch(resource->resource, path,
-					      (FNM_PATHNAME | FNM_LEADING_DIR));
-				if (ret == 0) {
-					*path_len = strlen(resource->resource);
-					return resource->detail;
-				}
-			}
-
-			if (compare_strings(path, resource->resource) == 0) {
-				NET_DBG("Got match for %s", resource->resource);
-
+			ret = fnmatch(resource->resource, path, (FNM_PATHNAME | FNM_LEADING_DIR));
+			if (ret == 0) {
 				*path_len = strlen(resource->resource);
 				return resource->detail;
 			}
+		}
+
+		if (compare_strings(path, resource->resource) == 0) {
+			NET_DBG("Got match for %s", resource->resource);
+
+			*path_len = strlen(resource->resource);
+			return resource->detail;
 		}
 	}
 

--- a/subsys/net/lib/http/http_server_http1.c
+++ b/subsys/net/lib/http/http_server_http1.c
@@ -859,7 +859,7 @@ int handle_http1_request(struct http_client_ctx *client)
 
 		if (client->websocket_upgrade) {
 			if (IS_ENABLED(CONFIG_HTTP_SERVER_WEBSOCKET)) {
-				detail = get_resource_detail(client->url_buffer,
+				detail = get_resource_detail(client->service, client->url_buffer,
 							     &path_len, true);
 				if (detail == NULL) {
 					goto not_found;
@@ -899,7 +899,7 @@ upgrade_not_found:
 		}
 	}
 
-	detail = get_resource_detail(client->url_buffer, &path_len, false);
+	detail = get_resource_detail(client->service, client->url_buffer, &path_len, false);
 	if (detail != NULL) {
 		detail->path_len = path_len;
 

--- a/subsys/net/lib/http/http_server_http2.c
+++ b/subsys/net/lib/http/http_server_http2.c
@@ -1029,7 +1029,7 @@ int handle_http1_to_http2_upgrade(struct http_client_ctx *client)
 		client->preface_sent = true;
 	}
 
-	detail = get_resource_detail(client->url_buffer, &path_len, false);
+	detail = get_resource_detail(client->service, client->url_buffer, &path_len, false);
 	if (detail != NULL) {
 		detail->path_len = path_len;
 
@@ -1509,7 +1509,7 @@ int handle_http_frame_headers(struct http_client_ctx *client)
 		return 0;
 	}
 
-	detail = get_resource_detail(client->url_buffer, &path_len, false);
+	detail = get_resource_detail(client->service, client->url_buffer, &path_len, false);
 	if (detail != NULL) {
 		detail->path_len = path_len;
 


### PR DESCRIPTION
Currently the mechanism of defining resources for each specific HTTP service using `HTTP_RESOURCE_DEFINE` doesn't seem to work as intended, since `get_resource_detail` iterates over all services and resources. This means that a resource defined for one service will actually be served for any service.

Perhaps the easiest way to demonstrate this is to comment out the following line in the HTTP server sample so that the resource is defined only for the HTTPS service and not the HTTP one:

```
// HTTP_RESOURCE_DEFINE(uptime_resource, test_http_service, "/uptime", &uptime_resource_detail);
```

The result is that a curl request to either http://192.0.2.1/uptime or https://192.0.2.1/uptime returns the uptime, while it should give a 404 response over http.

This PR ensures that resources are only served to a client connected on a service that the resource was registered against, based on the server fd used to accept the client connection. This could be useful for e.g. serving certain resources only over HTTPS, not over unencrypted HTTP.