### PR TITLE
sensor: shell: Allow individual axis data to be processed

### DIFF
--- a/drivers/sensor/default_rtio_sensor.c
+++ b/drivers/sensor/default_rtio_sensor.c
@@ -318,25 +318,44 @@ static int get_frame_count(const uint8_t *buffer, struct sensor_chan_spec channe
 
 	switch (channel.chan_type) {
 	case SENSOR_CHAN_ACCEL_XYZ:
-		channel.chan_type = SENSOR_CHAN_ACCEL_X;
-		break;
 	case SENSOR_CHAN_GYRO_XYZ:
-		channel.chan_type = SENSOR_CHAN_GYRO_X;
-		break;
 	case SENSOR_CHAN_MAGN_XYZ:
-		channel.chan_type = SENSOR_CHAN_MAGN_X;
-		break;
 	case SENSOR_CHAN_POS_DXYZ:
-		channel.chan_type = SENSOR_CHAN_POS_DX;
+		for (size_t i = 0 ; i < header->num_channels; ++i) {
+			/* For 3-axis channels, we need to verify we have each individual axis */
+			struct sensor_chan_spec channel_x = {
+				.chan_type = channel.chan_type - 3,
+				.chan_idx = channel.chan_idx,
+			};
+			struct sensor_chan_spec channel_y = {
+				.chan_type = channel.chan_type - 2,
+				.chan_idx = channel.chan_idx,
+			};
+			struct sensor_chan_spec channel_z = {
+				.chan_type = channel.chan_type - 1,
+				.chan_idx = channel.chan_idx,
+			};
+
+			/** The three axes don't need to be at the beginning of the header, but
+			 * they should be consecutive.
+			 */
+			if (((header->num_channels - i) >= 3) &&
+			    sensor_chan_spec_eq(header->channels[i], channel_x) &&
+			    sensor_chan_spec_eq(header->channels[i + 1], channel_y) &&
+			    sensor_chan_spec_eq(header->channels[i + 2], channel_z)) {
+				*frame_count = 1;
+				return 0;
+			}
+		}
 		break;
 	default:
-		break;
-	}
-	for (size_t i = 0; i < header->num_channels; ++i) {
-		if (sensor_chan_spec_eq(header->channels[i], channel)) {
-			*frame_count = 1;
-			return 0;
+		for (size_t i = 0; i < header->num_channels; ++i) {
+			if (sensor_chan_spec_eq(header->channels[i], channel)) {
+				*frame_count = 1;
+				return 0;
+			}
 		}
+		break;
 	}
 
 	return -ENOTSUP;
@@ -353,21 +372,9 @@ int sensor_natively_supported_channel_size_info(struct sensor_chan_spec channel,
 	}
 
 	switch (channel.chan_type) {
-	case SENSOR_CHAN_ACCEL_X:
-	case SENSOR_CHAN_ACCEL_Y:
-	case SENSOR_CHAN_ACCEL_Z:
 	case SENSOR_CHAN_ACCEL_XYZ:
-	case SENSOR_CHAN_GYRO_X:
-	case SENSOR_CHAN_GYRO_Y:
-	case SENSOR_CHAN_GYRO_Z:
 	case SENSOR_CHAN_GYRO_XYZ:
-	case SENSOR_CHAN_MAGN_X:
-	case SENSOR_CHAN_MAGN_Y:
-	case SENSOR_CHAN_MAGN_Z:
 	case SENSOR_CHAN_MAGN_XYZ:
-	case SENSOR_CHAN_POS_DX:
-	case SENSOR_CHAN_POS_DY:
-	case SENSOR_CHAN_POS_DZ:
 	case SENSOR_CHAN_POS_DXYZ:
 		*base_size = sizeof(struct sensor_three_axis_data);
 		*frame_size = sizeof(struct sensor_three_axis_sample_data);
@@ -480,33 +487,21 @@ static int decode(const uint8_t *buffer, struct sensor_chan_spec chan_spec,
 
 	/* Check for 3d channel mappings */
 	switch (chan_spec.chan_type) {
-	case SENSOR_CHAN_ACCEL_X:
-	case SENSOR_CHAN_ACCEL_Y:
-	case SENSOR_CHAN_ACCEL_Z:
 	case SENSOR_CHAN_ACCEL_XYZ:
 		count = decode_three_axis(header, q, data_out, SENSOR_CHAN_ACCEL_X,
 					  SENSOR_CHAN_ACCEL_Y, SENSOR_CHAN_ACCEL_Z,
 					  chan_spec.chan_idx);
 		break;
-	case SENSOR_CHAN_GYRO_X:
-	case SENSOR_CHAN_GYRO_Y:
-	case SENSOR_CHAN_GYRO_Z:
 	case SENSOR_CHAN_GYRO_XYZ:
 		count = decode_three_axis(header, q, data_out, SENSOR_CHAN_GYRO_X,
 					  SENSOR_CHAN_GYRO_Y, SENSOR_CHAN_GYRO_Z,
 					  chan_spec.chan_idx);
 		break;
-	case SENSOR_CHAN_MAGN_X:
-	case SENSOR_CHAN_MAGN_Y:
-	case SENSOR_CHAN_MAGN_Z:
 	case SENSOR_CHAN_MAGN_XYZ:
 		count = decode_three_axis(header, q, data_out, SENSOR_CHAN_MAGN_X,
 					  SENSOR_CHAN_MAGN_Y, SENSOR_CHAN_MAGN_Z,
 					  chan_spec.chan_idx);
 		break;
-	case SENSOR_CHAN_POS_DX:
-	case SENSOR_CHAN_POS_DY:
-	case SENSOR_CHAN_POS_DZ:
 	case SENSOR_CHAN_POS_DXYZ:
 		count = decode_three_axis(header, q, data_out, SENSOR_CHAN_POS_DX,
 					  SENSOR_CHAN_POS_DY, SENSOR_CHAN_POS_DZ,

--- a/drivers/sensor/sensor_shell.c
+++ b/drivers/sensor/sensor_shell.c
@@ -359,23 +359,6 @@ void sensor_shell_processing_callback(int result, uint8_t *buf, uint32_t buf_len
 		size_t frame_size;
 		uint16_t frame_count;
 
-		/* Channels with multi-axis equivalents are skipped */
-		switch (ch.chan_type) {
-		case SENSOR_CHAN_ACCEL_X:
-		case SENSOR_CHAN_ACCEL_Y:
-		case SENSOR_CHAN_ACCEL_Z:
-		case SENSOR_CHAN_GYRO_X:
-		case SENSOR_CHAN_GYRO_Y:
-		case SENSOR_CHAN_GYRO_Z:
-		case SENSOR_CHAN_MAGN_X:
-		case SENSOR_CHAN_MAGN_Y:
-		case SENSOR_CHAN_MAGN_Z:
-		case SENSOR_CHAN_POS_DX:
-		case SENSOR_CHAN_POS_DY:
-		case SENSOR_CHAN_POS_DZ:
-			continue;
-		}
-
 		rc = decoder->get_size_info(ch, &base_size, &frame_size);
 		if (rc != 0) {
 			LOG_DBG("skipping unsupported channel %s:%d",

--- a/samples/sensor/sensor_shell/pytest/test_sensor_shell.py
+++ b/samples/sensor/sensor_shell/pytest/test_sensor_shell.py
@@ -21,16 +21,12 @@ def test_sensor_shell_info(shell: Shell):
 def test_sensor_shell_get(shell: Shell):
     logger.info('send "sensor get" command')
 
-    lines = shell.exec_command('sensor get sensor@0 voltage')
-    assert any(['channel type=31(voltage)' in line for line in lines]), 'expected response not found'
-
-    lines = shell.exec_command('sensor get sensor@1 53')
-    assert any(['channel type=53(gauge_state_of_health)' in line for line in lines]), 'expected response not found'
-
     # Channel should be the last one before 'all' (because 'all' doesn't print anything) so that the
     # for-loop in `parse_named_int()` will go through everything
-    lines = shell.exec_command('sensor get sensor@0 gauge_desired_charging_current')
-    assert any(['channel type=59(gauge_desired_charging_current)' in line for line in lines]), 'expected response not found'
+    for channel in range(59):
+        logger.info(f'channel {channel}')
+        lines = shell.exec_command(f'sensor get sensor@0 {channel}')
+        assert any([f'channel type={channel}' in line for line in lines]), 'expected response not found'
 
     logger.info('response is valid')
 

--- a/tests/drivers/build_all/sensor/src/generic_test.c
+++ b/tests/drivers/build_all/sensor/src/generic_test.c
@@ -217,33 +217,8 @@ static void run_generic_test(const struct device *dev)
 			q31_t q;
 			int8_t shift;
 
-			switch (ch) {
-			/* Special handling to break out triplet samples. */
-			case SENSOR_CHAN_MAGN_X:
-			case SENSOR_CHAN_ACCEL_X:
-			case SENSOR_CHAN_GYRO_X:
-				q = decoded_data.three_axis.readings[0].x;
-				shift = decoded_data.three_axis.shift;
-				break;
-			case SENSOR_CHAN_MAGN_Y:
-			case SENSOR_CHAN_ACCEL_Y:
-			case SENSOR_CHAN_GYRO_Y:
-				q = decoded_data.three_axis.readings[0].y;
-				shift = decoded_data.three_axis.shift;
-				break;
-			case SENSOR_CHAN_MAGN_Z:
-			case SENSOR_CHAN_ACCEL_Z:
-			case SENSOR_CHAN_GYRO_Z:
-				q = decoded_data.three_axis.readings[0].z;
-				shift = decoded_data.three_axis.shift;
-				break;
-
-			/* Default case for single Q31 samples */
-			default:
-				q = decoded_data.q31.readings[0].value;
-				shift = decoded_data.q31.shift;
-				break;
-			}
+			q = decoded_data.q31.readings[0].value;
+			shift = decoded_data.q31.shift;
 
 			/* Align everything to be a 64-bit Q32.32 number for comparison */
 			int64_t expected_shifted =


### PR DESCRIPTION
### Description
This PR allows the sensor-shell to process individual axis data by making two changes:
1. Allow _sensor_shell_ to request/process individual axis data.
2. Fix the default decoder to properly distinguish individual axis data from 3-axis data.

Fixes #72840

### Testing

- Build and Run
``` console
west build -b native_sim -t run samples/sensor/sensor_shell/ -- -DCONFIG_SAMPLES_SENSOR_SHELL_FAKE_SENSOR=y
```
- Console output
``` console
uart:~$ sensor get sensor@0 accel_x
channel type=0(accel_x) index=0 shift=0 num_samples=1 value=10660000000ns (0.000000)
uart:~$ sensor get sensor@0 accel_y
channel type=1(accel_y) index=0 shift=1 num_samples=1 value=11800000000ns (1.000000)
uart:~$ sensor get sensor@0 accel_z
channel type=2(accel_z) index=0 shift=2 num_samples=1 value=12800000000ns (2.000000)
uart:~$ sensor get sensor@0 accel_xyz
channel type=0(accel_x) index=0 shift=2 num_samples=1 value=15870000000ns (3.000000)
channel type=1(accel_y) index=0 shift=2 num_samples=1 value=15870000000ns (3.000000)
channel type=2(accel_z) index=0 shift=2 num_samples=1 value=15870000000ns (3.000000)
channel type=3(accel_xyz) index=0 shift=2 num_samples=1 value=15870000000ns, (3.000000, 3.000000, 3.000000)
uart:~$ sensor get sensor@0 gyro_x
channel type=4(gyro_x) index=0 shift=3 num_samples=1 value=25600000000ns (4.000000)
uart:~$ sensor get sensor@0 gyro_y
channel type=5(gyro_y) index=0 shift=3 num_samples=1 value=26640000000ns (5.000000)
uart:~$ sensor get sensor@0 gyro_z
channel type=6(gyro_z) index=0 shift=3 num_samples=1 value=27560000000ns (6.000000)
uart:~$ sensor get sensor@0 gyro_xyz
channel type=4(gyro_x) index=0 shift=3 num_samples=1 value=28880000000ns (7.000000)
channel type=5(gyro_y) index=0 shift=3 num_samples=1 value=28880000000ns (7.000000)
channel type=6(gyro_z) index=0 shift=3 num_samples=1 value=28880000000ns (7.000000)
channel type=7(gyro_xyz) index=0 shift=3 num_samples=1 value=28880000000ns, (7.000000, 7.000000, 7.000000)
uart:~$ 
```