### PR TITLE
net: websocket: don't mask data sent from server via zvfs write

### DIFF
--- a/subsys/net/lib/websocket/websocket.c
+++ b/subsys/net/lib/websocket/websocket.c
@@ -276,6 +276,7 @@ int websocket_connect(int sock, struct websocket_request *wreq,
 	ctx->recv_buf.size = wreq->tmp_buf_len;
 	ctx->sec_accept_key = sec_accept_key;
 	ctx->http_cb = wreq->http_cb;
+	ctx->is_client = 1;
 
 	mbedtls_sha1((const unsigned char *)&rnd_value, sizeof(rnd_value),
 			 sec_accept_key);
@@ -1070,9 +1071,8 @@ static int websocket_send(struct websocket_context *ctx, const uint8_t *buf,
 
 	NET_DBG("[%p] Sending %zd bytes", ctx, buf_len);
 
-	ret = websocket_send_msg(ctx->sock, buf, buf_len,
-				 WEBSOCKET_OPCODE_DATA_TEXT,
-				 true, true, timeout);
+	ret = websocket_send_msg(ctx->sock, buf, buf_len, WEBSOCKET_OPCODE_DATA_TEXT,
+				 ctx->is_client, true, timeout);
 	if (ret < 0) {
 		errno = -ret;
 		return -1;
@@ -1184,6 +1184,7 @@ int websocket_register(int sock, uint8_t *recv_buf, size_t recv_buf_len)
 	ctx->real_sock = sock;
 	ctx->recv_buf.buf = recv_buf;
 	ctx->recv_buf.size = recv_buf_len;
+	ctx->is_client = 0;
 
 	fd = zvfs_reserve_fd();
 	if (fd < 0) {

--- a/subsys/net/lib/websocket/websocket_internal.h
+++ b/subsys/net/lib/websocket/websocket_internal.h
@@ -119,6 +119,9 @@ __net_socket struct websocket_context {
 
 	/** Did we receive all from peer during HTTP handshake */
 	uint8_t all_received : 1;
+
+	/** 1 if this websocket is a client, 0 if a server */
+	uint8_t is_client : 1;
 };
 
 #if defined(CONFIG_NET_TEST)


### PR DESCRIPTION
RFC6455 section 5.1 specifies that "A server MUST NOT mask any frames that it sends to the client". Implement this for websocket write calls via ZVFS, by storing in the websocket_context whether a socket is acting in the client or server role, and using this to determine if sent data should be masked.

Previously this was causing issues with the websocket console (see https://github.com/zephyrproject-rtos/zephyr/pull/72514), which worked in Firefox but not in Chrome. It seems that Firefox is tolerant of masked websocket messages sent by a server, while Chrome considers this an error and immediately closes the connection.