### PR TITLE
newlib: correct signature of _open() for xtensa

### DIFF
--- a/lib/libc/newlib/libc-hooks.c
+++ b/lib/libc/newlib/libc-hooks.c
@@ -26,7 +26,7 @@
 int _fstat(int fd, struct stat *st);
 int _read(int fd, void *buf, int nbytes);
 int _write(int fd, const void *buf, int nbytes);
-int _open(const char *name, int mode);
+int _open(const char *name, int flags, ...);
 int _close(int file);
 int _lseek(int file, int ptr, int dir);
 int _kill(int pid, int sig);
@@ -239,7 +239,7 @@ int _write(int fd, const void *buf, int nbytes)
 }
 __weak FUNC_ALIAS(_write, write, int);
 
-int _open(const char *name, int mode)
+int _open(const char *name, int flags, ...)
 {
 	return -1;
 }
@@ -518,7 +518,7 @@ int _open_r(struct _reent *r, const char *name, int flags, int mode)
 	ARG_UNUSED(r);
 	ARG_UNUSED(flags);
 
-	return _open(name, mode);
+	return _open(name, flags, mode);
 }
 
 int _close_r(struct _reent *r, int file)


### PR DESCRIPTION
Previously, in `newlib/libc-hooks.c`, the signature of `_open()` was as shown below.

```cpp
int _open(const char *name, int mode);
```

This conflicted with the signature of `_open()` [from newlib](https://github.com/zephyrproject-rtos/newlib-cygwin/blob/fc9428506eb4a49902b04b26ad2f99592234f953/newlib/libc/include/sys/_default_fcntl.h#L232), which is

```cpp
int _open(const char *name, int flags, ...);
```

Moreover, the mode and flags field were reversed, but only for the Xtensa architecture due to the `_open_r()` hook that is present in `libc-hooks.c`.

This manifested itself via a call to `fopen(file, "w+")`, where the expected flags should include `O_CREAT | O_TRUNC`, or `0x200 | 0x400`. Instead, the unexpected flags passed to the underlying `zvfs_open()` call were `0x1b6`.

This change corrects the function signature and order of the arguments.

Fixes #83482