### PR TITLE
os: fdtable: set offset to zero with newly reserved fd's

### DIFF
--- a/lib/os/fdtable.c
+++ b/lib/os/fdtable.c
@@ -249,6 +249,7 @@ int zvfs_reserve_fd(void)
 		(void)z_fd_ref(fd);
 		fdtable[fd].obj = NULL;
 		fdtable[fd].vtable = NULL;
+		fdtable[fd].offset = 0;
 		k_mutex_init(&fdtable[fd].lock);
 		k_condvar_init(&fdtable[fd].cond);
 	}


### PR DESCRIPTION
If a file object is is re-used, it could inherit the offset field of the previously closed file object, making reading from the beginning of the file impossible until the offset was manually zero'ed.

The offset should *always* be zero when a file is ready to be used.

The issue really only presents itself when implementing a vtable backend.