### PR TITLE
posix: options: remove default setting of toolchain option

### DIFF
--- a/lib/posix/options/Kconfig.c_lang_r
+++ b/lib/posix/options/Kconfig.c_lang_r
@@ -9,7 +9,6 @@ config POSIX_C_LANG_SUPPORT_R
 	select COMMON_LIBC_CTIME_R if ! TC_PROVIDES_POSIX_C_LANG_SUPPORT_R
 	select COMMON_LIBC_GMTIME_R if ! TC_PROVIDES_POSIX_C_LANG_SUPPORT_R
 	select COMMON_LIBC_LOCALTIME_R_UTC if ! TC_PROVIDES_POSIX_C_LANG_SUPPORT_R
-	default y if TC_PROVIDES_POSIX_C_LANG_SUPPORT_R
 	help
 	  Select 'y' here and Zephyr will provide an implementation of the POSIX_C_LANG_SUPPORT_R
 	  Option Group, consisting of asctime_r(), ctime_r(), gmtime_r(), localtime_r(), rand_r(),


### PR DESCRIPTION
Do not set TC_PROVIDES_POSIX_C_LANG_SUPPORT_R as the default in lib/posix/options/Kconfig.c_lang_r . TC_PROVIDES options are only intended to be set by external C libraries that implement parts of the POSIX standard so that multiple symbols aren't defined at link time.