### PR TITLE
posix: fcntl.h: define constants in terms of zvfs constants

### DIFF
--- a/include/zephyr/posix/fcntl.h
+++ b/include/zephyr/posix/fcntl.h
@@ -7,28 +7,23 @@
 #ifndef ZEPHYR_POSIX_FCNTL_H_
 #define ZEPHYR_POSIX_FCNTL_H_
 
-#ifdef CONFIG_PICOLIBC
-#define O_CREAT	 0x0040
-#define O_TRUNC	 0x0200
-#define O_APPEND 0x0400
-#else
-#define O_CREAT	 0x0200
-#define O_TRUNC	 0x0400
-#define O_APPEND 0x0008
-#endif
+#include <zephyr/sys/fdtable.h>
 
-#define O_ACCMODE (O_RDONLY | O_WRONLY | O_RDWR)
+#define O_APPEND   ZVFS_O_APPEND
+#define O_CREAT    ZVFS_O_CREAT
+#define O_EXCL     ZVFS_O_EXCL
+#define O_NONBLOCK ZVFS_O_NONBLOCK
+#define O_TRUNC    ZVFS_O_TRUNC
 
-#define O_RDONLY 00
-#define O_WRONLY 01
-#define O_RDWR	 02
+#define O_ACCMODE (ZVFS_O_RDONLY | ZVFS_O_RDWR | ZVFS_O_WRONLY)
 
-#define O_EXCL	   0x0800
-#define O_NONBLOCK 0x4000
+#define O_RDONLY ZVFS_O_RDONLY
+#define O_RDWR   ZVFS_O_RDWR
+#define O_WRONLY ZVFS_O_WRONLY
 
-#define F_DUPFD 0
-#define F_GETFL 3
-#define F_SETFL 4
+#define F_DUPFD ZVFS_F_DUPFD
+#define F_GETFL ZVFS_F_GETFL
+#define F_SETFL ZVFS_F_SETFL
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/zephyr/sys/fdtable.h
+++ b/include/zephyr/sys/fdtable.h
@@ -14,6 +14,27 @@
 #include <zephyr/kernel.h>
 #include <zephyr/sys/util.h>
 
+#ifdef CONFIG_PICOLIBC
+#define ZVFS_O_APPEND 0x0400
+#define ZVFS_O_CREAT  0x0040
+#define ZVFS_O_TRUNC  0x0200
+#else
+#define ZVFS_O_APPEND 0x0008
+#define ZVFS_O_CREAT  0x0200
+#define ZVFS_O_TRUNC  0x0400
+#endif
+
+#define ZVFS_O_RDONLY 00
+#define ZVFS_O_WRONLY 01
+#define ZVFS_O_RDWR   02
+
+#define ZVFS_O_EXCL     0x0800
+#define ZVFS_O_NONBLOCK 0x4000
+
+#define ZVFS_F_DUPFD 0
+#define ZVFS_F_GETFL 3
+#define ZVFS_F_SETFL 4
+
 /* File mode bits */
 #define ZVFS_MODE_IFMT   0170000
 #define ZVFS_MODE_UNSPEC 0000000

--- a/lib/os/fdtable.c
+++ b/lib/os/fdtable.c
@@ -18,7 +18,6 @@
 #include <string.h>
 #include <stdio.h>
 
-#include <zephyr/posix/fcntl.h>
 #include <zephyr/kernel.h>
 #include <zephyr/sys/fdtable.h>
 #include <zephyr/sys/speculation.h>


### PR DESCRIPTION
Define `fcntl.h` constants in terms of zvfs constants.