### PR TITLE
drivers: sedi: Update device definition macros to use DT_INST variants

### DIFF
--- a/drivers/dma/dma_sedi.c
+++ b/drivers/dma/dma_sedi.c
@@ -376,7 +376,7 @@ static int dma_sedi_init(const struct device *dev)
 		.chn_num = DT_INST_PROP(inst, dma_channels), \
 		.irq_config = dma_sedi_##inst##_irq_config \
 	}; \
-	DEVICE_DT_DEFINE(DT_INST(inst, DT_DRV_COMPAT), &dma_sedi_init, \
+	DEVICE_DT_INST_DEFINE(inst, &dma_sedi_init, \
 	      NULL, &dma_sedi_dev_data_##inst, &dma_sedi_config_data_##inst, PRE_KERNEL_2, \
 	      CONFIG_KERNEL_INIT_PRIORITY_DEVICE, (void *)&dma_funcs); \
 									\

--- a/drivers/i2c/i2c_sedi.c
+++ b/drivers/i2c/i2c_sedi.c
@@ -237,8 +237,8 @@ static void i2c_sedi_isr(const struct device *dev)
 		.cb_sedi = &i2c_sedi_callback_##n,                                                 \
 		.irq_config = &i2c_sedi_irq_config_##n,                                            \
 	};                                                                                         \
-	PM_DEVICE_DT_DEFINE(DT_NODELABEL(i2c##n), i2c_sedi_pm_action);                             \
-	I2C_DEVICE_DT_INST_DEFINE(n, i2c_sedi_init, PM_DEVICE_DT_GET(DT_NODELABEL(i2c##n)),        \
+	PM_DEVICE_DT_INST_DEFINE(n, i2c_sedi_pm_action);                                           \
+	I2C_DEVICE_DT_INST_DEFINE(n, i2c_sedi_init, PM_DEVICE_DT_INST_GET(n),                      \
 				  &i2c_sedi_data_##n, &i2c_sedi_config_##n, PRE_KERNEL_2,          \
 				  CONFIG_I2C_INIT_PRIORITY, &i2c_sedi_apis);
 

--- a/drivers/ipm/ipm_sedi.c
+++ b/drivers/ipm/ipm_sedi.c
@@ -284,10 +284,10 @@ static DEVICE_API(ipm, ipm_funcs) = {
 			    DT_INST_PROP(n, peripheral_id),		\
 			    DT_INST_IRQ(n, sense));			\
 	}								\
-	PM_DEVICE_DT_DEFINE(DT_NODELABEL(ipm##n), ipm_power_ctrl);	\
+	PM_DEVICE_DT_INST_DEFINE(n, ipm_power_ctrl);			\
 	DEVICE_DT_INST_DEFINE(n,					\
 			      &ipm_init,				\
-			      PM_DEVICE_DT_GET(DT_NODELABEL(ipm##n)),   \
+			      PM_DEVICE_DT_INST_GET(n),			\
 			      &ipm_data_##n,				\
 			      &ipm_config_##n,				\
 			      POST_KERNEL,				\

--- a/drivers/serial/uart_sedi.c
+++ b/drivers/serial/uart_sedi.c
@@ -63,11 +63,11 @@ static void uart_sedi_cb(struct device *port);
 	};							      \
 								      \
 	static struct uart_sedi_drv_data drv_data_##n;		      \
-	PM_DEVICE_DT_DEFINE(DT_NODELABEL(uart##n),                    \
+	PM_DEVICE_DT_INST_DEFINE(n,                                   \
 			    uart_sedi_pm_action);		      \
-	DEVICE_DT_DEFINE(DT_NODELABEL(uart##n),		              \
+	DEVICE_DT_INST_DEFINE(n,			              \
 		      &uart_sedi_init,				      \
-		      PM_DEVICE_DT_GET(DT_NODELABEL(uart##n)),        \
+		      PM_DEVICE_DT_INST_GET(n),			      \
 		      &drv_data_##n, &config_info_##n,		      \
 		      PRE_KERNEL_1,				      \
 		      CONFIG_SERIAL_INIT_PRIORITY, &api);	      \

--- a/drivers/spi/spi_sedi.c
+++ b/drivers/spi/spi_sedi.c
@@ -406,10 +406,10 @@ static int spi_sedi_device_ctrl(const struct device *dev,
 		DEVICE_MMIO_ROM_INIT(DT_DRV_INST(num)),                        \
 		.spi_device = num, .irq_config = spi_##num##_irq_init,         \
 	};								       \
-	PM_DEVICE_DEFINE(spi_##num, spi_sedi_device_ctrl);		       \
+	PM_DEVICE_DT_INST_DEFINE(spi_##num, spi_sedi_device_ctrl);	       \
 	SPI_DEVICE_DT_INST_DEFINE(num,					       \
 			      spi_sedi_init,				       \
-			      PM_DEVICE_GET(spi_##num),		               \
+			      PM_DEVICE_DT_INST_GET(spi_##num),	               \
 			      &spi_##num##_data,			       \
 			      &spi_##num##_config,			       \
 			      POST_KERNEL,				       \


### PR DESCRIPTION
Updated various device definition macros to use the DT_INST variants for consistency and improved readability.