### PR TITLE
drivers: watchdog: kconfig option for callback support

### DIFF
--- a/doc/releases/release-notes-4.1.rst
+++ b/doc/releases/release-notes-4.1.rst
@@ -257,6 +257,9 @@ Drivers and Sensors
 
 * Watchdog
 
+  * Added :kconfig:option:`CONFIG_HAS_WDT_NO_CALLBACKS` which drivers select when they do not support
+    a callback being provided in :c:struct:`wdt_timeout_cfg`.
+
 * Wi-Fi
 
 Networking

--- a/drivers/watchdog/Kconfig
+++ b/drivers/watchdog/Kconfig
@@ -20,6 +20,11 @@ config WDT_DISABLE_AT_BOOT
 	help
 	  Disable watchdog at Zephyr system startup.
 
+config HAS_WDT_NO_CALLBACKS
+	bool
+	help
+	  Watchdog driver does not support callbacks.
+
 module = WDT
 module-str = watchdog
 source "subsys/logging/Kconfig.template.log_config"

--- a/drivers/watchdog/Kconfig.gd32
+++ b/drivers/watchdog/Kconfig.gd32
@@ -14,6 +14,7 @@ config WWDGT_GD32
 	bool "GD32 Window watchdog timer (WWDGT) Driver"
 	default y
 	depends on DT_HAS_GD_GD32_WWDGT_ENABLED
+	select HAS_WDT_NO_CALLBACKS
 	select USE_GD32_WWDGT
 	help
 	  Enable the Window watchdog timer (WWDGT) driver for GD32 SoCs.

--- a/drivers/watchdog/Kconfig.rpi_pico
+++ b/drivers/watchdog/Kconfig.rpi_pico
@@ -6,6 +6,7 @@ config WDT_RPI_PICO
 	default y
 	depends on DT_HAS_RASPBERRYPI_PICO_WATCHDOG_ENABLED
 	select HAS_WDT_DISABLE_AT_BOOT
+	select HAS_WDT_NO_CALLBACKS
 
 config WDT_RPI_PICO_INITIAL_TIMEOUT
 	int "Default watchdog timeout in us"

--- a/drivers/watchdog/Kconfig.smartbond
+++ b/drivers/watchdog/Kconfig.smartbond
@@ -8,6 +8,7 @@ config WDT_SMARTBOND
 	default y
 	depends on DT_HAS_RENESAS_SMARTBOND_WATCHDOG_ENABLED
 	select HAS_WDT_DISABLE_AT_BOOT
+	select HAS_WDT_NO_CALLBACKS if !WDT_SMARTBOND_NMI
 	help
 	  Enable watchdog driver for Smartbond line of MCUs
 

--- a/drivers/watchdog/Kconfig.stm32
+++ b/drivers/watchdog/Kconfig.stm32
@@ -10,6 +10,7 @@ menuconfig IWDG_STM32
 	default y
 	depends on DT_HAS_ST_STM32_WATCHDOG_ENABLED
 	select HAS_WDT_DISABLE_AT_BOOT
+	select HAS_WDT_NO_CALLBACKS
 	help
 	  Enable IWDG driver for STM32 line of MCUs
 

--- a/drivers/watchdog/Kconfig.tco
+++ b/drivers/watchdog/Kconfig.tco
@@ -8,5 +8,6 @@ config WDT_TCO
 	default y
 	depends on DT_HAS_INTEL_TCO_WDT_ENABLED
 	select HAS_WDT_DISABLE_AT_BOOT
+	select HAS_WDT_NO_CALLBACKS
 	help
 	  Enable support for Intel TCO WDT driver.

--- a/drivers/watchdog/Kconfig.ti_tps382x
+++ b/drivers/watchdog/Kconfig.ti_tps382x
@@ -7,6 +7,7 @@ config WDT_TI_TPS382X
 	default y
 	depends on DT_HAS_TI_TPS382X_ENABLED
 	depends on GPIO
+	select HAS_WDT_NO_CALLBACKS
 	help
 	  Enable WDT driver for TI TPS382x. This is an external IC and requires
 	  a GPIO connection from the processor.


### PR DESCRIPTION
Add a non-configurable option which drivers can select to indicate that they do not support callbacks on watchdog expiry.

`HAS_WDT_NO_CALLBACKS` was chosen over `HAS_WDT_CALLBACKS` since the majority of the driver do support callbacks.