### PR TITLE
watchdog: cmsdk_apb: fix API conformance

### DIFF
--- a/drivers/watchdog/wdt_cmsdk_apb.c
+++ b/drivers/watchdog/wdt_cmsdk_apb.c
@@ -88,6 +88,10 @@ static int wdog_cmsdk_apb_setup(const struct device *dev, uint8_t options)
 	ARG_UNUSED(dev);
 	ARG_UNUSED(options);
 
+	/* Reset pending interrupts before starting */
+	wdog->intclr = CMSDK_APB_WDOG_INTCLR;
+	wdog->load = reload_cycles;
+
 	/* Start the watchdog counter with INTEN bit */
 	wdog->ctrl = (CMSDK_APB_WDOG_CTRL_RESEN | CMSDK_APB_WDOG_CTRL_INTEN);
 

--- a/drivers/watchdog/wdt_cmsdk_apb.c
+++ b/drivers/watchdog/wdt_cmsdk_apb.c
@@ -69,6 +69,7 @@ const struct device *wdog_r;
 static unsigned int reload_cycles = CMSDK_APB_WDOG_RELOAD;
 static uint8_t assigned_channels;
 static uint8_t flags;
+static bool enabled;
 
 static void (*user_cb)(const struct device *dev, int channel_id);
 
@@ -88,6 +89,11 @@ static int wdog_cmsdk_apb_setup(const struct device *dev, uint8_t options)
 	ARG_UNUSED(dev);
 	ARG_UNUSED(options);
 
+	/* Check if watchdog is already running */
+	if (enabled) {
+		return -EBUSY;
+	}
+
 	/* Reset pending interrupts before starting */
 	wdog->intclr = CMSDK_APB_WDOG_INTCLR;
 	wdog->load = reload_cycles;
@@ -95,6 +101,7 @@ static int wdog_cmsdk_apb_setup(const struct device *dev, uint8_t options)
 	/* Start the watchdog counter with INTEN bit */
 	wdog->ctrl = (CMSDK_APB_WDOG_CTRL_RESEN | CMSDK_APB_WDOG_CTRL_INTEN);
 
+	enabled = true;
 	return 0;
 }
 
@@ -107,6 +114,7 @@ static int wdog_cmsdk_apb_disable(const struct device *dev)
 	/* Stop the watchdog counter with INTEN bit */
 	wdog->ctrl = ~(CMSDK_APB_WDOG_CTRL_RESEN | CMSDK_APB_WDOG_CTRL_INTEN);
 
+	enabled = false;
 	assigned_channels = 0;
 
 	return 0;
@@ -122,6 +130,9 @@ static int wdog_cmsdk_apb_install_timeout(const struct device *dev,
 
 	if (config->window.max == 0) {
 		return -EINVAL;
+	}
+	if (enabled == true) {
+		return -EBUSY;
 	}
 	if (assigned_channels == 1) {
 		return -ENOMEM;


### PR DESCRIPTION
Reset the watchdog back to the initial state before enabling the
expiry interrupt. This prevents the watchdog expiring immediately if
there is a long gap between `wdt_install_timeout` and `wdt_setup`.

Do not allow attempting to install new channels after the watchdog has been started.