### PR TITLE
STM32: Vref sensor: take calibration data resolution into account

### DIFF
--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -1107,6 +1107,7 @@
 		compatible = "st,stm32-vref";
 		vrefint-cal-addr = <0x1FF1E860>;
 		vrefint-cal-mv = <3300>;
+		vrefint-cal-resolution = <16>;
 		status = "disabled";
 	};
 

--- a/dts/arm/st/u5/stm32u5.dtsi
+++ b/dts/arm/st/u5/stm32u5.dtsi
@@ -959,6 +959,7 @@
 		compatible = "st,stm32-vref";
 		vrefint-cal-addr = <0x0BFA07A5>;
 		vrefint-cal-mv = <3000>;
+		vrefint-cal-resolution = <14>;
 		io-channels = <&adc1 0>;
 		status = "disabled";
 	};
@@ -967,6 +968,7 @@
 		compatible = "st,stm32-vref";
 		vrefint-cal-addr = <0x0BFA07A5>;
 		vrefint-cal-mv = <3000>;
+		vrefint-cal-resolution = <14>;
 		io-channels = <&adc4 0>;
 		status = "disabled";
 	};

--- a/dts/bindings/sensor/st,stm32-vref.yaml
+++ b/dts/bindings/sensor/st,stm32-vref.yaml
@@ -21,3 +21,18 @@ properties:
     description: |
       VDDA/VREF+ voltage in millivolts applied during manufacturing to determine
       the internal bandgap voltage reference VREFINT.
+
+  vrefint-cal-resolution:
+    type: int
+    description: |
+      ADC resolution used for measuring calibration data
+
+      This is usually equal to the ADC's native resolution.
+
+      Most series have a 12-bit ADC, but 14-bit and 16-bit
+      also exists on e.g., STM32U5 and STM32H7 series.
+    default: 12
+    enum:
+      - 12
+      - 14
+      - 16


### PR DESCRIPTION
The `Vref+` sensor driver always reads the `VREFINT` channel using 12-bit resolution.
However, it does not take into account the resolution used to perform the read of calibration data (except for STM32U5 via a series-specific check). As a result, all readings for the STM32H7 series (which has calibration data acquired at 16-bit resolution) return a value for `Vref+` that is 2⁴=16 times too big.

Instead of adding yet another per-series hack, mirror the behavior of the `stm32_temp` driver by adding a property holding the calibration resolution to the binding, and updating the driver to take this new property into account.

Demonstration by running `samples/sensor/soc_voltage` on Nucleo-H743ZI2:

* Before the fix:
```
*** Booting Zephyr OS build v4.0.0-2814-ge01ae1567e19 ***
Sensor voltage[vref]: 52.58 V
Sensor voltage[vbat]: 3.33 V
```

* After the fix:
```
*** Booting Zephyr OS build v4.0.0-2817-g7c5f196ba111 ***
Sensor voltage[vref]: 3.28 V
Sensor voltage[vbat]: 3.33 V
```