### PR TITLE
posix: options: kconfig: fix typo informnation -> information

### DIFF
--- a/lib/posix/options/Kconfig.c_lang_r
+++ b/lib/posix/options/Kconfig.c_lang_r
@@ -15,5 +15,5 @@ config POSIX_C_LANG_SUPPORT_R
 	  Option Group, consisting of asctime_r(), ctime_r(), gmtime_r(), localtime_r(), rand_r(),
 	  strerror_r(), and strtok_r()
 
-	  For more informnation, please see
+	  For more information, please see
 	  https://pubs.opengroup.org/onlinepubs/9699919799/xrat/V4_subprofiles.html

--- a/lib/posix/options/Kconfig.c_lib_ext
+++ b/lib/posix/options/Kconfig.c_lib_ext
@@ -10,7 +10,7 @@ menuconfig POSIX_C_LIB_EXT
 	  stpcpy(), stpncpy(), strcasecmp(), strdup(), strfmon(), and strncasecmp(), strndup(), and
 	  strnlen().
 
-	  For more informnation, please see
+	  For more information, please see
 	  https://pubs.opengroup.org/onlinepubs/9699919799/xrat/V4_subprofiles.html
 
 if POSIX_C_LIB_EXT

--- a/lib/posix/options/Kconfig.device_io
+++ b/lib/posix/options/Kconfig.device_io
@@ -15,7 +15,7 @@ config POSIX_DEVICE_IO
 	  Group such as FD_CLR(), FD_ISSET(), FD_SET(), FD_ZERO(), close(), fdopen(), fileno(), open(),
 	  poll(), pread(), pselect(), pwrite(), read(), select(), and write().
 
-	  For more informnation, please see
+	  For more information, please see
 	  https://pubs.opengroup.org/onlinepubs/9699919799/xrat/V4_subprofiles.html
 
 if POSIX_DEVICE_IO

--- a/lib/posix/options/Kconfig.file_system_r
+++ b/lib/posix/options/Kconfig.file_system_r
@@ -10,5 +10,5 @@ config POSIX_FILE_SYSTEM_R
 	  Select 'y' here and Zephyr will provide an implementation of the POSIX_FILE_SYSTEM_R
 	  Option Group, consisting of readdir_r().
 
-	  For more informnation, please see
+	  For more information, please see
 	  https://pubs.opengroup.org/onlinepubs/9699919799/xrat/V4_subprofiles.html


### PR DESCRIPTION
A copy-paste error propogated this typo to a few different Kconfig files.

Correct 'informnation' to 'information'.

Thanks for catching this @kartben 👍 