### PR TITLE
posix: options: file_system_r: include sys/util.h header for MIN

### DIFF
--- a/lib/posix/options/file_system_r.c
+++ b/lib/posix/options/file_system_r.c
@@ -16,6 +16,7 @@
 #include <zephyr/fs/fs.h>
 #include <zephyr/posix/posix_features.h>
 #include <zephyr/posix/dirent.h>
+#include <zephyr/sys/util.h>
 
 int readdir_r(DIR *dirp, struct dirent *entry, struct dirent **result)
 {


### PR DESCRIPTION
Oddly, even though CI passed when the file_system_r change was merged, now CI has encountered a [build error](https://github.com/zephyrproject-rtos/zephyr/actions/runs/12583987928/job/35073476270?pr=83505) because MIN() was not defined.

Include `<zephyr/sys/util.h>` to pull in the definition.