### PR TITLE
drivers: sensor: ams/tsl2591: Don't check return code of initial reset

### DIFF
--- a/drivers/sensor/ams/tsl2591/tsl2591.c
+++ b/drivers/sensor/ams/tsl2591/tsl2591.c
@@ -418,11 +418,11 @@ static int tsl2591_setup(const struct device *dev)
 	uint8_t device_id;
 	int ret;
 
-	ret = tsl2591_reg_write(dev, TSL2591_REG_CONFIG, TSL2591_SRESET);
-	if (ret < 0) {
-		LOG_ERR("Failed to reset device");
-		return ret;
-	}
+	/* Reset the sensor. Although this is not clearly documented in the datasheet,
+	 * it is  suspected that because the sensor is reset, it doesn't explicitly send
+	 * an ACK. Thus, don't check the return code.
+	 */
+	tsl2591_reg_write(dev, TSL2591_REG_CONFIG, TSL2591_SRESET);
 
 	ret = tsl2591_reg_read(dev, TSL2591_REG_ID, &device_id, 1U);
 	if (ret < 0) {


### PR DESCRIPTION
The TSL2591 driver fails to initialize because the sensor responds with a NACK on the initial RESET. Although the datasheet from Adafruit claims that this should be valid (RESET is part of the CONTROL register), other sample non-Zephyr drivers provided by Arduino don't explicitly reset the sensor on initialization (see
https://github.com/adafruit/Adafruit_TSL2591_Library/blob/master/Adafruit_TSL2591.cpp).

After removing this initial RESET, the driver initializes successfully.