### PR TITLE
drivers: counter: sam: Allow empty pinctrl config

### DIFF
--- a/drivers/counter/counter_sam_tc.c
+++ b/drivers/counter/counter_sam_tc.c
@@ -319,7 +319,7 @@ static int counter_sam_initialize(const struct device *dev)
 
 	/* Connect pins to the peripheral */
 	retval = pinctrl_apply_state(dev_cfg->pcfg, PINCTRL_STATE_DEFAULT);
-	if (retval < 0) {
+	if (retval < 0 && retval != -ENOENT) {
 		return retval;
 	}
 


### PR DESCRIPTION
The Atmel counter driver requires a valid pinctrl list to initialize. This relax this condition since the timer can be used as general purpose timer, which may not require a pin associated with the timer unit.

Fixes #83509