### PR TITLE
boards: esp32c3_supermini: increase board heap and stack

### DIFF
--- a/boards/others/esp32c3_supermini/Kconfig
+++ b/boards/others/esp32c3_supermini/Kconfig
@@ -5,4 +5,4 @@
 
 config HEAP_MEM_POOL_ADD_SIZE_BOARD
 	int
-	default 2048
+	default 4096

--- a/boards/others/esp32c3_supermini/esp32c3_supermini_defconfig
+++ b/boards/others/esp32c3_supermini/esp32c3_supermini_defconfig
@@ -1,6 +1,8 @@
 # Copyright (c) 2024 Arrel Neumiller
 # SPDX-License-Identifier: Apache-2.0
 
+CONFIG_MAIN_STACK_SIZE=2048
+
 CONFIG_CONSOLE=y
 CONFIG_SERIAL=y
 CONFIG_UART_CONSOLE=y


### PR DESCRIPTION
The heap and stack are now consistent with other ESP32-C3 boards in tree. This is necessary for Bluetooth to not crash on boot.