### PR TITLE
fs: littlefs: Block device cache size improvements

### DIFF
--- a/subsys/fs/Kconfig.littlefs
+++ b/subsys/fs/Kconfig.littlefs
@@ -56,8 +56,7 @@ config FS_LITTLEFS_LOOKAHEAD_SIZE
 	help
 	  A larger lookahead buffer increases the number of blocks found
 	  during an allocation pass. The lookahead buffer is stored as a
-	  compact bitmap, so each byte of RAM can track 8 blocks. Must
-	  be a multiple of 8.
+	  compact bitmap, so each byte of RAM can track 8 blocks.
 
 config FS_LITTLEFS_BLOCK_CYCLES
 	int "Number of erase cycles before moving data to another block"

--- a/subsys/fs/littlefs_fs.c
+++ b/subsys/fs/littlefs_fs.c
@@ -844,7 +844,6 @@ static int littlefs_init_cfg(struct fs_littlefs *fs, int flags)
 	lcp->context = fs->backend;
 	/* Set the validated/defaulted values. */
 	if (littlefs_on_blkdev(flags)) {
-		lfs_size_t new_cache_size = block_size;
 		lfs_size_t new_lookahead_size = block_size * 4;
 
 		lcp->read = lfs_api_read_blk;
@@ -854,12 +853,11 @@ static int littlefs_init_cfg(struct fs_littlefs *fs, int flags)
 		lcp->read_size = block_size;
 		lcp->prog_size = block_size;
 
-		if (cache_size < new_cache_size) {
+		if (cache_size < block_size) {
 			LOG_ERR("Configured cache size is too small: %d < %d", cache_size,
-				new_cache_size);
-			return -ENOMEM;
+				block_size);
 		}
-		lcp->cache_size = new_cache_size;
+		lcp->cache_size = ROUND_DOWN(cache_size, block_size);
 
 		if (lookahead_size < new_lookahead_size) {
 			LOG_ERR("Configured lookahead size is too small: %d < %d",

--- a/subsys/fs/littlefs_fs.c
+++ b/subsys/fs/littlefs_fs.c
@@ -844,8 +844,6 @@ static int littlefs_init_cfg(struct fs_littlefs *fs, int flags)
 	lcp->context = fs->backend;
 	/* Set the validated/defaulted values. */
 	if (littlefs_on_blkdev(flags)) {
-		lfs_size_t new_lookahead_size = block_size * 4;
-
 		lcp->read = lfs_api_read_blk;
 		lcp->prog = lfs_api_prog_blk;
 		lcp->erase = lfs_api_erase_blk;
@@ -859,12 +857,7 @@ static int littlefs_init_cfg(struct fs_littlefs *fs, int flags)
 		}
 		lcp->cache_size = ROUND_DOWN(cache_size, block_size);
 
-		if (lookahead_size < new_lookahead_size) {
-			LOG_ERR("Configured lookahead size is too small: %d < %d",
-				lookahead_size, new_lookahead_size);
-			return -ENOMEM;
-		}
-		lcp->lookahead_size = new_lookahead_size;
+		lcp->lookahead_size = lookahead_size;
 
 		lcp->sync = lfs_api_sync_blk;
 


### PR DESCRIPTION
Instead of picking a set of safe block multiple sized values for caches, round down to the nearest block multiple, increasing static buffer usage determined by Kconfig variables.