### PR TITLE
runners: openocd: support `--erase`

### DIFF
--- a/boards/common/openocd-stm32.board.cmake
+++ b/boards/common/openocd-stm32.board.cmake
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: Apache-2.0
+
+if(CONFIG_SOC_SERIES_STM32L0X OR CONFIG_SOC_SERIES_STM32L1X)
+  board_runner_args(openocd "--cmd-erase=stm32l1x mass_erase 0")
+elseif(CONFIG_SOC_SERIES_STM32L4X OR
+       CONFIG_SOC_SERIES_STM32L5X OR
+       CONFIG_SOC_SERIES_STM32U5X OR
+       CONFIG_SOC_SERIES_STM32WBX OR
+       CONFIG_SOC_SERIES_STM32G0X OR
+       CONFIG_SOC_SERIES_STM32G4X)
+  board_runner_args(openocd "--cmd-erase=stm32l4x mass_erase 0")
+elseif(CONFIG_SOC_SERIES_STM32F0X OR
+       CONFIG_SOC_SERIES_STM32F1X OR
+       CONFIG_SOC_SERIES_STM32F3X)
+  board_runner_args(openocd "--cmd-erase=stm32f1x mass_erase 0")
+elseif(CONFIG_SOC_SERIES_STM32F2X OR
+       CONFIG_SOC_SERIES_STM32F4X OR
+       CONFIG_SOC_SERIES_STM32F7X)
+  board_runner_args(openocd "--cmd-erase=stm32f2x mass_erase 0")
+endif()

--- a/boards/common/openocd.board.cmake
+++ b/boards/common/openocd.board.cmake
@@ -20,3 +20,6 @@ board_finalize_runner_args(openocd
   --cmd-load "${OPENOCD_CMD_LOAD_DEFAULT}"
   --cmd-verify "${OPENOCD_CMD_VERIFY_DEFAULT}"
   )
+
+# Manufacturer common options
+include(${CMAKE_CURRENT_LIST_DIR}/openocd-stm32.board.cmake)

--- a/doc/releases/release-notes-4.1.rst
+++ b/doc/releases/release-notes-4.1.rst
@@ -143,6 +143,10 @@ Build system and Infrastructure
     Twister XML reports have full testsuite name as ``testcase.classname property`` resolving
     possible duplicate testcase elements in ``twister_report.xml`` testsuite container.
 
+* West
+
+  * Added support for the ``--erase`` option on the OpenOCD runner for boards which specify ``--cmd-erase``.
+
 Drivers and Sensors
 *******************
 

--- a/scripts/west_commands/runners/openocd.py
+++ b/scripts/west_commands/runners/openocd.py
@@ -44,8 +44,8 @@ class OpenOcdBinaryRunner(ZephyrBinaryRunner):
     '''Runner front-end for openocd.'''
 
     def __init__(self, cfg, pre_init=None, reset_halt_cmd=DEFAULT_OPENOCD_RESET_HALT_CMD,
-                 pre_load=None, load_cmd=None, verify_cmd=None, post_verify=None,
-                 do_verify=False, do_verify_only=False,
+                 pre_load=None, erase_cmd=None, load_cmd=None, verify_cmd=None,
+                 post_verify=None, do_verify=False, do_verify_only=False, do_erase=False,
                  tui=None, config=None, serial=None, use_elf=None,
                  no_halt=False, no_init=False, no_targets=False,
                  tcl_port=DEFAULT_OPENOCD_TCL_PORT,
@@ -93,11 +93,13 @@ class OpenOcdBinaryRunner(ZephyrBinaryRunner):
         self.pre_init = pre_init or []
         self.reset_halt_cmd = reset_halt_cmd
         self.pre_load = pre_load or []
+        self.erase_cmd = erase_cmd
         self.load_cmd = load_cmd
         self.verify_cmd = verify_cmd
         self.post_verify = post_verify or []
         self.do_verify = do_verify or False
         self.do_verify_only = do_verify_only or False
+        self.do_erase = do_erase or False
         self.tcl_port = tcl_port
         self.telnet_port = telnet_port
         self.gdb_port = gdb_port
@@ -120,7 +122,8 @@ class OpenOcdBinaryRunner(ZephyrBinaryRunner):
 
     @classmethod
     def capabilities(cls):
-        return RunnerCaps(commands={'flash', 'debug', 'debugserver', 'attach', 'rtt'}, rtt=True)
+        return RunnerCaps(commands={'flash', 'debug', 'debugserver', 'attach', 'rtt'},
+                          rtt=True, erase=True)
 
     @classmethod
     def do_add_parser(cls, parser):
@@ -142,6 +145,8 @@ class OpenOcdBinaryRunner(ZephyrBinaryRunner):
         parser.add_argument('--cmd-pre-load', action='append',
                             help='''Command to run before flashing;
                             may be given multiple times''')
+        parser.add_argument('--cmd-erase', action='append',
+                            help='''Command to erase device; may be given multiple times''')
         parser.add_argument('--cmd-load',
                             help='''Command to load/flash binary
                             (required when flashing)''')
@@ -191,9 +196,9 @@ class OpenOcdBinaryRunner(ZephyrBinaryRunner):
         return OpenOcdBinaryRunner(
             cfg,
             pre_init=args.cmd_pre_init, reset_halt_cmd=args.cmd_reset_halt,
-            pre_load=args.cmd_pre_load, load_cmd=args.cmd_load,
+            pre_load=args.cmd_pre_load, erase_cmd=args.cmd_erase, load_cmd=args.cmd_load,
             verify_cmd=args.cmd_verify, post_verify=args.cmd_post_verify,
-            do_verify=args.verify, do_verify_only=args.verify_only,
+            do_verify=args.verify, do_verify_only=args.verify_only, do_erase=args.erase,
             tui=args.tui, config=args.config, serial=args.serial,
             use_elf=args.use_elf, no_halt=args.no_halt, no_init=args.no_init,
             no_targets=args.no_targets, tcl_port=args.tcl_port,
@@ -285,8 +290,20 @@ class OpenOcdBinaryRunner(ZephyrBinaryRunner):
 
         load_image = []
         if not self.do_verify_only:
-            load_image = ['-c', self.reset_halt_cmd,
-                          '-c', self.load_cmd + ' ' + hex_name]
+            # Halt target
+            load_image = ['-c', self.reset_halt_cmd]
+            # Perform any erase operations
+            if self.do_erase:
+                if self.erase_cmd is None:
+                    self.logger.error('--erase not supported for target without --cmd-erase')
+                    return
+                for erase_cmd in self.erase_cmd:
+                    load_image += ["-c", erase_cmd]
+                # Trim the "erase" from "flash write_image erase" since a mass erase is already done
+                if self.load_cmd.endswith(' erase'):
+                    self.load_cmd = self.load_cmd[:-6]
+            # Load image
+            load_image +=['-c', self.load_cmd + ' ' + hex_name]
 
         verify_image = []
         if self.do_verify or self.do_verify_only:


### PR DESCRIPTION
Add support for the `--erase` option on `west flash`, for boards that specify at least one `--cmd-erase` option.

Add the appropriate mass erase command for STM32 SoC families. Family to command mapping taken from:
      https://openocd.org/doc/html/Flash-Commands.html

I will admit that this is less useful for STM parts now that the default runner is `STM32_Programmer_CLI`, which natively supports `--erase`, but it may be useful for other SoC's.
![image](https://github.com/user-attachments/assets/00a99c24-6e51-4afd-ab9e-565cc5a279fd)
