### PR TITLE
Variable network buffer configurations

### DIFF
--- a/drivers/wifi/nrf_wifi/Kconfig.nrfwifi
+++ b/drivers/wifi/nrf_wifi/Kconfig.nrfwifi
@@ -561,6 +561,12 @@ config NET_TC_TX_COUNT
 
 endif # NETWORKING
 
+# nRF70 now uses variable buffers as default to optimize RAM usage. Default pool sizes are used, samples/apps can override
+# for higher performance.
+choice NET_PKT_DATA_ALLOC_TYPE
+	default NET_BUF_VARIABLE_DATA_SIZE
+endchoice
+
 config MAIN_STACK_SIZE
 	default 4096
 

--- a/subsys/net/ip/Kconfig
+++ b/subsys/net/ip/Kconfig
@@ -822,7 +822,7 @@ config NET_BUF_TX_COUNT
 	  Each data buffer will occupy CONFIG_NET_BUF_DATA_SIZE + smallish
 	  header (sizeof(struct net_buf)) amount of data.
 
-choice
+choice NET_PKT_DATA_ALLOC_TYPE
 	prompt "Network packet data allocator type"
 	default NET_BUF_FIXED_DATA_SIZE
 	help


### PR DESCRIPTION
Add a name to the existing Kconfig choice for better clarity. Add variable network configuration control into the driver, removing the need for per-sample settings.