### PR TITLE
drivers: nrf_wifi: Fix offloaded raw tx deinit API

### DIFF
--- a/drivers/wifi/nrf_wifi/off_raw_tx/src/off_raw_tx_api.c
+++ b/drivers/wifi/nrf_wifi/off_raw_tx/src/off_raw_tx_api.c
@@ -279,7 +279,6 @@ void nrf70_off_raw_tx_deinit(void)
 	}
 
 	nrf_wifi_fmac_off_raw_tx_deinit(off_raw_tx_drv_priv.fmac_priv);
-	nrf_wifi_osal_deinit();
 
 	k_spin_unlock(&off_raw_tx_drv_priv.lock, key);
 }


### PR DESCRIPTION
The osal apis spinlock - take, release and bus qspi sleep are trying to use ops after deinit. So removing osal deinit for temporary workaround.