### PR TITLE
boards: renesas: Fixing the pinctrl for SPI on ek_ra8d1

### DIFF
--- a/boards/renesas/ek_ra8d1/ek_ra8d1-pinctrl.dtsi
+++ b/boards/renesas/ek_ra8d1/ek_ra8d1-pinctrl.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Renesas Electronics Corporation
+ * Copyright (c) 2024-2025 Renesas Electronics Corporation
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -16,7 +16,7 @@
 		};
 	};
 
-	spi0_default: spi0_default {
+	spi1_default: spi1_default {
 		group1 {
 			/* MISO MOSI RSPCK SSL */
 			psels = <RA_PSEL(RA_PSEL_SPI, 4, 10)>,

--- a/boards/renesas/ek_ra8d1/ek_ra8d1.dts
+++ b/boards/renesas/ek_ra8d1/ek_ra8d1.dts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Renesas Electronics Corporation
+ * Copyright (c) 2024-2025 Renesas Electronics Corporation
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -154,12 +154,6 @@
 	status = "okay";
 };
 
-&sci0 {
-	/* sci0 and spi0 cannot be enabled together */
-	pinctrl-0 = <&sci9_default>;
-	pinctrl-names = "default";
-};
-
 &sci9 {
 	pinctrl-0 = <&sci9_default>;
 	pinctrl-names = "default";
@@ -174,8 +168,8 @@
 	status = "okay";
 };
 
-&spi0 {
-	pinctrl-0 = <&spi0_default>;
+&spi1 {
+	pinctrl-0 = <&spi1_default>;
 	pinctrl-names = "default";
 	status = "okay";
 };

--- a/tests/drivers/spi/spi_loopback/boards/ek_ra8d1.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/ek_ra8d1.overlay
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2024 Renesas Electronics Corporation
+ * Copyright (c) 2024-2025 Renesas Electronics Corporation
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&spi0 {
+&spi1 {
 	rx-dtc;
 	tx-dtc;
 	slow@0 {


### PR DESCRIPTION
Currently, the SPI pinctrl is incorrect for the spi0 node.
In this PR (https://github.com/zephyrproject-rtos/zephyr/pull/77850), we changed the pinctrl number for SPI from spi0 to spi1, but we forgot to update the node name to spi1.
This PR aims to fix this issue.