### PR TITLE
scripts: west_commands: fix type of path options

### DIFF
--- a/scripts/west_commands/patch.py
+++ b/scripts/west_commands/patch.py
@@ -96,6 +96,7 @@ class Patch(WestCommand):
             help="Directory containing patch files",
             metavar="DIR",
             default=_WEST_MANIFEST_DIR / WEST_PATCH_BASE,
+            type=Path,
         )
         parser.add_argument(
             "-l",
@@ -103,6 +104,7 @@ class Patch(WestCommand):
             help="Path to patches.yml file",
             metavar="FILE",
             default=_WEST_MANIFEST_DIR / WEST_PATCH_YAML,
+            type=Path,
         )
         parser.add_argument(
             "-w",
@@ -110,6 +112,7 @@ class Patch(WestCommand):
             help="West workspace",
             metavar="DIR",
             default=_WEST_TOPDIR,
+            type=Path,
         )
 
         subparsers = parser.add_subparsers(


### PR DESCRIPTION
Using `west patch` with the `--patch-base`, `--patch-yaml` or `--west-workspace` option results in an unhandled AttributeError in filter_args() because the function expects these args to be of type path. Adding the type to the argument definition forces argparse to create variables of type path.