### PR TITLE
Http Content Range

### DIFF
--- a/include/zephyr/net/http/client.h
+++ b/include/zephyr/net/http/client.h
@@ -197,9 +197,16 @@ struct http_response {
 	 */
 	uint16_t http_status_code;
 
+	/**
+	 * HTTP Content-Range response field value. Consist of range_start,
+	 * range_end and total_size. Total is set to 0 if not supplied.
+	 */
+	struct http_content_range content_range;
+
 	uint8_t cl_present : 1;       /**< Is Content-Length field present */
 	uint8_t body_found : 1;       /**< Is message body found */
 	uint8_t message_complete : 1; /**< Is HTTP message parsing complete */
+	uint8_t cr_present : 1;       /**< Is Content-Range field present */
 };
 
 /** HTTP client internal data that the application should not touch

--- a/include/zephyr/net/http/parser.h
+++ b/include/zephyr/net/http/parser.h
@@ -133,6 +133,8 @@ enum http_errno {
 	HPE_INVALID_CONTENT_LENGTH,
 	HPE_UNEXPECTED_CONTENT_LENGTH,
 	HPE_INVALID_CHUNK_SIZE,
+	HPE_INVALID_CONTENT_RANGE,
+	HPE_UNEXPECTED_CONTENT_RANGE,
 	HPE_INVALID_CONSTANT,
 	HPE_INVALID_INTERNAL_STATE,
 	HPE_STRICT,
@@ -143,6 +145,11 @@ enum http_errno {
 /* Get an http_errno value from an http_parser */
 #define HTTP_PARSER_ERRNO(p)            ((enum http_errno) (p)->http_errno)
 
+struct http_content_range {
+	uint64_t start;
+	uint64_t end;
+	uint64_t total;
+};
 
 struct http_parser {
 	/** PRIVATE **/
@@ -160,6 +167,8 @@ struct http_parser {
 	uint64_t content_length; /* # bytes in body (0 if no Content-Length
 				  * header)
 				  */
+	uint8_t content_range_present;
+	struct http_content_range content_range;
 	/** READ-ONLY **/
 	unsigned short http_major;
 	unsigned short http_minor;

--- a/include/zephyr/net/http/parser.h
+++ b/include/zephyr/net/http/parser.h
@@ -48,6 +48,7 @@ typedef unsigned __int64 uint64_t;
 #include <zephyr/net/http/method.h>
 #include <zephyr/net/http/parser_state.h>
 #include <zephyr/net/http/parser_url.h>
+#include <stdbool.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -167,7 +168,7 @@ struct http_parser {
 	uint64_t content_length; /* # bytes in body (0 if no Content-Length
 				  * header)
 				  */
-	uint8_t content_range_present;
+	bool content_range_present;
 	struct http_content_range content_range;
 	/** READ-ONLY **/
 	unsigned short http_major;

--- a/subsys/net/lib/http/http_parser.c
+++ b/subsys/net/lib/http/http_parser.c
@@ -100,7 +100,9 @@ int count_header_size(struct http_parser *parser, int bytes)
 
 #define PROXY_CONNECTION "proxy-connection"
 #define CONNECTION "connection"
+#define CONTENT "content-"
 #define CONTENT_LENGTH "content-length"
+#define CONTENT_RANGE "content-range"
 #define TRANSFER_ENCODING "transfer-encoding"
 #define UPGRADE "upgrade"
 #define CHUNKED "chunked"
@@ -183,11 +185,17 @@ enum header_states {
 	h_CON,
 	h_matching_connection,
 	h_matching_proxy_connection,
+	h_matching_content,
+	h_CONTENT_,
 	h_matching_content_length,
+	h_matching_content_range,
 	h_matching_transfer_encoding,
 	h_matching_upgrade,
 	h_connection,
 	h_content_length,
+	h_content_range_start,
+	h_content_range_end,
+	h_content_range_total,
 	h_transfer_encoding,
 	h_upgrade,
 	h_matching_transfer_encoding_chunked,
@@ -356,6 +364,8 @@ static struct {
 	{"HPE_INVALID_CONTENT_LENGTH", "invalid character in content-length "
 				       "header"},
 	{"HPE_UNEXPECTED_CONTENT_LENGTH", "unexpected content-length header"},
+	{"HPE_INVALID_CONTENT_RANGE", "invalid character in content-range header"},
+	{"HPE_UNEXPECTED_CONTENT_RANGE", "unexpected content-range header"},
 	{"HPE_INVALID_CHUNK_SIZE", "invalid character in chunk size header"},
 	{"HPE_INVALID_CONSTANT", "invalid constant string"},
 	{"HPE_INVALID_INTERNAL_STATE", "encountered unexpected internal state"},
@@ -392,7 +402,7 @@ int parser_header_state(struct http_parser *parser, char ch, char c)
 			parser->header_state = h_matching_connection;
 			break;
 		case 't':
-			parser->header_state = h_matching_content_length;
+			parser->header_state = h_matching_content;
 			break;
 		default:
 			parser->header_state = h_general;
@@ -424,7 +434,29 @@ int parser_header_state(struct http_parser *parser, char ch, char c)
 		}
 		break;
 
-	/* content-length */
+	/*content-length or content-range*/
+
+	case h_matching_content:
+		parser->index++;
+		cond1 = parser->index > sizeof(CONTENT) - 1;
+		if (cond1 || c != CONTENT[parser->index]) {
+			parser->header_state = h_general;
+		} else if (parser->index == sizeof(CONTENT) - 2) {
+			parser->header_state = h_CONTENT_;
+		}
+		break;
+
+	case h_CONTENT_:
+		parser->index++;
+		if (c == 'l') {
+			parser->header_state = h_matching_content_length;
+		} else if (c == 'r') {
+			parser->header_state = h_matching_content_range;
+		} else {
+			parser->header_state = h_general;
+		}
+		break;
+
 
 	case h_matching_content_length:
 		parser->index++;
@@ -433,6 +465,16 @@ int parser_header_state(struct http_parser *parser, char ch, char c)
 			parser->header_state = h_general;
 		} else if (parser->index == sizeof(CONTENT_LENGTH) - 2) {
 			parser->header_state = h_content_length;
+		}
+		break;
+
+	case h_matching_content_range:
+		parser->index++;
+		cond1 = parser->index > sizeof(CONTENT_RANGE) - 1;
+		if (cond1 || c != CONTENT_RANGE[parser->index]) {
+			parser->header_state = h_general;
+		} else if (parser->index == sizeof(CONTENT_RANGE) - 2) {
+			parser->header_state = h_content_range_start;
 		}
 		break;
 
@@ -462,6 +504,9 @@ int parser_header_state(struct http_parser *parser, char ch, char c)
 
 	case h_connection:
 	case h_content_length:
+	case h_content_range_start:
+	case h_content_range_end:
+	case h_content_range_total:
 	case h_transfer_encoding:
 	case h_upgrade:
 		if (ch != ' ') {
@@ -543,6 +588,117 @@ int header_states(struct http_parser *parser, const char *data, size_t len,
 		}
 
 		parser->content_length = t;
+		break;
+	}
+
+	case h_content_range_start: {
+		uint64_t t;
+		uint64_t value;
+
+		if (IS_ALPHA(ch)) {
+			break;
+		}
+
+		if (ch == ' ') {
+			break;
+		}
+
+		if (ch == '-' || ch == '*') {
+			h_state = h_content_range_end;
+			break;
+		}
+
+		if (UNLIKELY(!IS_NUM(ch))) {
+			SET_ERRNO(HPE_INVALID_CONTENT_RANGE);
+			parser->header_state = h_state;
+			return -1;
+		}
+
+		t = parser->content_range.start;
+		t *= 10U;
+		t += ch - '0';
+
+		/* Overflow? Test against a conservative limit for simplicity */
+		value = (ULLONG_MAX - 10) / 10;
+
+		if (UNLIKELY(value < parser->content_range.start)) {
+			SET_ERRNO(HPE_INVALID_CONTENT_RANGE);
+			parser->header_state = h_state;
+			return -1;
+		}
+
+		parser->content_range.start = t;
+		break;
+	}
+
+	case h_content_range_end: {
+		uint64_t t;
+		uint64_t value;
+
+		if (ch == ' ') {
+			break;
+		}
+
+		if (ch == '/') {
+			h_state = h_content_range_total;
+			break;
+		}
+
+		if (UNLIKELY(!IS_NUM(ch))) {
+			SET_ERRNO(HPE_INVALID_CONTENT_RANGE);
+			parser->header_state = h_state;
+			return -1;
+		}
+
+		t = parser->content_range.end;
+		t *= 10U;
+		t += ch - '0';
+
+		/* Overflow? Test against a conservative limit for simplicity */
+		value = (ULLONG_MAX - 10) / 10;
+
+		if (UNLIKELY(value < parser->content_range.end)) {
+			SET_ERRNO(HPE_INVALID_CONTENT_RANGE);
+			parser->header_state = h_state;
+			return -1;
+		}
+
+		parser->content_range.end = t;
+		break;
+	}
+
+	case h_content_range_total: {
+		uint64_t t;
+		uint64_t value;
+
+		if (ch == ' ') {
+			break;
+		}
+
+		if (ch == '*') {
+			break;
+		}
+
+		if (UNLIKELY(!IS_NUM(ch))) {
+			SET_ERRNO(HPE_INVALID_CONTENT_RANGE);
+			parser->header_state = h_state;
+			return -1;
+		}
+
+		t = parser->content_range.total;
+		t *= 10U;
+		t += ch - '0';
+
+		/* Overflow? Test against a conservative limit for simplicity */
+		value = (ULLONG_MAX - 10) / 10;
+
+		if (UNLIKELY(value < parser->content_range.total)) {
+			SET_ERRNO(HPE_INVALID_CONTENT_RANGE);
+			parser->header_state = h_state;
+			return -1;
+		}
+
+		parser->content_range.total = t;
 		break;
 	}
 
@@ -811,6 +967,10 @@ reexecute:
 			}
 			parser->flags = 0U;
 			parser->content_length = ULLONG_MAX;
+			parser->content_range.start = 0U;
+			parser->content_range.end = 0U;
+			parser->content_range.total = 0U;
+			parser->content_range_present = 0;
 
 			if (ch == 'H') {
 				UPDATE_STATE(s_res_or_resp_H);
@@ -1104,6 +1264,10 @@ reexecute:
 			}
 			parser->flags = 0U;
 			parser->content_length = ULLONG_MAX;
+			parser->content_range.start = 0U;
+			parser->content_range.end = 0U;
+			parser->content_range.total = 0U;
+			parser->content_range_present = 0;
 
 			if (UNLIKELY(!IS_ALPHA(ch))) {
 				SET_ERRNO(HPE_INVALID_METHOD);
@@ -1637,6 +1801,16 @@ reexecute:
 
 				parser->flags |= F_CONTENTLENGTH;
 				parser->content_length = ch - '0';
+				break;
+
+			case h_content_range_start:
+				if (parser->content_range_present) {
+					SET_ERRNO(HPE_UNEXPECTED_CONTENT_RANGE);
+					goto error;
+				}
+
+				parser->content_range_present = 1;
+				parser->content_range.start = 0;
 				break;
 
 			case h_connection:

--- a/subsys/net/lib/http/http_parser.c
+++ b/subsys/net/lib/http/http_parser.c
@@ -970,7 +970,7 @@ reexecute:
 			parser->content_range.start = 0U;
 			parser->content_range.end = 0U;
 			parser->content_range.total = 0U;
-			parser->content_range_present = 0;
+			parser->content_range_present = false;
 
 			if (ch == 'H') {
 				UPDATE_STATE(s_res_or_resp_H);
@@ -1267,7 +1267,7 @@ reexecute:
 			parser->content_range.start = 0U;
 			parser->content_range.end = 0U;
 			parser->content_range.total = 0U;
-			parser->content_range_present = 0;
+			parser->content_range_present = false;
 
 			if (UNLIKELY(!IS_ALPHA(ch))) {
 				SET_ERRNO(HPE_INVALID_METHOD);
@@ -1809,7 +1809,7 @@ reexecute:
 					goto error;
 				}
 
-				parser->content_range_present = 1;
+				parser->content_range_present = true;
 				parser->content_range.start = 0;
 				break;
 


### PR DESCRIPTION
Content-Range parsing has been added to the http subsystem.
PR consist of changes in:
- http_parser: Added parsing Content-Range header. Parsing is done by writing
the output to the output structure called "http_content_range". 
Structure contains fields: start, end, total. Unit automatically translates to bytes.

- http_client: If header field matches Content-Range scheme, fields are returned via
http_content_range struct. cr_present flag indicates that Content-Range is present.

Changes are much needed because currently Zephyr doesn't support Content-Range header, which
is extensively used approach in http-based download apps.
