### PR TITLE
tests: drivers: uart: Add nrf54l09pdk_nrf54l09_cpuapp target to tests

### DIFF
--- a/tests/drivers/uart/uart_async_api/boards/nrf54l09pdk_nrf54l09_cpuapp.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/nrf54l09pdk_nrf54l09_cpuapp.overlay
@@ -1,0 +1,26 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+&pinctrl {
+	uart21_default_alt: uart21_default_alt {
+		group1 {
+			psels = <NRF_PSEL(UART_TX, 1, 10)>,
+				<NRF_PSEL(UART_RX, 1, 11)>;
+		};
+	};
+
+	uart21_sleep_alt: uart21_sleep_alt {
+		group1 {
+			psels = <NRF_PSEL(UART_TX, 1, 10)>,
+				<NRF_PSEL(UART_RX, 1, 11)>;
+			low-power-enable;
+		};
+	};
+};
+
+dut: &uart21 {
+	status = "okay";
+	pinctrl-0 = <&uart21_default_alt>;
+	pinctrl-1 = <&uart21_sleep_alt>;
+	pinctrl-names = "default", "sleep";
+	current-speed = <115200>;
+};

--- a/tests/drivers/uart/uart_elementary/boards/nrf54l09pdk_nrf54l09_cpuapp.overlay
+++ b/tests/drivers/uart/uart_elementary/boards/nrf54l09pdk_nrf54l09_cpuapp.overlay
@@ -1,0 +1,31 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+&pinctrl {
+	uart21_default: uart21_default {
+		group1 {
+			psels = <NRF_PSEL(UART_TX, 1, 10)>,
+				<NRF_PSEL(UART_RX, 1, 11)>,
+				<NRF_PSEL(UART_RTS, 1, 8)>,
+				<NRF_PSEL(UART_CTS, 1, 9)>;
+		};
+	};
+
+	uart21_sleep: uart21_sleep {
+		group1 {
+			psels = <NRF_PSEL(UART_TX, 1, 10)>,
+				<NRF_PSEL(UART_RX, 1, 11)>,
+				<NRF_PSEL(UART_RTS, 1, 8)>,
+				<NRF_PSEL(UART_CTS, 1, 9)>;
+			low-power-enable;
+		};
+	};
+};
+
+dut: &uart21 {
+	status = "okay";
+	current-speed = <115200>;
+	pinctrl-0 = <&uart21_default>;
+	pinctrl-1 = <&uart21_sleep>;
+	pinctrl-names = "default", "sleep";
+	hw-flow-control;
+};

--- a/tests/drivers/uart/uart_elementary/testcase.yaml
+++ b/tests/drivers/uart/uart_elementary/testcase.yaml
@@ -11,6 +11,7 @@ tests:
     filter: CONFIG_SERIAL_SUPPORT_INTERRUPT
     platform_allow:
       - nrf54h20dk/nrf54h20/cpuapp
+      - nrf54l09pdk/nrf54l09/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l20pdk/nrf54l20/cpuapp
       - nrf54l15dk/nrf54l15/cpuflpr

--- a/tests/drivers/uart/uart_mix_fifo_poll/boards/nrf54l09pdk_nrf54l09_cpuapp.overlay
+++ b/tests/drivers/uart/uart_mix_fifo_poll/boards/nrf54l09pdk_nrf54l09_cpuapp.overlay
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&pinctrl {
+	uart21_default: uart21_default {
+		group1 {
+			psels = <NRF_PSEL(UART_TX, 1, 10)>,
+				<NRF_PSEL(UART_RX, 1, 11)>,
+				<NRF_PSEL(UART_RTS, 1, 8)>,
+				<NRF_PSEL(UART_CTS, 1, 9)>;
+		};
+	};
+
+	uart21_sleep: uart21_sleep {
+		group1 {
+			psels = <NRF_PSEL(UART_TX, 1, 10)>,
+				<NRF_PSEL(UART_RX, 1, 11)>,
+				<NRF_PSEL(UART_RTS, 1, 8)>,
+				<NRF_PSEL(UART_CTS, 1, 9)>;
+			low-power-enable;
+		};
+	};
+};
+
+dut: &uart21 {
+	status = "okay";
+	current-speed = <115200>;
+	pinctrl-0 = <&uart21_default>;
+	pinctrl-1 = <&uart21_sleep>;
+	pinctrl-names = "default", "sleep";
+	hw-flow-control;
+};
+
+counter_dev: &timer00 {
+	status = "okay";
+};
+
+&grtc {
+	interrupts = <228 2>;
+};

--- a/tests/drivers/uart/uart_mix_fifo_poll/testcase.yaml
+++ b/tests/drivers/uart/uart_mix_fifo_poll/testcase.yaml
@@ -9,6 +9,7 @@ common:
     - nrf9160dk/nrf9160
     - nrf5340dk/nrf5340/cpuapp
     - nrf5340bsim/nrf5340/cpuapp
+    - nrf54l09pdk/nrf54l09/cpuapp
     - nrf54l15dk/nrf54l15/cpuapp
     - nrf54l20pdk/nrf54l20/cpuapp
     - nrf54l15bsim/nrf54l15/cpuapp
@@ -79,3 +80,6 @@ tests:
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
       - nrf9160dk/nrf9160
+      - nrf54l09pdk/nrf54l09/cpuapp
+      - nrf54l09pdk/nrf54l09/cpuapp
+      - nrf54l09pdk/nrf54l09/cpuapp

--- a/tests/drivers/uart/uart_pm/boards/nrf54l09pdk_nrf54l09_cpuapp.overlay
+++ b/tests/drivers/uart/uart_pm/boards/nrf54l09pdk_nrf54l09_cpuapp.overlay
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&pinctrl {
+	uart21_default: uart21_default {
+		group1 {
+			psels = <NRF_PSEL(UART_TX, 1, 10)>,
+				<NRF_PSEL(UART_RX, 1, 11)>;
+		};
+	};
+
+	uart21_sleep: uart21_sleep {
+		group1 {
+			psels = <NRF_PSEL(UART_TX, 1, 10)>,
+				<NRF_PSEL(UART_RX, 1, 11)>;
+			low-power-enable;
+		};
+	};
+};
+
+/ {
+	chosen {
+		zephyr,console = &uart20;
+	};
+};
+
+dut: &uart21 {
+	status = "okay";
+	current-speed = <115200>;
+	pinctrl-0 = <&uart21_default>;
+	pinctrl-1 = <&uart21_sleep>;
+	pinctrl-names = "default", "sleep";
+};

--- a/tests/drivers/uart/uart_pm/testcase.yaml
+++ b/tests/drivers/uart/uart_pm/testcase.yaml
@@ -5,6 +5,7 @@ common:
   harness: ztest
   platform_allow:
     - nrf52840dk/nrf52840
+    - nrf54l09pdk/nrf54l09/cpuapp
     - nrf54l15dk/nrf54l15/cpuapp
     - nrf54l20pdk/nrf54l20/cpuapp
     - nrf54l15bsim/nrf54l15/cpuapp
@@ -32,6 +33,7 @@ tests:
       - CONFIG_UART_NRFX_UARTE_LEGACY_SHIM=y
     extra_args: DTC_OVERLAY_FILE="boards/nrf52840dk_nrf52840.overlay;nrf_rx_disable.overlay"
     platform_exclude:
+      - nrf54l09pdk/nrf54l09/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l20pdk/nrf54l20/cpuapp
       - nrf54l15bsim/nrf54l15/cpuapp
@@ -44,6 +46,7 @@ tests:
       - CONFIG_UART_0_ENHANCED_POLL_OUT=y
       - CONFIG_UART_NRFX_UARTE_LEGACY_SHIM=y
     platform_exclude:
+      - nrf54l09pdk/nrf54l09/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l20pdk/nrf54l20/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
@@ -64,6 +67,7 @@ tests:
       - CONFIG_UART_0_ENHANCED_POLL_OUT=y
       - CONFIG_UART_NRFX_UARTE_LEGACY_SHIM=y
     platform_exclude:
+      - nrf54l09pdk/nrf54l09/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l20pdk/nrf54l20/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
@@ -84,6 +88,7 @@ tests:
       - CONFIG_UART_0_ENHANCED_POLL_OUT=y
       - CONFIG_UART_NRFX_UARTE_LEGACY_SHIM=y
     platform_exclude:
+      - nrf54l09pdk/nrf54l09/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l20pdk/nrf54l20/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp


### PR DESCRIPTION
Add new target to the following tests:
   - uart_elementary
   - uart_async_api
   - uart_mix_fifo_poll
   - uart_pm

Support for some tests was not added because those require two uart instances and nrf54l09 has 3 UARTE instances but one is used for console and one is available only on P0 (uart20 and uart21 are on P1) and there are no pin connections available in the test setup.

Based on #82330.