### PR TITLE
cmake: dts: print binding dirs and board extension overlays

### DIFF
--- a/cmake/modules/dts.cmake
+++ b/cmake/modules/dts.cmake
@@ -179,6 +179,10 @@ endif()
 # with them.
 #
 
+foreach(board_extension_dir ${BOARD_EXTENSION_DIRS})
+  message(STATUS "Found board extension dir: ${board_extension_dir}")
+endforeach()
+
 zephyr_file(CONF_FILES ${BOARD_EXTENSION_DIRS} DTS board_extension_dts_files)
 
 set(dts_files
@@ -222,6 +226,7 @@ unset(DTS_ROOT_BINDINGS)
 foreach(dts_root ${DTS_ROOT})
   set(bindings_path ${dts_root}/dts/bindings)
   if(EXISTS ${bindings_path})
+    message(STATUS "Found DTS bindings dir: ${bindings_path}")
     list(APPEND
       DTS_ROOT_BINDINGS
       ${bindings_path}

--- a/doc/build/dts/howtos.rst
+++ b/doc/build/dts/howtos.rst
@@ -276,6 +276,18 @@ finds in the configuration phase, like this:
 
    -- Found devicetree overlay: .../some/file.overlay
 
+Additional directories containing devicetree overlay files can also be added
+by appending to the ``BOARD_EXTENSION_DIRS`` CMake variable in the application
+:file:`CMakeLists.txt` file. Make sure to do so **before** pulling in the
+Zephyr boilerplate with ``find_package(Zephyr ...)``.
+
+.. note::
+
+   When specifying ``BOARD_EXTENSION_DIRS`` in a CMakeLists.txt, then an absolute path must
+   be provided, for example ``list(APPEND BOARD_EXTENSION_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/<extension-dir>``.
+   When using ``-DBOARD_EXTENSION_DIRS=<extension-dir>`` both absolute and relative paths can be
+   used. Relative paths are treated relatively to the application directory.
+
 .. _use-dt-overlays:
 
 Use devicetree overlays


### PR DESCRIPTION
To make debugging why entries end up in devicetree_generated.h
but do not end up in .config, this commit adds a bit more
verbosity to dts.cmake by printing overlays found in
BOARD_EXTENSION_DIRS and DTS_ROOT binding paths.

This PR also adds a note about BOARD_EXTENSION_DIRS to the documentation on how to set devicetree overlays: https://docs.zephyrproject.org/latest/build/dts/howtos.html#set-devicetree-overlays