### PR TITLE
Bluetooth: TMAP: Remove double definitions of TMAP roles support

### DIFF
--- a/include/zephyr/bluetooth/audio/tmap.h
+++ b/include/zephyr/bluetooth/audio/tmap.h
@@ -3,7 +3,7 @@
  * @brief Header for Bluetooth TMAP.
  *
  * Copyright 2023 NXP
- * Copyright (c) 2024 Nordic Semiconductor ASA
+ * Copyright (c) 2024-2025 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -30,37 +30,6 @@
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
-
-/** Call Gateway (CG) supported */
-#define BT_TMAP_CG_SUPPORTED                                                                       \
-	(IS_ENABLED(CONFIG_BT_CAP_INITIATOR) && IS_ENABLED(CONFIG_BT_BAP_UNICAST_CLIENT) &&        \
-	 IS_ENABLED(CONFIG_BT_TBS) && IS_ENABLED(CONFIG_BT_VCP_VOL_CTLR))
-
-/** Call Terminal (CT) supported */
-#define BT_TMAP_CT_SUPPORTED                                                                       \
-	(IS_ENABLED(CONFIG_BT_CAP_ACCEPTOR) && IS_ENABLED(CONFIG_BT_BAP_UNICAST_SERVER) &&         \
-	 IS_ENABLED(CONFIG_BT_TBS_CLIENT) &&                                                       \
-	 (IS_ENABLED(CONFIG_BT_ASCS_ASE_SNK) &&                                                    \
-	  IS_ENABLED(CONFIG_BT_VCP_VOL_REND) == IS_ENABLED(CONFIG_BT_ASCS_ASE_SNK)))
-
-/** Unicast Media Sender (UMS) supported */
-#define BT_TMAP_UMS_SUPPORTED                                                                      \
-	(IS_ENABLED(CONFIG_BT_CAP_INITIATOR) &&                                                    \
-	 IS_ENABLED(CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SNK) && IS_ENABLED(CONFIG_BT_VCP_VOL_CTLR) && \
-	 IS_ENABLED(CONFIG_BT_MCS))
-
-/** Unicast Media Receiver (UMR) supported */
-#define BT_TMAP_UMR_SUPPORTED                                                                      \
-	(IS_ENABLED(CONFIG_BT_CAP_ACCEPTOR) && IS_ENABLED(CONFIG_BT_ASCS_ASE_SNK) &&               \
-	 IS_ENABLED(CONFIG_BT_VCP_VOL_REND))
-
-/** Broadcast Media Sender (BMS) supported */
-#define BT_TMAP_BMS_SUPPORTED                                                                      \
-	(IS_ENABLED(CONFIG_BT_CAP_INITIATOR) && IS_ENABLED(CONFIG_BT_BAP_BROADCAST_SOURCE))
-
-/** Broadcast Media Receiver (BMR) supported */
-#define BT_TMAP_BMR_SUPPORTED                                                                      \
-	(IS_ENABLED(CONFIG_BT_CAP_ACCEPTOR) && IS_ENABLED(CONFIG_BT_BAP_BROADCAST_SINK))
 
 /** @brief TMAP Role characteristic */
 enum bt_tmap_role {

--- a/subsys/bluetooth/audio/shell/tmap.c
+++ b/subsys/bluetooth/audio/shell/tmap.c
@@ -4,7 +4,7 @@
  */
 
 /*
- * Copyright (c) 2023 Nordic Semiconductor ASA
+ * Copyright (c) 2023-2025 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -13,22 +13,25 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include <zephyr/autoconf.h>
 #include <zephyr/bluetooth/audio/tmap.h>
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/kernel.h>
 #include <zephyr/shell/shell.h>
 #include <zephyr/sys/util.h>
+#include <zephyr/sys/util_macro.h>
 
 #include "host/shell/bt.h"
 
 static int cmd_tmap_init(const struct shell *sh, size_t argc, char **argv)
 {
-	const enum bt_tmap_role role = (BT_TMAP_CG_SUPPORTED ? BT_TMAP_ROLE_CG : 0U) |
-				       (BT_TMAP_CT_SUPPORTED ? BT_TMAP_ROLE_CT : 0U) |
-				       (BT_TMAP_UMS_SUPPORTED ? BT_TMAP_ROLE_UMS : 0U) |
-				       (BT_TMAP_UMR_SUPPORTED ? BT_TMAP_ROLE_UMR : 0U) |
-				       (BT_TMAP_BMS_SUPPORTED ? BT_TMAP_ROLE_BMS : 0U) |
-				       (BT_TMAP_BMR_SUPPORTED ? BT_TMAP_ROLE_BMR : 0U);
+	const enum bt_tmap_role role =
+		(IS_ENABLED(CONFIG_BT_TMAP_CG_SUPPORTED) ? BT_TMAP_ROLE_CG : 0U) |
+		(IS_ENABLED(CONFIG_BT_TMAP_CT_SUPPORTED) ? BT_TMAP_ROLE_CT : 0U) |
+		(IS_ENABLED(CONFIG_BT_TMAP_UMS_SUPPORTED) ? BT_TMAP_ROLE_UMS : 0U) |
+		(IS_ENABLED(CONFIG_BT_TMAP_UMR_SUPPORTED) ? BT_TMAP_ROLE_UMR : 0U) |
+		(IS_ENABLED(CONFIG_BT_TMAP_BMS_SUPPORTED) ? BT_TMAP_ROLE_BMS : 0U) |
+		(IS_ENABLED(CONFIG_BT_TMAP_BMR_SUPPORTED) ? BT_TMAP_ROLE_BMR : 0U);
 	int err;
 
 	shell_info(sh, "Registering TMAS with role: 0x%04X", role);

--- a/tests/bluetooth/tester/src/audio/btp_tmap.c
+++ b/tests/bluetooth/tester/src/audio/btp_tmap.c
@@ -2,13 +2,16 @@
 
 /*
  * Copyright (c) 2024 Codecoup
+ * Copyright (c) 2025 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+#include <zephyr/autoconf.h>
 #include <zephyr/bluetooth/audio/tmap.h>
 #include "btp/btp.h"
 
 #include <zephyr/logging/log.h>
+#include <zephyr/sys/util_macro.h>
 LOG_MODULE_REGISTER(bttester_tmap, CONFIG_BTTESTER_LOG_LEVEL);
 
 static uint8_t read_supported_commands(const void *cmd, uint16_t cmd_len, void *rsp,
@@ -81,12 +84,13 @@ static const struct btp_handler tmap_handlers[] = {
 
 uint8_t tester_init_tmap(void)
 {
-	const enum bt_tmap_role role = (BT_TMAP_CG_SUPPORTED ? BT_TMAP_ROLE_CG : 0U) |
-				       (BT_TMAP_CT_SUPPORTED ? BT_TMAP_ROLE_CT : 0U) |
-				       (BT_TMAP_UMS_SUPPORTED ? BT_TMAP_ROLE_UMS : 0U) |
-				       (BT_TMAP_UMR_SUPPORTED ? BT_TMAP_ROLE_UMR : 0U) |
-				       (BT_TMAP_BMS_SUPPORTED ? BT_TMAP_ROLE_BMS : 0U) |
-				       (BT_TMAP_BMR_SUPPORTED ? BT_TMAP_ROLE_BMR : 0U);
+	const enum bt_tmap_role role =
+		(IS_ENABLED(CONFIG_BT_TMAP_CG_SUPPORTED) ? BT_TMAP_ROLE_CG : 0U) |
+		(IS_ENABLED(CONFIG_BT_TMAP_CT_SUPPORTED) ? BT_TMAP_ROLE_CT : 0U) |
+		(IS_ENABLED(CONFIG_BT_TMAP_UMS_SUPPORTED) ? BT_TMAP_ROLE_UMS : 0U) |
+		(IS_ENABLED(CONFIG_BT_TMAP_UMR_SUPPORTED) ? BT_TMAP_ROLE_UMR : 0U) |
+		(IS_ENABLED(CONFIG_BT_TMAP_BMS_SUPPORTED) ? BT_TMAP_ROLE_BMS : 0U) |
+		(IS_ENABLED(CONFIG_BT_TMAP_BMR_SUPPORTED) ? BT_TMAP_ROLE_BMR : 0U);
 	int err;
 
 	err = bt_tmap_register(role);


### PR DESCRIPTION
Both the TMAP kconfig file and public header file defined which roles were supported.

The Kconfig file options were recently added and were more up to date (and correct), and allows for other Kconfig files to use these values, thus allowing for more flexibility when implementing applications.