### PR TITLE
tests: Bluetooth: TMAP: Add missing FAIL if register fails

### DIFF
--- a/tests/bsim/bluetooth/audio/src/tmap_client_test.c
+++ b/tests/bsim/bluetooth/audio/src/tmap_client_test.c
@@ -149,6 +149,7 @@ static void test_main(void)
 	/* Initialize TMAP */
 	err = bt_tmap_register(BT_TMAP_ROLE_CG | BT_TMAP_ROLE_UMS);
 	if (err != 0) {
+		FAIL("Failed to register TMAP (err %d)\n", err);
 		return;
 	}
 

--- a/tests/bsim/bluetooth/audio/src/tmap_server_test.c
+++ b/tests/bsim/bluetooth/audio/src/tmap_server_test.c
@@ -50,6 +50,7 @@ static void test_main(void)
 	/* Initialize TMAP */
 	err = bt_tmap_register(BT_TMAP_ROLE_CT | BT_TMAP_ROLE_UMR);
 	if (err != 0) {
+		FAIL("Failed to register TMAP (err %d)\n", err);
 		return;
 	}
 	printk("TMAP initialized. Start advertising...\n");


### PR DESCRIPTION
If the register fails it would just return, instead of failing the test.