### PR TITLE
drivers: clock: stm32: Fix stm32c0 apb2_prescaler

### DIFF
--- a/include/zephyr/drivers/clock_control/stm32_clock_control.h
+++ b/include/zephyr/drivers/clock_control/stm32_clock_control.h
@@ -70,7 +70,7 @@
 
 #define STM32_AHB_PRESCALER	DT_PROP(DT_NODELABEL(rcc), ahb_prescaler)
 #define STM32_APB1_PRESCALER	DT_PROP(DT_NODELABEL(rcc), apb1_prescaler)
-#define STM32_APB2_PRESCALER	DT_PROP(DT_NODELABEL(rcc), apb2_prescaler)
+#define STM32_APB2_PRESCALER	DT_PROP_OR(DT_NODELABEL(rcc), apb2_prescaler, 1)
 #define STM32_APB3_PRESCALER	DT_PROP(DT_NODELABEL(rcc), apb3_prescaler)
 #define STM32_APB5_PRESCALER	DT_PROP(DT_NODELABEL(rcc), apb5_prescaler)
 #define STM32_APB7_PRESCALER	DT_PROP(DT_NODELABEL(rcc), apb7_prescaler)


### PR DESCRIPTION
The stm32c0 fail to build when using timer3 because of missing apb2_prescaler definition. This add a default value to fix the issue.

Fixes #83543