### PR TITLE
dts: boards: stm32h562: add timer 8

### DIFF
--- a/dts/arm/st/h5/stm32h562.dtsi
+++ b/dts/arm/st/h5/stm32h562.dtsi
@@ -329,6 +329,22 @@
 			};
 		};
 
+		timers8: timers@40013400 {
+			compatible = "st,stm32-timers";
+			reg = <0x40013400 0x400>;
+			clocks = <&rcc STM32_CLOCK(APB2, 13)>;
+			resets = <&rctl STM32_RESET(APB2, 13)>;
+			interrupts = <65 0>, <66 0>, <67 0>, <68 0>;
+			interrupt-names = "brk", "up", "trgcom", "cc";
+			status = "disabled";
+
+			pwm {
+				compatible = "st,stm32-pwm";
+				status = "disabled";
+				#pwm-cells = <3>;
+			};
+		};
+
 		timers12: timers@40001800 {
 			compatible = "st,stm32-timers";
 			reg = <0x40001800 0x400>;


### PR DESCRIPTION
TIM8 was missing from the dts board file. This is one of the advandaced-control timers on the STM32H562xx/STM32H563xx processors.

![tim8](https://github.com/user-attachments/assets/7b6501c9-bd6c-4df2-95ed-316590233ec5)
