### PR TITLE
samples: net: syslog_net: add missing dep of net log backend

### DIFF
--- a/samples/net/syslog_net/prj.conf
+++ b/samples/net/syslog_net/prj.conf
@@ -35,7 +35,5 @@ CONFIG_NET_CONFIG_PEER_IPV4_ADDR="192.0.2.2"
 
 # logging net backend config
 CONFIG_LOG_BACKEND_NET=y
+CONFIG_POSIX_C_LANG_SUPPORT_R=y
 CONFIG_LOG_BACKEND_NET_SERVER="[2001:db8::2]:514"
-
-# Get a proper libc by default in order to get working time function support
-CONFIG_REQUIRES_FULL_LIBC=y


### PR DESCRIPTION
The network log backend had the `POSIX_C_LANG_SUPPORT_R` dependency added in 1d4249dea6474f3d02418eb7d9aba0d2f6df7aa8 but the dependency was never added to the sample.

Select `CONFIG_LOG_BACKEND_NET=y` in `samples/net/syslog_net/prj.conf` to fulfill the dependency.