### PR TITLE
drivers: dma: sam0: Reset DMA controller during initialization

### DIFF
--- a/drivers/dma/dma_sam0.c
+++ b/drivers/dma/dma_sam0.c
@@ -413,6 +413,13 @@ static int dma_sam0_init(const struct device *dev)
 	PM->APBBMASK.bit.DMAC_ = 1;
 #endif
 
+	/* Reset the DMA controller */
+	DMAC->CTRL.bit.DMAENABLE = 0;
+	DMAC->CTRL.bit.CRCENABLE = 0;
+	DMAC->CTRL.bit.SWRST = 1;
+	while (DMAC->CTRL.bit.SWRST) {
+	}
+
 	/* Set up the descriptor and write back addresses */
 	DMA_REGS->BASEADDR.reg = (uintptr_t)&data->descriptors;
 	DMA_REGS->WRBADDR.reg = (uintptr_t)&data->descriptors_wb;


### PR DESCRIPTION
This pull request resolves issue #83555, where UART transmit operations fail in Zephyr sysbuild projects using MCUboot and the asynchronous UART API (`CONFIG_UART_ASYNC_API=y`) on SAM0 devices like the ATSAMC21G18A. The problem occurs because the DMA controller is not reset during initialization, causing `BASEADDR` and `WRBADDR` registers to retain MCUboot's configuration and preventing proper reconfiguration in the application. This fix ensures the DMA controller is properly reset during initialization in `dma_sam0.c` by disabling the DMA and CRC modules, performing a software reset, and clearing previous configurations. These changes ensure that the DMA controller starts in a clean state, allowing proper reconfiguration and resolving the UART TX failures. The fix has been tested on ATSAMC21G18A with MCUboot, `CONFIG_DMA=y`, and `CONFIG_UART_ASYNC_API=y`, and UART TX operations now work as expected. This update improves stability and ensures compatibility between MCUboot and application DMA usage in sysbuild projects.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/83555