### PR TITLE
boards: tdk: robokit1: align driver init levels with devicetree deps

### DIFF
--- a/boards/tdk/robokit1/Kconfig.defconfig
+++ b/boards/tdk/robokit1/Kconfig.defconfig
@@ -1,0 +1,18 @@
+# Copyright (c) 2024 Henrik Brix Andersen <henrik@brixandersen.dk>
+# SPDX-License-Identifier: Apache-2.0
+
+if BOARD_ROBOKIT1
+
+config ADC_ADS7052_INIT_PRIORITY
+	default 60
+	depends on ADC_ADS7052
+
+config SENSOR_INIT_PRIORITY
+	default 60
+	depends on SENSOR
+
+config EEPROM_INIT_PRIORITY
+	default 60
+	depends on EEPROM
+
+endif # BOARD_ROBOKIT1


### PR DESCRIPTION
This board contains both an NTC sensor dependings on a specific SPI ADC and a TMP116 containing both a sensor and an EEPROM.

Align these driver initialization priorities with the devicetree dependencies to avoid build failures with CONFIG_CHECK_INIT_PRIORITIES=y.