### PR TITLE
sensors_shell: fix missing channel and attribute names

### DIFF
--- a/drivers/sensor/sensor_shell.c
+++ b/drivers/sensor/sensor_shell.c
@@ -106,6 +106,9 @@ static const char *sensor_channel_name[SENSOR_CHAN_COMMON_COUNT] = {
 	[SENSOR_CHAN_GAUGE_DESIGN_VOLTAGE] = "gauge_design_voltage",
 	[SENSOR_CHAN_GAUGE_DESIRED_VOLTAGE] = "gauge_desired_voltage",
 	[SENSOR_CHAN_GAUGE_DESIRED_CHARGING_CURRENT] = "gauge_desired_charging_current",
+	[SENSOR_CHAN_GAME_ROTATION_VECTOR] = "game_rotation_vector",
+	[SENSOR_CHAN_GRAVITY_VECTOR] = "gravity_vector",
+	[SENSOR_CHAN_GBIAS_XYZ] = "gbias_xyz",
 	[SENSOR_CHAN_ALL] = "all",
 };
 
@@ -126,6 +129,8 @@ static const char *sensor_attribute_name[SENSOR_ATTR_COMMON_COUNT] = {
 	[SENSOR_ATTR_ALERT] = "alert",
 	[SENSOR_ATTR_FF_DUR] = "ff_dur",
 	[SENSOR_ATTR_BATCH_DURATION] = "batch_dur",
+	[SENSOR_ATTR_GAIN] = "gain",
+	[SENSOR_ATTR_RESOLUTION] = "resolution",
 };
 
 enum sample_stats_state {


### PR DESCRIPTION
The three sensor channels listed below were recently added by the commit 9471df95a577776998494a135feedb2fafc68820:
 - SENSOR_CHAN_GAME_ROTATION_VECTOR
 - SENSOR_CHAN_GRAVITY_VECTOR
 - SENSOR_CHAN_GBIAS_XYZ

Theses channel names are missing and causes the fault attached below if the SENSOR_LOG_LEVEL is set to DEBUG.

Also, the two sensor attributes SENSOR_ATTR_GAIN and SENSOR_ATTR_RESOLUTION were added by the commit f849140de7f6e29791d6fe2f34756b69e9d26691.

This adds these missing channel and attribute to the list of names in the sensor shell.

Fixes:

	uart:~$ sensor get bmp280@76
	channel type=13(ambient_temp) index=0 shift=16 num_samples=1 value=39132900004ns (18.829986)
	channel type=14(press) index=0 shift=23 num_samples=1 value=39132900004ns (96.027343)
	channel type=16(humidity) index=0 shift=21 num_samples=1 value=39132900004ns (0.000000)
	[00:00:39.160,000] <err> os:  ** CPU 0 EXCCAUSE 28 (load prohibited)
	[00:00:39.160,000] <err> os:  **  PC 0x400014fd VADDR 0
	[00:00:39.160,000] <err> os:  **  PS 0x60220
	[00:00:39.160,000] <err> os:  **    (INTLEVEL:0 EXCM: 0 UM:1 RING:0 WOE:1 OWB:2 CALLINC:2)
	[00:00:39.160,000] <err> os:  **  A0 0x800d5a15  SP 0x3ffbe9d0  A2 0  A3 0xfffffffc
	[00:00:39.160,000] <err> os:  **  A4 0xff  A5 0xff00  A6 0xff0000  A7 0xff000000
	[00:00:39.160,000] <err> os:  **  A8 0  A9 0x3f40ff64 A10 0x1 A11 0x33
	[00:00:39.160,000] <err> os:  ** A12 0x3a A13 0 A14 0x70 A15 0x25
	[00:00:39.160,000] <err> os:  ** LBEG 0x400014fd LEND 0x4000150d LCOUNT 0xffffffff
	[00:00:39.160,000] <err> os:  ** SAR 0x4
	[00:00:39.160,000] <err> os:  **  THREADPTR 0x4000c2f6

	[00:00:39.160,000] <err> os: >>> ZEPHYR FATAL ERROR 0: CPU exception on CPU 0
	[00:00:39.160,000] <err> os: Current thread: 0x3ffb70c8 (shell_uart)
	[00:00:39.282,000] <err> os: Halting system