### PR TITLE
flash: stm32l4/g4: force load option bytes after write

### DIFF
--- a/drivers/flash/flash_stm32g4x.c
+++ b/drivers/flash/flash_stm32g4x.c
@@ -285,7 +285,10 @@ int flash_stm32_option_bytes_write(const struct device *dev, uint32_t mask,
 		return rc;
 	}
 
-	return 0;
+	/* Force the option byte loading */
+	regs->CR |= FLASH_CR_OBL_LAUNCH;
+
+	return flash_stm32_wait_flash_idle(dev);
 }
 
 uint32_t flash_stm32_option_bytes_read(const struct device *dev)

--- a/drivers/flash/flash_stm32l4x.c
+++ b/drivers/flash/flash_stm32l4x.c
@@ -276,7 +276,10 @@ int flash_stm32_option_bytes_write(const struct device *dev, uint32_t mask,
 		return rc;
 	}
 
-	return 0;
+	/* Force the option byte loading */
+	regs->CR |= FLASH_CR_OBL_LAUNCH;
+
+	return flash_stm32_wait_flash_idle(dev);
 }
 
 uint32_t flash_stm32_option_bytes_read(const struct device *dev)


### PR DESCRIPTION
After writing option bytes, force them to be loaded. Failing to perform this step means the values are never applied and not actually written to non-volatile memory.

This step is documented on the HAL `FLASH_OB_RDPConfig` function, but nowhere else:
![image](https://github.com/user-attachments/assets/5ca5f7d1-af7c-45d6-bba3-ceea2dc65aab)

![image](https://github.com/user-attachments/assets/01a1b0a6-e3d8-4fc7-bd26-1080e4283369)


