### PR TITLE
runners: jlink: win32: search for valid `JLink.exe`

### DIFF
--- a/scripts/west_commands/runners/jlink.py
+++ b/scripts/west_commands/runners/jlink.py
@@ -5,6 +5,7 @@
 '''Runner for debugging with J-Link.'''
 
 import argparse
+import glob
 import ipaddress
 import logging
 import os
@@ -25,7 +26,37 @@ try:
 except ImportError:
     MISSING_REQUIREMENTS = True
 
-DEFAULT_JLINK_EXE = 'JLink.exe' if sys.platform == 'win32' else 'JLinkExe'
+if sys.platform == 'win32':
+    # JLink.exe can collide with the JDK executable of the same name
+    # Look in the usual locations before falling back to $PATH
+    for root in [os.environ["ProgramFiles"], os.environ["ProgramFiles(x86)"], str(Path.home())]: # noqa SIM112
+        # SEGGER folder can contain a single "JLink" folder
+        _direct = Path(root) / "SEGGER" / "JLink" / "JLink.exe"
+        if _direct.exists():
+            DEFAULT_JLINK_EXE = str(_direct)
+            del _direct
+        else:
+            # SEGGER folder can contain multiple versions such as:
+            #   JLink_V796b
+            #   JLink_V796t
+            #   JLink_V798c
+            # Find the latest version
+            _versions = glob.glob(str(Path(root) / "SEGGER" / "JLink_V*"))
+            if len(_versions) == 0:
+                continue
+            _expected_jlink = Path(_versions[-1]) / "JLink.exe"
+            if not _expected_jlink.exists():
+                continue
+            DEFAULT_JLINK_EXE = str(_expected_jlink)
+            # Cleanup variables
+            del _versions
+            del _expected_jlink
+        break
+    else:
+        # Not found in the normal locations, hope that $PATH is correct
+        DEFAULT_JLINK_EXE = "JLink.exe"
+else:
+    DEFAULT_JLINK_EXE = "JLinkExe"
 DEFAULT_JLINK_GDB_PORT = 2331
 DEFAULT_JLINK_RTT_PORT = 19021
 


### PR DESCRIPTION
Since "JLink.exe" is also an executable distributed with JDK's, do an explicit search on the standard SEGGER install directories for a JTAG "JLink.exe" before falling back to whatever is first on PATH.

Fixes #51825.