### PR TITLE
github: security: remove v3.6 from the list of supported releases

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -12,8 +12,7 @@ At this time, with the latest release of v4.0, the supported
 versions are:
 
   - v4.0: Current release
-  - v3.7: Current LTS
-  - v3.6: Prior release
+  - v3.7: Prior release and Current LTS
   - v2.7: Prior LTS
 
 ## Reporting process


### PR DESCRIPTION
Remove v3.6 from the list of supported releases. Zephyr v3.6.0 reached end-of-life on 2024-11-29.

Fixes: ea8bd5a09aed42b688df479068ee358503282de0