### PR TITLE
drivers: mipi-dbi-spi: DTS string properties and MISRA-C conformance

### DIFF
--- a/drivers/mipi_dbi/mipi_dbi_spi.c
+++ b/drivers/mipi_dbi/mipi_dbi_spi.c
@@ -33,26 +33,28 @@ struct mipi_dbi_spi_data {
 };
 
 /* Expands to 1 if the node does not have the `write-only` property */
-#define _WRITE_ONLY_ABSENT(n) (!DT_INST_PROP(n, write_only)) |
+#define MIPI_DBI_SPI_WRITE_ONLY_ABSENT(n) (!DT_INST_PROP(n, write_only)) |
 
 /* This macro will evaluate to 1 if any of the nodes with zephyr,mipi-dbi-spi
  * lack a `write-only` property. The intention here is to allow the entire
  * command_read function to be optimized out when it is not needed.
  */
-#define MIPI_DBI_SPI_READ_REQUIRED DT_INST_FOREACH_STATUS_OKAY(_WRITE_ONLY_ABSENT) 0
+#define MIPI_DBI_SPI_READ_REQUIRED DT_INST_FOREACH_STATUS_OKAY(MIPI_DBI_SPI_WRITE_ONLY_ABSENT) 0
 uint32_t var = MIPI_DBI_SPI_READ_REQUIRED;
 
 /* Expands to 1 if the node does reflect the enum in `xfr-min-bits` property */
-#define _XFR_8BITS(n) (DT_INST_STRING_UPPER_TOKEN(n, xfr_min_bits) == MIPI_DBI_SPI_XFR_8BIT) |
-#define _XFR_16BITS(n) (DT_INST_STRING_UPPER_TOKEN(n, xfr_min_bits) == MIPI_DBI_SPI_XFR_16BIT) |
+#define MIPI_DBI_SPI_XFR_8BITS(n) (DT_INST_STRING_UPPER_TOKEN(n, xfr_min_bits) \
+						== MIPI_DBI_SPI_XFR_8BIT) |
+#define MIPI_DBI_SPI_XFR_16BITS(n) (DT_INST_STRING_UPPER_TOKEN(n, xfr_min_bits) \
+						== MIPI_DBI_SPI_XFR_16BIT) |
 
 /* This macros will evaluate to 1 if any of the nodes with zephyr,mipi-dbi-spi
  * have the `xfr-min-bits` property to corresponding enum value. The intention
  * here is to allow the write helper functions to be optimized out when not all
  * minimum transfer bits will be needed.
  */
-#define MIPI_DBI_SPI_WRITE_8BIT_REQUIRED DT_INST_FOREACH_STATUS_OKAY(_XFR_8BITS) 0
-#define MIPI_DBI_SPI_WRITE_16BIT_REQUIRED DT_INST_FOREACH_STATUS_OKAY(_XFR_16BITS) 0
+#define MIPI_DBI_SPI_WRITE_8BIT_REQUIRED DT_INST_FOREACH_STATUS_OKAY(MIPI_DBI_SPI_XFR_8BITS) 0
+#define MIPI_DBI_SPI_WRITE_16BIT_REQUIRED DT_INST_FOREACH_STATUS_OKAY(MIPI_DBI_SPI_XFR_16BITS) 0
 
 /* In Type C mode 1 MIPI BIT communication, the 9th bit of the word
  * (first bit sent in each word) indicates if the word is a command or

--- a/drivers/mipi_dbi/mipi_dbi_spi.c
+++ b/drivers/mipi_dbi/mipi_dbi_spi.c
@@ -1,6 +1,6 @@
 /*
  * Copyright 2023 NXP
- * Copyright 2024 TiaC Systems
+ * Copyright 2024-2025 TiaC Systems
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -43,8 +43,8 @@ struct mipi_dbi_spi_data {
 uint32_t var = MIPI_DBI_SPI_READ_REQUIRED;
 
 /* Expands to 1 if the node does reflect the enum in `xfr-min-bits` property */
-#define _XFR_8BITS(n) (DT_INST_PROP(n, xfr_min_bits) == MIPI_DBI_SPI_XFR_8BIT) |
-#define _XFR_16BITS(n) (DT_INST_PROP(n, xfr_min_bits) == MIPI_DBI_SPI_XFR_16BIT) |
+#define _XFR_8BITS(n) (DT_INST_STRING_UPPER_TOKEN(n, xfr_min_bits) == MIPI_DBI_SPI_XFR_8BIT) |
+#define _XFR_16BITS(n) (DT_INST_STRING_UPPER_TOKEN(n, xfr_min_bits) == MIPI_DBI_SPI_XFR_16BIT) |
 
 /* This macros will evaluate to 1 if any of the nodes with zephyr,mipi-dbi-spi
  * have the `xfr-min-bits` property to corresponding enum value. The intention
@@ -560,7 +560,7 @@ static DEVICE_API(mipi_dbi, mipi_dbi_spi_driver_api) = {
 				    DT_INST_PHANDLE(n, spi_dev)),		\
 		    .cmd_data = GPIO_DT_SPEC_INST_GET_OR(n, dc_gpios, {}),	\
 		    .reset = GPIO_DT_SPEC_INST_GET_OR(n, reset_gpios, {}),	\
-		    .xfr_min_bits = DT_INST_PROP(n, xfr_min_bits)               \
+		    .xfr_min_bits = DT_INST_STRING_UPPER_TOKEN(n, xfr_min_bits) \
 	};									\
 	static struct mipi_dbi_spi_data mipi_dbi_spi_data_##n;			\
 										\

--- a/dts/bindings/mipi-dbi/zephyr,mipi-dbi-spi.yaml
+++ b/dts/bindings/mipi-dbi/zephyr,mipi-dbi-spi.yaml
@@ -28,20 +28,16 @@ properties:
       Reset GPIO pin. Set high to reset the display
 
   xfr-min-bits:
-    type: int
-    default: 8
+    type: string
+    default: "MIPI_DBI_SPI_XFR_8BIT"
     description:
       On rare types of SPI interfaces, discrete shift registers can be found
       whose task is to convert the serial SPI bit stream to the parallel MCU
       interface with clock and bit accuracy. Typically, these are 16 bits wide.
-
-      Use the macros, not the actual enum value. Here is the concordance list
-      (see dt-bindings/mipi_dbi/mipi_dbi.h)
-         8     MIPI_DBI_SPI_XFR_8BIT
-        16     MIPI_DBI_SPI_XFR_16BIT
+      These definitions should match those in dt-bindings/mipi_dbi/mipi_dbi.h
     enum:
-      - 8
-      - 16
+      - "MIPI_DBI_SPI_XFR_8BIT"
+      - "MIPI_DBI_SPI_XFR_16BIT"
 
   write-only:
     type: boolean

--- a/tests/drivers/build_all/display/app.overlay
+++ b/tests/drivers/build_all/display/app.overlay
@@ -168,7 +168,7 @@
 			spi-dev = <&test_spi>;
 			#address-cells = <1>;
 			#size-cells = <0>;
-			xfr-min-bits = <MIPI_DBI_SPI_XFR_16BIT>;
+			xfr-min-bits = "MIPI_DBI_SPI_XFR_16BIT";
 			write-only;
 
 			test_mipi_dbi_xfr_16bit_ili9342c: ili9342c@0 {


### PR DESCRIPTION
This is the follow up improvement to PR #67089 and fix the last two comments:

- [use a string enum for xfr-min-bits property](https://github.com/zephyrproject-rtos/zephyr/pull/67089#pullrequestreview-2478891010), similar to what was done here: #81293
- [underscores (in macro names) should not be used](https://github.com/zephyrproject-rtos/zephyr/pull/67089#pullrequestreview-2488541055), see #9882 and **MISRA-C** rules **21.1** and **21.2** (Zephyr rule 121 and 122) in table _"Main rules"_ at https://docs.zephyrproject.org/latest/contribute/coding_guidelines/index.html