### PR TITLE
drivers: i2c: Add zephyr-keep-sorted defines

### DIFF
--- a/drivers/i2c/CMakeLists.txt
+++ b/drivers/i2c/CMakeLists.txt
@@ -6,20 +6,23 @@ zephyr_library()
 
 zephyr_library_sources(i2c_common.c)
 
+# zephyr-keep-sorted-start
 zephyr_library_sources_ifdef(CONFIG_GPIO_I2C_SWITCH	gpio_i2c_switch.c)
 zephyr_library_sources_ifdef(CONFIG_I2C_BITBANG		i2c_bitbang.c)
 zephyr_library_sources_ifdef(CONFIG_I2C_EMUL		i2c_emul.c)
 zephyr_library_sources_ifdef(CONFIG_I2C_GPIO		i2c_gpio.c)
-zephyr_library_sources_ifdef(CONFIG_I2C_SHELL		i2c_shell.c)
 zephyr_library_sources_ifdef(CONFIG_I2C_RTIO
 	i2c_rtio.c
 	i2c_rtio_default.c
-)
+ )
+zephyr_library_sources_ifdef(CONFIG_I2C_SHELL		i2c_shell.c)
 zephyr_library_sources_ifdef(CONFIG_I2C_TEST		i2c_test.c)
 zephyr_library_sources_ifdef(CONFIG_USERSPACE		i2c_handlers.c)
+# zephyr-keep-sorted-stop
+
 add_subdirectory_ifdef(CONFIG_I2C_TARGET target)
 
-
+# zephyr-keep-sorted-start
 zephyr_library_sources_ifdef(CONFIG_I2C_AMBIQ		i2c_ambiq.c)
 zephyr_library_sources_ifdef(CONFIG_I2C_ANDES_ATCIIC100	i2c_andes_atciic100.c)
 zephyr_library_sources_ifdef(CONFIG_I2C_CC13XX_CC26XX	i2c_cc13xx_cc26xx.c)
@@ -30,62 +33,27 @@ zephyr_library_sources_ifdef(CONFIG_I2C_ESP32		i2c_esp32.c)
 zephyr_library_sources_ifdef(CONFIG_I2C_GD32		i2c_gd32.c)
 zephyr_library_sources_ifdef(CONFIG_I2C_GECKO		i2c_gecko.c)
 zephyr_library_sources_ifdef(CONFIG_I2C_IMX		i2c_imx.c)
-zephyr_library_sources_ifdef(CONFIG_I2C_IPROC		i2c_bcm_iproc.c)
 zephyr_library_sources_ifdef(CONFIG_I2C_INFINEON_CAT1	i2c_ifx_cat1.c)
 zephyr_library_sources_ifdef(CONFIG_I2C_INFINEON_XMC4	i2c_ifx_xmc4.c)
-zephyr_library_sources_ifdef(CONFIG_I2C_ITE_IT8XXX2	i2c_ite_it8xxx2.c)
+zephyr_library_sources_ifdef(CONFIG_I2C_IPROC		i2c_bcm_iproc.c)
 zephyr_library_sources_ifdef(CONFIG_I2C_ITE_ENHANCE	i2c_ite_enhance.c)
+zephyr_library_sources_ifdef(CONFIG_I2C_ITE_IT8XXX2	i2c_ite_it8xxx2.c)
 zephyr_library_sources_ifdef(CONFIG_I2C_LITEX		i2c_litex.c)
 zephyr_library_sources_ifdef(CONFIG_I2C_LPC11U6X	i2c_lpc11u6x.c)
 zephyr_library_sources_ifdef(CONFIG_I2C_MCHP_MSS	i2c_mchp_mss.c)
 zephyr_library_sources_ifdef(CONFIG_I2C_MCUX		i2c_mcux.c)
 zephyr_library_sources_ifdef(CONFIG_I2C_MCUX_FLEXCOMM	i2c_mcux_flexcomm.c)
-if(CONFIG_I2C_RTIO)
-  zephyr_library_sources_ifdef(CONFIG_I2C_MCUX_LPI2C	i2c_mcux_lpi2c_rtio.c)
-else()
-  zephyr_library_sources_ifdef(CONFIG_I2C_MCUX_LPI2C	i2c_mcux_lpi2c.c)
-endif()
 zephyr_library_sources_ifdef(CONFIG_I2C_NIOS2		i2c_nios2.c)
 zephyr_library_sources_ifdef(CONFIG_I2C_NPCX		i2c_npcx_controller.c)
 zephyr_library_sources_ifdef(CONFIG_I2C_NPCX		i2c_npcx_port.c)
-if(CONFIG_I2C_RTIO)
-	zephyr_library_sources_ifdef(CONFIG_I2C_NRFX_TWI
-		i2c_nrfx_twi_rtio.c
-		i2c_nrfx_twi_common.c
-	)
-	zephyr_library_sources_ifdef(CONFIG_I2C_NRFX_TWIM
-		i2c_nrfx_twim_rtio.c
-		i2c_nrfx_twim_common.c
-	)
-else()
-	zephyr_library_sources_ifdef(CONFIG_I2C_NRFX_TWI
-		i2c_nrfx_twi.c
-		i2c_nrfx_twi_common.c
-	)
-	zephyr_library_sources_ifdef(CONFIG_I2C_NRFX_TWIM
-		i2c_nrfx_twim.c
-		i2c_nrfx_twim_common.c
-	)
-endif()
 zephyr_library_sources_ifdef(CONFIG_I2C_NRFX_TWIS	i2c_nrfx_twis.c)
 zephyr_library_sources_ifdef(CONFIG_I2C_NUMAKER		i2c_numaker.c)
-zephyr_library_sources_ifdef(CONFIG_I2C_SAM_TWI		i2c_sam_twi.c)
-if(CONFIG_I2C_RTIO)
-	zephyr_library_sources_ifdef(CONFIG_I2C_SAM_TWIHS
-		i2c_sam_twihs_rtio.c
-	)
-else()
-	zephyr_library_sources_ifdef(CONFIG_I2C_SAM_TWIHS
-		i2c_sam_twihs.c
-	)
-endif()
-if(CONFIG_I2C_RTIO)
-	zephyr_library_sources_ifdef(CONFIG_I2C_MAX32	i2c_max32_rtio.c)
-else()
-	zephyr_library_sources_ifdef(CONFIG_I2C_MAX32	i2c_max32.c)
-endif()
-zephyr_library_sources_ifdef(CONFIG_I2C_SAM_TWIM	i2c_sam4l_twim.c)
+zephyr_library_sources_ifdef(CONFIG_I2C_RCAR		i2c_rcar.c)
+zephyr_library_sources_ifdef(CONFIG_I2C_RENESAS_RA_IIC	i2c_renesas_ra_iic.c)
+zephyr_library_sources_ifdef(CONFIG_I2C_RV32M1_LPI2C	i2c_rv32m1_lpi2c.c)
 zephyr_library_sources_ifdef(CONFIG_I2C_SAM0		i2c_sam0.c)
+zephyr_library_sources_ifdef(CONFIG_I2C_SAM_TWI		i2c_sam_twi.c)
+zephyr_library_sources_ifdef(CONFIG_I2C_SAM_TWIM	i2c_sam4l_twim.c)
 zephyr_library_sources_ifdef(CONFIG_I2C_SBCON		i2c_sbcon.c)
 zephyr_library_sources_ifdef(CONFIG_I2C_SC18IM704	i2c_sc18im704.c)
 zephyr_library_sources_ifdef(CONFIG_I2C_SEDI		i2c_sedi.c)
@@ -94,16 +62,36 @@ zephyr_library_sources_ifdef(CONFIG_I2C_SMARTBOND	i2c_smartbond.c)
 zephyr_library_sources_ifdef(CONFIG_I2C_STM32_V1
 	i2c_ll_stm32_v1.c
 	i2c_ll_stm32.c
-)
+ )
 zephyr_library_sources_ifdef(CONFIG_I2C_STM32_V2
 	i2c_ll_stm32_v2.c
 	i2c_ll_stm32.c
-)
-zephyr_library_sources_ifdef(CONFIG_I2C_RENESAS_RA_IIC	i2c_renesas_ra_iic.c)
-zephyr_library_sources_ifdef(CONFIG_I2C_RCAR		i2c_rcar.c)
-zephyr_library_sources_ifdef(CONFIG_I2C_RV32M1_LPI2C	i2c_rv32m1_lpi2c.c)
+ )
 zephyr_library_sources_ifdef(CONFIG_I2C_TCA954X		i2c_tca954x.c)
 zephyr_library_sources_ifdef(CONFIG_I2C_TELINK_B91	i2c_b91.c)
 zephyr_library_sources_ifdef(CONFIG_I2C_XEC		i2c_mchp_xec.c)
 zephyr_library_sources_ifdef(CONFIG_I2C_XEC_V2		i2c_mchp_xec_v2.c)
 zephyr_library_sources_ifdef(CONFIG_I2C_XILINX_AXI	i2c_xilinx_axi.c)
+# zephyr-keep-sorted-stop
+
+if(CONFIG_I2C_RTIO)
+	# zephyr-keep-sorted-start
+	zephyr_library_sources_ifdef(CONFIG_I2C_MAX32		i2c_max32_rtio.c)
+	zephyr_library_sources_ifdef(CONFIG_I2C_MCUX_LPI2C	i2c_mcux_lpi2c_rtio.c)
+	zephyr_library_sources_ifdef(CONFIG_I2C_NRFX_TWI	i2c_nrfx_twi_common.c)
+	zephyr_library_sources_ifdef(CONFIG_I2C_NRFX_TWI	i2c_nrfx_twi_rtio.c)
+	zephyr_library_sources_ifdef(CONFIG_I2C_NRFX_TWIM	i2c_nrfx_twim_common.c)
+	zephyr_library_sources_ifdef(CONFIG_I2C_NRFX_TWIM	i2c_nrfx_twim_rtio.c)
+	zephyr_library_sources_ifdef(CONFIG_I2C_SAM_TWIHS	i2c_sam_twihs_rtio.c)
+	# zephyr-keep-sorted-stop
+else()
+	# zephyr-keep-sorted-start
+	zephyr_library_sources_ifdef(CONFIG_I2C_MAX32		i2c_max32.c)
+	zephyr_library_sources_ifdef(CONFIG_I2C_MCUX_LPI2C	i2c_mcux_lpi2c.c)
+	zephyr_library_sources_ifdef(CONFIG_I2C_NRFX_TWI	i2c_nrfx_twi.c)
+	zephyr_library_sources_ifdef(CONFIG_I2C_NRFX_TWI	i2c_nrfx_twi_common.c)
+	zephyr_library_sources_ifdef(CONFIG_I2C_NRFX_TWIM	i2c_nrfx_twim.c)
+	zephyr_library_sources_ifdef(CONFIG_I2C_NRFX_TWIM	i2c_nrfx_twim_common.c)
+	zephyr_library_sources_ifdef(CONFIG_I2C_SAM_TWIHS	i2c_sam_twihs.c)
+	# zephyr-keep-sorted-stop
+endif()

--- a/drivers/i2c/Kconfig
+++ b/drivers/i2c/Kconfig
@@ -117,6 +117,7 @@ endif # I2C_RTIO
 # Include these first so that any properties (e.g. defaults) below can be
 # overridden (by defining symbols in multiple locations)
 source "drivers/i2c/target/Kconfig"
+# zephyr-keep-sorted-start
 source "drivers/i2c/Kconfig.ambiq"
 source "drivers/i2c/Kconfig.andes_atciic100"
 source "drivers/i2c/Kconfig.b91"
@@ -127,10 +128,10 @@ source "drivers/i2c/Kconfig.ene"
 source "drivers/i2c/Kconfig.esp32"
 source "drivers/i2c/Kconfig.gd32"
 source "drivers/i2c/Kconfig.gpio"
+source "drivers/i2c/Kconfig.i2c_emul"
 source "drivers/i2c/Kconfig.ifx_cat1"
 source "drivers/i2c/Kconfig.ifx_xmc4"
 source "drivers/i2c/Kconfig.it8xxx2"
-source "drivers/i2c/Kconfig.i2c_emul"
 source "drivers/i2c/Kconfig.litex"
 source "drivers/i2c/Kconfig.lpc11u6x"
 source "drivers/i2c/Kconfig.max32"
@@ -139,8 +140,8 @@ source "drivers/i2c/Kconfig.mcux"
 source "drivers/i2c/Kconfig.npcx"
 source "drivers/i2c/Kconfig.nrfx"
 source "drivers/i2c/Kconfig.numaker"
-source "drivers/i2c/Kconfig.renesas_ra"
 source "drivers/i2c/Kconfig.rcar"
+source "drivers/i2c/Kconfig.renesas_ra"
 source "drivers/i2c/Kconfig.sam0"
 source "drivers/i2c/Kconfig.sam_twihs"
 source "drivers/i2c/Kconfig.sbcon"
@@ -149,11 +150,11 @@ source "drivers/i2c/Kconfig.sedi"
 source "drivers/i2c/Kconfig.sifive"
 source "drivers/i2c/Kconfig.smartbond"
 source "drivers/i2c/Kconfig.stm32"
-
 source "drivers/i2c/Kconfig.tca954x"
 source "drivers/i2c/Kconfig.test"
 source "drivers/i2c/Kconfig.xec"
 source "drivers/i2c/Kconfig.xilinx_axi"
+# zephyr-keep-sorted-stop
 
 config I2C_INIT_PRIORITY
 	int "Init priority"

--- a/drivers/i2c/target/CMakeLists.txt
+++ b/drivers/i2c/target/CMakeLists.txt
@@ -1,3 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
+# zephyr-keep-sorted-start
 zephyr_library_sources_ifdef(CONFIG_I2C_EEPROM_TARGET eeprom_target.c)
+# zephyr-keep-sorted-stop

--- a/drivers/i2c/target/Kconfig
+++ b/drivers/i2c/target/Kconfig
@@ -25,6 +25,8 @@ config I2C_TARGET_BUFFER_MODE
 	help
 	  This is an option to enable buffer mode.
 
+# zephyr-keep-sorted-start
 source "drivers/i2c/target/Kconfig.eeprom"
+# zephyr-keep-sorted-stop
 
 endif # I2C_TARGET


### PR DESCRIPTION
The previous re-organization has the zephyr-keep-sorted defines missing. Add them for the I2C drivers and targets.