### PR TITLE
boards: stm32h7b3i_dk: Move LV_DRAW_DMA2D_HAL_INCLUDE to the soc

### DIFF
--- a/boards/st/stm32h7b3i_dk/Kconfig.defconfig
+++ b/boards/st/stm32h7b3i_dk/Kconfig.defconfig
@@ -25,9 +25,6 @@ config CACHE_MANAGEMENT
 config LV_USE_DRAW_DMA2D
 	default y
 
-config LV_DRAW_DMA2D_HAL_INCLUDE
-	default "stm32h7xx.h"
-
 config STM32_LTDC_FB_NUM
 	default 2
 

--- a/soc/st/stm32/stm32h7x/Kconfig.defconfig
+++ b/soc/st/stm32/stm32h7x/Kconfig.defconfig
@@ -14,4 +14,11 @@ config ROM_START_OFFSET
 	default 0x400 if BOOTLOADER_MCUBOOT
 	default 0x0   if !BOOTLOADER_MCUBOOT
 
+if LVGL
+
+config LV_DRAW_DMA2D_HAL_INCLUDE
+	default "stm32h7xx.h"
+
+endif # LVGL
+
 endif # SOC_SERIES_STM32H7X


### PR DESCRIPTION
Moves the LV_DRAW_DMA2D_HAL_INCLUDE to the soc instead of the development kit since the hal include is the same across all boards using the soc.

Leftover from https://github.com/zephyrproject-rtos/zephyr/pull/68168/files#r1834036495