### PR TITLE
fs: ext2: Fix nbytes_to_read calculation in ext2_inode_read()

### DIFF
--- a/subsys/fs/ext2/ext2_impl.c
+++ b/subsys/fs/ext2/ext2_impl.c
@@ -630,7 +630,7 @@ ssize_t ext2_inode_read(struct ext2_inode *inode, void *buf, uint32_t offset, si
 		memcpy((uint8_t *)buf + read, inode_current_block_mem(inode) + block_off, to_read);
 
 		read += to_read;
-		nbytes_to_read -= read;
+		nbytes_to_read -= to_read;
 		offset += to_read;
 	}
 


### PR DESCRIPTION
Fix incorrect nbytes_to_read calculation in ext2_inode_read() function. Previously nbytes_to_read was decremented by read value which caused incorrect calculation of bytes to read in subsequent iterations. Now nbytes_to_read is decremented by to_read value which represents the actual number of bytes read in current iteration.

This fixes potential data corruption issues when reading files from ext2 filesystem.

Fixes #83625