### PR TITLE
soc: npcx: add default SYS_CLOCK_HW_CYCLES_PER_SEC

### DIFF
--- a/soc/nuvoton/npcx/npcx4/Kconfig.defconfig
+++ b/soc/nuvoton/npcx/npcx4/Kconfig.defconfig
@@ -15,4 +15,7 @@ config ESPI_TAF_NPCX
 	default y
 	depends on ESPI_TAF
 
+config SYS_CLOCK_HW_CYCLES_PER_SEC
+	default 15000000
+
 endif # SOC_SERIES_NPCX4

--- a/soc/nuvoton/npcx/npcx7/Kconfig.defconfig
+++ b/soc/nuvoton/npcx/npcx7/Kconfig.defconfig
@@ -11,4 +11,7 @@ config NUM_IRQS
 config CORTEX_M_SYSTICK
 	default !NPCX_ITIM_TIMER
 
+config SYS_CLOCK_HW_CYCLES_PER_SEC
+	default 15000000
+
 endif # SOC_SERIES_NPCX7

--- a/soc/nuvoton/npcx/npcx9/Kconfig.defconfig
+++ b/soc/nuvoton/npcx/npcx9/Kconfig.defconfig
@@ -11,4 +11,7 @@ config NUM_IRQS
 config CORTEX_M_SYSTICK
 	default !NPCX_ITIM_TIMER
 
+config SYS_CLOCK_HW_CYCLES_PER_SEC
+	default 15000000
+
 endif # SOC_SERIES_NPCX9


### PR DESCRIPTION
This commit adds the default value of `SYS_CLOCK_HW_CYCLES_PER_SEC` in the SoC Kconfig.defconfig files.
The value should be set to match the frequency of the APB2 clock. It can be achieved by dividing the `OFMCLK` by `APB2` prescaler defined in the `pcc` DTS node:
```
	pcc: clock-controller@4000d000 {
                        clock-frequency = <DT_FREQ_M(90)>; /* OFMCLK runs at 90MHz */
                        core-prescaler = <6>; /* CORE_CLK runs at 15MHz */
                        apb1-prescaler = <6>; /* APB1_CLK runs at 15MHz */
                        apb2-prescaler = <6>; /* APB2_CLK runs at 15MHz */
                        ...
        };
```