### PR TITLE
drivers: sensor: bma4xx: Implement streaming APIs

### DIFF
--- a/drivers/sensor/bosch/bma4xx/CMakeLists.txt
+++ b/drivers/sensor/bosch/bma4xx/CMakeLists.txt
@@ -6,6 +6,7 @@ zephyr_library_sources(
     bma4xx.c
     bma4xx_common.c
     bma4xx_decoder.c
+    bma4xx_rtio.c
 )
 
 zephyr_library_sources_ifdef(CONFIG_I2C bma4xx_i2c.c)

--- a/drivers/sensor/bosch/bma4xx/CMakeLists.txt
+++ b/drivers/sensor/bosch/bma4xx/CMakeLists.txt
@@ -3,5 +3,6 @@
 zephyr_library()
 
 zephyr_library_sources(bma4xx.c)
+zephyr_library_sources(bma4xx_common.c)
 zephyr_library_sources(bma4xx_i2c.c)
 zephyr_library_sources(bma4xx_spi.c)

--- a/drivers/sensor/bosch/bma4xx/CMakeLists.txt
+++ b/drivers/sensor/bosch/bma4xx/CMakeLists.txt
@@ -11,4 +11,6 @@ zephyr_library_sources(
 
 zephyr_library_sources_ifdef(CONFIG_I2C bma4xx_i2c.c)
 zephyr_library_sources_ifdef(CONFIG_SPI bma4xx_spi.c)
+zephyr_library_sources_ifdef(CONFIG_BMA4XX_STREAM bma4xx_rtio_stream.c)
+zephyr_library_sources_ifdef(CONFIG_BMA4XX_STREAM bma4xx_interrupt.c)
 zephyr_library_sources_ifdef(CONFIG_EMUL_BMA4XX bma4xx_emul.c)

--- a/drivers/sensor/bosch/bma4xx/CMakeLists.txt
+++ b/drivers/sensor/bosch/bma4xx/CMakeLists.txt
@@ -2,7 +2,11 @@
 
 zephyr_library()
 
-zephyr_library_sources(bma4xx.c)
-zephyr_library_sources(bma4xx_common.c)
-zephyr_library_sources(bma4xx_i2c.c)
-zephyr_library_sources(bma4xx_spi.c)
+zephyr_library_sources(
+    bma4xx.c
+    bma4xx_common.c
+    bma4xx_decoder.c
+)
+
+zephyr_library_sources_ifdef(CONFIG_I2C bma4xx_i2c.c)
+zephyr_library_sources_ifdef(CONFIG_SPI bma4xx_spi.c)

--- a/drivers/sensor/bosch/bma4xx/CMakeLists.txt
+++ b/drivers/sensor/bosch/bma4xx/CMakeLists.txt
@@ -11,3 +11,4 @@ zephyr_library_sources(
 
 zephyr_library_sources_ifdef(CONFIG_I2C bma4xx_i2c.c)
 zephyr_library_sources_ifdef(CONFIG_SPI bma4xx_spi.c)
+zephyr_library_sources_ifdef(CONFIG_EMUL_BMA4XX bma4xx_emul.c)

--- a/drivers/sensor/bosch/bma4xx/Kconfig
+++ b/drivers/sensor/bosch/bma4xx/Kconfig
@@ -2,10 +2,11 @@
 #
 # Copyright (c) 2023 Google LLC
 # Copyright (c) 2024 Croxel Inc.
+# Copyright (c) 2024 Cienet
 #
 # SPDX-License-Identifier: Apache-2.0
 
-config BMA4XX
+menuconfig BMA4XX
 	bool "BMA4XX 3-axis acceleration sensor"
 	default y
 	depends on DT_HAS_BOSCH_BMA4XX_ENABLED
@@ -15,10 +16,11 @@ config BMA4XX
 	help
 	  Enable driver for Bosch BMA4XX (I2C-based)
 
+if BMA4XX
+
 config BMA4XX_TEMPERATURE
 	bool "Allow reading the BMA4XX die temperature"
 	default n
-	depends on BMA4XX
 	help
 	  Allow reading the BMA4xx's on-chip temperature sensor. This creates
 	  extra bus activity and increases code size.
@@ -26,8 +28,17 @@ config BMA4XX_TEMPERATURE
 config EMUL_BMA4XX
 	bool "Emulator for the BMA4XX"
 	default y
-	depends on BMA4XX
 	depends on EMUL
 	help
 	  Enable the hardware emulator for the BMA4XX. Doing so allows exercising
 	  sensor APIs for this sensor in native_sim and qemu.
+
+config BMA4XX_STREAM
+	bool "Use hardware FIFO to stream data"
+	default y
+	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_BOSCH_BMA4XX),int1-gpios)
+	help
+	  Use this config option to enable streaming sensor data via RTIO subsystem.
+
+endif # BMA4XX

--- a/drivers/sensor/bosch/bma4xx/bma4xx.c
+++ b/drivers/sensor/bosch/bma4xx/bma4xx.c
@@ -2,6 +2,7 @@
  *
  * Copyright (c) 2023 Google LLC
  * Copyright (c) 2024 Croxel Inc.
+ * Copyright (c) 2024 Cienet
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -274,8 +275,9 @@ static int bma4xx_chip_init(const struct device *dev)
 	}
 
 	/* Enable accelerometer */
-	status = bma4xx->hw_ops->update_reg(dev, BMA4XX_REG_POWER_CTRL, BMA4XX_BIT_ACC_EN,
-					    BMA4XX_BIT_ACC_EN);
+	status =
+		bma4xx->hw_ops->update_reg(dev, BMA4XX_REG_POWER_CTRL, BMA4XX_BIT_POWER_CTRL_ACC_EN,
+					   BMA4XX_BIT_POWER_CTRL_ACC_EN);
 	if (status) {
 		LOG_ERR("Could not enable accel: %d", status);
 		return status;

--- a/drivers/sensor/bosch/bma4xx/bma4xx.c
+++ b/drivers/sensor/bosch/bma4xx/bma4xx.c
@@ -15,12 +15,13 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/pm/device.h>
 #include <zephyr/rtio/work.h>
-#include <zephyr/drivers/sensor_clock.h>
 
-LOG_MODULE_REGISTER(bma4xx, CONFIG_SENSOR_LOG_LEVEL);
 #include "bma4xx.h"
+#include "bma4xx_interrupt.h"
 #include "bma4xx_decoder.h"
 #include "bma4xx_rtio.h"
+
+LOG_MODULE_REGISTER(bma4xx, CONFIG_SENSOR_LOG_LEVEL);
 
 /**
  * @brief Helper for converting m/s^2 offset values into register values
@@ -112,8 +113,7 @@ static int bma4xx_odr_to_reg(uint32_t microhertz, uint8_t *reg_val)
 }
 
 /**
- * Set the sensor's acceleration offset (per axis). Use bma4xx_commit_nvm() to save these
- * offsets to nonvolatile memory so they are automatically set during power-on-reset.
+ * Set the sensor's acceleration offset (per axis).
  */
 static int bma4xx_attr_set_odr(const struct sensor_value *val,
 			       struct bma4xx_runtime_config *new_config)
@@ -226,6 +226,17 @@ static int bma4xx_attr_set(const struct device *dev, enum sensor_channel chan,
 			res = -ENOTSUP;
 		}
 		break;
+	case SENSOR_CHAN_ALL:
+		if (attr == SENSOR_ATTR_BATCH_DURATION) {
+			if (val->val1 < 0) {
+				return -EINVAL;
+			}
+			new_config.batch_ticks = val->val1;
+		} else {
+			LOG_ERR("Unsupported attribute");
+			res = -EINVAL;
+		}
+		break;
 	default:
 		LOG_ERR("Unsupported channel");
 		res = -EINVAL;
@@ -252,7 +263,7 @@ static int bma4xx_chip_init(const struct device *dev)
 	/* Sensor bus-specific initialization */
 	status = cfg->bus_init(dev);
 	if (status) {
-		LOG_ERR("bus_init failed: %d", status);
+		LOG_ERR("Failed to initialize bus: %d", status);
 		return status;
 	}
 
@@ -275,31 +286,26 @@ static int bma4xx_chip_init(const struct device *dev)
 		return status;
 	}
 
-	k_sleep(K_USEC(1000));
+	if (IS_ENABLED(CONFIG_BMA4XX_STREAM)) {
+		status = bma4xx_init_interrupt(dev);
+		if (status != 0) {
+			LOG_ERR("Failed to initialize bma4xx interrupt");
+			return status;
+		}
+	}
 
 	/* Default is: range = +/-4G, ODR = 100 Hz, BWP = "NORM_AVG4" */
 	bma4xx->cfg.accel_fs_range = BMA4XX_RANGE_4G;
 	bma4xx->cfg.accel_bwp = BMA4XX_BWP_NORM_AVG4;
 	bma4xx->cfg.accel_odr = BMA4XX_ODR_100;
 
-	/* Switch to performance power mode */
-	status = bma4xx->hw_ops->update_reg(dev, BMA4XX_REG_ACCEL_CONFIG, BMA4XX_BIT_ACC_PERF_MODE,
-					    BMA4XX_BIT_ACC_PERF_MODE);
+	status = bma4xx_configure(dev, &bma4xx->cfg);
 	if (status) {
-		LOG_ERR("Could not enable performance power save mode: %d", status);
+		LOG_ERR("Failed to initialize bma4xx trigger");
 		return status;
 	}
 
-	/* Enable accelerometer */
-	status =
-		bma4xx->hw_ops->update_reg(dev, BMA4XX_REG_POWER_CTRL, BMA4XX_BIT_POWER_CTRL_ACC_EN,
-					   BMA4XX_BIT_POWER_CTRL_ACC_EN);
-	if (status) {
-		LOG_ERR("Could not enable accel: %d", status);
-		return status;
-	}
-
-	return status;
+	return 0;
 }
 
 /*
@@ -308,8 +314,8 @@ static int bma4xx_chip_init(const struct device *dev)
 
 static DEVICE_API(sensor, bma4xx_driver_api) = {
 	.attr_set = bma4xx_attr_set,
-	.submit = bma4xx_submit,
 	.get_decoder = bma4xx_get_decoder,
+	.submit = bma4xx_submit,
 };
 
 /*
@@ -343,9 +349,18 @@ static DEVICE_API(sensor, bma4xx_driver_api) = {
 #define BMA4XX_DEFINE_BUS(inst)                                                                    \
 	COND_CODE_1(DT_INST_ON_BUS(inst, spi), (BMA4XX_CONFIG_SPI(inst)), (BMA4XX_CONFIG_I2C(inst)))
 
+#define BMA4XX_DT_CONFIG_INIT(inst)                                                                \
+	{                                                                                          \
+		.fifo_en = IS_ENABLED(CONFIG_BMA4XX_STREAM),                                       \
+		.batch_ticks = 0,                                                                  \
+		.interrupt1_fifo_wm = false,                                                       \
+		.interrupt1_fifo_full = false,                                                     \
+	}
+
 #define BMA4XX_DEFINE_DATA(inst)                                                                   \
 	BMA4XX_DEFINE_RTIO(inst);                                                                  \
 	static struct bma4xx_data bma4xx_driver_##inst = {                                         \
+		.cfg = BMA4XX_DT_CONFIG_INIT(inst),                                                \
 		.r = &bma4xx_rtio_##inst,                                                          \
 		.iodev = &bma4xx_iodev_##inst,                                                     \
 	};
@@ -357,7 +372,10 @@ static DEVICE_API(sensor, bma4xx_driver_api) = {
 #define BMA4XX_INIT(inst)                                                                          \
 	BMA4XX_DEFINE_DATA(inst);                                                                  \
                                                                                                    \
-	static const struct bma4xx_config bma4xx_config_##inst = {BMA4XX_DEFINE_BUS(inst)};        \
+	static const struct bma4xx_config bma4xx_config_##inst = {                                 \
+		BMA4XX_DEFINE_BUS(inst)                                                            \
+			IF_ENABLED(CONFIG_BMA4XX_STREAM, ( \
+		.gpio_interrupt = GPIO_DT_SPEC_INST_GET_OR(inst, int1_gpios, {0}),))};         \
                                                                                                    \
 	SENSOR_DEVICE_DT_INST_DEFINE(inst, bma4xx_chip_init, NULL, &bma4xx_driver_##inst,          \
 				     &bma4xx_config_##inst, POST_KERNEL,                           \

--- a/drivers/sensor/bosch/bma4xx/bma4xx.h
+++ b/drivers/sensor/bosch/bma4xx/bma4xx.h
@@ -69,32 +69,6 @@ struct bma4xx_data {
 	uint8_t chip_id;
 };
 
-/*
- * RTIO types
- */
-
-struct bma4xx_decoder_header {
-	uint64_t timestamp;
-	uint8_t is_fifo: 1;
-	uint8_t accel_fs: 2;
-	uint8_t reserved: 5;
-} __attribute__((__packed__));
-
-struct bma4xx_encoded_data {
-	struct bma4xx_decoder_header header;
-	struct {
-		/** Set if `accel_xyz` has data */
-		uint8_t has_accel: 1;
-		/** Set if `temp` has data */
-		uint8_t has_temp: 1;
-		uint8_t reserved: 6;
-	} __attribute__((__packed__));
-	int16_t accel_xyz[3];
-#ifdef CONFIG_BMA4XX_TEMPERATURE
-	int8_t temp;
-#endif /* CONFIG_BMA4XX_TEMPERATURE */
-};
-
 int bma4xx_spi_init(const struct device *dev);
 int bma4xx_i2c_init(const struct device *dev);
 

--- a/drivers/sensor/bosch/bma4xx/bma4xx.h
+++ b/drivers/sensor/bosch/bma4xx/bma4xx.h
@@ -51,13 +51,18 @@ struct bma4xx_hw_operations {
 	int (*update_reg)(const struct device *dev, uint8_t reg_addr, uint8_t mask, uint8_t value);
 };
 
-struct bma4xx_data {
+struct bma4xx_runtime_config {
+	bool fifo_en;
 	/** Current full-scale range setting as a register value */
 	uint8_t accel_fs_range;
 	/** Current bandwidth parameter (BWP) as a register value */
 	uint8_t accel_bwp;
 	/** Current output data rate as a register value */
 	uint8_t accel_odr;
+};
+
+struct bma4xx_data {
+	struct bma4xx_runtime_config cfg;
 	/** Pointer to bus-specific I/O API */
 	const struct bma4xx_hw_operations *hw_ops;
 	/** Chip ID value stored in BMA4XX_REG_CHIP_ID */
@@ -92,5 +97,29 @@ struct bma4xx_encoded_data {
 
 int bma4xx_spi_init(const struct device *dev);
 int bma4xx_i2c_init(const struct device *dev);
+
+/**
+ * @brief (Re)Configure the sensor with the given configuration
+ *
+ * @param dev bma4xx device pointer
+ * @param cfg bma4xx_runtime_config pointer
+ *
+ * @retval 0 success
+ * @retval -errno Error
+ */
+int bma4xx_configure(const struct device *dev, struct bma4xx_runtime_config *cfg);
+
+/**
+ * @brief Safely (re)Configure the sensor with the given configuration
+ *
+ * Will rollback to prior configuration if new configuration is invalid
+ *
+ * @param dev bma4xx device pointer
+ * @param cfg bma4xx_runtime_config pointer
+ *
+ * @retval 0 success
+ * @retval -errno Error
+ */
+int bma4xx_safely_configure(const struct device *dev, struct bma4xx_runtime_config *cfg);
 
 #endif /* ZEPHYR_DRIVERS_SENSOR_BMA4XX_BMA4XX_H_ */

--- a/drivers/sensor/bosch/bma4xx/bma4xx.h
+++ b/drivers/sensor/bosch/bma4xx/bma4xx.h
@@ -25,6 +25,9 @@
  * Types
  */
 
+#define BMA4XX_BUS_I2C 0
+#define BMA4XX_BUS_SPI 1
+
 union bma4xx_bus_cfg {
 #if DT_ANY_INST_ON_BUS_STATUS_OKAY(i2c)
 	struct i2c_dt_spec i2c;
@@ -38,6 +41,7 @@ union bma4xx_bus_cfg {
 struct bma4xx_config {
 	int (*bus_init)(const struct device *dev);
 	const union bma4xx_bus_cfg bus_cfg;
+	uint8_t bus_type;
 };
 
 /** Used to implement bus-specific R/W operations. See bma4xx_i2c.c and
@@ -67,6 +71,8 @@ struct bma4xx_data {
 	const struct bma4xx_hw_operations *hw_ops;
 	/** Chip ID value stored in BMA4XX_REG_CHIP_ID */
 	uint8_t chip_id;
+	struct rtio *r;
+	struct rtio_iodev *iodev;
 };
 
 int bma4xx_spi_init(const struct device *dev);

--- a/drivers/sensor/bosch/bma4xx/bma4xx.h
+++ b/drivers/sensor/bosch/bma4xx/bma4xx.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2023 Google LLC
+ * Copyright (c) 2024 Cienet
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -10,6 +11,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/device.h>
 #include <zephyr/drivers/sensor.h>
+#include "bma4xx_defs.h"
 
 #if DT_ANY_INST_ON_BUS_STATUS_OKAY(spi)
 #include <zephyr/drivers/spi.h>
@@ -18,153 +20,6 @@
 #if DT_ANY_INST_ON_BUS_STATUS_OKAY(i2c)
 #include <zephyr/drivers/i2c.h>
 #endif /* DT_ANY_INST_ON_BUS_STATUS_OKAY(i2c) */
-
-/*
- * Register definitions
- */
-
-#define BMA4XX_REG_CHIP_ID         (0x00)
-#define BMA4XX_REG_ERROR           (0x02)
-#define BMA4XX_REG_STATUS          (0x03)
-#define BMA4XX_REG_DATA_0          (0x0A)
-#define BMA4XX_REG_DATA_1          (0x0B)
-#define BMA4XX_REG_DATA_2          (0x0C)
-#define BMA4XX_REG_DATA_3          (0x0D)
-#define BMA4XX_REG_DATA_4          (0x0E)
-#define BMA4XX_REG_DATA_5          (0x0F)
-#define BMA4XX_REG_DATA_6          (0x10)
-#define BMA4XX_REG_DATA_7          (0x11)
-#define BMA4XX_REG_DATA_8          (0x12)
-#define BMA4XX_REG_DATA_9          (0x13)
-#define BMA4XX_REG_DATA_10         (0x14)
-#define BMA4XX_REG_DATA_11         (0x15)
-#define BMA4XX_REG_DATA_12         (0x16)
-#define BMA4XX_REG_DATA_13         (0x17)
-#define BMA4XX_REG_SENSORTIME_0    (0x18)
-#define BMA4XX_REG_INT_STAT_0      (0x1C)
-#define BMA4XX_REG_INT_STAT_1      (0x1D)
-#define BMA4XX_REG_STEP_CNT_OUT_0  (0x1E)
-#define BMA4XX_REG_HIGH_G_OUT      (0x1F)
-#define BMA4XX_REG_TEMPERATURE     (0x22)
-#define BMA4XX_REG_FIFO_LENGTH_0   (0x24)
-#define BMA4XX_REG_FIFO_LENGTH_1   (0x25)
-#define BMA4XX_REG_FIFO_DATA       (0x26)
-#define BMA4XX_REG_ACTIVITY_OUT    (0x27)
-#define BMA4XX_REG_ORIENTATION_OUT (0x28)
-#define BMA4XX_REG_ACCEL_CONFIG    (0x40)
-#define BMA4XX_REG_ACCEL_RANGE     (0x41)
-#define BMA4XX_REG_AUX_CONFIG      (0x44)
-#define BMA4XX_REG_FIFO_DOWN       (0x45)
-#define BMA4XX_REG_FIFO_WTM_0      (0x46)
-#define BMA4XX_REG_FIFO_CONFIG_0   (0x48)
-#define BMA4XX_REG_FIFO_CONFIG_1   (0x49)
-#define BMA4XX_REG_AUX_DEV_ID      (0x4B)
-#define BMA4XX_REG_AUX_IF_CONF     (0x4C)
-#define BMA4XX_REG_AUX_RD          (0x4D)
-#define BMA4XX_REG_AUX_WR          (0x4E)
-#define BMA4XX_REG_AUX_WR_DATA     (0x4F)
-#define BMA4XX_REG_INT1_IO_CTRL    (0x53)
-#define BMA4XX_REG_INT2_IO_CTRL    (0x54)
-#define BMA4XX_REG_INT_LATCH       (0x55)
-#define BMA4XX_REG_INT_MAP_1       (0x56)
-#define BMA4XX_REG_INT_MAP_2       (0x57)
-#define BMA4XX_REG_INT_MAP_DATA    (0x58)
-#define BMA4XX_REG_INIT_CTRL       (0x59)
-#define BMA4XX_REG_RESERVED_REG_5B (0x5B)
-#define BMA4XX_REG_RESERVED_REG_5C (0x5C)
-#define BMA4XX_REG_FEATURE_CONFIG  (0x5E)
-#define BMA4XX_REG_IF_CONFIG       (0x6B)
-#define BMA4XX_REG_ACC_SELF_TEST   (0x6D)
-#define BMA4XX_REG_NV_CONFIG       (0x70)
-#define BMA4XX_REG_OFFSET_0        (0x71)
-#define BMA4XX_REG_OFFSET_1        (0x72)
-#define BMA4XX_REG_OFFSET_2        (0x73)
-#define BMA4XX_REG_POWER_CONF      (0x7C)
-#define BMA4XX_REG_POWER_CTRL      (0x7D)
-#define BMA4XX_REG_CMD             (0x7E)
-
-/*
- * Bit positions and masks
- */
-
-#define BMA4XX_BIT_ADV_PWR_SAVE BIT(0)
-
-#define BMA4XX_MASK_ACC_CONF_ODR  GENMASK(3, 0)
-#define BMA4XX_MASK_ACC_CONF_BWP  GENMASK(6, 4)
-#define BMA4XX_SHIFT_ACC_CONF_BWP (4)
-
-#define BMA4XX_MASK_ACC_RANGE GENMASK(1, 0)
-
-#define BMA4XX_BIT_ACC_PERF_MODE BIT(7)
-
-#define BMA4XX_BIT_ACC_EN BIT(2)
-
-/* INT_STATUS_1 accelerometer data ready to interrupt */
-#define BMA4XX_ACC_DRDY_INT BIT(7)
-
-/* CMD: Clears all data in FIFO, does not change FIFO_CONFIG and FIFO_DOWNS register */
-#define BMA4XX_CMD_FIFO_FLUSH (0xB0)
-
-/* FIFO_CONFIG_1 enable: Store Accelerometer data in FIFO (all 3 axes) */
-#define BMA4XX_FIFO_ACC_EN BIT(6)
-
-/* Bandwidth parameters */
-#define BMA4XX_BWP_OSR4_AVG1  (0x0)
-#define BMA4XX_BWP_OSR2_AVG2  (0x1)
-#define BMA4XX_BWP_NORM_AVG4  (0x2)
-#define BMA4XX_BWP_CIC_AVG8   (0x3)
-#define BMA4XX_BWP_RES_AVG16  (0x4)
-#define BMA4XX_BWP_RES_AVG32  (0x5)
-#define BMA4XX_BWP_RES_AVG64  (0x6)
-#define BMA4XX_BWP_RES_AVG128 (0x7)
-
-/* Full-scale ranges */
-#define BMA4XX_RANGE_2G  (0x0)
-#define BMA4XX_RANGE_4G  (0x1)
-#define BMA4XX_RANGE_8G  (0x2)
-#define BMA4XX_RANGE_16G (0x3)
-
-/* Output data rates (ODR) */
-#define BMA4XX_ODR_RESERVED (0x00)
-#define BMA4XX_ODR_0_78125  (0x01)
-#define BMA4XX_ODR_1_5625   (0x02)
-#define BMA4XX_ODR_3_125    (0x03)
-#define BMA4XX_ODR_6_25     (0x04)
-#define BMA4XX_ODR_12_5     (0x05)
-#define BMA4XX_ODR_25       (0x06)
-#define BMA4XX_ODR_50       (0x07)
-#define BMA4XX_ODR_100      (0x08)
-#define BMA4XX_ODR_200      (0x09)
-#define BMA4XX_ODR_400      (0x0a)
-#define BMA4XX_ODR_800      (0x0b)
-#define BMA4XX_ODR_1600     (0x0c)
-#define BMA4XX_ODR_3200     (0x0d)
-#define BMA4XX_ODR_6400     (0x0e)
-#define BMA4XX_ODR_12800    (0x0f)
-
-/*
- * BMA4xx commands
- */
-
-#define BMA4XX_CMD_SOFT_RESET (0xB6)
-
-#define BMA4XX_CHIP_ID_BMA422 (0x12)
-#define BMA4XX_CHIP_ID_BMA423 (0x13)
-
-/*
- * Other constants
- */
-
-/* Each bit count is 3.9mG or 3900uG */
-#define BMA4XX_OFFSET_MICROG_PER_BIT (3900)
-#define BMA4XX_OFFSET_MICROG_MIN     (INT8_MIN * BMA4XX_OFFSET_MICROG_PER_BIT)
-#define BMA4XX_OFFSET_MICROG_MAX     (INT8_MAX * BMA4XX_OFFSET_MICROG_PER_BIT)
-
-/* Range is -104C to 150C. Use shift of 8 (+/-256) */
-#define BMA4XX_TEMP_SHIFT (8)
-
-/* The total number of used registers specified in bma422 datasheet is 7E */
-#define BMA4XX_NUM_REGS 0x7E
 
 /*
  * Types

--- a/drivers/sensor/bosch/bma4xx/bma4xx_common.c
+++ b/drivers/sensor/bosch/bma4xx/bma4xx_common.c
@@ -8,11 +8,53 @@
 
 #include <zephyr/drivers/sensor.h>
 #include <zephyr/drivers/i2c.h>
+#include <zephyr/drivers/sensor_clock.h>
 #include "bma4xx.h"
+#include "bma4xx_interrupt.h"
 #include "bma4xx_defs.h"
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(bma4xx, CONFIG_SENSOR_LOG_LEVEL);
+
+#ifdef CONFIG_BMA4XX_STREAM
+
+static uint16_t bma4xx_compute_fifo_wm(const struct bma4xx_runtime_config *new_cfg)
+{
+	int64_t odr;
+	int rc;
+	const bool accel_enabled = new_cfg->accel_pwr_mode != 0;
+	const bool aux_enabled = new_cfg->aux_pwr_mode != 0;
+
+	if (new_cfg->batch_ticks == 0 || !accel_enabled) {
+		return 0;
+	}
+
+	const int pkt_size = (accel_enabled && aux_enabled)
+				     ? BMA4XX_FIFO_MA_LENGTH + BMA4XX_FIFO_HEADER_LENGTH
+				     : BMA4XX_FIFO_A_LENGTH + BMA4XX_FIFO_HEADER_LENGTH;
+
+	struct sensor_value val = {0};
+
+	rc = bma4xx_accel_reg_to_hz(new_cfg->accel_odr, &val);
+
+	if (rc) {
+		LOG_ERR("Invalid ord value");
+		return -EINVAL;
+	}
+
+	/* Measured in Hz */
+	odr = sensor_value_to_micro(&val) / INT64_C(1000000);
+
+	/* Convert 'odr' to bytes * batch_ticks / sec */
+	odr *= (int64_t)new_cfg->batch_ticks * pkt_size;
+
+	/* 'odr' = byte_ticks_per_sec * sensor_ns_per_tick / NSEC_PER_SEC = bytes */
+	odr = DIV_ROUND_UP(sensor_clock_cycles_to_ns(odr), NSEC_PER_SEC);
+
+	return (uint16_t)MIN(odr, 0x3ff);
+}
+
+#endif /* CONFIG_BMA4XX_STREAM */
 
 int bma4xx_configure(const struct device *dev, struct bma4xx_runtime_config *cfg)
 {
@@ -79,14 +121,64 @@ int bma4xx_configure(const struct device *dev, struct bma4xx_runtime_config *cfg
 	res |= dev_data->hw_ops->read_reg(dev, BMA4XX_REG_INT_STAT_1, &value);
 	__ASSERT(res == 0, "%s could not clear interrupt status", __func__);
 
-	LOG_INF("FIFO DISABLED");
+#ifdef CONFIG_BMA4XX_STREAM
+	if (cfg->fifo_en) {
+		LOG_INF("FIFO ENABLED");
 
-	/* No fifo mode so set data ready as interrupt source */
-	uint8_t int_map_data = FIELD_PREP(BMA4XX_BIT_INT_MAP_DATA_INT1_DRDY, 1);
+		/* Enable FIFO header mode and FIFO acceleration data and
+		 * disable FIFO auxiliary data.
+		 */
+		uint8_t fifo_config_1_value = FIELD_PREP(BMA4XX_FIFO_HEADER_EN, 1) |
+					      FIELD_PREP(BMA4XX_FIFO_ACC_EN, 1) |
+					      FIELD_PREP(BMA4XX_FIFO_AUX_EN, 0);
 
-	LOG_DBG("MAP_DATA (0x%x) 0x%x", BMA4XX_REG_INT_MAP_DATA, int_map_data);
-	res |= dev_data->hw_ops->write_reg(dev, BMA4XX_REG_INT_MAP_DATA, int_map_data);
-	__ASSERT(res == 0, "%s could not enable FIFO data ready interrupt", __func__);
+		LOG_DBG("FIFO_CONFIG1 (0x%x) 0x%x", BMA4XX_REG_FIFO_CONFIG_1, fifo_config_1_value);
+		res |= dev_data->hw_ops->write_reg(dev, BMA4XX_REG_FIFO_CONFIG_1,
+						   fifo_config_1_value);
+		__ASSERT(res == 0, "%s could not write fifo config 1", __func__);
+
+		uint8_t pwr_ctrl_value = 0;
+
+		res |= dev_data->hw_ops->read_reg(dev, BMA4XX_REG_POWER_CTRL, &pwr_ctrl_value);
+		__ASSERT(res == 0, "%s could not read power ctrl value", __func__);
+
+		cfg->accel_pwr_mode = FIELD_GET(BMA4XX_BIT_POWER_CTRL_ACC_EN, pwr_ctrl_value);
+		cfg->aux_pwr_mode = FIELD_GET(BMA4XX_BIT_POWER_CTRL_AUX_EN, pwr_ctrl_value);
+
+		/* Set watermark and interrupt handling first */
+		uint16_t fifo_wm = bma4xx_compute_fifo_wm(cfg);
+
+		__ASSERT(fifo_wm >= 0, "%s could not get valid watermark value", __func__);
+
+		uint8_t fifo_wml = fifo_wm & 0xFF;
+
+		LOG_DBG("FIFO_WTM_0( (0x%x)) (WM Low) 0x%x", BMA4XX_REG_FIFO_WTM_0, fifo_wml);
+		res |= dev_data->hw_ops->write_reg(dev, BMA4XX_REG_FIFO_WTM_0, fifo_wml);
+		__ASSERT(res == 0, "%s could not write watermark level LSB", __func__);
+
+		uint8_t fifo_wmh = (fifo_wm >> 8) & 0x0F;
+
+		LOG_DBG("FIFO_WTM_1 (0x%x) (WM High) 0x%x", BMA4XX_REG_FIFO_WTM_1, fifo_wmh);
+		res |= dev_data->hw_ops->write_reg(dev, BMA4XX_REG_FIFO_WTM_1, fifo_wmh);
+		__ASSERT(res == 0, "%s could not write watermark level MSB", __func__);
+
+		res |= bma4xx_enable_interrupt1(dev, cfg);
+		__ASSERT(res == 0, "%s could not enable interrupts", __func__);
+
+	} else {
+#endif /* CONFIG_BMA4XX_STREAM */
+		LOG_INF("FIFO DISABLED");
+
+		/* No fifo mode so set data ready as interrupt source */
+		uint8_t int_map_data = FIELD_PREP(BMA4XX_BIT_INT_MAP_DATA_INT1_DRDY, 1);
+
+		LOG_DBG("MAP_DATA (0x%x) 0x%x", BMA4XX_REG_INT_MAP_DATA, int_map_data);
+		res |= dev_data->hw_ops->write_reg(dev, BMA4XX_REG_INT_MAP_DATA, int_map_data);
+		__ASSERT(res == 0, "%s could not enable FIFO data ready interrupt", __func__);
+
+#ifdef CONFIG_BMA4XX_STREAM
+	}
+#endif /* CONFIG_BMA4XX_STREAM */
 
 	return res;
 }

--- a/drivers/sensor/bosch/bma4xx/bma4xx_common.c
+++ b/drivers/sensor/bosch/bma4xx/bma4xx_common.c
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2024 Cienet
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT bosch_bma4xx
+
+#include <zephyr/drivers/sensor.h>
+#include <zephyr/drivers/i2c.h>
+#include "bma4xx.h"
+#include "bma4xx_defs.h"
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_DECLARE(bma4xx, CONFIG_SENSOR_LOG_LEVEL);
+
+int bma4xx_configure(const struct device *dev, struct bma4xx_runtime_config *cfg)
+{
+	struct bma4xx_data *dev_data = dev->data;
+	int res;
+	uint8_t value;
+
+	/* Disable interrupts, reconfigured at end */
+	res = dev_data->hw_ops->write_reg(dev, BMA4XX_REG_INT_MAP_DATA, 0);
+	__ASSERT(res == 0, "%s could not disable interrupts", __func__);
+
+	/* If FIFO is enabled now, disable and flush */
+	if (dev_data->cfg.fifo_en) {
+		res |= dev_data->hw_ops->write_reg(dev, BMA4XX_REG_FIFO_CONFIG_1,
+						   FIELD_PREP(BMA4XX_FIFO_ACC_EN, 0));
+		__ASSERT(res == 0, "%s could not disable fifo acceleration", __func__);
+
+		res |= dev_data->hw_ops->write_reg(dev, BMA4XX_REG_CMD,
+						   FIELD_PREP(BMA4XX_CMD_FIFO_FLUSH, 1));
+		__ASSERT(res == 0, "%s could not flush fifo", __func__);
+	}
+
+	/* Switch to performance power mode */
+	res |= dev_data->hw_ops->write_reg(dev, BMA4XX_REG_ACCEL_CONFIG,
+					   FIELD_PREP(BMA4XX_BIT_ACC_PERF_MODE, 1));
+	__ASSERT(res == 0, "%s could not enable performance power mode", __func__);
+
+	/* Enable non-latch mode
+	 * Regarding the discussion in the Bosch Community, enabling latch mode on bma4xx
+	 * might result in multiple FIFO interrupts. Therefore, it is recommended to use
+	 * non-latch mode instead.
+	 * Reference:
+	 * https://community.bosch-sensortec.com/mems-sensors-forum-jrmujtaw/post/bma456-sends-multiple-fifo-interrupt-bma4-fifo-wm-int-vWCT2Uz7Alv6flK
+	 */
+	res |= dev_data->hw_ops->write_reg(dev, BMA4XX_REG_INT_LATCH, 0);
+	__ASSERT(res == 0, "%s could not enable non-latch mode", __func__);
+
+	if (dev_data->cfg.accel_odr > 0) {
+		/* Enable accelerometer */
+		res |= dev_data->hw_ops->write_reg(dev, BMA4XX_REG_POWER_CTRL,
+						   FIELD_PREP(BMA4XX_BIT_POWER_CTRL_ACC_EN, 1));
+		__ASSERT(res == 0, "%s could not enable accelerometer", __func__);
+	} else {
+		LOG_DBG("Sample rate is 0, accelerometer not enabled");
+	}
+
+	/* Disable advance power save mode */
+	res |= dev_data->hw_ops->write_reg(dev, BMA4XX_REG_POWER_CONF,
+					   FIELD_PREP(BMA4XX_BIT_POWER_CONF_ADV_PWR_SAVE, 0));
+	__ASSERT(res == 0, "%s could not disable advance power save mode", __func__);
+
+	/* Write acceleration range */
+	res |= dev_data->hw_ops->write_reg(dev, BMA4XX_REG_ACCEL_RANGE,
+					   FIELD_PREP(BMA4XX_MASK_ACC_RANGE, cfg->accel_fs_range));
+	__ASSERT(res == 0, "%s could not write acceleration range", __func__);
+
+	/* Write data rate and bandwidth */
+	uint8_t odr_bw_value = FIELD_PREP(BMA4XX_MASK_ACC_CONF_ODR, cfg->accel_odr) |
+			       FIELD_PREP(BMA4XX_MASK_ACC_CONF_BWP, cfg->accel_bwp);
+
+	res |= dev_data->hw_ops->write_reg(dev, BMA4XX_REG_ACCEL_CONFIG, odr_bw_value);
+	__ASSERT(res == 0, "%s could not write data rate and bandwidth", __func__);
+
+	res |= dev_data->hw_ops->read_reg(dev, BMA4XX_REG_INT_STAT_1, &value);
+	__ASSERT(res == 0, "%s could not clear interrupt status", __func__);
+
+	LOG_INF("FIFO DISABLED");
+
+	/* No fifo mode so set data ready as interrupt source */
+	uint8_t int_map_data = FIELD_PREP(BMA4XX_BIT_INT_MAP_DATA_INT1_DRDY, 1);
+
+	LOG_DBG("MAP_DATA (0x%x) 0x%x", BMA4XX_REG_INT_MAP_DATA, int_map_data);
+	res |= dev_data->hw_ops->write_reg(dev, BMA4XX_REG_INT_MAP_DATA, int_map_data);
+	__ASSERT(res == 0, "%s could not enable FIFO data ready interrupt", __func__);
+
+	return res;
+}
+
+int bma4xx_safely_configure(const struct device *dev, struct bma4xx_runtime_config *cfg)
+{
+	struct bma4xx_data *drv_data = dev->data;
+	int ret = bma4xx_configure(dev, cfg);
+
+	if (ret == 0) {
+		memcpy(&drv_data->cfg, cfg, sizeof(struct bma4xx_runtime_config));
+	} else {
+		ret = bma4xx_configure(dev, &drv_data->cfg);
+	}
+
+	return ret;
+}

--- a/drivers/sensor/bosch/bma4xx/bma4xx_decoder.c
+++ b/drivers/sensor/bosch/bma4xx/bma4xx_decoder.c
@@ -1,0 +1,283 @@
+/*
+ * Copyright (c) 2024 Cienet
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT bosch_bma4xx
+
+#include "bma4xx_decoder.h"
+#include "bma4xx_defs.h"
+#include "bma4xx.h"
+#include <errno.h>
+#include <zephyr/sys/byteorder.h>
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_DECLARE(bma4xx, CONFIG_SENSOR_LOG_LEVEL);
+
+#define IS_ACCEL(chan)                                                                             \
+	((chan) == SENSOR_CHAN_ACCEL_X || (chan) == SENSOR_CHAN_ACCEL_Y ||                         \
+	 (chan) == SENSOR_CHAN_ACCEL_Z || (chan) == SENSOR_CHAN_ACCEL_XYZ)
+
+/*
+ * RTIO decoder
+ */
+
+static int bma4xx_decoder_get_frame_count(const uint8_t *buffer, struct sensor_chan_spec ch,
+					  uint16_t *frame_count)
+{
+	const struct bma4xx_fifo_data *edata = (const struct bma4xx_fifo_data *)buffer;
+	const struct bma4xx_decoder_header *header = &edata->header;
+
+	if (ch.chan_idx != 0) {
+		return -ENOTSUP;
+	}
+
+	if (!header->is_fifo) {
+		switch (ch.chan_type) {
+		case SENSOR_CHAN_ACCEL_X:
+		case SENSOR_CHAN_ACCEL_Y:
+		case SENSOR_CHAN_ACCEL_Z:
+		case SENSOR_CHAN_ACCEL_XYZ:
+		case SENSOR_CHAN_DIE_TEMP:
+			*frame_count = 1;
+			return 0;
+		default:
+			return -ENOTSUP;
+		}
+	}
+
+	if (!IS_ACCEL(ch.chan_type)) {
+		return -ENOTSUP;
+	}
+	/* Skip the header */
+	buffer += sizeof(struct bma4xx_fifo_data);
+
+	uint16_t count = 0;
+	const uint8_t *end = buffer + edata->fifo_count;
+
+	while (buffer < end) {
+		uint8_t size = BMA4XX_FIFO_HEADER_LENGTH;
+		const bool has_accel = FIELD_GET(BMA4XX_BIT_FIFO_HEADER_ACCEL, buffer[0]) == 1;
+		const bool has_aux = FIELD_GET(BMA4XX_BIT_FIFO_HEADER_AUX, buffer[0]) == 1;
+
+		if (FIELD_GET(BMA4XX_BIT_FIFO_HEADER_REGULAR, buffer[0])) {
+			if (has_accel && has_aux) {
+				size += BMA4XX_FIFO_MA_LENGTH;
+			} else if (has_accel) {
+				size += BMA4XX_FIFO_A_LENGTH;
+			} else if (has_aux) {
+				size += BMA4XX_FIFO_M_LENGTH;
+			}
+			++count;
+		} else if (FIELD_GET(BMA4XX_BIT_FIFO_HEADER_CONTROL, buffer[0])) {
+			if (FIELD_GET(BMA4XX_BIT_FIFO_HEADER_SENSORTIME, buffer[0])) {
+				size += BMA4XX_FIFO_ST_LENGTH;
+			} else if (FIELD_GET(BMA4XX_BIT_FIFO_HEAD_OVER_READ_MSB, buffer[0])) {
+				size = *end;
+			} else {
+				size += BMA4XX_FIFO_CF_LENGTH;
+			}
+		}
+
+		buffer += size;
+	}
+
+	*frame_count = count;
+
+	return 0;
+}
+
+static int bma4xx_decoder_get_size_info(struct sensor_chan_spec ch, size_t *base_size,
+					size_t *frame_size)
+{
+	switch (ch.chan_type) {
+	case SENSOR_CHAN_ACCEL_X:
+	case SENSOR_CHAN_ACCEL_Y:
+	case SENSOR_CHAN_ACCEL_Z:
+	case SENSOR_CHAN_ACCEL_XYZ:
+		*base_size = sizeof(struct sensor_three_axis_data);
+		*frame_size = sizeof(struct sensor_three_axis_sample_data);
+		return 0;
+	case SENSOR_CHAN_DIE_TEMP:
+		*base_size = sizeof(struct sensor_q31_data);
+		*frame_size = sizeof(struct sensor_q31_sample_data);
+		return 0;
+	default:
+		return -ENOTSUP;
+	}
+}
+
+static int bma4xx_get_shift(struct sensor_chan_spec ch, uint8_t accel_fs, int8_t *shift)
+{
+	switch (ch.chan_type) {
+	case SENSOR_CHAN_ACCEL_X:
+	case SENSOR_CHAN_ACCEL_Y:
+	case SENSOR_CHAN_ACCEL_Z:
+	case SENSOR_CHAN_ACCEL_XYZ:
+		switch (accel_fs) {
+		case BMA4XX_RANGE_2G:
+			/* 2 G's = 19.62 m/s^2. Use shift of 5 (+/-32) */
+			*shift = 5;
+			return 0;
+		case BMA4XX_RANGE_4G:
+			*shift = 6;
+			return 0;
+		case BMA4XX_RANGE_8G:
+			*shift = 7;
+			return 0;
+		case BMA4XX_RANGE_16G:
+			*shift = 8;
+			return 0;
+		default:
+			return -EINVAL;
+		}
+	case SENSOR_CHAN_DIE_TEMP:
+		*shift = BMA4XX_TEMP_SHIFT;
+		return 0;
+	default:
+		return -EINVAL;
+	}
+}
+
+static void bma4xx_convert_raw_accel_to_q31(int16_t raw_val, q31_t *out)
+{
+	/* The full calculation is (assuming floating math):
+	 *   value_ms2 = raw_value * range * 9.80665 / BIT(11)
+	 * We can treat 'range * 9.80665' as a scale, the scale is calculated by first getting 1g
+	 * represented as a q31 value with the same shift as our result:
+	 *   1g = (9.80665 * BIT(31)) >> shift
+	 * Next, we need to multiply it by our range in g, which for this driver is one of
+	 * [2, 4, 8, 16] and maps to a left shift of [1, 2, 3, 4]:
+	 *   1g <<= log2(range)
+	 * Note we used a right shift by 'shift' and left shift by log2(range). 'shift' is
+	 * [5, 6, 7, 8] for range values [2, 4, 8, 16] since it's the final shift in m/s2. It is
+	 * calculated via:
+	 *   shift = ceil(log2(range * 9.80665))
+	 * This means that we can shorten the above 1g alterations to:
+	 *   1g = (1g >> ceil(log2(range * 9.80665))) << log2(range)
+	 * For the range values [2, 4, 8, 16], the following is true:
+	 *   (x >> ceil(log2(range * 9.80665))) << log2(range)
+	 *   = x >> 4
+	 * Since the range cancels out in the right and left shift, we've now reduced the following:
+	 *   range * 9.80665 = 9.80665 * BIT(31 - 4)
+	 * All that's left is to divide by the bma4xx's maximum range BIT(11).
+	 */
+
+	int16_t value = (int16_t)sys_le16_to_cpu(raw_val << 4) >> 4;
+
+	const int64_t scale = (int64_t)(9.80665 * BIT64(31 - 4));
+
+	*out = CLAMP(((int64_t)value * scale) >> 11, INT32_MIN, INT32_MAX);
+}
+
+#ifdef CONFIG_BMA4XX_TEMPERATURE
+/**
+ * @brief Convert the 8-bit temp register value into a Q31 celsius value
+ */
+static void bma4xx_convert_raw_temp_to_q31(int8_t raw_val, q31_t *out)
+{
+	/* Value of 0 equals 23 degrees C. Each bit count equals 1 degree C */
+
+	int64_t intermediate =
+		((int64_t)raw_val + 23) * ((int64_t)INT32_MAX + 1) / (1 << BMA4XX_TEMP_SHIFT);
+
+	*out = CLAMP(intermediate, INT32_MIN, INT32_MAX);
+}
+#endif /* CONFIG_BMA4XX_TEMPERATURE */
+
+static int bma4xx_one_shot_decode(const uint8_t *buffer, struct sensor_chan_spec ch, uint32_t *fit,
+				  uint16_t max_count, void *data_out)
+{
+	const struct bma4xx_encoded_data *edata = (const struct bma4xx_encoded_data *)buffer;
+	const struct bma4xx_decoder_header *header = &edata->header;
+	int16_t raw_x, raw_y, raw_z;
+	int rc;
+
+	if (*fit != 0) {
+		return 0;
+	}
+	if (max_count == 0 || ch.chan_idx != 0) {
+		return -EINVAL;
+	}
+
+	switch (ch.chan_type) {
+	case SENSOR_CHAN_ACCEL_X:
+	case SENSOR_CHAN_ACCEL_Y:
+	case SENSOR_CHAN_ACCEL_Z:
+	case SENSOR_CHAN_ACCEL_XYZ: {
+		struct sensor_three_axis_data *out = (struct sensor_three_axis_data *)data_out;
+
+		out->header.base_timestamp_ns = edata->header.timestamp;
+		out->header.reading_count = 1;
+		rc = bma4xx_get_shift((struct sensor_chan_spec){.chan_type = SENSOR_CHAN_ACCEL_XYZ,
+								.chan_idx = 3},
+				      header->accel_fs, &out->shift);
+		if (rc != 0) {
+			return -EINVAL;
+		}
+
+		raw_x = (((int16_t)edata->accel_xyz_raw_data[1]) << 4) |
+			FIELD_GET(GENMASK(7, 4), edata->accel_xyz_raw_data[0]);
+		raw_y = (((int16_t)edata->accel_xyz_raw_data[3]) << 4) |
+			FIELD_GET(GENMASK(7, 4), edata->accel_xyz_raw_data[2]);
+		raw_z = (((int16_t)edata->accel_xyz_raw_data[5]) << 4) |
+			FIELD_GET(GENMASK(7, 4), edata->accel_xyz_raw_data[4]);
+
+		bma4xx_convert_raw_accel_to_q31(raw_x, &out->readings[0].x);
+		bma4xx_convert_raw_accel_to_q31(raw_y, &out->readings[0].y);
+		bma4xx_convert_raw_accel_to_q31(raw_z, &out->readings[0].z);
+
+		*fit = 1;
+		return 1;
+	}
+#ifdef CONFIG_BMA4XX_TEMPERATURE
+	case SENSOR_CHAN_DIE_TEMP: {
+		struct sensor_q31_data *out = (struct sensor_q31_data *)data_out;
+
+		out->header.base_timestamp_ns = edata->header.timestamp;
+		out->header.reading_count = 1;
+		rc = bma4xx_get_shift((struct sensor_chan_spec){.chan_type = SENSOR_CHAN_DIE_TEMP,
+								.chan_idx = 12},
+				      0, &out->shift);
+
+		if (rc != 0) {
+			return -EINVAL;
+		}
+
+		bma4xx_convert_raw_temp_to_q31(edata->temp, &out->readings[0].temperature);
+
+		*fit = 1;
+		return 1;
+	}
+#endif /* CONFIG_BMA4XX_TEMPERATURE */
+	default:
+		return -EINVAL;
+	}
+}
+
+static int bma4xx_decoder_decode(const uint8_t *buffer, struct sensor_chan_spec ch, uint32_t *fit,
+				 uint16_t max_count, void *data_out)
+{
+	return bma4xx_one_shot_decode(buffer, ch, fit, max_count, data_out);
+}
+
+static bool bma4xx_decoder_has_trigger(const uint8_t *buffer, enum sensor_trigger_type trigger)
+{
+	return false;
+}
+
+SENSOR_DECODER_API_DT_DEFINE() = {
+	.get_frame_count = bma4xx_decoder_get_frame_count,
+	.get_size_info = bma4xx_decoder_get_size_info,
+	.decode = bma4xx_decoder_decode,
+	.has_trigger = bma4xx_decoder_has_trigger,
+};
+
+int bma4xx_get_decoder(const struct device *dev, const struct sensor_decoder_api **decoder)
+{
+	ARG_UNUSED(dev);
+	*decoder = &SENSOR_DECODER_NAME();
+
+	return 0;
+}

--- a/drivers/sensor/bosch/bma4xx/bma4xx_decoder.h
+++ b/drivers/sensor/bosch/bma4xx/bma4xx_decoder.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2024 Cienet
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_DRIVERS_SENSOR_BMA4XX_DECODER_H_
+#define ZEPHYR_DRIVERS_SENSOR_BMA4XX_DECODER_H_
+
+#include <stdint.h>
+#include <zephyr/drivers/sensor.h>
+
+/*
+ * RTIO types
+ */
+
+struct bma4xx_decoder_header {
+	uint64_t timestamp;
+	uint8_t is_fifo: 1;
+	uint8_t accel_fs: 2;
+	uint8_t reserved: 5;
+} __attribute__((__packed__));
+
+struct bma4xx_fifo_data {
+	struct bma4xx_decoder_header header;
+	uint8_t int_status;
+	uint16_t accel_odr: 4;
+	uint16_t fifo_count: 10;
+	uint16_t reserved: 1;
+} __attribute__((__packed__));
+
+struct bma4xx_encoded_data {
+	struct bma4xx_decoder_header header;
+	uint8_t accel_xyz_raw_data[6];
+#ifdef CONFIG_BMA4XX_TEMPERATURE
+	int8_t temp;
+#endif /* CONFIG_BMA4XX_TEMPERATURE */
+};
+
+int bma4xx_get_decoder(const struct device *dev, const struct sensor_decoder_api **decoder);
+
+#endif /* ZEPHYR_DRIVERS_SENSOR_BMA4XX_DECODER_H_ */

--- a/drivers/sensor/bosch/bma4xx/bma4xx_defs.h
+++ b/drivers/sensor/bosch/bma4xx/bma4xx_defs.h
@@ -1,0 +1,219 @@
+/*
+ * Copyright (c) 2024 Cienet
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_DRIVERS_SENSOR_BMA4XX_REG_H_
+#define ZEPHYR_DRIVERS_SENSOR_BMA4XX_REG_H_
+
+#include <zephyr/sys/util.h>
+
+/*
+ * Register definitions
+ */
+
+#define BMA4XX_REG_CHIP_ID         (0x00)
+#define BMA4XX_REG_ERROR           (0x02)
+#define BMA4XX_REG_STATUS          (0x03)
+#define BMA4XX_REG_DATA_0          (0x0A)
+#define BMA4XX_REG_DATA_1          (0x0B)
+#define BMA4XX_REG_DATA_2          (0x0C)
+#define BMA4XX_REG_DATA_3          (0x0D)
+#define BMA4XX_REG_DATA_4          (0x0E)
+#define BMA4XX_REG_DATA_5          (0x0F)
+#define BMA4XX_REG_DATA_6          (0x10)
+#define BMA4XX_REG_DATA_7          (0x11)
+#define BMA4XX_REG_DATA_8          (0x12)
+#define BMA4XX_REG_DATA_9          (0x13)
+#define BMA4XX_REG_DATA_10         (0x14)
+#define BMA4XX_REG_DATA_11         (0x15)
+#define BMA4XX_REG_DATA_12         (0x16)
+#define BMA4XX_REG_DATA_13         (0x17)
+#define BMA4XX_REG_SENSORTIME_0    (0x18)
+#define BMA4XX_REG_EVENT           (0x1B)
+#define BMA4XX_REG_INT_STAT_0      (0x1C)
+#define BMA4XX_REG_INT_STAT_1      (0x1D)
+#define BMA4XX_REG_STEP_CNT_OUT_0  (0x1E)
+#define BMA4XX_REG_HIGH_G_OUT      (0x1F)
+#define BMA4XX_REG_TEMPERATURE     (0x22)
+#define BMA4XX_REG_FIFO_LENGTH_0   (0x24)
+#define BMA4XX_REG_FIFO_LENGTH_1   (0x25)
+#define BMA4XX_REG_FIFO_DATA       (0x26)
+#define BMA4XX_REG_ACTIVITY_OUT    (0x27)
+#define BMA4XX_REG_ORIENTATION_OUT (0x28)
+#define BMA4XX_REG_ACCEL_CONFIG    (0x40)
+#define BMA4XX_REG_ACCEL_RANGE     (0x41)
+#define BMA4XX_REG_AUX_CONFIG      (0x44)
+#define BMA4XX_REG_FIFO_DOWN       (0x45)
+#define BMA4XX_REG_FIFO_WTM_0      (0x46)
+#define BMA4XX_REG_FIFO_WTM_1      (0x47)
+#define BMA4XX_REG_FIFO_CONFIG_0   (0x48)
+#define BMA4XX_REG_FIFO_CONFIG_1   (0x49)
+#define BMA4XX_REG_AUX_DEV_ID      (0x4B)
+#define BMA4XX_REG_AUX_IF_CONF     (0x4C)
+#define BMA4XX_REG_AUX_RD          (0x4D)
+#define BMA4XX_REG_AUX_WR          (0x4E)
+#define BMA4XX_REG_AUX_WR_DATA     (0x4F)
+#define BMA4XX_REG_INT1_IO_CTRL    (0x53)
+#define BMA4XX_REG_INT2_IO_CTRL    (0x54)
+#define BMA4XX_REG_INT_LATCH       (0x55)
+#define BMA4XX_REG_INT_MAP_1       (0x56)
+#define BMA4XX_REG_INT_MAP_2       (0x57)
+#define BMA4XX_REG_INT_MAP_DATA    (0x58)
+#define BMA4XX_REG_INIT_CTRL       (0x59)
+#define BMA4XX_REG_RESERVED_REG_5B (0x5B)
+#define BMA4XX_REG_RESERVED_REG_5C (0x5C)
+#define BMA4XX_REG_FEATURE_CONFIG  (0x5E)
+#define BMA4XX_REG_IF_CONFIG       (0x6B)
+#define BMA4XX_REG_ACC_SELF_TEST   (0x6D)
+#define BMA4XX_REG_NV_CONFIG       (0x70)
+#define BMA4XX_REG_OFFSET_0        (0x71)
+#define BMA4XX_REG_OFFSET_1        (0x72)
+#define BMA4XX_REG_OFFSET_2        (0x73)
+#define BMA4XX_REG_POWER_CONF      (0x7C)
+#define BMA4XX_REG_POWER_CTRL      (0x7D)
+#define BMA4XX_REG_CMD             (0x7E)
+
+/* BMA4xx I2C register */
+#define BMA4XX_REG_I2C_SDO_HIGH (0x19)
+#define BMA4XX_REG_I2C_SDO_LOW  (0x18)
+
+/*
+ * Bit positions and masks
+ */
+
+#define BMA4XX_REG_ADDRESS_MASK GENMASK(7, 0)
+
+#define BMA4XX_BIT_ADV_PWR_SAVE BIT(0)
+
+#define BMA4XX_MASK_ACC_CONF_ODR  GENMASK(3, 0)
+#define BMA4XX_MASK_ACC_CONF_BWP  GENMASK(6, 4)
+#define BMA4XX_SHIFT_ACC_CONF_BWP (4)
+
+#define BMA4XX_MASK_ACC_RANGE GENMASK(1, 0)
+
+#define BMA4XX_BIT_ACC_PERF_MODE BIT(7)
+
+/* CMD: Clears all data in FIFO, does not change FIFO_CONFIG and FIFO_DOWNS register */
+#define BMA4XX_CMD_FIFO_FLUSH (0xB0)
+
+/* BMA4xx EVENT bit definition */
+#define BMA4XX_BIT_POR_DETECTED BIT(0)
+
+/* BMA4xx INT1_IO_CTRL bit definition */
+#define BMA4XX_BIT_INT1_IO_CTRL_EDGE_CTRL BIT(0)
+#define BMA4XX_BIT_INT1_IO_CTRL_LVL       BIT(1)
+#define BMA4XX_BIT_INT1_IO_CTRL_OD        BIT(2)
+#define BMA4XX_BIT_INT1_IO_CTRL_OUTPUT_EN BIT(3)
+#define BMA4XX_BIT_INT1_IO_CTRL_INPUT_EN  BIT(4)
+
+/* BMA4xx INT_MAP_DATA bit definition */
+#define BMA4XX_BIT_INT_MAP_DATA_INT1_FFUL BIT(0)
+#define BMA4XX_BIT_INT_MAP_DATA_INT1_FWM  BIT(1)
+#define BMA4XX_BIT_INT_MAP_DATA_INT1_DRDY BIT(2)
+
+/* BMA4xx INT_STATUS_1 bit definition */
+#define BMA4XX_BIT_INT_STAT_1_FFULL_INT    BIT(0)
+#define BMA4XX_BIT_INT_STAT_1_FWM_INT      BIT(1)
+#define BMA4XX_BIT_INT_STAT_1_ACC_DRDY_INT BIT(7)
+
+/* BMA4xx PWR_CTRL bit definition */
+#define BMA4XX_BIT_POWER_CTRL_AUX_EN BIT(0)
+#define BMA4XX_BIT_POWER_CTRL_ACC_EN BIT(2)
+
+/* BMA4xx PWR_CONF bit definition */
+#define BMA4XX_BIT_POWER_CONF_ADV_PWR_SAVE BIT(0)
+
+/* BMA4xx EVENT bit definition */
+#define BMA4XX_BIT_EVENT_POR_DETECTED BIT(0)
+
+/* BMA4xx FIFO_CONFIG_1 bit definition */
+#define BMA4XX_FIFO_ACC_EN    BIT(6)
+#define BMA4XX_FIFO_AUX_EN    BIT(5)
+#define BMA4XX_FIFO_HEADER_EN BIT(4)
+
+/* Bandwidth parameters */
+#define BMA4XX_BWP_OSR4_AVG1  (0x0)
+#define BMA4XX_BWP_OSR2_AVG2  (0x1)
+#define BMA4XX_BWP_NORM_AVG4  (0x2)
+#define BMA4XX_BWP_CIC_AVG8   (0x3)
+#define BMA4XX_BWP_RES_AVG16  (0x4)
+#define BMA4XX_BWP_RES_AVG32  (0x5)
+#define BMA4XX_BWP_RES_AVG64  (0x6)
+#define BMA4XX_BWP_RES_AVG128 (0x7)
+
+/* Full-scale ranges */
+#define BMA4XX_RANGE_2G  (0x0)
+#define BMA4XX_RANGE_4G  (0x1)
+#define BMA4XX_RANGE_8G  (0x2)
+#define BMA4XX_RANGE_16G (0x3)
+
+/* Output data rates (ODR) */
+#define BMA4XX_ODR_RESERVED (0x00)
+#define BMA4XX_ODR_0_78125  (0x01)
+#define BMA4XX_ODR_1_5625   (0x02)
+#define BMA4XX_ODR_3_125    (0x03)
+#define BMA4XX_ODR_6_25     (0x04)
+#define BMA4XX_ODR_12_5     (0x05)
+#define BMA4XX_ODR_25       (0x06)
+#define BMA4XX_ODR_50       (0x07)
+#define BMA4XX_ODR_100      (0x08)
+#define BMA4XX_ODR_200      (0x09)
+#define BMA4XX_ODR_400      (0x0a)
+#define BMA4XX_ODR_800      (0x0b)
+#define BMA4XX_ODR_1600     (0x0c)
+#define BMA4XX_ODR_3200     (0x0d)
+#define BMA4XX_ODR_6400     (0x0e)
+#define BMA4XX_ODR_12800    (0x0f)
+
+/* BMA4xx soft-reset commands */
+#define BMA4XX_CMD_SOFT_RESET (0xB6)
+
+/* BMA4xx chip id */
+#define BMA4XX_CHIP_ID_BMA422 (0x12)
+#define BMA4XX_CHIP_ID_BMA423 (0x13)
+
+#define BMA4XX_REG_I2C_READ_BIT BIT(7)
+
+/*
+ * BMA4xx FIFO Header bit definition
+ */
+
+/* fh_parm, regular */
+#define BMA4XX_BIT_FIFO_HEADER_ACCEL BIT(2)
+#define BMA4XX_BIT_FIFO_HEADER_AUX   BIT(4)
+
+/* fh_mode */
+#define BMA4XX_BIT_FIFO_HEADER_CONTROL BIT(6)
+#define BMA4XX_BIT_FIFO_HEADER_REGULAR BIT(7)
+
+/* fh_parm, control */
+#define BMA4XX_BIT_FIFO_HEADER_SENSORTIME  BIT(2)
+#define BMA4XX_BIT_FIFO_HEAD_OVER_READ_MSB BIT(5)
+
+/*
+ * Other constants
+ */
+
+/* BMA4xx FIFO Length definition */
+#define BMA4XX_FIFO_HEADER_LENGTH UINT8_C(1)
+#define BMA4XX_FIFO_A_LENGTH      UINT8_C(6)
+#define BMA4XX_FIFO_M_LENGTH      UINT8_C(8)
+#define BMA4XX_FIFO_MA_LENGTH     UINT8_C(14)
+#define BMA4XX_FIFO_ST_LENGTH     UINT8_C(3)
+#define BMA4XX_FIFO_CF_LENGTH     UINT8_C(1)
+#define BMA4XX_FIFO_DATA_LENGTH   UINT8_C(2)
+
+/* Each bit count is 3.9mG or 3900uG */
+#define BMA4XX_OFFSET_MICROG_PER_BIT (3900)
+#define BMA4XX_OFFSET_MICROG_MIN     (INT8_MIN * BMA4XX_OFFSET_MICROG_PER_BIT)
+#define BMA4XX_OFFSET_MICROG_MAX     (INT8_MAX * BMA4XX_OFFSET_MICROG_PER_BIT)
+
+/* Range is -104C to 150C. Use shift of 8 (+/-256) */
+#define BMA4XX_TEMP_SHIFT (8)
+
+/* The total number of used registers specified in bma422 datasheet is 7E */
+#define BMA4XX_NUM_REGS 0x7E
+
+#endif /* ZEPHYR_DRIVERS_SENSOR_BMA4XX_REG_H_ */

--- a/drivers/sensor/bosch/bma4xx/bma4xx_emul.c
+++ b/drivers/sensor/bosch/bma4xx/bma4xx_emul.c
@@ -22,7 +22,7 @@
 
 #define DT_DRV_COMPAT bosch_bma4xx
 
-LOG_MODULE_REGISTER(bma4xx_emul, CONFIG_SENSOR_LOG_LEVEL);
+LOG_MODULE_DECLARE(bma4xx, CONFIG_SENSOR_LOG_LEVEL);
 
 struct bma4xx_emul_data {
 	/* Holds register data. */
@@ -44,6 +44,7 @@ void bma4xx_emul_set_reg(const struct emul *target, uint8_t reg_addr, const uint
 void bma4xx_emul_get_reg(const struct emul *target, uint8_t reg_addr, uint8_t *val, size_t count)
 {
 	struct bma4xx_emul_data *data = target->data;
+	LOG_INF("*** bma4xx_emul_get_reg: %x, %d", reg_addr, count);
 
 	__ASSERT_NO_MSG(reg_addr + count <= BMA4XX_NUM_REGS);
 	memcpy(val, data->regs + reg_addr, count);
@@ -151,6 +152,7 @@ static int bma4xx_emul_init(const struct emul *target, const struct device *pare
 
 	data->regs[BMA4XX_REG_CHIP_ID] = BMA4XX_CHIP_ID_BMA422;
 	data->regs[BMA4XX_REG_ACCEL_RANGE] = BMA4XX_RANGE_4G;
+	data->regs[BMA4XX_REG_EVENT] = 0x01;
 
 	return 0;
 }
@@ -208,6 +210,8 @@ void bma4xx_emul_set_accel_data(const struct emul *target, q31_t value, int8_t s
 	intermediate = (unshifted * BIT(11)) / (g << range_g);
 
 	intermediate /= accel_range;
+
+	intermediate = intermediate > 0 ? intermediate + 1 : intermediate;
 
 	reg_val = CLAMP(intermediate, -2048, 2047);
 
@@ -270,34 +274,36 @@ static int bma4xx_emul_backend_get_sample_range(const struct emul *target,
 
 	struct bma4xx_emul_data *data = target->data;
 
+	int16_t upper_bound_scale = (BIT(11) - 1);
+
 	switch (data->regs[BMA4XX_REG_ACCEL_RANGE]) {
 	case BMA4XX_RANGE_2G:
 		*shift = 5;
-		*upper = (q31_t)(2 * 9.80665 * BIT(31 - 5));
-		*lower = -*upper;
-		/* (1 << (31 - shift) >> 12) * 2 (where 2 comes from 2g range) */
-		*epsilon = BIT(31 - 5 - 12 + 1);
+		*upper = (q31_t)(2 * 9.80665 * upper_bound_scale * BIT(31 - 11 - 5));
+		*lower = -(q31_t)(2 * 9.80665 * BIT(31 - 5));
+		/* (1 << (31 - shift) >> 11) * 2 (where 2 comes from 2g range) */
+		*epsilon = 9.80665 * BIT(31 - 5 - 11 + 1);
 		break;
 	case BMA4XX_RANGE_4G:
 		*shift = 6;
-		*upper = (q31_t)(4 * 9.80665 * BIT(31 - 6));
-		*lower = -*upper;
-		/* (1 << (31 - shift) >> 12) * 4 (where 4 comes from 4g range) */
-		*epsilon = BIT(31 - 6 - 12 + 2);
+		*upper = (q31_t)(4 * 9.80665 * upper_bound_scale * BIT(31 - 11 - 6));
+		*lower = -(q31_t)(4 * 9.80665 * BIT(31 - 6));
+		/* (1 << (31 - shift) >> 11) * 4 (where 4 comes from 4g range) */
+		*epsilon = 9.80665 * BIT(31 - 6 - 11 + 2);
 		break;
 	case BMA4XX_RANGE_8G:
 		*shift = 7;
-		*upper = (q31_t)(8 * 9.80665 * BIT(31 - 7));
-		*lower = -*upper;
-		/* (1 << (31 - shift) >> 12) * 8 (where 8 comes from 8g range) */
-		*epsilon = BIT(31 - 7 - 12 + 3);
+		*upper = (q31_t)(8 * 9.80665 * upper_bound_scale * BIT(31 - 11 - 7));
+		*lower = -(q31_t)(8 * 9.80665 * BIT(31 - 7));
+		/* (1 << (31 - shift) >> 11) * 8 (where 8 comes from 8g range) */
+		*epsilon = 9.80665 * BIT(31 - 7 - 11 + 3);
 		break;
 	case BMA4XX_RANGE_16G:
 		*shift = 8;
-		*upper = (q31_t)(16 * 9.80665 * BIT(31 - 8));
-		*lower = -*upper;
-		/* (1 << (31 - shift) >> 12) * 16 (where 16 comes from 16g range) */
-		*epsilon = BIT(31 - 8 - 12 + 4);
+		*upper = (q31_t)(16 * 9.80665 * upper_bound_scale * BIT(31 - 11 - 8));
+		*lower = -(q31_t)(16 * 9.80665 * BIT(31 - 8));
+		/* (1 << (31 - shift) >> 11) * 16 (where 16 comes from 16g range) */
+		*epsilon = 9.80665 * BIT(31 - 8 - 11 + 4);
 		break;
 	default:
 		return -ENOTSUP;

--- a/drivers/sensor/bosch/bma4xx/bma4xx_emul.c
+++ b/drivers/sensor/bosch/bma4xx/bma4xx_emul.c
@@ -125,11 +125,11 @@ static int bma4xx_emul_write_byte(const struct emul *target, int reg, uint8_t va
 		data->regs[reg] = val;
 		return 0;
 	case BMA4XX_REG_POWER_CTRL:
-		if ((val & ~BMA4XX_BIT_ACC_EN) != 0) {
+		if ((val & ~BMA4XX_BIT_POWER_CTRL_ACC_EN) != 0) {
 			LOG_ERR("unhandled bits in POWER_CTRL write: %#x", val);
 			return -ENOTSUP;
 		}
-		data->regs[reg] = (val & BMA4XX_BIT_ACC_EN) != 0;
+		data->regs[reg] = (val & BMA4XX_BIT_POWER_CTRL_ACC_EN) != 0;
 		return 0;
 	case BMA4XX_REG_CMD:
 		if (val == BMA4XX_CMD_FIFO_FLUSH) { /* fifo_flush */
@@ -245,7 +245,7 @@ static int bma4xx_emul_backend_set_channel(const struct emul *target, struct sen
 	}
 
 	/* Set data ready flag */
-	data->regs[BMA4XX_REG_INT_STAT_1] |= BMA4XX_ACC_DRDY_INT;
+	data->regs[BMA4XX_REG_INT_STAT_1] |= BMA4XX_BIT_INT_STAT_1_ACC_DRDY_INT;
 
 	return 0;
 }

--- a/drivers/sensor/bosch/bma4xx/bma4xx_i2c.c
+++ b/drivers/sensor/bosch/bma4xx/bma4xx_i2c.c
@@ -29,9 +29,26 @@ static int bma4xx_i2c_write_data(const struct device *dev, uint8_t reg_addr,
 				  uint8_t *value, uint8_t len)
 {
 	const struct bma4xx_config *cfg = dev->config;
+	const struct bma4xx_data *bma4xx = dev->data;
+	int res = 0;
 
-	return i2c_burst_write_dt(&cfg->bus_cfg.i2c, reg_addr, value,
-				  len);
+	res = i2c_burst_write_dt(&cfg->bus_cfg.i2c, reg_addr, value, len);
+	if (res) {
+		LOG_ERR("Could not perform i2c write data");
+		return -ENOTSUP;
+	}
+
+	/* A 1.3us delay is required after write operation when device operates in
+	 * power performance mode whereas 1000us is required when the device operates
+	 * in low power mode.
+	 */
+	if (bma4xx->cfg.accel_pwr_mode) {
+		k_sleep(K_NSEC(1300));
+	} else {
+		k_sleep(K_USEC(1000));
+	}
+
+	return 0;
 }
 
 static int bma4xx_i2c_read_reg(const struct device *dev, uint8_t reg_addr,
@@ -46,16 +63,51 @@ static int bma4xx_i2c_write_reg(const struct device *dev, uint8_t reg_addr,
 				uint8_t value)
 {
 	const struct bma4xx_config *cfg = dev->config;
+	const struct bma4xx_data *bma4xx = dev->data;
+	int res = 0;
 
-	return i2c_reg_write_byte_dt(&cfg->bus_cfg.i2c, reg_addr, value);
+	res = i2c_reg_write_byte_dt(&cfg->bus_cfg.i2c, reg_addr, value);
+	if (res) {
+		LOG_ERR("Could not perform i2c write reg");
+		return -ENOTSUP;
+	}
+
+	/* A 1.3us delay is required after write operation when device operates in
+	 * power performance mode whereas 1000us is required when the device operates
+	 * in low power mode.
+	 */
+	if (bma4xx->cfg.accel_pwr_mode) {
+		k_sleep(K_NSEC(1300));
+	} else {
+		k_sleep(K_USEC(1000));
+	}
+
+	return 0;
 }
 
 static int bma4xx_i2c_update_reg(const struct device *dev, uint8_t reg_addr,
 				  uint8_t mask, uint8_t value)
 {
 	const struct bma4xx_config *cfg = dev->config;
+	const struct bma4xx_data *bma4xx = dev->data;
+	int res = 0;
 
-	return i2c_reg_update_byte_dt(&cfg->bus_cfg.i2c, reg_addr, mask, value);
+	res = i2c_reg_update_byte_dt(&cfg->bus_cfg.i2c, reg_addr, mask, value);
+	if (res) {
+		LOG_ERR("Could not perform i2c update data");
+		return -ENOTSUP;
+	}
+
+	/* A 1.3us delay is required after write operation when device operates in
+	 * power performance mode whereas 1000us is required when the device operates
+	 * in low power mode.
+	 */
+	if (bma4xx->cfg.accel_pwr_mode) {
+		k_sleep(K_NSEC(1300));
+	} else {
+		k_sleep(K_USEC(1000));
+	}
+	return 0;
 }
 
 static const struct bma4xx_hw_operations i2c_ops = {

--- a/drivers/sensor/bosch/bma4xx/bma4xx_interrupt.c
+++ b/drivers/sensor/bosch/bma4xx/bma4xx_interrupt.c
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2024 Cienet
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT bosch_bma4xx
+
+#include <zephyr/device.h>
+#include <zephyr/drivers/sensor.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/sys/util.h>
+
+#include "bma4xx.h"
+#include "bma4xx_interrupt.h"
+#include "bma4xx_defs.h"
+#include "bma4xx_rtio.h"
+
+LOG_MODULE_DECLARE(bma4xx, CONFIG_SENSOR_LOG_LEVEL);
+
+#ifdef CONFIG_BMA4XX_STREAM
+
+static void bma4xx_gpio_callback(const struct device *dev, struct gpio_callback *cb, uint32_t pins)
+{
+	struct bma4xx_data *data = CONTAINER_OF(cb, struct bma4xx_data, gpio_cb);
+
+	ARG_UNUSED(dev);
+	ARG_UNUSED(pins);
+
+	bma4xx_fifo_event(data->dev);
+}
+
+int bma4xx_init_interrupt(const struct device *dev)
+{
+	struct bma4xx_data *data = dev->data;
+	const struct bma4xx_config *cfg = dev->config;
+	int ret = 0;
+
+	if (!cfg->gpio_interrupt.port) {
+		LOG_ERR("Stream enabled but no interrupt gpio supplied");
+		return -ENODEV;
+	}
+
+	if (!gpio_is_ready_dt(&cfg->gpio_interrupt)) {
+		LOG_ERR("GPIO interrupt not ready");
+		return -ENODEV;
+	}
+
+	ret = gpio_pin_configure_dt(&cfg->gpio_interrupt, GPIO_INPUT);
+	if (ret < 0) {
+		LOG_ERR("Failed to configure gpio pin");
+		return ret;
+	}
+
+	gpio_init_callback(&data->gpio_cb, bma4xx_gpio_callback, BIT(cfg->gpio_interrupt.pin));
+
+	ret = gpio_add_callback(cfg->gpio_interrupt.port, &data->gpio_cb);
+	if (ret < 0) {
+		LOG_ERR("Failed to add gpio callback");
+		return ret;
+	}
+
+	data->dev = dev;
+
+	return 0;
+}
+
+int bma4xx_enable_interrupt1(const struct device *dev, struct bma4xx_runtime_config *new_cfg)
+{
+	struct bma4xx_data *data = dev->data;
+	uint8_t value = 0;
+
+	if (new_cfg->interrupt1_fifo_wm) {
+		value |= FIELD_PREP(BMA4XX_BIT_INT_MAP_DATA_INT1_FWM, 1);
+	}
+	if (new_cfg->interrupt1_fifo_full) {
+		value |= FIELD_PREP(BMA4XX_BIT_INT_MAP_DATA_INT1_FFUL, 1);
+	}
+
+	return data->hw_ops->write_reg(dev, BMA4XX_REG_INT_MAP_DATA, value);
+}
+
+#endif /* CONFIG_BMA4XX_STREAM */

--- a/drivers/sensor/bosch/bma4xx/bma4xx_interrupt.h
+++ b/drivers/sensor/bosch/bma4xx/bma4xx_interrupt.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2024 Cienet
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_DRIVERS_SENSOR_BMA4XX_INTERRUPT_H_
+#define ZEPHYR_DRIVERS_SENSOR_BMA4XX_INTERRUPT_H_
+
+#include <zephyr/device.h>
+#include <zephyr/drivers/sensor.h>
+
+/**
+ * @brief Initialize the bma4xx interrupt system
+ *
+ * @param dev bma4xx device pointer
+ * @return int 0 on success, negative error code otherwise
+ */
+int bma4xx_init_interrupt(const struct device *dev);
+
+/**
+ * @brief Enable the trigger gpio interrupt1
+ *
+ * @param dev bma4xx device pointer
+ * @param new_cfg New configuration to use for the device
+ * @return int 0 on success, negative error code otherwise
+ */
+int bma4xx_enable_interrupt1(const struct device *dev, struct bma4xx_runtime_config *new_cfg);
+
+#endif /* ZEPHYR_DRIVERS_SENSOR_BMA4XX_INTERRUPT_H_ */

--- a/drivers/sensor/bosch/bma4xx/bma4xx_rtio.c
+++ b/drivers/sensor/bosch/bma4xx/bma4xx_rtio.c
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2024 Cienet
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT bosch_bma4xx
+
+#include <zephyr/drivers/sensor.h>
+#include <zephyr/rtio/work.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/drivers/sensor_clock.h>
+
+#include "bma4xx.h"
+#include "bma4xx_decoder.h"
+#include "bma4xx_defs.h"
+#include "bma4xx_rtio.h"
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_DECLARE(bma4xx, CONFIG_SENSOR_LOG_LEVEL);
+
+static void bma4xx_complete_result(struct rtio *ctx, const struct rtio_sqe *sqe, void *arg)
+{
+	struct rtio_iodev_sqe *iodev_sqe = (struct rtio_iodev_sqe *)sqe->userdata;
+	struct rtio_cqe *cqe;
+	int err = 0;
+
+	do {
+		cqe = rtio_cqe_consume(ctx);
+		if (cqe != NULL) {
+			err = cqe->result;
+			rtio_cqe_release(ctx, cqe);
+		}
+	} while (cqe != NULL);
+	if (err) {
+		rtio_iodev_sqe_err(iodev_sqe, err);
+	} else {
+		rtio_iodev_sqe_ok(iodev_sqe, 0);
+	}
+	LOG_DBG("bma4xx_submit_fetch completed");
+}
+
+/*
+ * RTIO submit and encoding
+ */
+
+static void bma4xx_submit_one_shot(const struct device *dev, struct rtio_iodev_sqe *iodev_sqe)
+{
+	const struct bma4xx_data *bma4xx = dev->data;
+	const struct bma4xx_config *drv_cfg = dev->config;
+	struct bma4xx_encoded_data *edata;
+	uint8_t *buf;
+	uint32_t buf_len;
+	uint32_t min_buf_len = sizeof(struct bma4xx_encoded_data);
+	uint64_t cycles;
+	int rc;
+
+	/* Get the buffer for the frame, it may be allocated dynamically by the rtio context */
+	rc = rtio_sqe_rx_buf(iodev_sqe, min_buf_len, min_buf_len, &buf, &buf_len);
+	if (rc != 0) {
+		LOG_ERR("Failed to get a read buffer of size %u bytes", min_buf_len);
+		rtio_iodev_sqe_err(iodev_sqe, rc);
+		return;
+	}
+
+	/* Prepare response */
+	edata = (struct bma4xx_encoded_data *)buf;
+
+	edata->header.is_fifo = false;
+	edata->header.accel_fs = bma4xx->cfg.accel_fs_range;
+
+	rc = sensor_clock_get_cycles(&cycles);
+	if (rc != 0) {
+		LOG_ERR("Failed to get sensor clock cycles");
+		rtio_iodev_sqe_err(iodev_sqe, rc);
+		return;
+	}
+
+	edata->header.timestamp = sensor_clock_cycles_to_ns(cycles);
+
+	struct rtio_sqe *write_accel_sqe = rtio_sqe_acquire(bma4xx->r);
+	struct rtio_sqe *read_accel_sqe = rtio_sqe_acquire(bma4xx->r);
+
+	if (!write_accel_sqe || !read_accel_sqe) {
+		LOG_ERR("Failed to acquire RTIO SQEs");
+		rtio_iodev_sqe_err(iodev_sqe, -ENOMEM);
+		return;
+	}
+
+	const uint8_t reg_accel = BMA4XX_REG_DATA_8;
+
+	rtio_sqe_prep_tiny_write(write_accel_sqe, bma4xx->iodev, RTIO_PRIO_HIGH, &reg_accel, 1,
+				 NULL);
+	write_accel_sqe->flags |= RTIO_SQE_TRANSACTION;
+
+	rtio_sqe_prep_read(read_accel_sqe, bma4xx->iodev, RTIO_PRIO_HIGH, edata->accel_xyz_raw_data,
+			   BMA4XX_REG_DATA_13 - BMA4XX_REG_DATA_8 + 1, NULL);
+	read_accel_sqe->flags |= RTIO_SQE_CHAINED;
+
+	if (drv_cfg->bus_type == BMA4XX_BUS_I2C) {
+		read_accel_sqe->iodev_flags |= RTIO_IODEV_I2C_STOP | RTIO_IODEV_I2C_RESTART;
+	}
+
+#ifdef CONFIG_BMA4XX_TEMPERATURE
+	struct rtio_sqe *write_temp_sqe = rtio_sqe_acquire(bma4xx->r);
+	struct rtio_sqe *read_temp_sqe = rtio_sqe_acquire(bma4xx->r);
+
+	if (!write_temp_sqe || !read_temp_sqe) {
+		LOG_ERR("Failed to acquire RTIO SQEs");
+		rtio_iodev_sqe_err(iodev_sqe, -ENOMEM);
+		return;
+	}
+
+	const uint8_t reg_temp = BMA4XX_REG_TEMPERATURE;
+
+	rtio_sqe_prep_tiny_write(write_temp_sqe, bma4xx->iodev, RTIO_PRIO_HIGH, &reg_temp, 1, NULL);
+	write_temp_sqe->flags |= RTIO_SQE_TRANSACTION;
+
+	rtio_sqe_prep_read(read_temp_sqe, bma4xx->iodev, RTIO_PRIO_HIGH, &edata->temp, 1, NULL);
+	read_temp_sqe->flags |= RTIO_SQE_CHAINED;
+
+	if (drv_cfg->bus_type == BMA4XX_BUS_I2C) {
+		read_temp_sqe->iodev_flags |= RTIO_IODEV_I2C_STOP | RTIO_IODEV_I2C_RESTART;
+	}
+#endif /* CONFIG_BMA4XX_TEMPERATURE */
+
+	struct rtio_sqe *complete_sqe = rtio_sqe_acquire(bma4xx->r);
+
+	if (!complete_sqe) {
+		LOG_ERR("Failed to acquire RTIO SQEs");
+		rtio_iodev_sqe_err(iodev_sqe, -ENOMEM);
+		return;
+	}
+
+	rtio_sqe_prep_callback_no_cqe(complete_sqe, bma4xx_complete_result, (void *)dev, iodev_sqe);
+	rtio_submit(bma4xx->r, 0);
+}
+
+void bma4xx_submit(const struct device *dev, struct rtio_iodev_sqe *iodev_sqe)
+{
+	const struct sensor_read_config *cfg = iodev_sqe->sqe.iodev->data;
+
+	if (!cfg->is_streaming) {
+		bma4xx_submit_one_shot(dev, iodev_sqe);
+	} else {
+		rtio_iodev_sqe_err(iodev_sqe, -ENOTSUP);
+	}
+}

--- a/drivers/sensor/bosch/bma4xx/bma4xx_rtio.c
+++ b/drivers/sensor/bosch/bma4xx/bma4xx_rtio.c
@@ -66,7 +66,10 @@ static void bma4xx_submit_one_shot(const struct device *dev, struct rtio_iodev_s
 	/* Prepare response */
 	edata = (struct bma4xx_encoded_data *)buf;
 
-	edata->header.is_fifo = false;
+	if (IS_ENABLED(CONFIG_BMA4XX_STREAM)) {
+		edata->header.is_fifo = false;
+	}
+
 	edata->header.accel_fs = bma4xx->cfg.accel_fs_range;
 
 	rc = sensor_clock_get_cycles(&cycles);
@@ -142,6 +145,8 @@ void bma4xx_submit(const struct device *dev, struct rtio_iodev_sqe *iodev_sqe)
 
 	if (!cfg->is_streaming) {
 		bma4xx_submit_one_shot(dev, iodev_sqe);
+	} else if (IS_ENABLED(CONFIG_BMA4XX_STREAM)) {
+		bma4xx_submit_stream(dev, iodev_sqe);
 	} else {
 		rtio_iodev_sqe_err(iodev_sqe, -ENOTSUP);
 	}

--- a/drivers/sensor/bosch/bma4xx/bma4xx_rtio.h
+++ b/drivers/sensor/bosch/bma4xx/bma4xx_rtio.h
@@ -13,4 +13,8 @@
 
 void bma4xx_submit(const struct device *dev, struct rtio_iodev_sqe *iodev_sqe);
 
+void bma4xx_submit_stream(const struct device *sensor, struct rtio_iodev_sqe *iodev_sqe);
+
+void bma4xx_fifo_event(const struct device *dev);
+
 #endif /* ZEPHYR_DRIVERS_SENSOR_BMA4XX_RTIO_H_ */

--- a/drivers/sensor/bosch/bma4xx/bma4xx_rtio.h
+++ b/drivers/sensor/bosch/bma4xx/bma4xx_rtio.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2023 Google LLC
+ * Copyright (c) 2024 Cienet
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_DRIVERS_SENSOR_BMA4XX_RTIO_H_
+#define ZEPHYR_DRIVERS_SENSOR_BMA4XX_RTIO_H_
+
+#include <zephyr/device.h>
+#include <zephyr/rtio/rtio.h>
+
+void bma4xx_submit(const struct device *dev, struct rtio_iodev_sqe *iodev_sqe);
+
+#endif /* ZEPHYR_DRIVERS_SENSOR_BMA4XX_RTIO_H_ */

--- a/drivers/sensor/bosch/bma4xx/bma4xx_rtio_stream.c
+++ b/drivers/sensor/bosch/bma4xx/bma4xx_rtio_stream.c
@@ -1,0 +1,355 @@
+/*
+ * Copyright (c) 2024 Cienet
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT bosch_bma4xx
+
+#include <zephyr/logging/log.h>
+#include <zephyr/drivers/sensor_clock.h>
+
+#include "bma4xx.h"
+#include "bma4xx_defs.h"
+#include "bma4xx_decoder.h"
+#include "bma4xx_rtio.h"
+
+#ifdef CONFIG_BMA4XX_STREAM
+
+LOG_MODULE_DECLARE(bma4xx, CONFIG_SENSOR_LOG_LEVEL);
+
+void bma4xx_submit_stream(const struct device *sensor, struct rtio_iodev_sqe *iodev_sqe)
+{
+	const struct sensor_read_config *cfg = iodev_sqe->sqe.iodev->data;
+	struct bma4xx_data *data = sensor->data;
+	struct bma4xx_runtime_config new_config = data->cfg;
+	const struct bma4xx_config *cfg_bma4xx = sensor->config;
+	int ret;
+
+	ret = gpio_pin_interrupt_configure_dt(&cfg_bma4xx->gpio_interrupt, GPIO_INT_DISABLE);
+	if (ret) {
+		LOG_DBG("Failed to disable interrupt");
+		rtio_iodev_sqe_err(iodev_sqe, ret);
+		return;
+	}
+
+	new_config.interrupt1_fifo_wm = false;
+	new_config.interrupt1_fifo_full = false;
+	/* Only one trigger will be sent per time */
+	for (int i = 0; i < cfg->count; ++i) {
+		switch (cfg->triggers[i].trigger) {
+		case SENSOR_TRIG_FIFO_WATERMARK:
+			new_config.interrupt1_fifo_wm = true;
+			break;
+		case SENSOR_TRIG_FIFO_FULL:
+			new_config.interrupt1_fifo_full = true;
+			break;
+		default:
+			LOG_DBG("Trigger (%d) not supported", cfg->triggers[i].trigger);
+			rtio_iodev_sqe_err(iodev_sqe, -ENOTSUP);
+			return;
+		}
+	}
+
+	if (new_config.interrupt1_fifo_wm != data->cfg.interrupt1_fifo_wm ||
+	    new_config.interrupt1_fifo_full != data->cfg.interrupt1_fifo_full) {
+
+		ret = bma4xx_safely_configure(sensor, &new_config);
+
+		if (ret != 0) {
+			LOG_ERR("Failed to configure sensor");
+			rtio_iodev_sqe_err(iodev_sqe, ret);
+			return;
+		}
+	}
+
+	ret = gpio_pin_interrupt_configure_dt(&cfg_bma4xx->gpio_interrupt, GPIO_INT_EDGE_TO_ACTIVE);
+	if (ret) {
+		LOG_DBG("Failed to set interrupt");
+		rtio_iodev_sqe_err(iodev_sqe, ret);
+		return;
+	}
+
+	data->streaming_sqe = iodev_sqe;
+}
+
+static struct sensor_stream_trigger *
+bma4xx_get_read_config_trigger(const struct sensor_read_config *cfg, enum sensor_trigger_type trig)
+{
+	for (int i = 0; i < cfg->count; ++i) {
+		if (cfg->triggers[i].trigger == trig) {
+			return &cfg->triggers[i];
+		}
+	}
+	LOG_DBG("Unsupported trigger (%d)", trig);
+	return NULL;
+}
+
+static void bma4xx_complete_cb(struct rtio *r, const struct rtio_sqe *sqe, void *arg)
+{
+	const struct device *dev = arg;
+	struct bma4xx_data *drv_data = dev->data;
+	const struct bma4xx_config *drv_cfg = dev->config;
+	struct rtio_iodev_sqe *iodev_sqe = sqe->userdata;
+
+	rtio_iodev_sqe_ok(iodev_sqe, drv_data->fifo_count);
+
+	gpio_pin_interrupt_configure_dt(&drv_cfg->gpio_interrupt, GPIO_INT_EDGE_TO_ACTIVE);
+}
+
+static void bma4xx_fifo_count_cb(struct rtio *r, const struct rtio_sqe *sqe, void *arg)
+{
+	const struct device *dev = arg;
+	struct bma4xx_data *drv_data = dev->data;
+	const struct bma4xx_config *drv_cfg = dev->config;
+	struct rtio_iodev *iodev = drv_data->iodev;
+	uint8_t *fifo_count_buf = (uint8_t *)&drv_data->fifo_count;
+	uint16_t fifo_count = (((fifo_count_buf[1] & 0x3F) << 8) | fifo_count_buf[0]);
+
+	drv_data->fifo_count = fifo_count;
+
+	/* Pull a operation from our device iodev queue, validated to only be reads */
+	struct rtio_iodev_sqe *iodev_sqe = drv_data->streaming_sqe;
+
+	drv_data->streaming_sqe = NULL;
+
+	/* Not inherently an underrun/overrun as we may have a buffer to fill next time */
+	if (iodev_sqe == NULL) {
+		LOG_DBG("No pending SQE");
+		gpio_pin_interrupt_configure_dt(&drv_cfg->gpio_interrupt, GPIO_INT_EDGE_TO_ACTIVE);
+		return;
+	}
+
+	const size_t packet_size = (drv_data->cfg.accel_pwr_mode && drv_data->cfg.aux_pwr_mode)
+					   ? BMA4XX_FIFO_MA_LENGTH + BMA4XX_FIFO_HEADER_LENGTH
+					   : BMA4XX_FIFO_A_LENGTH + BMA4XX_FIFO_HEADER_LENGTH;
+	const size_t min_read_size = sizeof(struct bma4xx_fifo_data) + packet_size;
+	const size_t ideal_read_size = sizeof(struct bma4xx_fifo_data) + fifo_count;
+	uint8_t *buf;
+	uint32_t buf_len;
+
+	if (rtio_sqe_rx_buf(iodev_sqe, min_read_size, ideal_read_size, &buf, &buf_len) != 0) {
+		LOG_ERR("Failed to get buffer");
+		rtio_iodev_sqe_err(iodev_sqe, -ENOMEM);
+		return;
+	}
+	LOG_DBG("Requesting buffer [%u, %u] got %u", (unsigned int)min_read_size,
+		(unsigned int)ideal_read_size, buf_len);
+
+	/* Read FIFO and call back to rtio with rtio_sqe completion */
+	struct bma4xx_fifo_data hdr;
+
+	hdr.header.is_fifo = true;
+	hdr.header.accel_fs = drv_data->cfg.accel_fs_range;
+	hdr.header.timestamp = drv_data->timestamp;
+	hdr.int_status = drv_data->int_status;
+	hdr.accel_odr = drv_data->cfg.accel_odr;
+
+	uint32_t buf_avail = buf_len;
+
+	memcpy(buf, &hdr, sizeof(hdr));
+	buf_avail -= sizeof(hdr);
+
+	uint32_t read_len = MIN(fifo_count, buf_avail);
+	uint32_t pkts = read_len / packet_size;
+
+	read_len = pkts * packet_size;
+	((struct bma4xx_fifo_data *)buf)->fifo_count = read_len;
+
+	__ASSERT_NO_MSG(read_len % packet_size == 0);
+
+	uint8_t *read_buf = buf + sizeof(hdr);
+
+	/* Flush out completions  */
+	struct rtio_cqe *cqe;
+
+	do {
+		cqe = rtio_cqe_consume(r);
+		if (cqe != NULL) {
+			rtio_cqe_release(r, cqe);
+		}
+	} while (cqe != NULL);
+
+	/* Setup new rtio chain to read the fifo data and report then check the
+	 * result
+	 */
+	struct rtio_sqe *write_fifo_addr = rtio_sqe_acquire(r);
+	struct rtio_sqe *read_fifo_data = rtio_sqe_acquire(r);
+	struct rtio_sqe *complete_op = rtio_sqe_acquire(r);
+	const uint8_t reg_addr = BMA4XX_REG_FIFO_DATA;
+
+	rtio_sqe_prep_tiny_write(write_fifo_addr, iodev, RTIO_PRIO_NORM, &reg_addr, 1, NULL);
+	write_fifo_addr->flags = RTIO_SQE_TRANSACTION;
+	rtio_sqe_prep_read(read_fifo_data, iodev, RTIO_PRIO_NORM, read_buf, read_len, iodev_sqe);
+	read_fifo_data->flags = RTIO_SQE_CHAINED;
+
+	if (drv_cfg->bus_type == BMA4XX_BUS_I2C) {
+		read_fifo_data->iodev_flags |= RTIO_IODEV_I2C_STOP | RTIO_IODEV_I2C_RESTART;
+	}
+
+	rtio_sqe_prep_callback(complete_op, bma4xx_complete_cb, (void *)dev, iodev_sqe);
+
+	rtio_submit(r, 0);
+}
+
+static void bma4xx_int_status_cb(struct rtio *r, const struct rtio_sqe *sqr, void *arg)
+{
+	const struct device *dev = arg;
+	struct bma4xx_data *drv_data = dev->data;
+	const struct bma4xx_config *drv_cfg = dev->config;
+	struct rtio_iodev *iodev = drv_data->iodev;
+	struct rtio_iodev_sqe *streaming_sqe = drv_data->streaming_sqe;
+	struct sensor_read_config *read_config;
+
+	if (streaming_sqe == NULL) {
+		return;
+	}
+
+	read_config = (struct sensor_read_config *)streaming_sqe->sqe.iodev->data;
+	__ASSERT_NO_MSG(read_config != NULL);
+
+	if (!read_config->is_streaming) {
+		return;
+	}
+
+	gpio_pin_interrupt_configure_dt(&drv_cfg->gpio_interrupt, GPIO_INT_DISABLE);
+
+	struct sensor_stream_trigger *fifo_wm_cfg =
+		bma4xx_get_read_config_trigger(read_config, SENSOR_TRIG_FIFO_WATERMARK);
+	bool has_fifo_wm_trig = fifo_wm_cfg != NULL &&
+				FIELD_GET(BMA4XX_BIT_INT_STAT_1_FWM_INT, drv_data->int_status) != 0;
+
+	struct sensor_stream_trigger *fifo_full_cfg =
+		bma4xx_get_read_config_trigger(read_config, SENSOR_TRIG_FIFO_FULL);
+	bool has_fifo_full_trig =
+		fifo_full_cfg != NULL &&
+		FIELD_GET(BMA4XX_BIT_INT_STAT_1_FFULL_INT, drv_data->int_status) != 0;
+
+	if (!has_fifo_wm_trig && !has_fifo_full_trig) {
+		gpio_pin_interrupt_configure_dt(&drv_cfg->gpio_interrupt, GPIO_INT_EDGE_TO_ACTIVE);
+		return;
+	}
+
+	/* Flush completions */
+	struct rtio_cqe *cqe;
+
+	do {
+		cqe = rtio_cqe_consume(r);
+		if (cqe != NULL) {
+			rtio_cqe_release(r, cqe);
+		}
+	} while (cqe != NULL);
+
+	enum sensor_stream_data_opt data_opt;
+
+	if (has_fifo_wm_trig && !has_fifo_full_trig) {
+		/* Only care about fifo threshold */
+		data_opt = fifo_wm_cfg->opt;
+	} else if (!has_fifo_wm_trig && has_fifo_full_trig) {
+		/* Only care about fifo full */
+		data_opt = fifo_full_cfg->opt;
+	} else {
+		/* Both fifo threshold and full */
+		data_opt = MIN(fifo_wm_cfg->opt, fifo_full_cfg->opt);
+	}
+
+	if (data_opt == SENSOR_STREAM_DATA_NOP || data_opt == SENSOR_STREAM_DATA_DROP) {
+		uint8_t *buf;
+		uint32_t buf_len;
+
+		/* Clear streaming_sqe since we're done with the call */
+		drv_data->streaming_sqe = NULL;
+		if (rtio_sqe_rx_buf(streaming_sqe, sizeof(struct bma4xx_fifo_data),
+				    sizeof(struct bma4xx_fifo_data), &buf, &buf_len) != 0) {
+			rtio_iodev_sqe_err(streaming_sqe, -ENOMEM);
+			return;
+		}
+
+		struct bma4xx_fifo_data *data = (struct bma4xx_fifo_data *)buf;
+
+		memset(buf, 0, buf_len);
+		data->header.timestamp = drv_data->timestamp;
+		data->int_status = drv_data->int_status;
+		data->fifo_count = 0;
+		data->header.is_fifo = true;
+		rtio_iodev_sqe_ok(streaming_sqe, 0);
+		gpio_pin_interrupt_configure_dt(&drv_cfg->gpio_interrupt, GPIO_INT_EDGE_TO_ACTIVE);
+		if (data_opt == SENSOR_STREAM_DATA_DROP) {
+			/* Flush the FIFO */
+			struct rtio_sqe *write_signal_path_reset = rtio_sqe_acquire(r);
+			uint8_t write_buffer[] = {
+				FIELD_GET(BMA4XX_REG_ADDRESS_MASK, BMA4XX_REG_CMD),
+				BMA4XX_CMD_FIFO_FLUSH,
+			};
+
+			rtio_sqe_prep_tiny_write(write_signal_path_reset, iodev, RTIO_PRIO_NORM,
+						 write_buffer, ARRAY_SIZE(write_buffer), NULL);
+			rtio_submit(r, 0);
+			ARG_UNUSED(rtio_cqe_consume(r));
+		}
+		return;
+	}
+
+	/* We need the data, read the fifo length */
+	struct rtio_sqe *write_fifo_count_reg = rtio_sqe_acquire(r);
+	struct rtio_sqe *read_fifo_count = rtio_sqe_acquire(r);
+	struct rtio_sqe *check_fifo_count = rtio_sqe_acquire(r);
+	uint8_t reg = BMA4XX_REG_FIFO_LENGTH_0;
+	uint8_t *read_buf = (uint8_t *)&drv_data->fifo_count;
+
+	rtio_sqe_prep_tiny_write(write_fifo_count_reg, iodev, RTIO_PRIO_NORM, &reg, 1, NULL);
+	write_fifo_count_reg->flags = RTIO_SQE_TRANSACTION;
+	rtio_sqe_prep_read(read_fifo_count, iodev, RTIO_PRIO_NORM, read_buf,
+			   BMA4XX_FIFO_DATA_LENGTH, NULL);
+	read_fifo_count->flags = RTIO_SQE_CHAINED;
+
+	if (drv_cfg->bus_type == BMA4XX_BUS_I2C) {
+		read_fifo_count->iodev_flags |= RTIO_IODEV_I2C_STOP | RTIO_IODEV_I2C_RESTART;
+	}
+
+	rtio_sqe_prep_callback(check_fifo_count, bma4xx_fifo_count_cb, arg, NULL);
+
+	rtio_submit(r, 0);
+}
+
+void bma4xx_fifo_event(const struct device *dev)
+{
+	struct bma4xx_data *drv_data = dev->data;
+	const struct bma4xx_config *drv_cfg = dev->config;
+	struct rtio_iodev *iodev = drv_data->iodev;
+	struct rtio *r = drv_data->r;
+	uint64_t cycles;
+	int rc;
+
+	if (drv_data->streaming_sqe == NULL) {
+		return;
+	}
+
+	rc = sensor_clock_get_cycles(&cycles);
+	if (rc != 0) {
+		LOG_ERR("Failed to get sensor clock cycles");
+		rtio_iodev_sqe_err(drv_data->streaming_sqe, rc);
+		return;
+	}
+
+	drv_data->timestamp = sensor_clock_cycles_to_ns(cycles);
+
+	struct rtio_sqe *write_int_reg = rtio_sqe_acquire(r);
+	struct rtio_sqe *read_int_reg = rtio_sqe_acquire(r);
+	struct rtio_sqe *check_int_status = rtio_sqe_acquire(r);
+	uint8_t reg = BMA4XX_REG_INT_STAT_1;
+
+	rtio_sqe_prep_tiny_write(write_int_reg, iodev, RTIO_PRIO_NORM, &reg, 1, NULL);
+	write_int_reg->flags = RTIO_SQE_TRANSACTION;
+	rtio_sqe_prep_read(read_int_reg, iodev, RTIO_PRIO_NORM, &drv_data->int_status, 1, NULL);
+	read_int_reg->flags = RTIO_SQE_CHAINED;
+
+	if (drv_cfg->bus_type == BMA4XX_BUS_I2C) {
+		read_int_reg->iodev_flags |= RTIO_IODEV_I2C_STOP | RTIO_IODEV_I2C_RESTART;
+	}
+
+	rtio_sqe_prep_callback(check_int_status, bma4xx_int_status_cb, (void *)dev, NULL);
+	rtio_submit(r, 0);
+}
+
+#endif /* CONFIG_BMA4XX_STREAM */


### PR DESCRIPTION
Add a streaming implementation for the BMA4XX using both FIFO watermark and FIFO full interrupts.
A batch duration of 3,000 have been used for verification.
```
uart:~$ sensor attr_set bma4xx@19 all batch_dur 3000
bma4xx@19 channel=all, attr=batch_dur set to value=3000
[00:00:03.111,602] <inf> bma4xx: FIFO ENABLED
uart:~$ sensor stream bma4xx@19 on fifo_wm incl
Enabling stream...
channel type=0(accel_x) index=0 shift=6 num_samples=11 value=12784741210ns (1.398213)
channel type=1(accel_y) index=0 shift=6 num_samples=11 value=12784741210ns (1.398213)
channel type=2(accel_z) index=0 shift=6 num_samples=11 value=12784741210ns (1.398213)
channel type=3(accel_xyz) index=0 shift=6 num_samples=11 value=12784741210ns, (1.398213, 0.315163, 9.528051)
channel type=0(accel_x) index=0 shift=6 num_samples=10 value=12879747314ns (1.403959)
channel type=1(accel_y) index=0 shift=6 num_samples=10 value=12879747314ns (1.403959)
channel type=2(accel_z) index=0 shift=6 num_samples=10 value=12879747314ns (1.403959)
channel type=3(accel_xyz) index=0 shift=6 num_samples=10 value=12879747314ns, (1.403959, 0.256658, 9.482953)
channel type=0(accel_x) index=0 shift=6 num_samples=10 value=12979814453ns (1.415452)
channel type=1(accel_y) index=0 shift=6 num_samples=10 value=12979814453ns (1.415452)
channel type=2(accel_z) index=0 shift=6 num_samples=10 value=12979814453ns (1.415452)
channel type=3(accel_xyz) index=0 shift=6 num_samples=10 value=12979814453ns, (1.415452, 0.342849, 9.525091)
…
…
…
```