### PR TITLE
samples: echo_client: OpenThread RCP set CONFIG_SETTINGS_NVS=y

### DIFF
--- a/samples/net/sockets/echo_client/overlay-ot-rcp-host-uart.conf
+++ b/samples/net/sockets/echo_client/overlay-ot-rcp-host-uart.conf
@@ -26,6 +26,7 @@ CONFIG_NET_L2_OPENTHREAD=y
 
 # Use NVS as settings backend
 CONFIG_NVS=y
+CONFIG_SETTINGS_NVS=y
 
 # Enable Openthread rcp host
 CONFIG_HDLC_RCP_IF=y


### PR DESCRIPTION
By default OpenThread uses storage API to store configuration options.

On for example mimxrt1020_evk the enabled by default is CONFIG_SETTINGS_NONE when CONFIG_SETTINGS is enabled. Fix this problem by using the CONFIG_SETTINGS_NVS=y.