### PR TITLE
scripts: ci: check_compliance: do not use git mailmap

### DIFF
--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -1322,7 +1322,7 @@ class Identity(ComplianceTest):
 
     def run(self):
         for shaidx in get_shas(COMMIT_RANGE):
-            commit = git("log", "--decorate=short", "-n 1", shaidx)
+            commit = git("log", "--decorate=short", "--no-use-mailmap", "-n 1", shaidx)
             signed = []
             author = ""
             sha = ""


### PR DESCRIPTION
When looking at git author in a commit range using git log, explicitly indicate we don't want to use the mailmap file (default git client behavior is to use it), so that the "actual" author info from the commit is used to perform the compliance check, and not whatever identity the author may have mapped to in the mailmap file (ex. their "main" email address might be different from the one they used to commit).