### PR TITLE
doc: licensing: clarify the impact of the various files

### DIFF
--- a/doc/LICENSING.rst
+++ b/doc/LICENSING.rst
@@ -10,42 +10,109 @@ are not covered by the `Apache 2.0 License`_. In some places
 there is no LICENSE file or way to put a LICENSE file there, so we describe the
 licensing in this document.
 
+Continuous Integration Scripts
+------------------------------
+
+* *Origin:* Linux Kernel
+* *Licensing:* `GPLv2 License`_
+* *Impact:* These files are used in Continuous Integration (CI) and never linked into the firmware.
+* *Files:*
+
+  * :zephyr_file:`scripts/checkpatch.pl`
+  * :zephyr_file:`scripts/checkstack.pl`
+  * :zephyr_file:`scripts/spelling.txt`
+
+Coccinelle Scripts
+------------------
+
+  * *Origin:* Coccinelle
+  * *Licensing:* `GPLv2 License`_
+  * *Impact:* These files are used by `Coccinelle`_, a tool for transforming C-code, and never linked
+    into the firmware.
+  * *Files:*
+
+    * :zephyr_file:`scripts/coccicheck`
+    * :zephyr_file:`scripts/coccinelle/array_size.cocci`
+    * :zephyr_file:`scripts/coccinelle/deref_null.cocci`
+    * :zephyr_file:`scripts/coccinelle/deref_null.cocci`
+    * :zephyr_file:`scripts/coccinelle/deref_null.cocci`
+    * :zephyr_file:`scripts/coccinelle/mini_lock.cocci`
+    * :zephyr_file:`scripts/coccinelle/mini_lock.cocci`
+    * :zephyr_file:`scripts/coccinelle/mini_lock.cocci`
+    * :zephyr_file:`scripts/coccinelle/noderef.cocci`
+    * :zephyr_file:`scripts/coccinelle/noderef.cocci`
+    * :zephyr_file:`scripts/coccinelle/returnvar.cocci`
+    * :zephyr_file:`scripts/coccinelle/semicolon.cocci`
+
+GCOV Coverage Header File
+-------------------------
+
+* *Origin:* GCC, the GNU Compiler Collection
+* *Licensing:* `GPLv2 License`_ with Runtime Library Exception
+* *Impact:* This file is only linked into the firmware if :kconfig:option:`CONFIG_COVERAGE_GCOV` is
+  enabled.
+* *Files:*
+
+  * :zephyr_file:`subsys/testsuite/coverage/coverage.h`
+
+ENE KB1200_EVB Board OpenOCD Configuration
+------------------------------------------
+
+* *Licensing:* `GPLv2 License`_
+* *Impact:* This file is used by `OpenOCD`_ when programming and debugging the :ref:`ene_kb1200_evb`
+  board. It is never linked into the firmware.
+* *Files:*
+
+  * :zephyr_file:`boards/ene/kb1200_evb/support/openocd.cfg`
+
+Thread-Metric RTOS Test Suite Source Files
+------------------------------------------
+
+* *Origin:* ThreadX
+* *Licensing:* `MIT License`_
+* *Impact:* These files are only linked into the Thread-Metric RTOS Test Suite test firmware.
+* *Files:*
+
+  * :zephyr_file:`tests/benchmarks/thread_metric/thread_metric_readme.txt`
+  * :zephyr_file:`tests/benchmarks/thread_metric/src/tm_api.h`
+  * :zephyr_file:`tests/benchmarks/thread_metric/src/tm_basic_processing_test.c`
+  * :zephyr_file:`tests/benchmarks/thread_metric/src/tm_cooperative_scheduling_test.c`
+  * :zephyr_file:`tests/benchmarks/thread_metric/src/tm_interrupt_preemption_processing_test.c`
+  * :zephyr_file:`tests/benchmarks/thread_metric/src/tm_interrupt_processing_test.c`
+  * :zephyr_file:`tests/benchmarks/thread_metric/src/tm_memory_allocation_test.c`
+  * :zephyr_file:`tests/benchmarks/thread_metric/src/tm_message_processing_test.c`
+  * :zephyr_file:`tests/benchmarks/thread_metric/src/tm_porting_layer.h`
+  * :zephyr_file:`tests/benchmarks/thread_metric/src/tm_porting_layer_zephyr.c`
+  * :zephyr_file:`tests/benchmarks/thread_metric/src/tm_preemptive_scheduling_test.c`
+  * :zephyr_file:`tests/benchmarks/thread_metric/src/tm_synchronization_processing_test.c`
+
+OpenThread Spinel HDLC RCP Host Interface Files
+-----------------------------------------------
+
+* *Origin:* OpenThread
+* *Licensing:* `BSD-3-clause`_
+* *Impact:* These files are only linked into the firmware if :kconfig:option:`CONFIG_HDLC_RCP_IF` is
+  enabled.
+* *Files*:
+
+  * :zephyr_file:`modules/openthread/platform/hdlc_interface.hpp`
+  * :zephyr_file:`modules/openthread/platform/radio_spinel.cpp`
+  * :zephyr_file:`modules/openthread/platform/hdlc_interface.cpp`
+
 .. _Apache 2.0 License:
    https://github.com/zephyrproject-rtos/zephyr/blob/main/LICENSE
 
 .. _GPLv2 License:
    https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/plain/COPYING
 
-*scripts/{checkpatch.pl,checkstack.pl,spelling.txt}*
-  *Origin:* Linux Kernel
-
-  *Licensing:* `GPLv2 License`_
-
-*scripts/{coccicheck,coccinelle/array_size.cocci,coccinelle/deref_null.cocci,coccinelle/deref_null.cocci,coccinelle/deref_null.cocci,coccinelle/mini_lock.cocci,coccinelle/mini_lock.cocci,coccinelle/mini_lock.cocci,coccinelle/noderef.cocci,coccinelle/noderef.cocci,coccinelle/returnvar.cocci,coccinelle/semicolon.cocci}*
-  *Origin:* Coccinelle
-
-  *Licensing:* `GPLv2 License`_
-
-*subsys/testsuite/coverage/coverage.h*
-  *Origin:* GCC, the GNU Compiler Collection
-
-  *Licensing:* `GPLv2 License`_ with Runtime Library Exception
-
-*boards/ene/kb1200_evb/support/openocd.cfg*
-  *Licensing:* `GPLv2 License`_
-
 .. _MIT License:
   https://opensource.org/licenses/MIT
-
-*tests/benchmarks/thread_metric/{thread_metric_readme.txt,src/\*}*
-  *Origin:* ThreadX
-
-  *Licensing:* `MIT License`_
 
 .. _BSD-3-clause:
    https://opensource.org/license/bsd-3-clause
 
-*modules/openthread/platform/{hdlc_interface.cpp,hdlc_interface.hpp,radio_spinel.cpp}*
-  *Origin:* OpenThread
+.. _Coccinelle:
+   https://coccinelle.gitlabpages.inria.fr/website/
 
-  *Licensing:* `BSD-3-clause`_
+.. _OpenOCD:
+   https://openocd.org


### PR DESCRIPTION
- Clarify the impact of the various non-Apache-2.0 licensed files in the tree.
- Clean up the formatting to improve readability and better match the other parts of the project documentation.

The impact of the licenses of the files mentioned on this page was a source for questions from several attendees at our recent Zephyr Meet-up in Aarhus, Denmark. It was unclear what these files were used for and whether their license could affect the license of their downstream firmware.

Documentation preview: https://builds.zephyrproject.io/zephyr/pr/83593/docs/LICENSING.html