### PR TITLE
setting pins P0.09 and P0.10 as IO no longer as NFC

### DIFF
--- a/boards/rakwireless/rak4631/rak4631_nrf52840.dts
+++ b/boards/rakwireless/rak4631/rak4631_nrf52840.dts
@@ -56,6 +56,7 @@
 
 &uicr {
 	gpio-as-nreset;
+	nfct-pins-as-gpios;
 };
 
 &gpiote {


### PR DESCRIPTION
This Sets the Pins P0.09 and P0.10 as IO and no longer as NFC.   
As stated in this [documentation](https://docs.zephyrproject.org/latest/build/dts/api/bindings/arm/nordic%2Cnrf-uicr.html).

Closes #83595

