### PR TITLE
net: support configuring offloaded network device as default interface

### DIFF
--- a/subsys/net/ip/Kconfig
+++ b/subsys/net/ip/Kconfig
@@ -930,6 +930,9 @@ config NET_DEFAULT_IF_PPP
 	bool "PPP interface"
 	depends on NET_L2_PPP
 
+config NET_DEFAULT_IF_OFFLOADED_NETDEV
+	bool "Offloaded network device"
+
 config NET_DEFAULT_IF_WIFI
 	bool "WiFi interface"
 	depends on NET_L2_ETHERNET

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -632,6 +632,9 @@ struct net_if *net_if_get_default(void)
 #if defined(CONFIG_NET_DEFAULT_IF_PPP)
 	iface = net_if_get_first_by_type(&NET_L2_GET_NAME(PPP));
 #endif
+#if defined(CONFIG_NET_DEFAULT_IF_OFFLOADED_NETDEV)
+	iface = net_if_get_first_by_type(&NET_L2_GET_NAME(OFFLOADED_NETDEV));
+#endif
 #if defined(CONFIG_NET_DEFAULT_IF_UP)
 	iface = net_if_get_first_up();
 #endif


### PR DESCRIPTION
Adds Kconfig option for making an offloaded network device the default interface.

Offloaded network device interface originally added in https://github.com/zephyrproject-rtos/zephyr/pull/55878