### PR TITLE
scripts: west_commands: runners: Fix broken jlink runner

### DIFF
--- a/scripts/west_commands/runners/jlink.py
+++ b/scripts/west_commands/runners/jlink.py
@@ -269,7 +269,7 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
             + ['-speed', self.speed]
             + ['-device', self.device]
             + ['-silent']
-            + ['-endian' 'big' if big_endian else 'little']
+            + ['-endian', 'big' if big_endian else 'little']
             + ['-singlerun']
             + (['-nogui'] if self.supports_nogui else [])
             + (['-rtos', plugin_dir] if rtos else [])


### PR DESCRIPTION
The cleanup pass (336c7da) to address long lines accidentally removed a needed comman in the jlink runner.

Fixes #83605