### PR TITLE
sensing: Fix static assert in get_sensor_by_dev()

### DIFF
--- a/subsys/sensing/sensor_mgmt.h
+++ b/subsys/sensing/sensor_mgmt.h
@@ -66,7 +66,7 @@ static inline struct sensing_sensor *get_sensor_by_dev(const struct device *dev)
 		}
 	}
 
-	__ASSERT(true, "device %s is not a sensing sensor", dev->name);
+	__ASSERT(false, "device %s is not a sensing sensor", dev->name);
 
 	return NULL;
 }


### PR DESCRIPTION
With assert condition set to true, assertion never happens. Change __ASSERT(true) to __ASSERT(false).