### PR TITLE
demand_paging: Fix static assert in k_mem_paging_backing_store_page_out()

### DIFF
--- a/subsys/demand_paging/backing_store/backing_store_ondemand_semihost.c
+++ b/subsys/demand_paging/backing_store/backing_store_ondemand_semihost.c
@@ -34,7 +34,7 @@ void k_mem_paging_backing_store_location_free(uintptr_t location)
 
 void k_mem_paging_backing_store_page_out(uintptr_t location)
 {
-	__ASSERT(true, "not ever supposed to be called");
+	__ASSERT(false, "not ever supposed to be called");
 	k_panic();
 }
 


### PR DESCRIPTION
With assert condition set to true, assertion never happens. Change __ASSERT(true) to __ASSERT(false).