### PR TITLE
Fix 1 byte OOB read in cbprintf_complete.c

### DIFF
--- a/lib/os/cbprintf_complete.c
+++ b/lib/os/cbprintf_complete.c
@@ -801,7 +801,10 @@ static char *encode_uint(uint_value_type value,
 	bool upcase = isupper((int)conv->specifier) != 0;
 	const unsigned int radix = conversion_radix(conv->specifier);
 	char *bp = bps + (bpe - bps);
-
+	if (bps >= bpe) {
+		/* Return without writing if no space available */
+		return bps;
+	}
 	do {
 		unsigned int lsv = (unsigned int)(value % radix);
 

--- a/lib/os/cbprintf_complete.c
+++ b/lib/os/cbprintf_complete.c
@@ -652,6 +652,12 @@ static inline const char *extract_conversion(struct conversion *conv,
 	 * fast-exit.
 	 */
 	++sp;
+	/* Ensure that sp is still valid string */
+	if (*sp == '\0') {
+		// Mark the conversion as invalid
+		conv->invalid = true;
+		return sp;
+	}
 	if (*sp == '%') {
 		conv->specifier = *sp;
 		++sp;


### PR DESCRIPTION
## OOB Bug Description

The `extract_conversion` function in `z_cbvprintf_impl` can cause a potential 1 byte OOB read when the format string ends with a `%` character. The issue arises because `extract_conversion` increments the format string pointer (`sp`) without verifying if it has reached the null terminator. This can potentially cause null pointer dereferences.

## OOB Underflow Bug Description

In the event that `encode_uint` passes `bps` and `bpe` where `bpe` points to a single character, in the do while loop following this, `bp` is immediately decremented and dereferenced, this can cause potential 1 byte underflow write. To fix this, checks have been added to ensure `bps` never exceeds `bpe`.

## Reproducing OOB Bug

1. Consider using a string "12345%", the `z_cbvprintf_impl` will call `OUTS` macro which will filter all characters until `%`. Now `fp` points to `%`. 
2. `extract_conversion` is called where it first increments `fp` (sp).
3. `sp` points to OOB memory (null byte in this case) and dereferencing it can cause potential null pointer dereference.
