### PR TITLE
arch: arm: Allow NMI handlers to be registered from C++

### DIFF
--- a/include/zephyr/arch/arm/nmi.h
+++ b/include/zephyr/arch/arm/nmi.h
@@ -13,8 +13,16 @@
 #ifndef ZEPHYR_INCLUDE_ARCH_ARM_NMI_H_
 #define ZEPHYR_INCLUDE_ARCH_ARM_NMI_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #if !defined(_ASMLANGUAGE) && defined(CONFIG_RUNTIME_NMI)
 extern void z_arm_nmi_set_handler(void (*pHandler)(void));
+#endif
+
+#ifdef __cplusplus
+}
 #endif
 
 #endif /* ZEPHYR_INCLUDE_ARCH_ARM_NMI_H_ */


### PR DESCRIPTION
This exports the API function with C-linkage so that it can be used in a C++ application.