### PR TITLE
kernel: Add missing marshalling header for k_reschedule

### DIFF
--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -1066,6 +1066,7 @@ static inline void z_vrfy_k_reschedule(void)
 {
 	z_impl_k_reschedule();
 }
+#include <zephyr/syscalls/k_reschedule_mrsh.c>
 #endif /* CONFIG_USERSPACE */
 
 bool k_can_yield(void)


### PR DESCRIPTION
Without this header, compiling the kernel.poll test with `-Werror=unused-function` fails.