### PR TITLE
task_wdt: Kconfig: Increase TASK_WDT_HW_FALLBACK_DELAY range

### DIFF
--- a/subsys/task_wdt/Kconfig
+++ b/subsys/task_wdt/Kconfig
@@ -47,7 +47,7 @@ config TASK_WDT_HW_FALLBACK_DELAY
 	int "Additional delay for hardware watchdog (ms)"
 	depends on TASK_WDT_HW_FALLBACK
 	default 20
-	range 1 1000
+	range 1 10000
 	help
 	  The timeout of the hardware watchdog fallback will be increased by
 	  this value to provide sufficient time for corrective actions in the


### PR DESCRIPTION
If a time-intensive task (like coredump storage over logging interface) is run in the task watchdog callback, the hardware watchdog might reset the system before the task finishes.

Increasing the delay from 1s to 10s, which should be sufficient for any use case.

Fixes #80802
Supersedes #80803