### PR TITLE
devicetree: Add DT_COMPAT macro

### DIFF
--- a/doc/build/dts/api-usage.rst
+++ b/doc/build/dts/api-usage.rst
@@ -62,6 +62,10 @@ By chosen node
    Use :c:macro:`DT_CHOSEN()` to get a node identifier for ``/chosen`` node
    properties.
 
+By compatible
+   Use :c:macro:`DT_COMPAT()` to get a node identifier for the first matching
+   compatible.
+
 By parent/child
    Use :c:macro:`DT_PARENT()` and :c:macro:`DT_CHILD()` to get a node identifier
    for a parent or child node, starting from a node identifier you already have.

--- a/include/zephyr/devicetree.h
+++ b/include/zephyr/devicetree.h
@@ -425,6 +425,16 @@
  */
 #define DT_CHILD(node_id, child) UTIL_CAT(node_id, DT_S_PREFIX(child))
 
+
+/**
+ * @brief Get a node identifier for a compatible
+ * @param compat lowercase-and-underscores compatible, without quotes
+ * @return node identifier for a node with that compatible, or
+ *         @ref DT_INVALID_NODE
+ */
+#define DT_COMPAT(compat) DT_COMPAT_GET_ANY_STATUS_OKAY(compat)
+
+
 /**
  * @brief Get a node identifier for a status `okay` node with a compatible
  *

--- a/tests/lib/devicetree/api/src/main.c
+++ b/tests/lib/devicetree/api/src/main.c
@@ -2700,8 +2700,11 @@ ZTEST(devicetree_api, test_ranges_empty)
 #undef FAIL
 }
 
-ZTEST(devicetree_api, test_compat_get_any_status_okay)
+ZTEST(devicetree_api, test_compat)
 {
+	zassert_true(DT_SAME_NODE(DT_COMPAT(vnd_reg_holder),TEST_REG), "");
+	zassert_false(DT_NODE_EXISTS(DT_COMPAT(this_is_not_a_real_compat)), "");
+
 	zassert_true(
 		DT_SAME_NODE(
 			DT_COMPAT_GET_ANY_STATUS_OKAY(vnd_reg_holder),


### PR DESCRIPTION
This provides a new way to obtain the node identifier in https://docs.zephyrproject.org/latest/build/dts/api-usage.html#a-note-for-linux-developers
```
By ...

By compatible

...
```

But I am hesitant whether to directly replace `DT_COMPAT_GET_ANY_STATUS_OKAY` with `DT_COMPAT` instead of wrapping it. And, in other words, the name `DT_COMPAT_GET_ANY_STATUS_OKAY` is overly long. Typically, we wouldn't attempt to retrieve nodes that are disabled.


## 
This PR has no corresponding issue opened, so don't try to find it.
