### PR TITLE
boards: gardena: Fix link to manual

### DIFF
--- a/boards/gardena/sgrm/doc/index.rst
+++ b/boards/gardena/sgrm/doc/index.rst
@@ -5,7 +5,7 @@ Overview
 
 This is a SoM that is used as a radio module by the GARDENA smart gateway (manual_, `FOSS parts`_).
 
-.. _manual: https://www.gardena.com/tdrdownload//pub000070911/doc000120830
+.. _manual: https://content.tdr.dss.husqvarnagroup.net/pub000094159/doc000240276
 .. _FOSS parts: https://github.com/husqvarnagroup/smart-garden-gateway-public
 
 Hardware


### PR DESCRIPTION
Updating the gateway manual URL because the old URL is now 404.