### PR TITLE
Fix cmake warning when BLE is not needed

### DIFF
--- a/drivers/bluetooth/hci/Kconfig
+++ b/drivers/bluetooth/hci/Kconfig
@@ -208,6 +208,7 @@ config BT_AMBIQ_HCI
 	select GPIO if SOC_SERIES_APOLLO4X
 	select CLOCK_CONTROL if SOC_SERIES_APOLLO4X
 	select BT_HCI_SETUP
+	select AMBIQ_COMPONENT_USE_BT
 	help
 	  Supports Ambiq Bluetooth SoC using SPI as the communication protocol.
 	  HCI packets are sent and received as single Byte transfers.

--- a/modules/hal_ambiq/Kconfig.components
+++ b/modules/hal_ambiq/Kconfig.components
@@ -3,5 +3,8 @@
 # Copyright (c) 2023 Antmicro <www.antmicro.com>
 # Copyright (c) 2025, Ambiq Micro Inc. <www.ambiq.com>
 
-rsource "Kconfig.hal"
-rsource "Kconfig.components"
+config AMBIQ_COMPONENT_USE_BT
+	bool
+	depends on SOC_AMBIQ_BT_SUPPORTED
+	help
+	  Use Bluetooth component from Ambiq

--- a/modules/hal_ambiq/Kconfig.hal
+++ b/modules/hal_ambiq/Kconfig.hal
@@ -1,0 +1,114 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright (c) 2023 Antmicro <www.antmicro.com>
+# Copyright (c) 2025, Ambiq Micro Inc. <www.ambiq.com>
+
+config AMBIQ_HAL
+	bool "Ambiq HAL drivers support"
+	depends on SOC_SERIES_APOLLO3X || SOC_SERIES_APOLLO4X
+	help
+	  Use the Ambiq HAL
+
+if AMBIQ_HAL
+
+config AMBIQ_HAL_USE_ADC
+	bool
+	help
+	  Use the ADC driver from Ambiq HAL
+
+config AMBIQ_HAL_USE_ITM
+	bool
+	help
+	  Use the ITM HAL from Ambiq
+
+config AMBIQ_HAL_USE_TPIU
+	bool
+	help
+	  Use the TPIU HAL from Ambiq
+
+config AMBIQ_HAL_USE_DCU
+	bool
+	help
+	  Use the DCU HAL from Ambiq
+
+config AMBIQ_HAL_USE_GPIO
+	bool
+	help
+	  Use the GPIO driver from Ambiq HAL
+
+config AMBIQ_HAL_USE_STIMER
+	bool
+	help
+	  Use the STIMER driver from Ambiq HAL
+
+config AMBIQ_HAL_USE_TIMER
+	bool
+	help
+	  Use the TIMER driver from Ambiq HAL
+
+config AMBIQ_HAL_USE_WDT
+	bool
+	help
+	  Use the WDT driver from Ambiq HAL
+
+config AMBIQ_HAL_USE_I2C
+	bool
+	help
+	  Use the I2C driver from Ambiq HAL
+
+config AMBIQ_HAL_USE_SPIC
+	bool
+	help
+	  Use the SPI Controller driver from Ambiq HAL
+
+config AMBIQ_HAL_USE_SPID
+	bool
+	help
+	  Use the SPI Device driver from Ambiq HAL
+
+config AMBIQ_HAL_USE_MSPI
+	bool
+	help
+	  Use the MSPI driver from Ambiq HAL
+
+config AMBIQ_HAL_USE_HWINFO
+	bool
+	help
+	  Use the HWINFO driver from Ambiq HAL
+
+config AMBIQ_HAL_USE_BLEIF
+	bool
+	help
+	  Use the BLEIF driver from Ambiq HAL
+
+config AMBIQ_HAL_USE_ADC
+	bool
+	help
+	  Use the ADC driver from Ambiq HAL
+
+config AMBIQ_HAL_USE_USB
+	bool
+	help
+	  Use the USB driver from Ambiq HAL
+
+config AMBIQ_HAL_USE_SDIO
+	bool
+	help
+	  Use the SDIO driver from Ambiq HAL
+
+config AMBIQ_HAL_USE_ADC
+	bool
+	help
+	  Use the ADC driver from Ambiq HAL
+
+config AMBIQ_HAL_USE_DSI
+	bool
+	help
+	  Use the DSI driver from Ambiq HAL
+
+config AMBIQ_HAL_USE_USB
+	bool
+	help
+	  Use the USB driver from Ambiq HAL
+
+endif # AMBIQ_HAL

--- a/soc/ambiq/CMakeLists.txt
+++ b/soc/ambiq/CMakeLists.txt
@@ -5,3 +5,15 @@
 add_subdirectory(${SOC_SERIES})
 
 zephyr_include_directories(.)
+
+if(CONFIG_SOC_AMBIQ_BT_SUPPORTED)
+  if(CONFIG_SOC_APOLLO4P)
+    if(CONFIG_AMBIQ_COMPONENT_USE_BT)
+      message(FATAL_ERROR "AMBIQ_COMPONENT_USE_BT is set to ${CONFIG_AMBIQ_COMPONENT_USE_BT} \
+for not supported SoC ${CONFIG_SOC}")
+    else()
+      message(WARNING "SOC_AMBIQ_BT_SUPPORTED is set to ${CONFIG_SOC_AMBIQ_BT_SUPPORTED} \
+for not supported SoC ${CONFIG_SOC}")
+    endif()
+  endif()
+endif()

--- a/soc/ambiq/Kconfig.soc
+++ b/soc/ambiq/Kconfig.soc
@@ -8,4 +8,7 @@ config SOC_FAMILY_AMBIQ
 config SOC_FAMILY
 	default "ambiq" if SOC_FAMILY_AMBIQ
 
+config SOC_AMBIQ_BT_SUPPORTED
+	bool
+
 rsource "*/Kconfig.soc"

--- a/soc/ambiq/apollo3x/Kconfig.soc
+++ b/soc/ambiq/apollo3x/Kconfig.soc
@@ -11,12 +11,14 @@ config SOC_SERIES_APOLLO3X
 config SOC_APOLLO3P_BLUE
 	bool
 	select SOC_SERIES_APOLLO3X
+	select SOC_AMBIQ_BT_SUPPORTED
 	help
 	  Apollo3P Blue
 
 config SOC_APOLLO3_BLUE
 	bool
 	select SOC_SERIES_APOLLO3X
+	select SOC_AMBIQ_BT_SUPPORTED
 	help
 	  Apollo3 Blue
 

--- a/soc/ambiq/apollo4x/Kconfig.soc
+++ b/soc/ambiq/apollo4x/Kconfig.soc
@@ -18,6 +18,7 @@ config SOC_APOLLO4P
 config SOC_APOLLO4P_BLUE
 	bool
 	select SOC_SERIES_APOLLO4X
+	select SOC_AMBIQ_BT_SUPPORTED
 	help
 	  Apollo4 Blue Plus
 

--- a/west.yml
+++ b/west.yml
@@ -152,7 +152,7 @@ manifest:
       groups:
         - hal
     - name: hal_ambiq
-      revision: 87a188b91aca22ce3ce7deb4a1cbf7780d784673
+      revision: 77d99efc16c7de7c17e9507693e4e3d8be1a5cb7
       path: modules/hal/ambiq
       groups:
         - hal


### PR DESCRIPTION
Empty zephyr_library() in hal_ambiq\components is producing warning when BLE is not needed for compile.
The solution is to add proper Kconfig to exclude the components\bluetooth directory.