### PR TITLE
Revert "doc: requirements: avoid using pygments v2.19.0"

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -4,7 +4,7 @@ sphinx
 sphinx_rtd_theme~=3.0
 sphinx-tabs
 sphinxcontrib-svg2pdfconverter
-pygments>=2.9,!=2.19.0
+pygments>=2.9
 sphinx-notfound-page
 sphinx-copybutton
 sphinx-togglebutton


### PR DESCRIPTION
This reverts commit https://github.com/zephyrproject-rtos/zephyr/commit/b114e0f6db39662d29e3221cde0fa55347110623 as the temporary exclusion of this particular version of pygments is not needed anymore now that 2.19.1 maintenance release is out with a fix for the regression in the IniLexer that was causing our docs build to fail.