### PR TITLE
net: openthread: radio: Fix platform radio state machine

### DIFF
--- a/modules/openthread/platform/diag.c
+++ b/modules/openthread/platform/diag.c
@@ -104,8 +104,8 @@ bool otPlatDiagModeGet(void)
 
 void otPlatDiagChannelSet(uint8_t aChannel)
 {
-	ARG_UNUSED(aChannel);
 	sChannel = aChannel;
+	platformRadioChannelSet(aChannel);
 }
 
 void otPlatDiagTxPowerSet(int8_t aTxPower)

--- a/modules/openthread/platform/platform-zephyr.h
+++ b/modules/openthread/platform/platform-zephyr.h
@@ -70,6 +70,16 @@ void platformUartPanic(void);
  */
 uint16_t platformRadioChannelGet(otInstance *aInstance);
 
+#if defined(CONFIG_OPENTHREAD_DIAG)
+/**
+ * Set channel on radio driver.
+ *
+ * @param[in]  aChannel  The channel that the radio driver should use for operation.
+ *
+ */
+void platformRadioChannelSet(uint8_t aChannel);
+#endif /* CONFIG_OPENTHREAD_DIAG */
+
 #if defined(CONFIG_IEEE802154_CARRIER_FUNCTIONS)
 /**
  * Start/stop continuous carrier wave transmission.

--- a/modules/openthread/platform/radio.c
+++ b/modules/openthread/platform/radio.c
@@ -756,19 +756,25 @@ bool otPlatRadioIsEnabled(otInstance *aInstance)
 
 otError otPlatRadioEnable(otInstance *aInstance)
 {
-	if (!otPlatRadioIsEnabled(aInstance)) {
-		sState = OT_RADIO_STATE_SLEEP;
+	ARG_UNUSED(aInstance);
+
+	if (sState != OT_RADIO_STATE_DISABLED && sState != OT_RADIO_STATE_SLEEP) {
+		return OT_ERROR_INVALID_STATE;
 	}
 
+	sState = OT_RADIO_STATE_SLEEP;
 	return OT_ERROR_NONE;
 }
 
 otError otPlatRadioDisable(otInstance *aInstance)
 {
-	if (otPlatRadioIsEnabled(aInstance)) {
-		sState = OT_RADIO_STATE_DISABLED;
+	ARG_UNUSED(aInstance);
+
+	if (sState != OT_RADIO_STATE_DISABLED && sState != OT_RADIO_STATE_SLEEP) {
+		return OT_ERROR_INVALID_STATE;
 	}
 
+	sState = OT_RADIO_STATE_DISABLED;
 	return OT_ERROR_NONE;
 }
 
@@ -776,22 +782,23 @@ otError otPlatRadioSleep(otInstance *aInstance)
 {
 	ARG_UNUSED(aInstance);
 
-	otError error = OT_ERROR_INVALID_STATE;
-
-	if (sState == OT_RADIO_STATE_SLEEP ||
-	    sState == OT_RADIO_STATE_RECEIVE ||
-	    sState == OT_RADIO_STATE_TRANSMIT) {
-		error = OT_ERROR_NONE;
-		radio_api->stop(radio_dev);
-		sState = OT_RADIO_STATE_SLEEP;
+	if (sState != OT_RADIO_STATE_SLEEP && sState != OT_RADIO_STATE_RECEIVE) {
+		return OT_ERROR_INVALID_STATE;
 	}
 
-	return error;
+	radio_api->stop(radio_dev);
+	sState = OT_RADIO_STATE_SLEEP;
+
+	return OT_ERROR_NONE;
 }
 
 otError otPlatRadioReceive(otInstance *aInstance, uint8_t aChannel)
 {
 	ARG_UNUSED(aInstance);
+
+	if (sState == OT_RADIO_STATE_DISABLED) {
+		return OT_ERROR_INVALID_STATE;
+	}
 
 	channel = aChannel;
 
@@ -897,7 +904,9 @@ otError otPlatRadioTransmit(otInstance *aInstance, otRadioFrame *aPacket)
 
 	radio_caps = radio_api->get_capabilities(radio_dev);
 
-	if ((sState == OT_RADIO_STATE_RECEIVE) || (radio_caps & IEEE802154_HW_SLEEP_TO_TX)) {
+	if (sState == OT_RADIO_STATE_RECEIVE ||
+	    (sState == OT_RADIO_STATE_SLEEP &&
+	     radio_caps & IEEE802154_HW_SLEEP_TO_TX)) {
 		if (run_tx_task(aInstance) == 0) {
 			error = OT_ERROR_NONE;
 		}

--- a/modules/openthread/platform/radio.c
+++ b/modules/openthread/platform/radio.c
@@ -722,6 +722,13 @@ uint16_t platformRadioChannelGet(otInstance *aInstance)
 	return channel;
 }
 
+#if defined(CONFIG_OPENTHREAD_DIAG)
+void platformRadioChannelSet(uint8_t aChannel)
+{
+	channel = aChannel;
+}
+#endif
+
 void otPlatRadioSetPanId(otInstance *aInstance, uint16_t aPanId)
 {
 	ARG_UNUSED(aInstance);

--- a/tests/subsys/openthread/radio_test.c
+++ b/tests/subsys/openthread/radio_test.c
@@ -625,12 +625,18 @@ ZTEST(openthread_radio, test_radio_state_test)
 
 	zassert_equal(otPlatRadioSetTransmitPower(ot, power), OT_ERROR_NONE,
 		      "Failed to set TX power.");
+
+	zassert_equal(otPlatRadioSleep(ot), OT_ERROR_NONE, "Failed to switch to sleep mode.");
+
 	zassert_equal(otPlatRadioDisable(ot), OT_ERROR_NONE, "Failed to disable radio.");
 
 	zassert_false(otPlatRadioIsEnabled(ot), "Radio reports as enabled.");
 
 	zassert_equal(otPlatRadioSleep(ot), OT_ERROR_INVALID_STATE,
 		      "Changed to sleep regardless being disabled.");
+
+	zassert_equal(otPlatRadioReceive(ot, channel), OT_ERROR_INVALID_STATE,
+		      "Changed to receive regardless being disabled.");
 
 	zassert_equal(otPlatRadioEnable(ot), OT_ERROR_NONE, "Enabling radio failed.");
 
@@ -644,6 +650,9 @@ ZTEST(openthread_radio, test_radio_state_test)
 	zassert_equal(otPlatRadioReceive(ot, channel), OT_ERROR_NONE, "Failed to receive.");
 	zassert_equal(platformRadioChannelGet(ot), channel, "Channel number not remembered.");
 
+	zassert_equal(otPlatRadioDisable(ot), OT_ERROR_INVALID_STATE,
+		      "Changed to disabled regardless being in receive state.");
+
 	zassert_true(otPlatRadioIsEnabled(ot), "Radio reports as disabled.");
 	zassert_equal(1, set_channel_mock_fake.call_count);
 	zassert_equal(channel, set_channel_mock_fake.arg1_val);
@@ -651,7 +660,7 @@ ZTEST(openthread_radio, test_radio_state_test)
 	zassert_equal(power, set_txpower_mock_fake.arg1_val);
 	zassert_equal(1, start_mock_fake.call_count);
 	zassert_equal_ptr(radio, start_mock_fake.arg0_val, NULL);
-	zassert_equal(1, stop_mock_fake.call_count);
+	zassert_equal(2, stop_mock_fake.call_count);
 	zassert_equal_ptr(radio, stop_mock_fake.arg0_val, NULL);
 }
 
@@ -814,6 +823,7 @@ ZTEST(openthread_radio, test_net_pkt_transmit)
 		      "Failed to set TX power.");
 
 	set_channel_mock_fake.return_val = 0;
+	zassert_equal(otPlatRadioEnable(ot), OT_ERROR_NONE, "Failed to enable.");
 	zassert_equal(otPlatRadioReceive(ot, channel), OT_ERROR_NONE, "Failed to receive.");
 	zassert_equal(1, set_channel_mock_fake.call_count);
 	zassert_equal(channel, set_channel_mock_fake.arg1_val);


### PR DESCRIPTION
Fix platform radio state machine to be compliant with one shown in OpenThread's `include/openthread/platform/radio.h`