### PR TITLE
smartbond_timer: Use hw clock frequency for watchdog expire ticks

### DIFF
--- a/drivers/timer/smartbond_timer.c
+++ b/drivers/timer/smartbond_timer.c
@@ -120,7 +120,8 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 			 * RC32K maximum frequency.
 			 */
 			watchdog_expire_ticks = SYS_WDOG->WATCHDOG_REG *
-				CONFIG_SYS_CLOCK_TICKS_PER_SEC / (get_rc32k_max_frequency() / 320);
+				CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC /
+				(get_rc32k_max_frequency() / 320);
 		}
 		if (watchdog_expire_ticks - 2 < ticks) {
 			ticks = watchdog_expire_ticks - 2;

--- a/drivers/timer/smartbond_timer.c
+++ b/drivers/timer/smartbond_timer.c
@@ -103,7 +103,7 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 	 * as soon as system is awaken. Following code makes sure that
 	 * system never goes to sleep for longer time that watchdog reload value.
 	 */
-	if (!IS_ENABLED(CONFIG_WDT_SMARTBOND) && IS_ENABLED(CONFIG_PM)) {
+	if (IS_ENABLED(CONFIG_PM)) {
 		uint32_t watchdog_expire_ticks;
 
 		if (CRG_TOP->CLK_RCX_REG & CRG_TOP_CLK_RCX_REG_RCX_ENABLE_Msk) {


### PR DESCRIPTION
Use hardware clock frequency to calculate watchdog expire ticks instead of kernel's "ticks" and if PM is enabled, always adjust timeout ticks according to watchdog expiration.