### PR TITLE
mailmap: remove duplicate emails and normalize mapping entries

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,14 +1,14 @@
 Alexandr Kolosov <rikorsev@gmail.com>
 Alexandre d'Alton <alexandre.dalton@intel.com>
-Amir Kaplan <amir.kaplan@intel.com> <amir.kaplan@intel.com>
-Anas Nashif <anas.nashif@intel.com> <anas.nashif@intel.com>
+Amir Kaplan <amir.kaplan@intel.com>
+Anas Nashif <anas.nashif@intel.com>
 Andrzej Kuroś <andrzej.kuros@nordicsemi.no>
 Anthony Smigielski <thebasti0ncode@gmail.com>
 Armand Ciejak <armand@riedonetworks.com>  <armandciejak@users.noreply.github.com>
 Aska Wu <aska.wu@linaro.org>
-Bit Pathe <bitpathe@gmail.com> <bitpathe@gmail.com>
+Bit Pathe <bitpathe@gmail.com>
 Bjarki Arge Andreasen <baa@trackunit.com>
-Carles Cufi <carles.cufi@nordicsemi.no> <carles.cufi@nordicsemi.no>
+Carles Cufi <carles.cufi@nordicsemi.no>
 chao an <anchao@xiaomi.com>
 Charles E. Youse <charles.youse@intel.com>
 Chen Xingyu <hi@xingrz.me>
@@ -16,32 +16,32 @@ Christoph Schnetzler <christoph.schnetzler@husqvarnagroup.com>
 Christoph Schramm <schramm@makaio.com>
 Christopher Friedt <cfriedt@meta.com>
 Christopher Friedt <cfriedt@meta.com> <cfriedt@fb.com>
-Chuck Jordan <cjordan@synopsys.com> <cjordan@synopsys.com>
+Chuck Jordan <cjordan@synopsys.com>
 Chunlin Han <chunlin.han@linaro.org> <chunlin.han@acer.com>
 David B. Kinder <david.b.kinder@intel.com>
 David Komel <a8961713@gmail.com>
 David Leach <david.leach@nxp.com>
-Dirk Brandewie <dirk.j.brandewie@intel.com> <dirk.j.brandewie@intel.com>
-Douglas Su <d0u9.su@outlook.com> <d0u9.su@outlook.com>
+Dirk Brandewie <dirk.j.brandewie@intel.com>
+Douglas Su <d0u9.su@outlook.com>
 Enjia Mai <enjia.mai@intel.com>
-Enjia Mai <enjia.mai@intel.com> <enjiax.mai@intel.com>
-Evan Couzens <evanx.couzens@intel.com> <evanx.couzens@intel.com>
+Enjia Mai <enjia.mai@intel.com>
+Evan Couzens <evanx.couzens@intel.com>
 Evgeniy Paltsev <PaltsevEvgeniy@gmail.com>
 Evgeniy Paltsev <PaltsevEvgeniy@gmail.com> <Eugeniy.Paltsev@synopsys.com>
-Felipe Neves <ryukokki.felipe@gmail.com> <ryukokki.felipe@gmail.com>
+Felipe Neves <ryukokki.felipe@gmail.com>
 Findlay Feng <i@fengch.me>
 Flavio Arieta Netto <flavio@exati.com.br>
 Francois Ramu <francois.ramu@st.com>
-Gerardo Aceves <gerardo.aceves@intel.com> <gerardo.aceves@intel.com>
+Gerardo Aceves <gerardo.aceves@intel.com>
 Gregory Shue <gregory.shue@legrand.com>
 Gregory Shue <gregory.shue@legrand.com> <gregory.shue@legrand.us>
 HaiLong Yang <cameledyang@pm.me>
 James Johnson <james.johnson672@t-mobile.com>
 Jarno Lämsä <jarno.lamsa@nordicsemi.no>
 Jędrzej Ciupis <jedrzej.ciupis@nordicsemi.no>
-Jeremie Garcia <jeremie.garcia@intel.com> <jeremie.garcia@intel.com>
+Jeremie Garcia <jeremie.garcia@intel.com>
 Jim Benjamin Luther <jilu@oticon.com>
-Johan Kruger <johan.kruger@windriver.com> <johan.kruger@windriver.com>
+Johan Kruger <johan.kruger@windriver.com>
 Johann Fischer <j.fischer@phytec.de>
 Jørgen Kvalvaag <jorgen.kvalvaag@nordicsemi.no>
 Juan Manuel Cruz Alcaraz <juan.m.cruz.alcaraz@intel.com>
@@ -51,11 +51,11 @@ Jun Li <jun.r.li@intel.com>
 Justin Watson <jwatson5@gmail.com>
 Kamil Sroka <kamil.sroka@nordicsemi.no>
 Katarzyna Giądła <katarzyna.giadla@nordicsemi.no>
-Keren Siman-Tov <keren.siman-tov@intel.com> <keren.siman-tov@intel.com>
+Keren Siman-Tov <keren.siman-tov@intel.com>
 Krzysztof Chruściński <krzysztof.chruscinski@nordicsemi.no>
-Kuo-Lang Tseng <kuo-lang.tseng@intel.com> <kuo-lang.tseng@intel.com>
-Lei Liu <lei.a.liu@intel.com> <lei.a.liu@intel.com>
-Leona Cook <leonax.cook@intel.com> <leonax.cook@intel.com>
+Kuo-Lang Tseng <kuo-lang.tseng@intel.com>
+Lei Liu <lei.a.liu@intel.com>
+Leona Cook <leonax.cook@intel.com>
 Leona Cook <leonax.cook@intel.com> <lsc@hackeress.com>
 Lixin Guo <lixinx.guo@intel.com>
 Łukasz Mazur <lukasz.mazur@hidglobal.com>
@@ -72,14 +72,14 @@ Martí Bolívar <marti.bolivar@nordicsemi.no> <marti.bolivar@linaro.org>
 Martí Bolívar <marti.bolivar@nordicsemi.no> <marti.f.bolivar@gmail.com>
 Martí Bolívar <marti.bolivar@nordicsemi.no> <marti@foundries.io>
 Martí Bolívar <marti.bolivar@nordicsemi.no> <marti@opensourcefoundries.com>
-Martin Jäger <martin@libre.solar>  <17674105+martinjaeger@users.noreply.github.com>
+Martin Jäger <martin@libre.solar> <17674105+martinjaeger@users.noreply.github.com>
 Mateusz Hołenko <mholenko@antmicro.com>
 Michael Rosen <michael.r.rosen@intel.com>
 Michal Narajowski <michal.narajowski@codecoup.pl>
-Mike Hirst <michael.hirst@windriver.com> <michael.hirst@windriver.com>
+Mike Hirst <michael.hirst@windriver.com>
 Ming Shao <ming.shao@intel.com>
 Mohan Kumar Kumar <mohankm@fb.com>
-Naga Raja Rao Tulasi <tulasi.r@tcs.com> <tulasi.r@tcs.com>
+Naga Raja Rao Tulasi <tulasi.r@tcs.com>
 Navin Sankar Velliangiri <navin@linumiz.com>
 NingX Zhao <ningx.zhao@intel.com>
 Nishikant Nayak <nishikantax.nayak@intel.com>
@@ -100,21 +100,23 @@ Radosław Koppel <radoslaw.koppel@nordicsemi.no> <r.koppel@k-el.com>
 Raja D. Singh <rdsingh@iotwizards.com>
 Ricardo Salveti <ricardo@opensourcefoundries.com>
 Ricardo Salveti <ricardo@opensourcefoundries.com> <ricardo.salveti@linaro.org>
-Ruud Derwig <Ruud.Derwig@synopsys.com> <Ruud.Derwig@synopsys.com>
+Ruud Derwig <Ruud.Derwig@synopsys.com>
 Saku Rautio <saku.rautio@nordicsemi.no>
 Scott Worley <scott.worley@microchip.com>
 Sean Nyekjaer <sean@geanix.com> <sean.nyekjaer@prevas.dk>
 Sean Nyekjaer <sean@geanix.com> <sean@nyekjaer.dk>
 Sharron Liu <sharron.liu@intel.com>
 Shilpashree L C <shilpashree.lc@intel.com>
-Shuang He <shuang.he@intel.com> <shuang.he@intel.com>
+Shuang He <shuang.he@intel.com>
 Sigvart Hovland <sigvart.hovland@nordicsemi.no>
 Stéphane D'Alu <sdalu@sdalu.com>
 Stine Åkredalen <stine.akredalen@nordicsemi.no>
-Thomas Heeley <thomas.heeley@intel.com> <thomas.heeley@intel.com>
+Thomas Heeley <thomas.heeley@intel.com>
 Tim Sørensen <tims@demant.com>
 Tim Sørensen <tims@demant.com> <tims@oticon.com>
-Vinayak Kariappa Chettimada <vinayak.kariappa.chettimada@nordicsemi.no> <vinayak.kariappa.chettimada@nordicsemi.no> <vich@nordicsemi.no> <vinayak.kariappa@gmail.com>
+Vinayak Kariappa Chettimada <vinayak.kariappa.chettimada@nordicsemi.no>
+Vinayak Kariappa Chettimada <vinayak.kariappa.chettimada@nordicsemi.no> <vich@nordicsemi.no>
+Vinayak Kariappa Chettimada <vinayak.kariappa.chettimada@nordicsemi.no> <vinayak.kariappa@gmail.com>
 Xiaorui Hu <xiaorui.hu@linaro.org>
 Yannis Damigos <giannis.damigos@gmail.com> <ydamigos@iccs.gr>
 Yonattan Louise <yonattan.a.louise.mendoza@intel.com>


### PR DESCRIPTION
Change entries of the form:
`Proper Name <proper@email.xx> <proper@email.xx>`
to:
`Proper Name <proper@email.xx>`

This makes it clearer that no e-mail address mapping takes place in these entries, only the `Proper Name` is mapped based on `<proper@email.xx>`.

Normalize all e-mail mapping entries to:
`Proper Name <proper@email.xx> <other@email.xx>`

This makes it clearer which e-mail address is being mapped and follows the formats listed in the gitmailmap documentation.