### PR TITLE
drivers: regulator, mfd: npm2100 fixes

### DIFF
--- a/drivers/mfd/mfd_npm2100.c
+++ b/drivers/mfd/mfd_npm2100.c
@@ -355,17 +355,6 @@ int mfd_npm2100_hibernate(const struct device *dev, uint32_t time_ms, bool pass_
 		}
 	}
 
-	/* Ensure shiphold button is enabled so that wakeup will work */
-	ret = i2c_reg_write_byte_dt(&config->i2c, RESET_WRITESTICKY, 0);
-	if (ret < 0) {
-		return ret;
-	}
-
-	ret = i2c_reg_write_byte_dt(&config->i2c, RESET_STROBESTICKY, 1U);
-	if (ret < 0) {
-		return ret;
-	}
-
 	return i2c_reg_write_byte_dt(
 		&config->i2c, pass_through ? HIBERNATE_TASKS_HIBERPT : HIBERNATE_TASKS_HIBER, 1U);
 }

--- a/drivers/mfd/mfd_npm2100.c
+++ b/drivers/mfd/mfd_npm2100.c
@@ -26,6 +26,7 @@
 #define SHPHLD_WAKEUP         0xC1U
 #define SHPHLD_SHPHLD         0xC2U
 #define HIBERNATE_TASKS_HIBER 0xC8U
+#define HIBERNATE_TASKS_HIBERPT 0xC9U
 #define RESET_TASKS_RESET     0xD0U
 #define RESET_BUTTON          0xD2U
 #define RESET_PIN             0xD3U
@@ -337,7 +338,7 @@ int mfd_npm2100_reset(const struct device *dev)
 	return i2c_reg_write_byte_dt(&config->i2c, RESET_TASKS_RESET, 1U);
 }
 
-int mfd_npm2100_hibernate(const struct device *dev, uint32_t time_ms)
+int mfd_npm2100_hibernate(const struct device *dev, uint32_t time_ms, bool pass_through)
 {
 	const struct mfd_npm2100_config *config = dev->config;
 	int ret;
@@ -365,7 +366,8 @@ int mfd_npm2100_hibernate(const struct device *dev, uint32_t time_ms)
 		return ret;
 	}
 
-	return i2c_reg_write_byte_dt(&config->i2c, HIBERNATE_TASKS_HIBER, 1U);
+	return i2c_reg_write_byte_dt(
+		&config->i2c, pass_through ? HIBERNATE_TASKS_HIBERPT : HIBERNATE_TASKS_HIBER, 1U);
 }
 
 int mfd_npm2100_add_callback(const struct device *dev, struct gpio_callback *callback)

--- a/drivers/mfd/mfd_npm2100.c
+++ b/drivers/mfd/mfd_npm2100.c
@@ -14,24 +14,24 @@
 #include <zephyr/drivers/gpio/gpio_utils.h>
 #include <zephyr/drivers/mfd/npm2100.h>
 
-#define EVENTS_SET            0x00U
-#define EVENTS_CLR            0x05U
-#define INTEN_SET             0x0AU
-#define GPIO_CONFIG           0x80U
-#define GPIO_USAGE            0x83U
-#define TIMER_TASKS_START     0xB0U
-#define TIMER_CONFIG          0xB3U
-#define TIMER_TARGET          0xB4U
-#define TIMER_STATUS          0xB7U
-#define SHPHLD_WAKEUP         0xC1U
-#define SHPHLD_SHPHLD         0xC2U
-#define HIBERNATE_TASKS_HIBER 0xC8U
+#define EVENTS_SET              0x00U
+#define EVENTS_CLR              0x05U
+#define INTEN_SET               0x0AU
+#define GPIO_CONFIG             0x80U
+#define GPIO_USAGE              0x83U
+#define TIMER_TASKS_START       0xB0U
+#define TIMER_CONFIG            0xB3U
+#define TIMER_TARGET            0xB4U
+#define TIMER_STATUS            0xB7U
+#define SHPHLD_WAKEUP           0xC1U
+#define SHPHLD_SHPHLD           0xC2U
+#define HIBERNATE_TASKS_HIBER   0xC8U
 #define HIBERNATE_TASKS_HIBERPT 0xC9U
-#define RESET_TASKS_RESET     0xD0U
-#define RESET_BUTTON          0xD2U
-#define RESET_PIN             0xD3U
-#define RESET_WRITESTICKY     0xDBU
-#define RESET_STROBESTICKY    0xDCU
+#define RESET_TASKS_RESET       0xD0U
+#define RESET_BUTTON            0xD2U
+#define RESET_PIN               0xD3U
+#define RESET_WRITESTICKY       0xDBU
+#define RESET_STROBESTICKY      0xDCU
 
 #define SHPHLD_RESISTOR_MASK     0x03U
 #define SHPHLD_RESISTOR_PULLUP   0x00U

--- a/drivers/mfd/mfd_npm2100.c
+++ b/drivers/mfd/mfd_npm2100.c
@@ -218,7 +218,7 @@ static int config_shphold(const struct device *dev)
 	}
 
 	reg = config->shiphold_hibernate_wakeup ? WAKEUP_HIBERNATE_PIN : WAKEUP_HIBERNATE_NOPIN;
-	if ((config->shiphold_flags & GPIO_ACTIVE_HIGH) != 0U) {
+	if ((config->shiphold_flags & GPIO_ACTIVE_LOW) == 0U) {
 		reg |= WAKEUP_EDGE_RISING;
 	}
 

--- a/drivers/regulator/regulator_npm2100.c
+++ b/drivers/regulator/regulator_npm2100.c
@@ -642,18 +642,6 @@ static int regulator_npm2100_ship_mode(const struct device *dev)
 {
 	const struct regulator_npm2100_pconfig *pconfig = dev->config;
 
-	/* Ensure shiphold button is enabled so that wakeup will work */
-	int ret = i2c_reg_write_byte_dt(&pconfig->i2c, RESET_WRITESTICKY, 0);
-
-	if (ret < 0) {
-		return ret;
-	}
-
-	ret = i2c_reg_write_byte_dt(&pconfig->i2c, RESET_STROBESTICKY, 1U);
-	if (ret < 0) {
-		return ret;
-	}
-
 	return i2c_reg_write_byte_dt(&pconfig->i2c, SHIP_TASK_SHIP, 1U);
 }
 

--- a/include/zephyr/drivers/mfd/npm2100.h
+++ b/include/zephyr/drivers/mfd/npm2100.h
@@ -92,15 +92,18 @@ int mfd_npm2100_reset(const struct device *dev);
  * @brief npm2100 hibernate
  *
  * Enters low power state, and wakes after specified time or "shphld" pin signal.
+ * Pass-through mode can be used when the battery voltage is high enough to supply the pmic directly
+ * without boosting. This lowers the power consumption of the pmic when hibernate mode is active.
  *
  * @param dev npm2100 mfd device
  * @param time_ms timer value in ms. Set to 0 to disable timer.
+ * @param pass_through set to use pass-through hibernate mode.
  * @retval 0 If successful
  * @retval -EINVAL if time value is too large
  * @retval -EBUSY if the timer is already in use.
  * @retval -errno In case of any bus error (see i2c_write_dt())
  */
-int mfd_npm2100_hibernate(const struct device *dev, uint32_t time_ms);
+int mfd_npm2100_hibernate(const struct device *dev, uint32_t time_ms, bool pass_through);
 
 /**
  * @brief Add npm2100 event callback


### PR DESCRIPTION
multiple fixes for the npm2100 PMIC drivers:
* proper shphld polarity handling
* added hibernate_pt mode support
* removed shphld reconfiguration on entering ship/hibernate mode to avoid unexpected behavior