### PR TITLE
tests: pwm: pwm_gpio_loopback: add nrf platforms

### DIFF
--- a/tests/drivers/pwm/pwm_gpio_loopback/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/tests/drivers/pwm/pwm_gpio_loopback/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Test requires wire connection between:
+ *  - PWM130 OUT[0] at P0.00 <-> GPIO input at P0.01
+ *  - PWM120 OUT[0] at P7.00 <-> GPIO input at P1.09
+ *  - PWM120 OUT[1] at P7.01 <-> GPIO input at P1.05
+ */
+
+/ {
+	zephyr,user {
+		pwms = <&pwm130 0 160000 PWM_POLARITY_NORMAL>,
+			<&pwm120 0 80000 PWM_POLARITY_NORMAL>,
+			<&pwm120 1 80000 PWM_POLARITY_NORMAL>;
+		gpios = <&gpio0 1 GPIO_ACTIVE_HIGH>,
+			<&gpio1 9 GPIO_ACTIVE_HIGH>,
+			<&gpio1 5 GPIO_ACTIVE_HIGH>;
+	};
+};
+
+&pinctrl {
+	pwm130_default: pwm130_default {
+		group1 {
+			psels = <NRF_PSEL(PWM_OUT0, 0, 0)>;
+		};
+	};
+
+	pwm130_sleep: pwm130_sleep {
+		group1 {
+			psels = <NRF_PSEL(PWM_OUT0, 0, 0)>;
+			low-power-enable;
+		};
+	};
+
+	pwm120_default: pwm120_default {
+		group1 {
+			psels = <NRF_PSEL(PWM_OUT0, 7, 0)>,
+				<NRF_PSEL(PWM_OUT1, 7, 1)>;
+		};
+	};
+	pwm120_sleep: pwm120_sleep {
+		group1 {
+			psels = <NRF_PSEL(PWM_OUT0, 7, 0)>,
+				<NRF_PSEL(PWM_OUT1, 7, 1)>;
+			low-power-enable;
+		};
+	};
+};
+
+&gpio1 {
+	status = "okay";
+};
+
+&pwm120 {
+	status = "okay";
+	pinctrl-0 = <&pwm120_default>;
+	pinctrl-1 = <&pwm120_sleep>;
+	pinctrl-names = "default", "sleep";
+	memory-regions = <&dma_fast_region>;
+};
+
+&dma_fast_region {
+	status = "okay";
+};

--- a/tests/drivers/pwm/pwm_gpio_loopback/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/tests/drivers/pwm/pwm_gpio_loopback/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Test requires jumper between:
+ *  - PWM20 OUT[0] at P1.10 <-> GPIO input at P1.11
+ */
+
+/ {
+	zephyr,user {
+		pwms = <&pwm20 0 160000 PWM_POLARITY_NORMAL>;
+		gpios = <&gpio1 11 GPIO_ACTIVE_HIGH>;
+	};
+};

--- a/tests/drivers/pwm/pwm_gpio_loopback/src/main.c
+++ b/tests/drivers/pwm/pwm_gpio_loopback/src/main.c
@@ -22,22 +22,22 @@
 
 static struct gpio_callback gpio_cb;
 
-#define PWM_COUNT                      DT_PROP_LEN(DT_PATH(zephyr_user), pwms)
-#define PWM_CONFIG_ENTRY(idx, node_id) PWM_DT_SPEC_GET_BY_IDX(node_id, idx)
-#define PWM_CONFIG_ARRAY(node_id)                                                                  \
+#define TEST_PWM_COUNT                      DT_PROP_LEN(DT_PATH(zephyr_user), pwms)
+#define TEST_PWM_CONFIG_ENTRY(idx, node_id) PWM_DT_SPEC_GET_BY_IDX(node_id, idx)
+#define TEST_PWM_CONFIG_ARRAY(node_id)                                                             \
 	{                                                                                          \
-		LISTIFY(PWM_COUNT, PWM_CONFIG_ENTRY, (,), node_id)                                 \
+		LISTIFY(TEST_PWM_COUNT, TEST_PWM_CONFIG_ENTRY, (,), node_id)                       \
 	}
 
-#define GPIO_COUNT                      DT_PROP_LEN(DT_PATH(zephyr_user), gpios)
-#define GPIO_CONFIG_ENTRY(idx, node_id) GPIO_DT_SPEC_GET_BY_IDX(node_id, gpios, idx)
-#define GPIO_CONFIG_ARRAY(node_id)                                                                 \
+#define TEST_GPIO_COUNT                      DT_PROP_LEN(DT_PATH(zephyr_user), gpios)
+#define TEST_GPIO_CONFIG_ENTRY(idx, node_id) GPIO_DT_SPEC_GET_BY_IDX(node_id, gpios, idx)
+#define TEST_GPIO_CONFIG_ARRAY(node_id)                                                            \
 	{                                                                                          \
-		LISTIFY(GPIO_COUNT, GPIO_CONFIG_ENTRY, (,), node_id)                               \
+		LISTIFY(TEST_GPIO_COUNT, TEST_GPIO_CONFIG_ENTRY, (,), node_id)                     \
 	}
 
-static const struct pwm_dt_spec pwms_dt[] = PWM_CONFIG_ARRAY(DT_PATH(zephyr_user));
-static const struct gpio_dt_spec gpios_dt[] = GPIO_CONFIG_ARRAY(DT_PATH(zephyr_user));
+static const struct pwm_dt_spec pwms_dt[] = TEST_PWM_CONFIG_ARRAY(DT_PATH(zephyr_user));
+static const struct gpio_dt_spec gpios_dt[] = TEST_GPIO_CONFIG_ARRAY(DT_PATH(zephyr_user));
 
 static struct test_context {
 	uint32_t last_edge_time;
@@ -218,7 +218,7 @@ static void test_run(const struct pwm_dt_spec *pwm_dt, const struct gpio_dt_spec
 
 ZTEST(pwm_gpio_loopback, test_pwm)
 {
-	for (int i = 0; i < PWM_COUNT; i++) {
+	for (int i = 0; i < TEST_PWM_COUNT; i++) {
 		zassert_true(device_is_ready(pwms_dt[i].dev), "PWM device is not ready");
 		zassert_true(device_is_ready(gpios_dt[i].port), "GPIO device is not ready");
 
@@ -238,7 +238,7 @@ ZTEST(pwm_gpio_loopback, test_pwm)
 
 ZTEST(pwm_gpio_loopback, test_pwm_cross)
 {
-	for (int i = 0; i < PWM_COUNT; i++) {
+	for (int i = 0; i < TEST_PWM_COUNT; i++) {
 		/* Test case: [Duty: 40%] */
 		test_run(&pwms_dt[i], &gpios_dt[i], 40, true);
 	}
@@ -246,7 +246,7 @@ ZTEST(pwm_gpio_loopback, test_pwm_cross)
 	/* Set all channels and check if they retain the original
 	 * configuration without calling pwm_set again
 	 */
-	for (int i = 0; i < PWM_COUNT; i++) {
+	for (int i = 0; i < TEST_PWM_COUNT; i++) {
 		test_run(&pwms_dt[i], &gpios_dt[i], 40, false);
 	}
 }

--- a/tests/drivers/pwm/pwm_gpio_loopback/testcase.yaml
+++ b/tests/drivers/pwm/pwm_gpio_loopback/testcase.yaml
@@ -15,3 +15,8 @@ tests:
       - esp32c6_devkitc
       - esp32s2_saola
       - esp32s3_devkitm/esp32s3/procpu
+
+  drivers.pwm.gpio_loopback.nrf:
+    platform_allow:
+      - nrf54h20dk/nrf54h20/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp


### PR DESCRIPTION
Add Nordic platforms and rename the defines
to avoid redefining a nrf driver internal symbols