### PR TITLE
Fix SPIRAM alloc attributes and linker

### DIFF
--- a/soc/espressif/esp32/default.ld
+++ b/soc/espressif/esp32/default.ld
@@ -799,7 +799,7 @@ SECTIONS
   /* --- SPIRAM BEGIN --- */
 
 #ifdef CONFIG_ESP_SPIRAM
-  .ext_ram.bss (NOLOAD):
+  .ext_ram (NOLOAD):
   {
     _ext_ram_start = ABSOLUTE(.);
     _ext_ram_noinit_start = ABSOLUTE(.);
@@ -812,10 +812,17 @@ SECTIONS
     *libsubsys__net.a:(.noinit .noinit.*)
 #endif /* CONFIG_ESP32_WIFI_NET_ALLOC_SPIRAM */
     . = ALIGN(16);
+
+    *(.ext_ram_noinit*)
+    *(.ext_ram_noinit.*)
+
+    . = ALIGN(16);
     _ext_ram_noinit_end = ABSOLUTE(.);
 
     _ext_ram_bss_start = ABSOLUTE(.);
+
     *(.ext_ram.bss*)
+
     . = ALIGN(16);
     _ext_ram_bss_end = ABSOLUTE(.);
 

--- a/soc/espressif/esp32s2/default.ld
+++ b/soc/espressif/esp32s2/default.ld
@@ -90,7 +90,7 @@ MEMORY
 #endif
 
 #ifdef CONFIG_ESP_SPIRAM
-  ext_data_ram_seg(RW): org = 0x3f800000, len = CONFIG_ESP_SPIRAM_SIZE /* OR 0x780000 */
+  ext_ram_seg(RW): org = 0x3f800000, len = CONFIG_ESP_SPIRAM_SIZE /* OR 0x780000 */
 #endif /* CONFIG_ESP_SPIRAM */
 
 #ifdef CONFIG_GEN_ISR_TABLES
@@ -779,18 +779,11 @@ SECTIONS
 
 #ifdef CONFIG_ESP_SPIRAM
   /* This section holds .ext_ram.bss data, and will be put in PSRAM */
-  .ext_ram.bss (NOLOAD):
+  .ext_ram (NOLOAD):
   {
-    _ext_ram_data_start = ABSOLUTE(.);
-    _ext_ram_bss_start = ABSOLUTE(.);
-    *(.ext_ram.bss*)
-    . = ALIGN(4);
-    _ext_ram_bss_end = ABSOLUTE(.);
-  } > ext_data_ram_seg
-
-  .ext_ram_noinit (NOLOAD) :
-  {
+    _ext_ram_start = ABSOLUTE(.);
     _ext_ram_noinit_start = ABSOLUTE(.);
+
 #ifdef CONFIG_ESP32_WIFI_NET_ALLOC_SPIRAM
     *libdrivers__wifi.a:(.noinit .noinit.*)
     *libsubsys__net__l2__ethernet.a:(.noinit .noinit.*)
@@ -798,13 +791,26 @@ SECTIONS
     *libsubsys__net__ip.a:(.noinit .noinit.*)
     *libsubsys__net.a:(.noinit .noinit.*)
 #endif /* CONFIG_ESP32_WIFI_NET_ALLOC_SPIRAM */
+    . = ALIGN(16);
+
+    *(.ext_ram_noinit*)
+    *(.ext_ram_noinit.*)
+
+    . = ALIGN(16);
     _ext_ram_noinit_end = ABSOLUTE(.);
+
+    _ext_ram_bss_start = ABSOLUTE(.);
+
+    *(.ext_ram.bss*)
+
+    . = ALIGN(16);
+    _ext_ram_bss_end = ABSOLUTE(.);
 
     _spiram_heap_start = ABSOLUTE(.);
     . += CONFIG_ESP_SPIRAM_HEAP_SIZE;
 
-    _ext_ram_data_end = ABSOLUTE(.);
-  } > ext_data_ram_seg
+    _ext_ram_end = ABSOLUTE(.);
+  } GROUP_LINK_IN(ext_ram_seg)
 #endif /* CONFIG_ESP_SPIRAM */
 
   .dram0.noinit (NOLOAD) :
@@ -1004,6 +1010,6 @@ SECTIONS
   /* --- XTENSA GLUE AND DEBUG END --- */
 
 #ifdef CONFIG_ESP_SPIRAM
-ASSERT(((_ext_ram_data_end - _ext_ram_data_start) <= CONFIG_ESP_SPIRAM_SIZE),
+ASSERT(((_ext_ram_end - _ext_ram_start) <= CONFIG_ESP_SPIRAM_SIZE),
           "External SPIRAM overflowed.")
 #endif /* CONFIG_ESP_SPIRAM */

--- a/soc/espressif/esp32s3/default.ld
+++ b/soc/espressif/esp32s3/default.ld
@@ -1001,7 +1001,7 @@ SECTIONS
 
     _spiram_heap_start = ABSOLUTE(.);
     . = . + CONFIG_ESP_SPIRAM_HEAP_SIZE - (_spiram_heap_start - _ext_ram_bss_start);
-    . = ALIGN(4);
+    . = ALIGN(16);
 
     _ext_ram_end = ABSOLUTE(.);
   } GROUP_LINK_IN(ext_dram_seg)


### PR DESCRIPTION
Allow to use EXT_RAM_NOINIT_ATTR and EXT_RAM_BSS_ATTR so that variables end in the desired sections.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/74284 