### PR TITLE
lib: smf: mark as unstable

### DIFF
--- a/include/zephyr/smf.h
+++ b/include/zephyr/smf.h
@@ -18,7 +18,7 @@
 /**
  * @brief State Machine Framework API
  * @defgroup smf State Machine Framework API
- * @version 0.1.0
+ * @version 0.2.0
  * @ingroup os_services
  * @{
  */


### PR DESCRIPTION
mark State Machine Framework API as unstable,
as it is now used by usb-c and hawkBit.

As noted here: https://github.com/zephyrproject-rtos/zephyr/issues/71675#issuecomment-2098677258