### PR TITLE
posix: options: mlock: include demand paging header

### DIFF
--- a/lib/posix/options/mlock.c
+++ b/lib/posix/options/mlock.c
@@ -9,16 +9,22 @@
 #include <zephyr/kernel.h>
 #include <zephyr/posix/sys/mman.h>
 
+#include <zephyr/kernel/mm/demand_paging.h>
+
 int mlock(const void *addr, size_t len)
 {
-	k_mem_pin(addr, len);
+	void *const _addr = (void *)addr;
+
+	k_mem_pin(_addr, len);
 
 	return 0;
 }
 
 int munlock(const void *addr, size_t len)
 {
-	k_mem_unpin(addr, len);
+	void *const _addr = (void *)addr;
+
+	k_mem_unpin(_addr, len);
 
 	return 0;
 }


### PR DESCRIPTION
Fix a compile error because `k_mem_pin()` and `k_mem_unpin()` are not defined.

Forked from #83303