### PR TITLE
posix: options: mprotect: include toolchain header

### DIFF
--- a/lib/posix/options/mprotect.c
+++ b/lib/posix/options/mprotect.c
@@ -9,6 +9,7 @@
 #include <sys/types.h>
 
 #include <zephyr/posix/sys/mman.h>
+#include <zephyr/toolchain.h>
 
 int mprotect(void *addr, size_t len, int prot)
 {


### PR DESCRIPTION
`Include zephyr/toolchain.h` to get access to `ARG_UNUSED()`.

Forked from #83303