### PR TITLE
posix: options: mlockall: include toolchain header

### DIFF
--- a/lib/posix/options/mlockall.c
+++ b/lib/posix/options/mlockall.c
@@ -9,6 +9,7 @@
 #include <sys/types.h>
 
 #include <zephyr/posix/sys/mman.h>
+#include <zephyr/toolchain.h>
 
 int mlockall(int flags)
 {


### PR DESCRIPTION
Include the toolchain header because `ARG_UNUSED()` is not defined.

Forked from #83303