### PR TITLE
posix: options: mlock: refine imply for MMU and DEMAND_PAGING

### DIFF
--- a/lib/posix/options/Kconfig.mem
+++ b/lib/posix/options/Kconfig.mem
@@ -49,7 +49,7 @@ config POSIX_MEMLOCK
 
 config POSIX_MEMLOCK_RANGE
 	bool "POSIX range memory locking"
-	imply MMU
+	imply MMU if (CPU_HAS_MMU && ARCH_HAS_DEMAND_PAGING)
 	imply DEMAND_PAGING
 	help
 	  Select 'y' here and Zephyr will provide support for mlock() and munlock().

--- a/lib/posix/options/mlock.c
+++ b/lib/posix/options/mlock.c
@@ -13,18 +13,28 @@
 
 int mlock(const void *addr, size_t len)
 {
-	void *const _addr = (void *)addr;
+	if (IS_ENABLED(CONFIG_DEMAND_PAGING)) {
+		void *const _addr = (void *)addr;
 
-	k_mem_pin(_addr, len);
+		k_mem_pin(_addr, len);
 
-	return 0;
+		return 0;
+	}
+
+	errno = ENOTSUP;
+	return -1;
 }
 
 int munlock(const void *addr, size_t len)
 {
-	void *const _addr = (void *)addr;
+	if (IS_ENABLED(CONFIG_DEMAND_PAGING)) {
+		void *const _addr = (void *)addr;
 
-	k_mem_unpin(_addr, len);
+		k_mem_unpin(_addr, len);
 
-	return 0;
+		return 0;
+	}
+
+	errno = ENOTSUP;
+	return -1;
 }


### PR DESCRIPTION
POSIX mlock() and munlock() require an MMU as well as DEMAND_PAGING.

Forked from #83303