### PR TITLE
posix: options: mmap: disable xtensa support due to linker issue

### DIFF
--- a/lib/posix/options/Kconfig.mem
+++ b/lib/posix/options/Kconfig.mem
@@ -27,7 +27,8 @@ config POSIX_SHARED_MEMORY_OBJECTS
 
 config POSIX_MAPPED_FILES
 	bool "POSIX memory-mapped files"
-	imply MMU
+	# disable Xtensa for now until linker issues are resolved
+	imply MMU if (CPU_HAS_MMU && !XTENSA)
 	help
 	  Select 'y' here and Zephyr will provide support for mmap(), msync(), and munmap().
 


### PR DESCRIPTION
The Xtensa linker scripts seem to be injecting syntax errors when MMU is enabled. Disable the implication in Kconfig.mem for Xtensa until linker issues are resolved.

Forked from #83303