### PR TITLE
posix: options: mlock: do not enable for x86 with userspace

### DIFF
--- a/lib/posix/options/Kconfig.mem
+++ b/lib/posix/options/Kconfig.mem
@@ -49,7 +49,7 @@ config POSIX_MEMLOCK
 config POSIX_MEMLOCK_RANGE
 	bool "POSIX range memory locking"
 	imply MMU
-	imply DEMAND_PAGING
+	imply DEMAND_PAGING if !(X86 && !X86_64 && USERSPACE)
 	help
 	  Select 'y' here and Zephyr will provide support for mlock() and munlock().
 


### PR DESCRIPTION
Oddly, demand paging does not seem to work wth 32-bit x86 and userspace, so do not imply demand paging in that case.

Forked from #83303