### PR TITLE
demand_paging: use ram backend by default

### DIFF
--- a/subsys/demand_paging/backing_store/Kconfig
+++ b/subsys/demand_paging/backing_store/Kconfig
@@ -3,7 +3,7 @@
 
 choice BACKING_STORE_CHOICE
 	prompt "Backing store algorithms"
-	default BACKING_STORE_CUSTOM
+	default BACKING_STORE_RAM
 
 config BACKING_STORE_CUSTOM
 	bool "Custom backing store implementation"


### PR DESCRIPTION
In order to be functional and avoid linker errors, use a default setting for `BACKING_STORE_CHOICE` that is something other than "this is not implemented".

Forked from #83303