### PR TITLE
posix: features: define _POSIX_SUBPROFILE

### DIFF
--- a/include/zephyr/posix/posix_features.h
+++ b/include/zephyr/posix/posix_features.h
@@ -28,6 +28,11 @@
 #endif
 
 /*
+ * Subprofiling Considerations
+ */
+#define _POSIX_SUBPROFILE 1
+
+/*
  * POSIX System Interfaces
  */
 


### PR DESCRIPTION
As our implementations do not meet all of the requirements of a POSIX.1-conforming implementation.

See https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/V1_chap02.html#tag_02_01_05_02:

> Profiles shall require the definition of the macro _POSIX_SUBPROFILE in [<unistd.h>](https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/unistd.h.html) on implementations that do not meet all of the requirements of a POSIX.1-conforming implementation.