### PR TITLE
tests: arm_irq_vector_table: Disable bellboard for nRF54/nRF92

### DIFF
--- a/tests/arch/arm/arm_irq_vector_table/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/tests/arch/arm/arm_irq_vector_table/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&cpusec_cpuapp_ipc {
+	status = "disabled";
+};
+
+&cpusec_bellboard{
+	status = "disabled";
+};

--- a/tests/arch/arm/arm_irq_vector_table/boards/nrf54h20dk_nrf54h20_cpurad.overlay
+++ b/tests/arch/arm/arm_irq_vector_table/boards/nrf54h20dk_nrf54h20_cpurad.overlay
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&cpusec_cpurad_ipc {
+	status = "disabled";
+};
+
+&cpusec_bellboard{
+	status = "disabled";
+};

--- a/tests/arch/arm/arm_irq_vector_table/boards/nrf9280pdk_nrf9280_cpuapp.overlay
+++ b/tests/arch/arm/arm_irq_vector_table/boards/nrf9280pdk_nrf9280_cpuapp.overlay
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&cpusec_cpuapp_ipc {
+	status = "disabled";
+};
+
+&cpusec_bellboard{
+	status = "disabled";
+};

--- a/tests/arch/arm/arm_irq_vector_table/boards/nrf9280pdk_nrf9280_cpurad.overlay
+++ b/tests/arch/arm/arm_irq_vector_table/boards/nrf9280pdk_nrf9280_cpurad.overlay
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&cpusec_cpurad_ipc {
+	status = "disabled";
+};
+
+&cpusec_bellboard{
+	status = "disabled";
+};


### PR DESCRIPTION
This test uses the bellboard interrupts for the application and the radio core builds on nRF54H20 and nRF9280. Since it uses the bellboard interrupts it makes sense to ensure that bellboard is disabled in device tree to avoid runtime issues.

This is preparation work, bellboard is planned to be enabled by default later and this makes sure that the test will continue to work.