### PR TITLE
posix: features: correction on posix2 feature test macros

### DIFF
--- a/include/zephyr/posix/posix_features.h
+++ b/include/zephyr/posix/posix_features.h
@@ -201,9 +201,9 @@
 /*
  * POSIX2 Options
  */
-#define _POSIX2_VERSION _POSIX_VERSION
-#define _POSIX2_C_BIND  _POSIX2_VERSION
-#define _POSIX2_C_DEV   _POSIX2_VERSION
+/* #define _POSIX2_VERSION (-1) */
+#define _POSIX2_C_BIND _POSIX_VERSION
+/* #define _POSIX2_C_DEV (-1) */
 /* #define _POSIX2_CHAR_TERM (-1L) */
 /* #define _POSIX2_FORT_DEV (-1L) */
 /* #define _POSIX2_FORT_RUN (-1L) */

--- a/include/zephyr/posix/sys/sysconf.h
+++ b/include/zephyr/posix/sys/sysconf.h
@@ -233,7 +233,8 @@ enum {
 #define __z_posix_sysconf_SC_BC_SCALE_MAX                 _POSIX2_BC_SCALE_MAX
 #define __z_posix_sysconf_SC_BC_STRING_MAX                _POSIX2_BC_STRING_MAX
 #define __z_posix_sysconf_SC_2_C_BIND                     _POSIX2_C_BIND
-#define __z_posix_sysconf_SC_2_C_DEV                      _POSIX2_C_DEV
+#define __z_posix_sysconf_SC_2_C_DEV                                                               \
+	COND_CODE_1(_POSIX2_C_DEV > 0, (_POSIX2_C_DEV), (-1))
 #define __z_posix_sysconf_SC_2_CHAR_TERM                  (-1L)
 #define __z_posix_sysconf_SC_COLL_WEIGHTS_MAX             _POSIX2_COLL_WEIGHTS_MAX
 #define __z_posix_sysconf_SC_DELAYTIMER_MAX               _POSIX_DELAYTIMER_MAX
@@ -250,7 +251,8 @@ enum {
 #define __z_posix_sysconf_SC_2_PBS_TRACK                  (-1L)
 #define __z_posix_sysconf_SC_2_SW_DEV                     (-1L)
 #define __z_posix_sysconf_SC_2_UPE                        (-1L)
-#define __z_posix_sysconf_SC_2_VERSION                    _POSIX2_VERSION
+#define __z_posix_sysconf_SC_2_VERSION                                                             \
+	COND_CODE_1(_POSIX2_VERSION > 0, (_POSIX2_VERSION), (-1))
 #define __z_posix_sysconf_SC_XOPEN_CRYPT                  (-1L)
 #define __z_posix_sysconf_SC_XOPEN_ENH_I18N               (-1L)
 #define __z_posix_sysconf_SC_XOPEN_REALTIME               (-1L)


### PR DESCRIPTION
The `_POSIX2_VERSION` feature test macro should be either `-1` or left undefined on systems that do not have a POSIX conformant shell or utilities. Otherwise, it should be defined to the value `_POSIX_VERSION`.

Since Zephyr has neither a conformant shell nor utilities, leave `_POSIX2_VERSION` undefined.

Similarly, the `_POSIX2_C_DEV` macro should be either `-1` or left undefined if the implementation does not support the `c99`, `lex`, and `yacc` shell utilities. Otherwise it should be defined to the value `_POSIX_VERSION`.

Since Zephyr has none of those shell utilities, leave `_POSIX2_C_DEV` undefined.

Although `_POSIX2_C_BIND` appears to be related to the `_POSIX2` family of feature test macros, all it conveys is that the implementation supports POSIX C Language bindings, which is always the case if the implementation uses the C programming language, even if the implementation does not support a conformant shell and utilities. `_POSIX2_C_BIND` should be defined to the same value as `_POSIX_VERSION`.

Define `_POSIX2_C_BIND` as `_POSIX_VERSION` since Zephyr's implementation of the POSIX API supports C language bindings.

The information above comes from the "unistd.h" page in the spec and also through word search of the term "C-Language Development Utilities".

https://pubs.opengroup.org/onlinepubs/9699919799/index.html