### PR TITLE
manifest: update hal_microchip version include PIC32CX

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -188,7 +188,7 @@ manifest:
       groups:
         - hal
     - name: hal_microchip
-      revision: 71eba057c0cb7fc11b6f33eb40a82f1ebe2c571c
+      revision: fa2431a906ffb560160d40739d7cf04169551103
       path: modules/hal/microchip
       groups:
         - hal


### PR DESCRIPTION
Update the version of external hal_microchip that now includes the PIC32CX family.