### PR TITLE
west: runners: add option 'v' prefix to OpenOCD version string

### DIFF
--- a/scripts/west_commands/runners/openocd.py
+++ b/scripts/west_commands/runners/openocd.py
@@ -222,7 +222,7 @@ class OpenOcdBinaryRunner(ZephyrBinaryRunner):
         out = self.check_output([self.openocd_cmd[0], '--version'],
                                 stderr=subprocess.STDOUT).decode()
 
-        version_match = re.search(r"Open On-Chip Debugger (\d+.\d+.\d+)", out)
+        version_match = re.search(r"Open On-Chip Debugger v?(\d+.\d+.\d+)", out)
         version = version_match.group(1).split('.')
 
         return [to_num(i) for i in version]


### PR DESCRIPTION
The Espressif branch of OpenOCD uses the version string "v0.12.0" instead of "0.12.0" causing the version regex match to fail.

Add an optional 'v' prefix to avoid the failure.

Fixes: #83373