### PR TITLE
fs: allow mounting filesystems at /

### DIFF
--- a/subsys/fs/fs.c
+++ b/subsys/fs/fs.c
@@ -686,7 +686,7 @@ int fs_mount(struct fs_mount_t *mp)
 
 	len = strlen(mp->mnt_point);
 
-	if ((len <= 1) || (mp->mnt_point[0] != '/')) {
+	if ((len == 0) || (mp->mnt_point[0] != '/')) {
 		LOG_ERR("invalid mount point!!");
 		return -EINVAL;
 	}


### PR DESCRIPTION
Previously, filesystems could not be mounted at '/' because mount points were restricted to being at least 2 characters.

Since '/' corresponds to the standard POSIX root filesystem location, reduce the minimum length of a mount point to 1 character.

With that, we can mount a POSIX root filesystem.

Forked from #83368