### PR TITLE
dts: atm: atmel: samx7x: remove #address-cells/#size-cells from usbhs

### DIFF
--- a/dts/arm/atmel/samx7x.dtsi
+++ b/dts/arm/atmel/samx7x.dtsi
@@ -310,8 +310,6 @@
 
 		usbhs: usbd@40038000 {
 			compatible = "atmel,sam-usbhs";
-			#address-cells = <1>;
-			#size-cells = <0>;
 			reg = <0x40038000 0x4000>;
 			interrupts = <34 0>;
 			interrupt-names = "usbhs";


### PR DESCRIPTION
Remove unnecessary #address-cells/#size-cells from the usbhs devicetree node.

This removes the following build warning:
```
zephyr/build/zephyr/zephyr.dts:325.37-339.5:
  Warning (avoid_unnecessary_addr_size): /soc/usbd@40038000: unnecessary
  #address-cells/#size-cells without "ranges" or child "reg" property
```