### PR TITLE
include: zephyr: sys: Introduce IS_BIT_SET() macro

### DIFF
--- a/drivers/dai/intel/ssp/ssp.c
+++ b/drivers/dai/intel/ssp/ssp.c
@@ -864,7 +864,7 @@ static void dai_ssp_program_channel_map(struct dai_intel_ssp *dp,
 	 /* Set upper slot number from configuration */
 	pcmsycm = pcmsycm | (dp->ssp_plat_data->params.tdm_slots - 1) << 4;
 
-	if (DAI_INTEL_SSP_IS_BIT_SET(cfg->link_config, 15)) {
+	if (IS_BIT_SET(cfg->link_config, 15)) {
 		uint32_t reg_add = dai_ip_base(dp) + 0x1000 * ssp_index + PCMS0CM_OFFSET;
 		/* Program HDA output stream parameters */
 		sys_write16((pcmsycm & 0xffff), reg_add);
@@ -880,7 +880,7 @@ static void dai_ssp_program_channel_map(struct dai_intel_ssp *dp,
 	uint16_t pcmsycm = cfg->link_config;
 	uint8_t slot_count = 0;
 
-	if (DAI_INTEL_SSP_IS_BIT_SET(cfg->link_config, 15)) {
+	if (IS_BIT_SET(cfg->link_config, 15)) {
 		if (blob30->version == SSP_BLOB_VER_3_0) {
 			time_slot_map =
 				blob30->i2s_ssp_config.ssmidytsa[cfg->tdm_slot_group];

--- a/drivers/dai/intel/ssp/ssp.h
+++ b/drivers/dai/intel/ssp/ssp.h
@@ -39,7 +39,6 @@
 	(((x) & (1ULL << (b))) >> (b))
 #define DAI_INTEL_SSP_GET_BITS(b_hi, b_lo, x) \
 	(((x) & MASK(b_hi, b_lo)) >> (b_lo))
-#define DAI_INTEL_SSP_IS_BIT_SET(reg, bit)	(((reg >> bit) & (0x1)) != 0)
 
 /* ssp_freq array constants */
 #define DAI_INTEL_SSP_NUM_FREQ			3

--- a/drivers/mm/mm_drv_intel_adsp.h
+++ b/drivers/mm/mm_drv_intel_adsp.h
@@ -55,7 +55,6 @@
 #define MAX_EBB_BANKS_IN_SEGMENT	32
 #define SRAM_BANK_SIZE				(128 * 1024)
 #define L2_SRAM_BANK_NUM			(L2_SRAM_SIZE / SRAM_BANK_SIZE)
-#define IS_BIT_SET(value, idx)		((value) & (1 << (idx)))
 
 /**
  * Calculate TLB entry based on physical address.

--- a/include/zephyr/sys/util_macro.h
+++ b/include/zephyr/sys/util_macro.h
@@ -93,6 +93,14 @@ extern "C" {
  */
 #define IS_BIT_MASK(m) IS_SHIFTED_BIT_MASK(m, 0)
 
+/**
+ * @brief Check if bit is set in a value
+ *
+ * @param value Value that contain checked bit
+ * @param bit Bit number
+ */
+#define IS_BIT_SET(value, bit) ((((value) >> (bit)) & (0x1)) != 0)
+
 /** @brief Extract the Least Significant Bit from @p value. */
 #define LSB_GET(value) ((value) & -(value))
 

--- a/soc/nuvoton/npcx/common/reg/reg_access.h
+++ b/soc/nuvoton/npcx/common/reg/reg_access.h
@@ -10,7 +10,6 @@
 /*
  * NPCX register bit/field access operations
  */
-#define IS_BIT_SET(reg, bit)        (((reg >> bit) & (0x1)) != 0)
 
 #define GET_POS_FIELD(pos, size)    pos
 #define GET_SIZE_FIELD(pos, size)   size

--- a/subsys/net/lib/shell/http.c
+++ b/subsys/net/lib/shell/http.c
@@ -12,8 +12,7 @@ LOG_MODULE_DECLARE(net_shell);
 #include <zephyr/net/http/server.h>
 #include <zephyr/net/http/method.h>
 #include <zephyr/net/http/parser.h>
-
-#define IS_BIT_SET(val, bit) (((val >> bit) & (0x1)) != 0)
+#include <zephyr/sys/util.h>
 
 static int cmd_net_http(const struct shell *sh, size_t argc, char *argv[])
 {


### PR DESCRIPTION
This PR provides one definition of IS_BIT_SET() in util_macro.h and removes all other definitions.

This macro is defined in a few places which leads to macro redefinition error e.g. when compiling prometheus network sample for NPCX boards, see #81548.