### PR TITLE
ci: twister: define llvm toolchain path

### DIFF
--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -50,6 +50,7 @@ jobs:
       PUSH_OPTIONS: ' --clobber-output -M --show-footprint --report-filtered'
       COMMIT_RANGE: ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}
       BASE_REF: ${{ github.base_ref }}
+      LLVM_TOOLCHAIN_PATH: /usr/lib/llvm-16
     steps:
       - name: Print cloud service information
         run: |


### PR DESCRIPTION
Twister can now build using llvm, so define the toolchain path.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
