### PR TITLE
dts: arm: atmel: samx7x.dtsi: sort devicetree nodes according to address

### DIFF
--- a/dts/arm/atmel/samx7x.dtsi
+++ b/dts/arm/atmel/samx7x.dtsi
@@ -45,44 +45,73 @@
 	};
 
 	soc {
-		pmc: pmc@400e0600 {
-			compatible = "atmel,sam-pmc";
-			reg = <0x400e0600 0x200>;
-			interrupts = <5 0>;
-			#clock-cells = <2>;
-			status = "okay";
+		ssc: ssc@40004000 {
+			compatible = "atmel,sam-ssc";
+			reg = <0x40004000 0x4000>;
+			interrupts = <22 0>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 22>;
+			status = "disabled";
 		};
 
-		supc: supc@400e1810 {
-			compatible = "atmel,sam-supc";
-			reg = <0x400e1810 0x20>;
-			#wakeup-source-id-cells = <1>;
-			status = "okay";
-		};
-
-		eefc: flash-controller@400e0c00 {
-			compatible = "atmel,sam-flash-controller";
-			reg = <0x400e0c00 0x200>;
-			interrupts = <6 0>;
-			clocks = <&pmc PMC_TYPE_PERIPHERAL 6>;
-
+		spi0: spi@40008000 {
+			compatible = "atmel,sam-spi";
 			#address-cells = <1>;
-			#size-cells = <1>;
-			#erase-block-cells = <2>;
+			#size-cells = <0>;
+			reg = <0x40008000 0x4000>;
+			interrupts = <21 0>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 21>;
+			status = "disabled";
+		};
 
-			flash0: flash@400000 {
-				compatible = "atmel,sam-flash", "soc-nv-flash";
-				write-block-size = <16>;
-				erase-block-size = <8192>;
+		tc0: tc@4000c000 {
+			compatible = "atmel,sam-tc";
+			reg = <0x4000c000 0x100>;
+			interrupts = <23 0
+				      24 0
+				      25 0>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 23>,
+				 <&pmc PMC_TYPE_PERIPHERAL 24>,
+				 <&pmc PMC_TYPE_PERIPHERAL 25>;
+			status = "disabled";
+
+			qdec {
+				compatible = "atmel,sam-tc-qdec";
+				status = "disabled";
 			};
 		};
 
-		wdt: watchdog@400e1850 {
-			compatible = "atmel,sam-watchdog";
-			reg = <0x400e1850 0xc>;
-			interrupts = <4 0>;
-			clocks = <&pmc PMC_TYPE_PERIPHERAL 4>;
+		tc1: tc@40010000 {
+			compatible = "atmel,sam-tc";
+			reg = <0x40010000 0x100>;
+			interrupts = <26 0
+				      27 0
+				      28 0>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 26>,
+				 <&pmc PMC_TYPE_PERIPHERAL 27>,
+				 <&pmc PMC_TYPE_PERIPHERAL 28>;
 			status = "disabled";
+
+			qdec {
+				compatible = "atmel,sam-tc-qdec";
+				status = "disabled";
+			};
+		};
+
+		tc2: tc@40014000 {
+			compatible = "atmel,sam-tc";
+			reg = <0x40014000 0x100>;
+			interrupts = <47 0
+				      48 0
+				      49 0>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 47>,
+				 <&pmc PMC_TYPE_PERIPHERAL 48>,
+				 <&pmc PMC_TYPE_PERIPHERAL 49>;
+			status = "disabled";
+
+			qdec {
+				compatible = "atmel,sam-tc-qdec";
+				status = "disabled";
+			};
 		};
 
 		twihs0: i2c@40018000 {
@@ -107,75 +136,15 @@
 			status = "disabled";
 		};
 
-		twihs2: i2c@40060000 {
-			compatible = "atmel,sam-i2c-twihs";
-			clock-frequency = <I2C_BITRATE_STANDARD>;
-			#address-cells = <1>;
-			#size-cells = <0>;
-			reg = <0x40060000 0x12B>;
-			interrupts = <41 0>;
-			clocks = <&pmc PMC_TYPE_PERIPHERAL 41>;
+		pwm0: pwm0@40020000 {
+			compatible = "atmel,sam-pwm";
+			reg = <0x40020000 0x4000>;
+			interrupts = <31 0>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 31>;
 			status = "disabled";
-		};
-
-		spi0: spi@40008000 {
-			compatible = "atmel,sam-spi";
-			#address-cells = <1>;
-			#size-cells = <0>;
-			reg = <0x40008000 0x4000>;
-			interrupts = <21 0>;
-			clocks = <&pmc PMC_TYPE_PERIPHERAL 21>;
-			status = "disabled";
-		};
-
-		spi1: spi@40058000 {
-			compatible = "atmel,sam-spi";
-			#address-cells = <1>;
-			#size-cells = <0>;
-			reg = <0x40058000 0x4000>;
-			interrupts = <42 0>;
-			clocks = <&pmc PMC_TYPE_PERIPHERAL 42>;
-			status = "disabled";
-		};
-
-		uart0: uart@400e0800 {
-			compatible = "atmel,sam-uart";
-			reg = <0x400e0800 0x100>;
-			interrupts = <7 1>;
-			clocks = <&pmc PMC_TYPE_PERIPHERAL 7>;
-			status = "disabled";
-		};
-
-		uart1: uart@400e0a00 {
-			compatible = "atmel,sam-uart";
-			reg = <0x400e0a00 0x100>;
-			interrupts = <8 1>;
-			clocks = <&pmc PMC_TYPE_PERIPHERAL 8>;
-			status = "disabled";
-		};
-
-		uart2: uart@400e1a00 {
-			compatible = "atmel,sam-uart";
-			reg = <0x400e1a00 0x100>;
-			interrupts = <44 1>;
-			clocks = <&pmc PMC_TYPE_PERIPHERAL 44>;
-			status = "disabled";
-		};
-
-		uart3: uart@400e1c00 {
-			compatible = "atmel,sam-uart";
-			reg = <0x400e1c00 0x100>;
-			interrupts = <45 1>;
-			clocks = <&pmc PMC_TYPE_PERIPHERAL 45>;
-			status = "disabled";
-		};
-
-		uart4: uart@400e1e00 {
-			compatible = "atmel,sam-uart";
-			reg = <0x400e1e00 0x100>;
-			interrupts = <46 1>;
-			clocks = <&pmc PMC_TYPE_PERIPHERAL 46>;
-			status = "disabled";
+			prescaler = <10>;
+			divider = <1>;
+			#pwm-cells = <3>;
 		};
 
 		usart0: usart@40024000 {
@@ -202,20 +171,46 @@
 			status = "disabled";
 		};
 
+		can0: can@40030000 {
+			compatible = "atmel,sam-can";
+			reg = <0x40030000 0x100>, <0x40088110 0x04>;
+			reg-names = "m_can", "dma_base";
+			interrupts = <35 0>, <36 0>;
+			interrupt-names = "int0", "int1";
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 35>;
+			divider = <6>;
+			bosch,mram-cfg = <0x0 28 8 3 3 0 1 1>;
+			status = "disabled";
+		};
+
+		can1: can@40034000 {
+			compatible = "atmel,sam-can";
+			reg = <0x40034000 0x100>, <0x40088114 0x4>;
+			reg-names = "m_can", "dma_base";
+			interrupts = <37 0>, <38 0>;
+			interrupt-names = "int0", "int1";
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 37>;
+			divider = <6>;
+			bosch,mram-cfg = <0x0 28 8 3 3 0 1 1>;
+			status = "disabled";
+		};
+
+		usbhs: usbd@40038000 {
+			compatible = "atmel,sam-usbhs";
+			reg = <0x40038000 0x4000>;
+			interrupts = <34 0>;
+			interrupt-names = "usbhs";
+			maximum-speed = "high-speed";
+			num-bidir-endpoints = <10>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 34>;
+			status = "disabled";
+		};
+
 		afec0: adc@4003c000 {
 			compatible = "atmel,sam-afec";
 			reg = <0x4003c000 0x100>;
 			interrupts = <29 0>;
 			clocks = <&pmc PMC_TYPE_PERIPHERAL 29>;
-			status = "disabled";
-			#io-channel-cells = <1>;
-		};
-
-		afec1: adc@40064000 {
-			compatible = "atmel,sam-afec";
-			reg = <0x40064000 0x100>;
-			interrupts = <40 0>;
-			clocks = <&pmc PMC_TYPE_PERIPHERAL 40>;
 			status = "disabled";
 			#io-channel-cells = <1>;
 		};
@@ -227,6 +222,142 @@
 			clocks = <&pmc PMC_TYPE_PERIPHERAL 30>;
 			status = "disabled";
 			#io-channel-cells = <1>;
+		};
+
+		gmac: ethernet@40050000 {
+			compatible = "atmel,sam-gmac";
+			reg = <0x40050000 0x4000>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 39>;
+			interrupts = <39 0>, <66 0>, <67 0>;
+			interrupt-names = "gmac", "q1", "q2";
+			num-queues = <3>;
+			local-mac-address = [00 00 00 00 00 00];
+			status = "disabled";
+		};
+
+		mdio: mdio@40050000 {
+			compatible = "atmel,sam-mdio";
+			reg = <0x40050000 0x4000>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 39>;
+			status = "disabled";
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+
+		tc3: tc@40054000 {
+			compatible = "atmel,sam-tc";
+			reg = <0x40054000 0x100>;
+			interrupts = <50 0
+				      51 0
+				      52 0>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 50>,
+				 <&pmc PMC_TYPE_PERIPHERAL 51>,
+				 <&pmc PMC_TYPE_PERIPHERAL 52>;
+			status = "disabled";
+
+			qdec {
+				compatible = "atmel,sam-tc-qdec";
+				status = "disabled";
+			};
+		};
+
+		spi1: spi@40058000 {
+			compatible = "atmel,sam-spi";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x40058000 0x4000>;
+			interrupts = <42 0>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 42>;
+			status = "disabled";
+		};
+
+		pwm1: pwm1@4005c000 {
+			compatible = "atmel,sam-pwm";
+			reg = <0x4005c000 0x4000>;
+			interrupts = <60 0>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 60>;
+			status = "disabled";
+			prescaler = <10>;
+			divider = <1>;
+			#pwm-cells = <3>;
+		};
+
+		twihs2: i2c@40060000 {
+			compatible = "atmel,sam-i2c-twihs";
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x40060000 0x12B>;
+			interrupts = <41 0>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 41>;
+			status = "disabled";
+		};
+
+		afec1: adc@40064000 {
+			compatible = "atmel,sam-afec";
+			reg = <0x40064000 0x100>;
+			interrupts = <40 0>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 40>;
+			status = "disabled";
+			#io-channel-cells = <1>;
+		};
+
+		trng: random@40070000 {
+			compatible = "atmel,sam-trng";
+			reg = <0x40070000 0x4000>;
+			interrupts = <57 0>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 57>;
+			status = "okay";
+		};
+
+		xdmac: dma0: dma-controller@40078000 {
+			compatible = "atmel,sam-xdmac";
+			reg = <0x40078000 0x400>;
+			interrupts = <58 0>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 58>;
+			#dma-cells = <2>;
+			status = "disabled";
+		};
+
+		pmc: pmc@400e0600 {
+			compatible = "atmel,sam-pmc";
+			reg = <0x400e0600 0x200>;
+			interrupts = <5 0>;
+			#clock-cells = <2>;
+			status = "okay";
+		};
+
+		uart0: uart@400e0800 {
+			compatible = "atmel,sam-uart";
+			reg = <0x400e0800 0x100>;
+			interrupts = <7 1>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 7>;
+			status = "disabled";
+		};
+
+		uart1: uart@400e0a00 {
+			compatible = "atmel,sam-uart";
+			reg = <0x400e0a00 0x100>;
+			interrupts = <8 1>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 8>;
+			status = "disabled";
+		};
+
+		eefc: flash-controller@400e0c00 {
+			compatible = "atmel,sam-flash-controller";
+			reg = <0x400e0c00 0x200>;
+			interrupts = <6 0>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 6>;
+
+			#address-cells = <1>;
+			#size-cells = <1>;
+			#erase-block-cells = <2>;
+
+			flash0: flash@400000 {
+				compatible = "atmel,sam-flash", "soc-nv-flash";
+				write-block-size = <16>;
+				erase-block-size = <8192>;
+			};
 		};
 
 		pinctrl: pinctrl@400e0e00 {
@@ -286,181 +417,26 @@
 			};
 		};
 
-		pwm0: pwm0@40020000 {
-			compatible = "atmel,sam-pwm";
-			reg = <0x40020000 0x4000>;
-			interrupts = <31 0>;
-			clocks = <&pmc PMC_TYPE_PERIPHERAL 31>;
-			status = "disabled";
-			prescaler = <10>;
-			divider = <1>;
-			#pwm-cells = <3>;
-		};
-
-		pwm1: pwm1@4005c000 {
-			compatible = "atmel,sam-pwm";
-			reg = <0x4005c000 0x4000>;
-			interrupts = <60 0>;
-			clocks = <&pmc PMC_TYPE_PERIPHERAL 60>;
-			status = "disabled";
-			prescaler = <10>;
-			divider = <1>;
-			#pwm-cells = <3>;
-		};
-
-		usbhs: usbd@40038000 {
-			compatible = "atmel,sam-usbhs";
-			reg = <0x40038000 0x4000>;
-			interrupts = <34 0>;
-			interrupt-names = "usbhs";
-			maximum-speed = "high-speed";
-			num-bidir-endpoints = <10>;
-			clocks = <&pmc PMC_TYPE_PERIPHERAL 34>;
-			status = "disabled";
-		};
-
-		gmac: ethernet@40050000 {
-			compatible = "atmel,sam-gmac";
-			reg = <0x40050000 0x4000>;
-			clocks = <&pmc PMC_TYPE_PERIPHERAL 39>;
-			interrupts = <39 0>, <66 0>, <67 0>;
-			interrupt-names = "gmac", "q1", "q2";
-			num-queues = <3>;
-			local-mac-address = [00 00 00 00 00 00];
-			status = "disabled";
-		};
-
-		mdio: mdio@40050000 {
-			compatible = "atmel,sam-mdio";
-			reg = <0x40050000 0x4000>;
-			clocks = <&pmc PMC_TYPE_PERIPHERAL 39>;
-			status = "disabled";
-			#address-cells = <1>;
-			#size-cells = <0>;
-		};
-
-		tc0: tc@4000c000 {
-			compatible = "atmel,sam-tc";
-			reg = <0x4000c000 0x100>;
-			interrupts = <23 0
-				      24 0
-				      25 0>;
-			clocks = <&pmc PMC_TYPE_PERIPHERAL 23>,
-				 <&pmc PMC_TYPE_PERIPHERAL 24>,
-				 <&pmc PMC_TYPE_PERIPHERAL 25>;
-			status = "disabled";
-
-			qdec {
-				compatible = "atmel,sam-tc-qdec";
-				status = "disabled";
-			};
-		};
-
-		tc1: tc@40010000 {
-			compatible = "atmel,sam-tc";
-			reg = <0x40010000 0x100>;
-			interrupts = <26 0
-				      27 0
-				      28 0>;
-			clocks = <&pmc PMC_TYPE_PERIPHERAL 26>,
-				 <&pmc PMC_TYPE_PERIPHERAL 27>,
-				 <&pmc PMC_TYPE_PERIPHERAL 28>;
-			status = "disabled";
-
-			qdec {
-				compatible = "atmel,sam-tc-qdec";
-				status = "disabled";
-			};
-		};
-
-		tc2: tc@40014000 {
-			compatible = "atmel,sam-tc";
-			reg = <0x40014000 0x100>;
-			interrupts = <47 0
-				      48 0
-				      49 0>;
-			clocks = <&pmc PMC_TYPE_PERIPHERAL 47>,
-				 <&pmc PMC_TYPE_PERIPHERAL 48>,
-				 <&pmc PMC_TYPE_PERIPHERAL 49>;
-			status = "disabled";
-
-			qdec {
-				compatible = "atmel,sam-tc-qdec";
-				status = "disabled";
-			};
-		};
-
-		tc3: tc@40054000 {
-			compatible = "atmel,sam-tc";
-			reg = <0x40054000 0x100>;
-			interrupts = <50 0
-				      51 0
-				      52 0>;
-			clocks = <&pmc PMC_TYPE_PERIPHERAL 50>,
-				 <&pmc PMC_TYPE_PERIPHERAL 51>,
-				 <&pmc PMC_TYPE_PERIPHERAL 52>;
-			status = "disabled";
-
-			qdec {
-				compatible = "atmel,sam-tc-qdec";
-				status = "disabled";
-			};
-		};
-
-		trng: random@40070000 {
-			compatible = "atmel,sam-trng";
-			reg = <0x40070000 0x4000>;
-			interrupts = <57 0>;
-			clocks = <&pmc PMC_TYPE_PERIPHERAL 57>;
-			status = "okay";
-		};
-
-		xdmac: dma0: dma-controller@40078000 {
-			compatible = "atmel,sam-xdmac";
-			reg = <0x40078000 0x400>;
-			interrupts = <58 0>;
-			clocks = <&pmc PMC_TYPE_PERIPHERAL 58>;
-			#dma-cells = <2>;
-			status = "disabled";
-		};
-
-		ssc: ssc@40004000 {
-			compatible = "atmel,sam-ssc";
-			reg = <0x40004000 0x4000>;
-			interrupts = <22 0>;
-			clocks = <&pmc PMC_TYPE_PERIPHERAL 22>;
-			status = "disabled";
-		};
-
-		can0: can@40030000 {
-			compatible = "atmel,sam-can";
-			reg = <0x40030000 0x100>, <0x40088110 0x04>;
-			reg-names = "m_can", "dma_base";
-			interrupts = <35 0>, <36 0>;
-			interrupt-names = "int0", "int1";
-			clocks = <&pmc PMC_TYPE_PERIPHERAL 35>;
-			divider = <6>;
-			bosch,mram-cfg = <0x0 28 8 3 3 0 1 1>;
-			status = "disabled";
-		};
-
-		can1: can@40034000 {
-			compatible = "atmel,sam-can";
-			reg = <0x40034000 0x100>, <0x40088114 0x4>;
-			reg-names = "m_can", "dma_base";
-			interrupts = <37 0>, <38 0>;
-			interrupt-names = "int0", "int1";
-			clocks = <&pmc PMC_TYPE_PERIPHERAL 37>;
-			divider = <6>;
-			bosch,mram-cfg = <0x0 28 8 3 3 0 1 1>;
-			status = "disabled";
-		};
-
 		rstc: rstc@400e1800 {
 			compatible = "atmel,sam-rstc";
 			reg = <0x400e1800 0x10>;
 			clocks = <&pmc PMC_TYPE_PERIPHERAL 1>;
 			user-nrst;
+		};
+
+		supc: supc@400e1810 {
+			compatible = "atmel,sam-supc";
+			reg = <0x400e1810 0x20>;
+			#wakeup-source-id-cells = <1>;
+			status = "okay";
+		};
+
+		wdt: watchog@400e1850 {
+			compatible = "atmel,sam-watchdog";
+			reg = <0x400e1850 0xc>;
+			interrupts = <4 0>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 4>;
+			status = "disabled";
 		};
 
 		rtc: rtc@400e1860 {
@@ -469,6 +445,30 @@
 			interrupts = <2 0>;
 			clocks = <&pmc PMC_TYPE_PERIPHERAL 2>;
 			alarms-count = <1>;
+			status = "disabled";
+		};
+
+		uart2: uart@400e1a00 {
+			compatible = "atmel,sam-uart";
+			reg = <0x400e1a00 0x100>;
+			interrupts = <44 1>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 44>;
+			status = "disabled";
+		};
+
+		uart3: uart@400e1c00 {
+			compatible = "atmel,sam-uart";
+			reg = <0x400e1c00 0x100>;
+			interrupts = <45 1>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 45>;
+			status = "disabled";
+		};
+
+		uart4: uart@400e1e00 {
+			compatible = "atmel,sam-uart";
+			reg = <0x400e1e00 0x100>;
+			interrupts = <46 1>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 46>;
 			status = "disabled";
 		};
 	};


### PR DESCRIPTION
Sort the Atmel SAMx7x periheral devicetree nodes according to their address in the memory map.