### PR TITLE
llext-edk: rework, read data from `build_info.yml` and `.config`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1990,7 +1990,6 @@ if (CONFIG_LLEXT AND CONFIG_LLEXT_EXPORT_BUILTINS_BY_SLID)
     --elf-file ${PROJECT_BINARY_DIR}/${KERNEL_ELF_NAME}
     --slid-listing ${PROJECT_BINARY_DIR}/slid_listing.txt
   )
-
 endif()
 
 if(NOT CMAKE_C_COMPILER_ID STREQUAL "ARMClang")
@@ -2236,6 +2235,10 @@ list(APPEND llext_edk_cflags ${llext_filt_flags})
 list(APPEND llext_edk_cflags ${LLEXT_APPEND_FLAGS})
 list(APPEND llext_edk_cflags ${LLEXT_EDK_APPEND_FLAGS})
 
+build_info(llext-edk file PATH ${llext_edk_file})
+build_info(llext-edk cflags VALUE ${llext_edk_cflags})
+build_info(llext-edk include-dirs VALUE "$<TARGET_PROPERTY:zephyr_interface,INTERFACE_INCLUDE_DIRECTORIES>")
+
 add_custom_command(
     OUTPUT ${llext_edk_file}
     # Regenerate syscalls in case CONFIG_LLEXT_EDK_USERSPACE_ONLY
@@ -2252,17 +2255,8 @@ add_custom_command(
         ${SYSCALL_LONG_REGISTERS_ARG}
         ${SYSCALL_SPLIT_TIMEOUT_ARG}
     COMMAND ${CMAKE_COMMAND}
-        -DPROJECT_BINARY_DIR=${PROJECT_BINARY_DIR}
-        -DAPPLICATION_SOURCE_DIR=${APPLICATION_SOURCE_DIR}
-        -DINTERFACE_INCLUDE_DIRECTORIES="$<TARGET_PROPERTY:zephyr_interface,INTERFACE_INCLUDE_DIRECTORIES>"
-        -Dllext_edk_file=${llext_edk_file}
-        -Dllext_edk_cflags="${llext_edk_cflags}"
-        -Dllext_edk_name=${CONFIG_LLEXT_EDK_NAME}
-        -DWEST_TOPDIR=${WEST_TOPDIR}
-        -DZEPHYR_BASE=${ZEPHYR_BASE}
-        -DCONFIG_LLEXT_EDK_USERSPACE_ONLY=${CONFIG_LLEXT_EDK_USERSPACE_ONLY}
         -P ${ZEPHYR_BASE}/cmake/llext-edk.cmake
-    DEPENDS ${logical_target_for_zephyr_elf}
+    DEPENDS ${logical_target_for_zephyr_elf} build_info_yaml_saved
     COMMAND_EXPAND_LISTS
 )
 add_custom_target(llext-edk DEPENDS ${llext_edk_file})
@@ -2286,9 +2280,8 @@ add_subdirectory_ifdef(
 
 toolchain_linker_finalize()
 
-yaml_context(EXISTS NAME build_info result)
-if(result)
-  build_info(zephyr version VALUE ${PROJECT_VERSION_STR})
-  build_info(zephyr zephyr-base VALUE ${ZEPHYR_BASE})
-  yaml_save(NAME build_info)
-endif()
+# export build information
+build_info(zephyr version VALUE ${PROJECT_VERSION_STR})
+build_info(zephyr zephyr-base VALUE ${ZEPHYR_BASE})
+
+yaml_save(NAME build_info)

--- a/cmake/llext-edk.cmake
+++ b/cmake/llext-edk.cmake
@@ -30,14 +30,6 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-if (CONFIG_LLEXT_EXPORT_BUILTINS_BY_SLID)
-  message(FATAL_ERROR
-    "The LLEXT EDK is not compatible with CONFIG_LLEXT_EXPORT_BUILTINS_BY_SLID.")
-endif()
-
-set(llext_edk ${PROJECT_BINARY_DIR}/${llext_edk_name})
-set(llext_edk_inc ${llext_edk}/include)
-
 # Usage:
 #   relative_dir(<dir> <relative_out> <bindir_out>)
 #
@@ -88,6 +80,16 @@ function(relative_dir dir relative_out bindir_out)
         set(${bindir_out} FALSE PARENT_SCOPE)
     endif()
 endfunction()
+
+
+
+if (CONFIG_LLEXT_EXPORT_BUILTINS_BY_SLID)
+  message(FATAL_ERROR
+    "The LLEXT EDK is not compatible with CONFIG_LLEXT_EXPORT_BUILTINS_BY_SLID.")
+endif()
+
+set(llext_edk ${PROJECT_BINARY_DIR}/${llext_edk_name})
+set(llext_edk_inc ${llext_edk}/include)
 
 string(REGEX REPLACE "[^a-zA-Z0-9]" "_" llext_edk_name_sane ${llext_edk_name})
 string(TOUPPER ${llext_edk_name_sane} llext_edk_name_sane)

--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -3703,11 +3703,11 @@ function(topological_sort)
 endfunction()
 
 # Usage:
-#   build_info(<tag>... VALUE <value>... )
-#   build_info(<tag>... PATH  <path>... )
+#   build_info(<tag>... VALUE <value>...)
+#   build_info(<tag>... PATH  <path>...)
 #
-# This function populates updates the build_info.yml info file with exchangable build information
-# related to the current build.
+# This function populates the build_info.yml info file with exchangable build
+# information related to the current build.
 #
 # Example:
 #   build_info(devicetree files VALUE file1.dts file2.dts file3.dts)
@@ -3735,6 +3735,14 @@ function(build_info)
 
   if(index EQUAL -1)
     message(FATAL_ERROR "${CMAKE_CURRENT_FUNCTION}(...) missing a required argument: VALUE or PATH")
+  endif()
+
+  string(GENEX_STRIP "${arg_list}" arg_list_no_genexes)
+  if (NOT "${arg_list}" STREQUAL "${arg_list_no_genexes}")
+    if (convert_path)
+      message(FATAL_ERROR "build_info: generator expressions unsupported on PATH entries")
+    endif()
+    set(genex_flag GENEX)
   endif()
 
   yaml_context(EXISTS NAME build_info result)
@@ -3779,7 +3787,7 @@ function(build_info)
     endif()
   endif()
 
-  yaml_set(NAME build_info KEY cmake ${keys} ${type} "${values}")
+  yaml_set(NAME build_info KEY cmake ${keys} ${type} "${values}" ${genex_flag})
 endfunction()
 
 ########################################################

--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -5905,7 +5905,7 @@ endfunction()
 # depending on the exact use of the function in script mode.
 #
 # Current Zephyr CMake scripts which includes `extensions.cmake` in script mode
-# are: package_helper.cmake, verify-toolchain.cmake
+# are: package_helper.cmake, verify-toolchain.cmake, llext-edk.cmake
 #
 
 if(CMAKE_SCRIPT_MODE_FILE)

--- a/cmake/modules/yaml.cmake
+++ b/cmake/modules/yaml.cmake
@@ -476,9 +476,7 @@ function(yaml_save)
     set_property(TARGET ${save_target} PROPERTY json_file ${json_file})
 
     # comment this to keep the temporary JSON files
-    get_property(temp_files TARGET ${save_target} PROPERTY temp_files)
-    list(APPEND temp_files ${json_file})
-    set_property(TARGET ${save_target} PROPERTY temp_files ${temp_files})
+    set_property(TARGET ${save_target} APPEND PROPERTY temp_files ${json_file})
 
     FILE(GENERATE OUTPUT ${json_file}
       CONTENT "${json_content}"

--- a/scripts/schemas/build-schema.yml
+++ b/scripts/schemas/build-schema.yml
@@ -71,6 +71,19 @@ mapping:
             type: seq
             sequence:
               - type: str
+      llext-edk:
+        type: map
+        mapping:
+          cflags:
+            type: seq
+            sequence:
+              - type: str
+          file:
+            type: str
+          include-dirs:
+            type: seq
+            sequence:
+              - type: str
       sysbuild:
         type: bool
       toolchain:


### PR DESCRIPTION
This PR improves the LLEXT EDK in several ways:
* an internal rework to reduce code duplication and improve extensibility
* read existing data from the current build artifacts, instead of using arguments

It is effectively a subset of #78727 that does not add any new information to the LLEXT EDK. 