### PR TITLE
maintainers: add uLipe as collaborator on the OpenAMP

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3142,6 +3142,8 @@ Open AMP:
   status: maintained
   maintainers:
     - carlocaione
+  collaborators:
+    - uLipe
   files:
     - lib/open-amp/
     - samples/subsys/ipc/openamp/
@@ -5191,6 +5193,7 @@ West:
   status: odd fixes
   collaborators:
     - carlocaione
+    - uLipe
   files:
     - modules/Kconfig.open-amp
   labels:


### PR DESCRIPTION
Adding uLipe as collaborator to suplement the reviewers for the OpenAMP related modules and stuff since I have interest on contributing there and I had previous experience as OpenAMP / OpenAMP System References contributor, He also deals with some driver level contributions that gets consumed by OpenAMP code like: IVSHMEM IPM and MBOX drivers, and ESP32 AMP support.

Additionally, currently these modules is only being maintained by a single person, and having other collaborator may help on review cycles.