### PR TITLE
posix: pin init functions and data for demand paging

### DIFF
--- a/lib/posix/options/barrier.c
+++ b/lib/posix/options/barrier.c
@@ -19,7 +19,9 @@ struct posix_barrier {
 	uint32_t count;
 };
 
+__pinned_bss
 static struct posix_barrier posix_barrier_pool[CONFIG_MAX_PTHREAD_BARRIER_COUNT];
+
 SYS_BITARRAY_DEFINE_STATIC(posix_barrier_bitarray, CONFIG_MAX_PTHREAD_BARRIER_COUNT);
 
 /*
@@ -195,6 +197,7 @@ int pthread_barrierattr_destroy(pthread_barrierattr_t *attr)
 	return 0;
 }
 
+__boot_func
 static int pthread_barrier_pool_init(void)
 {
 	int err;

--- a/lib/posix/options/cond.c
+++ b/lib/posix/options/cond.c
@@ -17,7 +17,9 @@ LOG_MODULE_REGISTER(pthread_cond, CONFIG_PTHREAD_COND_LOG_LEVEL);
 
 int64_t timespec_to_timeoutms(const struct timespec *abstime);
 
+__pinned_bss
 static struct k_condvar posix_cond_pool[CONFIG_MAX_PTHREAD_COND_COUNT];
+
 SYS_BITARRAY_DEFINE_STATIC(posix_cond_bitarray, CONFIG_MAX_PTHREAD_COND_COUNT);
 
 /*
@@ -209,6 +211,7 @@ int pthread_cond_destroy(pthread_cond_t *cvar)
 	return 0;
 }
 
+__boot_func
 static int pthread_cond_pool_init(void)
 {
 	int err;

--- a/lib/posix/options/mutex.c
+++ b/lib/posix/options/mutex.c
@@ -29,7 +29,9 @@ static const struct pthread_mutexattr def_attr = {
 	.type = PTHREAD_MUTEX_DEFAULT,
 };
 
+__pinned_bss
 static struct k_mutex posix_mutex_pool[CONFIG_MAX_PTHREAD_MUTEX_COUNT];
+
 static uint8_t posix_mutex_type[CONFIG_MAX_PTHREAD_MUTEX_COUNT];
 SYS_BITARRAY_DEFINE_STATIC(posix_mutex_bitarray, CONFIG_MAX_PTHREAD_MUTEX_COUNT);
 
@@ -451,6 +453,7 @@ int pthread_mutexattr_setprioceiling(pthread_mutexattr_t *attr, int prioceiling)
 
 #endif /* CONFIG_POSIX_THREAD_PRIO_PROTECT */
 
+__boot_func
 static int pthread_mutex_pool_init(void)
 {
 	int err;

--- a/lib/posix/options/pthread.c
+++ b/lib/posix/options/pthread.c
@@ -83,12 +83,17 @@ BUILD_ASSERT(CONFIG_POSIX_PTHREAD_ATTR_STACKSIZE_BITS + CONFIG_POSIX_PTHREAD_ATT
 
 int64_t timespec_to_timeoutms(const struct timespec *abstime);
 static void posix_thread_recycle(void);
+
+__pinned_data
 static sys_dlist_t posix_thread_q[] = {
 	SYS_DLIST_STATIC_INIT(&posix_thread_q[POSIX_THREAD_READY_Q]),
 	SYS_DLIST_STATIC_INIT(&posix_thread_q[POSIX_THREAD_RUN_Q]),
 	SYS_DLIST_STATIC_INIT(&posix_thread_q[POSIX_THREAD_DONE_Q]),
 };
+
+__pinned_bss
 static struct posix_thread posix_thread_pool[CONFIG_MAX_PTHREAD_COUNT];
+
 static SYS_SEM_DEFINE(pthread_pool_lock, 1, 1);
 static int pthread_concurrency;
 
@@ -1536,6 +1541,7 @@ int pthread_sigmask(int how, const sigset_t *ZRESTRICT set, sigset_t *ZRESTRICT 
 	return ret;
 }
 
+__boot_func
 static int posix_thread_pool_init(void)
 {
 	ARRAY_FOR_EACH_PTR(posix_thread_pool, th) {


### PR DESCRIPTION
Boot time initialization functions and data used there must be available at boot. With demand paging, these may not exist in memory when they are being used, resulting in page faults. So pin these functions and data in linker sections to make sure they are in memory at boot time.