### PR TITLE
submanifests: optional: Update zephyr-lang-rust

### DIFF
--- a/submanifests/optional.yaml
+++ b/submanifests/optional.yaml
@@ -60,7 +60,7 @@ manifest:
       groups:
         - optional
     - name: zephyr-lang-rust
-      revision: 7af3db47bf7335ac6a6fe7480df6b41fb46dbe9d
+      revision: f82407c13059528e88bfcc892a488504e9caa80c
       path: modules/lang/rust
       remote: upstream
       groups:


### PR DESCRIPTION
Move to the latest version:

    commit f82407c13059528e88bfcc892a488504e9caa80c
    Author: David Brown <david.brown@linaro.org>
    Date:   Thu Jan 16 17:05:59 2025 -0700

This brings in numerous features to the rust support including:

  - Simple logging through Zephyr's logging
  - Mutex/Condvar (k_mutex, k_condvar), Semaphores (k_sem), and Queue
    (k_queue)
  - A rust interface to timers, both waiting for events and callback based
  - A SpinMutex that protects data in a rust safe way using a spinlock
  - Some documentation for the rust support.  Documentation is generated,
    per-pr, on the module to allow preview
  - A dining philosopher sample that implements using several different
    mechanism.
  - Basic device support.  The device tree is imported into Rust, with a
    yaml file describing the association between DT nodes and devices.
  - Basic interface to GPIO and flash devices.

Signed-off-by: David Brown <david.brown@linaro.org>

 submanifests/optional.yaml | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
