### PR TITLE
Changes MPU region alignment to 128 when FPU_SHARING and MPU_STACK_GUARD

### DIFF
--- a/arch/arm/core/mpu/Kconfig
+++ b/arch/arm/core/mpu/Kconfig
@@ -47,6 +47,7 @@ config ARM_MPU
 config ARM_MPU_REGION_MIN_ALIGN_AND_SIZE
 	int
 	default 256 if ARM_MPU && ARMV6_M_ARMV8_M_BASELINE && !ARMV8_M_BASELINE
+	default 128 if ARM_MPU && FPU_SHARING && MPU_STACK_GUARD
 	default 64 if ARM_MPU && AARCH32_ARMV8_R
 	default 32 if ARM_MPU
 	default 4


### PR DESCRIPTION
Changes ARM_MPU_REGION_MIN_ALIGN_AND_SIZE to 128 if ARM_MPU && FPU_SHARING && MPU_STACK_GUARD

Fixes: #83714

Signed-off-by: Maciej Kusio <rysiof@gmail.com>