### PR TITLE
arch: arm: cortex_m: Consolidate bss/noinit sections for kernel/user mode

### DIFF
--- a/include/zephyr/arch/arm/cortex_m/scripts/linker.ld
+++ b/include/zephyr/arch/arm/cortex_m/scripts/linker.ld
@@ -277,35 +277,6 @@ SECTIONS
 
 	_app_smem_size = _app_smem_end - _app_smem_start;
 	_app_smem_rom_start = LOADADDR(_APP_SMEM_SECTION_NAME);
-
-    SECTION_DATA_PROLOGUE(_BSS_SECTION_NAME,(NOLOAD),)
-	{
-        /*
-         * For performance, BSS section is assumed to be 4 byte aligned and
-         * a multiple of 4 bytes
-         */
-        . = ALIGN(4);
-	__bss_start = .;
-	__kernel_ram_start = .;
-
-	*(.bss)
-	*(".bss.*")
-	*(COMMON)
-	*(".kernel_bss.*")
-
-#ifdef CONFIG_CODE_DATA_RELOCATION
-#include <linker_sram_bss_relocate.ld>
-#endif
-
-        /*
-         * As memory is cleared in words only, it is simpler to ensure the BSS
-         * section ends on a 4 byte boundary. This wastes a maximum of 3 bytes.
-		 */
-	__bss_end = ALIGN(4);
-	} GROUP_DATA_LINK_IN(RAMABLE_REGION, RAMABLE_REGION)
-
-#include <zephyr/linker/common-noinit.ld>
-
 #endif  /* CONFIG_USERSPACE */
 
     GROUP_START(DATA_REGION)
@@ -449,8 +420,7 @@ SECTION_PROLOGUE(.last_section,,)
  * calculate this value here. */
 _flash_used = LOADADDR(.last_section) + SIZEOF(.last_section) - __rom_region_start;
 
-#ifndef CONFIG_USERSPACE
-   SECTION_DATA_PROLOGUE(_BSS_SECTION_NAME,(NOLOAD),)
+    SECTION_DATA_PROLOGUE(_BSS_SECTION_NAME,(NOLOAD),)
 	{
         /*
          * For performance, BSS section is assumed to be 4 byte aligned and
@@ -476,23 +446,7 @@ _flash_used = LOADADDR(.last_section) + SIZEOF(.last_section) - __rom_region_sta
 	__bss_end = ALIGN(4);
 	} GROUP_DATA_LINK_IN(RAMABLE_REGION, RAMABLE_REGION)
 
-    SECTION_PROLOGUE(_NOINIT_SECTION_NAME,(NOLOAD),)
-        {
-        /*
-         * This section is used for non-initialized objects that
-         * will not be cleared during the boot process.
-         */
-        *(.noinit)
-        *(".noinit.*")
-	*(".kernel_noinit.*")
-
-/* Located in generated directory. This file is populated by the
- * zephyr_linker_sources() Cmake function.
- */
-#include <snippets-noinit.ld>
-
-        } GROUP_NOLOAD_LINK_IN(RAMABLE_REGION, RAMABLE_REGION)
-#endif /* CONFIG_USERSPACE */
+#include <zephyr/linker/common-noinit.ld>
 
     /* Define linker symbols */
 


### PR DESCRIPTION
Userspace originally required bss to precede kobject_data, as kobject_data size was not known until the final linking stage (#21747).

#33687 reserved space for kobject_data, allowing bss to now be after kobject_data.

Placing bss/noinit at the end of the linker script reduces the size of a "zephyr.bin" file, as the NOLOAD sections can be excluded. It also keeps the code common between kernel/user mode

---

@tejlmand as discussed here: https://github.com/zephyrproject-rtos/zephyr/pull/74042#issuecomment-2538812642