### PR TITLE
alder lake: Add missing intel,x86_64 compat

### DIFF
--- a/dts/x86/intel/alder_lake.dtsi
+++ b/dts/x86/intel/alder_lake.dtsi
@@ -25,7 +25,7 @@
 
 		cpu@1 {
 			device_type = "cpu";
-			compatible = "intel,alder-lake";
+			compatible = "intel,alder-lake", "intel,x86_64";
 			d-cache-line-size = <64>;
 			reg = <1>;
 		};


### PR DESCRIPTION
Second core doesn't have `intel,x86_64` compat, this commit adds it.