### PR TITLE
net: pkt: Clone all needed attributes

### DIFF
--- a/subsys/net/ip/net_pkt.c
+++ b/subsys/net/ip/net_pkt.c
@@ -2068,15 +2068,24 @@ static void clone_pkt_attributes(struct net_pkt *pkt, struct net_pkt *clone_pkt)
 	net_pkt_set_captured(clone_pkt, net_pkt_is_captured(pkt));
 	net_pkt_set_eof(clone_pkt, net_pkt_eof(pkt));
 	net_pkt_set_ptp(clone_pkt, net_pkt_is_ptp(pkt));
+	net_pkt_set_ppp(clone_pkt, net_pkt_is_ppp(pkt));
+	net_pkt_set_lldp(clone_pkt, net_pkt_is_lldp(pkt));
+	net_pkt_set_ipv4_acd(clone_pkt, net_pkt_ipv4_acd(pkt));
 	net_pkt_set_tx_timestamping(clone_pkt, net_pkt_is_tx_timestamping(pkt));
 	net_pkt_set_rx_timestamping(clone_pkt, net_pkt_is_rx_timestamping(pkt));
 	net_pkt_set_forwarding(clone_pkt, net_pkt_forwarding(pkt));
 	net_pkt_set_chksum_done(clone_pkt, net_pkt_is_chksum_done(pkt));
 	net_pkt_set_ip_reassembled(pkt, net_pkt_is_ip_reassembled(pkt));
-
+	net_pkt_set_cooked_mode(clone_pkt, net_pkt_is_cooked_mode(pkt));
+	net_pkt_set_ipv4_pmtu(clone_pkt, net_pkt_ipv4_pmtu(pkt));
 	net_pkt_set_l2_bridged(clone_pkt, net_pkt_is_l2_bridged(pkt));
 	net_pkt_set_l2_processed(clone_pkt, net_pkt_is_l2_processed(pkt));
 	net_pkt_set_ll_proto_type(clone_pkt, net_pkt_ll_proto_type(pkt));
+
+#if defined(CONFIG_NET_OFFLOAD) || defined(CONFIG_NET_L2_IPIP)
+	net_pkt_set_remote_address(clone_pkt, net_pkt_remote_address(pkt),
+				   sizeof(struct sockaddr_storage));
+#endif
 
 	if (pkt->buffer && clone_pkt->buffer) {
 		memcpy(net_pkt_lladdr_src(clone_pkt), net_pkt_lladdr_src(pkt),


### PR DESCRIPTION
The net_pkt_clone() did not cloned all needed fields. Added what was missing from the clone.

Fixes #83157