### PR TITLE
Sample: i2c rtio loopback: add nrf board overlays

### DIFF
--- a/drivers/i2c/i2c_nrfx_twim_rtio.c
+++ b/drivers/i2c/i2c_nrfx_twim_rtio.c
@@ -74,7 +74,8 @@ static bool i2c_nrfx_twim_rtio_start(const struct device *dev)
 			sqe->tx.buf = config->common.msg_buf;
 		}
 		return i2c_nrfx_twim_rtio_msg_start(dev, I2C_MSG_WRITE | sqe->iodev_flags,
-						    sqe->tx.buf, sqe->tx.buf_len, dt_spec->addr);
+						    (uint8_t *)sqe->tx.buf, sqe->tx.buf_len,
+						    dt_spec->addr);
 	case RTIO_OP_I2C_CONFIGURE:
 		(void)i2c_nrfx_twim_configure(dev, sqe->i2c_config);
 		return false;

--- a/samples/drivers/i2c/rtio_loopback/boards/nrf5340dk_nrf5340_cpuapp.conf
+++ b/samples/drivers/i2c/rtio_loopback/boards/nrf5340dk_nrf5340_cpuapp.conf
@@ -1,0 +1,4 @@
+# Copyright (c) 2024 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_I2C_TARGET_BUFFER_MODE=y

--- a/samples/drivers/i2c/rtio_loopback/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/samples/drivers/i2c/rtio_loopback/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * SDA = P0.26 and P1.2
+ * SCL = P0.25 and P1.3
+ */
+
+/ {
+	aliases {
+		i2c-controller = &i2c1;
+		i2c-controller-target = &i2c2;
+	};
+};
+
+&pinctrl {
+	i2c2_default: i2c2_default {
+		group1 {
+			psels = <NRF_PSEL(TWIS_SDA, 0, 26)>,
+				<NRF_PSEL(TWIS_SCL, 0, 25)>;
+			bias-pull-up;
+		};
+	};
+
+	i2c2_sleep: i2c2_sleep {
+		group1 {
+			psels = <NRF_PSEL(TWIS_SDA, 0, 26)>,
+				<NRF_PSEL(TWIS_SCL, 0, 25)>;
+			low-power-enable;
+		};
+	};
+};
+
+&i2c2 {
+	compatible = "nordic,nrf-twis";
+	pinctrl-0 = <&i2c2_default>;
+	pinctrl-1 = <&i2c2_sleep>;
+	pinctrl-names = "default", "sleep";
+	status = "okay";
+};

--- a/samples/drivers/i2c/rtio_loopback/boards/nrf54l15dk_nrf54l15_cpuapp.conf
+++ b/samples/drivers/i2c/rtio_loopback/boards/nrf54l15dk_nrf54l15_cpuapp.conf
@@ -1,0 +1,4 @@
+# Copyright (c) 2024 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_I2C_NRFX_TWIS_BUF_SIZE=256

--- a/samples/drivers/i2c/rtio_loopback/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/samples/drivers/i2c/rtio_loopback/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * SDA = P1.8 and P1.9
+ * SCL = P1.10 and P1.11
+ */
+
+/ {
+	aliases {
+		i2c-controller = &i2c21;
+		i2c-controller-target = &i2c22;
+	};
+};
+
+&pinctrl {
+	i2c21_default: i2c21_default {
+		group1 {
+			psels = <NRF_PSEL(TWIS_SDA, 1, 8)>,
+				<NRF_PSEL(TWIS_SCL, 1, 10)>;
+			bias-pull-up;
+		};
+	};
+
+	i2c21_sleep: i2c21_sleep {
+		group1 {
+			psels = <NRF_PSEL(TWIS_SDA, 1, 8)>,
+				<NRF_PSEL(TWIS_SCL, 1, 10)>;
+			low-power-enable;
+		};
+	};
+
+	i2c22_default: i2c22_default {
+		group1 {
+			psels = <NRF_PSEL(TWIS_SDA, 1, 9)>,
+				<NRF_PSEL(TWIS_SCL, 1, 11)>;
+			bias-pull-up;
+		};
+	};
+
+	i2c22_sleep: i2c22_sleep {
+		group1 {
+			psels = <NRF_PSEL(TWIS_SDA, 1, 9)>,
+				<NRF_PSEL(TWIS_SCL, 1, 11)>;
+			low-power-enable;
+		};
+	};
+};
+
+&i2c21 {
+	pinctrl-0 = <&i2c21_default>;
+	pinctrl-1 = <&i2c21_sleep>;
+	pinctrl-names = "default", "sleep";
+	zephyr,concat-buf-size = <256>;
+	status = "okay";
+};
+
+&i2c22 {
+	compatible = "nordic,nrf-twis";
+	pinctrl-0 = <&i2c22_default>;
+	pinctrl-1 = <&i2c22_sleep>;
+	pinctrl-names = "default", "sleep";
+	status = "okay";
+};

--- a/samples/drivers/i2c/rtio_loopback/sample.yaml
+++ b/samples/drivers/i2c/rtio_loopback/sample.yaml
@@ -7,3 +7,5 @@ tests:
       - i2c_target
     platform_allow:
       - b_u585i_iot02a
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp


### PR DESCRIPTION
Add overlays for nrf boards to the I2C RTIO loopback sample along with a typecast required for the TWIM RTIO driver to suppress a const to non-const cast warning (our SDK driver reuses non-const buffer pointers for both TX and RX)