### PR TITLE
MAINTAINERS: llext: add `tests/misc/llext-edk/` to the `llext` area

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -5544,6 +5544,7 @@ zbus:
     - cmake/llext-edk.cmake
     - samples/subsys/llext/
     - include/zephyr/llext/
+    - tests/misc/llext-edk/
     - tests/subsys/llext/
     - subsys/llext/
     - doc/services/llext/


### PR DESCRIPTION
The LLEXT Extension Development Kit, mostly implemented in `cmake/llext-edk.cmake`, is already part of the `llext` area of the MAINTAINERS file, but its test is currently unowned: in #83661 I had to manually set assignee and reviewers.

Add the missing directory to the `llext` area.

cc @teburd 