### PR TITLE
cmake: modules: Prefer imgtool being in MCUboot directory

### DIFF
--- a/cmake/mcuboot.cmake
+++ b/cmake/mcuboot.cmake
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2023 Nordic Semiconductor ASA
+# Copyright (c) 2020-2025 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
 # This file includes extra build system logic that is enabled when
@@ -52,23 +52,8 @@ function(zephyr_mcuboot_tasks)
     endif()
   endforeach()
 
-  # Find imgtool. Even though west is installed, imgtool might not be.
-  # The user may also have a custom manifest which doesn't include
-  # MCUboot.
-  #
-  # Therefore, go with an explicitly installed imgtool first, falling
-  # back on mcuboot/scripts/imgtool.py.
-  if(IMGTOOL)
-    set(imgtool_path "${IMGTOOL}")
-  elseif(DEFINED ZEPHYR_MCUBOOT_MODULE_DIR)
-    set(IMGTOOL_PY "${ZEPHYR_MCUBOOT_MODULE_DIR}/scripts/imgtool.py")
-    if(EXISTS "${IMGTOOL_PY}")
-      set(imgtool_path "${IMGTOOL_PY}")
-    endif()
-  endif()
-
   # No imgtool, no signed binaries.
-  if(NOT DEFINED imgtool_path)
+  if(NOT DEFINED IMGTOOL)
     message(FATAL_ERROR "Can't sign images for MCUboot: can't find imgtool. To fix, install imgtool with pip3, or add the mcuboot repository to the west manifest and ensure it has a scripts/imgtool.py file.")
     return()
   endif()
@@ -94,7 +79,7 @@ function(zephyr_mcuboot_tasks)
   endif()
 
   # Basic 'imgtool sign' command with known image information.
-  set(imgtool_sign ${PYTHON_EXECUTABLE} ${imgtool_path} sign
+  set(imgtool_sign ${PYTHON_EXECUTABLE} ${IMGTOOL} sign
       --version ${CONFIG_MCUBOOT_IMGTOOL_SIGN_VERSION} --header-size ${CONFIG_ROM_START_OFFSET}
       --slot-size ${slot_size})
 

--- a/cmake/modules/FindHostTools.cmake
+++ b/cmake/modules/FindHostTools.cmake
@@ -61,9 +61,10 @@ find_program(OPENOCD openocd)
 # bossac is an optional dependency
 find_program(BOSSAC bossac)
 
-# imgtool is an optional dependency (the build may also fall back to scripts/imgtool.py
-# in the mcuboot repository if that's present in some cases)
-find_program(IMGTOOL imgtool)
+# imgtool is an optional dependency (prefer the version that is in the mcuboot repository, if
+# present and a user has not specified a different version)
+zephyr_get(IMGTOOL SYSBUILD LOCAL)
+find_program(IMGTOOL imgtool.py HINTS ${ZEPHYR_MCUBOOT_MODULE_DIR}/scripts/ NAMES imgtool NAMES_PER_DIR)
 
 # winpty is an optional dependency
 find_program(PTY_INTERFACE winpty)


### PR DESCRIPTION
Changes the priority of imgtool so that the preferred version is the one inside of the MCUboot directory