### PR TITLE
llext: fix minor Coverity issue #434586 (again)

### DIFF
--- a/subsys/llext/llext_link.c
+++ b/subsys/llext/llext_link.c
@@ -188,7 +188,7 @@ static void llext_link_plt(struct llext_loader *ldr, struct llext *ext, elf_shdr
 			ret = llext_read(ldr, &sym, sizeof(sym));
 		}
 
-		if (ret < 0) {
+		if (ret != 0) {
 			LOG_ERR("PLT: failed to read symbol table #%u RELA #%u, trying to continue",
 				j, i);
 			continue;


### PR DESCRIPTION
The check combination of "is zero" and then "less than zero" leaves open the theoretical possibility of a positive return value, which would continue on with an uinitialized `sym`.

Checking for "not zero" has the same effect and covers all situations.

Commit 56fd85442 did the same thing for `rela` a few lines above, but missed this instance. 
No other places in the llext code have this issue.