### PR TITLE
kernel: Streamline z_is_thread_ready()

### DIFF
--- a/kernel/include/kthread.h
+++ b/kernel/include/kthread.h
@@ -108,8 +108,7 @@ static inline bool z_is_thread_timeout_active(struct k_thread *thread)
 
 static inline bool z_is_thread_ready(struct k_thread *thread)
 {
-	return !((z_is_thread_prevented_from_running(thread)) != 0U ||
-		 z_is_thread_timeout_active(thread));
+	return !z_is_thread_prevented_from_running(thread);
 }
 
 static inline bool z_is_thread_state_set(struct k_thread *thread, uint32_t state)

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -1164,9 +1164,9 @@ void z_impl_k_wakeup(k_tid_t thread)
 {
 	SYS_PORT_TRACING_OBJ_FUNC(k_thread, wakeup, thread);
 
-	z_abort_thread_timeout(thread);
-
 	k_spinlock_key_t  key = k_spin_lock(&_sched_spinlock);
+
+	z_abort_thread_timeout(thread);
 
 	if (!z_is_thread_sleeping(thread)) {
 		k_spin_unlock(&_sched_spinlock, key);

--- a/kernel/timeout.c
+++ b/kernel/timeout.c
@@ -16,6 +16,10 @@ static uint64_t curr_tick;
 
 static sys_dlist_t timeout_list = SYS_DLIST_STATIC_INIT(&timeout_list);
 
+/*
+ * The timeout code shall take no locks other than its own (timeout_lock), nor
+ * shall it call any other subsystem while holding this lock.
+ */
 static struct k_spinlock timeout_lock;
 
 #define MAX_WAIT (IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) \


### PR DESCRIPTION
The check for an active timeout in z_is_thread_ready() was originally added to cover the case of a sleeping thread. However, since there is now a bit in the thread state that indicates if the thread is sleeping we can drop that superfluous check. (This improves the thread_metric preemptive benchmark performance by about 1.3 %)

Making this change necessitates moving k_wakeup()'s call to z_abort_thread_timeout() so that it is within the locked _sched_spinlock section to ensure that we do not end up with a stray thread timeout in the timeout list.