### PR TITLE
tests: Bluetooth: Audio: Use ext adv for all connectable adv

### DIFF
--- a/tests/bsim/bluetooth/audio/src/bap_broadcast_sink_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_broadcast_sink_test.c
@@ -59,7 +59,6 @@ static uint32_t broadcaster_broadcast_id;
 static struct audio_test_stream broadcast_sink_streams[CONFIG_BT_BAP_BROADCAST_SNK_STREAM_COUNT];
 static struct bt_bap_stream *streams[ARRAY_SIZE(broadcast_sink_streams)];
 static uint32_t requested_bis_sync;
-static struct bt_le_ext_adv *ext_adv;
 static const struct bt_bap_scan_delegator_recv_state *req_recv_state;
 static uint8_t recv_state_broadcast_code[BT_ISO_BROADCAST_CODE_SIZE];
 
@@ -897,39 +896,6 @@ static void test_broadcast_delete_inval(void)
 	}
 }
 
-static void test_start_adv(void)
-{
-	const struct bt_data ad[] = {
-		BT_DATA_BYTES(BT_DATA_FLAGS, (BT_LE_AD_GENERAL | BT_LE_AD_NO_BREDR)),
-		BT_DATA_BYTES(BT_DATA_UUID16_ALL, BT_UUID_16_ENCODE(BT_UUID_BASS_VAL),
-			      BT_UUID_16_ENCODE(BT_UUID_PACS_VAL)),
-		BT_DATA_BYTES(BT_DATA_SVC_DATA16, BT_UUID_16_ENCODE(BT_UUID_BASS_VAL)),
-	};
-	int err;
-
-	/* Create a connectable advertising set */
-	err = bt_le_ext_adv_create(BT_LE_EXT_ADV_CONN, NULL, &ext_adv);
-	if (err != 0) {
-		FAIL("Failed to create advertising set (err %d)\n", err);
-
-		return;
-	}
-
-	err = bt_le_ext_adv_set_data(ext_adv, ad, ARRAY_SIZE(ad), NULL, 0);
-	if (err != 0) {
-		FAIL("Failed to set advertising data (err %d)\n", err);
-
-		return;
-	}
-
-	err = bt_le_ext_adv_start(ext_adv, BT_LE_EXT_ADV_START_DEFAULT);
-	if (err != 0) {
-		FAIL("Failed to start advertising set (err %d)\n", err);
-
-		return;
-	}
-}
-
 static void test_common(void)
 {
 	int err;
@@ -1144,6 +1110,7 @@ static void test_sink_encrypted_incorrect_code(void)
 
 static void broadcast_sink_with_assistant(void)
 {
+	struct bt_le_ext_adv *ext_adv;
 	int err;
 
 	err = init();
@@ -1152,7 +1119,7 @@ static void broadcast_sink_with_assistant(void)
 		return;
 	}
 
-	test_start_adv();
+	setup_connectable_adv(&ext_adv);
 	WAIT_FOR_FLAG(flag_connected);
 
 	printk("Waiting for PA sync request\n");
@@ -1200,6 +1167,7 @@ static void broadcast_sink_with_assistant(void)
 
 static void broadcast_sink_with_assistant_incorrect_code(void)
 {
+	struct bt_le_ext_adv *ext_adv;
 	int err;
 
 	err = init();
@@ -1208,7 +1176,7 @@ static void broadcast_sink_with_assistant_incorrect_code(void)
 		return;
 	}
 
-	test_start_adv();
+	setup_connectable_adv(&ext_adv);
 	WAIT_FOR_FLAG(flag_connected);
 
 	printk("Waiting for PA sync request\n");

--- a/tests/bsim/bluetooth/audio/src/bap_scan_delegator_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_scan_delegator_test.c
@@ -691,6 +691,7 @@ static void sync_all_broadcasts(void)
 
 static int common_init(void)
 {
+	struct bt_le_ext_adv *ext_adv;
 	int err;
 
 	err = bt_enable(NULL);
@@ -709,13 +710,7 @@ static int common_init(void)
 
 	bt_le_per_adv_sync_cb_register(&pa_sync_cb);
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_1, ad, AD_SIZE, NULL, 0);
-	if (err) {
-		FAIL("Advertising failed to start (err %d)\n", err);
-		return err;
-	}
-
-	printk("Advertising successfully started\n");
+	setup_connectable_adv(&ext_adv);
 
 	WAIT_FOR_FLAG(flag_connected);
 

--- a/tests/bsim/bluetooth/audio/src/bap_unicast_server_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_unicast_server_test.c
@@ -70,19 +70,6 @@ static struct audio_test_stream
 static const struct bt_bap_qos_cfg_pref qos_pref =
 	BT_BAP_QOS_CFG_PREF(true, BT_GAP_LE_PHY_2M, 0x02, 10, 40000, 40000, 40000, 40000);
 
-static uint8_t unicast_server_addata[] = {
-	BT_UUID_16_ENCODE(BT_UUID_ASCS_VAL),    /* ASCS UUID */
-	BT_AUDIO_UNICAST_ANNOUNCEMENT_TARGETED, /* Target Announcement */
-	BT_BYTES_LIST_LE16(PREF_CONTEXT),
-	BT_BYTES_LIST_LE16(PREF_CONTEXT),
-	0x00, /* Metadata length */
-};
-
-static const struct bt_data unicast_server_ad[] = {
-	BT_DATA_BYTES(BT_DATA_FLAGS, (BT_LE_AD_GENERAL | BT_LE_AD_NO_BREDR)),
-	BT_DATA_BYTES(BT_DATA_UUID16_ALL, BT_UUID_16_ENCODE(BT_UUID_ASCS_VAL)),
-	BT_DATA(BT_DATA_SVC_DATA16, unicast_server_addata, ARRAY_SIZE(unicast_server_addata)),
-};
 static struct bt_le_ext_adv *ext_adv;
 
 CREATE_FLAG(flag_stream_configured);
@@ -460,26 +447,7 @@ static void init(void)
 					  &stream_ops);
 	}
 
-	/* Create a connectable advertising set */
-	err = bt_le_ext_adv_create(BT_LE_EXT_ADV_CONN, NULL, &ext_adv);
-	if (err != 0) {
-		FAIL("Failed to create advertising set (err %d)\n", err);
-		return;
-	}
-
-	err = bt_le_ext_adv_set_data(ext_adv, unicast_server_ad, ARRAY_SIZE(unicast_server_ad),
-				     NULL, 0);
-	if (err != 0) {
-		FAIL("Failed to set advertising data (err %d)\n", err);
-		return;
-	}
-
-	err = bt_le_ext_adv_start(ext_adv, BT_LE_EXT_ADV_START_DEFAULT);
-	if (err != 0) {
-		FAIL("Failed to start advertising set (err %d)\n", err);
-		return;
-	}
-	printk("Advertising started\n");
+	setup_connectable_adv(&ext_adv);
 }
 
 static void test_main(void)
@@ -540,22 +508,7 @@ static void test_main_acl_disconnect(void)
 	 * bt_conn object is properly unref'ed by the stack
 	 */
 	for (size_t i = 0U; i < ARRAY_SIZE(dummy_ext_adv); i++) {
-		const struct bt_le_adv_param param = BT_LE_ADV_PARAM_INIT(
-			(BT_LE_ADV_OPT_EXT_ADV | BT_LE_ADV_OPT_CONN), BT_GAP_ADV_SLOW_INT_MAX,
-			BT_GAP_ADV_SLOW_INT_MAX, NULL);
-		int err;
-
-		err = bt_le_ext_adv_create(&param, NULL, &dummy_ext_adv[i]);
-		if (err != 0) {
-			FAIL("Failed to create advertising set[%zu] (err %d)\n", i, err);
-			return;
-		}
-
-		err = bt_le_ext_adv_start(dummy_ext_adv[i], BT_LE_EXT_ADV_START_DEFAULT);
-		if (err != 0) {
-			FAIL("Failed to start advertising set[%zu] (err %d)\n", i, err);
-			return;
-		}
+		setup_connectable_adv(&dummy_ext_adv[i]);
 	}
 
 	bt_conn_cb_register(&conn_callbacks);

--- a/tests/bsim/bluetooth/audio/src/common.h
+++ b/tests/bsim/bluetooth/audio/src/common.h
@@ -17,6 +17,7 @@
 #include <zephyr/bluetooth/audio/audio.h>
 #include <zephyr/bluetooth/audio/bap.h>
 #include <zephyr/bluetooth/audio/cap.h>
+#include <zephyr/bluetooth/audio/csip.h>
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/bluetooth/conn.h>
@@ -26,6 +27,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/sys/atomic_types.h>
 #include <zephyr/sys/util.h>
+#include <zephyr/sys/util_macro.h>
 #include <zephyr/sys_clock.h>
 #include <zephyr/types.h>
 
@@ -102,23 +104,37 @@ extern enum bst_result_t bst_result;
 		bs_trace_info_time(1, "PASSED: " __VA_ARGS__); \
 	} while (0)
 
-#define AD_SIZE 1
-
 #define PA_SYNC_INTERVAL_TO_TIMEOUT_RATIO 20 /* Set the timeout relative to interval */
 #define PA_SYNC_SKIP         5
 
 #define PBP_STREAMS_TO_SEND 2
 
+#define SINK_CONTEXT                                                                               \
+	(BT_AUDIO_CONTEXT_TYPE_UNSPECIFIED | BT_AUDIO_CONTEXT_TYPE_MEDIA |                         \
+	 BT_AUDIO_CONTEXT_TYPE_CONVERSATIONAL)
+#define SOURCE_CONTEXT                                                                             \
+	(BT_AUDIO_CONTEXT_TYPE_UNSPECIFIED | BT_AUDIO_CONTEXT_TYPE_CONVERSATIONAL |                \
+	 BT_AUDIO_CONTEXT_TYPE_NOTIFICATIONS)
+
+#define TMAP_ROLE_SUPPORTED                                                                        \
+	((IS_ENABLED(CONFIG_BT_TMAP_CG_SUPPORTED) ? BT_TMAP_ROLE_CG : 0U) |                        \
+	 (IS_ENABLED(CONFIG_BT_TMAP_CT_SUPPORTED) ? BT_TMAP_ROLE_CT : 0U) |                        \
+	 (IS_ENABLED(CONFIG_BT_TMAP_UMS_SUPPORTED) ? BT_TMAP_ROLE_UMS : 0U) |                      \
+	 (IS_ENABLED(CONFIG_BT_TMAP_UMR_SUPPORTED) ? BT_TMAP_ROLE_UMR : 0U) |                      \
+	 (IS_ENABLED(CONFIG_BT_TMAP_BMS_SUPPORTED) ? BT_TMAP_ROLE_BMS : 0U) |                      \
+	 (IS_ENABLED(CONFIG_BT_TMAP_BMR_SUPPORTED) ? BT_TMAP_ROLE_BMR : 0U))
+
 extern struct bt_le_scan_cb common_scan_cb;
-extern const struct bt_data ad[AD_SIZE];
 extern struct bt_conn *default_conn;
 extern atomic_t flag_connected;
 extern atomic_t flag_disconnected;
 extern atomic_t flag_conn_updated;
 extern atomic_t flag_audio_received;
 extern volatile bt_security_t security_level;
+extern uint8_t csip_rsi[BT_CSIP_RSI_SIZE];
 
 void disconnected(struct bt_conn *conn, uint8_t reason);
+void setup_connectable_adv(struct bt_le_ext_adv **ext_adv);
 void test_tick(bs_time_t HW_device_time);
 void test_init(void);
 uint16_t get_dev_cnt(void);

--- a/tests/bsim/bluetooth/audio/src/csip_set_member_test.c
+++ b/tests/bsim/bluetooth/audio/src/csip_set_member_test.c
@@ -53,11 +53,7 @@ static struct bt_csip_set_member_cb csip_cbs = {
 
 static void bt_ready(int err)
 {
-	uint8_t rsi[BT_CSIP_RSI_SIZE];
-	struct bt_data ad[] = {
-		BT_DATA_BYTES(BT_DATA_FLAGS, (BT_LE_AD_GENERAL | BT_LE_AD_NO_BREDR)),
-		BT_CSIP_DATA_RSI(rsi),
-	};
+	struct bt_le_ext_adv *ext_adv;
 
 	if (err != 0) {
 		FAIL("Bluetooth init failed (err %d)\n", err);
@@ -74,16 +70,13 @@ static void bt_ready(int err)
 		return;
 	}
 
-	err = bt_csip_set_member_generate_rsi(svc_inst, rsi);
+	err = bt_csip_set_member_generate_rsi(svc_inst, csip_rsi);
 	if (err != 0) {
 		FAIL("Failed to generate RSI (err %d)\n", err);
 		return;
 	}
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_1, ad, ARRAY_SIZE(ad), NULL, 0);
-	if (err != 0) {
-		FAIL("Advertising failed to start (err %d)\n", err);
-	}
+	setup_connectable_adv(&ext_adv);
 }
 
 static void test_sirk(void)

--- a/tests/bsim/bluetooth/audio/src/gmap_ugt_test.c
+++ b/tests/bsim/bluetooth/audio/src/gmap_ugt_test.c
@@ -88,12 +88,6 @@ static struct bt_bap_stream_ops unicast_stream_ops = {
 	.started = unicast_stream_started_cb,
 };
 
-/* TODO: Expand with GMAP service data */
-static const struct bt_data gmap_acceptor_ad[] = {
-	BT_DATA_BYTES(BT_DATA_FLAGS, (BT_LE_AD_GENERAL | BT_LE_AD_NO_BREDR)),
-	BT_DATA_BYTES(BT_DATA_UUID16_ALL, BT_UUID_16_ENCODE(BT_UUID_CAS_VAL)),
-};
-
 static struct bt_csip_set_member_svc_inst *csip_set_member;
 
 static struct bt_bap_stream *unicast_stream_alloc(void)
@@ -368,6 +362,7 @@ static void test_main(void)
 	static struct bt_pacs_cap unicast_cap = {
 		.codec_cap = &codec_cap,
 	};
+	struct bt_le_ext_adv *ext_adv;
 	int err;
 
 	err = bt_enable(NULL);
@@ -445,12 +440,7 @@ static void test_main(void)
 		return;
 	}
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_1, gmap_acceptor_ad, ARRAY_SIZE(gmap_acceptor_ad),
-			      NULL, 0);
-	if (err != 0) {
-		FAIL("Advertising failed to start (err %d)\n", err);
-		return;
-	}
+	setup_connectable_adv(&ext_adv);
 
 	WAIT_FOR_FLAG(flag_connected);
 

--- a/tests/bsim/bluetooth/audio/src/has_test.c
+++ b/tests/bsim/bluetooth/audio/src/has_test.c
@@ -41,15 +41,9 @@ static const struct bt_has_preset_ops preset_ops = {
 
 static void start_adv(void)
 {
-	int err;
+	struct bt_le_ext_adv *ext_adv;
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_1, ad, AD_SIZE, NULL, 0);
-	if (err) {
-		FAIL("Advertising failed to start (err %d)\n", err);
-		return;
-	}
-
-	LOG_DBG("Advertising successfully started");
+	setup_connectable_adv(&ext_adv);
 }
 
 static void test_common(void)

--- a/tests/bsim/bluetooth/audio/src/ias_test.c
+++ b/tests/bsim/bluetooth/audio/src/ias_test.c
@@ -50,6 +50,7 @@ BT_IAS_CB_DEFINE(ias_callbacks) = {
 
 static void test_main(void)
 {
+	struct bt_le_ext_adv *ext_adv;
 	int err;
 
 	err = bt_enable(NULL);
@@ -58,13 +59,7 @@ static void test_main(void)
 		return;
 	}
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_1, ad, AD_SIZE, NULL, 0);
-	if (err) {
-		FAIL("Advertising failed to start (err %d)\n", err);
-		return;
-	}
-
-	printk("Advertising successfully started\n");
+	setup_connectable_adv(&ext_adv);
 
 	WAIT_FOR_FLAG(flag_connected);
 

--- a/tests/bsim/bluetooth/audio/src/mcs_test.c
+++ b/tests/bsim/bluetooth/audio/src/mcs_test.c
@@ -16,21 +16,9 @@
 #ifdef CONFIG_BT_MCS
 extern enum bst_result_t bst_result;
 
-static void start_adv(void)
-{
-	int err;
-
-	err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_1, ad, AD_SIZE, NULL, 0);
-	if (err) {
-		FAIL("Advertising failed to start (err %d)\n", err);
-		return;
-	}
-
-	printk("Advertising successfully started\n");
-}
-
 static void test_main(void)
 {
+	struct bt_le_ext_adv *ext_adv;
 	int err;
 
 	printk("Media Control Server test application.  Board: %s\n", CONFIG_BOARD);
@@ -50,12 +38,22 @@ static void test_main(void)
 	}
 	printk("Bluetooth initialized\n");
 
+	setup_connectable_adv(&ext_adv);
+
 	PASS("MCS passed\n");
 
 	while (1) {
-		start_adv();
 		WAIT_FOR_FLAG(flag_connected);
 		WAIT_FOR_UNSET_FLAG(flag_connected);
+
+		err = bt_le_ext_adv_start(ext_adv, BT_LE_EXT_ADV_START_DEFAULT);
+		if (err != 0) {
+			FAIL("Failed to start advertising set (err %d)\n", err);
+
+			bt_le_ext_adv_delete(ext_adv);
+
+			return;
+		}
 	}
 }
 

--- a/tests/bsim/bluetooth/audio/src/media_controller_test.c
+++ b/tests/bsim/bluetooth/audio/src/media_controller_test.c
@@ -1649,16 +1649,14 @@ void test_media_controller_local_player(void)
 /* BabbleSim entry point for remote player test */
 void test_media_controller_remote_player(void)
 {
-	int err;
+	struct bt_le_ext_adv *ext_adv;
+
 	printk("Media Control remote player test application.  Board: %s\n", CONFIG_BOARD);
 
 	initialize_bluetooth();
 	initialize_media();
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_1, ad, AD_SIZE, NULL, 0);
-	if (err) {
-		FAIL("Advertising failed to start (err %d)\n", err);
-	}
+	setup_connectable_adv(&ext_adv);
 
 	WAIT_FOR_FLAG(flag_connected);
 

--- a/tests/bsim/bluetooth/audio/src/micp_mic_dev_test.c
+++ b/tests/bsim/bluetooth/audio/src/micp_mic_dev_test.c
@@ -385,6 +385,7 @@ static void test_main(void)
 {
 	int err;
 	struct bt_micp_mic_dev_register_param micp_param;
+	struct bt_le_ext_adv *ext_adv;
 
 	err = bt_enable(NULL);
 	if (err != 0) {
@@ -431,14 +432,7 @@ static void test_main(void)
 	}
 
 	printk("MICP initialized\n");
-
-	err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_1, ad, AD_SIZE, NULL, 0);
-	if (err != 0) {
-		FAIL("Advertising failed to start (err %d)\n", err);
-		return;
-	}
-
-	printk("Advertising successfully started\n");
+	setup_connectable_adv(&ext_adv);
 
 	WAIT_FOR_FLAG(flag_connected);
 

--- a/tests/bsim/bluetooth/audio/src/pacs_notify_server_test.c
+++ b/tests/bsim/bluetooth/audio/src/pacs_notify_server_test.c
@@ -158,9 +158,7 @@ static void test_main(void)
 {
 	int err;
 	enum bt_audio_context available, available_for_conn;
-	const struct bt_data ad[] = {
-		BT_DATA_BYTES(BT_DATA_FLAGS, (BT_LE_AD_GENERAL | BT_LE_AD_NO_BREDR)),
-	};
+	struct bt_le_ext_adv *ext_adv;
 
 	LOG_DBG("Enabling Bluetooth");
 	err = bt_enable(NULL);
@@ -191,11 +189,7 @@ static void test_main(void)
 	}
 
 	LOG_DBG("Start Advertising");
-	err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_1, ad, ARRAY_SIZE(ad), NULL, 0);
-	if (err != 0) {
-		FAIL("Advertising failed to start (err %d)", err);
-		return;
-	}
+	setup_connectable_adv(&ext_adv);
 
 	LOG_DBG("Waiting to be connected");
 	WAIT_FOR_FLAG(flag_connected);
@@ -210,24 +204,21 @@ static void test_main(void)
 	LOG_INF("Trigger changes while device is connected");
 	trigger_notifications();
 
-	/* Now wait for client to disconnect, then stop adv so it does not reconnect */
+	/* Now wait for client to disconnect */
 	LOG_DBG("Wait for client disconnect");
 	WAIT_FOR_UNSET_FLAG(flag_connected);
 	LOG_DBG("Client disconnected");
-
-	err = bt_le_adv_stop();
-	if (err != 0) {
-		FAIL("Advertising failed to stop (err %d)", err);
-		return;
-	}
 
 	LOG_INF("Trigger changes while device is disconnected");
 	trigger_notifications();
 
 	LOG_DBG("Start Advertising");
-	err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_1, ad, ARRAY_SIZE(ad), NULL, 0);
+	err = bt_le_ext_adv_start(ext_adv, BT_LE_EXT_ADV_START_DEFAULT);
 	if (err != 0) {
-		FAIL("Advertising failed to start (err %d)", err);
+		FAIL("Failed to start advertising set (err %d)\n", err);
+
+		bt_le_ext_adv_delete(ext_adv);
+
 		return;
 	}
 
@@ -235,16 +226,13 @@ static void test_main(void)
 	WAIT_FOR_UNSET_FLAG(flag_connected);
 	LOG_DBG("Client disconnected");
 
-	err = bt_le_adv_stop();
-	if (err != 0) {
-		FAIL("Advertising failed to stop (err %d)", err);
-		return;
-	}
-
 	LOG_DBG("Start Advertising");
-	err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_1, ad, ARRAY_SIZE(ad), NULL, 0);
+	err = bt_le_ext_adv_start(ext_adv, BT_LE_EXT_ADV_START_DEFAULT);
 	if (err != 0) {
-		FAIL("Advertising failed to start (err %d)", err);
+		FAIL("Failed to start advertising set (err %d)\n", err);
+
+		bt_le_ext_adv_delete(ext_adv);
+
 		return;
 	}
 
@@ -269,16 +257,13 @@ static void test_main(void)
 	WAIT_FOR_UNSET_FLAG(flag_connected);
 	LOG_DBG("Client disconnected");
 
-	err = bt_le_adv_stop();
-	if (err != 0) {
-		FAIL("Advertising failed to stop (err %d)", err);
-		return;
-	}
-
 	LOG_DBG("Start Advertising");
-	err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_1, ad, ARRAY_SIZE(ad), NULL, 0);
+	err = bt_le_ext_adv_start(ext_adv, BT_LE_EXT_ADV_START_DEFAULT);
 	if (err != 0) {
-		FAIL("Advertising failed to start (err %d)", err);
+		FAIL("Failed to start advertising set (err %d)\n", err);
+
+		bt_le_ext_adv_delete(ext_adv);
+
 		return;
 	}
 

--- a/tests/bsim/bluetooth/audio/src/tbs_client_test.c
+++ b/tests/bsim/bluetooth/audio/src/tbs_client_test.c
@@ -481,6 +481,7 @@ static void discover_tbs(void)
 
 static void test_main(void)
 {
+	struct bt_le_ext_adv *ext_adv;
 	int err;
 	int index = 0;
 
@@ -503,11 +504,7 @@ static void test_main(void)
 
 	printk("Audio Server: Bluetooth discovered\n");
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_1, ad, AD_SIZE, NULL, 0);
-	if (err != 0) {
-		FAIL("Advertising failed to start (err %d)\n", err);
-		return;
-	}
+	setup_connectable_adv(&ext_adv);
 
 	printk("Advertising successfully started\n");
 

--- a/tests/bsim/bluetooth/audio/src/tmap_client_test.c
+++ b/tests/bsim/bluetooth/audio/src/tmap_client_test.c
@@ -1,5 +1,6 @@
 /*
  * Copyright 2023 NXP
+ * Copyright (c) 2025 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tests/bsim/bluetooth/audio/src/tmap_server_test.c
+++ b/tests/bsim/bluetooth/audio/src/tmap_server_test.c
@@ -24,21 +24,10 @@
 #ifdef CONFIG_BT_TMAP
 extern enum bst_result_t bst_result;
 
-static uint8_t tmap_addata[] = {
-	BT_UUID_16_ENCODE(BT_UUID_TMAS_VAL), /* TMAS UUID */
-	(BT_TMAP_ROLE_UMR | BT_TMAP_ROLE_CT), 0x00, /* TMAP Role  */
-};
-
-static const struct bt_data ad_tmas[] = {
-	BT_DATA_BYTES(BT_DATA_FLAGS, (BT_LE_AD_GENERAL | BT_LE_AD_NO_BREDR)),
-	BT_DATA_BYTES(BT_DATA_GAP_APPEARANCE, 0x09, 0x41), /* Appearance - Earbud  */
-	BT_DATA(BT_DATA_SVC_DATA16, tmap_addata, ARRAY_SIZE(tmap_addata)),
-};
-
 static void test_main(void)
 {
 	int err;
-	struct bt_le_ext_adv *adv;
+	struct bt_le_ext_adv *ext_adv;
 
 	err = bt_enable(NULL);
 	if (err != 0) {
@@ -48,31 +37,13 @@ static void test_main(void)
 
 	printk("Bluetooth initialized\n");
 	/* Initialize TMAP */
-	err = bt_tmap_register(BT_TMAP_ROLE_CT | BT_TMAP_ROLE_UMR);
+	err = bt_tmap_register(TMAP_ROLE_SUPPORTED);
 	if (err != 0) {
 		return;
 	}
 	printk("TMAP initialized. Start advertising...\n");
-	/* Create a connectable extended advertising set */
-	err = bt_le_ext_adv_create(BT_LE_EXT_ADV_CONN, NULL, &adv);
-	if (err) {
-		printk("Failed to create advertising set (err %d)\n", err);
-		return;
-	}
+	setup_connectable_adv(&ext_adv);
 
-	err = bt_le_ext_adv_set_data(adv, ad_tmas, ARRAY_SIZE(ad_tmas), NULL, 0);
-	if (err) {
-		printk("Failed to set advertising data (err %d)\n", err);
-		return;
-	}
-
-	err = bt_le_ext_adv_start(adv, BT_LE_EXT_ADV_START_DEFAULT);
-	if (err) {
-		printk("Failed to start advertising set (err %d)\n", err);
-		return;
-	}
-
-	printk("Advertising successfully started\n");
 	WAIT_FOR_FLAG(flag_connected);
 	printk("Connected!\n");
 

--- a/tests/bsim/bluetooth/audio/src/vcp_vol_rend_test.c
+++ b/tests/bsim/bluetooth/audio/src/vcp_vol_rend_test.c
@@ -1029,6 +1029,7 @@ static void test_standalone(void)
 
 static void test_main(void)
 {
+	struct bt_le_ext_adv *ext_adv;
 	int err;
 
 	err = bt_enable(NULL);
@@ -1044,13 +1045,7 @@ static void test_main(void)
 
 	printk("VCP initialized\n");
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_1, ad, AD_SIZE, NULL, 0);
-	if (err != 0) {
-		FAIL("Advertising failed to start (err %d)\n", err);
-		return;
-	}
-
-	printk("Advertising successfully started\n");
+	setup_connectable_adv(&ext_adv);
 
 	WAIT_FOR_FLAG(flag_connected);
 

--- a/tests/bsim/bluetooth/audio/test_scripts/ccp.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/ccp.sh
@@ -13,7 +13,7 @@ cd ${BSIM_OUT_PATH}/bin
 SIMULATION_ID="ccp"
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
-  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=ccp_call_control_server -rs=1 -D=1
+  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=ccp_call_control_server -rs=10 -D=1
 
 # Simulation time should be larger than the WAIT_TIME in common.h
 Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} \

--- a/tests/bsim/bluetooth/audio/test_scripts/csip.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/csip.sh
@@ -18,19 +18,19 @@ SIMULATION_ID="csip"
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=csip_set_coordinator \
-  -RealEncryption=1 -rs=1 -D=4
+  -RealEncryption=1 -rs=10 -D=4
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=1 -testid=csip_set_member \
-  -RealEncryption=1 -rs=2 -D=4 -argstest rank 1
+  -RealEncryption=1 -rs=20 -D=4 -argstest rank 1
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=2 -testid=csip_set_member \
-  -RealEncryption=1 -rs=3 -D=4 -argstest rank 2
+  -RealEncryption=1 -rs=30 -D=4 -argstest rank 2
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=3 -testid=csip_set_member \
-  -RealEncryption=1 -rs=4 -D=4 -argstest rank 3
+  -RealEncryption=1 -rs=40 -D=4 -argstest rank 3
 
 # Simulation time should be larger than the WAIT_TIME in common.h
 Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} \

--- a/tests/bsim/bluetooth/audio/test_scripts/csip_encrypted_sirk.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/csip_encrypted_sirk.sh
@@ -18,19 +18,19 @@ SIMULATION_ID="csip_sirk_encrypted"
 printf "\n\n======== Running test with SIRK encrypted ========\n\n"
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=csip_set_coordinator \
-  -RealEncryption=1 -rs=1 -D=4
+  -RealEncryption=1 -rs=10 -D=4
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=1 -testid=csip_set_member_enc \
-  -RealEncryption=1 -rs=2 -D=4 -argstest rank 1
+  -RealEncryption=1 -rs=20 -D=4 -argstest rank 1
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=2 -testid=csip_set_member_enc \
-  -RealEncryption=1 -rs=3 -D=4 -argstest rank 2
+  -RealEncryption=1 -rs=30 -D=4 -argstest rank 2
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=3 -testid=csip_set_member_enc \
-  -RealEncryption=1 -rs=4 -D=4 -argstest rank 3
+  -RealEncryption=1 -rs=40 -D=4 -argstest rank 3
 
 # Simulation time should be larger than the WAIT_TIME in common.h
 Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} \

--- a/tests/bsim/bluetooth/audio/test_scripts/csip_forced_release.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/csip_forced_release.sh
@@ -18,19 +18,19 @@ SIMULATION_ID="csip_forced_release"
 printf "\n\n======== Running test with forced release of lock ========\n\n"
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=csip_set_coordinator \
-  -RealEncryption=1 -rs=1 -D=4
+  -RealEncryption=1 -rs=10 -D=4
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=1 -testid=csip_set_member \
-  -RealEncryption=1 -rs=2 -D=4 -argstest rank 1
+  -RealEncryption=1 -rs=20 -D=4 -argstest rank 1
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=2 -testid=csip_set_member \
-  -RealEncryption=1 -rs=3 -D=4 -argstest rank 2
+  -RealEncryption=1 -rs=30 -D=4 -argstest rank 2
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=3 -testid=csip_set_member_release \
-  -RealEncryption=1 -rs=4 -D=4 -argstest rank 3
+  -RealEncryption=1 -rs=40 -D=4 -argstest rank 3
 
 # Simulation time should be larger than the WAIT_TIME in common.h
 Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} \

--- a/tests/bsim/bluetooth/audio/test_scripts/csip_new_sirk.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/csip_new_sirk.sh
@@ -18,19 +18,19 @@ SIMULATION_ID="csip_new_sirk"
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=csip_set_coordinator_new_sirk \
-  -RealEncryption=1 -rs=1 -D=4
+  -RealEncryption=1 -rs=10 -D=4
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=1 -testid=csip_set_member_new_sirk \
-  -RealEncryption=1 -rs=2 -D=4 -argstest rank 1
+  -RealEncryption=1 -rs=20 -D=4 -argstest rank 1
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=2 -testid=csip_set_member_new_sirk \
-  -RealEncryption=1 -rs=3 -D=4 -argstest rank 2
+  -RealEncryption=1 -rs=30 -D=4 -argstest rank 2
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=3 -testid=csip_set_member_new_sirk \
-  -RealEncryption=1 -rs=4 -D=4 -argstest rank 3
+  -RealEncryption=1 -rs=40 -D=4 -argstest rank 3
 
 # Simulation time should be larger than the WAIT_TIME in common.h
 Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} \

--- a/tests/bsim/bluetooth/audio/test_scripts/csip_no_lock.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/csip_no_lock.sh
@@ -17,19 +17,19 @@ SIMULATION_ID="csip_no_lock"
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=csip_set_coordinator \
-  -RealEncryption=1 -rs=1 -D=4 -argstest no-lock
+  -RealEncryption=1 -rs=10 -D=4 -argstest no-lock
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=1 -testid=csip_set_member \
-  -RealEncryption=1 -rs=2 -D=4 -argstest rank 1 not-lockable
+  -RealEncryption=1 -rs=20 -D=4 -argstest rank 1 not-lockable
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=2 -testid=csip_set_member \
-  -RealEncryption=1 -rs=3 -D=4 -argstest rank 2 not-lockable
+  -RealEncryption=1 -rs=30 -D=4 -argstest rank 2 not-lockable
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=3 -testid=csip_set_member \
-  -RealEncryption=1 -rs=4 -D=4 -argstest rank 3 not-lockable
+  -RealEncryption=1 -rs=40 -D=4 -argstest rank 3 not-lockable
 
 # Simulation time should be larger than the WAIT_TIME in common.h
 Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} \

--- a/tests/bsim/bluetooth/audio/test_scripts/csip_no_rank.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/csip_no_rank.sh
@@ -17,19 +17,19 @@ SIMULATION_ID="csip_no_rank"
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=csip_set_coordinator \
-  -RealEncryption=1 -rs=1 -D=4 -argstest no-rank no-lock
+  -RealEncryption=1 -rs=10 -D=4 -argstest no-rank no-lock
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=1 -testid=csip_set_member \
-  -RealEncryption=1 -rs=2 -D=4 -argstest rank 0 not-lockable
+  -RealEncryption=1 -rs=20 -D=4 -argstest rank 0 not-lockable
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=2 -testid=csip_set_member \
-  -RealEncryption=1 -rs=3 -D=4 -argstest rank 0 not-lockable
+  -RealEncryption=1 -rs=30 -D=4 -argstest rank 0 not-lockable
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=3 -testid=csip_set_member \
-  -RealEncryption=1 -rs=4 -D=4 -argstest rank 0 not-lockable
+  -RealEncryption=1 -rs=40 -D=4 -argstest rank 0 not-lockable
 
 # Simulation time should be larger than the WAIT_TIME in common.h
 Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} \

--- a/tests/bsim/bluetooth/audio/test_scripts/csip_no_size.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/csip_no_size.sh
@@ -17,19 +17,19 @@ SIMULATION_ID="csip_no_size"
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=csip_set_coordinator \
-  -RealEncryption=1 -rs=1 -D=4 -argstest no-size
+  -RealEncryption=1 -rs=10 -D=4 -argstest no-size
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=1 -testid=csip_set_member \
-  -RealEncryption=1 -rs=2 -D=4 -argstest rank 1 size 0
+  -RealEncryption=1 -rs=20 -D=4 -argstest rank 1 size 0
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=2 -testid=csip_set_member \
-  -RealEncryption=1 -rs=3 -D=4 -argstest rank 2 size 0
+  -RealEncryption=1 -rs=30 -D=4 -argstest rank 2 size 0
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=3 -testid=csip_set_member \
-  -RealEncryption=1 -rs=4 -D=4 -argstest rank 3s size 0
+  -RealEncryption=1 -rs=40 -D=4 -argstest rank 3s size 0
 
 # Simulation time should be larger than the WAIT_TIME in common.h
 Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} \


### PR DESCRIPTION
Most specs require the use of extended advertising, and most tests used legacy advertising.

Implement a common function to create and start an extended advertising set to reduce code duplication.