### PR TITLE
twister: Fix toolchain assignment for posix

### DIFF
--- a/scripts/pylib/twister/twisterlib/environment.py
+++ b/scripts/pylib/twister/twisterlib/environment.py
@@ -1143,14 +1143,6 @@ class TwisterEnv:
         return results
 
     def get_toolchain(self):
-        toolchain_script = Path(ZEPHYR_BASE) / Path('cmake/verify-toolchain.cmake')
-        result = self.run_cmake_script([toolchain_script, "FORMAT=json"])
-
-        try:
-            if result['returncode']:
-                raise TwisterRuntimeError(f"E: {result['returnmsg']}")
-        except Exception as e:
-            print(str(e))
-            sys.exit(2)
-        self.toolchain = json.loads(result['stdout'])['ZEPHYR_TOOLCHAIN_VARIANT']
-        logger.info(f"Using '{self.toolchain}' toolchain.")
+        self.toolchain = os.environ.get("ZEPHYR_TOOLCHAIN_VARIANT")
+        if self.toolchain:
+            logger.info(f"Using '{self.toolchain}' toolchain.")

--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -898,9 +898,12 @@ class TestPlan:
             ):
                 if itoolchain:
                     toolchain = itoolchain
+                elif self.env.toolchain:
+                    toolchain = self.env.toolchain
+                elif plat.arch in ['posix', 'unit']:
+                    toolchain = "host"
                 else:
-                    default_toolchain = "zephyr" if not self.env.toolchain else self.env.toolchain
-                    toolchain = default_toolchain if plat.arch not in ['posix', 'unit'] else "host"
+                    toolchain = "zephyr"
 
                 instance = TestInstance(ts, plat, toolchain, self.env.outdir)
                 instance.run = instance.check_runnable(


### PR DESCRIPTION
twister was unconditionally setting the toolchain to "host" for the "posix" and "unit" architectures, clobbering the toolchain setup in the environment.