### PR TITLE
 test: drivers: adc: Change the property names in the overlay

### DIFF
--- a/tests/drivers/adc/adc_accuracy_test/README.txt
+++ b/tests/drivers/adc/adc_accuracy_test/README.txt
@@ -17,5 +17,5 @@ voltage on the same range.
 
 In the reference voltage case, the ADC is expected to be connected to a
 known voltage reference, whose value is informed, in millivolts, at
-property "reference_mv" from "zephyr,user" node. The test reads the ADC
+property "reference-mv" from "zephyr,user" node. The test reads the ADC
 to see if they match.

--- a/tests/drivers/adc/adc_accuracy_test/boards/ek_ra4e2.overlay
+++ b/tests/drivers/adc/adc_accuracy_test/boards/ek_ra4e2.overlay
@@ -7,8 +7,8 @@
 / {
 	zephyr,user {
 		io-channels = <&adc0 0>;
-		reference_mv = <3300>;
-		expected_accuracy = <32>;
+		reference-mv = <3300>;
+		expected-accuracy = <32>;
 	};
 };
 

--- a/tests/drivers/adc/adc_accuracy_test/boards/ek_ra4m2.overlay
+++ b/tests/drivers/adc/adc_accuracy_test/boards/ek_ra4m2.overlay
@@ -7,8 +7,8 @@
 / {
 	zephyr,user {
 		io-channels = <&adc0 0>;
-		reference_mv = <3300>;
-		expected_accuracy = <32>;
+		reference-mv = <3300>;
+		expected-accuracy = <32>;
 	};
 };
 

--- a/tests/drivers/adc/adc_accuracy_test/boards/ek_ra4m3.overlay
+++ b/tests/drivers/adc/adc_accuracy_test/boards/ek_ra4m3.overlay
@@ -7,8 +7,8 @@
 / {
 	zephyr,user {
 		io-channels = <&adc0 0>;
-		reference_mv = <3300>;
-		expected_accuracy = <32>;
+		reference-mv = <3300>;
+		expected-accuracy = <32>;
 	};
 };
 

--- a/tests/drivers/adc/adc_accuracy_test/boards/ek_ra4w1.overlay
+++ b/tests/drivers/adc/adc_accuracy_test/boards/ek_ra4w1.overlay
@@ -7,8 +7,8 @@
 / {
 	zephyr,user {
 		io-channels = <&adc0 4>;
-		reference_mv = <3300>;
-		expected_accuracy = <32>;
+		reference-mv = <3300>;
+		expected-accuracy = <32>;
 	};
 };
 

--- a/tests/drivers/adc/adc_accuracy_test/boards/ek_ra6e2.overlay
+++ b/tests/drivers/adc/adc_accuracy_test/boards/ek_ra6e2.overlay
@@ -7,8 +7,8 @@
 / {
 	zephyr,user {
 		io-channels = <&adc0 0>;
-		reference_mv = <3300>;
-		expected_accuracy = <32>;
+		reference-mv = <3300>;
+		expected-accuracy = <32>;
 	};
 };
 

--- a/tests/drivers/adc/adc_accuracy_test/boards/ek_ra6m1.overlay
+++ b/tests/drivers/adc/adc_accuracy_test/boards/ek_ra6m1.overlay
@@ -7,8 +7,8 @@
 / {
 	zephyr,user {
 		io-channels = <&adc0 0>;
-		reference_mv = <3300>;
-		expected_accuracy = <32>;
+		reference-mv = <3300>;
+		expected-accuracy = <32>;
 	};
 };
 

--- a/tests/drivers/adc/adc_accuracy_test/boards/ek_ra6m2.overlay
+++ b/tests/drivers/adc/adc_accuracy_test/boards/ek_ra6m2.overlay
@@ -7,8 +7,8 @@
 / {
 	zephyr,user {
 		io-channels = <&adc0 0>;
-		reference_mv = <3300>;
-		expected_accuracy = <32>;
+		reference-mv = <3300>;
+		expected-accuracy = <32>;
 	};
 };
 

--- a/tests/drivers/adc/adc_accuracy_test/boards/ek_ra6m3.overlay
+++ b/tests/drivers/adc/adc_accuracy_test/boards/ek_ra6m3.overlay
@@ -7,8 +7,8 @@
 / {
 	zephyr,user {
 		io-channels = <&adc0 0>;
-		reference_mv = <3300>;
-		expected_accuracy = <32>;
+		reference-mv = <3300>;
+		expected-accuracy = <32>;
 	};
 };
 

--- a/tests/drivers/adc/adc_accuracy_test/boards/ek_ra6m4.overlay
+++ b/tests/drivers/adc/adc_accuracy_test/boards/ek_ra6m4.overlay
@@ -7,8 +7,8 @@
 / {
 	zephyr,user {
 		io-channels = <&adc0 0>;
-		reference_mv = <3300>;
-		expected_accuracy = <32>;
+		reference-mv = <3300>;
+		expected-accuracy = <32>;
 	};
 };
 

--- a/tests/drivers/adc/adc_accuracy_test/boards/ek_ra6m5.overlay
+++ b/tests/drivers/adc/adc_accuracy_test/boards/ek_ra6m5.overlay
@@ -7,8 +7,8 @@
 / {
 	zephyr,user {
 		io-channels = <&adc0 0>;
-		reference_mv = <3300>;
-		expected_accuracy = <32>;
+		reference-mv = <3300>;
+		expected-accuracy = <32>;
 	};
 };
 

--- a/tests/drivers/adc/adc_accuracy_test/boards/ek_ra8d1.overlay
+++ b/tests/drivers/adc/adc_accuracy_test/boards/ek_ra8d1.overlay
@@ -7,8 +7,8 @@
 / {
 	zephyr,user {
 		io-channels = <&adc0 0>;
-		reference_mv = <3300>;
-		expected_accuracy = <32>;
+		reference-mv = <3300>;
+		expected-accuracy = <32>;
 	};
 };
 

--- a/tests/drivers/adc/adc_accuracy_test/boards/ek_ra8m1.overlay
+++ b/tests/drivers/adc/adc_accuracy_test/boards/ek_ra8m1.overlay
@@ -7,8 +7,8 @@
 / {
 	zephyr,user {
 		io-channels = <&adc0 0>;
-		reference_mv = <3300>;
-		expected_accuracy = <32>;
+		reference-mv = <3300>;
+		expected-accuracy = <32>;
 	};
 };
 

--- a/tests/drivers/adc/adc_accuracy_test/boards/fpb_ra6e1.overlay
+++ b/tests/drivers/adc/adc_accuracy_test/boards/fpb_ra6e1.overlay
@@ -7,8 +7,8 @@
 / {
 	zephyr,user {
 		io-channels = <&adc0 0>;
-		reference_mv = <3300>;
-		expected_accuracy = <32>;
+		reference-mv = <3300>;
+		expected-accuracy = <32>;
 	};
 };
 

--- a/tests/drivers/adc/adc_accuracy_test/boards/fpb_ra6e2.overlay
+++ b/tests/drivers/adc/adc_accuracy_test/boards/fpb_ra6e2.overlay
@@ -7,8 +7,8 @@
 / {
 	zephyr,user {
 		io-channels = <&adc0 0>;
-		reference_mv = <3300>;
-		expected_accuracy = <32>;
+		reference-mv = <3300>;
+		expected-accuracy = <32>;
 	};
 };
 

--- a/tests/drivers/adc/adc_accuracy_test/boards/frdm_kl25z.overlay
+++ b/tests/drivers/adc/adc_accuracy_test/boards/frdm_kl25z.overlay
@@ -7,8 +7,8 @@
 / {
 	zephyr,user {
 		io-channels = <&adc0 12>;
-		reference_mv = <1100>;
-		expected_accuracy = <32>;
+		reference-mv = <1100>;
+		expected-accuracy = <32>;
 	};
 };
 

--- a/tests/drivers/adc/adc_accuracy_test/boards/frdm_mcxc242.overlay
+++ b/tests/drivers/adc/adc_accuracy_test/boards/frdm_mcxc242.overlay
@@ -9,8 +9,8 @@
 / {
 	zephyr,user {
 		io-channels = <&adc0 1>;
-		reference_mv = <1650>;
-		expected_accuracy = <32>;
+		reference-mv = <1650>;
+		expected-accuracy = <32>;
 	};
 };
 

--- a/tests/drivers/adc/adc_accuracy_test/boards/mck_ra8t1.overlay
+++ b/tests/drivers/adc/adc_accuracy_test/boards/mck_ra8t1.overlay
@@ -7,8 +7,8 @@
 / {
 	zephyr,user {
 		io-channels = <&adc0 0>;
-		reference_mv = <3300>;
-		expected_accuracy = <32>;
+		reference-mv = <3300>;
+		expected-accuracy = <32>;
 	};
 };
 

--- a/tests/drivers/adc/adc_accuracy_test/boards/nrf52840dk_nrf52840.overlay
+++ b/tests/drivers/adc/adc_accuracy_test/boards/nrf52840dk_nrf52840.overlay
@@ -8,8 +8,8 @@
 / {
 	zephyr,user {
 		io-channels = <&adc 0>;
-		reference_mv = <3000>;
-		expected_accuracy = <32>;
+		reference-mv = <3000>;
+		expected-accuracy = <32>;
 	};
 };
 

--- a/tests/drivers/adc/adc_accuracy_test/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/tests/drivers/adc/adc_accuracy_test/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -7,8 +7,8 @@
 / {
 	zephyr,user {
 		io-channels = <&adc 0>;
-		reference_mv = <1800>;
-		expected_accuracy = <64>;
+		reference-mv = <1800>;
+		expected-accuracy = <64>;
 	};
 };
 

--- a/tests/drivers/adc/adc_accuracy_test/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/tests/drivers/adc/adc_accuracy_test/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -7,8 +7,8 @@
 / {
 	zephyr,user {
 		io-channels = <&adc 0>;
-		reference_mv = <1800>;
-		expected_accuracy = <64>;
+		reference-mv = <1800>;
+		expected-accuracy = <64>;
 	};
 };
 


### PR DESCRIPTION
Change the property names in the bindings and DTS
to use hyphens(-) for separation instead of underscores(_).