### PR TITLE
dts: bindings: dma: Change the property names in the bindings

### DIFF
--- a/doc/releases/migration-guide-4.2.rst
+++ b/doc/releases/migration-guide-4.2.rst
@@ -69,6 +69,12 @@ DAI
 * Renamed the devicetree property ``quad_ch`` to ``quad-ch``.
 * Renamed the devicetree property ``int_odd`` to ``int-odd``.
 
+DMA
+===
+
+* Renamed the devicetree property ``nxp,a_on`` to ``nxp,a-on``.
+* Renamed the devicetree property ``dma_channels`` to ``dma-channels``.
+
 Counter
 =======
 

--- a/dts/arm/nxp/nxp_rt10xx.dtsi
+++ b/dts/arm/nxp/nxp_rt10xx.dtsi
@@ -896,7 +896,7 @@
 			dma-channels = <32>;
 			dma-requests = <128>;
 			nxp,mem2mem;
-			nxp,a_on;
+			nxp,a-on;
 			reg = <0x400E8000 0x4000>,
 				<0x400EC000 0x4000>;
 			interrupts = <0 0>, <1 0>, <2 0>, <3 0>,

--- a/dts/arm/nxp/nxp_rt11xx.dtsi
+++ b/dts/arm/nxp/nxp_rt11xx.dtsi
@@ -1060,7 +1060,7 @@
 			dma-channels = <32>;
 			dma-requests = <208>;
 			nxp,mem2mem;
-			nxp,a_on;
+			nxp,a-on;
 			reg = <0x40070000 0x4000>,
 				<0x40074000 0x4000>;
 			clocks = <&ccm IMX_CCM_EDMA_CLK 0x7C 0x000000C0>;
@@ -1079,7 +1079,7 @@
 			dma-channels = <32>;
 			dma-requests = <208>;
 			nxp,mem2mem;
-			nxp,a_on;
+			nxp,a-on;
 			reg = <0x40c14000 0x4000>,
 				<0x40c18000 0x4000>;
 			clocks = <&ccm IMX_CCM_EDMA_LPSR_CLK 0x7C 0x000000C0>;

--- a/dts/arm/silabs/efr32bg2x.dtsi
+++ b/dts/arm/silabs/efr32bg2x.dtsi
@@ -302,7 +302,7 @@
 			compatible = "silabs,ldma";
 			reg = <0x40040000 0x4000>;
 			#dma-cells = <1>;
-			dma_channels = <8>;
+			dma-channels = <8>;
 			status = "disabled";
 		};
 

--- a/dts/arm/silabs/efr32mg21.dtsi
+++ b/dts/arm/silabs/efr32mg21.dtsi
@@ -333,7 +333,7 @@
 			reg = <0x40040000 0x4000>;
 			interrupts = <21 0>;
 			#dma-cells = <1>;
-			dma_channels = <8>;
+			dma-channels = <8>;
 			status = "disabled";
 		};
 

--- a/dts/arm/silabs/efr32mg24.dtsi
+++ b/dts/arm/silabs/efr32mg24.dtsi
@@ -398,7 +398,7 @@
 			reg = <0x40040000 0x4000>;
 			interrupts = <21 0>;
 			#dma-cells = <1>;
-			dma_channels = <8>;
+			dma-channels = <8>;
 			status = "disabled";
 		};
 

--- a/dts/arm/silabs/efr32xg23.dtsi
+++ b/dts/arm/silabs/efr32xg23.dtsi
@@ -428,7 +428,7 @@
 			reg = <0x50040000 0x4000>;
 			interrupts = <22 0>;
 			#dma-cells = <1>;
-			dma_channels = <8>;
+			dma-channels = <8>;
 			status = "disabled";
 		};
 

--- a/dts/arm/silabs/xg29/xg29.dtsi
+++ b/dts/arm/silabs/xg29/xg29.dtsi
@@ -326,7 +326,7 @@
 			interrupts = <26 0>;
 			interrupt-names = "ldma";
 			#dma-cells = <1>;
-			dma_channels = <8>;
+			dma-channels = <8>;
 			status = "disabled";
 		};
 

--- a/dts/bindings/dma/nxp,mcux-edma.yaml
+++ b/dts/bindings/dma/nxp,mcux-edma.yaml
@@ -40,7 +40,7 @@ properties:
     type: boolean
     description: If the DMA controller supports memory to memory transfer
 
-  nxp,a_on:
+  nxp,a-on:
     type: boolean
     description: If the DMA controller supports always on
 

--- a/dts/bindings/dma/silabs,ldma.yaml
+++ b/dts/bindings/dma/silabs,ldma.yaml
@@ -21,7 +21,7 @@ properties:
   interrupts:
     required: true
 
-  dma_channels:
+  dma-channels:
     type: int
     required: true
 


### PR DESCRIPTION
Change the property names in the bindings and DTS
to use hyphens(-) for separation instead of underscores(_).