### PR TITLE
dts: bindings: counter: Change the property names in the overlay

### DIFF
--- a/doc/releases/migration-guide-4.1.rst
+++ b/doc/releases/migration-guide-4.1.rst
@@ -115,6 +115,14 @@ ADC
 
 * Renamed the ``compatible`` from ``nxp,kinetis-adc12`` to :dtcompatible:`nxp,adc12`.
 
+Counter
+=======
+
+* Renamed the devicetree property ``primary_source`` to ``primary-source``.
+* Renamed the devicetree property ``secondary_source`` to ``secondary-source``.
+* Renamed the devicetree property ``filter_count`` to ``filter-count``.
+* Renamed the devicetree property ``filter_period`` to ``filter-period``.
+
 Controller Area Network (CAN)
 =============================
 

--- a/dts/bindings/counter/nxp,imx-tmr.yaml
+++ b/dts/bindings/counter/nxp,imx-tmr.yaml
@@ -33,7 +33,7 @@ properties:
       - "kQTMR_SecSrcTrigPriCnt"
       - "kQTMR_CascadeCount"
 
-  primary_source:
+  primary-source:
     type: string
     required: true
     description: Primary source of the timer, see qtmr_primary_count_source_t enumerator type
@@ -56,7 +56,7 @@ properties:
       - "kQTMR_ClockDivide_64"
       - "kQTMR_ClockDivide_128"
 
-  secondary_source:
+  secondary-source:
     type: string
     description: Secondary source of the timer, see qtmr_input_source_t enumerator type
       of the MCUXpresso SDK
@@ -66,11 +66,11 @@ properties:
       - "kQTMR_Counter2InputPin"
       - "kQTMR_Counter3InputPin"
 
-  filter_count:
+  filter-count:
     type: int
     description: Fault filter count (0-255).
 
-  filter_period:
+  filter-period:
     type: int
     description: Fault filter period (0-255).
 

--- a/tests/drivers/counter/counter_basic_api/boards/mimxrt1060_evk_mimxrt1062_qspi.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/mimxrt1060_evk_mimxrt1062_qspi.overlay
@@ -20,6 +20,6 @@
 
 &qtmr1_timer0 {
 	status = "okay";
-	primary_source = "kQTMR_ClockDivide_128";
+	primary-source = "kQTMR_ClockDivide_128";
 	mode = "kQTMR_PriSrcRiseEdge";
 };

--- a/tests/drivers/counter/counter_basic_api/boards/mimxrt1180_evk_mimxrt1189_cm33.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/mimxrt1180_evk_mimxrt1189_cm33.overlay
@@ -6,6 +6,6 @@
 
 &qtmr1_timer0 {
 	status = "okay";
-	primary_source = "kQTMR_ClockDivide_128";
+	primary-source = "kQTMR_ClockDivide_128";
 	mode = "kQTMR_PriSrcRiseEdge";
 };

--- a/tests/drivers/counter/counter_basic_api/boards/mimxrt1180_evk_mimxrt1189_cm7.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/mimxrt1180_evk_mimxrt1189_cm7.overlay
@@ -6,6 +6,6 @@
 
 &qtmr1_timer0 {
 	status = "okay";
-	primary_source = "kQTMR_ClockDivide_128";
+	primary-source = "kQTMR_ClockDivide_128";
 	mode = "kQTMR_PriSrcRiseEdge";
 };


### PR DESCRIPTION
Change the property names in the bindings and overlay to use hyphens(-) for separation instead of underscores(_).