### PR TITLE
dts: bindings: usb: Change the property names in the DTS

### DIFF
--- a/boards/nxp/frdm_mcxn947/frdm_mcxn947_mcxn947_cpu0.dtsi
+++ b/boards/nxp/frdm_mcxn947/frdm_mcxn947_mcxn947_cpu0.dtsi
@@ -182,7 +182,7 @@
 
 zephyr_udc0: &usb1 {
 	status = "okay";
-	phy_handle = <&usbphy1>;
+	phy-handle = <&usbphy1>;
 };
 
 &usbphy1 {

--- a/boards/nxp/lpcxpresso55s16/lpcxpresso55s16.dts
+++ b/boards/nxp/lpcxpresso55s16/lpcxpresso55s16.dts
@@ -26,7 +26,7 @@
 
 zephyr_udc0: &usbhs {
 	status = "okay";
-	phy_handle = <&usbphy1>;
+	phy-handle = <&usbphy1>;
 };
 
 &usbphy1 {

--- a/boards/nxp/lpcxpresso55s69/lpcxpresso55s69_lpc55s69_cpu0.dts
+++ b/boards/nxp/lpcxpresso55s69/lpcxpresso55s69_lpc55s69_cpu0.dts
@@ -152,7 +152,7 @@
 
 zephyr_udc0: &usbhs {
 	status = "okay";
-	phy_handle = <&usbphy1>;
+	phy-handle = <&usbphy1>;
 };
 
 &usbphy1 {

--- a/boards/nxp/mimxrt1060_evk/mimxrt1060_evk.dtsi
+++ b/boards/nxp/mimxrt1060_evk/mimxrt1060_evk.dtsi
@@ -185,7 +185,7 @@ arduino_i2c: &lpi2c1 {
 
 zephyr_udc0: &usb1 {
 	status = "okay";
-	phy_handle = <&usbphy1>;
+	phy-handle = <&usbphy1>;
 };
 
 &usbphy1 {

--- a/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm7.dts
+++ b/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm7.dts
@@ -150,7 +150,7 @@ nxp_mipi_i2c: &lpi2c5 {
 
 zephyr_udc0: &usb1 {
 	status = "okay";
-	phy_handle = <&usbphy1>;
+	phy-handle = <&usbphy1>;
 };
 
 &usbphy1 {

--- a/boards/nxp/mimxrt685_evk/mimxrt685_evk_mimxrt685s_cm33.dts
+++ b/boards/nxp/mimxrt685_evk/mimxrt685_evk_mimxrt685s_cm33.dts
@@ -359,7 +359,7 @@ i2s1: &flexcomm3 {
 
 zephyr_udc0: &usbhs {
 	status = "okay";
-	phy_handle = <&usbphy>;
+	phy-handle = <&usbphy>;
 };
 
 &usbphy {

--- a/doc/releases/migration-guide-4.1.rst
+++ b/doc/releases/migration-guide-4.1.rst
@@ -259,6 +259,11 @@ Timer
 * Renamed the ``compatible`` from ``nxp,kinetis-ftm`` to :dtcompatible:`nxp,ftm` and relocate it
   under ``dts/bindings/timer``.
 
+USB
+===
+
+* Renamed the devicetree property names ``phy_handle`` to ``phy-handle``.
+
 Video
 =====
 

--- a/dts/bindings/usb/nxp,ehci.yaml
+++ b/dts/bindings/usb/nxp,ehci.yaml
@@ -8,5 +8,5 @@ compatible: nxp,ehci
 include: "nxp,mcux-usbd.yaml"
 
 properties:
-  phy_handle:
+  phy-handle:
     type: phandle

--- a/dts/bindings/usb/nxp,lpcip3511.yaml
+++ b/dts/bindings/usb/nxp,lpcip3511.yaml
@@ -8,5 +8,5 @@ compatible: nxp,lpcip3511
 include: "nxp,mcux-usbd.yaml"
 
 properties:
-  phy_handle:
+  phy-handle:
     type: phandle


### PR DESCRIPTION
Change the property names in the bindings and DTS
to use hyphens(-) for separation instead of underscores(_).