### PR TITLE
hostap: Fix wrong security printing about WPA3 PWE

### DIFF
--- a/modules/hostap/src/supp_api.c
+++ b/modules/hostap/src/supp_api.c
@@ -1045,14 +1045,14 @@ static int wpas_add_and_config_network(struct wpa_supplicant *wpa_s,
 				}
 			}
 
-			if (params->security == WIFI_SECURITY_TYPE_SAE_H2E ||
-			    params->security == WIFI_SECURITY_TYPE_SAE_AUTO) {
-				if (!wpa_cli_cmd_v("set sae_pwe %d",
-						   (params->security == WIFI_SECURITY_TYPE_SAE_H2E)
-							   ? 1
-							   : 2)) {
-					goto out;
-				}
+
+			if (!wpa_cli_cmd_v("set sae_pwe %d",
+				(params->security == WIFI_SECURITY_TYPE_SAE_H2E)
+				   ? 1
+				   : ((params->security == WIFI_SECURITY_TYPE_SAE_AUTO)
+					   ? 2
+					   : 0))) {
+				goto out;
 			}
 
 			if (!wpa_cli_cmd_v("set_network %d key_mgmt SAE%s", resp.network_id,


### PR DESCRIPTION
'wifi status' CMD shows wrong security information when STA connects to Ext-AP with WIFI_SECURITY_TYPE_SAE_HNP, after connection using WIFI_SECURITY_TYPE_SAE_AUTO. Setting sae_pwe for all the WPA3 SAE types can fix this issue.