### PR TITLE
dts: bindings: can: infineon: xmc4xxx: rename clock_div8 to clock-div8

### DIFF
--- a/dts/bindings/can/infineon,xmc4xxx-can-node.yaml
+++ b/dts/bindings/can/infineon,xmc4xxx-can-node.yaml
@@ -16,7 +16,7 @@ properties:
   interrupts:
     required: true
 
-  clock_div8:
+  clock-div8:
     description: Option enables clock divide by a factor of 8.
     type: boolean
 


### PR DESCRIPTION
Rename the Infineon XMC4xxx CAN node devicetree property clock_div8 to clock-div8 (prefering hyphens over underscores to separate devicetree property names).