### PR TITLE
Bluetooth: RFCOMM: Add a argument server to bt rfcomm server.accept

### DIFF
--- a/include/zephyr/bluetooth/classic/rfcomm.h
+++ b/include/zephyr/bluetooth/classic/rfcomm.h
@@ -118,11 +118,13 @@ struct bt_rfcomm_server {
 	 *  authorization.
 	 *
 	 *  @param conn The connection that is requesting authorization
+	 *  @param server Pointer to the server structure this callback relates to
 	 *  @param dlc Pointer to received the allocated dlc
 	 *
 	 *  @return 0 in case of success or negative value in case of error.
 	 */
-	int (*accept)(struct bt_conn *conn, struct bt_rfcomm_dlc **dlc);
+	int (*accept)(struct bt_conn *conn, struct bt_rfcomm_server *server,
+		      struct bt_rfcomm_dlc **dlc);
 
 	struct bt_rfcomm_server	*_next;
 };

--- a/subsys/bluetooth/host/classic/hfp_hf.c
+++ b/subsys/bluetooth/host/classic/hfp_hf.c
@@ -716,7 +716,8 @@ static void hfp_hf_sent(struct bt_rfcomm_dlc *dlc, int err)
 	LOG_DBG("DLC %p sent cb (err %d)", dlc, err);
 }
 
-static int bt_hfp_hf_accept(struct bt_conn *conn, struct bt_rfcomm_dlc **dlc)
+static int bt_hfp_hf_accept(struct bt_conn *conn, struct bt_rfcomm_server *server,
+			    struct bt_rfcomm_dlc **dlc)
 {
 	int i;
 	static struct bt_rfcomm_dlc_ops ops = {

--- a/subsys/bluetooth/host/classic/rfcomm.c
+++ b/subsys/bluetooth/host/classic/rfcomm.c
@@ -478,7 +478,7 @@ static struct bt_rfcomm_dlc *rfcomm_dlc_accept(struct bt_rfcomm_session *session
 		return NULL;
 	}
 
-	if (server->accept(session->br_chan.chan.conn, &dlc) < 0) {
+	if (server->accept(session->br_chan.chan.conn, server, &dlc) < 0) {
 		LOG_DBG("Incoming connection rejected");
 		return NULL;
 	}

--- a/subsys/bluetooth/host/classic/shell/rfcomm.c
+++ b/subsys/bluetooth/host/classic/shell/rfcomm.c
@@ -126,7 +126,8 @@ static struct bt_rfcomm_dlc rfcomm_dlc = {
 	.mtu = 30,
 };
 
-static int rfcomm_accept(struct bt_conn *conn, struct bt_rfcomm_dlc **dlc)
+static int rfcomm_accept(struct bt_conn *conn, struct bt_rfcomm_server *server,
+			 struct bt_rfcomm_dlc **dlc)
 {
 	bt_shell_print("Incoming RFCOMM conn %p", conn);
 


### PR DESCRIPTION
* Bluetooth: RFCOMM: Add a argument `server` to `bt_rfcomm_server.accept`

In current implementation, the `accept` cannot be identified if the same one `accept` callback is passed by the upper layer.

Similar with `accept` of `bt_l2cap_server.accept`, add a parameter `server` to the `bt_rfcomm_server.accept` callback.
