### PR TITLE
Bluetooth: RFCOMM: Move BT_RFCOMM_BUF_SIZE to rfcomm.h

### DIFF
--- a/include/zephyr/bluetooth/classic/rfcomm.h
+++ b/include/zephyr/bluetooth/classic/rfcomm.h
@@ -19,10 +19,26 @@
 
 #include <zephyr/bluetooth/buf.h>
 #include <zephyr/bluetooth/conn.h>
+#include <zephyr/bluetooth/l2cap.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/** RFCOMM Maximum Header Size. The length could be 2 bytes, it depends on information length. */
+#define BT_RFCOMM_HDR_MAX_SIZE 4
+/** RFCOMM FCS Size */
+#define BT_RFCOMM_FCS_SIZE     1
+
+/** @brief Helper to calculate needed buffer size for RFCOMM PDUs.
+ *         Useful for creating buffer pools.
+ *
+ *  @param mtu Needed RFCOMM PDU MTU.
+ *
+ *  @return Needed buffer size to match the requested RFCOMM PDU MTU.
+ */
+#define BT_RFCOMM_BUF_SIZE(mtu)                                                                    \
+	BT_L2CAP_BUF_SIZE(BT_RFCOMM_HDR_MAX_SIZE + BT_RFCOMM_FCS_SIZE + (mtu))
 
 /* RFCOMM channels (1-30): pre-allocated for profiles to avoid conflicts */
 enum {

--- a/subsys/bluetooth/host/classic/rfcomm_internal.h
+++ b/subsys/bluetooth/host/classic/rfcomm_internal.h
@@ -133,15 +133,6 @@ struct bt_rfcomm_rpn {
 #define BT_RFCOMM_CHECK_MTU(mtu) (!!((mtu) >= BT_RFCOMM_SIG_MIN_MTU && \
 				     (mtu) <= BT_RFCOMM_SIG_MAX_MTU))
 
-/* Helper to calculate needed outgoing buffer size.
- * Length in rfcomm header can be two bytes depending on user data length.
- * One byte in the tail should be reserved for FCS.
- */
-#define BT_RFCOMM_BUF_SIZE(mtu) (BT_BUF_RESERVE + \
-				 BT_HCI_ACL_HDR_SIZE + BT_L2CAP_HDR_SIZE + \
-				 sizeof(struct bt_rfcomm_hdr) + 1 + (mtu) + \
-				 BT_RFCOMM_FCS_SIZE)
-
 #define BT_RFCOMM_GET_DLCI(addr)                  (((addr) & 0xfc) >> 2)
 #define BT_RFCOMM_GET_FRAME_TYPE(ctrl)            ((ctrl) & 0xef)
 #define BT_RFCOMM_GET_MSG_TYPE(type)              (((type) & 0xfc) >> 2)
@@ -192,7 +183,6 @@ struct bt_rfcomm_rpn {
 
 /* Length can be 2 bytes depending on data size */
 #define BT_RFCOMM_HDR_SIZE  (sizeof(struct bt_rfcomm_hdr) + 1)
-#define BT_RFCOMM_FCS_SIZE  1
 
 #define BT_RFCOMM_FCS_LEN_UIH      2
 #define BT_RFCOMM_FCS_LEN_NON_UIH  3


### PR DESCRIPTION
* Bluetooth: RFCOMM: Add a argument `server` to `bt_rfcomm_server.accept`

In current implementation, the `accept` cannot be identified if the same one `accept` callback is passed by the upper layer.

Similar with `accept` of `bt_l2cap_server.accept`, add a parameter `server` to the `bt_rfcomm_server.accept` callback.
