### PR TITLE
fs: zms: fix Copyright notice

### DIFF
--- a/include/zephyr/fs/zms.h
+++ b/include/zephyr/fs/zms.h
@@ -1,4 +1,5 @@
-/* Copyright (c) 2024 BayLibre SAS
+/* Copyright (c) 2018 Laczen
+ * Copyright (c) 2024 BayLibre SAS
  *
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/subsys/fs/zms/Kconfig
+++ b/subsys/fs/zms/Kconfig
@@ -1,3 +1,4 @@
+# Copyright (c) 2018 Laczen
 # Copyright (c) 2024 BayLibre SAS
 
 # SPDX-License-Identifier: Apache-2.0

--- a/subsys/fs/zms/zms.c
+++ b/subsys/fs/zms/zms.c
@@ -1,4 +1,5 @@
-/* Copyright (c) 2024 BayLibre SAS
+/* Copyright (c) 2018 Laczen
+ * Copyright (c) 2024 BayLibre SAS
  *
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/subsys/fs/zms/zms_priv.h
+++ b/subsys/fs/zms/zms_priv.h
@@ -1,4 +1,5 @@
-/* Copyright (c) 2024 BayLibre SAS
+/* Copyright (c) 2018 Laczen
+ * Copyright (c) 2024 BayLibre SAS
  *
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/tests/subsys/fs/zms/boards/native_sim.overlay
+++ b/tests/subsys/fs/zms/boards/native_sim.overlay
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Nordic Semiconductor ASA
+ * Copyright (c) 2022 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tests/subsys/fs/zms/boards/qemu_x86_ev_0x00.overlay
+++ b/tests/subsys/fs/zms/boards/qemu_x86_ev_0x00.overlay
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Nordic Semiconductor ASA
+ * Copyright (c) 2020 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tests/subsys/fs/zms/src/main.c
+++ b/tests/subsys/fs/zms/src/main.c
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
  * Copyright (c) 2024 BayLibre SAS
  *
  * SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
Add missing Copyright from derived files and fix the Copyright year for some files to keep the original Copyright notice