### PR TITLE
drivers: rtc: Fix failing RV8803 driver build when int-gpios not used

### DIFF
--- a/drivers/rtc/rtc_rv8803.c
+++ b/drivers/rtc/rtc_rv8803.c
@@ -205,7 +205,7 @@ static int rv8803_write_regs(const struct device *dev, uint8_t addr, const void 
 	return err;
 }
 
-#ifdef RV8803_INT_GPIOS_IN_USE
+#if defined(RV8803_INT_GPIOS_IN_USE) || defined(CONFIG_RTC_ALARM) || defined(CONFIG_RTC_CALIBRATION)
 static int rv8803_write_reg8(const struct device *dev, uint8_t addr, uint8_t val)
 {
 	return rv8803_write_regs(dev, addr, &val, sizeof(val));


### PR DESCRIPTION
This PR fixes the issue that building the driver with either 
CONFIG_RTC_CALIBRATION=y or CONFIG_RTC_ALARM=y 
and without 'int-gpios' used will cause 'undefined reference 
to `rv8803_write_reg8'' error.