### PR TITLE
dts: arm: st: stm32h5: relocate `power-states` node

### DIFF
--- a/dts/arm/st/h5/stm32h5.dtsi
+++ b/dts/arm/st/h5/stm32h5.dtsi
@@ -39,6 +39,15 @@
 				reg = <0xe000ed90 0x40>;
 			};
 		};
+
+		power-states {
+			stop: state0 {
+				compatible = "zephyr,power-state";
+				power-state-name = "suspend-to-idle";
+				substate-id = <1>;
+				min-residency-us = <20>;
+			};
+		};
 	};
 
 	clocks {
@@ -135,15 +144,6 @@
 			clocks = <&rcc STM32_CLOCK(AHB1, 28U)>;
 			zephyr,memory-region = "BACKUP_SRAM";
 			status = "disabled";
-		};
-
-		power-states {
-			stop: state0 {
-				compatible = "zephyr,power-state";
-				power-state-name = "suspend-to-idle";
-				substate-id = <1>;
-				min-residency-us = <20>;
-			};
 		};
 
 		rcc: rcc@44020c00 {


### PR DESCRIPTION
Relocate the `power-states` node from under the `soc` node to the `cpus` node, making it consistent with other STM32 SoC series.

This resolves the device-tree warning:
(simple_bus_reg): /soc/power-states: missing or empty reg/ranges property.