### PR TITLE
tests: kernel: workq_stop uninitialized variable

### DIFF
--- a/tests/kernel/workq/work_queue/src/start_stop.c
+++ b/tests/kernel/workq/work_queue/src/start_stop.c
@@ -25,7 +25,7 @@ ZTEST(workqueue_api, test_k_work_queue_stop)
 {
 	size_t i;
 	struct k_work work;
-	struct k_work_q work_q;
+	struct k_work_q work_q = {0};
 	struct k_work works[NUM_TEST_ITEMS];
 	struct k_work_queue_config cfg = {
 		.name = "test_work_q",


### PR DESCRIPTION
test_k_workqueue_stop uses an uninitialized variable, causing sporadic test failures.

Documentation for `k_work_queue_start` says:
```
pointer to the queue structure. It must be initialized in zeroed/bss memory or with @ref k_work_queue_init before
use.
```


Fixes #83047