### PR TITLE
tests: bluetooth: tester: Increase number of PSA key slots for mesh

### DIFF
--- a/tests/bluetooth/tester/overlay-mesh.conf
+++ b/tests/bluetooth/tester/overlay-mesh.conf
@@ -1,3 +1,8 @@
+# Different test cases require different number of
+# PSA key slots; in order to make sure there is always
+# enough key slots allocating 32 slots.
+CONFIG_MBEDTLS_PSA_KEY_SLOT_COUNT=32
+
 CONFIG_BT_MESH=y
 CONFIG_BT_MESH_RELAY=y
 CONFIG_BT_MESH_PB_ADV=y


### PR DESCRIPTION
MESH PTS tests require different number of keys, as an example; only one netkey requires 8 key slots and there are test cases that use at least two netkeys which consume the default 16 slots, so it is better to have enough slots all times. Setting slot count to 32.