### PR TITLE
doc: add updating zephyr dependencies

### DIFF
--- a/doc/develop/beyond-GSG.rst
+++ b/doc/develop/beyond-GSG.rst
@@ -144,6 +144,21 @@ the previous paragraph.
    git pull
    west update
 
+Keeping Zephyr dependencies updated
+===================================
+
+To update the Python dependencies of the Zephyr project, you can use the
+``west packages pip --install -- --upgrade`` command. This command will install or upgrade the
+Python packages required by Zephyr and it's modules. This should be done after updating the Zephyr
+project source code. Make sure to execute this command while the virtual environment, you use when
+working with Zephyr, is active.
+
+.. code-block:: console
+
+   # replace zephyrproject with the path you gave west init
+   cd zephyrproject/zephyr
+   west packages pip --install -- --upgrade
+
 Export Zephyr CMake package
 ***************************
 


### PR DESCRIPTION
add part about updating zephyr dependencies.

sometimes dependencies change, so users should update these too.

For example it's very extreme for the nanopb module, there the `protobuf` python package must not be older than the nanopb module or else building will fail.