### PR TITLE
Bluetooth: Host: Conn: Iterate over connections in TX list to avoid starvation of other connections

### DIFF
--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -904,47 +904,44 @@ struct bt_conn *get_conn_ready(void)
 	sys_snode_t *prev = NULL;
 
 	if (dont_have_viewbufs()) {
-		/* We will get scheduled again when the (view) buffers are freed. If
-		 * you hit this a lot, try increasing `CONFIG_BT_CONN_FRAG_COUNT`
+		/* We will get scheduled again when the (view) buffers are freed. If you
+		 * hit this a lot, try increasing `CONFIG_BT_CONN_FRAG_COUNT`
 		 */
 		LOG_DBG("no view bufs");
 		return NULL;
 	}
 
-	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&bt_dev.le.conn_ready, conn, tmp,
-					  _conn_ready) {
+	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&bt_dev.le.conn_ready, conn, tmp, _conn_ready) {
+		__ASSERT_NO_MSG(tmp != conn);
+
 		/* Iterate over the list of connections that have data to send
 		 * and return the first one that can be sent.
 		 */
 
 		if (cannot_send_to_controller(conn)) {
-			/* When buffers are full, try next connection.
-			 */
+			/* When buffers are full, try next connection. */
 			LOG_DBG("no LL bufs for %p", conn);
 			prev = &conn->_conn_ready;
 			continue;
 		}
 
 		if (dont_have_tx_context(conn)) {
-			/* When TX contexts are not available, try next connection.
-			 */
+			/* When TX contexts are not available, try next connection. */
 			LOG_DBG("no TX contexts for %p", conn);
 			prev = &conn->_conn_ready;
 			continue;
 		}
 
 		CHECKIF(dont_have_methods(conn)) {
-			/* When a connection is missing mandatory methods, try next
-			 * connection.
-			 */
-			LOG_DBG("conn %p (type %d) is missing mandatory methods",
-				conn, conn->type);
+			/* When a connection is missing mandatory methods, try next connection. */
+			LOG_DBG("conn %p (type %d) is missing mandatory methods", conn, conn->type);
 			prev = &conn->_conn_ready;
 			continue;
 		}
 
 		if (should_stop_tx(conn)) {
 			/* Move reference off the list */
+			__ASSERT_NO_MSG(prev != &conn->_conn_ready);
 			sys_slist_remove(&bt_dev.le.conn_ready, prev, &conn->_conn_ready);
 			(void)atomic_set(&conn->_conn_ready_lock, 0);
 			bt_conn_unref(conn);

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -944,13 +944,14 @@ struct bt_conn *get_conn_ready(void)
 			__ASSERT_NO_MSG(prev != &conn->_conn_ready);
 			sys_slist_remove(&bt_dev.le.conn_ready, prev, &conn->_conn_ready);
 			(void)atomic_set(&conn->_conn_ready_lock, 0);
-			bt_conn_unref(conn);
 
 			/* Append connection to list if it still has data */
 			if (conn->has_data(conn)) {
 				LOG_DBG("appending %p to back of TX queue", conn);
 				bt_conn_data_ready(conn);
 			}
+
+			return conn;
 		}
 
 		return bt_conn_ref(conn);

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -900,67 +900,67 @@ __maybe_unused static bool dont_have_methods(struct bt_conn *conn)
 
 struct bt_conn *get_conn_ready(void)
 {
-	/* Here we only peek: we pop the conn (and insert it at the back if it
-	 * still has data) after the QoS function returns false.
-	 */
-	sys_snode_t *node  = sys_slist_peek_head(&bt_dev.le.conn_ready);
-
-	if (node == NULL) {
-		return NULL;
-	}
-
-	/* `conn` borrows from the list node. That node is _not_ popped yet.
-	 *
-	 * If we end up not popping that conn off the list, we have to make sure
-	 * to increase the refcount before returning a pointer to that
-	 * connection out of this function.
-	 */
-	struct bt_conn *conn = CONTAINER_OF(node, struct bt_conn, _conn_ready);
+	struct bt_conn *conn, *tmp;
+	sys_snode_t *prev = NULL;
 
 	if (dont_have_viewbufs()) {
-		/* We will get scheduled again when the (view) buffers are freed. If you
-		 * hit this a lot, try increasing `CONFIG_BT_CONN_FRAG_COUNT`
+		/* We will get scheduled again when the (view) buffers are freed. If
+		 * you hit this a lot, try increasing `CONFIG_BT_CONN_FRAG_COUNT`
 		 */
 		LOG_DBG("no view bufs");
 		return NULL;
 	}
 
-	if (cannot_send_to_controller(conn)) {
-		/* We will get scheduled again when the buffers are freed. */
-		LOG_DBG("no LL bufs for %p", conn);
-		return NULL;
-	}
+	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&bt_dev.le.conn_ready, conn, tmp,
+					  _conn_ready) {
+		/* Iterate over the list of connections that have data to send
+		 * and return the first one that can be sent.
+		 */
 
-	if (dont_have_tx_context(conn)) {
-		/* We will get scheduled again when TX contexts are available. */
-		LOG_DBG("no TX contexts");
-		return NULL;
-	}
-
-	CHECKIF(dont_have_methods(conn)) {
-		LOG_DBG("conn %p (type %d) is missing mandatory methods",
-			conn, conn->type);
-
-		return NULL;
-	}
-
-	if (should_stop_tx(conn)) {
-		/* Move reference off the list and into the `conn` variable. */
-		__maybe_unused sys_snode_t *s = sys_slist_get(&bt_dev.le.conn_ready);
-
-		__ASSERT_NO_MSG(s == node);
-		(void)atomic_set(&conn->_conn_ready_lock, 0);
-
-		/* Append connection to list if it still has data */
-		if (conn->has_data(conn)) {
-			LOG_DBG("appending %p to back of TX queue", conn);
-			bt_conn_data_ready(conn);
+		if (cannot_send_to_controller(conn)) {
+			/* When buffers are full, try next connection.
+			 */
+			LOG_DBG("no LL bufs for %p", conn);
+			prev = &conn->_conn_ready;
+			continue;
 		}
 
-		return conn;
+		if (dont_have_tx_context(conn)) {
+			/* When TX contexts are not available, try next connection.
+			 */
+			LOG_DBG("no TX contexts for %p", conn);
+			prev = &conn->_conn_ready;
+			continue;
+		}
+
+		CHECKIF(dont_have_methods(conn)) {
+			/* When a connection is missing mandatory methods, try next
+			 * connection.
+			 */
+			LOG_DBG("conn %p (type %d) is missing mandatory methods",
+				conn, conn->type);
+			prev = &conn->_conn_ready;
+			continue;
+		}
+
+		if (should_stop_tx(conn)) {
+			/* Move reference off the list */
+			sys_slist_remove(&bt_dev.le.conn_ready, prev, &conn->_conn_ready);
+			(void)atomic_set(&conn->_conn_ready_lock, 0);
+			bt_conn_unref(conn);
+
+			/* Append connection to list if it still has data */
+			if (conn->has_data(conn)) {
+				LOG_DBG("appending %p to back of TX queue", conn);
+				bt_conn_data_ready(conn);
+			}
+		}
+
+		return bt_conn_ref(conn);
 	}
 
-	return bt_conn_ref(conn);
+	/* No connection has data to send */
+	return NULL;
 }
 
 /* Crazy that this file is compiled even if this is not true, but here we are. */


### PR DESCRIPTION
Currently, starvation can happen when sending data through the `bt_conn_tx_processor` as connections who are currently not able to send are chosen again in the next iteration. 

By iterating over all the connections in the TX list, we can find another connection which is currently able to send data, instead of returning NULL when the first connection can't send data. This avoids starvation of other connections which are be able to send data (another connection could have LL buffers or TX context).

Discord discussion: https://discord.com/channels/720317445772017664/1326845512829370420