### PR TITLE
net: http_server: allow specifying a default resource

### DIFF
--- a/doc/connectivity/networking/api/http_server.rst
+++ b/doc/connectivity/networking/api/http_server.rst
@@ -107,7 +107,7 @@ macro:
 
     static uint16_t http_service_port = 80;
 
-    HTTP_SERVICE_DEFINE(my_service, "0.0.0.0", &http_service_port, 1, 10, NULL);
+    HTTP_SERVICE_DEFINE(my_service, "0.0.0.0", &http_service_port, 1, 10, NULL, NULL);
 
 Alternatively, an HTTPS service can be defined with
 :c:macro:`HTTPS_SERVICE_DEFINE`:
@@ -125,7 +125,43 @@ Alternatively, an HTTPS service can be defined with
     };
 
     HTTPS_SERVICE_DEFINE(my_service, "0.0.0.0", &https_service_port, 1, 10,
-                         NULL, sec_tag_list, sizeof(sec_tag_list));
+                         NULL, NULL, sec_tag_list, sizeof(sec_tag_list));
+
+The ``_res_fallback`` parameter can be used when defining an HTTP/HTTPS service to
+specify a fallback resource which will be used if no other resource matches the
+URL. This can be used for example to serve an index page for all unknown paths
+(useful for a single-page app which handles routing in the frontend), or for a
+customised 404 response.
+
+.. code-block:: c
+
+    static int default_handler(struct http_client_ctx *client, enum http_data_status status,
+		       const struct http_request_ctx *request_ctx,
+		       struct http_response_ctx *response_ctx, void *user_data)
+    {
+        static const char response_404[] = "Oops, page not found!";
+
+        if (status == HTTP_SERVER_DATA_FINAL) {
+            response_ctx->status = 404;
+            response_ctx->body = response_404;
+            response_ctx->body_len = sizeof(response_404) - 1;
+            response_ctx->final_chunk = true;
+        }
+
+        return 0;
+    }
+
+    static struct http_resource_detail_dynamic default_detail = {
+        .common = {
+            .type = HTTP_RESOURCE_TYPE_DYNAMIC,
+            .bitmask_of_supported_http_methods = BIT(HTTP_GET),
+        },
+        .cb = default_handler,
+        .user_data = NULL,
+    };
+
+    /* Register a fallback resource to handle any unknown path */
+    HTTP_SERVICE_DEFINE(my_service, "0.0.0.0", &http_service_port, 1, 10, NULL, &default_detail);
 
 .. note::
 

--- a/doc/releases/migration-guide-4.1.rst
+++ b/doc/releases/migration-guide-4.1.rst
@@ -507,6 +507,11 @@ Networking
   access the request headers of the HTTP upgrade request, which may be useful in deciding whether
   to accept or reject a websocket connection.
 
+* An additional ``_res_fallback`` parameter has been added to the :c:macro:`HTTP_SERVICE_DEFINE`
+  and :c:macro:`HTTPS_SERVICE_DEFINE` macros, allowing a fallback resource to be served if no other
+  resources match the requested path. To retain the existing behaviour, ``NULL`` can be passed as the
+  additional parameter.
+
 * The :kconfig:option:`CONFIG_NET_L2_OPENTHREAD` symbol no longer implies the
   :kconfig:option:`CONFIG_NVS` Kconfig option. Platforms using OpenThread must explicitly enable
   either the :kconfig:option:`CONFIG_NVS` or :kconfig:option:`CONFIG_ZMS` Kconfig option.

--- a/include/zephyr/shell/shell_websocket.h
+++ b/include/zephyr/shell/shell_websocket.h
@@ -121,6 +121,7 @@ int shell_websocket_enable(const struct shell *sh);
 			     SHELL_WEBSOCKET_SERVICE_COUNT,		  \
 			     SHELL_WEBSOCKET_SERVICE_COUNT,		  \
 			     NULL,					  \
+			     NULL,                                        \
 			     _sec_tag_list,				  \
 			     _sec_tag_list_size);			  \
 	DEFINE_WEBSOCKET_SERVICE(_service);				  \
@@ -136,7 +137,7 @@ int shell_websocket_enable(const struct shell *sh);
 			    &SHELL_WS_PORT_NAME(_service),		\
 			    SHELL_WEBSOCKET_SERVICE_COUNT,		\
 			    SHELL_WEBSOCKET_SERVICE_COUNT,		\
-			    NULL);					\
+			    NULL, NULL);				\
 	DEFINE_WEBSOCKET_SERVICE(_service)
 
 #endif /* CONFIG_NET_SOCKETS_SOCKOPT_TLS */

--- a/samples/net/prometheus/src/main.c
+++ b/samples/net/prometheus/src/main.c
@@ -40,7 +40,7 @@ struct app_context {
 #if defined(CONFIG_NET_SAMPLE_HTTP_SERVICE)
 static uint16_t test_http_service_port = CONFIG_NET_SAMPLE_HTTP_SERVER_SERVICE_PORT;
 HTTP_SERVICE_DEFINE(test_http_service, CONFIG_NET_CONFIG_MY_IPV4_ADDR, &test_http_service_port, 1,
-		    10, NULL);
+		    10, NULL, NULL);
 
 static int dyn_handler(struct http_client_ctx *client, enum http_data_status status,
 		       const struct http_request_ctx *request_ctx,
@@ -99,7 +99,7 @@ const sec_tag_t sec_tag_list_verify_none[] = {
 
 static uint16_t test_https_service_port = CONFIG_NET_SAMPLE_HTTPS_SERVER_SERVICE_PORT;
 HTTPS_SERVICE_DEFINE(test_https_service, CONFIG_NET_CONFIG_MY_IPV4_ADDR, &test_https_service_port,
-		     1, 10, NULL, sec_tag_list_verify_none, sizeof(sec_tag_list_verify_none));
+		     1, 10, NULL, NULL, sec_tag_list_verify_none, sizeof(sec_tag_list_verify_none));
 
 HTTP_RESOURCE_DEFINE(index_html_gz_resource_https, test_https_service, "/metrics",
 		     &dyn_resource_detail);

--- a/samples/net/sockets/http_server/src/main.c
+++ b/samples/net/sockets/http_server/src/main.c
@@ -248,7 +248,7 @@ struct http_resource_detail_websocket ws_netstats_resource_detail = {
 #if defined(CONFIG_NET_SAMPLE_HTTP_SERVICE)
 static uint16_t test_http_service_port = CONFIG_NET_SAMPLE_HTTP_SERVER_SERVICE_PORT;
 HTTP_SERVICE_DEFINE(test_http_service, NULL, &test_http_service_port, 1,
-		    10, NULL);
+		    10, NULL, NULL);
 
 HTTP_RESOURCE_DEFINE(index_html_gz_resource, test_http_service, "/",
 		     &index_html_gz_resource_detail);
@@ -281,7 +281,7 @@ static const sec_tag_t sec_tag_list_verify_none[] = {
 
 static uint16_t test_https_service_port = CONFIG_NET_SAMPLE_HTTPS_SERVER_SERVICE_PORT;
 HTTPS_SERVICE_DEFINE(test_https_service, NULL,
-		     &test_https_service_port, 1, 10, NULL,
+		     &test_https_service_port, 1, 10, NULL, NULL,
 		     sec_tag_list_verify_none, sizeof(sec_tag_list_verify_none));
 
 HTTP_RESOURCE_DEFINE(index_html_gz_resource_https, test_https_service, "/",

--- a/subsys/net/lib/http/http_server_core.c
+++ b/subsys/net/lib/http/http_server_core.c
@@ -719,6 +719,17 @@ static int compare_strings(const char *path, const char *resource)
 	return 1; /* Strings are not equal */
 }
 
+static int path_len_without_query(const char *path)
+{
+	int len = 0;
+
+	while ((path[len] != '\0') && (path[len] != '?')) {
+		len++;
+	}
+
+	return len;
+}
+
 static bool skip_this(struct http_resource_desc *resource, bool is_websocket)
 {
 	struct http_resource_detail *detail;
@@ -762,6 +773,11 @@ struct http_resource_detail *get_resource_detail(const struct http_service_desc 
 			*path_len = strlen(resource->resource);
 			return resource->detail;
 		}
+	}
+
+	if (service->res_fallback != NULL) {
+		*path_len = path_len_without_query(path);
+		return service->res_fallback;
 	}
 
 	NET_DBG("No match for %s", path);

--- a/tests/net/lib/http_server/common/sections-rom.ld
+++ b/tests/net/lib/http_server/common/sections-rom.ld
@@ -3,3 +3,4 @@
 ITERABLE_SECTION_ROM(http_resource_desc_service_A, Z_LINK_ITERABLE_SUBALIGN)
 ITERABLE_SECTION_ROM(http_resource_desc_service_B, Z_LINK_ITERABLE_SUBALIGN)
 ITERABLE_SECTION_ROM(http_resource_desc_service_D, Z_LINK_ITERABLE_SUBALIGN)
+ITERABLE_SECTION_ROM(http_resource_desc_service_E, Z_LINK_ITERABLE_SUBALIGN)

--- a/tests/net/lib/http_server/common/src/main.c
+++ b/tests/net/lib/http_server/common/src/main.c
@@ -50,14 +50,14 @@ static struct http_resource_detail detail[] = {
  * the paths (and implementation-specific details) are known at compile time.
  */
 static const uint16_t service_A_port = 4242;
-HTTP_SERVICE_DEFINE(service_A, "a.service.com", &service_A_port, 4, 2, DETAIL(0));
+HTTP_SERVICE_DEFINE(service_A, "a.service.com", &service_A_port, 4, 2, DETAIL(0), NULL);
 HTTP_RESOURCE_DEFINE(resource_0, service_A, "/", RES(0));
 HTTP_RESOURCE_DEFINE(resource_1, service_A, "/index.html", RES(1));
 HTTP_RESOURCE_DEFINE(resource_2, service_A, "/fs/*", RES(5));
 
 /* ephemeral port of 0 */
 static uint16_t service_B_port;
-HTTP_SERVICE_DEFINE(service_B, "b.service.com", &service_B_port, 7, 3, DETAIL(1));
+HTTP_SERVICE_DEFINE(service_B, "b.service.com", &service_B_port, 7, 3, DETAIL(1), NULL);
 HTTP_RESOURCE_DEFINE(resource_3, service_B, "/foo.htm", RES(2));
 HTTP_RESOURCE_DEFINE(resource_4, service_B, "/bar/baz.php", RES(3));
 
@@ -67,16 +67,21 @@ HTTP_RESOURCE_DEFINE(resource_4, service_B, "/bar/baz.php", RES(3));
  * runtime.
  */
 static const uint16_t service_C_port = 5959;
-HTTP_SERVICE_DEFINE_EMPTY(service_C, "192.168.1.1", &service_C_port, 5, 9, DETAIL(2));
+HTTP_SERVICE_DEFINE_EMPTY(service_C, "192.168.1.1", &service_C_port, 5, 9, DETAIL(2), NULL);
 
 /* Wildcard resources */
 static uint16_t service_D_port = service_A_port + 1;
-HTTP_SERVICE_DEFINE(service_D, "2001:db8::1", &service_D_port, 7, 3, DETAIL(3));
+HTTP_SERVICE_DEFINE(service_D, "2001:db8::1", &service_D_port, 7, 3, DETAIL(3), NULL);
 HTTP_RESOURCE_DEFINE(resource_5, service_D, "/foo1.htm*", RES(0));
 HTTP_RESOURCE_DEFINE(resource_6, service_D, "/fo*", RES(1));
 HTTP_RESOURCE_DEFINE(resource_7, service_D, "/f[ob]o3.html", RES(1));
 HTTP_RESOURCE_DEFINE(resource_8, service_D, "/fb?3.htm", RES(0));
 HTTP_RESOURCE_DEFINE(resource_9, service_D, "/f*4.html", RES(3));
+
+/* Default resource in case of no match */
+static uint16_t service_E_port = 8080;
+HTTP_SERVICE_DEFINE(service_E, "192.0.2.1", &service_E_port, 0, 0, NULL, DETAIL(0));
+HTTP_RESOURCE_DEFINE(resource_10, service_E, "/index.html", RES(4));
 
 ZTEST(http_service, test_HTTP_SERVICE_DEFINE)
 {
@@ -110,7 +115,7 @@ ZTEST(http_service, test_HTTP_SERVICE_COUNT)
 
 	n_svc = 4273;
 	HTTP_SERVICE_COUNT(&n_svc);
-	zassert_equal(n_svc, 4);
+	zassert_equal(n_svc, 5);
 }
 
 ZTEST(http_service, test_HTTP_SERVICE_RESOURCE_COUNT)
@@ -127,6 +132,7 @@ ZTEST(http_service, test_HTTP_SERVICE_FOREACH)
 	size_t have_service_B = 0;
 	size_t have_service_C = 0;
 	size_t have_service_D = 0;
+	size_t have_service_E = 0;
 
 	HTTP_SERVICE_FOREACH(svc) {
 		if (svc == &service_A) {
@@ -137,17 +143,21 @@ ZTEST(http_service, test_HTTP_SERVICE_FOREACH)
 			have_service_C = 1;
 		} else if (svc == &service_D) {
 			have_service_D = 1;
+		} else if (svc == &service_E) {
+			have_service_E = 1;
 		} else {
-			zassert_unreachable("svc (%p) not equal to &service_A (%p), &service_B "
-					    "(%p), or &service_C (%p)",
-					    svc, &service_A, &service_B, &service_C);
+			zassert_unreachable("svc (%p) not equal to any defined service", svc);
 		}
 
 		n_svc++;
 	}
 
-	zassert_equal(n_svc, 4);
-	zassert_equal(have_service_A + have_service_B + have_service_C + have_service_D, n_svc);
+	zassert_equal(n_svc, 5);
+	zassert_equal(have_service_A, 1);
+	zassert_equal(have_service_B, 1);
+	zassert_equal(have_service_C, 1);
+	zassert_equal(have_service_D, 1);
+	zassert_equal(have_service_E, 1);
 }
 
 ZTEST(http_service, test_HTTP_RESOURCE_FOREACH)
@@ -363,6 +373,31 @@ ZTEST(http_service, test_HTTP_RESOURCE_WILDCARD)
 	res = CHECK_PATH(service_A, "/fbo3.htm", &len);
 	zassert_is_null(res, "Resource found");
 	zassert_equal(len, 0, "Length set");
+}
+
+ZTEST(http_service, test_HTTP_RESOURCE_DEFAULT)
+{
+#define NON_EXISTING_PATH "/this_path_is_not_registered"
+	struct http_resource_detail *res;
+	int len;
+
+	/* For a path that does exist, the correct resource should be returned */
+	res = CHECK_PATH(service_E, "/index.html", &len);
+	zassert_not_null(res, "Cannot find resource");
+	zassert_true(len > 0, "Length not set");
+	zassert_equal(res, RES(4), "Resource mismatch");
+
+	/* For a path that does not exist, the default resource should be returned */
+	res = CHECK_PATH(service_E, NON_EXISTING_PATH, &len);
+	zassert_not_null(res, "Cannot find resource");
+	zassert_equal(len, strlen(NON_EXISTING_PATH), "Length incorrect");
+	zassert_equal(res, RES(0), "Resource mismatch");
+
+	/* If query params are present, length should not include them */
+	res = CHECK_PATH(service_E, NON_EXISTING_PATH "?param=value", &len);
+	zassert_not_null(res, "Cannot find resource");
+	zassert_equal(len, strlen(NON_EXISTING_PATH), "Length incorrect");
+	zassert_equal(res, RES(0), "Resource mismatch");
 }
 
 extern void http_server_get_content_type_from_extension(char *url, char *content_type,

--- a/tests/net/lib/http_server/core/src/main.c
+++ b/tests/net/lib/http_server/core/src/main.c
@@ -235,7 +235,7 @@ BUILD_ASSERT(sizeof(long_payload) - 1 > CONFIG_HTTP_SERVER_CLIENT_BUFFER_SIZE,
 
 static uint16_t test_http_service_port = SERVER_PORT;
 HTTP_SERVICE_DEFINE(test_http_service, SERVER_IPV4_ADDR,
-		    &test_http_service_port, 1, 10, NULL);
+		    &test_http_service_port, 1, 10, NULL, NULL);
 
 static const char static_resource_payload[] = TEST_STATIC_PAYLOAD;
 struct http_resource_detail_static static_resource_detail = {

--- a/tests/net/lib/http_server/crime/src/main.c
+++ b/tests/net/lib/http_server/crime/src/main.c
@@ -46,7 +46,7 @@ static const unsigned char compressed_inc_file[] = {
 static uint16_t test_http_service_port = SERVER_PORT;
 HTTP_SERVICE_DEFINE(test_http_service, MY_IPV4_ADDR,
 		    &test_http_service_port, 1,
-		    10, NULL);
+		    10, NULL, NULL);
 
 struct http_resource_detail_static index_html_gz_resource_detail = {
 	.common = {

--- a/tests/net/lib/http_server/tls/src/main.c
+++ b/tests/net/lib/http_server/tls/src/main.c
@@ -43,7 +43,7 @@ static const sec_tag_t server_tag_list_verify[] = {
 
 static uint16_t test_http_service_port = SERVER_PORT;
 HTTPS_SERVICE_DEFINE(test_http_service, MY_IPV4_ADDR, &test_http_service_port,
-		     1, 10, NULL, server_tag_list_verify,
+		     1, 10, NULL, NULL, server_tag_list_verify,
 		     sizeof(server_tag_list_verify));
 
 static const unsigned char ca[] = {


### PR DESCRIPTION
Add a `_res_fallback` parameter to `HTTP_SERVICE_DEFINE`, which can be used to specify a fallback resource detail which will be served if no other resource is matched.

This could be used to:
- Provide a custom 404 response
- Better support a single-page app with routing handled in the frontend. This use-case is where I ran into issues at the moment - the routing in the frontend works fine until the page is refreshed, at which point the browser sends a request to the backend, the path doesn't exist, and a 404 is returned