### PR TITLE
tests: kernel: timer_behaviour shouldn't use fabs

### DIFF
--- a/tests/kernel/timer/timer_behavior/src/jitter_drift.c
+++ b/tests/kernel/timer/timer_behavior/src/jitter_drift.c
@@ -235,6 +235,8 @@ static void do_test_using(void (*sample_collection_fn)(void), const char *mechan
 		* CONFIG_TIMER_TEST_SAMPLES;
 	double time_diff_us = actual_time_us - expected_time_us
 		- expected_time_drift_us;
+	double time_diff_us_abs = time_diff_us >= 0.0 ? time_diff_us : -time_diff_us;
+
 	/* If max stddev is lower than a single clock cycle then round it up. */
 	uint32_t max_stddev = MAX(k_cyc_to_us_ceil32(1), CONFIG_TIMER_TEST_MAX_STDDEV);
 
@@ -333,7 +335,7 @@ static void do_test_using(void (*sample_collection_fn)(void), const char *mechan
 		     "Standard deviation (in microseconds) outside expected bound");
 
 	/* Validate the timer drift (accuracy over time) is within a configurable bound */
-	zassert_true(fabs(time_diff_us) < CONFIG_TIMER_TEST_MAX_DRIFT,
+	zassert_true(time_diff_us_abs < CONFIG_TIMER_TEST_MAX_DRIFT,
 		     "Drift (in microseconds) outside expected bound");
 }
 


### PR DESCRIPTION
Currently the timer_behavior test uses fabs.
Since the C library functions being used in the kernel is restricted in [Rule A.4 in the Coding Standard](https://docs.zephyrproject.org/latest/contribute/coding_guidelines/index.html#rule-a-4-c-standard-library-usage-restrictions-in-zephyr-kernel)
We should probably not use these functions in kernel tests either.

To reproduce
```
scripts/twister -p qemu_cortex_m0 -T tests/kernel/timer/timer_behavior/ -x CONFIG_MINIMAL_LIBC=y
[...]
/workdir/zephyr/tests/kernel/timer/timer_behavior/src/jitter_drift.c: In function 'do_test_using':
/workdir/zephyr/tests/kernel/timer/timer_behavior/src/jitter_drift.c:336:22: error: implicit declaration of function 'fabs'; did you mean 'labs'? [-Werror=implicit-function-declaration]
  336 |         zassert_true(fabs(time_diff_us) < CONFIG_TIMER_TEST_MAX_DRIFT,
[...]
```

I am unsure if this is the "correctest" solution, but since it is simple and makes the test work in strictly more cases I think it should be fine?

There are tests FORCING minimal libc on similar kernel tests, possibly to uncover similar issues. Should I add it to this test as well?
