### PR TITLE
tests: twister: add supported toolchains for unit tests

### DIFF
--- a/subsys/testsuite/boards/unit_testing/unit_testing/unit_testing.yaml
+++ b/subsys/testsuite/boards/unit_testing/unit_testing/unit_testing.yaml
@@ -2,5 +2,7 @@ identifier: unit_testing
 name: Unit Testing
 type: unit
 arch: unit
+toolchain:
+  - host
 testing:
   default: true


### PR DESCRIPTION
Allowed toolchains was not set in 'board' metadata causing those to not
build and get filtered.

Fixes #83792

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
