### PR TITLE
kernel: poll: Allow 0 events for submitted work

### DIFF
--- a/kernel/poll.c
+++ b/kernel/poll.c
@@ -675,7 +675,7 @@ int k_work_poll_submit_to_queue(struct k_work_q *work_q,
 	__ASSERT(work_q != NULL, "NULL work_q\n");
 	__ASSERT(work != NULL, "NULL work\n");
 	__ASSERT(events != NULL, "NULL events\n");
-	__ASSERT(num_events > 0, "zero events\n");
+	__ASSERT(num_events >= 0, "<0 events\n");
 
 	SYS_PORT_TRACING_FUNC_ENTER(k_work_poll, submit_to_queue, work_q, work, timeout);
 


### PR DESCRIPTION
Change:
    commit cc6317d7ac30479db060f60c66bb48a12b2d0be6
    Author: Jukka Rissanen <jukka.rissanen@linux.intel.com>
    Date:   Fri Nov 1 14:03:32 2019 +0200

        kernel: poll: Allow 0 event input

Allows `k_poll` to be user with 0 events, which is useful for allowing just a sleep without having to create artivical events.

Allow the same for `k_work_submit_to_queue()` and `k_work_submit()`.