### PR TITLE
Re-enable `-Wunused-function` for clang

### DIFF
--- a/cmake/compiler/clang/compiler_flags.cmake
+++ b/cmake/compiler/clang/compiler_flags.cmake
@@ -103,7 +103,6 @@ check_set_compiler_property(PROPERTY warning_extended
                             #FIXME: need to fix all of those
                             -Wno-self-assign
                             -Wno-address-of-packed-member
-                            -Wno-unused-function
                             -Wno-initializer-overrides
                             -Wno-section
                             -Wno-unused-variable


### PR DESCRIPTION
Re-enable the `-Wunused-function` warning when building with `clang`. Unlike `gcc`, `clang` generates warnings before optimizations, so it catches more. 

Depends on https://github.com/zephyrproject-rtos/zephyr/pull/84063