### PR TITLE
scripts: west_commands: runners: fix support for JLink RTT

### DIFF
--- a/scripts/west_commands/runners/jlink.py
+++ b/scripts/west_commands/runners/jlink.py
@@ -330,9 +330,7 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
                         break
                     except ConnectionRefusedError:
                         time.sleep(0.1)
-                sock.shutdown(socket.SHUT_RDWR)
-                time.sleep(0.1)
-                self.run_telnet_client('localhost', self.rtt_port)
+                self.run_telnet_client('localhost', self.rtt_port, sock)
             except Exception as e:
                 self.logger.error(e)
             finally:


### PR DESCRIPTION
JLink refuses new RTT telnet connections for a few moments after a socket closes. This causes an issue when using `nc` as the telnet viewer, since JLink would deny the connection. To resolve this, keep the "ping" socket we use to determine if the RTT viewer is active connected, and use that socket for RTT communication.

Another solution here would be to simply increase the delay before opening the `nc` connection- however I think this approach makes less sense, as it will increase latency when starting `west rtt`. Moreover, it isn't clear exactly how long JLink will deny new connections for, so the new delay would be arbitrary 