### PR TITLE
tests: kernel/msgq_api: add k_thread_join after k_thread_abort

### DIFF
--- a/tests/kernel/msgq/msgq_api/src/main.c
+++ b/tests/kernel/msgq/msgq_api/src/main.c
@@ -27,6 +27,7 @@ extern struct k_msgq kmsgq;
 extern struct k_msgq msgq;
 extern struct k_sem end_sema;
 extern struct k_thread tdata;
+extern k_tid_t tids[2];
 K_THREAD_STACK_DECLARE(tstack, STACK_SIZE);
 
 void *msgq_api_setup(void)
@@ -36,6 +37,29 @@ void *msgq_api_setup(void)
 	k_thread_heap_assign(k_current_get(), &test_pool);
 	return NULL;
 }
-ZTEST_SUITE(msgq_api, NULL, msgq_api_setup, NULL, NULL, NULL);
+
+static void test_end_threads_join(void)
+{
+	for (int i = 0; i < ARRAY_SIZE(tids); i++) {
+		if (tids[i] != NULL) {
+			k_thread_join(tids[i], K_FOREVER);
+			tids[i] = NULL;
+		}
+	}
+}
+
+static void msgq_api_test_after(void *data)
+{
+	test_end_threads_join();
+}
+
+static void msgq_api_test_1cpu_after(void *data)
+{
+	test_end_threads_join();
+
+	ztest_simple_1cpu_after(data);
+}
+
+ZTEST_SUITE(msgq_api, NULL, msgq_api_setup, NULL, msgq_api_test_after, NULL);
 ZTEST_SUITE(msgq_api_1cpu, NULL, msgq_api_setup,
-	    ztest_simple_1cpu_before, ztest_simple_1cpu_after, NULL);
+	    ztest_simple_1cpu_before, msgq_api_test_1cpu_after, NULL);

--- a/tests/kernel/msgq/msgq_api/src/test_msgq_purge.c
+++ b/tests/kernel/msgq/msgq_api/src/test_msgq_purge.c
@@ -8,6 +8,7 @@
 
 K_THREAD_STACK_DECLARE(tstack, STACK_SIZE);
 extern struct k_thread tdata;
+extern k_tid_t tids[2];
 extern struct k_msgq msgq;
 static ZTEST_BMEM char __aligned(4) tbuffer[MSG_SIZE * MSGQ_LEN];
 static ZTEST_DMEM uint32_t data[MSGQ_LEN] = { MSG0, MSG1 };
@@ -29,10 +30,10 @@ static void purge_when_put(struct k_msgq *q)
 		zassert_equal(ret, 0);
 	}
 	/*create another thread waiting to put msg*/
-	k_thread_create(&tdata, tstack, STACK_SIZE,
-			tThread_entry, q, NULL, NULL,
-			K_PRIO_PREEMPT(0), K_USER | K_INHERIT_PERMS,
-			K_NO_WAIT);
+	tids[0] = k_thread_create(&tdata, tstack, STACK_SIZE,
+				  tThread_entry, q, NULL, NULL,
+				  K_PRIO_PREEMPT(0), K_USER | K_INHERIT_PERMS,
+				  K_NO_WAIT);
 	k_msleep(TIMEOUT_MS >> 1);
 	/**TESTPOINT: msgq purge while another thread waiting to put msg*/
 	k_msgq_purge(q);
@@ -43,7 +44,7 @@ static void purge_when_put(struct k_msgq *q)
 		zassert_equal(ret, 0);
 	}
 
-	k_thread_abort(&tdata);
+	k_thread_abort(tids[0]);
 }
 
 /**


### PR DESCRIPTION
On SMP systems, threads going through k_thread_abort() may still be running while the test moves on to the next one. This creates some interferences and may result in the next test failing. So add k_thread_join() after k_thread_abort() to make sure those threads have stopped before moving on.