### PR TITLE
Re-enable `-Wmissing-braces` warning for clang

### DIFF
--- a/cmake/compiler/clang/compiler_flags.cmake
+++ b/cmake/compiler/clang/compiler_flags.cmake
@@ -102,7 +102,6 @@ check_set_compiler_property(APPEND PROPERTY warning_dw_3
 check_set_compiler_property(PROPERTY warning_extended
                             #FIXME: need to fix all of those
                             -Wno-sometimes-uninitialized
-                            -Wno-missing-braces
                             -Wno-self-assign
                             -Wno-address-of-packed-member
                             -Wno-unused-function


### PR DESCRIPTION
All warnings in the code base have been resolved.