### PR TITLE
Re-enable -Wshift-overflow for clang

### DIFF
--- a/cmake/compiler/clang/compiler_flags.cmake
+++ b/cmake/compiler/clang/compiler_flags.cmake
@@ -102,7 +102,6 @@ check_set_compiler_property(APPEND PROPERTY warning_dw_3
 check_set_compiler_property(PROPERTY warning_extended
                             #FIXME: need to fix all of those
                             -Wno-sometimes-uninitialized
-                            -Wno-shift-overflow
                             -Wno-missing-braces
                             -Wno-self-assign
                             -Wno-address-of-packed-member


### PR DESCRIPTION
There is a `FIXME` to re-enable the warnings that are currently disabled in clang. It appears that this warning can be re-enabled without any changes (no warnings emitted).