### PR TITLE
Re-enable `-Wtautological-compare` for clang

### DIFF
--- a/cmake/compiler/clang/compiler_flags.cmake
+++ b/cmake/compiler/clang/compiler_flags.cmake
@@ -113,8 +113,6 @@ check_set_compiler_property(PROPERTY warning_extended
                             -Wno-unused-variable
                             -Wno-format-invalid-specifier
                             -Wno-gnu
-                            # comparison of unsigned expression < 0 is always false
-                            -Wno-tautological-compare
 )
 
 set_compiler_property(PROPERTY warning_error_coding_guideline

--- a/samples/modules/lvgl/screen_transparency/src/main.c
+++ b/samples/modules/lvgl/screen_transparency/src/main.c
@@ -44,7 +44,7 @@ int main(void)
 	}
 
 	display_get_capabilities(display_dev, &display_caps);
-	if (!(display_caps.supported_pixel_formats | PIXEL_FORMAT_ARGB_8888)) {
+	if (!(display_caps.supported_pixel_formats & PIXEL_FORMAT_ARGB_8888)) {
 		LOG_ERR("Display does not support ARGB8888 mode");
 		return -ENOTSUP;
 	}


### PR DESCRIPTION
All warnings in the code base have been resolved.