### PR TITLE
dts: bindings: display: Change the property names in the overlay

### DIFF
--- a/boards/shields/ftdi_vm800c/ftdi_vm800c.overlay
+++ b/boards/shields/ftdi_vm800c/ftdi_vm800c.overlay
@@ -19,7 +19,7 @@
 		irq-gpios = <&arduino_header 8 GPIO_ACTIVE_LOW>;
 
 		pclk = <5>;
-		pclk_pol = <1>;
+		pclk-pol = <1>;
 		cspread = <1>;
 		swizzle = <0>;
 		vsize = <272>;

--- a/boards/shields/ssd1306/ssd1306_128x64_spi.overlay
+++ b/boards/shields/ssd1306/ssd1306_128x64_spi.overlay
@@ -26,7 +26,7 @@
 		segment-remap;
 		com-invdir;
 		prechargep = <0x22>;
-		data_cmd-gpios = <&arduino_header 15 0>;
+		data-cmd-gpios = <&arduino_header 15 0>;
 		/* reset-gpios = <&arduino_header 14 GPIO_ACTIVE_LOW>; */
 	};
 };

--- a/doc/releases/migration-guide-4.1.rst
+++ b/doc/releases/migration-guide-4.1.rst
@@ -143,6 +143,8 @@ Display
         ...
     };
 
+* Renamed the devicetree propertys ``pclk_pol`` and ``data_cmd-gpios``
+  to ``pclk-pol`` and ``data-cmd-gpios``.
 
 Enhanced Serial Peripheral Interface (eSPI)
 ===========================================

--- a/dts/bindings/display/ftdi,ft800.yaml
+++ b/dts/bindings/display/ftdi,ft800.yaml
@@ -20,7 +20,7 @@ properties:
       typical main clock was 48MHz and this value is 5, the PCLK
       will be 9.6 MHz. Must be positive value to enable the screen
 
-  pclk_pol:
+  pclk-pol:
     type: int
     required: true
     description: |

--- a/dts/bindings/display/sinowealth,sh1106-spi.yaml
+++ b/dts/bindings/display/sinowealth,sh1106-spi.yaml
@@ -8,7 +8,7 @@ compatible: "sinowealth,sh1106"
 include: ["solomon,ssd1306fb-common.yaml", "spi-device.yaml"]
 
 properties:
-  data_cmd-gpios:
+  data-cmd-gpios:
     type: phandle-array
     required: true
     description: D/C# pin.

--- a/dts/bindings/display/solomon,ssd1306fb-spi.yaml
+++ b/dts/bindings/display/solomon,ssd1306fb-spi.yaml
@@ -8,7 +8,7 @@ compatible: "solomon,ssd1306fb"
 include: ["solomon,ssd1306fb-common.yaml", "spi-device.yaml"]
 
 properties:
-  data_cmd-gpios:
+  data-cmd-gpios:
     type: phandle-array
     required: true
     description: D/C# pin.


### PR DESCRIPTION
Unify property names in bindings and overrides, using hyphens (-) instead of underscores (_) as separators.