### PR TITLE
cmake: unittest: add `-t run` support

### DIFF
--- a/cmake/modules/unittest.cmake
+++ b/cmake/modules/unittest.cmake
@@ -162,6 +162,13 @@ if(VALGRIND_PROGRAM)
     )
 endif()
 
+add_custom_target(run
+  COMMAND
+  $<TARGET_FILE:testbinary>
+  DEPENDS testbinary
+  WORKING_DIRECTORY ${APPLICATION_BINARY_DIR}
+  )
+
 add_custom_target(run-test
   COMMAND
   ${VALGRIND} ${VALGRIND_FLAGS}


### PR DESCRIPTION
Add support to run unit tests directly from `west build`, for environments where `west build -t run-test` (which runs the binary under valgrind) is inappropriate or unavailable (WSL).

`west build -t run` also has the muscle-memory advantage of being the same target name as the `native_sim` boards.

Example complete command:
```
west build -b unit_testing -t run tests/unit/crc/
```