### PR TITLE
dts: bindings: stepper: use hyphens instead of underscore

### DIFF
--- a/doc/releases/migration-guide-4.1.rst
+++ b/doc/releases/migration-guide-4.1.rst
@@ -279,6 +279,16 @@ Stepper
     :kconfig:option:`STEPPER_ADI_TMC5041_RAMP_GEN` option.
   * To control the velocity for :dtcompatible:`adi,tmc5041` stepper driver, use
     :c:func:`tmc5041_stepper_set_max_velocity` or :c:func:`tmc5041_stepper_set_ramp`.
+  * Renamed the DeviceTree property ``en_spreadcycle`` to ``en-spreadcycle``.
+  * Renamed the DeviceTree property ``i_scale_analog`` to ``i-scale-analog``.
+  * Renamed the DeviceTree property ``index_optw`` to ``index-otpw``.
+  * Renamed the DeviceTree property ``ìndex_step`` to ``index-step``.
+  * Renamed the DeviceTree property ``internal_rsense`` to ``internal-rsense``.
+  * Renamed the DeviceTree property ``lock_gconf`` to ``lock-gconf``.
+  * Renamed the DeviceTree property ``mstep_reg_select`` to ``mstep-reg-select``.
+  * Renamed the DeviceTree property ``pdn_disable`` to ``pdn-disable``.
+  * Renamed the DeviceTree property ``poscmp_enable`` to ``poscmp-enable``.
+  * Renamed the DeviceTree property ``test_mode`` to ``test-mode``.
 
 SPI
 ===

--- a/dts/bindings/stepper/adi/adi,tmc5041.yaml
+++ b/dts/bindings/stepper/adi/adi,tmc5041.yaml
@@ -20,7 +20,7 @@ description: |
             #address-cells = <1>;
             #size-cells = <0>;
 
-            poscmp_enable; test_mode; lock_gconf; /* ADI TMC Global configuration flags */
+            poscmp-enable; test-mode; lock-gconf; /* ADI TMC Global configuration flags */
             clock-frequency = <DT_FREQ_M(16)>; /* Internal/External Clock frequency */
 
             motor: motor@0 {
@@ -62,11 +62,11 @@ include:
   - name: spi-device.yaml
   - name: adi,trinamic-gconf.yaml
     property-allowlist:
-      - poscmp_enable
+      - poscmp-enable
       - shaft1
       - shaft2
-      - test_mode
-      - lock_gconf
+      - test-mode
+      - lock-gconf
 
 properties:
   "#address-cells":

--- a/dts/bindings/stepper/adi/adi,trinamic-gconf.yaml
+++ b/dts/bindings/stepper/adi/adi,trinamic-gconf.yaml
@@ -4,51 +4,51 @@
 description: Global configuration flags for Trinamic stepper controller.
 
 properties:
-  en_spreadcycle:
+  en-spreadcycle:
     type: boolean
     description: |
       A high level on the pin SPREAD inverts this flag to switch between both chopper modes.
       0: StealthChop mode
       1: SpreadCycle mode enabled
 
-  i_scale_analog:
+  i-scale-analog:
     type: boolean
     description: |
       0: Use internal reference derived from 5VOUT
       1: Use voltage supplied to VREF as current reference
 
-  internal_rsense:
+  internal-rsense:
     type: boolean
     description: |
       0: Operation with external sense resistors
       1: Internal sense resistors. Use current supplied into VREF as reference for internal
          sense resistor. VREF pin internally is driven to GND in this mode.
 
-  index_otpw:
+  index-otpw:
     type: boolean
     description: |
       0: INDEX shows the first microstep position of sequencer
       1: INDEX output shows step pulses from internal pulse generator (toggle upon each step)
 
-  index_step:
+  index-step:
     type: boolean
     description: |
-      0: INDEX output as selected by index_otpw
+      0: INDEX output as selected by index-otpw
       1: INDEX pin shows the current step position of sequencer
 
-  pdn_disable:
+  pdn-disable:
     type: boolean
     description: |
       0: Normal operation
       1: Power down mode
 
-  mstep_reg_select:
+  mstep-reg-select:
     type: boolean
     description: |
       0: Microstep resolution selected by pins MS1, MS2
       1: Microstep resolution selected by MRES register
 
-  poscmp_enable:
+  poscmp-enable:
     type: boolean
     description: |
       Enable position compare feature
@@ -56,9 +56,9 @@ properties:
       1: Position compare pulse (PP) and interrupt output (INT) are available
 
       Attention – do not leave the outputs floating in tristate condition, provide an external
-      pull-up or set poscmp_enable=1
+      pull-up or set poscmp-enable=1
 
-  test_mode:
+  test-mode:
     type: boolean
     description: |
       Enable test mode
@@ -68,7 +68,7 @@ properties:
 
       Attention: Not for user, set to 0 for normal operation!
 
-  lock_gconf:
+  lock-gconf:
     type: boolean
     description: |
       1: GCONF is locked against further write access.


### PR DESCRIPTION
This commit replaces hyphens with underscore in order to comply with devicetree standards