### PR TITLE
dts: bindings: timer use hyphen instead of underscore

### DIFF
--- a/doc/releases/migration-guide-4.1.rst
+++ b/doc/releases/migration-guide-4.1.rst
@@ -299,6 +299,7 @@ Timer
 
 * Renamed the ``compatible`` from ``nxp,kinetis-ftm`` to :dtcompatible:`nxp,ftm` and relocate it
   under ``dts/bindings/timer``.
+* Renamed the device tree property from ``ticks_us`` to ``ticks-us``.
 
 USB
 ===

--- a/dts/bindings/timer/sy1xx,sys-timer.yaml
+++ b/dts/bindings/timer/sy1xx,sys-timer.yaml
@@ -14,6 +14,6 @@ properties:
   interrupts:
     required: true
 
-  ticks_us:
+  ticks-us:
     type: int
     required: true

--- a/dts/riscv/sensry/ganymed-sy1xx.dtsi
+++ b/dts/riscv/sensry/ganymed-sy1xx.dtsi
@@ -52,7 +52,7 @@
 			reg = <0x1a10b040 0x04>;
 			interrupt-parent = <&event0>;
 			interrupts = <10 0>;
-			ticks_us = <1000>;
+			ticks-us = <1000>;
 		};
 
 		timer1: timer@1a10b044 {
@@ -60,7 +60,7 @@
 			reg = <0x1a10b044 0x04>;
 			interrupt-parent = <&event0>;
 			interrupts = <11 0>;
-			ticks_us = <1000>;
+			ticks-us = <1000>;
 		};
 
 		uart0: uart@1a102000 {


### PR DESCRIPTION
Use hyphen in order to comply with device tree specification