### PR TITLE
dts: bindings: spi: use hyphen instead of underscore

### DIFF
--- a/boards/microchip/mec15xxevb_assy6853/mec15xxevb_assy6853.dts
+++ b/boards/microchip/mec15xxevb_assy6853/mec15xxevb_assy6853.dts
@@ -186,8 +186,8 @@
 
 &spi0 {
 	status = "okay";
-	port_sel = <0>;
-	chip_select = <0>;
+	port-sel = <0>;
+	chip-select = <0>;
 	lines = <1>;
 	pinctrl-0 = < &shd_cs0_n_gpio055
 		      &shd_clk_gpio056

--- a/doc/releases/migration-guide-4.2.rst
+++ b/doc/releases/migration-guide-4.2.rst
@@ -127,6 +127,12 @@ Networking
   (because the addr is not a pointer) and must be changed to ``if (lladdr->len == 0)``
   if the code wants to check that the link address is not set.
 
+SPI
+===
+
+* Renamed the device tree property ``port_sel`` to ``port-sel``.
+* Renamed the device tree property ``chip_select`` to ``chip-select``.
+
 Other subsystems
 ****************
 

--- a/dts/arm/microchip/mec1501hsz.dtsi
+++ b/dts/arm/microchip/mec1501hsz.dtsi
@@ -471,7 +471,7 @@
 			rxdma = <11>;
 			txdma = <10>;
 			lines = <1>;
-			chip_select = <0>;
+			chip-select = <0>;
 			dcsckon = <6>;
 			dckcsoff = <4>;
 			dldh = <6>;

--- a/dts/bindings/spi/microchip,xec-qmspi.yaml
+++ b/dts/bindings/spi/microchip,xec-qmspi.yaml
@@ -11,7 +11,7 @@ properties:
   reg:
     required: true
 
-  port_sel:
+  port-sel:
     type: int
     required: true
     description: SPI Port 0 or 1.
@@ -37,7 +37,7 @@ properties:
     required: true
     description: QMSPI lines 1, 2, or 4
 
-  chip_select:
+  chip-select:
     type: int
     required: true
     description: Use QMSPI CS0# or CS1#

--- a/samples/drivers/espi/boards/mec1501modular_assy6885.overlay
+++ b/samples/drivers/espi/boards/mec1501modular_assy6885.overlay
@@ -16,8 +16,8 @@
 
 &spi0 {
 	status = "okay";
-	port_sel = <0>;
-	chip_select = <0>;
+	port-sel = <0>;
+	chip-select = <0>;
 	lines = <4>;
 	pinctrl-0 = < &shd_cs0_n_gpio055
 		      &shd_clk_gpio056

--- a/samples/drivers/espi/boards/mec15xxevb_assy6853.overlay
+++ b/samples/drivers/espi/boards/mec15xxevb_assy6853.overlay
@@ -20,7 +20,7 @@
 
 &spi0 {
 	status = "okay";
-	port_sel = <0>;
-	chip_select = <0>;
+	port-sel = <0>;
+	chip-select = <0>;
 	lines = <4>;
 };

--- a/tests/boards/mec15xxevb_assy6853/qspi/boards/mec15xxevb_assy6853.overlay
+++ b/tests/boards/mec15xxevb_assy6853/qspi/boards/mec15xxevb_assy6853.overlay
@@ -6,8 +6,8 @@
 
 &spi0 {
 	status = "okay";
-	port_sel = <0>;
-	chip_select = <0>;
+	port-sel = <0>;
+	chip-select = <0>;
 	lines = <4>;
 
 	pinctrl-0 = < &shd_cs0_n_gpio055


### PR DESCRIPTION
use hyphen instead of underscore in order to comply with device tree specification

Todo:
- [x] update commit message 
- [x] Add migration guide entry commit