### PR TITLE
boards: nordic: nRF91x1: update jlink device name

### DIFF
--- a/boards/nordic/nrf9131ek/board.cmake
+++ b/boards/nordic/nrf9131ek/board.cmake
@@ -8,7 +8,6 @@ if(CONFIG_TFM_FLASH_MERGED_BINARY)
   set_property(TARGET runners_yaml_props_target PROPERTY hex_file tfm_merged.hex)
 endif()
 
-# TODO: change to nRF9131_xxAA when such device is available in JLink
-board_runner_args(jlink "--device=nRF9160_xxAA" "--speed=4000")
+board_runner_args(jlink "--device=nRF9131_xxCA" "--speed=4000")
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/nordic/nrf9151dk/board.cmake
+++ b/boards/nordic/nrf9151dk/board.cmake
@@ -8,7 +8,6 @@ if(CONFIG_TFM_FLASH_MERGED_BINARY)
   set_property(TARGET runners_yaml_props_target PROPERTY hex_file tfm_merged.hex)
 endif()
 
-# TODO: change to nRF9151_xxAA when such device is available in JLink
-board_runner_args(jlink "--device=nRF9160_xxAA" "--speed=4000")
+board_runner_args(jlink "--device=nRF9151_xxCA" "--speed=4000")
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/nordic/nrf9161dk/board.cmake
+++ b/boards/nordic/nrf9161dk/board.cmake
@@ -8,7 +8,6 @@ if(CONFIG_TFM_FLASH_MERGED_BINARY)
   set_property(TARGET runners_yaml_props_target PROPERTY hex_file tfm_merged.hex)
 endif()
 
-# TODO: change to nRF9161_xxAA when such device is available in JLink
-board_runner_args(jlink "--device=nRF9160_xxAA" "--speed=4000")
+board_runner_args(jlink "--device=nRF9161_xxCA" "--speed=4000")
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)


### PR DESCRIPTION
JLink now recognises the proper device names.
![image](https://github.com/user-attachments/assets/66aef633-e1aa-471b-8ad6-d46a58b7193d)
