### PR TITLE
drivers: spi: stm32: correct the operation flag type

### DIFF
--- a/drivers/spi/spi_ll_stm32.c
+++ b/drivers/spi/spi_ll_stm32.c
@@ -462,7 +462,7 @@ static void spi_stm32_shift_s(SPI_TypeDef *spi, struct spi_stm32_data *data)
 static int spi_stm32_shift_frames(const struct spi_stm32_config *cfg,
 	struct spi_stm32_data *data)
 {
-	uint16_t operation = data->ctx.config->operation;
+	spi_operation_t operation = data->ctx.config->operation;
 
 	if (SPI_OP_MODE_GET(operation) == SPI_OP_MODE_MASTER) {
 		spi_stm32_shift_m(cfg, data);


### PR DESCRIPTION
The commit 2c3165d1876f ("drivers: spi: add opaque type to encode SPI operation flags") introduces new type for operation flag, since it is 16/32-bit depending on CONFIG_SPI_EXTENDED_MODES.

Use the new type for safe, if the function 'spi_stm32_shift_frames' may use extended operation flag later.