### PR TITLE
dts: bindings: gpio: use hyphens instead of underscore

### DIFF
--- a/boards/snps/em_starterkit/em_starterkit_r23.dtsi
+++ b/boards/snps/em_starterkit/em_starterkit_r23.dtsi
@@ -34,9 +34,9 @@
 			compatible = "snps,creg-gpio";
 			reg = <0xf0000014 0x4>;
 			ngpios = <6>;
-			bit_per_gpio = <1>;
-			off_val = <0>;
-			on_val = <1>;
+			bit-per-gpio = <1>;
+			off-val = <0>;
+			on-val = <1>;
 
 			gpio-controller;
 			#gpio-cells = <2>;

--- a/doc/releases/migration-guide-4.1.rst
+++ b/doc/releases/migration-guide-4.1.rst
@@ -170,6 +170,16 @@ Entropy
 GNSS
 ====
 
+GPIO
+====
+
+* Renamed the device tree property ``pin_mask`` to ``pin-mask``.
+* Renamed the device tree property ``pinmux_mask`` to ``pinmux-mask``.
+* Renamed the device tree property ``vbatts_pins`` to ``vbatts-pins``.
+* Renamed the device tree property ``bit_per_gpio`` to ``bit-per-gpio``.
+* Renamed the device tree property ``off_val`` to ``off-val``.
+* Renamed the device tree property ``on_val`` to ``on-val``.
+
 I2C
 ===
 

--- a/dts/arc/synopsys/arc_hs4xd.dtsi
+++ b/dts/arc/synopsys/arc_hs4xd.dtsi
@@ -135,9 +135,9 @@
 			compatible = "snps,creg-gpio";
 			reg = <0xf00014b0 0x4>;
 			ngpios = <12>;
-			bit_per_gpio = <2>;
-			off_val = <0>;
-			on_val = <2>;
+			bit-per-gpio = <2>;
+			off-val = <0>;
+			on-val = <2>;
 
 			gpio-controller;
 			#gpio-cells = <2>;

--- a/dts/arc/synopsys/arc_hsdk.dtsi
+++ b/dts/arc/synopsys/arc_hsdk.dtsi
@@ -135,9 +135,9 @@
 			compatible = "snps,creg-gpio";
 			reg = <0xf00014b0 0x4>;
 			ngpios = <12>;
-			bit_per_gpio = <2>;
-			off_val = <0>;
-			on_val = <2>;
+			bit-per-gpio = <2>;
+			off-val = <0>;
+			on-val = <2>;
 
 			gpio-controller;
 			#gpio-cells = <2>;

--- a/dts/arm/renesas/ra/ra8/ra8x1.dtsi
+++ b/dts/arm/renesas/ra/ra8/ra8x1.dtsi
@@ -97,7 +97,7 @@
 			gpio-controller;
 			#gpio-cells = <2>;
 			ngpios = <16>;
-			vbatts_pins = <2 3 4>;
+			vbatts-pins = <2 3 4>;
 			status = "disabled";
 		};
 

--- a/dts/bindings/gpio/nuvoton,nct38xx-gpio-port.yaml
+++ b/dts/bindings/gpio/nuvoton,nct38xx-gpio-port.yaml
@@ -11,7 +11,7 @@ properties:
   reg:
     required: true
 
-  pin_mask:
+  pin-mask:
     type: int
     required: true
     description: |
@@ -21,7 +21,7 @@ properties:
       NCT3808: <0xdc>
       others: <0xff>
 
-  pinmux_mask:
+  pinmux-mask:
     type: int
     description: |
       NCT38XX series port 0 has Pin Multiplexing functionality. However, not

--- a/dts/bindings/gpio/nuvoton,nct38xx-gpio.yaml
+++ b/dts/bindings/gpio/nuvoton,nct38xx-gpio.yaml
@@ -23,8 +23,8 @@ description: |
               gpio-controller;
               #gpio-cells = <2>;
               ngpios = <8>;
-              pin_mask = <0xff>;
-              pinmux_mask = <0xf7>;
+              pin-mask = <0xff>;
+              pinmux-mask = <0xf7>;
             };
 
             gpio@1 {
@@ -33,7 +33,7 @@ description: |
               gpio-controller;
               #gpio-cells = <2>;
               ngpios = <8>;
-              pin_mask = <0xff>;
+              pin-mask = <0xff>;
             };
           };
         };
@@ -53,8 +53,8 @@ description: |
               gpio-controller;
               #gpio-cells = <2>;
               ngpios = <8>;
-              pin_mask = <0xdc>;
-              pinmux_mask = <0xff>;
+              pin-mask = <0xdc>;
+              pinmux-mask = <0xff>;
             };
           };
         };
@@ -74,8 +74,8 @@ description: |
               gpio-controller;
               #gpio-cells = <2>;
               ngpios = <8>;
-              pin_mask = <0xdc>;
-              pinmux_mask = <0xff>;
+              pin-mask = <0xdc>;
+              pinmux-mask = <0xff>;
             };
           };
         };

--- a/dts/bindings/gpio/renesas,ra-gpio-ioport.yaml
+++ b/dts/bindings/gpio/renesas,ra-gpio-ioport.yaml
@@ -15,7 +15,7 @@ properties:
     type: int
     required: true
 
-  vbatts_pins:
+  vbatts-pins:
     type: array
     description: Array of vbatt pin on port
 

--- a/dts/bindings/gpio/snps,creg-gpio.yaml
+++ b/dts/bindings/gpio/snps,creg-gpio.yaml
@@ -11,15 +11,15 @@ properties:
   reg:
     required: true
 
-  bit_per_gpio:
+  bit-per-gpio:
     type: int
     required: true
 
-  off_val:
+  off-val:
     type: int
     required: true
 
-  on_val:
+  on-val:
     type: int
     required: true
 

--- a/tests/drivers/build_all/gpio/app.overlay
+++ b/tests/drivers/build_all/gpio/app.overlay
@@ -172,8 +172,8 @@
 						gpio-controller;
 						#gpio-cells = <2>;
 						ngpios = <8>;
-						pin_mask = <0xff>;
-						pinmux_mask = <0xf7>;
+						pin-mask = <0xff>;
+						pinmux-mask = <0xf7>;
 					};
 
 					gpio@1 {
@@ -182,7 +182,7 @@
 						gpio-controller;
 						#gpio-cells = <2>;
 						ngpios = <8>;
-						pin_mask = <0xff>;
+						pin-mask = <0xff>;
 					};
 				};
 			};
@@ -201,8 +201,8 @@
 						gpio-controller;
 						#gpio-cells = <2>;
 						ngpios = <8>;
-						pin_mask = <0xdc>;
-						pinmux_mask = <0xff>;
+						pin-mask = <0xdc>;
+						pinmux-mask = <0xff>;
 					};
 				};
 			};
@@ -221,8 +221,8 @@
 						gpio-controller;
 						#gpio-cells = <2>;
 						ngpios = <8>;
-						pin_mask = <0xdc>;
-						pinmux_mask = <0xff>;
+						pin-mask = <0xdc>;
+						pinmux-mask = <0xff>;
 					};
 				};
 			};


### PR DESCRIPTION
replace underscore with hyphens to comply with device tree spec

Todos:
- [x] Add migration guide entry commit