### PR TITLE
fix: i2c hyphen in device tree

### DIFF
--- a/boards/microchip/mec1501modular_assy6885/mec1501modular_assy6885.dts
+++ b/boards/microchip/mec1501modular_assy6885/mec1501modular_assy6885.dts
@@ -52,7 +52,7 @@
 
 &i2c_smb_0 {
 	status = "okay";
-	port_sel = <0>;
+	port-sel = <0>;
 	sda-gpios = <MCHP_GPIO_DECODE_003 0>;
 	scl-gpios = <MCHP_GPIO_DECODE_004 0>;
 	pinctrl-0 = < &i2c00_scl_gpio004 &i2c00_sda_gpio003 >;
@@ -61,7 +61,7 @@
 
 &i2c_smb_1 {
 	status = "okay";
-	port_sel = <1>;
+	port-sel = <1>;
 	sda-gpios = <MCHP_GPIO_DECODE_130 0>;
 	scl-gpios = <MCHP_GPIO_DECODE_131 0>;
 	pinctrl-0 = < &i2c01_scl_gpio131 &i2c01_sda_gpio130 >;

--- a/boards/microchip/mec15xxevb_assy6853/mec15xxevb_assy6853.dts
+++ b/boards/microchip/mec15xxevb_assy6853/mec15xxevb_assy6853.dts
@@ -80,7 +80,7 @@
 
 &i2c_smb_0 {
 	status = "okay";
-	port_sel = <0>;
+	port-sel = <0>;
 	sda-gpios = <MCHP_GPIO_DECODE_003 0>;
 	scl-gpios = <MCHP_GPIO_DECODE_004 0>;
 	pinctrl-0 = < &i2c00_scl_gpio004 &i2c00_sda_gpio003 >;
@@ -89,7 +89,7 @@
 
 &i2c_smb_1 {
 	status = "okay";
-	port_sel = <1>;
+	port-sel = <1>;
 	sda-gpios = <MCHP_GPIO_DECODE_130 0>;
 	scl-gpios = <MCHP_GPIO_DECODE_131 0>;
 	pinctrl-0 = < &i2c01_scl_gpio131 &i2c01_sda_gpio130 >;
@@ -114,7 +114,7 @@
 
 &i2c_smb_2 {
 	status = "okay";
-	port_sel = <7>;
+	port-sel = <7>;
 	sda-gpios = <MCHP_GPIO_DECODE_012 0>;
 	scl-gpios = <MCHP_GPIO_DECODE_013 0>;
 	pinctrl-0 = < &i2c07_scl_gpio013 &i2c07_sda_gpio012 >;

--- a/boards/microchip/mec172xevb_assy6906/mec172xevb_assy6906.dts
+++ b/boards/microchip/mec172xevb_assy6906/mec172xevb_assy6906.dts
@@ -125,7 +125,7 @@
 /* I2C */
 &i2c_smb_0 {
 	status = "okay";
-	port_sel = <0>;
+	port-sel = <0>;
 
 	pinctrl-0 = < &i2c00_scl_gpio004 &i2c00_sda_gpio003 >;
 	pinctrl-names = "default";
@@ -145,7 +145,7 @@
 
 &i2c_smb_1 {
 	status = "okay";
-	port_sel = <1>;
+	port-sel = <1>;
 	pinctrl-0 = <&i2c01_scl_gpio131 &i2c01_sda_gpio130>;
 	pinctrl-names = "default";
 
@@ -180,7 +180,7 @@
 
 &i2c_smb_2 {
 	status = "okay";
-	port_sel = <7>;
+	port-sel = <7>;
 	pinctrl-0 = <&i2c07_scl_gpio013 &i2c07_sda_gpio012>;
 	pinctrl-names = "default";
 };

--- a/boards/microchip/mec172xmodular_assy6930/mec172xmodular_assy6930.dts
+++ b/boards/microchip/mec172xmodular_assy6930/mec172xmodular_assy6930.dts
@@ -119,7 +119,7 @@
 /* I2C */
 &i2c_smb_0 {
 	status = "okay";
-	port_sel = <0>;
+	port-sel = <0>;
 
 	pinctrl-0 = < &i2c00_scl_gpio004 &i2c00_sda_gpio003 >;
 	pinctrl-names = "default";
@@ -139,7 +139,7 @@
 
 &i2c_smb_1 {
 	status = "okay";
-	port_sel = <1>;
+	port-sel = <1>;
 	pinctrl-0 = <&i2c01_scl_gpio131 &i2c01_sda_gpio130>;
 	pinctrl-names = "default";
 };
@@ -158,7 +158,7 @@
 
 &i2c_smb_2 {
 	status = "okay";
-	port_sel = <7>;
+	port-sel = <7>;
 	pinctrl-0 = <&i2c07_scl_gpio013 &i2c07_sda_gpio012>;
 	pinctrl-names = "default";
 };

--- a/doc/releases/migration-guide-4.1.rst
+++ b/doc/releases/migration-guide-4.1.rst
@@ -186,6 +186,7 @@ I2C
 ===
 
 * Renamed the ``compatible`` from ``nxp,imx-lpi2c`` to :dtcompatible:`nxp,lpi2c`.
+* Renamed the device tree property ``port_sel`` to ``port-sel```.
 
 I2S
 ===

--- a/dts/bindings/i2c/microchip,xec-i2c-v2.yaml
+++ b/dts/bindings/i2c/microchip,xec-i2c-v2.yaml
@@ -11,7 +11,7 @@ properties:
   reg:
     required: true
 
-  port_sel:
+  port-sel:
     type: int
     description: soc block mapping to pin
     required: true

--- a/dts/bindings/i2c/microchip,xec-i2c.yaml
+++ b/dts/bindings/i2c/microchip,xec-i2c.yaml
@@ -11,7 +11,7 @@ properties:
   reg:
     required: true
 
-  port_sel:
+  port-sel:
     type: int
     description: soc block mapping to pin
     required: true


### PR DESCRIPTION
As per device tree specification, use hyphen in device tree properties
