### PR TITLE
twister: recording: Allow multiple patterns & Thread-Metric benchmark data collection

### DIFF
--- a/doc/develop/test/twister.rst
+++ b/doc/develop/test/twister.rst
@@ -626,12 +626,20 @@ harness_config: <harness configuration options>
         Check the regular expression strings in orderly or randomly fashion
 
     record: <recording options> (optional)
-      regex: <regular expression> (required)
-        The regular expression with named subgroups to match data fields
-        at the test's output lines where the test provides some custom data
+      regex: <list of regular expressions> (required)
+        Regular expressions with named subgroups to match data fields found
+        in the test instance's output lines where it provides some custom data
         for further analysis. These records will be written into the build
         directory ``recording.csv`` file as well as ``recording`` property
         of the test suite object in ``twister.json``.
+
+        With several regular expressions given, each of them will be applied
+        to each output line producing either several different records from
+        the same output line, or different records from different lines,
+        or similar records from different lines.
+
+        The .CSV file will have as many columns as there are fields detected
+        in all records; missing values are filled by empty strings.
 
         For example, to extract three data fields ``metric``, ``cycles``,
         ``nanoseconds``:
@@ -639,13 +647,22 @@ harness_config: <harness configuration options>
         .. code-block:: yaml
 
           record:
-            regex: "(?P<metric>.*):(?P<cycles>.*) cycles, (?P<nanoseconds>.*) ns"
+            regex:
+              - "(?P<metric>.*):(?P<cycles>.*) cycles, (?P<nanoseconds>.*) ns"
+
+      merge: <True|False> (default False)
+        Allows to keep only one record in a test instance with all the data
+        fields extracted by the regular expressions. Fields with the same name
+        will be put into lists ordered as their appearance in recordings.
+        It is possible for such multi value fields to have different number
+        of values depending on the regex rules and the test's output.
 
       as_json: <list of regex subgroup names> (optional)
-        Data fields, extracted by the regular expression into named subgroups,
+        Data fields, extracted by the regular expressions into named subgroups,
         which will be additionally parsed as JSON encoded strings and written
         into ``twister.json`` as nested ``recording`` object properties.
-        The corresponding ``recording.csv`` columns will contain strings as-is.
+        The corresponding ``recording.csv`` columns will contain JSON strings
+        as-is.
 
         Using this option, a test log can convey layered data structures
         passed from the test image for further analysis with summary results,

--- a/scripts/pylib/twister/twisterlib/harness.py
+++ b/scripts/pylib/twister/twisterlib/harness.py
@@ -53,7 +53,8 @@ class Harness:
         self.capture_coverage = False
         self.next_pattern = 0
         self.record = None
-        self.record_pattern = None
+        self.record_patterns = []
+        self.record_merge = False
         self.record_as_json = None
         self.recording = []
         self.ztest = False
@@ -99,7 +100,8 @@ class Harness:
             self.ordered = config.get('ordered', True)
             self.record = config.get('record', {})
             if self.record:
-                self.record_pattern = re.compile(self.record.get("regex", ""))
+                self.record_patterns = [re.compile(p) for p in self.record.get("regex", [])]
+                self.record_merge = self.record.get("merge", False)
                 self.record_as_json = self.record.get("as_json")
 
     def build(self):
@@ -125,17 +127,27 @@ class Harness:
                     record[k] = { 'ERROR': { 'msg': str(parse_error), 'doc': record[k] } }
         return record
 
-    def parse_record(self, line) -> re.Match:
-        match = None
-        if self.record_pattern:
-            match = self.record_pattern.search(line)
+    def parse_record(self, line) -> int:
+        match_cnt = 0
+        for record_pattern in self.record_patterns:
+            match = record_pattern.search(line)
             if match:
+                match_cnt += 1
                 rec = self.translate_record(
                     { k:v.strip() for k,v in match.groupdict(default="").items() }
                 )
-                self.recording.append(rec)
-        return match
-    #
+                if self.record_merge and len(self.recording) > 0:
+                    for k,v in rec.items():
+                        if k in self.recording[0]:
+                            if isinstance(self.recording[0][k], list):
+                                self.recording[0][k].append(v)
+                            else:
+                                self.recording[0][k] = [self.recording[0][k], v]
+                        else:
+                            self.recording[0][k] = v
+                else:
+                    self.recording.append(rec)
+        return match_cnt
 
     def process_test(self, line):
 

--- a/scripts/pylib/twister/twisterlib/testinstance.py
+++ b/scripts/pylib/twister/twisterlib/testinstance.py
@@ -105,9 +105,12 @@ class TestInstance:
                 self.recording.extend(recording)
 
             filename = os.path.join(self.build_dir, fname_csv)
+            fieldnames = set()
+            for r in self.recording:
+                fieldnames.update(r)
             with open(filename, 'w') as csvfile:
                 cw = csv.DictWriter(csvfile,
-                                    fieldnames = self.recording[0].keys(),
+                                    fieldnames = sorted(list(fieldnames)),
                                     lineterminator = os.linesep,
                                     quoting = csv.QUOTE_NONNUMERIC)
                 cw.writeheader()

--- a/scripts/schemas/twister/testsuite-schema.yaml
+++ b/scripts/schemas/twister/testsuite-schema.yaml
@@ -151,8 +151,13 @@ schema;scenario-schema:
           required: false
           mapping:
             "regex":
-              type: str
+              type: seq
               required: true
+              sequence:
+                - type: str
+            "merge":
+              type: bool
+              required: false
             "as_json":
               type: seq
               required: false

--- a/tests/benchmarks/latency_measure/testcase.yaml
+++ b/tests/benchmarks/latency_measure/testcase.yaml
@@ -19,7 +19,8 @@ tests:
     harness_config:
       type: one_line
       record:
-        regex: "(?P<metric>.*) - (?P<description>.*):(?P<cycles>.*) cycles ,(?P<nanoseconds>.*) ns"
+        regex:
+          - "(?P<metric>.*) - (?P<description>.*):(?P<cycles>.*) cycles ,(?P<nanoseconds>.*) ns"
       regex:
         - "PROJECT EXECUTION SUCCESSFUL"
 
@@ -35,7 +36,8 @@ tests:
     harness_config:
       type: one_line
       record:
-        regex: "(?P<metric>.*) - (?P<description>.*):(?P<cycles>.*) cycles ,(?P<nanoseconds>.*) ns"
+        regex:
+          - "(?P<metric>.*) - (?P<description>.*):(?P<cycles>.*) cycles ,(?P<nanoseconds>.*) ns"
       regex:
         - "PROJECT EXECUTION SUCCESSFUL"
 
@@ -53,7 +55,8 @@ tests:
     harness_config:
       type: one_line
       record:
-        regex: "(?P<metric>.*) - (?P<description>.*):(?P<cycles>.*) cycles ,(?P<nanoseconds>.*) ns"
+        regex:
+          - "(?P<metric>.*) - (?P<description>.*):(?P<cycles>.*) cycles ,(?P<nanoseconds>.*) ns"
       regex:
         - "PROJECT EXECUTION SUCCESSFUL"
 
@@ -75,6 +78,7 @@ tests:
     harness_config:
       type: one_line
       record:
-        regex: "(?P<metric>.*) - (?P<description>.*):(?P<cycles>.*) cycles ,(?P<nanoseconds>.*) ns"
+        regex:
+          - "(?P<metric>.*) - (?P<description>.*):(?P<cycles>.*) cycles ,(?P<nanoseconds>.*) ns"
       regex:
         - "PROJECT EXECUTION SUCCESSFUL"

--- a/tests/benchmarks/posix/threads/testcase.yaml
+++ b/tests/benchmarks/posix/threads/testcase.yaml
@@ -14,7 +14,8 @@ common:
   harness_config:
     type: one_line
     record:
-      regex: "(?P<api>.*), ALL, (?P<time>.*), (?P<threads>.*), (?P<cores>.*), (?P<rate>.*)"
+      regex:
+        - "(?P<api>.*), ALL, (?P<time>.*), (?P<threads>.*), (?P<cores>.*), (?P<rate>.*)"
     regex:
       - "PROJECT EXECUTION SUCCESSFUL"
 tests:

--- a/tests/benchmarks/sched_queues/testcase.yaml
+++ b/tests/benchmarks/sched_queues/testcase.yaml
@@ -16,7 +16,7 @@ common:
       - "PROJECT EXECUTION SUCCESSFUL"
     record:
       regex:
-        "REC: (?P<metric>.*) - (?P<description>.*):(?P<cycles>.*) cycles ,(?P<nanoseconds>.*) ns"
+        - "REC: (?P<metric>.*) - (?P<description>.*):(?P<cycles>.*) cycles ,(?P<nanoseconds>.*) ns"
   extra_configs:
     - CONFIG_BENCHMARK_RECORDING=y
 

--- a/tests/benchmarks/thread_metric/testcase.yaml
+++ b/tests/benchmarks/thread_metric/testcase.yaml
@@ -9,8 +9,10 @@ common:
   # time does not pass while the CPU executes. So the benchmark just appears as if hung.
   arch_exclude:
     - posix
-  # qemu_nios2 excluded as it is slow
+  # some slow qemu_* excluded
   platform_exclude:
+    - qemu_malta/qemu_malta
+    - qemu_malta/qemu_malta/be
     - qemu_nios2
   integration_platforms:
     - qemu_x86
@@ -18,9 +20,22 @@ common:
   timeout: 300
   harness: console
   harness_config:
-    type: one_line
+    type: multi_line
+    ordered: true
     regex:
-      - "(.*) Relative Time: (.*)"
+      # Collect at least 3 measurements for each benchmark:
+      - "(.*) Thread-Metric(.+) Relative Time:[ ]*[0-9]+(.*)"
+      - "(.*)Time Period Total:[ ]*[0-9]+(.*)"
+      - "(.*) Thread-Metric(.+) Relative Time:[ ]*[0-9]+(.*)"
+      - "(.*)Time Period Total:[ ]*[0-9]+(.*)"
+      - "(.*) Thread-Metric(.+) Relative Time:[ ]*[0-9]+(.*)"
+      - "(.*)Time Period Total:[ ]*[0-9]+(.*)"
+    record:
+      regex:
+        - "Time Period Total:[ ]*(?P<total_time_period>[0-9]+)"
+        - "ERROR:[ ]*(?P<error_message>.*)"
+        - "[ ]+Average:(?P<error_details>.*)"
+      merge: true
 
 tests:
   benchmark.thread_metric.basic:

--- a/tests/benchmarks/thread_metric/thread_metric_readme.txt
+++ b/tests/benchmarks/thread_metric/thread_metric_readme.txt
@@ -123,6 +123,27 @@ tm_memory_allocation_test.c                   Basic memory allocation test
 tm_porting_layer_zephyr.c                     Specific porting layer source
                                                  code for Zephyr
 
+2.5. Test execution with Twister tool
+
+When the test suite is executed by Twister it takes parameters from testcase.yaml
+file, in particular:
+
+    * check expected benchmark output presence at least three times to collect
+      measurements from 3 consequtive intervals for each of the benchmark tests.
+
+    * use 300 sec. timeout on each benchmark test from this suite;
+      it is expected to be at least twice bigger than normally needed
+      to collect measurements 3 times with 30 sec. intervals on most of the
+      platforms except some simulators.
+
+    * parse benchmark output to extract measurements and errors when
+      it happens e.g. on counters diverged from average; Twister records
+      this data in twister.json and recording.csv report files for analysis.
+
+For more details see Twister testcase.yaml documentation and 'harness_config:'
+parameters.
+
+
 3 Porting
 
 3.1 Porting Layer
@@ -216,7 +237,7 @@ measurement tests:
     of memory. If successful, a TM_SUCCESS is returned.
 
 
-2.2 Porting Requirements Checklist
+3.2 Porting Requirements Checklist
 
 The following requirements are made in order to ensure fair benchmarks
 are achieved on each RTOS performing the test:

--- a/tests/benchmarks/wait_queues/testcase.yaml
+++ b/tests/benchmarks/wait_queues/testcase.yaml
@@ -15,7 +15,7 @@ common:
       - "PROJECT EXECUTION SUCCESSFUL"
     record:
       regex:
-        "REC: (?P<metric>.*) - (?P<description>.*):(?P<cycles>.*) cycles ,(?P<nanoseconds>.*) ns"
+        - "REC: (?P<metric>.*) - (?P<description>.*):(?P<cycles>.*) cycles ,(?P<nanoseconds>.*) ns"
   extra_configs:
     - CONFIG_BENCHMARK_RECORDING=y
 

--- a/tests/kernel/timer/timer_behavior/testcase.yaml
+++ b/tests/kernel/timer/timer_behavior/testcase.yaml
@@ -10,7 +10,8 @@ tests:
       - renode
     harness_config:
       record:
-        regex: "RECORD:(?P<metrics>.*)"
+        regex:
+          - "RECORD:(?P<metrics>.*)"
         as_json: ['metrics']
   kernel.timer.timer_behavior_external:
     filter: dt_compat_enabled("test-kernel-timer-behavior-external")
@@ -20,7 +21,8 @@ tests:
                     'address=127.0.0.1,port=10430,channel=1,sample-rate=6_250_000,threshold-volts=3.3']
       fixture: gpio_timerout
       record:
-        regex: "RECORD:(?P<metrics>.*)"
+        regex:
+          - "RECORD:(?P<metrics>.*)"
         as_json: ['metrics']
     extra_configs:
       - CONFIG_TIMER_EXTERNAL_TEST=y


### PR DESCRIPTION
1) Extend Twister Harness 'recording' feature to allow multiple regular expression patterns to extract different types of records from test output.
Add 'merge' recording mode to collect all extracted data fields into a single record object of the test instance.
Export to CSV file now takes all field names occurred in the collected records, sort it alphabetically, and then use it for columns instead of using only the first record's fields. This is done to address possible situation when records have different set of fields.
Adjust Twister documentation and test suite to the above changes.

2) Adjust testcase.yaml files to changes in Twister schema which now allows multiple recording patterns ('record: regex:').

3) Extentd `benchmark.thread_metric` (tests/benchmarks/thread_metric) test suite to collect benchmark measurements into Twister reports as recordings parsed from the test's output: time period values as well as errors.
Additionally, each test is executed until it makes at least 3 measurements to estimate variance.
