### PR TITLE
drv: ft8xx: support multiple instances

### DIFF
--- a/doc/releases/migration-guide-4.1.rst
+++ b/doc/releases/migration-guide-4.1.rst
@@ -192,6 +192,11 @@ Misc
   API to a single-instance model, compatible with the API defined in the FT8xx programming guide.
   These functions have not been modified.
 
+* The :c:func:`ft8xx_register_int` function now takes an additional ``void *user_data`` parameter
+  to allow user-defined data to be passed to the interrupt handler.
+  Additionally, the signature of the ft8xx interrupt handler has changed to include the
+  ``void *user_data`` parameter.
+
 MMU/MPU
 =======
 

--- a/doc/releases/migration-guide-4.1.rst
+++ b/doc/releases/migration-guide-4.1.rst
@@ -181,6 +181,17 @@ Interrupt Controller
 LED Strip
 =========
 
+Misc
+====
+
+* All the functions in the ft8xx driver take an additional ``const struct *device`` parameter
+  to allow for multiple instances of the driver.
+
+  The exception to this is the functions and macros defined in the
+  :zephyr_file:`include/zephyr/drivers/misc/ft8xx/ft8xx_reference_api.h` file, which translate the
+  API to a single-instance model, compatible with the API defined in the FT8xx programming guide.
+  These functions have not been modified.
+
 MMU/MPU
 =======
 

--- a/drivers/misc/ft8xx/ft8xx.c
+++ b/drivers/misc/ft8xx/ft8xx.c
@@ -20,6 +20,7 @@
 #include <zephyr/drivers/misc/ft8xx/ft8xx_dl.h>
 #include <zephyr/drivers/misc/ft8xx/ft8xx_memory.h>
 
+#include "ft8xx_dev_data.h"
 #include "ft8xx_drv.h"
 #include "ft8xx_host_commands.h"
 
@@ -46,38 +47,11 @@ struct ft8xx_config {
 	uint8_t swizzle  :4;
 };
 
-struct ft8xx_data {
-	const struct ft8xx_config *config;
-	ft8xx_int_callback irq_callback;
-};
-
-const static struct ft8xx_config ft8xx_config = {
-	.pclk     = DT_INST_PROP(0, pclk),
-	.pclk_pol = DT_INST_PROP(0, pclk_pol),
-	.cspread  = DT_INST_PROP(0, cspread),
-	.swizzle  = DT_INST_PROP(0, swizzle),
-	.vsize    = DT_INST_PROP(0, vsize),
-	.voffset  = DT_INST_PROP(0, voffset),
-	.vcycle   = DT_INST_PROP(0, vcycle),
-	.vsync0   = DT_INST_PROP(0, vsync0),
-	.vsync1   = DT_INST_PROP(0, vsync1),
-	.hsize    = DT_INST_PROP(0, hsize),
-	.hoffset  = DT_INST_PROP(0, hoffset),
-	.hcycle   = DT_INST_PROP(0, hcycle),
-	.hsync0   = DT_INST_PROP(0, hsync0),
-	.hsync1   = DT_INST_PROP(0, hsync1),
-};
-
-static struct ft8xx_data ft8xx_data = {
-	.config = &ft8xx_config,
-	.irq_callback = NULL,
-};
-
-static void host_command(uint8_t cmd)
+static void host_command(const struct device *dev, uint8_t cmd)
 {
 	int err;
 
-	err = ft8xx_drv_command(cmd);
+	err = ft8xx_drv_command(dev, cmd);
 	__ASSERT(err == 0, "Writing FT8xx command failed");
 }
 
@@ -86,9 +60,9 @@ static void wait(void)
 	k_sleep(K_MSEC(20));
 }
 
-static bool verify_chip(void)
+static bool verify_chip(const struct device *dev)
 {
-	uint32_t id = ft8xx_rd32(FT800_REG_ID);
+	uint32_t id = ft8xx_rd32(dev, FT800_REG_ID);
 
 	return (id & 0xff) == FT8XX_EXPECTED_ID;
 }
@@ -97,131 +71,165 @@ static int ft8xx_init(const struct device *dev)
 {
 	int ret;
 	const struct ft8xx_config *config = dev->config;
+	struct ft8xx_data *data = dev->data;
 
-	ret = ft8xx_drv_init();
+	data->ft8xx_dev = dev;
+
+	ret = ft8xx_drv_init(dev);
 	if (ret < 0) {
 		LOG_ERR("FT8xx driver initialization failed with %d", ret);
 		return ret;
 	}
 
 	/* Reset display controller */
-	host_command(CORERST);
-	host_command(ACTIVE);
+	host_command(dev, CORERST);
+	host_command(dev, ACTIVE);
 	wait();
-	host_command(CLKEXT);
-	host_command(CLK48M);
-	wait();
-
-	host_command(CORERST);
-	host_command(ACTIVE);
-	wait();
-	host_command(CLKEXT);
-	host_command(CLK48M);
+	host_command(dev, CLKEXT);
+	host_command(dev, CLK48M);
 	wait();
 
-	if (!verify_chip()) {
+	host_command(dev, CORERST);
+	host_command(dev, ACTIVE);
+	wait();
+	host_command(dev, CLKEXT);
+	host_command(dev, CLK48M);
+	wait();
+
+	if (!verify_chip(dev)) {
 		LOG_ERR("FT8xx chip not recognized");
 		return -ENODEV;
 	}
 
 	/* Disable LCD */
-	ft8xx_wr8(FT800_REG_GPIO, 0);
-	ft8xx_wr8(FT800_REG_PCLK, 0);
+	ft8xx_wr8(dev, FT800_REG_GPIO, 0);
+	ft8xx_wr8(dev, FT800_REG_PCLK, 0);
 
 	/* Configure LCD */
-	ft8xx_wr16(FT800_REG_HSIZE, config->hsize);
-	ft8xx_wr16(FT800_REG_HCYCLE, config->hcycle);
-	ft8xx_wr16(FT800_REG_HOFFSET, config->hoffset);
-	ft8xx_wr16(FT800_REG_HSYNC0, config->hsync0);
-	ft8xx_wr16(FT800_REG_HSYNC1, config->hsync1);
-	ft8xx_wr16(FT800_REG_VSIZE, config->vsize);
-	ft8xx_wr16(FT800_REG_VCYCLE, config->vcycle);
-	ft8xx_wr16(FT800_REG_VOFFSET, config->voffset);
-	ft8xx_wr16(FT800_REG_VSYNC0, config->vsync0);
-	ft8xx_wr16(FT800_REG_VSYNC1, config->vsync1);
-	ft8xx_wr8(FT800_REG_SWIZZLE, config->swizzle);
-	ft8xx_wr8(FT800_REG_PCLK_POL, config->pclk_pol);
-	ft8xx_wr8(FT800_REG_CSPREAD, config->cspread);
+	ft8xx_wr16(dev, FT800_REG_HSIZE, config->hsize);
+	ft8xx_wr16(dev, FT800_REG_HCYCLE, config->hcycle);
+	ft8xx_wr16(dev, FT800_REG_HOFFSET, config->hoffset);
+	ft8xx_wr16(dev, FT800_REG_HSYNC0, config->hsync0);
+	ft8xx_wr16(dev, FT800_REG_HSYNC1, config->hsync1);
+	ft8xx_wr16(dev, FT800_REG_VSIZE, config->vsize);
+	ft8xx_wr16(dev, FT800_REG_VCYCLE, config->vcycle);
+	ft8xx_wr16(dev, FT800_REG_VOFFSET, config->voffset);
+	ft8xx_wr16(dev, FT800_REG_VSYNC0, config->vsync0);
+	ft8xx_wr16(dev, FT800_REG_VSYNC1, config->vsync1);
+	ft8xx_wr8(dev, FT800_REG_SWIZZLE, config->swizzle);
+	ft8xx_wr8(dev, FT800_REG_PCLK_POL, config->pclk_pol);
+	ft8xx_wr8(dev, FT800_REG_CSPREAD, config->cspread);
 
 	/* Display initial screen */
 
 	/* Set the initial color */
-	ft8xx_wr32(FT800_RAM_DL + 0, FT8XX_CLEAR_COLOR_RGB(0, 0x80, 0));
+	ft8xx_wr32(dev, FT800_RAM_DL + 0, FT8XX_CLEAR_COLOR_RGB(0, 0x80, 0));
 	/* Clear to the initial color */
-	ft8xx_wr32(FT800_RAM_DL + 4, FT8XX_CLEAR(1, 1, 1));
+	ft8xx_wr32(dev, FT800_RAM_DL + 4, FT8XX_CLEAR(1, 1, 1));
 	/* End the display list */
-	ft8xx_wr32(FT800_RAM_DL + 8, FT8XX_DISPLAY());
-	ft8xx_wr8(FT800_REG_DLSWAP, FT8XX_DLSWAP_FRAME);
+	ft8xx_wr32(dev, FT800_RAM_DL + 8, FT8XX_DISPLAY());
+	ft8xx_wr8(dev, FT800_REG_DLSWAP, FT8XX_DLSWAP_FRAME);
 
 	/* Enable LCD */
 
 	/* Enable display bit */
-	ft8xx_wr8(FT800_REG_GPIO_DIR, 0x80);
-	ft8xx_wr8(FT800_REG_GPIO, 0x80);
+	ft8xx_wr8(dev, FT800_REG_GPIO_DIR, 0x80);
+	ft8xx_wr8(dev, FT800_REG_GPIO, 0x80);
 	/* Enable backlight */
-	ft8xx_wr16(FT800_REG_PWM_HZ, 0x00FA);
-	ft8xx_wr8(FT800_REG_PWM_DUTY, 0x10);
+	ft8xx_wr16(dev, FT800_REG_PWM_HZ, 0x00FA);
+	ft8xx_wr8(dev, FT800_REG_PWM_DUTY, 0x10);
 	/* Enable LCD signals */
-	ft8xx_wr8(FT800_REG_PCLK, config->pclk);
+	ft8xx_wr8(dev, FT800_REG_PCLK, config->pclk);
 
 	return 0;
 }
 
-DEVICE_DT_INST_DEFINE(0, ft8xx_init, NULL, &ft8xx_data, &ft8xx_config,
-		      POST_KERNEL, CONFIG_FT800_INIT_PRIORITY, NULL);
-
-int ft8xx_get_touch_tag(void)
+int ft8xx_get_touch_tag(const struct device *dev)
 {
 	/* Read FT800_REG_INT_FLAGS to clear IRQ */
-	(void)ft8xx_rd8(FT800_REG_INT_FLAGS);
+	(void)ft8xx_rd8(dev, FT800_REG_INT_FLAGS);
 
-	return (int)ft8xx_rd8(FT800_REG_TOUCH_TAG);
+	return (int)ft8xx_rd8(dev, FT800_REG_TOUCH_TAG);
 }
 
-void ft8xx_drv_irq_triggered(const struct device *dev, struct gpio_callback *cb,
-			      uint32_t pins)
+void ft8xx_drv_irq_triggered(const struct device *gpio_port, struct gpio_callback *cb,
+			     uint32_t pins)
 {
-	if (ft8xx_data.irq_callback != NULL) {
-		ft8xx_data.irq_callback();
+	struct ft8xx_data *ft8xx_data = CONTAINER_OF(cb, struct ft8xx_data, irq_cb_data);
+	const struct device *ft8xx_dev = ft8xx_data->ft8xx_dev;
+
+	if (ft8xx_data->irq_callback != NULL) {
+		ft8xx_data->irq_callback(ft8xx_dev);
 	}
 }
 
-void ft8xx_register_int(ft8xx_int_callback callback)
+void ft8xx_register_int(const struct device *dev, ft8xx_int_callback callback)
 {
-	if (ft8xx_data.irq_callback != NULL) {
+	struct ft8xx_data *ft8xx_data = dev->data;
+
+	if (ft8xx_data->irq_callback != NULL) {
 		return;
 	}
 
-	ft8xx_data.irq_callback = callback;
-	ft8xx_wr8(FT800_REG_INT_MASK, 0x04);
-	ft8xx_wr8(FT800_REG_INT_EN, 0x01);
+	ft8xx_data->irq_callback = callback;
+	ft8xx_wr8(dev, FT800_REG_INT_MASK, 0x04);
+	ft8xx_wr8(dev, FT800_REG_INT_EN, 0x01);
 }
 
-void ft8xx_calibrate(struct ft8xx_touch_transform *data)
+void ft8xx_calibrate(const struct device *dev, struct ft8xx_touch_transform *data)
 {
 	uint32_t result = 0;
 
 	do {
-		ft8xx_copro_cmd_dlstart();
-		ft8xx_copro_cmd(FT8XX_CLEAR_COLOR_RGB(0x00, 0x00, 0x00));
-		ft8xx_copro_cmd(FT8XX_CLEAR(1, 1, 1));
-		ft8xx_copro_cmd_calibrate(&result);
+		ft8xx_copro_cmd_dlstart(dev);
+		ft8xx_copro_cmd(dev, FT8XX_CLEAR_COLOR_RGB(0x00, 0x00, 0x00));
+		ft8xx_copro_cmd(dev, FT8XX_CLEAR(1, 1, 1));
+		ft8xx_copro_cmd_calibrate(dev, &result);
 	} while (result == 0);
 
-	data->a = ft8xx_rd32(FT800_REG_TOUCH_TRANSFORM_A);
-	data->b = ft8xx_rd32(FT800_REG_TOUCH_TRANSFORM_B);
-	data->c = ft8xx_rd32(FT800_REG_TOUCH_TRANSFORM_C);
-	data->d = ft8xx_rd32(FT800_REG_TOUCH_TRANSFORM_D);
-	data->e = ft8xx_rd32(FT800_REG_TOUCH_TRANSFORM_E);
-	data->f = ft8xx_rd32(FT800_REG_TOUCH_TRANSFORM_F);
+	data->a = ft8xx_rd32(dev, FT800_REG_TOUCH_TRANSFORM_A);
+	data->b = ft8xx_rd32(dev, FT800_REG_TOUCH_TRANSFORM_B);
+	data->c = ft8xx_rd32(dev, FT800_REG_TOUCH_TRANSFORM_C);
+	data->d = ft8xx_rd32(dev, FT800_REG_TOUCH_TRANSFORM_D);
+	data->e = ft8xx_rd32(dev, FT800_REG_TOUCH_TRANSFORM_E);
+	data->f = ft8xx_rd32(dev, FT800_REG_TOUCH_TRANSFORM_F);
 }
 
-void ft8xx_touch_transform_set(const struct ft8xx_touch_transform *data)
+void ft8xx_touch_transform_set(const struct device *dev, const struct ft8xx_touch_transform *data)
 {
-	ft8xx_wr32(FT800_REG_TOUCH_TRANSFORM_A, data->a);
-	ft8xx_wr32(FT800_REG_TOUCH_TRANSFORM_B, data->b);
-	ft8xx_wr32(FT800_REG_TOUCH_TRANSFORM_C, data->c);
-	ft8xx_wr32(FT800_REG_TOUCH_TRANSFORM_D, data->d);
-	ft8xx_wr32(FT800_REG_TOUCH_TRANSFORM_E, data->e);
-	ft8xx_wr32(FT800_REG_TOUCH_TRANSFORM_F, data->f);
+	ft8xx_wr32(dev, FT800_REG_TOUCH_TRANSFORM_A, data->a);
+	ft8xx_wr32(dev, FT800_REG_TOUCH_TRANSFORM_B, data->b);
+	ft8xx_wr32(dev, FT800_REG_TOUCH_TRANSFORM_C, data->c);
+	ft8xx_wr32(dev, FT800_REG_TOUCH_TRANSFORM_D, data->d);
+	ft8xx_wr32(dev, FT800_REG_TOUCH_TRANSFORM_E, data->e);
+	ft8xx_wr32(dev, FT800_REG_TOUCH_TRANSFORM_F, data->f);
 }
+
+#define FT8XX_DEVICE(idx)                                                                          \
+const static struct ft8xx_config ft8xx_##idx##_config = {                                          \
+	.pclk     = DT_INST_PROP(idx, pclk),                                                       \
+	.pclk_pol = DT_INST_PROP(idx, pclk_pol),                                                   \
+	.cspread  = DT_INST_PROP(idx, cspread),                                                    \
+	.swizzle  = DT_INST_PROP(idx, swizzle),                                                    \
+	.vsize    = DT_INST_PROP(idx, vsize),                                                      \
+	.voffset  = DT_INST_PROP(idx, voffset),                                                    \
+	.vcycle   = DT_INST_PROP(idx, vcycle),                                                     \
+	.vsync0   = DT_INST_PROP(idx, vsync0),                                                     \
+	.vsync1   = DT_INST_PROP(idx, vsync1),                                                     \
+	.hsize    = DT_INST_PROP(idx, hsize),                                                      \
+	.hoffset  = DT_INST_PROP(idx, hoffset),                                                    \
+	.hcycle   = DT_INST_PROP(idx, hcycle),                                                     \
+	.hsync0   = DT_INST_PROP(idx, hsync0),                                                     \
+	.hsync1   = DT_INST_PROP(idx, hsync1),                                                     \
+};                                                                                                 \
+static struct ft8xx_data ft8xx_##idx##_data = {                                                    \
+	.ft8xx_dev = NULL,                                                                         \
+	.irq_callback = NULL,                                                                      \
+												   \
+	.spi = SPI_DT_SPEC_INST_GET(idx, SPI_WORD_SET(8) | SPI_OP_MODE_MASTER, 0),                 \
+	.irq_gpio = GPIO_DT_SPEC_INST_GET(idx, irq_gpios),                                         \
+};                                                                                                 \
+DEVICE_DT_INST_DEFINE(idx, ft8xx_init, NULL, &ft8xx_##idx##_data, &ft8xx_##idx##_config,           \
+		      POST_KERNEL, CONFIG_FT800_INIT_PRIORITY, NULL);
+
+DT_INST_FOREACH_STATUS_OKAY(FT8XX_DEVICE)

--- a/drivers/misc/ft8xx/ft8xx.c
+++ b/drivers/misc/ft8xx/ft8xx.c
@@ -159,11 +159,11 @@ void ft8xx_drv_irq_triggered(const struct device *gpio_port, struct gpio_callbac
 	const struct device *ft8xx_dev = ft8xx_data->ft8xx_dev;
 
 	if (ft8xx_data->irq_callback != NULL) {
-		ft8xx_data->irq_callback(ft8xx_dev);
+		ft8xx_data->irq_callback(ft8xx_dev, ft8xx_data->irq_callback_ud);
 	}
 }
 
-void ft8xx_register_int(const struct device *dev, ft8xx_int_callback callback)
+void ft8xx_register_int(const struct device *dev, ft8xx_int_callback callback, void *user_data)
 {
 	struct ft8xx_data *ft8xx_data = dev->data;
 
@@ -172,6 +172,7 @@ void ft8xx_register_int(const struct device *dev, ft8xx_int_callback callback)
 	}
 
 	ft8xx_data->irq_callback = callback;
+	ft8xx_data->irq_callback_ud = user_data;
 	ft8xx_wr8(dev, FT800_REG_INT_MASK, 0x04);
 	ft8xx_wr8(dev, FT800_REG_INT_EN, 0x01);
 }
@@ -225,6 +226,7 @@ const static struct ft8xx_config ft8xx_##idx##_config = {                       
 static struct ft8xx_data ft8xx_##idx##_data = {                                                    \
 	.ft8xx_dev = NULL,                                                                         \
 	.irq_callback = NULL,                                                                      \
+	.irq_callback_ud = NULL,                                                                   \
 												   \
 	.spi = SPI_DT_SPEC_INST_GET(idx, SPI_WORD_SET(8) | SPI_OP_MODE_MASTER, 0),                 \
 	.irq_gpio = GPIO_DT_SPEC_INST_GET(idx, irq_gpios),                                         \

--- a/drivers/misc/ft8xx/ft8xx_common.c
+++ b/drivers/misc/ft8xx/ft8xx_common.c
@@ -9,62 +9,62 @@
 #include <zephyr/sys/byteorder.h>
 #include "ft8xx_drv.h"
 
-void ft8xx_wr8(uint32_t address, uint8_t data)
+void ft8xx_wr8(const struct device *dev, uint32_t address, uint8_t data)
 {
 	int err;
 
-	err = ft8xx_drv_write(address, &data, sizeof(data));
+	err = ft8xx_drv_write(dev, address, &data, sizeof(data));
 	__ASSERT(err == 0, "Writing FT8xx data at 0x%x failed", address);
 }
 
-void ft8xx_wr16(uint32_t address, uint16_t data)
+void ft8xx_wr16(const struct device *dev, uint32_t address, uint16_t data)
 {
 	int err;
 	uint8_t buffer[2];
 
 	*(uint16_t *)buffer = sys_cpu_to_le16(data);
-	err = ft8xx_drv_write(address, buffer, sizeof(buffer));
+	err = ft8xx_drv_write(dev, address, buffer, sizeof(buffer));
 	__ASSERT(err == 0, "Writing FT8xx data at 0x%x failed", address);
 }
 
-void ft8xx_wr32(uint32_t address, uint32_t data)
+void ft8xx_wr32(const struct device *dev, uint32_t address, uint32_t data)
 {
 	int err;
 	uint8_t buffer[4];
 
 	*(uint32_t *)buffer = sys_cpu_to_le32(data);
-	err = ft8xx_drv_write(address, buffer, sizeof(buffer));
+	err = ft8xx_drv_write(dev, address, buffer, sizeof(buffer));
 	__ASSERT(err == 0, "Writing FT8xx data at 0x%x failed", address);
 }
 
-uint8_t ft8xx_rd8(uint32_t address)
+uint8_t ft8xx_rd8(const struct device *dev, uint32_t address)
 {
 	int err;
 	uint8_t data = 0;
 
-	err = ft8xx_drv_read(address, &data, sizeof(data));
+	err = ft8xx_drv_read(dev, address, &data, sizeof(data));
 	__ASSERT(err == 0, "Reading FT8xx data from 0x%x failed", address);
 
 	return data;
 }
 
-uint16_t ft8xx_rd16(uint32_t address)
+uint16_t ft8xx_rd16(const struct device *dev, uint32_t address)
 {
 	int err;
 	uint8_t buffer[2] = {0};
 
-	err = ft8xx_drv_read(address, buffer, sizeof(buffer));
+	err = ft8xx_drv_read(dev, address, buffer, sizeof(buffer));
 	__ASSERT(err == 0, "Reading FT8xx data from 0x%x failed", address);
 
 	return sys_le16_to_cpu(*(const uint16_t *)buffer);
 }
 
-uint32_t ft8xx_rd32(uint32_t address)
+uint32_t ft8xx_rd32(const struct device *dev, uint32_t address)
 {
 	int err;
 	uint8_t buffer[4] = {0};
 
-	err = ft8xx_drv_read(address, buffer, sizeof(buffer));
+	err = ft8xx_drv_read(dev, address, buffer, sizeof(buffer));
 	__ASSERT(err == 0, "Reading FT8xx data from 0x%x failed", address);
 
 	return sys_le32_to_cpu(*(const uint32_t *)buffer);

--- a/drivers/misc/ft8xx/ft8xx_copro.c
+++ b/drivers/misc/ft8xx/ft8xx_copro.c
@@ -11,6 +11,7 @@
 
 #include <zephyr/drivers/misc/ft8xx/ft8xx_common.h>
 #include <zephyr/drivers/misc/ft8xx/ft8xx_memory.h>
+#include "ft8xx_dev_data.h"
 #include "ft8xx_drv.h"
 
 #define FT800_RAM_CMD_SIZE 4096UL
@@ -23,62 +24,72 @@ enum {
 	CMD_CALIBRATE = 0xffffff15,
 } ft8xx_cmd;
 
-static uint16_t reg_cmd_read;
-static uint16_t reg_cmd_write;
-
-static uint16_t ram_cmd_fullness(void)
+static uint16_t ram_cmd_fullness(const struct device *dev)
 {
-	return (reg_cmd_write - reg_cmd_read) % 4096UL;
+	const struct ft8xx_data *data = dev->data;
+
+	return (data->reg_cmd_write - data->reg_cmd_read) % 4096UL;
 }
 
-static uint16_t ram_cmd_freespace(void)
+static uint16_t ram_cmd_freespace(const struct device *dev)
 {
-	return (FT800_RAM_CMD_SIZE - 4UL) - ram_cmd_fullness();
+	return (FT800_RAM_CMD_SIZE - 4UL) - ram_cmd_fullness(dev);
 }
 
-static void refresh_reg_cmd_read(void)
+static void refresh_reg_cmd_read(const struct device *dev)
 {
-	reg_cmd_read = ft8xx_rd32(FT800_REG_CMD_READ);
+	struct ft8xx_data *data = dev->data;
+
+	data->reg_cmd_read = ft8xx_rd32(dev, FT800_REG_CMD_READ);
 }
 
-static void flush_reg_cmd_write(void)
+static void flush_reg_cmd_write(const struct device *dev)
 {
-	ft8xx_wr32(FT800_REG_CMD_WRITE, reg_cmd_write);
+	struct ft8xx_data *data = dev->data;
+
+	ft8xx_wr32(dev, FT800_REG_CMD_WRITE, data->reg_cmd_write);
 }
 
-static void increase_reg_cmd_write(uint16_t value)
+static void increase_reg_cmd_write(const struct device *dev, uint16_t value)
 {
-	reg_cmd_write = (reg_cmd_write + value) % FT800_RAM_CMD_SIZE;
+	struct ft8xx_data *data = dev->data;
+
+	data->reg_cmd_write = (data->reg_cmd_write + value) % FT800_RAM_CMD_SIZE;
 }
 
-void ft8xx_copro_cmd(uint32_t cmd)
+void ft8xx_copro_cmd(const struct device *dev, uint32_t cmd)
 {
-	while (ram_cmd_freespace() < sizeof(cmd)) {
-		refresh_reg_cmd_read();
+	struct ft8xx_data *data = dev->data;
+
+	while (ram_cmd_freespace(dev) < sizeof(cmd)) {
+		refresh_reg_cmd_read(dev);
 	}
 
-	ft8xx_wr32(FT800_RAM_CMD + reg_cmd_write, cmd);
-	increase_reg_cmd_write(sizeof(cmd));
+	ft8xx_wr32(dev, FT800_RAM_CMD + data->reg_cmd_write, cmd);
+	increase_reg_cmd_write(dev, sizeof(cmd));
 
-	flush_reg_cmd_write();
+	flush_reg_cmd_write(dev);
 }
 
-void ft8xx_copro_cmd_dlstart(void)
+void ft8xx_copro_cmd_dlstart(const struct device *dev)
 {
-	ft8xx_copro_cmd(CMD_DLSTART);
+	ft8xx_copro_cmd(dev, CMD_DLSTART);
 }
 
-void ft8xx_copro_cmd_swap(void)
+void ft8xx_copro_cmd_swap(const struct device *dev)
 {
-	ft8xx_copro_cmd(CMD_SWAP);
+	ft8xx_copro_cmd(dev, CMD_SWAP);
 }
 
-void ft8xx_copro_cmd_text(int16_t x,
+void ft8xx_copro_cmd_text(const struct device *dev,
+			   int16_t x,
 			   int16_t y,
 			   int16_t font,
 			   uint16_t options,
 			   const char *s)
 {
+	struct ft8xx_data *data = dev->data;
+
 	const uint16_t str_bytes = strlen(s) + 1;
 	const uint16_t padding_bytes = (4 - (str_bytes % 4)) % 4;
 	const uint16_t cmd_size = sizeof(CMD_TEXT) +
@@ -89,37 +100,40 @@ void ft8xx_copro_cmd_text(int16_t x,
 				   str_bytes +
 				   padding_bytes;
 
-	while (ram_cmd_freespace() < cmd_size) {
-		refresh_reg_cmd_read();
+	while (ram_cmd_freespace(dev) < cmd_size) {
+		refresh_reg_cmd_read(dev);
 	}
 
-	ft8xx_wr32(FT800_RAM_CMD + reg_cmd_write, CMD_TEXT);
-	increase_reg_cmd_write(sizeof(CMD_TEXT));
+	ft8xx_wr32(dev, FT800_RAM_CMD + data->reg_cmd_write, CMD_TEXT);
+	increase_reg_cmd_write(dev, sizeof(CMD_TEXT));
 
-	ft8xx_wr16(FT800_RAM_CMD + reg_cmd_write, x);
-	increase_reg_cmd_write(sizeof(x));
+	ft8xx_wr16(dev, FT800_RAM_CMD + data->reg_cmd_write, x);
+	increase_reg_cmd_write(dev, sizeof(x));
 
-	ft8xx_wr16(FT800_RAM_CMD + reg_cmd_write, y);
-	increase_reg_cmd_write(sizeof(y));
+	ft8xx_wr16(dev, FT800_RAM_CMD + data->reg_cmd_write, y);
+	increase_reg_cmd_write(dev, sizeof(y));
 
-	ft8xx_wr16(FT800_RAM_CMD + reg_cmd_write, font);
-	increase_reg_cmd_write(sizeof(font));
+	ft8xx_wr16(dev, FT800_RAM_CMD + data->reg_cmd_write, font);
+	increase_reg_cmd_write(dev, sizeof(font));
 
-	ft8xx_wr16(FT800_RAM_CMD + reg_cmd_write, options);
-	increase_reg_cmd_write(sizeof(options));
+	ft8xx_wr16(dev, FT800_RAM_CMD + data->reg_cmd_write, options);
+	increase_reg_cmd_write(dev, sizeof(options));
 
-	(void)ft8xx_drv_write(FT800_RAM_CMD + reg_cmd_write, s, str_bytes);
-	increase_reg_cmd_write(str_bytes + padding_bytes);
+	(void)ft8xx_drv_write(dev, FT800_RAM_CMD + data->reg_cmd_write, (uint8_t *)s, str_bytes);
+	increase_reg_cmd_write(dev, str_bytes + padding_bytes);
 
-	flush_reg_cmd_write();
+	flush_reg_cmd_write(dev);
 }
 
-void ft8xx_copro_cmd_number(int16_t x,
+void ft8xx_copro_cmd_number(const struct device *dev,
+			     int16_t x,
 			     int16_t y,
 			     int16_t font,
 			     uint16_t options,
 			     int32_t n)
 {
+	struct ft8xx_data *data = dev->data;
+
 	const uint16_t cmd_size = sizeof(CMD_NUMBER) +
 				   sizeof(x) +
 				   sizeof(y) +
@@ -127,53 +141,55 @@ void ft8xx_copro_cmd_number(int16_t x,
 				   sizeof(options) +
 				   sizeof(n);
 
-	while (ram_cmd_freespace() < cmd_size) {
-		refresh_reg_cmd_read();
+	while (ram_cmd_freespace(dev) < cmd_size) {
+		refresh_reg_cmd_read(dev);
 	}
 
-	ft8xx_wr32(FT800_RAM_CMD + reg_cmd_write, CMD_NUMBER);
-	increase_reg_cmd_write(sizeof(CMD_NUMBER));
+	ft8xx_wr32(dev, FT800_RAM_CMD + data->reg_cmd_write, CMD_NUMBER);
+	increase_reg_cmd_write(dev, sizeof(CMD_NUMBER));
 
-	ft8xx_wr16(FT800_RAM_CMD + reg_cmd_write, x);
-	increase_reg_cmd_write(sizeof(x));
+	ft8xx_wr16(dev, FT800_RAM_CMD + data->reg_cmd_write, x);
+	increase_reg_cmd_write(dev, sizeof(x));
 
-	ft8xx_wr16(FT800_RAM_CMD + reg_cmd_write, y);
-	increase_reg_cmd_write(sizeof(y));
+	ft8xx_wr16(dev, FT800_RAM_CMD + data->reg_cmd_write, y);
+	increase_reg_cmd_write(dev, sizeof(y));
 
-	ft8xx_wr16(FT800_RAM_CMD + reg_cmd_write, font);
-	increase_reg_cmd_write(sizeof(font));
+	ft8xx_wr16(dev, FT800_RAM_CMD + data->reg_cmd_write, font);
+	increase_reg_cmd_write(dev, sizeof(font));
 
-	ft8xx_wr16(FT800_RAM_CMD + reg_cmd_write, options);
-	increase_reg_cmd_write(sizeof(options));
+	ft8xx_wr16(dev, FT800_RAM_CMD + data->reg_cmd_write, options);
+	increase_reg_cmd_write(dev, sizeof(options));
 
-	ft8xx_wr32(FT800_RAM_CMD + reg_cmd_write, n);
-	increase_reg_cmd_write(sizeof(n));
+	ft8xx_wr32(dev, FT800_RAM_CMD + data->reg_cmd_write, n);
+	increase_reg_cmd_write(dev, sizeof(n));
 
-	flush_reg_cmd_write();
+	flush_reg_cmd_write(dev);
 }
 
-void ft8xx_copro_cmd_calibrate(uint32_t *result)
+void ft8xx_copro_cmd_calibrate(const struct device *dev, uint32_t *result)
 {
+	struct ft8xx_data *data = dev->data;
+
 	const uint16_t cmd_size = sizeof(CMD_CALIBRATE) + sizeof(uint32_t);
 	uint32_t result_address;
 
-	while (ram_cmd_freespace() < cmd_size) {
-		refresh_reg_cmd_read();
+	while (ram_cmd_freespace(dev) < cmd_size) {
+		refresh_reg_cmd_read(dev);
 	}
 
-	ft8xx_wr32(FT800_RAM_CMD + reg_cmd_write, CMD_CALIBRATE);
-	increase_reg_cmd_write(sizeof(CMD_CALIBRATE));
+	ft8xx_wr32(dev, FT800_RAM_CMD + data->reg_cmd_write, CMD_CALIBRATE);
+	increase_reg_cmd_write(dev, sizeof(CMD_CALIBRATE));
 
-	result_address = FT800_RAM_CMD + reg_cmd_write;
-	ft8xx_wr32(result_address, 1UL);
-	increase_reg_cmd_write(sizeof(uint32_t));
+	result_address = FT800_RAM_CMD + data->reg_cmd_write;
+	ft8xx_wr32(dev, result_address, 1UL);
+	increase_reg_cmd_write(dev, sizeof(uint32_t));
 
-	flush_reg_cmd_write();
+	flush_reg_cmd_write(dev);
 
 	/* Wait until calibration is finished. */
-	while (ram_cmd_fullness() > 0) {
-		refresh_reg_cmd_read();
+	while (ram_cmd_fullness(dev) > 0) {
+		refresh_reg_cmd_read(dev);
 	}
 
-	*result = ft8xx_rd32(result_address);
+	*result = ft8xx_rd32(dev, result_address);
 }

--- a/drivers/misc/ft8xx/ft8xx_dev_data.h
+++ b/drivers/misc/ft8xx/ft8xx_dev_data.h
@@ -25,6 +25,7 @@ extern "C" {
 struct ft8xx_data {
 	const struct device *ft8xx_dev; /* Required for GPIO IRQ handling */
 	ft8xx_int_callback irq_callback;
+	void *irq_callback_ud;
 
 	const struct spi_dt_spec spi;
 	const struct gpio_dt_spec irq_gpio;

--- a/drivers/misc/ft8xx/ft8xx_dev_data.h
+++ b/drivers/misc/ft8xx/ft8xx_dev_data.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2024 Hubert Miś
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief FT8XX device driver data structure
+ */
+
+#ifndef ZEPHYR_DRIVERS_MISC_FT8XX_FT8XX_DEV_DATA_H_
+#define ZEPHYR_DRIVERS_MISC_FT8XX_FT8XX_DEV_DATA_H_
+
+#include <stdint.h>
+
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/drivers/spi.h>
+#include <zephyr/drivers/misc/ft8xx/ft8xx.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct ft8xx_data {
+	const struct device *ft8xx_dev; /* Required for GPIO IRQ handling */
+	ft8xx_int_callback irq_callback;
+
+	const struct spi_dt_spec spi;
+	const struct gpio_dt_spec irq_gpio;
+	struct gpio_callback irq_cb_data;
+
+	uint16_t reg_cmd_read;
+	uint16_t reg_cmd_write;
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_DRIVERS_MISC_FT8XX_FT8XX_DEV_DATA_H_ */

--- a/drivers/misc/ft8xx/ft8xx_drv.h
+++ b/drivers/misc/ft8xx/ft8xx_drv.h
@@ -21,10 +21,11 @@
 extern "C" {
 #endif
 
-int ft8xx_drv_init(void);
-int ft8xx_drv_read(uint32_t address, uint8_t *data, unsigned int length);
-int ft8xx_drv_write(uint32_t address, const uint8_t *data, unsigned int length);
-int ft8xx_drv_command(uint8_t command);
+int ft8xx_drv_init(const struct device *dev);
+int ft8xx_drv_read(const struct device *dev, uint32_t address, uint8_t *data, unsigned int length);
+int ft8xx_drv_write(const struct device *dev, uint32_t address, const uint8_t *data,
+		    unsigned int length);
+int ft8xx_drv_command(const struct device *dev, uint8_t command);
 
 extern void ft8xx_drv_irq_triggered(const struct device *dev,
 		struct gpio_callback *cb, uint32_t pins);

--- a/include/zephyr/drivers/misc/ft8xx/ft8xx.h
+++ b/include/zephyr/drivers/misc/ft8xx/ft8xx.h
@@ -48,8 +48,9 @@ struct ft8xx_touch_transform {
  * This callback is called from IRQ context.
  *
  * @param dev Pointer to the device structure for the driver instance
+ * @param user_data Pointer to user data provided during callback registration
  */
-typedef void (*ft8xx_int_callback)(const struct device *dev);
+typedef void (*ft8xx_int_callback)(const struct device *dev, void *user_data);
 
 /**
  * @brief Calibrate touchscreen
@@ -102,9 +103,11 @@ int ft8xx_get_touch_tag(const struct device *dev);
  *
  * @param dev       Pointer to the device structure for the driver instance
  * @param callback  Pointer to function called when FT8xx triggers interrupt
+ * @param user_data Pointer to user data to be passed to the @p callback
  */
 void ft8xx_register_int(const struct device *dev,
-			ft8xx_int_callback callback);
+			ft8xx_int_callback callback,
+			void *user_data);
 
 /**
  * @}

--- a/include/zephyr/drivers/misc/ft8xx/ft8xx.h
+++ b/include/zephyr/drivers/misc/ft8xx/ft8xx.h
@@ -13,6 +13,7 @@
 #define ZEPHYR_DRIVERS_MISC_FT8XX_FT8XX_H_
 
 #include <stdint.h>
+#include <zephyr/device.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -45,8 +46,10 @@ struct ft8xx_touch_transform {
  * @brief Callback API to inform API user that FT8xx triggered interrupt
  *
  * This callback is called from IRQ context.
+ *
+ * @param dev Pointer to the device structure for the driver instance
  */
-typedef void (*ft8xx_int_callback)(void);
+typedef void (*ft8xx_int_callback)(const struct device *dev);
 
 /**
  * @brief Calibrate touchscreen
@@ -59,9 +62,11 @@ typedef void (*ft8xx_int_callback)(void);
  * ft8xx_touch_transform_set() to avoid calibrating touchscreen after each
  * device reset.
  *
+ * @param dev  Pointer to the device structure for the driver instance
  * @param data Pointer to touchscreen transform structure to populate
  */
-void ft8xx_calibrate(struct ft8xx_touch_transform *data);
+void ft8xx_calibrate(const struct device *dev,
+		     struct ft8xx_touch_transform *data);
 
 /**
  * @brief Set touchscreen calibration data
@@ -70,16 +75,20 @@ void ft8xx_calibrate(struct ft8xx_touch_transform *data);
  * Data is to be obtained from calibration procedure started with
  * ft8xx_calibrate().
  *
+ * @param dev  Pointer to the device structure for the driver instance
  * @param data Pointer to touchscreen transform structure to apply
  */
-void ft8xx_touch_transform_set(const struct ft8xx_touch_transform *data);
+void ft8xx_touch_transform_set(const struct device *dev,
+			       const struct ft8xx_touch_transform *data);
 
 /**
  * @brief Get tag of recently touched element
  *
+ * @param dev Pointer to the device structure for the driver instance
+ *
  * @return Tag value 0-255 of recently touched element
  */
-int ft8xx_get_touch_tag(void);
+int ft8xx_get_touch_tag(const struct device *dev);
 
 /**
  * @brief Set callback executed when FT8xx triggers interrupt
@@ -91,9 +100,11 @@ int ft8xx_get_touch_tag(void);
  * kept active until ft8xx_get_touch_tag() is called. It results in single
  * execution of @p callback until ft8xx_get_touch_tag() is called.
  *
- * @param callback Pointer to function called when FT8xx triggers interrupt
+ * @param dev       Pointer to the device structure for the driver instance
+ * @param callback  Pointer to function called when FT8xx triggers interrupt
  */
-void ft8xx_register_int(ft8xx_int_callback callback);
+void ft8xx_register_int(const struct device *dev,
+			ft8xx_int_callback callback);
 
 /**
  * @}

--- a/include/zephyr/drivers/misc/ft8xx/ft8xx_common.h
+++ b/include/zephyr/drivers/misc/ft8xx/ft8xx_common.h
@@ -13,6 +13,7 @@
 #define ZEPHYR_DRIVERS_MISC_FT8XX_FT8XX_COMMON_H_
 
 #include <stdint.h>
+#include <zephyr/device.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -28,53 +29,59 @@ extern "C" {
 /**
  * @brief Write 1 byte (8 bits) to FT8xx memory
  *
+ * @param dev Pointer to the device structure for the driver instance
  * @param address Memory address to write to
  * @param data Byte to write
  */
-void ft8xx_wr8(uint32_t address, uint8_t data);
+void ft8xx_wr8(const struct device *dev, uint32_t address, uint8_t data);
 
 /**
  * @brief Write 2 bytes (16 bits) to FT8xx memory
  *
+ * @param dev Pointer to the device structure for the driver instance
  * @param address Memory address to write to
  * @param data Value to write
  */
-void ft8xx_wr16(uint32_t address, uint16_t data);
+void ft8xx_wr16(const struct device *dev, uint32_t address, uint16_t data);
 
 /**
  * @brief Write 4 bytes (32 bits) to FT8xx memory
  *
+ * @param dev Pointer to the device structure for the driver instance
  * @param address Memory address to write to
  * @param data Value to write
  */
-void ft8xx_wr32(uint32_t address, uint32_t data);
+void ft8xx_wr32(const struct device *dev, uint32_t address, uint32_t data);
 
 /**
  * @brief Read 1 byte (8 bits) from FT8xx memory
  *
+ * @param dev Pointer to the device structure for the driver instance
  * @param address Memory address to read from
  *
  * @return Value read from memory
  */
-uint8_t ft8xx_rd8(uint32_t address);
+uint8_t ft8xx_rd8(const struct device *dev, uint32_t address);
 
 /**
  * @brief Read 2 bytes (16 bits) from FT8xx memory
  *
+ * @param dev Pointer to the device structure for the driver instance
  * @param address Memory address to read from
  *
  * @return Value read from memory
  */
-uint16_t ft8xx_rd16(uint32_t address);
+uint16_t ft8xx_rd16(const struct device *dev, uint32_t address);
 
 /**
  * @brief Read 4 bytes (32 bits) from FT8xx memory
  *
+ * @param dev Pointer to the device structure for the driver instance
  * @param address Memory address to read from
  *
  * @return Value read from memory
  */
-uint32_t ft8xx_rd32(uint32_t address);
+uint32_t ft8xx_rd32(const struct device *dev, uint32_t address);
 
 /**
  * @}

--- a/include/zephyr/drivers/misc/ft8xx/ft8xx_copro.h
+++ b/include/zephyr/drivers/misc/ft8xx/ft8xx_copro.h
@@ -13,6 +13,7 @@
 #define ZEPHYR_DRIVERS_MISC_FT8XX_FT8XX_COPRO_H_
 
 #include <stdint.h>
+#include <zephyr/device.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -65,19 +66,24 @@ extern "C" {
 /**
  * @brief Execute a display list command by co-processor engine
  *
+ * @param dev Device structure
  * @param cmd Display list command to execute
  */
-void ft8xx_copro_cmd(uint32_t cmd);
+void ft8xx_copro_cmd(const struct device *dev, uint32_t cmd);
 
 /**
  * @brief Start a new display list
+ *
+ * @param dev Device structure
  */
-void ft8xx_copro_cmd_dlstart(void);
+void ft8xx_copro_cmd_dlstart(const struct device *dev);
 
 /**
  * @brief Swap the current display list
+ *
+ * @param dev Device structure
  */
-void ft8xx_copro_cmd_swap(void);
+void ft8xx_copro_cmd_swap(const struct device *dev);
 
 /**
  * @brief Draw text
@@ -88,17 +94,19 @@ void ft8xx_copro_cmd_swap(void);
  * the text in both directions. @ref FT8XX_OPT_RIGHTX right-justifies the text,
  * so that the @p x is the rightmost pixel.
  *
+ * @param dev Device structure
  * @param x x-coordinate of text base, in pixels
  * @param y y-coordinate of text base, in pixels
  * @param font Font to use for text, 0-31. 16-31 are ROM fonts
  * @param options Options to apply
  * @param s Character string to display, terminated with a null character
  */
-void ft8xx_copro_cmd_text(int16_t x,
-			   int16_t y,
-			   int16_t font,
-			   uint16_t options,
-			   const char *s);
+void ft8xx_copro_cmd_text(const struct device *dev,
+			  int16_t x,
+			  int16_t y,
+			  int16_t font,
+			  uint16_t options,
+			  const char *s);
 
 /**
  * @brief Draw a decimal number
@@ -113,17 +121,19 @@ void ft8xx_copro_cmd_text(int16_t x,
  * If @ref FT8XX_OPT_SIGNED is given, the number is treated as signed, and
  * prefixed by a minus sign if negative.
  *
+ * @param dev Device structure
  * @param x x-coordinate of text base, in pixels
  * @param y y-coordinate of text base, in pixels
  * @param font Font to use for text, 0-31. 16-31 are ROM fonts
  * @param options Options to apply
  * @param n The number to display.
  */
-void ft8xx_copro_cmd_number(int16_t x,
-			     int16_t y,
-			     int16_t font,
-			     uint16_t options,
-			     int32_t n);
+void ft8xx_copro_cmd_number(const struct device *dev,
+			    int16_t x,
+			    int16_t y,
+			    int16_t font,
+			    uint16_t options,
+			    int32_t n);
 
 /**
  * @brief Execute the touch screen calibration routine
@@ -134,9 +144,10 @@ void ft8xx_copro_cmd_number(int16_t x,
  * engine overlays the touch targets on the current display list, gathers the
  * calibration input and updates REG_TOUCH_TRANSFORM_A-F.
  *
+ * @param dev Device structure
  * @param result Calibration result, written with 0 on failure of calibration
  */
-void ft8xx_copro_cmd_calibrate(uint32_t *result);
+void ft8xx_copro_cmd_calibrate(const struct device *dev, uint32_t *result);
 
 /**
  * @}

--- a/include/zephyr/drivers/misc/ft8xx/ft8xx_reference_api.h
+++ b/include/zephyr/drivers/misc/ft8xx/ft8xx_reference_api.h
@@ -46,7 +46,7 @@ extern "C" {
  */
 static inline void wr8(uint32_t address, uint8_t data)
 {
-	ft8xx_wr8(address, data);
+	ft8xx_wr8(DEVICE_DT_GET_ONE(ftdi_ft800), address, data);
 }
 
 /**
@@ -57,7 +57,7 @@ static inline void wr8(uint32_t address, uint8_t data)
  */
 static inline void wr16(uint32_t address, uint16_t data)
 {
-	ft8xx_wr16(address, data);
+	ft8xx_wr16(DEVICE_DT_GET_ONE(ftdi_ft800), address, data);
 }
 
 /**
@@ -68,7 +68,7 @@ static inline void wr16(uint32_t address, uint16_t data)
  */
 static inline void wr32(uint32_t address, uint32_t data)
 {
-	ft8xx_wr32(address, data);
+	ft8xx_wr32(DEVICE_DT_GET_ONE(ftdi_ft800), address, data);
 }
 
 /**
@@ -80,7 +80,7 @@ static inline void wr32(uint32_t address, uint32_t data)
  */
 static inline uint8_t rd8(uint32_t address)
 {
-	return ft8xx_rd8(address);
+	return ft8xx_rd8(DEVICE_DT_GET_ONE(ftdi_ft800), address);
 }
 
 /**
@@ -92,7 +92,7 @@ static inline uint8_t rd8(uint32_t address)
  */
 static inline uint16_t rd16(uint32_t address)
 {
-	return ft8xx_rd16(address);
+	return ft8xx_rd16(DEVICE_DT_GET_ONE(ftdi_ft800), address);
 }
 
 /**
@@ -104,7 +104,7 @@ static inline uint16_t rd16(uint32_t address)
  */
 static inline uint32_t rd32(uint32_t address)
 {
-	return ft8xx_rd32(address);
+	return ft8xx_rd32(DEVICE_DT_GET_ONE(ftdi_ft800), address);
 }
 
 
@@ -152,7 +152,7 @@ static inline uint32_t rd32(uint32_t address)
  */
 static inline void cmd(uint32_t command)
 {
-	ft8xx_copro_cmd(command);
+	ft8xx_copro_cmd(DEVICE_DT_GET_ONE(ftdi_ft800), command);
 }
 
 /**
@@ -160,7 +160,7 @@ static inline void cmd(uint32_t command)
  */
 static inline void cmd_dlstart(void)
 {
-	ft8xx_copro_cmd_dlstart();
+	ft8xx_copro_cmd_dlstart(DEVICE_DT_GET_ONE(ftdi_ft800));
 }
 
 /**
@@ -168,7 +168,7 @@ static inline void cmd_dlstart(void)
  */
 static inline void cmd_swap(void)
 {
-	ft8xx_copro_cmd_swap();
+	ft8xx_copro_cmd_swap(DEVICE_DT_GET_ONE(ftdi_ft800));
 }
 
 /**
@@ -191,7 +191,7 @@ static inline void cmd_text(int16_t x,
 			   uint16_t options,
 			   const char *s)
 {
-	ft8xx_copro_cmd_text(x, y, font, options, s);
+	ft8xx_copro_cmd_text(DEVICE_DT_GET_ONE(ftdi_ft800), x, y, font, options, s);
 }
 
 /**
@@ -218,7 +218,7 @@ static inline void cmd_number(int16_t x,
 			     uint16_t options,
 			     int32_t n)
 {
-	ft8xx_copro_cmd_number(x, y, font, options, n);
+	ft8xx_copro_cmd_number(DEVICE_DT_GET_ONE(ftdi_ft800), x, y, font, options, n);
 }
 
 /**
@@ -234,7 +234,7 @@ static inline void cmd_number(int16_t x,
  */
 static inline void cmd_calibrate(uint32_t *result)
 {
-	ft8xx_copro_cmd_calibrate(result);
+	ft8xx_copro_cmd_calibrate(DEVICE_DT_GET_ONE(ftdi_ft800), result);
 }
 
 

--- a/samples/drivers/misc/ft800/src/main.c
+++ b/samples/drivers/misc/ft800/src/main.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/device.h>
 #include <zephyr/kernel.h>
 
 #include <zephyr/drivers/misc/ft8xx/ft8xx.h>
@@ -23,22 +24,30 @@
 
 static volatile bool process_touch;
 
-static void touch_irq(void)
+static void touch_irq(const struct device *dev)
 {
+	(void)dev;
+
 	process_touch = true;
 }
 
 int main(void)
 {
+	const struct device *ft8xx = DEVICE_DT_GET_ONE(ftdi_ft800);
 	int cnt;
 	int val;
 	struct ft8xx_touch_transform tt;
 
+	if (!device_is_ready(ft8xx)) {
+		printk("FT8xx device is not ready. Aborting\n");
+		return -1;
+	}
+
 	/* To get touch events calibrate the display */
-	ft8xx_calibrate(&tt);
+	ft8xx_calibrate(ft8xx, &tt);
 
 	/* Get interrupts on touch event */
-	ft8xx_register_int(touch_irq);
+	ft8xx_register_int(ft8xx, touch_irq);
 
 	/* Starting counting */
 	val = 0;
@@ -46,40 +55,40 @@ int main(void)
 
 	while (1) {
 		/* Start Display List */
-		ft8xx_copro_cmd_dlstart();
-		ft8xx_copro_cmd(FT8XX_CLEAR_COLOR_RGB(0x00, 0x00, 0x00));
-		ft8xx_copro_cmd(FT8XX_CLEAR(1, 1, 1));
+		ft8xx_copro_cmd_dlstart(ft8xx);
+		ft8xx_copro_cmd(ft8xx, FT8XX_CLEAR_COLOR_RGB(0x00, 0x00, 0x00));
+		ft8xx_copro_cmd(ft8xx, FT8XX_CLEAR(1, 1, 1));
 
 		/* Set color */
-		ft8xx_copro_cmd(FT8XX_COLOR_RGB(0xf0, 0xf0, 0xf0));
+		ft8xx_copro_cmd(ft8xx, FT8XX_COLOR_RGB(0xf0, 0xf0, 0xf0));
 
 		/* Display the counter */
-		ft8xx_copro_cmd_number(20, 20, 29, FT8XX_OPT_SIGNED, cnt);
+		ft8xx_copro_cmd_number(ft8xx, 20, 20, 29, FT8XX_OPT_SIGNED, cnt);
 		cnt++;
 
 		/* Display the hello message */
-		ft8xx_copro_cmd_text(20, 70, 30, 0, "Hello,");
+		ft8xx_copro_cmd_text(ft8xx, 20, 70, 30, 0, "Hello,");
 		/* Set Zephyr color */
-		ft8xx_copro_cmd(FT8XX_COLOR_RGB(0x78, 0x29, 0xd2));
-		ft8xx_copro_cmd_text(20, 105, 30, 0, "Zephyr!");
+		ft8xx_copro_cmd(ft8xx, FT8XX_COLOR_RGB(0x78, 0x29, 0xd2));
+		ft8xx_copro_cmd_text(ft8xx, 20, 105, 30, 0, "Zephyr!");
 
 		/* Display value set with buttons */
-		ft8xx_copro_cmd(FT8XX_COLOR_RGB(0xff, 0xff, 0xff));
-		ft8xx_copro_cmd_number(80, 170, 29,
+		ft8xx_copro_cmd(ft8xx, FT8XX_COLOR_RGB(0xff, 0xff, 0xff));
+		ft8xx_copro_cmd_number(ft8xx, 80, 170, 29,
 					FT8XX_OPT_SIGNED | FT8XX_OPT_RIGHTX,
 					val);
-		ft8xx_copro_cmd(FT8XX_TAG(TAG_PLUS));
-		ft8xx_copro_cmd_text(90, 160, 31, 0, "+");
-		ft8xx_copro_cmd(FT8XX_TAG(TAG_MINUS));
-		ft8xx_copro_cmd_text(20, 160, 31, 0, "-");
+		ft8xx_copro_cmd(ft8xx, FT8XX_TAG(TAG_PLUS));
+		ft8xx_copro_cmd_text(ft8xx, 90, 160, 31, 0, "+");
+		ft8xx_copro_cmd(ft8xx, FT8XX_TAG(TAG_MINUS));
+		ft8xx_copro_cmd_text(ft8xx, 20, 160, 31, 0, "-");
 
 		/* Finish Display List */
-		ft8xx_copro_cmd(FT8XX_DISPLAY());
+		ft8xx_copro_cmd(ft8xx, FT8XX_DISPLAY());
 		/* Display created frame */
-		ft8xx_copro_cmd_swap();
+		ft8xx_copro_cmd_swap(ft8xx);
 
 		if (process_touch) {
-			int tag = ft8xx_get_touch_tag();
+			int tag = ft8xx_get_touch_tag(ft8xx);
 
 			if (tag == TAG_PLUS) {
 				val++;

--- a/samples/drivers/misc/ft800/src/main.c
+++ b/samples/drivers/misc/ft800/src/main.c
@@ -24,9 +24,10 @@
 
 static volatile bool process_touch;
 
-static void touch_irq(const struct device *dev)
+static void touch_irq(const struct device *dev, void *user_data)
 {
 	(void)dev;
+	(void)user_data;
 
 	process_touch = true;
 }
@@ -47,7 +48,7 @@ int main(void)
 	ft8xx_calibrate(ft8xx, &tt);
 
 	/* Get interrupts on touch event */
-	ft8xx_register_int(ft8xx, touch_irq);
+	ft8xx_register_int(ft8xx, touch_irq, NULL);
 
 	/* Starting counting */
 	val = 0;


### PR DESCRIPTION
Improve the FT8xx display driver to support multiple driver instances.

The ft8xx_reference_api.h still follows the FT8xx programming guides, limiting the usage of the driver to one instance.