### PR TITLE
sensor: adxl3xx: Move run-time ODR changes from cfg to data

### DIFF
--- a/drivers/sensor/adi/adxl345/adxl345.c
+++ b/drivers/sensor/adi/adxl345/adxl345.c
@@ -229,7 +229,7 @@ static int adxl345_attr_set_odr(const struct device *dev,
 				const struct sensor_value *val)
 {
 	enum adxl345_odr odr;
-	struct adxl345_dev_config *cfg = (struct adxl345_dev_config *)dev->config;
+	struct adxl345_dev_data *data = dev->data;
 
 	switch (val->val1) {
 	case 12:
@@ -257,7 +257,7 @@ static int adxl345_attr_set_odr(const struct device *dev,
 	int ret = adxl345_set_odr(dev, odr);
 
 	if (ret == 0) {
-		cfg->odr = odr;
+		data->odr = odr;
 	}
 
 	return ret;

--- a/drivers/sensor/adi/adxl345/adxl345.h
+++ b/drivers/sensor/adi/adxl345/adxl345.h
@@ -156,6 +156,7 @@ struct adxl345_dev_data {
 	struct adxl345_fifo_config fifo_config;
 	uint8_t is_full_res;
 	uint8_t selected_range;
+	enum adxl345_odr odr;
 #ifdef CONFIG_ADXL345_TRIGGER
 	struct gpio_callback gpio_cb;
 

--- a/drivers/sensor/adi/adxl345/adxl345_stream.c
+++ b/drivers/sensor/adi/adxl345/adxl345_stream.c
@@ -159,7 +159,7 @@ static void adxl345_process_fifo_samples_cb(struct rtio *r, const struct rtio_sq
 	hdr->int_status = data->status1;
 	hdr->is_full_res = data->is_full_res;
 	hdr->selected_range = data->selected_range;
-	hdr->accel_odr = cfg->odr;
+	hdr->accel_odr = data->odr;
 	hdr->sample_set_size = sample_set_size;
 
 	uint32_t buf_avail = buf_len;

--- a/drivers/sensor/adi/adxl372/adxl372.c
+++ b/drivers/sensor/adi/adxl372/adxl372.c
@@ -550,7 +550,7 @@ static int adxl372_attr_set_odr(const struct device *dev,
 				const struct sensor_value *val)
 {
 	enum adxl372_odr odr;
-	struct adxl372_dev_config *cfg = (struct adxl372_dev_config *)dev->config;
+	struct adxl372_data *data = dev->data;
 
 	switch (val->val1) {
 	case 400:
@@ -575,7 +575,7 @@ static int adxl372_attr_set_odr(const struct device *dev,
 	int ret = adxl372_set_odr(dev, odr);
 
 	if (ret == 0) {
-		cfg->odr = odr;
+		data->odr = odr;
 	}
 
 	return ret;

--- a/drivers/sensor/adi/adxl372/adxl372.h
+++ b/drivers/sensor/adi/adxl372/adxl372.h
@@ -312,6 +312,7 @@ struct adxl372_data {
 	const struct adxl372_transfer_function *hw_tf;
 	struct adxl372_fifo_config fifo_config;
 	enum adxl372_act_proc_mode act_proc_mode;
+	enum adxl372_odr odr;
 #ifdef CONFIG_ADXL372_TRIGGER
 	struct gpio_callback gpio_cb;
 

--- a/drivers/sensor/adi/adxl372/adxl372_stream.c
+++ b/drivers/sensor/adi/adxl372/adxl372_stream.c
@@ -213,7 +213,7 @@ static void adxl372_process_fifo_samples_cb(struct rtio *r, const struct rtio_sq
 	hdr->is_fifo = 1;
 	hdr->timestamp = data->timestamp;
 	hdr->int_status = data->status1;
-	hdr->accel_odr = cfg->odr;
+	hdr->accel_odr = data->odr;
 	hdr->sample_set_size = sample_set_size;
 
 	if ((cfg->fifo_config.fifo_format == ADXL372_X_FIFO) ||


### PR DESCRIPTION
`cfg` struct is constant and attempting to modify it triggers a fault. Instead, moved to `data`.

Fixes #83853 