### PR TITLE
dts: bindings: sdhc: replace underscore with hyphen

### DIFF
--- a/doc/releases/migration-guide-4.1.rst
+++ b/doc/releases/migration-guide-4.1.rst
@@ -223,6 +223,12 @@ PWM
 
 * Renamed the ``compatible`` from ``nxp,kinetis-ftm-pwm`` to :dtcompatible:`nxp,ftm-pwm`.
 
+SDHC
+====
+
+* Renamed the device tree property from ``power_delay_ms`` to ``power-delay-ms```
+* Renamed the device tree property from ``max_current_330`` to ``max-current-330``
+
 Sensors
 =======
 

--- a/dts/arm64/intel/intel_socfpga_agilex5.dtsi
+++ b/dts/arm64/intel/intel_socfpga_agilex5.dtsi
@@ -128,7 +128,7 @@
 			<0x10B92000 0x1000>;
 		reg-names = "reg_base", "combo_phy";
 		clock-frequency = <200000000>;
-		power_delay_ms = <1000>;
+		power-delay-ms = <1000>;
 		resets = <&reset RSTMGR_SDMMC_RSTLINE>,
 			<&reset RSTMGR_SDMMCECC_RSTLINE>,
 			<&reset RSTMGR_SOFTPHY_RSTLINE>;

--- a/dts/bindings/sdhc/cdns,sdhc.yaml
+++ b/dts/bindings/sdhc/cdns,sdhc.yaml
@@ -14,7 +14,7 @@ properties:
   reg:
     required: true
     description: register space
-  power_delay_ms:
+  power-delay-ms:
     type: int
     required: true
     description: delay required to switch on the SDHC

--- a/dts/bindings/sdhc/nxp,imx-usdhc.yaml
+++ b/dts/bindings/sdhc/nxp,imx-usdhc.yaml
@@ -29,7 +29,7 @@ properties:
     description: |
       Number of words used as write watermark level in FIFO queue for USDHC
 
-  max_current_330:
+  max-current-330:
     type: int
     default: 0
     description: |


### PR DESCRIPTION
Adhering to device tree spec, underscore is replaced with hyphen