### PR TITLE
lib: libc: Add fopen in newlibc, minimal and picolibc

### DIFF
--- a/include/zephyr/posix/fcntl.h
+++ b/include/zephyr/posix/fcntl.h
@@ -30,6 +30,7 @@ extern "C" {
 #endif
 
 int open(const char *name, int flags, ...);
+int close(int fd);
 int fcntl(int fildes, int cmd, ...);
 
 #ifdef __cplusplus

--- a/lib/libc/minimal/CMakeLists.txt
+++ b/lib/libc/minimal/CMakeLists.txt
@@ -35,6 +35,10 @@ zephyr_library_sources(
   ${STRERROR_TABLE_H}
 )
 
+zephyr_library_sources_ifdef(CONFIG_POSIX_FILE_SYSTEM
+  source/file_ops.c
+  )
+
 if(CONFIG_MINIMAL_LIBC_TIME)
   zephyr_library_sources(source/time/gmtime.c)
 endif()

--- a/lib/libc/minimal/source/stdio/file_ops.c
+++ b/lib/libc/minimal/source/stdio/file_ops.c
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2025  Ahmed Adel <a.adel2010@gmail.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <zephyr/posix/fcntl.h>
+#include <errno.h>
+
+static int mode2flags(const char *mode)
+{
+	int flags = 0;
+
+	switch (mode[0]) {
+	case 'r':
+		flags = O_RDONLY;
+		if (mode[1] == '+') {
+			flags = O_RDWR;
+		}
+		break;
+	case 'w':
+		flags = O_WRONLY | O_CREAT | O_TRUNC;
+		if (mode[1] == '+') {
+			flags = O_RDWR | O_CREAT | O_TRUNC;
+		}
+		break;
+	case 'a':
+		flags = O_WRONLY | O_CREAT | O_APPEND;
+		if (mode[1] == '+') {
+			flags = O_RDWR | O_CREAT | O_APPEND;
+		}
+		break;
+	default:
+		errno = EINVAL;
+		return -1;
+	}
+
+	return flags;
+}
+
+FILE *fopen(const char *ZRESTRICT filename, const char *ZRESTRICT mode)
+{
+	int flags = 0;
+	int fd = 0;
+	FILE *stream = NULL;
+
+	if (filename == NULL || mode == NULL) {
+		errno = EINVAL;
+		return NULL;
+	}
+
+	flags = mode2flags(mode);
+	if (flags < 0) {
+		errno = EINVAL;
+		return NULL;
+	}
+
+	fd = open(filename, flags);
+	if (fd < 0) {
+		errno = EIO;
+		return NULL;
+	}
+
+	stream = (FILE *)calloc(1, sizeof(FILE));
+	if (stream != NULL) {
+		*stream = fd;
+	} else {
+		close(fd);
+		errno = ENOMEM;
+	}
+
+	return stream;
+}
+
+int fclose(FILE *stream)
+{
+	if (stream == NULL) {
+		errno = EINVAL;
+		return EOF;
+	}
+
+	int fd = *stream;
+	int rc = close(fd);
+
+	if (rc < 0) {
+		errno = EIO;
+		return EOF;
+	}
+
+	free((void *)stream);
+
+	return 0;
+}

--- a/lib/libc/newlib/CMakeLists.txt
+++ b/lib/libc/newlib/CMakeLists.txt
@@ -3,6 +3,10 @@
 zephyr_library()
 zephyr_library_sources(libc-hooks.c)
 
+zephyr_library_sources_ifdef(CONFIG_POSIX_FILE_SYSTEM
+  source/file_ops.c
+  )
+
 # Do not allow LTO when compiling libc-hooks.c file
 set_source_files_properties(libc-hooks.c PROPERTIES COMPILE_OPTIONS $<TARGET_PROPERTY:compiler,prohibit_lto>)
 

--- a/lib/libc/newlib/source/file_ops.c
+++ b/lib/libc/newlib/source/file_ops.c
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2025  Ahmed Adel <a.adel2010@gmail.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <zephyr/posix/fcntl.h>
+#include <errno.h>
+
+static int mode2flags(const char *mode)
+{
+	int flags = 0;
+
+	switch (mode[0]) {
+	case 'r':
+		flags = O_RDONLY;
+		if (mode[1] == '+') {
+			flags = O_RDWR;
+		}
+		break;
+	case 'w':
+		flags = O_WRONLY | O_CREAT | O_TRUNC;
+		if (mode[1] == '+') {
+			flags = O_RDWR | O_CREAT | O_TRUNC;
+		}
+		break;
+	case 'a':
+		flags = O_WRONLY | O_CREAT | O_APPEND;
+		if (mode[1] == '+') {
+			flags = O_RDWR | O_CREAT | O_APPEND;
+		}
+		break;
+	default:
+		errno = EINVAL;
+		return -1;
+	}
+
+	return flags;
+}
+
+FILE *fopen(const char *ZRESTRICT filename, const char *ZRESTRICT mode)
+{
+	int flags = 0;
+	int fd = 0;
+	FILE *stream = NULL;
+
+	if (filename == NULL || mode == NULL) {
+		errno = EINVAL;
+		return NULL;
+	}
+
+	flags = mode2flags(mode);
+	if (flags < 0) {
+		errno = EINVAL;
+		return NULL;
+	}
+
+	fd = open(filename, flags);
+	if (fd < 0) {
+		errno = EIO;
+		return NULL;
+	}
+
+	stream = (FILE *)calloc(1, sizeof(FILE));
+	if (stream != NULL) {
+		stream->_file = fd;
+	} else {
+		close(fd);
+		errno = ENOMEM;
+	}
+
+	return stream;
+}
+
+int fclose(FILE *stream)
+{
+	if (stream == NULL) {
+		errno = EINVAL;
+		return EOF;
+	}
+
+	int fd = stream->_file;
+	int rc = close(fd);
+
+	if (rc < 0) {
+		errno = EIO;
+		return EOF;
+	}
+
+	free((void *)stream);
+
+	return 0;
+}

--- a/lib/libc/picolibc/CMakeLists.txt
+++ b/lib/libc/picolibc/CMakeLists.txt
@@ -11,6 +11,10 @@ zephyr_library_sources(
   stdio.c
   )
 
+zephyr_library_sources_ifdef(CONFIG_POSIX_FILE_SYSTEM
+  file_ops.c
+  )
+
 zephyr_library_compile_options(-fno-lto)
 
 # define __LINUX_ERRNO_EXTENSIONS__ so we get errno defines like -ESHUTDOWN

--- a/lib/libc/picolibc/file_ops.c
+++ b/lib/libc/picolibc/file_ops.c
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2025  Ahmed Adel <a.adel2010@gmail.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <zephyr/posix/fcntl.h>
+#include <errno.h>
+
+static int mode2flags(const char *mode)
+{
+	int flags = 0;
+
+	switch (mode[0]) {
+	case 'r':
+		flags = O_RDONLY;
+		if (mode[1] == '+') {
+			flags = O_RDWR;
+		}
+		break;
+	case 'w':
+		flags = O_WRONLY | O_CREAT | O_TRUNC;
+		if (mode[1] == '+') {
+			flags = O_RDWR | O_CREAT | O_TRUNC;
+		}
+		break;
+	case 'a':
+		flags = O_WRONLY | O_CREAT | O_APPEND;
+		if (mode[1] == '+') {
+			flags = O_RDWR | O_CREAT | O_APPEND;
+		}
+		break;
+	default:
+		errno = EINVAL;
+		return -1;
+	}
+
+	return flags;
+}
+
+FILE *fopen(const char *ZRESTRICT filename, const char *ZRESTRICT mode)
+{
+	int flags = 0;
+	int fd = 0;
+
+	if (filename == NULL || mode == NULL) {
+		errno = EINVAL;
+		return NULL;
+	}
+
+	flags = mode2flags(mode);
+	if (flags < 0) {
+		errno = EINVAL;
+		return NULL;
+	}
+
+	fd = open(filename, flags);
+	if (fd < 0) {
+		errno = EIO;
+		return NULL;
+	}
+
+	/*
+	 * Append the file descriptor to the end of
+	 * the stream structure to be used later in fclose
+	 */
+	FILE *stream = (FILE *)calloc(1, (sizeof(FILE) + sizeof(int)));
+
+	if (stream != NULL) {
+		*(int *)(stream + 1) = fd;
+	} else {
+		close(fd);
+		errno = ENOMEM;
+	}
+
+	return stream;
+}
+
+int fclose(FILE *__stream)
+{
+	if (__stream == NULL) {
+		errno = EINVAL;
+		return EOF;
+	}
+
+	/* Extract the file descriptor from the stream */
+	int fd = *(int *)(__stream + 1);
+	int rc = close(fd);
+
+	if (rc < 0) {
+		errno = EIO;
+		return EOF;
+	}
+
+	free((void *)__stream);
+
+	return 0;
+}


### PR DESCRIPTION
Implementation of fopen and fclose for newlibc, minimal libc
and picolibc. `fopen` calls the POSIX `open` function in
device_io, which in turn calls `zvfs_open`.

This PR should close issue#[66939](https://github.com/zephyrproject-rtos/zephyr/issues/66939) and issue#[66931](https://github.com/zephyrproject-rtos/zephyr/issues/66931)