### PR TITLE
i2c: nrf_twim: Add cast to const buffer pointers

### DIFF
--- a/drivers/i2c/i2c_nrfx_twim_rtio.c
+++ b/drivers/i2c/i2c_nrfx_twim_rtio.c
@@ -74,7 +74,8 @@ static bool i2c_nrfx_twim_rtio_start(const struct device *dev)
 			sqe->tx.buf = config->common.msg_buf;
 		}
 		return i2c_nrfx_twim_rtio_msg_start(dev, I2C_MSG_WRITE | sqe->iodev_flags,
-						    sqe->tx.buf, sqe->tx.buf_len, dt_spec->addr);
+						    (uint8_t *)sqe->tx.buf, sqe->tx.buf_len,
+						    dt_spec->addr);
 	case RTIO_OP_I2C_CONFIGURE:
 		(void)i2c_nrfx_twim_configure(dev, sqe->i2c_config);
 		return false;


### PR DESCRIPTION
A warning was issued in the build as the rtio tx and tiny_tx buffer pointers are now labeled const. The internal API expects mutable buffers so an explicit cast is needed here to avoid the warning.

Same issue as #77943.