### PR TITLE
devicetree: Fix DT_HAS_COMPAT_ON_BUS_STATUS_OKAY documentation

### DIFF
--- a/include/zephyr/devicetree.h
+++ b/include/zephyr/devicetree.h
@@ -4665,7 +4665,7 @@
 #define DT_INST_STRING_UNQUOTED_OR(inst, name, default_value) \
 	DT_STRING_UNQUOTED_OR(DT_DRV_INST(inst), name, default_value)
 
-/*
+/**
  * @brief Test if any enabled node with the given compatible is on
  *        the given bus type
  *


### PR DESCRIPTION
The doxygen comment was malformed.