### PR TITLE
cmake: modules: dts: Remove duplicate zephyr.dts log

### DIFF
--- a/cmake/modules/dts.cmake
+++ b/cmake/modules/dts.cmake
@@ -327,8 +327,7 @@ execute_process(
   COMMAND_ERROR_IS_FATAL ANY
   )
 zephyr_file_copy(${DEVICETREE_GENERATED_H}.new ${DEVICETREE_GENERATED_H} ONLY_IF_DIFFERENT)
-file(REMOVE ${ZEPHYR_DTS}.new ${DEVICETREE_GENERATED_H}.new)
-message(STATUS "Generated zephyr.dts: ${ZEPHYR_DTS}")
+file(REMOVE ${DEVICETREE_GENERATED_H}.new)
 message(STATUS "Generated devicetree_generated.h: ${DEVICETREE_GENERATED_H}")
 
 #


### PR DESCRIPTION
Recently, the "Generated zephyr.dts" message started being shown twice, because of some now redundant code that was left behind by commit fe3287a9ac19bebf851d23ba72d90639c6053e6f.