### PR TITLE
[NXP][MCXW][RW] Fix stack overflow in BLE samples after migration to mbedtls

### DIFF
--- a/soc/nxp/mcx/mcxw/Kconfig.defconfig
+++ b/soc/nxp/mcx/mcxw/Kconfig.defconfig
@@ -14,6 +14,16 @@ config MCUX_FLASH_K4_API
 
 if BT
 
+config MAIN_STACK_SIZE
+	default 2560
+
+if SHELL
+
+config SHELL_STACK_SIZE
+	default 4096
+
+endif # SHELL
+
 # Include intercore messaging component
 config NXP_RF_IMU
 	default y

--- a/soc/nxp/rw/Kconfig.defconfig
+++ b/soc/nxp/rw/Kconfig.defconfig
@@ -26,7 +26,14 @@ config HCI_NXP_SET_CAL_DATA
 	default y
 
 config MAIN_STACK_SIZE
-	default 1280
+	default 2560
+
+if SHELL
+
+config SHELL_STACK_SIZE
+	default 4096
+
+endif # SHELL
 
 endif # BT
 


### PR DESCRIPTION
mbedtls is now used in BLE samples, increasing the stack depth needed of the calling threads. This was causing stack overflows in several BLE samples.
Increasing the main stack size for common samples, but also the shell stack size for samples calling bt API from the shell thread like the bt shell.

Fixes #83551