### PR TITLE
soc: stm32wb0: replace SYS_INIT with early init hook

### DIFF
--- a/soc/st/stm32/stm32wb0x/Kconfig
+++ b/soc/st/stm32/stm32wb0x/Kconfig
@@ -10,6 +10,7 @@ config SOC_SERIES_STM32WB0X
 	select CPU_CORTEX_M_HAS_SYSTICK
 	select CPU_HAS_ARM_MPU
 	select HAS_STM32CUBE
+	select SOC_EARLY_INIT_HOOK
 	# WB0x has a ROM bootloader executed at reset,
 	# which makes the following option required
 	select INIT_ARCH_HW_AT_BOOT

--- a/soc/st/stm32/stm32wb0x/soc.c
+++ b/soc/st/stm32/stm32wb0x/soc.c
@@ -146,12 +146,9 @@ static void configure_smps(void)
 /**
  * @brief Perform basic hardware initialization at boot.
  *
- * This needs to be run from the very beginning,
- * so the init priority has to be 0 (zero).
- *
- * @return 0
+ * This needs to be run from the very beginning.
  */
-static int stm32wb0_init(void)
+void soc_early_init_hook(void)
 {
 	/* Update CMSIS SystemCoreClock variable (CLK_SYS) */
 	/* On reset, the 64MHz HSI is selected as input to
@@ -181,8 +178,4 @@ static int stm32wb0_init(void)
 
 	/* Configure SMPS step-down converter */
 	configure_smps();
-
-	return 0;
 }
-
-SYS_INIT(stm32wb0_init, PRE_KERNEL_1, 0);


### PR DESCRIPTION
STM32WB0 series was missed when SoC initialization code was migrated from SYS_INIT routines to the new soc_early_init_hook method (c.f. commit c6a03606c2dd007e0df3ffac8b6f552ca4624982)

Update that series' initialization code to align it with all others.