### PR TITLE
net: if: Fix net_if_list iteration issue with llvm & ASAN

### DIFF
--- a/include/zephyr/net/net_if.h
+++ b/include/zephyr/net/net_if.h
@@ -3269,7 +3269,7 @@ extern int net_stats_prometheus_scrape(struct prometheus_collector *collector,
 	};								\
 	static Z_DECL_ALIGN(struct net_if)				\
 		       NET_IF_GET_NAME(dev_id, sfx)[_num_configs]	\
-		       __used __in_section(_net_if, static,		\
+		       __used __noasan __in_section(_net_if, static,	\
 					   dev_id) = {			\
 		[0 ... (_num_configs - 1)] = {				\
 			.if_dev = &(NET_IF_DEV_GET_NAME(dev_id, sfx)),	\


### PR DESCRIPTION
The address sanitizer in llvm adds padding (redzones) after data. But for those structures we are re-grouping using the linker script and for which we iterate over we cannot have that extra padding.

Fixes #83863