### PR TITLE
drivers: ieee802154: nrf5: cast payload ptr to void for debug output

### DIFF
--- a/drivers/ieee802154/ieee802154_nrf5.c
+++ b/drivers/ieee802154/ieee802154_nrf5.c
@@ -585,7 +585,7 @@ static int nrf5_tx(const struct device *dev,
 		return -EMSGSIZE;
 	}
 
-	LOG_DBG("%p (%u)", payload, payload_len);
+	LOG_DBG("%p (%u)", (void *)payload, payload_len);
 
 	nrf5_radio->tx_psdu[0] = payload_len + IEEE802154_FCS_LENGTH;
 	memcpy(nrf5_radio->tx_psdu + 1, payload, payload_len);


### PR DESCRIPTION
Without this fix I get an MPU fault in `samples/net/openthread/shell/` with `CONFIG_IEEE802154_DRIVER_LOG_LEVEL_DBG=y`.

Related commit: a7224830ce865fd1ec6183093acf8d44a5659391

See also:

https://github.com/zephyrproject-rtos/zephyr/blob/0728f5d0e27ed1d1274f1c82b2bdc0ffd31d2aee/lib/os/cbprintf_packaged.c#L1007-L1010