### PR TITLE
tests: bluetooth: Add missing mocks after fix on host

### DIFF
--- a/tests/bluetooth/host/conn/mocks/kernel.c
+++ b/tests/bluetooth/host/conn/mocks/kernel.c
@@ -29,5 +29,7 @@ DEFINE_FAKE_VALUE_FUNC(void *, k_queue_get, struct k_queue *, k_timeout_t);
 DEFINE_FAKE_VOID_FUNC(k_queue_prepend, struct k_queue *, void *);
 DEFINE_FAKE_VALUE_FUNC(void *, k_heap_alloc, struct k_heap *, size_t, k_timeout_t);
 DEFINE_FAKE_VOID_FUNC(k_heap_free, struct k_heap *, void *);
+DEFINE_FAKE_VOID_FUNC(k_sched_lock);
+DEFINE_FAKE_VOID_FUNC(k_sched_unlock);
 
 struct k_work_q k_sys_work_q;

--- a/tests/bluetooth/host/conn/mocks/kernel.h
+++ b/tests/bluetooth/host/conn/mocks/kernel.h
@@ -29,7 +29,9 @@
 	FAKE(k_queue_get)                                                                          \
 	FAKE(k_queue_prepend)                                                                      \
 	FAKE(k_heap_alloc)                                                                         \
-	FAKE(k_heap_free)
+	FAKE(k_heap_free)                                                                          \
+	FAKE(k_sched_lock)                                                                         \
+	FAKE(k_sched_unlock)                                                                       \
 
 DECLARE_FAKE_VALUE_FUNC(bool, k_is_in_isr);
 DECLARE_FAKE_VALUE_FUNC(int, k_poll_signal_raise, struct k_poll_signal *, int);
@@ -52,3 +54,5 @@ DECLARE_FAKE_VALUE_FUNC(void *, k_queue_get, struct k_queue *, k_timeout_t);
 DECLARE_FAKE_VOID_FUNC(k_queue_prepend, struct k_queue *, void *);
 DECLARE_FAKE_VALUE_FUNC(void *, k_heap_alloc, struct k_heap *, size_t, k_timeout_t);
 DECLARE_FAKE_VOID_FUNC(k_heap_free, struct k_heap *, void *);
+DECLARE_FAKE_VOID_FUNC(k_sched_lock);
+DECLARE_FAKE_VOID_FUNC(k_sched_unlock);


### PR DESCRIPTION
Added two mocks that were missing in kernel mocks
