### PR TITLE
drivers: udc_dwc2: Fix large control write transfers

### DIFF
--- a/drivers/usb/udc/udc_dwc2.c
+++ b/drivers/usb/udc/udc_dwc2.c
@@ -1577,6 +1577,9 @@ static int udc_dwc2_ep_set_halt(const struct device *dev,
 	LOG_DBG("Set halt ep 0x%02x", cfg->addr);
 	if (ep_idx != 0) {
 		cfg->stat.halted = true;
+	} else if (!udc_buf_peek(dev, USB_CONTROL_EP_OUT)) {
+		/* Data stage is STALLed, allow receiving next SETUP */
+		dwc2_ctrl_feed_dout(dev, 8);
 	}
 
 	return 0;


### PR DESCRIPTION
The DOEPTSIZ0 XferSize field is 7 bits long, meaning that maximum single transfer can be 127 bytes long. Configure the control write (OUT) transfers considering the XferSize field size to support transfers with data stage larger than 127 bytes.