### PR TITLE
STM32 uart circular dma sample :   update the CI filter selection

### DIFF
--- a/samples/boards/st/uart/circular_dma/sample.yaml
+++ b/samples/boards/st/uart/circular_dma/sample.yaml
@@ -7,5 +7,5 @@ tests:
     tags:
       - serial
       - uart
-    filter: dt_chosen_enabled("zephyr,shell-uart")
+    filter: dt_chosen_enabled("zephyr,shell-uart") and CONFIG_SOC_FAMILY_STM32
     harness: keyboard


### PR DESCRIPTION
The  sample is designed specifically for the STM32 family. 

Update sample.yaml to skip CI tests on other vendors' platforms.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/83873 