### PR TITLE
samples: boards: st: remove nxp vender from ci test

### DIFF
--- a/samples/boards/st/uart/circular_dma/sample.yaml
+++ b/samples/boards/st/uart/circular_dma/sample.yaml
@@ -2,6 +2,8 @@ sample:
   name: UART driver sample
 tests:
   sample.boards.stm32.uart.circular_dma:
+    vendor_exclude:
+      - nxp
     integration_platforms:
       - nucleo_g071rb
     tags:


### PR DESCRIPTION
The sample is designed to test STM UART
No need for nxp boards to be tested.
Fixes #83918 