### PR TITLE
Re-enable `-Wsometimes-uninitialized` for clang

### DIFF
--- a/cmake/compiler/clang/compiler_flags.cmake
+++ b/cmake/compiler/clang/compiler_flags.cmake
@@ -101,7 +101,6 @@ check_set_compiler_property(APPEND PROPERTY warning_dw_3
 
 check_set_compiler_property(PROPERTY warning_extended
                             #FIXME: need to fix all of those
-                            -Wno-sometimes-uninitialized
                             -Wno-self-assign
                             -Wno-address-of-packed-member
                             -Wno-unused-function

--- a/tests/lib/cmsis_dsp/distance/src/f32.c
+++ b/tests/lib/cmsis_dsp/distance/src/f32.c
@@ -54,7 +54,7 @@ static void test_arm_distance_f32(int op, bool scratchy, const uint16_t *dims,
 
 	/* Enumerate input */
 	for (index = 0; index < length; index++) {
-		float32_t val;
+		float32_t val = 0.0f;
 
 		/* Load input values into the scratch buffers */
 		if (scratchy) {


### PR DESCRIPTION
All warnings in the code base have been resolved.