### PR TITLE
bluetooth: mesh: Remove assertion for Received List message PDU size

### DIFF
--- a/subsys/bluetooth/mesh/dfd_srv.c
+++ b/subsys/bluetooth/mesh/dfd_srv.c
@@ -35,12 +35,8 @@ BUILD_ASSERT((DFD_UPLOAD_START_MSG_MAXLEN + BT_MESH_MODEL_OP_LEN(BT_MESH_DFD_OP_
 	     "The Firmware Distribution Upload Start message does not fit into the maximum "
 	     "incoming SDU size.");
 
-#define DFD_RECEIVERS_LIST_MSG_MAXLEN (4 + CONFIG_BT_MESH_DFD_SRV_TARGETS_MAX * 5)
-
-BUILD_ASSERT((DFD_RECEIVERS_LIST_MSG_MAXLEN + BT_MESH_MODEL_OP_LEN(BT_MESH_DFD_OP_RECEIVERS_LIST) +
-	      BT_MESH_MIC_SHORT) <= BT_MESH_TX_SDU_MAX,
-	     "The Firmware Distribution Receivers List message does not fit into the maximum "
-	     "outgoing SDU size.");
+#define DFD_RECEIVERS_LIST_MSG_MAXLEN (BT_MESH_TX_SDU_MAX - BT_MESH_MIC_SHORT - \
+				       BT_MESH_MODEL_OP_LEN(BT_MESH_DFD_OP_RECEIVERS_LIST))
 
 #define DFD_RECEIVERS_ADD_MSG_MAXLEN (CONFIG_BT_MESH_DFD_SRV_TARGETS_MAX * 3)
 


### PR DESCRIPTION
According to MshDFUv1.0, section 6.2.3.5, the Firmware Distribution Receivers List message is not limited by the size of the receivers list:

```
The number of selected entries shall be limited by the following:
- The number of entries shall not exceed the value of the Entries Limit field from the Firmware Distribution Receivers Get message.
- The number of entries shall not cause the message payload to exceed the maximum Access PDU size.
```

Thus, this assertion is incorrect as it doesn't allow to have the receivers list bigger than number of maximal Access PDU size.