### PR TITLE
Re-enable `-Waddress-of-packed-member` for clang

### DIFF
--- a/cmake/compiler/clang/compiler_flags.cmake
+++ b/cmake/compiler/clang/compiler_flags.cmake
@@ -103,7 +103,6 @@ check_set_compiler_property(PROPERTY warning_extended
                             #FIXME: need to fix all of those
                             -Wno-sometimes-uninitialized
                             -Wno-self-assign
-                            -Wno-address-of-packed-member
                             -Wno-unused-function
                             -Wno-initializer-overrides
                             -Wno-section

--- a/subsys/net/l2/ieee802154/ieee802154.c
+++ b/subsys/net/l2/ieee802154/ieee802154.c
@@ -256,13 +256,15 @@ static inline void swap_and_set_pkt_ll_addr(struct net_linkaddr *addr, bool has_
 	switch (mode) {
 	case IEEE802154_ADDR_MODE_EXTENDED:
 		addr->len = IEEE802154_EXT_ADDR_LENGTH;
-		addr->addr = has_pan_id ? ll->plain.addr.ext_addr : ll->comp.addr.ext_addr;
+		BUILD_ASSERT(offsetof(struct ieee802154_address, ext_addr) == 0);
+		addr->addr = (uint8_t*)(has_pan_id ? &ll->plain.addr : &ll->comp.addr);
 		break;
 
 	case IEEE802154_ADDR_MODE_SHORT:
 		addr->len = IEEE802154_SHORT_ADDR_LENGTH;
-		addr->addr = (uint8_t *)(has_pan_id ? &ll->plain.addr.short_addr
-						    : &ll->comp.addr.short_addr);
+		BUILD_ASSERT(offsetof(struct ieee802154_address, short_addr) == 0);
+		addr->addr = (uint8_t *)(has_pan_id ? &ll->plain.addr
+						    : &ll->comp.addr);
 		break;
 
 	case IEEE802154_ADDR_MODE_NONE:

--- a/subsys/net/lib/http/http_server_http2.c
+++ b/subsys/net/lib/http/http_server_http2.c
@@ -259,15 +259,13 @@ int send_settings_frame(struct http_client_ctx *client, bool ack)
 
 		setting = (struct http2_settings_field *)
 			(settings_frame + HTTP2_FRAME_HEADER_SIZE);
-		UNALIGNED_PUT(htons(HTTP2_SETTINGS_HEADER_TABLE_SIZE),
-			      &setting->id);
-		UNALIGNED_PUT(0, &setting->value);
+		setting->id = htons(HTTP2_SETTINGS_HEADER_TABLE_SIZE);
+		setting->value = 0;
 
 		setting++;
-		UNALIGNED_PUT(htons(HTTP2_SETTINGS_MAX_CONCURRENT_STREAMS),
-			      &setting->id);
-		UNALIGNED_PUT(htonl(CONFIG_HTTP_SERVER_MAX_STREAMS),
-			      &setting->value);
+		setting->id = htons(HTTP2_SETTINGS_MAX_CONCURRENT_STREAMS);
+		setting->value = htonl(CONFIG_HTTP_SERVER_MAX_STREAMS);
+
 
 		len = HTTP2_FRAME_HEADER_SIZE +
 		      2 * sizeof(struct http2_settings_field);


### PR DESCRIPTION
All warnings in the code base have been resolved.