### PR TITLE
Re-enable `-Winitializer-overrides` for clang

### DIFF
--- a/cmake/compiler/clang/compiler_flags.cmake
+++ b/cmake/compiler/clang/compiler_flags.cmake
@@ -105,7 +105,6 @@ check_set_compiler_property(PROPERTY warning_extended
                             -Wno-self-assign
                             -Wno-address-of-packed-member
                             -Wno-unused-function
-                            -Wno-initializer-overrides
                             -Wno-section
                             -Wno-unused-variable
                             -Wno-gnu


### PR DESCRIPTION
All warnings in the code base have been resolved.