### PR TITLE
Re-enable `-Wunknown-warning-option` for clang

### DIFF
--- a/cmake/compiler/clang/compiler_flags.cmake
+++ b/cmake/compiler/clang/compiler_flags.cmake
@@ -109,7 +109,6 @@ check_set_compiler_property(PROPERTY warning_extended
                             -Wno-unused-function
                             -Wno-initializer-overrides
                             -Wno-section
-                            -Wno-unknown-warning-option
                             -Wno-unused-variable
                             -Wno-format-invalid-specifier
                             -Wno-gnu


### PR DESCRIPTION
All warnings in the code base have been resolved.