### PR TITLE
kernel: Introduce z_reschedule_locked() for side effects decisions

### DIFF
--- a/kernel/condvar.c
+++ b/kernel/condvar.c
@@ -93,7 +93,12 @@ int z_impl_k_condvar_broadcast(struct k_condvar *condvar)
 
 	SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_condvar, broadcast, condvar, woken);
 
-	z_reschedule(&lock, key);
+
+	if (woken == 0) {
+		k_spin_unlock(&lock, key);
+	} else {
+		z_reschedule(&lock, key);
+	}
 
 	return woken;
 }

--- a/kernel/futex.c
+++ b/kernel/futex.c
@@ -47,7 +47,11 @@ int z_impl_k_futex_wake(struct k_futex *futex, bool wake_all)
 		}
 	} while (thread && wake_all);
 
-	z_reschedule(&futex_data->lock, key);
+	if (woken == 0) {
+		k_spin_unlock(&futex_data->lock, key);
+	} else {
+		z_reschedule(&futex_data->lock, key);
+	}
 
 	return woken;
 }

--- a/kernel/include/kernel_internal.h
+++ b/kernel/include/kernel_internal.h
@@ -221,7 +221,7 @@ void z_mem_manage_init(void);
 void z_mem_manage_boot_finish(void);
 
 
-void z_handle_obj_poll_events(sys_dlist_t *events, uint32_t state);
+bool z_handle_obj_poll_events(sys_dlist_t *events, uint32_t state);
 
 #ifdef CONFIG_PM
 

--- a/kernel/msg_q.c
+++ b/kernel/msg_q.c
@@ -132,6 +132,7 @@ int z_impl_k_msgq_put(struct k_msgq *msgq, const void *data, k_timeout_t timeout
 	struct k_thread *pending_thread;
 	k_spinlock_key_t key;
 	int result;
+	bool resched = false;
 
 	key = k_spin_lock(&msgq->lock);
 
@@ -141,16 +142,13 @@ int z_impl_k_msgq_put(struct k_msgq *msgq, const void *data, k_timeout_t timeout
 		/* message queue isn't full */
 		pending_thread = z_unpend_first_thread(&msgq->wait_q);
 		if (unlikely(pending_thread != NULL)) {
-			SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_msgq, put, msgq, timeout, 0);
+			resched = true;
 
 			/* give message to waiting thread */
-			(void)memcpy(pending_thread->base.swap_data, data,
-			       msgq->msg_size);
+			(void)memcpy(pending_thread->base.swap_data, data, msgq->msg_size);
 			/* wake up waiting thread */
 			arch_thread_return_value_set(pending_thread, 0);
 			z_ready_thread(pending_thread);
-			z_reschedule(&msgq->lock, key);
-			return 0;
 		} else {
 			/* put message in queue */
 			__ASSERT_NO_MSG(msgq->write_ptr >= msgq->buffer_start &&
@@ -161,7 +159,7 @@ int z_impl_k_msgq_put(struct k_msgq *msgq, const void *data, k_timeout_t timeout
 				msgq->write_ptr = msgq->buffer_start;
 			}
 			msgq->used_msgs++;
-			(void)handle_poll_events(msgq);
+			resched = handle_poll_events(msgq);
 		}
 		result = 0;
 	} else if (K_TIMEOUT_EQ(timeout, K_NO_WAIT)) {
@@ -180,7 +178,11 @@ int z_impl_k_msgq_put(struct k_msgq *msgq, const void *data, k_timeout_t timeout
 
 	SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_msgq, put, msgq, timeout, result);
 
-	z_reschedule(&msgq->lock, key);
+	if (resched) {
+		z_reschedule(&msgq->lock, key);
+	} else {
+		k_spin_unlock(&msgq->lock, key);
+	}
 
 	return result;
 }
@@ -222,6 +224,7 @@ int z_impl_k_msgq_get(struct k_msgq *msgq, void *data, k_timeout_t timeout)
 	k_spinlock_key_t key;
 	struct k_thread *pending_thread;
 	int result;
+	bool resched = false;
 
 	key = k_spin_lock(&msgq->lock);
 
@@ -255,11 +258,7 @@ int z_impl_k_msgq_get(struct k_msgq *msgq, void *data, k_timeout_t timeout)
 			/* wake up waiting thread */
 			arch_thread_return_value_set(pending_thread, 0);
 			z_ready_thread(pending_thread);
-			z_reschedule(&msgq->lock, key);
-
-			SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_msgq, get, msgq, timeout, 0);
-
-			return 0;
+			resched = true;
 		}
 		result = 0;
 	} else if (K_TIMEOUT_EQ(timeout, K_NO_WAIT)) {
@@ -278,7 +277,11 @@ int z_impl_k_msgq_get(struct k_msgq *msgq, void *data, k_timeout_t timeout)
 
 	SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_msgq, get, msgq, timeout, result);
 
-	k_spin_unlock(&msgq->lock, key);
+	if (resched) {
+		z_reschedule(&msgq->lock, key);
+	} else {
+		k_spin_unlock(&msgq->lock, key);
+	}
 
 	return result;
 }
@@ -379,22 +382,29 @@ void z_impl_k_msgq_purge(struct k_msgq *msgq)
 {
 	k_spinlock_key_t key;
 	struct k_thread *pending_thread;
+	bool resched = false;
 
 	key = k_spin_lock(&msgq->lock);
 
 	SYS_PORT_TRACING_OBJ_FUNC(k_msgq, purge, msgq);
 
 	/* wake up any threads that are waiting to write */
-	for (pending_thread = z_unpend_first_thread(&msgq->wait_q); pending_thread != NULL;
-		 pending_thread = z_unpend_first_thread(&msgq->wait_q)) {
+	for (pending_thread = z_unpend_first_thread(&msgq->wait_q);
+	     pending_thread != NULL;
+	     pending_thread = z_unpend_first_thread(&msgq->wait_q)) {
 		arch_thread_return_value_set(pending_thread, -ENOMSG);
 		z_ready_thread(pending_thread);
+		resched = true;
 	}
 
 	msgq->used_msgs = 0;
 	msgq->read_ptr = msgq->write_ptr;
 
-	z_reschedule(&msgq->lock, key);
+	if (resched) {
+		z_reschedule(&msgq->lock, key);
+	} else {
+		k_spin_unlock(&msgq->lock, key);
+	}
 }
 
 #ifdef CONFIG_USERSPACE

--- a/kernel/msg_q.c
+++ b/kernel/msg_q.c
@@ -29,12 +29,16 @@
 static struct k_obj_type obj_type_msgq;
 #endif /* CONFIG_OBJ_CORE_MSGQ */
 
-#ifdef CONFIG_POLL
-static inline void handle_poll_events(struct k_msgq *msgq, uint32_t state)
+static inline bool handle_poll_events(struct k_msgq *msgq)
 {
-	z_handle_obj_poll_events(&msgq->poll_events, state);
-}
+#ifdef CONFIG_POLL
+	return z_handle_obj_poll_events(&msgq->poll_events,
+					K_POLL_STATE_MSGQ_DATA_AVAILABLE);
+#else
+	ARG_UNUSED(msgq);
+	return false;
 #endif /* CONFIG_POLL */
+}
 
 void k_msgq_init(struct k_msgq *msgq, char *buffer, size_t msg_size,
 		 uint32_t max_msgs)
@@ -157,9 +161,7 @@ int z_impl_k_msgq_put(struct k_msgq *msgq, const void *data, k_timeout_t timeout
 				msgq->write_ptr = msgq->buffer_start;
 			}
 			msgq->used_msgs++;
-#ifdef CONFIG_POLL
-			handle_poll_events(msgq, K_POLL_STATE_MSGQ_DATA_AVAILABLE);
-#endif /* CONFIG_POLL */
+			(void)handle_poll_events(msgq);
 		}
 		result = 0;
 	} else if (K_TIMEOUT_EQ(timeout, K_NO_WAIT)) {

--- a/kernel/poll.c
+++ b/kernel/poll.c
@@ -454,7 +454,7 @@ static int signal_poll_event(struct k_poll_event *event, uint32_t state)
 	return retcode;
 }
 
-void z_handle_obj_poll_events(sys_dlist_t *events, uint32_t state)
+bool z_handle_obj_poll_events(sys_dlist_t *events, uint32_t state)
 {
 	struct k_poll_event *poll_event;
 	k_spinlock_key_t key = k_spin_lock(&lock);
@@ -465,6 +465,8 @@ void z_handle_obj_poll_events(sys_dlist_t *events, uint32_t state)
 	}
 
 	k_spin_unlock(&lock, key);
+
+	return (poll_event != NULL);
 }
 
 void z_impl_k_poll_signal_init(struct k_poll_signal *sig)

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -1164,21 +1164,13 @@ void z_impl_k_wakeup(k_tid_t thread)
 
 	k_spinlock_key_t  key = k_spin_lock(&_sched_spinlock);
 
-	z_abort_thread_timeout(thread);
-
-	if (!z_is_thread_sleeping(thread)) {
-		k_spin_unlock(&_sched_spinlock, key);
-		return;
-	}
-
-	z_mark_thread_as_not_sleeping(thread);
-
-	ready_thread(thread);
-
-	if (arch_is_in_isr()) {
-		k_spin_unlock(&_sched_spinlock, key);
-	} else {
+	if (z_is_thread_sleeping(thread)) {
+		z_abort_thread_timeout(thread);
+		z_mark_thread_as_not_sleeping(thread);
+		ready_thread(thread);
 		z_reschedule(&_sched_spinlock, key);
+	} else {
+		k_spin_unlock(&_sched_spinlock, key);
 	}
 }
 

--- a/kernel/sem.c
+++ b/kernel/sem.c
@@ -96,7 +96,7 @@ void z_impl_k_sem_give(struct k_sem *sem)
 {
 	k_spinlock_key_t key = k_spin_lock(&lock);
 	struct k_thread *thread;
-	bool resched = true;
+	bool resched;
 
 	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_sem, give, sem);
 
@@ -105,6 +105,7 @@ void z_impl_k_sem_give(struct k_sem *sem)
 	if (unlikely(thread != NULL)) {
 		arch_thread_return_value_set(thread, 0);
 		z_ready_thread(thread);
+		resched = true;
 	} else {
 		sem->count += (sem->count != sem->limit) ? 1U : 0U;
 		resched = handle_poll_events(sem);
@@ -166,12 +167,14 @@ void z_impl_k_sem_reset(struct k_sem *sem)
 {
 	struct k_thread *thread;
 	k_spinlock_key_t key = k_spin_lock(&lock);
+	bool resched = false;
 
 	while (true) {
 		thread = z_unpend_first_thread(&sem->wait_q);
 		if (thread == NULL) {
 			break;
 		}
+		resched = true;
 		arch_thread_return_value_set(thread, -EAGAIN);
 		z_ready_thread(thread);
 	}
@@ -179,9 +182,13 @@ void z_impl_k_sem_reset(struct k_sem *sem)
 
 	SYS_PORT_TRACING_OBJ_FUNC(k_sem, reset, sem);
 
-	(void)handle_poll_events(sem);
+	resched = handle_poll_events(sem) || resched;
 
-	z_reschedule(&lock, key);
+	if (resched) {
+		z_reschedule(&lock, key);
+	} else {
+		k_spin_unlock(&lock, key);
+	}
 }
 
 #ifdef CONFIG_USERSPACE

--- a/kernel/sem.c
+++ b/kernel/sem.c
@@ -85,8 +85,7 @@ int z_vrfy_k_sem_init(struct k_sem *sem, unsigned int initial_count,
 static inline bool handle_poll_events(struct k_sem *sem)
 {
 #ifdef CONFIG_POLL
-	z_handle_obj_poll_events(&sem->poll_events, K_POLL_STATE_SEM_AVAILABLE);
-	return true;
+	return z_handle_obj_poll_events(&sem->poll_events, K_POLL_STATE_SEM_AVAILABLE);
 #else
 	ARG_UNUSED(sem);
 	return false;
@@ -180,7 +179,7 @@ void z_impl_k_sem_reset(struct k_sem *sem)
 
 	SYS_PORT_TRACING_OBJ_FUNC(k_sem, reset, sem);
 
-	handle_poll_events(sem);
+	(void)handle_poll_events(sem);
 
 	z_reschedule(&lock, key);
 }


### PR DESCRIPTION
In many places throughout the kernel we have the following pattern ...

if (nothing happened) {
   k_spin_unlock();
   return;
} else {
    return z_reschedule();
}

This series of commits aims to replace this pattern with ...
    z_reschedule_locked(spinlock, key, side_effect);
where a side effect is short hand for" something happened and we need a schedule point". In practice, this "something" is typically "a thread was unpended" or "a polling event happened" or "the user says we need a schedule point". The intent is to move the decision making criteria for how to handle a schedule into code that is more scheduler oriented. For example, semaphore code should not be deciding what to do at the schedule point; it should pass the information along that "something of consequence happened", or "nothing of consequence happened" to the schedule point decision making apparatus and let that decide what to do.

(Aside: I'm sure that some of these of commits can be squashed together, but at this point in time I figured that it is easier to squash them later than to separate them later.)