### PR TITLE
Bluetooth: Mesh: Fix Assert in bt_mesh_adv_unref when messages to a proxy

### DIFF
--- a/subsys/bluetooth/mesh/adv.h
+++ b/subsys/bluetooth/mesh/adv.h
@@ -58,7 +58,11 @@ struct bt_mesh_adv_ctx {
 };
 
 struct bt_mesh_adv {
-	sys_snode_t node;
+	void *adv_bearer;
+
+#if defined(CONFIG_BT_MESH_GATT)
+	void *gatt_bearer[CONFIG_BT_MAX_CONN];
+#endif
 
 	struct bt_mesh_adv_ctx ctx;
 


### PR DESCRIPTION
Fixes:https://github.com/zephyrproject-rtos/zephyr/issues/83904

This solution fix is to define a separate variable for the each proxy FIFO.