### PR TITLE
Fix overflow and ensure null termination in u8_to_dec

### DIFF
--- a/lib/utils/dec.c
+++ b/lib/utils/dec.c
@@ -11,6 +11,10 @@ uint8_t u8_to_dec(char *buf, uint8_t buflen, uint8_t value)
 	uint8_t divisor = 100;
 	uint8_t num_digits = 0;
 	uint8_t digit;
+	
+	if (buf == NULL || buflen < 4) {
+        	return 0;
+    	}
 
 	while ((buflen > 0) && (divisor > 0)) {
 		digit = value / divisor;


### PR DESCRIPTION
### Description

The `u8_to_dec` function, which converts an 8-bit unsigned integer (`uint8_t`) to its decimal string representation, currently has no safeguards for scenarios where the provided buffer (`buf`) is too small. This can lead to issues in the worst-case scenario, including:

If `buflen` is insufficient (less than `4` bytes for the maximum value of `255`), the function writes beyond the bounds of the buffer, resulting in corruption of adjacent memory.

### Fix

The fix ensures that `u8_to_dec` now checks the `buflen` to be more than 4 bytes and ensures buffer is not `NULL`.
