### PR TITLE
soc: nordic: common: vpr: Remove tp register

### DIFF
--- a/soc/nordic/common/vpr/soc_context.h
+++ b/soc/nordic/common/vpr/soc_context.h
@@ -8,14 +8,9 @@
 
 #define SOC_ESF_MEMBERS						\
 	unsigned long minttresh;				\
-	unsigned long sp_align;					\
-	unsigned long padding0;					\
-	unsigned long padding1;					\
-	unsigned long padding2
+	unsigned long sp_align;
 
 #define SOC_ESF_INIT						\
-	0,							\
-	0,							\
 	0,							\
 	0
 

--- a/soc/nordic/common/vpr/soc_isr_stacking.h
+++ b/soc/nordic/common/vpr/soc_isr_stacking.h
@@ -20,7 +20,6 @@
 	struct arch_esf {                                                                          \
 		unsigned long s0;                                                                  \
 		unsigned long mstatus;                                                             \
-		unsigned long tp;                                                                  \
 		struct soc_esf soc_context;                                                        \
                                                                                                    \
 		unsigned long t2;                                                                  \
@@ -43,7 +42,6 @@
 	struct arch_esf {                                                                          \
 		unsigned long s0;                                                                  \
 		unsigned long mstatus;                                                             \
-		unsigned long tp;                                                                  \
 		struct soc_esf soc_context;                                                        \
                                                                                                    \
 		unsigned long ra;                                                                  \
@@ -79,7 +77,7 @@
  * Size of the SW managed part of the ESF in case of interrupt
  *   sizeof(__padding) + ... + sizeof(soc_context)
  */
-#define ESF_SW_IRQ_SIZEOF (0x20)
+#define ESF_SW_IRQ_SIZEOF (0x10)
 
 /*
  * VPR needs aligned(8) SP when doing HW stacking, if this condition is not fulfilled it will move


### PR DESCRIPTION
The tp register has been remove from the common RISC-V stack frame so remove it from the VPR specific variant declared via SOC_ISR_STACKING_ESF_DECLARE. This saves 4 bytes and allows removing a lot of padding to get the 16B aligned size.


The tp register handling was removed here
https://github.com/zephyrproject-rtos/zephyr/commit/3f8e326d1a63af7eb294c59078a80a3da7f71dfc