### PR TITLE
boards: mimxrt1180_evk: set LinkServer as the default runner

### DIFF
--- a/boards/nxp/mimxrt1180_evk/board.cmake
+++ b/boards/nxp/mimxrt1180_evk/board.cmake
@@ -19,5 +19,5 @@ board_runner_args(linkserver "--core=cm7")
 board_runner_args(jlink "--device=MIMXRT1189xxx8_M7" "--speed=4000" "--no-reset" "--tool-opt=-jlinkscriptfile ${RT1180_BOARD_DIR}/jlinkscript/evkmimxrt1180_cm7.jlinkscript" "--tool-opt=-ir")
 endif()
 
-include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/linkserver.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/nxp/mimxrt1180_evk/doc/index.rst
+++ b/boards/nxp/mimxrt1180_evk/doc/index.rst
@@ -183,18 +183,19 @@ Build and flash applications as usual (see :ref:`build_an_application` and
 Configuring a Debug Probe
 =========================
 
+LinkServer is the default runner for this board.
 A debug probe is used for both flashing and debugging the board. This board is
-configured by default to use the :ref:`mcu-link-cmsis-onboard-debug-probe`,
-however the :ref:`pyocd-debug-host-tools` do not yet support programming the
-external flashes on this board so you must reconfigure the board for one of the
-following debug probes instead.
+configured by default to use the :ref:`mcu-link-cmsis-onboard-debug-probe`.
+The :ref:`pyocd-debug-host-tools` do not yet support programming the
+external flashes on this board. Use one of the other supported debug probes
+below.
 
 .. _Using J-Link RT1180:
 
 Using J-Link
 ------------
 
-Please ensure used JLINK above V7.94g and jumper JP5 installed if using
+Please ensure to use a version of JLINK above V7.94g and jumper JP5 is installed if using
 external jlink plus on J37 as debugger.
 
 When debugging cm33 core, need to ensure the SW5 on "0100" mode.
@@ -212,7 +213,7 @@ EVK.
 Using Linkserver
 ----------------
 
-Please ensure used linkserver above V1.5.30 and jumper JP5 uninstalled.
+Please ensure to use a version of Linkserver above V1.5.30 and jumper JP5 is uninstalled (default setting).
 
 When debugging cm33 core, need to ensure the SW5 on "0100" mode.
 When debugging cm7 core, need to ensure the SW5 on "0001" mode.


### PR DESCRIPTION
Sets LinkServer as the default runner for the mimxrt1180-evk board, as the board is configured for CMSIS-DAP by default.