### PR TITLE
dts: mfd: it8801: Require irq-gpios to prevent driver crashes

### DIFF
--- a/dts/bindings/mfd/ite,it8801-mfd.yaml
+++ b/dts/bindings/mfd/ite,it8801-mfd.yaml
@@ -51,6 +51,7 @@ properties:
 
   irq-gpios:
     type: phandle-array
+    required: true
     description: |
       An interrupt can be asserted on SMB_INT# pin to notify
       the host-side since an effective interrupt occurs.


### PR DESCRIPTION
Marked the irq-gpios property as "required: true" in the yaml file. This ensures that the property is always defined in the device tree, preventing the driver from crashing when irq-gpios is missing.