### PR TITLE
docs: samples: subsys: lorawan: class_a: clarify LoRaWAN example README limitations and guidance

### DIFF
--- a/samples/subsys/lorawan/class_a/README.rst
+++ b/samples/subsys/lorawan/class_a/README.rst
@@ -25,3 +25,16 @@ The following commands build and flash the sample.
    :board: nucleo_wl55jc
    :goals: build flash
    :compact:
+
+Important Notes for Multiple Runs
+*********************************
+
+By default, this example will only succeed the first time it is run. On subsequent join attempts, the LoRaWAN network server may reject the join request due to a hardcoded ``dev_nonce`` value. According to the LoRaWAN specification, ``dev_nonce`` must increment for every new connection attempt.
+
+To run this sample multiple times, choose one of the following options:
+
+1. **Manually Increment ``dev_nonce``:**
+   Modify the sample code to increment ``join_cfg.otaa.dev_nonce`` before each connection attempt and ensure it is preserved across reboots.
+
+2. **Built-in Zephyr Settings Implementation:**
+   Enable :kconfig:option:`CONFIG_LORAWAN_NVM_SETTINGS` in the Kconfig. This allows proper storage and reuse of configuration settings, including the ``dev_nonce``, across multiple runs.


### PR DESCRIPTION
### Summary
This pull request updates the README for the LoRaWAN Class A example to clarify limitations for multiple runs and provide guidance for resolving the issue. It addresses the problem of a hardcoded `dev_nonce` causing join failures.

### Changes Made
- Added a new "Important Notes for Multiple Runs" section in the README.
- Explained the limitation with the `dev_nonce`.
- Provided solutions, including enabling `CONFIG_LORAWAN_NVM_SETTINGS` or programmatically setting a random `dev_nonce`.

Fixes #83920
