### PR TITLE
doc: _extensions: fix :zephyr:board: role with Intersphinx

### DIFF
--- a/doc/_extensions/zephyr/domain/__init__.py
+++ b/doc/_extensions/zephyr/domain/__init__.py
@@ -836,7 +836,7 @@ class ZephyrDomain(Domain):
         else:
             return
 
-        if elem:
+        if elem and "docname" in elem:
             if not node.get("refexplicit"):
                 contnode = [nodes.Text(elem["name"] if type != "board" else elem["full_name"])]
 


### PR DESCRIPTION
Resolving the target for a zephyr:board role when using Interpshinx needs to account for the fact that a board object might be in the domain (it's part of the catalog), and yet not have any actual docname associated with it for there's no page in the "local" docs that defines a ..zephyr:board:: documentation for it. Handle that case so that ZephyrDomain#resolve_xref yields to Intersphinx that will eventually find the target in the inventory for docs.zephyrproject.org.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/83737