### PR TITLE
scripts: west_commands: patch: add src module argument

### DIFF
--- a/scripts/schemas/patch-schema.yml
+++ b/scripts/schemas/patch-schema.yml
@@ -11,7 +11,7 @@ schema;patch-schema:
     - type: map
       mapping:
 
-        # The path to the patch file, relative to the root of the module
+        # The path to the patch file, relative to patch-base
         # E.g. zephyr/kernel-pipe-fix-not-k-no-wait-and-ge-min-xfer-bytes.patch
         path:
           required: true


### PR DESCRIPTION
This patch adds the `--src-module` argument to west patch to be able to select the module where west patch looks for the patch definition without having to set `--patch-yml` and `--patch-base`. For clarification the present `--module` argument is renamed to `--dest-module`.

This patch also changes `--dest-module` and `module:` in `patches.yml` to take the name of the module instead of the path.