### PR TITLE
Fix/modbus

### DIFF
--- a/subsys/modbus/modbus_serial.c
+++ b/subsys/modbus/modbus_serial.c
@@ -560,6 +560,7 @@ int modbus_serial_init(struct modbus_context *ctx,
 	struct modbus_serial_config *cfg = ctx->cfg;
 	const uint32_t if_delay_max = 3500000;
 	const uint32_t numof_bits = 11;
+	int err;
 
 	switch (param.mode) {
 	case MODBUS_MODE_RTU:
@@ -595,7 +596,11 @@ int modbus_serial_init(struct modbus_context *ctx,
 	cfg->uart_buf_ctr = 0;
 	cfg->uart_buf_ptr = &cfg->uart_buf[0];
 
-	uart_irq_callback_user_data_set(cfg->dev, uart_cb_handler, ctx);
+	err = uart_irq_callback_user_data_set(cfg->dev, uart_cb_handler, ctx);
+	if (err != 0) {
+		return err;
+	};
+
 	k_timer_init(&cfg->rtu_timer, rtu_tmr_handler, NULL);
 	k_timer_user_data_set(&cfg->rtu_timer, ctx);
 

--- a/subsys/modbus/modbus_server.c
+++ b/subsys/modbus/modbus_server.c
@@ -309,7 +309,7 @@ static bool mbs_fc03_hreg_read(struct modbus_context *ctx)
 	const uint16_t regs_limit = 125;
 	const uint8_t request_len = 4;
 	uint8_t *presp;
-	uint16_t err;
+	uint16_t err = 0;
 	uint16_t reg_addr;
 	uint16_t reg_qty;
 	uint16_t num_bytes;
@@ -421,7 +421,7 @@ static bool mbs_fc04_inreg_read(struct modbus_context *ctx)
 	const uint16_t regs_limit = 125;
 	const uint8_t request_len = 4;
 	uint8_t *presp;
-	int err;
+	int err = 0;
 	uint16_t reg_addr;
 	uint16_t reg_qty;
 	uint16_t num_bytes;


### PR DESCRIPTION
Two simple fixes for modbus.

The first commit introduces a missing check for a return value of a function called.

The second commit ensures the initialization of a local variable when a specific config option is not set.