### PR TITLE
drivers: counter: tpm: enable interrupt after TPM init

### DIFF
--- a/drivers/counter/counter_mcux_tpm.c
+++ b/drivers/counter/counter_mcux_tpm.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 NXP
+ * Copyright 2023-2025 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -295,11 +295,15 @@ static DEVICE_API(counter, mcux_tpm_driver_api) = {
 										\
 	static int mcux_tpm_## n ##_init(const struct device *dev)		\
 	{									\
+		int ret;							\
+		ret = mcux_tpm_init(dev);					\
+		if (ret)							\
+			return ret;						\
 		IRQ_CONNECT(DT_INST_IRQN(n),					\
 			DT_INST_IRQ(n, priority),				\
 			mcux_tpm_isr, DEVICE_DT_INST_GET(n), 0);		\
 		irq_enable(DT_INST_IRQN(n));					\
-		return mcux_tpm_init(dev);					\
+		return 0;							\
 	}									\
 
 DT_INST_FOREACH_STATUS_OKAY(TPM_DEVICE_INIT_MCUX)


### PR DESCRIPTION
Change to enable the TPM interrupt after the TPM is initialized, because it will trigger the following exception when re-run the Zephyr without cold reset, due to the pending TPM interrupt in last run is not cleared and results in the TPM ISR is invoked before the TPM initialization.

Exception log on i.MX95:
[00:00:00.000,000] <err> os: ELR_ELn: 0x00000000d000aa78 [00:00:00.000,000] <err> os: ESR_ELn: 0x0000000096000005
[00:00:00.000,000] <err> os:   EC:  0x25 (Data Abort taken without a change in Exception level)
[00:00:00.000,000] <err> os:   IL:  0x1
[00:00:00.000,000] <err> os:   ISS: 0x5
[00:00:00.000,000] <err> os: FAR_ELn: 0x0000000000000014
[00:00:00.000,000] <err> os: TPIDRRO: 0x02000000d003cc20
[00:00:00.000,000] <err> os: x0:  0x0000000000000000  x1:  0x0000000000000101
[00:00:00.000,000] <err> os: x2:  0x00000000d0045480  x3:  0x00000000d000aa58
[00:00:00.000,000] <err> os: x4:  0x000000000001000f  x5:  0x0000000000000000
[00:00:00.000,000] <err> os: x6:  0x0000000000000000  x7:  0x0000000000000000
[00:00:00.000,000] <err> os: x8:  0xffffffffffffffff  x9:  0xffffffffffffffff
[00:00:00.000,000] <err> os: x10: 0xffffffffffffffff  x11: 0xffffffffffffffff
[00:00:00.000,000] <err> os: x12: 0xffffffffffffffff  x13: 0xffffffffffffffff
[00:00:00.000,000] <err> os: x14: 0xffffffffffffffff  x15: 0xffffffffffffffff
[00:00:00.000,000] <err> os: x16: 0x00000000d000989c  x17: 0xffffffffffffffff
[00:00:00.000,000] <err> os: x18: 0xffffffffffffffff  lr:  0x00000000d00010f4
[00:00:00.000,000] <err> os: >>> ZEPHYR FATAL ERROR 0: CPU exception on CPU 0
[00:00:00.000,000] <err> os: Current thread: 0xd002c340 (main)
[00:00:00.134,000] <err> os: Halting system