### PR TITLE
modules: lvgl: fix buffer overflow when using monochrome displays

### DIFF
--- a/modules/lvgl/lvgl_display_mono.c
+++ b/modules/lvgl/lvgl_display_mono.c
@@ -9,6 +9,8 @@
 #include <string.h>
 #include "lvgl_display.h"
 
+#define COLOR_PALETTE_HEADER_SIZE (8)
+
 static uint8_t *mono_conv_buf;
 static uint32_t mono_conv_buf_size;
 
@@ -50,8 +52,9 @@ static void lvgl_transform_buffer(uint8_t **px_map, uint32_t width, uint32_t hei
 
 	memset(mono_conv_buf, clear_color, mono_conv_buf_size);
 
-	/* Needed because LVGL reserves 2x4 bytes in the buffer for the color palette. */
-	*px_map += 8;
+	/* Needed because LVGL reserves some bytes in the buffer for the color palette. */
+	*px_map += COLOR_PALETTE_HEADER_SIZE;
+
 	uint8_t *src_buf = *px_map;
 	uint32_t stride = (width + CONFIG_LV_DRAW_BUF_STRIDE_ALIGN - 1) &
 			  ~(CONFIG_LV_DRAW_BUF_STRIDE_ALIGN - 1);
@@ -67,7 +70,7 @@ static void lvgl_transform_buffer(uint8_t **px_map, uint32_t width, uint32_t hei
 		}
 	}
 
-	memcpy(src_buf, mono_conv_buf, mono_conv_buf_size);
+	memcpy(src_buf, mono_conv_buf, mono_conv_buf_size - COLOR_PALETTE_HEADER_SIZE);
 }
 
 void lvgl_flush_cb_mono(lv_display_t *display, const lv_area_t *area, uint8_t *px_map)


### PR DESCRIPTION
In lvgl_transform_buffer() the pixel map buffer start address is modified to skip the library color palette header but the memcpy size argument was not modified accordingly thus causing writes beyond buffer reserved space.