### PR TITLE
drivers: i2s: sai: Fix a pinmux offset calculation error

### DIFF
--- a/drivers/i2s/i2s_mcux_sai.c
+++ b/drivers/i2s/i2s_mcux_sai.c
@@ -402,7 +402,7 @@ static void enable_mclk_direction(const struct device *dev, bool dir)
 	const struct i2s_mcux_config *dev_cfg = dev->config;
 	uint32_t offset = dev_cfg->mclk_pin_offset;
 	uint32_t mask = dev_cfg->mclk_pin_mask;
-	uint32_t *base = (uint32_t *)(dev_cfg->mclk_control_base + offset);
+	uint32_t *base = dev_cfg->mclk_control_base + offset / sizeof(uint32_t);
 
 	if (dir) {
 		*base |= mask;
@@ -1149,9 +1149,9 @@ static DEVICE_API(i2s, i2s_mcux_driver_api) = {
 		.pll_num = DT_PHA_BY_NAME(DT_DRV_INST(i2s_id), pll_clocks, num, value),            \
 		.pll_den = DT_PHA_BY_NAME(DT_DRV_INST(i2s_id), pll_clocks, den, value),            \
 		.mclk_control_base =                                                               \
-			(uint32_t *)DT_REG_ADDR(DT_PHANDLE(DT_DRV_INST(i2s_id), pinmuxes)),    \
-		.mclk_pin_mask = DT_PHA_BY_IDX(DT_DRV_INST(i2s_id), pinmuxes, 0, function),        \
-		.mclk_pin_offset = DT_PHA_BY_IDX(DT_DRV_INST(i2s_id), pinmuxes, 0, pin),           \
+			(uint32_t *)DT_REG_ADDR(DT_PHANDLE(DT_DRV_INST(i2s_id), pinmuxes)),	   \
+		.mclk_pin_mask = DT_PHA_BY_IDX(DT_DRV_INST(i2s_id), pinmuxes, 0, mask),		   \
+		.mclk_pin_offset = DT_PHA_BY_IDX(DT_DRV_INST(i2s_id), pinmuxes, 0, offset),	   \
 		.clk_sub_sys =                                                                     \
 			(clock_control_subsys_t)DT_INST_CLOCKS_CELL_BY_IDX(i2s_id, 0, name),       \
 		.ccm_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(i2s_id)),                             \

--- a/dts/bindings/pinctrl/nxp,imx-gpr.yaml
+++ b/dts/bindings/pinctrl/nxp,imx-gpr.yaml
@@ -1,7 +1,14 @@
 # Copyright (c) 2021, NXP
 # SPDX-License-Identifier: Apache-2.0
 
-description: i.MX IOMUXC node
+description: |
+  i.MX IOMUXC node
+
+  The specifier space "pinmux" of this binding should have two cells describing
+  the resources needed from the GPR registers.
+  For each specifier, the first cell should be the offset of the GPR register in bytes
+  from the base address of the GPR device base address. The second cell should be a
+  bitmask indicating which bits in the specified register are relevant to the referencing device.
 
 compatible: "nxp,imx-gpr"
 
@@ -12,5 +19,5 @@ properties:
     required: true
 
 pinmux-cells:
-  - pin
-  - function
+  - offset
+  - mask


### PR DESCRIPTION
Offset of pinmux base register address is how many bytes offset in device tree not words.
Fixes:#83882