### PR TITLE
Add dfs validation to spi_context_get_next_buf

### DIFF
--- a/drivers/spi/spi_context.h
+++ b/drivers/spi/spi_context.h
@@ -273,6 +273,11 @@ static inline void *spi_context_get_next_buf(const struct spi_buf **current,
 					     size_t *buf_len,
 					     uint8_t dfs)
 {
+	/* Validate data frame size */
+	if (dfs == 0) {
+		*buf_len = 0;
+		return NULL;
+	}
 	/* This loop skips zero-length buffers in the set, if any. */
 	while (*count) {
 		if (((*current)->len / dfs) != 0) {


### PR DESCRIPTION
### Description

Found a potential division by zero vulnerability in the SPI context buffer handling code. The data frame size (dfs) parameter is used as a divisor without validation in `spi_context_get_next_buf()`.

```c
if (((*current)->len / dfs) != 0)
```

### Impact

* A buggy caller could trigger a division by zero by passing `dfs=0`.
* This could potentially crash the system depending on architecture.