### PR TITLE
include: cbprintf: Fix prototype warning

### DIFF
--- a/include/zephyr/sys/cbprintf.h
+++ b/include/zephyr/sys/cbprintf.h
@@ -293,7 +293,7 @@ BUILD_ASSERT(Z_IS_POW2(CBPRINTF_PACKAGE_ALIGNMENT));
 #ifdef __CHECKER__
 typedef int (*cbprintf_cb)(int c, void *ctx);
 #else
-typedef int (*cbprintf_cb)(/* int c, void *ctx */);
+typedef int (*cbprintf_cb)(int c, ... /* void *ctx */);
 #endif
 
 /* Create local cbprintf_cb type to make calng-based compilers happy when handles


### PR DESCRIPTION
Fix this warning:

zephyr/include/zephyr/sys/cbprintf.h:296:1: warning: function declaration isn't a prototype [-Wstrict-prototypes]
  296 | typedef int (*cbprintf_cb)(/* int c, void *ctx */);
      | ^~~~~~~