### PR TITLE
lib: net_buf: support getting max used buf and packet

### DIFF
--- a/include/zephyr/net_buf.h
+++ b/include/zephyr/net_buf.h
@@ -1098,6 +1098,9 @@ struct net_buf_pool {
 	/** Total size of the pool. */
 	const uint16_t pool_size;
 
+	/** Maximum count of used buffers. */
+	uint16_t max_used;
+
 	/** Name of the pool. Used when printing pool information. */
 	const char *name;
 #endif /* CONFIG_NET_BUF_POOL_USAGE */
@@ -1115,6 +1118,7 @@ struct net_buf_pool {
 /** @cond INTERNAL_HIDDEN */
 #define NET_BUF_POOL_USAGE_INIT(_pool, _count) \
 	IF_ENABLED(CONFIG_NET_BUF_POOL_USAGE, (.avail_count = ATOMIC_INIT(_count),)) \
+	IF_ENABLED(CONFIG_NET_BUF_POOL_USAGE, (.max_used = 0,)) \
 	IF_ENABLED(CONFIG_NET_BUF_POOL_USAGE, (.name = STRINGIFY(_pool),))
 
 #define NET_BUF_POOL_INITIALIZER(_pool, _alloc, _bufs, _count, _ud_size, _destroy) \

--- a/lib/net_buf/buf.c
+++ b/lib/net_buf/buf.c
@@ -344,6 +344,8 @@ success:
 #if defined(CONFIG_NET_BUF_POOL_USAGE)
 	atomic_dec(&pool->avail_count);
 	__ASSERT_NO_MSG(atomic_get(&pool->avail_count) >= 0);
+	pool->max_used = MAX(pool->max_used,
+			     pool->buf_count - atomic_get(&pool->avail_count));
 #endif
 	return buf;
 }

--- a/subsys/net/lib/shell/mem.c
+++ b/subsys/net/lib/shell/mem.c
@@ -114,19 +114,25 @@ static int cmd_net_mem(const struct shell *sh, size_t argc, char *argv[])
 	PR("Network buffer pools:\n");
 
 #if defined(CONFIG_NET_BUF_POOL_USAGE)
-	PR("Address\t\tTotal\tAvail\tName\n");
+	PR("Address\t\tTotal\tAvail\tMaxUsed\tName\n");
+#if defined(CONFIG_MEM_SLAB_TRACE_MAX_UTILIZATION)
+	PR("%p\t%d\t%u\t%u\tRX\n", rx, rx->info.num_blocks,
+	   k_mem_slab_num_free_get(rx), rx->info.max_used);
 
-	PR("%p\t%d\t%u\tRX\n",
+	PR("%p\t%d\t%u\t%u\tTX\n", tx, tx->info.num_blocks,
+	   k_mem_slab_num_free_get(tx), tx->info.max_used);
+#else
+	PR("%p\t%d\t%u\t-\tRX\n",
 	       rx, rx->info.num_blocks, k_mem_slab_num_free_get(rx));
 
-	PR("%p\t%d\t%u\tTX\n",
+	PR("%p\t%d\t%u\t-\tTX\n",
 	       tx, tx->info.num_blocks, k_mem_slab_num_free_get(tx));
+#endif
+	PR("%p\t%d\t%ld\t%d\tRX DATA (%s)\n", rx_data, rx_data->buf_count,
+	   atomic_get(&rx_data->avail_count), rx_data->max_used, rx_data->name);
 
-	PR("%p\t%d\t%ld\tRX DATA (%s)\n", rx_data, rx_data->buf_count,
-	   atomic_get(&rx_data->avail_count), rx_data->name);
-
-	PR("%p\t%d\t%ld\tTX DATA (%s)\n", tx_data, tx_data->buf_count,
-	   atomic_get(&tx_data->avail_count), tx_data->name);
+	PR("%p\t%d\t%ld\t%d\tTX DATA (%s)\n", tx_data, tx_data->buf_count,
+	   atomic_get(&tx_data->avail_count), tx_data->max_used, tx_data->name);
 #else
 	PR("Address\t\tTotal\tName\n");
 


### PR DESCRIPTION
lib: net_buf: support getting max used buf and packet
When defined both CONFIG_NET_BUF_POOL_USAGE and CONFIG_MEM_SLAB_TRACE_MAX_UTILIZATION, support using 'net mem' cmd to get the maximum count of used buffers and net packets.


