### PR TITLE
dts: common: nordic: nrf54h20: Fix flpr bus-width

### DIFF
--- a/dts/common/nordic/nrf54h20.dtsi
+++ b/dts/common/nordic/nrf54h20.dtsi
@@ -84,7 +84,7 @@
 			device_type = "cpu";
 			clock-frequency = <DT_FREQ_M(320)>;
 			riscv,isa = "rv32emc";
-			nordic,bus-width = <64>;
+			nordic,bus-width = <32>;
 
 			cpuflpr_vevif_rx: mailbox {
 				compatible = "nordic,nrf-vevif-task-rx";


### PR DESCRIPTION
EngB+ uses 32bit bus-width stacking sequence for all VPR cores