### PR TITLE
drivers: dai: intel: ssp: Log start for ACE3 and newer

### DIFF
--- a/drivers/dai/intel/ssp/ssp.c
+++ b/drivers/dai/intel/ssp/ssp.c
@@ -2327,29 +2327,29 @@ static void dai_ssp_start(struct dai_intel_ssp *dp, int direction)
 
 
 	/* enable DMA */
-#if SSP_IP_VER > SSP_IP_VER_2_0
 	if (direction == DAI_DIR_PLAYBACK) {
+		LOG_INF("SSP%d TX", dp->dai_index);
+#if SSP_IP_VER > SSP_IP_VER_2_0
 		dai_ssp_update_bits(dp, SSMODyCS(dp->tdm_slot_group),
 				    SSMODyCS_TSRE, SSMODyCS_TSRE);
 		dai_ssp_update_bits(dp, SSMODyCS(dp->tdm_slot_group),
 				    SSMODyCS_TXEN, SSMODyCS_TXEN);
+#else
+		dai_ssp_update_bits(dp, SSCR1, SSCR1_TSRE, SSCR1_TSRE);
+		dai_ssp_update_bits(dp, SSTSA, SSTSA_TXEN, SSTSA_TXEN);
+#endif
 	} else {
+		LOG_INF("SSP%d RX", dp->dai_index);
+#if SSP_IP_VER > SSP_IP_VER_2_0
 		dai_ssp_update_bits(dp, SSMIDyCS(dp->tdm_slot_group),
 				    SSMIDyCS_RSRE, SSMIDyCS_RSRE);
 		dai_ssp_update_bits(dp, SSMIDyCS(dp->tdm_slot_group),
 				    SSMIDyCS_RXEN, SSMIDyCS_RXEN);
-	}
 #else
-	if (direction == DAI_DIR_PLAYBACK) {
-		LOG_INF("SSP%d TX", dp->dai_index);
-		dai_ssp_update_bits(dp, SSCR1, SSCR1_TSRE, SSCR1_TSRE);
-		dai_ssp_update_bits(dp, SSTSA, SSTSA_TXEN, SSTSA_TXEN);
-	} else {
-		LOG_INF("SSP%d RX", dp->dai_index);
 		dai_ssp_update_bits(dp, SSCR1, SSCR1_RSRE, SSCR1_RSRE);
 		dai_ssp_update_bits(dp, SSRSA, SSRSA_RXEN, SSRSA_RXEN);
-	}
 #endif
+	}
 
 	dp->state[direction] = DAI_STATE_RUNNING;
 


### PR DESCRIPTION
With ACE3 the logging is skipped in dai_ssp_start(), move the code under the same if cases to preserve them.