### PR TITLE
tests: drivers: uart: mix_fifo_poll: Fix for nrf54h20dk//cpurad

### DIFF
--- a/tests/drivers/uart/uart_mix_fifo_poll/src/main.c
+++ b/tests/drivers/uart/uart_mix_fifo_poll/src/main.c
@@ -50,7 +50,7 @@ static struct dut_data duts[] = {
 		.dev = DEVICE_DT_GET(UART_NODE),
 		.name = DT_NODE_FULL_NAME(UART_NODE),
 	},
-#if DT_NODE_EXISTS(DT_NODELABEL(dut2))
+#if DT_NODE_EXISTS(DT_NODELABEL(dut2)) && DT_NODE_HAS_STATUS(DT_NODELABEL(dut2), okay)
 	{
 		.dev = DEVICE_DT_GET(DT_NODELABEL(dut2)),
 		.name = DT_NODE_FULL_NAME(DT_NODELABEL(dut2)),


### PR DESCRIPTION
Add check for status okay for dut2. Compilation was failing if dut2 existed but was disabled.