### PR TITLE
manifest: hostap: update hostap revision to get RSNO support

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -274,7 +274,7 @@ manifest:
         - hal
     - name: hostap
       path: modules/lib/hostap
-      revision: b4c42d88afc5ee04751fe258db757c4ef70abb09
+      revision: 4957416a01c86579aebb333b43f1c23da0375835
     - name: liblc3
       revision: bb85f7dde4195bfc0fca9e9c7c2eed0f8694203c
       path: modules/lib/liblc3


### PR DESCRIPTION
Update hostap to support Wi-Fi 7 RSN Override support.