### PR TITLE
Add imx91evk SoC and board support.

### DIFF
--- a/boards/nxp/imx91_evk/Kconfig.imx91_evk
+++ b/boards/nxp/imx91_evk/Kconfig.imx91_evk
@@ -1,0 +1,6 @@
+# Copyright 2025 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+config BOARD_IMX91_EVK
+	select SOC_MIMX9131
+	select SOC_PART_NUMBER_MIMX9131CVVXJ

--- a/boards/nxp/imx91_evk/board.yml
+++ b/boards/nxp/imx91_evk/board.yml
@@ -1,0 +1,6 @@
+board:
+  name: imx91_evk
+  full_name: i.MX91 EVK
+  vendor: nxp
+  socs:
+  - name: mimx9131

--- a/boards/nxp/imx91_evk/doc/index.rst
+++ b/boards/nxp/imx91_evk/doc/index.rst
@@ -1,0 +1,128 @@
+.. zephyr:board:: imx91_evk
+
+Overview
+********
+
+The i.MX 91 Evaluation Kit (MCIMX91-EVK board) is a platform designed
+to display the most commonly used features of the i.MX 91 applications
+processor. The MCIMX91-EVK board is an entry-level development board
+with a small and low-cost package. The board can be used by developers
+to get familiar with the processor before investing a large amount of
+resources in more specific designs.
+
+The i.MX 91 applications processor features an Arm Cortex-A55 core
+that can operate at speeds of up to 1.4 GHz.
+
+- Board features:
+
+  - RAM: 2GB LPDDR4
+  - Storage:
+
+    - SanDisk 16GB eMMC5.1
+    - microSD Socket
+  - Wireless:
+
+    - Murata Type-2EL (SDIO+UART+SPI) module. It is based on NXP IW612 SoC,
+      which supports dual-band (2.4 GHz /5 GHz) 1x1 Wi-Fi 6, Bluetooth 5.2,
+      and 802.15.4
+  - USB:
+
+    - Two USB 2.0 Type C connectors
+  - Ethernet:
+
+    - ENET: 10/100/1000 Mbit/s RGMII Ethernet connected with external PHY
+      RTL8211
+    - ENET_QoS: 10/100/1000 Mbit/s RGMII Ethernet supporting TSN connected
+      with external PHY RTL8211
+  - PCIe:
+
+    - One M.2/NGFF Key E mini card 75-pin connector
+  - Connectors:
+
+    - 40-Pin Dual Row Header
+  - LEDs:
+
+    - 1x Power status LED
+    - 2x UART LED
+  - Debug:
+
+    - JTAG 20-pin connector
+    - MicroUSB for UART debug
+
+
+Supported Features
+==================
+
+The ``imx91_evk`` board supports the following hardware features:
+
++-----------+------------+-------------------------------------+
+| Interface | Controller | Driver/Component                    |
++===========+============+=====================================+
+| GIC-v3    | on-chip    | interrupt controller                |
++-----------+------------+-------------------------------------+
+| ARM TIMER | on-chip    | system clock                        |
++-----------+------------+-------------------------------------+
+| CLOCK     | on-chip    | clock_control                       |
++-----------+------------+-------------------------------------+
+| PINMUX    | on-chip    | pinmux                              |
++-----------+------------+-------------------------------------+
+| UART      | on-chip    | serial port                         |
++-----------+------------+-------------------------------------+
+
+Devices
+========
+System Clock
+------------
+
+This board configuration uses a system clock frequency of 24 MHz.
+Cortex-A55 Core runs up to 1.4 GHz.
+
+Serial Port
+-----------
+
+This board configuration uses a single serial communication channel with the
+CPU's UART1 for A55 core.
+
+Programming and Debugging
+*******************************
+
+U-Boot "go" command is used to load and kick Zephyr to Cortex-A55 Core.
+
+Copy the compiled ``zephyr.bin`` to the first FAT partition of the SD card and
+plug the SD card into the board. Power it up and stop the u-boot execution at
+prompt.
+
+Use U-Boot to load and kick zephyr.bin to Cortex-A55 Core:
+
+.. code-block:: console
+
+    fatload mmc 1:1 0x80000000 zephyr.bin; dcache flush; icache flush; go 0x80000000
+
+Use this configuration to run basic Zephyr applications and kernel tests,
+for example, with the :zephyr:code-sample:`synchronization` sample:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/synchronization
+   :host-os: unix
+   :board: imx91_evk/mimx9131
+   :goals: build
+
+This will build an image with the synchronization sample app, boot it and
+display the following console output:
+
+.. code-block:: console
+
+    *** Booting Zephyr OS build v4.0.0-3277-g69f43115c9a8 ***
+    thread_a: Hello World from cpu 0 on imx91_evk!
+    thread_b: Hello World from cpu 0 on imx91_evk!
+    thread_a: Hello World from cpu 0 on imx91_evk!
+    thread_b: Hello World from cpu 0 on imx91_evk!
+
+References
+==========
+
+More information can refer to NXP official website:
+`NXP website`_.
+
+.. _NXP website:
+   https://www.nxp.com/products/i.MX91

--- a/boards/nxp/imx91_evk/imx91_evk-pinctrl.dtsi
+++ b/boards/nxp/imx91_evk/imx91_evk-pinctrl.dtsi
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2025 NXP
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+#include <nxp/nxp_imx/mimx9131cvvxj-pinctrl.dtsi>
+
+&pinctrl {
+	uart1_default: uart1_default {
+		group0 {
+			pinmux = <&iomuxc1_uart1_rxd_lpuart_rx_lpuart1_rx>,
+				<&iomuxc1_uart1_txd_lpuart_tx_lpuart1_tx>;
+			bias-pull-up;
+			slew-rate = "slightly_fast";
+			drive-strength = "x5";
+		};
+	};
+
+	uart2_default: uart2_default {
+		group0 {
+			pinmux = <&iomuxc1_uart2_rxd_lpuart_rx_lpuart2_rx>,
+				<&iomuxc1_uart2_txd_lpuart_tx_lpuart2_tx>;
+			bias-pull-up;
+			slew-rate = "slightly_fast";
+			drive-strength = "x5";
+		};
+	};
+};

--- a/boards/nxp/imx91_evk/imx91_evk_mimx9131.dts
+++ b/boards/nxp/imx91_evk/imx91_evk_mimx9131.dts
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2025 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/dts-v1/;
+
+#include <nxp/nxp_mimx91.dtsi>
+#include "imx91_evk-pinctrl.dtsi"
+
+/ {
+	model = "NXP i.MX91 A55";
+	compatible = "fsl,mimx91";
+
+	chosen {
+		zephyr,console = &lpuart1;
+		zephyr,shell-uart = &lpuart1;
+		/* sram node actually locates at DDR DRAM */
+		zephyr,sram = &dram;
+	};
+
+	dram: memory@80000000 {
+		reg = <0x80000000 DT_SIZE_M(1)>;
+	};
+
+};
+
+&lpuart1 {
+	status = "okay";
+	current-speed = <115200>;
+	pinctrl-0 = <&uart1_default>;
+	pinctrl-names = "default";
+};

--- a/boards/nxp/imx91_evk/imx91_evk_mimx9131.yaml
+++ b/boards/nxp/imx91_evk/imx91_evk_mimx9131.yaml
@@ -1,0 +1,17 @@
+#
+# Copyright 2025 NXP
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+identifier: imx91_evk/mimx9131
+name: NXP i.MX91 EVK
+type: mcu
+arch: arm64
+toolchain:
+  - zephyr
+  - cross-compile
+ram: 1024
+supported:
+  - uart
+vendor: nxp

--- a/boards/nxp/imx91_evk/imx91_evk_mimx9131_defconfig
+++ b/boards/nxp/imx91_evk/imx91_evk_mimx9131_defconfig
@@ -1,0 +1,30 @@
+#
+# Copyright 2025 NXP
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# ARM Options
+CONFIG_AARCH64_IMAGE_HEADER=y
+CONFIG_ARMV8_A_NS=y
+
+# MMU Options
+# Increase the value when encounter the assert on the MAX_XLAT_TABLES
+CONFIG_MAX_XLAT_TABLES=24
+
+# Cache Options
+CONFIG_CACHE_MANAGEMENT=y
+CONFIG_DCACHE_LINE_SIZE_DETECT=y
+CONFIG_ICACHE_LINE_SIZE_DETECT=y
+
+# Zephyr Kernel Configuration
+CONFIG_XIP=n
+
+# Serial Drivers
+CONFIG_SERIAL=y
+CONFIG_UART_INTERRUPT_DRIVEN=y
+
+# Enable Console
+CONFIG_CONSOLE=y
+CONFIG_UART_CONSOLE=y
+
+CONFIG_CLOCK_CONTROL=y

--- a/drivers/clock_control/clock_control_mcux_ccm_rev2.c
+++ b/drivers/clock_control/clock_control_mcux_ccm_rev2.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021,2024 NXP
+ * Copyright 2021,2024-2025 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -287,7 +287,7 @@ static int mcux_ccm_get_subsys_rate(const struct device *dev,
 	default:
 		return -EINVAL;
 	}
-#ifdef CONFIG_SOC_MIMX9352
+#if defined(CONFIG_SOC_MIMX9352) || defined(CONFIG_SOC_MIMX9131)
 	*rate = CLOCK_GetIpFreq(clock_root);
 #else
 	*rate = CLOCK_GetRootClockFreq(clock_root);

--- a/drivers/pinctrl/pinctrl_imx.c
+++ b/drivers/pinctrl/pinctrl_imx.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, 2024 NXP
+ * Copyright 2022, 2024-2025 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -33,7 +33,7 @@ int pinctrl_configure_pins(const pinctrl_soc_pin_t *pins, uint8_t pin_cnt,
 		}
 #endif
 
-#ifdef CONFIG_SOC_MIMX9352
+#if defined(CONFIG_SOC_MIMX9352) || defined(CONFIG_SOC_MIMX9131)
 		sys_write32(IOMUXC1_SW_MUX_CTL_PAD_MUX_MODE(mux_mode) |
 			IOMUXC1_SW_MUX_CTL_PAD_SION(MCUX_IMX_INPUT_ENABLE(pin_ctrl_flags)),
 			(mem_addr_t)mux_register);

--- a/dts/arm64/nxp/nxp_mimx91.dtsi
+++ b/dts/arm64/nxp/nxp_mimx91.dtsi
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2025 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <mem.h>
+#include <freq.h>
+#include <arm64/armv8-a.dtsi>
+#include <zephyr/dt-bindings/clock/imx_ccm_rev2.h>
+#include <zephyr/dt-bindings/interrupt-controller/arm-gic.h>
+
+/ {
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	cpus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		cpu@0 {
+			device_type = "cpu";
+			compatible = "arm,cortex-a55";
+			reg = <0>;
+		};
+	};
+
+	arch_timer: timer {
+		compatible = "arm,armv8-timer";
+		interrupts = <GIC_PPI 13 IRQ_TYPE_LEVEL
+			      IRQ_DEFAULT_PRIORITY>,
+			     <GIC_PPI 14 IRQ_TYPE_LEVEL
+			      IRQ_DEFAULT_PRIORITY>,
+			     <GIC_PPI 11 IRQ_TYPE_LEVEL
+			      IRQ_DEFAULT_PRIORITY>,
+			     <GIC_PPI 10 IRQ_TYPE_LEVEL
+			      IRQ_DEFAULT_PRIORITY>;
+		interrupt-parent = <&gic>;
+	};
+
+	psci: psci {
+		compatible = "arm,psci-1.1";
+		method = "smc";
+	};
+
+	gic: interrupt-controller@48000000 {
+		compatible = "arm,gic-v3", "arm,gic";
+		reg = <0x48000000 0x10000>, /* GIC Dist */
+		      <0x48040000 0xc0000>; /* GICR (RD_base + SGI_base) */
+		interrupt-controller;
+		#interrupt-cells = <4>;
+		status = "okay";
+	};
+
+	iomuxc: iomuxc@443c0000 {
+		compatible = "nxp,imx-iomuxc";
+		reg = <0x443c0000 DT_SIZE_K(64)>;
+		status = "okay";
+		pinctrl: pinctrl {
+			status = "okay";
+			compatible = "nxp,imx93-pinctrl";
+		};
+	};
+
+	ana_pll: ana_pll@44480000 {
+		compatible = "nxp,imx-ana";
+		reg = <0x44480000 DT_SIZE_K(64)>;
+	};
+
+	ccm: ccm@44450000 {
+		compatible = "nxp,imx-ccm-rev2";
+		reg = <0x44450000 DT_SIZE_K(64)>;
+		#clock-cells = <3>;
+	};
+
+	lpuart1: serial@44380000 {
+		compatible = "nxp,imx-lpuart", "nxp,lpuart";
+		reg = <0x44380000 DT_SIZE_K(64)>;
+		interrupts = <GIC_SPI 19 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+		interrupt-names = "irq_0";
+		interrupt-parent = <&gic>;
+		clocks = <&ccm IMX_CCM_LPUART1_CLK 0x6c 24>;
+		status = "disabled";
+	};
+
+	lpuart2: serial@44390000 {
+		compatible = "nxp,imx-lpuart", "nxp,lpuart";
+		reg = <0x44390000 DT_SIZE_K(64)>;
+		interrupts = <GIC_SPI 20 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+		interrupt-names = "irq_0";
+		interrupt-parent = <&gic>;
+		clocks = <&ccm IMX_CCM_LPUART2_CLK 0x6c 24>;
+		status = "disabled";
+	};
+};

--- a/soc/nxp/imx/imx9/CMakeLists.txt
+++ b/soc/nxp/imx/imx9/CMakeLists.txt
@@ -1,7 +1,9 @@
-# Copyright 2024 NXP
+# Copyright 2024-2025 NXP
 # SPDX-License-Identifier: Apache-2.0
 
-if(CONFIG_SOC_MIMX9352)
+if(CONFIG_SOC_MIMX9131)
+  add_subdirectory(imx91)
+elseif(CONFIG_SOC_MIMX9352)
   add_subdirectory(imx93)
 elseif(CONFIG_SOC_MIMX9596)
   add_subdirectory(imx95)

--- a/soc/nxp/imx/imx9/imx91/CMakeLists.txt
+++ b/soc/nxp/imx/imx9/imx91/CMakeLists.txt
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+zephyr_compile_options(-Wno-misleading-indentation)
+
+zephyr_include_directories(.)
+
+zephyr_sources_ifdef(CONFIG_ARM_MMU mmu_regions.c)
+
+set(SOC_LINKER_SCRIPT ${ZEPHYR_BASE}/include/zephyr/arch/arm64/scripts/linker.ld CACHE INTERNAL "")

--- a/soc/nxp/imx/imx9/imx91/Kconfig
+++ b/soc/nxp/imx/imx9/imx91/Kconfig
@@ -1,0 +1,12 @@
+# Copyright 2025 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+config SOC_MIMX9131
+	select ARM64
+	select CPU_CORTEX_A55
+	select ARM_ARCH_TIMER if SYS_CLOCK_EXISTS
+	select HAS_MCUX if CLOCK_CONTROL
+	select HAS_MCUX_CCM_REV2 if CLOCK_CONTROL
+	select HAS_MCUX_IOMUXC if PINCTRL
+	select HAS_MCUX_CACHE
+	select KERNEL_DIRECT_MAP if HAS_MCUX

--- a/soc/nxp/imx/imx9/imx91/Kconfig.defconfig
+++ b/soc/nxp/imx/imx9/imx91/Kconfig.defconfig
@@ -1,0 +1,8 @@
+# Copyright 2025 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+if SOC_SERIES_IMX9
+
+rsource "Kconfig.defconfig.*"
+
+endif # SOC_SERIES_IMX9

--- a/soc/nxp/imx/imx9/imx91/Kconfig.defconfig.mimx91
+++ b/soc/nxp/imx/imx9/imx91/Kconfig.defconfig.mimx91
@@ -1,0 +1,21 @@
+# Copyright 2025 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+if SOC_MIMX9131
+
+# Workaround for not being able to have commas in macro arguments
+DT_CHOSEN_Z_FLASH := zephyr,flash
+
+config FLASH_SIZE
+	default $(dt_chosen_reg_size_int,$(DT_CHOSEN_Z_FLASH),0,K)
+
+config FLASH_BASE_ADDRESS
+	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_FLASH))
+
+config NUM_IRQS
+	default 300
+
+config SYS_CLOCK_HW_CYCLES_PER_SEC
+	default 24000000
+
+endif

--- a/soc/nxp/imx/imx9/imx91/Kconfig.soc
+++ b/soc/nxp/imx/imx9/imx91/Kconfig.soc
@@ -1,0 +1,21 @@
+# Copyright 2025 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+config SOC_MIMX9131
+	bool
+	select SOC_SERIES_IMX9
+	help
+	  NXP i.MX91
+
+config SOC_PART_NUMBER_MIMX9131CVVXJ
+	bool
+
+config SOC_PART_NUMBER_MIMX9131DVVXJ
+	bool
+
+config SOC_PART_NUMBER
+	default "MIMX9131CVVXJ" if SOC_PART_NUMBER_MIMX9131CVVXJ
+	default "MIMX9131DVVXJ" if SOC_PART_NUMBER_MIMX9131DVVXJ
+
+config SOC
+	default "mimx9131" if SOC_MIMX9131

--- a/soc/nxp/imx/imx9/imx91/mmu_regions.c
+++ b/soc/nxp/imx/imx9/imx91/mmu_regions.c
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2025 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/arch/arm64/arm_mmu.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/sys/util.h>
+
+static const struct arm_mmu_region mmu_regions[] = {
+	MMU_REGION_FLAT_ENTRY("GIC", DT_REG_ADDR_BY_IDX(DT_NODELABEL(gic), 0),
+			      DT_REG_SIZE_BY_IDX(DT_NODELABEL(gic), 0),
+			      MT_DEVICE_nGnRnE | MT_P_RW_U_NA | MT_NS),
+
+	MMU_REGION_FLAT_ENTRY("GIC", DT_REG_ADDR_BY_IDX(DT_NODELABEL(gic), 1),
+			      DT_REG_SIZE_BY_IDX(DT_NODELABEL(gic), 1),
+			      MT_DEVICE_nGnRnE | MT_P_RW_U_NA | MT_NS),
+
+	MMU_REGION_FLAT_ENTRY("CCM", DT_REG_ADDR(DT_NODELABEL(ccm)), DT_REG_SIZE(DT_NODELABEL(ccm)),
+			      MT_DEVICE_nGnRnE | MT_P_RW_U_NA | MT_NS),
+
+	MMU_REGION_FLAT_ENTRY("ANA_PLL", DT_REG_ADDR(DT_NODELABEL(ana_pll)),
+			      DT_REG_SIZE(DT_NODELABEL(ana_pll)),
+			      MT_DEVICE_nGnRnE | MT_P_RW_U_NA | MT_NS),
+
+	MMU_REGION_FLAT_ENTRY("IOMUXC", DT_REG_ADDR(DT_NODELABEL(iomuxc)),
+			      DT_REG_SIZE(DT_NODELABEL(iomuxc)),
+			      MT_DEVICE_nGnRnE | MT_P_RW_U_NA | MT_NS),
+
+	MMU_REGION_DT_COMPAT_FOREACH_FLAT_ENTRY(nxp_lpuart,
+						(MT_DEVICE_nGnRnE | MT_P_RW_U_NA | MT_NS))
+};
+
+const struct arm_mmu_config mmu_config = {
+	.num_regions = ARRAY_SIZE(mmu_regions),
+	.mmu_regions = mmu_regions,
+};

--- a/soc/nxp/imx/imx9/imx91/pinctrl_soc.h
+++ b/soc/nxp/imx/imx9/imx91/pinctrl_soc.h
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2025 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_SOC_ARM64_NXP_IMX9_PINCTRL_SOC_H_
+#define ZEPHYR_SOC_ARM64_NXP_IMX9_PINCTRL_SOC_H_
+
+#include <zephyr/devicetree.h>
+#include <zephyr/types.h>
+#include "fsl_common.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define MCUX_IMX_INPUT_SCHMITT_ENABLE_SHIFT IOMUXC1_SW_PAD_CTL_PAD_HYS_SHIFT
+#define MCUX_IMX_DRIVE_OPEN_DRAIN_SHIFT     IOMUXC1_SW_PAD_CTL_PAD_OD_SHIFT
+#define MCUX_IMX_BIAS_PULL_DOWN_SHIFT       IOMUXC1_SW_PAD_CTL_PAD_PD_SHIFT
+#define MCUX_IMX_BIAS_PULL_UP_SHIFT         IOMUXC1_SW_PAD_CTL_PAD_PU_SHIFT
+#define MCUX_IMX_SLEW_RATE_SHIFT            IOMUXC1_SW_PAD_CTL_PAD_FSEL1_SHIFT
+#define MCUX_IMX_DRIVE_STRENGTH_SHIFT       IOMUXC1_SW_PAD_CTL_PAD_DSE_SHIFT
+#define MCUX_IMX_INPUT_ENABLE_SHIFT         23 /* Shift to a bit not used by IOMUXC_SW_PAD_CTL */
+#define MCUX_IMX_INPUT_ENABLE(x)            ((x >> MCUX_IMX_INPUT_ENABLE_SHIFT) & 0x1)
+
+#define Z_PINCTRL_MCUX_IMX_PINCFG_INIT(node_id)                                                    \
+	((DT_PROP(node_id, input_schmitt_enable) << MCUX_IMX_INPUT_SCHMITT_ENABLE_SHIFT) |         \
+	 (DT_PROP(node_id, drive_open_drain) << MCUX_IMX_DRIVE_OPEN_DRAIN_SHIFT) |                 \
+	 (DT_PROP(node_id, bias_pull_down) << MCUX_IMX_BIAS_PULL_DOWN_SHIFT) |                     \
+	 (DT_PROP(node_id, bias_pull_up) << MCUX_IMX_BIAS_PULL_UP_SHIFT) |                         \
+	 (DT_ENUM_IDX(node_id, slew_rate) << MCUX_IMX_SLEW_RATE_SHIFT) |                           \
+	 ((~(0xff << DT_ENUM_IDX(node_id, drive_strength))) << MCUX_IMX_DRIVE_STRENGTH_SHIFT) |    \
+	 (DT_PROP(node_id, input_enable) << MCUX_IMX_INPUT_ENABLE_SHIFT))
+
+/* This struct must be present. It is used by the mcux gpio driver */
+struct pinctrl_soc_pinmux {
+	uint32_t mux_register;    /*!< IOMUXC SW_PAD_MUX register */
+	uint32_t config_register; /*!< IOMUXC SW_PAD_CTL register */
+	uint32_t input_register;  /*!< IOMUXC SELECT_INPUT DAISY register */
+	uint8_t mux_mode: 4;      /*!< Mux value for SW_PAD_MUX register */
+	uint32_t input_daisy: 4;  /*!< Mux value for SELECT_INPUT_DAISY register */
+};
+
+struct pinctrl_soc_pin {
+	struct pinctrl_soc_pinmux pinmux;
+	uint32_t pin_ctrl_flags; /*!< value to write to IOMUXC_SW_PAD_CTL register */
+};
+
+typedef struct pinctrl_soc_pin pinctrl_soc_pin_t;
+
+/* This definition must be present. It is used by the mcux gpio driver */
+#define MCUX_IMX_PINMUX(node_id)                                                                   \
+	{                                                                                          \
+		.mux_register = DT_PROP_BY_IDX(node_id, pinmux, 0),                                \
+		.config_register = DT_PROP_BY_IDX(node_id, pinmux, 4),                             \
+		.input_register = DT_PROP_BY_IDX(node_id, pinmux, 2),                              \
+		.mux_mode = DT_PROP_BY_IDX(node_id, pinmux, 1),                                    \
+		.input_daisy = DT_PROP_BY_IDX(node_id, pinmux, 3),                                 \
+	}
+
+#define Z_PINCTRL_PINMUX(group_id, pin_prop, idx)                                                  \
+	MCUX_IMX_PINMUX(DT_PHANDLE_BY_IDX(group_id, pin_prop, idx))
+
+#define Z_PINCTRL_STATE_PIN_INIT(group_id, pin_prop, idx)                                          \
+	{                                                                                          \
+		.pinmux = Z_PINCTRL_PINMUX(group_id, pin_prop, idx),                               \
+		.pin_ctrl_flags = Z_PINCTRL_MCUX_IMX_PINCFG_INIT(group_id),                        \
+	},
+
+#define Z_PINCTRL_STATE_PINS_INIT(node_id, prop)                                                   \
+	{DT_FOREACH_CHILD_VARGS(DT_PHANDLE(node_id, prop), DT_FOREACH_PROP_ELEM, pinmux,           \
+				Z_PINCTRL_STATE_PIN_INIT)};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_SOC_ARM64_NXP_IMX9_PINCTRL_SOC_H_ */

--- a/soc/nxp/imx/soc.yml
+++ b/soc/nxp/imx/soc.yml
@@ -35,6 +35,7 @@ family:
       - name: m4
   - name: imx9
     socs:
+    - name: mimx9131
     - name: mimx9352
       cpuclusters:
       - name: a55

--- a/west.yml
+++ b/west.yml
@@ -203,7 +203,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: 0b86efa2ad563e60d4d57fe7fa7ac6ccfa092f8c
+      revision: 07a87b69098d8e0c9b93355bde411e72427867ba
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
Add imx91evk SoC and board support.

Depends on:
- [ ] https://github.com/zephyrproject-rtos/hal_nxp/pull/497