### PR TITLE
arch/riscv: add Zaamo and Zlrsc extension subsets

### DIFF
--- a/arch/riscv/Kconfig.isa
+++ b/arch/riscv/Kconfig.isa
@@ -33,6 +33,8 @@ config RISCV_ISA_EXT_M
 
 config RISCV_ISA_EXT_A
 	bool
+	imply RISCV_ISA_EXT_ZAAMO
+	imply RISCV_ISA_EXT_ZLRSC
 	help
 	  (A) - Standard Extension for Atomic Instructions
 
@@ -110,6 +112,20 @@ config RISCV_ISA_EXT_ZIFENCEI
 	  The "Zifencei" extension includes the FENCE.I instruction that
 	  provides explicit synchronization between writes to instruction
 	  memory and instruction fetches on the same hart.
+
+config RISCV_ISA_EXT_ZAAMO
+	bool
+	help
+	  (Zaamo) - Atomic memory operation subset of the A extension
+
+	  The Zaamo extension enables support for AMO*.W/D-style instructions.
+
+config RISCV_ISA_EXT_ZLRSC
+	bool
+	help
+	  (Zlrsc) - Load-Reserved/Store-Conditional subset of the A extension
+
+	  The Zlrsc extension enables support for LR.W/D and SC.W/D-style instructions.
 
 config RISCV_ISA_EXT_ZBA
 	bool

--- a/cmake/compiler/gcc/target_riscv.cmake
+++ b/cmake/compiler/gcc/target_riscv.cmake
@@ -53,6 +53,18 @@ if(CONFIG_RISCV_ISA_EXT_ZIFENCEI)
     string(CONCAT riscv_march ${riscv_march} "_zifencei")
 endif()
 
+# Check whether we already imply Zaamo/Zlrsc by selecting the A extension; if not - check them
+# individually and enable them as needed
+if(NOT CONFIG_RISCV_ISA_EXT_A)
+  if(CONFIG_RISCV_ISA_EXT_ZAAMO)
+    string(CONCAT riscv_march ${riscv_march} "_zaamo")
+  endif()
+
+  if(CONFIG_RISCV_ISA_EXT_ZLRSC)
+    string(CONCAT riscv_march ${riscv_march} "_zlrsc")
+  endif()
+endif()
+
 if(CONFIG_RISCV_ISA_EXT_ZBA)
     string(CONCAT riscv_march ${riscv_march} "_zba")
 endif()


### PR DESCRIPTION
The Zaamo and Zalrsc Extension (Version v1.0.0, 2024-04-25; Ratified) split the standard A extension into two subextensions. As of date, the `_zaamo` and `_zlrsc` extension specifications are accepted by the upstream in-development GCC through the `march` argument. This means that those subextensions are not yet supported by GCC shipped with Zephyr SDK.

Ratified extensions list: https://lf-riscv.atlassian.net/wiki/spaces/HOME/pages/16154732/Ratified+Extensions
Zaamo and Zalrsc extensions: https://drive.google.com/file/d/1y2jMvCgnlPhFIe_MKv6NvSzxS-Jduz76/view
Upstream GCC `march` canonicalize script: https://gcc.gnu.org/git/?p=gcc.git;a=blob;f=gcc/config/riscv/arch-canonicalize;h=fd552551abae9140a32d8d190e5406fc3b63fc53;hb=HEAD#l44