### PR TITLE
NXP IRQSTEER support for ARM arch

### DIFF
--- a/arch/arm/core/cortex_a_r/irq_manage.c
+++ b/arch/arm/core/cortex_a_r/irq_manage.c
@@ -33,6 +33,14 @@ extern void z_arm_reserved(void);
  * Generic Interrupt Controller (GIC) and therefore the architecture interrupt
  * control functions are mapped to the GIC driver interface.
  *
+ * When GIC is used together with other interrupt controller for
+ * multi-level interrupts support (i.e. CONFIG_MULTI_LEVEL_INTERRUPTS
+ * is enabled), the architecture interrupt control functions are mapped
+ * to the SoC layer in `include/arch/arm/irq.h`.
+ * The exported arm interrupt control functions which are wrappers of
+ * GIC control could be used for SoC to do level 1 irq control to implement SoC
+ * layer interrupt control functions.
+ *
  * When a custom interrupt controller is used (i.e.
  * CONFIG_ARM_CUSTOM_INTERRUPT_CONTROLLER is enabled), the architecture
  * interrupt control functions are mapped to the SoC layer in
@@ -40,17 +48,17 @@ extern void z_arm_reserved(void);
  */
 
 #if !defined(CONFIG_ARM_CUSTOM_INTERRUPT_CONTROLLER)
-void arch_irq_enable(unsigned int irq)
+void arm_irq_enable(unsigned int irq)
 {
 	arm_gic_irq_enable(irq);
 }
 
-void arch_irq_disable(unsigned int irq)
+void arm_irq_disable(unsigned int irq)
 {
 	arm_gic_irq_disable(irq);
 }
 
-int arch_irq_is_enabled(unsigned int irq)
+int arm_irq_is_enabled(unsigned int irq)
 {
 	return arm_gic_irq_is_enabled(irq);
 }
@@ -65,10 +73,11 @@ int arch_irq_is_enabled(unsigned int irq)
  * priority levels which are reserved: three for various types of exceptions,
  * and possibly one additional to support zero latency interrupts.
  */
-void z_arm_irq_priority_set(unsigned int irq, unsigned int prio, uint32_t flags)
+void arm_irq_priority_set(unsigned int irq, unsigned int prio, uint32_t flags)
 {
 	arm_gic_irq_set_priority(irq, prio, flags);
 }
+
 #endif /* !CONFIG_ARM_CUSTOM_INTERRUPT_CONTROLLER */
 
 void z_arm_fatal_error(unsigned int reason, const struct arch_esf *esf);

--- a/arch/arm/core/cortex_m/irq_init.c
+++ b/arch/arm/core/cortex_m/irq_init.c
@@ -27,7 +27,12 @@ void z_arm_interrupt_init(void)
 {
 	int irq = 0;
 
+/* CONFIG_2ND_LVL_ISR_TBL_OFFSET could be treated as total number of level1 interrupts */
+#if defined(CONFIG_MULTI_LEVEL_INTERRUPTS) && defined(CONFIG_2ND_LVL_ISR_TBL_OFFSET)
+	for (; irq < CONFIG_2ND_LVL_ISR_TBL_OFFSET; irq++) {
+#else
 	for (; irq < CONFIG_NUM_IRQS; irq++) {
+#endif
 		NVIC_SetPriority((IRQn_Type)irq, _IRQ_PRIO_OFFSET);
 	}
 }

--- a/arch/arm/core/cortex_m/irq_manage.c
+++ b/arch/arm/core/cortex_m/irq_manage.c
@@ -32,19 +32,38 @@ extern void z_arm_reserved(void);
 #define REG_FROM_IRQ(irq) (irq / NUM_IRQS_PER_REG)
 #define BIT_FROM_IRQ(irq) (irq % NUM_IRQS_PER_REG)
 
+/*
+ * For Cortex-M core, the default interrupt controller is the ARM
+ * NVIC and therefore the architecture interrupt control functions
+ * are mapped to the NVIC driver interface.
+ *
+ * When NVIC is used together with other interrupt controller for
+ * multi-level interrupts support (i.e. CONFIG_MULTI_LEVEL_INTERRUPTS
+ * is enabled), the architecture interrupt control functions are mapped
+ * to the SoC layer in `include/arch/arm/irq.h`.
+ * The exported arm interrupt control functions which are wrappers of
+ * NVIC control could be used for SoC to do level 1 irq control to implement SoC
+ * layer interrupt control functions.
+ *
+ * When a custom interrupt controller is used (i.e.
+ * CONFIG_ARM_CUSTOM_INTERRUPT_CONTROLLER is enabled), the architecture
+ * interrupt control functions are mapped to the SoC layer in
+ * `include/arch/arm/irq.h`.
+ */
+
 #if !defined(CONFIG_ARM_CUSTOM_INTERRUPT_CONTROLLER)
 
-void arch_irq_enable(unsigned int irq)
+void arm_irq_enable(unsigned int irq)
 {
 	NVIC_EnableIRQ((IRQn_Type)irq);
 }
 
-void arch_irq_disable(unsigned int irq)
+void arm_irq_disable(unsigned int irq)
 {
 	NVIC_DisableIRQ((IRQn_Type)irq);
 }
 
-int arch_irq_is_enabled(unsigned int irq)
+int arm_irq_is_enabled(unsigned int irq)
 {
 	return NVIC->ISER[REG_FROM_IRQ(irq)] & BIT(BIT_FROM_IRQ(irq));
 }
@@ -58,7 +77,7 @@ int arch_irq_is_enabled(unsigned int irq)
  * of priority levels is a little complex, as there are some hardware
  * priority levels which are reserved.
  */
-void z_arm_irq_priority_set(unsigned int irq, unsigned int prio, uint32_t flags)
+void arm_irq_priority_set(unsigned int irq, unsigned int prio, uint32_t flags)
 {
 	/* The kernel may reserve some of the highest priority levels.
 	 * So we offset the requested priority level with the number

--- a/drivers/interrupt_controller/Kconfig.nxp_irqsteer
+++ b/drivers/interrupt_controller/Kconfig.nxp_irqsteer
@@ -6,7 +6,6 @@ config NXP_IRQSTEER
 	default y
 	depends on DT_HAS_NXP_IRQSTEER_INTC_ENABLED
 	depends on MULTI_LEVEL_INTERRUPTS
-	depends on XTENSA
 	help
 		The IRQSTEER INTC provides support for MUX-ing
 		multiple interrupts from peripheral to one or

--- a/drivers/interrupt_controller/intc_nxp_irqsteer.c
+++ b/drivers/interrupt_controller/intc_nxp_irqsteer.c
@@ -265,6 +265,18 @@ LOG_MODULE_REGISTER(nxp_irqstr);
 #define DISPATCHER_REGMAP(disp) \
 	(((const struct irqsteer_config *)disp->dev->config)->regmap_phys)
 
+#if defined(CONFIG_XTENSA)
+#define irqsteer_level1_irq_enable(irq)     xtensa_irq_enable(XTENSA_IRQ_NUMBER(irq))
+#define irqsteer_level1_irq_disable(irq)    xtensa_irq_disable(XTENSA_IRQ_NUMBER(irq))
+#define irqsteer_level1_irq_is_enabled(irq) xtensa_irq_is_enabled(XTENSA_IRQ_NUMBER(irq))
+#elif defined(CONFIG_ARM)
+#define irqsteer_level1_irq_enable(irq)     arm_irq_enable(irq)
+#define irqsteer_level1_irq_disable(irq)    arm_irq_disable(irq)
+#define irqsteer_level1_irq_is_enabled(irq) arm_irq_is_enabled(irq)
+#else
+#error ARCH not supported
+#endif
+
 struct irqsteer_config {
 	uint32_t regmap_phys;
 	uint32_t regmap_size;
@@ -336,13 +348,11 @@ static void _irqstr_disp_enable_disable(struct irqsteer_dispatcher *disp,
 	uint32_t regmap = DISPATCHER_REGMAP(disp);
 
 	if (enable) {
-		xtensa_irq_enable(XTENSA_IRQ_NUMBER(disp->irq));
-
+		irqsteer_level1_irq_enable(disp->irq);
 		IRQSTEER_EnableMasterInterrupt(UINT_TO_IRQSTEER(regmap), disp->irq);
 	} else {
 		IRQSTEER_DisableMasterInterrupt(UINT_TO_IRQSTEER(regmap), disp->irq);
-
-		xtensa_irq_disable(XTENSA_IRQ_NUMBER(disp->irq));
+		irqsteer_level1_irq_disable(disp->irq);
 	}
 }
 
@@ -467,9 +477,9 @@ void z_soc_irq_enable_disable(uint32_t irq, bool enable)
 	if (irq_get_level(irq) == 1) {
 		/* LEVEL 1 interrupts are DSP direct */
 		if (enable) {
-			xtensa_irq_enable(XTENSA_IRQ_NUMBER(irq));
+			irqsteer_level1_irq_enable(irq);
 		} else {
-			xtensa_irq_disable(XTENSA_IRQ_NUMBER(irq));
+			irqsteer_level1_irq_disable(irq);
 		}
 		return;
 	}
@@ -513,8 +523,7 @@ int z_soc_irq_is_enabled(unsigned int irq)
 	bool enabled;
 
 	if (irq_get_level(irq) == 1) {
-		/* LEVEL 1 interrupts are DSP direct */
-		return xtensa_irq_is_enabled(XTENSA_IRQ_NUMBER(irq));
+		return irqsteer_level1_irq_is_enabled(irq);
 	}
 
 	parent_irq = irq_parent_level_2(irq);
@@ -538,6 +547,18 @@ int z_soc_irq_is_enabled(unsigned int irq)
 	return false;
 }
 
+#if defined(CONFIG_ARM)
+void z_soc_irq_priority_set(unsigned int irq, unsigned int prio, unsigned int flags)
+{
+	uint32_t level1_irq = irq;
+
+	if (irq_get_level(irq) != 1) {
+		level1_irq = irq_parent_level_2(irq);
+	}
+
+	arm_irq_priority_set(level1_irq, prio, flags);
+}
+#endif
 
 static void irqsteer_isr_dispatcher(const void *data)
 {

--- a/drivers/interrupt_controller/intc_nxp_irqsteer.c
+++ b/drivers/interrupt_controller/intc_nxp_irqsteer.c
@@ -307,7 +307,7 @@ static int to_zephyr_irq(uint32_t regmap, uint32_t irq,
 {
 	int i, idx;
 
-	idx = irq;
+	idx = irq - FSL_FEATURE_IRQSTEER_IRQ_START_INDEX;
 
 	for (i = dispatcher->master_index - 1; i >= 0; i--) {
 		idx -= IRQSTEER_GetMasterIrqCount(UINT_TO_IRQSTEER(regmap), i);
@@ -325,10 +325,10 @@ static int to_system_irq(uint32_t regmap, int irq, int master_index)
 		irq += IRQSTEER_GetMasterIrqCount(UINT_TO_IRQSTEER(regmap), i);
 	}
 
-	return irq;
+	return irq + FSL_FEATURE_IRQSTEER_IRQ_START_INDEX;
 }
 
-/* used to convert zephyr INTID to system INTID */
+/* used to convert zephyr INTID (level 2) to system INTID */
 static int from_zephyr_irq(uint32_t regmap, uint32_t irq, uint32_t master_index)
 {
 	int i, idx;
@@ -339,7 +339,7 @@ static int from_zephyr_irq(uint32_t regmap, uint32_t irq, uint32_t master_index)
 		idx += IRQSTEER_GetMasterIrqCount(UINT_TO_IRQSTEER(regmap), i);
 	}
 
-	return idx;
+	return idx + FSL_FEATURE_IRQSTEER_IRQ_START_INDEX;
 }
 
 static void _irqstr_disp_enable_disable(struct irqsteer_dispatcher *disp,

--- a/include/zephyr/arch/arm/irq.h
+++ b/include/zephyr/arch/arm/irq.h
@@ -35,20 +35,23 @@ GTEXT(z_soc_irq_eoi)
 #else
 
 #if !defined(CONFIG_ARM_CUSTOM_INTERRUPT_CONTROLLER)
+extern void arm_irq_enable(unsigned int irq);
+extern void arm_irq_disable(unsigned int irq);
+extern int arm_irq_is_enabled(unsigned int irq);
+extern void arm_irq_priority_set(unsigned int irq, unsigned int prio, uint32_t flags);
+#if !defined(CONFIG_MULTI_LEVEL_INTERRUPTS)
+#define arch_irq_enable(irq)                     arm_irq_enable(irq)
+#define arch_irq_disable(irq)                    arm_irq_disable(irq)
+#define arch_irq_is_enabled(irq)                 arm_irq_is_enabled(irq)
+#define z_arm_irq_priority_set(irq, prio, flags) arm_irq_priority_set(irq, prio, flags)
+#endif
+#endif
 
-extern void arch_irq_enable(unsigned int irq);
-extern void arch_irq_disable(unsigned int irq);
-extern int arch_irq_is_enabled(unsigned int irq);
-
-/* internal routine documented in C file, needed by IRQ_CONNECT() macro */
-extern void z_arm_irq_priority_set(unsigned int irq, unsigned int prio,
-				   uint32_t flags);
-
-#else
-
+#if defined(CONFIG_ARM_CUSTOM_INTERRUPT_CONTROLLER) || defined(CONFIG_MULTI_LEVEL_INTERRUPTS)
 /*
- * When a custom interrupt controller is specified, map the architecture
- * interrupt control functions to the SoC layer interrupt control functions.
+ * When a custom interrupt controller or multi-level interrupts is specified,
+ * map the architecture interrupt control functions to the SoC layer interrupt
+ * control functions.
  */
 
 void z_soc_irq_init(void);
@@ -69,7 +72,7 @@ void z_soc_irq_eoi(unsigned int irq);
 #define z_arm_irq_priority_set(irq, prio, flags)	\
 	z_soc_irq_priority_set(irq, prio, flags)
 
-#endif /* !CONFIG_ARM_CUSTOM_INTERRUPT_CONTROLLER */
+#endif
 
 extern void z_arm_int_exit(void);
 


### PR DESCRIPTION
This PR is to add ARM arch support for NXP IRQSTEER.
Verified on i.MX95 M7.