### PR TITLE
llext: add debugging support

### DIFF
--- a/cmake/bintools/bintools_template.cmake
+++ b/cmake/bintools/bintools_template.cmake
@@ -66,6 +66,7 @@
 #   elfconvert_flag_final         : Flags that must always be applied last at the elfconvert command
 #   elfconvert_flag_strip_all     : Flag that is used for stripping all symbols when converting
 #   elfconvert_flag_strip_debug   : Flag that is used to strip debug symbols when converting
+#   elfconvert_flag_strip_unneeded: Flag that is used to strip all unreferenced symbols when converting
 #   elfconvert_flag_compress_debug_sections: Flag that is used to compress debug sections when converting
 #   elfconvert_flag_intarget      : Flag for specifying target used for infile
 #   elfconvert_flag_outtarget     : Flag for specifying target to use for converted file.
@@ -142,6 +143,8 @@ set_property(TARGET bintools PROPERTY elfconvert_command ${CMAKE_COMMAND} -E ech
 set_property(TARGET bintools PROPERTY elfconvert_formats "")
 set_property(TARGET bintools PROPERTY elfconvert_flag "")
 set_property(TARGET bintools PROPERTY elfconvert_flag_final "")
+set_property(TARGET bintools PROPERTY elfconvert_flag_strip_debug "")
+set_property(TARGET bintools PROPERTY elfconvert_flag_strip_unneeded "")
 set_property(TARGET bintools PROPERTY elfconvert_flag_compress_debug_sections "")
 set_property(TARGET bintools PROPERTY elfconvert_flag_outtarget "")
 set_property(TARGET bintools PROPERTY elfconvert_flag_section_remove "")

--- a/cmake/bintools/gnu/target_bintools.cmake
+++ b/cmake/bintools/gnu/target_bintools.cmake
@@ -7,6 +7,7 @@
 #   elfconvert_flag_final         : empty
 #   elfconvert_flag_strip_all     : -S
 #   elfconvert_flag_strip_debug   : -g
+#   elfconvert_flag_strip_unneeded: --strip-unneeded
 #   elfconvert_flag_compress_debug_sections: --compress-debug-sections
 #   elfconvert_flag_intarget      : --input-target=
 #   elfconvert_flag_outtarget     : --output-target=
@@ -34,6 +35,7 @@ set_property(TARGET bintools PROPERTY elfconvert_flag_final "")
 
 set_property(TARGET bintools PROPERTY elfconvert_flag_strip_all "-S")
 set_property(TARGET bintools PROPERTY elfconvert_flag_strip_debug "-g")
+set_property(TARGET bintools PROPERTY elfconvert_flag_strip_unneeded "--strip-unneeded")
 
 set_property(TARGET bintools PROPERTY elfconvert_flag_compress_debug_sections "--compress-debug-sections")
 

--- a/cmake/bintools/llvm/target_bintools.cmake
+++ b/cmake/bintools/llvm/target_bintools.cmake
@@ -7,6 +7,7 @@
 #   elfconvert_flag_final         : empty
 #   elfconvert_flag_strip_all     : -S
 #   elfconvert_flag_strip_debug   : -g
+#   elfconvert_flag_strip_unneeded: --strip-unneeded
 #   elfconvert_flag_compress_debug_sections: --compress-debug-sections
 #   elfconvert_flag_intarget      : --input-target=
 #   elfconvert_flag_outtarget     : --output-target=
@@ -34,6 +35,7 @@ set_property(TARGET bintools PROPERTY elfconvert_flag_final "")
 
 set_property(TARGET bintools PROPERTY elfconvert_flag_strip_all "-S")
 set_property(TARGET bintools PROPERTY elfconvert_flag_strip_debug "-g")
+set_property(TARGET bintools PROPERTY elfconvert_flag_strip_unneeded "--strip-unneeded")
 
 set_property(TARGET bintools PROPERTY elfconvert_flag_compress_debug_sections "--compress-debug-sections")
 

--- a/cmake/compiler/gcc/target_arc.cmake
+++ b/cmake/compiler/gcc/target_arc.cmake
@@ -15,7 +15,6 @@ set(LLEXT_REMOVE_FLAGS
   -fno-pie
   -ffunction-sections
   -fdata-sections
-  -g.*
   -Os
 )
 

--- a/cmake/compiler/gcc/target_arm.cmake
+++ b/cmake/compiler/gcc/target_arm.cmake
@@ -54,7 +54,6 @@ set(LLEXT_REMOVE_FLAGS
   -fno-pie
   -ffunction-sections
   -fdata-sections
-  -g.*
   -Os
 )
 
@@ -67,8 +66,9 @@ set(LLEXT_APPEND_FLAGS
 list(APPEND LLEXT_EDK_REMOVE_FLAGS
     --sysroot=.*
     -fmacro-prefix-map=.*
-    )
+    -g.*
+)
 
 list(APPEND LLEXT_EDK_APPEND_FLAGS
     -nodefaultlibs
-    )
+)

--- a/cmake/compiler/gcc/target_arm64.cmake
+++ b/cmake/compiler/gcc/target_arm64.cmake
@@ -22,13 +22,13 @@ set(LLEXT_REMOVE_FLAGS
   -fno-pie
   -ffunction-sections
   -fdata-sections
-  -g.*
   -Os
 )
 
 list(APPEND LLEXT_EDK_REMOVE_FLAGS
   --sysroot=.*
   -fmacro-prefix-map=.*
+  -g.*
 )
 
 list(APPEND LLEXT_EDK_APPEND_FLAGS

--- a/cmake/compiler/gcc/target_xtensa.cmake
+++ b/cmake/compiler/gcc/target_xtensa.cmake
@@ -5,7 +5,6 @@
 set(LLEXT_REMOVE_FLAGS
   -ffunction-sections
   -fdata-sections
-  -g.*
   -Os
   -mcpu=.*
 )

--- a/cmake/compiler/xt-clang/target.cmake
+++ b/cmake/compiler/xt-clang/target.cmake
@@ -7,7 +7,6 @@ include(${ZEPHYR_BASE}/cmake/compiler/xcc/target.cmake)
 set(LLEXT_REMOVE_FLAGS
   -ffunction-sections
   -fdata-sections
-  -g.*
   -Os
   -mcpu=.*
 )

--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -5652,6 +5652,7 @@ function(add_llext_target target_name)
     target_link_options(${llext_lib_target} PRIVATE
       $<TARGET_PROPERTY:linker,partial_linking>)
     set_target_properties(${llext_lib_target} PROPERTIES
+      RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/llext
       SUFFIX ${CMAKE_C_OUTPUT_EXTENSION})
     set(llext_lib_output $<TARGET_FILE:${llext_lib_target}>)
 
@@ -5664,6 +5665,9 @@ function(add_llext_target target_name)
 
     # Create a shared library
     add_library(${llext_lib_target} SHARED ${source_files})
+    set_target_properties(${llext_lib_target} PROPERTIES
+      LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/llext
+    )
     set(llext_lib_output $<TARGET_FILE:${llext_lib_target}>)
 
     # Add the llext flags to the linking step as well
@@ -5692,11 +5696,14 @@ function(add_llext_target target_name)
     zephyr_generated_headers
   )
 
+  # Make sure the intermediate output directory exists.
+  file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/llext)
+
   # Set up an intermediate processing step between compilation and packaging
   # to be used to support POST_BUILD commands on targets that do not use a
   # dynamic library.
   set(llext_proc_target ${target_name}_llext_proc)
-  set(llext_pkg_input ${PROJECT_BINARY_DIR}/${target_name}_debug.elf)
+  set(llext_pkg_input ${PROJECT_BINARY_DIR}/llext/${target_name}_debug.elf)
   add_custom_target(${llext_proc_target} DEPENDS ${llext_pkg_input})
   set_property(TARGET ${llext_proc_target} PROPERTY has_post_build_cmds 0)
 
@@ -5799,7 +5806,7 @@ function(add_llext_command)
   # ARM uses an object file representation so there is no link step.
   if(CONFIG_ARM AND LLEXT_PRE_BUILD)
     message(FATAL_ERROR
-	    "add_llext_command: PRE_BUILD not supported on this arch")
+            "add_llext_command: PRE_BUILD not supported on this arch")
   endif()
 
   # Determine the build step and the target to attach the command to

--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -5696,7 +5696,7 @@ function(add_llext_target target_name)
   # to be used to support POST_BUILD commands on targets that do not use a
   # dynamic library.
   set(llext_proc_target ${target_name}_llext_proc)
-  set(llext_pkg_input ${PROJECT_BINARY_DIR}/${target_name}.llext.pkg_input)
+  set(llext_pkg_input ${PROJECT_BINARY_DIR}/${target_name}_debug.elf)
   add_custom_target(${llext_proc_target} DEPENDS ${llext_pkg_input})
   set_property(TARGET ${llext_proc_target} PROPERTY has_post_build_cmds 0)
 
@@ -5729,49 +5729,19 @@ function(add_llext_target target_name)
     set(slid_inject_cmd ${CMAKE_COMMAND} -E true)
   endif()
 
-  # Type-specific packaging of the built binary file into an .llext file
-  if(CONFIG_LLEXT_TYPE_ELF_OBJECT)
-
-    # No packaging required, simply copy the object file
-    add_custom_command(
-      OUTPUT ${llext_pkg_output}
-      COMMAND ${CMAKE_COMMAND} -E copy ${llext_pkg_input} ${llext_pkg_output}
-      COMMAND ${slid_inject_cmd}
-      DEPENDS ${llext_proc_target} ${llext_pkg_input}
-    )
-
-  elseif(CONFIG_LLEXT_TYPE_ELF_RELOCATABLE)
-
-    # Need to remove just some sections from the relocatable object
-    # (using strip in this case would remove _all_ symbols)
-    add_custom_command(
-      OUTPUT ${llext_pkg_output}
-      COMMAND $<TARGET_PROPERTY:bintools,elfconvert_command>
-              $<TARGET_PROPERTY:bintools,elfconvert_flag>
-              $<TARGET_PROPERTY:bintools,elfconvert_flag_section_remove>.xt.*
-              $<TARGET_PROPERTY:bintools,elfconvert_flag_infile>${llext_pkg_input}
-              $<TARGET_PROPERTY:bintools,elfconvert_flag_outfile>${llext_pkg_output}
-              $<TARGET_PROPERTY:bintools,elfconvert_flag_final>
-      COMMAND ${slid_inject_cmd}
-      DEPENDS ${llext_proc_target} ${llext_pkg_input}
-    )
-
-  elseif(CONFIG_LLEXT_TYPE_ELF_SHAREDLIB)
-
-    # Need to strip the shared library of some sections
-    add_custom_command(
-      OUTPUT ${llext_pkg_output}
-      COMMAND $<TARGET_PROPERTY:bintools,strip_command>
-              $<TARGET_PROPERTY:bintools,strip_flag>
-              $<TARGET_PROPERTY:bintools,strip_flag_remove_section>.xt.*
-              $<TARGET_PROPERTY:bintools,strip_flag_infile>${llext_pkg_input}
-              $<TARGET_PROPERTY:bintools,strip_flag_outfile>${llext_pkg_output}
-              $<TARGET_PROPERTY:bintools,strip_flag_final>
-      COMMAND ${slid_inject_cmd}
-      DEPENDS ${llext_proc_target} ${llext_pkg_input}
-    )
-
-  endif()
+  # Remove sections that are unused by the llext loader
+  add_custom_command(
+    OUTPUT ${llext_pkg_output}
+    COMMAND $<TARGET_PROPERTY:bintools,elfconvert_command>
+            $<TARGET_PROPERTY:bintools,elfconvert_flag>
+            $<TARGET_PROPERTY:bintools,elfconvert_flag_strip_unneeded>
+            $<TARGET_PROPERTY:bintools,elfconvert_flag_section_remove>.xt.*
+            $<TARGET_PROPERTY:bintools,elfconvert_flag_infile>${llext_pkg_input}
+            $<TARGET_PROPERTY:bintools,elfconvert_flag_outfile>${llext_pkg_output}
+            $<TARGET_PROPERTY:bintools,elfconvert_flag_final>
+    COMMAND ${slid_inject_cmd}
+    DEPENDS ${llext_proc_target} ${llext_pkg_input}
+  )
 
   # Add user-visible target and dependency, and fill in properties
   get_filename_component(output_name ${llext_pkg_output} NAME)

--- a/doc/services/llext/debug.rst
+++ b/doc/services/llext/debug.rst
@@ -1,0 +1,359 @@
+.. _llext_debug:
+
+Debugging extensions
+####################
+
+Debugging extensions is a complex task. Since the extension code is by
+definition not built with the Zephyr application, the final Zephyr ELF file
+does not contain the symbols for extension code. Furthermore, the extension is
+dynamically relocated by :c:func:`llext_load` at runtime, so even if the
+symbols were available, it would be impossible for the debugger to know the
+final locations of the symbols in the extension code.
+
+Setting up the debugger session properly in this case requires a few manual
+steps. The following sections will provide some tips on how to do it with the
+Zephyr SDK and the debug features provided by ``west``, but the instructions
+can be adapted to any GDB-based debugging environment.
+
+Extension debugging process
+===========================
+
+1. Make sure the project is set up to display the verbose LLEXT debug output
+   (:kconfig:option:`CONFIG_LOG` and :kconfig:option:`CONFIG_LLEXT_LOG_LEVEL_DBG`
+   are set).
+
+2. Build the Zephyr application and the extensions.
+
+   For each target ``name`` included in the current build, two files will be
+   generated into the ``llext`` subdirectory of the build root:
+
+   ``name_ext_debug.elf``
+
+        An intermediate ELF file with full debugging information.
+
+   ``name.llext``
+
+        The final extension binary, stripped to the essential data required for
+        loading into the Zephyr application.
+
+   Other files may be present, depending on the target architecture and the
+   build configuration.
+
+3. Start a debugging session of the main Zephyr application. This is described
+   in the :ref:`Debugging <west-debugging>` section of the documentation; on
+   supported boards it is as easy as running ``west debug``, perhaps with some
+   additional arguments.
+
+4. Set a breakpoint just after the :c:func:`llext_load` function in your code
+   and let it run. This will load the extension into memory and relocate it.
+   The output logs will contain a line with ``gdb add-symbol-file flags:``,
+   followed by lines all starting with ``-s``.
+
+5. Type this command in the GDB console to load this extension's symbols:
+
+   .. code-block::
+
+      add-symbol-file <path-to-debug.elf> <load-addresses>
+
+   where ``<path-to-debug.elf>`` is the full path of the ELF file with debug
+   information identified in step 2, and ``<load-addresses>`` is a space
+   separated list of all the ``-s`` lines collected from the log in the
+   previous step.
+
+6. The extension symbols are now available to the debugger. You can set
+   breakpoints, inspect variables, and step through the code as usual.
+
+Steps 4-6 can be repeated for every extension that is loaded by the
+application, if there are several.
+
+Symbol lookup issues
+====================
+
+.. warning::
+
+   It is almost certain that the loaded symbols will be shadowed by others in
+   the main application; for example, they may be located inside the memory
+   area of the ELF buffer or the LLEXT heap.
+
+   In this case GDB chooses the first known symbol and therefore associates the
+   addresses to some ``elf_buffer+0x123`` instead of an expected ``ext_fn``.
+   This further confuses its high-level operations like source stepping or
+   inspecting locals, since they are meaningless in that context.
+
+Two possible solutions to this problem are discussed in the following
+paragraphs.
+
+Discard all Zephyr symbols
+--------------------------
+
+The simplest option is to drop all the Zephyr application symbols from GDB by
+invoking ``add-symbol-file`` with no arguments, before step 5. This will
+however focus the debugging session to the llext only, as all information about
+the Zephyr application will be lost. For example, the debugger may not be able to
+properly follow stack traces outside the extension code.
+
+It is possible to use the same technique multiple times in the same session to
+switch between the main and extension symbol tables as required, but it rapidly
+becomes cumbersome.
+
+Edit the ELF file
+-----------------
+
+This alternative is more complex but allows for a more seamless debugging
+experience. The idea is to edit the main Zephyr ELF file to remove information
+about the symbols that overlap with the extension that is to be debugged, so
+that when the extension symbols are loaded, GDB will not have any ambiguity.
+This can be done by using ``objcopy`` with the ``-N <symbol>`` option.
+
+Identifying the offending symbols is however an iterative trial-and-error
+procedure, as there can be many different layers; for example, the ELF buffer
+may be itself contained in a symbol for the data segment. Fortunately, this
+knowledge can then be used several times as the list is unlikely to change for
+a given project.
+
+Example debugging session
+=========================
+
+This example demonstrates how to debug the ``detached_fn`` extension in the
+``tests/subsys/llext`` project (specifically, the ``writable`` case), on an
+emulated ``mps2/an385`` board which is based on an ARM Cortex-M3.
+
+.. note::
+
+   The logs below have been obtained using Zephyr version 4.1 and the Zephyr
+   SDK version 0.17.0. However, the exact addresses may still vary between
+   runs even when using the same versions. Adjust the commands below to
+   match the results of your own session.
+
+The following command will build the project and start the emulator in
+debugging mode:
+
+.. code-block::
+   :caption: Terminal 1 (build, QEMU emulator, GDB server)
+
+   zephyr$ west build -p -b mps2/an385 tests/subsys/llext/ -T llext.writable -t debugserver_qemu
+   -- west build: generating a build system
+   [...]
+   -- west build: running target debugserver_qemu
+   [...]
+   [186/187] To exit from QEMU enter: 'CTRL+a, x'[QEMU] CPU: cortex-m3
+
+On a separate terminal, set ``ZEPHYR_SDK_INSTALL_DIR`` to the directory for the
+Zephyr SDK on your installation, then start the GDB client for the target:
+
+.. code-block::
+   :caption: Terminal 2 (GDB client)
+
+   zephyr$ export LLEXT_SDK_INSTALL_DIR=/opt/zephyr-sdk-0.17.0
+   zephyr$ ${LLEXT_SDK_INSTALL_DIR}/arm-zephyr-eabi/bin/arm-zephyr-eabi-gdb build/zephyr/zephyr.elf
+   GNU gdb (Zephyr SDK 0.17.0) 12.1
+   [...]
+   Reading symbols from build/zephyr/zephyr.elf...
+   (gdb)
+
+Connect, set a breakpoint on the ``llext_load`` function and run until it
+finishes:
+
+.. code-block::
+   :caption: Terminal 2 (GDB client)
+
+   (gdb) target extended-remote :1234
+   Remote debugging using :1234
+   z_arm_reset () at zephyr/arch/arm/core/cortex_m/reset.S:124
+   124         movs.n r0, #_EXC_IRQ_DEFAULT_PRIO
+   (gdb) break llext_load
+   Breakpoint 1 at 0x236c: file zephyr/subsys/llext/llext.c, line 168.
+   (gdb) continue
+   Continuing.
+
+   Breakpoint 1, llext_load (ldr=ldr@entry=0x2000bef0 <ztest_thread_stack+3488>,
+                             name=name@entry=0x9d98 "test_detached",
+                             ext=ext@entry=0x2000abb8 <detached_llext>,
+                             ldr_parm=ldr_parm@entry=0x2000bee8 <ztest_thread_stack+3480>)
+                 at zephyr/subsys/llext/llext.c:168
+   168             *ext = llext_by_name(name);
+   (gdb) finish
+   Run till exit from #0  llext_load ([...])
+       at zephyr/subsys/llext/llext.c:168
+   llext_test_detached () at zephyr/tests/subsys/llext/src/test_llext.c:481
+   481             zassert_ok(res, "load should succeed");
+
+The first terminal will have printed lots of debugging information related to
+the extension loading. Find the section with the addresses:
+
+.. code-block::
+   :caption: Terminal 1 (build, QEMU emulator, GDB server)
+
+   [...]
+   D: Allocate and copy regions...
+   [...]
+   D: gdb add-symbol-file flags:
+   D: -s .text 0x20000034
+   D: -s .data 0x200000b4
+   D: -s .bss 0x2000c2e0
+   D: -s .rodata 0x200000b8
+   D: -s .detach 0x200001d0
+   D: Counting exported symbols...
+   [...]
+
+Use these addresses to load the symbols into GDB:
+
+.. code-block::
+   :caption: Terminal 2 (GDB client)
+
+   (gdb) add-symbol-file build/llext/detached_fn_ext_debug.elf -s .text 0x20000034 -s .data 0x200000b4 -s .bss 0x2000c2e0 -s .rodata 0x200000b8 -s .detach 0x200001d0
+   add symbol table from file "build/llext/detached_fn_ext_debug.elf" at
+           .text_addr = 0x20000034
+           .data_addr = 0x200000b4
+           .bss_addr = 0x2000c2e0
+           .rodata_addr = 0x200000b8
+           .detach_addr = 0x200001d0
+   (y or n) y
+   Reading symbols from build/llext/detached_fn_ext_debug.elf...
+   (gdb) break detached_entry
+   Breakpoint 2 at 0x200001d0 (2 locations)
+   (gdb) continue
+   Continuing.
+
+   Breakpoint 2, 0x200001d0 in test_detached_ext ()
+   (gdb) backtrace
+   #0  0x200001d0 in test_detached_ext ()
+   #1  0x200000ac in test_detached_ext ()
+   #2  0x00000706 in llext_test_detached () at zephyr/tests/subsys/llext/src/test_llext.c:496
+   #3  0x00001a36 in run_test_functions (suite=0x92bc <z_ztest_test_node_llext>, data=0x0 <cbvprintf_package>, test=0x92d8 <z_ztest_unit_test.llext.test_detached>) at zephyr/subsys/testsuite/ztest/src/ztest.c:328
+   #4  test_cb (a=0x92bc <z_ztest_test_node_llext>, b=0x92d8 <z_ztest_unit_test.llext.test_detached>, c=0x0 <cbvprintf_package>) at zephyr/subsys/testsuite/ztest/src/ztest.c:662
+   #5  0x00000e96 in z_thread_entry (entry=0x1a05 <test_cb>, p1=0x92bc <z_ztest_test_node_llext>, p2=0x92d8 <z_ztest_unit_test.llext.test_detached>, p3=0x0 <cbvprintf_package>) at zephyr/lib/os/thread_entry.c:48
+   #6  0x00000000 in ?? ()
+
+The symbol associated with the breakpoint location and the last stack frames
+mistakenly reference the ELF buffer in the Zephyr application instead of the
+extension symbols. Note that GDB however knows both:
+
+.. code-block::
+   :caption: Terminal 2 (GDB client)
+
+   (gdb) info sym 0x200001d0
+   test_detached_ext + 464 in section datas of zephyr/build/zephyr/zephyr.elf
+   detached_entry in section .detach of zephyr/build/llext/detached_fn_ext_debug.elf
+   (gdb) info sym 0x200000ac
+   test_detached_ext + 172 in section datas of zephyr/build/zephyr/zephyr.elf
+   test_entry + 8 in section .text of zephyr/build/llext/detached_fn_ext_debug.elf
+
+It is also impossible to inspect the variables in the extension or step through
+code properly:
+
+.. code-block::
+   :caption: Terminal 2 (GDB client)
+
+   (gdb) print bss_cnt
+   No symbol "bss_cnt" in current context.
+   (gdb) print data_cnt
+   No symbol "data_cnt" in current context.
+   (gdb) next
+   Single stepping until exit from function test_detached_ext,
+   which has no line number information.
+
+   Breakpoint 2, 0x200001ea in test_detached_ext ()
+   (gdb)
+
+Discarding symbols
+------------------
+
+Discarding the Zephyr symbols and only focusing on the extension restores full
+debugging functionality at the cost of losing the global context (note the
+backtrace stops outside the extension):
+
+.. code-block::
+   :caption: Terminal 2 (GDB client)
+
+   (gdb) symbol-file
+   Discard symbol table from `zephyr/build/zephyr/zephyr.elf'? (y or n) y
+   Error in re-setting breakpoint 1: No symbol table is loaded.  Use the "file" command.
+   No symbol file now.
+   (gdb) add-symbol-file build/llext/detached_fn_ext_debug.elf -s .text 0x20000034 -s .data 0x200000b4 -s .bss 0x2000c2e0 -s .rodata 0x200000b8 -s .detach 0x200001d0
+   add symbol table from file "build/llext/detached_fn_ext_debug.elf" at
+           .text_addr = 0x20000034
+           .data_addr = 0x200000b4
+           .bss_addr = 0x2000c2e0
+           .rodata_addr = 0x200000b8
+           .detach_addr = 0x200001d0
+   (y or n) y
+   Reading symbols from build/llext/detached_fn_ext_debug.elf...
+   (gdb) backtrace
+   #0  detached_entry () at zephyr/tests/subsys/llext/src/detached_fn_ext.c:18
+   #1  0x200000ac in test_entry () at zephyr/tests/subsys/llext/src/detached_fn_ext.c:26
+   #2  0x00000706 in ?? ()
+   Backtrace stopped: previous frame identical to this frame (corrupt stack?)
+   (gdb) next
+   19              zassert_true(data_cnt < 0);
+   (gdb) print bss_cnt
+   $1 = 1
+   (gdb) print data_cnt
+   $2 = -2
+   (gdb)
+
+
+Editing the ELF file
+--------------------
+
+In this alternative approach, the patches to the Zephyr ELF file must be
+performed after building the Zephyr binary and starting the emulator on
+Terminal 1, but before starting the GDB client on Terminal 2.
+
+The above debugging session already identified ``test_detached_ext``, the char
+array that holds the ELF file, as an offending symbol, so that will be removed
+in a first pass. Performing the same steps multiple times, ``__data_start`` and
+``__data_region_start`` can also be found to overlap the memory area of
+interest.
+
+The following commands will remove all of these from the Zephyr ELF file, then
+start a debugging session on the modified file:
+
+.. code-block::
+   :caption: Terminal 2 (GDB client)
+
+   zephyr$ export LLEXT_SDK_INSTALL_DIR=/opt/zephyr-sdk-0.17.0
+   zephyr$ ${LLEXT_SDK_INSTALL_DIR}/arm-zephyr-eabi/bin/arm-zephyr-eabi-objcopy -N test_detached_ext -N __data_start -N __data_region_start build/zephyr/zephyr.elf build/zephyr/zephyr-edit.elf
+   zephyr$ ${LLEXT_SDK_INSTALL_DIR}/arm-zephyr-eabi/bin/arm-zephyr-eabi-gdb build/zephyr/zephyr-edit.elf
+   GNU gdb (Zephyr SDK 0.17.0) 12.1
+   [...]
+   Reading symbols from build/zephyr/zephyr-edit.elf...
+   (gdb)
+
+The same steps used in the previous run can be performed again to attach to the
+GDB server and load both the extension and its debug symbols. This time, however,
+the result is rather different:
+
+ * the ``break`` command includes line number information;
+
+ * the output from ``backtrace`` contains functions from both the extension and
+   the Zephyr application;
+
+ * the local variables can be properly inspected.
+
+.. code-block::
+   :caption: Terminal 2 (GDB client)
+
+   (gdb) add-symbol-file build/llext/detached_fn_ext_debug.elf [...]
+   [...]
+   Reading symbols from build/llext/detached_fn_ext_debug.elf...
+   (gdb) break detached_entry
+   Breakpoint 2 at 0x200001d6: file zephyr/tests/subsys/llext/src/detached_fn_ext.c, line 17.
+   (gdb) continue
+   Continuing.
+
+   Breakpoint 2, detached_entry () at zephyr/tests/subsys/llext/src/detached_fn_ext.c:17
+   17              printk("bss %u @ %p\n", bss_cnt++, &bss_cnt);
+   (gdb) backtrace
+   #0  detached_entry () at zephyr/tests/subsys/llext/src/detached_fn_ext.c:17
+   #1  0x200000ac in test_entry () at zephyr/tests/subsys/llext/src/detached_fn_ext.c:26
+   #2  0x00000706 in llext_test_detached () at zephyr/tests/subsys/llext/src/test_llext.c:496
+   #3  0x00001a36 in run_test_functions (suite=0x92bc <z_ztest_test_node_llext>, data=0x0 <cbvprintf_package>, test=0x92d8 <z_ztest_unit_test.llext.test_detached>) at zephyr/subsys/testsuite/ztest/src/ztest.c:328
+   #4  test_cb (a=0x92bc <z_ztest_test_node_llext>, b=0x92d8 <z_ztest_unit_test.llext.test_detached>, c=0x0 <cbvprintf_package>) at zephyr/subsys/testsuite/ztest/src/ztest.c:662
+   #5  0x00000e96 in z_thread_entry (entry=0x1a05 <test_cb>, p1=0x92bc <z_ztest_test_node_llext>, p2=0x92d8 <z_ztest_unit_test.llext.test_detached>, p3=0x0 <cbvprintf_package>) at zephyr/lib/os/thread_entry.c:48
+   #6  0x00000000 in ?? ()
+   (gdb) print bss_cnt
+   $1 = 0
+   (gdb) print data_cnt
+   $2 = -3
+   (gdb)

--- a/doc/services/llext/index.rst
+++ b/doc/services/llext/index.rst
@@ -16,6 +16,7 @@ and introspected to some degree, as well as unloaded when no longer needed.
    config
    build
    load
+   debug
    api
 
 .. note::

--- a/doc/services/llext/load.rst
+++ b/doc/services/llext/load.rst
@@ -94,13 +94,7 @@ If any of this happens, the following tips may help understand the issue:
   the issue.
 
 * Use a debugger to inspect the memory and registers to try to understand what
-  is happening.
-
-  .. note::
-     When using GDB, the ``add_symbol_file`` command may be used to load the
-     debugging information and symbols from the ELF file. Make sure to specify
-     the proper offset (usually the start of the ``.text`` section, reported
-     as ``region 0`` in the debug logs.)
+  is happening. See :ref:`Debugging extensions <llext_debug>` for more details.
 
 If the issue persists, please open an issue in the GitHub repository, including
 all the above information.

--- a/samples/subsys/llext/modules/CMakeLists.txt
+++ b/samples/subsys/llext/modules/CMakeLists.txt
@@ -11,7 +11,7 @@ if(CONFIG_HELLO_WORLD_MODE STREQUAL "m")
 
   set(ext_name hello_world)
   set(ext_src src/${ext_name}_ext.c)
-  set(ext_bin ${ZEPHYR_BINARY_DIR}/${ext_name}.llext)
+  set(ext_bin ${PROJECT_BINARY_DIR}/llext/${ext_name}.llext)
   set(ext_inc ${ZEPHYR_BINARY_DIR}/include/generated/${ext_name}_ext.inc)
   add_llext_target(${ext_name}_ext
     OUTPUT  ${ext_bin}

--- a/subsys/llext/llext_link.c
+++ b/subsys/llext/llext_link.c
@@ -345,6 +345,11 @@ int llext_link(struct llext_loader *ldr, struct llext *ext, const struct llext_l
 			continue;
 		}
 
+		if (!(ext->sect_hdrs[shdr->sh_info].sh_flags & SHF_ALLOC)) {
+			/* ignore relocations acting on volatile (debug) sections */
+			continue;
+		}
+
 		LOG_DBG("relocation section %s (%d) acting on section %d has %zd relocations",
 			name, i, shdr->sh_info, (size_t)rel_cnt);
 

--- a/subsys/llext/llext_load.c
+++ b/subsys/llext/llext_load.c
@@ -152,6 +152,8 @@ static int llext_load_elf_data(struct llext_loader *ldr, struct llext *ext)
 static int llext_find_tables(struct llext_loader *ldr, struct llext *ext)
 {
 	int table_cnt, i;
+	int shstrtab_ndx = ldr->hdr.e_shstrndx;
+	int strtab_ndx = -1;
 
 	memset(ldr->sects, 0, sizeof(ldr->sects));
 
@@ -171,28 +173,28 @@ static int llext_find_tables(struct llext_loader *ldr, struct llext *ext)
 			shdr->sh_link,
 			shdr->sh_info);
 
-		switch (shdr->sh_type) {
-		case SHT_SYMTAB:
-		case SHT_DYNSYM:
+		if (shdr->sh_type == SHT_SYMTAB && ldr->hdr.e_type == ET_REL) {
 			LOG_DBG("symtab at %d", i);
 			ldr->sects[LLEXT_MEM_SYMTAB] = *shdr;
 			ldr->sect_map[i].mem_idx = LLEXT_MEM_SYMTAB;
+			strtab_ndx = shdr->sh_link;
 			table_cnt++;
-			break;
-		case SHT_STRTAB:
-			if (ldr->hdr.e_shstrndx == i) {
-				LOG_DBG("shstrtab at %d", i);
-				ldr->sects[LLEXT_MEM_SHSTRTAB] = *shdr;
-				ldr->sect_map[i].mem_idx = LLEXT_MEM_SHSTRTAB;
-			} else {
-				LOG_DBG("strtab at %d", i);
-				ldr->sects[LLEXT_MEM_STRTAB] = *shdr;
-				ldr->sect_map[i].mem_idx = LLEXT_MEM_STRTAB;
-			}
+		} else if (shdr->sh_type == SHT_DYNSYM && ldr->hdr.e_type == ET_DYN) {
+			LOG_DBG("dynsym at %d", i);
+			ldr->sects[LLEXT_MEM_SYMTAB] = *shdr;
+			ldr->sect_map[i].mem_idx = LLEXT_MEM_SYMTAB;
+			strtab_ndx = shdr->sh_link;
 			table_cnt++;
-			break;
-		default:
-			break;
+		} else if (shdr->sh_type == SHT_STRTAB && i == shstrtab_ndx) {
+			LOG_DBG("shstrtab at %d", i);
+			ldr->sects[LLEXT_MEM_SHSTRTAB] = *shdr;
+			ldr->sect_map[i].mem_idx = LLEXT_MEM_SHSTRTAB;
+			table_cnt++;
+		} else if (shdr->sh_type == SHT_STRTAB && i == strtab_ndx) {
+			LOG_DBG("strtab at %d", i);
+			ldr->sects[LLEXT_MEM_STRTAB] = *shdr;
+			ldr->sect_map[i].mem_idx = LLEXT_MEM_STRTAB;
+			table_cnt++;
 		}
 	}
 
@@ -395,9 +397,10 @@ static int llext_map_sections(struct llext_loader *ldr, struct llext *ext,
 				continue;
 			}
 
-			if (ldr->hdr.e_type == ET_DYN) {
+			if ((ldr->hdr.e_type == ET_DYN) &&
+			    (x->sh_flags & SHF_ALLOC) && (y->sh_flags & SHF_ALLOC)) {
 				/*
-				 * Test all merged VMA ranges for overlaps
+				 * Test regions that have VMA ranges for overlaps
 				 */
 				if ((x->sh_addr <= y->sh_addr &&
 				     x->sh_addr + x->sh_size > y->sh_addr) ||

--- a/subsys/llext/llext_mem.c
+++ b/subsys/llext/llext_mem.c
@@ -170,6 +170,22 @@ int llext_copy_regions(struct llext_loader *ldr, struct llext *ext,
 		}
 	}
 
+	if (IS_ENABLED(CONFIG_LLEXT_LOG_LEVEL_DBG)) {
+		LOG_DBG("gdb add-symbol-file flags:");
+		for (int i = 0; i < ext->sect_cnt; ++i) {
+			elf_shdr_t *shdr = ext->sect_hdrs + i;
+			enum llext_mem mem_idx = ldr->sect_map[i].mem_idx;
+			const char *name = llext_string(ldr, ext, LLEXT_MEM_SHSTRTAB,
+							shdr->sh_name);
+
+			/* only show sections mapped to program memory */
+			if (mem_idx < LLEXT_MEM_EXPORT) {
+				LOG_DBG("-s %s 0x%zx", name,
+					(size_t)ext->mem[mem_idx] + ldr->sect_map[i].offset);
+			}
+		}
+	}
+
 	return 0;
 }
 

--- a/tests/subsys/llext/CMakeLists.txt
+++ b/tests/subsys/llext/CMakeLists.txt
@@ -45,10 +45,10 @@ if (NOT CONFIG_LLEXT_TYPE_ELF_SHAREDLIB)
     list(APPEND ext_names init_fini)
 endif()
 
-# generate extension targets foreach extension given by 'ext_names'
+# generate extension targets for each extension in 'ext_names'
 foreach(ext_name ${ext_names})
   set(ext_src ${PROJECT_SOURCE_DIR}/src/${ext_name}_ext.c)
-  set(ext_bin ${ZEPHYR_BINARY_DIR}/${ext_name}.llext)
+  set(ext_bin ${PROJECT_BINARY_DIR}/llext/${ext_name}.llext)
   set(ext_inc ${ZEPHYR_BINARY_DIR}/include/generated/${ext_name}.inc)
   add_llext_target(${ext_name}_ext
     OUTPUT  ${ext_bin}
@@ -59,10 +59,10 @@ endforeach()
 
 if(NOT CONFIG_LLEXT_TYPE_ELF_OBJECT)
   add_llext_target(multi_file_ext
-    OUTPUT  ${ZEPHYR_BINARY_DIR}/multi_file.llext
+    OUTPUT  ${PROJECT_BINARY_DIR}/llext/multi_file.llext
     SOURCES ${PROJECT_SOURCE_DIR}/src/multi_file_ext1.c ${PROJECT_SOURCE_DIR}/src/multi_file_ext2.c
   )
-  generate_inc_file_for_target(app ${ZEPHYR_BINARY_DIR}/multi_file.llext
+  generate_inc_file_for_target(app ${PROJECT_BINARY_DIR}/llext/multi_file.llext
     ${ZEPHYR_BINARY_DIR}/include/generated/multi_file.inc
   )
 endif()
@@ -82,10 +82,10 @@ endif()
 
 if(NOT CONFIG_LLEXT_TYPE_ELF_OBJECT AND CONFIG_RISCV AND CONFIG_RISCV_ISA_EXT_C)
   add_llext_target(riscv_edge_case_cb_type_ext
-    OUTPUT  ${ZEPHYR_BINARY_DIR}/riscv_edge_case_cb_type_ext.llext
+    OUTPUT  ${PROJECT_BINARY_DIR}/llext/riscv_edge_case_cb_type_ext.llext
     SOURCES ${PROJECT_SOURCE_DIR}/src/riscv_edge_case_cb_type.c ${PROJECT_SOURCE_DIR}/src/riscv_edge_case_cb_type_trigger.S
   )
-  generate_inc_file_for_target(app ${ZEPHYR_BINARY_DIR}/riscv_edge_case_cb_type_ext.llext
+  generate_inc_file_for_target(app ${PROJECT_BINARY_DIR}/llext/riscv_edge_case_cb_type_ext.llext
     ${ZEPHYR_BINARY_DIR}/include/generated/riscv_edge_case_cb_type.inc
   )
 endif()


### PR DESCRIPTION
Extensions have always been built without debug symbols to simplify the LLEXT loading process, but this complicates analyzing runtime issues in the loaded code. This PR aims to ease the debugging of a loaded extension in several ways:

* The LLEXT CMake tooling now **builds all extensions with debug symbols**, and then strips them in the packaging step. The packaging input file in the build directory is now renamed to `<name>_ext_debug.elf` to clearly state its intended use.

* When the LLEXT debug log is enabled, **`llext_load()` prints a table with the final addresses of all program sections** in a format that is compatible with the GDB `add-symbol-file` command. On a running debugging session, adding these options will enable GDB to properly resolve all defined symbols.
  
* With a few minor scattered cleanups, LLEXT can now **load ELF files that include debugging information** (even though the extra data is useless and silently ignored).

* Added a **documentation page** explaining [how debugging extensions works](https://builds.zephyrproject.io/zephyr/pr/84019/docs/services/llext/debug.html) with an annotated debug session.

Debugging flags are still stripped from the set of flags exposed by the EDK, for compatibility with current code. Now that LLEXT supports it, it should be trivial to provide this functionality in downstream build systems if desired.