### PR TITLE
include: util: Add generic function to count bits set in a value

### DIFF
--- a/doc/releases/release-notes-4.2.rst
+++ b/doc/releases/release-notes-4.2.rst
@@ -98,6 +98,10 @@ New APIs and options
 
     * LE Connection Subrating is no longer experimental.
 
+* Other
+
+  * :c:func:`count_bits`
+
 New Boards
 **********
 

--- a/include/zephyr/sys/util.h
+++ b/include/zephyr/sys/util.h
@@ -783,6 +783,34 @@ static inline void mem_xor_128(uint8_t dst[16], const uint8_t src1[16], const ui
 	mem_xor_n(dst, src1, src2, 16);
 }
 
+/**
+ * @brief Returns the number of bits set in a value
+ *
+ * @param value The value to count number of bits set of
+ * @param len The number of octets in @p value
+ */
+static inline size_t count_bits(const void *value, size_t len)
+{
+	const uint8_t *value_u8 = (const uint8_t *)value;
+	size_t cnt = 0U;
+
+	for (size_t i = 0U; i < len; i++) {
+		if (value_u8[i] != 0U) {
+#ifdef POPCOUNT
+			cnt += POPCOUNT(value_u8[i]);
+#else
+			/* Implements Brian Kernighan’s Algorithm to count bits */
+			while (value_u8[i]) {
+				cnt += value_u8[i] & 1;
+				value_u8[i] >>= 1;
+			}
+#endif
+		}
+	}
+
+	return cnt;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/samples/bluetooth/cap_acceptor/src/cap_acceptor_broadcast.c
+++ b/samples/bluetooth/cap_acceptor/src/cap_acceptor_broadcast.c
@@ -1,7 +1,7 @@
 /** @file
  *  @brief Bluetooth Common Audio Profile (CAP) Acceptor broadcast.
  *
- *  Copyright (c) 2024 Nordic Semiconductor ASA
+ *  Copyright (c) 2024-2025 Nordic Semiconductor ASA
  *
  *  SPDX-License-Identifier: Apache-2.0
  */
@@ -459,7 +459,8 @@ static int bis_sync_req_cb(struct bt_conn *conn,
 
 	LOG_INF("BIS sync request received for %p: 0x%08x", recv_state, bis_sync_req[0]);
 
-	if (new_bis_sync_req != BT_BAP_BIS_SYNC_NO_PREF && POPCOUNT(new_bis_sync_req) > 1U) {
+	if (new_bis_sync_req != BT_BAP_BIS_SYNC_NO_PREF &&
+	    count_bits(&new_bis_sync_req, sizeof(new_bis_sync_req)) > 1U) {
 		LOG_WRN("Rejecting BIS sync request for 0x%08X as we do not support that",
 			new_bis_sync_req);
 

--- a/subsys/bluetooth/audio/audio.c
+++ b/subsys/bluetooth/audio/audio.c
@@ -2,6 +2,7 @@
 
 /*
  * Copyright (c) 2022 Codecoup
+ * Copyright (c) 2025 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -23,6 +24,7 @@
 #include <zephyr/bluetooth/hci_types.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/check.h>
+#include <zephyr/sys/util.h>
 #include <zephyr/toolchain.h>
 
 #include "audio_internal.h"
@@ -146,18 +148,7 @@ uint8_t bt_audio_get_chan_count(enum bt_audio_location chan_allocation)
 		return 1;
 	}
 
-#ifdef POPCOUNT
-	return POPCOUNT(chan_allocation);
-#else
-	uint8_t cnt = 0U;
-
-	while (chan_allocation != 0U) {
-		cnt += chan_allocation & 1U;
-		chan_allocation >>= 1U;
-	}
-
-	return cnt;
-#endif
+	return count_bits(&chan_allocation, sizeof(chan_allocation));
 }
 
 static bool valid_ltv_cb(struct bt_data *data, void *user_data)

--- a/subsys/bluetooth/audio/bap_broadcast_sink.c
+++ b/subsys/bluetooth/audio/bap_broadcast_sink.c
@@ -1071,22 +1071,6 @@ int bt_bap_broadcast_sink_create(struct bt_le_per_adv_sync *pa_sync, uint32_t br
 	return 0;
 }
 
-static uint8_t bit_count(uint32_t bitfield)
-{
-#ifdef POPCOUNT
-	return POPCOUNT(bitfield);
-#else
-	uint8_t cnt = 0U;
-
-	while (bitfield != 0U) {
-		cnt += bitfield & 1U;
-		bitfield >>= 1U;
-	}
-
-	return cnt;
-#endif
-}
-
 struct sync_base_info_data {
 	struct bt_audio_codec_cfg codec_cfgs[CONFIG_BT_BAP_BROADCAST_SNK_STREAM_COUNT];
 	struct bt_audio_codec_cfg *subgroup_codec_cfg;
@@ -1271,7 +1255,7 @@ int bt_bap_broadcast_sink_sync(struct bt_bap_broadcast_sink *sink, uint32_t inde
 	}
 
 	/* Validate that number of bits set is within supported range */
-	bis_count = bit_count(indexes_bitfield);
+	bis_count = count_bits(&indexes_bitfield, sizeof(indexes_bitfield));
 	if (bis_count > CONFIG_BT_BAP_BROADCAST_SNK_STREAM_COUNT) {
 		LOG_DBG("Cannot sync to more than %d streams (%u was requested)",
 			CONFIG_BT_BAP_BROADCAST_SNK_STREAM_COUNT, bis_count);

--- a/tests/bsim/bluetooth/audio/src/bap_broadcast_sink_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_broadcast_sink_test.c
@@ -801,7 +801,7 @@ static void test_broadcast_sync(const uint8_t broadcast_code[BT_ISO_BROADCAST_CO
 		return;
 	}
 
-	stream_sync_cnt = POPCOUNT(bis_index_bitfield);
+	stream_sync_cnt = count_bits(&bis_index_bitfield, sizeof(bis_index_bitfield));
 }
 
 static void test_broadcast_sync_inval(void)

--- a/tests/unit/util/main.c
+++ b/tests/unit/util/main.c
@@ -1,13 +1,18 @@
 /*
  * Copyright (c) 2019 Oticon A/S
+ * Copyright (c) 2025 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/ztest.h>
-#include <zephyr/sys/util.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <string.h>
+
+#include <zephyr/ztest.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/ztest_assert.h>
+#include <zephyr/ztest_test.h>
 
 ZTEST(util, test_u8_to_dec) {
 	char text[4];
@@ -766,6 +771,25 @@ ZTEST(util, test_mem_xor_128)
 
 	mem_xor_128(dst, src1, src2);
 	zassert_mem_equal(expected_result, dst, 16);
+}
+
+ZTEST(util, test_count_bits)
+{
+	uint8_t zero = 0U;
+	uint8_t u8 = 29U;
+	uint16_t u16 = 29999U;
+	uint32_t u32 = 2999999999U;
+	uint64_t u64 = 123456789012345ULL;
+	uint8_t u8_arr[] = {u8, u8, u8, u8, u8, u8, u8, u8, u8, u8, u8, u8, u8, u8, u8, u8,
+			    u8, u8, u8, u8, u8, u8, u8, u8, u8, u8, u8, u8, u8, u8, u8, u8};
+
+	zassert_equal(count_bits(&zero, sizeof(zero)), 0);
+	zassert_equal(count_bits(&u8, sizeof(u8)), 4);
+	zassert_equal(count_bits(&u16, sizeof(u16)), 10);
+	zassert_equal(count_bits(&u32, sizeof(u32)), 20);
+	zassert_equal(count_bits(&u64, sizeof(u64)), 23);
+
+	zassert_equal(count_bits(u8_arr, sizeof(u8_arr)), 128);
 }
 
 ZTEST(util, test_CONCAT)


### PR DESCRIPTION
Adds a generic function that will count the number of bits set in a value.
    
It uses POPCOUNT (e.g. __builtin_popcount for GCC) if available,
or else it will use Brian Kernighan’s Algorithm to count bits.
    
POPCOUNT will likely always support unsigned ints, but the function
was implemented to use it with uint8_t for the sake of simplicity
and compatibility with Brian Kernighan’s Algorithm.
    
A generic solution was chosen rather than a macro/function per
type (e.g. uint8_t, uint16_t, etc.) as that is easier to maintain
and also supports array types (e.g. counting the number of bits
in 128 or 256 octet arrays).