### PR TITLE
manifest: libmctp: pull "library without sources" fix

### DIFF
--- a/subsys/mctp/Kconfig
+++ b/subsys/mctp/Kconfig
@@ -2,7 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig MCTP
-	bool "Management Component Transport Protocol"
+	bool "Management Component Transport Protocol [EXPERIMENTAL]"
+	select EXPERIMENTAL
 	help
 	  Enable the MCTP Subsystem and Module Usage
 

--- a/west.yml
+++ b/west.yml
@@ -279,7 +279,7 @@ manifest:
       revision: bb85f7dde4195bfc0fca9e9c7c2eed0f8694203c
       path: modules/lib/liblc3
     - name: libmctp
-      revision: fa152665577a124cd957756f78fb81419c095c87
+      revision: b97860e78998551af99931ece149eeffc538bdb1
       path: modules/lib/libmctp
     - name: libmetal
       revision: 3e8781aae9d7285203118c05bc01d4eb0ca565a7


### PR DESCRIPTION
Pull libmctp module update implementing fix for
"No SOURCES given to Zephyr library: modules_mctp" warning showing up when building any application with MCTP not enabled