### PR TITLE
drivers: led_strip: ws2812_spi: fix error when writing to SPI on STM32 SoCs with dcache and DMA

### DIFF
--- a/drivers/led_strip/ws2812_spi.c
+++ b/drivers/led_strip/ws2812_spi.c
@@ -200,7 +200,7 @@ static DEVICE_API(led_strip, ws2812_spi_api) = {
 
 #define WS2812_SPI_DEVICE(idx)						 \
 									 \
-	static uint8_t ws2812_spi_##idx##_px_buf[WS2812_SPI_BUFSZ(idx)]; \
+	static __nocache uint8_t ws2812_spi_##idx##_px_buf[WS2812_SPI_BUFSZ(idx)]; \
 									 \
 	WS2812_COLOR_MAPPING(idx);					 \
 									 \


### PR DESCRIPTION
The ws2812_spi driver fails to write to SPI on STM32 SoCs with data cache, but only when DMA is enabled on the targeted SPI interface. This is because of a check in spi_ll_stm32.c that causes the write to return `-EFAULT`.

This PR fixes the bug by marking the driver's pixel buffers with the __nocache macro.

I ran into this bug while trying to get the ws2812_spi driver up and running on my Nucleo-F722ZE board. Initially, the SPI writes were succeeding, but the timings were too sloppy for the driver to work correctly. So, I had to enable DMA on the SPI interfaces. When I enabled DMA, the driver's calls to `spi_write_dt` all failed with `-EFAULT`. I determined that the error code was being returned by line 1149 of zephyr/drivers/spi/spi_ll_stm32.c, which is doing a simple check to make sure the caller's tx buffer is within the `__nocache` region. When I added __nocache to the driver, the problem was solved. My LEDs are now happily blinking away!