### PR TITLE
Fix color inversion issue on GC9A01A display

### DIFF
--- a/drivers/display/display_gc9x01x.c
+++ b/drivers/display/display_gc9x01x.c
@@ -215,6 +215,11 @@ static const struct gc9x01x_default_init_regs default_init_regs[] = {
 		.len = 2U,
 		.data = {0x3EU, 0x07U},
 	},
+	{
+		.cmd = 0x20U,
+		.len = 0U,
+		.data = {0x00U},
+	},
 };
 
 static int gc9x01x_transmit(const struct device *dev, uint8_t cmd, const void *tx_data,


### PR DESCRIPTION
Related to #80578

Add a command to disable color inversion in the `default_init_regs` array in `drivers/display/display_gc9x01x.c`.

* Add a new entry in the `default_init_regs` array to disable color inversion by setting the `cmd` to `0x20U`, `len` to `0U`, and `data` to `{0x00U}`.

