### PR TITLE
arch: common: timing: Fix timing cycles 32bit rollover

### DIFF
--- a/arch/common/timing.c
+++ b/arch/common/timing.c
@@ -22,13 +22,21 @@ void arch_timing_stop(void)
 
 timing_t arch_timing_counter_get(void)
 {
+#if CONFIG_TIMER_HAS_64BIT_CYCLE_COUNTER
+	return k_cycle_get_64();
+#else
 	return k_cycle_get_32();
+#endif
 }
 
 uint64_t arch_timing_cycles_get(volatile timing_t *const start,
 				volatile timing_t *const end)
 {
+#if CONFIG_TIMER_HAS_64BIT_CYCLE_COUNTER
 	return (*end - *start);
+#else
+	return ((uint32_t)*end - (uint32_t)*start);
+#endif
 }
 
 


### PR DESCRIPTION
Fix arch_timing_cycles_get() to prevent overflow on 32bit cycles rollover.

The issue is observable, for example when `tests/benchmarks/wait_queues` or `tests/benchmarks/sched_queues` are executed on qemu for `mps2/an385` and the benchmark has its iterations large enough as the default `BENCHMARK_NUM_ITERATIONS=1000`.

Fixes #84051 