### PR TITLE
k_pipe: add-ons to the k_pipe API rewrite

### DIFF
--- a/doc/kernel/services/data_passing/pipes.rst
+++ b/doc/kernel/services/data_passing/pipes.rst
@@ -19,7 +19,8 @@ is referenced by its memory address.
 
 A pipe has the following key property:
 
-* A **size** that indicates the capacity of the pipe's ring buffer.
+* A **size** that indicates the capacity of the pipe's ring buffer. Note that a
+  size of zero defines a pipe with no ring buffer.
 
 A pipe must be initialized before it can be used. When initialized, the pipe
 is empty.
@@ -27,12 +28,16 @@ is empty.
 Threads interact with the pipe as follows:
 
 - **Writing**: Data is synchronously written, either in whole or in part, to
-  a pipe by a thread. If the pipe's ring buffer is full, the operation blocks
-  until sufficient space becomes available or the specified timeout expires.
+  a pipe by a thread. Accepted data is either copied directly to the waiting
+  reader(s) or to the pipe's ring buffer. If the ring buffer is full or simply
+  absent, the operation blocks until sufficient space becomes available or
+  the specified timeout expires.
 
 - **Reading**: Data is synchronously read, either in whole or in part, from a
-  pipe by a thread. If the pipe's ring buffer is empty, the operation blocks
-  until data becomes available or the specified timeout expires.
+  pipe by a thread. Accepted data is either copied from the pipe's ring buffer
+  or directly from the waiting sender(s). If the ring buffer is empty or simply
+  absent, the operation blocks until data becomes available or the specified
+  timeout expires.
 
 - **Resetting**: A thread can reset a pipe, which resets its internal state and
   ends all pending read and write operations with an error code.
@@ -65,6 +70,9 @@ ring buffer:
     K_PIPE_DEFINE(my_pipe, 100, 4);
 
 This has the same effect as the code above.
+
+When no ring buffer is used, the buffer pointer argument should be NULL and
+the size argument should be 0.
 
 Writing to a Pipe
 =================

--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -4998,8 +4998,8 @@ void k_mbox_data_get(struct k_mbox_msg *rx_msg, void *buffer);
  * This routine initializes a pipe object, prior to its first use.
  *
  * @param pipe Address of the pipe.
- * @param buffer Address of the pipe's buffer.
- * @param buffer_size Size of the pipe's buffer.
+ * @param buffer Address of the pipe's buffer, or NULL if no ring buffer is used.
+ * @param buffer_size Size of the pipe's buffer, or zero if no ring buffer is used.
  */
 __syscall void k_pipe_init(struct k_pipe *pipe, uint8_t *buffer, size_t buffer_size);
 
@@ -5247,7 +5247,8 @@ struct k_pipe {
  * @code extern struct k_pipe <name>; @endcode
  *
  * @param name Name of the pipe.
- * @param pipe_buffer_size Size of the pipe's ring buffer (in bytes).
+ * @param pipe_buffer_size Size of the pipe's ring buffer (in bytes)
+ *                         or zero if no ring buffer is used.
  * @param pipe_align Alignment of the pipe's ring buffer (power of 2).
  *
  */

--- a/tests/benchmarks/app_kernel/src/master.c
+++ b/tests/benchmarks/app_kernel/src/master.c
@@ -23,7 +23,7 @@
 BENCH_BMEM char msg[MAX_MSG];
 BENCH_BMEM char data_bench[MESSAGE_SIZE];
 
-BENCH_DMEM struct k_pipe *test_pipes[] = {&PIPE_SMALLBUFF, &PIPE_BIGBUFF};
+BENCH_DMEM struct k_pipe *test_pipes[] = {&PIPE_NOBUFF, &PIPE_SMALLBUFF, &PIPE_BIGBUFF};
 BENCH_BMEM char sline[SLINE_LEN + 1];
 
 /*
@@ -70,6 +70,7 @@ K_MBOX_DEFINE(MAILB1);
 
 K_MUTEX_DEFINE(DEMO_MUTEX);
 
+K_PIPE_DEFINE(PIPE_NOBUFF, 0, 4);
 K_PIPE_DEFINE(PIPE_SMALLBUFF, 256, 4);
 K_PIPE_DEFINE(PIPE_BIGBUFF, 4096, 4);
 
@@ -187,7 +188,7 @@ int main(void)
 	k_thread_access_grant(&recv_thread, &DEMOQX1, &DEMOQX4, &DEMOQX192,
 			      &MB_COMM, &CH_COMM, &SEM0, &SEM1, &SEM2, &SEM3,
 			      &SEM4, &STARTRCV, &DEMO_MUTEX,
-			      &PIPE_SMALLBUFF, &PIPE_BIGBUFF);
+			      &PIPE_NOBUFF, &PIPE_SMALLBUFF, &PIPE_BIGBUFF);
 
 	k_thread_start(&recv_thread);
 	k_thread_start(&test_thread);
@@ -211,7 +212,7 @@ int main(void)
 	k_thread_access_grant(&test_thread, &DEMOQX1, &DEMOQX4, &DEMOQX192,
 			      &MB_COMM, &CH_COMM, &SEM0, &SEM1, &SEM2, &SEM3,
 			      &SEM4, &STARTRCV, &DEMO_MUTEX,
-			      &PIPE_SMALLBUFF, &PIPE_BIGBUFF);
+			      &PIPE_NOBUFF, &PIPE_SMALLBUFF, &PIPE_BIGBUFF);
 
 	k_thread_start(&recv_thread);
 	k_thread_start(&test_thread);
@@ -235,11 +236,11 @@ int main(void)
 	k_thread_access_grant(&test_thread, &DEMOQX1, &DEMOQX4, &DEMOQX192,
 			      &MB_COMM, &CH_COMM, &SEM0, &SEM1, &SEM2, &SEM3,
 			      &SEM4, &STARTRCV, &DEMO_MUTEX,
-			      &PIPE_SMALLBUFF, &PIPE_BIGBUFF);
+			      &PIPE_NOBUFF, &PIPE_SMALLBUFF, &PIPE_BIGBUFF);
 	k_thread_access_grant(&recv_thread, &DEMOQX1, &DEMOQX4, &DEMOQX192,
 			      &MB_COMM, &CH_COMM, &SEM0, &SEM1, &SEM2, &SEM3,
 			      &SEM4, &STARTRCV, &DEMO_MUTEX,
-			      &PIPE_SMALLBUFF, &PIPE_BIGBUFF);
+			      &PIPE_NOBUFF, &PIPE_SMALLBUFF, &PIPE_BIGBUFF);
 
 	k_thread_start(&recv_thread);
 	k_thread_start(&test_thread);

--- a/tests/benchmarks/app_kernel/src/pipe_b.c
+++ b/tests/benchmarks/app_kernel/src/pipe_b.c
@@ -90,7 +90,7 @@ void pipe_test(void)
 	PRINT_STRING(dashline);
 
 	for (putsize = 8U; putsize <= MESSAGE_SIZE_PIPE; putsize <<= 1) {
-		for (pipe = 0; pipe < 2; pipe++) {
+		for (pipe = 0; pipe < 3; pipe++) {
 			putcount = NR_OF_PIPE_RUNS;
 			pipeput(test_pipes[pipe], _ALL_N, putsize, putcount,
 				 &puttime[pipe]);
@@ -125,7 +125,7 @@ void pipe_test(void)
 
 	for (putsize = 8U; putsize <= (MESSAGE_SIZE_PIPE); putsize <<= 1) {
 		putcount = MESSAGE_SIZE_PIPE / putsize;
-		for (pipe = 0; pipe < 2; pipe++) {
+		for (pipe = 0; pipe < 3; pipe++) {
 			pipeput(test_pipes[pipe], _1_TO_N, putsize,
 					 putcount, &puttime[pipe]);
 			/* size*count == MESSAGE_SIZE_PIPE */

--- a/tests/benchmarks/app_kernel/src/pipe_r.c
+++ b/tests/benchmarks/app_kernel/src/pipe_r.c
@@ -36,7 +36,7 @@ void piperecvtask(void)
 	/* matching (ALL_N) */
 
 	for (getsize = 8; getsize <= MESSAGE_SIZE_PIPE; getsize <<= 1) {
-		for (pipe = 0; pipe < 2; pipe++) {
+		for (pipe = 0; pipe < 3; pipe++) {
 			getcount = NR_OF_PIPE_RUNS;
 			pipeget(test_pipes[pipe], _ALL_N, getsize,
 				getcount, &gettime);
@@ -52,7 +52,7 @@ void piperecvtask(void)
 		/* non-matching (1_TO_N) */
 		for (getsize = (MESSAGE_SIZE_PIPE); getsize >= 8; getsize >>= 1) {
 			getcount = MESSAGE_SIZE_PIPE / getsize;
-			for (pipe = 0; pipe < 2; pipe++) {
+			for (pipe = 0; pipe < 3; pipe++) {
 				/* size*count == MESSAGE_SIZE_PIPE */
 				pipeget(test_pipes[pipe], _1_TO_N,
 						getsize, getcount, &gettime);


### PR DESCRIPTION
This implements various cleanups and optimizations I saw the potential for
when I reviewed PR #83283. The original author did quite a lot of good work
already and I didn't want to block the merging of his own PR with these any
longer. Furthermore, it becomes easier to convey those things directly in
the code at some point.

Then it was pretty easy to add back the ability to do direct writer-to-reader
transfers and no-ring-buffer operations as the deprecated code did.
