### PR TITLE
[drivers][gpio]: Support TCA9536

### DIFF
--- a/drivers/gpio/gpio_pca953x.c
+++ b/drivers/gpio/gpio_pca953x.c
@@ -30,12 +30,6 @@ LOG_MODULE_REGISTER(pca953x, CONFIG_GPIO_LOG_LEVEL);
 #define REG_INPUT_LATCH_PORT0		0x42
 #define REG_INT_MASK_PORT0		0x45
 
-/* Number of pins supported by the device */
-#define NUM_PINS 8
-
-/* Max to select all pins supported on the device. */
-#define ALL_PINS ((uint8_t)BIT_MASK(NUM_PINS))
-
 /** Cache of the output configuration and data of the pins. */
 struct pca953x_pin_state {
 	uint8_t dir;
@@ -478,7 +472,10 @@ static DEVICE_API(gpio, api_table) = {
 	.manage_callback = gpio_pca953x_manage_callback,
 };
 
+#define GET_NGPIOS(n) DT_INST_PROP(n, ngpios)
+
 #define GPIO_PCA953X_INIT(n)							\
+	BUILD_ASSERT((GET_NGPIOS(n) == 4) || (GET_NGPIOS(n) == 8));    \
 	static const struct pca953x_config pca953x_cfg_##n = {			\
 		.i2c = I2C_DT_SPEC_INST_GET(n),					\
 		.common = {							\
@@ -492,8 +489,8 @@ static DEVICE_API(gpio, api_table) = {
 										\
 	static struct pca953x_drv_data pca953x_drvdata_##n = {			\
 		.lock = Z_SEM_INITIALIZER(pca953x_drvdata_##n.lock, 1, 1),	\
-		.pin_state.dir = ALL_PINS,					\
-		.pin_state.output = ALL_PINS,					\
+		.pin_state.dir = GPIO_PORT_PIN_MASK_FROM_DT_INST(n),  \
+		.pin_state.output = GPIO_PORT_PIN_MASK_FROM_DT_INST(n),  \
 	};									\
 	DEVICE_DT_INST_DEFINE(n,						\
 		gpio_pca953x_init,						\

--- a/dts/bindings/gpio/ti,tca9538.yaml
+++ b/dts/bindings/gpio/ti,tca9538.yaml
@@ -2,7 +2,7 @@
 # Copyright (c) 2021, Laird Connectivity
 # SPDX-License-Identifier: Apache-2.0
 
-description: TCA9538 GPIO node
+description: TCA9538 GPIO node. Supports variants such as TCA9536 which have 8 or less outputs
 
 compatible: "ti,tca9538"
 
@@ -14,7 +14,6 @@ properties:
 
   ngpios:
     required: true
-    const: 8
     description: |
       Number of GPIOs available on port expander.
 


### PR DESCRIPTION
The PCA953x driver supports the TCA953x family of GPIO expanders from TI. Currently, it makes the assumption that there are always 8 pins on the module. However, the variant TCA9536 is identical to TCA9538 except it only has 4 output pins. 

To properly support TCA953x, we need to allow for a number of GPIOs that aren't 8. This change allows this in the driver. 

There seem to be no DTS definitions in the Zephyr tree where `ngpios` isn't explicitly selected for this driver, so no definitions are changing besides just the driver in this PR. 