### PR TITLE
drivers: icm42670: Change LOG_ERR in fetch_from_registers to LOG_DBG

### DIFF
--- a/drivers/sensor/tdk/icm42670/icm42670.c
+++ b/drivers/sensor/tdk/icm42670/icm42670.c
@@ -785,7 +785,7 @@ static int icm42670_fetch_from_registers(const struct device *dev, enum sensor_c
 	int res = 0;
 	uint8_t int_status;
 
-	LOG_ERR("Fetch from reg");
+	LOG_DBG("Fetch from reg");
 
 	icm42670_lock(dev);
 


### PR DESCRIPTION
Change the `LOG_ERR` call in `icm42670_fetch_from_registers` to `LOG_DBG`. 

To solve issue #83767 