### PR TITLE
Sample: bluetooth: Enable MIMXRT1170 EVKB for peripheral_ht

### DIFF
--- a/samples/bluetooth/peripheral_ht/boards/mimxrt1170_evk_mimxrt1176_cm7_B.overlay
+++ b/samples/bluetooth/peripheral_ht/boards/mimxrt1170_evk_mimxrt1176_cm7_B.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright 2025 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	chosen {
+		zephyr,sram = &dtcm;
+	};
+};

--- a/samples/bluetooth/peripheral_ht/sample.yaml
+++ b/samples/bluetooth/peripheral_ht/sample.yaml
@@ -32,3 +32,10 @@ tests:
       - frdm_rw612
     extra_configs:
       - CONFIG_NXP_MONOLITHIC_NBU=n
+  sample.bluetooth.peripheral_ht.nxp_nw612:
+    build_only: true
+    harness: bluetooth
+    platform_allow:
+      - mimxrt1170_evk@B/mimxrt1176/cm7
+    extra_configs:
+      - CONFIG_BUILD_ONLY_NO_BLOBS=y


### PR DESCRIPTION
Enable MIMXRT1170 EVKB for peripheral_ht.