### PR TITLE
[DO NOT REVIEW] kernel: thread: fix warning of always false

### DIFF
--- a/include/zephyr/kernel/thread_stack.h
+++ b/include/zephyr/kernel/thread_stack.h
@@ -89,9 +89,9 @@ static inline char *z_stack_ptr_align(char *ptr)
 	(type *)((ptr) - sizeof(type))
 
 #ifdef ARCH_KERNEL_STACK_RESERVED
-#define K_KERNEL_STACK_RESERVED	((size_t)ARCH_KERNEL_STACK_RESERVED)
+#define K_KERNEL_STACK_RESERVED ARCH_KERNEL_STACK_RESERVED
 #else
-#define K_KERNEL_STACK_RESERVED	((size_t)0)
+#define K_KERNEL_STACK_RESERVED 0
 #endif /* ARCH_KERNEL_STACK_RESERVED */
 
 #define Z_KERNEL_STACK_SIZE_ADJUST(size) (ROUND_UP(size, \

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -413,6 +413,7 @@ static char *setup_thread_stack(struct k_thread *new_thread,
 		stack_buf_start = K_KERNEL_STACK_BUFFER(stack);
 		stack_buf_size = stack_obj_size - K_KERNEL_STACK_RESERVED;
 
+#if ((K_KERNEL_STACK_RESERVED) > 0)
 		/* Zephyr treats stack overflow as an app bug.  But
 		 * this particular overflow can be seen by static
 		 * analysis so needs to be handled somehow.
@@ -420,7 +421,7 @@ static char *setup_thread_stack(struct k_thread *new_thread,
 		if (K_KERNEL_STACK_RESERVED > stack_obj_size) {
 			k_panic();
 		}
-
+#endif /* K_KERNEL_STACK_RESERVED > 0 */
 	}
 
 #ifdef CONFIG_THREAD_STACK_MEM_MAPPED


### PR DESCRIPTION
K_KERNEL_STACK_RESERVED can be 0 which can give a warning with -Wtype-limits. Only perform the check if K_KERNEL_STACK_RESERVED is not 0.