### PR TITLE
Bluetooth: BR: Fix error Wtautological-constant-out-of-range-compare

### DIFF
--- a/subsys/bluetooth/host/classic/br.c
+++ b/subsys/bluetooth/host/classic/br.c
@@ -394,7 +394,7 @@ static struct bt_br_discovery_result *get_result_slot(const bt_addr_t *addr, int
 	}
 
 	/* ignore if invalid RSSI */
-	if (rssi == 0xff) {
+	if (rssi == (int8_t)0xff) {
 		return NULL;
 	}
 


### PR DESCRIPTION
There is an error reported on platform `native_sim` with tool-chain `llvm`, that result of comparison of constant 255 with expression of type 'int8_t' (aka 'signed char') is always false.

Covert `0xff` to the type of `rssi` to fix the issue.