### PR TITLE
drivers: led: gpio: select the GPIO Kconfig option

### DIFF
--- a/drivers/led/Kconfig.gpio
+++ b/drivers/led/Kconfig.gpio
@@ -4,6 +4,7 @@
 config LED_GPIO
 	bool "GPIO LED driver"
 	default y
-	depends on GPIO && DT_HAS_GPIO_LEDS_ENABLED
+	depends on DT_HAS_GPIO_LEDS_ENABLED
+	select GPIO
 	help
 	  Enable driver for GPIO LEDs.


### PR DESCRIPTION
Have the GPIO LED driver select CONFIG_GPIO instead of depending on it.