### PR TITLE
Bluetooth: Classic: Fix invalid comparison with int8_t

### DIFF
--- a/subsys/bluetooth/host/classic/br.c
+++ b/subsys/bluetooth/host/classic/br.c
@@ -22,6 +22,8 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(bt_br);
 
+#define RSSI_INVALID 127
+
 struct bt_br_discovery_result *discovery_results;
 static size_t discovery_results_size;
 static size_t discovery_results_count;
@@ -394,7 +396,7 @@ static struct bt_br_discovery_result *get_result_slot(const bt_addr_t *addr, int
 	}
 
 	/* ignore if invalid RSSI */
-	if (rssi == 0xff) {
+	if (rssi == RSSI_INVALID) {
 		return NULL;
 	}
 
@@ -512,7 +514,7 @@ void bt_hci_remote_name_request_complete(struct net_buf *buf)
 	int i;
 	struct bt_br_discovery_cb *listener, *next;
 
-	result = get_result_slot(&evt->bdaddr, 0xff);
+	result = get_result_slot(&evt->bdaddr, RSSI_INVALID);
 	if (!result) {
 		return;
 	}


### PR DESCRIPTION
We can't use 0xff to compare with an int8_t since it'll trigger compiler warnings/errors:

subsys/bluetooth/host/classic/br.c:397:11: error: result of comparison of constant 255 with expression of type 'int8_t' (aka 'signed char') is always false [-Werror,-Wtautological-constant-out-of-range-compare]
        if (rssi == 0xff) {
            ~~ ^  ~~
1 error generated.

Use 127 instead for situations where we don't know the RSSI value, like when processing remote name events. This is fine since from a spec perspective only -127 - +20 are valid values for the parameter.