### PR TITLE
doc: gh_utils: ignore added-but-not-committed files

### DIFF
--- a/doc/_extensions/zephyr/gh_utils.py
+++ b/doc/_extensions/zephyr/gh_utils.py
@@ -211,6 +211,8 @@ def git_info_filter(app: Sphinx, pagename) -> tuple[str, str] | None:
             .decode("utf-8")
             .strip()
         )
+        if not date_and_sha1: # added but not committed
+            return None
         date, sha1 = date_and_sha1.split(" ", 1)
         date_object = datetime.fromtimestamp(int(date))
         last_update_fmt = app.config.html_last_updated_fmt


### PR DESCRIPTION
If the file is added to the index, but not committed yet, the `git log` command will return an empty string. This patch checks for this case and treats it as if the file was not tracked at all.