### PR TITLE
drivers: display: ssd1306: add power pin support

### DIFF
--- a/drivers/display/ssd1306_regs.h
+++ b/drivers/display/ssd1306_regs.h
@@ -118,5 +118,6 @@
 
 /* time constants in ms */
 #define SSD1306_RESET_DELAY			1
+#define SSD1306_SUPPLY_DELAY			20
 
 #endif


### PR DESCRIPTION
Enable power when starting. Also toggle power supply in blanking on and off.
This power line is the high voltage for OLED (7-16V), not the logic voltage for the controller, so we can still communicate with the chip when powered off. Maybe "supply" in not a great name for the variable, I could change it for "panel_driving_supply" or "high_power_supply" or something?