### PR TITLE
modules: hal_nordic: nrfx: Move some defines back to CMakeLists

### DIFF
--- a/modules/hal_nordic/nrfx/CMakeLists.txt
+++ b/modules/hal_nordic/nrfx/CMakeLists.txt
@@ -188,6 +188,16 @@ if(CONFIG_SOC_NRF54L_CPUAPP_COMMON)
 	zephyr_compile_definitions("NRF_CONFIG_CPU_FREQ_MHZ=${clock_frequency_mhz}")
 endif()
 
+zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF54LX_SKIP_CLOCK_CONFIG NRF_SKIP_CLOCK_CONFIGURATION)
+zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF54LX_DISABLE_FICR_TRIMCNF NRF_DISABLE_FICR_TRIMCNF)
+zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF54LX_SKIP_GLITCHDETECTOR_DISABLE NRF_SKIP_GLITCHDETECTOR_DISABLE)
+
+# Inject code to skip TAMPC setup for nRF54L20 and nRF54L09. It is not supported for now.
+# It needs to be removed when support is provided.
+if(CONFIG_SOC_NRF54L20_ENGA_CPUAPP OR CONFIG_SOC_NRF54L09_ENGA_CPUAPP)
+	  zephyr_compile_definitions(NRF_SKIP_TAMPC_SETUP)
+endif()
+
 if(CONFIG_SOC_COMPATIBLE_NRF54LX AND CONFIG_NRFX_GPPI)
   zephyr_library_sources(${HELPERS_DIR}/nrfx_gppi_dppi_ppib_lumos.c)
   zephyr_library_sources(${NRFX_DIR}/soc/interconnect/dppic_ppib/nrfx_interconnect_dppic_ppib.c)

--- a/modules/hal_nordic/nrfx/nrfx_kconfig.h
+++ b/modules/hal_nordic/nrfx/nrfx_kconfig.h
@@ -964,26 +964,6 @@
 	CONFIG_NRF52_ANOMALY_109_WORKAROUND_EGU_INSTANCE
 #endif
 
-#ifdef CONFIG_SOC_NRF54LX_SKIP_CLOCK_CONFIG
-#define NRF_SKIP_CLOCK_CONFIGURATION
-#endif
-
-#ifdef CONFIG_SOC_NRF54LX_DISABLE_FICR_TRIMCNF
-#define NRF_DISABLE_FICR_TRIMCNF
-#endif
-
-#ifdef CONFIG_SOC_NRF54LX_SKIP_GLITCHDETECTOR_DISABLE
-#define NRF_SKIP_GLITCHDETECTOR_DISABLE
-#endif
-
-/*
- * Inject code to skip TAMPC setup for nRF54L20 and nRF54L09. It is not supported for now.
- * It needs to be removed when support is provided.
- */
-#if defined(CONFIG_SOC_NRF54L20_ENGA_CPUAPP) || defined(CONFIG_SOC_NRF54L09_ENGA_CPUAPP)
-#define NRF_SKIP_TAMPC_SETUP
-#endif
-
 #if	DT_HAS_COMPAT_STATUS_OKAY(nordic_nrf_dppic_global) || \
 	DT_HAS_COMPAT_STATUS_OKAY(nordic_nrf_dppic_local)
 #ifndef NRFX_DPPI_ENABLED


### PR DESCRIPTION
534916c2253 moved some defines from CMakeLists.txt to nrfx_kconfig.h but those defines are used by MDK which does not include nrfx_kconfig.h and that broke some nrf platforms (e.g. nrf54l20). Moving those defines back to CMakeLists.txt