### PR TITLE
tests: drivers: gpio: Add nrf54l09pdk support

### DIFF
--- a/boards/nordic/nrf54l09pdk/nrf54l09pdk_nrf54l09-common.dtsi
+++ b/boards/nordic/nrf54l09pdk/nrf54l09pdk_nrf54l09-common.dtsi
@@ -10,7 +10,7 @@
 	leds {
 		compatible = "gpio-leds";
 		led0: led_0 {
-			gpios = <&gpio1 7 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpio1 10 GPIO_ACTIVE_HIGH>;
 			label = "Green LED 1";
 		};
 		led1: led_1 {

--- a/tests/drivers/gpio/gpio_basic_api/boards/nrf54l09pdk_nrf54l09_cpuapp.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/nrf54l09pdk_nrf54l09_cpuapp.overlay
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	resources {
+		compatible = "test-gpio-basic-api";
+		out-gpios = <&gpio1 10 0>;
+		in-gpios = <&gpio1 11 0>;
+	};
+};
+
+&gpiote20 {
+	status = "okay";
+};
+
+&gpio1 {
+	status = "okay";
+};


### PR DESCRIPTION
Change led0 pin for nrf54l09pdk to make `gpio_api_1pin` test pass.
Add nrf54l09pdk/nrf54l09/cpuapp overlay for `gpio_basic_api`.