### PR TITLE
Bluetooth: audio: Fix byteorder in csip sef crypto function

### DIFF
--- a/subsys/bluetooth/audio/csip_crypto.c
+++ b/subsys/bluetooth/audio/csip_crypto.c
@@ -171,14 +171,8 @@ int bt_csip_sef(const uint8_t k[BT_CSIP_CRYPTO_KEY_SIZE], const uint8_t sirk[BT_
 
 	LOG_DBG("SIRK %s", bt_hex(sirk, BT_CSIP_SIRK_SIZE));
 
-	if (IS_ENABLED(CONFIG_LITTLE_ENDIAN)) {
-		/* Swap because aes_cmac is big endian
-		 * and we are little endian
-		 */
-		sys_memcpy_swap(k1_tmp, k, sizeof(k1_tmp));
-	} else {
-		(void)memcpy(k1_tmp, k, sizeof(k1_tmp));
-	}
+	/* Swap because aes_cmac is big endian and k is little endian */
+	sys_memcpy_swap(k1_tmp, k, sizeof(k1_tmp));
 	LOG_DBG("BE: k %s", bt_hex(k1_tmp, sizeof(k1_tmp)));
 
 	err = s1(m, sizeof(m), s1_out);
@@ -195,10 +189,8 @@ int bt_csip_sef(const uint8_t k[BT_CSIP_CRYPTO_KEY_SIZE], const uint8_t sirk[BT_
 
 	LOG_DBG("BE: k1 result %s", bt_hex(k1_out, sizeof(k1_out)));
 
-	if (IS_ENABLED(CONFIG_LITTLE_ENDIAN)) {
-		/* Swap result back to little endian */
-		sys_mem_swap(k1_out, sizeof(k1_out));
-	}
+	/* Get result back to little endian. */
+	sys_mem_swap(k1_out, sizeof(k1_out));
 
 	mem_xor_128(out_sirk, k1_out, sirk);
 	LOG_DBG("out %s", bt_hex(out_sirk, BT_CSIP_SIRK_SIZE));

--- a/subsys/bluetooth/audio/csip_set_coordinator.c
+++ b/subsys/bluetooth/audio/csip_set_coordinator.c
@@ -266,23 +266,19 @@ static int sirk_decrypt(struct bt_conn *conn,
 			uint8_t *out_sirk)
 {
 	int err;
-	uint8_t *k;
+	const uint8_t *k;
 
 	if (IS_ENABLED(CONFIG_BT_CSIP_SET_COORDINATOR_TEST_SAMPLE_DATA)) {
 		/* test_k is from the sample data from A.2 in the CSIS spec */
-		static uint8_t test_k[] = {0x67, 0x6e, 0x1b, 0x9b,
-					   0xd4, 0x48, 0x69, 0x6f,
-					   0x06, 0x1e, 0xc6, 0x22,
-					   0x3c, 0xe5, 0xce, 0xd9};
-		static bool swapped;
+		static const uint8_t test_k[] = {
+			/* Sample data is in big-endian, we need it in little-endian. */
+			REVERSE_ARGS(0x67, 0x6e, 0x1b, 0x9b,
+				     0xd4, 0x48, 0x69, 0x6f,
+				     0x06, 0x1e, 0xc6, 0x22,
+				     0x3c, 0xe5, 0xce, 0xd9) };
 
 		LOG_DBG("Decrypting with sample data K");
 
-		if (!swapped && IS_ENABLED(CONFIG_LITTLE_ENDIAN)) {
-			/* Swap test_k to little endian */
-			sys_mem_swap(test_k, 16);
-			swapped = true;
-		}
 		k = test_k;
 	} else {
 		k = conn->le.keys->ltk.val;

--- a/subsys/bluetooth/audio/csip_set_member.c
+++ b/subsys/bluetooth/audio/csip_set_member.c
@@ -145,21 +145,16 @@ static int sirk_encrypt(struct bt_conn *conn, const struct bt_csip_sirk *sirk,
 			struct bt_csip_sirk *enc_sirk)
 {
 	int err;
-	uint8_t *k;
+	const uint8_t *k;
 
 	if (IS_ENABLED(CONFIG_BT_CSIP_SET_MEMBER_TEST_SAMPLE_DATA)) {
 		/* test_k is from the sample data from A.2 in the CSIS spec */
-		static uint8_t test_k[] = {0x67, 0x6e, 0x1b, 0x9b,
-					   0xd4, 0x48, 0x69, 0x6f,
-					   0x06, 0x1e, 0xc6, 0x22,
-					   0x3c, 0xe5, 0xce, 0xd9};
-		static bool swapped;
-
-		if (!swapped && IS_ENABLED(CONFIG_LITTLE_ENDIAN)) {
-			/* Swap test_k to little endian */
-			sys_mem_swap(test_k, 16);
-			swapped = true;
-		}
+		static const uint8_t test_k[] = {
+			/* Sample data is in big-endian, we need it in little-endian. */
++                       REVERSE_ARGS(0x67, 0x6e, 0x1b, 0x9b,
+				     0xd4, 0x48, 0x69, 0x6f,
+				     0x06, 0x1e, 0xc6, 0x22,
+				     0x3c, 0xe5, 0xce, 0xd9) };
 		LOG_DBG("Encrypting test SIRK");
 		k = test_k;
 	} else {


### PR DESCRIPTION
Fix byteorder handling in csip sef crypto function. On big-endian system we also need to convert the k array from little-endian to big-endian. The Bluetooth protocol is always using little-endian ordering.