### PR TITLE
mgmt: mcumgr: grp: os_mgmt: Fix compilation warning

### DIFF
--- a/subsys/mgmt/mcumgr/grp/os_mgmt/src/os_mgmt.c
+++ b/subsys/mgmt/mcumgr/grp/os_mgmt/src/os_mgmt.c
@@ -450,7 +450,7 @@ os_mgmt_bootloader_info(struct smp_streamer *ctxt)
 	zcbor_state_t *zsd = ctxt->reader->zs;
 	struct zcbor_string query = { 0 };
 	size_t decoded;
-	bool ok;
+	bool ok = true;
 	bool has_output = false;
 
 #if defined(CONFIG_MCUMGR_GRP_OS_BOOTLOADER_INFO_HOOK)


### PR DESCRIPTION
This is a follow up to commit 770482a45a07adcd2d118b3876fa151c0a57ba63.

Add initialization of the `ok` variable to prevent the "may be uninitialized" warning when `CONFIG_BOOTLOADER_MCUBOOT` is not defined.