### PR TITLE
Cortex-M SysTick: extend support for low-power mode features

### DIFF
--- a/drivers/timer/Kconfig.cortex_m_systick
+++ b/drivers/timer/Kconfig.cortex_m_systick
@@ -94,3 +94,18 @@ config CORTEX_M_SYSTICK_LPM_TIMER_HOOKS
 
 endif # PM
 endchoice # CORTEX_M_SYSTICK_LPM_TIMER
+
+config CORTEX_M_SYSTICK_RESET_BY_LPM
+	bool
+	depends on !CORTEX_M_SYSTICK_LPM_TIMER_NONE
+	help
+	  Some SoCs provide one or more low-power mode which, as part of their
+	  operation, place SysTick or the entire CPU under reset. This requires
+	  special care from the driver - notably, SysTick needs to be restarted
+	  after waking up from such a low-power mode.
+
+	  Select this symbol if your SoC has a low-power mode that places SysTick
+	  under reset. Note that this requires that the platform provides a timer
+	  active in low-power mode, since SysTick cannot be used for timekeeping.
+
+	  Refer to CONFIG_CORTEX_M_SYSTICK_LPM_TIMER for more details.

--- a/drivers/timer/Kconfig.cortex_m_systick
+++ b/drivers/timer/Kconfig.cortex_m_systick
@@ -86,5 +86,11 @@ config CORTEX_M_SYSTICK_LPM_TIMER_COUNTER
 
 	  The device is selected by property "/chosen/cortex-m-idle-timer".
 
+config CORTEX_M_SYSTICK_LPM_TIMER_HOOKS
+	bool "Hook-based timer"
+	help
+	  Use hooks in the SysTick driver to configure the low-power mode timer.
+	  Refer to `include/drivers/timer/cortex_m_systick.h` for more details.
+
 endif # PM
 endchoice # CORTEX_M_SYSTICK_LPM_TIMER

--- a/drivers/timer/Kconfig.cortex_m_systick
+++ b/drivers/timer/Kconfig.cortex_m_systick
@@ -43,20 +43,48 @@ config CORTEX_M_SYSTICK_64BIT_CYCLE_COUNTER
 	  This is set to y by default when the hardware clock is fast enough
 	  to wrap sys_clock_cycle_get_32() in about a minute or less.
 
-config CORTEX_M_SYSTICK_IDLE_TIMER
-	bool "Use an additional timer while entering IDLE"
-	default $(dt_chosen_enabled,$(DT_CHOSEN_IDLE_TIMER))
-	depends on COUNTER
-	depends on TICKLESS_KERNEL
-	depends on PM
+choice CORTEX_M_SYSTICK_LPM_TIMER
+	prompt "SysTick companion low-power mode timer"
+	# If all dependencies are enabled, and /chosen/cortex-m-idle-timer
+	# is enabled, default to using the Counter API-based LPM timer.
+	# Otherwise, the first choice (LPM_TIMER_NONE) will be selected
+	# automatically, and no LPM timer will be enabled.
+	default CORTEX_M_SYSTICK_LPM_TIMER_COUNTER
 	help
-	  There are chips e.g. STMFX family that use SysTick as a system timer,
-	  but SysTick is not clocked in low power mode. These chips usually have
-	  another timer that is not stopped, but it has lower frequency e.g.
-	  RTC, thus it can't be used as a main system timer.
+	  It is common for SoCs equipped with SysTick to use it as system timer.
+	  However, depending on the SoC implementation, entering low-power mode
+	  may turn off the SysTick clock or place SysTick under reset.
 
-	  Use the IDLE timer for timeout (wakeup) when the system is entering
-	  IDLE state.
+	  On such SoCs, a vendor-specific timer that remains active in low-power
+	  mode will usually be provided - however, it may be unfit for usage as
+	  system timer, for example because its frequency is too low.
 
-	  The chosen IDLE timer node has to support setting alarm from the
-	  counter API.
+	  With this option, such vendor-specific timer can be selected and used by
+	  the SysTick driver to ensure proper system operation in low-power mode.
+
+	  NOTE: since Power Management has to be enabled if the SoC may enter in
+	  low-power mode, no LPM timer can be selected if PM is not enabled.
+	  Tickless kernel must also be enabled, since periodic interrupts would
+	  prevent the system from entering in low-power modes.
+
+config CORTEX_M_SYSTICK_LPM_TIMER_NONE
+	bool "None"
+	help
+	  Use no additional device as low-power mode timer.
+
+	  The SoC must never enter a low-power mode where SysTick is disabled when
+	  this option is selected; otherwise, system behavior becomes unpredictable.
+
+if TICKLESS_KERNEL && PM
+
+config CORTEX_M_SYSTICK_LPM_TIMER_COUNTER
+	bool "Counter API timer"
+	depends on $(dt_chosen_enabled,$(DT_CHOSEN_IDLE_TIMER))
+	depends on COUNTER
+	help
+	  Use a device that implements the counter API as low-power mode timer.
+
+	  The device is selected by property "/chosen/cortex-m-idle-timer".
+
+endif # PM
+endchoice # CORTEX_M_SYSTICK_LPM_TIMER

--- a/drivers/timer/cortex_m_systick.h
+++ b/drivers/timer/cortex_m_systick.h
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2025 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_TIMER_CORTEX_M_SYSTICK_H_
+#define ZEPHYR_INCLUDE_DRIVERS_TIMER_CORTEX_M_SYSTICK_H_
+
+#include <zephyr/types.h>
+
+/**
+ * Hooks/callbacks definitions for interaction between the Cortex-M
+ * SysTick driver and a platform-specific low-power timer driver.
+ *
+ * These functions are invoked by the Cortex-M SysTick driver to
+ * configure a platform-specific timer that remains active when
+ * the system enters a low-power mode.
+ *
+ * In the rest of this file, the "platform-specific low-power mode timer"
+ * is named "LPTIM", and the platform-specific driver that configures the
+ * LPTIM (and implements these hooks/callbacks) is named "LPTIM driver".
+ *
+ * The following behavior is observed when this option is enabled:
+ *
+ * |------(1)---(2)--------------------(3)-------(4)--------------> Time
+ *
+ * (1) cmsd_hook_on_lpm_entry() is invoked
+ * (2) The system enters in low-power mode
+ * (3) The system exits low-power mode (due to timeout or HW event)
+ * (4) cmsd_hook_lpm_time_elapsed() is called
+ *
+ * The return value of cmsd_hook_lpm_time_elapsed() should be as close
+ * as possible to the real time interval between events (1) and (4).
+ *
+ * These hooks should be implemented by the application if and only if
+ * CONFIG_CORTEX_M_SYSTICK_LPM_TIMER_HOOKS is enabled.
+ *
+ * NOTE: the hooks are not invoked when the system enters in low-power
+ * mode for an indefinite amount of time (requires CONFIG_TICKLESS_KERNEL
+ * and no thread PENDING with timeout).
+ */
+
+/**
+ * @brief Hook invoked when the system is about to enter low-power mode
+ *
+ * @param max_lpm_time_us Maximal time allowed in low-power mode (µs)
+ *
+ * The LPTIM driver should configure the LPTIM to wake up the system
+ * after at most @a{max_lpm_time_us} elapses; depending on hardware
+ * capabilities, the LPTIM may have to be configured to wake up the
+ * system earlier than requested (but no later!).
+ *
+ * Note that this hook is not called if the system enters low-power
+ * mode for an indefinite amount of time (i.e., when no threads are
+ * runnable or waiting with timeout).
+ */
+void z_cms_lptim_hook_on_lpm_entry(uint64_t max_lpm_time_us);
+
+/**
+ * @brief Callback invoked after system exits low-power mode
+ *
+ * This function should return the time elapsed, in microseconds,
+ * since entry in low-power mode occurred (i.e., since the call
+ * to @ref{cmsd_hook_on_lpm_entry}).
+ */
+uint64_t z_cms_lptim_hook_on_lpm_exit(void);
+#endif /* ZEPHYR_INCLUDE_DRIVERS_TIMER_CORTEX_M_SYSTICK_H_ */


### PR DESCRIPTION
This PR aims to improve several aspects of the Cortex-M SysTick driver related to low-power mode/PM, mainly for support of Deepstop LPM on STM32WB0 series.

The existing implementation supports a companion "IDLE timer", but it must implement the Counter API, which can be a poor fit depending on the hardware. However, the only things the SysTick drivers requests from the companion time is:
1. to wake up the SoC after *at most* a specified timeout elapses
2. measuring how much time elapsed while SysTick was inactive

This PR implements a simple ("hook-based") API that the SysTick driver can use to perform these two functions in place of the Counter API timer, which is useful when the platform-specific timer is a poor fit for the Counter API.

Another limitation of the driver is that it expects SysTick to remain powered in low-power modes, which is not true on some SoCs. This PR creates a new Kconfig symbol which, if selected, modifies the SysTick driver such that it stops the counter cleanly before low-power mode entry, and restarts it after low-power mode exit.

This PR is a proposal, hence the DNM label - I don't think the changes are large enough to warrant the RFC label. Comments are nonetheless welcome and highly appreciated :smile: 