### PR TITLE
Collect test names in lcov reports

### DIFF
--- a/scripts/pylib/twister/twisterlib/coverage.py
+++ b/scripts/pylib/twister/twisterlib/coverage.py
@@ -279,7 +279,24 @@ class Lcov(CoverageTool):
         coveragefile = os.path.join(outdir, "coverage.info")
         ztestfile = os.path.join(outdir, "ztest.info")
 
-        cmd = ["--capture", "--directory", outdir, "--output-file", coveragefile]
+        if build_dirs:
+            files = []
+            for dir_ in build_dirs:
+                files_ = [fname for fname in
+                            [os.path.join(dir_, "coverage.info"),
+                             os.path.join(dir_, "ztest.info")]
+                          if os.path.exists(fname)]
+                if not files_:
+                    logger.debug("Coverage merge no files in: %s", dir_)
+                    continue
+                files += files_
+            logger.debug("Coverage merge %d reports in %s", len(files), outdir)
+            cmd = ["--output-file", coveragefile]
+            for filename in files:
+                cmd.append("--add-tracefile")
+                cmd.append(filename)
+        else:
+            cmd = ["--capture", "--directory", outdir, "--output-file", coveragefile]
         self.run_lcov(cmd, coveragelog)
 
         # We want to remove tests/* and tests/ztest/test/* but save tests/ztest

--- a/scripts/pylib/twister/twisterlib/coverage.py
+++ b/scripts/pylib/twister/twisterlib/coverage.py
@@ -297,6 +297,10 @@ class Lcov(CoverageTool):
                 cmd.append(filename)
         else:
             cmd = ["--capture", "--directory", outdir, "--output-file", coveragefile]
+            if self.coverage_per_instance and len(self.instances) == 1:
+                invalid_chars = re.compile(r"[^A-Za-z0-9_]")
+                cmd.append("--test-name")
+                cmd.append(invalid_chars.sub("_", next(iter(self.instances))))
         self.run_lcov(cmd, coveragelog)
 
         # We want to remove tests/* and tests/ztest/test/* but save tests/ztest
@@ -325,7 +329,10 @@ class Lcov(CoverageTool):
 
         cmd = ["genhtml", "--legend", "--branch-coverage",
                "--prefix", self.base_dir,
-               "-output-directory", os.path.join(outdir, "coverage")] + files
+               "-output-directory", os.path.join(outdir, "coverage")]
+        if self.coverage_per_instance:
+            cmd.append("--show-details")
+        cmd += files
         ret = self.run_command(cmd, coveragelog)
 
         # TODO: Add LCOV summary coverage report.

--- a/scripts/pylib/twister/twisterlib/environment.py
+++ b/scripts/pylib/twister/twisterlib/environment.py
@@ -400,8 +400,8 @@ structure in the main Zephyr tree: boards/<vendor>/<board_name>/""")
                 action="store_true", default=False,
                 help="""Don't aggregate coverage report statistics for all the test suites
                         selected to run with enabled coverage. Requires another reporting mode to be
-                        active (`--coverage-split`) to have at least one of these reporting modes.
-                        Default: %(default)s""")
+                        active (`--coverage-per-instance`) to have at least one of these reporting
+                        modes. Default: %(default)s""")
 
     parser.add_argument(
         "--test-config",


### PR DESCRIPTION
If the flag `--coverage-by-instance` is passed to twister, pass the test name to lcov so that the coverage reports will include test details.

Here is an example without the test names populated:
![42AEQv8ZynYtoK7](https://github.com/user-attachments/assets/59219e84-c8dd-4535-b136-089026dab7af)

And with:
![w4t2fuyT64kWDRy](https://github.com/user-attachments/assets/973e6f8b-9b3b-4506-9844-a77f47d4fa93)

