### PR TITLE
net: http_server: fix HTTP 1.0 500 response template formatting error

### DIFF
--- a/subsys/net/lib/http/http_server_http1.c
+++ b/subsys/net/lib/http/http_server_http1.c
@@ -111,7 +111,7 @@ static void send_http1_500(struct http_client_ctx *client, int error_code)
 
 	(void)snprintk(http_response, sizeof(http_response),
 		       HTTP_500_RESPONSE_TEMPLATE,
-		       sizeof("Internal Server Error\r\n") - 1 + desc_len,
+		       (int)sizeof("Internal Server Error\r\n") - 1 + desc_len,
 		       desc_separator, error_desc);
 	(void)http_server_sendall(client, http_response, strlen(http_response));
 }


### PR DESCRIPTION
Template string for HTTP 1.0 500 response expects content length as a %d but was getting passed a 'long unsigned int' instead of an 'int'.

Fixes CI failure in `main`
https://github.com/zephyrproject-rtos/zephyr/actions/runs/12810335769/job/35717170327#step:11:3858