### PR TITLE
drivers: spi_nxp_lpspi: Add tristate output config

### DIFF
--- a/boards/nxp/mimxrt1050_evk/mimxrt1050_evk.dtsi
+++ b/boards/nxp/mimxrt1050_evk/mimxrt1050_evk.dtsi
@@ -166,6 +166,7 @@ zephyr_lcdif: &lcdif {
 	dma-names = "rx", "tx";
 	pinctrl-0 = <&pinmux_lpspi1>;
 	pinctrl-names = "default";
+	tristate-output;
 };
 
 &lpspi3 {

--- a/boards/nxp/mimxrt1064_evk/mimxrt1064_evk.dts
+++ b/boards/nxp/mimxrt1064_evk/mimxrt1064_evk.dts
@@ -304,6 +304,7 @@ zephyr_udc0: &usb1 {
 	/* DMA channels 0 and 1, muxed to LPSPI1 RX and TX */
 	dmas = <&edma0 0 13>, <&edma0 1 14>;
 	dma-names = "rx", "tx";
+	tristate-output;
 	pinctrl-0 = <&pinmux_lpspi1>;
 	pinctrl-names = "default";
 };

--- a/drivers/spi/spi_nxp_lpspi/spi_nxp_lpspi_common.c
+++ b/drivers/spi/spi_nxp_lpspi/spi_nxp_lpspi_common.c
@@ -89,6 +89,8 @@ int spi_mcux_configure(const struct device *dev, const struct spi_config *spi_cf
 	master_config.lastSckToPcsDelayInNanoSec = config->sck_pcs_delay;
 	master_config.betweenTransferDelayInNanoSec = config->transfer_delay;
 	master_config.pinCfg = config->data_pin_config;
+	master_config.dataOutConfig = config->output_config ? kLpspiDataOutTristate :
+							      kLpspiDataOutRetained;
 
 	LPSPI_MasterInit(base, &master_config, clock_freq);
 	LPSPI_SetDummyData(base, 0);

--- a/drivers/spi/spi_nxp_lpspi/spi_nxp_lpspi_priv.h
+++ b/drivers/spi/spi_nxp_lpspi/spi_nxp_lpspi_priv.h
@@ -41,6 +41,7 @@ struct spi_mcux_config {
 	uint32_t transfer_delay;
 	const struct pinctrl_dev_config *pincfg;
 	lpspi_pin_config_t data_pin_config;
+	bool output_config;
 };
 
 #ifdef CONFIG_SPI_MCUX_LPSPI_DMA
@@ -115,6 +116,7 @@ int spi_mcux_release(const struct device *dev, const struct spi_config *spi_cfg)
 					   DT_INST_PROP(n, transfer_delay)),                       \
 		.pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),                                       \
 		.data_pin_config = DT_INST_ENUM_IDX(n, data_pin_config),                           \
+		.output_config = DT_INST_PROP(n, tristate_output),                                 \
 	};
 
 #define SPI_NXP_LPSPI_COMMON_INIT(n)                                                               \

--- a/dts/bindings/spi/nxp,lpspi.yaml
+++ b/dts/bindings/spi/nxp,lpspi.yaml
@@ -43,3 +43,10 @@ properties:
     description: |
       Configures which pins (SDO and SDI) are used for input and output data
       during single bit transfers.
+
+  tristate-output:
+    type: boolean
+    description:
+      Configures whether or not the output data is tristated between accesses
+      (when PCS is negated). If set, the output will be tristated when PCS is negated,
+      otherwise the output line retains the last value when PCS is negated.


### PR DESCRIPTION
Add DT property to configure the LPSPI instance to use tristated output instead of retained output when PCS is negated.

Turn on the config on a couple boards for test coverage.

Fixes #66372