### PR TITLE
scripts: build: Add support for generating string literals in file2hex.py

### DIFF
--- a/scripts/build/file2hex.py
+++ b/scripts/build/file2hex.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 #
 # Copyright (c) 2017 Intel Corporation
+# Copyright (c) 2025 Siemens AG
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -31,6 +32,8 @@ def parse_args():
     parser.add_argument("-l", "--length", type=lambda x: int(x, 0), default=-1,
                         help="""Length in bytes to read from the input file.
                         Defaults to reading till the end of the input file.""")
+    parser.add_argument("-m", "--format", default="list",
+                        help="Output format: 'list' (default) or 'literal' (string literal)")
     parser.add_argument("-g", "--gzip", action="store_true",
                         help="Compress the file using gzip before output")
     parser.add_argument("-t", "--gzip-mtime", type=int, default=0,
@@ -56,6 +59,12 @@ def make_hex(chunk):
     print(get_nice_string(hexlist) + ',')
 
 
+def make_string_literal(chunk):
+    hexdata = codecs.encode(chunk, 'hex').decode("utf-8")
+    hexlist = map(''.join, zip(*[iter(hexdata)] * 2))
+    print(''.join("\\x" + str(x) for x in hexlist), end='')
+
+
 def main():
     parse_args()
 
@@ -74,14 +83,30 @@ def main():
     else:
         with open(args.file, "rb") as fp:
             fp.seek(args.offset)
-            if args.length < 0:
-                for chunk in iter(lambda: fp.read(1024), b''):
-                    make_hex(chunk)
+
+            if args.format == "literal":
+                if args.length < 0:
+                    print('"', end='')
+                    for chunk in iter(lambda: fp.read(1024), b''):
+                        make_string_literal(chunk)
+                    print('"', end='')
+                else:
+                    print('"', end='')
+                    remainder = args.length
+                    for chunk in iter(lambda: fp.read(min(1024, remainder)), b''):
+                        make_string_literal(chunk)
+                        remainder = remainder - len(chunk)
+                    print('"', end='')
+
             else:
-                remainder = args.length
-                for chunk in iter(lambda: fp.read(min(1024, remainder)), b''):
-                    make_hex(chunk)
-                    remainder = remainder - len(chunk)
+                if args.length < 0:
+                    for chunk in iter(lambda: fp.read(1024), b''):
+                        make_hex(chunk)
+                else:
+                    remainder = args.length
+                    for chunk in iter(lambda: fp.read(min(1024, remainder)), b''):
+                        make_hex(chunk)
+                        remainder = remainder - len(chunk)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Currently, file2hex.py supports conversion of binary data into hexadecimal character list format only. The generated list can then be used to embed the binary data by using the list to initialize an array. However, this approach is highly inefficient for large binary files.

A close but considerably more efficient alternative is to use string literals composed of hex characters (in escaped form) to initialize the array, instead of an initializer list. Benchmarking (with GCC and clang) indicates that compile time and host memory usage by the compiler can be more than an order of magnitude less with string literal approach compared to the initializer list form.

The only caveat is that string literals contain the null character as terminator so where accurate length is required, the correct length must be specified explicitly while defining the array.

See https://github.com/zephyrproject-rtos/zephyr/pull/82603#issuecomment-2595532515 for the context behind this enhancement.

**Usage:**
* Hex initializer list format is the default, so existing usage of file2hex.py, both in tree or anywhere out in the community, should continue to work as before.
* To generate string literal form for binary data inclusion, file2hex.py should be invoked with `-mliteral` or `--format=literal` parameter, e.g.:
    ```
    scripts/build/file2hex.py -mliteral -f test.img
    ```

**Compile time and host memory usage benchmarks:**
* Test binary files are created using `dd`. (Content is all bytes set to zero, except the last byte which is set to 1.)
* File sizes below 1KiB (have been tested - down to 2 bytes size - but) are not included in the compile time and host memory usage benchmark below because there is no meaningful variation - the numbers are almost the same as the ones for files of 1KiB size.
* For comparison, host GCC and clang compilers are used. Host machine is a Xubuntu VM with 32GiB RAM, running under Hyper-V on a Windows 11 host.
  * GCC version:
    ```
    gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
    ```
  * clang version:
    ```
    Ubuntu clang version 18.1.3 (1ubuntu1)
    Target: x86_64-pc-linux-gnu
    ```
* Compared to initializer list form, string literal approach is a clear winner, both in terms of compile-time and host memory usage.
* clang beats GCC in both cases, in terms of compile time, but for host memory usage, GCC beats clang when using string literal form. The compile time difference between GCC and clang is much more significant for the string literal form.

**Table 1: Compile time (in seconds) taken to compile binary data included using initializer list format vs. string literal form.** 
(Note that conversion times - from binary to initializer list or string literal form - are not included in these numbers)

<table>
<tr>
<th></th>
<th colspan="2">Initializer List</th>
<th colspan="2">String Literal</th>
</tr>
<tr>
<th>File Size</th>
<th>GCC</th>
<th>clang</th>
<th>GCC</th>
<th>clang</th>
</tr>
<tr>
<th align='right'>&NoBreak;1KiB</th>
<td align='right'>&NoBreak;0.013</td>
<td align='right'>&NoBreak;0.021</td>
<td align='right'>&NoBreak;0.012</td>
<td align='right'>&NoBreak;0.021</td>
</tr>
<tr>
<th align='right'>&NoBreak;2KiB</th>
<td align='right'>&NoBreak;0.014</td>
<td align='right'>&NoBreak;0.023</td>
<td align='right'>&NoBreak;0.012</td>
<td align='right'>&NoBreak;0.023</td>
</tr>
<tr>
<th align='right'>&NoBreak;4KiB</th>
<td align='right'>&NoBreak;0.015</td>
<td align='right'>&NoBreak;0.024</td>
<td align='right'>&NoBreak;0.014</td>
<td align='right'>&NoBreak;0.022</td>
</tr>
<tr>
<th align='right'>&NoBreak;8KiB</th>
<td align='right'>&NoBreak;0.018</td>
<td align='right'>&NoBreak;0.026</td>
<td align='right'>&NoBreak;0.013</td>
<td align='right'>&NoBreak;0.022</td>
</tr>
<tr>
<th align='right'>&NoBreak;16KiB</th>
<td align='right'>&NoBreak;0.024</td>
<td align='right'>&NoBreak;0.031</td>
<td align='right'>&NoBreak;0.014</td>
<td align='right'>&NoBreak;0.022</td>
</tr>
<tr>
<th align='right'>&NoBreak;32KiB</th>
<td align='right'>&NoBreak;0.037</td>
<td align='right'>&NoBreak;0.043</td>
<td align='right'>&NoBreak;0.016</td>
<td align='right'>&NoBreak;0.022</td>
</tr>
<tr>
<th align='right'>&NoBreak;64KiB</th>
<td align='right'>&NoBreak;0.063</td>
<td align='right'>&NoBreak;0.064</td>
<td align='right'>&NoBreak;0.020</td>
<td align='right'>&NoBreak;0.022</td>
</tr>
<tr>
<th align='right'>&NoBreak;128KiB</th>
<td align='right'>&NoBreak;0.110</td>
<td align='right'>&NoBreak;0.109</td>
<td align='right'>&NoBreak;0.026</td>
<td align='right'>&NoBreak;0.024</td>
</tr>
<tr>
<th align='right'>&NoBreak;256KiB</th>
<td align='right'>&NoBreak;0.209</td>
<td align='right'>&NoBreak;0.201</td>
<td align='right'>&NoBreak;0.040</td>
<td align='right'>&NoBreak;0.026</td>
</tr>
<tr>
<th align='right'>&NoBreak;512KiB</th>
<td align='right'>&NoBreak;0.425</td>
<td align='right'>&NoBreak;0.388</td>
<td align='right'>&NoBreak;0.063</td>
<td align='right'>&NoBreak;0.030</td>
</tr>
<tr>
<th align='right'>&NoBreak;1MiB</th>
<td align='right'>&NoBreak;0.904</td>
<td align='right'>&NoBreak;0.760</td>
<td align='right'>&NoBreak;0.116</td>
<td align='right'>&NoBreak;0.038</td>
</tr>
<tr>
<th align='right'>&NoBreak;2MiB</th>
<td align='right'>&NoBreak;1.917</td>
<td align='right'>&NoBreak;1.567</td>
<td align='right'>&NoBreak;0.223</td>
<td align='right'>&NoBreak;0.058</td>
</tr>
<tr>
<th align='right'>&NoBreak;4MiB</th>
<td align='right'>&NoBreak;4.554</td>
<td align='right'>&NoBreak;2.988</td>
<td align='right'>&NoBreak;0.433</td>
<td align='right'>&NoBreak;0.097</td>
</tr>
<tr>
<th align='right'>&NoBreak;8MiB</th>
<td align='right'>&NoBreak;10.077</td>
<td align='right'>&NoBreak;5.893</td>
<td align='right'>&NoBreak;0.881</td>
<td align='right'>&NoBreak;0.176</td>
</tr>
<tr>
<th align='right'>&NoBreak;16MiB</th>
<td align='right'>&NoBreak;22.199</td>
<td align='right'>&NoBreak;12.052</td>
<td align='right'>&NoBreak;1.742</td>
<td align='right'>&NoBreak;0.330</td>
</tr>
<tr>
<th align='right'>&NoBreak;32MiB</th>
<td align='right'>&NoBreak;41.135</td>
<td align='right'>&NoBreak;23.827</td>
<td align='right'>&NoBreak;3.425</td>
<td align='right'>&NoBreak;0.633</td>
</tr>
<tr>
<th align='right'>&NoBreak;64MiB</th>
<td align='right'>&NoBreak;80.364</td>
<td align='right'>&NoBreak;46.960</td>
<td align='right'>&NoBreak;6.769</td>
<td align='right'>&NoBreak;1.288</td>
</tr>
<tr>
<th align='right'>&NoBreak;128MiB</th>
<td align='right'>&NoBreak;166.988</td>
<td align='right'>&NoBreak;94.351</td>
<td align='right'>&NoBreak;13.608</td>
<td align='right'>&NoBreak;2.545</td>
</tr>
<tr>
<th align='right'>&NoBreak;256MiB</th>
<td align='right'>&NoBreak;339.445</td>
<td align='right'>&NoBreak;189.123</td>
<td align='right'>&NoBreak;26.772</td>
<td align='right'>&NoBreak;5.100</td>
</tr>
</table>

**Table 2: Host memory usage by the compiler (in MiB) taken to compile binary data included using initializer list format vs. string literal form.**

<table>
<tr>
<th></th>
<th colspan="2">Initializer List</th>
<th colspan="2">String Literal</th>
</tr>
<tr>
<th>File Size</th>
<th>GCC</th>
<th>clang</th>
<th>GCC</th>
<th>clang</th>
</tr>
<tr>
<th align='right'>&NoBreak;1KiB</th>
<td align='right'>&NoBreak;19.38</td>
<td align='right'>&NoBreak;85.38</td>
<td align='right'>&NoBreak;19.12</td>
<td align='right'>&NoBreak;85.38</td>
</tr>
<tr>
<th align='right'>&NoBreak;2KiB</th>
<td align='right'>&NoBreak;19.38</td>
<td align='right'>&NoBreak;85.38</td>
<td align='right'>&NoBreak;19.25</td>
<td align='right'>&NoBreak;85.38</td>
</tr>
<tr>
<th align='right'>&NoBreak;4KiB</th>
<td align='right'>&NoBreak;19.62</td>
<td align='right'>&NoBreak;85.38</td>
<td align='right'>&NoBreak;19.25</td>
<td align='right'>&NoBreak;85.38</td>
</tr>
<tr>
<th align='right'>&NoBreak;8KiB</th>
<td align='right'>&NoBreak;20.00</td>
<td align='right'>&NoBreak;85.50</td>
<td align='right'>&NoBreak;19.25</td>
<td align='right'>&NoBreak;85.38</td>
</tr>
<tr>
<th align='right'>&NoBreak;16KiB</th>
<td align='right'>&NoBreak;20.88</td>
<td align='right'>&NoBreak;86.22</td>
<td align='right'>&NoBreak;19.38</td>
<td align='right'>&NoBreak;85.38</td>
</tr>
<tr>
<th align='right'>&NoBreak;32KiB</th>
<td align='right'>&NoBreak;22.59</td>
<td align='right'>&NoBreak;87.38</td>
<td align='right'>&NoBreak;19.50</td>
<td align='right'>&NoBreak;85.51</td>
</tr>
<tr>
<th align='right'>&NoBreak;64KiB</th>
<td align='right'>&NoBreak;26.02</td>
<td align='right'>&NoBreak;89.89</td>
<td align='right'>&NoBreak;19.89</td>
<td align='right'>&NoBreak;85.66</td>
</tr>
<tr>
<th align='right'>&NoBreak;128KiB</th>
<td align='right'>&NoBreak;33.02</td>
<td align='right'>&NoBreak;94.88</td>
<td align='right'>&NoBreak;20.64</td>
<td align='right'>&NoBreak;85.98</td>
</tr>
<tr>
<th align='right'>&NoBreak;256KiB</th>
<td align='right'>&NoBreak;46.53</td>
<td align='right'>&NoBreak;104.89</td>
<td align='right'>&NoBreak;21.89</td>
<td align='right'>&NoBreak;86.85</td>
</tr>
<tr>
<th align='right'>&NoBreak;512KiB</th>
<td align='right'>&NoBreak;74.01</td>
<td align='right'>&NoBreak;128.53</td>
<td align='right'>&NoBreak;24.50</td>
<td align='right'>&NoBreak;88.73</td>
</tr>
<tr>
<th align='right'>&NoBreak;1MiB</th>
<td align='right'>&NoBreak;128.95</td>
<td align='right'>&NoBreak;180.27</td>
<td align='right'>&NoBreak;29.89</td>
<td align='right'>&NoBreak;92.75</td>
</tr>
<tr>
<th align='right'>&NoBreak;2MiB</th>
<td align='right'>&NoBreak;243.25</td>
<td align='right'>&NoBreak;283.27</td>
<td align='right'>&NoBreak;40.89</td>
<td align='right'>&NoBreak;108.75</td>
</tr>
<tr>
<th align='right'>&NoBreak;4MiB</th>
<td align='right'>&NoBreak;555.72</td>
<td align='right'>&NoBreak;454.89</td>
<td align='right'>&NoBreak;62.77</td>
<td align='right'>&NoBreak;140.75</td>
</tr>
<tr>
<th align='right'>&NoBreak;8MiB</th>
<td align='right'>&NoBreak;1370.90</td>
<td align='right'>&NoBreak;831.77</td>
<td align='right'>&NoBreak;107.50</td>
<td align='right'>&NoBreak;204.75</td>
</tr>
<tr>
<th align='right'>&NoBreak;16MiB</th>
<td align='right'>&NoBreak;2744.64</td>
<td align='right'>&NoBreak;1583.78</td>
<td align='right'>&NoBreak;203.50</td>
<td align='right'>&NoBreak;332.75</td>
</tr>
<tr>
<th align='right'>&NoBreak;32MiB</th>
<td align='right'>&NoBreak;4675.61</td>
<td align='right'>&NoBreak;3088.57</td>
<td align='right'>&NoBreak;395.62</td>
<td align='right'>&NoBreak;588.75</td>
</tr>
<tr>
<th align='right'>&NoBreak;64MiB</th>
<td align='right'>&NoBreak;8379.11</td>
<td align='right'>&NoBreak;6096.74</td>
<td align='right'>&NoBreak;779.50</td>
<td align='right'>&NoBreak;1100.75</td>
</tr>
<tr>
<th align='right'>&NoBreak;128MiB</th>
<td align='right'>&NoBreak;15786.36</td>
<td align='right'>&NoBreak;12113.65</td>
<td align='right'>&NoBreak;1547.50</td>
<td align='right'>&NoBreak;2124.75</td>
</tr>
<tr>
<th align='right'>&NoBreak;256MiB</th>
<td align='right'>&NoBreak;30600.66</td>
<td align='right'>&NoBreak;23359.49</td>
<td align='right'>&NoBreak;3083.50</td>
<td align='right'>&NoBreak;4172.75</td>
</tr>
</table>

p.s. Binary data inclusion with **incbin** still beats them all, but that is out of scope here, so I haven't included the numbers in the benchmarks results here.