### PR TITLE
Improve support for legacy GCC versions

### DIFF
--- a/cmake/compiler/gcc/compiler_flags.cmake
+++ b/cmake/compiler/gcc/compiler_flags.cmake
@@ -232,9 +232,7 @@ set_property(TARGET compiler-cpp PROPERTY no_threadsafe_statics "-fno-threadsafe
 set_property(TARGET asm PROPERTY required "-xassembler-with-cpp")
 
 # gcc flag for colourful diagnostic messages
-if (NOT COMPILER STREQUAL "xcc")
-set_compiler_property(PROPERTY diagnostic -fdiagnostics-color=always)
-endif()
+check_set_compiler_property(PROPERTY diagnostic -fdiagnostics-color=always)
 
 # Compiler flag for disabling pointer arithmetic warnings
 set_compiler_property(PROPERTY warning_no_pointer_arithmetic "-Wno-pointer-arith")

--- a/cmake/compiler/gcc/compiler_flags.cmake
+++ b/cmake/compiler/gcc/compiler_flags.cmake
@@ -121,7 +121,7 @@ if (NOT CONFIG_NEWLIB_LIBC AND
   set_compiler_property(APPEND PROPERTY nostdinc_include ${NOSTDINC})
 endif()
 
-set_compiler_property(PROPERTY no_printf_return_value -fno-printf-return-value)
+check_set_compiler_property(PROPERTY no_printf_return_value -fno-printf-return-value)
 
 set_property(TARGET compiler-cpp PROPERTY nostdincxx "-nostdinc++")
 

--- a/cmake/compiler/gcc/target.cmake
+++ b/cmake/compiler/gcc/target.cmake
@@ -42,7 +42,8 @@ execute_process(
     OUTPUT_VARIABLE temp_compiler_version
     )
 
-if("${temp_compiler_version}" VERSION_GREATER_EQUAL 13.1.0)
+if("${temp_compiler_version}" VERSION_LESS 4.3.0 OR
+    "${temp_compiler_version}" VERSION_GREATER_EQUAL 13.1.0)
     set(fix_header_file include/limits.h)
 else()
     set(fix_header_file include-fixed/limits.h)

--- a/cmake/modules/FindGnuLd.cmake
+++ b/cmake/modules/FindGnuLd.cmake
@@ -87,10 +87,11 @@ if(GNULD_LINKER)
     # - "GNU ld (GNU Binutils for Ubuntu) 2.34"
     # - "GNU ld (Zephyr SDK 0.15.2) 2.38"
     # - "GNU ld (Gentoo 2.39 p5) 2.39.0"
+    # - "GNU ld version 2.17.50.0.9 20070103"
     string(REGEX MATCH
-           "GNU ld \\(.+\\) ([0-9]+[.][0-9]+[.]?[0-9]*).*"
+           "GNU ld (\\(.+\\)|version) ([0-9]+[.][0-9]+[.]?[0-9]*).*"
            out_var ${gnuld_version_output})
-    set(GNULD_VERSION_STRING ${CMAKE_MATCH_1} CACHE STRING "GNU ld version" FORCE)
+    set(GNULD_VERSION_STRING ${CMAKE_MATCH_2} CACHE STRING "GNU ld version" FORCE)
   endif()
 endif()
 

--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -755,7 +755,7 @@ struct _static_thread_data {
 #define Z_THREAD_INIT_DELAY_INITIALIZER(ms) .init_delay_ms = (ms)
 #define Z_THREAD_INIT_DELAY(thread) SYS_TIMEOUT_MS((thread)->init_delay_ms)
 #else
-#define Z_THREAD_INIT_DELAY_INITIALIZER(ms) .init_delay = SYS_TIMEOUT_MS(ms)
+#define Z_THREAD_INIT_DELAY_INITIALIZER(ms) .init_delay = SYS_TIMEOUT_MS_INIT(ms)
 #define Z_THREAD_INIT_DELAY(thread) (thread)->init_delay
 #endif
 

--- a/include/zephyr/sys/time_units.h
+++ b/include/zephyr/sys/time_units.h
@@ -38,10 +38,16 @@ extern "C" {
  */
 #define SYS_FOREVER_US (-1)
 
+/** @brief System-wide macro to initialize #k_timeout_t with a number of ticks
+ * converted from milliseconds.
+ */
+#define SYS_TIMEOUT_MS_INIT(ms) \
+	Z_TIMEOUT_TICKS_INIT((ms) == SYS_FOREVER_MS ? \
+	K_TICKS_FOREVER : Z_TIMEOUT_MS_TICKS(ms))
+
 /** @brief System-wide macro to convert milliseconds to kernel timeouts
  */
-#define SYS_TIMEOUT_MS(ms) Z_TIMEOUT_TICKS((ms) == SYS_FOREVER_MS ? \
-					   K_TICKS_FOREVER : Z_TIMEOUT_MS_TICKS(ms))
+#define SYS_TIMEOUT_MS(ms) ((k_timeout_t) SYS_TIMEOUT_MS_INIT(ms))
 
 /* Exhaustively enumerated, highly optimized time unit conversion API */
 

--- a/include/zephyr/sys_clock.h
+++ b/include/zephyr/sys_clock.h
@@ -115,12 +115,14 @@ typedef struct {
 /** @} */
 
 /** @cond INTERNAL_HIDDEN */
-#define Z_TIMEOUT_NO_WAIT ((k_timeout_t) {0})
+#define Z_TIMEOUT_NO_WAIT_INIT {0}
+#define Z_TIMEOUT_NO_WAIT ((k_timeout_t) Z_TIMEOUT_NO_WAIT_INIT)
 #if defined(__cplusplus) && ((__cplusplus - 0) < 202002L)
-#define Z_TIMEOUT_TICKS(t) ((k_timeout_t) { (t) })
+#define Z_TIMEOUT_TICKS_INIT(t) { (t) }
 #else
-#define Z_TIMEOUT_TICKS(t) ((k_timeout_t) { .ticks = (t) })
+#define Z_TIMEOUT_TICKS_INIT(t) { .ticks = (t) }
 #endif
+#define Z_TIMEOUT_TICKS(t) ((k_timeout_t) Z_TIMEOUT_TICKS_INIT(t))
 #define Z_FOREVER Z_TIMEOUT_TICKS(K_TICKS_FOREVER)
 
 #ifdef CONFIG_TIMEOUT_64BIT

--- a/include/zephyr/toolchain/gcc.h
+++ b/include/zephyr/toolchain/gcc.h
@@ -103,6 +103,10 @@
 #define FUNC_ALIAS(real_func, new_alias, return_type) \
 	return_type new_alias() ALIAS_OF(real_func)
 
+#if TOOLCHAIN_GCC_VERSION < 400500
+#define __builtin_unreachable() __builtin_trap()
+#endif
+
 #if defined(CONFIG_ARCH_POSIX) && !defined(_ASMLANGUAGE)
 #include <zephyr/arch/posix/posix_trace.h>
 

--- a/include/zephyr/toolchain/zephyr_stdint.h
+++ b/include/zephyr/toolchain/zephyr_stdint.h
@@ -16,6 +16,33 @@
  * common expectations and usage.
  */
 
+/*
+ * If the compiler does not define __SIZEOF_INT__ deduce it from __INT_MAX__
+ * or INT_MAX.
+ */
+#if !defined(__SIZEOF_INT__)
+
+#if defined(__INT_MAX__)
+/* GCC >= 3.3.0 has __<val>__ implicitly defined. */
+#define __Z_INT_MAX __INT_MAX__
+#else
+/* Fall back to POSIX versions from <limits.h> */
+#define __Z_INT_MAX INT_MAX
+#include <limits.h>
+#endif
+
+#if __Z_INT_MAX == 0x7fff
+#define __SIZEOF_INT__ 2
+#elif __Z_INT_MAX == 0x7fffffffL
+#define __SIZEOF_INT__ 4
+#elif __Z_INT_MAX > 0x7fffffffL
+#define __SIZEOF_INT__ 8
+#endif
+
+#undef __Z_INT_MAX
+
+#endif
+
 #if __SIZEOF_INT__ != 4
 #error "unexpected int width"
 #endif

--- a/lib/libc/picolibc/CMakeLists.txt
+++ b/lib/libc/picolibc/CMakeLists.txt
@@ -11,7 +11,7 @@ zephyr_library_sources(
   stdio.c
   )
 
-zephyr_library_compile_options(-fno-lto)
+zephyr_library_compile_options($<TARGET_PROPERTY:compiler,prohibit_lto>)
 
 # define __LINUX_ERRNO_EXTENSIONS__ so we get errno defines like -ESHUTDOWN
 # used by the network stack


### PR DESCRIPTION
This patch set corrects various code and build system issues encountered while building Zephyr with a legacy version of the GCC tool-chain. With these fixes, and various fixes to picolibc which have now been accepted upstream [[1]](https://github.com/picolibc/picolibc/pull/913) [[2]](https://github.com/picolibc/picolibc/pull/916), it is possible to build Zephyr on GCC version 4.1.2 and newer.