### PR TITLE
driver: serial/uart: npcx: disable rx interrupt at init

### DIFF
--- a/drivers/serial/uart_npcx.c
+++ b/drivers/serial/uart_npcx.c
@@ -1066,6 +1066,9 @@ static int uart_npcx_init(const struct device *dev)
 	/* Disable all UART tx FIFO interrupts */
 	uart_npcx_dis_all_tx_interrupts(dev);
 
+	/* Disable rx FIFO not empty interrupt */
+	uart_npcx_irq_rx_disable(dev);
+
 	/* Clear UART rx FIFO */
 	uart_npcx_clear_rx_fifo(dev);
 


### PR DESCRIPTION
In the application, after the sysjump, the RX interrupt might remain enabled. During initialization, once the IRQ is enabled, the RX interrupt could be triggered if there is any traffic on the RX line, potentially causing an interrupt storm.

This change disables the UART RX interrupt at the driver initialization to prevent this issue from occurring.