### PR TITLE
drivers: spi: spi_max32: MAX32 SPI driver improvements

### DIFF
--- a/boards/adi/max32655evkit/max32655evkit_max32655_m4.dts
+++ b/boards/adi/max32655evkit/max32655evkit_max32655_m4.dts
@@ -10,7 +10,6 @@
  #include <adi/max32/max32655-pinctrl.dtsi>
  #include <zephyr/dt-bindings/gpio/adi-max32-gpio.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
-#include <zephyr/dt-bindings/dma/max32655_dma.h>
 
 / {
 	 model = "Analog Devices MAX32655EVKIT";

--- a/boards/adi/max32655fthr/max32655fthr_max32655_m4.dts
+++ b/boards/adi/max32655fthr/max32655fthr_max32655_m4.dts
@@ -10,7 +10,6 @@
 #include <adi/max32/max32655-pinctrl.dtsi>
 #include <zephyr/dt-bindings/gpio/adi-max32-gpio.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
-#include <zephyr/dt-bindings/dma/max32655_dma.h>
 
 / {
 	model = "Analog Devices MAX32655FTHR";

--- a/drivers/spi/spi_max32.c
+++ b/drivers/spi/spi_max32.c
@@ -610,6 +610,11 @@ static int transceive_dma(const struct device *dev, const struct spi_config *con
 		ret = spi_context_wait_for_completion(ctx);
 	} while (!ret && (spi_context_tx_on(ctx) || spi_context_rx_on(ctx)));
 
+	if (ret < 0) {
+		dma_stop(cfg->tx_dma.dev, cfg->tx_dma.channel);
+		dma_stop(cfg->rx_dma.dev, cfg->rx_dma.channel);
+	}
+
 unlock:
 	/* Deassert the CS line if hw control disabled */
 	if (!hw_cs_ctrl) {

--- a/drivers/spi/spi_max32.c
+++ b/drivers/spi/spi_max32.c
@@ -539,6 +539,8 @@ static int transceive_dma(const struct device *dev, const struct spi_config *con
 
 	spi_context_lock(ctx, async, cb, userdata, config);
 
+	MXC_SPI_ClearTXFIFO(spi);
+
 	ret = dma_get_status(cfg->tx_dma.dev, cfg->tx_dma.channel, &status);
 	if (ret < 0 || status.busy) {
 		ret = ret < 0 ? ret : -EBUSY;
@@ -568,13 +570,13 @@ static int transceive_dma(const struct device *dev, const struct spi_config *con
 	/* Assert the CS line if HW control disabled */
 	if (!hw_cs_ctrl) {
 		spi_context_cs_control(ctx, true);
+	} else {
+		spi->ctrl0 = (spi->ctrl0 & ~MXC_F_SPI_CTRL0_START) | MXC_F_SPI_CTRL0_SS_CTRL;
 	}
 
 	MXC_SPI_SetSlave(cfg->regs, ctx->config->slave);
 
 	do {
-		spi->ctrl0 &= ~(MXC_F_SPI_CTRL0_EN);
-
 		len = spi_context_max_continuous_chunk(ctx);
 		dfs_shift = spi_max32_get_dfs_shift(ctx);
 		word_count = len >> dfs_shift;
@@ -603,8 +605,6 @@ static int transceive_dma(const struct device *dev, const struct spi_config *con
 			goto unlock;
 		}
 
-		spi->ctrl0 |= MXC_F_SPI_CTRL0_EN;
-
 		data->dma_stat = 0;
 		MXC_SPI_StartTransmission(spi);
 		ret = spi_context_wait_for_completion(ctx);
@@ -614,6 +614,10 @@ unlock:
 	/* Deassert the CS line if hw control disabled */
 	if (!hw_cs_ctrl) {
 		spi_context_cs_control(ctx, false);
+	} else {
+		spi->ctrl0 &=
+			~(MXC_F_SPI_CTRL0_START | MXC_F_SPI_CTRL0_SS_CTRL | MXC_F_SPI_CTRL0_EN);
+		spi->ctrl0 |= MXC_F_SPI_CTRL0_EN;
 	}
 
 	spi_context_release(ctx, ret);

--- a/dts/arm/adi/max32/max32655.dtsi
+++ b/dts/arm/adi/max32/max32655.dtsi
@@ -6,6 +6,7 @@
 
 #include <arm/armv7-m.dtsi>
 #include <adi/max32/max32xxx.dtsi>
+#include <zephyr/dt-bindings/dma/max32655_dma.h>
 
 &pinctrl {
 	reg = <0x40008000 0x2400>;


### PR DESCRIPTION
Introduce a few improvements to the MAX32 SPI driver.

1. Move DMA bindings to a common dtsi.
2. Handle hardware chip selection in Zephyr driver for finer grained control of CS line.
3. Stop DMA if transaction times out.
