### PR TITLE
samples: boards: nordic: system_off: fix sample regex.

### DIFF
--- a/samples/boards/nordic/system_off/sample.yaml
+++ b/samples/boards/nordic/system_off/sample.yaml
@@ -112,12 +112,6 @@ tests:
         - "system off demo"
         - "Retained data not supported"
         - "Entering system off; change signal level at comparator input to restart"
-        - "system off demo"
-        - "Retained data not supported"
-        - "Entering system off; change signal level at comparator input to restart"
-        - "system off demo"
-        - "Retained data not supported"
-        - "Entering system off; change signal level at comparator input to restart"
   sample.boards.nrf.system_off.retained_mem.lpcomp_wakeup:
     extra_args:
       - "DTC_OVERLAY_FILE=
@@ -140,11 +134,5 @@ tests:
         - "Retained data: INVALID"
         - "Boot count: 1"
         - "Off count: 0"
-        - "Active Ticks:"
-        - "Entering system off; change signal level at comparator input to restart"
-        - "system off demo"
-        - "Retained data: valid"
-        - "Boot count: 2"
-        - "Off count: 1"
         - "Active Ticks:"
         - "Entering system off; change signal level at comparator input to restart"


### PR DESCRIPTION
Application won't wakeup without external trigger in the analog comparator wakeup configuration.

Therefore removing post-wakeup lines from sample regex as they are not expected to occur in default testing scenario (without external triggers).

fixes: https://github.com/zephyrproject-rtos/zephyr/issues/83897