### PR TITLE
drivers: bluetooth: silabs: Improve robustness under load

### DIFF
--- a/drivers/bluetooth/hci/Kconfig.silabs
+++ b/drivers/bluetooth/hci/Kconfig.silabs
@@ -41,4 +41,9 @@ config BT_SILABS_EFR32_ACCEPT_LINK_LAYER_STACK_SIZE
 	default 1024
 	help
 	  Link layer stack size.
+
+config BT_SILABS_EFR32_LL_THREAD_PRIO
+	# Hidden option for Co-Operative Link Layer thread priority
+	def_int 0
+
 endmenu

--- a/soc/silabs/Kconfig.defconfig
+++ b/soc/silabs/Kconfig.defconfig
@@ -19,4 +19,7 @@ config CORTEX_M_SYSTICK
 config IDLE_STACK_SIZE
 	default 512 if SOC_GECKO_PM_BACKEND_PMGR
 
+configdefault NUM_METAIRQ_PRIORITIES
+	default 1 if BT_SILABS_EFR32
+
 endif


### PR DESCRIPTION
The Silabs Bluetooth driver is running an entire BT controller, including the Link Layer underneath it. This imposes timing requirements, and failure to satisfy them degrades the BT performance. If the Link Layer doesn't get runtime in a timely manner, it needs to skip tasks, e.g., connection events. This leads to packet loss, and eventually connection timeout.

This PR divides the driver thread into two: a meta-IRQ thread running the Link Layer and a cooperative thread passing HCI events to the BT host. The meta-IRQ thread is responsible for time-critical execution of the Link Layer, and it can preempt any lower priority thread, even cooperative ones. HCI events emitted by the controller are queued for a lower priority HCI RX thread, which passes them to the BT host.

In addition to guaranteeing runtime for the Link Layer, this PR implements mechanism similar to many other HCI drivers, where it potentially discards unimportant HCI events. In case the system is flooded with events such as advertising reports, discarding some of them ensures that the system can still handle other events.

> [!IMPORTANT]  
> This PR is affected by zephyrproject-rtos/zephyr#80574. The issue prevents the meta-IRQ from preempting a cooperative thread. I've tested the changes in this PR with a [workaround](https://github.com/zephyrproject-rtos/zephyr/issues/80574#issuecomment-2451800979) proposed in the issue. However, the issue doesn't prevent merging this PR, but the benefits are available only after the issue is fixed.