### PR TITLE
drivers: disk: sdmmc_subsys: stm32_sdmmc driver custom disk name support

### DIFF
--- a/drivers/disk/sdmmc_stm32.c
+++ b/drivers/disk/sdmmc_stm32.c
@@ -537,7 +537,7 @@ static const struct disk_operations stm32_sdmmc_ops = {
 };
 
 static struct disk_info stm32_sdmmc_info = {
-	.name = "SD",
+	.name = DT_INST_PROP_OR(0, disk_name, "SD"),
 	.ops = &stm32_sdmmc_ops,
 };
 

--- a/dts/bindings/mmc/st,stm32-sdmmc.yaml
+++ b/dts/bindings/mmc/st,stm32-sdmmc.yaml
@@ -5,6 +5,11 @@ compatible: "st,stm32-sdmmc"
 include: [mmc.yaml, pinctrl-device.yaml, reset-device.yaml]
 
 properties:
+  disk-name:
+    type: string
+    description: |
+      Disk name.
+
   clocks:
     required: true
 


### PR DESCRIPTION
In order to allow a custom disk name same as with the standard sdmmc driver an additional device-tree property was introduced.

In https://github.com/zephyrproject-rtos/zephyr/commit/a1dc0b8b3e97542ca9f0c84cba37067710b61ccb the kconfig option was removed but no alternative was introduced for this driver thus the changes.