### PR TITLE
drivers: nrfx: Avoid unhandled event calling assert function

### DIFF
--- a/drivers/clock_control/clock_control_nrf.c
+++ b/drivers/clock_control/clock_control_nrf.c
@@ -622,6 +622,11 @@ static void clock_event_handler(nrfx_clock_evt_type_t event)
 			__ASSERT_NO_MSG(false);
 		}
 		break;
+	case NRFX_CLOCK_EVT_PLL_STARTED:
+	{
+		/* unhandled event */
+		break;
+	}
 	default:
 		__ASSERT_NO_MSG(0);
 		break;


### PR DESCRIPTION
For the internal LFCLK the unhandled NRFX_CLOCK_EVT_PLL_STARTED event has the effect that the assert function is called. This will be avoided by this PR.