### PR TITLE
drivers/sensor: ism330dhcx: toggle device_conf bit

### DIFF
--- a/drivers/sensor/st/ism330dhcx/ism330dhcx.c
+++ b/drivers/sensor/st/ism330dhcx/ism330dhcx.c
@@ -713,6 +713,15 @@ static int ism330dhcx_init_chip(const struct device *dev)
 
 	k_busy_wait(100);
 
+	/*
+	 * Set device_conf bit to 1 for a proper configuration
+	 * as stated in DS chapter paragraph 9.20
+	 */
+	if (ism330dhcx_device_conf_set(ism330dhcx->ctx, 1) < 0) {
+		LOG_DBG("Failed setting device_conf bit");
+		return -EIO;
+	}
+
 	LOG_DBG("accel range is %d", cfg->accel_range);
 	if (ism330dhcx_accel_range_set(dev, cfg->accel_range) < 0) {
 		LOG_DBG("failed to set accelerometer full-scale");


### PR DESCRIPTION
Set ctrl9_xl.device_conf bit to 1 in ism330dhcx_init_chip() prior to start device configuration, as stated in paragraph 9.20 of the datasheet.

It may fix #62350