### PR TITLE
Bluetooth: Controller: Fix div-by-zero with BT_CONN_PARAM_ANY

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_central.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_central.c
@@ -101,6 +101,13 @@ uint8_t ll_create_connection(uint16_t scan_interval, uint16_t scan_window,
 	uint8_t hop;
 	int err;
 
+	/* Disallow invalid connection interval */
+	if (!IS_ENABLED(CONFIG_BT_CTLR_CONN_INTERVAL_LOW_LATENCY) &&
+	    !IN_RANGE(interval, BT_HCI_LE_INTERVAL_MIN, BT_HCI_LE_INTERVAL_MAX)) {
+		return BT_HCI_ERR_INVALID_PARAM;
+	}
+
+	/* Concurrent scanning and initiating not supported */
 	scan = ull_scan_is_disabled_get(SCAN_HANDLE_1M);
 	if (!scan) {
 		return BT_HCI_ERR_CMD_DISALLOWED;

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_common.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_common.c
@@ -235,7 +235,14 @@ static void lp_comm_tx(struct ll_conn *conn, struct proc_ctx *ctx)
 		 * NOTE: As the supervision timeout is at most 32s the normal procedure response
 		 * timeout of 40s will never come into play for the ACL Termination procedure.
 		 */
-		const uint32_t conn_interval_us = conn->lll.interval * CONN_INT_UNIT_US;
+		uint32_t conn_interval_us;
+
+		if (conn->lll.interval >= BT_HCI_LE_INTERVAL_MIN) {
+			conn_interval_us = conn->lll.interval * CONN_INT_UNIT_US;
+		} else {
+			conn_interval_us = (conn->lll.interval + 1U) * CONN_LOW_LAT_INT_UNIT_US;
+		}
+
 		const uint16_t sto_reload = RADIO_CONN_EVENTS(
 			(conn->supervision_timeout * 10U * 1000U),
 			conn_interval_us);

--- a/subsys/bluetooth/controller/ll_sw/ull_peripheral.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_peripheral.c
@@ -157,10 +157,15 @@ void ull_periph_setup(struct node_rx_pdu *rx, struct node_rx_ftr *ftr,
 			       sizeof(lll->data_chan_map));
 	lll->data_chan_hop = pdu_adv->connect_ind.hop;
 	lll->interval = sys_le16_to_cpu(pdu_adv->connect_ind.interval);
+
+	/* Check for minimum required channels, hop count and disallow invalid
+	 * connection interval value.
+	 */
 	if ((lll->data_chan_count < CHM_USED_COUNT_MIN) ||
 	    (lll->data_chan_hop < CHM_HOP_COUNT_MIN) ||
 	    (lll->data_chan_hop > CHM_HOP_COUNT_MAX) ||
-	    !lll->interval) {
+	    (!IS_ENABLED(CONFIG_BT_CTLR_CONN_INTERVAL_LOW_LATENCY) &&
+	     !IN_RANGE(lll->interval, BT_HCI_LE_INTERVAL_MIN, BT_HCI_LE_INTERVAL_MAX)) {
 		invalid_release(&adv->ull, lll, link, rx);
 
 		return;


### PR DESCRIPTION
Fix div-by-zero usage fault when BT_CONN_PARAM_ANY is enabled and a value of 0 is used as connection interval value.