### PR TITLE
net: ethernet: Only try ARP for IP packets

### DIFF
--- a/include/zephyr/net/net_core.h
+++ b/include/zephyr/net/net_core.h
@@ -186,8 +186,7 @@ struct net_l3_register {
 		.handler = _handler,					\
 		.name = STRINGIFY(_name),				\
 		.l2 = _l2_type,						\
-	};								\
-	BUILD_ASSERT((_handler) != NULL, "Handler is not defined")
+	};
 
 /* @endcond */
 

--- a/subsys/net/ip/ipv4.c
+++ b/subsys/net/ip/ipv4.c
@@ -454,8 +454,6 @@ drop:
 
 enum net_verdict net_ipv4_prepare_for_send(struct net_pkt *pkt)
 {
-	net_pkt_set_ll_proto_type(pkt, NET_ETH_PTYPE_IP);
-
 	if (IS_ENABLED(CONFIG_NET_IPV4_PMTU)) {
 		struct net_pmtu_entry *entry;
 		struct sockaddr_in dst = {

--- a/subsys/net/ip/ipv4_fragment.c
+++ b/subsys/net/ip/ipv4_fragment.c
@@ -441,6 +441,8 @@ static int send_ipv4_fragment(struct net_pkt *pkt, uint16_t rand_id, uint16_t fi
 	net_pkt_cursor_backup(pkt, &cur_pkt);
 	net_pkt_cursor_backup(frag_pkt, &cur);
 
+	net_pkt_set_ll_proto_type(frag_pkt, net_pkt_ll_proto_type(pkt));
+
 	/* Copy the original IPv4 headers back to the fragment packet */
 	if (net_pkt_copy(frag_pkt, pkt, net_pkt_ip_hdr_len(pkt))) {
 		goto fail;

--- a/subsys/net/ip/ipv6_fragment.c
+++ b/subsys/net/ip/ipv6_fragment.c
@@ -609,6 +609,8 @@ static int send_ipv6_fragment(struct net_pkt *pkt,
 
 	net_pkt_cursor_init(pkt);
 
+	net_pkt_set_ll_proto_type(frag_pkt, net_pkt_ll_proto_type(pkt));
+
 	/* We copy original headers back to the fragment packet
 	 * Note that we insert the right next header to point to fragment header
 	 */

--- a/subsys/net/ip/ipv6_nbr.c
+++ b/subsys/net/ip/ipv6_nbr.c
@@ -806,8 +806,6 @@ enum net_verdict net_ipv6_prepare_for_send(struct net_pkt *pkt)
 		return NET_DROP;
 	}
 
-	net_pkt_set_ll_proto_type(pkt, NET_ETH_PTYPE_IPV6);
-
 #if defined(CONFIG_NET_IPV6_FRAGMENT)
 	/* If we have already fragmented the packet, the fragment id will
 	 * contain a proper value and we can skip other checks.

--- a/subsys/net/l2/ethernet/arp.c
+++ b/subsys/net/l2/ethernet/arp.c
@@ -78,6 +78,9 @@ static struct arp_entry *arp_entry_find(sys_slist_t *list,
 
 		if (entry->iface == iface &&
 		    net_ipv4_addr_cmp(&entry->ip, dst)) {
+			NET_DBG("found dst %s",
+				net_sprint_ipv4_addr(dst));
+
 			return entry;
 		}
 
@@ -463,7 +466,7 @@ struct net_pkt *net_arp_prepare(struct net_pkt *pkt,
 	NET_DBG("ARP using ll %s for IP %s",
 		net_sprint_ll_addr(net_pkt_lladdr_dst(pkt)->addr,
 				   sizeof(struct net_eth_addr)),
-		net_sprint_ipv4_addr(&NET_IPV4_HDR(pkt)->dst));
+		net_sprint_ipv4_addr(NET_IPV4_HDR(pkt)->dst));
 
 	return pkt;
 }
@@ -691,10 +694,10 @@ void net_arp_update(struct net_if *iface,
 		net_pkt_lladdr_dst(pkt)->addr =
 			(uint8_t *) &NET_ETH_HDR(pkt)->dst.addr;
 
-		NET_DBG("iface %d (%p) dst %s pending %p frag %p",
+		NET_DBG("iface %d (%p) dst %s pending %p frag %p ptype 0x%04x",
 			net_if_get_by_iface(iface), iface,
 			net_sprint_ipv4_addr(&entry->ip),
-			pkt, pkt->frags);
+			pkt, pkt->frags, net_pkt_ll_proto_type(pkt));
 
 		/* We directly send the packet without first queueing it.
 		 * The pkt has already been queued for sending, once by

--- a/subsys/net/l2/ethernet/ethernet.c
+++ b/subsys/net/l2/ethernet/ethernet.c
@@ -711,7 +711,8 @@ static int ethernet_send(struct net_if *iface, struct net_pkt *pkt)
 		goto send;
 	}
 
-	if (IS_ENABLED(CONFIG_NET_IPV4) && net_pkt_family(pkt) == AF_INET) {
+	if (IS_ENABLED(CONFIG_NET_IPV4) && net_pkt_family(pkt) == AF_INET &&
+	    net_pkt_ll_proto_type(pkt) == NET_ETH_PTYPE_IP) {
 		if (!net_pkt_ipv4_acd(pkt)) {
 			struct net_pkt *tmp;
 

--- a/subsys/net/l2/ethernet/ethernet.c
+++ b/subsys/net/l2/ethernet/ethernet.c
@@ -353,7 +353,8 @@ static enum net_verdict ethernet_recv(struct net_if *iface,
 	net_buf_pull(pkt->frags, hdr_len);
 
 	STRUCT_SECTION_FOREACH(net_l3_register, l3) {
-		if (l3->ptype != type || l3->l2 != &NET_L2_GET_NAME(ETHERNET)) {
+		if (l3->ptype != type || l3->l2 != &NET_L2_GET_NAME(ETHERNET) ||
+		    l3->handler == NULL) {
 			continue;
 		}
 

--- a/tests/net/arp/src/main.c
+++ b/tests/net/arp/src/main.c
@@ -565,9 +565,6 @@ ZTEST(arp_fn_tests, test_arp)
 
 	net_pkt_unref(pkt);
 
-	/* Clear the ARP cache so that old entries do not confuse the tests */
-	net_arp_clear_cache(iface);
-
 	/* Then feed in ARP request */
 	pkt = net_pkt_alloc_with_buffer(iface, sizeof(struct net_eth_hdr) +
 					sizeof(struct net_arp_hdr),


### PR DESCRIPTION
The work in Ethernet send in commit 2f10d7d81624 ("net: ethernet: Set the ptype by the caller in send") introduced a bug because we could try to do ARP resolving for ARP packets too. This is clearly a wrong thing to do. So before trying to do ARP resolving, make sure the the packet type is IP packet.
