### PR TITLE
include: util: Add `memeq` and `bool_memcmp`

### DIFF
--- a/include/zephyr/sys/util.h
+++ b/include/zephyr/sys/util.h
@@ -28,6 +28,7 @@
 #include <zephyr/types.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <string.h>
 
 /** @brief Number of bits that make up a type */
 #define NUM_BITS(t) (sizeof(t) * BITS_PER_BYTE)
@@ -781,6 +782,40 @@ static inline void mem_xor_32(uint8_t dst[4], const uint8_t src1[4], const uint8
 static inline void mem_xor_128(uint8_t dst[16], const uint8_t src1[16], const uint8_t src2[16])
 {
 	mem_xor_n(dst, src1, src2, 16);
+}
+
+/**
+ * @brief Compare memory areas. The same way as `memcmp` it assume areas to be
+ * the same length
+ *
+ * @param m1 First memory area to compare, cannot be NULL even if length is 0
+ * @param m2 Second memory area to compare, cannot be NULL even if length is 0
+ * @param n First n bytes of @p m1 and @p m2 to compares
+ *
+ * @returns true if the @p n first bytes of @p m1 and @p m2 are the same, else
+ * false
+ */
+static inline bool util_memeq(const void *m1, const void *m2, size_t n)
+{
+	return memcmp(m1, m2, n) == 0;
+}
+
+/**
+ * @brief Compare memory areas and their length
+ *
+ * If the length are 0, return true.
+ *
+ * @param m1 First memory area to compare, cannot be NULL even if length is 0
+ * @param len1 Length of the first memory area to compare
+ * @param m2 Second memory area to compare, cannot be NULL even if length is 0
+ * @param len2 Length of the second memory area to compare
+ *
+ * @returns true if both the length of the memory areas and their content are
+ * equal else false
+ */
+static inline bool util_eq(const void *m1, size_t len1, const void *m2, size_t len2)
+{
+	return len1 == len2 && (m1 == m2 || util_memeq(m1, m2, len1));
 }
 
 #ifdef __cplusplus

--- a/subsys/bluetooth/host/keys.h
+++ b/subsys/bluetooth/host/keys.h
@@ -9,6 +9,7 @@
 #ifndef ZEPHYR_SUBSYS_BLUETOOTH_HOST_KEYS_H_
 #define ZEPHYR_SUBSYS_BLUETOOTH_HOST_KEYS_H_
 
+#include <zephyr/sys/util.h>
 #include <zephyr/bluetooth/bluetooth.h>
 
 /** @cond INTERNAL_HIDDEN */
@@ -54,7 +55,7 @@ struct bt_irk {
 
 static inline bool bt_irk_eq(struct bt_irk const *a, struct bt_irk const *b)
 {
-	return (memcmp(a->val, b->val, sizeof(a->val)) == 0);
+	return util_memeq(a->val, b->val, sizeof(a->val));
 }
 
 struct bt_csrk {

--- a/tests/bsim/bluetooth/host/misc/disconnect/tester/src/main.c
+++ b/tests/bsim/bluetooth/host/misc/disconnect/tester/src/main.c
@@ -5,6 +5,7 @@
  */
 
 #include <zephyr/kernel.h>
+#include <zephyr/sys/util.h>
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/__assert.h>
 
@@ -190,8 +191,7 @@ static void handle_att_write(struct net_buf *buf)
 
 	static uint8_t ccc_write[2] = {0x03, 0x00};
 
-	TEST_ASSERT(buf->len == 2, "unexpected write length: %d", buf->len);
-	TEST_ASSERT(memcmp(buf->data, ccc_write, sizeof(ccc_write)) == 0, "bad data");
+	TEST_ASSERT(util_eq(buf->data, buf->len, ccc_write, sizeof(ccc_write)), "bad data\n");
 
 	send_write_rsp();
 }

--- a/tests/unit/util/main.c
+++ b/tests/unit/util/main.c
@@ -918,4 +918,55 @@ ZTEST(util, test_utf8_lcpy_null_termination)
 	zassert_str_equal(dest_str, expected_result, "Failed to truncate");
 }
 
+ZTEST(util, test_util_eq)
+{
+	uint8_t src1[16];
+	uint8_t src2[16];
+
+	bool mem_area_matching_1;
+	bool mem_area_matching_2;
+
+	memset(src1, 0, sizeof(src1));
+	memset(src2, 0, sizeof(src2));
+
+	for (size_t i = 0U; i < 16; i++) {
+		src1[i] = 0xAB;
+		src2[i] = 0xAB;
+	}
+
+	src1[15] = 0xCD;
+	src2[15] = 0xEF;
+
+	mem_area_matching_1 = util_eq(src1, sizeof(src1), src2, sizeof(src2));
+	mem_area_matching_2 = util_eq(src1, sizeof(src1) - 1, src2, sizeof(src2) - 1);
+
+	zassert_false(mem_area_matching_1);
+	zassert_true(mem_area_matching_2);
+}
+
+ZTEST(util, test_util_memeq)
+{
+	uint8_t src1[16];
+	uint8_t src2[16];
+	uint8_t src3[16];
+
+	bool mem_area_matching_1;
+	bool mem_area_matching_2;
+
+	memset(src1, 0, sizeof(src1));
+	memset(src2, 0, sizeof(src2));
+
+	for (size_t i = 0U; i < 16; i++) {
+		src1[i] = 0xAB;
+		src2[i] = 0xAB;
+		src3[i] = 0xCD;
+	}
+
+	mem_area_matching_1 = util_memeq(src1, src2, sizeof(src1));
+	mem_area_matching_2 = util_memeq(src1, src3, sizeof(src1));
+
+	zassert_true(mem_area_matching_1);
+	zassert_false(mem_area_matching_2);
+}
+
 ZTEST_SUITE(util, NULL, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
Those two functions are used to compare memory area. `bool_memcmp` is basically `memcmp` but return a `bool` instead of an `int`. `memeq` compare the length of the memory area in addition to the bytes themselves.