### PR TITLE
net: coap: Fix response matching algorithm 

### DIFF
--- a/subsys/net/lib/coap/coap.c
+++ b/subsys/net/lib/coap/coap.c
@@ -1172,7 +1172,7 @@ bool coap_packet_is_request(const struct coap_packet *cpkt)
 {
 	uint8_t code = coap_header_get_code(cpkt);
 
-	return !(code & ~COAP_REQUEST_MASK);
+	return (code != COAP_CODE_EMPTY) && !(code & ~COAP_REQUEST_MASK);
 }
 
 int coap_handle_request_len(struct coap_packet *cpkt,
@@ -1183,7 +1183,7 @@ int coap_handle_request_len(struct coap_packet *cpkt,
 			    struct sockaddr *addr, socklen_t addr_len)
 {
 	if (!coap_packet_is_request(cpkt)) {
-		return 0;
+		return -ENOTSUP;
 	}
 
 	/* FIXME: deal with hierarchical resources */

--- a/subsys/net/lib/coap/coap.c
+++ b/subsys/net/lib/coap/coap.c
@@ -1808,32 +1808,63 @@ struct coap_reply *coap_response_received(
 {
 	struct coap_reply *r;
 	uint8_t token[COAP_TOKEN_MAX_LEN];
+	bool piggybacked = false;
+	uint8_t type;
 	uint16_t id;
 	uint8_t tkl;
 	size_t i;
 
-	if (!is_empty_message(response) && coap_packet_is_request(response)) {
-		/* Request can't be response */
+	type = coap_header_get_type(response);
+	id = coap_header_get_id(response);
+	tkl = coap_header_get_token(response, token);
+
+	if ((type == COAP_TYPE_ACK && is_empty_message(response)) ||
+	    coap_packet_is_request(response)) {
+		/* Request or empty ACK can't be response */
 		return NULL;
 	}
 
-	id = coap_header_get_id(response);
-	tkl = coap_header_get_token(response, token);
+	if (type == COAP_TYPE_ACK) {
+		piggybacked = true;
+	}
 
 	for (i = 0, r = replies; i < len; i++, r++) {
 		int age;
 
-		if ((r->id == 0U) && (r->tkl == 0U)) {
+		/* Skip unused entry. */
+		if (r->reply == NULL) {
 			continue;
 		}
 
-		/* Piggybacked must match id when token is empty */
-		if ((r->id != id) && (tkl == 0U)) {
+		/* Reset should only be handled if Message ID matches. */
+		if (type == COAP_TYPE_RESET) {
+			if (r->id != id) {
+				continue;
+			}
+
+			goto handle_reply;
+		}
+
+		/* In a piggybacked response, the Message ID of the Confirmable
+		 * request and the Acknowledgment MUST match, and the tokens of
+		 * the response and original request MUST match.  In a separate
+		 * response, just the tokens of the response and original request
+		 * MUST match.
+		 */
+		if (piggybacked) {
+			if (r->id != id) {
+				continue;
+			}
+		}
+
+		if (r->tkl != tkl) {
 			continue;
 		}
 
-		if (tkl > 0 && memcmp(r->token, token, tkl)) {
-			continue;
+		if (r->tkl > 0) {
+			if (memcmp(r->token, token, r->tkl) != 0) {
+				continue;
+			}
 		}
 
 		age = coap_get_option_int(response, COAP_OPTION_OBSERVE);
@@ -1841,6 +1872,7 @@ struct coap_reply *coap_response_received(
 		if (age == -ENOENT || coap_age_is_newer(r->age, age)) {
 			r->age = age;
 			if (coap_header_get_code(response) != COAP_RESPONSE_CODE_CONTINUE) {
+handle_reply:
 				r->reply(response, r, from);
 			}
 		}

--- a/tests/net/lib/coap/src/main.c
+++ b/tests/net/lib/coap/src/main.c
@@ -1855,4 +1855,127 @@ ZTEST(coap, test_age_is_newer)
 		     "Max age should be marked as newer");
 }
 
+struct test_coap_request {
+	uint16_t id;
+	uint8_t token[COAP_TOKEN_MAX_LEN];
+	uint8_t tkl;
+	uint8_t code;
+	enum coap_msgtype type;
+	struct coap_reply *match;
+};
+
+static int reply_cb(const struct coap_packet *response,
+		    struct coap_reply *reply,
+		    const struct sockaddr *from)
+{
+	return 0;
+}
+
+ZTEST(coap, test_response_matching)
+{
+	struct coap_reply matches[] = {
+		{ }, /* Non-initialized (unused) entry. */
+		{ .id = 100, .reply = reply_cb },
+		{ .id = 101, .token = { 1, 2, 3, 4 }, .tkl = 4, .reply = reply_cb },
+	};
+	struct test_coap_request test_responses[] = {
+		/* #0 Piggybacked ACK, empty token */
+		{ .id = 100, .type = COAP_TYPE_ACK, .match = &matches[1],
+		  .code = COAP_RESPONSE_CODE_CONTENT },
+		/* #1 Piggybacked ACK, matching token */
+		{ .id = 101, .type = COAP_TYPE_ACK, .match = &matches[2],
+		  .code = COAP_RESPONSE_CODE_CONTENT, .token = { 1, 2, 3, 4 },
+		  .tkl = 4  },
+		/* #2 Piggybacked ACK, token mismatch */
+		{ .id = 101, .type = COAP_TYPE_ACK, .match = NULL,
+		  .code = COAP_RESPONSE_CODE_CONTENT, .token = { 1, 2, 3, 3 },
+		  .tkl = 4 },
+		/* #3 Piggybacked ACK, token mismatch 2 */
+		{ .id = 100, .type = COAP_TYPE_ACK, .match = NULL,
+		  .code = COAP_RESPONSE_CODE_CONTENT, .token = { 1, 2, 3, 4 },
+		  .tkl = 4 },
+		/* #4 Piggybacked ACK, token mismatch 3 */
+		{ .id = 101, .type = COAP_TYPE_ACK, .match = NULL,
+		  .code = COAP_RESPONSE_CODE_CONTENT, .token = { 1, 2, 3 },
+		  .tkl = 3 },
+		/* #5 Piggybacked ACK, token mismatch 4 */
+		{ .id = 101, .type = COAP_TYPE_ACK, .match = NULL,
+		  .code = COAP_RESPONSE_CODE_CONTENT },
+		/* #6 Piggybacked ACK, id mismatch */
+		{ .id = 102, .type = COAP_TYPE_ACK, .match = NULL,
+		  .code = COAP_RESPONSE_CODE_CONTENT, .token = { 1, 2, 3, 4 },
+		  .tkl = 4 },
+		/* #7 Separate reply, empty token */
+		{ .id = 101, .type = COAP_TYPE_CON, .match = &matches[1],
+		  .code = COAP_RESPONSE_CODE_CONTENT },
+		/* #8 Separate reply, matching token 1 */
+		{ .id = 101, .type = COAP_TYPE_CON, .match = &matches[2],
+		  .code = COAP_RESPONSE_CODE_CONTENT, .token = { 1, 2, 3, 4 },
+		  .tkl = 4 },
+		/* #9 Separate reply, matching token 2 */
+		{ .id = 102, .type = COAP_TYPE_CON, .match = &matches[2],
+		  .code = COAP_RESPONSE_CODE_CONTENT, .token = { 1, 2, 3, 4 },
+		  .tkl = 4 },
+		/* #10 Separate reply, token mismatch */
+		{ .id = 101, .type = COAP_TYPE_CON, .match = NULL,
+		  .code = COAP_RESPONSE_CODE_CONTENT, .token = { 1, 2, 3, 3 },
+		  .tkl = 4 },
+		/* #11 Separate reply, token mismatch 2 */
+		{ .id = 100, .type = COAP_TYPE_CON, .match = NULL,
+		  .code = COAP_RESPONSE_CODE_CONTENT, .token = { 1, 2, 3, 3 },
+		  .tkl = 4 },
+		/* #12 Separate reply, token mismatch 3 */
+		{ .id = 100, .type = COAP_TYPE_CON, .match = NULL,
+		  .code = COAP_RESPONSE_CODE_CONTENT, .token = { 1, 2, 3 },
+		  .tkl = 3 },
+		/* #13 Request, empty token */
+		{ .id = 100, .type = COAP_TYPE_CON, .match = NULL,
+		  .code = COAP_METHOD_GET },
+		/* #14 Request, matching token */
+		{ .id = 101, .type = COAP_TYPE_CON, .match = NULL,
+		  .code = COAP_METHOD_GET, .token = { 1, 2, 3, 4 }, .tkl = 4 },
+		/* #15 Empty ACK */
+		{ .id = 100, .type = COAP_TYPE_ACK, .match = NULL,
+		  .code = COAP_CODE_EMPTY },
+		/* #16 Empty ACK 2 */
+		{ .id = 101, .type = COAP_TYPE_ACK, .match = NULL,
+		  .code = COAP_CODE_EMPTY },
+		/* #17 Empty RESET */
+		{ .id = 100, .type = COAP_TYPE_RESET, .match = &matches[1],
+		  .code = COAP_CODE_EMPTY },
+		/* #18 Empty RESET 2 */
+		{ .id = 101, .type = COAP_TYPE_RESET, .match = &matches[2],
+		  .code = COAP_CODE_EMPTY },
+		/* #19 Empty RESET, id mismatch */
+		{ .id = 102, .type = COAP_TYPE_RESET, .match = NULL,
+		  .code = COAP_CODE_EMPTY },
+	};
+
+	ARRAY_FOR_EACH_PTR(test_responses, response) {
+		struct coap_packet response_pkt = { 0 };
+		struct sockaddr from = { 0 };
+		struct coap_reply *match;
+		uint8_t data[64];
+		int ret;
+
+		ret = coap_packet_init(&response_pkt, data, sizeof(data), COAP_VERSION_1,
+				       response->type, response->tkl, response->token,
+				       response->code, response->id);
+		zassert_ok(ret, "Failed to initialize test packet: %d", ret);
+
+		match = coap_response_received(&response_pkt, &from, matches,
+					       ARRAY_SIZE(matches));
+		if (response->match != NULL) {
+			zassert_not_null(match, "Did not found a response match when expected");
+			zassert_equal_ptr(response->match, match,
+					  "Wrong response match, test %d match %d",
+					  response - test_responses, match - matches);
+		} else {
+			zassert_is_null(match,
+					"Found unexpected response match, test %d match %d",
+					response - test_responses, match - matches);
+		}
+	}
+}
+
 ZTEST_SUITE(coap, NULL, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
* Add test case for matching pending replies with received responses.
Cover corner cases that are failing with the current implementation.

* Fix response matching algorithm 

Fixes #84100