### PR TITLE
ci: twister: rename weekly twister job

### DIFF
--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -160,7 +160,7 @@ jobs:
           fi
 
       - if: github.event_name == 'schedule'
-        name: Run Tests with Twister (Daily)
+        name: Run Tests with Twister (Weekly)
         id: run_twister_sched
         run: |
           export ZEPHYR_BASE=${PWD}


### PR DESCRIPTION
Properly name the twister weekly job to reflect it's running... weekly, not daily.