### PR TITLE
samples: smp: pi: keep main thread sleeping until ready

### DIFF
--- a/samples/arch/smp/pi/src/main.c
+++ b/samples/arch/smp/pi/src/main.c
@@ -30,6 +30,8 @@ static struct k_thread tthread[THREADS_NUM];
 static char th_buffer[THREADS_NUM][DIGITS_NUM + 1];
 static atomic_t th_counter = THREADS_NUM;
 
+struct k_sem main_sem;
+
 void test_thread(void *arg1, void *arg2, void *arg3)
 {
 	atomic_t *counter = (atomic_t *)arg1;
@@ -74,13 +76,20 @@ void test_thread(void *arg1, void *arg2, void *arg3)
 		buffer += 4;
 	}
 
-	atomic_dec(counter);
+	if (atomic_dec(counter) == 1) {
+		k_sem_give(&main_sem);
+	}
 }
 
 int main(void)
 {
 	uint32_t start_time, stop_time, cycles_spent, nanoseconds_spent;
 	int i;
+
+	if (k_sem_init(&main_sem, 0, 1)) {
+		printk("Failed initialization!\n");
+		return -1;
+	}
 
 	printk("Calculate first %d digits of Pi independently by %d threads.\n",
 	       DIGITS_NUM, THREADS_NUM);
@@ -96,9 +105,7 @@ int main(void)
 	}
 
 	/* Wait for all workers to finish their calculations */
-	while (th_counter) {
-		k_sleep(K_MSEC(1));
-	}
+	k_sem_take(&main_sem, K_FOREVER);
 
 	/* Capture final time stamp */
 	stop_time = k_cycle_get_32();


### PR DESCRIPTION
Use `k_sleep(K_FOREVER)` in the main thread to keep it sleeping while worker threads are running. The last worker thread to finish calculation wakes up the main thread.