### PR TITLE
soc: lowrisc: opentitan: Fix manifest sizing

### DIFF
--- a/soc/lowrisc/opentitan/Kconfig.defconfig
+++ b/soc/lowrisc/opentitan/Kconfig.defconfig
@@ -21,6 +21,6 @@ config NUM_IRQS
 # The OpenTitan SoC requires a manifest in front of the
 # application binary.
 config ROM_START_OFFSET
-	default 0x404
+	default 0x400
 
 endif # SOC_OPENTITAN

--- a/soc/lowrisc/opentitan/rom_header.S
+++ b/soc/lowrisc/opentitan/rom_header.S
@@ -17,7 +17,7 @@ GTEXT(__rom_header)
  * 0x6c47 (minor).  The manifest format is documented here:
  * https://github.com/lowRISC/opentitan/blob/689a163294e1791bd30cfe096decf7f9233abad4/sw/host/opentitanlib/src/image/manifest.rs#L205
  */
-SECTION_FUNC(rom_header, __rom_header)
+SECTION_VAR(rom_header, __rom_header)
 	.rept(225)
 	.word 0
 	.endr


### PR DESCRIPTION
The actual manifest is 1024 bytes, but we previously had padding bytes due to the implementation of SECTION_FUNC(). The manifest is not executable code so SECTION_VAR() is appropriate and produces a section of the appropriate size.

Fixes: #82822