### PR TITLE
samples: Add support for different base address of the shared mem in the memory map of each core

### DIFF
--- a/lib/open-amp/CMakeLists.txt
+++ b/lib/open-amp/CMakeLists.txt
@@ -5,13 +5,20 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-zephyr_include_directories_ifdef(CONFIG_OPENAMP_RSC_TABLE .)
-
-# include vendor-specific resource table files
-if(CONFIG_OPENAMP_VENDOR_RSC_TABLE)
-  zephyr_sources(vendor/${CONFIG_OPENAMP_VENDOR_RSC_TABLE_FILE})
+# include vendor-specific resources
+if(CONFIG_OPENAMP_VENDOR_RSC_TABLE OR CONFIG_OPENAMP_VENDOR_ADDR_TRANSLATION)
   zephyr_include_directories(vendor)
-elseif(CONFIG_OPENAMP_RSC_TABLE)
-# include generic resource table
-  zephyr_sources(resource_table.c)
+endif()
+
+if(CONFIG_OPENAMP_RSC_TABLE)
+  zephyr_include_directories(.)
+  # include generic address translation ops
+  zephyr_sources(addr_translation.c)
+  # include vendor-specific resource table files
+  if(CONFIG_OPENAMP_VENDOR_RSC_TABLE)
+    zephyr_sources(vendor/${CONFIG_OPENAMP_VENDOR_RSC_TABLE_FILE})
+  else()
+    # include generic resource table
+    zephyr_sources(resource_table.c)
+  endif()
 endif()

--- a/lib/open-amp/Kconfig
+++ b/lib/open-amp/Kconfig
@@ -63,3 +63,17 @@ config OPENAMP_VENDOR_RSC_TABLE_FILE
 	help
 	  Name of a source file containing vendor-specific
 	  resource table.
+
+config OPENAMP_VENDOR_ADDR_TRANSLATION
+	bool "Address translation support for OpenAMP"
+	depends on OPENAMP_RSC_TABLE
+	help
+	  Enable support for address translation from remote driver to device
+
+config OPENAMP_VENDOR_ADDR_TRANSLATION_FILE
+	string "Header file containing vendor-specific address translation table"
+	default "addr_translation.h"
+	depends on OPENAMP_VENDOR_ADDR_TRANSLATION
+	help
+	  Name of a header file containing vendor-specific
+	  address translation table.

--- a/lib/open-amp/addr_translation.c
+++ b/lib/open-amp/addr_translation.c
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2025 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/init.h>
+#include <zephyr/logging/log.h>
+#include <addr_translation.h>
+
+#ifdef CONFIG_OPENAMP_VENDOR_ADDR_TRANSLATION_FILE
+/*
+ * In this file get_phys_pages() needs to be defined,
+ * see example in nxp_addr_translation.h
+ */
+#include CONFIG_OPENAMP_VENDOR_ADDR_TRANSLATION_FILE
+#else
+/*
+ * Return table of base physical addresses for the I/O region
+ * that starts with the specified physical base address (phys)
+ */
+static inline const struct phys_pages *get_phys_map(metal_phys_addr_t phys)
+{
+	(void)phys;
+	return NULL;
+}
+#endif
+
+static const struct phys_pages *phys_pages;
+
+/**
+ * @brief Translates an offset within an I/O region to a physical address.
+ *
+ * This function first attempts to translate the offset using the driver's
+ * physical address map. If no valid mapping is found, it falls back to the
+ * device physical address map.
+ *
+ * @param io Pointer to the I/O region.
+ * @param offset Offset within the I/O region.
+ *
+ * @return physical address if valid, otherwise METAL_BAD_PHYS.
+ */
+static metal_phys_addr_t translate_offset_to_phys(struct metal_io_region *io,
+						  unsigned long offset)
+{
+	(void)io;
+	size_t i;
+	metal_phys_addr_t tmp_addr;
+	size_t tmp_size;
+	unsigned long tmp_offset = 0;
+
+	if (offset > io->size) {
+		return METAL_BAD_PHYS;
+	}
+
+	for (i = 0; i < phys_pages->no_pages; i++) {
+		tmp_addr = phys_pages->map[i].addr;
+		tmp_size = phys_pages->map[i].size;
+		if ((tmp_offset <= offset) && (offset < tmp_offset + tmp_size)) {
+			return tmp_addr + (offset - tmp_offset);
+		}
+		tmp_offset += tmp_size;
+	}
+
+	return METAL_BAD_PHYS;
+}
+
+/**
+ * @brief Translates a physical address to an offset within an I/O region.
+ *
+ * This function first attempts to translate the physical address using the
+ * driver's address map. If no valid mapping is found, it falls back to the
+ * device address map.
+ *
+ * @param io Pointer to the I/O region.
+ * @param phys Physical address to translate.
+ *
+ * @return offset if valid, otherwise METAL_BAD_OFFSET.
+ */
+static unsigned long translate_phys_to_offset(struct metal_io_region *io,
+					      metal_phys_addr_t phys)
+{
+	(void)io;
+	size_t i;
+	metal_phys_addr_t tmp_addr;
+	size_t tmp_size;
+	unsigned long offset = 0;
+
+	for (i = 0; i < phys_pages->no_pages; i++) {
+		tmp_addr = phys_pages->map[i].addr;
+		tmp_size = phys_pages->map[i].size;
+		if ((tmp_addr <= phys) && (phys < tmp_addr + tmp_size)) {
+			offset += (phys - tmp_addr);
+			return (offset < io->size ? offset : METAL_BAD_OFFSET);
+		}
+		offset += tmp_size;
+	}
+
+	/* if not found in local addr, search in remote addr */
+	offset = 0;
+	for (i = 0; i < phys_pages->no_pages; i++) {
+		tmp_addr = phys_pages->map[i].remote_addr;
+		tmp_size = phys_pages->map[i].size;
+		if ((phys >= tmp_addr) && (phys < tmp_addr + tmp_size)) {
+			offset += (phys - tmp_addr);
+			return (offset < io->size ? offset : METAL_BAD_OFFSET);
+		}
+		offset += tmp_size;
+	}
+
+	return METAL_BAD_OFFSET;
+}
+
+/* Address translation operations for OpenAMP */
+static const struct metal_io_ops openamp_addr_translation_ops = {
+	.phys_to_offset = translate_phys_to_offset,
+	.offset_to_phys = translate_offset_to_phys,
+};
+
+/**
+ * @brief Return generic I/O operations
+ *
+ * @param	phys	Physical base address of the I/O region
+ * @return	metal_io_ops struct
+ */
+const struct metal_io_ops *addr_translation_get_ops(metal_phys_addr_t phys)
+{
+	phys_pages = get_phys_map(phys);
+	if (!phys_pages) {
+		return NULL;
+	}
+
+	return &openamp_addr_translation_ops;
+}

--- a/lib/open-amp/addr_translation.h
+++ b/lib/open-amp/addr_translation.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2025 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <metal/io.h>
+
+/*
+ * Description of a single physical page from the I/O region.
+ * Local address is remap to remote address -
+ * according to the memory map from the reference manual.
+ */
+struct phys_page_info {
+	const metal_phys_addr_t addr;		/* local address */
+	const metal_phys_addr_t remote_addr;	/* remote address */
+	const size_t size;
+};
+
+/*
+ * Table of base physical addresses, local and remote,
+ * of the pages in the I/O region, along with size (no_pages)
+ */
+struct phys_pages {
+	size_t no_pages;			/* number of pages */
+	const struct phys_page_info *map;	/* table of pages */
+};
+
+/**
+ * @brief Return generic I/O operations
+ *
+ * @param	phys	Physical base address of the I/O region
+ * @return	metal_io_ops struct
+ */
+const struct metal_io_ops *addr_translation_get_ops(metal_phys_addr_t phys);

--- a/lib/open-amp/vendor/nxp_addr_translation.h
+++ b/lib/open-amp/vendor/nxp_addr_translation.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2025 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * This is for the memory I/O region
+ * of the shared memory between HiFi4 DSP and A35 system
+ */
+static const struct phys_page_info physmap[] = {
+	{
+		.addr = 0x1bef0000,
+		.remote_addr = 0x8fef0000,
+		.size = 0x10000000
+	}
+};
+
+static const struct phys_pages vendor_phys_map = {
+	.no_pages = 1,
+	.map = physmap
+};
+
+/*
+ * Return table of base physical addresses for the I/O region
+ * that starts with the specified physical base address (phys)
+ */
+static inline const struct phys_pages *get_phys_map(metal_phys_addr_t phys)
+{
+	if (phys == physmap[0].addr) {
+		return &vendor_phys_map;
+	}
+	return NULL;
+}

--- a/samples/subsys/ipc/openamp_rsc_table/boards/imx8ulp_evk_mimx8ud7_adsp.conf
+++ b/samples/subsys/ipc/openamp_rsc_table/boards/imx8ulp_evk_mimx8ud7_adsp.conf
@@ -9,3 +9,7 @@ CONFIG_IPM_MBOX=y
 #vendor-specific resource table
 CONFIG_OPENAMP_VENDOR_RSC_TABLE=y
 CONFIG_OPENAMP_VENDOR_RSC_TABLE_FILE="nxp_resource_table.c"
+
+#address translation support
+CONFIG_OPENAMP_VENDOR_ADDR_TRANSLATION=y
+CONFIG_OPENAMP_VENDOR_ADDR_TRANSLATION_FILE="nxp_addr_translation.h"

--- a/samples/subsys/ipc/openamp_rsc_table/src/main_remote.c
+++ b/samples/subsys/ipc/openamp_rsc_table/src/main_remote.c
@@ -17,6 +17,7 @@
 #include <metal/sys.h>
 #include <metal/io.h>
 #include <resource_table.h>
+#include <addr_translation.h>
 
 #ifdef CONFIG_SHELL_BACKEND_RPMSG
 #include <zephyr/shell/shell_rpmsg.h>
@@ -159,7 +160,7 @@ int platform_init(void)
 
 	/* declare shared memory region */
 	metal_io_init(shm_io, (void *)SHM_START_ADDR, &shm_physmap,
-		      SHM_SIZE, -1, 0, NULL);
+		      SHM_SIZE, -1, 0, addr_translation_get_ops(shm_physmap));
 
 	/* declare resource table region */
 	rsc_table_get(&rsc_table, &rsc_size);


### PR DESCRIPTION
Now, in openamp_rsc_table sample we support only the devices
that have the same value for driver and device physical address.
But, in case they are different, we need to convert from driver
to device address.

This PR introduces address translation support for OpenAMP:
- implements the address translation functions;
- returns the I/O operations used for address translation.

The ops can be used in Libmetal (see metal_io_init()).

Each vendor can add his own addr translation table.

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/84168