### PR TITLE
cmake: llvm: Add elfconvert_flag_lma_adjust property

### DIFF
--- a/cmake/bintools/llvm/target_bintools.cmake
+++ b/cmake/bintools/llvm/target_bintools.cmake
@@ -44,6 +44,8 @@ set_property(TARGET bintools PROPERTY elfconvert_flag_section_remove "--remove-s
 set_property(TARGET bintools PROPERTY elfconvert_flag_section_only "--only-section=")
 set_property(TARGET bintools PROPERTY elfconvert_flag_section_rename "--rename-section;")
 
+set_property(TARGET bintools PROPERTY elfconvert_flag_lma_adjust "--change-section-lma;")
+
 # llvm-objcopy doesn't support gap fill argument.
 set_property(TARGET bintools PROPERTY elfconvert_flag_gapfill "")
 set_property(TARGET bintools PROPERTY elfconvert_flag_srec_len "--srec-len=")


### PR DESCRIPTION
The elfconvert_flag_lma_adjust property is required when using CONFIG_BUILD_OUTPUT_ADJUST_LMA, but was missing for LLVM.