### PR TITLE
soc: st: stm32wb0x: Increase main stack size for BLE applications

### DIFF
--- a/soc/st/stm32/stm32wb0x/Kconfig.defconfig
+++ b/soc/st/stm32/stm32wb0x/Kconfig.defconfig
@@ -8,6 +8,8 @@ if SOC_SERIES_STM32WB0X
 config NUM_IRQS
 	default 32
 
+if BT
+
 config BT_AUTO_PHY_UPDATE
 	default n
 
@@ -16,5 +18,10 @@ config BT_AUTO_DATA_LEN_UPDATE
 
 config BT_HCI_ACL_FLOW_CONTROL
 	default n
+
+config MAIN_STACK_SIZE
+	default 1600
+
+endif # BT
 
 endif # SOC_SERIES_STM32WB0X


### PR DESCRIPTION
Increase the size of the main stack for BLE applications to avoid stack overflow on STM32WB0x series. Beacon sample was considered as a reference for the size increase.

It is applied at the SoC level to avoid repetition for each board.