### PR TITLE
doc: contribute: remove need to fix new style immediately

### DIFF
--- a/doc/contribute/contributor_expectations.rst
+++ b/doc/contribute/contributor_expectations.rst
@@ -370,9 +370,9 @@ Reviewer Expectations
 
 - Style changes that the reviewer disagrees with but that are not documented as
   part of the project can be pointed out as non-blocking, but cannot constitute
-  a reason for a request for changes. The reviewer can optionally correct any
-  potential inconsistencies in the tree, document the new guidelines or rules,
-  and then enforce them as part of the review.
+  a reason for a request for changes. The reviewer can optionally propose and
+  document new guidelines or rules, and then enforce them after they've been
+  evaluated, reviewed, agreed and merged.
 
 - Whenever requesting style related changes, reviewers should be able to point
   out the corresponding guideline, rule or rationale in the project's


### PR DESCRIPTION
Follow-up to review of commit ea4e46d07549 ("doc: contribute: Extend Reviewer Expectations with additional rules") where this was already discussed.

It is not really realistic to request that new guidelines be applied immediately all across the tree and it would also go against the "smaller PRs" guideline. It should be possible to implement new rules more gradually.

Also clarify that new rules can be enforced only after they've been merged.