### PR TITLE
boards: weact: Add support for WeAct STM32H5 Core Board

### DIFF
--- a/boards/weact/stm32h5_core/Kconfig.weact_stm32h5_core
+++ b/boards/weact/stm32h5_core/Kconfig.weact_stm32h5_core
@@ -1,0 +1,5 @@
+# Copyright (c) 2025 Kacper Brzostowski
+# SPDX-License-Identifier: Apache-2.0
+
+config BOARD_WEACT_STM32H5_CORE
+	select SOC_STM32H562XX

--- a/boards/weact/stm32h5_core/board.cmake
+++ b/boards/weact/stm32h5_core/board.cmake
@@ -1,0 +1,7 @@
+# Copyright (c) 2025 Kacper Brzostowski
+# SPDX-License-Identifier: Apache-2.0
+
+board_runner_args(dfu-util "--pid=0483:df11" "--alt=0" "--dfuse")
+
+# Keep first
+include(${ZEPHYR_BASE}/boards/common/dfu-util.board.cmake)

--- a/boards/weact/stm32h5_core/board.yml
+++ b/boards/weact/stm32h5_core/board.yml
@@ -1,0 +1,6 @@
+board:
+  name: weact_stm32h5_core
+  full_name: STM32H5 Core Board
+  vendor: weact
+  socs:
+    - name: stm32h562xx

--- a/boards/weact/stm32h5_core/doc/index.rst
+++ b/boards/weact/stm32h5_core/doc/index.rst
@@ -1,0 +1,230 @@
+.. zephyr:board:: weact_stm32h5_core
+
+Overview
+********
+
+The ``weact_stm32h5_core`` board is a compact development board equipped with
+an STM32H562RGT6 microcontroller. It features basic set of peripherals:
+user LED and button, microSD |trade| card slot, and combined SWD & UART header.
+
+Key Features
+
+- STM32 microcontroller in LQFP64 package
+- USB OTG or full-speed device
+- 1 user LED
+- User, boot, and reset push-buttons
+- 32.768 kHz and 8MHz HSE crystal oscillators
+- Board connectors:
+
+   - microSD |trade| card
+   - USB Type-C Connector
+   - SWD & UART header for external debugger
+   - 2x 30-pin GPIO connector
+
+More information about the board can be found on the `WeAct GitHub`_.
+
+Hardware
+********
+
+The ``weact_stm32h5_core`` board provides the following hardware components:
+
+   - STM32H562RGT6 in LQFP64 package
+   - ARM 32-bit Cortex-M33 CPU with FPU
+   - CORDIC for trigonometric functions acceleration
+   - FMAC (filter mathematical accelerator)
+   - CRC calculation unit
+   - 240 MHz max CPU frequency
+   - VDD from 1.71 V to 3.6 V
+   - 1MB Flash, 2 banks read-while-write
+   - 640kB SRAM
+   - 4 Kbytes of backup SRAM available in the lowest power modes
+   - 2x watchdogs
+   - 2x SysTick timer
+   - 32-bit timers (2)
+   - 16-bit advanced motor control timers (2)
+   - 16-bit low power timers (6)
+   - 16-bit timers (10)
+   - 1x USB Type-C / USB power-delivery controller
+   - 1x USB 2.0 full-speed host and device
+   - 4x I2C FM+ interfaces (SMBus/PMBus)
+   - 1x I3C interface
+   - 12x U(S)ARTS (ISO7816 interface, LIN, IrDA, modem control)
+   - 1x LP UART
+   - 6x SPIs including 3 muxed with full-duplex I2S
+   - 2x SAI
+   - 1x FDCAN
+   - Flexible external memory controller with up to 16-bit data bus: SRAM, PSRAM, FRAM, SDRAM/LPSDR SDRAM, NOR/NAND memories
+   - 1x OCTOSPI memory interface with on-the-fly decryption and support for serial PSRAM/NAND/NOR, Hyper RAM/Flash frame formats
+   - 1x SD/SDIO/MMC interfaces
+   - 1x HDMI-CEC
+   - 2x 12-bit ADC with up to 5 MSPS in 12-bit
+   - 1x 12-bit D/A with 2 channels
+   - 1x Digital temperature sensor
+
+More information about STM32H562RG can be found here:
+
+- `STM32H562RG on www.st.com`_
+- `STM32H562 reference manual`_
+
+Supported Features
+==================
+
+The Zephyr ``weact_stm32h5_core`` board supports the following hardware features:
+
++-----------+------------+-------------------------------------+
+| Interface | Controller | Driver/Component                    |
++===========+============+=====================================+
+| CAN/CANFD | on-chip    | CAN                                 |
++-----------+------------+-------------------------------------+
+| CLOCK     | on-chip    | reset and clock control             |
++-----------+------------+-------------------------------------+
+| GPIO      | on-chip    | gpio                                |
++-----------+------------+-------------------------------------+
+| NVIC      | on-chip    | nested vector interrupt controller  |
++-----------+------------+-------------------------------------+
+| PINMUX    | on-chip    | pinmux                              |
++-----------+------------+-------------------------------------+
+| RNG       | on-chip    | True Random number generator        |
++-----------+------------+-------------------------------------+
+| RTC       | on-chip    | Real Time Clock                     |
++-----------+------------+-------------------------------------+
+| SPI       | on-chip    | spi bus                             |
++-----------+------------+-------------------------------------+
+| I2C       | on-chip    | i2c bus                             |
++-----------+------------+-------------------------------------+
+| UART      | on-chip    | serial port-polling;                |
+|           |            | serial port-interrupt               |
++-----------+------------+-------------------------------------+
+| WATCHDOG  | on-chip    | independent watchdog                |
++-----------+------------+-------------------------------------+
+| USB       | on-chip    | USB full-speed host/device bus      |
++-----------+------------+-------------------------------------+
+| SDMMC     | on-chip    | disk access                         |
++-----------+------------+-------------------------------------+
+
+Other hardware features have not been enabled yet for this board.
+
+The default configuration per core can be found in the defconfig file:
+:zephyr_file:`boards/weact/stm32h5_core/weact_stm32h5_core_defconfig`
+
+Pin Mapping
+===========
+
+Default Zephyr Peripheral Mapping:
+----------------------------------
+
+The ``weact_stm32h5_core`` board is configured as follows
+
+- USER_LED : PB2
+- USER_PB : PC13
+- SDMMC1 CLK/DCMD/CD/D0/D1/D2/D3 : PC12/PD2/PD4/PC8/PC9/PC10/PC11 (microSD card)
+- USB DM/DP : PA11/PA12 (USB CDC ACM)
+- UART on debug header : RX/TX - pA10/PA9
+
+System Clock
+============
+
+The STM32H562RG System Clock can be driven by an internal or external oscillator,
+as well as by the main PLL clock. By default, the System clock is driven
+by the PLL clock at 240MHz. PLL clock is fed by a 8MHz external clock.
+
+Serial Port (USB CDC ACM)
+=========================
+
+The Zephyr console output is assigned to the USB CDC ACM virtual serial port.
+Virtual COM port interface. Default communication settings are 115200 8N1.
+
+Programming and Debugging
+*************************
+
+The ``weact_stm32h5_core`` board facilitates firmware flashing via the USB DFU
+bootloader. This method simplifies the process of updating images, although
+it doesn't provide debugging capabilities. However, the board provides header
+pins for the Serial Wire Debug (SWD) interface, which can be used to connect
+an external debugger, such as ST-Link.
+
+Flashing
+========
+
+To activate the bootloader, follow these steps:
+
+1. Press and hold the BOOT0 key.
+2. While still holding the BOOT0 key, press and release the RESET key.
+3. Wait for 0.5 seconds, then release the BOOT0 key.
+
+Upon successful execution of these steps, the device will transition into
+bootloader mode and present itself as a USB DFU Mode device. You can program
+the device using the west tool or the STM32CubeProgrammer.
+
+Flashing an application to ``weact_stm32h5_core``
+-------------------------------------------------
+
+Here is an example for the :zephyr:code-sample:`hello_world` application.
+
+First, put the board in bootloader mode as described above. Then build and flash
+the application in the usual way. Just add ``CONFIG_BOOT_DELAY=5000`` to the
+configuration, so that USB CDC ACM is initialized before any text is printed,
+as below:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :board: weact_stm32h5_core
+   :goals: build flash
+   :gen-args: -DCONFIG_BOOT_DELAY=5000
+
+Run a serial host program to connect with your board:
+
+.. code-block:: console
+
+   $ minicom -D <tty_device> -b 115200
+
+Then, press the RESET button, you should see the following message after few seconds:
+
+.. code-block:: console
+
+   Hello World! weact_stm32h5_core
+
+Replace :code:`<tty_device>` with the port where the board can be found.
+For example, under Linux, :code:`/dev/ttyACM0`.
+
+Debugging
+---------
+
+This current Zephyr port does not support debugging.
+
+Testing the LEDs in the ``weact_stm32h5_core``
+**********************************************
+
+There is a sample that allows to test that LED on the board are working
+properly with Zephyr:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/basic/blinky
+   :board: weact_stm32h5_core
+   :goals: build flash
+   :gen-args: -DCONFIG_BOOT_DELAY=5000
+
+You can build and flash the examples to make sure Zephyr is running correctly on
+your board. The LED definitions can be found in
+:zephyr_file:`boards/weact/stm32h5_core/weact_stm32h5_core.dts`.
+
+Testing shell over USB in the ``weact_stm32h5_core``
+****************************************************
+
+There is a sample that allows to test shell interface over USB CDC ACM interface
+with Zephyr:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/subsys/shell/shell_module
+   :board: weact_stm32h5_core
+   :goals: build flash
+   :gen-args: -DCONFIG_BOOT_DELAY=5000
+
+.. _WeAct GitHub:
+   https://github.com/WeActStudio/WeActStudio.STM32H5_64Pin_CoreBoard
+
+.. _STM32H562RG on www.st.com:
+   https://www.st.com/en/microcontrollers-microprocessors/stm32h562rg.html
+
+.. _STM32H562 reference manual:
+   https://www.st.com/resource/en/reference_manual/rm0481-stm32h52333xx-stm32h56263xx-and-stm32h573xx-armbased-32bit-mcus-stmicroelectronics.pdf

--- a/boards/weact/stm32h5_core/weact_stm32h5_core.dts
+++ b/boards/weact/stm32h5_core/weact_stm32h5_core.dts
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2025 Kacper Brzostowski
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/dts-v1/;
+#include <st/h5/stm32h562Xg.dtsi>
+#include <st/h5/stm32h562rgtx-pinctrl.dtsi>
+#include <zephyr/dt-bindings/input/input-event-codes.h>
+
+/ {
+	model = "WeAct Studio STM32H5 Core Board";
+	compatible = "weact,stm32h5-core";
+
+	chosen {
+		zephyr,console = &usart1;
+		zephyr,shell-uart = &usart1;
+		zephyr,code-partition = &slot0_partition;
+		zephyr,sram = &sram1;
+		zephyr,flash = &flash0;
+	};
+
+	aliases {
+		led0 = &led_0;
+		sw0 = &button_0;
+		watchdog0 = &iwdg;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_0: led0 {
+			gpios = <&gpiob 2 GPIO_ACTIVE_HIGH>;
+			label = "User LED";
+		};
+	};
+
+	gpio_keys {
+		compatible = "gpio-keys";
+
+		button_0: button0 {
+			label = "User Button";
+			gpios = <&gpioc 13 (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>;
+			zephyr,code = <INPUT_KEY_0>;
+		};
+	};
+};
+
+&sdmmc1 {
+	pinctrl-0 = <&sdmmc1_d0_pc8 &sdmmc1_d1_pc9
+				&sdmmc1_d2_pc10 &sdmmc1_d3_pc11
+				&sdmmc1_ck_pc12 &sdmmc1_cmd_pd2>;
+	cd-gpios = <&gpioa 8 GPIO_ACTIVE_LOW>;
+	pinctrl-names = "default";
+	cd-gpios = <&gpioa 8 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
+	status = "okay";
+};
+
+&clk_lsi {
+	status = "okay";
+};
+
+&clk_lse {
+	status = "okay";
+};
+
+&clk_hsi {
+	status = "okay";
+};
+
+&clk_hse {
+	status = "okay";
+	clock-frequency = <DT_FREQ_M(8)>;
+};
+
+&rcc {
+	clocks = <&pll>;
+	clock-frequency = <DT_FREQ_M(240)>;
+	ahb-prescaler = <1>;
+	apb1-prescaler = <2>;
+	apb2-prescaler = <1>;
+	apb3-prescaler = <2>;
+};
+
+&pll {
+	div-m = <2>;
+	mul-n = <120>;
+	div-p = <2>;
+	div-q = <3>;
+	div-r = <2>;
+	clocks = <&clk_hse>;
+	status = "okay";
+};
+
+&rtc {
+	clocks = <&rcc STM32_CLOCK_BUS_APB3 0x00200000>,
+			<&rcc STM32_SRC_LSE RTC_SEL(1)>;
+	status = "okay";
+};
+
+stm32_lp_tick_source: &lptim4 {
+	clocks = <&rcc STM32_CLOCK_BUS_APB3 0x2000>,
+			<&rcc STM32_SRC_LSI LPTIM4_SEL(4)>;
+	status = "okay";
+};
+
+&iwdg {
+	status = "okay";
+};
+
+&usart1 {
+	status = "okay";
+	pinctrl-0 = <&usart1_tx_pa9 &usart1_rx_pa10>;
+	pinctrl-names = "default";
+	current-speed = <115200>;
+};
+
+&rng {
+	status = "okay";
+};
+
+&spi1 {
+	pinctrl-0 = <&spi1_nss_pa4 &spi1_sck_pa5 &spi1_miso_pa6 &spi1_mosi_pa7>;
+	pinctrl-names = "default";
+	cs-gpios = <&gpioa 4 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+	status = "okay";
+};
+
+&fdcan1 {
+	pinctrl-0 = <&fdcan1_rx_pb8 &fdcan1_tx_pb7>;
+	pinctrl-names = "default";
+	clocks = <&rcc STM32_CLOCK_BUS_APB1_2 0x00000200>,
+		<&rcc STM32_SRC_PLL1_Q FDCAN_SEL(1)>;
+	clk-divider = <2>;
+	status = "okay";
+};
+
+zephyr_udc0: &usb {
+	pinctrl-0 = <&usb_dm_pa11 &usb_dp_pa12>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
+&flash0 {
+	partitions {
+		compatible = "fixed-partitions";
+
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		boot_partition: partition@0 {
+			label = "mcuboot";
+			reg = <0x00000000 DT_SIZE_K(64)>;
+		};
+
+		slot0_partition: partition@10000 {
+			label = "image-0";
+			reg = <0x00010000 DT_SIZE_K(448)>;
+		};
+
+		slot1_partition: partition@80000 {
+			label = "image-1";
+			reg = <0x00080000 DT_SIZE_K(448)>;
+		};
+
+		storage_partition: partition@f0000 {
+			label = "storage";
+			reg = <0x000f0000 DT_SIZE_K(64)>;
+		};
+	};
+};

--- a/boards/weact/stm32h5_core/weact_stm32h5_core.yaml
+++ b/boards/weact/stm32h5_core/weact_stm32h5_core.yaml
@@ -1,0 +1,20 @@
+identifier: weact_stm32h5_core
+name: WeAct Studio STM32H5 Core Board
+type: mcu
+arch: arm
+toolchain:
+  - zephyr
+  - gnuarmemb
+  - xtools
+ram: 640
+flash: 1024
+supported:
+  - gpio
+  - can
+  - uart
+  - entropy
+  - spi
+  - usb_device
+  - rtc
+  - watchdog
+vendor: weact

--- a/boards/weact/stm32h5_core/weact_stm32h5_core_defconfig
+++ b/boards/weact/stm32h5_core/weact_stm32h5_core_defconfig
@@ -1,0 +1,18 @@
+# Copyright (c) 2025 Kacper Brzostowski
+# SPDX-License-Identifier: Apache-2.0
+
+# Enable uart driver
+CONFIG_SERIAL=y
+
+# Console
+CONFIG_CONSOLE=y
+CONFIG_UART_CONSOLE=y
+
+# Enable MPU
+CONFIG_ARM_MPU=y
+
+# Enable HW stack protection
+CONFIG_HW_STACK_PROTECTION=y
+
+# Enable GPIO
+CONFIG_GPIO=y

--- a/dts/arm/st/h5/stm32h562Xg.dtsi
+++ b/dts/arm/st/h5/stm32h562Xg.dtsi
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2025 Kacper Brzostowski
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <mem.h>
+#include <st/h5/stm32h562.dtsi>
+
+/ {
+	soc {
+		flash-controller@40022000 {
+			flash0: flash@8000000 {
+				reg = <0x08000000 DT_SIZE_M(1)>;
+			};
+		};
+	};
+};


### PR DESCRIPTION
Low cost STM32H5 series development board with bare minimum to run the MCU