### PR TITLE
fs: littlefs: define default disk version in Kconfig

### DIFF
--- a/subsys/fs/Kconfig.littlefs
+++ b/subsys/fs/Kconfig.littlefs
@@ -125,4 +125,11 @@ config FS_LITTLEFS_DISK_VERSION
 	  to maintain backward compatibility with existing littlefs
 	  with the same major disk version.
 
+config FS_LITTLEFS_DISK_VERSION_NUMBER
+	hex "Default littlefs disk version"
+	default 0
+	depends on FS_LITTLEFS_DISK_VERSION
+	help
+	  Set to 0 to use the latest littlefs disk version (LFS_DISK_VERSION).
+
 endif # FILE_SYSTEM_LITTLEFS

--- a/subsys/fs/littlefs_fs.c
+++ b/subsys/fs/littlefs_fs.c
@@ -793,7 +793,10 @@ static int littlefs_init_cfg(struct fs_littlefs *fs, int flags)
 	uint32_t disk_version = lcp->disk_version;
 
 	if (disk_version == 0) {
-		disk_version = LFS_DISK_VERSION;
+		disk_version = CONFIG_FS_LITTLEFS_DISK_VERSION_NUMBER;
+		if (disk_version == 0) {
+			disk_version = LFS_DISK_VERSION;
+		}
 	}
 #endif /* CONFIG_FS_LITTLEFS_DISK_VERSION */
 


### PR DESCRIPTION
This makes it possible to set the disk version when Devicetree is not used for configuration.