### PR TITLE
boards: esp32s3_touch_lcd_1_28: Fix default flash partition

### DIFF
--- a/boards/waveshare/esp32s3_touch_lcd_1_28/esp32s3_touch_lcd_1_28_esp32s3_appcpu.dts
+++ b/boards/waveshare/esp32s3_touch_lcd_1_28/esp32s3_touch_lcd_1_28_esp32s3_appcpu.dts
@@ -5,7 +5,7 @@
 
 /dts-v1/;
 #include <espressif/esp32s3/esp32s3_r2.dtsi>
-#include <espressif/partitions_0x0_amp.dtsi>
+#include <espressif/partitions_0x0_amp_16M.dtsi>
 
 / {
 	model = "ESP32-S3-Touch-LCD-1.28 APPCPU";

--- a/boards/waveshare/esp32s3_touch_lcd_1_28/esp32s3_touch_lcd_1_28_esp32s3_procpu.dts
+++ b/boards/waveshare/esp32s3_touch_lcd_1_28/esp32s3_touch_lcd_1_28_esp32s3_procpu.dts
@@ -9,7 +9,7 @@
 #include <zephyr/dt-bindings/display/panel.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 #include <zephyr/dt-bindings/pwm/pwm.h>
-#include <espressif/partitions_0x0_amp.dtsi>
+#include <espressif/partitions_0x0_amp_16M.dtsi>
 
 / {
 	model = "ESP32-S3-Touch-LCD-1.28 PROCPU";


### PR DESCRIPTION
The default partition file included in the board definition is for 4MB flash. However, this board has 16MB flash.
This commit should address that.