### PR TITLE
Bluetooth: fix old-style warning gcc

### DIFF
--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -133,7 +133,7 @@ static uint16_t bt_att_mtu(struct bt_att_chan *chan)
 /* Descriptor of application-specific authorization callbacks that are used
  * with the CONFIG_BT_GATT_AUTHORIZATION_CUSTOM Kconfig enabled.
  */
-const static struct bt_gatt_authorization_cb *authorization_cb;
+static const struct bt_gatt_authorization_cb *authorization_cb;
 
 /* ATT connection specific data */
 struct bt_att {


### PR DESCRIPTION
fix GCC warning old-style-declaration on bluetooth host/att.c

Bug reproduced with the following simple modifications

`west build -b b_u585i_iot02a /zephyr/samples/bluetooth/peripheral_gatt_write -p`
with following additions in CMakeLists.txt to see the warning:

```
zephyr_compile_options("-Wextra")
zephyr_compile_options("-Wno-unused-parameter")
zephyr_compile_options("-Wno-sign-compare")
```

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/84005