### PR TITLE
dts: arm: nxp: s32: add `#address-cells` to interrupt provider

### DIFF
--- a/dts/arm/nxp/nxp_s32k344_m7.dtsi
+++ b/dts/arm/nxp/nxp_s32k344_m7.dtsi
@@ -90,6 +90,7 @@
 			eirq0: eirq@40290010 {
 				compatible = "nxp,s32-siul2-eirq";
 				reg = <0x40290010 0xb4>;
+				#address-cells = <0>;
 				interrupts = <53 0>, <54 0>, <55 0>, <56 0>;
 				interrupt-controller;
 				#interrupt-cells = <2>;

--- a/dts/arm/nxp/nxp_s32z27x_r52.dtsi
+++ b/dts/arm/nxp/nxp_s32z27x_r52.dtsi
@@ -105,6 +105,7 @@
 			compatible = "arm,gic-v3", "arm,gic";
 			reg = <0x47800000 0x10000>,
 				<0x47900000 0x80000>;
+			#address-cells = <0>;
 			interrupt-controller;
 			#interrupt-cells = <4>;
 			status = "okay";
@@ -219,6 +220,7 @@
 			eirq0: eirq0@40520010 {
 				compatible = "nxp,s32-siul2-eirq";
 				reg = <0x40520010 0xb4>;
+				#address-cells = <0>;
 				interrupts = <GIC_SPI 514 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
 				interrupt-controller;
 				#interrupt-cells = <2>;
@@ -270,6 +272,7 @@
 			eirq1: eirq1@40d20010 {
 				compatible = "nxp,s32-siul2-eirq";
 				reg = <0x40d20010 0xb4>;
+				#address-cells = <0>;
 				interrupts = <GIC_SPI 515 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
 				interrupt-controller;
 				#interrupt-cells = <2>;
@@ -345,6 +348,7 @@
 			eirq4: eirq4@42520010 {
 				compatible = "nxp,s32-siul2-eirq";
 				reg = <0x42520010 0xb4>;
+				#address-cells = <0>;
 				interrupts = <GIC_SPI 516 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
 				interrupt-controller;
 				#interrupt-cells = <2>;
@@ -418,6 +422,7 @@
 			eirq5: eirq5@42d20010 {
 				compatible = "nxp,s32-siul2-eirq";
 				reg = <0x42d20010 0xb4>;
+				#address-cells = <0>;
 				interrupts = <GIC_SPI 517 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
 				interrupt-controller;
 				#interrupt-cells = <2>;


### PR DESCRIPTION
Add `#address-cells = <0>;` to interrupt provider nodes in the NXP S32 device tree to resolve warnings: e.g.
Warning (interrupt_provider): /soc/interrupt-controller@47800000: Missing #address-cells in interrupt provider
Warning (interrupt_provider): /soc/siul2@40520000/eirq0@40520010: Missing #address-cells in interrupt provider

This ensures compliance with device tree specifications and eliminates build warnings.