### PR TITLE
drivers: flash: shell: Remove erase test command size limit

### DIFF
--- a/drivers/flash/flash_shell.c
+++ b/drivers/flash/flash_shell.c
@@ -480,7 +480,7 @@ static int cmd_write_test(const struct shell *sh, size_t argc, char *argv[])
 
 		++loops;
 		total_time += loop_time;
-		shell_print(sh, "Loop #%u done in %llu ticks.", loops, loop_time);
+		shell_print(sh, "Loop #%u done in %llu ms.", loops, loop_time);
 	}
 
 	if (result == 0) {


### PR DESCRIPTION
The erase command does not require a buffer, so the size does not need
to be limited to the buff size. This allows for test block erase 
(32k/64k), and chip erase.  

And fix cmd_write_test print unit errors.