### PR TITLE
drivers: ethernet: Fix DSA tag size for KSZ8863.

### DIFF
--- a/drivers/ethernet/Kconfig.dsa
+++ b/drivers/ethernet/Kconfig.dsa
@@ -45,6 +45,14 @@ config DSA_KSZ_TAIL_TAGGING
 	help
 	  Add support for tail tagging on DSA device.
 
+config DSA_TAG_SIZE
+	int "DSA tag size in bytes"
+	default 1 if DSA_KSZ8794 || DSA_KSZ8863
+	default 0
+	depends on DSA_KSZ_TAIL_TAGGING
+	help
+	  Set the DSA tag length in bytes.
+
 config DSA_SPI
 	bool "Support for PHY SPI interface"
 	depends on SPI && (DSA_KSZ8794 || DSA_KSZ8863)

--- a/include/zephyr/net/dsa.h
+++ b/include/zephyr/net/dsa.h
@@ -28,12 +28,8 @@
 #define NET_DSA_PORT_MAX_COUNT 8
 #define DSA_STATUS_PERIOD_MS K_MSEC(1000)
 
-/*
- * Size of the DSA TAG:
- * - KSZ8794 - 1 byte
- */
-#if defined(CONFIG_DSA_KSZ8794) && defined(CONFIG_DSA_KSZ_TAIL_TAGGING)
-#define DSA_TAG_SIZE 1
+#ifdef CONFIG_DSA_TAG_SIZE
+#define DSA_TAG_SIZE CONFIG_DSA_TAG_SIZE
 #else
 #define DSA_TAG_SIZE 0
 #endif


### PR DESCRIPTION
Allow DSA_TAG_SIZE to be set based on the size determined by Kconfig and the enabled switch hardware.

This fixes support for the KSZ8863 which also has a tail tag of one byte.