### PR TITLE
doc: Add k_pipe deprication notice to 4.1 release notes

### DIFF
--- a/doc/releases/migration-guide-4.1.rst
+++ b/doc/releases/migration-guide-4.1.rst
@@ -35,6 +35,45 @@ perform a full erase, pass the ``--erase`` option when executing ``west flash``.
 Kernel
 ******
 
+
+k_pipe API
+==========
+
+The k_pipe API has been reworked and the API used in ``CONFIG_PIPES`` is now deprecated.
+The k_pipe API is enabled by default when ``CONFIG_MULTITHREADING`` is set.
+Function renames and modifications:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Old API
+     - New API
+     - Changes
+   * - ``k_pipe_put(..)``
+     - ``k_pipe_write(..)``
+     - Removed ``min_xfer`` parameter (partial transfers based on thresholds are no longer supported)
+       ``bytes_written`` is now the return value
+   * - ``k_pipe_get(..)``
+     - ``k_pipe_read(..)``
+     - Removed ``min_xfer`` parameter (partial transfers based on thresholds are no longer supported)
+       ``bytes_read`` is now the return value
+   * - ``k_pipe_flush(..)`` & ``k_pipe_buffer_flush(..)``
+     - ``k_pipe_reset(..)``
+     - Reset the pipe, discarding all data in the pipe, non blocking.
+   * - ``k_pipe_alloc_init(..)``, ``k_pipe_cleanup(..)``
+     - **Removed**
+     - Dynamic allocation of pipes is no longer supported
+   * - ``k_pipe_read_avail(..)``, ``k_pipe_write_avail(..)``
+     - **Removed**
+     - Querying the number of bytes in the pipe is no longer supported
+   * - None
+     - ``k_pipe_close(..)``
+     - Close a pipe, waking up all pending readers and writers with an error code. No further
+       reading or writing is allowed on the pipe. The pipe can be re-opened by calling
+       ``k_pipe_init(..)`` again. **Note**, all data in the pipe is available to readers until the
+       pipe is emptied.
+
+
 Security
 ********
 

--- a/doc/releases/release-notes-4.1.rst
+++ b/doc/releases/release-notes-4.1.rst
@@ -97,6 +97,26 @@ Deprecated APIs and options
   1. when Stream Flash is not configured to do erase on its own
   2. when erase is used for removal of a data prior or after Stream Flash uses the designated area.
 
+* The pipe API has been reworked.
+  The new API is enabled by default when ``CONFIG_MULTITHREADING`` is set.
+
+  * Deprecates the ``CONFIG_PIPES`` Kconfig option.
+  * Introduces the ``k_pipe_close(..)`` function.
+  * ``k_pipe_put(..)`` translates to ``k_pipe_write(..)``.
+  * ``k_pipe_get(..)`` translates to ``k_pipe_read(..)``.
+  * ``k_pipe_flush(..)`` & ``k_pipe_buffer_flush()`` can be translated to ``k_pipe_reset(..)``.
+
+  * Dynamic allocation of pipes is no longer supported.
+
+    - ``k_pipe_alloc_init(..)`` API has been removed.
+    - ``k_pipe_cleanup(..)`` API has been removed.
+
+  * Querying the number of bytes in the pipe is no longer supported.
+
+    - ``k_pipe_read_avail(..)`` API has been removed.
+    - ``k_pipe_write_avail(..)`` API has been removed.
+
+
 * For the native_sim target :kconfig:option:`CONFIG_NATIVE_SIM_NATIVE_POSIX_COMPAT` has been
   switched to ``n`` by default, and this option has been deprecated.
 


### PR DESCRIPTION
Add a notice to the 4.1 release notes that `CONFIG_PIPES` `k_pipe` implementation is deprecated from 4.1.