### PR TITLE
fs: enable custom mount points for fatfs

### DIFF
--- a/modules/fatfs/zephyr_fatfs_config.h
+++ b/modules/fatfs/zephyr_fatfs_config.h
@@ -118,6 +118,21 @@
 #endif /* defined(CONFIG_FS_FATFS_EXTRA_NATIVE_API) */
 
 /*
+ * When custom mount points are activated FF_VOLUME_STRS needs
+ * to be undefined in order to be able to provide a custom
+ * VolumeStr array containing the contents of
+ * CONFIG_FS_FATFS_CUSTOM_MOUNT_POINTS. Additionally the
+ * FF_VOLUMES define needs to be set to the correct mount
+ * point count contained in
+ * CONFIG_FS_FATFS_CUSTOM_MOUNT_POINT_COUNT.
+ */
+#if CONFIG_FS_FATFS_CUSTOM_MOUNT_POINT_COUNT
+#undef FF_VOLUMES
+#define FF_VOLUMES CONFIG_FS_FATFS_CUSTOM_MOUNT_POINT_COUNT
+#undef FF_VOLUME_STRS
+#endif /* CONFIG_FS_FATFS_CUSTOM_MOUNT_POINT_COUNT */
+
+/*
  * Options provided below have been added to ELM FAT source code to
  * support Zephyr specific features, and are not part of ffconf.h.
  */

--- a/modules/fatfs/zfs_diskio.c
+++ b/modules/fatfs/zfs_diskio.c
@@ -16,14 +16,19 @@
 #include <zfs_diskio.h> /* Zephyr specific FatFS API */
 #include <zephyr/storage/disk_access.h>
 
-static const char * const pdrv_str[] = {FF_VOLUME_STRS};
+#if CONFIG_FS_FATFS_CUSTOM_MOUNT_POINT_COUNT
+#define PDRV_STR_ARRAY VolumeStr
+#else
+static const char *const pdrv_str[] = {FF_VOLUME_STRS};
+#define PDRV_STR_ARRAY pdrv_str
+#endif /* CONFIG_FS_FATFS_CUSTOM_MOUNT_POINT_COUNT */
 
 /* Get Drive Status */
 DSTATUS disk_status(BYTE pdrv)
 {
-	__ASSERT(pdrv < ARRAY_SIZE(pdrv_str), "pdrv out-of-range\n");
+	__ASSERT(pdrv < ARRAY_SIZE(PDRV_STR_ARRAY), "pdrv out-of-range\n");
 
-	if (disk_access_status(pdrv_str[pdrv]) != 0) {
+	if (disk_access_status(PDRV_STR_ARRAY[pdrv]) != 0) {
 		return STA_NOINIT;
 	} else {
 		return RES_OK;
@@ -41,22 +46,21 @@ DSTATUS disk_initialize(BYTE pdrv)
 /* Read Sector(s) */
 DRESULT disk_read(BYTE pdrv, BYTE *buff, LBA_t sector, UINT count)
 {
-	__ASSERT(pdrv < ARRAY_SIZE(pdrv_str), "pdrv out-of-range\n");
+	__ASSERT(pdrv < ARRAY_SIZE(PDRV_STR_ARRAY), "pdrv out-of-range\n");
 
-	if (disk_access_read(pdrv_str[pdrv], buff, sector, count) != 0) {
+	if (disk_access_read(PDRV_STR_ARRAY[pdrv], buff, sector, count) != 0) {
 		return RES_ERROR;
 	} else {
 		return RES_OK;
 	}
-
 }
 
 /* Write Sector(s) */
 DRESULT disk_write(BYTE pdrv, const BYTE *buff, LBA_t sector, UINT count)
 {
-	__ASSERT(pdrv < ARRAY_SIZE(pdrv_str), "pdrv out-of-range\n");
+	__ASSERT(pdrv < ARRAY_SIZE(PDRV_STR_ARRAY), "pdrv out-of-range\n");
 
-	if (disk_access_write(pdrv_str[pdrv], buff, sector, count) != 0) {
+	if (disk_access_write(PDRV_STR_ARRAY[pdrv], buff, sector, count) != 0) {
 		return RES_ERROR;
 	} else {
 		return RES_OK;
@@ -69,19 +73,18 @@ DRESULT disk_ioctl(BYTE pdrv, BYTE cmd, void *buff)
 	int ret = RES_OK;
 	uint32_t sector_size = 0;
 
-	__ASSERT(pdrv < ARRAY_SIZE(pdrv_str), "pdrv out-of-range\n");
+	__ASSERT(pdrv < ARRAY_SIZE(PDRV_STR_ARRAY), "pdrv out-of-range\n");
 
 	switch (cmd) {
 	case CTRL_SYNC:
-		if (disk_access_ioctl(pdrv_str[pdrv],
-				DISK_IOCTL_CTRL_SYNC, buff) != 0) {
+		if (disk_access_ioctl(PDRV_STR_ARRAY[pdrv], DISK_IOCTL_CTRL_SYNC, buff) != 0) {
 			ret = RES_ERROR;
 		}
 		break;
 
 	case GET_SECTOR_COUNT:
-		if (disk_access_ioctl(pdrv_str[pdrv],
-				DISK_IOCTL_GET_SECTOR_COUNT, buff) != 0) {
+		if (disk_access_ioctl(PDRV_STR_ARRAY[pdrv], DISK_IOCTL_GET_SECTOR_COUNT, buff) !=
+		    0) {
 			ret = RES_ERROR;
 		}
 		break;
@@ -91,9 +94,9 @@ DRESULT disk_ioctl(BYTE pdrv, BYTE cmd, void *buff)
 		 * 32-bit number while FatFS's GET_SECTOR_SIZE is supposed to
 		 * return a 16-bit number.
 		 */
-		if ((disk_access_ioctl(pdrv_str[pdrv],
-				DISK_IOCTL_GET_SECTOR_SIZE, &sector_size) == 0) &&
-			(sector_size == (uint16_t)sector_size)) {
+		if ((disk_access_ioctl(PDRV_STR_ARRAY[pdrv], DISK_IOCTL_GET_SECTOR_SIZE,
+				       &sector_size) == 0) &&
+		    (sector_size == (uint16_t)sector_size)) {
 			*(uint16_t *)buff = (uint16_t)sector_size;
 		} else {
 			ret = RES_ERROR;
@@ -101,8 +104,8 @@ DRESULT disk_ioctl(BYTE pdrv, BYTE cmd, void *buff)
 		break;
 
 	case GET_BLOCK_SIZE:
-		if (disk_access_ioctl(pdrv_str[pdrv],
-				DISK_IOCTL_GET_ERASE_BLOCK_SZ, buff) != 0) {
+		if (disk_access_ioctl(PDRV_STR_ARRAY[pdrv], DISK_IOCTL_GET_ERASE_BLOCK_SZ, buff) !=
+		    0) {
 			ret = RES_ERROR;
 		}
 		break;
@@ -113,16 +116,14 @@ DRESULT disk_ioctl(BYTE pdrv, BYTE cmd, void *buff)
 	case CTRL_POWER:
 		if (((*(uint8_t *)buff)) == DISK_IOCTL_POWER_OFF) {
 			/* Power disk off */
-			if (disk_access_ioctl(pdrv_str[pdrv],
-					      DISK_IOCTL_CTRL_DEINIT,
-					      NULL) != 0) {
+			if (disk_access_ioctl(PDRV_STR_ARRAY[pdrv], DISK_IOCTL_CTRL_DEINIT, NULL) !=
+			    0) {
 				ret = RES_ERROR;
 			}
 		} else {
 			/* Power disk on */
-			if (disk_access_ioctl(pdrv_str[pdrv],
-					      DISK_IOCTL_CTRL_INIT,
-					      NULL) != 0) {
+			if (disk_access_ioctl(PDRV_STR_ARRAY[pdrv], DISK_IOCTL_CTRL_INIT, NULL) !=
+			    0) {
 				ret = STA_NOINIT;
 			}
 		}

--- a/subsys/fs/Kconfig.fatfs
+++ b/subsys/fs/Kconfig.fatfs
@@ -277,6 +277,28 @@ config FS_FATFS_MULTI_PARTITION
 	  physical drive number and only an FAT volume found on the physical drive
 	  will be mounted.
 
+config FS_FATFS_CUSTOM_MOUNT_POINT_COUNT
+	int "Count of custom mount points"
+	default 0
+	range 0 10
+	help
+	  This option has to be used in combination with FS_FATFS_CUSTOM_MOUNT_POINTS.
+	  It specifies how many custom mount points are defined in the custom mount
+	  point string.
+
+config FS_FATFS_CUSTOM_MOUNT_POINTS
+	string "Support for custom mountpoints when using fatfs"
+	help
+	   This option allows to specify custom mount points where fatfs filesystems
+	   can be mounted. The option has to be defined as a comma separated list
+	   with no whitespaces and no trailing commas.
+	   Example: "RAM,SD,SD2,NAND".
+	   It is also necessary to define the count of mount points specified in the
+	   list with the option FS_FATFS_CUSTOM_MOUNT_POINT_COUNT.
+	   If this option is active no mount points not defined within the list can
+	   be used for mounting fatfs filesystems anymore.
+	depends on FS_FATFS_CUSTOM_MOUNT_POINT_COUNT > 0
+
 endmenu
 
 endif # FAT_FILESYSTEM_ELM

--- a/subsys/fs/fat_fs.c
+++ b/subsys/fs/fat_fs.c
@@ -557,9 +557,30 @@ static const struct fs_file_system_t fatfs_fs = {
 #endif
 };
 
+#if CONFIG_FS_FATFS_CUSTOM_MOUNT_POINT_COUNT
+const char *VolumeStr[CONFIG_FS_FATFS_CUSTOM_MOUNT_POINT_COUNT];
+#endif /* CONFIG_FS_FATFS_CUSTOM_MOUNT_POINT_COUNT */
+
 static int fatfs_init(void)
 {
+#if CONFIG_FS_FATFS_CUSTOM_MOUNT_POINT_COUNT
+	static char mount_points[] = CONFIG_FS_FATFS_CUSTOM_MOUNT_POINTS;
+	int mount_point_count = 0;
 
+	VolumeStr[0] = mount_points;
+	for (int i = 0; i < ARRAY_SIZE(mount_points) - 1; i++) {
+		if (mount_points[i] == ',') {
+			mount_points[i] = 0;
+			mount_point_count++;
+			if (mount_point_count >= ARRAY_SIZE(VolumeStr)) {
+				LOG_ERR("Mount point count not sufficient for defined mount "
+					"points.");
+				return -1;
+			}
+			VolumeStr[mount_point_count] = &mount_points[i + 1];
+		}
+	}
+#endif /* CONFIG_FS_FATFS_CUSTOM_MOUNT_POINT_COUNT */
 	return fs_register(FS_FATFS, &fatfs_fs);
 }
 


### PR DESCRIPTION
In order to use custom named mount points with fatfs some adjustments to the zephyr fatfs integration had to be done.

If somebody sees a possibility how `CONFIG_FS_FATFS_CUSTOM_MOUNT_POINT_COUNT` could be removed i am very open to suggestions.