### PR TITLE
samples: usb: dfu: Exclude Atmel SAM

### DIFF
--- a/samples/subsys/usb/dfu/sample.yaml
+++ b/samples/subsys/usb/dfu/sample.yaml
@@ -12,6 +12,8 @@ common:
     - mimxrt1060_evk@B/mimxrt1062/qspi
     - mimxrt1060_evk@C/mimxrt1062/qspi
     - sam4l_ek
+    - same54_xpro
+    - samr21_xpro
     - mimxrt1050_evk/mimxrt1052/hyperflash
     - mimxrt1050_evk/mimxrt1052/qspi
     - mimxrt1060_evk/mimxrt1062/hyperflash


### PR DESCRIPTION
The dfu sample filter seems not to work. It should select only boards when slot0_partition and slot1_partition are define.

```
filter:
    dt_label_with_parent_compat_enabled("slot0_partition", "fixed-partitions")
and dt_label_with_parent_compat_enabled("slot1_partition", "fixed-partitions")
and dt_chosen_enabled("zephyr,flash-controller")
and CONFIG_FLASH_HAS_DRIVER_ENABLED
```

This means that sam4l_ek, same54_xpro and samr21_xpro should never be selected because the final devicetree is defined without those partitions. See below fragment from same54_xpro:

```
nvmctrl: nvmctrl@41004000 {
	compatible = "atmel,sam0-nvmctrl";
	reg = < 0x41004000 0x22 >;
	interrupts = < 0x1d 0x0 >, < 0x1e 0x0 >;
	#address-cells = < 0x1 >;
	#size-cells = < 0x1 >;
	lock-regions = < 0x20 >;
	flash0: flash@0 {
		compatible = "soc-nv-flash";
		write-block-size = < 0x8 >;
		reg = < 0x0 0x100000 >;
		partitions {
			compatible = "fixed-partitions";
			#address-cells = < 0x1 >;
			#size-cells = < 0x1 >;
			storage_partition: partition@fc000 {
				label = "storage";
				reg = < 0xfc000 0x4000 >;
			};
		};
	};
};
```

This excludes same54_xpro and samr21_xpro to avoid ci issues until ci filter is fixed.