### PR TITLE
drivers: input: sbus: Fix SBUS parser overflow

### DIFF
--- a/drivers/input/input_sbus.c
+++ b/drivers/input/input_sbus.c
@@ -123,7 +123,7 @@ static void input_sbus_input_report_thread(const struct device *dev, void *dummy
 
 	uint8_t i, channel;
 	uint8_t *sbus_channel_data = &data->sbus_frame[1]; /* Omit header */
-	uint16_t value;
+	uint32_t value;
 	int bits_read;
 	unsigned int key;
 	int ret;


### PR DESCRIPTION
SBUS parser discards portion of the received data, this is a result of SBUS parser intermediate variable overflow. Fix by changing said variable type to uint32_t.

Fixes: #84199