### PR TITLE
samples: alarm: esp32c6_devkitc

### DIFF
--- a/samples/drivers/counter/alarm/boards/esp32c6_devkitc.overlay
+++ b/samples/drivers/counter/alarm/boards/esp32c6_devkitc.overlay
@@ -1,0 +1,3 @@
+&timer0 {
+	status = "okay";
+};


### PR DESCRIPTION
samples/drivers/counter/alarm/boards/esp32c6_devkitc.overlay: addition of esp32c6_devkitc.overlay for alarm sample. tested.

![image](https://github.com/user-attachments/assets/b04b09b3-9bcb-4728-b352-cd14f7609183)
