### PR TITLE
west.yaml: update hal_rpi_pico to be based on Pico SDK 2.1.0

### DIFF
--- a/drivers/counter/counter_rpi_pico_timer.c
+++ b/drivers/counter/counter_rpi_pico_timer.c
@@ -68,7 +68,9 @@ static uint32_t counter_rpi_pico_timer_get_top_value(const struct device *dev)
 
 static int counter_rpi_pico_timer_get_value(const struct device *dev, uint32_t *ticks)
 {
-	*ticks = time_us_32();
+	const struct counter_rpi_pico_timer_config *config = dev->config;
+
+	*ticks = timer_time_us_32(config->timer);
 	return 0;
 }
 
@@ -158,6 +160,7 @@ static int counter_rpi_pico_timer_set_guard_period(const struct device *dev, uin
 static void counter_rpi_pico_irq_handle(uint32_t ch, void *arg)
 {
 	struct device *dev = arg;
+	const struct counter_rpi_pico_timer_config *config = dev->config;
 	struct counter_rpi_pico_timer_data *data = dev->data;
 	counter_alarm_callback_t cb = data->ch_data[ch].callback;
 	void *user_data = data->ch_data[ch].user_data;
@@ -165,7 +168,7 @@ static void counter_rpi_pico_irq_handle(uint32_t ch, void *arg)
 	if (cb) {
 		data->ch_data[ch].callback = NULL;
 		data->ch_data[ch].user_data = NULL;
-		cb(dev, ch, time_us_32(), user_data);
+		cb(dev, ch, timer_time_us_32(config->timer), user_data);
 	}
 }
 

--- a/modules/hal_rpi_pico/CMakeLists.txt
+++ b/modules/hal_rpi_pico/CMakeLists.txt
@@ -69,6 +69,7 @@ if(CONFIG_HAS_RPI_PICO)
 
   zephyr_include_directories(
     ${common_dir}/pico_base_headers/include
+    ${rp2_common_dir}/boot_bootrom_headers/include
     ${rp2_common_dir}/hardware_base/include
     ${rp2_common_dir}/hardware_clocks/include
     ${rp2_common_dir}/hardware_watchdog/include
@@ -82,6 +83,7 @@ if(CONFIG_HAS_RPI_PICO)
     ${rp2_common_dir}/hardware_ticks/include
     ${rp2_common_dir}/hardware_sync_spin_lock/include
     ${rp2_common_dir}/pico_bootrom/include
+    ${rp2_common_dir}/pico_flash/include
     ${rp2_common_dir}/pico_platform_compiler/include
     ${rp2_common_dir}/pico_platform_sections/include
     ${rp2_common_dir}/pico_platform_panic/include

--- a/tests/drivers/counter/counter_basic_api/socs/rp2350a_m33.overlay
+++ b/tests/drivers/counter/counter_basic_api/socs/rp2350a_m33.overlay
@@ -1,0 +1,7 @@
+&timer0 {
+	status = "okay";
+};
+
+&timer1 {
+	status = "okay";
+};

--- a/west.yml
+++ b/west.yml
@@ -224,7 +224,7 @@ manifest:
         - hal
     - name: hal_rpi_pico
       path: modules/hal/rpi_pico
-      revision: 79ee0f9e058a6327fc943d2f2a19cf3ade107cec
+      revision: 7b57b24588797e6e7bf18b6bda168e6b96374264
       groups:
         - hal
     - name: hal_silabs


### PR DESCRIPTION
This should not be merged until https://github.com/zephyrproject-rtos/hal_rpi_pico/pull/8 has been approved .

## Summary

- Update `hal_rpi_pico` to the 2.1.0 release. This brings in a number of bugfixes and improvements.
- Correct `rpi_pico_timer`. Updating the HAL to use a newer version of the SDK brings in a bugfix in the SDK, which in turn exposes a bug in the `rpi_pico_timer`. Fix the bug and extend the test coverage to confirm and verify this.

This PR supersedes #82680 

## Testing

Locally tested against the Raspberry Pico 2, with no regressions identified. Build-only testing for a couple of RP2040-based boards with no issues found.

Fixes #82452

