### PR TITLE
samples: led_strip: boards esp32c6_devkitc

### DIFF
--- a/samples/drivers/led/led_strip/boards/esp32c6_devkitc.overlay
+++ b/samples/drivers/led/led_strip/boards/esp32c6_devkitc.overlay
@@ -1,0 +1,37 @@
+#include <zephyr/dt-bindings/led/led.h>
+
+&spi2 {
+	/* Workaround to support WS2812 driver */
+	line-idle-low;
+
+	led_strip: ws2812@0 {
+		compatible = "worldsemi,ws2812-spi";
+
+		/* SPI */
+		reg = <0>; /* ignored, but necessary for SPI bindings */
+		spi-max-frequency = <6400000>;
+
+		/* WS2812 */
+		chain-length = <1>; /* arbitrary; change at will */
+		spi-cpha;
+		spi-one-frame = <0xf0>; /* 11110000: 625 ns high and 625 ns low */
+		spi-zero-frame = <0xc0>; /* 11000000: 312.5 ns high and 937.5 ns low */
+		color-mapping = <LED_COLOR_ID_GREEN
+				 LED_COLOR_ID_RED
+				 LED_COLOR_ID_BLUE>;
+	};
+};
+
+&pinctrl {
+	spim2_default: spim2_default {
+		group2 {
+			pinmux = <SPIM2_MOSI_GPIO8>;
+		};
+	};
+};
+
+/ {
+	aliases {
+		led-strip = &led_strip;
+	};
+};


### PR DESCRIPTION
esp32c6_devkitc.overlay overlay added for led_strip. tested


https://github.com/user-attachments/assets/361da199-4f72-4f13-b5ce-194beef26d83

