### PR TITLE
west.yml: update `hal_nordic` to ignore binary blobs

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -193,7 +193,7 @@ manifest:
       groups:
         - hal
     - name: hal_nordic
-      revision: ecea8cdbd1a7d557563b47ad304ee9ba7a8709e5
+      revision: e540db12eca4b7b4f2fdc1e7354cdd71da462ef0
       path: modules/hal/nordic
       groups:
         - hal


### PR DESCRIPTION
Update the `hal_nordic` repository so that git ignore binary blobs fetched by `west blobs fetch hal_nordic`.