### PR TITLE
boards: nrf7002dk: specify `netif:wifi` support

### DIFF
--- a/boards/nordic/nrf7002dk/nrf7002dk_nrf5340_cpuapp.yaml
+++ b/boards/nordic/nrf7002dk/nrf7002dk_nrf5340_cpuapp.yaml
@@ -16,4 +16,5 @@ supported:
   - usbd
   - usb_device
   - netif:openthread
+  - netif:wifi
 vendor: nordic


### PR DESCRIPTION
The `nrf7002dk` board has a WiFi chipset supported by in-tree drivers. Mark it as a supported feature so that `twister` filters are matched.