### PR TITLE
posix: options: shm: use truncation flag that has been added

### DIFF
--- a/lib/posix/options/shm.c
+++ b/lib/posix/options/shm.c
@@ -305,7 +305,7 @@ int shm_open(const char *name, int oflag, mode_t mode)
 	bool rw = (oflag & O_RDWR) != 0;
 	bool creat = (oflag & O_CREAT) != 0;
 	bool excl = (oflag & O_EXCL) != 0;
-	bool trunc = false; /* (oflag & O_TRUNC) != 0 */
+	bool trunc = (oflag & O_TRUNC) != 0;
 	size_t name_len = (name == NULL) ? 0 : strnlen(name, PATH_MAX);
 
 	/* revisit when file-based permissions are available */


### PR DESCRIPTION
Originally, when the POSIX_SHARED_MEMORY_OBJECTS option was added, the O_TRUNC flag was not consistently available.

Now that it is consistently available, ensure it is used within the shm_open() function.

Fixes #74818