### PR TITLE
dts: bindings: dac: Change the property names in the overlay

### DIFF
--- a/doc/releases/migration-guide-4.1.rst
+++ b/doc/releases/migration-guide-4.1.rst
@@ -157,6 +157,12 @@ Display
 * Renamed the devicetree propertys ``pclk_pol`` and ``data_cmd-gpios``
   to ``pclk-pol`` and ``data-cmd-gpios``.
 
+DAC
+===
+
+* Renamed the devicetree properties ``voltage_reference`` and ``power_down_mode``
+  to ``voltage-reference`` and ``power-down-mode``.
+
 Enhanced Serial Peripheral Interface (eSPI)
 ===========================================
 

--- a/dts/bindings/dac/microchip,mcp4728.yaml
+++ b/dts/bindings/dac/microchip,mcp4728.yaml
@@ -8,7 +8,7 @@ properties:
   "#io-channel-cells":
     const: 1
 
-  voltage_reference:
+  voltage-reference:
     type: array
     required: true
     description: |
@@ -17,7 +17,7 @@ properties:
       1 - Internal voltage reference (2.048V)
       Note: array entries correspond to the successive channels
 
-  power_down_mode:
+  power-down-mode:
     type: array
     required: true
     description: |

--- a/tests/drivers/build_all/dac/app.overlay
+++ b/tests/drivers/build_all/dac/app.overlay
@@ -65,8 +65,8 @@
 				compatible = "microchip,mcp4728";
 				reg = <0x61>;
 				#io-channel-cells = <1>;
-				voltage_reference = <0>;
-				power_down_mode = <0>;
+				voltage-reference = <0>;
+				power-down-mode = <0>;
 			};
 
 			test_i2c_dacx0501:dacx0501@62 {


### PR DESCRIPTION
Change the property names in the bindings and overlay
to use hyphens(-) for separation instead of underscores(_).