### PR TITLE
drivers: gpio: xlnx: Add support for versal2 PS/PMC GPIO

### DIFF
--- a/drivers/gpio/gpio_xlnx_ps_bank.c
+++ b/drivers/gpio/gpio_xlnx_ps_bank.c
@@ -454,7 +454,7 @@ static const struct gpio_xlnx_ps_bank_dev_cfg gpio_xlnx_ps_bank##idx##_cfg = {\
 	.common = {\
 		.port_pin_mask = GPIO_PORT_PIN_MASK_FROM_DT_INST(idx),\
 	},\
-	.bank_index = idx,\
+	.bank_index = DT_INST_REG_ADDR(idx),\
 };\
 static struct gpio_xlnx_ps_bank_dev_data gpio_xlnx_ps_bank##idx##_data = {\
 	.base = 0,\

--- a/tests/drivers/gpio/gpio_basic_api/boards/kv260_r5.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/kv260_r5.overlay
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2025 Advanced Micro Devices, Inc. (AMD)
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	loop {
+		compatible = "test-gpio-basic-api";
+
+		out-gpios = <&psgpio_bank3 0 0>; /* GPIOPS BANK 3 PIN 0 */
+		in-gpios = <&psgpio_bank3 1 0>; /* GPIOPS BANK 3 PIN 1 */
+	};
+};
+
+&psgpio {
+	status = "okay";
+};

--- a/tests/drivers/gpio/gpio_basic_api/testcase.yaml
+++ b/tests/drivers/gpio/gpio_basic_api/testcase.yaml
@@ -111,3 +111,9 @@ tests:
     platform_allow:
       - siwx917_rb4338a
     extra_args: "DTC_OVERLAY_FILE=boards/siwx917_rb4338a-uulp.overlay"
+
+  drivers.gpio.kv260_r5:
+    filter: CONFIG_GPIO_XLNX_PS
+    platform_allow:
+      - kv260_r5
+    extra_args: "DTC_OVERLAY_FILE=boards/kv260_r5.overlay"


### PR DESCRIPTION
Add driver support for Versal Gen 2 PS/PMC GPIO controller by updating the logic of bank index calculation.

This logic depends on "register" DT property to identify bank index instead of depending on node instance ID as Versal Gen 2 GPIO banks are not in sequential order as Zynqmp.

- Versal Gen 2 PS GPIO: Banks(0,3,4)
- Zynqmp PS GPIO: Banks(0,1,2,3,4,5)