### PR TITLE
Update tfm_integration samples module dependencies

### DIFF
--- a/samples/tfm_integration/tfm_psa_test/sample.yaml
+++ b/samples/tfm_integration/tfm_psa_test/sample.yaml
@@ -10,7 +10,6 @@ common:
     - v2m_musca_s1/musca_s1/ns
   modules:
     - psa-arch-tests
-    - tf-m-tests
   integration_platforms:
     - mps2/an521/cpu0/ns
   harness: console

--- a/samples/tfm_integration/tfm_regression_test/sample.yaml
+++ b/samples/tfm_integration/tfm_regression_test/sample.yaml
@@ -3,7 +3,7 @@ common:
     - trusted-firmware-m
     - mcuboot
   modules:
-    - psa-arch-tests
+    - tf-m-tests
   platform_allow:
     - nrf5340dk/nrf5340/cpuapp/ns
     - nrf9160dk/nrf9160/ns


### PR DESCRIPTION
[tfm_regression_test](https://github.com/zephyrproject-rtos/zephyr/tree/main/samples/tfm_integration/tfm_regression_test) depends on the [tf-m-tests](https://github.com/zephyrproject-rtos/tf-m-tests)
[tfm_psa_test](https://github.com/zephyrproject-rtos/zephyr/tree/main/samples/tfm_integration/tfm_psa_test)   depends on the [psa-arch-tests](https://github.com/zephyrproject-rtos/psa-arch-tests)

This PR set module dependencies to correct values.