### PR TITLE
net: pkt: Alloc headroom also for variable size data buffers

### DIFF
--- a/subsys/net/ip/net_pkt.c
+++ b/subsys/net/ip/net_pkt.c
@@ -1033,13 +1033,12 @@ static struct net_buf *pkt_alloc_buffer(struct net_pkt *pkt,
 
 #if defined(CONFIG_NET_PKT_ALLOC_STATS)
 	uint32_t start_time = k_cycle_get_32();
-	size_t total_size = size;
+	size_t total_size = size + headroom;
 #else
 	ARG_UNUSED(pkt);
 #endif
-	ARG_UNUSED(headroom);
 
-	buf = net_buf_alloc_len(pool, size, timeout);
+	buf = net_buf_alloc_len(pool, size + headroom, timeout);
 
 #if CONFIG_NET_PKT_LOG_LEVEL >= LOG_LEVEL_DBG
 	NET_FRAG_CHECK_IF_NOT_IN_USE(buf, buf->ref + 1);

--- a/tests/net/vlan/testcase.yaml
+++ b/tests/net/vlan/testcase.yaml
@@ -11,3 +11,7 @@ tests:
   net.vlan.header_reserved:
     extra_configs:
       - CONFIG_NET_L2_ETHERNET_RESERVE_HEADER=y
+  net.vlan.header_reserved.variable_size:
+    extra_configs:
+      - CONFIG_NET_L2_ETHERNET_RESERVE_HEADER=y
+      - CONFIG_NET_BUF_VARIABLE_DATA_SIZE=y


### PR DESCRIPTION
The headroom was not taken into account for variable size data buffers when CONFIG_NET_L2_ETHERNET_RESERVE_HEADER was enabled.

Add a test case for it to make sure the reserve allocation works properly.

Fixes #84053