### PR TITLE
Allow to filter testsuite roots

### DIFF
--- a/scripts/ci/testsuite_excludes.yaml
+++ b/scripts/ci/testsuite_excludes.yaml
@@ -1,0 +1,17 @@
+# This file contains information on what files are associated with which
+# twister testsuite excludes patterns.
+#
+# File format is the same as for tags.yaml - please refer to its description.
+
+# zephyr-keep-sorted-start
+"*tests/kernel*":
+  files:
+    - kernel/
+    - arch/
+    - tests/kernel/
+
+"*tests/posix*":
+  files:
+    - lib/posix/
+    - tests/posix/
+# zephyr-keep-sorted-stop

--- a/scripts/pylib/twister/twisterlib/environment.py
+++ b/scripts/pylib/twister/twisterlib/environment.py
@@ -146,6 +146,15 @@ Artificially long but functional example:
              "'tests/' directories at the base of the Zephyr tree.")
 
     case_select.add_argument(
+        "--testsuite-exclude-path", action="append", default=[], type = norm_path,
+        help="Directory to exclude from searching for test cases. "
+             "This is a filter pattern for paths provided with the testsuite-root option. "
+             "Supports Unix shell-style wildcards, e.g. *samples/sub* (fnmatch). "
+             "The exclude pattern is matched against an absolute path for the test suite. "
+             "This option can be used multiple times, multiple invocations "
+             "are treated as a logical 'or' relationship.")
+
+    case_select.add_argument(
         "-f",
         "--only-failed",
         action="store_true",
@@ -1063,6 +1072,7 @@ class TwisterEnv:
         logger.info(f"Using {self.generator}..")
 
         self.test_roots = options.testsuite_root
+        self.test_exclude_paths = options.testsuite_exclude_path
 
         if not isinstance(options.board_root, list):
             self.board_roots = [options.board_root]

--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -7,6 +7,7 @@
 # SPDX-License-Identifier: Apache-2.0
 import collections
 import copy
+import fnmatch
 import itertools
 import json
 import logging
@@ -507,6 +508,15 @@ class TestPlan:
                     continue
 
                 logger.debug("Found possible testsuite in " + dirpath)
+
+                skip_path = False
+                for test_exclude_path in self.env.test_exclude_paths:
+                    if fnmatch.fnmatch(dirpath, test_exclude_path):
+                        skip_path = True
+                        break
+                if skip_path:
+                    logger.debug(f"Skipping {dirpath} due to excludes")
+                    continue
 
                 suite_yaml_path = os.path.join(dirpath, filename)
                 suite_path = os.path.dirname(suite_yaml_path)

--- a/scripts/tests/twister/test_testplan.py
+++ b/scripts/tests/twister/test_testplan.py
@@ -1306,7 +1306,8 @@ tests:
     env = mock.Mock(
         test_roots=[tmp_test_root_dir],
         options=mock.Mock(detailed_test_id=detailed_id),
-        alt_config_root=[tmp_alt_test_root_dir] if use_alt_root else []
+        alt_config_root=[tmp_alt_test_root_dir] if use_alt_root else [],
+        test_exclude_paths=[]
     )
 
     testplan = TestPlan(env=env)


### PR DESCRIPTION
This PR contains 2 changes: for twister and test_plan (the one used at CI for test scope selection).

For twister, it adds a new parameter `--testsuite-exclude-path` which can be used to exclude the test suite path from
discovering tests (base on `--testsuite-root`).
So you can use `--testsuite-root tests --testsuite-exclude-path "*tests/kernel*" --testsuite-exclude-path "*tests/lib*" ` to run all tests except those in the tests/kernel and tests/lib paths.
This can be useful to limit the number of executed tests (e.g. if it is known that nothing related to these tests has changed).

For test_plan, an option is added to include the relationship between test suite paths and modified files in the test scope selection process. The new way works almost the same as filtering by tags, but it filters by test suite paths. The relationship to the modified files is the same i.e. if the PR does not modify the specified files/paths, the test suite path is removed from execution.

Test suite path based filtering has several advantages:
- There is no need to tag every test. Most of the tests are not tagged, so they cannot be easily excluded (which limits the ability to filter on Zephyr and downstream (forked Zephyr repositories)).
- Test suite path-based approach is easily extensible - just one file change. It can be easily overwritten downstream with custom configuration.
- Tag-based filtering approach may result in unintentionally skipped tests if multiple tags are added to the test and only one of them is filtered out by test_plan.

The downside may be that if you add a new test and its path is already listed in excludes, it will not be automatically executed. The opposite is true for tags, if the new test does not have one, it will not be filtered out.

Tag-based filtering and test suite path filtering can be used together or separately.

The `scripts/ci/testsuite_excludes.yaml` has example content (but valid), I plan to extend it for all tests and samples (not at this PR). If wanted, I can share that dependency list so it can be used for zephyr CI.

This PR does not affect test scope selection used currently at zephyr CI! (new filtering is not enabled there).