### PR TITLE
net: http_server: fix URL matching with '?' character in resource

### DIFF
--- a/subsys/net/lib/http/http_server_core.c
+++ b/subsys/net/lib/http/http_server_core.c
@@ -700,16 +700,19 @@ closing:
 	return ret;
 }
 
-/* Compare two strings where the terminator is either "\0" or "?" */
-static int compare_strings(const char *s1, const char *s2)
+/* Compare a path and a resource string. The path string comes from the HTTP request and may be
+ * terminated by either '?' or '\0'. The resource string is registered along with the resource and
+ * may only be terminated by `\0`.
+ */
+static int compare_strings(const char *path, const char *resource)
 {
-	while ((*s1 && *s2) && (*s1 == *s2) && (*s1 != '?')) {
-		s1++;
-		s2++;
+	while ((*path && *resource) && (*path == *resource) && (*path != '?')) {
+		path++;
+		resource++;
 	}
 
-	/* Check if both strings have reached their terminators or '?' */
-	if ((*s1 == '\0' || *s1 == '?') && (*s2 == '\0' || *s2 == '?')) {
+	/* Check if both strings have reached their terminators */
+	if ((*path == '\0' || *path == '?') && (*resource == '\0')) {
 		return 0; /* Strings are equal */
 	}
 

--- a/tests/net/lib/http_server/common/src/main.c
+++ b/tests/net/lib/http_server/common/src/main.c
@@ -342,6 +342,10 @@ ZTEST(http_service, test_HTTP_RESOURCE_WILDCARD)
 	zassert_true(len > 0, "Length not set");
 	zassert_equal(res, RES(3), "Resource mismatch");
 
+	res = CHECK_PATH(service_D, "/fb", &len);
+	zassert_is_null(res, "Resource found");
+	zassert_equal(len, 0, "Length set");
+
 	res = CHECK_PATH(service_A, "/fs/index.html", &len);
 	zassert_not_null(res, "Cannot find resource");
 	zassert_true(len > 0, "Length not set");


### PR DESCRIPTION
Fixes #84198.

If a '?' character is used as part of a wildcard resource, do not treat this as the end of the string when comparing with a path from the HTTP request. Only the path from the HTTP request may be terminated by '?' (in the case of a request with query parameters).