### PR TITLE
drivers: video: ov7670: Implement missing video API functions, controls and update init regs.

### DIFF
--- a/drivers/video/ov7670.c
+++ b/drivers/video/ov7670.c
@@ -256,7 +256,7 @@ static const struct ov7670_reg ov7670_init_regtbl[] = {
 
 	/* display , need retain */
 	{OV7670_COM15, 0xD0}, /* Common Control 15 */
-	{OV7670_TSLB, 0x0C},  /* Line Buffer Test Option */
+	{OV7670_TSLB, 0x04},  /* Reserved */
 	{OV7670_COM13, 0x80}, /* Common Control 13 */
 	{OV7670_MANU, 0x11},  /* Manual U Value */
 	{OV7670_MANV, 0xFF},  /* Manual V Value */

--- a/drivers/video/ov7670.c
+++ b/drivers/video/ov7670.c
@@ -210,8 +210,8 @@ static const struct ov7670_reg ov7670_init_regtbl[] = {
 	{OV7670_MVFP, 0x00}, /* MVFP: Mirror/VFlip,Normal image */
 
 	/* configure the output timing */
-	/* PCLK does not toggle during horizontal blank, one PCLK, one pixel */
-	{OV7670_COM10, 0x20}, /* COM10 */
+	/* Free running PCLK, default VSYNC, HSYNC and PCLK */
+	{OV7670_COM10, 0x00}, /* COM10 */
 	{OV7670_COM12, 0x00}, /* COM12,No HREF when VSYNC is low */
 	/* Brightness Control, with signal -128 to +128, 0x00 is middle value */
 	{OV7670_BRIGHT, 0x2f},


### PR DESCRIPTION
Add the missing `stream_start` and `stream_stop` API functions (the driver doesn't work without them) and implement video controls for horizontal mirror (hmirror) and vertical flip. Additionally, I've changed PCLK to free-running as the STM32 DCMI doesn't seem to work without it.

I would also like to change the default VSYNC/HSYNC polarity to high (0x03) to make this driver consistent with others. This change would allow us to reuse the same overlay without modifying vsync-active. Since this driver wasn't functioning at all, I assume it is safe to make this change as it won't break anything else?