### PR TITLE
dts: nxp: rt1060: correct PTP clock reference in enet2

### DIFF
--- a/dts/arm/nxp/nxp_rt1060.dtsi
+++ b/dts/arm/nxp/nxp_rt1060.dtsi
@@ -57,7 +57,7 @@
 				interrupts = <152 0>;
 				interrupt-names = "COMMON";
 				nxp,mdio = <&enet2_mdio>;
-				nxp,ptp-clock = <&enet_ptp_clock>;
+				nxp,ptp-clock = <&enet2_ptp_clock>;
 				status = "disabled";
 			};
 			enet2_mdio: mdio {


### PR DESCRIPTION
The enet2 node in nxp_rt1060.dtsi incorrectly references &enet_ptp_clock for its nxp,ptp-clock property. This commit updates the reference to &enet2_ptp_clock.