### PR TITLE
manifest: Update bsim to version v2.5

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -37,7 +37,7 @@ manifest:
       remote: babblesim
       repo-path: base
       path: tools/bsim/components
-      revision: 0cc70e78a88c1de9d8ec045a703b38134861e7e7
+      revision: 153101c61ce7106f6ba8b108b5c6488efdc1151a
       groups:
         - babblesim
     - name: babblesim_ext_2G4_channel_NtNcable
@@ -107,12 +107,12 @@ manifest:
       remote: babblesim
       repo-path: ext_libCryptov1
       path: tools/bsim/components/ext_libCryptov1
-      revision: 236309584c90be32ef12848077bd6de54e9f4deb
+      revision: da246018ebe031e4fe4a8228187fb459e9f3b2fa
       groups:
         - babblesim
     - name: bsim
       repo-path: babblesim-manifest
-      revision: 1f242f4ed7fc141fdfcfeca8d21c6d9e801179d7
+      revision: a88d3353451387ca490a6a7f7c478a90c4ee05b7
       path: tools/bsim
       groups:
         - babblesim


### PR DESCRIPTION
Main changes since v2.4:
* libRandv2: New API to fill buffers & Wextra warning fixes
* libCryptov1: Add new AES-ECB API

Note: Like before, bsim remains fully backwards compatible,
and just like before it is safe to update either this repo pointer or the docker image ahead of the other.