### PR TITLE
llext: fix EXPORT_SYMBOL() for extensions

### DIFF
--- a/include/zephyr/llext/symbol.h
+++ b/include/zephyr/llext/symbol.h
@@ -92,7 +92,7 @@ struct llext_symtable {
 /* Extension build: add exported symbols to llext table */
 #define Z_LL_EXTENSION_SYMBOL_NAMED(sym_ident, sym_name)			\
 	static const struct llext_const_symbol					\
-			Z_GENERIC_SECTION(".exported_sym") __used		\
+			Z_GENERIC_SECTION(.exported_sym) __used			\
 			__llext_sym_ ## sym_name = {				\
 		.name = STRINGIFY(sym_name), .addr = (const void *)&sym_ident,	\
 	}
@@ -135,7 +135,7 @@ struct llext_symtable {
 #elif defined(CONFIG_LLEXT_EXPORT_BUILTINS_BY_SLID)
 /* SLID-enabled LLEXT application: export symbols, names in separate section */
 #define Z_EXPORT_SYMBOL_NAMED(sym_ident, sym_name)				\
-	static const char Z_GENERIC_SECTION("llext_exports_strtab") __used	\
+	static const char Z_GENERIC_SECTION(llext_exports_strtab) __used	\
 		__llext_sym_name_ ## sym_name[] = STRINGIFY(sym_name);		\
 	static const STRUCT_SECTION_ITERABLE(llext_const_symbol,		\
 					     __llext_sym_ ## sym_name) = {	\

--- a/tests/subsys/llext/src/init_fini_ext.c
+++ b/tests/subsys/llext/src/init_fini_ext.c
@@ -49,14 +49,14 @@ static void fini_fn(void)
 	number |= 4;
 }
 
-static const void *const preinit_fn_ptrs[] __used Z_GENERIC_SECTION(".preinit_array") = {
+static const void *const preinit_fn_ptrs[] __used Z_GENERIC_SECTION(.preinit_array) = {
 	preinit_fn_1,
 	preinit_fn_2
 };
-static const void *const init_fn_ptrs[] __used Z_GENERIC_SECTION(".init_array") = {
+static const void *const init_fn_ptrs[] __used Z_GENERIC_SECTION(.init_array) = {
 	init_fn
 };
-static const void *const fini_fn_ptrs[] __used Z_GENERIC_SECTION(".fini_array") = {
+static const void *const fini_fn_ptrs[] __used Z_GENERIC_SECTION(.fini_array) = {
 	fini_fn
 };
 


### PR DESCRIPTION
When symbols are exported from extensions, EXPORT_SYMBOL() uses Z_GENERIC_SECTION() to place exported symbols in the ".exported_sym" section. However, the section name in its argument should be used with no quotes, which is exactly what currently is done. This patch removes excessive quotes.

Note, that there are a couple more potentially problematic locations in the code:

doc/hardware/cache/guide.rst:  uint8_t buffer[BUF_SIZE] Z_GENERIC_SECTION("SRAM4");
include/zephyr/llext/symbol.h:  static const char Z_GENERIC_SECTION("llext_exports_strtab") __used      \
soc/st/stm32/stm32wb0x/soc.c:Z_GENERIC_SECTION("stm32wb0_RAM_VR")
soc/st/stm32/stm32wb0x/soc.c:Z_GENERIC_SECTION("stm32wb0_BLUE_RAM")
tests/subsys/llext/simple/src/init_fini_ext.c:static const void *const preinit_fn_ptrs[] __used Z_GENERIC_SECTION(".preinit_array") = {
tests/subsys/llext/simple/src/init_fini_ext.c:static const void *const init_fn_ptrs[] __used Z_GENERIC_SECTION(".init_array") = {
tests/subsys/llext/simple/src/init_fini_ext.c:static const void *const fini_fn_ptrs[] __used Z_GENERIC_SECTION(".fini_array") = {

or maybe only this one was bad because of multiple redirection levels. This bug leads to a section table like
```
  4 ".exported_sym" 00000038  a068f0ec  a068f0ec  000002d8  2**2
                  CONTENTS, ALLOC, LOAD, RELOC, READONLY, DATA
  5 .data         00000000  a0690000  a0690000  00000310  2**0
                  CONTENTS, ALLOC, LOAD, DATA
  6 .bss          00000000  a0690000  a0690000  00000310  2**0
                  ALLOC
```