### PR TITLE
drivers: sensor: lis2de12: fix read accel via spi

### DIFF
--- a/drivers/sensor/st/lis2de12/lis2de12.c
+++ b/drivers/sensor/st/lis2de12/lis2de12.c
@@ -435,7 +435,7 @@ static int lis2de12_init(const struct device *dev)
 
 #define LIS2DE12_CONFIG_SPI(inst)						\
 	{									\
-		STMEMSC_CTX_SPI(&lis2de12_config_##inst.stmemsc_cfg),		\
+		STMEMSC_CTX_SPI_INCR(&lis2de12_config_##inst.stmemsc_cfg),		\
 		.stmemsc_cfg = {						\
 			.spi = SPI_DT_SPEC_INST_GET(inst, LIS2DE12_SPI_OP, 0),	\
 		},								\

--- a/drivers/sensor/st/stmemsc/stmemsc_spi.c
+++ b/drivers/sensor/st/stmemsc/stmemsc_spi.c
@@ -73,6 +73,9 @@ int stmemsc_spi_read_incr(const struct spi_dt_spec *stmemsc,
 int stmemsc_spi_write_incr(const struct spi_dt_spec *stmemsc,
 			   uint8_t reg_addr, uint8_t *value, uint8_t len)
 {
-	reg_addr |= STMEMSC_SPI_ADDR_AUTO_INCR;
+	if (len > 1) {
+		reg_addr |= STMEMSC_SPI_ADDR_AUTO_INCR;
+	}
+
 	return stmemsc_spi_write(stmemsc, reg_addr, value, len);
 }

--- a/drivers/sensor/st/stmemsc/stmemsc_spi.c
+++ b/drivers/sensor/st/stmemsc/stmemsc_spi.c
@@ -63,7 +63,10 @@ int stmemsc_spi_write(const struct spi_dt_spec *stmemsc,
 int stmemsc_spi_read_incr(const struct spi_dt_spec *stmemsc,
 			  uint8_t reg_addr, uint8_t *value, uint8_t len)
 {
-	reg_addr |= STMEMSC_SPI_ADDR_AUTO_INCR;
+	if (len > 1) {
+		reg_addr |= STMEMSC_SPI_ADDR_AUTO_INCR;
+	}
+
 	return stmemsc_spi_read(stmemsc, reg_addr, value, len);
 }
 


### PR DESCRIPTION
Fixes: #83794 

Added a fix for reading acceleration data from LIS2DE12 sensor over SPI.