### PR TITLE
samples: net: http_get: restore original google.com hostname

### DIFF
--- a/samples/net/sockets/http_get/src/http_get.c
+++ b/samples/net/sockets/http_get/src/http_get.c
@@ -30,7 +30,7 @@
 #endif
 
 /* HTTP server to connect to */
-#define HTTP_HOST "www.google.com"
+#define HTTP_HOST "google.com"
 /* Port to connect to, as string */
 #if defined(CONFIG_NET_SOCKETS_SOCKOPT_TLS)
 #define HTTP_PORT "443"


### PR DESCRIPTION
This sample is expected to hit google.com so that the reply (a redirect) is minimal and can easily be visualized. This is also what sample.yaml expects to see (checks for "The document has moved").