### PR TITLE
Bluetooth: Mesh: remove experimental mesh mbedtls

### DIFF
--- a/doc/releases/migration-guide-4.1.rst
+++ b/doc/releases/migration-guide-4.1.rst
@@ -369,6 +369,11 @@ Bluetooth Mesh
   set as deprecated. Default option for platforms that do not support TF-M
   is :kconfig:option:`CONFIG_BT_MESH_USES_MBEDTLS_PSA`.
 
+* Mesh explicitly depends on the Secure Storage subsystem if storing into
+  non-volatile memory (:kconfig:option:`CONFIG_BT_SETTINGS`) is enabled and
+  Mbed TLS library (:kconfig:option:`CONFIG_BT_MESH_USES_MBEDTLS_PSA`) is used.
+  Applications should be built with :kconfig:option:`CONFIG_SECURE_STORAGE` enabled.
+
 Bluetooth Audio
 ===============
 

--- a/subsys/bluetooth/mesh/Kconfig
+++ b/subsys/bluetooth/mesh/Kconfig
@@ -1477,8 +1477,7 @@ config BT_MESH_USES_TINYCRYPT
 	  Use TinyCrypt library to perform crypto operations.
 
 config BT_MESH_USES_MBEDTLS_PSA
-	bool "mbed TLS PSA [EXPERIMENTAL]"
-	select EXPERIMENTAL
+	bool "mbed TLS PSA"
 	select MBEDTLS
 	select MBEDTLS_PSA_CRYPTO_C
 	select PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_IMPORT
@@ -1488,7 +1487,6 @@ config BT_MESH_USES_MBEDTLS_PSA
 	select PSA_WANT_ALG_CMAC
 	select PSA_WANT_ALG_ECB_NO_PADDING
 	select PSA_WANT_KEY_TYPE_AES
-	imply MBEDTLS_AES_ROM_TABLES
 	select PSA_WANT_ALG_CCM
 	select PSA_WANT_KEY_TYPE_HMAC
 	select PSA_WANT_ALG_HMAC
@@ -1496,10 +1494,9 @@ config BT_MESH_USES_MBEDTLS_PSA
 	select PSA_WANT_ALG_ECDH
 	select PSA_WANT_ECC_SECP_R1_256
 	select BT_MESH_SECURE_STORAGE if BT_SETTINGS
+	imply MBEDTLS_AES_ROM_TABLES
 	help
-	  Use Mbed TLS as PSA Crypto API provider. This is useful on platforms
-	  that do not support TF-M.
-	  This feature is experimental and only BabbleSim tests were run.
+	  Use Mbed TLS as PSA Crypto API provider.
 
 config BT_MESH_USES_TFM_PSA
 	bool "Use TF-M PSA [EXPERIMENTAL]"


### PR DESCRIPTION
PR:
1. Removes experimental tag from mesh support of Mbed TLS PSA crypto.
2. Adds dependency on secure storage description into migration guide.