### PR TITLE
some stm32f4xx devices have no div-q output on their plli2s

### DIFF
--- a/drivers/clock_control/clock_stm32_ll_common.c
+++ b/drivers/clock_control/clock_stm32_ll_common.c
@@ -432,7 +432,7 @@ static int stm32_clock_control_get_subsys_rate(const struct device *clock,
 					      STM32_PLL_R_DIVISOR);
 		break;
 #endif
-#if defined(STM32_SRC_PLLI2S_Q) & STM32_PLLI2S_ENABLED
+#if defined(STM32_SRC_PLLI2S_Q) & STM32_PLLI2S_Q_ENABLED & STM32_PLLI2S_ENABLED
 	case STM32_SRC_PLLI2S_Q:
 		*rate = get_pll_div_frequency(get_pllsrc_frequency(),
 					      STM32_PLLI2S_M_DIVISOR,

--- a/drivers/clock_control/clock_stm32f2_f4_f7.c
+++ b/drivers/clock_control/clock_stm32f2_f4_f7.c
@@ -157,7 +157,7 @@ void config_plli2s(void)
 				       STM32_PLLI2S_N_MULTIPLIER,
 				       plli2sr(STM32_PLLI2S_R_DIVISOR));
 
-#if STM32_PLLI2S_Q_ENABLED
+#if STM32_PLLI2S_Q_ENABLED && !defined(RCC_DCKCFGR_PLLI2SDIVQ)
 	/* There is a Q divider on the PLLI2S to configure the PLL48CK */
 	LL_RCC_PLLI2S_ConfigDomain_48M(get_pll_source(),
 				       plli2sm(STM32_PLLI2S_M_DIVISOR),

--- a/include/zephyr/drivers/clock_control/stm32_clock_control.h
+++ b/include/zephyr/drivers/clock_control/stm32_clock_control.h
@@ -180,7 +180,7 @@
 #define STM32_PLLI2S_R_DIVISOR		DT_PROP_OR(DT_NODELABEL(plli2s), div_r, 1)
 #endif
 
-#if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(plli2s), st_stm32f412_plli2s_clock, okay)
+#if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(plli2s), st_stm32f411_plli2s_clock, okay)
 #define STM32_PLLI2S_ENABLED	1
 #define STM32_PLLI2S_M_DIVISOR		DT_PROP(DT_NODELABEL(plli2s), div_m)
 #define STM32_PLLI2S_N_MULTIPLIER	DT_PROP(DT_NODELABEL(plli2s), mul_n)


### PR DESCRIPTION
Some stm32f4 have a PLL I2S of type "st,stm32f411-plli2s-clock" or "st,stm32f4-plli2s-clock" 

The "st,stm32f411-plli2s-clock"  has a div-Q output, the "st,stm32f4-plli2s-clock"  has not
The stm32_clock_control_get_subsys_rate() in the clock_stm32_ll_common.c must consider this difference

This PR is fixing  the build error on stm32f405/f407 or f415/f417 mcu:
```
clock_stm32_ll_common.c:440:47: error: 'STM32_PLLI2S_Q_DIVISOR' undeclared (first use in this function); did you mean 'STM32_PLLI2S_M_DIVISOR'?
  440 |                                               STM32_PLLI2S_Q_DIVISOR);
      |                                               ^~~~~~~~~~~~~~~~~~~~~~

```
