### PR TITLE
boards: STM32h750B-DK: add memory partitions for MCUboot

### DIFF
--- a/boards/st/stm32h750b_dk/stm32h750b_dk.dts
+++ b/boards/st/stm32h750b_dk/stm32h750b_dk.dts
@@ -21,6 +21,7 @@
 		zephyr,flash = &flash0;
 		zephyr,flash-controller = &mt25ql512ab1;
 		zephyr,display = &ltdc;
+		zephyr,code-partition = &slot0_partition;
 	};
 
 	sdram2: sdram@d0000000 {
@@ -76,6 +77,19 @@
 
 &clk_lse {
 	status = "okay";
+};
+
+&flash0 {
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+		/* Flash has 128KB sector size */
+		boot_partition: partition@0 {
+			label = "mcuboot";
+			reg = <0x00000000 DT_SIZE_K(128)>;
+		};
+	};
 };
 
 &ltdc {
@@ -165,6 +179,8 @@
 	dual-flash;
 	status = "okay";
 
+	/* Sector erase 64KB uniform granularity */
+	/* Subsector erase 4KB, 32KB granularity */
 	mt25ql512ab1: qspi-nor-flash-1@90000000 {
 		compatible = "st,stm32-qspi-nor";
 		reg = <0x90000000 DT_SIZE_M(64)>; /* 512 Mbits */
@@ -178,8 +194,19 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 
-			partition@0 {
-				reg = <0x0 DT_SIZE_M(64)>;
+			slot0_partition: partition@0 {
+				label = "image-0";
+				reg = <0x00000000 DT_SIZE_K(2048)>;
+			};
+
+			slot1_partition: partition@200000 {
+				label = "image-1";
+				reg = <0x00200000 DT_SIZE_K(2048)>;
+			};
+
+			storage_partition: partition@400000 {
+				label = "storage";
+				reg = <0x00400000 DT_SIZE_K(128)>;
 			};
 		};
 	};

--- a/tests/drivers/flash/stm32/boards/stm32h750b_dk.overlay
+++ b/tests/drivers/flash/stm32/boards/stm32h750b_dk.overlay
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/delete-node/ &storage_partition;
+
 &flash0 {
 	partitions {
 		compatible = "fixed-partitions";


### PR DESCRIPTION
Add memory partitions for MCUboot and storage.

Tested with https://github.com/mcu-tools/mcuboot/pull/2154

![Screenshot_mcuboot](https://github.com/user-attachments/assets/a162a8ee-30b8-48ed-bf55-a693f1baf153)

