### PR TITLE
Revert "cmake clang/compiler_flags.cmake: Re-enable -Wgnu"

### DIFF
--- a/cmake/compiler/clang/compiler_flags.cmake
+++ b/cmake/compiler/clang/compiler_flags.cmake
@@ -108,6 +108,7 @@ check_set_compiler_property(PROPERTY warning_extended
                             -Wno-initializer-overrides
                             -Wno-section
                             -Wno-unused-variable
+                            -Wno-gnu
 )
 
 set_compiler_property(PROPERTY warning_error_coding_guideline


### PR DESCRIPTION
This reverts commit 8133f470ddc8511ffe39dc1159dfed4e710285de. Causes issues in pow2.c test