### PR TITLE
tests: Bluetooth: Tester: Reorder btp_buf to fix variable array

### DIFF
--- a/tests/bluetooth/tester/src/btp.c
+++ b/tests/bluetooth/tester/src/btp.c
@@ -31,11 +31,11 @@ static struct k_thread cmd_thread;
 #define CMD_QUEUED 2
 struct btp_buf {
 	intptr_t _reserved;
+	uint8_t rsp[BTP_MTU];
 	union {
 		uint8_t data[BTP_MTU];
 		struct btp_hdr hdr;
 	};
-	uint8_t rsp[BTP_MTU];
 };
 
 static struct btp_buf cmd_buf[CMD_QUEUED];


### PR DESCRIPTION
The `btp_hdr` needs to be last in the struct, as it has a variable length array (data[]).