### PR TITLE
Bluetooth: Controller: Fix regression in Code PHY S2 Rx to any PHY Tx

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5_dppi.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5_dppi.h
@@ -559,7 +559,7 @@ static inline void hal_radio_sw_switch_coded_tx_config_set(uint8_t ppi_en,
 	HAL_SW_SWITCH_TIMER_S8_DISABLE_PPI_REGISTER_EVT =
 		HAL_SW_SWITCH_TIMER_S8_DISABLE_PPI_EVT;
 	nrf_timer_subscribe_set(SW_SWITCH_TIMER,
-				nrf_timer_capture_task_get(cc_s2),
+				nrf_timer_capture_task_get(SW_SWITCH_TIMER_EVTS_COMP(group_index)),
 				HAL_SW_SWITCH_TIMER_S8_DISABLE_PPI);
 
 	nrf_dppi_channels_enable(NRF_DPPIC,

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5_ppi.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5_ppi.h
@@ -517,7 +517,8 @@ static inline void hal_radio_sw_switch_coded_tx_config_set(uint8_t ppi_en,
 	nrf_ppi_event_endpoint_setup(NRF_PPI, HAL_SW_SWITCH_TIMER_S8_DISABLE_PPI,
 				     HAL_SW_SWITCH_TIMER_S8_DISABLE_PPI_EVT);
 	nrf_ppi_task_endpoint_setup(NRF_PPI, HAL_SW_SWITCH_TIMER_S8_DISABLE_PPI,
-				    HAL_SW_SWITCH_TIMER_S8_DISABLE_PPI_TASK(cc_s2));
+				    HAL_SW_SWITCH_TIMER_S8_DISABLE_PPI_TASK(
+					    SW_SWITCH_TIMER_EVTS_COMP(group_index)));
 
 	nrf_ppi_channels_enable(
 		NRF_PPI,


### PR DESCRIPTION
Fix regression in Coded PHY S2 reception to any other PHY Tx in the s/w switch implementation.

Regression in commit 55b7dba8ec93 ("Bluetooth: Controller: Refactor sw_switch hal interface use").