### PR TITLE
Soc: Silabs: Optimize power management for Silabs Series 2

### DIFF
--- a/dts/arm/silabs/efr32bg2x.dtsi
+++ b/dts/arm/silabs/efr32bg2x.dtsi
@@ -118,6 +118,9 @@
 			 * Using BURTC as sys_clock instead of SysTick
 			 * has implications on system performance. Read
 			 * KConfig documentation entry before enabling it.
+			 *
+			 * The minimum residency and exit latency is
+			 * managed by sl_power_manager on S2 devices.
 			 */
 			cpu-power-states = <&pstate_em1 &pstate_em2 &pstate_em3>;
 		};
@@ -130,9 +133,7 @@
 			pstate_em1: em1 {
 				compatible = "zephyr,power-state";
 				power-state-name = "runtime-idle";
-				min-residency-us = <4>;
 				/* HFXO remains active */
-				exit-latency-us = <2>;
 			};
 
 			/*
@@ -142,8 +143,6 @@
 			pstate_em2: em2 {
 				compatible = "zephyr,power-state";
 				power-state-name = "suspend-to-idle";
-				min-residency-us = <260>;
-				exit-latency-us = <250>;
 			};
 
 			/*
@@ -155,8 +154,6 @@
 			pstate_em3: em3 {
 				compatible = "zephyr,power-state";
 				power-state-name = "standby";
-				min-residency-us = <20000>;
-				exit-latency-us = <2000>;
 			};
 		};
 	};

--- a/dts/arm/silabs/efr32mg24.dtsi
+++ b/dts/arm/silabs/efr32mg24.dtsi
@@ -139,6 +139,10 @@
 			compatible = "arm,cortex-m33";
 			reg = <0>;
 			cpu-power-states = <&pstate_em1 &pstate_em2 &pstate_em3>;
+			/*
+			 * The minimum residency and exit latency is
+			 * managed by sl_power_manager on S2 devices.
+			 */
 		};
 
 		power-states {
@@ -149,9 +153,7 @@
 			pstate_em1: em1 {
 				compatible = "zephyr,power-state";
 				power-state-name = "runtime-idle";
-				min-residency-us = <4>;
 				/* HFXO remains active */
-				exit-latency-us = <2>;
 			};
 
 			/*
@@ -161,8 +163,6 @@
 			pstate_em2: em2 {
 				compatible = "zephyr,power-state";
 				power-state-name = "suspend-to-idle";
-				min-residency-us = <260>;
-				exit-latency-us = <250>;
 			};
 
 			/*
@@ -174,8 +174,6 @@
 			pstate_em3: em3 {
 				compatible = "zephyr,power-state";
 				power-state-name = "standby";
-				min-residency-us = <20000>;
-				exit-latency-us = <2000>;
 			};
 		};
 	};

--- a/dts/arm/silabs/efr32xg23.dtsi
+++ b/dts/arm/silabs/efr32xg23.dtsi
@@ -149,6 +149,10 @@
 			compatible = "arm,cortex-m33";
 			reg = <0>;
 			cpu-power-states = <&pstate_em1 &pstate_em2 &pstate_em3>;
+			/*
+			 * The minimum residency and exit latency is
+			 * managed by sl_power_manager on S2 devices.
+			 */
 		};
 
 		power-states {
@@ -159,9 +163,7 @@
 			pstate_em1: em1 {
 				compatible = "zephyr,power-state";
 				power-state-name = "runtime-idle";
-				min-residency-us = <4>;
 				/* HFXO remains active */
-				exit-latency-us = <2>;
 			};
 
 			/*
@@ -171,8 +173,6 @@
 			pstate_em2: em2 {
 				compatible = "zephyr,power-state";
 				power-state-name = "suspend-to-idle";
-				min-residency-us = <260>;
-				exit-latency-us = <250>;
 			};
 
 			/*
@@ -184,8 +184,6 @@
 			pstate_em3: em3 {
 				compatible = "zephyr,power-state";
 				power-state-name = "standby";
-				min-residency-us = <20000>;
-				exit-latency-us = <2000>;
 			};
 		};
 	};

--- a/dts/arm/silabs/xg29/xg29.dtsi
+++ b/dts/arm/silabs/xg29/xg29.dtsi
@@ -146,6 +146,10 @@
 			compatible = "arm,cortex-m33";
 			reg = <0>;
 			cpu-power-states = <&pstate_em1 &pstate_em2>;
+			/*
+			 * The minimum residency and exit latency is
+			 * managed by sl_power_manager on S2 devices.
+			 */
 		};
 
 		power-states {
@@ -156,9 +160,7 @@
 			pstate_em1: em1 {
 				compatible = "zephyr,power-state";
 				power-state-name = "runtime-idle";
-				min-residency-us = <4>;
 				/* HFXO remains active */
-				exit-latency-us = <2>;
 			};
 
 			/*
@@ -168,8 +170,6 @@
 			pstate_em2: em2 {
 				compatible = "zephyr,power-state";
 				power-state-name = "suspend-to-idle";
-				min-residency-us = <260>;
-				exit-latency-us = <250>;
 			};
 		};
 	};

--- a/soc/silabs/common/soc_power_pmgr.c
+++ b/soc/silabs/common/soc_power_pmgr.c
@@ -60,7 +60,9 @@ void pm_state_set(enum pm_state state, uint8_t substate_id)
 
 	LOG_DBG("Entry to energy mode %d", energy_mode);
 
-	if (energy_mode != SL_POWER_MANAGER_EM0) {
+	if (energy_mode == SL_POWER_MANAGER_EM4) {
+		sl_power_manager_enter_em4();
+	} else if (energy_mode != SL_POWER_MANAGER_EM0) {
 		sl_power_manager_add_em_requirement(energy_mode);
 		sl_power_manager_sleep();
 		k_cpu_idle();

--- a/soc/silabs/common/soc_power_pmgr.c
+++ b/soc/silabs/common/soc_power_pmgr.c
@@ -63,9 +63,16 @@ void pm_state_set(enum pm_state state, uint8_t substate_id)
 	if (energy_mode == SL_POWER_MANAGER_EM4) {
 		sl_power_manager_enter_em4();
 	} else if (energy_mode != SL_POWER_MANAGER_EM0) {
+		/* Calling the tracing and hook functions provided in arch_cpu_idle(). */
+#if defined(CONFIG_TRACING)
+		sys_trace_idle();
+#endif
+#if CONFIG_ARM_ON_ENTER_CPU_IDLE_PREPARE_HOOK
+		z_arm_on_enter_cpu_idle_prepare();
+#endif
+
 		sl_power_manager_add_em_requirement(energy_mode);
 		sl_power_manager_sleep();
-		k_cpu_idle();
 		sl_power_manager_remove_em_requirement(energy_mode);
 	}
 

--- a/soc/silabs/common/soc_power_pmgr.c
+++ b/soc/silabs/common/soc_power_pmgr.c
@@ -8,6 +8,8 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/pm/pm.h>
 #include <sl_power_manager.h>
+#include <sl_hfxo_manager.h>
+#include <sli_hfxo_manager.h>
 
 LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);
 
@@ -46,18 +48,6 @@ void pm_state_set(enum pm_state state, uint8_t substate_id)
 		break;
 	}
 
-	/* FIXME: When this function is entered the Kernel has disabled
-	 * interrupts using BASEPRI register. This is incorrect as it prevents
-	 * waking up from any interrupt which priority is not 0. Work around the
-	 * issue and disable interrupts using PRIMASK register as recommended
-	 * by ARM.
-	 */
-
-	/* Set PRIMASK */
-	__disable_irq();
-	/* Set BASEPRI to 0 */
-	irq_unlock(0);
-
 	LOG_DBG("Entry to energy mode %d", energy_mode);
 
 	if (energy_mode == SL_POWER_MANAGER_EM4) {
@@ -77,15 +67,39 @@ void pm_state_set(enum pm_state state, uint8_t substate_id)
 	}
 
 	LOG_DBG("Exit from energy mode %d", energy_mode);
-
-	/* Clear PRIMASK */
-	__enable_irq();
 }
 
 void pm_state_exit_post_ops(enum pm_state state, uint8_t substate_id)
 {
 	ARG_UNUSED(state);
 	ARG_UNUSED(substate_id);
+}
+
+/* This function is called by sl_power_manager_sleep() after it has set the PRIMASK. */
+bool sl_power_manager_is_ok_to_sleep(void)
+{
+	/* FIXME: When this function is entered the Kernel has disabled
+	 * interrupts using BASEPRI register. This is incorrect as it prevents
+	 * waking up from any interrupt which priority is not 0. Work around the
+	 * issue and disable interrupts using PRIMASK register as recommended
+	 * by ARM.
+	 */
+	/* Set BASEPRI to 0. */
+	irq_unlock(0);
+
+	return true;
+}
+
+/* This function is called by sl_power_manager_sleep() right after it was woken up from WFI. */
+void sli_power_manager_on_wakeup(void)
+{
+#if defined(HFXO_MANAGER_SLEEPTIMER_SYSRTC_INTEGRATION_ON)
+	/* Handle the HFXO IRQ as soon as possible to retrieve the startup time. */
+	sl_hfxo_manager_irq_handler();
+#endif
+	/* Forces a clock restore before handling interrupts. */
+	sl_power_manager_add_em_requirement(SL_POWER_MANAGER_EM1);
+	sl_power_manager_remove_em_requirement(SL_POWER_MANAGER_EM1);
 }
 
 /**


### PR DESCRIPTION
The objective of this pull request is to optimize the power of Silabs Series 2 devices.
This pull request does the following:
- Fix the implementation of the pm_state PM_STATE_SOFT_OFF to enter EM4.
- Remove the double call to WFI in pm_state_set() by removing the call to k_cpu_idle() and replacing it with its tracing and hook functions.
- Handle the PRIMASK correctly for sl_power_manager_sleep() by moving the setting of BASEPRI to 0.
- Retrieve the startup measurements correctly, reducing the early wakeup time.
- Remove the exit latency and minimum residency in Zephyr because the power manager already handles it.