### PR TITLE
hci: esp32: remove deprecated symbol

### DIFF
--- a/drivers/bluetooth/hci/Kconfig
+++ b/drivers/bluetooth/hci/Kconfig
@@ -155,6 +155,7 @@ config BT_ESP32
 	default y
 	depends on DT_HAS_ESPRESSIF_ESP32_BT_HCI_ENABLED
 	depends on ZEPHYR_HAL_ESPRESSIF_MODULE_BLOBS || BUILD_ONLY_NO_BLOBS
+	select HAS_BT_CTLR
 	help
 	  Espressif HCI bluetooth interface
 

--- a/soc/espressif/esp32/Kconfig.defconfig
+++ b/soc/espressif/esp32/Kconfig.defconfig
@@ -34,7 +34,4 @@ config GDBSTUB_BUF_SZ
 
 endif # GDBSTUB config
 
-config BT_CTLR
-	default y if BT
-
 endif # SOC_SERIES_ESP32 config

--- a/soc/espressif/esp32c3/Kconfig.defconfig
+++ b/soc/espressif/esp32c3/Kconfig.defconfig
@@ -12,7 +12,4 @@ config FLASH_SIZE
 config FLASH_BASE_ADDRESS
 	default $(dt_node_reg_addr_hex,/soc/flash-controller@60002000/flash@0)
 
-config BT_CTLR
-	default y if BT
-
 endif # SOC_SERIES_ESP32C3

--- a/soc/espressif/esp32s3/Kconfig.defconfig
+++ b/soc/espressif/esp32s3/Kconfig.defconfig
@@ -12,7 +12,4 @@ config FLASH_BASE_ADDRESS
 config BOOTLOADER_MCUBOOT
 	default y if SOC_ESP32S3_APPCPU
 
-config BT_CTLR
-	default y if BT
-
 endif # SOC_SERIES_ESP32S3


### PR DESCRIPTION
Make sure HAS_BT_CTLR is used instead
of deprecated BT_CTLR symbol.