### PR TITLE
zbus: remove `k_malloc` dependency for `ZBUS_RUNTIME_OBSERVERS`

### DIFF
--- a/doc/releases/migration-guide-4.2.rst
+++ b/doc/releases/migration-guide-4.2.rst
@@ -280,6 +280,13 @@ SPI
 Other subsystems
 ****************
 
+ZBus
+====
+
+* The function :c:func:`zbus_chan_add_obs` now requires a :c:struct:`zbus_observer_node` as an argument,
+  which was previously allocated through :c:func:`k_malloc` internally. The structure must remain valid
+  in memory until :c:func:`zbus_chan_rem_obs` is called.
+
 Modules
 *******
 

--- a/doc/services/zbus/index.rst
+++ b/doc/services/zbus/index.rst
@@ -848,25 +848,28 @@ The following code has the exact behavior of the code in :ref:`reading from a ch
 Runtime observer registration
 -----------------------------
 
-It is possible to add observers to channels in runtime. This feature uses the heap to allocate the
-nodes dynamically. The heap size limits the number of dynamic observers zbus can create. Therefore,
-set the :kconfig:option:`CONFIG_ZBUS_RUNTIME_OBSERVERS` to enable the feature. It is possible to
-adjust the heap size by changing the configuration :kconfig:option:`CONFIG_HEAP_MEM_POOL_SIZE`. The
-following example illustrates the runtime registration usage.
-
-
+It is possible to add observers to channels at runtime if
+:kconfig:option:`CONFIG_ZBUS_RUNTIME_OBSERVERS` is enabled. In addition to the channel and observer
+references, :c:func:`zbus_chan_add_obs` also requires a :c:struct:`zbus_observer_node` to link the two
+together, which must remain valid in memory for the duration that the observer is attached to the
+channel. The simplest way to achieve this is to make the structure ``static``.
 
 .. code-block:: c
 
     ZBUS_LISTENER_DEFINE(my_listener, callback);
     // ...
     void thread_entry(void) {
+            static struct zbus_observer_node obs_node;
             // ...
             /* Adding the observer to channel chan1 */
-            zbus_chan_add_obs(&chan1, &my_listener, K_NO_WAIT);
+            zbus_chan_add_obs(&chan1, &my_listener, &obs_node, K_NO_WAIT);
             /* Removing the observer from channel chan1 */
             zbus_chan_rm_obs(&chan1, &my_listener, K_NO_WAIT);
 
+.. warning::
+
+  The :c:struct:`zbus_observer_node` can only be re-used in :c:func:`zbus_chan_add_obs` after removing
+  the channel observer it was first associated with through :c:func:`zbus_chan_rm_obs`.
 
 Samples
 *******

--- a/include/zephyr/zbus/zbus.h
+++ b/include/zephyr/zbus/zbus.h
@@ -862,23 +862,31 @@ static inline void zbus_chan_pub_stats_update(const struct zbus_channel *chan)
 #if defined(CONFIG_ZBUS_RUNTIME_OBSERVERS) || defined(__DOXYGEN__)
 
 /**
+ * @brief Structure for linking observers to chanels
+ */
+struct zbus_observer_node {
+	sys_snode_t node;
+	const struct zbus_observer *obs;
+};
+
+/**
  * @brief Add an observer to a channel.
  *
  * This routine adds an observer to the channel.
  *
  * @param chan The channel's reference.
  * @param obs The observer's reference to be added.
+ * @param node Persistent structure to link the channel to the observer
  * @param timeout Waiting period to add an observer,
  *                or one of the special values K_NO_WAIT and K_FOREVER.
  *
  * @retval 0 Observer added to the channel.
  * @retval -EALREADY The observer is already present in the channel's runtime observers list.
- * @retval -ENOMEM Returned without waiting.
  * @retval -EAGAIN Waiting period timed out.
  * @retval -EINVAL Some parameter is invalid.
  */
 int zbus_chan_add_obs(const struct zbus_channel *chan, const struct zbus_observer *obs,
-		      k_timeout_t timeout);
+		      struct zbus_observer_node *node, k_timeout_t timeout);
 
 /**
  * @brief Remove an observer from a channel.
@@ -899,15 +907,6 @@ int zbus_chan_add_obs(const struct zbus_channel *chan, const struct zbus_observe
  */
 int zbus_chan_rm_obs(const struct zbus_channel *chan, const struct zbus_observer *obs,
 		     k_timeout_t timeout);
-
-/** @cond INTERNAL_HIDDEN */
-
-struct zbus_observer_node {
-	sys_snode_t node;
-	const struct zbus_observer *obs;
-};
-
-/** @endcond */
 
 #endif /* CONFIG_ZBUS_RUNTIME_OBSERVERS */
 

--- a/samples/subsys/zbus/runtime_obs_registration/src/main.c
+++ b/samples/subsys/zbus/runtime_obs_registration/src/main.c
@@ -44,10 +44,11 @@ int main(void)
 	LOG_INF("System started");
 
 	const struct zbus_channel *chan;
+	struct zbus_observer_node obs_node;
 
 	while (1) {
 		LOG_INF("Activating filter");
-		zbus_chan_add_obs(&raw_data_chan, &filter_lis, K_MSEC(200));
+		zbus_chan_add_obs(&raw_data_chan, &filter_lis, &obs_node, K_MSEC(200));
 
 		zbus_sub_wait(&state_change_sub, &chan, K_FOREVER);
 
@@ -55,7 +56,7 @@ int main(void)
 		zbus_chan_rm_obs(&raw_data_chan, &filter_lis, K_MSEC(200));
 
 		LOG_INF("Bypass filter");
-		zbus_chan_add_obs(&raw_data_chan, &consumer_sub, K_MSEC(200));
+		zbus_chan_add_obs(&raw_data_chan, &consumer_sub, &obs_node, K_MSEC(200));
 
 		zbus_sub_wait(&state_change_sub, &chan, K_FOREVER);
 

--- a/tests/subsys/zbus/unittests/src/main.c
+++ b/tests/subsys/zbus/unittests/src/main.c
@@ -137,6 +137,7 @@ static struct action_msg ga;
 
 static void isr_handler(const void *operation)
 {
+	static struct zbus_observer_node fast_node, aux_node;
 	enum operation *op = (enum operation *)operation;
 
 	switch (*op) {
@@ -156,7 +157,7 @@ static void isr_handler(const void *operation)
 		isr_return = zbus_chan_finish(NULL);
 		break;
 	case ADD_OBS_ISR_INVAL:
-		isr_return = zbus_chan_add_obs(&aux2_chan, &fast_lis, K_MSEC(200));
+		isr_return = zbus_chan_add_obs(&aux2_chan, &fast_lis, &fast_node, K_MSEC(200));
 		break;
 	case RM_OBS_ISR_INVAL:
 		isr_return = zbus_chan_rm_obs(&aux2_chan, &fast_lis, K_MSEC(200));
@@ -177,7 +178,7 @@ static void isr_handler(const void *operation)
 		isr_return = zbus_chan_finish(&aux2_chan);
 		break;
 	case ADD_OBS_ISR:
-		isr_return = zbus_chan_add_obs(&aux2_chan, NULL, K_MSEC(200));
+		isr_return = zbus_chan_add_obs(&aux2_chan, NULL, &aux_node, K_MSEC(200));
 		break;
 	case RM_OBS_ISR:
 		isr_return = zbus_chan_rm_obs(&aux2_chan, NULL, K_MSEC(200));
@@ -244,6 +245,7 @@ const STRUCT_SECTION_ITERABLE(zbus_observer, invalid_obs) = {
 
 ZTEST(basic, test_specification_based__zbus_chan)
 {
+	static struct zbus_observer_node node;
 	struct action_msg a = {0};
 
 	/* Trying invalid parameters */
@@ -269,9 +271,11 @@ ZTEST(basic, test_specification_based__zbus_chan)
 
 	zassert_equal(-EFAULT, zbus_chan_finish(NULL), "It must be -EFAULT");
 
-	zassert_equal(-EFAULT, zbus_chan_add_obs(NULL, &sub1, K_MSEC(200)), NULL);
+	zassert_equal(-EFAULT, zbus_chan_add_obs(NULL, &sub1, &node, K_MSEC(200)), NULL);
 
-	zassert_equal(-EFAULT, zbus_chan_add_obs(&aux2_chan, NULL, K_MSEC(200)), NULL);
+	zassert_equal(-EFAULT, zbus_chan_add_obs(&aux2_chan, NULL, &node, K_MSEC(200)), NULL);
+
+	zassert_equal(-EFAULT, zbus_chan_add_obs(&aux2_chan, &sub1, NULL, K_MSEC(200)), NULL);
 
 	zassert_equal(-EFAULT, zbus_chan_rm_obs(NULL, &sub1, K_MSEC(200)), NULL);
 
@@ -326,7 +330,7 @@ ZTEST(basic, test_specification_based__zbus_chan)
 
 	k_msleep(100);
 
-	zassert_equal(0, zbus_chan_add_obs(&stuck_chan, &sub1, K_MSEC(200)), NULL);
+	zassert_equal(0, zbus_chan_add_obs(&stuck_chan, &sub1, &node, K_MSEC(200)), NULL);
 
 	zassert_equal(0, zbus_chan_notify(&stuck_chan, K_MSEC(200)), "It must finish correctly");
 
@@ -599,6 +603,7 @@ ZTEST(basic, test_hard_channel)
 
 ZTEST(basic, test_specification_based__zbus_obs_set_enable)
 {
+	struct zbus_observer_node node;
 	bool enable;
 
 	count_fast = 0;
@@ -617,7 +622,7 @@ ZTEST(basic, test_specification_based__zbus_obs_set_enable)
 	zbus_obs_is_enabled(&rt_fast_lis, &enable);
 	zassert_equal(false, enable);
 
-	zassert_equal(0, zbus_chan_add_obs(&aux1_chan, &rt_fast_lis, K_MSEC(200)), NULL);
+	zassert_equal(0, zbus_chan_add_obs(&aux1_chan, &rt_fast_lis, &node, K_MSEC(200)), NULL);
 
 	zassert_equal(0, zbus_obs_set_enable(&fast_lis, false),
 		      "Must be zero. The observer must be disabled");


### PR DESCRIPTION
Remove the dependency on the system heap existing when enabling
`ZBUS_RUNTIME_OBSERVERS`. Instead the previously allocated memory is
required to be provided to `zbus_chan_add_obs` (which can still be
allocated through malloc).

Alternative implementation of #79777