### PR TITLE
esp32c3_supermini: Fix: Switch from SRAM0 to SRAM1 for correct SRAM usage

### DIFF
--- a/boards/others/esp32c3_supermini/esp32c3_supermini.dts
+++ b/boards/others/esp32c3_supermini/esp32c3_supermini.dts
@@ -16,7 +16,7 @@
 	compatible = "espressif,esp32c3_supermini";
 
 	chosen {
-		zephyr,sram = &sram0;
+		zephyr,sram = &sram1;
 		zephyr,console = &usb_serial;
 		zephyr,shell-uart = &usb_serial;
 		zephyr,flash = &flash0;


### PR DESCRIPTION
According to the technical reference manual, SRAM0 is dedicated to IBUS and caching, whereas SRAM1 is assigned to
DBUS, so `zephyr,sram` should be switched to `sram1`.

Despite of invalid SRAM usage, this would resolve incorrect heap calculations in `malloc_prepare()`.

Compiling basic/minimal with `CONFIG_ASSERT=y` would previously trigger following assertion:

```
ASSERTION FAIL [bytes / 8U <= 0x7fffU] @ WEST_TOPDIR/zephyr/lib/heap/heap.c:491
        heap size is too big
```
