### PR TITLE
dts: ambiq: move compatible fields from board dts to dtsi

### DIFF
--- a/boards/ambiq/apollo3_evb/apollo3_evb.dts
+++ b/boards/ambiq/apollo3_evb/apollo3_evb.dts
@@ -140,7 +140,6 @@
 };
 
 &spi0 {
-	compatible = "ambiq,spi";
 	pinctrl-0 = <&spi0_default>;
 	pinctrl-names = "default";
 	cs-gpios = <&gpio0_31 11 GPIO_ACTIVE_LOW>;
@@ -149,7 +148,6 @@
 };
 
 &i2c3 {
-	compatible = "ambiq,i2c";
 	pinctrl-0 = <&i2c3_default>;
 	pinctrl-names = "default";
 	clock-frequency = <I2C_BITRATE_STANDARD>;
@@ -196,7 +194,6 @@
 };
 
 &adc0 {
-	compatible = "ambiq,adc";
 	pinctrl-0 = <&adc0_default>;
 	pinctrl-names = "default";
 	status = "disabled";

--- a/boards/ambiq/apollo3p_evb/apollo3p_evb.dts
+++ b/boards/ambiq/apollo3p_evb/apollo3p_evb.dts
@@ -118,7 +118,6 @@
 };
 
 &spi0 {
-	compatible = "ambiq,spi";
 	pinctrl-0 = <&spi0_default>;
 	pinctrl-names = "default";
 	cs-gpios = <&gpio0_31 11 GPIO_ACTIVE_LOW>;
@@ -127,7 +126,6 @@
 };
 
 &i2c3 {
-	compatible = "ambiq,i2c";
 	pinctrl-0 = <&i2c3_default>;
 	pinctrl-names = "default";
 	clock-frequency = <I2C_BITRATE_STANDARD>;
@@ -174,7 +172,6 @@
 };
 
 &adc0 {
-	compatible = "ambiq,adc";
 	pinctrl-0 = <&adc0_default>;
 	pinctrl-names = "default";
 	status = "disabled";

--- a/boards/ambiq/apollo4p_blue_kxr_evb/apollo4p_blue_kxr_evb.dts
+++ b/boards/ambiq/apollo4p_blue_kxr_evb/apollo4p_blue_kxr_evb.dts
@@ -90,7 +90,6 @@
 };
 
 &i2c0 {
-	compatible = "ambiq,i2c";
 	pinctrl-0 = <&i2c0_default>;
 	pinctrl-names = "default";
 	clock-frequency = <I2C_BITRATE_STANDARD>;
@@ -100,7 +99,6 @@
 };
 
 &spi1 {
-	compatible = "ambiq,spi";
 	pinctrl-0 = <&spi1_default>;
 	pinctrl-names = "default";
 	cs-gpios = <&gpio0_31 11 GPIO_ACTIVE_LOW>;

--- a/boards/ambiq/apollo4p_evb/apollo4p_evb.dts
+++ b/boards/ambiq/apollo4p_evb/apollo4p_evb.dts
@@ -76,7 +76,6 @@
 };
 
 &adc0 {
-	compatible = "ambiq,adc";
 	pinctrl-0 = <&adc0_default>;
 	pinctrl-names = "default";
 	status = "okay";
@@ -96,7 +95,6 @@
 };
 
 &iom0_i2c {
-	compatible = "ambiq,i2c";
 	pinctrl-0 = <&i2c0_default>;
 	pinctrl-names = "default";
 	clock-frequency = <I2C_BITRATE_STANDARD>;
@@ -106,7 +104,6 @@
 };
 
 &iom1_spi {
-	compatible = "ambiq,spi";
 	pinctrl-0 = <&spi1_default>;
 	pinctrl-names = "default";
 	cs-gpios = <&gpio0_31 11 GPIO_ACTIVE_LOW>;

--- a/dts/arm/ambiq/ambiq_apollo3_blue.dtsi
+++ b/dts/arm/ambiq/ambiq_apollo3_blue.dtsi
@@ -209,6 +209,7 @@
 		};
 
 		spi0: spi@50004000 {
+			compatible = "ambiq,spi";
 			reg = <0x50004000 0x1000>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -219,6 +220,7 @@
 		};
 
 		spi1: spi@50005000 {
+			compatible = "ambiq,spi";
 			reg = <0x50005000 0x1000>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -229,6 +231,7 @@
 		};
 
 		spi2: spi@50006000 {
+			compatible = "ambiq,spi";
 			reg = <0x50006000 0x1000>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -239,6 +242,7 @@
 		};
 
 		spi3: spi@50007000 {
+			compatible = "ambiq,spi";
 			reg = <0x50007000 0x1000>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -249,6 +253,7 @@
 		};
 
 		spi4: spi@50008000 {
+			compatible = "ambiq,spi";
 			reg = <0x50008000 0x1000>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -259,6 +264,7 @@
 		};
 
 		spi5: spi@50009000 {
+			compatible = "ambiq,spi";
 			reg = <0x50009000 0x1000>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -269,6 +275,7 @@
 		};
 
 		i2c0: i2c@50004000 {
+			compatible = "ambiq,i2c";
 			reg = <0x50004000 0x1000>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -279,6 +286,7 @@
 		};
 
 		i2c1: i2c@50005000 {
+			compatible = "ambiq,i2c";
 			reg = <0x50005000 0x1000>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -289,6 +297,7 @@
 		};
 
 		i2c2: i2c@50006000 {
+			compatible = "ambiq,i2c";
 			reg = <0x50006000 0x1000>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -299,6 +308,7 @@
 		};
 
 		i2c3: i2c@50007000 {
+			compatible = "ambiq,i2c";
 			reg = <0x50007000 0x1000>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -309,6 +319,7 @@
 		};
 
 		i2c4: i2c@50008000 {
+			compatible = "ambiq,i2c";
 			reg = <0x50008000 0x1000>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -319,6 +330,7 @@
 		};
 
 		i2c5: i2c@50009000 {
+			compatible = "ambiq,i2c";
 			reg = <0x50009000 0x1000>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -329,6 +341,7 @@
 		};
 
 		adc0: adc@50010000 {
+			compatible = "ambiq,adc";
 			reg = <0x50010000 0x400>;
 			interrupts = <18 0>;
 			interrupt-names = "ADC";

--- a/dts/arm/ambiq/ambiq_apollo3p_blue.dtsi
+++ b/dts/arm/ambiq/ambiq_apollo3p_blue.dtsi
@@ -227,6 +227,7 @@
 		};
 
 		spi0: spi@50004000 {
+			compatible = "ambiq,spi";
 			reg = <0x50004000 0x1000>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -237,6 +238,7 @@
 		};
 
 		spi1: spi@50005000 {
+			compatible = "ambiq,spi";
 			reg = <0x50005000 0x1000>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -247,6 +249,7 @@
 		};
 
 		spi2: spi@50006000 {
+			compatible = "ambiq,spi";
 			reg = <0x50006000 0x1000>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -257,6 +260,7 @@
 		};
 
 		spi3: spi@50007000 {
+			compatible = "ambiq,spi";
 			reg = <0x50007000 0x1000>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -267,6 +271,7 @@
 		};
 
 		spi4: spi@50008000 {
+			compatible = "ambiq,spi";
 			reg = <0x50008000 0x1000>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -277,6 +282,7 @@
 		};
 
 		spi5: spi@50009000 {
+			compatible = "ambiq,spi";
 			reg = <0x50009000 0x1000>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -287,6 +293,7 @@
 		};
 
 		i2c0: i2c@50004000 {
+			compatible = "ambiq,i2c";
 			reg = <0x50004000 0x1000>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -297,6 +304,7 @@
 		};
 
 		i2c1: i2c@50005000 {
+			compatible = "ambiq,i2c";
 			reg = <0x50005000 0x1000>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -307,6 +315,7 @@
 		};
 
 		i2c2: i2c@50006000 {
+			compatible = "ambiq,i2c";
 			reg = <0x50006000 0x1000>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -317,6 +326,7 @@
 		};
 
 		i2c3: i2c@50007000 {
+			compatible = "ambiq,i2c";
 			reg = <0x50007000 0x1000>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -327,6 +337,7 @@
 		};
 
 		i2c4: i2c@50008000 {
+			compatible = "ambiq,i2c";
 			reg = <0x50008000 0x1000>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -337,6 +348,7 @@
 		};
 
 		i2c5: i2c@50009000 {
+			compatible = "ambiq,i2c";
 			reg = <0x50009000 0x1000>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -347,6 +359,7 @@
 		};
 
 		adc0: adc@50010000 {
+			compatible = "ambiq,adc";
 			reg = <0x50010000 0x400>;
 			interrupts = <18 0>;
 			interrupt-names = "ADC";

--- a/dts/arm/ambiq/ambiq_apollo4p.dtsi
+++ b/dts/arm/ambiq/ambiq_apollo4p.dtsi
@@ -154,6 +154,7 @@
 		};
 
 		iom0_spi: spi@40050000 {
+			compatible = "ambiq,spi";
 			reg = <0x40050000 0x1000>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -163,6 +164,7 @@
 		};
 
 		iom0_i2c: i2c@40050000 {
+			compatible = "ambiq,i2c";
 			reg = <0x40050000 0x1000>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -172,6 +174,7 @@
 		};
 
 		iom1_spi: spi@40051000 {
+			compatible = "ambiq,spi";
 			reg = <0x40051000 0x1000>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -181,6 +184,7 @@
 		};
 
 		iom1_i2c: i2c@40051000 {
+			compatible = "ambiq,i2c";
 			reg = <0x40051000 0x1000>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -190,6 +194,7 @@
 		};
 
 		iom2_spi: spi@40052000 {
+			compatible = "ambiq,spi";
 			reg = <0x40052000 0x1000>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -199,6 +204,7 @@
 		};
 
 		iom2_i2c: i2c@40052000 {
+			compatible = "ambiq,i2c";
 			reg = <0x40052000 0x1000>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -208,6 +214,7 @@
 		};
 
 		iom3_spi: spi@40053000 {
+			compatible = "ambiq,spi";
 			reg = <0x40053000 0x1000>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -217,6 +224,7 @@
 		};
 
 		iom3_i2c: i2c@40053000 {
+			compatible = "ambiq,i2c";
 			reg = <0x40053000 0x1000>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -226,6 +234,7 @@
 		};
 
 		iom4_spi: spi@40054000 {
+			compatible = "ambiq,spi";
 			reg = <0x40054000 0x1000>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -235,6 +244,7 @@
 		};
 
 		iom4_i2c: i2c@40054000 {
+			compatible = "ambiq,i2c";
 			reg = <0x40054000 0x1000>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -244,6 +254,7 @@
 		};
 
 		iom5_spi: spi@40055000 {
+			compatible = "ambiq,spi";
 			reg = <0x40055000 0x1000>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -253,6 +264,7 @@
 		};
 
 		iom5_i2c: i2c@40055000 {
+			compatible = "ambiq,i2c";
 			reg = <0x40055000 0x1000>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -262,6 +274,7 @@
 		};
 
 		iom6_spi: spi@40056000 {
+			compatible = "ambiq,spi";
 			reg = <0x40056000 0x1000>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -271,6 +284,7 @@
 		};
 
 		iom6_i2c: i2c@40056000 {
+			compatible = "ambiq,i2c";
 			reg = <0x40056000 0x1000>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -280,6 +294,7 @@
 		};
 
 		iom7_spi: spi@40057000 {
+			compatible = "ambiq,spi";
 			reg = <0x40057000 0x1000>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -289,6 +304,7 @@
 		};
 
 		iom7_i2c: i2c@40057000 {
+			compatible = "ambiq,i2c";
 			reg = <0x40057000 0x1000>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -298,6 +314,7 @@
 		};
 
 		adc0: adc@40038000 {
+			compatible = "ambiq,adc";
 			reg = <0x40038000 0x400>;
 			interrupts = <19 0>;
 			interrupt-names = "ADC";

--- a/dts/arm/ambiq/ambiq_apollo4p_blue.dtsi
+++ b/dts/arm/ambiq/ambiq_apollo4p_blue.dtsi
@@ -135,6 +135,7 @@
 		};
 
 		spi0: spi@40050000 {
+			compatible = "ambiq,spi";
 			reg = <0x40050000 0x1000>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -144,6 +145,7 @@
 		};
 
 		spi1: spi@40051000 {
+			compatible = "ambiq,spi";
 			reg = <0x40051000 0x1000>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -153,6 +155,7 @@
 		};
 
 		spi2: spi@40052000 {
+			compatible = "ambiq,spi";
 			reg = <0x40052000 0x1000>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -162,6 +165,7 @@
 		};
 
 		spi3: spi@40053000 {
+			compatible = "ambiq,spi";
 			reg = <0x40053000 0x1000>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -193,6 +197,7 @@
 		};
 
 		spi5: spi@40055000 {
+			compatible = "ambiq,spi";
 			reg = <0x40055000 0x1000>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -202,6 +207,7 @@
 		};
 
 		spi6: spi@40056000 {
+			compatible = "ambiq,spi";
 			reg = <0x40056000 0x1000>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -211,6 +217,7 @@
 		};
 
 		spi7: spi@40057000 {
+			compatible = "ambiq,spi";
 			reg = <0x40057000 0x1000>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -220,6 +227,7 @@
 		};
 
 		i2c0: i2c@40050000 {
+			compatible = "ambiq,i2c";
 			reg = <0x40050000 0x1000>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -229,6 +237,7 @@
 		};
 
 		i2c1: i2c@40051000 {
+			compatible = "ambiq,i2c";
 			reg = <0x40051000 0x1000>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -238,6 +247,7 @@
 		};
 
 		i2c2: i2c@40052000 {
+			compatible = "ambiq,i2c";
 			reg = <0x40052000 0x1000>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -247,6 +257,7 @@
 		};
 
 		i2c3: i2c@40053000 {
+			compatible = "ambiq,i2c";
 			reg = <0x40053000 0x1000>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -256,6 +267,7 @@
 		};
 
 		i2c4: i2c@40054000 {
+			compatible = "ambiq,i2c";
 			reg = <0x40054000 0x1000>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -265,6 +277,7 @@
 		};
 
 		i2c5: i2c@40055000 {
+			compatible = "ambiq,i2c";
 			reg = <0x40055000 0x1000>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -274,6 +287,7 @@
 		};
 
 		i2c6: i2c@40056000 {
+			compatible = "ambiq,i2c";
 			reg = <0x40056000 0x1000>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -283,6 +297,7 @@
 		};
 
 		i2c7: i2c@40057000 {
+			compatible = "ambiq,i2c";
 			reg = <0x40057000 0x1000>;
 			#address-cells = <1>;
 			#size-cells = <0>;


### PR DESCRIPTION
compatible fields should be defined in dtsi instead of overlays