### PR TITLE
net: buf: revert disallowing blocking in syswq

### DIFF
--- a/include/zephyr/net_buf.h
+++ b/include/zephyr/net_buf.h
@@ -1329,19 +1329,14 @@ int net_buf_id(const struct net_buf *buf);
 /**
  * @brief Allocate a new fixed buffer from a pool.
  *
- * @note Some types of data allocators do not support
- *       blocking (such as the HEAP type). In this case it's still possible
- *       for net_buf_alloc() to fail (return NULL) even if it was given
- *       K_FOREVER.
- *
- * @note The timeout value will be overridden to K_NO_WAIT if called from the
- *       system workqueue.
- *
  * @param pool Which pool to allocate the buffer from.
  * @param timeout Affects the action taken should the pool be empty.
  *        If K_NO_WAIT, then return immediately. If K_FOREVER, then
  *        wait as long as necessary. Otherwise, wait until the specified
- *        timeout.
+ *        timeout. Note that some types of data allocators do not support
+ *        blocking (such as the HEAP type). In this case it's still possible
+ *        for net_buf_alloc() to fail (return NULL) even if it was given
+ *        K_FOREVER.
  *
  * @return New buffer or NULL if out of buffers.
  */
@@ -1369,20 +1364,15 @@ static inline struct net_buf * __must_check net_buf_alloc(struct net_buf_pool *p
 /**
  * @brief Allocate a new variable length buffer from a pool.
  *
- * @note Some types of data allocators do not support
- *       blocking (such as the HEAP type). In this case it's still possible
- *       for net_buf_alloc() to fail (return NULL) even if it was given
- *       K_FOREVER.
- *
- * @note The timeout value will be overridden to K_NO_WAIT if called from the
- *       system workqueue.
- *
  * @param pool Which pool to allocate the buffer from.
  * @param size Amount of data the buffer must be able to fit.
  * @param timeout Affects the action taken should the pool be empty.
  *        If K_NO_WAIT, then return immediately. If K_FOREVER, then
  *        wait as long as necessary. Otherwise, wait until the specified
- *        timeout.
+ *        timeout. Note that some types of data allocators do not support
+ *        blocking (such as the HEAP type). In this case it's still possible
+ *        for net_buf_alloc() to fail (return NULL) even if it was given
+ *        K_FOREVER.
  *
  * @return New buffer or NULL if out of buffers.
  */
@@ -1406,21 +1396,16 @@ struct net_buf * __must_check net_buf_alloc_len(struct net_buf_pool *pool,
  * Allocate a new buffer from a pool, where the data pointer comes from the
  * user and not from the pool.
  *
- * @note Some types of data allocators do not support
- *       blocking (such as the HEAP type). In this case it's still possible
- *       for net_buf_alloc() to fail (return NULL) even if it was given
- *       K_FOREVER.
- *
- * @note The timeout value will be overridden to K_NO_WAIT if called from the
- *       system workqueue.
- *
  * @param pool Which pool to allocate the buffer from.
  * @param data External data pointer
  * @param size Amount of data the pointed data buffer if able to fit.
  * @param timeout Affects the action taken should the pool be empty.
  *        If K_NO_WAIT, then return immediately. If K_FOREVER, then
  *        wait as long as necessary. Otherwise, wait until the specified
- *        timeout.
+ *        timeout. Note that some types of data allocators do not support
+ *        blocking (such as the HEAP type). In this case it's still possible
+ *        for net_buf_alloc() to fail (return NULL) even if it was given
+ *        K_FOREVER.
  *
  * @return New buffer or NULL if out of buffers.
  */

--- a/lib/net_buf/buf.c
+++ b/lib/net_buf/buf.c
@@ -271,12 +271,6 @@ struct net_buf *net_buf_alloc_len(struct net_buf_pool *pool, size_t size,
 
 	k_spin_unlock(&pool->lock, key);
 
-	if (!K_TIMEOUT_EQ(timeout, K_NO_WAIT) &&
-	    k_current_get() == k_work_queue_thread_get(&k_sys_work_q)) {
-		LOG_WRN("Timeout discarded. No blocking in syswq");
-		timeout = K_NO_WAIT;
-	}
-
 #if defined(CONFIG_NET_BUF_LOG) && (CONFIG_NET_BUF_LOG_LEVEL >= LOG_LEVEL_WRN)
 	if (K_TIMEOUT_EQ(timeout, K_FOREVER)) {
 		uint32_t ref = k_uptime_get_32();


### PR DESCRIPTION
Reverts the change made in d4d53010f00cadbb4f89c6d41391937646fc1740 (The changes was moved to another file in a restructuring)

The commit incorrectly assumed that no blocking would be allowed in the syswq. This has caused issues observed among others in #77241 and #80167