### PR TITLE
samples: subsys: shell: shell_module: Fix incorrect help message of sub_cmd1

### DIFF
--- a/samples/subsys/shell/shell_module/src/test_module.c
+++ b/samples/subsys/shell/shell_module/src/test_module.c
@@ -42,5 +42,5 @@ static int sub_cmd1_handler(const struct shell *sh, size_t argc, char **argv)
 	return 0;
 }
 
-SHELL_SUBCMD_COND_ADD(1, (section_cmd, cmd1), sub_cmd1, NULL, "help for cmd2",
+SHELL_SUBCMD_COND_ADD(1, (section_cmd, cmd1), sub_cmd1, NULL, "help for sub_cmd1",
 			sub_cmd1_handler, 1, 0);


### PR DESCRIPTION
Change sub_cmd1 help message from "help for cmd2" to "help for sub_cmd1".

![image](https://github.com/user-attachments/assets/a1d508fa-ce9c-48e4-9c90-d73c45939ca3)

**Expected Behavior**
![image](https://github.com/user-attachments/assets/2122013d-4dc7-41e1-a359-40b6e9f9be72)

issue: https://github.com/zephyrproject-rtos/zephyr/issues/84288 