### PR TITLE
subsys: shell: Add parentheses in condition check of while loop

### DIFF
--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -672,7 +672,7 @@ static int execute(const struct shell *sh)
 
 	/* Below loop is analyzing subcommands of found root command. */
 	while ((argc != 1) && (cmd_lvl < CONFIG_SHELL_ARGC_MAX)
-		&& args_left > 0) {
+		&& (args_left > 0)) {
 		quote = z_shell_make_argv(&argc, argvp, cmd_buf, 2);
 		cmd_buf = (char *)argvp[1];
 


### PR DESCRIPTION
This is for better coding style and readability. No feature impact.
![image](https://github.com/user-attachments/assets/7138a0cc-b103-4ed3-8448-b864c4e68d83)
This was added by https://github.com/zephyrproject-rtos/zephyr/commit/512de5ecac62de202cf17676d57c7c9d466dc3e2#diff-ada658f52221d7e6c6143eaa3be265c83de76dec8e4df770395ffe9c7c259d31
**Expected**
![image](https://github.com/user-attachments/assets/9ddfdae6-2be1-4d5c-a152-06f8ce49d35d)

Issue https://github.com/zephyrproject-rtos/zephyr/issues/84291