### PR TITLE
Bluetooth: BAP: Fix issue with sink recv state notifications

### DIFF
--- a/subsys/bluetooth/audio/bap_endpoint.h
+++ b/subsys/bluetooth/audio/bap_endpoint.h
@@ -181,6 +181,7 @@ struct bt_bap_broadcast_sink {
 	struct bt_bap_qos_cfg qos_cfg;
 	struct bt_le_per_adv_sync *pa_sync;
 	struct bt_iso_big *big;
+	uint8_t base_size;
 	uint8_t base[BT_BASE_MAX_SIZE];
 	struct bt_bap_broadcast_sink_bis bis[CONFIG_BT_BAP_BROADCAST_SNK_STREAM_COUNT];
 	struct bt_bap_broadcast_sink_subgroup subgroups[CONFIG_BT_BAP_BROADCAST_SNK_SUBGROUP_COUNT];


### PR DESCRIPTION
There was a bug in pa_decode_base that would would spent time parsing incoming BASEs and also update the receive states, which caused some tests to fail.

This commit adds a simply check to verify that the BASE is different before spending parsing the content and updating the receive states.