### PR TITLE
Fix zephyr,sram node value for esp32xx based boards

### DIFF
--- a/boards/espressif/esp32s2_devkitc/esp32s2_devkitc.dts
+++ b/boards/espressif/esp32s2_devkitc/esp32s2_devkitc.dts
@@ -23,7 +23,7 @@
 	};
 
 	chosen {
-		zephyr,sram = &sram0;
+		zephyr,sram = &sram1;
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,flash = &flash0;

--- a/boards/espressif/esp32s2_saola/esp32s2_saola.dts
+++ b/boards/espressif/esp32s2_saola/esp32s2_saola.dts
@@ -23,7 +23,7 @@
 	};
 
 	chosen {
-		zephyr,sram = &sram0;
+		zephyr,sram = &sram1;
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,flash = &flash0;

--- a/boards/franzininho/esp32s2_franzininho/esp32s2_franzininho.dts
+++ b/boards/franzininho/esp32s2_franzininho/esp32s2_franzininho.dts
@@ -22,7 +22,7 @@
 	};
 
 	chosen {
-		zephyr,sram = &sram0;
+		zephyr,sram = &sram1;
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,flash = &flash0;

--- a/boards/lilygo/ttgo_t7v1_5/ttgo_t7v1_5_esp32_appcpu.dts
+++ b/boards/lilygo/ttgo_t7v1_5/ttgo_t7v1_5_esp32_appcpu.dts
@@ -13,7 +13,7 @@
 	compatible = "espressif,esp32";
 
 	chosen {
-		zephyr,sram = &sram0;
+		zephyr,sram = &sram1;
 		zephyr,ipc_shm = &shm0;
 		zephyr,ipc = &ipm0;
 		zephyr,flash = &flash0;

--- a/boards/lilygo/ttgo_t7v1_5/ttgo_t7v1_5_esp32_procpu.dts
+++ b/boards/lilygo/ttgo_t7v1_5/ttgo_t7v1_5_esp32_procpu.dts
@@ -22,7 +22,7 @@
 	};
 
 	chosen {
-		zephyr,sram = &sram0;
+		zephyr,sram = &sram1;
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,flash = &flash0;

--- a/boards/wemos/esp32s2_lolin_mini/esp32s2_lolin_mini.dts
+++ b/boards/wemos/esp32s2_lolin_mini/esp32s2_lolin_mini.dts
@@ -22,7 +22,7 @@
 	};
 
 	chosen {
-		zephyr,sram = &sram0;
+		zephyr,sram = &sram1;
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,flash = &flash0;


### PR DESCRIPTION
This PR fixes the node value of zephyr,sram for the following boards:
- esp32s2_devkitcc
- esp32s2_saola
- esp32s2_franzininho
- esp32s2_lolin_mini
- ttgo_t7v1_5_esp32

This PR is directly related to:
- #80340
- #84275