### PR TITLE
net: pkt: Fix fixed buffer allocation with headroom bug

### DIFF
--- a/subsys/net/ip/net_pkt.c
+++ b/subsys/net/ip/net_pkt.c
@@ -970,7 +970,7 @@ static struct net_buf *pkt_alloc_buffer(struct net_pkt *pkt,
 
 				size = 0U;
 			} else {
-				size -= current->size;
+				size -= current->size - headroom;
 			}
 		} else {
 			if (current->size > size) {


### PR DESCRIPTION
The size calculation for the first buffer, in case extra headroom is requested, had a bug which could result in a size variable underflow followed by net_buf exhaustion.

In case the net_buf size was larger than requested size, but smaller than requested size + headroom, the whole buffer size was subtracted from the requested size. This however did not take the extra headroom into account and in effect could result in underflow.