### PR TITLE
drivers: can: can_tcan4x5x: fix compiler build warning/error

### DIFF
--- a/drivers/can/can_tcan4x5x.c
+++ b/drivers/can/can_tcan4x5x.c
@@ -508,8 +508,10 @@ static int tcan4x5x_wake(const struct device *dev)
 
 static int tcan4x5x_reset(const struct device *dev)
 {
+#if TCAN4X5X_RST_GPIO_SUPPORT
 	const struct can_mcan_config *mcan_config = dev->config;
 	const struct tcan4x5x_config *tcan_config = mcan_config->custom;
+#endif /* TCAN4X5X_RST_GPIO_SUPPORT */
 	int err;
 
 	err = tcan4x5x_wake(dev);


### PR DESCRIPTION
- Fix compiler warning when optional property `reset-gpios` is not supplied in the `ti,tcan4x5x`-compatible device tree node because of unused local variables in that case
- Now build will succeed if building with `CONFIG_COMPILER_WARNINGS_AS_ERRORS=y`

Closes #84306 

Will backport to `v4.0-branch` and `v3.7-branch` after this one gets approved and merged