### PR TITLE
samples: subsys: shell: shell_module: Incorrect help message of sub_cmd1

### DIFF
--- a/samples/subsys/shell/shell_module/src/test_module.c
+++ b/samples/subsys/shell/shell_module/src/test_module.c
@@ -42,5 +42,5 @@ static int sub_cmd1_handler(const struct shell *sh, size_t argc, char **argv)
 	return 0;
 }
 
-SHELL_SUBCMD_COND_ADD(1, (section_cmd, cmd1), sub_cmd1, NULL, "help for cmd2",
+SHELL_SUBCMD_COND_ADD(1, (section_cmd, cmd1), sub_cmd1, NULL, "help for sub_cmd1",
 			sub_cmd1_handler, 1, 0);


### PR DESCRIPTION
Change sub_cmd1 help message from "help for cmd2" to "help for sub_cmd1".
![image](https://github.com/user-attachments/assets/8d1dee32-21c1-42ce-91db-14d97e8ecc3c)
Expected Behavior
![image](https://github.com/user-attachments/assets/335b81b4-3bf8-464c-97b9-f480c06e728a)

issue: https://github.com/zephyrproject-rtos/zephyr/issues/84288