### PR TITLE
net: ethernet: Allow drivers to reserve net_pkt headroom 

### DIFF
--- a/include/zephyr/net/ethernet.h
+++ b/include/zephyr/net/ethernet.h
@@ -234,7 +234,8 @@ enum ethernet_config_type {
 	ETHERNET_CONFIG_TYPE_T1S_PARAM,
 	ETHERNET_CONFIG_TYPE_TXINJECTION_MODE,
 	ETHERNET_CONFIG_TYPE_RX_CHECKSUM_SUPPORT,
-	ETHERNET_CONFIG_TYPE_TX_CHECKSUM_SUPPORT
+	ETHERNET_CONFIG_TYPE_TX_CHECKSUM_SUPPORT,
+	ETHERNET_CONFIG_TYPE_EXTRA_TX_PKT_HEADROOM,
 };
 
 enum ethernet_qav_param_type {
@@ -529,6 +530,8 @@ struct ethernet_config {
 		enum ethernet_checksum_support chksum_support;
 
 		struct ethernet_filter filter;
+
+		uint16_t extra_tx_pkt_headroom;
 	};
 };
 

--- a/subsys/net/l2/ethernet/ethernet.c
+++ b/subsys/net/l2/ethernet/ethernet.c
@@ -858,8 +858,15 @@ static int ethernet_l2_alloc(struct net_if *iface, struct net_pkt *pkt,
 			     size_t size, enum net_ip_protocol proto,
 			     k_timeout_t timeout)
 {
-	return net_pkt_alloc_buffer_with_reserve(pkt, size,
-						 get_reserve_ll_header_size(iface),
+	size_t reserve = get_reserve_ll_header_size(iface);
+	struct ethernet_config config;
+
+	if (net_eth_get_hw_config(iface, ETHERNET_CONFIG_TYPE_EXTRA_TX_PKT_HEADROOM,
+				  &config) == 0) {
+		reserve += config.extra_tx_pkt_headroom;
+	}
+
+	return net_pkt_alloc_buffer_with_reserve(pkt, size, reserve,
 						 proto, timeout);
 }
 #else

--- a/subsys/net/l2/ethernet/ethernet.c
+++ b/subsys/net/l2/ethernet/ethernet.c
@@ -668,23 +668,6 @@ static void ethernet_update_tx_stats(struct net_if *iface, struct net_pkt *pkt)
 #define ethernet_update_tx_stats(...)
 #endif /* CONFIG_NET_STATISTICS_ETHERNET */
 
-static void ethernet_remove_l2_header(struct net_pkt *pkt)
-{
-	size_t reserve = get_reserve_ll_header_size(net_pkt_iface(pkt));
-	struct net_buf *buf;
-
-	/* Remove the buffer added in ethernet_fill_header() */
-	if (reserve == 0U) {
-		buf = pkt->buffer;
-		pkt->buffer = buf->frags;
-		buf->frags = NULL;
-
-		net_pkt_frag_unref(buf);
-	} else {
-		net_buf_pull(pkt->buffer, reserve);
-	}
-}
-
 static int ethernet_send(struct net_if *iface, struct net_pkt *pkt)
 {
 	const struct ethernet_api *api = net_if_get_device(iface)->api;
@@ -790,14 +773,12 @@ send:
 	ret = net_l2_send(api->send, net_if_get_device(iface), iface, pkt);
 	if (ret != 0) {
 		eth_stats_update_errors_tx(iface);
-		ethernet_remove_l2_header(pkt);
 		goto arp_error;
 	}
 
 	ethernet_update_tx_stats(iface, pkt);
 
 	ret = net_pkt_get_len(pkt);
-	ethernet_remove_l2_header(pkt);
 
 	net_pkt_unref(pkt);
 error:


### PR DESCRIPTION
* Introduce new Ethernet config, allowing drivers to allocate extra space in the packet headroom
* Remove L2 header stripping after transmission, it doesn't seem to make much sense and may be problematic for drivers taking ownership of the packet.

Resolves #84129