### PR TITLE
manifest: update hal_nordic revision to integrate nrfx 3.10.0

### DIFF
--- a/drivers/clock_control/clock_control_nrf.c
+++ b/drivers/clock_control/clock_control_nrf.c
@@ -623,6 +623,11 @@ static void clock_event_handler(nrfx_clock_evt_type_t event)
 		}
 		break;
 	case NRFX_CLOCK_EVT_PLL_STARTED:
+#if NRF_CLOCK_HAS_XO_TUNE
+	case NRFX_CLOCK_EVT_XO_TUNED:
+	case NRFX_CLOCK_EVT_XO_TUNE_ERROR:
+	case NRFX_CLOCK_EVT_XO_TUNE_FAILED:
+#endif
 	{
 		/* unhandled event */
 		break;

--- a/west.yml
+++ b/west.yml
@@ -193,7 +193,7 @@ manifest:
       groups:
         - hal
     - name: hal_nordic
-      revision: 31ec68ca7cce969ebec6d849332e2fbab59ec3f4
+      revision: a1db06a2f6a1d069994d595cef563f58e44c4344
       path: modules/hal/nordic
       groups:
         - hal


### PR DESCRIPTION
New nrfx version contains support for nRF7120 Eng A device.