### PR TITLE
drivers: bluetooth: hci: Increase default RX stack size

### DIFF
--- a/drivers/bluetooth/hci/Kconfig
+++ b/drivers/bluetooth/hci/Kconfig
@@ -294,7 +294,7 @@ config BT_DRV_RX_STACK_SIZE
 	default BT_RX_STACK_SIZE if (BT_H4 || BT_HCI_RAW_H4)
 	default BT_STM32_IPM_RX_STACK_SIZE if BT_STM32_IPM
 	default HCI_NXP_RX_STACK_SIZE if HCI_NXP_RX_THREAD
-	default 256
+	default 512
 	help
 	  Stack size for the HCI driver's RX thread.
 


### PR DESCRIPTION
The `BT_DRV_RX_STACK_SIZE` config is used by HCI drivers to determine a suitable stack size for their RX thread. These threads handle the HCI transport and pass HCI messages to the Bluetooth host via `bt_hci_recv()`. Previously, the default stack size was 256 bytes, but it seems to be too small currently.

Measuring the peak stack usage of `bt_hci_recv()` in different scenarios indicates that the function needs over 300 bytes of stack. Thus, an RX thread stack size of 512 should cover that and leave some margin.