### PR TITLE
modules: openthread: ble: Update after BT_LE_ADV_CONN got deprecated

### DIFF
--- a/modules/openthread/platform/ble.c
+++ b/modules/openthread/platform/ble.c
@@ -438,7 +438,7 @@ otError otPlatBleGapAdvStart(otInstance *aInstance, uint16_t aInterval)
 	ARG_UNUSED(aInstance);
 	ARG_UNUSED(aInterval);
 
-	int err = bt_le_adv_start(BT_LE_ADV_CONN, ad, ARRAY_SIZE(ad), sd, ARRAY_SIZE(sd));
+	int err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_2, ad, ARRAY_SIZE(ad), sd, ARRAY_SIZE(sd));
 
 	if (err != 0 && err != -EALREADY) {
 		LOG_WRN("Advertising failed to start (err %d)", err);


### PR DESCRIPTION
This is a follow-up to commit 8cfad44852845cd30336d40f61dade69ab4357db.

Replace the deprecated BT_LE_ADV_CONN macro with BT_LE_ADV_CONN_FAST_2.