### PR TITLE
[Backport v4.0-branch] Bluetooth: Controller: Fix regression in connection update

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -2179,8 +2179,9 @@ static void ull_conn_update_ticker(struct ll_conn *conn,
 
 	/* start periph/central with new timings */
 	uint8_t ticker_id_conn = TICKER_ID_CONN_BASE + ll_conn_handle_get(conn);
-	uint32_t ticker_status = ticker_stop(TICKER_INSTANCE_ID_CTLR, TICKER_USER_ID_ULL_HIGH,
-				    ticker_id_conn, ticker_stop_conn_op_cb, (void *)conn);
+	uint32_t ticker_status = ticker_stop_abs(TICKER_INSTANCE_ID_CTLR, TICKER_USER_ID_ULL_HIGH,
+						 ticker_id_conn, ticks_at_expire,
+						 ticker_stop_conn_op_cb, (void *)conn);
 	LL_ASSERT((ticker_status == TICKER_STATUS_SUCCESS) ||
 		  (ticker_status == TICKER_STATUS_BUSY));
 	ticker_status = ticker_start(

--- a/tests/bluetooth/controller/mock_ctrl/src/ticker.c
+++ b/tests/bluetooth/controller/mock_ctrl/src/ticker.c
@@ -33,6 +33,13 @@ uint8_t ticker_stop(uint8_t instance_index, uint8_t user_id, uint8_t ticker_id,
 	return TICKER_STATUS_SUCCESS;
 }
 
+uint8_t ticker_stop_abs(uint8_t instance_index, uint8_t user_id,
+			 uint8_t ticker_id, uint32_t ticks_at_stop,
+			 ticker_op_func fp_op_func, void *op_context)
+{
+	return TICKER_STATUS_SUCCESS;
+}
+
 void ticker_job_sched(uint8_t instance_index, uint8_t user_id)
 {
 }


### PR DESCRIPTION
The connection event at the connection update instant was skipped due to previous ticker node in use that is being stopped was registering a relative occupied time that overlapped with the new ticker node being started for scheduling the connection with new interval.

Added mock interface for ticker_stop_abs() hence needed by the Controller unit testing.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>
(cherry picked from commit 5dffad061cfc55f9c12f54b28ef46dd37dc40583)

Fixes #84315.