### PR TITLE
twister: reporting: fix gcov_tool path on Windows

### DIFF
--- a/scripts/pylib/twister/twisterlib/reports.py
+++ b/scripts/pylib/twister/twisterlib/reports.py
@@ -11,7 +11,7 @@ import string
 import xml.etree.ElementTree as ET
 from datetime import datetime
 from enum import Enum
-from pathlib import Path, PosixPath
+from pathlib import Path
 
 from colorama import Fore
 from twisterlib.statuses import TwisterStatus
@@ -27,6 +27,13 @@ class ReportStatus(str, Enum):
     ERROR = 'error'
     FAIL = 'failure'
     SKIP = 'skipped'
+
+
+class ReportingJSONEncoder(json.JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, Path):
+            return str(obj)
+        return super().default(obj)
 
 
 class Reporting:
@@ -294,10 +301,6 @@ class Reporting:
         else:
             report_options = self.env.non_default_options()
 
-        # Resolve known JSON serialization problems.
-        for k,v in report_options.items():
-            report_options[k] = str(v) if type(v) in [PosixPath] else v
-
         report = {}
         report["environment"] = {"os": os.name,
                                  "zephyr_version": version,
@@ -483,7 +486,7 @@ class Reporting:
 
         report["testsuites"] = suites
         with open(filename, 'w') as json_file:
-            json.dump(report, json_file, indent=4, separators=(',',':'))
+            json.dump(report, json_file, indent=4, separators=(',',':'), cls=ReportingJSONEncoder)
 
 
     def compare_metrics(self, filename):


### PR DESCRIPTION
Refactor Reporting to use custom ReportingJSONEncoder and encode all pathlib.Path derived instances there which are possible e.g. in 'environment.options' received from command line.

Fixes: #83823 