### PR TITLE
Adjust girq_regs to avoid flexible-array-like behaviors

### DIFF
--- a/soc/microchip/mec/mec172x/reg/mec172x_ecia.h
+++ b/soc/microchip/mec/mec172x/reg/mec172x_ecia.h
@@ -1132,7 +1132,7 @@ struct girq_regs {
 	volatile uint32_t EN_SET;
 	volatile uint32_t RESULT;
 	volatile uint32_t EN_CLR;
-	uint32_t RSVD1[1];
+	volatile uint32_t RSVD1;
 };
 
 /** @brief ECIA registers with each GIRQ elucidated */


### PR DESCRIPTION
Struct girq_regs has an array field of length 1 at its end. Since this field is never used in the code base, we can replace it with a non-array field of its original element type to remove the flexible-array-like behaviors and avoid using a flexible array file in the middle of a struct or defining an array of flexible array struct type.

Fixes #84251