### PR TITLE
linker: fix lnkr_pinned_rodata_* mismatched types

### DIFF
--- a/include/zephyr/linker/utils.h
+++ b/include/zephyr/linker/utils.h
@@ -24,8 +24,8 @@
 static inline bool linker_is_in_rodata(const void *addr)
 {
 #if defined(CONFIG_LINKER_USE_PINNED_SECTION)
-	extern const char lnkr_pinned_rodata_start[];
-	extern const char lnkr_pinned_rodata_end[];
+	extern char lnkr_pinned_rodata_start[];
+	extern char lnkr_pinned_rodata_end[];
 
 	if (((const char *)addr >= (const char *)lnkr_pinned_rodata_start) &&
 	    ((const char *)addr < (const char *)lnkr_pinned_rodata_end)) {


### PR DESCRIPTION
In linker-defs.h, lnkr_pinned_rodata_[start/end] are declared as extern char. However, in linker/utils.h:linker_is_in_rodata(), they are declared as extern const char. So remove the const in linker_is_in_rodata() to align both declarations.

Fixes #83461