### PR TITLE
Fix gnu folding constant

### DIFF
--- a/include/zephyr/toolchain/llvm.h
+++ b/include/zephyr/toolchain/llvm.h
@@ -32,6 +32,7 @@
 
 #define TOOLCHAIN_WARNING_SIZEOF_ARRAY_DECAY            "-Wsizeof-array-decay"
 #define TOOLCHAIN_WARNING_UNNEEDED_INTERNAL_DECLARATION "-Wunneeded-internal-declaration"
+#define TOOLCHAIN_WARNING_GNU_FOLDING_CONSTANT "-Wgnu-folding-constant"
 
 #define TOOLCHAIN_DISABLE_CLANG_WARNING(warning) _TOOLCHAIN_DISABLE_WARNING(clang, warning)
 #define TOOLCHAIN_ENABLE_CLANG_WARNING(warning)  _TOOLCHAIN_ENABLE_WARNING(clang, warning)

--- a/tests/kernel/common/src/pow2.c
+++ b/tests/kernel/common/src/pow2.c
@@ -26,7 +26,9 @@
  * @details Check if static array allocations are sized as expected.
  */
 
+TOOLCHAIN_DISABLE_CLANG_WARNING(TOOLCHAIN_WARNING_GNU_FOLDING_CONSTANT);
 char static_array1[Z_POW2_CEIL(1)];
+TOOLCHAIN_ENABLE_CLANG_WARNING(TOOLCHAIN_WARNING_GNU_FOLDING_CONSTANT);
 char static_array2[Z_POW2_CEIL(2)];
 char static_array3[Z_POW2_CEIL(3)];
 char static_array4[Z_POW2_CEIL(4)];


### PR DESCRIPTION
When building with clang it warns:
    
```
    tests/kernel/common/src/pow2.c:30:6: error: variable length array folded
    to constant array as an extension [-Werror,-Wgnu-folding-constant]
    char static_array1[Z_POW2_CEIL(1)];
         ^
```
    
We want the variable length array folded into a constant array, so disable the warning.

Depends on https://github.com/zephyrproject-rtos/zephyr/pull/84063