### PR TITLE
twister: testplan: display plan gap

### DIFF
--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -1035,7 +1035,10 @@ class TestPlan:
                 if ts.depends_on:
                     dep_intersection = ts.depends_on.intersection(set(plat.supported))
                     if dep_intersection != set(ts.depends_on):
-                        instance.add_filter("No hardware support", Filters.PLATFORM)
+                        instance.add_filter(
+                            f"No hardware support for {set(ts.depends_on)-dep_intersection}",
+                            Filters.PLATFORM
+                        )
 
                 if plat.flash < ts.min_flash:
                     instance.add_filter("Not enough FLASH", Filters.PLATFORM)


### PR DESCRIPTION
In situations where a test won't be run because there is a gap in the hardware support, add the gap information to the "reason" field to aid in debugging test cases.

With this change, the reason field for the error in test case will show the gap:

e.g. reason field now updated with gaps

"No hardware support for {'usbd'} but is one of the integration platforms"