### PR TITLE
modules: hal_nordic: enable CLOCK_CONTROL if nrf-802154 RD

### DIFF
--- a/modules/hal_nordic/Kconfig
+++ b/modules/hal_nordic/Kconfig
@@ -23,6 +23,7 @@ menuconfig NRF_802154_RADIO_DRIVER
 	depends on HAS_HW_NRF_RADIO_IEEE802154
 	select DYNAMIC_INTERRUPTS
 	select ENTROPY_GENERATOR
+	select CLOCK_CONTROL
 	depends on !$(dt_nodelabel_enabled,timer1)
 	help
 	  This option enables nRF IEEE 802.15.4 radio driver in Zephyr. Note,


### PR DESCRIPTION
Selects CLOCK_CONTROL config whenever nRF 802.15.4 Radio Driver is enabled.

The driver requires HFCLK api available under the config switch.