### PR TITLE
Allow llvm toolchain for unit tests

### DIFF
--- a/subsys/testsuite/boards/unit_testing/unit_testing/unit_testing.yaml
+++ b/subsys/testsuite/boards/unit_testing/unit_testing/unit_testing.yaml
@@ -4,5 +4,6 @@ type: unit
 arch: unit
 toolchain:
   - host
+  - llvm
 testing:
   default: true


### PR DESCRIPTION
llvm is just as good as host for unit tests.
