### PR TITLE
arch: x86: add missing semicolon for z_x86_kpti_is_access_ok()

### DIFF
--- a/arch/x86/include/x86_mmu.h
+++ b/arch/x86/include/x86_mmu.h
@@ -139,7 +139,7 @@ extern uint8_t z_shared_kernel_page_start;
 /* Called from page fault handler. ptables here is the ptage tables for the
  * faulting user thread and not the current set of page tables
  */
-extern bool z_x86_kpti_is_access_ok(void *virt, pentry_t *ptables)
+extern bool z_x86_kpti_is_access_ok(void *virt, pentry_t *ptables);
 #endif /* CONFIG_DEMAND_PAGING */
 #endif /* CONFIG_X86_KPTI */
 #endif /* CONFIG_USERSPACE */


### PR DESCRIPTION
The function prototype / extern declaration for `z_x86_kpti_is_access_ok()` in `x86_mmu.h` was missing a semicolon.

Add it to avoid being surprised by compile errors in certain circumstances.