### PR TITLE
kernel/pipe: squash compiler warning

### DIFF
--- a/kernel/pipe.c
+++ b/kernel/pipe.c
@@ -89,7 +89,7 @@ struct pipe_buf_spec {
 static size_t copy_to_pending_readers(struct k_pipe *pipe, bool *need_resched,
 				      const uint8_t *data, size_t len)
 {
-	struct k_thread *reader;
+	struct k_thread *reader = NULL;
 	struct pipe_buf_spec *reader_buf;
 	size_t copy_size, written = 0;
 


### PR DESCRIPTION
The compiler complains that:

```
zephyr/kernel/include/kernel_internal.h:121:29: error: 'reader' may be used uninitialized [-Werror=maybe-uninitialized]
  121 |         thread->swap_retval = value;
      |         ~~~~~~~~~~~~~~~~~~~~^~~~~~~
zephyr/kernel/pipe.c: In function 'copy_to_pending_readers':
zephyr/kernel/pipe.c:92:26: note: 'reader' was declared here
   92 |         struct k_thread *reader;
      |                          ^~~~~~
```

The static analyzer fails to see through the `LOCK_SCHED_SPINLOCK`
construct that the `reader` pointer is always initialized.
