### PR TITLE
arch: x86: fatal: initialize was_valid_access

### DIFF
--- a/arch/x86/core/fatal.c
+++ b/arch/x86/core/fatal.c
@@ -458,6 +458,7 @@ void z_x86_page_fault_handler(struct arch_esf *esf)
 		 * the page is present in the kernel's page tables and the
 		 * instruction will just be re-tried, producing another fault.
 		 */
+		was_valid_access = true;
 		if (was_user &&
 		    !z_x86_kpti_is_access_ok(virt, get_ptables(esf))) {
 			was_valid_access = false;


### PR DESCRIPTION
This change initializes `was_valid_access` in the case that `CONFIG_X86_KPTI` is selected. Previously, there was an uninitialized variable warning that would be escalated to an error when run with twister.

For context, please see #83303