### PR TITLE
boards: nxp: frdm_rw612: Add missing chosen to dtsi

### DIFF
--- a/boards/nxp/frdm_rw612/frdm_rw612_common.dtsi
+++ b/boards/nxp/frdm_rw612/frdm_rw612_common.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 NXP
+ * Copyright 2024-2025 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -22,6 +22,8 @@
 		zephyr,flash = &w25q512jvfiq;
 		zephyr,console = &flexcomm3;
 		zephyr,shell-uart = &flexcomm3;
+		zephyr,flash-controller = &w25q512jvfiq;
+		zephyr,code-partition = &slot0_partition;
 	};
 
 	leds {


### PR DESCRIPTION
Add zephyr,flash-controller and zephyr,code-partition chosen info.