### PR TITLE
driver: serial: silabs:  Change PM Device definition order

### DIFF
--- a/drivers/serial/uart_silabs_usart.c
+++ b/drivers/serial/uart_silabs_usart.c
@@ -497,6 +497,7 @@ static DEVICE_API(uart, uart_silabs_driver_api) = {
 #define SILABS_USART_INIT(idx)                                                                     \
 	SILABS_USART_IRQ_HANDLER(idx);                                                             \
 	PINCTRL_DT_INST_DEFINE(idx);                                                               \
+	PM_DEVICE_DT_INST_DEFINE(idx, uart_silabs_pm_action);                                      \
                                                                                                    \
 	static struct uart_config uart_cfg_##idx = {                                               \
 		.baudrate = DT_INST_PROP(idx, current_speed),                                      \
@@ -521,8 +522,6 @@ static DEVICE_API(uart, uart_silabs_driver_api) = {
                                                                                                    \
 	DEVICE_DT_INST_DEFINE(idx, uart_silabs_init, PM_DEVICE_DT_INST_GET(idx),                   \
 			      &uart_silabs_data_##idx, &uart_silabs_cfg_##idx, PRE_KERNEL_1,       \
-			      CONFIG_SERIAL_INIT_PRIORITY, &uart_silabs_driver_api);               \
-                                                                                                   \
-	PM_DEVICE_DT_INST_DEFINE(idx, uart_silabs_pm_action);
+			      CONFIG_SERIAL_INIT_PRIORITY, &uart_silabs_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(SILABS_USART_INIT)


### PR DESCRIPTION
Change the definition order of the PM Device to fix the CI build error. More details can be found in the CI of this PR : https://github.com/zephyrproject-rtos/zephyr/actions/runs/12889649031/job/35947088811?pr=84318

The problem is that PM_DEVICE_DT_INST_DEFINE() is done after DEVICE_DT_INST_DEFINE() then we get this error:
```
from /__w/zephyr/zephyr/drivers/serial/uart_silabs_usart.c:8:
/__w/zephyr/zephyr/include/zephyr/pm/device.h:273:42: error: '__pm_device_dts_ord_70' undeclared here
```