### PR TITLE
drivers: mbox: imx: allow sending empty message

### DIFF
--- a/drivers/mbox/mbox_nxp_imx_mu.c
+++ b/drivers/mbox/mbox_nxp_imx_mu.c
@@ -46,7 +46,7 @@ static int nxp_imx_mu_send(const struct device *dev, uint32_t channel, const str
 	}
 
 	/* Data transfer mode. */
-	if (msg->size != MU_MBOX_SIZE) {
+	if (msg->size > MU_MBOX_SIZE) {
 		/* We can only send this many bytes at a time. */
 		return -EMSGSIZE;
 	}


### PR DESCRIPTION
Allow sending empty messages - with size 0 or msg NULL. In some cases these kind of messages are just an ack (for example, in openamp_rsc_table sample).