### PR TITLE
Disable Ethernet Energy Efficient mode

### DIFF
--- a/drivers/ethernet/phy/Kconfig.dm8806
+++ b/drivers/ethernet/phy/Kconfig.dm8806
@@ -29,6 +29,13 @@ config PHY_DM8806_TRIGGER_GLOBAL_THREAD
 
 endchoice
 
+config PHY_DM8806_ENERGY_EFFICIENT_MODE
+	bool "Energy efficient mode"
+	help
+	  By default in DM8806, the energy efficient mode is enabled.
+	  It had been observed that the network randomly fails when
+	  this mode is on. Thus, this symbol is by default disabled.
+
 config PHY_DM8806_TRIGGER
 	bool
 

--- a/drivers/ethernet/phy/phy_dm8806_priv.h
+++ b/drivers/ethernet/phy/phy_dm8806_priv.h
@@ -143,6 +143,15 @@
 /* Interrupt Mask & Control Register Register Address. */
 #define DM8806_INT_MASK_CTRL_REG_ADDR 0x19u
 
+/* Switch Register offset  */
+#define DM8806_SWITCH_REGISTER_OFFSET 0x08
+
+/* Energy Efficient Ethernet Control Register Address. */
+#define DM8806_ENERGY_EFFICIENT_ETH_CTRL_REG_ADDR 0x1e
+
+/* Energy Efficient Ethernet enable bit */
+#define DM8806_EEE_EN BIT(15)
+
 #define DM8806_PORT5_MAC_CONTROL     0x15u
 /* Port 5 Force Speed control bit */
 #define DM8806_P5_SPEED_100M         ~BIT(0)


### PR DESCRIPTION
Energy efficient mode is the feature of the DM8806 described in the EEE 802.3az Energy Efficient for reducing power consumption. For unknown reason it seams to not working correctly with all endpoints and sometimes the network randomly fails when this mode is on. Thus it is now possible to turn off it in compile time by KConfig option:
PHY_DM8806_ENERGY_EFFICIENT_MODE if in case of network problems