### PR TITLE
llext: avoid always compiling extensions

### DIFF
--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -5640,7 +5640,7 @@ function(add_llext_target target_name)
   if(CONFIG_LLEXT_TYPE_ELF_OBJECT)
 
     # Create an object library to compile the source file
-    add_library(${llext_lib_target} OBJECT ${source_files})
+    add_library(${llext_lib_target} EXCLUDE_FROM_ALL OBJECT ${source_files})
     set(llext_lib_output $<TARGET_OBJECTS:${llext_lib_target}>)
 
   elseif(CONFIG_LLEXT_TYPE_ELF_RELOCATABLE)
@@ -5668,7 +5668,7 @@ function(add_llext_target target_name)
   elseif(CONFIG_LLEXT_TYPE_ELF_SHAREDLIB)
 
     # Create a shared library
-    add_library(${llext_lib_target} SHARED ${source_files})
+    add_library(${llext_lib_target} EXCLUDE_FROM_ALL SHARED ${source_files})
     set_target_properties(${llext_lib_target} PROPERTIES
       LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/llext
     )


### PR DESCRIPTION
In CMake, unless explicitly disabled, the `add_library()` and `add_executable()` functions add their result to the `ALL` target. This is undesirable for `add_llext_target()`, since it causes the source files for all defined extensions to be compiled even when the extension is not otherwise used by the build process.

Add `EXCLUDE_FROM_ALL` where appropriate so that the object files are only built when the extension is actually used by the project. 

This is evident following the [instructions](https://builds.zephyrproject.io/zephyr/pr/84393/docs/samples/subsys/llext/shell_loader/README.html#building) in #79429 and/or its successor #84393: calling `ninja -vvv hello_world_ext` manually to compile the extension skips the interesting source compilation step and only performs the packaging stages.