### PR TITLE
tests: drivers: spi: Add initial support for nRF54L09 and nRF54L09 PDKs

### DIFF
--- a/tests/drivers/spi/spi_error_cases/boards/nrf54l20pdk_nrf54l20_cpuapp.overlay
+++ b/tests/drivers/spi/spi_error_cases/boards/nrf54l20pdk_nrf54l20_cpuapp.overlay
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&pinctrl {
+	spi22_default_alt: spi22_default_alt {
+		group1 {
+			psels = <NRF_PSEL(SPIM_SCK, 1, 13)>,
+				<NRF_PSEL(SPIM_MISO, 1, 11)>,
+				<NRF_PSEL(SPIM_MOSI, 1, 9)>;
+		};
+	};
+
+	spi22_sleep_alt: spi22_sleep_alt {
+		group1 {
+			psels = <NRF_PSEL(SPIM_SCK, 1, 13)>,
+				<NRF_PSEL(SPIM_MISO, 1, 11)>,
+				<NRF_PSEL(SPIM_MOSI, 1, 9)>;
+			low-power-enable;
+		};
+	};
+
+	spi21_default_alt: spi21_default_alt {
+		group1 {
+			psels = <NRF_PSEL(SPIS_SCK, 1, 12)>,
+				<NRF_PSEL(SPIS_MISO, 1, 10)>,
+				<NRF_PSEL(SPIS_MOSI, 1, 8)>,
+				<NRF_PSEL(SPIS_CSN, 1, 14)>;
+		};
+	};
+
+	spi21_sleep_alt: spi21_sleep_alt {
+		group1 {
+			psels = <NRF_PSEL(SPIS_SCK, 1, 12)>,
+				<NRF_PSEL(SPIS_MISO, 1, 10)>,
+				<NRF_PSEL(SPIS_MOSI, 1, 8)>,
+				<NRF_PSEL(SPIS_CSN, 1, 14)>;
+			low-power-enable;
+		};
+	};
+
+};
+
+&gpio2 {
+	status = "okay";
+};
+
+&spi22 {
+	status = "okay";
+	pinctrl-0 = <&spi22_default_alt>;
+	pinctrl-1 = <&spi22_sleep_alt>;
+	pinctrl-names = "default", "sleep";
+	overrun-character = <0x00>;
+	cs-gpios = <&gpio2 10 GPIO_ACTIVE_LOW>;
+	dut_spi_dt: test-spi-dev@0 {
+		compatible = "vnd,spi-device";
+		reg = <0>;
+		spi-max-frequency = <4000000>;
+	};
+};
+
+dut_spis: &spi21 {
+	compatible = "nordic,nrf-spis";
+	status = "okay";
+	def-char = <0x00>;
+	pinctrl-0 = <&spi21_default_alt>;
+	pinctrl-1 = <&spi21_sleep_alt>;
+	pinctrl-names = "default", "sleep";
+	/delete-property/rx-delay-supported;
+	/delete-property/rx-delay;
+};

--- a/tests/drivers/spi/spi_error_cases/testcase.yaml
+++ b/tests/drivers/spi/spi_error_cases/testcase.yaml
@@ -12,6 +12,7 @@ tests:
       - nrf52840dk/nrf52840
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
+      - nrf54l20pdk/nrf54l20/cpuapp
     integration_platforms:
       - nrf52840dk/nrf52840
   drivers.spi.spi_error_cases.fast:

--- a/tests/drivers/spi/spi_loopback/boards/nrf54l09pdk_nrf54l09_cpuapp.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nrf54l09pdk_nrf54l09_cpuapp.overlay
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&pinctrl {
+	spi21_default: spi21_default {
+		group1 {
+			psels = <NRF_PSEL(SPIM_SCK, 1, 6)>,
+				<NRF_PSEL(SPIM_MISO, 1, 9)>,
+				<NRF_PSEL(SPIM_MOSI, 1, 8)>;
+		};
+	};
+
+	spi21_sleep: spi21_sleep {
+		group1 {
+			psels = <NRF_PSEL(SPIM_SCK, 1, 6)>,
+				<NRF_PSEL(SPIM_MISO, 1, 9)>,
+				<NRF_PSEL(SPIM_MOSI, 1, 8)>;
+			low-power-enable;
+		};
+	};
+};
+
+&spi21 {
+	status = "okay";
+	pinctrl-0 = <&spi21_default>;
+	pinctrl-1 = <&spi21_sleep>;
+	pinctrl-names = "default", "sleep";
+	overrun-character = <0x00>;
+	zephyr,pm-device-runtime-auto;
+	slow@0 {
+		compatible = "test-spi-loopback-slow";
+		reg = <0>;
+		spi-max-frequency = <DT_FREQ_M(2)>;
+	};
+	fast@0 {
+		compatible = "test-spi-loopback-fast";
+		reg = <0>;
+		spi-max-frequency = <DT_FREQ_M(4)>;
+	};
+};
+
+&gpio1 {
+	status = "okay";
+};

--- a/tests/drivers/spi/spi_loopback/boards/nrf54l20pdk_nrf54l20_cpuapp.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nrf54l20pdk_nrf54l20_cpuapp.overlay
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&pinctrl {
+	spi00_default: spi00_default {
+		group1 {
+			psels = <NRF_PSEL(SPIM_SCK, 2, 6)>,
+				<NRF_PSEL(SPIM_MISO, 2, 9)>,
+				<NRF_PSEL(SPIM_MOSI, 2, 8)>;
+		};
+	};
+
+	spi00_sleep: spi00_sleep {
+		group1 {
+			psels = <NRF_PSEL(SPIM_SCK, 2, 6)>,
+				<NRF_PSEL(SPIM_MISO, 2, 9)>,
+				<NRF_PSEL(SPIM_MOSI, 2, 8)>;
+			low-power-enable;
+		};
+	};
+};
+
+&spi00 {
+	status = "okay";
+	pinctrl-0 = <&spi00_default>;
+	pinctrl-1 = <&spi00_sleep>;
+	pinctrl-names = "default", "sleep";
+	overrun-character = <0x00>;
+	zephyr,pm-device-runtime-auto;
+	slow@0 {
+		compatible = "test-spi-loopback-slow";
+		reg = <0>;
+		spi-max-frequency = <DT_FREQ_M(2)>;
+	};
+	fast@0 {
+		compatible = "test-spi-loopback-fast";
+		reg = <0>;
+		spi-max-frequency = <DT_FREQ_M(4)>;
+	};
+};
+
+&gpio2 {
+	status = "okay";
+};


### PR DESCRIPTION
Added support for nRF54L09 and nRF54L20 PDKs in SPIM twister tests.