### PR TITLE
LLEXT: fix dependencies for relocatable extensions

### DIFF
--- a/include/zephyr/llext/llext.h
+++ b/include/zephyr/llext/llext.h
@@ -67,6 +67,7 @@ struct llext_loader;
 
 /* Maximim number of dependency LLEXTs */
 #define LLEXT_MAX_DEPENDENCIES 8
+#define LLEXT_MAX_NAME_LENGTH 16
 
 /**
  * @brief Structure describing a linkable loadable extension
@@ -86,7 +87,7 @@ struct llext {
 	/** @endcond */
 
 	/** Name of the llext */
-	char name[16];
+	char name[LLEXT_MAX_NAME_LENGTH];
 
 	/** Lookup table of memory regions */
 	void *mem[LLEXT_MEM_COUNT];

--- a/include/zephyr/llext/llext.h
+++ b/include/zephyr/llext/llext.h
@@ -126,6 +126,7 @@ struct llext {
 	unsigned int sect_cnt;
 	elf_shdr_t *sect_hdrs;
 	bool sect_hdrs_on_heap;
+	bool pre_located;
 	/** @endcond */
 };
 

--- a/include/zephyr/llext/loader.h
+++ b/include/zephyr/llext/loader.h
@@ -99,6 +99,7 @@ struct llext_loader {
 	elf_ehdr_t hdr;
 	elf_shdr_t sects[LLEXT_MEM_COUNT];
 	struct llext_elf_sect_map *sect_map;
+	char dependency[LLEXT_MAX_DEPENDENCIES][LLEXT_MAX_NAME_LENGTH];
 	/** @endcond */
 };
 

--- a/samples/subsys/llext/modules/prj.conf
+++ b/samples/subsys/llext/modules/prj.conf
@@ -20,7 +20,7 @@ CONFIG_LLEXT_TYPE_ELF_RELOCATABLE=y # supported by all targets
 # This test consumes large amounts of stack when loading the LLEXT.
 # Increase the available size to avoid overflowing (see issue #74536).
 
-CONFIG_MAIN_STACK_SIZE=2048
+CONFIG_MAIN_STACK_SIZE=2560
 
 # NOTE
 #

--- a/subsys/llext/llext_link.c
+++ b/subsys/llext/llext_link.c
@@ -125,6 +125,16 @@ int llext_dependency_restore(struct llext_loader *ldr, struct llext *ext)
 			return -ENOENT;
 		}
 
+		if (!ext->dependency[i]->pre_located) {
+			/*
+			 * The dependency could've been reloaded, so if its
+			 * addresses aren't fixed, re-linking is required
+			 */
+			LOG_ERR("Dependency %s isn't pre-located, re-linking required",
+				ldr->dependency[i]);
+			return -EINVAL;
+		}
+
 		ext->dependency[i]->use_count++;
 	}
 

--- a/subsys/llext/llext_load.c
+++ b/subsys/llext/llext_load.c
@@ -728,6 +728,11 @@ int do_llext_load(struct llext_loader *ldr, struct llext *ext,
 			LOG_ERR("Failed to link, ret %d", ret);
 			goto out;
 		}
+	} else {
+		ret = llext_dependency_restore(ldr, ext);
+		if (ret != 0) {
+			goto out;
+		}
 	}
 
 	ret = llext_export_symbols(ldr, ext);

--- a/subsys/llext/llext_load.c
+++ b/subsys/llext/llext_load.c
@@ -741,6 +741,8 @@ int do_llext_load(struct llext_loader *ldr, struct llext *ext,
 		goto out;
 	}
 
+	ext->pre_located = ldr_parm->pre_located;
+
 	llext_adjust_mmu_permissions(ext);
 
 out:

--- a/subsys/llext/llext_priv.h
+++ b/subsys/llext/llext_priv.h
@@ -65,6 +65,7 @@ static inline const char *llext_string(struct llext_loader *ldr, struct llext *e
 
 int llext_link(struct llext_loader *ldr, struct llext *ext,
 	       const struct llext_load_param *ldr_parm);
+ssize_t llext_file_offset(struct llext_loader *ldr, uintptr_t offset);
 void llext_dependency_remove_all(struct llext *ext);
 
 #endif /* ZEPHYR_SUBSYS_LLEXT_PRIV_H_ */

--- a/subsys/llext/llext_priv.h
+++ b/subsys/llext/llext_priv.h
@@ -67,5 +67,6 @@ int llext_link(struct llext_loader *ldr, struct llext *ext,
 	       const struct llext_load_param *ldr_parm);
 ssize_t llext_file_offset(struct llext_loader *ldr, uintptr_t offset);
 void llext_dependency_remove_all(struct llext *ext);
+int llext_dependency_restore(struct llext_loader *ldr, struct llext *ext);
 
 #endif /* ZEPHYR_SUBSYS_LLEXT_PRIV_H_ */


### PR DESCRIPTION
Dependencies have originally been mostly tested with "shared object" type extensions, this fixes them for relocatable extensions, as used by SOF with the Cadence toolchain, too