### PR TITLE
modules: mbedtls: Provide CONFIG_MBEDTLS_ASN1_PARSE_C

### DIFF
--- a/modules/mbedtls/Kconfig.tls-generic
+++ b/modules/mbedtls/Kconfig.tls-generic
@@ -138,6 +138,7 @@ config MBEDTLS_ECDH_C
 config MBEDTLS_ECDSA_C
 	bool "Elliptic curve DSA library"
 	depends on MBEDTLS_ECP_C
+	select MBEDTLS_ASN1_PARSE_C
 
 config MBEDTLS_ECJPAKE_C
 	bool "Elliptic curve J-PAKE library"
@@ -372,6 +373,9 @@ config MBEDTLS_MD
 
 config MBEDTLS_GENPRIME_ENABLED
 	bool "prime-number generation code."
+
+config MBEDTLS_ASN1_PARSE_C
+	bool "Support for ASN1 parser functions"
 
 config MBEDTLS_PEM_CERTIFICATE_FORMAT
 	bool "Support for PEM certificate format"

--- a/modules/mbedtls/configs/config-tls-generic.h
+++ b/modules/mbedtls/configs/config-tls-generic.h
@@ -431,7 +431,7 @@
 #define MBEDTLS_PK_C
 #endif
 
-#if defined(MBEDTLS_ECDSA_C) || defined(MBEDTLS_X509_USE_C)
+#if defined(CONFIG_MBEDTLS_ASN1_PARSE_C) || defined(MBEDTLS_X509_USE_C)
 #define MBEDTLS_ASN1_PARSE_C
 #endif
 


### PR DESCRIPTION
The commit exports control of MBEDTLS_ASN1_PARSE_C, in mbedTLS module, via Kconfig.
This allows applications to use ASN1 parser independently from other functions.

This change is part of rework done in MCUboot that uses these functions and when compiled with Zephyr is supposed to use them from Zephyr provided mbedTLS.