### PR TITLE
tests: drivers: watchdog: Add further support for nRF54L09 PDK.

### DIFF
--- a/tests/drivers/watchdog/wdt_basic_api/boards/nrf54l09pdk_nrf54l09_cpuapp.overlay
+++ b/tests/drivers/watchdog/wdt_basic_api/boards/nrf54l09pdk_nrf54l09_cpuapp.overlay
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&wdt31 {
+	status = "okay";
+};


### PR DESCRIPTION
Added further support for nRF54L09 PDK in watchdog twister tests.