### PR TITLE
Add device init/de-init functionality

### DIFF
--- a/cmake/linker_script/common/common-rom.cmake
+++ b/cmake/linker_script/common/common-rom.cmake
@@ -8,9 +8,6 @@ zephyr_linker_section_obj_level(SECTION init LEVEL POST_KERNEL)
 zephyr_linker_section_obj_level(SECTION init LEVEL APPLICATION)
 zephyr_linker_section_obj_level(SECTION init LEVEL SMP)
 
-zephyr_linker_section(NAME deferred_init_list KVMA RAM_REGION GROUP RODATA_REGION)
-zephyr_linker_section_configure(SECTION deferred_init_list INPUT ".z_deferred_init*" KEEP SORT NAME)
-
 zephyr_iterable_section(NAME device NUMERIC KVMA RAM_REGION GROUP RODATA_REGION SUBALIGN ${CONFIG_LINKER_ITERABLE_SUBALIGN})
 
 if(CONFIG_GEN_SW_ISR_TABLE AND NOT CONFIG_DYNAMIC_INTERRUPTS)

--- a/drivers/misc/devmux/devmux.c
+++ b/drivers/misc/devmux/devmux.c
@@ -129,7 +129,7 @@ int z_vrfy_devmux_select_set(struct device *dev, size_t index)
 #include <zephyr/syscalls/devmux_select_set_mrsh.c>
 #endif
 
-static int devmux_init(struct device *const dev)
+static int devmux_init(const struct device *dev)
 {
 	size_t inst = devmux_inst_get(dev);
 	struct devmux_data *const data = dev->data;
@@ -143,7 +143,7 @@ static int devmux_init(struct device *const dev)
 		return -ENODEV;
 	}
 
-	*dev = *config->devs[sel];
+	*(struct device *)dev = *config->devs[sel];
 
 	return 0;
 }

--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -451,6 +451,12 @@ typedef uint8_t device_flags_t;
 
 /** @} */
 
+/** Device operations */
+struct device_ops {
+	/** Initialization function */
+	int (*init)(const struct device *dev);
+};
+
 /**
  * @brief Runtime device structure (in ROM) per driver instance
  */
@@ -465,8 +471,8 @@ struct device {
 	struct device_state *state;
 	/** Address of the device instance private data */
 	void *data;
-	/** Initialization function (optional) */
-	int (*init_fn)(const struct device *);
+	/** Device operations */
+	struct device_ops ops;
 	/** Device flags */
 	device_flags_t flags;
 #if defined(CONFIG_DEVICE_DEPS) || defined(__DOXYGEN__)
@@ -1090,7 +1096,7 @@ device_get_dt_nodelabels(const struct device *dev)
 		.api = (api_),								\
 		.state = (state_),							\
 		.data = (data_),							\
-		.init_fn = (init_fn_),							\
+		.ops = { .init = (init_fn_) },						\
 		.flags = (flags_),							\
 		IF_ENABLED(CONFIG_DEVICE_DEPS, (.deps = (deps_),)) /**/			\
 		IF_ENABLED(CONFIG_PM_DEVICE, Z_DEVICE_INIT_PM_BASE(pm_)) /**/		\

--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -825,13 +825,12 @@ __syscall bool device_is_ready(const struct device *dev);
  *
  * A device whose initialization was deferred (by marking it as
  * ``zephyr,deferred-init`` on devicetree) needs to be initialized manually via
- * this call. Note that only devices whose initialization was deferred can be
- * initialized via this call - one can not try to initialize a non
- * initialization deferred device that failed initialization with this call.
+ * this call. De-initialized devices can also be initialized again via this
+ * call.
  *
  * @param dev device to be initialized.
  *
- * @retval -ENOENT If device was not found - or isn't a deferred one.
+ * @retval -EALREADY Device is already initialized.
  * @retval -errno For other errors.
  */
 __syscall int device_init(const struct device *dev);

--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -1156,18 +1156,14 @@ device_get_dt_nodelabels(const struct device *dev)
 	static const Z_DECL_ALIGN(struct init_entry) __used __noasan Z_INIT_ENTRY_SECTION(         \
 		level, prio, Z_DEVICE_INIT_SUB_PRIO(node_id))                                      \
 		Z_INIT_ENTRY_NAME(DEVICE_NAME_GET(dev_id)) = {                                     \
-			COND_CODE_1(Z_DEVICE_IS_MUTABLE(node_id),                                  \
-				    (.dev = { .dev_rw = &DEVICE_NAME_GET(dev_id)}),                \
-				    (.dev = { .dev = &DEVICE_NAME_GET(dev_id)}))                   \
+			.dev = (const struct device *)&DEVICE_NAME_GET(dev_id)                     \
 		}
 
 #define Z_DEFER_DEVICE_INIT_ENTRY_DEFINE(node_id, dev_id)                                          \
 	static const Z_DECL_ALIGN(struct init_entry) __used __noasan                               \
 		__attribute__((__section__(".z_deferred_init")))                                   \
 		Z_INIT_ENTRY_NAME(DEVICE_NAME_GET(dev_id)) = {                                     \
-			COND_CODE_1(Z_DEVICE_IS_MUTABLE(node_id),                                  \
-				    (.dev = { .dev_rw = &DEVICE_NAME_GET(dev_id)}),                \
-				    (.dev = { .dev = &DEVICE_NAME_GET(dev_id)}))                   \
+			.dev = (const struct device *)&DEVICE_NAME_GET(dev_id)                     \
 		}
 
 /**

--- a/include/zephyr/drivers/can.h
+++ b/include/zephyr/drivers/can.h
@@ -761,8 +761,8 @@ struct can_device_state {
 	Z_DEVICE_DEFINE(node_id, Z_DEVICE_DT_DEV_ID(node_id),		\
 			DEVICE_DT_NAME(node_id),			\
 			&UTIL_CAT(Z_DEVICE_DT_DEV_ID(node_id), _init),	\
-			Z_DEVICE_DT_FLAGS(node_id), pm, data, config,	\
-			level, prio, api,				\
+			NULL, Z_DEVICE_DT_FLAGS(node_id), pm, data,	\
+			config,	level, prio, api,			\
 			&(Z_DEVICE_STATE_NAME(Z_DEVICE_DT_DEV_ID(node_id)).devstate), \
 			__VA_ARGS__)
 

--- a/include/zephyr/drivers/can.h
+++ b/include/zephyr/drivers/can.h
@@ -761,7 +761,8 @@ struct can_device_state {
 	Z_DEVICE_DEFINE(node_id, Z_DEVICE_DT_DEV_ID(node_id),		\
 			DEVICE_DT_NAME(node_id),			\
 			&UTIL_CAT(Z_DEVICE_DT_DEV_ID(node_id), _init),	\
-			pm, data, config, level, prio, api,		\
+			Z_DEVICE_DT_FLAGS(node_id), pm, data, config,	\
+			level, prio, api,				\
 			&(Z_DEVICE_STATE_NAME(Z_DEVICE_DT_DEV_ID(node_id)).devstate), \
 			__VA_ARGS__)
 

--- a/include/zephyr/drivers/i2c.h
+++ b/include/zephyr/drivers/i2c.h
@@ -668,7 +668,8 @@ static inline void i2c_xfer_stats(const struct device *dev, struct i2c_msg *msgs
 	Z_DEVICE_DEFINE(node_id, Z_DEVICE_DT_DEV_ID(node_id),		\
 			DEVICE_DT_NAME(node_id),			\
 			&UTIL_CAT(Z_DEVICE_DT_DEV_ID(node_id), _init),	\
-			pm, data, config, level, prio, api,	\
+			Z_DEVICE_DT_FLAGS(node_id), pm, data, config,	\
+			level, prio, api,				\
 			&(Z_DEVICE_STATE_NAME(Z_DEVICE_DT_DEV_ID(node_id)).devstate), \
 			__VA_ARGS__)
 

--- a/include/zephyr/drivers/i2c.h
+++ b/include/zephyr/drivers/i2c.h
@@ -668,8 +668,8 @@ static inline void i2c_xfer_stats(const struct device *dev, struct i2c_msg *msgs
 	Z_DEVICE_DEFINE(node_id, Z_DEVICE_DT_DEV_ID(node_id),		\
 			DEVICE_DT_NAME(node_id),			\
 			&UTIL_CAT(Z_DEVICE_DT_DEV_ID(node_id), _init),	\
-			Z_DEVICE_DT_FLAGS(node_id), pm, data, config,	\
-			level, prio, api,				\
+			NULL, Z_DEVICE_DT_FLAGS(node_id), pm, data,	\
+			config,	level, prio, api,			\
 			&(Z_DEVICE_STATE_NAME(Z_DEVICE_DT_DEV_ID(node_id)).devstate), \
 			__VA_ARGS__)
 

--- a/include/zephyr/drivers/smbus.h
+++ b/include/zephyr/drivers/smbus.h
@@ -510,7 +510,7 @@ static inline void smbus_xfer_stats(const struct device *dev, uint8_t sent,
 	Z_DEVICE_DEFINE(node_id, Z_DEVICE_DT_DEV_NAME(node_id),		\
 			DEVICE_DT_NAME(node_id),			\
 			&UTIL_CAT(Z_DEVICE_DT_DEV_NAME(node_id), _init),\
-			Z_DEVICE_DT_FLAGS(node_id), pm_device,		\
+			NULL, Z_DEVICE_DT_FLAGS(node_id), pm_device,	\
 			data_ptr, cfg_ptr, level, prio,			\
 			api_ptr,					\
 			&(Z_DEVICE_STATE_NAME(Z_DEVICE_DT_DEV_NAME	\

--- a/include/zephyr/drivers/smbus.h
+++ b/include/zephyr/drivers/smbus.h
@@ -510,7 +510,7 @@ static inline void smbus_xfer_stats(const struct device *dev, uint8_t sent,
 	Z_DEVICE_DEFINE(node_id, Z_DEVICE_DT_DEV_NAME(node_id),		\
 			DEVICE_DT_NAME(node_id),			\
 			&UTIL_CAT(Z_DEVICE_DT_DEV_NAME(node_id), _init),\
-			pm_device,					\
+			Z_DEVICE_DT_FLAGS(node_id), pm_device,		\
 			data_ptr, cfg_ptr, level, prio,			\
 			api_ptr,					\
 			&(Z_DEVICE_STATE_NAME(Z_DEVICE_DT_DEV_NAME	\

--- a/include/zephyr/drivers/spi.h
+++ b/include/zephyr/drivers/spi.h
@@ -579,7 +579,7 @@ struct spi_device_state {
 	Z_DEVICE_DEFINE(node_id, Z_DEVICE_DT_DEV_ID(node_id),		\
 			DEVICE_DT_NAME(node_id),			\
 			&UTIL_CAT(Z_DEVICE_DT_DEV_ID(node_id), _init),	\
-			Z_DEVICE_DT_FLAGS(node_id), pm_device,		\
+			NULL, Z_DEVICE_DT_FLAGS(node_id), pm_device,	\
 			data_ptr, cfg_ptr, level, prio,			\
 			api_ptr,					\
 			&(Z_DEVICE_STATE_NAME(Z_DEVICE_DT_DEV_ID(node_id)).devstate), \
@@ -614,7 +614,7 @@ static inline void spi_transceive_stats(const struct device *dev, int error,
 				api, ...)			\
 	Z_DEVICE_STATE_DEFINE(Z_DEVICE_DT_DEV_ID(node_id));			\
 	Z_DEVICE_DEFINE(node_id, Z_DEVICE_DT_DEV_ID(node_id),			\
-			DEVICE_DT_NAME(node_id), init_fn,			\
+			DEVICE_DT_NAME(node_id), init_fn, NULL,			\
 			Z_DEVICE_DT_FLAGS(node_id), pm, data, config,		\
 			level, prio, api,					\
 			&Z_DEVICE_STATE_NAME(Z_DEVICE_DT_DEV_ID(node_id)),	\

--- a/include/zephyr/drivers/spi.h
+++ b/include/zephyr/drivers/spi.h
@@ -579,7 +579,7 @@ struct spi_device_state {
 	Z_DEVICE_DEFINE(node_id, Z_DEVICE_DT_DEV_ID(node_id),		\
 			DEVICE_DT_NAME(node_id),			\
 			&UTIL_CAT(Z_DEVICE_DT_DEV_ID(node_id), _init),	\
-			pm_device,					\
+			Z_DEVICE_DT_FLAGS(node_id), pm_device,		\
 			data_ptr, cfg_ptr, level, prio,			\
 			api_ptr,					\
 			&(Z_DEVICE_STATE_NAME(Z_DEVICE_DT_DEV_ID(node_id)).devstate), \
@@ -614,7 +614,8 @@ static inline void spi_transceive_stats(const struct device *dev, int error,
 				api, ...)			\
 	Z_DEVICE_STATE_DEFINE(Z_DEVICE_DT_DEV_ID(node_id));			\
 	Z_DEVICE_DEFINE(node_id, Z_DEVICE_DT_DEV_ID(node_id),			\
-			DEVICE_DT_NAME(node_id), init_fn, pm, data, config,	\
+			DEVICE_DT_NAME(node_id), init_fn,			\
+			Z_DEVICE_DT_FLAGS(node_id), pm, data, config,		\
 			level, prio, api,					\
 			&Z_DEVICE_STATE_NAME(Z_DEVICE_DT_DEV_ID(node_id)),	\
 			__VA_ARGS__)

--- a/include/zephyr/init.h
+++ b/include/zephyr/init.h
@@ -73,12 +73,7 @@ struct init_entry {
 	 * If the init entry belongs to a device, this fields stores a
 	 * reference to it, otherwise it is set to NULL.
 	 */
-	union {
-		const struct device *dev;
-#ifdef CONFIG_DEVICE_MUTABLE
-		struct device *dev_rw;
-#endif
-	} dev;
+	const struct device *dev;
 };
 
 /** @cond INTERNAL_HIDDEN */

--- a/include/zephyr/init.h
+++ b/include/zephyr/init.h
@@ -112,7 +112,7 @@ struct init_entry {
 #ifdef CONFIG_DEVICE_MUTABLE
 		struct device *dev_rw;
 #endif
-	};
+	} dev;
 };
 
 /** @cond INTERNAL_HIDDEN */

--- a/include/zephyr/init.h
+++ b/include/zephyr/init.h
@@ -50,43 +50,6 @@ extern "C" {
 struct device;
 
 /**
- * @brief Initialization function for init entries.
- *
- * Init entries support both the system initialization and the device
- * APIs. Each API has its own init function signature; hence, we have a
- * union to cover both.
- */
-union init_function {
-	/**
-	 * System initialization function.
-	 *
-	 * @retval 0 On success
-	 * @retval -errno If init fails.
-	 */
-	int (*sys)(void);
-	/**
-	 * Device initialization function.
-	 *
-	 * @param dev Device instance.
-	 *
-	 * @retval 0 On success
-	 * @retval -errno If device initialization fails.
-	 */
-	int (*dev)(const struct device *dev);
-#ifdef CONFIG_DEVICE_MUTABLE
-	/**
-	 * Device initialization function (rw).
-	 *
-	 * @param dev Device instance.
-	 *
-	 * @retval 0 On success
-	 * @retval -errno If device initialization fails.
-	 */
-	int (*dev_rw)(struct device *dev);
-#endif
-};
-
-/**
  * @brief Structure to store initialization entry information.
  *
  * @internal
@@ -101,8 +64,11 @@ union init_function {
  * @endinternal
  */
 struct init_entry {
-	/** Initialization function. */
-	union init_function init_fn;
+	/**
+	 * If the init function belongs to a SYS_INIT, this field stored the
+	 * initialization function, otherwise it is set to NULL.
+	 */
+	int (*init_fn)(void);
 	/**
 	 * If the init entry belongs to a device, this fields stores a
 	 * reference to it, otherwise it is set to NULL.
@@ -150,39 +116,6 @@ struct init_entry {
 #define Z_INIT_ENTRY_SECTION(level, prio, sub_prio)                           \
 	__attribute__((__section__(                                           \
 		".z_init_" #level STRINGIFY(prio)"_" STRINGIFY(sub_prio)"_")))
-
-
-/* Designated initializers where added to C in C99. There were added to
- * C++ 20 years later in a much more restricted form. C99 allows many
- * variations: out of order, mix of designated and not, overlap,
- * override,... but C++ allows none of these. See differences detailed
- * in the P0329R0.pdf C++ proposal.
- * Note __STDC_VERSION__ is undefined when compiling C++.
- */
-#if defined(__STDC_VERSION__) && (__STDC_VERSION__) < 201100
-
-/* Anonymous unions require C11. Some pre-C11 gcc versions have early
- * support for anonymous unions but they require these braces when
- * combined with C99 designated initializers, see longer discussion in
- * #69411.
- * These braces are compatible with any C version but not with C++20.
- */
-#  define Z_INIT_SYS_INIT_DEV_NULL  { .dev = NULL }
-
-#else
-
-/* When using -std=c++20 or higher, g++ (v12.2.0) reject braces for
- * initializing anonymous unions because it is technically a mix of
- * designated and not designated initializers which is not allowed in
- * C++. Interestingly, the _same_ g++ version does accept the braces above
- * when using -std=c++17 or lower!
- * The tests/lib/cpp/cxx/ added by commit 3d9c428d57bf invoke the C++
- * compiler with a range of different `-std=...` parameters without needing
- * any manual configuration.
- */
-#  define Z_INIT_SYS_INIT_DEV_NULL    .dev = NULL
-
-#endif
 
 /** @endcond */
 
@@ -238,8 +171,7 @@ struct init_entry {
 #define SYS_INIT_NAMED(name, init_fn_, level, prio)                                       \
 	static const Z_DECL_ALIGN(struct init_entry)                                      \
 		Z_INIT_ENTRY_SECTION(level, prio, 0) __used __noasan                      \
-		Z_INIT_ENTRY_NAME(name) = {.init_fn = {.sys = (init_fn_)},                \
-			Z_INIT_SYS_INIT_DEV_NULL}
+		Z_INIT_ENTRY_NAME(name) = {.init_fn = (init_fn_)}                         \
 
 /** @} */
 

--- a/include/zephyr/linker/common-rom/common-rom-kernel-devices.ld
+++ b/include/zephyr/linker/common-rom/common-rom-kernel-devices.ld
@@ -18,9 +18,6 @@
 		CREATE_OBJ_LEVEL(init, APPLICATION)
 		CREATE_OBJ_LEVEL(init, SMP)
 		__init_end = .;
-		__deferred_init_list_start = .;
-		KEEP(*(.z_deferred_init*))
-		__deferred_init_list_end = .;
 	} GROUP_ROM_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 
 	ITERABLE_SECTION_ROM_NUMERIC(device, Z_LINK_ITERABLE_SUBALIGN)

--- a/include/zephyr/net/ethernet.h
+++ b/include/zephyr/net/ethernet.h
@@ -1171,7 +1171,8 @@ static inline bool net_eth_is_vlan_interface(struct net_if *iface)
 				       init_fn, pm, data, config, prio,	\
 				       api, mtu)			\
 	Z_DEVICE_STATE_DEFINE(dev_id);					\
-	Z_DEVICE_DEFINE(node_id, dev_id, name, init_fn, pm, data,	\
+	Z_DEVICE_DEFINE(node_id, dev_id, name, init_fn,			\
+			Z_DEVICE_DT_FLAGS(node_id), pm, data,		\
 			config, POST_KERNEL, prio, api,			\
 			&Z_DEVICE_STATE_NAME(dev_id));
 

--- a/include/zephyr/net/ethernet.h
+++ b/include/zephyr/net/ethernet.h
@@ -1171,7 +1171,7 @@ static inline bool net_eth_is_vlan_interface(struct net_if *iface)
 				       init_fn, pm, data, config, prio,	\
 				       api, mtu)			\
 	Z_DEVICE_STATE_DEFINE(dev_id);					\
-	Z_DEVICE_DEFINE(node_id, dev_id, name, init_fn,			\
+	Z_DEVICE_DEFINE(node_id, dev_id, name, init_fn, NULL,		\
 			Z_DEVICE_DT_FLAGS(node_id), pm, data,		\
 			config, POST_KERNEL, prio, api,			\
 			&Z_DEVICE_STATE_NAME(dev_id));

--- a/include/zephyr/net/net_if.h
+++ b/include/zephyr/net/net_if.h
@@ -3331,7 +3331,8 @@ extern int net_stats_prometheus_scrape(struct prometheus_collector *collector,
 				   init_fn, pm, data, config, prio,	\
 				   api, l2, l2_ctx_type, mtu)		\
 	Z_DEVICE_STATE_DEFINE(dev_id);					\
-	Z_DEVICE_DEFINE(node_id, dev_id, name, init_fn, pm, data,	\
+	Z_DEVICE_DEFINE(node_id, dev_id, name, init_fn,			\
+			Z_DEVICE_DT_FLAGS(node_id), pm, data,		\
 			config, POST_KERNEL, prio, api,			\
 			&Z_DEVICE_STATE_NAME(dev_id));			\
 	NET_L2_DATA_INIT(dev_id, instance, l2_ctx_type);		\
@@ -3478,7 +3479,8 @@ extern int net_stats_prometheus_scrape(struct prometheus_collector *collector,
 #define Z_NET_DEVICE_OFFLOAD_INIT(node_id, dev_id, name, init_fn, pm,	\
 				  data, config, prio, api, mtu)		\
 	Z_DEVICE_STATE_DEFINE(dev_id);					\
-	Z_DEVICE_DEFINE(node_id, dev_id, name, init_fn, pm, data,	\
+	Z_DEVICE_DEFINE(node_id, dev_id, name, init_fn,			\
+			Z_DEVICE_DT_FLAGS(node_id), pm, data,		\
 			config, POST_KERNEL, prio, api,			\
 			&Z_DEVICE_STATE_NAME(dev_id));			\
 	NET_IF_OFFLOAD_INIT(dev_id, 0, mtu)

--- a/include/zephyr/net/net_if.h
+++ b/include/zephyr/net/net_if.h
@@ -3331,7 +3331,7 @@ extern int net_stats_prometheus_scrape(struct prometheus_collector *collector,
 				   init_fn, pm, data, config, prio,	\
 				   api, l2, l2_ctx_type, mtu)		\
 	Z_DEVICE_STATE_DEFINE(dev_id);					\
-	Z_DEVICE_DEFINE(node_id, dev_id, name, init_fn,			\
+	Z_DEVICE_DEFINE(node_id, dev_id, name, init_fn, NULL,		\
 			Z_DEVICE_DT_FLAGS(node_id), pm, data,		\
 			config, POST_KERNEL, prio, api,			\
 			&Z_DEVICE_STATE_NAME(dev_id));			\
@@ -3479,7 +3479,7 @@ extern int net_stats_prometheus_scrape(struct prometheus_collector *collector,
 #define Z_NET_DEVICE_OFFLOAD_INIT(node_id, dev_id, name, init_fn, pm,	\
 				  data, config, prio, api, mtu)		\
 	Z_DEVICE_STATE_DEFINE(dev_id);					\
-	Z_DEVICE_DEFINE(node_id, dev_id, name, init_fn,			\
+	Z_DEVICE_DEFINE(node_id, dev_id, name, init_fn,	NULL,		\
 			Z_DEVICE_DT_FLAGS(node_id), pm, data,		\
 			config, POST_KERNEL, prio, api,			\
 			&Z_DEVICE_STATE_NAME(dev_id));			\

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -306,8 +306,8 @@ static int do_device_init(const struct device *dev)
 {
 	int rc = 0;
 
-	if (dev->init_fn != NULL) {
-		rc = dev->init_fn(dev);
+	if (dev->ops.init != NULL) {
+		rc = dev->ops.init(dev);
 		/* Mark device initialized. If initialization
 		 * failed, record the error condition.
 		 */

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -378,18 +378,11 @@ static void z_sys_init_run_level(enum init_level level)
 
 int z_impl_device_init(const struct device *dev)
 {
-	const struct device *devs;
-	size_t devc;
-
-	devc = z_device_get_all_static(&devs);
-
-	for (const struct device *dev_ = devs; dev_ < (devs + devc); dev_++) {
-		if ((dev_ == dev) && ((dev->flags & DEVICE_FLAG_INIT_DEFERRED) != 0U)) {
-			return do_device_init(dev);
-		}
+	if (dev->state->initialized) {
+		return -EALREADY;
 	}
 
-	return -ENOENT;
+	return do_device_init(dev);
 }
 
 #ifdef CONFIG_USERSPACE

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -367,7 +367,7 @@ static void z_sys_init_run_level(enum init_level level)
 		if (dev != NULL) {
 			result = do_device_init(dev);
 		} else {
-			result = entry->init_fn.sys();
+			result = entry->init_fn();
 		}
 		sys_trace_sys_init_exit(entry, level, result);
 	}

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -304,7 +304,7 @@ bool z_sys_post_kernel;
 
 static int do_device_init(const struct init_entry *entry)
 {
-	const struct device *dev = entry->dev;
+	const struct device *dev = entry->dev.dev;
 	int rc = 0;
 
 	if (entry->init_fn.dev != NULL) {
@@ -361,7 +361,7 @@ static void z_sys_init_run_level(enum init_level level)
 	const struct init_entry *entry;
 
 	for (entry = levels[level]; entry < levels[level+1]; entry++) {
-		const struct device *dev = entry->dev;
+		const struct device *dev = entry->dev.dev;
 		int result;
 
 		sys_trace_sys_init_enter(entry, level);
@@ -382,7 +382,7 @@ int z_impl_device_init(const struct device *dev)
 	}
 
 	STRUCT_SECTION_FOREACH_ALTERNATE(_deferred_init, init_entry, entry) {
-		if (entry->dev == dev) {
+		if (entry->dev.dev == dev) {
 			return do_device_init(entry);
 		}
 	}

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -360,7 +360,7 @@ static void z_sys_init_run_level(enum init_level level)
 	const struct init_entry *entry;
 
 	for (entry = levels[level]; entry < levels[level+1]; entry++) {
-		const struct device *dev = entry->dev.dev;
+		const struct device *dev = entry->dev;
 		int result;
 
 		sys_trace_sys_init_enter(entry, level);
@@ -381,7 +381,7 @@ int z_impl_device_init(const struct device *dev)
 	}
 
 	STRUCT_SECTION_FOREACH_ALTERNATE(_deferred_init, init_entry, entry) {
-		if (entry->dev.dev == dev) {
+		if (entry->dev == dev) {
 			return do_device_init(dev);
 		}
 	}

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -302,13 +302,12 @@ extern volatile uintptr_t __stack_chk_guard;
 __pinned_bss
 bool z_sys_post_kernel;
 
-static int do_device_init(const struct init_entry *entry)
+static int do_device_init(const struct device *dev)
 {
-	const struct device *dev = entry->dev.dev;
 	int rc = 0;
 
-	if (entry->init_fn.dev != NULL) {
-		rc = entry->init_fn.dev(dev);
+	if (dev->init_fn != NULL) {
+		rc = dev->init_fn(dev);
 		/* Mark device initialized. If initialization
 		 * failed, record the error condition.
 		 */
@@ -366,7 +365,7 @@ static void z_sys_init_run_level(enum init_level level)
 
 		sys_trace_sys_init_enter(entry, level);
 		if (dev != NULL) {
-			result = do_device_init(entry);
+			result = do_device_init(dev);
 		} else {
 			result = entry->init_fn.sys();
 		}
@@ -383,7 +382,7 @@ int z_impl_device_init(const struct device *dev)
 
 	STRUCT_SECTION_FOREACH_ALTERNATE(_deferred_init, init_entry, entry) {
 		if (entry->dev.dev == dev) {
-			return do_device_init(entry);
+			return do_device_init(dev);
 		}
 	}
 

--- a/tests/lib/devicetree/devices/src/main.c
+++ b/tests/lib/devicetree/devices/src/main.c
@@ -86,16 +86,16 @@ ZTEST(devicetree_devices, test_init_get)
 		      DEVICE_DT_GET(TEST_NOLABEL), NULL);
 
 	/* Check init functions */
-	zassert_equal(DEVICE_INIT_DT_GET(TEST_GPIO)->init_fn.dev, dev_init);
-	zassert_equal(DEVICE_INIT_DT_GET(TEST_I2C)->init_fn.dev, dev_init);
-	zassert_equal(DEVICE_INIT_DT_GET(TEST_DEVA)->init_fn.dev, dev_init);
-	zassert_equal(DEVICE_INIT_DT_GET(TEST_DEVB)->init_fn.dev, dev_init);
-	zassert_equal(DEVICE_INIT_DT_GET(TEST_GPIOX)->init_fn.dev, dev_init);
-	zassert_equal(DEVICE_INIT_DT_GET(TEST_DEVC)->init_fn.dev, dev_init);
-	zassert_equal(DEVICE_INIT_DT_GET(TEST_PARTITION)->init_fn.dev, dev_init);
-	zassert_equal(DEVICE_INIT_DT_GET(TEST_GPIO_INJECTED)->init_fn.dev, dev_init);
-	zassert_equal(DEVICE_INIT_GET(manual_dev)->init_fn.dev, dev_init);
-	zassert_equal(DEVICE_INIT_DT_GET(TEST_NOLABEL)->init_fn.dev, dev_init);
+	zassert_equal(DEVICE_DT_GET(TEST_GPIO)->init_fn, dev_init);
+	zassert_equal(DEVICE_DT_GET(TEST_I2C)->init_fn, dev_init);
+	zassert_equal(DEVICE_DT_GET(TEST_DEVA)->init_fn, dev_init);
+	zassert_equal(DEVICE_DT_GET(TEST_DEVB)->init_fn, dev_init);
+	zassert_equal(DEVICE_DT_GET(TEST_GPIOX)->init_fn, dev_init);
+	zassert_equal(DEVICE_DT_GET(TEST_DEVC)->init_fn, dev_init);
+	zassert_equal(DEVICE_DT_GET(TEST_PARTITION)->init_fn, dev_init);
+	zassert_equal(DEVICE_DT_GET(TEST_GPIO_INJECTED)->init_fn, dev_init);
+	zassert_equal(DEVICE_GET(manual_dev)->init_fn, dev_init);
+	zassert_equal(DEVICE_DT_GET(TEST_NOLABEL)->init_fn, dev_init);
 }
 
 ZTEST(devicetree_devices, test_init_order)

--- a/tests/lib/devicetree/devices/src/main.c
+++ b/tests/lib/devicetree/devices/src/main.c
@@ -64,25 +64,25 @@ DEVICE_DT_DEFINE(TEST_NOLABEL, dev_init, NULL,
 ZTEST(devicetree_devices, test_init_get)
 {
 	/* Check device pointers */
-	zassert_equal(DEVICE_INIT_DT_GET(TEST_GPIO)->dev,
+	zassert_equal(DEVICE_INIT_DT_GET(TEST_GPIO)->dev.dev,
 		      DEVICE_DT_GET(TEST_GPIO), NULL);
-	zassert_equal(DEVICE_INIT_DT_GET(TEST_I2C)->dev,
+	zassert_equal(DEVICE_INIT_DT_GET(TEST_I2C)->dev.dev,
 		      DEVICE_DT_GET(TEST_I2C), NULL);
-	zassert_equal(DEVICE_INIT_DT_GET(TEST_DEVA)->dev,
+	zassert_equal(DEVICE_INIT_DT_GET(TEST_DEVA)->dev.dev,
 		      DEVICE_DT_GET(TEST_DEVA), NULL);
-	zassert_equal(DEVICE_INIT_DT_GET(TEST_DEVB)->dev,
+	zassert_equal(DEVICE_INIT_DT_GET(TEST_DEVB)->dev.dev,
 		      DEVICE_DT_GET(TEST_DEVB), NULL);
-	zassert_equal(DEVICE_INIT_DT_GET(TEST_GPIOX)->dev,
+	zassert_equal(DEVICE_INIT_DT_GET(TEST_GPIOX)->dev.dev,
 		      DEVICE_DT_GET(TEST_GPIOX), NULL);
-	zassert_equal(DEVICE_INIT_DT_GET(TEST_DEVC)->dev,
+	zassert_equal(DEVICE_INIT_DT_GET(TEST_DEVC)->dev.dev,
 		      DEVICE_DT_GET(TEST_DEVC), NULL);
-	zassert_equal(DEVICE_INIT_DT_GET(TEST_PARTITION)->dev,
+	zassert_equal(DEVICE_INIT_DT_GET(TEST_PARTITION)->dev.dev,
 		      DEVICE_DT_GET(TEST_PARTITION), NULL);
-	zassert_equal(DEVICE_INIT_DT_GET(TEST_GPIO_INJECTED)->dev,
+	zassert_equal(DEVICE_INIT_DT_GET(TEST_GPIO_INJECTED)->dev.dev,
 		      DEVICE_DT_GET(TEST_GPIO_INJECTED), NULL);
-	zassert_equal(DEVICE_INIT_GET(manual_dev)->dev,
+	zassert_equal(DEVICE_INIT_GET(manual_dev)->dev.dev,
 		      DEVICE_GET(manual_dev), NULL);
-	zassert_equal(DEVICE_INIT_DT_GET(TEST_NOLABEL)->dev,
+	zassert_equal(DEVICE_INIT_DT_GET(TEST_NOLABEL)->dev.dev,
 		      DEVICE_DT_GET(TEST_NOLABEL), NULL);
 
 	/* Check init functions */

--- a/tests/lib/devicetree/devices/src/main.c
+++ b/tests/lib/devicetree/devices/src/main.c
@@ -86,16 +86,16 @@ ZTEST(devicetree_devices, test_init_get)
 		      DEVICE_DT_GET(TEST_NOLABEL), NULL);
 
 	/* Check init functions */
-	zassert_equal(DEVICE_DT_GET(TEST_GPIO)->init_fn, dev_init);
-	zassert_equal(DEVICE_DT_GET(TEST_I2C)->init_fn, dev_init);
-	zassert_equal(DEVICE_DT_GET(TEST_DEVA)->init_fn, dev_init);
-	zassert_equal(DEVICE_DT_GET(TEST_DEVB)->init_fn, dev_init);
-	zassert_equal(DEVICE_DT_GET(TEST_GPIOX)->init_fn, dev_init);
-	zassert_equal(DEVICE_DT_GET(TEST_DEVC)->init_fn, dev_init);
-	zassert_equal(DEVICE_DT_GET(TEST_PARTITION)->init_fn, dev_init);
-	zassert_equal(DEVICE_DT_GET(TEST_GPIO_INJECTED)->init_fn, dev_init);
-	zassert_equal(DEVICE_GET(manual_dev)->init_fn, dev_init);
-	zassert_equal(DEVICE_DT_GET(TEST_NOLABEL)->init_fn, dev_init);
+	zassert_equal(DEVICE_DT_GET(TEST_GPIO)->ops.init, dev_init);
+	zassert_equal(DEVICE_DT_GET(TEST_I2C)->ops.init, dev_init);
+	zassert_equal(DEVICE_DT_GET(TEST_DEVA)->ops.init, dev_init);
+	zassert_equal(DEVICE_DT_GET(TEST_DEVB)->ops.init, dev_init);
+	zassert_equal(DEVICE_DT_GET(TEST_GPIOX)->ops.init, dev_init);
+	zassert_equal(DEVICE_DT_GET(TEST_DEVC)->ops.init, dev_init);
+	zassert_equal(DEVICE_DT_GET(TEST_PARTITION)->ops.init, dev_init);
+	zassert_equal(DEVICE_DT_GET(TEST_GPIO_INJECTED)->ops.init, dev_init);
+	zassert_equal(DEVICE_GET(manual_dev)->ops.init, dev_init);
+	zassert_equal(DEVICE_DT_GET(TEST_NOLABEL)->ops.init, dev_init);
 }
 
 ZTEST(devicetree_devices, test_init_order)

--- a/tests/lib/devicetree/devices/src/main.c
+++ b/tests/lib/devicetree/devices/src/main.c
@@ -64,25 +64,25 @@ DEVICE_DT_DEFINE(TEST_NOLABEL, dev_init, NULL,
 ZTEST(devicetree_devices, test_init_get)
 {
 	/* Check device pointers */
-	zassert_equal(DEVICE_INIT_DT_GET(TEST_GPIO)->dev.dev,
+	zassert_equal(DEVICE_INIT_DT_GET(TEST_GPIO)->dev,
 		      DEVICE_DT_GET(TEST_GPIO), NULL);
-	zassert_equal(DEVICE_INIT_DT_GET(TEST_I2C)->dev.dev,
+	zassert_equal(DEVICE_INIT_DT_GET(TEST_I2C)->dev,
 		      DEVICE_DT_GET(TEST_I2C), NULL);
-	zassert_equal(DEVICE_INIT_DT_GET(TEST_DEVA)->dev.dev,
+	zassert_equal(DEVICE_INIT_DT_GET(TEST_DEVA)->dev,
 		      DEVICE_DT_GET(TEST_DEVA), NULL);
-	zassert_equal(DEVICE_INIT_DT_GET(TEST_DEVB)->dev.dev,
+	zassert_equal(DEVICE_INIT_DT_GET(TEST_DEVB)->dev,
 		      DEVICE_DT_GET(TEST_DEVB), NULL);
-	zassert_equal(DEVICE_INIT_DT_GET(TEST_GPIOX)->dev.dev,
+	zassert_equal(DEVICE_INIT_DT_GET(TEST_GPIOX)->dev,
 		      DEVICE_DT_GET(TEST_GPIOX), NULL);
-	zassert_equal(DEVICE_INIT_DT_GET(TEST_DEVC)->dev.dev,
+	zassert_equal(DEVICE_INIT_DT_GET(TEST_DEVC)->dev,
 		      DEVICE_DT_GET(TEST_DEVC), NULL);
-	zassert_equal(DEVICE_INIT_DT_GET(TEST_PARTITION)->dev.dev,
+	zassert_equal(DEVICE_INIT_DT_GET(TEST_PARTITION)->dev,
 		      DEVICE_DT_GET(TEST_PARTITION), NULL);
-	zassert_equal(DEVICE_INIT_DT_GET(TEST_GPIO_INJECTED)->dev.dev,
+	zassert_equal(DEVICE_INIT_DT_GET(TEST_GPIO_INJECTED)->dev,
 		      DEVICE_DT_GET(TEST_GPIO_INJECTED), NULL);
-	zassert_equal(DEVICE_INIT_GET(manual_dev)->dev.dev,
+	zassert_equal(DEVICE_INIT_GET(manual_dev)->dev,
 		      DEVICE_GET(manual_dev), NULL);
-	zassert_equal(DEVICE_INIT_DT_GET(TEST_NOLABEL)->dev.dev,
+	zassert_equal(DEVICE_INIT_DT_GET(TEST_NOLABEL)->dev,
 		      DEVICE_DT_GET(TEST_NOLABEL), NULL);
 
 	/* Check init functions */


### PR DESCRIPTION
This RFC is about adding a new core feature to the device model: device
de-initialization.

## Why ?

One may think that this is an unnecessary feature since Zephyr primary goal is
to allocate resources at compile time. However, cases arise occasionally asking
for more dynamic features, see e.g. #20012, #40385.

The following scenarios would benefit from being able to de-initialize a device:

(1) Multi-functional IP (e.g. USART/SPI/I2C)
(2) Re-allocation of device resources (e.g. pin re-assignment)
(3) Runtime interpreters like Micropython (where some devices may be dynamically loaded based on user input)
(4) Bootloaders: to leave some devices in their reset state
(5) See concrete case: "Allow multiple ICE40 on the same SPI bus" #77980, #80010

One could argue that all these cases could be solved by exposing custom device
level APIs, however, since this requirement applies to a few vendors, solving
the problem in a more generic way seems like a better approach. Some may also
argue that PM can partly solve some of these problems, however, we should
acknowledge that Zephyr PM subsystem has not been widely adopted, and still
today, many of its design points are discussed #84049.

## How... ?

To support de-initialization, `device_deinit()` is proposed. However, while all devices now have an init function, they do
not have any de-init function, so the following is introduced:

```c
struct device_ops {
    int (*init)(const struct device *);
    int (*deinit)(const struct device *);
}
```

And introduce additional device definition macros that allow passing a de-init function, e.g. `DEVICE_DT_DEINIT_DEFINE(node_id, init_fn, deinit_fn, ...)`.

```c
/* A device that supports de-init */
static int mydev_init(const struct device *dev)
{
    ...
}

static int mydev_deinit(const struct device *dev)
{
    ...
}

DEVICE_DT_INST_DEINIT_DEFINE(0, mydev_init, mydev_deinit, ...);
```

## Open questions

All have been discussed. The Agreement was to implement the simplest option: a new deinit API with no guarantees, no usage tracking, etc.

## Samples

- Last commits, tagged with `[DNM]` show required driver changes or sample de-init implementations
- A generic sample that allows switching UART pins at runtime is provided. It works on both nRF5340DK and ST Nucleo H743Z, see 7d7370291f18a2c1282249f03307541d026b305c.
