### PR TITLE
dts: stm32-pinctrl.yaml: remove calculation of pinmux

### DIFF
--- a/dts/bindings/pinctrl/st,stm32-pinctrl.yaml
+++ b/dts/bindings/pinctrl/st,stm32-pinctrl.yaml
@@ -54,8 +54,8 @@ child-binding:
       description: |
         Reused from
         https://github.com/torvalds/linux/blob/master/Documentation/devicetree/bindings/pinctrl/st,stm32-pinctrl.yaml
-        Integer array, represents gpio pin number and mux setting.
-        These defines are calculated as: ((port * 16 + line) << 8) | function
+        Integer represents gpio pin number and mux setting.
+        Each integer encodes a port, line and alternate function.
         With:
         - port: The gpio port index (PA = 0, PB = 1, ..., PK = 11)
         - line: The line offset within the port (PA0 = 0, PA1 = 1, ..., PA15 = 15)
@@ -74,7 +74,7 @@ child-binding:
 
         To simplify the usage, macro is available to generate "pinmux" field.
         This macro is available here:
-          -include/zephyr/dt-bindings/pinctrl/stm32-pinctrl-common.h
+          -include/zephyr/dt-bindings/pinctrl/stm32-pinctrl.h
         Some examples of macro usage:
            GPIO A9 set as alternate function 2
         ... {

--- a/dts/bindings/pinctrl/st,stm32f1-pinctrl.yaml
+++ b/dts/bindings/pinctrl/st,stm32f1-pinctrl.yaml
@@ -61,8 +61,8 @@ child-binding:
       description: |
         Adapted from
         https://github.com/torvalds/linux/blob/master/Documentation/devicetree/bindings/pinctrl/st,stm32-pinctrl.yaml
-        Integer array, represents gpio pin number and mux setting.
-        These defines are calculated as: ((port * 16 + line) << 8) | (function << 6) | remap)
+        Integer represents gpio pin number and mux setting.
+        Each integer encodes a port, line, alternate function and remap.
         With:
         - port: The gpio port index (PA = 0, PB = 1, ..., PK = 11)
         - line: The line offset within the port (PA0 = 0, PA1 = 1, ..., PA15 = 15)


### PR DESCRIPTION
This is version 2 of PR: "dts: stm32-pinctrl.yaml: fix calculation of pinmux" #83921

- remove calculation of pinmux value for stm32 in device tree binding documentation.
- stm32-pinctrl.yaml contains wrong calculation as can be compared to #define STM32_PINMUX in stm32-pinctrl.h.
- stm32f1-pinctrl.yaml also contains different wrong calculation compared to #define STM32F1_PINMUX in stm32f1-pinctrl.h.