### PR TITLE
dts: i2s_mcux_sai: Clarify IOMUXC GPR binding

### DIFF
--- a/drivers/i2s/i2s_mcux_sai.c
+++ b/drivers/i2s/i2s_mcux_sai.c
@@ -1153,8 +1153,8 @@ static DEVICE_API(i2s, i2s_mcux_driver_api) = {
 		.pll_num = DT_PHA_BY_NAME_OR(DT_DRV_INST(i2s_id), pll_clocks, num, value, 0),      \
 		.pll_den = DT_PHA_BY_NAME_OR(DT_DRV_INST(i2s_id), pll_clocks, den, value, 0),      \
 		.mclk_control_base = DT_REG_ADDR(DT_PHANDLE(DT_DRV_INST(i2s_id), pinmuxes)),       \
-		.mclk_pin_mask = DT_PHA_BY_IDX(DT_DRV_INST(i2s_id), pinmuxes, 0, function),        \
-		.mclk_pin_offset = DT_PHA_BY_IDX(DT_DRV_INST(i2s_id), pinmuxes, 0, pin),           \
+		.mclk_pin_mask = DT_PHA_BY_IDX(DT_DRV_INST(i2s_id), pinmuxes, 0, mask),            \
+		.mclk_pin_offset = DT_PHA_BY_IDX(DT_DRV_INST(i2s_id), pinmuxes, 0, offset),        \
 		.clk_sub_sys =                                                                     \
 			(clock_control_subsys_t)DT_INST_CLOCKS_CELL_BY_IDX(i2s_id, 0, name),       \
 		.ccm_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(i2s_id)),                             \

--- a/dts/bindings/pinctrl/nxp,imx-gpr.yaml
+++ b/dts/bindings/pinctrl/nxp,imx-gpr.yaml
@@ -1,7 +1,14 @@
 # Copyright (c) 2021, NXP
 # SPDX-License-Identifier: Apache-2.0
 
-description: i.MX IOMUXC node
+description: |
+  i.MX IOMUXC node
+
+  The specifier space "pinmux" of this binding should have two cells describing
+  the resources needed from the GPR registers.
+  For each specifier, the first cell should be the offset of the GPR register in bytes
+  from the base address of the GPR device base address. The second cell should be a
+  bitmask indicating which bits in the specified register are relevant to the referencing device.
 
 compatible: "nxp,imx-gpr"
 
@@ -12,5 +19,5 @@ properties:
     required: true
 
 pinmux-cells:
-  - pin
-  - function
+  - offset
+  - mask


### PR DESCRIPTION
Improve the documentation of the IOMUXC GPR binding so that it is clear what the cells in the specifier space of "pinmux" space mean. And change the names of the cells to be more appropriate. "offset" instead of "pin" and "mask" instead of "function" describes more precisely what the cells in the specifier mean.