### PR TITLE
drivers: disk: fix compiler warning of drivers__disk

### DIFF
--- a/drivers/disk/CMakeLists.txt
+++ b/drivers/disk/CMakeLists.txt
@@ -4,6 +4,7 @@
 if(CONFIG_DISK_DRIVERS)
 
 zephyr_library()
+zephyr_library_property(ALLOW_EMPTY TRUE)
 
 zephyr_library_sources_ifdef(CONFIG_DISK_DRIVER_FLASH flashdisk.c)
 zephyr_library_sources_ifdef(CONFIG_DISK_DRIVER_RAM ramdisk.c)


### PR DESCRIPTION
This PR fixes the following compiler warning:
No SOURCES given to Zephyr library: drivers__disk

west build -p -b esp32_devkitc_wroom/esp32/procpu samples/subsys/fs/fs_sample/