### PR TITLE
scripts: build: Optimize hex character list generation in file2hex.py

### DIFF
--- a/scripts/build/file2hex.py
+++ b/scripts/build/file2hex.py
@@ -43,7 +43,11 @@ def parse_args():
 
 
 def get_nice_string(list_or_iterator):
-    return ", ".join("0x" + str(x) for x in list_or_iterator)
+    # Convert into comma separated list form.
+    s = ", ".join("0x" + str(x) for x in list_or_iterator)
+
+    # Format the list to eight values per line.
+    return "\n".join(s[i:i+47] for i in range(0, len(s), 48))
 
 
 def make_hex(chunk):
@@ -71,11 +75,11 @@ def main():
         with open(args.file, "rb") as fp:
             fp.seek(args.offset)
             if args.length < 0:
-                for chunk in iter(lambda: fp.read(8), b''):
+                for chunk in iter(lambda: fp.read(1024), b''):
                     make_hex(chunk)
             else:
                 remainder = args.length
-                for chunk in iter(lambda: fp.read(min(8, remainder)), b''):
+                for chunk in iter(lambda: fp.read(min(1024, remainder)), b''):
                     make_hex(chunk)
                     remainder = remainder - len(chunk)
 


### PR DESCRIPTION
Read and convert binary data in chunks of 1024 bytes, instead of 8 bytes. This significantly reduces the conversion time. The improvement increases with increasing file sizes but saturates to around 60-61% as file size approaches 64MiB, and beyond.

The existing generated output format of eight byte-values per line is still preserved.

**Notes:**
* I also experimented with other chunk sizes; conversion time improves with increasing chunk size, but beyond 1024, it results in just marginal improvement. So 1024 appears to be a reasonable tradeoff.
* Filesystem reads, though relevant, do not seem to be the major bottleneck; the main culprit is the `join` call in the last (now second last) conversion step. Larger sizes likely push the bulk of work to more performant lower level native implementation, resulting in less overhead.
* Inspired by a related enhancement: #84116

**Benchmark test results:**
* File sizes below 1KiB (have been tested - down to 2 bytes size - but) are not included here to avoid clutter and the numbers are almost the same as the ones for files of around 1KiB size.

<table>
<tr>
<th>File Size</th>
<th>8 Bytes Chunk</th>
<th>1024 Bytes Chunk</th>
<th>Improvement</th>
</tr>
<tr>
<th align='right'>&NoBreak;1KiB</th>
<td align='right'>&NoBreak;0.023</td>
<td align='right'>&NoBreak;0.023</td>
<td align='right'>&NoBreak;0.00</td>
</tr>
<tr>
<th align='right'>&NoBreak;2KiB</th>
<td align='right'>&NoBreak;0.023</td>
<td align='right'>&NoBreak;0.023</td>
<td align='right'>&NoBreak;0.00</td>
</tr>
<tr>
<th align='right'>&NoBreak;4KiB</th>
<td align='right'>&NoBreak;0.023</td>
<td align='right'>&NoBreak;0.022</td>
<td align='right'>&NoBreak;4.35</td>
</tr>
<tr>
<th align='right'>&NoBreak;8KiB</th>
<td align='right'>&NoBreak;0.025</td>
<td align='right'>&NoBreak;0.022</td>
<td align='right'>&NoBreak;12.00</td>
</tr>
<tr>
<th align='right'>&NoBreak;16KiB</th>
<td align='right'>&NoBreak;0.027</td>
<td align='right'>&NoBreak;0.025</td>
<td align='right'>&NoBreak;7.41</td>
</tr>
<tr>
<th align='right'>&NoBreak;32KiB</th>
<td align='right'>&NoBreak;0.032</td>
<td align='right'>&NoBreak;0.025</td>
<td align='right'>&NoBreak;21.87</td>
</tr>
<tr>
<th align='right'>&NoBreak;64KiB</th>
<td align='right'>&NoBreak;0.041</td>
<td align='right'>&NoBreak;0.031</td>
<td align='right'>&NoBreak;24.39</td>
</tr>
<tr>
<th align='right'>&NoBreak;128KiB</th>
<td align='right'>&NoBreak;0.058</td>
<td align='right'>&NoBreak;0.038</td>
<td align='right'>&NoBreak;34.48</td>
</tr>
<tr>
<th align='right'>&NoBreak;256KiB</th>
<td align='right'>&NoBreak;0.094</td>
<td align='right'>&NoBreak;0.055</td>
<td align='right'>&NoBreak;41.49</td>
</tr>
<tr>
<th align='right'>&NoBreak;512KiB</th>
<td align='right'>&NoBreak;0.180</td>
<td align='right'>&NoBreak;0.084</td>
<td align='right'>&NoBreak;53.33</td>
</tr>
<tr>
<th align='right'>&NoBreak;1MiB</th>
<td align='right'>&NoBreak;0.307</td>
<td align='right'>&NoBreak;0.140</td>
<td align='right'>&NoBreak;54.40</td>
</tr>
<tr>
<th align='right'>&NoBreak;2MiB</th>
<td align='right'>&NoBreak;0.599</td>
<td align='right'>&NoBreak;0.254</td>
<td align='right'>&NoBreak;57.60</td>
</tr>
<tr>
<th align='right'>&NoBreak;4MiB</th>
<td align='right'>&NoBreak;1.176</td>
<td align='right'>&NoBreak;0.475</td>
<td align='right'>&NoBreak;59.61</td>
</tr>
<tr>
<th align='right'>&NoBreak;8MiB</th>
<td align='right'>&NoBreak;2.365</td>
<td align='right'>&NoBreak;0.950</td>
<td align='right'>&NoBreak;59.83</td>
</tr>
<tr>
<th align='right'>&NoBreak;16MiB</th>
<td align='right'>&NoBreak;4.664</td>
<td align='right'>&NoBreak;1.836</td>
<td align='right'>&NoBreak;60.63</td>
</tr>
<tr>
<th align='right'>&NoBreak;32MiB</th>
<td align='right'>&NoBreak;9.350</td>
<td align='right'>&NoBreak;3.719</td>
<td align='right'>&NoBreak;60.22</td>
</tr>
<tr>
<th align='right'>&NoBreak;64MiB</th>
<td align='right'>&NoBreak;18.814</td>
<td align='right'>&NoBreak;7.249</td>
<td align='right'>&NoBreak;61.47</td>
</tr>
<tr>
<th align='right'>&NoBreak;128MiB</th>
<td align='right'>&NoBreak;38.198</td>
<td align='right'>&NoBreak;14.752</td>
<td align='right'>&NoBreak;61.38</td>
</tr>
<tr>
<th align='right'>&NoBreak;256MiB</th>
<td align='right'>&NoBreak;74.529</td>
<td align='right'>&NoBreak;29.077</td>
<td align='right'>&NoBreak;60.99</td>
</tr>
</table>
