### PR TITLE
soc: amd: acp_6_0: Kconfig: fix SOC_TOOLCHAIN_NAME

### DIFF
--- a/soc/amd/acp_6_0/Kconfig.soc
+++ b/soc/amd/acp_6_0/Kconfig.soc
@@ -10,4 +10,4 @@ config SOC
 
 config SOC_TOOLCHAIN_NAME
 	string
-	default "amd_acp_6_0_adsp"
+	default "amd_acp_6_0_adsp" if SOC_ACP_6_0


### PR DESCRIPTION
Add guard for acp_6_0 SOC_TOOLCHAIN_NAME symbol default value, otherwise it is included in builds of all SoCs that don't define a custom default value for it.