### PR TITLE
doc: Adapt ICM42688 example to new dt option names.

### DIFF
--- a/dts/bindings/sensor/invensense,icm42688.yaml
+++ b/dts/bindings/sensor/invensense,icm42688.yaml
@@ -15,12 +15,12 @@ description: |
     icm42688: icm42688@0 {
       ...
 
-      accel-pwr-mode = <ICM42688_ACCEL_LN>;
-      accel-fs = <ICM42688_ACCEL_FS_16G>;
-      accel-odr = <ICM42688_ACCEL_ODR_2000>;
-      gyro-pwr-mode= <ICM42688_GYRO_LN>;
-      gyro-fs = <ICM42688_GYRO_FS_2000>;
-      gyro-odr = <ICM42688_GYRO_ODR_2000>;
+      accel-pwr-mode = <ICM42688_DT_ACCEL_LN>;
+      accel-fs = <ICM42688_DT_ACCEL_FS_16>;
+      accel-odr = <ICM42688_DT_ACCEL_ODR_2000>;
+      gyro-pwr-mode= <ICM42688_DT_GYRO_LN>;
+      gyro-fs = <ICM42688_DT_GYRO_FS_2000>;
+      gyro-odr = <ICM42688_DT_GYRO_ODR_2000>;
     };
 compatible: "invensense,icm42688"
 include: [sensor-device.yaml, spi-device.yaml]


### PR DESCRIPTION
Example for creating ICM42688 dt node uses old dt option names. Fix by changing to newest dt option names.