### PR TITLE
i2c_shell: only include i3c if I3C=y

### DIFF
--- a/drivers/i2c/i2c_shell.c
+++ b/drivers/i2c/i2c_shell.c
@@ -338,7 +338,11 @@ static int cmd_i2c_speed(const struct shell *shell_ctx, size_t argc, char **argv
 
 static bool device_is_i2c(const struct device *dev)
 {
+#ifdef CONFIG_I3C
 	return DEVICE_API_IS(i2c, dev) || DEVICE_API_IS(i3c, dev);
+#else
+	return DEVICE_API_IS(i2c, dev);
+#endif
 }
 
 static void device_name_get(size_t idx, struct shell_static_entry *entry)


### PR DESCRIPTION
Only lookup for i3c devices if I3C=y, fixes a build error:

zephyr/drivers/i2c/i2c_shell.c:
In function 'device_is_i2c':
zephyr/drivers/i2c/i2c_shell.c:341:43:
error: array type has incomplete element type 'struct i3c_driver_api'
341 |         return DEVICE_API_IS(i2c, dev) || DEVICE_API_IS(i3c, dev);