### PR TITLE
spi: shell: Add command to include CS GPIO in SPI device

### DIFF
--- a/drivers/spi/spi_shell.c
+++ b/drivers/spi/spi_shell.c
@@ -17,6 +17,10 @@
 #define CONF_ARGV_FREQUENCY (2)
 #define CONF_ARGV_SETTINGS  (3)
 
+#define CS_ARGV_GPIO_DEV    (1)
+#define CS_ARGV_GPIO_PIN    (2)
+#define CS_ARGV_GPIO_FLAGS  (3)
+
 /* Maximum bytes we can write and read at once */
 #define MAX_SPI_BYTES MIN((CONFIG_SHELL_ARGC_MAX - TXRX_ARGV_BYTES), 32)
 
@@ -135,6 +139,41 @@ out:
 	return 0;
 }
 
+static int cmd_spi_conf_cs(const struct shell *ctx, size_t argc, char **argv)
+{
+	struct device *dev = (struct device *)shell_device_get_binding(argv[CS_ARGV_GPIO_DEV]);
+	char *endptr = NULL;
+
+	if (dev == NULL) {
+		shell_error(ctx, "device %s not found.", argv[CS_ARGV_GPIO_DEV]);
+		return -ENODEV;
+	}
+
+	int pin = strtol(argv[CS_ARGV_GPIO_PIN], &endptr, 10);
+
+	if (endptr == argv[CS_ARGV_GPIO_PIN] || (pin < 0)) {
+		shell_error(ctx, "invalid pin number: %s", argv[CS_ARGV_GPIO_PIN]);
+		return -EINVAL;
+	}
+
+	config.cs.gpio.port = dev;
+	config.cs.gpio.pin = pin;
+
+	/* Include flags if provided */
+	if (argc == (CS_ARGV_GPIO_FLAGS + 1)) {
+		uint32_t flags = strtol(argv[CS_ARGV_GPIO_FLAGS], &endptr, 16);
+
+		if (endptr == argv[CS_ARGV_GPIO_FLAGS]) {
+			shell_error(ctx, "invalid gpio flags: %s", argv[CS_ARGV_GPIO_FLAGS]);
+			return -EINVAL;
+		}
+
+		config.cs.gpio.dt_flags = flags;
+	}
+
+	return 0;
+}
+
 SHELL_STATIC_SUBCMD_SET_CREATE(sub_spi_cmds,
 			       SHELL_CMD_ARG(conf, &dsub_device_name,
 					     "Configure SPI\n"
@@ -146,6 +185,11 @@ SHELL_STATIC_SUBCMD_SET_CREATE(sub_spi_cmds,
 					     "T - SPI_FRAME_FORMAT_TI\n"
 					     "example: spi conf spi1 1000000 ol",
 					     cmd_spi_conf, 3, 1),
+			       SHELL_CMD_ARG(cs, &dsub_device_name,
+					     "Assign CS GPIO to SPI device\n"
+					     "Usage: spi cs <gpio-device> <pin> [<gpio flags>]"
+					     "example: spi conf gpio1 3 0x01",
+					     cmd_spi_conf_cs, 3, 1),
 			       SHELL_CMD_ARG(transceive, NULL,
 					     "Transceive data to and from an SPI device\n"
 					     "Usage: spi transceive <TX byte 1> [<TX byte 2> ...]",


### PR DESCRIPTION
### Description

This allows to configure a GPIO pin as a CS line, in order to perform spi transfers to a particular device in the bus.
Example usage for using GPIO1.12 with GPIO_ACTIVE_LOW:
`spi cs gpio1 12 0x01`

### Testing

Using nRF52840DK with an ADXL345, reading the DEVID (0xe5):

- Build
``` console
west build -b nrf52840dk/nrf52840 samples/subsys/shell/shell_module -- -DCONFIG_SPI=y -DCONFIG_SPI_SHELL=y
```

- Console Output
``` console
*** Booting Zephyr OS build v4.0.0-3867-g3bccb227ae85 ***

uart:~$ spi conf 
  spi@40004000  spi@4002f000  
uart:~$ spi conf spi@4002f000 1000000 oh
uart:~$ spi cs gpio1 12 0x01
uart:~$ spi transceive 0x80 0x00
TX:
00000000: 80 00                                            |..               |
RX:
00000000: 0e e5                                            |..               |
uart:~$ spi transceive 0x80 0x00
TX:
00000000: 80 00                                            |..               |
RX:
00000000: e5 e5                                            |..               |
uart:~$ 
```