### PR TITLE
dts: renesas: correct interrupt numbers for ra4w1

### DIFF
--- a/boards/renesas/ek_ra4w1/ek_ra4w1.dts
+++ b/boards/renesas/ek_ra4w1/ek_ra4w1.dts
@@ -90,7 +90,7 @@
 };
 
 &port_irq4 {
-	interrupts = <31 12>;
+	interrupts = <27 12>;
 	status = "okay";
 };
 

--- a/dts/arm/renesas/ra/ra4/ra4-cm4-common.dtsi
+++ b/dts/arm/renesas/ra/ra4/ra4-cm4-common.dtsi
@@ -149,8 +149,6 @@
 
 		sci9: sci9@40070120  {
 			compatible = "renesas,ra-sci";
-			interrupts = <36 1>, <37 1>, <38 1>, <39 1>;
-			interrupt-names = "rxi", "txi", "tei", "eri";
 			reg = <0x40070120 0x20>;
 			clocks = <&pclka MSTPB 22>;
 			status = "disabled";


### PR DESCRIPTION
- Update the overlapping irq number between `port_irq4` and `spi1`
- Remove irq number for `sci9` as it exceeds the limit (32 irq numbers), due to limited irq numbers, for now, users will define themselves
Related to #79285 , #79849 and #76081