### PR TITLE
[NXP][MCXW][RW] Fix stack overflow in BLE samples after migration to mbedtl

### DIFF
--- a/soc/nxp/mcx/mcxw/Kconfig.defconfig
+++ b/soc/nxp/mcx/mcxw/Kconfig.defconfig
@@ -17,6 +17,12 @@ if BT
 config MAIN_STACK_SIZE
 	default 2560
 
+config BT_LONG_WQ_STACK_SIZE
+	default 2560
+
+config SYSTEM_WORKQUEUE_STACK_SIZE
+	default 2048
+
 if SHELL
 
 config SHELL_STACK_SIZE

--- a/soc/nxp/rw/Kconfig.defconfig
+++ b/soc/nxp/rw/Kconfig.defconfig
@@ -28,6 +28,12 @@ config HCI_NXP_SET_CAL_DATA
 config MAIN_STACK_SIZE
 	default 2560
 
+config BT_LONG_WQ_STACK_SIZE
+	default 2560
+
+config SYSTEM_WORKQUEUE_STACK_SIZE
+	default 2048
+
 if SHELL
 
 config SHELL_STACK_SIZE


### PR DESCRIPTION
    soc: nxp: rw/mcxw: fix stack overflow in BLE samples

    mbedtls is now used in BLE samples, increasing the stack depth needed
    of the calling threads. This was causing stack overflows in several BLE
    samples.
    Increasing the BT_LONG_WQ_STACK stack size for peripheral_sc_only sample, and the SYSTEM_WORKQUEUE stack size for ibeacon sample.

