### PR TITLE
boards: mimxrt1180: fix MCUBoot build

### DIFF
--- a/boards/nxp/mimxrt1180_evk/mimxrt1180_evk_mimxrt1189_cm33.dts
+++ b/boards/nxp/mimxrt1180_evk/mimxrt1180_evk_mimxrt1189_cm33.dts
@@ -19,8 +19,10 @@
 		zephyr,itcm = &itcm;
 		zephyr,flash-controller = &w25q128jw;
 		zephyr,flash = &w25q128jw;
+		zephyr,code-partition = &slot0_partition;
 		zephyr,console = &lpuart1;
 		zephyr,shell-uart = &lpuart1;
+		zephyr,uart-mcumgr = &lpuart1;
 		zephyr,canbus = &flexcan3;
 	};
 

--- a/soc/nxp/imxrt/imxrt118x/Kconfig.defconfig
+++ b/soc/nxp/imxrt/imxrt118x/Kconfig.defconfig
@@ -30,7 +30,8 @@ if SECOND_CORE_MCUX
 
 # RT Boot header is only needed on primary core
 config NXP_IMXRT_BOOT_HEADER
-	depends on !CPU_CORTEX_M7
+	default y
+	depends on !(CPU_CORTEX_M7 || BOOTLOADER_MCUBOOT)
 
 endif # SECOND_CORE_MCUX
 


### PR DESCRIPTION
- Fixes building of MCUBoot for mimxrt1180-evk.
- Disables RT Boot header for MCUBoot applications.