### PR TITLE
doc boards nrfbsim: Update list of supported HW

### DIFF
--- a/boards/native/nrf_bsim/doc/nrf54l15bsim.rst
+++ b/boards/native/nrf_bsim/doc/nrf54l15bsim.rst
@@ -40,6 +40,7 @@ This boards include models of some of the nRF54L15 SOC peripherals:
 * AAR (Accelerated Address Resolver)
 * CCM (AES CCM mode encryption)
 * CLOCK (Clock control)
+* CRACEN (Crypto Accelerator Engine)
 * DPPI (Distributed Programmable Peripheral Interconnect)
 * ECB (AES electronic codebook mode encryption)
 * EGU (Event Generator Unit)
@@ -49,7 +50,6 @@ This boards include models of some of the nRF54L15 SOC peripherals:
 * PPIB (PPI Bridge)
 * RADIO
 * RRAMC (Resistive RAM Controller)
-* RTC (Real Time Counter)
 * TEMP (Temperature sensor)
 * TIMER
 * UARTE (UART with Easy DMA)


### PR DESCRIPTION
The models include enough of the CRACEN to run the same nrfx drivers as in Zephyr. So let's add it to the list.

Also let's remove the RTC from the list as the hal does not expose it anymore for this platform as the GRTC is to be used instead.