### PR TITLE
Exclude psa/crypto test for tf-m small profile 

### DIFF
--- a/tests/subsys/secure_storage/psa/crypto/testcase.yaml
+++ b/tests/subsys/secure_storage/psa/crypto/testcase.yaml
@@ -9,6 +9,6 @@ tests:
       - native_sim
       - nrf54l15dk/nrf54l15/cpuapp
   secure_storage.psa.crypto.tfm:
-    filter: CONFIG_BUILD_WITH_TFM
+    filter: CONFIG_BUILD_WITH_TFM and not CONFIG_TFM_PROFILE_TYPE_SMALL
     integration_platforms:
       - nrf9151dk/nrf9151/ns


### PR DESCRIPTION
TF-M small profile does not support secure storage (know as Protected storage), this commit add filter for tf-m test case to pass it incase of small profile been set, see tf-m profiles in below link

https://tf-m-user-guide.trustedfirmware.org/configuration/profiles/index.html