### PR TITLE
tests: fat: fat_fs_api reduce the wipe partition sects

### DIFF
--- a/tests/subsys/fs/fat_fs_api/src/common.c
+++ b/tests/subsys/fs/fat_fs_api/src/common.c
@@ -89,6 +89,10 @@ int wipe_partition(void)
 		return TC_FAIL;
 	}
 
+	if (sector_count > 64) {
+		/* partition only in first 32k */
+		sector_count = 64;
+	}
 	sector_wr_size = MIN(sector_size, ARRAY_SIZE(erase_buffer));
 	sector_wr_jmp = sector_wr_size / sector_wr_size;
 	TC_PRINT("For "DISK_NAME" using sector write size %"PRIu32" to write %"PRIu32" at once\n",


### PR DESCRIPTION
As SD partition tables, GPT or MBT, is positioned at the beginning of a device
it is enough to wipe first 64 sectors, of 512 bytes.
Wipe of entire SD card is very slow and unnecessary.

fixes: #84428
