### PR TITLE
drivers: clock_control: hsfll: Add option to set lowest oppoint in init

### DIFF
--- a/drivers/clock_control/Kconfig.nrf
+++ b/drivers/clock_control/Kconfig.nrf
@@ -179,7 +179,6 @@ config CLOCK_CONTROL_NRF2
 	depends on SOC_SERIES_NRF54HX && !RISCV_CORE_NORDIC_VPR
 	select ONOFF
 	select NRFS if HAS_NRFS
-	imply NRFS_LOCAL_DOMAIN_DVFS_SCALE_DOWN_AFTER_INIT if NRFS_DVFS_LOCAL_DOMAIN
 	help
 	  Support for nRF clock control devices.
 

--- a/drivers/clock_control/Kconfig.nrf
+++ b/drivers/clock_control/Kconfig.nrf
@@ -184,6 +184,12 @@ config CLOCK_CONTROL_NRF2
 
 if CLOCK_CONTROL_NRF2
 
+config CLOCK_CONTROL_NRF2_HSFLL_REQ_LOW_FREQ
+	bool "Local domain scale down after init"
+	default y if NRFS_DVFS_LOCAL_DOMAIN
+	help
+	  Request the lowest operating point after DVFS initialization.
+
 config CLOCK_CONTROL_NRF2_NRFS_DVFS_TIMEOUT_MS
 	int "Timeout waiting for nrfs dvfs service callback in milliseconds"
 	default 2000

--- a/drivers/clock_control/clock_control_nrf2_hsfll.c
+++ b/drivers/clock_control/clock_control_nrf2_hsfll.c
@@ -218,6 +218,21 @@ static DEVICE_API(nrf_clock_control, hsfll_drv_api) = {
 static struct hsfll_dev_data hsfll_data;
 #endif
 
+#ifdef CONFIG_CLOCK_CONTROL_NRF2_HSFLL_REQ_LOW_FREQ
+static int dvfs_low_init(void)
+{
+	static const k_timeout_t timeout = K_MSEC(CONFIG_CLOCK_CONTROL_NRF2_NRFS_DVFS_TIMEOUT_MS);
+	static const struct device *hsfll_dev = DEVICE_DT_GET(DT_CLOCKS_CTLR(DT_NODELABEL(cpu)));
+	static const struct nrf_clock_spec clk_spec = {
+		.frequency = HSFLL_FREQ_LOW
+	};
+
+	return nrf_clock_control_request_sync(hsfll_dev, &clk_spec, timeout);
+}
+
+SYS_INIT(dvfs_low_init, APPLICATION, 0);
+#endif
+
 DEVICE_DT_INST_DEFINE(0, hsfll_init, NULL,
 		      COND_CODE_1(CONFIG_NRFS_DVFS_LOCAL_DOMAIN,
 				  (&hsfll_data),

--- a/modules/hal_nordic/nrfs/dvfs/Kconfig
+++ b/modules/hal_nordic/nrfs/dvfs/Kconfig
@@ -17,6 +17,7 @@ config NRFS_LOCAL_DOMAIN_DVFS_TEST
 
 config NRFS_LOCAL_DOMAIN_DVFS_SCALE_DOWN_AFTER_INIT
 	bool "Local domain scale down after init"
+	select DEPRECATED
 	help
 	  Request lowest oppoint after DVFS initialization.
 


### PR DESCRIPTION
Add option to set the lowest DVFS operation point during initialization. Option is by default enabled for nrf54h cores with DVFS.

Deprecate NRFS_LOCAL_DOMAIN_DVFS_SCALE_DOWN_AFTER_INIT which was previously used for that but it bypasses clock control API that should be used for that (it was added before clock control API for DVFS was added and not removed then).