### PR TITLE
audio: liblc3: Fix global include path issue

### DIFF
--- a/modules/liblc3/CMakeLists.txt
+++ b/modules/liblc3/CMakeLists.txt
@@ -20,6 +20,9 @@ endif()
 
 zephyr_include_directories(
 	${ZEPHYR_LIBLC3_MODULE_DIR}/include
+)
+
+zephyr_library_include_directories(
 	${ZEPHYR_LIBLC3_MODULE_DIR}/src
 )
 


### PR DESCRIPTION
-liblc3 added a library-internal path to zephyr_interface containing
 a file that collides with common.h required e.g. by Mbed TLS
 This commit fixes build-issues by making this include-folder
 PRIVATE to the named library liblc3