### PR TITLE
Coverage: Update color to font_color in header_format

### DIFF
--- a/scripts/ci/coverage/coverage_analysis.py
+++ b/scripts/ci/coverage/coverage_analysis.py
@@ -334,7 +334,7 @@ class Json_report:
             {
                 "bold": True,
                 "fg_color":  "#538DD5",
-                "color":"white"
+                "font_color":"white"
             }
         )
         cell_format = workbook.add_format(
@@ -404,7 +404,7 @@ class Json_report:
             {
                 "bold": True,
                 "fg_color":  "#538DD5",
-                "color":"white"
+                "font_color":"white"
             }
         )
 
@@ -415,7 +415,7 @@ class Json_report:
                 "align": "center",
                 "valign": "vcenter",
                 "fg_color":  "#538DD5",
-                "color":"white"
+                "font_color":"white"
             }
         )
         cell_format = self.report_book.add_format(


### PR DESCRIPTION
Updated the code to use the `font_color` property, which is the correct attribute for setting the text color in recent versions of xlsxwriter (3.2.1).

Fix: 
Affected coverage reporting.
https://github.com/zephyrproject-rtos/zephyr/actions/runs/12923620733/job/36053386695#step:8:33