### PR TITLE
kernel: sched: Fix meta-IRQ preemption tracking for the idle thread

### DIFF
--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -273,7 +273,7 @@ static void update_metairq_preempt(struct k_thread *thread)
 	    !thread_is_preemptible(_current)) {
 		/* Record new preemption */
 		_current_cpu->metairq_preempted = _current;
-	} else if (!thread_is_metairq(thread) && !z_is_idle_thread_object(thread)) {
+	} else if (!thread_is_metairq(thread)) {
 		/* Returning from existing preemption */
 		_current_cpu->metairq_preempted = NULL;
 	}


### PR DESCRIPTION
When the PM subsystem is enabled, the idle thread locks the scheduler for the duration the system is suspended. If a meta-IRQ preempts the idle thread in this state, the idle thread is tracked in `metairq_preempted`. However, when returning from the preemption, the idle thread is not removed from `metairq_preempted`, unlike all the other threads. As a result, the scheduler keeps running the idle thread even if there are higher priority threads ready to run.

This change treats the idle thread the same way as all other threads when returning from a meta-IRQ preemption.

Fixes #64705