### PR TITLE
drivers + samples: Update APIs to use DEVICE_API macro

### DIFF
--- a/drivers/adc/adc_ads131m02.c
+++ b/drivers/adc/adc_ads131m02.c
@@ -648,7 +648,7 @@ int ads131m02_set_power_mode(const struct device *dev,
 	return ads131m02_reg_write(dev, ADS131M02_CLOCK_REG, temp);
 }
 
-static const struct adc_driver_api ads131m02_api = {
+static DEVICE_API(adc, ads131m02_api) = {
 	.channel_setup = ads131m02_channel_setup,
 	.read = ads131m02_read,
 	.ref_internal = ADS131M02_REF_INTERNAL,

--- a/drivers/clock_control/clock_control_nrf2_global_hsfll.c
+++ b/drivers/clock_control/clock_control_nrf2_global_hsfll.c
@@ -132,7 +132,7 @@ static int api_cancel_or_release_global_hsfll(const struct device *dev,
 	return -EINVAL;
 }
 
-static struct nrf_clock_control_driver_api driver_api = {
+static DEVICE_API(nrf_clock_control, driver_api) = {
 	.std_api = {
 		.on = api_nosys_on_off,
 		.off = api_nosys_on_off,

--- a/drivers/dac/dac_max22017.c
+++ b/drivers/dac/dac_max22017.c
@@ -211,7 +211,7 @@ fail:
 	return ret;
 }
 
-static const struct dac_driver_api max22017_driver_api = {
+static DEVICE_API(dac, max22017_driver_api) = {
 	.channel_setup = max22017_channel_setup,
 	.write_value = max22017_write_value,
 };

--- a/drivers/dma/dma_ifx_cat1.c
+++ b/drivers/dma/dma_ifx_cat1.c
@@ -674,7 +674,7 @@ static void ifx_cat1_dma_isr(struct ifx_cat1_dma_irq_context *irq_context)
 	}
 }
 
-static const struct dma_driver_api ifx_cat1_dma_api = {
+static DEVICE_API(dma, ifx_cat1_dma_api) = {
 	.config = ifx_cat1_dma_configure,
 	.start = ifx_cat1_dma_start,
 	.stop = ifx_cat1_dma_stop,

--- a/drivers/ethernet/phy/phy_microchip_t1s.c
+++ b/drivers/ethernet/phy/phy_microchip_t1s.c
@@ -531,7 +531,7 @@ static int phy_mc_t1s_init(const struct device *dev)
 	return 0;
 }
 
-static const struct ethphy_driver_api mc_t1s_phy_api = {
+static DEVICE_API(ethphy, mc_t1s_phy_api) = {
 	.get_link = phy_mc_t1s_get_link,
 	.cfg_link = phy_mc_t1s_cfg_link,
 	.link_cb_set = phy_mc_t1s_link_cb_set,

--- a/drivers/gpio/gpio_max22017.c
+++ b/drivers/gpio/gpio_max22017.c
@@ -383,7 +383,7 @@ static int gpio_adi_max22017_init(const struct device *dev)
 	return 0;
 }
 
-static const struct gpio_driver_api gpio_adi_max22017_api = {
+static DEVICE_API(gpio, gpio_adi_max22017_api) = {
 	.pin_configure = gpio_adi_max22017_configure,
 	.port_set_masked_raw = gpio_adi_max22017_port_set_masked_raw,
 	.port_set_bits_raw = gpio_adi_max22017_port_set_bits_raw,

--- a/drivers/gpio/gpio_mchp_mec5.c
+++ b/drivers/gpio/gpio_mchp_mec5.c
@@ -475,7 +475,7 @@ static void gpio_mec5_port_isr(const struct device *dev)
 }
 
 /* GPIO driver official API table */
-static const struct gpio_driver_api gpio_mec5_driver_api = {
+static DEVICE_API(gpio, gpio_mec5_driver_api) = {
 	.pin_configure = gpio_mec5_configure,
 	.port_get_raw = gpio_mec5_port_get_raw,
 	.port_set_masked_raw = gpio_mec5_port_set_masked_raw,

--- a/drivers/gpio/gpio_sy1xx.c
+++ b/drivers/gpio/gpio_sy1xx.c
@@ -150,7 +150,7 @@ int sy1xx_gpio_driver_port_toggle_bits(const struct device *dev, gpio_port_pins_
 }
 
 /* Define the GPIO API structure */
-static const struct gpio_driver_api sy1xx_gpio_driver_api = {
+static DEVICE_API(gpio, sy1xx_gpio_driver_api) = {
 	.pin_configure = sy1xx_gpio_driver_configure,
 	.port_get_raw = sy1xx_gpio_driver_port_get_raw,
 	.port_set_masked_raw = sy1xx_gpio_driver_port_set_masked_raw,

--- a/drivers/mdio/mdio_lan865x.c
+++ b/drivers/mdio/mdio_lan865x.c
@@ -62,12 +62,14 @@ static int lan865x_mdio_c45_write(const struct device *dev, uint8_t prtad, uint8
 	return eth_lan865x_mdio_c45_write(cfg->dev, prtad, devad, regad, data);
 }
 
-static const struct mdio_driver_api mdio_lan865x_api = {.read = lan865x_mdio_c22_read,
-							.write = lan865x_mdio_c22_write,
-							.read_c45 = lan865x_mdio_c45_read,
-							.write_c45 = lan865x_mdio_c45_write,
-							.bus_enable = lan865x_mdio_bus_enable,
-							.bus_disable = lan865x_mdio_bus_disable};
+static DEVICE_API(mdio, mdio_lan865x_api) = {
+	.read = lan865x_mdio_c22_read,
+	.write = lan865x_mdio_c22_write,
+	.read_c45 = lan865x_mdio_c45_read,
+	.write_c45 = lan865x_mdio_c45_write,
+	.bus_enable = lan865x_mdio_bus_enable,
+	.bus_disable = lan865x_mdio_bus_disable,
+};
 
 #define MICROCHIP_LAN865X_MDIO_INIT(n)                                                             \
 	static const struct mdio_lan865x_config mdio_lan865x_config_##n = {                        \

--- a/drivers/pwm/pwm_renesas_ra.c
+++ b/drivers/pwm/pwm_renesas_ra.c
@@ -437,7 +437,7 @@ static void fsp_callback(timer_callback_args_t *p_args)
 
 #endif /* CONFIG_PWM_CAPTURE */
 
-static const struct pwm_driver_api pwm_renesas_ra_driver_api = {
+static DEVICE_API(pwm, pwm_renesas_ra_driver_api) = {
 	.get_cycles_per_sec = pwm_renesas_ra_get_cycles_per_sec,
 	.set_cycles = pwm_renesas_ra_set_cycles,
 #ifdef CONFIG_PWM_CAPTURE

--- a/drivers/rtc/rtc_rv8803.c
+++ b/drivers/rtc/rtc_rv8803.c
@@ -826,7 +826,7 @@ static int rv8803_init(const struct device *dev)
 	return 0;
 }
 
-static const struct rtc_driver_api rv8803_driver_api = {
+static DEVICE_API(rtc, rv8803_driver_api) = {
 	.set_time = rv8803_set_time,
 	.get_time = rv8803_get_time,
 #ifdef CONFIG_RTC_ALARM

--- a/drivers/sensor/ti/tmp435/tmp435.c
+++ b/drivers/sensor/ti/tmp435/tmp435.c
@@ -143,7 +143,7 @@ static int tmp435_channel_get(const struct device *dev, enum sensor_channel chan
 	return ret;
 }
 
-static const struct sensor_driver_api tmp435_driver_api = {
+static DEVICE_API(sensor, tmp435_driver_api) = {
 	.sample_fetch = tmp435_sample_fetch,
 	.channel_get = tmp435_channel_get,
 };

--- a/drivers/serial/uart_mchp_mec5.c
+++ b/drivers/serial/uart_mchp_mec5.c
@@ -591,7 +591,7 @@ static void uart_mec5_isr(const struct device *dev)
 }
 #endif /* CONFIG_UART_INTERRUPT_DRIVEN */
 
-static const struct uart_driver_api uart_mec5_driver_api = {
+static DEVICE_API(uart, uart_mec5_driver_api) = {
 	.poll_in = uart_mec5_poll_in,
 	.poll_out = uart_mec5_poll_out,
 #ifdef CONFIG_UART_USE_RUNTIME_CONFIGURE

--- a/samples/userspace/prod_consumer/src/sample_driver_foo.c
+++ b/samples/userspace/prod_consumer/src/sample_driver_foo.c
@@ -65,7 +65,7 @@ static int sample_driver_foo_state_set(const struct device *dev, bool active)
 	return 0;
 }
 
-static struct sample_driver_api sample_driver_foo_api = {
+static DEVICE_API(sample, sample_driver_foo_api) = {
 	.write = sample_driver_foo_write,
 	.set_callback = sample_driver_foo_set_callback,
 	.state_set = sample_driver_foo_state_set


### PR DESCRIPTION
Some drivers APIs were not wrapped using the DEVICE_API macro.