### PR TITLE
net: tls_credentials: Do not free slot when cred buf is NULL

### DIFF
--- a/subsys/net/lib/tls_credentials/tls_credentials_shell.c
+++ b/subsys/net/lib/tls_credentials/tls_credentials_shell.c
@@ -561,7 +561,7 @@ static int tls_cred_cmd_del(const struct shell *sh, size_t argc, char *argv[])
 		goto cleanup;
 	}
 
-	ref_slot = find_ref_slot(cred->buf);
+	ref_slot = cred->buf != NULL ? find_ref_slot(cred->buf) : -1;
 	if (ref_slot >= 0) {
 		/* This was a credential we copied to heap. Clear and free it. */
 		memset((void *)cred_buf, 0, cred->len);


### PR DESCRIPTION
Do not free the slot when cred buf is NULL.
If the TLS credential storage backend does not have a buffer pointer to the TLS credential, then the buffer pointer can be NULL. This may happen with an out-of-tree TLS credential storage backend.

In this case where credential buffer is NULL find_ref_slot retrieves a new slot, and then tries to free it, causing a crash.