### PR TITLE
mesh: Fix common.h issue in onoff_level_lighting_vnd_app

### DIFF
--- a/samples/boards/nordic/mesh/onoff_level_lighting_vnd_app/CMakeLists.txt
+++ b/samples/boards/nordic/mesh/onoff_level_lighting_vnd_app/CMakeLists.txt
@@ -18,7 +18,7 @@ target_sources(app PRIVATE
 	       src/mesh/transition.c
 	       )
 
-zephyr_include_directories(
+target_include_directories(app PRIVATE
 	src/
 	src/mesh
 )


### PR DESCRIPTION
-Mbed TLS requires common.h to build. The sample provides common.h
 in sample folder level but included the path to zephyr_interface.
 This commit changes the include to be sample-specific