### PR TITLE
drivers: sensor: mpu6050: adds samplerate divider setting

### DIFF
--- a/drivers/sensor/tdk/mpu6050/Kconfig
+++ b/drivers/sensor/tdk/mpu6050/Kconfig
@@ -53,20 +53,4 @@ config MPU6050_THREAD_STACK_SIZE
 	help
 	  Stack size of thread used by the driver to handle interrupts.
 
-config MPU6050_ACCEL_FS
-	int "Accelerometer full-scale range"
-	default 2
-	help
-	  Magnetometer full-scale range.
-	  An X value for the config represents a range of +/- X g. Valid
-	  values are 2, 4, 8 and 16.
-
-config MPU6050_GYRO_FS
-	int "Gyroscope full-scale range"
-	default 250
-	help
-	  Gyroscope full-scale range.
-	  An X value for the config represents a range of +/- X degrees/second.
-	  Valid values are 250, 500, 1000, 2000.
-
 endif # MPU6050

--- a/drivers/sensor/tdk/mpu6050/mpu6050.c
+++ b/drivers/sensor/tdk/mpu6050/mpu6050.c
@@ -186,7 +186,7 @@ int mpu6050_init(const struct device *dev)
 
 	/* set accelerometer full-scale range */
 	for (i = 0U; i < 4; i++) {
-		if (BIT(i+1) == CONFIG_MPU6050_ACCEL_FS) {
+		if (BIT(i+1) == cfg->accel_fs) {
 			break;
 		}
 	}
@@ -206,7 +206,7 @@ int mpu6050_init(const struct device *dev)
 
 	/* set gyroscope full-scale range */
 	for (i = 0U; i < 4; i++) {
-		if (BIT(i) * 250 == CONFIG_MPU6050_GYRO_FS) {
+		if (BIT(i) * 250 == cfg->gyro_fs) {
 			break;
 		}
 	}
@@ -223,6 +223,12 @@ int mpu6050_init(const struct device *dev)
 	}
 
 	drv_data->gyro_sensitivity_x10 = mpu6050_gyro_sensitivity_x10[i];
+
+	if (i2c_reg_write_byte_dt(&cfg->i2c, MPU6050_REG_SMPLRT_DIV,
+				  cfg->smplrt_div) < 0) {
+		LOG_ERR("Failed to write samplerate divider.");
+		return -EIO;
+	}
 
 #ifdef CONFIG_MPU6050_TRIGGER
 	if (cfg->int_gpio.port) {
@@ -241,6 +247,9 @@ int mpu6050_init(const struct device *dev)
 												\
 	static const struct mpu6050_config mpu6050_config_##inst = {				\
 		.i2c = I2C_DT_SPEC_INST_GET(inst),						\
+		.accel_fs = DT_INST_PROP(inst, accel_fs),					\
+		.gyro_fs = DT_INST_PROP(inst, gyro_fs),						\
+		.smplrt_div = DT_INST_PROP(inst, smplrt_div),					\
 		IF_ENABLED(CONFIG_MPU6050_TRIGGER,						\
 			   (.int_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, int_gpios, { 0 }),))	\
 	};											\

--- a/drivers/sensor/tdk/mpu6050/mpu6050.h
+++ b/drivers/sensor/tdk/mpu6050/mpu6050.h
@@ -20,6 +20,8 @@
 #define MPU9250_CHIP_ID			0x71
 #define MPU6880_CHIP_ID			0x19
 
+#define MPU6050_REG_SMPLRT_DIV		0x19
+
 #define MPU6050_REG_GYRO_CFG		0x1B
 #define MPU6050_GYRO_FS_SHIFT		3
 
@@ -80,6 +82,9 @@ struct mpu6050_data {
 
 struct mpu6050_config {
 	struct i2c_dt_spec i2c;
+	uint8_t accel_fs;
+	uint16_t gyro_fs;
+	uint8_t smplrt_div;
 #ifdef CONFIG_MPU6050_TRIGGER
 	struct gpio_dt_spec int_gpio;
 #endif /* CONFIG_MPU6050_TRIGGER */

--- a/dts/bindings/sensor/invensense,mpu6050.yaml
+++ b/dts/bindings/sensor/invensense,mpu6050.yaml
@@ -16,3 +16,39 @@ properties:
       The INT signal default configuration is active-high.  The
       property value should ensure the flags properly describe the
       signal that is presented to the driver.
+
+  accel-fs:
+    type: int
+    default: 2
+    description: |
+      Accelerometer full-scale range.
+      An X value represents a range of +/- X g.
+      The power-on reset state of the sensor matches the default value of 2.
+    enum:
+      - 2
+      - 4
+      - 8
+      - 16
+
+  gyro-fs:
+    type: int
+    default: 250
+    description: |
+      Gyroscope full-scale range.
+      An X value represents a range of +/- X deg/s.
+      The power-on reset state of the sensor matches the default value of 250.
+    enum:
+      - 250
+      - 500
+      - 1000
+      - 2000
+
+  smplrt-div:
+    type: int
+    default: 0
+    description: |
+      The base sample rate is 8 kHz for the gyroscope and 1 kHz for
+      the accelerometer.
+      A division factor of X sets the sample rate to: baserate / (1 + X).
+      Valid values for X are 0 through 255.
+      The power-on reset state of the sensor matches the default value of 0.

--- a/samples/sensor/mpu6050/README.rst
+++ b/samples/sensor/mpu6050/README.rst
@@ -12,8 +12,8 @@ This sample application periodically (0.5 Hz) measures the sensor
 temperature, acceleration, and angular velocity, displaying the values
 on the console along with a timestamp since startup.
 
-When triggered mode is enabled the measurements are displayed at the
-rate they are produced by the sensor.
+When triggered mode is enabled the measurements are displayed at a rate
+of 32Hz governed by the sensor's internal clock and divider.
 
 Wiring
 *******

--- a/samples/sensor/mpu6050/boards/nrf52dk_nrf52832.overlay
+++ b/samples/sensor/mpu6050/boards/nrf52dk_nrf52832.overlay
@@ -10,5 +10,6 @@
 		reg = <0x68>;
 		status = "okay";
 		int-gpios = <&gpio0 11 GPIO_ACTIVE_HIGH>;
+		smplrt-div = <249>;
 	};
 };


### PR DESCRIPTION
Moves the MPU6050 accel/gyro scale settings from KConfig to Devicetree.
Adds a new setting for the MPU6050 sample rate divider register and
transmits it to the sensor upon initialization.
This helps to reduce the interrupt firing rate when combined with the
data ready trigger.
A default division factor is provided which ensures compatibility with
existing applications.
The MPU6050 sample application is extended and used for hardware tests.