### PR TITLE
secure storage: Add missing include for mbedtls_platform_zeroize

### DIFF
--- a/subsys/secure_storage/src/its/transform/aead.c
+++ b/subsys/secure_storage/src/its/transform/aead.c
@@ -5,6 +5,7 @@
 #include <zephyr/secure_storage/its/transform.h>
 #include <zephyr/secure_storage/its/transform/aead_get.h>
 #include <zephyr/sys/__assert.h>
+#include <mbedtls/platform_util.h>
 
 static psa_status_t psa_aead_crypt(psa_key_usage_t operation, secure_storage_its_uid_t uid,
 				   const uint8_t nonce

--- a/subsys/secure_storage/src/its/transform/aead_get.c
+++ b/subsys/secure_storage/src/its/transform/aead_get.c
@@ -8,6 +8,7 @@
 #include <psa/crypto.h>
 #include <string.h>
 #include <sys/types.h>
+#include <mbedtls/platform_util.h>
 
 LOG_MODULE_DECLARE(secure_storage, CONFIG_SECURE_STORAGE_LOG_LEVEL);
 


### PR DESCRIPTION
-Adding explicit include for mbedtls/platform_util.h to get acces
 to mbedtls_platform_zeroize in ITS. Somehow not visibile in Zephyr but
 it caused build issues in nRF Connect SDK.