### PR TITLE
samples: lvgl: enhacements for CI check updates for NXP platforms

### DIFF
--- a/boards/nxp/mimxrt1040_evk/mimxrt1040_evk.yaml
+++ b/boards/nxp/mimxrt1040_evk/mimxrt1040_evk.yaml
@@ -17,9 +17,11 @@ supported:
   - adc
   - arduino_gpio
   - counter
+  - display
   - flash
   - gpio
   - i2c
+  - lcd_if
   - pwm
   - spi
 vendor: nxp

--- a/boards/nxp/mimxrt1050_evk/mimxrt1050_evk_mimxrt1052_hyperflash.yaml
+++ b/boards/nxp/mimxrt1050_evk/mimxrt1050_evk_mimxrt1052_hyperflash.yaml
@@ -23,6 +23,7 @@ supported:
   - flash
   - gpio
   - i2c
+  - lcd_if
   - netif:eth
   - sdhc
   - spi

--- a/boards/nxp/mimxrt1050_evk/mimxrt1050_evk_mimxrt1052_qspi.yaml
+++ b/boards/nxp/mimxrt1050_evk/mimxrt1050_evk_mimxrt1052_qspi.yaml
@@ -23,6 +23,7 @@ supported:
   - flash
   - gpio
   - i2c
+  - lcd_if
   - netif:eth
   - sdhc
   - spi

--- a/boards/nxp/mimxrt1060_evk/mimxrt1060_evk_mimxrt1062_hyperflash.yaml
+++ b/boards/nxp/mimxrt1060_evk/mimxrt1060_evk_mimxrt1062_hyperflash.yaml
@@ -24,6 +24,7 @@ supported:
   - flash
   - gpio
   - i2c
+  - lcd_if
   - netif:eth
   - pwm
   - sdhc

--- a/boards/nxp/mimxrt1060_evk/mimxrt1060_evk_mimxrt1062_qspi.yaml
+++ b/boards/nxp/mimxrt1060_evk/mimxrt1060_evk_mimxrt1062_qspi.yaml
@@ -26,6 +26,7 @@ supported:
   - flash
   - gpio
   - i2c
+  - lcd_if
   - netif:eth
   - pwm
   - sdhc

--- a/boards/nxp/mimxrt1060_evk/mimxrt1060_evk_mimxrt1062_qspi_B.yaml
+++ b/boards/nxp/mimxrt1060_evk/mimxrt1060_evk_mimxrt1062_qspi_B.yaml
@@ -25,6 +25,7 @@ supported:
   - dma
   - gpio
   - i2c
+  - lcd_if
   - netif:eth
   - sdhc
   - spi

--- a/boards/nxp/mimxrt1060_evk/mimxrt1060_evk_mimxrt1062_qspi_C.yaml
+++ b/boards/nxp/mimxrt1060_evk/mimxrt1060_evk_mimxrt1062_qspi_C.yaml
@@ -25,6 +25,7 @@ supported:
   - dma
   - gpio
   - i2c
+  - lcd_if
   - netif:eth
   - sdhc
   - spi

--- a/boards/nxp/mimxrt1064_evk/mimxrt1064_evk.yaml
+++ b/boards/nxp/mimxrt1064_evk/mimxrt1064_evk.yaml
@@ -25,6 +25,7 @@ supported:
   - gpio
   - hwinfo
   - i2c
+  - lcd_if
   - netif:eth
   - pwm
   - sdhc

--- a/boards/nxp/mimxrt1160_evk/mimxrt1160_evk_mimxrt1166_cm7.yaml
+++ b/boards/nxp/mimxrt1160_evk/mimxrt1160_evk_mimxrt1166_cm7.yaml
@@ -17,10 +17,12 @@ supported:
   - can
   - counter
   - dma
+  - display
   - flash
   - gpio
   - hwinfo
   - i2c
+  - mipi_dsi
   - netif:eth
   - pwm
   - spi

--- a/boards/nxp/mimxrt595_evk/mimxrt595_evk_mimxrt595s_cm33.yaml
+++ b/boards/nxp/mimxrt595_evk/mimxrt595_evk_mimxrt595s_cm33.yaml
@@ -20,10 +20,12 @@ supported:
   - counter
   - dma
   - dmic
+  - display
   - flash
   - gpio
   - i2c
   - i2s
+  - mipi_dsi
   - pwm
   - sdhc
   - spi

--- a/dts/arm/nxp/nxp_rt5xx_common.dtsi
+++ b/dts/arm/nxp/nxp_rt5xx_common.dtsi
@@ -650,6 +650,7 @@
 		#size-cells = <0>;
 		reg = <0x31000 0x1000>;
 		interrupts = <71 0>;
+		phy-clock = <748154880>;
 		clocks = <&clkctl1 MCUX_MIPI_DSI_DPHY_CLK>,
 			<&clkctl1 MCUX_MIPI_DSI_ESC_CLK>,
 			<&clkctl1 MCUX_LCDIF_PIXEL_CLK>;

--- a/samples/subsys/display/lvgl/boards/mimxrt1060_evk.conf
+++ b/samples/subsys/display/lvgl/boards/mimxrt1060_evk.conf
@@ -1,8 +1,0 @@
-# Copyright 2023 NXP
-# SPDX-License-Identifier: Apache-2.0
-
-# Enable PXP DMA engine and set rotation angle to 0 degrees.
-# This allows us to verify the DMA driver functions without altering
-# the output image
-CONFIG_DMA=y
-CONFIG_MCUX_ELCDIF_PXP=y

--- a/samples/subsys/display/lvgl/boards/mimxrt1170_evk_mimxrt1176_cm7_A.conf
+++ b/samples/subsys/display/lvgl/boards/mimxrt1170_evk_mimxrt1176_cm7_A.conf
@@ -1,8 +1,0 @@
-# Copyright 2023 NXP
-# SPDX-License-Identifier: Apache-2.0
-
-# Enable PXP DMA engine and set rotation angle to 0 degrees.
-# This allows us to verify the DMA driver functions without altering
-# the output image
-CONFIG_DMA=y
-CONFIG_MCUX_ELCDIF_PXP=y

--- a/samples/subsys/display/lvgl/nxp_elcdif_pxp.conf
+++ b/samples/subsys/display/lvgl/nxp_elcdif_pxp.conf
@@ -1,0 +1,4 @@
+# Copyright 2025 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_MAIN_STACK_SIZE=20480

--- a/samples/subsys/display/lvgl/nxp_mipi.conf
+++ b/samples/subsys/display/lvgl/nxp_mipi.conf
@@ -1,0 +1,6 @@
+# Copyright 2025 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_DMA=y
+CONFIG_MAIN_STACK_SIZE=20480
+CONFIG_MIPI_DSI=y

--- a/samples/subsys/display/lvgl/sample.yaml
+++ b/samples/subsys/display/lvgl/sample.yaml
@@ -46,6 +46,18 @@ tests:
     harness: console
     harness_config:
       fixture: fixture_display
+      type: multi_line
+      regex:
+        - "lvgl sample"
+        - "run"
+    modules:
+      - lvgl
+    tags:
+      - samples
+      - display
+      - shield
+      - lvgl
+      - gui
   sample.subsys.display.lvgl.st_b_lcd40_dsi1_mb1166_a09:
     tags: shield
     filter: dt_compat_enabled("frida,nt35510")
@@ -54,21 +66,37 @@ tests:
     harness: console
     harness_config:
       fixture: fixture_display
-  sample.subsys.display.lvgl.rk043fn66hs_ctg:
-    tags: shield
+      type: multi_line
+      regex:
+        - "lvgl sample"
+        - "run"
+    modules:
+      - lvgl
+    tags:
+      - samples
+      - display
+      - shield
+      - lvgl
+      - gui
+  samples.subsys.display.lvgl.rk043fn66hs_ctg:
     platform_allow:
       - mimxrt1064_evk
       - mimxrt1060_evk/mimxrt1062/qspi
+      - mimxrt1060_evk@C/mimxrt1062/qspi
       - mimxrt1050_evk/mimxrt1052/hyperflash
       - mimxrt1040_evk
     integration_platforms:
       - mimxrt1040_evk
-    harness: console
+    tags: display
     extra_args: SHIELD=rk043fn66hs_ctg
+    harness: console
     harness_config:
       fixture: fixture_display_rk043fn66hs_ctg
-  sample.subsys.display.lvgl.rk043fn02h_ct:
-    tags: shield
+      type: multi_line
+      regex:
+        - "lvgl sample"
+        - "run"
+  samples.subsys.display.lvgl.rk043fn02h_ct:
     platform_allow:
       - mimxrt1064_evk
       - mimxrt1060_evk@C/mimxrt1062/qspi
@@ -80,14 +108,21 @@ tests:
     extra_args: SHIELD=rk043fn02h_ct
     harness_config:
       fixture: fixture_display_rk043fn02h_ct
-  sample.subsys.display.lvgl.rtkmipilcdb00000be:
-    tags: shield
+      type: multi_line
+      regex:
+        - "lvgl sample"
+        - "run"
+  samples.subsys.display.lvgl.rtkmipilcdb00000be:
     platform_allow:
       - ek_ra8d1
     harness: console
     extra_args: SHIELD=rtkmipilcdb00000be
     harness_config:
       fixture: fixture_display
+      type: multi_line
+      regex:
+        - "lvgl sample"
+        - "run"
   sample.subsys.display.lvgl.seeed_xiao_round_display:
     tags: shield
     min_flash: 320
@@ -104,3 +139,7 @@ tests:
     harness: console
     harness_config:
       fixture: fixture_seeed_xiao_round_display
+      type: multi_line
+      regex:
+        - "lvgl sample"
+        - "run"

--- a/samples/subsys/display/lvgl/sample.yaml
+++ b/samples/subsys/display/lvgl/sample.yaml
@@ -22,6 +22,10 @@ tests:
     integration_platforms:
       - native_sim/native/64
   sample.display.lvgl.rk055hdmipi4m:
+    depends_on: mipi_dsi
+    filter: (CONFIG_MIPI_DSI_MCUX or CONFIG_MIPI_DSI_MCUX_2L)
+            and dt_chosen_enabled("zephyr,display")
+            and dt_compat_enabled("goodix,gt911")
     tags: shield
     # This sample is intended to test the RT1170 and RT595, which require
     # a display shield to work with LVGL
@@ -29,17 +33,44 @@ tests:
     # The minimum RAM needed for this display is actually around 8MB,
     # but the RT595 uses external PSRAM for the display buffer
     min_ram: 32
-    harness: none
-    extra_args: SHIELD="rk055hdmipi4m"
-    platform_allow:
-      - mimxrt1170_evk/mimxrt1176/cm7
-      - mimxrt595_evk/mimxrt595s/cm33
+    harness: console
+    extra_args:
+      - SHIELD="rk055hdmipi4m"
+      - EXTRA_CONF_FILE="nxp_mipi.conf"
     integration_platforms:
       - mimxrt1170_evk/mimxrt1176/cm7
     harness_config:
       fixture: fixture_display_rk055hdmipi4m
-  sample.subsys.display.lvgl.st_b_lcd40_dsi1_mb1166:
+      type: multi_line
+      regex:
+        - "lvgl sample"
+        - "run"
+
+  sample.display.lvgl.rk055hdmipi4ma0:
+    depends_on: mipi_dsi
+    filter: (CONFIG_MIPI_DSI_MCUX or CONFIG_MIPI_DSI_MCUX_2L)
+            and dt_chosen_enabled("zephyr,display")
+            and dt_compat_enabled("goodix,gt911")
     tags: shield
+    # This sample is intended to test the RT1170 and RT595, which require
+    # a display shield to work with LVGL
+    min_flash: 250
+    # The minimum RAM needed for this display is actually around 8MB,
+    # but the RT595 uses external PSRAM for the display buffer
+    min_ram: 32
+    harness: console
+    extra_args:
+      - SHIELD="rk055hdmipi4ma0"
+      - EXTRA_CONF_FILE="nxp_mipi.conf"
+    integration_platforms:
+      - mimxrt1170_evk/mimxrt1176/cm7
+    harness_config:
+      fixture: fixture_display_rk055hdmipi4ma0
+      type: multi_line
+      regex:
+        - "lvgl sample"
+        - "run"
+  sample.subsys.display.lvgl.st_b_lcd40_dsi1_mb1166:
     filter: dt_compat_enabled("orisetech,otm8009a")
     platform_allow: stm32h747i_disco/stm32h747xx/m7
     extra_args: SHIELD=st_b_lcd40_dsi1_mb1166
@@ -59,7 +90,6 @@ tests:
       - lvgl
       - gui
   sample.subsys.display.lvgl.st_b_lcd40_dsi1_mb1166_a09:
-    tags: shield
     filter: dt_compat_enabled("frida,nt35510")
     platform_allow: stm32h747i_disco/stm32h747xx/m7
     extra_args: SHIELD=st_b_lcd40_dsi1_mb1166_a09
@@ -79,16 +109,16 @@ tests:
       - lvgl
       - gui
   samples.subsys.display.lvgl.rk043fn66hs_ctg:
-    platform_allow:
-      - mimxrt1064_evk
-      - mimxrt1060_evk/mimxrt1062/qspi
-      - mimxrt1060_evk@C/mimxrt1062/qspi
-      - mimxrt1050_evk/mimxrt1052/hyperflash
-      - mimxrt1040_evk
+    depends_on: lcd_if
+    filter: CONFIG_DISPLAY_MCUX_ELCDIF
+            and dt_chosen_enabled("zephyr,display")
+            and dt_compat_enabled("goodix,gt911")
     integration_platforms:
       - mimxrt1040_evk
     tags: display
-    extra_args: SHIELD=rk043fn66hs_ctg
+    extra_args:
+      - SHIELD=rk043fn66hs_ctg
+      - EXTRA_CONF_FILE="nxp_elcdif_pxp.conf"
     harness: console
     harness_config:
       fixture: fixture_display_rk043fn66hs_ctg
@@ -97,15 +127,16 @@ tests:
         - "lvgl sample"
         - "run"
   samples.subsys.display.lvgl.rk043fn02h_ct:
-    platform_allow:
-      - mimxrt1064_evk
-      - mimxrt1060_evk@C/mimxrt1062/qspi
-      - mimxrt1050_evk/mimxrt1052/hyperflash
-      - mimxrt1040_evk
+    depends_on: lcd_if
+    filter: CONFIG_DISPLAY_MCUX_ELCDIF
+            and dt_chosen_enabled("zephyr,display")
+            and dt_compat_enabled("goodix,gt911")
     integration_platforms:
       - mimxrt1040_evk
     harness: console
-    extra_args: SHIELD=rk043fn02h_ct
+    extra_args:
+      - SHIELD=rk043fn02h_ct
+      - EXTRA_CONF_FILE="nxp_elcdif_pxp.conf"
     harness_config:
       fixture: fixture_display_rk043fn02h_ct
       type: multi_line

--- a/samples/subsys/display/lvgl/src/main.c
+++ b/samples/subsys/display/lvgl/src/main.c
@@ -144,10 +144,12 @@ int main(void)
 	lv_timer_handler();
 	display_blanking_off(display_dev);
 
+	printf("lvgl sample\n");
 	while (1) {
 		if ((count % 100) == 0U) {
 			sprintf(count_str, "%d", count/100U);
 			lv_label_set_text(count_label, count_str);
+			printf("run %u\n", count/100U);
 		}
 		lv_timer_handler();
 		++count;


### PR DESCRIPTION
fix runtime memory issue on mimxrt1060_evkc
also add regx support for this sample, so twsiter can run this sample in board CI.
remove NXP cases constrains with platform_allow, now it is based on tags and dts/kconfig.
Also fix a build issue in rt595 when display feature is in support list.


fixes: #84456