### PR TITLE
i2c_shell: add missing i3c include

### DIFF
--- a/drivers/i2c/i2c_shell.c
+++ b/drivers/i2c/i2c_shell.c
@@ -5,6 +5,7 @@
  */
 
 #include <zephyr/drivers/i2c.h>
+#include <zephyr/drivers/i3c.h>
 #include <zephyr/shell/shell.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
This is necessary for the I3C device type check, tested with:

west build -p -b nucleo_h563zi samples/subsys/shell/shell_module -DCONFIG_I2C=y -DCONFIG_I2C_SHELL=y -DCONFIG_I3C=y

and

west build -p -b nucleo_h563zi samples/subsys/shell/shell_module -DCONFIG_I2C=y -DCONFIG_I2C_SHELL=y -DCONFIG_I3C=n