### PR TITLE
kernel: minor SMP clean up

### DIFF
--- a/kernel/include/kswap.h
+++ b/kernel/include/kswap.h
@@ -124,7 +124,6 @@ static ALWAYS_INLINE unsigned int do_swap(unsigned int key,
 		z_sched_usage_switch(new_thread);
 
 #ifdef CONFIG_SMP
-		_current_cpu->swap_ok = 0;
 		new_thread->base.cpu = arch_curr_cpu()->id;
 
 		if (!is_spinlock) {

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -1048,9 +1048,6 @@ void z_impl_k_yield(void)
 
 	k_spinlock_key_t key = k_spin_lock(&_sched_spinlock);
 
-#ifdef CONFIG_SMP
-	z_mark_thread_as_queued(_current);
-#endif
 	runq_yield();
 
 	update_cache(1);


### PR DESCRIPTION
1. k_yield() does not need to mark the current thread as queued for SMP--that will get done automatically by do_swap().
2. Removes a superfluous clearing of the swap_ok field in the SMP case of do_swap()--that was already done by next_up() which was called previously by z_swap_next_thread().