### PR TITLE
mbedtls: Separate psa_crypto_init in its own SYS_INIT

### DIFF
--- a/modules/mbedtls/CMakeLists.txt
+++ b/modules/mbedtls/CMakeLists.txt
@@ -119,6 +119,10 @@ zephyr_interface_library_named(mbedTLS)
       zephyr_entropy.c
     )
 
+    if(CONFIG_MBEDTLS_PSA_CRYPTO_CLIENT)
+      list(APPEND mbedtls_base_src psa_init.c)
+    endif()
+
     zephyr_library_sources(${mbedtls_base_src})
 
     zephyr_library_sources_ifdef(CONFIG_MBEDTLS_DEBUG debug.c)

--- a/modules/mbedtls/psa_init.c
+++ b/modules/mbedtls/psa_init.c
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <errno.h>
+#include <zephyr/init.h>
+#include <psa/crypto.h>
+
+static int _psa_crypto_init(void)
+{
+	if (psa_crypto_init() != PSA_SUCCESS) {
+		return -EIO;
+	}
+
+	return 0;
+}
+
+/* Enforcing initialization of PSA crypto before any other users
+ * like entropy_psa_crypto (which has a higher priority number).
+ * This is done without dependency on CONFIG_MBEDTLS_INIT.
+ */
+SYS_INIT(_psa_crypto_init, PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);

--- a/modules/mbedtls/zephyr_init.c
+++ b/modules/mbedtls/zephyr_init.c
@@ -1,9 +1,3 @@
-/** @file
- * @brief mbed TLS initialization
- *
- * Initialize the mbed TLS library like setup the heap etc.
- */
-
 /*
  * Copyright (c) 2017 Intel Corporation
  * Copyright (c) 2024 Nordic Semiconductor ASA
@@ -51,12 +45,6 @@ static int _mbedtls_init(void)
 
 #if defined(CONFIG_MBEDTLS_DEBUG_LEVEL)
 	mbedtls_debug_set_threshold(CONFIG_MBEDTLS_DEBUG_LEVEL);
-#endif
-
-#if defined(CONFIG_MBEDTLS_PSA_CRYPTO_CLIENT)
-	if (psa_crypto_init() != PSA_SUCCESS) {
-		return -EIO;
-	}
 #endif
 
 	return 0;


### PR DESCRIPTION
-This commit adds psa_init.c that contains a SYS_INIT to enforce
 early initialization of PSA crypto by calling psa_crypto_init() in
 PRE_KERNEL_1, before any other users (include entropy_psa_crypto).
-This is separated from CONFIG_MBEDTLS_INIT which has a SYS_INIT that
 happens in POST_KERNEL and include initializing the Mbed TLS heap
 if this is enabled.