### PR TITLE
tests: kernel: pipe: Use zephyr_compile_options instead of CMAKE_C_FLAGS

### DIFF
--- a/tests/kernel/pipe/deprecated/pipe/CMakeLists.txt
+++ b/tests/kernel/pipe/deprecated/pipe/CMakeLists.txt
@@ -4,5 +4,6 @@ cmake_minimum_required(VERSION 3.20.0)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(pipe)
 
+zephyr_compile_options(-Wno-error=deprecated-declarations)
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/kernel/pipe/deprecated/pipe/testcase.yaml
+++ b/tests/kernel/pipe/deprecated/pipe/testcase.yaml
@@ -4,4 +4,3 @@ tests:
       - kernel
       - userspace
     ignore_faults: true
-    extra_args: CMAKE_C_FLAGS="-D__deprecated='' -D__DEPRECATED_MACRO=''"

--- a/tests/kernel/pipe/deprecated/pipe_api/CMakeLists.txt
+++ b/tests/kernel/pipe/deprecated/pipe_api/CMakeLists.txt
@@ -4,5 +4,6 @@ cmake_minimum_required(VERSION 3.20.0)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(pipe_api)
 
+zephyr_compile_options(-Wno-error=deprecated-declarations)
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/kernel/pipe/deprecated/pipe_api/testcase.yaml
+++ b/tests/kernel/pipe/deprecated/pipe_api/testcase.yaml
@@ -3,4 +3,3 @@ tests:
     tags:
       - kernel
       - userspace
-    extra_args: CMAKE_C_FLAGS="-D__deprecated='' -D__DEPRECATED_MACRO=''"


### PR DESCRIPTION
Replace the previous -DCMAKE_C_FLAGS definition with zephyr_compile_options to ensure compatibility with both sysbuild and CMake builds.