### PR TITLE
samples: dac: simplify meta data

### DIFF
--- a/samples/drivers/dac/Kconfig
+++ b/samples/drivers/dac/Kconfig
@@ -1,0 +1,16 @@
+# Private config options for dac sample
+
+# Copyright (c) 2025 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+mainmenu "DAC sample application"
+
+source "Kconfig.zephyr"
+
+ZEPHYR_USER := zephyr,user
+
+config DAC_SAMPLE_RUN
+	bool "Run DAC sample application"
+	default y if $(dt_node_has_prop,/$(ZEPHYR_USER),dac)
+	help
+	  platform supports dac sample

--- a/samples/drivers/dac/sample.yaml
+++ b/samples/drivers/dac/sample.yaml
@@ -3,48 +3,8 @@ sample:
 tests:
   sample.drivers.dac:
     tags: DAC
-    platform_allow:
-      - arduino_zero
-      - b_u585i_iot02a
-      - bl652_dvk
-      - bl653_dvk
-      - bl654_dvk
-      - bl5340_dvk/nrf5340/cpuapp
-      - disco_l475_iot1
-      - esp32_devkitc_wroom/esp32/procpu
-      - esp32_devkitc_wrover/esp32/procpu
-      - esp32s2_saola
-      - frdm_k22f
-      - frdm_k64f
-      - gd32a503v_eval
-      - gd32e103v_eval
-      - gd32f450i_eval
-      - longan_nano
-      - longan_nano/gd32vf103/lite
-      - nucleo_f091rc
-      - nucleo_f207zg
-      - nucleo_f429zi
-      - nucleo_f746zg
-      - nucleo_f767zi
-      - nucleo_g071rb
-      - nucleo_g431rb
-      - nucleo_g474re
-      - nucleo_h743zi
-      - nucleo_l073rz
-      - nucleo_l152re
-      - nucleo_l552ze_q
-      - nucleo_u575zi_q
-      - nucleo_wl55jc
-      - sam_e70_xplained/same70q21
-      - sam_e70_xplained/same70q21b
-      - sam_v71_xult/samv71q21
-      - sam_v71_xult/samv71q21b
-      - stm32f3_disco
-      - stm32l562e_dk
-      - twr_ke18f
-      - lpcxpresso55s36
-      - rd_rw612_bga
     depends_on: dac
+    filter: CONFIG_DAC_SAMPLE_RUN
     integration_platforms:
       - nucleo_l152re
     harness: console


### PR DESCRIPTION
use config from dts to get the supporting status.
remove the platfrom_allow list.