### PR TITLE
cmsis: backport cmsis_6 IAR fix to 5.9.0

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -117,7 +117,7 @@ manifest:
       groups:
         - babblesim
     - name: cmsis
-      revision: 4b96cbb174678dcd3ca86e11e1f24bc5f8726da0
+      revision: d1b8b20b6278615b00e136374540eb1c00dcabe7
       path: modules/hal/cmsis
       groups:
         - hal


### PR DESCRIPTION
Currently IAR is broken with CMSIS 5.9.0 and we need a backport of https://github.com/ARM-software/CMSIS_6/pull/102 into CMSIS 5.9.0