### PR TITLE
Support mDNS responder probing

### DIFF
--- a/samples/net/mdns_responder/sample.yaml
+++ b/samples/net/mdns_responder/sample.yaml
@@ -12,6 +12,14 @@ tests:
       - qemu_cortex_m3
     integration_platforms:
       - qemu_x86
+  sample.net.mdns_responder.probing:
+    extra_args:
+      - CONFIG_MDNS_RESPONDER_PROBE=y
+    platform_allow:
+      - qemu_x86
+      - qemu_cortex_m3
+    integration_platforms:
+      - qemu_x86
   sample.net.mdns_responder.wifi.nrf70dk:
     extra_args:
       - SNIPPET=wifi-ipv4

--- a/subsys/net/ip/net_private.h
+++ b/subsys/net/ip/net_private.h
@@ -168,7 +168,7 @@ extern int dns_resolve_init_with_svc(struct dns_resolve_context *ctx,
 				     const char *servers[],
 				     const struct sockaddr *servers_sa[],
 				     const struct net_socket_service_desc *svc,
-				     uint16_t port);
+				     uint16_t port, int interfaces[]);
 #endif /* CONFIG_DNS_RESOLVER */
 
 #if defined(CONFIG_NET_TEST)

--- a/subsys/net/ip/net_private.h
+++ b/subsys/net/ip/net_private.h
@@ -153,6 +153,18 @@ extern void mdns_init_responder(void);
 static inline void mdns_init_responder(void) { }
 #endif /* CONFIG_MDNS_RESPONDER */
 
+#if defined(CONFIG_DNS_RESOLVER)
+#include <zephyr/net/dns_resolve.h>
+extern int dns_resolve_name_internal(struct dns_resolve_context *ctx,
+				     const char *query,
+				     enum dns_query_type type,
+				     uint16_t *dns_id,
+				     dns_resolve_cb_t cb,
+				     void *user_data,
+				     int32_t timeout,
+				     bool use_cache);
+#endif /* CONFIG_DNS_RESOLVER */
+
 #if defined(CONFIG_NET_TEST)
 extern void loopback_enable_address_swap(bool swap_addresses);
 #endif /* CONFIG_NET_TEST */

--- a/subsys/net/ip/net_private.h
+++ b/subsys/net/ip/net_private.h
@@ -163,6 +163,12 @@ extern int dns_resolve_name_internal(struct dns_resolve_context *ctx,
 				     void *user_data,
 				     int32_t timeout,
 				     bool use_cache);
+#include <zephyr/net/socket_service.h>
+extern int dns_resolve_init_with_svc(struct dns_resolve_context *ctx,
+				     const char *servers[],
+				     const struct sockaddr *servers_sa[],
+				     const struct net_socket_service_desc *svc,
+				     uint16_t port);
 #endif /* CONFIG_DNS_RESOLVER */
 
 #if defined(CONFIG_NET_TEST)

--- a/subsys/net/lib/dns/Kconfig
+++ b/subsys/net/lib/dns/Kconfig
@@ -188,6 +188,36 @@ config MDNS_RESPONDER_INIT_PRIO
 	  Note that if NET_CONFIG_AUTO_INIT is enabled, then this value
 	  should be bigger than its value.
 
+config MDNS_RESPONDER_PROBE
+	bool "mDNS probing support [EXPERIMENTAL]"
+	select NET_CONNECTION_MANAGER
+	select MDNS_RESOLVER
+	select DNS_RESOLVER
+	select EXPERIMENTAL
+	help
+	  Note that for probing to work, the mDNS and DNS resolver need to
+	  be enabled. The probing is made optional to allow smaller memory
+	  usage.
+
+config MDNS_WORKQ_STACK_SIZE
+	int "mDNS work queue thread stack size"
+	default 1200 if X86
+	default 1024
+	depends on MDNS_RESPONDER_PROBE
+	help
+	  Set the mDNS work queue thread stack size in bytes.
+
+config MDNS_WORKER_PRIO
+	int "Priority of the mDNS work queue"
+	default 2
+	depends on MDNS_RESPONDER_PROBE
+	help
+	  Set the priority of the mDNS worker queue, that handles all
+	  mDNS probing. Value 0 = highest priortity.
+	  When CONFIG_NET_TC_THREAD_COOPERATIVE = y, lowest priority is
+	  CONFIG_NUM_COOP_PRIORITIES-1 else lowest priority is
+	  CONFIG_NUM_PREEMPT_PRIORITIES-1.
+
 config MDNS_RESPONDER_DNS_SD
 	bool "DNS Service Discovery via mDNS"
 	default y


### PR DESCRIPTION
The mDNS probing is described in RFC 6762 chapter 8.1. The code will send an unsolicited mDNS query to network and will check if there are existing hosts with the same name. If there are, then the mDNS responder will not respond to queries it is configured to use.

Fixes #84333
