### PR TITLE
k_pipe: fix trace point for blocking writes

### DIFF
--- a/kernel/pipe.c
+++ b/kernel/pipe.c
@@ -46,7 +46,11 @@ static int wait_for(_wait_q_t *waitq, struct k_pipe *pipe, k_spinlock_key_t *key
 
 	pipe->waiting++;
 	*need_resched = false;
-	SYS_PORT_TRACING_OBJ_FUNC_BLOCKING(k_pipe, read, pipe, timeout);
+	if (waitq == &pipe->space) {
+		SYS_PORT_TRACING_OBJ_FUNC_BLOCKING(k_pipe, write, pipe, timeout);
+	} else {
+		SYS_PORT_TRACING_OBJ_FUNC_BLOCKING(k_pipe, read, pipe, timeout);
+	}
 	rc = z_pend_curr(&pipe->lock, *key, waitq, timeout);
 	*key = k_spin_lock(&pipe->lock);
 	pipe->waiting--;


### PR DESCRIPTION
Fix the trace point in k_pipe wait_for.

Fixes #84486 

It checks if "waitq" points to pipe->space, in which case it is a write operation.
A read will have "waitq" point to pipe->data instead.

I'm not entirely satisfied with this fix since it relies on comparing the address passed to wait_for in order to determine which trace point to use. Maybe add another "is_read" parameter to wait_for instead?

If anyone has a better way of doing this please let me know.

Signed-off-by: Erik Tamlin <erik.tamlin@percepio.com>