### PR TITLE
drivers: wifi: esp32: connect to highest signal AP

### DIFF
--- a/drivers/wifi/esp32/Kconfig.esp32
+++ b/drivers/wifi/esp32/Kconfig.esp32
@@ -54,6 +54,13 @@ config ESP32_WIFI_STA_RECONNECT
 	help
 	  Set auto WiFI reconnection when disconnected.
 
+config ESP32_WIFI_STA_SCAN_ALL
+	bool "Scan all available APs when connecting in station mode"
+	help
+	  When connecting in station mode, scan all channels and connect to the channel with the
+	  highest RSSI. Without this, a fast scan is performed which connects to the first AP
+	  found.
+
 config ESP32_WIFI_SW_COEXIST_ENABLE
 	bool
 	help

--- a/drivers/wifi/esp32/src/esp_wifi_drv.c
+++ b/drivers/wifi/esp32/src/esp_wifi_drv.c
@@ -568,6 +568,11 @@ static int esp32_wifi_connect(const struct device *dev,
 		return -EIO;
 	}
 
+#if defined(CONFIG_ESP32_WIFI_STA_SCAN_ALL)
+	wifi_config.sta.scan_method = WIFI_ALL_CHANNEL_SCAN;
+	wifi_config.sta.sort_method = WIFI_CONNECT_AP_BY_SIGNAL;
+#endif
+
 	if (params->channel == WIFI_CHANNEL_ANY) {
 		wifi_config.sta.channel = 0U;
 		data->status.channel = 0U;


### PR DESCRIPTION
The station-mode channel scan method is currently set to WIFI_FAST_SCAN which ignores the signal strength and connects to the first channel found which may result in poor WiFi bandwidth.

Change the scan mode to scan all channels and connect to the channel with the highest RSSI.

Fixes #84488