### PR TITLE
tests: net: ipv6: Increase stack size for variable buf test

### DIFF
--- a/tests/net/ipv6/testcase.yaml
+++ b/tests/net/ipv6/testcase.yaml
@@ -18,6 +18,7 @@ tests:
       - CONFIG_NET_PKT_BUF_RX_DATA_POOL_SIZE=4096
       - CONFIG_NET_PKT_BUF_TX_DATA_POOL_SIZE=4096
       - CONFIG_NET_IPV6_PE=n
+      - CONFIG_TEST_EXTRA_STACK_SIZE=1024
   net.ipv6.privacy_extension.prefer_public:
     extra_configs:
       - CONFIG_NET_IPV6_PE=y


### PR DESCRIPTION
Increasing the stack size for variable_buf_size test. This avoids stack overflow in various boards.

Fixes #84489