### PR TITLE
samples: Bluetooth: GATT write commands with connection PHY Update

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/lll_conn.h
+++ b/subsys/bluetooth/controller/ll_sw/lll_conn.h
@@ -86,10 +86,14 @@ struct lll_conn {
 
 #if defined(CONFIG_BT_PERIPHERAL)
 		struct {
-			uint8_t  initiated:1;
-			uint8_t  cancelled:1;
-			uint8_t  forced:1;
-			uint8_t  latency_enabled:1;
+			uint8_t initiated:1;
+			uint8_t cancelled:1;
+			uint8_t forced:1;
+			uint8_t latency_enabled:1;
+
+#if defined(CONFIG_BT_CTLR_PHY)
+			uint8_t phy_rx_event:3;
+#endif /* CONFIG_BT_CTLR_PHY */
 
 			uint32_t window_widening_periodic_us;
 			uint32_t window_widening_max_us;

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
@@ -993,7 +993,7 @@ static void isr_done(void *param)
 
 #if defined(CONFIG_BT_CTLR_PHY)
 			preamble_to_addr_us =
-				addr_us_get(lll->phy_rx);
+				addr_us_get(lll->periph.phy_rx_event);
 #else /* !CONFIG_BT_CTLR_PHY */
 			preamble_to_addr_us =
 				addr_us_get(0);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
@@ -698,10 +698,26 @@ void lll_conn_isr_tx(void *param)
 	}
 #endif /* CONFIG_BT_CTLR_DF_CONN_CTE_TX */
 
+#if !defined(CONFIG_BOARD_NRF52_BSIM) && \
+	!defined(CONFIG_BOARD_NRF5340BSIM_NRF5340_CPUNET) && \
+	!defined(CONFIG_BOARD_NRF54L15BSIM_NRF54L15_CPUAPP)
+
 	/* +/- 2us active clock jitter, +1 us PPI to timer start compensation */
 	hcto = radio_tmr_tifs_base_get() + lll->tifs_hcto_us +
 	       (EVENT_CLOCK_JITTER_US << 1) + RANGE_DELAY_US +
 	       HAL_RADIO_TMR_START_DELAY_US;
+
+#else /* FIXME: Why different for BabbleSIM? */
+	/* HACK: Have exact 150 us */
+	hcto = radio_tmr_tifs_base_get() + lll->tifs_hcto_us;
+
+	/* HACK: Could wrong MODE register value (next in tIFS switching) being
+	 *       use for Rx Chain Delay in BabbleSIM? or is there a bug in
+	 *       target implementation?
+	 */
+	hcto += radio_rx_chain_delay_get(lll->phy_tx, PHY_FLAGS_S8);
+#endif /* FIXME: Why different for BabbleSIM? */
+
 #if defined(CONFIG_BT_CTLR_DF_CONN_CTE_TX)
 	hcto += cte_len;
 #endif /* CONFIG_BT_CTLR_DF_CONN_CTE_TX */

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_peripheral.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_peripheral.c
@@ -177,6 +177,11 @@ static int prepare_cb(struct lll_prepare_param *p)
 		lll->periph.window_size_prepare_us;
 	lll->periph.window_size_prepare_us = 0;
 
+#if defined(CONFIG_BT_CTLR_PHY)
+	/* back up rx PHY for use in drift compensation */
+	lll->periph.phy_rx_event = lll->phy_rx;
+#endif /* CONFIG_BT_CTLR_PHY */
+
 	/* Ensure that empty flag reflects the state of the Tx queue, as a
 	 * peripheral if this is the first connection event and as no prior PDU
 	 * is transmitted, an incorrect acknowledgment by peer should not

--- a/tests/bsim/bluetooth/ll/throughput/prj.conf
+++ b/tests/bsim/bluetooth/ll/throughput/prj.conf
@@ -4,13 +4,45 @@ CONFIG_BT_PERIPHERAL=y
 CONFIG_BT_SMP=y
 CONFIG_BT_GATT_CLIENT=y
 
-CONFIG_BT_BUF_ACL_RX_SIZE=255
-CONFIG_BT_BUF_ACL_TX_SIZE=251
-CONFIG_BT_BUF_CMD_TX_SIZE=255
-CONFIG_BT_BUF_EVT_DISCARDABLE_SIZE=255
-
+# Maximum L2CAP size for one LL PDU size
 CONFIG_BT_L2CAP_TX_MTU=247
 
+# Auto initiated PHY update on connection established
+CONFIG_BT_AUTO_PHY_UPDATE=y
+# Enable user initiated PHY update support
+CONFIG_BT_USER_PHY_UPDATE=y
+
+# Auto initiated Data Length update on connection established
+CONFIG_BT_AUTO_DATA_LEN_UPDATE=y
+# Enable user initiated Data Length update support
+CONFIG_BT_USER_DATA_LEN_UPDATE=y
+
+# BT HCI Command Buffers
+# Greater than BT_BUF_ACL_TX_COUNT, to be able to Send Host Number of Completed Packets commands
+CONFIG_BT_BUF_CMD_TX_COUNT=4
+CONFIG_BT_BUF_CMD_TX_SIZE=255
+
+# BT HCI Event Buffers
+# Greater than BT_BUF_ACL_TX_COUNT, to be able to receive Number of Completed Packets events
+CONFIG_BT_BUF_EVT_RX_COUNT=4
+CONFIG_BT_BUF_EVT_RX_SIZE=255
+
+# BT HCI Discardable Event Buffers
+CONFIG_BT_BUF_EVT_DISCARDABLE_COUNT=3
+CONFIG_BT_BUF_EVT_DISCARDABLE_SIZE=255
+
+# BT HCI ACL TX Data Buffers
+CONFIG_BT_BUF_ACL_TX_COUNT=3
+CONFIG_BT_BUF_ACL_TX_SIZE=251
+
+# BT HCI ACL RX Data Buffers
+CONFIG_BT_BUF_ACL_RX_COUNT_EXTRA=0
+CONFIG_BT_BUF_ACL_RX_SIZE=255
+
+# Maximum LL ACL PDU length
 CONFIG_BT_CTLR_DATA_LENGTH_MAX=251
+
+# Enable Coded PHY Support
+CONFIG_BT_CTLR_PHY_CODED=y
 
 CONFIG_LOG=y

--- a/tests/bsim/bluetooth/ll/throughput/src/main.c
+++ b/tests/bsim/bluetooth/ll/throughput/src/main.c
@@ -16,7 +16,15 @@
 #include "time_machine.h"
 #include "bstests.h"
 
-#define COUNT      5000   /* Arbitrary GATT Write Cmd iterations used */
+/* There are 13 iterations of PHY update every 3 seconds, and based on actual
+ * simulation 10000 iterations are sufficient to finish these iterations with
+ * a stable 2M throughput value to be verified. If Central and Peripheral take
+ * different duration to complete these iterations, the test will fail due to
+ * the throughput calculated over one second duration will be low due to the
+ * connection being disconnected before the other device could complete all the
+ * iterations.
+ */
+#define COUNT 10000
 
 /* Write Throughput calculation:
  *  Measure interval = 1 s


### PR DESCRIPTION
Update the Central and Peripheral GATT write command sample to measure throughput across all supported connection PHYs.

Relates to #84265, so that a coverage added to ensure future regressions are caught early in PR or by manually testing these samples.

Cover the sample in BabbleSIM CI testing to validate the 2M PHY throughput after all supported PHYs have been changed once.

Pending:
- [x] BabbleSIM testing has failure (watch this PR CI)
- [ ] nRF54L15DK has Zephyr Controller assertion with CONFIG_BT_SMP=y, investigation pending; This issue is outside the scope of this PR.
- [x] nRF52840DK testing
- [x] nRF5340DK testing

nRF54L15DK Central (`CONFIG_BT_SMP=n`):
```
[2025-01-24 13:09:00.271] *** Booting Zephyr OS build v4.0.0-3935-g87fe59722fb9 ***
[2025-01-24 13:09:00.276] [00:00:00.431,699] <inf> bt_hci_core: HW Platform: Nordic Semiconductor (0x0002)
[2025-01-24 13:09:00.284] [00:00:00.431,713] <inf> bt_hci_core: HW Variant: nRF54Lx (0x0005)
[2025-01-24 13:09:00.291] [00:00:00.431,726] <inf> bt_hci_core: Firmware: Standard Bluetooth controller (0x00) Version 4.0 Build 99
[2025-01-24 13:09:00.301] [00:00:00.432,077] <inf> bt_hci_core: Identity: F4:81:FA:23:32:D0 (random)
[2025-01-24 13:09:00.308] [00:00:00.432,093] <inf> bt_hci_core: HCI: version 5.4 (0x0d) revision 0x0000, manufacturer 0x05f1
[2025-01-24 13:09:00.318] [00:00:00.432,106] <inf> bt_hci_core: LMP: version 5.4 (0x0d) subver 0xffff
[2025-01-24 13:09:00.325] Bluetooth initialized
[2025-01-24 13:09:00.327] start_scan: Scanning successfully started
[2025-01-24 13:09:00.331] [DEVICE]: FF:05:04:03:02:FF (random), AD evt type 3, AD data len 0, RSSI -95
[2025-01-24 13:09:00.339] [DEVICE]: 4F:47:9C:9B:C7:5E (random), AD evt type 0, AD data len 25, RSSI -75
[2025-01-24 13:09:00.345] [DEVICE]: 4F:47:9C:9B:C7:5E (random), AD evt type 4, AD data len 15, RSSI -75
[2025-01-24 13:09:00.352] [DEVICE]: F6:FF:77:B6:A8:87 (random), AD evt type 0, AD data len 3, RSSI -20
[2025-01-24 13:09:00.359] [00:00:00.454,601] <wrn> bt_conn: *conn should be unreferenced and initialized to NULL
[2025-01-24 13:09:00.367] Updated MTU: TX: 23 RX: 23 bytes
[2025-01-24 13:09:00.370] connected: F6:FF:77:B6:A8:87 (random) role 0
[2025-01-24 13:09:00.374] mtu_exchange: Current MTU = 23
[2025-01-24 13:09:00.377] mtu_exchange: Exchange MTU...
[2025-01-24 13:09:00.380] Updated MTU: TX: 247 RX: 247 bytes
[2025-01-24 13:09:01.385] Updated MTU: TX: 247 RX: 247 bytes
[2025-01-24 13:09:01.388] mtu_exchange_cb: MTU exchange successful (247)
[2025-01-24 13:09:01.393] LE PHY Updated: F6:FF:77:B6:A8:87 (random) Tx 0x2, Rx 0x2
[2025-01-24 13:09:01.399] write_cmd_cb: count= 0, len= 0, rate= 0 bps.
[2025-01-24 13:09:03.273] write_cmd_cb: count= 397, len= 96868, rate= 775321 bps.
[2025-01-24 13:09:03.278] write_cmd_cb: count= 400, len= 97600, rate= 780829 bps.
[2025-01-24 13:09:05.277] write_cmd_cb: count= 400, len= 97600, rate= 780828 bps.
[2025-01-24 13:09:05.283] write_cmd_cb: PHY Update requested 1 1 (0)
[2025-01-24 13:09:05.287] LE PHY Updated: F6:FF:77:B6:A8:87 (random) Tx 0x1, Rx 0x1
[2025-01-24 13:09:05.293] write_cmd_cb: count= 235, len= 57340, rate= 460046 bps.
[2025-01-24 13:09:06.396] le_param_req: int (0x00a0, 0x00a0) lat 0 to 120
[2025-01-24 13:09:06.400] le_param_updated: int 0x00a0 lat 0 to 120
[2025-01-24 13:09:06.404] write_cmd_cb: count= 219, len= 53436, rate= 428139 bps.
[2025-01-24 13:09:08.286] write_cmd_cb: count= 220, len= 53680, rate= 429449 bps.
[2025-01-24 13:09:08.292] write_cmd_cb: count= 220, len= 53680, rate= 429455 bps.
[2025-01-24 13:09:08.297] write_cmd_cb: PHY Update requested 1 2 (0)
[2025-01-24 13:09:10.295] write_cmd_cb: count= 91, len= 22204, rate= 177639 bps.
[2025-01-24 13:09:10.301] LE PHY Updated: F6:FF:77:B6:A8:87 (random) Tx 0x1, Rx 0x2
[2025-01-24 13:09:10.306] write_cmd_cb: count= 244, len= 59536, rate= 477775 bps.
[2025-01-24 13:09:12.299] write_cmd_cb: count= 290, len= 70760, rate= 566091 bps.
[2025-01-24 13:09:12.304] write_cmd_cb: count= 290, len= 70760, rate= 566100 bps.
[2025-01-24 13:09:12.310] write_cmd_cb: PHY Update requested 1 4 (0)
[2025-01-24 13:09:14.306] write_cmd_cb: count= 118, len= 28792, rate= 230340 bps.
[2025-01-24 13:09:14.311] LE PHY Updated: F6:FF:77:B6:A8:87 (random) Tx 0x1, Rx 0x4
[2025-01-24 13:09:14.316] write_cmd_cb: count= 236, len= 57584, rate= 460762 bps.
[2025-01-24 13:09:16.319] write_cmd_cb: count= 144, len= 35136, rate= 281096 bps.
[2025-01-24 13:09:17.326] write_cmd_cb: count= 145, len= 35380, rate= 283044 bps.
[2025-01-24 13:09:17.331] write_cmd_cb: PHY Update requested 2 1 (0)
[2025-01-24 13:09:17.335] write_cmd_cb: count= 60, len= 14640, rate= 117124 bps.
[2025-01-24 13:09:18.933] LE PHY Updated: F6:FF:77:B6:A8:87 (random) Tx 0x2, Rx 0x1
[2025-01-24 13:09:18.938] write_cmd_cb: count= 202, len= 49288, rate= 395608 bps.
[2025-01-24 13:09:20.337] write_cmd_cb: count= 290, len= 70760, rate= 566094 bps.
[2025-01-24 13:09:20.343] write_cmd_cb: count= 290, len= 70760, rate= 566100 bps.
[2025-01-24 13:09:20.348] write_cmd_cb: PHY Update requested 2 2 (0)
[2025-01-24 13:09:22.344] write_cmd_cb: count= 66, len= 16104, rate= 128836 bps.
[2025-01-24 13:09:22.349] LE PHY Updated: F6:FF:77:B6:A8:87 (random) Tx 0x2, Rx 0x2
[2025-01-24 13:09:22.355] write_cmd_cb: count= 316, len= 77104, rate= 617304 bps.
[2025-01-24 13:09:24.348] write_cmd_cb: count= 415, len= 101260, rate= 810099 bps.
[2025-01-24 13:09:24.353] write_cmd_cb: count= 415, len= 101260, rate= 810110 bps.
[2025-01-24 13:09:24.359] write_cmd_cb: PHY Update requested 2 4 (0)
[2025-01-24 13:09:26.353] write_cmd_cb: count= 168, len= 40992, rate= 327940 bps.
[2025-01-24 13:09:26.358] LE PHY Updated: F6:FF:77:B6:A8:87 (random) Tx 0x2, Rx 0x4
[2025-01-24 13:09:26.363] write_cmd_cb: count= 361, len= 88084, rate= 705879 bps.
[2025-01-24 13:09:28.362] write_cmd_cb: count= 170, len= 41480, rate= 331847 bps.
[2025-01-24 13:09:29.368] write_cmd_cb: count= 170, len= 41480, rate= 331845 bps.
[2025-01-24 13:09:29.373] write_cmd_cb: PHY Update requested 4 1 (2)
[2025-01-24 13:09:29.377] write_cmd_cb: count= 41, len= 10004, rate= 81405 bps.
[2025-01-24 13:09:31.133] LE PHY Updated: F6:FF:77:B6:A8:87 (random) Tx 0x4, Rx 0x1
[2025-01-24 13:09:31.138] write_cmd_cb: count= 53, len= 12932, rate= 105259 bps.
[2025-01-24 13:09:32.390] write_cmd_cb: count= 50, len= 12200, rate= 97602 bps.
[2025-01-24 13:09:33.410] write_cmd_cb: count= 50, len= 12200, rate= 97603 bps.
[2025-01-24 13:09:33.414] write_cmd_cb: PHY Update requested 4 2 (2)
[2025-01-24 13:09:34.429] write_cmd_cb: count= 23, len= 5612, rate= 44897 bps.
[2025-01-24 13:09:34.433] LE PHY Updated: F6:FF:77:B6:A8:87 (random) Tx 0x4, Rx 0x2
[2025-01-24 13:09:35.442] write_cmd_cb: count= 51, len= 12444, rate= 100076 bps.
[2025-01-24 13:09:36.460] write_cmd_cb: count= 55, len= 13420, rate= 107362 bps.
[2025-01-24 13:09:37.478] write_cmd_cb: count= 55, len= 13420, rate= 107364 bps.
[2025-01-24 13:09:37.483] write_cmd_cb: PHY Update requested 4 4 (2)
[2025-01-24 13:09:38.496] write_cmd_cb: count= 24, len= 5856, rate= 46849 bps.
[2025-01-24 13:09:38.501] LE PHY Updated: F6:FF:77:B6:A8:87 (random) Tx 0x4, Rx 0x4
[2025-01-24 13:09:38.506] write_cmd_cb: count= 43, len= 10492, rate= 86330 bps.
[2025-01-24 13:09:40.567] write_cmd_cb: count= 25, len= 6100, rate= 48801 bps.
[2025-01-24 13:09:41.600] write_cmd_cb: count= 25, len= 6100, rate= 48801 bps.
[2025-01-24 13:09:41.605] write_cmd_cb: PHY Update requested 4 1 (1)
[2025-01-24 13:09:41.609] write_cmd_cb: count= 34, len= 8296, rate= 66565 bps.
[2025-01-24 13:09:43.332] LE PHY Updated: F6:FF:77:B6:A8:87 (random) Tx 0x4, Rx 0x1
[2025-01-24 13:09:43.337] write_cmd_cb: count= 115, len= 28060, rate= 225710 bps.
[2025-01-24 13:09:44.615] write_cmd_cb: count= 145, len= 35380, rate= 283047 bps.
[2025-01-24 13:09:45.622] write_cmd_cb: count= 145, len= 35380, rate= 283051 bps.
[2025-01-24 13:09:45.627] write_cmd_cb: PHY Update requested 4 2 (1)
[2025-01-24 13:09:45.631] write_cmd_cb: count= 60, len= 14640, rate= 117124 bps.
[2025-01-24 13:09:47.331] LE PHY Updated: F6:FF:77:B6:A8:87 (random) Tx 0x4, Rx 0x2
[2025-01-24 13:09:47.337] write_cmd_cb: count= 152, len= 37088, rate= 297575 bps.
[2025-01-24 13:09:48.637] write_cmd_cb: count= 170, len= 41480, rate= 331849 bps.
[2025-01-24 13:09:49.643] write_cmd_cb: count= 170, len= 41480, rate= 331853 bps.
[2025-01-24 13:09:49.648] write_cmd_cb: PHY Update requested 4 4 (1)
[2025-01-24 13:09:49.652] write_cmd_cb: count= 70, len= 17080, rate= 136645 bps.
[2025-01-24 13:09:51.332] LE PHY Updated: F6:FF:77:B6:A8:87 (random) Tx 0x4, Rx 0x4
[2025-01-24 13:09:51.337] write_cmd_cb: count= 149, len= 36356, rate= 292445 bps.
[2025-01-24 13:09:52.662] write_cmd_cb: count= 105, len= 25620, rate= 204966 bps.
[2025-01-24 13:09:53.671] write_cmd_cb: count= 105, len= 25620, rate= 204967 bps.
[2025-01-24 13:09:53.676] write_cmd_cb: PHY Update requested 2 2 (0)
[2025-01-24 13:09:54.680] write_cmd_cb: count= 45, len= 10980, rate= 87841 bps.
[2025-01-24 13:09:54.685] LE PHY Updated: F6:FF:77:B6:A8:87 (random) Tx 0x2, Rx 0x2
[2025-01-24 13:09:55.546] [00:00:55.697,461] <wrn> bt_conn: conn 0x20000c58: not connected
[2025-01-24 13:09:55.553] write_cmd_cb: count= 151, len= 36844, rate= 346467 bps.
[2025-01-24 13:09:55.557] [00:00:55.697,586] <wrn> bt_conn: conn 0x20000c58: not connected
[2025-01-24 13:09:55.564] disconnected: F6:FF:77:B6:A8:87 (random) role 0, reason 8 
[2025-01-24 13:09:55.570] start_scan: Scanning successfully started

```

nRF54l15dk Peripheral (`CONFIG_BT_SMP=n`):
```
[2025-01-24 13:09:00.254] *** Booting Zephyr OS build v4.0.0-3935-g87fe59722fb9 ***
[2025-01-24 13:09:00.259] [00:00:00.431,649] <inf> bt_hci_core: HW Platform: Nordic Semiconductor (0x0002)
[2025-01-24 13:09:00.266] [00:00:00.431,663] <inf> bt_hci_core: HW Variant: nRF54Lx (0x0005)
[2025-01-24 13:09:00.273] [00:00:00.431,675] <inf> bt_hci_core: Firmware: Standard Bluetooth controller (0x00) Version 4.0 Build 99
[2025-01-24 13:09:00.283] [00:00:00.432,010] <inf> bt_hci_core: Identity: F6:FF:77:B6:A8:87 (random)
[2025-01-24 13:09:00.290] [00:00:00.432,026] <inf> bt_hci_core: HCI: version 5.4 (0x0d) revision 0x0000, manufacturer 0x05f1
[2025-01-24 13:09:00.299] [00:00:00.432,040] <inf> bt_hci_core: LMP: version 5.4 (0x0d) subver 0xffff
[2025-01-24 13:09:00.307] Bluetooth initialized
[2025-01-24 13:09:00.309] Advertising successfully started
[2025-01-24 13:09:01.254] Updated MTU: TX: 23 RX: 23 bytes
[2025-01-24 13:09:01.257] connected: F4:81:FA:23:32:D0 (random) role 1
[2025-01-24 13:09:01.261] mtu_exchange: Current MTU = 23
[2025-01-24 13:09:01.264] mtu_exchange: Exchange MTU...
[2025-01-24 13:09:01.266] Updated MTU: TX: 247 RX: 247 bytes
[2025-01-24 13:09:01.269] Updated MTU: TX: 247 RX: 247 bytes
[2025-01-24 13:09:01.272] mtu_exchange_cb: MTU exchange successful (247)
[2025-01-24 13:09:01.277] LE PHY Updated: F4:81:FA:23:32:D0 (random) Tx 0x1, Rx 0x1
[2025-01-24 13:09:01.282] LE PHY Updated: F4:81:FA:23:32:D0 (random) Tx 0x2, Rx 0x2
[2025-01-24 13:09:01.287] write_cmd_cb: count= 0, len= 0, rate= 0 bps.
[2025-01-24 13:09:03.255] write_cmd_cb: count= 389, len= 94916, rate= 760283 bps.
[2025-01-24 13:09:03.260] write_cmd_cb: count= 400, len= 97600, rate= 780839 bps.
[2025-01-24 13:09:05.260] write_cmd_cb: count= 400, len= 97600, rate= 780840 bps.
[2025-01-24 13:09:05.265] write_cmd_cb: PHY Update requested 1 1 (0)
[2025-01-24 13:09:05.269] LE PHY Updated: F4:81:FA:23:32:D0 (random) Tx 0x2, Rx 0x2
[2025-01-24 13:09:05.274] LE PHY Updated: F4:81:FA:23:32:D0 (random) Tx 0x1, Rx 0x1
[2025-01-24 13:09:05.279] write_cmd_cb: count= 308, len= 75152, rate= 601571 bps.
[2025-01-24 13:09:06.732] le_param_updated: int 0x00a0 lat 0 to 120
[2025-01-24 13:09:06.737] write_cmd_cb: count= 219, len= 53436, rate= 428144 bps.
[2025-01-24 13:09:08.271] write_cmd_cb: count= 220, len= 53680, rate= 429455 bps.
[2025-01-24 13:09:08.276] write_cmd_cb: count= 220, len= 53680, rate= 429463 bps.
[2025-01-24 13:09:08.281] write_cmd_cb: PHY Update requested 2 1 (0)
[2025-01-24 13:09:09.734] LE PHY Updated: F4:81:FA:23:32:D0 (random) Tx 0x1, Rx 0x1
[2025-01-24 13:09:09.739] write_cmd_cb: count= 251, len= 61244, rate= 489977 bps.
[2025-01-24 13:09:10.933] LE PHY Updated: F4:81:FA:23:32:D0 (random) Tx 0x2, Rx 0x1
[2025-01-24 13:09:10.939] write_cmd_cb: count= 243, len= 59292, rate= 475471 bps.
[2025-01-24 13:09:12.284] write_cmd_cb: count= 290, len= 70760, rate= 566099 bps.
[2025-01-24 13:09:12.289] write_cmd_cb: count= 290, len= 70760, rate= 566108 bps.
[2025-01-24 13:09:12.295] write_cmd_cb: PHY Update requested 4 1 (0)
[2025-01-24 13:09:13.733] LE PHY Updated: F4:81:FA:23:32:D0 (random) Tx 0x2, Rx 0x1
[2025-01-24 13:09:13.739] write_cmd_cb: count= 395, len= 96380, rate= 771080 bps.
[2025-01-24 13:09:14.934] LE PHY Updated: F4:81:FA:23:32:D0 (random) Tx 0x4, Rx 0x1
[2025-01-24 13:09:14.939] write_cmd_cb: count= 238, len= 58072, rate= 466269 bps.
[2025-01-24 13:09:16.301] write_cmd_cb: count= 144, len= 35136, rate= 281097 bps.
[2025-01-24 13:09:17.308] write_cmd_cb: count= 145, len= 35380, rate= 283053 bps.
[2025-01-24 13:09:17.313] write_cmd_cb: PHY Update requested 1 2 (0)
[2025-01-24 13:09:17.317] LE PHY Updated: F4:81:FA:23:32:D0 (random) Tx 0x4, Rx 0x1
[2025-01-24 13:09:17.322] write_cmd_cb: count= 101, len= 24644, rate= 197162 bps.
[2025-01-24 13:09:18.933] LE PHY Updated: F4:81:FA:23:32:D0 (random) Tx 0x1, Rx 0x2
[2025-01-24 13:09:18.939] write_cmd_cb: count= 200, len= 48800, rate= 390756 bps.
[2025-01-24 13:09:20.320] write_cmd_cb: count= 290, len= 70760, rate= 566102 bps.
[2025-01-24 13:09:20.326] write_cmd_cb: count= 290, len= 70760, rate= 566106 bps.
[2025-01-24 13:09:20.331] write_cmd_cb: PHY Update requested 2 2 (0)
[2025-01-24 13:09:21.734] LE PHY Updated: F4:81:FA:23:32:D0 (random) Tx 0x1, Rx 0x2
[2025-01-24 13:09:21.739] write_cmd_cb: count= 147, len= 35868, rate= 286959 bps.
[2025-01-24 13:09:23.134] LE PHY Updated: F4:81:FA:23:32:D0 (random) Tx 0x2, Rx 0x2
[2025-01-24 13:09:23.139] write_cmd_cb: count= 314, len= 76616, rate= 613391 bps.
[2025-01-24 13:09:24.331] write_cmd_cb: count= 415, len= 101260, rate= 810109 bps.
[2025-01-24 13:09:24.337] write_cmd_cb: count= 415, len= 101260, rate= 810123 bps.
[2025-01-24 13:09:24.342] write_cmd_cb: PHY Update requested 4 2 (0)
[2025-01-24 13:09:25.734] LE PHY Updated: F4:81:FA:23:32:D0 (random) Tx 0x2, Rx 0x2
[2025-01-24 13:09:25.740] write_cmd_cb: count= 311, len= 75884, rate= 607099 bps.
[2025-01-24 13:09:27.133] LE PHY Updated: F4:81:FA:23:32:D0 (random) Tx 0x4, Rx 0x2
[2025-01-24 13:09:27.138] write_cmd_cb: count= 365, len= 89060, rate= 715535 bps.
[2025-01-24 13:09:28.346] write_cmd_cb: count= 170, len= 41480, rate= 331853 bps.
[2025-01-24 13:09:29.352] write_cmd_cb: count= 170, len= 41480, rate= 331856 bps.
[2025-01-24 13:09:29.357] write_cmd_cb: PHY Update requested 1 4 (2)
[2025-01-24 13:09:29.361] LE PHY Updated: F4:81:FA:23:32:D0 (random) Tx 0x4, Rx 0x2
[2025-01-24 13:09:29.366] write_cmd_cb: count= 55, len= 13420, rate= 109434 bps.
[2025-01-24 13:09:31.133] LE PHY Updated: F4:81:FA:23:32:D0 (random) Tx 0x1, Rx 0x4
[2025-01-24 13:09:31.138] write_cmd_cb: count= 53, len= 12932, rate= 103705 bps.
[2025-01-24 13:09:32.388] write_cmd_cb: count= 50, len= 12200, rate= 97603 bps.
[2025-01-24 13:09:33.407] write_cmd_cb: count= 50, len= 12200, rate= 97604 bps.
[2025-01-24 13:09:33.412] write_cmd_cb: PHY Update requested 2 4 (2)
[2025-01-24 13:09:33.416] LE PHY Updated: F4:81:FA:23:32:D0 (random) Tx 0x1, Rx 0x4
[2025-01-24 13:09:34.427] write_cmd_cb: count= 149, len= 36356, rate= 290864 bps.
[2025-01-24 13:09:34.431] LE PHY Updated: F4:81:FA:23:32:D0 (random) Tx 0x2, Rx 0x4
[2025-01-24 13:09:35.441] write_cmd_cb: count= 51, len= 12444, rate= 99973 bps.
[2025-01-24 13:09:36.459] write_cmd_cb: count= 55, len= 13420, rate= 107366 bps.
[2025-01-24 13:09:37.477] write_cmd_cb: count= 55, len= 13420, rate= 107365 bps.
[2025-01-24 13:09:37.481] write_cmd_cb: PHY Update requested 4 4 (2)
[2025-01-24 13:09:37.485] LE PHY Updated: F4:81:FA:23:32:D0 (random) Tx 0x2, Rx 0x4
[2025-01-24 13:09:38.495] write_cmd_cb: count= 214, len= 52216, rate= 417750 bps.
[2025-01-24 13:09:38.500] LE PHY Updated: F4:81:FA:23:32:D0 (random) Tx 0x4, Rx 0x4
[2025-01-24 13:09:39.519] write_cmd_cb: count= 44, len= 10736, rate= 86724 bps.
[2025-01-24 13:09:40.584] write_cmd_cb: count= 25, len= 6100, rate= 48802 bps.
[2025-01-24 13:09:41.618] write_cmd_cb: count= 25, len= 6100, rate= 48802 bps.
[2025-01-24 13:09:41.622] write_cmd_cb: PHY Update requested 1 4 (1)
[2025-01-24 13:09:41.626] LE PHY Updated: F4:81:FA:23:32:D0 (random) Tx 0x4, Rx 0x4
[2025-01-24 13:09:41.631] write_cmd_cb: count= 73, len= 17812, rate= 143360 bps.
[2025-01-24 13:09:43.332] LE PHY Updated: F4:81:FA:23:32:D0 (random) Tx 0x1, Rx 0x4
[2025-01-24 13:09:43.337] write_cmd_cb: count= 116, len= 28304, rate= 226650 bps.
[2025-01-24 13:09:44.633] write_cmd_cb: count= 145, len= 35380, rate= 283051 bps.
[2025-01-24 13:09:45.640] write_cmd_cb: count= 145, len= 35380, rate= 283056 bps.
[2025-01-24 13:09:45.645] write_cmd_cb: PHY Update requested 2 4 (1)
[2025-01-24 13:09:45.649] LE PHY Updated: F4:81:FA:23:32:D0 (random) Tx 0x1, Rx 0x4
[2025-01-24 13:09:45.655] write_cmd_cb: count= 130, len= 31720, rate= 253773 bps.
[2025-01-24 13:09:47.332] LE PHY Updated: F4:81:FA:23:32:D0 (random) Tx 0x2, Rx 0x4
[2025-01-24 13:09:47.337] write_cmd_cb: count= 152, len= 37088, rate= 298195 bps.
[2025-01-24 13:09:48.653] write_cmd_cb: count= 170, len= 41480, rate= 331853 bps.
[2025-01-24 13:09:49.659] write_cmd_cb: count= 170, len= 41480, rate= 331858 bps.
[2025-01-24 13:09:49.664] write_cmd_cb: PHY Update requested 4 4 (1)
[2025-01-24 13:09:49.669] LE PHY Updated: F4:81:FA:23:32:D0 (random) Tx 0x2, Rx 0x4
[2025-01-24 13:09:49.674] write_cmd_cb: count= 180, len= 43920, rate= 351378 bps.
[2025-01-24 13:09:51.332] LE PHY Updated: F4:81:FA:23:32:D0 (random) Tx 0x4, Rx 0x4
[2025-01-24 13:09:51.337] write_cmd_cb: count= 148, len= 36112, rate= 291191 bps.
[2025-01-24 13:09:52.676] write_cmd_cb: count= 105, len= 25620, rate= 204969 bps.
[2025-01-24 13:09:53.685] write_cmd_cb: count= 105, len= 25620, rate= 204970 bps.
[2025-01-24 13:09:53.690] write_cmd_cb: PHY Update requested 2 2 (0)
[2025-01-24 13:09:53.694] LE PHY Updated: F4:81:FA:23:32:D0 (random) Tx 0x4, Rx 0x4
[2025-01-24 13:09:53.699] write_cmd_cb: count= 119, len= 29036, rate= 232298 bps.
[2025-01-24 13:09:55.331] LE PHY Updated: F4:81:FA:23:32:D0 (random) Tx 0x2, Rx 0x2
[2025-01-24 13:09:56.532] [00:00:55.713,259] <wrn> bt_conn: conn 0x20000c80: not connected
[2025-01-24 13:09:56.539] write_cmd_cb: count= 149, len= 36356, rate= 348056 bps.
[2025-01-24 13:09:56.544] [00:00:55.713,395] <wrn> bt_conn: conn 0x20000c80: not connected
[2025-01-24 13:09:56.551] disconnected: F4:81:FA:23:32:D0 (random) role 1, reason 8 
[2025-01-24 13:09:56.556] [00:00:55.713,512] <wrn> bt_att: Not connected
[2025-01-24 13:09:56.561] write_cmd: Write cmd failed (-128).

```