### PR TITLE
dts: arm: st: u0: add missing USART4 to .dtsi

### DIFF
--- a/dts/arm/st/u0/stm32u0.dtsi
+++ b/dts/arm/st/u0/stm32u0.dtsi
@@ -215,6 +215,15 @@
 			status = "disabled";
 		};
 
+		usart4: serial@40004C00 {
+			compatible = "st,stm32-usart", "st,stm32-uart";
+			reg = <0x40004C00 0x400>;
+			clocks = <&rcc STM32_CLOCK(APB1, 19U)>;
+			resets = <&rctl STM32_RESET(APB1L, 19U)>;
+			interrupts = <30 0>;
+			status = "disabled";
+		};
+
 		lpuart1: serial@40008000 {
 			compatible = "st,stm32-lpuart", "st,stm32-uart";
 			reg = <0x40008000 0x400>;


### PR DESCRIPTION
Sources of information:
- address: "RM0503 Reference Manual", p. 60
- interrupts: "RM0503 Reference Manual", p. 260

Fixes: #84459