### PR TITLE
drivers: sensor: ADT75 Temperature Sensor Driver

### DIFF
--- a/drivers/sensor/adi/CMakeLists.txt
+++ b/drivers/sensor/adi/CMakeLists.txt
@@ -5,6 +5,7 @@
 add_subdirectory_ifdef(CONFIG_ADLTC2990 adltc2990)
 add_subdirectory_ifdef(CONFIG_ADT7310 adt7310)
 add_subdirectory_ifdef(CONFIG_ADT7420 adt7420)
+add_subdirectory_ifdef(CONFIG_ADT75 adt75)
 add_subdirectory_ifdef(CONFIG_ADXL345 adxl345)
 add_subdirectory_ifdef(CONFIG_ADXL362 adxl362)
 add_subdirectory_ifdef(CONFIG_ADXL367 adxl367)

--- a/drivers/sensor/adi/Kconfig
+++ b/drivers/sensor/adi/Kconfig
@@ -5,6 +5,7 @@
 source "drivers/sensor/adi/adltc2990/Kconfig"
 source "drivers/sensor/adi/adt7310/Kconfig"
 source "drivers/sensor/adi/adt7420/Kconfig"
+source "drivers/sensor/adi/adt75/Kconfig"
 source "drivers/sensor/adi/adxl345/Kconfig"
 source "drivers/sensor/adi/adxl362/Kconfig"
 source "drivers/sensor/adi/adxl367/Kconfig"

--- a/drivers/sensor/adi/adt75/CMakeLists.txt
+++ b/drivers/sensor/adi/adt75/CMakeLists.txt
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
+zephyr_library()
+
+zephyr_library_sources(adt75.c)

--- a/drivers/sensor/adi/adt75/Kconfig
+++ b/drivers/sensor/adi/adt75/Kconfig
@@ -1,0 +1,13 @@
+# ADT75 temperature sensor configuration options
+
+# Copyright (c) 2024 Analog Devices Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+config ADT75
+	bool "ADT75 Temperature Sensor"
+	default y
+	depends on DT_HAS_ADI_ADT75_ENABLED
+	select I2C
+	help
+	  Enable the driver for Analog Devices ADT75
+	  12-bit Digital I2C Temperature Sensors.

--- a/drivers/sensor/adi/adt75/adt75.c
+++ b/drivers/sensor/adi/adt75/adt75.c
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2024 Analog Devices Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT adi_adt75
+
+#include <zephyr/device.h>
+#include <zephyr/drivers/i2c.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/kernel.h>
+#include <zephyr/drivers/sensor.h>
+#include <zephyr/sys/__assert.h>
+
+#include "adt75.h"
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(ADT75, CONFIG_SENSOR_LOG_LEVEL);
+
+static int adt75_temp_reg_read(const struct device *dev, uint8_t reg, int16_t *val)
+{
+	const struct adt75_dev_config *cfg = dev->config;
+
+	if (i2c_burst_read_dt(&cfg->i2c, reg, (uint8_t *)val, 2) < 0) {
+		return -EIO;
+	}
+
+	*val = sys_be16_to_cpu(*val);
+	return 0;
+}
+
+static int adt75_sample_fetch(const struct device *dev, enum sensor_channel chan)
+{
+	struct adt75_data *drv_data = dev->data;
+	int16_t value;
+
+	__ASSERT_NO_MSG(chan == SENSOR_CHAN_ALL || chan == SENSOR_CHAN_AMBIENT_TEMP);
+
+	if (adt75_temp_reg_read(dev, ADT75_REG_TEMPERATURE, &value) < 0) {
+		return -EIO;
+	}
+
+	drv_data->sample = value >> 4; /* use 12-bit only */
+	return 0;
+}
+
+static int adt75_channel_get(const struct device *dev, enum sensor_channel chan,
+			     struct sensor_value *val)
+{
+	struct adt75_data *drv_data = dev->data;
+	int32_t value;
+
+	if (chan != SENSOR_CHAN_AMBIENT_TEMP) {
+		return -ENOTSUP;
+	}
+
+	value = (int32_t)drv_data->sample * ADT75_TEMP_SCALE;
+	val->val1 = value / 1000000;
+	val->val2 = value % 1000000;
+
+	return 0;
+}
+
+static const struct sensor_driver_api adt75_driver_api = {
+	.sample_fetch = adt75_sample_fetch,
+	.channel_get = adt75_channel_get,
+};
+
+static int adt75_probe(const struct device *dev)
+{
+	const struct adt75_dev_config *cfg = dev->config;
+	uint8_t value;
+	int ret;
+
+	ret = i2c_reg_write_byte_dt(&cfg->i2c, ADT75_REG_CONFIGURATION,
+				    ADT75_DEFAULT_CONFIGURATION);
+	if (ret) {
+		return ret;
+	}
+
+	ret = i2c_reg_read_byte_dt(&cfg->i2c, ADT75_REG_CONFIGURATION, &value);
+	if (ret) {
+		return ret;
+	}
+
+	if (value != ADT75_DEFAULT_CONFIGURATION) {
+		LOG_INF("%d", value);
+		return -ENODEV;
+	}
+
+	ret = i2c_reg_write_byte_dt(&cfg->i2c, ADT75_REG_CONFIGURATION,
+				    ADT75_CONFIG_OS_SMBUS_ALERT_MODE);
+
+	if (ret) {
+		return ret;
+	}
+
+	ret = i2c_reg_write_byte_dt(&cfg->i2c, ADT75_REG_CONFIGURATION,
+				    ADT75_DEFAULT_CONFIGURATION);
+	if (ret) {
+		return ret;
+	}
+
+	return 0;
+}
+
+static int adt75_init(const struct device *dev)
+{
+	const struct adt75_dev_config *cfg = dev->config;
+
+	LOG_INF("Initializing sensor");
+
+	if (!device_is_ready(cfg->i2c.bus)) {
+		LOG_ERR("Bus device is not ready");
+		return -EINVAL;
+	}
+
+	return adt75_probe(dev);
+}
+
+#define ADT75_DEFINE(inst)                                                                         \
+	static struct adt75_data adt75_data_##inst;                                                \
+                                                                                                   \
+	static const struct adt75_dev_config adt75_config_##inst = {                               \
+		.i2c = I2C_DT_SPEC_INST_GET(inst)};                                                \
+                                                                                                   \
+	SENSOR_DEVICE_DT_INST_DEFINE(inst, adt75_init, NULL, &adt75_data_##inst,                   \
+				     &adt75_config_##inst, POST_KERNEL,                            \
+				     CONFIG_SENSOR_INIT_PRIORITY, &adt75_driver_api);
+
+DT_INST_FOREACH_STATUS_OKAY(ADT75_DEFINE)

--- a/drivers/sensor/adi/adt75/adt75.h
+++ b/drivers/sensor/adi/adt75/adt75.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2024 Analog Devices Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_DRIVERS_SENSOR_ADT75_ADT75_H_
+#define ZEPHYR_DRIVERS_SENSOR_ADT75_ADT75_H_
+
+#include <zephyr/types.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/gpio.h>
+
+/******************************* ADT75 Register addresses *******************************/
+#define ADT75_REG_TEMPERATURE    0x00 /* Status register */
+#define ADT75_REG_CONFIGURATION  0x01 /* Status register */
+#define ADT75_REG_THYST_SETPOINT 0x02 /* T Hyst Set Point Register */
+#define ADT75_REG_OS_SETPOINT    0x03 /* OS Set Point Register */
+#define ADT75_REG_ONESHOT        0x04 /* One Shot Register */
+
+/* ADT75 Register Power-On Defaults */
+#define ADT75_DEFAULT_TEMPERATURE    0x00
+#define ADT75_DEFAULT_CONFIGURATION  0x00
+#define ADT75_DEFAULT_THYST_SETPOINT 0x4B00 /* 75 deg C */
+#define ADT75_DEFAULT_OS_SETPOINT    0x5000 /* 80 deg C */
+
+/* ADT75_REG_CONFIG definition */
+#define ADT75_CONFIG_SHUTDOWN            BIT(0)
+#define ADT75_CONFIG_CMP_INT             BIT(1)
+#define ADT75_CONFIG_OS_ALERT_POL        BIT(2)
+#define ADT75_CONFIG_FAULT_QUEUE(x)      (((x) & 0x3) << 3)
+#define ADT75_CONFIG_ONE_SHOT            BIT(5)
+#define ADT75_CONFIG_OS_SMBUS_ALERT_MODE BIT(7)
+
+/* ADT75_CONFIG_FAULT_QUEUE(x) options */
+#define ADT75_FAULT_QUEUE_1_FAULT  0
+#define ADT75_FAULT_QUEUE_2_FAULTS 1
+#define ADT75_FAULT_QUEUE_4_FAULTS 2
+#define ADT75_FAULT_QUEUE_6_FAULTS 3
+
+/* scale in micro degrees Celsius */
+#define ADT75_TEMP_SCALE 62500
+
+struct adt75_data {
+	int16_t sample;
+};
+
+struct adt75_dev_config {
+	struct i2c_dt_spec i2c;
+};
+
+#endif /* ZEPHYR_DRIVERS_SENSOR_ADT75_ADT75_H_ */

--- a/dts/bindings/sensor/adi,adt75.yaml
+++ b/dts/bindings/sensor/adi,adt75.yaml
@@ -1,0 +1,5 @@
+description: ADT75 12-Bit digital I2C temperature sensor
+
+compatible: "adi,adt75"
+
+include: [sensor-device.yaml, i2c-device.yaml]

--- a/tests/drivers/build_all/sensor/i2c.dtsi
+++ b/tests/drivers/build_all/sensor/i2c.dtsi
@@ -1230,3 +1230,8 @@ test_i2c_tmp435: tmp435@a9 {
 	resistance-correction;
 	beta-compensation = <0x0f>;
 };
+
+test_i2c_adt75: adt75@aa {
+	compatible = "adi,adt75";
+	reg = <0x48>;
+};


### PR DESCRIPTION
- Add ADT75 Devicetree binding
- Add KConfig
- Add ADT75 sensor API
- Add the ADT75 to the build_all test.