### PR TITLE
test: net: lib: http_server: core: Add min_flash requirement

### DIFF
--- a/tests/net/lib/http_server/core/testcase.yaml
+++ b/tests/net/lib/http_server/core/testcase.yaml
@@ -1,6 +1,7 @@
 common:
   depends_on: netif
   min_ram: 80
+  min_flash: 200
   tags:
     - http
     - net


### PR DESCRIPTION
As the test coverage keeps growing, the test suite no longer fits into smaller devices, hence add min_flash requirement for the test suite to filter them out.

Fixes #84493