### PR TITLE
tests: watchdog: Add missing wdt_disable in API test

### DIFF
--- a/tests/drivers/watchdog/wdt_basic_api/src/test_wdt.c
+++ b/tests/drivers/watchdog/wdt_basic_api/src/test_wdt.c
@@ -257,6 +257,12 @@ static int test_wdt_callback_1(void)
 		}
 	}
 
+	err = wdt_disable(wdt);
+	if (err < 0 && err != -EPERM && err != -EFAULT) {
+		TC_PRINT("Watchdog disable error\n");
+		return TC_FAIL;
+	}
+
 	m_testvalue = 0U;
 	m_cfg_wdt0.flags = WDT_FLAG_RESET_SOC;
 	m_cfg_wdt0.callback = wdt_int_cb0;
@@ -316,6 +322,11 @@ static int test_wdt_callback_2(void)
 		}
 	}
 
+	err = wdt_disable(wdt);
+	if (err < 0 && err != -EPERM && err != -EFAULT) {
+		TC_PRINT("Watchdog disable error\n");
+		return TC_FAIL;
+	}
 
 	m_testvalue = 0U;
 	m_cfg_wdt0.callback = wdt_int_cb0;
@@ -369,6 +380,12 @@ static int test_wdt_bad_window_max(void)
 	}
 
 	TC_PRINT("Testcase: %s\n", __func__);
+
+	err = wdt_disable(wdt);
+	if (err < 0 && err != -EPERM && err != -EFAULT) {
+		TC_PRINT("Watchdog disable error\n");
+		return TC_FAIL;
+	}
 
 	m_cfg_wdt0.callback = NULL;
 	m_cfg_wdt0.flags = WDT_FLAG_RESET_SOC;


### PR DESCRIPTION
The current watchdog tests assume that watchdog can be configured once it is running. This is a concept that do not work in practice becasue most of watchdog once configured will be locked. The tests should take that in consideration before enable another test. The other important details is that even when a watchdog is running it should be disable in some controllers to allow reconfigure.

This change was tested with SAM4L watchdog controller #83475 which allows reconfigure the watchdog once it is enabled. To do the correct configuration it is necessary execute the wdt_disable() call.

The change will validate if the watchdog is already locked and skip the test because it will always fail to reconfigure. If the watchdog is not locked but it is enabled it should be disabled to allow a new configuration.

CC: @martinjaeger 