### PR TITLE
dts: arm: nxp: mcxc141: Fix sram base address

### DIFF
--- a/dts/arm/nxp/nxp_mcxc141.dtsi
+++ b/dts/arm/nxp/nxp_mcxc141.dtsi
@@ -7,7 +7,7 @@
 #include <nxp/nxp_mcxc_common.dtsi>
 
 &sram0 {
-	reg = <0x1FFFF000 DT_SIZE_K(8)>;
+	reg = <0x1FFFF800 DT_SIZE_K(8)>;
 };
 
 &flash0 {


### PR DESCRIPTION
The current nxp_mcxc141.dtsi sets the SRAMs base address to 0x1FFF_F000. This leads to the mcxc141 faulting during initialization when the first write to SRAM occurs:

```
z_prep_c -> z_bss_zero -> z_early_memset -> memset
```

The correct base address is 0x1FFF_F800. This information is not obvious in the "MCX C24X Sub-Family Reference Manual, Rev. 1, 07/2024". The address was taken from an MCUXpresso IDE sample project.

Link: https://www.nxp.com/webapp/Download?colCode=MCXC24XP64M48RM