### PR TITLE
samples: Bluetooth: BAP unicast server fix RX stack size

### DIFF
--- a/samples/bluetooth/bap_unicast_server/boards/nrf5340_audio_dk_nrf5340_cpuapp.conf
+++ b/samples/bluetooth/bap_unicast_server/boards/nrf5340_audio_dk_nrf5340_cpuapp.conf
@@ -1,6 +1,9 @@
 # For LC3 the following configs are needed
 CONFIG_FPU=y
 CONFIG_LIBLC3=y
+# The LC3 codec uses a large amount of stack. This app runs the codec in the BT RX thread, hence
+# increase stack size for that thread.
+CONFIG_BT_RX_STACK_SIZE=4096
 
 CONFIG_BT_BUF_EVT_RX_SIZE=255
 CONFIG_BT_BUF_ACL_RX_SIZE=255

--- a/samples/bluetooth/bap_unicast_server/boards/nrf5340dk_nrf5340_cpuapp.conf
+++ b/samples/bluetooth/bap_unicast_server/boards/nrf5340dk_nrf5340_cpuapp.conf
@@ -1,9 +1,9 @@
 # For LC3 the following configs are needed
 CONFIG_FPU=y
 CONFIG_LIBLC3=y
-# The LC3 codec uses a large amount of stack. This app runs the codec in the work-queue, hence
-# inctease stack size for that thread.
-CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=4096
+# The LC3 codec uses a large amount of stack. This app runs the codec in the BT RX thread, hence
+# increase stack size for that thread.
+CONFIG_BT_RX_STACK_SIZE=4096
 
 CONFIG_BT_BUF_EVT_RX_SIZE=255
 CONFIG_BT_BUF_ACL_RX_SIZE=255


### PR DESCRIPTION
The sample is currently decoding in the BT RX thread, and not the system workqueue thread,
which then requires additional stack size.

Ideally it would decode in a separate thread to avoid expensive operations in the BT RX thread, but that is outside the scope of this commit.