### PR TITLE
arch: arm: cortex_m: Fix meta-IRQ unable to preempt from interrupt

### DIFF
--- a/arch/arm/core/cortex_m/exc_exit.c
+++ b/arch/arm/core/cortex_m/exc_exit.c
@@ -55,13 +55,8 @@ FUNC_ALIAS(z_arm_exc_exit, z_arm_int_exit, void);
 Z_GENERIC_SECTION(.text._HandlerModeExit) void z_arm_exc_exit(void)
 {
 #ifdef CONFIG_PREEMPT_ENABLED
-	/* If thread is preemptible */
-	if (_kernel.cpus->current->base.prio >= 0) {
-		/* and cached thread is not current thread */
-		if (_kernel.ready_q.cache != _kernel.cpus->current) {
-			/* trigger a context switch */
-			SCB->ICSR |= SCB_ICSR_PENDSVSET_Msk;
-		}
+	if (_kernel.ready_q.cache != _kernel.cpus->current) {
+		SCB->ICSR |= SCB_ICSR_PENDSVSET_Msk;
 	}
 #endif /* CONFIG_PREEMPT_ENABLED */
 

--- a/tests/kernel/sched/metairq/src/main.c
+++ b/tests/kernel/sched/metairq/src/main.c
@@ -77,6 +77,8 @@ void metairq_thread(void *p1, void *p2, void *p3)
 
 	k_msleep(WAIT_MS);
 
+	zassert_not_equal(coop_cnt2, LOOP_CNT, "thread2 wasn't preempted");
+
 	printk("give sem1\n");
 	k_sem_give(&coop_sem1);
 
@@ -112,6 +114,8 @@ void coop_thread1(void *p1, void *p2, void *p3)
 	zassert_equal(cnt1, 1, "Unexpected cnt1 at end: %d", cnt1);
 	cnt2 = coop_cnt2;
 	zassert_equal(cnt2, LOOP_CNT, "Unexpected cnt2 at end: %d", cnt2);
+
+	printk("thread1 end\n");
 
 	k_sem_give(&coop_sem1);
 }
@@ -154,6 +158,8 @@ void coop_thread2(void *p1, void *p2, void *p3)
 	zassert_equal(cnt1, 0, "Unexpected cnt1 at end: %d", cnt1);
 	cnt2 = coop_cnt2;
 	zassert_equal(cnt2, LOOP_CNT, "Unexpected cnt2 at end: %d", cnt2);
+
+	printk("thread2 end\n");
 
 	k_sem_give(&coop_sem2);
 }


### PR DESCRIPTION
This reverts commit 42036cdbcae270d00b5bd08e805e33bbd3b5787f.

Architecture specific code should not do preemption checking before context switch. This is already handled by the scheduler, so duplicating it would be redundant and error prone. These checks used to be necessary, but the scheduler has been rewritten since then and the checks were removed in 3a0cb2d35d9 (kernel: Remove legacy preemption checking, 2018-05-23).

The added checks tried to address #61761, and were motivated by this in the Architecture Porting Guide:
https://github.com/zephyrproject-rtos/zephyr/blob/5bc6446dcc317d3f3cff49b703ad32e8ecb724cd/doc/hardware/porting/arch.rst?plain=1#L255-L257

However, that part of the guide predates 3a0cb2d35d9 and is outdated. The check was also incorrect, as it didn't take scheduler locking nor meta-IRQs into account, and it was never verified to fix the issue according to [this comment](https://github.com/zephyrproject-rtos/zephyr/issues/61761#issuecomment-1946262214).

This PR also updates the meta-IRQ test to verify that meta-IRQs can preempt cooperative threads.

Fixes #80574