### PR TITLE
boards: frdm_rw612: add chosen uart-mcumgr

### DIFF
--- a/boards/nxp/frdm_rw612/frdm_rw612_common.dtsi
+++ b/boards/nxp/frdm_rw612/frdm_rw612_common.dtsi
@@ -24,6 +24,7 @@
 		zephyr,shell-uart = &flexcomm3;
 		zephyr,flash-controller = &w25q512jvfiq;
 		zephyr,code-partition = &slot0_partition;
+		zephyr,uart-mcumgr = &flexcomm3;
 	};
 
 	leds {


### PR DESCRIPTION
Adds chosen zephy,uart-mcumgr used by DFU MCUMgr via UART.