### PR TITLE
MAINTAINERS: Some updates to NXP maintainer areas

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -2236,16 +2236,6 @@ Release Notes:
   labels:
     - "area: Wi-Fi"
 
-"Drivers: Wi-Fi NXP":
-  status: maintained
-  maintainers:
-    - dleach02
-    - MaochenWang1
-  files:
-    - drivers/wifi/nxp/
-  labels:
-    - "platform: NXP Drivers"
-
 "Drivers: Memory Management":
   status: maintained
   maintainers:
@@ -3740,17 +3730,33 @@ NXP Drivers:
     - include/zephyr/dt-bindings/inputmux/
     - include/zephyr/dt-bindings/rdc/
     - include/zephyr/drivers/*/*nxp*
+    - include/zephyr/drivers/*/*nxp*/
     - include/zephyr/drivers/*/*mcux*
     - arch/arm/core/mpu/nxp_mpu.c
     - dts/bindings/*/nxp*
   files-exclude:
-    - drivers/wifi/nxp/
-    - drivers/usb/*/*mcux*
+    - drivers/wifi/
+    - drivers/bluetooth/
+    - drivers/usb/
   files-regex-exclude:
     - .*s32.*
   labels:
     - "platform: NXP Drivers"
   description: NXP Drivers
+
+NXP Wireless:
+  status: maintained
+  maintainers:
+    - dleach02
+  collaborators:
+    - MaochenWang1
+    - axelnxp
+  files:
+    - drivers/wifi/nxp/
+    - drivers/bluetooth/hci/*nxp*
+    - drivers/ieee802154/ieee802154_kw41z.c
+  labels:
+    - "platform: NXP Drivers"
 
 NXP MCUX USB:
   status: maintained
@@ -3759,6 +3765,7 @@ NXP MCUX USB:
     - MarkWangChinese
   files:
     - drivers/usb/*/*mcux*
+    - boards/nxp/usb_kw24d512/
   labels:
     - "platform: NXP Drivers"
   description: NXP MCUX USB shim drivers
@@ -3770,7 +3777,6 @@ NXP Platforms (MCU):
     - mmahadevan108
   collaborators:
     - DerekSnell
-    - yvanderv
     - EmilioCBen
     - decsny
     - butok
@@ -3779,8 +3785,11 @@ NXP Platforms (MCU):
     - boards/nxp/frdm*/
     - boards/nxp/lpcxpress*/
     - boards/nxp/twr_*/
-    - boards/nxp/vmu*/
     - boards/nxp/*rw*/
+    - boards/nxp/hexiwear/
+    - boards/nxp/common/
+    - boards/nxp/*
+    - soc/nxp/common/
     - soc/nxp/imxrt/
     - soc/nxp/kinetis/
     - soc/nxp/lpc/
@@ -3801,13 +3810,9 @@ NXP Platforms (S32):
   maintainers:
     - manuargue
   collaborators:
-    - PetervdPerk-NXP
-    - bperseghetti
     - Dat-NguyenDuy
   files:
-    - boards/nxp/s32*/
-    - boards/nxp/mr_canhubk3/
-    - boards/nxp/ucans32k1sic/
+    - boards/nxp/*s32*/
     - boards/common/*nxp_s32*
     - soc/nxp/s32/
     - drivers/*/*nxp_s32*
@@ -3830,12 +3835,12 @@ NXP Platforms (MPU):
     - dleach02
     - dbaluta
     - iuliana-prodan
-    - yvanderv
   files:
     - dts/arm64/nxp/
     - dts/arm/nxp/nxp_imx*
     - soc/nxp/imx/
     - soc/nxp/layerscape/
+    - boards/nxp/ls1046ardb/
   files-regex:
     - boards/nxp/m?imx[^(rt)].*/
   labels:
@@ -3854,6 +3859,19 @@ NXP Platforms (Xtensa):
   labels:
     - "platform: NXP Xtensa"
   description: NXP Xtensa platforms
+
+NXP Platforms (Robotics Products):
+  status: maintained
+  maintainers:
+    - bperseghetti
+    - PetervdPerk-NXP
+  files:
+    - boards/nxp/vmu*/
+    - boards/nxp/rddrone_fmuk66/
+    - boards/nxp/mr_canhubk3/
+  labels:
+    - "platform: NXP"
+  description: NXP Robotics Module Platform Products
 
 Microchip MEC Platforms:
   status: maintained


### PR DESCRIPTION
A few updates:
- Add all orphaned nxp files to the areas
- Make new NXP wireless area to house all wireless related things for now like wifi, bluetooth, ieee802154
- Add axelnxp to wireless area
- Add kw41z ieee802154 to wireless area (previously orphaned)
- Add kw24 usb board to NXP USB area (previously orphaned)
- Add hexiwear board to NXP MCU area (previously orphaned)
- Add common NXP files previously orphaned to NXP platform area
- Create new robotic product area and move all robotic boards to that area, move bperseghetti and PetervdPerk-NXP to this area.
- Add rddrone_fmuk66 to robotic area (previously orphaned)
- Add layerscape board to NXP MPU area (previously orphaned)
- Remove yvanderv (inactive collaborator)