### PR TITLE
Add WDT support to TI cc23x0 SoC

### DIFF
--- a/boards/ti/lp_em_cc2340r5/lp_em_cc2340r5.dts
+++ b/boards/ti/lp_em_cc2340r5/lp_em_cc2340r5.dts
@@ -30,6 +30,7 @@
 		led1 = &led1;
 		sw0 = &btn0;
 		sw1 = &btn1;
+		watchdog0 = &wdt0;
 	};
 
 	leds {
@@ -89,4 +90,8 @@
 		     &spi0_miso_default
 		     &spi0_cs_default>;
 	pinctrl-names = "default";
+};
+
+&wdt0 {
+	status = "okay";
 };

--- a/drivers/watchdog/CMakeLists.txt
+++ b/drivers/watchdog/CMakeLists.txt
@@ -14,6 +14,7 @@ zephyr_library_sources_ifdef(CONFIG_WDOG_CMSDK_APB wdt_cmsdk_apb.c)
 
 zephyr_library_sources_ifdef(CONFIG_WDT_CC32XX wdt_cc32xx.c)
 zephyr_library_sources_ifdef(CONFIG_WDT_CC13XX_CC26XX wdt_cc13xx_cc26xx.c)
+zephyr_library_sources_ifdef(CONFIG_WDT_CC23X0 wdt_cc23x0.c)
 zephyr_library_sources_ifdef(CONFIG_WDT_ESP32 wdt_esp32.c)
 zephyr_library_sources_ifdef(CONFIG_WDT_XT_ESP32 xt_wdt_esp32.c)
 zephyr_library_sources_ifdef(CONFIG_WDT_GECKO wdt_gecko.c)

--- a/drivers/watchdog/Kconfig
+++ b/drivers/watchdog/Kconfig
@@ -97,6 +97,8 @@ source "drivers/watchdog/Kconfig.cc32xx"
 
 source "drivers/watchdog/Kconfig.cc13xx_cc26xx"
 
+source "drivers/watchdog/Kconfig.cc23x0"
+
 source "drivers/watchdog/Kconfig.it51xxx"
 
 source "drivers/watchdog/Kconfig.it8xxx2"

--- a/drivers/watchdog/Kconfig.cc23x0
+++ b/drivers/watchdog/Kconfig.cc23x0
@@ -1,0 +1,19 @@
+# Copyright (c) 2024 BayLibre, SAS
+# SPDX-License-Identifier: Apache-2.0
+
+config WDT_CC23X0
+	bool "Watchdog Driver for CC23x0 family of MCUs"
+	default y
+	depends on DT_HAS_TI_CC23X0_WDT_ENABLED
+	select HAS_WDT_DISABLE_AT_BOOT
+	help
+	  Enable watchdog for CC23x0 family of MCUs
+
+config WDT_CC23X0_INITIAL_TIMEOUT
+	int "Value for initial WDT timeout in ms"
+	depends on WDT_CC23X0
+	default 2000
+	range 1 131072
+	help
+	  The CC23x0 watchdog timer is sourced from the LFOSC 32.768 clock
+	  Resolution is 32768 ticks per ms

--- a/drivers/watchdog/wdt_cc23x0.c
+++ b/drivers/watchdog/wdt_cc23x0.c
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2024 BayLibre, SAS
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT ti_cc23x0_wdt
+
+#include <zephyr/drivers/watchdog.h>
+#include <zephyr/irq.h>
+#include <soc.h>
+#include <errno.h>
+
+#include <inc/hw_ckmd.h>
+#include <inc/hw_types.h>
+#include <inc/hw_memmap.h>
+
+#define LOG_LEVEL CONFIG_WDT_LOG_LEVEL
+#include <zephyr/logging/log.h>
+
+LOG_MODULE_REGISTER(wdt_cc23x0);
+
+#define CC23X0_WDT_UNLOCK(_base)        (HWREG((_base) + CKMD_O_WDTLOCK) = 0x1ACCE551)
+#define CC23X0_WDT_LOCK(_base)          (HWREG((_base) + CKMD_O_WDTLOCK) = 0x1)
+#define CC23X0_WDT_FEED(_base, _value)  (HWREG((_base) + CKMD_O_WDTCNT) = (_value))
+#define CC23X0_WDT_STALL_ENABLE(_base)  (HWREG((_base) + CKMD_O_WDTTEST) = 0x1)
+#define CC23X0_WDT_STALL_DISABLE(_base) (HWREG((_base) + CKMD_O_WDTTEST) = 0x0)
+
+#define WDT_SOURCE_FREQ      32768
+#define WDT_MS_RATIO         (WDT_SOURCE_FREQ / 1000)
+#define WDT_MAX_RELOAD_MS    0xffffffff / WDT_MS_RATIO
+#define WDT_MS_TO_TICKS(_ms) ((_ms) * WDT_MS_RATIO)
+
+struct wdt_cc23x0_data {
+	uint8_t enabled;
+	uint32_t reload;
+	uint8_t flags;
+};
+
+struct wdt_cc23x0_config {
+	uint32_t base;
+};
+
+static int wdt_cc23x0_install_timeout(const struct device *dev, const struct wdt_timeout_cfg *cfg)
+{
+	struct wdt_cc23x0_data *data = dev->data;
+
+	/* window watchdog not supported */
+	if (cfg->window.min != 0U || cfg->window.max == 0U) {
+		return -EINVAL;
+	}
+
+	if (cfg->window.max > WDT_MAX_RELOAD_MS) {
+		return -EINVAL;
+	}
+	data->reload = WDT_MS_TO_TICKS(cfg->window.max);
+	data->flags = cfg->flags;
+
+	LOG_DBG("raw reload value: %d", data->reload);
+
+	return 0;
+}
+
+static int wdt_cc23x0_setup(const struct device *dev, uint8_t options)
+{
+	const struct wdt_cc23x0_config *config = dev->config;
+
+	/* Stall the WDT counter when halted by debugger */
+	if ((options & WDT_OPT_PAUSE_HALTED_BY_DBG) != 0U) {
+		CC23X0_WDT_STALL_ENABLE(config->base);
+	} else {
+		CC23X0_WDT_STALL_DISABLE(config->base);
+	}
+
+	return 0;
+}
+
+static int wdt_cc23x0_disable(const struct device *dev)
+{
+	ARG_UNUSED(dev);
+
+	return -ENOTSUP;
+}
+
+static int wdt_cc23x0_feed(const struct device *dev, int channel_id)
+{
+	ARG_UNUSED(channel_id);
+
+	const struct wdt_cc23x0_config *config = dev->config;
+	struct wdt_cc23x0_data *data = dev->data;
+
+	CC23X0_WDT_UNLOCK(config->base);
+	CC23X0_WDT_FEED(config->base, data->reload);
+
+	return 0;
+}
+
+static int wdt_cc23x0_init(const struct device *dev)
+{
+	ARG_UNUSED(dev);
+
+	return 0;
+}
+
+static DEVICE_API(wdt, wdt_cc23x0_api) = {
+	.setup = wdt_cc23x0_setup,
+	.disable = wdt_cc23x0_disable,
+	.install_timeout = wdt_cc23x0_install_timeout,
+	.feed = wdt_cc23x0_feed,
+};
+
+#define CC23X0_WDT_INIT(index)                                                                     \
+	static struct wdt_cc23x0_data wdt_cc23x0_data_##index = {                                  \
+		.reload = WDT_MS_TO_TICKS(CONFIG_WDT_CC23X0_INITIAL_TIMEOUT),                      \
+	};                                                                                         \
+	static struct wdt_cc23x0_config wdt_cc23x0_config_##index = {                              \
+		.base = DT_INST_REG_ADDR(index),                                                   \
+	};                                                                                         \
+	DEVICE_DT_INST_DEFINE(index, wdt_cc23x0_init, NULL, &wdt_cc23x0_data_##index,              \
+			      &wdt_cc23x0_config_##index, POST_KERNEL,                             \
+			      CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &wdt_cc23x0_api);
+
+DT_INST_FOREACH_STATUS_OKAY(CC23X0_WDT_INIT)

--- a/dts/arm/ti/cc23x0.dtsi
+++ b/dts/arm/ti/cc23x0.dtsi
@@ -103,6 +103,12 @@
 			interrupts = <10 0>;
 			status = "disabled";
 		};
+
+		wdt0: watchdog@40001000 {
+			compatible = "ti,cc23x0-wdt";
+			reg = <0x40001000 0x310>;
+			status = "disabled";
+		};
 	};
 };
 

--- a/dts/bindings/watchdog/ti,cc23x0-watchdog.yaml
+++ b/dts/bindings/watchdog/ti,cc23x0-watchdog.yaml
@@ -1,0 +1,12 @@
+# Copyright (c) 2024 BayLibre, SAS
+# SPDX-License-Identifier: Apache-2.0
+
+description: TI CC23x0 watchdog
+
+compatible: "ti,cc23x0-wdt"
+
+include: base.yaml
+
+properties:
+  reg:
+    required: true


### PR DESCRIPTION
This series adds WDT support to TI cc23x0 SoC.

Datasheet: https://www.ti.com/lit/ds/symlink/cc2340r5.pdf