### PR TITLE
RFC: pinctrl: add partial state setting functions

### DIFF
--- a/doc/hardware/pinctrl/index.rst
+++ b/doc/hardware/pinctrl/index.rst
@@ -436,6 +436,11 @@ function :c:func:`pinctrl_apply_state_direct` to skip state lookup if it is
 cached in advance (e.g. at init time). Since state lookup time is expected to be
 fast, it is recommended to use :c:func:`pinctrl_apply_state`.
 
+Device drivers like timers may need to control multiple groups of similar pins
+separately so that different states are applied to each group. In such cases,
+the driver can partially apply a state to a group of contiguously defined pins
+using :c:func:`pinctrl_apply_partial_state` or its ``_direct`` variant.
+
 The example below contains a complete example of a device driver that uses the
 ``pinctrl`` API.
 

--- a/tests/drivers/pinctrl/api/src/main.c
+++ b/tests/drivers/pinctrl/api/src/main.c
@@ -120,6 +120,23 @@ ZTEST(pinctrl_api, test_apply_state)
 #endif
 }
 
+/**
+ * @brief Test that pinctrl_apply_partial_state() works as expected.
+ */
+ZTEST(pinctrl_api, test_apply_partial_state)
+{
+	zassert_not_ok(pinctrl_apply_partial_state(pcfg1, PINCTRL_STATE_MYSTATE, 2, 2));
+	zassert_ok(pinctrl_apply_partial_state(pcfg1, PINCTRL_STATE_MYSTATE, 1, 2));
+
+	zassert_equal(pcfg1->states[1].pins + 1, pinctrl_configure_pins_fake.arg0_val);
+	zassert_equal(2, pinctrl_configure_pins_fake.arg1_val);
+#ifdef CONFIG_PINCTRL_STORE_REG
+	zassert_equal(1, pinctrl_configure_pins_fake.arg2_val);
+#else
+	zassert_equal(PINCTRL_REG_NONE, pinctrl_configure_pins_fake.arg2_val);
+#endif
+}
+
 /** Test device 0 alternative pins for default state */
 PINCTRL_DT_STATE_PINS_DEFINE(DT_PATH(zephyr_user), test_device0_alt_default);
 /** Test device 0 alternative pins for sleep state */


### PR DESCRIPTION
Add `pinctrl_apply_partial_state` and `pinctrl_apply_partial_state_direct` functions to apply a state only to a subset of the state pins. This is useful for channel-based devices, such as timers or LED drivers, that operate multiple (groups of) pins independently.

Test suite and docs are also updated for the new feature.