### PR TITLE
Makes esp_console_init() calling conditional

### DIFF
--- a/drivers/clock_control/clock_control_esp32.c
+++ b/drivers/clock_control/clock_control_esp32.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020 Mohamed ElShahawi.
- * Copyright (c) 2021-2024 Espressif Systems (Shanghai) Co., Ltd.
+ * Copyright (c) 2021-2025 Espressif Systems (Shanghai) Co., Ltd.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -193,10 +193,10 @@ static void esp32_clock_perip_init(void)
 		common_perip_clk =
 #if defined(CONFIG_SOC_SERIES_ESP32C2)
 			SYSTEM_SPI2_CLK_EN |
-#if ESP_CONSOLE_UART_NUM != 0
+#if CONFIG_ESP_CONSOLE_UART_NUM != 0
 			SYSTEM_UART_CLK_EN |
 #endif
-#if ESP_CONSOLE_UART_NUM != 1
+#if CONFIG_ESP_CONSOLE_UART_NUM != 1
 			SYSTEM_UART1_CLK_EN |
 #endif
 			SYSTEM_LEDC_CLK_EN |
@@ -205,14 +205,14 @@ static void esp32_clock_perip_init(void)
 #elif (defined(CONFIG_SOC_SERIES_ESP32C3) || defined(CONFIG_SOC_SERIES_ESP32S3))
 			SYSTEM_WDG_CLK_EN |
 			SYSTEM_I2S0_CLK_EN |
-#if ESP_CONSOLE_UART_NUM != 0
+#if CONFIG_ESP_CONSOLE_UART_NUM != 0
 			SYSTEM_UART_CLK_EN |
 #endif
-#if ESP_CONSOLE_UART_NUM != 1
+#if CONFIG_ESP_CONSOLE_UART_NUM != 1
 			SYSTEM_UART1_CLK_EN |
 #endif
 #if defined(CONFIG_SOC_SERIES_ESP32S3)
-#if ESP_CONSOLE_UART_NUM != 2
+#if CONFIG_ESP_CONSOLE_UART_NUM != 2
 			SYSTEM_UART2_CLK_EN |
 #endif
 			SYSTEM_USB_CLK_EN |
@@ -313,23 +313,23 @@ static void esp32_clock_perip_init(void)
 	common_perip_clk |=
 #if defined(CONFIG_SOC_SERIES_ESP32C2)
 			SYSTEM_SPI2_CLK_EN |
-#if ESP_CONSOLE_UART_NUM != 0
+#if CONFIG_ESP_CONSOLE_UART_NUM != 0
 			SYSTEM_UART_CLK_EN |
 #endif
-#if ESP_CONSOLE_UART_NUM != 1
+#if CONFIG_ESP_CONSOLE_UART_NUM != 1
 			SYSTEM_UART1_CLK_EN |
 #endif
 			SYSTEM_I2C_EXT0_CLK_EN;
 #elif (defined(CONFIG_SOC_SERIES_ESP32C3) || defined(CONFIG_SOC_SERIES_ESP32S3))
 			SYSTEM_I2S0_CLK_EN |
-#if ESP_CONSOLE_UART_NUM != 0
+#if CONFIG_ESP_CONSOLE_UART_NUM != 0
 			SYSTEM_UART_CLK_EN |
 #endif
-#if ESP_CONSOLE_UART_NUM != 1
+#if CONFIG_ESP_CONSOLE_UART_NUM != 1
 			SYSTEM_UART1_CLK_EN |
 #endif
 #if defined(CONFIG_SOC_SERIES_ESP32S3)
-#if ESP_CONSOLE_UART_NUM != 2
+#if CONFIG_ESP_CONSOLE_UART_NUM != 2
 			SYSTEM_UART2_CLK_EN |
 #endif
 			SYSTEM_USB_CLK_EN |
@@ -354,15 +354,15 @@ static void esp32_clock_perip_init(void)
 			DPORT_UHCI1_CLK_EN |
 			DPORT_SPI3_CLK_EN |
 			DPORT_I2C_EXT1_CLK_EN |
-#if ESP_CONSOLE_UART_NUM != 0
+#if CONFIG_ESP_CONSOLE_UART_NUM != 0
 			DPORT_UART_CLK_EN |
 #endif
-#if ESP_CONSOLE_UART_NUM != 1
+#if CONFIG_ESP_CONSOLE_UART_NUM != 1
 			DPORT_UART1_CLK_EN |
 #endif
 #if defined(CONFIG_SOC_SERIES_ESP32)
 			DPORT_SPI_DMA_CLK_EN |
-#if ESP_CONSOLE_UART_NUM != 2
+#if CONFIG_ESP_CONSOLE_UART_NUM != 2
 			DPORT_UART2_CLK_EN |
 #endif
 #endif /* CONFIG_SOC_SERIES_ESP32 */
@@ -637,7 +637,7 @@ static int esp32_cpu_clock_configure(const struct esp32_cpu_clock_config *cpu_cf
 	rtc_clk_cfg.xtal_freq = cpu_cfg->xtal_freq;
 	rtc_clk_cfg.cpu_freq_mhz = cpu_cfg->cpu_freq;
 
-	esp_rom_uart_tx_wait_idle(ESP_CONSOLE_UART_NUM);
+	esp_rom_uart_tx_wait_idle(CONFIG_ESP_CONSOLE_UART_NUM);
 
 #if defined(CONFIG_SOC_SERIES_ESP32C6)
 	rtc_clk_modem_clock_domain_active_state_icg_map_preinit();
@@ -702,15 +702,15 @@ static int esp32_cpu_clock_configure(const struct esp32_cpu_clock_config *cpu_cf
 	esp_cpu_set_cycle_count((uint64_t)esp_cpu_get_cycle_count() * rtc_clk_cfg.cpu_freq_mhz /
 				old_config.freq_mhz);
 
-#if !defined(ESP_CONSOLE_UART_NONE)
+#if !defined(CONFIG_ESP_CONSOLE_UART_NONE)
 #if !defined(CONFIG_SOC_SERIES_ESP32C2) && !defined(CONFIG_SOC_SERIES_ESP32C6)
 #if defined(CONFIG_MCUBOOT) && defined(ESP_ROM_UART_CLK_IS_XTAL)
 	uint32_t uart_clock_src_hz = (uint32_t)rtc_clk_xtal_freq_get() * MHZ(1);
 #else
 	uint32_t uart_clock_src_hz = esp_clk_apb_freq();
 #endif
-	esp_rom_uart_set_clock_baudrate(ESP_CONSOLE_UART_NUM, uart_clock_src_hz,
-					ESP_CONSOLE_UART_BAUDRATE);
+	esp_rom_uart_set_clock_baudrate(CONFIG_ESP_CONSOLE_UART_NUM, uart_clock_src_hz,
+					CONFIG_ESP_CONSOLE_UART_BAUDRATE);
 #endif
 #endif
 	return 0;

--- a/soc/espressif/esp32/hw_init.c
+++ b/soc/espressif/esp32/hw_init.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2024-2025 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -51,9 +51,11 @@ int hardware_init(void)
 
 	bootloader_clock_configure();
 
+#ifdef CONFIG_ESP_CONSOLE
 	/* initialize console, from now on, we can log */
 	esp_console_init();
 	print_banner();
+#endif /* CONFIG_ESP_CONSOLE */
 
 	spi_flash_init_chip_state();
 	err = esp_flash_init_default_chip();

--- a/soc/espressif/esp32c2/hw_init.c
+++ b/soc/espressif/esp32c2/hw_init.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2024-2025 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -51,9 +51,11 @@ int hardware_init(void)
 
 	bootloader_clock_configure();
 
+#ifdef CONFIG_ESP_CONSOLE
 	/* initialize console, from now on, we can log */
 	esp_console_init();
 	print_banner();
+#endif /* CONFIG_ESP_CONSOLE */
 
 	spi_flash_init_chip_state();
 	err = esp_flash_init_default_chip();

--- a/soc/espressif/esp32c3/hw_init.c
+++ b/soc/espressif/esp32c3/hw_init.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2024-2025 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -53,9 +53,12 @@ int hardware_init(void)
 
 	bootloader_clock_configure();
 
+#ifdef CONFIG_ESP_CONSOLE
 	/* initialize console, from now on, we can log */
 	esp_console_init();
 	print_banner();
+#endif /* CONFIG_ESP_CONSOLE */
+
 
 	spi_flash_init_chip_state();
 	err = esp_flash_init_default_chip();

--- a/soc/espressif/esp32c6/hw_init.c
+++ b/soc/espressif/esp32c6/hw_init.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2024-2025 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -69,9 +69,11 @@ int hardware_init(void)
 
 	bootloader_clock_configure();
 
+#ifdef CONFIG_ESP_CONSOLE
 	/* initialize console, from now on, we can log */
 	esp_console_init();
 	print_banner();
+#endif /* CONFIG_ESP_CONSOLE */
 
 	spi_flash_init_chip_state();
 	err = esp_flash_init_default_chip();

--- a/soc/espressif/esp32s2/hw_init.c
+++ b/soc/espressif/esp32s2/hw_init.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2024-2025 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -51,9 +51,11 @@ int hardware_init(void)
 
 	bootloader_clock_configure();
 
+#ifdef CONFIG_ESP_CONSOLE
 	/* initialize console, from now on, we can log */
 	esp_console_init();
 	print_banner();
+#endif /* CONFIG_ESP_CONSOLE */
 
 	spi_flash_init_chip_state();
 	err = esp_flash_init_default_chip();

--- a/soc/espressif/esp32s3/hw_init.c
+++ b/soc/espressif/esp32s3/hw_init.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2024-2025 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -57,9 +57,11 @@ int hardware_init(void)
 
 	bootloader_clock_configure();
 
+#ifdef CONFIG_ESP_CONSOLE
 	/* initialize console, from now on, we can log */
 	esp_console_init();
 	print_banner();
+#endif /* CONFIG_ESP_CONSOLE */
 
 	spi_flash_init_chip_state();
 	err = esp_flash_init_default_chip();

--- a/west.yml
+++ b/west.yml
@@ -162,7 +162,7 @@ manifest:
       groups:
         - hal
     - name: hal_espressif
-      revision: 59d49a284136fb718cdd6e7b6a56d484f746d215
+      revision: c0b38024651cb917d7b6e31b50adf1202e0a10d6
       path: modules/hal/espressif
       west-commands: west/west-commands.yml
       groups:


### PR DESCRIPTION
Makes the esp_console_init() calling during hardware initialization conditioned to CONFIG_ESP_CONSOLE_UART and to
CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG since the definition of esp_console_init() definition is conditioned to these both parameter.

Fixes #84115