### PR TITLE
samples: usb: dfu: Exclude all Atmel SAM0

### DIFF
--- a/samples/subsys/usb/dfu/sample.yaml
+++ b/samples/subsys/usb/dfu/sample.yaml
@@ -12,8 +12,21 @@ common:
     - mimxrt1060_evk@B/mimxrt1062/qspi
     - mimxrt1060_evk@C/mimxrt1062/qspi
     - sam4l_ek
+    - samd21_xpro
     - same54_xpro
+    - saml21_xpro
     - samr21_xpro
+    - samr34_xpro
+    - adafruit_feather_m4_express
+    - adafruit_grand_central_m4_express
+    - adafruit_itsybitsy_m4_express
+    - adafruit_trinket_m0
+    - arduino_nano_33_iot
+    - arduino_mkrzero
+    - arduino_zero
+    - seeeduino_xiao
+    - serpente
+    - wio_terminal
     - mimxrt1050_evk/mimxrt1052/hyperflash
     - mimxrt1050_evk/mimxrt1052/qspi
     - mimxrt1060_evk/mimxrt1062/hyperflash


### PR DESCRIPTION
The dfu sample filter seems not to work. It should select only boards when `slot0_partition` and `slot1_partition` are define. This is just a continuation of #84195. The issue is documented on #84196.

This add all the sam0 boards in the exclusion list until the issue is fixed.