### PR TITLE
Renamed _Fault to z_${ARCH}_fault

### DIFF
--- a/arch/arc/core/fault.c
+++ b/arch/arc/core/fault.c
@@ -346,7 +346,7 @@ static void dump_exception_info(uint32_t vector, uint32_t cause, uint32_t parame
  * invokes the user provided routine k_sys_fatal_error_handler() which is
  * responsible for implementing the error handling policy.
  */
-void _Fault(struct arch_esf *esf, uint32_t old_sp)
+void z_arc_fault(struct arch_esf *esf, uint32_t old_sp)
 {
 	uint32_t vector, cause, parameter;
 	uint32_t exc_addr = z_arc_v2_aux_reg_read(_ARC_V2_EFA);

--- a/arch/arc/core/fault_s.S
+++ b/arch/arc/core/fault_s.S
@@ -19,7 +19,7 @@
 #include <zephyr/syscall.h>
 #include <zephyr/arch/arc/asm-compat/assembler.h>
 
-GTEXT(_Fault)
+GTEXT(z_arc_fault)
 GTEXT(__reset)
 GTEXT(__memory_error)
 GTEXT(__instruction_error)
@@ -99,11 +99,11 @@ _exc_entry:
 
 	_save_exc_regs_into_stack
 
-	/* sp is parameter of _Fault */
+	/* sp is parameter of z_arc_fault */
 	MOVR r0, sp
 	/* ilink is the thread's original sp */
 	MOVR r1, ilink
-	jl _Fault
+	jl z_arc_fault
 
 _exc_return:
 /* the exception cause must be fixed in exception handler when exception returns

--- a/arch/mips/core/fatal.c
+++ b/arch/mips/core/fatal.c
@@ -84,7 +84,7 @@ static char *cause_str(unsigned long cause)
 	}
 }
 
-void _Fault(struct arch_esf *esf)
+void z_mips_fault(struct arch_esf *esf)
 {
 	unsigned long cause;
 

--- a/arch/mips/core/isr.S
+++ b/arch/mips/core/isr.S
@@ -66,7 +66,7 @@
 	addi sp, sp, __struct_arch_esf_SIZEOF	;
 
 /* imports */
-GTEXT(_Fault)
+GTEXT(z_mips_fault)
 
 GTEXT(_k_neg_eagain)
 GTEXT(z_thread_mark_switched_in)
@@ -125,7 +125,7 @@ SECTION_FUNC(exception.other, _mips_interrupt)
 
 unhandled:
 	move a0, sp
-	jal _Fault
+	jal z_mips_fault
 	eret
 
 is_kernel_syscall:

--- a/arch/nios2/core/exception.S
+++ b/arch/nios2/core/exception.S
@@ -12,7 +12,7 @@
 GTEXT(_exception)
 
 /* import */
-GTEXT(_Fault)
+GTEXT(z_nios2_fault)
 GTEXT(arch_swap)
 #ifdef CONFIG_IRQ_OFFLOAD
 GTEXT(z_irq_do_offload)
@@ -171,12 +171,12 @@ not_interrupt:
 
 _exception_enter_fault:
 	/* If we get here, the exception wasn't in interrupt or an
-	 * invocation of irq_offload(). Let _Fault() handle it in
+	 * invocation of irq_offload(). Let z_nios2_fault() handle it in
 	 * C domain
 	 */
 
 	mov  r4, sp
-	call _Fault
+	call z_nios2_fault
 	jmpi _exception_exit
 
 no_reschedule:

--- a/arch/nios2/core/exception.S
+++ b/arch/nios2/core/exception.S
@@ -171,7 +171,7 @@ not_interrupt:
 
 _exception_enter_fault:
 	/* If we get here, the exception wasn't in interrupt or an
-	 * invocation of irq_oflload(). Let _Fault() handle it in
+	 * invocation of irq_offload(). Let _Fault() handle it in
 	 * C domain
 	 */
 

--- a/arch/nios2/core/fatal.c
+++ b/arch/nios2/core/fatal.c
@@ -102,7 +102,7 @@ static char *cause_str(uint32_t cause_code)
 }
 #endif
 
-FUNC_NORETURN void _Fault(const struct arch_esf *esf)
+FUNC_NORETURN void z_nios2_fault(const struct arch_esf *esf)
 {
 #if defined(CONFIG_PRINTK) || defined(CONFIG_LOG)
 	/* Unfortunately, completely unavailable on Nios II/e cores */

--- a/arch/riscv/core/fatal.c
+++ b/arch/riscv/core/fatal.c
@@ -203,7 +203,7 @@ static bool bad_stack_pointer(struct arch_esf *esf)
 	return false;
 }
 
-void _Fault(struct arch_esf *esf)
+void z_riscv_fault(struct arch_esf *esf)
 {
 #ifdef CONFIG_USERSPACE
 	/*

--- a/arch/riscv/core/isr.S
+++ b/arch/riscv/core/isr.S
@@ -72,7 +72,7 @@ GDATA(_sw_isr_table)
 GTEXT(__soc_is_irq)
 #endif
 GTEXT(__soc_handle_irq)
-GTEXT(_Fault)
+GTEXT(z_riscv_fault)
 #ifdef CONFIG_RISCV_SOC_CONTEXT_SAVE
 GTEXT(__soc_save_context)
 GTEXT(__soc_restore_context)
@@ -336,7 +336,7 @@ no_fp:	/* increment _current->arch.exception_depth */
 
 	/*
 	 * If the exception is the result of an ECALL, check whether to
-	 * perform a context-switch or an IRQ offload. Otherwise call _Fault
+	 * perform a context-switch or an IRQ offload. Otherwise call z_riscv_fault
 	 * to report the exception.
 	 */
 	csrr t0, mcause
@@ -375,15 +375,15 @@ no_fp:	/* increment _current->arch.exception_depth */
 #endif /* CONFIG_USERSPACE */
 
 	/*
-	 * Call _Fault to handle exception.
+	 * Call z_riscv_fault to handle exception.
 	 * Stack pointer is pointing to a struct_arch_esf structure, pass it
-	 * to _Fault (via register a0).
-	 * If _Fault shall return, set return address to
+	 * to z_riscv_fault (via register a0).
+	 * If z_riscv_fault shall return, set return address to
 	 * no_reschedule to restore stack.
 	 */
 	mv a0, sp
 	la ra, no_reschedule
-	tail _Fault
+	tail z_riscv_fault
 
 is_kernel_syscall:
 	/*


### PR DESCRIPTION
During the development of the OpenRISC port of Zephyr, it was noticed that multiple architectures have common fatal exception handling code in a function named `_Fault`. This name is inconsistent with all other functions defined in code for the various architectures. 

This PR proposes that these functions be renamed to `z_${ARCH}_fault` i.e. `z_arc_fault`, `z_mips_fault`, `z_nios2_fault` and `z_riscv_fault` respectively to improve consistency.