### PR TITLE
drivers: counter: Add MCP7940N property to enable VBAT backup

### DIFF
--- a/dts/bindings/rtc/microchip,mcp7940n.yaml
+++ b/dts/bindings/rtc/microchip,mcp7940n.yaml
@@ -1,6 +1,7 @@
 #
 # Copyright (c) 2021 Laird Connectivity
 # Copyright (c) 2023 Nordic Semiconductor ASA
+# Copyright (c) 2025 Marcin Lyda <elektromarcin@gmail.com>
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -21,3 +22,8 @@ properties:
       Host input connected to the MCP7940N MFP open drain output pin
 
       Notifies when an alarm has triggered by asserting this line.
+
+  vbat-enable:
+    type: boolean
+    description: |
+      Enables external battery backup functionality


### PR DESCRIPTION
This PR adds a new devicetree property that allows enabling external battery backup functionality.