### PR TITLE
soc: adi: max32: Enable primary core to configure/start secondary core

### DIFF
--- a/soc/adi/max32/Kconfig
+++ b/soc/adi/max32/Kconfig
@@ -16,6 +16,21 @@ config SOC_FAMILY_MAX32_M4
 	select CPU_HAS_ARM_MPU
 	select CPU_HAS_FPU
 
+config SOC_MAX32655_M4
+	select MAX32_HAS_SECONDARY_RV32
+
+config SOC_MAX32680_M4
+	select MAX32_HAS_SECONDARY_RV32
+
+config SOC_MAX32690_M4
+	select MAX32_HAS_SECONDARY_RV32
+
+config SOC_MAX78000_M4
+	select MAX32_HAS_SECONDARY_RV32
+
+config SOC_MAX78002_M4
+	select MAX32_HAS_SECONDARY_RV32
+
 if SOC_FAMILY_MAX32
 
 config MAX32_ON_ENTER_CPU_IDLE_HOOK
@@ -27,5 +42,19 @@ config MAX32_ON_ENTER_CPU_IDLE_HOOK
 	  the CPU is made idle (by k_cpu_idle() or k_cpu_atomic_idle()).
 	  If needed, this hook can be used to prevent the CPU from actually
 	  entering sleep by skipping the WFE/WFI instruction.
+
+config MAX32_HAS_SECONDARY_RV32
+	bool
+
+config MAX32_SECONDARY_RV32
+	bool "Secondary RISC-V core enable"
+	depends on MAX32_HAS_SECONDARY_RV32
+
+DT_CHOSEN_Z_CODE_RV32_PARTITION := zephyr,code-rv32-partition
+
+config MAX32_SECONDARY_RV32_BOOT_ADDRESS
+	hex "Secondary RISC-V core boot address"
+	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_CODE_RV32_PARTITION))
+	depends on MAX32_SECONDARY_RV32
 
 endif # SOC_FAMILY_MAX32

--- a/soc/adi/max32/Kconfig
+++ b/soc/adi/max32/Kconfig
@@ -4,44 +4,17 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config SOC_FAMILY_MAX32
-	select ARM
-	select CPU_HAS_ARM_MPU
-	select CPU_HAS_FPU
-	select CPU_CORTEX_M_HAS_SYSTICK
 	select CLOCK_CONTROL
 	select BUILD_OUTPUT_HEX
 	select SOC_EARLY_INIT_HOOK
 	select HAS_SEGGER_RTT if ZEPHYR_SEGGER_MODULE
 
-config SOC_MAX32655
+config SOC_FAMILY_MAX32_M4
+	select ARM
 	select CPU_CORTEX_M4
-
-config SOC_MAX32662
-	select CPU_CORTEX_M4
-
-config SOC_MAX32666
-	select CPU_CORTEX_M4
-
-config SOC_MAX32670
-	select CPU_CORTEX_M4
-
-config SOC_MAX32672
-	select CPU_CORTEX_M4
-
-config SOC_MAX32675
-	select CPU_CORTEX_M4
-
-config SOC_MAX32680
-	select CPU_CORTEX_M4
-
-config SOC_MAX32690
-	select CPU_CORTEX_M4
-
-config SOC_MAX78000_M4
-	select CPU_CORTEX_M4
-
-config SOC_MAX78002_M4
-	select CPU_CORTEX_M4
+	select CPU_CORTEX_M_HAS_SYSTICK
+	select CPU_HAS_ARM_MPU
+	select CPU_HAS_FPU
 
 if SOC_FAMILY_MAX32
 

--- a/soc/adi/max32/Kconfig.soc
+++ b/soc/adi/max32/Kconfig.soc
@@ -6,72 +6,76 @@
 config SOC_FAMILY_MAX32
 	bool
 
+config SOC_FAMILY_MAX32_M4
+	bool
+	select SOC_FAMILY_MAX32
+
 config SOC_FAMILY
 	default "max32" if SOC_FAMILY_MAX32
 
 config SOC_MAX32655
 	bool
-	select SOC_FAMILY_MAX32
 
 config SOC_MAX32655_M4
 	bool
 	select SOC_MAX32655
+	select SOC_FAMILY_MAX32_M4
 
 config SOC_MAX32662
 	bool
-	select SOC_FAMILY_MAX32
+	select SOC_FAMILY_MAX32_M4
 
 config SOC_MAX32666
 	bool
-	select SOC_FAMILY_MAX32
 
 config SOC_MAX32666_CPU0
 	bool
 	select SOC_MAX32666
+	select SOC_FAMILY_MAX32_M4
 
 config SOC_MAX32670
 	bool
-	select SOC_FAMILY_MAX32
+	select SOC_FAMILY_MAX32_M4
 
 config SOC_MAX32672
 	bool
-	select SOC_FAMILY_MAX32
+	select SOC_FAMILY_MAX32_M4
 
 config SOC_MAX32675
 	bool
-	select SOC_FAMILY_MAX32
+	select SOC_FAMILY_MAX32_M4
 
 config SOC_MAX32680
 	bool
-	select SOC_FAMILY_MAX32
 
 config SOC_MAX32680_M4
 	bool
 	select SOC_MAX32680
+	select SOC_FAMILY_MAX32_M4
 
 config SOC_MAX32690
 	bool
-	select SOC_FAMILY_MAX32
 
 config SOC_MAX32690_M4
 	bool
 	select SOC_MAX32690
+	select SOC_FAMILY_MAX32_M4
 
 config SOC_MAX78000
 	bool
-	select SOC_FAMILY_MAX32
 
 config SOC_MAX78000_M4
 	bool
 	select SOC_MAX78000
+	select SOC_FAMILY_MAX32_M4
 
 config SOC_MAX78002
 	bool
-	select SOC_FAMILY_MAX32
 
 config SOC_MAX78002_M4
 	bool
 	select SOC_MAX78002
+	select SOC_FAMILY_MAX32_M4
 
 config SOC
 	default "max32655" if SOC_MAX32655

--- a/soc/adi/max32/soc.c
+++ b/soc/adi/max32/soc.c
@@ -14,6 +14,10 @@
 
 #include <wrap_max32_sys.h>
 
+#ifdef CONFIG_MAX32_SECONDARY_RV32
+#include <fcr_regs.h>
+#endif
+
 #if defined(CONFIG_MAX32_ON_ENTER_CPU_IDLE_HOOK)
 bool z_arm_on_enter_cpu_idle(void)
 {
@@ -31,4 +35,10 @@ void soc_early_init_hook(void)
 {
 	/* Apply device related preinit configuration */
 	max32xx_system_init();
+
+#ifdef CONFIG_MAX32_SECONDARY_RV32
+	MXC_FCR->urvbootaddr = CONFIG_MAX32_SECONDARY_RV32_BOOT_ADDRESS;
+	MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_CPU1);
+	MXC_GCR->rst1 |= MXC_F_GCR_RST1_CPU1;
+#endif /* CONFIG_MAX32_SECONDARY_RV32 */
 }


### PR DESCRIPTION
Adds support for the primary m4 core to configure the boot address and
start the clock for the secondary risc-v core. Unlike the msdk which
defers this function to applications and requires users to copy/paste
code from an msdk example application into their own application, in
zephyr it is implemented in the common soc init routine of the primary
core. It can be enabled/disabled and configured with Kconfig symbols and
a devicetree chosen node, allowing applications to override board-level
defaults if desired using overlays instead of modifying zephyr code.

Signed-off-by: Maureen Helm <maureen.helm@analog.com>