### PR TITLE
logging: backend_fs: disable ANSI color for filesystem logging

### DIFF
--- a/subsys/logging/backends/log_backend_fs.c
+++ b/subsys/logging/backends/log_backend_fs.c
@@ -481,7 +481,7 @@ static void dropped(const struct log_backend *const backend, uint32_t cnt)
 static void process(const struct log_backend *const backend,
 		union log_msg_generic *msg)
 {
-	uint32_t flags = log_backend_std_get_flags();
+	uint32_t flags = log_backend_std_get_flags() & ~LOG_OUTPUT_FLAG_COLORS;
 
 	log_format_func_t log_output_func = log_format_func_t_get(log_format_current);
 


### PR DESCRIPTION
Disable ANSI color output for the filesystem backend.

Previously with LOG_BACKEND_SHOW_COLOR=n and CONFIG_SHELL_VT100_COLORS=y the shell would still display colors by enabling the flag in the `shell_log_backend.c`.

See discussion in https://discord.com/channels/720317445772017664/1331905134703284274 for some context.