### PR TITLE
modules: hal_rpi_pico: Add XIP-cache codes

### DIFF
--- a/modules/hal_rpi_pico/CMakeLists.txt
+++ b/modules/hal_rpi_pico/CMakeLists.txt
@@ -63,6 +63,7 @@ if(CONFIG_HAS_RPI_PICO)
     ${rp2_common_dir}/hardware_watchdog/watchdog.c
     ${rp2_common_dir}/hardware_sync_spin_lock/sync_spin_lock.c
     ${rp2_common_dir}/hardware_ticks/ticks.c
+    ${rp2_common_dir}/hardware_xip_cache/xip_cache.c
     ${rp2_common_dir}/pico_bootrom/bootrom.c
     ${rp2xxx_dir}/pico_platform/platform.c
   )
@@ -82,6 +83,7 @@ if(CONFIG_HAS_RPI_PICO)
     ${rp2_common_dir}/hardware_boot_lock/include
     ${rp2_common_dir}/hardware_ticks/include
     ${rp2_common_dir}/hardware_sync_spin_lock/include
+    ${rp2_common_dir}/hardware_xip_cache/include
     ${rp2_common_dir}/pico_bootrom/include
     ${rp2_common_dir}/pico_flash/include
     ${rp2_common_dir}/pico_platform_compiler/include

--- a/west.yml
+++ b/west.yml
@@ -224,7 +224,7 @@ manifest:
         - hal
     - name: hal_rpi_pico
       path: modules/hal/rpi_pico
-      revision: 7b57b24588797e6e7bf18b6bda168e6b96374264
+      revision: pull/9/head
       groups:
         - hal
     - name: hal_silabs


### PR DESCRIPTION
Add XIP-cache codes that are referenced from the flash driver.

This patch fixes the compilation error in modules/hal/rpi_pico/src/rp2_common/hardware_flash/flash.c.