### PR TITLE
drivers: gnss: Add geoid separation to gnss_info

### DIFF
--- a/drivers/gnss/gnss_nmea0183.c
+++ b/drivers/gnss/gnss_nmea0183.c
@@ -545,6 +545,16 @@ int gnss_nmea0183_parse_gga(const char **argv, uint16_t argc, struct gnss_data *
 	}
 
 	data->nav_data.altitude = (int32_t)tmp64;
+
+	/* Parse geoid separation */
+	if ((gnss_parse_dec_to_milli(argv[11], &tmp64) < 0) ||
+	    (tmp64 > INT32_MAX) ||
+	    (tmp64 < INT32_MIN)) {
+		return -EINVAL;
+	}
+
+	data->info.geoid_separation = (int32_t)tmp64;
+
 	return 0;
 }
 

--- a/include/zephyr/data/navigation.h
+++ b/include/zephyr/data/navigation.h
@@ -31,7 +31,7 @@ struct navigation_data {
 	uint32_t bearing;
 	/** Speed in millimeters per second */
 	uint32_t speed;
-	/** Altitude in millimeters */
+	/** Altitude above MSL in millimeters */
 	int32_t altitude;
 };
 

--- a/include/zephyr/drivers/gnss.h
+++ b/include/zephyr/drivers/gnss.h
@@ -140,6 +140,8 @@ struct gnss_info {
 	uint16_t satellites_cnt;
 	/** Horizontal dilution of precision in 1/1000 */
 	uint32_t hdop;
+	/** Geoid separation in millimeters */
+	int32_t geoid_separation;
 	/** The fix status */
 	enum gnss_fix_status fix_status;
 	/** The fix quality */


### PR DESCRIPTION
Currently altitude is only provided above MSL. Adding geoid separation allows for ellipsoidal height to be determined. This is important for many applications.

Curious whether others think this should live in `navigation_data` or `gnss_info`