### PR TITLE
drivers: gpio_rpi_pico: Extend the driver API

### DIFF
--- a/drivers/gpio/gpio_rpi_pico.c
+++ b/drivers/gpio/gpio_rpi_pico.c
@@ -57,6 +57,12 @@ static int gpio_rpi_configure(const struct device *dev,
 	/* Avoid gpio_init, since that also clears previously set direction/high/low */
 	gpio_set_function(pin, GPIO_FUNC_SIO);
 
+	if (flags & GPIO_INPUT) {
+		gpio_set_dir(pin, GPIO_IN);
+	} else {
+		gpio_set_input_enabled(pin, false);
+	}
+
 	if (flags & GPIO_OUTPUT) {
 		if (flags & GPIO_SINGLE_ENDED) {
 			data->single_ended_mask |= BIT(pin);
@@ -84,8 +90,6 @@ static int gpio_rpi_configure(const struct device *dev,
 			}
 			gpio_set_dir(pin, GPIO_OUT);
 		}
-	} else if (flags & GPIO_INPUT) {
-		gpio_set_dir(pin, GPIO_IN);
 	}
 
 	return 0;

--- a/drivers/gpio/gpio_rpi_pico.c
+++ b/drivers/gpio/gpio_rpi_pico.c
@@ -39,8 +39,15 @@ static int gpio_rpi_configure(const struct device *dev,
 {
 	struct gpio_rpi_data *data = dev->data;
 
-	if ((flags & GPIO_DIR_MASK) == GPIO_DISCONNECTED) {
-		return -ENOTSUP;
+	if (flags == GPIO_DISCONNECTED) {
+		gpio_disable_pulls(pin);
+		/* This is almost the opposite of the Pico SDK's gpio_set_function. */
+		hw_write_masked(&pads_bank0_hw->io[pin], PADS_BANK0_GPIO0_OD_BITS,
+				PADS_BANK0_GPIO0_IE_BITS | PADS_BANK0_GPIO0_OD_BITS);
+#ifdef SOC_SERIES_RP2350
+		hw_set_bits(&pads_bank0_hw->io[gpio], PADS_BANK0_GPIO0_ISO_BITS);
+#endif
+		return 0;
 	}
 
 	gpio_set_pulls(pin,

--- a/drivers/gpio/gpio_rpi_pico.c
+++ b/drivers/gpio/gpio_rpi_pico.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021, Yonatan Schachter
+ * Copyright (c) 2025, Andrew Featherstone
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -193,6 +194,19 @@ static int gpio_rpi_manage_callback(const struct device *dev,
 	return gpio_manage_callback(&data->callbacks, callback, set);
 }
 
+static uint32_t gpio_rpi_get_pending_int(const struct device *dev)
+{
+	io_bank0_irq_ctrl_hw_t *irq_ctrl_base =
+		get_core_num() ? &io_bank0_hw->proc1_irq_ctrl : &io_bank0_hw->proc0_irq_ctrl;
+	ARRAY_FOR_EACH_PTR(irq_ctrl_base->ints, p) {
+		if (*p) {
+			return 1;
+		}
+	}
+
+	return 0;
+}
+
 static DEVICE_API(gpio, gpio_rpi_driver_api) = {
 	.pin_configure = gpio_rpi_configure,
 	.port_get_raw = gpio_rpi_port_get_raw,
@@ -202,6 +216,7 @@ static DEVICE_API(gpio, gpio_rpi_driver_api) = {
 	.port_toggle_bits = gpio_rpi_port_toggle_bits,
 	.pin_interrupt_configure = gpio_rpi_pin_interrupt_configure,
 	.manage_callback = gpio_rpi_manage_callback,
+	.get_pending_int = gpio_rpi_get_pending_int,
 };
 
 static void gpio_rpi_isr(const struct device *dev)


### PR DESCRIPTION
Edit:

The original goal of this PR was to add just the `gpio_get_config`. This PR has now widened to include a lot more functionality, extending the both the existing APIs to be more feature-complete, and adding new APIs that were missing.

Tested locally using a physical test fixture supporting the GPIO loopback.