### PR TITLE
drivers: bluetooth: hci: h4_ifx_cyw43xxx: add missing hci includes

### DIFF
--- a/drivers/bluetooth/hci/h4_ifx_cyw43xxx.c
+++ b/drivers/bluetooth/hci/h4_ifx_cyw43xxx.c
@@ -15,6 +15,8 @@
 #include <zephyr/kernel.h>
 #include <zephyr/device.h>
 #include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/hci.h>
+#include <zephyr/bluetooth/hci_types.h>
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/uart.h>
 


### PR DESCRIPTION
Add missing `bluetooth/hci.h` and `hci_types.h` include to fix the build error and warnings of the infineon h4 ble driver.

The driver is using `bt_hci_cmd_create()` and `bt_hci_cmd_send_sync()` from bluetooth/hci.h, and `BT_HCI_OP_RESET` from bluetooth/hci_types.h

bluetooth/hci.h was removed in pr #81618, so the necessary files have neither been directly nor indirectly included.
