### PR TITLE
drivers: display: Add display_clear function

### DIFF
--- a/doc/releases/release-notes-4.2.rst
+++ b/doc/releases/release-notes-4.2.rst
@@ -81,6 +81,10 @@ New APIs and options
 
     * :c:func:`bt_le_get_local_features`
 
+* Display
+
+  * :c:func:`display_clear`
+
 New Boards
 **********
 

--- a/drivers/display/display_sdl.c
+++ b/drivers/display/display_sdl.c
@@ -428,6 +428,45 @@ static int sdl_display_read(const struct device *dev, const uint16_t x,
 	return 0;
 }
 
+static int sdl_display_clear(const struct device *dev)
+{
+	const struct sdl_display_config *config = dev->config;
+	struct sdl_display_data *disp_data = dev->data;
+	uint8_t bgcolor = 0x00u;
+	size_t size;
+
+	LOG_DBG("Clearing display screen to black");
+
+	switch (disp_data->current_pixel_format) {
+	case PIXEL_FORMAT_ARGB_8888:
+		size = config->width * config->height * 4U;
+		bgcolor = 0xFFu;
+		break;
+	case PIXEL_FORMAT_RGB_888:
+		size = config->width * config->height * 3U;
+		break;
+	case PIXEL_FORMAT_MONO10:
+		size = config->height * DIV_ROUND_UP(config->width,
+						NUM_BITS(uint8_t));
+		break;
+	case PIXEL_FORMAT_MONO01:
+		size = config->height * DIV_ROUND_UP(config->width,
+						NUM_BITS(uint8_t));
+		bgcolor = 0xFFu;
+		break;
+	case PIXEL_FORMAT_RGB_565:
+	case PIXEL_FORMAT_BGR_565:
+		size = config->width * config->height * 2U;
+		break;
+	default:
+		LOG_ERR("Pixel format not supported");
+	}
+	LOG_DBG("size: %zu, bgcolor: %hhu", size, bgcolor);
+	memset(disp_data->buf, bgcolor, size);
+
+	return 0;
+}
+
 static int sdl_display_blanking_off(const struct device *dev)
 {
 	struct sdl_display_data *disp_data = dev->data;
@@ -506,6 +545,7 @@ static DEVICE_API(display, sdl_display_api) = {
 	.blanking_off = sdl_display_blanking_off,
 	.write = sdl_display_write,
 	.read = sdl_display_read,
+	.clear = sdl_display_clear,
 	.get_capabilities = sdl_display_get_capabilities,
 	.set_pixel_format = sdl_display_set_pixel_format,
 };

--- a/include/zephyr/drivers/display.h
+++ b/include/zephyr/drivers/display.h
@@ -166,6 +166,13 @@ typedef int (*display_read_api)(const struct device *dev, const uint16_t x,
 				void *buf);
 
 /**
+ * @typedef display_clear
+ * @brief Callback API for clearing the screen of the display
+ * See display_clear() for argument description
+ */
+typedef int (*display_clear_api)(const struct device *dev);
+
+/**
  * @typedef display_get_framebuffer_api
  * @brief Callback API to get framebuffer pointer
  * See display_get_framebuffer() for argument description
@@ -224,6 +231,7 @@ __subsystem struct display_driver_api {
 	display_blanking_off_api blanking_off;
 	display_write_api write;
 	display_read_api read;
+	display_clear_api clear;
 	display_get_framebuffer_api get_framebuffer;
 	display_set_brightness_api set_brightness;
 	display_set_contrast_api set_contrast;
@@ -279,6 +287,26 @@ static inline int display_read(const struct device *dev, const uint16_t x,
 	}
 
 	return api->read(dev, x, y, desc, buf);
+}
+
+/**
+ * @brief Clear the screen of the display device
+ *
+ * @param dev Pointer to device structure
+ *
+ * @retval 0 on success else negative errno code.
+ * @retval -ENOSYS if not implemented.
+ */
+static inline int display_clear(const struct device *dev)
+{
+	struct display_driver_api *api =
+		(struct display_driver_api *)dev->api;
+
+	if (api->clear == NULL) {
+		return -ENOSYS;
+	}
+
+	return api->clear(dev);
 }
 
 /**


### PR DESCRIPTION
from #12937

vanwinkeljan:
It is suggested that a new API should be introduced to clear the display screen, rather than misusing `display_set_contrast`.

cc @vanwinkeljan 

I believe this makes sense for application developers. Sometimes, when implementing screen clearing, I have to write functions that send raw messages, so I prefer to leave the implementation to the driver vendors rather than the users.

Closes: #12937