### PR TITLE
Drivers: SDHC: Infineon fix initialization

### DIFF
--- a/drivers/sdhc/ifx_cat1_sdio.c
+++ b/drivers/sdhc/ifx_cat1_sdio.c
@@ -292,6 +292,13 @@ static int ifx_cat1_sdio_init(const struct device *dev)
 	data->cyhal_sdio_config.resource = &data->hw_resource;
 	data->cyhal_sdio_config.host_config = &host_config,
 	data->cyhal_sdio_config.card_config = &sd_host_sd_card_config,
+	data->cyhal_sdio_config.gpios.cmd = NC;
+	data->cyhal_sdio_config.gpios.clk = NC;
+	data->cyhal_sdio_config.gpios.data[0] = NC;
+	data->cyhal_sdio_config.gpios.data[1] = NC;
+	data->cyhal_sdio_config.gpios.data[2] = NC;
+	data->cyhal_sdio_config.gpios.data[3] = NC;
+	data->cyhal_sdio_config.clock = NULL;
 
 	ret = cyhal_sdio_init_cfg(&data->sdio_obj, &data->cyhal_sdio_config);
 	if (ret != CY_RSLT_SUCCESS) {

--- a/drivers/sdhc/ifx_cat1_sdio.c
+++ b/drivers/sdhc/ifx_cat1_sdio.c
@@ -47,6 +47,7 @@
 #include <soc.h>
 #include <zephyr/drivers/pinctrl.h>
 
+#include <cyhal_hw_resources.h>
 #include <cyhal_sdhc.h>
 #include <cyhal_sdio.h>
 #include <cyhal_gpio.h>
@@ -283,8 +284,9 @@ static int ifx_cat1_sdio_init(const struct device *dev)
 	}
 
 	/* Dedicate SDIO HW resource */
-	data->hw_resource.type = CYHAL_RSC_SDIODEV;
+	data->hw_resource.type = CYHAL_RSC_SDHC;
 	data->hw_resource.block_num = _get_hw_block_num(config->reg_addr);
+	data->hw_resource.channel_num = 0;
 
 	/* Initialize the SDIO peripheral */
 	data->cyhal_sdio_config.resource = &data->hw_resource;


### PR DESCRIPTION
The latest HAL update(#83681) broke the `infineon_cat1_sdhc_sdio` driver initialization.

As the hal didn't use some initialization values before, it didn't matter that those were not/wrong initialized, however this is no longer the case and they need to be properly initialized.

Tested with a wifi module.