### PR TITLE
net: l2: ethernet: Fix interface state check

### DIFF
--- a/subsys/net/l2/ethernet/ethernet_mgmt.c
+++ b/subsys/net/l2/ethernet/ethernet_mgmt.c
@@ -90,7 +90,7 @@ static int ethernet_set_config(uint32_t mgmt_request,
 		config.full_duplex = params->full_duplex;
 		type = ETHERNET_CONFIG_TYPE_DUPLEX;
 	} else if (mgmt_request == NET_REQUEST_ETHERNET_SET_MAC_ADDRESS) {
-		if (net_if_is_up(iface)) {
+		if (net_if_is_admin_up(iface)) {
 			return -EACCES;
 		}
 


### PR DESCRIPTION
Modifying MAC address is allowed only when the interface is not administratively UP, as it typically involves conveying the MAC address to the chip firmware, and accepting the MAC address when interface is administratively UP will not reflect in the actual usage.

So, modify the check to reject MAC address change if the interface is administratively UP.

Fixes #81486.