### PR TITLE
net: dhcpv4_server: allow skipping the router option, do not send empty DNS servers

### DIFF
--- a/subsys/net/lib/dhcpv4/Kconfig
+++ b/subsys/net/lib/dhcpv4/Kconfig
@@ -181,4 +181,13 @@ config NET_DHCPV4_SERVER_OPTION_DNS_ADDRESS
 	  acknowledgment messages sent to the clients, allowing them to use the
 	  specified DNS server for name resolution.
 
+config NET_DHCPV4_SERVER_OPTION_ROUTER
+	bool "Set the router option in the DHCP server response"
+	default y
+	help
+	  If enabled, set the DHCP router option pointing to the interface own
+	  gateway address in responses from the DHCP server. This can be
+	  disabled so that the client does not try to forward traffic to our
+	  device.
+
 endif # NET_DHCPV4_SERVER

--- a/subsys/net/lib/dhcpv4/dhcpv4_server.c
+++ b/subsys/net/lib/dhcpv4/dhcpv4_server.c
@@ -516,6 +516,10 @@ static uint8_t *dhcpv4_encode_requested_params(
 			break;
 
 		case DHCPV4_OPTIONS_ROUTER:
+			if (!IS_ENABLED(CONFIG_NET_DHCPV4_SERVER_OPTION_ROUTER)) {
+				break;
+			}
+
 			buf = dhcpv4_encode_router_option(
 				buf, buflen, &ctx->iface->config.ip.ipv4->gw);
 			if (buf == NULL) {

--- a/subsys/net/lib/dhcpv4/dhcpv4_server.c
+++ b/subsys/net/lib/dhcpv4/dhcpv4_server.c
@@ -528,6 +528,10 @@ static uint8_t *dhcpv4_encode_requested_params(
 			break;
 
 		case DHCPV4_OPTIONS_DNS_SERVER:
+			if (strlen(CONFIG_NET_DHCPV4_SERVER_OPTION_DNS_ADDRESS) == 0) {
+				break;
+			}
+
 			buf = dhcpv4_encode_dns_server_option(buf, buflen);
 			if (buf == NULL) {
 				goto out;


### PR DESCRIPTION
Add a Kconfig option to skip the router DHCP server option, do not send unconfigured DNS servers.