### PR TITLE
fb: cfb: Fix print of ASCII chars from 128 to 255

### DIFF
--- a/subsys/fb/cfb.c
+++ b/subsys/fb/cfb.c
@@ -67,7 +67,7 @@ struct char_framebuffer {
 
 static struct char_framebuffer char_fb;
 
-static inline uint8_t *get_glyph_ptr(const struct cfb_font *fptr, char c)
+static inline uint8_t *get_glyph_ptr(const struct cfb_font *fptr, uint8_t c)
 {
 	return (uint8_t *)fptr->data +
 	       (c - fptr->first_char) *
@@ -92,7 +92,7 @@ static inline uint8_t get_glyph_byte(uint8_t *glyph_ptr, const struct cfb_font *
  * a byte is interpreted as 8 pixels ordered vertically among each other.
  */
 static uint8_t draw_char_vtmono(const struct char_framebuffer *fb,
-				char c, uint16_t x, uint16_t y,
+				uint8_t c, uint16_t x, uint16_t y,
 				bool draw_bg)
 {
 	const struct cfb_font *fptr = &(fb->fonts[fb->font_idx]);


### PR DESCRIPTION
Change the "c" variable type from char to uint8_t in get_glyph_ptr() and draw_char_vtmono() to fix issues with the range check of the "c" value.

The easiest way to print localized text with Zephyr is to ask GCC for compile-time conversion:

  INCLUDE(${ZEPHYR_BASE}/cmake/cfb.cmake NO_POLICY_SCOPE)
    GENERATE_CFB_FONT_FOR_TARGET(app
    "${CMAKE_CURRENT_SOURCE_DIR}/fonts/koi8-u.png"
    "${ZEPHYR_BINARY_DIR}/include/generated/cfb_font_dice.h"
    8 16 --first 0 --last 255)

  TARGET_COMPILE_OPTIONS(app PRIVATE
    -finput-charset=UTF-8
    -fexec-charset=KOI8-U)