### PR TITLE
submanifests: optional: Hotfix for rust trying to build on too many t…

### DIFF
--- a/submanifests/optional.yaml
+++ b/submanifests/optional.yaml
@@ -60,7 +60,7 @@ manifest:
       groups:
         - optional
     - name: zephyr-lang-rust
-      revision: f82407c13059528e88bfcc892a488504e9caa80c
+      revision: c94328f3671a671ac215885c6986b0359a6a37b8
       path: modules/lang/rust
       remote: upstream
       groups:


### PR DESCRIPTION

    commit c94328f3671a671ac215885c6986b0359a6a37b8
    Author: David Brown <david.brown@linaro.org>
    Date:   Fri Jan 24 23:32:21 2025 -0700

        samples: Properly filter samples by supported Rust targets

A few new samples in the Rust module were added, but missed the proper filter and platform list, resulting in the daily twister run trying to build these.