### PR TITLE
Bluetooth: Controller: RF Noise at peripheral test

### DIFF
--- a/samples/bluetooth/peripheral_hr/src/main.c
+++ b/samples/bluetooth/peripheral_hr/src/main.c
@@ -186,6 +186,22 @@ static void blink_stop(void)
 #endif /* LED0_NODE */
 #endif /* CONFIG_GPIO */
 
+static void disconnect(struct bt_conn *conn, void *data)
+{
+	char addr[BT_ADDR_LE_STR_LEN];
+	int err;
+
+	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+
+	printk("Disconnecting %s...\n", addr);
+	err = bt_conn_disconnect(conn, BT_HCI_ERR_REMOTE_USER_TERM_CONN);
+	if (err) {
+		printk("Failed disconnection %s.\n", addr);
+		return;
+	}
+	printk("success.\n");
+}
+
 int main(void)
 {
 	int err;
@@ -300,6 +316,16 @@ int main(void)
 #if defined(HAS_LED)
 			blink_start();
 #endif /* HAS_LED */
+		}
+
+
+		static uint8_t s_countdown;
+
+		if (!s_countdown--) {
+			s_countdown = 10U;
+
+			printk("Disconnecting all...\n");
+			bt_conn_foreach(BT_CONN_TYPE_LE, disconnect, NULL);
 		}
 	}
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_aux.c
@@ -869,7 +869,12 @@ static inline int isr_rx_pdu(struct lll_adv_aux *lll_aux, uint8_t phy_flags_rx,
 			rx = ull_pdu_rx_alloc_peek(3);
 		}
 
-		if (!rx) {
+		static uint8_t s_skip;
+
+		s_skip++;
+
+		/* Simulate RF noise by not responding with CONNECT_RSP */
+		if (!rx || (s_skip & 0x01) == 1U) {
 			return -ENOBUFS;
 		}
 

--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -1075,7 +1075,13 @@ uint8_t ll_adv_enable(uint8_t enable)
 		conn_lll->periph.forced = 0;
 		conn_lll->data_chan_sel = 0;
 		conn_lll->data_chan_use = 0;
-		conn_lll->event_counter = 0;
+
+		static uint8_t s_skip;
+
+		s_skip++;
+
+		/* Simulate RF noise by not completing the connection establishment */
+		conn_lll->event_counter = s_skip & 0x01;
 
 		conn_lll->latency_prepare = 0;
 		conn_lll->latency_event = 0;

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp.c
@@ -462,7 +462,6 @@ void ull_llcp_init(struct ll_conn *conn)
 #endif /* LLCP_TX_CTRL_BUF_QUEUE_ENABLE */
 
 	conn->llcp.tx_q_pause_data_mask = 0;
-	conn->lll.event_counter = 0;
 
 	conn->llcp.tx_node_release = NULL;
 	conn->llcp.rx_node_release = NULL;


### PR DESCRIPTION
RF Noise at peripheral test.

1. Not respond with CONNECT_RSP
2. Not receive on correct radio channel

Investigation of #84328