### PR TITLE
tests: Bluetooth: Tester: Add missing PACS register

### DIFF
--- a/tests/bluetooth/tester/src/audio/btp_bap.c
+++ b/tests/bluetooth/tester/src/audio/btp_bap.c
@@ -480,7 +480,28 @@ static const struct btp_handler bap_handlers[] = {
 
 uint8_t tester_init_pacs(void)
 {
+	const struct bt_bap_pacs_register_param pacs_param = {
+#if defined(CONFIG_BT_PAC_SNK)
+		.snk_pac = true,
+#endif /* CONFIG_BT_PAC_SNK */
+#if defined(CONFIG_BT_PAC_SNK_LOC)
+		.snk_loc = true,
+#endif /* CONFIG_BT_PAC_SNK_LOC */
+#if defined(CONFIG_BT_PAC_SRC)
+		.src_pac = true,
+#endif /* CONFIG_BT_PAC_SRC */
+#if defined(CONFIG_BT_PAC_SRC_LOC)
+		.src_loc = true
+#endif /* CONFIG_BT_PAC_SRC_LOC */
+	};
 	int err;
+
+	/* PACS shall be registered before ASCS in btp_bap_unicast_init */
+	err = bt_pacs_register(&pacs_param);
+	if (err != 0) {
+		LOG_DBG("Failed to register client callbacks: %d", err);
+		return BTP_STATUS_FAILED;
+	}
 
 	btp_bap_unicast_init();
 


### PR DESCRIPTION
PACS needs to be dynamically registered which was
missing from the BT Tester.