### PR TITLE
boards native_posix: Detect attempt to configure not existing int

### DIFF
--- a/boards/native/native_posix/irq_handler.c
+++ b/boards/native/native_posix/irq_handler.c
@@ -248,6 +248,11 @@ void posix_isr_declare(unsigned int irq_p, int flags, void isr_p(const void *),
  */
 void posix_irq_priority_set(unsigned int irq, unsigned int prio, uint32_t flags)
 {
+	if (irq >= N_IRQS) {
+		posix_print_error_and_exit("Attempted to configure not existent interrupt %u\n",
+					   irq);
+		return;
+	}
 	hw_irq_ctrl_prio_set(irq, prio);
 }
 

--- a/boards/native/native_sim/irq_handler.c
+++ b/boards/native/native_sim/irq_handler.c
@@ -256,6 +256,11 @@ void posix_isr_declare(unsigned int irq_p, int flags, void isr_p(const void *),
  */
 void posix_irq_priority_set(unsigned int irq, unsigned int prio, uint32_t flags)
 {
+	if (irq >= N_IRQS) {
+		posix_print_error_and_exit("Attempted to configure not existent interrupt %u\n",
+					   irq);
+		return;
+	}
 	hw_irq_ctrl_prio_set(irq, prio);
 }
 

--- a/boards/native/nrf_bsim/irq_handler.c
+++ b/boards/native/nrf_bsim/irq_handler.c
@@ -278,6 +278,11 @@ void posix_isr_declare(unsigned int irq_p, int flags, void isr_p(const void *),
  */
 void posix_irq_priority_set(unsigned int irq, unsigned int prio, uint32_t flags)
 {
+	if (irq >= NHW_INTCTRL_MAX_INTLINES) {
+		bs_trace_error_time_line("Attempted to configure not existent interrupt %u\n",
+					 irq);
+		return;
+	}
 	hw_irq_ctrl_prio_set(CONFIG_NATIVE_SIMULATOR_MCU_N, irq, prio);
 }
 


### PR DESCRIPTION
Similar to 66a4fe32cef. Prevent overrunning the irq vector table in posix_irq_priority_set. This is not happening today in tree, but coverity thinks it may. Checking for it to prevent it is not a bad idea anyhow, so let's do it.

Fixes #81996.
Fixes #81914.