### PR TITLE
Usbfs mcxn947

### DIFF
--- a/boards/nxp/frdm_mcxn947/board.c
+++ b/boards/nxp/frdm_mcxn947/board.c
@@ -285,6 +285,13 @@ static int frdm_mcxn947_init(void)
 	CLOCK_AttachClk(kFRO_HF_to_ADC0);
 #endif
 
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(usb0)) && (CONFIG_USB_KINETIS || CONFIG_UDC_KINETIS)
+	CLOCK_AttachClk(kCLK_48M_to_USB0);
+    CLOCK_EnableClock(kCLOCK_Usb0Ram);
+    CLOCK_EnableClock(kCLOCK_Usb0Fs);
+    CLOCK_EnableUsbfsClock();
+#endif
+
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(usb1)) && (CONFIG_USB_DC_NXP_EHCI || CONFIG_UDC_NXP_EHCI)
 	SPC0->ACTIVE_VDELAY = 0x0500;
 	/* Change the power DCDC to 1.8v (By default, DCDC is 1.8V), CORELDO to 1.1v (By default,

--- a/drivers/usb/device/usb_dc_kinetis.c
+++ b/drivers/usb/device/usb_dc_kinetis.c
@@ -40,6 +40,11 @@ LOG_MODULE_REGISTER(usb_dc_kinetis);
 #define KINETIS_EP_NUMOF_MASK	0xf
 #define KINETIS_ADDR2IDX(addr)	((addr) & (KINETIS_EP_NUMOF_MASK))
 
+// In some SoC USB0 base register is defined as USBFS0
+#if !defined(USB0) && defined(USBFS0)
+#define USB0	USBFS0
+#endif
+
 /*
  * Buffer Descriptor (BD) entry provides endpoint buffer control
  * information for USBFS controller. Every endpoint direction requires

--- a/dts/arm/nxp/nxp_mcxn94x_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxn94x_common.dtsi
@@ -880,6 +880,16 @@
 		clocks = <&syscon MCUX_LPADC2_CLK>;
 	};
 
+	usb0: usbd@dd000 {
+		compatible = "nxp,kinetis-usbd";
+		reg = <0xdd000 0x1000>;
+		interrupts = <50 1>;
+		interrupt-names = "usbfs0";
+		num-bidir-endpoints = <16>;
+		no-voltage-regulator;
+		status = "disabled";
+	};
+
 	usb1: usbd@10b000 {
 		compatible = "nxp,ehci";
 		reg = <0x10b000 0x1000>;


### PR DESCRIPTION
Add USB support for frdm_mcxn947 board:

* Adapt USB DC Kinetis driver
* Add usb configuration in soc devicetree
* Enable USB clock for board