### PR TITLE
Add USB FS (USBFS0) support on NXP MCX N94x

### DIFF
--- a/drivers/usb/device/usb_dc_kinetis.c
+++ b/drivers/usb/device/usb_dc_kinetis.c
@@ -41,6 +41,13 @@ LOG_MODULE_REGISTER(usb_dc_kinetis);
 #define KINETIS_ADDR2IDX(addr)	((addr) & (KINETIS_EP_NUMOF_MASK))
 
 /*
+ * In some SoC USB0 base register is defined as USBFS0
+ */
+#if !defined(USB0) && defined(USBFS0)
+#define USB0				USBFS0
+#endif
+
+/*
  * Buffer Descriptor (BD) entry provides endpoint buffer control
  * information for USBFS controller. Every endpoint direction requires
  * two BD entries.

--- a/dts/arm/nxp/nxp_mcxn94x_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxn94x_common.dtsi
@@ -880,6 +880,16 @@
 		clocks = <&syscon MCUX_LPADC2_CLK>;
 	};
 
+	usb0: usbd@dd000 {
+		compatible = "nxp,kinetis-usbd";
+		reg = <0xdd000 0x1000>;
+		interrupts = <50 1>;
+		interrupt-names = "usbfs0";
+		num-bidir-endpoints = <16>;
+		no-voltage-regulator;
+		status = "disabled";
+	};
+
 	usb1: usbd@10b000 {
 		compatible = "nxp,ehci";
 		reg = <0x10b000 0x1000>;


### PR DESCRIPTION
Add USB FS support on NXP mcx n94x soc:

* Adapt USB DC Kinetis driver
* Add usb configuration in soc devicetree