### PR TITLE
kernel: fix void* to k_thread_entry_t conversion

### DIFF
--- a/kernel/include/ksched.h
+++ b/kernel/include/ksched.h
@@ -119,7 +119,7 @@ static inline bool z_is_prio_lower_or_equal(int prio1, int prio2)
 	return z_is_prio1_lower_than_or_equal_to_prio2(prio1, prio2);
 }
 
-static inline bool _is_valid_prio(int prio, void *entry_point)
+static inline bool _is_valid_prio(int prio, k_thread_entry_t entry_point)
 {
 	if ((prio == K_IDLE_PRIO) && z_is_idle_thread_entry(entry_point)) {
 		return true;


### PR DESCRIPTION
Fix a void* to k_thread_entry_t (function pointer) conversion (that is silent in GCC but not so in some other tools) in _is_valid_prio()