### PR TITLE
boards: espressif: Fix used partition type

### DIFF
--- a/boards/espressif/esp32_ethernet_kit/esp32_ethernet_kit_procpu.dts
+++ b/boards/espressif/esp32_ethernet_kit/esp32_ethernet_kit_procpu.dts
@@ -7,7 +7,7 @@
 
 #include <espressif/esp32/esp32_wrover_e_n4r8.dtsi>
 #include "esp32_ethernet_kit-pinctrl.dtsi"
-#include <espressif/partitions_0x1000_default.dtsi>
+#include <espressif/partitions_0x1000_amp.dtsi>
 
 / {
 	model = "Espressif ESP32-Ethernet-Kit PROCPU";


### PR DESCRIPTION
Use the amp partition layout instead of default one.