### PR TITLE
dts: common: nordic: nrf54l20: set CPU frequency to 64MHz

### DIFF
--- a/dts/common/nordic/nrf54l09.dtsi
+++ b/dts/common/nordic/nrf54l09.dtsi
@@ -33,7 +33,8 @@
 			itm: itm@e0000000 {
 				compatible = "arm,armv8m-itm";
 				reg = <0xe0000000 0x1000>;
-				swo-ref-frequency = <DT_FREQ_M(128)>;
+				/* NRFX-6881: Restore to 128MHz when PDK becomes available. */
+				swo-ref-frequency = <DT_FREQ_M(64)>;
 			};
 		};
 
@@ -41,7 +42,8 @@
 			compatible = "nordic,vpr";
 			reg = <1>;
 			device_type = "cpu";
-			clock-frequency = <DT_FREQ_M(128)>;
+			/* NRFX-6881: Restore to 128MHz when PDK becomes available. */
+			clock-frequency = <DT_FREQ_M(64)>;
 			riscv,isa = "rv32emc";
 			nordic,bus-width = <32>;
 		};
@@ -63,7 +65,8 @@
 		hfpll: hfpll {
 			compatible = "fixed-clock";
 			#clock-cells = <0>;
-			clock-frequency = <DT_FREQ_M(128)>;
+			/* NRFX-6881: Restore to 128MHz when PDK becomes available. */
+			clock-frequency = <DT_FREQ_M(64)>;
 		};
 	};
 

--- a/dts/common/nordic/nrf54l20.dtsi
+++ b/dts/common/nordic/nrf54l20.dtsi
@@ -29,7 +29,8 @@
 			itm: itm@e0000000 {
 				compatible = "arm,armv8m-itm";
 				reg = <0xe0000000 0x1000>;
-				swo-ref-frequency = <DT_FREQ_M(128)>;
+				/* NRFX-6881: Restore to 128MHz when PDK becomes available. */
+				swo-ref-frequency = <DT_FREQ_M(64)>;
 			};
 		};
 	};
@@ -50,7 +51,8 @@
 		hfpll: hfpll {
 			compatible = "fixed-clock";
 			#clock-cells = <0>;
-			clock-frequency = <DT_FREQ_M(128)>;
+			/* NRFX-6881: Restore to 128MHz when PDK becomes available. */
+			clock-frequency = <DT_FREQ_M(64)>;
 		};
 	};
 


### PR DESCRIPTION
The CPU frequency needs to be set to 64MHz until nRF54L20 and nRF54L09 PDKs become available. This is needed to make the kernel tests pass.