### PR TITLE
FRDM_K64F: Add pyocd.yaml with configuration.

### DIFF
--- a/boards/nxp/frdm_k64f/support/pyocd.yaml
+++ b/boards/nxp/frdm_k64f/support/pyocd.yaml
@@ -1,0 +1,2 @@
+connect_mode: 'under-reset'
+reset_type: 'hw'


### PR DESCRIPTION
This PR adds a new configuration file for PyOCD with two parameters:
- connect_mode
- reset_type

These changes address a problem with the `FRDM-K64F` board, which sometimes experiences flash errors during tests. The error message looks like this:
Example log:
```
INFO    - Using Ninja..
INFO    - Zephyr version: v4.0.0-4013-g222f8d87b546
INFO    - Using 'zephyr' toolchain.
INFO    - Building initial testsuite list...
INFO    - Writing JSON report <path_to>/twister-out/testplan.json

Device testing on:

| Platform   | ID   | Serial device   |
|------------|------|-----------------|

INFO    - JOBS: 6
INFO    - Adding tasks to the queue...
INFO    - Added initial list of jobs to queue
INFO    -   1/132 frdm_k64f/mk64f12         tests/kernel/mutex/sys_mutex/kernel.mutex.system.nouser PASSED (device: 02400b0177384e45002070016f01001ac401000197969900, 11.292s <zephyr>)
INFO    -   2/132 frdm_k64f/mk64f12         tests/kernel/pending/kernel.objects.minimallibc    PASSED (device: 02400b0177384e45002070016f01001ac401000197969900, 9.870s <zephyr>)
INFO    -   3/132 frdm_k64f/mk64f12         tests/kernel/mutex/mutex_api/kernel.mutex          PASSED (device: 02400b0177384e45002070016f01001ac401000197969900, 17.268s <zephyr>)
INFO    -   4/132 frdm_k64f/mk64f12         tests/kernel/workq/critical/kernel.workqueue.critical PASSED (device: 02400b0177384e45002070016f01001ac401000197969900, 3.394s <zephyr>)
INFO    -   5/132 frdm_k64f/mk64f12         tests/kernel/mutex/sys_mutex/kernel.mutex.system   PASSED (device: 02400b0177384e45002070016f01001ac401000197969900, 12.858s <zephyr>)
INFO    -   6/132 frdm_k64f/mk64f12         tests/kernel/mutex/mutex_error_case/kernel.mutex.error ERROR Device issue (Flash error?) (device: 02400b0177384e45002070016f01001ac401000197969900, 1.562s <zephyr>)
ERROR   - see: twister-out/frdm_k64f_mk64f12/zephyr/tests/kernel/mutex/mutex_error_case/kernel.mutex.error/device.log
INFO    -   7/132 frdm_k64f/mk64f12         tests/kernel/workq/work/kernel.workqueue.api       ERROR Device issue (Flash error?) (device: 02400b0177384e45002070016f01001ac401000197969900, 6.396s <zephyr>)
ERROR   - see: twister-out/frdm_k64f_mk64f12/zephyr/tests/kernel/workq/work/kernel.workqueue.api/device.log
INFO    -   8/132 frdm_k64f/mk64f12         tests/kernel/workq/user_work/kernel.workqueue.user ERROR Device issue (Flash error?) (device: 02400b0177384e45002070016f01001ac401000197969900, 5.268s <zephyr>)
```
`device.log`
```
...
0001071 E Error during board uninit: [session]
0001072 C flash erase sector failure (address 0x00000000; result code 0x69) [__main__]
FATAL ERROR: command exited with status 1
```
The platform is no longer available and has to be manually unlocked.
This issue is described here: https://docs.zephyrproject.org/latest/boards/nxp/frdm_k64f/doc/index.html#troubleshooting

This update helps make the connection and reset process more reliable, which should reduce the chance of seeing these flash errors. While the issue might still happen sometimes, the change ensures that the board can be connected without problems for future tests.

Example log.
```
INFO    - Using Ninja..
INFO    - Zephyr version: v4.0.0-4013-g222f8d87b546
INFO    - Using 'zephyr' toolchain.
INFO    - Building initial testsuite list...
INFO    - Writing JSON report <path_to>/twister-out/testplan.json

Device testing on:

| Platform   | ID   | Serial device   |
|------------|------|-----------------|

INFO    - JOBS: 6
INFO    - Adding tasks to the queue...
INFO    - Added initial list of jobs to queue
INFO    -   1/132 frdm_k64f/mk64f12         tests/kernel/tickless/tickless_concept/kernel.tickless.concept PASSED (device: 02400b0177384e45002070016f01001ac401000197969900, 4.478s <zephyr>)
INFO    -   2/132 frdm_k64f/mk64f12         tests/kernel/mutex/sys_mutex/kernel.mutex.system.nouser PASSED (device: 02400b0177384e45002070016f01001ac401000197969900, 13.846s <zephyr>)
INFO    -   3/132 frdm_k64f/mk64f12         tests/kernel/mutex/mutex_error_case/kernel.mutex.error PASSED (device: 02400b0177384e45002070016f01001ac401000197969900, 5.198s <zephyr>)
INFO    -   4/132 frdm_k64f/mk64f12         tests/kernel/pending/kernel.objects                ERROR Device issue (Flash error?) (device: 02400b0177384e45002070016f01001ac401000197969900, 2.161s <zephyr>)
ERROR   - see: twister-out/frdm_k64f_mk64f12/zephyr/tests/kernel/pending/kernel.objects/device.log
INFO    -   5/132 frdm_k64f/mk64f12         tests/kernel/mutex/mutex_api/kernel.mutex          PASSED (device: 02400b0177384e45002070016f01001ac401000197969900, 17.475s <zephyr>)
INFO    -   6/132 frdm_k64f/mk64f12         tests/kernel/workq/work/kernel.workqueue.api       PASSED (device: 02400b0177384e45002070016f01001ac401000197969900, 6.675s <zephyr>)
```
In summary, this PR improves stability and makes it easier to run tests on the FRDM-K64F board especially under CI.
