### PR TITLE
tests: flash_map: Increase the maximum number of supported sectors

### DIFF
--- a/tests/subsys/storage/flash_map/src/main.c
+++ b/tests/subsys/storage/flash_map/src/main.c
@@ -18,7 +18,7 @@
 #define SLOT1_PARTITION_OFFSET	FIXED_PARTITION_OFFSET(SLOT1_PARTITION)
 
 extern int flash_map_entries;
-struct flash_sector fs_sectors[1024];
+struct flash_sector fs_sectors[2048];
 
 ZTEST(flash_map, test_flash_area_disabled_device)
 {


### PR DESCRIPTION
Fix test_flash_area_get_sectors test for platforms with maximum number of sectors per image slot > 1024. Increase the support value to 2048.