### PR TITLE
Bluetooth: Host: Fix overwriting ECC error value

### DIFF
--- a/subsys/bluetooth/host/ecc.c
+++ b/subsys/bluetooth/host/ecc.c
@@ -213,6 +213,7 @@ static void generate_dh_key(struct k_work *work)
 	if (psa_destroy_key(key_id) != PSA_SUCCESS) {
 		LOG_ERR("Failed to destroy the key");
 		err = -EIO;
+		goto exit;
 	}
 
 	err = 0;


### PR DESCRIPTION
Jump straight to the exit portion of the function in the case that psa_destroy_key() failed and we set err to a non-zero value. This also fixes Coverity CID 487701 "Code maintainability issues  (UNUSED_VALUE)".