### PR TITLE
Use mode specific APIs

### DIFF
--- a/drivers/wifi/nrf_wifi/Kconfig.nrfwifi
+++ b/drivers/wifi/nrf_wifi/Kconfig.nrfwifi
@@ -45,17 +45,15 @@ choice NRF70_OPER_MODES
 	help
 	  Select the operating mode of the nRF70 driver
 
-config NRF70_SYSTEM_MODE
-	bool "nRF70 system mode"
-	depends on WIFI_NRF7002 || WIFI_NRF7001
-	select WIFI_NM_WPA_SUPPLICANT
-	help
-	  Select this option to enable system mode of the nRF70 driver
-
 config NRF70_SCAN_ONLY
 	bool "nRF70 scan only mode"
 	help
 	  Select this option to enable scan only mode of the nRF70 driver
+
+config NRF70_SYSTEM_MODE
+	bool "System mode of the nRF70 driver"
+	help
+	  Select this option to enable system mode of the nRF70 driver
 
 config NRF70_RADIO_TEST
 	bool "Radio test mode of the nRF70 driver"
@@ -64,13 +62,6 @@ config NRF70_OFFLOADED_RAW_TX
 	bool "Offloaded raw TX mode of the nRF70 driver"
 
 endchoice
-
-config NRF70_SYSTEM_WITH_RAW_MODES
-	bool "nRF70 system mode with raw modes"
-	depends on NRF70_SYSTEM_MODE
-	default y if (NRF70_RAW_DATA_TX || NRF70_RAW_DATA_RX || NRF70_PROMISC_DATA_RX)
-	help
-	  Select this option to enable system mode of the nRF70 driver with raw modes.
 
 config NET_L2_ETHERNET
 	default y if (!NRF70_RADIO_TEST && !NRF70_OFFLOADED_RAW_TX)
@@ -85,17 +76,27 @@ if NRF70_SYSTEM_MODE
 config NRF70_STA_MODE
 	bool "nRF70 STA mode"
 	default y
+	depends on WIFI_NRF7002 || WIFI_NRF7001
+	select WIFI_NM_WPA_SUPPLICANT
+	select NRF70_DATA_TX
 	help
 	  Select this option to enable STA mode of the nRF70 driver.
-
 config NRF70_AP_MODE
 	bool "Access point mode"
+	depends on WIFI_NRF7002 || WIFI_NRF7001
+	select NRF70_DATA_TX
 	depends on WIFI_NM_WPA_SUPPLICANT_AP
 	default y if WIFI_NM_WPA_SUPPLICANT_AP
 
 config NRF70_P2P_MODE
 	bool "P2P support in driver"
-endif # NRF70_SYSTEM_MODE
+
+config NRF70_SYSTEM_WITH_RAW_MODES
+	bool
+	default y if (NRF70_RAW_DATA_TX || NRF70_RAW_DATA_RX || NRF70_PROMISC_DATA_RX)
+	depends on WIFI_NRF7002 || WIFI_NRF7001
+	help
+	  Select this option to enable system mode of the nRF70 driver with raw modes.
 
 config NRF70_RAW_DATA_TX
 	bool "RAW TX data path in the driver"
@@ -112,8 +113,8 @@ config NRF70_PROMISC_DATA_RX
 	select NET_PROMISCUOUS_MODE
 
 config NRF70_DATA_TX
-	bool "TX data path in the driver"
-	default y if NRF70_SYSTEM_MODE
+	bool
+endif # NRF70_SYSTEM_MODE
 
 config NRF_WIFI_IF_AUTO_START
 	bool "Wi-Fi interface auto start on boot"

--- a/drivers/wifi/nrf_wifi/inc/fmac_main.h
+++ b/drivers/wifi/nrf_wifi/inc/fmac_main.h
@@ -27,9 +27,11 @@
 #ifdef CONFIG_NRF70_STA_MODE
 #include <drivers/driver_zephyr.h>
 #endif /* CONFIG_NRF70_STA_MODE */
+#include <system/fmac_api.h>
+#else
+#include <radio_test/fmac_api.h>
 #endif /* !CONFIG_NRF70_RADIO_TEST */
 
-#include <fmac_api.h>
 #include <host_rpu_umac_if.h>
 
 #define NRF70_DRIVER_VERSION "1."KERNEL_VERSION_STRING

--- a/drivers/wifi/nrf_wifi/inc/net_if.h
+++ b/drivers/wifi/nrf_wifi/inc/net_if.h
@@ -15,8 +15,8 @@
 #include <zephyr/net/net_pkt.h>
 #include <zephyr/net/net_if.h>
 #include <zephyr/net/ethernet.h>
-#include <fmac_structs.h>
 #include <zephyr/net/wifi_mgmt.h>
+#include <system/fmac_structs.h>
 
 #define UNICAST_MASK GENMASK(7, 1)
 #define LOCAL_BIT BIT(1)

--- a/drivers/wifi/nrf_wifi/off_raw_tx/inc/off_raw_tx.h
+++ b/drivers/wifi/nrf_wifi/off_raw_tx/inc/off_raw_tx.h
@@ -8,7 +8,7 @@
  * @brief File containing internal structures for the offloaded raw TX feature in the driver.
  */
 
-#include "fmac_structs_common.h"
+#include "offload_raw_tx/fmac_structs.h"
 #include "osal_api.h"
 
 struct nrf_wifi_ctx_zep {

--- a/drivers/wifi/nrf_wifi/src/fmac_main.c
+++ b/drivers/wifi/nrf_wifi/src/fmac_main.c
@@ -781,18 +781,18 @@ static int nrf_wifi_drv_main_zep(const struct device *dev)
 	}
 
 #ifdef CONFIG_NRF70_DATA_TX
-	struct nrf_wifi_fmac_priv_def *def_priv = NULL;
+	struct nrf_wifi_sys_fmac_priv *sys_fpriv = NULL;
 
-	def_priv = wifi_fmac_priv(rpu_drv_priv_zep.fmac_priv);
-	def_priv->max_ampdu_len_per_token =
+	sys_fpriv = wifi_fmac_priv(rpu_drv_priv_zep.fmac_priv);
+	sys_fpriv->max_ampdu_len_per_token =
 		(RPU_PKTRAM_SIZE - (CONFIG_NRF70_RX_NUM_BUFS * CONFIG_NRF70_RX_MAX_DATA_SIZE)) /
 		CONFIG_NRF70_MAX_TX_TOKENS;
 	/* Align to 4-byte */
-	def_priv->max_ampdu_len_per_token &= ~0x3;
+	sys_fpriv->max_ampdu_len_per_token &= ~0x3;
 
 	/* Alignment overhead for size based coalesce */
-	def_priv->avail_ampdu_len_per_token =
-	def_priv->max_ampdu_len_per_token -
+	sys_fpriv->avail_ampdu_len_per_token =
+	sys_fpriv->max_ampdu_len_per_token -
 		(MAX_PKT_RAM_TX_ALIGN_OVERHEAD * max_tx_aggregation);
 #endif /* CONFIG_NRF70_DATA_TX */
 

--- a/drivers/wifi/nrf_wifi/src/net_if.c
+++ b/drivers/wifi/nrf_wifi/src/net_if.c
@@ -23,8 +23,7 @@ LOG_MODULE_DECLARE(wifi_nrf, CONFIG_WIFI_NRF70_LOG_LEVEL);
 #include "net_private.h"
 
 #include "util.h"
-#include "fmac_api.h"
-#include "fmac_util.h"
+#include "common/fmac_util.h"
 #include "shim.h"
 #include "fmac_main.h"
 #include "wpa_supp_if.h"
@@ -490,7 +489,7 @@ static void ip_maddr_event_handler(struct net_if *iface,
 		   &mac_addr,
 		   NRF_WIFI_ETH_ADDR_LEN);
 
-	status = nrf_wifi_fmac_set_mcast_addr(rpu_ctx_zep->rpu_ctx,
+	status = nrf_wifi_sys_fmac_set_mcast_addr(rpu_ctx_zep->rpu_ctx,
 					      vif_ctx_zep->vif_idx,
 					      mcast_info);
 	if (status == NRF_WIFI_STATUS_FAIL) {
@@ -751,7 +750,7 @@ int nrf_wifi_if_start_zep(const struct device *dev)
 	       dev->name,
 	       strlen(dev->name));
 
-	vif_ctx_zep->vif_idx = nrf_wifi_fmac_add_vif(fmac_dev_ctx,
+	vif_ctx_zep->vif_idx = nrf_wifi_sys_fmac_add_vif(fmac_dev_ctx,
 						     vif_ctx_zep,
 						     &add_vif_info);
 	if (vif_ctx_zep->vif_idx >= MAX_NUM_VIFS) {
@@ -785,7 +784,7 @@ int nrf_wifi_if_start_zep(const struct device *dev)
 		mac_addr_len = WIFI_MAC_ADDR_LEN;
 	}
 
-	status = nrf_wifi_fmac_set_vif_macaddr(rpu_ctx_zep->rpu_ctx,
+	status = nrf_wifi_sys_fmac_set_vif_macaddr(rpu_ctx_zep->rpu_ctx,
 					       vif_ctx_zep->vif_idx,
 					       mac_addr);
 
@@ -806,12 +805,12 @@ int nrf_wifi_if_start_zep(const struct device *dev)
 	       dev->name,
 	       strlen(dev->name));
 
-	status = nrf_wifi_fmac_chg_vif_state(rpu_ctx_zep->rpu_ctx,
+	status = nrf_wifi_sys_fmac_chg_vif_state(rpu_ctx_zep->rpu_ctx,
 					     vif_ctx_zep->vif_idx,
 					     &vif_info);
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		LOG_ERR("%s: nrf_wifi_fmac_chg_vif_state failed",
+		LOG_ERR("%s: nrf_wifi_sys_fmac_chg_vif_state failed",
 			__func__);
 		goto del_vif;
 	}
@@ -820,12 +819,12 @@ int nrf_wifi_if_start_zep(const struct device *dev)
 	nrf_wifi_wpa_supp_event_mac_chgd(vif_ctx_zep);
 
 #ifdef CONFIG_NRF_WIFI_LOW_POWER
-	status = nrf_wifi_fmac_set_power_save(rpu_ctx_zep->rpu_ctx,
+	status = nrf_wifi_sys_fmac_set_power_save(rpu_ctx_zep->rpu_ctx,
 					      vif_ctx_zep->vif_idx,
 					      NRF_WIFI_PS_ENABLED);
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		LOG_ERR("%s: nrf_wifi_fmac_set_power_save failed",
+		LOG_ERR("%s: nrf_wifi_sys_fmac_set_power_save failed",
 			__func__);
 		goto dev_rem;
 	}
@@ -838,9 +837,9 @@ int nrf_wifi_if_start_zep(const struct device *dev)
 
 	goto out;
 del_vif:
-	status = nrf_wifi_fmac_del_vif(rpu_ctx_zep->rpu_ctx, vif_ctx_zep->vif_idx);
+	status = nrf_wifi_sys_fmac_del_vif(rpu_ctx_zep->rpu_ctx, vif_ctx_zep->vif_idx);
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		LOG_ERR("%s: nrf_wifi_fmac_del_vif failed",
+		LOG_ERR("%s: nrf_wifi_sys_fmac_del_vif failed",
 			__func__);
 	}
 dev_rem:
@@ -891,12 +890,12 @@ int nrf_wifi_if_stop_zep(const struct device *dev)
 
 #ifdef CONFIG_NRF70_STA_MODE
 #ifdef CONFIG_NRF_WIFI_LOW_POWER
-	status = nrf_wifi_fmac_set_power_save(rpu_ctx_zep->rpu_ctx,
+	status = nrf_wifi_sys_fmac_set_power_save(rpu_ctx_zep->rpu_ctx,
 					      vif_ctx_zep->vif_idx,
 					      NRF_WIFI_PS_DISABLED);
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		LOG_ERR("%s: nrf_wifi_fmac_set_power_save failed",
+		LOG_ERR("%s: nrf_wifi_sys_fmac_set_power_save failed",
 			__func__);
 	}
 #endif /* CONFIG_NRF_WIFI_LOW_POWER */
@@ -909,20 +908,20 @@ int nrf_wifi_if_stop_zep(const struct device *dev)
 	vif_info.state = NRF_WIFI_FMAC_IF_OP_STATE_DOWN;
 	vif_info.if_index = vif_ctx_zep->vif_idx;
 
-	status = nrf_wifi_fmac_chg_vif_state(rpu_ctx_zep->rpu_ctx,
+	status = nrf_wifi_sys_fmac_chg_vif_state(rpu_ctx_zep->rpu_ctx,
 					     vif_ctx_zep->vif_idx,
 					     &vif_info);
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		LOG_ERR("%s: nrf_wifi_fmac_chg_vif_state failed",
+		LOG_ERR("%s: nrf_wifi_sys_fmac_chg_vif_state failed",
 			__func__);
 	}
 
-	status = nrf_wifi_fmac_del_vif(rpu_ctx_zep->rpu_ctx,
+	status = nrf_wifi_sys_fmac_del_vif(rpu_ctx_zep->rpu_ctx,
 				       vif_ctx_zep->vif_idx);
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		LOG_ERR("%s: nrf_wifi_fmac_del_vif failed",
+		LOG_ERR("%s: nrf_wifi_sys_fmac_del_vif failed",
 			__func__);
 	}
 
@@ -1098,8 +1097,8 @@ int nrf_wifi_if_set_config_zep(const struct device *dev,
 			       (NRF_WIFI_TX_INJECTION_MODE);
 		}
 
-		ret = nrf_wifi_fmac_set_mode(rpu_ctx_zep->rpu_ctx,
-					     vif_ctx_zep->vif_idx, mode);
+		ret = nrf_wifi_sys_fmac_set_mode(rpu_ctx_zep->rpu_ctx,
+						 vif_ctx_zep->vif_idx, mode);
 
 		if (ret != NRF_WIFI_STATUS_SUCCESS) {
 			LOG_ERR("%s: Mode set operation failed", __func__);
@@ -1126,8 +1125,8 @@ int nrf_wifi_if_set_config_zep(const struct device *dev,
 			       (NRF_WIFI_PROMISCUOUS_MODE);
 		}
 
-		ret = nrf_wifi_fmac_set_mode(rpu_ctx_zep->rpu_ctx,
-					     vif_ctx_zep->vif_idx, mode);
+		ret = nrf_wifi_sys_fmac_set_mode(rpu_ctx_zep->rpu_ctx,
+						 vif_ctx_zep->vif_idx, mode);
 
 		if (ret != NRF_WIFI_STATUS_SUCCESS) {
 			LOG_ERR("%s: mode set operation failed", __func__);
@@ -1173,7 +1172,7 @@ int nrf_wifi_stats_get(const struct device *dev, struct net_stats_wifi *zstats)
 #ifdef CONFIG_NRF70_RAW_DATA_TX
 	struct nrf_wifi_sys_fmac_dev_ctx *sys_dev_ctx = NULL;
 #endif /* CONFIG_NRF70_RAW_DATA_TX */
-	struct rpu_op_stats stats;
+	struct rpu_sys_op_stats stats;
 	int ret = -1;
 
 	if (!dev) {
@@ -1204,8 +1203,8 @@ int nrf_wifi_stats_get(const struct device *dev, struct net_stats_wifi *zstats)
 		goto unlock;
 	}
 
-	memset(&stats, 0, sizeof(struct rpu_op_stats));
-	status = nrf_wifi_fmac_stats_get(rpu_ctx_zep->rpu_ctx, 0, &stats);
+	memset(&stats, 0, sizeof(struct rpu_sys_op_stats));
+	status = nrf_wifi_sys_fmac_stats_get(rpu_ctx_zep->rpu_ctx, 0, &stats);
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		LOG_ERR("%s: nrf_wifi_fmac_stats_get failed", __func__);
 		goto unlock;

--- a/drivers/wifi/nrf_wifi/src/net_if.c
+++ b/drivers/wifi/nrf_wifi/src/net_if.c
@@ -178,7 +178,7 @@ void nrf_wifi_rpu_recovery_cb(void *vif_ctx_handle,
 {
 	struct nrf_wifi_fmac_vif_ctx *vif_ctx = vif_ctx_handle;
 	struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx = NULL;
-	struct nrf_wifi_fmac_dev_ctx_def *def_dev_ctx = NULL;
+	struct nrf_wifi_sys_fmac_dev_ctx *sys_dev_ctx = NULL;
 	struct nrf_wifi_vif_ctx_zep *vif_ctx_zep = NULL;
 
 	if (!vif_ctx) {
@@ -188,9 +188,9 @@ void nrf_wifi_rpu_recovery_cb(void *vif_ctx_handle,
 	}
 
 	fmac_dev_ctx = vif_ctx->fmac_dev_ctx;
-	def_dev_ctx = wifi_dev_priv(fmac_dev_ctx);
-	if (!def_dev_ctx) {
-		LOG_ERR("%s: def_dev_ctx is NULL",
+	sys_dev_ctx = wifi_dev_priv(fmac_dev_ctx);
+	if (!sys_dev_ctx) {
+		LOG_ERR("%s: sys_dev_ctx is NULL",
 			__func__);
 		goto out;
 	}
@@ -238,10 +238,10 @@ void nrf_wifi_if_sniffer_rx_frm(void *os_vif_ctx, void *frm,
 	struct net_pkt *pkt;
 	struct nrf_wifi_ctx_zep *rpu_ctx_zep = vif_ctx_zep->rpu_ctx_zep;
 	struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx = rpu_ctx_zep->rpu_ctx;
-	struct nrf_wifi_fmac_dev_ctx_def *def_dev_ctx = NULL;
+	struct nrf_wifi_sys_fmac_dev_ctx *sys_dev_ctx = NULL;
 	int ret;
 
-	def_dev_ctx = wifi_dev_priv(fmac_dev_ctx);
+	sys_dev_ctx = wifi_dev_priv(fmac_dev_ctx);
 
 	pkt = net_raw_pkt_from_nbuf(iface, frm, sizeof(struct raw_rx_pkt_header),
 				    raw_rx_hdr,
@@ -269,11 +269,11 @@ void nrf_wifi_if_rx_frm(void *os_vif_ctx, void *frm)
 	int status;
 	struct nrf_wifi_ctx_zep *rpu_ctx_zep = vif_ctx_zep->rpu_ctx_zep;
 	struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx = rpu_ctx_zep->rpu_ctx;
-	struct nrf_wifi_fmac_dev_ctx_def *def_dev_ctx = NULL;
+	struct nrf_wifi_sys_fmac_dev_ctx *sys_dev_ctx = NULL;
 	struct rpu_host_stats *host_stats = NULL;
 
-	def_dev_ctx = wifi_dev_priv(fmac_dev_ctx);
-	host_stats = &def_dev_ctx->host_stats;
+	sys_dev_ctx = wifi_dev_priv(fmac_dev_ctx);
+	host_stats = &sys_dev_ctx->host_stats;
 	host_stats->total_rx_pkts++;
 
 	pkt = net_pkt_from_nbuf(iface, frm);
@@ -356,7 +356,7 @@ int nrf_wifi_if_send(const struct device *dev,
 #ifdef CONFIG_NRF70_DATA_TX
 	struct nrf_wifi_vif_ctx_zep *vif_ctx_zep = NULL;
 	struct nrf_wifi_ctx_zep *rpu_ctx_zep = NULL;
-	struct nrf_wifi_fmac_dev_ctx_def *def_dev_ctx = NULL;
+	struct nrf_wifi_sys_fmac_dev_ctx *sys_dev_ctx = NULL;
 	struct rpu_host_stats *host_stats = NULL;
 	void *nbuf = NULL;
 
@@ -383,8 +383,8 @@ int nrf_wifi_if_send(const struct device *dev,
 		goto unlock;
 	}
 
-	def_dev_ctx = wifi_dev_priv(rpu_ctx_zep->rpu_ctx);
-	host_stats = &def_dev_ctx->host_stats;
+	sys_dev_ctx = wifi_dev_priv(rpu_ctx_zep->rpu_ctx);
+	host_stats = &sys_dev_ctx->host_stats;
 	nbuf = net_pkt_to_nbuf(pkt);
 	if (!nbuf) {
 		LOG_DBG("Failed to allocate net_pkt");
@@ -951,7 +951,7 @@ int nrf_wifi_if_get_config_zep(const struct device *dev,
 	struct nrf_wifi_vif_ctx_zep *vif_ctx_zep = NULL;
 	struct nrf_wifi_ctx_zep *rpu_ctx_zep = NULL;
 	struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx = NULL;
-	struct nrf_wifi_fmac_dev_ctx_def *def_dev_ctx = NULL;
+	struct nrf_wifi_sys_fmac_dev_ctx *sys_dev_ctx = NULL;
 
 	if (!dev || !config) {
 		LOG_ERR("%s: Invalid parameters",
@@ -979,9 +979,9 @@ int nrf_wifi_if_get_config_zep(const struct device *dev,
 		goto unlock;
 	}
 	fmac_dev_ctx = rpu_ctx_zep->rpu_ctx;
-	def_dev_ctx = wifi_dev_priv(fmac_dev_ctx);
-	if (!def_dev_ctx) {
-		LOG_ERR("%s: def_dev_ctx is NULL",
+	sys_dev_ctx = wifi_dev_priv(fmac_dev_ctx);
+	if (!sys_dev_ctx) {
+		LOG_ERR("%s: sys_dev_ctx is NULL",
 			__func__);
 		goto unlock;
 	}
@@ -990,7 +990,7 @@ int nrf_wifi_if_get_config_zep(const struct device *dev,
 
 	if (type == ETHERNET_CONFIG_TYPE_TXINJECTION_MODE) {
 		config->txinjection_mode =
-			def_dev_ctx->vif_ctx[vif_ctx_zep->vif_idx]->txinjection_mode;
+			sys_dev_ctx->vif_ctx[vif_ctx_zep->vif_idx]->txinjection_mode;
 	}
 #ifdef CONFIG_NRF70_TCP_IP_CHECKSUM_OFFLOAD
 	if (type  == ETHERNET_CONFIG_TYPE_TX_CHECKSUM_SUPPORT ||
@@ -1018,7 +1018,7 @@ int nrf_wifi_if_set_config_zep(const struct device *dev,
 	struct nrf_wifi_vif_ctx_zep *vif_ctx_zep = NULL;
 	struct nrf_wifi_ctx_zep *rpu_ctx_zep = NULL;
 	struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx = NULL;
-	struct nrf_wifi_fmac_dev_ctx_def *def_dev_ctx = NULL;
+	struct nrf_wifi_sys_fmac_dev_ctx *sys_dev_ctx = NULL;
 	int ret = -1;
 
 	if (!dev) {
@@ -1067,9 +1067,9 @@ int nrf_wifi_if_set_config_zep(const struct device *dev,
 	}
 
 	fmac_dev_ctx = rpu_ctx_zep->rpu_ctx;
-	def_dev_ctx = wifi_dev_priv(fmac_dev_ctx);
-	if (!def_dev_ctx) {
-		LOG_ERR("%s: def_dev_ctx is NULL",
+	sys_dev_ctx = wifi_dev_priv(fmac_dev_ctx);
+	if (!sys_dev_ctx) {
+		LOG_ERR("%s: sys_dev_ctx is NULL",
 			__func__);
 		goto unlock;
 	}
@@ -1078,7 +1078,7 @@ int nrf_wifi_if_set_config_zep(const struct device *dev,
 	if (type == ETHERNET_CONFIG_TYPE_TXINJECTION_MODE) {
 		unsigned char mode;
 
-		if (def_dev_ctx->vif_ctx[vif_ctx_zep->vif_idx]->txinjection_mode ==
+		if (sys_dev_ctx->vif_ctx[vif_ctx_zep->vif_idx]->txinjection_mode ==
 		    config->txinjection_mode) {
 			LOG_INF("%s: Driver TX injection setting is same as configured setting",
 				__func__);
@@ -1091,10 +1091,10 @@ int nrf_wifi_if_set_config_zep(const struct device *dev,
 		 * as is
 		 */
 		if (config->txinjection_mode) {
-			mode = (def_dev_ctx->vif_ctx[vif_ctx_zep->vif_idx]->mode) |
+			mode = (sys_dev_ctx->vif_ctx[vif_ctx_zep->vif_idx]->mode) |
 			       (NRF_WIFI_TX_INJECTION_MODE);
 		} else {
-			mode = (def_dev_ctx->vif_ctx[vif_ctx_zep->vif_idx]->mode) ^
+			mode = (sys_dev_ctx->vif_ctx[vif_ctx_zep->vif_idx]->mode) ^
 			       (NRF_WIFI_TX_INJECTION_MODE);
 		}
 
@@ -1111,7 +1111,7 @@ int nrf_wifi_if_set_config_zep(const struct device *dev,
 	else if (type == ETHERNET_CONFIG_TYPE_PROMISC_MODE) {
 		unsigned char mode;
 
-		if (def_dev_ctx->vif_ctx[vif_ctx_zep->vif_idx]->promisc_mode ==
+		if (sys_dev_ctx->vif_ctx[vif_ctx_zep->vif_idx]->promisc_mode ==
 		    config->promisc_mode) {
 			LOG_ERR("%s: Driver promisc mode setting is same as configured setting",
 				__func__);
@@ -1119,10 +1119,10 @@ int nrf_wifi_if_set_config_zep(const struct device *dev,
 		}
 
 		if (config->promisc_mode) {
-			mode = (def_dev_ctx->vif_ctx[vif_ctx_zep->vif_idx]->mode) |
+			mode = (sys_dev_ctx->vif_ctx[vif_ctx_zep->vif_idx]->mode) |
 			       (NRF_WIFI_PROMISCUOUS_MODE);
 		} else {
-			mode = (def_dev_ctx->vif_ctx[vif_ctx_zep->vif_idx]->mode) ^
+			mode = (sys_dev_ctx->vif_ctx[vif_ctx_zep->vif_idx]->mode) ^
 			       (NRF_WIFI_PROMISCUOUS_MODE);
 		}
 
@@ -1171,7 +1171,7 @@ int nrf_wifi_stats_get(const struct device *dev, struct net_stats_wifi *zstats)
 	struct nrf_wifi_ctx_zep *rpu_ctx_zep = NULL;
 	struct nrf_wifi_vif_ctx_zep *vif_ctx_zep = NULL;
 #ifdef CONFIG_NRF70_RAW_DATA_TX
-	struct nrf_wifi_fmac_dev_ctx_def *def_dev_ctx = NULL;
+	struct nrf_wifi_sys_fmac_dev_ctx *sys_dev_ctx = NULL;
 #endif /* CONFIG_NRF70_RAW_DATA_TX */
 	struct rpu_op_stats stats;
 	int ret = -1;
@@ -1229,8 +1229,8 @@ int nrf_wifi_stats_get(const struct device *dev, struct net_stats_wifi *zstats)
 	zstats->overrun_count = stats.host.total_tx_drop_pkts + stats.host.total_rx_drop_pkts;
 
 #ifdef CONFIG_NRF70_RAW_DATA_TX
-	def_dev_ctx = wifi_dev_priv(rpu_ctx_zep->rpu_ctx);
-	zstats->errors.tx += def_dev_ctx->raw_pkt_stats.raw_pkt_send_failure;
+	sys_dev_ctx = wifi_dev_priv(rpu_ctx_zep->rpu_ctx);
+	zstats->errors.tx += sys_dev_ctx->raw_pkt_stats.raw_pkt_send_failure;
 #endif /* CONFIG_NRF70_RAW_DATA_TX */
 	ret = 0;
 unlock:
@@ -1244,7 +1244,7 @@ int nrf_wifi_stats_reset(const struct device *dev)
 	enum nrf_wifi_status status = NRF_WIFI_STATUS_FAIL;
 	struct nrf_wifi_ctx_zep *rpu_ctx_zep = NULL;
 	struct nrf_wifi_vif_ctx_zep *vif_ctx_zep = NULL;
-	struct nrf_wifi_fmac_dev_ctx_def *def_dev_ctx = NULL;
+	struct nrf_wifi_sys_fmac_dev_ctx *sys_dev_ctx = NULL;
 	int ret = -1;
 
 	if (!dev) {
@@ -1277,8 +1277,8 @@ int nrf_wifi_stats_reset(const struct device *dev)
 		goto unlock;
 	}
 
-	def_dev_ctx = wifi_dev_priv(rpu_ctx_zep->rpu_ctx);
-	memset(&def_dev_ctx->host_stats, 0, sizeof(struct rpu_host_stats));
+	sys_dev_ctx = wifi_dev_priv(rpu_ctx_zep->rpu_ctx);
+	memset(&sys_dev_ctx->host_stats, 0, sizeof(struct rpu_host_stats));
 
 	ret = 0;
 unlock:

--- a/drivers/wifi/nrf_wifi/src/wifi_mgmt.c
+++ b/drivers/wifi/nrf_wifi/src/wifi_mgmt.c
@@ -15,9 +15,9 @@
 #include <zephyr/logging/log.h>
 
 #include "util.h"
-#include "fmac_api.h"
-#include "fmac_tx.h"
-#include "fmac_util.h"
+#include "system/fmac_api.h"
+#include "system/fmac_tx.h"
+#include "common/fmac_util.h"
 #include "fmac_main.h"
 #include "wifi_mgmt.h"
 
@@ -69,7 +69,7 @@ int nrf_wifi_set_power_save(const struct device *dev,
 				WIFI_PS_PARAM_LISTEN_INTERVAL_RANGE_INVALID;
 			return -EINVAL;
 		}
-		status = nrf_wifi_fmac_set_listen_interval(
+		status = nrf_wifi_sys_fmac_set_listen_interval(
 						rpu_ctx_zep->rpu_ctx,
 						vif_ctx_zep->vif_idx,
 						params->listen_interval);
@@ -90,7 +90,7 @@ int nrf_wifi_set_power_save(const struct device *dev,
 			goto out;
 		}
 
-		status = nrf_wifi_fmac_set_power_save_timeout(
+		status = nrf_wifi_sys_fmac_set_power_save_timeout(
 							rpu_ctx_zep->rpu_ctx,
 							vif_ctx_zep->vif_idx,
 							params->timeout_ms);
@@ -100,17 +100,17 @@ int nrf_wifi_set_power_save(const struct device *dev,
 			uapsd_queue = UAPSD_Q_MAX; /* WMM mode */
 		}
 
-		status = nrf_wifi_fmac_set_uapsd_queue(rpu_ctx_zep->rpu_ctx,
+		status = nrf_wifi_sys_fmac_set_uapsd_queue(rpu_ctx_zep->rpu_ctx,
 						       vif_ctx_zep->vif_idx,
 						       uapsd_queue);
 	break;
 	case  WIFI_PS_PARAM_STATE:
-		status = nrf_wifi_fmac_set_power_save(rpu_ctx_zep->rpu_ctx,
+		status = nrf_wifi_sys_fmac_set_power_save(rpu_ctx_zep->rpu_ctx,
 						      vif_ctx_zep->vif_idx,
 						      params->enabled);
 	break;
 	case WIFI_PS_PARAM_WAKEUP_MODE:
-		status = nrf_wifi_fmac_set_ps_wakeup_mode(
+		status = nrf_wifi_sys_fmac_set_ps_wakeup_mode(
 							rpu_ctx_zep->rpu_ctx,
 							vif_ctx_zep->vif_idx,
 							params->wakeup_mode);
@@ -128,7 +128,7 @@ int nrf_wifi_set_power_save(const struct device *dev,
 			return -EINVAL;
 		}
 
-		status = nrf_wifi_fmac_set_ps_exit_strategy(
+		status = nrf_wifi_sys_fmac_set_ps_exit_strategy(
 							rpu_ctx_zep->rpu_ctx,
 							vif_ctx_zep->vif_idx,
 							exit_strategy);
@@ -211,11 +211,11 @@ int nrf_wifi_get_power_save_config(const struct device *dev,
 
 	vif_ctx_zep->ps_config_info_evnt = false;
 
-	status = nrf_wifi_fmac_get_power_save_info(rpu_ctx_zep->rpu_ctx,
+	status = nrf_wifi_sys_fmac_get_power_save_info(rpu_ctx_zep->rpu_ctx,
 						   vif_ctx_zep->vif_idx);
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		LOG_ERR("%s: nrf_wifi_fmac_get_power_save_info failed",
+		LOG_ERR("%s: nrf_wifi_sys_fmac_get_power_save_info failed",
 			__func__);
 		goto out;
 	}
@@ -468,7 +468,7 @@ int nrf_wifi_twt_teardown_flows(struct nrf_wifi_vif_ctx_zep *vif_ctx_zep,
 			continue;
 		}
 		twt_info.twt_flow_id = flow_id;
-		status = nrf_wifi_fmac_twt_teardown(rpu_ctx_zep->rpu_ctx,
+		status = nrf_wifi_sys_fmac_twt_teardown(rpu_ctx_zep->rpu_ctx,
 						vif_ctx_zep->vif_idx,
 						&twt_info);
 		if (status != NRF_WIFI_STATUS_SUCCESS) {
@@ -569,7 +569,7 @@ int nrf_wifi_set_twt(const struct device *dev,
 		twt_info.dialog_token = twt_params->dialog_token;
 		twt_info.twt_wake_ahead_duration = twt_params->setup.twt_wake_ahead_duration;
 
-		status = nrf_wifi_fmac_twt_setup(rpu_ctx_zep->rpu_ctx,
+		status = nrf_wifi_sys_fmac_twt_setup(rpu_ctx_zep->rpu_ctx,
 					   vif_ctx_zep->vif_idx,
 					   &twt_info);
 
@@ -811,8 +811,9 @@ int nrf_wifi_mode(const struct device *dev,
 		 * context maps the correct network interface index to current driver
 		 * interface index.
 		 */
-		status = nrf_wifi_fmac_set_mode(rpu_ctx_zep->rpu_ctx,
-						vif_ctx_zep->vif_idx, mode->mode);
+		status = nrf_wifi_sys_fmac_set_mode(rpu_ctx_zep->rpu_ctx,
+						    vif_ctx_zep->vif_idx,
+						    mode->mode);
 		if (status != NRF_WIFI_STATUS_SUCCESS) {
 			LOG_ERR("%s: mode set operation failed", __func__);
 			goto out;
@@ -891,8 +892,9 @@ int nrf_wifi_channel(const struct device *dev,
 		 * context maps the correct network interface index to current driver
 		 * interface index.
 		 */
-		status = nrf_wifi_fmac_set_channel(rpu_ctx_zep->rpu_ctx, vif_ctx_zep->vif_idx,
-						   channel->channel);
+		status = nrf_wifi_sys_fmac_set_channel(rpu_ctx_zep->rpu_ctx,
+						       vif_ctx_zep->vif_idx,
+						       channel->channel);
 
 		if (status != NRF_WIFI_STATUS_SUCCESS) {
 			LOG_ERR("%s: set channel failed", __func__);
@@ -972,8 +974,10 @@ int nrf_wifi_filter(const struct device *dev,
 		 * context maps the correct network interface index to current driver
 		 * interface index
 		 */
-		status = nrf_wifi_fmac_set_packet_filter(rpu_ctx_zep->rpu_ctx, filter->filter,
-							 vif_ctx_zep->vif_idx, filter->buffer_size);
+		status = nrf_wifi_sys_fmac_set_packet_filter(rpu_ctx_zep->rpu_ctx,
+							     filter->filter,
+							     vif_ctx_zep->vif_idx,
+							     filter->buffer_size);
 		if (status != NRF_WIFI_STATUS_SUCCESS) {
 			LOG_ERR("%s: Set filter operation failed\n", __func__);
 			goto out;
@@ -1036,7 +1040,7 @@ int nrf_wifi_set_rts_threshold(const struct device *dev,
 
 	k_mutex_lock(&vif_ctx_zep->vif_lock, K_FOREVER);
 
-	status = nrf_wifi_fmac_set_wiphy_params(rpu_ctx_zep->rpu_ctx,
+	status = nrf_wifi_sys_fmac_set_wiphy_params(rpu_ctx_zep->rpu_ctx,
 						vif_ctx_zep->vif_idx,
 						&wiphy_info);
 

--- a/drivers/wifi/nrf_wifi/src/wifi_mgmt_scan.c
+++ b/drivers/wifi/nrf_wifi/src/wifi_mgmt_scan.c
@@ -15,8 +15,8 @@
 #include <zephyr/logging/log.h>
 
 #include "util.h"
-#include "fmac_api.h"
-#include "fmac_tx.h"
+#include "system/fmac_api.h"
+#include "system/fmac_tx.h"
 #include "fmac_main.h"
 #include "wifi_mgmt_scan.h"
 
@@ -210,10 +210,10 @@ int nrf_wifi_disp_scan_zep(const struct device *dev, struct wifi_scan_params *pa
 	scan_info->scan_params.passive_scan = 1;
 #endif /* CONFIG_NRF70_PASSIVE_SCAN_ONLY */
 
-	status = nrf_wifi_fmac_scan(rpu_ctx_zep->rpu_ctx, vif_ctx_zep->vif_idx, scan_info);
+	status = nrf_wifi_sys_fmac_scan(rpu_ctx_zep->rpu_ctx, vif_ctx_zep->vif_idx, scan_info);
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		LOG_ERR("%s: nrf_wifi_fmac_scan failed", __func__);
+		LOG_ERR("%s: nrf_wifi_sys_fmac_scan failed", __func__);
 		goto out;
 	}
 
@@ -249,12 +249,12 @@ enum nrf_wifi_status nrf_wifi_disp_scan_res_get_zep(struct nrf_wifi_vif_ctx_zep 
 		goto out;
 	}
 
-	status = nrf_wifi_fmac_scan_res_get(rpu_ctx_zep->rpu_ctx,
+	status = nrf_wifi_sys_fmac_scan_res_get(rpu_ctx_zep->rpu_ctx,
 					    vif_ctx_zep->vif_idx,
 					    SCAN_DISPLAY);
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		LOG_ERR("%s: nrf_wifi_fmac_scan failed", __func__);
+		LOG_ERR("%s: nrf_wifi_sys_fmac_scan failed", __func__);
 		goto out;
 	}
 

--- a/drivers/wifi/nrf_wifi/src/wifi_util.c
+++ b/drivers/wifi/nrf_wifi/src/wifi_util.c
@@ -9,8 +9,8 @@
  */
 #include <stdlib.h>
 #include "host_rpu_umac_if.h"
-#include "fmac_api.h"
-#include "fmac_util.h"
+#include "common/fmac_util.h"
+#include "system/fmac_api.h"
 #include "fmac_main.h"
 #include "wifi_util.h"
 
@@ -161,10 +161,10 @@ static int nrf_wifi_util_set_he_ltf_gi(const struct shell *sh,
 		return -ENOEXEC;
 	}
 
-	status = nrf_wifi_fmac_conf_ltf_gi(ctx->rpu_ctx,
-					   ctx->conf_params.he_ltf,
-					   ctx->conf_params.he_gi,
-					   val);
+	status = nrf_wifi_sys_fmac_conf_ltf_gi(ctx->rpu_ctx,
+					       ctx->conf_params.he_ltf,
+					       ctx->conf_params.he_gi,
+					       val);
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		shell_fprintf(sh,
@@ -199,7 +199,7 @@ static int nrf_wifi_util_set_uapsd_queue(const struct shell *sh,
 	}
 
 	if (ctx->conf_params.uapsd_queue != val) {
-		status = nrf_wifi_fmac_set_uapsd_queue(ctx->rpu_ctx,
+		status = nrf_wifi_sys_fmac_set_uapsd_queue(ctx->rpu_ctx,
 						       0,
 						       val);
 
@@ -272,7 +272,7 @@ static int nrf_wifi_util_tx_stats(const struct shell *sh,
 	struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx = NULL;
 	void *queue = NULL;
 	unsigned int tx_pending_pkts = 0;
-	struct nrf_wifi_fmac_dev_ctx_def *def_dev_ctx = NULL;
+	struct nrf_wifi_sys_fmac_dev_ctx *sys_dev_ctx = NULL;
 	int ret;
 
 	vif_index = atoi(argv[1]);
@@ -295,7 +295,7 @@ static int nrf_wifi_util_tx_stats(const struct shell *sh,
 	}
 
 	fmac_dev_ctx = ctx->rpu_ctx;
-	def_dev_ctx = wifi_dev_priv(fmac_dev_ctx);
+	sys_dev_ctx = wifi_dev_priv(fmac_dev_ctx);
 
 	/* TODO: Get peer_index from shell once AP mode is supported */
 	shell_fprintf(sh,
@@ -304,7 +304,7 @@ static int nrf_wifi_util_tx_stats(const struct shell *sh,
 		vif_index);
 
 	for (int i = 0; i < NRF_WIFI_FMAC_AC_MAX ; i++) {
-		queue = def_dev_ctx->tx_config.data_pending_txq[peer_index][i];
+		queue = sys_dev_ctx->tx_config.data_pending_txq[peer_index][i];
 		tx_pending_pkts = nrf_wifi_utils_q_len(queue);
 
 		shell_fprintf(
@@ -312,7 +312,7 @@ static int nrf_wifi_util_tx_stats(const struct shell *sh,
 			SHELL_INFO,
 			"Outstanding tokens: ac: %d -> %d (pending_q_len: %d)\n",
 			i,
-			def_dev_ctx->tx_config.outstanding_descs[i],
+			sys_dev_ctx->tx_config.outstanding_descs[i],
 			tx_pending_pkts);
 	}
 
@@ -373,9 +373,9 @@ static int nrf_wifi_util_tx_rate(const struct shell *sh,
 
 	}
 
-	status = nrf_wifi_fmac_set_tx_rate(ctx->rpu_ctx,
-					   rate_flag,
-					   data_rate);
+	status = nrf_wifi_sys_fmac_set_tx_rate(ctx->rpu_ctx,
+					       rate_flag,
+					       data_rate);
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		shell_fprintf(sh,
@@ -399,8 +399,8 @@ static int nrf_wifi_util_show_host_rpu_ps_ctrl_state(const struct shell *sh,
 	enum nrf_wifi_status status = NRF_WIFI_STATUS_FAIL;
 	int rpu_ps_state = -1;
 
-	status = nrf_wifi_fmac_get_host_rpu_ps_ctrl_state(ctx->rpu_ctx,
-							  &rpu_ps_state);
+	status = nrf_wifi_sys_fmac_get_host_rpu_ps_ctrl_state(ctx->rpu_ctx,
+							      &rpu_ps_state);
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		shell_fprintf(sh,
@@ -456,7 +456,7 @@ static int nrf_wifi_util_dump_rpu_stats(const struct shell *sh,
 {
 	enum nrf_wifi_status status = NRF_WIFI_STATUS_FAIL;
 	struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx = NULL;
-	struct rpu_op_stats stats;
+	struct rpu_sys_op_stats stats;
 	enum rpu_stats_type stats_type = RPU_STATS_TYPE_ALL;
 	int ret;
 
@@ -490,8 +490,8 @@ static int nrf_wifi_util_dump_rpu_stats(const struct shell *sh,
 	}
 	fmac_dev_ctx = ctx->rpu_ctx;
 
-	memset(&stats, 0, sizeof(struct rpu_op_stats));
-	status = nrf_wifi_fmac_stats_get(fmac_dev_ctx, 0, &stats);
+	memset(&stats, 0, sizeof(struct rpu_sys_op_stats));
+	status = nrf_wifi_sys_fmac_stats_get(fmac_dev_ctx, 0, &stats);
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		shell_fprintf(sh,
@@ -898,7 +898,7 @@ static int nrf_wifi_util_trigger_rpu_recovery(const struct shell *sh,
 
 	fmac_dev_ctx = ctx->rpu_ctx;
 
-	status = nrf_wifi_fmac_rpu_recovery_callback(fmac_dev_ctx, NULL, 0);
+	status = nrf_wifi_sys_fmac_rpu_recovery_callback(fmac_dev_ctx, NULL, 0);
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		shell_fprintf(sh,
 			      SHELL_ERROR,

--- a/drivers/wifi/nrf_wifi/src/wifi_util.h
+++ b/drivers/wifi/nrf_wifi/src/wifi_util.h
@@ -15,7 +15,7 @@
 #include <zephyr/init.h>
 #include <ctype.h>
 #include <host_rpu_sys_if.h>
-#include <fmac_structs.h>
+#include <common/fmac_structs_common.h>
 #include <queue.h>
 
 struct nrf_wifi_ctx_zep_rt {

--- a/drivers/wifi/nrf_wifi/src/wpa_supp_if.c
+++ b/drivers/wifi/nrf_wifi/src/wpa_supp_if.c
@@ -14,7 +14,7 @@
 #include <zephyr/logging/log.h>
 
 #include "fmac_main.h"
-#include "fmac_util.h"
+#include "common/fmac_util.h"
 #include "wifi_mgmt.h"
 #include "wpa_supp_if.h"
 
@@ -563,7 +563,7 @@ int nrf_wifi_wpa_supp_scan2(void *if_priv, struct wpa_driver_scan_params *params
 		goto out;
 	}
 
-	status = nrf_wifi_fmac_scan(rpu_ctx_zep->rpu_ctx, vif_ctx_zep->vif_idx, scan_info);
+	status = nrf_wifi_sys_fmac_scan(rpu_ctx_zep->rpu_ctx, vif_ctx_zep->vif_idx, scan_info);
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		LOG_ERR("%s: Scan trigger failed", __func__);
@@ -614,10 +614,10 @@ int nrf_wifi_wpa_supp_scan_abort(void *if_priv)
 		goto out;
 	}
 
-	status = nrf_wifi_fmac_abort_scan(rpu_ctx_zep->rpu_ctx, vif_ctx_zep->vif_idx);
+	status = nrf_wifi_sys_fmac_abort_scan(rpu_ctx_zep->rpu_ctx, vif_ctx_zep->vif_idx);
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		LOG_ERR("%s: nrf_wifi_fmac_abort_scan failed", __func__);
+		LOG_ERR("%s: nrf_wifi_sys_fmac_abort_scan failed", __func__);
 		goto out;
 	}
 
@@ -660,11 +660,11 @@ int nrf_wifi_wpa_supp_scan_results_get(void *if_priv)
 		goto out;
 	}
 
-	status = nrf_wifi_fmac_scan_res_get(rpu_ctx_zep->rpu_ctx, vif_ctx_zep->vif_idx,
+	status = nrf_wifi_sys_fmac_scan_res_get(rpu_ctx_zep->rpu_ctx, vif_ctx_zep->vif_idx,
 					    SCAN_CONNECT);
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		LOG_ERR("%s: nrf_wifi_fmac_scan_res_get failed", __func__);
+		LOG_ERR("%s: nrf_wifi_sys_fmac_scan_res_get failed", __func__);
 		goto out;
 	}
 
@@ -706,10 +706,10 @@ int nrf_wifi_wpa_supp_deauthenticate(void *if_priv, const char *addr, unsigned s
 
 	memcpy(deauth_info.mac_addr, addr, sizeof(deauth_info.mac_addr));
 
-	status = nrf_wifi_fmac_deauth(rpu_ctx_zep->rpu_ctx, vif_ctx_zep->vif_idx, &deauth_info);
+	status = nrf_wifi_sys_fmac_deauth(rpu_ctx_zep->rpu_ctx, vif_ctx_zep->vif_idx, &deauth_info);
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		LOG_ERR("%s: nrf_wifi_fmac_deauth failed", __func__);
+		LOG_ERR("%s: nrf_wifi_sys_fmac_deauth failed", __func__);
 		goto out;
 	}
 
@@ -850,7 +850,7 @@ int nrf_wifi_wpa_supp_authenticate(void *if_priv, struct wpa_driver_auth_params 
 		auth_info.nrf_wifi_flags |= NRF_WIFI_CMD_AUTHENTICATE_LOCAL_STATE_CHANGE;
 	}
 
-	status = nrf_wifi_fmac_auth(rpu_ctx_zep->rpu_ctx, vif_ctx_zep->vif_idx, &auth_info);
+	status = nrf_wifi_sys_fmac_auth(rpu_ctx_zep->rpu_ctx, vif_ctx_zep->vif_idx, &auth_info);
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		LOG_ERR("%s: MLME command failed (auth): count=%d ret=%d", __func__, count, ret);
@@ -931,7 +931,7 @@ int nrf_wifi_wpa_supp_associate(void *if_priv, struct wpa_driver_associate_param
 		assoc_info.bss_max_idle_time = params->bss_max_idle_period;
 	}
 
-	status = nrf_wifi_fmac_assoc(rpu_ctx_zep->rpu_ctx, vif_ctx_zep->vif_idx, &assoc_info);
+	status = nrf_wifi_sys_fmac_assoc(rpu_ctx_zep->rpu_ctx, vif_ctx_zep->vif_idx, &assoc_info);
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		LOG_ERR("%s: MLME command failed (assoc)", __func__);
@@ -1025,20 +1025,20 @@ int nrf_wifi_wpa_supp_set_key(void *if_priv, const unsigned char *ifname, enum w
 	key_info.valid_fields |= NRF_WIFI_KEY_IDX_VALID;
 
 	if (alg == WPA_ALG_NONE) {
-		status = nrf_wifi_fmac_del_key(rpu_ctx_zep->rpu_ctx, vif_ctx_zep->vif_idx,
+		status = nrf_wifi_sys_fmac_del_key(rpu_ctx_zep->rpu_ctx, vif_ctx_zep->vif_idx,
 					       &key_info, mac_addr);
 
 		if (status != NRF_WIFI_STATUS_SUCCESS) {
-			LOG_ERR("%s: nrf_wifi_fmac_del_key failed", __func__);
+			LOG_ERR("%s: nrf_wifi_sys_fmac_del_key failed", __func__);
 		} else {
 			ret = 0;
 		}
 	} else {
-		status = nrf_wifi_fmac_add_key(rpu_ctx_zep->rpu_ctx, vif_ctx_zep->vif_idx,
+		status = nrf_wifi_sys_fmac_add_key(rpu_ctx_zep->rpu_ctx, vif_ctx_zep->vif_idx,
 					       &key_info, mac_addr);
 
 		if (status != NRF_WIFI_STATUS_SUCCESS) {
-			LOG_ERR("%s: nrf_wifi_fmac_add_key failed", __func__);
+			LOG_ERR("%s: nrf_wifi_sys_fmac_add_key failed", __func__);
 		} else {
 			ret = 0;
 		}
@@ -1071,10 +1071,10 @@ int nrf_wifi_wpa_supp_set_key(void *if_priv, const unsigned char *ifname, enum w
 		key_info.nrf_wifi_flags |= NRF_WIFI_KEY_DEFAULT_TYPE_UNICAST;
 	}
 
-	status = nrf_wifi_fmac_set_key(rpu_ctx_zep->rpu_ctx, vif_ctx_zep->vif_idx, &key_info);
+	status = nrf_wifi_sys_fmac_set_key(rpu_ctx_zep->rpu_ctx, vif_ctx_zep->vif_idx, &key_info);
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		LOG_ERR("%s: nrf_wifi_fmac_set_key failed", __func__);
+		LOG_ERR("%s: nrf_wifi_sys_fmac_set_key failed", __func__);
 		ret = -1;
 	} else {
 		ret = 0;
@@ -1129,10 +1129,12 @@ int nrf_wifi_wpa_set_supp_port(void *if_priv, int authorized, char *bssid)
 		chg_sta_info.sta_flags2.nrf_wifi_set = 1 << 1;
 	}
 
-	status = nrf_wifi_fmac_chg_sta(rpu_ctx_zep->rpu_ctx, vif_ctx_zep->vif_idx, &chg_sta_info);
+	status = nrf_wifi_sys_fmac_chg_sta(rpu_ctx_zep->rpu_ctx,
+					   vif_ctx_zep->vif_idx,
+					   &chg_sta_info);
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		LOG_ERR("%s: nrf_wifi_fmac_chg_sta failed", __func__);
+		LOG_ERR("%s: nrf_wifi_sys_fmac_chg_sta failed", __func__);
 		ret = -1;
 		goto out;
 	}
@@ -1178,7 +1180,9 @@ int nrf_wifi_wpa_supp_signal_poll(void *if_priv, struct wpa_signal_info *si, uns
 		nrf_wifi_osal_time_elapsed_us(vif_ctx_zep->rssi_record_timestamp_us) / 1000;
 
 	if (rssi_record_elapsed_time_ms > CONFIG_NRF70_RSSI_STALE_TIMEOUT_MS) {
-		ret = nrf_wifi_fmac_get_station(rpu_ctx_zep->rpu_ctx, vif_ctx_zep->vif_idx, bssid);
+		ret = nrf_wifi_sys_fmac_get_station(rpu_ctx_zep->rpu_ctx,
+						    vif_ctx_zep->vif_idx,
+						    bssid);
 		if (ret != NRF_WIFI_STATUS_SUCCESS) {
 			LOG_ERR("%s: Failed to send get station info command", __func__);
 			goto out;
@@ -1194,7 +1198,7 @@ int nrf_wifi_wpa_supp_signal_poll(void *if_priv, struct wpa_signal_info *si, uns
 		si->data.signal = (int)vif_ctx_zep->rssi;
 	}
 
-	ret = nrf_wifi_fmac_get_interface(rpu_ctx_zep->rpu_ctx, vif_ctx_zep->vif_idx);
+	ret = nrf_wifi_sys_fmac_get_interface(rpu_ctx_zep->rpu_ctx, vif_ctx_zep->vif_idx);
 	if (ret != NRF_WIFI_STATUS_SUCCESS) {
 		LOG_ERR("%s: Failed to send get interface info command", __func__);
 		goto out;
@@ -1454,12 +1458,12 @@ int nrf_wifi_nl80211_send_mlme(void *if_priv, const u8 *data,
 
 	LOG_DBG("%s: Sending frame to RPU: cookie=%d wait_time=%d no_ack=%d", __func__,
 		    cookie, wait_time, noack);
-	status = nrf_wifi_fmac_mgmt_tx(rpu_ctx_zep->rpu_ctx,
+	status = nrf_wifi_sys_fmac_mgmt_tx(rpu_ctx_zep->rpu_ctx,
 			vif_ctx_zep->vif_idx,
 			mgmt_tx_info);
 
 	if (status == NRF_WIFI_STATUS_FAIL) {
-		LOG_ERR("%s: nrf_wifi_fmac_mgmt_tx failed", __func__);
+		LOG_ERR("%s: nrf_wifi_sys_fmac_mgmt_tx failed", __func__);
 		goto out;
 	}
 
@@ -1656,10 +1660,10 @@ int nrf_wifi_supp_get_wiphy(void *if_priv)
 		goto out;
 	}
 
-	status = nrf_wifi_fmac_get_wiphy(rpu_ctx_zep->rpu_ctx, vif_ctx_zep->vif_idx);
+	status = nrf_wifi_sys_fmac_get_wiphy(rpu_ctx_zep->rpu_ctx, vif_ctx_zep->vif_idx);
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		LOG_ERR("%s: nrf_wifi_fmac_get_wiphy failed", __func__);
+		LOG_ERR("%s: nrf_wifi_sys_fmac_get_wiphy failed", __func__);
 		goto out;
 	}
 out:
@@ -1700,11 +1704,11 @@ int nrf_wifi_supp_register_frame(void *if_priv,
 	frame_info.frame_match.frame_match_len = match_len;
 	memcpy(frame_info.frame_match.frame_match, match, match_len);
 
-	status = nrf_wifi_fmac_register_frame(rpu_ctx_zep->rpu_ctx, vif_ctx_zep->vif_idx,
+	status = nrf_wifi_sys_fmac_register_frame(rpu_ctx_zep->rpu_ctx, vif_ctx_zep->vif_idx,
 			&frame_info);
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		LOG_ERR("%s: nrf_wifi_fmac_register_frame failed", __func__);
+		LOG_ERR("%s: nrf_wifi_sys_fmac_register_frame failed", __func__);
 		goto out;
 	}
 out:
@@ -1843,9 +1847,9 @@ int nrf_wifi_supp_get_conn_info(void *if_priv, struct wpa_conn_info *info)
 	fmac_dev_ctx = rpu_ctx_zep->rpu_ctx;
 
 	vif_ctx_zep->conn_info = info;
-	ret = nrf_wifi_fmac_get_conn_info(rpu_ctx_zep->rpu_ctx, vif_ctx_zep->vif_idx);
+	ret = nrf_wifi_sys_fmac_get_conn_info(rpu_ctx_zep->rpu_ctx, vif_ctx_zep->vif_idx);
 	if (ret != NRF_WIFI_STATUS_SUCCESS) {
-		LOG_ERR("%s: nrf_wifi_fmac_get_conn_info failed", __func__);
+		LOG_ERR("%s: nrf_wifi_sys_fmac_get_conn_info failed", __func__);
 		goto out;
 	}
 
@@ -1990,12 +1994,12 @@ static int nrf_wifi_vif_state_change(struct nrf_wifi_vif_ctx_zep *vif_ctx_zep,
 	vif_state_info.state = state;
 	vif_state_info.if_index = vif_ctx_zep->vif_idx;
 	vif_ctx->ifflags = false;
-	status = nrf_wifi_fmac_chg_vif_state(rpu_ctx_zep->rpu_ctx,
+	status = nrf_wifi_sys_fmac_chg_vif_state(rpu_ctx_zep->rpu_ctx,
 					     vif_ctx_zep->vif_idx,
 					     &vif_state_info);
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		LOG_ERR("%s: nrf_wifi_fmac_chg_vif_state failed",
+		LOG_ERR("%s: nrf_wifi_sys_fmac_chg_vif_state failed",
 			__func__);
 		goto out;
 	}
@@ -2047,9 +2051,11 @@ static int nrf_wifi_iftype_change(struct nrf_wifi_vif_ctx_zep *vif_ctx_zep, int 
 	chg_vif_info.iftype = iftype;
 	vif_ctx_zep->set_if_event_received = false;
 	vif_ctx_zep->set_if_status = 0;
-	status = nrf_wifi_fmac_chg_vif(rpu_ctx_zep->rpu_ctx, vif_ctx_zep->vif_idx, &chg_vif_info);
+	status = nrf_wifi_sys_fmac_chg_vif(rpu_ctx_zep->rpu_ctx,
+					   vif_ctx_zep->vif_idx,
+					   &chg_vif_info);
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		LOG_ERR("%s: nrf_wifi_fmac_chg_vif failed", __func__);
+		LOG_ERR("%s: nrf_wifi_sys_fmac_chg_vif failed", __func__);
 		goto out;
 	}
 
@@ -2261,11 +2267,11 @@ int nrf_wifi_supp_register_mgmt_frame(void *if_priv,
 	}
 	memcpy(mgmt_frame_info.frame_match.frame_match, match, match_len);
 
-	status = nrf_wifi_fmac_mgmt_frame_reg(rpu_ctx_zep->rpu_ctx,
+	status = nrf_wifi_sys_fmac_mgmt_frame_reg(rpu_ctx_zep->rpu_ctx,
 					      vif_ctx_zep->vif_idx,
 					      &mgmt_frame_info);
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		LOG_ERR("%s: nrf_wifi_fmac_mgmt_frame_reg failed", __func__);
+		LOG_ERR("%s: nrf_wifi_sys_fmac_mgmt_frame_reg failed", __func__);
 		goto out;
 	}
 
@@ -2324,9 +2330,9 @@ static int nrf_wifi_set_bss(struct nrf_wifi_vif_ctx_zep *vif_ctx_zep,
 	bss_info.nrf_wifi_slot = params->short_slot_time;
 	bss_info.ap_isolate = params->isolate;
 
-	status = nrf_wifi_fmac_set_bss(rpu_ctx_zep->rpu_ctx, vif_ctx_zep->vif_idx, &bss_info);
+	status = nrf_wifi_sys_fmac_set_bss(rpu_ctx_zep->rpu_ctx, vif_ctx_zep->vif_idx, &bss_info);
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		LOG_ERR("%s: nrf_wifi_fmac_set_bss failed", __func__);
+		LOG_ERR("%s: nrf_wifi_sys_fmac_set_bss failed", __func__);
 		goto out;
 	}
 
@@ -2423,9 +2429,11 @@ int nrf_wifi_wpa_supp_start_ap(void *if_priv, struct wpa_driver_ap_params *param
 		NRF_WIFI_SET_FREQ_PARAMS_CHANNEL_TYPE_VALID;
 
 	vif_ctx_zep->if_carr_state = NRF_WIFI_FMAC_IF_CARR_STATE_OFF;
-	status = nrf_wifi_fmac_start_ap(rpu_ctx_zep->rpu_ctx, vif_ctx_zep->vif_idx, &start_ap_info);
+	status = nrf_wifi_sys_fmac_start_ap(rpu_ctx_zep->rpu_ctx,
+					    vif_ctx_zep->vif_idx,
+					    &start_ap_info);
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		LOG_ERR("%s: nrf_wifi_fmac_start_ap failed", __func__);
+		LOG_ERR("%s: nrf_wifi_sys_fmac_start_ap failed", __func__);
 		goto out;
 	}
 
@@ -2474,9 +2482,11 @@ int nrf_wifi_wpa_supp_change_beacon(void *if_priv, struct wpa_driver_ap_params *
 
 	nrf_wifi_set_beacon_data(params, &chg_bcn_info.beacon_data);
 
-	status = nrf_wifi_fmac_chg_bcn(rpu_ctx_zep->rpu_ctx, vif_ctx_zep->vif_idx, &chg_bcn_info);
+	status = nrf_wifi_sys_fmac_chg_bcn(rpu_ctx_zep->rpu_ctx,
+					   vif_ctx_zep->vif_idx,
+					   &chg_bcn_info);
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		LOG_ERR("%s: nrf_wifi_fmac_chg_bcn failed", __func__);
+		LOG_ERR("%s: nrf_wifi_sys_fmac_chg_bcn failed", __func__);
 		goto out;
 	}
 
@@ -2511,10 +2521,10 @@ int nrf_wifi_wpa_supp_stop_ap(void *if_priv)
 		goto out;
 	}
 
-	status = nrf_wifi_fmac_stop_ap(rpu_ctx_zep->rpu_ctx, vif_ctx_zep->vif_idx);
+	status = nrf_wifi_sys_fmac_stop_ap(rpu_ctx_zep->rpu_ctx, vif_ctx_zep->vif_idx);
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		LOG_ERR("%s: nrf_wifi_fmac_stop_ap failed", __func__);
+		LOG_ERR("%s: nrf_wifi_sys_fmac_stop_ap failed", __func__);
 		goto out;
 	}
 
@@ -2593,7 +2603,7 @@ int nrf_wifi_sta_flags_to_nrf(int wpas_sta_flags)
 		nrf_sta_flags |= NRF_WIFI_STA_FLAG_TDLS_PEER;
 	}
 	/* Note: Do not set flags > NRF_WIFI_STA_FLAG_TDLS_PEER, else
-	 * nrf_wifi_fmac_chg_sta will fail. This is equivalent to not
+	 * nrf_wifi_sys_fmac_chg_sta will fail. This is equivalent to not
 	 * setting WPA_DRIVER_FLAGS_FULL_AP_CLIENT_STATE flag.
 	 */
 
@@ -2685,16 +2695,16 @@ int nrf_wifi_wpa_supp_sta_add(void *if_priv, struct hostapd_sta_add_params *para
 		sta_info.sta_flags2.nrf_wifi_set, sta_info.sta_flags2.nrf_wifi_mask);
 
 	if (params->set) {
-		status = nrf_wifi_fmac_chg_sta(rpu_ctx_zep->rpu_ctx,
+		status = nrf_wifi_sys_fmac_chg_sta(rpu_ctx_zep->rpu_ctx,
 					vif_ctx_zep->vif_idx,
 					(struct nrf_wifi_umac_chg_sta_info *)&sta_info);
 	} else {
-		status = nrf_wifi_fmac_add_sta(rpu_ctx_zep->rpu_ctx,
+		status = nrf_wifi_sys_fmac_add_sta(rpu_ctx_zep->rpu_ctx,
 					vif_ctx_zep->vif_idx,
 					&sta_info);
 	}
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		LOG_ERR("%s: nrf_wifi_fmac_add_sta failed", __func__);
+		LOG_ERR("%s: nrf_wifi_sys_fmac_add_sta failed", __func__);
 		goto out;
 	}
 
@@ -2732,9 +2742,9 @@ int nrf_wifi_wpa_supp_sta_remove(void *if_priv, const u8 *addr)
 
 	memcpy(del_sta.mac_addr, addr, sizeof(del_sta.mac_addr));
 
-	status = nrf_wifi_fmac_del_sta(rpu_ctx_zep->rpu_ctx, vif_ctx_zep->vif_idx, &del_sta);
+	status = nrf_wifi_sys_fmac_del_sta(rpu_ctx_zep->rpu_ctx, vif_ctx_zep->vif_idx, &del_sta);
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		LOG_ERR("%s: nrf_wifi_fmac_del_sta failed", __func__);
+		LOG_ERR("%s: nrf_wifi_sys_fmac_del_sta failed", __func__);
 		goto out;
 	}
 
@@ -2781,9 +2791,9 @@ int nrf_wifi_wpa_supp_sta_set_flags(void *if_priv, const u8 *addr,
 	LOG_DBG("%s %x, %x", __func__,
 		chg_sta.sta_flags2.nrf_wifi_set, chg_sta.sta_flags2.nrf_wifi_mask);
 
-	status = nrf_wifi_fmac_chg_sta(rpu_ctx_zep->rpu_ctx, vif_ctx_zep->vif_idx, &chg_sta);
+	status = nrf_wifi_sys_fmac_chg_sta(rpu_ctx_zep->rpu_ctx, vif_ctx_zep->vif_idx, &chg_sta);
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		LOG_ERR("%s: nrf_wifi_fmac_chg_sta failed", __func__);
+		LOG_ERR("%s: nrf_wifi_sys_fmac_chg_sta failed", __func__);
 		goto out;
 	}
 
@@ -2820,10 +2830,11 @@ int nrf_wifi_wpa_supp_sta_get_inact_sec(void *if_priv, const u8 *addr)
 		goto out;
 	}
 
-	status = nrf_wifi_fmac_get_station(rpu_ctx_zep->rpu_ctx, vif_ctx_zep->vif_idx,
-					(unsigned char *) addr);
+	status = nrf_wifi_sys_fmac_get_station(rpu_ctx_zep->rpu_ctx,
+					       vif_ctx_zep->vif_idx,
+					       (unsigned char *) addr);
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		LOG_ERR("%s: nrf_wifi_fmac_get_station failed", __func__);
+		LOG_ERR("%s: nrf_wifi_sys_fmac_get_station failed", __func__);
 		goto out;
 	}
 

--- a/include/zephyr/drivers/wifi/nrf_wifi/off_raw_tx/off_raw_tx_api.h
+++ b/include/zephyr/drivers/wifi/nrf_wifi/off_raw_tx/off_raw_tx_api.h
@@ -16,7 +16,6 @@
 
 #include <stdbool.h>
 #include <stdint.h>
-#include "osal_api.h"
 
 /*  Minimum frame size for raw packet transmission */
 #define NRF_WIFI_OFF_RAW_TX_FRAME_SIZE_MIN 26

--- a/west.yml
+++ b/west.yml
@@ -321,7 +321,7 @@ manifest:
       revision: 2570f4a697ce2da860ff39ec34afd91749bd66d3
       path: modules/bsim_hw_models/nrf_hw_models
     - name: nrf_wifi
-      revision: 913d9f60b9dd6b92b70169ce857570f5bf5b1e3c
+      revision: 01359dffd9b6da4d162b4565fdd621ad94bd5d4e
       path: modules/lib/nrf_wifi
     - name: open-amp
       revision: 52bb1783521c62c019451cee9b05b8eda9d7425f


### PR DESCRIPTION
Update the nrf70 Wi-Fi driver to use the mode specific APIs (as a precursor to enable combining modes as required).