### PR TITLE
west.yml: MCUboot synchronization from v3.7-branch

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -23,6 +23,8 @@ manifest:
       url-base: https://github.com/zephyrproject-rtos
     - name: babblesim
       url-base: https://github.com/BabbleSim
+    - name: nordicjm
+      url-base: https://github.com/nordicjm
 
   group-filter: [-babblesim, -optional]
 
@@ -287,8 +289,9 @@ manifest:
       groups:
         - crypto
     - name: mcuboot
-      revision: ea2410697dd0262edec041a0ccb07fdbde7c1aff
+      revision: 58538ddfe21843edb39d7e7502812e61696e55c4
       path: bootloader/mcuboot
+      remote: nordicjm
     - name: mipi-sys-t
       path: modules/debug/mipi-sys-t
       groups:


### PR DESCRIPTION
Update Zephyr fork of MCUboot to revision:
  58538ddfe21843edb39d7e7502812e61696e55c4

Brings following Zephyr relevant fixes:

  - 58538ddf swap_move: correct appsize calcs and warning
  - 5ce8b311 zephyr: flash map: fix comparison signedness
  - 7d4de010 boot: bootutil: Fix usage of flash_area object
  - 61e1264b boot: bootutil: Take into account scratch trailer when computing max image size
  - 1a50ec2f boot: bootutil: Ensure the whole trailer is erased when it is large
  - c81ba032 boot: bootutil: Fix scratch trailer overwritten if image trailer is large
  - 913e9162 boot: bootutil: Fix underflow in swap-scratch when trailer is large
  - 509834cd boot: bootutil: Fix invalid last sector computation for swap-scratch
  - 834a0afa mynewt: Add flash_sector_get_size
  - ad7a2dd9 doc: imgtool: importance of clear flag
  - 50b727e7 docs: release-notes: Add note on fix for revert issue
  - 014d436c boot: bootutil: loader: Fix issue with stuck revert
  - 0c3ecbef boot: bootutil: Refactor some functions to have state
  - 78bb9c09 zephyr: Fix image encryption configuration for mbedTLS.
  - d8647ed3 zephyr: Fix usage of CONFIG_MBEDTLS_BUILTIN and ASN1
  - 41c82413 bootutil: Add missing MBEDTLS_ASN1_PARSE_C
  - 6f61d4fc zephyr: Remove scratch from flash_area_id_from_multi_image_slot
  - f48f5c5a boot: boot_serial: Fix uninitialised variables for upload
  - f40c2430 added missing MCUBOOT_VERSION_TWEAK in Zephyr port
  - a49a0337 boot: bootutil: loader.c: Add check if has upgrade before pushing state change
  - 664093d0 bootutil: Fix device brick after power failure during swap-move revert
  - c50b332b bootutil: Fix the reading of image headers after partial swap completion
  - 172694ea boot: zephyr: Fix sample.bootloader.mcuboot.usb_cdc_acm_recovery
  - 226a9a70 Allow bootstrapping for multiple images

Fixes #84614