### PR TITLE
ci: do_not_merge: add the manifest specific dnm label to the list

### DIFF
--- a/.github/workflows/do_not_merge.yml
+++ b/.github/workflows/do_not_merge.yml
@@ -11,6 +11,7 @@ jobs:
     steps:
       - name: Check for label
         if: ${{ contains(github.event.*.labels.*.name, 'DNM') ||
+                contains(github.event.*.labels.*.name, 'DNM (manifest)') ||
                 contains(github.event.*.labels.*.name, 'TSC') ||
                 contains(github.event.*.labels.*.name, 'Architecture Review') ||
                 contains(github.event.*.labels.*.name, 'dev-review') }}


### PR DESCRIPTION
Add "DNM (manifest)" to the "do not merge" labels. This is meant to be a DNM controlled by the manifest action specific, so that the normal one can be used by humans and the two are not going to fight with each other.