### PR TITLE
actions: manifest: use a manifest specitic dnm label

### DIFF
--- a/.github/workflows/manifest.yml
+++ b/.github/workflows/manifest.yml
@@ -36,4 +36,4 @@ jobs:
           label-prefix: 'manifest-'
           verbosity-level: '1'
           labels: 'manifest'
-          dnm-labels: 'DNM'
+          dnm-labels: 'DNM (manifest)'


### PR DESCRIPTION
Reconfigure the manifest action to use a manifest specific DNM label, so that the "DNM" one can be used by humans.

---

The plan:

- [x] Create the label
- [x] Merge https://github.com/zephyrproject-rtos/zephyr/pull/84617
- [x] Merge this
- [x] Manually go through https://github.com/zephyrproject-rtos/zephyr/pulls?q=is%3Aopen+is%3Apr+label%3ADNM and relabel the ones that needs it (I can hardly wait)