### PR TITLE
lib: fix typo in multiple directories

### DIFF
--- a/lib/acpi/acpi.c
+++ b/lib/acpi/acpi.c
@@ -408,7 +408,7 @@ int acpi_legacy_irq_init(const char *hid, const char *uid)
 		 * If Name path exist then PCI interrupts are configurable and are not hardwired to
 		 * any specific interrupt inputs on the interrupt controller. OSPM can uses
 		 * _PRS/_CRS/_SRS to configure interrupts. But currently leave existing PCI bus
-		 * driver with arch_irq_allocate() menthod for allocate and configure interrupts
+		 * driver with arch_irq_allocate() method for allocate and configure interrupts
 		 * without conflicting.
 		 */
 		return -ENOENT;

--- a/lib/heap/heap.h
+++ b/lib/heap/heap.h
@@ -10,7 +10,7 @@
  * Internal heap APIs
  */
 
-/* Theese validation checks are non-trivially expensive, so enable
+/* These validation checks are non-trivially expensive, so enable
  * only when debugging the heap code.  They shouldn't be routine
  * assertions.
  */

--- a/lib/os/mpsc_pbuf.c
+++ b/lib/os/mpsc_pbuf.c
@@ -201,7 +201,7 @@ static bool drop_item_locked(struct mpsc_pbuf_buffer *buffer,
 
 	uint32_t rd_wlen = buffer->get_wlen(item);
 
-	/* If packet is busy need to be ommited. */
+	/* If packet is busy need to be omitted. */
 	if (!is_valid(item)) {
 		return false;
 	} else if (item->hdr.busy) {
@@ -215,7 +215,7 @@ static bool drop_item_locked(struct mpsc_pbuf_buffer *buffer,
 		buffer->wr_idx = idx_inc(buffer, buffer->wr_idx, rd_wlen);
 
 		/* If allocation wrapped around the buffer and found busy packet
-		 * that was already ommited, skip it again.
+		 * that was already omitted, skip it again.
 		 */
 		if (buffer->rd_idx == buffer->tmp_rd_idx) {
 			buffer->tmp_rd_idx = idx_inc(buffer, buffer->tmp_rd_idx, rd_wlen);

--- a/lib/posix/options/semaphore.c
+++ b/lib/posix/options/semaphore.c
@@ -60,7 +60,7 @@ static void nsem_cleanup(struct nsem_obj *nsem)
 	}
 }
 
-/* Remove a named semaphore if it isn't unsed */
+/* Remove a named semaphore if it isn't used */
 static void nsem_unref(struct nsem_obj *nsem)
 {
 	nsem->ref_count -= 1;
@@ -265,7 +265,7 @@ sem_t *sem_open(const char *name, int oflags, ...)
 		goto unlock;
 	}
 
-	/* Named sempahore doesn't exist, try to create new one */
+	/* Named semaphore doesn't exist, try to create new one */
 
 	if ((oflags & O_CREAT) == 0) {
 		errno = ENOENT;

--- a/lib/utils/json.c
+++ b/lib/utils/json.c
@@ -728,7 +728,7 @@ static int arr_data_parse(struct json_obj *obj, struct json_obj_token *val)
 			} else if (*obj->lex.pos == JSON_TOK_STRING) {
 				string_state = true;
 			} else if (*obj->lex.pos == JSON_TOK_ARRAY_START) {
-				/* arrary in array update structure count */
+				/* array in array update structure count */
 				array_in_array++;
 			}
 		}


### PR DESCRIPTION
Utilize a code spell-checking tool to scan for and correct spelling errors in various files within the `lib` directory.