### PR TITLE
drivers: entropy: nRF CRACEN: Fix comment

### DIFF
--- a/drivers/entropy/entropy_nrf_cracen.c
+++ b/drivers/entropy/entropy_nrf_cracen.c
@@ -18,7 +18,7 @@ static int nrf_cracen_get_entropy_isr(const struct device *dev, uint8_t *buf, ui
 
 	unsigned int key = irq_lock();
 
-	/* This will be done in less than 1 microsecond */
+	/* This will take approximately 2 + (ceil(len/16) + 3)*3 us. i.e. 14us for 16 bytes */
 	int ret = nrfx_cracen_ctr_drbg_random_get(buf, len);
 
 	irq_unlock(key);


### PR DESCRIPTION
Correct the comment that tells how long it takes to get random numbers. The old comment was way too optimistic.