### PR TITLE
drivers: usb: stm32: add support for incomplete isochronous in transfer

### DIFF
--- a/drivers/usb/device/usb_dc_stm32.c
+++ b/drivers/usb/device/usb_dc_stm32.c
@@ -1277,6 +1277,19 @@ void HAL_PCD_DataInStageCallback(PCD_HandleTypeDef *hpcd, uint8_t epnum)
 	}
 }
 
+void HAL_PCD_ISOINIncompleteCallback(PCD_HandleTypeDef *hpcd, uint8_t epnum)
+{
+	uint8_t ep_idx = USB_EP_GET_IDX(epnum);
+	uint8_t ep = ep_idx | USB_EP_DIR_IN;
+	struct usb_dc_stm32_ep_state *ep_state = usb_dc_stm32_get_ep_state(ep);
+
+	LOG_DBG("epnum 0x%02x", epnum);
+
+	__ASSERT(ep_state, "No corresponding ep_state for ep");
+
+	k_sem_give(&ep_state->write_sem);
+}
+
 #if (defined(USB) || defined(USB_DRD_FS)) && DT_INST_NODE_HAS_PROP(0, disconnect_gpios)
 void HAL_PCDEx_SetConnectionState(PCD_HandleTypeDef *hpcd, uint8_t state)
 {


### PR DESCRIPTION
Currently the `write_sem` for an endpoint is only given back if the data was actually read by host (and thus calling `HAL_PCD_DataInStageCallback` wherin the semaphore is given back).

The problem that occurs is when you want to implement an isochronous endpoint that periodically writes data to the endpoint. As isochronous transfers are not supposed to have any guarantee of delivery it should be possible to send data again and again without a host having to read/receive them. With the current design this is not possible.

To solve this problem another HAL callback was implemented in a similar fashion to `HAL_PCD_DataInStageCallback`. This other callback function is named `HAL_PCD_ISOINIncompleteCallback`, and as its name suggests it is being called when data in an isochronous in endpoint has not been "delivered". So, in this callback the write semaphore is given back allowing for sequent writes.

Please let me know if you have any input on this!