### PR TITLE
dts: nxp,mcux-i2s: Fix pinmux names after change

### DIFF
--- a/dts/bindings/i2s/nxp,mcux-i2s.yaml
+++ b/dts/bindings/i2s/nxp,mcux-i2s.yaml
@@ -66,5 +66,5 @@ properties:
     description: Clock mux source for SAI root clock
 
 pinmux-cells:
-  - pin
-  - function
+  - offset
+  - mask


### PR DESCRIPTION
After a recent change for the imx gpr binding, the i2s driver was changed to reflect the new names of the cells, but apparently also the sai node can refer to itself with a phandle and need cells names to match also.

Fixes #84578