### PR TITLE
soc: nxp: Make clock init weak and global

### DIFF
--- a/soc/nxp/imx/imx6sx/soc.c
+++ b/soc/nxp/imx/imx6sx/soc.c
@@ -183,7 +183,7 @@ static void SOC_CacheInit(void)
 }
 
 /* Initialize clock. */
-static void SOC_ClockInit(void)
+void __weak SOC_ClockInit(void)
 {
 	/* OSC/PLL is already initialized by Cortex-A9 core */
 

--- a/soc/nxp/imx/imx7d/soc.c
+++ b/soc/nxp/imx/imx7d/soc.c
@@ -11,7 +11,7 @@
 #include "wdog_imx.h"
 
 /* Initialize clock. */
-void SOC_ClockInit(void)
+__weak void SOC_ClockInit(void)
 {
 	/* OSC/PLL is already initialized by Cortex-A7 (u-boot) */
 

--- a/soc/nxp/imx/imx8m/a53/soc.c
+++ b/soc/nxp/imx/imx8m/a53/soc.c
@@ -58,7 +58,7 @@ static void soc_rdc_init(void)
 
 #endif
 
-static void soc_clock_init(void)
+__weak void soc_clock_init(void)
 {
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(i2c3))
 	/* Set I2C source to SysPLL1 Div5 160MHZ */

--- a/soc/nxp/imx/imx8m/m4_mini/soc.c
+++ b/soc/nxp/imx/imx8m/m4_mini/soc.c
@@ -71,7 +71,7 @@ static const ccm_analog_frac_pll_config_t g_audioPll2Config = {
 	.postDiv = 1U, /* AUDIO PLL2 frequency  = 722534399HZ */
 };
 
-static void SOC_ClockInit(void)
+__weak void SOC_ClockInit(void)
 {
 	/*
 	 * Switch AHB NOC root to 24M first in order to configure

--- a/soc/nxp/imx/imx8m/m4_quad/soc.c
+++ b/soc/nxp/imx/imx8m/m4_quad/soc.c
@@ -46,7 +46,7 @@ static void SOC_RdcInit(void)
 	CLOCK_ControlGate(kCLOCK_VideoPll2Gate, kCLOCK_ClockNeededAll);
 }
 
-static void SOC_ClockInit(void)
+__weak void SOC_ClockInit(void)
 {
 	/*
 	 * Switch AHB NOC root to 25M first in order to configure

--- a/soc/nxp/imx/imx8m/m7/soc.c
+++ b/soc/nxp/imx/imx8m/m7/soc.c
@@ -80,7 +80,7 @@ const ccm_analog_integer_pll_config_t g_sysPll3Config = {
 	.postDiv = 2U, /*!< SYSTEM PLL3 frequency  = 600MHZ */
 };
 
-static void SOC_ClockInit(void)
+__weak void SOC_ClockInit(void)
 {
 	/*
 	 * The following steps just show how to configure the PLL clock sources using the clock

--- a/soc/nxp/imxrt/imxrt10xx/soc.c
+++ b/soc/nxp/imxrt/imxrt10xx/soc.c
@@ -135,7 +135,7 @@ const __imx_boot_ivt_section ivt image_vector_table = {
 /**
  * @brief Initialize the system clock
  */
-static ALWAYS_INLINE void clock_init(void)
+__weak void clock_init(void)
 {
 	/* Boot ROM did initialize the XTAL, here we only sets external XTAL
 	 * OSC freq

--- a/soc/nxp/imxrt/imxrt118x/soc.c
+++ b/soc/nxp/imxrt/imxrt118x/soc.c
@@ -99,7 +99,7 @@ __attribute__((weak)) void board_flexspi_clock_safe_config(void)
 /**
  * @brief Initialize the system clock
  */
-static ALWAYS_INLINE void clock_init(void)
+__weak void clock_init(void)
 {
 	clock_root_config_t rootCfg = {0};
 

--- a/soc/nxp/imxrt/imxrt11xx/soc.c
+++ b/soc/nxp/imxrt/imxrt11xx/soc.c
@@ -160,7 +160,7 @@ const __imx_boot_ivt_section ivt image_vector_table = {
 /**
  * @brief Initialize the system clock
  */
-static ALWAYS_INLINE void clock_init(void)
+__weak void clock_init(void)
 {
 	clock_root_config_t rootCfg = {0};
 

--- a/soc/nxp/imxrt/imxrt6xx/cm33/soc.c
+++ b/soc/nxp/imxrt/imxrt6xx/cm33/soc.c
@@ -181,7 +181,7 @@ static void usb_device_clock_init(void)
 /**
  * @brief Initialize the system clock
  */
-static ALWAYS_INLINE void clock_init(void)
+__weak void clock_init(void)
 {
 #ifdef CONFIG_SOC_MIMXRT685S_CM33
 	/* Configure LPOSC clock*/

--- a/soc/nxp/kinetis/k2x/soc.c
+++ b/soc/nxp/kinetis/k2x/soc.c
@@ -84,7 +84,7 @@ static const sim_clock_config_t simConfig = {
  * clock.
  *
  */
-static ALWAYS_INLINE void clock_init(void)
+__weak void clock_init(void)
 {
 	CLOCK_SetSimSafeDivs();
 

--- a/soc/nxp/kinetis/k6x/soc.c
+++ b/soc/nxp/kinetis/k6x/soc.c
@@ -87,7 +87,7 @@ static const sim_clock_config_t simConfig = {
  * clock.
  *
  */
-static ALWAYS_INLINE void clock_init(void)
+__weak void clock_init(void)
 {
 	CLOCK_SetSimSafeDivs();
 

--- a/soc/nxp/kinetis/k8x/soc.c
+++ b/soc/nxp/kinetis/k8x/soc.c
@@ -69,7 +69,7 @@ static const sim_clock_config_t sim_config = {
 	.pllFllFrac = (0),
 };
 
-static ALWAYS_INLINE void clk_init(void)
+__weak void clk_init(void)
 {
 	CLOCK_SetSimSafeDivs();
 

--- a/soc/nxp/kinetis/ke1xf/soc.c
+++ b/soc/nxp/kinetis/ke1xf/soc.c
@@ -145,7 +145,7 @@ static const scg_spll_config_t scg_spll_config = {
 	.mult        = (SCG_CLOCK_MULT(pll) - 16U)
 };
 
-static ALWAYS_INLINE void clk_init(void)
+__weak void clk_init(void)
 {
 	const scg_sys_clk_config_t scg_sys_clk_config_safe = {
 		.divSlow = kSCG_SysClkDivBy4,

--- a/soc/nxp/kinetis/ke1xz/soc.c
+++ b/soc/nxp/kinetis/ke1xz/soc.c
@@ -81,7 +81,7 @@ static const scg_firc_config_t scg_firc_config = {
 	.trimConfig = NULL
 };
 
-static ALWAYS_INLINE void clk_init(void)
+__weak void clk_init(void)
 {
 	const scg_sys_clk_config_t scg_sys_clk_config_safe = {
 		.divSlow = kSCG_SysClkDivBy4,

--- a/soc/nxp/kinetis/kl2x/soc.c
+++ b/soc/nxp/kinetis/kl2x/soc.c
@@ -24,7 +24,7 @@
  * Variables
  ******************************************************************************/
 
-static ALWAYS_INLINE void clock_init(void)
+__weak void clock_init(void)
 {
    /*
     * Core clock: 48MHz

--- a/soc/nxp/kinetis/kv5x/soc.c
+++ b/soc/nxp/kinetis/kv5x/soc.c
@@ -63,7 +63,7 @@ static const sim_clock_config_t sim_config = {
 		   SIM_CLKDIV1_OUTDIV4(CLOCK_DIVIDER(flash_clk)),
 };
 
-static ALWAYS_INLINE void clk_init(void)
+__weak void clk_init(void)
 {
 	CLOCK_SetSimSafeDivs();
 

--- a/soc/nxp/kinetis/kwx/soc_kw2xd.c
+++ b/soc/nxp/kinetis/kwx/soc_kw2xd.c
@@ -117,7 +117,7 @@ static void set_modem_clock(void)
  * clock.
  *
  */
-static ALWAYS_INLINE void clock_init(void)
+__weak void clock_init(void)
 {
 	CLOCK_SetSimSafeDivs();
 

--- a/soc/nxp/kinetis/kwx/soc_kw4xz.c
+++ b/soc/nxp/kinetis/kwx/soc_kw4xz.c
@@ -52,7 +52,7 @@ static void CLOCK_SYS_FllStableDelay(void)
 	}
 }
 
-static ALWAYS_INLINE void clock_init(void)
+__weak void clock_init(void)
 {
 	CLOCK_SetSimSafeDivs();
 

--- a/soc/nxp/lpc/lpc54xxx/soc.c
+++ b/soc/nxp/lpc/lpc54xxx/soc.c
@@ -46,7 +46,7 @@
  */
 #define CPU_FREQ DT_PROP(DT_PATH(cpus, cpu_0), clock_frequency)
 
-static ALWAYS_INLINE void clock_init(void)
+__weak void clock_init(void)
 {
 
 #ifdef CONFIG_SOC_LPC54114_M4

--- a/soc/nxp/lpc/lpc55xxx/soc.c
+++ b/soc/nxp/lpc/lpc55xxx/soc.c
@@ -78,7 +78,7 @@ const pll_setup_t pll1Setup = {
  *
  */
 
-static ALWAYS_INLINE void clock_init(void)
+__weak void clock_init(void)
 {
 	ExternalClockFrequency = 0;
 

--- a/soc/nxp/mcx/mcxc/soc.c
+++ b/soc/nxp/mcx/mcxc/soc.c
@@ -83,7 +83,7 @@ const osc_config_t oscConfig_BOARD_BootClockRUN = {
 	}
 };
 
-static void clock_init(void)
+__weak void clock_init(void)
 {
 	/* Set the system clock dividers in SIM to safe value. */
 	CLOCK_SetSimSafeDivs();

--- a/soc/nxp/mcx/mcxw/soc.c
+++ b/soc/nxp/mcx/mcxw/soc.c
@@ -19,7 +19,7 @@
 extern uint32_t SystemCoreClock;
 extern void nxp_nbu_init(void);
 
-static ALWAYS_INLINE void clock_init(void)
+__weak void clock_init(void)
 {
 	/* Unlock Reference Clock Status Registers to allow writes */
 	CLOCK_UnlockFircControlStatusReg();

--- a/soc/nxp/rw/soc.c
+++ b/soc/nxp/rw/soc.c
@@ -79,7 +79,7 @@ const clock_avpll_config_t avpll_config = {
  * clock needs to be re-initialized on exit from Standby mode. Hence
  * this function is relocated to RAM.
  */
-__ramfunc void clock_init(void)
+__weak __ramfunc void clock_init(void)
 {
 	POWER_DisableGDetVSensors();
 


### PR DESCRIPTION
Make clock init functions in SOC level weak and global so they can be overriden by board/app level.

Ideally these should have been put at board level but for now just make them weak so they can be overriden without breaking anything.

Fixes #64515