### PR TITLE
llext: enforce bitness match

### DIFF
--- a/cmake/compiler/gcc/target_arc.cmake
+++ b/cmake/compiler/gcc/target_arc.cmake
@@ -18,5 +18,9 @@ set(LLEXT_REMOVE_FLAGS
   -Os
 )
 
+set(LLEXT_APPEND_FLAGS
+  -mcpu=${GCC_ARC_TUNED_CPU} # Force compiler and linker match
+)
+
 list(APPEND TOOLCHAIN_C_FLAGS -mcpu=${GCC_ARC_TUNED_CPU})
 list(APPEND TOOLCHAIN_LD_FLAGS -mcpu=${GCC_ARC_TUNED_CPU})

--- a/tests/subsys/llext/CMakeLists.txt
+++ b/tests/subsys/llext/CMakeLists.txt
@@ -75,6 +75,7 @@ if (CONFIG_LLEXT_TYPE_ELF_RELOCATABLE AND NOT CONFIG_ARM AND NOT CONFIG_RISCV)
     TARGET pre_located_ext
     POST_BUILD
     COMMAND ${CMAKE_C_COMPILER}
+    ${LLEXT_APPEND_FLAGS}
     -Wl,-r -Wl,-Ttext=0xbada110c -nostdlib -nodefaultlibs -nostartfiles
     $<TARGET_OBJECTS:${pre_located_target}> -o ${pre_located_file}
   )


### PR DESCRIPTION
Enforces bitness match of ARC compilers and linkers invoked building LLEXT apps by inheriting -mcpu flag from Zephyr. The ARC toolchain becomes confused without the -mcpu flag. On qemu_hs5x we see GCC select elf32-littlearc64 for linking an object previously compiled as elf64-littlearc64.

Fixes #80949