### PR TITLE
boards: gardena: Add AquaPrecise

### DIFF
--- a/boards/gardena/boac/Kconfig.boac
+++ b/boards/gardena/boac/Kconfig.boac
@@ -1,0 +1,6 @@
+# Copyright (c) 2025 Reto Schneider
+#
+# SPDX-License-Identifier: Apache-2.0
+
+config BOARD_BOAC
+	select SOC_NRF52840_QIAA if BOARD_BOAC_NRF52840

--- a/boards/gardena/boac/boac-pinctrl.dtsi
+++ b/boards/gardena/boac/boac-pinctrl.dtsi
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2025 Reto Schneider
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&pinctrl {
+	uart0_default: uart0_default {
+		group1 {
+			psels = <NRF_PSEL(UART_TX, 1, 11)>;
+		};
+		group2 {
+			psels = <NRF_PSEL(UART_RX, 1, 12)>;
+			bias-pull-up;
+		};
+	};
+
+	uart0_sleep: uart0_sleep {
+		group1 {
+			psels = <NRF_PSEL(UART_TX, 1, 11)>,
+				<NRF_PSEL(UART_RX, 1, 12)>;
+			low-power-enable;
+		};
+	};
+};

--- a/boards/gardena/boac/boac.dts
+++ b/boards/gardena/boac/boac.dts
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2025 Reto Schneider
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/dts-v1/;
+#include <nordic/nrf52840_qiaa.dtsi>
+#include <nordic/nrf52840_partition.dtsi>
+#include "boac-pinctrl.dtsi"
+
+/ {
+	model = "GARDENA AquaPrecise";
+	compatible = "gardena,boac-nrf52840", "nordic,nrf52840";
+
+	chosen {
+		zephyr,bt-c2h-uart = &uart0;
+		zephyr,bt-mon-uart = &uart0;
+		zephyr,console = &uart0;
+		zephyr,shell-uart = &cdc_acm_uart0;
+		zephyr,uart-mcumgr = &cdc_acm_uart0;
+    zephyr,flash = &flash0;
+	};
+
+	buttons {
+		compatible = "gpio-keys";
+		button0: button_0 {
+			gpios = <&gpio1 13 (GPIO_ACTIVE_HIGH)>;
+			label = "Push button switch 0";
+			zephyr,code = <INPUT_KEY_0>;
+		};
+	};
+
+	/* These aliases are provided for compatibility with samples */
+	aliases {
+		sw0 = &button0;
+		watchdog0 = &wdt0;
+	};
+};
+
+&reg0 {
+	status = "okay";
+};
+
+&reg1 {
+	regulator-initial-mode = <NRF5X_REG_MODE_DCDC>;
+};
+
+&uicr {
+	gpio-as-nreset;
+};
+
+&gpiote {
+	status = "okay";
+};
+
+&gpio1 {
+	status = "okay";
+};
+
+&uart0 {
+	compatible = "nordic,nrf-uarte";
+	status = "okay";
+	current-speed = <115200>;
+	pinctrl-0 = <&uart0_default>;
+	pinctrl-1 = <&uart0_sleep>;
+	pinctrl-names = "default", "sleep";
+};
+
+zephyr_udc0: &usbd {
+	compatible = "nordic,nrf-usbd";
+	status = "okay";
+	cdc_acm_uart0: cdc_acm_uart0 {
+		compatible = "zephyr,cdc-acm-uart";
+	};
+};

--- a/boards/gardena/boac/board.cmake
+++ b/boards/gardena/boac/board.cmake
@@ -1,0 +1,6 @@
+# Copyright (c) 2025 Reto Schneider
+#
+# SPDX-License-Identifier: Apache-2.0
+
+board_runner_args(jlink "--device=nRF52840_xxAA" "--speed=4000")
+include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/gardena/boac/board.yml
+++ b/boards/gardena/boac/board.yml
@@ -1,0 +1,10 @@
+# Copyright (c) 2025 Reto Schneider
+#
+# SPDX-License-Identifier: Apache-2.0
+
+board:
+  name: boac
+  full_name: AquaPrecise
+  vendor: gardena
+  socs:
+    - name: nrf52840

--- a/boards/gardena/boac/pre_dt_board.cmake
+++ b/boards/gardena/boac/pre_dt_board.cmake
@@ -1,0 +1,7 @@
+# Copyright (c) 2022 Nordic Semiconductor
+# SPDX-License-Identifier: Apache-2.0
+
+# Suppress "unique_unit_address_if_enabled" to handle the following overlaps:
+# - power@40000000 & clock@40000000 & bprot@40000000
+# - acl@4001e000 & flash-controller@4001e000
+list(APPEND EXTRA_DTC_FLAGS "-Wno-unique_unit_address_if_enabled")


### PR DESCRIPTION
This adds support for the solar powered, nRF52840 based AquaPrecise [1] board.

[1] https://www.gardena.com/int/aquaprecise/970746801.html