### PR TITLE
bluetooth: host: Add select PSA_WANT_ALG_ECB_NO_PADDING

### DIFF
--- a/subsys/bluetooth/host/Kconfig.gatt
+++ b/subsys/bluetooth/host/Kconfig.gatt
@@ -118,6 +118,7 @@ config BT_GATT_CACHING
 	depends on PSA_CRYPTO_CLIENT
 	select PSA_WANT_KEY_TYPE_AES
 	select PSA_WANT_ALG_CMAC
+	select PSA_WANT_ALG_ECB_NO_PADDING
 	imply MBEDTLS_AES_ROM_TABLES if MBEDTLS_PSA_CRYPTO_C
 	help
 	  This option enables support for GATT Caching. When enabled the stack


### PR DESCRIPTION
This is a follow-up to commit 12eee615333625049d70f167f674018489f7139c.

Explicitly enable "PSA_WANT_ALG_ECB_NO_PADDING" to select the AES ECB mode that it is used in CMAC operation.