### PR TITLE
Bluetooth: Controller: Fix incorrect event_count when CIG overlaps

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/lll_conn_iso.h
+++ b/subsys/bluetooth/controller/ll_sw/lll_conn_iso.h
@@ -45,7 +45,8 @@ struct lll_conn_iso_stream {
 	struct lll_conn_iso_stream_rxtx tx; /* TX parameters */
 
 	/* Event and payload counters */
-	uint64_t event_count:39;    /* cisEventCount */
+	uint64_t event_count_prepare:39; /* cisEventCount in overlapping CIG prepare */
+	uint64_t event_count:39;         /* cisEventCount in current CIG event */
 
 	/* Acknowledgment and flow control */
 	uint8_t sn:1;               /* Sequence number */

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_central_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_central_iso.c
@@ -92,22 +92,11 @@ int lll_central_iso_reset(void)
 
 void lll_central_iso_prepare(void *param)
 {
-	struct lll_conn_iso_group *cig_lll;
-	struct lll_prepare_param *p;
-	uint16_t elapsed;
 	int err;
 
 	/* Initiate HF clock start up */
 	err = lll_hfclock_on();
 	LL_ASSERT(err >= 0);
-
-	/* Instants elapsed */
-	p = param;
-	elapsed = p->lazy + 1U;
-
-	/* Save the (latency + 1) for use in event and/or supervision timeout */
-	cig_lll = p->param;
-	cig_lll->latency_prepare += elapsed;
 
 	/* Invoke common pipeline handling of prepare */
 	err = lll_prepare(lll_is_abort_cb, abort_cb, prepare_cb, 0U, param);
@@ -135,7 +124,6 @@ static int prepare_cb(struct lll_prepare_param *p)
 	struct ull_hdr *ull;
 	uint32_t remainder;
 	uint32_t start_us;
-	uint16_t lazy;
 	uint32_t ret;
 	uint8_t phy;
 	int err = 0;
@@ -173,9 +161,9 @@ static int prepare_cb(struct lll_prepare_param *p)
 					   &data_chan_prn_s,
 					   &data_chan_remap_idx);
 
-	/* Store the current event latency */
-	cig_lll->latency_event = cig_lll->latency_prepare;
-	lazy = cig_lll->latency_prepare - 1U;
+	/* Calculate the current event latency */
+	cig_lll->lazy_prepare = p->lazy;
+	cig_lll->latency_event = cig_lll->latency_prepare + cig_lll->lazy_prepare;
 
 	/* Reset accumulated latencies */
 	cig_lll->latency_prepare = 0U;
@@ -395,13 +383,13 @@ static int prepare_cb(struct lll_prepare_param *p)
 
 static void abort_cb(struct lll_prepare_param *prepare_param, void *param)
 {
+	struct lll_conn_iso_group *cig_lll;
 	int err;
 
 	/* NOTE: This is not a prepare being cancelled */
 	if (!prepare_param) {
 		struct lll_conn_iso_stream *next_cis_lll;
 		struct lll_conn_iso_stream *cis_lll;
-		struct lll_conn_iso_group *cig_lll;
 
 		cis_lll = ull_conn_iso_lll_stream_get(cis_handle_curr);
 		cig_lll = param;
@@ -430,6 +418,13 @@ static void abort_cb(struct lll_prepare_param *prepare_param, void *param)
 	 */
 	err = lll_hfclock_off();
 	LL_ASSERT(err >= 0);
+
+	/* Get reference to CIG LLL context */
+	cig_lll = prepare_param->param;
+
+	/* Accumulate the latency as event is aborted while being in pipeline */
+	cig_lll->lazy_prepare = prepare_param->lazy;
+	cig_lll->latency_prepare += (cig_lll->lazy_prepare + 1U);
 
 	lll_done(param);
 }

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_central_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_central_iso.c
@@ -150,6 +150,9 @@ static int prepare_cb(struct lll_prepare_param *p)
 	/* Get reference to ACL context */
 	conn_lll = ull_conn_lll_get(cis_lll->acl_handle);
 
+	/* Pick the event_count calculated in the ULL prepare */
+	cis_lll->event_count = cis_lll->event_count_prepare;
+
 	/* Event counter value,  0-15 bit of cisEventCounter */
 	event_counter = cis_lll->event_count;
 
@@ -357,6 +360,9 @@ static int prepare_cb(struct lll_prepare_param *p)
 	do {
 		cis_lll = ull_conn_iso_lll_stream_get_by_group(cig_lll, &cis_handle);
 		if (cis_lll && cis_lll->active) {
+			/* Pick the event_count calculated in the ULL prepare */
+			cis_lll->event_count = cis_lll->event_count_prepare;
+
 			/* Adjust sn and nesn for skipped CIG events */
 			payload_count_lazy_update(cis_lll, cig_lll->latency_event);
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_central_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_central_iso.c
@@ -171,7 +171,7 @@ static int prepare_cb(struct lll_prepare_param *p)
 	se_curr = 1U;
 
 	/* Adjust the SN and NESN for skipped CIG events */
-	payload_count_lazy_update(cis_lll, lazy);
+	payload_count_lazy_update(cis_lll, cig_lll->latency_event);
 
 	/* Start setting up of Radio h/w */
 	radio_reset();
@@ -358,7 +358,7 @@ static int prepare_cb(struct lll_prepare_param *p)
 		cis_lll = ull_conn_iso_lll_stream_get_by_group(cig_lll, &cis_handle);
 		if (cis_lll && cis_lll->active) {
 			/* Adjust sn and nesn for skipped CIG events */
-			payload_count_lazy_update(cis_lll, lazy);
+			payload_count_lazy_update(cis_lll, cig_lll->latency_event);
 
 			/* Adjust sn and nesn for canceled events */
 			if (err) {

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_peripheral_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_peripheral_iso.c
@@ -204,7 +204,7 @@ static int prepare_cb(struct lll_prepare_param *p)
 	se_curr = 1U;
 
 	/* Adjust sn and nesn for skipped CIG events */
-	payload_count_lazy(cis_lll, cig_lll->lazy_prepare);
+	payload_count_lazy(cis_lll, cig_lll->latency_event);
 
 	/* Start setting up of Radio h/w */
 	radio_reset();
@@ -375,7 +375,7 @@ static int prepare_cb(struct lll_prepare_param *p)
 		}
 
 		/* Adjust sn and nesn for skipped CIG events */
-		payload_count_lazy(cis_lll, cig_lll->lazy_prepare);
+		payload_count_lazy(cis_lll, cig_lll->latency_event);
 
 		/* Adjust sn and nesn for canceled events */
 		if (err) {

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_peripheral_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_peripheral_iso.c
@@ -164,6 +164,9 @@ static int prepare_cb(struct lll_prepare_param *p)
 	/* Get reference to ACL context */
 	conn_lll = ull_conn_lll_get(cis_lll->acl_handle);
 
+	/* Pick the event_count calculated in the ULL prepare */
+	cis_lll->event_count = cis_lll->event_count_prepare;
+
 	/* Event counter value,  0-15 bit of cisEventCounter */
 	event_counter = cis_lll->event_count;
 
@@ -373,6 +376,9 @@ static int prepare_cb(struct lll_prepare_param *p)
 		if (!cis_lll) {
 			break;
 		}
+
+		/* Pick the event_count calculated in the ULL prepare */
+		cis_lll->event_count = cis_lll->event_count_prepare;
 
 		/* Adjust sn and nesn for skipped CIG events */
 		payload_count_lazy(cis_lll, cig_lll->latency_event);

--- a/subsys/bluetooth/controller/ll_sw/ull_central_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_central_iso.c
@@ -929,6 +929,11 @@ uint8_t ull_central_iso_setup(uint16_t cis_handle,
 #if defined(CONFIG_BT_CTLR_ISOAL_PSN_IGNORE)
 	cis->pkt_seq_num = 0U;
 #endif /* CONFIG_BT_CTLR_ISOAL_PSN_IGNORE */
+	/* It is intentional to initialize to the 39 bit maximum value and rollover to 0 in the
+	 * prepare function, the event counter is pre-incremented in prepare function for the
+	 * current ISO event.
+	 */
+	cis->lll.event_count_prepare = LLL_CONN_ISO_EVENT_COUNT_MAX;
 	cis->lll.event_count = LLL_CONN_ISO_EVENT_COUNT_MAX;
 	cis->lll.next_subevent = 0U;
 	cis->lll.tifs_us = conn->lll.tifs_cis_us;

--- a/subsys/bluetooth/controller/ll_sw/ull_conn_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_iso.c
@@ -711,17 +711,17 @@ void ull_conn_iso_ticker_cb(uint32_t ticks_at_expire, uint32_t ticks_drift,
 		 * has been reached, and offset calculated.
 		 */
 		if (cis->lll.handle != 0xFFFF && cis->lll.active) {
-			cis->lll.event_count += (lazy + 1U);
+			cis->lll.event_count_prepare += (lazy + 1U);
 
 #if !defined(CONFIG_BT_CTLR_JIT_SCHEDULING)
-			cis->lll.event_count -= cis->lll.lazy_active;
+			cis->lll.event_count_prepare -= cis->lll.lazy_active;
 			cis->lll.lazy_active = 0U;
 #endif /* !CONFIG_BT_CTLR_JIT_SCHEDULING */
 
 			leading_event_count = MAX(leading_event_count,
-						cis->lll.event_count);
+						cis->lll.event_count_prepare);
 
-			ull_iso_lll_event_prepare(cis->lll.handle, cis->lll.event_count);
+			ull_iso_lll_event_prepare(cis->lll.handle, cis->lll.event_count_prepare);
 		}
 
 		/* Latch datapath validity entering event */
@@ -975,7 +975,7 @@ void ull_conn_iso_start(struct ll_conn *conn, uint16_t cis_handle,
 				cis_offset = cis->offset + iso_interval_us - acl_latency_us;
 			}
 
-			cis->lll.event_count += lost_cig_events;
+			cis->lll.event_count_prepare += lost_cig_events;
 
 			lost_payloads = (lost_cig_events - (cis->lll.rx.ft - 1)) * cis->lll.rx.bn;
 			cis->lll.rx.payload_count += lost_payloads;
@@ -1520,7 +1520,7 @@ void ull_conn_iso_transmit_test_cig_interval(uint16_t handle, uint32_t ticks_at_
 		 * on 64-bit sdu_counter:
 		 *   (39 bits x 22 bits (4x10^6 us) = 61 bits / 8 bits (255 us) = 53 bits)
 		 */
-		sdu_counter = DIV_ROUND_UP((cis->lll.event_count + 1U) * iso_interval,
+		sdu_counter = DIV_ROUND_UP((cis->lll.event_count_prepare + 1U) * iso_interval,
 					       sdu_interval);
 
 		if (cis->hdr.test_mode.tx.sdu_counter == 0U) {

--- a/subsys/bluetooth/controller/ll_sw/ull_peripheral_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_peripheral_iso.c
@@ -333,6 +333,11 @@ uint8_t ull_peripheral_iso_setup(struct pdu_data_llctrl_cis_ind *ind,
 #if defined(CONFIG_BT_CTLR_ISOAL_PSN_IGNORE)
 	cis->pkt_seq_num = 0U;
 #endif /* CONFIG_BT_CTLR_ISOAL_PSN_IGNORE */
+	/* It is intentional to initialize to the 39 bit maximum value and rollover to 0 in the
+	 * prepare function, the event counter is pre-incremented in prepare function for the
+	 * current ISO event.
+	 */
+	cis->lll.event_count_prepare = LLL_CONN_ISO_EVENT_COUNT_MAX;
 	cis->lll.event_count = LLL_CONN_ISO_EVENT_COUNT_MAX;
 	cis->lll.next_subevent = 0U;
 	cis->lll.tifs_us = conn->lll.tifs_cis_us;


### PR DESCRIPTION
Fix incorrect event_count use in CIG events when the next
CIG interval's prepare overlaps with the current CIG event.
Use separate event_count_prepare variable in ULL and copy
the value in LLL event.

Fixes #83584.

Other miscellaneous improvements:
- Fix Connected ISO to use accumulated latency to update the
payload count.
- Fix incorrect elapsed events value when event prepare are
aborted in the pipeline. This can caused premature
supervision timeouts.
Relates to commit https://github.com/zephyrproject-rtos/zephyr/commit/247037bd3e2ab6f137bcc02d6e0f10f4dcfa9c99 ("Bluetooth: Controller: Fix
incorrect elapsed events value").