### PR TITLE
manifest: Update nRF hw models to latest and leave branch behind

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -318,7 +318,7 @@ manifest:
       groups:
         - tools
     - name: nrf_hw_models
-      revision: 68df9ed65dd9d93bb257bf8f295cb753ecf83cd8
+      revision: 2570f4a697ce2da860ff39ec34afd91749bd66d3
       path: modules/bsim_hw_models/nrf_hw_models
     - name: nrf_wifi
       revision: 23160ca8417e2cfebbce887f01a355483954824c


### PR DESCRIPTION
Update the HW models module back to the main branch, 2570f4a697ce2d860ff39ec34afd91749bd66d3
leaving behind zephyr_2025_01_22
* 68df9ed Force build of cracen hal even if HAL is not 3.10

As the nordic HAL has been updated to be this version, we do not need this hack in the HW models anymore to be able to build the CRACEN HW models for the nrf54l15.

This update includes the following new commit in main:
* 2570f4a docs: Do not list the RTC as included for the 54L15