### PR TITLE
MAINTAINERS: Update maintainer information for OpenThread

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3060,7 +3060,7 @@ Networking:
   collaborators:
     - pdgendt
     - canisLupus1313
-    - mariuszpos
+    - kkasperczyk-no
     - edmont
     - maciejbaczmanski
   files:


### PR DESCRIPTION
One of the collaborators of Networking: OpenThread is not active anymore and was replaced by another one.

A list of sample contributions in the Networking/OpenThread from the new collaborator:
* https://github.com/zephyrproject-rtos/zephyr/pull/84355
* https://github.com/zephyrproject-rtos/zephyr/pull/82209
* https://github.com/zephyrproject-rtos/zephyr/pull/50888
* https://github.com/zephyrproject-rtos/zephyr/pull/32395