### PR TITLE
doc: gsg: Add note on AArch64 Linux multilib availability

### DIFF
--- a/doc/develop/getting_started/index.rst
+++ b/doc/develop/getting_started/index.rst
@@ -95,6 +95,11 @@ The current minimum required version for the main dependencies are:
               python3-dev python3-pip python3-setuptools python3-tk python3-wheel xz-utils file \
               make gcc gcc-multilib g++-multilib libsdl2-dev libmagic1
 
+         .. note::
+
+            Due to the unavailability of ``gcc-multilib`` and ``g++-multilib`` on AArch64
+            (ARM64) systems, you may need to remove them from the list of packages to install.
+
       #. Verify the versions of the main dependencies installed on your system by entering:
 
          .. code-block:: bash


### PR DESCRIPTION
Currently, multilib packages are ~mostly unavailable~ not available for AArch64 Linux

---

Someone asked why they could not build the `unit_testing` board on AArch64:
https://discord.com/channels/720317445772017664/991025779993370654/1333555236471574700
It might be helpful to document this limitation until the packages are readily available