### PR TITLE
tests: drivers: sensor: temp: Add support for nRF54L20 and nRF54L09 PDKs

### DIFF
--- a/tests/drivers/sensor/temp_sensor/boards/nrf54l09pdk_nrf54l09_cpuapp.overlay
+++ b/tests/drivers/sensor/temp_sensor/boards/nrf54l09pdk_nrf54l09_cpuapp.overlay
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+temp_sensor: &temp {
+	status = "okay";
+};

--- a/tests/drivers/sensor/temp_sensor/boards/nrf54l20pdk_nrf54l20_cpuapp.overlay
+++ b/tests/drivers/sensor/temp_sensor/boards/nrf54l20pdk_nrf54l20_cpuapp.overlay
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+temp_sensor: &temp {
+	status = "okay";
+};


### PR DESCRIPTION
Add support for nRF54L20 and nRF54L09 PDKs in temp_sensor twister tests.

It will be added to testcase.yaml once PDKs are available. 