### PR TITLE
tests: net: vlan: Increase stack size for header reserve test

### DIFF
--- a/tests/net/vlan/testcase.yaml
+++ b/tests/net/vlan/testcase.yaml
@@ -11,6 +11,7 @@ tests:
   net.vlan.header_reserved:
     extra_configs:
       - CONFIG_NET_L2_ETHERNET_RESERVE_HEADER=y
+      - CONFIG_TEST_EXTRA_STACK_SIZE=1024
   net.vlan.header_reserved.variable_size:
     extra_configs:
       - CONFIG_NET_L2_ETHERNET_RESERVE_HEADER=y


### PR DESCRIPTION
Increasing the stack size for header_reserved test. This avoids stack overflow in various boards.

Fixes #84620