### PR TITLE
subsys: shell: modules: add shell control features

### DIFF
--- a/subsys/shell/modules/kernel_service/thread/CMakeLists.txt
+++ b/subsys/shell/modules/kernel_service/thread/CMakeLists.txt
@@ -16,3 +16,9 @@ zephyr_sources_ifdef(CONFIG_KERNEL_THREAD_SHELL_MASK pin.c)
 zephyr_sources_ifdef(CONFIG_KERNEL_THREAD_SHELL_STACKS stacks.c)
 
 zephyr_sources_ifdef(CONFIG_KERNEL_THREAD_SHELL_UNWIND unwind.c)
+
+zephyr_sources_ifdef(CONFIG_KERNEL_THREAD_SHELL_SUSPEND suspend.c)
+
+zephyr_sources_ifdef(CONFIG_KERNEL_THREAD_SHELL_RESUME resume.c)
+
+zephyr_sources_ifdef(CONFIG_KERNEL_THREAD_SHELL_KILL kill.c)

--- a/subsys/shell/modules/kernel_service/thread/Kconfig
+++ b/subsys/shell/modules/kernel_service/thread/Kconfig
@@ -52,3 +52,24 @@ config KERNEL_THREAD_SHELL_UNWIND
 	select KERNEL_THREAD_SHELL
 	help
 	  Internal helper macro to compile the `unwind` subcommand
+
+config KERNEL_THREAD_SHELL_SUSPEND
+	bool
+	default y
+	select KERNEL_THREAD_SHELL
+	help
+	  Internal helper macro to compile the 'suspend' subcommand
+
+config KERNEL_THREAD_SHELL_RESUME
+	bool
+	default y
+	select KERNEL_THREAD_SHELL
+	help
+	  Internal helper macro to compile the 'resume' subcommand
+
+config KERNEL_THREAD_SHELL_KILL
+	bool
+	default y
+	select KERNEL_THREAD_SHELL
+	help
+	  Internal helper macro to compile the 'kill' subcommad

--- a/subsys/shell/modules/kernel_service/thread/kill.c
+++ b/subsys/shell/modules/kernel_service/thread/kill.c
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2025 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "kernel_shell.h"
+
+#include <kernel_internal.h>
+#include <zephyr/kernel.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+static int cmd_kernel_thread_kill(const struct shell *sh, size_t argc, char **argv)
+{
+	/* thread_id is converetd from hex to decimal */
+	k_tid_t thread_id = (k_tid_t)strtoul(argv[1], NULL, 16);
+
+	if (!z_thread_is_valid(thread_id)) {
+		shell_error(sh, "Thread ID %p is not valid", thread_id);
+		return -EINVAL;
+	}
+
+	/*Check if the thread ID is the shell thread */
+	if (thread_id == k_current_get()) {
+		shell_error(sh, "Error:Shell thread cannot be killed");
+		return -EINVAL;
+	}
+
+	k_thread_abort(thread_id);
+
+	shell_print(sh, "\n Thread %p killed", thread_id);
+
+	return 0;
+}
+
+KERNEL_THREAD_CMD_ARG_ADD(kill, NULL, "kernel thread kill <thread_id>", cmd_kernel_thread_kill, 2,
+			  0);

--- a/subsys/shell/modules/kernel_service/thread/resume.c
+++ b/subsys/shell/modules/kernel_service/thread/resume.c
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2025 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "kernel_shell.h"
+
+#include <kernel_internal.h>
+#include <zephyr/kernel.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+static int cmd_kernel_thread_resume(const struct shell *sh, size_t argc, char **argv)
+{
+	/* thread_id is converetd from hex to decimal */
+	k_tid_t thread_id = (k_tid_t)strtoul(argv[1], NULL, 16);
+
+	if (!z_thread_is_valid(thread_id)) {
+		shell_error(sh, "Thread ID %p is not valid", thread_id);
+		return -EINVAL;
+	}
+
+	/*Check if the thread ID is the shell thread */
+	if (thread_id == k_current_get()) {
+		shell_error(sh, "Error:Shell thread cannot be resumed");
+		return -EINVAL;
+	}
+
+	k_thread_resume(thread_id);
+
+	shell_print(sh, "Thread %p resumed", thread_id);
+
+	return 0;
+}
+
+KERNEL_THREAD_CMD_ARG_ADD(resume, NULL, "kernel thread resume <thread_id>",
+			  cmd_kernel_thread_resume, 2, 0);

--- a/subsys/shell/modules/kernel_service/thread/suspend.c
+++ b/subsys/shell/modules/kernel_service/thread/suspend.c
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2025 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "kernel_shell.h"
+
+#include <kernel_internal.h>
+#include <zephyr/kernel.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+static int cmd_kernel_thread_suspend(const struct shell *sh, size_t argc, char **argv)
+{
+	/* thread_id is converetd from hex to decimal */
+	k_tid_t thread_id = (k_tid_t)strtoul(argv[1], NULL, 16);
+
+	if (!z_thread_is_valid(thread_id)) {
+		shell_error(sh, "Thread ID %p is not valid", thread_id);
+		return -EINVAL;
+	}
+
+	/*Check if the thread ID is the shell thread */
+	if (thread_id == k_current_get()) {
+		shell_error(sh, "Error:Shell thread cannot be suspended");
+		return -EINVAL;
+	}
+
+	k_thread_suspend(thread_id);
+
+	shell_print(sh, "Thread %p suspended", thread_id);
+
+	return 0;
+}
+
+KERNEL_THREAD_CMD_ARG_ADD(suspend, NULL, "kernel thread suspend <thread_id>",
+			  cmd_kernel_thread_suspend, 2, 0);


### PR DESCRIPTION
This commit extends the shell command functionality by adding three new operations for thread management. kernel thread suspend <thread_id>:
Suspends any thread based on its identifier.
kernel thread resume <thread_id>:
Resumes the thread that was previously suspended.
kernel thread kill <thread_id>:
Terminates any thread based on its identifier
These extended commands are useful for controlling any threads through Zephyr Shell.