### PR TITLE
samples: net: http_get: Fix format string issue

### DIFF
--- a/samples/net/sockets/http_get/src/http_get.c
+++ b/samples/net/sockets/http_get/src/http_get.c
@@ -41,7 +41,7 @@
 #define HTTP_PATH "/"
 
 #define SSTRLEN(s) (sizeof(s) - 1)
-#define CHECK(r) { if (r < 0) { printf("Error: %d\n", r); exit(1); } }
+#define CHECK(r) { if (r < 0) { printf("Error: %d\n", (int)r); exit(1); } }
 
 #define REQUEST "GET " HTTP_PATH " HTTP/1.1\r\nHost: " HTTP_HOST "\r\n\r\n"
 


### PR DESCRIPTION
This issue is seen by at least gcc 11.4.0
```
samples/net/sockets/http_get/src/http_get.c:44:40: warning:
 format ‘%d’ expects argument of type ‘int’, but argument 2
 has type ‘ssize_t’ {aka ‘long int’} [-Wformat=]
   44 | #define CHECK(r) { if (r < 0) {
      |                          printf("Error: %d\n", r); exit(1); } }
      |                                 ^~~~~~~~~~~~~
samples/net/sockets/http_get/src/http_get.c:44:49: note: format string is
 defined here
   44 | #define CHECK(r) { if (r < 0) {
                                 printf("Error: %d\n", r); exit(1); } }
      |                                         ~^
      |                                          |
      |                                          int
      |                                          %ld
```
