### PR TITLE
adc: esp32c3: fix overlay and adc driver calib setup

### DIFF
--- a/drivers/adc/adc_esp32.c
+++ b/drivers/adc/adc_esp32.c
@@ -535,6 +535,11 @@ static int adc_esp32_channel_setup(const struct device *dev, const struct adc_ch
 			conf->unit, cfg->channel_id, data->attenuation[cfg->channel_id],
 			data->resolution[cfg->channel_id]);
 
+		if (data->cal_handle[cfg->channel_id] != NULL) {
+			/* delete pre-existing calib scheme */
+			adc_cali_delete_scheme_curve_fitting(data->cal_handle[cfg->channel_id]);
+		}
+
 		adc_cali_create_scheme_curve_fitting(&cal_config,
 						     &data->cal_handle[cfg->channel_id]);
 #endif /* ADC_CALI_SCHEME_CURVE_FITTING_SUPPORTED */
@@ -552,6 +557,11 @@ static int adc_esp32_channel_setup(const struct device *dev, const struct adc_ch
 		LOG_DBG("Line fitting calib [unit_id: %u, chan: %u, atten: %u, bitwidth: %u]",
 			conf->unit, cfg->channel_id, data->attenuation[cfg->channel_id],
 			data->resolution[cfg->channel_id]);
+
+		if (data->cal_handle[cfg->channel_id] != NULL) {
+			/* delete pre-existing calib scheme */
+			adc_cali_delete_scheme_curve_fitting(data->cal_handle[cfg->channel_id]);
+		}
 
 		adc_cali_create_scheme_line_fitting(&cal_config,
 						    &data->cal_handle[cfg->channel_id]);

--- a/samples/drivers/adc/adc_dt/boards/esp32c3_devkitm.overlay
+++ b/samples/drivers/adc/adc_dt/boards/esp32c3_devkitm.overlay
@@ -6,27 +6,11 @@
 
 / {
 	zephyr,user {
-		io-channels =
-			<&adc0 0>,
-			<&adc1 0>;
+		io-channels = <&adc0 0>;
 	};
 };
 
 &adc0 {
-	status = "okay";
-	#address-cells = <1>;
-	#size-cells = <0>;
-
-	channel@0 {
-		reg = <0>;
-		zephyr,gain = "ADC_GAIN_1_4";
-		zephyr,reference = "ADC_REF_INTERNAL";
-		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
-		zephyr,resolution = <12>;
-	};
-};
-
-&adc1 {
 	status = "okay";
 	#address-cells = <1>;
 	#size-cells = <0>;

--- a/samples/drivers/adc/adc_dt/boards/esp32c3_luatos_core.overlay
+++ b/samples/drivers/adc/adc_dt/boards/esp32c3_luatos_core.overlay
@@ -6,27 +6,11 @@
 
 / {
 	zephyr,user {
-		io-channels =
-			<&adc0 0>,
-			<&adc1 0>;
+		io-channels = <&adc0 0>;
 	};
 };
 
 &adc0 {
-	status = "okay";
-	#address-cells = <1>;
-	#size-cells = <0>;
-
-	channel@0 {
-		reg = <0>;
-		zephyr,gain = "ADC_GAIN_1_4";
-		zephyr,reference = "ADC_REF_INTERNAL";
-		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
-		zephyr,resolution = <12>;
-	};
-};
-
-&adc1 {
 	status = "okay";
 	#address-cells = <1>;
 	#size-cells = <0>;

--- a/samples/drivers/adc/adc_dt/boards/esp32c3_luatos_core_esp32c3_usb.overlay
+++ b/samples/drivers/adc/adc_dt/boards/esp32c3_luatos_core_esp32c3_usb.overlay
@@ -6,27 +6,11 @@
 
 / {
 	zephyr,user {
-		io-channels =
-			<&adc0 0>,
-			<&adc1 0>;
+		io-channels = <&adc0 0>;
 	};
 };
 
 &adc0 {
-	status = "okay";
-	#address-cells = <1>;
-	#size-cells = <0>;
-
-	channel@0 {
-		reg = <0>;
-		zephyr,gain = "ADC_GAIN_1_4";
-		zephyr,reference = "ADC_REF_INTERNAL";
-		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
-		zephyr,resolution = <12>;
-	};
-};
-
-&adc1 {
 	status = "okay";
 	#address-cells = <1>;
 	#size-cells = <0>;


### PR DESCRIPTION
As a continuation of #84254, remove ADC2 support
for this remaining ESP32C3 based board targets.

This also changes ADC driver to delete previous calib curve in case channel_setup is run again.