### PR TITLE
usb: device_next: Make buf ownership consistent for usbd_uac2_send

### DIFF
--- a/include/zephyr/usb/class/usbd_uac2.h
+++ b/include/zephyr/usb/class/usbd_uac2.h
@@ -176,6 +176,9 @@ void usbd_uac2_set_ops(const struct device *dev,
  * Data buffer must be sufficiently aligned and otherwise suitable for use by
  * UDC driver.
  *
+ * @note Buffer ownership is transferred to the stack in case of success, in
+ * case of an error the caller retains the ownership of the buffer.
+ *
  * @param dev USB Audio 2 device
  * @param terminal Output Terminal ID linked to AudioStreaming interface
  * @param data Buffer containing outgoing data

--- a/subsys/usb/device_next/class/usbd_uac2.c
+++ b/subsys/usb/device_next/class/usbd_uac2.c
@@ -284,7 +284,6 @@ int usbd_uac2_send(const struct device *dev, uint8_t terminal,
 		 */
 		LOG_ERR("No netbuf for send");
 		atomic_clear_bit(queued_bits, as_idx);
-		ctx->ops->buf_release_cb(dev, terminal, data, ctx->user_data);
 		return -ENOMEM;
 	}
 
@@ -293,7 +292,6 @@ int usbd_uac2_send(const struct device *dev, uint8_t terminal,
 		LOG_ERR("Failed to enqueue net_buf for 0x%02x", ep);
 		net_buf_unref(buf);
 		atomic_clear_bit(queued_bits, as_idx);
-		ctx->ops->buf_release_cb(dev, terminal, data, ctx->user_data);
 	}
 
 	return ret;


### PR DESCRIPTION
The usbd_uac2_send function sometimes took ownership of the provided buffer in error cases, and sometimes not.

The commit modifies the function so that ownership is never taken in case a non-0 return value.