### PR TITLE
net: sockets: Make sure recvmsg() doesn't modify buffer configuration 

### DIFF
--- a/subsys/net/lib/sockets/sockets_inet.c
+++ b/subsys/net/lib/sockets/sockets_inet.c
@@ -1164,15 +1164,12 @@ static inline ssize_t zsock_recv_dgram(struct net_context *ctx,
 
 			if (len <= tmp_read_len) {
 				tmp_read_len -= len;
-				msg->msg_iov[iovec].iov_len = len;
 				iovec++;
 			} else {
 				errno = EINVAL;
 				return -1;
 			}
 		}
-
-		msg->msg_iovlen = iovec;
 
 		if (recv_len != read_len) {
 			msg->msg_flags |= ZSOCK_MSG_TRUNC;
@@ -1325,7 +1322,7 @@ static ssize_t zsock_recv_stream_timed(struct net_context *ctx, struct msghdr *m
 {
 	int res;
 	k_timepoint_t end;
-	size_t recv_len = 0, iovec = 0, available_len, max_iovlen = 0;
+	size_t recv_len = 0, iovec = 0, available_len;
 	const bool waitall = (flags & ZSOCK_MSG_WAITALL) == ZSOCK_MSG_WAITALL;
 
 	if (msg != NULL && buf == NULL) {
@@ -1335,8 +1332,6 @@ static ssize_t zsock_recv_stream_timed(struct net_context *ctx, struct msghdr *m
 
 		buf = msg->msg_iov[iovec].iov_base;
 		available_len = msg->msg_iov[iovec].iov_len;
-		msg->msg_iov[iovec].iov_len = 0;
-		max_iovlen = msg->msg_iovlen;
 	}
 
 	for (end = sys_timepoint_calc(timeout); max_len > 0; timeout = sys_timepoint_timeout(end)) {
@@ -1365,7 +1360,6 @@ again:
 				return -EAGAIN;
 			}
 
-			msg->msg_iov[iovec].iov_len += res;
 			buf = (uint8_t *)(msg->msg_iov[iovec].iov_base) + res;
 			max_len -= res;
 
@@ -1373,14 +1367,12 @@ again:
 				/* All data to this iovec was written */
 				iovec++;
 
-				if (iovec == max_iovlen) {
+				if (iovec == msg->msg_iovlen) {
 					break;
 				}
 
-				msg->msg_iovlen = iovec;
 				buf = msg->msg_iov[iovec].iov_base;
 				available_len = msg->msg_iov[iovec].iov_len;
-				msg->msg_iov[iovec].iov_len = 0;
 
 				/* If there is more data, read it now and do not wait */
 				if (buf != NULL && available_len > 0) {


### PR DESCRIPTION
The recvmsg() function should not modify the buffer configuration provided in struct msghdr, such behavior is not specified in the POSIX function description, nor is it consistent with well-known behavior of this function in Linux.

Align respective tests to verify this.

Fixes #84475