### PR TITLE
net: socket: Release packets in accepted socket in close

### DIFF
--- a/subsys/net/lib/sockets/sockets_inet.c
+++ b/subsys/net/lib/sockets/sockets_inet.c
@@ -63,6 +63,11 @@ static void zsock_flush_queue(struct net_context *ctx)
 	while ((p = k_fifo_get(&ctx->recv_q, K_NO_WAIT)) != NULL) {
 		if (is_listen) {
 			NET_DBG("discarding ctx %p", p);
+
+			/* Note that we must release all the packets we
+			 * might have received to the accepted socket.
+			 */
+			zsock_flush_queue(p);
 			net_context_put(p);
 		} else {
 			NET_DBG("discarding pkt %p", p);


### PR DESCRIPTION
If we have received data to the accepted socket, then release those before removing the accepted socket. This is a rare event as it requires that we get multiple simultaneous connections and there is a failure before the socket accept is called by the application.
For example one such scenario is when HTTP server receives multiple connection attempts at the same time, and the server poll fails before socket accept is called. This leads to buffer leak as the socket close is not called for the accepted socket because the accepted is not yet created from application point of view. The solution is to flush the received queue of the accepted socket before removing the actual accepted socket.

Fixes #84538