### PR TITLE
drivers: wifi: winc1500: Initialize wifi_scan_result struct

### DIFF
--- a/drivers/wifi/winc1500/wifi_winc1500.c
+++ b/drivers/wifi/winc1500/wifi_winc1500.c
@@ -683,7 +683,7 @@ static void reset_scan_data(void)
 static void handle_scan_result(void *pvMsg)
 {
 	tstrM2mWifiscanResult *pstrScanResult = (tstrM2mWifiscanResult *)pvMsg;
-	struct wifi_scan_result result;
+	struct wifi_scan_result result = { 0 };
 
 	if (!w1500_data.scan_cb) {
 		return;


### PR DESCRIPTION
The wifi_scan_result struct needs to be initialized to 0 so that the ssid gets properly null terminated.

Fixes #81971
Coverity-CID: 434570