### PR TITLE
 drivers: video: video_stm32_dcmi: Misc driver fixes.

### DIFF
--- a/drivers/video/video_stm32_dcmi.c
+++ b/drivers/video/video_stm32_dcmi.c
@@ -278,14 +278,14 @@ static int video_stm32_dcmi_stream_stop(const struct device *dev)
 		return -EIO;
 	}
 
-	/* Release the video buffer allocated in stream_start */
-	k_fifo_put(&data->fifo_in, data->vbuf);
-
 	err = HAL_DCMI_Stop(&data->hdcmi);
 	if (err != HAL_OK) {
 		LOG_ERR("Failed to stop DCMI");
 		return -EIO;
 	}
+
+	/* Release the video buffer allocated in stream_start */
+	k_fifo_put(&data->fifo_in, data->vbuf);
 
 	return 0;
 }

--- a/drivers/video/video_stm32_dcmi.c
+++ b/drivers/video/video_stm32_dcmi.c
@@ -206,6 +206,10 @@ static int video_stm32_dcmi_set_fmt(const struct device *dev,
 		return -EINVAL;
 	}
 
+	if ((fmt->pitch * fmt->height) > CONFIG_VIDEO_BUFFER_POOL_SZ_MAX) {
+		return -EINVAL;
+	}
+
 	data->pixel_format = fmt->pixelformat;
 	data->pitch = fmt->pitch;
 	data->height = fmt->height;


### PR DESCRIPTION
- Ensure the DCMI video buffer is released only after the DCMI has been fully stopped.
- Add a check to ensure the frame size does not exceed the video buffer size defined by `CONFIG_VIDEO_BUFFER_POOL_SZ_MAX`