### PR TITLE
soc: add FlexSPI2 clock configuration in clock_init for rt11xx

### DIFF
--- a/soc/nxp/imxrt/imxrt11xx/soc.c
+++ b/soc/nxp/imxrt/imxrt11xx/soc.c
@@ -567,6 +567,14 @@ static ALWAYS_INLINE void clock_init(void)
 	CLOCK_SetRootClock(kCLOCK_Root_Flexspi1, &rootCfg);
 #endif
 
+#if !(DT_NODE_HAS_COMPAT(DT_PARENT(DT_CHOSEN(zephyr_flash)), nxp_imx_flexspi)) &&  \
+	defined(CONFIG_MEMC_MCUX_FLEXSPI) && DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(flexspi2))
+	/* Configure FLEXSPI2 using OSC_RC_48M_DIV2 */
+	rootCfg.mux = kCLOCK_FLEXSPI2_ClockRoot_MuxOscRc48MDiv2;
+	rootCfg.div = 1;
+	CLOCK_SetRootClock(kCLOCK_Root_Flexspi2, &rootCfg);
+#endif
+
 	/* Keep core clock ungated during WFI */
 	CCM->GPR_PRIVATE1_SET = 0x1;
 	/* Keep the system clock running so SYSTICK can wake up the system from


### PR DESCRIPTION
The current soc clock_init only configures the FlexSPI1 interface and not the FlexSPI2. 

This Commit adds the clock configuration for the second FlexSPI in case one boots from the FlexSPI2.

Fixes #77411