### PR TITLE
tests: drivers: spi: Add further support for nRF54L20 PDK

### DIFF
--- a/tests/drivers/spi/spi_controller_peripheral/boards/nrf54l20pdk_nrf54l20_cpuapp.overlay
+++ b/tests/drivers/spi/spi_controller_peripheral/boards/nrf54l20pdk_nrf54l20_cpuapp.overlay
@@ -55,10 +55,11 @@
 	pinctrl-names = "default", "sleep";
 	overrun-character = <0x00>;
 	cs-gpios = <&gpio1 0 GPIO_ACTIVE_LOW>;
+	zephyr,pm-device-runtime-auto;
 	dut_spi_dt: test-spi-dev@0 {
 		compatible = "vnd,spi-device";
 		reg = <0>;
-		spi-max-frequency = <4000000>;
+		spi-max-frequency = <DT_FREQ_M(16)>;
 	};
 };
 

--- a/tests/drivers/spi/spi_controller_peripheral/testcase.yaml
+++ b/tests/drivers/spi/spi_controller_peripheral/testcase.yaml
@@ -63,6 +63,7 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54h20dk/nrf54h20/cpurad
       - nrf54h20dk/nrf54h20/cpuppr
+      - nrf54l20pdk/nrf54l20/cpuapp
 
   drivers.spi.pm_runtime:
     extra_configs:


### PR DESCRIPTION
Added support for nRF54L20 PDK in tests involving multiple instances. Corrected pin assignements in `spi_error_cases` test.