### PR TITLE
scripts: twister: Fix too early error count clearing

### DIFF
--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -1849,8 +1849,8 @@ class TwisterRunner:
                 self.results.done = self.results.total - self.results.failed
                 self.results.failed = 0
                 if self.options.retry_build_errors:
-                    self.results.error = 0
                     self.results.done -= self.results.error
+                    self.results.error = 0
             else:
                 self.results.done = self.results.filtered_static
 


### PR DESCRIPTION
`ExecutionCounter`'s `error` count was set to 0 before being used to lower the `done` count properly for the next retry iteration. It effectively rendered the following line a No-OPeration.

This should fix in-progress overcounting, where Twister claimed to execute more tests than planned