### PR TITLE
cmake: Update imxrt10xx CMakeLists.txt

### DIFF
--- a/soc/nxp/imxrt/imxrt10xx/CMakeLists.txt
+++ b/soc/nxp/imxrt/imxrt10xx/CMakeLists.txt
@@ -11,7 +11,7 @@ if(CONFIG_PM)
   zephyr_code_relocate(FILES power.c LOCATION ITCM_TEXT)
   if(CONFIG_SOC_MIMXRT1064)
     zephyr_sources(lpm_rt1064.c)
-    zephyr_code_relocate(FILES lpm_rt1064 LOCATION ITCM_TEXT)
+    zephyr_code_relocate(FILES lpm_rt1064.c LOCATION ITCM_TEXT)
   endif()
 endif()
 


### PR DESCRIPTION
In Line 14 the .c ending was missing in lpm_rt1064 file name. Linker didn't move the code to ITCM RAM. The CPU was not able to sleep.