### PR TITLE
drivers: gc2145: fix integer underflow in retry logic

### DIFF
--- a/drivers/video/gc2145.c
+++ b/drivers/video/gc2145.c
@@ -736,8 +736,7 @@ static int gc2145_write_reg(const struct i2c_dt_spec *spec, uint8_t reg_addr, ui
 		}
 		/* If writing failed wait 5ms before next attempt */
 		k_msleep(5);
-
-	} while (tries--);
+	} while (tries-- > 0);
 
 	LOG_ERR("failed to write 0x%x to 0x%x,", value, reg_addr);
 	return ret;
@@ -761,8 +760,7 @@ static int gc2145_read_reg(const struct i2c_dt_spec *spec, uint8_t reg_addr, uin
 		}
 		/* If writing failed wait 5ms before next attempt */
 		k_msleep(5);
-
-	} while (tries--);
+	} while (tries-- > 0);
 
 	LOG_ERR("failed to read 0x%x register", reg_addr);
 	return ret;


### PR DESCRIPTION
Properly stop retrying instead of underflowing uint8_t fixes CID-487682 and CID-487631

Fixes #84728 and #84757