### PR TITLE
Fix compiler version detection for __builtin_unreachable()

### DIFF
--- a/include/zephyr/toolchain/gcc.h
+++ b/include/zephyr/toolchain/gcc.h
@@ -103,7 +103,7 @@
 #define FUNC_ALIAS(real_func, new_alias, return_type) \
 	return_type new_alias() ALIAS_OF(real_func)
 
-#if TOOLCHAIN_GCC_VERSION < 400500
+#if TOOLCHAIN_GCC_VERSION < 40500
 #define __builtin_unreachable() __builtin_trap()
 #endif
 


### PR DESCRIPTION
Fixes a regression introduced in #84119. The original commit (1716bbdb19363abfdaf144d5917efc2a70d90a40) clarifies that this is supposed to be GCC v4.5.0, not GCC v40.5.0.