### PR TITLE
Add/fix net-shell event decoding

### DIFF
--- a/subsys/net/lib/shell/events.c
+++ b/subsys/net/lib/shell/events.c
@@ -334,6 +334,18 @@ static char *get_l3_desc(struct event_msg *msg,
 		*desc = "DHCPv4";
 		*desc2 = "stop";
 		break;
+	case NET_EVENT_IPV4_MCAST_JOIN:
+		*desc = "IPv4 mcast";
+		*desc2 = "join";
+		info = net_addr_ntop(AF_INET, msg->data, extra_info,
+				     extra_info_len);
+		break;
+	case NET_EVENT_IPV4_MCAST_LEAVE:
+		*desc = "IPv4 mcast";
+		*desc2 = "leave";
+		info = net_addr_ntop(AF_INET, msg->data, extra_info,
+				     extra_info_len);
+		break;
 	case NET_EVENT_IPV4_ACD_SUCCEED:
 		*desc = "IPv4 ACD";
 		*desc2 = "ok";

--- a/subsys/net/lib/shell/events.c
+++ b/subsys/net/lib/shell/events.c
@@ -292,6 +292,18 @@ static char *get_l3_desc(struct event_msg *msg,
 		info = net_addr_ntop(AF_INET, msg->data, extra_info,
 				     extra_info_len);
 		break;
+	case NET_EVENT_IPV4_MADDR_ADD:
+		*desc = "IPv4 mcast address";
+		*desc2 = "add";
+		info = net_addr_ntop(AF_INET, msg->data, extra_info,
+				     extra_info_len);
+		break;
+	case NET_EVENT_IPV4_MADDR_DEL:
+		*desc = "IPv4 mcast address";
+		*desc2 = "del";
+		info = net_addr_ntop(AF_INET, msg->data, extra_info,
+				     extra_info_len);
+		break;
 	case NET_EVENT_IPV4_ROUTER_ADD:
 		*desc = "IPv4 router";
 		*desc2 = "add";

--- a/subsys/net/lib/shell/events.c
+++ b/subsys/net/lib/shell/events.c
@@ -96,6 +96,14 @@ static char *get_l2_desc(struct event_msg *msg,
 		*desc = "interface";
 		*desc2 = "up";
 		break;
+	case NET_EVENT_IF_ADMIN_UP:
+		*desc = "interface";
+		*desc2 = "admin up";
+		break;
+	case NET_EVENT_IF_ADMIN_DOWN:
+		*desc = "interface";
+		*desc2 = "admin down";
+		break;
 	case NET_EVENT_ETHERNET_CARRIER_ON:
 #if defined(CONFIG_NET_L2_ETHERNET_MGMT)
 		*desc = "Ethernet";


### PR DESCRIPTION
The "net events" command can monitor network events in the system. Add some missing events to the printouts, also enhance some prints to print IP address information for the event.