### PR TITLE
picolibc: Use common abort(), call from assert when !__ASSERT_ON

### DIFF
--- a/lib/libc/Kconfig
+++ b/lib/libc/Kconfig
@@ -87,6 +87,7 @@ config PICOLIBC
 	select NEED_LIBC_MEM_PARTITION
 	select TC_PROVIDES_POSIX_C_LANG_SUPPORT_R
 	imply COMMON_LIBC_MALLOC
+	imply COMMON_LIBC_ABORT
 	depends on PICOLIBC_SUPPORTED
 	help
 	  Build with picolibc library. The picolibc library is built as

--- a/lib/libc/picolibc/assert.c
+++ b/lib/libc/picolibc/assert.c
@@ -11,18 +11,22 @@
 FUNC_NORETURN void __assert_func(const char *file, int line,
 				 const char *function, const char *expression)
 {
+#if __ASSERT_ON
 	__ASSERT(0, "assertion \"%s\" failed: file \"%s\", line %d%s%s\n",
 		 expression, file, line,
 		 function ? ", function: " : "", function ? function : "");
-	CODE_UNREACHABLE;
+#endif
+	abort();
 }
 
 #else
 
 FUNC_NORETURN void __assert_no_args(void)
 {
+#if __ASSERT_ON
 	__ASSERT_NO_MSG(0);
-	CODE_UNREACHABLE;
+#endif
+	abort();
 }
 
 #endif


### PR DESCRIPTION
Switch to the common abort implementation so that we can use it from the assert hooks when __ASSERT is disabled to avoid undefined behavior.

Closes: #84824