### PR TITLE
posix: semaphore: explicitly ignore return of k_mutex_unlock()

### DIFF
--- a/lib/posix/options/semaphore.c
+++ b/lib/posix/options/semaphore.c
@@ -33,7 +33,7 @@ static inline void nsem_list_lock(void)
 
 static inline void nsem_list_unlock(void)
 {
-	k_mutex_unlock(&nsem_mutex);
+	(void)k_mutex_unlock(&nsem_mutex);
 }
 
 static struct nsem_obj *nsem_find(const char *name)


### PR DESCRIPTION
The `nsem_list_unlock()` static inline function looks as though it was designed to always ignore the return value of
`k_mutex_unlock()`, presumably for performance reasons.

A quick audit of the code looks as though the call should always succeed.

Prepend `(void)` to the call to avoid the coverity defect in the future.

[CID 444386](https://scan9.scan.coverity.com/#/project-view/39971/12996?selectedIssue=444386)

Fixes #84778