### PR TITLE
posix: shm: ensure addend is less than INTPTR_MAX

### DIFF
--- a/lib/posix/options/shm.c
+++ b/lib/posix/options/shm.c
@@ -159,7 +159,7 @@ static off_t shm_lseek(struct shm_obj *shm, off_t offset, int whence, size_t cur
 		return -1;
 	}
 
-	if ((INTPTR_MAX - addend) < offset) {
+	if ((addend > INTPTR_MAX) || ((INTPTR_MAX - addend) < offset)) {
 		errno = EOVERFLOW;
 		return -1;
 	}


### PR DESCRIPTION
Although it's quite unlikely that we will see shared memory objects in practice that are greater than 2GiB, there is a possibility of integer overflow when comparing `intptr_t` and `size_t`, since the former is signed and the latter is unsigned.

Explicitly check to ensure that the `addend` is less than `INTPTR_MAX` before subtraction.

[CID 487734](https://scan9.scan.coverity.com/#/project-view/39971/12996?selectedIssue=487734)

Fixes #84699