### PR TITLE
MAINTAINERS: rpi_pico: Add @ThreeEights as collaborator

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3568,6 +3568,7 @@ Raspberry Pi Pico Platforms:
     - soburi
   collaborators:
     - yonsch
+    - threeeights
   files:
     - boards/raspberrypi/
     - boards/adafruit/kb2040/
@@ -4939,6 +4940,7 @@ West:
     - soburi
   collaborators:
     - yonsch
+    - threeeights
   files:
     - modules/hal_rpi_pico/
   labels:


### PR DESCRIPTION
I recommend @ThreeEights as a collaborator on RaspberryPi Pico.

He has a proven track record of adding WiFi support to RaspberryPi Pico,
and supporting the underlying SPI implementation with PIO.


https://github.com/zephyrproject-rtos/zephyr/pull/69634
https://github.com/zephyrproject-rtos/zephyr/pull/78773
https://github.com/zephyrproject-rtos/zephyr/pull/82187