### PR TITLE
doc: releases: 4.1: Document removed PM symbol

### DIFF
--- a/doc/releases/release-notes-4.1.rst
+++ b/doc/releases/release-notes-4.1.rst
@@ -79,6 +79,10 @@ Removed APIs and options
 
 * :kconfig:option:`CONFIG_WIFI_NM_WPA_SUPPLICANT_CRYPTO`
 
+* The :kconfig:option:`CONFIG_PM_DEVICE_RUNTIME_EXCLUSIVE` option has been removed
+  after being deprecated in favor of :kconfig:option:`CONFIG_PM_DEVICE_SYSTEM_MANAGED`.
+
+
 Deprecated APIs and options
 ===========================
 

--- a/subsys/pm/Kconfig
+++ b/subsys/pm/Kconfig
@@ -101,14 +101,6 @@ config PM_DEVICE_RUNTIME
 	  enabled, devices can be suspended or resumed based on the device
 	  usage even while the CPU or system is running.
 
-config PM_DEVICE_RUNTIME_EXCLUSIVE
-	depends on PM_DEVICE_RUNTIME
-	bool "[DEPRECATED] Use only on Runtime Power Management on system suspend / resume"
-	select DEPRECATED
-	help
-	  On system suspend / resume do not trigger the Device PM hooks but
-	  only rely on Runtime PM to manage the devices power states.
-
 config PM_DEVICE_SHELL
 	bool "Device Power Management shell"
 	depends on SHELL
@@ -118,7 +110,7 @@ config PM_DEVICE_SHELL
 
 config PM_DEVICE_SYSTEM_MANAGED
 	bool "System-Managed Device Power Management"
-	default y if !PM_DEVICE_RUNTIME_EXCLUSIVE && !PM_DEVICE_RUNTIME
+	default y if !PM_DEVICE_RUNTIME
 	help
 	  This option enables the system-managed device power
 	  management.  The power management subsystem will suspend


### PR DESCRIPTION
The deprecated PM_DEVICE_RUNTIME_EXCLUSIVE option is been removed in this release.