### PR TITLE
drivers: bluetooth: silabs_efr32: Add support for vendor HCI extensions

### DIFF
--- a/drivers/bluetooth/hci/Kconfig.silabs
+++ b/drivers/bluetooth/hci/Kconfig.silabs
@@ -4,6 +4,11 @@
 menu "EFR32 Bluetooth Controller Configuration"
 	depends on BT_SILABS_EFR32
 
+config BT_SILABS_EFR32_HCI_VS
+	bool "Silicon Labs vendor specific HCI extensions"
+	help
+	  Enable Silicon Labs vendor specific HCI extensions.
+
 config BT_SILABS_EFR32_BUFFER_MEMORY
 	int "Memory buffer size"
 	default 6144

--- a/drivers/bluetooth/hci/hci_silabs_efr32.c
+++ b/drivers/bluetooth/hci/hci_silabs_efr32.c
@@ -330,6 +330,10 @@ static int slz_bt_open(const struct device *dev, bt_hci_recv_t recv)
 	sl_btctrl_hci_parser_init_adv();
 	sl_btctrl_hci_parser_init_phy();
 
+	if (IS_ENABLED(CONFIG_BT_SILABS_EFR32_HCI_VS)) {
+		sl_bthci_init_vs();
+	}
+
 	if (IS_ENABLED(CONFIG_PM)) {
 		RAIL_ConfigSleep(BTLE_LL_GetRadioHandle(), RAIL_SLEEP_CONFIG_TIMERSYNC_ENABLED);
 		RAIL_Status_t status = RAIL_InitPowerManager();

--- a/modules/hal_silabs/simplicity_sdk/src/blob_stubs.c
+++ b/modules/hal_silabs/simplicity_sdk/src/blob_stubs.c
@@ -109,6 +109,10 @@ void sl_btctrl_hci_parser_init_phy(void)
 {
 }
 
+void sl_bthci_init_vs(void)
+{
+}
+
 void AGC_IRQHandler(void)
 {
 }


### PR DESCRIPTION
Add a Kconfig option which can be used to enable vendor HCI extensions for Silicon Labs EFR32 devices.