### PR TITLE
drivers: udc: stm32: update `STM32_CLOCK_CHECK` definition

### DIFF
--- a/drivers/usb/udc/Kconfig.stm32
+++ b/drivers/usb/udc/Kconfig.stm32
@@ -35,4 +35,12 @@ config UDC_STM32_MAX_QMESSAGES
 	help
 	  Maximum number of messages for handling of STM32 USBD ISR events.
 
+config UDC_STM32_CLOCK_CHECK
+	bool "Runtime USB 48MHz clock check"
+	default y if !(SOC_SERIES_STM32F1X || SOC_SERIES_STM32F3X || SOC_SERIES_STM32U5X)
+	help
+	  Enable USB clock 48MHz configuration runtime check.
+	  In specific cases, this check might provide wrong verdict and should
+	  be disabled.
+
 endif

--- a/drivers/usb/udc/udc_stm32.c
+++ b/drivers/usb/udc/udc_stm32.c
@@ -1116,7 +1116,7 @@ static int priv_clock_enable(void)
 		return -EIO;
 	}
 
-	if (IS_ENABLED(CONFIG_USB_DC_STM32_CLOCK_CHECK)) {
+	if (IS_ENABLED(CONFIG_UDC_STM32_CLOCK_CHECK)) {
 		uint32_t usb_clock_rate;
 
 		if (clock_control_get_rate(clk,


### PR DESCRIPTION
Introduce `UDC_STM32_CLOCK_CHECK` Kconfig option since `USB_DC_STM32_CLOCK_CHECK` was intended for use with `usb_dc_stm32.c`, which is mutually exclusive with `udc_stm32.c`.