### PR TITLE
scripts: runners: nrf: Fix a missing indirection

### DIFF
--- a/scripts/west_commands/runners/nrf_common.py
+++ b/scripts/west_commands/runners/nrf_common.py
@@ -494,7 +494,7 @@ class NrfBinaryRunner(ZephyrBinaryRunner):
         op = op['operation']
         if op['type'] not in ('erase', 'recover', 'program'):
             return None
-        if op['type'] == 'program' and op['chip_erase_mode'] != "ERASE_UICR":
+        if op['type'] == 'program' and op['options']['chip_erase_mode'] != "ERASE_UICR":
             return None
 
         file = _get_suit_starter()


### PR DESCRIPTION
In commit 6e9e8391953d8dcf606824c43c00077750581b11, an indirection via the new `options` dictionary was missed in the SUIT handling.