### PR TITLE
llext: make EDK Kconfig menu visible only when LLEXT is enabled

### DIFF
--- a/subsys/llext/Kconfig
+++ b/subsys/llext/Kconfig
@@ -113,8 +113,6 @@ module = LLEXT
 module-str = llext
 source "subsys/logging/Kconfig.template.log_config"
 
-endif
-
 menu "Linkable loadable Extension Development Kit (EDK)"
 
 config LLEXT_EDK_NAME
@@ -135,3 +133,5 @@ config LLEXT_EDK_USERSPACE_ONLY
 	  not contain the routing code, and only generate the userspace one.
 
 endmenu
+
+endif # LLEXT


### PR DESCRIPTION
Properly guard LLEXT EDK menu to prevent associated options from bleeding into project conf even when LLEXT is disabled