### PR TITLE
doc: boards: extensions: add link to board source to sidebar

### DIFF
--- a/doc/_extensions/zephyr/domain/__init__.py
+++ b/doc/_extensions/zephyr/domain/__init__.py
@@ -268,6 +268,21 @@ class ConvertBoardNode(SphinxTransform):
                 field += field_body
                 field_list += field
 
+            gh_link = gh_link_get_url(self.app, self.env.docname)
+            gh_link_button = nodes.raw(
+                "",
+                f"""
+                <div id="board-github-link">
+                    <a href="{gh_link}/../.." class="btn btn-info fa fa-github"
+                        target="_blank">
+                        Browse board sources
+                    </a>
+                </div>
+                """,
+                format="html",
+            )
+            sidebar += gh_link_button
+
             # Move the sibling nodes under the new section
             new_section.extend(siblings_to_move)
 

--- a/doc/_static/css/custom.css
+++ b/doc/_static/css/custom.css
@@ -1128,6 +1128,10 @@ li>a.code-sample-link.reference.internal.current {
     }
 }
 
+.sidebar.board-overview {
+    color: var(--admonition-note-color);
+}
+
 .sidebar.board-overview .sidebar-title {
     font-family: var(--header-font-family);
     background: var(--admonition-note-title-background-color);
@@ -1135,10 +1139,6 @@ li>a.code-sample-link.reference.internal.current {
     border-radius: 12px 12px 0px 0px;
     margin: 0px;
     text-align: center;
-}
-
-.sidebar.board-overview * {
-    color: var(--admonition-note-color);
 }
 
 .sidebar.board-overview figure {
@@ -1174,4 +1174,18 @@ li>a.code-sample-link.reference.internal.current {
 
 .sidebar.board-overview dl.field-list>dd code {
     font-size: 0.9em;
+}
+
+.sidebar.board-overview #board-github-link {
+    text-align: center;
+    margin-bottom: 1em;
+    font-size: 0.9em;
+}
+
+.sidebar.board-overview #board-github-link a {
+    display: inline-block;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width:80%;
 }


### PR DESCRIPTION
Similar to how we have a button in code samples' READMEs, this helps direcly taking the reader to the board's sources on GitHub

https://builds.zephyrproject.io/zephyr/pr/84853/docs/boards/seeed/wio_terminal/doc/index.html

![image](https://github.com/user-attachments/assets/9ea0d03e-b8bd-47bf-8c38-5b2ba90386f1)
