### PR TITLE
boards: esp32s3_touch_lcd_1_28: fix display pixel format

### DIFF
--- a/boards/waveshare/esp32s3_touch_lcd_1_28/esp32s3_touch_lcd_1_28_esp32s3_procpu.dts
+++ b/boards/waveshare/esp32s3_touch_lcd_1_28/esp32s3_touch_lcd_1_28_esp32s3_procpu.dts
@@ -74,7 +74,7 @@
 			compatible = "galaxycore,gc9x01x";
 			reg = <0>;
 			mipi-max-frequency = <100000000>;
-			pixel-format = <PANEL_PIXEL_FORMAT_RGB_888>;
+			pixel-format = <PANEL_PIXEL_FORMAT_RGB_565>;
 			display-inversion;
 			width = <240>;
 			height = <240>;


### PR DESCRIPTION
The pixel format was set to PANEL_PIXEL_FORMAT_RGB_888 which resulted in horizontal lines of wrong color ... with PANEL_PIXEL_FORMAT_RGB_565 everything looks good.
