### PR TITLE
doc: services: retention: Fix device names

### DIFF
--- a/doc/services/retention/index.rst
+++ b/doc/services/retention/index.rst
@@ -114,8 +114,8 @@ using:
 	#include <zephyr/device.h>
 	#include <zephyr/retention/retention.h>
 
+	const struct device *retention0 = DEVICE_DT_GET(DT_NODELABEL(retention0));
 	const struct device *retention1 = DEVICE_DT_GET(DT_NODELABEL(retention1));
-	const struct device *retention2 = DEVICE_DT_GET(DT_NODELABEL(retention2));
 
 When the write function is called, the magic header and checksum (if enabled)
 will be set on the area, and it will be marked as valid from that point


### PR DESCRIPTION
Fixes device names to use correctly defined values

Fixes #84340