### PR TITLE
samples: net: prometheus: Add netif dependency

### DIFF
--- a/samples/net/prometheus/sample.yaml
+++ b/samples/net/prometheus/sample.yaml
@@ -3,6 +3,7 @@ sample:
   name: prometheus_client_sample
 common:
   harness: net
+  depends_on: netif
   min_ram: 192
   tags:
     - http


### PR DESCRIPTION
There's no point building the sample for platforms that do not support networking, hence add netif dependency to reduce the CI execution scope.