### PR TITLE
arch: arm: Fix Coverity issues

### DIFF
--- a/arch/arm/core/mpu/arm_mpu_v7_internal.h
+++ b/arch/arm/core/mpu/arm_mpu_v7_internal.h
@@ -233,7 +233,9 @@ static int mpu_configure_static_mpu_regions(const struct z_arm_mpu_partition
 	mpu_reg_index = mpu_configure_regions(static_regions,
 		regions_num, mpu_reg_index, true);
 
-	static_regions_num = mpu_reg_index;
+	if (mpu_reg_index != -EINVAL) {
+		static_regions_num = mpu_reg_index;
+	}
 
 	return mpu_reg_index;
 }

--- a/arch/arm/core/mpu/arm_mpu_v8_internal.h
+++ b/arch/arm/core/mpu/arm_mpu_v8_internal.h
@@ -669,7 +669,9 @@ static int mpu_configure_static_mpu_regions(const struct z_arm_mpu_partition
 	mpu_reg_index = mpu_configure_regions_and_partition(static_regions,
 		regions_num, mpu_reg_index, true);
 
-	static_regions_num = mpu_reg_index;
+	if (mpu_reg_index != -EINVAL) {
+		static_regions_num = mpu_reg_index;
+	}
 
 	return mpu_reg_index;
 }


### PR DESCRIPTION
What is the change?
 - The change satisfies a minor coverity issue.
 - Fixes #84754 

Why is this needed?
 - Coverity issue CID 487634 reported of an integer overflow when configuring a static mpu region returns EINVAL. This change maintains code consistency and satisfies Coverity's requirement, even though an assert is in place to handle this scenario in the upper layer fn arm_core_mpu_configure_static_mpu_regions().