### PR TITLE
stm32: drivers: Remove useless usages of USE_STM32_LL_FOO

### DIFF
--- a/drivers/counter/Kconfig.stm32_rtc
+++ b/drivers/counter/Kconfig.stm32_rtc
@@ -8,9 +8,6 @@ menuconfig COUNTER_RTC_STM32
 	default y if !RTC
 	depends on DT_HAS_ST_STM32_RTC_ENABLED
 	select USE_STM32_LL_RTC
-	select USE_STM32_LL_PWR
-	select USE_STM32_LL_RCC
-	select USE_STM32_LL_EXTI
 	help
 	  Build RTC driver for STM32 SoCs.
 	  Tested on STM32 C0, F0, F2, F3, F4, F7, G0, G4, H7, L1, L4, L5, U5 series

--- a/drivers/entropy/Kconfig.stm32
+++ b/drivers/entropy/Kconfig.stm32
@@ -8,7 +8,6 @@ menuconfig ENTROPY_STM32_RNG
 	default y
 	depends on DT_HAS_ST_STM32_RNG_ENABLED || DT_HAS_ST_STM32_RNG_NOIRQ_ENABLED
 	select ENTROPY_HAS_DRIVER
-	select USE_STM32_LL_RNG
 	help
 	  This option enables the RNG processor, which is a entropy number
 	  generator, based on a continuous analog noise, that provides

--- a/drivers/ipm/Kconfig.stm32
+++ b/drivers/ipm/Kconfig.stm32
@@ -5,7 +5,6 @@ config IPM_STM32_IPCC
 	bool "STM32 IPCC controller"
 	default y
 	depends on DT_HAS_ST_STM32_IPCC_MAILBOX_ENABLED
-	select USE_STM32_LL_IPCC
 	help
 	  Driver for stm32 IPCC mailboxes
 

--- a/drivers/rtc/Kconfig.stm32
+++ b/drivers/rtc/Kconfig.stm32
@@ -6,7 +6,5 @@ config RTC_STM32
 	default y if !COUNTER
 	depends on DT_HAS_ST_STM32_RTC_ENABLED && !SOC_SERIES_STM32F1X
 	select USE_STM32_LL_RTC
-	select USE_STM32_LL_PWR
-	select USE_STM32_LL_RCC
 	help
 	  Build RTC driver for STM32 SoCs, excluding STM32F1 series.

--- a/drivers/spi/Kconfig.stm32
+++ b/drivers/spi/Kconfig.stm32
@@ -8,7 +8,6 @@ menuconfig SPI_STM32
 	default y
 	depends on DT_HAS_ST_STM32_SPI_ENABLED
 	select PINCTRL
-	select USE_STM32_LL_SPI
 	help
 	  Enable SPI support on the STM32 family of processors.
 


### PR DESCRIPTION
clean up usage of select USE_STM32_LL_FOO from Kconfig.stm32