### PR TITLE
net: vlan: Allow VLAN count to be set to 0

### DIFF
--- a/include/zephyr/net/ethernet.h
+++ b/include/zephyr/net/ethernet.h
@@ -618,9 +618,7 @@ struct ethernet_vlan {
 #if defined(CONFIG_NET_VLAN_COUNT)
 #define NET_VLAN_MAX_COUNT CONFIG_NET_VLAN_COUNT
 #else
-/* Even thou there are no VLAN support, the minimum count must be set to 1.
- */
-#define NET_VLAN_MAX_COUNT 1
+#define NET_VLAN_MAX_COUNT 0
 #endif
 
 /** @endcond */
@@ -681,7 +679,14 @@ struct ethernet_context {
 	struct net_if *iface;
 
 #if defined(CONFIG_NET_LLDP)
-	struct ethernet_lldp lldp[NET_VLAN_MAX_COUNT];
+#if NET_VLAN_MAX_COUNT > 0
+#define NET_LLDP_MAX_COUNT NET_VLAN_MAX_COUNT
+#else
+#define NET_LLDP_MAX_COUNT 1
+#endif /* NET_VLAN_MAX_COUNT > 0 */
+
+	/** LLDP specific parameters */
+	struct ethernet_lldp lldp[NET_LLDP_MAX_COUNT];
 #endif
 
 	/**
@@ -988,7 +993,7 @@ int net_eth_get_hw_config(struct net_if *iface, enum ethernet_config_type type,
  *
  * @return 0 if ok, <0 if error
  */
-#if defined(CONFIG_NET_VLAN)
+#if defined(CONFIG_NET_VLAN) && NET_VLAN_MAX_COUNT > 0
 int net_eth_vlan_enable(struct net_if *iface, uint16_t tag);
 #else
 static inline int net_eth_vlan_enable(struct net_if *iface, uint16_t tag)
@@ -1008,7 +1013,7 @@ static inline int net_eth_vlan_enable(struct net_if *iface, uint16_t tag)
  *
  * @return 0 if ok, <0 if error
  */
-#if defined(CONFIG_NET_VLAN)
+#if defined(CONFIG_NET_VLAN) && NET_VLAN_MAX_COUNT > 0
 int net_eth_vlan_disable(struct net_if *iface, uint16_t tag);
 #else
 static inline int net_eth_vlan_disable(struct net_if *iface, uint16_t tag)
@@ -1031,7 +1036,7 @@ static inline int net_eth_vlan_disable(struct net_if *iface, uint16_t tag)
  * @return VLAN tag for this interface or NET_VLAN_TAG_UNSPEC if VLAN
  * is not configured for that interface.
  */
-#if defined(CONFIG_NET_VLAN)
+#if defined(CONFIG_NET_VLAN) && NET_VLAN_MAX_COUNT > 0
 uint16_t net_eth_get_vlan_tag(struct net_if *iface);
 #else
 static inline uint16_t net_eth_get_vlan_tag(struct net_if *iface)
@@ -1073,7 +1078,7 @@ struct net_if *net_eth_get_vlan_iface(struct net_if *iface, uint16_t tag)
  * @return Network interface related to this tag or NULL if no such interface
  * exists.
  */
-#if defined(CONFIG_NET_VLAN)
+#if defined(CONFIG_NET_VLAN) && NET_VLAN_MAX_COUNT > 0
 struct net_if *net_eth_get_vlan_main(struct net_if *iface);
 #else
 static inline
@@ -1119,7 +1124,7 @@ static inline bool net_eth_is_vlan_enabled(struct ethernet_context *ctx,
  *
  * @return True if VLAN is enabled for this network interface, false if not.
  */
-#if defined(CONFIG_NET_VLAN)
+#if defined(CONFIG_NET_VLAN) && NET_VLAN_MAX_COUNT > 0
 bool net_eth_get_vlan_status(struct net_if *iface);
 #else
 static inline bool net_eth_get_vlan_status(struct net_if *iface)
@@ -1137,7 +1142,7 @@ static inline bool net_eth_get_vlan_status(struct net_if *iface)
  *
  * @return True if this network interface is VLAN one, false if not.
  */
-#if defined(CONFIG_NET_VLAN)
+#if defined(CONFIG_NET_VLAN) && NET_VLAN_MAX_COUNT > 0
 bool net_eth_is_vlan_interface(struct net_if *iface);
 #else
 static inline bool net_eth_is_vlan_interface(struct net_if *iface)

--- a/samples/net/mdns_responder/src/vlan.c
+++ b/samples/net/mdns_responder/src/vlan.c
@@ -105,6 +105,11 @@ int init_vlan(void)
 	struct ud user_data;
 	int ret;
 
+	if (CONFIG_NET_VLAN_COUNT == 0) {
+		LOG_DBG("No VLAN interfaces defined.");
+		return 0;
+	}
+
 	iface = net_if_get_first_by_type(&NET_L2_GET_NAME(ETHERNET));
 	if (!iface) {
 		LOG_ERR("No ethernet interfaces found.");

--- a/samples/net/sockets/echo_client/src/vlan.c
+++ b/samples/net/sockets/echo_client/src/vlan.c
@@ -85,6 +85,11 @@ int init_vlan(void)
 	struct ud ud;
 	int ret;
 
+	if (CONFIG_NET_VLAN_COUNT == 0) {
+		LOG_DBG("No VLAN interfaces defined.");
+		return 0;
+	}
+
 	iface = net_if_get_first_by_type(&NET_L2_GET_NAME(ETHERNET));
 	if (!iface) {
 		LOG_ERR("No ethernet interfaces found.");

--- a/samples/net/sockets/echo_server/src/vlan.c
+++ b/samples/net/sockets/echo_server/src/vlan.c
@@ -107,6 +107,11 @@ int init_vlan(void)
 	struct ud ud;
 	int ret;
 
+	if (CONFIG_NET_VLAN_COUNT == 0) {
+		LOG_DBG("No VLAN interfaces defined.");
+		return 0;
+	}
+
 	memset(&ud, 0, sizeof(ud));
 
 	net_if_foreach(iface_cb, &ud);

--- a/samples/net/sockets/txtime/src/vlan.c
+++ b/samples/net/sockets/txtime/src/vlan.c
@@ -99,6 +99,11 @@ int init_vlan(void)
 	struct ud ud;
 	int ret;
 
+	if (CONFIG_NET_VLAN_COUNT == 0) {
+		LOG_DBG("No VLAN interfaces defined.");
+		return 0;
+	}
+
 	iface = net_if_get_first_by_type(&NET_L2_GET_NAME(ETHERNET));
 	if (!iface) {
 		LOG_ERR("No ethernet interfaces found.");

--- a/subsys/net/ip/Kconfig.ipv4
+++ b/subsys/net/ip/Kconfig.ipv4
@@ -13,7 +13,7 @@ if NET_IPV4
 
 config NET_IF_MAX_IPV4_COUNT
 	int "Max number of IPv4 network interfaces in the system"
-	default NET_VLAN_COUNT if NET_VLAN
+	default NET_VLAN_COUNT if NET_VLAN && NET_VLAN_COUNT > 0
 	default 2 if NET_LOOPBACK
 	default 1
 	help

--- a/subsys/net/ip/Kconfig.ipv6
+++ b/subsys/net/ip/Kconfig.ipv6
@@ -14,7 +14,7 @@ if NET_IPV6
 
 config NET_IF_MAX_IPV6_COUNT
 	int "Max number of IPv6 network interfaces in the system"
-	default NET_VLAN_COUNT if NET_VLAN
+	default NET_VLAN_COUNT if NET_VLAN && NET_VLAN_COUNT > 0
 	default 2 if NET_LOOPBACK
 	default 1
 	help

--- a/subsys/net/l2/ethernet/Kconfig
+++ b/subsys/net/l2/ethernet/Kconfig
@@ -41,10 +41,14 @@ config NET_VLAN
 config NET_VLAN_COUNT
 	int "Max VLAN tags supported in the system"
 	default 1
-	range 1 $(UINT8_MAX)
+	range 0 $(UINT8_MAX)
 	depends on NET_VLAN
 	help
-	  How many VLAN tags can be configured.
+	  How many VLAN tags can be configured. If set to 0, then only
+	  priority tagged VLAN frames with tag value 0 can be handled.
+	  This is useful if you do not want to receive any other VLAN
+	  tagged frames than tag 0. This will save some memory as the
+	  VLAN virtual interface is not created in this case.
 
 config NET_VLAN_TXRX_DEBUG
 	bool "Debug received and sent packets in VLAN"

--- a/subsys/net/l2/ethernet/ethernet.c
+++ b/subsys/net/l2/ethernet/ethernet.c
@@ -281,19 +281,26 @@ static enum net_verdict ethernet_recv(struct net_if *iface,
 		    !eth_is_vlan_tag_stripped(iface)) {
 			struct net_eth_vlan_hdr *hdr_vlan =
 				(struct net_eth_vlan_hdr *)NET_ETH_HDR(pkt);
+			struct net_if *vlan_iface;
 
 			net_pkt_set_vlan_tci(pkt, ntohs(hdr_vlan->vlan.tci));
 			type = ntohs(hdr_vlan->type);
 			hdr_len = sizeof(struct net_eth_vlan_hdr);
 			is_vlan_pkt = true;
 
-			net_pkt_set_iface(pkt,
-					  net_eth_get_vlan_iface(iface,
-						       net_pkt_vlan_tag(pkt)));
-
 			/* If we receive a packet with a VLAN tag, for that we don't
 			 * have a VLAN interface, drop the packet.
 			 */
+			vlan_iface = net_eth_get_vlan_iface(iface,
+							    net_pkt_vlan_tag(pkt));
+			if (vlan_iface == NULL) {
+				NET_DBG("Dropping frame, no VLAN interface for tag %d",
+					net_pkt_vlan_tag(pkt));
+				goto drop;
+			}
+
+			net_pkt_set_iface(pkt, vlan_iface);
+
 			if (net_if_l2(net_pkt_iface(pkt)) == NULL) {
 				goto drop;
 			}

--- a/subsys/net/l2/ethernet/vlan.c
+++ b/subsys/net/l2/ethernet/vlan.c
@@ -26,6 +26,12 @@ LOG_MODULE_REGISTER(net_ethernet_vlan, CONFIG_NET_L2_ETHERNET_LOG_LEVEL);
 #define DEBUG_RX 0
 #endif
 
+/* If the VLAN interface count is 0, then only priority tagged (tag 0)
+ * Ethernet frames can be received. In this case we do not need to
+ * allocate any memory for VLAN interfaces.
+ */
+#if CONFIG_NET_VLAN_COUNT > 0
+
 #define MAX_VLAN_NAME_LEN MIN(sizeof("VLAN-<#####>"), \
 			      CONFIG_NET_INTERFACE_NAME_LEN)
 #define MAX_VIRT_NAME_LEN MIN(sizeof("<not attached>"), \
@@ -672,3 +678,27 @@ static void vlan_iface_init(struct net_if *iface)
 
 	ctx->init_done = true;
 }
+
+#else /* CONFIG_NET_VLAN_COUNT > 0 */
+
+/* Dummy functions if VLAN is not really used. This is only needed
+ * if priority tagged frames (tag 0) are supported.
+ */
+bool net_eth_is_vlan_enabled(struct ethernet_context *ctx,
+			     struct net_if *iface)
+{
+	ARG_UNUSED(ctx);
+	ARG_UNUSED(iface);
+
+	return true;
+}
+
+struct net_if *net_eth_get_vlan_iface(struct net_if *iface, uint16_t tag)
+{
+	if (tag == NET_VLAN_TAG_PRIORITY) {
+		return iface;
+	}
+
+	return NULL;
+}
+#endif /* CONFIG_NET_VLAN_COUNT > 0 */

--- a/subsys/net/lib/shell/net_shell_private.h
+++ b/subsys/net/lib/shell/net_shell_private.h
@@ -64,8 +64,12 @@ struct net_shell_user_data {
 #if !defined(NET_VLAN_MAX_COUNT)
 #define MAX_IFACE_COUNT NET_IF_MAX_CONFIGS
 #else
+#if NET_VLAN_MAX_COUNT > 0
 #define MAX_IFACE_COUNT NET_VLAN_MAX_COUNT
-#endif
+#else
+#define MAX_IFACE_COUNT NET_IF_MAX_CONFIGS
+#endif /* NET_VLAN_MAX_COUNT > 0 */
+#endif /* !NET_VLAN_MAX_COUNT */
 
 #if defined(CONFIG_NET_IPV6) && !defined(CONFIG_NET_IPV4)
 #define ADDR_LEN NET_IPV6_ADDR_LEN

--- a/tests/net/vlan/testcase.yaml
+++ b/tests/net/vlan/testcase.yaml
@@ -17,3 +17,6 @@ tests:
       - CONFIG_NET_L2_ETHERNET_RESERVE_HEADER=y
       - CONFIG_NET_BUF_VARIABLE_DATA_SIZE=y
       - CONFIG_TEST_EXTRA_STACK_SIZE=1024
+  net.vlan.priority_tagging_only:
+    extra_configs:
+      - CONFIG_NET_VLAN_COUNT=0


### PR DESCRIPTION
If VLAN count is set to 0, then only priority tagged VLAN frames that have tag value 0 can be received. Also this means that VLAN interfaces are not created which can save memory if you do not need to receive any other VLAN frames than those tagged with value 0.

Fixes #84023

Signed-off-by: Jukka Rissanen <jukka.rissanen@nordicsemi.no>
