### PR TITLE
Bluetooth: Mesh: clean up for better integration with PSA 

### DIFF
--- a/doc/connectivity/bluetooth/api/mesh/dfu.rst
+++ b/doc/connectivity/bluetooth/api/mesh/dfu.rst
@@ -212,9 +212,10 @@ re-provisioned. The complete list of available options is defined in :c:enum:`bt
    provisioning. In this case, the device stays provisioned and the new composition data takes place
    after re-provisioning using the Remote Provisioning models.
 :c:enumerator:`BT_MESH_DFU_EFFECT_UNPROV`
-  This effect is chosen if the composition data in the new firmware changes, the device doesn't
+  This effect is chosen if the composition data in the new firmware changes, the device does not
   support the remote provisioning, and the new composition data takes effect after applying the
-  firmware.
+  firmware. The effect can also be chosen, if it is necessary to unprovision the device for
+  application-specific reasons.
 
 When the Target node receives the Firmware Update Firmware Metadata Check message, the Firmware
 Update Server model calls the :c:member:`bt_mesh_dfu_srv_cb.check` callback, the application can

--- a/doc/releases/migration-guide-4.1.rst
+++ b/doc/releases/migration-guide-4.1.rst
@@ -456,6 +456,16 @@ Bluetooth Mesh
   set as deprecated. Default option for platforms that do not support TF-M
   is :kconfig:option:`CONFIG_BT_MESH_USES_MBEDTLS_PSA`.
 
+* Mesh key representations are not backward compatible if images are built with TinyCrypt and
+  crypto libraries based on the PSA API. Mesh no longer stores the key values for those crypto
+  libraries. The crypto library stores the keys in the internal trusted storage.
+  If a provisioned device is going to update its image that was built with
+  the :kconfig:option:`CONFIG_BT_MESH_USES_TINYCRYPT` Kconfig option set on an image
+  that was built with :kconfig:option:`CONFIG_BT_MESH_USES_MBEDTLS_PSA` or
+  :kconfig:option:`CONFIG_BT_MESH_USES_TFM_PSA` without erasing the persistent area,
+  it should be unprovisioned first and reprovisioned after update again.
+  If the image is changed over Mesh DFU, use :c:enumerator:`BT_MESH_DFU_EFFECT_UNPROV`.
+
 * Mesh explicitly depends on the Secure Storage subsystem if storing into
   non-volatile memory (:kconfig:option:`CONFIG_BT_SETTINGS`) is enabled and
   Mbed TLS library (:kconfig:option:`CONFIG_BT_MESH_USES_MBEDTLS_PSA`) is used.

--- a/subsys/bluetooth/mesh/cdb.c
+++ b/subsys/bluetooth/mesh/cdb.c
@@ -55,7 +55,7 @@ struct node_val {
 
 /* NetKey storage information */
 struct net_key_val {
-	uint8_t kr_flag:1,
+	uint8_t unused:1,
 		kr_phase:7;
 	struct bt_mesh_key val[2];
 } __packed;
@@ -491,7 +491,7 @@ static void store_cdb_subnet(const struct bt_mesh_cdb_subnet *sub)
 
 	memcpy(&key.val[0], &sub->keys[0].net_key, sizeof(struct bt_mesh_key));
 	memcpy(&key.val[1], &sub->keys[1].net_key, sizeof(struct bt_mesh_key));
-	key.kr_flag = 0U; /* Deprecated */
+	key.unused = 0U;
 	key.kr_phase = sub->kr_phase;
 
 	snprintk(path, sizeof(path), "bt/mesh/cdb/Subnet/%x", sub->net_idx);

--- a/subsys/bluetooth/mesh/net.c
+++ b/subsys/bluetooth/mesh/net.c
@@ -1109,17 +1109,23 @@ BT_MESH_SETTINGS_DEFINE(seq, "Seq", seq_set);
 #if defined(CONFIG_BT_MESH_RPR_SRV)
 static int dev_key_cand_set(const char *name, size_t len_rd, settings_read_cb read_cb,
 		   void *cb_arg)
-{	int err;
+{
+	int err;
+	struct bt_mesh_key key;
 
-	if (len_rd < 16) {
-		return -EINVAL;
+	if (len_rd == 0) {
+		LOG_DBG("val (null)");
+
+		bt_mesh_key_destroy(&bt_mesh.dev_key_cand);
+		memset(&bt_mesh.dev_key_cand, 0, sizeof(struct bt_mesh_key));
+		return 0;
 	}
 
-	err = bt_mesh_settings_set(read_cb, cb_arg, &bt_mesh.dev_key_cand,
-				   sizeof(struct bt_mesh_key));
+	err = bt_mesh_settings_set(read_cb, cb_arg, &key, sizeof(struct bt_mesh_key));
 	if (!err) {
 		LOG_DBG("DevKey candidate recovered from storage");
 		atomic_set_bit(bt_mesh.flags, BT_MESH_DEVKEY_CAND);
+		bt_mesh_key_assign(&bt_mesh.dev_key_cand, &key);
 	}
 
 	return err;


### PR DESCRIPTION
PR:
* fixes device key candidate restoring for PSA API
* clears deprecated field in cdb
* adds clarification about key representation incompatibility in migration guide