### PR TITLE
net: lwm2m: gateway: Prevent underflow when processing URI options

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_obj_gateway.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_gateway.c
@@ -159,6 +159,10 @@ int lwm2m_gw_handle_req(struct lwm2m_message *msg)
 		return ret;
 	}
 
+	if (ret == 0) {
+		return -ENOENT;
+	}
+
 	for (int index = 0; index < MAX_INSTANCE_COUNT; index++) {
 		/* Skip uninitialized objects */
 		if (!inst[index].obj) {


### PR DESCRIPTION
lwm2m_gw_handle_req() function logic expects that at least one URI option was found, therefore add an extra check to return the function early if that isn't the case.

Fixes #84750