### PR TITLE
modules: hostap: Decrease supplicant thread stack size

### DIFF
--- a/modules/hostap/Kconfig
+++ b/modules/hostap/Kconfig
@@ -31,7 +31,7 @@ config HEAP_MEM_POOL_ADD_SIZE_HOSTAP
 
 config WIFI_NM_WPA_SUPPLICANT_THREAD_STACK_SIZE
 	int "Stack size for wpa_supplicant thread"
-	default 8192
+	default 5200
 
 config WIFI_NM_WPA_SUPPLICANT_WQ_STACK_SIZE
 	int "Stack size for wpa_supplicant iface workqueue"


### PR DESCRIPTION
Based on few tests, it was observed that WPA supplicant's maximum usage for connection and disconnection is 4360.

This would save ~4K which is huge as we have a crunch for RAM.

This was missed when hostap was upstreamed from NCS.