### PR TITLE
dts: arm: st: u0: usb_fs_phy was erroneously placed under soc

### DIFF
--- a/dts/arm/st/u0/stm32u073.dtsi
+++ b/dts/arm/st/u0/stm32u073.dtsi
@@ -59,11 +59,6 @@
 			clocks = <&rcc STM32_CLOCK(APB1, 13U)>;
 			status = "disabled";
 		};
-
-		usb_fs_phy: usbphy {
-			compatible = "usb-nop-xceiv";
-			#phy-cells = <0>;
-		};
 	};
 
 	sram1: memory@20000000 {
@@ -74,5 +69,10 @@
 	sram2: memory@20008000 {
 		compatible = "zephyr,memory-region", "mmio-sram";
 		zephyr,memory-region = "SRAM2";
+	};
+
+	usb_fs_phy: usbphy {
+		compatible = "usb-nop-xceiv";
+		#phy-cells = <0>;
 	};
 };


### PR DESCRIPTION
Fixes warning:

Warning (simple_bus_reg): /soc/usbphy: missing or empty reg/ranges property

Fixes #84880