### PR TITLE
MAINTAINERS: add mbolivar for devicetree

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -898,7 +898,9 @@ DFU:
     - dfu
 
 Devicetree:
-  status: odd fixes
+  status: maintained
+  maintainers:
+    - mbolivar
   collaborators:
     - decsny
     - galak


### PR DESCRIPTION
I was a devicetree maintainer for several years, but had to step away from the role for various reasons. I've received approval to resume this work at my current employer. Add myself to the maintainers list and restore the 'maintained' status of the subsystem.