### PR TITLE
dts: arm: nxp: RT10xx/11xx .dtsi Files: Remove flexram,bank-spec prop

### DIFF
--- a/dts/arm/nxp/nxp_rt1010.dtsi
+++ b/dts/arm/nxp/nxp_rt1010.dtsi
@@ -8,11 +8,6 @@
 
 &flexram {
 	flexram,num-ram-banks = <4>;
-	/* default fuse */
-	flexram,bank-spec = <FLEXRAM_OCRAM>,
-			     <FLEXRAM_OCRAM>,
-			     <FLEXRAM_DTCM>,
-			     <FLEXRAM_ITCM>;
 };
 
 &sysclk {

--- a/dts/arm/nxp/nxp_rt1015.dtsi
+++ b/dts/arm/nxp/nxp_rt1015.dtsi
@@ -12,11 +12,6 @@
 	/* Note: RT1015 has five flexram banks, but only 4 of the 5 can
 	 * be used at the same time, for a total of 128KB of RAM.
 	 */
-	flexram,bank-spec = <FLEXRAM_OCRAM>,
-			     <FLEXRAM_OCRAM>,
-			     <FLEXRAM_DTCM>,
-			     <FLEXRAM_DTCM>,
-			     <FLEXRAM_ITCM>;
 };
 
 &sysclk {

--- a/dts/arm/nxp/nxp_rt1020.dtsi
+++ b/dts/arm/nxp/nxp_rt1020.dtsi
@@ -9,15 +9,6 @@
 
 &flexram {
 	flexram,num-ram-banks = <8>;
-	/* default fuse */
-	flexram,bank-spec = <FLEXRAM_OCRAM>,
-			     <FLEXRAM_OCRAM>,
-			     <FLEXRAM_DTCM>,
-			     <FLEXRAM_DTCM>,
-			     <FLEXRAM_ITCM>,
-			     <FLEXRAM_ITCM>,
-			     <FLEXRAM_OCRAM>,
-			     <FLEXRAM_OCRAM>;
 };
 
 &sysclk {

--- a/dts/arm/nxp/nxp_rt1024.dtsi
+++ b/dts/arm/nxp/nxp_rt1024.dtsi
@@ -9,15 +9,6 @@
 
 &flexram {
 	flexram,num-ram-banks = <8>;
-	/* default fuse */
-	flexram,bank-spec = <FLEXRAM_OCRAM>,
-			     <FLEXRAM_OCRAM>,
-			     <FLEXRAM_DTCM>,
-			     <FLEXRAM_DTCM>,
-			     <FLEXRAM_ITCM>,
-			     <FLEXRAM_ITCM>,
-			     <FLEXRAM_OCRAM>,
-			     <FLEXRAM_OCRAM>;
 };
 
 &sysclk {

--- a/dts/arm/nxp/nxp_rt1050.dtsi
+++ b/dts/arm/nxp/nxp_rt1050.dtsi
@@ -7,23 +7,6 @@
 
 &flexram {
 	flexram,num-ram-banks = <16>;
-	/* default fuse */
-	flexram,bank-spec = <FLEXRAM_OCRAM>,
-			     <FLEXRAM_OCRAM>,
-			     <FLEXRAM_OCRAM>,
-			     <FLEXRAM_OCRAM>,
-			     <FLEXRAM_DTCM>,
-			     <FLEXRAM_DTCM>,
-			     <FLEXRAM_ITCM>,
-			     <FLEXRAM_ITCM>,
-			     <FLEXRAM_ITCM>,
-			     <FLEXRAM_ITCM>,
-			     <FLEXRAM_DTCM>,
-			     <FLEXRAM_DTCM>,
-			     <FLEXRAM_OCRAM>,
-			     <FLEXRAM_OCRAM>,
-			     <FLEXRAM_OCRAM>,
-			     <FLEXRAM_OCRAM>;
 };
 
 &ccm {

--- a/dts/arm/nxp/nxp_rt1060.dtsi
+++ b/dts/arm/nxp/nxp_rt1060.dtsi
@@ -16,23 +16,6 @@
 	};
 
 	flexram,num-ram-banks = <16>;
-	/* default fuse */
-	flexram,bank-spec = <FLEXRAM_OCRAM>,
-			     <FLEXRAM_OCRAM>,
-			     <FLEXRAM_OCRAM>,
-			     <FLEXRAM_OCRAM>,
-			     <FLEXRAM_DTCM>,
-			     <FLEXRAM_DTCM>,
-			     <FLEXRAM_ITCM>,
-			     <FLEXRAM_ITCM>,
-			     <FLEXRAM_ITCM>,
-			     <FLEXRAM_ITCM>,
-			     <FLEXRAM_DTCM>,
-			     <FLEXRAM_DTCM>,
-			     <FLEXRAM_OCRAM>,
-			     <FLEXRAM_OCRAM>,
-			     <FLEXRAM_OCRAM>,
-			     <FLEXRAM_OCRAM>;
 };
 
 &ccm {

--- a/dts/arm/nxp/nxp_rt1064.dtsi
+++ b/dts/arm/nxp/nxp_rt1064.dtsi
@@ -9,23 +9,6 @@
 
 &flexram {
 	flexram,num-ram-banks = <16>;
-	/* default fuse */
-	flexram,bank-spec = <FLEXRAM_OCRAM>,
-			     <FLEXRAM_OCRAM>,
-			     <FLEXRAM_OCRAM>,
-			     <FLEXRAM_OCRAM>,
-			     <FLEXRAM_DTCM>,
-			     <FLEXRAM_DTCM>,
-			     <FLEXRAM_ITCM>,
-			     <FLEXRAM_ITCM>,
-			     <FLEXRAM_ITCM>,
-			     <FLEXRAM_ITCM>,
-			     <FLEXRAM_DTCM>,
-			     <FLEXRAM_DTCM>,
-			     <FLEXRAM_OCRAM>,
-			     <FLEXRAM_OCRAM>,
-			     <FLEXRAM_OCRAM>,
-			     <FLEXRAM_OCRAM>;
 };
 
 &flexspi2 {

--- a/dts/arm/nxp/nxp_rt11xx_cm7.dtsi
+++ b/dts/arm/nxp/nxp_rt11xx_cm7.dtsi
@@ -34,23 +34,6 @@
 			flexram,bank-size = <32>;
 			flexram,num-ram-banks = <16>;
 			flexram,has-magic-addr;
-			/* same as default fuse value */
-			flexram,bank-spec = <FLEXRAM_DTCM>,
-					     <FLEXRAM_DTCM>,
-					     <FLEXRAM_DTCM>,
-					     <FLEXRAM_DTCM>,
-					     <FLEXRAM_ITCM>,
-					     <FLEXRAM_ITCM>,
-					     <FLEXRAM_ITCM>,
-					     <FLEXRAM_ITCM>,
-					     <FLEXRAM_DTCM>,
-					     <FLEXRAM_DTCM>,
-					     <FLEXRAM_DTCM>,
-					     <FLEXRAM_DTCM>,
-					     <FLEXRAM_ITCM>,
-					     <FLEXRAM_ITCM>,
-					     <FLEXRAM_ITCM>,
-					     <FLEXRAM_ITCM>;
 
 			itcm: itcm@0 {
 				compatible = "zephyr,memory-region", "nxp,imx-itcm";

--- a/dts/bindings/memory-controllers/nxp,flexram.yaml
+++ b/dts/bindings/memory-controllers/nxp,flexram.yaml
@@ -1,7 +1,44 @@
 # Copyright 2023 NXP
 # SPDX-License-Identifier: Apache-2.0
 
-description: NXP FlexRAM on-chip ram controller
+description: |
+  NXP FlexRAM on-chip ram controller
+  If the flexram,bank-spec property is specified, then the flexram will be
+  dynamically reconfigured to the configuration specified at runtime. An
+  example to configure the flexram dynamically using the
+  flexram,bank-spec property for rt1060 is as follows:
+
+  &itcm {
+          reg = < 0x0 DT_SIZE_K(64) >;
+  };
+  &dtcm {
+          reg = < 0x20000000 DT_SIZE_K(384) >;
+  };
+  &ocram {
+          reg = < 0x20280000 DT_SIZE_K(64) >;
+  };
+  &flexram {
+          flexram,bank-spec = <FLEXRAM_OCRAM>,
+                              <FLEXRAM_OCRAM>,
+                              <FLEXRAM_DTCM>,
+                              <FLEXRAM_DTCM>,
+                              <FLEXRAM_DTCM>,
+                              <FLEXRAM_DTCM>,
+                              <FLEXRAM_DTCM>,
+                              <FLEXRAM_DTCM>,
+                              <FLEXRAM_ITCM>,
+                              <FLEXRAM_ITCM>,
+                              <FLEXRAM_DTCM>,
+                              <FLEXRAM_DTCM>,
+                              <FLEXRAM_DTCM>,
+                              <FLEXRAM_DTCM>,
+                              <FLEXRAM_DTCM>,
+                              <FLEXRAM_DTCM>;
+  };
+
+  This will configure the flexram for 384K of DTCM, 64K of ITCM,
+  and 64K of OCRAM.
+
 
 include: base.yaml
 

--- a/samples/boards/nxp/mimxrt1170_evk_cm7/magic_addr/boards/mimxrt1170_evk_mimxrt1176_cm7_A.overlay
+++ b/samples/boards/nxp/mimxrt1170_evk_cm7/magic_addr/boards/mimxrt1170_evk_mimxrt1176_cm7_A.overlay
@@ -1,0 +1,19 @@
+/* default fuse */
+&flexram {
+	flexram,bank-spec = <FLEXRAM_DTCM>,
+			    <FLEXRAM_DTCM>,
+			    <FLEXRAM_DTCM>,
+			    <FLEXRAM_DTCM>,
+			    <FLEXRAM_ITCM>,
+			    <FLEXRAM_ITCM>,
+			    <FLEXRAM_ITCM>,
+			    <FLEXRAM_ITCM>,
+			    <FLEXRAM_DTCM>,
+			    <FLEXRAM_DTCM>,
+			    <FLEXRAM_DTCM>,
+			    <FLEXRAM_DTCM>,
+			    <FLEXRAM_ITCM>,
+			    <FLEXRAM_ITCM>,
+			    <FLEXRAM_ITCM>,
+			    <FLEXRAM_ITCM>;
+};


### PR DESCRIPTION
This commit removes the flexram,bank-spec property from dtsi files. The property causes flexram to be dynamically configured based on the configuration in flexram,bank-spec. 

This is a problem for 2 reasons: 1) The FlexRAM will always be dynamically reconfigured to default fuse configuration. This is unnecessary if using default fuses. 2) If a user decides to program fuses. The FlexRAM will still be reconfigured to the default fuse configuration.

Modify description in the binding to show how to use the property at:
dts/bindings/memory-controllers/nxp,flexram.yaml

Added board overlay to mimxrt1170_evk_cm7 magic_addr:
samples/boards/nxp/mimxrt1170_evk_cm7/magic_addr/boards