### PR TITLE
devicetree: add phandles support for chosen properties

### DIFF
--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -4362,7 +4362,7 @@ function(dt_has_chosen var)
     endif()
   endforeach()
 
-  get_target_property(exists devicetree_target "DT_CHOSEN|${DT_CHOSEN_PROPERTY}")
+  get_target_property(exists devicetree_target "DT_CHOSEN|${DT_CHOSEN_PROPERTY}-0")
 
   if(${exists} STREQUAL exists-NOTFOUND)
     set(${var} FALSE PARENT_SCOPE)
@@ -4374,7 +4374,7 @@ endfunction()
 # Usage:
 #   dt_chosen(<var> PROPERTY <prop>)
 #
-# Get a node path for a /chosen node property.
+# Get path of the 1st node in a /chosen node property.
 #
 # The node's path will be returned in the <var> parameter. The
 # variable will be left undefined if the chosen node does not exist.
@@ -4397,7 +4397,7 @@ function(dt_chosen var)
     endif()
   endforeach()
 
-  get_target_property(${var} devicetree_target "DT_CHOSEN|${DT_CHOSEN_PROPERTY}")
+  get_target_property(${var} devicetree_target "DT_CHOSEN|${DT_CHOSEN_PROPERTY}-0")
 
   if(${${var}} STREQUAL ${var}-NOTFOUND)
     set(${var} PARENT_SCOPE)

--- a/include/zephyr/devicetree.h
+++ b/include/zephyr/devicetree.h
@@ -2909,9 +2909,9 @@
  * This is only valid to call if `DT_HAS_CHOSEN(prop)` is 1.
  * @param prop lowercase-and-underscores property name for
  *             the /chosen node
- * @return a node identifier for the chosen node property
+ * @return a node identifier for the 1st node of the chosen property
  */
-#define DT_CHOSEN(prop) DT_CAT(DT_CHOSEN_, prop)
+#define DT_CHOSEN(prop) DT_CAT3(DT_CHOSEN_, prop, _0)
 
 /**
  * @brief Test if the devicetree has a `/chosen` node
@@ -2919,8 +2919,63 @@
  * @return 1 if the chosen property exists and refers to a node,
  *         0 otherwise
  */
-#define DT_HAS_CHOSEN(prop) IS_ENABLED(DT_CAT3(DT_CHOSEN_, prop, _EXISTS))
+#define DT_HAS_CHOSEN(prop) IS_ENABLED(DT_CAT4(DT_CHOSEN_, prop, _0, _EXISTS))
 
+/**
+ * @brief Get a node identifier for a `/chosen` node property at an index.
+ *
+ * When a `/chosen` node's value at a logical index contains a phandle, this
+ * macro returns a node identifier for the node with that phandle.
+ *
+ * Example devicetree fragment:
+ *
+ * @code{.dts}
+ *     chosen {
+ *             zephyr,foo = <&n2 &n3>;
+ *     };
+ *
+ *     n2: node-2 { ... };
+ *     n3: node-3 { ... };
+ * @endcode
+ *
+ * Above, `zephyr,foo` chosen property has two elements:
+ *
+ * - index 0 has phandle `&n2`, which is `node-2`'s phandle
+ * - index 1 has phandle `&n3`, which is `node-3`'s phandle
+ *
+ * Example usage:
+ *
+ * @code{.c}
+ *
+ *     DT_CHOSEN_NODE_BY_IDX(zephyr_foo, 0) // node identifier for node-2
+ *     DT_CHOSEN_NODE_BY_IDX(zephyr_foo, 1) // node identifier for node-3
+ * @endcode
+ *
+ * This is only valid to call if `DT_CHOSEN_HAS_NODE_IDX(prop, idx)` is 1.
+ * @param prop lowercase-and-underscores `/chosen` node property name
+ * @param idx index into @p prop
+ * @return node identifier for the node with the phandle at that index
+ */
+#define DT_CHOSEN_NODE_BY_IDX(prop, idx) DT_CAT3(DT_CHOSEN_, prop, _##idx)
+
+/**
+ * @brief Test if @p prop of devicetree `/chosen` node has phandle of index @p idx
+ * @param prop lowercase-and-underscores devicetree property
+ * @param idx index into @p prop
+ * @return 1 if phandle of index idx of chosen property exists and refers to a node,
+ *         0 otherwise
+ */
+#define DT_CHOSEN_HAS_NODE_IDX(prop, idx) IS_ENABLED(DT_CAT4(DT_CHOSEN_, prop, _##idx, _EXISTS))
+
+/**
+ * @brief Get number of phandles assigned to @p prop of devicetree `/chosen` node
+ * @param prop lowercase-and-underscores devicetree property
+ * @return number of phandles of `/chosen` node property
+ */
+#define DT_CHOSEN_NODES_NBR(prop)                                                                  \
+	COND_CODE_1(DT_HAS_CHOSEN(prop),                                                           \
+		    (DT_CAT3(DT_CHOSEN_, prop, _NODES_NBR)),                                       \
+		    (0))
 /**
  * @}
  */

--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -881,9 +881,12 @@ def write_chosen(edt: edtlib.EDT):
 
     out_comment("Chosen nodes\n")
     chosen = {}
-    for name, node in edt.chosen_nodes.items():
-        chosen[f"DT_CHOSEN_{str2ident(name)}"] = f"DT_{node.z_path_id}"
-        chosen[f"DT_CHOSEN_{str2ident(name)}_EXISTS"] = 1
+    for name, prop_nodes_list in edt.chosen_props_nodes.items():
+        chosen[f"DT_CHOSEN_{str2ident(name)}_NODES_NBR"] = len(prop_nodes_list)
+        for node_index, node in enumerate(prop_nodes_list):
+            chosen[f"DT_CHOSEN_{str2ident(name)}_{node_index}"] = f"DT_{node.z_path_id}"
+            chosen[f"DT_CHOSEN_{str2ident(name)}_{node_index}_EXISTS"] = 1
+
     max_len = max(map(len, chosen), default=0)
     for macro, value in chosen.items():
         out_define(macro, value, width=max_len)

--- a/scripts/dts/gen_dts_cmake.py
+++ b/scripts/dts/gen_dts_cmake.py
@@ -100,10 +100,10 @@ def main():
     # macros.bnf for C macros.
 
     cmake_props = []
-    chosen_nodes = edt.chosen_nodes
-    for node in chosen_nodes:
-        path = chosen_nodes[node].path
-        cmake_props.append(f'"DT_CHOSEN|{node}" "{path}"')
+    chosen_nodes = edt.chosen_props_nodes
+    for prop_name in chosen_nodes:
+        for index, node in enumerate(chosen_nodes[prop_name]):
+            cmake_props.append(f'"DT_CHOSEN|{prop_name}-{index}" "{node.path}"')
 
     # The separate loop over edt.nodes here is meant to keep
     # all of the alias-related properties in one place.


### PR DESCRIPTION
This PR adds the necessary Python code to parse chosen properties that have multiple phandles as a value.
Also adds DeviceTree macros to get node at an index from a chosen property.
Other chosen properties are treated as if they are of type Phandles with 1 element, and as such, a '0' index is appended to them in generated DeviceTree header and CMake DTS data.

This will be usefull for adding LVGL multi-display support (#83567) and being able to get the display devices and their number from DT directly to create the buffers statically for all displays.