### PR TITLE
MAX32 Add OpenOCD Erase Support

### DIFF
--- a/boards/adi/apard32690/board.cmake
+++ b/boards/adi/apard32690/board.cmake
@@ -1,9 +1,8 @@
-# Copyright (c) 2024 Analog Devices, Inc.
+# Copyright (c) 2024-2025 Analog Devices, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(openocd --cmd-pre-init "source [find interface/cmsis-dap.cfg]")
-board_runner_args(openocd --cmd-pre-init "source [find target/max32690.cfg]")
 board_runner_args(jlink "--device=MAX32690" "--reset-after-load")
 
+include(${ZEPHYR_BASE}/boards/common/openocd-adi-max32.boards.cmake)
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/adi/apard32690/doc/index.rst
+++ b/boards/adi/apard32690/doc/index.rst
@@ -190,7 +190,8 @@ SWD port. SWD debug can be accessed through the Cortex 10-pin connector, P9.
 Logic levels are either 1.8V or 3.3V (based on P51 selection).
 
 Once the debug probe is connected to your host computer, then you can simply run the
-``west flash`` command to write a firmware image into flash.
+``west flash`` command to write a firmware image into flash. To perform a full erase,
+pass the ``--erase`` option when executing ``west flash``.
 
 .. note::
 

--- a/boards/adi/max32655evkit/board.cmake
+++ b/boards/adi/max32655evkit/board.cmake
@@ -1,9 +1,8 @@
-# Copyright (c) 2023-2024 Analog Devices, Inc.
+# Copyright (c) 2023-2025 Analog Devices, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(openocd --cmd-pre-init "source [find interface/cmsis-dap.cfg]")
-board_runner_args(openocd --cmd-pre-init "source [find target/max32655.cfg]")
 board_runner_args(jlink "--device=MAX32655" "--reset-after-load")
 
+include(${ZEPHYR_BASE}/boards/common/openocd-adi-max32.boards.cmake)
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/adi/max32655evkit/doc/index.rst
+++ b/boards/adi/max32655evkit/doc/index.rst
@@ -169,7 +169,8 @@ SWD port. SWD debug can be accessed through the Cortex 10-pin connector, JH3.
 Logic levels are fixed to VDDIO (1.8V).
 
 Once the debug probe is connected to your host computer, then you can simply run the
-``west flash`` command to write a firmware image into flash.
+``west flash`` command to write a firmware image into flash. To perform a full erase,
+pass the ``--erase`` option when executing ``west flash``.
 
 .. note::
 

--- a/boards/adi/max32655fthr/board.cmake
+++ b/boards/adi/max32655fthr/board.cmake
@@ -1,7 +1,5 @@
-# Copyright (c) 2023-2024 Analog Devices, Inc.
+# Copyright (c) 2023-2025 Analog Devices, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(openocd --cmd-pre-init "source [find interface/cmsis-dap.cfg]")
-board_runner_args(openocd --cmd-pre-init "source [find target/max32655.cfg]")
-
+include(${ZEPHYR_BASE}/boards/common/openocd-adi-max32.boards.cmake)
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)

--- a/boards/adi/max32655fthr/doc/index.rst
+++ b/boards/adi/max32655fthr/doc/index.rst
@@ -191,7 +191,8 @@ The MAX32625 microcontroller on the board is flashed with DAPLink firmware at th
 It allows debugging and flashing the MAX32655 Arm Core over USB.
 
 Once the USB cable is connected to your host computer, then you can simply run the
-``west flash`` command to write a firmware image into flash.
+``west flash`` command to write a firmware image into flash. To perform a full erase,
+pass the ``--erase`` option when executing ``west flash``.
 
 Debugging
 =========

--- a/boards/adi/max32662evkit/board.cmake
+++ b/boards/adi/max32662evkit/board.cmake
@@ -1,9 +1,8 @@
-# Copyright (c) 2024 Analog Devices, Inc.
+# Copyright (c) 2024-2025 Analog Devices, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(openocd --cmd-pre-init "source [find interface/cmsis-dap.cfg]")
-board_runner_args(openocd --cmd-pre-init "source [find target/max32662.cfg]")
 board_runner_args(jlink "--device=MAX32662" "--reset-after-load")
 
+include(${ZEPHYR_BASE}/boards/common/openocd-adi-max32.boards.cmake)
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/adi/max32662evkit/doc/index.rst
+++ b/boards/adi/max32662evkit/doc/index.rst
@@ -212,7 +212,8 @@ the UART1A port can also be accessed through J3.
 
 
 Once the debug probe is connected to your host computer, then you can simply run the
-``west flash`` command to write a firmware image into flash.
+``west flash`` command to write a firmware image into flash. To perform a full erase,
+pass the ``--erase`` option when executing ``west flash``.
 
 .. note::
 

--- a/boards/adi/max32666evkit/board.cmake
+++ b/boards/adi/max32666evkit/board.cmake
@@ -1,9 +1,8 @@
-# Copyright (c) 2024 Analog Devices, Inc.
+# Copyright (c) 2024-2025 Analog Devices, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(openocd --cmd-pre-init "source [find interface/cmsis-dap.cfg]")
-board_runner_args(openocd --cmd-pre-init "source [find target/max32665.cfg]")
 board_runner_args(jlink "--device=MAX32666" "--reset-after-load")
 
+include(${ZEPHYR_BASE}/boards/common/openocd-adi-max32.boards.cmake)
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/adi/max32666evkit/doc/index.rst
+++ b/boards/adi/max32666evkit/doc/index.rst
@@ -296,7 +296,8 @@ SWD port. SWD debug can be accessed through the Cortex 10-pin connector, J6.
 Logic levels are fixed to VDDIOH (1.8V or 3.3V).
 
 Once the debug probe is connected to your host computer, then you can simply run the
-``west flash`` command to write a firmware image into flash.
+``west flash`` command to write a firmware image into flash. To perform a full erase,
+pass the ``--erase`` option when executing ``west flash``.
 
 .. note::
 

--- a/boards/adi/max32666fthr/board.cmake
+++ b/boards/adi/max32666fthr/board.cmake
@@ -1,9 +1,8 @@
-# Copyright (c) 2023-2024 Analog Devices, Inc.
+# Copyright (c) 2023-2025 Analog Devices, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(openocd --cmd-pre-init "source [find interface/cmsis-dap.cfg]")
-board_runner_args(openocd --cmd-pre-init "source [find target/max32665.cfg]")
 board_runner_args(jlink "--device=MAX32666" "--reset-after-load")
 
+include(${ZEPHYR_BASE}/boards/common/openocd-adi-max32.boards.cmake)
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/adi/max32666fthr/doc/index.rst
+++ b/boards/adi/max32666fthr/doc/index.rst
@@ -216,7 +216,8 @@ SWD debug can be accessed through the Cortex 10-pin connector, JH2.
 Logic levels are fixed to VDDIO (1.8V).
 
 Once the debug probe is connected to your host computer, then you can simply run the
-``west flash`` command to write a firmware image into flash.
+``west flash`` command to write a firmware image into flash. To perform a full erase,
+pass the ``--erase`` option when executing ``west flash``.
 
 .. note::
 

--- a/boards/adi/max32670evkit/board.cmake
+++ b/boards/adi/max32670evkit/board.cmake
@@ -1,7 +1,5 @@
-# Copyright (c) 2024 Analog Devices, Inc.
+# Copyright (c) 2024-2025 Analog Devices, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(openocd --cmd-pre-init "source [find interface/cmsis-dap.cfg]")
-board_runner_args(openocd --cmd-pre-init "source [find target/max32670.cfg]")
-
+include(${ZEPHYR_BASE}/boards/common/openocd-adi-max32.boards.cmake)
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)

--- a/boards/adi/max32670evkit/doc/index.rst
+++ b/boards/adi/max32670evkit/doc/index.rst
@@ -185,7 +185,8 @@ The MAX32670 EVKIT integrates a MAX32625PICO based debugger for DAPLink function
 
 
 Once the debug probe is connected to your host computer, then you can simply run the
-``west flash`` command to write a firmware image into flash.
+``west flash`` command to write a firmware image into flash. To perform a full erase,
+pass the ``--erase`` option when executing ``west flash``.
 
 Debugging
 =========

--- a/boards/adi/max32672evkit/board.cmake
+++ b/boards/adi/max32672evkit/board.cmake
@@ -1,9 +1,8 @@
-# Copyright (c) 2024 Analog Devices, Inc.
+# Copyright (c) 2024-2025 Analog Devices, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(openocd --cmd-pre-init "source [find interface/cmsis-dap.cfg]")
-board_runner_args(openocd --cmd-pre-init "source [find target/max32672.cfg]")
 board_runner_args(jlink "--device=MAX32672" "--reset-after-load")
 
+include(${ZEPHYR_BASE}/boards/common/openocd-adi-max32.boards.cmake)
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/adi/max32672evkit/doc/index.rst
+++ b/boards/adi/max32672evkit/doc/index.rst
@@ -327,7 +327,8 @@ is supplied externally. Be sure to remove jumper JP15 (LDO_DUT_EN) to disconnect
 LDO if supplying VDD and VDDA externally.
 
 Once the debug probe is connected to your host computer, then you can simply run the
-``west flash`` command to write a firmware image into flash.
+``west flash`` command to write a firmware image into flash. To perform a full erase,
+pass the ``--erase`` option when executing ``west flash``.
 
 .. note::
 

--- a/boards/adi/max32672fthr/board.cmake
+++ b/boards/adi/max32672fthr/board.cmake
@@ -1,7 +1,5 @@
-# Copyright (c) 2024 Analog Devices, Inc.
+# Copyright (c) 2024-2025 Analog Devices, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(openocd --cmd-pre-init "source [find interface/cmsis-dap.cfg]")
-board_runner_args(openocd --cmd-pre-init "source [find target/max32672.cfg]")
-
+include(${ZEPHYR_BASE}/boards/common/openocd-adi-max32.boards.cmake)
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)

--- a/boards/adi/max32672fthr/doc/index.rst
+++ b/boards/adi/max32672fthr/doc/index.rst
@@ -204,7 +204,8 @@ The MAX32625 microcontroller on the board is flashed with DAPLink firmware at th
 It allows debugging and flashing the MAX32672 Arm Core over USB.
 
 Once the debug probe is connected to your host computer, then you can simply run the
-``west flash`` command to write a firmware image into flash.
+``west flash`` command to write a firmware image into flash. To perform a full erase,
+pass the ``--erase`` option when executing ``west flash``.
 
 Debugging
 =========

--- a/boards/adi/max32675evkit/board.cmake
+++ b/boards/adi/max32675evkit/board.cmake
@@ -1,9 +1,8 @@
-# Copyright (c) 2024 Analog Devices, Inc.
+# Copyright (c) 2024-2025 Analog Devices, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(openocd --cmd-pre-init "source [find interface/cmsis-dap.cfg]")
-board_runner_args(openocd --cmd-pre-init "source [find target/max32675.cfg]")
 board_runner_args(jlink "--device=MAX32675" "--reset-after-load")
 
+include(${ZEPHYR_BASE}/boards/common/openocd-adi-max32.boards.cmake)
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/adi/max32675evkit/doc/index.rst
+++ b/boards/adi/max32675evkit/doc/index.rst
@@ -379,7 +379,8 @@ is supplied externally. Be sure to remove jumper JP15 (LDO_DUT_EN) to disconnect
 the 3.3V LDO if supplying VDD and VDDA externally.
 
 Once the debug probe is connected to your host computer, then you can simply run the
-``west flash`` command to write a firmware image into flash.
+``west flash`` command to write a firmware image into flash. To perform a full erase,
+pass the ``--erase`` option when executing ``west flash``.
 
 .. note::
 

--- a/boards/adi/max32680evkit/board.cmake
+++ b/boards/adi/max32680evkit/board.cmake
@@ -1,7 +1,5 @@
-# Copyright (c) 2024 Analog Devices, Inc.
+# Copyright (c) 2024-2025 Analog Devices, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(openocd --cmd-pre-init "source [find interface/cmsis-dap.cfg]")
-board_runner_args(openocd --cmd-pre-init "source [find target/max32680.cfg]")
-
+include(${ZEPHYR_BASE}/boards/common/openocd-adi-max32.boards.cmake)
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)

--- a/boards/adi/max32680evkit/doc/index.rst
+++ b/boards/adi/max32680evkit/doc/index.rst
@@ -327,7 +327,8 @@ SWD port. SWD debug can be accessed through the Cortex 10-pin connector, JH10.
 Logic levels are set to 1.8V (VDDIO_AUX).
 
 Once the debug probe is connected to your host computer, then you can simply run the
-``west flash`` command to write a firmware image into flash.
+``west flash`` command to write a firmware image into flash. To perform a full erase,
+pass the ``--erase`` option when executing ``west flash``.
 
 Debugging
 =========

--- a/boards/adi/max32690evkit/board.cmake
+++ b/boards/adi/max32690evkit/board.cmake
@@ -1,9 +1,8 @@
-# Copyright (c) 2023-2024 Analog Devices, Inc.
+# Copyright (c) 2023-2025 Analog Devices, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(openocd --cmd-pre-init "source [find interface/cmsis-dap.cfg]")
-board_runner_args(openocd --cmd-pre-init "source [find target/max32690.cfg]")
 board_runner_args(jlink "--device=MAX32690" "--reset-after-load")
 
+include(${ZEPHYR_BASE}/boards/common/openocd-adi-max32.boards.cmake)
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/adi/max32690evkit/doc/index.rst
+++ b/boards/adi/max32690evkit/doc/index.rst
@@ -284,7 +284,8 @@ SWD port. SWD debug can be accessed through the Cortex 10-pin connector, J3.
 Logic levels are fixed to VDDIO (1.8V).
 
 Once the debug probe is connected to your host computer, then you can simply run the
-``west flash`` command to write a firmware image into flash.
+``west flash`` command to write a firmware image into flash. To perform a full erase,
+pass the ``--erase`` option when executing ``west flash``.
 
 .. note::
 

--- a/boards/adi/max32690fthr/board.cmake
+++ b/boards/adi/max32690fthr/board.cmake
@@ -1,9 +1,8 @@
 # Copyright (c) 2023-2024 Analog Devices, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(openocd --cmd-pre-init "source [find interface/cmsis-dap.cfg]")
-board_runner_args(openocd --cmd-pre-init "source [find target/max32690.cfg]")
 board_runner_args(jlink "--device=MAX32690" "--reset-after-load")
 
+include(${ZEPHYR_BASE}/boards/common/openocd-adi-max32.boards.cmake)
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/adi/max32690fthr/doc/index.rst
+++ b/boards/adi/max32690fthr/doc/index.rst
@@ -97,7 +97,8 @@ Logic levels are fixed to VDDIO (1.8V).
 
 Once the debug probe is connected to your host computer, then you can run the
 ``west flash`` command to write a firmware image into flash. Here is an example
-for the :zephyr:code-sample:`hello_world` application.
+for the :zephyr:code-sample:`hello_world` application. To perform a full erase,
+pass the ``--erase`` option when executing ``west flash``.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/hello_world

--- a/boards/adi/max78000evkit/board.cmake
+++ b/boards/adi/max78000evkit/board.cmake
@@ -1,9 +1,8 @@
 # Copyright (c) 2025 Analog Devices, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(openocd --cmd-pre-init "source [find interface/cmsis-dap.cfg]")
-board_runner_args(openocd --cmd-pre-init "source [find target/max78000.cfg]")
 board_runner_args(jlink "--device=MAX78000" "--reset-after-load")
 
+include(${ZEPHYR_BASE}/boards/common/openocd-adi-max32.boards.cmake)
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/adi/max78000evkit/doc/index.rst
+++ b/boards/adi/max78000evkit/doc/index.rst
@@ -283,7 +283,8 @@ SWD port. SWD debug can be accessed through the Cortex 10-pin connector, JH5.
 Logic levels are fixed to VDDIO (1.8V).
 
 Once the debug probe is connected to your host computer, then you can simply run the
-``west flash`` command to write a firmware image into flash.
+``west flash`` command to write a firmware image into flash. To perform a full erase,
+pass the ``--erase`` option when executing ``west flash``.
 
 .. note::
 

--- a/boards/adi/max78000fthr/board.cmake
+++ b/boards/adi/max78000fthr/board.cmake
@@ -1,7 +1,5 @@
 # Copyright (c) 2025 Analog Devices, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(openocd --cmd-pre-init "source [find interface/cmsis-dap.cfg]")
-board_runner_args(openocd --cmd-pre-init "source [find target/max78000.cfg]")
-
+include(${ZEPHYR_BASE}/boards/common/openocd-adi-max32.boards.cmake)
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)

--- a/boards/adi/max78000fthr/doc/index.rst
+++ b/boards/adi/max78000fthr/doc/index.rst
@@ -185,7 +185,8 @@ The MAX32625 microcontroller on the board is preprogrammed with DAPLink firmware
 It allows debugging and programming of the MAX78000 Arm core over USB.
 
 Once the debug probe is connected to your host computer, then you can simply run the
-``west flash`` command to write a firmware image into flash.
+``west flash`` command to write a firmware image into flash. To perform a full erase,
+pass the ``--erase`` option when executing ``west flash``.
 
 .. note::
 

--- a/boards/adi/max78002evkit/board.cmake
+++ b/boards/adi/max78002evkit/board.cmake
@@ -1,9 +1,8 @@
-# Copyright (c) 2024 Analog Devices, Inc.
+# Copyright (c) 2024-2025 Analog Devices, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(openocd --cmd-pre-init "source [find interface/cmsis-dap.cfg]")
-board_runner_args(openocd --cmd-pre-init "source [find target/max78002.cfg]")
 board_runner_args(jlink "--device=MAX78002" "--reset-after-load")
 
+include(${ZEPHYR_BASE}/boards/common/openocd-adi-max32.boards.cmake)
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/adi/max78002evkit/doc/index.rst
+++ b/boards/adi/max78002evkit/doc/index.rst
@@ -450,7 +450,8 @@ SWD port. SWD debug can be accessed through the Cortex 10-pin connector, JH8.
 Logic levels are fixed to VDDIO (1.8V).
 
 Once the debug probe is connected to your host computer, then you can simply run the
-``west flash`` command to write a firmware image into flash.
+``west flash`` command to write a firmware image into flash. To perform a full erase,
+pass the ``--erase`` option when executing ``west flash``.
 
 .. note::
 

--- a/boards/common/openocd-adi-max32.boards.cmake
+++ b/boards/common/openocd-adi-max32.boards.cmake
@@ -1,0 +1,36 @@
+#
+# Copyright (c) 2025 Analog Devices, Inc
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Default cmsis-dap, it will be overwritten below if requires
+set(MAX32_INTERFACE_CFG "cmsis-dap.cfg")
+
+if(CONFIG_SOC_MAX32655_M4)
+  set(MAX32_TARGET_CFG "max32655.cfg")
+elseif(CONFIG_SOC_MAX32662)
+  set(MAX32_TARGET_CFG "max32662.cfg")
+elseif(CONFIG_SOC_MAX32666)
+  set(MAX32_TARGET_CFG "max32665.cfg")
+elseif(CONFIG_SOC_MAX32670)
+  set(MAX32_TARGET_CFG "max32670.cfg")
+elseif(CONFIG_SOC_MAX32672)
+  set(MAX32_TARGET_CFG "max32672.cfg")
+elseif(CONFIG_SOC_MAX32675)
+  set(MAX32_TARGET_CFG "max32675.cfg")
+elseif(CONFIG_SOC_MAX32680_M4)
+  set(MAX32_TARGET_CFG "max32680.cfg")
+elseif(CONFIG_SOC_MAX32690_M4)
+  set(MAX32_TARGET_CFG "max32690.cfg")
+elseif(CONFIG_SOC_MAX78000_M4)
+  set(MAX32_TARGET_CFG "max78000.cfg")
+elseif(CONFIG_SOC_MAX78002_M4)
+  set(MAX32_TARGET_CFG "max78002.cfg")
+endif()
+
+board_runner_args(openocd --cmd-pre-init "source [find interface/${MAX32_INTERFACE_CFG}]")
+board_runner_args(openocd --cmd-pre-init "source [find target/${MAX32_TARGET_CFG}]")
+
+if(CONFIG_SOC_FAMILY_MAX32_M4)
+  board_runner_args(openocd --cmd-pre-init "allow_low_pwr_dbg")
+endif()

--- a/boards/common/openocd-adi-max32.boards.cmake
+++ b/boards/common/openocd-adi-max32.boards.cmake
@@ -33,4 +33,5 @@ board_runner_args(openocd --cmd-pre-init "source [find target/${MAX32_TARGET_CFG
 
 if(CONFIG_SOC_FAMILY_MAX32_M4)
   board_runner_args(openocd --cmd-pre-init "allow_low_pwr_dbg")
+  board_runner_args(openocd "--cmd-erase=max32xxx mass_erase 0")
 endif()


### PR DESCRIPTION
First commit centralize MAX32 openOCD configuration
Second commit add erase support for MAX32 MCUs. As it be enabled by  https://github.com/zephyrproject-rtos/zephyr/pull/83516

Usage: 
`west flash --erase`


See: **max32xxx mass erase complete** below output
```
C:\Users\sozer\zephyrproject\zephyr>west flash --skip-rebuild --erase    
-- west flash: using runner openocd
-- runners.openocd: mass erase requested
-- runners.openocd: Flashing file: C:/Users/sozer/zephyrproject/zephyr/build/zephyr/zephyr.hex
Open On-Chip Debugger (Analog Devices Build-96)  OpenOCD 0.12.0 (2024-12-16-15:08)
Licensed under GNU GPL v2
Report bugs to <processor.tools.support@analog.com>
1
Info : CMSIS-DAP: SWD supported
Info : CMSIS-DAP: Atomic commands supported
Info : CMSIS-DAP: Test domain timer supported
Info : CMSIS-DAP: FW Version = 2.0.0
Info : CMSIS-DAP: Serial# = 0423170248a24e7000000000000000000000000097969906
Info : CMSIS-DAP: Interface Initialised (SWD)
Info : SWCLK/TCK = 1 SWDIO/TMS = 1 TDI = 0 TDO = 0 nTRST = 0 nRESET = 1
Info : CMSIS-DAP: Interface ready
Info : clock speed 2000 kHz
Info : SWD DPIDR 0x2ba01477
Enable debug to connect in low-power mode
Info : [max32xxx.cpu] Cortex-M4 r0p1 processor detected
Info : [max32xxx.cpu] target has 6 breakpoints, 4 watchpoints
Info : [max32xxx.cpu] Examination succeed
Info : starting gdb server for max32xxx.cpu on 3333
Info : Listening on port 3333 for gdb connections
    TargetName         Type       Endian TapName            State
--  ------------------ ---------- ------ ------------------ ------------
 0* max32xxx.cpu       cortex_m   little max32xxx.cpu       unknown
Enable debug to connect in low-power mode
[max32xxx.cpu] halted due to breakpoint, current mode: Thread
xPSR: 0x01000000 pc: 0x000001b4 msp: 0x20004000
max32xxx mass erase complete
wrote 22140 bytes from file C:/Users/sozer/zephyrproject/zephyr/build/zephyr/zephyr.hex in 0.829712s (26.059 KiB/s)
Enable debug to connect in low-power mode
shutdown command invoked
```