### PR TITLE
serial: xilinx: uartlite: update irq_enable to use DT_INST_IRQN_BY_IDX

### DIFF
--- a/drivers/serial/uart_xlnx_uartlite.c
+++ b/drivers/serial/uart_xlnx_uartlite.c
@@ -382,7 +382,7 @@ static DEVICE_API(uart, xlnx_uartlite_driver_api) = {
 			    xlnx_uartlite_isr,				\
 			    DEVICE_DT_INST_GET(n), 0);			\
 									\
-		irq_enable(DT_INST_IRQ_BY_IDX(n, i, irq));		\
+		irq_enable(DT_INST_IRQN_BY_IDX(n, i));			\
 	} while (false)
 #define XLNX_UARTLITE_CONFIG_FUNC(n)					\
 	static void xlnx_uartlite_config_func_##n(const struct device *dev) \


### PR DESCRIPTION
This pull request updates the irq_enable macro to use the DT_INST_IRQN_BY_IDX helper.
This ensures proper handling of IRQ numbers in systems with multi-level interrupt configurations.