### PR TITLE
mgmt: mcumgr: grp: img_mgmt: Fix calling confirm

### DIFF
--- a/subsys/mgmt/mcumgr/grp/img_mgmt/src/img_mgmt_state.c
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt/src/img_mgmt_state.c
@@ -388,11 +388,6 @@ img_mgmt_state_confirm(void)
 {
 	int rc;
 
-#if defined(CONFIG_MCUMGR_GRP_IMG_STATUS_HOOKS)
-	int32_t err_rc;
-	uint16_t err_group;
-#endif
-
 	/* Confirm disallowed if a test is pending. */
 	if (img_mgmt_state_any_pending()) {
 		rc = IMG_MGMT_ERR_IMAGE_ALREADY_PENDING;
@@ -402,8 +397,13 @@ img_mgmt_state_confirm(void)
 	rc = img_mgmt_write_confirmed();
 
 #if defined(CONFIG_MCUMGR_GRP_IMG_STATUS_HOOKS)
-	(void)mgmt_callback_notify(MGMT_EVT_OP_IMG_MGMT_DFU_CONFIRMED, NULL, 0, &err_rc,
-				   &err_group);
+	if (!rc) {
+		int32_t err_rc;
+		uint16_t err_group;
+
+		(void)mgmt_callback_notify(MGMT_EVT_OP_IMG_MGMT_DFU_CONFIRMED, NULL, 0, &err_rc,
+					   &err_group);
+	}
 #endif
 
 err:


### PR DESCRIPTION
Fixes calling the registered callbacks for image being confirmed if the confirmation was not successful

Fixes #84902