### PR TITLE
Add lpuart1 support on NXP FRDM MCX C242

### DIFF
--- a/boards/nxp/frdm_mcxc242/doc/index.rst
+++ b/boards/nxp/frdm_mcxc242/doc/index.rst
@@ -101,6 +101,10 @@ PORTB/GPIOB, PORTC/GPIOC, PORTD/GPIOD, and PORTE/GPIOE) for the FRDM-MCXC242 boa
 +-------+-------------+---------------------------+
 | PTA2  | LPUART0_TX  | UART Console              |
 +-------+-------------+---------------------------+
+| PTE1  | LPUART1_RX  | UART                      |
++-------+-------------+---------------------------+
+| PTE0  | LPUART1_TX  | UART                      |
++-------+-------------+---------------------------+
 | PTA20 | RESET       | RESET Button SW1          |
 +-------+-------------+---------------------------+
 | PTC1  | GPIO        | User button SW2           |

--- a/boards/nxp/frdm_mcxc242/frdm_mcxc242-pinctrl.dtsi
+++ b/boards/nxp/frdm_mcxc242/frdm_mcxc242-pinctrl.dtsi
@@ -16,6 +16,14 @@
 			slew-rate = "slow";
 		};
 	};
+	pinmux_lpuart1: pinmux_lpuart1 {
+		group0 {
+			pinmux = <LPUART1_RX_PTE1>,
+				<LPUART1_TX_PTE0>;
+			drive-strength = "low";
+			slew-rate = "slow";
+		};
+	};
 	pinmux_uart2: pinmux_uart2 {
 		group0 {
 			pinmux = <UART2_RX_PTD2>,

--- a/boards/nxp/frdm_mcxc242/frdm_mcxc242.dts
+++ b/boards/nxp/frdm_mcxc242/frdm_mcxc242.dts
@@ -122,6 +122,13 @@
 	pinctrl-names = "default";
 };
 
+&lpuart1 {
+	status = "okay";
+	current-speed = <115200>;
+	pinctrl-0 = <&pinmux_lpuart1>;
+	pinctrl-names = "default";
+};
+
 &uart2 {
 	status = "disabled";
 	current-speed = <115200>;


### PR DESCRIPTION
According to the quick start guide of the FRDM-MCXC242 board, lpuart1 shoud be avalaible on J3 Header pins 1 and 3 (PTE0/PTE1).
Enable and configure it in board dts.