### PR TITLE
drivers: gpio: npm2100: properly handle I2C write return value

### DIFF
--- a/drivers/gpio/gpio_npm2100.c
+++ b/drivers/gpio/gpio_npm2100.c
@@ -62,8 +62,8 @@ static int gpio_npm2100_port_set_masked_raw(const struct device *dev, gpio_port_
 
 	for (size_t idx = 0; idx < NPM2100_GPIO_PINS; idx++) {
 		if ((mask & BIT(idx)) != 0U) {
-			i2c_reg_write_byte_dt(&config->i2c, NPM2100_GPIO_OUTPUT + idx,
-					      !!(value & BIT(idx)));
+			ret = i2c_reg_write_byte_dt(&config->i2c, NPM2100_GPIO_OUTPUT + idx,
+						    !!(value & BIT(idx)));
 			if (ret != 0U) {
 				return ret;
 			}


### PR DESCRIPTION
properly check return code from i2c_reg_write_byte_dt effectively making it possible for gpio_npm2100_port_set_masked_raw to error out since:

if (ret != 0U) {
	return ret;
}

was dead code before this fix.

Fixes CID-444376
Fixes #84784