### PR TITLE
fs: ext2: Fix potential integer overflow in disk access size calculation

### DIFF
--- a/subsys/fs/ext2/ext2_disk_access.c
+++ b/subsys/fs/ext2/ext2_disk_access.c
@@ -23,7 +23,7 @@ static int64_t disk_access_device_size(struct ext2_data *fs)
 {
 	struct disk_data *disk = fs->backend;
 
-	return disk->sector_count * disk->sector_size;
+	return (uint64_t)disk->sector_count * (uint64_t)disk->sector_size;
 }
 
 static int64_t disk_access_write_size(struct ext2_data *fs)


### PR DESCRIPTION
Cast sector_count and sector_size to uint64_t to prevent potential integer overflow when calculating total device size in disk_access_device_size().

Fixes Coverity issue CID-322647
Fixes #84808