### PR TITLE
llext: fix symbol exporting for ET_REL

### DIFF
--- a/kernel/idle.c
+++ b/kernel/idle.c
@@ -8,6 +8,7 @@
 #include <zephyr/toolchain.h>
 #include <zephyr/linker/sections.h>
 #include <zephyr/drivers/timer/system_timer.h>
+#include <zephyr/llext/symbol.h>
 #include <zephyr/pm/pm.h>
 #include <stdbool.h>
 #include <zephyr/logging/log.h>
@@ -100,3 +101,4 @@ void __weak arch_spin_relax(void)
 
 	arch_nop();
 }
+EXPORT_SYMBOL(arch_spin_relax);

--- a/kernel/spinlock_validate.c
+++ b/kernel/spinlock_validate.c
@@ -5,6 +5,7 @@
  */
 #include <kernel_internal.h>
 #include <zephyr/spinlock.h>
+#include <zephyr/llext/symbol.h>
 
 bool z_spin_lock_valid(struct k_spinlock *l)
 {
@@ -17,6 +18,7 @@ bool z_spin_lock_valid(struct k_spinlock *l)
 	}
 	return true;
 }
+EXPORT_SYMBOL(z_spin_lock_valid);
 
 bool z_spin_unlock_valid(struct k_spinlock *l)
 {
@@ -33,15 +35,18 @@ bool z_spin_unlock_valid(struct k_spinlock *l)
 	}
 	return true;
 }
+EXPORT_SYMBOL(z_spin_unlock_valid);
 
 void z_spin_lock_set_owner(struct k_spinlock *l)
 {
 	l->thread_cpu = _current_cpu->id | (uintptr_t)_current;
 }
+EXPORT_SYMBOL(z_spin_lock_set_owner);
 
 #ifdef CONFIG_KERNEL_COHERENCE
 bool z_spin_lock_mem_coherent(struct k_spinlock *l)
 {
 	return arch_mem_coherent((void *)l);
 }
+EXPORT_SYMBOL(z_spin_lock_mem_coherent);
 #endif /* CONFIG_KERNEL_COHERENCE */

--- a/subsys/llext/llext_priv.h
+++ b/subsys/llext/llext_priv.h
@@ -65,6 +65,7 @@ static inline const char *llext_string(struct llext_loader *ldr, struct llext *e
 
 int llext_link(struct llext_loader *ldr, struct llext *ext,
 	       const struct llext_load_param *ldr_parm);
+ssize_t llext_file_offset(struct llext_loader *ldr, uintptr_t offset);
 void llext_dependency_remove_all(struct llext *ext);
 
 #endif /* ZEPHYR_SUBSYS_LLEXT_PRIV_H_ */


### PR DESCRIPTION
When building relocatable extensions, exported symbol names might end up in a separate section (in my case ".rodata.str1.1") for which storage address don't match section address. To access those names addresses have to be relalculated.