### PR TITLE
fs: ext2: Explicit int cast ret assignment in ext2_init_storage

### DIFF
--- a/subsys/fs/ext2/ext2_impl.c
+++ b/subsys/fs/ext2/ext2_impl.c
@@ -203,13 +203,13 @@ int ext2_init_storage(struct ext2_data **fsp, const void *storage_dev, int flags
 
 	dev_size = fs->backend_ops->get_device_size(fs);
 	if (dev_size < 0) {
-		ret = dev_size;
+		ret = (int)dev_size;
 		goto err;
 	}
 
 	write_size = fs->backend_ops->get_write_size(fs);
 	if (write_size < 0) {
-		ret = write_size;
+		ret = (int)write_size;
 		goto err;
 	}
 


### PR DESCRIPTION
Adds cast to int when ret is assigned error code returned by functions that return int64_t. The cast has been added to indicate that assignment with truncation is here intentional.

This PR is result of https://github.com/zephyrproject-rtos/zephyr/issues/84711, but is not considered bug fix as there is no issue as such.