### PR TITLE
tests: Bluetooth: BAP: Add deregister of services for unicast server

### DIFF
--- a/tests/bsim/bluetooth/audio/src/bap_unicast_server_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_unicast_server_test.c
@@ -471,6 +471,29 @@ static void init(void)
 	setup_connectable_adv(&ext_adv);
 }
 
+static void deinit(void)
+{
+	int err;
+
+	err = bt_bap_unicast_server_unregister_cb(&unicast_server_cb);
+	if (err != 0) {
+		FAIL("Failed to unregister unicast server callbacks (err %d)\n", err);
+		return;
+	}
+
+	err = bt_bap_unicast_server_unregister();
+	if (err != 0) {
+		FAIL("Failed to unregister unicast server (err %d)\n", err);
+		return;
+	}
+
+	err = bt_pacs_unregister();
+	if (err != 0) {
+		FAIL("Failed to unregister PACS (err %d)\n", err);
+		return;
+	}
+}
+
 static void test_main(void)
 {
 	init();
@@ -484,6 +507,8 @@ static void test_main(void)
 	WAIT_FOR_FLAG(flag_stream_started);
 	transceive_test_streams();
 	WAIT_FOR_UNSET_FLAG(flag_connected);
+
+	deinit();
 	PASS("Unicast server passed\n");
 }
 
@@ -540,6 +565,8 @@ static void test_main_acl_disconnect(void)
 	/* The client will reconnect */
 	WAIT_FOR_UNSET_FLAG(flag_connected);
 	WAIT_FOR_FLAG(flag_connected);
+
+	deinit();
 	PASS("Unicast server ACL disconnect  passed\n");
 }
 


### PR DESCRIPTION
Adds a deinit step that tests the unicast server callbacks, unicast server and pacs unregister.