### PR TITLE
samples: psa: add some configs

### DIFF
--- a/samples/psa/its/overlay-secure_storage.conf
+++ b/samples/psa/its/overlay-secure_storage.conf
@@ -3,6 +3,8 @@
 CONFIG_MBEDTLS=y
 CONFIG_MBEDTLS_PSA_CRYPTO_C=y
 
+CONFIG_PSA_WANT_ALG_ECB_NO_PADDING=y
+
 # The default stack size (1024) is not enough for the PSA Crypto core.
 # On top of that, the ITS implementation uses the stack for buffers.
 CONFIG_MAIN_STACK_SIZE=3072

--- a/samples/psa/its/sample.yaml
+++ b/samples/psa/its/sample.yaml
@@ -13,6 +13,8 @@ common:
 tests:
   sample.psa.its.tfm:
     filter: CONFIG_BUILD_WITH_TFM
+    extra_args:
+      - CONFIG_TFM_PROFILE_TYPE_NOT_SET=y
     tags:
       - trusted-firmware-m
   sample.psa.its.secure_storage.entropy_driver:

--- a/samples/psa/persistent_key/overlay-secure_storage.conf
+++ b/samples/psa/persistent_key/overlay-secure_storage.conf
@@ -3,6 +3,8 @@
 CONFIG_MBEDTLS=y
 CONFIG_MBEDTLS_PSA_CRYPTO_C=y
 
+CONFIG_PSA_WANT_ALG_ECB_NO_PADDING=y
+
 # The default stack size (1024) is not enough for the PSA Crypto core.
 # On top of that, the ITS implementation uses the stack for buffers.
 CONFIG_MAIN_STACK_SIZE=3072

--- a/samples/psa/persistent_key/sample.yaml
+++ b/samples/psa/persistent_key/sample.yaml
@@ -13,6 +13,8 @@ common:
 tests:
   sample.psa.persistent_key.tfm:
     filter: CONFIG_BUILD_WITH_TFM
+    extra_args:
+      - CONFIG_TFM_PROFILE_TYPE_NOT_SET=y
     tags:
       - trusted-firmware-m
   sample.psa.persistent_key.secure_storage.entropy_driver:


### PR DESCRIPTION
Set CONFIG_TFM_PROFILE_TYPE_NOT_SET when built with TF-M to ensure that default type is not changed.

Add ECB cipher support to overlay-secure_storage.conf.