### PR TITLE
drivers: sensor: kconfig: Explicitly add default trigger mode as none

### DIFF
--- a/drivers/sensor/Kconfig.trigger_template
+++ b/drivers/sensor/Kconfig.trigger_template
@@ -4,6 +4,7 @@
 
 choice "$(module)_TRIGGER_MODE"
 	prompt "Trigger mode"
+	default $(module)_TRIGGER_NONE
 	help
 	  Specify the type of triggering to be used by the sensor module.
 


### PR DESCRIPTION
Explicitly add default trigger mode as none in the kconfig trigger template for better readability.