### PR TITLE
modules: hostap: Disable advanced feature for nRF boards

### DIFF
--- a/modules/hostap/Kconfig
+++ b/modules/hostap/Kconfig
@@ -85,7 +85,7 @@ endif # WIFI_NM_WPA_SUPPLICANT_LOG_LEVEL_DBG
 # Memory optimizations
 config WIFI_NM_WPA_SUPPLICANT_ADVANCED_FEATURES
 	bool "Advanced features"
-	default y
+	default y if !SOC_FAMILY_NORDIC_NRF
 
 if WIFI_NM_WPA_SUPPLICANT_ADVANCED_FEATURES
 


### PR DESCRIPTION
nRF boards have a ROM crunch esp. with combined with Matter/networking features, as the advanced features are not essential for typical Wi-Fi operation, disable them by default. Individual samples can choose to enable it.