### PR TITLE
 device: add a DEVICE_DT_GET_BY_IDX macro

### DIFF
--- a/doc/build/dts/zephyr-user-node.rst
+++ b/doc/build/dts/zephyr-user-node.rst
@@ -79,19 +79,16 @@ device pointers like this:
    const struct device *my_device =
    	DEVICE_DT_GET(DT_PROP(ZEPHYR_USER_NODE, handle));
 
-   #define PHANDLE_TO_DEVICE(node_id, prop, idx) \
-        DEVICE_DT_GET(DT_PHANDLE_BY_IDX(node_id, prop, idx)),
-
    /*
     * Same thing as:
     *
     * ... *my_devices[] = {
     *         DEVICE_DT_GET(DT_NODELABEL(gpio0)),
-    *         DEVICE_DT_GET(DT_NODELABEL(gpio1)),
+    *         DEVICE_DT_GET(DT_NODELABEL(gpio1))
     * };
     */
    const struct device *my_devices[] = {
-   	DT_FOREACH_PROP_ELEM(ZEPHYR_USER_NODE, handles, PHANDLE_TO_DEVICE)
+        DT_FOREACH_PROP_ELEM_SEP(ZEPHYR_USER_NODE, handles, DEVICE_DT_GET_BY_IDX, (,))
    };
 
 GPIOs

--- a/drivers/ethernet/nxp_enet/eth_nxp_enet.c
+++ b/drivers/ethernet/nxp_enet/eth_nxp_enet.c
@@ -882,9 +882,6 @@ static const struct ethernet_api api_funcs = {
 		irq_enable(DT_IRQ_BY_IDX(node_id, idx, irq));			\
 	} while (false);
 
-#define NXP_ENET_DT_PHY_DEV(node_id, phy_phandle, idx)						\
-	DEVICE_DT_GET(DT_PHANDLE_BY_IDX(node_id, phy_phandle, idx))
-
 #if DT_NODE_HAS_STATUS_OKAY(DT_CHOSEN(zephyr_dtcm)) && \
 	CONFIG_ETH_NXP_ENET_USE_DTCM_FOR_DMA_BUFFER
 #define _nxp_enet_dma_desc_section __dtcm_bss_section

--- a/drivers/gpio/gpio_nct38xx_alert.c
+++ b/drivers/gpio/gpio_nct38xx_alert.c
@@ -157,12 +157,9 @@ static int nct38xx_alert_init(const struct device *dev)
 /* NCT38XX alert driver must be initialized after NCT38XX GPIO driver */
 BUILD_ASSERT(CONFIG_GPIO_NCT38XX_ALERT_INIT_PRIORITY > CONFIG_GPIO_NCT38XX_INIT_PRIORITY);
 
-#define NCT38XX_DEV_AND_COMMA(node_id, prop, idx)                                                  \
-	DEVICE_DT_GET(DT_PHANDLE_BY_IDX(node_id, prop, idx)),
-
 #define NCT38XX_ALERT_DEVICE_INSTANCE(inst)                                                        \
 	const struct device *nct38xx_dev_##inst[] = {                                              \
-		DT_INST_FOREACH_PROP_ELEM(inst, nct38xx_dev, NCT38XX_DEV_AND_COMMA)};              \
+		DT_INST_FOREACH_PROP_ELEM_SEP(inst, nct38xx_dev, DEVICE_DT_GET_BY_IDX, (,))};      \
 	static struct nct38xx_mfd nct38xx_mfd_##inst[DT_INST_PROP_LEN(inst, nct38xx_dev)];         \
 	static const struct nct38xx_alert_config nct38xx_alert_cfg_##inst = {                      \
 		.irq_gpio = GPIO_DT_SPEC_INST_GET(inst, irq_gpios),                                \

--- a/drivers/i2c/i2c_emul.c
+++ b/drivers/i2c/i2c_emul.c
@@ -312,7 +312,7 @@ static DEVICE_API(i2c, i2c_emul_api) = {
 
 #define EMUL_FORWARD_ITEM(node_id, prop, idx)                                                      \
 	{                                                                                          \
-		.bus = DEVICE_DT_GET(DT_PHANDLE_BY_IDX(node_id, prop, idx)),                       \
+		.bus = DEVICE_DT_GET_BY_IDX(node_id, prop, idx),                                   \
 		.addr = DT_PHA_BY_IDX(node_id, prop, idx, addr),                                   \
 	},
 

--- a/drivers/misc/devmux/devmux.c
+++ b/drivers/misc/devmux/devmux.c
@@ -148,11 +148,8 @@ static int devmux_init(struct device *const dev)
 	return 0;
 }
 
-#define DEVMUX_PHANDLE_TO_DEVICE(node_id, prop, idx)                                               \
-	DEVICE_DT_GET(DT_PHANDLE_BY_IDX(node_id, prop, idx))
-
 #define DEVMUX_PHANDLE_DEVICES(_n)                                                                 \
-	DT_INST_FOREACH_PROP_ELEM_SEP(_n, devices, DEVMUX_PHANDLE_TO_DEVICE, (,))
+	DT_INST_FOREACH_PROP_ELEM_SEP(_n, devices, DEVICE_DT_GET_BY_IDX, (,))
 
 #define DEVMUX_SELECTED(_n) DT_INST_PROP(_n, selected)
 

--- a/drivers/usb_c/ppc/shell.c
+++ b/drivers/usb_c/ppc/shell.c
@@ -10,7 +10,7 @@
 /** Macro used to iterate over USB-C connector and call a function if the node has PPC property */
 #define CALL_IF_HAS_PPC(usb_node, func)                                                            \
 	COND_CODE_1(DT_NODE_HAS_PROP(usb_node, ppc),                                               \
-		    (ret |= func(DEVICE_DT_GET(DT_PHANDLE_BY_IDX(usb_node, ppc, 0)));), ())
+		    (ret |= func(DEVICE_DT_GET_BY_IDX(usb_node, ppc, 0));), ())
 
 /**
  * @brief Command that dumps registers of one or all of the PPCs

--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -347,6 +347,22 @@ typedef int16_t device_handle_t;
 		    (DEVICE_DT_GET(node_id)), (NULL))
 
 /**
+ * @brief Get a @ref device reference from a devicetree phandles by idx.
+ *
+ * Returns a pointer to a device object referenced by a phandles property, by idx.
+ *
+ * @param node_id A devicetree node identifier
+ * @param prop lowercase-and-underscores property with type `phandle`,
+ *            `phandles`, or `phandle-array`
+ * @param idx logical index into @p phs, which must be zero if @p phs
+ *            has type `phandle`
+ *
+ * @return A pointer to the device object created for that node
+ */
+#define DEVICE_DT_GET_BY_IDX(node_id, prop, idx) \
+	DEVICE_DT_GET(DT_PHANDLE_BY_IDX(node_id, prop, idx))
+
+/**
  * @brief Obtain a pointer to a device object by name
  *
  * @details Return the address of a device object created by

--- a/tests/drivers/console_switching/src/main.c
+++ b/tests/drivers/console_switching/src/main.c
@@ -13,9 +13,8 @@
 #define BUF_SIZE 32
 
 /* array of const struct device* */
-#define PHANDLE_TO_DEVICE(node_id, prop, idx) DEVICE_DT_GET(DT_PHANDLE_BY_IDX(node_id, prop, idx))
 static const struct device *devs[] = {
-	DT_FOREACH_PROP_ELEM_SEP(DT_NODELABEL(devmux0), devices, PHANDLE_TO_DEVICE, (,))};
+	DT_FOREACH_PROP_ELEM_SEP(DT_NODELABEL(devmux0), devices, DEVICE_DT_GET_BY_IDX, (,))};
 
 /* array of names, e.g. "euart0" */
 #define PHANDLE_TO_NAME(node_id, prop, idx) DT_NODE_FULL_NAME(DT_PHANDLE_BY_IDX(node_id, prop, idx))

--- a/tests/drivers/i2c/i2c_emul/src/test_forwarding_buf.cpp
+++ b/tests/drivers/i2c/i2c_emul/src/test_forwarding_buf.cpp
@@ -13,12 +13,10 @@
 namespace
 {
 
-#define GET_TARGET_DEVICE(node_id, prop, n) DEVICE_DT_GET(DT_PHANDLE_BY_IDX(node_id, prop, n)),
-
 /* Get the devicetree constants */
 constexpr const struct device *controller = DEVICE_DT_GET(CONTROLLER_LABEL);
 constexpr const struct device *targets[FORWARD_COUNT] = {
-	DT_FOREACH_PROP_ELEM(CONTROLLER_LABEL, forwards, GET_TARGET_DEVICE)};
+	DT_FOREACH_PROP_ELEM_SEP(CONTROLLER_LABEL, forwards, DEVICE_DT_GET_BY_IDX, (,))};
 
 ZTEST(i2c_emul_forwarding, test_write_is_forwarded)
 {

--- a/tests/drivers/i2c/i2c_emul/src/test_forwarding_pio.cpp
+++ b/tests/drivers/i2c/i2c_emul/src/test_forwarding_pio.cpp
@@ -12,12 +12,10 @@
 namespace
 {
 
-#define GET_TARGET_DEVICE(node_id, prop, n) DEVICE_DT_GET(DT_PHANDLE_BY_IDX(node_id, prop, n)),
-
 /* Get the devicetree constants */
 constexpr const struct device *controller = DEVICE_DT_GET(CONTROLLER_LABEL);
 constexpr const struct device *targets[FORWARD_COUNT] = {
-	DT_FOREACH_PROP_ELEM(CONTROLLER_LABEL, forwards, GET_TARGET_DEVICE)};
+	DT_FOREACH_PROP_ELEM_SEP(CONTROLLER_LABEL, forwards, DEVICE_DT_GET_BY_IDX, (,))};
 
 ZTEST(i2c_emul_forwarding, test_write_is_forwarded)
 {

--- a/tests/drivers/i2c/i2c_emul/src/test_fowarding_common.cpp
+++ b/tests/drivers/i2c/i2c_emul/src/test_fowarding_common.cpp
@@ -12,12 +12,10 @@
 namespace
 {
 
-#define GET_TARGET_DEVICE(node_id, prop, n) DEVICE_DT_GET(DT_PHANDLE_BY_IDX(node_id, prop, n)),
-
 /* Get the devicetree constants */
 constexpr const struct device *controller = DEVICE_DT_GET(CONTROLLER_LABEL);
 constexpr const struct device *targets[FORWARD_COUNT] = {
-	DT_FOREACH_PROP_ELEM(CONTROLLER_LABEL, forwards, GET_TARGET_DEVICE)};
+	DT_FOREACH_PROP_ELEM_SEP(CONTROLLER_LABEL, forwards, DEVICE_DT_GET_BY_IDX, (,))};
 
 static void *i2c_emul_forwarding_setup(void)
 {

--- a/tests/drivers/regulator/voltage/src/main.c
+++ b/tests/drivers/regulator/voltage/src/main.c
@@ -10,14 +10,11 @@
 #include <zephyr/sys/util.h>
 #include <zephyr/ztest.h>
 
-#define REG_INIT(node_id, prop, idx) \
-	DEVICE_DT_GET(DT_PHANDLE_BY_IDX(node_id, prop, idx)),
-
 #define ADC_INIT(node_id, prop, idx) \
 	ADC_DT_SPEC_GET_BY_IDX(node_id, idx),
 
 static const struct device *regs[] = {
-	DT_FOREACH_PROP_ELEM(DT_NODELABEL(resources), regulators, REG_INIT)
+	DT_FOREACH_PROP_ELEM_SEP(DT_NODELABEL(resources), regulators, DEVICE_DT_GET_BY_IDX, (,))
 };
 
 static const struct adc_dt_spec adc_chs[] = {


### PR DESCRIPTION
Add a DEVICE_DT_GET_BY_IDX macro to get a struct device reference for a phandles node. This can be used directly as an argument of macros such as DT_INST_FOREACH_PROP_ELEM_SEP.