### PR TITLE
kernel: Initialize kheap spinlock

### DIFF
--- a/kernel/kheap.c
+++ b/kernel/kheap.c
@@ -15,6 +15,7 @@
 void k_heap_init(struct k_heap *heap, void *mem, size_t bytes)
 {
 	z_waitq_init(&heap->wait_q);
+	heap->lock = (struct k_spinlock) {};
 	sys_heap_init(&heap->heap, mem, bytes);
 
 	SYS_PORT_TRACING_OBJ_INIT(k_heap, heap);


### PR DESCRIPTION
Initializes the kheap spinlock when the kheap is initialized.