### PR TITLE
libc: Fix include order

### DIFF
--- a/lib/libc/minimal/include/errno.h
+++ b/lib/libc/minimal/include/errno.h
@@ -28,13 +28,14 @@
  * @{
  */
 
+/* errno_private.h depends on errno being defined first. */
+#define errno (*z_errno())
+
 #include <zephyr/sys/errno_private.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#define errno (*z_errno())
 
 #define EPERM 1         /**< Not owner */
 #define ENOENT 2        /**< No such file or directory */


### PR DESCRIPTION
I ran into an issue with the include order when building Zephyr using Bazel. This seems to check out when I walked through the include order, there's a circular dependency here that's resolved by moving the definition up.