### PR TITLE
toolchain: Add toolchain compiler warning macro indirection

### DIFF
--- a/include/zephyr/toolchain.h
+++ b/include/zephyr/toolchain.h
@@ -158,6 +158,117 @@
 #endif
 
 /**
+ * @def TOOLCHAIN_WARNING_ADDRESS_OF_PACKED_MEMBER
+ * @brief Toolchain-specific warning for taking the address of a packed member.
+ *
+ * Use this as an argument to the @ref TOOLCHAIN_DISABLE_WARNING and
+ * @ref TOOLCHAIN_ENABLE_WARNING family of macros.
+ */
+#ifndef TOOLCHAIN_WARNING_ADDRESS_OF_PACKED_MEMBER
+#define TOOLCHAIN_WARNING_ADDRESS_OF_PACKED_MEMBER
+#endif
+
+/**
+ * @def TOOLCHAIN_WARNING_ARRAY_BOUNDS
+ * @brief Toolchain-specific warning for array bounds violations.
+ *
+ * Use this as an argument to the @ref TOOLCHAIN_DISABLE_WARNING and
+ * @ref TOOLCHAIN_ENABLE_WARNING family of macros.
+ */
+#ifndef TOOLCHAIN_WARNING_ARRAY_BOUNDS
+#define TOOLCHAIN_WARNING_ARRAY_BOUNDS
+#endif
+
+/**
+ * @def TOOLCHAIN_WARNING_ATTRIBUTES
+ * @brief Toolchain-specific warning for unknown attributes.
+ *
+ * Use this as an argument to the @ref TOOLCHAIN_DISABLE_WARNING and
+ * @ref TOOLCHAIN_ENABLE_WARNING family of macros.
+ */
+#ifndef TOOLCHAIN_WARNING_ATTRIBUTES
+#define TOOLCHAIN_WARNING_ATTRIBUTES
+#endif
+
+/**
+ * @def TOOLCHAIN_WARNING_DELETE_NON_VIRTUAL_DTOR
+ * @brief Toolchain-specific warning for deleting a pointer to an object
+ * with a non-virtual destructor.
+ *
+ * Use this as an argument to the @ref TOOLCHAIN_DISABLE_WARNING and
+ * @ref TOOLCHAIN_ENABLE_WARNING family of macros.
+ */
+#ifndef TOOLCHAIN_WARNING_DELETE_NON_VIRTUAL_DTOR
+#define TOOLCHAIN_WARNING_DELETE_NON_VIRTUAL_DTOR
+#endif
+
+/**
+ * @def TOOLCHAIN_WARNING_EXTRA
+ * @brief Toolchain-specific warning for extra warnings.
+ *
+ * Use this as an argument to the @ref TOOLCHAIN_DISABLE_WARNING and
+ * @ref TOOLCHAIN_ENABLE_WARNING family of macros.
+ */
+#ifndef TOOLCHAIN_WARNING_EXTRA
+#define TOOLCHAIN_WARNING_EXTRA
+#endif
+
+/**
+ * @def TOOLCHAIN_WARNING_NONNULL
+ * @brief Toolchain-specific warning for null pointer arguments to functions marked with "nonnull".
+ *
+ * Use this as an argument to the @ref TOOLCHAIN_DISABLE_WARNING and
+ * @ref TOOLCHAIN_ENABLE_WARNING family of macros.
+ */
+#ifndef TOOLCHAIN_WARNING_NONNULL
+#define TOOLCHAIN_WARNING_NONNULL
+#endif
+
+/**
+ * @def TOOLCHAIN_WARNING_POINTER_ARITH
+ * @brief Toolchain-specific warning for pointer arithmetic.
+ *
+ * Use this as an argument to the @ref TOOLCHAIN_DISABLE_WARNING and
+ * @ref TOOLCHAIN_ENABLE_WARNING family of macros.
+ */
+#ifndef TOOLCHAIN_WARNING_POINTER_ARITH
+#define TOOLCHAIN_WARNING_POINTER_ARITH
+#endif
+
+/**
+ * @def TOOLCHAIN_WARNING_SHADOW
+ * @brief Toolchain-specific warning for shadow variables.
+ *
+ * Use this as an argument to the @ref TOOLCHAIN_DISABLE_WARNING and
+ * @ref TOOLCHAIN_ENABLE_WARNING family of macros.
+ */
+#ifndef TOOLCHAIN_WARNING_SHADOW
+#define TOOLCHAIN_WARNING_SHADOW
+#endif
+
+/**
+ * @def TOOLCHAIN_WARNING_UNUSED_LABEL
+ * @brief Toolchain-specific warning for unused labels.
+ *
+ * Use this as an argument to the @ref TOOLCHAIN_DISABLE_WARNING and
+ * @ref TOOLCHAIN_ENABLE_WARNING family of macros.
+ */
+#ifndef TOOLCHAIN_WARNING_UNUSED_LABEL
+#define TOOLCHAIN_WARNING_UNUSED_LABEL
+#endif
+
+/**
+ * @def TOOLCHAIN_WARNING_UNUSED_VARIABLE
+ * @brief Toolchain-specific warning for unused variables.
+ *
+ * Use this as an argument to the @ref TOOLCHAIN_DISABLE_WARNING and
+ * @ref TOOLCHAIN_ENABLE_WARNING family of macros.
+ */
+#ifndef TOOLCHAIN_WARNING_UNUSED_VARIABLE
+#define TOOLCHAIN_WARNING_UNUSED_VARIABLE
+#endif
+
+/**
  * @def TOOLCHAIN_DISABLE_WARNING
  * @brief Disable the specified compiler warning for all compilers.
  */

--- a/include/zephyr/toolchain/gcc.h
+++ b/include/zephyr/toolchain/gcc.h
@@ -688,6 +688,21 @@ do {                                                                    \
 
 #endif /* !_LINKER */
 
+#define TOOLCHAIN_WARNING_ADDRESS_OF_PACKED_MEMBER "-Waddress-of-packed-member"
+#define TOOLCHAIN_WARNING_ARRAY_BOUNDS             "-Warray-bounds"
+#define TOOLCHAIN_WARNING_ATTRIBUTES               "-Wattributes"
+#define TOOLCHAIN_WARNING_DELETE_NON_VIRTUAL_DTOR  "-Wdelete-non-virtual-dtor"
+#define TOOLCHAIN_WARNING_EXTRA                    "-Wextra"
+#define TOOLCHAIN_WARNING_NONNULL                  "-Wnonnull"
+#define TOOLCHAIN_WARNING_SHADOW                   "-Wshadow"
+#define TOOLCHAIN_WARNING_UNUSED_LABEL             "-Wunused-label"
+#define TOOLCHAIN_WARNING_UNUSED_VARIABLE          "-Wunused-variable"
+
+/* GCC-specific warnings that aren't in clang. */
+#if defined(__GNUC__) && !defined(__clang__)
+#define TOOLCHAIN_WARNING_POINTER_ARITH "-Wpointer-arith"
+#endif
+
 #define _TOOLCHAIN_DISABLE_WARNING(compiler, warning)                                              \
 	TOOLCHAIN_PRAGMA(compiler diagnostic push)                                                 \
 	TOOLCHAIN_PRAGMA(compiler diagnostic ignored warning)

--- a/include/zephyr/toolchain/llvm.h
+++ b/include/zephyr/toolchain/llvm.h
@@ -30,6 +30,8 @@
 
 #include <zephyr/toolchain/gcc.h>
 
+#define TOOLCHAIN_WARNING_SIZEOF_ARRAY_DECAY "-Wsizeof-array-decay"
+
 #define TOOLCHAIN_DISABLE_CLANG_WARNING(warning) _TOOLCHAIN_DISABLE_WARNING(clang, warning)
 #define TOOLCHAIN_ENABLE_CLANG_WARNING(warning)  _TOOLCHAIN_ENABLE_WARNING(clang, warning)
 

--- a/subsys/testsuite/include/zephyr/test_toolchain.h
+++ b/subsys/testsuite/include/zephyr/test_toolchain.h
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2025 Google, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_TESTSUITE_INCLUDE_TEST_TOOLCHAIN_H_
+#define ZEPHYR_TESTSUITE_INCLUDE_TEST_TOOLCHAIN_H_
+
+#include <zephyr/toolchain.h>
+
+#if defined(__llvm__) || (defined(_LINKER) && defined(__LLD_LINKER_CMD__))
+#include <zephyr/test_toolchain/llvm.h>
+#elif defined(__GNUC__) || (defined(_LINKER) && defined(__GCC_LINKER_CMD__))
+#include <zephyr/test_toolchain/gcc.h>
+#endif
+
+/**
+ * @def TOOLCHAIN_WARNING_ALLOC_SIZE_LARGER_THAN
+ * @brief Toolchain-specific warning for allocations larger than a given size.
+ *
+ * Use this as an argument to the @ref TOOLCHAIN_DISABLE_WARNING and
+ * @ref TOOLCHAIN_ENABLE_WARNING family of macros.
+ */
+#ifndef TOOLCHAIN_WARNING_ALLOC_SIZE_LARGER_THAN
+#define TOOLCHAIN_WARNING_ALLOC_SIZE_LARGER_THAN
+#endif
+
+/**
+ * @def TOOLCHAIN_WARNING_DANGLING_POINTER
+ * @brief Toolchain-specific warning for dangling pointers.
+ *
+ * Use this as an argument to the @ref TOOLCHAIN_DISABLE_WARNING and
+ * @ref TOOLCHAIN_ENABLE_WARNING family of macros.
+ */
+#ifndef TOOLCHAIN_WARNING_DANGLING_POINTER
+#define TOOLCHAIN_WARNING_DANGLING_POINTER
+#endif
+
+/**
+ * @def TOOLCHAIN_WARNING_FORMAT_TRUNCATION
+ * @brief Toolchain-specific warning for format truncation.
+ *
+ * Use this as an argument to the @ref TOOLCHAIN_DISABLE_WARNING and
+ * @ref TOOLCHAIN_ENABLE_WARNING family of macros.
+ */
+#ifndef TOOLCHAIN_WARNING_FORMAT_TRUNCATION
+#define TOOLCHAIN_WARNING_FORMAT_TRUNCATION
+#endif
+
+/**
+ * @def TOOLCHAIN_WARNING_INFINITE_RECURSION
+ * @brief Toolchain-specific warning for infinite recursion.
+ *
+ * Use this as an argument to the @ref TOOLCHAIN_DISABLE_WARNING and
+ * @ref TOOLCHAIN_ENABLE_WARNING family of macros.
+ */
+#ifndef TOOLCHAIN_WARNING_INFINITE_RECURSION
+#define TOOLCHAIN_WARNING_INFINITE_RECURSION
+#endif
+
+/**
+ * @def TOOLCHAIN_WARNING_INTEGER_OVERFLOW
+ * @brief Toolchain-specific warning for integer overflow.
+ *
+ * Use this as an argument to the @ref TOOLCHAIN_DISABLE_WARNING and
+ * @ref TOOLCHAIN_ENABLE_WARNING family of macros.
+ */
+#ifndef TOOLCHAIN_WARNING_INTEGER_OVERFLOW
+#define TOOLCHAIN_WARNING_INTEGER_OVERFLOW
+#endif
+
+/**
+ * @def TOOLCHAIN_WARNING_OVERFLOW
+ * @brief Toolchain-specific warning for integer overflow.
+ *
+ * Use this as an argument to the @ref TOOLCHAIN_DISABLE_WARNING and
+ * @ref TOOLCHAIN_ENABLE_WARNING family of macros.
+ */
+#ifndef TOOLCHAIN_WARNING_OVERFLOW
+#define TOOLCHAIN_WARNING_OVERFLOW
+#endif
+
+/**
+ * @def TOOLCHAIN_WARNING_PRAGMAS
+ * @brief Toolchain-specific warning for unknown pragmas.
+ *
+ * Use this as an argument to the @ref TOOLCHAIN_DISABLE_WARNING and
+ * @ref TOOLCHAIN_ENABLE_WARNING family of macros.
+ */
+#ifndef TOOLCHAIN_WARNING_PRAGMAS
+#define TOOLCHAIN_WARNING_PRAGMAS
+#endif
+
+/**
+ * @def TOOLCHAIN_WARNING_SIZEOF_ARRAY_DECAY
+ * @brief Toolchain-specific warning for sizeof array decay.
+ *
+ * Use this as an argument to the @ref TOOLCHAIN_DISABLE_WARNING and
+ * @ref TOOLCHAIN_ENABLE_WARNING family of macros.
+ */
+#ifndef TOOLCHAIN_WARNING_SIZEOF_ARRAY_DECAY
+#define TOOLCHAIN_WARNING_SIZEOF_ARRAY_DECAY
+#endif
+
+/**
+ * @def TOOLCHAIN_WARNING_STRINGOP_OVERFLOW
+ * @brief Toolchain-specific warning for stringop overflow.
+ *
+ * Use this as an argument to the @ref TOOLCHAIN_DISABLE_WARNING and
+ * @ref TOOLCHAIN_ENABLE_WARNING family of macros.
+ */
+#ifndef TOOLCHAIN_WARNING_STRINGOP_OVERFLOW
+#define TOOLCHAIN_WARNING_STRINGOP_OVERFLOW
+#endif
+
+/**
+ * @def TOOLCHAIN_WARNING_STRINGOP_TRUNCATION
+ * @brief Toolchain-specific warning for stringop truncation.
+ *
+ * Use this as an argument to the @ref TOOLCHAIN_DISABLE_WARNING and
+ * @ref TOOLCHAIN_ENABLE_WARNING family of macros.
+ */
+#ifndef TOOLCHAIN_WARNING_STRINGOP_TRUNCATION
+#define TOOLCHAIN_WARNING_STRINGOP_TRUNCATION
+#endif
+
+/**
+ * @def TOOLCHAIN_WARNING_UNUSED_FUNCTION
+ * @brief Toolchain-specific warning for unused function.
+ *
+ * Use this as an argument to the @ref TOOLCHAIN_DISABLE_WARNING and
+ * @ref TOOLCHAIN_ENABLE_WARNING family of macros.
+ */
+#ifndef TOOLCHAIN_WARNING_UNUSED_FUNCTION
+#define TOOLCHAIN_WARNING_UNUSED_FUNCTION
+#endif
+
+#endif

--- a/subsys/testsuite/include/zephyr/test_toolchain/gcc.h
+++ b/subsys/testsuite/include/zephyr/test_toolchain/gcc.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2025 Google, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_TESTSUITE_INCLUDE_TEST_TOOLCHAIN_GCC_H_
+#define ZEPHYR_TESTSUITE_INCLUDE_TEST_TOOLCHAIN_GCC_H_
+
+#ifndef ZEPHYR_TESTSUITE_INCLUDE_TEST_TOOLCHAIN_H_
+#error "Please do not include test toolchain-specific headers directly, \
+use <zephyr/test_toolchain.h> instead"
+#endif
+
+#define TOOLCHAIN_WARNING_DANGLING_POINTER   "-Wdangling-pointer"
+#define TOOLCHAIN_WARNING_FORMAT_TRUNCATION  "-Wformat-truncation"
+#define TOOLCHAIN_WARNING_INFINITE_RECURSION "-Winfinite-recursion"
+#define TOOLCHAIN_WARNING_OVERFLOW           "-Woverflow"
+#define TOOLCHAIN_WARNING_PRAGMAS            "-Wpragmas"
+#define TOOLCHAIN_WARNING_UNUSED_FUNCTION    "-Wunused-function"
+
+/* GCC-specific warnings that aren't in clang. */
+#if defined(__GNUC__) && !defined(__clang__)
+#define TOOLCHAIN_WARNING_ALLOC_SIZE_LARGER_THAN "-Walloc-size-larger-than="
+#define TOOLCHAIN_WARNING_STRINGOP_OVERFLOW      "-Wstringop-overflow"
+#define TOOLCHAIN_WARNING_STRINGOP_TRUNCATION    "-Wstringop-truncation"
+#endif
+
+#endif

--- a/subsys/testsuite/include/zephyr/test_toolchain/llvm.h
+++ b/subsys/testsuite/include/zephyr/test_toolchain/llvm.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2025 Google, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_TESTSUITE_INCLUDE_TEST_TOOLCHAIN_LLVM_H_
+#define ZEPHYR_TESTSUITE_INCLUDE_TEST_TOOLCHAIN_LLVM_H_
+
+#ifndef ZEPHYR_TESTSUITE_INCLUDE_TEST_TOOLCHAIN_H_
+#error "Please do not include test toolchain-specific headers directly, \
+use <zephyr/test_toolchain.h> instead"
+#endif
+
+#include <zephyr/test_toolchain/gcc.h>
+
+#define TOOLCHAIN_WARNING_INTEGER_OVERFLOW "-Winteger-overflow"
+
+#endif


### PR DESCRIPTION
In order to support new toolchains that are not compatible with gcc/clang (e.g., IAR), we need to add a level of indirection for the name of warnings.

Depends on https://github.com/zephyrproject-rtos/zephyr/pull/84063