### PR TITLE
logging: fixes and enhancements to initialization and shell cmds

### DIFF
--- a/include/zephyr/logging/log_backend.h
+++ b/include/zephyr/logging/log_backend.h
@@ -83,6 +83,7 @@ struct log_backend_control_block {
 	void *ctx;
 	uint8_t id;
 	bool active;
+	bool initialized;
 
 	/* Initialization level. */
 	uint8_t level;
@@ -140,6 +141,7 @@ static inline void log_backend_init(const struct log_backend *const backend)
 	if (backend->api->init) {
 		backend->api->init(backend);
 	}
+	backend->cb->initialized = true;
 }
 
 /**

--- a/subsys/logging/log_core.c
+++ b/subsys/logging/log_core.c
@@ -330,8 +330,14 @@ static uint32_t z_log_init(bool blocking, bool can_sleep)
 
 	int backend_index = 0;
 
-	/* Activate autostart backends */
 	STRUCT_SECTION_FOREACH(log_backend, backend) {
+		uint32_t id;
+		/* As first slot in filtering mask is reserved, backend ID has offset.*/
+		id = LOG_FILTER_FIRST_BACKEND_SLOT_IDX;
+		id += backend - log_backend_get(0);
+		log_backend_id_set(backend, id);
+
+		/* Activate autostart backends */
 		if (backend->autostart) {
 			log_backend_init(backend);
 

--- a/subsys/logging/log_mgmt.c
+++ b/subsys/logging/log_mgmt.c
@@ -560,12 +560,6 @@ void log_backend_enable(struct log_backend const *const backend,
 			void *ctx,
 			uint32_t level)
 {
-	/* As first slot in filtering mask is reserved, backend ID has offset.*/
-	uint32_t id = LOG_FILTER_FIRST_BACKEND_SLOT_IDX;
-
-	id += backend - log_backend_get(0);
-
-	log_backend_id_set(backend, id);
 	backend->cb->level = level;
 	backend_filter_set(backend, level);
 	log_backend_activate(backend, ctx);


### PR DESCRIPTION
## logging: init backend id regardless of autostart

The `id` is basically a compile-time constant. Setting it every
time the backend is enabled is unnecessary. Instead, set it on
`z_log_init()` regardless of whether or not it requires to be
`autostart`ed.

Fixes an issue where the `filter_get`/`filter_set`
accessed the wrong index and displayed the wrong log level when
user accesses the status of an uninitialized backend via:
`log backend <uninitialized_backend> status`.

Also fixes an issue when user tries to list the backends via:
`log list_backends`, where all uninitialized backends will have
ID = 0.


## logging: log_cmds: init uninitialized backend on `log_go()`

For backends that do not autostart themselves, initialize
& enable them on `log backend <log_backend_*> go`, so
that they function properly.

Fixes #84952
Fixes #84954

## Testing

<details>

<summary> Console log </summary>

```
Hello World! qemu_riscv64/qemu_virt_riscv64

*** Booting Zephyr OS build v4.0.0-3714-gb6f8eff2f322 ***
uart:~$ log list_backends 
log_backend_uart
        - Status: disabled
        - ID: 1

shell_uart_backend
        - Status: enabled
        - ID: 2

uart:~$ log backend shell_uart_backend status
module_name                              | current | built-in 
----------------------------------------------------------
cbprintf_package                         | inf     | inf
getopt                                   | inf     | inf
log                                      | inf     | inf
log_mgmt                                 | inf     | inf
log_uart                                 | inf     | inf
mpu                                      | inf     | inf
os                                       | inf     | inf
shell.shell_uart                         | inf     | inf
shell_uart                               | inf     | inf
uart_ns16550                             | inf     | inf
uart:~$ log backend log_backend_uart status
Logs are halted!
module_name                              | current | built-in 
----------------------------------------------------------
cbprintf_package                         | none    | inf
getopt                                   | none    | inf
log                                      | none    | inf
log_mgmt                                 | none    | inf
log_uart                                 | none    | inf
mpu                                      | none    | inf
os                                       | none    | inf
shell.shell_uart                         | none    | inf
shell_uart                               | none    | inf
uart_ns16550                             | none    | inf
uart:~$ log backend shell_uart_backend enable wrn
uart:~$ log backend shell_uart_backend status
module_name                              | current | built-in 
----------------------------------------------------------
cbprintf_package                         | wrn     | inf
getopt                                   | wrn     | inf
log                                      | wrn     | inf
log_mgmt                                 | wrn     | inf
log_uart                                 | wrn     | inf
mpu                                      | wrn     | inf
os                                       | wrn     | inf
shell.shell_uart                         | wrn     | inf
shell_uart                               | wrn     | inf
uart_ns16550                             | wrn     | inf
uart:~$ log backend log_backend_uart status
Logs are halted!
module_name                              | current | built-in 
----------------------------------------------------------
cbprintf_package                         | none    | inf
getopt                                   | none    | inf
log                                      | none    | inf
log_mgmt                                 | none    | inf
log_uart                                 | none    | inf
mpu                                      | none    | inf
os                                       | none    | inf
shell.shell_uart                         | none    | inf
shell_uart                               | none    | inf
uart_ns16550                             | none    | inf
uart:~$ log backend log_backend_uart go
uart:~$ log backend log_backend_uart status
module_name                              | current | built-in 
----------------------------------------------------------
cbprintf_package                         | inf     | inf
getopt                                   | inf     | inf
log                                      | inf     | inf
log_mgmt                                 | inf     | inf
log_uart                                 | inf     | inf
mpu                                      | inf     | inf
os                                       | inf     | inf
shell.shell_uart                         | inf     | inf
shell_uart                               | inf     | inf
uart_ns16550                             | inf     | inf
uart:~$ log backend shell_uart_backend status
module_name                              | current | built-in 
----------------------------------------------------------
cbprintf_package                         | wrn     | inf
getopt                                   | wrn     | inf
log                                      | wrn     | inf
log_mgmt                                 | wrn     | inf
log_uart                                 | wrn     | inf
mpu                                      | wrn     | inf
os                                       | wrn     | inf
shell.shell_uart                         | wrn     | inf
shell_uart                               | wrn     | inf
uart_ns16550                             | wrn     | inf
uart:~$ log backend log_backend_uart enable err
uart:~$ log backend log_backend_uart status
module_name                              | current | built-in 
----------------------------------------------------------
cbprintf_package                         | err     | inf
getopt                                   | err     | inf
log                                      | err     | inf
log_mgmt                                 | err     | inf
log_uart                                 | err     | inf
mpu                                      | err     | inf
os                                       | err     | inf
shell.shell_uart                         | err     | inf
shell_uart                               | err     | inf
uart_ns16550                             | err     | inf
uart:~$ log backend shell_uart_backend status
module_name                              | current | built-in 
----------------------------------------------------------
cbprintf_package                         | wrn     | inf
getopt                                   | wrn     | inf
log                                      | wrn     | inf
log_mgmt                                 | wrn     | inf
log_uart                                 | wrn     | inf
mpu                                      | wrn     | inf
os                                       | wrn     | inf
shell.shell_uart                         | wrn     | inf
shell_uart                               | wrn     | inf
uart_ns16550                             | wrn     | inf
```
</details>