### PR TITLE
tests: adc: wio_terminal: enable adc0 node

### DIFF
--- a/tests/drivers/adc/adc_api/boards/wio_terminal.overlay
+++ b/tests/drivers/adc/adc_api/boards/wio_terminal.overlay
@@ -13,6 +13,7 @@
 };
 
 &adc0 {
+	status = "okay";
 	#address-cells = <1>;
 	#size-cells = <0>;
 


### PR DESCRIPTION
the adc0 node is now disabled by default in the soc enable it so that adc test passes for this board