### PR TITLE
boards: samr34_xpro: add pre_dt_board.cmake

### DIFF
--- a/boards/atmel/sam0/samr34_xpro/pre_dt_board.cmake
+++ b/boards/atmel/sam0/samr34_xpro/pre_dt_board.cmake
@@ -1,0 +1,5 @@
+# Copyright (c) 2021 Linaro Limited
+# SPDX-License-Identifier: Apache-2.0
+
+# SPI is implemented via sercom so node name isn't spi@...
+list(APPEND EXTRA_DTC_FLAGS "-Wno-spi_bus_bridge")


### PR DESCRIPTION
Add pre-devicetree CMake configuration for SAMR34 Xplained Pro board to suppress SPI bus bridge warnings promoted to errors in weekly CI run.