### PR TITLE
boards: panasonic: remove arduino_gpio from pan178x_evb boards

### DIFF
--- a/boards/panasonic/pan1781_evb/pan1781_evb.yaml
+++ b/boards/panasonic/pan1781_evb/pan1781_evb.yaml
@@ -13,7 +13,6 @@ toolchain:
   - zephyr
   - gnuarmemb
 supported:
-  - arduino_gpio
   - arduino_i2c
   - arduino_spi
   - ble

--- a/boards/panasonic/pan1782_evb/pan1782_evb.yaml
+++ b/boards/panasonic/pan1782_evb/pan1782_evb.yaml
@@ -14,7 +14,6 @@ toolchain:
   - gnuarmemb
 supported:
   - adc
-  - arduino_gpio
   - arduino_i2c
   - arduino_spi
   - usb_device


### PR DESCRIPTION
Remove arduino_gpio from supported features on pan1781_evb and pan1782_evb boards due to them exposing only a "reduced" Arduino header (see compatible `panasonic,reduced-arduino-header`)

Fixes test failures in weekly CI run.

west twister -p pan1782_evb/nrf52833 -s drivers.gpio.st_2pin_arduino