### PR TITLE
west.yml: hal_stm32: stm32h7/h5: Fix ethernet load issue

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -234,7 +234,7 @@ manifest:
       groups:
         - hal
     - name: hal_stm32
-      revision: f1317150eac951fdd8259337a47cbbc4c2e6d335
+      revision: 0657d9f97d973542e438f628a704f5d8ea0cdef5
       path: modules/hal/stm32
       groups:
         - hal


### PR DESCRIPTION
Point to fix cherry picked from hal_stm32 main branch to fix a ethernet load issue.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/79066 (Issue reported on stm32h7)
Fixes https://github.com/zephyrproject-rtos/zephyr/issues/84737 (Issue reported on stm32h5).