### PR TITLE
drivers: adc: esp32: delete line curve scheme

### DIFF
--- a/drivers/adc/adc_esp32.c
+++ b/drivers/adc/adc_esp32.c
@@ -560,7 +560,7 @@ static int adc_esp32_channel_setup(const struct device *dev, const struct adc_ch
 
 		if (data->cal_handle[cfg->channel_id] != NULL) {
 			/* delete pre-existing calib scheme */
-			adc_cali_delete_scheme_curve_fitting(data->cal_handle[cfg->channel_id]);
+			adc_cali_delete_scheme_line_fitting(data->cal_handle[cfg->channel_id]);
 		}
 
 		adc_cali_create_scheme_line_fitting(&cal_config,


### PR DESCRIPTION
Make sure to delete line scheme instead of curve scheme for socs that uses line scheme.