### PR TITLE
bluetooth: controller: Only BT_CTLR_ECDH default y if BT_HCI_RAW

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -550,7 +550,7 @@ config BT_CTLR_LE_ENC
 config BT_CTLR_ECDH
 	bool "Elliptic Curve Diffie-Hellman (ECDH)"
 	depends on BT_CTLR_ECDH_SUPPORT
-	default y
+	default y if BT_HCI_RAW
 	help
 	  Enable support for Bluetooth v4.2 Elliptic Curve Diffie-Hellman
 	  feature in the controller.


### PR DESCRIPTION
In https://github.com/zephyrproject-rtos/zephyr/pull/84268 the ability to use the controller for ECDH was removed from the host.

This means that BT_CTLR_ECDH is now only useful when using BT_HCI_RAW.