### PR TITLE
drivers: dac: sam: Fix typo in BUILD_ASSERT

### DIFF
--- a/drivers/dac/dac_sam.c
+++ b/drivers/dac/dac_sam.c
@@ -25,7 +25,7 @@
 #include <zephyr/irq.h>
 LOG_MODULE_REGISTER(dac_sam, CONFIG_DAC_LOG_LEVEL);
 
-BUILD_ASSERT(IS_ENABLED(CONFIG_SOC_SERIES_SAMX7X)
+BUILD_ASSERT(IS_ENABLED(CONFIG_SOC_SERIES_SAMX7X),
 	     "Only SAMx7x series devices are currently supported.");
 
 #define DAC_CHANNEL_NO  2


### PR DESCRIPTION
Fixed a typo in BUILD_ASSERT macro causing driver to effectively fail to compile as seen in:
```
west twister -p sam_v71_xult/samv71q21b -s drivers.dac.api
```