### PR TITLE
drivers: flash: spi_nor: make wait_until_ready erase delay configurable

### DIFF
--- a/drivers/flash/Kconfig.nor
+++ b/drivers/flash/Kconfig.nor
@@ -68,6 +68,15 @@ config SPI_NOR_SLEEP_WHILE_WAITING_UNTIL_READY
 	  result in significant flash savings if this driver is the only user
 	  of "k_sleep". This can be the case when building as a bootloader.
 
+config SPI_NOR_SLEEP_ERASE_MS
+	int "Delay between polls while waiting for an erase operation in ms"
+	default 50
+	help
+	  The delay between polling while waiting for the flash to finish
+	  an erase operation.
+	depends on SPI_NOR_SLEEP_WHILE_WAITING_UNTIL_READY
+
+
 config SPI_NOR_FLASH_LAYOUT_PAGE_SIZE
 	int "Page size to use for FLASH_LAYOUT feature"
 	default 65536

--- a/drivers/flash/spi_nor.c
+++ b/drivers/flash/spi_nor.c
@@ -221,12 +221,17 @@ static const struct jesd216_erase_type minimal_erase_types_4b[JESD216_NUM_ERASE_
 };
 #endif /* CONFIG_SPI_NOR_SFDP_MINIMAL */
 
+
 /* Register writes should be ready extremely quickly */
 #define WAIT_READY_REGISTER K_NO_WAIT
 /* Page writes range from sub-ms to 10ms */
 #define WAIT_READY_WRITE K_TICKS(1)
-/* Erases can range from 45ms to 240sec */
-#define WAIT_READY_ERASE K_MSEC(50)
+
+#ifdef CONFIG_SPI_NOR_SLEEP_WHILE_WAITING_UNTIL_READY
+#define WAIT_READY_ERASE K_MSEC(CONFIG_SPI_NOR_SLEEP_ERASE_MS)
+#else
+#define WAIT_READY_ERASE K_NO_WAIT
+#endif
 
 static int spi_nor_write_protection_set(const struct device *dev,
 					bool write_protect);


### PR DESCRIPTION
The erase time varies between different SPI NOR flash chips. Some have typical erase times in the 20-25ms range, at which point the default 50ms poll interval means we get half the possible erase speed. With slower memory, or larger erases, 50ms might not be a lot, but for block erases, if we are unlucky we may end up polling just as the it's about to finish erasing, and have to wait another poll interval.