### PR TITLE
drivers/sensor: lis3mdl: fix lis3mdl_sample_fetch API

### DIFF
--- a/drivers/sensor/st/lis3mdl/lis3mdl.c
+++ b/drivers/sensor/st/lis3mdl/lis3mdl.c
@@ -66,7 +66,7 @@ int lis3mdl_sample_fetch(const struct device *dev, enum sensor_channel chan)
 	const struct lis3mdl_config *config = dev->config;
 	int16_t buf[4];
 
-	__ASSERT_NO_MSG(chan == SENSOR_CHAN_ALL);
+	__ASSERT_NO_MSG(chan == SENSOR_CHAN_ALL || chan == SENSOR_CHAN_MAGN_XYZ);
 
 	/* fetch magnetometer sample */
 	if (i2c_burst_read_dt(&config->i2c, LIS3MDL_REG_SAMPLE_START,


### PR DESCRIPTION
Fix a runtime bug when both CONFIG_LIS3MDL_TRIGGER and CONFIG_ASSERT are set. The correct assertion should verify that sensor channel is either SENSOR_CHAN_ALL or SENSOR_CHAN_MAGN_XYZ.

Fix: #84145

EDIT:
The issue DOES NOT depend by CONFIG_LIS3MDL_TRIGGER being set. It happens if CONFIG_ASSERT is set AND the fetch does not use SENSOR_CHAN_ALL but instead SENSOR_CHAN_MAGN_XYZ.