### PR TITLE
arch: arm: fix mpu compiler warnings

### DIFF
--- a/arch/arm/core/mpu/arm_mpu.c
+++ b/arch/arm/core/mpu/arm_mpu.c
@@ -42,7 +42,8 @@ BUILD_ASSERT((DT_FOREACH_STATUS_OKAY_NODE_VARGS(
 	 (DT_REG_SIZE(node_id) >= CONFIG_CORTEX_M_NULL_POINTER_EXCEPTION_PAGE_SIZE)) ||
 
 #define DT_NULL_PAGE_DETECT_NODE_EXIST                                                             \
-	(DT_FOREACH_STATUS_OKAY_NODE_VARGS(NULL_PAGE_DETECT_NODE_FINDER, zephyr_memory_attr) false)
+	(DT_FOREACH_STATUS_OKAY_VARGS(zephyr_memory_region, NULL_PAGE_DETECT_NODE_FINDER,          \
+				      zephyr_memory_attr) false)
 
 /*
  * Global status variable holding the number of HW MPU region indices, which


### PR DESCRIPTION
What is the change?
 - Use a macro to search for "zephyr, memory-attr" in only those nodes that have the property "zephyr, memory-regions".
 - Fixes #83448.

Why is this needed?
 - Using `DT_REG_ADDR` inside `DT_FOREACH_STATUS_OKAY_NODE_VARGS` can lead to compiler warnings if a devicetree node has an addresses larger than 64bits. An example of such node is wm8904 i3c with 92 bit encoding addresses `audio_codec: wm8904@1a0000000000000000`. We can avoid this warning since this is not applicable for nodes that have the attribute "zephyr,memory-regions".