### PR TITLE
tests: Fix thread_metric message processing

### DIFF
--- a/tests/benchmarks/thread_metric/src/tm_message_processing_test.c
+++ b/tests/benchmarks/thread_metric/src/tm_message_processing_test.c
@@ -44,8 +44,8 @@
 /* Define the counters used in the demo application...  */
 
 unsigned long tm_message_processing_counter;
-unsigned long tm_message_sent[4];
-unsigned long tm_message_received[4];
+unsigned int tm_message_sent[4];
+unsigned int tm_message_received[4];
 
 /* Define the test thread prototypes.  */
 
@@ -102,10 +102,10 @@ void tm_message_processing_thread_0_entry(void *p1, void *p2, void *p3)
 
 	while (1) {
 		/* Send a message to the queue.  */
-		tm_queue_send(0, tm_message_sent);
+		tm_queue_send(0, (unsigned long *)tm_message_sent);
 
 		/* Receive a message from the queue.  */
-		tm_queue_receive(0, tm_message_received);
+		tm_queue_receive(0, (unsigned long *)tm_message_received);
 
 		/* Check for invalid message.  */
 		if (tm_message_received[3] != tm_message_sent[3]) {


### PR DESCRIPTION
Changes the type of both the tm_message_sent and tm_message_received arrays from 'unsigned long' to 'unsigned int'. The test expects those arrays to be 16 bytes long. This was a problem on 64-bit platforms as 'unsigned long' is 8 bytes, which made the arrays 32 bytes long. On both our supported 32-bit and 64-bit platforms, 'unsigned int' works out to be 4 bytes long, thereby giving us the requisite 16 byte buffer.

Although a case could be made for using 'uint32_t', this was not chosen simply to keep the structure as close as practical to the original thread_metric implementation.

Fixes #83864