### PR TITLE
drivers: udc_mcux_ehci: fix typo in transfer handler

### DIFF
--- a/drivers/usb/udc/udc_mcux_ehci.c
+++ b/drivers/usb/udc/udc_mcux_ehci.c
@@ -359,7 +359,7 @@ static bool udc_mcux_handler_zlt(const struct device *dev, uint8_t ep, struct ne
 			usb_status_t status;
 
 			udc_ep_buf_clear_zlp(buf);
-			status = mcux_if->deviceRecv(priv->mcux_device.controllerHandle,
+			status = mcux_if->deviceSend(priv->mcux_device.controllerHandle,
 					ep, NULL, 0);
 			if (status != kStatus_USB_Success) {
 				udc_submit_event(dev, UDC_EVT_ERROR, -EIO);


### PR DESCRIPTION
If the to-host data stage length is less than that requested by the
host, but equal to or a multiple of MPS, the device should send a ZLP,
not receive it.

Fixes: #84999
Tested on mimxrt1020_evk

udc_mcux_ip3511.c has similar type, but according to the reporter it would not fix similar issue there, so there should be something else.