### PR TITLE
boards: raspberrypi: rpi_pico2: enable wdt0

### DIFF
--- a/boards/raspberrypi/rpi_pico2/rpi_pico2.dtsi
+++ b/boards/raspberrypi/rpi_pico2/rpi_pico2.dtsi
@@ -137,6 +137,10 @@
 	status = "okay";
 };
 
+&wdt0 {
+	status = "okay";
+};
+
 zephyr_udc0: &usbd {
 	status = "okay";
 };

--- a/boards/raspberrypi/rpi_pico2/rpi_pico2_rp2350a_m33.yaml
+++ b/boards/raspberrypi/rpi_pico2/rpi_pico2_rp2350a_m33.yaml
@@ -18,3 +18,4 @@ supported:
   - pwm
   - spi
   - uart
+  - watchdog

--- a/drivers/clock_control/clock_control_rpi_pico.c
+++ b/drivers/clock_control/clock_control_rpi_pico.c
@@ -676,7 +676,7 @@ static int clock_control_rpi_pico_init(const struct device *dev)
 			     RESETS_RESET_USBCTRL_BITS));
 
 	/* Start tick in watchdog */
-	watchdog_start_tick(cycles_per_tick);
+	tick_start(TICK_WATCHDOG, cycles_per_tick);
 #if defined(CONFIG_SOC_SERIES_RP2350)
 	tick_start(TICK_TIMER0, cycles_per_tick);
 	tick_start(TICK_TIMER1, cycles_per_tick);

--- a/modules/hal_rpi_pico/CMakeLists.txt
+++ b/modules/hal_rpi_pico/CMakeLists.txt
@@ -61,7 +61,6 @@ if(CONFIG_HAS_RPI_PICO)
     ${rp2_common_dir}/hardware_clocks/clocks.c
     ${rp2_common_dir}/hardware_pll/pll.c
     ${rp2_common_dir}/hardware_xosc/xosc.c
-    ${rp2_common_dir}/hardware_watchdog/watchdog.c
     ${rp2_common_dir}/hardware_sync_spin_lock/sync_spin_lock.c
     ${rp2_common_dir}/hardware_ticks/ticks.c
     ${rp2_common_dir}/pico_bootrom/bootrom.c


### PR DESCRIPTION
Enables the watchdog timer to match the rpi_pico's configuration.

Also includes a minor cleanup of related code.


~~We need to solve https://github.com/zephyrproject-rtos/zephyr/pull/84974 first.~~