### PR TITLE
boards: raspberrypi: rp2040-zero,xiao_rp2040: fix: inconsistencies in flash memory

### DIFF
--- a/boards/seeed/xiao_rp2040/xiao_rp2040.dts
+++ b/boards/seeed/xiao_rp2040/xiao_rp2040.dts
@@ -78,6 +78,18 @@
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+
+		/* Reserved memory for the second stage bootloader */
+		second_stage_bootloader: partition@0 {
+			label = "second_stage_bootloader";
+			reg = <0x00000000 0x100>;
+			read-only;
+		};
+
+		/*
+		 * Usable flash. Starts at 0x100, after the bootloader. The partition
+		 * size is 2MB minus the 0x100 bytes taken by the bootloader.
+		 */
 		code_partition: partition@100 {
 			label = "code";
 			reg = <0x100 (DT_SIZE_M(2) - 0x100)>;

--- a/boards/seeed/xiao_rp2040/xiao_rp2040.yaml
+++ b/boards/seeed/xiao_rp2040/xiao_rp2040.yaml
@@ -3,7 +3,7 @@ name: XIAO RP2040
 type: mcu
 arch: arm
 flash: 2048
-ram: 256
+ram: 264
 toolchain:
   - zephyr
   - gnuarmemb

--- a/boards/waveshare/rp2040_zero/rp2040_zero.dts
+++ b/boards/waveshare/rp2040_zero/rp2040_zero.dts
@@ -28,7 +28,7 @@
 };
 
 &flash0 {
-	reg = <0x10000000 DT_SIZE_M(16)>;
+	reg = <0x10000000 DT_SIZE_M(2)>;
 
 	partitions {
 		compatible = "fixed-partitions";
@@ -44,11 +44,11 @@
 
 		/*
 		 * Usable flash. Starts at 0x100, after the bootloader. The partition
-		 * size is 16MB minus the 0x100 bytes taken by the bootloader.
+		 * size is 2MB minus the 0x100 bytes taken by the bootloader.
 		 */
 		code_partition: partition@100 {
 			label = "code-partition";
-			reg = <0x100 (DT_SIZE_M(16) - 0x100)>;
+			reg = <0x100 (DT_SIZE_M(2) - 0x100)>;
 			read-only;
 		};
 	};

--- a/boards/waveshare/rp2040_zero/rp2040_zero.yaml
+++ b/boards/waveshare/rp2040_zero/rp2040_zero.yaml
@@ -2,7 +2,7 @@ identifier: rp2040_zero
 name: Waveshare RP2040-Zero
 type: mcu
 arch: arm
-flash: 16384
+flash: 2048
 ram: 264
 toolchain:
   - zephyr


### PR DESCRIPTION
Noticed some inconsistencies with these two boards and their stated specs.

The zero has [2MB flash](https://www.waveshare.com/wiki/RP2040-Zero), not 16.
The xiao has [264 KB SRAM](https://wiki.seeedstudio.com/XIAO-RP2040/), not 256.

The xiao also does not have its second stage bootloader partition explicitly stated, which is inconsistent, so I added it in.