### PR TITLE
cpp: Add c++ version number

### DIFF
--- a/lib/cpp/Kconfig
+++ b/lib/cpp/Kconfig
@@ -12,6 +12,27 @@ config CPP
 
 if CPP
 
+config STD_CPP_VERSION
+	int
+	default 199711 if STD_CPP98
+	default 201103 if STD_CPP11
+	default 201402 if STD_CPP14
+	default 201703 if STD_CPP17
+	default 202002 if STD_CPP20 || STD_CPP2A || STD_CPP2B
+	help
+	  The version number of C++ standard being used (NOTE: this uses the
+	  full year and month, and is the same as the __cplusplus macro defined
+	  by the compiler). This config can be used to check for a minimum
+	  supported version. Example:
+
+	    depends on STD_CPP_VERSION >= 201703
+
+	  Adding this to your library's enablement Kconfig will force a minimum
+	  c++17 standard.
+
+	  The full year is used so c++98 can be checked using > and < operators
+	  without conflicting with c++11 or higher.
+
 choice STD_CPP
 	prompt "C++ Standard"
 	default STD_CPP11


### PR DESCRIPTION
Several downstream libraries need to specify that they work with c++ 17+ or 20+ and there's no easy way to do this without constantly updating the Kconfig file and supporting different Kconfig versions for different Zephyr versions (since I can't add a dependency on a new c++ standard and have it backwards compatible.