### PR TITLE
dts: boards: sample: Make MBOX default for NXP CM boards

### DIFF
--- a/boards/nxp/lpcxpresso55s69/lpcxpresso55s69_lpc55s69_cpu0.dts
+++ b/boards/nxp/lpcxpresso55s69/lpcxpresso55s69_lpc55s69_cpu0.dts
@@ -141,7 +141,7 @@
 	pinctrl-names = "default";
 };
 
-&mailbox0 {
+&mbox {
 	status = "okay";
 };
 

--- a/boards/nxp/lpcxpresso55s69/lpcxpresso55s69_lpc55s69_cpu1.dts
+++ b/boards/nxp/lpcxpresso55s69/lpcxpresso55s69_lpc55s69_cpu1.dts
@@ -54,7 +54,7 @@
 	status = "okay";
 };
 
-&mailbox0 {
+&mbox {
 	status = "okay";
 };
 

--- a/boards/nxp/mimxrt1160_evk/mimxrt1160_evk_mimxrt1166_cm4.dts
+++ b/boards/nxp/mimxrt1160_evk/mimxrt1160_evk_mimxrt1166_cm4.dts
@@ -26,7 +26,7 @@
 		zephyr,flash-controller = &is25wp128;
 		zephyr,flash = &is25wp128;
 		nxp,m4-partition = &slot1_partition;
-		zephyr,ipc = &mailbox_b;
+		zephyr,ipc = &mbox;
 	};
 
 
@@ -63,6 +63,6 @@
 	status = "okay";
 };
 
-&mailbox_b {
+&mbox {
 	status = "okay";
 };

--- a/boards/nxp/mimxrt1160_evk/mimxrt1160_evk_mimxrt1166_cm7.dts
+++ b/boards/nxp/mimxrt1160_evk/mimxrt1160_evk_mimxrt1166_cm7.dts
@@ -25,7 +25,7 @@
 		zephyr,code-partition = &slot0_partition;
 		zephyr,uart-mcumgr = &lpuart1;
 		zephyr,cpu1-region = &ocram;
-		zephyr,ipc = &mailbox_a;
+		zephyr,ipc = &mbox;
 	};
 
 	sdram0: memory@80000000 {
@@ -124,7 +124,7 @@ zephyr_udc0: &usb1 {
 	status = "okay";
 };
 
-&mailbox_a {
+&mbox {
 	status = "okay";
 };
 

--- a/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm4.dts
+++ b/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm4.dts
@@ -27,7 +27,7 @@
 		zephyr,flash-controller = &is25wp128;
 		zephyr,flash = &ocram;
 		nxp,m4-partition = &slot1_partition;
-		zephyr,ipc = &mailbox_b;
+		zephyr,ipc = &mbox;
 	};
 
 	sdram0: memory@80000000 {
@@ -67,6 +67,6 @@
 	status = "okay";
 };
 
-&mailbox_b {
+&mbox {
 	status = "okay";
 };

--- a/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm7.dts
+++ b/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm7.dts
@@ -30,7 +30,7 @@
 		zephyr,code-partition = &slot0_partition;
 		zephyr,uart-mcumgr = &lpuart1;
 		zephyr,cpu1-region = &ocram;
-		zephyr,ipc = &mailbox_a;
+		zephyr,ipc = &mbox;
 	};
 
 	sdram0: memory@80000000 {
@@ -160,7 +160,7 @@ zephyr_udc0: &usb1 {
 	tx-cal-45-dm-ohms = <6>;
 };
 
-&mailbox_a {
+&mbox {
 	status = "okay";
 };
 

--- a/dts/arm/nxp/nxp_lpc55S6x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S6x_common.dtsi
@@ -220,10 +220,12 @@
 		#dma-cells = <1>;
 	};
 
-	mailbox0:mailbox@8b000 {
-		compatible = "nxp,lpc-mailbox";
+	mbox:mailbox0@8b000 {
+		compatible = "nxp,mbox-mailbox";
 		reg = <0x8b000 0xEC>;
 		interrupts = <31 0>;
+		rx-channels = <4>;
+		#mbox-cells = <1>;
 		resets = <&reset NXP_SYSCON_RESET(0, 26)>;
 		status = "disabled";
 	};

--- a/dts/arm/nxp/nxp_rt11xx_cm4.dtsi
+++ b/dts/arm/nxp/nxp_rt11xx_cm4.dtsi
@@ -53,10 +53,12 @@
 			#gpio-cells = <2>;
 		};
 
-		mailbox_b: mailbox@40c4c000 {
-			compatible = "nxp,imx-mu";
+		mbox:mbox@40c4c000 {
+			compatible = "nxp,mbox-imx-mu";
 			reg = <0x40c4c000 0x4000>;
 			interrupts = <118 0>;
+			rx-channels = <4>;
+			#mbox-cells = <1>;
 			rdc = <0>;
 		};
 	};

--- a/dts/arm/nxp/nxp_rt11xx_cm7.dtsi
+++ b/dts/arm/nxp/nxp_rt11xx_cm7.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 NXP
+ * Copyright 2021-2025 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -36,21 +36,21 @@
 			flexram,has-magic-addr;
 			/* same as default fuse value */
 			flexram,bank-spec = <FLEXRAM_DTCM>,
-					     <FLEXRAM_DTCM>,
-					     <FLEXRAM_DTCM>,
-					     <FLEXRAM_DTCM>,
-					     <FLEXRAM_ITCM>,
-					     <FLEXRAM_ITCM>,
-					     <FLEXRAM_ITCM>,
-					     <FLEXRAM_ITCM>,
-					     <FLEXRAM_DTCM>,
-					     <FLEXRAM_DTCM>,
-					     <FLEXRAM_DTCM>,
-					     <FLEXRAM_DTCM>,
-					     <FLEXRAM_ITCM>,
-					     <FLEXRAM_ITCM>,
-					     <FLEXRAM_ITCM>,
-					     <FLEXRAM_ITCM>;
+						 <FLEXRAM_DTCM>,
+						 <FLEXRAM_DTCM>,
+						 <FLEXRAM_DTCM>,
+						 <FLEXRAM_ITCM>,
+						 <FLEXRAM_ITCM>,
+						 <FLEXRAM_ITCM>,
+						 <FLEXRAM_ITCM>,
+						 <FLEXRAM_DTCM>,
+						 <FLEXRAM_DTCM>,
+						 <FLEXRAM_DTCM>,
+						 <FLEXRAM_DTCM>,
+						 <FLEXRAM_ITCM>,
+						 <FLEXRAM_ITCM>,
+						 <FLEXRAM_ITCM>,
+						 <FLEXRAM_ITCM>;
 
 			itcm: itcm@0 {
 				compatible = "zephyr,memory-region", "nxp,imx-itcm";
@@ -102,10 +102,12 @@
 			#gpio-cells = <2>;
 		};
 
-		mailbox_a: mailbox@40c48000 {
-			compatible = "nxp,imx-mu";
+		mbox:mbox@40c48000 {
+			compatible = "nxp,mbox-imx-mu";
 			reg = <0x40c48000 0x4000>;
 			interrupts = <118 0>;
+			rx-channels = <4>;
+			#mbox-cells = <1>;
 			rdc = <0>;
 		};
 	};

--- a/dts/bindings/mbox/nxp,mbox-imx-mu.yaml
+++ b/dts/bindings/mbox/nxp,mbox-imx-mu.yaml
@@ -3,7 +3,7 @@ description: |
 
 compatible: "nxp,mbox-imx-mu"
 
-include: [base.yaml, mailbox-controller.yaml]
+include: [base.yaml, mailbox-controller.yaml, "nxp,rdc-policy.yaml"]
 
 properties:
   interrupts:

--- a/dts/bindings/mbox/nxp,mbox-mailbox.yaml
+++ b/dts/bindings/mbox/nxp,mbox-mailbox.yaml
@@ -11,7 +11,7 @@ description: |
 
 compatible: "nxp,mbox-mailbox"
 
-include: [base.yaml, mailbox-controller.yaml]
+include: [base.yaml, mailbox-controller.yaml , reset-device.yaml]
 
 properties:
   interrupts:

--- a/samples/drivers/mbox/boards/lpcxpresso55s69_lpc55s69_cpu0.overlay
+++ b/samples/drivers/mbox/boards/lpcxpresso55s69_lpc55s69_cpu0.overlay
@@ -12,21 +12,6 @@
 		/delete-property/ zephyr,ipc;
 	};
 
-	soc {
-		/* Delete IPM Driver node nxp,lpc-mailbox */
-		/delete-node/ mailbox@8b000;
-
-		/* Attach MBOX driver to Mailbox Unit */
-		mbox:mailbox0@5008b000 {
-			compatible = "nxp,mbox-mailbox";
-			reg = <0x5008b000 0xEC>;
-			interrupts = <31 0>;
-			rx-channels = <4>;
-			#mbox-cells = <1>;
-			status = "okay";
-		};
-	};
-
 	mbox-consumer {
 		compatible = "vnd,mbox-consumer";
 		mboxes = <&mbox 1>, <&mbox 0>;

--- a/samples/drivers/mbox/boards/mimxrt1160_evk_mimxrt1166_cm7.overlay
+++ b/samples/drivers/mbox/boards/mimxrt1160_evk_mimxrt1166_cm7.overlay
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 NXP
+ * Copyright 2023-2025 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -10,21 +10,6 @@
 		 * configured.
 		 */
 		/delete-property/ zephyr,ipc;
-	};
-
-	soc {
-		/* Delete IPM Driver node nxp,imx-mu */
-		/delete-node/ mailbox@40c48000;
-
-		/* Attach MBOX driver to MU Unit */
-		mbox:mbox@40c48000 {
-			compatible = "nxp,mbox-imx-mu";
-			reg = <0x40c48000 0x4000>;
-			interrupts = <118 0>;
-			rx-channels = <4>;
-			#mbox-cells = <1>;
-			status = "okay";
-		};
 	};
 
 	mbox-consumer {

--- a/samples/drivers/mbox/boards/mimxrt1170_evk_mimxrt1176_cm7_A.overlay
+++ b/samples/drivers/mbox/boards/mimxrt1170_evk_mimxrt1176_cm7_A.overlay
@@ -12,21 +12,6 @@
 		/delete-property/ zephyr,ipc;
 	};
 
-	soc {
-		/* Delete IPM Driver node nxp,imx-mu */
-		/delete-node/ mailbox@40c48000;
-
-		/* Attach MBOX driver to MU Unit */
-		mbox:mbox@40c48000 {
-			compatible = "nxp,mbox-imx-mu";
-			reg = <0x40c48000 0x4000>;
-			interrupts = <118 0>;
-			rx-channels = <4>;
-			#mbox-cells = <1>;
-			status = "okay";
-		};
-	};
-
 	mbox-consumer {
 		compatible = "vnd,mbox-consumer";
 		mboxes = <&mbox 1>, <&mbox 0>;

--- a/samples/drivers/mbox/boards/mimxrt1170_evk_mimxrt1176_cm7_B.overlay
+++ b/samples/drivers/mbox/boards/mimxrt1170_evk_mimxrt1176_cm7_B.overlay
@@ -12,21 +12,6 @@
 		/delete-property/ zephyr,ipc;
 	};
 
-	soc {
-		/* Delete IPM Driver node nxp,imx-mu */
-		/delete-node/ mailbox@40c48000;
-
-		/* Attach MBOX driver to MU Unit */
-		mbox:mbox@40c48000 {
-			compatible = "nxp,mbox-imx-mu";
-			reg = <0x40c48000 0x4000>;
-			interrupts = <118 0>;
-			rx-channels = <4>;
-			#mbox-cells = <1>;
-			status = "okay";
-		};
-	};
-
 	mbox-consumer {
 		compatible = "vnd,mbox-consumer";
 		mboxes = <&mbox 1>, <&mbox 0>;

--- a/samples/drivers/mbox/remote/boards/lpcxpresso55s69_lpc55s69_cpu1.overlay
+++ b/samples/drivers/mbox/remote/boards/lpcxpresso55s69_lpc55s69_cpu1.overlay
@@ -14,21 +14,6 @@
 		zephyr,shell-uart = &flexcomm0;
 	};
 
-	soc {
-		/* Delete IPM Driver node nxp,lpc-mailbox */
-		/delete-node/ mailbox@8b000;
-
-		/* Attach MBOX driver to Mailbox Unit */
-		mbox:mbox@5008b000 {
-			compatible = "nxp,mbox-mailbox";
-			reg = <0x5008b000 0xEC>;
-			interrupts = <31 0>;
-			rx-channels = <4>;
-			#mbox-cells = <1>;
-			status = "okay";
-		};
-	};
-
 	mbox-consumer {
 		compatible = "vnd,mbox-consumer";
 		mboxes = <&mbox 0>, <&mbox 1>;

--- a/samples/drivers/mbox/remote/boards/mimxrt1160_evk_mimxrt1166_cm4.overlay
+++ b/samples/drivers/mbox/remote/boards/mimxrt1160_evk_mimxrt1166_cm4.overlay
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 NXP
+ * Copyright 2023-2025 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -24,19 +24,6 @@
 			compatible = "nxp,gpt-hw-timer";
 			reg = <0x400f0000 0x4000>;
 			interrupts = <120 0>;
-			status = "okay";
-		};
-
-		/* Delete IPM Driver node nxp,imx-mu */
-		/delete-node/ mailbox@40c4c000;
-
-		/* Attach MBOX driver to MU Unit */
-		mbox:mbox@40c4c000 {
-			compatible = "nxp,mbox-imx-mu";
-			reg = <0x40c4c000 0x4000>;
-			interrupts = <118 0>;
-			rx-channels = <4>;
-			#mbox-cells = <1>;
 			status = "okay";
 		};
 	};

--- a/samples/drivers/mbox/remote/boards/mimxrt1170_evk_mimxrt1176_cm4.overlay
+++ b/samples/drivers/mbox/remote/boards/mimxrt1170_evk_mimxrt1176_cm4.overlay
@@ -26,19 +26,6 @@
 			interrupts = <120 0>;
 			status = "okay";
 		};
-
-		/* Delete IPM Driver node nxp,imx-mu */
-		/delete-node/ mailbox@40c4c000;
-
-		/* Attach MBOX driver to MU Unit */
-		mbox:mbox@40c4c000 {
-			compatible = "nxp,mbox-imx-mu";
-			reg = <0x40c4c000 0x4000>;
-			interrupts = <118 0>;
-			rx-channels = <4>;
-			#mbox-cells = <1>;
-			status = "okay";
-		};
 	};
 
 	mbox-consumer {

--- a/samples/drivers/mbox/remote/boards/mimxrt1170_evk_mimxrt1176_cm4_B.overlay
+++ b/samples/drivers/mbox/remote/boards/mimxrt1170_evk_mimxrt1176_cm4_B.overlay
@@ -26,19 +26,6 @@
 			interrupts = <120 0>;
 			status = "okay";
 		};
-
-		/* Delete IPM Driver node nxp,imx-mu */
-		/delete-node/ mailbox@40c4c000;
-
-		/* Attach MBOX driver to MU Unit */
-		mbox:mbox@40c4c000 {
-			compatible = "nxp,mbox-imx-mu";
-			reg = <0x40c4c000 0x4000>;
-			interrupts = <118 0>;
-			rx-channels = <4>;
-			#mbox-cells = <1>;
-			status = "okay";
-		};
 	};
 
 	mbox-consumer {

--- a/samples/drivers/mbox_data/boards/mimxrt1160_evk_mimxrt1166_cm7.overlay
+++ b/samples/drivers/mbox_data/boards/mimxrt1160_evk_mimxrt1166_cm7.overlay
@@ -12,21 +12,6 @@
 		/delete-property/ zephyr,ipc;
 	};
 
-	soc {
-		/* Delete IPM Driver node nxp,imx-mu */
-		/delete-node/ mailbox@40c48000;
-
-		/* Attach MBOX driver to MU Unit */
-		mbox:mbox@40c48000 {
-			compatible = "nxp,mbox-imx-mu";
-			reg = <0x40c48000 0x4000>;
-			interrupts = <118 0>;
-			rx-channels = <4>;
-			#mbox-cells = <1>;
-			status = "okay";
-		};
-	};
-
 	mbox-consumer {
 		compatible = "vnd,mbox-consumer";
 		mboxes = <&mbox 3>, <&mbox 2>;

--- a/samples/drivers/mbox_data/boards/mimxrt1170_evk_mimxrt1176_cm7_A.overlay
+++ b/samples/drivers/mbox_data/boards/mimxrt1170_evk_mimxrt1176_cm7_A.overlay
@@ -12,21 +12,6 @@
 		/delete-property/ zephyr,ipc;
 	};
 
-	soc {
-		/* Delete IPM Driver node nxp,imx-mu */
-		/delete-node/ mailbox@40c48000;
-
-		/* Attach MBOX driver to MU Unit */
-		mbox:mbox@40c48000 {
-			compatible = "nxp,mbox-imx-mu";
-			reg = <0x40c48000 0x4000>;
-			interrupts = <118 0>;
-			rx-channels = <4>;
-			#mbox-cells = <1>;
-			status = "okay";
-		};
-	};
-
 	mbox-consumer {
 		compatible = "vnd,mbox-consumer";
 		mboxes = <&mbox 3>, <&mbox 2>;

--- a/samples/drivers/mbox_data/boards/mimxrt1170_evk_mimxrt1176_cm7_B.overlay
+++ b/samples/drivers/mbox_data/boards/mimxrt1170_evk_mimxrt1176_cm7_B.overlay
@@ -12,21 +12,6 @@
 		/delete-property/ zephyr,ipc;
 	};
 
-	soc {
-		/* Delete IPM Driver node nxp,imx-mu */
-		/delete-node/ mailbox@40c48000;
-
-		/* Attach MBOX driver to MU Unit */
-		mbox:mbox@40c48000 {
-			compatible = "nxp,mbox-imx-mu";
-			reg = <0x40c48000 0x4000>;
-			interrupts = <118 0>;
-			rx-channels = <4>;
-			#mbox-cells = <1>;
-			status = "okay";
-		};
-	};
-
 	mbox-consumer {
 		compatible = "vnd,mbox-consumer";
 		mboxes = <&mbox 3>, <&mbox 2>;

--- a/samples/drivers/mbox_data/remote/boards/mimxrt1160_evk_mimxrt1166_cm4.overlay
+++ b/samples/drivers/mbox_data/remote/boards/mimxrt1160_evk_mimxrt1166_cm4.overlay
@@ -26,19 +26,6 @@
 			interrupts = <120 0>;
 			status = "okay";
 		};
-
-		/* Delete IPM Driver node nxp,imx-mu */
-		/delete-node/ mailbox@40c4c000;
-
-		/* Attach MBOX driver to MU Unit */
-		mbox:mbox@40c4c000 {
-			compatible = "nxp,mbox-imx-mu";
-			reg = <0x40c4c000 0x4000>;
-			interrupts = <118 0>;
-			rx-channels = <4>;
-			#mbox-cells = <1>;
-			status = "okay";
-		};
 	};
 
 	mbox-consumer {

--- a/samples/drivers/mbox_data/remote/boards/mimxrt1170_evk_mimxrt1176_cm4.overlay
+++ b/samples/drivers/mbox_data/remote/boards/mimxrt1170_evk_mimxrt1176_cm4.overlay
@@ -26,19 +26,6 @@
 			interrupts = <120 0>;
 			status = "okay";
 		};
-
-		/* Delete IPM Driver node nxp,imx-mu */
-		/delete-node/ mailbox@40c4c000;
-
-		/* Attach MBOX driver to MU Unit */
-		mbox:mbox@40c4c000 {
-			compatible = "nxp,mbox-imx-mu";
-			reg = <0x40c4c000 0x4000>;
-			interrupts = <118 0>;
-			rx-channels = <4>;
-			#mbox-cells = <1>;
-			status = "okay";
-		};
 	};
 
 	mbox-consumer {

--- a/samples/drivers/mbox_data/remote/boards/mimxrt1170_evk_mimxrt1176_cm4_B.overlay
+++ b/samples/drivers/mbox_data/remote/boards/mimxrt1170_evk_mimxrt1176_cm4_B.overlay
@@ -26,19 +26,6 @@
 			interrupts = <120 0>;
 			status = "okay";
 		};
-
-		/* Delete IPM Driver node nxp,imx-mu */
-		/delete-node/ mailbox@40c4c000;
-
-		/* Attach MBOX driver to MU Unit */
-		mbox:mbox@40c4c000 {
-			compatible = "nxp,mbox-imx-mu";
-			reg = <0x40c4c000 0x4000>;
-			interrupts = <118 0>;
-			rx-channels = <4>;
-			#mbox-cells = <1>;
-			status = "okay";
-		};
 	};
 
 	mbox-consumer {

--- a/samples/subsys/ipc/ipc_service/static_vrings/boards/lpcxpresso55s69_lpc55s69_cpu0.overlay
+++ b/samples/subsys/ipc/ipc_service/static_vrings/boards/lpcxpresso55s69_lpc55s69_cpu0.overlay
@@ -33,21 +33,6 @@
 		zephyr,memory-attr = <( DT_MEM_ARM(ATTR_MPU_IO))>;
 	};
 
-	soc {
-		/* Delete IPM Driver node nxp,lpc-mailbox */
-		/delete-node/ mailbox@8b000;
-
-		/* Attach MBOX driver to Mailbox Unit */
-		mbox:mailbox0@5008b000 {
-			compatible = "nxp,mbox-mailbox";
-			reg = <0x5008b000 0xEC>;
-			interrupts = <31 0>;
-			rx-channels = <4>;
-			#mbox-cells = <1>;
-			status = "okay";
-		};
-	 };
-
 	ipc {
 		/delete-node/ ipc0;
 

--- a/samples/subsys/ipc/ipc_service/static_vrings/boards/mimxrt1160_evk_mimxrt1166_cm7.overlay
+++ b/samples/subsys/ipc/ipc_service/static_vrings/boards/mimxrt1160_evk_mimxrt1166_cm7.overlay
@@ -35,21 +35,6 @@
 		zephyr,memory-attr = <( DT_MEM_ARM(ATTR_MPU_IO))>;
 	};
 
-	soc {
-		/* Delete IPM Driver node nxp,imx-mu */
-		/delete-node/ mailbox@40c48000;
-
-		/* Attach MBOX driver to MU Unit */
-		mbox:mbox@40c48000 {
-			compatible = "nxp,mbox-imx-mu";
-			reg = <0x40c48000 0x4000>;
-			interrupts = <118 0>;
-			rx-channels = <4>;
-			#mbox-cells = <1>;
-			status = "okay";
-		};
-	};
-
 	ipc {
 		/delete-node/ ipc0;
 

--- a/samples/subsys/ipc/ipc_service/static_vrings/boards/mimxrt1170_evk_mimxrt1176_cm7.overlay
+++ b/samples/subsys/ipc/ipc_service/static_vrings/boards/mimxrt1170_evk_mimxrt1176_cm7.overlay
@@ -35,21 +35,6 @@
 		zephyr,memory-attr = <( DT_MEM_ARM(ATTR_MPU_IO))>;
 	};
 
-	soc {
-		/* Delete IPM Driver node nxp,imx-mu */
-		/delete-node/ mailbox@40c48000;
-
-		/* Attach MBOX driver to MU Unit */
-		mbox:mbox@40c48000 {
-			compatible = "nxp,mbox-imx-mu";
-			reg = <0x40c48000 0x4000>;
-			interrupts = <118 0>;
-			rx-channels = <4>;
-			#mbox-cells = <1>;
-			status = "okay";
-		};
-	};
-
 	ipc {
 		/delete-node/ ipc0;
 

--- a/samples/subsys/ipc/ipc_service/static_vrings/boards/mimxrt1170_evk_mimxrt1176_cm7_B.overlay
+++ b/samples/subsys/ipc/ipc_service/static_vrings/boards/mimxrt1170_evk_mimxrt1176_cm7_B.overlay
@@ -35,21 +35,6 @@
 		zephyr,memory-attr = <( DT_MEM_ARM(ATTR_MPU_IO))>;
 	};
 
-	soc {
-		/* Delete IPM Driver node nxp,imx-mu */
-		/delete-node/ mailbox@40c48000;
-
-		/* Attach MBOX driver to MU Unit */
-		mbox:mbox@40c48000 {
-			compatible = "nxp,mbox-imx-mu";
-			reg = <0x40c48000 0x4000>;
-			interrupts = <118 0>;
-			rx-channels = <4>;
-			#mbox-cells = <1>;
-			status = "okay";
-		};
-	};
-
 	ipc {
 		/delete-node/ ipc0;
 

--- a/samples/subsys/ipc/ipc_service/static_vrings/remote/boards/lpcxpresso55s69_lpc55s69_cpu1.overlay
+++ b/samples/subsys/ipc/ipc_service/static_vrings/remote/boards/lpcxpresso55s69_lpc55s69_cpu1.overlay
@@ -33,21 +33,6 @@
 		zephyr,memory-attr = <( DT_MEM_ARM(ATTR_MPU_IO))>;
 	};
 
-	soc {
-		/* Delete IPM Driver node nxp,lpc-mailbox */
-		/delete-node/ mailbox@8b000;
-
-		/* Attach MBOX driver to Mailbox Unit */
-		mbox:mailbox0@5008b000 {
-			compatible = "nxp,mbox-mailbox";
-			reg = <0x5008b000 0xEC>;
-			interrupts = <31 0>;
-			rx-channels = <4>;
-			#mbox-cells = <1>;
-			status = "okay";
-		};
-	};
-
 	ipc {
 		/delete-node/ ipc0;
 

--- a/samples/subsys/ipc/ipc_service/static_vrings/remote/boards/mimxrt1160_evk_mimxrt1166_cm4.overlay
+++ b/samples/subsys/ipc/ipc_service/static_vrings/remote/boards/mimxrt1160_evk_mimxrt1166_cm4.overlay
@@ -46,19 +46,6 @@
 			interrupts = <120 0>;
 			status = "okay";
 		};
-
-		/* Delete IPM Driver node nxp,imx-mu */
-		/delete-node/ mailbox@40c4c000;
-
-		/* Attach MBOX driver to MU Unit */
-		mbox:mbox@40c4c000 {
-			compatible = "nxp,mbox-imx-mu";
-			reg = <0x40c4c000 0x4000>;
-			interrupts = <118 0>;
-			rx-channels = <4>;
-			#mbox-cells = <1>;
-			status = "okay";
-		};
 	};
 
 	ipc {

--- a/samples/subsys/ipc/ipc_service/static_vrings/remote/boards/mimxrt1170_evk_mimxrt1176_cm4.overlay
+++ b/samples/subsys/ipc/ipc_service/static_vrings/remote/boards/mimxrt1170_evk_mimxrt1176_cm4.overlay
@@ -46,19 +46,6 @@
 			interrupts = <120 0>;
 			status = "okay";
 		};
-
-		/* Delete IPM Driver node nxp,imx-mu */
-		/delete-node/ mailbox@40c4c000;
-
-		/* Attach MBOX driver to MU Unit */
-		mbox:mbox@40c4c000 {
-			compatible = "nxp,mbox-imx-mu";
-			reg = <0x40c4c000 0x4000>;
-			interrupts = <118 0>;
-			rx-channels = <4>;
-			#mbox-cells = <1>;
-			status = "okay";
-		};
 	};
 
 	ipc {

--- a/samples/subsys/ipc/ipc_service/static_vrings/remote/boards/mimxrt1170_evk_mimxrt1176_cm4_B.overlay
+++ b/samples/subsys/ipc/ipc_service/static_vrings/remote/boards/mimxrt1170_evk_mimxrt1176_cm4_B.overlay
@@ -46,19 +46,6 @@
 			interrupts = <120 0>;
 			status = "okay";
 		};
-
-		/* Delete IPM Driver node nxp,imx-mu */
-		/delete-node/ mailbox@40c4c000;
-
-		/* Attach MBOX driver to MU Unit */
-		mbox:mbox@40c4c000 {
-			compatible = "nxp,mbox-imx-mu";
-			reg = <0x40c4c000 0x4000>;
-			interrupts = <118 0>;
-			rx-channels = <4>;
-			#mbox-cells = <1>;
-			status = "okay";
-		};
 	};
 
 	ipc {

--- a/samples/subsys/ipc/openamp/boards/lpcxpresso55s69_lpc55s69_cpu0.overlay
+++ b/samples/subsys/ipc/openamp/boards/lpcxpresso55s69_lpc55s69_cpu0.overlay
@@ -19,4 +19,10 @@
 		compatible = "mmio-sram";
 		reg = <0x20040000 DT_SIZE_K(16)>;
 	};
+
+    mailbox0: ipm-mbox {
+		compatible = "zephyr,mbox-ipm";
+		mboxes = <&mbox 1>, <&mbox 0>;
+		mbox-names = "tx", "rx";
+	};
 };

--- a/samples/subsys/ipc/openamp/boards/mimxrt1160_evk_mimxrt1166_cm7.overlay
+++ b/samples/subsys/ipc/openamp/boards/mimxrt1160_evk_mimxrt1166_cm7.overlay
@@ -9,6 +9,7 @@
 / {
 	chosen {
 		zephyr,ipc_shm = &ocram2_overlay;
+        zephyr,ipc = &mailbox0;
 	};
 
 	/* OpenAMP fails with full 512K OCRAM2 memory region as shared memory.
@@ -20,5 +21,11 @@
 		reg = <0x202c0000 DT_SIZE_K(16)>;
 		zephyr,memory-region="OCRAM2_OVERLAY";
 		zephyr,memory-attr = <( DT_MEM_ARM(ATTR_MPU_IO) )>;
+	};
+
+    mailbox0: ipm-mbox {
+		compatible = "zephyr,mbox-ipm";
+		mboxes = <&mbox 1>, <&mbox 0>;
+		mbox-names = "tx", "rx";
 	};
 };

--- a/samples/subsys/ipc/openamp/boards/mimxrt1170_evk_mimxrt1176_cm7_A.overlay
+++ b/samples/subsys/ipc/openamp/boards/mimxrt1170_evk_mimxrt1176_cm7_A.overlay
@@ -9,6 +9,7 @@
 / {
 	chosen {
 		zephyr,ipc_shm = &ocram2_overlay;
+        zephyr,ipc = &mailbox0;
 	};
 
 	/* OpenAMP fails with full 512K OCRAM2 memory region as shared memory.
@@ -20,5 +21,11 @@
 		reg = <0x202c0000 DT_SIZE_K(16)>;
 		zephyr,memory-region="OCRAM2_OVERLAY";
 		zephyr,memory-attr = <( DT_MEM_ARM(ATTR_MPU_IO) )>;
+	};
+
+    mailbox0: ipm-mbox {
+		compatible = "zephyr,mbox-ipm";
+		mboxes = <&mbox 1>, <&mbox 0>;
+		mbox-names = "tx", "rx";
 	};
 };

--- a/samples/subsys/ipc/openamp/boards/mimxrt1170_evk_mimxrt1176_cm7_B.overlay
+++ b/samples/subsys/ipc/openamp/boards/mimxrt1170_evk_mimxrt1176_cm7_B.overlay
@@ -9,6 +9,7 @@
 / {
 	chosen {
 		zephyr,ipc_shm = &ocram2_overlay;
+        zephyr,ipc = &mailbox0;
 	};
 
 	/* OpenAMP fails with full 512K OCRAM2 memory region as shared memory.
@@ -20,5 +21,11 @@
 		reg = <0x202c0000 DT_SIZE_K(16)>;
 		zephyr,memory-region="OCRAM2_OVERLAY";
 		zephyr,memory-attr = <( DT_MEM_ARM(ATTR_MPU_IO) )>;
+	};
+
+    mailbox0: ipm-mbox {
+		compatible = "zephyr,mbox-ipm";
+		mboxes = <&mbox 1>, <&mbox 0>;
+		mbox-names = "tx", "rx";
 	};
 };

--- a/samples/subsys/ipc/openamp/remote/boards/lpcxpresso55s69_lpc55s69_cpu1.overlay
+++ b/samples/subsys/ipc/openamp/remote/boards/lpcxpresso55s69_lpc55s69_cpu1.overlay
@@ -19,4 +19,10 @@
 		compatible = "mmio-sram";
 		reg = <0x20040000 DT_SIZE_K(16)>;
 	};
+
+    mailbox0: ipm-mbox {
+		compatible = "zephyr,mbox-ipm";
+		mboxes = <&mbox 0>, <&mbox 1>;
+		mbox-names = "tx", "rx";
+	};
 };

--- a/samples/subsys/ipc/openamp/remote/boards/mimxrt1160_evk_mimxrt1166_cm4.overlay
+++ b/samples/subsys/ipc/openamp/remote/boards/mimxrt1160_evk_mimxrt1166_cm4.overlay
@@ -13,6 +13,7 @@
 		zephyr,console = &lpuart2;
 		zephyr,shell-uart = &lpuart2;
 		zephyr,ipc_shm = &ocram2_overlay;
+        zephyr,ipc = &mailbox0;
 	};
 
 	soc {
@@ -36,6 +37,12 @@
 		reg = <0x202c0000 DT_SIZE_K(16)>;
 		zephyr,memory-region="OCRAM2_OVERLAY";
 		zephyr,memory-attr = <( DT_MEM_ARM(ATTR_MPU_IO) )>;
+	};
+
+    mailbox0: ipm-mbox {
+		compatible = "zephyr,mbox-ipm";
+		mboxes = <&mbox 0>, <&mbox 1>;
+		mbox-names = "tx", "rx";
 	};
 };
 

--- a/samples/subsys/ipc/openamp/remote/boards/mimxrt1170_evk_mimxrt1176_cm4.overlay
+++ b/samples/subsys/ipc/openamp/remote/boards/mimxrt1170_evk_mimxrt1176_cm4.overlay
@@ -13,6 +13,7 @@
 		zephyr,console = &lpuart2;
 		zephyr,shell-uart = &lpuart2;
 		zephyr,ipc_shm = &ocram2_overlay;
+        zephyr,ipc = &mailbox0;
 	};
 
 	soc {
@@ -36,6 +37,12 @@
 		reg = <0x202c0000 DT_SIZE_K(16)>;
 		zephyr,memory-region="OCRAM2_OVERLAY";
 		zephyr,memory-attr = <( DT_MEM_ARM(ATTR_MPU_IO) )>;
+	};
+
+    mailbox0: ipm-mbox {
+		compatible = "zephyr,mbox-ipm";
+		mboxes = <&mbox 0>, <&mbox 1>;
+		mbox-names = "tx", "rx";
 	};
 };
 

--- a/samples/subsys/ipc/openamp/remote/boards/mimxrt1170_evk_mimxrt1176_cm4_B.overlay
+++ b/samples/subsys/ipc/openamp/remote/boards/mimxrt1170_evk_mimxrt1176_cm4_B.overlay
@@ -11,6 +11,7 @@
 		zephyr,console = &lpuart2;
 		zephyr,shell-uart = &lpuart2;
 		zephyr,ipc_shm = &ocram2_overlay;
+        zephyr,ipc = &mailbox0;
 	};
 
 	soc {
@@ -34,6 +35,12 @@
 		reg = <0x202c0000 DT_SIZE_K(16)>;
 		zephyr,memory-region="OCRAM2_OVERLAY";
 		zephyr,memory-attr = <( DT_MEM_ARM(ATTR_MPU_IO) )>;
+	};
+
+    mailbox0: ipm-mbox {
+		compatible = "zephyr,mbox-ipm";
+		mboxes = <&mbox 0>, <&mbox 1>;
+		mbox-names = "tx", "rx";
 	};
 };
 


### PR DESCRIPTION
This commit changes to use IPC MBOX driver as default instead of using older IPM driver.

Change is done for NXP multicore Cortex M boards.
RT1160, RT1170 and LPC55s69