### PR TITLE
drivers: display: st7789v: Add ready time to startup

### DIFF
--- a/drivers/display/display_st7789v.c
+++ b/drivers/display/display_st7789v.c
@@ -45,6 +45,7 @@ struct st7789v_config {
 	uint8_t rgb_param[3];
 	uint16_t height;
 	uint16_t width;
+	uint8_t ready_time_ms;
 };
 
 struct st7789v_data {
@@ -409,6 +410,8 @@ static int st7789v_init(const struct device *dev)
 		return -ENODEV;
 	}
 
+	k_sleep(K_TIMEOUT_ABS_MS(config->ready_time_ms));
+
 	ret = st7789v_reset_display(dev);
 	if (ret < 0) {
 		LOG_ERR("Failed to reset display (%d)", ret);
@@ -496,6 +499,7 @@ static DEVICE_API(display, st7789v_api) = {
 		.rgb_param = DT_INST_PROP(inst, rgb_param),				\
 		.width = DT_INST_PROP(inst, width),					\
 		.height = DT_INST_PROP(inst, height),					\
+		.ready_time_ms = DT_INST_PROP(inst, ready_time_ms),			\
 	};										\
 											\
 	static struct st7789v_data st7789v_data_ ## inst = {				\

--- a/dts/bindings/display/sitronix,st7789v.yaml
+++ b/dts/bindings/display/sitronix,st7789v.yaml
@@ -96,5 +96,13 @@ properties:
     required: true
     description: RGB Interface Control Parameter
 
+  ready-time-ms:
+    type: int
+    default: 40
+    description: |
+      Time it takes for the device from power up to become responsive and
+      accepting commands. Defaults to 40ms (found by trial and error) if not
+      provided.
+
   mipi-mode:
     required: true


### PR DESCRIPTION
Add additional property to allow a configurable delay to the display initialization to allow the st7789v to be ready to receive commands.

Encountered this while working on a keyboard that incorporates an ST7789 display. Initial power up would fail to initialize the display, but upon *reset* it would initialize fine. Tracked it down to a necessary delay for the device to be fully powered and ready to use. This implementation matches the one found in the SSD1306 display driver.