### PR TITLE
boards: add usbd supports for the rp2350 implemented boards

### DIFF
--- a/boards/pimoroni/pico_plus2/pico_plus2_rp2350b_m33.yaml
+++ b/boards/pimoroni/pico_plus2/pico_plus2_rp2350b_m33.yaml
@@ -17,4 +17,5 @@ supported:
   - i2c
   - pwm
   - spi
+  - usbd
   - uart

--- a/boards/raspberrypi/rpi_pico2/rpi_pico2_rp2350a_m33.yaml
+++ b/boards/raspberrypi/rpi_pico2/rpi_pico2_rp2350a_m33.yaml
@@ -18,4 +18,5 @@ supported:
   - pwm
   - spi
   - uart
+  - usbd
   - watchdog

--- a/boards/wiznet/w5500_evb_pico2/w5500_evb_pico2_rp2350a_m33.yaml
+++ b/boards/wiznet/w5500_evb_pico2/w5500_evb_pico2_rp2350a_m33.yaml
@@ -18,4 +18,5 @@ supported:
   - pwm
   - spi
   - uart
+  - usbd
   - watchdog


### PR DESCRIPTION
Add `usbd` test feature for the Raspberry Pi Pico2.

~#85025 is a known issue. That test is not passed.~ Solved.

~Incorporate the method of Pico-SDK's to improve the detection of transfer abortion.
https://github.com/raspberrypi/pico-extras/blob/f05d4f7371802440cadd36744789a26944d950ac/src/rp2_common/usb_device/usb_device.c#L146-L154~

Added `usbd` to the `supported` section in the yaml for boards confirmed to work on actual devices.