### PR TITLE
MAINTAINERS: add Arduino boards category

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -162,6 +162,15 @@ ARC arch:
   tests:
     - arch.arc
 
+Arduino Platforms:
+  status: maintained
+  maintainers:
+    - pillo79
+  collaborators:
+    - facchinm
+  files:
+    - boards/arduino/
+
 ARM arch:
   status: maintained
   maintainers:


### PR DESCRIPTION
Add Arduino category to MAINTAINERS.yml file.