### PR TITLE
audio: codec_shell: add missing headphone left/right channel

### DIFF
--- a/drivers/audio/codec_shell.c
+++ b/drivers/audio/codec_shell.c
@@ -39,6 +39,8 @@ static const char *const codec_channel_name[] = {
 	[AUDIO_CHANNEL_REAR_CENTER] = "rear_center",
 	[AUDIO_CHANNEL_SIDE_LEFT] = "side_left",
 	[AUDIO_CHANNEL_SIDE_RIGHT] = "side_right",
+	[AUDIO_CHANNEL_HEADPHONE_LEFT] = "headphone_left",
+	[AUDIO_CHANNEL_HEADPHONE_RIGHT] = "headphone_right",
 	[AUDIO_CHANNEL_ALL] = "all",
 };
 


### PR DESCRIPTION
Add the audio codec channels headphone left/right that were missing in the audio codec shell.

This is especially useful on the devboard stm32f4_disco, where only the headphones outputs are wired to the audio codec.