### PR TITLE
Bug Fixes for the new RTC/Sensors driver maxim,ds3231

### DIFF
--- a/drivers/rtc/rtc_ds3231.c
+++ b/drivers/rtc/rtc_ds3231.c
@@ -358,7 +358,7 @@ struct rtc_ds3231_alarm_details {
 };
 static struct rtc_ds3231_alarm_details alarms[] = {{DS3231_REG_ALARM_1_SECONDS, 4},
 						   {DS3231_REG_ALARM_2_MINUTES, 3}};
-static int rtc_ds3231_alarm_get_supported_fields(const struct device *dev, u int16_t id,
+static int rtc_ds3231_alarm_get_supported_fields(const struct device *dev, uint16_t id,
 						 uint16_t *mask)
 {
 	*mask = RTC_ALARM_TIME_MASK_MONTHDAY | RTC_ALARM_TIME_MASK_WEEKDAY |

--- a/drivers/rtc/rtc_ds3231.c
+++ b/drivers/rtc/rtc_ds3231.c
@@ -192,12 +192,15 @@ static int rtc_ds3231_modify_ctrl_sts(const struct device *dev,
 
 	return rtc_ds3231_modify_register(dev, reg, &buf, bitmask);
 }
+
+#ifdef CONFIG_RTC_ALARM
 static int rtc_ds3231_get_ctrl_sts(const struct device *dev, uint8_t *buf)
 {
 	const struct rtc_ds3231_conf *config = dev->config;
 
 	return mfd_ds3231_i2c_get_registers(config->mfd, DS3231_REG_CTRL_STS, buf, 1);
 }
+#endif /* CONFIG_RTC_ALARM */
 
 struct rtc_ds3231_settings {
 	bool osc;                      /* bit 0 */
@@ -641,7 +644,7 @@ static int rtc_ds3231_init_alarms(struct rtc_ds3231_data *data)
 	data->alarms[1] = (struct rtc_ds3231_alarm){NULL, NULL};
 	return 0;
 }
-#endif
+#endif /* CONFIG_RTC_ALARM */
 
 #ifdef CONFIG_RTC_UPDATE
 static int rtc_ds3231_init_update(struct rtc_ds3231_data *data)
@@ -805,7 +808,7 @@ static int rtc_ds3231_init(const struct device *dev)
 	int err = 0;
 
 	const struct rtc_ds3231_conf *config = dev->config;
-	struct rtc_ds3231_data *data = dev->data;
+	struct rtc_ds3231_data __maybe_unused *data = dev->data;
 
 	if (!device_is_ready(config->mfd)) {
 		return -ENODEV;

--- a/drivers/sensor/maxim/ds3231/ds3231.c
+++ b/drivers/sensor/maxim/ds3231/ds3231.c
@@ -37,6 +37,16 @@ struct sensor_ds3231_conf {
 	const struct device *mfd;
 };
 
+static inline void sensor_ds3231_temp_from_raw(struct sensor_ds3231_data *data,
+					       struct sensor_value *val)
+{
+	const uint16_t raw_temp = data->raw_temp;
+	uint8_t frac = raw_temp & 3;
+
+	val->val1 = (int8_t)(raw_temp & GENMASK(8, 2)) >> 2;
+	val->val2 = (frac * 25) * pow(10, 4);
+}
+
 int sensor_ds3231_read_temp(const struct device *dev, uint16_t *raw_temp)
 {
 	const struct sensor_ds3231_conf *config = dev->config;
@@ -74,13 +84,7 @@ static int sensor_ds3231_channel_get(const struct device *dev, enum sensor_chann
 
 	switch (chan) {
 	case SENSOR_CHAN_AMBIENT_TEMP:
-		const uint16_t raw_temp = data->raw_temp;
-
-		val->val1 = (int8_t)(raw_temp & GENMASK(8, 2)) >> 2;
-
-		uint8_t frac = raw_temp & 3;
-
-		val->val2 = (frac * 25) * pow(10, 4);
+		sensor_ds3231_temp_from_raw(data, val);
 		break;
 	default:
 		return -ENOTSUP;


### PR DESCRIPTION
- avoid warnings about unused code (in case of unused features, e.g. alarm or update)
- avoid compilation error (probably most important for the codebase, a really unsightly typo)
- as the C language treats “cases” similarly to “labels”, a “case” block must begin with a statement and not with a variable declaration (declarations are not statements)