### PR TITLE
tests: adc: enable adc node on SAMD boards

### DIFF
--- a/tests/drivers/adc/adc_api/boards/adafruit_trinket_m0.overlay
+++ b/tests/drivers/adc/adc_api/boards/adafruit_trinket_m0.overlay
@@ -13,6 +13,7 @@
 };
 
 &adc {
+	status = "okay";
 	#address-cells = <1>;
 	#size-cells = <0>;
 


### PR DESCRIPTION
the adc0 node is now disabled by default in the soc. enable it so that adc test passes.