### PR TITLE
drivers: wifi: esp_at: fix dns resolve failure

### DIFF
--- a/drivers/wifi/esp_at/Kconfig.esp_at
+++ b/drivers/wifi/esp_at/Kconfig.esp_at
@@ -163,6 +163,7 @@ config WIFI_ESP_AT_DNS_USE
 
 config WIFI_ESP_AT_CIPDINFO_USE
 	bool "Use CIPDINFO to get peer ip and port"
+	default y if DNS_RESOLVER
 	help
 	  Enable AT+CIPDINFO to get peer ip-address and port.
 

--- a/drivers/wifi/esp_at/esp.c
+++ b/drivers/wifi/esp_at/esp.c
@@ -825,7 +825,13 @@ static int cmd_ipd_parse_hdr(struct esp_data *dev,
 		char *remote_ip;
 		long port;
 
-		err = esp_pull_quoted(&str, str_end, &remote_ip);
+		if (IS_ENABLED(CONFIG_WIFI_ESP_AT_VERSION_1_7)) {
+			/* NOT quoted per AT version 1.7.0 */
+			err = esp_pull_raw(&str, str_end, &remote_ip);
+		} else {
+			/* Quoted per AT version 2.1.0/2.2.0 */
+			err = esp_pull_quoted(&str, str_end, &remote_ip);
+		}
 		if (err) {
 			if (err == -EAGAIN && match_len >= MAX_IPD_LEN) {
 				LOG_ERR("Failed to pull remote_ip");


### PR DESCRIPTION
For `esp_at` driver, this fixes DNS resolve failure with `CONFIG_DNS_RESOLVER` enabled, including:
1. Enable `CONFIG_WIFI_ESP_AT_CIPDINFO_USE` (AT+CIPDINFO) to get peer ip-address and port, required by `CONFIG_DNS_RESOLVER`
2. Fix parse error on AT+CIPDINFO