### PR TITLE
mgmt: mcumgr: grp: img_mgmt: Limit scope of includes

### DIFF
--- a/include/zephyr/mgmt/mcumgr/grp/img_mgmt/img_mgmt.h
+++ b/include/zephyr/mgmt/mcumgr/grp/img_mgmt/img_mgmt.h
@@ -9,10 +9,13 @@
 #define H_IMG_MGMT_
 
 #include <inttypes.h>
-#include <zephyr/mgmt/mcumgr/mgmt/mgmt.h>
-#include <zephyr/mgmt/mcumgr/smp/smp.h>
 #include <bootutil/image.h>
 #include <zcbor_common.h>
+
+#ifdef CONFIG_MCUMGR_GRP_IMG_VERBOSE_ERR
+#include <zephyr/mgmt/mcumgr/mgmt/mgmt.h>
+#include <zephyr/mgmt/mcumgr/smp/smp.h>
+#endif
 
 /**
  * @brief MCUmgr img_mgmt API


### PR DESCRIPTION
Limits the scope of includes to only include some files if they are needed, which is when a Kconfig is set

Fixes #53516