### PR TITLE
arch: arm: cortex_m: 'movs reg, imm' mnemonic

### DIFF
--- a/arch/arm/core/cortex_m/thread.c
+++ b/arch/arm/core/cortex_m/thread.c
@@ -611,7 +611,7 @@ FUNC_NORETURN void z_arm_switch_to_main_no_multithreading(k_thread_entry_t main_
 		"msr  PSPLIM, %[_psplim]\n" /* __set_PSPLIM(_psplim) */
 #endif
 		"msr  PSP, %[_psp]\n" /* __set_PSP(psp) */
-		"mov r0, #0\n"
+		"movs r0, #0\n"
 		"ldr r1, =arch_irq_unlock_outlined\n"
 		"blx r1\n"
 


### PR DESCRIPTION
One nmemonic was missed by f84342828cd1 in PR https://github.com/zephyrproject-rtos/zephyr/pull/80441

This is causing test failures on m0 with IAR.

That commit said it better than I could myself:

> The ARM Thumb-1 instruction set, used by ARMv6-M and ARMv8-M Baseline cores, does not have a valid encoding for "immediate-to-register move without affecting flags" instruction (i.e. `mov reg, imm`), and the only valid variant of immediate-to-register move instruction for it is `movs`, which affects the flags.
> 
> Since none of the register initialisation instructions used here are flag-sensitive in their context, this commit changes `mov` to `movs`.
> 
> This fixes the compilation errors with Clang/LLVM, which is more picky about the `mov` mnemonic usage and prints out an "invalid instruction" error when `mov reg, imm` is specified in Thumb-1 mode.
> 
> Note that GNU assembler implicitly converts `mov reg, imm` to `movs reg, imm` when assembling in Thumb-1 mode.