### PR TITLE
toolchain: x86: Fix broken -Os detection in ia32.cmake

### DIFF
--- a/arch/x86/ia32.cmake
+++ b/arch/x86/ia32.cmake
@@ -3,7 +3,10 @@
 
 # Find out if we are optimizing for size
 get_target_property(zephyr_COMPILE_OPTIONS zephyr_interface INTERFACE_COMPILE_OPTIONS)
-if ("-Os" IN_LIST zephyr_COMPILE_OPTIONS)
+#Any -Os is (or may be) wraped in $<COMPILE_LANGUAGE> guards
+list(FILTER zephyr_COMPILE_OPTIONS INCLUDE REGEX "-Os")
+list(LENGTH zephyr_COMPILE_OPTIONS have_os)
+if (${have_os} GREATER 0)
   zephyr_cc_option(-mpreferred-stack-boundary=2)
 else()
   zephyr_compile_definitions(PERF_OPT)


### PR DESCRIPTION
Our efforts for iar toolchain has forced us to include compile-language guards around entries in the COMPILE_OPTIONS property for zephyr_interface. Unfortunately this causes the formerly bare -Os entry to be wrapped in a cmake-generator expressions causing the current -Os detection in ia32.cmake to fail. 

This change fixes that, while keeping as much of the current behavior. 
It may be that it would be better to look for CONFIG_SIZE_OPTIMIZATIONS or something like that instead, but someone with more insight is welcome to follow up in that case.