### PR TITLE
tests: kernel: Don't use VLA in pipe_api test.

### DIFF
--- a/tests/kernel/pipe/pipe_api/src/stress.c
+++ b/tests/kernel/pipe/pipe_api/src/stress.c
@@ -11,6 +11,9 @@
 #include <zephyr/random/random.h>
 #include <zephyr/timing/timing.h>
 
+#define WRITE_LEN 512
+#define READ_LEN  512
+
 LOG_MODULE_REGISTER(k_k_pipe_stress, LOG_LEVEL_INF);
 
 ZTEST_SUITE(k_pipe_stress, NULL, NULL, NULL, NULL, NULL);
@@ -19,9 +22,9 @@ ZTEST(k_pipe_stress, test_write)
 {
 	int rc;
 	struct k_pipe pipe;
-	size_t len = 512;
-	uint8_t buffer[len];
-	uint8_t buf[len];
+	const size_t len = WRITE_LEN;
+	uint8_t buffer[WRITE_LEN];
+	uint8_t buf[WRITE_LEN];
 	size_t sent;
 	uint32_t start_cycles, end_cycles;
 
@@ -41,9 +44,9 @@ ZTEST(k_pipe_stress, test_read)
 {
 	int rc;
 	struct k_pipe pipe;
-	size_t len = 512;
-	uint8_t buffer[len];
-	uint8_t buf[len];
+	const size_t len = READ_LEN;
+	uint8_t buffer[READ_LEN];
+	uint8_t buf[READ_LEN];
 	size_t sent, read;
 	uint32_t start_cycles, end_cycles;
 


### PR DESCRIPTION
In the current pipe_api test file we inadvertantly use VLA. 
Toolchains are allowed by standard to allocate VLA on heap for example. 
Therefore in my opinion we should maximize portability and try to avoid
VLA atleast in kernel+kernel tests.