### PR TITLE
Bluetooth: Host: Allow application to leverage the LONG WQ

### DIFF
--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -12,9 +12,7 @@ config BT_LONG_WQ
 
 if BT_LONG_WQ
 config BT_LONG_WQ_STACK_SIZE
-	# Hidden: Long workqueue stack size. Should be derived from system
-	# requirements.
-	int
+	int "Long workqueue stack size"
 	default 1400 if BT_ECC
 	default 1300 if BT_GATT_CACHING
 	default 1024


### PR DESCRIPTION
* Applications can also benefit from the WQ for long-running tasks without having to create a new WQ