### PR TITLE
drivers: sensor: st: add missing buffer size config

### DIFF
--- a/drivers/sensor/st/stmemsc/stmemsc_i2c.c
+++ b/drivers/sensor/st/stmemsc/stmemsc_i2c.c
@@ -41,7 +41,7 @@ int stmemsc_i2c_read_incr(const struct i2c_dt_spec *stmemsc,
 int stmemsc_i2c_write_incr(const struct i2c_dt_spec *stmemsc,
 			   uint8_t reg_addr, uint8_t *value, uint8_t len)
 {
-	uint8_t buf[17];
+	uint8_t buf[CONFIG_STMEMSC_I3C_I2C_WRITE_BUFFER_SIZE];
 
 	__ASSERT_NO_MSG(len <= sizeof(buf) - 1);
 


### PR DESCRIPTION
Previously, the Kconfig option CONFIG_STMEMSC_I3C_I2C_WRITE_BUFFER_SIZE has been introduced to replace i2c_burst_write with i2c_write using a buffer combining the address and data. See #79347

Add missing buffer size config to stmemsc_i2c_write_incr to replace fixed buffer size.