### PR TITLE
Bluetooth: ISO: Shell: Fix underflow of count for TX

### DIFF
--- a/subsys/bluetooth/host/shell/iso.c
+++ b/subsys/bluetooth/host/shell/iso.c
@@ -10,6 +10,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <stddef.h>
 #include <stdlib.h>
 #include <ctype.h>
 #include <zephyr/kernel.h>
@@ -557,6 +558,12 @@ static int cmd_send(const struct shell *sh, size_t argc, char *argv[])
 
 			return -ENOEXEC;
 		}
+
+		if (count < 1) {
+			shell_error(sh, "Cannot send 0 times");
+
+			return -ENOEXEC;
+		}
 	}
 
 	if (!iso_chan.iso) {
@@ -670,6 +677,12 @@ static int cmd_broadcast(const struct shell *sh, size_t argc, char *argv[])
 		count = shell_strtoul(argv[1], 0, &ret);
 		if (ret != 0) {
 			shell_error(sh, "Could not parse count: %d", ret);
+
+			return -ENOEXEC;
+		}
+
+		if (count < 1) {
+			shell_error(sh, "Cannot send 0 times");
 
 			return -ENOEXEC;
 		}


### PR DESCRIPTION
The cmd_broadcast and cmd_send both should not take a count value less than 1.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/84764
Fixes https://github.com/zephyrproject-rtos/zephyr/issues/84718