### PR TITLE
samples: hid-keyboard: clear report buffer at startup

### DIFF
--- a/include/zephyr/drivers/usb/udc_buf.h
+++ b/include/zephyr/drivers/usb/udc_buf.h
@@ -70,7 +70,7 @@
  */
 #define UDC_STATIC_BUF_DEFINE(name, size)					\
 	static uint8_t Z_UDC_BUF_SECTION __aligned(UDC_BUF_ALIGN)		\
-	name[ROUND_UP(size, UDC_BUF_GRANULARITY)];
+	name[ROUND_UP(size, UDC_BUF_GRANULARITY)]
 
 /**
  * @brief Verify that the buffer is aligned as required by the UDC driver

--- a/samples/subsys/usb/hid-keyboard/src/main.c
+++ b/samples/subsys/usb/hid-keyboard/src/main.c
@@ -175,6 +175,12 @@ int main(void)
 	const struct device *hid_dev;
 	int ret;
 
+	/*
+	 * Set the report buffer to 0, since it can be placed in a memory area
+	 * that is not initialized during boot.
+	 */
+	memset(report, 0, sizeof(report));
+
 	for (unsigned int i = 0; i < ARRAY_SIZE(kb_leds); i++) {
 		if (kb_leds[i].port == NULL) {
 			continue;


### PR DESCRIPTION
include: udc: remove semicolon from macro definition 

Set the report buffer to 0, since it can be placed in a memory area
that is not initialized during boot, for example nocache area.