### PR TITLE
Bluetooth: Audio: Shell: Fix ad data returning -1

### DIFF
--- a/subsys/bluetooth/audio/shell/audio.h
+++ b/subsys/bluetooth/audio/shell/audio.h
@@ -40,17 +40,17 @@
 
 extern struct bt_csip_set_member_svc_inst *svc_inst;
 
-ssize_t audio_ad_data_add(struct bt_data *data, const size_t data_size, const bool discoverable,
-			  const bool connectable);
-ssize_t audio_pa_data_add(struct bt_data *data_array, const size_t data_array_size);
-ssize_t csis_ad_data_add(struct bt_data *data, const size_t data_size, const bool discoverable);
+size_t audio_ad_data_add(struct bt_data *data, const size_t data_size, const bool discoverable,
+			 const bool connectable);
+size_t audio_pa_data_add(struct bt_data *data_array, const size_t data_array_size);
+size_t csis_ad_data_add(struct bt_data *data, const size_t data_size, const bool discoverable);
 size_t cap_acceptor_ad_data_add(struct bt_data data[], size_t data_size, bool discoverable);
 size_t bap_scan_delegator_ad_data_add(struct bt_data data[], size_t data_size);
 size_t gmap_ad_data_add(struct bt_data data[], size_t data_size);
 size_t pbp_ad_data_add(struct bt_data data[], size_t data_size);
-ssize_t cap_initiator_ad_data_add(struct bt_data *data_array, const size_t data_array_size,
-				  const bool discoverable, const bool connectable);
-ssize_t cap_initiator_pa_data_add(struct bt_data *data_array, const size_t data_array_size);
+size_t cap_initiator_ad_data_add(struct bt_data *data_array, const size_t data_array_size,
+				 const bool discoverable, const bool connectable);
+size_t cap_initiator_pa_data_add(struct bt_data *data_array, const size_t data_array_size);
 
 #if defined(CONFIG_BT_AUDIO)
 /* Must guard before including audio.h as audio.h uses Kconfigs guarded by

--- a/subsys/bluetooth/audio/shell/bap.c
+++ b/subsys/bluetooth/audio/shell/bap.c
@@ -47,6 +47,7 @@
 #include <zephyr/sys/util_macro.h>
 #include <zephyr/sys_clock.h>
 
+#include "common/bt_shell_private.h"
 #include "host/shell/bt.h"
 #include "audio.h"
 
@@ -4222,8 +4223,7 @@ static int cmd_bap(const struct shell *sh, size_t argc, char **argv)
 
 SHELL_CMD_ARG_REGISTER(bap, &bap_cmds, "Bluetooth BAP shell commands", cmd_bap, 1, 1);
 
-static ssize_t connectable_ad_data_add(struct bt_data *data_array,
-				       size_t data_array_size)
+static size_t connectable_ad_data_add(struct bt_data *data_array, size_t data_array_size)
 {
 	static const uint8_t ad_ext_uuid16[] = {
 		IF_ENABLED(CONFIG_BT_MICP_MIC_DEV, (BT_UUID_16_ENCODE(BT_UUID_MICS_VAL),))
@@ -4305,8 +4305,7 @@ static ssize_t connectable_ad_data_add(struct bt_data *data_array,
 	return ad_len;
 }
 
-static ssize_t nonconnectable_ad_data_add(struct bt_data *data_array,
-					  const size_t data_array_size)
+static size_t nonconnectable_ad_data_add(struct bt_data *data_array, const size_t data_array_size)
 {
 	static const uint8_t ad_ext_uuid16[] = {
 		IF_ENABLED(CONFIG_BT_PACS, (BT_UUID_16_ENCODE(BT_UUID_PACS_VAL),))
@@ -4337,9 +4336,9 @@ static ssize_t nonconnectable_ad_data_add(struct bt_data *data_array,
 
 		err = bt_rand(&broadcast_id, BT_AUDIO_BROADCAST_ID_SIZE);
 		if (err != 0) {
-			printk("Unable to generate broadcast ID: %d\n", err);
+			bt_shell_error("Unable to generate broadcast ID: %d\n", err);
 
-			return -1;
+			return 0;
 		}
 
 		sys_put_le24(broadcast_id, &ad_bap_broadcast_announcement[2]);
@@ -4365,10 +4364,10 @@ static ssize_t nonconnectable_ad_data_add(struct bt_data *data_array,
 	return ad_len;
 }
 
-ssize_t audio_ad_data_add(struct bt_data *data_array, const size_t data_array_size,
-			  const bool discoverable, const bool connectable)
+size_t audio_ad_data_add(struct bt_data *data_array, const size_t data_array_size,
+			 const bool discoverable, const bool connectable)
 {
-	ssize_t ad_len = 0;
+	size_t ad_len = 0;
 
 	if (!discoverable) {
 		return 0;
@@ -4388,8 +4387,7 @@ ssize_t audio_ad_data_add(struct bt_data *data_array, const size_t data_array_si
 	return ad_len;
 }
 
-ssize_t audio_pa_data_add(struct bt_data *data_array,
-			  const size_t data_array_size)
+size_t audio_pa_data_add(struct bt_data *data_array, const size_t data_array_size)
 {
 	size_t ad_len = 0;
 
@@ -4405,9 +4403,9 @@ ssize_t audio_pa_data_add(struct bt_data *data_array,
 
 		err = bt_bap_broadcast_source_get_base(default_source.bap_source, &base_buf);
 		if (err != 0) {
-			printk("Unable to get BASE: %d\n", err);
+			bt_shell_error("Unable to get BASE: %d\n", err);
 
-			return -1;
+			return 0;
 		}
 
 		data_array[ad_len].type = BT_DATA_SVC_DATA16;

--- a/subsys/bluetooth/audio/shell/cap_initiator.c
+++ b/subsys/bluetooth/audio/shell/cap_initiator.c
@@ -33,6 +33,7 @@
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/audio/cap.h>
 
+#include "common/bt_shell_private.h"
 #include "host/shell/bt.h"
 #include "audio.h"
 
@@ -1426,7 +1427,7 @@ SHELL_CMD_ARG_REGISTER(cap_initiator, &cap_initiator_cmds,
 		       "Bluetooth CAP initiator shell commands",
 		       cmd_cap_initiator, 1, 1);
 
-static ssize_t nonconnectable_ad_data_add(struct bt_data *data_array, const size_t data_array_size)
+static size_t nonconnectable_ad_data_add(struct bt_data *data_array, const size_t data_array_size)
 {
 #if defined(CONFIG_BT_BAP_BROADCAST_SOURCE)
 	if (default_source.cap_source != NULL && default_source.is_cap) {
@@ -1438,9 +1439,9 @@ static ssize_t nonconnectable_ad_data_add(struct bt_data *data_array, const size
 
 		err = bt_rand(&broadcast_id, BT_AUDIO_BROADCAST_ID_SIZE);
 		if (err) {
-			printk("Unable to generate broadcast ID: %d\n", err);
+			bt_shell_error("Unable to generate broadcast ID: %d\n", err);
 
-			return -1;
+			return 0;
 		}
 
 		sys_put_le24(broadcast_id, &ad_cap_broadcast_announcement[2]);
@@ -1455,8 +1456,8 @@ static ssize_t nonconnectable_ad_data_add(struct bt_data *data_array, const size
 	return 0;
 }
 
-ssize_t cap_initiator_ad_data_add(struct bt_data *data_array, const size_t data_array_size,
-				  const bool discoverable, const bool connectable)
+size_t cap_initiator_ad_data_add(struct bt_data *data_array, const size_t data_array_size,
+				 const bool discoverable, const bool connectable)
 {
 	if (!discoverable) {
 		return 0;
@@ -1469,7 +1470,7 @@ ssize_t cap_initiator_ad_data_add(struct bt_data *data_array, const size_t data_
 	return 0;
 }
 
-ssize_t cap_initiator_pa_data_add(struct bt_data *data_array, const size_t data_array_size)
+size_t cap_initiator_pa_data_add(struct bt_data *data_array, const size_t data_array_size)
 {
 #if defined(CONFIG_BT_BAP_BROADCAST_SOURCE)
 	if (default_source.cap_source != NULL && default_source.is_cap) {
@@ -1483,9 +1484,9 @@ ssize_t cap_initiator_pa_data_add(struct bt_data *data_array, const size_t data_
 
 		err = bt_cap_initiator_broadcast_get_base(default_source.cap_source, &base_buf);
 		if (err != 0) {
-			printk("Unable to get BASE: %d\n", err);
+			bt_shell_error("Unable to get BASE: %d\n", err);
 
-			return -1;
+			return 0;
 		}
 
 		data_array[0].type = BT_DATA_SVC_DATA16;

--- a/subsys/bluetooth/audio/shell/csip_set_member.c
+++ b/subsys/bluetooth/audio/shell/csip_set_member.c
@@ -312,8 +312,8 @@ SHELL_CMD_ARG_REGISTER(csip_set_member, &csip_set_member_cmds,
 		       "Bluetooth CSIP set member shell commands",
 		       cmd_csip_set_member, 1, 1);
 
-ssize_t csis_ad_data_add(struct bt_data *data_array, const size_t data_array_size,
-			 const bool discoverable)
+size_t csis_ad_data_add(struct bt_data *data_array, const size_t data_array_size,
+			const bool discoverable)
 {
 	size_t ad_len = 0;
 
@@ -333,7 +333,8 @@ ssize_t csis_ad_data_add(struct bt_data *data_array, const size_t data_array_siz
 		err = bt_csip_set_member_generate_rsi(svc_inst, ad_rsi);
 		if (err != 0) {
 			bt_shell_error("Failed to generate RSI (err %d)", err);
-			return err;
+
+			return 0;
 		}
 
 		__ASSERT(data_array_size > ad_len, "No space for AD_RSI");

--- a/subsys/bluetooth/host/shell/bt.c
+++ b/subsys/bluetooth/host/shell/bt.c
@@ -1941,15 +1941,9 @@ static ssize_t ad_init(struct bt_data *data_array, const size_t data_array_size,
 
 	if (IS_ENABLED(CONFIG_BT_AUDIO) && IS_ENABLED(CONFIG_BT_EXT_ADV) && adv_ext) {
 		const bool connectable = atomic_test_bit(adv_options, SHELL_ADV_OPT_CONNECTABLE);
-		ssize_t audio_ad_len;
 
-		audio_ad_len = audio_ad_data_add(&data_array[ad_len], data_array_size - ad_len,
-						 discoverable, connectable);
-		if (audio_ad_len < 0) {
-			return audio_ad_len;
-		}
-
-		ad_len += audio_ad_len;
+		ad_len += audio_ad_data_add(&data_array[ad_len], data_array_size - ad_len,
+					    discoverable, connectable);
 	}
 
 	return ad_len;


### PR DESCRIPTION
Several advertising data function could return -1 in case of errors, which could mess up the advertising data since they are intended to increment a counter.

Instead of returning an error we use bt_shell_error to inform the user and then just return with no data changes, so that if any of them fails, the failing data is just omitted rather than causing major issues.

fixes https://github.com/zephyrproject-rtos/zephyr/issues/84700