### PR TITLE
soc: intel: ace: Fix intel_adsp power down issue when CONFIG_ADSP_POWER_DOWN_HPSRAM not defined

### DIFF
--- a/soc/intel/intel_adsp/ace/power.c
+++ b/soc/intel/intel_adsp/ace/power.c
@@ -340,7 +340,7 @@ void pm_state_set(enum pm_state state, uint8_t substate_id)
 			sys_cache_data_flush_range((void *)imr_layout, sizeof(*imr_layout));
 #endif /* CONFIG_ADSP_IMR_CONTEXT_SAVE */
 			/* do power down - this function won't return */
-			power_down(true, CONFIG_ADSP_POWER_DOWN_HPSRAM, true);
+			power_down(true, IS_ENABLED(CONFIG_ADSP_POWER_DOWN_HPSRAM), true);
 		} else {
 			power_gate_entry(cpu);
 		}


### PR DESCRIPTION
CONFIG_ADSP_POWER_DOWN_HPSRAM may not be defined (when it's "n") so update the code accordingly so that power_down() is called with correct parameters.

Fixes multiple CI tests failing in weekly run.

Simple repro:

```
west build -p auto -b intel_adsp/ace15_mtpm/sim samples/hello_world -- -DCONFIG_PM=y -DCONFIG_ADSP_POWER_DOWN_HPSRAM=n
```

Tests failing:

```
west twister -p intel_adsp/ace15_mtpm/sim -s cpp.main.cpp14 -i
west twister -p intel_adsp/ace15_mtpm/sim -s cpp.main.cpp17 -i
west twister -p intel_adsp/ace15_mtpm/sim -s cpp.main.cpp20 -i
west twister -p intel_adsp/ace15_mtpm/sim -s cpp.main.cpp2A -i
west twister -p intel_adsp/ace15_mtpm/sim -s cpp.main.cpp2B -i
west twister -p intel_adsp/ace15_mtpm/sim -s cpp.main.cpp98 -i
west twister -p intel_adsp/ace15_mtpm/sim -s cpp.main.minimal -i
west twister -p intel_adsp/ace15_mtpm/sim -s cpp.main.newlib -i
west twister -p intel_adsp/ace15_mtpm/sim -s cpp.main.picolibc -i
west twister -p intel_adsp/ace15_mtpm/sim -s net.coap.server.common -i
west twister -p intel_adsp/ace15_mtpm -s cpp.main.cpp14 -i
west twister -p intel_adsp/ace15_mtpm -s cpp.main.cpp17 -i
west twister -p intel_adsp/ace15_mtpm -s cpp.main.cpp20 -i
west twister -p intel_adsp/ace15_mtpm -s cpp.main.cpp2A -i
west twister -p intel_adsp/ace15_mtpm -s cpp.main.cpp2B -i
west twister -p intel_adsp/ace15_mtpm -s cpp.main.cpp98 -i
west twister -p intel_adsp/ace15_mtpm -s cpp.main.minimal -i
west twister -p intel_adsp/ace15_mtpm -s cpp.main.newlib -i
west twister -p intel_adsp/ace15_mtpm -s cpp.main.picolibc -i
west twister -p intel_adsp/ace20_lnl/sim -s cpp.main.cpp14 -i
west twister -p intel_adsp/ace20_lnl/sim -s cpp.main.cpp17 -i
west twister -p intel_adsp/ace20_lnl/sim -s cpp.main.cpp20 -i
west twister -p intel_adsp/ace20_lnl/sim -s cpp.main.cpp2A -i
west twister -p intel_adsp/ace20_lnl/sim -s cpp.main.cpp2B -i
west twister -p intel_adsp/ace20_lnl/sim -s cpp.main.cpp98 -i
west twister -p intel_adsp/ace20_lnl/sim -s cpp.main.minimal -i
west twister -p intel_adsp/ace20_lnl/sim -s cpp.main.newlib -i
west twister -p intel_adsp/ace20_lnl/sim -s cpp.main.picolibc -i
west twister -p intel_adsp/ace20_lnl/sim -s net.coap.server.common -i
west twister -p intel_adsp/ace20_lnl -s cpp.main.cpp14 -i
west twister -p intel_adsp/ace20_lnl -s cpp.main.cpp17 -i
west twister -p intel_adsp/ace20_lnl -s cpp.main.cpp20 -i
west twister -p intel_adsp/ace20_lnl -s cpp.main.cpp2A -i
west twister -p intel_adsp/ace20_lnl -s cpp.main.cpp2B -i
west twister -p intel_adsp/ace20_lnl -s cpp.main.cpp98 -i
west twister -p intel_adsp/ace20_lnl -s cpp.main.minimal -i
west twister -p intel_adsp/ace20_lnl -s cpp.main.newlib -i
west twister -p intel_adsp/ace20_lnl -s cpp.main.picolibc -i
west twister -p intel_adsp/ace30/ptl/sim -s cpp.main.cpp14 -i
west twister -p intel_adsp/ace30/ptl/sim -s cpp.main.cpp17 -i
west twister -p intel_adsp/ace30/ptl/sim -s cpp.main.cpp20 -i
west twister -p intel_adsp/ace30/ptl/sim -s cpp.main.cpp2A -i
west twister -p intel_adsp/ace30/ptl/sim -s cpp.main.cpp2B -i
west twister -p intel_adsp/ace30/ptl/sim -s cpp.main.cpp98 -i
west twister -p intel_adsp/ace30/ptl/sim -s cpp.main.minimal -i
west twister -p intel_adsp/ace30/ptl/sim -s cpp.main.newlib -i
west twister -p intel_adsp/ace30/ptl/sim -s cpp.main.picolibc -i
west twister -p intel_adsp/ace30/ptl/sim -s net.coap.server.common -i
west twister -p intel_adsp/ace30/ptl/sim -s sample.audio.sof -i
west twister -p intel_adsp/ace30/ptl -s cpp.main.cpp14 -i
west twister -p intel_adsp/ace30/ptl -s cpp.main.cpp17 -i
west twister -p intel_adsp/ace30/ptl -s cpp.main.cpp20 -i
west twister -p intel_adsp/ace30/ptl -s cpp.main.cpp2A -i
west twister -p intel_adsp/ace30/ptl -s cpp.main.cpp2B -i
west twister -p intel_adsp/ace30/ptl -s cpp.main.cpp98 -i
west twister -p intel_adsp/ace30/ptl -s cpp.main.minimal -i
west twister -p intel_adsp/ace30/ptl -s cpp.main.newlib -i
west twister -p intel_adsp/ace30/ptl -s cpp.main.picolibc -i
```
