### PR TITLE
dts: bindings: dma: Update the STM32 DMA reference link

### DIFF
--- a/dts/bindings/dma/st,stm32-bdma.yaml
+++ b/dts/bindings/dma/st,stm32-bdma.yaml
@@ -90,7 +90,7 @@ properties:
 
 # Parameter syntax of stm32 follows the dma client dts syntax
 # in the Linux kernel declared in
-# https://git.kernel.org/pub/scm/linux/kernel/git/devicetree/devicetree-rebasing.git/plain/Bindings/dma/st,stm32-dma.yaml
+# https://git.kernel.org/pub/scm/linux/kernel/git/devicetree/devicetree-rebasing.git/plain/Bindings/dma/stm32/st,stm32-dma.yaml
 
 dma-cells:
   - channel

--- a/dts/bindings/dma/st,stm32-dma-v1.yaml
+++ b/dts/bindings/dma/st,stm32-dma-v1.yaml
@@ -84,7 +84,7 @@ properties:
 
 # Parameter syntax of stm32 follows the dma client dts syntax
 # in the Linux kernel declared in
-# https://git.kernel.org/pub/scm/linux/kernel/git/devicetree/devicetree-rebasing.git/plain/Bindings/dma/st,stm32-dma.yaml
+# https://git.kernel.org/pub/scm/linux/kernel/git/devicetree/devicetree-rebasing.git/plain/Bindings/dma/stm32/st,stm32-dma.yaml
 
 dma-cells:
   - channel

--- a/dts/bindings/dma/st,stm32-dma-v2.yaml
+++ b/dts/bindings/dma/st,stm32-dma-v2.yaml
@@ -83,7 +83,7 @@ properties:
 
 # Parameter syntax of stm32 follows the dma client dts syntax
 # in the Linux kernel declared in
-# https://git.kernel.org/pub/scm/linux/kernel/git/devicetree/devicetree-rebasing.git/plain/Bindings/dma/st,stm32-dma.yaml
+# https://git.kernel.org/pub/scm/linux/kernel/git/devicetree/devicetree-rebasing.git/plain/Bindings/dma/stm32/st,stm32-dma.yaml
 
 dma-cells:
   - channel

--- a/dts/bindings/dma/st,stm32-dma-v2bis.yaml
+++ b/dts/bindings/dma/st,stm32-dma-v2bis.yaml
@@ -78,7 +78,7 @@ properties:
 
 # Parameter syntax of stm32 follows the dma client dts syntax
 # in the Linux kernel declared in
-# https://git.kernel.org/pub/scm/linux/kernel/git/devicetree/devicetree-rebasing.git/plain/Bindings/dma/st,stm32-dma.yaml
+# https://git.kernel.org/pub/scm/linux/kernel/git/devicetree/devicetree-rebasing.git/plain/Bindings/dma/stm32/st,stm32-dma.yaml
 
 dma-cells:
   - channel

--- a/dts/bindings/dma/st,stm32-dmamux.yaml
+++ b/dts/bindings/dma/st,stm32-dmamux.yaml
@@ -71,7 +71,7 @@ properties:
 
 # Parameter syntax of stm32 follows the dma client dts syntax
 # in the Linux kernel declared in
-# https://git.kernel.org/pub/scm/linux/kernel/git/devicetree/devicetree-rebasing.git/plain/Bindings/dma/st,stm32-dmamux.yaml
+# https://git.kernel.org/pub/scm/linux/kernel/git/devicetree/devicetree-rebasing.git/plain/Bindings/dma/stm32/st,stm32-dmamux.yaml
 
 dma-cells:
   - channel


### PR DESCRIPTION
ST engineer has moved STM32 DMA controllers bindings under ./dma/stm32/ in Linux source code reference by this commit:
	https://git.kernel.org/torvalds/c/8494ae75dde4