### PR TITLE
Update testcase filters to exclude small targets

### DIFF
--- a/boards/arm/mps2/mps2_an385.yaml
+++ b/boards/arm/mps2/mps2_an385.yaml
@@ -17,3 +17,5 @@ supported:
 testing:
   default: true
 vendor: arm
+ram: 4096
+flash: 4096

--- a/boards/qemu/cortex_a53/qemu_cortex_a53.yaml
+++ b/boards/qemu/cortex_a53/qemu_cortex_a53.yaml
@@ -7,7 +7,8 @@ arch: arm64
 toolchain:
   - zephyr
   - cross-compile
-ram: 128
+ram: 131072
+flash: 65536
 testing:
   default: true
   ignore_tags:

--- a/boards/qemu/xtensa/qemu_xtensa_dc233c.yaml
+++ b/boards/qemu/xtensa/qemu_xtensa_dc233c.yaml
@@ -12,3 +12,5 @@ testing:
     - net
     - bluetooth
 vendor: cdns
+ram: 16384
+flash: 32768

--- a/tests/drivers/build_all/eeprom/testcase.yaml
+++ b/tests/drivers/build_all/eeprom/testcase.yaml
@@ -6,6 +6,7 @@ common:
 tests:
   drivers.eeprom.build:
     min_ram: 32
+    min_flash: 128
     platform_exclude: serpente
     depends_on:
       - gpio
@@ -13,7 +14,8 @@ tests:
       - spi
 
   drivers.eeprom.emul.build:
-    min_ram: 32
+    min_ram: 64
+    min_flash: 128
     platform_exclude: serpente
     depends_on:
       - gpio

--- a/tests/drivers/stepper/drv8424/api/testcase.yaml
+++ b/tests/drivers/stepper/drv8424/api/testcase.yaml
@@ -12,7 +12,3 @@ tests:
       - nucleo_f767zi
       - mimxrt1060_evk/mimxrt1062/qspi
       - native_sim
-    integration_platforms:
-      - nucleo_f767zi
-      - mimxrt1060_evk/mimxrt1062/qspi
-      - native_sim

--- a/tests/drivers/stepper/drv8424/emul/testcase.yaml
+++ b/tests/drivers/stepper/drv8424/emul/testcase.yaml
@@ -9,5 +9,3 @@ tests:
       - drv8424
     platform_allow:
       - native_sim
-    integration_platforms:
-      - native_sim

--- a/tests/drivers/stepper/shell/testcase.yaml
+++ b/tests/drivers/stepper/shell/testcase.yaml
@@ -6,10 +6,10 @@ common:
 
 tests:
   drivers.stepper.shell:
-    integration_platforms:
+    platform_allow:
       - native_sim
       - native_sim/native/64
   drivers.stepper.shell_async:
-    integration_platforms:
+    platform_allow:
       - native_sim
       - native_sim/native/64

--- a/tests/subsys/llext/testcase.yaml
+++ b/tests/subsys/llext/testcase.yaml
@@ -19,6 +19,8 @@ common:
     - arch:arm64:CONFIG_LLEXT_HEAP_SIZE=128
   extra_conf_files:
     - prj.conf
+  min_ram: 172                # Size on arm: max: 145, min: 79
+  min_flash: 172              # Size on arm: max: 140, min: 105
 
 tests:
   # While there is in practice no value in compiling subsys/llext/*.c
@@ -42,7 +44,6 @@ tests:
     extra_configs:
       - CONFIG_LLEXT_STORAGE_WRITABLE=n
   llext.readonly_mpu:
-    min_ram: 128
     arch_allow: arm # Xtensa needs writable storage, currently not supported on RISC-V
     filter: CONFIG_ARCH_HAS_USERSPACE
     extra_configs:


### PR DESCRIPTION
Some tests are built for small and unsupported targets, update filters to exclude them. The filters now use min_ram and min_flash for filtering, this requires boards to define rom: and flash: in their board.yaml files, so some boards which are marked as integration platforms where updated with these values.