### PR TITLE
rtio: Fix completion count overflow issue

### DIFF
--- a/include/zephyr/rtio/rtio.h
+++ b/include/zephyr/rtio/rtio.h
@@ -1177,7 +1177,16 @@ static inline void rtio_cqe_submit(struct rtio *r, int result, void *userdata, u
 		rtio_cqe_produce(r, cqe);
 	}
 
-	atomic_inc(&r->cq_count);
+	/* atomic_t isn't guaranteed to wrap correctly as it could be signed, so
+	 * we must resort to a cas loop.
+	 */
+	atomic_t val, new_val;
+
+	do {
+		val = atomic_get(&r->cq_count);
+		new_val = (atomic_t)((uintptr_t)val + 1);
+	} while (!atomic_cas(&r->cq_count, val, new_val));
+
 #ifdef CONFIG_RTIO_SUBMIT_SEM
 	if (r->submit_count > 0) {
 		r->submit_count--;
@@ -1428,6 +1437,8 @@ static inline int z_impl_rtio_cqe_copy_out(struct rtio *r,
  * submission chain, freeing submission queue events when done, and
  * producing completion queue events as submissions are completed.
  *
+ * @warning It is undefined behavior to have re-entrant calls to submit
+ *
  * @param r RTIO context
  * @param wait_count Number of submissions to wait for completion of.
  *
@@ -1435,13 +1446,11 @@ static inline int z_impl_rtio_cqe_copy_out(struct rtio *r,
  */
 __syscall int rtio_submit(struct rtio *r, uint32_t wait_count);
 
+#ifdef CONFIG_RTIO_SUBMIT_SEM
 static inline int z_impl_rtio_submit(struct rtio *r, uint32_t wait_count)
 {
 	int res = 0;
 
-#ifdef CONFIG_RTIO_SUBMIT_SEM
-	/* TODO undefined behavior if another thread calls submit of course
-	 */
 	if (wait_count > 0) {
 		__ASSERT(!k_is_in_isr(),
 			 "expected rtio submit with wait count to be called from a thread");
@@ -1449,35 +1458,43 @@ static inline int z_impl_rtio_submit(struct rtio *r, uint32_t wait_count)
 		k_sem_reset(r->submit_sem);
 		r->submit_count = wait_count;
 	}
-#else
-	uintptr_t cq_count = (uintptr_t)atomic_get(&r->cq_count) + wait_count;
-#endif
 
-	/* Submit the queue to the executor which consumes submissions
-	 * and produces completions through ISR chains or other means.
-	 */
 	rtio_executor_submit(r);
-
-
-	/* TODO could be nicer if we could suspend the thread and not
-	 * wake up on each completion here.
-	 */
-#ifdef CONFIG_RTIO_SUBMIT_SEM
 
 	if (wait_count > 0) {
 		res = k_sem_take(r->submit_sem, K_FOREVER);
 		__ASSERT(res == 0,
 			 "semaphore was reset or timed out while waiting on completions!");
 	}
-#else
-	while ((uintptr_t)atomic_get(&r->cq_count) < cq_count) {
-		Z_SPIN_DELAY(10);
-		k_yield();
-	}
-#endif
 
 	return res;
 }
+#else
+static inline int z_impl_rtio_submit(struct rtio *r, uint32_t wait_count)
+{
+
+	int res = 0;
+	uintptr_t cq_count = (uintptr_t)atomic_get(&r->cq_count);
+	uintptr_t cq_complete_count = cq_count + wait_count;
+	bool wraps = cq_complete_count < cq_count;
+
+	rtio_executor_submit(r);
+
+	if (wraps) {
+		while ((uintptr_t)atomic_get(&r->cq_count) >= cq_count) {
+			Z_SPIN_DELAY(10);
+			k_yield();
+		}
+	}
+
+	while ((uintptr_t)atomic_get(&r->cq_count) < cq_complete_count) {
+		Z_SPIN_DELAY(10);
+		k_yield();
+	}
+
+	return res;
+}
+#endif /* CONFIG_RTIO_SUBMIT_SEM */
 
 /**
  * @}

--- a/tests/subsys/rtio/rtio_api/src/test_rtio_api.c
+++ b/tests/subsys/rtio/rtio_api/src/test_rtio_api.c
@@ -616,6 +616,25 @@ ZTEST(rtio_api, test_rtio_transaction)
 	}
 }
 
+ZTEST(rtio_api, test_rtio_cqe_count_overflow)
+{
+	/* atomic_t is signed, but RTIO uses cq_count as `uintptr_t` */
+	const atomic_t max_val = (1ULL << (ATOMIC_BITS)) - 1;
+
+	TC_PRINT("initializing iodev test devices\n");
+
+	for (int i = 0; i < 2; i++) {
+		rtio_iodev_test_init(iodev_test_transaction[i]);
+	}
+
+	TC_PRINT("rtio transaction CQE overflow\n");
+	atomic_set(&r_transaction.cq_count, max_val - 3);
+	for (int i = 0; i < TEST_REPEATS; i++) {
+		test_rtio_transaction_(&r_transaction);
+	}
+}
+
+
 #define THROUGHPUT_ITERS 100000
 RTIO_DEFINE(r_throughput, SQE_POOL_SIZE, CQE_POOL_SIZE);
 

--- a/tests/subsys/rtio/rtio_api/src/test_rtio_api.c
+++ b/tests/subsys/rtio/rtio_api/src/test_rtio_api.c
@@ -618,8 +618,11 @@ ZTEST(rtio_api, test_rtio_transaction)
 
 ZTEST(rtio_api, test_rtio_cqe_count_overflow)
 {
-	/* atomic_t is signed, but RTIO uses cq_count as `uintptr_t` */
-	const atomic_t max_val = (1ULL << (ATOMIC_BITS)) - 1;
+	/* atomic_t max value as `uintptr_t` */
+	const atomic_t max_uval = UINTPTR_MAX;
+
+	/* atomic_t max value as if it were a signed word `intptr_t` */
+	const atomic_t max_sval = UINTPTR_MAX >> 1;
 
 	TC_PRINT("initializing iodev test devices\n");
 
@@ -628,7 +631,19 @@ ZTEST(rtio_api, test_rtio_cqe_count_overflow)
 	}
 
 	TC_PRINT("rtio transaction CQE overflow\n");
-	atomic_set(&r_transaction.cq_count, max_val - 3);
+	atomic_set(&r_transaction.cq_count, max_uval - 3);
+	for (int i = 0; i < TEST_REPEATS; i++) {
+		test_rtio_transaction_(&r_transaction);
+	}
+
+	TC_PRINT("initializing iodev test devices\n");
+
+	for (int i = 0; i < 2; i++) {
+		rtio_iodev_test_init(iodev_test_transaction[i]);
+	}
+
+	TC_PRINT("rtio transaction CQE overflow\n");
+	atomic_set(&r_transaction.cq_count, max_sval - 3);
 	for (int i = 0; i < TEST_REPEATS; i++) {
 		test_rtio_transaction_(&r_transaction);
 	}

--- a/tests/subsys/rtio/rtio_api/testcase.yaml
+++ b/tests/subsys/rtio/rtio_api/testcase.yaml
@@ -12,6 +12,8 @@ tests:
   rtio.api:
     filter: not CONFIG_ARCH_HAS_USERSPACE
     tags: rtio
+    extra_configs:
+      - CONFIG_RTIO_SUBMIT_SEM=n
     integration_platforms:
       - native_sim
   rtio.api.submit_sem:
@@ -25,6 +27,7 @@ tests:
     filter: CONFIG_ARCH_HAS_USERSPACE
     extra_configs:
       - CONFIG_USERSPACE=y
+      - CONFIG_RTIO_SUBMIT_SEM=n
     arch_exclude:
       - posix
     tags:


### PR DESCRIPTION
As noted by @JordanYates in #81802 cq_count being overflowed wasn't properly dealt with. This now correctly accounts for the completion count overflowing and wrapping.

fixes #81802 