### PR TITLE
tests: kernel: fatal: exception: Re-enable warning

### DIFF
--- a/tests/kernel/fatal/exception/src/main.c
+++ b/tests/kernel/fatal/exception/src/main.c
@@ -192,20 +192,10 @@ __no_optimization void blow_up_stack(void)
 /* stack sentinel doesn't catch it in time before it trashes the entire kernel
  */
 
-#if defined(__GNUC__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wpragmas"
-#pragma GCC diagnostic ignored "-Winfinite-recursion"
-#endif
-
 __no_optimization int stack_smasher(int val)
 {
 	return stack_smasher(val * 2) + stack_smasher(val * 3);
 }
-
-#if defined(__GNUC__)
-#pragma GCC diagnostic pop
-#endif
 
 void blow_up_stack(void)
 {


### PR DESCRIPTION
CI passes with this warning re-enabled, so remove it.