### PR TITLE
tests: kernel: gen_isr_table: Re-enable warning

### DIFF
--- a/tests/kernel/gen_isr_table/src/main.c
+++ b/tests/kernel/gen_isr_table/src/main.c
@@ -410,9 +410,6 @@ static void *gen_isr_table_setup(void)
 {
 	TC_PRINT("IRQ configuration (total lines %d):\n", CONFIG_NUM_IRQS);
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-label"
-
 	return NULL;
 }
 


### PR DESCRIPTION
This warning doesn't appear to be needed anymore and CI passes with it removed.