### PR TITLE
tests: posix: Re-enable `-Wunused-value` warning

### DIFF
--- a/tests/posix/headers/src/sys_socket_h.c
+++ b/tests/posix/headers/src/sys_socket_h.c
@@ -12,8 +12,6 @@
 #include <zephyr/posix/sys/socket.h>
 #endif
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-value"
 /**
  * @brief existence test for `<sys/socket.h>`
  *
@@ -51,9 +49,9 @@ ZTEST(posix_headers, test_sys_socket_h)
 	zassert_not_equal(-1, offsetof(struct cmsghdr, cmsg_level));
 	zassert_not_equal(-1, offsetof(struct cmsghdr, cmsg_type));
 
-	CMSG_DATA(&cmsg);
-	CMSG_NXTHDR(&mhdr, &cmsg);
-	CMSG_FIRSTHDR(&mhdr);
+	ARG_UNUSED(CMSG_DATA(&cmsg));
+	__unused struct cmsghdr *next = CMSG_NXTHDR(&mhdr, &cmsg);
+	__unused struct cmsghdr *first = CMSG_FIRSTHDR(&mhdr);
 
 	zassert_not_equal(-1, offsetof(struct linger, l_onoff));
 	zassert_not_equal(-1, offsetof(struct linger, l_linger));
@@ -120,4 +118,3 @@ ZTEST(posix_headers, test_sys_socket_h)
 		zassert_not_null(socketpair);
 	}
 }
-#pragma GCC diagnostic pop


### PR DESCRIPTION
Rather than disabling `-Wunused-value` for the entire file, explicitly
mark variables that are unused.