### PR TITLE
drivers: net: Select UART_INTERRUPT_DRIVEN with UART RCP communication

### DIFF
--- a/drivers/hdlc_rcp_if/Kconfig.uart
+++ b/drivers/hdlc_rcp_if/Kconfig.uart
@@ -12,6 +12,7 @@ config HDLC_RCP_IF_UART
 	bool "UART HDLC interface for Zephyr Openthread RCP host"
 	default y
 	depends on DT_HAS_UART_HDLC_RCP_IF_ENABLED
+	depends on UART_INTERRUPT_DRIVEN
 
 config OPENTHREAD_HDLC_RCP_IF_UART_RX_RING_BUFFER_SIZE
 	int "Set HDLC RCP IF UART RX ring buffer size"


### PR DESCRIPTION
The Openthread communication with RCP via UART (with HDLC protocol) is performed with serial driver using interrupts. As it was tested with echo_client sample program, the
CONFIG_SHELL_BACKEND_SERIAL_API_INTERRUPT_DRIVEN is defined by default for it. This config selects aforementioned UART_INTERRUPT_DRIVEN.

Problem starts when somebody wants to integrated the driver as a standalone one (without echo_client) as a part of user application. In this situation the UART_INTERRUPT_DRIVEN is not defined by default and there is no serial communication between RCP and HOST devices.