### PR TITLE
arch: arm: cortex_a_r: move exit_exc from vector_table.S to exc.S

### DIFF
--- a/arch/arm/core/cortex_a_r/exc.S
+++ b/arch/arm/core/cortex_a_r/exc.S
@@ -237,6 +237,28 @@ SECTION_SUBSEC_FUNC(TEXT, __exc, z_arm_data_abort)
 	b z_arm_exc_exit
 
 #else
+
+GTEXT(z_arm_cortex_ar_exit_exc)
+SECTION_SUBSEC_FUNC(TEXT, _HandlerModeExit, z_arm_cortex_ar_exit_exc)
+
+	/* Note:
+	 * This function is expected to be *always* called with
+	 * processor mode set to MODE_SYS.
+	 */
+
+	/* decrement exception depth */
+	get_cpu r2
+	ldrb r1, [r2, #_cpu_offset_to_exc_depth]
+	sub r1, r1, #1
+	strb r1, [r2, #_cpu_offset_to_exc_depth]
+
+	/*
+	 * Restore r0-r3, r12, lr, lr_und and spsr_und from the exception stack
+	 * and return to the current thread.
+	 */
+	pop {r0-r3, r12, lr}
+	rfeia sp!
+
 /**
  * @brief Undefined instruction exception handler
  *

--- a/arch/arm/core/cortex_a_r/vector_table.S
+++ b/arch/arm/core/cortex_a_r/vector_table.S
@@ -35,27 +35,3 @@ SECTION_SUBSEC_FUNC(exc_vector_table,_vector_table_section,_vector_table)
 #else
 	ldr pc,=z_irq_spurious
 #endif
-
-
-#ifdef CONFIG_USE_SWITCH
-GTEXT(z_arm_cortex_ar_exit_exc)
-SECTION_SUBSEC_FUNC(TEXT, _HandlerModeExit, z_arm_cortex_ar_exit_exc)
-
-	/* Note:
-	 * This function is expected to be *always* called with
-	 * processor mode set to MODE_SYS.
-	 */
-
-	/* decrement exception depth */
-	get_cpu r2
-	ldrb r1, [r2, #_cpu_offset_to_exc_depth]
-	sub r1, r1, #1
-	strb r1, [r2, #_cpu_offset_to_exc_depth]
-
-	/*
-	 * Restore r0-r3, r12, lr, lr_und and spsr_und from the exception stack
-	 * and return to the current thread.
-	 */
-	pop {r0-r3, r12, lr}
-	rfeia sp!
-#endif


### PR DESCRIPTION
It makes more sense to keep the exit_exc code close to where it is used.