### PR TITLE
drivers: udc: increase default UDC_BUF_POOL_SIZE value

### DIFF
--- a/drivers/usb/udc/Kconfig
+++ b/drivers/usb/udc/Kconfig
@@ -21,7 +21,7 @@ config UDC_BUF_COUNT
 config UDC_BUF_POOL_SIZE
 	int "Memory available for requests"
 	range 64 32768
-	default 1024
+	default 1200
 	help
 	  Total amount of memory available for UDC requests.
 


### PR DESCRIPTION
The previous value of 1024 would result in "Failed to allocate net_buf" error messages when connected to a Windows 10 host.

Fixes #85108