### PR TITLE
RFC: drivers: misc: pio_rpi_pico: Use `reg` to identify sm index

### DIFF
--- a/drivers/misc/pio_rpi_pico/pio_rpi_pico.c
+++ b/drivers/misc/pio_rpi_pico/pio_rpi_pico.c
@@ -5,20 +5,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/device.h>
-#include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/misc/pio_rpi_pico/pio_rpi_pico.h>
 #include <zephyr/drivers/pinctrl.h>
-#include <zephyr/drivers/reset.h>
 
 #define DT_DRV_COMPAT raspberrypi_pico_pio
-
-struct pio_rpi_pico_config {
-	PIO pio;
-	const struct device *clk_dev;
-	clock_control_subsys_t clk_id;
-	const struct reset_dt_spec reset;
-};
 
 int pio_rpi_pico_allocate_sm(const struct device *dev, size_t *sm)
 {
@@ -32,13 +22,6 @@ int pio_rpi_pico_allocate_sm(const struct device *dev, size_t *sm)
 
 	*sm = (size_t)retval;
 	return 0;
-}
-
-PIO pio_rpi_pico_get_pio(const struct device *dev)
-{
-	const struct pio_rpi_pico_config *config = dev->config;
-
-	return config->pio;
 }
 
 static int pio_rpi_pico_init(const struct device *dev)

--- a/dts/arm/raspberrypi/rpi_pico/rp2040.dtsi
+++ b/dts/arm/raspberrypi/rpi_pico/rp2040.dtsi
@@ -395,6 +395,8 @@
 
 		pio0: pio@50200000 {
 			compatible = "raspberrypi,pico-pio";
+			#address-cells = <1>;
+			#size-cells = <0>;
 			reg = <0x50200000 DT_SIZE_K(4)>;
 			clocks = <&clocks RPI_PICO_CLKID_CLK_SYS>;
 			resets = <&reset RPI_PICO_RESETS_RESET_PIO0>;
@@ -403,6 +405,8 @@
 
 		pio1: pio@50300000 {
 			compatible = "raspberrypi,pico-pio";
+			#address-cells = <1>;
+			#size-cells = <0>;
 			reg = <0x50300000 DT_SIZE_K(4)>;
 			clocks = <&clocks RPI_PICO_CLKID_CLK_SYS>;
 			resets = <&reset RPI_PICO_RESETS_RESET_PIO1>;

--- a/dts/arm/raspberrypi/rpi_pico/rp2350.dtsi
+++ b/dts/arm/raspberrypi/rpi_pico/rp2350.dtsi
@@ -403,6 +403,8 @@
 
 		pio0: pio@50200000 {
 			compatible = "raspberrypi,pico-pio";
+			#address-cells = <1>;
+			#size-cells = <0>;
 			reg = <0x50200000 DT_SIZE_K(4)>;
 			clocks = <&clocks RPI_PICO_CLKID_CLK_SYS>;
 			resets = <&reset RPI_PICO_RESETS_RESET_PIO0>;
@@ -411,6 +413,8 @@
 
 		pio1: pio@50300000 {
 			compatible = "raspberrypi,pico-pio";
+			#address-cells = <1>;
+			#size-cells = <0>;
 			reg = <0x50300000 DT_SIZE_K(4)>;
 			clocks = <&clocks RPI_PICO_CLKID_CLK_SYS>;
 			resets = <&reset RPI_PICO_RESETS_RESET_PIO1>;
@@ -419,6 +423,8 @@
 
 		pio2: pio@50400000 {
 			compatible = "raspberrypi,pico-pio";
+			#address-cells = <1>;
+			#size-cells = <0>;
 			reg = <0x50400000 DT_SIZE_K(4)>;
 			clocks = <&clocks RPI_PICO_CLKID_CLK_SYS>;
 			resets = <&reset RPI_PICO_RESETS_RESET_PIO2>;

--- a/dts/bindings/misc/raspberrypi,pico-pio.yaml
+++ b/dts/bindings/misc/raspberrypi,pico-pio.yaml
@@ -6,3 +6,11 @@ description: Raspberry Pi Pico PIO
 compatible: "raspberrypi,pico-pio"
 
 include: [base.yaml, reset-device.yaml]
+
+properties:
+  "#address-cells":
+    required: true
+    const: 1
+  "#size-cells":
+    required: true
+    const: 0

--- a/include/zephyr/drivers/misc/pio_rpi_pico/pio_rpi_pico.h
+++ b/include/zephyr/drivers/misc/pio_rpi_pico/pio_rpi_pico.h
@@ -9,9 +9,19 @@
 #ifndef ZEPHYR_DRIVERS_MISC_PIO_PICO_RPI_PIO_PICO_RPI_H_
 #define ZEPHYR_DRIVERS_MISC_PIO_PICO_RPI_PIO_PICO_RPI_H_
 
+#include <zephyr/device.h>
+#include <zephyr/drivers/clock_control.h>
+#include <zephyr/drivers/reset.h>
 #include <zephyr/devicetree/gpio.h>
 
 #include <hardware/pio.h>
+
+struct pio_rpi_pico_config {
+	PIO pio;
+	const struct device *clk_dev;
+	clock_control_subsys_t clk_id;
+	const struct reset_dt_spec reset;
+};
 
 /**
  * @brief Utility macro to define a PIO program. The program is a list
@@ -134,7 +144,12 @@
  * @param dev Pointer to device structure for rpi_pio device instance
  * @return PIO object
  */
-PIO pio_rpi_pico_get_pio(const struct device *dev);
+static inline PIO pio_rpi_pico_get_pio(const struct device *dev)
+{
+	const struct pio_rpi_pico_config *config = dev->config;
+
+	return config->pio;
+}
 
 /**
  * Allocate a state machine.

--- a/samples/sensor/bme280/rpi_pico_spi_pio.overlay
+++ b/samples/sensor/bme280/rpi_pico_spi_pio.overlay
@@ -14,7 +14,9 @@
 &pio0 {
 	status = "okay";
 
-	pio0_spi0: pio0_spi0 {
+	pio0_spi0: pio0_spi0@0 {
+		reg = <0>;
+
 		pinctrl-0 = <&pio0_spi0_default>;
 		pinctrl-names = "default";
 

--- a/tests/drivers/spi/spi_loopback/boards/rpi_pico_pio.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/rpi_pico_pio.overlay
@@ -20,7 +20,10 @@
 &pio0 {
 	status = "okay";
 
-	pio0_spi0: pio0_spi0 {
+	pio0_spi0: pio0_spi0@0 {
+		reg = <0>;
+		reg-names = "sm";
+
 		pinctrl-0 = <&pio0_spi0_default>;
 		pinctrl-names = "default";
 


### PR DESCRIPTION
A state machine is part of the hardware resources of PIO, so there is no reason why they can not be specified in the DT.

This commit demonstrates one example of defining such with the `reg` property. `reg` is flexible enough to hold multiple values and thus would also work for devices that require more than one state machine.

More about the `reg` properties: https://github.com/devicetree-org/devicetree-specification/blob/main/source/chapter2-devicetree-basics.rst#reg

This is in response to the discussion on the Discord channel regarding implementing DMA on the PIO SPI driver.

This PR should be merged after https://github.com/zephyrproject-rtos/zephyr/pull/85167.