### PR TITLE
modules: segger: RTT control block alignment

### DIFF
--- a/modules/segger/CMakeLists.txt
+++ b/modules/segger/CMakeLists.txt
@@ -1,5 +1,6 @@
 if(CONFIG_USE_SEGGER_RTT)
   zephyr_library()
+  zephyr_library_compile_definitions(SEGGER_RTT_ALIGNMENT=CONFIG_SEGGER_RTT_CB_ALIGNMENT)
   set(SEGGER_DIR ${ZEPHYR_CURRENT_MODULE_DIR})
   zephyr_include_directories_ifdef(CONFIG_USE_SEGGER_RTT
     ${SEGGER_DIR}/SEGGER

--- a/modules/segger/Kconfig
+++ b/modules/segger/Kconfig
@@ -25,6 +25,14 @@ config SEGGER_RTT_CUSTOM_LOCKING
 	help
 	  Enable custom locking using Zephyr APIs.
 
+config SEGGER_RTT_CB_ALIGNMENT
+	int "Alignment of the RTT control block"
+	default 16
+	help
+	  Specify the alignment of the RTT control block in memory. The default
+	  alignment of 16 bytes is chosen because PyOCD fails to discover blocks
+	  where the 16 byte `acID` field falls across a 32 byte boundary.
+
 config SEGGER_RTT_MAX_NUM_UP_BUFFERS
 	int "Maximum number of up-buffers"
 	default 3


### PR DESCRIPTION
Make the alignment of the RTT control block configurable, defaulting to 16 bytes. The default is chosen as PyOCD fails to discover the control block if the 16 byte ID array falls across a 32 byte boundary.