### PR TITLE
boards: nordic: enable trace irq on app bellboard nRF9280 PDK

### DIFF
--- a/boards/nordic/nrf9280pdk/nrf9280pdk_nrf9280_cpuapp.dts
+++ b/boards/nordic/nrf9280pdk/nrf9280pdk_nrf9280_cpuapp.dts
@@ -131,9 +131,9 @@
 	 *  - Bell 6: cpusys
 	 *  - Bell 13: cpuppr
 	 *  - Bell 18: cpurad
-	 *  - Bells 24, 25, 29, 31: cpucell
+	 *  - Bells 24, 25, 29, 30, 31: cpucell
 	 */
-	nordic,interrupt-mapping = <0xA3042041 0>;
+	nordic,interrupt-mapping = <0xE3042041 0>;
 };
 
 &cpurad_bellboard {


### PR DESCRIPTION
Enable trace IRQ for application bellboard, application nrf9280pdk.