### PR TITLE
drivers: clock control of stm32f4 serie w/o clk 48M on PLL I2S

### DIFF
--- a/drivers/clock_control/clock_stm32f2_f4_f7.c
+++ b/drivers/clock_control/clock_stm32f2_f4_f7.c
@@ -157,7 +157,8 @@ void config_plli2s(void)
 				       STM32_PLLI2S_N_MULTIPLIER,
 				       plli2sr(STM32_PLLI2S_R_DIVISOR));
 
-#if STM32_PLLI2S_Q_ENABLED && !defined(RCC_DCKCFGR_PLLI2SDIVQ)
+#if STM32_PLLI2S_Q_ENABLED && \
+	(defined(RCC_PLLI2SCFGR_PLLI2SQ) && !defined(RCC_DCKCFGR_PLLI2SDIVQ))
 	/* There is a Q divider on the PLLI2S to configure the PLL48CK */
 	LL_RCC_PLLI2S_ConfigDomain_48M(get_pll_source(),
 				       plli2sm(STM32_PLLI2S_M_DIVISOR),


### PR DESCRIPTION
Some stm32f4, like the sm32f411 mcu have clk 48M on the main PLL output q 
Some stm32f4, like the sm32f412 mcu have clk 48M on the PLL I2S output q 

This PR is for selecting the right one  and fixes the build error
`clock_stm32f2_f4_f7.c:162:9: warning: implicit declaration of function 'LL_RCC_PLLI2S_ConfigDomain_48M'; did you mean 'LL_RCC_PLLI2S_ConfigDomain_I2S'? [-Wimplicit-function-declaration]`



