### PR TITLE
scripts: runners: nrf: Fix missing kind in erase operations

### DIFF
--- a/scripts/west_commands/runners/nrf_common.py
+++ b/scripts/west_commands/runners/nrf_common.py
@@ -337,8 +337,8 @@ class NrfBinaryRunner(ZephyrBinaryRunner):
                 )
 
             if self.erase:
-                self.exec_op('erase', core='Application')
-                self.exec_op('erase', core='Network')
+                self.exec_op('erase', core='Application', kind='all')
+                self.exec_op('erase', core='Network', kind='all')
 
             # Manage SUIT artifacts.
             # This logic should be executed only once per build.


### PR DESCRIPTION
Commit dc7d8bb introduced the requirement to provide the erase kind when executing the corresponding op, but it was forgotten in this particular spot.