### PR TITLE
bluetooth: host: Add PSA returns to debug prints

### DIFF
--- a/subsys/bluetooth/host/crypto_psa.c
+++ b/subsys/bluetooth/host/crypto_psa.c
@@ -29,8 +29,10 @@ LOG_MODULE_REGISTER(bt_host_crypto);
 
 int prng_init(void)
 {
-	if (psa_crypto_init() != PSA_SUCCESS) {
-		LOG_ERR("psa_crypto_init() failed");
+	psa_status_t status = psa_crypto_init();
+
+	if (status != PSA_SUCCESS) {
+		LOG_ERR("psa_crypto_init() failed %d", status);
 		return -EIO;
 	}
 	return 0;
@@ -39,11 +41,13 @@ int prng_init(void)
 #if defined(CONFIG_BT_HOST_CRYPTO_PRNG)
 int bt_rand(void *buf, size_t len)
 {
-	if (psa_generate_random(buf, len) == PSA_SUCCESS) {
+	psa_status_t status = psa_generate_random(buf, len);
+
+	if (status == PSA_SUCCESS) {
 		return 0;
 	}
 
-	LOG_ERR("psa_generate_random() failed");
+	LOG_ERR("psa_generate_random() failed %d", status);
 	return -EIO;
 }
 #else /* !CONFIG_BT_HOST_CRYPTO_PRNG */
@@ -79,8 +83,9 @@ int bt_encrypt_le(const uint8_t key[16], const uint8_t plaintext[16],
 	psa_set_key_bits(&attr, 128);
 	psa_set_key_usage_flags(&attr, PSA_KEY_USAGE_ENCRYPT);
 	psa_set_key_algorithm(&attr, PSA_ALG_ECB_NO_PADDING);
-	if (psa_import_key(&attr, tmp, 16, &key_id) != PSA_SUCCESS) {
-		LOG_ERR("Failed to import AES key");
+	status = psa_import_key(&attr, tmp, 16, &key_id);
+	if (status != PSA_SUCCESS) {
+		LOG_ERR("Failed to import AES key %d", status);
 		return -EINVAL;
 	}
 
@@ -89,12 +94,12 @@ int bt_encrypt_le(const uint8_t key[16], const uint8_t plaintext[16],
 	status = psa_cipher_encrypt(key_id, PSA_ALG_ECB_NO_PADDING, tmp, 16,
 					enc_data, 16, &out_len);
 	if (status != PSA_SUCCESS) {
-		LOG_ERR("AES encryption failed");
+		LOG_ERR("AES encryption failed %d", status);
 	}
 
 	destroy_status = psa_destroy_key(key_id);
 	if (destroy_status != PSA_SUCCESS) {
-		LOG_ERR("Failed to destroy AES key");
+		LOG_ERR("Failed to destroy AES key %d", destroy_status);
 	}
 
 	if ((status != PSA_SUCCESS) || (destroy_status != PSA_SUCCESS)) {
@@ -127,20 +132,21 @@ int bt_encrypt_be(const uint8_t key[16], const uint8_t plaintext[16],
 	psa_set_key_bits(&attr, 128);
 	psa_set_key_usage_flags(&attr, PSA_KEY_USAGE_ENCRYPT);
 	psa_set_key_algorithm(&attr, PSA_ALG_ECB_NO_PADDING);
-	if (psa_import_key(&attr, key, 16, &key_id) != PSA_SUCCESS) {
-		LOG_ERR("Failed to import AES key");
+	status = psa_import_key(&attr, key, 16, &key_id);
+	if (status != PSA_SUCCESS) {
+		LOG_ERR("Failed to import AES key %d", status);
 		return -EINVAL;
 	}
 
 	status = psa_cipher_encrypt(key_id, PSA_ALG_ECB_NO_PADDING,
 				plaintext, 16, enc_data, 16, &out_len);
 	if (status != PSA_SUCCESS) {
-		LOG_ERR("AES encryption failed");
+		LOG_ERR("AES encryption failed %d", status);
 	}
 
 	destroy_status = psa_destroy_key(key_id);
 	if (destroy_status != PSA_SUCCESS) {
-		LOG_ERR("Failed to destroy AES key");
+		LOG_ERR("Failed to destroy AES key %d", destroy_status);
 	}
 
 	if ((status != PSA_SUCCESS) || (destroy_status != PSA_SUCCESS)) {


### PR DESCRIPTION
Recently I have had to debug issues with PSA and having the returns values from PSA is very useful in order to find the root cause of the issue.