### PR TITLE
net: l2: Add a config option to allow mismatched L3/L2 address packets

### DIFF
--- a/subsys/net/l2/ethernet/Kconfig
+++ b/subsys/net/l2/ethernet/Kconfig
@@ -32,6 +32,14 @@ config NET_L2_ETHERNET_MGMT
 	  Enable support net_mgmt Ethernet interface which can be used to
 	  configure at run-time Ethernet drivers and L2 settings.
 
+
+config NET_L2_ETHERNET_ACCEPT_MISMATCH_L3_L2_ADDR
+	bool "Accept mismatched L3 and L2 addresses"
+	help
+	  If enabled, then accept packets where the L3 and L2 addresses do not
+	  conform to RFC1122 section 3.3.6. This is useful in dealing with
+	  buggy devices that do not follow the RFC.
+
 config NET_VLAN
 	bool "Virtual LAN support"
 	select NET_L2_VIRTUAL

--- a/subsys/net/l2/ethernet/ethernet.c
+++ b/subsys/net/l2/ethernet/ethernet.c
@@ -178,6 +178,10 @@ static inline
 enum net_verdict ethernet_check_ipv4_bcast_addr(struct net_pkt *pkt,
 						struct net_eth_hdr *hdr)
 {
+	if (IS_ENABLED(CONFIG_NET_L2_ETHERNET_ACCEPT_MISMATCH_L3_L2_ADDR)) {
+		return NET_OK;
+	}
+
 	if (net_eth_is_addr_broadcast(&hdr->dst) &&
 	    !(net_ipv4_is_addr_mcast((struct in_addr *)NET_IPV4_HDR(pkt)->dst) ||
 	      net_ipv4_is_addr_bcast(net_pkt_iface(pkt),


### PR DESCRIPTION
The RFC1122 section 3.3.6 says we SHOULD drop the packets if L2 address is brodcast but L3 address is unicast, but we had seen some Wi-Fi access points in the field not conforming to that, and DHCP offer is dropped due to this and causes Wi-Fi connectivity issues.

As the RFC saus it's SHOULD and not a MUST, add a config option to allow such packets, disabled by default.