### PR TITLE
Bluetooth: Controller: Add casting to radio_aa_set for BASE0

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
@@ -405,7 +405,7 @@ void radio_aa_set(const uint8_t *aa)
 	NRF_RADIO->RXADDRESSES =
 	    ((RADIO_RXADDRESSES_ADDR0_Enabled) << RADIO_RXADDRESSES_ADDR0_Pos);
 	NRF_RADIO->PREFIX0 = aa[3];
-	NRF_RADIO->BASE0 = (((uint32_t) aa[2]) << 24) | (aa[1] << 16) | (aa[0] << 8);
+	NRF_RADIO->BASE0 = sys_get_le24(aa) << 8;
 }
 
 void radio_pkt_configure(uint8_t bits_len, uint8_t max_len, uint8_t flags)


### PR DESCRIPTION
We have previously fixed an issue with shifting and assigning the value without a cast, but coverity
is still complaining about aa[1] and aa[0] with:

"Casting narrower unsigned aa[1] to wider signed type int effectively tests its lower bound."

Using the common function, sys_get_le24, should fix this issue.

Partially fixes https://github.com/zephyrproject-rtos/zephyr/issues/59509 but may not fix it 100%