### PR TITLE
usb: device_next: fix Get Status request response

### DIFF
--- a/include/zephyr/usb/usbd.h
+++ b/include/zephyr/usb/usbd.h
@@ -254,6 +254,8 @@ struct usbd_status {
 	unsigned int suspended : 1;
 	/** USB remote wake-up feature is enabled */
 	unsigned int rwup : 1;
+	/** USB device is self-powered */
+	unsigned int self_powered : 1;
 	/** USB device speed */
 	enum usbd_speed speed : 2;
 };
@@ -1049,6 +1051,17 @@ bool usbd_is_suspended(struct usbd_context *uds_ctx);
  * @return 0 on success, other values on fail.
  */
 int usbd_wakeup_request(struct usbd_context *uds_ctx);
+
+/**
+ * @brief Set the self-powered status of the USB device
+ *
+ * The status is used in the Self Powered field of the Get Status request
+ * response to indicate whether the device is currently self-powered.
+ *
+ * @param[in] uds_ctx Pointer to a device context
+ * @param[in] status Sets self-powered status if true, clears it otherwise
+ */
+void usbd_self_powered(struct usbd_context *uds_ctx, const bool status);
 
 /**
  * @brief Get actual device speed

--- a/samples/subsys/usb/common/sample_usbd_init.c
+++ b/samples/subsys/usb/common/sample_usbd_init.c
@@ -151,6 +151,7 @@ struct usbd_context *sample_usbd_setup_device(usbd_msg_cb_t msg_cb)
 	/* doc functions register end */
 
 	sample_fix_code_triple(&sample_usbd, USBD_SPEED_FS);
+	usbd_self_powered(&sample_usbd, attributes & USB_SCD_SELF_POWERED);
 
 	if (msg_cb != NULL) {
 		/* doc device init-and-msg start */

--- a/subsys/usb/device_next/usbd_ch9.c
+++ b/subsys/usb/device_next/usbd_ch9.c
@@ -426,6 +426,8 @@ static int sreq_get_status(struct usbd_context *const uds_ctx,
 
 		response = uds_ctx->status.rwup ?
 			   USB_GET_STATUS_REMOTE_WAKEUP : 0;
+		response |= uds_ctx->status.self_powered ?
+			    USB_GET_STATUS_SELF_POWERED : 0;
 		break;
 	case USB_REQTYPE_RECIPIENT_ENDPOINT:
 		response = usbd_ep_is_halted(uds_ctx, ep) ? BIT(0) : 0;

--- a/subsys/usb/device_next/usbd_device.c
+++ b/subsys/usb/device_next/usbd_device.c
@@ -197,6 +197,13 @@ wakeup_request_error:
 	return ret;
 }
 
+void usbd_self_powered(struct usbd_context *uds_ctx, const bool status)
+{
+	usbd_device_lock(uds_ctx);
+	uds_ctx->status.self_powered = status;
+	usbd_device_unlock(uds_ctx);
+}
+
 bool usbd_is_suspended(struct usbd_context *uds_ctx)
 {
 	return uds_ctx->status.suspended;


### PR DESCRIPTION
Set the Self Powered field if the device is self-powered in the current configuration.
Fixes: #85095 