### PR TITLE
dts: atmel sam4s: fix sram address

### DIFF
--- a/dts/arm/atmel/sam4s.dtsi
+++ b/dts/arm/atmel/sam4s.dtsi
@@ -55,7 +55,7 @@
 			status = "okay";
 		};
 
-		sram0: memory@20100000 {
+		sram0: memory@20000000 {
 			compatible = "mmio-sram";
 		};
 

--- a/dts/arm/atmel/sam4s16b.dtsi
+++ b/dts/arm/atmel/sam4s16b.dtsi
@@ -16,8 +16,8 @@
 			};
 		};
 
-		sram0: memory@20100000 {
-			reg = <0x20100000 DT_SIZE_K(128)>;
+		sram0: memory@20000000 {
+			reg = <0x20000000 DT_SIZE_K(128)>;
 		};
 	};
 };

--- a/dts/arm/atmel/sam4s16c.dtsi
+++ b/dts/arm/atmel/sam4s16c.dtsi
@@ -16,8 +16,8 @@
 			};
 		};
 
-		sram0: memory@20100000 {
-			reg = <0x20100000 DT_SIZE_K(128)>;
+		sram0: memory@20000000 {
+			reg = <0x20000000 DT_SIZE_K(128)>;
 		};
 	};
 };

--- a/dts/arm/atmel/sam4s2a.dtsi
+++ b/dts/arm/atmel/sam4s2a.dtsi
@@ -16,8 +16,8 @@
 			};
 		};
 
-		sram0: memory@20100000 {
-			reg = <0x20100000 DT_SIZE_K(64)>;
+		sram0: memory@20000000 {
+			reg = <0x20000000 DT_SIZE_K(64)>;
 		};
 	};
 };

--- a/dts/arm/atmel/sam4s2b.dtsi
+++ b/dts/arm/atmel/sam4s2b.dtsi
@@ -16,8 +16,8 @@
 			};
 		};
 
-		sram0: memory@20100000 {
-			reg = <0x20100000 DT_SIZE_K(64)>;
+		sram0: memory@20000000 {
+			reg = <0x20000000 DT_SIZE_K(64)>;
 		};
 	};
 };

--- a/dts/arm/atmel/sam4s2c.dtsi
+++ b/dts/arm/atmel/sam4s2c.dtsi
@@ -16,8 +16,8 @@
 			};
 		};
 
-		sram0: memory@20100000 {
-			reg = <0x20100000 DT_SIZE_K(64)>;
+		sram0: memory@20000000 {
+			reg = <0x20000000 DT_SIZE_K(64)>;
 		};
 	};
 };

--- a/dts/arm/atmel/sam4s4a.dtsi
+++ b/dts/arm/atmel/sam4s4a.dtsi
@@ -16,8 +16,8 @@
 			};
 		};
 
-		sram0: memory@20100000 {
-			reg = <0x20100000 DT_SIZE_K(64)>;
+		sram0: memory@20000000 {
+			reg = <0x20000000 DT_SIZE_K(64)>;
 		};
 	};
 };

--- a/dts/arm/atmel/sam4s4b.dtsi
+++ b/dts/arm/atmel/sam4s4b.dtsi
@@ -16,8 +16,8 @@
 			};
 		};
 
-		sram0: memory@20100000 {
-			reg = <0x20100000 DT_SIZE_K(64)>;
+		sram0: memory@20000000 {
+			reg = <0x20000000 DT_SIZE_K(64)>;
 		};
 	};
 };

--- a/dts/arm/atmel/sam4s4c.dtsi
+++ b/dts/arm/atmel/sam4s4c.dtsi
@@ -16,8 +16,8 @@
 			};
 		};
 
-		sram0: memory@20100000 {
-			reg = <0x20100000 DT_SIZE_K(64)>;
+		sram0: memory@20000000 {
+			reg = <0x20000000 DT_SIZE_K(64)>;
 		};
 	};
 };

--- a/dts/arm/atmel/sam4s8b.dtsi
+++ b/dts/arm/atmel/sam4s8b.dtsi
@@ -16,8 +16,8 @@
 			};
 		};
 
-		sram0: memory@20100000 {
-			reg = <0x20100000 DT_SIZE_K(128)>;
+		sram0: memory@20000000 {
+			reg = <0x20000000 DT_SIZE_K(128)>;
 		};
 	};
 };

--- a/dts/arm/atmel/sam4s8c.dtsi
+++ b/dts/arm/atmel/sam4s8c.dtsi
@@ -16,8 +16,8 @@
 			};
 		};
 
-		sram0: memory@20100000 {
-			reg = <0x20100000 DT_SIZE_K(128)>;
+		sram0: memory@20000000 {
+			reg = <0x20000000 DT_SIZE_K(128)>;
 		};
 	};
 };

--- a/dts/arm/atmel/sam4sa16c.dtsi
+++ b/dts/arm/atmel/sam4sa16c.dtsi
@@ -16,8 +16,8 @@
 			};
 		};
 
-		sram0: memory@20100000 {
-			reg = <0x20100000 DT_SIZE_K(160)>;
+		sram0: memory@20000000 {
+			reg = <0x20000000 DT_SIZE_K(160)>;
 		};
 	};
 };


### PR DESCRIPTION
Changed Atmel SAM4S series sram adress from 0x20100000 to 0x20000000. Now it matches what is in Atmel SAM4S Series Datasheet chapter 8 section 1.1 Internal SRAM:


https://ww1.microchip.com/downloads/aemDocuments/documents/OTH/ProductDocuments/DataSheets/Atmel-11100-32-bitCortex-M4-Microcontroller-SAM4S_Datasheet.pdf#G1.1069257

Fixes #85211.