### PR TITLE
doc: Fix acronym expansion, SDHC refers to "SD host controller", not "Secure Digital High Capacity"

### DIFF
--- a/doc/hardware/peripherals/sdhc.rst
+++ b/doc/hardware/peripherals/sdhc.rst
@@ -1,30 +1,31 @@
 .. _sdhc_api:
 
-
-Secure Digital High Capacity (SDHC)
+Secure Digital (SD card) interface
 ###################################
 
-The SDHC api offers a generic interface for interacting with an SD host
-controller device. It is used by the SD subsystem, and is not intended to be
-directly used by the application
+Zephyr can communicate with an attached SD card either using a system's native
+SD card interface or over SPI (Serial Peripheral Interface). Some devices can
+also communicate with MMC (MultiMediaCard) devices.
 
-Basic Operation
-***************
+Applications can use Zephyr's :ref:`the disk access API <disk_access_api>`
+to use SD cards as storage devices, or Zephyr's SD card subsystem to
+directly read from and write to a card.
 
-SD Host Controller
-==================
+SD Host Controller (SDHC)
+*************************
 
-An SD host controller is a device capable of sending SD commands to an attached
-SD card. These commands can be sent using the native SD protocol, or over SPI.
-Some SD host controllers are also capable of communicating with MMC devices.
-The SDHC api is designed to provide a generic way to send commands to and
-interact with attached SD devices.
+An SD host controller (SDHC) is a device capable of sending commands to an
+SD card. These commands can be sent using a system's native SD card interface,
+or over SPI.
+
+Applications should generally not use the SD host controller API directly,
+instead they should use Zephyr's SD card subsystem.
 
 Requests
 ========
 
-The core of the SDHC api is the :c:func:`sdhc_request` api. Requests contain a
-:c:struct:`sdhc_command` command structure, and an optional
+The core of the SD host controller (SDHC) API is the :c:func:`sdhc_request` API.
+Requests contain a :c:struct:`sdhc_command` command structure, and an optional
 :c:struct:`sdhc_data` data structure. The caller may check the return code,
 or the ``response`` field of the SD command structure to determine if the
 SDHC request succeeded. The data structure allows the caller to specify a
@@ -35,7 +36,7 @@ command opcode provided.
 Host Controller I/O
 ===================
 
-The :c:func:`sdhc_set_io` api allows the user to change I/O settings of the SD
+The :c:func:`sdhc_set_io` API allows the user to change I/O settings of the SD
 host controller, such as clock frequency, I/O voltage, and card power. Not all
 controllers will support applying all I/O settings. For example, SPI mode
 controllers typically cannot toggle power to the SD card.


### PR DESCRIPTION
Minor fix for an incorrect acronym expansion introduced in 0ae3247 and c41dd36.

SDHC is Zephyr's "SD host controller" driver. That driver can talk to many card types, _including_ "Secure Digital High Capacity" SD cards but also SDSD, SDXC, SDUC, SD I/O, and MMC.