### PR TITLE
dts: stm32h7: Fix ltdc reset lines

### DIFF
--- a/dts/arm/st/h7/stm32h723.dtsi
+++ b/dts/arm/st/h7/stm32h723.dtsi
@@ -89,7 +89,7 @@
 			interrupts = <88 0>, <89 0>;
 			interrupt-names = "ltdc", "ltdc_er";
 			clocks = <&rcc STM32_CLOCK(APB3, 3U)>;
-			resets = <&rctl STM32_RESET(APB3, 4U)>;
+			resets = <&rctl STM32_RESET(APB3, 3U)>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/h7/stm32h743.dtsi
+++ b/dts/arm/st/h7/stm32h743.dtsi
@@ -49,7 +49,7 @@
 			interrupts = <88 0>, <89 0>;
 			interrupt-names = "ltdc", "ltdc_er";
 			clocks = <&rcc STM32_CLOCK(APB3, 3U)>;
-			resets = <&rctl STM32_RESET(APB3, 4U)>;
+			resets = <&rctl STM32_RESET(APB3, 3U)>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/h7/stm32h745.dtsi
+++ b/dts/arm/st/h7/stm32h745.dtsi
@@ -42,7 +42,7 @@
 			interrupts = <88 0>, <89 0>;
 			interrupt-names = "ltdc", "ltdc_er";
 			clocks = <&rcc STM32_CLOCK(APB3, 3U)>;
-			resets = <&rctl STM32_RESET(APB3, 4U)>;
+			resets = <&rctl STM32_RESET(APB3, 3U)>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/h7/stm32h7a3.dtsi
+++ b/dts/arm/st/h7/stm32h7a3.dtsi
@@ -52,7 +52,7 @@
 			interrupts = <88 0>, <89 0>;
 			interrupt-names = "ltdc", "ltdc_er";
 			clocks = <&rcc STM32_CLOCK(APB3, 3U)>;
-			resets = <&rctl STM32_RESET(APB3, 4U)>;
+			resets = <&rctl STM32_RESET(APB3, 3U)>;
 			status = "disabled";
 		};
 


### PR DESCRIPTION
LTDC reset lines where off by 1. Fix it.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/85123