### PR TITLE
doc: usb: minor fixes to improve consistency

### DIFF
--- a/doc/connectivity/usb/device_next/api/index.rst
+++ b/doc/connectivity/usb/device_next/api/index.rst
@@ -11,5 +11,5 @@ New USB device support APIs
    usbd_hid_device.rst
    uac2_device.rst
    usbd_msc_device.rst
-   usb_midi.rst
+   usbd_midi2.rst
    usbd_dfu.rst

--- a/doc/connectivity/usb/device_next/api/usbd_midi2.rst
+++ b/doc/connectivity/usb/device_next/api/usbd_midi2.rst
@@ -1,4 +1,4 @@
-.. _usb_midi:
+.. _usbd_midi2:
 
 MIDI 2.0 Class device API
 #########################
@@ -8,5 +8,5 @@ USB MIDI 2.0 device specific API defined in :zephyr_file:`include/zephyr/usb/cla
 API Reference
 *************
 
-.. doxygengroup:: usb_midi
+.. doxygengroup:: usbd_midi2
 .. doxygengroup:: midi_ump

--- a/include/zephyr/usb/class/usbd_midi2.h
+++ b/include/zephyr/usb/class/usbd_midi2.h
@@ -13,7 +13,7 @@ extern "C" {
 
 /**
  * @brief USB MIDI 2.0 class device API
- * @defgroup usb_midi USB MIDI 2.0 Class device API
+ * @defgroup usbd_midi2 USB MIDI 2.0 Class device API
  * @ingroup usb
  * @since 4.1
  * @version 0.1.0

--- a/samples/subsys/usb/common/sample_usbd_init.c
+++ b/samples/subsys/usb/common/sample_usbd_init.c
@@ -79,6 +79,7 @@ static void sample_fix_code_triple(struct usbd_context *uds_ctx,
 	if (IS_ENABLED(CONFIG_USBD_CDC_ACM_CLASS) ||
 	    IS_ENABLED(CONFIG_USBD_CDC_ECM_CLASS) ||
 	    IS_ENABLED(CONFIG_USBD_CDC_NCM_CLASS) ||
+	    IS_ENABLED(CONFIG_USBD_MIDI2_CLASS) ||
 	    IS_ENABLED(CONFIG_USBD_AUDIO2_CLASS)) {
 		/*
 		 * Class with multiple interfaces have an Interface

--- a/samples/subsys/usb/midi/README.rst
+++ b/samples/subsys/usb/midi/README.rst
@@ -1,8 +1,8 @@
-.. zephyr:code-sample:: midi
-   :name: USB MIDI device class
-   :relevant-api: usbd_api usb_midi input_events
+.. zephyr:code-sample:: usb-midi2-device
+   :name: USB MIDI2 device
+   :relevant-api: usbd_api usbd_midi2 input_events
 
-   Implements a simple USB-MIDI loopback and keyboard device.
+   Implements a simple USB MIDI loopback and keyboard device.
 
 Overview
 ********


### PR DESCRIPTION
Follow-up on newly introduced USB MIDI2 support.
Prefix with usbd_, use midi2 consistently.

Use correct Class Code triple in midi sample.

@titouanc 