### PR TITLE
stm32: Remove useless #ifdef STM32_SRC_SYSCLK and the code under the #else

### DIFF
--- a/drivers/clock_control/clock_stm32_ll_common.c
+++ b/drivers/clock_control/clock_stm32_ll_common.c
@@ -122,10 +122,8 @@ int enabled_clock(uint32_t src_clk)
 	int r = 0;
 
 	switch (src_clk) {
-#if defined(STM32_SRC_SYSCLK)
 	case STM32_SRC_SYSCLK:
 		break;
-#endif /* STM32_SRC_SYSCLK */
 #if defined(STM32_SRC_PCLK)
 	case STM32_SRC_PCLK:
 		break;
@@ -295,7 +293,6 @@ static inline int stm32_clock_control_configure(const struct device *dev,
 						clock_control_subsys_t sub_system,
 						void *data)
 {
-#if defined(STM32_SRC_SYSCLK)
 	/* At least one alt src clock available */
 	struct stm32_pclken *pclken = (struct stm32_pclken *)(sub_system);
 	int err;
@@ -320,10 +317,6 @@ static inline int stm32_clock_control_configure(const struct device *dev,
 		     STM32_CLOCK_VAL_GET(pclken->enr) << STM32_CLOCK_SHIFT_GET(pclken->enr));
 
 	return 0;
-#else
-	/* No src clock available: Not supported */
-	return -ENOTSUP;
-#endif
 }
 
 static int stm32_clock_control_get_subsys_rate(const struct device *clock,
@@ -395,11 +388,9 @@ static int stm32_clock_control_get_subsys_rate(const struct device *clock,
 		*rate = ahb3_clock;
 		break;
 #endif
-#if defined(STM32_SRC_SYSCLK)
 	case STM32_SRC_SYSCLK:
 		*rate = SystemCoreClock * STM32_CORE_PRESCALER;
 		break;
-#endif
 #if defined(STM32_SRC_PLLCLK) & defined(STM32_SYSCLK_SRC_PLL)
 	case STM32_SRC_PLLCLK:
 		if (get_pllout_frequency() == 0) {

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32_common_devices/src/test_stm32_clock_configuration_adc.c
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32_common_devices/src/test_stm32_clock_configuration_adc.c
@@ -94,13 +94,11 @@ ZTEST(stm32_common_devices_clocks, test_adc_clk_config)
 		dev_actual_clk_src = GET_ADC_SOURCE();
 
 		switch (pclken[1].bus) {
-#if defined(STM32_SRC_SYSCLK)
 		case STM32_SRC_SYSCLK:
 			zassert_equal(dev_actual_clk_src, ADC_SOURCE_SYSCLK,
 					"Expected ADC1 src: SYSCLK (0x%lx). Actual ADC1 src: 0x%x",
 					ADC_SOURCE_SYSCLK, dev_actual_clk_src);
 			break;
-#endif /* STM32_SRC_SYSCLK */
 #if defined(STM32_SRC_PLL_P)
 		case STM32_SRC_PLL_P:
 			zassert_equal(dev_actual_clk_src, ADC_SOURCE_PLL,


### PR DESCRIPTION
Clean up of #ifdef STM32_SRC_SYSCLK and the code under the #else part from the following files:
- drivers/clock_control/clock_stm32_ll_common.c
-  tests/drivers/clock_control/stm32_clock_configuration/stm32_common_devices/src/test_stm32_clock_configuration_adc.c.
