### PR TITLE
llext: support section alignment requirements

### DIFF
--- a/arch/riscv/core/elf.c
+++ b/arch/riscv/core/elf.c
@@ -175,7 +175,7 @@ static int llext_riscv_find_sym_pcrel(struct llext_loader *ldr, struct llext *ex
 		return ret;
 	}
 
-	symbol_name = llext_string(ldr, ext, LLEXT_MEM_STRTAB, candidate_sym.st_name);
+	symbol_name = llext_symbol_name(ldr, ext, &candidate_sym);
 
 	ret = llext_lookup_symbol(ldr, ext, &link_addr, &candidate, &candidate_sym,
 				  symbol_name, shdr);

--- a/arch/xtensa/core/elf.c
+++ b/arch/xtensa/core/elf.c
@@ -41,7 +41,7 @@ static void xtensa_elf_relocate(struct llext_loader *ldr, struct llext *ext,
 
 	switch (type) {
 	case R_XTENSA_RELATIVE:
-		if (ldr_parm && ldr_parm->pre_located) {
+		if (ldr_parm->pre_located) {
 			/* Relative relocations are already correct in the pre-located case */
 			break;
 		}

--- a/include/zephyr/llext/inspect.h
+++ b/include/zephyr/llext/inspect.h
@@ -58,11 +58,13 @@ static inline int llext_get_region_info(const struct llext_loader *ldr,
 	if (hdr) {
 		*hdr = &ldr->sects[region];
 	}
+
+	/* address and size compensated for alignment prepad */
 	if (addr) {
-		*addr = ext->mem[region];
+		*addr = (void *)((uintptr_t)ext->mem[region] + ldr->sects[region].sh_info);
 	}
 	if (size) {
-		*size = ext->mem_size[region];
+		*size = ext->mem_size[region] - ldr->sects[region].sh_info;
 	}
 
 	return 0;
@@ -117,14 +119,18 @@ static inline int llext_get_section_info(const struct llext_loader *ldr,
 		return -ENOTSUP;
 	}
 
+	enum llext_mem mem_idx = ldr->sect_map[shndx].mem_idx;
+
 	if (hdr) {
 		*hdr = &ext->sect_hdrs[shndx];
 	}
 	if (region) {
-		*region = ldr->sect_map[shndx].mem_idx;
+		*region = mem_idx;
 	}
+
+	/* offset compensated for alignment prepad */
 	if (offset) {
-		*offset = ldr->sect_map[shndx].offset;
+		*offset = ldr->sect_map[shndx].offset - ldr->sects[mem_idx].sh_info;
 	}
 
 	return 0;

--- a/include/zephyr/llext/llext_internal.h
+++ b/include/zephyr/llext/llext_internal.h
@@ -43,11 +43,24 @@ static inline uintptr_t llext_get_reloc_instruction_location(struct llext_loader
 	return (uintptr_t) llext_loaded_sect_ptr(ldr, ext, shndx) + rela->r_offset;
 }
 
-static inline const char *llext_symbol_name(struct llext_loader *ldr, struct llext *ext,
+static inline const char *llext_section_name(const struct llext_loader *ldr,
+					     const struct llext *ext,
+					     const elf_shdr_t *shdr)
+{
+	return llext_string(ldr, ext, LLEXT_MEM_SHSTRTAB, shdr->sh_name);
+}
+
+static inline const char *llext_symbol_name(const struct llext_loader *ldr,
+					    const struct llext *ext,
 					    const elf_sym_t *sym)
 {
-	return llext_string(ldr, ext, LLEXT_MEM_STRTAB, sym->st_name);
+	if (ELF_ST_TYPE(sym->st_info) == STT_SECTION) {
+		return llext_section_name(ldr, ext, ext->sect_hdrs + sym->st_shndx);
+	} else {
+		return llext_string(ldr, ext, LLEXT_MEM_STRTAB, sym->st_name);
+	}
 }
+
 /*
  * Determine address of a symbol.
  */

--- a/subsys/llext/llext.c
+++ b/subsys/llext/llext.c
@@ -29,8 +29,7 @@ int llext_section_shndx(const struct llext_loader *ldr, const struct llext *ext,
 	unsigned int i;
 
 	for (i = 1; i < ext->sect_cnt; i++) {
-		const char *name = llext_string(ldr, ext, LLEXT_MEM_SHSTRTAB,
-						ext->sect_hdrs[i].sh_name);
+		const char *name = llext_section_name(ldr, ext, ext->sect_hdrs + i);
 
 		if (!strcmp(name, sect_name)) {
 			return i;

--- a/subsys/llext/llext_link.c
+++ b/subsys/llext/llext_link.c
@@ -195,7 +195,7 @@ int llext_lookup_symbol(struct llext_loader *ldr, struct llext *ext, uintptr_t *
 			return -ENODATA;
 		}
 
-		LOG_INF("found symbol %s at 0x%lx", name, *link_addr);
+		LOG_INF("found symbol %s at %#lx", name, *link_addr);
 	} else if (sym->st_shndx == SHN_ABS) {
 		/* Absolute symbol */
 		*link_addr = sym->st_value;
@@ -220,7 +220,7 @@ int llext_lookup_symbol(struct llext_loader *ldr, struct llext *ext, uintptr_t *
 			(uintptr_t)llext_loaded_sect_ptr(ldr, ext, sym->st_shndx) + sym->st_value;
 	} else {
 		LOG_ERR("cannot apply relocation: "
-			"target symbol has unexpected section index %d (0x%X)",
+			"target symbol has unexpected section index %d (%#x)",
 			sym->st_shndx, sym->st_shndx);
 		return -ENOEXEC;
 	}
@@ -492,18 +492,15 @@ int llext_link(struct llext_loader *ldr, struct llext *ext, const struct llext_l
 					return ret;
 				}
 
-				LOG_DBG("relocation %d:%d info 0x%zx (type %zd, sym %zd) offset %zd"
+				LOG_DBG("relocation %d:%d info %#zx (type %zd, sym %zd) offset %zd"
 					" sym_name %s sym_type %d sym_bind %d sym_ndx %d",
 					i, j, (size_t)rel.r_info, (size_t)ELF_R_TYPE(rel.r_info),
 					(size_t)ELF_R_SYM(rel.r_info), (size_t)rel.r_offset,
 					name, ELF_ST_TYPE(sym.st_info),
 					ELF_ST_BIND(sym.st_info), sym.st_shndx);
 
-				LOG_INF("writing relocation symbol %s type %zd sym %zd at addr "
-					"0x%lx addr 0x%lx",
-					name, (size_t)ELF_R_TYPE(rel.r_info),
-					(size_t)ELF_R_SYM(rel.r_info),
-					op_loc, link_addr);
+				LOG_INF("writing relocation type %d at %#lx with symbol %s (%#lx)",
+					(int)ELF_R_TYPE(rel.r_info), op_loc, name, link_addr);
 			}
 #endif /* CONFIG_LLEXT_LOG_LEVEL */
 

--- a/subsys/llext/llext_link.c
+++ b/subsys/llext/llext_link.c
@@ -239,7 +239,7 @@ static void llext_link_plt(struct llext_loader *ldr, struct llext *ext, elf_shdr
 	uint8_t *text = ext->mem[LLEXT_MEM_TEXT];
 
 	LOG_DBG("Found %p in PLT %u size %zu cnt %u text %p",
-		(void *)llext_string(ldr, ext, LLEXT_MEM_SHSTRTAB, shdr->sh_name),
+		(void *)llext_section_name(ldr, ext, shdr),
 		shdr->sh_type, (size_t)shdr->sh_entsize, sh_cnt, (void *)text);
 
 	const elf_shdr_t *sym_shdr = ldr->sects + LLEXT_MEM_SYMTAB;
@@ -289,7 +289,7 @@ static void llext_link_plt(struct llext_loader *ldr, struct llext *ext, elf_shdr
 			continue;
 		}
 
-		const char *name = llext_string(ldr, ext, LLEXT_MEM_STRTAB, sym.st_name);
+		const char *name = llext_symbol_name(ldr, ext, &sym);
 
 		/*
 		 * Both r_offset and sh_addr are addresses for which the extension
@@ -411,7 +411,7 @@ int llext_link(struct llext_loader *ldr, struct llext *ext, const struct llext_l
 
 		rel_cnt = shdr->sh_size / shdr->sh_entsize;
 
-		name = llext_string(ldr, ext, LLEXT_MEM_SHSTRTAB, shdr->sh_name);
+		name = llext_section_name(ldr, ext, shdr);
 
 		/*
 		 * FIXME: The Xtensa port is currently using a different way of

--- a/subsys/llext/llext_load.c
+++ b/subsys/llext/llext_load.c
@@ -162,8 +162,8 @@ static int llext_find_tables(struct llext_loader *ldr, struct llext *ext)
 	for (i = 0, table_cnt = 0; i < ext->sect_cnt && table_cnt < 3; ++i) {
 		elf_shdr_t *shdr = ext->sect_hdrs + i;
 
-		LOG_DBG("section %d at 0x%zx: name %d, type %d, flags 0x%zx, "
-			"addr 0x%zx, size %zd, link %d, info %d",
+		LOG_DBG("section %d at %#zx: name %d, type %d, flags %#zx, "
+			"addr %#zx, size %zd, link %d, info %d",
 			i,
 			(size_t)shdr->sh_offset,
 			shdr->sh_name,
@@ -410,8 +410,8 @@ static int llext_map_sections(struct llext_loader *ldr, struct llext *ext,
 				     x->sh_addr + x->sh_size > y->sh_addr) ||
 				    (y->sh_addr <= x->sh_addr &&
 				     y->sh_addr + y->sh_size > x->sh_addr)) {
-					LOG_ERR("Region %d VMA range (0x%zx +%zd) "
-						"overlaps with %d (0x%zx +%zd)",
+					LOG_ERR("Region %d VMA range (%#zx +%zd) "
+						"overlaps with %d (%#zx +%zd)",
 						i, (size_t)x->sh_addr, (size_t)x->sh_size,
 						j, (size_t)y->sh_addr, (size_t)y->sh_size);
 					return -ENOEXEC;
@@ -431,8 +431,8 @@ static int llext_map_sections(struct llext_loader *ldr, struct llext *ext,
 			     x->sh_offset + x->sh_size > y->sh_offset) ||
 			    (y->sh_offset <= x->sh_offset &&
 			     y->sh_offset + y->sh_size > x->sh_offset)) {
-				LOG_ERR("Region %d ELF file range (0x%zx +%zd) "
-					"overlaps with %d (0x%zx +%zd)",
+				LOG_ERR("Region %d ELF file range (%#zx +%zd) "
+					"overlaps with %d (%#zx +%zd)",
 					i, (size_t)x->sh_offset, (size_t)x->sh_size,
 					j, (size_t)y->sh_offset, (size_t)y->sh_size);
 				return -ENOEXEC;

--- a/subsys/llext/llext_load.c
+++ b/subsys/llext/llext_load.c
@@ -231,7 +231,7 @@ static int llext_map_sections(struct llext_loader *ldr, struct llext *ext,
 	for (i = 0; i < ext->sect_cnt; ++i) {
 		elf_shdr_t *shdr = ext->sect_hdrs + i;
 
-		name = llext_string(ldr, ext, LLEXT_MEM_SHSTRTAB, shdr->sh_name);
+		name = llext_section_name(ldr, ext, shdr);
 
 		if (ldr->sect_map[i].mem_idx != LLEXT_MEM_COUNT) {
 			LOG_DBG("section %d name %s already mapped to region %d",
@@ -494,7 +494,7 @@ static int llext_count_export_syms(struct llext_loader *ldr, struct llext *ext)
 		uint32_t stb = ELF_ST_BIND(sym.st_info);
 		uint32_t sect = sym.st_shndx;
 
-		name = llext_string(ldr, ext, LLEXT_MEM_STRTAB, sym.st_name);
+		name = llext_symbol_name(ldr, ext, &sym);
 
 		if ((stt == STT_FUNC || stt == STT_OBJECT) && stb == STB_GLOBAL) {
 			LOG_DBG("function symbol %d, name %s, type tag %d, bind %d, sect %d",
@@ -614,7 +614,7 @@ static int llext_copy_symbols(struct llext_loader *ldr, struct llext *ext,
 
 		if ((stt == STT_FUNC || stt == STT_OBJECT) &&
 		    stb == STB_GLOBAL && shndx != SHN_UNDEF) {
-			const char *name = llext_string(ldr, ext, LLEXT_MEM_STRTAB, sym.st_name);
+			const char *name = llext_symbol_name(ldr, ext, &sym);
 
 			__ASSERT(j <= sym_tab->sym_cnt, "Miscalculated symbol number %u\n", j);
 

--- a/subsys/llext/llext_load.c
+++ b/subsys/llext/llext_load.c
@@ -560,7 +560,7 @@ static int llext_export_symbols(struct llext_loader *ldr, struct llext *ext,
 		 */
 		const char *name = NULL;
 
-		if (ldr_parm && ldr_parm->pre_located) {
+		if (ldr_parm->pre_located) {
 			ssize_t name_offset = llext_file_offset(ldr, (uintptr_t)sym->name);
 
 			if (name_offset > 0) {
@@ -706,7 +706,7 @@ int do_llext_load(struct llext_loader *ldr, struct llext *ext,
 	}
 
 	LOG_DBG("Allocate and copy strings...");
-	ret = llext_copy_strings(ldr, ext);
+	ret = llext_copy_strings(ldr, ext, ldr_parm);
 	if (ret != 0) {
 		LOG_ERR("Failed to copy ELF string sections, ret %d", ret);
 		goto out;
@@ -770,7 +770,7 @@ out:
 	 * Note that this exploits the fact that freeing a NULL pointer has no effect.
 	 */
 
-	if (ret != 0 || !ldr_parm || !ldr_parm->keep_section_info) {
+	if (ret != 0 || !ldr_parm->keep_section_info) {
 		llext_free_inspection_data(ldr, ext);
 	}
 

--- a/subsys/llext/llext_mem.c
+++ b/subsys/llext/llext_mem.c
@@ -176,8 +176,7 @@ int llext_copy_regions(struct llext_loader *ldr, struct llext *ext,
 		for (int i = 0; i < ext->sect_cnt; ++i) {
 			elf_shdr_t *shdr = ext->sect_hdrs + i;
 			enum llext_mem mem_idx = ldr->sect_map[i].mem_idx;
-			const char *name = llext_string(ldr, ext, LLEXT_MEM_SHSTRTAB,
-							shdr->sh_name);
+			const char *name = llext_section_name(ldr, ext, shdr);
 
 			/* only show sections mapped to program memory */
 			if (mem_idx < LLEXT_MEM_EXPORT) {

--- a/subsys/llext/llext_mem.c
+++ b/subsys/llext/llext_mem.c
@@ -55,7 +55,7 @@ static void llext_init_mem_part(struct llext *ext, enum llext_mem mem_idx,
 	}
 #endif
 
-	LOG_DBG("region %d: start 0x%zx, size %zd", mem_idx, (size_t)start, len);
+	LOG_DBG("region %d: start %#zx, size %zd", mem_idx, (size_t)start, len);
 }
 
 static int llext_copy_region(struct llext_loader *ldr, struct llext *ext,
@@ -181,7 +181,7 @@ int llext_copy_regions(struct llext_loader *ldr, struct llext *ext,
 
 			/* only show sections mapped to program memory */
 			if (mem_idx < LLEXT_MEM_EXPORT) {
-				LOG_DBG("-s %s 0x%zx", name,
+				LOG_DBG("-s %s %#zx", name,
 					(size_t)ext->mem[mem_idx] + ldr->sect_map[i].offset);
 			}
 		}

--- a/subsys/llext/llext_priv.h
+++ b/subsys/llext/llext_priv.h
@@ -15,7 +15,8 @@
  * Memory management (llext_mem.c)
  */
 
-int llext_copy_strings(struct llext_loader *ldr, struct llext *ext);
+int llext_copy_strings(struct llext_loader *ldr, struct llext *ext,
+		       const struct llext_load_param *ldr_parm);
 int llext_copy_regions(struct llext_loader *ldr, struct llext *ext,
 		       const struct llext_load_param *ldr_parm);
 void llext_free_regions(struct llext *ext);

--- a/tests/subsys/llext/CMakeLists.txt
+++ b/tests/subsys/llext/CMakeLists.txt
@@ -25,6 +25,7 @@ set(ext_names
 	threads_kernel_objects
 	export_dependent
 	export_dependency
+	align
 )
 
 if(CONFIG_ARM)

--- a/tests/subsys/llext/src/align_ext.c
+++ b/tests/subsys/llext/src/align_ext.c
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2025 Arduino SA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Define symbols with different alignment requirements and verify that LLEXT
+ * correctly handles them by testing the runtime address and the contents of
+ * each defined symbol.
+ */
+
+#include <stdint.h>
+#include <zephyr/kernel.h>
+#include <zephyr/llext/symbol.h>
+#include <zephyr/ztest_assert.h>
+
+/*
+ * Create constants requesting a specific alignment in memory and with a value
+ * that is related but not equal to their alignment requirement.
+ */
+#define ALIGNED_ENTRY(name, n) \
+	 const int name ## _ ## n __aligned(n) = n / 2 + 1
+
+ALIGNED_ENTRY(common, 8);
+ALIGNED_ENTRY(common, 16);
+ALIGNED_ENTRY(common, 32);
+ALIGNED_ENTRY(common, 64);
+ALIGNED_ENTRY(common, 128);
+ALIGNED_ENTRY(common, 256);
+ALIGNED_ENTRY(common, 512);
+
+/*
+ * Create similar constants in a set of independent sections to test merging.
+ */
+#define ALIGNED_SECT_ENTRY(name, n) \
+	Z_GENERIC_SECTION(name ## _sect_ ## n) ALIGNED_ENTRY(name, n)
+
+ALIGNED_SECT_ENTRY(independent, 8);
+ALIGNED_SECT_ENTRY(independent, 16);
+ALIGNED_SECT_ENTRY(independent, 32);
+ALIGNED_SECT_ENTRY(independent, 64);
+ALIGNED_SECT_ENTRY(independent, 128);
+ALIGNED_SECT_ENTRY(independent, 256);
+ALIGNED_SECT_ENTRY(independent, 512);
+
+/*
+ * Test that each symbol matches its expected value and alignment.
+ */
+#define ASSERT_ENTRY(name, n) \
+	zassert_equal(name ## _ ## n, n / 2 + 1); \
+	zassert_true(IS_ALIGNED(&name ## _ ## n, n))
+
+void test_entry(void)
+{
+	ASSERT_ENTRY(common, 8);
+	ASSERT_ENTRY(common, 16);
+	ASSERT_ENTRY(common, 32);
+	ASSERT_ENTRY(common, 64);
+	ASSERT_ENTRY(common, 128);
+	ASSERT_ENTRY(common, 256);
+	ASSERT_ENTRY(common, 512);
+
+	ASSERT_ENTRY(independent, 8);
+	ASSERT_ENTRY(independent, 16);
+	ASSERT_ENTRY(independent, 32);
+	ASSERT_ENTRY(independent, 64);
+	ASSERT_ENTRY(independent, 128);
+	ASSERT_ENTRY(independent, 256);
+	ASSERT_ENTRY(independent, 512);
+}
+EXPORT_SYMBOL(test_entry);

--- a/tests/subsys/llext/src/detached_fn_ext.c
+++ b/tests/subsys/llext/src/detached_fn_ext.c
@@ -9,7 +9,7 @@
 #include <zephyr/sys/printk.h>
 #include <zephyr/ztest_assert.h>
 
-__section(".detach") void detached_entry(void)
+Z_GENERIC_SECTION(.detach) void detached_entry(void)
 {
 	static int data_cnt = -3;
 	static unsigned int bss_cnt;

--- a/tests/subsys/llext/src/test_llext.c
+++ b/tests/subsys/llext/src/test_llext.c
@@ -317,6 +317,11 @@ LLEXT_LOAD_UNLOAD(threads_kernel_objects,
 	.test_setup = threads_objects_test_setup,
 )
 
+static LLEXT_CONST uint8_t align_ext[] ELF_ALIGN = {
+	#include "align.inc"
+};
+LLEXT_LOAD_UNLOAD(align)
+
 static LLEXT_CONST uint8_t inspect_ext[] ELF_ALIGN = {
 	#include "inspect.inc"
 };


### PR DESCRIPTION
This PR adds support in LLEXT for symbol / section alignment requirements.

Symbols that require precise alignment will cause the compiler to generate proper padding inside each section so that they are properly placed; also, the section itself will be flagged to be aligned to the largest alignment requirement of any symbol in the section. The ELF spec also guarantees that symbol alignment is respected in the file offsets, so a suitably placed ELF file could be directly used.

* When LLEXT maps similar sections into a contiguous region, each section's alignment is checked to ensure offsets and alignments are coherent, so that every section will be properly allocated once the region is fully defined. 
 Special care is taken when a section is appended to a region which starts at an address that does not match the current aligment requirements. In that case, the region start must be moved backwards to satisfy the new, stricter alignment requirements, and this may result in false positives in the overlap detection.    

* Finally, memory is allocated also taking into account the existing MMU/MPU requirements, if applicable. When the ELF file buffer can be directly reused, the section addresses are simply checked for compliance.

### Review notes

* The first 4 commits are preparatory search-and-replace that introduce no functional changes (except for some log messages). Might be useful to view those ignoring whitespace due to large indentation reductions. 
* Commits 5, 6 and 7 are refactors of existing code that minimize the changes in the following commits.
* The new features for this PR are implemented in the last two commits.