### PR TITLE
drivers: serial: silabs: Fix build for efm32wg_stk3800/efm32wg990f256

### DIFF
--- a/drivers/serial/uart_gecko.c
+++ b/drivers/serial/uart_gecko.c
@@ -835,6 +835,7 @@ static DEVICE_API(uart, uart_gecko_driver_api) = {
 	VALIDATE_GECKO_UART_RTS_CTS_PIN_LOCATIONS(idx);				\
 										\
 	GECKO_UART_IRQ_HANDLER_DECL(idx);					\
+	PM_DEVICE_DT_INST_DEFINE(idx, uart_gecko_pm_action);			\
 										\
 	static struct uart_config uart_cfg_##idx = {				\
 		.baudrate  = DT_INST_PROP(idx, current_speed),			\
@@ -861,12 +862,10 @@ static DEVICE_API(uart, uart_gecko_driver_api) = {
 		.uart_cfg = &uart_cfg_##idx,					\
 	};									\
 										\
-	DEVICE_DT_INST_DEFINE(idx, uart_gecko_init,				\
-			    NULL, &uart_gecko_data_##idx,			\
-			    &uart_gecko_cfg_##idx, PRE_KERNEL_1,		\
-			    CONFIG_SERIAL_INIT_PRIORITY,			\
-			    &uart_gecko_driver_api);				\
-										\
+	DEVICE_DT_INST_DEFINE(idx, uart_gecko_init, PM_DEVICE_DT_INST_GET(idx),	\
+			      &uart_gecko_data_##idx, &uart_gecko_cfg_##idx,	\
+			      PRE_KERNEL_1, CONFIG_SERIAL_INIT_PRIORITY,	\
+			      &uart_gecko_driver_api);				\
 										\
 	GECKO_UART_IRQ_HANDLER(idx)
 


### PR DESCRIPTION
The `gecko_uart.c` driver supports both `silabs,gecko_uart` and `silabs,gecko_usart` compat strings, however `PM_DEVICE_DT_INST_DEFINE()` was missing when defining `gecko_uart` type instances. The efm32wg_stk3800/efm32wg990f256 platform enables by default one `gecko_uart` DT node and no `gecko_usart` nodes. This results in the following build warning/error:

`uart_gecko.c:673:12: warning: 'uart_gecko_pm_action' defined but not used`

Add the missing call to `PM_DEVICE_DT_INST_DEFINE()`.
