### PR TITLE
drivers: mfd: mfd_adp5585: Fix `-Wsometimes-uninitialized` warning

### DIFF
--- a/drivers/mfd/mfd_adp5585.c
+++ b/drivers/mfd/mfd_adp5585.c
@@ -56,9 +56,8 @@ static void mfd_adp5585_work_handler(struct k_work *work)
 
 	k_sem_take(&data->lock, K_FOREVER);
 	/* Read Interrput Flag */
-	if (ret == 0) {
-		ret = i2c_reg_read_byte_dt(&config->i2c_bus, ADP5585_INT_STATUS, &reg_int_status);
-	}
+	ret = i2c_reg_read_byte_dt(&config->i2c_bus, ADP5585_INT_STATUS, &reg_int_status);
+
 	/* Clear Interrput Flag */
 	if (ret == 0) {
 		ret = i2c_reg_write_byte_dt(&config->i2c_bus, ADP5585_INT_STATUS, reg_int_status);


### PR DESCRIPTION
When building with clang it warns:

```
drivers/mfd/mfd_adp5585.c:59:6: error: variable 'reg_int_status' is used uninitialized whenever 'if' condition is false
[-Werror,-Wsometimes-uninitialized]
        if (ret == 0) {
            ^~~~~~~~
drivers/mfd/mfd_adp5585.c:70:7: note: uninitialized use occurs here
        if ((reg_int_status & ADP5585_INT_GPI)
             ^~~~~~~~~~~~~~    && device_is_ready(data->child.gpio_dev)) {
drivers/mfd/mfd_adp5585.c:59:2: note: remove the 'if' if its condition
is always true
        if (ret == 0) {
        ^~~~~~~~~~~~~~
drivers/mfd/mfd_adp5585.c:54:24: note: initialize the variable
'reg_int_status' to silence this warning
        uint8_t reg_int_status;
                              ^
                               = '\0'
```