### PR TITLE
tests: lib: cmsis_dsp: Fix `-Wsometimes-uninitialized` warning

### DIFF
--- a/tests/lib/cmsis_dsp/distance/src/u32.c
+++ b/tests/lib/cmsis_dsp/distance/src/u32.c
@@ -44,7 +44,7 @@ static void test_arm_distance(int op, const uint16_t *dims,
 
 	/* Enumerate input */
 	for (index = 0; index < length; index++) {
-		float32_t val;
+		float32_t val = 0.0f;
 
 		/* Run test function */
 		switch (op) {


### PR DESCRIPTION
Building with clang warns:

```
tests/lib/cmsis_dsp/distance/src/u32.c:82:3: error: variable 'val' is used uninitialized whenever switch default is taken [-Werror,-Wsometimes-uninitialized]
                default:
                ^~~~~~~
tests/lib/cmsis_dsp/distance/src/u32.c:87:19: note: uninitialized use occurs here
                output[index] = val;
                                ^~~
tests/lib/cmsis_dsp/distance/src/u32.c:47:16: note: initialize the variable 'val' to silence this warning
                float32_t val;
                             ^
                              = 0.0
```

Hitting the default switch will assert, so this won't cause any problems as written, but it doesn't hurt to initialize the variable.