### PR TITLE
tests: kernel: thread_apis: Fix `-Wsometimes-uninitialized` warning

### DIFF
--- a/tests/kernel/threads/thread_apis/src/main.c
+++ b/tests/kernel/threads/thread_apis/src/main.c
@@ -326,7 +326,7 @@ static void do_join_from_isr(const void *arg)
 static int join_scenario_interval(enum control_method m, int64_t *interval)
 {
 	k_timeout_t timeout = K_FOREVER;
-	int ret;
+	int ret = 0;
 
 	LOG_DBG("ztest_thread: method %d, create join_thread", m);
 	k_thread_create(&join_thread, join_stack, STACK_SIZE, join_entry,


### PR DESCRIPTION
Building kernel.threads.apis with clang warns:

```
tests/kernel/threads/thread_apis/src/main.c:362:6: error: variable 'ret' is used uninitialized whenever 'if' condition is true [-Werror,-Wsometimes-uninitialized]
        if (m == ISR_ALREADY_EXIT || m == ISR_RUNNING) {
            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
tests/kernel/threads/thread_apis/src/main.c:380:6: note: uninitialized use occurs here
        if (ret != 0) {
            ^~~
tests/kernel/threads/thread_apis/src/main.c:362:2: note: remove the 'if' if its condition is always false
        if (m == ISR_ALREADY_EXIT || m == ISR_RUNNING) {
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
tests/kernel/threads/thread_apis/src/main.c:362:6: error: variable 'ret' is used uninitialized whenever '||' condition is true [-Werror,-Wsometimes-uninitialized]
        if (m == ISR_ALREADY_EXIT || m == ISR_RUNNING) {
            ^~~~~~~~~~~~~~~~~~~~~
tests/kernel/threads/thread_apis/src/main.c:380:6: note: uninitialized use occurs here
        if (ret != 0) {
            ^~~
tests/kernel/threads/thread_apis/src/main.c:362:6: note: remove the '||' if its condition is always false
        if (m == ISR_ALREADY_EXIT || m == ISR_RUNNING) {
            ^~~~~~~~~~~~~~~~~~~~~~~~
tests/kernel/threads/thread_apis/src/main.c:329:9: note: initialize the variable 'ret' to silence this warning
        int ret;
               ^
                = 0
```