### PR TITLE
Bluetooth: TBS: Fix `-Wsometimes-uninitialized` warning

### DIFF
--- a/subsys/bluetooth/audio/tbs.c
+++ b/subsys/bluetooth/audio/tbs.c
@@ -1623,7 +1623,7 @@ static bool valid_register_param(const struct bt_tbs_register_param *param)
 
 int bt_tbs_register_bearer(const struct bt_tbs_register_param *param)
 {
-	int ret;
+	int ret = -ENOEXEC;
 
 	CHECKIF(!valid_register_param(param)) {
 		LOG_DBG("Invalid parameters");


### PR DESCRIPTION
Building bluetooth.shell.audio.only_gtbs with clang warns:

```
subsys/bluetooth/audio/tbs.c:1646:6: error: variable 'ret' is used uninitialized whenever 'if' condition is false
[-Werror,-Wsometimes-uninitialized]
        if (param->gtbs) {
            ^~~~~~~~~~~
subsys/bluetooth/audio/tbs.c:1667:9: note: uninitialized use occurs here
        return ret;
               ^~~
subsys/bluetooth/audio/tbs.c:1646:2: note: remove the 'if' if its condition is always true
        if (param->gtbs) {
        ^~~~~~~~~~~~~~~~~
subsys/bluetooth/audio/tbs.c:1626:9: note: initialize the variable 'ret' to silence this warning
        int ret;
               ^
                = 0
```