### PR TITLE
tests: net: socket: Fix `-Wsometimes-uninitialized` warning

### DIFF
--- a/tests/net/socket/tcp/src/main.c
+++ b/tests/net/socket/tcp/src/main.c
@@ -357,8 +357,8 @@ void tcp_server_block_thread(void *vps_sock, void *unused2, void *unused3)
 void test_send_recv_large_common(int tcp_nodelay, int family)
 {
 	int rv;
-	int c_sock;
-	int s_sock;
+	int c_sock = 0;
+	int s_sock = 0;
 	struct sockaddr *c_saddr = NULL;
 	struct sockaddr *s_saddr = NULL;
 	size_t addrlen = 0;


### PR DESCRIPTION
Building with clang warns:

```
tests/net/socket/tcp/src/main.c:377:13: error: variable 'c_sock' is used uninitialized whenever 'if' condition is false
[-Werror,-Wsometimes-uninitialized]
        } else if (family == AF_INET6) {
                   ^~~~~~~~~~~~~~~~~~
tests/net/socket/tcp/src/main.c:396:15: note: uninitialized use occurs here
        test_connect(c_sock, s_saddr, addrlen);
                     ^~~~~~
tests/net/socket/tcp/src/main.c:377:9: note: remove the 'if' if its condition is always true
        } else if (family == AF_INET6) {
               ^~~~~~~~~~~~~~~~~~~~~~~~
tests/net/socket/tcp/src/main.c:360:12: note: initialize the variable 'c_sock' to silence this warning
        int c_sock;
                  ^
                   = 0
tests/net/socket/tcp/src/main.c:377:13: error: variable 's_sock' is used uninitialized whenever 'if' condition is false
[-Werror,-Wsometimes-uninitialized]
        } else if (family == AF_INET6) {
                   ^~~~~~~~~~~~~~~~~~
tests/net/socket/tcp/src/main.c:387:12: note: uninitialized use occurs here
        test_bind(s_sock, s_saddr, addrlen);
                  ^~~~~~
tests/net/socket/tcp/src/main.c:377:9: note: remove the 'if' if its condition is always true
        } else if (family == AF_INET6) {
               ^~~~~~~~~~~~~~~~~~~~~~~~
tests/net/socket/tcp/src/main.c:361:12: note: initialize the variable 's_sock' to silence this warning
        int s_sock;
                  ^
                   = 0
```

Not really needed since we have `zassert_unreachable()`, but doesn't hurt to initialize the variables.