### PR TITLE
tests: posix: timers: Fix `-Wsometimes-uninitialized` warning

### DIFF
--- a/tests/posix/timers/src/nanosleep.c
+++ b/tests/posix/timers/src/nanosleep.c
@@ -149,7 +149,7 @@ static void common_lower_bound_check(int selection, clockid_t clock_id, int flag
 				     uint32_t ns)
 {
 	int r;
-	uint64_t actual_ns;
+	uint64_t actual_ns = 0;
 	uint64_t exp_ns;
 	uint64_t now;
 	uint64_t then;


### PR DESCRIPTION
Building portability.posix.timers with clang warns:

```
tests/posix/timers/src/nanosleep.c:180:2: error: variable 'actual_ns' is used uninitialized whenever switch default is taken [-Werror,-Wsometimes-uninitialized]
        default:
        ^~~~~~~
tests/posix/timers/src/nanosleep.c:197:15: note: uninitialized use occurs here
        zassert_true(actual_ns >= exp_ns, "actual: %llu expected: %llu",
                     ^~~~~~~~~                          actual_ns, exp_ns);
subsys/testsuite/ztest/include/zephyr/ztest_assert.h:275:41: note:
                                      ^~ expanded from macro 'zassert_true'
subsys/testsuite/ztest/include/zephyr/ztest_assert.h:194:14: note:
expanded from macro 'zassert'
        _zassert_va(cond, default_msg, COND_CODE_1(__VA_OPT__(1),
                    ^~~~               (__VA_ARGS__), (NULL)))
subsys/testsuite/ztest/include/zephyr/ztest_assert.h:191:16: note:
expanded from macro '_zassert_va'
        _zassert_base(cond, default_msg, msg, ##__VA_ARGS__)
                      ^~~~
subsys/testsuite/ztest/include/zephyr/ztest_assert.h:180:14: note:
expanded from macro '_zassert_base'
                        z_zassert(cond, _msg ? ("(" default_msg ")") :
                                  ^~~~   (default_msg), __FILE__,    \
tests/posix/timers/src/nanosleep.c:152:20: note: initialize the variable
'actual_ns' to silence this warning
        uint64_t actual_ns;
                          ^
                           = 0
```

Not really necessary since there is a `zassert_unreachable()`, but doesn't hurt to initialize the variable.