### PR TITLE
Bluetooth: ISO: Fix `-Wsometimes-uninitialized` warning

### DIFF
--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -2134,7 +2134,7 @@ static bool valid_cig_param(const struct bt_iso_cig_param *param, bool advanced,
 int bt_iso_cig_create(const struct bt_iso_cig_param *param, struct bt_iso_cig **out_cig)
 {
 	int err;
-	struct net_buf *rsp;
+	struct net_buf *rsp = NULL;
 	struct bt_iso_cig *cig;
 	struct bt_hci_rp_le_set_cig_params *cig_rsp;
 	struct bt_iso_chan *cis;
@@ -2255,7 +2255,7 @@ int bt_iso_cig_reconfigure(struct bt_iso_cig *cig, const struct bt_iso_cig_param
 	struct bt_hci_rp_le_set_cig_params *cig_rsp;
 	uint8_t existing_num_cis;
 	bool advanced = false;
-	struct net_buf *rsp;
+	struct net_buf *rsp = NULL;
 	int err;
 
 	CHECKIF(cig == NULL) {


### PR DESCRIPTION
Building sample.bluetooth.tmap_central with clang warns:

```
subsys/bluetooth/host/iso.c:2194:6: error: variable 'rsp' is used uninitialized whenever 'if' condition is false
[-Werror,-Wsometimes-uninitialized]
        if (!advanced) {
            ^~~~~~~~~
subsys/bluetooth/host/iso.c:2202:6: note: uninitialized use occurs here
        if (rsp == NULL) {
            ^~~
subsys/bluetooth/host/iso.c:2194:2: note: remove the 'if' if its condition is always true
        if (!advanced) {
        ^~~~~~~~~~~~~~~
subsys/bluetooth/host/iso.c:2137:21: note: initialize the variable 'rsp' to silence this warning
        struct net_buf *rsp;
                           ^
                            = NULL
subsys/bluetooth/host/iso.c:2295:6: error: variable 'rsp' is used uninitialized whenever 'if' condition is false
[-Werror,-Wsometimes-uninitialized]
        if (!advanced) {
            ^~~~~~~~~
subsys/bluetooth/host/iso.c:2303:6: note: uninitialized use occurs here
        if (rsp == NULL) {
            ^~~
subsys/bluetooth/host/iso.c:2295:2: note: remove the 'if' if its condition is always true
        if (!advanced) {
        ^~~~~~~~~~~~~~~
subsys/bluetooth/host/iso.c:2258:21: note: initialize the variable 'rsp' to silence this warning
        struct net_buf *rsp;
                           ^
                            = NULL
```