### PR TITLE
llext: Use relocatable by default for xtensa

### DIFF
--- a/subsys/llext/Kconfig
+++ b/subsys/llext/Kconfig
@@ -14,8 +14,7 @@ if LLEXT
 choice LLEXT_BINARY_TYPE
 	prompt "Binary object type for llext"
 	default LLEXT_TYPE_ELF_OBJECT if ARM || ARM64
-	default LLEXT_TYPE_ELF_SHAREDLIB if XTENSA
-	default LLEXT_TYPE_ELF_RELOCATABLE if RISCV
+	default LLEXT_TYPE_ELF_RELOCATABLE if XTENSA || RISCV
 	help
 	  Object type for llext
 

--- a/tests/subsys/llext/testcase.yaml
+++ b/tests/subsys/llext/testcase.yaml
@@ -71,6 +71,18 @@ tests:
     extra_conf_files: ['no_mem_protection.conf']
     extra_configs:
       - CONFIG_LLEXT_STORAGE_WRITABLE=y
+  llext.writable_dynamic:
+    arch_allow:
+      - xtensa
+    toolchain_exclude:
+      - xt-clang
+    integration_platforms:
+      - qemu_xtensa/dc233c      # Xtensa ISA
+    filter: not CONFIG_MPU and not CONFIG_MMU
+    extra_conf_files: ['no_mem_protection.conf']
+    extra_configs:
+      - CONFIG_LLEXT_STORAGE_WRITABLE=y
+      - CONFIG_LLEXT_TYPE_ELF_SHAREDLIB=y
   llext.writable_relocatable:
     arch_allow:
       - arm


### PR DESCRIPTION
LLEXT supports relocatable ELFs with Xtensa alongside dynamic/shared ELFs. Not all Xtensa toolchains support working with/linking shared ELFs though. Change the default to be relocatable and only test shared with working toolchains.