### PR TITLE
doc: getting_started: Install Perl in Windows

### DIFF
--- a/doc/contribute/guidelines.rst
+++ b/doc/contribute/guidelines.rst
@@ -561,6 +561,13 @@ before opening a new Pull Request:
 
    ./scripts/ci/check_compliance.py -c upstream/main..
 
+.. note::
+   On Windows if the .pl extension has not yet been associated with an
+   application, then the first time a .pl file is run without specifying an
+   interpreter, Windows will ask what application will open Perl files.
+   Set the default app to Strawberry Perl. By default the executable is
+   installed at ``C:\Strawberry\perl\bin\perl.exe``.
+
 twister
 -------
 

--- a/doc/develop/getting_started/index.rst
+++ b/doc/develop/getting_started/index.rst
@@ -186,7 +186,7 @@ The current minimum required version for the main dependencies are:
          .. code-block:: bat
 
             choco install cmake --installargs 'ADD_CMAKE_TO_PATH=System'
-            choco install ninja gperf python311 git dtc-msys2 wget 7zip
+            choco install ninja gperf python311 git dtc-msys2 wget 7zip strawberryperl
 
          .. warning::
 


### PR DESCRIPTION
Related to https://github.com/zephyrproject-rtos/zephyr/pull/84626, Perl is required for check_compliance.py/checkpatch.pl, and needs to be installed in Windows to run these scripts.  Most Linux distributions install with Perl, which is likely why Perl has been missing from these installation instructions.

Using choco to install `strawperryperl` like this also adds Perl to the ``PATH`` environment variable.

Note that the [Documentation Generation page](https://docs.zephyrproject.org/latest/contribute/documentation/generation.html#installing-the-documentation-processors) already gives instructions to install `strawberryperl` in Windows.