### PR TITLE
kernel: Improve ordering in SMP k_thread_suspend()

### DIFF
--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -453,7 +453,7 @@ void z_impl_k_thread_suspend(k_tid_t thread)
 	/* Special case "suspend the current thread" as it doesn't
 	 * need the async complexity below.
 	 */
-	if (thread == _current && !arch_is_in_isr() && !IS_ENABLED(CONFIG_SMP)) {
+	if (!IS_ENABLED(CONFIG_SMP) && (thread == _current) && !arch_is_in_isr()) {
 		k_spinlock_key_t key = k_spin_lock(&_sched_spinlock);
 
 		z_mark_thread_as_suspended(thread);


### PR DESCRIPTION
The routine k_thread_suspend() has a fast path for non-SMP when suspending the current thread. When SMP is enabled, it is expected that the compiler drop the entire fast path checks because the whole expression would always evaluate to false. However, the compiler has been observed to only drop whole fast path check when the "!IS_ENABLED(CONFIG_SMP)" condition appears at the beginning of the fast path check.