### PR TITLE
tests: i2c_emul: Remove unused variable

### DIFF
--- a/tests/drivers/i2c/i2c_emul/src/test_forwarding_buf.cpp
+++ b/tests/drivers/i2c/i2c_emul/src/test_forwarding_buf.cpp
@@ -15,8 +15,6 @@ namespace
 
 /* Get the devicetree constants */
 constexpr const struct device *controller = DEVICE_DT_GET(CONTROLLER_LABEL);
-constexpr const struct device *targets[FORWARD_COUNT] = {
-	DT_FOREACH_PROP_ELEM_SEP(CONTROLLER_LABEL, forwards, DEVICE_DT_GET_BY_IDX, (,))};
 
 ZTEST(i2c_emul_forwarding, test_write_is_forwarded)
 {


### PR DESCRIPTION
Building with clang warns:

```
tests/drivers/i2c/i2c_emul/src/test_forwarding_buf.cpp:20:32: error: unused variable 'targets' [-Werror,-Wunused-const-variable] constexpr const struct device *targets[FORWARD_COUNT] = {
                               ^
```