### PR TITLE
drivers: sensor: fxls8974: fix size misalignment memory access

### DIFF
--- a/drivers/sensor/nxp/fxls8974/fxls8974.c
+++ b/drivers/sensor/nxp/fxls8974/fxls8974.c
@@ -399,7 +399,7 @@ static int fxls8974_channel_get(const struct device *dev,
 		return 0;
 }
 
-int fxls8974_get_active(const struct device *dev, enum fxls8974_active *active)
+int fxls8974_get_active(const struct device *dev, uint8_t *active)
 {
 		const struct fxls8974_config *cfg = dev->config;
 		uint8_t val;
@@ -415,7 +415,7 @@ int fxls8974_get_active(const struct device *dev, enum fxls8974_active *active)
 		return 0;
 }
 
-int fxls8974_set_active(const struct device *dev, enum fxls8974_active active)
+int fxls8974_set_active(const struct device *dev, uint8_t active)
 {
 		const struct fxls8974_config *cfg = dev->config;
 
@@ -498,7 +498,7 @@ static int fxls8974_init(const struct device *dev)
 			return -EIO;
 		}
 
-		if (fxls8974_get_active(dev, (enum fxls8974_active *)&regVal)) {
+		if (fxls8974_get_active(dev, &regVal)) {
 			LOG_ERR("Failed to set standby mode");
 			return -EIO;
 		}
@@ -560,7 +560,7 @@ static int fxls8974_init(const struct device *dev)
 			return -EIO;
 		}
 
-		if (fxls8974_get_active(dev, (enum fxls8974_active *)&regVal)) {
+		if (fxls8974_get_active(dev, &regVal)) {
 			LOG_ERR("Failed to get active mode");
 			return -EIO;
 		}

--- a/drivers/sensor/nxp/fxls8974/fxls8974.h
+++ b/drivers/sensor/nxp/fxls8974/fxls8974.h
@@ -155,8 +155,8 @@ struct fxls8974_data {
 #endif
 };
 
-int fxls8974_get_active(const struct device *dev, enum fxls8974_active *active);
-int fxls8974_set_active(const struct device *dev, enum fxls8974_active active);
+int fxls8974_get_active(const struct device *dev, uint8_t *active);
+int fxls8974_set_active(const struct device *dev, uint8_t active);
 
 #if DT_ANY_INST_ON_BUS_STATUS_OKAY(spi)
 int fxls8974_byte_write_spi(const struct device *dev,


### PR DESCRIPTION
Coverity identified out-of-bounds access. A uint8_t being cast to an enum is undefined in that the enum can be allocated 4bytes.

Change the internal function to use the base type of the variable, uint8_t to avoid potential compiler size alignement problems.

Fixes #81927