### PR TITLE
samples: Fix fs format sample README to correct a formatting problem

### DIFF
--- a/samples/subsys/fs/format/README.rst
+++ b/samples/subsys/fs/format/README.rst
@@ -45,6 +45,7 @@ Sample Output
 =============
 
 When the sample runs successfully you should see following message on the screen:
+
 .. code-block:: console
 
   I: LittleFS version 2.4, disk version 2.0


### PR DESCRIPTION
The Sample Output section is missing a blank line before the code block markup, resulting in the sample output text showing up with an incorrect format. Fixed by adding a blank line.

See the incorrect rendering in the generated document at: https://docs.zephyrproject.org/latest/samples/subsys/fs/format/README.html