### PR TITLE
Improve lvgl performance on Renesas RA8D1 by enabling cache and changing default LCD shield config

### DIFF
--- a/boards/shields/rtkmipilcdb00000be/boards/ek_ra8d1.conf
+++ b/boards/shields/rtkmipilcdb00000be/boards/ek_ra8d1.conf
@@ -1,0 +1,6 @@
+# Copyright (c) 2025 Renesas Electronics Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_LV_Z_FLUSH_THREAD=n
+CONFIG_LV_Z_BITS_PER_PIXEL=16
+CONFIG_LV_COLOR_DEPTH_16=y

--- a/boards/shields/rtkmipilcdb00000be/boards/ek_ra8d1.overlay
+++ b/boards/shields/rtkmipilcdb00000be/boards/ek_ra8d1.overlay
@@ -23,3 +23,7 @@
 	pinctrl-0 = <&iic1_default>;
 	pinctrl-names = "default";
 };
+
+&zephyr_lcdif {
+	input-pixel-format = <PANEL_PIXEL_FORMAT_RGB_565>;
+};

--- a/soc/renesas/ra/ra8d1/Kconfig.defconfig
+++ b/soc/renesas/ra/ra8d1/Kconfig.defconfig
@@ -10,4 +10,7 @@ config NUM_IRQS
 config FLASH_FILL_BUFFER_SIZE
 	default 128
 
+config CACHE_MANAGEMENT
+	default y
+
 endif # SOC_SERIES_RA8D1

--- a/soc/renesas/ra/ra8d1/soc.c
+++ b/soc/renesas/ra/ra8d1/soc.c
@@ -17,9 +17,13 @@
 #include <zephyr/arch/arm/nmi.h>
 #include <zephyr/irq.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/sys/barrier.h>
+#include <zephyr/cache.h>
 LOG_MODULE_REGISTER(soc, CONFIG_SOC_LOG_LEVEL);
 
 #include <bsp_api.h>
+
+#define CCR_CACHE_ENABLE (SCB_CCR_IC_Msk | SCB_CCR_BP_Msk | SCB_CCR_LOB_Msk)
 
 uint32_t SystemCoreClock BSP_SECTION_EARLY_INIT;
 
@@ -34,4 +38,24 @@ void soc_early_init_hook(void)
 {
 	SystemCoreClock = BSP_MOCO_HZ;
 	g_protect_pfswe_counter = 0;
+
+	SCB->CCR = (uint32_t)CCR_CACHE_ENABLE;
+	barrier_dsync_fence_full();
+	barrier_isync_fence_full();
+
+	/* Apply Arm Cortex-M85 errata workarounds for D-Cache
+	 * Attributing all cacheable memory as write-through set FORCEWT bit in MSCR register.
+	 * Set bit 16 in ACTLR to 1.
+	 * See erratum 3175626 and 3190818 in the Cortex-M85 AT640 and Cortex-M85 with FPU AT641
+	 * Software Developer Errata Notice (Date of issue: March 07, 2024, Document version: 13.0,
+	 * Document ID: SDEN-2236668).
+	 */
+	MEMSYSCTL->MSCR |= MEMSYSCTL_MSCR_FORCEWT_Msk;
+	barrier_dsync_fence_full();
+	barrier_isync_fence_full();
+	ICB->ACTLR |= (1U << 16U);
+	barrier_dsync_fence_full();
+	barrier_isync_fence_full();
+
+	sys_cache_data_enable();
 }


### PR DESCRIPTION
Enable I cache and D cache support in SOC early init hook for RA8D1 to improve image rendering and display performance.
Change default input format of the shield to RGB565 to achieve better frame rate performance. 
Remove LV_Z_FLUSH_THREAD as temporary solution for flickering screen issue when CPU go too high
Adding config LV_ATTRIBUTE_MEM_ALIGN_SIZE to avoid unexpected memory alignment issue when building with Os optimization