### PR TITLE
twister: runner: Log trace on general exception

### DIFF
--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -2017,7 +2017,7 @@ class TwisterRunner:
                             break
                 return True
         except Exception as e:
-            logger.error(f"General exception: {e}")
+            logger.error(f"General exception: {e}\n{traceback.format_exc()}")
             sys.exit(1)
 
     def execute(self, pipeline, done):


### PR DESCRIPTION
Log trace on general exception at ProjectBuilder to provide more details on its cause instead of just
```
ERROR   - General exception: [Errno 32] Broken pipe
```
https://github.com/zephyrproject-rtos/zephyr/actions/runs/13095023661/job/36536311689#step:13:5834

[See discussion on Discord](https://discord.com/channels/720317445772017664/1014241011989487716/1336421325685788703)