### PR TITLE
drivers: led: lp50xx: add support for single color LEDs

### DIFF
--- a/boards/seagate/faze/faze.dts
+++ b/boards/seagate/faze/faze.dts
@@ -93,7 +93,7 @@
 		};
 		led1: led_1 {
 			label = "LED LP5030 1";
-			index = <1>;
+			index = <3>;
 			color-mapping =
 				<LED_COLOR_ID_RED>,
 				<LED_COLOR_ID_GREEN>,
@@ -101,7 +101,7 @@
 		};
 		led2: led_2 {
 			label = "LED LP5030 2";
-			index = <2>;
+			index = <6>;
 			color-mapping =
 				<LED_COLOR_ID_RED>,
 				<LED_COLOR_ID_GREEN>,
@@ -109,7 +109,7 @@
 		};
 		led3: led_3 {
 			label = "LED LP5030 3";
-			index = <3>;
+			index = <9>;
 			color-mapping =
 				<LED_COLOR_ID_RED>,
 				<LED_COLOR_ID_GREEN>,
@@ -117,7 +117,7 @@
 		};
 		led4: led_4 {
 			label = "LED LP5030 4";
-			index = <4>;
+			index = <12>;
 			color-mapping =
 				<LED_COLOR_ID_RED>,
 				<LED_COLOR_ID_GREEN>,
@@ -125,7 +125,7 @@
 		};
 		led5: led_5 {
 			label = "LED LP5030 5";
-			index = <5>;
+			index = <15>;
 			color-mapping =
 				<LED_COLOR_ID_RED>,
 				<LED_COLOR_ID_GREEN>,

--- a/doc/releases/migration-guide-4.2.rst
+++ b/doc/releases/migration-guide-4.2.rst
@@ -200,6 +200,14 @@ I2S
 * configure the MCLK signal as an output.  Older driver versions used the macro
 * ``I2S_OPT_BIT_CLK_SLAVE`` to configure the MCLK signal direction. (:github:`88554`)
 
+LED
+===
+
+* The :dtcompatible:`ti,lp50xx` devicetree property has been renamed from ``max_curr_opt`` to ``max-curr-opt``.
+  The devicetree index property now refers to the controller output channel number (OUTx). For RGB LEDs
+  set the index property to the location of the red LED. For a single LED simply set the index property to
+  the connected OUTx where x should match the devicetree index property.
+
 Sensors
 =======
 

--- a/drivers/led/lp50xx.c
+++ b/drivers/led/lp50xx.c
@@ -51,6 +51,7 @@ LOG_MODULE_REGISTER(lp50xx, CONFIG_LED_LOG_LEVEL);
 #define LP50XX_DEVICE_CONFIG1		0x01
 #define LP50XX_LED_CONFIG0		0x02
 
+/* Intentional INTs division aligning on bank base of specific chip reg mapping */
 #define LP50XX_BANK_BASE(nmodules)		\
 	(0x03 + (((nmodules) - 1) / 8))
 
@@ -79,7 +80,7 @@ struct lp50xx_config {
 	struct i2c_dt_spec bus;
 	const struct gpio_dt_spec gpio_enable;
 	uint8_t num_modules;
-	uint8_t max_leds;
+	uint8_t max_chans;
 	uint8_t num_leds;
 	bool log_scale_en;
 	bool max_curr_opt;
@@ -132,7 +133,15 @@ static int lp50xx_set_brightness(const struct device *dev,
 		return -EINVAL;
 	}
 
-	buf[0] = LP50XX_LED0_BRIGHTNESS(config->num_modules) + led_info->index;
+	if (led_info->num_colors == 3 || led_info->num_colors == 2) {
+		buf[0] = LP50XX_LED0_BRIGHTNESS(config->num_modules);
+		buf[0] += led_info->index / 3;
+	} else if (led_info->num_colors == 1) {
+		buf[0] = LP50XX_OUT0_COLOR(config->num_modules);
+		buf[0] += led_info->index;
+	} else {
+		return -ENOTSUP;
+	}
 	buf[1] = (value * 0xff) / 100;
 
 	return i2c_write_dt(&config->bus, buf, sizeof(buf));
@@ -169,7 +178,7 @@ static int lp50xx_set_color(const struct device *dev, uint32_t led,
 	}
 
 	buf[0] = LP50XX_OUT0_COLOR(config->num_modules);
-	buf[0] += LP50XX_COLORS_PER_LED * led_info->index;
+	buf[0] += led_info->index;
 
 	for (i = 0; i < led_info->num_colors; i++) {
 		buf[1 + i] = color[i];
@@ -268,6 +277,7 @@ static int lp50xx_init(const struct device *dev)
 {
 	const struct lp50xx_config *config = dev->config;
 	uint8_t led;
+	uint8_t used_chans = 0;
 	int err;
 
 	if (!i2c_is_ready_dt(&config->bus)) {
@@ -276,20 +286,28 @@ static int lp50xx_init(const struct device *dev)
 	}
 
 	/* Check LED configuration found in DT */
-	if (config->num_leds > config->max_leds) {
-		LOG_ERR("%s: invalid number of LEDs %d (max %d)",
-			dev->name,
-			config->num_leds,
-			config->max_leds);
-		return -EINVAL;
-	}
 	for (led = 0; led < config->num_leds; led++) {
-		const struct led_info *led_info =
-			lp50xx_led_to_info(config, led);
+		const struct led_info *led_info = lp50xx_led_to_info(config, led);
+
+		used_chans += led_info->num_colors;
+
+		/* RGB LEDs should be placed on an index which is a multiple of 3 */
+		if (led_info->num_colors == LP50XX_COLORS_PER_LED && (led_info->index % 3 != 0)) {
+			LOG_ERR("%s: LED %d: invalid index (%d) for RGB module. Multiple of 3 "
+				"expected",
+				dev->name, led, led_info->index);
+			return -ENOTSUP;
+		}
+
+		if (used_chans > config->max_chans) {
+			LOG_ERR("%s: invalid number of used channels %d (max %d)", dev->name,
+				used_chans, config->max_chans);
+			return -EINVAL;
+		}
 
 		if (led_info->num_colors > LP50XX_COLORS_PER_LED) {
-			LOG_ERR("%s: LED %d: invalid number of colors (max %d)",
-				dev->name, led, LP50XX_COLORS_PER_LED);
+			LOG_ERR("%s: LED %d: invalid number of colors (max %d)", dev->name, led,
+				LP50XX_COLORS_PER_LED);
 			return -EINVAL;
 		}
 	}
@@ -385,7 +403,7 @@ static DEVICE_API(led, lp50xx_led_api) = {
 		.gpio_enable		=					\
 			GPIO_DT_SPEC_INST_GET_OR(n, enable_gpios, {0}),		\
 		.num_modules		= nmodules,				\
-		.max_leds		= LP##id##_MAX_LEDS,			\
+		.max_chans		= LP##id##_MAX_CHANS,			\
 		.num_leds		= ARRAY_SIZE(lp##id##_leds_##n),	\
 		.log_scale_en		= DT_INST_PROP(n, log_scale_en),	\
 		.max_curr_opt		= DT_INST_PROP(n, max_curr_opt),	\

--- a/dts/bindings/led/ti,lp50xx.yaml
+++ b/dts/bindings/led/ti,lp50xx.yaml
@@ -1,5 +1,104 @@
 # Copyright (c) 2020 Seagate Technology LLC
+# Copyright (c) 2025 TecInvent Electronics Ltd
 # SPDX-License-Identifier: Apache-2.0
+
+description: |
+  Texas Instruments LP50xx 3-channel LED driver
+
+  This driver supports both single-channel and RGB LEDs. For single channel LEDs,
+  the led_set_brightness() API can be used to set the brightness of each LED.
+  For RGB LEDs, the led_set_color() API can be used to set the red, green and blue
+  components; the driver takes care of routing to the outputs described by the
+  color-mapping property. It is also possible to mix single LEDs with RGB modules
+  on a single LP50xx device.
+
+  The LED_SHELL application can be used for testing.
+
+  The index property refers to the output channel for the single LED and it refers
+  to the red component of a RGB LED.
+
+  The following defines two RGB LED DT node:
+
+  lp5024@28 {
+    compatible = "ti,lp5024";
+    reg = <0x28>;
+    enable-gpios = <&gpiob 12 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
+
+    led_rgb_1 {
+      label = "RGB 1";
+      index = <0>;
+      color-mapping =
+              <LED_COLOR_ID_RED>,
+              <LED_COLOR_ID_GREEN>,
+              <LED_COLOR_ID_BLUE>;
+    };
+
+    led_rgb_2 {
+      label = "RGB 2";
+      index = <3>;
+      color-mapping =
+              <LED_COLOR_ID_RED>,
+              <LED_COLOR_ID_GREEN>,
+              <LED_COLOR_ID_BLUE>;
+    };
+  };
+
+  In the above example you can see how the index property is being used. The index value
+  refers to the controller output channel where the red component is being connected.
+
+  The following example refers to a case where single-channel LEDs are being used:
+
+  lp5024@28 {
+    compatible = "ti,lp5024";
+    reg = <0x28>;
+    enable-gpios = <&gpiob 12 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
+
+    led_a_1 {
+      label = "Amber 1";
+      index = <0>;
+      color-mapping = <LED_COLOR_ID_AMBER>;
+    };
+    led_a_2 {
+      label = "Amber 2";
+      index = <1>;
+      color-mapping = <LED_COLOR_ID_AMBER>;
+    };
+  };
+
+  The meaning of the index is kept (as with the RGB case) and it refers to the output channel.
+
+  The last example describes a case where mixed LEDs are being used:
+
+  lp5024@28 {
+    compatible = "ti,lp5024";
+    reg = <0x28>;
+    enable-gpios = <&gpiob 12 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
+
+    led_a_1 {
+      label = "Amber 1";
+      index = <0>;
+      color-mapping = <LED_COLOR_ID_AMBER>;
+    };
+    led_a_2 {
+      label = "Amber 2";
+      index = <1>;
+      color-mapping = <LED_COLOR_ID_AMBER>;
+    };
+
+    led_rgb_1 {
+      label = "RGB 1";
+      index = <3>;
+      color-mapping =
+              <LED_COLOR_ID_RED>,
+              <LED_COLOR_ID_GREEN>,
+              <LED_COLOR_ID_BLUE>;
+    };
+
+  };
+
+  Note that the RGB is connected to output 3 as suggested by the data-sheet that states that
+  the RGB's red channel should be placed on a multiple of three output (e.g. 0, 3, 6, etc).
+  So in this case index (output channel) 2 is unused.
 
 include: ["i2c-device.yaml", "led-controller.yaml"]
 
@@ -12,7 +111,7 @@ properties:
     type: boolean
     description: |
       If enabled the maximum current output is set to 35 mA (25.5 mA else).
-  log_scale_en:
+  log-scale-en:
     type: boolean
     description: |
       If enabled a logarithmic dimming scale curve is used for LED brightness

--- a/include/zephyr/drivers/led/lp50xx.h
+++ b/include/zephyr/drivers/led/lp50xx.h
@@ -11,12 +11,12 @@
 
 #define LP50XX_COLORS_PER_LED	3
 
-#define LP5009_MAX_LEDS		3
-#define LP5012_MAX_LEDS		4
-#define LP5018_MAX_LEDS		6
-#define LP5024_MAX_LEDS		8
-#define LP5030_MAX_LEDS		10
-#define LP5036_MAX_LEDS		12
+#define LP5009_MAX_CHANS	9
+#define LP5012_MAX_CHANS	12
+#define LP5018_MAX_CHANS	18
+#define LP5024_MAX_CHANS	24
+#define LP5030_MAX_CHANS	30
+#define LP5036_MAX_CHANS	36
 
 /*
  * LED channels mapping.

--- a/samples/drivers/led/lp50xx/boards/lpcxpresso11u68.overlay
+++ b/samples/drivers/led/lp50xx/boards/lpcxpresso11u68.overlay
@@ -23,7 +23,7 @@
 		};
 		led_1 {
 			label = "LED LP5030 1";
-			index = <1>;
+			index = <3>;
 			color-mapping =
 				<LED_COLOR_ID_RED>,
 				<LED_COLOR_ID_GREEN>,
@@ -31,7 +31,7 @@
 		};
 		led_2 {
 			label = "LED LP5030 2";
-			index = <2>;
+			index = <6>;
 			color-mapping =
 				<LED_COLOR_ID_RED>,
 				<LED_COLOR_ID_GREEN>,
@@ -39,7 +39,7 @@
 		};
 		led_3 {
 			label = "LED LP5030 3";
-			index = <3>;
+			index = <9>;
 			color-mapping =
 				<LED_COLOR_ID_RED>,
 				<LED_COLOR_ID_GREEN>,
@@ -47,7 +47,7 @@
 		};
 		led_4 {
 			label = "LED LP5030 4";
-			index = <4>;
+			index = <12>;
 			color-mapping =
 				<LED_COLOR_ID_RED>,
 				<LED_COLOR_ID_GREEN>,
@@ -55,7 +55,7 @@
 		};
 		led_5 {
 			label = "LED LP5030 5";
-			index = <5>;
+			index = <15>;
 			color-mapping =
 				<LED_COLOR_ID_RED>,
 				<LED_COLOR_ID_GREEN>,
@@ -63,7 +63,7 @@
 		};
 		led_6 {
 			label = "LED LP5030 6";
-			index = <6>;
+			index = <18>;
 			color-mapping =
 				<LED_COLOR_ID_RED>,
 				<LED_COLOR_ID_GREEN>,
@@ -71,7 +71,7 @@
 		};
 		led_7 {
 			label = "LED LP5030 7";
-			index = <7>;
+			index = <21>;
 			color-mapping =
 				<LED_COLOR_ID_RED>,
 				<LED_COLOR_ID_GREEN>,
@@ -79,7 +79,7 @@
 		};
 		led_8 {
 			label = "LED LP5030 8";
-			index = <8>;
+			index = <24>;
 			color-mapping =
 				<LED_COLOR_ID_RED>,
 				<LED_COLOR_ID_GREEN>,
@@ -87,7 +87,7 @@
 		};
 		led_9 {
 			label = "LED LP5030 9";
-			index = <9>;
+			index = <27>;
 			color-mapping =
 				<LED_COLOR_ID_RED>,
 				<LED_COLOR_ID_GREEN>,

--- a/samples/drivers/led/lp50xx/src/main.c
+++ b/samples/drivers/led/lp50xx/src/main.c
@@ -342,7 +342,7 @@ int main(void)
 
 		if (device_is_ready(lp50xx_dev)) {
 			run_test(lp50xx_dev,
-				 LP5009_MAX_LEDS,
+				 LP5009_MAX_CHANS / LP50XX_COLORS_PER_LED,
 				 LP50XX_LED_BRIGHT_CHAN_BASE,
 				 LP5012_LED_COL_CHAN_BASE);
 		} else {
@@ -358,7 +358,7 @@ int main(void)
 
 		if (device_is_ready(lp50xx_dev)) {
 			run_test(lp50xx_dev,
-				 LP5012_MAX_LEDS,
+				 LP5012_MAX_CHANS / LP50XX_COLORS_PER_LED,
 				 LP50XX_LED_BRIGHT_CHAN_BASE,
 				 LP5012_LED_COL_CHAN_BASE);
 		} else {
@@ -374,7 +374,7 @@ int main(void)
 
 		if (device_is_ready(lp50xx_dev)) {
 			run_test(lp50xx_dev,
-				 LP5018_MAX_LEDS,
+				 LP5018_MAX_CHANS / LP50XX_COLORS_PER_LED,
 				 LP50XX_LED_BRIGHT_CHAN_BASE,
 				 LP5024_LED_COL_CHAN_BASE);
 		} else {
@@ -390,7 +390,7 @@ int main(void)
 
 		if (device_is_ready(lp50xx_dev)) {
 			run_test(lp50xx_dev,
-				 LP5024_MAX_LEDS,
+				 LP5024_MAX_CHANS / LP50XX_COLORS_PER_LED,
 				 LP50XX_LED_BRIGHT_CHAN_BASE,
 				 LP5024_LED_COL_CHAN_BASE);
 		} else {
@@ -406,7 +406,7 @@ int main(void)
 
 		if (device_is_ready(lp50xx_dev)) {
 			run_test(lp50xx_dev,
-				 LP5030_MAX_LEDS,
+				 LP5030_MAX_CHANS / LP50XX_COLORS_PER_LED,
 				 LP50XX_LED_BRIGHT_CHAN_BASE,
 				 LP5036_LED_COL_CHAN_BASE);
 		} else {
@@ -422,7 +422,7 @@ int main(void)
 
 		if (device_is_ready(lp50xx_dev)) {
 			run_test(lp50xx_dev,
-				 LP5036_MAX_LEDS,
+				 LP5036_MAX_CHANS / LP50XX_COLORS_PER_LED,
 				 LP50XX_LED_BRIGHT_CHAN_BASE,
 				 LP5036_LED_COL_CHAN_BASE);
 		} else {


### PR DESCRIPTION
Max LED quantities are based on the assumption that RGB LEDs are being used. This patch adds support for arbitrary LEDs (e.g. single classical LEDs) and limit check is being performed by reading the defined color-mapping field within the device tree definition.