### PR TITLE
sdhc: sdhc_spi: additional SPI PM calls

### DIFF
--- a/drivers/sdhc/sdhc_spi.c
+++ b/drivers/sdhc/sdhc_spi.c
@@ -183,8 +183,13 @@ static int sdhc_spi_card_busy(const struct device *dev)
 	int ret;
 	uint8_t response;
 
+	/* Request SPI bus to be active */
+	if (pm_device_runtime_get(config->spi_dev) < 0) {
+		return -EIO;
+	}
 
 	ret = sdhc_spi_rx(config->spi_dev, data->spi_cfg, &response, 1);
+	(void)pm_device_runtime_put(config->spi_dev);
 	if (ret) {
 		return -EIO;
 	}


### PR DESCRIPTION
`sdhc_spi_card_busy` requires additional PM calls to ensure the bus is enabled in the API call.