### PR TITLE
boards: arduino: add ADC assignments for SAMD21-based boards

### DIFF
--- a/boards/arduino/mkrzero/arduino_mkrzero-pinctrl.dtsi
+++ b/boards/arduino/mkrzero/arduino_mkrzero-pinctrl.dtsi
@@ -6,6 +6,18 @@
 #include <dt-bindings/pinctrl/samd21-da1gXabcd-pinctrl.h>
 
 &pinctrl {
+	adc_default: adc_default {
+		group1 {
+			pinmux = <PA2B_ADC_AIN0>,
+				 <PB2B_ADC_AIN10>,
+				 <PB3B_ADC_AIN11>,
+				 <PA4B_ADC_AIN4>,
+				 <PA5B_ADC_AIN5>,
+				 <PA6B_ADC_AIN6>,
+				 <PA7B_ADC_AIN7>;
+		};
+	};
+
 	dac_default: dac_default {
 		group1 {
 			pinmux = <PA2B_DAC_VOUT>;
@@ -18,6 +30,7 @@
 				 <PA9C_SERCOM0_PAD1>;
 		};
 	};
+
 	sercom1_spi_default: sercom1_spi_default {
 		group1 {
 			pinmux = <PA16C_SERCOM1_PAD0>,

--- a/boards/arduino/mkrzero/arduino_mkrzero.dts
+++ b/boards/arduino/mkrzero/arduino_mkrzero.dts
@@ -106,6 +106,13 @@
 	pinctrl-names = "default";
 };
 
+&adc {
+	status = "okay";
+
+	pinctrl-0 = <&adc_default>;
+	pinctrl-names = "default";
+};
+
 &dac0 {
 	status = "okay";
 

--- a/boards/arduino/nano_33_iot/arduino_nano_33_iot-pinctrl.dtsi
+++ b/boards/arduino/nano_33_iot/arduino_nano_33_iot-pinctrl.dtsi
@@ -6,6 +6,18 @@
 #include <dt-bindings/pinctrl/samd21-da1gXabcd-pinctrl.h>
 
 &pinctrl {
+	adc_default: adc_default {
+		group1 {
+			pinmux = <PA2B_ADC_AIN0>,
+				 <PB2B_ADC_AIN10>,
+				 <PA11B_ADC_AIN19>,
+				 <PA10B_ADC_AIN18>,
+				 <PB8B_ADC_AIN2>,
+				 <PB9B_ADC_AIN3>,
+				 <PA9B_ADC_AIN17>;
+		};
+	};
+
 	pwm_default: pwm_default {
 		group1 {
 			pinmux = <PA17E_TCC2_WO1>;

--- a/boards/arduino/nano_33_iot/arduino_nano_33_iot.dts
+++ b/boards/arduino/nano_33_iot/arduino_nano_33_iot.dts
@@ -48,6 +48,13 @@
 	clock-frequency = <48000000>;
 };
 
+&adc {
+	status = "okay";
+
+	pinctrl-0 = <&adc_default>;
+	pinctrl-names = "default";
+};
+
 &sercom1 {
 	status = "okay";
 	compatible = "atmel,sam0-spi";

--- a/boards/arduino/zero/arduino_zero-pinctrl.dtsi
+++ b/boards/arduino/zero/arduino_zero-pinctrl.dtsi
@@ -6,6 +6,17 @@
 #include <dt-bindings/pinctrl/samd21-da1gXabcd-pinctrl.h>
 
 &pinctrl {
+	adc_default: adc_default {
+		group1 {
+			pinmux = <PA2B_ADC_AIN0>,
+				 <PB8B_ADC_AIN2>,
+				 <PB9B_ADC_AIN3>,
+				 <PA4B_ADC_AIN4>,
+				 <PA5B_ADC_AIN5>,
+				 <PB2B_ADC_AIN10>;
+		};
+	};
+
 	dac_default: dac_default {
 		group1 {
 			pinmux = <PA2B_DAC_VOUT>;

--- a/boards/arduino/zero/arduino_zero.dts
+++ b/boards/arduino/zero/arduino_zero.dts
@@ -102,6 +102,13 @@
 	pinctrl-names = "default";
 };
 
+&adc {
+	status = "okay";
+
+	pinctrl-0 = <&adc_default>;
+	pinctrl-names = "default";
+};
+
 &dac0 {
 	status = "okay";
 


### PR DESCRIPTION
The ADC pin assignments for the Arduino Zero, MKR Zero and Nano 33 IoT boards were missing in the device tree files, even though the boards advertise ADC functionality. This was highlighted recently by commit 162f728 which made it a build error.

This patch fixes the issue by adding the detailed pinout assignments for the analog pins on these boards.