### PR TITLE
doc/hardware/arch/risc-v: update SMP documentation

### DIFF
--- a/doc/hardware/arch/risc-v.rst
+++ b/doc/hardware/arch/risc-v.rst
@@ -32,6 +32,8 @@ combinations.
 SMP support
 ***********
 
-SMP is supported on RISC-V, but currently only on Qemu platforms. In
-order to test the SMP support, one can use ``qemu_riscv32_smp`` or
-``qemu_riscv64_smp`` boards.
+SMP is supported on RISC-V for both QEMU-virtualized and hardware-based
+platforms. In order to test the SMP support, one can use
+:zephyr:board:`qemu_riscv32` or :zephyr:board:`qemu_riscv64` for QEMU-based
+platforms, or :zephyr:board:`beaglev_fire` or :zephyr:board:`mpfs_icicle` for
+hardware-based platforms.


### PR DESCRIPTION
This PR updates the SMP section documentation so that it reflects the current status of SMP support in Zephyr for RISC-V, including pointing to hardware-based platforms that as of date support SMP.