### PR TITLE
bluetooth: tester: btp_gap: fix building without extended adv

### DIFF
--- a/tests/bluetooth/tester/src/btp_gap.c
+++ b/tests/bluetooth/tester/src/btp_gap.c
@@ -336,6 +336,7 @@ static const char *oob_config_str(int oob_config)
 	if (!IS_ENABLED(CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY)) {
 		return "no";
 	}
+
 	switch (oob_config) {
 	case BT_CONN_OOB_LOCAL_ONLY:
 		return "Local";
@@ -366,10 +367,11 @@ static void oob_data_request(struct bt_conn *conn,
 	switch (oob_info->type) {
 	case BT_CONN_OOB_LE_SC:
 	{
-		if (!IS_ENABLED(CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY)) {
+		if (!IS_ENABLED(CONFIG_BT_SMP_SC_PAIR_ONLY)) {
 			LOG_ERR("OOB LE SC not supported");
 			break;
 		}
+
 		LOG_DBG("Set %s OOB SC data for %s, ",
 			oob_config_str(oob_info->lesc.oob_config),
 			addr);
@@ -408,8 +410,12 @@ static void oob_data_request(struct bt_conn *conn,
 		break;
 	}
 
-#if !defined(CONFIG_BT_SMP_SC_PAIR_ONLY)
 	case BT_CONN_OOB_LE_LEGACY:
+		if (!IS_ENABLED(CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY)) {
+			LOG_ERR("OOB LE Legacy not supported");
+			break;
+		}
+
 		LOG_DBG("Legacy OOB TK requested from remote %s", addr);
 
 		err = bt_le_oob_set_legacy_tk(conn, oob_legacy_tk);
@@ -418,7 +424,6 @@ static void oob_data_request(struct bt_conn *conn,
 		}
 
 		break;
-#endif /* !defined(CONFIG_BT_SMP_SC_PAIR_ONLY) */
 	default:
 		LOG_ERR("Unhandled OOB type %d", oob_info->type);
 		break;

--- a/tests/bluetooth/tester/src/btp_gap.c
+++ b/tests/bluetooth/tester/src/btp_gap.c
@@ -45,10 +45,8 @@ static uint8_t oob_legacy_tk[16] = { 0 };
 
 static bool filter_list_in_use;
 
-#if !defined(CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY)
 static struct bt_le_oob oob_sc_local = { 0 };
 static struct bt_le_oob oob_sc_remote = { 0 };
-#endif /* !defined(CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY) */
 
 /* connection parameters for rejection test */
 #define REJECT_INTERVAL_MIN 0x0C80
@@ -266,10 +264,10 @@ static uint8_t supported_commands(const void *cmd, uint16_t cmd_len,
 
 	/* octet 3 */
 	tester_set_bit(rp->data, BTP_GAP_OOB_LEGACY_SET_DATA);
-#if !defined(CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY)
-	tester_set_bit(rp->data, BTP_GAP_OOB_SC_GET_LOCAL_DATA);
-	tester_set_bit(rp->data, BTP_GAP_OOB_SC_SET_REMOTE_DATA);
-#endif /* !defined(CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY) */
+	if (!IS_ENABLED(CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY)) {
+		tester_set_bit(rp->data, BTP_GAP_OOB_SC_GET_LOCAL_DATA);
+		tester_set_bit(rp->data, BTP_GAP_OOB_SC_SET_REMOTE_DATA);
+	}
 	tester_set_bit(rp->data, BTP_GAP_SET_MITM);
 	tester_set_bit(rp->data, BTP_GAP_SET_FILTER_LIST);
 #if defined(CONFIG_BT_EXT_ADV)
@@ -308,9 +306,9 @@ static uint8_t controller_info(const void *cmd, uint16_t cmd_len,
 	/*
 	 * Re-use the oob data read here in get_oob_sc_local_data()
 	 */
-#if !defined(CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY)
-	oob_sc_local = oob_local;
-#endif /* !defined(CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY) */
+	if (!IS_ENABLED(CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY)) {
+		oob_sc_local = oob_local;
+	}
 
 	/*
 	 * If privacy is used, the device uses random type address, otherwise
@@ -339,9 +337,11 @@ static uint8_t controller_info(const void *cmd, uint16_t cmd_len,
 	return BTP_STATUS_SUCCESS;
 }
 
-#if !defined(CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY)
 static const char *oob_config_str(int oob_config)
 {
+	if (!IS_ENABLED(CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY)) {
+		return "no";
+	}
 	switch (oob_config) {
 	case BT_CONN_OOB_LOCAL_ONLY:
 		return "Local";
@@ -354,7 +354,6 @@ static const char *oob_config_str(int oob_config)
 		return "no";
 	}
 }
-#endif /* !defined(CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY) */
 
 static void oob_data_request(struct bt_conn *conn,
 			     struct bt_conn_oob_info *oob_info)
@@ -371,9 +370,12 @@ static void oob_data_request(struct bt_conn *conn,
 	bt_addr_le_to_str(info.le.dst, addr, sizeof(addr));
 
 	switch (oob_info->type) {
-#if !defined(CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY)
 	case BT_CONN_OOB_LE_SC:
 	{
+		if (!IS_ENABLED(CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY)) {
+			LOG_ERR("OOB LE SC not supported");
+			break;
+		}
 		LOG_DBG("Set %s OOB SC data for %s, ",
 			oob_config_str(oob_info->lesc.oob_config),
 			addr);
@@ -411,7 +413,6 @@ static void oob_data_request(struct bt_conn *conn,
 
 		break;
 	}
-#endif /* !defined(CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY) */
 
 #if !defined(CONFIG_BT_SMP_SC_PAIR_ONLY)
 	case BT_CONN_OOB_LE_LEGACY:
@@ -430,7 +431,7 @@ static void oob_data_request(struct bt_conn *conn,
 	}
 }
 
-#if !defined(CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY)
+# if !defined (CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY)
 static uint8_t get_oob_sc_local_data(const void *cmd, uint16_t cmd_len,
 				     void *rsp, uint16_t *rsp_len)
 {

--- a/tests/bluetooth/tester/src/btp_gap.c
+++ b/tests/bluetooth/tester/src/btp_gap.c
@@ -264,9 +264,9 @@ static uint8_t supported_commands(const void *cmd, uint16_t cmd_len,
 	}
 	tester_set_bit(rp->data, BTP_GAP_SET_MITM);
 	tester_set_bit(rp->data, BTP_GAP_SET_FILTER_LIST);
-#if defined(CONFIG_BT_EXT_ADV)
-	tester_set_bit(rp->data, BTP_GAP_SET_EXTENDED_ADVERTISING);
-#endif
+	if (IS_ENABLED(CONFIG_BT_EXT_ADV)) {
+		tester_set_bit(rp->data, BTP_GAP_SET_EXTENDED_ADVERTISING);
+	}
 
 	*rsp_len = sizeof(*rp) + 4;
 
@@ -425,7 +425,7 @@ static void oob_data_request(struct bt_conn *conn,
 	}
 }
 
-# if !defined (CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY)
+#if !defined(CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY)
 static uint8_t get_oob_sc_local_data(const void *cmd, uint16_t cmd_len,
 				     void *rsp, uint16_t *rsp_len)
 {
@@ -516,16 +516,22 @@ static struct bt_data ad[10] = {
 };
 static struct bt_data sd[10];
 
-#if defined(CONFIG_BT_EXT_ADV)
 static struct bt_le_ext_adv *ext_adv;
 
 struct bt_le_ext_adv *tester_gap_ext_adv_get(void)
 {
+	if (!IS_ENABLED(CONFIG_BT_EXT_ADV)) {
+		return NULL;
+	}
 	return ext_adv;
 }
 
 int tester_gap_start_ext_adv(void)
 {
+	if (!IS_ENABLED(CONFIG_BT_EXT_ADV)) {
+		return -ENOTSUP;
+	}
+
 	int err;
 
 	err = bt_le_ext_adv_start(ext_adv, BT_LE_EXT_ADV_START_DEFAULT);
@@ -542,6 +548,10 @@ int tester_gap_start_ext_adv(void)
 
 int tester_gap_stop_ext_adv(void)
 {
+	if (!IS_ENABLED(CONFIG_BT_EXT_ADV)) {
+		return -ENOTSUP;
+	}
+
 	int err;
 
 	err = bt_le_ext_adv_stop(ext_adv);
@@ -555,7 +565,6 @@ int tester_gap_stop_ext_adv(void)
 
 	return 0;
 }
-#endif /* defined(CONFIG_BT_EXT_ADV) */
 
 static uint8_t set_discoverable(const void *cmd, uint16_t cmd_len,
 			       void *rsp, uint16_t *rsp_len)
@@ -744,12 +753,9 @@ static uint8_t start_advertising(const void *cmd, uint16_t cmd_len,
 		return BTP_STATUS_FAILED;
 	}
 
-#if defined(CONFIG_BT_EXT_ADV)
-	if (atomic_test_bit(&current_settings, BTP_GAP_SETTINGS_EXTENDED_ADVERTISING)) {
+	if (IS_ENABLED(CONFIG_BT_EXT_ADV) &&
+	    atomic_test_bit(&current_settings, BTP_GAP_SETTINGS_EXTENDED_ADVERTISING)) {
 		err = bt_le_ext_adv_start(ext_adv, BT_LE_EXT_ADV_START_DEFAULT);
-#else
-	if (0) {
-#endif
 	} else {
 		err = bt_le_adv_start(&param, ad, adv_len, sd_len ? sd : NULL, sd_len);
 	}
@@ -1370,8 +1376,9 @@ static uint8_t set_filter_list(const void *cmd, uint16_t cmd_len,
 	return BTP_STATUS_SUCCESS;
 }
 
-static uint8_t set_extended_advertising(const void *cmd, uint16_t cmd_len,
-					void *rsp, uint16_t *rsp_len)
+#if defined(CONFIG_BT_EXT_ADV)
+static uint8_t set_extended_advertising(const void *cmd, uint16_t cmd_len, void *rsp,
+					uint16_t *rsp_len)
 {
 	const struct btp_gap_set_extended_advertising_cmd *cp = cmd;
 	struct btp_gap_set_extended_advertising_rp *rp = rsp;
@@ -1379,11 +1386,9 @@ static uint8_t set_extended_advertising(const void *cmd, uint16_t cmd_len,
 	LOG_DBG("ext adv settings: %u", cp->settings);
 
 	if (cp->settings != 0) {
-		atomic_set_bit(&current_settings,
-			       BTP_GAP_SETTINGS_EXTENDED_ADVERTISING);
+		atomic_set_bit(&current_settings, BTP_GAP_SETTINGS_EXTENDED_ADVERTISING);
 	} else {
-		atomic_clear_bit(&current_settings,
-				 BTP_GAP_SETTINGS_EXTENDED_ADVERTISING);
+		atomic_clear_bit(&current_settings, BTP_GAP_SETTINGS_EXTENDED_ADVERTISING);
 	}
 
 	rp->current_settings = sys_cpu_to_le32(current_settings);
@@ -1391,6 +1396,7 @@ static uint8_t set_extended_advertising(const void *cmd, uint16_t cmd_len,
 	*rsp_len = sizeof(*rp);
 	return BTP_STATUS_SUCCESS;
 }
+#endif /* defined(CONFIG_BT_EXT_ADV) */
 
 #if defined(CONFIG_BT_PER_ADV)
 static struct bt_data padv[10];

--- a/tests/bluetooth/tester/testcase.yaml
+++ b/tests/bluetooth/tester/testcase.yaml
@@ -40,3 +40,13 @@ tests:
     extra_args: EXTRA_CONF_FILE="overlay-mesh.conf"
     tags: bluetooth
     harness: bluetooth
+  bluetooth.general.tester.legacy_adv:
+    build_only: true
+    platform_allow:
+      - qemu_x86
+      - native_sim
+      - nrf52840dk/nrf52840
+    extra_configs:
+      - CONFIG_BT_EXT_ADV=n
+    tags: bluetooth
+    harness: bluetooth


### PR DESCRIPTION
btp_gap implementation references ext_adv, which is guarded by if defined macro. Disabling CONFIG_BT_EXT_ADV will fail compilation. Fixed it by moving declaration out of the guards, it will be dropped by linker if not used and marking as maybe_unused, to prevent warning if kconfig is not set. 
set_extended_advertising moved under the guard to avoid unused warning.