### PR TITLE
Bluetooth: CAP bsim test multiple acceptors

### DIFF
--- a/tests/bsim/bluetooth/audio/src/cap_commander_test.c
+++ b/tests/bsim/bluetooth/audio/src/cap_commander_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Nordic Semiconductor ASA
+ * Copyright (c) 2023-2025 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -771,12 +771,6 @@ static void discover_bass(size_t acceptor_cnt)
 {
 	k_sem_reset(&sem_bass_discovered);
 
-	if (acceptor_cnt > 1) {
-		FAIL("Current implementation does not support multiple connections for the "
-		     "broadcast assistant");
-		return;
-	}
-
 	for (size_t i = 0U; i < acceptor_cnt; i++) {
 		int err;
 
@@ -1215,14 +1209,20 @@ static void test_main_cap_commander_broadcast_reception(void)
 
 	test_distribute_broadcast_code(acceptor_count);
 
-	backchannel_sync_wait_any(); /* wait for the acceptor to receive data */
+	for (size_t i = 0U; i < acceptor_count; i++) {
+		backchannel_sync_wait_any(); /* wait for the acceptor to receive data */
+	}
 
 	test_broadcast_reception_stop(acceptor_count);
 
-	backchannel_sync_wait_any(); /* wait for the acceptor to stop reception */
+	for (size_t i = 0U; i < acceptor_count; i++) {
+		backchannel_sync_wait_any(); /* wait for the acceptor to stop reception */
+	}
 
 	/* Disconnect all CAP acceptors */
 	disconnect_acl(acceptor_count);
+
+	backchannel_sync_send_all(); /* let others know we have received what we wanted */
 
 	PASS("Broadcast reception passed\n");
 }

--- a/tests/bsim/bluetooth/audio/src/cap_initiator_broadcast_test.c
+++ b/tests/bsim/bluetooth/audio/src/cap_initiator_broadcast_test.c
@@ -40,7 +40,7 @@ CREATE_FLAG(flag_source_started);
 #define CAP_AC_MAX_STREAM       2
 #define LOCATION                (BT_AUDIO_LOCATION_FRONT_LEFT | BT_AUDIO_LOCATION_FRONT_RIGHT)
 #define CONTEXT                 (BT_AUDIO_CONTEXT_TYPE_MEDIA)
-#define BROADCAST_STREMT_CNT    MIN(CAP_AC_MAX_STREAM, CONFIG_BT_BAP_BROADCAST_SRC_STREAM_COUNT)
+#define BROADCAST_STREAM_CNT    MIN(CAP_AC_MAX_STREAM, CONFIG_BT_BAP_BROADCAST_SRC_STREAM_COUNT)
 
 struct cap_initiator_ac_param {
 	char *name;
@@ -51,7 +51,7 @@ struct cap_initiator_ac_param {
 static const struct named_lc3_preset *named_preset;
 
 extern enum bst_result_t bst_result;
-static struct audio_test_stream broadcast_source_streams[BROADCAST_STREMT_CNT];
+static struct audio_test_stream broadcast_source_streams[BROADCAST_STREAM_CNT];
 static struct bt_cap_stream *broadcast_streams[ARRAY_SIZE(broadcast_source_streams)];
 static struct bt_bap_lc3_preset broadcast_preset_16_2_1 =
 	BT_BAP_LC3_BROADCAST_PRESET_16_2_1(LOCATION, CONTEXT);
@@ -886,7 +886,7 @@ static void test_cap_initiator_ac_12(void)
 	test_cap_initiator_ac(&param);
 }
 
-#if BROADCAST_STREMT_CNT >= CAP_AC_MAX_STREAM
+#if BROADCAST_STREAM_CNT >= CAP_AC_MAX_STREAM
 static void test_cap_initiator_ac_13(void)
 {
 	const struct cap_initiator_ac_param param = {
@@ -898,7 +898,7 @@ static void test_cap_initiator_ac_13(void)
 
 	test_cap_initiator_ac(&param);
 }
-#endif /* BROADCAST_STREMT_CNT >= CAP_AC_MAX_STREAM */
+#endif /* BROADCAST_STREAM_CNT >= CAP_AC_MAX_STREAM */
 
 static void test_cap_initiator_ac_14(void)
 {
@@ -967,7 +967,7 @@ static const struct bst_test_instance test_cap_initiator_broadcast[] = {
 		.test_main_f = test_cap_initiator_ac_12,
 		.test_args_f = test_args,
 	},
-#if BROADCAST_STREMT_CNT >= CAP_AC_MAX_STREAM
+#if BROADCAST_STREAM_CNT >= CAP_AC_MAX_STREAM
 	{
 		.test_id = "cap_initiator_ac_13",
 		.test_pre_init_f = test_init,
@@ -975,7 +975,7 @@ static const struct bst_test_instance test_cap_initiator_broadcast[] = {
 		.test_main_f = test_cap_initiator_ac_13,
 		.test_args_f = test_args,
 	},
-#endif /* BROADCAST_STREMT_CNT >= CAP_AC_MAX_STREAM */
+#endif /* BROADCAST_STREAM_CNT >= CAP_AC_MAX_STREAM */
 	{
 		.test_id = "cap_initiator_ac_14",
 		.test_pre_init_f = test_init,

--- a/tests/bsim/bluetooth/audio/src/cap_initiator_broadcast_test.c
+++ b/tests/bsim/bluetooth/audio/src/cap_initiator_broadcast_test.c
@@ -37,10 +37,10 @@
 #if defined(CONFIG_BT_CAP_INITIATOR) && defined(CONFIG_BT_BAP_BROADCAST_SOURCE)
 CREATE_FLAG(flag_source_started);
 
-#define BROADCAST_STREMT_CNT    CONFIG_BT_BAP_BROADCAST_SRC_STREAM_COUNT
 #define CAP_AC_MAX_STREAM       2
 #define LOCATION                (BT_AUDIO_LOCATION_FRONT_LEFT | BT_AUDIO_LOCATION_FRONT_RIGHT)
 #define CONTEXT                 (BT_AUDIO_CONTEXT_TYPE_MEDIA)
+#define BROADCAST_STREMT_CNT    MIN(CAP_AC_MAX_STREAM, CONFIG_BT_BAP_BROADCAST_SRC_STREAM_COUNT)
 
 struct cap_initiator_ac_param {
 	char *name;
@@ -673,7 +673,8 @@ static void test_main_cap_initiator_broadcast(void)
 	WAIT_FOR_FLAG(flag_source_started);
 
 	/* Wait for other devices to have received the data they wanted */
-	backchannel_sync_wait_any();
+	printk("Waiting for broadcast stop signal");
+	backchannel_sync_wait_all();
 
 	test_broadcast_audio_tx_sync();
 

--- a/tests/bsim/bluetooth/audio/test_scripts/cap_broadcast_reception.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/cap_broadcast_reception.sh
@@ -6,7 +6,7 @@
 
 SIMULATION_ID="cap_broadcast_reception"
 VERBOSITY_LEVEL=2
-NR_OF_DEVICES=3
+NR_OF_DEVICES=4
 EXECUTE_TIMEOUT=180
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
@@ -20,12 +20,16 @@ Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
   -RealEncryption=1 -rs=46 -D=${NR_OF_DEVICES}
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
-  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=1 -testid=broadcast_source \
+  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=1 -testid=cap_initiator_broadcast \
   -RealEncryption=1 -rs=23 -D=${NR_OF_DEVICES}
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=2 -testid=cap_acceptor_broadcast_reception \
   -RealEncryption=1 -rs=69 -D=${NR_OF_DEVICES} -start_offset=7e3
+
+Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
+  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=3 -testid=cap_acceptor_broadcast_reception \
+  -RealEncryption=1 -rs=87 -D=${NR_OF_DEVICES} -start_offset=7e3
 
 # Simulation time should be larger than the WAIT_TIME in common.h
 Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} \


### PR DESCRIPTION
Adds testing of multiple acceptors in the CAP broadcast reception test. 

Required before https://github.com/zephyrproject-rtos/zephyr/issues/82483 can be implemented