### PR TITLE
tests: Bluetooth: CAP: Refactor CAP broadcast tests to multiple tests

### DIFF
--- a/tests/bsim/bluetooth/audio/src/cap_acceptor_test.c
+++ b/tests/bsim/bluetooth/audio/src/cap_acceptor_test.c
@@ -1004,6 +1004,28 @@ static void test_cap_acceptor_broadcast(void)
 	PASS("CAP acceptor broadcast passed\n");
 }
 
+static void test_cap_acceptor_broadcast_update(void)
+{
+	static struct bt_bap_stream *bap_streams[ARRAY_SIZE(broadcast_sink_streams)];
+	size_t stream_count;
+
+	init();
+
+	pa_sync_to_broadcaster();
+
+	create_and_sync_sink(bap_streams, &stream_count);
+
+	sink_wait_for_data();
+
+	printk("Waiting for metadata update");
+	WAIT_FOR_FLAG(flag_base_metadata_updated);
+	backchannel_sync_send_all(); /* let other devices know we have received metadata */
+
+	wait_for_streams_stop(stream_count);
+
+	PASS("CAP acceptor broadcast passed\n");
+}
+
 static void test_cap_acceptor_broadcast_reception(void)
 {
 	static struct bt_bap_stream *bap_streams[ARRAY_SIZE(broadcast_sink_streams)];
@@ -1072,6 +1094,12 @@ static const struct bst_test_instance test_cap_acceptor[] = {
 		.test_pre_init_f = test_init,
 		.test_tick_f = test_tick,
 		.test_main_f = test_cap_acceptor_broadcast,
+	},
+	{
+		.test_id = "cap_acceptor_broadcast_update",
+		.test_pre_init_f = test_init,
+		.test_tick_f = test_tick,
+		.test_main_f = test_cap_acceptor_broadcast_update,
 	},
 	{
 		.test_id = "cap_acceptor_broadcast_reception",

--- a/tests/bsim/bluetooth/audio/src/cap_initiator_broadcast_test.c
+++ b/tests/bsim/bluetooth/audio/src/cap_initiator_broadcast_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024 Nordic Semiconductor ASA
+ * Copyright (c) 2022-2025 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -656,6 +656,49 @@ static void test_main_cap_initiator_broadcast(void)
 
 	setup_extended_adv(&adv);
 
+	test_broadcast_audio_create(&broadcast_source);
+
+	test_broadcast_audio_start(broadcast_source, adv);
+
+	setup_extended_adv_data(broadcast_source, adv);
+
+	start_extended_adv(adv);
+
+	/* Wait for all to be started */
+	printk("Waiting for broadcast_streams to be started\n");
+	for (size_t i = 0U; i < stream_count; i++) {
+		k_sem_take(&sem_broadcast_stream_started, K_FOREVER);
+	}
+
+	WAIT_FOR_FLAG(flag_source_started);
+
+	/* Wait for other devices to have received the data they wanted */
+	backchannel_sync_wait_any();
+
+	test_broadcast_audio_tx_sync();
+
+	test_broadcast_audio_stop(broadcast_source);
+
+	test_broadcast_audio_delete(broadcast_source);
+	broadcast_source = NULL;
+
+	stop_and_delete_extended_adv(adv);
+	adv = NULL;
+
+	PASS("CAP initiator broadcast passed\n");
+}
+
+static void test_main_cap_initiator_broadcast_inval(void)
+{
+	struct bt_cap_broadcast_source *broadcast_source;
+	struct bt_le_ext_adv *adv;
+
+	(void)memset(broadcast_source_streams, 0, sizeof(broadcast_source_streams));
+
+	init();
+
+	setup_extended_adv(&adv);
+
 	test_broadcast_audio_create_inval();
 	test_broadcast_audio_create(&broadcast_source);
 
@@ -674,21 +717,64 @@ static void test_main_cap_initiator_broadcast(void)
 
 	WAIT_FOR_FLAG(flag_source_started);
 
-	/* Wait for other devices to have received what they wanted */
-	backchannel_sync_wait_any();
-
 	test_broadcast_audio_update_inval(broadcast_source);
 	test_broadcast_audio_update(broadcast_source);
 
 	/* Keeping running for a little while */
 	k_sleep(K_SECONDS(5));
 
-	test_broadcast_audio_tx_sync();
-
 	test_broadcast_audio_stop_inval();
 	test_broadcast_audio_stop(broadcast_source);
 
 	test_broadcast_audio_delete_inval();
+	test_broadcast_audio_delete(broadcast_source);
+	broadcast_source = NULL;
+
+	stop_and_delete_extended_adv(adv);
+	adv = NULL;
+
+	PASS("CAP initiator broadcast inval passed\n");
+}
+
+static void test_main_cap_initiator_broadcast_update(void)
+{
+	struct bt_cap_broadcast_source *broadcast_source;
+	struct bt_le_ext_adv *adv;
+
+	(void)memset(broadcast_source_streams, 0, sizeof(broadcast_source_streams));
+
+	init();
+
+	setup_extended_adv(&adv);
+
+	test_broadcast_audio_create(&broadcast_source);
+
+	test_broadcast_audio_start(broadcast_source, adv);
+
+	setup_extended_adv_data(broadcast_source, adv);
+
+	start_extended_adv(adv);
+
+	/* Wait for all to be started */
+	printk("Waiting for broadcast_streams to be started\n");
+	for (size_t i = 0U; i < stream_count; i++) {
+		k_sem_take(&sem_broadcast_stream_started, K_FOREVER);
+	}
+
+	WAIT_FOR_FLAG(flag_source_started);
+
+	/* Wait for other devices to have received the data they wanted */
+	backchannel_sync_wait_any();
+
+	test_broadcast_audio_update(broadcast_source);
+
+	/* Wait for other devices to have received the update */
+	backchannel_sync_wait_any();
+
+	test_broadcast_audio_tx_sync();
+
+	test_broadcast_audio_stop(broadcast_source);
+
 	test_broadcast_audio_delete(broadcast_source);
 	broadcast_source = NULL;
 
@@ -860,6 +946,18 @@ static const struct bst_test_instance test_cap_initiator_broadcast[] = {
 		.test_pre_init_f = test_init,
 		.test_tick_f = test_tick,
 		.test_main_f = test_main_cap_initiator_broadcast,
+	},
+	{
+		.test_id = "cap_initiator_broadcast_inval",
+		.test_pre_init_f = test_init,
+		.test_tick_f = test_tick,
+		.test_main_f = test_main_cap_initiator_broadcast_inval,
+	},
+	{
+		.test_id = "cap_initiator_broadcast_update",
+		.test_pre_init_f = test_init,
+		.test_tick_f = test_tick,
+		.test_main_f = test_main_cap_initiator_broadcast_update,
 	},
 	{
 		.test_id = "cap_initiator_ac_12",

--- a/tests/bsim/bluetooth/audio/test_scripts/_cap.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/_cap.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright (c) 2022-2023 Nordic Semiconductor ASA
+# Copyright (c) 2022-2025 Nordic Semiconductor ASA
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -8,28 +8,5 @@ dir_path=$(dirname "$0")
 
 set -e # Exit on error
 
-$dir_path/cap_unicast_inval.sh
-
-$dir_path/cap_unicast.sh
-
-$dir_path/cap_broadcast.sh
-$dir_path/cap_broadcast_ac_12.sh
-$dir_path/cap_broadcast_ac_13.sh
-$dir_path/cap_broadcast_ac_14.sh
-
-$dir_path/cap_unicast_ac_1.sh
-$dir_path/cap_unicast_ac_2.sh
-$dir_path/cap_unicast_ac_3.sh
-$dir_path/cap_unicast_ac_4.sh
-$dir_path/cap_unicast_ac_5.sh
-$dir_path/cap_unicast_ac_6_i.sh
-$dir_path/cap_unicast_ac_6_ii.sh
-$dir_path/cap_unicast_ac_7_i.sh
-$dir_path/cap_unicast_ac_7_ii.sh
-$dir_path/cap_unicast_ac_8_i.sh
-$dir_path/cap_unicast_ac_8_ii.sh
-$dir_path/cap_unicast_ac_9_i.sh
-$dir_path/cap_unicast_ac_9_ii.sh
-$dir_path/cap_unicast_ac_10.sh
-$dir_path/cap_unicast_ac_11_i.sh
-$dir_path/cap_unicast_ac_11_ii.sh
+$dir_path/_cap_broadcast.sh
+$dir_path/_cap_unicast.sh

--- a/tests/bsim/bluetooth/audio/test_scripts/_cap_broadcast.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/_cap_broadcast.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2025 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+
+dir_path=$(dirname "$0")
+
+set -e # Exit on error
+
+# Run all cap_broadcast* tests
+for file in "$dir_path"/cap_broadcast*.sh; do
+    if [ -f "$file" ]; then
+        echo "Running $file"
+        $file
+    fi
+done

--- a/tests/bsim/bluetooth/audio/test_scripts/_cap_unicast.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/_cap_unicast.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2025 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+
+dir_path=$(dirname "$0")
+
+set -e # Exit on error
+
+# Run all cap_unicast* tests
+for file in "$dir_path"/cap_unicast*.sh; do
+    if [ -f "$file" ]; then
+        echo "Running $file"
+        $file
+    fi
+done

--- a/tests/bsim/bluetooth/audio/test_scripts/cap_broadcast_inval.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/cap_broadcast_inval.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2025 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+
+SIMULATION_ID="cap_broadcast_inval"
+VERBOSITY_LEVEL=2
+EXECUTE_TIMEOUT=120
+
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
+cd ${BSIM_OUT_PATH}/bin
+
+printf "\n\n======== Running CAP broadcast inval test =========\n\n"
+
+Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
+  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=cap_initiator_broadcast_inval \
+  -RealEncryption=1 -rs=46 -D=1
+
+# Simulation time should be larger than the WAIT_TIME in common.h
+Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} \
+  -D=1 -sim_length=60e6 $@
+
+wait_for_background_jobs

--- a/tests/bsim/bluetooth/audio/test_scripts/cap_broadcast_reception.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/cap_broadcast_reception.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright (c) 2024 Nordic Semiconductor ASA
+# Copyright (c) 2024-2025 Nordic Semiconductor ASA
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/bsim/bluetooth/audio/test_scripts/cap_broadcast_update.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/cap_broadcast_update.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2025 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+
+SIMULATION_ID="cap_broadcast_update"
+VERBOSITY_LEVEL=2
+EXECUTE_TIMEOUT=120
+
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
+cd ${BSIM_OUT_PATH}/bin
+
+printf "\n\n======== Running CAP broadcast update test =========\n\n"
+
+Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
+  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=cap_initiator_broadcast_update \
+  -RealEncryption=1 -rs=46 -D=2
+
+Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
+  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=1 -testid=cap_acceptor_broadcast_update \
+  -RealEncryption=1 -rs=23 -D=2
+
+# Simulation time should be larger than the WAIT_TIME in common.h
+Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} \
+  -D=2 -sim_length=60e6 $@
+
+wait_for_background_jobs


### PR DESCRIPTION
The cap_broadcast test has been split into 3 tests: 1) Regular test
2) Regular test with metadata update
3) Test for invalid parameters

This will make it easier to use the regular cap_broadcast test for other test cases, as it does less now.
It also makes each test run faster seperately and reduce their scopes.