### PR TITLE
tests: Bluetooth: Audio: Open backchannel to self

### DIFF
--- a/tests/bsim/bluetooth/audio/src/common.c
+++ b/tests/bsim/bluetooth/audio/src/common.c
@@ -328,10 +328,8 @@ static void setup_backchannels(void)
 	uint *channels;
 
 	for (int32_t i = 0; i < dev_cnt; i++) {
-		if (i != self) { /* skip ourselves*/
-			backchannel_nums[chan_cnt] = get_chan_num((uint16_t)i);
-			device_numbers[chan_cnt++] = i;
-		}
+		backchannel_nums[chan_cnt] = get_chan_num((uint16_t)i);
+		device_numbers[chan_cnt++] = i;
 	}
 
 	channels = bs_open_back_channel(self, device_numbers, backchannel_nums, chan_cnt);


### PR DESCRIPTION
In order to use the device IDs send sending to a specific device, e.g. backchannel_sync_send(3), then we need to open all backchannels including the one to ourself, otherwise the ID and count will be off by one.