### PR TITLE
tests: Bluetooth: BAP: Make RX checks less strict

### DIFF
--- a/tests/bsim/bluetooth/audio/src/bap_stream_rx.c
+++ b/tests/bsim/bluetooth/audio/src/bap_stream_rx.c
@@ -30,55 +30,51 @@ void bap_stream_rx_recv_cb(struct bt_bap_stream *stream, const struct bt_iso_rec
 {
 	struct audio_test_stream *test_stream = audio_test_stream_from_bap_stream(stream);
 
-	if ((test_stream->rx_cnt % 50U) == 0U) {
-		log_stream_rx(stream, info, buf);
-	}
-
 	test_stream->rx_cnt++;
-
-	if (test_stream->valid_rx_cnt > 0U && info->ts == test_stream->last_info.ts) {
-		log_stream_rx(stream, info, buf);
-		FAIL("Duplicated timestamp received: %u\n", test_stream->last_info.ts);
-		return;
-	}
-
-	if (test_stream->valid_rx_cnt > 0U && info->seq_num == test_stream->last_info.seq_num) {
-		log_stream_rx(stream, info, buf);
-		FAIL("Duplicated PSN received: %u\n", test_stream->last_info.seq_num);
-		return;
-	}
-
-	if (info->flags & BT_ISO_FLAGS_ERROR) {
-		/* Fail the test if we have not received what we expected */
-		if (!TEST_FLAG(flag_audio_received)) {
-			log_stream_rx(stream, info, buf);
-			if (test_stream->valid_rx_cnt > 0) {
-				FAIL("ISO receive error\n");
-			}
-		}
-
-		return;
-	}
-
-	if (info->flags & BT_ISO_FLAGS_LOST) {
-		log_stream_rx(stream, info, buf);
-		if (test_stream->valid_rx_cnt > 0) {
-			FAIL("ISO receive lost\n");
-		}
-		return;
-	}
-
-	if (info->flags & BT_ISO_FLAGS_VALID) {
+	if ((info->flags & BT_ISO_FLAGS_VALID) != 0) {
 		if (memcmp(buf->data, mock_iso_data, buf->len) == 0) {
 			test_stream->valid_rx_cnt++;
 
-			if (test_stream->rx_cnt >= MIN_SEND_COUNT) {
+			if (test_stream->valid_rx_cnt >= MIN_SEND_COUNT) {
 				/* We set the flag is just one stream has received the expected */
 				SET_FLAG(flag_audio_received);
 			}
 		} else {
 			log_stream_rx(stream, info, buf);
 			FAIL("Unexpected data received\n");
+		}
+	}
+
+	if ((test_stream->rx_cnt % 50U) == 0U) {
+		log_stream_rx(stream, info, buf);
+	}
+
+	if (info->ts == test_stream->last_info.ts) {
+		log_stream_rx(stream, info, buf);
+		if (test_stream->valid_rx_cnt > 1U) {
+			FAIL("Duplicated timestamp received: %u\n", test_stream->last_info.ts);
+		}
+	}
+
+	if (info->seq_num == test_stream->last_info.seq_num) {
+		log_stream_rx(stream, info, buf);
+		if (test_stream->valid_rx_cnt > 1U) {
+			FAIL("Duplicated PSN received: %u\n", test_stream->last_info.seq_num);
+		}
+	}
+
+	if (info->flags & BT_ISO_FLAGS_ERROR) {
+		/* Fail the test if we have not received what we expected */
+		log_stream_rx(stream, info, buf);
+		if (test_stream->valid_rx_cnt > 1U && !TEST_FLAG(flag_audio_received)) {
+			FAIL("ISO receive error\n");
+		}
+	}
+
+	if (info->flags & BT_ISO_FLAGS_LOST) {
+		log_stream_rx(stream, info, buf);
+		if (test_stream->valid_rx_cnt > 1U) {
+			FAIL("ISO receive lost\n");
 		}
 	}
 }


### PR DESCRIPTION
Modify stream_rx.c so that the calls to FAIL are guarded by the newly added valid_rx_cnt.

This helps prevent timing issues, especially with
broadcast, where the first SDU(s) may be delayed from the application, and thus may be missed/contain errors. Now it will only treat missing or error SDUs as a FAIL if we have received a valid SDU. All fails, will still be logged. We now also log both valid and total count.