### PR TITLE
Fix mDNS responder with multiple network interfaces

### DIFF
--- a/subsys/net/lib/dns/mdns_responder.c
+++ b/subsys/net/lib/dns/mdns_responder.c
@@ -787,6 +787,9 @@ static int init_listener(void)
 			if (ret < 0) {
 				NET_DBG("Cannot bind sock %d to interface %d (%d)",
 					v6, ifindex, ret);
+			} else {
+				NET_DBG("Bound %s sock %d to interface %d",
+					"IPv6", v6, ifindex);
 			}
 		}
 
@@ -880,6 +883,9 @@ static int init_listener(void)
 			if (ret < 0) {
 				NET_DBG("Cannot bind sock %d to interface %d (%d)",
 					v4, ifindex, ret);
+			} else {
+				NET_DBG("Bound %s sock %d to interface %d",
+					"IPv4", v4, ifindex);
 			}
 		}
 

--- a/subsys/net/lib/sockets/sockets_inet.c
+++ b/subsys/net/lib/sockets/sockets_inet.c
@@ -1052,13 +1052,13 @@ static int update_msg_controllen(struct msghdr *msg)
 	return 0;
 }
 
-static inline ssize_t zsock_recv_dgram(struct net_context *ctx,
-				       struct msghdr *msg,
-				       void *buf,
-				       size_t max_len,
-				       int flags,
-				       struct sockaddr *src_addr,
-				       socklen_t *addrlen)
+static ssize_t zsock_recv_dgram(struct net_context *ctx,
+				struct msghdr *msg,
+				void *buf,
+				size_t max_len,
+				int flags,
+				struct sockaddr *src_addr,
+				socklen_t *addrlen)
 {
 	k_timeout_t timeout = K_FOREVER;
 	size_t recv_len = 0;


### PR DESCRIPTION
Restore only the socket descriptor that we marked as -1 after running the work related to that socket. Earlier we tried to restore the whole global array of descriptors which could go wrong and is not needed as we only support synchronous work.
This will fix the use case where mDNS responder is configured to work with multiple network interfaces.

Fixes #84234
