### PR TITLE
manifest: FAT FS module version upgrade to 0.15a

### DIFF
--- a/modules/fatfs/zephyr_fatfs_config.h
+++ b/modules/fatfs/zephyr_fatfs_config.h
@@ -4,7 +4,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#if FFCONF_DEF != 80286
+#if FFCONF_DEF != 5380
 #error "Configuration version mismatch"
 #endif
 

--- a/west.yml
+++ b/west.yml
@@ -137,7 +137,7 @@ manifest:
       groups:
         - tools
     - name: fatfs
-      revision: 427159bf95ea49b7680facffaa29ad506b42709b
+      revision: 16245c7c41d2b79e74984f49b5202551786b8a9b
       path: modules/fs/fatfs
       groups:
         - fs


### PR DESCRIPTION
The commit updates manifest entry for FAT FS driver to include update to version 0.15a