### PR TITLE
flash_map: remove select MBEDTLS_SHA256 for integrity check

### DIFF
--- a/subsys/storage/flash_map/Kconfig
+++ b/subsys/storage/flash_map/Kconfig
@@ -58,7 +58,6 @@ config FLASH_AREA_CHECK_INTEGRITY_PSA
 config FLASH_AREA_CHECK_INTEGRITY_MBEDTLS
 	bool "Use Mbed TLS"
 	select MBEDTLS
-	select MBEDTLS_SHA256
 	help
 	  Use the Mbed TLS library to perform the integrity check.
 


### PR DESCRIPTION
Removes the selection of MBEDTLS_SHA256 when using mbedtls for flash integrity check. MBEDTLS_SHA256 cannot be selected when mbedtls config file is not config-tls-generic.h, which makes builds fail when custom config is provided that still enables the use of the mbedtls sha256 functions.