### PR TITLE
boards: qemu: Add support for qemu_max board

### DIFF
--- a/boards/qemu/max/Kconfig
+++ b/boards/qemu/max/Kconfig
@@ -1,0 +1,3 @@
+# Copyright 2024-2025 HNU-ESNL: Guoqi Xie, Chenglai Xiong, Xingyu Hu and etc.
+# Copyright 2024-2025 openEuler SIG-Zephyr
+# SPDX-License-Identifier: Apache-2.0

--- a/boards/qemu/max/Kconfig.defconfig
+++ b/boards/qemu/max/Kconfig.defconfig
@@ -1,0 +1,36 @@
+# Copyright 2024-2025 HNU-ESNL: Guoqi Xie, Chenglai Xiong, Xingyu Hu and etc.
+# Copyright 2024-2025 openEuler SIG-Zephyr
+# SPDX-License-Identifier: Apache-2.0
+
+if BOARD_QEMU_MAX
+
+config BUILD_OUTPUT_BIN
+	default y
+
+config MAX_THREAD_BYTES
+	default 3
+
+# QEMU PCI requires at least 256M of virtual space
+config KERNEL_VM_SIZE
+	default 0x80000000 if PCIE
+
+# QEMU PCI requires physical addresses with more than 32 bits
+choice ARM64_VA_BITS
+	default ARM64_VA_BITS_40 if PCIE
+endchoice
+
+choice ARM64_PA_BITS
+	default ARM64_PA_BITS_40 if PCIE
+endchoice
+
+if QEMU_ICOUNT
+
+config QEMU_ICOUNT_SHIFT
+	default 4
+
+config QEMU_ICOUNT_SLEEP
+	default y
+
+endif # QEMU_ICOUNT
+
+endif # BOARD_QEMU_MAX

--- a/boards/qemu/max/Kconfig.qemu_max
+++ b/boards/qemu/max/Kconfig.qemu_max
@@ -1,0 +1,6 @@
+# Copyright 2024-2025 HNU-ESNL: Guoqi Xie, Chenglai Xiong, Xingyu Hu and etc.
+# Copyright 2024-2025 openEuler SIG-Zephyr
+# SPDX-License-Identifier: Apache-2.0
+
+config BOARD_QEMU_MAX
+	select SOC_QEMU_MAX

--- a/boards/qemu/max/board.cmake
+++ b/boards/qemu/max/board.cmake
@@ -1,0 +1,22 @@
+# Copyright 2024-2025 HNU-ESNL: Guoqi Xie, Chenglai Xiong, Xingyu Hu and etc.
+# Copyright 2024-2025 openEuler SIG-Zephyr
+# SPDX-License-Identifier: Apache-2.0
+
+set(SUPPORTED_EMU_PLATFORMS qemu)
+set(QEMU_ARCH aarch64)
+
+set(QEMU_CPU_TYPE_${ARCH} max)
+
+if(CONFIG_ARMV8_A_NS)
+set(QEMU_MACH virt,gic-version=3)
+else()
+set(QEMU_MACH virt,secure=on,gic-version=3)
+endif()
+
+set(QEMU_FLAGS_${ARCH}
+  -cpu ${QEMU_CPU_TYPE_${ARCH}}
+  -nographic
+  -machine ${QEMU_MACH}
+  )
+
+board_set_debugger_ifnset(qemu)

--- a/boards/qemu/max/board.yml
+++ b/boards/qemu/max/board.yml
@@ -1,0 +1,8 @@
+board:
+  name: qemu_max
+  full_name: QEMU Emulation for ARM MAX
+  vendor: arm
+  socs:
+  - name: qemu_max
+    variants:
+    - name: smp

--- a/boards/qemu/max/doc/index.rst
+++ b/boards/qemu/max/doc/index.rst
@@ -1,0 +1,109 @@
+.. zephyr:board:: qemu_max
+
+Overview
+********
+
+This board configuration will use QEMU to emulate a generic MAX hardware
+platform.
+
+This configuration provides support for an ARM MAX CPU and these
+devices:
+
+* GIC-400 interrupt controller
+* ARM architected timer
+* PL011 UART controller
+
+Hardware
+********
+Supported Features
+==================
+
+The following hardware features are supported:
+
++--------------+------------+----------------------+
+| Interface    | Controller | Driver/Component     |
++==============+============+======================+
+| GIC          | on-chip    | interrupt controller |
++--------------+------------+----------------------+
+| PL011 UART   | on-chip    | serial port          |
++--------------+------------+----------------------+
+| ARM TIMER    | on-chip    | system clock         |
++--------------+------------+----------------------+
+
+The kernel currently does not support other hardware features on this platform.
+
+Devices
+========
+System Clock
+------------
+
+This board configuration uses a system clock frequency of 62.5 MHz.
+
+Serial Port
+-----------
+
+This board configuration uses a single serial communication channel with the
+CPU's UART0.
+
+Known Problems or Limitations
+==============================
+
+The following platform features are unsupported:
+
+* Writing to the hardware's flash memory
+
+
+Programming and Debugging
+*************************
+
+Use this configuration to run basic Zephyr applications and kernel tests in the QEMU
+emulated environment, for example, with the :zephyr:code-sample:`synchronization` sample:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/synchronization
+   :host-os: unix
+   :board: qemu_max
+   :goals: run
+
+This will build an image with the synchronization sample app, boot it using
+QEMU, and display the following console output:
+
+.. code-block:: console
+
+        ***** Booting Zephyr OS build zephyr-v2.0.0-1657-g99d310da48e5 *****
+        threadA: Hello World from cpu 0 on qemu_max!
+        threadB: Hello World from cpu 0 on qemu_max!
+        threadA: Hello World from cpu 0 on qemu_max!
+        threadB: Hello World from cpu 0 on qemu_max!
+        threadA: Hello World from cpu 0 on qemu_max!
+        threadB: Hello World from cpu 0 on qemu_max!
+        threadA: Hello World from cpu 0 on qemu_max!
+        threadB: Hello World from cpu 0 on qemu_max!
+
+Exit QEMU by pressing :kbd:`CTRL+A` :kbd:`x`.
+
+Debugging
+=========
+
+Refer to the detailed overview about :ref:`application_debugging`.
+
+Networking
+==========
+
+The board supports the QEMU built-in Ethernet adapter to connect to the host
+system. See :ref:`networking_with_eth_qemu` for details.
+
+It is also possible to use SLIP networking over an emulated serial port.
+Although this board only supports a single UART, so subsystems like logging
+and shell would need to be disabled, therefore this is not directly supported.
+
+References
+**********
+
+.. target-notes::
+
+1. (ID050815) ARM® Cortex®-A Series - Programmer’s Guide for ARMv8-A
+2. (ID070919) Arm® Architecture Reference Manual - Armv8, for Armv8-A architecture profile
+3. (ARM DAI 0527A) Application Note Bare-metal Boot Code for ARMv8-A Processors
+4. AArch64 Exception and Interrupt Handling
+5. Fundamentals of ARMv8-A

--- a/boards/qemu/max/qemu_max.dts
+++ b/boards/qemu/max/qemu_max.dts
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2024-2025 HNU-ESNL: Guoqi Xie, Chenglai Xiong, Xingyu Hu and etc.
+ * Copyright 2024-2025 openEuler SIG-Zephyr
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/dts-v1/;
+#include <arm64/qemu/qemu-virt-max.dtsi>
+
+/ {
+	model = "QEMU MAX";
+	compatible = "qemu,arm-max";
+
+	psci {
+		compatible = "arm,psci-0.2";
+		method = "hvc";
+	};
+
+	chosen {
+		zephyr,sram = &sram0;
+		zephyr,console = &uart0;
+		zephyr,shell-uart = &uart0;
+		zephyr,flash = &flash0;
+	};
+
+	soc {
+		sram0: memory@40000000 {
+			compatible = "mmio-sram";
+			reg = <0x0 0x40000000 0x0 DT_SIZE_M(128)>;
+		};
+	};
+
+};
+
+&uart0 {
+	status = "okay";
+	current-speed = <115200>;
+};

--- a/boards/qemu/max/qemu_max.yaml
+++ b/boards/qemu/max/qemu_max.yaml
@@ -1,0 +1,16 @@
+identifier: qemu_max
+name: QEMU Emulation for ARM MAX
+type: qemu
+simulation:
+  - name: qemu
+arch: arm64
+toolchain:
+  - zephyr
+  - cross-compile
+ram: 128
+testing:
+  default: true
+  ignore_tags:
+    - net
+    - bluetooth
+vendor: qemu

--- a/boards/qemu/max/qemu_max_defconfig
+++ b/boards/qemu/max/qemu_max_defconfig
@@ -1,0 +1,21 @@
+CONFIG_ARM_ARCH_TIMER=y
+
+# Cache management
+CONFIG_CACHE_MANAGEMENT=y
+
+# Enable UART driver
+CONFIG_SERIAL=y
+
+# Enable console
+CONFIG_CONSOLE=y
+CONFIG_UART_CONSOLE=y
+
+# Enable serial port
+CONFIG_UART_INTERRUPT_DRIVEN=y
+
+# Avoid timing skew in tests
+CONFIG_QEMU_ICOUNT=y
+
+
+# MMU Options
+CONFIG_MAX_XLAT_TABLES=32

--- a/boards/qemu/max/qemu_max_qemu_max_smp.dts
+++ b/boards/qemu/max/qemu_max_qemu_max_smp.dts
@@ -1,0 +1,8 @@
+/*
+ * Copyright 2024-2025 HNU-ESNL: Guoqi Xie, Chenglai Xiong, Xingyu Hu and etc.
+ * Copyright 2024-2025 openEuler SIG-Zephyr
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "qemu_max.dts"

--- a/boards/qemu/max/qemu_max_qemu_max_smp.yaml
+++ b/boards/qemu/max/qemu_max_qemu_max_smp.yaml
@@ -1,0 +1,18 @@
+identifier: qemu_max/qemu_max/smp
+name: QEMU Emulation for MAX SMP (ARM)
+type: qemu
+simulation:
+  - name: qemu
+arch: arm64
+toolchain:
+  - zephyr
+  - cross-compile
+ram: 128
+supported:
+  - smp
+testing:
+  default: true
+  ignore_tags:
+    - net
+    - bluetooth
+vendor: qemu

--- a/boards/qemu/max/qemu_max_qemu_max_smp_defconfig
+++ b/boards/qemu/max/qemu_max_qemu_max_smp_defconfig
@@ -1,0 +1,32 @@
+CONFIG_ARM_ARCH_TIMER=y
+
+# Cache management
+CONFIG_CACHE_MANAGEMENT=y
+
+# Enable UART driver
+CONFIG_SERIAL=y
+
+# Enable console
+CONFIG_CONSOLE=y
+CONFIG_UART_CONSOLE=y
+
+# Enable serial port
+CONFIG_UART_INTERRUPT_DRIVEN=y
+
+# icount does not work well with SMP
+CONFIG_QEMU_ICOUNT=n
+
+# We have multiple QEMU-A53 boards, so let us exercise ARMV8_A_NS on this one
+# (plus it is needed for SMP)
+CONFIG_ARMV8_A_NS=y
+
+# PSCI is supported with NS
+CONFIG_PM_CPU_OPS=y
+
+# SMP-related
+CONFIG_SMP=y
+CONFIG_MP_MAX_NUM_CPUS=2
+CONFIG_TIMEOUT_64BIT=y
+
+# MMU Options
+CONFIG_MAX_XLAT_TABLES=32

--- a/dts/arm64/qemu/qemu-virt-max.dtsi
+++ b/dts/arm64/qemu/qemu-virt-max.dtsi
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2024-2025 HNU-ESNL: Guoqi Xie, Chenglai Xiong, Xingyu Hu and etc.
+ * Copyright 2024-2025 openEuler SIG-Zephyr
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <mem.h>
+#include <arm64/armv8-a.dtsi>
+#include <zephyr/dt-bindings/interrupt-controller/arm-gic.h>
+
+/ {
+	#address-cells = <2>;
+	#size-cells = <2>;
+
+	cpus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		cpu@0 {
+			device_type = "cpu";
+			compatible = "arm,cortex-a55";
+			reg = <0>;
+		};
+
+		cpu@1 {
+			device_type = "cpu";
+			compatible = "arm,cortex-a55";
+			reg = <1>;
+		};
+
+	};
+
+	timer {
+		compatible = "arm,armv8-timer";
+		interrupt-parent = <&gic>;
+		interrupts = <GIC_PPI 13 IRQ_TYPE_LEVEL
+			      IRQ_DEFAULT_PRIORITY>,
+			     <GIC_PPI 14 IRQ_TYPE_LEVEL
+			      IRQ_DEFAULT_PRIORITY>,
+			     <GIC_PPI 11 IRQ_TYPE_LEVEL
+			      IRQ_DEFAULT_PRIORITY>,
+			     <GIC_PPI 10 IRQ_TYPE_LEVEL
+			      IRQ_DEFAULT_PRIORITY>;
+	};
+
+	uartclk: apb-pclk {
+		compatible = "fixed-clock";
+		clock-frequency = <24000000>;
+		#clock-cells = <0>;
+	};
+
+	soc {
+		#address-cells = <2>;
+		#size-cells = <2>;
+		ranges;
+
+		interrupt-parent = <&gic>;
+
+		gic: interrupt-controller@8000000 {
+			compatible = "arm,gic-v3", "arm,gic";
+			reg = <0x00 0x8000000 0x00 0x010000>,
+			      <0x00 0x80a0000 0x00 0xf60000>;
+			interrupt-controller;
+			#interrupt-cells = <4>;
+			status = "okay";
+			#size-cells = <0x02>;
+			#address-cells = <0x02>;
+
+			its: its@8080000 {
+				compatible = "arm,gic-v3-its";
+				reg = <0x00 0x8080000 0x00 0x20000>;
+				msi-controller;
+			};
+		};
+
+		uart0: uart@9000000 {
+			compatible = "arm,pl011";
+			reg = <0x00 0x9000000 0x00 0x1000>;
+			status = "disabled";
+			interrupts = <GIC_SPI 1 IRQ_TYPE_LEVEL 0>;
+			interrupt-names = "irq_0";
+			clocks = <&uartclk>;
+		};
+
+		flash0: flash@0 {
+			compatible = "cfi-flash";
+			bank-width = <4>;
+			/* As this is pointed to by zephyr,flash we can only handle
+			 * one value in the reg property, so we comment out the
+			 * second flash bank for now
+			 */
+			reg = <0x0 0x0 0x0 DT_SIZE_M(64)>;
+		};
+	};
+};

--- a/soc/arm/qemu_max/CMakeLists.txt
+++ b/soc/arm/qemu_max/CMakeLists.txt
@@ -1,0 +1,9 @@
+# Copyright 2024-2025 HNU-ESNL: Guoqi Xie, Chenglai Xiong, Xingyu Hu and etc.
+# Copyright 2024-2025 openEuler SIG-Zephyr
+# SPDX-License-Identifier: Apache-2.0
+
+zephyr_library_sources_ifdef(CONFIG_ARM_MMU mmu_regions.c)
+
+zephyr_include_directories(.)
+
+set(SOC_LINKER_SCRIPT ${ZEPHYR_BASE}/include/zephyr/arch/arm64/scripts/linker.ld CACHE INTERNAL "")

--- a/soc/arm/qemu_max/Kconfig
+++ b/soc/arm/qemu_max/Kconfig
@@ -1,0 +1,8 @@
+# Copyright 2024-2025 HNU-ESNL: Guoqi Xie, Chenglai Xiong, Xingyu Hu and etc.
+# Copyright 2024-2025 openEuler SIG-Zephyr
+# SPDX-License-Identifier: Apache-2.0
+
+config SOC_QEMU_MAX
+	select ARM64
+	select CPU_CORTEX_A55
+	select QEMU_TARGET

--- a/soc/arm/qemu_max/Kconfig.defconfig
+++ b/soc/arm/qemu_max/Kconfig.defconfig
@@ -1,0 +1,25 @@
+# Copyright 2024-2025 HNU-ESNL: Guoqi Xie, Chenglai Xiong, Xingyu Hu and etc.
+# Copyright 2024-2025 openEuler SIG-Zephyr
+# SPDX-License-Identifier: Apache-2.0
+
+if SOC_QEMU_MAX
+
+config NUM_IRQS
+	# must be >= the highest interrupt number used
+	# - include the UART interrupts
+	default 16384 if GIC_V3_ITS
+	default 220 if !GIC_V3_ITS
+
+config SYS_CLOCK_HW_CYCLES_PER_SEC
+	default 62500000
+
+# Workaround for not being able to have commas in macro arguments
+DT_CHOSEN_Z_FLASH := zephyr,flash
+
+config FLASH_SIZE
+	default $(dt_chosen_reg_size_int,$(DT_CHOSEN_Z_FLASH),0,K)
+
+config FLASH_BASE_ADDRESS
+	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_FLASH))
+
+endif # SOC_QEMU_MAX

--- a/soc/arm/qemu_max/Kconfig.soc
+++ b/soc/arm/qemu_max/Kconfig.soc
@@ -1,0 +1,10 @@
+# Copyright 2024-2025 HNU-ESNL: Guoqi Xie, Chenglai Xiong, Xingyu Hu and etc.
+# Copyright 2024-2025 openEuler SIG-Zephyr
+# SPDX-License-Identifier: Apache-2.0
+
+config SOC_QEMU_MAX
+	bool
+	select SOC_FAMILY_ARM64
+
+config SOC
+	default "qemu_max" if SOC_QEMU_MAX

--- a/soc/arm/qemu_max/mmu_regions.c
+++ b/soc/arm/qemu_max/mmu_regions.c
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2024-2025 HNU-ESNL: Guoqi Xie, Chenglai Xiong, Xingyu Hu and etc.
+ * Copyright 2024-2025 openEuler SIG-Zephyr
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/arch/arm64/arm_mmu.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/sys/util.h>
+
+static const struct arm_mmu_region mmu_regions[] = {
+
+	MMU_REGION_FLAT_ENTRY("GIC",
+			      DT_REG_ADDR_BY_IDX(DT_INST(0, arm_gic), 0),
+			      DT_REG_SIZE_BY_IDX(DT_INST(0, arm_gic), 0),
+			      MT_DEVICE_nGnRnE | MT_P_RW_U_NA | MT_DEFAULT_SECURE_STATE),
+
+	MMU_REGION_FLAT_ENTRY("GIC",
+			      DT_REG_ADDR_BY_IDX(DT_INST(0, arm_gic), 1),
+			      DT_REG_SIZE_BY_IDX(DT_INST(0, arm_gic), 1),
+			      MT_DEVICE_nGnRnE | MT_P_RW_U_NA | MT_DEFAULT_SECURE_STATE),
+
+};
+
+const struct arm_mmu_config mmu_config = {
+	.num_regions = ARRAY_SIZE(mmu_regions),
+	.mmu_regions = mmu_regions,
+};

--- a/soc/arm/soc.yml
+++ b/soc/arm/soc.yml
@@ -34,4 +34,5 @@ family:
     - name: fvp_aemv8r_aarch32
   socs:
   - name: qemu_cortex_a53
+  - name: qemu_max
   - name: qemu_virt_arm64

--- a/tests/drivers/charger/sbs_charger/boards/emulated_board.overlay
+++ b/tests/drivers/charger/sbs_charger/boards/emulated_board.overlay
@@ -13,7 +13,7 @@
 		clock-frequency = <I2C_BITRATE_STANDARD>;
 		#address-cells = <1>;
 		#size-cells = <0>;
-		reg = <0x100 4>;
+		reg = <0x0 0x100 0 4>;
 	};
 };
 

--- a/tests/drivers/charger/sbs_charger/testcase.yaml
+++ b/tests/drivers/charger/sbs_charger/testcase.yaml
@@ -15,6 +15,8 @@ tests:
     platform_exclude:
       - qemu_cortex_a53
       - qemu_cortex_a53/qemu_cortex_a53/smp
+      - qemu_max
+      - qemu_max/qemu_max/smp
       - qemu_kvm_arm64
       - xenvm
       - xenvm/xenvm/gicv3
@@ -28,6 +30,8 @@ tests:
     platform_allow:
       - qemu_cortex_a53
       - qemu_cortex_a53/qemu_cortex_a53/smp
+      - qemu_max
+      - qemu_max/qemu_max/smp
       - qemu_kvm_arm64
       - xenvm
       - xenvm/xenvm/gicv3

--- a/tests/drivers/fuel_gauge/sbs_gauge/testcase.yaml
+++ b/tests/drivers/fuel_gauge/sbs_gauge/testcase.yaml
@@ -15,6 +15,8 @@ tests:
       - hifive_unmatched/fu740/u74
       - qemu_cortex_a53
       - qemu_cortex_a53/qemu_cortex_a53/smp
+      - qemu_max
+      - qemu_max/qemu_max/smp
       - qemu_kvm_arm64
       - xenvm
       - xenvm/xenvm/gicv3
@@ -34,6 +36,8 @@ tests:
       - hifive_unmatched/fu740/s7
       - qemu_cortex_a53
       - qemu_cortex_a53/qemu_cortex_a53/smp
+      - qemu_max
+      - qemu_max/qemu_max/smp
       - qemu_kvm_arm64
       - xenvm
       - xenvm/xenvm/gicv3

--- a/tests/ztest/error_hook/src/main.c
+++ b/tests/ztest/error_hook/src/main.c
@@ -120,7 +120,8 @@ __no_optimization static void trigger_fault_divide_zero(void)
  */
 #if (defined(CONFIG_SOC_SERIES_MPS2) && defined(CONFIG_QEMU_TARGET)) || \
 	(defined(CONFIG_SOC_SERIES_MPS3) && defined(CONFIG_QEMU_TARGET)) || \
-	defined(CONFIG_BOARD_QEMU_CORTEX_A53) || defined(CONFIG_SOC_QEMU_ARC) || \
+	defined(CONFIG_BOARD_QEMU_CORTEX_A53) || \
+	defined(CONFIG_BOARD_QEMU_MAX) || defined(CONFIG_SOC_QEMU_ARC) || \
 	defined(CONFIG_SOC_CORTEX_R8_VIRTUAL) || \
 	defined(CONFIG_ARMV6_M_ARMV8_M_BASELINE) || \
 	defined(CONFIG_BOARD_QEMU_CORTEX_R5) || \


### PR DESCRIPTION
This PR is the part 1 of a complete submission to ZVM. A draft of the complete PR can be found at:
#84123   ZVM : New-Generation Type 1.5 RTOS Virtualization Solution (Hypervisor)

----------------------------------

What is changed?

    - Added a new qemu_max board for QEMU emulation. This includes the addition of board-specific files such as Kconfig, defconfig, board.yaml and DTS files under `boards/qemu/max`.

    - Added support for multi-core SMP with QEMU through the `qemu_max_qemu_max_smp` configuration and associated DTS and YAML files.

    - Updated SoC-specific configurations under `soc/arm/qemu_max`, including Kconfig, SoC-specific settings, and memory regions in `mmu_regions.c`.

    - Added device tree include file `qemu-virt-max.dtsi` for enhanced compatibility with the qemu_max board.

    Why do we need this change?
    - The qemu_max board supports the hardware features of ARMv8.1+, while the existing qemu_cortex_a53 does not.