### PR TITLE
dts: bindings: clock: make clocks property required

### DIFF
--- a/dts/bindings/clock/st,stm32-clock-mux.yaml
+++ b/dts/bindings/clock/st,stm32-clock-mux.yaml
@@ -4,7 +4,7 @@
 description: |
         STM32 Clock multiplexer
         Describes a clock multiplexer, such as per_ck on STM32H7 or
-        CLK48 on STM32L5.
+        CLK48 on STM32WB.
         The only property of this node is to select a clock input.
         For instance:
                 &perck {
@@ -20,3 +20,8 @@ include:
       - status
       - compatible
       - clocks
+
+properties:
+
+  clocks:
+    required: true


### PR DESCRIPTION
Modify properties clocks as required in stm32-clock-mux.yaml.