### PR TITLE
scripts: twister: fix flash to esp32 using esp32 runner

### DIFF
--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/device/hardware_adapter.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/device/hardware_adapter.py
@@ -73,6 +73,9 @@ class HardwareAdapter(DeviceAdapter):
             if runner == 'pyocd':
                 extra_args.append('--board-id')
                 extra_args.append(board_id)
+            elif runner == "esp32":
+                extra_args.append("--esp-device")
+                extra_args.append(board_id)
             elif runner in ('nrfjprog', 'nrfutil'):
                 extra_args.append('--dev-id')
                 extra_args.append(board_id)

--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -565,14 +565,13 @@ class DeviceHandler(Handler):
 
                 board_id = hardware.probe_id or hardware.id
                 product = hardware.product
-                serial_port = hardware.serial
                 if board_id is not None:
                     if runner in ("pyocd", "nrfjprog", "nrfutil"):
                         command_extra_args.append("--dev-id")
                         command_extra_args.append(board_id)
                     elif runner == "esp32":
                         command_extra_args.append("--esp-device")
-                        command_extra_args.append(serial_port)
+                        command_extra_args.append(board_id)
                     elif (
                         runner == "openocd"
                         and product == "STM32 STLink"


### PR DESCRIPTION
This PR allows the ESP32 runner to flash to a different port than the one used for reading test results. 
The port for flashing the ESP32 can now be specified using the board ID.