### PR TITLE
video: Merge driver stream start/stop APIs

### DIFF
--- a/doc/releases/migration-guide-4.1.rst
+++ b/doc/releases/migration-guide-4.1.rst
@@ -465,6 +465,10 @@ Video
   ``pitch = width * video_pix_fmt_bpp(pixfmt)`` needs to be replaced by an equivalent
   ``pitch = width * video_bits_per_pixel(pixfmt) / BITS_PER_BYTE``.
 
+* The :c:func:`video_stream_start` and :c:func:`video_stream_stop` driver APIs are now merged
+  into the new :c:func:`video_set_stream` driver API. The user APIs are however unchanged to
+  keep backward compatibility with downstream applications.
+
 Watchdog
 ========
 

--- a/doc/releases/migration-guide-4.1.rst
+++ b/doc/releases/migration-guide-4.1.rst
@@ -129,9 +129,6 @@ Device Drivers and Devicetree
   The :c:macro:`DEVICE_API()` macro should be used by out-of-tree driver implementations for
   all the upstream driver classes.
 
-* The :c:func:`video_buffer_alloc` and :c:func:`video_buffer_aligned_alloc` functions in the
-  video API now take an additional timeout parameter.
-
 ADC
 ===
 
@@ -464,6 +461,9 @@ Video
   ``video_bits_per_pixel()`` which return a bit count. For instance, invocations such as
   ``pitch = width * video_pix_fmt_bpp(pixfmt)`` needs to be replaced by an equivalent
   ``pitch = width * video_bits_per_pixel(pixfmt) / BITS_PER_BYTE``.
+
+* The :c:func:`video_buffer_alloc` and :c:func:`video_buffer_aligned_alloc` functions in the
+  video API now take an additional timeout parameter.
 
 * The :c:func:`video_stream_start` and :c:func:`video_stream_stop` driver APIs are now merged
   into the new :c:func:`video_set_stream` driver API. The user APIs are however unchanged to

--- a/doc/releases/release-notes-4.1.rst
+++ b/doc/releases/release-notes-4.1.rst
@@ -77,6 +77,9 @@ Removed APIs and options
   and only supported 8-bit depth to :c:func:`video_bits_per_pixel()` returning
   the *bit* count and supporting any color depth.
 
+* The ``video_stream_start()`` and ``video_stream_stop()`` driver APIs have been
+  replaced by ``video_set_stream()``.
+
 * :kconfig:option:`CONFIG_WIFI_NM_WPA_SUPPLICANT_CRYPTO`
 
 * The :kconfig:option:`CONFIG_PM_DEVICE_RUNTIME_EXCLUSIVE` option has been removed
@@ -153,6 +156,11 @@ New APIs and options
 
     * Image management :c:macro:`MGMT_EVT_OP_IMG_MGMT_DFU_CONFIRMED` now has image data field
       :c:struct:`img_mgmt_image_confirmed`.
+
+* Video
+
+  * :c:func:`video_set_stream()` driver API has replaced :c:func:`video_stream_start()` and
+    :c:func:`video_stream_stop()` driver APIs.
 
 * Other
 

--- a/drivers/video/gc2145.c
+++ b/drivers/video/gc2145.c
@@ -1076,18 +1076,12 @@ static int gc2145_get_fmt(const struct device *dev, enum video_endpoint_id ep,
 	return 0;
 }
 
-static int gc2145_stream_start(const struct device *dev)
+static int gc2145_set_stream(const struct device *dev, bool enable)
 {
 	const struct gc2145_config *cfg = dev->config;
 
-	return gc2145_write_reg(&cfg->i2c, 0xf2, 0x0f);
-}
-
-static int gc2145_stream_stop(const struct device *dev)
-{
-	const struct gc2145_config *cfg = dev->config;
-
-	return gc2145_write_reg(&cfg->i2c, 0xf2, 0x00);
+	return enable ? gc2145_write_reg(&cfg->i2c, 0xf2, 0x0f)
+		      : gc2145_write_reg(&cfg->i2c, 0xf2, 0x00);
 }
 
 static int gc2145_get_caps(const struct device *dev, enum video_endpoint_id ep,
@@ -1113,8 +1107,7 @@ static DEVICE_API(video, gc2145_driver_api) = {
 	.set_format = gc2145_set_fmt,
 	.get_format = gc2145_get_fmt,
 	.get_caps = gc2145_get_caps,
-	.stream_start = gc2145_stream_start,
-	.stream_stop = gc2145_stream_stop,
+	.set_stream = gc2145_set_stream,
 	.set_ctrl = gc2145_set_ctrl,
 };
 

--- a/drivers/video/mt9m114.c
+++ b/drivers/video/mt9m114.c
@@ -451,14 +451,10 @@ static int mt9m114_get_fmt(const struct device *dev, enum video_endpoint_id ep,
 	return 0;
 }
 
-static int mt9m114_stream_start(const struct device *dev)
+static int mt9m114_set_stream(const struct device *dev, bool enable)
 {
-	return mt9m114_set_state(dev, MT9M114_SYS_STATE_START_STREAMING);
-}
-
-static int mt9m114_stream_stop(const struct device *dev)
-{
-	return mt9m114_set_state(dev, MT9M114_SYS_STATE_ENTER_SUSPEND);
+	return enable ? mt9m114_set_state(dev, MT9M114_SYS_STATE_START_STREAMING)
+		      : mt9m114_set_state(dev, MT9M114_SYS_STATE_ENTER_SUSPEND);
 }
 
 static int mt9m114_get_caps(const struct device *dev, enum video_endpoint_id ep,
@@ -499,8 +495,7 @@ static DEVICE_API(video, mt9m114_driver_api) = {
 	.set_format = mt9m114_set_fmt,
 	.get_format = mt9m114_get_fmt,
 	.get_caps = mt9m114_get_caps,
-	.stream_start = mt9m114_stream_start,
-	.stream_stop = mt9m114_stream_stop,
+	.set_stream = mt9m114_set_stream,
 	.set_ctrl = mt9m114_set_ctrl,
 };
 

--- a/drivers/video/ov2640.c
+++ b/drivers/video/ov2640.c
@@ -910,12 +910,7 @@ static int ov2640_get_fmt(const struct device *dev,
 	return 0;
 }
 
-static int ov2640_stream_start(const struct device *dev)
-{
-	return 0;
-}
-
-static int ov2640_stream_stop(const struct device *dev)
+static int ov2640_set_stream(const struct device *dev, bool enable)
 {
 	return 0;
 }
@@ -975,8 +970,7 @@ static DEVICE_API(video, ov2640_driver_api) = {
 	.set_format = ov2640_set_fmt,
 	.get_format = ov2640_get_fmt,
 	.get_caps = ov2640_get_caps,
-	.stream_start = ov2640_stream_start,
-	.stream_stop = ov2640_stream_stop,
+	.set_stream = ov2640_set_stream,
 	.set_ctrl = ov2640_set_ctrl,
 };
 

--- a/drivers/video/ov7670.c
+++ b/drivers/video/ov7670.c
@@ -550,12 +550,7 @@ static int ov7670_init(const struct device *dev)
 	return 0;
 }
 
-static int ov7670_stream_start(const struct device *dev)
-{
-	return 0;
-}
-
-static int ov7670_stream_stop(const struct device *dev)
+static int ov7670_set_stream(const struct device *dev, bool enable)
 {
 	return 0;
 }
@@ -580,8 +575,7 @@ static DEVICE_API(video, ov7670_api) = {
 	.set_format = ov7670_set_fmt,
 	.get_format = ov7670_get_fmt,
 	.get_caps = ov7670_get_caps,
-	.stream_start = ov7670_stream_start,
-	.stream_stop = ov7670_stream_stop,
+	.set_stream = ov7670_set_stream,
 	.set_ctrl = ov7670_set_ctrl,
 };
 

--- a/drivers/video/ov7725.c
+++ b/drivers/video/ov7725.c
@@ -517,12 +517,7 @@ static int ov7725_get_fmt(const struct device *dev,
 	return 0;
 }
 
-static int ov7725_stream_start(const struct device *dev)
-{
-	return 0;
-}
-
-static int ov7725_stream_stop(const struct device *dev)
+static int ov7725_set_stream(const struct device *dev, bool enable)
 {
 	return 0;
 }
@@ -552,8 +547,7 @@ static DEVICE_API(video, ov7725_driver_api) = {
 	.set_format = ov7725_set_fmt,
 	.get_format = ov7725_get_fmt,
 	.get_caps = ov7725_get_caps,
-	.stream_start = ov7725_stream_start,
-	.stream_stop = ov7725_stream_stop,
+	.set_stream = ov7725_set_stream,
 };
 
 static int ov7725_init(const struct device *dev)

--- a/drivers/video/video_emul_imager.c
+++ b/drivers/video/video_emul_imager.c
@@ -423,14 +423,9 @@ static int emul_imager_get_caps(const struct device *dev, enum video_endpoint_id
 	return 0;
 }
 
-static int emul_imager_stream_start(const struct device *dev)
+static int emul_imager_set_stream(const struct device *dev, bool enable)
 {
-	return emul_imager_write_reg(dev, EMUL_IMAGER_REG_CTRL, 1);
-}
-
-static int emul_imager_stream_stop(const struct device *dev)
-{
-	return emul_imager_write_reg(dev, EMUL_IMAGER_REG_CTRL, 0);
+	return emul_imager_write_reg(dev, EMUL_IMAGER_REG_CTRL, enable ? 1 : 0);
 }
 
 static DEVICE_API(video, emul_imager_driver_api) = {
@@ -442,8 +437,7 @@ static DEVICE_API(video, emul_imager_driver_api) = {
 	.set_format = emul_imager_set_fmt,
 	.get_format = emul_imager_get_fmt,
 	.get_caps = emul_imager_get_caps,
-	.stream_start = emul_imager_stream_start,
-	.stream_stop = emul_imager_stream_stop,
+	.set_stream = emul_imager_set_stream,
 };
 
 int emul_imager_init(const struct device *dev)

--- a/drivers/video/video_emul_rx.c
+++ b/drivers/video/video_emul_rx.c
@@ -232,9 +232,6 @@ static int emul_rx_flush(const struct device *dev, enum video_endpoint_id ep, bo
 	if (cancel) {
 		struct video_buffer *vbuf;
 
-		/* First, stop the hardware processing */
-		emul_rx_stream_stop(dev);
-
 		/* Cancel the jobs that were not running */
 		k_work_cancel(&data->work);
 

--- a/drivers/video/video_emul_rx.c
+++ b/drivers/video/video_emul_rx.c
@@ -131,20 +131,12 @@ static int emul_rx_get_caps(const struct device *dev, enum video_endpoint_id ep,
 	return video_get_caps(cfg->source_dev, VIDEO_EP_OUT, caps);
 }
 
-static int emul_rx_stream_start(const struct device *dev)
+static int emul_rx_set_stream(const struct device *dev, bool enable)
 {
 	const struct emul_rx_config *cfg = dev->config;
 
-	/* A real hardware driver would first start its own peripheral */
-	return video_stream_start(cfg->source_dev);
-}
-
-static int emul_rx_stream_stop(const struct device *dev)
-{
-	const struct emul_rx_config *cfg = dev->config;
-
-	return video_stream_stop(cfg->source_dev);
-	/* A real hardware driver would then stop its own peripheral */
+	/* A real hardware driver would first start / stop its own peripheral */
+	return enable ? video_stream_start(cfg->source_dev) : video_stream_stop(cfg->source_dev);
 }
 
 static void emul_rx_worker(struct k_work *work)
@@ -259,8 +251,7 @@ static DEVICE_API(video, emul_rx_driver_api) = {
 	.set_format = emul_rx_set_fmt,
 	.get_format = emul_rx_get_fmt,
 	.get_caps = emul_rx_get_caps,
-	.stream_start = emul_rx_stream_start,
-	.stream_stop = emul_rx_stream_stop,
+	.set_stream = emul_rx_set_stream,
 	.enqueue = emul_rx_enqueue,
 	.dequeue = emul_rx_dequeue,
 	.flush = emul_rx_flush,

--- a/drivers/video/video_mcux_csi.c
+++ b/drivers/video/video_mcux_csi.c
@@ -194,37 +194,30 @@ static int video_mcux_csi_get_fmt(const struct device *dev, enum video_endpoint_
 	return -EIO;
 }
 
-static int video_mcux_csi_stream_start(const struct device *dev)
+static int video_mcux_csi_set_stream(const struct device *dev, bool enable)
 {
 	const struct video_mcux_csi_config *config = dev->config;
 	struct video_mcux_csi_data *data = dev->data;
 	status_t ret;
 
-	ret = CSI_TransferStart(config->base, &data->csi_handle);
-	if (ret != kStatus_Success) {
-		return -EIO;
-	}
+	if (enable) {
+		ret = CSI_TransferStart(config->base, &data->csi_handle);
+		if (ret != kStatus_Success) {
+			return -EIO;
+		}
 
-	if (config->source_dev && video_stream_start(config->source_dev)) {
-		return -EIO;
-	}
+		if (config->source_dev && video_stream_start(config->source_dev)) {
+			return -EIO;
+		}
+	} else {
+		if (config->source_dev && video_stream_stop(config->source_dev)) {
+			return -EIO;
+		}
 
-	return 0;
-}
-
-static int video_mcux_csi_stream_stop(const struct device *dev)
-{
-	const struct video_mcux_csi_config *config = dev->config;
-	struct video_mcux_csi_data *data = dev->data;
-	status_t ret;
-
-	if (config->source_dev && video_stream_stop(config->source_dev)) {
-		return -EIO;
-	}
-
-	ret = CSI_TransferStop(config->base, &data->csi_handle);
-	if (ret != kStatus_Success) {
-		return -EIO;
+		ret = CSI_TransferStop(config->base, &data->csi_handle);
+		if (ret != kStatus_Success) {
+			return -EIO;
+		}
 	}
 
 	return 0;
@@ -471,8 +464,7 @@ static int video_mcux_csi_enum_frmival(const struct device *dev, enum video_endp
 static DEVICE_API(video, video_mcux_csi_driver_api) = {
 	.set_format = video_mcux_csi_set_fmt,
 	.get_format = video_mcux_csi_get_fmt,
-	.stream_start = video_mcux_csi_stream_start,
-	.stream_stop = video_mcux_csi_stream_stop,
+	.set_stream = video_mcux_csi_set_stream,
 	.flush = video_mcux_csi_flush,
 	.enqueue = video_mcux_csi_enqueue,
 	.dequeue = video_mcux_csi_dequeue,

--- a/drivers/video/video_mcux_mipi_csi2rx.c
+++ b/drivers/video/video_mcux_mipi_csi2rx.c
@@ -146,29 +146,23 @@ static int mipi_csi2rx_get_fmt(const struct device *dev, enum video_endpoint_id 
 	return 0;
 }
 
-static int mipi_csi2rx_stream_start(const struct device *dev)
-{
-	const struct mipi_csi2rx_config *config = dev->config;
-	struct mipi_csi2rx_data *drv_data = dev->data;
-
-	CSI2RX_Init((MIPI_CSI2RX_Type *)config->base, &drv_data->csi2rxConfig);
-
-	if (video_stream_start(config->sensor_dev)) {
-		return -EIO;
-	}
-
-	return 0;
-}
-
-static int mipi_csi2rx_stream_stop(const struct device *dev)
+static int mipi_csi2rx_set_stream(const struct device *dev, bool enable)
 {
 	const struct mipi_csi2rx_config *config = dev->config;
 
-	if (video_stream_stop(config->sensor_dev)) {
-		return -EIO;
-	}
+	if (enable) {
+		struct mipi_csi2rx_data *drv_data = dev->data;
 
-	CSI2RX_Deinit((MIPI_CSI2RX_Type *)config->base);
+		CSI2RX_Init((MIPI_CSI2RX_Type *)config->base, &drv_data->csi2rxConfig);
+		if (video_stream_start(config->sensor_dev)) {
+			return -EIO;
+		}
+	} else {
+		if (video_stream_stop(config->sensor_dev)) {
+			return -EIO;
+		}
+		CSI2RX_Deinit((MIPI_CSI2RX_Type *)config->base);
+	}
 
 	return 0;
 }
@@ -310,8 +304,7 @@ static DEVICE_API(video, mipi_csi2rx_driver_api) = {
 	.get_caps = mipi_csi2rx_get_caps,
 	.get_format = mipi_csi2rx_get_fmt,
 	.set_format = mipi_csi2rx_set_fmt,
-	.stream_start = mipi_csi2rx_stream_start,
-	.stream_stop = mipi_csi2rx_stream_stop,
+	.set_stream = mipi_csi2rx_set_stream,
 	.set_ctrl = mipi_csi2rx_set_ctrl,
 	.set_frmival = mipi_csi2rx_set_frmival,
 	.get_frmival = mipi_csi2rx_get_frmival,

--- a/drivers/video/video_sw_generator.c
+++ b/drivers/video/video_sw_generator.c
@@ -99,20 +99,15 @@ static int video_sw_generator_get_fmt(const struct device *dev, enum video_endpo
 	return 0;
 }
 
-static int video_sw_generator_stream_start(const struct device *dev)
+static int video_sw_generator_set_stream(const struct device *dev, bool enable)
 {
 	struct video_sw_generator_data *data = dev->data;
 
-	k_work_schedule(&data->buf_work, K_MSEC(1000 / data->frame_rate));
-
-	return 0;
-}
-
-static int video_sw_generator_stream_stop(const struct device *dev)
-{
-	struct video_sw_generator_data *data = dev->data;
-
-	k_work_cancel_delayable_sync(&data->buf_work, &data->work_sync);
+	if (enable) {
+		k_work_schedule(&data->buf_work, K_MSEC(1000 / data->frame_rate));
+	} else {
+		k_work_cancel_delayable_sync(&data->buf_work, &data->work_sync);
+	}
 
 	return 0;
 }
@@ -340,8 +335,7 @@ static int video_sw_generator_enum_frmival(const struct device *dev, enum video_
 static DEVICE_API(video, video_sw_generator_driver_api) = {
 	.set_format = video_sw_generator_set_fmt,
 	.get_format = video_sw_generator_get_fmt,
-	.stream_start = video_sw_generator_stream_start,
-	.stream_stop = video_sw_generator_stream_stop,
+	.set_stream = video_sw_generator_set_stream,
 	.flush = video_sw_generator_flush,
 	.enqueue = video_sw_generator_enqueue,
 	.dequeue = video_sw_generator_dequeue,


### PR DESCRIPTION
The video_stream_start/stop() APIs are counter-symetric and have the same function signature. Also, the implementation logic for those APIs is generally the same. Merge these **two drivers API** to save memory and code lines (e.g., **number of code lines are saved by nearly a half**)

**For the sake of simplicity, still keep the user APIs to keep backward compatibility with downstream applications.**

While at it:

- Fix a related bug in video_emul_rx
- Fix video related doc in migration guide 4.1