### PR TITLE
net: tcp: fix ECONNREFUSED not reported by zsock_connect

### DIFF
--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -2853,6 +2853,7 @@ static enum net_verdict tcp_in(struct tcp *conn, struct net_pkt *pkt)
 		net_stats_update_tcp_seg_rst(net_pkt_iface(pkt));
 		do_close = true;
 		close_status = -ECONNRESET;
+		conn->rst_received = true;
 
 		/* If we receive RST and ACK for the sent SYN, it means
 		 * that there is no socket listening the port we are trying
@@ -3951,7 +3952,11 @@ int net_tcp_connect(struct net_context *context,
 
 	if (!IS_ENABLED(CONFIG_NET_TEST_PROTOCOL)) {
 		if (conn->state == TCP_UNUSED || conn->state == TCP_CLOSED) {
-			ret = -ENOTCONN;
+			if (conn->rst_received) {
+				ret = -ECONNREFUSED;
+			} else {
+				ret = -ENOTCONN;
+			}
 			goto out_unref;
 		} else if ((K_TIMEOUT_EQ(timeout, K_NO_WAIT)) &&
 			   conn->state != TCP_ESTABLISHED) {
@@ -3964,7 +3969,11 @@ int net_tcp_connect(struct net_context *context,
 				tcp_conn_close(conn, -ETIMEDOUT);
 			}
 
-			ret = -ETIMEDOUT;
+			if (conn->rst_received) {
+				ret = -ECONNREFUSED;
+			} else {
+				ret = -ETIMEDOUT;
+			}
 			goto out_unref;
 		}
 		conn->in_connect = false;

--- a/subsys/net/ip/tcp_private.h
+++ b/subsys/net/ip/tcp_private.h
@@ -338,6 +338,7 @@ struct tcp { /* TCP connection */
 #endif /* CONFIG_NET_TCP_KEEPALIVE */
 	bool tcp_nodelay : 1;
 	bool addr_ref_done : 1;
+	bool rst_received : 1;
 };
 
 #define _flags(_fl, _op, _mask, _cond)					\

--- a/tests/net/socket/tls/src/main.c
+++ b/tests/net/socket/tls/src/main.c
@@ -916,7 +916,7 @@ ZTEST(net_socket_tls, test_connect_closed_port)
 	zassert_equal(zsock_connect(c_sock, (struct sockaddr *)&s_saddr,
 				    sizeof(s_saddr)),
 		      -1, "connect succeed");
-	zassert_equal(errno, ETIMEDOUT,
+	zassert_equal(errno, ECONNREFUSED,
 		      "connect should fail, got %d", errno);
 
 	test_sockets_close();


### PR DESCRIPTION
When a TCP connection is refused during zsock_connect, errno is set to -ENOTCONN, but errno should be set to -ECONNREFUSED. This change causes the ECONNREFUSED status to be propagated from tcp_conn_close to net_tcp_connect, which eventually causes errno to be set to -ECONNREFUSED.