### PR TITLE
bluetooth: host: hci_core: add missing `NULL` check

### DIFF
--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -884,6 +884,9 @@ int bt_le_create_conn_cancel(void)
 	struct bt_hci_cmd_state_set state;
 
 	buf = bt_hci_cmd_create(BT_HCI_OP_LE_CREATE_CONN_CANCEL, 0);
+	if (!buf) {
+		return -ENOBUFS;
+	}
 
 	bt_hci_cmd_state_set_init(buf, &state, bt_dev.flags,
 				  BT_DEV_INITIATING, false);


### PR DESCRIPTION
Add check that the command buffer claimed in `bt_le_create_conn_cancel` is not `NULL`. Fixes a fault caused by providing the `NULL` buffer to `bt_hci_cmd_state_set_init`.

The obvious case under which `bt_hci_cmd_create` can fail is no longer possible with the revert in #84282. Are callers to `bt_hci_cmd_create` still supposed to check whether the result is not `NULL`? If not, there are a lot of places in tree where the value is checked.

The test case added in this PR fails on `v3.7.0` (without the other changes) with a NULL dereference,  so the test case is useful IMO to prevent regressions even if the `NULL` check is no longer needed here. And if not needed here, it is still needed on `v3.7.0` and `v4.0.0`.