### PR TITLE
dts: arm: renesas: ra: Correct PWM's address and MSTPD bit for Renesas ra4-cm4 SoC

### DIFF
--- a/dts/arm/renesas/ra/ra4/r7fa4e10x.dtsi
+++ b/dts/arm/renesas/ra/ra4/r7fa4e10x.dtsi
@@ -12,6 +12,7 @@
 /delete-node/ &agt4;
 /delete-node/ &adc1;
 /delete-node/ &iic1;
+/delete-node/ &pwm0;
 
 / {
 	soc {

--- a/dts/arm/renesas/ra/ra4/r7fa4m1ab3cfp.dtsi
+++ b/dts/arm/renesas/ra/ra4/r7fa4m1ab3cfp.dtsi
@@ -312,3 +312,11 @@
 	port-irq12-pins = <2>;
 	port-irq14-pins = <5>;
 };
+
+&pwm2 {
+	clocks = <&pclkd MSTPD 6>;
+};
+
+&pwm3 {
+	clocks = <&pclkd MSTPD 6>;
+};

--- a/dts/arm/renesas/ra/ra4/r7fa4w1ad2cng.dtsi
+++ b/dts/arm/renesas/ra/ra4/r7fa4w1ad2cng.dtsi
@@ -47,12 +47,12 @@
 			channel-available-mask = <0x1a0670>;
 		};
 
-		pwm8: pwm8@40169800 {
+		pwm8: pwm8@40078800 {
 			compatible = "renesas,ra-pwm";
 			divider = <RA_PWM_SOURCE_DIV_1>;
 			channel = <RA_PWM_CHANNEL_8>;
 			clocks = <&pclkd MSTPD 6>;
-			reg = <0x40169800 0x100>;
+			reg = <0x40078800 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
 		};

--- a/dts/arm/renesas/ra/ra4/r7fa4w1ad2cng.dtsi
+++ b/dts/arm/renesas/ra/ra4/r7fa4w1ad2cng.dtsi
@@ -229,3 +229,11 @@
 	port-irq-names = "port-irq11";
 	port-irq11-pins = <1>;
 };
+
+&pwm2 {
+	clocks = <&pclkd MSTPD 5>;
+};
+
+&pwm3 {
+	clocks = <&pclkd MSTPD 5>;
+};

--- a/dts/arm/renesas/ra/ra4/ra4-cm4-common.dtsi
+++ b/dts/arm/renesas/ra/ra4/ra4-cm4-common.dtsi
@@ -338,62 +338,62 @@
 			status = "disabled";
 		};
 
-		pwm0: pwm0@40169000 {
+		pwm0: pwm0@40078000 {
 			compatible = "renesas,ra-pwm";
 			divider = <RA_PWM_SOURCE_DIV_1>;
 			channel = <RA_PWM_CHANNEL_0>;
 			clocks = <&pclkd MSTPD 5>;
-			reg = <0x40169000 0x100>;
+			reg = <0x40078000 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
 		};
 
-		pwm1: pwm1@40169100 {
+		pwm1: pwm1@40078100 {
 			compatible = "renesas,ra-pwm";
 			divider = <RA_PWM_SOURCE_DIV_1>;
 			channel = <RA_PWM_CHANNEL_1>;
 			clocks = <&pclkd MSTPD 5>;
-			reg = <0x40169100 0x100>;
+			reg = <0x40078100 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
 		};
 
-		pwm2: pwm2@40169200 {
+		pwm2: pwm2@40078200 {
 			compatible = "renesas,ra-pwm";
 			divider = <RA_PWM_SOURCE_DIV_1>;
 			channel = <RA_PWM_CHANNEL_2>;
 			clocks = <&pclkd MSTPD 5>;
-			reg = <0x40169200 0x100>;
+			reg = <0x40078200 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
 		};
 
-		pwm3: pwm3@40169300 {
+		pwm3: pwm3@40078300 {
 			compatible = "renesas,ra-pwm";
 			divider = <RA_PWM_SOURCE_DIV_1>;
 			channel = <RA_PWM_CHANNEL_3>;
 			clocks = <&pclkd MSTPD 5>;
-			reg = <0x40169300 0x100>;
+			reg = <0x40078300 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
 		};
 
-		pwm4: pwm4@40169400 {
+		pwm4: pwm4@40078400 {
 			compatible = "renesas,ra-pwm";
 			divider = <RA_PWM_SOURCE_DIV_1>;
 			channel = <RA_PWM_CHANNEL_4>;
 			clocks = <&pclkd MSTPD 5>;
-			reg = <0x40169400 0x100>;
+			reg = <0x40078400 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
 		};
 
-		pwm5: pwm5@40169500 {
+		pwm5: pwm5@40078500 {
 			compatible = "renesas,ra-pwm";
 			divider = <RA_PWM_SOURCE_DIV_1>;
 			channel = <RA_PWM_CHANNEL_5>;
 			clocks = <&pclkd MSTPD 6>;
-			reg = <0x40169500 0x100>;
+			reg = <0x40078500 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
 		};

--- a/dts/arm/renesas/ra/ra4/ra4-cm4-common.dtsi
+++ b/dts/arm/renesas/ra/ra4/ra4-cm4-common.dtsi
@@ -362,7 +362,6 @@
 			compatible = "renesas,ra-pwm";
 			divider = <RA_PWM_SOURCE_DIV_1>;
 			channel = <RA_PWM_CHANNEL_2>;
-			clocks = <&pclkd MSTPD 5>;
 			reg = <0x40078200 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
@@ -372,7 +371,6 @@
 			compatible = "renesas,ra-pwm";
 			divider = <RA_PWM_SOURCE_DIV_1>;
 			channel = <RA_PWM_CHANNEL_3>;
-			clocks = <&pclkd MSTPD 5>;
 			reg = <0x40078300 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
@@ -382,7 +380,7 @@
 			compatible = "renesas,ra-pwm";
 			divider = <RA_PWM_SOURCE_DIV_1>;
 			channel = <RA_PWM_CHANNEL_4>;
-			clocks = <&pclkd MSTPD 5>;
+			clocks = <&pclkd MSTPD 6>;
 			reg = <0x40078400 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";


### PR DESCRIPTION
- Correct PWM's address for `ra4-cm4`
- Correct MSTPD bit for PWM on `ra4-cm4`
- Remove unsupported PWM node on RA4E1 (`r7fa4e10x`)