### PR TITLE
arch: linker: Remove __used from .intList data

### DIFF
--- a/arch/common/CMakeLists.txt
+++ b/arch/common/CMakeLists.txt
@@ -57,11 +57,11 @@ zephyr_linker_sources_ifdef(CONFIG_GEN_IRQ_VECTOR_TABLE
 
 if(CONFIG_GEN_ISR_TABLES)
   zephyr_linker_section(NAME .intList VMA IDT_LIST LMA IDT_LIST NOINPUT PASS NOT LINKER_ZEPHYR_FINAL)
-  zephyr_linker_section_configure(SECTION .intList KEEP INPUT ".irq_info" FIRST)
-  zephyr_linker_section_configure(SECTION .intList KEEP INPUT ".intList")
+  zephyr_linker_section_configure(SECTION .intList KEEP INPUT ".irq_info" FIRST PASS NOT LINKER_ZEPHYR_FINAL)
+  zephyr_linker_section_configure(SECTION .intList KEEP INPUT ".intList" PASS NOT LINKER_ZEPHYR_FINAL)
 
-  zephyr_linker_section_configure(SECTION /DISCARD/ KEEP INPUT ".irq_info" PASS LINKER_ZEPHYR_FINAL)
-  zephyr_linker_section_configure(SECTION /DISCARD/ KEEP INPUT ".intList"  PASS LINKER_ZEPHYR_FINAL)
+  zephyr_linker_section_configure(SECTION /DISCARD/ INPUT ".irq_info" PASS LINKER_ZEPHYR_FINAL)
+  zephyr_linker_section_configure(SECTION /DISCARD/ INPUT ".intList"  PASS LINKER_ZEPHYR_FINAL)
 endif()
 
 zephyr_linker_sources_ifdef(CONFIG_ARCH_HAS_RAMFUNC_SUPPORT

--- a/arch/common/isr_tables.c
+++ b/arch/common/isr_tables.c
@@ -26,7 +26,7 @@ struct int_list_header {
  * header of the initList section, which is used by gen_isr_tables.py to create
  * the vector and sw isr tables,
  */
-Z_GENERIC_SECTION(.irq_info) __used struct int_list_header _iheader = {
+Z_GENERIC_SECTION(.irq_info) struct int_list_header _iheader = {
 	.table_size = IRQ_TABLE_SIZE,
 	.offset = CONFIG_GEN_IRQ_START_VECTOR,
 #if defined(CONFIG_ISR_TABLES_LOCAL_DECLARATION)

--- a/include/zephyr/sw_isr_table.h
+++ b/include/zephyr/sw_isr_table.h
@@ -203,7 +203,7 @@ extern struct z_shared_isr_table_entry z_shared_sw_isr_table[];
 #define _Z_ISR_TABLE_ENTRY(irq, func, param, sect) \
 	static Z_DECL_ALIGN(struct _isr_table_entry)                                      \
 		__attribute__((section(sect)))                                            \
-		__used _MK_ISR_ELEMENT_NAME(func, __COUNTER__) = {                        \
+		 _MK_ISR_ELEMENT_NAME(func, __COUNTER__) = {                        \
 			.arg = (const void *)(param),                                     \
 			.isr = (void (*)(const void *))(void *)(func)                     \
 	}
@@ -214,7 +214,7 @@ extern struct z_shared_isr_table_entry z_shared_sw_isr_table[];
 #define _Z_ISR_DECLARE_C(irq, flags, func, param, counter)                                \
 	_Z_ISR_TABLE_ENTRY(irq, func, param, _MK_ISR_ELEMENT_SECTION(counter));           \
 	static struct _isr_list_sname Z_GENERIC_SECTION(.intList)                         \
-		__used _MK_ISR_NAME(func, counter) =                                      \
+		 _MK_ISR_NAME(func, counter) =                                      \
 		{irq, flags, _MK_ISR_ELEMENT_SECTION(counter)}
 
 /* Create an entry for _isr_table to be then placed by the linker.
@@ -234,10 +234,10 @@ extern struct z_shared_isr_table_entry z_shared_sw_isr_table[];
 	COND_CODE_1(CONFIG_IRQ_VECTOR_TABLE_JUMP_BY_ADDRESS, (                                     \
 			static Z_DECL_ALIGN(uintptr_t)                                             \
 			__attribute__((section(sect)))                                             \
-			__used _MK_IRQ_ELEMENT_NAME(func, __COUNTER__) = ((uintptr_t)(func));      \
+			 _MK_IRQ_ELEMENT_NAME(func, __COUNTER__) = ((uintptr_t)(func));      \
 		), (                                                                               \
 			static void __attribute__((section(sect))) __attribute__((naked))          \
-			__used _MK_IRQ_ELEMENT_NAME(func, __COUNTER__)(void) {                     \
+			 _MK_IRQ_ELEMENT_NAME(func, __COUNTER__)(void) {                     \
 				__asm(ARCH_IRQ_VECTOR_JUMP_CODE(func));                            \
 			}                                                                          \
 		))
@@ -248,7 +248,7 @@ extern struct z_shared_isr_table_entry z_shared_sw_isr_table[];
 #define _Z_ISR_DECLARE_DIRECT_C(irq, flags, func, counter)                                         \
 	_Z_ISR_DIRECT_TABLE_ENTRY(irq, func, _MK_IRQ_ELEMENT_SECTION(counter));                    \
 	static struct _isr_list_sname Z_GENERIC_SECTION(.intList)                                  \
-		__used _MK_ISR_NAME(func, counter) = {                                             \
+		_MK_ISR_NAME(func, counter) = {                                             \
 			irq,                                                                       \
 			ISR_FLAG_DIRECT | (flags),                                                 \
 			_MK_IRQ_ELEMENT_SECTION(counter)}
@@ -272,7 +272,7 @@ extern struct z_shared_isr_table_entry z_shared_sw_isr_table[];
  */
 #define Z_ISR_DECLARE(irq, flags, func, param) \
 	static Z_DECL_ALIGN(struct _isr_list) Z_GENERIC_SECTION(.intList) \
-		__used _MK_ISR_NAME(func, __COUNTER__) = \
+		_MK_ISR_NAME(func, __COUNTER__) = \
 			{irq, flags, (void *)&func, (const void *)param}
 
 /* The version of the Z_ISR_DECLARE that should be used for direct ISR declaration.


### PR DESCRIPTION
 sw_ist_table.h declares the table entries that goes int .intList as
 __used. This is unnecessary since the linker-files does KEEP on the
 .intList section to force it to remain until gen_isr_tables.py has done
 its job.

 Without __used the linker is free to drop the section without explicit
 discard.