### PR TITLE
samples: mcux_acmp: allow for mimxrt1170_evk rev. A

### DIFF
--- a/samples/sensor/mcux_acmp/README.rst
+++ b/samples/sensor/mcux_acmp/README.rst
@@ -42,7 +42,7 @@ ACMP input voltage by changing the voltage input to J25-13.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/sensor/mcux_acmp
-   :board: mimxrt1170_evk_cm7
+   :board: mimxrt1170_evk@A/mimxrt1176/cm7
    :goals: flash
    :compact:
 

--- a/samples/sensor/mcux_acmp/sample.yaml
+++ b/samples/sensor/mcux_acmp/sample.yaml
@@ -4,8 +4,8 @@ sample:
 common:
   platform_allow:
     - twr_ke18f
-    - mimxrt1170_evk/mimxrt1176/cm7
-    - mimxrt1170_evk/mimxrt1176/cm4
+    - mimxrt1170_evk@A/mimxrt1176/cm7
+    - mimxrt1170_evk@A/mimxrt1176/cm4
     - frdm_ke17z
     - frdm_ke17z512
     - mimxrt1180_evk/mimxrt1189/cm33


### PR DESCRIPTION
Allow mcux_acmp sample for mimxrt1170-evk revA.
mimxrt1170-evkb does not support ACMP.