### PR TITLE
net: shell: Print interface status for iface command

### DIFF
--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -5487,9 +5487,8 @@ static void notify_iface_down(struct net_if *iface)
 	}
 }
 
-static inline const char *net_if_oper_state2str(enum net_if_oper_state state)
+const char *net_if_oper_state2str(enum net_if_oper_state state)
 {
-#if CONFIG_NET_IF_LOG_LEVEL >= LOG_LEVEL_DBG
 	switch (state) {
 	case NET_IF_OPER_UNKNOWN:
 		return "UNKNOWN";
@@ -5510,11 +5509,6 @@ static inline const char *net_if_oper_state2str(enum net_if_oper_state state)
 	}
 
 	return "<invalid>";
-#else
-	ARG_UNUSED(state);
-
-	return "";
-#endif /* CONFIG_NET_IF_LOG_LEVEL >= LOG_LEVEL_DBG */
 }
 
 static void update_operational_state(struct net_if *iface)

--- a/subsys/net/ip/net_private.h
+++ b/subsys/net/ip/net_private.h
@@ -59,6 +59,7 @@ extern void net_if_init(void);
 extern void net_if_post_init(void);
 extern void net_if_stats_reset(struct net_if *iface);
 extern void net_if_stats_reset_all(void);
+extern const char *net_if_oper_state2str(enum net_if_oper_state state);
 extern void net_process_rx_packet(struct net_pkt *pkt);
 extern void net_process_tx_packet(struct net_pkt *pkt);
 

--- a/subsys/net/lib/shell/iface.c
+++ b/subsys/net/lib/shell/iface.c
@@ -274,6 +274,11 @@ static void iface_cb(struct net_if *iface, void *user_data)
 	   net_if_get_device(iface) ? net_if_get_device(iface)->name : "<?>",
 	   net_if_get_device(iface));
 
+	PR("Status    : oper=%s, admin=%s, carrier=%s\n",
+	   net_if_oper_state2str(net_if_oper_state(iface)),
+	   net_if_is_admin_up(iface) ? "UP" : "DOWN",
+	   net_if_is_carrier_ok(iface) ? "ON" : "OFF");
+
 #if defined(CONFIG_NET_L2_ETHERNET_MGMT)
 	if (net_if_l2(iface) == &NET_L2_GET_NAME(ETHERNET)) {
 		count = 0;


### PR DESCRIPTION
Print interface status information for "net iface" command. This is useful information when debugging connectivity issues.