### PR TITLE
Fix/wifi l2 acs support

### DIFF
--- a/drivers/wifi/nxp/nxp_wifi_drv.c
+++ b/drivers/wifi/nxp/nxp_wifi_drv.c
@@ -492,6 +492,11 @@ static int nxp_wifi_start_ap(const struct device *dev, struct wifi_connect_req_p
 			nxp_wlan_uap_network.channel = params->channel;
 		}
 
+		if (nxp_wlan_uap_network.channel == 0) {
+			nxp_wlan_uap_network.acs_band =
+				(params->band == WIFI_FREQ_BAND_5_GHZ) ? 1 : 0;
+		}
+
 		if (params->mfp == WIFI_MFP_REQUIRED) {
 			nxp_wlan_uap_network.security.mfpc = true;
 			nxp_wlan_uap_network.security.mfpr = true;
@@ -1103,8 +1108,13 @@ static int nxp_wifi_uap_status(const struct device *dev, struct wifi_iface_statu
 				status->link_mode = WIFI_3;
 			}
 
-			status->band = nxp_wlan_uap_network.channel > 14 ? WIFI_FREQ_BAND_5_GHZ
-									 : WIFI_FREQ_BAND_2_4_GHZ;
+			if (nxp_wlan_uap_network.channel != 0) {
+				status->band = nxp_wlan_uap_network.channel > 14 ?
+					WIFI_FREQ_BAND_5_GHZ : WIFI_FREQ_BAND_2_4_GHZ;
+			} else {
+				status->band = nxp_wlan_uap_network.acs_band;
+			}
+
 			status->security = nxp_wifi_key_mgmt_to_zephyr(
 				nxp_wlan_uap_network.security.key_mgmt,
 				nxp_wlan_uap_network.security.pwe_derivation);

--- a/drivers/wifi/nxp/nxp_wifi_drv.c
+++ b/drivers/wifi/nxp/nxp_wifi_drv.c
@@ -1080,7 +1080,7 @@ static int nxp_wifi_uap_status(const struct device *dev, struct wifi_iface_statu
 
 			status->rssi = nxp_wlan_uap_network.rssi;
 
-			status->channel = nxp_wlan_uap_network.channel;
+			wlan_get_uap_channel(&status->channel);
 
 			status->beacon_interval = nxp_wlan_uap_network.beacon_period;
 

--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -670,12 +670,10 @@ static int __wifi_args_to_params(const struct shell *sh, size_t argc, char *argv
 			break;
 		case 'c':
 			channel = strtol(state->optarg, &endptr, 10);
-#ifdef CONFIG_WIFI_NM_HOSTAPD_AP
 			if (iface_mode == WIFI_MODE_AP && channel == 0) {
 				params->channel = channel;
 				break;
 			}
-#endif
 			for (band = 0; band < ARRAY_SIZE(all_bands); band++) {
 				offset += snprintf(bands_str + offset,
 						   sizeof(bands_str) - offset,


### PR DESCRIPTION
3ef5836aab1efe0b865b5a048eb62c597fd7a3fd
drivers: wifi: nxp: add ACS support for l2
    
    Updated wifi ap status command to reflect acs chnnel correctly.

87f93089ba9f3bedacb298c02d7c8177341d6505
drivers: wifi: nxp: add ACS support for l2
    
    Add ACS support in ap enable api for embedded supplicant.
    Channel set to 0 means ACS mode.

3784fadad78a02514f3cf2c53fce034a050c91eb
wifi: shell: add ACS case in ap enable cmd
    
    In ap enable cmd, channel set to 0 means ACS mode.
    Remove hostapd AP macro for this case to make ACS mode
    available for public usage.