### PR TITLE
drivers: can: add DLL clock limit check for can_renesas_ra

### DIFF
--- a/boards/renesas/ek_ra8d1/ek_ra8d1.dts
+++ b/boards/renesas/ek_ra8d1/ek_ra8d1.dts
@@ -113,7 +113,6 @@
 	};
 };
 
-
 &sciclk {
 	clocks = <&pllp>;
 	div = <4>;
@@ -121,8 +120,8 @@
 };
 
 &canfdclk {
-	clocks = <&pll>;
-	div = <5>;
+	clocks = <&pllp>;
+	div = <6>;
 	status = "okay";
 };
 

--- a/boards/renesas/ek_ra8m1/ek_ra8m1.dts
+++ b/boards/renesas/ek_ra8m1/ek_ra8m1.dts
@@ -158,8 +158,8 @@
 };
 
 &canfdclk {
-	clocks = <&pll>;
-	div = <5>;
+	clocks = <&pllp>;
+	div = <6>;
 	status = "okay";
 };
 

--- a/boards/renesas/mck_ra8t1/mck_ra8t1.dts
+++ b/boards/renesas/mck_ra8t1/mck_ra8t1.dts
@@ -85,8 +85,8 @@
 };
 
 &canfdclk {
-	clocks = <&pll>;
-	div = <5>;
+	clocks = <&pllp>;
+	div = <6>;
 	status = "okay";
 };
 

--- a/drivers/can/can_renesas_ra.c
+++ b/drivers/can/can_renesas_ra.c
@@ -88,7 +88,7 @@ LOG_MODULE_REGISTER(can_renesas_ra, CONFIG_CAN_LOG_LEVEL);
 #define CANFD_CFG_GLOBAL                                                                           \
 	((0U << R_CANFD_CFDGCFG_TPRI_Pos) | /* Transmission Priority: ID priority */               \
 	 (0U << R_CANFD_CFDGCFG_DCE_Pos) |  /* DLC check disabled */                               \
-	 (1U << R_CANFD_CFDGCFG_DCS_Pos))   /* DLL Clock Select: CANFDCLK */
+	 (0U << R_CANFD_CFDGCFG_DCS_Pos))   /* DLL Clock Select: CANFDCLK */
 
 /*
  * TX Message Buffer Interrupt Enable Configuration: refer to '34.2.43 CFDTMIEC : TX Message Buffer

--- a/drivers/can/can_renesas_ra.c
+++ b/drivers/can/can_renesas_ra.c
@@ -142,6 +142,8 @@ struct can_renesas_ra_global_cfg {
 	const struct device *ram_clk;
 	const struct clock_control_ra_subsys_cfg op_subsys;
 	const struct clock_control_ra_subsys_cfg ram_subsys;
+	const unsigned int dll_min_freq;
+	const unsigned int dll_max_freq;
 };
 
 struct can_renesas_ra_filter {
@@ -902,19 +904,33 @@ static inline int can_renesas_module_clock_init(const struct device *dev)
 		return ret;
 	}
 
+	if (dll_rate < global_cfg->dll_min_freq || dll_rate > global_cfg->dll_max_freq) {
+		LOG_ERR("%s frequency is out of supported range: %d < %s freq < %d",
+			cfg->dll_clk->name, global_cfg->dll_min_freq, cfg->dll_clk->name,
+			global_cfg->dll_max_freq);
+		return -ENOTSUP;
+	}
+
 	/* Clock constraint: refer to '34.1.2 Clock restriction' - RA8M1 MCU group HWM */
 	/*
 	 * Operation clock rate must be at least 40Mhz in case CANFD mode.
 	 * Otherwise, it must be at least 32MHz.
 	 */
-	if (IS_ENABLED(CONFIG_CAN_FD_MODE) ? op_rate < 40000000 : op_rate < 32000000) {
+	if (IS_ENABLED(CONFIG_CAN_FD_MODE) ? op_rate < MHZ(40) : op_rate < MHZ(32)) {
+		LOG_ERR("%s frequency should be at least %d", global_cfg->op_clk->name,
+			IS_ENABLED(CONFIG_CAN_FD_MODE) ? MHZ(40) : MHZ(32));
 		return -ENOTSUP;
 	}
+
 	/*
 	 * (RAM clock rate / 2) >= DLL rate
 	 * (CANFD operation clock rate) >= DLL rate
 	 */
 	if ((ram_rate / 2) < dll_rate || op_rate < dll_rate) {
+		LOG_ERR("%s frequency should be less than half of %s and %s frequency should "
+			"be less than %s",
+			global_cfg->ram_clk->name, cfg->dll_clk->name, global_cfg->op_clk->name,
+			cfg->dll_clk->name);
 		return -ENOTSUP;
 	}
 
@@ -998,12 +1014,10 @@ static DEVICE_API(can, can_renesas_ra_driver_api) = {
 	R_ICU->IELSR_b[VECTOR_NUMBER_CAN_GLERR].IELS = ELC_EVENT_CAN_GLERR;                        \
 	R_ICU->IELSR_b[VECTOR_NUMBER_CAN_RXF].IELS = ELC_EVENT_CAN_RXF;                            \
 	IRQ_CONNECT(VECTOR_NUMBER_CAN_GLERR,                                                       \
-		    DT_IRQ_BY_NAME(DT_COMPAT_GET_ANY_STATUS_OKAY(renesas_ra_canfd_global), glerr,  \
-				   priority),                                                      \
+		    DT_IRQ_BY_NAME(DT_INST(0, renesas_ra_canfd_global), glerr, priority),          \
 		    canfd_error_isr, NULL, 0);                                                     \
 	IRQ_CONNECT(VECTOR_NUMBER_CAN_RXF,                                                         \
-		    DT_IRQ_BY_NAME(DT_COMPAT_GET_ANY_STATUS_OKAY(renesas_ra_canfd_global), rxf,    \
-				   priority),                                                      \
+		    DT_IRQ_BY_NAME(DT_INST(0, renesas_ra_canfd_global), rxf, priority),            \
 		    canfd_rx_fifo_isr, NULL, 0);                                                   \
 	irq_enable(VECTOR_NUMBER_CAN_RXF);                                                         \
 	irq_enable(VECTOR_NUMBER_CAN_GLERR);
@@ -1012,30 +1026,26 @@ static canfd_global_cfg_t g_canfd_global_cfg = {
 	.global_interrupts = CANFD_CFG_GLERR_IRQ,
 	.global_config = CANFD_CFG_GLOBAL,
 	.rx_mb_config = CANFD_CFG_RXMB,
-	.global_err_ipl = DT_IRQ_BY_NAME(DT_COMPAT_GET_ANY_STATUS_OKAY(renesas_ra_canfd_global),
-					 glerr, priority),
-	.rx_fifo_ipl = DT_IRQ_BY_NAME(DT_COMPAT_GET_ANY_STATUS_OKAY(renesas_ra_canfd_global), rxf,
-				      priority),
+	.global_err_ipl = DT_IRQ_BY_NAME(DT_INST(0, renesas_ra_canfd_global), glerr, priority),
+	.rx_fifo_ipl = DT_IRQ_BY_NAME(DT_INST(0, renesas_ra_canfd_global), rxf, priority),
 	.rx_fifo_config = CANFD_CFG_RXFIFO,
 	.common_fifo_config = CANFD_CFG_COMMONFIFO,
 };
 
 static const struct can_renesas_ra_global_cfg g_can_renesas_ra_global_cfg = {
-	.op_clk = DEVICE_DT_GET(DT_CLOCKS_CTLR_BY_NAME(
-		DT_COMPAT_GET_ANY_STATUS_OKAY(renesas_ra_canfd_global), opclk)),
-	.ram_clk = DEVICE_DT_GET(DT_CLOCKS_CTLR_BY_NAME(
-		DT_COMPAT_GET_ANY_STATUS_OKAY(renesas_ra_canfd_global), ramclk)),
-	.op_subsys = {.mstp = DT_CLOCKS_CELL_BY_NAME(
-			      DT_COMPAT_GET_ANY_STATUS_OKAY(renesas_ra_canfd_global), opclk, mstp),
-		      .stop_bit = DT_CLOCKS_CELL_BY_NAME(
-			      DT_COMPAT_GET_ANY_STATUS_OKAY(renesas_ra_canfd_global), opclk,
-			      stop_bit)},
-	.ram_subsys = {.mstp = DT_CLOCKS_CELL_BY_NAME(
-			       DT_COMPAT_GET_ANY_STATUS_OKAY(renesas_ra_canfd_global), ramclk,
-			       mstp),
-		       .stop_bit = DT_CLOCKS_CELL_BY_NAME(
-			       DT_COMPAT_GET_ANY_STATUS_OKAY(renesas_ra_canfd_global), ramclk,
-			       stop_bit)},
+	.op_clk = DEVICE_DT_GET(DT_CLOCKS_CTLR_BY_NAME(DT_INST(0, renesas_ra_canfd_global), opclk)),
+	.ram_clk =
+		DEVICE_DT_GET(DT_CLOCKS_CTLR_BY_NAME(DT_INST(0, renesas_ra_canfd_global), ramclk)),
+	.op_subsys = {.mstp = DT_CLOCKS_CELL_BY_NAME(DT_INST(0, renesas_ra_canfd_global), opclk,
+						     mstp),
+		      .stop_bit = DT_CLOCKS_CELL_BY_NAME(DT_INST(0, renesas_ra_canfd_global), opclk,
+							 stop_bit)},
+	.ram_subsys = {.mstp = DT_CLOCKS_CELL_BY_NAME(DT_INST(0, renesas_ra_canfd_global), ramclk,
+						      mstp),
+		       .stop_bit = DT_CLOCKS_CELL_BY_NAME(DT_INST(0, renesas_ra_canfd_global),
+							  ramclk, stop_bit)},
+	.dll_min_freq = DT_PROP_OR(DT_INST(0, renesas_ra_canfd_global), dll_min_freq, 0),
+	.dll_max_freq = DT_PROP_OR(DT_INST(0, renesas_ra_canfd_global), dll_max_freq, UINT_MAX),
 };
 
 static int can_renesas_ra_global_init(const struct device *dev)

--- a/dts/arm/renesas/ra/ra4/r7fa4e2b93cfm.dtsi
+++ b/dts/arm/renesas/ra/ra4/r7fa4e2b93cfm.dtsi
@@ -75,6 +75,7 @@
 			interrupt-names = "rxf", "glerr";
 			clocks = <&pclkb 0 0>, <&pclka 0 0>;
 			clock-names = "opclk", "ramclk";
+			dll-max-freq = <DT_FREQ_M(40)>;
 			reg = <0x400b0000 0x2000>;
 			status = "disabled";
 

--- a/dts/arm/renesas/ra/ra6/r7fa6e2bx.dtsi
+++ b/dts/arm/renesas/ra/ra6/r7fa6e2bx.dtsi
@@ -53,6 +53,7 @@
 			interrupt-names = "rxf", "glerr";
 			clocks = <&pclkb 0 0>, <&pclka 0 0>;
 			clock-names = "opclk", "ramclk";
+			dll-max-freq = <DT_FREQ_M(40)>;
 			reg = <0x400b0000 0x2000>;
 			status = "disabled";
 

--- a/dts/arm/renesas/ra/ra8/ra8x1.dtsi
+++ b/dts/arm/renesas/ra/ra8/ra8x1.dtsi
@@ -559,6 +559,8 @@
 			interrupt-names = "rxf", "glerr";
 			clocks = <&pclka 0 0>, <&pclke 0 0>;
 			clock-names = "opclk", "ramclk";
+			dll-min-freq = <DT_FREQ_M(8)>;
+			dll-max-freq = <DT_FREQ_M(80)>;
 			reg = <0x40380000 0x4000>;
 			status = "disabled";
 

--- a/dts/bindings/can/renesas,ra-canfd-global.yaml
+++ b/dts/bindings/can/renesas,ra-canfd-global.yaml
@@ -13,3 +13,13 @@ properties:
 
   clocks:
     required: true
+
+  dll-min-freq:
+    type: int
+    description: |
+      Specifies the Data Link Layer clock limit on this device: DLL clock frequency > dll-min-freq.
+
+  dll-max-freq:
+    type: int
+    description: |
+      Specifies the Data Link Layer clock limit on this device: DLL clock frequency < dll-max-freq.


### PR DESCRIPTION
This PR to correct the Data Link Layer clock setting on these boards:
- ek_ra8m1
- ek_ra8d1
- mck_ra8t1

Add some minor change for `renesas,ra-canfd`
- Add DLL clock limit check on initialization
- Correct bit setting for CAN DLL clock as CANFDCLK