### PR TITLE
drivers/sensor: st: fix ASSERT in fetch API

### DIFF
--- a/drivers/sensor/st/hts221/hts221.c
+++ b/drivers/sensor/st/hts221/hts221.c
@@ -72,7 +72,8 @@ static int hts221_sample_fetch(const struct device *dev,
 	uint8_t buf[4];
 	int status;
 
-	__ASSERT_NO_MSG(chan == SENSOR_CHAN_ALL);
+	__ASSERT_NO_MSG(chan == SENSOR_CHAN_HUMIDITY || chan == SENSOR_CHAN_AMBIENT_TEMP ||
+			chan == SENSOR_CHAN_ALL);
 
 	status = hts221_read_reg(ctx, HTS221_HUMIDITY_OUT_L |
 				 HTS221_AUTOINCREMENT_ADDR, buf, 4);

--- a/drivers/sensor/st/iis3dhhc/iis3dhhc.c
+++ b/drivers/sensor/st/iis3dhhc/iis3dhhc.c
@@ -26,7 +26,7 @@ static int iis3dhhc_sample_fetch(const struct device *dev,
 	struct iis3dhhc_data *data = dev->data;
 	int16_t raw_accel[3];
 
-	__ASSERT_NO_MSG(chan == SENSOR_CHAN_ALL);
+	__ASSERT_NO_MSG(chan == SENSOR_CHAN_ACCEL_XYZ || chan == SENSOR_CHAN_ALL);
 
 	iis3dhhc_acceleration_raw_get(data->ctx, raw_accel);
 	data->acc[0] = raw_accel[0];

--- a/drivers/sensor/st/lps22hb/lps22hb.c
+++ b/drivers/sensor/st/lps22hb/lps22hb.c
@@ -36,7 +36,7 @@ static int lps22hb_sample_fetch(const struct device *dev,
 	const struct lps22hb_config *config = dev->config;
 	uint8_t out[5];
 
-	__ASSERT_NO_MSG(chan == SENSOR_CHAN_ALL);
+	__ASSERT_NO_MSG(chan == SENSOR_CHAN_PRESS || chan == SENSOR_CHAN_ALL);
 
 	if (i2c_burst_read_dt(&config->i2c, LPS22HB_REG_PRESS_OUT_XL,
 			      out, 5) < 0) {

--- a/drivers/sensor/st/lps25hb/lps25hb.c
+++ b/drivers/sensor/st/lps25hb/lps25hb.c
@@ -46,7 +46,7 @@ static int lps25hb_sample_fetch(const struct device *dev,
 	uint8_t out[5];
 	int offset;
 
-	__ASSERT_NO_MSG(chan == SENSOR_CHAN_ALL);
+	__ASSERT_NO_MSG(chan == SENSOR_CHAN_PRESS || chan == SENSOR_CHAN_ALL);
 
 	for (offset = 0; offset < sizeof(out); ++offset) {
 		if (i2c_reg_read_byte_dt(&config->i2c,

--- a/drivers/sensor/st/lps2xdf/lps2xdf.c
+++ b/drivers/sensor/st/lps2xdf/lps2xdf.c
@@ -136,7 +136,7 @@ static int lps2xdf_sample_fetch(const struct device *dev, enum sensor_channel ch
 	const struct lps2xdf_config *const cfg = dev->config;
 	const struct lps2xdf_chip_api *chip_api = cfg->chip_api;
 
-	__ASSERT_NO_MSG(chan == SENSOR_CHAN_ALL);
+	__ASSERT_NO_MSG(chan == SENSOR_CHAN_PRESS || chan == SENSOR_CHAN_ALL);
 
 	return chip_api->sample_fetch(dev, chan);
 }

--- a/drivers/sensor/st/stts751/stts751.c
+++ b/drivers/sensor/st/stts751/stts751.c
@@ -35,7 +35,7 @@ static int stts751_sample_fetch(const struct device *dev,
 	struct stts751_data *data = dev->data;
 	int16_t raw_temp;
 
-	__ASSERT_NO_MSG(chan == SENSOR_CHAN_ALL);
+	__ASSERT_NO_MSG(chan == SENSOR_CHAN_AMBIENT_TEMP || chan == SENSOR_CHAN_ALL);
 
 	if (stts751_temperature_raw_get(data->ctx, &raw_temp) < 0) {
 		LOG_DBG("Failed to read sample");


### PR DESCRIPTION
Many drivers use a wrong __ASSERT in the fetch API, where they just use SENSOR_CHAN_ALL, while it is more common fetching the specific sensor channel (i.e. SENSOR_CHAN_PRESS, SENSOR_CHAN_ACCEL_XYZ, ...).

Similar to #84989 (which is fixing issue #84145)