### PR TITLE
samples: fade_led: fix build error when PWM is not enabled

### DIFF
--- a/samples/basic/fade_led/src/main.c
+++ b/samples/basic/fade_led/src/main.c
@@ -15,8 +15,8 @@
 #include <zephyr/drivers/pwm.h>
 
 #define PWM_LED_ALIAS(i) DT_ALIAS(_CONCAT(pwm_led, i))
-#define PWM_LED(i, _)                                                                              \
-	IF_ENABLED(DT_NODE_EXISTS(PWM_LED_ALIAS(i)), (PWM_DT_SPEC_GET(PWM_LED_ALIAS(i)),))
+#define PWM_LED_IS_OKAY(i) DT_NODE_HAS_STATUS_OKAY(DT_PARENT(PWM_LED_ALIAS(i)))
+#define PWM_LED(i, _) IF_ENABLED(PWM_LED_IS_OKAY(i), (PWM_DT_SPEC_GET(PWM_LED_ALIAS(i)),))
 
 #define MAX_LEDS 10
 static const struct pwm_dt_spec pwm_leds[] = {LISTIFY(MAX_LEDS, PWM_LED, ())};


### PR DESCRIPTION
The Arduino Nano 33 BLE defines a PWM LED whose controller is disabled by default due to conflicts with other peripherals:

https://github.com/zephyrproject-rtos/zephyr/blob/8df15918ef720940421a90a8428670eb1b200628/boards/arduino/nano_33_ble/arduino_nano_33_ble-common.dtsi#L66-L75

In this case, the new sample code introduced in a5fd92b fails to build with a missing symbol error because it assumes defined nodes are usable.

Fix this by checking in the sample if the PWM device (the parent of the LED alias) is enabled before using it. This implicitly discards invalid aliases, as before.