### PR TITLE
espressif: add console and RTC kconfig entries

### DIFF
--- a/drivers/clock_control/clock_control_esp32.c
+++ b/drivers/clock_control/clock_control_esp32.c
@@ -702,7 +702,7 @@ static int esp32_cpu_clock_configure(const struct esp32_cpu_clock_config *cpu_cf
 	esp_cpu_set_cycle_count((uint64_t)esp_cpu_get_cycle_count() * rtc_clk_cfg.cpu_freq_mhz /
 				old_config.freq_mhz);
 
-#if !defined(CONFIG_ESP_CONSOLE_UART_NONE)
+#if defined(CONFIG_ESP_CONSOLE_UART)
 #if !defined(CONFIG_SOC_SERIES_ESP32C2) && !defined(CONFIG_SOC_SERIES_ESP32C6)
 #if defined(CONFIG_MCUBOOT) && defined(ESP_ROM_UART_CLK_IS_XTAL)
 	uint32_t uart_clock_src_hz = (uint32_t)rtc_clk_xtal_freq_get() * MHZ(1);

--- a/soc/espressif/Kconfig
+++ b/soc/espressif/Kconfig
@@ -35,6 +35,12 @@ endmenu
 
 menu "RTC Clock Config"
 
+config RESERVE_RTC_MEM
+	int
+	default 0
+	help
+	  This option reserves an area in RTC FAST memory.
+
 config RTC_CLK_CAL_CYCLES
 	int "Number of cycles for RTC_SLOW_CLK calibration"
 	default 3000

--- a/soc/espressif/common/Kconfig
+++ b/soc/espressif/common/Kconfig
@@ -51,6 +51,7 @@ config ESP32_PHY_MAX_TX_POWER
 endif
 
 rsource "Kconfig.amp"
+rsource "Kconfig.console"
 rsource "Kconfig.spiram"
 rsource "Kconfig.esptool"
 rsource "Kconfig.flash"

--- a/soc/espressif/common/Kconfig.console
+++ b/soc/espressif/common/Kconfig.console
@@ -1,0 +1,79 @@
+# Copyright (c) 2025 Espressif Systems (Shanghai) Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+if SOC_FAMILY_ESPRESSIF_ESP32
+
+DT_CHOSEN_Z_CONSOLE := zephyr,console
+
+if !$(dt_chosen_enabled,$(DT_CHOSEN_Z_CONSOLE))
+
+config ESP_CONSOLE_UART_NUM
+	int
+	default -1
+
+config ESP_CONSOLE_UART_BAUDRATE
+	int
+	default 0
+
+endif # !$(dt_chosen_enabled,$(DT_CHOSEN_Z_CONSOLE))
+
+if $(dt_chosen_enabled,$(DT_CHOSEN_Z_CONSOLE))
+
+if $(dt_nodelabel_enabled,uart0)
+	ESP32_UART0_NODE_PATH := $(dt_nodelabel_path,uart0)
+	ESP32_UART0_CURR_SPEED := $(dt_node_int_prop_int,$(ESP32_UART0_NODE_PATH),current-speed)
+endif # $(dt_nodelabel_enabled,uart0)
+
+if $(dt_nodelabel_enabled,uart1)
+	ESP32_UART1_NODE_PATH := $(dt_nodelabel_path,uart1)
+	ESP32_UART1_CURR_SPEED := $(dt_node_int_prop_int,$(ESP32_UART1_NODE_PATH),current-speed)
+endif # $(dt_nodelabel_enabled,uart1)
+
+if $(dt_nodelabel_enabled,uart2)
+	ESP32_UART2_NODE_PATH := $(dt_nodelabel_path,uart2)
+	ESP32_UART2_CURR_SPEED := $(dt_node_int_prop_int,$(ESP32_UART2_NODE_PATH),current-speed)
+endif # $(dt_nodelabel_enabled,uart2)
+
+if $(dt_nodelabel_enabled,usb_serial)
+	ESP32_USB_SERIAL_CURR_SPEED := 1
+
+config ESP_ROM_USB_SERIAL_DEVICE_NUM
+	int
+	default 4 if SOC_SERIES_ESP32S3
+	default 3
+
+endif # $(dt_nodelabel_enabled,usb_serial)
+
+config ESP_CONSOLE_UART
+	bool
+	default y if $(dt_nodelabel_enabled,uart0) && $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_CONSOLE)) = $(dt_nodelabel_reg_addr_hex,uart0) || \
+		     $(dt_nodelabel_enabled,uart1) && $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_CONSOLE)) = $(dt_nodelabel_reg_addr_hex,uart1) || \
+		     $(dt_nodelabel_enabled,uart2) && $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_CONSOLE)) = $(dt_nodelabel_reg_addr_hex,uart2)
+
+config ESP_CONSOLE_USB_SERIAL_JTAG
+	bool
+	default y if $(dt_nodelabel_enabled,usb_serial) && $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_CONSOLE)) = $(dt_nodelabel_reg_addr_hex,usb_serial)
+
+config ESP_CONSOLE_UART_NUM
+	int
+	default 0 if $(dt_nodelabel_enabled,uart0) && $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_CONSOLE)) = $(dt_nodelabel_reg_addr_hex,uart0)
+	default 1 if $(dt_nodelabel_enabled,uart1) && $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_CONSOLE)) = $(dt_nodelabel_reg_addr_hex,uart1)
+	default 2 if $(dt_nodelabel_enabled,uart2) && $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_CONSOLE)) = $(dt_nodelabel_reg_addr_hex,uart2)
+	default ESP_ROM_USB_SERIAL_DEVICE_NUM if $(dt_nodelabel_enabled,usb_serial) && $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_CONSOLE)) = $(dt_nodelabel_reg_addr_hex,usb_serial)
+	default -1
+
+config ESP_CONSOLE_UART_BAUDRATE
+	int
+	default $(ESP32_UART0_CURR_SPEED) if $(dt_nodelabel_enabled,uart0) && $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_CONSOLE)) = $(dt_nodelabel_reg_addr_hex,uart0)
+	default $(ESP32_UART1_CURR_SPEED) if $(dt_nodelabel_enabled,uart1) && $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_CONSOLE)) = $(dt_nodelabel_reg_addr_hex,uart1)
+	default $(ESP32_UART2_CURR_SPEED) if $(dt_nodelabel_enabled,uart2) && $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_CONSOLE)) = $(dt_nodelabel_reg_addr_hex,uart2)
+	default $(ESP32_USB_SERIAL_CURR_SPEED) if $(dt_nodelabel_enabled,usb_serial) && $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_CONSOLE)) = $(dt_nodelabel_reg_addr_hex,usb_serial)
+	default 0
+
+config ESP_CONSOLE
+	bool
+	default y if ESP_CONSOLE_UART || ESP_CONSOLE_USB_SERIAL_JTAG
+
+endif # $(dt_chosen_enabled,$(DT_CHOSEN_Z_CONSOLE))
+
+endif # SOC_FAMILY_ESPRESSIF_ESP32

--- a/west.yml
+++ b/west.yml
@@ -162,7 +162,7 @@ manifest:
       groups:
         - hal
     - name: hal_espressif
-      revision: 2b8198796816e085759a96c2844e2d237b7f512d
+      revision: 07526d59121822a7d85de6c1a4adcf47b906d232
       path: modules/hal/espressif
       west-commands: west/west-commands.yml
       groups:


### PR DESCRIPTION
Add hidden console and RTC configurations used in hal
to common SoC folder.

Fixes #85290.