### PR TITLE
nRF TWIS (I2C device) patch and add to driver test suites

### DIFF
--- a/drivers/i2c/i2c_nrfx_twis.c
+++ b/drivers/i2c/i2c_nrfx_twis.c
@@ -32,13 +32,13 @@
 	DT_IRQ(SHIM_NRF_TWIS_NODE(id), priority)
 
 #define SHIM_NRF_TWIS_HAS_MEMORY_REGIONS(id) \
-	DT_NODE_HAS_PROP(id, memory_regions)
+	DT_NODE_HAS_PROP(SHIM_NRF_TWIS_NODE(id), memory_regions)
 
 #define SHIM_NRF_TWIS_LINKER_REGION_NAME(id) \
 	LINKER_DT_NODE_REGION_NAME(DT_PHANDLE(SHIM_NRF_TWIS_NODE(id), memory_regions))
 
 #define SHIM_NRF_TWIS_BUF_ATTR_SECTION(id) \
-	__attribute__((__section__(SHIM_NRF_TWIS_LINKER_REGION_NAME, ())))
+	__attribute__((__section__(SHIM_NRF_TWIS_LINKER_REGION_NAME(id))))
 
 #define SHIM_NRF_TWIS_BUF_ATTR(id)								\
 	COND_CODE_1(										\

--- a/tests/drivers/i2c/i2c_target_api/boards/nrf54h20dk_nrf54h20_cpuapp.conf
+++ b/tests/drivers/i2c/i2c_target_api/boards/nrf54h20dk_nrf54h20_cpuapp.conf
@@ -1,0 +1,4 @@
+# Copyright (c) 2025 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_I2C_NRFX_TWIS_BUF_SIZE=256

--- a/tests/drivers/i2c/i2c_target_api/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * SDA = P2.8 and P2.9
+ * SCL = P1.2 and P1.3
+ */
+
+&pinctrl {
+	i2c130_default: i2c130_default {
+		group1 {
+			psels = <NRF_PSEL(TWIM_SDA, 2, 8)>,
+				<NRF_PSEL(TWIM_SCL, 1, 2)>;
+			bias-pull-up;
+		};
+	};
+
+	i2c130_sleep: i2c130_sleep {
+		group1 {
+			psels = <NRF_PSEL(TWIM_SDA, 2, 8)>,
+				<NRF_PSEL(TWIM_SCL, 1, 2)>;
+			low-power-enable;
+		};
+	};
+
+	i2c131_default: i2c131_default {
+		group1 {
+			psels = <NRF_PSEL(TWIM_SDA, 2, 9)>,
+				<NRF_PSEL(TWIM_SCL, 1, 3)>;
+			bias-pull-up;
+		};
+	};
+
+	i2c131_sleep: i2c131_sleep {
+		group1 {
+			psels = <NRF_PSEL(TWIM_SDA, 2, 9)>,
+				<NRF_PSEL(TWIM_SCL, 1, 3)>;
+			low-power-enable;
+		};
+	};
+};
+
+&i2c130 {
+	clock-frequency = <I2C_BITRATE_STANDARD>;
+	pinctrl-0 = <&i2c130_default>;
+	pinctrl-1 = <&i2c130_sleep>;
+	pinctrl-names = "default", "sleep";
+	zephyr,concat-buf-size = <256>;
+	memory-regions = <&cpuapp_dma_region>;
+	status = "okay";
+
+	eeprom1: eeprom@56 {
+		compatible = "zephyr,i2c-target-eeprom";
+		reg = <0x56>;
+		address-width = <8>;
+		size = <256>;
+	};
+};
+
+&i2c131 {
+	compatible = "nordic,nrf-twis";
+	clock-frequency = <I2C_BITRATE_STANDARD>;
+	pinctrl-0 = <&i2c131_default>;
+	pinctrl-1 = <&i2c131_sleep>;
+	pinctrl-names = "default", "sleep";
+	memory-regions = <&cpuapp_dma_region>;
+	status = "okay";
+
+	eeprom0: eeprom@54 {
+		compatible = "zephyr,i2c-target-eeprom";
+		reg = <0x54>;
+		address-width = <8>;
+		size = <256>;
+	};
+};

--- a/tests/drivers/i2c/i2c_target_api/boards/nrf54l15dk_nrf54l15_cpuapp.conf
+++ b/tests/drivers/i2c/i2c_target_api/boards/nrf54l15dk_nrf54l15_cpuapp.conf
@@ -1,0 +1,4 @@
+# Copyright (c) 2024 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_I2C_NRFX_TWIS_BUF_SIZE=256

--- a/tests/drivers/i2c/i2c_target_api/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * SDA = P1.8 and P1.9
+ * SCL = P1.10 and P1.11
+ */
+
+&pinctrl {
+	i2c21_default: i2c21_default {
+		group1 {
+			psels = <NRF_PSEL(TWIS_SDA, 1, 8)>,
+				<NRF_PSEL(TWIS_SCL, 1, 10)>;
+			bias-pull-up;
+		};
+	};
+
+	i2c21_sleep: i2c21_sleep {
+		group1 {
+			psels = <NRF_PSEL(TWIS_SDA, 1, 8)>,
+				<NRF_PSEL(TWIS_SCL, 1, 10)>;
+			low-power-enable;
+		};
+	};
+
+	i2c22_default: i2c22_default {
+		group1 {
+			psels = <NRF_PSEL(TWIS_SDA, 1, 9)>,
+				<NRF_PSEL(TWIS_SCL, 1, 11)>;
+			bias-pull-up;
+		};
+	};
+
+	i2c22_sleep: i2c22_sleep {
+		group1 {
+			psels = <NRF_PSEL(TWIS_SDA, 1, 9)>,
+				<NRF_PSEL(TWIS_SCL, 1, 11)>;
+			low-power-enable;
+		};
+	};
+};
+
+&i2c21 {
+	pinctrl-0 = <&i2c21_default>;
+	pinctrl-1 = <&i2c21_sleep>;
+	pinctrl-names = "default", "sleep";
+	zephyr,concat-buf-size = <256>;
+	status = "okay";
+
+	eeprom1: eeprom@56 {
+		compatible = "zephyr,i2c-target-eeprom";
+		reg = <0x56>;
+		address-width = <8>;
+		size = <256>;
+	};
+};
+
+&i2c22 {
+	compatible = "nordic,nrf-twis";
+	pinctrl-0 = <&i2c22_default>;
+	pinctrl-1 = <&i2c22_sleep>;
+	pinctrl-names = "default", "sleep";
+	status = "okay";
+
+	eeprom0: eeprom@54 {
+		compatible = "zephyr,i2c-target-eeprom";
+		reg = <0x54>;
+		address-width = <8>;
+		size = <256>;
+	};
+};

--- a/tests/drivers/i2c/i2c_target_api/testcase.yaml
+++ b/tests/drivers/i2c/i2c_target_api/testcase.yaml
@@ -56,5 +56,8 @@ tests:
       - max32675evkit
       - max32680evkit/max32680/m4
       - max32690evkit/max32690/m4
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf54h20dk/nrf54h20/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp
     integration_platforms:
       - max32690evkit/max32690/m4


### PR DESCRIPTION
Patch nRF TWIS driver to place DMA buffer correctly on nRFH20, and add the H20 and L15 to the i2c target API test suite.