### PR TITLE
dts: bindings: clock: Change the property names in the DTS

### DIFF
--- a/boards/mediatek/mt8195/mt8195_adsp.dts
+++ b/boards/mediatek/mt8195/mt8195_adsp.dts
@@ -34,9 +34,9 @@
 		cpuclk: cpuclk@10000000 {
 			compatible = "mediatek,mt8195_cpuclk";
 			reg = <0x10000000 380>;
-			cg_reg = <0x10720180>;
-			pll_ctrl_reg = <0x1000c7e0>;
-			freqs_mhz = <26 370 540 720>;
+			cg-reg = <0x10720180>;
+			pll-ctrl-reg = <0x1000c7e0>;
+			freqs-mhz = <26 370 540 720>;
 		};
 
 		core_intc: core_intc@0 {

--- a/doc/releases/migration-guide-4.1.rst
+++ b/doc/releases/migration-guide-4.1.rst
@@ -137,6 +137,12 @@ ADC
 
 * Renamed the ``compatible`` from ``nxp,kinetis-adc12`` to :dtcompatible:`nxp,adc12`.
 
+Clock
+=====
+* Renamed the devicetree property ``freqs_mhz`` to ``freqs-mhz``.
+* Renamed the devicetree property ``cg_reg`` to ``cg-reg``.
+* Renamed the devicetree property ``pll_ctrl_reg`` to ``pll-ctrl-reg``.
+
 Counter
 =======
 

--- a/dts/bindings/clock/mediatek,mt8195_cpuclk.yaml
+++ b/dts/bindings/clock/mediatek,mt8195_cpuclk.yaml
@@ -4,13 +4,13 @@
 description: MediaTek Audio DSP CPU Frequency Control
 compatible: "mediatek,mt8195_cpuclk"
 properties:
-  freqs_mhz:
+  freqs-mhz:
     type: array
     description: Available frequencies in ascending order
     required: true
   reg:
     type: array
-  cg_reg:
+  cg-reg:
     type: int
-  pll_ctrl_reg:
+  pll-ctrl-reg:
     type: int


### PR DESCRIPTION
Change underscores in clock binding to use hyphens.