### PR TITLE
bluetooth/monitor: Fix SEGGER RTT compilation error

### DIFF
--- a/subsys/bluetooth/host/monitor.c
+++ b/subsys/bluetooth/host/monitor.c
@@ -126,13 +126,12 @@ static void monitor_send(const void *data, size_t len)
 	}
 
 	if (!drop) {
-		if (!panic_mode) {
-			SEGGER_RTT_LOCK();
-		}
-		cnt = SEGGER_RTT_WriteNoLock(CONFIG_BT_DEBUG_MONITOR_RTT_BUFFER,
-					     rtt_buf, rtt_buf_offset);
-		if (!panic_mode) {
-			SEGGER_RTT_UNLOCK();
+		if (panic_mode) {
+			cnt = SEGGER_RTT_WriteNoLock(CONFIG_BT_DEBUG_MONITOR_RTT_BUFFER,
+						     rtt_buf, rtt_buf_offset);
+		} else {
+			cnt = SEGGER_RTT_Write(CONFIG_BT_DEBUG_MONITOR_RTT_BUFFER,
+					       rtt_buf, rtt_buf_offset);
 		}
 	}
 


### PR DESCRIPTION
This fixes out of scope IRQ lock key.

../bluetooth/host/monitor.c: In function 'monitor_send': ../SEGGER_RTT_Conf.h:159:20: warning: unused variable 'key' [-Wunused-variable]
  159 |       unsigned int key = zephyr_rtt_irq_lock()
      |                    ^~~
../bluetooth/host/monitor.c:130:25: note: in expansion of macro 'SEGGER_RTT_LOCK'
  130 |                         SEGGER_RTT_LOCK();
      |                         ^~~~~~~~~~~~~~~
../SEGGER_RTT_Conf.h:160:55: error: 'key' undeclared (first use in this function)
  160 |     #define SEGGER_RTT_UNLOCK() zephyr_rtt_irq_unlock(key); \
      |                                                       ^~~
../bluetooth/host/monitor.c:135:25: note: in expansion of macro 'SEGGER_RTT_UNLOCK'
  135 |                         SEGGER_RTT_UNLOCK();
      |                         ^~~~~~~~~~~~~~~~~
../SEGGER_RTT_Conf.h:160:55: note: each undeclared identifier is reported only once for each function it appears in
  160 |     #define SEGGER_RTT_UNLOCK() zephyr_rtt_irq_unlock(key); \
      |                                                       ^~~
../bluetooth/host/monitor.c:135:25: note: in expansion of macro 'SEGGER_RTT_UNLOCK'
  135 |                         SEGGER_RTT_UNLOCK();
      |                         ^~~~~~~~~~~~~~~~~