### PR TITLE
[backport v3.7-branch] bluetooth: host: hci_core: add missing `NULL` check

### DIFF
--- a/subsys/bluetooth/common/Kconfig
+++ b/subsys/bluetooth/common/Kconfig
@@ -172,6 +172,7 @@ config BT_BUF_CMD_TX_SIZE
 
 config BT_BUF_CMD_TX_COUNT
 	int "Number of HCI command buffers"
+	default 3 if BT_EXT_ADV && BT_CENTRAL
 	default 2
 	range 2 64
 	help

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -858,6 +858,9 @@ int bt_le_create_conn_cancel(void)
 	struct bt_hci_cmd_state_set state;
 
 	buf = bt_hci_cmd_create(BT_HCI_OP_LE_CREATE_CONN_CANCEL, 0);
+	if (!buf) {
+		return -ENOBUFS;
+	}
 
 	bt_hci_cmd_state_set_init(buf, &state, bt_dev.flags,
 				  BT_DEV_INITIATING, false);


### PR DESCRIPTION
Add check that the command buffer claimed in `bt_le_create_conn_cancel` is not `NULL`. Fixes a fault caused by providing the `NULL` buffer to `bt_hci_cmd_state_set_init`.

Primary fix from #85260.
Increasing the command buffer count as discussed in Bluetooth WG 2025/02/06
Once the changes are validated here, a duplicate PR to the `v4.0` branch will be created.

Fixes #85301
