### PR TITLE
Bluetooth: Controller: Fix LE Create BIG Complete event parameter

### DIFF
--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -8180,6 +8180,7 @@ static void le_big_complete(struct pdu_data *pdu_data,
 	sep->pto = lll->pto;
 	sep->irc = lll->irc;
 	sep->max_pdu = sys_cpu_to_le16(lll->max_pdu);
+	sep->iso_interval = sys_cpu_to_le16(lll->iso_interval);
 	sep->num_bis = lll->num_bis;
 
 	/* Connection handle list of all BISes in the BIG */


### PR DESCRIPTION
This fixes ISO Interval uninitialized parameter in LE Create Broadcast Isochronous Group Complete event.

Fixes #81023.