### PR TITLE
espressif: update HAL to latest sync

### DIFF
--- a/soc/espressif/esp32c2/Kconfig
+++ b/soc/espressif/esp32c2/Kconfig
@@ -15,6 +15,11 @@ config SOC_SERIES_ESP32C2
 
 if SOC_SERIES_ESP32C2
 
+config SOC_ESP32C2_REV_2_0
+	bool "SOC is revision v2.0 (ECO4)"
+	help
+	  ESP32-C2 revision v2.0 has updated ROM functions.
+
 config MAC_BB_PD
 	bool "Power down MAC and baseband of Wi-Fi and Bluetooth when PHY is disabled"
 	depends on SOC_SERIES_ESP32C2 && TICKLESS_KERNEL

--- a/west.yml
+++ b/west.yml
@@ -162,7 +162,7 @@ manifest:
       groups:
         - hal
     - name: hal_espressif
-      revision: 07526d59121822a7d85de6c1a4adcf47b906d232
+      revision: fbbe8f22f34cadc43b69f9eb3fca10e301874e36
       path: modules/hal/espressif
       west-commands: west/west-commands.yml
       groups:


### PR DESCRIPTION
This updates hal_espressif to bring drivers updates and bugfixes.
This also updates all binary blobs used in Wi-Fi/BLE.