### PR TITLE
bluetooth: host/crypto: fix the psa crypto init for host

### DIFF
--- a/subsys/bluetooth/host/crypto.h
+++ b/subsys/bluetooth/host/crypto.h
@@ -5,4 +5,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-int prng_init(void);
+int bt_crypto_init(void);

--- a/subsys/bluetooth/host/crypto_psa.c
+++ b/subsys/bluetooth/host/crypto_psa.c
@@ -27,7 +27,7 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(bt_host_crypto);
 
-int prng_init(void)
+int bt_crypto_init(void)
 {
 	psa_status_t status = psa_crypto_init();
 

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -3284,11 +3284,9 @@ static int common_init(void)
 	read_supported_commands_complete(rsp);
 	net_buf_unref(rsp);
 
-	if (IS_ENABLED(CONFIG_BT_HOST_CRYPTO_PRNG)) {
-		/* Initialize the PRNG so that it is safe to use it later
-		 * on in the initialization process.
-		 */
-		err = prng_init();
+	if (IS_ENABLED(CONFIG_BT_HOST_CRYPTO)) {
+		/* Initialize crypto for host */
+		err = bt_crypto_init();
 		if (err) {
 			return err;
 		}


### PR DESCRIPTION
psa_crypto_init was bounded to CONFIG_BT_HOST_CRYPTO_PRNG and used to be called under prng_init. Updating the ifdef condition and appropriating the function name for crypto init.

Also it is better to make sure psa_crypto_init called by host.