### PR TITLE
Drop CAN from nRF9280

### DIFF
--- a/boards/nordic/nrf9280pdk/nrf9280pdk_nrf9280-pinctrl.dtsi
+++ b/boards/nordic/nrf9280pdk/nrf9280pdk_nrf9280-pinctrl.dtsi
@@ -60,13 +60,6 @@
 		};
 	};
 
-	/omit-if-no-ref/ can120_default: can120_default {
-		group1 {
-			psels = <NRF_PSEL(CAN_RX, 9, 4)>,
-				<NRF_PSEL(CAN_TX, 9, 5)>;
-		};
-	};
-
 	/omit-if-no-ref/ pwm130_default: pwm130_default {
 		group1 {
 			psels = <NRF_PSEL(PWM_OUT0, 9, 2)>;

--- a/boards/nordic/nrf9280pdk/nrf9280pdk_nrf9280_cpuapp.dts
+++ b/boards/nordic/nrf9280pdk/nrf9280pdk_nrf9280_cpuapp.dts
@@ -27,7 +27,6 @@
 		zephyr,ieee802154 = &cpuapp_ieee802154;
 		zephyr,bt-hci = &bt_hci_ipc0;
 		nordic,802154-spinel-ipc = &ipc0;
-		zephyr,canbus = &can120;
 	};
 
 	aliases {
@@ -273,16 +272,6 @@ ipc0: &cpuapp_cpurad_ipc {
 
 zephyr_udc0: &usbhs {
 	status = "okay";
-};
-
-&canpll {
-	status = "okay";
-};
-
-&can120 {
-	status = "okay";
-	pinctrl-0 = <&can120_default>;
-	pinctrl-names = "default";
 };
 
 &pwm130 {

--- a/boards/nordic/nrf9280pdk/nrf9280pdk_nrf9280_cpuapp.yaml
+++ b/boards/nordic/nrf9280pdk/nrf9280pdk_nrf9280_cpuapp.yaml
@@ -13,7 +13,6 @@ ram: 512
 flash: 1024
 supported:
   - adc
-  - can
   - counter
   - gpio
   - i2c

--- a/dts/common/nordic/nrf9280.dtsi
+++ b/dts/common/nordic/nrf9280.dtsi
@@ -445,28 +445,6 @@
 				global-domain-id = <12>;
 			};
 
-			can120: can@8d8000 {
-				compatible = "nordic,nrf-can";
-				reg = <0x8d8000 0x400>, <0x2fbef800 0x800>, <0x2fbe8000 0x7800>;
-				reg-names = "wrapper", "m_can", "message_ram";
-				interrupts = <216 NRF_DEFAULT_IRQ_PRIORITY>;
-				clocks = <&canpll>, <&hsfll120>;
-				clock-names = "auxpll", "hsfll";
-				bosch,mram-cfg = <0x0 28 8 3 3 0 1 1>;
-				status = "disabled";
-			};
-
-			can121: can@8db000 {
-				compatible = "nordic,nrf-can";
-				reg = <0x8db000 0x400>, <0x2fbf7800 0x800>, <0x2fbf0000 0x7800>;
-				reg-names = "wrapper", "m_can", "message_ram";
-				interrupts = <219 NRF_DEFAULT_IRQ_PRIORITY>;
-				clocks = <&canpll>, <&hsfll120>;
-				clock-names = "auxpll", "hsfll";
-				bosch,mram-cfg = <0x0 28 8 3 3 0 1 1>;
-				status = "disabled";
-			};
-
 			dppic120: dppic@8e1000 {
 				compatible = "nordic,nrf-dppic-global";
 				reg = <0x8e1000 0x1000>;

--- a/tests/kernel/gen_isr_table/testcase.yaml
+++ b/tests/kernel/gen_isr_table/testcase.yaml
@@ -72,6 +72,8 @@ tests:
     platform_exclude:
       - m2gl025_miv
       - adp_xc7k/ae350
+      - nrf9280pdk/nrf9280/cpuppr
+      - nrf9280pdk/nrf9280/cpuppr/xip
     filter: CONFIG_RISCV_PRIVILEGED
     extra_configs:
       - CONFIG_GEN_IRQ_VECTOR_TABLE=y


### PR DESCRIPTION
CAN is not ready yet for this SoC, so remove it for now.

Fixes #85065