### PR TITLE
Bluetooth: PACS: Remove BAP infix for pacs_register_param

### DIFF
--- a/include/zephyr/bluetooth/audio/pacs.h
+++ b/include/zephyr/bluetooth/audio/pacs.h
@@ -46,7 +46,7 @@ struct bt_pacs_cap {
 };
 
 /** Structure for registering PACS */
-struct bt_bap_pacs_register_param {
+struct bt_pacs_register_param {
 #if defined(CONFIG_BT_PAC_SNK) || defined(__DOXYGEN__)
 	/**
 	 * @brief Enables or disables registration of Sink PAC Characteristic.
@@ -58,7 +58,7 @@ struct bt_bap_pacs_register_param {
 	/**
 	 * @brief Enables or disables registration of Sink Location Characteristic.
 	 *
-	 * Registration of Sink Location is dependent on @ref bt_bap_pacs_register_param.snk_pac
+	 * Registration of Sink Location is dependent on @ref bt_pacs_register_param.snk_pac
 	 * also being set.
 	 */
 	bool snk_loc;
@@ -75,7 +75,7 @@ struct bt_bap_pacs_register_param {
 	/**
 	 * @brief Enables or disables registration of Source Location Characteristic.
 	 *
-	 * Registration of Source Location is dependent on @ref bt_bap_pacs_register_param.src_pac
+	 * Registration of Source Location is dependent on @ref bt_pacs_register_param.src_pac
 	 * also being set.
 	 */
 	bool src_loc;
@@ -118,7 +118,7 @@ void bt_pacs_cap_foreach(enum bt_audio_dir dir,
  * @retval -EALREADY Already registered
  * @retval -ENOEXEC Request was rejected by GATT
  */
-int bt_pacs_register(const struct bt_bap_pacs_register_param *param);
+int bt_pacs_register(const struct bt_pacs_register_param *param);
 
 /**
  * @brief Unregister the Published Audio Capability Service instance.

--- a/samples/bluetooth/bap_broadcast_sink/src/main.c
+++ b/samples/bluetooth/bap_broadcast_sink/src/main.c
@@ -1275,7 +1275,7 @@ static struct bt_le_per_adv_sync_cb bap_pa_sync_cb = {
 
 static int init(void)
 {
-	const struct bt_bap_pacs_register_param pacs_param = {
+	const struct bt_pacs_register_param pacs_param = {
 		.snk_pac = true,
 		.snk_loc = true,
 	};

--- a/samples/bluetooth/bap_unicast_server/src/main.c
+++ b/samples/bluetooth/bap_unicast_server/src/main.c
@@ -725,11 +725,11 @@ static int set_available_contexts(void)
 int main(void)
 {
 	struct bt_le_ext_adv *adv;
-	const struct bt_bap_pacs_register_param pacs_param = {
+	const struct bt_pacs_register_param pacs_param = {
 		.snk_pac = true,
 		.snk_loc = true,
 		.src_pac = true,
-		.src_loc = true
+		.src_loc = true,
 	};
 	int err;
 

--- a/samples/bluetooth/cap_acceptor/src/main.c
+++ b/samples/bluetooth/cap_acceptor/src/main.c
@@ -256,11 +256,11 @@ static int init_cap_acceptor(void)
 	static const struct bt_audio_codec_cap lc3_codec_cap = BT_AUDIO_CODEC_CAP_LC3(
 		SUPPORTED_FREQ, SUPPORTED_DURATION, MAX_CHAN_PER_STREAM, MIN_SDU, MAX_SDU,
 		FRAMES_PER_SDU, (SINK_CONTEXT | SOURCE_CONTEXT));
-	const struct bt_bap_pacs_register_param pacs_param = {
+	const struct bt_pacs_register_param pacs_param = {
 		.snk_pac = true,
 		.snk_loc = true,
 		.src_pac = true,
-		.src_loc = true
+		.src_loc = true,
 	};
 	int err;
 

--- a/samples/bluetooth/hap_ha/src/bap_unicast_sr.c
+++ b/samples/bluetooth/hap_ha/src/bap_unicast_sr.c
@@ -416,11 +416,11 @@ static struct bt_pacs_cap cap_source = {
 
 int bap_unicast_sr_init(void)
 {
-	const struct bt_bap_pacs_register_param pacs_param = {
+	const struct bt_pacs_register_param pacs_param = {
 		.snk_pac = true,
 		.snk_loc = true,
 		.src_pac = true,
-		.src_loc = true
+		.src_loc = true,
 	};
 	int err;
 

--- a/samples/bluetooth/tmap_bmr/src/bap_broadcast_sink.c
+++ b/samples/bluetooth/tmap_bmr/src/bap_broadcast_sink.c
@@ -313,7 +313,7 @@ static int reset(void)
 
 int bap_broadcast_sink_init(void)
 {
-	const struct bt_bap_pacs_register_param pacs_param = {
+	const struct bt_pacs_register_param pacs_param = {
 		.snk_pac = true,
 		.snk_loc = true,
 	};

--- a/samples/bluetooth/tmap_peripheral/src/bap_unicast_sr.c
+++ b/samples/bluetooth/tmap_peripheral/src/bap_unicast_sr.c
@@ -370,11 +370,11 @@ static struct bt_pacs_cap cap = {
 
 int bap_unicast_sr_init(void)
 {
-	const struct bt_bap_pacs_register_param pacs_param = {
+	const struct bt_pacs_register_param pacs_param = {
 		.snk_pac = true,
 		.snk_loc = true,
 		.src_pac = true,
-		.src_loc = true
+		.src_loc = true,
 	};
 	int err;
 

--- a/subsys/bluetooth/audio/pacs.c
+++ b/subsys/bluetooth/audio/pacs.c
@@ -725,7 +725,7 @@ static const struct bt_gatt_attr _pacs_attrs[] = BT_PACS_SERVICE_DEFINITION();
 static struct bt_gatt_attr pacs_attrs[] = BT_PACS_SERVICE_DEFINITION();
 static struct bt_gatt_service pacs_svc = (struct bt_gatt_service)BT_GATT_SERVICE(pacs_attrs);
 
-static void configure_pacs_char(const struct bt_bap_pacs_register_param *param)
+static void configure_pacs_char(const struct bt_pacs_register_param *param)
 {
 	const uint8_t first_attr_offset = 1U;
 	struct bt_gatt_attr *svc_attrs =
@@ -784,7 +784,7 @@ static void configure_pacs_char(const struct bt_bap_pacs_register_param *param)
 #endif /* CONFIG_BT_PAC_SRC */
 }
 
-static bool valid_pacs_register_param(const struct bt_bap_pacs_register_param *param)
+static bool valid_pacs_register_param(const struct bt_pacs_register_param *param)
 {
 	bool any_pac_registered = false;
 
@@ -820,7 +820,7 @@ static bool valid_pacs_register_param(const struct bt_bap_pacs_register_param *p
 	return true;
 }
 
-int bt_pacs_register(const struct bt_bap_pacs_register_param *param)
+int bt_pacs_register(const struct bt_pacs_register_param *param)
 {
 	int err = 0;
 

--- a/subsys/bluetooth/audio/shell/bap.c
+++ b/subsys/bluetooth/audio/shell/bap.c
@@ -3770,7 +3770,7 @@ static int cmd_init(const struct shell *sh, size_t argc, char *argv[])
 		CONFIG_BT_ASCS_MAX_ASE_SNK_COUNT,
 		CONFIG_BT_ASCS_MAX_ASE_SRC_COUNT
 	};
-	const struct bt_bap_pacs_register_param pacs_param = {
+	const struct bt_pacs_register_param pacs_param = {
 #if defined(CONFIG_BT_PAC_SNK)
 		.snk_pac = true,
 #endif /* CONFIG_BT_PAC_SNK */
@@ -3781,7 +3781,7 @@ static int cmd_init(const struct shell *sh, size_t argc, char *argv[])
 		.src_pac = true,
 #endif /* CONFIG_BT_PAC_SRC */
 #if defined(CONFIG_BT_PAC_SRC_LOC)
-		.src_loc = true
+		.src_loc = true,
 #endif /* CONFIG_BT_PAC_SRC_LOC */
 	};
 

--- a/tests/bluetooth/audio/pacs/src/main.c
+++ b/tests/bluetooth/audio/pacs/src/main.c
@@ -34,7 +34,7 @@ ZTEST_SUITE(pacs_test_suite, NULL, NULL, NULL, pacs_test_suite_after, NULL);
 
 /* Helper macro to define parameters ignoring unsupported features */
 #define PACS_REGISTER_PARAM(_snk_pac, _snk_loc, _src_pac, _src_loc)                                \
-	(struct bt_bap_pacs_register_param)                                                        \
+	(struct bt_pacs_register_param)                                                            \
 	{                                                                                          \
 		IF_ENABLED(CONFIG_BT_PAC_SNK, (.snk_pac = (_snk_pac),))                            \
 		IF_ENABLED(CONFIG_BT_PAC_SNK_LOC, (.snk_loc = (_snk_loc),))                        \
@@ -44,7 +44,7 @@ ZTEST_SUITE(pacs_test_suite, NULL, NULL, NULL, pacs_test_suite_after, NULL);
 
 static ZTEST(pacs_test_suite, test_pacs_register)
 {
-	const struct bt_bap_pacs_register_param pacs_params[] = {
+	const struct bt_pacs_register_param pacs_params[] = {
 #if defined(CONFIG_BT_PAC_SNK)
 		/* valid snk_pac combinations */
 		PACS_REGISTER_PARAM(true, true, true, true),
@@ -133,7 +133,7 @@ static ZTEST(pacs_test_suite, test_pacs_register_inval_null_param)
 
 static ZTEST(pacs_test_suite, test_pacs_register_inval_double_register)
 {
-	const struct bt_bap_pacs_register_param pacs_param =
+	const struct bt_pacs_register_param pacs_param =
 		PACS_REGISTER_PARAM(true, true, true, true);
 	int err;
 
@@ -146,7 +146,7 @@ static ZTEST(pacs_test_suite, test_pacs_register_inval_double_register)
 
 static ZTEST(pacs_test_suite, test_pacs_register_inval_snk_loc_without_snk_pac)
 {
-	const struct bt_bap_pacs_register_param pacs_param =
+	const struct bt_pacs_register_param pacs_param =
 		PACS_REGISTER_PARAM(false, true, true, true);
 	int err;
 
@@ -160,7 +160,7 @@ static ZTEST(pacs_test_suite, test_pacs_register_inval_snk_loc_without_snk_pac)
 
 static ZTEST(pacs_test_suite, test_pacs_register_inval_src_loc_without_src_pac)
 {
-	const struct bt_bap_pacs_register_param pacs_param =
+	const struct bt_pacs_register_param pacs_param =
 		PACS_REGISTER_PARAM(true, true, false, true);
 	int err;
 
@@ -174,7 +174,7 @@ static ZTEST(pacs_test_suite, test_pacs_register_inval_src_loc_without_src_pac)
 
 static ZTEST(pacs_test_suite, test_pacs_register_inval_no_pac)
 {
-	const struct bt_bap_pacs_register_param pacs_param =
+	const struct bt_pacs_register_param pacs_param =
 		PACS_REGISTER_PARAM(false, false, false, false);
 	int err;
 

--- a/tests/bluetooth/tester/src/audio/btp_bap.c
+++ b/tests/bluetooth/tester/src/audio/btp_bap.c
@@ -480,7 +480,7 @@ static const struct btp_handler bap_handlers[] = {
 
 uint8_t tester_init_pacs(void)
 {
-	const struct bt_bap_pacs_register_param pacs_param = {
+	const struct bt_pacs_register_param pacs_param = {
 #if defined(CONFIG_BT_PAC_SNK)
 		.snk_pac = true,
 #endif /* CONFIG_BT_PAC_SNK */
@@ -491,7 +491,7 @@ uint8_t tester_init_pacs(void)
 		.src_pac = true,
 #endif /* CONFIG_BT_PAC_SRC */
 #if defined(CONFIG_BT_PAC_SRC_LOC)
-		.src_loc = true
+		.src_loc = true,
 #endif /* CONFIG_BT_PAC_SRC_LOC */
 	};
 	int err;

--- a/tests/bsim/bluetooth/audio/src/bap_broadcast_sink_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_broadcast_sink_test.c
@@ -627,11 +627,11 @@ static int init(void)
 	static struct bt_pacs_cap vs_cap = {
 		.codec_cap = &vs_codec_cap,
 	};
-	const struct bt_bap_pacs_register_param pacs_param = {
+	const struct bt_pacs_register_param pacs_param = {
 		.snk_pac = true,
 		.snk_loc = true,
 		.src_pac = true,
-		.src_loc = true
+		.src_loc = true,
 	};
 	int err;
 

--- a/tests/bsim/bluetooth/audio/src/bap_unicast_server_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_unicast_server_test.c
@@ -407,7 +407,7 @@ static void init(void)
 	static struct bt_pacs_cap cap = {
 		.codec_cap = &lc3_codec_cap,
 	};
-	const struct bt_bap_pacs_register_param pacs_param = {
+	const struct bt_pacs_register_param pacs_param = {
 #if defined(CONFIG_BT_PAC_SNK)
 		.snk_pac = true,
 #endif /* CONFIG_BT_PAC_SNK */
@@ -418,7 +418,7 @@ static void init(void)
 		.src_pac = true,
 #endif /* CONFIG_BT_PAC_SRC */
 #if defined(CONFIG_BT_PAC_SRC_LOC)
-		.src_loc = true
+		.src_loc = true,
 #endif /* CONFIG_BT_PAC_SRC_LOC */
 	};
 	int err;

--- a/tests/bsim/bluetooth/audio/src/cap_acceptor_test.c
+++ b/tests/bsim/bluetooth/audio/src/cap_acceptor_test.c
@@ -648,7 +648,7 @@ static void init(void)
 		BT_AUDIO_CODEC_CAP_FREQ_ANY, BT_AUDIO_CODEC_CAP_DURATION_ANY,
 		BT_AUDIO_CODEC_CAP_CHAN_COUNT_SUPPORT(1, 2), 30, 240, 2,
 		(BT_AUDIO_CONTEXT_TYPE_CONVERSATIONAL | BT_AUDIO_CONTEXT_TYPE_MEDIA));
-	const struct bt_bap_pacs_register_param pacs_param = {
+	const struct bt_pacs_register_param pacs_param = {
 #if defined(CONFIG_BT_PAC_SNK)
 		.snk_pac = true,
 #endif /* CONFIG_BT_PAC_SNK */
@@ -659,7 +659,7 @@ static void init(void)
 		.src_pac = true,
 #endif /* CONFIG_BT_PAC_SRC */
 #if defined(CONFIG_BT_PAC_SRC_LOC)
-		.src_loc = true
+		.src_loc = true,
 #endif /* CONFIG_BT_PAC_SRC_LOC */
 	};
 	int err;

--- a/tests/bsim/bluetooth/audio/src/gmap_ugt_test.c
+++ b/tests/bsim/bluetooth/audio/src/gmap_ugt_test.c
@@ -363,7 +363,7 @@ static void test_main(void)
 		.codec_cap = &codec_cap,
 	};
 	struct bt_le_ext_adv *ext_adv;
-	const struct bt_bap_pacs_register_param pacs_param = {
+	const struct bt_pacs_register_param pacs_param = {
 #if defined(CONFIG_BT_PAC_SNK)
 		.snk_pac = true,
 #endif /* CONFIG_BT_PAC_SNK */
@@ -374,7 +374,7 @@ static void test_main(void)
 		.src_pac = true,
 #endif /* CONFIG_BT_PAC_SRC */
 #if defined(CONFIG_BT_PAC_SRC_LOC)
-		.src_loc = true
+		.src_loc = true,
 #endif /* CONFIG_BT_PAC_SRC_LOC */
 	};
 	int err;

--- a/tests/bsim/bluetooth/audio/src/pacs_notify_server_test.c
+++ b/tests/bsim/bluetooth/audio/src/pacs_notify_server_test.c
@@ -159,11 +159,11 @@ static void test_main(void)
 	int err;
 	enum bt_audio_context available, available_for_conn;
 	struct bt_le_ext_adv *ext_adv;
-	const struct bt_bap_pacs_register_param pacs_param = {
+	const struct bt_pacs_register_param pacs_param = {
 		.snk_pac = true,
 		.snk_loc = true,
 		.src_pac = true,
-		.src_loc = true
+		.src_loc = true,
 	};
 
 	LOG_DBG("Enabling Bluetooth");

--- a/tests/bsim/bluetooth/audio/src/pbp_public_broadcast_sink_test.c
+++ b/tests/bsim/bluetooth/audio/src/pbp_public_broadcast_sink_test.c
@@ -197,11 +197,11 @@ static int reset(void)
 
 static int init(void)
 {
-	const struct bt_bap_pacs_register_param pacs_param = {
+	const struct bt_pacs_register_param pacs_param = {
 		.snk_pac = true,
 		.snk_loc = true,
 		.src_pac = true,
-		.src_loc = true
+		.src_loc = true,
 	};
 	int err;
 


### PR DESCRIPTION
Since the PACS service is not part of the bt_bap API it should not use the bt_bap prefix, and instead just be bt_pacs like the rest of the PACS API.