### PR TITLE
boards: nordic: nrf54l15dk: Set the right --device flag for JLink

### DIFF
--- a/boards/nordic/nrf54l15dk/board.cmake
+++ b/boards/nordic/nrf54l15dk/board.cmake
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 if(CONFIG_SOC_NRF54L05_CPUAPP OR CONFIG_SOC_NRF54L10_CPUAPP OR CONFIG_SOC_NRF54L15_CPUAPP)
-  board_runner_args(jlink "--device=cortex-m33" "--speed=4000")
+	board_runner_args(jlink "--device=nRF54L15_M33" "--speed=4000")
 elseif(CONFIG_SOC_NRF54L05_CPUFLPR OR CONFIG_SOC_NRF54L10_CPUFLPR OR CONFIG_SOC_NRF54L15_CPUFLPR)
   set(JLINKSCRIPTFILE ${CMAKE_CURRENT_LIST_DIR}/support/nrf54l_05_10_15_cpuflpr.JLinkScript)
   board_runner_args(jlink "--device=RISC-V" "--speed=4000" "-if SW" "--tool-opt=-jlinkscriptfile ${JLINKSCRIPTFILE}")


### PR DESCRIPTION
Starting in version 8.10f, Segger's JLink now supports the nRF54L15's Cortex-M33 core natively, being able to flash it and debug it properly. Use this new support in the Zephyr built-in board support.