### PR TITLE
drivers: flash: spi_nor: swap `depends on` and `help` in Kconfig.nor

### DIFF
--- a/drivers/flash/Kconfig.nor
+++ b/drivers/flash/Kconfig.nor
@@ -71,10 +71,10 @@ config SPI_NOR_SLEEP_WHILE_WAITING_UNTIL_READY
 config SPI_NOR_SLEEP_ERASE_MS
 	int "Delay between polls while waiting for an erase operation in ms"
 	default 50
+	depends on SPI_NOR_SLEEP_WHILE_WAITING_UNTIL_READY
 	help
 	  The delay between polling while waiting for the flash to finish
 	  an erase operation.
-	depends on SPI_NOR_SLEEP_WHILE_WAITING_UNTIL_READY
 
 
 config SPI_NOR_FLASH_LAYOUT_PAGE_SIZE


### PR DESCRIPTION
Fix mistake introduced in #84988 : change order of `depends on` and `help`, so `help` comes last.