### PR TITLE
boards: st: nucleo_n657x0: added missing led aliases.

### DIFF
--- a/boards/st/nucleo_n657x0_q/nucleo_n657x0_q_common.dtsi
+++ b/boards/st/nucleo_n657x0_q/nucleo_n657x0_q_common.dtsi
@@ -46,6 +46,8 @@
 
 	aliases {
 		led0 = &green_led;
+		led1 = &blue_led;
+		led2 = &red_led;
 		sw0 = &user_button;
 	};
 };


### PR DESCRIPTION
Fixes 'samples/basic/threads' example build.