### PR TITLE
net: http_client: Ignore message body on 101 Switching Protocols reply

### DIFF
--- a/subsys/net/lib/http/http_client.c
+++ b/subsys/net/lib/http/http_client.c
@@ -23,6 +23,7 @@ LOG_MODULE_REGISTER(net_http_client, CONFIG_NET_HTTP_LOG_LEVEL);
 #include <zephyr/net/net_ip.h>
 #include <zephyr/net/socket.h>
 #include <zephyr/net/http/client.h>
+#include <zephyr/net/http/status.h>
 
 #include "net_private.h"
 
@@ -325,6 +326,11 @@ static int on_headers_complete(struct http_parser *parser)
 	if (req->internal.response.http_cb &&
 	    req->internal.response.http_cb->on_headers_complete) {
 		req->internal.response.http_cb->on_headers_complete(parser);
+	}
+
+	if (parser->status_code == HTTP_101_SWITCHING_PROTOCOLS) {
+		NET_DBG("Switching protocols, skipping body");
+		return 1;
 	}
 
 	if (parser->status_code >= 500 && parser->status_code < 600) {


### PR DESCRIPTION
When HTTP 101 Switching Protocols response is received, force the HTTP parser to ignore any potential message body payload (which should already belong to the new protocol).

This is usually not an issue, as Switching Protocols reply should contain headers only, however it's been observed that some servers specify chunked transfer-encoding header which tricks the parser to wait for payload event though it never arrives.

Fixes #85215