### PR TITLE
scripts: runners: nrf54H/92: Use RESET_HARD instead of RESET_SYSTEM

### DIFF
--- a/scripts/west_commands/runners/nrf_common.py
+++ b/scripts/west_commands/runners/nrf_common.py
@@ -418,11 +418,12 @@ class NrfBinaryRunner(ZephyrBinaryRunner):
 
 
     def reset_target(self):
+        sw_reset = "RESET_HARD" if self.family in ('nrf54h', 'nrf92') else "RESET_SYSTEM"
         # Default to soft reset on nRF52 only, because ICs in these series can
         # reconfigure the reset pin as a regular GPIO
-        default = "RESET_SYSTEM" if self.family == 'nrf52' else "RESET_PIN"
-        kind = ("RESET_SYSTEM" if self.softreset else "RESET_PIN" if
-               self.pinreset else default)
+        default = sw_reset if self.family == 'nrf52' else "RESET_PIN"
+        kind = (sw_reset if self.softreset else "RESET_PIN" if
+                self.pinreset else default)
 
         if self.family == 'nrf52' and kind == "RESET_PIN":
             # Write to the UICR enabling nRESET in the corresponding pin


### PR DESCRIPTION
The nRF54H and the nRF92 series do not support the RESET_SYSTEM reset kind. Instead one must use RESET_HARD, which this patch now implements.