### PR TITLE
drivers: udc_dwc2: Avoid unnecessary context switches

### DIFF
--- a/drivers/usb/udc/udc_dwc2.c
+++ b/drivers/usb/udc/udc_dwc2.c
@@ -2318,12 +2318,14 @@ static int dwc2_driver_preinit(const struct device *dev)
 
 static void udc_dwc2_lock(const struct device *dev)
 {
+	k_sched_lock();
 	udc_lock_internal(dev, K_FOREVER);
 }
 
 static void udc_dwc2_unlock(const struct device *dev)
 {
 	udc_unlock_internal(dev);
+	k_sched_unlock();
 }
 
 static void dwc2_on_bus_reset(const struct device *dev)


### PR DESCRIPTION
DWC2 thread must acquire UDC mutex before accessing shared resources (peripheral registers and software data structures). Whenever software enqueues a buffer, the caller first obtains mutex, adds the buffer to the list, posts event to wake up DWC2 thread and releases mutex. If DWC2 thread has higher priority than the task currently holding a mutex, there will be two completely unnecessary task switches: DWC2 will switch in, try to obtain mutex, and then the control will be returned to the mutex holder.

Avoid the unnecessary task switches by suspending the DWC2 thread whenever the mutex is held by other thread. The only potential downside of doing this is the fact that the task holding mutex priority remains unchanged when there are any events posted to DWC2 thread, i.e. priority inheritance won't happen.