### PR TITLE
STM32N6 : Add the support of the USB_NEXT

### DIFF
--- a/boards/st/nucleo_n657x0_q/doc/index.rst
+++ b/boards/st/nucleo_n657x0_q/doc/index.rst
@@ -62,6 +62,36 @@ Supported Features
 
 .. zephyr:board-supported-hw::
 
+USB:
+====
+
+The USB pin assignments on the STM32N657XX microcontroller are immutable. This means that the specific
+pins designated for USB functionality are fixed and cannot be changed or reassigned to other functions,
+ensuring consistent and reliable USB communication.
+
+USB PIN (IOs)
+=============
+
++------------------+--------------------------------------+
+| Name             | Description                          |
++==========================+==============================+
+| OTG1_HSDM        | USB OTG1 High-Speed Data- (negative) |
++--------------------------+------------------------------+
+| OTG1_HSDP        | USB OTG1 High-Speed Data+ (positive) |
++---------+-----------------+-----------------------------+
+| OTG1_ID          | USB OTG1 ID Pin                      |
++--------------------------+------------------------------+
+| OTG1_TXRTUNE     | USB OTG1 Transmit Retune             |
++---------+-----------------+-----------------------------+
+| OTG2_HSDM        | USB OTG2 High-Speed Data- (negative) |
++--------------------------+------------------------------+
+| OTG2_HSDP        | USB OTG2 High-Speed Data+ (positive) |
++---------+-----------------+-----------------------------+
+| OTG2_ID          | USB OTG2 ID Pin                      |
++--------------------------+------------------------------+
+| OTG2_TXRTUNE     | USB OTG2 Transmit Retune             |
++---------+-----------------+-----------------------------+
+
 Connections and IOs
 ===================
 

--- a/boards/st/nucleo_n657x0_q/nucleo_n657x0_q_common.dtsi
+++ b/boards/st/nucleo_n657x0_q/nucleo_n657x0_q_common.dtsi
@@ -54,6 +54,12 @@
 	};
 };
 
+&clk_hse {
+	hse-div2;
+	clock-frequency = <DT_FREQ_M(48)>;
+	status = "okay";
+};
+
 &clk_hsi {
 	hsi-div = <1>;
 	status = "okay";
@@ -172,5 +178,8 @@
 	pinctrl-0 = <&usart3_tx_pd8 &usart3_rx_pd9>;
 	pinctrl-names = "default";
 	current-speed = <115200>;
+};
+
+zephyr_udc0: &usbotg_hs1 {
 	status = "okay";
 };

--- a/boards/st/nucleo_n657x0_q/twister.yaml
+++ b/boards/st/nucleo_n657x0_q/twister.yaml
@@ -15,6 +15,7 @@ supported:
   - spi
   - uart
   - usb_device
+  - usbd
 vendor: st
 variants:
   nucleo_n657x0_q/stm32n657xx:

--- a/boards/st/nucleo_n657x0_q/twister.yaml
+++ b/boards/st/nucleo_n657x0_q/twister.yaml
@@ -14,6 +14,7 @@ supported:
   - gpio
   - spi
   - uart
+  - usb_device
 vendor: st
 variants:
   nucleo_n657x0_q/stm32n657xx:

--- a/boards/st/stm32n6570_dk/doc/index.rst
+++ b/boards/st/stm32n6570_dk/doc/index.rst
@@ -66,6 +66,36 @@ Supported Features
 
 .. zephyr:board-supported-hw::
 
+USB:
+====
+
+The USB pin assignments on the STM32N657XX microcontroller are immutable. This means that the specific
+pins designated for USB functionality are fixed and cannot be changed or reassigned to other functions,
+ensuring consistent and reliable USB communication.
+
+USB PIN (IOs)
+=============
+
++------------------+--------------------------------------+
+| Name             | Description                          |
++==========================+==============================+
+| OTG1_HSDM        | USB OTG1 High-Speed Data- (negative) |
++--------------------------+------------------------------+
+| OTG1_HSDP        | USB OTG1 High-Speed Data+ (positive) |
++---------+-----------------+-----------------------------+
+| OTG1_ID          | USB OTG1 ID Pin                      |
++--------------------------+------------------------------+
+| OTG1_TXRTUNE     | USB OTG1 Transmit Retune             |
++---------+-----------------+-----------------------------+
+| OTG2_HSDM        | USB OTG2 High-Speed Data- (negative) |
++--------------------------+------------------------------+
+| OTG2_HSDP        | USB OTG2 High-Speed Data+ (positive) |
++---------+-----------------+-----------------------------+
+| OTG2_ID          | USB OTG2 ID Pin                      |
++--------------------------+------------------------------+
+| OTG2_TXRTUNE     | USB OTG2 Transmit Retune             |
++---------+-----------------+-----------------------------+
+
 Connections and IOs
 ===================
 

--- a/boards/st/stm32n6570_dk/stm32n6570_dk_common.dtsi
+++ b/boards/st/stm32n6570_dk/stm32n6570_dk_common.dtsi
@@ -36,6 +36,12 @@
 	};
 };
 
+&clk_hse {
+	hse-div2;
+	clock-frequency = <DT_FREQ_M(48)>;
+	status = "okay";
+};
+
 &clk_hsi {
 	hsi-div = <1>;
 	status = "okay";
@@ -154,5 +160,8 @@
 	pinctrl-0 = <&usart2_tx_pd5 &usart2_rx_pf6>;
 	pinctrl-names = "default";
 	current-speed = <115200>;
+};
+
+zephyr_udc0: &usbotg_hs1 {
 	status = "okay";
 };

--- a/boards/st/stm32n6570_dk/twister.yaml
+++ b/boards/st/stm32n6570_dk/twister.yaml
@@ -15,6 +15,7 @@ supported:
   - gpio
   - spi
   - uart
+  - usb_device
 variants:
   stm32n6570_dk/stm32n657xx:
     twister: false

--- a/boards/st/stm32n6570_dk/twister.yaml
+++ b/boards/st/stm32n6570_dk/twister.yaml
@@ -16,6 +16,7 @@ supported:
   - spi
   - uart
   - usb_device
+  - usbd
 variants:
   stm32n6570_dk/stm32n657xx:
     twister: false

--- a/dts/arm/st/n6/stm32n6.dtsi
+++ b/dts/arm/st/n6/stm32n6.dtsi
@@ -640,6 +640,27 @@
 			dma-offset = <0>;
 			status = "disabled";
 		};
+
+		usbotg_hs1: otghs@58040000 {
+			compatible = "st,stm32n6-otghs", "st,stm32-otghs";
+			reg = <0x58040000 0x2000>;
+			interrupts = <177 0>;
+			interrupt-names = "otghs";
+			num-bidir-endpoints = <9>;
+			ram-size = <4096>;
+			maximum-speed = "high-speed";
+			clocks = <&rcc STM32_CLOCK(AHB5, 26)>,
+				 <&rcc STM32_SRC_HSE OTGPHY1CKREF_SEL(1)>;
+			phys = <&usbphyc1>;
+			status = "disabled";
+		};
+
+		usbphyc1: usbphyc@5803fc00 {
+			compatible = "st,stm32-usbphyc";
+			reg = <0x5803FC00 0x400>;
+			clocks = <&rcc STM32_CLOCK(AHB5, 27)>;
+			#phy-cells = <0>;
+		};
 	};
 };
 

--- a/dts/bindings/usb/st,stm32-otghs-common.yaml
+++ b/dts/bindings/usb/st,stm32-otghs-common.yaml
@@ -1,0 +1,27 @@
+# Copyright (c) 2025, STMicroelectronics
+# SPDX-License-Identifier: Apache-2.0
+
+# Common fields for STM32 OTGHS controller
+
+include: [usb-ep.yaml, pinctrl-device.yaml]
+
+properties:
+  reg:
+    required: true
+
+  interrupts:
+    required: true
+
+  ram-size:
+    type: int
+    required: true
+    description: |
+      Size of USB dedicated RAM. STM32 SOC's reference
+      manual defines a shared FIFO size.
+
+  phys:
+    type: phandle
+    description: PHY provider specifier
+
+  clocks:
+    required: true

--- a/dts/bindings/usb/st,stm32-otghs.yaml
+++ b/dts/bindings/usb/st,stm32-otghs.yaml
@@ -1,35 +1,16 @@
 # Copyright (c) 2017, I-SENSE group of ICCS
+# Copyright (c) 2025, STMicroelectronics
 # SPDX-License-Identifier: Apache-2.0
 
 description: STM32 OTGHS controller
 
 compatible: "st,stm32-otghs"
 
-include: [usb-ep.yaml, pinctrl-device.yaml]
+include: st,stm32-otghs-common.yaml
 
 properties:
-  reg:
-    required: true
-
-  interrupts:
-    required: true
-
   pinctrl-0:
     required: true
 
   pinctrl-names:
-    required: true
-
-  ram-size:
-    type: int
-    required: true
-    description: |
-      Size of USB dedicated RAM. STM32 SOC's reference
-      manual defines a shared FIFO size.
-
-  phys:
-    type: phandle
-    description: PHY provider specifier
-
-  clocks:
     required: true

--- a/dts/bindings/usb/st,stm32n6-otghs.yaml
+++ b/dts/bindings/usb/st,stm32n6-otghs.yaml
@@ -1,0 +1,13 @@
+# Copyright (c) 2025, STMicroelectronics
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  STM32N6 OTGHS controller
+
+  In the STM32N6 series, the `pinctrl-0` and `pinctrl-names` properties are not required
+  for the USB OTG HS peripheral configuration. This is because the pin multiplexing
+  for the USB OTG HS peripheral are handled automatically by the hardware.
+
+compatible: "st,stm32n6-otghs"
+
+include: st,stm32-otghs-common.yaml


### PR DESCRIPTION
Add the support of the USB_NEXT

Based on [PR](https://github.com/zephyrproject-rtos/zephyr/pull/84976)