### PR TITLE
kernel: mmu: update dependencies for x86

### DIFF
--- a/kernel/Kconfig.vm
+++ b/kernel/Kconfig.vm
@@ -100,7 +100,7 @@ endif # KERNEL_VM_SUPPORT
 
 menuconfig MMU
 	bool "MMU features"
-	depends on CPU_HAS_MMU
+	depends on CPU_HAS_MMU && (!X86 || (X86 && X86_MMU))
 	select KERNEL_VM_SUPPORT
 	help
 	  This option is enabled when the CPU's memory management unit is active

--- a/tests/posix/xsi_realtime/testcase.yaml
+++ b/tests/posix/xsi_realtime/testcase.yaml
@@ -13,10 +13,6 @@ common:
   platform_exclude:
     # linker_zephyr_pre0.cmd:140: syntax error (??)
     - qemu_xtensa/dc233c
-    # CONFIG_MMU=y but no arch_mem_map() or arch_mem_unmap()
-    - intel_ish_5_4_1
-    - intel_ish_5_6_0
-    - intel_ish_5_8_0
     - native_sim
     - native_sim/native/64
 tests:


### PR DESCRIPTION
* kernel: mmu: update dependencies for x86
* test: posix: xsi_realtime: do not exclude `intel_ish` platforms

Currently, some x86 platforms do not support certain MMU operations out-of-the-box.

* `intel_ish_5_4_1`
* `intel_ish_5_6_0`
* `intel_ish_5_8_0`

Previously, linking would fail because `arch_mem_map()` and `arch_mem_unmap()` were not implemented on these platforms.

I don't claim to understand all of the nuances of the x86 arch by any means, so this change is mainly intended to fix a
regression by only allowing `CONFIG_MMU` to be enabled on x86 when `CONFIG_X86_MMU` is also enabled, which ensures that the arch-specific `arch_mem_map()` and `arch_mem_unmap()` symbols are pulled in when possible.

Fixes #85305