### PR TITLE
logging: fix corner case crashes in `log_flush()`

### DIFF
--- a/subsys/logging/log_core.c
+++ b/subsys/logging/log_core.c
@@ -563,9 +563,9 @@ bool z_impl_log_process(void)
 	msg = z_log_msg_claim(&backoff);
 
 	if (msg) {
-		atomic_dec(&buffered_cnt);
 		msg_process(msg);
 		z_log_msg_free(msg);
+		atomic_dec(&buffered_cnt);
 	} else if (CONFIG_LOG_PROCESSING_LATENCY_US > 0 && !K_TIMEOUT_EQ(backoff, K_NO_WAIT)) {
 		/* If backoff is requested, it means that there are pending
 		 * messages but they are too new and processing shall back off
@@ -1002,10 +1002,9 @@ static int enable_logger(void)
 void log_flush(void)
 {
 	if (IS_ENABLED(CONFIG_LOG_PROCESS_THREAD)) {
-		while (log_data_pending()) {
+		while (atomic_get(&buffered_cnt)) {
 			k_sleep(K_MSEC(10));
 		}
-		k_sleep(K_MSEC(10));
 	} else {
 		while (LOG_PROCESS()) {
 		}


### PR DESCRIPTION
The `log_flush()` function is used to wait for all pending log messages to be processed by the background thread. This is performed by polling the `log_data_pending()` function, which scans all available buffers.

The log core already provides a `buffered_cnt` variable (added in 1ba542c352323688a8e4d1511e9f824c94df5fc7) that keeps track of the number of pending messages for log batching purposes. This variable is updated atomically and could be a more efficient implementation for that check.

This commit moves the `buffered_cnt` decrement _after_ the message processing and buffer release, to ensure that the variable reflects the number of pending messages at any moment in time.

The `log_data_pending()` function is then replaced with a direct check of the `buffered_cnt` variable.