### PR TITLE
mm: tlb: Fix mmu support in update page flags function

### DIFF
--- a/drivers/mm/mm_drv_intel_adsp_mtl_tlb.c
+++ b/drivers/mm/mm_drv_intel_adsp_mtl_tlb.c
@@ -462,7 +462,7 @@ int sys_mm_drv_update_page_flags(void *virt, uint32_t flags)
 	tlb_entries[entry_idx] = entry;
 
 #ifdef CONFIG_MMU
-	arch_mem_map(virt, tlb_entry_to_pa(entry), CONFIG_MM_DRV_PAGE_SIZE, flags);
+	arch_mem_map(virt, va, CONFIG_MM_DRV_PAGE_SIZE, flags);
 #endif
 
 out:


### PR DESCRIPTION
Revise the sys_mm_drv_update_page_flags function to pass a cacheable virtual address as the second parameter to the arch_mem_map function. This approach aligns with the implementation of the sys_mm_drv_map_page function.