### PR TITLE
Update picolibc module to version 1.8.9

### DIFF
--- a/include/zephyr/posix/posix_features.h
+++ b/include/zephyr/posix/posix_features.h
@@ -245,6 +245,13 @@
 /* #define _XOPEN_UNIX (-1L) */
 /* #define _XOPEN_UUCP (-1L) */
 
+#if _POSIX_C_SOURCE >= 200809L && (__PICOLIBC__ > 1 ||			\
+(__PICOLIBC__ == 1 && (__PICOLIBC_MINOR__ > 8 ||			\
+__PICOLIBC_MINOR__ == 8 && __PICOLIBC_PATCHLEVEL__ >= 9)))
+/* Use picolibc's limits.h when building POSIX code */
+#include <limits.h>
+#else
+
 /* Maximum values */
 #define _POSIX_CLOCKRES_MIN (20000000L)
 
@@ -306,6 +313,8 @@
 #define _XOPEN_IOV_MAX                      (16)
 #define _XOPEN_NAME_MAX                     (255)
 #define _XOPEN_PATH_MAX                     (1024)
+
+#endif /* __PICOLIBC__ */
 
 /* Other invariant values */
 #define NL_LANGMAX (14)

--- a/lib/libc/picolibc/Kconfig
+++ b/lib/libc/picolibc/Kconfig
@@ -161,12 +161,14 @@ config PICOLIBC_IO_MINIMAL_LONG_LONG
 	  Include long long support in the minimal picolibc printf code
 
 config PICOLIBC_LOCALE_INFO
-	bool "support locales in libc functions"
+	bool "support locale info in libc functions [DEPRECATED]"
+	select DEPRECATED
 	help
 	  Includes code for basic locale support
 
 config PICOLIBC_LOCALE_EXTENDED_INFO
-	bool "support extended locales in libc functions"
+	bool "support extended locale info in libc functions [DEPRECATED]"
+	select DEPRECATED
 	help
 	  Includes code for extended locale support
 

--- a/west.yml
+++ b/west.yml
@@ -336,7 +336,7 @@ manifest:
         - debug
     - name: picolibc
       path: modules/lib/picolibc
-      revision: 82d62ed1ac55b4e34a12d0390aced2dc9af13fc9
+      revision: 0b02b9779a5cc6ed3eebc760d54e9befeb255f31
     - name: segger
       revision: cf56b1d9c80f81a26e2ac5727c9cf177116a4692
       path: modules/debug/segger


### PR DESCRIPTION
Change west manifest to pull version 1.8.9. Update picolibc Kconfig to deprecate a couple of no-longer-used (and never useful) options.