### PR TITLE
kernel/sched: Panic after aborting essential thread, not before

### DIFF
--- a/tests/kernel/threads/thread_apis/src/test_essential_thread.c
+++ b/tests/kernel/threads/thread_apis/src/test_essential_thread.c
@@ -67,8 +67,6 @@ void k_sys_fatal_error_handler(unsigned int reason,
 	ARG_UNUSED(reason);
 
 	fatal_error_signaled = true;
-
-	z_thread_essential_clear(_current);
 }
 
 static void abort_thread_entry(void *p1, void *p2, void *p3)
@@ -77,16 +75,19 @@ static void abort_thread_entry(void *p1, void *p2, void *p3)
 	ARG_UNUSED(p2);
 	ARG_UNUSED(p3);
 
-	z_thread_essential_set(_current);
-
 	if (z_is_thread_essential(_current)) {
-		k_busy_wait(100);
+		k_msleep(200);
 	} else {
 		zassert_unreachable("The thread is not set as essential");
 	}
 
-	k_sem_give(&sync_sem);
-	k_sleep(K_FOREVER);
+	zassert_true(false, "Should not reach this line");
+}
+
+static void abort_thread_self(void *p1, void *p2, void *p3)
+{
+	k_thread_abort(k_current_get());
+	zassert_true(false, "Should not reach this line");
 }
 
 /**
@@ -102,13 +103,22 @@ static void abort_thread_entry(void *p1, void *p2, void *p3)
 
 ZTEST(threads_lifecycle, test_essential_thread_abort)
 {
-	k_tid_t tid = k_thread_create(&kthread_thread1, kthread_stack, STACKSIZE,
-				      abort_thread_entry,
-				      NULL, NULL, NULL, K_PRIO_PREEMPT(0), 0,
-				      K_NO_WAIT);
+	fatal_error_signaled = false;
+	k_thread_create(&kthread_thread1, kthread_stack, STACKSIZE,
+			abort_thread_entry,
+			NULL, NULL, NULL, K_PRIO_PREEMPT(0), K_ESSENTIAL,
+			K_NO_WAIT);
 
-	k_sem_take(&sync_sem, K_FOREVER);
-	k_thread_abort(tid);
+	k_msleep(100);
+	k_thread_abort(&kthread_thread1);
+	zassert_true(fatal_error_signaled, "fatal error was not signaled");
 
+	fatal_error_signaled = false;
+	k_thread_create(&kthread_thread1, kthread_stack, STACKSIZE,
+			abort_thread_self,
+			NULL, NULL, NULL, K_PRIO_PREEMPT(0), K_ESSENTIAL,
+			K_NO_WAIT);
+
+	k_msleep(100);
 	zassert_true(fatal_error_signaled, "fatal error was not signaled");
 }


### PR DESCRIPTION
The essential thread check and panic happens at the top of k_thread_abort().  This is arguably a performance bug: the system is going to blow up anyway no matter where we put the test, we shouldn'q add instructions to the path taken by systems that DON'T blow up.

But really it's more of a testability/robustness glitch: if you have a fatal error handler that wants to catch this panic (say, a test using ztest_set_fault_valid()), then the current code will panic and early-exit BEFORE THE THREAD IS DEAD.  And so it won't actually die, and will continue on causing mayhem when presumably the handler code expected it to have been aborted.

It's sort of an unanswerable question as to what the "right" behavior is here (the system is, after all, supposed to have panicked!).  But this seems preferable for definable practical reasons.

Kill the thread, then panic.

Fixes: #84460