### PR TITLE
soc: nxp: mcxw: Enable RTT Support

### DIFF
--- a/soc/nxp/mcx/mcxw/Kconfig
+++ b/soc/nxp/mcx/mcxw/Kconfig
@@ -15,6 +15,7 @@ config SOC_SERIES_MCXW
 	select SOC_RESET_HOOK
 	select SOC_EARLY_INIT_HOOK
 	select CLOCK_CONTROL
+	select HAS_SEGGER_RTT if ZEPHYR_SEGGER_MODULE
 
 	rsource "../../common/Kconfig.nbu"
 


### PR DESCRIPTION
Enabled RTT Support for the mcxw soc devices.