### PR TITLE
more ring buffer cleanups/improvements

### DIFF
--- a/include/zephyr/sys/ring_buffer.h
+++ b/include/zephyr/sys/ring_buffer.h
@@ -29,11 +29,17 @@ extern "C" {
 /* The limit is used by algorithm for distinguishing between empty and full
  * state.
  */
-#define RING_BUFFER_MAX_SIZE 0x80000000U
-#define RING_BUFFER_SIZE_ASSERT_MSG \
-	"Size too big"
+#ifdef CONFIG_RING_BUFFER_LARGE
+typedef uint32_t ring_buf_idx_t;
+#define RING_BUFFER_MAX_SIZE (UINT32_MAX / 2)
+#else
+typedef uint16_t ring_buf_idx_t;
+#define RING_BUFFER_MAX_SIZE (UINT16_MAX / 2)
+#endif
 
-struct ring_buf_index { int32_t head, tail, base; };
+#define RING_BUFFER_SIZE_ASSERT_MSG "Size too big"
+
+struct ring_buf_index { ring_buf_idx_t head, tail, base; };
 
 /** @endcond */
 
@@ -61,7 +67,7 @@ int ring_buf_area_finish(struct ring_buf *buf, struct ring_buf_index *ring,
  *
  * Any value other than 0 makes sense only in validation testing context.
  */
-static inline void ring_buf_internal_reset(struct ring_buf *buf, int32_t value)
+static inline void ring_buf_internal_reset(struct ring_buf *buf, ring_buf_idx_t value)
 {
 	buf->put.head = buf->put.tail = buf->put.base = value;
 	buf->get.head = buf->get.tail = buf->get.base = value;
@@ -90,7 +96,7 @@ static inline void ring_buf_internal_reset(struct ring_buf *buf, int32_t value)
  * @param size8 Size of ring buffer (in bytes).
  */
 #define RING_BUF_DECLARE(name, size8) \
-	BUILD_ASSERT(size8 < RING_BUFFER_MAX_SIZE,\
+	BUILD_ASSERT(size8 <= RING_BUFFER_MAX_SIZE,\
 		RING_BUFFER_SIZE_ASSERT_MSG); \
 	static uint8_t __noinit _ring_buffer_data_##name[size8]; \
 	struct ring_buf name = RING_BUF_INIT(_ring_buffer_data_##name, size8)
@@ -111,7 +117,7 @@ static inline void ring_buf_internal_reset(struct ring_buf *buf, int32_t value)
  * @param size32 Size of ring buffer (in 32-bit words).
  */
 #define RING_BUF_ITEM_DECLARE(name, size32) \
-	BUILD_ASSERT((size32) < RING_BUFFER_MAX_SIZE / 4,\
+	BUILD_ASSERT((size32) <= RING_BUFFER_MAX_SIZE / 4, \
 		RING_BUFFER_SIZE_ASSERT_MSG); \
 	static uint32_t __noinit _ring_buffer_data_##name[size32]; \
 	struct ring_buf name = { \
@@ -168,7 +174,7 @@ static inline void ring_buf_init(struct ring_buf *buf,
 				 uint32_t size,
 				 uint8_t *data)
 {
-	__ASSERT(size < RING_BUFFER_MAX_SIZE, RING_BUFFER_SIZE_ASSERT_MSG);
+	__ASSERT(size <= RING_BUFFER_MAX_SIZE, RING_BUFFER_SIZE_ASSERT_MSG);
 
 	buf->size = size;
 	buf->buffer = data;
@@ -192,7 +198,7 @@ static inline void ring_buf_item_init(struct ring_buf *buf,
 				      uint32_t size,
 				      uint32_t *data)
 {
-	__ASSERT(size < RING_BUFFER_MAX_SIZE / 4, RING_BUFFER_SIZE_ASSERT_MSG);
+	__ASSERT(size <= RING_BUFFER_MAX_SIZE / 4, RING_BUFFER_SIZE_ASSERT_MSG);
 	ring_buf_init(buf, 4 * size, (uint8_t *)data);
 }
 
@@ -227,7 +233,9 @@ static inline void ring_buf_reset(struct ring_buf *buf)
  */
 static inline uint32_t ring_buf_space_get(struct ring_buf *buf)
 {
-	return buf->size - (buf->put.head - buf->get.tail);
+	ring_buf_idx_t allocated = buf->put.head - buf->get.tail;
+
+	return buf->size - allocated;
 }
 
 /**
@@ -255,15 +263,17 @@ static inline uint32_t ring_buf_capacity_get(struct ring_buf *buf)
 }
 
 /**
- * @brief Determine used space in a ring buffer.
+ * @brief Determine size of available data in a ring buffer.
  *
  * @param buf Address of ring buffer.
  *
- * @return Ring buffer space used (in bytes).
+ * @return Ring buffer data size (in bytes).
  */
 static inline uint32_t ring_buf_size_get(struct ring_buf *buf)
 {
-	return buf->put.tail - buf->get.head;
+	ring_buf_idx_t available = buf->put.tail - buf->get.head;
+
+	return available;
 }
 
 /**

--- a/include/zephyr/sys/ring_buffer.h
+++ b/include/zephyr/sys/ring_buffer.h
@@ -209,7 +209,7 @@ static inline void ring_buf_item_init(struct ring_buf *buf,
  *
  * @return true if the ring buffer is empty, or false if not.
  */
-static inline bool ring_buf_is_empty(struct ring_buf *buf)
+static inline bool ring_buf_is_empty(const struct ring_buf *buf)
 {
 	return buf->get.head == buf->put.tail;
 }
@@ -231,7 +231,7 @@ static inline void ring_buf_reset(struct ring_buf *buf)
  *
  * @return Ring buffer free space (in bytes).
  */
-static inline uint32_t ring_buf_space_get(struct ring_buf *buf)
+static inline uint32_t ring_buf_space_get(const struct ring_buf *buf)
 {
 	ring_buf_idx_t allocated = buf->put.head - buf->get.tail;
 
@@ -245,7 +245,7 @@ static inline uint32_t ring_buf_space_get(struct ring_buf *buf)
  *
  * @return Ring buffer free space (in 32-bit words).
  */
-static inline uint32_t ring_buf_item_space_get(struct ring_buf *buf)
+static inline uint32_t ring_buf_item_space_get(const struct ring_buf *buf)
 {
 	return ring_buf_space_get(buf) / 4;
 }
@@ -257,7 +257,7 @@ static inline uint32_t ring_buf_item_space_get(struct ring_buf *buf)
  *
  * @return Ring buffer capacity (in bytes).
  */
-static inline uint32_t ring_buf_capacity_get(struct ring_buf *buf)
+static inline uint32_t ring_buf_capacity_get(const struct ring_buf *buf)
 {
 	return buf->size;
 }
@@ -269,7 +269,7 @@ static inline uint32_t ring_buf_capacity_get(struct ring_buf *buf)
  *
  * @return Ring buffer data size (in bytes).
  */
-static inline uint32_t ring_buf_size_get(struct ring_buf *buf)
+static inline uint32_t ring_buf_size_get(const struct ring_buf *buf)
 {
 	ring_buf_idx_t available = buf->put.tail - buf->get.head;
 

--- a/lib/utils/Kconfig
+++ b/lib/utils/Kconfig
@@ -12,9 +12,9 @@ config JSON_LIBRARY
 config RING_BUFFER
 	bool "Ring buffers"
 	help
-	  Enable usage of ring buffers. This is similar to kernel FIFOs but ring
-	  buffers manage their own buffer memory and can store arbitrary data.
-	  For optimal performance, use buffer sizes that are a power of 2.
+	  Provide highly efficient ring buffer management for arbitrary data.
+	  Some facilities such as kernel pipes are built on top of this.
+	  May be used directly e.g. when the pipe overhead is unnecessary.
 
 config NOTIFY
 	bool "Asynchronous Notifications"

--- a/lib/utils/Kconfig
+++ b/lib/utils/Kconfig
@@ -16,6 +16,13 @@ config RING_BUFFER
 	  Some facilities such as kernel pipes are built on top of this.
 	  May be used directly e.g. when the pipe overhead is unnecessary.
 
+config RING_BUFFER_LARGE
+	bool "Allow large ring buffer sizes"
+	depends on RING_BUFFER
+	help
+	  Increase maximum buffer size from 32KB to 2GB. When this is enabled,
+	  all struct ring_buf instances become 12 bytes bigger.
+
 config NOTIFY
 	bool "Asynchronous Notifications"
 	help

--- a/lib/utils/ring_buffer.c
+++ b/lib/utils/ring_buffer.c
@@ -12,7 +12,7 @@
 uint32_t ring_buf_area_claim(struct ring_buf *buf, struct ring_buf_index *ring,
 			     uint8_t **data, uint32_t size)
 {
-	uint32_t head_offset, wrap_size;
+	ring_buf_idx_t head_offset, wrap_size;
 
 	head_offset = ring->head - ring->base;
 	if (unlikely(head_offset >= buf->size)) {
@@ -31,7 +31,7 @@ uint32_t ring_buf_area_claim(struct ring_buf *buf, struct ring_buf_index *ring,
 int ring_buf_area_finish(struct ring_buf *buf, struct ring_buf_index *ring,
 			 uint32_t size)
 {
-	uint32_t claimed_size, tail_offset;
+	ring_buf_idx_t claimed_size, tail_offset;
 
 	claimed_size = ring->head - ring->tail;
 	if (unlikely(size > claimed_size)) {

--- a/lib/utils/ring_buffer.c
+++ b/lib/utils/ring_buffer.c
@@ -12,20 +12,17 @@
 uint32_t ring_buf_area_claim(struct ring_buf *buf, struct ring_buf_index *ring,
 			     uint8_t **data, uint32_t size)
 {
-	uint32_t wrap_size;
-	int32_t base;
+	uint32_t head_offset, wrap_size;
 
-	base = ring->base;
-	wrap_size = ring->head - base;
-	if (unlikely(wrap_size >= buf->size)) {
+	head_offset = ring->head - ring->base;
+	if (unlikely(head_offset >= buf->size)) {
 		/* ring->base is not yet adjusted */
-		wrap_size -= buf->size;
-		base += buf->size;
+		head_offset -= buf->size;
 	}
-	wrap_size = buf->size - wrap_size;
+	wrap_size = buf->size - head_offset;
 	size = MIN(size, wrap_size);
 
-	*data = &buf->buffer[ring->head - base];
+	*data = &buf->buffer[head_offset];
 	ring->head += size;
 
 	return size;
@@ -34,7 +31,7 @@ uint32_t ring_buf_area_claim(struct ring_buf *buf, struct ring_buf_index *ring,
 int ring_buf_area_finish(struct ring_buf *buf, struct ring_buf_index *ring,
 			 uint32_t size)
 {
-	uint32_t claimed_size, wrap_size;
+	uint32_t claimed_size, tail_offset;
 
 	claimed_size = ring->head - ring->tail;
 	if (unlikely(size > claimed_size)) {
@@ -44,8 +41,8 @@ int ring_buf_area_finish(struct ring_buf *buf, struct ring_buf_index *ring,
 	ring->tail += size;
 	ring->head = ring->tail;
 
-	wrap_size = ring->tail - ring->base;
-	if (unlikely(wrap_size >= buf->size)) {
+	tail_offset = ring->tail - ring->base;
+	if (unlikely(tail_offset >= buf->size)) {
 		/* we wrapped: adjust ring->base */
 		ring->base += buf->size;
 	}

--- a/subsys/net/lib/lwm2m/lwm2m_registry.c
+++ b/subsys/net/lib/lwm2m/lwm2m_registry.c
@@ -1723,13 +1723,11 @@ size_t lwm2m_cache_size(const struct lwm2m_time_series_resource *cache_entry)
 #if defined(CONFIG_LWM2M_RESOURCE_DATA_CACHE_SUPPORT)
 	uint32_t bytes_available;
 
-	/* ring_buf_is_empty() takes non-const pointer but still does not modify */
-	if (ring_buf_is_empty((struct ring_buf *) &cache_entry->rb)) {
+	if (ring_buf_is_empty(&cache_entry->rb)) {
 		return 0;
 	}
 
-	/* ring_buf_size_get() takes non-const pointer but still does not modify */
-	bytes_available = ring_buf_size_get((struct ring_buf *) &cache_entry->rb);
+	bytes_available = ring_buf_size_get(&cache_entry->rb);
 
 	return (bytes_available / sizeof(struct lwm2m_time_series_elem));
 #else

--- a/tests/lib/ringbuffer/src/concurrent.c
+++ b/tests/lib/ringbuffer/src/concurrent.c
@@ -262,7 +262,7 @@ static void test_ztress(ztress_handler high_handler,
 		uint32_t buf32[32];
 	} buf;
 	k_timeout_t timeout;
-	int32_t offset;
+	uint32_t offset;
 
 	if (item_mode) {
 		ring_buf_item_init(&ringbuf, ARRAY_SIZE(buf.buf32), buf.buf32);
@@ -270,8 +270,8 @@ static void test_ztress(ztress_handler high_handler,
 		ring_buf_init(&ringbuf, ARRAY_SIZE(buf.buf8), buf.buf8);
 	}
 
-	/* force internal 32-bit index roll-over */
-	offset = INT32_MAX - ring_buf_capacity_get(&ringbuf)/2;
+	/* force internal index roll-over */
+	offset = (ring_buf_idx_t)-1 - ring_buf_capacity_get(&ringbuf)/2;
 	ring_buf_internal_reset(&ringbuf, offset);
 
 	/* Timeout after 5 seconds. */


### PR DESCRIPTION
Notably, shrink size of struct ring_buf by leveraging the fact that nobody
uses very big buffer sizes.
