### PR TITLE
sw_isr_table: Force align _isr_list_sname instances

### DIFF
--- a/include/zephyr/sw_isr_table.h
+++ b/include/zephyr/sw_isr_table.h
@@ -213,7 +213,7 @@ extern struct z_shared_isr_table_entry z_shared_sw_isr_table[];
 
 #define _Z_ISR_DECLARE_C(irq, flags, func, param, counter)                                \
 	_Z_ISR_TABLE_ENTRY(irq, func, param, _MK_ISR_ELEMENT_SECTION(counter));           \
-	static struct _isr_list_sname Z_GENERIC_SECTION(.intList)                         \
+	static Z_DECL_ALIGN(struct _isr_list_sname) Z_GENERIC_SECTION(.intList)           \
 		__used _MK_ISR_NAME(func, counter) =                                      \
 		{irq, flags, _MK_ISR_ELEMENT_SECTION(counter)}
 
@@ -247,7 +247,7 @@ extern struct z_shared_isr_table_entry z_shared_sw_isr_table[];
 
 #define _Z_ISR_DECLARE_DIRECT_C(irq, flags, func, counter)                                         \
 	_Z_ISR_DIRECT_TABLE_ENTRY(irq, func, _MK_IRQ_ELEMENT_SECTION(counter));                    \
-	static struct _isr_list_sname Z_GENERIC_SECTION(.intList)                                  \
+	static Z_DECL_ALIGN(struct _isr_list_sname) Z_GENERIC_SECTION(.intList)                    \
 		__used _MK_ISR_NAME(func, counter) = {                                             \
 			irq,                                                                       \
 			ISR_FLAG_DIRECT | (flags),                                                 \

--- a/tests/kernel/interrupt/testcase.yaml
+++ b/tests/kernel/interrupt/testcase.yaml
@@ -56,7 +56,7 @@ tests:
     extra_configs:
       - CONFIG_SHARED_INTERRUPTS=y
     filter: not CONFIG_TRUSTED_EXECUTION_NONSECURE
-  arch.shared_interrupt.lto:
+  arch.shared_interrupt.lto: &shared-interrupt-lto
     # excluded because of failures during test_prevent_interruption
     platform_exclude: qemu_cortex_m0
     arch_exclude:
@@ -79,6 +79,14 @@ tests:
     filter: >
       not CONFIG_TRUSTED_EXECUTION_NONSECURE and CONFIG_ISR_TABLES_LOCAL_DECLARATION_SUPPORTED
       and not CONFIG_CODE_DATA_RELOCATION
+  arch.shared_interrupt.lto.speed:
+    <<: *shared-interrupt-lto
+    extra_configs:
+      - CONFIG_SHARED_INTERRUPTS=y
+      - CONFIG_TEST_USERSPACE=n
+      - CONFIG_ISR_TABLES_LOCAL_DECLARATION=y
+      - CONFIG_LTO=y
+      - CONFIG_SPEED_OPTIMIZATIONS=y
   arch.interrupt.multilevel:
     filter: CONFIG_MULTI_LEVEL_INTERRUPTS
     extra_args:


### PR DESCRIPTION
For some target and optimization level combinations (aarch64 and -O2, for example), GCC will over align _isr_list_sname instances. The local isr declaration parser doesn't expect the extra padding that may be introduced and will produce unexpected errors about bad IRQs (`error: IRQ 1903323438 (offset=0) exceeds the maximum of 42`, for example). Prevent this issue by forcing the expected alignment of _isr_list_sname.

Fixes #81254