### PR TITLE
sensor: icm42688: one-shot get_frame_count yields ENODATA on not-collected fields

### DIFF
--- a/drivers/sensor/tdk/icm42688/icm42688_decoder.c
+++ b/drivers/sensor/tdk/icm42688/icm42688_decoder.c
@@ -515,10 +515,19 @@ static int icm42688_decoder_get_frame_count(const uint8_t *buffer,
 					    uint16_t *frame_count)
 {
 	const struct icm42688_fifo_data *data = (const struct icm42688_fifo_data *)buffer;
+	const struct icm42688_encoded_data *enc_data = (const struct icm42688_encoded_data *)buffer;
 	const struct icm42688_decoder_header *header = &data->header;
 
 	if (chan_spec.chan_idx != 0) {
 		return -ENOTSUP;
+	}
+
+	uint8_t channel_request = icm42688_encode_channel(chan_spec.chan_type);
+
+
+	if ((!enc_data->header.is_fifo) &&
+	    (enc_data->channels & channel_request) != channel_request) {
+		return -ENODATA;
 	}
 
 	if (!header->is_fifo) {


### PR DESCRIPTION
### Description
This PR fixes the ICM42688 decoder working as one-shot read sequences. Previously, `get_frame_count` would return a frame is always available, irrespective of actually collecting it.

### Testing
Sample running with sensor shell commands:
- Output before the fix:
``` console
uart:~$ sensor get icm42688@0 accel_x
channel type=0(accel_x) index=0 shift=8 num_samples=1 value=9440887213ns (-0.090978)
channel type=1(accel_y) index=0 shift=0 num_samples=0 value=0ns (0.000000)
channel type=2(accel_z) index=0 shift=0 num_samples=0 value=0ns (0.000000)
channel type=3(accel_xyz) index=0 shift=0 num_samples=0 value=0ns, (0.000000, 0.000000, 0.000000)
channel type=4(gyro_x) index=0 shift=0 num_samples=0 value=0ns (0.000000)
channel type=5(gyro_y) index=0 shift=0 num_samples=0 value=0ns (0.000000)
channel type=6(gyro_z) index=0 shift=0 num_samples=0 value=0ns (0.000000)
channel type=7(gyro_xyz) index=0 shift=0 num_samples=0 value=0ns, (0.000000, 0.000000, 0.000000)
channel type=12(die_temp) index=0 shift=0 num_samples=0 value=0ns (0.000000)
uart:~$ sensor get icm42688@0 accel_y
channel type=0(accel_x) index=0 shift=0 num_samples=0 value=0ns (0.000000)
channel type=1(accel_y) index=0 shift=8 num_samples=1 value=7521667480ns (-0.100555)
channel type=2(accel_z) index=0 shift=0 num_samples=0 value=0ns (0.000000)
channel type=3(accel_xyz) index=0 shift=0 num_samples=0 value=0ns, (0.000000, 0.000000, 0.000000)
channel type=4(gyro_x) index=0 shift=0 num_samples=0 value=0ns (0.000000)
channel type=5(gyro_y) index=0 shift=0 num_samples=0 value=0ns (0.000000)
channel type=6(gyro_z) index=0 shift=0 num_samples=0 value=0ns (0.000000)
channel type=7(gyro_xyz) index=0 shift=0 num_samples=0 value=0ns, (0.000000, 0.000000, 0.000000)
channel type=12(die_temp) index=0 shift=0 num_samples=0 value=0ns (0.000000)
uart:~$ sensor get icm42688@0 accel_z
channel type=0(accel_x) index=0 shift=0 num_samples=0 value=0ns (0.000000)
channel type=1(accel_y) index=0 shift=0 num_samples=0 value=0ns (0.000000)
channel type=2(accel_z) index=0 shift=8 num_samples=1 value=8129791259ns (10.280700)
channel type=3(accel_xyz) index=0 shift=0 num_samples=0 value=0ns, (0.000000, 0.000000, 0.000000)
channel type=4(gyro_x) index=0 shift=0 num_samples=0 value=0ns (0.000000)
channel type=5(gyro_y) index=0 shift=0 num_samples=0 value=0ns (0.000000)
channel type=6(gyro_z) index=0 shift=0 num_samples=0 value=0ns (0.000000)
channel type=7(gyro_xyz) index=0 shift=0 num_samples=0 value=0ns, (0.000000, 0.000000, 0.000000)
channel type=12(die_temp) index=0 shift=0 num_samples=0 value=0ns (0.000000)
```
- Output after the fix:
``` console
uart:~$ sensor get icm42688@0 accel_x
channel type=0(accel_x) index=0 shift=8 num_samples=1 value=1166335021735ns (-0.335187)
uart:~$ sensor get icm42688@0 accel_y
channel type=1(accel_y) index=0 shift=8 num_samples=1 value=1167166839362ns (0.129285)
uart:~$ sensor get icm42688@0 accel_z
channel type=2(accel_z) index=0 shift=8 num_samples=1 value=1167806945563ns (10.084376)

```
