### PR TITLE
tests: gen_isr_table: filter *arm_mainline test on *_M_MAINLINE config

### DIFF
--- a/tests/kernel/gen_isr_table/testcase.yaml
+++ b/tests/kernel/gen_isr_table/testcase.yaml
@@ -56,7 +56,7 @@ tests:
       - CONFIG_ISR_TABLES_LOCAL_DECLARATION=y
   arch.interrupt.gen_isr_table_local.arm_mainline:
     <<: *arm-mainline
-    filter: CONFIG_GEN_ISR_TABLES and CONFIG_ARMV6_M_ARMV8_M_BASELINE and not CONFIG_USERSPACE
+    filter: CONFIG_GEN_ISR_TABLES and CONFIG_ARMV7_M_ARMV8_M_MAINLINE and not CONFIG_USERSPACE
     extra_configs:
       - CONFIG_NULL_POINTER_EXCEPTION_DETECTION_NONE=y
       - CONFIG_ISR_TABLES_LOCAL_DECLARATION=y


### PR DESCRIPTION
Since it was added, `arch.interrupt.gen_isr_table_local.arm_mainline` filters on `CONFIG_ARMV6_M_ARMV8_M_BASELINE`. I'm not entirely sure whether this was intentional, but this seems odd to me given a) the naming of the test b) that the `platform_allow` is `qemu_cortex_m3` and c) that the `arch.interrupt.gen_isr_table.arm_mainline` test it inherits part of its config from filters on `CONFIG_ARMV7_M_ARMV8_M_MAINLINE`.

The current filtering setup also means that a command like `west twister -c -T tests/kernel/gen_isr_table/` currently filters out all of the `*gen_isr_table_local*` tests which was a surprise to me when testing locally (no tests broke for a change I made as they were all filtered out).

Assuming this is undesirable, change the filter to check against
`CONFIG_ARMV7_M_ARMV8_M_MAINLINE` to make it possible to run the tests on the expected platform without needing to work around the filter.