### PR TITLE
fix: spi: rtio: Log module instantiation

### DIFF
--- a/drivers/spi/spi_rtio.c
+++ b/drivers/spi/spi_rtio.c
@@ -12,7 +12,7 @@
 #include <zephyr/sys/mpsc_lockfree.h>
 
 #include <zephyr/logging/log.h>
-LOG_MODULE_DECLARE(spi_rtio, CONFIG_SPI_LOG_LEVEL);
+LOG_MODULE_REGISTER(spi_rtio, CONFIG_SPI_LOG_LEVEL);
 
 const struct rtio_iodev_api spi_iodev_api = {
 	.submit = spi_iodev_submit,


### PR DESCRIPTION
This fixes compilation issue coming from having both CONFIG_LOG and CONFIG_SPI_RTIO enabled.

Fixes #85356