### PR TITLE
driver: sensor: lsm6dsv16x: add support for device PM and wakeup trigger

### DIFF
--- a/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x.h
+++ b/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x.h
@@ -174,8 +174,8 @@ struct lsm6dsv16x_data {
 	const struct sensor_trigger *trig_drdy_acc;
 	sensor_trigger_handler_t handler_drdy_gyr;
 	const struct sensor_trigger *trig_drdy_gyr;
-	sensor_trigger_handler_t handler_drdy_temp;
-	const struct sensor_trigger *trig_drdy_temp;
+	sensor_trigger_handler_t handler_wakeup;
+	const struct sensor_trigger *trig_wakeup;
 
 #if defined(CONFIG_LSM6DSV16X_TRIGGER_OWN_THREAD)
 	K_KERNEL_STACK_MEMBER(thread_stack, CONFIG_LSM6DSV16X_THREAD_STACK_SIZE);

--- a/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x.h
+++ b/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x.h
@@ -30,6 +30,8 @@
 #include <zephyr/drivers/i3c.h>
 #endif /* DT_ANY_INST_ON_BUS_STATUS_OKAY(i3c) */
 
+bool lsm6dsv16x_is_active(const struct device *dev);
+
 #if DT_ANY_INST_ON_BUS_STATUS_OKAY(i3c)
 	#define ON_I3C_BUS(cfg)  (cfg->i3c.bus != NULL)
 	#define I3C_INT_PIN(cfg) (cfg->int_en_i3c)

--- a/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x_rtio.c
+++ b/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x_rtio.c
@@ -153,6 +153,10 @@ void lsm6dsv16x_submit_sync(struct rtio_iodev_sqe *iodev_sqe)
 
 void lsm6dsv16x_submit(const struct device *dev, struct rtio_iodev_sqe *iodev_sqe)
 {
+	if (!lsm6dsv16x_is_active(dev)) {
+		return;
+	}
+
 	struct rtio_work_req *req = rtio_work_req_alloc();
 
 	if (req == NULL) {

--- a/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x_trigger.c
+++ b/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x_trigger.c
@@ -133,6 +133,10 @@ int lsm6dsv16x_trigger_set(const struct device *dev,
 		return -EINVAL;
 	}
 
+	if (!lsm6dsv16x_is_active(dev)) {
+		return -EBUSY;
+	}
+
 	switch (trig->type) {
 	case SENSOR_TRIG_DATA_READY:
 		if (trig->chan == SENSOR_CHAN_ACCEL_XYZ) {


### PR DESCRIPTION
* Adds device PM support which will ensure the accelerometer and gyro are powered off and public APIs are not accessible.
* Adds support for the SENSOR_TRIG_DELTA trigger and associated sensor attributes.

Tested on a custom board with INT1 pin connected to interrupt source. SENSOR_TRIG_DELTA trigger was enabled with various
thresholds and verified that handler was called giving the necessary external stimuli.