### PR TITLE
drivers: udc: Do not allow lock/unlock to fail

### DIFF
--- a/drivers/usb/udc/udc_ambiq.c
+++ b/drivers/usb/udc/udc_ambiq.c
@@ -594,14 +594,14 @@ static int udc_ambiq_shutdown(const struct device *dev)
 	return 0;
 }
 
-static int udc_ambiq_lock(const struct device *dev)
+static void udc_ambiq_lock(const struct device *dev)
 {
-	return udc_lock_internal(dev, K_FOREVER);
+	udc_lock_internal(dev, K_FOREVER);
 }
 
-static int udc_ambiq_unlock(const struct device *dev)
+static void udc_ambiq_unlock(const struct device *dev)
 {
-	return udc_unlock_internal(dev);
+	udc_unlock_internal(dev);
 }
 
 static void ambiq_handle_evt_setup(const struct device *dev)

--- a/drivers/usb/udc/udc_dwc2.c
+++ b/drivers/usb/udc/udc_dwc2.c
@@ -2262,14 +2262,14 @@ static int dwc2_driver_preinit(const struct device *dev)
 	return 0;
 }
 
-static int udc_dwc2_lock(const struct device *dev)
+static void udc_dwc2_lock(const struct device *dev)
 {
-	return udc_lock_internal(dev, K_FOREVER);
+	udc_lock_internal(dev, K_FOREVER);
 }
 
-static int udc_dwc2_unlock(const struct device *dev)
+static void udc_dwc2_unlock(const struct device *dev)
 {
-	return udc_unlock_internal(dev);
+	udc_unlock_internal(dev);
 }
 
 static void dwc2_on_bus_reset(const struct device *dev)

--- a/drivers/usb/udc/udc_it82xx2.c
+++ b/drivers/usb/udc/udc_it82xx2.c
@@ -1495,14 +1495,14 @@ static int it82xx2_shutdown(const struct device *dev)
 	return 0;
 }
 
-static int it82xx2_lock(const struct device *dev)
+static void it82xx2_lock(const struct device *dev)
 {
-	return udc_lock_internal(dev, K_FOREVER);
+	udc_lock_internal(dev, K_FOREVER);
 }
 
-static int it82xx2_unlock(const struct device *dev)
+static void it82xx2_unlock(const struct device *dev)
 {
-	return udc_unlock_internal(dev);
+	udc_unlock_internal(dev);
 }
 
 static const struct udc_api it82xx2_api = {

--- a/drivers/usb/udc/udc_kinetis.c
+++ b/drivers/usb/udc/udc_kinetis.c
@@ -1069,14 +1069,14 @@ static int usbfsotg_shutdown(const struct device *dev)
 	return 0;
 }
 
-static int usbfsotg_lock(const struct device *dev)
+static void usbfsotg_lock(const struct device *dev)
 {
-	return udc_lock_internal(dev, K_FOREVER);
+	udc_lock_internal(dev, K_FOREVER);
 }
 
-static int usbfsotg_unlock(const struct device *dev)
+static void usbfsotg_unlock(const struct device *dev)
 {
-	return udc_unlock_internal(dev);
+	udc_unlock_internal(dev);
 }
 
 static int usbfsotg_driver_preinit(const struct device *dev)

--- a/drivers/usb/udc/udc_mcux_ehci.c
+++ b/drivers/usb/udc/udc_mcux_ehci.c
@@ -64,14 +64,14 @@ struct udc_mcux_event {
 K_MEM_SLAB_DEFINE(udc_event_slab, sizeof(struct udc_mcux_event),
 		  CONFIG_UDC_NXP_EVENT_COUNT, sizeof(void *));
 
-static int udc_mcux_lock(const struct device *dev)
+static void udc_mcux_lock(const struct device *dev)
 {
-	return udc_lock_internal(dev, K_FOREVER);
+	udc_lock_internal(dev, K_FOREVER);
 }
 
-static int udc_mcux_unlock(const struct device *dev)
+static void udc_mcux_unlock(const struct device *dev)
 {
-	return udc_unlock_internal(dev);
+	udc_unlock_internal(dev);
 }
 
 static int udc_mcux_control(const struct device *dev, usb_device_control_type_t command,

--- a/drivers/usb/udc/udc_mcux_ip3511.c
+++ b/drivers/usb/udc/udc_mcux_ip3511.c
@@ -64,14 +64,14 @@ struct udc_mcux_event {
 K_MEM_SLAB_DEFINE(udc_event_slab, sizeof(struct udc_mcux_event),
 		  CONFIG_UDC_NXP_EVENT_COUNT, sizeof(void *));
 
-static int udc_mcux_lock(const struct device *dev)
+static void udc_mcux_lock(const struct device *dev)
 {
-	return udc_lock_internal(dev, K_FOREVER);
+	udc_lock_internal(dev, K_FOREVER);
 }
 
-static int udc_mcux_unlock(const struct device *dev)
+static void udc_mcux_unlock(const struct device *dev)
 {
-	return udc_unlock_internal(dev);
+	udc_unlock_internal(dev);
 }
 
 static int udc_mcux_control(const struct device *dev, usb_device_control_type_t command,

--- a/drivers/usb/udc/udc_nrf.c
+++ b/drivers/usb/udc/udc_nrf.c
@@ -911,14 +911,14 @@ static int udc_nrf_driver_init(const struct device *dev)
 	return 0;
 }
 
-static int udc_nrf_lock(const struct device *dev)
+static void udc_nrf_lock(const struct device *dev)
 {
-	return udc_lock_internal(dev, K_FOREVER);
+	udc_lock_internal(dev, K_FOREVER);
 }
 
-static int udc_nrf_unlock(const struct device *dev)
+static void udc_nrf_unlock(const struct device *dev)
 {
-	return udc_unlock_internal(dev);
+	udc_unlock_internal(dev);
 }
 
 static const struct udc_nrf_config udc_nrf_cfg = {

--- a/drivers/usb/udc/udc_numaker.c
+++ b/drivers/usb/udc/udc_numaker.c
@@ -1622,14 +1622,14 @@ static int udc_numaker_shutdown(const struct device *dev)
 	return 0;
 }
 
-static int udc_numaker_lock(const struct device *dev)
+static void udc_numaker_lock(const struct device *dev)
 {
-	return udc_lock_internal(dev, K_FOREVER);
+	udc_lock_internal(dev, K_FOREVER);
 }
 
-static int udc_numaker_unlock(const struct device *dev)
+static void udc_numaker_unlock(const struct device *dev)
 {
-	return udc_unlock_internal(dev);
+	udc_unlock_internal(dev);
 }
 
 static int udc_numaker_driver_preinit(const struct device *dev)

--- a/drivers/usb/udc/udc_renesas_ra.c
+++ b/drivers/usb/udc/udc_renesas_ra.c
@@ -641,14 +641,14 @@ static int udc_renesas_ra_driver_preinit(const struct device *dev)
 	return 0;
 }
 
-static int udc_renesas_ra_lock(const struct device *dev)
+static void udc_renesas_ra_lock(const struct device *dev)
 {
-	return udc_lock_internal(dev, K_FOREVER);
+	udc_lock_internal(dev, K_FOREVER);
 }
 
-static int udc_renesas_ra_unlock(const struct device *dev)
+static void udc_renesas_ra_unlock(const struct device *dev)
 {
-	return udc_unlock_internal(dev);
+	udc_unlock_internal(dev);
 }
 
 static const struct udc_api udc_renesas_ra_api = {

--- a/drivers/usb/udc/udc_rpi_pico.c
+++ b/drivers/usb/udc/udc_rpi_pico.c
@@ -1050,14 +1050,14 @@ static int udc_rpi_pico_driver_preinit(const struct device *dev)
 	return 0;
 }
 
-static int udc_rpi_pico_lock(const struct device *dev)
+static void udc_rpi_pico_lock(const struct device *dev)
 {
-	return udc_lock_internal(dev, K_FOREVER);
+	udc_lock_internal(dev, K_FOREVER);
 }
 
-static int udc_rpi_pico_unlock(const struct device *dev)
+static void udc_rpi_pico_unlock(const struct device *dev)
 {
-	return udc_unlock_internal(dev);
+	udc_unlock_internal(dev);
 }
 
 static const struct udc_api udc_rpi_pico_api = {

--- a/drivers/usb/udc/udc_skeleton.c
+++ b/drivers/usb/udc/udc_skeleton.c
@@ -323,14 +323,14 @@ static int udc_skeleton_driver_preinit(const struct device *dev)
 	return 0;
 }
 
-static int udc_skeleton_lock(const struct device *dev)
+static void udc_skeleton_lock(const struct device *dev)
 {
-	return udc_lock_internal(dev, K_FOREVER);
+	udc_lock_internal(dev, K_FOREVER);
 }
 
-static int udc_skeleton_unlock(const struct device *dev)
+static void udc_skeleton_unlock(const struct device *dev)
 {
-	return udc_unlock_internal(dev);
+	udc_unlock_internal(dev);
 }
 
 /*

--- a/drivers/usb/udc/udc_smartbond.c
+++ b/drivers/usb/udc/udc_smartbond.c
@@ -1695,14 +1695,14 @@ static int udc_smartbond_init(const struct device *dev)
 	return 0;
 }
 
-static int udc_smartbond_lock(const struct device *dev)
+static void udc_smartbond_lock(const struct device *dev)
 {
-	return udc_lock_internal(dev, K_FOREVER);
+	udc_lock_internal(dev, K_FOREVER);
 }
 
-static int udc_smartbond_unlock(const struct device *dev)
+static void udc_smartbond_unlock(const struct device *dev)
 {
-	return udc_unlock_internal(dev);
+	udc_unlock_internal(dev);
 }
 
 static const struct udc_api udc_smartbond_api = {

--- a/drivers/usb/udc/udc_stm32.c
+++ b/drivers/usb/udc/udc_stm32.c
@@ -73,14 +73,14 @@ struct udc_stm32_msg {
 	uint16_t rx_count;
 };
 
-static int udc_stm32_lock(const struct device *dev)
+static void udc_stm32_lock(const struct device *dev)
 {
-	return udc_lock_internal(dev, K_FOREVER);
+	udc_lock_internal(dev, K_FOREVER);
 }
 
-static int udc_stm32_unlock(const struct device *dev)
+static void udc_stm32_unlock(const struct device *dev)
 {
-	return udc_unlock_internal(dev);
+	udc_unlock_internal(dev);
 }
 
 #define hpcd2data(hpcd) CONTAINER_OF(hpcd, struct udc_stm32_data, pcd);

--- a/drivers/usb/udc/udc_virtual.c
+++ b/drivers/usb/udc/udc_virtual.c
@@ -612,14 +612,14 @@ static int udc_vrt_driver_preinit(const struct device *dev)
 	return 0;
 }
 
-static int udc_vrt_lock(const struct device *dev)
+static void udc_vrt_lock(const struct device *dev)
 {
-	return udc_lock_internal(dev, K_FOREVER);
+	udc_lock_internal(dev, K_FOREVER);
 }
 
-static int udc_vrt_unlock(const struct device *dev)
+static void udc_vrt_unlock(const struct device *dev)
 {
-	return udc_unlock_internal(dev);
+	udc_unlock_internal(dev);
 }
 
 static const struct udc_api udc_vrt_api = {

--- a/include/zephyr/drivers/usb/udc.h
+++ b/include/zephyr/drivers/usb/udc.h
@@ -249,8 +249,8 @@ struct udc_api {
 	int (*disable)(const struct device *dev);
 	int (*init)(const struct device *dev);
 	int (*shutdown)(const struct device *dev);
-	int (*lock)(const struct device *dev);
-	int (*unlock)(const struct device *dev);
+	void (*lock)(const struct device *dev);
+	void (*unlock)(const struct device *dev);
 };
 
 /**


### PR DESCRIPTION
USB stack does not check api->lock() and api->unlock() return value and all UDC drivers block without timeout in its lock() and unlock() api implementations. There is no realistic way to handle lock() and unlock() errors without making USB device stack API unnecessarily complex.

Remove the return type from lock() and unlock() to make it clear that the functions must not fail.