### PR TITLE
doc: ci: exclude unneeded files from documentation tarball

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -145,7 +145,7 @@ jobs:
 
     - name: compress-docs
       run: |
-        tar --use-compress-program="xz -T0" -cf html-output.tar.xz --directory=doc/_build html
+        tar --use-compress-program="xz -T0" -cf html-output.tar.xz --exclude html/_sources --exclude html/doxygen/xml --directory=doc/_build html
         tar --use-compress-program="xz -T0" -cf api-output.tar.xz --directory=doc/_build html/doxygen/html
         tar --use-compress-program="xz -T0" -cf api-coverage.tar.xz coverage-report
 


### PR DESCRIPTION
There is no point in including source .rst files or Doxygen XML output in html-output.tar.xz as it unnecessarily slows down the creation of html-output.tar.xz (there are thousands of files...) as well as transfer to/decompression on S3.