### PR TITLE
boards: stm32f769i_disco: drop led_4 node

### DIFF
--- a/boards/st/stm32f769i_disco/stm32f769i_disco.dts
+++ b/boards/st/stm32f769i_disco/stm32f769i_disco.dts
@@ -52,10 +52,6 @@
 			gpios = <&gpioa 12 GPIO_ACTIVE_HIGH>;
 			label = "User LD3";
 		};
-		red_led_4:led_4 {
-			gpios = <&gpiod 4 GPIO_ACTIVE_HIGH>;
-			label = "User LD4";
-		};
 	};
 
 	gpio_keys {
@@ -76,7 +72,6 @@
 		led0 = &red_led_1;
 		led1 = &green_led_2;
 		led2 = &green_led_3;
-		led3 = &red_led_4;
 		sw0 = &user_button;
 	};
 


### PR DESCRIPTION
The LED 4 is connected to the STMPS2151STR on the FAULT output pin which is pulled low, automatically turning on the LED, in case of current limit faults. Therefore, pin D4 should not be configured as a LED but rather as an input to detect the fault condition.

Additionally, it should be noted that the board's silkscreen labels this LED as "OC" (OverCurrent) rather than usr{1,2,3}, as is the case for the other LEDs described in the DTS.