### PR TITLE
tests: drivers: adc: Correct the reference-mv in Kconfig

### DIFF
--- a/tests/drivers/adc/adc_accuracy_test/Kconfig
+++ b/tests/drivers/adc/adc_accuracy_test/Kconfig
@@ -15,7 +15,7 @@ config DAC_SOURCE_TEST
 
 config REFERENCE_VOLTAGE_TEST
 	bool
-	default y if $(dt_node_has_prop,/$(ZEPHYR_USER),reference_mv)
+	default y if $(dt_node_has_prop,/$(ZEPHYR_USER),reference-mv)
 
 config NUMBER_OF_PASSES
 	int "Number of passes"


### PR DESCRIPTION
Correct `reference-mv` in Kconfig of `adc_accuracy_test`
Bug PR: https://github.com/zephyrproject-rtos/zephyr/pull/83768