### PR TITLE
boards: renesas: Add support missing HWIP node for Renesas ek_ra4m1

### DIFF
--- a/boards/renesas/ek_ra4m1/doc/index.rst
+++ b/boards/renesas/ek_ra4m1/doc/index.rst
@@ -87,6 +87,12 @@ The below features are currently supported on Zephyr for the ``ek_ra4m1`` board:
 +-----------+------------+----------------------+
 | ADC       | on-chip    | adc                  |
 +-----------+------------+----------------------+
+| ENTROPY   | on-chip    | entropy              |
++-----------+------------+----------------------+
+| PWM       | on-chip    | pwm                  |
++-----------+------------+----------------------+
+| I2C       | on-chip    | i2c                  |
++-----------+------------+----------------------+
 
 Other hardware features are currently not supported by the port.
 

--- a/boards/renesas/ek_ra4m1/ek_ra4m1-pinctrl.dtsi
+++ b/boards/renesas/ek_ra4m1/ek_ra4m1-pinctrl.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Renesas Electronics Corporation
+ * Copyright (c) 2024-2025 Renesas Electronics Corporation
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -27,6 +27,23 @@
 			/* input */
 			psels = <RA_PSEL(RA_PSEL_ADC, 0, 0)>;
 			renesas,analog-enable;
+		};
+	};
+
+	pwm1_default: pwm1_default {
+		group1 {
+			/* GTIOC1A GTIOC1B */
+			psels = <RA_PSEL(RA_PSEL_GPT1, 4, 5)>,
+				<RA_PSEL(RA_PSEL_GPT1, 4, 6)>;
+		};
+	};
+
+	iic1_default: iic1_default {
+		group1 {
+			/* SCL1 SDA1 */
+			psels = <RA_PSEL(RA_PSEL_I2C, 1, 0)>,
+			<RA_PSEL(RA_PSEL_I2C, 2, 6)>;
+			drive-strength = "medium";
 		};
 	};
 };

--- a/boards/renesas/ek_ra4m1/ek_ra4m1.dts
+++ b/boards/renesas/ek_ra4m1/ek_ra4m1.dts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Renesas Electronics Corporation
+ * Copyright (c) 2024-2025 Renesas Electronics Corporation
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -20,6 +20,7 @@
 		zephyr,flash = &flash0;
 		zephyr,console = &uart1;
 		zephyr,shell-uart = &uart1;
+		zephyr,entropy = &trng;
 	};
 
 	leds {
@@ -102,5 +103,28 @@
 
 &port_irq0 {
 	interrupts = <27 12>;
+	status = "okay";
+};
+
+&trng {
+	status = "okay";
+};
+
+&pwm1 {
+	pinctrl-0 = <&pwm1_default>;
+	pinctrl-names = "default";
+	interrupts = <8 1>, <9 1>;
+	interrupt-names = "gtioca", "overflow";
+	status = "okay";
+};
+
+&iic1 {
+	pinctrl-0 = <&iic1_default>;
+	pinctrl-names = "default";
+	#address-cells = <1>;
+	#size-cells = <0>;
+	clock-frequency = <DT_FREQ_M(1)>;
+	interrupts = <10 1>, <11 1>, <12 1>, <13 1>;
+	interrupt-names = "rxi", "txi", "tei", "eri";
 	status = "okay";
 };

--- a/dts/arm/renesas/ra/ra4/r7fa4m1ab3cfp.dtsi
+++ b/dts/arm/renesas/ra/ra4/r7fa4m1ab3cfp.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Renesas Electronics Corporation
+ * Copyright (c) 2024-2025 Renesas Electronics Corporation
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -107,6 +107,31 @@
 			channel = <12>;
 			renesas,sample-clock-div = <64>;
 			#port-irq-cells = <0>;
+			status = "disabled";
+		};
+
+		trng: trng {
+			compatible = "renesas,ra-sce5-rng";
+			status = "disabled";
+		};
+
+		pwm6: pwm6@40078600 {
+			compatible = "renesas,ra-pwm";
+			divider = <RA_PWM_SOURCE_DIV_1>;
+			channel = <RA_PWM_CHANNEL_6>;
+			clocks = <&pclkd MSTPD 6>;
+			reg = <0x40078600 0x100>;
+			#pwm-cells = <3>;
+			status = "disabled";
+		};
+
+		pwm7: pwm7@40078700 {
+			compatible = "renesas,ra-pwm";
+			divider = <RA_PWM_SOURCE_DIV_1>;
+			channel = <RA_PWM_CHANNEL_7>;
+			clocks = <&pclkd MSTPD 6>;
+			reg = <0x40078700 0x100>;
+			#pwm-cells = <3>;
 			status = "disabled";
 		};
 	};

--- a/samples/drivers/counter/alarm/boards/ek_ra4m1.overlay
+++ b/samples/drivers/counter/alarm/boards/ek_ra4m1.overlay
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&agt0 {
+	status = "okay";
+	interrupts = <30 1>, <31 1>;
+	interrupt-names = "agti", "agtcmai";
+	renesas,prescaler = <4>;
+	counter0: counter {
+		status = "okay";
+	};
+};

--- a/tests/drivers/adc/adc_accuracy_test/boards/ek_ra4m1.overlay
+++ b/tests/drivers/adc/adc_accuracy_test/boards/ek_ra4m1.overlay
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	zephyr,user {
+		io-channels = <&adc0 0>;
+		reference-mv = <3300>;
+		expected-accuracy = <32>;
+	};
+};
+
+&adc0{
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+		zephyr,vref-mv = <3300>;
+	};
+};

--- a/tests/drivers/adc/adc_api/boards/ek_ra4m1.overlay
+++ b/tests/drivers/adc/adc_api/boards/ek_ra4m1.overlay
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
+/ {
+	zephyr,user {
+		io-channels = <&adc0 0>, <&adc0 2>;
+	};
+};
+
+&adc0 {
+	status = "okay";
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,resolution = <12>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,vref-mv = <3300>;
+	};
+
+	channel@2 {
+		reg = <2>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,resolution = <12>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,vref-mv = <3300>;
+	};
+};

--- a/tests/drivers/i2c/i2c_api/boards/ek_ra4m1.conf
+++ b/tests/drivers/i2c/i2c_api/boards/ek_ra4m1.conf
@@ -1,0 +1,4 @@
+# Copyright (c) 2025 Renesas Electronics Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_SENSOR_GY271_QMC=y

--- a/tests/drivers/i2c/i2c_api/boards/ek_ra4m1.overlay
+++ b/tests/drivers/i2c/i2c_api/boards/ek_ra4m1.overlay
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		i2c-0 = &iic1;
+		gy271 = &iic1;
+	};
+};

--- a/tests/drivers/pwm/pwm_loopback/boards/ek_ra4m1.overlay
+++ b/tests/drivers/pwm/pwm_loopback/boards/ek_ra4m1.overlay
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/pwm/pwm.h>
+#include <zephyr/dt-bindings/pwm/ra_pwm.h>
+
+/ {
+	pwm_loopback_0 {
+		compatible = "test-pwm-loopback";
+		/* first index must be a 32-Bit timer */
+		pwms = <&pwm1 0 0 PWM_POLARITY_NORMAL>,
+			<&pwm3 0 0 PWM_POLARITY_NORMAL>;
+	};
+};
+
+&pinctrl {
+	pwm3_default: pwm3_default {
+		group1 {
+			/* GTIOC3A */
+			psels = <RA_PSEL(RA_PSEL_GPT1, 1, 11)>;
+		};
+	};
+};
+
+&pwm3 {
+	pinctrl-0 = <&pwm3_default>;
+	pinctrl-names = "default";
+	interrupts = <30 1>, <31 1>;
+	interrupt-names = "gtioca", "overflow";
+	status = "okay";
+};

--- a/tests/drivers/spi/spi_loopback/boards/ek_ra4m1.conf
+++ b/tests/drivers/spi/spi_loopback/boards/ek_ra4m1.conf
@@ -1,0 +1,6 @@
+# Copyright (c) 2025 Renesas Electronics Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_SPI_LOOPBACK_MODE_LOOP=y
+CONFIG_SPI_INTERRUPT=y
+CONFIG_SPI_RA_DTC=y

--- a/tests/drivers/spi/spi_loopback/boards/ek_ra4m1.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/ek_ra4m1.overlay
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&spi1 {
+	rx-dtc;
+	tx-dtc;
+	slow@0 {
+		compatible = "test-spi-loopback-slow";
+		reg = <0>;
+		spi-max-frequency = <2000000>;
+	};
+	fast@0 {
+		compatible = "test-spi-loopback-fast";
+		reg = <0>;
+		spi-max-frequency = <3000000>;
+	};
+};

--- a/tests/drivers/uart/uart_async_api/boards/ek_ra4m1.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/ek_ra4m1.overlay
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&pinctrl {
+	sci9_default: sci9_default {
+		group1 {
+			/* tx rx */
+			psels = <RA_PSEL(RA_PSEL_SCI_9, 6, 2)>,
+			<RA_PSEL(RA_PSEL_SCI_9, 6, 1)>;
+		};
+	};
+};
+
+&sci9 {
+	pinctrl-0 = <&sci9_default>;
+	pinctrl-names = "default";
+	interrupts = <28 1>, <29 1>, <30 1>, <31 1>;
+	interrupt-names = "rxi", "txi", "tei", "eri";
+	status = "okay";
+	dut: uart {
+		current-speed = <115200>;
+		status = "okay";
+	};
+};


### PR DESCRIPTION
- Add missing PWM and entropy node for RA4M1 soc.
- Add configurations to enable entropy, PWM, and I2C on `ek_ra4m1`.
- Provide test and sample support for available HWIPs supported on `ek_ra4m1`.