### PR TITLE
drivers: gpio: gpio_stm32: add gpio speed

### DIFF
--- a/drivers/gpio/gpio_stm32.c
+++ b/drivers/gpio/gpio_stm32.c
@@ -91,6 +91,23 @@ static int gpio_stm32_flags_to_conf(gpio_flags_t flags, uint32_t *pincfg)
 		*pincfg = STM32_PINCFG_MODE_ANALOG;
 	}
 
+#if !defined(CONFIG_SOC_SERIES_STM32F1X)
+	switch (flags & (STM32_GPIO_SPEED_MASK << STM32_GPIO_SPEED_SHIFT)) {
+	case STM32_GPIO_VERY_HIGH_SPEED:
+		*pincfg |= STM32_OSPEEDR_VERY_HIGH_SPEED;
+		break;
+	case STM32_GPIO_HIGH_SPEED:
+		*pincfg |= STM32_OSPEEDR_HIGH_SPEED;
+		break;
+	case STM32_GPIO_MEDIUM_SPEED:
+		*pincfg |= STM32_OSPEEDR_MEDIUM_SPEED;
+		break;
+	default:
+		*pincfg |= STM32_OSPEEDR_LOW_SPEED;
+		break;
+	}
+#endif /* !CONFIG_SOC_SERIES_STM32F1X */
+
 	return 0;
 }
 

--- a/include/zephyr/dt-bindings/gpio/stm32-gpio.h
+++ b/include/zephyr/dt-bindings/gpio/stm32-gpio.h
@@ -14,6 +14,7 @@
  * follows:
  *
  * - Bit 8: Configure a GPIO pin to power on the system after Poweroff.
+ * - Bit 10..9: Configure the output speed of a GPIO pin.
  *
  * @ingroup gpio_interface
  * @{
@@ -24,7 +25,24 @@
  * This flag is reserved to GPIO pins that are associated with wake-up pins
  * in STM32 PWR devicetree node, through the property "wkup-gpios".
  */
-#define STM32_GPIO_WKUP		(1 << 8)
+#define STM32_GPIO_WKUP (1 << 8)
+
+/** @cond INTERNAL_HIDDEN */
+#define STM32_GPIO_SPEED_SHIFT 9
+#define STM32_GPIO_SPEED_MASK  0x3
+/** @endcond */
+
+/** Configure the GPIO pin output speed to be low */
+#define STM32_GPIO_LOW_SPEED (0x0 << STM32_GPIO_SPEED_SHIFT)
+
+/** Configure the GPIO pin output speed to be medium */
+#define STM32_GPIO_MEDIUM_SPEED (0x1 << STM32_GPIO_SPEED_SHIFT)
+
+/** Configure the GPIO pin output speed to be high */
+#define STM32_GPIO_HIGH_SPEED (0x2 << STM32_GPIO_SPEED_SHIFT)
+
+/** Configure the GPIO pin output speed to be very high */
+#define STM32_GPIO_VERY_HIGH_SPEED (0x3 << STM32_GPIO_SPEED_SHIFT)
 
 /** @} */
 


### PR DESCRIPTION
The driver already read the speed flags (cfr. `ospeed`) and called `LL_GPIO_SetPinSpeed` with them, but these flags could not be set yet.
This enables the speed to be set via the devicetree
Tested and confirmed on a stm32h573