### PR TITLE
soc: atmel: sam0: rename EMPTY bit-fields

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -157,7 +157,7 @@ manifest:
       groups:
         - hal
     - name: hal_atmel
-      revision: d697369628ba67d4613b90aa61a2822c3aaa876e
+      revision: da767444cce3c1d9ccd6b8a35fd7c67dc82d489c
       path: modules/hal/atmel
       groups:
         - hal


### PR DESCRIPTION
Rename EMPTY bit-fields, since they collide with the utility macro [EMPTY](https://docs.zephyrproject.org/apidoc/latest/group__sys-util.html#ga2b7cf2a3641be7b89138615764d60ba3).