### PR TITLE
MAINTAINERS: Add Sensry Platforms

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -4322,6 +4322,17 @@ Secure storage:
   tests:
     - psa.secure_storage
 
+Sensry Platforms:
+  status: maintained
+  maintainers:
+    - tswaehn
+  files:
+    - boards/sensry/
+  files-regex:
+    - .*sy1xx.*
+  labels:
+    - "platform: sensry"
+
 Storage:
   status: odd fixes
   files:


### PR DESCRIPTION
Sensry currently supports 2 boards, based on its own ganymed soc sy1xx (arch RISCV32), in Zephyr.
Given the growing interest from our customers and our commitment to expanding support for Sensry platforms, I am volunteering to take over the maintenance of these boards and ganymed family socs.