### PR TITLE
net: coap_client: Fix build with C++ projects

### DIFF
--- a/include/zephyr/net/coap_client.h
+++ b/include/zephyr/net/coap_client.h
@@ -24,6 +24,10 @@
 #include <zephyr/net/coap.h>
 #include <zephyr/kernel.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /** Maximum size of a CoAP message */
 #define MAX_COAP_MSG_LEN (CONFIG_COAP_CLIENT_MESSAGE_HEADER_SIZE + \
 			  CONFIG_COAP_CLIENT_MESSAGE_SIZE)
@@ -194,6 +198,10 @@ static inline struct coap_client_option coap_client_option_initial_block2(void)
 
 	return block2;
 }
+
+#ifdef __cplusplus
+}
+#endif
 
 /**
  * @}

--- a/include/zephyr/net/coap_client.h
+++ b/include/zephyr/net/coap_client.h
@@ -188,16 +188,7 @@ void coap_client_cancel_request(struct coap_client *client, struct coap_client_r
  *
  * @return CoAP client initial Block2 option structure
  */
-static inline struct coap_client_option coap_client_option_initial_block2(void)
-{
-	struct coap_client_option block2 = {
-		.code = COAP_OPTION_BLOCK2,
-		.len = 1,
-		.value[0] = coap_bytes_to_block_size(CONFIG_COAP_CLIENT_BLOCK_SIZE),
-	};
-
-	return block2;
-}
+struct coap_client_option coap_client_option_initial_block2(void);
 
 #ifdef __cplusplus
 }

--- a/subsys/net/lib/coap/coap_client.c
+++ b/subsys/net/lib/coap/coap_client.c
@@ -1112,6 +1112,16 @@ int coap_client_init(struct coap_client *client, const char *info)
 	return 0;
 }
 
+struct coap_client_option coap_client_option_initial_block2(void)
+{
+	struct coap_client_option block2 = {
+		.code = COAP_OPTION_BLOCK2,
+		.len = 1,
+		.value[0] = coap_bytes_to_block_size(CONFIG_COAP_CLIENT_BLOCK_SIZE),
+	};
+
+	return block2;
+}
 
 K_THREAD_DEFINE(coap_client_recv_thread, CONFIG_COAP_CLIENT_STACK_SIZE,
 		coap_client_recv, NULL, NULL, NULL,


### PR DESCRIPTION
* Add missing cpp guard in the header
* Move the `coap_client_option_initial_block2()` implementation to the library C file