### PR TITLE
drivers: serial: silabs_usart: Implement power management

### DIFF
--- a/drivers/serial/Kconfig.silabs_usart
+++ b/drivers/serial/Kconfig.silabs_usart
@@ -13,6 +13,5 @@ config UART_SILABS_USART
 	select DMA if UART_ASYNC_API
 	select PINCTRL
 	select CLOCK_CONTROL
-	select PM_DEVICE if PM
 	help
 	  Enable the Silicon Labs usart driver.

--- a/tests/drivers/uart/uart_async_api/boards/xg24_rb4187c.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/xg24_rb4187c.overlay
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2025, Silicon Laboratories Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Need to connect PC1 and PC2 of the Expension Pin header
+ */
+/ {
+	chosen {
+		zephyr,console = &eusart1;
+		zephyr,shell-uart = &eusart1;
+		zephyr,uart-pipe = &eusart1;
+	};
+};
+
+&pinctrl{
+	usart0_default: usart0_default {
+		group0 {
+			pins = <USART0_TX_PC1>;
+			drive-push-pull;
+			output-high;
+		};
+		group1 {
+			pins = <USART0_RX_PC2>;
+			input-enable;
+			silabs,input-filter;
+		};
+	};
+	eusart1_default: eusart1_default {
+		group0 {
+			pins = <EUSART1_TX_PA8>;
+			drive-push-pull;
+			output-high;
+		};
+		group1 {
+			pins = <EUSART1_RX_PA9>;
+			input-enable;
+			silabs,input-filter;
+		};
+	};
+};
+
+dut: &usart0 {
+	dmas = <&dma0 DMA_REQSEL_USART0TXBL>,
+	       <&dma0 DMA_REQSEL_USART0RXDATAV>;
+	dma-names = "tx", "rx";
+	pinctrl-0 = <&usart0_default>;
+	pinctrl-names = "default";
+};
+
+&eusart1 {
+	compatible = "silabs,eusart-uart";
+	current-speed = <115200>;
+	pinctrl-0 = <&eusart1_default>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
+&dma0 {
+	status = "okay";
+};


### PR DESCRIPTION
This PR implements power management for the USART peripheral on Silabs Series 2 devices.

PM Suspend and Resume actions are mapped to starting/stopping the USART, enabling/disabling the bus clock and reconfiguring pins.

Additionally, PM states representing deep sleep states are locked whenever a TX or RX operation is in progress, as the USART loses its clock in these states.

This PR enables support for runtime device power management, but does not enable it by default at the driver level, as subsystems that make use of UART (such as shell) do not yet get/put the PM handle. To enable runtime device power management, `zephyr,pm-device-runtime-auto` must be set by users in DTS.

To work properly with system-managed device power management, `zephyr,pm-device-disabled` must be set on the EM1 sleep mode in DTS to prevent the USART from being stopped during sleep. This is not handled in this PR.