### PR TITLE
net: socket: service: Restart instead of bailing out when error

### DIFF
--- a/subsys/net/lib/sockets/sockets_service.c
+++ b/subsys/net/lib/sockets/sockets_service.c
@@ -254,8 +254,8 @@ restart:
 			if (ctx.events[i].revents > 0) {
 				ret = trigger_work(&ctx.events[i]);
 				if (ret < 0) {
-					NET_ERR("Triggering work failed (%d)", ret);
-					goto out;
+					NET_DBG("Triggering work failed (%d)", ret);
+					goto restart;
 				}
 			}
 		}


### PR DESCRIPTION
It might happen now after the commit 8519fa162787 ("net: socket service resets its restart flag") that the event has disappeared before we call the work, if that happens we must not bail out but restart the service