### PR TITLE
Bluetooth: ISO: Add range to BT_ISO_MAX_BIG

### DIFF
--- a/subsys/bluetooth/Kconfig
+++ b/subsys/bluetooth/Kconfig
@@ -372,6 +372,7 @@ if BT_ISO_BROADCAST
 config BT_ISO_MAX_BIG
 	int "Maximum number of Broadcast Isochronous Groups (BIGs) to support"
 	default 1
+	range 1 BT_EXT_ADV_MAX_ADV_SET
 	help
 	  Maximum number of BIGs that are supported by the host. A BIG can be
 	  used for either transmitting or receiving, but not at the same time.


### PR DESCRIPTION
If BT_ISO_BROADCAST is enabled, then we shall support at least 1 BIG and at most BT_EXT_ADV_MAX_ADV_SET since each BIG requires its own advertising set.