### PR TITLE
drivers: spi: nrfx: Add explicit dependency to GPIO

### DIFF
--- a/drivers/spi/Kconfig.nrfx
+++ b/drivers/spi/Kconfig.nrfx
@@ -6,6 +6,7 @@ menuconfig SPI_NRFX
 	default y
 	depends on SOC_FAMILY_NORDIC_NRF
 	depends on MULTITHREADING
+	select GPIO
 	select PINCTRL
 	help
 	  Enable support for nrfx SPI drivers for nRF MCU series.


### PR DESCRIPTION
This dependency was always there but not explicitly defined. By adding the explicit dependency it becomes more obvious what is wrong when SPI is enabled but GPIO disabled.

This was found when building `samples/bluetooth/peripheral` for `nrf54l15dk/nrf54l15/cpuapp` with `CONFIG_GPIO=n`.

Before we got:
 - A linker error in `spi_nrfx_common.c` failing to reference some nrfx_gpiote APIs.
 - A linker error in `spi_nrfx_spim.c` failing to reference the GPIO dts entry.

Now we will get:
- A CMake warning will be issued that the SPI driver is not compiled in.
- A linker error in `spi_nor.c` failing to reference a SPI driver.

With this it becomes more obvious that SPI driver is enabled by default because of the external flash mounted on the DK.
