### PR TITLE
twister: extend reason field in Twister reports

### DIFF
--- a/scripts/tests/twister_blackbox/test_report.py
+++ b/scripts/tests/twister_blackbox/test_report.py
@@ -114,8 +114,8 @@ class TestReport:
             os.path.join(TEST_DATA, 'tests', 'one_fail_two_error_one_pass'),
             ['qemu_x86/atom'],
             [r'one_fail_two_error_one_pass.agnostic.group1.subgroup2 on qemu_x86/atom FAILED \(.*\)',
-            r'one_fail_two_error_one_pass.agnostic.group1.subgroup3 on qemu_x86/atom ERROR \(Build failure\)',
-            r'one_fail_two_error_one_pass.agnostic.group1.subgroup4 on qemu_x86/atom ERROR \(Build failure\)'],
+            r'one_fail_two_error_one_pass.agnostic.group1.subgroup3 on qemu_x86/atom ERROR \(Build failure.*\)',
+            r'one_fail_two_error_one_pass.agnostic.group1.subgroup4 on qemu_x86/atom ERROR \(Build failure.*\)'],
         )
     ]
 


### PR DESCRIPTION
Extended the reason field in Twister report to include more detailed information for 'Build failure' and
'CMake build failure'
Added parsing of specific error keys from logs to provide clearer context in the reports.

Requested here: https://discord.com/channels/720317445772017664/733037890514321419/1337400203019550786

To test you can modify hello_world sample, e.g.:
- add unused variable to main.c, to have build error
- add test configuration with wrong Kconfig to have Cmake error
```
  sample.cmake_err.helloworld:
    extra_args:
      - CONFIG_LOG="blah"
 ```

and run:
`$ZEPHYR_BASE/scripts/twister -vv -T samples/hello_world -p native_sim -ll debug`
then you will find more details in `reason` field in twister.json (and in `message` field in junit reports).



