### PR TITLE
modules: debug: mipi-sys-t PR 14 "potential error warning removed"

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -311,7 +311,7 @@ manifest:
       path: modules/debug/mipi-sys-t
       groups:
         - debug
-      revision: 71ace1f5caa03e56c8740a09863e685efb4b2360
+      revision: 33e5c23cbedda5ba12dbe50c4baefb362a791001
     - name: net-tools
       revision: 93acc8bac4661e74e695eb1aea94c7c5262db2e2
       path: tools/net-tools


### PR DESCRIPTION
Adjusted code where a deliberate assignment happened in a q-mark operator, which caused IAR to give a warning
"did you mean '==' instead of '=' ?"