### PR TITLE
scripts: west_commands: runners: fix and removes the '--dt-flash' option.

### DIFF
--- a/boards/common/silabs_commander.board.cmake
+++ b/boards/common/silabs_commander.board.cmake
@@ -1,4 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 board_set_flasher_ifnset(silabs_commander)
-board_finalize_runner_args(silabs_commander)
+board_finalize_runner_args(silabs_commander "--dt-flash=y")

--- a/scripts/west_commands/runners/core.py
+++ b/scripts/west_commands/runners/core.py
@@ -558,7 +558,7 @@ class ZephyrBinaryRunner(abc.ABC):
             parser.add_argument('-i', '--dev-id', help=argparse.SUPPRESS)
 
         if caps.flash_addr:
-            parser.add_argument('--dt-flash', default='n', choices=_YN_CHOICES,
+            parser.add_argument('--dt-flash', default=False, choices=_YN_CHOICES,
                                 action=_DTFlashAction,
                                 help='''If 'yes', try to use flash address
                                 information from devicetree when flash

--- a/scripts/west_commands/runners/minichlink.py
+++ b/scripts/west_commands/runners/minichlink.py
@@ -57,7 +57,7 @@ class MiniChLinkBinaryRunner(ZephyrBinaryRunner):
             minichlink=args.minichlink,
             erase=args.erase,
             reset=args.reset,
-            dt_flash=(args.dt_flash == "y"),
+            dt_flash=args.dt_flash,
             terminal=args.terminal,
         )
 

--- a/scripts/west_commands/runners/spi_burn.py
+++ b/scripts/west_commands/runners/spi_burn.py
@@ -56,11 +56,14 @@ class SpiBurnBinaryRunner(ZephyrBinaryRunner):
             iceman  = 'ICEman'
 
         # Get flash address offset
-        if args.dt_flash == 'y':
+        if args.dt_flash:
             build_conf = BuildConfiguration(cfg.build_dir)
-            address = hex(
-                cls.get_flash_address(args, build_conf) - build_conf['CONFIG_FLASH_BASE_ADDRESS']
-            )
+
+            if build_conf.getboolean('CONFIG_HAS_FLASH_LOAD_OFFSET'):
+                address = hex(build_conf['CONFIG_FLASH_LOAD_OFFSET'])
+            else:
+                address = '0x0'
+
         else:
             address = args.addr
 


### PR DESCRIPTION
 The '--dt-flash' parameter accepts a string like "y", "yes", "no", etc, and is supposed to be converted into a boolean value. This is only the theory as in practice, the default value is set to 'n' and is never converted to False afterwards.

Some runners are depending on this behavior, so this pull request fixes these runners, and corrects the value of the '--dt-flash' option.

~Once everything is fixed, I noticed that the --dt-flash option was not really useful, as it was set to True almost everywhere. So the fourth commit removes the option, except for the spi_burn runner, which seems to be using it. I didn't really understand what was spi_burn trying to do, so I just moved the handling of the option into `spi_burn.py`. Maybe it isn't useful and should also be removed ?~

~If --dt-flash is useful and I just didn't saw why, I can remove the fourth commit and only keep the first three.~

Edit: dt-flash is a public API so this PR now doesn't remove it, it just fixes the bug.