### PR TITLE
Bluetooth: Controller: Fix assertion terminating Periodic Sync

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
@@ -1100,6 +1100,7 @@ static void isr_done_cleanup(void *param)
 		node_rx2->hdr.type = NODE_RX_TYPE_EXT_AUX_RELEASE;
 
 		node_rx2->rx_ftr.param = lll;
+		node_rx2->rx_ftr.lll_aux = lll->lll_aux;
 
 		ull_rx_put_sched(node_rx2->hdr.link, node_rx2);
 	}

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
@@ -710,6 +710,7 @@ static void isr_done(void *param)
 		node_rx->hdr.type = NODE_RX_TYPE_EXT_AUX_RELEASE;
 
 		node_rx->rx_ftr.param = lll;
+		node_rx->rx_ftr.lll_aux = lll->lll_aux;
 		node_rx->rx_ftr.aux_failed = 1U;
 
 		ull_rx_put_sched(node_rx->hdr.link, node_rx);
@@ -897,6 +898,7 @@ isr_rx_do_close:
 			 * free it.
 			 */
 			node_rx2->rx_ftr.param = lll;
+			node_rx2->rx_ftr.lll_aux = lll->lll_aux;
 
 			ull_rx_put_sched(node_rx2->hdr.link, node_rx2);
 		}
@@ -1620,7 +1622,8 @@ isr_rx_connect_rsp_do_close:
 
 		node_rx->hdr.type = NODE_RX_TYPE_EXT_AUX_RELEASE;
 
-		node_rx->rx_ftr.param = lll->lll_aux;
+		node_rx->rx_ftr.param = lll;
+		node_rx->rx_ftr.lll_aux = lll->lll_aux;
 
 		ull_rx_put_sched(node_rx->hdr.link, node_rx);
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync.c
@@ -1152,6 +1152,7 @@ isr_rx_aux_chain_done:
 		node_rx->hdr.type = NODE_RX_TYPE_EXT_AUX_RELEASE;
 
 		node_rx->rx_ftr.param = lll;
+		node_rx->rx_ftr.lll_aux = lll->lll_aux;
 		node_rx->rx_ftr.aux_failed = 1U;
 
 		ull_rx_put(node_rx->hdr.link, node_rx);
@@ -1250,6 +1251,7 @@ static void isr_done(void *param)
 		node_rx->hdr.type = NODE_RX_TYPE_EXT_AUX_RELEASE;
 
 		node_rx->rx_ftr.param = lll;
+		node_rx->rx_ftr.lll_aux = lll->lll_aux;
 		node_rx->rx_ftr.aux_failed = 1U;
 
 		ull_rx_put_sched(node_rx->hdr.link, node_rx);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync.c
@@ -635,6 +635,9 @@ static void abort_cb(struct lll_prepare_param *prepare_param, void *param)
 	lll = prepare_param->param;
 	lll->skip_prepare += (lll->lazy_prepare + 1U);
 
+	/* Reset Sync context association with any Aux context as the chain reception is aborted. */
+	lll->lll_aux = NULL;
+
 	/* Extra done event, to check sync lost */
 	e = ull_event_done_extra_get();
 	LL_ASSERT(e);
@@ -1184,6 +1187,9 @@ isr_rx_aux_chain_done:
 static void isr_rx_done_cleanup(struct lll_sync *lll, uint8_t crc_ok, bool sync_term)
 {
 	struct event_done_extra *e;
+
+	/* Reset Sync context association with any Aux context as the chain reception is done. */
+	lll->lll_aux = NULL;
 
 	/* Calculate and place the drift information in done event */
 	e = ull_event_done_extra_get();

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync.c
@@ -834,6 +834,7 @@ static int isr_rx(struct lll_sync *lll, uint8_t node_type, uint8_t crc_ok,
 
 			ftr = &(node_rx->rx_ftr);
 			ftr->param = lll;
+			ftr->lll_aux = lll->lll_aux;
 			ftr->aux_failed = 0U;
 			ftr->rssi = (rssi_ready) ? radio_rssi_get() :
 						   BT_HCI_LE_RSSI_NOT_AVAILABLE;

--- a/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
@@ -293,7 +293,13 @@ void ull_scan_aux_setup(memq_link_t *link, struct node_rx_pdu *rx)
 			 */
 			sync_lll = ftr->param;
 
-			lll_aux = sync_lll->lll_aux;
+			/* We can not retrieve aux context that was stored in
+			 * lll_sync when superior PDU was handled, as it may be
+			 * reset to NULL before this node rx is processed here.
+			 * The reset happens when new Periodic Advertising chain
+			 * is being received before we process the node here.
+			 */
+			lll_aux =  ftr->lll_aux;
 			LL_ASSERT(lll_aux);
 
 			aux = HDR_LLL2ULL(lll_aux);

--- a/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
@@ -1104,7 +1104,7 @@ void ull_scan_aux_release(memq_link_t *link, struct node_rx_pdu *rx)
 		rx->hdr.type = NODE_RX_TYPE_RELEASE;
 
 		lll = rx->rx_ftr.param;
-		lll_aux = lll->lll_aux;
+		lll_aux = rx->rx_ftr.lll_aux;
 
 	} else if (!IS_ENABLED(CONFIG_BT_CTLR_SYNC_PERIODIC) ||
 		   ull_scan_aux_is_valid_get(param_ull)) {
@@ -1123,7 +1123,7 @@ void ull_scan_aux_release(memq_link_t *link, struct node_rx_pdu *rx)
 		sync->data_len = 0U;
 
 		lll = rx->rx_ftr.param;
-		lll_aux = lll->lll_aux;
+		lll_aux = rx->rx_ftr.lll_aux;
 
 		/* Change node type so HCI can dispatch report for truncated
 		 * data properly.


### PR DESCRIPTION
Fix assertion due to changes introduced to support multiple
advertising chain reception.

Auxiliary context association with the Periodic Sync context
was not cleared due to which when terminating a Periodic
Synchronization triggered an assertion check, under race
conditions, detecting that the auxiliary context was already
released.

Fix regression introduced in Periodic Advertising
Synchronization due to change related to multiple
Advertising chain reception.

Related commit c334ed515b08 ("Bluetooth: Controller: Fix
multiple Extended Adv chain reception"), and
commit da792a9e1707 ("Bluetooth: Controller: Fix interleaved
extended scanning assert").

Fix to release aux context stored in node rx, and not in the
superior scan or sync context as the one in the superior scan
or sync context could be reset or have a different new aux
context when multiple advertising chain reception is used.
