### PR TITLE
net: ipv6: Remove unused function

### DIFF
--- a/subsys/net/ip/ipv6_nbr.c
+++ b/subsys/net/ip/ipv6_nbr.c
@@ -135,21 +135,6 @@ static inline struct net_nbr *get_nbr(int idx)
 	return &net_neighbor_pool[idx].nbr;
 }
 
-static inline struct net_nbr *get_nbr_from_data(struct net_ipv6_nbr_data *data)
-{
-	int i;
-
-	for (i = 0; i < CONFIG_NET_IPV6_MAX_NEIGHBORS; i++) {
-		struct net_nbr *nbr = get_nbr(i);
-
-		if (nbr->data == (uint8_t *)data) {
-			return nbr;
-		}
-	}
-
-	return NULL;
-}
-
 static void ipv6_nbr_set_state(struct net_nbr *nbr,
 			       enum net_ipv6_nbr_state new_state)
 {


### PR DESCRIPTION
Building with clang warns:

subsys/net/ip/ipv6_nbr.c:137:31: error: unused function
'get_nbr_from_data' [-Werror,-Wunused-function]
static inline struct net_nbr *get_nbr_from_data(struct net_ipv6_nbr_data
                              ^                 *data)

