### PR TITLE
stm32h7 split etc sram name declaration and sram configuration

### DIFF
--- a/soc/st/stm32/stm32h7x/mpu_regions.c
+++ b/soc/st/stm32/stm32h7x/mpu_regions.c
@@ -22,19 +22,19 @@ static const struct arm_mpu_region mpu_regions[] = {
 					MPU_RASR_XN_Msk | P_RW_U_NA_Msk) }),
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(mac))
+
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(sram3))
-	MPU_REGION_ENTRY("SRAM3_ETH_BUF",
-					 DT_REG_ADDR(DT_NODELABEL(sram3)),
-					 REGION_RAM_NOCACHE_ATTR(REGION_16K)),
-	MPU_REGION_ENTRY("SRAM3_ETH_DESC",
-					 DT_REG_ADDR(DT_NODELABEL(sram3)),
-					 REGION_PPB_ATTR(REGION_256B)),
+#define sram_eth_node	DT_NODELABEL(sram3)
 #else
-	MPU_REGION_ENTRY("SRAM2_ETH_BUF",
-					 DT_REG_ADDR(DT_NODELABEL(sram2)),
+#define sram_eth_node	DT_NODELABEL(sram2)
+#endif
+
+#if DT_NODE_HAS_STATUS_OKAY(sram_eth_node)
+	MPU_REGION_ENTRY("SRAM_ETH_BUF",
+					 DT_REG_ADDR(sram_eth_node),
 					 REGION_RAM_NOCACHE_ATTR(REGION_16K)),
-	MPU_REGION_ENTRY("SRAM2_ETH_DESC",
-					 DT_REG_ADDR(DT_NODELABEL(sram2)),
+	MPU_REGION_ENTRY("SRAM_ETH_DESC",
+					 DT_REG_ADDR(sram_eth_node),
 					 REGION_PPB_ATTR(REGION_256B)),
 #endif
 #endif

--- a/soc/st/stm32/stm32h7x/sections.ld
+++ b/soc/st/stm32/stm32h7x/sections.ld
@@ -4,24 +4,23 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#if DT_NODE_HAS_STATUS(DT_NODELABEL(mac), okay)
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(mac))
 
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(sram3))
+#define sram_eth_node	DT_NODELABEL(sram3)
+#else
+#define sram_eth_node	DT_NODELABEL(sram2)
+#endif
+
+#if DT_NODE_HAS_STATUS_OKAY(sram_eth_node)
 SECTION_DATA_PROLOGUE(eth_stm32,(NOLOAD),)
 {
-#if DT_NODE_HAS_STATUS(DT_NODELABEL(sram3), okay)
-    . = ABSOLUTE(DT_REG_ADDR(DT_NODELABEL(sram3)));
+    . = ABSOLUTE(DT_REG_ADDR(sram_eth_node));
     *(.eth_stm32_desc)
-    . = ABSOLUTE(DT_REG_ADDR(DT_NODELABEL(sram3))) + 256;
+    . = ABSOLUTE(DT_REG_ADDR(sram_eth_node)) + 256;
     *(.eth_stm32_buf)
-    . = ABSOLUTE(DT_REG_ADDR(DT_NODELABEL(sram3))) + 16K;
-} GROUP_DATA_LINK_IN(LINKER_DT_NODE_REGION_NAME(DT_NODELABEL(sram3)), LINKER_DT_NODE_REGION_NAME(DT_NODELABEL(sram3)))
+    . = ABSOLUTE(DT_REG_ADDR(sram_eth_node)) + 16K;
+} GROUP_DATA_LINK_IN(LINKER_DT_NODE_REGION_NAME(sram_eth_node), LINKER_DT_NODE_REGION_NAME(sram_eth_node))
+#endif
 
-#else
-    . = ABSOLUTE(DT_REG_ADDR(DT_NODELABEL(sram2)));
-    *(.eth_stm32_desc)
-    . = ABSOLUTE(DT_REG_ADDR(DT_NODELABEL(sram2))) + 256;
-    *(.eth_stm32_buf)
-    . = ABSOLUTE(DT_REG_ADDR(DT_NODELABEL(sram2))) + 16K;
-} GROUP_DATA_LINK_IN(LINKER_DT_NODE_REGION_NAME(DT_NODELABEL(sram2)), LINKER_DT_NODE_REGION_NAME(DT_NODELABEL(sram2)))
-#endif
-#endif
+#endif /* DT_NODE_HAS_STATUS(DT_NODELABEL(mac), okay) */


### PR DESCRIPTION
This change splits eth sram region name definition
and configuration.
In the end the configuration is stored only once
er declared name.
This name shall increase readability and maintainability