### PR TITLE
W1/Scanner sample overlay files for MAX Boards

### DIFF
--- a/samples/drivers/w1/scanner/boards/max32655evkit_max32655_m4.overlay
+++ b/samples/drivers/w1/scanner/boards/max32655evkit_max32655_m4.overlay
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2025 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&owm_io_p0_6 {
+	power-source=<MAX32_VSEL_VDDIOH>;
+};
+
+&owm_pe_p0_7 {
+	power-source=<MAX32_VSEL_VDDIOH>;
+};
+
+&w1 {
+	status = "okay";
+	internal-pullup = <1>;
+	external-pullup = <0>;
+};

--- a/samples/drivers/w1/scanner/boards/max32666evkit_max32666_cpu0.overlay
+++ b/samples/drivers/w1/scanner/boards/max32666evkit_max32666_cpu0.overlay
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2025 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&owm_io_p0_4 {
+	power-source=<MAX32_VSEL_VDDIOH>;
+};
+
+&owm_pe_p0_5 {
+	power-source=<MAX32_VSEL_VDDIOH>;
+};
+
+&w1 {
+	status = "okay";
+	internal-pullup = <1>;
+	external-pullup = <0>;
+};

--- a/samples/drivers/w1/scanner/boards/max32666fthr_max32666_cpu0.overlay
+++ b/samples/drivers/w1/scanner/boards/max32666fthr_max32666_cpu0.overlay
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2025 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&owm_io_p0_12 {
+	power-source=<MAX32_VSEL_VDDIOH>;
+};
+
+&owm_pe_p0_13 {
+	power-source=<MAX32_VSEL_VDDIOH>;
+};
+
+&w1 {
+	status = "okay";
+	internal-pullup = <1>;
+	external-pullup = <0>;
+};

--- a/samples/drivers/w1/scanner/boards/max32690evkit_max32690_m4.overlay
+++ b/samples/drivers/w1/scanner/boards/max32690evkit_max32690_m4.overlay
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2025 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&owm_io_p0_8 {
+	power-source=<MAX32_VSEL_VDDIOH>;
+};
+
+&owm_pe_p0_7 {
+	power-source=<MAX32_VSEL_VDDIOH>;
+};
+
+&w1 {
+	status = "okay";
+	internal-pullup = <1>;
+	external-pullup = <0>;
+};

--- a/samples/drivers/w1/scanner/boards/max78000evkit_max78000_m4.overlay
+++ b/samples/drivers/w1/scanner/boards/max78000evkit_max78000_m4.overlay
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2025 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&owm_io_p0_18 {
+	power-source=<MAX32_VSEL_VDDIOH>;
+};
+
+&owm_pe_p0_19 {
+	power-source=<MAX32_VSEL_VDDIOH>;
+};
+
+&w1 {
+	status = "okay";
+	internal-pullup = <1>;
+	external-pullup = <0>;
+};

--- a/samples/drivers/w1/scanner/boards/max78000fthr_max78000_m4.overlay
+++ b/samples/drivers/w1/scanner/boards/max78000fthr_max78000_m4.overlay
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2025 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&owm_io_p0_18 {
+	power-source=<MAX32_VSEL_VDDIOH>;
+};
+
+&owm_pe_p0_19 {
+	power-source=<MAX32_VSEL_VDDIOH>;
+};
+
+&w1 {
+	status = "okay";
+	internal-pullup = <1>;
+	external-pullup = <0>;
+};

--- a/samples/drivers/w1/scanner/boards/max78002evkit_max78002_m4.overlay
+++ b/samples/drivers/w1/scanner/boards/max78002evkit_max78002_m4.overlay
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2025 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&owm_io_p0_6 {
+	power-source=<MAX32_VSEL_VDDIOH>;
+};
+
+&owm_pe_p0_7 {
+	power-source=<MAX32_VSEL_VDDIOH>;
+};
+
+&w1 {
+	status = "okay";
+	internal-pullup = <1>;
+	external-pullup = <0>;
+};

--- a/samples/drivers/w1/scanner/sample.yaml
+++ b/samples/drivers/w1/scanner/sample.yaml
@@ -50,3 +50,20 @@ tests:
       regex:
         - "Number of devices found on bus: .*"
       fixture: w1_scanner_w1_serial
+  sample.drivers.w1.scanner.max:
+    depends_on: w1
+    platform_allow:
+      - max32655evkit/max32655/m4
+      - max32666evkit/max32666/cpu0
+      - max32666fthr/max32666/cpu0
+      - max32690evkit/max32690/m4
+      - max78000evkit/max78000/m4
+      - max78000fthr/max78000/m4
+      - max78002evkit/max78002/m4
+    integration_platforms:
+      - max32655evkit/max32655/m4
+    harness_config:
+      type: one_line
+      regex:
+        - "Number of devices found on bus: .*"
+      fixture: w1_scanner_w1_max


### PR DESCRIPTION
This PR enables w1/scanner sample for:
 - MAX32655EVKIT
 - MAX32666EVKIT
 - MAX32666FTHR
 - MAX32690EVKIT
 - MAX78000EVKIT
 - MAX78000FTHR
 - MAX78002EVKIT