### PR TITLE
test: net: shell Remove unused function

### DIFF
--- a/tests/net/shell/src/main.c
+++ b/tests/net/shell/src/main.c
@@ -107,24 +107,6 @@ static int tester_send(const struct device *dev, struct net_pkt *pkt)
 	return 0;
 }
 
-static inline struct in_addr *if_get_addr(struct net_if *iface)
-{
-	int i;
-
-	for (i = 0; i < NET_IF_MAX_IPV4_ADDR; i++) {
-		if (iface->config.ip.ipv4->unicast[i].ipv4.is_used &&
-		    iface->config.ip.ipv4->unicast[i].ipv4.address.family ==
-								AF_INET &&
-		    iface->config.ip.ipv4->unicast[i].ipv4.addr_state ==
-							NET_ADDR_PREFERRED) {
-			return
-			    &iface->config.ip.ipv4->unicast[i].ipv4.address.in_addr;
-		}
-	}
-
-	return NULL;
-}
-
 struct net_udp_context net_udp_context_data;
 
 static struct dummy_api net_udp_if_api = {


### PR DESCRIPTION
Building with clang warns:

tests/net/shell/src/main.c:110:31: error: unused function 'if_get_addr'
[-Werror,-Wunused-function]
static inline struct in_addr *if_get_addr(struct net_if *iface)
                              ^