### PR TITLE
drivers: flash: spi_nor: Fix unused function warning

### DIFF
--- a/drivers/flash/spi_nor.c
+++ b/drivers/flash/spi_nor.c
@@ -305,12 +305,12 @@ static inline void record_entered_dpd(const struct device *const dev)
 #endif
 }
 
+#if ANY_INST_HAS_DPD
 /* Check the current time against the time DPD was entered and delay
  * until it's ok to initiate the DPD exit process.
  */
 static inline void delay_until_exit_dpd_ok(const struct device *const dev)
 {
-#if ANY_INST_HAS_DPD
 	const struct spi_nor_config *const driver_config = dev->config;
 
 	if (driver_config->dpd_exist) {
@@ -338,10 +338,8 @@ static inline void delay_until_exit_dpd_ok(const struct device *const dev)
 			}
 		}
 	}
-#else
-	ARG_UNUSED(dev);
-#endif /* ANY_INST_HAS_DPD */
 }
+#endif /* ANY_INST_HAS_DPD */
 
 /* Indicates that an access command includes bytes for the address.
  * If not provided the opcode is not followed by address bytes.


### PR DESCRIPTION
Building with clang warns:

drivers/flash/spi_nor.c:306:20: error: unused function
'delay_until_exit_dpd_ok' [-Werror,-Wunused-function]
static inline void delay_until_exit_dpd_ok(const struct device *const dev)
                   ^

delay_until_exit_dpd_ok is only used when ANY_INST_HAS_DPD is defined.