### PR TITLE
drivers: ieee802154: Remove unused function

### DIFF
--- a/drivers/ieee802154/ieee802154_dw1000.c
+++ b/drivers/ieee802154/ieee802154_dw1000.c
@@ -274,16 +274,6 @@ static inline uint32_t dwt_reg_read_u32(const struct device *dev,
 	return sys_get_le32(buf);
 }
 
-static inline uint16_t dwt_reg_read_u16(const struct device *dev,
-				     uint8_t reg, uint16_t offset)
-{
-	uint8_t buf[sizeof(uint16_t)];
-
-	dwt_spi_transfer(dev, reg, offset, sizeof(buf), buf, false);
-
-	return sys_get_le16(buf);
-}
-
 static inline uint8_t dwt_reg_read_u8(const struct device *dev,
 				   uint8_t reg, uint16_t offset)
 {


### PR DESCRIPTION
Building with clang warns:

drivers/ieee802154/ieee802154_dw1000.c:277:24: error: unused function
'dwt_reg_read_u16' [-Werror,-Wunused-function]
static inline uint16_t dwt_reg_read_u16(const struct device *dev,
                       ^