### PR TITLE
drivers: sensor: Fix unused function warning

### DIFF
--- a/drivers/sensor/st/lis2dw12/lis2dw12.c
+++ b/drivers/sensor/st/lis2dw12/lis2dw12.c
@@ -190,18 +190,6 @@ static int lis2dw12_config(const struct device *dev, enum sensor_channel chan,
 	return -ENOTSUP;
 }
 
-
-static inline int32_t sensor_ms2_to_mg(const struct sensor_value *ms2)
-{
-	int64_t nano_ms2 = (ms2->val1 * 1000000LL + ms2->val2) * 1000LL;
-
-	if (nano_ms2 > 0) {
-		return (nano_ms2 + SENSOR_G / 2) / SENSOR_G;
-	} else {
-		return (nano_ms2 - SENSOR_G / 2) / SENSOR_G;
-	}
-}
-
 #if (CONFIG_LIS2DW12_SLEEP || CONFIG_LIS2DW12_WAKEUP)
 
 /* Converts a lis2dw12_fs_t range to its value in milli-g

--- a/include/zephyr/drivers/sensor.h
+++ b/include/zephyr/drivers/sensor.h
@@ -1209,6 +1209,25 @@ static inline void sensor_g_to_ms2(int32_t g, struct sensor_value *ms2)
 }
 
 /**
+ * @brief Helper function to convert acceleration from m/s^2 to milli Gs
+ *
+ * @param ms2 A pointer to a sensor_value struct holding the acceleration,
+ *            in m/s^2.
+ *
+ * @return The converted value, in milli Gs.
+ */
+static inline int32_t sensor_ms2_to_mg(const struct sensor_value *ms2)
+{
+	int64_t nano_ms2 = (ms2->val1 * 1000000LL + ms2->val2) * 1000LL;
+
+	if (nano_ms2 > 0) {
+		return (nano_ms2 + SENSOR_G / 2) / SENSOR_G;
+	} else {
+		return (nano_ms2 - SENSOR_G / 2) / SENSOR_G;
+	}
+}
+
+/**
  * @brief Helper function to convert acceleration from m/s^2 to micro Gs
  *
  * @param ms2 A pointer to a sensor_value struct holding the acceleration,


### PR DESCRIPTION
Building with clang warns:

drivers/sensor/st/lis2dw12/lis2dw12.c:194:23: error: unused
function 'sensor_ms2_to_mg' [-Werror,-Wunused-function]
static inline int32_t sensor_ms2_to_mg(const struct sensor_value *ms2)
                      ^

Move the function to include/zephyr/drivers/sensor.h with the other
sensor_ms2_to* functions.