### PR TITLE
drivers: sensor: Fix unused function warning

### DIFF
--- a/drivers/sensor/st/lsm9ds0_mfd/lsm9ds0_mfd.c
+++ b/drivers/sensor/st/lsm9ds0_mfd/lsm9ds0_mfd.c
@@ -38,7 +38,8 @@ static inline int lsm9ds0_mfd_reboot_memory(const struct device *dev)
 	return 0;
 }
 
-#if !defined(LSM9DS0_MFD_ACCEL_DISABLED)
+#if !defined(LSM9DS0_MFD_ACCEL_DISABLED) && defined(CONFIG_LSM9DS0_MFD_ACCEL_SAMPLING_RATE_RUNTIME)
+
 static inline int lsm9ds0_mfd_accel_set_odr_raw(const struct device *dev,
 						uint8_t odr)
 {
@@ -49,7 +50,6 @@ static inline int lsm9ds0_mfd_accel_set_odr_raw(const struct device *dev,
 				      odr << LSM9DS0_MFD_SHIFT_CTRL_REG1_XM_AODR);
 }
 
-#if defined(CONFIG_LSM9DS0_MFD_ACCEL_SAMPLING_RATE_RUNTIME)
 static const struct {
 	int freq_int;
 	int freq_micro;
@@ -121,7 +121,6 @@ static int lsm9ds0_mfd_accel_set_fs(const struct device *dev, int val)
 
 	return -ENOTSUP;
 }
-#endif
 #endif
 
 #if !defined(LSM9DS0_MFD_MAGN_DISABLED)


### PR DESCRIPTION
Building with clang warns:

drivers/sensor/st/lsm9ds0_mfd/lsm9ds0_mfd.c:42:19: error: unused
function 'lsm9ds0_mfd_accel_set_odr_raw' [-Werror,-Wunused-function]
static inline int lsm9ds0_mfd_accel_set_odr_raw(const struct device *dev,
                  ^

lsm9ds0_mfd_accel_set_odr_raw is only used by code that was guarded by
defined(CONFIG_LSM9DS0_MFD_ACCEL_SAMPLING_RATE_RUNTIME) in addition to
!defined(LSM9DS0_MFD_ACCEL_DISABLED).