### PR TITLE
drivers: sensor: Remove unused function

### DIFF
--- a/drivers/sensor/st/iis2iclx/iis2iclx.c
+++ b/drivers/sensor/st/iis2iclx/iis2iclx.c
@@ -65,20 +65,6 @@ static int iis2iclx_accel_range_to_fs_val(int32_t range)
 	return -EINVAL;
 }
 
-static inline int iis2iclx_reboot(const struct device *dev)
-{
-	const struct iis2iclx_config *cfg = dev->config;
-
-	if (iis2iclx_boot_set((stmdev_ctx_t *)&cfg->ctx, 1) < 0) {
-		return -EIO;
-	}
-
-	/* Wait sensor turn-on time as per datasheet */
-	k_msleep(35);
-
-	return 0;
-}
-
 static int iis2iclx_accel_set_fs_raw(const struct device *dev, uint8_t fs)
 {
 	const struct iis2iclx_config *cfg = dev->config;


### PR DESCRIPTION
Building with clang warns:

drivers/sensor/st/iis2iclx/iis2iclx.c:68:19: error: unused function
'iis2iclx_reboot' [-Werror,-Wunused-function]
static inline int iis2iclx_reboot(const struct device *dev)
                  ^