### PR TITLE
drivers: modem: Remove unused function

### DIFF
--- a/drivers/modem/modem_cmd_handler.c
+++ b/drivers/modem/modem_cmd_handler.c
@@ -99,12 +99,6 @@ static bool starts_with(struct net_buf *buf, const char *str)
  * Cmd Handler Functions
  */
 
-static inline struct net_buf *read_rx_allocator(k_timeout_t timeout,
-						void *user_data)
-{
-	return net_buf_alloc((struct net_buf_pool *)user_data, timeout);
-}
-
 /* return scanned length for params */
 static int parse_params(struct modem_cmd_handler_data *data,  size_t match_len,
 			const struct modem_cmd *cmd,


### PR DESCRIPTION
Building with clang warns:

drivers/modem/modem_cmd_handler.c:102:31: error: unused function
'read_rx_allocator' [-Werror,-Wunused-function]
static inline struct net_buf *read_rx_allocator(k_timeout_t timeout,
                              ^