### PR TITLE
net: utils: Fix unused function warning

### DIFF
--- a/subsys/net/ip/utils.c
+++ b/subsys/net/ip/utils.c
@@ -636,6 +636,7 @@ uint16_t calc_chksum(uint16_t sum_in, const uint8_t *data, size_t len)
 	}
 }
 
+#if defined(CONFIG_NET_NATIVE_IP)
 static inline uint16_t pkt_calc_chksum(struct net_pkt *pkt, uint16_t sum)
 {
 	struct net_pkt_cursor *cur = &pkt->cursor;
@@ -673,7 +674,6 @@ static inline uint16_t pkt_calc_chksum(struct net_pkt *pkt, uint16_t sum)
 	return sum;
 }
 
-#if defined(CONFIG_NET_NATIVE_IP)
 uint16_t net_calc_chksum(struct net_pkt *pkt, uint8_t proto)
 {
 	size_t len = 0U;


### PR DESCRIPTION
Building with clang warns:

subsys/net/ip/utils.c:600:24: error: unused function 'pkt_calc_chksum'
[-Werror,-Wunused-function]
static inline uint16_t pkt_calc_chksum(struct net_pkt *pkt, uint16_t sum)
                       ^

pkt_calc_chksum is called by net_calc_chksum, which only exists when
CONFIG_NET_NATIVE_IP is defined.