### PR TITLE
net: lib: http_server: Remove unused function

### DIFF
--- a/subsys/net/lib/http/http_hpack.c
+++ b/subsys/net/lib/http/http_hpack.c
@@ -18,11 +18,6 @@ static inline bool http_hpack_key_is_static(uint32_t key)
 	return key > HTTP_SERVER_HPACK_INVALID && key <= HTTP_SERVER_HPACK_WWW_AUTHENTICATE;
 }
 
-static inline bool http_hpack_key_is_dynamic(uint32_t key)
-{
-	return key > HTTP_SERVER_HPACK_WWW_AUTHENTICATE;
-}
-
 struct hpack_table_entry {
 	const char *name;
 	const char *value;


### PR DESCRIPTION
Building with clang warns:

subsys/net/lib/http/http_hpack.c:21:20: error: unused function
'http_hpack_key_is_dynamic' [-Werror,-Wunused-function]
static inline bool http_hpack_key_is_dynamic(uint32_t key)
                   ^