### PR TITLE
ztest: ztest_mock: Fix typo

### DIFF
--- a/subsys/testsuite/ztest/src/ztest_mock.c
+++ b/subsys/testsuite/ztest/src/ztest_mock.c
@@ -253,7 +253,7 @@ void z_ztest_check_expected_data(const char *fn, const char *name, void *data, u
 		ztest_test_fail();
 	} else if (data != NULL) {
 		if (memcmp(data, expected, length) != 0) {
-			PRINT_DATA("%s:%s data provided don't match\n", fn, name);
+			PRINT_DATA("%s:%s data provided doesn't match\n", fn, name);
 			ztest_test_fail();
 		}
 	}


### PR DESCRIPTION
"data provided don't match" should be
"data provided doesn't match"