### PR TITLE
drivers: gpio: gpio_dw: add optional API to set data and control source

### DIFF
--- a/drivers/gpio/gpio_dw.c
+++ b/drivers/gpio/gpio_dw.c
@@ -171,10 +171,9 @@ static int gpio_dw_pin_interrupt_configure(const struct device *port,
 					   enum gpio_int_mode mode,
 					   enum gpio_int_trig trig)
 {
-	struct gpio_dw_runtime *context = port->data;
 	const struct gpio_dw_config *config = port->config;
-	uint32_t base_addr = dw_base_to_block_base(context->base_addr);
-	uint32_t port_base_addr = context->base_addr;
+	uint32_t base_addr = dw_base_to_block_base(config->base_addr);
+	uint32_t port_base_addr = config->base_addr;
 	uint32_t dir_port = dw_get_dir_port(port_base_addr);
 	uint32_t data_port = dw_get_data_port(port_base_addr);
 	uint32_t dir_reg;
@@ -235,10 +234,9 @@ static int gpio_dw_pin_interrupt_configure(const struct device *port,
 static inline void dw_pin_config(const struct device *port,
 				 uint32_t pin, int flags)
 {
-	struct gpio_dw_runtime *context = port->data;
 	const struct gpio_dw_config *config = port->config;
-	uint32_t base_addr = dw_base_to_block_base(context->base_addr);
-	uint32_t port_base_addr = context->base_addr;
+	uint32_t base_addr = dw_base_to_block_base(config->base_addr);
+	uint32_t port_base_addr = config->base_addr;
 	uint32_t dir_port = dw_get_dir_port(port_base_addr);
 	bool pin_is_output, need_debounce;
 
@@ -267,11 +265,9 @@ static inline void dw_pin_config(const struct device *port,
 
 static void gpio_dw_set_hw_mode(const struct device *port, gpio_pin_t pin, bool hw_mode)
 {
-	struct gpio_dw_runtime *context = port->data;
-	__unused const struct gpio_driver_config *const cfg =
-		(const struct gpio_driver_config *)port->config;
-	uint32_t base_addr = dw_base_to_block_base(context->base_addr);
-	uint32_t port_id = dw_derive_port_from_base(context->base_addr);
+	const struct gpio_dw_config *config = port->config;
+	uint32_t base_addr = dw_base_to_block_base(config->base_addr);
+	uint32_t port_id = dw_derive_port_from_base(config->base_addr);
 	uint32_t ctl_port;
 
 	/* 4-port GPIO implementation translates from base address to port */
@@ -339,9 +335,9 @@ static inline int gpio_dw_config(const struct device *port,
 
 static int gpio_dw_port_get_raw(const struct device *port, uint32_t *value)
 {
-	struct gpio_dw_runtime *context = port->data;
-	uint32_t base_addr = dw_base_to_block_base(context->base_addr);
-	uint32_t port_base_addr = context->base_addr;
+	const struct gpio_dw_config *config = port->config;
+	uint32_t base_addr = dw_base_to_block_base(config->base_addr);
+	uint32_t port_base_addr = config->base_addr;
 	uint32_t ext_port = dw_get_ext_port(port_base_addr);
 
 	*value = dw_read(base_addr, ext_port);
@@ -352,9 +348,9 @@ static int gpio_dw_port_get_raw(const struct device *port, uint32_t *value)
 static int gpio_dw_port_set_masked_raw(const struct device *port,
 				       uint32_t mask, uint32_t value)
 {
-	struct gpio_dw_runtime *context = port->data;
-	uint32_t base_addr = dw_base_to_block_base(context->base_addr);
-	uint32_t port_base_addr = context->base_addr;
+	const struct gpio_dw_config *config = port->config;
+	uint32_t base_addr = dw_base_to_block_base(config->base_addr);
+	uint32_t port_base_addr = config->base_addr;
 	uint32_t data_port = dw_get_data_port(port_base_addr);
 	uint32_t pins;
 
@@ -367,9 +363,9 @@ static int gpio_dw_port_set_masked_raw(const struct device *port,
 
 static int gpio_dw_port_set_bits_raw(const struct device *port, uint32_t mask)
 {
-	struct gpio_dw_runtime *context = port->data;
-	uint32_t base_addr = dw_base_to_block_base(context->base_addr);
-	uint32_t port_base_addr = context->base_addr;
+	const struct gpio_dw_config *config = port->config;
+	uint32_t base_addr = dw_base_to_block_base(config->base_addr);
+	uint32_t port_base_addr = config->base_addr;
 	uint32_t data_port = dw_get_data_port(port_base_addr);
 	uint32_t pins;
 
@@ -383,9 +379,9 @@ static int gpio_dw_port_set_bits_raw(const struct device *port, uint32_t mask)
 static int gpio_dw_port_clear_bits_raw(const struct device *port,
 				       uint32_t mask)
 {
-	struct gpio_dw_runtime *context = port->data;
-	uint32_t base_addr = dw_base_to_block_base(context->base_addr);
-	uint32_t port_base_addr = context->base_addr;
+	const struct gpio_dw_config *config = port->config;
+	uint32_t base_addr = dw_base_to_block_base(config->base_addr);
+	uint32_t port_base_addr = config->base_addr;
 	uint32_t data_port = dw_get_data_port(port_base_addr);
 	uint32_t pins;
 
@@ -398,9 +394,9 @@ static int gpio_dw_port_clear_bits_raw(const struct device *port,
 
 static int gpio_dw_port_toggle_bits(const struct device *port, uint32_t mask)
 {
-	struct gpio_dw_runtime *context = port->data;
-	uint32_t base_addr = dw_base_to_block_base(context->base_addr);
-	uint32_t port_base_addr = context->base_addr;
+	const struct gpio_dw_config *config = port->config;
+	uint32_t base_addr = dw_base_to_block_base(config->base_addr);
+	uint32_t port_base_addr = config->base_addr;
 	uint32_t data_port = dw_get_data_port(port_base_addr);
 	uint32_t pins;
 
@@ -424,7 +420,8 @@ static inline int gpio_dw_manage_callback(const struct device *port,
 static void gpio_dw_isr(const struct device *port)
 {
 	struct gpio_dw_runtime *context = port->data;
-	uint32_t base_addr = dw_base_to_block_base(context->base_addr);
+	const struct gpio_dw_config *config = port->config;
+	uint32_t base_addr = dw_base_to_block_base(config->base_addr);
 	uint32_t int_status;
 
 	int_status = dw_read(base_addr, INTSTATUS);
@@ -448,13 +445,12 @@ static DEVICE_API(gpio, api_funcs) = {
 
 static int gpio_dw_initialize(const struct device *port)
 {
-	struct gpio_dw_runtime *context = port->data;
 	const struct gpio_dw_config *config = port->config;
 	uint32_t base_addr;
 
 	if (dw_interrupt_support(config)) {
 
-		base_addr = dw_base_to_block_base(context->base_addr);
+		base_addr = dw_base_to_block_base(config->base_addr);
 
 		/* interrupts in sync with system clock */
 		dw_set_bit(base_addr, INT_CLOCK_SYNC, LS_SYNC_POS, 1);
@@ -491,14 +487,13 @@ static int gpio_dw_initialize(const struct device *port)
 		.common = {									\
 			.port_pin_mask = GPIO_PORT_PIN_MASK_FROM_DT_INST(n),			\
 		},										\
+		.base_addr = DT_INST_REG_ADDR(n),						\
 		.irq_num = COND_CODE_1(DT_INST_IRQ_HAS_IDX(n, 0), (DT_INST_IRQN(n)), (0)),	\
 		.ngpios = DT_INST_PROP(n, ngpios),						\
 		.config_func = gpio_config_##n##_irq,						\
 	};											\
 												\
-	static struct gpio_dw_runtime gpio_##n##_runtime = {					\
-		.base_addr = DT_INST_REG_ADDR(n),						\
-	};											\
+	static struct gpio_dw_runtime gpio_##n##_runtime;					\
 												\
 	DEVICE_DT_INST_DEFINE(n, gpio_dw_initialize, NULL, &gpio_##n##_runtime,			\
 		      &gpio_dw_config_##n, PRE_KERNEL_1,					\

--- a/drivers/gpio/gpio_dw.h
+++ b/drivers/gpio/gpio_dw.h
@@ -20,6 +20,7 @@ typedef void (*gpio_config_irq_t)(const struct device *port);
 struct gpio_dw_config {
 	/* gpio_driver_config needs to be first */
 	struct gpio_driver_config common;
+	uint32_t base_addr;
 	uint32_t ngpios;
 	uint32_t irq_num; /* set to 0 if GPIO port cannot interrupt */
 	gpio_config_irq_t config_func;
@@ -28,7 +29,6 @@ struct gpio_dw_config {
 struct gpio_dw_runtime {
 	/* gpio_driver_data needs to be first */
 	struct gpio_driver_data common;
-	uint32_t base_addr;
 	sys_slist_t callbacks;
 };
 

--- a/include/zephyr/dt-bindings/gpio/snps-designware-gpio.h
+++ b/include/zephyr/dt-bindings/gpio/snps-designware-gpio.h
@@ -15,4 +15,12 @@
  */
 #define DW_GPIO_DEBOUNCE (1U << 8)
 
+/**
+ * @brief Enable hardware control/data source for a pin.
+ *
+ * Configures a pin to be controlled by a hardware data source (if
+ * supported).
+ */
+#define DW_GPIO_HW_MODE (1U << 9)
+
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_GPIO_SNPS_DESIGNWARE_GPIO_H_ */


### PR DESCRIPTION
If supported, the data and control source for a signal can come from either software or hardware. This change adds a driver specific API to set this for a specific pin.