### PR TITLE
fb: cfb: Use signed-integer for API that specifies coordinations

### DIFF
--- a/doc/releases/migration-guide-4.4.rst
+++ b/doc/releases/migration-guide-4.4.rst
@@ -958,6 +958,13 @@ LoRaWAN
 Other subsystems
 ****************
 
+CFB
+===
+
+* Change using signed values to represent the coordinates.
+  As a result, :c:func:`cfb_print`, :c:func:`cfb_invert_area`,
+  and :c:struct:`cfb_position` definitions are changed.
+
 * The DAP subsystem initialization and configuration has changed. Please take a look at
   :zephyr:code-sample:`cmsis-dap` sample on how to initialize Zephyr DAP Link with USB backend.
 

--- a/include/zephyr/display/cfb.h
+++ b/include/zephyr/display/cfb.h
@@ -24,7 +24,7 @@ extern "C" {
  * @brief Public Monochrome Character Framebuffer API
  * @defgroup monochrome_character_framebuffer Monochrome Character Framebuffer
  * @since 1.14.0
- * @version 0.9.0
+ * @version 0.10.0
  * @ingroup display_interface
  * @{
  */
@@ -53,8 +53,10 @@ struct cfb_font {
 };
 
 struct cfb_position {
-	uint16_t x;
-	uint16_t y;
+	/** X position */
+	int16_t x;
+	/** Y position */
+	int16_t y;
 };
 
 /**
@@ -88,7 +90,7 @@ struct cfb_position {
  *
  * @return 0 on success, negative value otherwise
  */
-int cfb_print(const struct device *dev, const char *const str, uint16_t x, uint16_t y);
+int cfb_print(const struct device *dev, const char *const str, int16_t x, int16_t y);
 
 /**
  * @brief Print a string into the framebuffer.
@@ -179,7 +181,7 @@ int cfb_framebuffer_invert(const struct device *dev);
  *
  * @return 0 on success, negative value otherwise
  */
-int cfb_invert_area(const struct device *dev, uint16_t x, uint16_t y,
+int cfb_invert_area(const struct device *dev, int16_t x, int16_t y,
 		    uint16_t width, uint16_t height);
 
 /**

--- a/subsys/fb/cfb.c
+++ b/subsys/fb/cfb.c
@@ -129,7 +129,7 @@ static uint8_t draw_char_vtmono(const struct char_framebuffer *fb,
 
 			const int16_t fb_y = y + g_y;
 			const size_t fb_index = (fb_y / 8U) * fb->x_res + fb_x;
-			const size_t offset = y % 8;
+			const size_t offset = ((y % 8) + 8) % 8;
 			const uint8_t bottom_lines = ((offset + fptr->height) % 8);
 			uint8_t bg_mask;
 			uint8_t byte;
@@ -432,41 +432,46 @@ int cfb_draw_text(const struct device *dev, const char *const str, int16_t x, in
 	return draw_text(dev, str, x, y, false);
 }
 
-int cfb_print(const struct device *dev, const char *const str, uint16_t x, uint16_t y)
+int cfb_print(const struct device *dev, const char *const str, int16_t x, int16_t y)
 {
 	return draw_text(dev, str, x, y, true);
 }
 
-int cfb_invert_area(const struct device *dev, uint16_t x, uint16_t y,
+int cfb_invert_area(const struct device *dev, int16_t x, int16_t y,
 		    uint16_t width, uint16_t height)
 {
 	const struct char_framebuffer *fb = &char_fb;
 	const bool need_reverse = ((fb->screen_info & SCREEN_INFO_MONO_MSB_FIRST) != 0);
 
-	if (x >= fb->x_res || y >= fb->y_res) {
-		LOG_ERR("Coordinates outside of framebuffer");
-
-		return -EINVAL;
+	if ((x + width) < 0 || x >= fb->x_res) {
+		return 0;
 	}
 
-	if (x > fb->x_res) {
-		x = fb->x_res;
+	if ((y + height) < 0 || y >= fb->y_res) {
+		return 0;
 	}
 
-	if (y > fb->y_res) {
-		y = fb->y_res;
+	if (x < 0) {
+		width += x;
+		x = 0;
 	}
 
-	if (x + width > fb->x_res) {
+	if (y < 0) {
+		height += y;
+		y = 0;
+	}
+
+	if (width > (fb->x_res - x)) {
 		width = fb->x_res - x;
 	}
 
-	if (y + height > fb->y_res) {
+	if (height > (fb->y_res - y)) {
 		height = fb->y_res - y;
 	}
 
+
 	if ((fb->screen_info & SCREEN_INFO_MONO_VTILED)) {
-		for (size_t i = x; i < x + width; i++) {
+		for (size_t i = x; i < (x + width); i++) {
 			for (size_t j = y; j < (y + height); j++) {
 				/*
 				 * Process inversion in the y direction

--- a/tests/subsys/display/cfb/basic/src/invert_area.c
+++ b/tests/subsys/display/cfb/basic/src/invert_area.c
@@ -66,26 +66,29 @@ ZTEST(invert_area, test_invert_area_overlapped_2times)
 
 ZTEST(invert_area, test_invert_area_overlap_top_left)
 {
-	int err;
+	zassert_ok(cfb_invert_area(dev, -10, -10, 20, 20));
+	zassert_ok(cfb_framebuffer_finalize(dev));
 
-	err = cfb_invert_area(dev, -10, -10, 20, 20);
-	zassert_not_ok(err, "out of rect");
+	zassert_true(verify_color_inside_rect(0, 0, 10, 10, 0xFFFFFF));
+	zassert_true(verify_color_outside_rect(0, 0, 10, 10, 0x0));
 }
 
 ZTEST(invert_area, test_invert_area_overlap_top_right)
 {
-	int err;
+	zassert_ok(cfb_invert_area(dev, display_width - 10, -10, 20, 20));
+	zassert_ok(cfb_framebuffer_finalize(dev));
 
-	err = cfb_invert_area(dev, 230, -10, 20, 20);
-	zassert_not_ok(err, "out of rect");
+	zassert_true(verify_color_inside_rect(display_width - 10, 0, 10, 10, 0xFFFFFF));
+	zassert_true(verify_color_outside_rect(display_width - 10, 0, 10, 10, 0x0));
 }
 
 ZTEST(invert_area, test_invert_area_overlap_bottom_left)
 {
-	int err;
+	zassert_ok(cfb_invert_area(dev, -10, display_height - 10, 20, 20));
+	zassert_ok(cfb_framebuffer_finalize(dev));
 
-	err = cfb_invert_area(dev, -10, display_height - 10, 20, 20);
-	zassert_not_ok(err, "out of rect");
+	zassert_true(verify_color_inside_rect(0, display_height - 10, 10, 10, 0xFFFFFF));
+	zassert_true(verify_color_outside_rect(0, display_height - 10, 10, 10, 0x0));
 }
 
 ZTEST(invert_area, test_invert_area_overlap_bottom_right)
@@ -101,12 +104,42 @@ ZTEST(invert_area, test_invert_area_overlap_bottom_right)
 
 ZTEST(invert_area, test_invert_area_outside_top_left)
 {
-	zassert_not_ok(cfb_invert_area(dev, -10, -10, 10, 10), "out of rect");
+	zassert_ok(cfb_invert_area(dev, -10, -10, 10, 10));
+	zassert_ok(cfb_framebuffer_finalize(dev));
+
+	zassert_true(verify_color_inside_rect(0, 0, display_width, display_height, 0x0));
+}
+
+ZTEST(invert_area, test_invert_area_outside_left_only)
+{
+	zassert_ok(cfb_invert_area(dev, -11, 0, 10, 10));
+	zassert_ok(cfb_framebuffer_finalize(dev));
+
+	zassert_true(verify_color_inside_rect(0, 0, display_width, display_height, 0x0));
+}
+
+ZTEST(invert_area, test_invert_area_outside_top_only)
+{
+	zassert_ok(cfb_invert_area(dev, 0, -11, 10, 10));
+	zassert_ok(cfb_framebuffer_finalize(dev));
+
+	zassert_true(verify_color_inside_rect(0, 0, display_width, display_height, 0x0));
 }
 
 ZTEST(invert_area, test_invert_area_outside_bottom_right)
 {
-	zassert_not_ok(cfb_invert_area(dev, display_width, display_height, 20, 20), "out of rect");
+	zassert_ok(cfb_invert_area(dev, display_width, display_height, 20, 20));
+	zassert_ok(cfb_framebuffer_finalize(dev));
+
+	zassert_true(verify_color_inside_rect(0, 0, display_width, display_height, 0x0));
+}
+
+ZTEST(invert_area, test_invert_area_outside_bottom_only)
+{
+	zassert_ok(cfb_invert_area(dev, 0, display_height, 10, 10));
+	zassert_ok(cfb_framebuffer_finalize(dev));
+
+	zassert_true(verify_color_inside_rect(0, 0, display_width, display_height, 0x0));
 }
 
 ZTEST_SUITE(invert_area, NULL, NULL, cfb_test_before, cfb_test_after, NULL);

--- a/tests/subsys/display/cfb/basic/src/print_rectspace1016.c
+++ b/tests/subsys/display/cfb/basic/src/print_rectspace1016.c
@@ -61,6 +61,15 @@ static void cfb_test_after(void *test_fixture)
 	cfb_framebuffer_deinit(dev);
 }
 
+static void verify_rectspace1016_bottom_half_at_origin(void)
+{
+	zassert_true(verify_color_inside_rect(0, 0, 1, 8, 0xFFFFFF));
+	zassert_true(verify_color_inside_rect(9, 0, 1, 8, 0xFFFFFF));
+	zassert_true(verify_color_inside_rect(1, 0, 8, 7, 0x0));
+	zassert_true(verify_color_inside_rect(0, 7, 10, 1, 0xFFFFFF));
+	zassert_true(verify_color_outside_rect(0, 0, 10, 8, 0x0));
+}
+
 /*
  * normal rendering
  */
@@ -180,6 +189,14 @@ ZTEST(print_rectspace1016, test_print_outside_top_left)
 	zassert_ok(cfb_framebuffer_finalize(dev));
 
 	zassert_true(verify_image_and_bg(0, 0, outside_top_left, 3, 4, 0));
+}
+
+ZTEST(print_rectspace1016, test_print_outside_top_tile_aligned)
+{
+	zassert_ok(cfb_print(dev, " ", 0, -8));
+	zassert_ok(cfb_framebuffer_finalize(dev));
+
+	verify_rectspace1016_bottom_half_at_origin();
 }
 
 ZTEST(print_rectspace1016, test_print_outside_top_right)


### PR DESCRIPTION
Change the arguments of `cfb_invert_area`, `cfb_print`, and
`cfb_draw_(point|line|rect|circle)`, which used unsigned integers to specify
coordinates to signed integers.

This is because coordinate are usually specify with real numbers,
so it is difficult to use unless negative numbers are accepted.
We clip drawings outside the drawable area on the implementation side.