### PR TITLE
samples: fix dts missing in some NXP platforms

### DIFF
--- a/samples/sensor/accel_trig/boards/mimxrt1040_evk.overlay
+++ b/samples/sensor/accel_trig/boards/mimxrt1040_evk.overlay
@@ -1,0 +1,12 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2025 NXP
+ */
+
+
+&fxls8974 {
+	status = "okay";
+	int1-gpios = <&gpio1 11 GPIO_ACTIVE_LOW>;
+	int2-gpios = <&gpio1 12 GPIO_ACTIVE_LOW>;
+};

--- a/samples/sensor/accel_trig/boards/twr_ke18f.overlay
+++ b/samples/sensor/accel_trig/boards/twr_ke18f.overlay
@@ -1,0 +1,11 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2025 NXP
+ */
+
+&fxos8700 {
+	status = "okay";
+	int1-gpios = <&gpioa 14 GPIO_ACTIVE_LOW>;
+	int2-gpios = <&gpioa 17 GPIO_ACTIVE_LOW>;
+};

--- a/samples/sensor/magn_trig/boards/twr_ke18f.overlay
+++ b/samples/sensor/magn_trig/boards/twr_ke18f.overlay
@@ -1,0 +1,12 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2025 NXP
+ */
+
+
+&fxos8700 {
+	status = "okay";
+	int1-gpios = <&gpioa 14 GPIO_ACTIVE_LOW>;
+	int2-gpios = <&gpioa 17 GPIO_ACTIVE_LOW>;
+};

--- a/samples/sensor/magn_trig/sample.yaml
+++ b/samples/sensor/magn_trig/sample.yaml
@@ -6,7 +6,7 @@ tests:
     tags: sensors
     filter: dt_alias_exists("magn0")
     harness_config:
-      fixture: fixture_sensor_accel_int
+      fixture: fixture_sensor_magn_int
       type: one_line
       regex:
         - "^\\s*[0-9A-Za-z_,+-.]*@[0-9A-Fa-f]* \\(x, y, z\\):    \


### PR DESCRIPTION
fix the dts missed properties, as those need board rework.
also fix a naming issue in magn_trig fixture.

fixes: #85444  