### PR TITLE
drivers:sensor:sensirion:scd4x: Fixed ID for power down command

### DIFF
--- a/drivers/sensor/sensirion/scd4x/scd4x.h
+++ b/drivers/sensor/sensirion/scd4x/scd4x.h
@@ -29,7 +29,7 @@
 #define SCD4X_CMD_FACTORY_RESET                  17
 #define SCD4X_CMD_MEASURE_SINGLE_SHOT            18
 #define SCD4X_CMD_MEASURE_SINGLE_SHOT_RHT        19
-#define SCD4X_CMD_POWER_DOWN                     10
+#define SCD4X_CMD_POWER_DOWN                     20
 #define SCD4X_CMD_WAKE_UP                        21
 #define SCD4X_CMD_SET_SELF_CALIB_INITIAL_PERIOD  22
 #define SCD4X_CMD_GET_SELF_CALIB_INITIAL_PERIOD  23


### PR DESCRIPTION
SCD4X_CMD_POWER_DOWN should be 20 instead of 10. 

The command to perform power down in SCD41 sensor is `0x36e0`, which represents 20th element in `scd4x_cmds` array. The fix was tested with the actual sensor.
