### PR TITLE
drivers: serial: add placeholder file for new device stack USB CDC ACM

### DIFF
--- a/drivers/serial/CMakeLists.txt
+++ b/drivers/serial/CMakeLists.txt
@@ -9,6 +9,7 @@ zephyr_library_sources_ifdef(CONFIG_SERIAL_TEST serial_test.c)
 zephyr_library_sources_ifdef(CONFIG_UART_ASYNC_RX_HELPER uart_async_rx.c)
 zephyr_library_sources_ifdef(CONFIG_UART_ASYNC_TO_INT_DRIVEN_API uart_async_to_irq.c)
 zephyr_library_sources_ifdef(CONFIG_UART_SHELL uart_shell.c)
+zephyr_library_sources_ifdef(CONFIG_USBD_CDC_ACM_CLASS ${ZEPHYR_BASE}/misc/empty_file.c)
 zephyr_library_sources_ifdef(CONFIG_USB_CDC_ACM ${ZEPHYR_BASE}/misc/empty_file.c)
 # zephyr-keep-sorted-stop
 


### PR DESCRIPTION
This is necessary to suppress CMake build warning due to no source file defined for drivers__serial.