### PR TITLE
arch: arm: cortex_m: Apply clang-format on cortex_m related code

### DIFF
--- a/arch/arm/core/cortex_m/cmse/arm_core_cmse.c
+++ b/arch/arm/core/cortex_m/cmse/arm_core_cmse.c
@@ -9,7 +9,7 @@
 
 int arm_cmse_mpu_region_get(uint32_t addr)
 {
-	cmse_address_info_t addr_info =	cmse_TT((void *)addr);
+	cmse_address_info_t addr_info = cmse_TT((void *)addr);
 
 	if (addr_info.flags.mpu_region_valid) {
 		return addr_info.flags.mpu_region;
@@ -40,8 +40,7 @@ int arm_cmse_addr_readwrite_ok(uint32_t addr, int force_npriv)
 	return arm_cmse_addr_read_write_ok(addr, force_npriv, 1);
 }
 
-static int arm_cmse_addr_range_read_write_ok(uint32_t addr, uint32_t size,
-	int force_npriv, int rw)
+static int arm_cmse_addr_range_read_write_ok(uint32_t addr, uint32_t size, int force_npriv, int rw)
 {
 	int flags = 0;
 
@@ -74,10 +73,10 @@ int arm_cmse_addr_range_readwrite_ok(uint32_t addr, uint32_t size, int force_npr
 
 int arm_cmse_mpu_nonsecure_region_get(uint32_t addr)
 {
-	cmse_address_info_t addr_info =	cmse_TTA((void *)addr);
+	cmse_address_info_t addr_info = cmse_TTA((void *)addr);
 
 	if (addr_info.flags.mpu_region_valid) {
-		return  addr_info.flags.mpu_region;
+		return addr_info.flags.mpu_region;
 	}
 
 	return -EINVAL;
@@ -85,7 +84,7 @@ int arm_cmse_mpu_nonsecure_region_get(uint32_t addr)
 
 int arm_cmse_sau_region_get(uint32_t addr)
 {
-	cmse_address_info_t addr_info =	cmse_TT((void *)addr);
+	cmse_address_info_t addr_info = cmse_TT((void *)addr);
 
 	if (addr_info.flags.sau_region_valid) {
 		return addr_info.flags.sau_region;
@@ -96,7 +95,7 @@ int arm_cmse_sau_region_get(uint32_t addr)
 
 int arm_cmse_idau_region_get(uint32_t addr)
 {
-	cmse_address_info_t addr_info =	cmse_TT((void *)addr);
+	cmse_address_info_t addr_info = cmse_TT((void *)addr);
 
 	if (addr_info.flags.idau_region_valid) {
 		return addr_info.flags.idau_region;
@@ -107,13 +106,12 @@ int arm_cmse_idau_region_get(uint32_t addr)
 
 int arm_cmse_addr_is_secure(uint32_t addr)
 {
-	cmse_address_info_t addr_info =	cmse_TT((void *)addr);
+	cmse_address_info_t addr_info = cmse_TT((void *)addr);
 
 	return addr_info.flags.secure;
 }
 
-static int arm_cmse_addr_nonsecure_read_write_ok(uint32_t addr,
-	int force_npriv, int rw)
+static int arm_cmse_addr_nonsecure_read_write_ok(uint32_t addr, int force_npriv, int rw)
 {
 	cmse_address_info_t addr_info;
 	if (force_npriv) {
@@ -122,8 +120,7 @@ static int arm_cmse_addr_nonsecure_read_write_ok(uint32_t addr,
 		addr_info = cmse_TTA((void *)addr);
 	}
 
-	return rw ? addr_info.flags.nonsecure_readwrite_ok :
-		addr_info.flags.nonsecure_read_ok;
+	return rw ? addr_info.flags.nonsecure_readwrite_ok : addr_info.flags.nonsecure_read_ok;
 }
 
 int arm_cmse_addr_nonsecure_read_ok(uint32_t addr, int force_npriv)
@@ -137,7 +134,7 @@ int arm_cmse_addr_nonsecure_readwrite_ok(uint32_t addr, int force_npriv)
 }
 
 static int arm_cmse_addr_range_nonsecure_read_write_ok(uint32_t addr, uint32_t size,
-	int force_npriv, int rw)
+						       int force_npriv, int rw)
 {
 	int flags = CMSE_NONSECURE;
 
@@ -156,18 +153,14 @@ static int arm_cmse_addr_range_nonsecure_read_write_ok(uint32_t addr, uint32_t s
 	}
 }
 
-int arm_cmse_addr_range_nonsecure_read_ok(uint32_t addr, uint32_t size,
-	int force_npriv)
+int arm_cmse_addr_range_nonsecure_read_ok(uint32_t addr, uint32_t size, int force_npriv)
 {
-	return arm_cmse_addr_range_nonsecure_read_write_ok(addr, size,
-		force_npriv, 0);
+	return arm_cmse_addr_range_nonsecure_read_write_ok(addr, size, force_npriv, 0);
 }
 
-int arm_cmse_addr_range_nonsecure_readwrite_ok(uint32_t addr, uint32_t size,
-	int force_npriv)
+int arm_cmse_addr_range_nonsecure_readwrite_ok(uint32_t addr, uint32_t size, int force_npriv)
 {
-	return arm_cmse_addr_range_nonsecure_read_write_ok(addr, size,
-		force_npriv, 1);
+	return arm_cmse_addr_range_nonsecure_read_write_ok(addr, size, force_npriv, 1);
 }
 
 #endif /* CONFIG_ARM_SECURE_FIRMWARE */

--- a/arch/arm/core/cortex_m/coredump.c
+++ b/arch/arm/core/cortex_m/coredump.c
@@ -7,31 +7,31 @@
 #include <string.h>
 #include <zephyr/debug/coredump.h>
 
-#define ARCH_HDR_VER			2
+#define ARCH_HDR_VER 2
 
 uint32_t z_arm_coredump_fault_sp;
 
 struct arm_arch_block {
 	struct {
-		uint32_t	r0;
-		uint32_t	r1;
-		uint32_t	r2;
-		uint32_t	r3;
-		uint32_t	r12;
-		uint32_t	lr;
-		uint32_t	pc;
-		uint32_t	xpsr;
-		uint32_t	sp;
+		uint32_t r0;
+		uint32_t r1;
+		uint32_t r2;
+		uint32_t r3;
+		uint32_t r12;
+		uint32_t lr;
+		uint32_t pc;
+		uint32_t xpsr;
+		uint32_t sp;
 
 		/* callee registers - optionally collected in V2 */
-		uint32_t	r4;
-		uint32_t	r5;
-		uint32_t	r6;
-		uint32_t	r7;
-		uint32_t	r8;
-		uint32_t	r9;
-		uint32_t	r10;
-		uint32_t	r11;
+		uint32_t r4;
+		uint32_t r5;
+		uint32_t r6;
+		uint32_t r7;
+		uint32_t r8;
+		uint32_t r9;
+		uint32_t r10;
+		uint32_t r11;
 	} r;
 } __packed;
 
@@ -76,12 +76,12 @@ void arch_coredump_info_dump(const struct arch_esf *esf)
 
 #if defined(CONFIG_EXTRA_EXCEPTION_INFO)
 	if (esf->extra_info.callee) {
-		arch_blk.r.r4  = esf->extra_info.callee->v1;
-		arch_blk.r.r5  = esf->extra_info.callee->v2;
-		arch_blk.r.r6  = esf->extra_info.callee->v3;
-		arch_blk.r.r7  = esf->extra_info.callee->v4;
-		arch_blk.r.r8  = esf->extra_info.callee->v5;
-		arch_blk.r.r9  = esf->extra_info.callee->v6;
+		arch_blk.r.r4 = esf->extra_info.callee->v1;
+		arch_blk.r.r5 = esf->extra_info.callee->v2;
+		arch_blk.r.r6 = esf->extra_info.callee->v3;
+		arch_blk.r.r7 = esf->extra_info.callee->v4;
+		arch_blk.r.r8 = esf->extra_info.callee->v5;
+		arch_blk.r.r9 = esf->extra_info.callee->v6;
 		arch_blk.r.r10 = esf->extra_info.callee->v7;
 		arch_blk.r.r11 = esf->extra_info.callee->v8;
 	}

--- a/arch/arm/core/cortex_m/cpu_idle.c
+++ b/arch/arm/core/cortex_m/cpu_idle.c
@@ -30,27 +30,31 @@ void z_arm_cpu_idle_init(void)
 #if defined(CONFIG_ARM_ON_EXIT_CPU_IDLE)
 #define ON_EXIT_IDLE_HOOK SOC_ON_EXIT_CPU_IDLE
 #else
-#define ON_EXIT_IDLE_HOOK do {} while (false)
+#define ON_EXIT_IDLE_HOOK                                                                          \
+	do {                                                                                       \
+	} while (false)
 #endif
 
 #if defined(CONFIG_ARM_ON_ENTER_CPU_IDLE_HOOK)
-#define SLEEP_IF_ALLOWED(wait_instr) do { \
-	/* Skip the wait instr if on_enter_cpu_idle returns false */ \
-	if (z_arm_on_enter_cpu_idle()) { \
-		/* Wait for all memory transaction to complete */ \
-		/* before entering low power state. */ \
-		__DSB(); \
-		wait_instr(); \
-		/* Inline the macro provided by SoC-specific code */ \
-		ON_EXIT_IDLE_HOOK; \
-	} \
-} while (false)
+#define SLEEP_IF_ALLOWED(wait_instr)                                                               \
+	do {                                                                                       \
+		/* Skip the wait instr if on_enter_cpu_idle returns false */                       \
+		if (z_arm_on_enter_cpu_idle()) {                                                   \
+			/* Wait for all memory transaction to complete */                          \
+			/* before entering low power state. */                                     \
+			__DSB();                                                                   \
+			wait_instr();                                                              \
+			/* Inline the macro provided by SoC-specific code */                       \
+			ON_EXIT_IDLE_HOOK;                                                         \
+		}                                                                                  \
+	} while (false)
 #else
-#define SLEEP_IF_ALLOWED(wait_instr) do { \
-	__DSB(); \
-	wait_instr(); \
-	ON_EXIT_IDLE_HOOK; \
-} while (false)
+#define SLEEP_IF_ALLOWED(wait_instr)                                                               \
+	do {                                                                                       \
+		__DSB();                                                                           \
+		wait_instr();                                                                      \
+		ON_EXIT_IDLE_HOOK;                                                                 \
+	} while (false)
 #endif
 
 #ifndef CONFIG_ARCH_HAS_CUSTOM_CPU_IDLE

--- a/arch/arm/core/cortex_m/debug.c
+++ b/arch/arm/core/cortex_m/debug.c
@@ -35,7 +35,7 @@ bool z_arm_debug_monitor_event_error_check(void)
 			printk("Null-pointer exception?\n");
 		}
 		__ASSERT((DWT->FUNCTION0 & DWT_FUNCTION_MATCHED_Msk) == 0,
-			"MATCHED flag should have been cleared on read.");
+			 "MATCHED flag should have been cleared on read.");
 
 		return true;
 	}
@@ -55,8 +55,8 @@ bool z_arm_debug_monitor_event_error_check(void)
  * so we add a build assert that catches it.
  */
 BUILD_ASSERT(!(CONFIG_CORTEX_M_NULL_POINTER_EXCEPTION_PAGE_SIZE &
-	(CONFIG_CORTEX_M_NULL_POINTER_EXCEPTION_PAGE_SIZE - 1)),
-	"the size of the partition must be power of 2");
+	       (CONFIG_CORTEX_M_NULL_POINTER_EXCEPTION_PAGE_SIZE - 1)),
+	     "the size of the partition must be power of 2");
 
 int z_arm_debug_enable_null_pointer_detection(void)
 {
@@ -81,20 +81,12 @@ int z_arm_debug_enable_null_pointer_detection(void)
 	DWT->COMP0 = 0;
 	DWT->COMP1 = CONFIG_CORTEX_M_NULL_POINTER_EXCEPTION_PAGE_SIZE - 1;
 
-	DWT->FUNCTION0 =
-		((0x4 << DWT_FUNCTION_MATCH_Pos) & DWT_FUNCTION_MATCH_Msk)
-		|
-		((0x1 << DWT_FUNCTION_ACTION_Pos) & DWT_FUNCTION_ACTION_Msk)
-		|
-		((0x0 << DWT_FUNCTION_DATAVSIZE_Pos) & DWT_FUNCTION_DATAVSIZE_Msk)
-		;
-	DWT->FUNCTION1 =
-		((0x7 << DWT_FUNCTION_MATCH_Pos) & DWT_FUNCTION_MATCH_Msk)
-		|
-		((0x1 << DWT_FUNCTION_ACTION_Pos) & DWT_FUNCTION_ACTION_Msk)
-		|
-		((0x0 << DWT_FUNCTION_DATAVSIZE_Pos) & DWT_FUNCTION_DATAVSIZE_Msk)
-		;
+	DWT->FUNCTION0 = ((0x4 << DWT_FUNCTION_MATCH_Pos) & DWT_FUNCTION_MATCH_Msk) |
+			 ((0x1 << DWT_FUNCTION_ACTION_Pos) & DWT_FUNCTION_ACTION_Msk) |
+			 ((0x0 << DWT_FUNCTION_DATAVSIZE_Pos) & DWT_FUNCTION_DATAVSIZE_Msk);
+	DWT->FUNCTION1 = ((0x7 << DWT_FUNCTION_MATCH_Pos) & DWT_FUNCTION_MATCH_Msk) |
+			 ((0x1 << DWT_FUNCTION_ACTION_Pos) & DWT_FUNCTION_ACTION_Msk) |
+			 ((0x0 << DWT_FUNCTION_DATAVSIZE_Pos) & DWT_FUNCTION_DATAVSIZE_Msk);
 #elif defined(CONFIG_ARMV7_M_ARMV8_M_MAINLINE)
 
 	/* ASSERT that we have the comparator needed for the implementation */
@@ -106,13 +98,10 @@ int z_arm_debug_enable_null_pointer_detection(void)
 	/* Use comparator 0, R/W access check */
 	DWT->COMP0 = 0;
 
-	DWT->FUNCTION0 = (0x7 << DWT_FUNCTION_FUNCTION_Pos) &
-		DWT_FUNCTION_FUNCTION_Msk;
-
+	DWT->FUNCTION0 = (0x7 << DWT_FUNCTION_FUNCTION_Pos) & DWT_FUNCTION_FUNCTION_Msk;
 
 	/* Set mask according to the desired size */
-	DWT->MASK0 = 32 - __builtin_clzl(
-		CONFIG_CORTEX_M_NULL_POINTER_EXCEPTION_PAGE_SIZE - 1);
+	DWT->MASK0 = 32 - __builtin_clzl(CONFIG_CORTEX_M_NULL_POINTER_EXCEPTION_PAGE_SIZE - 1);
 #endif
 
 	return 0;

--- a/arch/arm/core/cortex_m/fault.c
+++ b/arch/arm/core/cortex_m/fault.c
@@ -22,7 +22,7 @@
 LOG_MODULE_DECLARE(os, CONFIG_KERNEL_LOG_LEVEL);
 
 #if defined(CONFIG_PRINTK) || defined(CONFIG_LOG)
-#define PR_EXC(...) LOG_ERR(__VA_ARGS__)
+#define PR_EXC(...)              LOG_ERR(__VA_ARGS__)
 #define STORE_xFAR(reg_var, reg) uint32_t reg_var = (uint32_t)reg
 #else
 #define PR_EXC(...)
@@ -36,8 +36,8 @@ LOG_MODULE_DECLARE(os, CONFIG_KERNEL_LOG_LEVEL);
 #endif
 
 #if defined(CONFIG_ARM_MPU) && defined(CONFIG_CPU_HAS_NXP_SYSMPU)
-#define EMN(edr)   (((edr) & SYSMPU_EDR_EMN_MASK) >> SYSMPU_EDR_EMN_SHIFT)
-#define EACD(edr)  (((edr) & SYSMPU_EDR_EACD_MASK) >> SYSMPU_EDR_EACD_SHIFT)
+#define EMN(edr)  (((edr) & SYSMPU_EDR_EMN_MASK) >> SYSMPU_EDR_EMN_SHIFT)
+#define EACD(edr) (((edr) & SYSMPU_EDR_EACD_MASK) >> SYSMPU_EDR_EACD_SHIFT)
 #endif
 
 /* Integrity signature for an ARMv8-M implementation */
@@ -54,15 +54,12 @@ LOG_MODULE_DECLARE(os, CONFIG_KERNEL_LOG_LEVEL);
 
 #if defined(CONFIG_ARMV7_M_ARMV8_M_MAINLINE)
 /* helpers to access memory/bus/usage faults */
-#define SCB_CFSR_MEMFAULTSR \
-	(uint32_t)((SCB->CFSR & SCB_CFSR_MEMFAULTSR_Msk) \
-		   >> SCB_CFSR_MEMFAULTSR_Pos)
-#define SCB_CFSR_BUSFAULTSR \
-	(uint32_t)((SCB->CFSR & SCB_CFSR_BUSFAULTSR_Msk) \
-		   >> SCB_CFSR_BUSFAULTSR_Pos)
-#define SCB_CFSR_USGFAULTSR \
-	(uint32_t)((SCB->CFSR & SCB_CFSR_USGFAULTSR_Msk) \
-		   >> SCB_CFSR_USGFAULTSR_Pos)
+#define SCB_CFSR_MEMFAULTSR                                                                        \
+	(uint32_t)((SCB->CFSR & SCB_CFSR_MEMFAULTSR_Msk) >> SCB_CFSR_MEMFAULTSR_Pos)
+#define SCB_CFSR_BUSFAULTSR                                                                        \
+	(uint32_t)((SCB->CFSR & SCB_CFSR_BUSFAULTSR_Msk) >> SCB_CFSR_BUSFAULTSR_Pos)
+#define SCB_CFSR_USGFAULTSR                                                                        \
+	(uint32_t)((SCB->CFSR & SCB_CFSR_USGFAULTSR_Msk) >> SCB_CFSR_USGFAULTSR_Pos)
 #endif /* CONFIG_ARMV7_M_ARMV8_M_MAINLINE */
 
 /**
@@ -103,8 +100,8 @@ static void fault_show(const struct arch_esf *esf, int fault)
 	PR_EXC("Fault! EXC #%d", fault);
 
 #if defined(CONFIG_ARMV7_M_ARMV8_M_MAINLINE)
-	PR_EXC("MMFSR: 0x%x, BFSR: 0x%x, UFSR: 0x%x", SCB_CFSR_MEMFAULTSR,
-	       SCB_CFSR_BUSFAULTSR, SCB_CFSR_USGFAULTSR);
+	PR_EXC("MMFSR: 0x%x, BFSR: 0x%x, UFSR: 0x%x", SCB_CFSR_MEMFAULTSR, SCB_CFSR_BUSFAULTSR,
+	       SCB_CFSR_USGFAULTSR);
 #if defined(CONFIG_ARM_SECURE_FIRMWARE)
 	PR_EXC("SFSR: 0x%x", SAU->SFSR);
 #endif /* CONFIG_ARM_SECURE_FIRMWARE */
@@ -127,9 +124,7 @@ static void fault_show(const struct arch_esf *esf, int fault)
 #ifdef CONFIG_USERSPACE
 Z_EXC_DECLARE(z_arm_user_string_nlen);
 
-static const struct z_exc_handle exceptions[] = {
-	Z_EXC_HANDLE(z_arm_user_string_nlen)
-};
+static const struct z_exc_handle exceptions[] = {Z_EXC_HANDLE(z_arm_user_string_nlen)};
 #endif
 
 /* Perform an assessment whether an MPU fault shall be
@@ -146,12 +141,12 @@ static bool memory_fault_recoverable(struct arch_esf *esf, bool synchronous)
 		uint32_t end = (uint32_t)exceptions[i].end & ~0x1U;
 
 #if defined(CONFIG_NULL_POINTER_EXCEPTION_DETECTION_DWT)
-	/* Non-synchronous exceptions (e.g. DebugMonitor) may have
-	 * allowed PC to continue to the next instruction.
-	 */
-	end += (synchronous) ? 0x0 : 0x4;
+		/* Non-synchronous exceptions (e.g. DebugMonitor) may have
+		 * allowed PC to continue to the next instruction.
+		 */
+		end += (synchronous) ? 0x0 : 0x4;
 #else
-	ARG_UNUSED(synchronous);
+		ARG_UNUSED(synchronous);
 #endif
 		if (esf->basic.pc >= start && esf->basic.pc < end) {
 			esf->basic.pc = (uint32_t)(exceptions[i].fixup);
@@ -168,8 +163,7 @@ static bool memory_fault_recoverable(struct arch_esf *esf, bool synchronous)
 #elif defined(CONFIG_ARMV7_M_ARMV8_M_MAINLINE)
 
 #if defined(CONFIG_MPU_STACK_GUARD) || defined(CONFIG_USERSPACE)
-uint32_t z_check_thread_stack_fail(const uint32_t fault_addr,
-	const uint32_t psp);
+uint32_t z_check_thread_stack_fail(const uint32_t fault_addr, const uint32_t psp);
 #endif /* CONFIG_MPU_STACK_GUARD || defined(CONFIG_USERSPACE) */
 
 /**
@@ -180,8 +174,7 @@ uint32_t z_check_thread_stack_fail(const uint32_t fault_addr,
  *
  * @return error code to identify the fatal error reason
  */
-static uint32_t mem_manage_fault(struct arch_esf *esf, int from_hard_fault,
-			      bool *recoverable)
+static uint32_t mem_manage_fault(struct arch_esf *esf, int from_hard_fault, bool *recoverable)
 {
 	uint32_t reason = K_ERR_ARM_MEM_GENERIC;
 	uint32_t mmfar = -EINVAL;
@@ -191,7 +184,7 @@ static uint32_t mem_manage_fault(struct arch_esf *esf, int from_hard_fault,
 	if ((SCB->CFSR & SCB_CFSR_MSTKERR_Msk) != 0) {
 		reason = K_ERR_ARM_MEM_STACKING;
 		PR_FAULT_INFO("  Stacking error (context area might be"
-			" not valid)");
+			      " not valid)");
 	}
 	if ((SCB->CFSR & SCB_CFSR_MUNSTKERR_Msk) != 0) {
 		reason = K_ERR_ARM_MEM_UNSTACKING;
@@ -226,8 +219,7 @@ static uint32_t mem_manage_fault(struct arch_esf *esf, int from_hard_fault,
 #if defined(CONFIG_ARMV7_M_ARMV8_M_FP)
 	if ((SCB->CFSR & SCB_CFSR_MLSPERR_Msk) != 0) {
 		reason = K_ERR_ARM_MEM_FP_LAZY_STATE_PRESERVATION;
-		PR_FAULT_INFO(
-			"  Floating-point lazy state preservation error");
+		PR_FAULT_INFO("  Floating-point lazy state preservation error");
 	}
 #endif /* CONFIG_ARMV7_M_ARMV8_M_FP */
 
@@ -244,8 +236,7 @@ static uint32_t mem_manage_fault(struct arch_esf *esf, int from_hard_fault,
 	 * Data Access Violation errors may or may not be caused by
 	 * thread stack overflows.
 	 */
-	if ((SCB->CFSR & SCB_CFSR_MSTKERR_Msk) ||
-		(SCB->CFSR & SCB_CFSR_DACCVIOL_Msk)) {
+	if ((SCB->CFSR & SCB_CFSR_MSTKERR_Msk) || (SCB->CFSR & SCB_CFSR_DACCVIOL_Msk)) {
 #if defined(CONFIG_MPU_STACK_GUARD) || defined(CONFIG_USERSPACE)
 		/* MemManage Faults are always banked between security
 		 * states. Therefore, we can safely assume the fault
@@ -265,8 +256,8 @@ static uint32_t mem_manage_fault(struct arch_esf *esf, int from_hard_fault,
 		 * handle the case of 'mmfar' holding the -EINVAL value.
 		 */
 		if (SCB->ICSR & SCB_ICSR_RETTOBASE_Msk) {
-			uint32_t min_stack_ptr = z_check_thread_stack_fail(mmfar,
-				((uint32_t) &esf[0]));
+			uint32_t min_stack_ptr =
+				z_check_thread_stack_fail(mmfar, ((uint32_t)&esf[0]));
 
 			if (min_stack_ptr) {
 				/* When MemManage Stacking Error has occurred,
@@ -299,14 +290,14 @@ static uint32_t mem_manage_fault(struct arch_esf *esf, int from_hard_fault,
 				reason = K_ERR_STACK_CHK_FAIL;
 			} else {
 				__ASSERT(!(SCB->CFSR & SCB_CFSR_MSTKERR_Msk),
-					"Stacking error not a stack fail\n");
+					 "Stacking error not a stack fail\n");
 			}
 		}
 #else
-	(void)mmfar;
-	__ASSERT(!(SCB->CFSR & SCB_CFSR_MSTKERR_Msk),
-		"Stacking or Data Access Violation error "
-		"without stack guard, user-mode or null-pointer detection\n");
+		(void)mmfar;
+		__ASSERT(!(SCB->CFSR & SCB_CFSR_MSTKERR_Msk),
+			 "Stacking or Data Access Violation error "
+			 "without stack guard, user-mode or null-pointer detection\n");
 #endif /* CONFIG_MPU_STACK_GUARD || CONFIG_USERSPACE */
 	}
 
@@ -408,13 +399,10 @@ static int bus_fault(struct arch_esf *esf, int from_hard_fault, bool *recoverabl
 
 			PR_FAULT_INFO("  NXP MPU error, port %d", i);
 			PR_FAULT_INFO("    Mode: %s, %s Address: 0x%x",
-			       edr & BIT(2) ? "Supervisor" : "User",
-			       edr & BIT(1) ? "Data" : "Instruction",
-			       ear);
-			PR_FAULT_INFO(
-					"    Type: %s, Master: %d, Regions: 0x%x",
-			       edr & BIT(0) ? "Write" : "Read",
-			       EMN(edr), EACD(edr));
+				      edr & BIT(2) ? "Supervisor" : "User",
+				      edr & BIT(1) ? "Data" : "Instruction", ear);
+			PR_FAULT_INFO("    Type: %s, Master: %d, Regions: 0x%x",
+				      edr & BIT(0) ? "Write" : "Read", EMN(edr), EACD(edr));
 
 			/* When stack protection is enabled, we need to assess
 			 * if the memory violation error is a stack corruption.
@@ -437,8 +425,7 @@ static int bus_fault(struct arch_esf *esf, int from_hard_fault, bool *recoverabl
 				 */
 				if (SCB->ICSR & SCB_ICSR_RETTOBASE_Msk) {
 					uint32_t min_stack_ptr =
-						z_check_thread_stack_fail(ear,
-							((uint32_t) &esf[0]));
+						z_check_thread_stack_fail(ear, ((uint32_t)&esf[0]));
 
 					if (min_stack_ptr) {
 						/* When BusFault Stacking Error
@@ -468,16 +455,14 @@ static int bus_fault(struct arch_esf *esf, int from_hard_fault, bool *recoverabl
 						 */
 						__set_PSP(min_stack_ptr);
 
-						reason =
-							K_ERR_STACK_CHK_FAIL;
+						reason = K_ERR_STACK_CHK_FAIL;
 						break;
 					}
 				}
 #else
 				(void)ear;
 				__ASSERT(0,
-					"Stacking error without stack guard"
-					"or User-mode support");
+					 "Stacking error without stack guard or User-mode support");
 #endif /* CONFIG_MPU_STACK_GUARD || CONFIG_USERSPACE */
 			}
 		}
@@ -617,8 +602,7 @@ static void debug_monitor(struct arch_esf *esf, bool *recoverable)
 {
 	*recoverable = false;
 
-	PR_FAULT_INFO(
-		"***** Debug monitor exception *****");
+	PR_FAULT_INFO("***** Debug monitor exception *****");
 
 #if defined(CONFIG_NULL_POINTER_EXCEPTION_DETECTION_DWT)
 	if (!z_arm_debug_monitor_event_error_check()) {
@@ -675,7 +659,7 @@ static inline bool z_arm_is_synchronous_svc(struct arch_esf *esf)
 #endif /* ARMV6_M_ARMV8_M_BASELINE && !ARMV8_M_BASELINE */
 
 	if (((fault_insn & 0xff00) == _SVC_OPCODE) &&
-		((fault_insn & 0x00ff) == _SVC_CALL_RUNTIME_EXCEPT)) {
+	    ((fault_insn & 0x00ff) == _SVC_CALL_RUNTIME_EXCEPT)) {
 		return true;
 	}
 #undef _SVC_OPCODE
@@ -759,13 +743,11 @@ static uint32_t hard_fault(struct arch_esf *esf, bool *recoverable)
 			reason = secure_fault(esf);
 #endif /* CONFIG_ARM_SECURE_FIRMWARE */
 		} else {
-			__ASSERT(0,
-			"Fault escalation without FSR info");
+			__ASSERT(0, "Fault escalation without FSR info");
 		}
 	} else {
-		__ASSERT(0,
-		"HardFault without HFSR info"
-		" Shall never occur");
+		__ASSERT(0, "HardFault without HFSR info"
+			    " Shall never occur");
 	}
 #else
 #error Unknown ARM architecture
@@ -786,8 +768,7 @@ static void reserved_exception(const struct arch_esf *esf, int fault)
 	ARG_UNUSED(esf);
 
 	PR_FAULT_INFO("***** %s %d) *****",
-	       fault < 16 ? "Reserved Exception (" : "Spurious interrupt (IRQ ",
-	       fault - 16);
+		      fault < 16 ? "Reserved Exception (" : "Spurious interrupt (IRQ ", fault - 16);
 }
 
 /* Handler function for ARM fault conditions. */
@@ -802,7 +783,7 @@ static uint32_t fault_handle(struct arch_esf *esf, int fault, bool *recoverable)
 		reason = hard_fault(esf, recoverable);
 		break;
 #if defined(CONFIG_ARMV6_M_ARMV8_M_BASELINE)
-	/* HardFault is raised for all fault conditions on ARMv6-M. */
+		/* HardFault is raised for all fault conditions on ARMv6-M. */
 #elif defined(CONFIG_ARMV7_M_ARMV8_M_MAINLINE)
 	case 4:
 		reason = mem_manage_fault(esf, 0, recoverable);
@@ -860,7 +841,7 @@ static void secure_stack_dump(const struct arch_esf *secure_esf)
 	uint32_t sec_ret_addr;
 #if defined(CONFIG_ARMV7_M_ARMV8_M_FP)
 	if ((*top_of_sec_stack == INTEGRITY_SIGNATURE_STD) ||
-		(*top_of_sec_stack == INTEGRITY_SIGNATURE_EXT)) {
+	    (*top_of_sec_stack == INTEGRITY_SIGNATURE_EXT)) {
 #else
 	if (*top_of_sec_stack == INTEGRITY_SIGNATURE) {
 #endif /* CONFIG_ARMV7_M_ARMV8_M_FP */
@@ -879,7 +860,6 @@ static void secure_stack_dump(const struct arch_esf *secure_esf)
 		sec_ret_addr = *top_of_sec_stack;
 	}
 	PR_FAULT_INFO("  S instruction address:  0x%x", sec_ret_addr);
-
 }
 #define SECURE_STACK_DUMP(esf) secure_stack_dump(esf)
 #else
@@ -900,15 +880,14 @@ static void secure_stack_dump(const struct arch_esf *secure_esf)
  * @return ESF pointer on success, otherwise return NULL
  */
 static inline struct arch_esf *get_esf(uint32_t msp, uint32_t psp, uint32_t exc_return,
-	bool *nested_exc)
+				       bool *nested_exc)
 {
 	bool alternative_state_exc = false;
 	struct arch_esf *ptr_esf = NULL;
 
 	*nested_exc = false;
 
-	if ((exc_return & EXC_RETURN_INDICATOR_PREFIX) !=
-			EXC_RETURN_INDICATOR_PREFIX) {
+	if ((exc_return & EXC_RETURN_INDICATOR_PREFIX) != EXC_RETURN_INDICATOR_PREFIX) {
 		/* Invalid EXC_RETURN value. This is a fatal error. */
 		return NULL;
 	}
@@ -988,8 +967,7 @@ static inline struct arch_esf *get_esf(uint32_t msp, uint32_t psp, uint32_t exc_
 	/* The processor has a single execution state.
 	 * We verify that the Thread mode is using PSP.
 	 */
-	if ((exc_return & EXC_RETURN_MODE_THREAD) &&
-		(!(exc_return & EXC_RETURN_SPSEL_PROCESS))) {
+	if ((exc_return & EXC_RETURN_MODE_THREAD) && (!(exc_return & EXC_RETURN_SPSEL_PROCESS))) {
 		PR_EXC("SPSEL in thread mode does not indicate PSP");
 		return NULL;
 	}
@@ -998,7 +976,7 @@ static inline struct arch_esf *get_esf(uint32_t msp, uint32_t psp, uint32_t exc_
 	if (!alternative_state_exc) {
 		if (exc_return & EXC_RETURN_MODE_THREAD) {
 			/* Returning to thread mode */
-			ptr_esf =  (struct arch_esf *)psp;
+			ptr_esf = (struct arch_esf *)psp;
 
 		} else {
 			/* Returning to handler mode */
@@ -1041,8 +1019,7 @@ static inline struct arch_esf *get_esf(uint32_t msp, uint32_t psp, uint32_t exc_
  * @param callee_regs Callee-saved registers (R4-R11, PSP)
  *
  */
-void z_arm_fault(uint32_t msp, uint32_t psp, uint32_t exc_return,
-	_callee_saved_t *callee_regs)
+void z_arm_fault(uint32_t msp, uint32_t psp, uint32_t exc_return, _callee_saved_t *callee_regs)
 {
 	uint32_t reason = K_ERR_CPU_EXCEPTION;
 	int fault = SCB->ICSR & SCB_ICSR_VECTACTIVE_Msk;
@@ -1060,9 +1037,8 @@ void z_arm_fault(uint32_t msp, uint32_t psp, uint32_t exc_return,
 	/* Retrieve the Exception Stack Frame (ESF) to be supplied
 	 * as argument to the remainder of the fault handling process.
 	 */
-	 esf = get_esf(msp, psp, exc_return, &nested_exc);
-	__ASSERT(esf != NULL,
-		"ESF could not be retrieved successfully. Shall never occur.");
+	esf = get_esf(msp, psp, exc_return, &nested_exc);
+	__ASSERT(esf != NULL, "ESF could not be retrieved successfully. Shall never occur.");
 
 	z_arm_set_fault_sp(esf, exc_return);
 
@@ -1080,11 +1056,8 @@ void z_arm_fault(uint32_t msp, uint32_t psp, uint32_t exc_return,
 	 * so we only copy the fields before those.
 	 */
 	memcpy(&esf_copy, esf, offsetof(struct arch_esf, extra_info));
-	esf_copy.extra_info = (struct __extra_esf_info) {
-		.callee = callee_regs,
-		.exc_return = exc_return,
-		.msp = msp
-	};
+	esf_copy.extra_info = (struct __extra_esf_info){
+		.callee = callee_regs, .exc_return = exc_return, .msp = msp};
 #endif /* CONFIG_EXTRA_EXCEPTION_INFO */
 
 	/* Overwrite stacked IPSR to mark a nested exception,

--- a/arch/arm/core/cortex_m/fpu.c
+++ b/arch/arm/core/cortex_m/fpu.c
@@ -23,11 +23,10 @@ void z_arm_save_fp_context(struct fpu_ctx_full *buffer)
 
 	if (CONTROL & CONTROL_FPCA_Msk) {
 		/* Store caller-saved and callee-saved FP registers. */
-		__asm__ volatile(
-			"vstmia %0, {s0-s15}\n"
-			"vstmia %1, {s16-s31}\n"
-			:: "r" (buffer->caller_saved), "r" (buffer->callee_saved) :
-		);
+		__asm__ volatile("vstmia %0, {s0-s15}\n"
+				 "vstmia %1, {s16-s31}\n" ::"r"(buffer->caller_saved),
+				 "r"(buffer->callee_saved)
+				 :);
 
 		buffer->fpscr = __get_FPSCR();
 		buffer->ctx_saved = true;
@@ -55,11 +54,10 @@ void z_arm_restore_fp_context(const struct fpu_ctx_full *buffer)
 		/* Restore FP state. */
 		__set_FPSCR(buffer->fpscr);
 
-		__asm__ volatile(
-			"vldmia %0, {s0-s15}\n"
-			"vldmia %1, {s16-s31}\n"
-			:: "r" (buffer->caller_saved), "r" (buffer->callee_saved) :
-		);
+		__asm__ volatile("vldmia %0, {s0-s15}\n"
+				 "vldmia %1, {s16-s31}\n" ::"r"(buffer->caller_saved),
+				 "r"(buffer->callee_saved)
+				 :);
 	}
 #endif
 }

--- a/arch/arm/core/cortex_m/irq_manage.c
+++ b/arch/arm/core/cortex_m/irq_manage.c
@@ -28,7 +28,7 @@
 
 extern void z_arm_reserved(void);
 
-#define NUM_IRQS_PER_REG 32
+#define NUM_IRQS_PER_REG  32
 #define REG_FROM_IRQ(irq) (irq / NUM_IRQS_PER_REG)
 #define BIT_FROM_IRQ(irq) (irq % NUM_IRQS_PER_REG)
 
@@ -87,8 +87,7 @@ void z_arm_irq_priority_set(unsigned int irq, unsigned int prio, uint32_t flags)
 	 */
 	__ASSERT(prio <= (BIT(NUM_IRQ_PRIO_BITS) - 1),
 		 "invalid priority %d for %d irq! values must be less than %lu\n",
-		 prio - _IRQ_PRIO_OFFSET, irq,
-		 BIT(NUM_IRQ_PRIO_BITS) - (_IRQ_PRIO_OFFSET));
+		 prio - _IRQ_PRIO_OFFSET, irq, BIT(NUM_IRQ_PRIO_BITS) - (_IRQ_PRIO_OFFSET));
 	NVIC_SetPriority((IRQn_Type)irq, prio);
 }
 
@@ -141,7 +140,6 @@ void _arch_isr_direct_pm(void)
 #else
 #error Unknown ARM architecture
 #endif /* CONFIG_ARMV6_M_ARMV8_M_BASELINE */
-
 }
 #endif
 
@@ -165,8 +163,7 @@ void _arch_isr_direct_pm(void)
  *
  * @return The resulting target state of the given IRQ
  */
-irq_target_state_t irq_target_state_set(unsigned int irq,
-	irq_target_state_t irq_target_state)
+irq_target_state_t irq_target_state_set(unsigned int irq, irq_target_state_t irq_target_state)
 {
 	uint32_t result;
 
@@ -217,7 +214,7 @@ int irq_target_state_is_secure(unsigned int irq)
  * - Bits corresponding to un-implemented interrupts are RES0, so writes
  *   will be ignored.
  *
-*/
+ */
 void irq_target_state_set_all_non_secure(void)
 {
 	int i;
@@ -241,8 +238,8 @@ void irq_target_state_set_all_non_secure(void)
 #ifdef CONFIG_DYNAMIC_INTERRUPTS
 #ifdef CONFIG_GEN_ISR_TABLES
 int arch_irq_connect_dynamic(unsigned int irq, unsigned int priority,
-			     void (*routine)(const void *parameter),
-			     const void *parameter, uint32_t flags)
+			     void (*routine)(const void *parameter), const void *parameter,
+			     uint32_t flags)
 {
 	z_isr_install(irq, routine, parameter);
 	z_arm_irq_priority_set(irq, priority, flags);

--- a/arch/arm/core/cortex_m/prep_c.c
+++ b/arch/arm/core/cortex_m/prep_c.c
@@ -37,8 +37,7 @@
 #include <string.h>
 
 #if defined(CONFIG_SW_VECTOR_RELAY) || defined(CONFIG_SW_VECTOR_RELAY_CLIENT)
-Z_GENERIC_SECTION(.vt_pointer_section) __attribute__((used))
-void *_vector_table_pointer;
+Z_GENERIC_SECTION(.vt_pointer_section) __attribute__((used)) void *_vector_table_pointer;
 #endif
 
 #ifdef CONFIG_CPU_CORTEX_M_HAS_VTOR
@@ -64,8 +63,8 @@ static inline void relocate_vector_table(void)
 
 void __weak relocate_vector_table(void)
 {
-#if defined(CONFIG_XIP) && (CONFIG_FLASH_BASE_ADDRESS != 0) || \
-    !defined(CONFIG_XIP) && (CONFIG_SRAM_BASE_ADDRESS != 0)
+#if defined(CONFIG_XIP) && (CONFIG_FLASH_BASE_ADDRESS != 0) ||                                     \
+	!defined(CONFIG_XIP) && (CONFIG_SRAM_BASE_ADDRESS != 0)
 	size_t vector_size = (size_t)_vector_end - (size_t)_vector_start;
 	(void)memcpy(VECTOR_ADDRESS, _vector_start, vector_size);
 #elif defined(CONFIG_SW_VECTOR_RELAY) || defined(CONFIG_SW_VECTOR_RELAY_CLIENT)
@@ -100,7 +99,7 @@ static inline void z_arm_floating_point_init(void)
 #else
 	/* Privileged access only */
 	SCB->CPACR |= CPACR_CP10_PRIV_ACCESS | CPACR_CP11_PRIV_ACCESS;
-#endif /* CONFIG_USERSPACE */
+#endif  /* CONFIG_USERSPACE */
 	/*
 	 * Upon reset, the FPU Context Control Register is 0xC0000000
 	 * (both Automatic and Lazy state preservation is enabled).
@@ -170,7 +169,7 @@ static inline void z_arm_floating_point_init(void)
 	 *
 	 * If CONFIG_INIT_ARCH_HW_AT_BOOT is set, CONTROL is cleared at reset.
 	 */
-#if (!defined(CONFIG_FPU) || !defined(CONFIG_FPU_SHARING)) && \
+#if (!defined(CONFIG_FPU) || !defined(CONFIG_FPU_SHARING)) &&                                      \
 	(!defined(CONFIG_INIT_ARCH_HW_AT_BOOT))
 
 	__set_CONTROL(__get_CONTROL() & (~(CONTROL_FPCA_Msk)));

--- a/arch/arm/core/cortex_m/scb.c
+++ b/arch/arm/core/cortex_m/scb.c
@@ -55,8 +55,7 @@ void z_arm_clear_arm_mpu_config(void)
 {
 	int i;
 
-	int num_regions =
-		((MPU->TYPE & MPU_TYPE_DREGION_Msk) >> MPU_TYPE_DREGION_Pos);
+	int num_regions = ((MPU->TYPE & MPU_TYPE_DREGION_Msk) >> MPU_TYPE_DREGION_Pos);
 
 	for (i = 0; i < num_regions; i++) {
 		ARM_MPU_ClrRegion(i);
@@ -90,7 +89,7 @@ void z_arm_clear_arm_mpu_config(void)
  */
 void z_arm_init_arch_hw_at_boot(void)
 {
-    /* Disable interrupts */
+	/* Disable interrupts */
 	__disable_irq();
 
 #if defined(CONFIG_ARMV7_M_ARMV8_M_MAINLINE)

--- a/arch/arm/core/cortex_m/semihost.c
+++ b/arch/arm/core/cortex_m/semihost.c
@@ -9,11 +9,10 @@
 
 long semihost_exec(enum semihost_instr instr, void *args)
 {
-	register unsigned int r0 __asm__ ("r0") = instr;
-	register void *r1 __asm__ ("r1") = args;
-	register int ret __asm__ ("r0");
+	register unsigned int r0 __asm__("r0") = instr;
+	register void *r1 __asm__("r1") = args;
+	register int ret __asm__("r0");
 
-	__asm__ __volatile__ ("bkpt 0xab"
-			      : "=r" (ret) : "r" (r0), "r" (r1) : "memory");
+	__asm__ __volatile__("bkpt 0xab" : "=r"(ret) : "r"(r0), "r"(r1) : "memory");
 	return ret;
 }

--- a/arch/arm/core/cortex_m/thread.c
+++ b/arch/arm/core/cortex_m/thread.c
@@ -22,15 +22,14 @@
 #include <cmsis_core.h>
 
 #if (MPU_GUARD_ALIGN_AND_SIZE_FLOAT > MPU_GUARD_ALIGN_AND_SIZE)
-#define FP_GUARD_EXTRA_SIZE	(MPU_GUARD_ALIGN_AND_SIZE_FLOAT - \
-				 MPU_GUARD_ALIGN_AND_SIZE)
+#define FP_GUARD_EXTRA_SIZE (MPU_GUARD_ALIGN_AND_SIZE_FLOAT - MPU_GUARD_ALIGN_AND_SIZE)
 #else
-#define FP_GUARD_EXTRA_SIZE	0
+#define FP_GUARD_EXTRA_SIZE 0
 #endif
 
 #ifndef EXC_RETURN_FTYPE
 /* bit [4] allocate stack for floating-point context: 0=done 1=skipped  */
-#define EXC_RETURN_FTYPE           (0x00000010UL)
+#define EXC_RETURN_FTYPE (0x00000010UL)
 #endif
 
 /* Default last octet of EXC_RETURN, for threads that have not run yet.
@@ -58,9 +57,8 @@ K_THREAD_STACK_DECLARE(z_main_stack, CONFIG_MAIN_STACK_SIZE);
  * addresses, we have to unset it manually before storing it in the 'pc' field
  * of the ESF.
  */
-void arch_new_thread(struct k_thread *thread, k_thread_stack_t *stack,
-		     char *stack_ptr, k_thread_entry_t entry,
-		     void *p1, void *p2, void *p3)
+void arch_new_thread(struct k_thread *thread, k_thread_stack_t *stack, char *stack_ptr,
+		     k_thread_entry_t entry, void *p1, void *p2, void *p3)
 {
 	struct __basic_sf *iframe;
 
@@ -105,8 +103,7 @@ void arch_new_thread(struct k_thread *thread, k_thread_stack_t *stack,
 	iframe->a3 = (uint32_t)p2;
 	iframe->a4 = (uint32_t)p3;
 
-	iframe->xpsr =
-		0x01000000UL; /* clear all, thumb bit is 1, even if RO */
+	iframe->xpsr = 0x01000000UL; /* clear all, thumb bit is 1, even if RO */
 
 	thread->callee_saved.psp = (uint32_t)iframe;
 	thread->arch.basepri = 0;
@@ -131,52 +128,42 @@ void arch_new_thread(struct k_thread *thread, k_thread_stack_t *stack,
 	 */
 }
 
-#if defined(CONFIG_MPU_STACK_GUARD) && defined(CONFIG_FPU) \
-	&& defined(CONFIG_FPU_SHARING)
+#if defined(CONFIG_MPU_STACK_GUARD) && defined(CONFIG_FPU) && defined(CONFIG_FPU_SHARING)
 
-static inline void z_arm_thread_stack_info_adjust(struct k_thread *thread,
-	bool use_large_guard)
+static inline void z_arm_thread_stack_info_adjust(struct k_thread *thread, bool use_large_guard)
 {
 	if (use_large_guard) {
 		/* Switch to use a large MPU guard if not already. */
-		if ((thread->arch.mode &
-			Z_ARM_MODE_MPU_GUARD_FLOAT_Msk) == 0) {
+		if ((thread->arch.mode & Z_ARM_MODE_MPU_GUARD_FLOAT_Msk) == 0) {
 			/* Default guard size is used. Update required. */
 			thread->arch.mode |= Z_ARM_MODE_MPU_GUARD_FLOAT_Msk;
 #if defined(CONFIG_USERSPACE)
 			if (thread->arch.priv_stack_start) {
 				/* User thread */
-				thread->arch.priv_stack_start +=
-					FP_GUARD_EXTRA_SIZE;
+				thread->arch.priv_stack_start += FP_GUARD_EXTRA_SIZE;
 			} else
 #endif /* CONFIG_USERSPACE */
 			{
 				/* Privileged thread */
-				thread->stack_info.start +=
-					FP_GUARD_EXTRA_SIZE;
-				thread->stack_info.size -=
-					FP_GUARD_EXTRA_SIZE;
+				thread->stack_info.start += FP_GUARD_EXTRA_SIZE;
+				thread->stack_info.size -= FP_GUARD_EXTRA_SIZE;
 			}
 		}
 	} else {
 		/* Switch to use the default MPU guard size if not already. */
-		if ((thread->arch.mode &
-			Z_ARM_MODE_MPU_GUARD_FLOAT_Msk) != 0) {
+		if ((thread->arch.mode & Z_ARM_MODE_MPU_GUARD_FLOAT_Msk) != 0) {
 			/* Large guard size is used. Update required. */
 			thread->arch.mode &= ~Z_ARM_MODE_MPU_GUARD_FLOAT_Msk;
 #if defined(CONFIG_USERSPACE)
 			if (thread->arch.priv_stack_start) {
 				/* User thread */
-				thread->arch.priv_stack_start -=
-					FP_GUARD_EXTRA_SIZE;
+				thread->arch.priv_stack_start -= FP_GUARD_EXTRA_SIZE;
 			} else
 #endif /* CONFIG_USERSPACE */
 			{
 				/* Privileged thread */
-				thread->stack_info.start -=
-					FP_GUARD_EXTRA_SIZE;
-				thread->stack_info.size +=
-					FP_GUARD_EXTRA_SIZE;
+				thread->stack_info.start -= FP_GUARD_EXTRA_SIZE;
+				thread->stack_info.size += FP_GUARD_EXTRA_SIZE;
 			}
 		}
 	}
@@ -190,7 +177,7 @@ static inline void z_arm_thread_stack_info_adjust(struct k_thread *thread,
 uint32_t z_arm_mpu_stack_guard_and_fpu_adjust(struct k_thread *thread)
 {
 	if (((thread->base.user_options & K_FP_REGS) != 0) ||
-		((thread->arch.mode_exc_return & EXC_RETURN_FTYPE) == 0)) {
+	    ((thread->arch.mode_exc_return & EXC_RETURN_FTYPE) == 0)) {
 		/* The thread has been pre-tagged (at creation or later) with
 		 * K_FP_REGS, i.e. it is expected to be using the FPU registers
 		 * (if not already). Activate lazy stacking and program a large
@@ -226,13 +213,11 @@ uint32_t z_arm_mpu_stack_guard_and_fpu_adjust(struct k_thread *thread)
 #endif
 
 #ifdef CONFIG_USERSPACE
-FUNC_NORETURN void arch_user_mode_enter(k_thread_entry_t user_entry,
-					void *p1, void *p2, void *p3)
+FUNC_NORETURN void arch_user_mode_enter(k_thread_entry_t user_entry, void *p1, void *p2, void *p3)
 {
 
 	/* Set up privileged stack before entering user mode */
-	_current->arch.priv_stack_start =
-		(uint32_t)z_priv_stack_find(_current->stack_obj);
+	_current->arch.priv_stack_start = (uint32_t)z_priv_stack_find(_current->stack_obj);
 #if defined(CONFIG_MPU_STACK_GUARD)
 #if defined(CONFIG_THREAD_STACK_INFO)
 	/* We're dropping to user mode which means the guard area is no
@@ -256,20 +241,18 @@ FUNC_NORETURN void arch_user_mode_enter(k_thread_entry_t user_entry,
 	 */
 #if defined(CONFIG_FPU) && defined(CONFIG_FPU_SHARING)
 	_current->arch.priv_stack_start +=
-		((_current->arch.mode & Z_ARM_MODE_MPU_GUARD_FLOAT_Msk) != 0) ?
-		MPU_GUARD_ALIGN_AND_SIZE_FLOAT : MPU_GUARD_ALIGN_AND_SIZE;
+		((_current->arch.mode & Z_ARM_MODE_MPU_GUARD_FLOAT_Msk) != 0)
+			? MPU_GUARD_ALIGN_AND_SIZE_FLOAT
+			: MPU_GUARD_ALIGN_AND_SIZE;
 #else
 	_current->arch.priv_stack_start += MPU_GUARD_ALIGN_AND_SIZE;
 #endif /* CONFIG_FPU && CONFIG_FPU_SHARING */
 #endif /* CONFIG_MPU_STACK_GUARD */
 
-	z_arm_userspace_enter(user_entry, p1, p2, p3,
-			     (uint32_t)_current->stack_info.start,
-			     _current->stack_info.size -
-			     _current->stack_info.delta);
+	z_arm_userspace_enter(user_entry, p1, p2, p3, (uint32_t)_current->stack_info.start,
+			      _current->stack_info.size - _current->stack_info.delta);
 	CODE_UNREACHABLE;
 }
-
 
 bool z_arm_thread_is_in_user_mode(void)
 {
@@ -311,14 +294,12 @@ void configure_builtin_stack_guard(struct k_thread *thread)
 	 * than the default thread stack (ensured by design).
 	 */
 	uint32_t guard_start =
-		((thread->arch.priv_stack_start) &&
-			(__get_PSP() >= thread->arch.priv_stack_start)) ?
-		(uint32_t)thread->arch.priv_stack_start :
-		(uint32_t)thread->stack_obj;
+		((thread->arch.priv_stack_start) && (__get_PSP() >= thread->arch.priv_stack_start))
+			? (uint32_t)thread->arch.priv_stack_start
+			: (uint32_t)thread->stack_obj;
 
 	__ASSERT(thread->stack_info.start == ((uint32_t)thread->stack_obj),
-		"stack_info.start does not point to the start of the"
-		"thread allocated area.");
+		 "stack_info.start does not point to the start of the thread allocated area.");
 #else
 	uint32_t guard_start = thread->stack_info.start;
 #endif
@@ -332,13 +313,11 @@ void configure_builtin_stack_guard(struct k_thread *thread)
 
 #if defined(CONFIG_MPU_STACK_GUARD) || defined(CONFIG_USERSPACE)
 
-#define IS_MPU_GUARD_VIOLATION(guard_start, guard_len, fault_addr, stack_ptr) \
-	((fault_addr != -EINVAL) ? \
-	((fault_addr >= guard_start) && \
-	(fault_addr < (guard_start + guard_len)) && \
-	(stack_ptr < (guard_start + guard_len))) \
-	: \
-	(stack_ptr < (guard_start + guard_len)))
+#define IS_MPU_GUARD_VIOLATION(guard_start, guard_len, fault_addr, stack_ptr)                      \
+	((fault_addr != -EINVAL)                                                                   \
+		 ? ((fault_addr >= guard_start) && (fault_addr < (guard_start + guard_len)) &&     \
+		    (stack_ptr < (guard_start + guard_len)))                                       \
+		 : (stack_ptr < (guard_start + guard_len)))
 
 /**
  * @brief Assess occurrence of current thread's stack corruption
@@ -386,11 +365,10 @@ uint32_t z_check_thread_stack_fail(const uint32_t fault_addr, const uint32_t psp
 	}
 #endif
 
-#if (defined(CONFIG_FPU) && defined(CONFIG_FPU_SHARING)) && \
-	defined(CONFIG_MPU_STACK_GUARD)
-	uint32_t guard_len =
-		((_current->arch.mode & Z_ARM_MODE_MPU_GUARD_FLOAT_Msk) != 0) ?
-		MPU_GUARD_ALIGN_AND_SIZE_FLOAT : MPU_GUARD_ALIGN_AND_SIZE;
+#if (defined(CONFIG_FPU) && defined(CONFIG_FPU_SHARING)) && defined(CONFIG_MPU_STACK_GUARD)
+	uint32_t guard_len = ((_current->arch.mode & Z_ARM_MODE_MPU_GUARD_FLOAT_Msk) != 0)
+				     ? MPU_GUARD_ALIGN_AND_SIZE_FLOAT
+				     : MPU_GUARD_ALIGN_AND_SIZE;
 #else
 	/* If MPU_STACK_GUARD is not enabled, the guard length is
 	 * effectively zero. Stack overflows may be detected only
@@ -404,10 +382,8 @@ uint32_t z_check_thread_stack_fail(const uint32_t fault_addr, const uint32_t psp
 		/* User thread */
 		if (z_arm_thread_is_in_user_mode() == false) {
 			/* User thread in privilege mode */
-			if (IS_MPU_GUARD_VIOLATION(
-				thread->arch.priv_stack_start - guard_len,
-					guard_len,
-				fault_addr, psp)) {
+			if (IS_MPU_GUARD_VIOLATION(thread->arch.priv_stack_start - guard_len,
+						   guard_len, fault_addr, psp)) {
 				/* Thread's privilege stack corruption */
 				return thread->arch.priv_stack_start;
 			}
@@ -419,26 +395,21 @@ uint32_t z_check_thread_stack_fail(const uint32_t fault_addr, const uint32_t psp
 		}
 	} else {
 		/* Supervisor thread */
-		if (IS_MPU_GUARD_VIOLATION(thread->stack_info.start -
-				guard_len,
-				guard_len,
-				fault_addr, psp)) {
+		if (IS_MPU_GUARD_VIOLATION(thread->stack_info.start - guard_len, guard_len,
+					   fault_addr, psp)) {
 			/* Supervisor thread stack corruption */
 			return thread->stack_info.start;
 		}
 	}
 #else /* CONFIG_USERSPACE */
 #if defined(CONFIG_MULTITHREADING)
-	if (IS_MPU_GUARD_VIOLATION(thread->stack_info.start - guard_len,
-			guard_len,
-			fault_addr, psp)) {
+	if (IS_MPU_GUARD_VIOLATION(thread->stack_info.start - guard_len, guard_len, fault_addr,
+				   psp)) {
 		/* Thread stack corruption */
 		return thread->stack_info.start;
 	}
 #else
-	if (IS_MPU_GUARD_VIOLATION((uint32_t)z_main_stack,
-			guard_len,
-			fault_addr, psp)) {
+	if (IS_MPU_GUARD_VIOLATION((uint32_t)z_main_stack, guard_len, fault_addr, psp)) {
 		/* Thread stack corruption */
 		return (uint32_t)K_THREAD_STACK_BUFFER(z_main_stack);
 	}
@@ -572,23 +543,23 @@ void arch_switch_to_main_thread(struct k_thread *main_thread, char *stack_ptr,
 	 * When calling arch_irq_unlock_outlined, LR is lost which is fine since
 	 * we do not intend to return after calling z_thread_entry.
 	 */
-	__asm__ volatile (
-	"mov   r4,  %0\n"	/* force _main to be stored in a register */
-	"msr   PSP, %1\n"	/* __set_PSP(stack_ptr) */
+	__asm__ volatile("mov   r4,  %0\n" /* force _main to be stored in a register */
+			 "msr   PSP, %1\n" /* __set_PSP(stack_ptr) */
 
-	"movs  r0,  #0\n"	/* arch_irq_unlock(0) */
-	"ldr   r3, =arch_irq_unlock_outlined\n"
-	"blx   r3\n"
+			 "movs  r0,  #0\n" /* arch_irq_unlock(0) */
+			 "ldr   r3, =arch_irq_unlock_outlined\n"
+			 "blx   r3\n"
 
-	"mov   r0, r4\n"	/* z_thread_entry(_main, NULL, NULL, NULL) */
-	"movs  r1, #0\n"
-	"movs  r2, #0\n"
-	"movs  r3, #0\n"
-	"ldr   r4, =z_thread_entry\n"
-	"bx    r4\n"		/* We don’t intend to return, so there is no need to link. */
-	:
-	: "r" (_main), "r" (stack_ptr)
-	: "r0", "r1", "r2", "r3", "r4", "ip", "lr", "memory");
+			 "mov   r0, r4\n" /* z_thread_entry(_main, NULL, NULL, NULL) */
+			 "movs  r1, #0\n"
+			 "movs  r2, #0\n"
+			 "movs  r3, #0\n"
+			 "ldr   r4, =z_thread_entry\n"
+			 /* We don’t intend to return, so there is no need to link. */
+			 "bx    r4\n"
+			 :
+			 : "r"(_main), "r"(stack_ptr)
+			 : "r0", "r1", "r2", "r3", "r4", "ip", "lr", "memory");
 
 	CODE_UNREACHABLE;
 }
@@ -597,7 +568,7 @@ __used void arch_irq_unlock_outlined(unsigned int key)
 {
 #if defined(CONFIG_ARMV7_M_ARMV8_M_MAINLINE)
 	__enable_fault_irq(); /* alters FAULTMASK */
-	__enable_irq(); /* alters PRIMASK */
+	__enable_irq();       /* alters PRIMASK */
 #endif
 	arch_irq_unlock(key);
 }
@@ -609,14 +580,13 @@ __used unsigned int arch_irq_lock_outlined(void)
 
 #if !defined(CONFIG_MULTITHREADING)
 
-FUNC_NORETURN void z_arm_switch_to_main_no_multithreading(
-	k_thread_entry_t main_entry, void *p1, void *p2, void *p3)
+FUNC_NORETURN void z_arm_switch_to_main_no_multithreading(k_thread_entry_t main_entry, void *p1,
+							  void *p2, void *p3)
 {
 	z_arm_prepare_switch_to_main();
 
 	/* Set PSP to the highest address of the main stack. */
-	char *psp =	K_THREAD_STACK_BUFFER(z_main_stack) +
-		K_THREAD_STACK_SIZEOF(z_main_stack);
+	char *psp = K_THREAD_STACK_BUFFER(z_main_stack) + K_THREAD_STACK_SIZEOF(z_main_stack);
 
 #if defined(CONFIG_BUILTIN_STACK_GUARD)
 	char *psplim = (K_THREAD_STACK_BUFFER(z_main_stack));
@@ -636,31 +606,31 @@ FUNC_NORETURN void z_arm_switch_to_main_no_multithreading(
 	 * with the thread entry process.
 	 */
 
-	__asm__ volatile (
+	__asm__ volatile(
 #ifdef CONFIG_BUILTIN_STACK_GUARD
-	"msr  PSPLIM, %[_psplim]\n" /* __set_PSPLIM(_psplim) */
+		"msr  PSPLIM, %[_psplim]\n" /* __set_PSPLIM(_psplim) */
 #endif
-	"msr  PSP, %[_psp]\n"       /* __set_PSP(psp) */
-	"mov r0, #0\n"
-	"ldr r1, =arch_irq_unlock_outlined\n"
-	"blx r1\n"
+		"msr  PSP, %[_psp]\n" /* __set_PSP(psp) */
+		"mov r0, #0\n"
+		"ldr r1, =arch_irq_unlock_outlined\n"
+		"blx r1\n"
 
-	"mov r0, %[_p1]\n"
-	"mov r1, %[_p2]\n"
-	"mov r2, %[_p3]\n"
-	"blx  %[_main_entry]\n"     /* main_entry(p1, p2, p3) */
+		"mov r0, %[_p1]\n"
+		"mov r1, %[_p2]\n"
+		"mov r2, %[_p3]\n"
+		"blx  %[_main_entry]\n" /* main_entry(p1, p2, p3) */
 
-	"ldr r0, =arch_irq_lock_outlined\n"
-	"blx r0\n"
-	"loop: b loop\n\t"    /* while (true); */
-	:
-	: [_p1]"r" (p1), [_p2]"r" (p2), [_p3]"r" (p3),
-	  [_psp]"r" (psp), [_main_entry]"r" (main_entry)
+		"ldr r0, =arch_irq_lock_outlined\n"
+		"blx r0\n"
+		"loop: b loop\n\t" /* while (true); */
+		:
+		: [_p1] "r"(p1), [_p2] "r"(p2), [_p3] "r"(p3), [_psp] "r"(psp),
+		  [_main_entry] "r"(main_entry)
 #ifdef CONFIG_BUILTIN_STACK_GUARD
-	, [_psplim]"r" (psplim)
+			  ,
+		  [_psplim] "r"(psplim)
 #endif
-	: "r0", "r1", "r2", "ip", "lr"
-	);
+		: "r0", "r1", "r2", "ip", "lr");
 
 	CODE_UNREACHABLE; /* LCOV_EXCL_LINE */
 }

--- a/arch/arm/core/cortex_m/timing.c
+++ b/arch/arm/core/cortex_m/timing.c
@@ -73,7 +73,6 @@ static inline uint64_t z_arm_dwt_freq_get(void)
 		} while ((dcyc == 0) || (ddwt == 0));
 
 		dwt_frequency = (cyc_freq * ddwt) / dcyc;
-
 	}
 	return dwt_frequency;
 #endif /* CONFIG_SOC_FAMILY_NORDIC_NRF */
@@ -100,8 +99,7 @@ timing_t arch_timing_counter_get(void)
 	return (timing_t)z_arm_dwt_get_cycles();
 }
 
-uint64_t arch_timing_cycles_get(volatile timing_t *const start,
-				volatile timing_t *const end)
+uint64_t arch_timing_cycles_get(volatile timing_t *const start, volatile timing_t *const end)
 {
 	return ((uint32_t)*end - (uint32_t)*start);
 }

--- a/arch/arm/include/cortex_m/cmse.h
+++ b/arch/arm/include/cortex_m/cmse.h
@@ -139,7 +139,7 @@ int arm_cmse_addr_range_readwrite_ok(uint32_t addr, uint32_t size, int force_npr
  * where typeof is used instead of __typeof__)
  */
 #ifndef typeof
-#define typeof  __typeof__
+#define typeof __typeof__
 #endif
 
 /**
@@ -157,8 +157,7 @@ int arm_cmse_addr_range_readwrite_ok(uint32_t addr, uint32_t size, int force_npr
  *
  * @return p_obj if object is readable, NULL otherwise.
  */
-#define ARM_CMSE_OBJECT_READ_OK(p_obj) \
-	cmse_check_pointed_object(p_obj, CMSE_MPU_READ)
+#define ARM_CMSE_OBJECT_READ_OK(p_obj) cmse_check_pointed_object(p_obj, CMSE_MPU_READ)
 
 /**
  * @brief Read accessibility of an object (nPRIV mode)
@@ -175,7 +174,7 @@ int arm_cmse_addr_range_readwrite_ok(uint32_t addr, uint32_t size, int force_npr
  *
  * @return p_obj if object is readable, NULL otherwise.
  */
-#define ARM_CMSE_OBJECT_UNPRIV_READ_OK(p_obj) \
+#define ARM_CMSE_OBJECT_UNPRIV_READ_OK(p_obj)                                                      \
 	cmse_check_pointed_object(p_obj, CMSE_MPU_UNPRIV | CMSE_MPU_READ)
 
 /**
@@ -193,8 +192,7 @@ int arm_cmse_addr_range_readwrite_ok(uint32_t addr, uint32_t size, int force_npr
  *
  * @return p_obj if object is Read and Writable, NULL otherwise.
  */
-#define ARM_CMSE_OBJECT_READWRITE_OK(p_obj) \
-	cmse_check_pointed_object(p_obj, CMSE_MPU_READWRITE)
+#define ARM_CMSE_OBJECT_READWRITE_OK(p_obj) cmse_check_pointed_object(p_obj, CMSE_MPU_READWRITE)
 
 /**
  * @brief Read and Write accessibility of an object (nPRIV mode)
@@ -211,7 +209,7 @@ int arm_cmse_addr_range_readwrite_ok(uint32_t addr, uint32_t size, int force_npr
  *
  * @return p_obj if object is Read and Writable, NULL otherwise.
  */
-#define ARM_CMSE_OBJECT_UNPRIV_READWRITE_OK(p_obj) \
+#define ARM_CMSE_OBJECT_UNPRIV_READWRITE_OK(p_obj)                                                 \
 	cmse_check_pointed_object(p_obj, CMSE_MPU_UNPRIV | CMSE_MPU_READWRITE)
 
 #if defined(CONFIG_ARM_SECURE_FIRMWARE)
@@ -231,7 +229,7 @@ int arm_cmse_addr_range_readwrite_ok(uint32_t addr, uint32_t size, int force_npr
  * @param addr The address for which the MPU region is requested
  *
  * @return a valid MPU region number or -EINVAL
-  */
+ */
 int arm_cmse_mpu_nonsecure_region_get(uint32_t addr);
 
 /**
@@ -249,7 +247,7 @@ int arm_cmse_mpu_nonsecure_region_get(uint32_t addr);
  * @param addr The address for which the SAU region is requested
  *
  * @return a valid SAU region number or -EINVAL
-  */
+ */
 int arm_cmse_sau_region_get(uint32_t addr);
 
 /**
@@ -267,7 +265,7 @@ int arm_cmse_sau_region_get(uint32_t addr);
  * @param addr The address for which the IDAU region is requested
  *
  * @return a valid IDAU region number or -EINVAL
-  */
+ */
 int arm_cmse_idau_region_get(uint32_t addr);
 
 /**
@@ -342,8 +340,7 @@ int arm_cmse_addr_nonsecure_readwrite_ok(uint32_t addr, int force_npriv);
  *
  * @return 1 if address range is readable, 0 otherwise.
  */
-int arm_cmse_addr_range_nonsecure_read_ok(uint32_t addr, uint32_t size,
-	int force_npriv);
+int arm_cmse_addr_range_nonsecure_read_ok(uint32_t addr, uint32_t size, int force_npriv);
 
 /**
  * @brief Non-Secure Read and Write accessibility of an address range
@@ -365,8 +362,7 @@ int arm_cmse_addr_range_nonsecure_read_ok(uint32_t addr, uint32_t size,
  *
  * @return 1 if address range is readable, 0 otherwise.
  */
-int arm_cmse_addr_range_nonsecure_readwrite_ok(uint32_t addr, uint32_t size,
-	int force_npriv);
+int arm_cmse_addr_range_nonsecure_readwrite_ok(uint32_t addr, uint32_t size, int force_npriv);
 
 /**
  * @brief Non-Secure Read accessibility of an object
@@ -383,7 +379,7 @@ int arm_cmse_addr_range_nonsecure_readwrite_ok(uint32_t addr, uint32_t size,
  *
  * @return p_obj if object is readable from Non-Secure state, NULL otherwise.
  */
-#define ARM_CMSE_OBJECT_NONSECURE_READ_OK(p_obj) \
+#define ARM_CMSE_OBJECT_NONSECURE_READ_OK(p_obj)                                                   \
 	cmse_check_pointed_object(p_obj, CMSE_NONSECURE | CMSE_MPU_READ)
 
 /**
@@ -401,9 +397,8 @@ int arm_cmse_addr_range_nonsecure_readwrite_ok(uint32_t addr, uint32_t size,
  *
  * @return p_obj if object is readable from Non-Secure state, NULL otherwise.
  */
-#define ARM_CMSE_OBJECT_NONSECURE_UNPRIV_READ_OK(p_obj) \
-	cmse_check_pointed_object(p_obj, \
-		CMSE_NONSECURE | CMSE_MPU_UNPRIV | CMSE_MPU_READ)
+#define ARM_CMSE_OBJECT_NONSECURE_UNPRIV_READ_OK(p_obj)                                            \
+	cmse_check_pointed_object(p_obj, CMSE_NONSECURE | CMSE_MPU_UNPRIV | CMSE_MPU_READ)
 
 /**
  * @brief Non-Secure Read and Write accessibility of an object
@@ -420,7 +415,7 @@ int arm_cmse_addr_range_nonsecure_readwrite_ok(uint32_t addr, uint32_t size,
  *
  * @return p_obj if object is Non-Secure Read and Writable, NULL otherwise.
  */
-#define ARM_CMSE_OBJECT_NONSECURE_READWRITE_OK(p_obj) \
+#define ARM_CMSE_OBJECT_NONSECURE_READWRITE_OK(p_obj)                                              \
 	cmse_check_pointed_object(p_obj, CMSE_NONSECURE | CMSE_MPU_READWRITE)
 
 /**
@@ -438,9 +433,8 @@ int arm_cmse_addr_range_nonsecure_readwrite_ok(uint32_t addr, uint32_t size,
  *
  * @return p_obj if object is Non-Secure Read and Writable, NULL otherwise.
  */
-#define ARM_CMSE_OBJECT_NON_SECURE_UNPRIV_READWRITE_OK(p_obj) \
-	cmse_check_pointed_object(p_obj, \
-			CMSE_NONSECURE | CMSE_MPU_UNPRIV | CMSE_MPU_READWRITE)
+#define ARM_CMSE_OBJECT_NON_SECURE_UNPRIV_READWRITE_OK(p_obj)                                      \
+	cmse_check_pointed_object(p_obj, CMSE_NONSECURE | CMSE_MPU_UNPRIV | CMSE_MPU_READWRITE)
 
 #endif /* CONFIG_ARM_SECURE_FIRMWARE */
 

--- a/arch/arm/include/cortex_m/dwt.h
+++ b/arch/arm/include/cortex_m/dwt.h
@@ -64,7 +64,7 @@ static inline void dwt_access(bool ena)
 			}
 		}
 	}
-#else /* CONFIG_CPU_CORTEX_M7 */
+#else  /* CONFIG_CPU_CORTEX_M7 */
 	ARG_UNUSED(ena);
 #endif /* CONFIG_CPU_CORTEX_M7 */
 }
@@ -103,9 +103,8 @@ static inline int z_arm_dwt_init_cycle_counter(void)
 	/* Assert that the cycle counter is indeed implemented.
 	 * The field is called NOCYCCNT. So 1 means there is no cycle counter.
 	 */
-	__ASSERT((DWT->CTRL & DWT_CTRL_NOCYCCNT_Msk) == 0,
-		"DWT implements no cycle counter. "
-		"Cannot be used for cycle counting\n");
+	__ASSERT((DWT->CTRL & DWT_CTRL_NOCYCCNT_Msk) == 0, "DWT implements no cycle counter. "
+							   "Cannot be used for cycle counting\n");
 
 	return 0;
 }
@@ -148,7 +147,7 @@ static inline void z_arm_dwt_enable_debug_monitor(void)
 	 * assert that the CPU is in normal mode.
 	 */
 	__ASSERT((CoreDebug->DHCSR & CoreDebug_DHCSR_C_DEBUGEN_Msk) == 0,
-		"Cannot enable DBM when CPU is in Debug mode\n");
+		 "Cannot enable DBM when CPU is in Debug mode\n");
 
 #if defined(CONFIG_ARMV8_M_SE) && !defined(CONFIG_ARM_NONSECURE_FIRMWARE)
 	/*
@@ -158,8 +157,7 @@ static inline void z_arm_dwt_enable_debug_monitor(void)
 	 * when enabling the DebugMonitor exception, assert that
 	 * it is not targeting the Non Secure domain.
 	 */
-	__ASSERT((CoreDebug->DEMCR & DCB_DEMCR_SDME_Msk) != 0,
-		"DebugMonitor targets Non-Secure\n");
+	__ASSERT((CoreDebug->DEMCR & DCB_DEMCR_SDME_Msk) != 0, "DebugMonitor targets Non-Secure\n");
 #endif
 
 	/* The DebugMonitor handler priority is set already

--- a/arch/arm/include/cortex_m/exception.h
+++ b/arch/arm/include/cortex_m/exception.h
@@ -37,7 +37,7 @@ extern volatile irq_offload_routine_t offload_routine;
 /* Writes to the AIRCR must be accompanied by a write of the value 0x05FA
  * to the Vector Key field, otherwise the writes are ignored.
  */
-#define AIRCR_VECT_KEY_PERMIT_WRITE 0x05FAUL
+#define AIRCR_VECT_KEY_PERMIT_WRITE            0x05FAUL
 
 /* Exception Return (EXC_RETURN) is provided in LR upon exception entry.
  * It is used to perform an exception return and to detect possible state
@@ -47,45 +47,44 @@ extern volatile irq_offload_routine_t offload_routine;
 /* Prefix. Indicates that this is an EXC_RETURN value.
  * This field reads as 0b11111111.
  */
-#define EXC_RETURN_INDICATOR_PREFIX     (0xFF << 24)
+#define EXC_RETURN_INDICATOR_PREFIX            (0xFF << 24)
 /* bit[0]: Exception Secure. The security domain the exception was taken to. */
-#define EXC_RETURN_EXCEPTION_SECURE_Pos 0
-#define EXC_RETURN_EXCEPTION_SECURE_Msk \
-		BIT(EXC_RETURN_EXCEPTION_SECURE_Pos)
+#define EXC_RETURN_EXCEPTION_SECURE_Pos        0
+#define EXC_RETURN_EXCEPTION_SECURE_Msk        BIT(EXC_RETURN_EXCEPTION_SECURE_Pos)
 #define EXC_RETURN_EXCEPTION_SECURE_Non_Secure 0
-#define EXC_RETURN_EXCEPTION_SECURE_Secure EXC_RETURN_EXCEPTION_SECURE_Msk
+#define EXC_RETURN_EXCEPTION_SECURE_Secure     EXC_RETURN_EXCEPTION_SECURE_Msk
 /* bit[2]: Stack Pointer selection. */
-#define EXC_RETURN_SPSEL_Pos 2
-#define EXC_RETURN_SPSEL_Msk BIT(EXC_RETURN_SPSEL_Pos)
-#define EXC_RETURN_SPSEL_MAIN 0
-#define EXC_RETURN_SPSEL_PROCESS EXC_RETURN_SPSEL_Msk
+#define EXC_RETURN_SPSEL_Pos                   2
+#define EXC_RETURN_SPSEL_Msk                   BIT(EXC_RETURN_SPSEL_Pos)
+#define EXC_RETURN_SPSEL_MAIN                  0
+#define EXC_RETURN_SPSEL_PROCESS               EXC_RETURN_SPSEL_Msk
 /* bit[3]: Mode. Indicates the Mode that was stacked from. */
-#define EXC_RETURN_MODE_Pos 3
-#define EXC_RETURN_MODE_Msk BIT(EXC_RETURN_MODE_Pos)
-#define EXC_RETURN_MODE_HANDLER 0
-#define EXC_RETURN_MODE_THREAD EXC_RETURN_MODE_Msk
+#define EXC_RETURN_MODE_Pos                    3
+#define EXC_RETURN_MODE_Msk                    BIT(EXC_RETURN_MODE_Pos)
+#define EXC_RETURN_MODE_HANDLER                0
+#define EXC_RETURN_MODE_THREAD                 EXC_RETURN_MODE_Msk
 /* bit[4]: Stack frame type. Indicates whether the stack frame is a standard
  * integer only stack frame or an extended floating-point stack frame.
  */
-#define EXC_RETURN_STACK_FRAME_TYPE_Pos 4
-#define EXC_RETURN_STACK_FRAME_TYPE_Msk BIT(EXC_RETURN_STACK_FRAME_TYPE_Pos)
-#define EXC_RETURN_STACK_FRAME_TYPE_EXTENDED 0
-#define EXC_RETURN_STACK_FRAME_TYPE_STANDARD EXC_RETURN_STACK_FRAME_TYPE_Msk
+#define EXC_RETURN_STACK_FRAME_TYPE_Pos        4
+#define EXC_RETURN_STACK_FRAME_TYPE_Msk        BIT(EXC_RETURN_STACK_FRAME_TYPE_Pos)
+#define EXC_RETURN_STACK_FRAME_TYPE_EXTENDED   0
+#define EXC_RETURN_STACK_FRAME_TYPE_STANDARD   EXC_RETURN_STACK_FRAME_TYPE_Msk
 /* bit[5]: Default callee register stacking. Indicates whether the default
  * stacking rules apply, or whether the callee registers are already on the
  * stack.
  */
-#define EXC_RETURN_CALLEE_STACK_Pos 5
-#define EXC_RETURN_CALLEE_STACK_Msk BIT(EXC_RETURN_CALLEE_STACK_Pos)
-#define EXC_RETURN_CALLEE_STACK_SKIPPED 0
-#define EXC_RETURN_CALLEE_STACK_DEFAULT EXC_RETURN_CALLEE_STACK_Msk
+#define EXC_RETURN_CALLEE_STACK_Pos            5
+#define EXC_RETURN_CALLEE_STACK_Msk            BIT(EXC_RETURN_CALLEE_STACK_Pos)
+#define EXC_RETURN_CALLEE_STACK_SKIPPED        0
+#define EXC_RETURN_CALLEE_STACK_DEFAULT        EXC_RETURN_CALLEE_STACK_Msk
 /* bit[6]: Secure or Non-secure stack. Indicates whether a Secure or
  * Non-secure stack is used to restore stack frame on exception return.
  */
-#define EXC_RETURN_RETURN_STACK_Pos 6
-#define EXC_RETURN_RETURN_STACK_Msk BIT(EXC_RETURN_RETURN_STACK_Pos)
-#define EXC_RETURN_RETURN_STACK_Non_Secure 0
-#define EXC_RETURN_RETURN_STACK_Secure EXC_RETURN_RETURN_STACK_Msk
+#define EXC_RETURN_RETURN_STACK_Pos            6
+#define EXC_RETURN_RETURN_STACK_Msk            BIT(EXC_RETURN_RETURN_STACK_Pos)
+#define EXC_RETURN_RETURN_STACK_Non_Secure     0
+#define EXC_RETURN_RETURN_STACK_Secure         EXC_RETURN_RETURN_STACK_Msk
 
 /*
  * The current executing vector is found in the IPSR register. All
@@ -170,8 +169,8 @@ static ALWAYS_INLINE void z_arm_exc_setup(void)
 #endif /* CONFIG_ARM_SECURE_FIRMWARE */
 
 	/* Enable Usage, Mem, & Bus Faults */
-	SCB->SHCSR |= SCB_SHCSR_USGFAULTENA_Msk | SCB_SHCSR_MEMFAULTENA_Msk |
-		      SCB_SHCSR_BUSFAULTENA_Msk;
+	SCB->SHCSR |=
+		SCB_SHCSR_USGFAULTENA_Msk | SCB_SHCSR_MEMFAULTENA_Msk | SCB_SHCSR_BUSFAULTENA_Msk;
 #if defined(CONFIG_ARM_SECURE_FIRMWARE)
 	/* Enable Secure Fault */
 	SCB->SHCSR |= SCB_SHCSR_SECUREFAULTENA_Msk;
@@ -180,25 +179,21 @@ static ALWAYS_INLINE void z_arm_exc_setup(void)
 #endif /* CONFIG_ARM_SECURE_FIRMWARE */
 #endif /* CONFIG_CPU_CORTEX_M_HAS_PROGRAMMABLE_FAULT_PRIOS */
 
-#if defined(CONFIG_ARM_SECURE_FIRMWARE) && \
-	!defined(CONFIG_ARM_SECURE_BUSFAULT_HARDFAULT_NMI)
+#if defined(CONFIG_ARM_SECURE_FIRMWARE) && !defined(CONFIG_ARM_SECURE_BUSFAULT_HARDFAULT_NMI)
 	/* Set NMI, Hard, and Bus Faults as Non-Secure.
 	 * NMI and Bus Faults targeting the Secure state will
 	 * escalate to a SecureFault or SecureHardFault.
 	 */
 	SCB->AIRCR =
-		(SCB->AIRCR & (~(SCB_AIRCR_VECTKEY_Msk)))
-		| SCB_AIRCR_BFHFNMINS_Msk
-		| ((AIRCR_VECT_KEY_PERMIT_WRITE << SCB_AIRCR_VECTKEY_Pos) &
-			SCB_AIRCR_VECTKEY_Msk);
+		(SCB->AIRCR & (~(SCB_AIRCR_VECTKEY_Msk))) | SCB_AIRCR_BFHFNMINS_Msk |
+		((AIRCR_VECT_KEY_PERMIT_WRITE << SCB_AIRCR_VECTKEY_Pos) & SCB_AIRCR_VECTKEY_Msk);
 	/* Note: Fault conditions that would generate a SecureFault
 	 * in a PE with the Main Extension instead generate a
 	 * SecureHardFault in a PE without the Main Extension.
 	 */
 #endif /* ARM_SECURE_FIRMWARE && !ARM_SECURE_BUSFAULT_HARDFAULT_NMI */
 
-#if defined(CONFIG_CPU_CORTEX_M_HAS_SYSTICK) && \
-	!defined(CONFIG_CORTEX_M_SYSTICK)
+#if defined(CONFIG_CPU_CORTEX_M_HAS_SYSTICK) && !defined(CONFIG_CORTEX_M_SYSTICK)
 	/* SoC implements SysTick, but the system does not use it
 	 * as driver for system timing. However, the SysTick IRQ is
 	 * always enabled, so we must ensure the interrupt priority
@@ -208,7 +203,6 @@ static ALWAYS_INLINE void z_arm_exc_setup(void)
 	 */
 	NVIC_SetPriority(SysTick_IRQn, _EXC_IRQ_DEFAULT_PRIO);
 #endif /* CPU_CORTEX_M_HAS_SYSTICK && ! CORTEX_M_SYSTICK */
-
 }
 
 /**
@@ -221,9 +215,7 @@ static ALWAYS_INLINE void z_arm_clear_faults(void)
 #if defined(CONFIG_ARMV6_M_ARMV8_M_BASELINE)
 #elif defined(CONFIG_ARMV7_M_ARMV8_M_MAINLINE)
 	/* Reset all faults */
-	SCB->CFSR = SCB_CFSR_USGFAULTSR_Msk |
-		    SCB_CFSR_MEMFAULTSR_Msk |
-		    SCB_CFSR_BUSFAULTSR_Msk;
+	SCB->CFSR = SCB_CFSR_USGFAULTSR_Msk | SCB_CFSR_MEMFAULTSR_Msk | SCB_CFSR_BUSFAULTSR_Msk;
 
 	/* Clear all Hard Faults - HFSR is write-one-to-clear */
 	SCB->HFSR = 0xffffffff;
@@ -253,7 +245,7 @@ static ALWAYS_INLINE void z_arm_set_fault_sp(const struct arch_esf *esf, uint32_
 	 * registers if necessary
 	 */
 	if ((exc_return & EXC_RETURN_STACK_FRAME_TYPE_STANDARD) ==
-			EXC_RETURN_STACK_FRAME_TYPE_EXTENDED) {
+	    EXC_RETURN_STACK_FRAME_TYPE_EXTENDED) {
 		z_arm_coredump_fault_sp += sizeof(esf->fpu);
 	}
 #endif /* CONFIG_FPU && CONFIG_FPU_SHARING */

--- a/arch/arm/include/cortex_m/kernel_arch_func.h
+++ b/arch/arm/include/cortex_m/kernel_arch_func.h
@@ -61,26 +61,21 @@ static ALWAYS_INLINE void arch_kernel_init(void)
 #endif /* CONFIG_SOC_PER_CORE_INIT_HOOK */
 }
 
-static ALWAYS_INLINE void
-arch_thread_return_value_set(struct k_thread *thread, unsigned int value)
+static ALWAYS_INLINE void arch_thread_return_value_set(struct k_thread *thread, unsigned int value)
 {
 	thread->arch.swap_return_value = value;
 }
 
 #if !defined(CONFIG_MULTITHREADING)
-extern FUNC_NORETURN void z_arm_switch_to_main_no_multithreading(
-	k_thread_entry_t main_func,
-	void *p1, void *p2, void *p3);
+extern FUNC_NORETURN void z_arm_switch_to_main_no_multithreading(k_thread_entry_t main_func,
+								 void *p1, void *p2, void *p3);
 
-#define ARCH_SWITCH_TO_MAIN_NO_MULTITHREADING \
-	z_arm_switch_to_main_no_multithreading
+#define ARCH_SWITCH_TO_MAIN_NO_MULTITHREADING z_arm_switch_to_main_no_multithreading
 
 #endif /* !CONFIG_MULTITHREADING */
 
-extern FUNC_NORETURN void z_arm_userspace_enter(k_thread_entry_t user_entry,
-					       void *p1, void *p2, void *p3,
-					       uint32_t stack_end,
-					       uint32_t stack_start);
+extern FUNC_NORETURN void z_arm_userspace_enter(k_thread_entry_t user_entry, void *p1, void *p2,
+						void *p3, uint32_t stack_end, uint32_t stack_start);
 
 extern void z_arm_fatal_error(unsigned int reason, const struct arch_esf *esf);
 
@@ -101,7 +96,6 @@ static ALWAYS_INLINE int arch_swap(unsigned int key)
 	 */
 	return _current->arch.swap_return_value;
 }
-
 
 #endif /* _ASMLANGUAGE */
 

--- a/arch/arm/include/cortex_m/stack.h
+++ b/arch/arm/include/cortex_m/stack.h
@@ -26,8 +26,7 @@
 extern "C" {
 #endif
 
-K_KERNEL_STACK_ARRAY_DECLARE(z_interrupt_stacks, CONFIG_MP_MAX_NUM_CPUS,
-			     CONFIG_ISR_STACK_SIZE);
+K_KERNEL_STACK_ARRAY_DECLARE(z_interrupt_stacks, CONFIG_MP_MAX_NUM_CPUS, CONFIG_ISR_STACK_SIZE);
 
 /**
  *
@@ -39,9 +38,8 @@ K_KERNEL_STACK_ARRAY_DECLARE(z_interrupt_stacks, CONFIG_MP_MAX_NUM_CPUS,
  */
 static ALWAYS_INLINE void z_arm_interrupt_stack_setup(void)
 {
-	uint32_t msp =
-		(uint32_t)(K_KERNEL_STACK_BUFFER(z_interrupt_stacks[0])) +
-			   K_KERNEL_STACK_SIZEOF(z_interrupt_stacks[0]);
+	uint32_t msp = (uint32_t)(K_KERNEL_STACK_BUFFER(z_interrupt_stacks[0])) +
+		       K_KERNEL_STACK_SIZEOF(z_interrupt_stacks[0]);
 
 	__set_MSP(msp);
 #if defined(CONFIG_BUILTIN_STACK_GUARD)

--- a/arch/arm/include/cortex_m/tz_ns.h
+++ b/arch/arm/include/cortex_m/tz_ns.h
@@ -46,24 +46,18 @@
  *                  the functions have been called. This instruction must leave
  *                  r0-r3 unmodified.
  */
-#define __TZ_WRAP_FUNC_RAW(preface, name, postface, store_lr, load_lr) \
-		__asm__ volatile( \
-			".global "#preface"; .type "#preface", %function"); \
-		__asm__ volatile( \
-			".global "#name"; .type "#name", %function"); \
-		__asm__ volatile( \
-			".global "#postface"; .type "#postface", %function"); \
-		__asm__ volatile( \
-			store_lr "\n\t" \
-			"push {r0-r3}\n\t" \
-			"bl " #preface "\n\t" \
-			"pop {r0-r3}\n\t" \
-			"bl " #name " \n\t" \
-			"push {r0-r3}\n\t" \
-			"bl " #postface "\n\t" \
-			"pop {r0-r3}\n\t" \
-			load_lr "\n\t" \
-			::);
+#define __TZ_WRAP_FUNC_RAW(preface, name, postface, store_lr, load_lr)                             \
+	__asm__ volatile(".global " #preface "; .type " #preface ", %function");                   \
+	__asm__ volatile(".global " #name "; .type " #name ", %function");                         \
+	__asm__ volatile(".global " #postface "; .type " #postface ", %function");                 \
+	__asm__ volatile(store_lr "\n\t"                                                           \
+				  "push {r0-r3}\n\t"                                               \
+				  "bl " #preface "\n\t"                                            \
+				  "pop {r0-r3}\n\t"                                                \
+				  "bl " #name "\n\t"                                               \
+				  "push {r0-r3}\n\t"                                               \
+				  "bl " #postface "\n\t"                                           \
+				  "pop {r0-r3}\n\t" load_lr "\n\t" ::);
 
 /**
  * @brief Macro for "sandwiching" a function call (@p name) in two other calls
@@ -98,10 +92,8 @@
  *
  * See @ref __TZ_WRAP_FUNC_RAW for more information.
  */
-#define __TZ_WRAP_FUNC(preface, name, postface) \
-	__TZ_WRAP_FUNC_RAW(preface, name, postface, "push {r4, lr}", \
-			"pop {r4, pc}")
-
+#define __TZ_WRAP_FUNC(preface, name, postface)                                                    \
+	__TZ_WRAP_FUNC_RAW(preface, name, postface, "push {r4, lr}", "pop {r4, pc}")
 
 #ifdef CONFIG_ARM_FIRMWARE_USES_SECURE_ENTRY_FUNCS
 /**
@@ -130,10 +122,10 @@
  * @param ...   The rest of the signature of the function. This must be the same
  *              signature as the corresponding NS entry function.
  */
-#define TZ_THREAD_SAFE_NONSECURE_ENTRY_FUNC(name, ret, nsc_name, ...) \
-	ret __attribute__((naked)) name(__VA_ARGS__) \
-	{ \
-		__TZ_WRAP_FUNC(k_sched_lock, nsc_name, k_sched_unlock); \
+#define TZ_THREAD_SAFE_NONSECURE_ENTRY_FUNC(name, ret, nsc_name, ...)                              \
+	ret __attribute__((naked)) name(__VA_ARGS__)                                               \
+	{                                                                                          \
+		__TZ_WRAP_FUNC(k_sched_lock, nsc_name, k_sched_unlock);                            \
 	}
 
 #endif /* CONFIG_ARM_FIRMWARE_USES_SECURE_ENTRY_FUNCS */

--- a/include/zephyr/arch/arm/cortex_m/cpu.h
+++ b/include/zephyr/arch/arm/cortex_m/cpu.h
@@ -12,9 +12,9 @@
 #define _SCS_BASE_ADDR _PPB_INT_SCS
 
 /* ICSR defines */
-#define _SCS_ICSR (_SCS_BASE_ADDR + 0xd04)
-#define _SCS_ICSR_PENDSV (1 << 28)
-#define _SCS_ICSR_UNPENDSV (1 << 27)
+#define _SCS_ICSR           (_SCS_BASE_ADDR + 0xd04)
+#define _SCS_ICSR_PENDSV    (1 << 28)
+#define _SCS_ICSR_UNPENDSV  (1 << 27)
 #define _SCS_ICSR_RETTOBASE (1 << 11)
 
 #define _SCS_MPU_CTRL (_SCS_BASE_ADDR + 0xd94)
@@ -34,20 +34,20 @@ extern "C" {
 #endif
 
 /* CP10 Access Bits */
-#define CPACR_CP10_Pos          20U
-#define CPACR_CP10_Msk          (3UL << CPACR_CP10_Pos)
-#define CPACR_CP10_NO_ACCESS    (0UL << CPACR_CP10_Pos)
-#define CPACR_CP10_PRIV_ACCESS  (1UL << CPACR_CP10_Pos)
-#define CPACR_CP10_RESERVED     (2UL << CPACR_CP10_Pos)
-#define CPACR_CP10_FULL_ACCESS  (3UL << CPACR_CP10_Pos)
+#define CPACR_CP10_Pos         20U
+#define CPACR_CP10_Msk         (3UL << CPACR_CP10_Pos)
+#define CPACR_CP10_NO_ACCESS   (0UL << CPACR_CP10_Pos)
+#define CPACR_CP10_PRIV_ACCESS (1UL << CPACR_CP10_Pos)
+#define CPACR_CP10_RESERVED    (2UL << CPACR_CP10_Pos)
+#define CPACR_CP10_FULL_ACCESS (3UL << CPACR_CP10_Pos)
 
 /* CP11 Access Bits */
-#define CPACR_CP11_Pos          22U
-#define CPACR_CP11_Msk          (3UL << CPACR_CP11_Pos)
-#define CPACR_CP11_NO_ACCESS    (0UL << CPACR_CP11_Pos)
-#define CPACR_CP11_PRIV_ACCESS  (1UL << CPACR_CP11_Pos)
-#define CPACR_CP11_RESERVED     (2UL << CPACR_CP11_Pos)
-#define CPACR_CP11_FULL_ACCESS  (3UL << CPACR_CP11_Pos)
+#define CPACR_CP11_Pos         22U
+#define CPACR_CP11_Msk         (3UL << CPACR_CP11_Pos)
+#define CPACR_CP11_NO_ACCESS   (0UL << CPACR_CP11_Pos)
+#define CPACR_CP11_PRIV_ACCESS (1UL << CPACR_CP11_Pos)
+#define CPACR_CP11_RESERVED    (2UL << CPACR_CP11_Pos)
+#define CPACR_CP11_FULL_ACCESS (3UL << CPACR_CP11_Pos)
 
 #ifdef CONFIG_PM_S2RAM
 

--- a/include/zephyr/arch/arm/cortex_m/exception.h
+++ b/include/zephyr/arch/arm/cortex_m/exception.h
@@ -43,17 +43,17 @@
 #define _EXCEPTION_RESERVED_PRIO 0
 #endif
 
-#define _EXC_FAULT_PRIO 0
+#define _EXC_FAULT_PRIO             0
 #define _EXC_ZERO_LATENCY_IRQS_PRIO 0
-#define _EXC_SVC_PRIO COND_CODE_1(CONFIG_ZERO_LATENCY_IRQS,		\
+#define _EXC_SVC_PRIO               COND_CODE_1(CONFIG_ZERO_LATENCY_IRQS,		\
 				  (CONFIG_ZERO_LATENCY_LEVELS), (0))
-#define _IRQ_PRIO_OFFSET (_EXCEPTION_RESERVED_PRIO + _EXC_SVC_PRIO)
-#define IRQ_PRIO_LOWEST (BIT(NUM_IRQ_PRIO_BITS) - (_IRQ_PRIO_OFFSET) - 1)
+#define _IRQ_PRIO_OFFSET            (_EXCEPTION_RESERVED_PRIO + _EXC_SVC_PRIO)
+#define IRQ_PRIO_LOWEST             (BIT(NUM_IRQ_PRIO_BITS) - (_IRQ_PRIO_OFFSET) - 1)
 
 #define _EXC_IRQ_DEFAULT_PRIO Z_EXC_PRIO(_IRQ_PRIO_OFFSET)
 
 /* Use lowest possible priority level for PendSV */
-#define _EXC_PENDSV_PRIO 0xff
+#define _EXC_PENDSV_PRIO      0xff
 #define _EXC_PENDSV_PRIO_MASK Z_EXC_PRIO(_EXC_PENDSV_PRIO)
 
 #ifdef _ASMLANGUAGE
@@ -99,7 +99,10 @@ struct __extra_esf_info {
 #endif /* CONFIG_EXTRA_EXCEPTION_INFO */
 
 /* ARM GPRs are often designated by two different names */
-#define sys_define_gpr_with_alias(name1, name2) union { uint32_t name1, name2; }
+#define sys_define_gpr_with_alias(name1, name2)                                                    \
+	union {                                                                                    \
+		uint32_t name1, name2;                                                             \
+	}
 
 struct arch_esf {
 	struct __basic_sf {

--- a/include/zephyr/arch/arm/cortex_m/memory_map.h
+++ b/include/zephyr/arch/arm/cortex_m/memory_map.h
@@ -18,8 +18,8 @@
 #include <zephyr/sys/util.h>
 
 /* 0x00000000 -> 0x1fffffff: Code in ROM [0.5 GB] */
-#define _CODE_BASE_ADDR           0x00000000
-#define _CODE_END_ADDR            0x1FFFFFFF
+#define _CODE_BASE_ADDR 0x00000000
+#define _CODE_END_ADDR  0x1FFFFFFF
 
 /* 0x20000000 -> 0x3fffffff: SRAM [0.5GB] */
 #define _SRAM_BASE_ADDR           0x20000000
@@ -38,78 +38,77 @@
 #define _PERI_END_ADDR            0x5FFFFFFF
 
 /* 0x60000000 -> 0x9fffffff: external RAM [1GB] */
-#define _ERAM_BASE_ADDR           0x60000000
-#define _ERAM_END_ADDR            0x9FFFFFFF
+#define _ERAM_BASE_ADDR 0x60000000
+#define _ERAM_END_ADDR  0x9FFFFFFF
 
 /* 0xa0000000 -> 0xdfffffff: external devices [1GB] */
-#define _EDEV_BASE_ADDR           0xA0000000
-#define _EDEV_END_ADDR            0xDFFFFFFF
+#define _EDEV_BASE_ADDR 0xA0000000
+#define _EDEV_END_ADDR  0xDFFFFFFF
 
 /* 0xe0000000 -> 0xffffffff: varies by processor (see below) */
 
 /* 0xe0000000 -> 0xe00fffff: private peripheral bus */
 /* 0xe0000000 -> 0xe003ffff: internal [256KB] */
-#define _PPB_INT_BASE_ADDR        0xE0000000
-#if defined(CONFIG_CPU_CORTEX_M0) || defined(CONFIG_CPU_CORTEX_M0PLUS) || \
+#define _PPB_INT_BASE_ADDR 0xE0000000
+#if defined(CONFIG_CPU_CORTEX_M0) || defined(CONFIG_CPU_CORTEX_M0PLUS) ||                          \
 	defined(CONFIG_CPU_CORTEX_M1)
-#define _PPB_INT_RSVD_0           0xE0000000
-#define _PPB_INT_DWT              0xE0001000
-#define _PPB_INT_BPU              0xE0002000
-#define _PPB_INT_RSVD_1           0xE0003000
-#define _PPB_INT_SCS              0xE000E000
-#define _PPB_INT_RSVD_2           0xE000F000
-#elif defined(CONFIG_CPU_CORTEX_M3) || defined(CONFIG_CPU_CORTEX_M4) || defined(CONFIG_CPU_CORTEX_M7)
-#define _PPB_INT_ITM              0xE0000000
-#define _PPB_INT_DWT              0xE0001000
-#define _PPB_INT_FPB              0xE0002000
-#define _PPB_INT_RSVD_1           0xE0003000
-#define _PPB_INT_SCS              0xE000E000
-#define _PPB_INT_RSVD_2           0xE000F000
-#elif defined(CONFIG_CPU_CORTEX_M23) || \
-	defined(CONFIG_CPU_CORTEX_M33) || \
-	defined(CONFIG_CPU_CORTEX_M55) || \
-	defined(CONFIG_CPU_CORTEX_M85)
-#define _PPB_INT_RSVD_0           0xE0000000
-#define _PPB_INT_SCS              0xE000E000
-#define _PPB_INT_SCB              0xE000ED00
-#define _PPB_INT_RSVD_1           0xE002E000
+#define _PPB_INT_RSVD_0 0xE0000000
+#define _PPB_INT_DWT    0xE0001000
+#define _PPB_INT_BPU    0xE0002000
+#define _PPB_INT_RSVD_1 0xE0003000
+#define _PPB_INT_SCS    0xE000E000
+#define _PPB_INT_RSVD_2 0xE000F000
+#elif defined(CONFIG_CPU_CORTEX_M3) || defined(CONFIG_CPU_CORTEX_M4) ||                            \
+	defined(CONFIG_CPU_CORTEX_M7)
+#define _PPB_INT_ITM    0xE0000000
+#define _PPB_INT_DWT    0xE0001000
+#define _PPB_INT_FPB    0xE0002000
+#define _PPB_INT_RSVD_1 0xE0003000
+#define _PPB_INT_SCS    0xE000E000
+#define _PPB_INT_RSVD_2 0xE000F000
+#elif defined(CONFIG_CPU_CORTEX_M23) || defined(CONFIG_CPU_CORTEX_M33) ||                          \
+	defined(CONFIG_CPU_CORTEX_M55) || defined(CONFIG_CPU_CORTEX_M85)
+#define _PPB_INT_RSVD_0 0xE0000000
+#define _PPB_INT_SCS    0xE000E000
+#define _PPB_INT_SCB    0xE000ED00
+#define _PPB_INT_RSVD_1 0xE002E000
 #else
 #error Unknown CPU
 #endif
-#define _PPB_INT_END_ADDR         0xE003FFFF
+#define _PPB_INT_END_ADDR 0xE003FFFF
 
 /* 0xe0000000 -> 0xe00fffff: private peripheral bus */
 /* 0xe0040000 -> 0xe00fffff: external [768K] */
-#define _PPB_EXT_BASE_ADDR        0xE0040000
-#if defined(CONFIG_CPU_CORTEX_M0) || defined(CONFIG_CPU_CORTEX_M0PLUS) \
-	|| defined(CONFIG_CPU_CORTEX_M1) || defined(CONFIG_CPU_CORTEX_M23)
+#define _PPB_EXT_BASE_ADDR 0xE0040000
+#if defined(CONFIG_CPU_CORTEX_M0) || defined(CONFIG_CPU_CORTEX_M0PLUS) ||                          \
+	defined(CONFIG_CPU_CORTEX_M1) || defined(CONFIG_CPU_CORTEX_M23)
 #elif defined(CONFIG_CPU_CORTEX_M3) || defined(CONFIG_CPU_CORTEX_M4)
-#define _PPB_EXT_TPIU             0xE0040000
-#define _PPB_EXT_ETM              0xE0041000
-#define _PPB_EXT_PPB              0xE0042000
-#define _PPB_EXT_ROM_TABLE        0xE00FF000
-#define _PPB_EXT_END_ADDR         0xE00FFFFF
-#elif defined(CONFIG_CPU_CORTEX_M33) || defined(CONFIG_CPU_CORTEX_M55) \
-	|| defined(CONFIG_CPU_CORTEX_M85)
-#undef  _PPB_EXT_BASE_ADDR
-#define _PPB_EXT_BASE_ADDR        0xE0044000
-#define _PPB_EXT_ROM_TABLE        0xE00FF000
-#define _PPB_EXT_END_ADDR         0xE00FFFFF
+#define _PPB_EXT_TPIU      0xE0040000
+#define _PPB_EXT_ETM       0xE0041000
+#define _PPB_EXT_PPB       0xE0042000
+#define _PPB_EXT_ROM_TABLE 0xE00FF000
+#define _PPB_EXT_END_ADDR  0xE00FFFFF
+#elif defined(CONFIG_CPU_CORTEX_M33) || defined(CONFIG_CPU_CORTEX_M55) ||                          \
+	defined(CONFIG_CPU_CORTEX_M85)
+#undef _PPB_EXT_BASE_ADDR
+#define _PPB_EXT_BASE_ADDR 0xE0044000
+#define _PPB_EXT_ROM_TABLE 0xE00FF000
+#define _PPB_EXT_END_ADDR  0xE00FFFFF
 #elif defined(CONFIG_CPU_CORTEX_M7)
-#define _PPB_EXT_BASE_ADDR        0xE0040000
-#define _PPB_EXT_RSVD_TPIU        0xE0040000
-#define _PPB_EXT_ETM              0xE0041000
-#define _PPB_EXT_CTI              0xE0042000
-#define _PPB_EXT_PPB              0xE0043000
-#define _PPB_EXT_PROC_ROM_TABLE   0xE00FE000
-#define _PPB_EXT_PPB_ROM_TABLE    0xE00FF000
+#define _PPB_EXT_BASE_ADDR      0xE0040000
+#define _PPB_EXT_RSVD_TPIU      0xE0040000
+#define _PPB_EXT_ETM            0xE0041000
+#define _PPB_EXT_CTI            0xE0042000
+#define _PPB_EXT_PPB            0xE0043000
+#define _PPB_EXT_PROC_ROM_TABLE 0xE00FE000
+#define _PPB_EXT_PPB_ROM_TABLE  0xE00FF000
 #else
 #error Unknown CPU
 #endif
-#define _PPB_EXT_END_ADDR         0xE00FFFFF
+#define _PPB_EXT_END_ADDR 0xE00FFFFF
 
 /* 0xe0100000 -> 0xffffffff: vendor-specific [0.5GB-1MB or 511MB]  */
-#define _VENDOR_BASE_ADDR         0xE0100000
-#define _VENDOR_END_ADDR          0xFFFFFFFF
+#define _VENDOR_BASE_ADDR 0xE0100000
+#define _VENDOR_END_ADDR  0xFFFFFFFF
 
 #endif /* ZEPHYR_INCLUDE_ARCH_ARM_CORTEX_M_MEMORY_MAP_H_ */

--- a/include/zephyr/arch/arm/mpu/arm_mpu.h
+++ b/include/zephyr/arch/arm/mpu/arm_mpu.h
@@ -6,16 +6,11 @@
 #ifndef ZEPHYR_INCLUDE_ARCH_ARM_MPU_ARM_MPU_H_
 #define ZEPHYR_INCLUDE_ARCH_ARM_MPU_ARM_MPU_H_
 
-#if defined(CONFIG_CPU_CORTEX_M0PLUS) || \
-	defined(CONFIG_CPU_CORTEX_M3) || \
-	defined(CONFIG_CPU_CORTEX_M4) || \
-	defined(CONFIG_CPU_CORTEX_M7) || \
-	defined(CONFIG_ARMV7_R)
+#if defined(CONFIG_CPU_CORTEX_M0PLUS) || defined(CONFIG_CPU_CORTEX_M3) ||                          \
+	defined(CONFIG_CPU_CORTEX_M4) || defined(CONFIG_CPU_CORTEX_M7) || defined(CONFIG_ARMV7_R)
 #include <zephyr/arch/arm/mpu/arm_mpu_v7m.h>
-#elif defined(CONFIG_CPU_CORTEX_M23) || \
-	defined(CONFIG_CPU_CORTEX_M33) || \
-	defined(CONFIG_CPU_CORTEX_M55) || \
-	defined(CONFIG_CPU_CORTEX_M85) || \
+#elif defined(CONFIG_CPU_CORTEX_M23) || defined(CONFIG_CPU_CORTEX_M33) ||                          \
+	defined(CONFIG_CPU_CORTEX_M55) || defined(CONFIG_CPU_CORTEX_M85) ||                        \
 	defined(CONFIG_AARCH32_ARMV8_R)
 #include <zephyr/arch/arm/mpu/arm_mpu_v8.h>
 #else
@@ -47,19 +42,19 @@ struct arm_mpu_config {
 };
 
 #if defined(CONFIG_ARMV7_R)
-#define MPU_REGION_ENTRY(_name, _base, _size, _attr) \
-	{\
-		.name = _name, \
-		.base = _base, \
-		.size = _size, \
-		.attr = _attr, \
+#define MPU_REGION_ENTRY(_name, _base, _size, _attr)                                               \
+	{                                                                                          \
+		.name = _name,                                                                     \
+		.base = _base,                                                                     \
+		.size = _size,                                                                     \
+		.attr = _attr,                                                                     \
 	}
 #else
-#define MPU_REGION_ENTRY(_name, _base, _attr) \
-	{\
-		.name = _name, \
-		.base = _base, \
-		.attr = _attr, \
+#define MPU_REGION_ENTRY(_name, _base, _attr)                                                      \
+	{                                                                                          \
+		.name = _name,                                                                     \
+		.base = _base,                                                                     \
+		.attr = _attr,                                                                     \
 	}
 #endif
 

--- a/include/zephyr/arch/arm/mpu/arm_mpu_v7m.h
+++ b/include/zephyr/arch/arm/mpu/arm_mpu_v7m.h
@@ -46,73 +46,69 @@
 #define NOT_EXEC MPU_RASR_XN_Msk
 
 /* The following definitions are for internal use in arm_mpu.h. */
-#define STRONGLY_ORDERED_SHAREABLE      MPU_RASR_S_Msk
-#define DEVICE_SHAREABLE                (MPU_RASR_B_Msk | MPU_RASR_S_Msk)
-#define NORMAL_OUTER_INNER_WRITE_THROUGH_SHAREABLE \
-		(MPU_RASR_C_Msk | MPU_RASR_S_Msk)
-#define NORMAL_OUTER_INNER_WRITE_THROUGH_NON_SHAREABLE	MPU_RASR_C_Msk
-#define NORMAL_OUTER_INNER_WRITE_BACK_SHAREABLE	\
-		(MPU_RASR_C_Msk | MPU_RASR_B_Msk | MPU_RASR_S_Msk)
-#define NORMAL_OUTER_INNER_WRITE_BACK_NON_SHAREABLE \
-		(MPU_RASR_C_Msk | MPU_RASR_B_Msk)
-#define NORMAL_OUTER_INNER_NON_CACHEABLE_SHAREABLE \
-		((1 << MPU_RASR_TEX_Pos) | MPU_RASR_S_Msk)
-#define NORMAL_OUTER_INNER_NON_CACHEABLE_NON_SHAREABLE \
-		(1 << MPU_RASR_TEX_Pos)
-#define NORMAL_OUTER_INNER_WRITE_BACK_WRITE_READ_ALLOCATE_SHAREABLE \
-	((1 << MPU_RASR_TEX_Pos) |\
-	 MPU_RASR_C_Msk | MPU_RASR_B_Msk | MPU_RASR_S_Msk)
-#define NORMAL_OUTER_INNER_WRITE_BACK_WRITE_READ_ALLOCATE_NON_SHAREABLE \
+#define STRONGLY_ORDERED_SHAREABLE                     MPU_RASR_S_Msk
+#define DEVICE_SHAREABLE                               (MPU_RASR_B_Msk | MPU_RASR_S_Msk)
+#define NORMAL_OUTER_INNER_WRITE_THROUGH_SHAREABLE     (MPU_RASR_C_Msk | MPU_RASR_S_Msk)
+#define NORMAL_OUTER_INNER_WRITE_THROUGH_NON_SHAREABLE MPU_RASR_C_Msk
+/* clang-format off */
+#define NORMAL_OUTER_INNER_WRITE_BACK_SHAREABLE                                                    \
+	(MPU_RASR_C_Msk | MPU_RASR_B_Msk | MPU_RASR_S_Msk)
+/* clang-format on */
+#define NORMAL_OUTER_INNER_WRITE_BACK_NON_SHAREABLE    (MPU_RASR_C_Msk | MPU_RASR_B_Msk)
+#define NORMAL_OUTER_INNER_NON_CACHEABLE_SHAREABLE     ((1 << MPU_RASR_TEX_Pos) | MPU_RASR_S_Msk)
+#define NORMAL_OUTER_INNER_NON_CACHEABLE_NON_SHAREABLE (1 << MPU_RASR_TEX_Pos)
+#define NORMAL_OUTER_INNER_WRITE_BACK_WRITE_READ_ALLOCATE_SHAREABLE                                \
+	((1 << MPU_RASR_TEX_Pos) | MPU_RASR_C_Msk | MPU_RASR_B_Msk | MPU_RASR_S_Msk)
+#define NORMAL_OUTER_INNER_WRITE_BACK_WRITE_READ_ALLOCATE_NON_SHAREABLE                            \
 	((1 << MPU_RASR_TEX_Pos) | MPU_RASR_C_Msk | MPU_RASR_B_Msk)
-#define DEVICE_NON_SHAREABLE            (2 << MPU_RASR_TEX_Pos)
+#define DEVICE_NON_SHAREABLE (2 << MPU_RASR_TEX_Pos)
 
 /* Bit-masks to disable sub-regions. */
-#define SUB_REGION_0_DISABLED	((0x01 << MPU_RASR_SRD_Pos) & MPU_RASR_SRD_Msk)
-#define SUB_REGION_1_DISABLED	((0x02 << MPU_RASR_SRD_Pos) & MPU_RASR_SRD_Msk)
-#define SUB_REGION_2_DISABLED	((0x04 << MPU_RASR_SRD_Pos) & MPU_RASR_SRD_Msk)
-#define SUB_REGION_3_DISABLED	((0x08 << MPU_RASR_SRD_Pos) & MPU_RASR_SRD_Msk)
-#define SUB_REGION_4_DISABLED	((0x10 << MPU_RASR_SRD_Pos) & MPU_RASR_SRD_Msk)
-#define SUB_REGION_5_DISABLED	((0x20 << MPU_RASR_SRD_Pos) & MPU_RASR_SRD_Msk)
-#define SUB_REGION_6_DISABLED	((0x40 << MPU_RASR_SRD_Pos) & MPU_RASR_SRD_Msk)
-#define SUB_REGION_7_DISABLED	((0x80 << MPU_RASR_SRD_Pos) & MPU_RASR_SRD_Msk)
+#define SUB_REGION_0_DISABLED ((0x01 << MPU_RASR_SRD_Pos) & MPU_RASR_SRD_Msk)
+#define SUB_REGION_1_DISABLED ((0x02 << MPU_RASR_SRD_Pos) & MPU_RASR_SRD_Msk)
+#define SUB_REGION_2_DISABLED ((0x04 << MPU_RASR_SRD_Pos) & MPU_RASR_SRD_Msk)
+#define SUB_REGION_3_DISABLED ((0x08 << MPU_RASR_SRD_Pos) & MPU_RASR_SRD_Msk)
+#define SUB_REGION_4_DISABLED ((0x10 << MPU_RASR_SRD_Pos) & MPU_RASR_SRD_Msk)
+#define SUB_REGION_5_DISABLED ((0x20 << MPU_RASR_SRD_Pos) & MPU_RASR_SRD_Msk)
+#define SUB_REGION_6_DISABLED ((0x40 << MPU_RASR_SRD_Pos) & MPU_RASR_SRD_Msk)
+#define SUB_REGION_7_DISABLED ((0x80 << MPU_RASR_SRD_Pos) & MPU_RASR_SRD_Msk)
 
+#define REGION_SIZE(size) ((ARM_MPU_REGION_SIZE_##size << MPU_RASR_SIZE_Pos) & MPU_RASR_SIZE_Msk)
 
-#define REGION_SIZE(size) ((ARM_MPU_REGION_SIZE_ ## size \
-	<< MPU_RASR_SIZE_Pos) & MPU_RASR_SIZE_Msk)
+#define REGION_32B  REGION_SIZE(32B)
+#define REGION_64B  REGION_SIZE(64B)
+#define REGION_128B REGION_SIZE(128B)
+#define REGION_256B REGION_SIZE(256B)
+#define REGION_512B REGION_SIZE(512B)
+#define REGION_1K   REGION_SIZE(1KB)
+#define REGION_2K   REGION_SIZE(2KB)
+#define REGION_4K   REGION_SIZE(4KB)
+#define REGION_8K   REGION_SIZE(8KB)
+#define REGION_16K  REGION_SIZE(16KB)
+#define REGION_32K  REGION_SIZE(32KB)
+#define REGION_64K  REGION_SIZE(64KB)
+#define REGION_128K REGION_SIZE(128KB)
+#define REGION_256K REGION_SIZE(256KB)
+#define REGION_512K REGION_SIZE(512KB)
+#define REGION_1M   REGION_SIZE(1MB)
+#define REGION_2M   REGION_SIZE(2MB)
+#define REGION_4M   REGION_SIZE(4MB)
+#define REGION_8M   REGION_SIZE(8MB)
+#define REGION_16M  REGION_SIZE(16MB)
+#define REGION_32M  REGION_SIZE(32MB)
+#define REGION_64M  REGION_SIZE(64MB)
+#define REGION_128M REGION_SIZE(128MB)
+#define REGION_256M REGION_SIZE(256MB)
+#define REGION_512M REGION_SIZE(512MB)
+#define REGION_1G   REGION_SIZE(1GB)
+#define REGION_2G   REGION_SIZE(2GB)
+#define REGION_4G   REGION_SIZE(4GB)
 
-#define REGION_32B      REGION_SIZE(32B)
-#define REGION_64B      REGION_SIZE(64B)
-#define REGION_128B     REGION_SIZE(128B)
-#define REGION_256B     REGION_SIZE(256B)
-#define REGION_512B     REGION_SIZE(512B)
-#define REGION_1K       REGION_SIZE(1KB)
-#define REGION_2K       REGION_SIZE(2KB)
-#define REGION_4K       REGION_SIZE(4KB)
-#define REGION_8K       REGION_SIZE(8KB)
-#define REGION_16K      REGION_SIZE(16KB)
-#define REGION_32K      REGION_SIZE(32KB)
-#define REGION_64K      REGION_SIZE(64KB)
-#define REGION_128K     REGION_SIZE(128KB)
-#define REGION_256K     REGION_SIZE(256KB)
-#define REGION_512K     REGION_SIZE(512KB)
-#define REGION_1M       REGION_SIZE(1MB)
-#define REGION_2M       REGION_SIZE(2MB)
-#define REGION_4M       REGION_SIZE(4MB)
-#define REGION_8M       REGION_SIZE(8MB)
-#define REGION_16M      REGION_SIZE(16MB)
-#define REGION_32M      REGION_SIZE(32MB)
-#define REGION_64M      REGION_SIZE(64MB)
-#define REGION_128M     REGION_SIZE(128MB)
-#define REGION_256M     REGION_SIZE(256MB)
-#define REGION_512M     REGION_SIZE(512MB)
-#define REGION_1G       REGION_SIZE(1GB)
-#define REGION_2G       REGION_SIZE(2GB)
-#define REGION_4G       REGION_SIZE(4GB)
-
-#define ARM_MPU_REGION_INIT(p_name, p_base, p_size, p_attr)	\
-	{ .name = p_name,					\
-	  .base = p_base,					\
-	  .attr = p_attr(size_to_mpu_rasr_size(p_size)),	\
+#define ARM_MPU_REGION_INIT(p_name, p_base, p_size, p_attr)                                        \
+	{                                                                                          \
+		.name = p_name,                                                                    \
+		.base = p_base,                                                                    \
+		.attr = p_attr(size_to_mpu_rasr_size(p_size)),                                     \
 	}
 
 /* Some helper defines for common regions */
@@ -121,33 +117,20 @@
  * CONFIG_XIP=n, the entire image will be linked to SRAM, so we need to keep
  * the SRAM region XN bit clear or the application code will not be executable.
  */
-#define REGION_RAM_ATTR(size) \
-{ \
-	(NORMAL_OUTER_INNER_WRITE_BACK_WRITE_READ_ALLOCATE_NON_SHAREABLE | \
-	 IF_ENABLED(CONFIG_XIP, (MPU_RASR_XN_Msk |)) size | P_RW_U_NA_Msk) \
-}
-#define REGION_RAM_NOCACHE_ATTR(size) \
-{ \
-	(NORMAL_OUTER_INNER_NON_CACHEABLE_NON_SHAREABLE | \
-	 MPU_RASR_XN_Msk | size | P_RW_U_NA_Msk) \
-}
+#define REGION_RAM_ATTR(size)                                                                      \
+	{(NORMAL_OUTER_INNER_WRITE_BACK_WRITE_READ_ALLOCATE_NON_SHAREABLE |                        \
+	  IF_ENABLED(CONFIG_XIP, (MPU_RASR_XN_Msk |)) size | P_RW_U_NA_Msk)}
+#define REGION_RAM_NOCACHE_ATTR(size)                                                              \
+	{(NORMAL_OUTER_INNER_NON_CACHEABLE_NON_SHAREABLE | MPU_RASR_XN_Msk | size | P_RW_U_NA_Msk)}
 #if defined(CONFIG_MPU_ALLOW_FLASH_WRITE)
-#define REGION_FLASH_ATTR(size) \
-{ \
-	(NORMAL_OUTER_INNER_WRITE_THROUGH_NON_SHAREABLE | size | \
-		P_RW_U_RO_Msk) \
-}
+#define REGION_FLASH_ATTR(size)                                                                    \
+	{(NORMAL_OUTER_INNER_WRITE_THROUGH_NON_SHAREABLE | size | P_RW_U_RO_Msk)}
 #else
-#define REGION_FLASH_ATTR(size) \
-{ \
-	(NORMAL_OUTER_INNER_WRITE_THROUGH_NON_SHAREABLE | size | RO_Msk) \
-}
+#define REGION_FLASH_ATTR(size) {(NORMAL_OUTER_INNER_WRITE_THROUGH_NON_SHAREABLE | size | RO_Msk)}
 #endif
-#define REGION_PPB_ATTR(size) { (STRONGLY_ORDERED_SHAREABLE | size | \
-		P_RW_U_NA_Msk) }
-#define REGION_IO_ATTR(size) { (DEVICE_NON_SHAREABLE | size | P_RW_U_NA_Msk) }
-#define REGION_EXTMEM_ATTR(size) { (STRONGLY_ORDERED_SHAREABLE | size | \
-		NO_ACCESS_Msk) }
+#define REGION_PPB_ATTR(size)    {(STRONGLY_ORDERED_SHAREABLE | size | P_RW_U_NA_Msk)}
+#define REGION_IO_ATTR(size)     {(DEVICE_NON_SHAREABLE | size | P_RW_U_NA_Msk)}
+#define REGION_EXTMEM_ATTR(size) {(STRONGLY_ORDERED_SHAREABLE | size | NO_ACCESS_Msk)}
 
 struct arm_mpu_region_attr {
 	/* Attributes belonging to RASR (including the encoded region size) */
@@ -162,12 +145,12 @@ typedef struct {
 } k_mem_partition_attr_t;
 
 /* Read-Write access permission attributes */
-#define _K_MEM_PARTITION_P_NA_U_NA	(NO_ACCESS_Msk | NOT_EXEC)
-#define _K_MEM_PARTITION_P_RW_U_RW	(P_RW_U_RW_Msk | NOT_EXEC)
-#define _K_MEM_PARTITION_P_RW_U_RO	(P_RW_U_RO_Msk | NOT_EXEC)
-#define _K_MEM_PARTITION_P_RW_U_NA	(P_RW_U_NA_Msk | NOT_EXEC)
-#define _K_MEM_PARTITION_P_RO_U_RO	(P_RO_U_RO_Msk | NOT_EXEC)
-#define _K_MEM_PARTITION_P_RO_U_NA	(P_RO_U_NA_Msk | NOT_EXEC)
+#define _K_MEM_PARTITION_P_NA_U_NA (NO_ACCESS_Msk | NOT_EXEC)
+#define _K_MEM_PARTITION_P_RW_U_RW (P_RW_U_RW_Msk | NOT_EXEC)
+#define _K_MEM_PARTITION_P_RW_U_RO (P_RW_U_RO_Msk | NOT_EXEC)
+#define _K_MEM_PARTITION_P_RW_U_NA (P_RW_U_NA_Msk | NOT_EXEC)
+#define _K_MEM_PARTITION_P_RO_U_RO (P_RO_U_RO_Msk | NOT_EXEC)
+#define _K_MEM_PARTITION_P_RO_U_NA (P_RO_U_NA_Msk | NOT_EXEC)
 
 /* Execution-allowed attributes */
 #define _K_MEM_PARTITION_P_RWX_U_RWX (P_RW_U_RW_Msk)
@@ -184,35 +167,44 @@ typedef struct {
  */
 
 /* Read-Write access permission attributes (default cache-ability) */
-#define K_MEM_PARTITION_P_NA_U_NA	((k_mem_partition_attr_t) \
-	{ _K_MEM_PARTITION_P_NA_U_NA | \
-	  NORMAL_OUTER_INNER_WRITE_BACK_WRITE_READ_ALLOCATE_NON_SHAREABLE})
-#define K_MEM_PARTITION_P_RW_U_RW	((k_mem_partition_attr_t) \
-	{ _K_MEM_PARTITION_P_RW_U_RW | \
-	  NORMAL_OUTER_INNER_WRITE_BACK_WRITE_READ_ALLOCATE_NON_SHAREABLE})
-#define K_MEM_PARTITION_P_RW_U_RO	((k_mem_partition_attr_t) \
-	{ _K_MEM_PARTITION_P_RW_U_RO | \
-	  NORMAL_OUTER_INNER_WRITE_BACK_WRITE_READ_ALLOCATE_NON_SHAREABLE})
-#define K_MEM_PARTITION_P_RW_U_NA	((k_mem_partition_attr_t) \
-	{ _K_MEM_PARTITION_P_RW_U_NA | \
-	  NORMAL_OUTER_INNER_WRITE_BACK_WRITE_READ_ALLOCATE_NON_SHAREABLE})
-#define K_MEM_PARTITION_P_RO_U_RO	((k_mem_partition_attr_t) \
-	{ _K_MEM_PARTITION_P_RO_U_RO | \
-	  NORMAL_OUTER_INNER_WRITE_BACK_WRITE_READ_ALLOCATE_NON_SHAREABLE})
-#define K_MEM_PARTITION_P_RO_U_NA	((k_mem_partition_attr_t) \
-	{ _K_MEM_PARTITION_P_RO_U_NA | \
-	  NORMAL_OUTER_INNER_WRITE_BACK_WRITE_READ_ALLOCATE_NON_SHAREABLE})
+#define K_MEM_PARTITION_P_NA_U_NA                                                                  \
+	((k_mem_partition_attr_t){                                                                 \
+		_K_MEM_PARTITION_P_NA_U_NA |                                                       \
+		NORMAL_OUTER_INNER_WRITE_BACK_WRITE_READ_ALLOCATE_NON_SHAREABLE})
+#define K_MEM_PARTITION_P_RW_U_RW                                                                  \
+	((k_mem_partition_attr_t){                                                                 \
+		_K_MEM_PARTITION_P_RW_U_RW |                                                       \
+		NORMAL_OUTER_INNER_WRITE_BACK_WRITE_READ_ALLOCATE_NON_SHAREABLE})
+#define K_MEM_PARTITION_P_RW_U_RO                                                                  \
+	((k_mem_partition_attr_t){                                                                 \
+		_K_MEM_PARTITION_P_RW_U_RO |                                                       \
+		NORMAL_OUTER_INNER_WRITE_BACK_WRITE_READ_ALLOCATE_NON_SHAREABLE})
+#define K_MEM_PARTITION_P_RW_U_NA                                                                  \
+	((k_mem_partition_attr_t){                                                                 \
+		_K_MEM_PARTITION_P_RW_U_NA |                                                       \
+		NORMAL_OUTER_INNER_WRITE_BACK_WRITE_READ_ALLOCATE_NON_SHAREABLE})
+#define K_MEM_PARTITION_P_RO_U_RO                                                                  \
+	((k_mem_partition_attr_t){                                                                 \
+		_K_MEM_PARTITION_P_RO_U_RO |                                                       \
+		NORMAL_OUTER_INNER_WRITE_BACK_WRITE_READ_ALLOCATE_NON_SHAREABLE})
+#define K_MEM_PARTITION_P_RO_U_NA                                                                  \
+	((k_mem_partition_attr_t){                                                                 \
+		_K_MEM_PARTITION_P_RO_U_NA |                                                       \
+		NORMAL_OUTER_INNER_WRITE_BACK_WRITE_READ_ALLOCATE_NON_SHAREABLE})
 
 /* Execution-allowed attributes (default-cacheability) */
-#define K_MEM_PARTITION_P_RWX_U_RWX	((k_mem_partition_attr_t) \
-	{ _K_MEM_PARTITION_P_RWX_U_RWX | \
-	  NORMAL_OUTER_INNER_WRITE_BACK_WRITE_READ_ALLOCATE_NON_SHAREABLE})
-#define K_MEM_PARTITION_P_RWX_U_RX	((k_mem_partition_attr_t) \
-	{ _K_MEM_PARTITION_P_RWX_U_RX | \
-	  NORMAL_OUTER_INNER_WRITE_BACK_WRITE_READ_ALLOCATE_NON_SHAREABLE})
-#define K_MEM_PARTITION_P_RX_U_RX	((k_mem_partition_attr_t) \
-	{ _K_MEM_PARTITION_P_RX_U_RX | \
-	  NORMAL_OUTER_INNER_WRITE_BACK_WRITE_READ_ALLOCATE_NON_SHAREABLE})
+#define K_MEM_PARTITION_P_RWX_U_RWX                                                                \
+	((k_mem_partition_attr_t){                                                                 \
+		_K_MEM_PARTITION_P_RWX_U_RWX |                                                     \
+		NORMAL_OUTER_INNER_WRITE_BACK_WRITE_READ_ALLOCATE_NON_SHAREABLE})
+#define K_MEM_PARTITION_P_RWX_U_RX                                                                 \
+	((k_mem_partition_attr_t){                                                                 \
+		_K_MEM_PARTITION_P_RWX_U_RX |                                                      \
+		NORMAL_OUTER_INNER_WRITE_BACK_WRITE_READ_ALLOCATE_NON_SHAREABLE})
+#define K_MEM_PARTITION_P_RX_U_RX                                                                  \
+	((k_mem_partition_attr_t){                                                                 \
+		_K_MEM_PARTITION_P_RX_U_RX |                                                       \
+		NORMAL_OUTER_INNER_WRITE_BACK_WRITE_READ_ALLOCATE_NON_SHAREABLE})
 
 /*
  * @brief Evaluate Write-ability
@@ -222,19 +214,19 @@ typedef struct {
  * @param attr The k_mem_partition_attr_t object holding the
  *             MPU attributes to be checked against write-ability.
  */
-#define K_MEM_PARTITION_IS_WRITABLE(attr) \
-	({ \
-		int __is_writable__; \
-		switch (attr.rasr_attr & MPU_RASR_AP_Msk) { \
-		case P_RW_U_RW_Msk: \
-		case P_RW_U_RO_Msk: \
-		case P_RW_U_NA_Msk: \
-			__is_writable__ = 1; \
-			break; \
-		default: \
-			__is_writable__ = 0; \
-		} \
-		__is_writable__; \
+#define K_MEM_PARTITION_IS_WRITABLE(attr)                                                          \
+	({                                                                                         \
+		int __is_writable__;                                                               \
+		switch (attr.rasr_attr & MPU_RASR_AP_Msk) {                                        \
+		case P_RW_U_RW_Msk:                                                                \
+		case P_RW_U_RO_Msk:                                                                \
+		case P_RW_U_NA_Msk:                                                                \
+			__is_writable__ = 1;                                                       \
+			break;                                                                     \
+		default:                                                                           \
+			__is_writable__ = 0;                                                       \
+		}                                                                                  \
+		__is_writable__;                                                                   \
 	})
 
 /*
@@ -246,46 +238,45 @@ typedef struct {
  *             MPU attributes to be checked against execution
  *             allowance.
  */
-#define K_MEM_PARTITION_IS_EXECUTABLE(attr) \
-	(!((attr.rasr_attr) & (NOT_EXEC)))
+#define K_MEM_PARTITION_IS_EXECUTABLE(attr) (!((attr.rasr_attr) & (NOT_EXEC)))
 
 /* Attributes for no-cache enabling (share-ability is selected by default) */
 
-#define K_MEM_PARTITION_P_NA_U_NA_NOCACHE ((k_mem_partition_attr_t) \
-	{(_K_MEM_PARTITION_P_NA_U_NA \
-	| NORMAL_OUTER_INNER_NON_CACHEABLE_SHAREABLE)})
-#define K_MEM_PARTITION_P_RW_U_RW_NOCACHE ((k_mem_partition_attr_t) \
-	{(_K_MEM_PARTITION_P_RW_U_RW \
-	| NORMAL_OUTER_INNER_NON_CACHEABLE_SHAREABLE)})
-#define K_MEM_PARTITION_P_RW_U_RO_NOCACHE ((k_mem_partition_attr_t) \
-	{(_K_MEM_PARTITION_P_RW_U_RO \
-	| NORMAL_OUTER_INNER_NON_CACHEABLE_SHAREABLE)})
-#define K_MEM_PARTITION_P_RW_U_NA_NOCACHE ((k_mem_partition_attr_t) \
-	{(_K_MEM_PARTITION_P_RW_U_NA \
-	| NORMAL_OUTER_INNER_NON_CACHEABLE_SHAREABLE)})
-#define K_MEM_PARTITION_P_RO_U_RO_NOCACHE ((k_mem_partition_attr_t) \
-	{(_K_MEM_PARTITION_P_RO_U_RO \
-	| NORMAL_OUTER_INNER_NON_CACHEABLE_SHAREABLE)})
-#define K_MEM_PARTITION_P_RO_U_NA_NOCACHE ((k_mem_partition_attr_t) \
-	{(_K_MEM_PARTITION_P_RO_U_NA \
-	| NORMAL_OUTER_INNER_NON_CACHEABLE_SHAREABLE)})
+#define K_MEM_PARTITION_P_NA_U_NA_NOCACHE                                                          \
+	((k_mem_partition_attr_t){                                                                 \
+		(_K_MEM_PARTITION_P_NA_U_NA | NORMAL_OUTER_INNER_NON_CACHEABLE_SHAREABLE)})
+#define K_MEM_PARTITION_P_RW_U_RW_NOCACHE                                                          \
+	((k_mem_partition_attr_t){                                                                 \
+		(_K_MEM_PARTITION_P_RW_U_RW | NORMAL_OUTER_INNER_NON_CACHEABLE_SHAREABLE)})
+#define K_MEM_PARTITION_P_RW_U_RO_NOCACHE                                                          \
+	((k_mem_partition_attr_t){                                                                 \
+		(_K_MEM_PARTITION_P_RW_U_RO | NORMAL_OUTER_INNER_NON_CACHEABLE_SHAREABLE)})
+#define K_MEM_PARTITION_P_RW_U_NA_NOCACHE                                                          \
+	((k_mem_partition_attr_t){                                                                 \
+		(_K_MEM_PARTITION_P_RW_U_NA | NORMAL_OUTER_INNER_NON_CACHEABLE_SHAREABLE)})
+#define K_MEM_PARTITION_P_RO_U_RO_NOCACHE                                                          \
+	((k_mem_partition_attr_t){                                                                 \
+		(_K_MEM_PARTITION_P_RO_U_RO | NORMAL_OUTER_INNER_NON_CACHEABLE_SHAREABLE)})
+#define K_MEM_PARTITION_P_RO_U_NA_NOCACHE                                                          \
+	((k_mem_partition_attr_t){                                                                 \
+		(_K_MEM_PARTITION_P_RO_U_NA | NORMAL_OUTER_INNER_NON_CACHEABLE_SHAREABLE)})
 
-#define K_MEM_PARTITION_P_RWX_U_RWX_NOCACHE ((k_mem_partition_attr_t) \
-	{(_K_MEM_PARTITION_P_RWX_U_RWX \
-	| NORMAL_OUTER_INNER_NON_CACHEABLE_SHAREABLE)})
-#define K_MEM_PARTITION_P_RWX_U_RX_NOCACHE  ((k_mem_partition_attr_t) \
-	{(_K_MEM_PARTITION_P_RWX_U_RX  \
-	| NORMAL_OUTER_INNER_NON_CACHEABLE_SHAREABLE)})
-#define K_MEM_PARTITION_P_RX_U_RX_NOCACHE   ((k_mem_partition_attr_t) \
-	{(_K_MEM_PARTITION_P_RX_U_RX   \
-	| NORMAL_OUTER_INNER_NON_CACHEABLE_SHAREABLE)})
+#define K_MEM_PARTITION_P_RWX_U_RWX_NOCACHE                                                        \
+	((k_mem_partition_attr_t){                                                                 \
+		(_K_MEM_PARTITION_P_RWX_U_RWX | NORMAL_OUTER_INNER_NON_CACHEABLE_SHAREABLE)})
+#define K_MEM_PARTITION_P_RWX_U_RX_NOCACHE                                                         \
+	((k_mem_partition_attr_t){                                                                 \
+		(_K_MEM_PARTITION_P_RWX_U_RX | NORMAL_OUTER_INNER_NON_CACHEABLE_SHAREABLE)})
+#define K_MEM_PARTITION_P_RX_U_RX_NOCACHE                                                          \
+	((k_mem_partition_attr_t){                                                                 \
+		(_K_MEM_PARTITION_P_RX_U_RX | NORMAL_OUTER_INNER_NON_CACHEABLE_SHAREABLE)})
 
 #endif /* _ASMLANGUAGE */
 
-#define _ARCH_MEM_PARTITION_ALIGN_CHECK(start, size) \
-	BUILD_ASSERT(!(((size) & ((size) - 1))) && \
-		(size) >= CONFIG_ARM_MPU_REGION_MIN_ALIGN_AND_SIZE && \
-		!((uint32_t)(start) & ((size) - 1)), \
-		"the size of the partition must be power of 2" \
-		" and greater than or equal to the minimum MPU region size." \
-		"start address of the partition must align with size.")
+#define _ARCH_MEM_PARTITION_ALIGN_CHECK(start, size)                                               \
+	BUILD_ASSERT(!(((size) & ((size) - 1))) &&                                                 \
+			     (size) >= CONFIG_ARM_MPU_REGION_MIN_ALIGN_AND_SIZE &&                 \
+			     !((uint32_t)(start) & ((size) - 1)),                                  \
+		     "The size of the partition must be power of 2 and greater than or equal to "  \
+		     "the minimum MPU region size.\n"                                              \
+		     "The start address of the partition must align with size.")

--- a/include/zephyr/arch/arm/mpu/arm_mpu_v8.h
+++ b/include/zephyr/arch/arm/mpu/arm_mpu_v8.h
@@ -12,25 +12,25 @@
  * cache-ability attribution.
  */
 #if defined(CONFIG_AARCH32_ARMV8_R)
-#define MPU_IR_REGION_Msk       (0xFFU)
-#define MPU_IR_REGION_Pos       8U
+#define MPU_IR_REGION_Msk (0xFFU)
+#define MPU_IR_REGION_Pos 8U
 /* MPU RBAR Register attribute msk Definitions */
-#define MPU_RBAR_BASE_Pos       6U
-#define MPU_RBAR_BASE_Msk       (0x3FFFFFFFFFFFFFFUL << MPU_RBAR_BASE_Pos)
-#define MPU_RBAR_SH_Pos         3U
-#define MPU_RBAR_SH_Msk         (0x3UL << MPU_RBAR_SH_Pos)
-#define MPU_RBAR_AP_Pos         1U
-#define MPU_RBAR_AP_Msk         (0x3UL << MPU_RBAR_AP_Pos)
+#define MPU_RBAR_BASE_Pos 6U
+#define MPU_RBAR_BASE_Msk (0x3FFFFFFFFFFFFFFUL << MPU_RBAR_BASE_Pos)
+#define MPU_RBAR_SH_Pos   3U
+#define MPU_RBAR_SH_Msk   (0x3UL << MPU_RBAR_SH_Pos)
+#define MPU_RBAR_AP_Pos   1U
+#define MPU_RBAR_AP_Msk   (0x3UL << MPU_RBAR_AP_Pos)
 /* RBAR XN */
-#define MPU_RBAR_XN_Pos         0U
-#define MPU_RBAR_XN_Msk         (0x1UL << MPU_RBAR_XN_Pos)
+#define MPU_RBAR_XN_Pos   0U
+#define MPU_RBAR_XN_Msk   (0x1UL << MPU_RBAR_XN_Pos)
 
 /* MPU PLBAR Register Definitions */
-#define MPU_RLAR_LIMIT_Pos      6U
-#define MPU_RLAR_LIMIT_Msk      (0x3FFFFFFFFFFFFFFUL << MPU_RLAR_LIMIT_Pos)
-#define MPU_RLAR_AttrIndx_Pos   1U
-#define MPU_RLAR_AttrIndx_Msk   (0x7UL << MPU_RLAR_AttrIndx_Pos)
-#define MPU_RLAR_EN_Msk         (0x1UL)
+#define MPU_RLAR_LIMIT_Pos    6U
+#define MPU_RLAR_LIMIT_Msk    (0x3FFFFFFFFFFFFFFUL << MPU_RLAR_LIMIT_Pos)
+#define MPU_RLAR_AttrIndx_Pos 1U
+#define MPU_RLAR_AttrIndx_Msk (0x7UL << MPU_RLAR_AttrIndx_Pos)
+#define MPU_RLAR_EN_Msk       (0x1UL)
 #else
 #include <cmsis_core.h>
 #endif
@@ -68,18 +68,14 @@
 
 /* Attribute flags for share-ability */
 #define NON_SHAREABLE       0x0
-#define NON_SHAREABLE_Msk \
-	((NON_SHAREABLE << MPU_RBAR_SH_Pos) & MPU_RBAR_SH_Msk)
-#define OUTER_SHAREABLE 0x2
-#define OUTER_SHAREABLE_Msk \
-	((OUTER_SHAREABLE << MPU_RBAR_SH_Pos) & MPU_RBAR_SH_Msk)
-#define INNER_SHAREABLE 0x3
-#define INNER_SHAREABLE_Msk \
-	((INNER_SHAREABLE << MPU_RBAR_SH_Pos) & MPU_RBAR_SH_Msk)
+#define NON_SHAREABLE_Msk   ((NON_SHAREABLE << MPU_RBAR_SH_Pos) & MPU_RBAR_SH_Msk)
+#define OUTER_SHAREABLE     0x2
+#define OUTER_SHAREABLE_Msk ((OUTER_SHAREABLE << MPU_RBAR_SH_Pos) & MPU_RBAR_SH_Msk)
+#define INNER_SHAREABLE     0x3
+#define INNER_SHAREABLE_Msk ((INNER_SHAREABLE << MPU_RBAR_SH_Pos) & MPU_RBAR_SH_Msk)
 
 /* Helper define to calculate the region limit address. */
-#define REGION_LIMIT_ADDR(base, size) \
-	(((base & MPU_RBAR_BASE_Msk) + size - 1) & MPU_RLAR_LIMIT_Msk)
+#define REGION_LIMIT_ADDR(base, size) (((base & MPU_RBAR_BASE_Msk) + size - 1) & MPU_RLAR_LIMIT_Msk)
 
 /* Attribute flags for cache-ability */
 
@@ -101,10 +97,10 @@
  *   nE: The response should come from the end slave, not buffering in
  *   the interconnect.
  */
-#define DEVICE_nGnRnE	0x0U
-#define DEVICE_nGnRE	0x4U
-#define DEVICE_nGRE	0x8U
-#define DEVICE_GRE	0xCU
+#define DEVICE_nGnRnE 0x0U
+#define DEVICE_nGnRE  0x4U
+#define DEVICE_nGRE   0x8U
+#define DEVICE_GRE    0xCU
 
 /* Read/Write Allocation Configurations for Cacheable Memory */
 #define R_NON_W_NON     0x0 /* Do not allocate Read/Write */
@@ -113,36 +109,30 @@
 #define R_ALLOC_W_ALLOC 0x3 /* Allocate Read/Write */
 
 /* Memory Attributes for Normal Memory */
-#define NORMAL_O_WT_NT  0x80 /* Normal, Outer Write-through non-transient */
-#define NORMAL_O_WB_NT  0xC0 /* Normal, Outer Write-back non-transient */
-#define NORMAL_O_NON_C  0x40 /* Normal, Outer Non-Cacheable  */
+#define NORMAL_O_WT_NT 0x80 /* Normal, Outer Write-through non-transient */
+#define NORMAL_O_WB_NT 0xC0 /* Normal, Outer Write-back non-transient */
+#define NORMAL_O_NON_C 0x40 /* Normal, Outer Non-Cacheable  */
 
-#define NORMAL_I_WT_NT  0x08 /* Normal, Inner Write-through non-transient */
-#define NORMAL_I_WB_NT  0x0C /* Normal, Inner Write-back non-transient */
-#define NORMAL_I_NON_C  0x04 /* Normal, Inner Non-Cacheable  */
+#define NORMAL_I_WT_NT 0x08 /* Normal, Inner Write-through non-transient */
+#define NORMAL_I_WB_NT 0x0C /* Normal, Inner Write-back non-transient */
+#define NORMAL_I_NON_C 0x04 /* Normal, Inner Non-Cacheable  */
 
-#define NORMAL_OUTER_INNER_WRITE_THROUGH_READ_ALLOCATE_NON_TRANS \
-	((NORMAL_O_WT_NT | (R_ALLOC_W_NON << 4)) \
-	 | \
-	 (NORMAL_I_WT_NT | R_ALLOC_W_NON)) \
+#define NORMAL_OUTER_INNER_WRITE_THROUGH_READ_ALLOCATE_NON_TRANS                                   \
+	((NORMAL_O_WT_NT | (R_ALLOC_W_NON << 4)) | (NORMAL_I_WT_NT | R_ALLOC_W_NON))
 
-#define NORMAL_OUTER_INNER_WRITE_BACK_WRITE_READ_ALLOCATE_NON_TRANS \
-	((NORMAL_O_WB_NT | (R_ALLOC_W_ALLOC << 4)) \
-	 | \
-	 (NORMAL_I_WB_NT | R_ALLOC_W_ALLOC))
+#define NORMAL_OUTER_INNER_WRITE_BACK_WRITE_READ_ALLOCATE_NON_TRANS                                \
+	((NORMAL_O_WB_NT | (R_ALLOC_W_ALLOC << 4)) | (NORMAL_I_WB_NT | R_ALLOC_W_ALLOC))
 
-#define NORMAL_OUTER_INNER_NON_CACHEABLE \
-	((NORMAL_O_NON_C | (R_NON_W_NON << 4)) \
-	 | \
-	 (NORMAL_I_NON_C | R_NON_W_NON))
+#define NORMAL_OUTER_INNER_NON_CACHEABLE                                                           \
+	((NORMAL_O_NON_C | (R_NON_W_NON << 4)) | (NORMAL_I_NON_C | R_NON_W_NON))
 
 /* Common cache-ability configuration for Flash, SRAM regions */
-#define MPU_CACHE_ATTRIBUTES_FLASH \
-	NORMAL_OUTER_INNER_WRITE_THROUGH_READ_ALLOCATE_NON_TRANS
-#define MPU_CACHE_ATTRIBUTES_SRAM \
+#define MPU_CACHE_ATTRIBUTES_FLASH        NORMAL_OUTER_INNER_WRITE_THROUGH_READ_ALLOCATE_NON_TRANS
+/* clang-format off */
+#define MPU_CACHE_ATTRIBUTES_SRAM                                                                  \
 	NORMAL_OUTER_INNER_WRITE_BACK_WRITE_READ_ALLOCATE_NON_TRANS
-#define MPU_CACHE_ATTRIBUTES_SRAM_NOCACHE \
-	NORMAL_OUTER_INNER_NON_CACHEABLE
+/* clang-format on */
+#define MPU_CACHE_ATTRIBUTES_SRAM_NOCACHE NORMAL_OUTER_INNER_NON_CACHEABLE
 
 /* Global MAIR configurations */
 #define MPU_MAIR_ATTR_FLASH         MPU_CACHE_ATTRIBUTES_FLASH
@@ -158,10 +148,10 @@
  * SRAM no cache-able regions(s): Attribute-2
  * DEVICE no cache-able regions(s): Attribute-3
  */
-#define MPU_MAIR_ATTRS							     \
-	((MPU_MAIR_ATTR_FLASH << (MPU_MAIR_INDEX_FLASH * 8)) |		     \
-	 (MPU_MAIR_ATTR_SRAM << (MPU_MAIR_INDEX_SRAM * 8)) |		     \
-	 (MPU_MAIR_ATTR_SRAM_NOCACHE << (MPU_MAIR_INDEX_SRAM_NOCACHE * 8)) | \
+#define MPU_MAIR_ATTRS                                                                             \
+	((MPU_MAIR_ATTR_FLASH << (MPU_MAIR_INDEX_FLASH * 8)) |                                     \
+	 (MPU_MAIR_ATTR_SRAM << (MPU_MAIR_INDEX_SRAM * 8)) |                                       \
+	 (MPU_MAIR_ATTR_SRAM_NOCACHE << (MPU_MAIR_INDEX_SRAM_NOCACHE * 8)) |                       \
 	 (MPU_MAIR_ATTR_DEVICE << (MPU_MAIR_INDEX_DEVICE * 8)))
 
 /* Some helper defines for common regions.
@@ -175,132 +165,118 @@
  */
 #if defined(CONFIG_AARCH32_ARMV8_R)
 
-#define ARM_MPU_REGION_INIT(p_name, p_base, p_size, p_attr)	\
-	{ .name = p_name,					\
-	  .base = p_base,					\
-	  .attr = p_attr(p_base + p_size),			\
+#define ARM_MPU_REGION_INIT(p_name, p_base, p_size, p_attr)                                        \
+	{                                                                                          \
+		.name = p_name,                                                                    \
+		.base = p_base,                                                                    \
+		.attr = p_attr(p_base + p_size),                                                   \
 	}
 
-#define REGION_RAM_ATTR(limit)						    \
-	{								    \
-		.rbar = NOT_EXEC |					    \
-			P_RW_U_NA_Msk | NON_SHAREABLE_Msk, /* AP, XN, SH */ \
-		/* Cache-ability */					    \
-		.mair_idx = MPU_MAIR_INDEX_SRAM,			    \
-		.r_limit = limit - 1,  /* Region Limit */		    \
+#define REGION_RAM_ATTR(limit)                                                                     \
+	{                                                                                          \
+		.rbar = NOT_EXEC | P_RW_U_NA_Msk | NON_SHAREABLE_Msk, /* AP, XN, SH */             \
+		.mair_idx = MPU_MAIR_INDEX_SRAM,                      /* Cache-ability */          \
+		.r_limit = limit - 1,                                 /* Region Limit */           \
 	}
 
-#define REGION_RAM_TEXT_ATTR(limit)					    \
-	{								    \
-		.rbar = P_RO_U_RO_Msk | NON_SHAREABLE_Msk, /* AP, XN, SH */ \
-		/* Cache-ability */					    \
-		.mair_idx = MPU_MAIR_INDEX_SRAM,			    \
-		.r_limit = limit - 1,  /* Region Limit */		    \
+#define REGION_RAM_TEXT_ATTR(limit)                                                                \
+	{                                                                                          \
+		.rbar = P_RO_U_RO_Msk | NON_SHAREABLE_Msk, /* AP, XN, SH */                        \
+		.mair_idx = MPU_MAIR_INDEX_SRAM,           /* Cache-ability */                     \
+		.r_limit = limit - 1,                      /* Region Limit */                      \
 	}
 
-#define REGION_RAM_RO_ATTR(limit)					    \
-	{								    \
-		.rbar = NOT_EXEC |					    \
-			P_RO_U_RO_Msk | NON_SHAREABLE_Msk, /* AP, XN, SH */ \
-		/* Cache-ability */					    \
-		.mair_idx = MPU_MAIR_INDEX_SRAM,			    \
-		.r_limit = limit - 1,  /* Region Limit */		    \
+#define REGION_RAM_RO_ATTR(limit)                                                                  \
+	{                                                                                          \
+		.rbar = NOT_EXEC | P_RO_U_RO_Msk | NON_SHAREABLE_Msk, /* AP, XN, SH */             \
+		.mair_idx = MPU_MAIR_INDEX_SRAM,                      /* Cache-ability */          \
+		.r_limit = limit - 1,                                 /* Region Limit */           \
 	}
-#define REGION_RAM_NOCACHE_ATTR(limit)					    \
-	{								    \
-		.rbar = NOT_EXEC |					    \
-			P_RW_U_NA_Msk | NON_SHAREABLE_Msk, /* AP, XN, SH */ \
-		/* Cache-ability */					    \
-		.mair_idx = MPU_MAIR_INDEX_SRAM_NOCACHE,		    \
-		.r_limit = limit - 1,  /* Region Limit */		    \
+#define REGION_RAM_NOCACHE_ATTR(limit)                                                             \
+	{                                                                                          \
+		.rbar = NOT_EXEC | P_RW_U_NA_Msk | NON_SHAREABLE_Msk, /* AP, XN, SH */             \
+		.mair_idx = MPU_MAIR_INDEX_SRAM_NOCACHE,              /* Cache-ability */          \
+		.r_limit = limit - 1,                                 /* Region Limit */           \
 	}
 #if defined(CONFIG_MPU_ALLOW_FLASH_WRITE)
 /* Note that the access permissions allow for un-privileged writes, contrary
  * to ARMv7-M where un-privileged code has Read-Only permissions.
  */
-#define REGION_FLASH_ATTR(limit)					    \
-	{								    \
-		.rbar = P_RW_U_RW_Msk | NON_SHAREABLE_Msk, /* AP, XN, SH */ \
-		/* Cache-ability */					    \
-		.mair_idx = MPU_MAIR_INDEX_FLASH,			    \
-		.r_limit = limit - 1,  /* Region Limit */		    \
+#define REGION_FLASH_ATTR(limit)                                                                   \
+	{                                                                                          \
+		.rbar = P_RW_U_RW_Msk | NON_SHAREABLE_Msk, /* AP, XN, SH */                        \
+		.mair_idx = MPU_MAIR_INDEX_FLASH,          /* Cache-ability */                     \
+		.r_limit = limit - 1,                      /* Region Limit */                      \
 	}
 #else /* CONFIG_MPU_ALLOW_FLASH_WRITE */
-#define REGION_FLASH_ATTR(limit)				     \
-	{							     \
-		.rbar = RO_Msk | NON_SHAREABLE_Msk, /* AP, XN, SH */ \
-		/* Cache-ability */				     \
-		.mair_idx = MPU_MAIR_INDEX_FLASH,		     \
-		.r_limit = limit - 1,  /* Region Limit */	     \
+#define REGION_FLASH_ATTR(limit)                                                                   \
+	{                                                                                          \
+		.rbar = RO_Msk | NON_SHAREABLE_Msk, /* AP, XN, SH */                               \
+		.mair_idx = MPU_MAIR_INDEX_FLASH,   /* Cache-ability */                            \
+		.r_limit = limit - 1,               /* Region Limit */                             \
 	}
 #endif /* CONFIG_MPU_ALLOW_FLASH_WRITE */
 
-#define REGION_DEVICE_ATTR(limit)				      \
-	{							      \
-		/* AP, XN, SH */				      \
-		.rbar = NOT_EXEC | P_RW_U_NA_Msk | NON_SHAREABLE_Msk, \
-		/* Cache-ability */				      \
-		.mair_idx = MPU_MAIR_INDEX_DEVICE,		      \
-		/* Region Limit */				      \
-		.r_limit = limit - 1,				      \
+#define REGION_DEVICE_ATTR(limit)                                                                  \
+	{                                                                                          \
+		.rbar = NOT_EXEC | P_RW_U_NA_Msk | NON_SHAREABLE_Msk, /* AP, XN, SH */             \
+		.mair_idx = MPU_MAIR_INDEX_DEVICE,                    /* Cache-ability */          \
+		.r_limit = limit - 1,                                 /* Region Limit */           \
 	}
 #else
 
-#define ARM_MPU_REGION_INIT(p_name, p_base, p_size, p_attr)	\
-	{ .name = p_name,					\
-	  .base = p_base,					\
-	  .attr = p_attr(p_base, p_size),			\
+#define ARM_MPU_REGION_INIT(p_name, p_base, p_size, p_attr)                                        \
+	{                                                                                          \
+		.name = p_name,                                                                    \
+		.base = p_base,                                                                    \
+		.attr = p_attr(p_base, p_size),                                                    \
 	}
 
 /* On Cortex-M, we can only set the XN bit when CONFIG_XIP=y. When
  * CONFIG_XIP=n, the entire image will be linked to SRAM, so we need to keep
  * the SRAM region XN bit clear or the application code will not be executable.
  */
-#define REGION_RAM_ATTR(base, size) \
-	{\
-		.rbar = IF_ENABLED(CONFIG_XIP, (NOT_EXEC |)) \
-			P_RW_U_NA_Msk | NON_SHAREABLE_Msk, /* AP, XN, SH */ \
-		/* Cache-ability */ \
-		.mair_idx = MPU_MAIR_INDEX_SRAM, \
-		.r_limit = REGION_LIMIT_ADDR(base, size),  /* Region Limit */ \
+/* clang-format off */
+#define REGION_RAM_ATTR(base, size)                                                                \
+	{                                                                                          \
+		.rbar = IF_ENABLED(CONFIG_XIP, (NOT_EXEC |)) P_RW_U_NA_Msk |                       \
+			NON_SHAREABLE_Msk,                /* AP, XN, SH */                         \
+		.mair_idx = MPU_MAIR_INDEX_SRAM,          /* Cache-ability */                      \
+		.r_limit = REGION_LIMIT_ADDR(base, size), /* Region Limit */                       \
 	}
+/* clang-format on */
 
-#define REGION_RAM_NOCACHE_ATTR(base, size) \
-	{\
-		.rbar = NOT_EXEC | \
-			P_RW_U_NA_Msk | NON_SHAREABLE_Msk, /* AP, XN, SH */ \
-		/* Cache-ability */ \
-		.mair_idx = MPU_MAIR_INDEX_SRAM_NOCACHE, \
-		.r_limit = REGION_LIMIT_ADDR(base, size),  /* Region Limit */ \
+#define REGION_RAM_NOCACHE_ATTR(base, size)                                                        \
+	{                                                                                          \
+		.rbar = NOT_EXEC | P_RW_U_NA_Msk | NON_SHAREABLE_Msk, /* AP, XN, SH */             \
+		.mair_idx = MPU_MAIR_INDEX_SRAM_NOCACHE,              /* Cache-ability */          \
+		.r_limit = REGION_LIMIT_ADDR(base, size),             /* Region Limit */           \
 	}
 
 #if defined(CONFIG_MPU_ALLOW_FLASH_WRITE)
 /* Note that the access permissions allow for un-privileged writes, contrary
  * to ARMv7-M where un-privileged code has Read-Only permissions.
  */
-#define REGION_FLASH_ATTR(base, size) \
-	{\
-		.rbar = P_RW_U_RW_Msk | NON_SHAREABLE_Msk, /* AP, XN, SH */ \
-		/* Cache-ability */ \
-		.mair_idx = MPU_MAIR_INDEX_FLASH, \
-		.r_limit = REGION_LIMIT_ADDR(base, size),  /* Region Limit */ \
+#define REGION_FLASH_ATTR(base, size)                                                              \
+	{                                                                                          \
+		.rbar = P_RW_U_RW_Msk | NON_SHAREABLE_Msk, /* AP, XN, SH */                        \
+		.mair_idx = MPU_MAIR_INDEX_FLASH,          /* Cache-ability */                     \
+		.r_limit = REGION_LIMIT_ADDR(base, size),  /* Region Limit */                      \
 	}
 #else /* CONFIG_MPU_ALLOW_FLASH_WRITE */
-#define REGION_FLASH_ATTR(base, size) \
-	{\
-		.rbar = RO_Msk | NON_SHAREABLE_Msk, /* AP, XN, SH */ \
-		/* Cache-ability */ \
-		.mair_idx = MPU_MAIR_INDEX_FLASH, \
-		.r_limit = REGION_LIMIT_ADDR(base, size),  /* Region Limit */ \
+#define REGION_FLASH_ATTR(base, size)                                                              \
+	{                                                                                          \
+		.rbar = RO_Msk | NON_SHAREABLE_Msk,       /* AP, XN, SH */                         \
+		.mair_idx = MPU_MAIR_INDEX_FLASH,         /* Cache-ability */                      \
+		.r_limit = REGION_LIMIT_ADDR(base, size), /* Region Limit */                       \
 	}
 #endif /* CONFIG_MPU_ALLOW_FLASH_WRITE */
 
 #define REGION_DEVICE_ATTR(base, size)                                                             \
 	{                                                                                          \
-		/* AP, XN, SH */                                                                   \
-		.rbar = NOT_EXEC | P_RW_U_NA_Msk | NON_SHAREABLE_Msk, /* Cache-ability */          \
-		.mair_idx = MPU_MAIR_INDEX_DEVICE,                                                 \
-		.r_limit = REGION_LIMIT_ADDR(base, size), /* Region Limit */                       \
+		.rbar = NOT_EXEC | P_RW_U_NA_Msk | NON_SHAREABLE_Msk, /* AP, XN, SH */             \
+		.mair_idx = MPU_MAIR_INDEX_DEVICE,                    /* Cache-ability */          \
+		.r_limit = REGION_LIMIT_ADDR(base, size),             /* Region Limit */           \
 	}
 #endif
 
@@ -333,20 +309,18 @@ typedef struct {
  */
 
 /* Read-Write access permission attributes */
-#define K_MEM_PARTITION_P_RW_U_RW ((k_mem_partition_attr_t) \
-	{(P_RW_U_RW_Msk | NOT_EXEC), MPU_MAIR_INDEX_SRAM})
-#define K_MEM_PARTITION_P_RW_U_NA ((k_mem_partition_attr_t) \
-	{(P_RW_U_NA_Msk | NOT_EXEC), MPU_MAIR_INDEX_SRAM})
-#define K_MEM_PARTITION_P_RO_U_RO ((k_mem_partition_attr_t) \
-	{(P_RO_U_RO_Msk | NOT_EXEC), MPU_MAIR_INDEX_SRAM})
-#define K_MEM_PARTITION_P_RO_U_NA ((k_mem_partition_attr_t) \
-	{(P_RO_U_NA_Msk | NOT_EXEC), MPU_MAIR_INDEX_SRAM})
+#define K_MEM_PARTITION_P_RW_U_RW                                                                  \
+	((k_mem_partition_attr_t){(P_RW_U_RW_Msk | NOT_EXEC), MPU_MAIR_INDEX_SRAM})
+#define K_MEM_PARTITION_P_RW_U_NA                                                                  \
+	((k_mem_partition_attr_t){(P_RW_U_NA_Msk | NOT_EXEC), MPU_MAIR_INDEX_SRAM})
+#define K_MEM_PARTITION_P_RO_U_RO                                                                  \
+	((k_mem_partition_attr_t){(P_RO_U_RO_Msk | NOT_EXEC), MPU_MAIR_INDEX_SRAM})
+#define K_MEM_PARTITION_P_RO_U_NA                                                                  \
+	((k_mem_partition_attr_t){(P_RO_U_NA_Msk | NOT_EXEC), MPU_MAIR_INDEX_SRAM})
 
 /* Execution-allowed attributes */
-#define K_MEM_PARTITION_P_RWX_U_RWX ((k_mem_partition_attr_t) \
-	{(P_RW_U_RW_Msk), MPU_MAIR_INDEX_SRAM})
-#define K_MEM_PARTITION_P_RX_U_RX ((k_mem_partition_attr_t) \
-	{(P_RO_U_RO_Msk), MPU_MAIR_INDEX_SRAM})
+#define K_MEM_PARTITION_P_RWX_U_RWX ((k_mem_partition_attr_t){(P_RW_U_RW_Msk), MPU_MAIR_INDEX_SRAM})
+#define K_MEM_PARTITION_P_RX_U_RX   ((k_mem_partition_attr_t){(P_RO_U_RO_Msk), MPU_MAIR_INDEX_SRAM})
 
 /*
  * @brief Evaluate Write-ability
@@ -356,18 +330,18 @@ typedef struct {
  * @param attr The k_mem_partition_attr_t object holding the
  *             MPU attributes to be checked against write-ability.
  */
-#define K_MEM_PARTITION_IS_WRITABLE(attr) \
-	({ \
-		int __is_writable__; \
-		switch (attr.rbar & MPU_RBAR_AP_Msk) { \
-		case P_RW_U_RW_Msk: \
-		case P_RW_U_NA_Msk: \
-			__is_writable__ = 1; \
-			break; \
-		default: \
-			__is_writable__ = 0; \
-		} \
-		__is_writable__; \
+#define K_MEM_PARTITION_IS_WRITABLE(attr)                                                          \
+	({                                                                                         \
+		int __is_writable__;                                                               \
+		switch (attr.rbar & MPU_RBAR_AP_Msk) {                                             \
+		case P_RW_U_RW_Msk:                                                                \
+		case P_RW_U_NA_Msk:                                                                \
+			__is_writable__ = 1;                                                       \
+			break;                                                                     \
+		default:                                                                           \
+			__is_writable__ = 0;                                                       \
+		}                                                                                  \
+		__is_writable__;                                                                   \
 	})
 
 /*
@@ -379,36 +353,37 @@ typedef struct {
  *             MPU attributes to be checked against execution
  *             allowance.
  */
-#define K_MEM_PARTITION_IS_EXECUTABLE(attr) \
-	(!((attr.rbar) & (NOT_EXEC)))
+#define K_MEM_PARTITION_IS_EXECUTABLE(attr) (!((attr.rbar) & (NOT_EXEC)))
 
 /* Attributes for no-cache enabling (share-ability is selected by default) */
 
 /* Read-Write access permission attributes */
-#define K_MEM_PARTITION_P_RW_U_RW_NOCACHE ((k_mem_partition_attr_t) \
-	{(P_RW_U_RW_Msk | NOT_EXEC | OUTER_SHAREABLE_Msk), \
-		MPU_MAIR_INDEX_SRAM_NOCACHE})
-#define K_MEM_PARTITION_P_RW_U_NA_NOCACHE ((k_mem_partition_attr_t) \
-	{(P_RW_U_NA_Msk | NOT_EXEC | OUTER_SHAREABLE_Msk), \
-		MPU_MAIR_INDEX_SRAM_NOCACHE})
-#define K_MEM_PARTITION_P_RO_U_RO_NOCACHE ((k_mem_partition_attr_t) \
-	{(P_RO_U_RO_Msk | NOT_EXEC | OUTER_SHAREABLE_Msk), \
-		MPU_MAIR_INDEX_SRAM_NOCACHE})
-#define K_MEM_PARTITION_P_RO_U_NA_NOCACHE ((k_mem_partition_attr_t) \
-	{(P_RO_U_NA_Msk | NOT_EXEC | OUTER_SHAREABLE_Msk), \
-		MPU_MAIR_INDEX_SRAM_NOCACHE})
+#define K_MEM_PARTITION_P_RW_U_RW_NOCACHE                                                          \
+	((k_mem_partition_attr_t){(P_RW_U_RW_Msk | NOT_EXEC | OUTER_SHAREABLE_Msk),                \
+				  MPU_MAIR_INDEX_SRAM_NOCACHE})
+#define K_MEM_PARTITION_P_RW_U_NA_NOCACHE                                                          \
+	((k_mem_partition_attr_t){(P_RW_U_NA_Msk | NOT_EXEC | OUTER_SHAREABLE_Msk),                \
+				  MPU_MAIR_INDEX_SRAM_NOCACHE})
+#define K_MEM_PARTITION_P_RO_U_RO_NOCACHE                                                          \
+	((k_mem_partition_attr_t){(P_RO_U_RO_Msk | NOT_EXEC | OUTER_SHAREABLE_Msk),                \
+				  MPU_MAIR_INDEX_SRAM_NOCACHE})
+#define K_MEM_PARTITION_P_RO_U_NA_NOCACHE                                                          \
+	((k_mem_partition_attr_t){(P_RO_U_NA_Msk | NOT_EXEC | OUTER_SHAREABLE_Msk),                \
+				  MPU_MAIR_INDEX_SRAM_NOCACHE})
 
 /* Execution-allowed attributes */
-#define K_MEM_PARTITION_P_RWX_U_RWX_NOCACHE ((k_mem_partition_attr_t) \
-	{(P_RW_U_RW_Msk | OUTER_SHAREABLE_Msk), MPU_MAIR_INDEX_SRAM_NOCACHE})
-#define K_MEM_PARTITION_P_RX_U_RX_NOCACHE ((k_mem_partition_attr_t) \
-	{(P_RO_U_RO_Msk | OUTER_SHAREABLE_Msk), MPU_MAIR_INDEX_SRAM_NOCACHE})
+#define K_MEM_PARTITION_P_RWX_U_RWX_NOCACHE                                                        \
+	((k_mem_partition_attr_t){(P_RW_U_RW_Msk | OUTER_SHAREABLE_Msk),                           \
+				  MPU_MAIR_INDEX_SRAM_NOCACHE})
+#define K_MEM_PARTITION_P_RX_U_RX_NOCACHE                                                          \
+	((k_mem_partition_attr_t){(P_RO_U_RO_Msk | OUTER_SHAREABLE_Msk),                           \
+				  MPU_MAIR_INDEX_SRAM_NOCACHE})
 
 #endif /* _ASMLANGUAGE */
 
-#define _ARCH_MEM_PARTITION_ALIGN_CHECK(start, size) \
-	BUILD_ASSERT((size > 0) && ((uint32_t)start % \
-			CONFIG_ARM_MPU_REGION_MIN_ALIGN_AND_SIZE == 0U) && \
-		((size) % CONFIG_ARM_MPU_REGION_MIN_ALIGN_AND_SIZE == 0), \
-		" the start and size of the partition must align " \
-		"with the minimum MPU region size.")
+#define _ARCH_MEM_PARTITION_ALIGN_CHECK(start, size)                                               \
+	BUILD_ASSERT((size > 0) &&                                                                 \
+			     ((uint32_t)start % CONFIG_ARM_MPU_REGION_MIN_ALIGN_AND_SIZE == 0U) && \
+			     ((size) % CONFIG_ARM_MPU_REGION_MIN_ALIGN_AND_SIZE == 0),             \
+		     "The start and size of the partition must align with the minimum MPU "        \
+		     "region size.")

--- a/include/zephyr/arch/arm/mpu/nxp_mpu.h
+++ b/include/zephyr/arch/arm/mpu/nxp_mpu.h
@@ -11,119 +11,102 @@
 #define NXP_MPU_REGION_NUMBER 12
 
 /* Bus Master User Mode Access */
-#define UM_READ		4
-#define UM_WRITE	2
-#define UM_EXEC		1
+#define UM_READ  4
+#define UM_WRITE 2
+#define UM_EXEC  1
 
-#define BM0_UM_SHIFT	0
-#define BM1_UM_SHIFT	6
-#define BM2_UM_SHIFT	12
-#define BM3_UM_SHIFT	18
+#define BM0_UM_SHIFT 0
+#define BM1_UM_SHIFT 6
+#define BM2_UM_SHIFT 12
+#define BM3_UM_SHIFT 18
 
 /* Bus Master Supervisor Mode Access */
-#define SM_RWX_ALLOW	0
-#define SM_RX_ALLOW	1
-#define SM_RW_ALLOW	2
-#define SM_SAME_AS_UM	3
+#define SM_RWX_ALLOW  0
+#define SM_RX_ALLOW   1
+#define SM_RW_ALLOW   2
+#define SM_SAME_AS_UM 3
 
-#define BM0_SM_SHIFT	3
-#define BM1_SM_SHIFT	9
-#define BM2_SM_SHIFT	15
-#define BM3_SM_SHIFT	21
+#define BM0_SM_SHIFT 3
+#define BM1_SM_SHIFT 9
+#define BM2_SM_SHIFT 15
+#define BM3_SM_SHIFT 21
 
-#define BM4_WE_SHIFT	24
-#define BM4_RE_SHIFT	25
+#define BM4_WE_SHIFT 24
+#define BM4_RE_SHIFT 25
 
 #if CONFIG_USB_KINETIS || CONFIG_UDC_KINETIS
-#define BM4_PERMISSIONS	((1 << BM4_RE_SHIFT) | (1 << BM4_WE_SHIFT))
+#define BM4_PERMISSIONS ((1 << BM4_RE_SHIFT) | (1 << BM4_WE_SHIFT))
 #else
-#define BM4_PERMISSIONS	0
+#define BM4_PERMISSIONS 0
 #endif
 
 /* Read Attribute */
-#define MPU_REGION_READ  ((UM_READ << BM0_UM_SHIFT) | \
-			  (UM_READ << BM1_UM_SHIFT) | \
-			  (UM_READ << BM2_UM_SHIFT) | \
-			  (UM_READ << BM3_UM_SHIFT))
+#define MPU_REGION_READ                                                                            \
+	((UM_READ << BM0_UM_SHIFT) | (UM_READ << BM1_UM_SHIFT) | (UM_READ << BM2_UM_SHIFT) |       \
+	 (UM_READ << BM3_UM_SHIFT))
 
 /* Write Attribute */
-#define MPU_REGION_WRITE ((UM_WRITE << BM0_UM_SHIFT) | \
-			  (UM_WRITE << BM1_UM_SHIFT) | \
-			  (UM_WRITE << BM2_UM_SHIFT) | \
-			  (UM_WRITE << BM3_UM_SHIFT))
+#define MPU_REGION_WRITE                                                                           \
+	((UM_WRITE << BM0_UM_SHIFT) | (UM_WRITE << BM1_UM_SHIFT) | (UM_WRITE << BM2_UM_SHIFT) |    \
+	 (UM_WRITE << BM3_UM_SHIFT))
 
 /* Execute Attribute */
-#define MPU_REGION_EXEC  ((UM_EXEC << BM0_UM_SHIFT) | \
-			  (UM_EXEC << BM1_UM_SHIFT) | \
-			  (UM_EXEC << BM2_UM_SHIFT) | \
-			  (UM_EXEC << BM3_UM_SHIFT))
+#define MPU_REGION_EXEC                                                                            \
+	((UM_EXEC << BM0_UM_SHIFT) | (UM_EXEC << BM1_UM_SHIFT) | (UM_EXEC << BM2_UM_SHIFT) |       \
+	 (UM_EXEC << BM3_UM_SHIFT))
 
 /* Super User Attributes */
-#define MPU_REGION_SU	 ((SM_SAME_AS_UM << BM0_SM_SHIFT) | \
-			  (SM_SAME_AS_UM << BM1_SM_SHIFT) | \
-			  (SM_SAME_AS_UM << BM2_SM_SHIFT) | \
-			  (SM_SAME_AS_UM << BM3_SM_SHIFT))
+#define MPU_REGION_SU                                                                              \
+	((SM_SAME_AS_UM << BM0_SM_SHIFT) | (SM_SAME_AS_UM << BM1_SM_SHIFT) |                       \
+	 (SM_SAME_AS_UM << BM2_SM_SHIFT) | (SM_SAME_AS_UM << BM3_SM_SHIFT))
 
-#define MPU_REGION_SU_RX ((SM_RX_ALLOW << BM0_SM_SHIFT) | \
-			  (SM_RX_ALLOW << BM1_SM_SHIFT) | \
-			  (SM_RX_ALLOW << BM2_SM_SHIFT) | \
-			  (SM_RX_ALLOW << BM3_SM_SHIFT))
+#define MPU_REGION_SU_RX                                                                           \
+	((SM_RX_ALLOW << BM0_SM_SHIFT) | (SM_RX_ALLOW << BM1_SM_SHIFT) |                           \
+	 (SM_RX_ALLOW << BM2_SM_SHIFT) | (SM_RX_ALLOW << BM3_SM_SHIFT))
 
-#define MPU_REGION_SU_RW ((SM_RW_ALLOW << BM0_SM_SHIFT) | \
-			  (SM_RW_ALLOW << BM1_SM_SHIFT) | \
-			  (SM_RW_ALLOW << BM2_SM_SHIFT) | \
-			  (SM_RW_ALLOW << BM3_SM_SHIFT))
+#define MPU_REGION_SU_RW                                                                           \
+	((SM_RW_ALLOW << BM0_SM_SHIFT) | (SM_RW_ALLOW << BM1_SM_SHIFT) |                           \
+	 (SM_RW_ALLOW << BM2_SM_SHIFT) | (SM_RW_ALLOW << BM3_SM_SHIFT))
 
-#define MPU_REGION_SU_RWX ((SM_RWX_ALLOW << BM0_SM_SHIFT) | \
-			   (SM_RWX_ALLOW << BM1_SM_SHIFT) | \
-			   (SM_RWX_ALLOW << BM2_SM_SHIFT) | \
-			   (SM_RWX_ALLOW << BM3_SM_SHIFT))
+#define MPU_REGION_SU_RWX                                                                          \
+	((SM_RWX_ALLOW << BM0_SM_SHIFT) | (SM_RWX_ALLOW << BM1_SM_SHIFT) |                         \
+	 (SM_RWX_ALLOW << BM2_SM_SHIFT) | (SM_RWX_ALLOW << BM3_SM_SHIFT))
 
 /* The ENDADDR field has the last 5 bit reserved and set to 1 */
 #define ENDADDR_ROUND(x) (x - 0x1F)
 
-#define REGION_USER_MODE_ATTR {(MPU_REGION_READ | \
-				MPU_REGION_WRITE | \
-				MPU_REGION_SU)}
+#define REGION_USER_MODE_ATTR {(MPU_REGION_READ | MPU_REGION_WRITE | MPU_REGION_SU)}
 
 /* Some helper defines for common regions */
 #if defined(CONFIG_MPU_ALLOW_FLASH_WRITE)
-#define REGION_RAM_ATTR	  {((MPU_REGION_SU_RWX) | \
-			   ((UM_READ | UM_WRITE | UM_EXEC) << BM3_UM_SHIFT) | \
-			   (BM4_PERMISSIONS))}
+#define REGION_RAM_ATTR                                                                            \
+	{((MPU_REGION_SU_RWX) | ((UM_READ | UM_WRITE | UM_EXEC) << BM3_UM_SHIFT) |                 \
+	  (BM4_PERMISSIONS))}
 
 #define REGION_FLASH_ATTR {(MPU_REGION_SU_RWX)}
 
 #else
-#define REGION_RAM_ATTR	  {((MPU_REGION_SU_RW) | \
-			   ((UM_READ | UM_WRITE) << BM3_UM_SHIFT) | \
-			   (BM4_PERMISSIONS))}
+#define REGION_RAM_ATTR                                                                            \
+	{((MPU_REGION_SU_RW) | ((UM_READ | UM_WRITE) << BM3_UM_SHIFT) | (BM4_PERMISSIONS))}
 
-#define REGION_FLASH_ATTR {(MPU_REGION_READ | \
-			   MPU_REGION_EXEC | \
-			   MPU_REGION_SU)}
+#define REGION_FLASH_ATTR {(MPU_REGION_READ | MPU_REGION_EXEC | MPU_REGION_SU)}
 #endif
 
-#define REGION_IO_ATTR	  {(MPU_REGION_READ | \
-			   MPU_REGION_WRITE | \
-			   MPU_REGION_EXEC | \
-			   MPU_REGION_SU)}
+#define REGION_IO_ATTR {(MPU_REGION_READ | MPU_REGION_WRITE | MPU_REGION_EXEC | MPU_REGION_SU)}
 
-#define REGION_RO_ATTR	  {(MPU_REGION_READ | MPU_REGION_SU)}
+#define REGION_RO_ATTR {(MPU_REGION_READ | MPU_REGION_SU)}
 
-#define REGION_USER_RO_ATTR {(MPU_REGION_READ | \
-			     MPU_REGION_SU)}
+#define REGION_USER_RO_ATTR {(MPU_REGION_READ | MPU_REGION_SU)}
 
 /* ENET (Master 3) and USB (Master 4) devices will not be able
 to access RAM when the region is dynamically disabled in NXP MPU.
 DEBUGGER (Master 1) can't be disabled in Region 0. */
-#define REGION_DEBUGGER_AND_DEVICE_ATTR  {((MPU_REGION_SU) | \
-				((UM_READ | UM_WRITE) << BM3_UM_SHIFT) | \
-				(BM4_PERMISSIONS))}
+#define REGION_DEBUGGER_AND_DEVICE_ATTR                                                            \
+	{((MPU_REGION_SU) | ((UM_READ | UM_WRITE) << BM3_UM_SHIFT) | (BM4_PERMISSIONS))}
 
-#define REGION_DEBUG_ATTR  {MPU_REGION_SU}
+#define REGION_DEBUG_ATTR {MPU_REGION_SU}
 
-#define REGION_BACKGROUND_ATTR	{MPU_REGION_SU_RW}
+#define REGION_BACKGROUND_ATTR {MPU_REGION_SU_RW}
 
 struct nxp_mpu_region_attr {
 	/* NXP MPU region access permission attributes */
@@ -145,27 +128,22 @@ typedef struct {
  */
 
 /* Read-Write access permission attributes */
-#define K_MEM_PARTITION_P_NA_U_NA	((k_mem_partition_attr_t) \
-	{(MPU_REGION_SU)})
-#define K_MEM_PARTITION_P_RW_U_RW	((k_mem_partition_attr_t) \
-	{(MPU_REGION_READ | MPU_REGION_WRITE | MPU_REGION_SU)})
-#define K_MEM_PARTITION_P_RW_U_RO	((k_mem_partition_attr_t) \
-	{(MPU_REGION_READ | MPU_REGION_SU_RW)})
-#define K_MEM_PARTITION_P_RW_U_NA	((k_mem_partition_attr_t) \
-	{(MPU_REGION_SU_RW)})
-#define K_MEM_PARTITION_P_RO_U_RO	((k_mem_partition_attr_t) \
-	{(MPU_REGION_READ | MPU_REGION_SU)})
-#define K_MEM_PARTITION_P_RO_U_NA	((k_mem_partition_attr_t) \
-	{(MPU_REGION_SU_RX)})
+#define K_MEM_PARTITION_P_NA_U_NA ((k_mem_partition_attr_t){(MPU_REGION_SU)})
+#define K_MEM_PARTITION_P_RW_U_RW                                                                  \
+	((k_mem_partition_attr_t){(MPU_REGION_READ | MPU_REGION_WRITE | MPU_REGION_SU)})
+#define K_MEM_PARTITION_P_RW_U_RO ((k_mem_partition_attr_t){(MPU_REGION_READ | MPU_REGION_SU_RW)})
+#define K_MEM_PARTITION_P_RW_U_NA ((k_mem_partition_attr_t){(MPU_REGION_SU_RW)})
+#define K_MEM_PARTITION_P_RO_U_RO ((k_mem_partition_attr_t){(MPU_REGION_READ | MPU_REGION_SU)})
+#define K_MEM_PARTITION_P_RO_U_NA ((k_mem_partition_attr_t){(MPU_REGION_SU_RX)})
 
 /* Execution-allowed attributes */
-#define K_MEM_PARTITION_P_RWX_U_RWX	((k_mem_partition_attr_t) \
-	{(MPU_REGION_READ | MPU_REGION_WRITE | \
-	  MPU_REGION_EXEC | MPU_REGION_SU)})
-#define K_MEM_PARTITION_P_RWX_U_RX	((k_mem_partition_attr_t) \
-	{(MPU_REGION_READ | MPU_REGION_EXEC | MPU_REGION_SU_RWX)})
-#define K_MEM_PARTITION_P_RX_U_RX	((k_mem_partition_attr_t) \
-	{(MPU_REGION_READ | MPU_REGION_EXEC | MPU_REGION_SU)})
+#define K_MEM_PARTITION_P_RWX_U_RWX                                                                \
+	((k_mem_partition_attr_t){                                                                 \
+		(MPU_REGION_READ | MPU_REGION_WRITE | MPU_REGION_EXEC | MPU_REGION_SU)})
+#define K_MEM_PARTITION_P_RWX_U_RX                                                                 \
+	((k_mem_partition_attr_t){(MPU_REGION_READ | MPU_REGION_EXEC | MPU_REGION_SU_RWX)})
+#define K_MEM_PARTITION_P_RX_U_RX                                                                  \
+	((k_mem_partition_attr_t){(MPU_REGION_READ | MPU_REGION_EXEC | MPU_REGION_SU)})
 
 /*
  * @brief Evaluate Write-ability
@@ -175,18 +153,18 @@ typedef struct {
  * @param attr The k_mem_partition_attr_t object holding the
  *             MPU attributes to be checked against write-ability.
  */
-#define K_MEM_PARTITION_IS_WRITABLE(attr) \
-	({ \
-		int __is_writable__; \
-		switch (attr.ap_attr) { \
-		case MPU_REGION_WRITE: \
-		case MPU_REGION_SU_RW: \
-			__is_writable__ = 1; \
-			break; \
-		default: \
-			__is_writable__ = 0; \
-		} \
-		__is_writable__; \
+#define K_MEM_PARTITION_IS_WRITABLE(attr)                                                          \
+	({                                                                                         \
+		int __is_writable__;                                                               \
+		switch (attr.ap_attr) {                                                            \
+		case MPU_REGION_WRITE:                                                             \
+		case MPU_REGION_SU_RW:                                                             \
+			__is_writable__ = 1;                                                       \
+			break;                                                                     \
+		default:                                                                           \
+			__is_writable__ = 0;                                                       \
+		}                                                                                  \
+		__is_writable__;                                                                   \
 	})
 
 /*
@@ -198,20 +176,19 @@ typedef struct {
  *             MPU attributes to be checked against execution
  *             allowance.
  */
-#define K_MEM_PARTITION_IS_EXECUTABLE(attr) \
-	({ \
-		int __is_executable__; \
-		switch (attr.ap_attr) { \
-		case MPU_REGION_SU_RX: \
-		case MPU_REGION_EXEC: \
-			__is_executable__ = 1; \
-			break; \
-		default: \
-			__is_executable__ = 0; \
-		} \
-		__is_executable__; \
+#define K_MEM_PARTITION_IS_EXECUTABLE(attr)                                                        \
+	({                                                                                         \
+		int __is_executable__;                                                             \
+		switch (attr.ap_attr) {                                                            \
+		case MPU_REGION_SU_RX:                                                             \
+		case MPU_REGION_EXEC:                                                              \
+			__is_executable__ = 1;                                                     \
+			break;                                                                     \
+		default:                                                                           \
+			__is_executable__ = 0;                                                     \
+		}                                                                                  \
+		__is_executable__;                                                                 \
 	})
-
 
 /* Region definition data structure */
 struct nxp_mpu_region {
@@ -225,12 +202,12 @@ struct nxp_mpu_region {
 	nxp_mpu_region_attr_t attr;
 };
 
-#define MPU_REGION_ENTRY(_name, _base, _end, _attr) \
-	{\
-		.name = _name, \
-		.base = _base, \
-		.end = _end, \
-		.attr = _attr, \
+#define MPU_REGION_ENTRY(_name, _base, _end, _attr)                                                \
+	{                                                                                          \
+		.name = _name,                                                                     \
+		.base = _base,                                                                     \
+		.end = _end,                                                                       \
+		.attr = _attr,                                                                     \
 	}
 
 /* MPU configuration data structure */
@@ -255,15 +232,13 @@ extern const struct nxp_mpu_config mpu_config;
 
 #endif /* _ASMLANGUAGE */
 
-#define _ARCH_MEM_PARTITION_ALIGN_CHECK(start, size) \
-	BUILD_ASSERT((size) % \
-		CONFIG_ARM_MPU_REGION_MIN_ALIGN_AND_SIZE == 0 && \
-		(size) >= CONFIG_ARM_MPU_REGION_MIN_ALIGN_AND_SIZE && \
-		(uint32_t)(start) % CONFIG_ARM_MPU_REGION_MIN_ALIGN_AND_SIZE == 0, \
-		"the size of the partition must align with minimum MPU \
-		 region size" \
-		" and greater than or equal to minimum MPU region size." \
-		"start address of the partition must align with minimum MPU \
-		 region size.")
+#define _ARCH_MEM_PARTITION_ALIGN_CHECK(start, size)                                               \
+	BUILD_ASSERT(                                                                              \
+		(size) % CONFIG_ARM_MPU_REGION_MIN_ALIGN_AND_SIZE == 0 &&                          \
+			(size) >= CONFIG_ARM_MPU_REGION_MIN_ALIGN_AND_SIZE &&                      \
+			(uint32_t)(start) % CONFIG_ARM_MPU_REGION_MIN_ALIGN_AND_SIZE == 0,         \
+		"The size of the partition must align with minimum MPU region size"                \
+		" and greater than or equal to minimum MPU region size.\n"                         \
+		"The start address of the partition must align with minimum MPU region size.")
 
 #endif /* ZEPHYR_INCLUDE_ARCH_ARM_MPU_NXP_MPU_H_ */

--- a/tests/arch/arm/arm_hardfault_validation/src/arm_hardfault.c
+++ b/tests/arch/arm/arm_hardfault_validation/src/arm_hardfault.c
@@ -25,8 +25,7 @@ void k_sys_fatal_error_handler(unsigned int reason, const struct arch_esf *pEsf)
 	}
 
 	if (reason != expected_reason) {
-		printk("Wrong crash type got %d expected %d\n", reason,
-			expected_reason);
+		printk("Wrong crash type got %d expected %d\n", reason, expected_reason);
 		k_fatal_halt(reason);
 	}
 
@@ -39,8 +38,7 @@ void k_sys_fatal_error_handler(unsigned int reason, const struct arch_esf *pEsf)
 		 * inside the current runtime error
 		 */
 		expected_reason = K_ERR_KERNEL_PANIC;
-		__ASSERT(0,
-		"Assert occurring inside kernel panic");
+		__ASSERT(0, "Assert occurring inside kernel panic");
 	}
 
 	expected_reason = -1;

--- a/tests/arch/arm/arm_interrupt/src/arm_interrupt.c
+++ b/tests/arch/arm/arm_interrupt/src/arm_interrupt.c
@@ -19,7 +19,7 @@ static volatile uint32_t expected_msp;
 static K_THREAD_STACK_DEFINE(esf_collection_stack, 2048);
 static struct k_thread esf_collection_thread;
 #define MAIN_PRIORITY 7
-#define PRIORITY 5
+#define PRIORITY      5
 
 /**
  * Validates that pEsf matches state from set_regs_with_known_pattern()
@@ -28,11 +28,8 @@ static int check_esf_matches_expectations(const struct arch_esf *pEsf)
 {
 	const uint16_t expected_fault_instruction = 0xde5a; /* udf #90 */
 	const bool caller_regs_match_expected =
-		(pEsf->basic.r0 == 0) &&
-		(pEsf->basic.r1 == 1) &&
-		(pEsf->basic.r2 == 2) &&
-		(pEsf->basic.r3 == 3) &&
-		(pEsf->basic.lr == 15) &&
+		(pEsf->basic.r0 == 0) && (pEsf->basic.r1 == 1) && (pEsf->basic.r2 == 2) &&
+		(pEsf->basic.r3 == 3) && (pEsf->basic.lr == 15) &&
 		(*(uint16_t *)pEsf->basic.pc == expected_fault_instruction);
 	if (!caller_regs_match_expected) {
 		printk("__basic_sf member of ESF is incorrect\n");
@@ -42,14 +39,10 @@ static int check_esf_matches_expectations(const struct arch_esf *pEsf)
 #if defined(CONFIG_EXTRA_EXCEPTION_INFO)
 	const struct _callee_saved *callee_regs = pEsf->extra_info.callee;
 	const bool callee_regs_match_expected =
-		(callee_regs->v1 /* r4 */ == 4) &&
-		(callee_regs->v2 /* r5 */ == 5) &&
-		(callee_regs->v3 /* r6 */ == 6) &&
-		(callee_regs->v4 /* r7 */ == 7) &&
-		(callee_regs->v5 /* r8 */ == 8) &&
-		(callee_regs->v6 /* r9 */ == 9) &&
-		(callee_regs->v7 /* r10 */ == 10) &&
-		(callee_regs->v8 /* r11 */ == 11);
+		(callee_regs->v1 /* r4 */ == 4) && (callee_regs->v2 /* r5 */ == 5) &&
+		(callee_regs->v3 /* r6 */ == 6) && (callee_regs->v4 /* r7 */ == 7) &&
+		(callee_regs->v5 /* r8 */ == 8) && (callee_regs->v6 /* r9 */ == 9) &&
+		(callee_regs->v7 /* r10 */ == 10) && (callee_regs->v8 /* r11 */ == 11);
 	if (!callee_regs_match_expected) {
 		printk("_callee_saved_t member of ESF is incorrect\n");
 		return -1;
@@ -62,10 +55,8 @@ static int check_esf_matches_expectations(const struct arch_esf *pEsf)
 	 */
 	const uint32_t exc_bits_set_mask = 0xff00000C;
 
-	if ((pEsf->extra_info.exc_return & exc_bits_set_mask) !=
-		exc_bits_set_mask) {
-		printk("Incorrect EXC_RETURN of 0x%08x",
-			pEsf->extra_info.exc_return);
+	if ((pEsf->extra_info.exc_return & exc_bits_set_mask) != exc_bits_set_mask) {
+		printk("Incorrect EXC_RETURN of 0x%08x", pEsf->extra_info.exc_return);
 		return -1;
 	}
 
@@ -73,15 +64,13 @@ static int check_esf_matches_expectations(const struct arch_esf *pEsf)
 	 * to the xpsr. (the xpsr value in the copy used for pEsf
 	 * is overwritten in fault.c)
 	 */
-	if (memcmp((void *)callee_regs->psp, pEsf,
-		offsetof(struct arch_esf, basic.xpsr)) != 0) {
+	if (memcmp((void *)callee_regs->psp, pEsf, offsetof(struct arch_esf, basic.xpsr)) != 0) {
 		printk("psp does not match __basic_sf provided\n");
 		return -1;
 	}
 
 	if (pEsf->extra_info.msp != expected_msp) {
-		printk("MSP is 0x%08x but should be 0x%08x",
-			pEsf->extra_info.msp, expected_msp);
+		printk("MSP is 0x%08x but should be 0x%08x", pEsf->extra_info.msp, expected_msp);
 		return -1;
 	}
 #endif /* CONFIG_EXTRA_EXCEPTION_INFO */
@@ -98,8 +87,7 @@ void k_sys_fatal_error_handler(unsigned int reason, const struct arch_esf *pEsf)
 	}
 
 	if (reason != expected_reason) {
-		printk("Wrong crash type got %d expected %d\n", reason,
-			expected_reason);
+		printk("Wrong crash type got %d expected %d\n", reason, expected_reason);
 		k_fatal_halt(reason);
 	}
 
@@ -131,29 +119,27 @@ void set_regs_with_known_pattern(void *p1, void *p2, void *p3)
 	ARG_UNUSED(p2);
 	ARG_UNUSED(p3);
 
-	__asm__ volatile(
-		"mov r1, #1\n"
-		"mov r2, #2\n"
-		"mov r3, #3\n"
-		"mov r4, #4\n"
-		"mov r5, #5\n"
-		"mov r6, #6\n"
-		"mov r7, #7\n"
-		"mov r0, #8\n"
-		"mov r8, r0\n"
-		"add r0, r0, #1\n"
-		"mov r9, r0\n"
-		"add r0, r0, #1\n"
-		"mov r10, r0\n"
-		"add r0, r0, #1\n"
-		"mov r11, r0\n"
-		"add r0, r0, #1\n"
-		"mov r12, r0\n"
-		"add r0, r0, #3\n"
-		"mov lr, r0\n"
-		"mov r0, #0\n"
-		"udf #90\n"
-	);
+	__asm__ volatile("mov r1, #1\n"
+			 "mov r2, #2\n"
+			 "mov r3, #3\n"
+			 "mov r4, #4\n"
+			 "mov r5, #5\n"
+			 "mov r6, #6\n"
+			 "mov r7, #7\n"
+			 "mov r0, #8\n"
+			 "mov r8, r0\n"
+			 "add r0, r0, #1\n"
+			 "mov r9, r0\n"
+			 "add r0, r0, #1\n"
+			 "mov r10, r0\n"
+			 "add r0, r0, #1\n"
+			 "mov r11, r0\n"
+			 "add r0, r0, #1\n"
+			 "mov r12, r0\n"
+			 "add r0, r0, #3\n"
+			 "mov lr, r0\n"
+			 "mov r0, #0\n"
+			 "udf #90\n");
 }
 
 ZTEST(arm_interrupt, test_arm_esf_collection)
@@ -181,23 +167,19 @@ ZTEST(arm_interrupt, test_arm_esf_collection)
 
 	TC_PRINT("Testing ESF Reporting\n");
 	k_thread_create(&esf_collection_thread, esf_collection_stack,
-			K_THREAD_STACK_SIZEOF(esf_collection_stack),
-			set_regs_with_known_pattern,
-			NULL, NULL, NULL, K_PRIO_COOP(PRIORITY), 0,
-			K_NO_WAIT);
+			K_THREAD_STACK_SIZEOF(esf_collection_stack), set_regs_with_known_pattern,
+			NULL, NULL, NULL, K_PRIO_COOP(PRIORITY), 0, K_NO_WAIT);
 
 	test_validation_rv = esf_validation_rv;
 
-	zassert_not_equal(test_validation_rv, TC_FAIL,
-		"ESF fault collection failed");
+	zassert_not_equal(test_validation_rv, TC_FAIL, "ESF fault collection failed");
 }
 
 void arm_isr_handler(const void *args)
 {
 	ARG_UNUSED(args);
 
-#if defined(CONFIG_CPU_CORTEX_M) && defined(CONFIG_FPU) && \
-	defined(CONFIG_FPU_SHARING)
+#if defined(CONFIG_CPU_CORTEX_M) && defined(CONFIG_FPU) && defined(CONFIG_FPU_SHARING)
 	/* Clear Floating Point Status and Control Register (FPSCR),
 	 * to prevent from having the interrupt line set to pending again,
 	 * in case FPU IRQ is selected by the test as "Available IRQ line"
@@ -235,8 +217,7 @@ void arm_isr_handler(const void *args)
 		 */
 		int reason = expected_reason;
 
-		zassert_equal(reason, -1,
-			"expected_reason has not been reset (%d)\n", reason);
+		zassert_equal(reason, -1, "expected_reason has not been reset (%d)\n", reason);
 #endif
 	}
 }
@@ -284,8 +265,7 @@ ZTEST(arm_interrupt, test_arm_interrupt)
 		}
 	}
 
-	zassert_true(i >= 0,
-		"No available IRQ line to use in the test\n");
+	zassert_true(i >= 0, "No available IRQ line to use in the test\n");
 
 	TC_PRINT("Available IRQ line: %u\n", i);
 
@@ -304,14 +284,10 @@ ZTEST(arm_interrupt, test_arm_interrupt)
 	 * expected reason variable is reset.
 	 */
 	reason = expected_reason;
-	zassert_equal(reason, -1,
-		"expected_reason has not been reset (%d)\n", reason);
+	zassert_equal(reason, -1, "expected_reason has not been reset (%d)\n", reason);
 	NVIC_DisableIRQ(i);
 
-	arch_irq_connect_dynamic(i, 0 /* highest priority */,
-		arm_isr_handler,
-		NULL,
-		0);
+	arch_irq_connect_dynamic(i, 0 /* highest priority */, arm_isr_handler, NULL, 0);
 
 	NVIC_ClearPendingIRQ(i);
 	NVIC_EnableIRQ(i);
@@ -355,17 +331,14 @@ ZTEST(arm_interrupt, test_arm_interrupt)
 	 * entry will make PSP descend below the limit and into the MPU guard
 	 * section (or beyond the address pointed by PSPLIM in ARMv8-M MCUs).
 	 */
-#if defined(CONFIG_FPU) && defined(CONFIG_FPU_SHARING) && \
-	defined(CONFIG_MPU_STACK_GUARD)
+#if defined(CONFIG_FPU) && defined(CONFIG_FPU_SHARING) && defined(CONFIG_MPU_STACK_GUARD)
 #define FPU_STACK_EXTRA_SIZE 0x48
 	/* If an FP context is present, we should not set the PSP
 	 * too close to the end of the stack, because stacking of
 	 * the ESF might corrupt kernel memory, making it not
 	 * possible to continue the test execution.
 	 */
-	uint32_t fp_extra_size =
-		(__get_CONTROL() & CONTROL_FPCA_Msk) ?
-			FPU_STACK_EXTRA_SIZE : 0;
+	uint32_t fp_extra_size = (__get_CONTROL() & CONTROL_FPCA_Msk) ? FPU_STACK_EXTRA_SIZE : 0;
 	__set_PSP(_current->stack_info.start + 0x10 + fp_extra_size);
 #else
 	__set_PSP(_current->stack_info.start + 0x10);
@@ -420,8 +393,7 @@ static inline void z_vrfy_test_arm_user_interrupt_syscall(void)
 ZTEST_USER(arm_interrupt, test_arm_user_interrupt)
 {
 	/* Test thread executing in user mode */
-	zassert_true(arch_is_user_context(),
-		"Test thread not running in user mode\n");
+	zassert_true(arch_is_user_context(), "Test thread not running in user mode\n");
 
 	/* Attempt to lock IRQs in user mode */
 	irq_lock();
@@ -476,12 +448,10 @@ ZTEST(arm_interrupt, test_arm_null_pointer_exception)
 
 	expected_reason = K_ERR_CPU_EXCEPTION;
 
-	printk("Reading a null pointer value: 0x%0x\n",
-		test_struct_null_pointer->val[1]);
+	printk("Reading a null pointer value: 0x%0x\n", test_struct_null_pointer->val[1]);
 
 	reason = expected_reason;
-	zassert_equal(reason, -1,
-		"expected_reason has not been reset (%d)\n", reason);
+	zassert_equal(reason, -1, "expected_reason has not been reset (%d)\n", reason);
 }
 #pragma GCC pop_options
 

--- a/tests/arch/arm/arm_irq_advanced_features/src/arm_dynamic_direct_interrupts.c
+++ b/tests/arch/arm/arm_irq_advanced_features/src/arm_dynamic_direct_interrupts.c
@@ -41,10 +41,8 @@ ZTEST(arm_irq_advanced_features, test_arm_dynamic_direct_interrupts)
 	irq_disable(DIRECT_ISR_OFFSET);
 
 	/* Attach the ISR handler at run time. */
-	irq_connect_dynamic(DIRECT_ISR_OFFSET, 0 /* highest priority */,
-		arm_direct_isr_handler_0,
-		NULL,
-		0);
+	irq_connect_dynamic(DIRECT_ISR_OFFSET, 0 /* highest priority */, arm_direct_isr_handler_0,
+			    NULL, 0);
 
 	/* Enable and pend the interrupt */
 	irq_enable(DIRECT_ISR_OFFSET);
@@ -65,10 +63,8 @@ ZTEST(arm_irq_advanced_features, test_arm_dynamic_direct_interrupts)
 	irq_disable(DIRECT_ISR_OFFSET);
 
 	/* Attach an alternative ISR handler at run-time. */
-	irq_connect_dynamic(DIRECT_ISR_OFFSET, 0 /* highest priority */,
-		arm_direct_isr_handler_1,
-		NULL,
-		0);
+	irq_connect_dynamic(DIRECT_ISR_OFFSET, 0 /* highest priority */, arm_direct_isr_handler_1,
+			    NULL, 0);
 
 	/* Enable and pend the interrupt */
 	irq_enable(DIRECT_ISR_OFFSET);

--- a/tests/arch/arm/arm_irq_advanced_features/src/arm_irq_target_state.c
+++ b/tests/arch/arm/arm_irq_advanced_features/src/arm_irq_target_state.c
@@ -8,11 +8,9 @@
 #include <zephyr/arch/cpu.h>
 #include <cmsis_core.h>
 
-#if defined(CONFIG_ARM_SECURE_FIRMWARE) && \
-	defined(CONFIG_ARMV7_M_ARMV8_M_MAINLINE)
+#if defined(CONFIG_ARM_SECURE_FIRMWARE) && defined(CONFIG_ARMV7_M_ARMV8_M_MAINLINE)
 
-extern irq_target_state_t irq_target_state_set(unsigned int irq,
-	irq_target_state_t target_state);
+extern irq_target_state_t irq_target_state_set(unsigned int irq, irq_target_state_t target_state);
 extern int irq_target_state_is_secure(unsigned int irq);
 
 ZTEST(arm_irq_advanced_features, test_arm_irq_target_state)
@@ -54,39 +52,29 @@ ZTEST(arm_irq_advanced_features, test_arm_irq_target_state)
 		}
 	}
 
-	zassert_true(i >= 0,
-		"No available IRQ line to configure as zero-latency\n");
+	zassert_true(i >= 0, "No available IRQ line to configure as zero-latency\n");
 
 	TC_PRINT("Available IRQ line: %u\n", i);
 
 	/* Set the available IRQ line to Secure and check the result. */
-	irq_target_state_t result_state =
-		irq_target_state_set(i, IRQ_TARGET_STATE_SECURE);
+	irq_target_state_t result_state = irq_target_state_set(i, IRQ_TARGET_STATE_SECURE);
 
-	zassert_equal(result_state, IRQ_TARGET_STATE_SECURE,
-		"Target state not set to Secure\n");
+	zassert_equal(result_state, IRQ_TARGET_STATE_SECURE, "Target state not set to Secure\n");
 
-	zassert_equal(irq_target_state_is_secure(i), 1,
-		"Target state not set to Secure\n");
+	zassert_equal(irq_target_state_is_secure(i), 1, "Target state not set to Secure\n");
 
 	/* Set the available IRQ line to Secure and check the result. */
-	result_state =
-		irq_target_state_set(i, IRQ_TARGET_STATE_NON_SECURE);
+	result_state = irq_target_state_set(i, IRQ_TARGET_STATE_NON_SECURE);
 
 	zassert_equal(result_state, IRQ_TARGET_STATE_NON_SECURE,
-		"Target state not set to Secure\n");
-	zassert_equal(irq_target_state_is_secure(i), 0,
-		"Target state not set to Non-Secure\n");
+		      "Target state not set to Secure\n");
+	zassert_equal(irq_target_state_is_secure(i), 0, "Target state not set to Non-Secure\n");
 
-	result_state =
-		irq_target_state_set(i, IRQ_TARGET_STATE_SECURE);
+	result_state = irq_target_state_set(i, IRQ_TARGET_STATE_SECURE);
 
-	zassert_equal(result_state, IRQ_TARGET_STATE_SECURE,
-		"Target state not set to Secure\n");
+	zassert_equal(result_state, IRQ_TARGET_STATE_SECURE, "Target state not set to Secure\n");
 
-	zassert_equal(irq_target_state_is_secure(i), 1,
-		"Target state not set to Secure\n");
-
+	zassert_equal(irq_target_state_is_secure(i), 1, "Target state not set to Secure\n");
 }
 #else
 ZTEST(arm_irq_advanced_features, test_arm_irq_target_state)

--- a/tests/arch/arm/arm_irq_advanced_features/src/arm_zero_latency_irqs.c
+++ b/tests/arch/arm/arm_irq_advanced_features/src/arm_zero_latency_irqs.c
@@ -70,17 +70,14 @@ ZTEST(arm_irq_advanced_features, test_arm_zero_latency_irqs)
 		}
 	}
 
-	zassert_true(i >= 0,
-		"No available IRQ line to configure as zero-latency\n");
+	zassert_true(i >= 0, "No available IRQ line to configure as zero-latency\n");
 
 	TC_PRINT("Available IRQ line: %u\n", i);
 
 	/* Configure the available IRQ line as zero-latency. */
 
-	arch_irq_connect_dynamic(i, 0 /* Unused */,
-		arm_zero_latency_isr_handler,
-		NULL,
-		IRQ_ZERO_LATENCY);
+	arch_irq_connect_dynamic(i, 0 /* Unused */, arm_zero_latency_isr_handler, NULL,
+				 IRQ_ZERO_LATENCY);
 
 	NVIC_ClearPendingIRQ(i);
 	NVIC_EnableIRQ(i);

--- a/tests/arch/arm/arm_irq_vector_table/src/arm_irq_vector_table.c
+++ b/tests/arch/arm/arm_irq_vector_table/src/arm_irq_vector_table.c
@@ -9,7 +9,6 @@
 #include <cmsis_core.h>
 #include <zephyr/linker/sections.h>
 
-
 /*
  * Offset (starting from the beginning of the vector table)
  * of the location where the ISRs will be manually installed.
@@ -83,7 +82,6 @@ void isr2(void)
  * @{
  */
 
-
 /**
  * @brief Test installation of ISRs directly in the vector table
  *
@@ -106,13 +104,12 @@ ZTEST(vector_table, test_arm_irq_vector_table)
 		k_sem_init(&sem[ii], 0, K_SEM_MAX_LIMIT);
 	}
 
-	zassert_true((k_sem_take(&sem[0], K_NO_WAIT) ||
-		      k_sem_take(&sem[1], K_NO_WAIT) ||
-		      k_sem_take(&sem[2], K_NO_WAIT)), NULL);
+	zassert_true((k_sem_take(&sem[0], K_NO_WAIT) || k_sem_take(&sem[1], K_NO_WAIT) ||
+		      k_sem_take(&sem[2], K_NO_WAIT)),
+		     NULL);
 
 	for (int ii = 0; ii < 3; ii++) {
-#if defined(CONFIG_ARMV6_M_ARMV8_M_BASELINE) || \
-	defined(CONFIG_SOC_TI_LM3S6965_QEMU)
+#if defined(CONFIG_ARMV6_M_ARMV8_M_BASELINE) || defined(CONFIG_SOC_TI_LM3S6965_QEMU)
 		/* the QEMU does not simulate the
 		 * STIR register: this is a workaround
 		 */
@@ -122,10 +119,9 @@ ZTEST(vector_table, test_arm_irq_vector_table)
 #endif
 	}
 
-	zassert_false((k_sem_take(&sem[0], K_NO_WAIT) ||
-		       k_sem_take(&sem[1], K_NO_WAIT) ||
-		       k_sem_take(&sem[2], K_NO_WAIT)), NULL);
-
+	zassert_false((k_sem_take(&sem[0], K_NO_WAIT) || k_sem_take(&sem[1], K_NO_WAIT) ||
+		       k_sem_take(&sem[2], K_NO_WAIT)),
+		      NULL);
 }
 
 typedef void (*vth)(void); /* Vector Table Handler */
@@ -143,26 +139,26 @@ typedef void (*vth)(void); /* Vector Table Handler */
  */
 void nrfx_power_clock_irq_handler(void);
 #if defined(CONFIG_SOC_SERIES_NRF51X) || defined(CONFIG_SOC_SERIES_NRF52X)
-#define POWER_CLOCK_IRQ_NUM	POWER_CLOCK_IRQn
+#define POWER_CLOCK_IRQ_NUM POWER_CLOCK_IRQn
 #elif defined(CONFIG_SOC_SERIES_NRF54HX) || defined(CONFIG_SOC_SERIES_NRF92X)
-#define POWER_CLOCK_IRQ_NUM	-1 /* not needed */
+#define POWER_CLOCK_IRQ_NUM -1 /* not needed */
 #else
-#define POWER_CLOCK_IRQ_NUM	CLOCK_POWER_IRQn
+#define POWER_CLOCK_IRQ_NUM CLOCK_POWER_IRQn
 #endif
 
 #if defined(CONFIG_BOARD_QEMU_CORTEX_M0)
 void timer0_nrf_isr(void);
-#define TIMER_IRQ_HANDLER	timer0_nrf_isr
-#define TIMER_IRQ_NUM		TIMER0_IRQn
-#elif defined(CONFIG_SOC_SERIES_NRF54LX) || defined(CONFIG_SOC_SERIES_NRF54HX) || \
+#define TIMER_IRQ_HANDLER timer0_nrf_isr
+#define TIMER_IRQ_NUM     TIMER0_IRQn
+#elif defined(CONFIG_SOC_SERIES_NRF54LX) || defined(CONFIG_SOC_SERIES_NRF54HX) ||                  \
 	defined(CONFIG_SOC_SERIES_NRF92X)
 void nrfx_grtc_irq_handler(void);
-#define TIMER_IRQ_HANDLER	nrfx_grtc_irq_handler
-#define TIMER_IRQ_NUM		GRTC_0_IRQn
+#define TIMER_IRQ_HANDLER nrfx_grtc_irq_handler
+#define TIMER_IRQ_NUM     GRTC_0_IRQn
 #else
 void rtc_nrf_isr(void);
-#define TIMER_IRQ_HANDLER	rtc_nrf_isr
-#define TIMER_IRQ_NUM		RTC1_IRQn
+#define TIMER_IRQ_HANDLER rtc_nrf_isr
+#define TIMER_IRQ_NUM     RTC1_IRQn
 #endif
 
 #define IRQ_VECTOR_TABLE_SIZE (MAX(POWER_CLOCK_IRQ_NUM, MAX(TIMER_IRQ_NUM, _ISR_OFFSET + 2)) + 1)
@@ -172,7 +168,9 @@ vth __irq_vector_table _irq_vector_table[IRQ_VECTOR_TABLE_SIZE] = {
 	[POWER_CLOCK_IRQ_NUM] = nrfx_power_clock_irq_handler,
 #endif
 	[TIMER_IRQ_NUM] = TIMER_IRQ_HANDLER,
-	[_ISR_OFFSET] = isr0, isr1, isr2,
+	[_ISR_OFFSET] = isr0,
+	isr1,
+	isr2,
 };
 #elif defined(CONFIG_SOC_SERIES_CC13X2_CC26X2) || defined(CONFIG_SOC_SERIES_CC13X2X7_CC26X2X7)
 /* TI CC13x2/CC26x2 based platforms also employ a Hardware RTC peripheral
@@ -181,13 +179,13 @@ vth __irq_vector_table _irq_vector_table[IRQ_VECTOR_TABLE_SIZE] = {
  * the custom vector table to handle the timer "tick" interrupts.
  */
 extern void rtc_isr(void);
-vth __irq_vector_table _irq_vector_table[] = {
-	isr0, isr1, isr2, 0,
-	rtc_isr
-};
-#elif (defined(CONFIG_SOC_SERIES_IMXRT6XX) || defined(CONFIG_SOC_SERIES_IMXRT5XX) ||	\
-	defined(CONFIG_SOC_SERIES_RW6XX)) && \
-	defined(CONFIG_MCUX_OS_TIMER)
+vth __irq_vector_table _irq_vector_table[] = {isr0, isr1, isr2, 0, rtc_isr};
+
+/* clang-format off */
+#elif (defined(CONFIG_SOC_SERIES_IMXRT6XX) || defined(CONFIG_SOC_SERIES_IMXRT5XX) ||               \
+	defined(CONFIG_SOC_SERIES_RW6XX)) && defined(CONFIG_MCUX_OS_TIMER)
+/* clang-format on */
+
 /* MXRT685 employs a OS Event timer to implement the Kernel system
  * timer, instead of the ARM Cortex-M SysTick. Therefore, a pointer to
  * the timer ISR needs to be added in the custom vector table to handle
@@ -196,10 +194,8 @@ vth __irq_vector_table _irq_vector_table[] = {
 extern void mcux_lpc_ostick_isr(void);
 vth __irq_vector_table _irq_vector_table[] = {
 	isr0, isr1, isr2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-	mcux_lpc_ostick_isr
-};
-#elif (defined(CONFIG_SOC_SERIES_IMXRT10XX) || defined(CONFIG_SOC_SERIES_IMXRT11XX)) && \
+	0,    0,    0,    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, mcux_lpc_ostick_isr};
+#elif (defined(CONFIG_SOC_SERIES_IMXRT10XX) || defined(CONFIG_SOC_SERIES_IMXRT11XX)) &&            \
 	defined(CONFIG_MCUX_GPT_TIMER)
 /** MXRT parts employ a GPT timer peripheral to implement the Kernel system
  * timer, instead of the ARM Cortex-M Systick. Thereforce, a pointer to the
@@ -208,12 +204,15 @@ vth __irq_vector_table _irq_vector_table[] = {
  */
 extern void mcux_imx_gpt_isr(void);
 #if defined(CONFIG_SOC_MIMXRT1011)
+/* clang-format off */
 /* RT1011 GPT timer interrupt is at offset 30 */
 vth __irq_vector_table _irq_vector_table[] = {
 	isr0, isr1, isr2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 	0, 0, 0, 0, 0, 0, 0, 0, 0, mcux_imx_gpt_isr
 };
+/* clang-format on */
 #elif defined(CONFIG_SOC_SERIES_IMXRT10XX)
+/* clang-format off */
 /* RT10xx GPT timer interrupt is at offset 100 */
 vth __irq_vector_table _irq_vector_table[] = {
 	isr0, isr1, isr2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -222,23 +221,21 @@ vth __irq_vector_table _irq_vector_table[] = {
 	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 	0, 0, 0, mcux_imx_gpt_isr
 };
+/* clang-format on */
 #elif defined(CONFIG_SOC_SERIES_IMXRT11XX)
 /* RT11xx GPT timer interrupt is at offset 119 */
 vth __irq_vector_table _irq_vector_table[] = {
-	isr0, isr1, isr2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-	mcux_imx_gpt_isr
-};
+	isr0, isr1, isr2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+	0,    0,    0,    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+	0,    0,    0,    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+	0,    0,    0,    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+	0,    0,    0,    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+	0,    0,    0,    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, mcux_imx_gpt_isr};
 #else
 #error "GPT timer enabled, but no known SOC selected. ISR table needs rework"
 #endif
 #else
-vth __irq_vector_table _irq_vector_table[] = {
-	isr0, isr1, isr2
-};
+vth __irq_vector_table _irq_vector_table[] = {isr0, isr1, isr2};
 #endif /* CONFIG_SOC_FAMILY_NORDIC_NRF */
 
 /**

--- a/tests/arch/arm/arm_irq_vector_table/src/main.c
+++ b/tests/arch/arm/arm_irq_vector_table/src/main.c
@@ -5,7 +5,7 @@
  */
 
 #if !defined(CONFIG_CPU_CORTEX_M)
-  #error project can only run on Cortex-M
+#error project can only run on Cortex-M
 #endif
 
 #include <zephyr/ztest.h>

--- a/tests/arch/arm/arm_irq_zero_latency_levels/src/main.c
+++ b/tests/arch/arm/arm_irq_zero_latency_levels/src/main.c
@@ -9,21 +9,14 @@
 #include <cmsis_core.h>
 #include <zephyr/sys/barrier.h>
 
-
 #define EXECUTION_TRACE_LENGTH 6
 
-#define IRQ_A_PRIO  1   /* lower priority */
-#define IRQ_B_PRIO  0   /* higher priority */
+#define IRQ_A_PRIO 1 /* lower priority */
+#define IRQ_B_PRIO 0 /* higher priority */
 
-
-#define CHECK_STEP(pos, val) zassert_equal(	\
-	execution_trace[pos],			\
-	val,					\
-	"Expected %s for step %d but got %s",	\
-	execution_step_str(val),		\
-	pos,					\
-	execution_step_str(execution_trace[pos]))
-
+#define CHECK_STEP(pos, val)                                                                       \
+	zassert_equal(execution_trace[pos], val, "Expected %s for step %d but got %s",             \
+		      execution_step_str(val), pos, execution_step_str(execution_trace[pos]))
 
 enum execution_step {
 	STEP_MAIN_BEGIN,
@@ -69,16 +62,12 @@ static const char *execution_step_str(enum execution_step s)
 	return res;
 }
 
-
 static void execution_trace_add(enum execution_step s)
 {
-	__ASSERT(execution_trace_pos < EXECUTION_TRACE_LENGTH,
-		 "Execution trace overflow");
+	__ASSERT(execution_trace_pos < EXECUTION_TRACE_LENGTH, "Execution trace overflow");
 	execution_trace[execution_trace_pos] = s;
 	execution_trace_pos++;
 }
-
-
 
 void isr_a_handler(const void *args)
 {
@@ -93,14 +82,12 @@ void isr_a_handler(const void *args)
 	execution_trace_add(STEP_ISR_A_END);
 }
 
-
 void isr_b_handler(const void *args)
 {
 	ARG_UNUSED(args);
 	execution_trace_add(STEP_ISR_B_BEGIN);
 	execution_trace_add(STEP_ISR_B_END);
 }
-
 
 static int find_unused_irq(int start)
 {
@@ -141,8 +128,7 @@ static int find_unused_irq(int start)
 		}
 	}
 
-	zassert_true(i >= 0,
-		     "No available IRQ line to configure as zero-latency\n");
+	zassert_true(i >= 0, "No available IRQ line to configure as zero-latency\n");
 
 	TC_PRINT("Available IRQ line: %u\n", i);
 	return i;
@@ -165,14 +151,12 @@ ZTEST(arm_irq_zero_latency_levels, test_arm_zero_latency_levels)
 	irq_b = find_unused_irq(irq_a);
 
 	/* Configure IRQ A as zero-latency interrupt with prio 1 */
-	arch_irq_connect_dynamic(irq_a, IRQ_A_PRIO, isr_a_handler,
-				 NULL, IRQ_ZERO_LATENCY);
+	arch_irq_connect_dynamic(irq_a, IRQ_A_PRIO, isr_a_handler, NULL, IRQ_ZERO_LATENCY);
 	NVIC_ClearPendingIRQ(irq_a);
 	NVIC_EnableIRQ(irq_a);
 
 	/* Configure irq_b as zero-latency interrupt with prio 0 */
-	arch_irq_connect_dynamic(irq_b, IRQ_B_PRIO, isr_b_handler,
-				 NULL, IRQ_ZERO_LATENCY);
+	arch_irq_connect_dynamic(irq_b, IRQ_B_PRIO, isr_b_handler, NULL, IRQ_ZERO_LATENCY);
 	NVIC_ClearPendingIRQ(irq_b);
 	NVIC_EnableIRQ(irq_b);
 

--- a/tests/arch/arm/arm_no_multithreading/src/main.c
+++ b/tests/arch/arm/arm_no_multithreading/src/main.c
@@ -11,7 +11,7 @@
 #include <zephyr/sys/barrier.h>
 
 #if !defined(CONFIG_CPU_CORTEX_M)
-  #error test can only run on Cortex-M MCUs
+#error test can only run on Cortex-M MCUs
 #endif
 
 #if defined(CONFIG_ARMV8_1_M_MAINLINE)
@@ -19,9 +19,9 @@
  * For ARMv8.1-M, the FPSCR[18:16] LTPSIZE field may always read 0b010 if MVE
  * is not implemented, so mask it when validating the value of the FPSCR.
  */
-#define FPSCR_MASK		(~FPU_FPDSCR_LTPSIZE_Msk)
+#define FPSCR_MASK (~FPU_FPDSCR_LTPSIZE_Msk)
 #else
-#define FPSCR_MASK		(0xffffffffU)
+#define FPSCR_MASK (0xffffffffU)
 #endif
 
 K_THREAD_STACK_DECLARE(z_main_stack, CONFIG_MAIN_STACK_SIZE);
@@ -46,8 +46,7 @@ void k_sys_fatal_error_handler(unsigned int reason, const struct arch_esf *pEsf)
 	}
 
 	if (reason != expected_reason) {
-		printk("Wrong crash type got %d expected %d\n", reason,
-			expected_reason);
+		printk("Wrong crash type got %d expected %d\n", reason, expected_reason);
 		k_fatal_halt(reason);
 	}
 
@@ -61,29 +60,22 @@ void test_main(void)
 	uint32_t psp = (uint32_t)__get_PSP();
 	uint32_t main_stack_base = (uint32_t)K_THREAD_STACK_BUFFER(z_main_stack);
 	uint32_t main_stack_top = (uint32_t)(K_THREAD_STACK_BUFFER(z_main_stack) +
-		K_THREAD_STACK_SIZEOF(z_main_stack));
+					     K_THREAD_STACK_SIZEOF(z_main_stack));
 
-	__ASSERT(
-		(psp >= main_stack_base) && (psp <= main_stack_top),
-			"PSP out of bounds: 0x%x (0x%x - 0x%x)",
-			psp, main_stack_base, main_stack_top);
+	__ASSERT((psp >= main_stack_base) && (psp <= main_stack_top),
+		 "PSP out of bounds: 0x%x (0x%x - 0x%x)", psp, main_stack_base, main_stack_top);
 
 #if defined(CONFIG_FPU)
-	__ASSERT((__get_FPSCR() & FPSCR_MASK) == 0,
-		"FPSCR not zero (0x%x)", __get_FPSCR());
+	__ASSERT((__get_FPSCR() & FPSCR_MASK) == 0, "FPSCR not zero (0x%x)", __get_FPSCR());
 #endif
 
 #if defined(CONFIG_BUILTIN_STACK_GUARD)
 	uint32_t psplim = (uint32_t)__get_PSPLIM();
-	__ASSERT(
-		(psplim == main_stack_base),
-			"PSPLIM not set to main stack base: (0x%x)",
-			psplim);
+	__ASSERT((psplim == main_stack_base), "PSPLIM not set to main stack base: (0x%x)", psplim);
 #endif
 
 	int key = arch_irq_lock();
-	__ASSERT(arch_irq_unlocked(key),
-		"IRQs locked in main()");
+	__ASSERT(arch_irq_unlocked(key), "IRQs locked in main()");
 
 	arch_irq_unlock(key);
 
@@ -136,10 +128,7 @@ void test_main(void)
 
 		printk("Available IRQ line: %u\n", i);
 
-		arch_irq_connect_dynamic(i, 0 /* highest priority */,
-			arm_isr_handler,
-			NULL,
-			0);
+		arch_irq_connect_dynamic(i, 0 /* highest priority */, arm_isr_handler, NULL, 0);
 
 		NVIC_EnableIRQ(i);
 

--- a/tests/arch/arm/arm_runtime_nmi/src/arm_runtime_nmi.c
+++ b/tests/arch/arm/arm_runtime_nmi/src/arm_runtime_nmi.c
@@ -35,7 +35,6 @@ static void nmi_test_isr(void)
  * @{
  */
 
-
 /**
  * @brief test the behavior of CONFIG_RUNTIME_NMI at run time
  *

--- a/tests/arch/arm/arm_sw_vector_relay/src/arm_sw_vector_relay.c
+++ b/tests/arch/arm/arm_sw_vector_relay/src/arm_sw_vector_relay.c
@@ -24,15 +24,12 @@ ZTEST(arm_sw_vector_relay, test_arm_sw_vector_relay)
 	 * entries for MSP and ResetHandler) point to the relay handling
 	 * function.
 	 */
-	const uint32_t *vector_relay_table_addr_val =
-		(uint32_t *)(vector_relay_table_addr);
+	const uint32_t *vector_relay_table_addr_val = (uint32_t *)(vector_relay_table_addr);
 
 	for (int i = 2; i < 16 + CONFIG_NUM_IRQS; i++) {
-		zassert_true(vector_relay_table_addr_val[i] ==
-			vector_relay_handler_func,
-			"vector relay table not pointing to the relay handler: 0x%x, 0x%x\n",
-			vector_relay_table_addr_val[i],
-			vector_relay_handler_func);
+		zassert_true(vector_relay_table_addr_val[i] == vector_relay_handler_func,
+			     "vector relay table not pointing to the relay handler: 0x%x, 0x%x\n",
+			     vector_relay_table_addr_val[i], vector_relay_handler_func);
 	}
 
 #if defined(CONFIG_CPU_CORTEX_M_HAS_VTOR)
@@ -45,25 +42,23 @@ ZTEST(arm_sw_vector_relay, test_arm_sw_vector_relay)
 	 */
 	uint32_t mask = MAX(128, Z_POW2_CEIL(4 * (16 + CONFIG_NUM_IRQS))) - 1;
 
-	zassert_true(((vector_table_addr) & mask) == 0,
-		"vector table not properly aligned: 0x%x\n",
-		vector_table_addr);
-	zassert_true(((vector_relay_table_addr) & mask) == 0,
-		"vector relay table not properly aligned: 0x%x\n",
-		vector_relay_table_addr);
+	zassert_true(((vector_table_addr)&mask) == 0, "vector table not properly aligned: 0x%x\n",
+		     vector_table_addr);
+	zassert_true(((vector_relay_table_addr)&mask) == 0,
+		     "vector relay table not properly aligned: 0x%x\n", vector_relay_table_addr);
 
 	/* Verify that the VTOR points to the real vector table,
 	 * NOT the table that contains the forwarding function.
 	 */
 	zassert_true(SCB->VTOR == (uint32_t)_vector_start,
-		"VTOR not pointing to the real vector table\n");
+		     "VTOR not pointing to the real vector table\n");
 #else
 	/* If VTOR is not present then we already need to forward interrupts
 	 * before loading any child chain-loadable image.
 	 */
 	zassert_true(_vector_table_pointer == (uint32_t)_vector_start,
-		"vector table pointer not pointing to vector start, 0x%x, 0x%x\n",
-		_vector_table_pointer, _vector_start);
+		     "vector table pointer not pointing to vector start, 0x%x, 0x%x\n",
+		     _vector_table_pointer, _vector_start);
 #endif
 }
 /**

--- a/tests/arch/arm/arm_sw_vector_relay/src/main.c
+++ b/tests/arch/arm/arm_sw_vector_relay/src/main.c
@@ -5,7 +5,7 @@
  */
 
 #if !defined(CONFIG_CPU_CORTEX_M)
-  #error test can only run on Cortex-M MCUs
+#error test can only run on Cortex-M MCUs
 #endif
 
 #include <zephyr/ztest.h>

--- a/tests/arch/arm/arm_thread_swap/src/arm_syscalls.c
+++ b/tests/arch/arm/arm_thread_swap/src/arm_syscalls.c
@@ -12,15 +12,14 @@
 #include <offsets_short_arch.h>
 #include <ksched.h>
 
-#if !defined(CONFIG_ARMV6_M_ARMV8_M_BASELINE) && \
-	!defined(CONFIG_ARMV7_M_ARMV8_M_MAINLINE)
+#if !defined(CONFIG_ARMV6_M_ARMV8_M_BASELINE) && !defined(CONFIG_ARMV7_M_ARMV8_M_MAINLINE)
 #error "Unsupported architecture"
 #endif
 
 #if defined(CONFIG_USERSPACE)
 
 #define PRIORITY 0
-#define DB_VAL 0xDEADBEEF
+#define DB_VAL   0xDEADBEEF
 
 static struct k_thread user_thread;
 static K_THREAD_STACK_DEFINE(user_thread_stack, 1024);
@@ -39,22 +38,20 @@ void z_impl_test_arm_user_syscall(void)
 	 * - MSPLIM register still guards the interrupt stack
 	 */
 	zassert_true((_current->arch.mode & CONTROL_nPRIV_Msk) == 0,
-	"mode variable not set to PRIV mode in system call\n");
+		     "mode variable not set to PRIV mode in system call\n");
 
-	zassert_false(arch_is_user_context(),
-	"arch_is_user_context() indicates nPRIV\n");
+	zassert_false(arch_is_user_context(), "arch_is_user_context() indicates nPRIV\n");
 
 	zassert_true(
 		((__get_PSP() >= _current->arch.priv_stack_start) &&
-		(__get_PSP() < (_current->arch.priv_stack_start +
-			CONFIG_PRIVILEGED_STACK_SIZE))),
-	"Process SP outside thread privileged stack limits\n");
+		 (__get_PSP() < (_current->arch.priv_stack_start + CONFIG_PRIVILEGED_STACK_SIZE))),
+		"Process SP outside thread privileged stack limits\n");
 
 #if defined(CONFIG_BUILTIN_STACK_GUARD)
 	zassert_true(__get_PSPLIM() == _current->arch.priv_stack_start,
-	"PSPLIM not guarding the thread's privileged stack\n");
+		     "PSPLIM not guarding the thread's privileged stack\n");
 	zassert_true(__get_MSPLIM() == (uint32_t)z_interrupt_stacks,
-	"MSPLIM not guarding the interrupt stack\n");
+		     "MSPLIM not guarding the interrupt stack\n");
 #endif
 }
 
@@ -63,7 +60,6 @@ static inline void z_vrfy_test_arm_user_syscall(void)
 	z_impl_test_arm_user_syscall();
 }
 #include <zephyr/syscalls/test_arm_user_syscall_mrsh.c>
-
 
 void arm_isr_handler(const void *args)
 {
@@ -79,16 +75,13 @@ void arm_isr_handler(const void *args)
 	 */
 
 	zassert_true((_current->arch.mode & CONTROL_nPRIV_Msk) != 0,
-	"mode variable not set to nPRIV mode for user thread\n");
+		     "mode variable not set to nPRIV mode for user thread\n");
 
-	zassert_false(arch_is_user_context(),
-	"arch_is_user_context() indicates nPRIV in ISR\n");
+	zassert_false(arch_is_user_context(), "arch_is_user_context() indicates nPRIV in ISR\n");
 
-	zassert_true(
-		((__get_PSP() >= _current->stack_info.start) &&
-		(__get_PSP() < (_current->stack_info.start +
-			_current->stack_info.size))),
-	"Process SP outside thread stack limits\n");
+	zassert_true(((__get_PSP() >= _current->stack_info.start) &&
+		      (__get_PSP() < (_current->stack_info.start + _current->stack_info.size))),
+		     "Process SP outside thread stack limits\n");
 
 	static int first_call = 1;
 
@@ -106,10 +99,9 @@ void arm_isr_handler(const void *args)
 		/* Second ISR run occurs after thread context-switch.
 		 * We expect PSPLIM to be clear at this point.
 		 */
-		zassert_true(__get_PSPLIM() == 0,
-		"PSPLIM not clear\n");
+		zassert_true(__get_PSPLIM() == 0, "PSPLIM not clear\n");
 		zassert_true(__get_MSPLIM() == (uint32_t)z_interrupt_stacks,
-		"MSPLIM not guarding the interrupt stack\n");
+			     "MSPLIM not guarding the interrupt stack\n");
 #endif
 		NVIC_DisableIRQ((uint32_t)args);
 	}
@@ -166,22 +158,19 @@ ZTEST(arm_thread_swap, test_arm_syscalls)
 	 * - MSPLIM register guards the interrupt stack
 	 */
 	zassert_true((_current->arch.mode & CONTROL_nPRIV_Msk) == 0,
-	"mode variable not set to PRIV mode for supervisor thread\n");
+		     "mode variable not set to PRIV mode for supervisor thread\n");
 
-	zassert_false(arch_is_user_context(),
-	"arch_is_user_context() indicates nPRIV\n");
+	zassert_false(arch_is_user_context(), "arch_is_user_context() indicates nPRIV\n");
 
-	zassert_true(
-		((__get_PSP() >= _current->stack_info.start) &&
-		(__get_PSP() < (_current->stack_info.start +
-			_current->stack_info.size))),
-	"Process SP outside thread stack limits\n");
+	zassert_true(((__get_PSP() >= _current->stack_info.start) &&
+		      (__get_PSP() < (_current->stack_info.start + _current->stack_info.size))),
+		     "Process SP outside thread stack limits\n");
 
 #if defined(CONFIG_BUILTIN_STACK_GUARD)
 	zassert_true(__get_PSPLIM() == _current->stack_info.start,
-	"PSPLIM not guarding the default stack\n");
+		     "PSPLIM not guarding the default stack\n");
 	zassert_true(__get_MSPLIM() == (uint32_t)z_interrupt_stacks,
-	"MSPLIM not guarding the interrupt stack\n");
+		     "MSPLIM not guarding the interrupt stack\n");
 #endif
 
 #if defined(CONFIG_ARMV7_M_ARMV8_M_MAINLINE)
@@ -207,15 +196,11 @@ ZTEST(arm_thread_swap, test_arm_syscalls)
 		}
 	}
 
-	zassert_true(i >= 0,
-		 "No available IRQ line to use in the test\n");
+	zassert_true(i >= 0, "No available IRQ line to use in the test\n");
 
 	TC_PRINT("Available IRQ line: %u\n", i);
 
-	arch_irq_connect_dynamic(i, 0 /* highest priority */,
-		arm_isr_handler,
-		(uint32_t *)i,
-		0);
+	arch_irq_connect_dynamic(i, 0 /* highest priority */, arm_isr_handler, (uint32_t *)i, 0);
 
 	NVIC_ClearPendingIRQ(i);
 	NVIC_EnableIRQ(i);
@@ -225,19 +210,15 @@ ZTEST(arm_thread_swap, test_arm_syscalls)
 	 * i.e. to allow the inspection of the thread state
 	 * while running in user mode.
 	 */
-	 SCB->CCR |= SCB_CCR_USERSETMPEND_Msk;
+	SCB->CCR |= SCB_CCR_USERSETMPEND_Msk;
 #endif /* CONFIG_ARMV7_M_ARMV8_M_MAINLINE*/
 
 	/* Create and switch to a user thread, passing
 	 * as argument the IRQ line to used in the test.
 	 */
-	k_thread_create(&user_thread,
-		user_thread_stack,
-		K_THREAD_STACK_SIZEOF(user_thread_stack),
-		user_thread_entry,
-		(uint32_t *)i, NULL, NULL,
-		K_PRIO_COOP(PRIORITY), K_USER,
-		K_NO_WAIT);
+	k_thread_create(&user_thread, user_thread_stack, K_THREAD_STACK_SIZEOF(user_thread_stack),
+			user_thread_entry, (uint32_t *)i, NULL, NULL, K_PRIO_COOP(PRIORITY), K_USER,
+			K_NO_WAIT);
 }
 
 void z_impl_test_arm_cpu_write_reg(void)
@@ -254,12 +235,10 @@ void z_impl_test_arm_cpu_write_reg(void)
 	 * after returning from the system call
 	 */
 	TC_PRINT("Writing 0xDEADBEEF values into registers\n");
-	__asm__ volatile (
-		"ldr r0, =0xDEADBEEF;\n\t"
-		"ldr r1, =0xDEADBEEF;\n\t"
-		"ldr r2, =0xDEADBEEF;\n\t"
-		"ldr r3, =0xDEADBEEF;\n\t"
-		);
+	__asm__ volatile("ldr r0, =0xDEADBEEF;\n\t"
+			 "ldr r1, =0xDEADBEEF;\n\t"
+			 "ldr r2, =0xDEADBEEF;\n\t"
+			 "ldr r3, =0xDEADBEEF;\n\t");
 	TC_PRINT("Exit from system call\n");
 }
 
@@ -286,15 +265,15 @@ ZTEST_USER(arm_thread_swap, test_syscall_cpu_scrubs_regs)
 
 	test_arm_cpu_write_reg();
 
-	__asm__ volatile ("mov %0, r0" : "=r"(arm_reg_val[0]));
-	__asm__ volatile ("mov %0, r1" : "=r"(arm_reg_val[1]));
-	__asm__ volatile ("mov %0, r2" : "=r"(arm_reg_val[2]));
-	__asm__ volatile ("mov %0, r3" : "=r"(arm_reg_val[3]));
+	__asm__ volatile("mov %0, r0" : "=r"(arm_reg_val[0]));
+	__asm__ volatile("mov %0, r1" : "=r"(arm_reg_val[1]));
+	__asm__ volatile("mov %0, r2" : "=r"(arm_reg_val[2]));
+	__asm__ volatile("mov %0, r3" : "=r"(arm_reg_val[3]));
 
 	for (int i = 0; i < 4; i++) {
 		zassert_not_equal(arm_reg_val[i], DB_VAL,
-				"register value is 0xDEADBEEF, "
-				"not scrubbed after system call.");
+				  "register value is 0xDEADBEEF, "
+				  "not scrubbed after system call.");
 	}
 }
 #else

--- a/tests/arch/arm/arm_thread_swap/src/arm_thread_arch.c
+++ b/tests/arch/arm/arm_thread_swap/src/arm_thread_arch.c
@@ -12,19 +12,18 @@
 #include <offsets_short_arch.h>
 #include <ksched.h>
 
-#if !defined(CONFIG_ARMV6_M_ARMV8_M_BASELINE) && \
-	!defined(CONFIG_ARMV7_M_ARMV8_M_MAINLINE)
+#if !defined(CONFIG_ARMV6_M_ARMV8_M_BASELINE) && !defined(CONFIG_ARMV7_M_ARMV8_M_MAINLINE)
 #error "Unsupported architecture"
 #endif
 
-#define PRIORITY 0
+#define PRIORITY           0
 #define BASEPRI_MODIFIED_1 0x20
 #define BASEPRI_MODIFIED_2 0x40
 #define SWAP_RETVAL        0x1234
 
 #ifndef EXC_RETURN_FTYPE
 /* bit [4] allocate stack for floating-point context: 0=done 1=skipped  */
-#define EXC_RETURN_FTYPE           (0x00000010UL)
+#define EXC_RETURN_FTYPE (0x00000010UL)
 #endif
 
 #if defined(CONFIG_ARMV8_1_M_MAINLINE)
@@ -32,9 +31,9 @@
  * For ARMv8.1-M, the FPSCR[18:16] LTPSIZE field may always read 0b010 if MVE
  * is not implemented, so mask it when validating the value of the FPSCR.
  */
-#define FPSCR_MASK		(~FPU_FPDSCR_LTPSIZE_Msk)
+#define FPSCR_MASK (~FPU_FPDSCR_LTPSIZE_Msk)
 #else
-#define FPSCR_MASK		(0xffffffffU)
+#define FPSCR_MASK (0xffffffffU)
 #endif
 
 extern void z_move_thread_to_end_of_prio_q(struct k_thread *thread);
@@ -53,75 +52,54 @@ int ztest_swap_return_val;
 /* Arbitrary values for the callee-saved registers,
  * enforced in the beginning of the test.
  */
-const _callee_saved_t ztest_thread_callee_saved_regs_init = {
-	.v1 = 0x12345678, .v2 = 0x23456789, .v3 = 0x3456789a, .v4 = 0x456789ab,
-	.v5 = 0x56789abc, .v6 = 0x6789abcd, .v7 = 0x789abcde, .v8 = 0x89abcdef
-};
+const _callee_saved_t ztest_thread_callee_saved_regs_init = {.v1 = 0x12345678,
+							     .v2 = 0x23456789,
+							     .v3 = 0x3456789a,
+							     .v4 = 0x456789ab,
+							     .v5 = 0x56789abc,
+							     .v6 = 0x6789abcd,
+							     .v7 = 0x789abcde,
+							     .v8 = 0x89abcdef};
 
 static void load_callee_saved_regs(const _callee_saved_t *regs)
 {
 	/* Load the callee-saved registers with given values */
 #if defined(CONFIG_ARMV6_M_ARMV8_M_BASELINE)
-	__asm__ volatile (
-		"mov r1, r7;\n\t"
-		"mov r0, %0;\n\t"
-		"add r0, #16;\n\t"
-		"ldmia r0!, {r4-r7};\n\t"
-		"mov r8, r4;\n\t"
-		"mov r9, r5;\n\t"
-		"mov r10, r6;\n\t"
-		"mov r11, r7;\n\t"
-		"sub r0, #32;\n\t"
-		"ldmia r0!, {r4-r7};\n\t"
-		"mov r7, r1;\n\t"
-		: /* no output */
-		: "r" (regs)
-		: "memory", "r1", "r0"
-	);
+	__asm__ volatile("mov r1, r7;\n\t"
+			 "mov r0, %0;\n\t"
+			 "add r0, #16;\n\t"
+			 "ldmia r0!, {r4-r7};\n\t"
+			 "mov r8, r4;\n\t"
+			 "mov r9, r5;\n\t"
+			 "mov r10, r6;\n\t"
+			 "mov r11, r7;\n\t"
+			 "sub r0, #32;\n\t"
+			 "ldmia r0!, {r4-r7};\n\t"
+			 "mov r7, r1;\n\t"
+			 : /* no output */
+			 : "r"(regs)
+			 : "memory", "r1", "r0");
 #elif defined(CONFIG_ARMV7_M_ARMV8_M_MAINLINE)
-	__asm__ volatile (
-		"mov r1, r7;\n\t"
-		"ldmia %0, {v1-v8};\n\t"
-		"mov r7, r1;\n\t"
-		: /* no output */
-		: "r" (regs)
-		: "memory", "r1"
-	);
+	__asm__ volatile("mov r1, r7;\n\t"
+			 "ldmia %0, {v1-v8};\n\t"
+			 "mov r7, r1;\n\t"
+			 : /* no output */
+			 : "r"(regs)
+			 : "memory", "r1");
 #endif
 	barrier_dsync_fence_full();
 }
 
-static void verify_callee_saved(const _callee_saved_t *src,
-		const _callee_saved_t *dst)
+static void verify_callee_saved(const _callee_saved_t *src, const _callee_saved_t *dst)
 {
 	/* Verify callee-saved registers are as expected */
-	zassert_true((src->v1 == dst->v1)
-			&& (src->v2 == dst->v2)
-			&& (src->v3 == dst->v3)
-			&& (src->v4 == dst->v4)
-			&& (src->v5 == dst->v5)
-			&& (src->v6 == dst->v6)
-			&& (src->v7 == dst->v7)
-			&& (src->v8 == dst->v8),
-		" got: 0x%0x 0x%0x 0x%0x 0x%0x 0x%0x 0x%0x 0x%0x 0x%0x\n"
-		" expected:  0x%0x 0x%0x 0x%0x 0x%0x 0x%0x 0x%0x 0x%0x 0x%0x\n",
-		src->v1,
-		src->v2,
-		src->v3,
-		src->v4,
-		src->v5,
-		src->v6,
-		src->v7,
-		src->v8,
-		dst->v1,
-		dst->v2,
-		dst->v3,
-		dst->v4,
-		dst->v5,
-		dst->v6,
-		dst->v7,
-		dst->v8
-	);
+	zassert_true((src->v1 == dst->v1) && (src->v2 == dst->v2) && (src->v3 == dst->v3) &&
+			     (src->v4 == dst->v4) && (src->v5 == dst->v5) && (src->v6 == dst->v6) &&
+			     (src->v7 == dst->v7) && (src->v8 == dst->v8),
+		     " got: 0x%0x 0x%0x 0x%0x 0x%0x 0x%0x 0x%0x 0x%0x 0x%0x\n"
+		     " expected:  0x%0x 0x%0x 0x%0x 0x%0x 0x%0x 0x%0x 0x%0x 0x%0x\n",
+		     src->v1, src->v2, src->v3, src->v4, src->v5, src->v6, src->v7, src->v8,
+		     dst->v1, dst->v2, dst->v3, dst->v4, dst->v5, dst->v6, dst->v7, dst->v8);
 }
 
 #if defined(CONFIG_FPU) && defined(CONFIG_FPU_SHARING)
@@ -131,85 +109,57 @@ static void verify_callee_saved(const _callee_saved_t *src,
 
 /* Arbitrary values for the floating-point callee-saved registers */
 struct _preempt_float ztest_thread_fp_callee_saved_regs = {
-	.s16 = 0x11111111, .s17 = 0x22222222,
-	.s18 = 0x33333333, .s19 = 0x44444444,
-	.s20 = 0x55555555, .s21 = 0x66666666,
-	.s22 = 0x77777777, .s23 = 0x88888888,
-	.s24 = 0x99999999, .s25 = 0xaaaaaaaa,
-	.s26 = 0xbbbbbbbb, .s27 = 0xcccccccc,
-	.s28 = 0xdddddddd, .s29 = 0xeeeeeeee,
-	.s30 = 0xffffffff, .s31 = 0x00000000,
+	.s16 = 0x11111111,
+	.s17 = 0x22222222,
+	.s18 = 0x33333333,
+	.s19 = 0x44444444,
+	.s20 = 0x55555555,
+	.s21 = 0x66666666,
+	.s22 = 0x77777777,
+	.s23 = 0x88888888,
+	.s24 = 0x99999999,
+	.s25 = 0xaaaaaaaa,
+	.s26 = 0xbbbbbbbb,
+	.s27 = 0xcccccccc,
+	.s28 = 0xdddddddd,
+	.s29 = 0xeeeeeeee,
+	.s30 = 0xffffffff,
+	.s31 = 0x00000000,
 };
 
-static void load_fp_callee_saved_regs(
-	const volatile struct _preempt_float *regs)
+static void load_fp_callee_saved_regs(const volatile struct _preempt_float *regs)
 {
-	__asm__ volatile (
-		"vldmia %0, {s16-s31};\n\t"
-		:
-		: "r" (regs)
-		: "memory"
-		);
+	__asm__ volatile("vldmia %0, {s16-s31};\n\t" : : "r"(regs) : "memory");
 	barrier_dsync_fence_full();
 }
 
 static void verify_fp_callee_saved(const struct _preempt_float *src,
-		const struct _preempt_float *dst)
+				   const struct _preempt_float *dst)
 {
 	/* Verify FP callee-saved registers are as expected */
-	zassert_true((src->s16 == dst->s16)
-			&& (src->s17 == dst->s17)
-			&& (src->s18 == dst->s18)
-			&& (src->s19 == dst->s19)
-			&& (src->s20 == dst->s20)
-			&& (src->s21 == dst->s21)
-			&& (src->s22 == dst->s22)
-			&& (src->s23 == dst->s23)
-			&& (src->s24 == dst->s24)
-			&& (src->s25 == dst->s25)
-			&& (src->s26 == dst->s26)
-			&& (src->s27 == dst->s27)
-			&& (src->s28 == dst->s28)
-			&& (src->s29 == dst->s29)
-			&& (src->s30 == dst->s30)
-			&& (src->s31 == dst->s31),
-		" got: 0x%0x 0x%0x 0x%0x 0x%0x 0x%0x 0x%0x 0x%0x 0x%0x"
-		" 0x%0x 0x%0x 0x%0x 0x%0x 0x%0x 0x%0x 0x%0x 0x%0x\n"
-		" expected:  0x%0x 0x%0x 0x%0x 0x%0x 0x%0x 0x%0x 0x%0x 0x%0x"
-		" 0x%0x 0x%0x 0x%0x 0x%0x 0x%0x 0x%0x 0x%0x 0x%0x\n",
-		(double)src->s16,
-		(double)src->s17,
-		(double)src->s18,
-		(double)src->s19,
-		(double)src->s20,
-		(double)src->s21,
-		(double)src->s22,
-		(double)src->s23,
-		(double)src->s24,
-		(double)src->s25,
-		(double)src->s26,
-		(double)src->s27,
-		(double)src->s28,
-		(double)src->s29,
-		(double)src->s30,
-		(double)src->s31,
-		(double)dst->s16,
-		(double)dst->s17,
-		(double)dst->s18,
-		(double)dst->s19,
-		(double)dst->s20,
-		(double)dst->s21,
-		(double)dst->s22,
-		(double)dst->s23,
-		(double)dst->s24,
-		(double)dst->s25,
-		(double)dst->s26,
-		(double)dst->s27,
-		(double)dst->s28,
-		(double)dst->s29,
-		(double)dst->s30,
-		(double)dst->s31
-	);
+	/* clang-format off */
+	zassert_true((src->s16 == dst->s16) &&
+		     (src->s17 == dst->s17) && (src->s18 == dst->s18) &&
+		     (src->s19 == dst->s19) && (src->s20 == dst->s20) &&
+		     (src->s21 == dst->s21) && (src->s22 == dst->s22) &&
+		     (src->s23 == dst->s23) && (src->s24 == dst->s24) &&
+		     (src->s25 == dst->s25) && (src->s26 == dst->s26) &&
+		     (src->s27 == dst->s27) && (src->s28 == dst->s28) &&
+		     (src->s29 == dst->s29) && (src->s30 == dst->s30) &&
+		     (src->s31 == dst->s31),
+		     " got: 0x%0x 0x%0x 0x%0x 0x%0x 0x%0x 0x%0x 0x%0x 0x%0x"
+		     " 0x%0x 0x%0x 0x%0x 0x%0x 0x%0x 0x%0x 0x%0x 0x%0x\n"
+		     " expected:  0x%0x 0x%0x 0x%0x 0x%0x 0x%0x 0x%0x 0x%0x 0x%0x"
+		     " 0x%0x 0x%0x 0x%0x 0x%0x 0x%0x 0x%0x 0x%0x 0x%0x\n",
+		     (double)src->s16, (double)src->s17, (double)src->s18, (double)src->s19,
+		     (double)src->s20, (double)src->s21, (double)src->s22, (double)src->s23,
+		     (double)src->s24, (double)src->s25, (double)src->s26, (double)src->s27,
+		     (double)src->s28, (double)src->s29, (double)src->s30, (double)src->s31,
+		     (double)dst->s16, (double)dst->s17, (double)dst->s18, (double)dst->s19,
+		     (double)dst->s20, (double)dst->s21, (double)dst->s22, (double)dst->s23,
+		     (double)dst->s24, (double)dst->s25, (double)dst->s26, (double)dst->s27,
+		     (double)dst->s28, (double)dst->s29, (double)dst->s30, (double)dst->s31);
+	/* clang-format on */
 }
 
 #else
@@ -226,91 +176,85 @@ static void alt_thread_entry(void *p1, void *p2, void *p3)
 	int init_flag, post_flag;
 
 	/* Lock interrupts to make sure we get preempted only when
-	 * it is required by the test */
+	 * it is required by the test
+	 */
 	(void)irq_lock();
 
 	init_flag = switch_flag;
 	zassert_true(init_flag == false,
-		"Alternative thread: switch flag not false on thread entry\n");
+		     "Alternative thread: switch flag not false on thread entry\n");
 
 	/* Set switch flag */
 	switch_flag = true;
 
 #if defined(CONFIG_NO_OPTIMIZATIONS)
 	zassert_true(p_ztest_thread->arch.basepri == 0,
-		"ztest thread basepri not preserved in swap-out\n");
+		     "ztest thread basepri not preserved in swap-out\n");
 #else
 	/* Verify that the main test thread has the correct value
 	 * for state variable thread.arch.basepri (set before swap).
 	 */
 	zassert_true(p_ztest_thread->arch.basepri == BASEPRI_MODIFIED_1,
-		"ztest thread basepri not preserved in swap-out\n");
+		     "ztest thread basepri not preserved in swap-out\n");
 
 	/* Verify original swap return value (set by arch_swap() */
 	zassert_true(p_ztest_thread->arch.swap_return_value == -EAGAIN,
-		"ztest thread swap-return-value not preserved in swap-out\n");
+		     "ztest thread swap-return-value not preserved in swap-out\n");
 #endif
 
 	/* Verify that the main test thread (ztest) has stored the callee-saved
 	 * registers properly in its corresponding callee-saved container.
 	 */
-	verify_callee_saved(
-		(const _callee_saved_t *)&p_ztest_thread->callee_saved,
-		&ztest_thread_callee_saved_regs_container);
+	verify_callee_saved((const _callee_saved_t *)&p_ztest_thread->callee_saved,
+			    &ztest_thread_callee_saved_regs_container);
 
 	/* Zero the container of the callee-saved registers, to validate,
 	 * later, that it is populated properly.
 	 */
-	memset(&ztest_thread_callee_saved_regs_container,
-		0, sizeof(_callee_saved_t));
+	memset(&ztest_thread_callee_saved_regs_container, 0, sizeof(_callee_saved_t));
 
 #if defined(CONFIG_FPU) && defined(CONFIG_FPU_SHARING)
 
 	/*  Verify that the _current_ (alt) thread is initialized with FPCA cleared. */
 	zassert_true((__get_CONTROL() & CONTROL_FPCA_Msk) == 0,
-		"CONTROL.FPCA is not cleared at initialization: 0x%x\n",
-		__get_CONTROL());
+		     "CONTROL.FPCA is not cleared at initialization: 0x%x\n", __get_CONTROL());
 
 	/* Verify that the _current_ (alt) thread is
 	 * initialized with EXC_RETURN.Ftype set
 	 */
 	zassert_true((_current->arch.mode_exc_return & EXC_RETURN_FTYPE) != 0,
-		"Alt thread FPCA flag not clear at initialization\n");
+		     "Alt thread FPCA flag not clear at initialization\n");
 #if defined(CONFIG_MPU_STACK_GUARD)
 	/* Alt thread is created with K_FP_REGS set, so we
 	 * expect lazy stacking and long guard to be enabled.
 	 */
-	zassert_true((_current->arch.mode &
-		Z_ARM_MODE_MPU_GUARD_FLOAT_Msk) != 0,
-		"Alt thread MPU GUAR DFLOAT flag not set at initialization\n");
+	zassert_true((_current->arch.mode & Z_ARM_MODE_MPU_GUARD_FLOAT_Msk) != 0,
+		     "Alt thread MPU GUAR DFLOAT flag not set at initialization\n");
 	zassert_true((_current->base.user_options & K_FP_REGS) != 0,
-		"Alt thread K_FP_REGS not set at initialization\n");
+		     "Alt thread K_FP_REGS not set at initialization\n");
 	zassert_true((FPU->FPCCR & FPU_FPCCR_LSPEN_Msk) != 0,
-		"Lazy FP Stacking not set at initialization\n");
+		     "Lazy FP Stacking not set at initialization\n");
 #endif
-
 
 	/* Verify that the _current_ (alt) thread is initialized with FPSCR cleared. */
 	zassert_true((__get_FPSCR() & FPSCR_MASK) == 0,
-		"(Alt thread) FPSCR is not cleared at initialization: 0x%x\n", __get_FPSCR());
+		     "(Alt thread) FPSCR is not cleared at initialization: 0x%x\n", __get_FPSCR());
 
 	zassert_true((p_ztest_thread->arch.mode_exc_return & EXC_RETURN_FTYPE) == 0,
-		"ztest thread mode Ftype flag not updated at swap-out: 0x%0x\n",
-		p_ztest_thread->arch.mode);
+		     "ztest thread mode Ftype flag not updated at swap-out: 0x%0x\n",
+		     p_ztest_thread->arch.mode);
 
 	/* Verify that the main test thread (ztest) has stored the FP
 	 *  callee-saved registers properly in its corresponding FP
 	 *  callee-saved container.
 	 */
-	verify_fp_callee_saved((const struct _preempt_float *)
-		&p_ztest_thread->arch.preempt_float,
-		&ztest_thread_fp_callee_saved_regs);
+	verify_fp_callee_saved((const struct _preempt_float *)&p_ztest_thread->arch.preempt_float,
+			       &ztest_thread_fp_callee_saved_regs);
 
 	/* Zero the container of the FP callee-saved registers, to validate,
 	 * later, that it is populated properly.
 	 */
-	memset(&ztest_thread_fp_callee_saved_regs,
-		0, sizeof(ztest_thread_fp_callee_saved_regs));
+	memset(&ztest_thread_fp_callee_saved_regs, 0, sizeof(ztest_thread_fp_callee_saved_regs));
 
 #endif /* CONFIG_FPU && CONFIG_FPU_SHARING */
 
@@ -336,7 +280,7 @@ static void alt_thread_entry(void *p1, void *p2, void *p3)
 	 * Note: preserve r7 register (frame pointer).
 	 */
 #if defined(CONFIG_ARMV6_M_ARMV8_M_BASELINE)
-	__asm__ volatile (
+	__asm__ volatile(
 		/* Stash r4-r11 in stack, they will be restored much later in
 		 * another inline asm -- that should be reworked since stack
 		 * must be balanced when we leave any inline asm. We could
@@ -373,21 +317,18 @@ static void alt_thread_entry(void *p1, void *p2, void *p3)
 		"pop {r0, r7};\n\t"
 
 		: /* no output */
-		: "r" (&ztest_thread_callee_saved_regs_container)
-		: "memory", "r0", "r2", "r3"
-	);
+		: "r"(&ztest_thread_callee_saved_regs_container)
+		: "memory", "r0", "r2", "r3");
 #elif defined(CONFIG_ARMV7_M_ARMV8_M_MAINLINE)
-	__asm__ volatile (
-		"push {v1-v8};\n\t"
-		"push {r0, r1};\n\t"
-		"mov r0, r7;\n\t"
-		"ldmia %0, {v1-v8};\n\t"
-		"mov r7, r0;\n\t"
-		"pop {r0, r1};\n\t"
-		: /* no output */
-		: "r" (&ztest_thread_callee_saved_regs_container)
-		: "memory", "r0"
-	);
+	__asm__ volatile("push {v1-v8};\n\t"
+			 "push {r0, r1};\n\t"
+			 "mov r0, r7;\n\t"
+			 "ldmia %0, {v1-v8};\n\t"
+			 "mov r7, r0;\n\t"
+			 "pop {r0, r1};\n\t"
+			 : /* no output */
+			 : "r"(&ztest_thread_callee_saved_regs_container)
+			 : "memory", "r0");
 #endif
 
 	/* Manually trigger a context-switch, to swap-out
@@ -399,20 +340,17 @@ static void alt_thread_entry(void *p1, void *p2, void *p3)
 
 	/* Restore stacked callee-saved registers */
 #if defined(CONFIG_ARMV6_M_ARMV8_M_BASELINE)
-	__asm__ volatile (
-		"pop {r4, r5, r6, r7};\n\t"
-		"mov r8, r4;\n\t"
-		"mov r9, r5;\n\t"
-		"mov r10, r6;\n\t"
-		"mov r11, r7;\n\t"
-		"pop {r4, r5, r6, r7};\n\t"
-		: : :
-	);
+	__asm__ volatile("pop {r4, r5, r6, r7};\n\t"
+			 "mov r8, r4;\n\t"
+			 "mov r9, r5;\n\t"
+			 "mov r10, r6;\n\t"
+			 "mov r11, r7;\n\t"
+			 "pop {r4, r5, r6, r7};\n\t"
+			 :
+			 :
+			 :);
 #elif defined(CONFIG_ARMV7_M_ARMV8_M_MAINLINE)
-	__asm__ volatile (
-		"pop {v1-v8};\n\t"
-		: : :
-	);
+	__asm__ volatile("pop {v1-v8};\n\t" : : :);
 #endif
 
 	/* Verify that the main test thread has managed to resume, before
@@ -422,7 +360,7 @@ static void alt_thread_entry(void *p1, void *p2, void *p3)
 	 */
 	post_flag = switch_flag;
 	zassert_true(post_flag == false,
-		"Alternative thread: switch flag not false on thread exit\n");
+		     "Alternative thread: switch flag not false on thread exit\n");
 }
 
 #if !defined(CONFIG_NO_OPTIMIZATIONS)
@@ -462,90 +400,77 @@ ZTEST(arm_thread_swap, test_arm_thread_swap)
 
 	/* Confirm initial conditions before starting the test. */
 	test_flag = switch_flag;
-	zassert_true(test_flag == false,
-		"Switch flag not initialized properly\n");
+	zassert_true(test_flag == false, "Switch flag not initialized properly\n");
 	zassert_true(_current->arch.basepri == 0,
-		"Thread BASEPRI flag not clear at thread start\n");
+		     "Thread BASEPRI flag not clear at thread start\n");
 	/* Verify, also, that the interrupts are unlocked. */
 #if defined(CONFIG_CPU_CORTEX_M_HAS_BASEPRI)
-	zassert_true(__get_BASEPRI() == 0,
-		"initial BASEPRI not zero\n");
+	zassert_true(__get_BASEPRI() == 0, "initial BASEPRI not zero\n");
 #else
 	/* For Cortex-M Baseline architecture, we verify that
 	 * the interrupt lock is disabled.
 	 */
-	 zassert_true(__get_PRIMASK() == 0,
-	 "initial PRIMASK not zero\n");
+	zassert_true(__get_PRIMASK() == 0, "initial PRIMASK not zero\n");
 #endif /* CONFIG_CPU_CORTEX_M_HAS_BASEPRI */
 
 #if defined(CONFIG_USERSPACE)
 	/* The main test thread is set to run in privilege mode */
 	zassert_false((arch_is_user_context()),
-		"Main test thread does not start in privilege mode\n");
+		      "Main test thread does not start in privilege mode\n");
 
 	/* Assert that the mode status variable indicates privilege mode */
 	zassert_true((_current->arch.mode & CONTROL_nPRIV_Msk) == 0,
-		"Thread nPRIV flag not clear for supervisor thread: 0x%0x\n",
-		_current->arch.mode);
+		     "Thread nPRIV flag not clear for supervisor thread: 0x%0x\n",
+		     _current->arch.mode);
 #endif /* CONFIG_USERSPACE */
 
 #if defined(CONFIG_FPU) && defined(CONFIG_FPU_SHARING)
 	/* The main test thread is not (yet) actively using the FP registers */
 	zassert_true((_current->arch.mode_exc_return & EXC_RETURN_FTYPE) != 0,
-		"Thread Ftype flag not set at initialization 0x%0x\n",
-		_current->arch.mode);
+		     "Thread Ftype flag not set at initialization 0x%0x\n", _current->arch.mode);
 
 	/* Verify that the main test thread is initialized with FPCA cleared. */
 	zassert_true((__get_CONTROL() & CONTROL_FPCA_Msk) == 0,
-		"CONTROL.FPCA is not cleared at initialization: 0x%x\n",
-		__get_CONTROL());
+		     "CONTROL.FPCA is not cleared at initialization: 0x%x\n", __get_CONTROL());
 	/* Verify that the main test thread is initialized with FPSCR cleared. */
 	zassert_true((__get_FPSCR() & FPSCR_MASK) == 0,
-		"FPSCR is not cleared at initialization: 0x%x\n", __get_FPSCR());
+		     "FPSCR is not cleared at initialization: 0x%x\n", __get_FPSCR());
 
 	/* Clear the thread's floating-point callee-saved registers' container.
 	 * The container will, later, be populated by the swap mechanism.
 	 */
-	memset(&_current->arch.preempt_float, 0,
-		sizeof(struct _preempt_float));
+	memset(&_current->arch.preempt_float, 0, sizeof(struct _preempt_float));
 
 	/* Randomize the FP callee-saved registers at test initialization */
 	load_fp_callee_saved_regs(&ztest_thread_fp_callee_saved_regs);
 
 	/* Modify bit-0 of the FPSCR - will be checked again upon swap-in. */
-	zassert_true((__get_FPSCR() & 0x1) == 0,
-		"FPSCR bit-0 has been set before testing it\n");
+	zassert_true((__get_FPSCR() & 0x1) == 0, "FPSCR bit-0 has been set before testing it\n");
 	__set_FPSCR(__get_FPSCR() | 0x1);
 
 	/* The main test thread is using the FP registers, but the .mode
 	 * flag is not updated until the next context switch.
 	 */
 	zassert_true((_current->arch.mode_exc_return & EXC_RETURN_FTYPE) != 0,
-		"Thread Ftype flag not set at initialization\n");
+		     "Thread Ftype flag not set at initialization\n");
 #if defined(CONFIG_MPU_STACK_GUARD)
-	zassert_true((_current->arch.mode &
-		Z_ARM_MODE_MPU_GUARD_FLOAT_Msk) == 0,
-		"Thread MPU GUAR DFLOAT flag not clear at initialization\n");
+	zassert_true((_current->arch.mode & Z_ARM_MODE_MPU_GUARD_FLOAT_Msk) == 0,
+		     "Thread MPU GUAR DFLOAT flag not clear at initialization\n");
 	zassert_true((_current->base.user_options & K_FP_REGS) == 0,
-		"Thread K_FP_REGS not clear at initialization\n");
+		     "Thread K_FP_REGS not clear at initialization\n");
 	zassert_true((FPU->FPCCR & FPU_FPCCR_LSPEN_Msk) == 0,
-		"Lazy FP Stacking not clear at initialization\n");
+		     "Lazy FP Stacking not clear at initialization\n");
 #endif
 #endif /* CONFIG_FPU && CONFIG_FPU_SHARING */
 
 	/* Create an alternative (supervisor) testing thread */
-	k_thread_create(&alt_thread,
-		alt_thread_stack,
-		K_THREAD_STACK_SIZEOF(alt_thread_stack),
-		alt_thread_entry,
-		NULL, NULL, NULL,
-		K_PRIO_COOP(PRIORITY), ALT_THREAD_OPTIONS,
-		K_NO_WAIT);
+	k_thread_create(&alt_thread, alt_thread_stack, K_THREAD_STACK_SIZEOF(alt_thread_stack),
+			alt_thread_entry, NULL, NULL, NULL, K_PRIO_COOP(PRIORITY),
+			ALT_THREAD_OPTIONS, K_NO_WAIT);
 
 	/* Verify context-switch has not occurred. */
 	test_flag = switch_flag;
-	zassert_true(test_flag == false,
-		"Switch flag incremented when it should not have\n");
+	zassert_true(test_flag == false, "Switch flag incremented when it should not have\n");
 
 	/* Prepare to force a context switch to the alternative thread,
 	 * by manually adding the current thread to the end of the queue,
@@ -565,8 +490,7 @@ ZTEST(arm_thread_swap, test_arm_thread_swap)
 
 	/* Verify context-switch has not occurred yet. */
 	test_flag = switch_flag;
-	zassert_true(test_flag == false,
-		"Switch flag incremented by unexpected context-switch.\n");
+	zassert_true(test_flag == false, "Switch flag incremented by unexpected context-switch.\n");
 
 	/* Store the callee-saved registers to some global memory
 	 * accessible to the alternative testing thread. That
@@ -575,27 +499,24 @@ ZTEST(arm_thread_swap, test_arm_thread_swap)
 	 * registers' container.
 	 */
 #if defined(CONFIG_ARMV6_M_ARMV8_M_BASELINE)
-	__asm__ volatile (
-		"push {r0, r1, r2, r3};\n\t"
-		"mov r1, %0;\n\t"
-		"stmia r1!, {r4-r7};\n\t"
-		"mov r2, r8;\n\t"
-		"mov r3, r9;\n\t"
-		"stmia r1!, {r2-r3};\n\t"
-		"mov r2, r10;\n\t"
-		"mov r3, r11;\n\t"
-		"stmia r1!, {r2-r3};\n\t"
-		"pop {r0, r1, r2, r3};\n\t"
-		:	: "r" (&ztest_thread_callee_saved_regs_container)
-		: "memory"
-	);
- #elif defined(CONFIG_ARMV7_M_ARMV8_M_MAINLINE)
-	__asm__ volatile (
-		"stmia %0, {v1-v8};\n\t"
-		:
-		: "r" (&ztest_thread_callee_saved_regs_container)
-		: "memory"
-	);
+	__asm__ volatile("push {r0, r1, r2, r3};\n\t"
+			 "mov r1, %0;\n\t"
+			 "stmia r1!, {r4-r7};\n\t"
+			 "mov r2, r8;\n\t"
+			 "mov r3, r9;\n\t"
+			 "stmia r1!, {r2-r3};\n\t"
+			 "mov r2, r10;\n\t"
+			 "mov r3, r11;\n\t"
+			 "stmia r1!, {r2-r3};\n\t"
+			 "pop {r0, r1, r2, r3};\n\t"
+			 :
+			 : "r"(&ztest_thread_callee_saved_regs_container)
+			 : "memory");
+#elif defined(CONFIG_ARMV7_M_ARMV8_M_MAINLINE)
+	__asm__ volatile("stmia %0, {v1-v8};\n\t"
+			 :
+			 : "r"(&ztest_thread_callee_saved_regs_container)
+			 : "memory");
 #endif
 
 	/* Manually trigger a context-switch to swap-out the current thread.
@@ -608,7 +529,7 @@ ZTEST(arm_thread_swap, test_arm_thread_swap)
 	irq_unlock(0);
 	/* The thread is now swapped-back in. */
 
-#else/* CONFIG_NO_OPTIMIZATIONS */
+#else /* CONFIG_NO_OPTIMIZATIONS */
 
 	/* Fake a different irq_unlock key when performing swap.
 	 * This will be verified by the alternative test thread.
@@ -622,27 +543,24 @@ ZTEST(arm_thread_swap, test_arm_thread_swap)
 
 	/* Dump callee-saved registers to memory. */
 #if defined(CONFIG_ARMV6_M_ARMV8_M_BASELINE)
-	__asm__ volatile (
-		"push {r0, r1, r2, r3};\n\t"
-		"mov r1, %0;\n\t"
-		"stmia r1!, {r4-r7};\n\t"
-		"mov r2, r8;\n\t"
-		"mov r3, r9;\n\t"
-		"stmia r1!, {r2-r3};\n\t"
-		"mov r2, r10;\n\t"
-		"mov r3, r11;\n\t"
-		"stmia r1!, {r2-r3};\n\t"
-		"pop {r0, r1, r2, r3};\n\t"
-		:	: "r" (&ztest_thread_callee_saved_regs_container)
-		: "memory"
-	);
- #elif defined(CONFIG_ARMV7_M_ARMV8_M_MAINLINE)
-	__asm__ volatile (
-		"stmia %0, {v1-v8};\n\t"
-		:
-		: "r" (&ztest_thread_callee_saved_regs_container)
-		: "memory"
-	);
+	__asm__ volatile("push {r0, r1, r2, r3};\n\t"
+			 "mov r1, %0;\n\t"
+			 "stmia r1!, {r4-r7};\n\t"
+			 "mov r2, r8;\n\t"
+			 "mov r3, r9;\n\t"
+			 "stmia r1!, {r2-r3};\n\t"
+			 "mov r2, r10;\n\t"
+			 "mov r3, r11;\n\t"
+			 "stmia r1!, {r2-r3};\n\t"
+			 "pop {r0, r1, r2, r3};\n\t"
+			 :
+			 : "r"(&ztest_thread_callee_saved_regs_container)
+			 : "memory");
+#elif defined(CONFIG_ARMV7_M_ARMV8_M_MAINLINE)
+	__asm__ volatile("stmia %0, {v1-v8};\n\t"
+			 :
+			 : "r"(&ztest_thread_callee_saved_regs_container)
+			 : "memory");
 #endif
 
 #if !defined(CONFIG_NO_OPTIMIZATIONS)
@@ -652,38 +570,30 @@ ZTEST(arm_thread_swap, test_arm_thread_swap)
 	 * used, as base register in the Store Multiple instruction.
 	 * We also enforce write-back to suppress assembler warning.
 	 */
-	__asm__ volatile (
-		"push {r0, r1, r2, r3, r4, r5, r6, r7};\n\t"
-		"stm %0!, {%1};\n\t"
-		"pop {r0, r1, r2, r3, r4, r5, r6, r7};\n\t"
-		:
-		: "r" (&ztest_swap_return_val), "r" (swap_return_val)
-		: "memory"
-	);
+	__asm__ volatile("push {r0, r1, r2, r3, r4, r5, r6, r7};\n\t"
+			 "stm %0!, {%1};\n\t"
+			 "pop {r0, r1, r2, r3, r4, r5, r6, r7};\n\t"
+			 :
+			 : "r"(&ztest_swap_return_val), "r"(swap_return_val)
+			 : "memory");
 #elif defined(CONFIG_ARMV7_M_ARMV8_M_MAINLINE)
-	__asm__ volatile (
-		"stm %0, {%1};\n\t"
-		:
-		: "r" (&ztest_swap_return_val), "r" (swap_return_val)
-		: "memory"
-	);
+	__asm__ volatile("stm %0, {%1};\n\t"
+			 :
+			 : "r"(&ztest_swap_return_val), "r"(swap_return_val)
+			 : "memory");
 #endif /* CONFIG_ARMV6_M_ARMV8_M_BASELINE */
 #endif
-
 
 	/* After swap-back, verify that the callee-saved registers loaded,
 	 * look exactly as what is located in the respective callee-saved
 	 * container of the thread.
 	 */
-	verify_callee_saved(
-		&ztest_thread_callee_saved_regs_container,
-		&_current->callee_saved);
+	verify_callee_saved(&ztest_thread_callee_saved_regs_container, &_current->callee_saved);
 
 	/* Verify context-switch did occur. */
 	test_flag = switch_flag;
-	zassert_true(test_flag == true,
-		"Switch flag not incremented as expected %u\n",
-		switch_flag);
+	zassert_true(test_flag == true, "Switch flag not incremented as expected %u\n",
+		     switch_flag);
 	/* Clear the switch flag to signal that the main test thread
 	 * has been successfully swapped-in, as expected by the test.
 	 */
@@ -694,71 +604,63 @@ ZTEST(arm_thread_swap, test_arm_thread_swap)
 	 * is now switched back in.
 	 */
 	zassert_true(_current->arch.basepri == 0,
-		"arch.basepri value not in accordance with the update\n");
+		     "arch.basepri value not in accordance with the update\n");
 
 #if defined(CONFIG_CPU_CORTEX_M_HAS_BASEPRI)
 	/* Verify that the BASEPRI register is updated during the last
 	 * swap-in of the thread.
 	 */
 	zassert_true(__get_BASEPRI() == BASEPRI_MODIFIED_2,
-		"BASEPRI not in accordance with the update: 0x%0x\n",
-		__get_BASEPRI());
+		     "BASEPRI not in accordance with the update: 0x%0x\n", __get_BASEPRI());
 #else
 	/* For Cortex-M Baseline architecture, we verify that
 	 * the interrupt lock is enabled.
 	 */
-	 zassert_true(__get_PRIMASK() != 0,
-	 "PRIMASK not in accordance with the update: 0x%0x\n",
-	 __get_PRIMASK());
+	zassert_true(__get_PRIMASK() != 0, "PRIMASK not in accordance with the update: 0x%0x\n",
+		     __get_PRIMASK());
 #endif /* CONFIG_CPU_CORTEX_M_HAS_BASEPRI */
 
 #if !defined(CONFIG_NO_OPTIMIZATIONS)
 	/* The thread is now swapped-back in. */
 	zassert_equal(_current->arch.swap_return_value, SWAP_RETVAL,
-		"Swap value not set as expected: 0x%x (0x%x)\n",
-		_current->arch.swap_return_value, SWAP_RETVAL);
+		      "Swap value not set as expected: 0x%x (0x%x)\n",
+		      _current->arch.swap_return_value, SWAP_RETVAL);
 	zassert_equal(_current->arch.swap_return_value, ztest_swap_return_val,
-		"Swap value not returned as expected 0x%x (0x%x)\n",
-		_current->arch.swap_return_value, ztest_swap_return_val);
+		      "Swap value not returned as expected 0x%x (0x%x)\n",
+		      _current->arch.swap_return_value, ztest_swap_return_val);
 #endif
 
 #if defined(CONFIG_FPU) && defined(CONFIG_FPU_SHARING)
 	/* Dump callee-saved registers to memory. */
-	__asm__ volatile (
-		"vstmia %0, {s16-s31};\n\t"
-		:
-		: "r" (&ztest_thread_fp_callee_saved_regs)
-		: "memory"
-	);
+	__asm__ volatile("vstmia %0, {s16-s31};\n\t"
+			 :
+			 : "r"(&ztest_thread_fp_callee_saved_regs)
+			 : "memory");
 
 	/* After swap-back, verify that the FP callee-saved registers loaded,
 	 * look exactly as what is located in the respective FP callee-saved
 	 * container of the thread.
 	 */
-	verify_fp_callee_saved(
-		&ztest_thread_fp_callee_saved_regs,
-		&_current->arch.preempt_float);
+	verify_fp_callee_saved(&ztest_thread_fp_callee_saved_regs, &_current->arch.preempt_float);
 
 	/* Verify that the main test thread restored the FPSCR bit-0. */
-	zassert_true((__get_FPSCR() & 0x1) == 0x1,
-		"FPSCR bit-0 not restored at swap: 0x%x\n", __get_FPSCR());
+	zassert_true((__get_FPSCR() & 0x1) == 0x1, "FPSCR bit-0 not restored at swap: 0x%x\n",
+		     __get_FPSCR());
 
 	/* The main test thread is using the FP registers, and the .mode
 	 * flag and MPU GUARD flag are now updated.
 	 */
 	zassert_true((_current->arch.mode_exc_return & EXC_RETURN_FTYPE) == 0,
-		"Thread Ftype flag not cleared after main returned back\n");
+		     "Thread Ftype flag not cleared after main returned back\n");
 #if defined(CONFIG_MPU_STACK_GUARD)
-	zassert_true((_current->arch.mode &
-		Z_ARM_MODE_MPU_GUARD_FLOAT_Msk) != 0,
-		"Thread MPU GUARD FLOAT flag not set\n");
+	zassert_true((_current->arch.mode & Z_ARM_MODE_MPU_GUARD_FLOAT_Msk) != 0,
+		     "Thread MPU GUARD FLOAT flag not set\n");
 	zassert_true((_current->base.user_options & K_FP_REGS) != 0,
-		"Thread K_FPREGS not set after main returned back\n");
+		     "Thread K_FPREGS not set after main returned back\n");
 	zassert_true((FPU->FPCCR & FPU_FPCCR_LSPEN_Msk) != 0,
-		"Lazy FP Stacking not set after main returned back\n");
+		     "Lazy FP Stacking not set after main returned back\n");
 #endif
 #endif /* CONFIG_FPU && CONFIG_FPU_SHARING */
-
 }
 /**
  * @}

--- a/tests/arch/arm/arm_thread_swap_tz/src/main.c
+++ b/tests/arch/arm/arm_thread_swap_tz/src/main.c
@@ -10,7 +10,7 @@
 
 #ifndef EXC_RETURN_S
 /* bit [6] stack used to push registers: 0=Non-secure 1=Secure */
-#define EXC_RETURN_S               (0x00000040UL)
+#define EXC_RETURN_S (0x00000040UL)
 #endif
 
 #define HASH_LEN 32
@@ -27,8 +27,8 @@ static void do_hash(char *hash)
 	size_t len;
 
 	/* Calculate correct hash. */
-	psa_status_t status = psa_hash_compute(PSA_ALG_SHA_256, dummy_string,
-			sizeof(dummy_string), hash, HASH_LEN, &len);
+	psa_status_t status = psa_hash_compute(PSA_ALG_SHA_256, dummy_string, sizeof(dummy_string),
+					       hash, HASH_LEN, &len);
 
 	zassert_equal(PSA_SUCCESS, status, "psa_hash_compute_fail: %d\n", status);
 	zassert_equal(HASH_LEN, len, "hash length not correct\n");
@@ -39,12 +39,12 @@ static void work_func(struct k_work *work)
 #ifdef CONFIG_ARM_NONSECURE_PREEMPTIBLE_SECURE_CALLS
 	/* Check that the main thread was executing in secure mode. */
 	zassert_true(main_thread->arch.mode_exc_return & EXC_RETURN_S,
-		"EXC_RETURN not secure: 0x%x\n", main_thread->arch.mode_exc_return);
+		     "EXC_RETURN not secure: 0x%x\n", main_thread->arch.mode_exc_return);
 
 #else
 	/* Check that the main thread was executing in nonsecure mode. */
 	zassert_false(main_thread->arch.mode_exc_return & EXC_RETURN_S,
-		"EXC_RETURN not nonsecure: 0x%x\n", main_thread->arch.mode_exc_return);
+		      "EXC_RETURN not nonsecure: 0x%x\n", main_thread->arch.mode_exc_return);
 #endif
 
 	work_done = true;
@@ -54,27 +54,23 @@ static void work_func(struct k_work *work)
 	 */
 #ifdef CONFIG_CPU_HAS_FPU
 	uint32_t clobber_val[16] = {
-		0xdeadbee0, 0xdeadbee1, 0xdeadbee2, 0xdeadbee3,
-		0xdeadbee4, 0xdeadbee5, 0xdeadbee6, 0xdeadbee7,
-		0xdeadbee8, 0xdeadbee9, 0xdeadbeea, 0xdeadbeeb,
+		0xdeadbee0, 0xdeadbee1, 0xdeadbee2, 0xdeadbee3, 0xdeadbee4, 0xdeadbee5,
+		0xdeadbee6, 0xdeadbee7, 0xdeadbee8, 0xdeadbee9, 0xdeadbeea, 0xdeadbeeb,
 		0xdeadbeec, 0xdeadbeed, 0xdeadbeee, 0xdeadbeef,
 	};
 
-	__asm__ volatile(
-		"vldmia %0, {s0-s15}\n"
-		"vldmia %0, {s16-s31}\n"
-		:: "r" (clobber_val) :
-	);
+	__asm__ volatile("vldmia %0, {s0-s15}\n"
+			 "vldmia %0, {s16-s31}\n" ::"r"(clobber_val)
+			 :);
 #endif /* CONFIG_CPU_HAS_FPU */
 
 	/* Call a secure service here as well, to test the added complexity of
 	 * calling secure services from two threads.
 	 */
-	psa_status_t status = psa_hash_compare(PSA_ALG_SHA_256, dummy_string,
-			sizeof(dummy_string), dummy_digest_correct, HASH_LEN);
+	psa_status_t status = psa_hash_compare(PSA_ALG_SHA_256, dummy_string, sizeof(dummy_string),
+					       dummy_digest_correct, HASH_LEN);
 
 	zassert_equal(PSA_SUCCESS, status, "psa_hash_compare failed\n");
-
 }
 
 ZTEST(thread_swap_tz, test_thread_swap_tz)
@@ -108,25 +104,22 @@ ZTEST(thread_swap_tz, test_thread_swap_tz)
 	 */
 #ifdef CONFIG_CPU_HAS_FPU
 	uint32_t test_val0[16] = {
-		0x1a2b3c40, 0x1a2b3c41, 0x1a2b3c42, 0x1a2b3c43,
-		0x1a2b3c44, 0x1a2b3c45, 0x1a2b3c46, 0x1a2b3c47,
-		0x1a2b3c48, 0x1a2b3c49, 0x1a2b3c4a, 0x1a2b3c4b,
+		0x1a2b3c40, 0x1a2b3c41, 0x1a2b3c42, 0x1a2b3c43, 0x1a2b3c44, 0x1a2b3c45,
+		0x1a2b3c46, 0x1a2b3c47, 0x1a2b3c48, 0x1a2b3c49, 0x1a2b3c4a, 0x1a2b3c4b,
 		0x1a2b3c4c, 0x1a2b3c4d, 0x1a2b3c4e, 0x1a2b3c4f,
 	};
 	uint32_t test_val1[16] = {
-		0x2b3c4d50, 0x2b3c4d51, 0x2b3c4d52, 0x2b3c4d53,
-		0x2b3c4d54, 0x2b3c4d55, 0x2b3c4d56, 0x2b3c4d57,
-		0x2b3c4d58, 0x2b3c4d59, 0x2b3c4d5a, 0x2b3c4d5b,
+		0x2b3c4d50, 0x2b3c4d51, 0x2b3c4d52, 0x2b3c4d53, 0x2b3c4d54, 0x2b3c4d55,
+		0x2b3c4d56, 0x2b3c4d57, 0x2b3c4d58, 0x2b3c4d59, 0x2b3c4d5a, 0x2b3c4d5b,
 		0x2b3c4d5c, 0x2b3c4d5d, 0x2b3c4d5e, 0x2b3c4d5f,
 	};
 	uint32_t test_val_res0[16];
 	uint32_t test_val_res1[16];
 
-	__asm__ volatile(
-		"vldmia %0, {s0-s15}\n"
-		"vldmia %1, {s16-s31}\n"
-		:: "r" (test_val0), "r" (test_val1) :
-	);
+	__asm__ volatile("vldmia %0, {s0-s15}\n"
+			 "vldmia %1, {s16-s31}\n" ::"r"(test_val0),
+			 "r"(test_val1)
+			 :);
 
 #endif /* CONFIG_CPU_HAS_FPU */
 
@@ -135,11 +128,10 @@ ZTEST(thread_swap_tz, test_thread_swap_tz)
 	zassert_true(work_done, "Interrupting work never happened\n");
 
 #ifdef CONFIG_CPU_HAS_FPU
-	__asm__ volatile(
-		"vstmia %0, {s0-s15}\n"
-		"vstmia %1, {s16-s31}\n"
-		:: "r" (test_val_res0), "r" (test_val_res1) :
-	);
+	__asm__ volatile("vstmia %0, {s0-s15}\n"
+			 "vstmia %1, {s16-s31}\n" ::"r"(test_val_res0),
+			 "r"(test_val_res1)
+			 :);
 
 	zassert_mem_equal(dummy_digest, dummy_digest_correct, HASH_LEN, NULL);
 	zassert_mem_equal(test_val0, test_val_res0, sizeof(test_val0), NULL);

--- a/tests/arch/arm/arm_tz_wrap_func/src/main.c
+++ b/tests/arch/arm/arm_tz_wrap_func/src/main.c
@@ -33,7 +33,6 @@ void reset_mocks(void)
 	foo1_arg4 = 0;
 }
 
-
 void preface(void)
 {
 	zassert_true(expect_preface, "%s unexpectedly called", __func__);
@@ -42,12 +41,10 @@ void preface(void)
 	expect_foo1 = true;
 }
 
-
 uint32_t foo1(uint32_t arg1, uint32_t arg2, uint32_t arg3, uint32_t arg4)
 {
 	zassert_true(expect_foo1, "%s unexpectedly called", __func__);
-	zassert_equal(arg1, foo1_arg1, "Was 0x%"PRIx32", expected 0x%"PRIx32,
-		arg1, foo1_arg1);
+	zassert_equal(arg1, foo1_arg1, "Was 0x%" PRIx32 ", expected 0x%" PRIx32, arg1, foo1_arg1);
 	zassert_equal(arg2, foo1_arg2);
 	zassert_equal(arg3, foo1_arg3);
 	zassert_equal(arg4, foo1_arg4);
@@ -57,7 +54,6 @@ uint32_t foo1(uint32_t arg1, uint32_t arg2, uint32_t arg3, uint32_t arg4)
 	return foo1_retval;
 }
 
-
 void postface(void)
 {
 	zassert_true(expect_postface, "%s unexpectedly called", __func__);
@@ -65,13 +61,11 @@ void postface(void)
 	postface_called = true;
 }
 
-
-uint32_t __attribute__((naked)) wrap_foo1(uint32_t arg1, uint32_t arg2,
-				uint32_t arg3, uint32_t arg4)
+uint32_t __attribute__((naked)) wrap_foo1(uint32_t arg1, uint32_t arg2, uint32_t arg3,
+					  uint32_t arg4)
 {
 	__TZ_WRAP_FUNC(preface, foo1, postface);
 }
-
 
 ZTEST(tz_wrap_func, test_tz_wrap_func)
 {
@@ -86,8 +80,7 @@ ZTEST(tz_wrap_func, test_tz_wrap_func)
 	msp1 = __get_MSP();
 	psp1 = __get_PSP();
 
-	zassert_equal(foo1_retval,
-		wrap_foo1(foo1_arg1, foo1_arg2, foo1_arg3, foo1_arg4), NULL);
+	zassert_equal(foo1_retval, wrap_foo1(foo1_arg1, foo1_arg2, foo1_arg3, foo1_arg4), NULL);
 
 	zassert_equal(msp1, __get_MSP());
 	zassert_equal(psp1, __get_PSP());


### PR DESCRIPTION
This commit updates cortex_m related code to align it with the rules from .clang-format. This is done to simplify future changes in these files as we are about to implement use_switch support.

Some rules conflict with checkpatch or generate terrible layout and therefore some small part of the code locally disable clang-format.