### PR TITLE
dts: bindings: video: st,stm32-dcmi: update to use video interface

### DIFF
--- a/boards/arduino/nicla_vision/arduino_nicla_vision_stm32h747xx_m7.dts
+++ b/boards/arduino/nicla_vision/arduino_nicla_vision_stm32h747xx_m7.dts
@@ -225,7 +225,7 @@ zephyr_udc0: &usbotg_hs {
 
 		port {
 			gc2145_ep_out: endpoint {
-				remote-endpoint = <&dcmi_ep_in>;
+				remote-endpoint-label = "dcmi_ep_in";
 			};
 		};
 
@@ -241,10 +241,6 @@ zephyr_udc0: &usbotg_hs {
 	status = "okay";
 
 	sensor = <&gc2145>;
-	bus-width = <8>;
-	hsync-active = <0>;
-	vsync-active = <0>;
-	pixelclk-active = <0>;
 	capture-rate = <1>;
 	dmas = <&dma1 0 38 (STM32_DMA_PERIPH_TO_MEMORY | STM32_DMA_PERIPH_NO_INC |
 		STM32_DMA_MEM_INC | STM32_DMA_PERIPH_8BITS | STM32_DMA_MEM_32BITS |
@@ -252,7 +248,11 @@ zephyr_udc0: &usbotg_hs {
 
 	port {
 		dcmi_ep_in: endpoint {
-			remote-endpoint = <&gc2145_ep_out>;
+			remote-endpoint-label = "gc2145_ep_out";
+			bus-width = <8>;
+			hsync-active = <0>;
+			vsync-active = <0>;
+			pclk-sample = <0>;
 		};
 	};
 };

--- a/boards/shields/st_b_cams_omv_mb1683/st_b_cams_omv_mb1683.overlay
+++ b/boards/shields/st_b_cams_omv_mb1683/st_b_cams_omv_mb1683.overlay
@@ -35,15 +35,15 @@
 	status = "okay";
 	sensor = <&ov5640>;
 
-	bus-width = <8>;
-	hsync-active = <0>;
-	vsync-active = <0>;
-	pixelclk-active = <1>;
 	capture-rate = <1>;
 
 	port {
 		dcmi_ep_in: endpoint {
 			remote-endpoint-label = "ov5640_ep_out";
+			bus-width = <8>;
+			hsync-active = <0>;
+			vsync-active = <0>;
+			pclk-sample = <1>;
 		};
 	};
 };

--- a/boards/shields/weact_ov2640_cam_module/boards/mini_stm32h743.overlay
+++ b/boards/shields/weact_ov2640_cam_module/boards/mini_stm32h743.overlay
@@ -37,14 +37,14 @@
 	pinctrl-names = "default";
 };
 
-&zephyr_camera_i2c {
+&st_cam_i2c {
 	ov2640: ov2640@30 {
 		supply-gpios = <&dcmi_camera_connector 8 GPIO_ACTIVE_HIGH>;
 		clock-rate-control = <0x80>;
 	};
 };
 
-&zephyr_camera_dvp {
+&st_cam_dvp {
 	dmas = <&dma1 0 75 (STM32_DMA_PERIPH_TO_MEMORY | STM32_DMA_PERIPH_NO_INC |
 		STM32_DMA_MEM_INC | STM32_DMA_PERIPH_8BITS | STM32_DMA_MEM_32BITS |
 		STM32_DMA_PRIORITY_HIGH) STM32_DMA_FIFO_1_4>;

--- a/boards/shields/weact_ov2640_cam_module/weact_ov2640_cam_module.overlay
+++ b/boards/shields/weact_ov2640_cam_module/weact_ov2640_cam_module.overlay
@@ -6,11 +6,11 @@
 
 / {
 	chosen {
-		zephyr,camera = &zephyr_camera_dvp;
+		zephyr,camera = &st_cam_dvp;
 	};
 };
 
-&zephyr_camera_i2c {
+&st_cam_i2c {
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 
@@ -21,24 +21,24 @@
 
 		port {
 			ov2640_ep_out: endpoint {
-				remote-endpoint = <&zephyr_camera_dvp_in>;
+				remote-endpoint-label = "dcmi_ep_in";
 			};
 		};
 	};
 };
 
-&zephyr_camera_dvp {
+&st_cam_dvp {
 	status = "okay";
 	sensor = <&ov2640>;
-	bus-width = <8>;
-	hsync-active = <0>;
-	vsync-active = <0>;
-	pixelclk-active = <1>;
 	capture-rate = <1>;
 
 	port {
-		zephyr_camera_dvp_in: endpoint {
-			remote-endpoint = <&ov2640_ep_out>;
+		dcmi_ep_in: endpoint {
+			remote-endpoint-label = "ov2640_ep_out";
+			bus-width = <8>;
+			hsync-active = <0>;
+			vsync-active = <0>;
+			pclk-sample = <1>;
 		};
 	};
 };

--- a/boards/weact/mini_stm32h743/mini_stm32h743.dts
+++ b/boards/weact/mini_stm32h743/mini_stm32h743.dts
@@ -240,12 +240,12 @@ zephyr_udc0: &usbotg_fs {
 	status = "okay";
 };
 
-zephyr_camera_i2c: &i2c1 {
+st_cam_i2c: &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
 };
 
-zephyr_camera_dvp: &dcmi {
+st_cam_dvp: &dcmi {
 	pinctrl-0 = <&dcmi_hsync_pa4 &dcmi_pixclk_pa6 &dcmi_vsync_pb7
 		     &dcmi_d0_pc6 &dcmi_d1_pc7 &dcmi_d2_pe0 &dcmi_d3_pe1
 		     &dcmi_d4_pe4 &dcmi_d5_pd3 &dcmi_d6_pe5 &dcmi_d7_pe6>;

--- a/drivers/video/video_stm32_dcmi.c
+++ b/drivers/video/video_stm32_dcmi.c
@@ -444,16 +444,16 @@ static struct video_stm32_dcmi_data video_stm32_dcmi_data_0 = {
 		.Instance = (DCMI_TypeDef *) DT_INST_REG_ADDR(0),
 		.Init = {
 				.SynchroMode = DCMI_SYNCHRO_HARDWARE,
-				.PCKPolarity = (DT_INST_PROP(0, pixelclk_active) ?
+				.PCKPolarity = (DT_PROP(DT_CHILD(DT_INST_CHILD(0, port), endpoint), pclk_sample) ?
 						DCMI_PCKPOLARITY_RISING : DCMI_PCKPOLARITY_FALLING),
-				.HSPolarity = (DT_INST_PROP(0, hsync_active) ?
+				.HSPolarity = (DT_PROP(DT_CHILD(DT_INST_CHILD(0, port), endpoint), hsync_active) ?
 						DCMI_HSPOLARITY_HIGH : DCMI_HSPOLARITY_LOW),
-				.VSPolarity = (DT_INST_PROP(0, vsync_active) ?
+				.VSPolarity = (DT_PROP(DT_CHILD(DT_INST_CHILD(0, port), endpoint), vsync_active) ?
 						DCMI_VSPOLARITY_HIGH : DCMI_VSPOLARITY_LOW),
 				.CaptureRate = STM32_DCMI_GET_CAPTURE_RATE(
 							DT_INST_PROP(0, capture_rate)),
 				.ExtendedDataMode = STM32_DCMI_GET_BUS_WIDTH(
-							DT_INST_PROP(0, bus_width)),
+						DT_PROP(DT_CHILD(DT_INST_CHILD(0, port), endpoint), bus_width)),
 				.JPEGMode = DCMI_JPEG_DISABLE,
 				.ByteSelectMode = DCMI_BSM_ALL,
 				.ByteSelectStart = DCMI_OEBS_ODD,

--- a/dts/bindings/video/st,stm32-dcmi.yaml
+++ b/dts/bindings/video/st,stm32-dcmi.yaml
@@ -15,10 +15,6 @@ description: |
                   &dcmi_d0_pc6 &dcmi_d1_pc7 &dcmi_d2_pe0 &dcmi_d3_pe1
                   &dcmi_d4_pe4 &dcmi_d5_pd3 &dcmi_d6_pe5 &dcmi_d7_pe6>;
       pinctrl-names = "default";
-      bus-width = <8>;
-      hsync-active = <0>;
-      vsync-active = <0>;
-      pixelclk-active = <1>;
       capture-rate = <1>;
       dmas = <&dma1 0 75 (STM32_DMA_PERIPH_TO_MEMORY | STM32_DMA_PERIPH_NO_INC |
               STM32_DMA_MEM_INC | STM32_DMA_PERIPH_8BITS | STM32_DMA_MEM_32BITS |
@@ -26,7 +22,11 @@ description: |
 
       port {
         dcmi_ep_in: endpoint {
-          remote-endpoint = <&ov2640_ep_out>;
+          remote-endpoint-label = "ov2640_ep_out";
+          bus-width = <8>;
+          hsync-active = <0>;
+          vsync-active = <0>;
+          pclk-sample = <1>;
         };
       };
     };
@@ -43,59 +43,6 @@ properties:
     required: true
     type: phandle
     description: phandle of connected sensor device
-
-  bus-width:
-    type: int
-    required: true
-    enum:
-      - 8
-      - 10
-      - 12
-      - 14
-    default: 8
-    description: |
-      Number of data lines actively used, valid for the parallel busses.
-
-  hsync-active:
-    type: int
-    required: true
-    enum:
-      - 0
-      - 1
-    description: |
-      Polarity of horizontal synchronization (DCMI_HSYNC_Polarity).
-      0 Horizontal synchronization active Low.
-      1 Horizontal synchronization active High.
-
-      For example, if DCMI_HSYNC_Polarity is programmed active high:
-      When HSYNC is low, the data is valid.
-      When HSYNC is high, the data is not valid (horizontal blanking).
-
-  vsync-active:
-    type: int
-    required: true
-    enum:
-      - 0
-      - 1
-    description: |
-      Polarity of vertical synchronization (DCMI_VSYNC_Polarity).
-      0 Vertical synchronization active Low.
-      1 Vertical synchronization active High.
-
-      For example, if DCMI_VSYNC_Polarity is programmed active high:
-      When VSYNC is low, the data is valid.
-      When VSYNC is high, the data is not valid (vertical blanking).
-
-  pixelclk-active:
-    type: int
-    required: true
-    enum:
-      - 0
-      - 1
-    description: |
-      Polarity of pixel clock (DCMI_PIXCK_Polarity).
-      0 Pixel clock active on Falling edge.
-      1 Pixel clock active on Rising edge.
 
   capture-rate:
     type: int
@@ -121,3 +68,7 @@ properties:
       dmas = <&dma1 0 75 (STM32_DMA_PERIPH_TO_MEMORY | STM32_DMA_PERIPH_NO_INC |
               STM32_DMA_MEM_INC | STM32_DMA_PERIPH_8BITS | STM32_DMA_MEM_32BITS |
               STM32_DMA_PRIORITY_HIGH) STM32_DMA_FIFO_1_4>;
+
+child-binding:
+    child-binding:
+      include: video-interfaces.yaml


### PR DESCRIPTION
Update the `st,stm32-dcmi.yaml` to use the common properties defined in `video-interfaces.yaml`.

@ngphibang @josuah @erwango, is it possible to add the `capture-rate` property into `video-interfaces.yaml`?

@uLipe, this PR updates the `zephyr/boards/arduino/nicla_vision/arduino_nicla_vision_stm32h747xx_m7.dts`.

Issue : https://github.com/zephyrproject-rtos/zephyr/issues/80514