### PR TITLE
SRAM cache fix (and loader workaround) for mt8196

### DIFF
--- a/soc/mediatek/mt8xxx/mtk_adsp_load.py
+++ b/soc/mediatek/mt8xxx/mtk_adsp_load.py
@@ -277,7 +277,13 @@ def find_winstream(maps):
     magic = b'\x74\x5f\x6a\xd0\x79\xe2\x4f\x00\xcd\xb8\xbd\xf9'
     for m in maps:
         if "dram" in m:
-            magoff = maps[m].find(magic)
+            # Some python versions produce bus errors (!) on the
+            # hardware when finding a 12 byte substring (maybe a SIMD
+            # load that the hardware doesn't like?).  Do it in two
+            # chunks.
+            magoff = maps[m].find(magic[0:8])
+            if magoff >= 0:
+                magoff = maps[m].find(magic[8:], magoff) - 8
             if magoff >= 0:
                 addr = le4(maps[m][magoff + 12 : magoff + 16])
                 return addr

--- a/soc/mediatek/mt8xxx/soc.c
+++ b/soc/mediatek/mt8xxx/soc.c
@@ -197,7 +197,6 @@ static void enable_mpu(void)
 		{ 0x10000000, 0x06f00 },          /* MMIO registers */
 		{ 0x1d000000, 0x06000 },          /* inaccessible */
 		{ SRAM_START, 0xf7f00 },          /* cached SRAM */
-		{ (uint32_t)&_mtk_adsp_sram_end, 0x06f00 }, /* uncached SRAM */
 		{ SRAM_END,   0x06000 },          /* inaccessible */
 		{ DRAM_START, 0xf7f00 },          /* cached DRAM */
 		{ (uint32_t)&_mtk_adsp_dram_end, 0x06f00 }, /* uncached DRAM */


### PR DESCRIPTION
Two small mtk_adsp patches.  One fairly obvious mixup with how SRAM is being treated.  The loader thing is just nuts though.  Took me all of Friday and almost half of my weekend to figure out the culprit, I was **convinced** it was a change to kernel config somehow and had a whole rig trying to delta the changes until I realized that the proximate cause of the loader failing with a bus error touching DMA memory was... **the python interpreter**.  ChromeOS pushed an otherwise routine update from 3.8 to 3.11 and kaboom.