### PR TITLE
ci: twister: fix steps for analyzing failures

### DIFF
--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -217,6 +217,14 @@ jobs:
     if: success() || failure()
 
     steps:
+      - name: Check out source code
+        if: needs.twister-build.result == 'failure'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
       - name: Download Artifacts
         uses: actions/download-artifact@v4
         with:
@@ -244,23 +252,17 @@ jobs:
           files: "**/twister.xml"
           comment_mode: off
 
-      - name: Check out source code
-        if: failure()
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 0
-          persist-credentials: false
-
       - name: Analyze Twister Reports
-        if: failure()
+        if: needs.twister-build.result == 'failure'
         run: |
           ./scripts/ci/twister_report_analyzer.py artifacts/*/*/twister.json --long-summary --platforms --output-md errors.md
-          echo '### Error Summary! 🚀' >> $GITHUB_STEP_SUMMARY
-          cat errors.md  >> $GITHUB_STEP_SUMMARY
+          if [[ -s "errors.md" ]]; then
+            echo '### Error Summary! 🚀' >> $GITHUB_STEP_SUMMARY
+            cat errors.md  >> $GITHUB_STEP_SUMMARY
+          fi
 
       - name: Upload Twister Analysis Results
-        if: failure()
+        if: needs.twister-build.result == 'failure'
         uses: actions/upload-artifact@v4
         with:
           name: Twister Analysis Results


### PR DESCRIPTION
Checkout code early, so files are downloaded and read from one single
place.

Check for job results, only run script on failures.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
