### PR TITLE
tests: logging: log_backend_fs: add missing include

### DIFF
--- a/tests/subsys/logging/log_backend_fs/src/log_fs_test.c
+++ b/tests/subsys/logging/log_backend_fs/src/log_fs_test.c
@@ -16,6 +16,7 @@
 #include <zephyr/ztest.h>
 #include <zephyr/fs/fs.h>
 #include <zephyr/fff.h>
+#include <zephyr/logging/log_backend.h>
 
 #define DT_DRV_COMPAT zephyr_fstab_littlefs
 #define TEST_AUTOMOUNT DT_PROP(DT_DRV_INST(0), automount)


### PR DESCRIPTION
Explicitly include `logging/log_backend.h` header so that non POSIX boards can build this test. For POSIX boards, this header was indirectly included through `ztest.h`->`ztest_assert.h`->`tc_util.h`->`log_ctrl.h`.

Fixes #85441

```
west twister -p mr_canhubk3 -p s32z2xxdc2/s32z270/rtu0 -p s32z2xxdc2/s32z270/rtu1 -T tests/subsys/logging/log_backend_fs
INFO    - Total complete:    6/   6  100%  built (not run):    6, filtered:    0, failed:    0, error:    0
```