### PR TITLE
drivers: sensor: bosch: bmg160: replace deprecated datasheet link

### DIFF
--- a/drivers/sensor/bosch/bmg160/bmg160.c
+++ b/drivers/sensor/bosch/bmg160/bmg160.c
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0
  *
  * Datasheet:
- * http://ae-bst.resource.bosch.com/media/_tech/media/datasheets/BST-BMG160-DS000-09.pdf
+ * https://web.archive.org/web/20181111220522/https://ae-bst.resource.bosch.com/media/_tech/media/datasheets/BST-BMG160-DS000-09.pdf
  */
 
 #define DT_DRV_COMPAT bosch_bmg160


### PR DESCRIPTION
Use an archived link to replace the previous link that is no longer valid

Related to https://github.com/zephyrproject-rtos/zephyr/pull/85076/