### PR TITLE
Change pins for MAX32690EVKIT

### DIFF
--- a/tests/drivers/gpio/gpio_basic_api/boards/max32690evkit_max32690_m4.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/max32690evkit_max32690_m4.overlay
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024 Analog Devices, Inc.
+ * Copyright (c) 2023-2025 Analog Devices, Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -7,7 +7,7 @@
 / {
 	resources {
 		compatible = "test-gpio-basic-api";
-		out-gpios = <&gpio2 7 0>;
-		in-gpios = <&gpio2 8 0>;
+		out-gpios = <&gpio0 7 0>;
+		in-gpios = <&gpio0 8 0>;
 	};
 };


### PR DESCRIPTION
This PR changes pins used in gpio_basic_api test for the Max32690 in order to run both I2C and GPIO test on hardware board. Current test gpios conflict with I2C SCL and SDA lines.