### PR TITLE
scripts: zephyr_module: Fix purl regex

### DIFF
--- a/scripts/west_commands/zspdx/walker.py
+++ b/scripts/west_commands/zspdx/walker.py
@@ -77,12 +77,12 @@ class Walker:
 
         purl = None
         # This is designed to match repository with the following url pattern:
-        # '<protocol><base_url>/<namespace>/<package>
-        COMMON_GIT_URL_REGEX=r'((git@|http(s)?:\/\/)(?P<base_url>[\w\.@]+)(\/|:))(?P<namespace>[\w,\-,\_]+)\/(?P<package>[\w,\-,\_]+)(.git){0,1}((\/){0,1})$'
+        # '<protocol><type>/<namespace>/<package>
+        COMMON_GIT_URL_REGEX=r'((git@|http(s)?:\/\/)(?P<type>[\w\.@]+)(\.\w+)(\/|:))(?P<namespace>[\w,\-,\_\/]+)\/(?P<package>[\w,\-,\_]+)(.git){0,1}((\/){0,1})$'
 
         match = re.fullmatch(COMMON_GIT_URL_REGEX, url)
         if match:
-            purl = f'pkg:{match.group("base_url")}/{match.group("namespace")}/{match.group("package")}'
+            purl = f'pkg:{match.group("type")}/{match.group("namespace")}/{match.group("package")}'
 
         if purl and (version or len(version) > 0):
             purl += f'@{version}'


### PR DESCRIPTION
**Remove root domain from PURL type**

Currently "github.com" was used instead of "github" as defined in PURL spec https://github.com/package-url/purl-spec/blob/master/PURL-SPECIFICATION.rst

**Nested PURL namespaces were not correctly detected**

Some platforms use nested namespace (for example https://gitlab.com/my_company/my_team/my_project) but it was not handle properly (only one level was supported).

This PR fixes part of this issue https://github.com/zephyrproject-rtos/zephyr/issues/82838#issuecomment-2598291139