### PR TITLE
arch: arm: fix compile issue if MEM_ATTR=n and ARM_MPU=y

### DIFF
--- a/arch/arm/core/mpu/arm_mpu.c
+++ b/arch/arm/core/mpu/arm_mpu.c
@@ -93,7 +93,7 @@ static int region_allocate_and_init(const uint8_t index,
 						    (reg).dt_addr,	\
 						    (reg).dt_size,	\
 						    _ATTR)
-
+#ifdef CONFIG_MEM_ATTR
 /* This internal function programs the MPU regions defined in the DT when using
  * the `zephyr,memory-attr = <( DT_MEM_ARM(...) )>` property.
  */
@@ -158,7 +158,7 @@ static int mpu_configure_regions_from_dt(uint8_t *reg_index)
 
 	return 0;
 }
-
+#endif /* CONFIG_MEM_ATTR */
 /* This internal function programs an MPU region
  * of a given configuration at a given MPU index.
  */
@@ -459,13 +459,13 @@ int z_arm_mpu_init(void)
 
 	/* Update the number of programmed MPU regions. */
 	static_regions_num = mpu_config.num_regions;
-
+#ifdef CONFIG_MEM_ATTR
 	/* DT-defined MPU regions. */
 	if (mpu_configure_regions_from_dt(&static_regions_num) == -EINVAL) {
 		__ASSERT(0, "Failed to allocate MPU regions from DT\n");
 		return -EINVAL;
 	}
-
+#endif /* CONFIG_MEM_ATTR */
 	/* Clear all regions before enabling MPU */
 	for (int i = static_regions_num; i < get_num_regions(); i++) {
 		mpu_clear_region(i);

--- a/arch/arm/core/mpu/nxp_mpu.c
+++ b/arch/arm/core/mpu/nxp_mpu.c
@@ -151,7 +151,7 @@ static int region_allocate_and_init(const uint8_t index,
 				  .end  = (reg).dt_addr + (reg).dt_size,	\
 				  .attr = _ATTR,				\
 				}
-
+#ifdef CONFIG_MEM_ATTR
 /* This internal function programs the MPU regions defined in the DT when using
  * the `zephyr,memory-attr = <( DT_MEM_ARM(...) )>` property.
  */
@@ -198,7 +198,7 @@ static int mpu_configure_regions_from_dt(uint8_t *reg_index)
 
 	return 0;
 }
-
+#endif /* CONFIG_MEM_ATTR */
 /**
  * This internal function is utilized by the MPU driver to combine a given
  * region attribute configuration and size and fill-in a driver-specific
@@ -700,13 +700,13 @@ int z_arm_mpu_init(void)
 
 	/* Update the number of programmed MPU regions. */
 	static_regions_num = mpu_config.num_regions;
-
+#ifdef CONFIG_MEM_ATTR
 	/* DT-defined MPU regions. */
 	if (mpu_configure_regions_from_dt(&static_regions_num) == -EINVAL) {
 		__ASSERT(0, "Failed to allocate MPU regions from DT\n");
 		return -EINVAL;
 	}
-
+#endif /* CONFIG_MEM_ATTR */
 	arm_core_mpu_enable();
 
 	return 0;

--- a/arch/arm64/core/cortex_r/arm_mpu.c
+++ b/arch/arm64/core/cortex_r/arm_mpu.c
@@ -196,7 +196,7 @@ static ALWAYS_INLINE void region_init(const uint32_t index,
 				  .limit = (reg).dt_addr + (reg).dt_size,	\
 				  .attr  = _ATTR,				\
 				}
-
+#ifdef CONFIG_MEM_ATTR
 /* This internal function programs the MPU regions defined in the DT when using
  * the `zephyr,memory-attr = <( DT_MEM_ARM(...) )>` property.
  */
@@ -247,7 +247,7 @@ static int mpu_configure_regions_from_dt(uint8_t *reg_index)
 
 	return 0;
 }
-
+#endif /* CONFIG_MEM_ATTR */
 /*
  * @brief MPU default configuration
  *
@@ -303,13 +303,13 @@ FUNC_NO_STACK_PROTECTOR void z_arm64_mm_init(bool is_primary_core)
 
 	/* Update the number of programmed MPU regions. */
 	tmp_static_num = mpu_config.num_regions;
-
+#ifdef CONFIG_MEM_ATTR
 	/* DT-defined MPU regions. */
 	if (mpu_configure_regions_from_dt(&tmp_static_num) == -EINVAL) {
 		__ASSERT(0, "Failed to allocate MPU regions from DT\n");
 		return;
 	}
-
+#endif
 	arm_core_mpu_enable();
 
 	if (!is_primary_core) {


### PR DESCRIPTION
It's possible to have MEM_ATTR=n and ARM_MPU=y, although this isn't the default. This fixes the compile issue with it by compiling out the calls to define the DT mpu regions.