### PR TITLE
Fix gpio_mcux driver building issues on NXP s32k146 platform

### DIFF
--- a/drivers/gpio/gpio_mcux.c
+++ b/drivers/gpio/gpio_mcux.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2016 Freescale Semiconductor, Inc.
- * Copyright 2017, 2023-2024 NXP
+ * Copyright 2017, 2023-2025 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -19,9 +19,6 @@
 
 #if defined(CONFIG_PINCTRL_NXP_IOCON)
 #include <fsl_iopctl.h>
-#include <fsl_reset.h>
-#include <fsl_clock.h>
-#include <fsl_gpio.h>
 /* Use IOCON to configure electrical characteristic, set PORT_Type as void. */
 #define PORT_Type void
 #endif

--- a/west.yml
+++ b/west.yml
@@ -203,7 +203,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: 49ff7e33f848e4b59da59369a77da63e346fb1a3
+      revision: 0b86efa2ad563e60d4d57fe7fa7ac6ccfa092f8c
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
The zephyr driver don't rely on the SDK driver code.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/85502