### PR TITLE
dts: nordic: Add wifi_spi label

### DIFF
--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20-common.dtsi
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20-common.dtsi
@@ -16,3 +16,6 @@
 &lfxo {
 	status = "okay";
 };
+
+/* Get a node label for wi-fi spi to use in shield files */
+wifi_spi: &spi130 {};

--- a/boards/nordic/nrf54l15dk/nrf54l15dk_common.dtsi
+++ b/boards/nordic/nrf54l15dk/nrf54l15dk_common.dtsi
@@ -98,3 +98,6 @@
 	pinctrl-1 = <&pwm20_sleep>;
 	pinctrl-names = "default", "sleep";
 };
+
+/* Get a node label for wi-fi spi to use in shield files */
+wifi_spi: &spi22 {};


### PR DESCRIPTION
Add wifi_spi label to nRF54h and nRF54l dts files to help in shield overlay files