### PR TITLE
BLE to Bluetooth (LE) rename

### DIFF
--- a/doc/connectivity/bluetooth/api/hci.txt
+++ b/doc/connectivity/bluetooth/api/hci.txt
@@ -805,7 +805,7 @@ event shall be generated.
 Zephyr Write Tx Power Level (per Role/Connection) Command
 =========================================================
 
-This command dynamically modifies BLE Tx power level given a handle and a
+This command dynamically modifies Bluetooth Tx power level given a handle and a
 handle type (advertiser, scanner, connection).
 
 +--------------------------+-------+--------------------+--------------------+
@@ -818,8 +818,8 @@ handle type (advertiser, scanner, connection).
 |                          |       |                    | Selected_Tx_Power  |
 +--------------------------+-------+--------------------+--------------------+
 
-The Tx power of the BLE radio interface is modified for any low-level link by
-the controller with a high degree of flexibility. The BLE link whose power is
+The Tx power of the Bluetooth radio interface is modified for any low-level link by
+the controller with a high degree of flexibility. The Bluetooth link whose power is
 set is identified based on a handle type (advertiser, scanner, connection) and
 handle pair.
 
@@ -927,10 +927,10 @@ event shall be generated.
 Zephyr Read Tx Power Level (per Role/Connection) Command
 ========================================================
 
-This command reads the BLE Tx power level. In contrast to the standardized HCI
+This command reads the Bluetooth Tx power level. In contrast to the standardized HCI
 command, i.e. Read_Transmit_Power_Level, which returns the transmitted power
 level only for a specified connection handle, this command operates for both
-connected and unconnected states. It gets the BLE Tx power level for any given
+connected and unconnected states. It gets the Bluetooth Tx power level for any given
 handle type (advertiser, scanner, connection) and handle.
 
 +--------------------------+-------+--------------------+--------------------+
@@ -943,7 +943,7 @@ handle type (advertiser, scanner, connection) and handle.
 |                          |       |                    | Tx_Power_Level     |
 +--------------------------+-------+--------------------+--------------------+
 
-The Tx power of the BLE radio interface used for a low-level link identified
+The Tx power of the Bluetooth radio interface used for a low-level link identified
 by a pair of Handle_Type and Handle is retrieved from the controller.
 
 The role/state defining input parameter is the Handle_Type, whereas its

--- a/doc/connectivity/bluetooth/bluetooth-arch.rst
+++ b/doc/connectivity/bluetooth/bluetooth-arch.rst
@@ -10,15 +10,14 @@ This page describes the software architecture of Zephyr's Bluetooth protocol
 stack.
 
 .. note::
-   Zephyr supports mainly Bluetooth Low Energy (BLE), the low-power
+   Zephyr supports mainly Bluetooth Low Energy (LE), the low-power
    version of the Bluetooth specification. Zephyr also has limited support
-   for portions of the BR/EDR Host. Throughout this architecture document we
-   use BLE interchangeably for Bluetooth except when noted.
+   for portions of the BR/EDR Host.
 
 .. _bluetooth-layers:
 
-BLE Layers
-==========
+Bluetooth LE Layers
+===================
 
 There are 3 main layers that together constitute a full Bluetooth Low Energy
 protocol stack:
@@ -62,7 +61,7 @@ following configurations are commonly used:
 
 * **Single-chip configuration**: In this configuration, a single microcontroller
   implements all three layers and the application itself. This can also be called a
-  system-on-chip (SoC) implementation. In this case the BLE Host and the BLE
+  system-on-chip (SoC) implementation. In this case the Bluetooth Host and the Bluetooth
   Controller communicate directly through function calls and queues in RAM. The
   Bluetooth specification does not specify how HCI is implemented in this
   single-chip configuration and so how HCI commands, events, and data flows between
@@ -75,11 +74,11 @@ following configurations are commonly used:
   configuration. This configuration allows for a wider variety of combinations of
   Hosts when using the Zephyr OS as a Controller. Since HCI ensures
   interoperability among Host and Controller implementations, including of course
-  Zephyr's very own BLE Host and Controller, users of the Zephyr Controller can
+  Zephyr's very own Bluetooth Host and Controller, users of the Zephyr Controller can
   choose to use whatever Host running on any platform they prefer. For example,
-  the host can be the Linux BLE Host stack (BlueZ) running on any processor
+  the host can be the Linux Bluetooth Host stack (BlueZ) running on any processor
   capable of supporting Linux. The Host processor may of course also run Zephyr
-  and the Zephyr OS BLE Host. Conversely, combining an IC running the Zephyr
+  and the Zephyr OS Bluetooth Host. Conversely, combining an IC running the Zephyr
   Host with an external Controller that does not run Zephyr is also supported.
 
 .. _bluetooth-build-types:
@@ -88,12 +87,12 @@ Build Types
 ===========
 
 The Zephyr software stack as an RTOS is highly configurable, and in particular,
-the BLE subsystem can be configured in multiple ways during the build process to
+the Bluetooth subsystem can be configured in multiple ways during the build process to
 include only the features and layers that are required to reduce RAM and ROM
 footprint as well as power consumption. Here's a short list of the different
-BLE-enabled builds that can be produced from the Zephyr project codebase:
+Bluetooth-enabled builds that can be produced from the Zephyr project codebase:
 
-* **Controller-only build**: When built as a BLE Controller, Zephyr includes
+* **Controller-only build**: When built as a Bluetooth Controller, Zephyr includes
   the Link Layer and a special application. This application is different
   depending on the physical transport chosen for HCI:
 
@@ -114,7 +113,7 @@ BLE-enabled builds that can be produced from the Zephyr project codebase:
   corresponding device tree node is enabled.
 
 * **Host-only build**: A Zephyr OS Host build will contain the Application and
-  the BLE Host, along with an HCI driver (UART or SPI) to interface with an
+  the Bluetooth Host, along with an HCI driver (UART or SPI) to interface with an
   external Controller chip.
   A build of this type sets the following Kconfig option values:
 
@@ -143,12 +142,12 @@ BLE-enabled builds that can be produced from the Zephyr project codebase:
   used for Controller-only builds can be built as Combined
 
 The picture below shows the SoC or single-chip configuration when using a Zephyr
-combined build (a build that includes both a BLE Host and a Controller in the
+combined build (a build that includes both a Bluetooth Host and a Controller in the
 same firmware image that is programmed onto the chip):
 
 .. figure:: img/ble_cfg_single.png
    :align: center
-   :alt: BLE Combined build on a single chip
+   :alt: Bluetooth Combined build on a single chip
 
    A Combined build on a Single-Chip configuration
 
@@ -157,25 +156,25 @@ combinations are possible, some of which are depicted below:
 
 .. figure:: img/ble_cfg_dual.png
    :align: center
-   :alt: BLE dual-chip configuration builds
+   :alt: Bluetooth dual-chip configuration builds
 
    Host-only and Controller-only builds on dual-chip configurations
 
 When using a Zephyr Host (left side of image), two instances of Zephyr OS
 must be built with different configurations, yielding two separate images that
 must be programmed into each of the chips respectively. The Host build image
-contains the application, the BLE Host and the selected HCI driver (UART or
+contains the application, the Bluetooth Host and the selected HCI driver (UART or
 SPI), while the Controller build runs either the
 :zephyr:code-sample:`bluetooth_hci_uart`, or the
 :zephyr:code-sample:`bluetooth_hci_spi` app to provide an interface to
-the BLE Controller.
+the Bluetooth Controller.
 
 This configuration is not limited to using a Zephyr OS Host, as the right side
 of the image shows. One can indeed take one of the many existing GNU/Linux
-distributions, most of which include Linux's own BLE Host (BlueZ), to connect it
+distributions, most of which include Linux's own Bluetooth Host (BlueZ), to connect it
 via UART or USB to one or more instances of the Zephyr OS Controller build.
 BlueZ as a Host supports multiple Controllers simultaneously for applications
-that require more than one BLE radio operating at the same time but sharing the
+that require more than one Bluetooth radio operating at the same time but sharing the
 same Host stack.
 
 Source tree layout

--- a/doc/connectivity/bluetooth/bluetooth-dev.rst
+++ b/doc/connectivity/bluetooth/bluetooth-dev.rst
@@ -139,7 +139,7 @@ Simulated nRF5x with BabbleSim
 The :ref:`nrf52_bsim <nrf52_bsim>` and :ref:`nrf5340bsim <nrf5340bsim>` boards,
 are simulated target boards
 which emulate the necessary peripherals of a nRF52/53 SOC to be able to develop
-and test BLE applications.
+and test Bluetooth LE applications.
 These boards, use:
 
    * `BabbleSim`_ to simulate the nRF5x modem and the radio environment.

--- a/doc/connectivity/bluetooth/bluetooth-le-host.rst
+++ b/doc/connectivity/bluetooth/bluetooth-le-host.rst
@@ -21,7 +21,7 @@ host, and vice-versa.
 
 Perhaps the most important block above the HCI handling is the Generic
 Access Profile (GAP). GAP simplifies Bluetooth LE access by defining
-four distinct roles of BLE usage:
+four distinct roles of Bluetooth usage:
 
 * Connection-oriented roles
 
@@ -31,9 +31,9 @@ four distinct roles of BLE usage:
 
 * Connection-less roles
 
-  * Broadcaster (sending out BLE advertisements, e.g. a smart beacon)
+  * Broadcaster (sending out Bluetooth LE advertisements, e.g. a smart beacon)
 
-  * Observer (scanning for BLE advertisements)
+  * Observer (scanning for Bluetooth LE advertisements)
 
 Each role comes with its own build-time configuration option:
 :kconfig:option:`CONFIG_BT_PERIPHERAL`, :kconfig:option:`CONFIG_BT_CENTRAL`,
@@ -49,7 +49,7 @@ section.
 Peripheral role
 ===============
 
-Most Zephyr-based BLE devices will most likely be peripheral-role
+Most Zephyr-based Bluetooth LE devices will most likely be peripheral-role
 devices. This means that they perform connectable advertising and expose
 one or more GATT services. After registering services using the
 :c:func:`bt_gatt_service_register` API the application will typically

--- a/doc/connectivity/bluetooth/bluetooth-tools.rst
+++ b/doc/connectivity/bluetooth/bluetooth-tools.rst
@@ -40,7 +40,7 @@ Using BlueZ with Zephyr
 ***********************
 
 The Linux Bluetooth Protocol Stack, BlueZ, comes with a very useful set of
-tools that can be used to debug and interact with Zephyr's BLE Host and
+tools that can be used to debug and interact with Zephyr's Bluetooth Host and
 Controller. In order to benefit from these tools you will need to make sure
 that you are running a recent version of the Linux Kernel and BlueZ:
 
@@ -62,7 +62,7 @@ You can then find :file:`btattach`, :file:`btmgt` and :file:`btproxy` in the
 :file:`tools/` folder and :file:`btmon` in the :file:`monitor/` folder.
 
 You'll need to enable BlueZ's experimental features so you can access its
-most recent BLE functionality. Do this by editing the file
+most recent Bluetooth functionality. Do this by editing the file
 :file:`/lib/systemd/system/bluetooth.service`
 and making sure to include the :literal:`-E` option in the daemon's execution
 start line:
@@ -160,11 +160,11 @@ building and running a sample:
 
      $ sudo ./build/zephyr/zephyr.exe --bt-dev=hci0
 
-Using a Zephyr-based BLE Controller
-===================================
+Using a Zephyr-based Bluetooth Controller
+=========================================
 
 Depending on which hardware you have available, you can choose between two
-transports when building a single-mode, Zephyr-based BLE Controller:
+transports when building a single-mode, Zephyr-based Bluetooth Controller:
 
 * UART: Use the :zephyr:code-sample:`bluetooth_hci_uart` sample and follow
   the instructions in :ref:`bluetooth-hci-uart-qemu-posix`.
@@ -309,7 +309,7 @@ peripheral samples such as :zephyr:code-sample:`ble_peripheral_hr` or
 Using Zephyr-based Controllers with BlueZ
 *****************************************
 
-If you want to test a Zephyr-powered BLE Controller using BlueZ's Bluetooth
+If you want to test a Zephyr-powered Bluetooth Controller using BlueZ's Bluetooth
 Host, you will need a few tools described in the :ref:`bluetooth_bluez` section.
 Once you have installed the tools you can then use them to interact with your
 Zephyr-based controller:

--- a/doc/connectivity/bluetooth/features.rst
+++ b/doc/connectivity/bluetooth/features.rst
@@ -8,10 +8,10 @@ Supported features
     :depth: 2
 
 Since its inception, Zephyr has had a strong focus on Bluetooth and, in
-particular, on Bluetooth Low Energy (BLE). Through the contributions of
+particular, on Bluetooth Low Energy (LE). Through the contributions of
 several companies and individuals involved in existing open source
 implementations of the Bluetooth specification (Linux's BlueZ) as well as the
-design and development of BLE radio hardware, the protocol stack in Zephyr has
+design and development of Bluetooth LE radio hardware, the protocol stack in Zephyr has
 grown to be mature and feature-rich, as can be seen in the section below.
 
 * Bluetooth v5.3 compliant
@@ -41,7 +41,7 @@ grown to be mature and feature-rich, as can be seen in the section below.
   * All v5.3 specification features supported (except a few minor items)
   * Concurrent multi-protocol support ready
   * Intelligent scheduling of roles to minimize overlap
-  * Portable design to any open BLE radio, currently supports Nordic
+  * Portable design to any open Bluetooth LE radio, currently supports Nordic
     Semiconductor nRF52x and nRF53x SoC Series, as well as proprietary radios
   * Supports little and big endian architectures, and abstracts the hard
     real-time specifics so that they can be encapsulated in a hardware-specific

--- a/doc/develop/test/bsim.rst
+++ b/doc/develop/test/bsim.rst
@@ -7,11 +7,11 @@ BabbleSim and Zephyr
 ********************
 
 In the Zephyr project we use the `Babblesim`_ simulator to test some of the Zephyr radio protocols,
-including the BLE stack, 802.15.4, and some of the networking stack.
+including the Bluetooth LE stack, 802.15.4, and some of the networking stack.
 
 BabbleSim_ is a physical layer simulator, which in combination with the Zephyr
 :ref:`bsim boards<bsim boards>`
-can be used to simulate a network of BLE and 15.4 devices.
+can be used to simulate a network of Bluetooth LE and 15.4 devices.
 When we build Zephyr targeting a :ref:`bsim board<bsim boards>` we produce a Linux
 executable, which includes the application, Zephyr OS, and models of the HW.
 

--- a/doc/hardware/porting/board_porting.rst
+++ b/doc/hardware/porting/board_porting.rst
@@ -281,7 +281,7 @@ The mandatory files are:
 #. :file:`plank_<qualifiers>.dts`: a hardware description
    in :ref:`devicetree <dt-guide>` format. This declares your SoC, connectors,
    and any other hardware components such as LEDs, buttons, sensors, or
-   communication peripherals (USB, BLE controller, etc).
+   communication peripherals (USB, Bluetooth controller, etc).
 
 #. :file:`Kconfig.plank`: the base software configuration for selecting SoC and
    other board and SoC related settings. Kconfig settings outside of the board

--- a/doc/security/vulnerabilities.rst
+++ b/doc/security/vulnerabilities.rst
@@ -1599,8 +1599,8 @@ This has been fixed in main for v3.6.0
 :cve:`2024-3077`
 ----------------
 
-Bluetooth: Integer underflow in gatt_find_info_rsp. A malicious BLE
-device can crash BLE victim device by sending malformed gatt packet.
+Bluetooth: Integer underflow in gatt_find_info_rsp. A malicious Bluetooth LE
+device can crash Bluetooth LE victim device by sending malformed gatt packet.
 
 - `Zephyr project bug tracker GHSA-gmfv-4vfh-2mh8
   <https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-gmfv-4vfh-2mh8>`_
@@ -1615,8 +1615,8 @@ This has been fixed in main for v3.7.0
 
 Bluetooth: DoS caused by null pointer dereference.
 
-A malicious BLE device can send a specific order of packet
-sequence to cause a DoS attack on the victim BLE device.
+A malicious Bluetooth LE device can send a specific order of packet
+sequence to cause a DoS attack on the victim Bluetooth LE device.
 
 - `Zephyr project bug tracker GHSA-jmr9-xw2v-5vf4
   <https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-jmr9-xw2v-5vf4>`_

--- a/doc/services/device_mgmt/mcumgr.rst
+++ b/doc/services/device_mgmt/mcumgr.rst
@@ -19,7 +19,7 @@ The following management operations are available:
 
 over the following transports:
 
-* BLE (Bluetooth Low Energy)
+* Bluetooth Low Energy (LE)
 * Serial (UART)
 * UDP over IP
 
@@ -32,7 +32,7 @@ The management subsystem is located in :zephyr_file:`subsys/mgmt/` inside of
 the Zephyr tree.
 
 Additionally, there is a :zephyr:code-sample:`sample <smp-svr>` server that provides
-management functionality over BLE and serial.
+management functionality over Bluetooth LE and serial.
 
 .. _mcumgr_tools_libraries:
 

--- a/doc/services/device_mgmt/ota.rst
+++ b/doc/services/device_mgmt/ota.rst
@@ -62,7 +62,7 @@ SMP Server
 ==========
 
 A Simple Management Protocol (SMP) server can be used to update firmware via
-Bluetooth Low Energy (BLE) or UDP. :ref:`mcu_mgr` is used to send a signed
+Bluetooth Low Energy (LE) or UDP. :ref:`mcu_mgr` is used to send a signed
 firmware binary to the remote device where it is verified by MCUboot before the
 upgrade occurs.
 

--- a/doc/services/device_mgmt/smp_transport.rst
+++ b/doc/services/device_mgmt/smp_transport.rst
@@ -8,10 +8,10 @@ side SMP transports.
 
 .. _mcumgr_smp_transport_ble:
 
-BLE (Bluetooth Low Energy)
-**************************
+Bluetooth Low Energy (LE)
+*************************
 
-MCUmgr Clients need to use following BLE Characteristics, when implementing
+MCUmgr Clients need to use following Bluetooth Characteristics, when implementing
 SMP client:
 
 - **Service UUID**: ``8D53DC1D-1DB7-4CD3-868B-8A527460AA84``

--- a/drivers/bluetooth/hci/spi.c
+++ b/drivers/bluetooth/hci/spi.c
@@ -377,7 +377,7 @@ static int bt_spi_open(const struct device *dev, bt_hci_recv_t recv)
 	struct bt_spi_data *hci = dev->data;
 	int err;
 
-	/* Configure RST pin and hold BLE in Reset */
+	/* Configure RST pin and hold Bluetooth LE in Reset */
 	err = gpio_pin_configure_dt(&rst_gpio, GPIO_OUTPUT_ACTIVE);
 	if (err) {
 		return err;
@@ -403,7 +403,7 @@ static int bt_spi_open(const struct device *dev, bt_hci_recv_t recv)
 
 	hci->recv = recv;
 
-	/* Take BLE out of reset */
+	/* Take Bluetooth LE out of reset */
 	k_sleep(K_MSEC(DT_INST_PROP_OR(0, reset_assert_duration_ms, 0)));
 	gpio_pin_set_dt(&rst_gpio, 0);
 

--- a/drivers/flash/Kconfig.nrf
+++ b/drivers/flash/Kconfig.nrf
@@ -37,7 +37,7 @@ config SOC_FLASH_NRF_RADIO_SYNC_TICKER
 	depends on BT_LL_SW_SPLIT
 	help
 	  Enable synchronization between flash memory driver and radio using
-	  BLE LL controller ticker API.
+	  Bluetooth LE LL controller ticker API.
 
 config SOC_FLASH_NRF_RADIO_SYNC_NONE
 	bool "none"

--- a/drivers/flash/Kconfig.nrf_rram
+++ b/drivers/flash/Kconfig.nrf_rram
@@ -50,7 +50,7 @@ config SOC_FLASH_NRF_RADIO_SYNC_TICKER
 	depends on BT_LL_SW_SPLIT
 	help
 	  Enable synchronization between flash memory driver and radio using
-	  BLE LL controller ticker API.
+	  Bluetooth LE LL controller ticker API.
 
 config SOC_FLASH_NRF_RADIO_SYNC_NONE
 	bool "none"

--- a/drivers/hwinfo/hwinfo_nrf.c
+++ b/drivers/hwinfo/hwinfo_nrf.c
@@ -41,7 +41,7 @@ ssize_t z_impl_hwinfo_get_device_id(uint8_t *buffer, size_t length)
 	buf[1] = nrf_ficr_deviceid_get(NRF_FICR, 1);
 #endif
 #elif NRF_FICR_HAS_DEVICE_ADDR || NRF_FICR_HAS_BLE_ADDR
-	/* DEVICEID is not accessible, use device/ble address instead.
+	/* DEVICEID is not accessible, use device/Bluetooth LE address instead.
 	 * Assume that it is always accessible from the non-secure image.
 	 */
 	buf[0] = nrf_ficr_deviceaddr_get(NRF_FICR, 0);

--- a/include/zephyr/bluetooth/hci_types.h
+++ b/include/zephyr/bluetooth/hci_types.h
@@ -1028,7 +1028,7 @@ struct bt_hci_rp_read_encryption_key_size {
 	uint8_t  key_size;
 } __packed;
 
-/* BLE */
+/* Bluetooth LE */
 
 #define BT_HCI_OP_LE_SET_EVENT_MASK             BT_OP(BT_OGF_LE, 0x0001) /* 0x2001 */
 struct bt_hci_cp_le_set_event_mask {

--- a/include/zephyr/bluetooth/mesh/statistic.h
+++ b/include/zephyr/bluetooth/mesh/statistic.h
@@ -1,5 +1,5 @@
 /** @file
- *  @brief BLE mesh statistic APIs.
+ *  @brief Bluetooth Mesh statistic APIs.
  */
 
 /*
@@ -51,7 +51,7 @@ struct bt_mesh_statistic {
 
 /** @brief Get mesh frame handling statistic.
  *
- *  @param st   BLE mesh statistic.
+ *  @param st   Bluetooh Mesh statistic.
  */
 void bt_mesh_stat_get(struct bt_mesh_statistic *st);
 

--- a/include/zephyr/logging/log_backend_ble.h
+++ b/include/zephyr/logging/log_backend_ble.h
@@ -9,7 +9,7 @@
 
 #include <stdbool.h>
 /**
- * @brief Raw adv UUID data to add the ble backend for the use with apps
+ * @brief Raw adv UUID data to add the Bluetooth backend for the use with apps
  *        such as the NRF Toolbox
  *
  */
@@ -19,7 +19,7 @@
 		0x6E
 
 /**
- * @brief Hook for application to know when the ble backend
+ * @brief Hook for application to know when the Bluetooth backend
  *        is enabled or disabled.
  * @param backend_status True if the backend is enabled or false if disabled
  * @param ctx User context
@@ -28,10 +28,10 @@
 typedef void (*logger_backend_ble_hook)(bool backend_status, void *ctx);
 
 /**
- * @brief Allows application to add a hook for the status of the BLE
+ * @brief Allows application to add a hook for the status of the Bluetooth
  *        logger backend.
- * @details The BLE logger backend is enabled or disabled auomatically by
- *          the subscription of the notification characteristic of this BLE
+ * @details The Bluetooth logger backend is enabled or disabled auomatically by
+ *          the subscription of the notification characteristic of this Bluetooth
  *          Logger backend service.
  *
  * @param hook The hook that will be called when the status of the backend changes

--- a/include/zephyr/mgmt/mcumgr/transport/smp.h
+++ b/include/zephyr/mgmt/mcumgr/transport/smp.h
@@ -42,7 +42,7 @@ typedef int (*smp_transport_out_fn)(struct net_buf *nb);
  * The supplied net_buf should contain a request received from the peer whose
  * MTU is being queried.  This function takes a net_buf parameter because some
  * transports store connection-specific information in the net_buf user header
- * (e.g., the BLE transport stores the peer address).
+ * (e.g., the Bluetooth transport stores the peer address).
  *
  * @param nb                    Contains a request from the relevant peer.
  *
@@ -55,7 +55,7 @@ typedef uint16_t (*smp_transport_get_mtu_fn)(const struct net_buf *nb);
  * @brief SMP copy user_data callback
  *
  * The supplied src net_buf should contain a user_data that cannot be copied
- * using regular memcpy function (e.g., the BLE transport net_buf user_data
+ * using regular memcpy function (e.g., the Bluetooth transport net_buf user_data
  * stores the connection reference that has to be incremented when is going
  * to be used by another buffer).
  *
@@ -71,7 +71,7 @@ typedef int (*smp_transport_ud_copy_fn)(struct net_buf *dst,
  * @brief SMP free user_data callback
  *
  * This function frees net_buf user data, because some transports store
- * connection-specific information in the net_buf user data (e.g., the BLE
+ * connection-specific information in the net_buf user data (e.g., the Bluetooth
  * transport stores the connection reference that has to be decreased).
  *
  * @param ud                    Contains a user_data pointer to be freed.

--- a/samples/bluetooth/central_multilink/README.rst
+++ b/samples/bluetooth/central_multilink/README.rst
@@ -8,7 +8,7 @@ Overview
 ********
 
 Application demonstrating Bluetooth LE Central role functionality by scanning for other
-BLE devices and establishing connection to up to 62 peripherals with a strong
+Bluetooth LE devices and establishing connection to up to 62 peripherals with a strong
 enough signal.
 
 Requirements

--- a/samples/bluetooth/hci_uart/README.rst
+++ b/samples/bluetooth/hci_uart/README.rst
@@ -33,11 +33,11 @@ Zephyr tree, and it is built as a standard Zephyr application.
 Using the controller with emulators and BlueZ
 *********************************************
 
-The instructions below show how to use a Nordic nRF5x device as a Zephyr BLE
+The instructions below show how to use a Nordic nRF5x device as a Zephyr Bluetooth
 controller and expose it to Linux's BlueZ. This can be very useful for testing
 the Zephyr Link Layer with the BlueZ Host. The Zephyr Bluetooth LE controller can also
 provide a modern Bluetooth LE 5.0 controller to a Linux-based machine for native
-BLE support or QEMU-based development.
+Bluetooth support or QEMU-based development.
 
 First, make sure you have a recent BlueZ version installed by following the
 instructions in the :ref:`bluetooth_bluez` section.

--- a/samples/bluetooth/hci_uart/src/main.c
+++ b/samples/bluetooth/hci_uart/src/main.c
@@ -54,7 +54,7 @@ static K_FIFO_DEFINE(uart_tx_queue);
 #define ST_DISCARD 3	/* Dropping packet. */
 
 /* Length of a discard/flush buffer.
- * This is sized to align with a BLE HCI packet:
+ * This is sized to align with a Bluetooth HCI packet:
  * 1 byte H:4 header + 32 bytes ACL/event data
  * Bigger values might overflow the stack since this is declared as a local
  * variable, smaller ones will force the caller to call into discard more

--- a/samples/bluetooth/hci_uart_3wire/README.rst
+++ b/samples/bluetooth/hci_uart_3wire/README.rst
@@ -33,11 +33,11 @@ Zephyr tree, and it is built as a standard Zephyr application.
 Using the controller with emulators and BlueZ
 *********************************************
 
-The instructions below show how to use a Nordic nRF5x device as a Zephyr BLE
+The instructions below show how to use a Nordic nRF5x device as a Zephyr Bluetooth
 controller and expose it to Linux's BlueZ. This can be very useful for testing
 the Zephyr Link Layer with the BlueZ Host. The Zephyr Bluetooth LE controller can also
 provide a modern Bluetooth LE 5.0 controller to a Linux-based machine for native
-BLE support or QEMU-based development.
+Bluetooth support or QEMU-based development.
 
 First, make sure you have a recent BlueZ version installed by following the
 instructions in the :ref:`bluetooth_bluez` section.

--- a/samples/bluetooth/hci_uart_async/README.rst
+++ b/samples/bluetooth/hci_uart_async/README.rst
@@ -36,7 +36,7 @@ in the Zephyr tree and is built as a standard Zephyr application.
 Using the controller with emulators and BlueZ
 *********************************************
 
-The instructions below show how to use a Nordic nRF5x device as a Zephyr BLE
+The instructions below show how to use a Nordic nRF5x device as a Zephyr Bluetooth
 controller and expose it to Linux's BlueZ.
 
 First, make sure you have a recent BlueZ version installed by following the

--- a/samples/bluetooth/iso_broadcast_benchmark/sample.yaml
+++ b/samples/bluetooth/iso_broadcast_benchmark/sample.yaml
@@ -1,5 +1,5 @@
 sample:
-  name: BLE ISO Broadcast
+  name: Bluetooth LE ISO Broadcast
   description: Bluetooth Low Energy ISO Broadcast Benchmark sample
 tests:
   sample.bluetooth.iso_broadcast_benchmark:

--- a/samples/bluetooth/iso_connected_benchmark/sample.yaml
+++ b/samples/bluetooth/iso_connected_benchmark/sample.yaml
@@ -1,5 +1,5 @@
 sample:
-  name: BLE ISO Connected
+  name: Bluetooth LE ISO Connected
   description: Bluetooth Low Energy ISO Connected Benchmark sample
 tests:
   sample.bluetooth.iso_connected_benchmark:

--- a/samples/bluetooth/mesh/README.rst
+++ b/samples/bluetooth/mesh/README.rst
@@ -2,7 +2,7 @@
    :name: Mesh
    :relevant-api: bt_mesh bluetooth
 
-   Use basic Bluetooth LE Mesh functionality.
+   Use basic Bluetooth Mesh functionality.
 
 Overview
 ********

--- a/samples/bluetooth/periodic_adv_conn/README.rst
+++ b/samples/bluetooth/periodic_adv_conn/README.rst
@@ -7,7 +7,7 @@
 Overview
 ********
 
-A simple application demonstrating the initiator side of the BLE
+A simple application demonstrating the initiator side of the Bluetooth LE
 Periodic Advertising Connection Procedure.
 
 How the initiator decides the address of the synced device to connect to

--- a/samples/bluetooth/periodic_sync_conn/README.rst
+++ b/samples/bluetooth/periodic_sync_conn/README.rst
@@ -7,7 +7,7 @@
 Overview
 ********
 
-A simple application demonstrating the responder side of the BLE
+A simple application demonstrating the responder side of the Bluetooth LE
 Periodic Advertising Connection Procedure.
 
 This sample will send its address in response to the advertiser when receiving

--- a/samples/bluetooth/peripheral/sample.yaml
+++ b/samples/bluetooth/peripheral/sample.yaml
@@ -1,6 +1,6 @@
 sample:
   name: Bluetooth Peripheral
-  description: Demonstrates the BLE Peripheral role
+  description: Demonstrates the Bluetooth LE Peripheral role
 tests:
   sample.bluetooth.peripheral:
     harness: bluetooth

--- a/samples/bluetooth/peripheral_accept_list/README.rst
+++ b/samples/bluetooth/peripheral_accept_list/README.rst
@@ -12,7 +12,7 @@ If no device is bonded to the peripheral, casual advertising will be performed.
 Once a device is bonded, on subsequent boots, connection requests will only be
 accepted if the central device is on the accept list. Additionally, scan response
 data will only be sent to devices that are on the accept list. As a result, some
-BLE central devices (such as Android smartphones) might not display the device
+Bluetooth LE central devices (such as Android smartphones) might not display the device
 in the scan results if the central device is not on the accept list.
 
 This sample also provides two Bluetooth LE characteristics. To perform a write, devices need

--- a/samples/bluetooth/scan_adv/sample.yaml
+++ b/samples/bluetooth/scan_adv/sample.yaml
@@ -1,6 +1,6 @@
 sample:
   name: Bluetooth Scan & Advertise
-  description: Demonstrates combined BLE Broadcaster & Observer role functionality
+  description: Demonstrates combined Bluetooth LE Broadcaster & Observer role functionality
 tests:
   sample.bluetooth.scan_adv:
     harness: bluetooth

--- a/samples/bluetooth/st_ble_sensor/README.rst
+++ b/samples/bluetooth/st_ble_sensor/README.rst
@@ -2,7 +2,7 @@
    :name: ST Bluetooth LE Sensor Demo
    :relevant-api: bt_gatt bluetooth
 
-   Export vendor-specific GATT services over BLE.
+   Export vendor-specific GATT services over Bluetooth.
 
 Overview
 ********

--- a/samples/bluetooth/st_ble_sensor/sample.yaml
+++ b/samples/bluetooth/st_ble_sensor/sample.yaml
@@ -1,6 +1,6 @@
 sample:
-  name: Bluetooth ST BLE Sensor Demo
-  description: Demonstrates BLE peripheral by exposing vendor-specific GATT
+  name: Bluetooth ST Bluetooth LE Sensor Demo
+  description: Demonstrates Bluetooth LE peripheral by exposing vendor-specific GATT
     services
 tests:
   sample.bluetooth.st_ble_sensor:

--- a/samples/boards/st/bluetooth/interactive_gui/src/main.c
+++ b/samples/boards/st/bluetooth/interactive_gui/src/main.c
@@ -51,7 +51,7 @@ static K_FIFO_DEFINE(uart_tx_queue);
 #define ST_DISCARD	3 /* Dropping packet. */
 
 /* Length of a discard/flush buffer.
- * This is sized to align with a BLE HCI packet:
+ * This is sized to align with a Bluetooth HCI packet:
  * 1 byte H:4 header + 32 bytes ACL/event data
  * Bigger values might overflow the stack since this is declared as a local
  * variable, smaller ones will force the caller to call into discard more

--- a/samples/boards/st/power_mgmt/stm32wb_ble/src/main.c
+++ b/samples/boards/st/power_mgmt/stm32wb_ble/src/main.c
@@ -122,7 +122,7 @@ int main(void)
 	/* Give time to bt_ready sequence */
 	k_sleep(K_SECONDS(6));
 
-	printk("BLE disable\n");
+	printk("Bluetooth disable\n");
 	err = bt_disable();
 	if (err) {
 		printk("Bluetooth disable failed (err %d)\n", err);
@@ -130,7 +130,7 @@ int main(void)
 
 	k_sleep(K_SECONDS(2));
 
-	printk("BLE restart\n");
+	printk("Bluetooth restart\n");
 	/* Initialize the Bluetooth Subsystem */
 	err = bt_enable(bt_ready);
 	if (err) {
@@ -140,7 +140,7 @@ int main(void)
 	/* Give time to bt_ready sequence */
 	k_sleep(K_SECONDS(6));
 
-	printk("BLE disable\n");
+	printk("Bluetooth disable\n");
 	err = bt_disable();
 	if (err) {
 		printk("Bluetooth disable failed (err %d)\n", err);

--- a/samples/subsys/logging/ble_backend/README.rst
+++ b/samples/subsys/logging/ble_backend/README.rst
@@ -1,24 +1,24 @@
 .. zephyr:code-sample:: logging-ble-backend
-   :name: BLE logging backend
+   :name: Bluetooth logging backend
    :relevant-api: log_api log_backend bt_gatt
 
-   Send log messages over BLE using the BLE logging backend.
+   Send log messages over Bluetooth using the Bluetooth logging backend.
 
 Overview
 ********
 
-Sample that demonstrates how to setup and use the BLE Logging backend. The
-BLE Logger uses the NRF Connect SDK NUS service as UUID to make it compatible
-with already existing apps to debug BLE connections over UART.
+Sample that demonstrates how to setup and use the Bluetooth Logging backend. The
+Bluetooth Logger uses the NRF Connect SDK NUS service as UUID to make it compatible
+with already existing apps to debug Bluetooth connections over UART.
 
-The notification size of the ble backend buffer is dependent on the
+The notification size of the Bluetooth backend buffer is dependent on the
 transmission size of the mtu set with :kconfig:option:`CONFIG_BT_L2CAP_TX_MTU`. Be sure
-to change this configuration to increase the logger throughput over BLE.
+to change this configuration to increase the logger throughput over Bluetooth.
 
 Requirements
 ************
 
-* A board with BLE support
+* A board with Bluetooth LE support
 
 Building and Running
 ********************
@@ -26,5 +26,5 @@ Building and Running
 This sample can be found under :zephyr_file:`samples/subsys/logging/ble_backend` in the
 Zephyr tree.
 
-The BLE logger can be tested with the NRF Toolbox app or any similar app that can connect over
-BLE and detect the NRF NUS UUID service.
+The Bluetooth logger can be tested with the NRF Toolbox app or any similar app that can connect over
+Bluetooth and detect the NRF NUS UUID service.

--- a/samples/subsys/logging/ble_backend/sample.yaml
+++ b/samples/subsys/logging/ble_backend/sample.yaml
@@ -1,6 +1,6 @@
 sample:
-  description: A simple application that demonstrates the use of the logging ble backend.
-  name: logger backend ble
+  description: A simple application that demonstrates the use of the logging Bluetooth backend.
+  name: logger backend Bluetooth
 tests:
   sample.logging.ble_backend.nrf52833:
     harness: bluetooth

--- a/samples/subsys/logging/ble_backend/src/main.c
+++ b/samples/subsys/logging/ble_backend/src/main.c
@@ -73,9 +73,9 @@ void backend_ble_hook(bool status, void *ctx)
 	ARG_UNUSED(ctx);
 
 	if (status) {
-		LOG_INF("BLE Logger Backend enabled.");
+		LOG_INF("Bluetooth Logger Backend enabled.");
 	} else {
-		LOG_INF("BLE Logger Backend disabled.");
+		LOG_INF("Bluetooth Logger Backend disabled.");
 	}
 }
 
@@ -84,7 +84,7 @@ int main(void)
 {
 	int err;
 
-	LOG_INF("BLE LOG Demo");
+	LOG_INF("Bluetooth LOG Demo");
 	logger_backend_ble_set_hook(backend_ble_hook, NULL);
 	err = bt_enable(NULL);
 	if (err) {

--- a/samples/subsys/mgmt/hawkbit/README.rst
+++ b/samples/subsys/mgmt/hawkbit/README.rst
@@ -29,7 +29,7 @@ Caveats
   :zephyr:board:`Freedom-K64F <frdm_k64f>` MCU by default. The application should
   build and run for other platforms with support internet connection. Some
   platforms need some modification. Overlay files would be needed to support
-  BLE 6lowpan, 802.15.4 or OpenThread configurations as well as the
+  Bluetooth LE, 6lowpan, 802.15.4 or OpenThread configurations as well as the
   understanding that most other connectivity options would require an edge
   gateway of some sort (Border Router, etc).
 

--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -143,12 +143,12 @@ config BT_CTLR
 	  the HAS_BT_CTLR option.
 
 config BT_LL_SW_SPLIT
-	bool "Software-based BLE Link Layer"
+	bool "Software-based Bluetooth LE Link Layer"
 	default y
 	depends on DT_HAS_ZEPHYR_BT_HCI_LL_SW_SPLIT_ENABLED
 	select HAS_BT_CTLR
 	help
-	  Use Zephyr software BLE Link Layer ULL LLL split implementation.
+	  Use Zephyr software Bluetooth LE Link Layer ULL LLL split implementation.
 
 config BT_CTLR_HCI
 	bool "Host Controller Interface (HCI)"
@@ -161,7 +161,7 @@ config BT_CTLR_HCI
 
 if HAS_BT_CTLR
 
-comment "BLE Controller configuration"
+comment "Bluetooth Controller configuration"
 
 config BT_CTLR_ENTROPY
 	bool "Random number generation in Controller"
@@ -216,7 +216,7 @@ config BT_CTLR_DUP_FILTER_LEN
 	depends on BT_LL_SW_SPLIT
 	default 16
 	help
-	  Set the number of unique BLE addresses that can be filtered as
+	  Set the number of unique Bluetooth LE addresses that can be filtered as
 	  duplicates while scanning.
 
 config BT_CTLR_DUP_FILTER_ADV_SET_MAX
@@ -322,7 +322,7 @@ choice BT_CTLR_TX_PWR
 	default BT_CTLR_TX_PWR_0
 	depends on BT_CTLR_TX_PWR_ANTENNA = 0 || BT_LL_SW_SPLIT
 	help
-	  Select a supported BLE Radio transmit power level in dBm.
+	  Select a supported Bluetooth LE Radio transmit power level in dBm.
 	  Only values supported natively by the SoC are available.
 	  The value set here represents the actual default power level fed
 	  to the antenna.
@@ -539,7 +539,7 @@ config BT_CTLR_TX_PWR_DYNAMIC_CONTROL
 	  Provides HCI VS commands to set and get the current Tx
 	  power on an individual role/connection basis.
 
-comment "BLE Controller features"
+comment "Bluetooth Controller features"
 
 if BT_CONN
 
@@ -1164,6 +1164,6 @@ config BT_CTLR_DEBUG_PINS_CPUAPP
 	bool "Bluetooth Controller Debug Pins"
 	depends on BOARD_NRF5340DK_NRF5340_CPUAPP
 	help
-	  Route debug GPIO toggling for the BLE Controller. Enable this when
+	  Route debug GPIO toggling for the Bluetooth Controller. Enable this when
 	  using Bluetooth Controller Debug Pins in co-processor and the main
 	  processor needs to setup and/or route the signals.

--- a/subsys/bluetooth/controller/Kconfig.ll_sw_split
+++ b/subsys/bluetooth/controller/Kconfig.ll_sw_split
@@ -95,7 +95,7 @@ config BT_LLL_VENDOR_OPENISA
 	  Use OpenISA Lower Link Layer implementation.
 
 # BT_CTLR_DF_SUPPORT is a wrapper for all DF features. Here we select features that are supported by
-# Zephyr's BLE Controller.
+# Zephyr's Bluetooth LE Controller.
 config BT_CTLR_DF_SUPPORT
 	depends on BT_LL_SW_SPLIT && !BT_CTLR_TIFS_HW
 	select BT_CTLR_DF_CTE_TX_SUPPORT
@@ -973,11 +973,11 @@ config BT_CTLR_SW_SWITCH_SINGLE_TIMER
 					  SOC_COMPATIBLE_NRF54LX)
 	help
 	  Implement the tIFS Trx SW switch with the same TIMER
-	  instance, as the one used for BLE event timing. Requires
+	  instance, as the one used for Bluetooth event timing. Requires
 	  SW switching be enabled. Using a single TIMER:
 	  (+) frees up one TIMER instance
 	  (+) removes jitter for HCTO implementation
-	  (-) introduces drifting to the absolute time inside BLE
+	  (-) introduces drifting to the absolute time inside Bluetooth
 	  events, that increases linearly with the number of
 	  packets exchanged in the event
 	  (-) makes it impossible to use most of the pre-programmed
@@ -1413,7 +1413,7 @@ endchoice
 
 source "subsys/bluetooth/controller/coex/Kconfig"
 
-comment "BLE Controller debug configuration"
+comment "Bluetooth LE Controller debug configuration"
 
 config BT_CTLR_PROFILE_ISR
 	bool "Profile radio ISR"
@@ -1427,7 +1427,7 @@ config BT_CTLR_DEBUG_PINS
 	bool "Bluetooth Controller Debug Pins"
 	depends on BOARD_NRF51DK_NRF51822 || BOARD_NRF52DK_NRF52832 || BOARD_NRF52DK_NRF52810 || BOARD_NRF52840DK_NRF52840 || BOARD_NRF52833DK_NRF52833 || BOARD_NRF5340DK_NRF5340_CPUNET || BOARD_RV32M1_VEGA
 	help
-	  Turn on debug GPIO toggling for the BLE Controller. This is useful
+	  Turn on debug GPIO toggling for the Bluetooth LE Controller. This is useful
 	  when debugging with a logic analyzer or profiling certain sections of
 	  the code.
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
@@ -2098,7 +2098,7 @@ static void *radio_ccm_ext_rx_pkt_set(struct ccm *cnf, uint8_t phy, uint8_t pdu_
 	       CCM_MODE_MODE_Msk;
 
 #if defined(CONFIG_SOC_COMPATIBLE_NRF54LX)
-	/* Enable CCM Protocol Mode BLE */
+	/* Enable CCM Protocol Mode Bluetooth LE */
 	mode |= (CCM_MODE_PROTOCOL_Ble << CCM_MODE_PROTOCOL_Pos) &
 		CCM_MODE_PROTOCOL_Msk;
 
@@ -2342,7 +2342,7 @@ static void *radio_ccm_ext_tx_pkt_set(struct ccm *cnf, uint8_t pdu_type, void *p
 		CCM_MODE_DATARATE_Msk;
 
 #elif defined(CONFIG_SOC_COMPATIBLE_NRF54LX)
-	/* Enable CCM Protocol Mode BLE */
+	/* Enable CCM Protocol Mode Bluetooth LE */
 	mode |= (CCM_MODE_PROTOCOL_Ble << CCM_MODE_PROTOCOL_Pos) &
 		CCM_MODE_PROTOCOL_Msk;
 

--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -287,7 +287,7 @@ config BT_FILTER_ACCEPT_LIST
 	bool "Filter accept list support"
 	help
 	  This option enables the filter accept list API. This takes advantage of the
-	  filtering feature of a BLE controller.
+	  filtering feature of a Bluetooth LE controller.
 	  The filter accept list is a global list and the same list is used
 	  by both scanner and advertiser. The filter accept list cannot be modified while
 	  it is in use.

--- a/subsys/bluetooth/host/uuid.c
+++ b/subsys/bluetooth/host/uuid.c
@@ -15,7 +15,7 @@
 
 #define UUID_16_BASE_OFFSET 12
 
-/* TODO: Decide whether to continue using BLE format or switch to RFC 4122 */
+/* TODO: Decide whether to continue using Bluetooth LE format or switch to RFC 4122 */
 
 /* Base UUID : 0000[0000]-0000-1000-8000-00805F9B34FB
  * 0x2800    : 0000[2800]-0000-1000-8000-00805F9B34FB

--- a/subsys/bluetooth/mesh/Kconfig
+++ b/subsys/bluetooth/mesh/Kconfig
@@ -1536,14 +1536,14 @@ endchoice
 if BT_MESH_USES_MBEDTLS_PSA || BT_MESH_USES_TFM_PSA
 
 config BT_MESH_PSA_KEY_ID_USER_MIN_OFFSET
-	int "Offset of BLE Mesh key id range regarding PSA_KEY_ID_USER_MIN"
+	int "Offset of Bluetooth Mesh key id range regarding PSA_KEY_ID_USER_MIN"
 	default 0
 	help
 	  The PSA specification mandates to set key identifiers for keys
 	  with persistent lifetime. The users of the PSA API is responsible
-	  (BLE Mesh is user of PSA API) to provide correct and unique identifiers.
-	  The BLE Mesh identifier range should be between PSA_KEY_ID_USER_MIN and
-	  PSA_KEY_ID_USER_MAX. BLE Mesh requires two ids for each subnetwork, two ids
+	  (Bluetooth Mesh is user of PSA API) to provide correct and unique identifiers.
+	  The Bluetooth Mesh identifier range should be between PSA_KEY_ID_USER_MIN and
+	  PSA_KEY_ID_USER_MAX. Bluetooth Mesh requires two ids for each subnetwork, two ids
 	  for each application key, and two ids for the device key and device key candidate.
 	  It should consider the Mesh Configuration Database instances if database enabled.
 

--- a/subsys/bluetooth/mesh/crypto_psa.c
+++ b/subsys/bluetooth/mesh/crypto_psa.c
@@ -32,7 +32,7 @@ LOG_MODULE_REGISTER(bt_mesh_crypto_psa);
 		CONFIG_BT_MESH_PSA_KEY_ID_USER_MIN_OFFSET)
 
 BUILD_ASSERT(BT_MESH_PSA_KEY_ID_USER_MIN + BT_MESH_KEY_ID_RANGE_SIZE <= PSA_KEY_ID_USER_MAX,
-	"BLE Mesh PSA key id range overlaps maximum allowed boundary.");
+	     "Bluetooth Mesh PSA key id range overlaps maximum allowed boundary.");
 
 BUILD_ASSERT(PSA_MAC_LENGTH(PSA_KEY_TYPE_AES, 128, PSA_ALG_CMAC) == 16,
 	"MAC length should be 16 bytes for 128-bits key for CMAC-AES");
@@ -286,12 +286,12 @@ const uint8_t *bt_mesh_pub_key_get(void)
 	return dh_pair.is_ready ? dh_pair.public_key_be + 1 : NULL;
 }
 
-BUILD_ASSERT(PSA_RAW_KEY_AGREEMENT_OUTPUT_SIZE(
-	PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_FAMILY_SECP_R1), 256) == DH_KEY_SIZE,
-	"Diffie-Hellman shared secret size should be the same in PSA and BLE Mesh");
+BUILD_ASSERT(PSA_RAW_KEY_AGREEMENT_OUTPUT_SIZE(PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_FAMILY_SECP_R1),
+					       256) == DH_KEY_SIZE,
+	     "Diffie-Hellman shared secret size should be the same in PSA and Bluetooth Mesh");
 
 BUILD_ASSERT(PSA_KEY_EXPORT_ECC_PUBLIC_KEY_MAX_SIZE(256) == PUB_KEY_SIZE + 1,
-	"Exported PSA public key should be 1 byte larger than BLE Mesh public key");
+	     "Exported PSA public key should be 1 byte larger than Bluetooth Mesh public key");
 
 int bt_mesh_dhkey_gen(const uint8_t *pub_key, const uint8_t *priv_key, uint8_t *dhkey)
 {

--- a/subsys/bluetooth/services/ots/ots_l2cap.c
+++ b/subsys/bluetooth/services/ots/ots_l2cap.c
@@ -28,7 +28,7 @@ LOG_MODULE_DECLARE(bt_ots, CONFIG_BT_OTS_LOG_LEVEL);
 LOG_MODULE_REGISTER(bt_ots, CONFIG_BT_OTS_CLIENT_LOG_LEVEL);
 #endif
 
-/* According to BLE specification Assigned Numbers that are used in the
+/* According to Bluetooth specification Assigned Numbers that are used in the
  * Logical Link Control for protocol/service multiplexers.
  */
 #define BT_GATT_OTS_L2CAP_PSM	0x0025

--- a/subsys/logging/backends/Kconfig.ble
+++ b/subsys/logging/backends/Kconfig.ble
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config LOG_BACKEND_BLE
-	bool "Bluetooth Low Energy (BLE) backend"
+	bool "Bluetooth Low Energy (LE) backend"
 	depends on BT
 	depends on LOG_PROCESS_THREAD_STACK_SIZE>=2048
 	select EXPERIMENTAL

--- a/subsys/logging/backends/log_backend_ble.c
+++ b/subsys/logging/backends/log_backend_ble.c
@@ -27,7 +27,7 @@ static void log_backend_ble_connect(struct bt_conn *conn, uint8_t err);
 static void log_backend_ble_disconnect(struct bt_conn *conn, uint8_t reason);
 
 /**
- * @brief Callback for the subscription to the ble logger notification characteristic
+ * @brief Callback for the subscription to the Bluetooth logger notification characteristic
  * @details This callback enables/disables automatically the logger when the notification
  *			is subscribed.
  *  @param attr   The attribute that's changed value
@@ -35,7 +35,7 @@ static void log_backend_ble_disconnect(struct bt_conn *conn, uint8_t reason);
  */
 static void log_notify_changed(const struct bt_gatt_attr *attr, uint16_t value);
 
-/** BLE Logger based on the UUIDs for the NRF Connect SDK NUS service
+/** Bluetooth Logger based on the UUIDs for the NRF Connect SDK NUS service
  *	https://developer.nordicsemi.com/nRF_Connect_SDK/doc/2.3.0/nrf/libraries/bluetooth_services/services/nus.html
  */
 #define NUS_SERVICE_UUID                                                                           \
@@ -55,7 +55,7 @@ BT_CONN_CB_DEFINE(log_backend_ble) = {
 };
 
 /**
- * @brief BLE Service that represents this backend
+ * @brief Bluetooth Service that represents this backend
  * @note Only transmission characteristic is used. The RX characteristic
  *       is added to make the backend usable with the NRF toolbox app
  *       which expects both characteristics.
@@ -175,7 +175,7 @@ static void panic(struct log_backend const *const backend)
 }
 
 /**
- * @brief Backend ready function for ble logger
+ * @brief Backend ready function for Bluetooth logger
  * @details After initialization of the logger, this function avoids
  *          the logger subys to enable it. The logger is enabled automatically
  *          via the notification changed callback.

--- a/tests/bluetooth/df/connectionless_cte_chains/CMakeLists.txt
+++ b/tests/bluetooth/df/connectionless_cte_chains/CMakeLists.txt
@@ -12,7 +12,7 @@ SET(common_sources ${CMAKE_CURRENT_SOURCE_DIR}/../common/src/radio_df_stub.c)
 
 target_sources(app PRIVATE ${common_sources} ${app_sources})
 
-# Include paths to allow access to functions implemented in BLE controller
+# Include paths to allow access to functions implemented in Bluetooth LE controller
 target_include_directories(app PRIVATE
 			   ${CMAKE_CURRENT_SOURCE_DIR}/../common/include)
 target_include_directories(app PRIVATE

--- a/tests/bsim/bluetooth/host/adv/extended/tests_scripts/ext_adv.sh
+++ b/tests/bsim/bluetooth/host/adv/extended/tests_scripts/ext_adv.sh
@@ -4,7 +4,7 @@
 
 # Extended advertising test:
 #
-# - Broadcasting Only: a BLE broadcaster advertises with extended
+# - Broadcasting Only: a Bluetooth LE broadcaster advertises with extended
 #   advertising, and a scanner scans the extended advertisement packets.
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source

--- a/tests/bsim/bluetooth/ll/edtt/README.txt
+++ b/tests/bsim/bluetooth/ll/edtt/README.txt
@@ -1,14 +1,14 @@
 Intro
 #####
 
-This is the embedded side of the BLE conformance tests which are part of the
+This is the embedded side of the Bluetooth conformance tests which are part of the
 EDTT (Embedded Device Test Tool).
 
 Much more info about the tool can be found in https://github.com/EDTTool/EDTT
 and in its `doc/` folder.
 
 In very short, there is 2 applications in this folder:
-1.) A controller only build of the BLE stack, where the HCI, and a few extra
+1.) A controller only build of the Bluetooth LE stack, where the HCI, and a few extra
     interfaces are exposed to the EDTT.
 2.) An application which implements the test GATT services specified by BT SIG
     in GATT_Test_Databases.xlsm, with an EDTT interface which allows the EDTT

--- a/tests/bsim/bluetooth/mesh/src/main.c
+++ b/tests/bsim/bluetooth/mesh/src/main.c
@@ -96,7 +96,7 @@ int main(void)
 	k_thread_create(&bsim_mesh_thread, bsim_mesh_thread_stack,
 			K_KERNEL_STACK_SIZEOF(bsim_mesh_thread_stack), bsim_mesh_entry_point, NULL,
 			NULL, NULL, K_PRIO_COOP(1), 0, K_NO_WAIT);
-	k_thread_name_set(&bsim_mesh_thread, "BabbleSim BLE Mesh tests");
+	k_thread_name_set(&bsim_mesh_thread, "BabbleSim Bluetooth Mesh tests");
 
 	return 0;
 }

--- a/tests/bsim/bluetooth/mesh/tests_scripts/advertiser/disable.sh
+++ b/tests/bsim/bluetooth/mesh/tests_scripts/advertiser/disable.sh
@@ -7,7 +7,7 @@ source $(dirname "${BASH_SOURCE[0]}")/../../_mesh_test.sh
 # The test checks that both advertisers, the legacy and the extended, behave identically.
 # In particular:
 # - `bt_mesh_send_cb.end` callback with error code `0` is called for the advertisement that the
-#   advertiser already pushed to the ble host (called `bt_mesh_send_cb.start`),
+#   advertiser already pushed to the Bluetooth Host (called `bt_mesh_send_cb.start`),
 # - `bt_mesh_send_cb.start` callback with error `-ENODEV` is called for every advertisement that
 #   was pushed to the mesh advertiser using `bt_mesh_adv_send` function,
 # - `bt_mesh_adv_create` returns NULL when attempting to create a new advertisement while the stack


### PR DESCRIPTION
Modifies several places in documentation and comments that used BLE to now use Bluetooth or Bluetooth LE depending on the context. 

BLE is not an official term for Bluetooth Low Energy. Similarly BLE Mesh is just called Bluetooth Mesh. 