### PR TITLE
net: Update IP address refcount properly when address already exists

### DIFF
--- a/include/zephyr/net/net_if.h
+++ b/include/zephyr/net/net_if.h
@@ -136,7 +136,10 @@ struct net_if_addr {
 	 */
 	uint8_t is_temporary : 1;
 
-	uint8_t _unused : 4;
+	/** Was this address added or not */
+	uint8_t is_added : 1;
+
+	uint8_t _unused : 3;
 };
 
 /**
@@ -1217,9 +1220,10 @@ int net_if_set_link_addr_locked(struct net_if *iface,
 extern int net_if_addr_unref_debug(struct net_if *iface,
 				   sa_family_t family,
 				   const void *addr,
+				   struct net_if_addr **ifaddr,
 				   const char *caller, int line);
-#define net_if_addr_unref(iface, family, addr) \
-	net_if_addr_unref_debug(iface, family, addr, __func__, __LINE__)
+#define net_if_addr_unref(iface, family, addr, ifaddr)			\
+	net_if_addr_unref_debug(iface, family, addr, ifaddr, __func__, __LINE__)
 
 extern struct net_if_addr *net_if_addr_ref_debug(struct net_if *iface,
 						 sa_family_t family,
@@ -1231,7 +1235,8 @@ extern struct net_if_addr *net_if_addr_ref_debug(struct net_if *iface,
 #else
 extern int net_if_addr_unref(struct net_if *iface,
 			     sa_family_t family,
-			     const void *addr);
+			     const void *addr,
+			     struct net_if_addr **ifaddr);
 extern struct net_if_addr *net_if_addr_ref(struct net_if *iface,
 					   sa_family_t family,
 					   const void *addr);

--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -784,7 +784,8 @@ static void tcp_conn_release(struct k_work *work)
 		net_if_addr_unref(conn->iface, conn->src.sa.sa_family,
 				  conn->src.sa.sa_family == AF_INET ?
 				  (const void *)&conn->src.sin.sin_addr :
-				  (const void *)&conn->src.sin6.sin6_addr);
+				  (const void *)&conn->src.sin6.sin6_addr,
+				  NULL);
 	}
 
 	conn->context->tcp = NULL;


### PR DESCRIPTION
If an IP address already exists when it is tried to be added to the network interface, then just return it but update ref count if it was not updated. This could happen if the address was added and then removed, but for example an active connection was still using it and keeping the ref count > 0. In this case we must update the ref count so that the IP address is not removed if the connection is closed.

Fixes #85380