### PR TITLE
doc: _extensions: kconfig: allow overwriting Kconfig path

### DIFF
--- a/doc/_extensions/zephyr/kconfig/__init__.py
+++ b/doc/_extensions/zephyr/kconfig/__init__.py
@@ -152,11 +152,18 @@ def kconfig_load(app: Sphinx) -> tuple[kconfiglib.Kconfig, dict[str, str]]:
             if not build_conf:
                 continue
 
+            # Module Kconfig file has already been specified
+            if f"ZEPHYR_{name_var}_KCONFIG" in os.environ:
+                continue
+
             if build_conf.get("kconfig"):
                 kconfig = Path(module.project) / build_conf["kconfig"]
                 os.environ[f"ZEPHYR_{name_var}_KCONFIG"] = str(kconfig)
             elif build_conf.get("kconfig-ext"):
                 for path in app.config.kconfig_ext_paths:
+                    # Assume that the kconfig file exists at this path.
+                    # Technically the cmake variable can be constructed arbitarily
+                    # by "{ext_path}/modules/modules.cmake"
                     kconfig = Path(path) / "modules" / name / "Kconfig"
                     if kconfig.exists():
                         os.environ[f"ZEPHYR_{name_var}_KCONFIG"] = str(kconfig)


### PR DESCRIPTION
Allow specifying the Kconfig file path in the environment (in practice in the `conf.py` file), to allow the script to correctly find Kconfig roots that aren't in the expected `"modules" / name / "Kconfig"` location.

This is required since in the normal build system, the `ZEPHYR_{name_var}_KCONFIG` cmake symbol can be constructed arbitrarily in `modules.cmake`.

An example of a module doing this sort of construction: https://github.com/memfault/memfault-firmware-sdk/blob/master/ports/zephyr/modules/modules.cmake (which was suggested by @tejlmand)