### PR TITLE
samples: led_strip: Make LED brightness configurable

### DIFF
--- a/samples/drivers/led/led_strip/Kconfig
+++ b/samples/drivers/led/led_strip/Kconfig
@@ -9,6 +9,14 @@ config SAMPLE_LED_UPDATE_DELAY
 	help
 	  Delay between LED updates in ms.
 
+config SAMPLE_LED_BRIGHTNESS
+	int "LED brightness"
+	default 16
+	range 1 255
+	help
+	  Brightness level of each LED. Defaults to a low value to make
+	  it easier to distinguish colors.
+
 endmenu
 
 source "Kconfig.zephyr"

--- a/samples/drivers/led/led_strip/README.rst
+++ b/samples/drivers/led/led_strip/README.rst
@@ -65,6 +65,9 @@ Building and Running
 The sample updates the LED strip periodically. The update frequency can be
 modified by changing the :kconfig:option:`CONFIG_SAMPLE_LED_UPDATE_DELAY`.
 
+The brightness level of each LED can be adjusted by changing the
+:kconfig:option:`CONFIG_SAMPLE_LED_BRIGHTNESS` configuration option.
+
 Then build and flash the application:
 
 .. zephyr-app-commands::

--- a/samples/drivers/led/led_strip/src/main.c
+++ b/samples/drivers/led/led_strip/src/main.c
@@ -32,9 +32,9 @@ LOG_MODULE_REGISTER(main);
 #define RGB(_r, _g, _b) { .r = (_r), .g = (_g), .b = (_b) }
 
 static const struct led_rgb colors[] = {
-	RGB(0x0f, 0x00, 0x00), /* red */
-	RGB(0x00, 0x0f, 0x00), /* green */
-	RGB(0x00, 0x00, 0x0f), /* blue */
+	RGB(CONFIG_SAMPLE_LED_BRIGHTNESS, 0x00, 0x00), /* red */
+	RGB(0x00, CONFIG_SAMPLE_LED_BRIGHTNESS, 0x00), /* green */
+	RGB(0x00, 0x00, CONFIG_SAMPLE_LED_BRIGHTNESS), /* blue */
 };
 
 static struct led_rgb pixels[STRIP_NUM_PIXELS];


### PR DESCRIPTION
~~Due to what looks like an oversight, the LED color values in the LED strip sample were not set to full brightness, i.e. 0x0f instead of 0xff.~~

Expose a Kconfig option to adjust max brightness level