### PR TITLE
llext: add new inspection API

### DIFF
--- a/doc/services/llext/api.rst
+++ b/doc/services/llext/api.rst
@@ -6,3 +6,5 @@ API Reference
 .. doxygengroup:: llext_symbols
 
 .. doxygengroup:: llext_loader_apis
+
+.. doxygengroup:: llext_inspect_apis

--- a/doc/services/llext/load.rst
+++ b/doc/services/llext/load.rst
@@ -60,6 +60,10 @@ The returned ``void *`` can then be cast to the appropriate type and used.
 A wrapper for calling a function with no arguments is provided in
 :c:func:`llext_call_fn`.
 
+Advanced users that need direct access to areas of the newly loaded extension
+may want to refer to :c:func:`llext_get_section_info` and other LLEXT
+inspection APIs.
+
 Cleaning up after use
 =====================
 

--- a/include/zephyr/llext/inspect.h
+++ b/include/zephyr/llext/inspect.h
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2025 Arduino SA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_LLEXT_INSPECT_H
+#define ZEPHYR_LLEXT_INSPECT_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stddef.h>
+#include <zephyr/llext/llext.h>
+#include <zephyr/llext/loader.h>
+#include <zephyr/llext/llext_internal.h>
+
+/**
+ * @file
+ * @brief LLEXT ELF inspection routines.
+ *
+ * This file contains routines to inspect the contents of an ELF file. It is
+ * intended to be used by applications that need advanced access to the ELF
+ * file structures of a loaded extension.
+ *
+ * @defgroup llext_inspect_apis ELF inspection APIs
+ * @ingroup llext_apis
+ * @{
+ */
+
+/**
+ * @brief Get information about a memory region for the specified extension.
+ *
+ * Retrieve information about a region (merged group of similar sections) in
+ * the extension. Any output parameter can be NULL if that information is not
+ * needed.
+ *
+ * @param[in] ldr Loader
+ * @param[in] ext Extension
+ * @param[in] region Region to get information about
+ * @param[out] hdr Variable storing the pointer to the region header
+ * @param[out] addr Variable storing the region load address
+ * @param[out] size Variable storing the region size
+ *
+ * @return 0 on success, -EINVAL if the region is invalid
+ */
+static inline int llext_get_region_info(const struct llext_loader *ldr,
+					const struct llext *ext,
+					enum llext_mem region,
+					const elf_shdr_t **hdr,
+					const void **addr, size_t *size)
+{
+	if ((unsigned int)region >= LLEXT_MEM_COUNT) {
+		return -EINVAL;
+	}
+
+	if (hdr) {
+		*hdr = &ldr->sects[region];
+	}
+	if (addr) {
+		*addr = ext->mem[region];
+	}
+	if (size) {
+		*size = ext->mem_size[region];
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Get the index of a section with the specified name.
+ *
+ * Requires the @ref llext_load_param.keep_section_info flag to be set at
+ * extension load time.
+ *
+ * @param[in] ldr Loader
+ * @param[in] ext Extension
+ * @param[in] section_name Name of the section to look for
+ *
+ * @return Section index on success, -ENOENT if the section was not found,
+ *         -ENOTSUP if section data is not available.
+ */
+int llext_section_shndx(const struct llext_loader *ldr, const struct llext *ext,
+			    const char *section_name);
+
+/**
+ * @brief Get information about a section for the specified extension.
+ *
+ * Retrieve information about an ELF sections in the extension. Any output
+ * parameter can be @c NULL if that information is not needed.
+ *
+ * Requires the @ref llext_load_param.keep_section_info flag to be set at
+ * extension load time.
+ *
+ * @param[in] ldr Loader
+ * @param[in] ext Extension
+ * @param[in] shndx Section index
+ * @param[out] hdr Variable storing the pointer to the section header
+ * @param[out] region Variable storing the region the section belongs to
+ * @param[out] offset Variable storing the offset of the section in the region
+ *
+ * @return 0 on success, -EINVAL if the section index is invalid,
+ *         -ENOTSUP if section data is not available.
+ */
+static inline int llext_get_section_info(const struct llext_loader *ldr,
+					 const struct llext *ext,
+					 unsigned int shndx,
+					 const elf_shdr_t **hdr,
+					 enum llext_mem *region,
+					 size_t *offset)
+{
+	if (shndx < 0 || shndx >= ext->sect_cnt) {
+		return -EINVAL;
+	}
+	if (!ldr->sect_map) {
+		return -ENOTSUP;
+	}
+
+	if (hdr) {
+		*hdr = &ext->sect_hdrs[shndx];
+	}
+	if (region) {
+		*region = ldr->sect_map[shndx].mem_idx;
+	}
+	if (offset) {
+		*offset = ldr->sect_map[shndx].offset;
+	}
+
+	return 0;
+}
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_LLEXT_INSPECT_H */

--- a/include/zephyr/llext/llext_internal.h
+++ b/include/zephyr/llext/llext_internal.h
@@ -21,6 +21,11 @@ extern "C" {
 struct llext_loader;
 struct llext;
 
+struct llext_elf_sect_map {
+	enum llext_mem mem_idx;
+	size_t offset;
+};
+
 const void *llext_loaded_sect_ptr(struct llext_loader *ldr, struct llext *ext, unsigned int sh_ndx);
 
 /** @endcond */

--- a/subsys/llext/llext.c
+++ b/subsys/llext/llext.c
@@ -23,30 +23,35 @@ static sys_slist_t _llext_list = SYS_SLIST_STATIC_INIT(&_llext_list);
 
 static struct k_mutex llext_lock = Z_MUTEX_INITIALIZER(llext_lock);
 
-int llext_get_section_header(struct llext_loader *ldr, struct llext *ext, const char *search_name,
-			     elf_shdr_t *shdr)
+int llext_section_shndx(const struct llext_loader *ldr, const struct llext *ext,
+			const char *sect_name)
 {
-	const elf_shdr_t *tmp;
 	unsigned int i;
 
-	for (i = 0, tmp = ext->sect_hdrs;
-	     i < ext->sect_cnt;
-	     i++, tmp++) {
-		const char *name = llext_peek(ldr,
-					      ldr->sects[LLEXT_MEM_SHSTRTAB].sh_offset +
-					      tmp->sh_name);
+	for (i = 1; i < ext->sect_cnt; i++) {
+		const char *name = llext_string(ldr, ext, LLEXT_MEM_SHSTRTAB,
+						ext->sect_hdrs[i].sh_name);
 
-		if (!name) {
-			return -ENOTSUP;
-		}
-
-		if (!strcmp(name, search_name)) {
-			*shdr = *tmp;
-			return 0;
+		if (!strcmp(name, sect_name)) {
+			return i;
 		}
 	}
 
 	return -ENOENT;
+}
+
+int llext_get_section_header(struct llext_loader *ldr, struct llext *ext, const char *search_name,
+			     elf_shdr_t *shdr)
+{
+	int ret;
+
+	ret = llext_section_shndx(ldr, ext, search_name);
+	if (ret < 0) {
+		return ret;
+	}
+
+	*shdr = ext->sect_hdrs[ret];
+	return 0;
 }
 
 ssize_t llext_find_section(struct llext_loader *ldr, const char *search_name)

--- a/subsys/llext/llext_priv.h
+++ b/subsys/llext/llext_priv.h
@@ -9,11 +9,7 @@
 
 #include <zephyr/kernel.h>
 #include <zephyr/llext/llext.h>
-
-struct llext_elf_sect_map {
-	enum llext_mem mem_idx;
-	size_t offset;
-};
+#include <zephyr/llext/llext_internal.h>
 
 /*
  * Memory management (llext_mem.c)
@@ -53,7 +49,7 @@ static inline void llext_free(void *ptr)
 int do_llext_load(struct llext_loader *ldr, struct llext *ext,
 		  const struct llext_load_param *ldr_parm);
 
-static inline const char *llext_string(struct llext_loader *ldr, struct llext *ext,
+static inline const char *llext_string(const struct llext_loader *ldr, const struct llext *ext,
 				       enum llext_mem mem_idx, unsigned int idx)
 {
 	return (char *)ext->mem[mem_idx] + idx;

--- a/tests/subsys/llext/CMakeLists.txt
+++ b/tests/subsys/llext/CMakeLists.txt
@@ -21,6 +21,7 @@ set(ext_names
 	relative_jump
 	object
 	syscalls
+	inspect
 	threads_kernel_objects
 	export_dependent
 	export_dependency

--- a/tests/subsys/llext/src/inspect_ext.c
+++ b/tests/subsys/llext/src/inspect_ext.c
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2025 Arduino SA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* This extension exports a number of symbols to be used by the LLEXT
+ * inspection APIs. Each symbol is exported within a different section
+ * and only the addresses are checked in this test.
+ */
+
+#include <zephyr/llext/symbol.h>
+
+int number_in_bss;
+int number_in_data = 1;
+const int number_in_rodata = 2;
+const int number_in_my_rodata Z_GENERIC_SECTION(.my_rodata) = 3;
+
+void function_in_text(void)
+{
+	/* only used for address check */
+}
+
+EXPORT_SYMBOL(number_in_bss);
+EXPORT_SYMBOL(number_in_data);
+EXPORT_SYMBOL(number_in_rodata);
+EXPORT_SYMBOL(number_in_my_rodata);
+EXPORT_SYMBOL(function_in_text);


### PR DESCRIPTION
### Introduction

This PR introduces a new set of functions that allows applications to access internal details about the loaded extensions. 
In particular, these new functions allows access to data related to the ELF file sections (and their runtime location, if they got picked up by the LLEXT loader):

* a [`llext_get_region_info()`](https://builds.zephyrproject.io/zephyr/pr/85498/docs/doxygen/html/group__llext__inspect__apis.html#gab1dd94250f5fbfa5ba17574a352b4411) function that retrieves the region header, its start address and length, given its index;
* a [`llext_get_section_info()`](https://builds.zephyrproject.io/zephyr/pr/85498/docs/doxygen/html/group__llext__inspect__apis.html#ga88439bee2531869ac0615ea04aba29aa) function that retrieves the ELF section header, its associated region and offset in the region, given its index;  
* a [`llext_section_shndx()`](https://builds.zephyrproject.io/zephyr/pr/85498/docs/doxygen/html/group__llext__inspect__apis.html#ga655023e915eb0ef60e76c0c1625c63c9) function that returns the index of a section given its name.
 
Using the new APIs requires explicitly asking for this data to be kept after `llext_load` completes via a new load-time parameter. If [`keep_section_info`](https://builds.zephyrproject.io/zephyr/pr/85498/docs/doxygen/html/structllext__load__param.html#ae8e62920c8f47e7d2bcf7b7309058fb7) is set in the load params, some of the structures will be retained to allow the application to retrieve the required information. This data can later be discarded by calling the [`llext_free_inspect_data()`](https://builds.zephyrproject.io/zephyr/pr/85498/docs/doxygen/html/group__llext__apis.html#ga54f3aaed749e8c6bad6fbecb1622ab06) function.

### Use case

This new API is extensively used in https://github.com/thesofproject/sof/pull/9831, to remove the strict dependency of SOF from LLEXT internal structures. 
An LLEXT test case that verifies that symbols in different sections map to the expected regions and memory locations are within proper bounds has also been added to the Zephyr test suite.

**I would like to include this in 4.1** so the new API is available for full SOF integration testing during the freeze window.
