### PR TITLE
net: dhcp: Avoid source port validation in replies

### DIFF
--- a/subsys/net/lib/dhcpv4/dhcpv4.c
+++ b/subsys/net/lib/dhcpv4/dhcpv4.c
@@ -1885,8 +1885,7 @@ int net_dhcpv4_init(void)
 	 * all dhcpv4 related incoming packets.
 	 */
 	ret = net_udp_register(AF_INET, NULL, &local_addr,
-			       DHCPV4_SERVER_PORT,
-			       DHCPV4_CLIENT_PORT,
+			       0, DHCPV4_CLIENT_PORT,
 			       NULL, net_dhcpv4_input, NULL, NULL);
 	if (ret < 0) {
 		NET_DBG("UDP callback registration failed");

--- a/subsys/net/lib/dhcpv6/dhcpv6.c
+++ b/subsys/net/lib/dhcpv6/dhcpv6.c
@@ -2222,7 +2222,7 @@ int net_dhcpv6_init(void)
 	unspec_addr.sa_family = AF_INET6;
 
 	ret = net_udp_register(AF_INET6, NULL, &unspec_addr,
-			       DHCPV6_SERVER_PORT, DHCPV6_CLIENT_PORT,
+			       0, DHCPV6_CLIENT_PORT,
 			       NULL, dhcpv6_input, NULL, NULL);
 	if (ret < 0) {
 		NET_DBG("UDP callback registration failed");


### PR DESCRIPTION
There's nothing in RFC 2131 or RFC 8415 that would mandate the DHCP server to reply with a source port set to the IANA assigned one, and some servers seem to send responses with some arbitrary source port set.

Therefore, make Zephyr's DHCP client implementation more permissive, accepting packets with a source port set to a different port than the IANA assigned server port.