### PR TITLE
bluetooth: host: Allow for ECDH operations through system workq

### DIFF
--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -1006,10 +1006,11 @@ config BT_ECC
 	select PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_EXPORT
 	select PSA_WANT_ECC_SECP_R1_256
 	imply MBEDTLS_PSA_P256M_DRIVER_ENABLED if MBEDTLS_PSA_CRYPTO_C
-	select BT_LONG_WQ
+	imply BT_LONG_WQ
 	help
-	  If this option is set, internal APIs will be available to perform ECDH operations
-	  through the long work queue. operations needed e.g. by LE Secure Connections.
+	  If this option is set, internal APIs will be available to perform ECDH operations through
+	  the long work queue (or system work queue). The operations are used e.g. by LE Secure
+	  Connections.
 
 endif # BT_HCI_HOST
 

--- a/subsys/bluetooth/host/ecc.c
+++ b/subsys/bluetooth/host/ecc.c
@@ -283,7 +283,11 @@ int bt_pub_key_gen(struct bt_pub_key_cb *new_cb)
 
 	atomic_clear_bit(bt_dev.flags, BT_DEV_HAS_PUB_KEY);
 
-	bt_long_wq_submit(&pub_key_work);
+	if (IS_ENABLED(CONFIG_BT_LONG_WQ)) {
+		bt_long_wq_submit(&pub_key_work);
+	} else {
+		k_work_submit(&pub_key_work);
+	}
 
 	return 0;
 }
@@ -341,7 +345,11 @@ int bt_dh_key_gen(const uint8_t remote_pk[BT_PUB_KEY_LEN], bt_dh_key_cb_t cb)
 	sys_memcpy_swap(&ecc.public_key_be[BT_PUB_KEY_COORD_LEN],
 			&remote_pk[BT_PUB_KEY_COORD_LEN], BT_PUB_KEY_COORD_LEN);
 
-	bt_long_wq_submit(&dh_key_work);
+	if (IS_ENABLED(CONFIG_BT_LONG_WQ)) {
+		bt_long_wq_submit(&dh_key_work);
+	} else {
+		k_work_submit(&dh_key_work);
+	}
 
 	return 0;
 }

--- a/tests/bsim/bluetooth/host/gatt/ccc_store/overlay-no_long_wq.conf
+++ b/tests/bsim/bluetooth/host/gatt/ccc_store/overlay-no_long_wq.conf
@@ -1,0 +1,2 @@
+# Disable the dedicated workqueue for long-running tasks.
+CONFIG_BT_LONG_WQ=n

--- a/tests/bsim/bluetooth/host/gatt/ccc_store/test_scripts/ccc_store_no_long_wq.sh
+++ b/tests/bsim/bluetooth/host/gatt/ccc_store/test_scripts/ccc_store_no_long_wq.sh
@@ -1,0 +1,41 @@
+#!/bin/env bash
+# Copyright 2025 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
+test_exe="bs_${BOARD_TS}_$(guess_test_long_name)_overlay-no_long_wq_conf"
+simulation_id="ccc_store_no_long_wq"
+verbosity_level=2
+EXECUTE_TIMEOUT=60
+
+cd ${BSIM_OUT_PATH}/bin
+
+if [ "${1}" != 'debug0' ]; then
+  Execute "./${test_exe}" \
+    -v=${verbosity_level} -s=${simulation_id} -d=0 -testid=central \
+    -flash="${simulation_id}_client.log.bin" -flash_rm -RealEncryption=1 -argstest 10
+fi
+
+if [ "${1}" != 'debug1' ]; then
+  Execute "./${test_exe}" \
+    -v=${verbosity_level} -s=${simulation_id} -d=1 -testid=peripheral \
+    -flash="${simulation_id}_server.log.bin" -flash_rm -RealEncryption=1 -argstest 10
+fi
+
+Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
+  -D=2 -sim_length=60e6
+
+if [ "${1}" == 'debug0' ]; then
+  gdb --args "./${test_exe}" \
+    -v=${verbosity_level} -s=${simulation_id} -d=0 -testid=central \
+    -flash="${simulation_id}_client.log.bin" -flash_rm -RealEncryption=1 -argstest 10
+fi
+
+if [ "${1}" == 'debug1' ]; then
+  gdb --args "./${test_exe}" \
+    -v=${verbosity_level} -s=${simulation_id} -d=1 -testid=peripheral \
+    -flash="${simulation_id}_server.log.bin" -flash_rm -RealEncryption=1 -argstest 10
+fi
+
+wait_for_background_jobs

--- a/tests/bsim/bluetooth/host/gatt/ccc_store/test_scripts/ccc_store_no_store_on_write.sh
+++ b/tests/bsim/bluetooth/host/gatt/ccc_store/test_scripts/ccc_store_no_store_on_write.sh
@@ -5,7 +5,7 @@
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 test_exe="bs_${BOARD_TS}_$(guess_test_long_name)_overlay-no_store_on_write_conf"
-simulation_id="ccc_no_store_on_write"
+simulation_id="ccc_store_no_store_on_write"
 verbosity_level=2
 EXECUTE_TIMEOUT=60
 

--- a/tests/bsim/bluetooth/host/gatt/ccc_store/testcase.yaml
+++ b/tests/bsim/bluetooth/host/gatt/ccc_store/testcase.yaml
@@ -10,8 +10,13 @@ tests:
   bluetooth.host.gatt.ccc_store:
     harness_config:
       bsim_exe_name: tests_bsim_bluetooth_host_gatt_ccc_store_prj_conf
-  bluetooth.host.gatt.ccc_store_2:
+  bluetooth.host.gatt.ccc_store_no_store_on_write:
     harness_config:
       bsim_exe_name: tests_bsim_bluetooth_host_gatt_ccc_store_overlay-no_store_on_write_conf
     extra_args:
       EXTRA_CONF_FILE=overlay-no_store_on_write.conf
+  bluetooth.host.gatt.ccc_store_no_long_wq:
+    harness_config:
+      bsim_exe_name: tests_bsim_bluetooth_host_gatt_ccc_store_overlay-no_long_wq_conf
+    extra_args:
+      EXTRA_CONF_FILE=overlay-no_long_wq.conf

--- a/tests/bsim/bluetooth/host/security/ccc_update/overlay-no_long_wq.conf
+++ b/tests/bsim/bluetooth/host/security/ccc_update/overlay-no_long_wq.conf
@@ -1,0 +1,2 @@
+# Disable the dedicated workqueue for long-running tasks.
+CONFIG_BT_LONG_WQ=n

--- a/tests/bsim/bluetooth/host/security/ccc_update/test_scripts/ccc_update_no_long_wq.sh
+++ b/tests/bsim/bluetooth/host/security/ccc_update/test_scripts/ccc_update_no_long_wq.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
-# Copyright 2023 Nordic Semiconductor ASA
+# Copyright 2025 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 test_name='ccc_update'
-test_exe="bs_${BOARD_TS}_tests_bsim_bluetooth_host_security_${test_name}_overlay-no_lazy_load_conf"
-simulation_id="${test_name}_no_lazy_load"
+test_exe="bs_${BOARD_TS}_tests_bsim_bluetooth_host_security_${test_name}_overlay-no_long_wq_conf"
+simulation_id="${test_name}_no_long_wq"
 verbosity_level=2
 
 cd ${BSIM_OUT_PATH}/bin

--- a/tests/bsim/bluetooth/host/security/ccc_update/testcase.yaml
+++ b/tests/bsim/bluetooth/host/security/ccc_update/testcase.yaml
@@ -10,8 +10,13 @@ tests:
   bluetooth.host.security.ccc_update:
     harness_config:
       bsim_exe_name: tests_bsim_bluetooth_host_security_ccc_update_prj_conf
-  bluetooth.host.security.ccc_update_2:
+  bluetooth.host.security.ccc_update_no_lazy_load:
     harness_config:
       bsim_exe_name: tests_bsim_bluetooth_host_security_ccc_update_overlay-no_lazy_load_conf
     extra_args:
       EXTRA_CONF_FILE=overlay-no_lazy_load.conf
+  bluetooth.host.security.ccc_update_no_long_wq:
+    harness_config:
+      bsim_exe_name: tests_bsim_bluetooth_host_security_ccc_update_overlay-no_long_wq_conf
+    extra_args:
+      EXTRA_CONF_FILE=overlay-no_long_wq.conf


### PR DESCRIPTION
Change allows performing ECDH operations through system workq. This is done to allow reducing memory consumption by disabling the long workq on small SoCs.