### PR TITLE
tests: bluetooth: tester: mesh: Increase CMD tx bufs

### DIFF
--- a/tests/bluetooth/tester/overlay-mesh.conf
+++ b/tests/bluetooth/tester/overlay-mesh.conf
@@ -58,3 +58,6 @@ CONFIG_BT_MESH_COMP_PAGE_2=y
 CONFIG_BT_MESH_BRG_CFG_SRV=y
 CONFIG_BT_MESH_BRG_CFG_CLI=y
 CONFIG_SETTINGS=y
+
+# Increase the number of buffers to avoid deadlock when running out of buffers
+CONFIG_BT_BUF_CMD_TX_COUNT=4


### PR DESCRIPTION
Increase CONFIG_BT_BUF_CMD_TX_COUNT to avoid deadlock when running out of buffers. See #77241 for the reference.

This fixes Mesh Provisioning Service tests (MESH/NODE/MPS).