### PR TITLE
Bluetooth: CCP: Add missing documentation for CCP discover

### DIFF
--- a/include/zephyr/bluetooth/audio/ccp.h
+++ b/include/zephyr/bluetooth/audio/ccp.h
@@ -145,6 +145,24 @@ struct bt_ccp_call_control_client_cb {
 	sys_snode_t _node;
 };
 
+/**
+ * @brief Discovers the Telephone Bearer Service (TBS) support on a remote device.
+ *
+ * This will discover the Telephone Bearer Service (TBS) and Generic Telephone Bearer Service (GTBS)
+ * on the remote device.
+ *
+ * @kconfig_dep{CONFIG_BT_CCP_CALL_CONTROL_CLIENT}.
+ *
+ * @param conn Connection to a remote server.
+ * @param out_client Pointer to client instance on success
+ *
+ * @retval 0 Success
+ * @retval -EINVAL @p conn or @p out_client is NULL
+ * @retval -ENOTCONN @p conn is not connected
+ * @retval -ENOMEM Could not allocated memory for the request
+ * @retval -EBUSY Already doing discovery for @p conn
+ * @retval -ENOEXEC Rejected by the GATT layer
+ */
 int bt_ccp_call_control_client_discover(struct bt_conn *conn,
 					struct bt_ccp_call_control_client **out_client);
 

--- a/subsys/bluetooth/audio/ccp_call_control_client.c
+++ b/subsys/bluetooth/audio/ccp_call_control_client.c
@@ -189,7 +189,7 @@ int bt_ccp_call_control_client_discover(struct bt_conn *conn,
 		atomic_clear_bit(client->flags, CCP_CALL_CONTROL_CLIENT_FLAG_BUSY);
 
 		/* Return known errors */
-		if (err == -EBUSY) {
+		if (err == -EBUSY || err == -ENOTCONN) {
 			return err;
 		}
 


### PR DESCRIPTION
Added missing documentation for
bt_ccp_call_control_client_discover.

Added missing handling of -ENOTCONN in the function as well.