### PR TITLE
Bluetooth: TBS: Add support for long read with dirty bit

### DIFF
--- a/include/zephyr/bluetooth/audio/tbs.h
+++ b/include/zephyr/bluetooth/audio/tbs.h
@@ -37,6 +37,11 @@
 extern "C" {
 #endif
 
+/** A characteristic value has changed while a Read Long Value Characteristic sub-procedure is in
+ * progress
+ */
+#define BT_TBS_ERR_VAL_CHANGED 0x80
+
 /**
  * @name Call States
  * @{


### PR DESCRIPTION
The TBS spec states that if a value is changed during a
long read procedure, then the server shall reject
read requests with offset != 0 with a specific TBS GATT
error until the value has been read from the beginning again
(i.e. with offset = 0).

fixes https://github.com/zephyrproject-rtos/zephyr/issues/68173