### PR TITLE
drivers: nrf_wifi: Fix SAP and P2P build issues

### DIFF
--- a/drivers/wifi/nrf_wifi/src/wpa_supp_if.c
+++ b/drivers/wifi/nrf_wifi/src/wpa_supp_if.c
@@ -1969,7 +1969,7 @@ static int nrf_wifi_vif_state_change(struct nrf_wifi_vif_ctx_zep *vif_ctx_zep,
 	unsigned int timeout = 0;
 	struct nrf_wifi_fmac_vif_ctx *vif_ctx = NULL;
 	enum nrf_wifi_status status = NRF_WIFI_STATUS_FAIL;
-	struct nrf_wifi_fmac_dev_ctx_def *def_dev_ctx = NULL;
+	struct nrf_wifi_sys_fmac_dev_ctx *sys_dev_ctx = NULL;
 	int ret = -1;
 
 	if (!vif_ctx_zep) {
@@ -1988,8 +1988,8 @@ static int nrf_wifi_vif_state_change(struct nrf_wifi_vif_ctx_zep *vif_ctx_zep,
 		goto out;
 	}
 
-	def_dev_ctx = wifi_dev_priv(rpu_ctx_zep->rpu_ctx);
-	vif_ctx = def_dev_ctx->vif_ctx[vif_ctx_zep->vif_idx];
+	sys_dev_ctx = wifi_dev_priv(rpu_ctx_zep->rpu_ctx);
+	vif_ctx = sys_dev_ctx->vif_ctx[vif_ctx_zep->vif_idx];
 
 	vif_state_info.state = state;
 	vif_state_info.if_index = vif_ctx_zep->vif_idx;

--- a/tests/drivers/wifi/nrf_wifi/testcase.yaml
+++ b/tests/drivers/wifi/nrf_wifi/testcase.yaml
@@ -7,6 +7,8 @@ common:
   platform_allow:
     - nrf7002dk/nrf5340/cpuapp
 tests:
+  nrf70.build.sta:
+    extra_configs: []
   nrf70.build.radio_test:
     extra_configs:
       - CONFIG_NRF70_RADIO_TEST=y
@@ -44,3 +46,9 @@ tests:
       - CONFIG_NETWORKING=n
       - CONFIG_WIFI_NM_WPA_SUPPLICANT=n
       - CONFIG_NET_L2_WIFI_MGMT=n
+  nrf70.build.softap:
+    extra_configs:
+      - CONFIG_WIFI_NM_WPA_SUPPLICANT_AP=y
+  nrf70.build.p2p:
+    extra_configs:
+      - CONFIG_NRF70_P2P_MODE=y

--- a/west.yml
+++ b/west.yml
@@ -321,7 +321,7 @@ manifest:
       revision: 2570f4a697ce2da860ff39ec34afd91749bd66d3
       path: modules/bsim_hw_models/nrf_hw_models
     - name: nrf_wifi
-      revision: 01359dffd9b6da4d162b4565fdd621ad94bd5d4e
+      revision: e35f707a782b7c4c0eb83a3b06ca4e6eb693f29f
       path: modules/lib/nrf_wifi
     - name: open-amp
       revision: 52bb1783521c62c019451cee9b05b8eda9d7425f


### PR DESCRIPTION
1. Fix build issues for SAP and P2P modes (missed in the previous PR for mode based code segregation). 
2. Also extend twister for the above modes.