### PR TITLE
modules: hostap: Fix the SoF in iface_wq

### DIFF
--- a/modules/hostap/Kconfig
+++ b/modules/hostap/Kconfig
@@ -35,7 +35,7 @@ config WIFI_NM_WPA_SUPPLICANT_THREAD_STACK_SIZE
 
 config WIFI_NM_WPA_SUPPLICANT_WQ_STACK_SIZE
 	int "Stack size for wpa_supplicant iface workqueue"
-	default 4096
+	default 4400
 
 config WIFI_NM_WPA_SUPPLICANT_WQ_PRIO
 	int "Thread priority of wpa_supplicant iface workqueue"


### PR DESCRIPTION
In case interface is UP, the interface is added to WPA supplicant in the iface_wq itself and the max stack size is 4264, so, increase the stack size of the iface_wq.

If the interface is added via net_mgmt thread then it works fine.