### PR TITLE
Activate Zero Latency IRQ for SILABS Series 2 SoC

### DIFF
--- a/soc/silabs/silabs_s2/Kconfig.defconfig
+++ b/soc/silabs/silabs_s2/Kconfig.defconfig
@@ -18,4 +18,17 @@ config SILABS_SLEEPTIMER_TIMER
 config CORTEX_M_SYSTICK
 	default n if SILABS_SLEEPTIMER_TIMER || GECKO_BURTC_TIMER
 
+# silabs_s2 uses simplicity_sdk hal library, which already have by default a zero latency
+# IRQs mechanism with a hardcoded value. In order to be aligned with simplicity_sdk, we
+# need to activate Zero Latency IRQ in Zephyr by default. The level (2) depends on the
+# hardcoded value in simplicity_sdk (CORE_ATOMIC_BASE_PRIORITY_LEVEL). Without this config,
+# if you use an IRQ with a priority of 0 or 1, irq_lock() and irq_unlock() have no effect
+# over this IRQ.
+
+config ZERO_LATENCY_IRQS
+	default y
+
+config ZERO_LATENCY_LEVELS
+	default 2
+
 endif


### PR DESCRIPTION
silabs_s2 SoC uses simplicity_sdk HAL library, which already have by default a zero latency IRQs mechanism with a hardcoded value. In order to be aligned with simplicity_sdk , we need to activate Zero Latency IRQ in Zephyr by default. The level (2) depends on the hardcoded value in simplicity_sdk (CORE_ATOMIC_BASE_PRIORITY_LEVEL).

Without this fix, if you use an IRQ with a priority of 0 or 1, irq_lock() and irq_unlock() will not have any effect.