### PR TITLE
doc: releases: remove 2.7 from the list of supported releases

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -198,7 +198,6 @@ html_context = {
         ("latest", "/"),
         ("4.0.0", "/4.0.0/"),
         ("3.7.0 (LTS)", "/3.7.0/"),
-        ("2.7.6 (LTS)", "/2.7.6/"),
     ),
     "display_gh_links": True,
     "reference_links": {

--- a/doc/releases/index.rst
+++ b/doc/releases/index.rst
@@ -58,8 +58,6 @@ Supported Releases
 +-----------------+----------------+---------------+
 | Release         | Release date   | EOL           |
 +=================+================+===============+
-| `Zephyr 2.7.6`_ | 2024-03-01     | 2025-01-26    |
-+-----------------+----------------+---------------+
 | `Zephyr 3.7.0`_ | 2024-07-26     | 2027-01-26    |
 +-----------------+----------------+---------------+
 | `Zephyr 4.0.0`_ | 2024-11-15     | 2025-07-18    |
@@ -81,7 +79,6 @@ needs to be changed are to be detailed in the release's migration guide.
    :glob:
    :reversed:
 
-   release-notes-2.7
    release-notes-3.7
    release-notes-4.[0-1]
 
@@ -131,6 +128,5 @@ Release notes and migration guides for end-of-life releases of Zephyr RTOS can b
 
 .. _`GitHub repository`: https://github.com/zephyrproject-rtos/zephyr
 .. _`GitHub tagged releases`: https://github.com/zephyrproject-rtos/zephyr/tags
-.. _`Zephyr 2.7.6`: https://docs.zephyrproject.org/2.7.6/
 .. _`Zephyr 3.7.0`: https://docs.zephyrproject.org/3.7.0/
 .. _`Zephyr 4.0.0`: https://docs.zephyrproject.org/4.0.0/


### PR DESCRIPTION
2.7 went EOL on January 26th, remove it from the list.