### PR TITLE
drivers: icm42688_spi: Fix spi read bufs

### DIFF
--- a/drivers/sensor/tdk/icm42688/icm42688_spi.c
+++ b/drivers/sensor/tdk/icm42688/icm42688_spi.c
@@ -34,14 +34,20 @@ static inline int spi_read_register(const struct spi_dt_spec *bus, uint8_t reg, 
 {
 	uint8_t tx_buffer = REG_SPI_READ_BIT | reg;
 
-	const struct spi_buf tx_buf = {
-		.buf = &tx_buffer,
-		.len = 1,
+	const struct spi_buf tx_buf[2] = {
+		{
+			.buf = &tx_buffer,
+			.len = 1,
+		},
+		{
+			.buf = NULL,
+			.len = len,
+		}
 	};
 
 	const struct spi_buf_set tx = {
-		.buffers = &tx_buf,
-		.count = 1,
+		.buffers = tx_buf,
+		.count = 2,
 	};
 
 	struct spi_buf rx_buf[2] = {


### PR DESCRIPTION
The spi read is implemented incorrectly, if a spi driver is implemented correctly, the TX buf size controls the length of the transfer, so need to declare a NULL tx buf for the transfer to be long enough to read the RX buf size.

Fixes #85355