### PR TITLE
modules: hal_norfic: rise 802.15.4 NET core init priority

### DIFF
--- a/modules/hal_nordic/Kconfig
+++ b/modules/hal_nordic/Kconfig
@@ -109,7 +109,7 @@ if NRF_802154_SER_RADIO
 
 config NRF_802154_SER_RADIO_INIT_PRIO
 	int "nRF52 IEEE 802.15.4 serialization initialization priority"
-	default 51
+	default 53
 	help
 	  Set the initialization priority number. Do not mess with it unless
 	  you know what you are doing.


### PR DESCRIPTION
Due to internal dependencies on other modules init priority the 802.15.4 priority level must be increased. Former init priority caused the module to be initialized before those it depends on, so that lead to hard faults.