### PR TITLE
MAINTAINERS: remove bbilas as LED collaborator

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1785,8 +1785,6 @@ Release Notes:
   maintainers:
     - Mani-Sadhasivam
     - simonguinot
-  collaborators:
-    - bbilas
   files:
     - drivers/led/
     - include/zephyr/drivers/led/


### PR DESCRIPTION
I don't have time to review the LED area in Zephyr, so I step aside to make room for someone else.

Thanks @simonguinot for the great discussions during the MRs review, I hope I get the chance to do it again in the future.