### PR TITLE
spi_nxp_lpspi: RX bigger than TX read all RX

### DIFF
--- a/drivers/spi/spi_nxp_lpspi/CMakeLists.txt
+++ b/drivers/spi/spi_nxp_lpspi/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Copyright 2024 NXP
 
 zephyr_library_sources_ifdef(CONFIG_SPI_MCUX_LPSPI spi_nxp_lpspi_common.c)
-zephyr_library_sources_ifdef(CONFIG_SPI_MCUX_LPSPI_NORMAL spi_nxp_lpspi.c)
+zephyr_library_sources_ifdef(CONFIG_SPI_MCUX_LPSPI_CPU spi_nxp_lpspi.c)
 zephyr_library_sources_ifdef(CONFIG_SPI_MCUX_LPSPI_DMA spi_nxp_lpspi_dma.c)

--- a/drivers/spi/spi_nxp_lpspi/Kconfig
+++ b/drivers/spi/spi_nxp_lpspi/Kconfig
@@ -20,11 +20,11 @@ config SPI_MCUX_LPSPI_DMA
 	  Enable the SPI DMA mode for SPI instances
 	  that enable dma channels in their device tree node.
 
-config SPI_MCUX_LPSPI_NORMAL
+config SPI_MCUX_LPSPI_CPU
 	bool "NXP MCUX LPSPI driver"
 	default y
 	depends on $(dt_compat_any_not_has_prop,$(DT_COMPAT_NXP_LPSPI),dmas) || !SPI_MCUX_LPSPI_DMA
 	help
-	  Use the traditional (non-RTIO) SPI driver for NXP LPSPI.
+	  Use the CPU-based LPSPI driver.
 
 endif # SPI_MCUX_LPSPI

--- a/drivers/spi/spi_nxp_lpspi/spi_nxp_lpspi.c
+++ b/drivers/spi/spi_nxp_lpspi/spi_nxp_lpspi.c
@@ -62,7 +62,7 @@ static inline size_t lpspi_rx_buf_write_words(const struct device *dev, uint8_t 
 	struct spi_mcux_data *data = dev->data;
 	struct lpspi_driver_data *lpspi_data = (struct lpspi_driver_data *)data->driver_data;
 	struct spi_context *ctx = &data->ctx;
-	size_t buf_len = ctx->rx_len / lpspi_data->word_size_bytes;
+	size_t buf_len = DIV_ROUND_UP(ctx->rx_len, lpspi_data->word_size_bytes);
 	uint8_t words_read = 0;
 	size_t offset = 0;
 
@@ -158,7 +158,7 @@ static void lpspi_next_tx_fill(const struct device *dev)
 	size_t max_chunk;
 
 	/* Convert bytes to words for this xfer */
-	max_chunk = ctx->tx_len / lpspi_data->word_size_bytes;
+	max_chunk = DIV_ROUND_UP(ctx->tx_len, lpspi_data->word_size_bytes);
 	max_chunk = MIN(max_chunk, config->tx_fifo_size);
 	lpspi_data->fill_len = max_chunk;
 

--- a/drivers/spi/spi_nxp_lpspi/spi_nxp_lpspi.c
+++ b/drivers/spi/spi_nxp_lpspi/spi_nxp_lpspi.c
@@ -13,8 +13,6 @@ LOG_MODULE_REGISTER(spi_mcux_lpspi, CONFIG_SPI_LOG_LEVEL);
 
 struct lpspi_driver_data {
 	size_t fill_len;
-	size_t tx_total_len;
-	size_t rx_total_len;
 	uint8_t word_size_bytes;
 };
 
@@ -252,9 +250,6 @@ static int transceive(const struct device *dev, const struct spi_config *spi_cfg
 	}
 
 	spi_context_buffers_setup(&data->ctx, tx_bufs, rx_bufs, lpspi_data->word_size_bytes);
-
-	lpspi_data->tx_total_len = spi_context_total_tx_len(&data->ctx);
-	lpspi_data->rx_total_len = spi_context_total_rx_len(&data->ctx);
 
 	ret = spi_mcux_configure(dev, spi_cfg);
 	if (ret) {

--- a/drivers/spi/spi_nxp_lpspi/spi_nxp_lpspi_common.c
+++ b/drivers/spi/spi_nxp_lpspi/spi_nxp_lpspi_common.c
@@ -57,6 +57,10 @@ int spi_mcux_configure(const struct device *dev, const struct spi_config *spi_cf
 		return ret;
 	}
 
+	base->CR |= LPSPI_CR_RST_MASK;
+	base->CR |= LPSPI_CR_RRF_MASK | LPSPI_CR_RTF_MASK;
+	base->CR = 0x00U;
+
 	if (data->ctx.config != NULL) {
 		/* Setting the baud rate in LPSPI_MasterInit requires module to be disabled. Only
 		 * disable if already configured, otherwise the clock is not enabled and the


### PR DESCRIPTION
Change the driver behavior so that if the provided RX buffer set is bigger than the TX buffer, we will read all the RX buffer and fill the TX with NOPs. The SPI driver API does not say to do this, and my original interpretation of the API was that the TX length controls the entire transfer length, but this behavior might fit better with some de facto expectations of in tree consumers.

Alternative to #85526 to Fixes #85355

There is clearly some ambiguity in the SPI API, I have on my todo list to improve the documentation of SPI API, and probably this behavior in this PR is preferable.

Fixes #85901

I also plan to add some test cases to the SPI loopback test suite soon to catch many of these bugs LPSPI is having that are not caught by the test.