### PR TITLE
net: l2: ethernet: Fix unused function warning

### DIFF
--- a/subsys/net/l2/ethernet/ethernet.c
+++ b/subsys/net/l2/ethernet/ethernet.c
@@ -171,6 +171,7 @@ static inline bool eth_is_vlan_tag_stripped(struct net_if *iface)
 	return (net_eth_get_hw_capabilities(iface) & ETHERNET_HW_VLAN_TAG_STRIP);
 }
 
+#if defined(CONFIG_NET_IPV4) || defined(CONFIG_NET_IPV6)
 /* Drop packet if it has broadcast destination MAC address but the IP
  * address is not multicast or broadcast address. See RFC 1122 ch 3.3.6
  */
@@ -191,6 +192,7 @@ enum net_verdict ethernet_check_ipv4_bcast_addr(struct net_pkt *pkt,
 
 	return NET_OK;
 }
+#endif
 
 #if defined(CONFIG_NET_NATIVE_IP) && !defined(CONFIG_NET_RAW_MODE)
 static void ethernet_mcast_monitor_cb(struct net_if *iface, const struct net_addr *addr,


### PR DESCRIPTION
Building with clang warns:

subsys/net/l2/ethernet/ethernet.c:178:18: error: unused function
'ethernet_check_ipv4_bcast_addr' [-Werror,-Wunused-function]
enum net_verdict ethernet_check_ipv4_bcast_addr(struct net_pkt *pkt,
                 ^

ethernet_check_ipv4_bcast_addr is called by ethernet_ip_recv, which only
exists when CONFIG_NET_IPV4 or CONFIG_NET_IPV6 is defined.