### PR TITLE
soc: xlnx: zynqmp: Support I/D caches

### DIFF
--- a/arch/arm/core/cortex_a_r/Kconfig
+++ b/arch/arm/core/cortex_a_r/Kconfig
@@ -82,6 +82,8 @@ config CPU_CORTEX_R5
 	select CPU_AARCH32_CORTEX_R
 	select ARMV7_R
 	select ARMV7_R_FP if CPU_HAS_FPU
+	select CPU_HAS_ICACHE
+	select CPU_HAS_DCACHE
 	help
 	  This option signifies the use of a Cortex-R5 CPU
 

--- a/arch/arm/core/cortex_a_r/cache.c
+++ b/arch/arm/core/cortex_a_r/cache.c
@@ -208,7 +208,13 @@ int arch_icache_flush_range(void *start_addr, size_t size)
 
 int arch_icache_invd_range(void *start_addr, size_t size)
 {
-	return -ENOTSUP;
+	/* Cortex A/R do have the ICIMVAU operation to selectively invalidate
+	 * the instruction cache, but not currently supported by CMSIS.
+	 * For now, invalidate the entire cache.
+	 */
+	L1C_InvalidateICacheAll();
+
+	return 0;
 }
 
 int arch_icache_flush_and_invd_range(void *start_addr, size_t size)

--- a/soc/xlnx/zynqmp/Kconfig
+++ b/soc/xlnx/zynqmp/Kconfig
@@ -6,5 +6,6 @@ config SOC_XILINX_ZYNQMP_RPU
 	select ARM
 	select CPU_CORTEX_R5
 	select SOC_RESET_HOOK
+	select SOC_EARLY_INIT_HOOK
 	select CPU_HAS_ARM_MPU
 	select VFP_DP_D16

--- a/soc/xlnx/zynqmp/soc.c
+++ b/soc/xlnx/zynqmp/soc.c
@@ -7,6 +7,7 @@
 
 #include <zephyr/kernel.h>
 #include <zephyr/device.h>
+#include <zephyr/cache.h>
 
 #include <cmsis_core.h>
 
@@ -19,4 +20,11 @@ void soc_reset_hook(void)
 
 	sctlr &= ~SCTLR_V_Msk;
 	__set_SCTLR(sctlr);
+}
+
+void soc_early_init_hook(void)
+{
+	/* Enable caches */
+	sys_cache_instr_enable();
+	sys_cache_data_enable();
 }


### PR DESCRIPTION
Support enabling the instruction and data caches in the Cortex-R5 on the Xilinx ZynqMP RPU platform when CONFIG_CACHE_MANAGEMENT is enabled.

Requested in https://github.com/zephyrproject-rtos/zephyr/issues/79990