### PR TITLE
kernel: Timeslicing and yield to share code

### DIFF
--- a/kernel/include/ksched.h
+++ b/kernel/include/ksched.h
@@ -49,7 +49,6 @@ extern struct k_spinlock _sched_spinlock;
 extern struct k_thread _thread_dummy;
 
 void z_sched_init(void);
-void z_move_thread_to_end_of_prio_q(struct k_thread *thread);
 void z_unpend_thread_no_timeout(struct k_thread *thread);
 struct k_thread *z_unpend1_no_timeout(_wait_q_t *wait_q);
 int z_pend_curr(struct k_spinlock *lock, k_spinlock_key_t key,
@@ -71,7 +70,7 @@ void z_ready_thread(struct k_thread *thread);
 void z_requeue_current(struct k_thread *curr);
 struct k_thread *z_swap_next_thread(void);
 void z_thread_abort(struct k_thread *thread);
-void move_thread_to_end_of_prio_q(struct k_thread *thread);
+void z_yield(struct k_thread *curr);
 bool thread_is_sliceable(struct k_thread *thread);
 
 static inline void z_reschedule_unlocked(void)

--- a/kernel/timeslicing.c
+++ b/kernel/timeslicing.c
@@ -123,7 +123,7 @@ void z_time_slice(void)
 		}
 #endif
 		if (!z_is_thread_prevented_from_running(curr)) {
-			move_thread_to_end_of_prio_q(curr);
+			z_yield(curr);
 		}
 		z_reset_time_slice(curr);
 	}

--- a/tests/arch/arm/arm_thread_swap/src/arm_syscalls.c
+++ b/tests/arch/arm/arm_thread_swap/src/arm_syscalls.c
@@ -21,6 +21,8 @@
 #define PRIORITY 0
 #define DB_VAL   0xDEADBEEF
 
+void z_yield_testing_only(struct k_thread *curr);
+
 static struct k_thread user_thread;
 static K_THREAD_STACK_DEFINE(user_thread_stack, 1024);
 
@@ -90,7 +92,7 @@ void arm_isr_handler(const void *args)
 
 		/* Trigger thread yield() manually */
 		(void)irq_lock();
-		z_move_thread_to_end_of_prio_q(_current);
+		z_yield_testing_only(_current);
 		SCB->ICSR |= SCB_ICSR_PENDSVSET_Msk;
 		irq_unlock(0);
 

--- a/tests/arch/arm/arm_thread_swap/src/arm_thread_arch.c
+++ b/tests/arch/arm/arm_thread_swap/src/arm_thread_arch.c
@@ -36,7 +36,7 @@
 #define FPSCR_MASK (0xffffffffU)
 #endif
 
-extern void z_move_thread_to_end_of_prio_q(struct k_thread *thread);
+void z_yield_testing_only(struct k_thread *curr);
 
 static struct k_thread alt_thread;
 static K_THREAD_STACK_DEFINE(alt_thread_stack, 1024);
@@ -270,7 +270,7 @@ static void alt_thread_entry(void *p1, void *p2, void *p3)
 	p_ztest_thread->arch.swap_return_value = SWAP_RETVAL;
 #endif
 
-	z_move_thread_to_end_of_prio_q(_current);
+	z_yield_testing_only(_current);
 
 	/* Modify the callee-saved registers by zero-ing them.
 	 * The main test thread will, later, assert that they
@@ -484,7 +484,7 @@ ZTEST(arm_thread_swap, test_arm_thread_swap)
 	 * explicitly required by the test.
 	 */
 	(void)irq_lock();
-	z_move_thread_to_end_of_prio_q(_current);
+	z_yield_testing_only(_current);
 
 	/* Clear the thread's callee-saved registers' container.
 	 * The container will, later, be populated by the swap


### PR DESCRIPTION
When timeslicing moves the current thread to the end of the priority queue, it is functionally equivalent to yielding. It makes sense for the two to share common code.