### PR TITLE
drivers: serial: pl011: fix missing TX callback with FIFO enabled

### DIFF
--- a/drivers/serial/uart_pl011.c
+++ b/drivers/serial/uart_pl011.c
@@ -343,6 +343,8 @@ static void pl011_irq_tx_enable(const struct device *dev)
 
 	get_uart(dev)->imsc |= PL011_IMSC_TXIM;
 	if (data->sw_call_txdrdy) {
+		data->sw_call_txdrdy = false;
+
 		/* Verify if the callback has been registered */
 		if (data->irq_cb) {
 			/*
@@ -357,14 +359,18 @@ static void pl011_irq_tx_enable(const struct device *dev)
 			 * [1]: PrimeCell UART (PL011) Technical Reference Manual
 			 *      functional-overview/interrupts
 			 */
-			data->irq_cb(dev, data->irq_cb_data);
+			while (get_uart(dev)->imsc & PL011_IMSC_TXIM) {
+				data->irq_cb(dev, data->irq_cb_data);
+			}
 		}
-		data->sw_call_txdrdy = false;
 	}
 }
 
 static void pl011_irq_tx_disable(const struct device *dev)
 {
+	struct pl011_data *data = dev->data;
+
+	data->sw_call_txdrdy = true;
 	get_uart(dev)->imsc &= ~PL011_IMSC_TXIM;
 }
 


### PR DESCRIPTION
When using the interrupt UART API, it is expected that the driver will call the callback function repeatedly while TX interrupt is enabled. However that is not necessarily the case with the FIFO is enabled.

If the application calls uart_fifo_fill() each time with only one byte of data, the TX interrupt will never trigger. This is because the 1/8 TX interrupt trigger threshold is never reached. For this reason, the callback function should be called multiple times from software as needed.

Fixes zephyrproject-rtos/zephyr#85479