### PR TITLE
net: l2: ethernet: Fail if building with clang

### DIFF
--- a/subsys/net/l2/ethernet/ethernet.c
+++ b/subsys/net/l2/ethernet/ethernet.c
@@ -192,6 +192,10 @@ enum net_verdict ethernet_check_ipv4_bcast_addr(struct net_pkt *pkt,
 	return NET_OK;
 }
 
+#ifdef __clang__
+#error "Building with clang"
+#endif
+
 #if defined(CONFIG_NET_NATIVE_IP) && !defined(CONFIG_NET_RAW_MODE)
 static void ethernet_mcast_monitor_cb(struct net_if *iface, const struct net_addr *addr,
 				      bool is_joined)


### PR DESCRIPTION
Test whether changes are actually being built with clang in CI after
https://github.com/zephyrproject-rtos/zephyr/pull/85091.