### PR TITLE
boards: NXP: mimxrt1170_evkb: cleanup documentations

### DIFF
--- a/boards/nxp/mimxrt1170_evk/doc/index.rst
+++ b/boards/nxp/mimxrt1170_evk/doc/index.rst
@@ -153,9 +153,9 @@ RT1170 EVKB (``mimxrt1170_evk@B//cm7/cm4``)
 |           |            | :ref:`rk055hdmipi4ma0`,                        |                 |                 |
 |           |            | and :ref:`g1120b0mipi` shields                 |                 |                 |
 +-----------+------------+------------------------------------------------+-----------------+-----------------+
-| ACMP      | on-chip    | sensor                                         | Supported       | No support      |
+| ACMP      | on-chip    | sensor                                         | Supported       | Supported       |
 +-----------+------------+------------------------------------------------+-----------------+-----------------+
-| CAAM RNG  | on-chip    | entropy                                        | Supported (M7)  | No support      |
+| CAAM RNG  | on-chip    | entropy                                        | Supported (M7)  | Supported (M7)  |
 +-----------+------------+------------------------------------------------+-----------------+-----------------+
 | FLEXSPI   | on-chip    | flash programming                              | Supported (M7)  | Supported (M7)  |
 +-----------+------------+------------------------------------------------+-----------------+-----------------+

--- a/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm7_B.yaml
+++ b/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm7_B.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 NXP
+# Copyright 2023, 2025 NXP
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -23,8 +23,10 @@ supported:
   - hwinfo
   - i2c
   - mipi_dsi
+  - netif:eth
+  - pwm
   - spi
-  - usb_device
+  - usbd
   - video
   - watchdog
 vendor: nxp


### PR DESCRIPTION
Clean up some oversite in the board enablement documentation and yaml file.