### PR TITLE
bluetooth: conn: move `bt_conn_lookup_index` to public header

### DIFF
--- a/doc/releases/release-notes-4.1.rst
+++ b/doc/releases/release-notes-4.1.rst
@@ -136,6 +136,7 @@ New APIs and options
   * Host
 
     * :c:func:`bt_conn_is_type`
+    * :c:func:`bt_conn_lookup_index`
 
   * Mesh
 

--- a/include/zephyr/bluetooth/conn.h
+++ b/include/zephyr/bluetooth/conn.h
@@ -719,6 +719,19 @@ void bt_conn_foreach(enum bt_conn_type type,
  */
 struct bt_conn *bt_conn_lookup_addr_le(uint8_t id, const bt_addr_le_t *peer);
 
+/** @brief Look up an existing connection by index.
+ *
+ *  Look up an existing connection based on the connection index.
+ *
+ *  The caller gets a new reference to the connection object which must be
+ *  released with bt_conn_unref() once done using the object.
+ *
+ *  @param index Connection index from bt_conn_index()
+ *
+ *  @return Connection object or NULL if not found.
+ */
+struct bt_conn *bt_conn_lookup_index(uint8_t index);
+
 /** @brief Get destination (peer) address of a connection.
  *
  *  @param conn Connection object.

--- a/subsys/bluetooth/host/conn_internal.h
+++ b/subsys/bluetooth/host/conn_internal.h
@@ -462,7 +462,6 @@ bool bt_conn_is_peer_addr_le(const struct bt_conn *conn, uint8_t id,
  * e.g. as the handle since that's assigned to us by the controller.
  */
 #define BT_CONN_INDEX_INVALID 0xff
-struct bt_conn *bt_conn_lookup_index(uint8_t index);
 
 /* Look up a connection state. For BT_ADDR_LE_ANY, returns the first connection
  * with the specific state


### PR DESCRIPTION
Move the `bt_conn_lookup_index` declaration to a public header. This function is essentially the inverse of `bt_conn_index`, which is already public.