### PR TITLE
modules: cmsis-nn: update to v7.0.0 and tflite-micro update

### DIFF
--- a/modules/cmsis-nn/CMakeLists.txt
+++ b/modules/cmsis-nn/CMakeLists.txt
@@ -85,4 +85,9 @@ if(CONFIG_CMSIS_NN)
     zephyr_library_sources(${SRC})
   endif()
 
+  if(CONFIG_CMSIS_NN_TRANSPOSE)
+    file(GLOB SRC "${CMSIS_NN_DIR}/Source/TransposeFunctions/*_s8.c")
+    zephyr_library_sources(${SRC})
+  endif()
+
 endif()

--- a/modules/cmsis-nn/CMakeLists.txt
+++ b/modules/cmsis-nn/CMakeLists.txt
@@ -90,4 +90,9 @@ if(CONFIG_CMSIS_NN)
     zephyr_library_sources(${SRC})
   endif()
 
+  if(CONFIG_CMSIS_NN_PAD)
+    file(GLOB SRC "${CMSIS_NN_DIR}/Source/PadFunctions/*_s8.c")
+    zephyr_library_sources(${SRC})
+  endif()
+
 endif()

--- a/modules/cmsis-nn/Kconfig
+++ b/modules/cmsis-nn/Kconfig
@@ -78,4 +78,9 @@ config CMSIS_NN_LSTM
 	help
 	  This option enables the NN libraries for Long Short-Term Memory.
 
+config CMSIS_NN_TRANSPOSE
+	bool "Transpose"
+	help
+	  This option enables the NN libraries for the transpose layers.
+
 endif #CMSIS_NN

--- a/modules/cmsis-nn/Kconfig
+++ b/modules/cmsis-nn/Kconfig
@@ -78,6 +78,11 @@ config CMSIS_NN_LSTM
 	help
 	  This option enables the NN libraries for Long Short-Term Memory.
 
+config CMSIS_NN_PAD
+	bool "Pad"
+	help
+	  This option enables the NN libraries for the pad layers.
+
 config CMSIS_NN_TRANSPOSE
 	bool "Transpose"
 	help

--- a/modules/tflite-micro/CMakeLists.txt
+++ b/modules/tflite-micro/CMakeLists.txt
@@ -41,9 +41,12 @@ if(CONFIG_TENSORFLOW_LITE_MICRO)
     ${TENSORFLOW_LITE_MICRO_DIR}/signal/src/kiss_fft_wrappers/kiss_fft_float.cc
     ${TENSORFLOW_LITE_MICRO_DIR}/signal/src/kiss_fft_wrappers/kiss_fft_int16.cc
     ${TENSORFLOW_LITE_MICRO_DIR}/signal/src/kiss_fft_wrappers/kiss_fft_int32.cc
+    ${TENSORFLOW_LITE_MICRO_DIR}/tensorflow/compiler/mlir/lite/core/api/error_reporter.cc
+    ${TENSORFLOW_LITE_MICRO_DIR}/tensorflow/compiler/mlir/lite/schema/schema_utils.cc
     ${TENSORFLOW_LITE_MICRO_DIR}/tensorflow/lite/array.cc
     ${TENSORFLOW_LITE_MICRO_DIR}/tensorflow/lite/core/c/common.cc
     ${TENSORFLOW_LITE_MICRO_DIR}/tensorflow/lite/micro/debug_log.cc
+    ${TENSORFLOW_LITE_MICRO_DIR}/tensorflow/lite/micro/hexdump.cc
     ${TENSORFLOW_LITE_MICRO_DIR}/tensorflow/lite/micro/fake_micro_context.cc
     ${TENSORFLOW_LITE_MICRO_DIR}/tensorflow/lite/micro/memory_helpers.cc
     ${TENSORFLOW_LITE_MICRO_DIR}/tensorflow/lite/micro/micro_allocation_info.cc
@@ -81,9 +84,7 @@ if(CONFIG_TENSORFLOW_LITE_MICRO)
     ${TENSORFLOW_LITE_MICRO_DIR}/tensorflow/lite/kernels/internal/reference/portable_tensor_utils.cc
     ${TENSORFLOW_LITE_MICRO_DIR}/tensorflow/lite/kernels/kernel_util.cc
     ${TENSORFLOW_LITE_MICRO_DIR}/tensorflow/lite/core/api/flatbuffer_conversions.cc
-    ${TENSORFLOW_LITE_MICRO_DIR}/tensorflow/lite/core/api/error_reporter.cc
     ${TENSORFLOW_LITE_MICRO_DIR}/tensorflow/lite/core/api/tensor_utils.cc
-    ${TENSORFLOW_LITE_MICRO_DIR}/tensorflow/lite/schema/schema_utils.cc
     ${TENSORFLOW_LITE_MICRO_DIR}/tensorflow/lite/micro/kernels/activations.cc
     ${TENSORFLOW_LITE_MICRO_DIR}/tensorflow/lite/micro/kernels/activations_common.cc
     ${TENSORFLOW_LITE_MICRO_DIR}/tensorflow/lite/micro/kernels/${CMSIS_NN_OPTIMIZED_KERNEL_DIR}/add.cc
@@ -91,7 +92,7 @@ if(CONFIG_TENSORFLOW_LITE_MICRO)
     ${TENSORFLOW_LITE_MICRO_DIR}/tensorflow/lite/micro/kernels/add_n.cc
     ${TENSORFLOW_LITE_MICRO_DIR}/tensorflow/lite/micro/kernels/arg_min_max.cc
     ${TENSORFLOW_LITE_MICRO_DIR}/tensorflow/lite/micro/kernels/assign_variable.cc
-    ${TENSORFLOW_LITE_MICRO_DIR}/tensorflow/lite/micro/kernels/batch_matmul.cc
+    ${TENSORFLOW_LITE_MICRO_DIR}/tensorflow/lite/micro/kernels/${CMSIS_NN_OPTIMIZED_KERNEL_DIR}/batch_matmul.cc
     ${TENSORFLOW_LITE_MICRO_DIR}/tensorflow/lite/micro/kernels/batch_to_space_nd.cc
     ${TENSORFLOW_LITE_MICRO_DIR}/tensorflow/lite/micro/kernels/broadcast_args.cc
     ${TENSORFLOW_LITE_MICRO_DIR}/tensorflow/lite/micro/kernels/broadcast_to.cc
@@ -105,6 +106,8 @@ if(CONFIG_TENSORFLOW_LITE_MICRO)
     ${TENSORFLOW_LITE_MICRO_DIR}/tensorflow/lite/micro/kernels/${CMSIS_NN_OPTIMIZED_KERNEL_DIR}/conv.cc
     ${TENSORFLOW_LITE_MICRO_DIR}/tensorflow/lite/micro/kernels/conv_common.cc
     ${TENSORFLOW_LITE_MICRO_DIR}/tensorflow/lite/micro/kernels/cumsum.cc
+    ${TENSORFLOW_LITE_MICRO_DIR}/tensorflow/lite/micro/kernels/decompress.cc
+    ${TENSORFLOW_LITE_MICRO_DIR}/tensorflow/lite/micro/kernels/decompress_common.cc
     ${TENSORFLOW_LITE_MICRO_DIR}/tensorflow/lite/micro/kernels/depth_to_space.cc
     ${TENSORFLOW_LITE_MICRO_DIR}/tensorflow/lite/micro/kernels/${CMSIS_NN_OPTIMIZED_KERNEL_DIR}/depthwise_conv.cc
     ${TENSORFLOW_LITE_MICRO_DIR}/tensorflow/lite/micro/kernels/depthwise_conv_common.cc
@@ -142,7 +145,7 @@ if(CONFIG_TENSORFLOW_LITE_MICRO)
     ${TENSORFLOW_LITE_MICRO_DIR}/tensorflow/lite/micro/kernels/lstm_eval.cc
     ${TENSORFLOW_LITE_MICRO_DIR}/tensorflow/lite/micro/kernels/lstm_eval_common.cc
     ${TENSORFLOW_LITE_MICRO_DIR}/tensorflow/lite/micro/kernels/log_softmax.cc
-    ${TENSORFLOW_LITE_MICRO_DIR}/tensorflow/lite/micro/kernels/maximum_minimum.cc
+    ${TENSORFLOW_LITE_MICRO_DIR}/tensorflow/lite/micro/kernels/${CMSIS_NN_OPTIMIZED_KERNEL_DIR}/maximum_minimum.cc
     ${TENSORFLOW_LITE_MICRO_DIR}/tensorflow/lite/micro/kernels/micro_tensor_utils.cc
     ${TENSORFLOW_LITE_MICRO_DIR}/tensorflow/lite/micro/kernels/mirror_pad.cc
     ${TENSORFLOW_LITE_MICRO_DIR}/tensorflow/lite/micro/kernels/${CMSIS_NN_OPTIMIZED_KERNEL_DIR}/mul.cc

--- a/modules/tflite-micro/Kconfig
+++ b/modules/tflite-micro/Kconfig
@@ -29,6 +29,7 @@ config TENSORFLOW_LITE_MICRO_CMSIS_NN_KERNELS
 	select CMSIS_NN_SVD
 	select CMSIS_NN_LSTM
 	select CMSIS_NN_TRANSPOSE
+	select CMSIS_NN_PAD
 	help
 	  This option adds support for CMSIS-NN optimized kernels when using TensorFlow Lite Micro.
 

--- a/modules/tflite-micro/Kconfig
+++ b/modules/tflite-micro/Kconfig
@@ -28,6 +28,7 @@ config TENSORFLOW_LITE_MICRO_CMSIS_NN_KERNELS
 	select CMSIS_NN_SOFTMAX
 	select CMSIS_NN_SVD
 	select CMSIS_NN_LSTM
+	select CMSIS_NN_TRANSPOSE
 	help
 	  This option adds support for CMSIS-NN optimized kernels when using TensorFlow Lite Micro.
 

--- a/submanifests/optional.yaml
+++ b/submanifests/optional.yaml
@@ -47,7 +47,7 @@ manifest:
       groups:
         - optional
     - name: tflite-micro
-      revision: 48613f7ba1ffbda46ad771a77a35408f48f922e9
+      revision: 8d404de73acf7687831e16d88e86e4f73cfddf8e
       path: optional/modules/lib/tflite-micro
       repo-path: tflite-micro
       remote: upstream

--- a/tests/lib/cmsis_nn/src/main.c
+++ b/tests/lib/cmsis_nn/src/main.c
@@ -203,6 +203,7 @@ ZTEST(cmsis_nn, test_convolve)
 					    kernel_data,
 					    &bias_dims,
 					    bias_data,
+					    NULL,
 					    &output_dims,
 					    output);
 

--- a/west.yml
+++ b/west.yml
@@ -125,7 +125,7 @@ manifest:
       revision: d80a49b2bb186317dc1db4ac88da49c0ab77e6e7
       path: modules/lib/cmsis-dsp
     - name: cmsis-nn
-      revision: ea987c1ca661be723de83bd159aed815d6cbd430
+      revision: e9328d612ea3ea7d0d210d3ac16ea8667c01abdd
       path: modules/lib/cmsis-nn
     - name: cmsis_6
       repo-path: CMSIS_6


### PR DESCRIPTION
Update manifest to cmsis-nn v7.0.0 and update tflite-micro to the latest hash at the time of this PR.

_tflite-micro doesn't use tags (or releases)_