### PR TITLE
drivers: flash: stm32: rename CR lock functions

### DIFF
--- a/drivers/flash/flash_stm32h7x.c
+++ b/drivers/flash/flash_stm32h7x.c
@@ -671,7 +671,7 @@ int flash_stm32_write_range(const struct device *dev, unsigned int offset, const
 	return rc;
 }
 
-static int flash_stm32h7_write_protection(const struct device *dev, bool enable)
+static int flash_stm32h7_cr_lock(const struct device *dev, bool enable)
 {
 	FLASH_TypeDef *regs = FLASH_STM32_REGS(dev);
 
@@ -750,7 +750,7 @@ static int flash_stm32h7_erase(const struct device *dev, off_t offset, size_t le
 
 	LOG_DBG("Erase offset: %ld, len: %zu", (long)offset, len);
 
-	rc = flash_stm32h7_write_protection(dev, false);
+	rc = flash_stm32h7_cr_lock(dev, false);
 	if (rc) {
 		goto done;
 	}
@@ -766,7 +766,7 @@ static int flash_stm32h7_erase(const struct device *dev, off_t offset, size_t le
 	}
 #endif /* CONFIG_CPU_CORTEX_M7 */
 done:
-	rc2 = flash_stm32h7_write_protection(dev, true);
+	rc2 = flash_stm32h7_cr_lock(dev, true);
 
 	if (!rc) {
 		rc = rc2;
@@ -794,12 +794,12 @@ static int flash_stm32h7_write(const struct device *dev, off_t offset, const voi
 
 	LOG_DBG("Write offset: %ld, len: %zu", (long)offset, len);
 
-	rc = flash_stm32h7_write_protection(dev, false);
+	rc = flash_stm32h7_cr_lock(dev, false);
 	if (!rc) {
 		rc = flash_stm32_write_range(dev, offset, data, len);
 	}
 
-	int rc2 = flash_stm32h7_write_protection(dev, true);
+	int rc2 = flash_stm32h7_cr_lock(dev, true);
 
 	if (!rc) {
 		rc = rc2;


### PR DESCRIPTION
Rename *write_protection functions to *cr_lock, because it is not enabling real write protection. It only blocks changing register by software accidentally.

Following up #83266 