### PR TITLE
STM32N6: add XSPI Flash support

### DIFF
--- a/boards/st/nucleo_n657x0_q/doc/index.rst
+++ b/boards/st/nucleo_n657x0_q/doc/index.rst
@@ -91,6 +91,17 @@ Default Zephyr Peripheral Mapping:
 - USART_1_RX : PE6
 - USART_3_TX : PD8
 - USART_3_RX : PD9
+- XSPI2_NCS1 : PN1
+- XSPI2_DQS0 : PN0
+- XSPI2_CLK : PN6
+- XSPI2_IO0 : PN2
+- XSPI2_IO1 : PN3
+- XSPI2_IO2 : PN4
+- XSPI2_IO3 : PN5
+- XSPI2_IO4 : PN8
+- XSPI2_IO5 : PN9
+- XSPI2_IO6 : PN10
+- XSPI2_IO7 : PN11
 
 System Clock
 ------------

--- a/boards/st/nucleo_n657x0_q/nucleo_n657x0_q_common.dtsi
+++ b/boards/st/nucleo_n657x0_q/nucleo_n657x0_q_common.dtsi
@@ -6,6 +6,7 @@
 
 #include <st/n6/stm32n657X0.dtsi>
 #include <st/n6/stm32n657x0hxq-pinctrl.dtsi>
+#include <zephyr/dt-bindings/flash_controller/xspi.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 #include "arduino_r3_connector.dtsi"
 
@@ -15,6 +16,7 @@
 		zephyr,shell-uart = &usart1;
 		zephyr,sram = &axisram2;
 		zephyr,canbus = &fdcan1;
+		spi-flash0 = &mx25um51245g;
 	};
 
 	leds: leds {
@@ -197,5 +199,35 @@
 		compatible = "ethernet-phy";
 		reg = <0x0>;
 		status = "okay";
+	};
+};
+
+&xspi2 {
+	pinctrl-0 = <&xspim_p2_ncs1_pn1 &xspim_p2_dqs0_pn0 &xspim_p2_clk_pn6
+		     &xspim_p2_io0_pn2 &xspim_p2_io1_pn3 &xspim_p2_io2_pn4
+		     &xspim_p2_io3_pn5 &xspim_p2_io4_pn8 &xspim_p2_io5_pn9
+		     &xspim_p2_io6_pn10 &xspim_p2_io7_pn11>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	mx25um51245g: ospi-nor-flash@70000000 {
+		compatible = "st,stm32-xspi-nor";
+		reg = <0x70000000 DT_SIZE_M(64)>; /* 512 Mbits */
+		ospi-max-frequency = <DT_FREQ_M(200)>;
+		spi-bus-width = <XSPI_OCTO_MODE>;
+		data-rate = <XSPI_DTR_TRANSFER>;
+		four-byte-opcodes;
+		status = "okay";
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			storage_partition: partition@3ff0000 {
+				label = "storage";
+				reg = <0x3ff0000 DT_SIZE_K(64)>;
+			};
+		};
 	};
 };

--- a/boards/st/stm32n6570_dk/doc/index.rst
+++ b/boards/st/stm32n6570_dk/doc/index.rst
@@ -95,6 +95,17 @@ Default Zephyr Peripheral Mapping:
 - USART_1_RX : PE6
 - USART_2_TX : PD5
 - USART_2_RX : PF6
+- XSPI2_NCS1 : PN1
+- XSPI2_DQS0 : PN0
+- XSPI2_CLK : PN6
+- XSPI2_IO0 : PN2
+- XSPI2_IO1 : PN3
+- XSPI2_IO2 : PN4
+- XSPI2_IO3 : PN5
+- XSPI2_IO4 : PN8
+- XSPI2_IO5 : PN9
+- XSPI2_IO6 : PN10
+- XSPI2_IO7 : PN11
 
 System Clock
 ------------

--- a/boards/st/stm32n6570_dk/stm32n6570_dk_common.dtsi
+++ b/boards/st/stm32n6570_dk/stm32n6570_dk_common.dtsi
@@ -6,8 +6,9 @@
 
 #include <st/n6/stm32n657X0.dtsi>
 #include <st/n6/stm32n657x0hxq-pinctrl.dtsi>
-#include "arduino_r3_connector.dtsi"
+#include <zephyr/dt-bindings/flash_controller/xspi.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
+#include "arduino_r3_connector.dtsi"
 
 / {
 	chosen {
@@ -15,6 +16,7 @@
 		zephyr,shell-uart = &usart1;
 		zephyr,sram = &axisram2;
 		zephyr,canbus = &fdcan1;
+		spi-flash0 = &mx66uw1g45g;
 	};
 
 	aliases {
@@ -155,4 +157,34 @@
 	pinctrl-names = "default";
 	current-speed = <115200>;
 	status = "okay";
+};
+
+&xspi2 {
+	pinctrl-0 = <&xspim_p2_ncs1_pn1 &xspim_p2_dqs0_pn0 &xspim_p2_clk_pn6
+		     &xspim_p2_io0_pn2 &xspim_p2_io1_pn3 &xspim_p2_io2_pn4
+		     &xspim_p2_io3_pn5 &xspim_p2_io4_pn8 &xspim_p2_io5_pn9
+		     &xspim_p2_io6_pn10 &xspim_p2_io7_pn11>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	mx66uw1g45g: ospi-nor-flash@70000000 {
+		compatible = "st,stm32-xspi-nor";
+		reg = <0x70000000 DT_SIZE_M(128)>; /* 1 Gbits */
+		ospi-max-frequency = <DT_FREQ_M(200)>;
+		spi-bus-width = <XSPI_OCTO_MODE>;
+		data-rate = <XSPI_DTR_TRANSFER>;
+		four-byte-opcodes;
+		status = "okay";
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			storage_partition: partition@7ff0000 {
+				label = "storage";
+				reg = <0x7ff0000 DT_SIZE_K(64)>;
+			};
+		};
+	};
 };

--- a/drivers/flash/flash_stm32_xspi.c
+++ b/drivers/flash/flash_stm32_xspi.c
@@ -190,7 +190,9 @@ static XSPI_RegularCmdTypeDef xspi_prepare_cmd(const uint8_t transfer_mode,
 		.DQSMode = (transfer_rate == XSPI_DTR_TRANSFER)
 				? HAL_XSPI_DQS_ENABLE
 				: HAL_XSPI_DQS_DISABLE,
+#ifdef XSPI_CCR_SIOO
 		.SIOOMode = HAL_XSPI_SIOO_INST_EVERY_CMD,
+#endif /* XSPI_CCR_SIOO */
 	};
 
 	switch (transfer_mode) {
@@ -773,7 +775,9 @@ static int stm32_xspi_mem_reset(const struct device *dev)
 		.DataLength = HAL_XSPI_DATA_NONE,
 		.DummyCycles = 0U,
 		.DQSMode = HAL_XSPI_DQS_DISABLE,
+#ifdef XSPI_CCR_SIOO
 		.SIOOMode = HAL_XSPI_SIOO_INST_EVERY_CMD,
+#endif /* XSPI_CCR_SIOO */
 	};
 
 	/* Reset enable in SPI mode and STR transfer mode */
@@ -1021,7 +1025,9 @@ static int flash_stm32_xspi_erase(const struct device *dev, off_t addr,
 		.DataMode = HAL_XSPI_DATA_NONE,
 		.DummyCycles = 0U,
 		.DQSMode = HAL_XSPI_DQS_DISABLE,
+#ifdef XSPI_CCR_SIOO
 		.SIOOMode = HAL_XSPI_SIOO_INST_EVERY_CMD,
+#endif /* XSPI_CCR_SIOO */
 	};
 
 	if (stm32_xspi_mem_ready(dev,
@@ -2121,11 +2127,13 @@ static int flash_stm32_xspi_init(const struct device *dev)
 	} else {
 
 	}
+#if defined(XSPI_DCR1_DLYBYP)
 #if STM32_XSPI_DLYB_BYPASSED
 	dev_data->hxspi.Init.DelayBlockBypass = HAL_XSPI_DELAY_BLOCK_BYPASS;
 #else
 	dev_data->hxspi.Init.DelayBlockBypass = HAL_XSPI_DELAY_BLOCK_ON;
 #endif /* STM32_XSPI_DLYB_BYPASSED */
+#endif /* XSPI_DCR1_DLYBYP */
 
 
 	if (HAL_XSPI_Init(&dev_data->hxspi) != HAL_OK) {

--- a/dts/arm/st/n6/stm32n6.dtsi
+++ b/dts/arm/st/n6/stm32n6.dtsi
@@ -660,6 +660,19 @@
 				status = "disabled";
 			};
 		};
+
+		xspi2: spi@5802a000 {
+			compatible = "st,stm32-xspi";
+			reg = <0x5802A000 0x1000>;
+			interrupts = <171 0>;
+			clock-names = "xspix", "xspi-ker", "xspi-mgr";
+			clocks = <&rcc STM32_CLOCK(AHB5, 12)>,
+				 <&rcc STM32_SRC_CKPER XSPI2_SEL(1)>,
+				 <&rcc STM32_CLOCK(AHB5, 13)>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "disabled";
+		};
 	};
 };
 

--- a/soc/st/stm32/stm32n6x/soc.c
+++ b/soc/st/stm32/stm32n6x/soc.c
@@ -59,4 +59,8 @@ void soc_early_init_hook(void)
 	LL_PWR_EnableVddIO3();
 	LL_PWR_EnableVddIO4();
 	LL_PWR_EnableVddIO5();
+
+	/* Set Vdd IO2 and IO3 to 1.8V */
+	LL_PWR_SetVddIO2VoltageRange(LL_PWR_VDDIO_VOLTAGE_RANGE_1V8);
+	LL_PWR_SetVddIO3VoltageRange(LL_PWR_VDDIO_VOLTAGE_RANGE_1V8);
 }


### PR DESCRIPTION
Add XSPI Flash support for STM32N6. Enable XSPI Flash on STM32N6570-DK and Nucleo N657X0.