### PR TITLE
Bluetooth: SDP: Check if frame len is consistent with attr list count

### DIFF
--- a/subsys/bluetooth/host/classic/sdp.c
+++ b/subsys/bluetooth/host/classic/sdp.c
@@ -2053,8 +2053,12 @@ static int sdp_client_receive_ssa_sa(struct bt_sdp_client *session, struct net_b
 
 	/* Get total value of all attributes to be collected */
 	frame_len -= sdp_client_get_total(session, buf, &total);
+	if (frame_len != total) {
+		LOG_ERR("Invalid attribute lists");
+		return 0;
+	}
 
-	if (total > net_buf_tailroom(session->rec_buf)) {
+	if (frame_len > net_buf_tailroom(session->rec_buf)) {
 		LOG_WRN("Not enough room for getting records data");
 		goto iterate;
 	}


### PR DESCRIPTION
The total attributes list bytes count is only used to check the tail room of response buffer. And the remaining frame length is used to copy data from receiving buffer.

It does not check whether the remaining frame length is consistent with the total attributes list bytes count.

Add the checking to make sure the attributes list is complete. And it is used to make sure the response buffer can be accessed safety.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/84733