### PR TITLE
I2C: nRF TWIM RTIO patch

### DIFF
--- a/samples/drivers/i2c/rtio_loopback/boards/nrf54h20dk_nrf54h20_cpuapp.conf
+++ b/samples/drivers/i2c/rtio_loopback/boards/nrf54h20dk_nrf54h20_cpuapp.conf
@@ -1,0 +1,4 @@
+# Copyright (c) 2024 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_I2C_NRFX_TWIS_BUF_SIZE=256

--- a/samples/drivers/i2c/rtio_loopback/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/samples/drivers/i2c/rtio_loopback/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * SDA = P2.8 and P2.9
+ * SCL = P1.2 and P1.3
+ */
+
+/ {
+	aliases {
+		i2c-controller = &i2c130;
+		i2c-controller-target = &i2c131;
+	};
+};
+
+&pinctrl {
+	i2c130_default: i2c130_default {
+		group1 {
+			psels = <NRF_PSEL(TWIM_SDA, 2, 8)>,
+				<NRF_PSEL(TWIM_SCL, 1, 2)>;
+			bias-pull-up;
+		};
+	};
+
+	i2c130_sleep: i2c130_sleep {
+		group1 {
+			psels = <NRF_PSEL(TWIM_SDA, 2, 8)>,
+				<NRF_PSEL(TWIM_SCL, 1, 2)>;
+			low-power-enable;
+		};
+	};
+
+	i2c131_default: i2c131_default {
+		group1 {
+			psels = <NRF_PSEL(TWIM_SDA, 2, 9)>,
+				<NRF_PSEL(TWIM_SCL, 1, 3)>;
+			bias-pull-up;
+		};
+	};
+
+	i2c131_sleep: i2c131_sleep {
+		group1 {
+			psels = <NRF_PSEL(TWIM_SDA, 2, 9)>,
+				<NRF_PSEL(TWIM_SCL, 1, 3)>;
+			low-power-enable;
+		};
+	};
+};
+
+&i2c130 {
+	clock-frequency = <I2C_BITRATE_STANDARD>;
+	pinctrl-0 = <&i2c130_default>;
+	pinctrl-1 = <&i2c130_sleep>;
+	pinctrl-names = "default", "sleep";
+	zephyr,concat-buf-size = <256>;
+	memory-regions = <&cpuapp_dma_region>;
+	status = "okay";
+};
+
+&i2c131 {
+	compatible = "nordic,nrf-twis";
+	clock-frequency = <I2C_BITRATE_STANDARD>;
+	pinctrl-0 = <&i2c131_default>;
+	pinctrl-1 = <&i2c131_sleep>;
+	pinctrl-names = "default", "sleep";
+	memory-regions = <&cpuapp_dma_region>;
+	status = "okay";
+};

--- a/samples/drivers/i2c/rtio_loopback/sample.yaml
+++ b/samples/drivers/i2c/rtio_loopback/sample.yaml
@@ -9,3 +9,4 @@ tests:
       - b_u585i_iot02a
       - nrf5340dk/nrf5340/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54h20dk/nrf54h20/cpuapp


### PR DESCRIPTION
The nRF TWIM RTIO device driver needed to be patched to place the DMA buffer in the correct section, and had to have logic added to use the DMA buffer for receiving.

Additionally add nRF54H20 board support to the I2C RTIO loopback sample.