### PR TITLE
fix usb driver zlt handle typo

### DIFF
--- a/drivers/usb/udc/udc_mcux_ip3511.c
+++ b/drivers/usb/udc/udc_mcux_ip3511.c
@@ -359,7 +359,7 @@ static bool udc_mcux_handler_zlt(const struct device *dev, uint8_t ep, struct ne
 			usb_status_t status;
 
 			udc_ep_buf_clear_zlp(buf);
-			status = mcux_if->deviceRecv(priv->mcux_device.controllerHandle,
+			status = mcux_if->deviceSend(priv->mcux_device.controllerHandle,
 					ep, NULL, 0);
 			if (status != kStatus_USB_Success) {
 				udc_submit_event(dev, UDC_EVT_ERROR, -EIO);

--- a/west.yml
+++ b/west.yml
@@ -203,7 +203,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: 2a1d73aeb863a73bb06ba8b236de7da6d3e31847
+      revision: 3fc5f811fb8c0bdd90a8d965c50707172ce80d05
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
Fix #83306

Zephyr USB device stack handles the zlt and the NXP usb controller drivers
process the control endpoint zlt defaultly, disable it in controller driver.