### PR TITLE
cmake: mcuboot: Set encrypted header flag when key is used

### DIFF
--- a/cmake/mcuboot.cmake
+++ b/cmake/mcuboot.cmake
@@ -183,8 +183,18 @@ function(zephyr_mcuboot_tasks)
     set(BYPRODUCT_KERNEL_SIGNED_HEX_NAME "${output}.signed.hex"
         CACHE FILEPATH "Signed kernel hex file" FORCE
     )
-    set_property(GLOBAL APPEND PROPERTY extra_post_build_commands COMMAND
-                 ${imgtool_sign} ${imgtool_args} ${output}.hex ${output}.signed.hex)
+
+    if(NOT "${keyfile_enc}" STREQUAL "")
+      # When encryption is enabled, set the encrypted bit when signing the image but do not
+      # encrypt the data, this means that when the image is moved out of the primary into the
+      # secondary, it will be encrypted rather than being in unencrypted
+      set_property(GLOBAL APPEND PROPERTY extra_post_build_commands COMMAND
+                   ${imgtool_sign} ${imgtool_args} --encrypt "${keyfile_enc}" --clear
+                   ${output}.hex ${output}.signed.hex)
+    else()
+      set_property(GLOBAL APPEND PROPERTY extra_post_build_commands COMMAND
+                   ${imgtool_sign} ${imgtool_args} ${output}.hex ${output}.signed.hex)
+    endif()
 
     if(CONFIG_MCUBOOT_GENERATE_CONFIRMED_IMAGE)
       list(APPEND byproducts ${output}.signed.confirmed.hex)

--- a/doc/releases/release-notes-4.1.rst
+++ b/doc/releases/release-notes-4.1.rst
@@ -164,6 +164,11 @@ New APIs and options
     * Image management :c:macro:`MGMT_EVT_OP_IMG_MGMT_DFU_CONFIRMED` now has image data field
       :c:struct:`img_mgmt_image_confirmed`.
 
+* MCUboot
+
+  * Signed hex files where an encryption key Kconfig is set now have the encrypted flag set in
+    the image header.
+
 * Video
 
   * :c:func:`video_set_stream()` driver API has replaced :c:func:`video_stream_start()` and


### PR DESCRIPTION
    Uses the clear imgtool argument to set the encrypted flag in the
    header of the signed hex output, without encrypting the data. This
    addresses an issue whereby the first update would swap images and
    leave the swapped output in the secondary slot without encryption
