### PR TITLE
modules: Update uoscore-uedhoc revision to the latest

### DIFF
--- a/modules/uoscore-uedhoc/CMakeLists.txt
+++ b/modules/uoscore-uedhoc/CMakeLists.txt
@@ -107,7 +107,8 @@ if (CONFIG_UOSCORE OR CONFIG_UEDHOC)
       ${UOSCORE_UEDHOC_SRC_DIR}/cbor/edhoc_decode_message_1.c
       ${UOSCORE_UEDHOC_SRC_DIR}/cbor/edhoc_decode_message_2.c
       ${UOSCORE_UEDHOC_SRC_DIR}/cbor/edhoc_decode_message_3.c
-      ${UOSCORE_UEDHOC_SRC_DIR}/cbor/edhoc_decode_plaintext.c
+      ${UOSCORE_UEDHOC_SRC_DIR}/cbor/edhoc_decode_plaintext2.c
+      ${UOSCORE_UEDHOC_SRC_DIR}/cbor/edhoc_decode_plaintext3.c
       ${UOSCORE_UEDHOC_SRC_DIR}/cbor/edhoc_encode_bstr_type.c
       ${UOSCORE_UEDHOC_SRC_DIR}/cbor/edhoc_encode_data_2.c
       ${UOSCORE_UEDHOC_SRC_DIR}/cbor/edhoc_encode_enc_structure.c

--- a/west.yml
+++ b/west.yml
@@ -358,7 +358,7 @@ manifest:
       groups:
         - tee
     - name: uoscore-uedhoc
-      revision: 84ef879a46d7bfd9a423fbfb502b04289861f9ea
+      revision: 54abc109c9c0adfd53c70077744c14e454f04f4a
       path: modules/lib/uoscore-uedhoc
     - name: zcbor
       revision: 9b07780aca6fb21f82a241ba386ad9b379809337


### PR DESCRIPTION
Pull latest revision of the uoscore-uedhoc module and align corresponding CMake file with the changes.