### PR TITLE
tests: drivers: watchodg: Enable wdt_error_cases on nRF5340dk

### DIFF
--- a/tests/drivers/watchdog/wdt_error_cases/src/main.c
+++ b/tests/drivers/watchdog/wdt_error_cases/src/main.c
@@ -42,8 +42,8 @@
 #define DEFAULT_WINDOW_MIN (0U)
 
 /* Align tests to the specific target: */
-#if defined(CONFIG_SOC_SERIES_NRF54LX) || defined(CONFIG_SOC_NRF54H20) || \
-	defined(CONFIG_SOC_NRF9280)
+#if defined(CONFIG_SOC_SERIES_NRF53X) || defined(CONFIG_SOC_SERIES_NRF54LX) || \
+	defined(CONFIG_SOC_NRF54H20) || defined(CONFIG_SOC_NRF9280)
 #define WDT_TEST_FLAGS                                                                             \
 	(WDT_DISABLE_SUPPORTED | WDT_FLAG_RESET_SOC_SUPPORTED |                                    \
 	 WDT_FLAG_ONLY_ONE_TIMEOUT_VALUE_SUPPORTED | WDT_OPT_PAUSE_IN_SLEEP_SUPPORTED |            \

--- a/tests/drivers/watchdog/wdt_error_cases/testcase.yaml
+++ b/tests/drivers/watchdog/wdt_error_cases/testcase.yaml
@@ -8,6 +8,7 @@ common:
 tests:
   drivers.watchdog.wdt_error_cases:
     platform_allow:
+      - nrf5340dk/nrf5340/cpuapp
       - nrf54l09pdk/nrf54l09/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l20pdk/nrf54l20/cpuapp


### PR DESCRIPTION
Enable wdt_error_cases test on nRF5340dk.

Define valid test configuration for that target (reuse from nRF54H/nRF54L).
Add target to the platform_allow.