### PR TITLE
soc: infineon: Move stack definitions to the correct place

### DIFF
--- a/boards/infineon/cy8cproto_062_4343w/cy8cproto_062_4343w_defconfig
+++ b/boards/infineon/cy8cproto_062_4343w/cy8cproto_062_4343w_defconfig
@@ -20,6 +20,3 @@ CONFIG_GPIO=y
 
 # Enable clock controller
 CONFIG_CLOCK_CONTROL=y
-
-# Main Stack Size
-CONFIG_MAIN_STACK_SIZE=2048

--- a/boards/infineon/cy8cproto_063_ble/cy8cproto_063_ble_defconfig
+++ b/boards/infineon/cy8cproto_063_ble/cy8cproto_063_ble_defconfig
@@ -22,8 +22,5 @@ CONFIG_GPIO=y
 # Enable clock controller
 CONFIG_CLOCK_CONTROL=y
 
-# Main Stack Size
-CONFIG_MAIN_STACK_SIZE=2048
-
 # Add catcm0p sleep images for CM0 Devices
 CONFIG_SOC_PSOC6_CM0P_IMAGE_SLEEP=y

--- a/boards/infineon/cyw920829m2evk_02/cyw920829m2evk_02_defconfig
+++ b/boards/infineon/cyw920829m2evk_02/cyw920829m2evk_02_defconfig
@@ -20,8 +20,5 @@ CONFIG_GPIO=y
 # Enable clock controller
 CONFIG_CLOCK_CONTROL=y
 
-# Main Stack Size
-CONFIG_MAIN_STACK_SIZE=2048
-
 # Enable code/data relocation to move SMIF driver into RAM
 CONFIG_CODE_DATA_RELOCATION=y

--- a/soc/infineon/cat1a/psoc6_01/Kconfig.defconfig
+++ b/soc/infineon/cat1a/psoc6_01/Kconfig.defconfig
@@ -13,6 +13,9 @@ config NUM_IRQS
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default 100000000
 
+config MAIN_STACK_SIZE
+	default 2048
+
 # add additional die specific params
 
 endif # SOC_DIE_PSOC6_01

--- a/soc/infineon/cat1a/psoc6_02/Kconfig.defconfig
+++ b/soc/infineon/cat1a/psoc6_02/Kconfig.defconfig
@@ -16,6 +16,9 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 config BUILD_OUTPUT_HEX
 	default y
 
+config MAIN_STACK_SIZE
+	default 2048
+
 # add additional die specific params
 
 endif # SOC_DIE_PSOC6_02

--- a/soc/infineon/cat1a/psoc6_03/Kconfig.defconfig
+++ b/soc/infineon/cat1a/psoc6_03/Kconfig.defconfig
@@ -13,6 +13,9 @@ config NUM_IRQS
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default 100000000
 
+config MAIN_STACK_SIZE
+	default 2048
+
 # add additional die specific params
 
 endif # SOC_DIE_PSOC6_03

--- a/soc/infineon/cat1a/psoc6_04/Kconfig.defconfig
+++ b/soc/infineon/cat1a/psoc6_04/Kconfig.defconfig
@@ -13,6 +13,9 @@ config NUM_IRQS
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default 100000000
 
+config MAIN_STACK_SIZE
+	default 2048
+
 # add additional die specific params
 
 endif # SOC_DIE_PSOC6_04

--- a/soc/infineon/cat1b/cyw20829/Kconfig.defconfig
+++ b/soc/infineon/cat1b/cyw20829/Kconfig.defconfig
@@ -22,6 +22,9 @@ config BUILD_OUTPUT_ADJUST_LMA
 	depends on XIP
 	default "0x60000000 - $(dt_node_reg_addr_hex,$(dt_nodelabel_path,flash0))"
 
+config MAIN_STACK_SIZE
+	default 2048
+
 # add additional die specific params
 
 endif # SOC_DIE_CYW20829

--- a/tests/drivers/uart/uart_async_api/boards/cy8cproto_063_ble.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/cy8cproto_063_ble.overlay
@@ -1,0 +1,11 @@
+&dma0 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	compatible = "infineon,cat1-dma";
+	status = "okay";
+};
+
+dut: &scb5 {
+	dmas = <&dma0 22>, <&dma0 23>;
+	dma-names = "tx", "rx";
+};


### PR DESCRIPTION
Moves CONFIG_MAIN_STACK_SIZE to be the default in the Kconfig.defconfig files