### PR TITLE
boards: Fixing rak4631 lora RX and TX pins

### DIFF
--- a/boards/rakwireless/rak4631/rak4631_nrf52840.dts
+++ b/boards/rakwireless/rak4631/rak4631_nrf52840.dts
@@ -119,7 +119,6 @@
 		reg = <0>;
 		reset-gpios = <&gpio1 6 GPIO_ACTIVE_LOW>;
 		busy-gpios = <&gpio1 14 GPIO_ACTIVE_HIGH>;
-		tx-enable-gpios = <&gpio1 7 GPIO_ACTIVE_LOW>;
 		rx-enable-gpios = <&gpio1 5 GPIO_ACTIVE_LOW>;
 		dio1-gpios = <&gpio1 15 GPIO_ACTIVE_HIGH>;
 		dio2-tx-enable;


### PR DESCRIPTION
Taking a look at the schematic shows that tx-enable-gpios and dio2-tx-enable were directly connected.
This had the effect tx-enable-gpios was trying to pull the line down while SX1262 is pulling the same line high. This increased the power consumption.
Now only the SX1262 sets the antenna to tx via dio2-tx-enable.
Setting the antenna to rx is still done via the rx-enable-gpios.
The antenna defaults to rx if not in use.  

What i don't like about this change:  
I want the default mode to be RX. So i need to use ``sx126x_set_rx_enable(0);`` inside of the ``case MODE_TX:`` to toggle the mode of the RX. No sure how save it is to use anything from the ``case MODE_TX:`` to influence the RX side. But i guess somehow we have to toggle those pins. Furthermore as long as the hardware is made this way i guess this is the best solution.

Power saving:
I measured the power reduction of this change with the nrf power profiler kit. This change reduce the power consumption by 30uA measured on the 5V side. So a reduction off 150 uW. But agian this is only messured.

Schematics: 
[Schematic Source](https://docs.rakwireless.com/product-categories/wisduo/rak4630-module/datasheet/)  
Nrf52480 Side:  
<img width="231" alt="image" src="https://github.com/user-attachments/assets/68fa53a4-e038-4c82-b9bb-80a6057bc81d" />
SX1262 Side:
<img width="1283" alt="image" src="https://github.com/user-attachments/assets/f62966ef-c986-4d05-b17e-3887663945be" />

Datasheets needed: 
[SX1262](https://www.mouser.com/datasheet/2/761/DS_SX1261-2_V1.1-1307803.pdf?srsltid=AfmBOoqdMf4kZMcg5_csKGPUbjofM_JKQY04rQhwb3g0fee6w54qxcMu)  
From the SX1262 the interesting bit might be "13.3.5 SetDIO2AsRfSwitchCtrl" --> "This command is used to configure DIO2 so that it can be used to control an external RF switch."
[PE4259](https://www.psemi.com/pdf/datasheets/pe4259ds.pdf)
The interesting part of the PE4259 datasheet is table 6 which we use.
<img width="558" alt="image" src="https://github.com/user-attachments/assets/3d4d4a8e-59e2-4f2e-875a-f29c8cde0a9b" />

Code from zephyr lora:
```
	switch (mode) {
	case MODE_TX:
		sx126x_set_rx_enable(0);
		sx126x_set_tx_enable(1);
		break;

	case MODE_RX:
	case MODE_RX_DC:
	case MODE_CAD:
		sx126x_set_tx_enable(0);
		sx126x_set_rx_enable(1);
		break;
```