### PR TITLE
manifest: Update nRF hw models to latest

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -318,7 +318,7 @@ manifest:
       groups:
         - tools
     - name: nrf_hw_models
-      revision: 2570f4a697ce2da860ff39ec34afd91749bd66d3
+      revision: 5dc34b26662c6ec91edf1174d775d78590b1a05b
       path: modules/bsim_hw_models/nrf_hw_models
     - name: nrf_wifi
       revision: 01359dffd9b6da4d162b4565fdd621ad94bd5d4e


### PR DESCRIPTION
Update the HW models module to:
5dc34b26662c6ec91edf1174d775d78590b1a05b

Including the following:
* 5dc34b2 CLOCK (52-54): Silly bugfix
* 4f622b7 CLOCK (52-54): Make TASK_*CLKSTOP instantaneous and clear LFCLK.STAT
* 07b1bdb RADIO 54: Correct 2 comments related the CCM trigger