### PR TITLE
STM32N6: add ADC support

### DIFF
--- a/boards/st/nucleo_n657x0_q/doc/index.rst
+++ b/boards/st/nucleo_n657x0_q/doc/index.rst
@@ -65,6 +65,8 @@ The Zephyr ``nucleo_n657x0_q`` board supports the following hardware features:
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |
 +===========+============+=====================================+
+| ADC       | on-chip    | adc                                 |
++-----------+------------+-------------------------------------+
 | CLOCK     | on-chip    | reset and clock control             |
 +-----------+------------+-------------------------------------+
 | CAN/CANFD | on-chip    | canbus                              |
@@ -97,6 +99,8 @@ For more details please refer to `NUCLEO-N657X0-Q User Manual`_.
 Default Zephyr Peripheral Mapping:
 ----------------------------------
 
+- ADC1_INP10 : PA9
+- ADC1_INP11 : PA10
 - FDCAN1_TX : PH2
 - FDCAN1_RX : PD0
 - LD1 : PO1

--- a/boards/st/nucleo_n657x0_q/nucleo_n657x0_q_common.dtsi
+++ b/boards/st/nucleo_n657x0_q/nucleo_n657x0_q_common.dtsi
@@ -111,6 +111,15 @@
 	apb5-prescaler = <1>;
 };
 
+&adc1 {
+	clocks = <&rcc STM32_CLOCK(AHB1, 5)>,
+		 <&rcc STM32_SRC_CKPER ADC12_SEL(1)>;
+	pinctrl-0 = <&adc1_inp10_pa9 &adc1_inp11_pa10>; /* Arduino A1 & A2 */
+	pinctrl-names = "default";
+	vref-mv = <1800>;
+	status = "okay";
+};
+
 &fdcan1 {
 	clocks = <&rcc STM32_CLOCK(APB1_2, 8)>,
 		 <&rcc STM32_SRC_CKPER FDCAN_SEL(1)>;

--- a/boards/st/nucleo_n657x0_q/twister.yaml
+++ b/boards/st/nucleo_n657x0_q/twister.yaml
@@ -5,6 +5,7 @@ ram: 1024
 flash: 1024
 supported:
   - arduino_serial
+  - adc
   - can
   - dma
   - gpio

--- a/boards/st/stm32n6570_dk/doc/index.rst
+++ b/boards/st/stm32n6570_dk/doc/index.rst
@@ -69,6 +69,8 @@ The Zephyr ``stm32n6570_dk`` board supports the following hardware features:
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |
 +===========+============+=====================================+
+| ADC       | on-chip    | adc                                 |
++-----------+------------+-------------------------------------+
 | CLOCK     | on-chip    | reset and clock control             |
 +-----------+------------+-------------------------------------+
 | CAN/CANFD | on-chip    | canbus                              |
@@ -101,6 +103,8 @@ For more details please refer to `STM32N6570_DK User Manual`_.
 Default Zephyr Peripheral Mapping:
 ----------------------------------
 
+- ADC1_INP10 : PA9
+- ADC1_INP11 : PA10
 - FDCAN1_TX : PH2
 - FDCAN1_RX : PD0
 - LD1 : PO1

--- a/boards/st/stm32n6570_dk/stm32n6570_dk_common.dtsi
+++ b/boards/st/stm32n6570_dk/stm32n6570_dk_common.dtsi
@@ -95,6 +95,15 @@
 	apb5-prescaler = <1>;
 };
 
+&adc1 {
+	clocks = <&rcc STM32_CLOCK(AHB1, 5)>,
+		 <&rcc STM32_SRC_CKPER ADC12_SEL(1)>;
+	pinctrl-0 = <&adc1_inp10_pa9 &adc1_inp11_pa10>; /* Arduino A1 & A2 */
+	pinctrl-names = "default";
+	vref-mv = <1800>;
+	status = "okay";
+};
+
 &fdcan1 {
 	clocks = <&rcc STM32_CLOCK(APB1_2, 8)>,
 		 <&rcc STM32_SRC_CKPER FDCAN_SEL(1)>;

--- a/boards/st/stm32n6570_dk/twister.yaml
+++ b/boards/st/stm32n6570_dk/twister.yaml
@@ -6,6 +6,7 @@ flash: 1024
 vendor: st
 supported:
   - arduino_serial
+  - adc
   - can
   - dma
   - gpio

--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -158,11 +158,17 @@ struct stream {
 };
 #endif /* CONFIG_ADC_STM32_DMA */
 
+#if defined(CONFIG_SOC_SERIES_STM32N6X)
+typedef uint32_t adc_data_size_t;
+#else
+typedef uint16_t adc_data_size_t;
+#endif
+
 struct adc_stm32_data {
 	struct adc_context ctx;
 	const struct device *dev;
-	uint16_t *buffer;
-	uint16_t *repeat_buffer;
+	adc_data_size_t *buffer;
+	adc_data_size_t *repeat_buffer;
 
 	uint8_t resolution;
 	uint32_t channels;
@@ -224,7 +230,7 @@ static int adc_stm32_dma_start(const struct device *dev,
 	blk_cfg = &dma->dma_blk_cfg;
 
 	/* prepare the block */
-	blk_cfg->block_size = channel_count * sizeof(int16_t);
+	blk_cfg->block_size = channel_count * sizeof(adc_data_size_t);
 
 	/* Source and destination */
 	blk_cfg->source_address = (uint32_t)LL_ADC_DMA_GetRegAddr(adc, LL_ADC_DMA_REG_REGULAR_DATA);
@@ -299,7 +305,7 @@ static int check_buffer(const struct adc_sequence *sequence,
 {
 	size_t needed_buffer_size;
 
-	needed_buffer_size = active_channels * sizeof(uint16_t);
+	needed_buffer_size = active_channels * sizeof(adc_data_size_t);
 
 	if (sequence->options) {
 		needed_buffer_size *= (1 + sequence->options->extra_samplings);

--- a/dts/arm/st/n6/stm32n6.dtsi
+++ b/dts/arm/st/n6/stm32n6.dtsi
@@ -5,6 +5,8 @@
  */
 
 #include <arm/armv8.1-m.dtsi>
+#include <zephyr/dt-bindings/adc/adc.h>
+#include <zephyr/dt-bindings/adc/stm32l4_adc.h>
 #include <zephyr/dt-bindings/clock/stm32n6_clock.h>
 #include <zephyr/dt-bindings/dma/stm32_dma.h>
 #include <zephyr/dt-bindings/reset/stm32n6_reset.h>
@@ -360,6 +362,38 @@
 				reg = <0x56024000 0x400>;
 				clocks = <&rcc STM32_CLOCK(AHB4, 16)>;
 			};
+		};
+
+		adc1: adc@50022000 {
+			compatible = "st,stm32n6-adc", "st,stm32-adc";
+			reg = <0x50022000 0x400>;
+			clocks = <&rcc STM32_CLOCK(AHB1, 5)>;
+			interrupts = <46 0>;
+			status = "disabled";
+			#io-channel-cells = <1>;
+			resolutions = <STM32_ADC_RES(12, 0x00)
+				       STM32_ADC_RES(10, 0x01)
+				       STM32_ADC_RES(8, 0x02)
+				       STM32_ADC_RES(6, 0x03)>;
+			sampling-times = <2 3 7 12 14 47 247 1500>;
+			st,adc-sequencer = "FULLY_CONFIGURABLE";
+			st,adc-oversampler = "OVERSAMPLER_EXTENDED";
+		};
+
+		adc2: adc@50022100 {
+			compatible = "st,stm32n6-adc", "st,stm32-adc";
+			reg = <0x50022100 0x300>;
+			clocks = <&rcc STM32_CLOCK(AHB1, 5)>;
+			interrupts = <46 0>;
+			status = "disabled";
+			#io-channel-cells = <1>;
+			resolutions = <STM32_ADC_RES(12, 0x00)
+				       STM32_ADC_RES(10, 0x01)
+				       STM32_ADC_RES(8, 0x02)
+				       STM32_ADC_RES(6, 0x03)>;
+			sampling-times = <2 3 7 12 14 47 247 1500>;
+			st,adc-sequencer = "FULLY_CONFIGURABLE";
+			st,adc-oversampler = "OVERSAMPLER_EXTENDED";
 		};
 
 		fdcan1: can@5000a000 {

--- a/dts/bindings/adc/st,stm32n6-adc.yaml
+++ b/dts/bindings/adc/st,stm32n6-adc.yaml
@@ -1,0 +1,15 @@
+# Copyright (c) 2024 STMicroelectronics
+
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+        ST STM32N6 ADC
+        This compatible stands for STM32N6 ADC.
+
+compatible: "st,stm32n6-adc"
+
+include:
+  - name: st,stm32-adc.yaml
+    property-blocklist:
+      - st,adc-clock-source
+      - st,adc-prescaler

--- a/tests/drivers/adc/adc_api/Kconfig
+++ b/tests/drivers/adc/adc_api/Kconfig
@@ -10,3 +10,6 @@ source "Kconfig.zephyr"
 config ADC_API_SAMPLE_INTERVAL_US
 	int "Interval between repeatead samples in us"
 	default 0
+
+config ADC_32_BITS_DATA
+	bool "ADC data is 32-bits long"

--- a/tests/drivers/adc/adc_api/boards/nucleo_n657x0_sb.conf
+++ b/tests/drivers/adc/adc_api/boards/nucleo_n657x0_sb.conf
@@ -1,0 +1,3 @@
+# USERSPACE not functional on N6 yet
+CONFIG_TEST_USERSPACE=n
+CONFIG_ADC_32_BITS_DATA=y

--- a/tests/drivers/adc/adc_api/boards/nucleo_n657x0_sb.overlay
+++ b/tests/drivers/adc/adc_api/boards/nucleo_n657x0_sb.overlay
@@ -1,0 +1,40 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2025 STMicroelectronics
+ */
+
+/ {
+	zephyr,user {
+		/* adjust channel number according to pinmux in board.dts */
+		io-channels = <&adc1 10>, <&adc1 11>;
+	};
+};
+
+&adc1 {
+	dmas = <&gpdma1 0 7 (STM32_DMA_PERIPH_RX | STM32_DMA_MEM_32BITS | STM32_DMA_PERIPH_32BITS)>;
+	dma-names = "gpdma";
+
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@a {
+		reg = <10>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_MAX>;
+		zephyr,resolution = <12>;
+	};
+
+	channel@b {
+		reg = <11>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_MAX>;
+		zephyr,resolution = <12>;
+	};
+};
+
+&gpdma1 {
+	status = "okay";
+};

--- a/tests/drivers/adc/adc_api/boards/stm32n6570_dk_sb.conf
+++ b/tests/drivers/adc/adc_api/boards/stm32n6570_dk_sb.conf
@@ -1,0 +1,3 @@
+# USERSPACE not functional on N6 yet
+CONFIG_TEST_USERSPACE=n
+CONFIG_ADC_32_BITS_DATA=y

--- a/tests/drivers/adc/adc_api/boards/stm32n6570_dk_sb.overlay
+++ b/tests/drivers/adc/adc_api/boards/stm32n6570_dk_sb.overlay
@@ -1,0 +1,40 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2025 STMicroelectronics
+ */
+
+/ {
+	zephyr,user {
+		/* adjust channel number according to pinmux in board.dts */
+		io-channels = <&adc1 10>, <&adc1 11>;
+	};
+};
+
+&adc1 {
+	dmas = <&gpdma1 0 7 (STM32_DMA_PERIPH_RX | STM32_DMA_MEM_32BITS | STM32_DMA_PERIPH_32BITS)>;
+	dma-names = "gpdma";
+
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@a {
+		reg = <10>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_MAX>;
+		zephyr,resolution = <12>;
+	};
+
+	channel@b {
+		reg = <11>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_MAX>;
+		zephyr,resolution = <12>;
+	};
+};
+
+&gpdma1 {
+	status = "okay";
+};


### PR DESCRIPTION
Add ADC support for STM32N6. Enable ADC on STM32N6570-DK and Nucleo N657X0, and add ADC test overlays for these two boards.