### PR TITLE
boards/qemu/xtensa: fix `DCACHE_LINE_SIZE` value for `sample_controller32`

### DIFF
--- a/boards/qemu/xtensa/Kconfig.defconfig
+++ b/boards/qemu/xtensa/Kconfig.defconfig
@@ -11,6 +11,7 @@ config IPM_CONSOLE_STACK_SIZE
 
 # Must match XCHAL_DCACHE_LINESIZE form core-isa.h
 config DCACHE_LINE_SIZE
+	default 4 if BOARD_QEMU_XTENSA_SAMPLE_CONTROLLER32_MPU
 	default 32
 
 endif # BOARD_QEMU_XTENSA


### PR DESCRIPTION
This PR adds a missing default value for the `DCHACHE_LINE_SIZE` option for the `qemu_xtensa/sample_controller32/mpu` platform. This is required after 8b39d4a6130c28260006a6a35756acd64c7133e9 added a build assert checking this value against `core-isa.h` from Xtensa HAL.

Fixes #85591.