### PR TITLE
Bluetooth: Host: Add API functions to determine PAST support for conn

### DIFF
--- a/include/zephyr/bluetooth/bluetooth.h
+++ b/include/zephyr/bluetooth/bluetooth.h
@@ -2061,6 +2061,19 @@ int bt_le_per_adv_sync_transfer(const struct bt_le_per_adv_sync *per_adv_sync,
 				const struct bt_conn *conn,
 				uint16_t service_data);
 
+/**
+ * @brief Check if periodic advertising sync transfer is supported for the connection as sender
+ *
+ * To use periodic advertising sync transfer (PAST) both sides need to support the feature.
+ * This check can be used before calling bt_le_per_adv_sync_transfer().
+ *
+ * @kconfig_dep{CONFIG_BT_PER_ADV_SYNC_TRANSFER_RECEIVER}
+ *
+ * @param conn          The peer device.
+ *
+ * @return true if PAST can be performed as the sender
+ */
+bool bt_le_per_adv_sync_transfer_supported(const struct bt_conn *conn);
 
 /**
  * @brief Transfer the information about a periodic advertising set.

--- a/include/zephyr/bluetooth/conn.h
+++ b/include/zephyr/bluetooth/conn.h
@@ -768,6 +768,16 @@ struct bt_conn_le_info {
 	/* Connection subrating parameters */
 	const struct bt_conn_le_subrating_info *subrate;
 #endif /* defined(CONFIG_BT_SUBRATING) */
+
+#if defined(CONFIG_BT_PER_ADV_SYNC_TRANSFER_SENDER)
+	/** Determines if periodic advertising sync transfer as sender is supported */
+	bool per_adv_sync_transfer_sender;
+#endif /* CONFIG_BT_PER_ADV_SYNC_TRANSFER_RECEIVER*/
+
+#if defined(CONFIG_BT_PER_ADV_SYNC_TRANSFER_RECEIVER)
+	/** Determines if periodic advertising sync transfer as sender is supported */
+	bool per_adv_sync_transfer_receiver;
+#endif /* CONFIG_BT_PER_ADV_SYNC_TRANSFER_RECEIVER*/
 };
 
 /** @brief Convert connection interval to milliseconds

--- a/subsys/bluetooth/audio/bap_broadcast_assistant.c
+++ b/subsys/bluetooth/audio/bap_broadcast_assistant.c
@@ -49,8 +49,6 @@ LOG_MODULE_REGISTER(bt_bap_broadcast_assistant, CONFIG_BT_BAP_BROADCAST_ASSISTAN
 #include "common/bt_str.h"
 
 #include "bap_internal.h"
-#include "../host/conn_internal.h"
-#include "../host/hci_core.h"
 
 #define MINIMUM_RECV_STATE_LEN          15
 
@@ -208,17 +206,23 @@ static bool past_available(const struct bt_conn *conn,
 			   const bt_addr_le_t *adv_addr,
 			   uint8_t sid)
 {
-	if (IS_ENABLED(CONFIG_BT_PER_ADV_SYNC_TRANSFER_SENDER)) {
-		LOG_DBG("%p remote %s PAST, local %s PAST", (void *)conn,
-			BT_FEAT_LE_PAST_RECV(conn->le.features) ? "supports" : "does not support",
-			BT_FEAT_LE_PAST_SEND(bt_dev.le.features) ? "supports" : "does not support");
+#if defined(CONFIG_BT_PER_ADV_SYNC_TRANSFER_SENDER)
+	struct bt_conn_info info;
+	int err;
 
-		return BT_FEAT_LE_PAST_RECV(conn->le.features) &&
-		       BT_FEAT_LE_PAST_SEND(bt_dev.le.features) &&
-		       bt_le_per_adv_sync_lookup_addr(adv_addr, sid) != NULL;
-	} else {
+	err = bt_conn_get_info(conn, &info);
+	if (err != 0) {
 		return false;
 	}
+
+	LOG_DBG("%p PAST %ssupported", (void *)conn,
+		info.le.per_adv_sync_transfer_sender ? "" : "not ");
+
+	return info.le.per_adv_sync_transfer_sender &&
+	       bt_le_per_adv_sync_lookup_addr(adv_addr, sid) != NULL;
+#else
+	return false;
+#endif
 }
 
 static int parse_recv_state(const void *data, uint16_t length,
@@ -378,7 +382,7 @@ static uint8_t broadcast_assistant_bap_ntf_read_func(struct bt_conn *conn, uint8
 		return BT_GATT_ITER_STOP;
 	}
 
-	LOG_DBG("conn %p err 0x%02x len %u", conn, err, length);
+	LOG_DBG("conn %p err 0x%02x len %u", (void *)conn, err, length);
 
 	if (err) {
 		LOG_DBG("Failed to read: %u", err);
@@ -427,7 +431,7 @@ static void long_bap_read(struct bt_conn *conn, uint16_t handle)
 	}
 
 	if (atomic_test_and_set_bit(inst->flags, BAP_BA_FLAG_BUSY)) {
-		LOG_DBG("conn %p", conn);
+		LOG_DBG("conn %p", (void *)conn);
 
 		/* If the client is busy reading reschedule the long read */
 		struct bt_conn_info conn_info;

--- a/subsys/bluetooth/audio/bap_broadcast_sink.c
+++ b/subsys/bluetooth/audio/bap_broadcast_sink.c
@@ -37,9 +37,6 @@
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
 
-#include "../host/conn_internal.h"
-#include "../host/iso_internal.h"
-
 #include "audio_internal.h"
 #include "bap_iso.h"
 #include "bap_endpoint.h"

--- a/subsys/bluetooth/audio/bap_scan_delegator.c
+++ b/subsys/bluetooth/audio/bap_scan_delegator.c
@@ -411,18 +411,23 @@ static struct bt_le_per_adv_sync_cb pa_sync_cb =  {
 
 static bool supports_past(struct bt_conn *conn, uint8_t pa_sync_val)
 {
-	if (IS_ENABLED(CONFIG_BT_PER_ADV_SYNC_TRANSFER_RECEIVER)) {
-		LOG_DBG("%p remote %s PAST, local %s PAST (req %u)", (void *)conn,
-			BT_FEAT_LE_PAST_SEND(conn->le.features) ? "supports" : "does not support",
-			BT_FEAT_LE_PAST_RECV(bt_dev.le.features) ? "supports" : "does not support",
-			pa_sync_val);
+#if defined(CONFIG_BT_PER_ADV_SYNC_TRANSFER_RECEIVER)
+	struct bt_conn_info info;
+	int err;
 
-		return pa_sync_val == BT_BAP_BASS_PA_REQ_SYNC_PAST &&
-		       BT_FEAT_LE_PAST_SEND(conn->le.features) &&
-		       BT_FEAT_LE_PAST_RECV(bt_dev.le.features);
-	} else {
+	err = bt_conn_get_info(conn, &info);
+	if (err != 0) {
 		return false;
 	}
+
+	LOG_DBG("%p PAST %ssupported (req %u)", (void *)conn,
+		info.le.per_adv_sync_transfer_receiver ? "" : "not ", pa_sync_val);
+
+	return pa_sync_val == BT_BAP_BASS_PA_REQ_SYNC_PAST &&
+	       info.le.per_adv_sync_transfer_receiver;
+#else
+	return false;
+#endif /* CONFIG_BT_PER_ADV_SYNC_TRANSFER_RECEIVER */
 }
 
 static int pa_sync_request(struct bt_conn *conn,
@@ -652,8 +657,8 @@ static int scan_delegator_add_source(struct bt_conn *conn,
 			(void)memset(state, 0, sizeof(*state));
 			internal_state->active = false;
 
-			LOG_DBG("PA sync %u from %p was rejected with reason %d", pa_sync, conn,
-				err);
+			LOG_DBG("PA sync %u from %p was rejected with reason %d", pa_sync,
+				(void *)conn, err);
 
 			return BT_GATT_ERR(BT_ATT_ERR_WRITE_REQ_REJECTED);
 		}
@@ -859,8 +864,8 @@ static int scan_delegator_mod_src(struct bt_conn *conn,
 			(void)memcpy(state, &backup_state,
 				     sizeof(backup_state));
 
-			LOG_DBG("PA sync %u from %p was rejected with reason %d", pa_sync, conn,
-				err);
+			LOG_DBG("PA sync %u from %p was rejected with reason %d", pa_sync,
+				(void *)conn, err);
 
 			return BT_GATT_ERR(BT_ATT_ERR_WRITE_REQ_REJECTED);
 		} else if (pa_sync_state != state->pa_sync_state) {
@@ -877,7 +882,8 @@ static int scan_delegator_mod_src(struct bt_conn *conn,
 		const int err = pa_sync_term_request(conn, &internal_state->state);
 
 		if (err != 0) {
-			LOG_DBG("PA sync term from %p was rejected with reason %d", conn, err);
+			LOG_DBG("PA sync term from %p was rejected with reason %d", (void *)conn,
+				err);
 
 			return BT_GATT_ERR(BT_ATT_ERR_WRITE_REQ_REJECTED);
 		}
@@ -972,7 +978,8 @@ static int scan_delegator_rem_src(struct bt_conn *conn,
 		/* Terminate PA sync */
 		err = pa_sync_term_request(conn, &internal_state->state);
 		if (err != 0) {
-			LOG_DBG("PA sync term from %p was rejected with reason %d", conn, err);
+			LOG_DBG("PA sync term from %p was rejected with reason %d", (void *)conn,
+				err);
 
 			return BT_GATT_ERR(BT_ATT_ERR_WRITE_REQ_REJECTED);
 		}

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -7,6 +7,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/bluetooth/hci_types.h>
 #include <zephyr/kernel.h>
 #include <string.h>
 #include <errno.h>
@@ -2963,6 +2964,20 @@ int bt_conn_get_info(const struct bt_conn *conn, struct bt_conn_info *info)
 #if defined(CONFIG_BT_SUBRATING)
 		info->le.subrate = &conn->le.subrate;
 #endif
+
+#if defined(CONFIG_BT_PER_ADV_SYNC_TRANSFER_SENDER)
+		info->le.per_adv_sync_transfer_sender = conn->state == BT_CONN_CONNECTED &&
+							BT_FEAT_LE_PAST_SEND(bt_dev.le.features) &&
+							BT_FEAT_LE_PAST_RECV(conn->le.features);
+#endif /* CONFIG_BT_PER_ADV_SYNC_TRANSFER_RECEIVER*/
+
+#if defined(CONFIG_BT_PER_ADV_SYNC_TRANSFER_RECEIVER)
+		info->le.per_adv_sync_transfer_receiver =
+			conn->state == BT_CONN_CONNECTED &&
+			BT_FEAT_LE_PAST_RECV(bt_dev.le.features) &&
+			BT_FEAT_LE_PAST_SEND(conn->le.features);
+#endif /* CONFIG_BT_PER_ADV_SYNC_TRANSFER_RECEIVER*/
+
 		if (conn->le.keys && (conn->le.keys->flags & BT_KEYS_SC)) {
 			info->security.flags |= BT_SECURITY_FLAG_SC;
 		}

--- a/subsys/bluetooth/host/scan.c
+++ b/subsys/bluetooth/host/scan.c
@@ -9,6 +9,7 @@
 #include <stdint.h>
 #include <string.h>
 
+#include <zephyr/bluetooth/hci_types.h>
 #include <zephyr/sys/atomic.h>
 #include <zephyr/kernel.h>
 #include <zephyr/sys/byteorder.h>


### PR DESCRIPTION
Adds bt_le_per_adv_sync_transfer_supported and
bt_le_per_adv_sync_receive_supported which returns whether PAST is supported for the given connection based on the local and remote features.