### PR TITLE
drivers : can: replace LL_RCC_GetFDCANClockFreq and remove stm32_ll_rcc.h include

### DIFF
--- a/drivers/can/Kconfig.stm32
+++ b/drivers/can/Kconfig.stm32
@@ -54,7 +54,6 @@ config CAN_STM32_FDCAN
 	depends on DT_HAS_ST_STM32_FDCAN_ENABLED
 	select CAN_MCAN
 	select PINCTRL
-	select USE_STM32_LL_RCC
 
 if CAN_STM32_FDCAN
 
@@ -82,4 +81,3 @@ config CAN_STM32H7_FDCAN
 	depends on DT_HAS_ST_STM32H7_FDCAN_ENABLED
 	select CAN_MCAN
 	select PINCTRL
-	select USE_STM32_LL_RCC

--- a/drivers/can/can_stm32_fdcan.c
+++ b/drivers/can/can_stm32_fdcan.c
@@ -13,7 +13,6 @@
 #include <zephyr/kernel.h>
 #include <zephyr/sys/__assert.h>
 #include <soc.h>
-#include <stm32_ll_rcc.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/irq.h>
 
@@ -403,13 +402,30 @@ static int can_stm32fd_clear_mram(const struct device *dev, uint16_t offset, siz
 
 static int can_stm32fd_get_core_clock(const struct device *dev, uint32_t *rate)
 {
-	const uint32_t rate_tmp = LL_RCC_GetFDCANClockFreq(LL_RCC_FDCAN_CLKSOURCE);
+	uint32_t rate_tmp;
+	const struct can_mcan_config *mcan_cfg = dev->config;
+	const struct can_stm32fd_config *stm32fd_cfg = mcan_cfg->custom;
+	const struct device *const clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 
 	ARG_UNUSED(dev);
+	if (!device_is_ready(clk)) {
+		return -ENODEV;
+	}
 
-	if (rate_tmp == LL_RCC_PERIPH_FREQUENCY_NO) {
-		LOG_ERR("Can't read core clock");
-		return -EIO;
+	if (IS_ENABLED(STM32_CANFD_DOMAIN_CLOCK_SUPPORT) && (stm32fd_cfg->pclk_len > 1)) {
+		if (clock_control_get_rate(clk,
+			 (clock_control_subsys_t) &stm32fd_cfg->pclken[1],
+			  &rate_tmp) < 0) {
+			LOG_ERR("Failed call clock_control_get_rate(pclk[1])");
+			return -EIO;
+		}
+	} else {
+		if (clock_control_get_rate(clk,
+			 (clock_control_subsys_t) &stm32fd_cfg->pclken[0],
+			  &rate_tmp) < 0) {
+			LOG_ERR("Failed call clock_control_get_rate(pclk[0])");
+			return -EIO;
+		}
 	}
 
 	if (FDCAN_CONFIG->CKDIV == 0) {

--- a/drivers/can/can_stm32h7_fdcan.c
+++ b/drivers/can/can_stm32h7_fdcan.c
@@ -11,7 +11,6 @@
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/kernel.h>
-#include <stm32_ll_rcc.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/irq.h>
 #include <zephyr/sys/util.h>
@@ -84,16 +83,33 @@ static int can_stm32h7_clear_mram(const struct device *dev, uint16_t offset, siz
 
 static int can_stm32h7_get_core_clock(const struct device *dev, uint32_t *rate)
 {
-	const uint32_t rate_tmp = LL_RCC_GetFDCANClockFreq(LL_RCC_FDCAN_CLKSOURCE);
+	uint32_t rate_tmp;
+	const struct can_mcan_config *mcan_cfg = dev->config;
+	const struct can_stm32h7_config *stm32h7_cfg = mcan_cfg->custom;
+	const struct device *const clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 	uint32_t cdiv;
 
 	ARG_UNUSED(dev);
-
-	if (rate_tmp == LL_RCC_PERIPH_FREQUENCY_NO) {
-		LOG_ERR("Can't read core clock");
-		return -EIO;
+	if (!device_is_ready(clk)) {
+		LOG_ERR("clock control device not ready");
+		return -ENODEV;
 	}
 
+	if (IS_ENABLED(STM32H7_FDCAN_DOMAIN_CLOCK_SUPPORT) && (stm32h7_cfg->pclk_len > 1)) {
+		if (clock_control_get_rate(clk,
+			 (clock_control_subsys_t) &stm32h7_cfg->pclken[1],
+			  &rate_tmp) < 0) {
+			LOG_ERR("Failed call clock_control_get_rate(pclk[1])");
+			return -EIO;
+		}
+	} else {
+		if (clock_control_get_rate(clk,
+			 (clock_control_subsys_t) &stm32h7_cfg->pclken[0],
+			  &rate_tmp) < 0) {
+			LOG_ERR("Failed call clock_control_get_rate(pclk[0])");
+			return -EIO;
+		}
+	}
 	cdiv = FIELD_GET(FDCANCCU_CCFG_CDIV, FDCAN_CCU->CCFG);
 	if (cdiv == 0U) {
 		*rate = rate_tmp;


### PR DESCRIPTION
replace LL_RCC_GetFDCANClockFreq with clock_control_get_rate, remove
stm32_ll_rcc.h include in can_stm32h7_fdcan.c and can_stm32_fdcan.c and remove use_stm32_ll_rcc from kconfig.
