### PR TITLE
drivers: bluetooth: silabs: Set maximum TX power

### DIFF
--- a/modules/hal_silabs/simplicity_sdk/src/blob_stubs.c
+++ b/modules/hal_silabs/simplicity_sdk/src/blob_stubs.c
@@ -31,6 +31,11 @@ void BTLE_LL_Process(uint32_t events)
 {
 }
 
+int16_t BTLE_LL_SetMaxPower(int16_t power)
+{
+	return 0;
+}
+
 void sl_btctrl_disable_2m_phy(void)
 {
 }


### PR DESCRIPTION
Honor Kconfig option `BT_CTLR_TX_PWR_ANTENNA` for limiting the maximum TX power. The default value for this option is 0 dBm, which means that after this change the actual TX power is likely lower than before, unless increased by this option.