### PR TITLE
twister: shell harness with commands alongside the harness_config

### DIFF
--- a/doc/develop/test/twister.rst
+++ b/doc/develop/test/twister.rst
@@ -993,13 +993,30 @@ framework and the pytest harness of twister.
 
 The following options apply to the shell harness:
 
-shell_params_file: <string> (default empty)
+shell_commands: <list of pairs of commands and their expected output> (default empty)
+    Specify a list of shell commands to be executed and their expected output.
+    For example:
+
+    .. code-block:: yaml
+
+        harness_config:
+          shell_commands:
+          - command: "kernel cycles"
+            expected: "cycles: .* hw cycles"
+          - command: "kernel version"
+            expected: "Zephyr version .*"
+          - command: "kernel sleep 100"
+
+
+    If expected output is not provided, the command will be executed and the output
+    will be logged.
+
+shell_commands_file: <string> (default empty)
     Specify a file containing test parameters to be used in the test.
     The file should contain a list of commands and their expected output. For example:
 
-    .. code-block:: none
+    .. code-block:: yaml
 
-      test_shell_harness:
       - command: "mpu mtest 1"
         expected: "The value is: 0x.*"
       - command: "mpu mtest 2"
@@ -1007,7 +1024,8 @@ shell_params_file: <string> (default empty)
 
 
     If no file is specified, the shell harness will use the default file
-      ``test_shell.yml`` in the test directory.
+    ``test_shell.yml`` in the test directory.
+    ``shell_commands`` will take precedence over ``shell_commands_file``.
 
 Selecting platform scope
 ************************

--- a/samples/arch/mpu/mpu_test/test_shell.yml
+++ b/samples/arch/mpu/mpu_test/test_shell.yml
@@ -1,4 +1,3 @@
-test_shell_harness:
 - command: "mpu mtest 1"
   expected: "The value is: 0x.*"
 - command: "mpu mtest 2"

--- a/samples/drivers/flash_shell/test_shell.yml
+++ b/samples/drivers/flash_shell/test_shell.yml
@@ -1,3 +1,2 @@
-test_shell_harness:
 - command: "flash page_info 0"
   expected: "Page for address 0x0"

--- a/samples/subsys/shell/shell_module/test_shell.yml
+++ b/samples/subsys/shell/shell_module/test_shell.yml
@@ -1,4 +1,3 @@
-test_shell_harness:
 - command: "kernel cycles"
   expected: "cycles: .* hw cycles"
 - command: "kernel version"

--- a/samples/subsys/testsuite/pytest/shell/testcase.yaml
+++ b/samples/subsys/testsuite/pytest/shell/testcase.yaml
@@ -1,28 +1,34 @@
+common:
+  tags:
+    - test_framework
+    - pytest
+    - shell
+  filter: CONFIG_SERIAL and not CONFIG_SMP and dt_chosen_enabled("zephyr,shell-uart")
+  extra_configs:
+    - arch:posix:CONFIG_NATIVE_UART_0_ON_STDINOUT=y
+  min_ram: 40
+  integration_platforms:
+    - native_sim
+    - qemu_cortex_m3
 tests:
   sample.pytest.shell:
-    filter: CONFIG_SERIAL and dt_chosen_enabled("zephyr,shell-uart")
-    min_ram: 40
     harness: pytest
-    extra_configs:
-      - arch:posix:CONFIG_NATIVE_UART_0_ON_STDINOUT=y
-    integration_platforms:
-      - native_sim
-      - qemu_cortex_m3
-    tags:
-      - test_framework
-      - pytest
-      - shell
   sample.pytest.shell.vt100_colors_off:
-    filter: CONFIG_SERIAL and dt_chosen_enabled("zephyr,shell-uart")
-    min_ram: 40
     harness: pytest
     extra_configs:
-      - arch:posix:CONFIG_NATIVE_UART_0_ON_STDINOUT=y
       - CONFIG_SHELL_VT100_COLORS=n
-    integration_platforms:
-      - native_sim
-      - qemu_cortex_m3
-    tags:
-      - test_framework
-      - pytest
-      - shell
+  sample.harness.shell:
+    harness: shell
+    harness_config:
+      shell_commands: &kernel_commands
+        - command: "kernel cycles"
+          expected: "cycles: .* hw cycles"
+        - command: "kernel version"
+          expected: "Zephyr version .*"
+        - command: "kernel sleep 100"
+  sample.harness.shell.vt100_colors_off:
+    harness: shell
+    extra_configs:
+      - CONFIG_SHELL_VT100_COLORS=n
+    harness_config:
+      shell_commands: *kernel_commands

--- a/scripts/pylib/shell-twister-harness/test_shell.py
+++ b/scripts/pylib/shell-twister-harness/test_shell.py
@@ -19,14 +19,19 @@ def testdata_path(request):
 def get_next_commands(testdata_path):
     with open(testdata_path) as yaml_file:
         data = yaml.safe_load(yaml_file)
-    for entry in data['test_shell_harness']:
-        yield entry['command'], entry['expected']
+    for entry in data:
+        yield entry['command'], entry.get('expected', None)
 
 
 def test_shell_harness(shell: Shell, testdata_path):
+    if not testdata_path:
+        pytest.skip('testdata not provided')
     for command, expected in get_next_commands(testdata_path):
         logger.info('send command: %s', command)
         lines = shell.exec_command(command)
+        if not expected:
+            logger.debug('no expected response')
+            continue
         match = False
         for line in lines:
             if re.match(expected, line):

--- a/scripts/schemas/twister/testsuite-schema.yaml
+++ b/scripts/schemas/twister/testsuite-schema.yaml
@@ -107,9 +107,20 @@ schema;scenario-schema:
       type: map
       required: false
       mapping:
-        "shell_params_file":
+        "shell_commands_file":
           type: str
           required: false
+        "shell_commands":
+          type: seq
+          required: false
+          sequence:
+            - type: map
+              mapping:
+                "command":
+                  type: str
+                  required: true
+                "expected":
+                  type: str
         "type":
           type: str
           required: false


### PR DESCRIPTION
Allow user to add shell commands in testcase/sample yaml file alongside the harness_config like in the console harness.

ref: https://github.com/zephyrproject-rtos/zephyr/pull/85033

Instead of having shell commands in a separate file, one can add:
```
        harness_config:
          shell_commands:
          - command: "kernel cycles"
            expected: "cycles: .* hw cycles"
          - command: "kernel version"
            expected: "Zephyr version .*"
          - command: "kernel sleep 100"
  ```

Added examples in samples/subsys/testsuite/pytest/shell and updated existing samples.
To test you can run:
```
$ZEPHYR_BASE/scripts/twister -vv -T samples/subsys/testsuite/pytest/shell -G --no-clean -ll debug

$ZEPHYR_BASE/scripts/twister -vv -T samples/drivers/flash_shell -p native_sim -c -ll debug

$ZEPHYR_BASE/scripts/twister -vv -T samples/subsys/shell/shell_module -s sample.shell.shell_module -p native_sim -c -ll debug
```

@nashif , @bjarki-andreasen answering that comment:
https://github.com/zephyrproject-rtos/zephyr/pull/85033#discussion_r1941835311
in one sample I added example usage of anchors in yaml files, it works!
```
  sample.harness.shell:
    harness_config:
      shell_commands: &kernel_commands     <-------
      - command: "kernel cycles"
        expected: "cycles: .* hw cycles"
      - command: "kernel version"
        expected: "Zephyr version .*"
      - command: "kernel sleep 100"
  sample.harness.shell.vt100_colors_off:
    harness_config:
      shell_commands: *kernel_commands   <------
```

