### PR TITLE
K3: M4: Lock resource table and add IPC DRAM region

### DIFF
--- a/boards/phytec/phyboard_electra/phyboard_electra_am6442_m4.dts
+++ b/boards/phytec/phyboard_electra/phyboard_electra_am6442_m4.dts
@@ -31,9 +31,15 @@
 		};
 	};
 
-	ddr0:memory@a4100000 {
+	rsc_table: memory@a4100000 {
 		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0xa4100000 DT_SIZE_K(4)>;
+		zephyr,memory-region = "RSC_TABLE";
+	};
+
+	ddr0: memory@a4101000 {
+		compatible = "zephyr,memory-region", "mmio-sram";
+		reg = <0xa4101000 (DT_SIZE_M(15) - DT_SIZE_K(4))>;
 		zephyr,memory-region = "DDR";
 	};
 

--- a/boards/phytec/phyboard_electra/phyboard_electra_am6442_m4.dts
+++ b/boards/phytec/phyboard_electra/phyboard_electra_am6442_m4.dts
@@ -17,7 +17,8 @@
 		zephyr,sram = &sram0;
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
-		zephyr,sram1 = &ddr0;
+		zephyr,ipc_shm = &ddr0;
+		zephyr,sram1 = &ddr1;
 	};
 
 	aliases {
@@ -31,13 +32,18 @@
 		};
 	};
 
+	ddr0: memory@a4000000 {
+		compatible = "mmio-sram";
+		reg = <0xa4000000 DT_SIZE_M(1)>;
+	};
+
 	rsc_table: memory@a4100000 {
 		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0xa4100000 DT_SIZE_K(4)>;
 		zephyr,memory-region = "RSC_TABLE";
 	};
 
-	ddr0: memory@a4101000 {
+	ddr1: memory@a4101000 {
 		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0xa4101000 (DT_SIZE_M(15) - DT_SIZE_K(4))>;
 		zephyr,memory-region = "DDR";

--- a/boards/phytec/phyboard_lyra/phyboard_lyra_am6234_m4.dts
+++ b/boards/phytec/phyboard_lyra/phyboard_lyra_am6234_m4.dts
@@ -31,9 +31,15 @@
 		};
 	};
 
-	ddr0:memory@9CC00000{
+	rsc_table: memory@9cc00000 {
 		compatible = "zephyr,memory-region", "mmio-sram";
-		reg = <0x9CC00000 DT_SIZE_K(4)>;
+		reg = <0x9cc00000 DT_SIZE_K(4)>;
+		zephyr,memory-region = "RSC_TABLE";
+	};
+
+	ddr0: memory@9cc01000{
+		compatible = "zephyr,memory-region", "mmio-sram";
+		reg = <0x9cc01000 (DT_SIZE_M(15) - DT_SIZE_K(4))>;
 		zephyr,memory-region = "DDR";
 	};
 

--- a/boards/phytec/phyboard_lyra/phyboard_lyra_am6234_m4.dts
+++ b/boards/phytec/phyboard_lyra/phyboard_lyra_am6234_m4.dts
@@ -17,7 +17,8 @@
 		zephyr,sram = &sram0;
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
-		zephyr,sram1 = &ddr0;
+		zephyr,ipc_shm = &ddr0;
+		zephyr,sram1 = &ddr1;
 	};
 
 	aliases {
@@ -31,13 +32,18 @@
 		};
 	};
 
+	ddr0: memory@9cb00000 {
+		compatible = "mmio-sram";
+		reg = <0x9cb00000 DT_SIZE_M(1)>;
+	};
+
 	rsc_table: memory@9cc00000 {
 		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0x9cc00000 DT_SIZE_K(4)>;
 		zephyr,memory-region = "RSC_TABLE";
 	};
 
-	ddr0: memory@9cc01000{
+	ddr1: memory@9cc01000 {
 		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0x9cc01000 (DT_SIZE_M(15) - DT_SIZE_K(4))>;
 		zephyr,memory-region = "DDR";

--- a/boards/ti/sk_am62/sk_am62_am6234_m4.dts
+++ b/boards/ti/sk_am62/sk_am62_am6234_m4.dts
@@ -26,9 +26,15 @@
 		};
 	};
 
-	ddr0:memory@9CC00000{
+	rsc_table: memory@9cc00000 {
 		compatible = "zephyr,memory-region", "mmio-sram";
-		reg = <0x9CC00000 DT_SIZE_K(4)>;
+		reg = <0x9cc00000 DT_SIZE_K(4)>;
+		zephyr,memory-region = "RSC_TABLE";
+	};
+
+	ddr0: memory@9cc01000{
+		compatible = "zephyr,memory-region", "mmio-sram";
+		reg = <0x9cc01000 (DT_SIZE_M(15) - DT_SIZE_K(4))>;
 		zephyr,memory-region = "DDR";
 	};
 };

--- a/boards/ti/sk_am62/sk_am62_am6234_m4.dts
+++ b/boards/ti/sk_am62/sk_am62_am6234_m4.dts
@@ -16,7 +16,8 @@
 		zephyr,sram = &sram0;
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
-		zephyr,sram1 = &ddr0;
+		zephyr,ipc_shm = &ddr0;
+		zephyr,sram1 = &ddr1;
 	};
 
 	cpus {
@@ -26,13 +27,18 @@
 		};
 	};
 
+	ddr0: memory@9cb00000 {
+		compatible = "mmio-sram";
+		reg = <0x9cb00000 DT_SIZE_M(1)>;
+	};
+
 	rsc_table: memory@9cc00000 {
 		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0x9cc00000 DT_SIZE_K(4)>;
 		zephyr,memory-region = "RSC_TABLE";
 	};
 
-	ddr0: memory@9cc01000{
+	ddr1: memory@9cc01000 {
 		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0x9cc01000 (DT_SIZE_M(15) - DT_SIZE_K(4))>;
 		zephyr,memory-region = "DDR";

--- a/soc/ti/k3/am6x/m4/linker.ld
+++ b/soc/ti/k3/am6x/m4/linker.ld
@@ -13,6 +13,6 @@ SECTIONS
 	SECTION_PROLOGUE(.resource_table,, SUBALIGN(4))
 	{
 		KEEP(*(.resource_table*))
-	} GROUP_LINK_IN(DDR)
+	} GROUP_LINK_IN(RSC_TABLE)
 #endif
 }


### PR DESCRIPTION
Set of patches to prepare for enabling IPC with a Linux/HLOS running on the A53 cores from Zephyr on the M4 cores.

Fix the location of the resource table in memory and add the VirtIO/Vring DRAM IPC regions. These locations are set in Linux DT as carved out for this purpose.