### PR TITLE
mcuboot: Alignments needed for devices without erase

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -23,6 +23,8 @@ manifest:
       url-base: https://github.com/zephyrproject-rtos
     - name: babblesim
       url-base: https://github.com/BabbleSim
+    - name: mcutools
+      url-base: https://github.com/mcu-tools
 
   group-filter: [-babblesim, -optional]
 
@@ -303,7 +305,7 @@ manifest:
       groups:
         - crypto
     - name: mcuboot
-      revision: 346f7374ff4467e40b5594658f8ac67a5e9813c9
+      revision: f2b6def94041820ddb9f5c384d0406a3a8f91b4a
       path: bootloader/mcuboot
       groups:
         - bootloader

--- a/west.yml
+++ b/west.yml
@@ -355,7 +355,7 @@ manifest:
       groups:
         - tee
     - name: trusted-firmware-m
-      revision: 2f138475047d566f1446f62657aa546b0e0b52c2
+      revision: pull/120/head
       path: modules/tee/tf-m/trusted-firmware-m
       groups:
         - tee


### PR DESCRIPTION
MCUboot support for devices without erase may require additional alignment in Zephyr.