### PR TITLE
llext-edk: additional options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2220,46 +2220,48 @@ if((CMAKE_BUILD_TYPE IN_LIST build_types) AND (NOT NO_BUILD_TYPE_WARNING))
 endif()
 
 # Extension Development Kit (EDK) generation.
-set(llext_edk_file ${PROJECT_BINARY_DIR}/${CONFIG_LLEXT_EDK_NAME}.tar.xz)
+if(CONFIG_LLEXT_EDK)
+  set(llext_edk_file ${PROJECT_BINARY_DIR}/${CONFIG_LLEXT_EDK_NAME}.tar.xz)
 
-# TODO maybe generate flags for C CXX ASM
-zephyr_get_compile_definitions_for_lang(C zephyr_defs)
-zephyr_get_compile_options_for_lang(C zephyr_flags)
+  # TODO maybe generate flags for C CXX ASM
+  zephyr_get_compile_definitions_for_lang(C zephyr_defs)
+  zephyr_get_compile_options_for_lang(C zephyr_flags)
 
-# Filter out non LLEXT and LLEXT_EDK flags - and add required ones
-llext_filter_zephyr_flags(LLEXT_REMOVE_FLAGS ${zephyr_flags} llext_filt_flags)
-llext_filter_zephyr_flags(LLEXT_EDK_REMOVE_FLAGS ${llext_filt_flags} llext_filt_flags)
+  # Filter out non LLEXT and LLEXT_EDK flags - and add required ones
+  llext_filter_zephyr_flags(LLEXT_REMOVE_FLAGS ${zephyr_flags} llext_filt_flags)
+  llext_filter_zephyr_flags(LLEXT_EDK_REMOVE_FLAGS ${llext_filt_flags} llext_filt_flags)
 
-set(llext_edk_cflags ${zephyr_defs} -DLL_EXTENSION_BUILD)
-list(APPEND llext_edk_cflags ${llext_filt_flags})
-list(APPEND llext_edk_cflags ${LLEXT_APPEND_FLAGS})
-list(APPEND llext_edk_cflags ${LLEXT_EDK_APPEND_FLAGS})
+  set(llext_edk_cflags ${zephyr_defs} -DLL_EXTENSION_BUILD)
+  list(APPEND llext_edk_cflags ${llext_filt_flags})
+  list(APPEND llext_edk_cflags ${LLEXT_APPEND_FLAGS})
+  list(APPEND llext_edk_cflags ${LLEXT_EDK_APPEND_FLAGS})
 
-build_info(llext-edk file PATH ${llext_edk_file})
-build_info(llext-edk cflags VALUE ${llext_edk_cflags})
-build_info(llext-edk include-dirs VALUE "$<TARGET_PROPERTY:zephyr_interface,INTERFACE_INCLUDE_DIRECTORIES>")
+  build_info(llext-edk file PATH ${llext_edk_file})
+  build_info(llext-edk cflags VALUE ${llext_edk_cflags})
+  build_info(llext-edk include-dirs VALUE "$<TARGET_PROPERTY:zephyr_interface,INTERFACE_INCLUDE_DIRECTORIES>")
 
-add_custom_command(
+  add_custom_command(
     OUTPUT ${llext_edk_file}
     # Regenerate syscalls in case CONFIG_LLEXT_EDK_USERSPACE_ONLY
     COMMAND ${CMAKE_COMMAND}
-        -E make_directory edk/include/generated/zephyr
+      -E make_directory edk/include/generated/zephyr
     COMMAND
-        ${PYTHON_EXECUTABLE}
-        ${ZEPHYR_BASE}/scripts/build/gen_syscalls.py
-        --json-file        ${syscalls_json}                     # Read this file
-        --base-output      edk/include/generated/zephyr/syscalls           # Write to this dir
-        --syscall-dispatch edk/include/generated/zephyr/syscall_dispatch.c # Write this file
-        --syscall-list     ${edk_syscall_list_h}
-        $<$<BOOL:${CONFIG_LLEXT_EDK_USERSPACE_ONLY}>:--userspace-only>
-        ${SYSCALL_LONG_REGISTERS_ARG}
-        ${SYSCALL_SPLIT_TIMEOUT_ARG}
+      ${PYTHON_EXECUTABLE}
+      ${ZEPHYR_BASE}/scripts/build/gen_syscalls.py
+      --json-file        ${syscalls_json}                     # Read this file
+      --base-output      edk/include/generated/zephyr/syscalls           # Write to this dir
+      --syscall-dispatch edk/include/generated/zephyr/syscall_dispatch.c # Write this file
+      --syscall-list     ${edk_syscall_list_h}
+      $<$<BOOL:${CONFIG_LLEXT_EDK_USERSPACE_ONLY}>:--userspace-only>
+      ${SYSCALL_LONG_REGISTERS_ARG}
+      ${SYSCALL_SPLIT_TIMEOUT_ARG}
     COMMAND ${CMAKE_COMMAND}
         -P ${ZEPHYR_BASE}/cmake/llext-edk.cmake
     DEPENDS ${logical_target_for_zephyr_elf} build_info_yaml_saved
     COMMAND_EXPAND_LISTS
-)
-add_custom_target(llext-edk DEPENDS ${llext_edk_file})
+  )
+  add_custom_target(llext-edk DEPENDS ${llext_edk_file})
+endif()
 
 # @Intent: Set compiler specific flags for standard C/C++ includes
 # Done at the very end, so any other system includes which may

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2221,7 +2221,16 @@ endif()
 
 # Extension Development Kit (EDK) generation.
 if(CONFIG_LLEXT_EDK)
-  set(llext_edk_file ${PROJECT_BINARY_DIR}/${CONFIG_LLEXT_EDK_NAME}.tar.xz)
+  if(CONFIG_LLEXT_EDK_FORMAT_TAR_XZ)
+    set(llext_edk_extension "tar.xz")
+  elseif(CONFIG_LLEXT_EDK_FORMAT_TAR_ZSTD)
+    set(llext_edk_extension "tar.Z")
+  elseif(CONFIG_LLEXT_EDK_FORMAT_ZIP)
+    set(llext_edk_extension "zip")
+  else()
+    message(FATAL_ERROR "Unsupported LLEXT_EDK_FORMAT choice")
+  endif()
+  set(llext_edk_file ${PROJECT_BINARY_DIR}/${CONFIG_LLEXT_EDK_NAME}.${llext_edk_extension})
 
   # TODO maybe generate flags for C CXX ASM
   zephyr_get_compile_definitions_for_lang(C zephyr_defs)

--- a/cmake/llext-edk.cmake
+++ b/cmake/llext-edk.cmake
@@ -238,12 +238,21 @@ foreach(target ${edk_targets})
     edk_write_var(${target} "LLEXT_GENERATED_IMACROS_CFLAGS" "${imacros_gen}")
 endforeach()
 
+if(CONFIG_LLEXT_EDK_FORMAT_TAR_XZ)
+  set(llext_edk_format FORMAT gnutar COMPRESSION XZ)
+elseif(CONFIG_LLEXT_EDK_FORMAT_TAR_ZSTD)
+  set(llext_edk_format FORMAT gnutar COMPRESSION Zstd)
+elseif(CONFIG_LLEXT_EDK_FORMAT_ZIP)
+  set(llext_edk_format FORMAT zip)
+else()
+  message(FATAL_ERROR "Unsupported LLEXT_EDK_FORMAT choice")
+endif()
+
 # Generate the tarball
 file(ARCHIVE_CREATE
     OUTPUT ${llext_edk_file}
     PATHS ${llext_edk}
-    FORMAT gnutar
-    COMPRESSION XZ
+    ${llext_edk_format}
 )
 
 file(REMOVE_RECURSE ${llext_edk})

--- a/subsys/llext/Kconfig
+++ b/subsys/llext/Kconfig
@@ -141,13 +141,38 @@ config LLEXT_EDK_NAME
 	string "Name for llext EDK (Extension Development Kit)"
 	default "llext-edk"
 	help
-	  Name will be used when generating the EDK file, as <name>.tar.xz.
+	  <name> will be used when generating the EDK file; the appropriate
+	  extension will be appended depending on the chosen output format.
 	  It will also be used, normalized, as the prefix for the variable
 	  stating EDK location, used on generated Makefile.cflags. For
 	  instance, the default name, "llext-edk", becomes LLEXT_EDK_INSTALL_DIR.
 
+choice LLEXT_EDK_FORMAT
+prompt "EDK compression and output format"
+default LLEXT_EDK_FORMAT_TAR_XZ
+
+config LLEXT_EDK_FORMAT_TAR_XZ
+	bool ".tar.xz"
+	help
+	  Use GNU tar with XZ compression for the EDK file. Highest compression
+	  ratio, slower choice.
+
+config LLEXT_EDK_FORMAT_TAR_ZSTD
+	bool ".tar.Z"
+	help
+	  Use GNU tar with Zstd compression for the EDK file. Way faster than
+	  XZ, but still with a high compression ratio.
+
+config LLEXT_EDK_FORMAT_ZIP
+	bool ".zip"
+	help
+	  Use Zip format and compression for the EDK file. This is the most
+	  portable option, but it may not compress as well as XZ or Zstd.
+
+endchoice
+
 config LLEXT_EDK_USERSPACE_ONLY
-	bool "Only generate the Userpace codepath on syscall stubs for the EDK"
+	bool "Only generate the Userspace codepath on syscall stubs for the EDK"
 	help
 	  Syscall stubs can contain code that verifies if running code is at user
 	  or kernel space and route the call accordingly. If the EDK is expected

--- a/subsys/llext/Kconfig
+++ b/subsys/llext/Kconfig
@@ -126,7 +126,16 @@ source "subsys/logging/Kconfig.template.log_config"
 
 endif
 
-menu "Linkable loadable Extension Development Kit (EDK)"
+menuconfig LLEXT_EDK
+	bool "Linkable loadable Extension Development Kit (EDK)"
+	default y if LLEXT
+	help
+	  Enable the generation of an Extension Development Kit (EDK) for the
+	  Linkable Loadable Extension subsystem. The EDK is an archive that
+	  contains the necessary files and build settings to build extensions
+	  for Zephyr without the need to have the full Zephyr source tree.
+
+if LLEXT_EDK
 
 config LLEXT_EDK_NAME
 	string "Name for llext EDK (Extension Development Kit)"
@@ -145,4 +154,4 @@ config LLEXT_EDK_USERSPACE_ONLY
 	  to be used by userspace only extensions, this option will make EDK stubs
 	  not contain the routing code, and only generate the userspace one.
 
-endmenu
+endif


### PR DESCRIPTION
Another take on hiding the EDK parameters from a default build; this was proposed recently in #84850, but was rejected because the EDK may be useful outside of LLEXT. 

This PR instead creates a separate top-level Kconfig (`CONFIG_LLEXT_EDK`) to enable that functionality separately from `CONFIG_LLEXT`.
Also use the opportunity to add a compression type choice to the LLEXT_EDK, defaulting to the previous behavior but also allowing the generation of a faster `.tar.Z` or a more compatible `.zip`. 

> [!NOTE]
> The PR re-indents the EDK portion of the main `CMakeLists.txt`; the diff is much smaller if whitespace changes are ignored.  

