### PR TITLE
boards: qemu/xtensa: fix dcache line sz for sample_controller32

### DIFF
--- a/boards/qemu/xtensa/Kconfig.defconfig
+++ b/boards/qemu/xtensa/Kconfig.defconfig
@@ -11,6 +11,7 @@ config IPM_CONSOLE_STACK_SIZE
 
 # Must match XCHAL_DCACHE_LINESIZE form core-isa.h
 config DCACHE_LINE_SIZE
+	default 4 if SOC_XTENSA_SAMPLE_CONTROLLER32=y
 	default 32
 
 endif # BOARD_QEMU_XTENSA


### PR DESCRIPTION
The data cache line size is 4 for sample_controller32. This fixes a build assert on mismatched kconfig and HAL's data cache line size definition.

Fixes #85591