### PR TITLE
samples: drivers: w1: s/samples/sample/ in sample.yaml

### DIFF
--- a/samples/drivers/w1/scanner/sample.yaml
+++ b/samples/drivers/w1/scanner/sample.yaml
@@ -27,7 +27,7 @@ tests:
       regex:
         - "Number of devices found on bus: .*"
       fixture: w1_scanner_ds2484
-  samples.drivers.w1.scanner.ds2485:
+  sample.drivers.w1.scanner.ds2485:
     depends_on: arduino_i2c
     extra_args: DTC_OVERLAY_FILE=ds2485.overlay
     platform_allow:
@@ -38,7 +38,7 @@ tests:
       regex:
         - "Number of devices found on bus: .*"
       fixture: w1_scanner_ds2485
-  samples.drivers.w1.scanner.w1_serial:
+  sample.drivers.w1.scanner.w1_serial:
     depends_on:
       - arduino_serial
     extra_args: DTC_OVERLAY_FILE=w1_serial.overlay


### PR DESCRIPTION
Use 'sample.' in the sample definition, in order to follow Zephyr
convention.