### PR TITLE
Enable dma driver tests for MAX32 boards

### DIFF
--- a/tests/drivers/dma/chan_blen_transfer/boards/max32662evkit.conf
+++ b/tests/drivers/dma/chan_blen_transfer/boards/max32662evkit.conf
@@ -1,0 +1,4 @@
+# Copyright (c) 2025 Analog Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_CODE_DATA_RELOCATION=y

--- a/tests/drivers/dma/chan_blen_transfer/boards/max32662evkit.overlay
+++ b/tests/drivers/dma/chan_blen_transfer/boards/max32662evkit.overlay
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2025 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+tst_dma0: &dma0 { };

--- a/tests/drivers/dma/chan_blen_transfer/boards/max32666evkit_max32666_cpu0.conf
+++ b/tests/drivers/dma/chan_blen_transfer/boards/max32666evkit_max32666_cpu0.conf
@@ -1,0 +1,4 @@
+# Copyright (c) 2025 Analog Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_CODE_DATA_RELOCATION=y

--- a/tests/drivers/dma/chan_blen_transfer/boards/max32666evkit_max32666_cpu0.overlay
+++ b/tests/drivers/dma/chan_blen_transfer/boards/max32666evkit_max32666_cpu0.overlay
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2025 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+tst_dma0: &dma0 { };

--- a/tests/drivers/dma/chan_blen_transfer/boards/max32666fthr_max32666_cpu0.conf
+++ b/tests/drivers/dma/chan_blen_transfer/boards/max32666fthr_max32666_cpu0.conf
@@ -1,0 +1,4 @@
+# Copyright (c) 2025 Analog Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_CODE_DATA_RELOCATION=y

--- a/tests/drivers/dma/chan_blen_transfer/boards/max32666fthr_max32666_cpu0.overlay
+++ b/tests/drivers/dma/chan_blen_transfer/boards/max32666fthr_max32666_cpu0.overlay
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2025 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+tst_dma0: &dma0 { };

--- a/tests/drivers/dma/loop_transfer/boards/max32662evkit.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/max32662evkit.overlay
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2025 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&sram0 {
+	compatible = "mmio-sram";
+	reg = <0x20000000 DT_SIZE_K(64)>;
+};
+
+/ {
+	chosen {
+		zephyr,sram = &sram0;
+	};
+};
+
+tst_dma0: &dma0 { };

--- a/tests/drivers/dma/loop_transfer/boards/max32666evkit_max32666_cpu0.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/max32666evkit_max32666_cpu0.overlay
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2025 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+tst_dma0: &dma0 { };

--- a/tests/drivers/dma/loop_transfer/boards/max32666fthr_max32666_cpu0.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/max32666fthr_max32666_cpu0.overlay
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2025 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+tst_dma0: &dma0 { };


### PR DESCRIPTION
This PR enables dma/chan_blen_transfer and dma/loop_transfer tests for:
 - MAX32662EVKIT
 - MAX32666EVKIT
 - MAX32666FTHR

Signed-off-by: Furkan Akkiz <hasanfurkan.akkiz@analog.com>
Signed-off-by: Mert Ekren <mert.ekren@analog.com>
Signed-off-by: Yasin Ustuner <Yasin.Ustuner@analog.com>