### PR TITLE
tests: drivers: adc: Enable DAC reference source for Renesas boards

### DIFF
--- a/tests/drivers/adc/adc_accuracy_test/Kconfig
+++ b/tests/drivers/adc/adc_accuracy_test/Kconfig
@@ -11,6 +11,7 @@ ZEPHYR_USER := zephyr,user
 
 config DAC_SOURCE_TEST
 	bool
+	select DAC
 	default y if $(dt_node_has_prop,/$(ZEPHYR_USER),dac)
 
 config REFERENCE_VOLTAGE_TEST

--- a/tests/drivers/adc/adc_accuracy_test/Kconfig
+++ b/tests/drivers/adc/adc_accuracy_test/Kconfig
@@ -1,4 +1,5 @@
 # Copyright (c) 2023 Intel Corporation
+# Copyright (c) 2025 Renesas Electronics Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -21,3 +22,12 @@ config REFERENCE_VOLTAGE_TEST
 config NUMBER_OF_PASSES
 	int "Number of passes"
 	default 5
+
+if DAC_SOURCE_TEST
+
+config DAC_BUFFER_NOT_SUPPORTED
+	bool "DAC on board/SoC does not support output buffer mode"
+	help
+	  If this config is selected, the test will run with no output buffer enabled
+
+endif # DAC_SOURCE_TEST

--- a/tests/drivers/adc/adc_accuracy_test/boards/ek_ra4e2.overlay
+++ b/tests/drivers/adc/adc_accuracy_test/boards/ek_ra4e2.overlay
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Renesas Electronics Corporation
+ * Copyright (c) 2024-2025 Renesas Electronics Corporation
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -7,8 +7,9 @@
 / {
 	zephyr,user {
 		io-channels = <&adc0 0>;
-		reference-mv = <3300>;
-		expected-accuracy = <32>;
+		dac = <&dac0>;
+		dac-channel-id = <0>;
+		dac-resolution = <12>;
 	};
 };
 
@@ -23,6 +24,5 @@
 		zephyr,reference = "ADC_REF_INTERNAL";
 		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
 		zephyr,resolution = <12>;
-		zephyr,vref-mv = <3300>;
 	};
 };

--- a/tests/drivers/adc/adc_accuracy_test/boards/ek_ra4l1.conf
+++ b/tests/drivers/adc/adc_accuracy_test/boards/ek_ra4l1.conf
@@ -1,0 +1,4 @@
+# Copyright (c) 2025 Renesas Electronics Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_DAC_BUFFER_NOT_SUPPORTED=y

--- a/tests/drivers/adc/adc_accuracy_test/boards/ek_ra4l1.overlay
+++ b/tests/drivers/adc/adc_accuracy_test/boards/ek_ra4l1.overlay
@@ -7,8 +7,9 @@
 / {
 	zephyr,user {
 		io-channels = <&adc0 1>;
-		reference-mv = <3300>;
-		expected-accuracy = <32>;
+		dac = <&dac0>;
+		dac-channel-id = <0>;
+		dac-resolution = <12>;
 	};
 };
 
@@ -23,6 +24,5 @@
 		zephyr,reference = "ADC_REF_INTERNAL";
 		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
 		zephyr,resolution = <12>;
-		zephyr,vref-mv = <3300>;
 	};
 };

--- a/tests/drivers/adc/adc_accuracy_test/boards/ek_ra4m1.conf
+++ b/tests/drivers/adc/adc_accuracy_test/boards/ek_ra4m1.conf
@@ -1,0 +1,4 @@
+# Copyright (c) 2025 Renesas Electronics Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_DAC_BUFFER_NOT_SUPPORTED=y

--- a/tests/drivers/adc/adc_accuracy_test/boards/ek_ra4m1.overlay
+++ b/tests/drivers/adc/adc_accuracy_test/boards/ek_ra4m1.overlay
@@ -7,8 +7,9 @@
 / {
 	zephyr,user {
 		io-channels = <&adc0 0>;
-		reference-mv = <3300>;
-		expected-accuracy = <32>;
+		dac = <&dac0>;
+		dac-channel-id = <0>;
+		dac-resolution = <12>;
 	};
 };
 
@@ -23,6 +24,5 @@
 		zephyr,reference = "ADC_REF_INTERNAL";
 		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
 		zephyr,resolution = <12>;
-		zephyr,vref-mv = <3300>;
 	};
 };

--- a/tests/drivers/adc/adc_accuracy_test/boards/ek_ra4m2.overlay
+++ b/tests/drivers/adc/adc_accuracy_test/boards/ek_ra4m2.overlay
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Renesas Electronics Corporation
+ * Copyright (c) 2024-2025 Renesas Electronics Corporation
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -7,8 +7,9 @@
 / {
 	zephyr,user {
 		io-channels = <&adc0 0>;
-		reference-mv = <3300>;
-		expected-accuracy = <32>;
+		dac = <&dac0>;
+		dac-channel-id = <0>;
+		dac-resolution = <12>;
 	};
 };
 
@@ -23,6 +24,5 @@
 		zephyr,reference = "ADC_REF_INTERNAL";
 		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
 		zephyr,resolution = <12>;
-		zephyr,vref-mv = <3300>;
 	};
 };

--- a/tests/drivers/adc/adc_accuracy_test/boards/ek_ra4m3.overlay
+++ b/tests/drivers/adc/adc_accuracy_test/boards/ek_ra4m3.overlay
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Renesas Electronics Corporation
+ * Copyright (c) 2024-2025 Renesas Electronics Corporation
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -7,8 +7,9 @@
 / {
 	zephyr,user {
 		io-channels = <&adc0 0>;
-		reference-mv = <3300>;
-		expected-accuracy = <32>;
+		dac = <&dac0>;
+		dac-channel-id = <0>;
+		dac-resolution = <12>;
 	};
 };
 
@@ -23,6 +24,5 @@
 		zephyr,reference = "ADC_REF_INTERNAL";
 		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
 		zephyr,resolution = <12>;
-		zephyr,vref-mv = <3300>;
 	};
 };

--- a/tests/drivers/adc/adc_accuracy_test/boards/ek_ra4w1.conf
+++ b/tests/drivers/adc/adc_accuracy_test/boards/ek_ra4w1.conf
@@ -1,0 +1,4 @@
+# Copyright (c) 2025 Renesas Electronics Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_DAC_BUFFER_NOT_SUPPORTED=y

--- a/tests/drivers/adc/adc_accuracy_test/boards/ek_ra4w1.overlay
+++ b/tests/drivers/adc/adc_accuracy_test/boards/ek_ra4w1.overlay
@@ -7,8 +7,9 @@
 / {
 	zephyr,user {
 		io-channels = <&adc0 4>;
-		reference-mv = <3300>;
-		expected-accuracy = <32>;
+		dac = <&dac0>;
+		dac-channel-id = <0>;
+		dac-resolution = <12>;
 	};
 };
 
@@ -23,6 +24,5 @@
 		zephyr,reference = "ADC_REF_INTERNAL";
 		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
 		zephyr,resolution = <12>;
-		zephyr,vref-mv = <3300>;
 	};
 };

--- a/tests/drivers/adc/adc_accuracy_test/boards/ek_ra6e2.overlay
+++ b/tests/drivers/adc/adc_accuracy_test/boards/ek_ra6e2.overlay
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Renesas Electronics Corporation
+ * Copyright (c) 2024-2025 Renesas Electronics Corporation
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -7,8 +7,9 @@
 / {
 	zephyr,user {
 		io-channels = <&adc0 0>;
-		reference-mv = <3300>;
-		expected-accuracy = <32>;
+		dac = <&dac0>;
+		dac-channel-id = <0>;
+		dac-resolution = <12>;
 	};
 };
 
@@ -23,6 +24,5 @@
 		zephyr,reference = "ADC_REF_INTERNAL";
 		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
 		zephyr,resolution = <12>;
-		zephyr,vref-mv = <3300>;
 	};
 };

--- a/tests/drivers/adc/adc_accuracy_test/boards/ek_ra6m1.overlay
+++ b/tests/drivers/adc/adc_accuracy_test/boards/ek_ra6m1.overlay
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Renesas Electronics Corporation
+ * Copyright (c) 2024-2025 Renesas Electronics Corporation
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -7,8 +7,9 @@
 / {
 	zephyr,user {
 		io-channels = <&adc0 0>;
-		reference-mv = <3300>;
-		expected-accuracy = <32>;
+		dac = <&dac0>;
+		dac-channel-id = <0>;
+		dac-resolution = <12>;
 	};
 };
 
@@ -23,6 +24,5 @@
 		zephyr,reference = "ADC_REF_INTERNAL";
 		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
 		zephyr,resolution = <12>;
-		zephyr,vref-mv = <3300>;
 	};
 };

--- a/tests/drivers/adc/adc_accuracy_test/boards/ek_ra6m2.overlay
+++ b/tests/drivers/adc/adc_accuracy_test/boards/ek_ra6m2.overlay
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Renesas Electronics Corporation
+ * Copyright (c) 2024-2025 Renesas Electronics Corporation
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -7,8 +7,9 @@
 / {
 	zephyr,user {
 		io-channels = <&adc0 0>;
-		reference-mv = <3300>;
-		expected-accuracy = <32>;
+		dac = <&dac0>;
+		dac-channel-id = <0>;
+		dac-resolution = <12>;
 	};
 };
 
@@ -23,6 +24,5 @@
 		zephyr,reference = "ADC_REF_INTERNAL";
 		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
 		zephyr,resolution = <12>;
-		zephyr,vref-mv = <3300>;
 	};
 };

--- a/tests/drivers/adc/adc_accuracy_test/boards/ek_ra6m3.overlay
+++ b/tests/drivers/adc/adc_accuracy_test/boards/ek_ra6m3.overlay
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Renesas Electronics Corporation
+ * Copyright (c) 2024-2025 Renesas Electronics Corporation
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -7,8 +7,9 @@
 / {
 	zephyr,user {
 		io-channels = <&adc0 0>;
-		reference-mv = <3300>;
-		expected-accuracy = <32>;
+		dac = <&dac0>;
+		dac-channel-id = <0>;
+		dac-resolution = <12>;
 	};
 };
 
@@ -23,6 +24,5 @@
 		zephyr,reference = "ADC_REF_INTERNAL";
 		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
 		zephyr,resolution = <12>;
-		zephyr,vref-mv = <3300>;
 	};
 };

--- a/tests/drivers/adc/adc_accuracy_test/boards/ek_ra6m4.overlay
+++ b/tests/drivers/adc/adc_accuracy_test/boards/ek_ra6m4.overlay
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Renesas Electronics Corporation
+ * Copyright (c) 2024-2025 Renesas Electronics Corporation
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -7,8 +7,9 @@
 / {
 	zephyr,user {
 		io-channels = <&adc0 0>;
-		reference-mv = <3300>;
-		expected-accuracy = <32>;
+		dac = <&dac0>;
+		dac-channel-id = <0>;
+		dac-resolution = <12>;
 	};
 };
 
@@ -23,6 +24,5 @@
 		zephyr,reference = "ADC_REF_INTERNAL";
 		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
 		zephyr,resolution = <12>;
-		zephyr,vref-mv = <3300>;
 	};
 };

--- a/tests/drivers/adc/adc_accuracy_test/boards/ek_ra6m5.overlay
+++ b/tests/drivers/adc/adc_accuracy_test/boards/ek_ra6m5.overlay
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Renesas Electronics Corporation
+ * Copyright (c) 2024-2025 Renesas Electronics Corporation
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -7,8 +7,9 @@
 / {
 	zephyr,user {
 		io-channels = <&adc0 0>;
-		reference-mv = <3300>;
-		expected-accuracy = <32>;
+		dac = <&dac0>;
+		dac-channel-id = <0>;
+		dac-resolution = <12>;
 	};
 };
 
@@ -23,6 +24,5 @@
 		zephyr,reference = "ADC_REF_INTERNAL";
 		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
 		zephyr,resolution = <12>;
-		zephyr,vref-mv = <3300>;
 	};
 };

--- a/tests/drivers/adc/adc_accuracy_test/boards/ek_ra8d1.overlay
+++ b/tests/drivers/adc/adc_accuracy_test/boards/ek_ra8d1.overlay
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Renesas Electronics Corporation
+ * Copyright (c) 2024-2025 Renesas Electronics Corporation
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -7,8 +7,9 @@
 / {
 	zephyr,user {
 		io-channels = <&adc0 0>;
-		reference-mv = <3300>;
-		expected-accuracy = <32>;
+		dac = <&dac0>;
+		dac-channel-id = <0>;
+		dac-resolution = <12>;
 	};
 };
 
@@ -23,6 +24,5 @@
 		zephyr,reference = "ADC_REF_INTERNAL";
 		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
 		zephyr,resolution = <12>;
-		zephyr,vref-mv = <3300>;
 	};
 };

--- a/tests/drivers/adc/adc_accuracy_test/boards/ek_ra8m1.overlay
+++ b/tests/drivers/adc/adc_accuracy_test/boards/ek_ra8m1.overlay
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Renesas Electronics Corporation
+ * Copyright (c) 2024-2025 Renesas Electronics Corporation
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -7,8 +7,9 @@
 / {
 	zephyr,user {
 		io-channels = <&adc0 0>;
-		reference-mv = <3300>;
-		expected-accuracy = <32>;
+		dac = <&dac0>;
+		dac-channel-id = <0>;
+		dac-resolution = <12>;
 	};
 };
 
@@ -23,6 +24,5 @@
 		zephyr,reference = "ADC_REF_INTERNAL";
 		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
 		zephyr,resolution = <12>;
-		zephyr,vref-mv = <3300>;
 	};
 };

--- a/tests/drivers/adc/adc_accuracy_test/boards/fpb_ra4e1.overlay
+++ b/tests/drivers/adc/adc_accuracy_test/boards/fpb_ra4e1.overlay
@@ -7,8 +7,9 @@
 / {
 	zephyr,user {
 		io-channels = <&adc0 0>;
-		reference_mv = <3300>;
-		expected_accuracy = <32>;
+		dac = <&dac0>;
+		dac-channel-id = <0>;
+		dac-resolution = <12>;
 	};
 };
 
@@ -23,6 +24,5 @@
 		zephyr,reference = "ADC_REF_INTERNAL";
 		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
 		zephyr,resolution = <12>;
-		zephyr,vref-mv = <3300>;
 	};
 };

--- a/tests/drivers/adc/adc_accuracy_test/boards/fpb_ra6e1.overlay
+++ b/tests/drivers/adc/adc_accuracy_test/boards/fpb_ra6e1.overlay
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Renesas Electronics Corporation
+ * Copyright (c) 2024-2025 Renesas Electronics Corporation
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -7,8 +7,9 @@
 / {
 	zephyr,user {
 		io-channels = <&adc0 0>;
-		reference-mv = <3300>;
-		expected-accuracy = <32>;
+		dac = <&dac0>;
+		dac-channel-id = <0>;
+		dac-resolution = <12>;
 	};
 };
 
@@ -23,6 +24,5 @@
 		zephyr,reference = "ADC_REF_INTERNAL";
 		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
 		zephyr,resolution = <12>;
-		zephyr,vref-mv = <3300>;
 	};
 };

--- a/tests/drivers/adc/adc_accuracy_test/boards/fpb_ra6e2.overlay
+++ b/tests/drivers/adc/adc_accuracy_test/boards/fpb_ra6e2.overlay
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Renesas Electronics Corporation
+ * Copyright (c) 2024-2025 Renesas Electronics Corporation
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -7,8 +7,9 @@
 / {
 	zephyr,user {
 		io-channels = <&adc0 0>;
-		reference-mv = <3300>;
-		expected-accuracy = <32>;
+		dac = <&dac0>;
+		dac-channel-id = <0>;
+		dac-resolution = <12>;
 	};
 };
 
@@ -23,6 +24,5 @@
 		zephyr,reference = "ADC_REF_INTERNAL";
 		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
 		zephyr,resolution = <12>;
-		zephyr,vref-mv = <3300>;
 	};
 };

--- a/tests/drivers/adc/adc_accuracy_test/boards/frdm_k64f.conf
+++ b/tests/drivers/adc/adc_accuracy_test/boards/frdm_k64f.conf
@@ -1,1 +1,0 @@
-CONFIG_DAC=y

--- a/tests/drivers/adc/adc_accuracy_test/boards/mck_ra8t1.overlay
+++ b/tests/drivers/adc/adc_accuracy_test/boards/mck_ra8t1.overlay
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Renesas Electronics Corporation
+ * Copyright (c) 2024-2025 Renesas Electronics Corporation
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -7,8 +7,9 @@
 / {
 	zephyr,user {
 		io-channels = <&adc0 0>;
-		reference-mv = <3300>;
-		expected-accuracy = <32>;
+		dac = <&dac0>;
+		dac-channel-id = <0>;
+		dac-resolution = <12>;
 	};
 };
 
@@ -23,6 +24,5 @@
 		zephyr,reference = "ADC_REF_INTERNAL";
 		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
 		zephyr,resolution = <12>;
-		zephyr,vref-mv = <3300>;
 	};
 };

--- a/tests/drivers/adc/adc_accuracy_test/src/dac_source.c
+++ b/tests/drivers/adc/adc_accuracy_test/src/dac_source.c
@@ -18,7 +18,7 @@ extern const struct adc_dt_spec *get_adc_channel(void);
 static const struct dac_channel_cfg dac_ch_cfg = {
 	.channel_id = DT_PROP(DT_PATH(zephyr_user), dac_channel_id),
 	.resolution = DT_PROP(DT_PATH(zephyr_user), dac_resolution),
-	.buffered = true
+	.buffered = !IS_ENABLED(CONFIG_DAC_BUFFER_NOT_SUPPORTED),
 };
 
 static const struct device *init_dac(void)


### PR DESCRIPTION
- Add select config DAC when using `DAC_SOURCE_TEST` for `adc_accuracy_test`
- Add config `DAC_BUFFER_NOT_SUPPORT` for `adc_accuracy_test` if `DAC_SOURCE_TEST` is selected
- Using `DAC_SOURCE_TEST` instead of VREF for all available Renesas boards in `adc_accuracy_test` test app