### PR TITLE
west_commands: runners: Fix parameters passed to xsdb

### DIFF
--- a/scripts/west_commands/runners/xsdb.py
+++ b/scripts/west_commands/runners/xsdb.py
@@ -54,5 +54,5 @@ class XSDBBinaryRunner(ZephyrBinaryRunner):
         elif self.fsbl:
             cmd = ['xsdb', self.xsdb_cfg_file, self.elf_file, self.fsbl]
         else:
-            cmd = ['xsdb', self.xsdb_cfg_file]
+            cmd = ['xsdb', self.xsdb_cfg_file, self.elf_file]
         self.check_call(cmd)

--- a/scripts/west_commands/tests/test_xsdb.py
+++ b/scripts/west_commands/tests/test_xsdb.py
@@ -13,13 +13,13 @@ TEST_CASES = [
         "config": None,
         "bitstream": None,
         "fsbl": None,
-        "expected_cmd": ["xsdb", "default_cfg_path"],
+        "expected_cmd": ["xsdb", "default_cfg_path", RC_KERNEL_ELF],
     },
     {
         "config": "custom_cfg_path",
         "bitstream": None,
         "fsbl": None,
-        "expected_cmd": ["xsdb", "custom_cfg_path"],
+        "expected_cmd": ["xsdb", "custom_cfg_path", RC_KERNEL_ELF],
     },
     {
         "config": None,


### PR DESCRIPTION
Existing logic is passing elf file as parameter only when fsbl or bit file parameter is present. This is incorrect, elf file should be always passed irrespective of other parameters.