### PR TITLE
drivers: Wrap driver instances in device API macro

### DIFF
--- a/drivers/dai/nxp/micfil/micfil.c
+++ b/drivers/dai/nxp/micfil/micfil.c
@@ -159,7 +159,7 @@ static int dai_nxp_micfil_remove(const struct device *dev)
 	return 0;
 }
 
-const struct dai_driver_api dai_nxp_micfil_ops = {
+static DEVICE_API(dai, dai_nxp_micfil_ops) = {
 	.probe			= dai_nxp_micfil_probe,
 	.remove			= dai_nxp_micfil_remove,
 	.config_set		= dai_nxp_micfil_set_config,

--- a/drivers/flash/flash_andes_qspi.c
+++ b/drivers/flash/flash_andes_qspi.c
@@ -902,7 +902,7 @@ flash_andes_qspi_get_parameters(const struct device *dev)
 	return &config->parameters;
 }
 
-static const struct flash_driver_api flash_andes_qspi_api = {
+static DEVICE_API(flash, flash_andes_qspi_api) = {
 	.read = flash_andes_qspi_read,
 	.write = flash_andes_qspi_write,
 	.erase = flash_andes_qspi_erase,

--- a/drivers/flash/soc_flash_cc23x0.c
+++ b/drivers/flash/soc_flash_cc23x0.c
@@ -223,7 +223,7 @@ static void flash_cc23x0_layout(const struct device *dev, const struct flash_pag
 }
 #endif /* CONFIG_FLASH_PAGE_LAYOUT */
 
-static const struct flash_driver_api flash_cc23x0_api = {
+static DEVICE_API(flash, flash_cc23x0_api) = {
 	.erase = flash_cc23x0_erase,
 	.write = flash_cc23x0_write,
 	.read = flash_cc23x0_read,

--- a/drivers/gpio/gpio_cc23x0.c
+++ b/drivers/gpio/gpio_cc23x0.c
@@ -256,7 +256,7 @@ static int gpio_cc23x0_init(const struct device *dev)
 	return 0;
 }
 
-static const struct gpio_driver_api gpio_cc23x0_driver_api = {
+static DEVICE_API(gpio, gpio_cc23x0_driver_api) = {
 	.pin_configure = gpio_cc23x0_config,
 #ifdef CONFIG_GPIO_GET_CONFIG
 	.pin_get_config = gpio_cc23x0_get_config,

--- a/drivers/gpio/gpio_mfxstm32l152.c
+++ b/drivers/gpio/gpio_mfxstm32l152.c
@@ -612,7 +612,7 @@ static int mfxstm32l152_init(const struct device *dev)
 	return ret;
 }
 
-static const struct gpio_driver_api mfxstm32l152_drv_api = {
+static DEVICE_API(gpio, mfxstm32l152_drv_api) = {
 	.pin_configure = mfxstm32l152_configure,
 	.port_get_raw = mfxstm32l152_port_get_raw,
 	.port_set_masked_raw = NULL,

--- a/drivers/mbox/mbox_ti_omap.c
+++ b/drivers/mbox/mbox_ti_omap.c
@@ -199,7 +199,7 @@ static int omap_mailbox_set_enabled(const struct device *dev, uint32_t channel, 
 	return 0;
 }
 
-static const struct mbox_driver_api omap_mailbox_driver_api = {
+static DEVICE_API(mbox, omap_mailbox_driver_api) = {
 	.send = omap_mailbox_send,
 	.register_callback = omap_mailbox_register_callback,
 	.mtu_get = omap_mailbox_mtu_get,

--- a/drivers/rtc/rtc_sam0.c
+++ b/drivers/rtc/rtc_sam0.c
@@ -552,7 +552,7 @@ static int rtc_sam0_init(const struct device *dev)
 	return 0;
 }
 
-static const struct rtc_driver_api rtc_sam0_driver_api = {
+static DEVICE_API(rtc, rtc_sam0_driver_api) = {
 	.set_time = rtc_sam0_set_time,
 	.get_time = rtc_sam0_get_time,
 #ifdef CONFIG_RTC_ALARM

--- a/drivers/serial/uart_cc23x0.c
+++ b/drivers/serial/uart_cc23x0.c
@@ -307,7 +307,7 @@ static void uart_cc23x0_isr(const struct device *dev)
 
 #endif /* CONFIG_UART_INTERRUPT_DRIVEN */
 
-static const struct uart_driver_api uart_cc23x0_driver_api = {
+static DEVICE_API(uart, uart_cc23x0_driver_api) = {
 	.poll_in = uart_cc23x0_poll_in,
 	.poll_out = uart_cc23x0_poll_out,
 	.err_check = uart_cc23x0_err_check,


### PR DESCRIPTION
Use the device API macro to place the driver API instance into an iterable section.