### PR TITLE
Add rt700 ostimer support

### DIFF
--- a/boards/nxp/mimxrt700_evk/board.c
+++ b/boards/nxp/mimxrt700_evk/board.c
@@ -400,6 +400,12 @@ void board_early_init_hook(void)
 	CLOCK_AttachClk(kSENSE_BASE_to_ADC);
 	CLOCK_SetClkDiv(kCLOCK_DivAdcClk, 1U);
 #endif
+
+#if (DT_NODE_HAS_STATUS(DT_NODELABEL(os_timer_cpu0), okay) || \
+		DT_NODE_HAS_STATUS(DT_NODELABEL(os_timer_cpu1), okay))
+	CLOCK_AttachClk(kLPOSC_to_OSTIMER);
+	CLOCK_SetClkDiv(kCLOCK_DivOstimerClk, 1U);
+#endif
 }
 
 static void GlikeyWriteEnable(GLIKEY_Type *base, uint8_t idx)

--- a/boards/nxp/mimxrt700_evk/doc/index.rst
+++ b/boards/nxp/mimxrt700_evk/doc/index.rst
@@ -81,6 +81,8 @@ the hardware features below.
 +-----------+------------+-------------------------------------+
 | ADC       | on-chip    | adc                                 |
 +-----------+------------+-------------------------------------+
+| OS_TIMER  | on-chip    | os timer                            |
++-----------+------------+-------------------------------------+
 
 The default configuration can be found in the defconfig file:
 

--- a/boards/nxp/mimxrt700_evk/mimxrt700_evk_mimxrt798s_cm33_cpu0.dts
+++ b/boards/nxp/mimxrt700_evk/mimxrt700_evk_mimxrt798s_cm33_cpu0.dts
@@ -65,8 +65,14 @@
 	status = "okay";
 };
 
-&systick {
+/*
+ * RT700-EVK board cm33_cpu0 uses OS timer as the kernel timer
+ * In case we need to switch to SYSTICK timer, then
+ * replace &os_timer with &systick
+ */
+&os_timer_cpu0 {
 	status = "okay";
+	wakeup-source;
 };
 
 &flexcomm0{

--- a/boards/nxp/mimxrt700_evk/mimxrt700_evk_mimxrt798s_cm33_cpu1.dts
+++ b/boards/nxp/mimxrt700_evk/mimxrt700_evk_mimxrt798s_cm33_cpu1.dts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 NXP
+ * Copyright 2024-2025 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -56,8 +56,14 @@
 	pinctrl-names = "default";
 };
 
-&systick {
+/*
+ * RT700-EVK board cm33_cpu1 uses OS timer as the kernel timer
+ * In case we need to switch to SYSTICK timer, then
+ * replace &os_timer with &systick
+ */
+&os_timer_cpu1 {
 	status = "okay";
+	wakeup-source;
 };
 
 &flexcomm19{

--- a/dts/arm/nxp/nxp_rt7xx_cm33_cpu0.dtsi
+++ b/dts/arm/nxp/nxp_rt7xx_cm33_cpu0.dtsi
@@ -1011,6 +1011,21 @@
 		interrupts = <55 0>;
 		clocks = <&clkctl4 MCUX_FLEXIO0_CLK>;
 	};
+
+	os_timer_cpu0: timers@207000 {
+		compatible = "nxp,os-timer";
+		reg = <0x207000 0x1000>;
+		interrupts = <34 0>;
+		status = "disabled";
+	};
+};
+
+&systick {
+	/*
+	 * RT700 cm33_cpu0 relies by default on the OS Timer for system
+	 * clock implementation, so the SysTick node is not to be enabled.
+	 */
+	status = "disabled";
 };
 
 &xspi0 {

--- a/dts/arm/nxp/nxp_rt7xx_cm33_cpu1.dtsi
+++ b/dts/arm/nxp/nxp_rt7xx_cm33_cpu1.dtsi
@@ -418,8 +418,23 @@
 		clocks = <&clkctl4 MCUX_LPI2C15_CLK>;
 		status = "disabled";
 	};
+
+	os_timer_cpu1: timers@209000 {
+		compatible = "nxp,os-timer";
+		reg = <0x209000 0x1000>;
+		interrupts = <30 0>;
+		status = "disabled";
+	};
 };
 
 &nvic {
 	arm,num-irq-priority-bits = <3>;
+};
+
+&systick {
+	/*
+	 * RT700 cm33_cpu1 relies by default on the OS Timer for system
+	 * clock implementation, so the SysTick node is not to be enabled.
+	 */
+	status = "disabled";
 };

--- a/soc/nxp/imxrt/imxrt7xx/Kconfig.defconfig
+++ b/soc/nxp/imxrt/imxrt7xx/Kconfig.defconfig
@@ -1,4 +1,4 @@
-# Copyright 2024 NXP
+# Copyright 2024-2025 NXP
 # SPDX-License-Identifier: Apache-2.0
 
 if SOC_MIMXRT798S_CM33_CPU0
@@ -11,6 +11,7 @@ config NUM_IRQS
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default 237500000 if CORTEX_M_SYSTICK
+	default 1000000 if MCUX_OS_TIMER
 
 choice CACHE_TYPE
 	default EXTERNAL_CACHE
@@ -25,6 +26,7 @@ config NUM_IRQS
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default 100000000 if CORTEX_M_SYSTICK
+	default 1000000 if MCUX_OS_TIMER
 
 endif # SOC_MIMXRT798S_CM33_CPU1
 


### PR DESCRIPTION
use ostimer as kernel tick for cm33_cpu0/1 cores.