### PR TITLE
drivers: sdhc: Fix acronym expansion for SD Host Controller in Kconfig

### DIFF
--- a/drivers/sdhc/Kconfig
+++ b/drivers/sdhc/Kconfig
@@ -2,9 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig SDHC
-	bool "Secure Digital High Capacity (SDHC) drivers"
+	bool "Secure Digital (SD card) host controller drivers"
 	help
-	  Include drivers for SD host controller
+	  Include drivers for interacting with SD cards
 
 if SDHC
 


### PR DESCRIPTION
Split off from #85140