### PR TITLE
doc: boards: extensions: Add Sphinx directive for board supported hardware

### DIFF
--- a/boards/bbc/microbit/doc/index.rst
+++ b/boards/bbc/microbit/doc/index.rst
@@ -13,13 +13,6 @@ magnetometer sensors, Bluetooth and USB connectivity, a display consisting of
 external battery pack. The device inputs and outputs are through five ring
 connectors that are part of the 23-pin edge connector.
 
-* :abbr:`NVIC (Nested Vectored Interrupt Controller)`
-* :abbr:`RTC (nRF RTC System Clock)`
-* UART
-* GPIO
-* FLASH
-* RADIO (Bluetooth Low Energy)
-
 More information about the board can be found at the `microbit website`_.
 
 Hardware
@@ -39,25 +32,7 @@ The micro:bit has the following physical features:
 Supported Features
 ==================
 
-The bbc_microbit board configuration supports the following nRF51
-hardware features:
-
-+-----------+------------+----------------------+
-| Interface | Controller | Driver/Component     |
-+===========+============+======================+
-| NVIC      | on-chip    | nested vectored      |
-|           |            | interrupt controller |
-+-----------+------------+----------------------+
-| RTC       | on-chip    | system clock         |
-+-----------+------------+----------------------+
-| UART      | on-chip    | serial port          |
-+-----------+------------+----------------------+
-| GPIO      | on-chip    | gpio                 |
-+-----------+------------+----------------------+
-| FLASH     | on-chip    | flash                |
-+-----------+------------+----------------------+
-| RADIO     | on-chip    | Bluetooth            |
-+-----------+------------+----------------------+
+.. zephyr:board-supported-hw::
 
 Programming and Debugging
 *************************

--- a/boards/bbc/microbit_v2/doc/index.rst
+++ b/boards/bbc/microbit_v2/doc/index.rst
@@ -33,25 +33,7 @@ The micro:bit-v2 has the following physical features:
 Supported Features
 ==================
 
-The bbc_microbit_v2 board configuration supports the following
-hardware features:
-
-+-----------+------------+----------------------+
-| Interface | Controller | Driver/Component     |
-+===========+============+======================+
-| NVIC      | on-chip    | nested vectored      |
-|           |            | interrupt controller |
-+-----------+------------+----------------------+
-| RTC       | on-chip    | system clock         |
-+-----------+------------+----------------------+
-| UART      | on-chip    | serial port          |
-+-----------+------------+----------------------+
-| GPIO      | on-chip    | gpio                 |
-+-----------+------------+----------------------+
-| FLASH     | on-chip    | flash                |
-+-----------+------------+----------------------+
-| RADIO     | on-chip    | Bluetooth            |
-+-----------+------------+----------------------+
+.. zephyr:board-supported-hw::
 
 Programming and Debugging
 *************************

--- a/doc/_extensions/zephyr/domain/templates/board-card.html
+++ b/doc/_extensions/zephyr/domain/templates/board-card.html
@@ -15,7 +15,17 @@
   data-arch="{{ board.archs | join(" ") }}"
   data-vendor="{{ board.vendor }}"
   data-socs="{{ board.socs | join(" ") }}"
-  data-supported-features="{{ board.supported_features | join(" ") }}" tabindex="0">
+  data-supported-features="
+    {%- set feature_types = [] -%}
+    {%- for target_features in board.supported_features.values() -%}
+      {%- for feature_type in target_features.keys() -%}
+        {%- if feature_type not in feature_types -%}
+          {%- set _ = feature_types.append(feature_type) -%}
+        {%- endif -%}
+      {%- endfor -%}
+    {%- endfor -%}
+    {{- feature_types|join(' ') -}}
+  " tabindex="0">
   <div class="vendor">{{ vendors[board.vendor] }}</div>
   {% if board.image -%}
   <img alt="A picture of the {{ board.full_name }} board"

--- a/doc/_static/css/custom.css
+++ b/doc/_static/css/custom.css
@@ -1190,3 +1190,12 @@ li>a.code-sample-link.reference.internal.current {
     text-overflow: ellipsis;
     max-width:80%;
 }
+
+#supported-features>div>table>tbody>tr>td>p {
+    white-space: normal;
+}
+
+#supported-features td {
+    background-color: var(--table-row-odd-background-color);
+    border-left-width: 1px;
+}

--- a/doc/contribute/documentation/guidelines.rst
+++ b/doc/contribute/documentation/guidelines.rst
@@ -1231,6 +1231,20 @@ Boards
    This directive is used to generate a catalog of Zephyr-supported boards that can be used to
    quickly browse the list of all supported boards and filter them according to various criteria.
 
+.. rst:directive:: .. zephyr:board-supported-hw::
+
+   This directive is used to show supported hardware features for all the targets of the board
+   documented in the current page. The tables are automatically generated based on the board's
+   Devicetree.
+
+   The directive must be used in a document that also contains a :rst:dir:`zephyr:board` directive,
+   as it relies on the board information to generate the table.
+
+   .. note::
+
+      This directive requires that the documentation is built with hardware features generation enabled
+      (``zephyr_generate_hw_features`` config option set to ``True``). If disabled, a warning message
+      will be shown instead of the hardware features tables.
 
 References
 **********

--- a/doc/templates/board.tmpl
+++ b/doc/templates/board.tmpl
@@ -17,7 +17,8 @@ Hardware
 
 Supported Features
 ==================
-[List of supported features and level of support in Zephyr]
+
+.. zephyr:board-supported-hw::
 
 Connections and IOs
 ===================

--- a/dts/bindings/binding-types.txt
+++ b/dts/bindings/binding-types.txt
@@ -1,0 +1,136 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 The Linux Foundation
+# SPDX-License-Identifier: Apache-2.0
+#
+# Devicetree binding types registry.
+#
+# This file contains the mapping of binding types (folders directly under this
+# file) to their descriptions and provides a definition for each acronym used.
+#
+# The contents of this file are parsed during documentation generation.
+#
+# Anything that starts with a '#' is treated as a comment and ignored.
+# Non-empty lines should be in this format:
+#
+# <binding-type><TAB><Description>
+
+# zephyr-keep-sorted-start
+acpi	ACPI (Advanced Configuration and Power Interface)
+adc	ADC (Analog to Digital Converter)
+alh	ALH (Audio Link Hub)
+arc	ARC architecture
+arm	ARM architecture
+audio	Audio
+auxdisplay	Auxiliary Display
+base	Base
+battery	Battery
+bluetooth	Bluetooth
+cache	Cache
+can	CAN (Controller Area Network)
+charger	Charger
+clock	Clock control
+comparator	Comparator
+coredump	Core dump
+counter	Counter
+cpu	CPU (Central Processing Unit)
+crypto	Cryptographic accelerator
+dac	DAC (Digital to Analog Converter)
+dai	DAI (Digital Audio Interface)
+debug	Debug
+dfpmcch	DFPMCCH
+dfpmccu	DFPMCCU
+disk	Disk
+display	Display
+dma	DMA (Direct Memory Access)
+dsa	DSA (Distributed Switch Architecture)
+edac	EDAC (Error Detection and Correction)
+espi	ESPI (Enhanced Serial Peripheral Interface)
+ethernet	Ethernet
+firmware	Firmware
+flash_controller	Flash controller
+fpga	FPGA (Field Programmable Gate Array)
+fs	File system
+fuel-gauge	Fuel gauge
+gnss	GNSS (Global Navigation Satellite System)
+gpio	GPIO (General Purpose Input/Output) & Headers
+haptics	Haptics
+hda	HDA (High Definition Audio)
+hdlc_rcp_if	IEEE 802.15.4 HDLC RCP interface
+hwinfo	Hardware information
+hwspinlock	Hardware spinlock
+i2c	I2C (Inter-Integrated Circuit)
+i2s	I2S (Inter-Integrated Circuit Sound)
+i3c	I3C (Improved Inter-Integrated Circuit)
+ieee802154	IEEE 802.15.4
+iio	IIO (Industrial I/O)
+input	Input
+interrupt-controller	Interrupt controller
+ipc	IPC (Inter-Processor Communication)
+ipm	IPM (Inter-Processor Mailbox)
+kscan	Keyscan
+led	LED (Light Emitting Diode)
+led_strip	LED (Light Emitting Diode) strip
+lora	LoRa
+mbox	Mailbox
+mdio	MDIO (Management Data Input/Output)
+memory-controllers	Memory controller
+memory-window	Memory window
+mfd	Multi-Function Device
+mhu	Mailbox Handling Unit
+mipi-dbi	Mobile Industry Processor Interface Display Bus Interface
+mipi-dsi	Mobile Industry Processor Interface Display Serial Interface
+misc	Miscellaneous
+mm	Memory management
+mmc	MMC (MultiMedia Card)
+mmu_mpu	MMU (Memory Management Unit) / MPU (Memory Protection Unit)
+modem	Modem
+mspi	Multi-bit SPI (Serial Peripheral Interface)
+mtd	MTD (Memory Technology Device)
+net	Networking
+options	Options
+ospi	OCTOSPI (Octal Serial Peripheral Interface)
+pcie	PCIe (Peripheral Component Interconnect Express)
+peci	PECI (Platform Environment Control Interface)
+phy	PHY
+pinctrl	Pin control
+pm_cpu_ops	Power management CPU operations
+power	Power management
+power-domain	Power domain
+ppc	PPC architecture
+ps2	PS/2 (Personal System/2)
+pwm	PWM (Pulse Width Modulation)
+qspi	QSPI (Quad Serial Peripheral Interface)
+regulator	Regulator
+reserved-memory	Reserved memory
+reset	Reset controller
+retained_mem	Retained memory
+retention	Retention
+riscv	RISC-V architecture
+rng	RNG (Random Number Generator)
+rtc	RTC (Real Time Clock)
+sd	SD (Secure Digital)
+sdhc	SDHC (Secure Digital High Capacity)
+sensor	Sensors
+serial	Serial controller
+shi	SHI (Serial Host Interface)
+sip_svc	Service in Platform
+smbus	SMbus (System Management Bus)
+sound	Sound
+spi	SPI (Serial Peripheral Interface)
+sram	SRAM (Static Random Access Memory)
+stepper	Stepper
+syscon	System controller
+tach	Tachometer
+tcpc	USB Type-C Port Controller
+test	Test
+timer	Timer
+timestamp	Timestamp
+usb	USB (Universal Serial Bus)
+usb-c	USB (Universal Serial Bus) Type-C
+video	Video
+virtualization	Virtualization
+w1	1-Wire
+watchdog	Watchdog
+wifi	Wi-Fi
+xen	Xen
+xspi	xSPI (Expanded Serial Peripheral Interface)
+# zephyr-keep-sorted-stop


### PR DESCRIPTION
Introduce a new directive for displaying hardware features supported by a board, using information available in the Devicetree.

It outputs a table for each board target, where the table contains type of hw peripheral / description / link to documentation of the binding.

![image](https://github.com/user-attachments/assets/35883220-d59e-4d1d-9f3a-e3d3aa57d693)

As a way to demonstrate the feature in action, documentation of the BBC micro:bit boards has been updated to adopt the new directive.

Only the last commit is relevant, the rest is tackled in #79754.

Same as other PR: due to this PR updating the doc-build.yml workflow, it's not publishing the CI output to builds.zephyrproject.io ; best way to test the actual user experience is to get the most recent successful build from my fork (https://github.com/kartben/zephyr/actions/workflows/doc-build.yml?query=event%3Aschedule), download the html-output artifact, unzip it, and open index.html in a browser


An obvious improvement opprtunity will be to use tabs for the various board targets ; it is, interestingly enough, not that easy to do elegantly, so hopefully people are fine if this comes at a later stage :) In any case, only boards that "opt-in" to migrate to using the new directive will get the new table(s) anyway, so it's not like it's going to directly impact users :)
