### PR TITLE
net: dns: Log with debug level instead of error level when recv fails

### DIFF
--- a/subsys/net/lib/dns/dispatcher.c
+++ b/subsys/net/lib/dns/dispatcher.c
@@ -190,7 +190,7 @@ void dns_dispatcher_svc_handler(struct net_socket_service_event *pev)
 
 	ret = recv_data(pev);
 	if (ret < 0 && ret != DNS_EAI_ALLDONE && ret != -ENOENT) {
-		NET_ERR("DNS recv error (%d)", ret);
+		NET_DBG("DNS recv error (%d)", ret);
 	}
 }
 


### PR DESCRIPTION
This condition can happen if there is MDNS activity on the network that is either not according to specifications or not supported by Zephyr.

Lowering the log level from ERR to DBG, since this does not indicate an error in the Zephyr application.

Fixes #85551