### PR TITLE
shell: rtt: increase bypass buffer size

### DIFF
--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -975,7 +975,11 @@ static void state_collect(const struct shell *sh)
 		shell_bypass_cb_t bypass = sh->ctx->bypass;
 
 		if (bypass) {
+#if defined(CONFIG_SHELL_BACKEND_RTT) && defined(CONFIG_SEGGER_RTT_BUFFER_SIZE_DOWN)
+			uint8_t buf[CONFIG_SEGGER_RTT_BUFFER_SIZE_DOWN];
+#else
 			uint8_t buf[16];
+#endif
 
 			(void)sh->iface->api->read(sh->iface, buf,
 							sizeof(buf), &count);


### PR DESCRIPTION
If the RTT shell backend is selected and the "down" buffer size has been modified, the shell bypass functionality should instead use the buffer size specified by the configuration.