### PR TITLE
drivers: counter: counter_max32:_rtc: Update api_start

### DIFF
--- a/drivers/counter/counter_max32_rtc.c
+++ b/drivers/counter/counter_max32_rtc.c
@@ -38,11 +38,6 @@ struct max32_rtc_config {
 
 static int api_start(const struct device *dev)
 {
-	/* Ensure that both sec and subsec are reset to 0 */
-	while (MXC_RTC_Init(0, 0) == E_BUSY) {
-		;
-	}
-
 	while (MXC_RTC_Start() == E_BUSY) {
 		;
 	}


### PR DESCRIPTION
This commit removes redundant initialization. The following PR addresses the issue caused by the offset
https://github.com/zephyrproject-rtos/zephyr/commit/5a2055