### PR TITLE
include: zephyr: sys: device_mmio: Fix DEVICE_MMIO_GET

### DIFF
--- a/include/zephyr/sys/device_mmio.h
+++ b/include/zephyr/sys/device_mmio.h
@@ -314,7 +314,7 @@ struct z_device_mmio_rom {
 #ifdef DEVICE_MMIO_IS_IN_RAM
 #define DEVICE_MMIO_GET(dev)	(*DEVICE_MMIO_RAM_PTR(dev))
 #else
-#define DEVICE_MMIO_GET(dev)	(DEVICE_MMIO_ROM_PTR(dev)->addr)
+#define DEVICE_MMIO_GET(dev)	(DEVICE_MMIO_ROM_PTR(dev)->phys_addr)
 #endif
 /** @} */
 


### PR DESCRIPTION
When DEVICE_MMIO_IS_IN_RAM is not set, the DEVICE_MMIO_GET defines uses DEVICE_MMIO_ROM_PTR instead of DEVICE_MMIO_RAM_PTR.

z_device_mmio_rom has no attribute `addr` and this define should use `phys_addr` instead.