### PR TITLE
drivers:  i2c: i2c_omap: Add pinctrl

### DIFF
--- a/drivers/i2c/Kconfig.omap
+++ b/drivers/i2c/Kconfig.omap
@@ -7,6 +7,7 @@ config I2C_OMAP
 	bool "TI OMAP I2C Driver"
 	default y
 	depends on DT_HAS_TI_OMAP_I2C_ENABLED
+	select PINCTRL
 	help
 	  Enable the I2C driver for TI OMAP SoCs.
 


### PR DESCRIPTION
Extend the I2c OMAP driver to automatically mux pins require by this interfaces.