### PR TITLE
drivers: gnss: Add accuracy to gnss_info

### DIFF
--- a/drivers/gnss/gnss_dump.c
+++ b/drivers/gnss/gnss_dump.c
@@ -83,11 +83,11 @@ int gnss_dump_info(char *str, uint16_t strsize, const struct gnss_info *info)
 {
 	int ret;
 	const char *fmt = "gnss_info: {satellites_cnt: %u, hdop: %u.%u, fix_status: %s, "
-			  "fix_quality: %s}";
+			  "fix_quality: %s, fix_accuracy: %u.%u}";
 
 	ret = snprintk(str, strsize, fmt, info->satellites_cnt, info->hdop / 1000,
 		       info->hdop % 1000, gnss_fix_status_to_str(info->fix_status),
-		       gnss_fix_quality_to_str(info->fix_quality));
+		       gnss_fix_quality_to_str(info->fix_quality), info->fix_accuracy / 1000);
 
 	return (strsize < ret) ? -ENOMEM : 0;
 }

--- a/drivers/gnss/gnss_emul.c
+++ b/drivers/gnss/gnss_emul.c
@@ -361,6 +361,7 @@ static void gnss_emul_set_fix(const struct device *dev)
 	data->data.info.hdop = 100;
 	data->data.info.fix_status = GNSS_FIX_STATUS_GNSS_FIX;
 	data->data.info.fix_quality = GNSS_FIX_QUALITY_GNSS_SPS;
+	data->data.info.fix_accuracy = 1000;
 }
 
 static void gnss_emul_set_utc(const struct device *dev)

--- a/include/zephyr/drivers/gnss.h
+++ b/include/zephyr/drivers/gnss.h
@@ -146,6 +146,8 @@ struct gnss_info {
 	enum gnss_fix_status fix_status;
 	/** The fix quality */
 	enum gnss_fix_quality fix_quality;
+	/** Accuracy radius in millimeters */
+	uint32_t fix_accuracy;
 };
 
 /** GNSS time data structure */


### PR DESCRIPTION
There is no option (at least i have not found any) to provide the accuracy radius via the gnss api, which is supported by most gnss modems. Added to the gnss_info struct to make it available via the gnss data callback.