### PR TITLE
boards: NXP MCXN947 remove cpu1 partition

### DIFF
--- a/boards/nxp/frdm_mcxn947/frdm_mcxn947.dtsi
+++ b/boards/nxp/frdm_mcxn947/frdm_mcxn947.dtsi
@@ -162,15 +162,11 @@ nxp_8080_touch_panel_i2c: &flexcomm2_lpi2c2 {
 		 */
 		slot0_partition: partition@14000 {
 			label = "image-0";
-			reg = <0x00014000 DT_SIZE_K(888)>;
+			reg = <0x00014000 DT_SIZE_K(984)>;
 		};
-		slot1_partition: partition@F2000 {
+		slot1_partition: partition@10A000 {
 			label = "image-1";
-			reg = <0x000F2000 DT_SIZE_K(888)>;
-		};
-		cpu1_partition: partition@1D0000 {
-			label = "cpu1-image";
-			reg = <0x001D0000 DT_SIZE_K(192)>;
+			reg = <0x0010A000 DT_SIZE_K(984)>;
 		};
 		/* storage_partition is placed in WINBOND flash memory*/
 	};

--- a/boards/nxp/frdm_mcxn947/frdm_mcxn947_mcxn947_cpu0.dtsi
+++ b/boards/nxp/frdm_mcxn947/frdm_mcxn947_mcxn947_cpu0.dtsi
@@ -27,7 +27,7 @@
 		zephyr,console = &flexcomm4_lpuart4;
 		zephyr,shell-uart = &flexcomm4_lpuart4;
 		zephyr,canbus = &flexcan0;
-		zephyr,code-cpu1-partition = &cpu1_partition;
+		zephyr,code-cpu1-partition = &slot1_partition;
 	};
 
 	aliases{

--- a/boards/nxp/frdm_mcxn947/frdm_mcxn947_mcxn947_cpu1.dts
+++ b/boards/nxp/frdm_mcxn947/frdm_mcxn947_mcxn947_cpu1.dts
@@ -21,7 +21,7 @@
 		zephyr,sram = &sramg;
 		zephyr,flash = &flash;
 		zephyr,flash-controller = &fmu;
-		zephyr,code-partition = &cpu1_partition;
+		zephyr,code-partition = &slot1_partition;
 		zephyr,console = &flexcomm2_lpuart2;
 		zephyr,shell-uart = &flexcomm2_lpuart2;
 	};


### PR DESCRIPTION
This commit reverts using of cpu1_partition because it is taking space from slot0 and slot1 partitions.
For now use slot1 partition for cpu1.