### PR TITLE
arch: arm: cortex_a_r: Add cfi directives to z_arm_cortex_r_svc

### DIFF
--- a/arch/arm/core/cortex_a_r/swap_helper.S
+++ b/arch/arm/core/cortex_a_r/swap_helper.S
@@ -423,5 +423,9 @@ valid_syscall_id:
 
 GTEXT(z_arm_cortex_r_svc)
 SECTION_FUNC(TEXT, z_arm_cortex_r_svc)
+    .cfi_sections .debug_frame
+    .cfi_startproc simple
+    .cfi_def_cfa 13, 0x0
     svc #_SVC_CALL_CONTEXT_SWITCH
     bx lr
+    .cfi_endproc


### PR DESCRIPTION
Add call frame information (cfi) directives to the function z_arm_cortex_r_svc, which triggers an SVC exception whose handler will execute a context switch. The return address stored on the stack of a suspended thread will point into z_arm_cortex_r_svc, that is, this function will be the starting point when a debugger tries to produce a call stack for a suspended thread. As the function is written in assembly, most compilers will not emit any cfi automatically. This patch adds cfi directives manually so that the call stack can be unwound.

The added cfi directives instruct the compiler to note in the .debug_frame section that the canonical frame address is at offset 0 from r13, i.e., from the stack pointer.



Trying to unwind the stack from the return address of a suspended thread (using the IAR C-SPY Debugger) currently begins and ends in z_arm_cortex_r_svc:
 
`  [z_arm_cortex_r_svc + 0x4]`
 
With this fix, we are able to unwind the stack from there:

```
  [z_arm_cortex_r_svc + 0x4]
  z_swap_irqlock
  f4
  f3
  (and so on...)
```
