### PR TITLE
samples: blinky: add esp32s3_supermini overlay

### DIFF
--- a/samples/basic/blinky_pwm/boards/esp32c3_supermini.overlay
+++ b/samples/basic/blinky_pwm/boards/esp32c3_supermini.overlay
@@ -1,0 +1,44 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2021 Andrei-Edward Popa
+ * Copyright (c) 2022 Espressif Systems (Shanghai) Co., Ltd.
+ */
+
+ #include <zephyr/dt-bindings/pwm/pwm.h>
+
+/ {
+	aliases {
+		pwm-0 = &ledc0;
+		pwm-led0 = &pwm_led_blue;
+	};
+
+	pwmleds {
+		compatible = "pwm-leds";
+		pwm_led_blue: pwm-led-gpio0-2 {
+			label = "PWM LED0";
+			pwms = <&ledc0 0 1000 PWM_POLARITY_NORMAL>;
+		};
+	};
+};
+
+&pinctrl {
+	ledc0_default: ledc0-default {
+		group1 {
+			pinmux = <LEDC_CH0_GPIO2>;
+			output-enable;
+		};
+	};
+};
+
+&ledc0 {
+	pinctrl-0 = <&ledc0_default>;
+	pinctrl-names = "default";
+	status = "okay";
+	#address-cells = <1>;
+	#size-cells = <0>;
+	channel0@0 {
+		reg = <0x0>;
+		timer = <0>;
+	};
+};


### PR DESCRIPTION
Add support for the supermini board to be build and run by default.

Fixes #83487