### PR TITLE
west.yml: MCUboot synchronization from upstream

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -303,7 +303,7 @@ manifest:
       groups:
         - crypto
     - name: mcuboot
-      revision: 9a02794a14fa2e539ffe039a986360590d9e025f
+      revision: 346f7374ff4467e40b5594658f8ac67a5e9813c9
       path: bootloader/mcuboot
       groups:
         - bootloader


### PR DESCRIPTION
Update Zephyr fork of MCUboot to revision:
  346f7374ff4467e40b5594658f8ac67a5e9813c9

Brings following Zephyr relevant fixes:
  - 2aa6da15 boot: Add flash area ID/device ID retrieval hooks
  - b3ed5cc6 boot: New boot_go hook
  - dbbcb78b boot/zephyr: Fix SINGLE_APPLICATION_SLOT_RAM_LOAD file inclusion
  - 33094fc5 boot: bootutil: loader: Fix issue with stuck revert

Notes on process:
 1) The MCUboot update from [mcu-tools/mcuboot/main](https://github.com/mcu-tools/mcuboot/tree/main) with the SHA used in west.yaml is already synchronized to [zephyrproject-rtos/mcuboot/upstream-sync](https://github.com/zephyrproject-rtos/mcuboot/tree/upstream-sync) branch, and is available in the Zephyr fork of MCUboot.
 2) The [DNM] on this PR should be kept until the PR passes all tests and is accepted.
 3) Once the PR passes all tests and gets accepted, the upstream-sync branch should be fast-forward merged to [zephyrproject-rtos/mcuboot/main](https://github.com/zephyrproject-rtos/mcuboot/tree/main) branch and [DNM] should be removed.
 4) After the main branch gets updated, this PR does not require further changes and should be merged as is.