### PR TITLE
Bluetooth: Host: Add host support for Advertising Coding Selection

### DIFF
--- a/include/zephyr/bluetooth/gap.h
+++ b/include/zephyr/bluetooth/gap.h
@@ -747,8 +747,16 @@ enum {
 	BT_GAP_LE_PHY_1M                      = BIT(0),
 	 /** LE 2M PHY */
 	BT_GAP_LE_PHY_2M                      = BIT(1),
-	/** LE Coded PHY */
+	/** LE Coded PHY, coding scheme not specified */
 	BT_GAP_LE_PHY_CODED                   = BIT(2),
+	/** LE Coded S=8 PHY. Only used for advertising reports
+	 * when Kconfig BT_EXT_ADV_CODING_SELECTION is enabled.
+	 */
+	BT_GAP_LE_PHY_CODED_S8                = BIT(3),
+	/** LE Coded S=2 PHY. Only used for advertising reports
+	 * when Kconfig BT_EXT_ADV_CODING_SELECTION is enabled.
+	 */
+	BT_GAP_LE_PHY_CODED_S2                = BIT(4),
 };
 
 /** Advertising PDU types */

--- a/include/zephyr/bluetooth/hci_types.h
+++ b/include/zephyr/bluetooth/hci_types.h
@@ -3203,6 +3203,14 @@ struct bt_hci_evt_le_phy_update_complete {
 #define BT_HCI_LE_ADV_EVT_TYPE_DATA_STATUS_INCOMPLETE 2
 #define BT_HCI_LE_ADV_EVT_TYPE_DATA_STATUS_RX_FAILED  0xFF
 
+/* Advertising Coding Selection extended advertising report PHY values.
+ * Only used when Kconfig BT_EXT_ADV_CODING_SELECTION is enabled.
+ */
+#define BT_HCI_LE_ADV_EVT_PHY_1M                0x01
+#define BT_HCI_LE_ADV_EVT_PHY_2M                0x02
+#define BT_HCI_LE_ADV_EVT_PHY_CODED_S8          0x03
+#define BT_HCI_LE_ADV_EVT_PHY_CODED_S2          0x04
+
 struct bt_hci_evt_le_ext_advertising_info {
 	uint16_t     evt_type;
 	bt_addr_le_t addr;

--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -787,6 +787,7 @@ config BT_CTLR_ADV_PERIODIC_RSP
 config BT_CTLR_ADV_EXT_CODING_SELECTION
 	bool "Advertising Coding Selection support"
 	depends on BT_CTLR_PHY_CODED && BT_CTLR_ADV_EXT_CODING_SELECTION_SUPPORT
+	select BT_CTLR_SET_HOST_FEATURE if BT_OBSERVER
 	default y if BT_EXT_ADV_CODING_SELECTION
 	help
 	  Enable support for Bluetooth 6.0 Advertising Coding Selection

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -3685,6 +3685,14 @@ static int le_init(void)
 		}
 	}
 
+	if (IS_ENABLED(CONFIG_BT_EXT_ADV_CODING_SELECTION) &&
+	    BT_FEAT_LE_ADV_CODING_SEL(bt_dev.le.features)) {
+		err = le_set_host_feature(BT_LE_FEAT_BIT_ADV_CODING_SEL_HOST, 1);
+		if (err) {
+			return err;
+		}
+	}
+
 	return  le_set_event_mask();
 }
 


### PR DESCRIPTION
Extends the API for Advertising Coding Selection.

The API is extended to set the Advertising Coding Selection (Host Support) bit. With this feature, the primary and secondary PHY can now explicitly report S=2 or S=8 coding in the extended advertising report. Previously, the report only indicated LE Coded regardless of whether S=2 or S=8 data coding was used. The API now sets the host support bit and ensures that the advertising PHY coding scheme is conveyed to the application via the scan callback.

The support is enabled by CONFIG_BT_EXT_ADV_CODING_SELECTION, and requires a controller that selects CONFIG_BT_CTLR_ADV_EXT_CODING_SELECTION_SUPPORT.