### PR TITLE
samples: flash_shell: filter on flash-controller

### DIFF
--- a/samples/drivers/flash_shell/sample.yaml
+++ b/samples/drivers/flash_shell/sample.yaml
@@ -6,7 +6,7 @@ tests:
     tags:
       - flash
       - shell
-    filter: CONFIG_FLASH_HAS_DRIVER_ENABLED
+    filter: CONFIG_FLASH_HAS_DRIVER_ENABLED and dt_chosen_enabled('zephyr,flash-controller')
     platform_exclude:
       - stm32h7s78_dk
       - gd32f350r_eval


### PR DESCRIPTION
Sample expects flash-controller to be enabled as chosen.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
