### PR TITLE
drivers: ipm: Select MBOX from IPM_MBOX

### DIFF
--- a/drivers/ipm/Kconfig
+++ b/drivers/ipm/Kconfig
@@ -59,7 +59,7 @@ config IPM_MBOX
 	bool "IPM over MBOX driver"
 	default y
 	depends on DT_HAS_ZEPHYR_MBOX_IPM_ENABLED
-	depends on MBOX
+	select MBOX
 	help
 	  IPM driver using a MBOX driver as the backend mechanism.
 


### PR DESCRIPTION
Projects using IPM will select CONFIG_IPM=y, then the appropriate driver will be enabled based on DT. For devices using the IPM over MBOX driver this will be config IPM_MBOX. But this config depends on MBOX so if the project has not also enabled that, then this driver will not be selected.

To fix this, select MBOX from IPM_MBOX. This causes the correct MBOX driver to then be selected also based on DT. This allows projects using only IPM to only need to select the same as before, MBOX will be selected as needed based on DT.