### PR TITLE
bluetooth: mesh: Correct callback check mesh blob client

### DIFF
--- a/subsys/bluetooth/mesh/blob_cli.c
+++ b/subsys/bluetooth/mesh/blob_cli.c
@@ -1086,7 +1086,7 @@ static void progress_checked(struct bt_mesh_blob_cli *cli)
 
 	cli->state = BT_MESH_BLOB_CLI_STATE_NONE;
 
-	if (cli->cb && cli->cb->end) {
+	if (cli->cb && cli->cb->xfer_progress_complete) {
 		cli->cb->xfer_progress_complete(cli);
 	}
 }


### PR DESCRIPTION
xfer_progress_complete should be checked instead of end callback