### PR TITLE
drivers: gpio: davinci: Select PINCTRL

### DIFF
--- a/drivers/gpio/Kconfig.davinci
+++ b/drivers/gpio/Kconfig.davinci
@@ -7,5 +7,6 @@ config GPIO_DAVINCI
 	bool "Davinci GPIO Driver"
 	default y
 	depends on DT_HAS_TI_DAVINCI_GPIO_ENABLED
+	select PINCTRL
 	help
 		Enable the Davinci GPIO controller support.


### PR DESCRIPTION
This driver includes pin-muxing functions and requires to have CONFIG_PINCTRL enabled. Automatically set this config when this driver is enabled.