### PR TITLE
soc: ti: k3: am6x: m4: Adjust default RAT configuration

### DIFF
--- a/soc/ti/k3/am6x/m4/soc.c
+++ b/soc/ti/k3/am6x/m4/soc.c
@@ -10,8 +10,8 @@
 #include <zephyr/init.h>
 #include <soc.h>
 
-#define ADDR_TRANSLATE_RAT_BASE_ADDR		(0x044200000u)
-#define PINCTRL_BASE_ADDR			(0x4080000u)
+#define ADDR_TRANSLATE_RAT_BASE_ADDR		(0x44200000u)
+#define PINCTRL_BASE_ADDR			(0x04080000u)
 #define KICK0_UNLOCK_VAL			(0x68EF3490U)
 #define KICK1_UNLOCK_VAL			(0xD172BC5AU)
 #define CSL_MCU_PADCONFIG_LOCK0_KICK0_OFFSET	(0x1008)
@@ -19,26 +19,20 @@
 
 static struct address_trans_region_config am6x_region_config[] = {
 	{
-		.system_addr = 0x0u,
-		.local_addr = 0x80000000u,
-		.size = address_trans_region_size_512M,
+		.system_addr = 0x00000000u,
+		.local_addr =  0x60000000u,
+		.size = address_trans_region_size_256M,
 	},
 	{
-		.local_addr = 0xA0000000u,
 		.system_addr = 0x20000000u,
+		.local_addr =  0xc0000000u,
 		.size = address_trans_region_size_512M,
 	},
 	{
-		.local_addr = 0xC0000000u,
 		.system_addr = 0x40000000u,
-		.size = address_trans_region_size_512M,
+		.local_addr =  0x70000000u,
+		.size = address_trans_region_size_256M,
 	},
-	{
-		.local_addr = 0x60000000u,
-		.system_addr = 0x60000000u,
-		.size = address_trans_region_size_512M,
-	},
-
 /*
  * Add regions here if you want to map more memory.
  */


### PR DESCRIPTION
The current default RAT configuration puts the first 512MB of address space on top of the first 512MB of DRAM. This DRAM can include the carveout region assigned for IPC with the host core, for instance the M4 on AM62 uses 0x9cc00000.

Split this first translation from 0x80000000 to 0x60000000 and 0xc0000000. Shrink the 0x40000000 translation and move down to 0x70000000. This provides the same system IP coverage without blocking access to the first 512MB of DRAM.

While here, fix typo with leading 0 for a couple BASE_ADDR translations, no functional change.