### PR TITLE
soc: ti: k3: Select VFP float support for R5F cores

### DIFF
--- a/soc/ti/k3/am6x/Kconfig
+++ b/soc/ti/k3/am6x/Kconfig
@@ -23,6 +23,7 @@ config SOC_SERIES_AM6X_R5
 	select ARM
 	select CPU_CORTEX_R5
 	select CPU_HAS_ARM_MPU
+	select VFP_SP_D16
 	select ARM_CUSTOM_INTERRUPT_CONTROLLER
 	select VIM
 	select TI_DM_TIMER


### PR DESCRIPTION
The R5F cores found in TI K3 SoCs have VFP FPUs,
enable this in the default configuration.