### PR TITLE
drivers: wifi: siwx91x: Various fixes

### DIFF
--- a/drivers/wifi/siwx91x/Kconfig.siwx91x
+++ b/drivers/wifi/siwx91x/Kconfig.siwx91x
@@ -45,4 +45,9 @@ config NET_MGMT_EVENT_STACK_SIZE
 config NET_MGMT_EVENT_QUEUE_SIZE
 	default 10
 
+# Override the WIFI_MGMT_SCAN_SSID_FILT_MAX parameter for the Wi-Fi subsystem.
+# This device supports filtering scan results for only one SSID.
+config WIFI_MGMT_SCAN_SSID_FILT_MAX
+	default 1
+
 endif

--- a/drivers/wifi/siwx91x/siwx91x_wifi.c
+++ b/drivers/wifi/siwx91x/siwx91x_wifi.c
@@ -231,8 +231,27 @@ static int siwx91x_scan(const struct device *dev, struct wifi_scan_params *z_sca
 		return -EBUSY;
 	}
 
-	/* The enum values are same, no conversion needed */
-	sl_scan_config.type = z_scan_config->scan_type;
+	if (z_scan_config->scan_type == WIFI_SCAN_TYPE_ACTIVE) {
+		sl_scan_config.type = SL_WIFI_SCAN_TYPE_ACTIVE;
+		if (!z_scan_config->dwell_time_active) {
+			ret = sl_si91x_configure_timeout(SL_SI91X_CHANNEL_ACTIVE_SCAN_TIMEOUT,
+							 SL_WIFI_DEFAULT_ACTIVE_CHANNEL_SCAN_TIME);
+		} else {
+			ret = sl_si91x_configure_timeout(SL_SI91X_CHANNEL_ACTIVE_SCAN_TIMEOUT,
+							 z_scan_config->dwell_time_active);
+		}
+
+		if (ret) {
+			return -EINVAL;
+		}
+	} else {
+		sl_scan_config.type = SL_WIFI_SCAN_TYPE_PASSIVE;
+		ret = sl_si91x_configure_timeout(SL_SI91X_CHANNEL_PASSIVE_SCAN_TIMEOUT,
+						 z_scan_config->dwell_time_passive);
+		if (ret) {
+			return -EINVAL;
+		}
+	}
 
 	for (int i = 0; i < WIFI_MGMT_SCAN_CHAN_MAX_MANUAL; i++) {
 		sl_scan_config.channel_bitmap_2g4 |= BIT(z_scan_config->band_chan[i].channel - 1);

--- a/drivers/wifi/siwx91x/siwx91x_wifi.h
+++ b/drivers/wifi/siwx91x/siwx91x_wifi.h
@@ -19,6 +19,7 @@ struct siwx91x_dev {
 	sl_mac_address_t macaddr;
 	enum wifi_iface_state state;
 	scan_result_cb_t scan_res_cb;
+	uint16_t scan_max_bss_cnt;
 
 #ifdef CONFIG_WIFI_SILABS_SIWX91X_NET_STACK_OFFLOAD
 	struct k_event fds_recv_event;


### PR DESCRIPTION
Fix scan features on Silabs SiWx91x:
  - scan timeouts were ignored
  - channel filtering was ignored
  - max_bss_cnt was ignored
  - ssids filtering was ignored
