### PR TITLE
doc: Fixes the documentation issue in samples/net/wifi/apsta_mode/README.rst

### DIFF
--- a/samples/net/wifi/apsta_mode/README.rst
+++ b/samples/net/wifi/apsta_mode/README.rst
@@ -40,7 +40,7 @@ Building, Flashing and Running
 ******************************
 
 .. zephyr-app-commands::
-   :zephyr-app: samples/boards/espressif/deep_sleep
+   :zephyr-app: samples/net/wifi/apsta_mode
    :board: esp32_devkitc_wroom/esp32/procpu
    :goals: build flash
    :compact:


### PR DESCRIPTION

In the above file, Building,Flashing and Running section is using :zephyr-app: as samples/boards/espressif/deep_sleep. But it should be samples/net/wifi/apsta_mode.
Fixes: #85505