### PR TITLE
tests: kernel: stack_random: Re-enable dangling-pointer warning

### DIFF
--- a/tests/kernel/mem_protect/stack_random/src/main.c
+++ b/tests/kernel/mem_protect/stack_random/src/main.c
@@ -14,16 +14,6 @@
 void *last_sp = (void *)0xFFFFFFFF;
 volatile unsigned int changed;
 
-/*
- * The `alternate_thread` function deliberately makes use of a dangling pointer
- * in order to test stack randomisation.
- */
-#if defined(__GNUC__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wpragmas"
-#pragma GCC diagnostic ignored "-Wdangling-pointer"
-#endif
-
 void alternate_thread(void *p1, void *p2, void *p3)
 {
 	ARG_UNUSED(p1);
@@ -45,10 +35,6 @@ void alternate_thread(void *p1, void *p2, void *p3)
 	}
 	last_sp = sp_val;
 }
-
-#if defined(__GNUC__)
-#pragma GCC diagnostic pop
-#endif
 
 K_THREAD_STACK_DEFINE(alt_thread_stack_area, STACKSIZE);
 static struct k_thread alt_thread_data;


### PR DESCRIPTION
CI passes with the warning removed.