### PR TITLE
tests: kernel: interrupt: Remove MS_TO_US

### DIFF
--- a/subsys/testsuite/include/zephyr/interrupt_util.h
+++ b/subsys/testsuite/include/zephyr/interrupt_util.h
@@ -7,8 +7,6 @@
 #ifndef INTERRUPT_UTIL_H_
 #define INTERRUPT_UTIL_H_
 
-#define MS_TO_US(ms)  (ms * USEC_PER_MSEC)
-
 #if defined(CONFIG_CPU_CORTEX_M)
 #include <cmsis_core.h>
 

--- a/tests/kernel/interrupt/src/nested_irq.c
+++ b/tests/kernel/interrupt/src/nested_irq.c
@@ -112,7 +112,7 @@ void isr0(const void *param)
 	trigger_irq(irq_line_1);
 
 	/* Wait for interrupt */
-	k_busy_wait(MS_TO_US(DURATION));
+	k_busy_wait(DURATION * USEC_PER_MSEC);
 
 	/* Validate nested ISR result token */
 	zassert_equal(isr1_result, ISR1_TOKEN, "isr1 did not execute");
@@ -160,7 +160,7 @@ ZTEST(interrupt_feature, test_nested_isr)
 	trigger_irq(irq_line_0);
 
 	/* Wait for interrupt */
-	k_busy_wait(MS_TO_US(DURATION));
+	k_busy_wait(DURATION * USEC_PER_MSEC);
 
 	/* Validate ISR result token */
 	zassert_equal(isr0_result, ISR0_TOKEN, "isr0 did not execute");


### PR DESCRIPTION
No files use MS_TO_US except tests/kernel/interrupt/src/nested_irq.c.
While the macro is convenient, we should put it in a more central
location and use it everywhere if we want to use it rather than just in
interrupt_util.h. For now, remove it and replace the two usages to match
how code is written in the rest of Zephyr.