### PR TITLE
doc: fixes a potential minor typo in /doc/hardware/peripherals/sensor…

### DIFF
--- a/doc/hardware/peripherals/sensor/triggers.rst
+++ b/doc/hardware/peripherals/sensor/triggers.rst
@@ -5,7 +5,7 @@ Sensor Triggers
 
 :dfn:`Triggers`, enumerated in :c:enum:`sensor_trigger_type`, are sensor
 generated events. Typically sensors allow setting up these events to cause
-digital line signaling for easy capture by a micro controller. The events can
+digital line signaling for easy capture by a microcontroller. The events can
 then commonly be inspected by reading registers to determine which event caused
 the digital line signaling to occur.
 


### PR DESCRIPTION
…/triggers.rst

not sure "micro controller" is a typo. Happy to update it if needed, or feel free to close this. Thanks for your work!