### PR TITLE
drivers: video: video_common: refactor video_closest_frmival_stepwise()

### DIFF
--- a/tests/drivers/video/api/src/video_common.c
+++ b/tests/drivers/video/api/src/video_common.c
@@ -110,7 +110,7 @@ ZTEST(video_common, test_video_closest_frmival_stepwise)
 
 	stepwise.min.numerator = 1;
 	stepwise.min.denominator = 30;
-	stepwise.max.numerator = 30;
+	stepwise.max.numerator = 60;
 	stepwise.max.denominator = 30;
 	stepwise.step.numerator = 1;
 	stepwise.step.denominator = 30;
@@ -118,29 +118,41 @@ ZTEST(video_common, test_video_closest_frmival_stepwise)
 	desired.numerator = 1;
 	desired.denominator = 1;
 	video_closest_frmival_stepwise(&stepwise, &desired, &match);
-	zassert_equal(video_frmival_nsec(&match), video_frmival_nsec(&desired), "1 / 1");
+	zassert_within(video_frmival_nsec(&match), video_frmival_nsec(&desired), 10, "1/1");
 
 	desired.numerator = 3;
 	desired.denominator = 30;
 	video_closest_frmival_stepwise(&stepwise, &desired, &match);
-	zassert_equal(video_frmival_nsec(&match), video_frmival_nsec(&desired), "3 / 30");
+	zassert_within(video_frmival_nsec(&match), video_frmival_nsec(&desired), 10, "3/30");
 
 	desired.numerator = 7;
 	desired.denominator = 80;
 	expected.numerator = 3;
 	expected.denominator = 30;
 	video_closest_frmival_stepwise(&stepwise, &desired, &match);
-	zassert_equal(video_frmival_nsec(&match), video_frmival_nsec(&expected), "7 / 80");
+	zassert_within(video_frmival_nsec(&match), video_frmival_nsec(&expected), 10, "7/80");
+
+	desired.numerator = 29994500;
+	desired.denominator = 20000000;
+	expected.numerator = 30000000;
+	expected.denominator = 20000000;
+	video_closest_frmival_stepwise(&stepwise, &desired, &match);
+	video_closest_frmival_stepwise(&stepwise, &desired, &match);
+	video_closest_frmival_stepwise(&stepwise, &desired, &match);
+	video_closest_frmival_stepwise(&stepwise, &desired, &match);
+	video_closest_frmival_stepwise(&stepwise, &desired, &match);
+	zassert_within(video_frmival_nsec(&match), video_frmival_nsec(&expected), 1000,
+		       "29994500/20000000");
 
 	desired.numerator = 1;
 	desired.denominator = 120;
 	video_closest_frmival_stepwise(&stepwise, &desired, &match);
-	zassert_equal(video_frmival_nsec(&match), video_frmival_nsec(&stepwise.min), "1 / 120");
+	zassert_within(video_frmival_nsec(&match), video_frmival_nsec(&stepwise.min), 10, "1/120");
 
 	desired.numerator = 100;
 	desired.denominator = 1;
 	video_closest_frmival_stepwise(&stepwise, &desired, &match);
-	zassert_equal(video_frmival_nsec(&match), video_frmival_nsec(&stepwise.max), "100 / 1");
+	zassert_within(video_frmival_nsec(&match), video_frmival_nsec(&stepwise.max), 100, "100/1");
 }
 
 ZTEST_SUITE(video_common, NULL, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
Avoid an integer overflow by reducing the precision until the result is checked to fit in 32-bit. This is possible by simplifying fractions by 2, which should not affect the result significantly as this is only done when the values are extremely large (too large to fit 32-bit int).

Also adding a test case that would overflow without proper handling.

Fixes:
- https://github.com/zephyrproject-rtos/zephyr/issues/84779
- https://github.com/zephyrproject-rtos/zephyr/issues/84776
- https://github.com/zephyrproject-rtos/zephyr/issues/84775