### PR TITLE
net: wifi: 11v BTM query support embedded supplicant

### DIFF
--- a/drivers/wifi/nxp/nxp_wifi_drv.c
+++ b/drivers/wifi/nxp/nxp_wifi_drv.c
@@ -1409,6 +1409,13 @@ static int nxp_wifi_11k_neighbor_request(const struct device *dev, struct wifi_1
 }
 #endif
 
+#ifdef CONFIG_NXP_WIFI_11V
+static int nxp_wifi_btm_query(const struct device *dev, uint8_t reason)
+{
+	return wlan_host_11v_bss_trans_query(reason);
+}
+#endif
+
 static int nxp_wifi_power_save(const struct device *dev, struct wifi_ps_params *params)
 {
 	int status = NXP_WIFI_RET_SUCCESS;
@@ -2067,6 +2074,9 @@ static const struct wifi_mgmt_ops nxp_wifi_sta_mgmt = {
 #ifdef CONFIG_NXP_WIFI_11K
 	.cfg_11k = nxp_wifi_11k_cfg,
 	.send_11k_neighbor_request = nxp_wifi_11k_neighbor_request,
+#endif
+#ifdef CONFIG_NXP_WIFI_11V
+	.btm_query = nxp_wifi_btm_query,
 #endif
 	.set_power_save = nxp_wifi_power_save,
 	.get_power_save_config = nxp_wifi_get_power_save,

--- a/include/zephyr/net/wifi.h
+++ b/include/zephyr/net/wifi.h
@@ -672,7 +672,6 @@ static const char * const wifi_ps_param_config_err_code_tbl[] = {
 };
 /** @endcond */
 
-#ifdef CONFIG_WIFI_NM_WPA_SUPPLICANT_WNM
 /** IEEE 802.11v BTM (BSS transition management) Query reasons.
  * Refer to IEEE Std 802.11v-2011 - Table 7-43x-Transition and Transition Query reasons table.
  */
@@ -684,7 +683,6 @@ enum wifi_btm_query_reason {
 	/** Leaving ESS. */
 	WIFI_BTM_QUERY_REASON_LEAVING_ESS = 20,
 };
-#endif
 
 /** Helper function to get user-friendly power save error code name. */
 static inline const char *wifi_ps_get_config_err_code_str(int16_t err_no)

--- a/include/zephyr/net/wifi_mgmt.h
+++ b/include/zephyr/net/wifi_mgmt.h
@@ -111,10 +111,8 @@ enum net_request_wifi_cmd {
 	NET_REQUEST_WIFI_CMD_AP_CONFIG_PARAM,
 	/** DPP actions */
 	NET_REQUEST_WIFI_CMD_DPP,
-#ifdef CONFIG_WIFI_NM_WPA_SUPPLICANT_WNM
 	/** BSS transition management query */
 	NET_REQUEST_WIFI_CMD_BTM_QUERY,
-#endif
 	/** Flush PMKSA cache entries */
 	NET_REQUEST_WIFI_CMD_PMKSA_FLUSH,
 	/** Set enterprise mode credential */
@@ -277,12 +275,10 @@ NET_MGMT_DEFINE_REQUEST_HANDLER(NET_REQUEST_WIFI_AP_CONFIG_PARAM);
 NET_MGMT_DEFINE_REQUEST_HANDLER(NET_REQUEST_WIFI_DPP);
 #endif /* CONFIG_WIFI_NM_WPA_SUPPLICANT_DPP */
 
-#ifdef CONFIG_WIFI_NM_WPA_SUPPLICANT_WNM
 /** Request a Wi-Fi BTM query */
 #define NET_REQUEST_WIFI_BTM_QUERY (_NET_WIFI_BASE | NET_REQUEST_WIFI_CMD_BTM_QUERY)
 
 NET_MGMT_DEFINE_REQUEST_HANDLER(NET_REQUEST_WIFI_BTM_QUERY);
-#endif
 
 /** Request a Wi-Fi PMKSA cache entries flush */
 #define NET_REQUEST_WIFI_PMKSA_FLUSH                           \
@@ -1467,7 +1463,7 @@ struct wifi_mgmt_ops {
 	 * @return 0 if ok, < 0 if error
 	 */
 	int (*channel)(const struct device *dev, struct wifi_channel_info *channel);
-#ifdef CONFIG_WIFI_NM_WPA_SUPPLICANT_WNM
+
 	/** Send BTM query
 	 *
 	 * @param dev Pointer to the device structure for the driver instance.
@@ -1476,7 +1472,6 @@ struct wifi_mgmt_ops {
 	 * @return 0 if ok, < 0 if error
 	 */
 	int (*btm_query)(const struct device *dev, uint8_t reason);
-#endif
 	/** Judge ap whether support the capability
 	 *
 	 * @param dev Pointer to the device structure for the driver instance.

--- a/subsys/net/l2/wifi/wifi_mgmt.c
+++ b/subsys/net/l2/wifi/wifi_mgmt.c
@@ -1184,7 +1184,6 @@ static int wifi_get_version(uint32_t mgmt_request, struct net_if *iface,
 
 NET_MGMT_REGISTER_REQUEST_HANDLER(NET_REQUEST_WIFI_VERSION, wifi_get_version);
 
-#ifdef CONFIG_WIFI_NM_WPA_SUPPLICANT_WNM
 static int wifi_btm_query(uint32_t mgmt_request, struct net_if *iface, void *data, size_t len)
 {
 	const struct device *dev = net_if_get_device(iface);
@@ -1208,7 +1207,6 @@ static int wifi_btm_query(uint32_t mgmt_request, struct net_if *iface, void *dat
 }
 
 NET_MGMT_REGISTER_REQUEST_HANDLER(NET_REQUEST_WIFI_BTM_QUERY, wifi_btm_query);
-#endif
 
 static int wifi_get_connection_params(uint32_t mgmt_request, struct net_if *iface,
 			void *data, size_t len)

--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -2298,7 +2298,6 @@ static int cmd_wifi_listen_interval(const struct shell *sh, size_t argc, char *a
 	return 0;
 }
 
-#ifdef CONFIG_WIFI_NM_WPA_SUPPLICANT_WNM
 static int cmd_wifi_btm_query(const struct shell *sh, size_t argc, char *argv[])
 {
 	struct net_if *iface = net_if_get_wifi_sta();
@@ -2323,7 +2322,6 @@ static int cmd_wifi_btm_query(const struct shell *sh, size_t argc, char *argv[])
 
 	return 0;
 }
-#endif
 
 static int cmd_wifi_wps_pbc(const struct shell *sh, size_t argc, char *argv[])
 {
@@ -3652,12 +3650,10 @@ SHELL_SUBCMD_ADD((wifi), 11k_neighbor_request, NULL,
 		 cmd_wifi_11k_neighbor_request,
 		 1, 2);
 
-#ifdef CONFIG_WIFI_NM_WPA_SUPPLICANT_WNM
 SHELL_SUBCMD_ADD((wifi), 11v_btm_query, NULL,
 		 "<query_reason: The reason code for a BSS transition management query>.\n",
 		 cmd_wifi_btm_query,
 		 2, 0);
-#endif
 
 SHELL_SUBCMD_ADD((wifi), channel, NULL,
 		 "wifi channel setting\n"


### PR DESCRIPTION
Remove the CONFIG_WIFI_NM_WPA_SUPPLICANT_WNM macro in L2 shell level to make 11v BTM query support embedded supplicant.