### PR TITLE
tests: drivers: regulator: add api test for count/list current_limit API

### DIFF
--- a/drivers/regulator/regulator_fake.c
+++ b/drivers/regulator/regulator_fake.c
@@ -32,6 +32,9 @@ DEFINE_FAKE_VALUE_FUNC(int, regulator_fake_set_voltage, const struct device *,
 		       int32_t, int32_t);
 DEFINE_FAKE_VALUE_FUNC(int, regulator_fake_get_voltage, const struct device *,
 		       int32_t *);
+DEFINE_FAKE_VALUE_FUNC(unsigned int, regulator_fake_count_current_limits, const struct device *);
+DEFINE_FAKE_VALUE_FUNC(int, regulator_fake_list_current_limit, const struct device *, unsigned int,
+		       int32_t *);
 DEFINE_FAKE_VALUE_FUNC(int, regulator_fake_set_current_limit,
 		       const struct device *, int32_t, int32_t);
 DEFINE_FAKE_VALUE_FUNC(int, regulator_fake_get_current_limit,
@@ -54,6 +57,8 @@ static DEVICE_API(regulator, api) = {
 	.list_voltage = regulator_fake_list_voltage,
 	.set_voltage = regulator_fake_set_voltage,
 	.get_voltage = regulator_fake_get_voltage,
+	.count_current_limits = regulator_fake_count_current_limits,
+	.list_current_limit = regulator_fake_list_current_limit,
 	.set_current_limit = regulator_fake_set_current_limit,
 	.get_current_limit = regulator_fake_get_current_limit,
 	.set_mode = regulator_fake_set_mode,

--- a/include/zephyr/drivers/regulator/fake.h
+++ b/include/zephyr/drivers/regulator/fake.h
@@ -23,6 +23,9 @@ DECLARE_FAKE_VALUE_FUNC(int, regulator_fake_set_voltage, const struct device *,
 			int32_t, int32_t);
 DECLARE_FAKE_VALUE_FUNC(int, regulator_fake_get_voltage, const struct device *,
 			int32_t *);
+DECLARE_FAKE_VALUE_FUNC(unsigned int, regulator_fake_count_current_limits, const struct device *);
+DECLARE_FAKE_VALUE_FUNC(int, regulator_fake_list_current_limit, const struct device *, unsigned int,
+			int32_t *);
 DECLARE_FAKE_VALUE_FUNC(int, regulator_fake_set_current_limit,
 			const struct device *, int32_t, int32_t);
 DECLARE_FAKE_VALUE_FUNC(int, regulator_fake_get_current_limit,

--- a/tests/drivers/regulator/api/src/main.c
+++ b/tests/drivers/regulator/api/src/main.c
@@ -420,6 +420,81 @@ ZTEST(regulator_api, test_get_voltage_error)
 	zassert_equal(regulator_fake_get_voltage_fake.arg1_val, NULL);
 }
 
+ZTEST(regulator_api, test_count_current_limits_not_implemented)
+{
+	unsigned int ret = regulator_count_current_limits(dummy_reg);
+
+	zassert_equal(ret, 0);
+}
+
+ZTEST(regulator_api, test_count_current_limits_ok)
+{
+	RESET_FAKE(regulator_fake_count_current_limits);
+
+	regulator_fake_count_current_limits_fake.return_val = 10;
+
+	zassert_equal(regulator_count_current_limits(reg0), 10U);
+	zassert_equal(regulator_fake_count_current_limits_fake.arg0_val, reg0);
+	zassert_equal(regulator_fake_count_current_limits_fake.call_count, 1U);
+}
+
+ZTEST(regulator_api, test_count_current_limits_fail)
+{
+	RESET_FAKE(regulator_fake_count_current_limits);
+
+	regulator_fake_count_current_limits_fake.return_val = -EINVAL;
+
+	zassert_equal(regulator_count_current_limits(reg0), -EINVAL);
+	zassert_equal(regulator_fake_count_current_limits_fake.arg0_val, reg0);
+	zassert_equal(regulator_fake_count_current_limits_fake.call_count, 1U);
+}
+
+ZTEST(regulator_api, test_list_current_limit_not_implemented)
+{
+	zassert_equal(regulator_list_current_limit(dummy_reg, 0, NULL), -EINVAL);
+}
+
+static int list_current_limit_ok(const struct device *dev, unsigned int idx, int32_t *curr_ua)
+{
+	ARG_UNUSED(dev);
+	ARG_UNUSED(idx);
+
+	*curr_ua = 100;
+
+	return 0;
+}
+
+ZTEST(regulator_api, test_list_current_limit_ok)
+{
+	RESET_FAKE(regulator_fake_list_current_limit);
+
+	int32_t curr_ua;
+
+	regulator_fake_list_current_limit_fake.custom_fake = list_current_limit_ok;
+
+	zassert_equal(regulator_list_current_limit(reg0, 1, &curr_ua), 0);
+	zassert_equal(curr_ua, 100);
+	zassert_equal(regulator_fake_list_current_limit_fake.arg0_val, reg0);
+	zassert_equal(regulator_fake_list_current_limit_fake.arg1_val, 1U);
+	zassert_equal(regulator_fake_list_current_limit_fake.arg2_val, &curr_ua);
+	zassert_equal(regulator_fake_list_current_limit_fake.call_count, 1U);
+}
+
+ZTEST(regulator_api, test_list_current_limit_fail)
+{
+	RESET_FAKE(regulator_fake_list_current_limit);
+
+	int32_t curr_ua;
+
+	regulator_fake_list_current_limit_fake.return_val = -EIO;
+
+	zassert_equal(regulator_list_current_limit(reg0, 1, &curr_ua), -EIO);
+	zassert_equal(regulator_fake_list_current_limit_fake.arg0_val, reg0);
+	zassert_equal(regulator_fake_list_current_limit_fake.arg1_val, 1U);
+	zassert_equal(regulator_fake_list_current_limit_fake.arg2_val, &curr_ua);
+	zassert_equal(regulator_fake_list_current_limit_fake.call_count, 1U);
+}
+
 ZTEST(regulator_api, test_set_current_limit_not_implemented)
 {
 	int ret = regulator_set_current_limit(dummy_reg, 0, 0);


### PR DESCRIPTION
Adds missing fake methods to regulator_fake and corresponding API tests.