### PR TITLE
Bluetooth: Controller: Fix regression in scan aux release

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
@@ -1089,6 +1089,9 @@ static void isr_done_cleanup(void *param)
 		lll->is_stop = 1U;
 	}
 
+	/* LLL scheduled auxiliary PDU reception is_abort on duration expire or
+	 * aborted in the unreserved time space.
+	 */
 	if (lll->is_aux_sched) {
 		struct node_rx_pdu *node_rx2;
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync.c
@@ -635,15 +635,6 @@ static void abort_cb(struct lll_prepare_param *prepare_param, void *param)
 	lll = prepare_param->param;
 	lll->skip_prepare += (lll->lazy_prepare + 1U);
 
-	/* Reset Sync context association with any Aux context as the chain reception is aborted.
-	 * There is no race with ULL execution context assigning lll_aux as this is prepare being
-	 * aborted and no assignment would be done yet before the superior PDU is received.
-	 * TODO: This code here is redundant as isr_rx_done_cleanup() should ensure it is reset
-	 *       on every periodic sync chain done. Remove it if there is no regression running
-	 *       conformance tests.
-	 */
-	lll->lll_aux = NULL;
-
 	/* Extra done event, to check sync lost */
 	e = ull_event_done_extra_get();
 	LL_ASSERT(e);
@@ -823,16 +814,6 @@ static int isr_rx(struct lll_sync *lll, uint8_t node_type, uint8_t crc_ok,
 		 * again a node_rx for periodic report incomplete.
 		 */
 		if (node_type != NODE_RX_TYPE_EXT_AUX_REPORT) {
-			/* Reset Sync context association with any Aux context
-			 * as a new chain is being setup for reception here.
-			 * TODO: This code here is redundant as
-			 *       isr_rx_done_cleanup() should ensure it is reset
-			 *       on every periodic sync chain done. Remove it if
-			 *       there is no regression running conformance
-			 *       tests.
-			 */
-			lll->lll_aux = NULL;
-
 			node_rx = ull_pdu_rx_alloc_peek(4);
 		} else {
 			node_rx = ull_pdu_rx_alloc_peek(3);


### PR DESCRIPTION
Fix regression in scan aux release now that aux context is retrieved from the node rx when supporting multiple chain reception.

The regression was detected on target when testing in comparison of design as part of #85717.

Relates to commit a8065926acac ("Bluetooth: Controller: Fix to release aux context stored in node rx").