### PR TITLE
MAINTAINERS: Add more collaborators for Bluetooth Classic

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -525,6 +525,9 @@ Bluetooth Classic:
     - lylezhu2012
   collaborators:
     - jhedberg
+    - MarkWangChinese
+    - gzh-terry
+    - makeshi
   files:
     - doc/connectivity/bluetooth/shell/classic/a2dp.rst
     - subsys/bluetooth/common/


### PR DESCRIPTION
Add @MarkWangChinese, @gzh-terry and @makeshi as collaborators for Bluetooth Classic. They've all been contributing extensively to this area.

It doesn't look like @gzh-terry and @makeshi are members of the zephyrproject-rtos organization, so I made a separate Collaborator nominations for them here: #85707 #85710
