### PR TITLE
drivers: sensor: lsm6dso: Add support for Accel LP filter

### DIFF
--- a/drivers/sensor/st/lsm6dso/lsm6dso.h
+++ b/drivers/sensor/st/lsm6dso/lsm6dso.h
@@ -52,6 +52,7 @@ struct lsm6dso_config {
 	} stmemsc_cfg;
 	uint8_t accel_pm;
 	uint8_t accel_odr;
+	uint8_t accel_lp_filter;
 #define ACCEL_RANGE_DOUBLE	BIT(7)
 #define ACCEL_RANGE_MASK	BIT_MASK(6)
 	uint8_t accel_range;

--- a/dts/bindings/sensor/st,lsm6dso-common.yaml
+++ b/dts/bindings/sensor/st,lsm6dso-common.yaml
@@ -94,6 +94,24 @@ properties:
 
     enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
 
+  accel-lp-filter:
+    type: int
+    default: 0
+    description: |
+      Specify the amount of low pass filtering applied to the accelerometer values.
+      Default is power-up configuration.
+
+      - 0  # ODR/2
+      - 1  # ODR/10
+      - 2  # ODR/20
+      - 3  # ODR/45
+      - 4  # ODR/100
+      - 5  # ODR/200
+      - 6  # ODR/400
+      - 7  # ODR/800
+
+    enum: [0, 1, 2, 3, 4, 5, 6, 7]
+
   gyro-pm:
     type: int
     default: 0


### PR DESCRIPTION
Add device tree support for enabling the second low pass filter (LPF2) for the accelerometer output.

This adds additional low pass on top of the default ODR/2 from the LPF1 output.