### PR TITLE
drivers: gpio: unnamed parameters not allowed

### DIFF
--- a/drivers/gpio/gpio_mmio32.c
+++ b/drivers/gpio/gpio_mmio32.c
@@ -165,8 +165,10 @@ static int gpio_mmio32_port_toggle_bits(const struct device *dev, uint32_t mask)
 	return 0;
 }
 
-int gpio_mmio32_pin_interrupt_configure(const struct device *port, gpio_pin_t pin,
-					enum gpio_int_mode, enum gpio_int_trig)
+int gpio_mmio32_pin_interrupt_configure(const struct device *port,
+					gpio_pin_t pin,
+					enum gpio_int_mode mode,
+					enum gpio_int_trig trig)
 {
 	return -ENOTSUP;
 }

--- a/include/zephyr/drivers/gpio.h
+++ b/include/zephyr/drivers/gpio.h
@@ -810,7 +810,8 @@ __subsystem struct gpio_driver_api {
 				gpio_port_pins_t pins);
 	int (*pin_interrupt_configure)(const struct device *port,
 				       gpio_pin_t pin,
-				       enum gpio_int_mode, enum gpio_int_trig);
+				       enum gpio_int_mode mode,
+				       enum gpio_int_trig trig);
 	int (*manage_callback)(const struct device *port,
 			       struct gpio_callback *cb,
 			       bool set);


### PR DESCRIPTION
This violates Zephyr Rule 44 and causes 
`Error[Pe141]: unnamed prototyped parameters not allowed when body is present`
on IAR.