### PR TITLE
cmake: fix EXTRAVERSION regex

### DIFF
--- a/cmake/modules/version.cmake
+++ b/cmake/modules/version.cmake
@@ -63,7 +63,7 @@ foreach(type file IN ZIP_LISTS VERSION_TYPE VERSION_FILE)
   string(REGEX MATCH "VERSION_TWEAK = ([0-9]*)" _ ${ver})
   set(${type}_VERSION_TWEAK ${CMAKE_MATCH_1})
 
-  string(REGEX MATCH "EXTRAVERSION = ([a-z0-9\.\-]*)" _ ${ver})
+  string(REGEX MATCH "EXTRAVERSION = ([a-z0-9\\.-]*)" _ ${ver})
   set(${type}_VERSION_EXTRA ${CMAKE_MATCH_1})
 
   # Validate all version fields fit in a single byte


### PR DESCRIPTION
Use '\\' instead of '\' for the regex argument described in cmake specification:
The quoted argument "\\(\\a\\+b\\)" specifies a regex that matches the exact string (a+b). Each \\ is parsed in a quoted argument as just \, so the regex itself is actually \(\a\+\b\).

This fixes build error reported in OpenAMP CI

CMake Error at zephyrproject/zephyr/cmake/modules/version.cmake:66 (string):
 Syntax error in cmake code at

 zephyrproject/zephyr/cmake/modules/version.cmake:66

 when parsing string

  EXTRAVERSION = ([a-z0-9\.\-]*)

 Invalid escape sequence \.
Call Stack (most recent call first):
 zephyrproject/zephyr/share/zephyr-package/cmake/ZephyrConfigVersion.cmake:59 (include)
 cmake/syscheck.cmake:8 (find_package)
 CMakeLists.txt:17 (include)