### PR TITLE
boards: Remove 'xtools' toolchain variant references (take 2)

### DIFF
--- a/boards/adi/max78000evkit/max78000evkit_max78000_m4.yaml
+++ b/boards/adi/max78000evkit/max78000evkit_max78000_m4.yaml
@@ -6,7 +6,6 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
-  - xtools
 supported:
   - adc
   - counter

--- a/boards/adi/max78000fthr/max78000fthr_max78000_m4.yaml
+++ b/boards/adi/max78000fthr/max78000fthr_max78000_m4.yaml
@@ -6,7 +6,6 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
-  - xtools
 supported:
   - adc
   - counter

--- a/boards/arm/mps2/mps2_an383.yaml
+++ b/boards/arm/mps2/mps2_an383.yaml
@@ -8,7 +8,6 @@ simulation:
 toolchain:
   - zephyr
   - gnuarmemb
-  - xtools
 supported:
   - counter
   - netif:serial-net

--- a/boards/arm/mps2/mps2_an386.yaml
+++ b/boards/arm/mps2/mps2_an386.yaml
@@ -8,7 +8,6 @@ simulation:
 toolchain:
   - zephyr
   - gnuarmemb
-  - xtools
 supported:
   - counter
   - gpio

--- a/boards/arm/mps2/mps2_an500.yaml
+++ b/boards/arm/mps2/mps2_an500.yaml
@@ -8,7 +8,6 @@ simulation:
 toolchain:
   - zephyr
   - gnuarmemb
-  - xtools
 supported:
   - counter
   - gpio

--- a/boards/nxp/frdm_mcxn947/frdm_mcxn947_mcxn947_cpu1.yaml
+++ b/boards/nxp/frdm_mcxn947/frdm_mcxn947_mcxn947_cpu1.yaml
@@ -13,7 +13,6 @@ flash: 200
 toolchain:
   - zephyr
   - gnuarmemb
-  - xtools
 supported:
   - dma
   - gpio

--- a/boards/nxp/frdm_mcxw72/frdm_mcxw72_mcxw727c_cpu0.yaml
+++ b/boards/nxp/frdm_mcxw72/frdm_mcxw72_mcxw727c_cpu0.yaml
@@ -7,7 +7,6 @@ flash: 2048
 toolchain:
   - zephyr
   - gnuarmemb
-  - xtools
 supported:
   - adc
   - can

--- a/boards/nxp/mcxw72_evk/mcxw72_evk_mcxw727c_cpu0.yaml
+++ b/boards/nxp/mcxw72_evk/mcxw72_evk_mcxw727c_cpu0.yaml
@@ -7,7 +7,6 @@ flash: 2048
 toolchain:
   - zephyr
   - gnuarmemb
-  - xtools
 supported:
   - adc
   - can

--- a/boards/nxp/mimxrt1060_evk/mimxrt1060_evk_mimxrt1062_qspi_C.yaml
+++ b/boards/nxp/mimxrt1060_evk/mimxrt1060_evk_mimxrt1062_qspi_C.yaml
@@ -11,7 +11,6 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
-  - xtools
 ram: 32768
 flash: 8192
 supported:

--- a/boards/rakwireless/rak3172/rak3172.yaml
+++ b/boards/rakwireless/rak3172/rak3172.yaml
@@ -5,7 +5,6 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
-  - xtools
 ram: 64
 flash: 256
 supported:

--- a/boards/silabs/radio_boards/siwx917_rb4338a/siwx917_rb4338a.yaml
+++ b/boards/silabs/radio_boards/siwx917_rb4338a/siwx917_rb4338a.yaml
@@ -7,7 +7,6 @@ flash: 1024
 toolchain:
   - zephyr
   - gnuarmemb
-  - xtools
 supported:
   - bluetooth
   - dma

--- a/boards/silabs/radio_boards/xg29_rb4412a/xg29_rb4412a.yaml
+++ b/boards/silabs/radio_boards/xg29_rb4412a/xg29_rb4412a.yaml
@@ -7,7 +7,6 @@ flash: 1024
 toolchain:
   - zephyr
   - gnuarmemb
-  - xtools
 supported:
   - bluetooth
   - gpio

--- a/boards/st/nucleo_f072rb/nucleo_f072rb.yaml
+++ b/boards/st/nucleo_f072rb/nucleo_f072rb.yaml
@@ -7,7 +7,6 @@ flash: 128
 toolchain:
   - zephyr
   - gnuarmemb
-  - xtools
 supported:
   - adc
   - arduino_gpio

--- a/boards/ti/lp_em_cc2340r5/lp_em_cc2340r5.yaml
+++ b/boards/ti/lp_em_cc2340r5/lp_em_cc2340r5.yaml
@@ -7,7 +7,6 @@ flash: 512
 toolchain:
   - zephyr
   - gnuarmemb
-  - xtools
 supported:
   - gpio
   - uart


### PR DESCRIPTION
A follow-up to commit fe87abe0b9549e3cb07194fbf039912dd321f9ed.
This addresses boards that had pending pull requests at the time the initial clean-up was done.