### PR TITLE
boards nrf54l15bsim: Fix UART00 clock

### DIFF
--- a/boards/native/nrf_bsim/nrf54l15bsim_nrf54l15_cpuapp.dts
+++ b/boards/native/nrf_bsim/nrf54l15bsim_nrf54l15_cpuapp.dts
@@ -83,10 +83,6 @@
 	};
 };
 
-&uart00 {
-	/delete-property/ clocks;
-};
-
 &uart20 {
 	status = "okay";
 	current-speed = <115200>;

--- a/west.yml
+++ b/west.yml
@@ -318,7 +318,7 @@ manifest:
       groups:
         - tools
     - name: nrf_hw_models
-      revision: 5dc34b26662c6ec91edf1174d775d78590b1a05b
+      revision: dcfcffeee5c3ad8718723df4b5297caec33c23e7
       path: modules/bsim_hw_models/nrf_hw_models
     - name: nrf_wifi
       revision: e35f707a782b7c4c0eb83a3b06ca4e6eb693f29f


### PR DESCRIPTION
In 923d313a04726f6475b19ef803eb8b5a080e91d7 the clock frequency in DTS for the UART00 was fixed, but not for the simulated target. This was likely due to the HW models modeling it as 16MHz instead of 128MHz for this particular one as it is in reality.

Now that the HW models have been fixed, let's let this clock be configured like for real HW.


Update the HW models module to dcfcffeee5c3ad8718723df4b5297caec33c23e7
    
Including the following:
* dcfcffe UART: Support diffent clocks, correct UART00 clock and fix BAUDRATE model
