### PR TITLE
samples: drivers: i2c: rtio_loopback: add fixture

### DIFF
--- a/samples/drivers/i2c/rtio_loopback/sample.yaml
+++ b/samples/drivers/i2c/rtio_loopback/sample.yaml
@@ -5,6 +5,9 @@ tests:
     tags:
       - rtio
       - i2c_target
+    harness: ztest
+    harness_config:
+      fixture: i2c_bus_short
     platform_allow:
       - b_u585i_iot02a
       - nrf5340dk/nrf5340/cpuapp


### PR DESCRIPTION
Add i2c_bus_short fixture to the rtio_loopback sample to ensure it is only run on boards with the bus shorted. The i2c_bus_short fixture is also used in the i2c_target_api test suite.