### PR TITLE
drivers: wm8904: Fix audio input configuration

### DIFF
--- a/drivers/audio/wm8904.c
+++ b/drivers/audio/wm8904.c
@@ -264,9 +264,9 @@ static int wm8904_in_update(
 static int wm8904_in_volume_config(const struct device *dev, audio_channel_t channel, int volume)
 {
 	const uint16_t val = WM8904_REGVAL_IN_VOL(0, volume);
-	const uint16_t mask = WM8904_REGMASK_IN_MUTE;
+	const uint16_t mask = WM8904_REGMASK_IN_VOLUME;
 
-	return wm8904_in_update(dev, channel, val, mask);
+	return wm8904_in_update(dev, channel, mask, val);
 }
 
 static int wm8904_in_mute_config(const struct device *dev, audio_channel_t channel, bool mute)
@@ -274,7 +274,7 @@ static int wm8904_in_mute_config(const struct device *dev, audio_channel_t chann
 	const uint16_t val = WM8904_REGVAL_IN_VOL(mute, 0);
 	const uint16_t mask = WM8904_REGMASK_IN_MUTE;
 
-	return wm8904_in_update(dev, channel, val, mask);
+	return wm8904_in_update(dev, channel, mask, val);
 }
 
 static int wm8904_route_input(const struct device *dev, audio_channel_t channel, uint32_t input)

--- a/drivers/audio/wm8904.h
+++ b/drivers/audio/wm8904.h
@@ -102,7 +102,7 @@
  * [1:0] - x_MODE: Input mode
  */
 #define WM8904_REGVAL_INSEL(cm, nin, pin, mode) \
-	(((cm) & 0b1) << 6) | (((nin) & 0b11) << 4)
+	(((cm) & 0b1) << 6) | (((nin) & 0b11) << 4) | (((pin) & 0b11) << 2)
 #define WM8904_REGMASK_INSEL_CMENA		0b01000000
 #define WM8904_REGMASK_INSEL_IP_SEL_N	0b00110000
 #define WM8904_REGMASK_INSEL_IP_SEL_P	0b00001100


### PR DESCRIPTION
A few bugs in the `wm8904` codec driver prevent correct audio input configuration, namely input volume and mute settings. Thus change erroneous mask in `wm8904_volume_config`, extend `WM8904_REGVAL_INSEL` and unflip register mask and value parameters.

Related to https://github.com/zephyrproject-rtos/zephyr/pull/77814, marking it as a prerequisite.