### PR TITLE
soc: nordic: nrf54l: Fix num of irq for nRF54L20

### DIFF
--- a/soc/nordic/nrf54l/Kconfig.defconfig.nrf54l20_enga_cpuapp
+++ b/soc/nordic/nrf54l/Kconfig.defconfig.nrf54l20_enga_cpuapp
@@ -6,6 +6,6 @@
 if SOC_NRF54L20_ENGA_CPUAPP
 
 config NUM_IRQS
-	default 274
+	default 290
 
 endif # SOC_NRF54L20_ENGA_CPUAPP


### PR DESCRIPTION
Change number of IRQ parameter for nRF54L20 devices.