### PR TITLE
modules: optional: Feature update for Rust

### DIFF
--- a/submanifests/optional.yaml
+++ b/submanifests/optional.yaml
@@ -60,7 +60,7 @@ manifest:
       groups:
         - optional
     - name: zephyr-lang-rust
-      revision: cf3dc6cb79631717464f1cd6b3fb122220f12915
+      revision: 49c6712fe53b5b82e5c09e94548a4a51a021acfe
       path: modules/lang/rust
       remote: upstream
       groups:


### PR DESCRIPTION
Move to the latest Rust.

This moves the rust support to the latest version of the module:

    commit 49c6712fe53b5b82e5c09e94548a4a51a021acfe (HEAD -> main, origin/main)
    Author: David Brown <david.brown@linaro.org>
    Date:   Wed Feb 12 12:16:22 2025 -0700

        zephyr: various comment cleanups from review suggestions

This primarily brings in support for Zephyr Work queues, along with an implementation of an Async Executor built using work queues and triggered work to schedule the execution.