### PR TITLE
doc: releases: refresh list of new boards, drivers, and samples

### DIFF
--- a/doc/releases/release-notes-4.1.rst
+++ b/doc/releases/release-notes-4.1.rst
@@ -220,6 +220,7 @@ New Boards
 * Adafruit Industries, LLC
 
    * :zephyr:board:`adafruit_feather_m4_express` (``adafruit_feather_m4_express``)
+   * :zephyr:board:`adafruit_macropad_rp2040` (``adafruit_macropad_rp2040``)
    * :zephyr:board:`adafruit_qt_py_esp32s3` (``adafruit_qt_py_esp32s3``)
 
 * Advanced Micro Devices (AMD), Inc.
@@ -228,6 +229,10 @@ New Boards
 
 * Analog Devices, Inc.
 
+   * :zephyr:board:`ad_swiot1l_sl` (``ad_swiot1l_sl``)
+   * :zephyr:board:`max32650evkit` (``max32650evkit``)
+   * :zephyr:board:`max32650fthr` (``max32650fthr``)
+   * :zephyr:board:`max32660evsys` (``max32660evsys``)
    * :zephyr:board:`max78000evkit` (``max78000evkit``)
    * :zephyr:board:`max78000fthr` (``max78000fthr``)
    * :zephyr:board:`max78002evkit` (``max78002evkit``)
@@ -253,6 +258,10 @@ New Boards
 
    * :zephyr:board:`cy8ckit_062s2_ai` (``cy8ckit_062s2_ai``)
 
+* Khadas
+
+   * :zephyr:board:`khadas_edge2` (``khadas_edge2``)
+
 * Lilygo Shenzhen Xinyuan Electronic Technology Co., Ltd
 
    * :zephyr:board:`ttgo_t7v1_5` (``ttgo_t7v1_5``)
@@ -274,6 +283,9 @@ New Boards
 
 * NXP Semiconductors
 
+   * :zephyr:board:`frdm_mcxw72` (``frdm_mcxw72``)
+   * :zephyr:board:`imx91_evk` (``imx91_evk``)
+   * :zephyr:board:`mcxw72_evk` (``mcxw72_evk``)
    * :zephyr:board:`mimxrt700_evk` (``mimxrt700_evk``)
 
 * Nordic Semiconductor
@@ -285,9 +297,21 @@ New Boards
    * :zephyr:board:`octopus_io_board` (``octopus_io_board``)
    * :zephyr:board:`octopus_som` (``octopus_som``)
 
+* Panasonic Corporation
+
+   * :zephyr:board:`panb511evb` (``panb511evb``)
+
+* Peregrine Consultoria e Servicos
+
+   * :zephyr:board:`sam4l_wm400_cape` (``sam4l_wm400_cape``)
+
 * Qorvo, Inc.
 
    * :zephyr:board:`decawave_dwm3001cdk` (``decawave_dwm3001cdk``)
+
+* RAKwireless Technology Limited
+
+   * :zephyr:board:`rak3172` (``rak3172``)
 
 * Raspberry Pi Foundation
 
@@ -299,6 +323,8 @@ New Boards
 
 * Renesas Electronics Corporation
 
+   * :zephyr:board:`ek_ra4l1` (``ek_ra4l1``)
+   * :zephyr:board:`ek_ra4m1` (``ek_ra4m1``)
    * :zephyr:board:`fpb_ra4e1` (``fpb_ra4e1``)
    * :zephyr:board:`rzg3s_smarc` (``rzg3s_smarc``)
    * :zephyr:board:`voice_ra4e1` (``voice_ra4e1``)
@@ -323,9 +349,14 @@ New Boards
 
 * Silicon Laboratories
 
+   * :zephyr:board:`siwx917_rb4338a` (``siwx917_rb4338a``)
    * :zephyr:board:`xg23_rb4210a` (``xg23_rb4210a``)
    * :zephyr:board:`xg24_ek2703a` (``xg24_ek2703a``)
    * :zephyr:board:`xg29_rb4412a` (``xg29_rb4412a``)
+
+* Texas Instruments
+
+   * :zephyr:board:`lp_em_cc2340r5` (``lp_em_cc2340r5``)
 
 * Toradex AG
 
@@ -338,6 +369,7 @@ New Boards
 * WeAct Studio
 
    * :zephyr:board:`mini_stm32h7b0` (``mini_stm32h7b0``)
+   * :zephyr:board:`weact_stm32h5_core` (``weact_stm32h5_core``)
 
 * WinChipHead
 
@@ -365,21 +397,33 @@ New Drivers
 * :abbr:`ADC (Analog to Digital Converter)`
 
    * :dtcompatible:`adi,ad4114-adc`
-   * :dtcompatible:`ti,ads131m02`
-   * :dtcompatible:`ti,tla2022`
-   * :dtcompatible:`ti,tla2024`
+   * :dtcompatible:`adi,ad7124-adc`
+   * :dtcompatible:`st,stm32n6-adc`
    * :dtcompatible:`ti,ads114s06`
    * :dtcompatible:`ti,ads124s06`
    * :dtcompatible:`ti,ads124s08`
+   * :dtcompatible:`ti,ads131m02`
+   * :dtcompatible:`ti,tla2022`
+   * :dtcompatible:`ti,tla2024`
 
 * ARM architecture
 
    * :dtcompatible:`nxp,nbu`
 
+* Audio
+
+   * :dtcompatible:`cirrus,cs43l22`
+   * :dtcompatible:`intel,adsp-mic-privacy`
+
 * Bluetooth
 
    * :dtcompatible:`renesas,bt-hci-da1453x`
+   * :dtcompatible:`silabs,siwx91x-bt-hci`
    * :dtcompatible:`st,hci-stm32wb0`
+
+* Charger
+
+   * :dtcompatible:`nxp,pf1550-charger`
 
 * Clock control
 
@@ -389,14 +433,24 @@ New Drivers
    * :dtcompatible:`nordic,nrf-hsfll-global`
    * :dtcompatible:`nuvoton,npcm-pcc`
    * :dtcompatible:`realtek,rts5912-sccon`
+   * :dtcompatible:`st,stm32n6-cpu-clock-mux`
+   * :dtcompatible:`st,stm32n6-hse-clock`
+   * :dtcompatible:`st,stm32n6-ic-clock-mux`
+   * :dtcompatible:`st,stm32n6-pll-clock`
+   * :dtcompatible:`st,stm32n6-rcc`
    * :dtcompatible:`wch,ch32v00x-hse-clock`
    * :dtcompatible:`wch,ch32v00x-hsi-clock`
    * :dtcompatible:`wch,ch32v00x-pll-clock`
    * :dtcompatible:`wch,rcc`
 
+* comparator
+
+   * :dtcompatible:`silabs,acmp`
+
 * Counter
 
    * :dtcompatible:`adi,max32-rtc-counter`
+   * :dtcompatible:`renesas,rz-gtm-counter`
 
 * CPU
 
@@ -405,10 +459,13 @@ New Drivers
 * :abbr:`DAC (Digital to Analog Converter)`
 
    * :dtcompatible:`adi,max22017-dac`
+   * :dtcompatible:`renesas,ra-dac`
+   * :dtcompatible:`renesas,ra-dac-global`
 
 * :abbr:`DAI (Digital Audio Interface)`
 
    * :dtcompatible:`mediatek,afe`
+   * :dtcompatible:`nxp,dai-micfil`
 
 * Display
 
@@ -421,8 +478,13 @@ New Drivers
    * :dtcompatible:`infineon,cat1-dma`
    * :dtcompatible:`nxp,sdma`
    * :dtcompatible:`silabs,ldma`
+   * :dtcompatible:`silabs,siwx91x-dma`
    * :dtcompatible:`xlnx,axi-dma-1.00.a`
    * :dtcompatible:`xlnx,eth-dma`
+
+* :abbr:`DSA (Distributed Switch Architecture)`
+
+   * :dtcompatible:`nxp,netc-switch`
 
 * Ethernet
 
@@ -431,10 +493,16 @@ New Drivers
    * :dtcompatible:`microchip,t1s-phy`
    * :dtcompatible:`microchip,vsc8541`
    * :dtcompatible:`renesas,ra-ethernet`
+   * :dtcompatible:`sensry,sy1xx-mac`
 
 * Firmware
 
    * :dtcompatible:`arm,scmi-power`
+
+* Flash controller
+
+   * :dtcompatible:`silabs,siwx91x-flash-controller`
+   * :dtcompatible:`ti,cc23x0-flash-controller`
 
 * :abbr:`FPGA (Field Programmable Gate Array)`
 
@@ -449,14 +517,20 @@ New Drivers
    * :dtcompatible:`ite,it8801-gpio`
    * :dtcompatible:`microchip,mec5-gpio`
    * :dtcompatible:`nordic,npm2100-gpio`
+   * :dtcompatible:`nxp,pca6416`
    * :dtcompatible:`raspberrypi,rp1-gpio`
    * :dtcompatible:`realtek,rts5912-gpio`
    * :dtcompatible:`renesas,ra-gpio-mipi-header`
    * :dtcompatible:`renesas,rz-gpio`
    * :dtcompatible:`renesas,rz-gpio-int`
    * :dtcompatible:`sensry,sy1xx-gpio`
+   * :dtcompatible:`silabs,siwx91x-gpio`
+   * :dtcompatible:`silabs,siwx91x-gpio-port`
+   * :dtcompatible:`silabs,siwx91x-gpio-uulp`
+   * :dtcompatible:`st,dcmi-camera-fpu-330zh`
    * :dtcompatible:`st,mfxstm32l152`
    * :dtcompatible:`stemma-qt-connector`
+   * :dtcompatible:`ti,cc23x0-gpio`
    * :dtcompatible:`wch,gpio`
 
 * IEEE 802.15.4 HDLC RCP interface
@@ -472,16 +546,23 @@ New Drivers
 
 * :abbr:`I3C (Improved Inter-Integrated Circuit)`
 
+   * :dtcompatible:`snps,designware-i3c`
    * :dtcompatible:`st,stm32-i3c`
+
+* IEEE 802.15.4
+
+   * :dtcompatible:`nxp,mcxw-ieee802154`
 
 * Input
 
+   * :dtcompatible:`cypress,cy8cmbr3xxx`
    * :dtcompatible:`ite,it8801-kbd`
    * :dtcompatible:`microchip,cap12xx`
    * :dtcompatible:`nintendo,nunchuk`
 
 * Interrupt controller
 
+   * :dtcompatible:`renesas,rz-ext-irq`
    * :dtcompatible:`wch,pfic`
 
 * Mailbox
@@ -493,6 +574,7 @@ New Drivers
 
    * :dtcompatible:`microchip,lan865x-mdio`
    * :dtcompatible:`renesas,ra-mdio`
+   * :dtcompatible:`sensry,sy1xx-mdio`
 
 * Memory controller
 
@@ -507,6 +589,7 @@ New Drivers
    * :dtcompatible:`ite,it8801-mfd-map`
    * :dtcompatible:`maxim,ds3231-mfd`
    * :dtcompatible:`nordic,npm2100`
+   * :dtcompatible:`nxp,pf1550`
 
 * :abbr:`MIPI DSI (Mobile Industry Processor Interface Display Serial Interface)`
 
@@ -527,6 +610,11 @@ New Drivers
    * :dtcompatible:`fujitsu,mb85rsxx`
    * :dtcompatible:`nxp,s32-qspi-hyperflash`
    * :dtcompatible:`nxp,xspi-mx25um51345g`
+   * :dtcompatible:`ti,cc23x0-ccfg-flash`
+
+* Networking
+
+   * :dtcompatible:`silabs,series2-radio`
 
 * :abbr:`PCIe (Peripheral Component Interconnect Express)`
 
@@ -543,12 +631,15 @@ New Drivers
    * :dtcompatible:`renesas,rzg-pinctrl`
    * :dtcompatible:`sensry,sy1xx-pinctrl`
    * :dtcompatible:`silabs,dbus-pinctrl`
+   * :dtcompatible:`silabs,siwx91x-pinctrl`
+   * :dtcompatible:`ti,cc23x0-pinctrl`
    * :dtcompatible:`wch,afio`
 
 * :abbr:`PWM (Pulse Width Modulation)`
 
    * :dtcompatible:`atmel,sam0-tc-pwm`
    * :dtcompatible:`ite,it8801-pwm`
+   * :dtcompatible:`renesas,rz-gpt-pwm`
    * :dtcompatible:`zephyr,fake-pwm`
 
 * Quad SPI
@@ -559,20 +650,27 @@ New Drivers
 * Regulator
 
    * :dtcompatible:`nordic,npm2100-regulator`
+   * :dtcompatible:`nxp,pf1550-regulator`
 
 * :abbr:`RNG (Random Number Generator)`
 
    * :dtcompatible:`nordic,nrf-cracen-ctrdrbg`
+   * :dtcompatible:`nxp,ele-trng`
    * :dtcompatible:`renesas,ra-sce5-rng`
    * :dtcompatible:`renesas,ra-sce7-rng`
    * :dtcompatible:`renesas,ra-sce9-rng`
    * :dtcompatible:`renesas,ra-trng`
+   * :dtcompatible:`sensry,sy1xx-trng`
+   * :dtcompatible:`silabs,siwx91x-rng`
    * :dtcompatible:`st,stm32-rng-noirq`
 
 * :abbr:`RTC (Real Time Clock)`
 
+   * :dtcompatible:`epson,rx8130ce-rtc`
+   * :dtcompatible:`maxim,ds1337`
    * :dtcompatible:`maxim,ds3231-rtc`
    * :dtcompatible:`microcrystal,rv8803`
+   * :dtcompatible:`ti,bq32002`
 
 * SDHC
 
@@ -582,11 +680,13 @@ New Drivers
 
    * :dtcompatible:`adi,adxl366`
    * :dtcompatible:`hc-sr04`
+   * :dtcompatible:`invensense,icm42370p`
    * :dtcompatible:`invensense,icm42670s`
-   * :dtcompatible:`invensense,icm42370`
+   * :dtcompatible:`invensense,icp101xx`
    * :dtcompatible:`maxim,ds3231-sensor`
    * :dtcompatible:`melexis,mlx90394`
    * :dtcompatible:`nordic,npm2100-vbat`
+   * :dtcompatible:`phosense,xbr818`
    * :dtcompatible:`renesas,hs400x`
    * :dtcompatible:`sensirion,scd40`
    * :dtcompatible:`sensirion,scd41`
@@ -606,11 +706,13 @@ New Drivers
    * :dtcompatible:`renesas,rz-scif-uart`
    * :dtcompatible:`silabs,eusart-uart`
    * :dtcompatible:`silabs,usart-uart`
+   * :dtcompatible:`ti,cc23x0-uart`
    * :dtcompatible:`wch,usart`
 
 * :abbr:`SPI (Serial Peripheral Interface)`
 
    * :dtcompatible:`ite,it8xxx2-spi`
+   * :dtcompatible:`nxp,lpspi`
    * :dtcompatible:`nxp,xspi`
    * :dtcompatible:`renesas,ra-spi`
 
@@ -628,14 +730,19 @@ New Drivers
    * :dtcompatible:`mediatek,ostimer64`
    * :dtcompatible:`realtek,rts5912-rtmr`
    * :dtcompatible:`realtek,rts5912-slwtimer`
+   * :dtcompatible:`renesas,rz-gpt`
+   * :dtcompatible:`renesas,rz-gtm`
    * :dtcompatible:`riscv,machine-timer`
+   * :dtcompatible:`ti,cc23x0-systim-timer`
    * :dtcompatible:`wch,systick`
 
 * USB
 
    * :dtcompatible:`ambiq,usb`
    * :dtcompatible:`renesas,ra-udc`
-   * :dtcompatible:`renesas,ra-usb`
+   * :dtcompatible:`renesas,ra-usbfs`
+   * :dtcompatible:`renesas,ra-usbhs`
+   * :dtcompatible:`zephyr,midi2-device`
 
 * Video
 
@@ -651,6 +758,7 @@ New Drivers
 * Wi-Fi
 
    * :dtcompatible:`infineon,airoc-wifi`
+   * :dtcompatible:`silabs,siwx91x-wifi`
 
 New Samples
 ***********
@@ -664,6 +772,7 @@ New Samples
 * :zephyr:code-sample:`bluetooth_ccp_call_control_client`
 * :zephyr:code-sample:`bluetooth_ccp_call_control_server`
 * :zephyr:code-sample:`coresight_stm_sample`
+* :zephyr:code-sample:`dfu-next`
 * :zephyr:code-sample:`i2c-rtio-loopback`
 * :zephyr:code-sample:`lvgl-screen-transparency`
 * :zephyr:code-sample:`mctp_endpoint_sample`
@@ -675,7 +784,10 @@ New Samples
 * :zephyr:code-sample:`sensor_clock`
 * :zephyr:code-sample:`stream_fifo`
 * :zephyr:code-sample:`tdk_apex`
+* :zephyr:code-sample:`tmc50xx`
 * :zephyr:code-sample:`uart`
+* :zephyr:code-sample:`usb-midi2-device`
+* :zephyr:code-sample:`usbd-cdc-acm-console`
 * :zephyr:code-sample:`webusb-next`
 
 Other notable changes


### PR DESCRIPTION
Synchronize the list of new boards, drivers, and code samples.

Lining up the PR already so that we aim at having an accurate list captured for RC1 (might require another round of update if new stuff lands between now and tomorrow, which is likely going to be the case, I guess)

* https://builds.zephyrproject.io/zephyr/pr/85740/docs/releases/release-notes-4.1.html#new-boards
* https://builds.zephyrproject.io/zephyr/pr/85740/docs/releases/release-notes-4.1.html#new-drivers
* https://builds.zephyrproject.io/zephyr/pr/85740/docs/releases/release-notes-4.1.html#new-samples