### PR TITLE
drivers: dma_mcux_lpc: Add host directions, integrate DMA driver context, implement dma_mcux_lpc_get_attribute

### DIFF
--- a/drivers/dma/dma_mcux_lpc.c
+++ b/drivers/dma/dma_mcux_lpc.c
@@ -56,6 +56,8 @@ struct dma_otrig {
 };
 
 struct dma_mcux_lpc_dma_data {
+	struct dma_context ctx;
+
 	struct channel_data *channel_data;
 	struct dma_otrig *otrig_array;
 	int8_t *channel_index;
@@ -401,6 +403,8 @@ static int dma_mcux_lpc_configure(const struct device *dev, uint32_t channel,
 
 	switch (config->channel_direction) {
 	case MEMORY_TO_MEMORY:
+	case HOST_TO_MEMORY:
+	case MEMORY_TO_HOST:
 		is_periph = false;
 		if (block_config->source_gather_en) {
 			src_inc = block_config->source_gather_interval / width;
@@ -825,10 +829,29 @@ static int dma_mcux_lpc_get_status(const struct device *dev, uint32_t channel,
 	return 0;
 }
 
+static int dma_mcux_lpc_get_attribute(const struct device *dev, uint32_t type, uint32_t *value)
+{
+	switch (type) {
+	case DMA_ATTR_BUFFER_ADDRESS_ALIGNMENT:
+	case DMA_ATTR_BUFFER_SIZE_ALIGNMENT:
+	case DMA_ATTR_COPY_ALIGNMENT:
+		*value = 4;
+		break;
+
+	default:
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
 static int dma_mcux_lpc_init(const struct device *dev)
 {
 	const struct dma_mcux_lpc_config *config = dev->config;
 	struct dma_mcux_lpc_dma_data *data = dev->data;
+
+	data->ctx.magic = DMA_MAGIC;
+	data->ctx.dma_channels = config->num_of_channels;
 
 	/* Indicate that the Otrig Muxes are not connected */
 	for (int i = 0; i < config->num_of_otrigs; i++) {
@@ -860,6 +883,7 @@ static DEVICE_API(dma, dma_mcux_lpc_api) = {
 	.stop = dma_mcux_lpc_stop,
 	.reload = dma_mcux_lpc_reload,
 	.get_status = dma_mcux_lpc_get_status,
+	.get_attribute = dma_mcux_lpc_get_attribute
 };
 
 #define DMA_MCUX_LPC_CONFIG_FUNC(n)					\


### PR DESCRIPTION
The `dma_mcux_lpc` driver doesn't integrate a valid Zephyr DMA driver context, implying undefined behaviour of some of the Zephyr's DMA functions that wrap around the DMA API and expect a valid context to be present (such as `z_impl_dma_request_channel` and `z_impl_dma_release_channel`). While not detrimental to the DMA functionality itself, some applications (such as SOF) are written against those wrapper functions, making the driver unusable.

SOF also expects DMA drivers to support `HOST_TO_MEMORY` and `MEMORY_TO_HOST` directions for transfers between domains. As domains on devices where this driver runs are closely intertwined (at the very least they share memory), I don't think that aliasing them to `MEMORY_TO_MEMORY` should imply any sticky situations. Use case of this is on the i.MX RT685.

...thus add support for `HOST_TO_MEMORY`, `MEMORY_TO_HOST` directions (aliases of `MEMORY_TO_MEMORY`), implement `dma_mcux_lpc_get_attribute` function and fix missing DMA driver context.

Somewhat related to https://github.com/zephyrproject-rtos/zephyr/pull/77814, marking it as a prerequisite.