### PR TITLE
drivers: wifi: siwx91x: Fix deinitialization

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -228,7 +228,7 @@ manifest:
       groups:
         - hal
     - name: hal_silabs
-      revision: 1e60d972b2d05de620ece65cfa48ec33c5f38bac
+      revision: 8a173e9e566a396a19d18da4661cb54ce098f268
       path: modules/hal/silabs
       groups:
         - hal


### PR DESCRIPTION
The issue if fixed in the HAL tree with commit "wiseconnect: Fix si91x_bus event during platform deinitialization". So this patch only update the pointer to hal_silabs.