### PR TITLE
samples/*/*shell: filter test with shell harness on bsim targets

### DIFF
--- a/samples/drivers/flash_shell/sample.yaml
+++ b/samples/drivers/flash_shell/sample.yaml
@@ -7,6 +7,7 @@ tests:
       - flash
       - shell
     filter: CONFIG_FLASH_HAS_DRIVER_ENABLED and dt_chosen_enabled('zephyr,flash-controller')
+            and not CONFIG_SOC_SERIES_BSIM_NRFXX
     platform_exclude:
       - stm32h7s78_dk
       - gd32f350r_eval

--- a/samples/subsys/shell/shell_module/sample.yaml
+++ b/samples/subsys/shell/shell_module/sample.yaml
@@ -1,7 +1,7 @@
 sample:
   name: Shell Sample
 common:
-  filter: not CONFIG_NATIVE_LIBC
+  filter: not CONFIG_NATIVE_LIBC and not CONFIG_SOC_SERIES_BSIM_NRFXX
   platform_exclude:
     - native_posix
     - native_posix/native/64


### PR DESCRIPTION
The shell harness expects the UART can be routed to stdin/out on POSIX arch based targets, but this is not the case for the bsim targets (at least not yet, and not using the native_posix UART configuration option)

This causes these tests to fail timing out in CI => let's filter these platforms by now.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/85750
(it works around the underlaying issue by filtering it)