### PR TITLE
samples: Bluetooth: CAP: Add missing k_sem_init

### DIFF
--- a/samples/bluetooth/cap_acceptor/src/cap_acceptor_unicast.c
+++ b/samples/bluetooth/cap_acceptor/src/cap_acceptor_unicast.c
@@ -456,5 +456,8 @@ int init_cap_acceptor_unicast(struct peer_config *peer)
 		}
 	}
 
+	k_sem_init(&peer->source_stream_sem, 0, 1);
+	k_sem_init(&peer->sink_stream_sem, 0, 1);
+
 	return 0;
 }


### PR DESCRIPTION
The source_stream_sem and sink_stream_sem semaphores were never initialized, and thus when a disconnect happened the call(s) to k_sem_give would fail fatally.