### PR TITLE
Bluetooth: ASCS: Missing cleanup of stream for idle state

### DIFF
--- a/subsys/bluetooth/audio/ascs.c
+++ b/subsys/bluetooth/audio/ascs.c
@@ -329,10 +329,7 @@ static void ase_enter_state_idle(struct bt_ascs_ase *ase)
 
 	ase->ep.receiver_ready = false;
 
-	if (stream->conn != NULL) {
-		bt_conn_unref(stream->conn);
-		stream->conn = NULL;
-	}
+	bt_bap_stream_detach(stream);
 
 	ops = stream->ops;
 	if (ops != NULL && ops->released != NULL) {


### PR DESCRIPTION
When the stream enters the idle state, some values were not properly reset (e.g. the stream->ep).

Use the bt_bap_stream_detach function to clean up the stream.

fixes https://github.com/zephyrproject-rtos/zephyr/issues/85754