### PR TITLE
tests: show thread_metric Kconfig menu first

### DIFF
--- a/tests/benchmarks/thread_metric/Kconfig
+++ b/tests/benchmarks/thread_metric/Kconfig
@@ -3,8 +3,6 @@
 
 mainmenu "Eclipse ThreadX Thread-Metric RTOS Test Suite"
 
-source "Kconfig.zephyr"
-
 choice TM_TEST
 	prompt "Select a Thread-Metric test to execute"
 	default TM_PREEMPTIVE
@@ -81,3 +79,5 @@ config TM_SYNCHRONIZATION
 	  is reported every 30 seconds.
 
 endchoice
+
+source "Kconfig.zephyr"


### PR DESCRIPTION
Put the thread_metric Kconfig menu first in the Kconfig "homepage", like other samples and tests typically do as this makes it easier to quickly get to the relevant options in menuconfig.