### PR TITLE
toolchain: Add assembly-side counterpart of __aligned

### DIFF
--- a/include/zephyr/toolchain/common.h
+++ b/include/zephyr/toolchain/common.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2010-2014 Wind River Systems, Inc.
+ * Copyright (c) 2025 Siemens AG
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -59,6 +60,37 @@
 #ifdef _ASMLANGUAGE
   #define SECTION .section
 #endif
+
+/*
+ * General directive for assembly code, to align the following symbol, in bytes.
+ *
+ * Example:
+ *
+ *    ALIGN(4)
+ *    test_symbol:
+ *
+ * 'test_symbol' will get aligned to 4 bytes.
+ */
+
+#if defined(_ASMLANGUAGE) && !defined(_LINKER)
+
+  #if defined(CONFIG_X86) || defined(CONFIG_ARM) || defined(CONFIG_ARM64) || \
+	defined(CONFIG_NIOS2) || defined(CONFIG_RISCV) || \
+	defined(CONFIG_XTENSA) || defined(CONFIG_MIPS) || \
+	defined(CONFIG_ARCH_POSIX)
+    #define   ALIGN(x)    .balign   x
+  #elif defined(CONFIG_ARC)
+    /* .align assembler directive is supported by all ARC toolchains and it is
+     * implemented in the same way across ARC toolchains.
+     */
+    #define   ALIGN(x)    .align    x
+  #elif defined(CONFIG_SPARC)
+    #define   ALIGN(x)    .align    x
+  #else
+    #error Architecture unsupported
+  #endif
+
+#endif /* defined(_ASMLANGUAGE) && !defined(_LINKER) */
 
 /*
  * If the project is being built for speed (i.e. not for minimum size) then


### PR DESCRIPTION
Zephyr toolchain abstraction provides a macro __aligned(x) to add specified alignment, in bytes, to a chosen symbol for C/C++ source files but there is no portable counterpart available for symbols defined in assembly source files. This change-set adds a new macro ALIGN(x) for this purpose.