### PR TITLE
bug-fix: RTIO Workqueue working during Device Initialization

### DIFF
--- a/lib/os/Kconfig
+++ b/lib/os/Kconfig
@@ -106,6 +106,16 @@ config MPSC_CLEAR_ALLOCATED
 	  When enabled packet space is zeroed before returning from allocation.
 endif
 
+if SCHED_DEADLINE
+
+config P4WQ_INIT_STAGE_EARLY
+	bool "Early initialization of P4WQ threads"
+	help
+	  Initialize P4WQ threads early so that the P4WQ can be used on devices
+	  initialization sequence.
+
+endif
+
 config REBOOT
 	bool "Reboot functionality"
 	help

--- a/lib/os/p4wq.c
+++ b/lib/os/p4wq.c
@@ -218,7 +218,11 @@ void k_p4wq_enable_static_thread(struct k_p4wq *queue, struct k_thread *thread,
  * so they can initialize in parallel instead of serially on the main
  * CPU.
  */
+#if defined(CONFIG_P4WQ_INIT_STAGE_EARLY)
+SYS_INIT(static_init, POST_KERNEL, 1);
+#else
 SYS_INIT(static_init, APPLICATION, 99);
+#endif
 
 void k_p4wq_submit(struct k_p4wq *queue, struct k_p4wq_work *item)
 {

--- a/subsys/rtio/Kconfig.workq
+++ b/subsys/rtio/Kconfig.workq
@@ -4,6 +4,7 @@
 config RTIO_WORKQ
 	bool "RTIO Work-queues service to process Sync operations"
 	select SCHED_DEADLINE
+	select P4WQ_INIT_STAGE_EARLY
 	select RTIO_CONSUME_SEM
 	help
 	  Enable RTIO Work-queues to allow processing synchronous operations


### PR DESCRIPTION
This PR enables P4WQ early initialization so RTIO Workqueue can be functional during Device Initialization (POST_KERNEL).

Fixes #85759 