### PR TITLE
drivers: espi: npcx: update the arbitration mechanism for eSPI TAF

### DIFF
--- a/drivers/espi/Kconfig.npcx
+++ b/drivers/espi/Kconfig.npcx
@@ -98,6 +98,14 @@ config ESPI_TAF_NPCX_RPMC_SUPPORT
 	help
 	  This option enable the handler for eSPI TAF RPMC request.
 
+config ESPI_TAF_NPCX_STS_AWAIT_TIMEOUT
+	int "A timeout value in microseconds to wait for automatic read status"
+	depends on ESPI_TAF_NPCX
+	default 20000
+	help
+	  This option specifies the timeout value in microseconds (us) for checking
+	  automatic read status.
+
 # The default value 'y' for the existing options if ESPI_NPCX is selected.
 if ESPI_NPCX
 

--- a/drivers/flash/flash_npcx_fiu_nor.c
+++ b/drivers/flash/flash_npcx_fiu_nor.c
@@ -23,6 +23,10 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(flash_npcx_fiu_nor, CONFIG_FLASH_LOG_LEVEL);
 
+#if defined(CONFIG_ESPI_TAF)
+static const struct device *const espi_dev = DEVICE_DT_GET(DT_NODELABEL(espi0));
+#endif
+
 #define BLOCK_64K_SIZE KB(64)
 #define BLOCK_4K_SIZE  KB(4)
 
@@ -45,6 +49,8 @@ struct flash_npcx_nor_config {
 
 /* Device data */
 struct flash_npcx_nor_data {
+	/* mutex for flash write and erase operation */
+	struct k_sem nor_flash_sem;
 	/* Specific control operation for Quad-SPI Nor Flash */
 	uint32_t operation;
 };
@@ -189,16 +195,32 @@ static int flash_npcx_nor_write_status_regs(const struct device *dev, uint8_t *s
 #if defined(CONFIG_FLASH_JESD216_API)
 static int flash_npcx_nor_read_jedec_id(const struct device *dev, uint8_t *id)
 {
+	int ret;
+
 	if (id == NULL) {
 		return -EINVAL;
 	}
 
-	return flash_npcx_uma_read(dev, SPI_NOR_CMD_RDID, id, SPI_NOR_MAX_ID_LEN);
+#if defined(CONFIG_ESPI_TAF)
+	if (espi_taf_npcx_block(espi_dev, true) != 0) {
+		LOG_ERR("TAF LOCK TIMEOUT");
+		return -ETIMEDOUT;
+	}
+#endif
+
+	ret = flash_npcx_uma_read(dev, SPI_NOR_CMD_RDID, id, SPI_NOR_MAX_ID_LEN);
+
+#if defined(CONFIG_ESPI_TAF)
+	espi_taf_npcx_block(espi_dev, false);
+#endif
+
+	return ret;
 }
 
 static int flash_npcx_nor_read_sfdp(const struct device *dev, off_t addr,
 				    void *data, size_t size)
 {
+	int ret;
 	uint8_t sfdp_addr[4];
 	struct npcx_uma_cfg cfg = { .opcode = JESD216_CMD_READ_SFDP,
 					.tx_buf = sfdp_addr,
@@ -214,8 +236,22 @@ static int flash_npcx_nor_read_sfdp(const struct device *dev, off_t addr,
 	sfdp_addr[0] = (addr >> 16) & 0xff;
 	sfdp_addr[1] = (addr >> 8) & 0xff;
 	sfdp_addr[2] = addr & 0xff;
-	return flash_npcx_uma_transceive(dev, &cfg, NPCX_UMA_ACCESS_WRITE |
+
+#if defined(CONFIG_ESPI_TAF)
+	if (espi_taf_npcx_block(espi_dev, true) != 0) {
+		LOG_ERR("TAF LOCK TIMEOUT");
+		return -ETIMEDOUT;
+	}
+#endif
+
+	ret = flash_npcx_uma_transceive(dev, &cfg, NPCX_UMA_ACCESS_WRITE |
 					 NPCX_UMA_ACCESS_READ);
+
+#if defined(CONFIG_ESPI_TAF)
+	espi_taf_npcx_block(espi_dev, false);
+#endif
+
+	return ret;
 }
 #endif /* CONFIG_FLASH_JESD216_API */
 
@@ -257,32 +293,47 @@ static int flash_npcx_nor_read(const struct device *dev, off_t addr,
 static int flash_npcx_nor_erase(const struct device *dev, off_t addr, size_t size)
 {
 	const struct flash_npcx_nor_config *config = dev->config;
+	struct flash_npcx_nor_data *dev_data = dev->data;
 	int ret = 0;
+
+	k_sem_take(&dev_data->nor_flash_sem, K_FOREVER);
 
 	/* Out of the region of nor flash device? */
 	if (!is_within_region(addr, size, 0, config->flash_size)) {
 		LOG_ERR("Addr %ld, size %d are out of range", addr, size);
-		return -EINVAL;
+		ret = -EINVAL;
+		goto out_nor_erase;
 	}
 
 	/* address must be sector-aligned */
 	if (!SPI_NOR_IS_SECTOR_ALIGNED(addr)) {
 		LOG_ERR("Addr %ld is not sector-aligned", addr);
-		return -EINVAL;
+		ret = -EINVAL;
+		goto out_nor_erase;
 	}
 
 	/* size must be a multiple of sectors */
 	if ((size % BLOCK_4K_SIZE) != 0) {
 		LOG_ERR("Size %d is not a multiple of sectors", size);
-		return -EINVAL;
+		ret = -EINVAL;
+		goto out_nor_erase;
 	}
+
+#if defined(CONFIG_ESPI_TAF)
+	if (espi_taf_npcx_block(espi_dev, true) != 0) {
+		LOG_ERR("TAF LOCK TIMEOUT");
+		ret = -ETIMEDOUT;
+		goto out_nor_erase;
+	}
+#endif
 
 	/* Select erase opcode by size */
 	if (size == config->flash_size) {
 		flash_npcx_uma_cmd_only(dev, SPI_NOR_CMD_WREN);
 		/* Send chip erase command */
 		flash_npcx_uma_cmd_only(dev, SPI_NOR_CMD_CE);
-		return flash_npcx_nor_wait_until_ready(dev);
+		ret = flash_npcx_nor_wait_until_ready(dev);
+		goto out_nor_erase_unblock;
 	}
 
 	while (size > 0) {
@@ -302,6 +353,12 @@ static int flash_npcx_nor_erase(const struct device *dev, off_t addr, size_t siz
 			break;
 		}
 	}
+out_nor_erase_unblock:
+#if defined(CONFIG_ESPI_TAF)
+	espi_taf_npcx_block(espi_dev, false);
+#endif
+out_nor_erase:
+	k_sem_give(&dev_data->nor_flash_sem);
 
 	return ret;
 }
@@ -310,12 +367,16 @@ static int flash_npcx_nor_write(const struct device *dev, off_t addr,
 				  const void *data, size_t size)
 {
 	const struct flash_npcx_nor_config *config = dev->config;
+	struct flash_npcx_nor_data *dev_data = dev->data;
 	uint8_t *tx_buf = (uint8_t *)data;
 	int ret = 0;
 	size_t sz_write;
 
+	k_sem_take(&dev_data->nor_flash_sem, K_FOREVER);
+
 	/* Out of the region of nor flash device? */
 	if (!is_within_region(addr, size, 0, config->flash_size)) {
+		k_sem_give(&dev_data->nor_flash_sem);
 		return -EINVAL;
 	}
 
@@ -335,19 +396,37 @@ static int flash_npcx_nor_write(const struct device *dev, off_t addr,
 	}
 
 	while (size > 0) {
+#if defined(CONFIG_ESPI_TAF)
+		if (espi_taf_npcx_block(espi_dev, true) != 0) {
+			LOG_ERR("TAF LOCK TIMEOUT");
+			k_sem_give(&dev_data->nor_flash_sem);
+
+			return -ETIMEDOUT;
+		}
+#endif
 		/* Start to write */
 		flash_npcx_uma_cmd_only(dev, SPI_NOR_CMD_WREN);
 		ret = flash_npcx_uma_write_by_addr(dev, SPI_NOR_CMD_PP, tx_buf,
 						   sz_write, addr);
 		if (ret != 0) {
+#if defined(CONFIG_ESPI_TAF)
+			espi_taf_npcx_block(espi_dev, false);
+#endif
 			break;
 		}
 
 		/* Wait for writing completed */
 		ret = flash_npcx_nor_wait_until_ready(dev);
 		if (ret != 0) {
+#if defined(CONFIG_ESPI_TAF)
+			espi_taf_npcx_block(espi_dev, false);
+#endif
 			break;
 		}
+
+#if defined(CONFIG_ESPI_TAF)
+		espi_taf_npcx_block(espi_dev, false);
+#endif
 
 		size -= sz_write;
 		tx_buf += sz_write;
@@ -359,6 +438,8 @@ static int flash_npcx_nor_write(const struct device *dev, off_t addr,
 			sz_write = size;
 		}
 	}
+
+	k_sem_give(&dev_data->nor_flash_sem);
 
 	return ret;
 }
@@ -459,7 +540,16 @@ static int flash_npcx_nor_ex_op(const struct device *dev, uint16_t code,
 		}
 #endif
 
+#if defined(CONFIG_ESPI_TAF)
+		if (espi_taf_npcx_block(espi_dev, true) != 0) {
+			LOG_ERR("TAF LOCK TIMEOUT");
+			return -ETIMEDOUT;
+		}
+#endif
 		ret = flash_npcx_nor_ex_exec_uma(dev, op_in, op_out);
+#if defined(CONFIG_ESPI_TAF)
+		espi_taf_npcx_block(espi_dev, false);
+#endif
 #ifdef CONFIG_USERSPACE
 		if (ret == 0 && syscall_trap) {
 			K_OOPS(k_usermode_to_copy(out, op_out, sizeof(out_copy)));
@@ -529,6 +619,7 @@ static DEVICE_API(flash, flash_npcx_nor_driver_api) = {
 static int flash_npcx_nor_init(const struct device *dev)
 {
 	const struct flash_npcx_nor_config *config = dev->config;
+	struct flash_npcx_nor_data *dev_data = dev->data;
 	int ret;
 
 	if (!IS_ENABLED(CONFIG_FLASH_NPCX_FIU_NOR_INIT)) {
@@ -590,6 +681,8 @@ static int flash_npcx_nor_init(const struct device *dev)
 	if (config->qspi_cfg.is_logical_low_dev && IS_ENABLED(CONFIG_FLASH_NPCX_FIU_DRA_V2)) {
 		qspi_npcx_fiu_set_spi_size(config->qspi_bus, &config->qspi_cfg);
 	}
+
+	k_sem_init(&dev_data->nor_flash_sem, 1, 1);
 
 	return 0;
 }

--- a/soc/nuvoton/npcx/common/reg/reg_def.h
+++ b/soc/nuvoton/npcx/common/reg/reg_def.h
@@ -753,6 +753,7 @@ struct espi_reg {
 #define NPCX_ESPISTS_VWUPD               8
 #define NPCX_ESPISTS_ESPIRST             9
 #define NPCX_ESPISTS_PLTRST              10
+#define NPCX_ESPISTS_FLAUTORDREQ         14
 #define NPCX_ESPISTS_AMERR               15
 #define NPCX_ESPISTS_AMDONE              16
 #define NPCX_ESPISTS_VWUPDW              17
@@ -762,6 +763,7 @@ struct espi_reg {
 #define NPCX_ESPISTS_BMBURSTERR          22
 #define NPCX_ESPISTS_BMBURSTDONE         23
 #define NPCX_ESPISTS_ESPIRST_LVL         24
+#define NPCX_ESPISTS_AUTO_RD_DIS_STS     29
 #define NPCX_VWSWIRQ_IRQ_NUM             FIELD(0, 7)
 #define NPCX_VWSWIRQ_IRQ_LVL             7
 #define NPCX_VWSWIRQ_INDEX               FIELD(8, 7)

--- a/soc/nuvoton/npcx/common/soc_espi_taf.h
+++ b/soc/nuvoton/npcx/common/soc_espi_taf.h
@@ -151,6 +151,8 @@ struct npcx_taf_head {
 
 int npcx_init_taf(const struct device *dev, sys_slist_t *callbacks);
 
+int espi_taf_npcx_block(const struct device *dev, bool en_block);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
In applications, it may encounter scenarios where both the EC and eSPI TAF simultaneously request access to flash data. Therefore, an arbitration mechanism is necessary to ensure the correctness of data accessed by both sides. 

This PR adds the arbitration mechanism for flash access between the eSPI TAF and the EC.