### PR TITLE
MAINTAINERS: ARM64 arch: add @JiafeiPan as collaborator

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -205,6 +205,7 @@ ARM64 arch:
     - sgrrzhf
     - wearyzen
     - ithinuel
+    - JiafeiPan
   files:
     - arch/arm64/
     - include/zephyr/arch/arm64/


### PR DESCRIPTION
I have already contributed a lot of patches to ARM64 arch regarding of booting, cache, SMP, GIC etc, and currently I am NXP MPU maintainer, so I would like to add me to be collaborator of ARM64 arch to help to review related patches.