### PR TITLE
drivers: i3c: cleanup target config description and add inline helpers

### DIFF
--- a/drivers/i3c/i3c_cdns.c
+++ b/drivers/i3c/i3c_cdns.c
@@ -2996,7 +2996,7 @@ static int cdns_i3c_config_get(const struct device *dev, enum i3c_config_type ty
 		uint32_t slv_status1 = sys_read32(dev_config->base + SLV_STATUS1);
 
 		/* if we are currently a target */
-		target_config->enable =
+		target_config->enabled =
 			!!!(sys_read32(dev_config->base + MST_STATUS0) & MST_STATUS0_MASTER_MODE);
 		if (data->common.ctrl_config.is_secondary) {
 			target_config->dynamic_addr = SLV_STATUS1_DA(slv_status1);

--- a/drivers/i3c/i3c_common.c
+++ b/drivers/i3c/i3c_common.c
@@ -17,23 +17,21 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(i3c, CONFIG_I3C_LOG_LEVEL);
 
-void i3c_dump_msgs(const char *name, const struct i3c_msg *msgs,
-		   uint8_t num_msgs, struct i3c_device_desc *target)
+void i3c_dump_msgs(const char *name, const struct i3c_msg *msgs, uint8_t num_msgs,
+		   struct i3c_device_desc *target)
 {
 	LOG_DBG("I3C msg: %s, addr=%x", name, target->dynamic_addr);
 	for (unsigned int i = 0; i < num_msgs; i++) {
 		const struct i3c_msg *msg = &msgs[i];
 
-		LOG_DBG("   %c len=%02x: ",
-			msg->flags & I3C_MSG_READ ? 'R' : 'W', msg->len);
+		LOG_DBG("   %c len=%02x: ", msg->flags & I3C_MSG_READ ? 'R' : 'W', msg->len);
 		if (!(msg->flags & I3C_MSG_READ)) {
 			LOG_HEXDUMP_DBG(msg->buf, msg->len, "contents:");
 		}
 	}
 }
 
-void i3c_addr_slots_set(struct i3c_addr_slots *slots,
-			uint8_t dev_addr,
+void i3c_addr_slots_set(struct i3c_addr_slots *slots, uint8_t dev_addr,
 			enum i3c_addr_slot_status status)
 {
 	int bitpos;
@@ -54,9 +52,7 @@ void i3c_addr_slots_set(struct i3c_addr_slots *slots,
 	slots->slots[idx] |= status << bitpos;
 }
 
-enum i3c_addr_slot_status
-i3c_addr_slots_status(struct i3c_addr_slots *slots,
-		      uint8_t dev_addr)
+enum i3c_addr_slot_status i3c_addr_slots_status(struct i3c_addr_slots *slots, uint8_t dev_addr)
 {
 	unsigned long status;
 	int bitpos;
@@ -82,13 +78,10 @@ i3c_addr_slots_status(struct i3c_addr_slots *slots,
 	return status;
 }
 
-
 int i3c_addr_slots_init(const struct device *dev)
 {
-	struct i3c_driver_data *data =
-		(struct i3c_driver_data *)dev->data;
-	const struct i3c_driver_config *config =
-		(const struct i3c_driver_config *)dev->config;
+	struct i3c_driver_data *data = (struct i3c_driver_data *)dev->data;
+	const struct i3c_driver_config *config = (const struct i3c_driver_config *)dev->config;
 	int i, ret = 0;
 	struct i3c_device_desc *i3c_dev;
 	struct i3c_i2c_device_desc *i2c_dev;
@@ -110,7 +103,6 @@ int i3c_addr_slots_init(const struct device *dev)
 		 */
 		i3c_addr_slots_set(&data->attached_dev.addr_slots, I3C_BROADCAST_ADDR ^ BIT(i),
 				   I3C_ADDR_SLOT_STATUS_RSVD);
-
 	}
 
 	/* The broadcast address is reserved */
@@ -149,8 +141,7 @@ out:
 	return ret;
 }
 
-bool i3c_addr_slots_is_free(struct i3c_addr_slots *slots,
-			    uint8_t dev_addr)
+bool i3c_addr_slots_is_free(struct i3c_addr_slots *slots, uint8_t dev_addr)
 {
 	enum i3c_addr_slot_status status;
 
@@ -198,8 +189,7 @@ struct i3c_device_desc *i3c_dev_list_find(const struct i3c_dev_list *dev_list,
 	return ret;
 }
 
-struct i3c_device_desc *i3c_dev_list_i3c_addr_find(const struct device *dev,
-						   uint8_t addr)
+struct i3c_device_desc *i3c_dev_list_i3c_addr_find(const struct device *dev, uint8_t addr)
 {
 	struct i3c_device_desc *ret = NULL;
 	struct i3c_device_desc *desc;
@@ -216,8 +206,7 @@ struct i3c_device_desc *i3c_dev_list_i3c_addr_find(const struct device *dev,
 	return ret;
 }
 
-struct i3c_device_desc *i3c_dev_list_i3c_static_addr_find(const struct device *dev,
-							  uint8_t addr)
+struct i3c_device_desc *i3c_dev_list_i3c_static_addr_find(const struct device *dev, uint8_t addr)
 {
 	struct i3c_device_desc *ret = NULL;
 	struct i3c_device_desc *desc;
@@ -234,8 +223,7 @@ struct i3c_device_desc *i3c_dev_list_i3c_static_addr_find(const struct device *d
 	return ret;
 }
 
-struct i3c_i2c_device_desc *i3c_dev_list_i2c_addr_find(const struct device *dev,
-							   uint16_t addr)
+struct i3c_i2c_device_desc *i3c_dev_list_i2c_addr_find(const struct device *dev, uint16_t addr)
 {
 	struct i3c_i2c_device_desc *ret = NULL;
 	struct i3c_i2c_device_desc *desc;
@@ -401,8 +389,8 @@ int i3c_detach_i2c_device(struct i3c_i2c_device_desc *target)
 	return status;
 }
 
-int i3c_sec_get_basic_info(const struct device *dev,
-	uint8_t dynamic_addr, uint8_t static_addr, uint8_t bcr, uint8_t dcr)
+int i3c_sec_get_basic_info(const struct device *dev, uint8_t dynamic_addr, uint8_t static_addr,
+			   uint8_t bcr, uint8_t dcr)
 {
 	struct i3c_ccc_getpid getpid;
 	struct i3c_device_desc temp_desc;
@@ -532,10 +520,9 @@ void i3c_sec_handoffed(struct k_work *work)
 	cur_dyn_addr = config_target.dynamic_addr;
 
 	/* Attach the previous AC */
-	ret = i3c_sec_get_basic_info(dev, deftgts->active_controller.addr,
-				deftgts->active_controller.static_addr,
-				deftgts->active_controller.bcr,
-				deftgts->active_controller.dcr);
+	ret = i3c_sec_get_basic_info(
+		dev, deftgts->active_controller.addr, deftgts->active_controller.static_addr,
+		deftgts->active_controller.bcr, deftgts->active_controller.dcr);
 
 	/* Attach all Targets */
 	for (n = 0; n < deftgts->count; n++) {
@@ -543,13 +530,14 @@ void i3c_sec_handoffed(struct k_work *work)
 			/* Must be an I3C device and skip itself */
 			if (deftgts->targets[n].addr != cur_dyn_addr) {
 				ret = i3c_sec_get_basic_info(dev, deftgts->targets[n].addr,
-					deftgts->targets[n].static_addr, deftgts->targets[n].bcr,
-					deftgts->targets[n].dcr);
+							     deftgts->targets[n].static_addr,
+							     deftgts->targets[n].bcr,
+							     deftgts->targets[n].dcr);
 			}
 		} else {
 			/* Must be an I2C device */
 			ret = i3c_sec_i2c_attach(dev, deftgts->targets[n].static_addr,
-				deftgts->targets[n].lvr);
+						 deftgts->targets[n].lvr);
 		}
 	}
 
@@ -559,11 +547,8 @@ void i3c_sec_handoffed(struct k_work *work)
 #endif
 
 int i3c_dev_list_daa_addr_helper(struct i3c_addr_slots *addr_slots,
-				 const struct i3c_dev_list *dev_list,
-				 uint64_t pid, bool must_match,
-				 bool assigned_okay,
-				 struct i3c_device_desc **target,
-				 uint8_t *addr)
+				 const struct i3c_dev_list *dev_list, uint64_t pid, bool must_match,
+				 bool assigned_okay, struct i3c_device_desc **target, uint8_t *addr)
 {
 	struct i3c_device_desc *desc;
 	const uint16_t vendor_id = (uint16_t)(pid >> 32);
@@ -584,8 +569,7 @@ int i3c_dev_list_daa_addr_helper(struct i3c_addr_slots *addr_slots,
 		 */
 		ret = -ENODEV;
 
-		LOG_DBG("PID 0x%04x%08x is not in registered device list",
-			vendor_id, part_no);
+		LOG_DBG("PID 0x%04x%08x is not in registered device list", vendor_id, part_no);
 
 		goto out;
 	}
@@ -818,7 +802,7 @@ int i3c_device_adv_info_get(struct i3c_device_desc *target)
 
 	/* CRCAPS */
 	if ((target->getcaps.getcap3 & I3C_CCC_GETCAPS3_GETCAPS_DEFINING_BYTE_SUPPORT) &&
-		    (i3c_device_is_controller_capable(target))) {
+	    (i3c_device_is_controller_capable(target))) {
 		ret = i3c_ccc_do_getcaps_fmt2(target, &caps, GETCAPS_FORMAT_2_CRCAPS);
 		if (ret != 0) {
 			return ret;
@@ -860,8 +844,7 @@ int i3c_device_adv_info_get(struct i3c_device_desc *target)
  *
  * @retval 0 if successful.
  */
-static int i3c_bus_setdasa(const struct device *dev,
-			   const struct i3c_dev_list *dev_list,
+static int i3c_bus_setdasa(const struct device *dev, const struct i3c_dev_list *dev_list,
 			   bool *need_daa, bool *need_aasa)
 {
 	int i, ret;
@@ -890,7 +873,7 @@ static int i3c_bus_setdasa(const struct device *dev,
 		 * is not requested
 		 */
 		if ((desc->supports_setaasa) && ((desc->init_dynamic_addr == 0) ||
-					       desc->init_dynamic_addr == desc->static_addr)) {
+						 desc->init_dynamic_addr == desc->static_addr)) {
 			*need_aasa = true;
 			continue;
 		}
@@ -902,9 +885,9 @@ static int i3c_bus_setdasa(const struct device *dev,
 		 * if configured
 		 */
 		if ((desc->init_dynamic_addr != 0) &&
-			(desc->init_dynamic_addr != desc->static_addr)) {
+		    (desc->init_dynamic_addr != desc->static_addr)) {
 			if (!i3c_addr_slots_is_free(&bus_data->attached_dev.addr_slots,
-				desc->init_dynamic_addr)) {
+						    desc->init_dynamic_addr)) {
 				if (i3c_detach_i3c_device(desc) != 0) {
 					LOG_ERR("Failed to detach %s", desc->dev->name);
 				}
@@ -916,8 +899,9 @@ static int i3c_bus_setdasa(const struct device *dev,
 		 * Note that the 7-bit address needs to start at bit 1
 		 * (aka left-justified). So shift left by 1;
 		 */
-		dyn_addr.addr = (desc->init_dynamic_addr ?
-					desc->init_dynamic_addr : desc->static_addr) << 1;
+		dyn_addr.addr =
+			(desc->init_dynamic_addr ? desc->init_dynamic_addr : desc->static_addr)
+			<< 1;
 
 		ret = i3c_ccc_do_setdasa(desc, dyn_addr);
 		if (ret == 0) {
@@ -932,8 +916,7 @@ static int i3c_bus_setdasa(const struct device *dev,
 			if (i3c_detach_i3c_device(desc) != 0) {
 				LOG_ERR("Failed to detach %s (%d)", desc->dev->name, ret);
 			}
-			LOG_ERR("SETDASA error on address 0x%x (%d)",
-				desc->static_addr, ret);
+			LOG_ERR("SETDASA error on address 0x%x (%d)", desc->static_addr, ret);
 		}
 	}
 
@@ -964,9 +947,8 @@ int i3c_bus_deftgts(const struct device *dev)
 	uint8_t n = 0;
 	size_t num_of_targets = sys_slist_len(&data->attached_dev.devices.i3c) +
 				sys_slist_len(&data->attached_dev.devices.i2c);
-	size_t data_len = sizeof(uint8_t) +
-				   sizeof(struct i3c_ccc_deftgts_active_controller) +
-				   (num_of_targets * sizeof(struct i3c_ccc_deftgts_target));
+	size_t data_len = sizeof(uint8_t) + sizeof(struct i3c_ccc_deftgts_active_controller) +
+			  (num_of_targets * sizeof(struct i3c_ccc_deftgts_target));
 
 	/*
 	 * Retrieve the active controller information
@@ -1144,13 +1126,11 @@ int i3c_bus_init(const struct device *dev, const struct i3c_dev_list *dev_list)
 		ret = (desc->static_addr == 0) ? i3c_device_adv_info_get(desc)
 					       : i3c_device_info_get(desc);
 		if (ret != 0) {
-			LOG_ERR("Error getting device info for 0x%02x",
-				desc->static_addr);
+			LOG_ERR("Error getting device info for 0x%02x", desc->static_addr);
 		} else {
 			LOG_DBG("Target 0x%02x, BCR 0x%02x, DCR 0x%02x, MRL %d, MWL %d, IBI %d",
-				desc->dynamic_addr, desc->bcr, desc->dcr,
-				desc->data_length.mrl, desc->data_length.mwl,
-				desc->data_length.max_ibi);
+				desc->dynamic_addr, desc->bcr, desc->dcr, desc->data_length.mrl,
+				desc->data_length.mwl, desc->data_length.max_ibi);
 		}
 	}
 

--- a/drivers/i3c/i3c_common.c
+++ b/drivers/i3c/i3c_common.c
@@ -511,7 +511,7 @@ void i3c_sec_handoffed(struct k_work *work)
 	/*
 	 * Retrieve the active controller information
 	 */
-	ret = i3c_config_get(dev, I3C_CONFIG_TARGET, &config_target);
+	ret = i3c_config_get_target(dev, &config_target);
 	if (ret != 0) {
 		LOG_ERR("Failed to retrieve active controller info");
 		return;

--- a/drivers/i3c/i3c_dw.c
+++ b/drivers/i3c/i3c_dw.c
@@ -2001,9 +2001,9 @@ static int dw_i3c_config_get(const struct device *dev, enum i3c_config_type type
 
 		if (!(sys_read32(dev_config->regs + PRESENT_STATE) &
 		      PRESENT_STATE_CURRENT_MASTER)) {
-			target_config->enable = true;
+			target_config->enabled = true;
 		} else {
-			target_config->enable = false;
+			target_config->enabled = false;
 		}
 	} else {
 		return -EINVAL;

--- a/include/zephyr/drivers/i3c.h
+++ b/include/zephyr/drivers/i3c.h
@@ -573,7 +573,7 @@ __subsystem struct i3c_driver_api {
 	 * @return See i3c_attach_i3c_device()
 	 */
 	int (*attach_i3c_device)(const struct device *dev,
-			struct i3c_device_desc *target);
+				 struct i3c_device_desc *target);
 
 	/**
 	 * I3C Address Update
@@ -589,8 +589,8 @@ __subsystem struct i3c_driver_api {
 	 * @return See i3c_reattach_i3c_device()
 	 */
 	int (*reattach_i3c_device)(const struct device *dev,
-			struct i3c_device_desc *target,
-			uint8_t old_dyn_addr);
+				   struct i3c_device_desc *target,
+				   uint8_t old_dyn_addr);
 
 	/**
 	 * I3C Device Detach
@@ -605,7 +605,7 @@ __subsystem struct i3c_driver_api {
 	 * @return See i3c_detach_i3c_device()
 	 */
 	int (*detach_i3c_device)(const struct device *dev,
-			struct i3c_device_desc *target);
+				 struct i3c_device_desc *target);
 
 	/**
 	 * I2C Device Attach
@@ -620,7 +620,7 @@ __subsystem struct i3c_driver_api {
 	 * @return See i3c_attach_i2c_device()
 	 */
 	int (*attach_i2c_device)(const struct device *dev,
-			struct i3c_i2c_device_desc *target);
+				 struct i3c_i2c_device_desc *target);
 
 	/**
 	 * I2C Device Detach
@@ -635,7 +635,7 @@ __subsystem struct i3c_driver_api {
 	 * @return See i3c_detach_i2c_device()
 	 */
 	int (*detach_i2c_device)(const struct device *dev,
-			struct i3c_i2c_device_desc *target);
+				 struct i3c_i2c_device_desc *target);
 
 	/**
 	 * Perform Dynamic Address Assignment via ENTDAA.
@@ -809,7 +809,7 @@ __subsystem struct i3c_driver_api {
 	 * @return See i3c_target_tx_write()
 	 */
 	int (*target_tx_write)(const struct device *dev,
-				 uint8_t *buf, uint16_t len, uint8_t hdr_mode);
+			       uint8_t *buf, uint16_t len, uint8_t hdr_mode);
 
 	/**
 	 * ACK or NACK controller handoffs
@@ -827,7 +827,7 @@ __subsystem struct i3c_driver_api {
 	 * @return See i3c_target_controller_handoff()
 	 */
 	int (*target_controller_handoff)(const struct device *dev,
-				      bool accept);
+					 bool accept);
 
 #ifdef CONFIG_I3C_RTIO
 	/**
@@ -841,7 +841,7 @@ __subsystem struct i3c_driver_api {
 	 * @return See i3c_iodev_submit()
 	 */
 	void (*iodev_submit)(const struct device *dev,
-				 struct rtio_iodev_sqe *iodev_sqe);
+			     struct rtio_iodev_sqe *iodev_sqe);
 #endif
 };
 
@@ -1291,7 +1291,7 @@ struct i3c_device_desc *i3c_dev_list_i3c_static_addr_find(const struct device *d
  *         `NULL` if none is found.
  */
 struct i3c_i2c_device_desc *i3c_dev_list_i2c_addr_find(const struct device *dev,
-							   uint16_t addr);
+						       uint16_t addr);
 
 /**
  * @brief Helper function to find a usable address during ENTDAA.

--- a/include/zephyr/drivers/i3c.h
+++ b/include/zephyr/drivers/i3c.h
@@ -503,6 +503,7 @@ struct i3c_device_desc;
 struct i3c_device_id;
 struct i3c_i2c_device_desc;
 struct i3c_target_config;
+struct i3c_config_target;
 
 __subsystem struct i3c_driver_api {
 	/**
@@ -895,7 +896,6 @@ struct i3c_device_desc {
 	const struct device * const dev;
 
 	/** Device Provisioned ID */
-	/* TODO: bring back the bitfield */
 	const uint64_t pid;
 
 	/**
@@ -1378,6 +1378,48 @@ static inline int i3c_configure(const struct device *dev,
 }
 
 /**
+ * @brief Get the controller device configuration for an I3C device.
+ *
+ * This function retrieves the configuration parameters specific to an
+ * I3C controller device. It is a type-safe wrapper around @ref i3c_config_get
+ * that ensures the correct structure type is passed.
+ *
+ * @param dev Pointer to the I3C controller device instance.
+ * @param config Pointer to a @ref i3c_config_controller structure
+ *               where the configuration will be stored.
+ *
+ * @retval 0 If successful.
+ * @retval -EIO General Input/Output errors.
+ * @retval -ENOSYS If not implemented.
+ */
+static inline int i3c_configure_controller(const struct device *dev,
+					   struct i3c_config_controller *config)
+{
+	return i3c_configure(dev, I3C_CONFIG_CONTROLLER, config);
+}
+
+/**
+ * @brief Get the target device configuration for an I3C device.
+ *
+ * This function retrieves the configuration parameters specific to an
+ * I3C target device. It is a type-safe wrapper around @ref i3c_config_get
+ * that ensures the correct structure type is passed.
+ *
+ * @param dev Pointer to the I3C controller device instance.
+ * @param config Pointer to a @ref i3c_config_target structure
+ *                    where the configuration will be stored.
+ *
+ * @retval 0 If successful.
+ * @retval -EIO General Input/Output errors.
+ * @retval -ENOSYS If not implemented.
+ */
+static inline int i3c_configure_target(const struct device *dev,
+				       struct i3c_config_target *config)
+{
+	return i3c_configure(dev, I3C_CONFIG_TARGET, config);
+}
+
+/**
  * @brief Get configuration of the I3C hardware.
  *
  * This provides a way to get the current configuration of the I3C hardware.
@@ -1408,6 +1450,48 @@ static inline int i3c_config_get(const struct device *dev,
 	}
 
 	return api->config_get(dev, type, config);
+}
+
+/**
+ * @brief Get the controller device configuration for an I3C device.
+ *
+ * This function sets the configuration parameters specific to an
+ * I3C controller device. It is a type-safe wrapper around @ref i3c_config_get
+ * that ensures the correct structure type is passed.
+ *
+ * @param[in] dev Pointer to the I3C controller device instance.
+ * @param[out] config Pointer to a @ref i3c_config_controller structure
+ *                    where the configuration will be used.
+ *
+ * @retval 0 If successful.
+ * @retval -EIO General Input/Output errors.
+ * @retval -ENOSYS If not implemented.
+ */
+static inline int i3c_config_get_controller(const struct device *dev,
+					    struct i3c_config_controller *config)
+{
+	return i3c_config_get(dev, I3C_CONFIG_CONTROLLER, config);
+}
+
+/**
+ * @brief Get the target device configuration for an I3C device.
+ *
+ * This function sets the configuration parameters specific to an
+ * I3C target device. It is a type-safe wrapper around @ref i3c_config_get
+ * that ensures the correct structure type is passed.
+ *
+ * @param[in] dev Pointer to the I3C controller device instance.
+ * @param[out] config Pointer to a @ref i3c_config_target structure
+ *                    where the configuration will be used.
+ *
+ * @retval 0 If successful.
+ * @retval -EIO General Input/Output errors.
+ * @retval -ENOSYS If not implemented.
+ */
+static inline int i3c_config_get_target(const struct device *dev,
+					struct i3c_config_target *config)
+{
+	return i3c_config_get(dev, I3C_CONFIG_TARGET, config);
 }
 
 /**

--- a/include/zephyr/drivers/i3c/target_device.h
+++ b/include/zephyr/drivers/i3c/target_device.h
@@ -31,27 +31,30 @@ struct i3c_driver_api;
  * @brief Configuration parameters for I3C hardware to act as target device.
  *
  * This can also be used to configure the controller if it is to act as
- * a secondary controller on the bus.
+ * a target on the bus.
  */
 struct i3c_config_target {
 	/**
-	 * If the hardware is to act as a target device
+	 * If the hardware is currently acting as a target device
 	 * on the bus.
 	 */
-	bool enable;
+	bool enabled;
 
 	/**
 	 * I3C target dynamic address.
 	 *
-	 * Used when operates as secondary controller
-	 * or as a target device.
+	 * Currently assigned dynamic address. 0 if no address
+	 * assigned.
+	 *
+	 * @note Only writeable if the hardware acts as a primary
+	 *       controller
 	 */
 	uint8_t dynamic_addr;
 
 	/**
 	 * I3C target static address.
 	 *
-	 * Used used when operates as secondary controller
+	 * Used used when operating as a secondary controller
 	 * or as a target device.
 	 */
 	uint8_t static_addr;
@@ -81,9 +84,6 @@ struct i3c_config_target {
 
 	/**
 	 * Bit mask of supported HDR modes (0 - 7).
-	 *
-	 * This can be used to enable or disable HDR mode
-	 * supported by the hardware at runtime.
 	 */
 	uint8_t supported_hdr;
 };


### PR DESCRIPTION
It shouldn't be possible to just  'enable' target mode of a device.
It is required by the specification to perform a handoff or request to
become a target or controller from the active controller. Not to just flip
a switch internally. change the parameter from `enable` to `enabled` to report
if it is currently a target or a controller otherwise.

Also, add inline helpers for `i3c_config_get` and `i3c_configure` to ensure
the proper struct is passed in.

Signed-off-by: Ryan McClelland <ryanmcclelland@meta.com>