### PR TITLE
Bluetooth: AICS: Add enum for BT_AICS_INPUT_TYPE_

### DIFF
--- a/doc/releases/migration-guide-4.1.rst
+++ b/doc/releases/migration-guide-4.1.rst
@@ -605,6 +605,10 @@ Bluetooth Audio
   depend on :kconfig:option:`CONFIG_BT_SMP` and may need to be explicitly enabled.
   (:github:`84994``)
 
+* ``bt_aics_register_param.type`` and ``bt_aics_type_cb`` now uses
+  :c:enumerator:`bt_aics_input_type` as the type for the input type, and uses of these will need to
+  use ``enum bt_aics_input_type`` instead of ``uint8_t``. (:github:`85772`)
+
 Bluetooth Classic
 =================
 

--- a/include/zephyr/bluetooth/audio/aics.h
+++ b/include/zephyr/bluetooth/audio/aics.h
@@ -4,7 +4,7 @@
  */
 
 /*
- * Copyright (c) 2020-2024 Nordic Semiconductor ASA
+ * Copyright (c) 2020-2025 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -85,26 +85,26 @@ extern "C" {
 /** @} */
 
 /**
- * @name Audio Input Control Service input types
- * @{
+ * Audio Input Control Service input types
  */
-/** The input is unspecified */
-#define BT_AICS_INPUT_TYPE_UNSPECIFIED             0x00
-/** The input is a Bluetooth Audio Stream */
-#define BT_AICS_INPUT_TYPE_BLUETOOTH               0x01
-/** The input is a microphone */
-#define BT_AICS_INPUT_TYPE_MICROPHONE              0x02
-/** The input is analog */
-#define BT_AICS_INPUT_TYPE_ANALOG                  0x03
-/** The input is digital */
-#define BT_AICS_INPUT_TYPE_DIGITAL                 0x04
-/** The input is a radio (AM/FM/XM/etc.) */
-#define BT_AICS_INPUT_TYPE_RADIO                   0x05
-/** The input is a Streaming Audio Source */
-#define BT_AICS_INPUT_TYPE_STREAMING               0x06
-/** The input is transparent / pass-through */
-#define BT_AICS_INPUT_TYPE_AMBIENT                 0x07
-/** @} */
+enum bt_aics_input_type {
+	/** The input is unspecified */
+	BT_AICS_INPUT_TYPE_UNSPECIFIED = 0x00,
+	/** The input is a Bluetooth Audio Stream */
+	BT_AICS_INPUT_TYPE_BLUETOOTH = 0x01,
+	/** The input is a microphone */
+	BT_AICS_INPUT_TYPE_MICROPHONE = 0x02,
+	/** The input is analog */
+	BT_AICS_INPUT_TYPE_ANALOG = 0x03,
+	/** The input is digital */
+	BT_AICS_INPUT_TYPE_DIGITAL = 0x04,
+	/** The input is a radio (AM/FM/XM/etc.) */
+	BT_AICS_INPUT_TYPE_RADIO = 0x05,
+	/** The input is a Streaming Audio Source */
+	BT_AICS_INPUT_TYPE_STREAMING = 0x06,
+	/** The input is transparent / pass-through */
+	BT_AICS_INPUT_TYPE_AMBIENT = 0x07,
+};
 
 /**
  * @name Audio Input Control Service Error codes
@@ -149,7 +149,7 @@ struct bt_aics_register_param {
 	int8_t max_gain;
 
 	/** Initial audio input type */
-	uint8_t type;
+	enum bt_aics_input_type type;
 
 	/** Initial audio input status (active/inactive) */
 	bool status;
@@ -275,9 +275,9 @@ typedef void (*bt_aics_gain_setting_cb)(struct bt_aics *inst, int err,
  * @param err          Error value. 0 on success, GATT error on positive value
  *                     or errno on negative value.
  *                     For notifications, this will always be 0.
- * @param type   The input type.
+ * @param type         The input type.
  */
-typedef void (*bt_aics_type_cb)(struct bt_aics *inst, int err, uint8_t type);
+typedef void (*bt_aics_type_cb)(struct bt_aics *inst, int err, enum bt_aics_input_type type);
 
 /**
  * @brief Callback function for the input status.

--- a/samples/bluetooth/hap_ha/src/micp_mic_dev.c
+++ b/samples/bluetooth/hap_ha/src/micp_mic_dev.c
@@ -53,12 +53,13 @@ static void micp_mic_dev_aics_gain_setting_cb(struct bt_aics *inst, int err, uin
 	}
 
 }
-static void micp_mic_dev_aics_input_type_cb(struct bt_aics *inst, int err, uint8_t input_type)
+static void micp_mic_dev_aics_input_type_cb(struct bt_aics *inst, int err,
+					    enum bt_aics_input_type input_type)
 {
 	if (err != 0) {
 		printk("AICS input type get failed (%d) for inst %p\n", err, inst);
 	} else {
-		printk("AICS inst %p input type %u\n", inst, input_type);
+		printk("AICS inst %p input type %d\n", inst, input_type);
 	}
 
 }

--- a/samples/bluetooth/hap_ha/src/vcp_vol_renderer.c
+++ b/samples/bluetooth/hap_ha/src/vcp_vol_renderer.c
@@ -61,12 +61,12 @@ static void aics_gain_setting_cb(struct bt_aics *inst, int err, uint8_t units, i
 	}
 }
 
-static void aics_input_type_cb(struct bt_aics *inst, int err, uint8_t input_type)
+static void aics_input_type_cb(struct bt_aics *inst, int err, enum bt_aics_input_type input_type)
 {
 	if (err) {
 		printk("AICS input type get failed (%d) for inst %p\n", err, inst);
 	} else {
-		printk("AICS inst %p input type %u\n", inst, input_type);
+		printk("AICS inst %p input type %d\n", inst, input_type);
 	}
 }
 

--- a/subsys/bluetooth/audio/aics.c
+++ b/subsys/bluetooth/audio/aics.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020 Bose Corporation
- * Copyright (c) 2020 Nordic Semiconductor ASA
+ * Copyright (c) 2020-2025 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -151,11 +151,11 @@ static ssize_t read_type(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 			 void *buf, uint16_t len, uint16_t offset)
 {
 	struct bt_aics *inst = BT_AUDIO_CHRC_USER_DATA(attr);
+	const uint8_t type_u8 = (uint8_t)inst->srv.type;
 
-	LOG_DBG("%u", inst->srv.type);
+	LOG_DBG("%u", type_u8);
 
-	return bt_gatt_attr_read(conn, attr, buf, len, offset, &inst->srv.type,
-				 sizeof(inst->srv.type));
+	return bt_gatt_attr_read(conn, attr, buf, len, offset, &type_u8, sizeof(type_u8));
 }
 
 static void aics_input_status_cfg_changed(const struct bt_gatt_attr *attr,
@@ -488,7 +488,7 @@ int bt_aics_register(struct bt_aics *aics, struct bt_aics_register_param *param)
 	}
 
 	CHECKIF(param->type > BT_AICS_INPUT_TYPE_AMBIENT) {
-		LOG_DBG("Invalid AICS input type value: %u", param->type);
+		LOG_DBG("Invalid AICS input type value: %d", param->type);
 		return -EINVAL;
 	}
 

--- a/subsys/bluetooth/audio/aics_client.c
+++ b/subsys/bluetooth/audio/aics_client.c
@@ -223,8 +223,8 @@ static uint8_t aics_client_read_type_cb(struct bt_conn *conn, uint8_t err,
 					const void *data, uint16_t length)
 {
 	int cb_err = err;
-	uint8_t *type = (uint8_t *)data;
 	struct bt_aics *inst = lookup_aics_by_handle(conn, params->single.handle);
+	uint8_t type = 0;
 
 	memset(params, 0, sizeof(*params));
 
@@ -245,10 +245,11 @@ static uint8_t aics_client_read_type_cb(struct bt_conn *conn, uint8_t err,
 	}
 
 	if (data) {
-		if (length == sizeof(*type)) {
-			LOG_DBG("Type %u", *type);
+		if (length == sizeof(type)) {
+			type = ((uint8_t *)data)[0];
+			LOG_DBG("Type %u", type);
 		} else {
-			LOG_DBG("Invalid length %u (expected %zu)", length, sizeof(*type));
+			LOG_DBG("Invalid length %u (expected %zu)", length, sizeof(type));
 			cb_err = BT_ATT_ERR_INVALID_ATTRIBUTE_LEN;
 		}
 	} else {
@@ -257,7 +258,7 @@ static uint8_t aics_client_read_type_cb(struct bt_conn *conn, uint8_t err,
 	}
 
 	if (inst->cli.cb && inst->cli.cb->type) {
-		inst->cli.cb->type(inst, cb_err, *type);
+		inst->cli.cb->type(inst, cb_err, (enum bt_aics_input_type)type);
 	}
 
 	return BT_GATT_ITER_STOP;

--- a/subsys/bluetooth/audio/aics_internal.h
+++ b/subsys/bluetooth/audio/aics_internal.h
@@ -4,7 +4,7 @@
 
 /*
  * Copyright (c) 2020 Bose Corporation
- * Copyright (c) 2020 Nordic Semiconductor ASA
+ * Copyright (c) 2020-2025 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -15,6 +15,7 @@
 #include <stdint.h>
 
 #include <zephyr/autoconf.h>
+#include <zephyr/bluetooth/audio/aics.h>
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/gatt.h>
 #include <zephyr/kernel.h>
@@ -113,7 +114,7 @@ struct bt_aics_server {
 	struct bt_aics_state state;
 	struct bt_aics_gain_settings gain_settings;
 	bool initialized;
-	uint8_t type;
+	enum bt_aics_input_type type;
 	uint8_t status;
 	struct bt_aics *inst;
 	char description[BT_AICS_MAX_DESC_SIZE];

--- a/subsys/bluetooth/audio/micp_mic_ctlr.c
+++ b/subsys/bluetooth/audio/micp_mic_ctlr.c
@@ -202,7 +202,7 @@ static void micp_mic_ctlr_aics_gain_setting_cb(struct bt_aics *inst, int err, ui
 	}
 }
 
-static void micp_mic_ctlr_aics_type_cb(struct bt_aics *inst, int err, uint8_t type)
+static void micp_mic_ctlr_aics_type_cb(struct bt_aics *inst, int err, enum bt_aics_input_type type)
 {
 	struct bt_micp_mic_ctlr_cb *listener, *next;
 

--- a/subsys/bluetooth/audio/shell/micp_mic_ctlr.c
+++ b/subsys/bluetooth/audio/shell/micp_mic_ctlr.c
@@ -150,12 +150,12 @@ static void micp_mic_ctlr_aics_gain_setting_cb(struct bt_aics *inst, int err,
 }
 
 static void micp_mic_ctlr_aics_input_type_cb(struct bt_aics *inst, int err,
-					     uint8_t input_type)
+					     enum bt_aics_input_type input_type)
 {
 	if (err != 0) {
 		bt_shell_error("AICS input type get failed (%d) for inst %p", err, inst);
 	} else {
-		bt_shell_print("AICS inst %p input type %u", inst, input_type);
+		bt_shell_print("AICS inst %p input type %d", inst, input_type);
 	}
 }
 

--- a/subsys/bluetooth/audio/shell/micp_mic_dev.c
+++ b/subsys/bluetooth/audio/shell/micp_mic_dev.c
@@ -61,14 +61,13 @@ static void micp_mic_dev_aics_gain_setting_cb(struct bt_aics *inst, int err,
 	}
 }
 static void micp_mic_dev_aics_input_type_cb(struct bt_aics *inst, int err,
-					    uint8_t input_type)
+					    enum bt_aics_input_type input_type)
 {
 	if (err != 0) {
 		bt_shell_error("AICS input type get failed (%d) for inst %p",
 			       err, inst);
 	} else {
-		bt_shell_print("AICS inst %p input type %u",
-			       inst, input_type);
+		bt_shell_print("AICS inst %p input type %d", inst, input_type);
 	}
 }
 static void micp_mic_dev_aics_status_cb(struct bt_aics *inst, int err,

--- a/subsys/bluetooth/audio/shell/vcp_vol_ctlr.c
+++ b/subsys/bluetooth/audio/shell/vcp_vol_ctlr.c
@@ -198,12 +198,12 @@ static void vcs_aics_gain_setting_cb(struct bt_aics *inst, int err,
 }
 
 static void vcs_aics_input_type_cb(struct bt_aics *inst, int err,
-				   uint8_t input_type)
+				   enum bt_aics_input_type input_type)
 {
 	if (err != 0) {
 		bt_shell_error("AICS input type get failed (%d) for inst %p", err, inst);
 	} else {
-		bt_shell_print("AICS inst %p input type %u", inst, input_type);
+		bt_shell_print("AICS inst %p input type %d", inst, input_type);
 	}
 }
 

--- a/subsys/bluetooth/audio/shell/vcp_vol_rend.c
+++ b/subsys/bluetooth/audio/shell/vcp_vol_rend.c
@@ -71,15 +71,13 @@ static void aics_gain_setting_cb(struct bt_aics *inst, int err, uint8_t units,
 	}
 }
 
-static void aics_input_type_cb(struct bt_aics *inst, int err,
-			       uint8_t input_type)
+static void aics_input_type_cb(struct bt_aics *inst, int err, enum bt_aics_input_type input_type)
 {
 	if (err) {
 		bt_shell_error("AICS input type get failed (%d) for inst %p",
 			       err, inst);
 	} else {
-		bt_shell_print("AICS inst %p input type %u",
-			       inst, input_type);
+		bt_shell_print("AICS inst %p input type %d", inst, input_type);
 	}
 }
 

--- a/subsys/bluetooth/audio/vcp_vol_ctlr.c
+++ b/subsys/bluetooth/audio/vcp_vol_ctlr.c
@@ -634,7 +634,7 @@ static void vcp_vol_ctlr_aics_gain_setting_cb(struct bt_aics *inst, int err, uin
 	}
 }
 
-static void vcp_vol_ctlr_aics_type_cb(struct bt_aics *inst, int err, uint8_t type)
+static void vcp_vol_ctlr_aics_type_cb(struct bt_aics *inst, int err, enum bt_aics_input_type type)
 {
 	struct bt_vcp_vol_ctlr_cb *listener, *next;
 

--- a/tests/bluetooth/tester/src/audio/btp_aics.c
+++ b/tests/bluetooth/tester/src/audio/btp_aics.c
@@ -31,14 +31,14 @@
 #define LOG_MODULE_NAME bttester_aics
 LOG_MODULE_REGISTER(LOG_MODULE_NAME, CONFIG_BTTESTER_LOG_LEVEL);
 
-#define BT_AICS_MAX_INPUT_DESCRIPTION_SIZE 16
+#define BT_AICS_MAX_INPUT_DESCRIPTION_SIZE  16
 #define BT_AICS_MAX_OUTPUT_DESCRIPTION_SIZE 16
 
 struct btp_aics_instance aics_client_instance;
 struct btp_aics_instance aics_server_instance;
 
-static struct net_buf_simple *rx_ev_buf = NET_BUF_SIMPLE(BT_AICS_MAX_INPUT_DESCRIPTION_SIZE +
-							 sizeof(struct btp_aics_description_ev));
+static struct net_buf_simple *rx_ev_buf =
+	NET_BUF_SIMPLE(BT_AICS_MAX_INPUT_DESCRIPTION_SIZE + sizeof(struct btp_aics_description_ev));
 
 static uint8_t aics_supported_commands(const void *cmd, uint16_t cmd_len, void *rsp,
 				       uint16_t *rsp_len)
@@ -66,7 +66,7 @@ void btp_send_aics_state_ev(struct bt_conn *conn, uint8_t att_status, int8_t gai
 	tester_event(BTP_SERVICE_ID_AICS, BTP_AICS_STATE_EV, &ev, sizeof(ev));
 }
 
-void btp_send_gain_setting_properties_ev(struct bt_conn *conn,  uint8_t att_status, uint8_t units,
+void btp_send_gain_setting_properties_ev(struct bt_conn *conn, uint8_t att_status, uint8_t units,
 					 int8_t minimum, int8_t maximum)
 {
 	struct btp_gain_setting_properties_ev ev;
@@ -526,12 +526,12 @@ static void aics_gain_setting_cb(struct bt_aics *inst, int err, uint8_t units, i
 	LOG_DBG("AICS gain setting callback (%d)", err);
 }
 
-static void aics_input_type_cb(struct bt_aics *inst, int err, uint8_t input_type)
+static void aics_input_type_cb(struct bt_aics *inst, int err, enum bt_aics_input_type input_type)
 {
 	struct bt_conn *conn;
 
 	bt_aics_client_conn_get(inst, &conn);
-	btp_send_aics_input_type_event(conn, err, input_type);
+	btp_send_aics_input_type_event(conn, err, (uint8_t)input_type);
 
 	LOG_DBG("AICS input type callback (%d)", err);
 }
@@ -612,18 +612,17 @@ static void aics_set_auto_gain_cb(struct bt_aics *inst, int err)
 	LOG_DBG("AICS set automatic gain cb (%d)", err);
 }
 
-struct bt_aics_cb aics_client_cb = {
-	.state = aics_state_cb,
-	.gain_setting = aics_gain_setting_cb,
-	.type = aics_input_type_cb,
-	.status = aics_status_cb,
-	.description = aics_description_cb,
+struct bt_aics_cb aics_client_cb = {.state = aics_state_cb,
+				    .gain_setting = aics_gain_setting_cb,
+				    .type = aics_input_type_cb,
+				    .status = aics_status_cb,
+				    .description = aics_description_cb,
 #if defined(CONFIG_BT_AICS_CLIENT)
-	.set_gain = aics_set_gain_cb,
-	.unmute = aics_unmute_cb,
-	.mute = aics_mute_cb,
-	.set_manual_mode = aics_set_man_gain_cb,
-	.set_auto_mode = aics_set_auto_gain_cb
+				    .set_gain = aics_set_gain_cb,
+				    .unmute = aics_unmute_cb,
+				    .mute = aics_mute_cb,
+				    .set_manual_mode = aics_set_man_gain_cb,
+				    .set_auto_mode = aics_set_auto_gain_cb
 #endif /* CONFIG_BT_AICS_CLIENT */
 };
 

--- a/tests/bluetooth/tester/src/audio/btp_micp.c
+++ b/tests/bluetooth/tester/src/audio/btp_micp.c
@@ -367,8 +367,7 @@ static void aics_gain_setting_cb(struct bt_aics *inst, int err, uint8_t units,
 	LOG_DBG("AICS gain setting callback (%d)", err);
 }
 
-static void aics_input_type_cb(struct bt_aics *inst, int err,
-			       uint8_t input_type)
+static void aics_input_type_cb(struct bt_aics *inst, int err, enum bt_aics_input_type input_type)
 {
 	LOG_DBG("AICS input type callback (%d)", err);
 }

--- a/tests/bluetooth/tester/src/audio/btp_vcp.c
+++ b/tests/bluetooth/tester/src/audio/btp_vcp.c
@@ -437,8 +437,7 @@ static void aics_gain_setting_cb(struct bt_aics *inst, int err, uint8_t units,
 	LOG_DBG("AICS gain setting callback (%d)", err);
 }
 
-static void aics_input_type_cb(struct bt_aics *inst, int err,
-			       uint8_t input_type)
+static void aics_input_type_cb(struct bt_aics *inst, int err, enum bt_aics_input_type input_type)
 {
 	LOG_DBG("AICS input type callback (%d)", err);
 }

--- a/tests/bsim/bluetooth/audio/src/micp_mic_ctlr_test.c
+++ b/tests/bsim/bluetooth/audio/src/micp_mic_ctlr_test.c
@@ -33,7 +33,7 @@ static volatile uint8_t g_aics_count;
 static volatile int8_t g_aics_gain;
 static volatile uint8_t g_aics_input_mute;
 static volatile uint8_t g_aics_mode;
-static volatile uint8_t g_aics_input_type;
+static volatile enum bt_aics_input_type g_aics_input_type;
 static volatile uint8_t g_aics_units;
 static volatile uint8_t g_aics_gain_max;
 static volatile uint8_t g_aics_gain_min;
@@ -71,8 +71,7 @@ static void aics_gain_setting_cb(struct bt_aics *inst, int err, uint8_t units,
 	g_cb = true;
 }
 
-static void aics_input_type_cb(struct bt_aics *inst, int err,
-			       uint8_t input_type)
+static void aics_input_type_cb(struct bt_aics *inst, int err, enum bt_aics_input_type input_type)
 {
 	if (err != 0) {
 		FAIL("AICS input type cb err (%d)", err);
@@ -207,7 +206,7 @@ static int test_aics(void)
 	int8_t expected_gain;
 	uint8_t expected_input_mute;
 	uint8_t expected_mode;
-	uint8_t expected_input_type;
+	enum bt_aics_input_type expected_input_type;
 	char expected_aics_desc[AICS_DESC_SIZE];
 	struct bt_conn *cached_conn;
 

--- a/tests/bsim/bluetooth/audio/src/micp_mic_dev_test.c
+++ b/tests/bsim/bluetooth/audio/src/micp_mic_dev_test.c
@@ -34,7 +34,7 @@ static volatile uint8_t g_mute;
 static volatile int8_t g_aics_gain;
 static volatile uint8_t g_aics_input_mute;
 static volatile uint8_t g_aics_mode;
-static volatile uint8_t g_aics_input_type;
+static volatile enum bt_aics_input_type g_aics_input_type;
 static volatile uint8_t g_aics_units;
 static volatile uint8_t g_aics_gain_max;
 static volatile uint8_t g_aics_gain_min;
@@ -81,8 +81,7 @@ static void aics_gain_setting_cb(struct bt_aics *inst, int err, uint8_t units,
 	g_cb = true;
 }
 
-static void aics_input_type_cb(struct bt_aics *inst, int err,
-			       uint8_t input_type)
+static void aics_input_type_cb(struct bt_aics *inst, int err, enum bt_aics_input_type input_type)
 {
 	if (err != 0) {
 		FAIL("AICS input type cb err (%d)", err);
@@ -133,7 +132,7 @@ static int test_aics_server_only(void)
 	int8_t expected_gain;
 	uint8_t expected_input_mute;
 	uint8_t expected_mode;
-	uint8_t expected_input_type;
+	enum bt_aics_input_type expected_input_type;
 	bool expected_aics_active;
 	char expected_aics_desc[AICS_DESC_SIZE];
 

--- a/tests/bsim/bluetooth/audio/src/vcp_vol_ctlr_test.c
+++ b/tests/bsim/bluetooth/audio/src/vcp_vol_ctlr_test.c
@@ -38,7 +38,7 @@ static char g_vocs_desc[VOCS_DESC_SIZE];
 static volatile int8_t g_aics_gain;
 static volatile uint8_t g_aics_input_mute;
 static volatile uint8_t g_aics_mode;
-static volatile uint8_t g_aics_input_type;
+static volatile enum bt_aics_input_type g_aics_input_type;
 static volatile uint8_t g_aics_units;
 static volatile uint8_t g_aics_gain_max;
 static volatile uint8_t g_aics_gain_min;
@@ -156,8 +156,7 @@ static void aics_gain_setting_cb(struct bt_aics *inst, int err, uint8_t units,
 	g_cb = true;
 }
 
-static void aics_input_type_cb(struct bt_aics *inst, int err,
-			       uint8_t input_type)
+static void aics_input_type_cb(struct bt_aics *inst, int err, enum bt_aics_input_type input_type)
 {
 	if (err != 0) {
 		FAIL("AICS input type cb err (%d)", err);
@@ -323,7 +322,7 @@ static void aics_gain_setting_get(void)
 
 static void aics_type_get(void)
 {
-	const uint8_t expected_input_type = BT_AICS_INPUT_TYPE_DIGITAL;
+	const enum bt_aics_input_type expected_input_type = BT_AICS_INPUT_TYPE_DIGITAL;
 	int err;
 
 	/* Invalid behavior */

--- a/tests/bsim/bluetooth/audio/src/vcp_vol_rend_test.c
+++ b/tests/bsim/bluetooth/audio/src/vcp_vol_rend_test.c
@@ -47,7 +47,7 @@ static char g_vocs_desc[VOCS_DESC_SIZE];
 static volatile int8_t g_aics_gain;
 static volatile uint8_t g_aics_input_mute;
 static volatile uint8_t g_aics_mode;
-static volatile uint8_t g_aics_input_type;
+static volatile enum bt_aics_input_type g_aics_input_type;
 static volatile uint8_t g_aics_units;
 static volatile uint8_t g_aics_gain_max;
 static volatile uint8_t g_aics_gain_min;
@@ -141,8 +141,7 @@ static void aics_gain_setting_cb(struct bt_aics *inst, int err, uint8_t units,
 	g_cb = true;
 }
 
-static void aics_input_type_cb(struct bt_aics *inst, int err,
-			       uint8_t input_type)
+static void aics_input_type_cb(struct bt_aics *inst, int err, enum bt_aics_input_type input_type)
 {
 	if (err != 0) {
 		FAIL("AICS input type cb err (%d)", err);
@@ -296,7 +295,7 @@ static void aics_gain_setting_get(void)
 
 static void aics_type_get(void)
 {
-	const uint8_t expected_input_type = BT_AICS_INPUT_TYPE_DIGITAL;
+	const enum bt_aics_input_type expected_input_type = BT_AICS_INPUT_TYPE_DIGITAL;
 	int err;
 
 	/* Invalid behavior */


### PR DESCRIPTION
Using a enum makes it easier to document and refer to the
possible values.