### PR TITLE
net: coap_client: Stop all socket activities when cancelling requests

### DIFF
--- a/include/zephyr/net/coap_client.h
+++ b/include/zephyr/net/coap_client.h
@@ -157,6 +157,8 @@ int coap_client_req(struct coap_client *client, int sock, const struct sockaddr 
  *
  * This is intended for canceling long-running requests (e.g. GETs with the OBSERVE option set)
  * which has gone stale for some reason.
+ * The function should also be called before the corresponding client socket is closed,
+ * to prevent the socket from being monitored by the internal polling thread.
  *
  * @param client Client instance.
  */

--- a/samples/net/sockets/coap_download/src/main.c
+++ b/samples/net/sockets/coap_download/src/main.c
@@ -82,6 +82,8 @@ static void do_coap_download(struct sockaddr *sa)
 	/* Wait for CoAP request to complete */
 	k_sem_take(&coap_done_sem, K_FOREVER);
 
+	coap_client_cancel_requests(&client);
+
 	zsock_close(sockfd);
 }
 

--- a/subsys/net/lib/coap/coap_client.c
+++ b/subsys/net/lib/coap/coap_client.c
@@ -1013,14 +1013,12 @@ static void cancel_requests_with(struct coap_client *client, int error)
 			 * request was cancelled anyway.
 			 */
 			report_callback_error(&client->requests[i], error);
-			release_internal_request(&client->requests[i]);
 		}
-		/* If our socket has failed, clear all requests, even completed ones,
-		 * so that our handle_poll() does not poll() anymore for this socket.
+
+		/* Clear all requests, even completed ones, so that our
+		 * handle_poll() does not poll() anymore for this socket.
 		 */
-		if (error == -EIO) {
-			reset_internal_request(&client->requests[i]);
-		}
+		reset_internal_request(&client->requests[i]);
 	}
 	k_mutex_unlock(&client->lock);
 


### PR DESCRIPTION
Calling `coap_client_cancel_requests()` clears the internal request context only for active requests (i. e. not replied yet). However,
if there are any pending request context monitoring ACK duplicates, those would still make the corresponding client socket being monitored by poll(). In result, when application closes the socket, the polling thread will throw POLLNVAL error for the socket.

Fix this, by resetting all request contexts unconditionally. The request callback will only be called for the active requests.

Note for reviewers - as an alternative I've considered introducing new coap_client API function to cleanup the client context before closing the socket. I figured however modifying `coap_client_cancel_requests()` will be less invasive way to prevent those POLLNVAL errors - the function is likely called anyway before closing the socket. I'm open for alternatives though.

Fixes #85766