### PR TITLE
drivers: adc: Fix Vref selection for nRF54L20pdk

### DIFF
--- a/boards/nordic/nrf54l20pdk/nrf54l20pdk_nrf54l20_cpuapp.yaml
+++ b/boards/nordic/nrf54l20pdk/nrf54l20pdk_nrf54l20_cpuapp.yaml
@@ -12,6 +12,7 @@ sysbuild: true
 ram: 512
 flash: 449
 supported:
+  - adc
   - counter
   - gpio
   - i2c

--- a/drivers/adc/adc_nrfx_saadc.c
+++ b/drivers/adc/adc_nrfx_saadc.c
@@ -672,7 +672,7 @@ static DEVICE_API(adc, adc_nrfx_driver_api) = {
 #ifdef CONFIG_ADC_ASYNC
 	.read_async    = adc_nrfx_read_async,
 #endif
-#if defined(CONFIG_SOC_NRF54L05) || defined(CONFIG_SOC_NRF54L10) ||  defined(CONFIG_SOC_NRF54L15)
+#if defined(CONFIG_SOC_COMPATIBLE_NRF54LX)
 	.ref_internal  = 900,
 #elif defined(CONFIG_NRF_PLATFORM_HALTIUM)
 	.ref_internal  = 1024,


### PR DESCRIPTION
Select Reference voltage of 900mV for ADC on nRF54L20pdk.

Add ADC to the list of supported peripherals.

This is a continuation of
https://github.com/zephyrproject-rtos/zephyr/commit/f78742ff752c302da1016c2bfb95d4824ea9460a