### PR TITLE
scripts: ci: check_compliance: Fix paths for disallowed Kconfigs

### DIFF
--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -715,10 +715,10 @@ class KconfigCheck(ComplianceTest):
 
         grep_stdout_boards = git("grep", "--line-number", "-I", "--null",
                                  "--perl-regexp", regex_boards, "--", ":boards",
-                                 cwd=Path(GIT_TOP))
+                                 cwd=ZEPHYR_BASE)
         grep_stdout_socs = git("grep", "--line-number", "-I", "--null",
                                "--perl-regexp", regex_socs, "--", ":soc",
-                               cwd=Path(GIT_TOP))
+                               cwd=ZEPHYR_BASE)
 
         # Board processing
         # splitlines() supports various line terminators


### PR DESCRIPTION
Fixes using the wrong path for checking if disallowed Kconfigs are present, to use the zephyr base instead of the git top level folder which caused issues for downstream manifests

Fixes #85783