### PR TITLE
drivers: gpio: extend max14916 to max14915

### DIFF
--- a/drivers/gpio/Kconfig.max14916
+++ b/drivers/gpio/Kconfig.max14916
@@ -7,7 +7,7 @@
 menuconfig GPIO_MAX14916
 	bool "MAX14916 GPIO driver"
 	default y
-	depends on DT_HAS_ADI_MAX14916_GPIO_ENABLED && SPI
+	depends on (DT_HAS_ADI_MAX14916_GPIO_ENABLED || DT_HAS_ADI_MAX14915_GPIO_ENABLED) && SPI
 	help
 	  Enabe MAX1416 octal industrial digital
 	  output with diagnostics

--- a/drivers/gpio/gpio_max14916.c
+++ b/drivers/gpio/gpio_max14916.c
@@ -20,8 +20,6 @@ LOG_MODULE_REGISTER(gpio_max14916);
 #include "gpio_max14916.h"
 #include "gpio_max149x6.h"
 
-#define DT_DRV_COMPAT adi_max14916_gpio
-
 static int gpio_max14916_diag_chan_get(const struct device *dev);
 
 static int max14916_pars_spi_diag(const struct device *dev, uint8_t *rx_diag_buff, uint8_t rw)
@@ -367,8 +365,8 @@ static DEVICE_API(gpio, gpio_max14916_api) = {
 	.port_toggle_bits = gpio_max14916_port_toggle_bits,
 };
 
-#define GPIO_MAX14906_DEVICE(id)                                                                   \
-	static const struct max14916_config max14916_##id##_cfg = {                                \
+#define GPIO_MAX14906_DEVICE(id, model)                                                            \
+	static const struct max14916_config max##model##_##id##_cfg = {                            \
 		.spi = SPI_DT_SPEC_INST_GET(id, SPI_OP_MODE_MASTER | SPI_WORD_SET(8U), 0U),        \
 		.ready_gpio = GPIO_DT_SPEC_INST_GET(id, drdy_gpios),                               \
 		.fault_gpio = GPIO_DT_SPEC_INST_GET(id, fault_gpios),                              \
@@ -391,10 +389,16 @@ static DEVICE_API(gpio, gpio_max14916_api) = {
 		.spi_addr = DT_INST_PROP(id, spi_addr),                                            \
 	};                                                                                         \
                                                                                                    \
-	static struct max14916_data max14916_##id##_data;                                          \
+	static struct max14916_data max##model##_##id##_data;                                      \
                                                                                                    \
-	DEVICE_DT_INST_DEFINE(id, &gpio_max14916_init, NULL, &max14916_##id##_data,                \
-			      &max14916_##id##_cfg, POST_KERNEL,                                   \
+	DEVICE_DT_INST_DEFINE(id, &gpio_max14916_init, NULL, &max##model##_##id##_data,            \
+			      &max##model##_##id##_cfg, POST_KERNEL,                               \
 			      CONFIG_GPIO_MAX14916_INIT_PRIORITY, &gpio_max14916_api);
 
-DT_INST_FOREACH_STATUS_OKAY(GPIO_MAX14906_DEVICE)
+#undef DT_DRV_COMPAT
+#define DT_DRV_COMPAT adi_max14915_gpio
+DT_INST_FOREACH_STATUS_OKAY_VARGS(GPIO_MAX14906_DEVICE, 14915)
+
+#undef DT_DRV_COMPAT
+#define DT_DRV_COMPAT adi_max14916_gpio
+DT_INST_FOREACH_STATUS_OKAY_VARGS(GPIO_MAX14906_DEVICE, 14916)

--- a/dts/bindings/gpio/adi,max14915-gpio.yaml
+++ b/dts/bindings/gpio/adi,max14915-gpio.yaml
@@ -1,0 +1,64 @@
+# Copyright (c) 2025 Analog Devices Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  ADI MAX14915 compact industrial octal high-side switch with
+  diagnostics
+
+  https://www.analog.com/media/en/technical-documentation/data-sheets/MAX14915.pdf
+
+  Example:
+
+  max14915: max14915@0 {
+      compatible = "adi,max14915-gpio";
+      status = "okay";
+      reg = <0x00>;
+      fault-gpios = <&gpiof 13 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+      sync-gpios = <&gpioc 7 GPIO_ACTIVE_LOW>;
+      en-gpios = <&gpiob 5 GPIO_ACTIVE_LOW>;
+      drdy-gpios = <&gpioa 15 GPIO_ACTIVE_LOW>;
+      spi-max-frequency = <10000000>;
+      gpio-controller;
+      #gpio-cells = <2>;
+      ngpios = <8>;
+      crc-en;
+      spi-addr = <0>;
+      ow-on-en = <0 0 0 0 0 0 0 0>;
+      ow-off-en = <0 0 0 0 0 0 0 0>;
+      sh-vdd-en = <0 0 0 0 0 0 0 0>;
+      /* Config Reg 1 */
+      fled-set;
+      sled-set;
+      fled-stretch = <3>;
+      ffilter-en;
+      filter-long;
+      flatch-en;
+      led-cur-lim;
+      /* Config Reg 2 */
+      vdd-on-thr;
+      synch-wd-en;
+      sht-vdd-thr = <3>;
+      ow-off-cs = <3>;
+      wd-to = <0>;
+    };
+
+compatible: "adi,max14915-gpio"
+
+properties:
+  wd-to:
+    type: int
+    default: 0
+    enum:
+      - 0
+      - 1
+      - 2
+      - 3
+    description: |
+      Default value according to documentation.
+      Set SPI and SYNCH Watchdog Timeout
+      0: Disable SPI Watchdog and set SYNCH Watchdog Timeout to 600ms (typ)
+      1: Set SPI and SYNCH Watchdog Timeout to 200ms (typ)
+      2: Set SPI and SYNCH Watchdog Timeout to 600ms (typ)
+      3: Set SPI and SYNCH Watchdog Timeout to 1.2s (typ)
+
+include: adi,max14916-gpio.yaml

--- a/tests/drivers/build_all/gpio/app.overlay
+++ b/tests/drivers/build_all/gpio/app.overlay
@@ -610,6 +610,22 @@
 					#gpio-cells = <2>;
 				};
 			};
+
+			test_max14915: max14915@c {
+				compatible = "adi,max14915-gpio";
+				status = "okay";
+				reg = <0x0c>;
+				spi-max-frequency = <0>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				ngpios = <8>;
+				crc-en;
+				spi-addr = <0>;
+				drdy-gpios = <&test_gpio 0 0>;
+				fault-gpios = <&test_gpio 0 0>;
+				sync-gpios = <&test_gpio 0 0>;
+				en-gpios = <&test_gpio 0 0>;
+			};
 		};
 	};
 };


### PR DESCRIPTION
The MAX14915 has eight high-side switches specified to deliver up to 700mA continuous current with simlary register map and diagnostics parameters to MAX14916.

Documentation:
https://www.analog.com/en/products/max14915.html