### PR TITLE
Fix check compliance

### DIFF
--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -664,7 +664,7 @@ class KconfigCheck(ComplianceTest):
 
         # Grep samples/ and tests/ for symbol definitions
         grep_stdout = git("grep", "-I", "-h", "--perl-regexp", regex, "--",
-                          ":samples", ":tests", cwd=ZEPHYR_BASE)
+                          ":samples", ":tests", cwd=ZEPHYR_BASE, ignore_non_zero=True)
 
         names = re.findall(regex, grep_stdout, re.MULTILINE)
 
@@ -715,10 +715,10 @@ class KconfigCheck(ComplianceTest):
 
         grep_stdout_boards = git("grep", "--line-number", "-I", "--null",
                                  "--perl-regexp", regex_boards, "--", ":boards",
-                                 cwd=Path(GIT_TOP))
+                                 cwd=Path(GIT_TOP), ignore_non_zero=True)
         grep_stdout_socs = git("grep", "--line-number", "-I", "--null",
                                "--perl-regexp", regex_socs, "--", ":soc",
-                               cwd=Path(GIT_TOP))
+                               cwd=Path(GIT_TOP), ignore_non_zero=True)
 
         # Board processing
         # splitlines() supports various line terminators


### PR DESCRIPTION
Fixes #85783:

> Since commit f8a5ebf ("scripts: ci: check_compliance: Add check for
> disallowed Kconfigs"), check_compliance.py run "git grep CONFIG_" in
> boards/ and soc/ directories. This command will fail if no match is
> found (or if the directories don't exist) and check_compliance.py
> returns an error.
> [...]
> It is not a problem for the main Zephyr repository. However, many Zephyr
> modules or downstream repositories calls check_compliance.py in their
> CI. These repositories don't always have soc/ or boards/ directories.
