### PR TITLE
drivers display_nrf_led_matrix: Init variable to avoid compile warning

### DIFF
--- a/drivers/display/display_nrf_led_matrix.c
+++ b/drivers/display/display_nrf_led_matrix.c
@@ -339,7 +339,7 @@ static void timer_irq_handler(void *arg)
 	const struct display_drv_config *dev_config = dev->config;
 	uint8_t iteration = dev_data->iteration;
 	uint8_t pixel_idx;
-	uint8_t row_idx;
+	uint8_t row_idx = 0;
 
 	/* The timer is automagically stopped and cleared by shortcuts
 	 * on the same event (COMPARE0) that generates this interrupt.


### PR DESCRIPTION
Initialize row_index to avoid a compile warning.
The warning seems incorrect, as row_index is initialized in the first interation of the loop, but the overhead of initializing it is trivial, so we may as well just do it.

Fixes this build warning seen in weekly CI:
``` 
FAILED: zephyr/drivers/display/CMakeFiles/drivers__display.dir/display_nrf_led_matrix.c.obj 
ccache /opt/toolchains/zephyr-sdk-0.17.0/arm-zephyr-eabi/bin/arm-zephyr-eabi-gcc -DKERNEL -DK_HEAP_MEM_POOL_SIZE=0 -DLV_CONF_INCLUDE_SIMPLE=1 -DLV_CONF_PATH=\"/__w/zephyr/zephyr/modules/lvgl/include/lv_conf.h\" -DNRF52833_XXAA -DPICOLIBC_DOUBLE_PRINTF_SCANF -D__LINUX_ERRNO_EXTENSIONS__ -D__PROGRAM_START -D__ZEPHYR_SUPERVISOR__ -D__ZEPHYR__=1 -I/__w/zephyr/zephyr/twister-out/bbc_microbit_v2_nrf52833/zephyr/samples/subsys/smf/smf_calculator/sample.smf.smf_calculator/zephyr/include/generated/zephyr -I/__w/zephyr/zephyr/include -I/__w/zephyr/zephyr/twister-out/bbc_microbit_v2_nrf52833/zephyr/samples/subsys/smf/smf_calculator/sample.smf.smf_calculator/zephyr/include/generated -I/__w/zephyr/zephyr/soc/nordic -I/__w/zephyr/zephyr/lib/posix/options/getopt -I/__w/zephyr/zephyr/soc/nordic/nrf52/. -I/__w/zephyr/zephyr/soc/nordic/common/. -I/__w/zephyr/zephyr/subsys/shell/modules/kernel_service/thread/.. -I/__w/zephyr/modules/hal/cmsis/CMSIS/Core/Include -I/__w/zephyr/zephyr/modules/cmsis/. -I/__w/zephyr/modules/hal/nordic/nrfx -I/__w/zephyr/modules/hal/nordic/nrfx/drivers/include -I/__w/zephyr/modules/hal/nordic/nrfx/mdk -I/__w/zephyr/zephyr/modules/hal_nordic/nrfx/. -I/__w/zephyr/modules/hal/st/sensor/stmemsc/lis2mdl_STdC/driver -I/__w/zephyr/modules/lib/gui/lvgl/src -I/__w/zephyr/zephyr/modules/lvgl/include -isystem /__w/zephyr/zephyr/lib/libc/common/include -Wshadow -fno-strict-aliasing -Werror -Og -imacros /__w/zephyr/zephyr/twister-out/bbc_microbit_v2_nrf52833/zephyr/samples/subsys/smf/smf_calculator/sample.smf.smf_calculator/zephyr/include/generated/zephyr/autoconf.h -fno-common -g -gdwarf-4 -fdiagnostics-color=always -mcpu=cortex-m4 -mthumb -mabi=aapcs -mfp16-format=ieee -mtp=soft --sysroot=/opt/toolchains/zephyr-sdk-0.17.0/arm-zephyr-eabi/arm-zephyr-eabi -imacros /__w/zephyr/zephyr/include/zephyr/toolchain/zephyr_stdint.h -Wall -Wformat -Wformat-security -Wno-format-zero-length -Wdouble-promotion -Wno-pointer-sign -Wpointer-arith -Wexpansion-to-defined -Wno-unused-but-set-variable -Werror=implicit-int -fno-pic -fno-pie -fno-asynchronous-unwind-tables -ftls-model=local-exec -fno-reorder-functions --param=min-pagesize=0 -fno-defer-pop -fmacro-prefix-map=/__w/zephyr/zephyr/samples/subsys/smf/smf_calculator=CMAKE_SOURCE_DIR -fmacro-prefix-map=/__w/zephyr/zephyr=ZEPHYR_BASE -fmacro-prefix-map=/__w/zephyr=WEST_TOPDIR -ffunction-sections -fdata-sections -specs=picolibc.specs -D_POSIX_THREADS -std=c99 -MD -MT zephyr/drivers/display/CMakeFiles/drivers__display.dir/display_nrf_led_matrix.c.obj -MF zephyr/drivers/display/CMakeFiles/drivers__display.dir/display_nrf_led_matrix.c.obj.d -o zephyr/drivers/display/CMakeFiles/drivers__display.dir/display_nrf_led_matrix.c.obj -c /__w/zephyr/zephyr/drivers/display/display_nrf_led_matrix.c
/__w/zephyr/zephyr/drivers/display/display_nrf_led_matrix.c: In function 'timer_irq_handler':
/__w/zephyr/zephyr/drivers/display/display_nrf_led_matrix.c:389:28: error: 'row_idx' may be used uninitialized [-Werror=maybe-uninitialized]
  389 |                         if (row_idx != GET_ROW_IDX(dev_config, pixel_idx)) {
      |                            ^
/__w/zephyr/zephyr/drivers/display/display_nrf_led_matrix.c:342:17: note: 'row_idx' was declared here
  342 |         uint8_t row_idx;
      |                 ^~~~~~~
cc1: all warnings being treated as errors
```