### PR TITLE
logging: backends: rtt: Do not enable when shell logging is used

### DIFF
--- a/subsys/logging/backends/Kconfig.rtt
+++ b/subsys/logging/backends/Kconfig.rtt
@@ -4,7 +4,7 @@
 config LOG_BACKEND_RTT
 	bool "Segger J-Link RTT backend"
 	depends on USE_SEGGER_RTT
-	default y if !SHELL_BACKEND_RTT
+	default y if !SHELL_LOG_BACKEND
 	select SEGGER_RTT_CUSTOM_LOCKING
 	select LOG_BACKEND_SUPPORTS_FORMAT_TIMESTAMP
 	help


### PR DESCRIPTION
Typically, when shell logging backend is used user wants to get logs on shell instances so do not enable raw RTT log backend in that case. When raw backend is enabled then initial logs go to RTT backend and they are not visible on shell which starts later as it requires additional thread.

It can be assumed that when RTT backend is used it will be explicitly enabled by the user.