### PR TITLE
ci: cleanup concurrency rules

### DIFF
--- a/.github/workflows/bsim-tests.yaml
+++ b/.github/workflows/bsim-tests.yaml
@@ -29,7 +29,7 @@ on:
       - "tests/drivers/uart/**"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -5,7 +5,7 @@ on:
     - cron: '25 06,18 * * *'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -66,7 +66,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 90
     concurrency:
-      group: doc-build-html-${{ github.ref }}
+      group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
       cancel-in-progress: true
 
     steps:
@@ -192,7 +192,7 @@ jobs:
     container: texlive/texlive:latest
     timeout-minutes: 120
     concurrency:
-      group: doc-build-pdf-${{ github.ref }}
+      group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
       cancel-in-progress: true
 
     steps:

--- a/.github/workflows/footprint-tracking.yml
+++ b/.github/workflows/footprint-tracking.yml
@@ -17,7 +17,7 @@ on:
       - 'v*'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/hello_world_multiplatform.yaml
+++ b/.github/workflows/hello_world_multiplatform.yaml
@@ -17,7 +17,7 @@ on:
       - 'SDK_VERSION'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -16,7 +16,7 @@ on:
     - cron: '0 3 * * 0'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
I can't believe we never noticed this but... This addresses issues were CI jobs would wrongly get cancelled due to sharing the concurrency group as other workflows.

For example:
- Twister runs being cancelled if both contributor submitting PRs named their branch the same (often, `main` :)). See e.g. https://github.com/zephyrproject-rtos/zephyr/actions/runs/13329593812 (from a branch named `main`) which was cancelled by a push to [this PR's branch](https://github.com/zephyrproject-rtos/zephyr/pull/85785), also named main... 
- ~~The scheduled doc-build systematically kills any ongoing "on_pull_request_target" workflow runs. See e.g https://github.com/zephyrproject-rtos/zephyr/actions/runs/13328805305?pr=84367~~

For reference, doc for `github.ref`, which I believe means is all we need vs. the `${{ github.head_ref || github.ref }}` dance from before (but someone please confirm :) is the following:

> The fully-formed ref of the branch or tag that triggered the workflow run. For workflows triggered by push, this is the branch or tag ref that was pushed. For workflows triggered by pull_request, this is the pull request merge branch. For workflows triggered by release, this is the release tag created. For other triggers, this is the branch or tag ref that triggered the workflow run. This is only set if a branch or tag is available for the event type. The ref given is fully-formed, meaning that for branches the format is refs/heads/<branch_name>. For pull requests events except pull_request_target, it is refs/pull/<pr_number>/merge. pull_request_target events have the ref from the base branch. For tags it is refs/tags/<tag_name>. For example, refs/heads/feature-branch-1.