### PR TITLE
Bluetooth: CAP: Add better active_proc checks

### DIFF
--- a/subsys/bluetooth/audio/cap_commander.c
+++ b/subsys/bluetooth/audio/cap_commander.c
@@ -334,25 +334,23 @@ int bt_cap_commander_broadcast_reception_start(
 	struct bt_conn *conn;
 	int err;
 
-	if (bt_cap_common_proc_is_active()) {
+	if (!valid_broadcast_reception_start_param(param)) {
+		return -EINVAL;
+	}
+
+	if (bt_cap_common_test_and_set_proc_active()) {
 		LOG_DBG("A CAP procedure is already in progress");
 
 		return -EBUSY;
 	}
 
-	if (!valid_broadcast_reception_start_param(param)) {
-		return -EINVAL;
-	}
-
-	bt_cap_common_start_proc(BT_CAP_COMMON_PROC_TYPE_BROADCAST_RECEPTION_START, param->count);
-
 	broadcast_assistant_cb.add_src = cap_commander_broadcast_assistant_add_src_cb;
-	if (!broadcast_assistant_cb_registered &&
-	    cap_commander_register_broadcast_assistant_cb() != 0) {
-		LOG_DBG("Failed to register broadcast assistant callbacks");
-
-		return -ENOEXEC;
+	if (!broadcast_assistant_cb_registered) {
+		err = cap_commander_register_broadcast_assistant_cb();
+		__ASSERT(err == 0, "Failed to register broadcast assistant callbacks: %d", err);
 	}
+
+	bt_cap_common_set_proc(BT_CAP_COMMON_PROC_TYPE_BROADCAST_RECEPTION_START, param->count);
 
 	active_proc = bt_cap_common_get_active_proc();
 
@@ -363,8 +361,11 @@ int bt_cap_commander_broadcast_reception_start(
 		struct bt_conn *member_conn =
 			bt_cap_common_get_member_conn(param->type, &member_param->member);
 
+		/* Perform extra check in case that connection state has changed */
 		if (member_conn == NULL) {
 			LOG_DBG("Invalid param->members[%zu]", i);
+
+			bt_cap_common_clear_active_proc();
 
 			return -EINVAL;
 		}
@@ -396,6 +397,8 @@ int bt_cap_commander_broadcast_reception_start(
 	err = bt_bap_broadcast_assistant_add_src(conn, &add_src_param);
 	if (err != 0) {
 		LOG_DBG("Failed to start broadcast reception for conn %p: %d", (void *)conn, err);
+
+		bt_cap_common_clear_active_proc();
 
 		return -ENOEXEC;
 	}
@@ -606,27 +609,25 @@ int bt_cap_commander_broadcast_reception_stop(
 	struct bt_conn *conn;
 	int err;
 
-	if (bt_cap_common_proc_is_active()) {
+	if (!valid_broadcast_reception_stop_param(param)) {
+		return -EINVAL;
+	}
+
+	if (bt_cap_common_test_and_set_proc_active()) {
 		LOG_DBG("A CAP procedure is already in progress");
 
 		return -EBUSY;
 	}
 
-	if (!valid_broadcast_reception_stop_param(param)) {
-		return -EINVAL;
-	}
-
-	bt_cap_common_start_proc(BT_CAP_COMMON_PROC_TYPE_BROADCAST_RECEPTION_STOP, param->count);
-
 	broadcast_assistant_cb.mod_src = cap_commander_broadcast_assistant_mod_src_cb;
 	broadcast_assistant_cb.rem_src = cap_commander_broadcast_assistant_rem_src_cb;
 	broadcast_assistant_cb.recv_state = cap_commander_broadcast_assistant_recv_state_cb;
-	if (!broadcast_assistant_cb_registered &&
-	    cap_commander_register_broadcast_assistant_cb() != 0) {
-		LOG_DBG("Failed to register broadcast assistant callbacks");
-
-		return -ENOEXEC;
+	if (!broadcast_assistant_cb_registered) {
+		err = cap_commander_register_broadcast_assistant_cb();
+		__ASSERT(err == 0, "Failed to register broadcast assistant callbacks: %d", err);
 	}
+
+	bt_cap_common_set_proc(BT_CAP_COMMON_PROC_TYPE_BROADCAST_RECEPTION_STOP, param->count);
 
 	active_proc = bt_cap_common_get_active_proc();
 
@@ -637,11 +638,15 @@ int bt_cap_commander_broadcast_reception_stop(
 		struct bt_conn *member_conn =
 			bt_cap_common_get_member_conn(param->type, &member_param->member);
 
+		/* Perform extra check in case that connection state has changed */
 		if (member_conn == NULL) {
 			LOG_DBG("Invalid param->member[%zu]", i);
 
+			bt_cap_common_clear_active_proc();
+
 			return -EINVAL;
 		}
+
 		/* Store the necessary parameters as we cannot assume that the supplied
 		 * parameters are kept valid
 		 */
@@ -665,6 +670,8 @@ int bt_cap_commander_broadcast_reception_stop(
 	err = bt_bap_broadcast_assistant_mod_src(conn, &mod_src_param);
 	if (err != 0) {
 		LOG_DBG("Failed to stop broadcast reception for conn %p: %d", (void *)conn, err);
+
+		bt_cap_common_clear_active_proc();
 
 		return -ENOEXEC;
 	}
@@ -787,26 +794,24 @@ int bt_cap_commander_distribute_broadcast_code(
 	struct bt_conn *conn;
 	int err;
 
-	if (bt_cap_common_proc_is_active()) {
+	if (!valid_distribute_broadcast_code_param(param)) {
+		return -EINVAL;
+	}
+
+	if (bt_cap_common_test_and_set_proc_active()) {
 		LOG_DBG("A CAP procedure is already in progress");
 
 		return -EBUSY;
 	}
 
-	if (!valid_distribute_broadcast_code_param(param)) {
-		return -EINVAL;
-	}
-
-	bt_cap_common_start_proc(BT_CAP_COMMON_PROC_TYPE_DISTRIBUTE_BROADCAST_CODE, param->count);
-
 	broadcast_assistant_cb.broadcast_code =
 		cap_commander_broadcast_assistant_set_broadcast_code_cb;
-	if (!broadcast_assistant_cb_registered &&
-	    cap_commander_register_broadcast_assistant_cb() != 0) {
-		LOG_DBG("Failed to register broadcast assistant callbacks");
-
-		return -ENOEXEC;
+	if (!broadcast_assistant_cb_registered) {
+		err = cap_commander_register_broadcast_assistant_cb();
+		__ASSERT(err == 0, "Failed to register broadcast assistant callbacks: %d", err);
 	}
+
+	bt_cap_common_set_proc(BT_CAP_COMMON_PROC_TYPE_DISTRIBUTE_BROADCAST_CODE, param->count);
 
 	active_proc = bt_cap_common_get_active_proc();
 
@@ -817,8 +822,11 @@ int bt_cap_commander_distribute_broadcast_code(
 		struct bt_conn *member_conn =
 			bt_cap_common_get_member_conn(param->type, &member_param->member);
 
+		/* Perform extra check in case that connection state has changed */
 		if (member_conn == NULL) {
 			LOG_DBG("Invalid param->member[%zu]", i);
+
+			bt_cap_common_clear_active_proc();
 
 			return -EINVAL;
 		}
@@ -846,6 +854,8 @@ int bt_cap_commander_distribute_broadcast_code(
 	if (err != 0) {
 		LOG_DBG("Failed to start distribute broadcast code for conn %p: %d", (void *)conn,
 			err);
+
+		bt_cap_common_clear_active_proc();
 
 		return -ENOEXEC;
 	}
@@ -1085,24 +1095,23 @@ int bt_cap_commander_change_volume(const struct bt_cap_commander_change_volume_p
 	struct bt_conn *conn;
 	int err;
 
-	if (bt_cap_common_proc_is_active()) {
+	if (!valid_change_volume_param(param)) {
+		return -EINVAL;
+	}
+
+	if (bt_cap_common_test_and_set_proc_active()) {
 		LOG_DBG("A CAP procedure is already in progress");
 
 		return -EBUSY;
 	}
 
-	if (!valid_change_volume_param(param)) {
-		return -EINVAL;
-	}
-
-	bt_cap_common_start_proc(BT_CAP_COMMON_PROC_TYPE_VOLUME_CHANGE, param->count);
-
 	vol_ctlr_cb.vol_set = cap_commander_vcp_vol_set_cb;
-	if (!vcp_cb_registered && cap_commander_register_vcp_cb() != 0) {
-		LOG_DBG("Failed to register VCP callbacks");
-
-		return -ENOEXEC;
+	if (!vcp_cb_registered) {
+		err = cap_commander_register_vcp_cb();
+		__ASSERT(err == 0, "Failed to register VCP callbacks: %d", err);
 	}
+
+	bt_cap_common_set_proc(BT_CAP_COMMON_PROC_TYPE_VOLUME_CHANGE, param->count);
 
 	active_proc = bt_cap_common_get_active_proc();
 
@@ -1110,8 +1119,12 @@ int bt_cap_commander_change_volume(const struct bt_cap_commander_change_volume_p
 		struct bt_conn *member_conn =
 			bt_cap_common_get_member_conn(param->type, &param->members[i]);
 
+		/* Perform extra check in case that connection state has changed */
 		if (member_conn == NULL) {
 			LOG_DBG("Invalid param->members[%zu]", i);
+
+			bt_cap_common_clear_active_proc();
+
 			return -EINVAL;
 		}
 
@@ -1129,6 +1142,9 @@ int bt_cap_commander_change_volume(const struct bt_cap_commander_change_volume_p
 				      proc_param->change_volume.volume);
 	if (err != 0) {
 		LOG_DBG("Failed to set volume for conn %p: %d", (void *)conn, err);
+
+		bt_cap_common_clear_active_proc();
+
 		return -ENOEXEC;
 	}
 
@@ -1264,34 +1280,36 @@ int bt_cap_commander_change_volume_mute_state(
 	struct bt_conn *conn;
 	int err;
 
-	if (bt_cap_common_proc_is_active()) {
+	if (!valid_change_volume_mute_state_param(param)) {
+		return -EINVAL;
+	}
+
+	if (bt_cap_common_test_and_set_proc_active()) {
 		LOG_DBG("A CAP procedure is already in progress");
 
 		return -EBUSY;
 	}
 
-	if (!valid_change_volume_mute_state_param(param)) {
-		return -EINVAL;
-	}
-
-	bt_cap_common_start_proc(BT_CAP_COMMON_PROC_TYPE_VOLUME_MUTE_CHANGE, param->count);
-
 	vol_ctlr_cb.mute = cap_commander_vcp_vol_mute_cb;
 	vol_ctlr_cb.unmute = cap_commander_vcp_vol_mute_cb;
-	if (!vcp_cb_registered && cap_commander_register_vcp_cb() != 0) {
-		LOG_DBG("Failed to register VCP callbacks");
-
-		return -ENOEXEC;
+	if (!vcp_cb_registered) {
+		err = cap_commander_register_vcp_cb();
+		__ASSERT(err == 0, "Failed to register VCP callbacks: %d", err);
 	}
 
+	bt_cap_common_set_proc(BT_CAP_COMMON_PROC_TYPE_VOLUME_MUTE_CHANGE, param->count);
 	active_proc = bt_cap_common_get_active_proc();
 
 	for (size_t i = 0U; i < param->count; i++) {
 		struct bt_conn *member_conn =
 			bt_cap_common_get_member_conn(param->type, &param->members[i]);
 
-		CHECKIF(member_conn == NULL) {
+		/* Perform extra check in case that connection state has changed */
+		if (member_conn == NULL) {
 			LOG_DBG("Invalid param->members[%zu]", i);
+
+			bt_cap_common_clear_active_proc();
+
 			return -EINVAL;
 		}
 
@@ -1314,6 +1332,9 @@ int bt_cap_commander_change_volume_mute_state(
 
 	if (err != 0) {
 		LOG_DBG("Failed to set volume mute state for conn %p: %d", (void *)conn, err);
+
+		bt_cap_common_clear_active_proc();
+
 		return -ENOEXEC;
 	}
 
@@ -1467,24 +1488,23 @@ int bt_cap_commander_change_volume_offset(
 	struct bt_conn *conn;
 	int err;
 
-	if (bt_cap_common_proc_is_active()) {
+	if (!valid_change_offset_param(param)) {
+		return -EINVAL;
+	}
+
+	if (bt_cap_common_test_and_set_proc_active()) {
 		LOG_DBG("A CAP procedure is already in progress");
 
 		return -EBUSY;
 	}
 
-	if (!valid_change_offset_param(param)) {
-		return -EINVAL;
-	}
-
-	bt_cap_common_start_proc(BT_CAP_COMMON_PROC_TYPE_VOLUME_OFFSET_CHANGE, param->count);
-
 	vol_ctlr_cb.vocs_cb.set_offset = cap_commander_vcp_set_offset_cb;
-	if (!vcp_cb_registered && cap_commander_register_vcp_cb() != 0) {
-		LOG_DBG("Failed to register VCP callbacks");
-
-		return -ENOEXEC;
+	if (!vcp_cb_registered) {
+		err = cap_commander_register_vcp_cb();
+		__ASSERT(err == 0, "Failed to register VCP callbacks: %d", err);
 	}
+
+	bt_cap_common_set_proc(BT_CAP_COMMON_PROC_TYPE_VOLUME_OFFSET_CHANGE, param->count);
 
 	active_proc = bt_cap_common_get_active_proc();
 
@@ -1495,20 +1515,30 @@ int bt_cap_commander_change_volume_offset(
 			bt_cap_common_get_member_conn(param->type, &member_param->member);
 		struct bt_vcp_included included;
 
+		/* Perform extra check in case that connection state has changed */
 		if (member_conn == NULL) {
 			LOG_DBG("Invalid param->members[%zu]", i);
+
+			bt_cap_common_clear_active_proc();
+
 			return -EINVAL;
 		}
 
 		vol_ctlr = bt_vcp_vol_ctlr_get_by_conn(member_conn);
 		if (vol_ctlr == NULL) {
 			LOG_DBG("Invalid param->members[%zu] vol_ctlr", i);
+
+			bt_cap_common_clear_active_proc();
+
 			return -EINVAL;
 		}
 
 		err = bt_vcp_vol_ctlr_included_get(vol_ctlr, &included);
 		if (err != 0 || included.vocs_cnt == 0) {
 			LOG_DBG("Invalid param->members[%zu] vocs", i);
+
+			bt_cap_common_clear_active_proc();
+
 			return -EINVAL;
 		}
 
@@ -1530,6 +1560,9 @@ int bt_cap_commander_change_volume_offset(
 	err = bt_vocs_state_set(proc_param->change_offset.vocs, proc_param->change_offset.offset);
 	if (err != 0) {
 		LOG_DBG("Failed to set volume for conn %p: %d", (void *)conn, err);
+
+		bt_cap_common_clear_active_proc();
+
 		return -ENOEXEC;
 	}
 
@@ -1687,24 +1720,23 @@ int bt_cap_commander_change_microphone_mute_state(
 	struct bt_conn *conn;
 	int err;
 
-	if (bt_cap_common_proc_is_active()) {
+	if (!valid_change_microphone_mute_state_param(param)) {
+		return -EINVAL;
+	}
+
+	if (bt_cap_common_test_and_set_proc_active()) {
 		LOG_DBG("A CAP procedure is already in progress");
 
 		return -EBUSY;
 	}
 
-	if (!valid_change_microphone_mute_state_param(param)) {
-		return -EINVAL;
-	}
-
-	bt_cap_common_start_proc(BT_CAP_COMMON_PROC_TYPE_MICROPHONE_MUTE_CHANGE, param->count);
+	bt_cap_common_set_proc(BT_CAP_COMMON_PROC_TYPE_MICROPHONE_MUTE_CHANGE, param->count);
 
 	mic_ctlr_cb.mute_written = cap_commander_micp_mic_mute_cb;
 	mic_ctlr_cb.unmute_written = cap_commander_micp_mic_mute_cb;
-	if (!micp_callbacks_registered && cap_commander_register_micp_callbacks() != 0) {
-		LOG_DBG("Failed to register MICP callbacks");
-
-		return -ENOEXEC;
+	if (!micp_callbacks_registered) {
+		err = cap_commander_register_micp_callbacks();
+		__ASSERT(err == 0, "Failed to register MICP callbacks: %d", err);
 	}
 
 	active_proc = bt_cap_common_get_active_proc();
@@ -1713,8 +1745,12 @@ int bt_cap_commander_change_microphone_mute_state(
 		struct bt_conn *member_conn =
 			bt_cap_common_get_member_conn(param->type, &param->members[i]);
 
-		CHECKIF(member_conn == NULL) {
+		/* Perform extra check in case that connection state has changed */
+		if (member_conn == NULL) {
 			LOG_DBG("Invalid param->members[%zu]", i);
+
+			bt_cap_common_clear_active_proc();
+
 			return -EINVAL;
 		}
 
@@ -1737,6 +1773,9 @@ int bt_cap_commander_change_microphone_mute_state(
 
 	if (err != 0) {
 		LOG_DBG("Failed to set microphone mute state for conn %p: %d", (void *)conn, err);
+
+		bt_cap_common_clear_active_proc();
+
 		return -ENOEXEC;
 	}
 
@@ -1880,23 +1919,22 @@ int bt_cap_commander_change_microphone_gain_setting(
 	struct bt_conn *conn;
 	int err;
 
-	if (bt_cap_common_proc_is_active()) {
+	if (!valid_change_microphone_gain_param(param)) {
+		return -EINVAL;
+	}
+
+	if (bt_cap_common_test_and_set_proc_active()) {
 		LOG_DBG("A CAP procedure is already in progress");
 
 		return -EBUSY;
 	}
 
-	if (!valid_change_microphone_gain_param(param)) {
-		return -EINVAL;
-	}
-
-	bt_cap_common_start_proc(BT_CAP_COMMON_PROC_TYPE_MICROPHONE_GAIN_CHANGE, param->count);
+	bt_cap_common_set_proc(BT_CAP_COMMON_PROC_TYPE_MICROPHONE_GAIN_CHANGE, param->count);
 
 	mic_ctlr_cb.aics_cb.set_gain = cap_commander_micp_gain_set_cb;
-	if (!micp_callbacks_registered && cap_commander_register_micp_callbacks() != 0) {
-		LOG_DBG("Failed to register MICP callbacks");
-
-		return -ENOEXEC;
+	if (!micp_callbacks_registered) {
+		err = cap_commander_register_micp_callbacks();
+		__ASSERT(err == 0, "Failed to register MICP callbacks: %d", err);
 	}
 
 	active_proc = bt_cap_common_get_active_proc();
@@ -1907,20 +1945,30 @@ int bt_cap_commander_change_microphone_gain_setting(
 		struct bt_micp_mic_ctlr *mic_ctlr;
 		struct bt_micp_included included;
 
+		/* Perform extra check in case that connection state has changed */
 		if (member_conn == NULL) {
 			LOG_DBG("Invalid param->param[%zu].member", i);
+
+			bt_cap_common_clear_active_proc();
+
 			return -EINVAL;
 		}
 
 		mic_ctlr = bt_micp_mic_ctlr_get_by_conn(member_conn);
 		if (mic_ctlr == NULL) {
 			LOG_DBG("Invalid param->param[%zu].member mic_ctlr", i);
+
+			bt_cap_common_clear_active_proc();
+
 			return -EINVAL;
 		}
 
 		err = bt_micp_mic_ctlr_included_get(mic_ctlr, &included);
 		if (err != 0 || included.aics_cnt == 0) {
 			LOG_DBG("Invalid param->param[%zu].member aics", i);
+
+			bt_cap_common_clear_active_proc();
+
 			return -EINVAL;
 		}
 
@@ -1942,6 +1990,9 @@ int bt_cap_commander_change_microphone_gain_setting(
 	err = bt_aics_gain_set(proc_param->change_gain.aics, proc_param->change_gain.gain);
 	if (err != 0) {
 		LOG_DBG("Failed to set gain for conn %p: %d", (void *)conn, err);
+
+		bt_cap_common_clear_active_proc();
+
 		return -ENOEXEC;
 	}
 

--- a/subsys/bluetooth/audio/cap_common.c
+++ b/subsys/bluetooth/audio/cap_common.c
@@ -43,11 +43,10 @@ void bt_cap_common_clear_active_proc(void)
 	(void)memset(&active_proc, 0, sizeof(active_proc));
 }
 
-void bt_cap_common_start_proc(enum bt_cap_common_proc_type proc_type, size_t proc_cnt)
+void bt_cap_common_set_proc(enum bt_cap_common_proc_type proc_type, size_t proc_cnt)
 {
 	LOG_DBG("Setting proc to %d for %zu streams", proc_type, proc_cnt);
 
-	atomic_set_bit(active_proc.proc_state_flags, BT_CAP_COMMON_PROC_STATE_ACTIVE);
 	active_proc.proc_cnt = proc_cnt;
 	active_proc.proc_type = proc_type;
 	active_proc.proc_done_cnt = 0U;
@@ -98,6 +97,12 @@ struct bt_conn *bt_cap_common_get_member_conn(enum bt_cap_set_type type,
 	}
 
 	return member->member;
+}
+
+bool bt_cap_common_test_and_set_proc_active(void)
+{
+	return atomic_test_and_set_bit(active_proc.proc_state_flags,
+				       BT_CAP_COMMON_PROC_STATE_ACTIVE);
 }
 
 bool bt_cap_common_proc_is_active(void)

--- a/subsys/bluetooth/audio/cap_internal.h
+++ b/subsys/bluetooth/audio/cap_internal.h
@@ -204,12 +204,13 @@ struct bt_cap_common_client {
 
 struct bt_cap_common_proc *bt_cap_common_get_active_proc(void);
 void bt_cap_common_clear_active_proc(void);
-void bt_cap_common_start_proc(enum bt_cap_common_proc_type proc_type, size_t proc_cnt);
+void bt_cap_common_set_proc(enum bt_cap_common_proc_type proc_type, size_t proc_cnt);
 void bt_cap_common_set_subproc(enum bt_cap_common_subproc_type subproc_type);
 bool bt_cap_common_proc_is_type(enum bt_cap_common_proc_type proc_type);
 bool bt_cap_common_subproc_is_type(enum bt_cap_common_subproc_type subproc_type);
 struct bt_conn *bt_cap_common_get_member_conn(enum bt_cap_set_type type,
 					      const union bt_cap_set_member *member);
+bool bt_cap_common_test_and_set_proc_active(void);
 bool bt_cap_common_proc_is_active(void);
 bool bt_cap_common_proc_is_aborted(void);
 bool bt_cap_common_proc_all_handled(void);


### PR DESCRIPTION
The existing checks were not thread safe at all.
Replace the checks by using atomic_test_and_set_bit and then clearing the bit again on error.