### PR TITLE
tests: nrf: Fix SPDX license tags

### DIFF
--- a/tests/boards/nrf/nrf70/bustest/CMakeLists.txt
+++ b/tests/boards/nrf/nrf70/bustest/CMakeLists.txt
@@ -1,7 +1,7 @@
 #
 # Copyright (c) 2024 Nordic Semiconductor ASA
 #
-# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-License-Identifier: Apache-2.0
 #
 
 cmake_minimum_required(VERSION 3.20.0)

--- a/tests/net/lib/wifi_credentials/prj.conf
+++ b/tests/net/lib/wifi_credentials/prj.conf
@@ -1,7 +1,7 @@
 #
 # Copyright (c) 2024 Nordic Semiconductor ASA
 #
-# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+# SPDX-License-Identifier: Apache-2.0
 #
 
 CONFIG_ZTEST=y


### PR DESCRIPTION
Both files are released by Nordic under the Apache v2.0 license, correct the SPDX tags accordingly.