### PR TITLE
tests: drivers: gpio: gpio_basic_api: Add support for kv260

### DIFF
--- a/boards/amd/kv260_r5/kv260_r5.yaml
+++ b/boards/amd/kv260_r5/kv260_r5.yaml
@@ -8,6 +8,7 @@ flash: 32768
 supported:
   - i2c
   - eeprom
+  - gpio
 testing:
   ignore_tags:
     - net

--- a/tests/drivers/gpio/gpio_basic_api/boards/kv260_r5.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/kv260_r5.overlay
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2025 Advanced Micro Devices, Inc. (AMD)
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	loop {
+		compatible = "test-gpio-basic-api";
+
+		out-gpios = <&psgpio_bank3 0 0>; /* GPIOPS BANK 3 PIN 0 */
+		in-gpios = <&psgpio_bank3 1 0>; /* GPIOPS BANK 3 PIN 1 */
+	};
+};


### PR DESCRIPTION
Add gpio driver testcase support for kv260. The overlay will select the PS gpio bank to be tested.
Add test scenario name with filter and etra_arg for kv260.

For running this testcase on kv260 PS gpio bank 3 has been chosen because it is EMIO and design is required to connect pins together.