### PR TITLE
soc: stm32wbax: hci_if: Clean the link layer porting

### DIFF
--- a/drivers/flash/flash_stm32wba_fm.c
+++ b/drivers/flash/flash_stm32wba_fm.c
@@ -24,7 +24,7 @@ LOG_MODULE_REGISTER(flash_stm32wba, CONFIG_FLASH_LOG_LEVEL);
 #define STM32_FLASH_TIMEOUT	\
 	(2 * DT_PROP(DT_INST(0, st_stm32_nv_flash), max_erase_time))
 
-extern struct k_work_q ble_ctlr_work_q;
+extern struct k_work_q ble_ctrl_work_q;
 struct k_work fm_work;
 
 static const struct flash_parameters flash_stm32_parameters = {
@@ -47,7 +47,7 @@ struct FM_CallbackNode cb_ptr = {
 
 void FM_ProcessRequest(void)
 {
-	k_work_submit_to_queue(&ble_ctlr_work_q, &fm_work);
+	k_work_submit_to_queue(&ble_ctrl_work_q, &fm_work);
 }
 
 void FM_BackgroundProcess_Entry(struct k_work *work)

--- a/soc/st/stm32/stm32wbax/hci_if/host_stack_if.c
+++ b/soc/st/stm32/stm32wbax/hci_if/host_stack_if.c
@@ -7,38 +7,35 @@
 #include <zephyr/kernel.h>
 #include <zephyr/init.h>
 
-#include "app_conf.h"
 #include "blestack.h"
 #include "bpka.h"
 #include "ll_intf.h"
 
-K_MUTEX_DEFINE(ble_ctlr_stack_mutex);
-struct k_work_q ble_ctlr_work_q, ll_work_q;
-struct k_work ble_ctlr_stack_work, bpka_work;
+K_MUTEX_DEFINE(ble_ctrl_stack_mutex);
+struct k_work_q ble_ctrl_work_q, ll_work_q;
+struct k_work ble_ctrl_stack_work, bpka_work;
 
 uint8_t ll_state_busy;
 
-#define BLE_CTLR_TASK_STACK_SIZE (256 * 7)
-#define LL_TASK_STACK_SIZE (256 * 7)
-#define BLE_CTLR_TASK_PRIO	 (14)
-#define LL_TASK_PRIO (14)
+/* TODO: More tests to be done to optimize thread stacks' sizes */
+#define BLE_CTRL_THREAD_STACK_SIZE (256 * 7)
+#define LL_THREAD_STACK_SIZE (256 * 7)
+#define BLE_CTRL_THREAD_PRIO (14)
+#define LL_THREAD_PRIO (14)
 
-K_THREAD_STACK_DEFINE(ble_ctlr_work_area, BLE_CTLR_TASK_STACK_SIZE);
-K_THREAD_STACK_DEFINE(ll_work_area, LL_TASK_STACK_SIZE);
+K_THREAD_STACK_DEFINE(ble_ctrl_work_area, BLE_CTRL_THREAD_STACK_SIZE);
+K_THREAD_STACK_DEFINE(ll_work_area, LL_THREAD_STACK_SIZE);
 
-void HostStack_Process(void)
+void HostStack_Process(void);
+
+static void ble_ctrl_stack_handler(struct k_work *work)
 {
-	k_work_submit_to_queue(&ble_ctlr_work_q, &ble_ctlr_stack_work);
-}
-
-static void ble_ctlr_stack_handler(struct k_work *work)
-{
-	uint8_t running = 0x0;
+	uint8_t running = 0x00;
 	change_state_options_t options;
 
-	k_mutex_lock(&ble_ctlr_stack_mutex, K_FOREVER);
+	k_mutex_lock(&ble_ctrl_stack_mutex, K_FOREVER);
 	running = BleStack_Process();
-	k_mutex_unlock(&ble_ctlr_stack_mutex);
+	k_mutex_unlock(&ble_ctrl_stack_mutex);
 
 	if (ll_state_busy == 1) {
 		options.combined_value = 0x0F;
@@ -51,32 +48,37 @@ static void ble_ctlr_stack_handler(struct k_work *work)
 	}
 }
 
-void BPKACB_Process(void)
-{
-	k_work_submit_to_queue(&ble_ctlr_work_q, &bpka_work);
-}
-
 static void bpka_work_handler(struct k_work *work)
 {
 	BPKA_BG_Process();
 }
 
-static int stm32wba_ble_ctlr_init(void)
+static int stm32wba_ble_ctrl_init(void)
 {
-	k_work_queue_init(&ble_ctlr_work_q);
-	k_work_queue_start(&ble_ctlr_work_q, ble_ctlr_work_area,
-				K_THREAD_STACK_SIZEOF(ble_ctlr_work_area),
-				BLE_CTLR_TASK_PRIO, NULL);
+	k_work_queue_init(&ble_ctrl_work_q);
+	k_work_queue_start(&ble_ctrl_work_q, ble_ctrl_work_area,
+				       K_THREAD_STACK_SIZEOF(ble_ctrl_work_area),
+				       BLE_CTRL_THREAD_PRIO, NULL);
 
 	k_work_queue_init(&ll_work_q);
 	k_work_queue_start(&ll_work_q, ll_work_area,
-				K_THREAD_STACK_SIZEOF(ll_work_area),
-				LL_TASK_PRIO, NULL);
+				       K_THREAD_STACK_SIZEOF(ll_work_area),
+				       LL_THREAD_PRIO, NULL);
 
-	k_work_init(&ble_ctlr_stack_work, &ble_ctlr_stack_handler);
+	k_work_init(&ble_ctrl_stack_work, &ble_ctrl_stack_handler);
 	k_work_init(&bpka_work, &bpka_work_handler);
 
 	return 0;
 }
 
-SYS_INIT(stm32wba_ble_ctlr_init, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
+void HostStack_Process(void)
+{
+	k_work_submit_to_queue(&ble_ctrl_work_q, &ble_ctrl_stack_work);
+}
+
+void BPKACB_Process(void)
+{
+	k_work_submit_to_queue(&ble_ctrl_work_q, &bpka_work);
+}
+
+SYS_INIT(stm32wba_ble_ctrl_init, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);

--- a/soc/st/stm32/stm32wbax/hci_if/host_stack_if.c
+++ b/soc/st/stm32/stm32wbax/hci_if/host_stack_if.c
@@ -21,7 +21,8 @@ uint8_t ll_state_busy;
 #define BLE_CTRL_THREAD_STACK_SIZE (256 * 7)
 #define LL_THREAD_STACK_SIZE (256 * 7)
 #define BLE_CTRL_THREAD_PRIO (14)
-#define LL_THREAD_PRIO (14)
+/* The LL thread has higher priority than the BLE CTRL thread and the Zephyr BLE stack threads */
+#define LL_THREAD_PRIO (4)
 
 K_THREAD_STACK_DEFINE(ble_ctrl_work_area, BLE_CTRL_THREAD_STACK_SIZE);
 K_THREAD_STACK_DEFINE(ll_work_area, LL_THREAD_STACK_SIZE);

--- a/soc/st/stm32/stm32wbax/hci_if/host_stack_if.c
+++ b/soc/st/stm32/stm32wbax/hci_if/host_stack_if.c
@@ -58,13 +58,13 @@ static int stm32wba_ble_ctrl_init(void)
 {
 	k_work_queue_init(&ble_ctrl_work_q);
 	k_work_queue_start(&ble_ctrl_work_q, ble_ctrl_work_area,
-				       K_THREAD_STACK_SIZEOF(ble_ctrl_work_area),
-				       BLE_CTRL_THREAD_PRIO, NULL);
+			   K_THREAD_STACK_SIZEOF(ble_ctrl_work_area),
+			   BLE_CTRL_THREAD_PRIO, NULL);
 
 	k_work_queue_init(&ll_work_q);
 	k_work_queue_start(&ll_work_q, ll_work_area,
-				       K_THREAD_STACK_SIZEOF(ll_work_area),
-				       LL_THREAD_PRIO, NULL);
+			   K_THREAD_STACK_SIZEOF(ll_work_area),
+			   LL_THREAD_PRIO, NULL);
 
 	k_work_init(&ble_ctrl_stack_work, &ble_ctrl_stack_handler);
 	k_work_init(&bpka_work, &bpka_work_handler);

--- a/soc/st/stm32/stm32wbax/hci_if/linklayer_plat_adapt.c
+++ b/soc/st/stm32/stm32wbax/hci_if/linklayer_plat_adapt.c
@@ -29,6 +29,8 @@ volatile int32_t prio_high_isr_counter;
 volatile int32_t prio_low_isr_counter;
 volatile int32_t prio_sys_isr_counter;
 volatile uint32_t local_basepri_value;
+volatile uint8_t irq_counter;
+static uint32_t primask_bit;
 
 /* Radio SW low ISR global variable */
 volatile uint8_t radio_sw_low_isr_is_running_high_prio;
@@ -147,6 +149,26 @@ void LINKLAYER_PLAT_TriggerSwLowIT(uint8_t priority)
 void LINKLAYER_PLAT_Assert(uint8_t condition)
 {
 	__ASSERT_NO_MSG(condition);
+}
+
+void LINKLAYER_PLAT_EnableIRQ(void)
+{
+	if (irq_counter > 0) {
+		irq_counter--;
+		if (irq_counter == 0) {
+			__set_PRIMASK(primask_bit);
+		}
+	}
+}
+
+void LINKLAYER_PLAT_DisableIRQ(void)
+{
+	if (irq_counter == 0) {
+		/* Save primask bit at first time interrupts disabling */
+		primask_bit = __get_PRIMASK();
+	}
+	__disable_irq();
+	irq_counter++;
 }
 
 void LINKLAYER_PLAT_EnableSpecificIRQ(uint8_t isr_type)

--- a/soc/st/stm32/stm32wbax/hci_if/linklayer_plat_adapt.c
+++ b/soc/st/stm32/stm32wbax/hci_if/linklayer_plat_adapt.c
@@ -119,7 +119,7 @@ void LINKLAYER_PLAT_TriggerSwLowIT(uint8_t priority)
 {
 	uint8_t low_isr_priority = RADIO_INTR_PRIO_LOW_Z;
 
-	LOG_DBG("Priotity: %d", priority);
+	LOG_DBG("Priority: %d", priority);
 
 	/* Check if a SW low interrupt as already been raised.
 	 * Nested call far radio low isr are not supported
@@ -238,10 +238,23 @@ void LINKLAYER_PLAT_RCOStopClbr(void)
 /* Required only for RCO module usage in the context of LSI2 calibration */
 }
 
+/* TODO: To do when porting the temperature measurement function and thread */
 void LINKLAYER_PLAT_RequestTemperature(void) {}
 
 void LINKLAYER_PLAT_SCHLDR_TIMING_UPDATE_NOT(Evnt_timing_t *p_evnt_timing) {}
 
-void LINKLAYER_PLAT_EnableOSContextSwitch(void) {}
+void LINKLAYER_PLAT_EnableOSContextSwitch(void)
+{
+	/* No implementation is needed. However, this function may be used to notify
+	 * upper layers that the link layer has just finished a critical radio job
+	 * (radio channels' calibration).
+	 **/
+}
 
-void LINKLAYER_PLAT_DisableOSContextSwitch(void) {}
+void LINKLAYER_PLAT_DisableOSContextSwitch(void)
+{
+	/* No implementation is needed. However, this function may be used to notify upper layers
+	 * that the link layer is running a critical radio job (radio channels' calibration);
+	 * A sequence of radio ISRs will appear in the next few milli seconds.
+	 **/
+}

--- a/soc/st/stm32/stm32wbax/hci_if/ll_sys_if_adapt.c
+++ b/soc/st/stm32/stm32wbax/hci_if/ll_sys_if_adapt.c
@@ -12,9 +12,16 @@ LOG_MODULE_REGISTER(ll_sys_if_adapt);
 
 #include "ll_sys.h"
 
-extern struct k_mutex ble_ctlr_stack_mutex;
+extern struct k_mutex ble_ctrl_stack_mutex;
 extern struct k_work_q ll_work_q;
 struct k_work ll_sys_work;
+
+static void ll_sys_bg_process_handler(struct k_work *work)
+{
+	k_mutex_lock(&ble_ctrl_stack_mutex, K_FOREVER);
+	ll_sys_bg_process();
+	k_mutex_unlock(&ble_ctrl_stack_mutex);
+}
 
 void ll_sys_schedule_bg_process(void)
 {
@@ -26,14 +33,11 @@ void ll_sys_schedule_bg_process_isr(void)
 	k_work_submit_to_queue(&ll_work_q, &ll_sys_work);
 }
 
-static void ll_sys_bg_process_handler(struct k_work *work)
-{
-	k_mutex_lock(&ble_ctlr_stack_mutex, K_FOREVER);
-	ll_sys_bg_process();
-	k_mutex_unlock(&ble_ctlr_stack_mutex);
-}
-
 void ll_sys_bg_process_init(void)
 {
 	k_work_init(&ll_sys_work, &ll_sys_bg_process_handler);
 }
+
+/* TODO: Implement temperature measurement thread after
+ * implementing temperature measurement request function
+ **/

--- a/west.yml
+++ b/west.yml
@@ -238,7 +238,7 @@ manifest:
       groups:
         - hal
     - name: hal_stm32
-      revision: 5dcc08c119d421fec7d67555fc7b0aa220288e56
+      revision: b3e05b628764352ee21ba23ac39418f8c953bc51
       path: modules/hal/stm32
       groups:
         - hal


### PR DESCRIPTION
* Migrate LINKLAYER_PLAT_EnableRadioIT and LINKLAYER_PLAT_DisableRadioIT from linklayer_plat.c (hal/stm32 module) and adapt it using irq Zephyr APIs.
* Migrate LINKLAYER_PLAT_EnableIRQ and LINKLAYER_PLAT_DisableIRQ
* Correct casting of irq type between using NVIC APIs or irq Zephyr APIs.
* Increase the link layer thread priority to be more than the BLE CTRL thread and more than the Zephyr BLE stack thread.
* Clean the code, rename some constants and variables for more consistency.