### PR TITLE
ci: twister: increase weekly matrix size

### DIFF
--- a/.github/workflows/twister-prep.yaml
+++ b/.github/workflows/twister-prep.yaml
@@ -28,10 +28,10 @@ jobs:
     env:
       MATRIX_SIZE: 10
       PUSH_MATRIX_SIZE: 20
-      DAILY_MATRIX_SIZE: 80
+      WEEKLY_MATRIX_SIZE: 200
       BSIM_OUT_PATH: /opt/bsim/
       BSIM_COMPONENTS_PATH: /opt/bsim/components
-      TESTS_PER_BUILDER: 700
+      TESTS_PER_BUILDER: 900
       COMMIT_RANGE: ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}
       BASE_REF: ${{ github.base_ref }}
     steps:
@@ -116,10 +116,10 @@ jobs:
     env:
       MATRIX_SIZE: 10
       PUSH_MATRIX_SIZE: 20
-      DAILY_MATRIX_SIZE: 80
+      WEEKLY_MATRIX_SIZE: 200
       BSIM_OUT_PATH: /opt/bsim/
       BSIM_COMPONENTS_PATH: /opt/bsim/components
-      TESTS_PER_BUILDER: 700
+      TESTS_PER_BUILDER: 900
       COMMIT_RANGE: ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}
       BASE_REF: ${{ github.base_ref }}
     steps:
@@ -136,8 +136,8 @@ jobs:
             subset="[$(seq -s',' 1 ${PUSH_MATRIX_SIZE})]"
             size=${MATRIX_SIZE}
           elif [ "${{github.event_name}}" = "schedule" -a "${{github.repository}}" = "zephyrproject-rtos/zephyr" ]; then
-            subset="[$(seq -s',' 1 ${DAILY_MATRIX_SIZE})]"
-            size=${DAILY_MATRIX_SIZE}
+            subset="[$(seq -s',' 1 ${WEEKLY_MATRIX_SIZE})]"
+            size=${WEEKLY_MATRIX_SIZE}
           else
             size=0
           fi


### PR DESCRIPTION
Increase matrix size to deal with builds aborting under heavy load or
when running out of resources.

Also increase number of tests per node to deal with growth.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
