### PR TITLE
drivers: spi: spi_pico_pio: Implement DMA support for 4-wire operation

### DIFF
--- a/drivers/spi/Kconfig.rpi_pico
+++ b/drivers/spi/Kconfig.rpi_pico
@@ -9,4 +9,13 @@ config SPI_RPI_PICO_PIO
 	select PICOSDK_USE_CLAIM
 	select PINCTRL
 	help
-	  Enable driving SPI via PIO on the Pico
+	  Enable driving SPI via PIO on the Raspberry Pi Pico
+
+if SPI_RPI_PICO_PIO
+
+config SPI_RPI_PICO_PIO_DMA
+	bool "Raspberry Pi Pico PIO SPI DMA mode"
+	select DMA
+	help
+	  Enables DMA support for Raspberry Pi Pico PIO SPI driver.
+endif

--- a/tests/drivers/spi/spi_loopback/boards/rpi_pico_pio_dma.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/rpi_pico_pio_dma.overlay
@@ -1,0 +1,14 @@
+#include <zephyr/dt-bindings/dma/rpi-pico-dma-rp2040.h>
+
+/* This file overrides pio0_spi0 configured in ./rpi_pico_pio.overlay
+ * and enables DMA.
+ */
+
+&dma {
+	status = "okay";
+};
+
+&pio0_spi0 {
+	dmas = <&dma 0 0 0>, <&dma 1 0 0>;
+	dma-names = "tx", "rx";
+};

--- a/tests/drivers/spi/spi_loopback/testcase.yaml
+++ b/tests/drivers/spi/spi_loopback/testcase.yaml
@@ -192,6 +192,14 @@ tests:
       - DTC_OVERLAY_FILE="boards/rpi_pico_pio.overlay"
       - EXTRA_CONF_FILE="overlay-rpi-pico-pio.conf"
     platform_allow: rpi_pico
+  drivers.spi.pio_spi_dma.loopback:
+    extra_args:
+      - DTC_OVERLAY_FILE="boards/rpi_pico_pio.overlay"
+      - EXTRA_DTC_OVERLAY_FILE="boards/rpi_pico_pio_dma.overlay"
+      - EXTRA_CONF_FILE="overlay-rpi-pico-pio.conf"
+    extra_configs:
+      - CONFIG_SPI_RPI_PICO_PIO_DMA=y
+    platform_allow: rpi_pico
   drivers.spi.flexio_spi.loopback:
     extra_args:
       - platform:mimxrt1170_evk/mimxrt1176/cm7:DTC_OVERLAY_FILE="boards/mimxrt1170_evk_mimxrt1176_cm7_flexio_spi.overlay"


### PR DESCRIPTION
This commit largely mirrors the approach of implementing DMA in the pl022 driver.

Though https://github.com/zephyrproject-rtos/zephyr/pull/85112 is still pending, I figured out that maybe it is enough for users to only specify the DMA channels and figure out the DREQ by myself in the code. I have been working on a personal project that uses DMA with PIO so I think it is to the benefit of the community if I submit it here.

Also included here is an updated version of the spi loopback test that includes a case for PIO with DMA.
