### PR TITLE
ci: twister: start weekly run earlier

### DIFF
--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -12,8 +12,8 @@ on:
       - v*-branch
       - collab-*
   schedule:
-    # Run at 03:00 UTC on every Sunday
-    - cron: '0 3 * * 0'
+    # Run at 17:00 UTC on every Saturday
+    - cron: '0 17 * * 6'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}


### PR DESCRIPTION
Start weekly run a bit earlier to make use of idle night time of the
weekend.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
