### PR TITLE
Revert "ci: cleanup concurrency rules"

### DIFF
--- a/.github/workflows/bsim-tests.yaml
+++ b/.github/workflows/bsim-tests.yaml
@@ -29,7 +29,7 @@ on:
       - "tests/drivers/uart/**"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -5,7 +5,7 @@ on:
     - cron: '25 06,18 * * *'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -66,7 +66,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 90
     concurrency:
-      group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+      group: doc-build-html-${{ github.ref }}
       cancel-in-progress: true
 
     steps:
@@ -192,7 +192,7 @@ jobs:
     container: texlive/texlive:latest
     timeout-minutes: 120
     concurrency:
-      group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+      group: doc-build-pdf-${{ github.ref }}
       cancel-in-progress: true
 
     steps:

--- a/.github/workflows/footprint-tracking.yml
+++ b/.github/workflows/footprint-tracking.yml
@@ -17,7 +17,7 @@ on:
       - 'v*'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/hello_world_multiplatform.yaml
+++ b/.github/workflows/hello_world_multiplatform.yaml
@@ -17,7 +17,7 @@ on:
       - 'SDK_VERSION'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -16,7 +16,7 @@ on:
     - cron: '0 3 * * 0'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
This reverts commit 2dcb61858b2cb2294bedca3b556fe210213a63d5. Completely breaks CI due to concurrency key being wrong and the same for every PR...