### PR TITLE
drivers: video: introduce an API for collecting statistics

### DIFF
--- a/drivers/video/video_emul_rx.c
+++ b/drivers/video/video_emul_rx.c
@@ -117,6 +117,25 @@ static int emul_rx_get_caps(const struct device *dev, enum video_endpoint_id ep,
 	return video_get_caps(cfg->source_dev, VIDEO_EP_OUT, caps);
 }
 
+static int emul_rx_get_stats(const struct device *dev, enum video_endpoint_id ep,
+			     struct video_stats *stats)
+{
+	struct video_stats_channels *chan = (void *)stats;
+
+	if ((stats->flags & VIDEO_STATS_CHANNELS_Y) == 0) {
+		return -ENOTSUP;
+	}
+
+	/* Fake data for the sake of demonstrating and testing the APIs */
+	chan->y = 0x7f;
+	stats->frame_counter = k_cycle_get_32() / 1024;
+
+	/* Let the caller know what type of statistics is collected */
+	stats->flags = VIDEO_STATS_CHANNELS_Y;
+
+	return 0;
+}
+
 static int emul_rx_set_stream(const struct device *dev, bool enable)
 {
 	const struct emul_rx_config *cfg = dev->config;
@@ -238,6 +257,7 @@ static DEVICE_API(video, emul_rx_driver_api) = {
 	.set_format = emul_rx_set_fmt,
 	.get_format = emul_rx_get_fmt,
 	.get_caps = emul_rx_get_caps,
+	.get_stats = emul_rx_get_stats,
 	.set_stream = emul_rx_set_stream,
 	.enqueue = emul_rx_enqueue,
 	.dequeue = emul_rx_dequeue,

--- a/tests/drivers/video/api/src/video_emul.c
+++ b/tests/drivers/video/api/src/video_emul.c
@@ -185,4 +185,33 @@ ZTEST(video_common, test_video_vbuf)
 	video_buffer_release(vbuf);
 }
 
+ZTEST(video_emul, test_video_stats)
+{
+	struct video_stats_channels chan = {
+		.base.flags = VIDEO_STATS_CHANNELS,
+	};
+
+	zexpect_ok(video_get_stats(rx_dev, VIDEO_EP_OUT, &chan.base),
+		   "statistics collection should succeed for the emulated device");
+
+	zexpect_equal(chan.base.flags & VIDEO_STATS_HISTOGRAM, 0, "histogram was not requested");
+
+	zexpect_not_equal(chan.base.flags & VIDEO_STATS_CHANNELS, 0,
+			  "this emulated device is known to support channel averages.");
+
+	if (chan.base.flags & VIDEO_STATS_CHANNELS_Y) {
+		zexpect_not_equal(chan.y, 0x00, "Test data likely not completely black.");
+		zexpect_not_equal(chan.y, 0xff, "Test data likely not completely white.");
+	}
+
+	if (chan.base.flags & VIDEO_STATS_CHANNELS_RGB) {
+		zexpect_not_equal(chan.rgb[0], 0x00, "Red channel likely not completely 0x00.");
+		zexpect_not_equal(chan.rgb[0], 0xff, "Red channel likely not completely 0xff.");
+		zexpect_not_equal(chan.rgb[1], 0x00, "Green channel likely not completely 0x00.");
+		zexpect_not_equal(chan.rgb[1], 0xff, "Green channel likely not completely 0xff.");
+		zexpect_not_equal(chan.rgb[2], 0x00, "Blue channel likely not completely 0x00.");
+		zexpect_not_equal(chan.rgb[2], 0xff, "Blue channel likely not completely 0xff.");
+	}
+}
+
 ZTEST_SUITE(video_emul, NULL, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
This is an implementation for this RFC:

- #85457

Downstream:

- #87008

This is an implementation used on a private repo to implement a basic ISP that does auto-exposure from `main()`.

Hardware -> RGB stats -> YRGB stats -> Y channel used for computing how far we are from a "goal" value -> video controls.