### PR TITLE
arch: arm: arm_mpu_v7m: Fix unsupported Cortex-R access permission mode

### DIFF
--- a/arch/arm/core/mpu/arm_mpu_v7_internal.h
+++ b/arch/arm/core/mpu/arm_mpu_v7_internal.h
@@ -145,7 +145,7 @@ static inline int get_dyn_region_min_index(void)
 /* Only a single bit is set for all user accessible permissions.
  * In ARMv7-M MPU this is bit AP[1].
  */
-#define MPU_USER_READ_ACCESSIBLE_Msk (P_RW_U_RO & P_RW_U_RW & P_RO_U_RO & RO)
+#define MPU_USER_READ_ACCESSIBLE_Msk (P_RW_U_RO & P_RW_U_RW & P_RO_U_RO)
 
 /**
  * This internal function checks if the region is user accessible or not.

--- a/include/zephyr/arch/arm/mpu/arm_mpu_v7m.h
+++ b/include/zephyr/arch/arm/mpu/arm_mpu_v7m.h
@@ -38,9 +38,7 @@
 /* Privileged Read Only, Unprivileged Read Only */
 #define P_RO_U_RO       0x6
 #define P_RO_U_RO_Msk   ((P_RO_U_RO << MPU_RASR_AP_Pos) & MPU_RASR_AP_Msk)
-/* Privileged Read Only, Unprivileged Read Only */
-#define RO              0x7
-#define RO_Msk          ((RO << MPU_RASR_AP_Pos) & MPU_RASR_AP_Msk)
+/* Note: mode 0x7 is the same as 0x6 but supported only by Cortex-M, not Cortex-R */
 
 /* Attribute flag for not-allowing execution (eXecute Never) */
 #define NOT_EXEC MPU_RASR_XN_Msk
@@ -126,7 +124,8 @@
 #define REGION_FLASH_ATTR(size)                                                                    \
 	{(NORMAL_OUTER_INNER_WRITE_THROUGH_NON_SHAREABLE | size | P_RW_U_RO_Msk)}
 #else
-#define REGION_FLASH_ATTR(size) {(NORMAL_OUTER_INNER_WRITE_THROUGH_NON_SHAREABLE | size | RO_Msk)}
+#define REGION_FLASH_ATTR(size)                                                                    \
+	{(NORMAL_OUTER_INNER_WRITE_THROUGH_NON_SHAREABLE | size | P_RO_U_RO_Msk)}
 #endif
 #define REGION_PPB_ATTR(size)    {(STRONGLY_ORDERED_SHAREABLE | size | P_RW_U_NA_Msk)}
 #define REGION_IO_ATTR(size)     {(DEVICE_NON_SHAREABLE | size | P_RW_U_NA_Msk)}


### PR DESCRIPTION
This file previously defined an MPU access permission mode of 0x7 which corresponded to privileged read-only, unprivileged read-only, similar to mode 0x6. However, it appears that at least Cortex-R5 does not support this mode, defining 0x7 as UNP (Unpredictable) or a value which should not be used.

This value was in turn referenced by the REGION_FLASH_ATTR macro, which caused the offending value to be used when a memory region was declared as DT_MEM_ARM(ATTR_MPU_FLASH) in the device tree, causing such regions to not work properly on Cortex-R5.

Since 0x6 is supported by both Cortex-M and Cortex-R and does the same thing, there is no reason to use 0x7. Remove the RO_Msk definition which referenced it, and change REGION_FLASH_ATTR to use P_RO_U_RO_Msk instead.