### PR TITLE
drivers: sensor: Add Vishay VEML6031 Ambient Light Sensor - V3

### DIFF
--- a/drivers/sensor/vishay/CMakeLists.txt
+++ b/drivers/sensor/vishay/CMakeLists.txt
@@ -4,5 +4,6 @@
 # zephyr-keep-sorted-start
 add_subdirectory_ifdef(CONFIG_VCNL36825T vcnl36825t)
 add_subdirectory_ifdef(CONFIG_VCNL4040 vcnl4040)
+add_subdirectory_ifdef(CONFIG_VEML6031 veml6031)
 add_subdirectory_ifdef(CONFIG_VEML7700 veml7700)
 # zephyr-keep-sorted-stop

--- a/drivers/sensor/vishay/Kconfig
+++ b/drivers/sensor/vishay/Kconfig
@@ -4,5 +4,6 @@
 # zephyr-keep-sorted-start
 source "drivers/sensor/vishay/vcnl36825t/Kconfig"
 source "drivers/sensor/vishay/vcnl4040/Kconfig"
+source "drivers/sensor/vishay/veml6031/Kconfig"
 source "drivers/sensor/vishay/veml7700/Kconfig"
 # zephyr-keep-sorted-stop

--- a/drivers/sensor/vishay/veml6031/CMakeLists.txt
+++ b/drivers/sensor/vishay/veml6031/CMakeLists.txt
@@ -1,0 +1,5 @@
+# Copyright (c) 2025 Andreas Klinger
+# SPDX-License-Identifier: Apache-2.0
+
+zephyr_library()
+zephyr_library_sources(veml6031.c)

--- a/drivers/sensor/vishay/veml6031/Kconfig
+++ b/drivers/sensor/vishay/veml6031/Kconfig
@@ -1,0 +1,12 @@
+# Copyright (c) 2025 Andreas Klinger
+# SPDX-License-Identifier: Apache-2.0
+
+# Vishay VEML6031 ambient light sensor driver options.
+
+config VEML6031
+	bool "Vishay VEML6031 ambient light sensor"
+	default y
+	depends on DT_HAS_VISHAY_VEML6031_ENABLED
+	select I2C
+	help
+	  Enable Vishay VEML6031 ambient light sensor driver.

--- a/drivers/sensor/vishay/veml6031/veml6031.c
+++ b/drivers/sensor/vishay/veml6031/veml6031.c
@@ -1,0 +1,617 @@
+/*
+ * Copyright (c) 2025 Andreas Klinger
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT vishay_veml6031
+
+#include <zephyr/device.h>
+#include <zephyr/drivers/i2c.h>
+#include <zephyr/drivers/sensor.h>
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/pm/device.h>
+#include <zephyr/sys/byteorder.h>
+
+#include <zephyr/drivers/sensor/veml6031.h>
+
+LOG_MODULE_REGISTER(VEML6031, CONFIG_SENSOR_LOG_LEVEL);
+
+/*
+ * ID code of device
+ */
+#define VEML6031_DEFAULT_ID 0x01
+
+/*
+ * Bit mask to check for data ready in single measurement.
+ */
+#define VEML6031_ALS_AF_DATA_READY BIT(3)
+
+/*
+ * Maximum value of ALS data which also means that the sensor is in saturation
+ * and that the measured value might be wrong.
+ * In such a case the user program should reduce one or more of the following
+ * attributes to get a relyable value:
+ *   gain
+ *   integration time
+ *   effective photodiode size
+ *
+ */
+#define VEML6031_ALS_DATA_OVERFLOW 0xFFFF
+
+/*
+ * 16-bit command register addresses
+ */
+#define VEML6031_CMDCODE_ALS_CONF_0 0x00
+#define VEML6031_CMDCODE_ALS_CONF_1 0x01
+#define VEML6031_CMDCODE_ALS_WH_L   0x04
+#define VEML6031_CMDCODE_ALS_WH_H   0x05
+#define VEML6031_CMDCODE_ALS_WL_L   0x06
+#define VEML6031_CMDCODE_ALS_WL_H   0x07
+#define VEML6031_CMDCODE_ALS_DATA_L 0x10
+#define VEML6031_CMDCODE_ALS_DATA_H 0x11
+#define VEML6031_CMDCODE_IR_DATA_L  0x12
+#define VEML6031_CMDCODE_IR_DATA_H  0x13
+#define VEML6031_CMDCODE_ID_L       0x14
+#define VEML6031_CMDCODE_ID_H       0x15
+#define VEML6031_CMDCODE_ALS_INT    0x17
+
+/*
+ * ALS integration time struct.
+ */
+struct veml6031_it_data {
+	enum veml6031_it num;
+	uint8_t val;
+	int us;
+};
+
+/*
+ * ALS integration time setting values.
+ *
+ * The enumerators of <tt>enum veml6031_it</tt> provide
+ * indices into this array to get the related value for the
+ * ALS_IT configuration bits.
+ */
+static const struct veml6031_it_data veml6031_it_values[] = {
+	{VEML6031_IT_3_125, 0x00, 3125}, /*   3.125 - 0b0000 */
+	{VEML6031_IT_6_25, 0x01, 6250},  /*   6.25  - 0b0001 */
+	{VEML6031_IT_12_5, 0x02, 12500}, /*  12.5   - 0b0010 */
+	{VEML6031_IT_25, 0x03, 25000},   /*  25     - 0b0011 */
+	{VEML6031_IT_50, 0x04, 50000},   /*  50     - 0b0100 */
+	{VEML6031_IT_100, 0x05, 100000}, /* 100     - 0b0101 */
+	{VEML6031_IT_200, 0x06, 200000}, /* 200     - 0b0110 */
+	{VEML6031_IT_400, 0x07, 400000}, /* 400     - 0b0111 */
+};
+
+/*
+ * Resolution matrix for values to convert between data provided
+ * by the sensor ("counts") and lux.
+ *
+ * These values depend on the current size, gain and integration time settings.
+ * The enumerators of <tt>enum veml6031_div4</tt>, <tt>enum veml6031_gain</tt>
+ * and <tt>enum veml6031_als_it</tt> are used for indices into this matrix.
+ */
+static const float
+	veml6031_resolution[VEML6031_DIV4_COUNT][VEML6031_GAIN_COUNT][VEML6031_IT_COUNT] = {
+		/*3.125ms   6.25ms   12.5ms     25ms     50ms    100ms    200ms     400ms IT */
+		/* size 4/4 */
+		{
+			{0.8704f, 0.4352f, 0.2176f, 0.1088f, 0.0544f, 0.0272f, 0.0136f,
+			 0.0068f}, /* Gain 1    */
+			{0.4352f, 0.2176f, 0.1088f, 0.0544f, 0.0272f, 0.0136f, 0.0068f,
+			 0.0034f}, /* Gain 2    */
+			{1.3188f, 0.6504f, 0.3297f, 0.1648f, 0.0824f, 0.0412f, 0.0206f,
+			 0.0103f}, /* Gain 0.66 */
+			{1.7408f, 0.8704f, 0.4352f, 0.2176f, 0.1088f, 0.0544f, 0.0272f,
+			 0.0136f}, /* Gain 0.5  */
+		},
+		{
+			/* size 1/4 */
+			{3.4816f, 1.7408f, 0.8704f, 0.4352f, 0.2176f, 0.1088f, 0.0544f,
+			 0.0272f}, /* Gain 1    */
+			{1.7408f, 0.8704f, 0.4352f, 0.2176f, 0.1088f, 0.0544f, 0.0272f,
+			 0.0136f}, /* Gain 2    */
+			{5.2752f, 2.6376f, 1.3188f, 0.6594f, 0.3297f, 0.1648f, 0.0824f,
+			 0.0412f}, /* Gain 0.66 */
+			{6.9632f, 3.4816f, 1.7408f, 0.8704f, 0.4352f, 0.2176f, 0.1088f,
+			 0.0544f}, /* Gain 0.5  */
+		},
+};
+
+struct veml6031_config {
+	struct i2c_dt_spec bus;
+};
+
+struct veml6031_data {
+	uint8_t sd;              /* Band gap and LDO shutdown */
+	uint8_t int_en;          /* ALS interrupt enable */
+	uint8_t trig;            /* ALS active force trigger */
+	uint8_t af;              /* Active force mode */
+	uint8_t ir_sd;           /* ALS and IR channel shutdown */
+	uint8_t cal;             /* Power on ready */
+	enum veml6031_div4 div4; /* effective photodiode size */
+	enum veml6031_gain gain; /* gain selection */
+	enum veml6031_it itim;   /* ALS integration time */
+	enum veml6031_pers pers; /* ALS persistens protect */
+	uint16_t thresh_high;
+	uint16_t thresh_low;
+	uint16_t als_data;
+	uint32_t als_lux;
+	uint16_t ir_data;
+	uint32_t int_flags;
+};
+
+static void veml6031_sleep_by_integration_time(const struct veml6031_data *data)
+{
+	k_sleep(K_USEC(veml6031_it_values[data->itim].us));
+}
+
+static int veml6031_check_gain(const struct sensor_value *val)
+{
+	return val->val1 >= VEML6031_GAIN_1 && val->val1 <= VEML6031_GAIN_0_5;
+}
+
+static int veml6031_check_it(const struct sensor_value *val)
+{
+	return val->val1 >= VEML6031_IT_3_125 && val->val1 <= VEML6031_IT_400;
+}
+
+static int veml6031_check_div4(const struct sensor_value *val)
+{
+	return val->val1 >= VEML6031_SIZE_4_4 && val->val1 <= VEML6031_SIZE_1_4;
+}
+
+static int veml6031_check_pers(const struct sensor_value *val)
+{
+	return val->val1 >= VEML6031_PERS_1 && val->val1 <= VEML6031_PERS_8;
+}
+
+static int veml6031_read(const struct device *dev, uint8_t cmd, uint8_t *data)
+{
+	const struct veml6031_config *conf = dev->config;
+
+	uint8_t recv_buf;
+	int ret;
+
+	ret = i2c_reg_read_byte_dt(&conf->bus, cmd, &recv_buf);
+	if (ret < 0) {
+		return ret;
+	}
+
+	*data = recv_buf;
+
+	return 0;
+}
+
+static int veml6031_read16(const struct device *dev, uint8_t cmd, uint8_t *data)
+{
+	const struct veml6031_config *conf = dev->config;
+	int ret;
+
+	ret = i2c_burst_read_dt(&conf->bus, cmd, data, 2);
+	if (ret < 0) {
+		return ret;
+	}
+
+	return 0;
+}
+
+static int veml6031_write16(const struct device *dev, uint8_t cmd, uint8_t *data)
+{
+	const struct veml6031_config *conf = dev->config;
+
+	return i2c_burst_write_dt(&conf->bus, cmd, data, 2);
+}
+
+static int veml6031_write_conf(const struct device *dev)
+{
+	int ret;
+	struct veml6031_data *data = dev->data;
+	uint8_t conf[2] = {0, 0};
+
+	/* Bits 7 -> ALS and IR channel shutdown */
+	conf[1] |= data->ir_sd << 7;
+	/* Bits 6 -> Effective photodiode size */
+	conf[1] |= data->div4 << 6;
+	/* Bit 5 -> reserved */
+	/* Bits 4:3 -> Gain selection */
+	conf[1] |= data->gain << 3;
+	/* Bits 2:1 -> ALS persistence protect number */
+	conf[1] |= data->pers << 1;
+	/* Bit 0 -> Power on ready */
+	if (data->cal) {
+		conf[1] |= BIT(0);
+	}
+	/* Bit 7 -> reserved, have to be 0 */
+	/* Bits 6:4 -> integration time (ALS_IT) */
+	conf[0] |= data->itim << 4;
+	/* Bit 3 -> Active force mode enable */
+	if (data->af) {
+		conf[0] |= BIT(3);
+	}
+	/* Bit 2 -> ALS active force trigger */
+	if (data->trig) {
+		conf[0] |= BIT(2);
+	}
+	/* Bit 1 -> ALS interrupt enable */
+	if (data->int_en) {
+		conf[0] |= BIT(1);
+	}
+	/* Bit 0 -> shut down setting (SD) */
+	if (data->sd) {
+		conf[0] |= BIT(0);
+	}
+
+	ret = veml6031_write16(dev, VEML6031_CMDCODE_ALS_CONF_0, conf);
+	if (ret) {
+		LOG_ERR("Error while writing conf[0] ret: %d", ret);
+		return ret;
+	}
+
+	return 0;
+}
+
+static int veml6031_write_thresh_high(const struct device *dev)
+{
+	int ret;
+	const struct veml6031_data *data = dev->data;
+	uint8_t val[2];
+
+	val[0] = data->thresh_high & 0xFF;
+	val[1] = data->thresh_high >> 8;
+
+	LOG_DBG("Writing high threshold counts: %d", data->thresh_high);
+	ret = veml6031_write16(dev, VEML6031_CMDCODE_ALS_WH_L, val);
+	if (ret) {
+		return ret;
+	}
+
+	return 0;
+}
+
+static int veml6031_write_thresh_low(const struct device *dev)
+{
+	int ret;
+	const struct veml6031_data *data = dev->data;
+	uint8_t val[2];
+
+	val[0] = data->thresh_low & 0xFF;
+	val[1] = data->thresh_low >> 8;
+
+	LOG_DBG("Writing low threshold counts: %d", data->thresh_low);
+	ret = veml6031_write16(dev, VEML6031_CMDCODE_ALS_WL_L, val);
+	if (ret) {
+		return ret;
+	}
+
+	return 0;
+}
+
+static int veml6031_fetch(const struct device *dev)
+{
+	struct veml6031_data *data = dev->data;
+	int ret;
+
+	ret = veml6031_read16(dev, VEML6031_CMDCODE_ALS_DATA_L, (uint8_t *)&data->als_data);
+	if (ret < 0) {
+		return ret;
+	}
+	data->als_data = sys_le16_to_cpu(data->als_data);
+
+	ret = veml6031_read16(dev, VEML6031_CMDCODE_IR_DATA_L, (uint8_t *)&data->ir_data);
+	if (ret < 0) {
+		return ret;
+	}
+	data->ir_data = sys_le16_to_cpu(data->ir_data);
+
+	data->als_lux = data->als_data * veml6031_resolution[data->div4][data->gain][data->itim];
+
+	LOG_DBG("Read ALS measurement: counts=%d, lux=%d ir=%d", data->als_data, data->als_lux,
+		data->ir_data);
+
+	if (data->als_data == VEML6031_ALS_DATA_OVERFLOW) {
+		return -E2BIG;
+	}
+
+	return 0;
+}
+
+static int veml6031_attr_set(const struct device *dev, enum sensor_channel chan,
+			     enum sensor_attribute attr, const struct sensor_value *val)
+{
+	struct veml6031_data *data = dev->data;
+
+	if (chan != SENSOR_CHAN_LIGHT) {
+		return -ENOTSUP;
+	}
+
+	/* SENSOR_ATTR_.*_THRESH are not in enum sensor_attribute_veml6031 */
+	switch ((int)attr) {
+	case SENSOR_ATTR_VEML6031_IT:
+		if (veml6031_check_it(val)) {
+			data->itim = (enum veml6031_it)val->val1;
+		} else {
+			return -EINVAL;
+		}
+		break;
+	case SENSOR_ATTR_VEML6031_DIV4:
+		if (veml6031_check_div4(val)) {
+			data->div4 = (enum veml6031_div4)val->val1;
+		} else {
+			return -EINVAL;
+		}
+		break;
+	case SENSOR_ATTR_VEML6031_GAIN:
+		if (veml6031_check_gain(val)) {
+			data->gain = (enum veml6031_gain)val->val1;
+		} else {
+			return -EINVAL;
+		}
+		break;
+	case SENSOR_ATTR_VEML6031_PERS:
+		if (veml6031_check_pers(val)) {
+			data->pers = (enum veml6031_pers)val->val1;
+		} else {
+			return -EINVAL;
+		}
+		break;
+	case SENSOR_ATTR_LOWER_THRESH:
+		data->thresh_low =
+			val->val1 / veml6031_resolution[data->div4][data->gain][data->itim];
+		return veml6031_write_thresh_low(dev);
+	case SENSOR_ATTR_UPPER_THRESH:
+		data->thresh_high =
+			val->val1 / veml6031_resolution[data->div4][data->gain][data->itim];
+		return veml6031_write_thresh_high(dev);
+	default:
+		return -ENOTSUP;
+	}
+
+	return 0;
+}
+
+static int veml6031_attr_get(const struct device *dev, enum sensor_channel chan,
+			     enum sensor_attribute attr, struct sensor_value *val)
+{
+	struct veml6031_data *data = dev->data;
+
+	if (chan != SENSOR_CHAN_LIGHT) {
+		return -ENOTSUP;
+	}
+
+	/* SENSOR_ATTR_.*_THRESH are not in enum sensor_attribute_veml6031 */
+	switch ((int)attr) {
+	case SENSOR_ATTR_VEML6031_IT:
+		val->val1 = data->itim;
+		break;
+	case SENSOR_ATTR_VEML6031_DIV4:
+		val->val1 = data->div4;
+		break;
+	case SENSOR_ATTR_VEML6031_GAIN:
+		val->val1 = data->gain;
+		break;
+	case SENSOR_ATTR_VEML6031_PERS:
+		val->val1 = data->pers;
+		break;
+	case SENSOR_ATTR_LOWER_THRESH:
+		val->val1 = data->thresh_low;
+		break;
+	case SENSOR_ATTR_UPPER_THRESH:
+		val->val1 = data->thresh_high;
+		break;
+	default:
+		return -ENOTSUP;
+	}
+
+	val->val2 = 0;
+
+	return 0;
+}
+
+static int veml6031_perform_single_measurement(const struct device *dev)
+{
+	struct veml6031_data *data = dev->data;
+	int ret;
+	uint8_t val;
+	int cnt = 0;
+
+	data->ir_sd = 0;
+	data->cal = 1;
+	data->af = 1;
+	data->trig = 1;
+	data->int_en = 0;
+	data->sd = 0;
+
+	ret = veml6031_write_conf(dev);
+	if (ret) {
+		return ret;
+	}
+
+	ret = veml6031_read(dev, VEML6031_CMDCODE_ALS_INT, &val);
+
+	veml6031_sleep_by_integration_time(data);
+
+	while (1) {
+		ret = veml6031_read(dev, VEML6031_CMDCODE_ALS_INT, &val);
+		if (ret) {
+			return ret;
+		}
+
+		if (val & VEML6031_ALS_AF_DATA_READY) {
+			break;
+		}
+
+		k_sleep(K_MSEC(1));
+
+		cnt++;
+	}
+
+	LOG_DBG("read VEML6031_CMDCODE_ALS_INT: %02X (%d)", val, cnt);
+
+	return 0;
+}
+
+static int veml6031_sample_fetch(const struct device *dev, enum sensor_channel chan)
+{
+	int ret;
+
+	/* Start sensor for new measurement */
+	if (chan == SENSOR_CHAN_LIGHT || chan == SENSOR_CHAN_ALL) {
+		ret = veml6031_perform_single_measurement(dev);
+		if (ret < 0) {
+			return ret;
+		}
+
+		return veml6031_fetch(dev);
+	} else {
+		return -ENOTSUP;
+	}
+
+	return 0;
+}
+
+static int veml6031_channel_get(const struct device *dev, enum sensor_channel chan,
+				struct sensor_value *val)
+{
+	struct veml6031_data *data = dev->data;
+
+	switch ((int)chan) {
+	case SENSOR_CHAN_LIGHT:
+		val->val1 = data->als_lux;
+		break;
+	case SENSOR_CHAN_VEML6031_ALS_RAW_COUNTS:
+		val->val1 = data->als_data;
+		break;
+	case SENSOR_CHAN_VEML6031_IR_RAW_COUNTS:
+		val->val1 = data->ir_data;
+		break;
+	default:
+		return -ENOTSUP;
+	}
+
+	val->val2 = 0;
+
+	return 0;
+}
+
+#ifdef CONFIG_PM_DEVICE
+
+static int veml6031_set_shutdown_flag(const struct device *dev, uint8_t new_val)
+{
+	struct veml6031_data *data = dev->data;
+	uint8_t prev_sd;
+	uint8_t prev_ir_sd;
+	int ret;
+
+	prev_sd = data->sd;
+	prev_ir_sd = data->ir_sd;
+	data->sd = new_val;
+	data->ir_sd = new_val;
+
+	ret = veml6031_write_conf(dev);
+	if (ret < 0) {
+		data->ir_sd = prev_ir_sd;
+		data->sd = prev_sd;
+	}
+	return ret;
+}
+
+static int veml6031_pm_action(const struct device *dev, enum pm_device_action action)
+{
+	struct veml6031_data *data = dev->data;
+
+	if (!data->sd) {
+		switch (action) {
+		case PM_DEVICE_ACTION_SUSPEND:
+			return veml6031_set_shutdown_flag(dev, 1);
+
+		case PM_DEVICE_ACTION_RESUME:
+			return veml6031_set_shutdown_flag(dev, 0);
+
+		default:
+			return -ENOTSUP;
+		}
+	}
+
+	return 0;
+}
+
+#endif /* CONFIG_PM_DEVICE */
+
+static int veml6031_init(const struct device *dev)
+{
+	const struct veml6031_config *conf = dev->config;
+	int ret;
+	uint8_t val8;
+
+	if (!i2c_is_ready_dt(&conf->bus)) {
+		LOG_ERR("VEML device not ready");
+		return -ENODEV;
+	}
+
+	ret = veml6031_read(dev, VEML6031_CMDCODE_ID_L, &val8);
+	if (ret < 0) {
+		LOG_ERR("Error while reading ID low. ret: %d", ret);
+		return ret;
+	}
+	if (val8 != VEML6031_DEFAULT_ID) {
+		LOG_ERR("Device ID wrong: %d", val8);
+		return -EIO;
+	}
+	ret = veml6031_read(dev, VEML6031_CMDCODE_ID_H, &val8);
+	if (ret < 0) {
+		LOG_ERR("Error while reading ID high. ret: %d", ret);
+		return ret;
+	}
+	LOG_DBG("veml6031 found package: %02d address: %02X version: %3s", val8 >> 6,
+		val8 >> 4 & 0x03 ? 0x10 : 0x29, val8 & 0x0F ? "XXX" : "A01");
+
+	/* Initialize sensor configuration */
+	ret = veml6031_write_thresh_low(dev);
+	if (ret < 0) {
+		LOG_ERR("Error while writing thresh low. ret: %d", ret);
+		return ret;
+	}
+
+	ret = veml6031_write_thresh_high(dev);
+	if (ret < 0) {
+		LOG_ERR("Error while writing thresh high. ret: %d", ret);
+		return ret;
+	}
+
+	ret = veml6031_write_conf(dev);
+	if (ret < 0) {
+		LOG_ERR("Error while writing conf. ret: %d", ret);
+		return ret;
+	}
+
+	return 0;
+}
+
+static DEVICE_API(sensor, veml6031_api) = {
+	.sample_fetch = veml6031_sample_fetch,
+	.channel_get = veml6031_channel_get,
+	.attr_set = veml6031_attr_set,
+	.attr_get = veml6031_attr_get,
+};
+
+#define VEML6031_INIT(n)                                                                           \
+	static struct veml6031_data veml6031_data_##n = {.trig = 1,                                \
+							 .af = 1,                                  \
+							 .div4 = VEML6031_SIZE_4_4,                \
+							 .gain = VEML6031_GAIN_1,                  \
+							 .itim = VEML6031_IT_100,                  \
+							 .pers = VEML6031_PERS_1,                  \
+							 .thresh_high = 0xFFFF};                   \
+                                                                                                   \
+	static const struct veml6031_config veml6031_config_##n = {                                \
+		.bus = I2C_DT_SPEC_INST_GET(n)};                                                   \
+                                                                                                   \
+	PM_DEVICE_DT_INST_DEFINE(n, veml6031_pm_action);                                           \
+                                                                                                   \
+	SENSOR_DEVICE_DT_INST_DEFINE(n, veml6031_init, PM_DEVICE_DT_INST_GET(n),                   \
+				     &veml6031_data_##n, &veml6031_config_##n, POST_KERNEL,        \
+				     CONFIG_SENSOR_INIT_PRIORITY, &veml6031_api);
+
+DT_INST_FOREACH_STATUS_OKAY(VEML6031_INIT)

--- a/dts/bindings/sensor/vishay,veml6031.yaml
+++ b/dts/bindings/sensor/vishay,veml6031.yaml
@@ -1,0 +1,10 @@
+# Copyright (c) 2025 Andreas Klinger
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+    Vishay VEML6031 High Accuracy Ambient Light Sensor With I2C Interface.
+    See: https://www.vishay.com/docs/80007/veml6031x00.pdf
+
+compatible: "vishay,veml6031"
+
+include: [sensor-device.yaml, i2c-device.yaml]

--- a/include/zephyr/drivers/sensor/veml6031.h
+++ b/include/zephyr/drivers/sensor/veml6031.h
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2025 Andreas Klinger
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_SENSOR_VEML6031_H_
+#define ZEPHYR_INCLUDE_DRIVERS_SENSOR_VEML6031_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief ALS integration time settings in veml6031_it
+ */
+#define VEML6031_IT_COUNT 8
+
+/**
+ * @brief Effective photodiode size in enum veml6031_size.
+ */
+#define VEML6031_DIV4_COUNT 2
+
+/**
+ * @brief Gain selections in enum veml6031_gain.
+ */
+#define VEML6031_GAIN_COUNT 4
+
+/**
+ * @brief VEML6031 integration time options for ambient light measurements.
+ */
+enum veml6031_it {
+	VEML6031_IT_3_125,
+	VEML6031_IT_6_25,
+	VEML6031_IT_12_5,
+	VEML6031_IT_25,
+	VEML6031_IT_50,
+	VEML6031_IT_100,
+	VEML6031_IT_200,
+	VEML6031_IT_400,
+};
+
+/**
+ * @brief VEML6031 size options for ambient light measurements.
+ */
+enum veml6031_div4 {
+	VEML6031_SIZE_4_4 = 0x00, /* 0b0 */
+	VEML6031_SIZE_1_4 = 0x01, /* 0b1 */
+};
+
+/**
+ * @brief VEML6031 gain options for ambient light measurements.
+ */
+enum veml6031_gain {
+	VEML6031_GAIN_1 = 0x00,    /* 0b00 */
+	VEML6031_GAIN_2 = 0x01,    /* 0b01 */
+	VEML6031_GAIN_0_66 = 0x02, /* 0b10 */
+	VEML6031_GAIN_0_5 = 0x03,  /* 0b11 */
+};
+
+/**
+ * @brief VEML6031 ALS interrupt persistence protect number options.
+ */
+enum veml6031_pers {
+	VEML6031_PERS_1 = 0x00, /* 0b00 */
+	VEML6031_PERS_2 = 0x01, /* 0b01 */
+	VEML6031_PERS_4 = 0x02, /* 0b10 */
+	VEML6031_PERS_8 = 0x03, /* 0b11 */
+};
+
+/**
+ * @brief VEML6031 specific sensor attributes.
+ *
+ * For high and low threshold window settings (ALS_WH_L, ALS_WH_H, ALS_WL_L and
+ * ALS_WL_H) use the generic attributes <tt>SENSOR_ATTR_UPPER_THRESH</tt> and
+ * <tt>SENSOR_ATTR_LOWER_THRESH</tt> with 16-bit unsigned integer values. Both
+ * threshold settings are in lux and converted by the driver to a value
+ * compatible with the sensor. This conversion depends on the current gain,
+ * integration time and effective photodiode size settings. So a change in
+ * gain, integration time or effective photodiode size usually requires an
+ * update of threshold window settings. To get the correct threshold values
+ * into the sensor update the thresholds -after- a change of gain or
+ * integration time.
+ *
+ * All attributes must be set for the <tt>SENSOR_CHAN_LIGHT</tt> channel.
+ *
+ * When the sensor goes into saturation <tt>-E2BIG</tt> is returned. This
+ * happens when the maximum value <tt>0xFFFF</tt> is returned as raw ALS value.
+ * In this case it's up to the user to reduce one or more of the following
+ * attributes to come back into the optimal measurement range of the sensor:
+ *  <tt>SENSOR_ATTR_VEML6031_GAIN</tt> (gain)
+ *  <tt>SENSOR_ATTR_VEML6031_IT</tt> (integration time)
+ *  <tt>SENSOR_ATTR_VEML6031_DIV4</tt> (effective photodiode size)
+ */
+enum sensor_attribute_veml6031 {
+	/**
+	 * @brief Integration time setting for ALS measurements (IT).
+	 *
+	 * Use enum veml6031_it for attribute values.
+	 */
+	SENSOR_ATTR_VEML6031_IT = SENSOR_ATTR_PRIV_START,
+	/**
+	 * @brief Effective photodiode size (DIV4)
+	 *
+	 * Use enum veml6031_div4 for attribute values.
+	 */
+	SENSOR_ATTR_VEML6031_DIV4,
+	/**
+	 * @brief Gain setting for ALS measurements (GAIN).
+	 *
+	 * Use enum veml6031_gain for attribute values.
+	 */
+	SENSOR_ATTR_VEML6031_GAIN,
+	/**
+	 * @brief ALS persistence protect number setting (PERS).
+	 *
+	 * Use enum veml6031_pers for attribute values.
+	 */
+	SENSOR_ATTR_VEML6031_PERS,
+};
+
+/**
+ * @brief VEML6031 specific sensor channels.
+ */
+enum sensor_channel_veml6031 {
+	/**
+	 * @brief Channel for raw ALS sensor values.
+	 *
+	 * This channel represents the raw measurement counts provided by the
+	 * sensor ALS register. It is useful for estimating good values for
+	 * integration time, effective photodiode size and gain attributes in
+	 * fetch and get mode.
+	 *
+	 * For future implementations with triggers it can also be used to
+	 * estimate the threshold window attributes for the sensor interrupt
+	 * handling.
+	 *
+	 * It cannot be fetched directly. Instead, this channel's value is
+	 * fetched implicitly using <tt>SENSOR_CHAN_LIGHT</tt>. Trying to call
+	 * <tt>sensor_channel_fetch_chan()</tt> with this enumerator as an
+	 * argument will result in a <tt>-ENOTSUP</tt>.
+	 */
+	SENSOR_CHAN_VEML6031_ALS_RAW_COUNTS = SENSOR_CHAN_PRIV_START,
+
+	/**
+	 * @brief Channel for IR sensor values.
+	 *
+	 * This channel is the raw IR Channel count output of the sensor. About
+	 * fetching the same as for
+	 * <tt>SENSOR_CHAN_VEML6031_ALS_RAW_COUNTS</tt> applies.
+	 */
+	SENSOR_CHAN_VEML6031_IR_RAW_COUNTS,
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_SENSOR_VEML6031_H_ */

--- a/samples/sensor/veml6031/CMakeLists.txt
+++ b/samples/sensor/veml6031/CMakeLists.txt
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(veml6031)
+
+target_sources(app PRIVATE src/main.c)

--- a/samples/sensor/veml6031/README.rst
+++ b/samples/sensor/veml6031/README.rst
@@ -1,0 +1,92 @@
+.. zephyr:code-sample:: veml6031
+   :name: VEML6031 High Accuracy Ambient Light Sensor
+   :relevant-api: sensor_interface
+
+   Get ambient light data from a VEML4040 sensor (polling mode).
+
+Overview
+********
+
+ This sample measures the ambient light for all possible combinations of sensor
+ attributes. There are:
+ - integration time
+ - effective photodiode size
+ - gain
+ These attributes can be used to put the sensor in an optimal working area.
+ When the light value reaches the maximum raw value (0xFFFF) an error is
+ returned to indicate the out of bounds situation to the user program.
+ With this program the raw value is also printed out together with the
+ attributes to be able to select good attribute values.
+ Interrupt and trigger mode is not supported so far, but planned for future
+ development.
+
+Requirements
+************
+
+ This sample uses the VEML6031 sensor controlled using the I2C-2 interface at
+ the Olimex-STM32-E407 board on feather PF0 and PF1.
+
+References
+**********
+
+ - VEML6031: https://www.vishay.com/docs/80007/veml6031x00.pdf
+
+Building and Running
+********************
+
+ This project outputs sensor data to the console. It requires a VEML6031
+ sensor to be connected to the desired board.
+
+ .. zephyr-app-commands::
+    :zephyr-app: samples/sensor/veml6031/
+    :goals: build flash
+
+
+Sample Output
+=============
+
+ .. code-block:: console
+
+    Test all attributes for a good guess of attribute usage away of saturation.
+    Light (lux):   6179 ALS (raw):   7100 IR (raw):     27   it: 0 div4: 0 gain: 0  --
+    Light (lux):   1500 ALS (raw):   3447 IR (raw):     34   it: 0 div4: 0 gain: 1  --
+    Light (lux):   4664 ALS (raw):   3537 IR (raw):     17   it: 0 div4: 0 gain: 2  --
+    Light (lux):   5601 ALS (raw):   3218 IR (raw):     13   it: 0 div4: 0 gain: 3  --
+    Light (lux):   1302 ALS (raw):    374 IR (raw):      5   it: 0 div4: 1 gain: 0  --
+    Light (lux):   5584 ALS (raw):   3208 IR (raw):     11   it: 0 div4: 1 gain: 1  --
+    Light (lux):   5285 ALS (raw):   1002 IR (raw):      3   it: 0 div4: 1 gain: 2  --
+    Light (lux):   1455 ALS (raw):    209 IR (raw):      2   it: 0 div4: 1 gain: 3  --
+    Light (lux):   4925 ALS (raw):  11317 IR (raw):     50   it: 1 div4: 0 gain: 0  --
+    Light (lux):   3916 ALS (raw):  17999 IR (raw):     90   it: 1 div4: 0 gain: 1  --
+    Light (lux):   2796 ALS (raw):   4299 IR (raw):     28   it: 1 div4: 0 gain: 2  --
+    Light (lux):   5178 ALS (raw):   5950 IR (raw):     26   it: 1 div4: 0 gain: 3  --
+    Light (lux):   4339 ALS (raw):   2493 IR (raw):     12   it: 1 div4: 1 gain: 0  --
+    Light (lux):   2186 ALS (raw):   2512 IR (raw):     19   it: 1 div4: 1 gain: 1  --
+    Light (lux):   5578 ALS (raw):   2115 IR (raw):      8   it: 1 div4: 1 gain: 2  --
+    Light (lux):   4494 ALS (raw):   1291 IR (raw):      6   it: 1 div4: 1 gain: 3  --
+    Light (lux):   3675 ALS (raw):  16892 IR (raw):     93   it: 2 div4: 0 gain: 0  --
+    Light (lux):   3209 ALS (raw):  29495 IR (raw):    172   it: 2 div4: 0 gain: 1  --
+    Light (lux):   4520 ALS (raw):  13710 IR (raw):     66   it: 2 div4: 0 gain: 2  --
+    Light (lux):   4215 ALS (raw):   9687 IR (raw):     49   it: 2 div4: 0 gain: 3  --
+    Light (lux):   3492 ALS (raw):   4013 IR (raw):     22   it: 2 div4: 1 gain: 0  --
+    Light (lux):   3786 ALS (raw):   8700 IR (raw):     43   it: 2 div4: 1 gain: 1  --
+    Light (lux):   4735 ALS (raw):   3591 IR (raw):     15   it: 2 div4: 1 gain: 2  --
+    Light (lux):   3779 ALS (raw):   2171 IR (raw):     11   it: 2 div4: 1 gain: 3  --
+    Light (lux):   3848 ALS (raw):  35376 IR (raw):    188   it: 3 div4: 0 gain: 0  --
+    Light (lux):   3565 ALS (raw):  65535 IR (raw):    359   it: 3 div4: 0 gain: 1  --  OVERFLOW
+    Light (lux):   4333 ALS (raw):  26297 IR (raw):    130   it: 3 div4: 0 gain: 2  --
+    Light (lux):   3576 ALS (raw):  16435 IR (raw):     93   it: 3 div4: 0 gain: 3  --
+    Light (lux):   4409 ALS (raw):  10133 IR (raw):     47   it: 3 div4: 1 gain: 0  --
+    Light (lux):   3395 ALS (raw):  15606 IR (raw):     85   it: 3 div4: 1 gain: 1  --
+    Light (lux):   4519 ALS (raw):   6854 IR (raw):     31   it: 3 div4: 1 gain: 2  --
+    Light (lux):   3694 ALS (raw):   4245 IR (raw):     23   it: 3 div4: 1 gain: 3  --
+    Light (lux):   3565 ALS (raw):  65535 IR (raw):    376   it: 4 div4: 0 gain: 0  --  OVERFLOW
+    Light (lux):   1782 ALS (raw):  65535 IR (raw):    723   it: 4 div4: 0 gain: 1  --  OVERFLOW
+    Light (lux):   3992 ALS (raw):  48450 IR (raw):    253   it: 4 div4: 0 gain: 2  --
+    Light (lux):   3943 ALS (raw):  36247 IR (raw):    191   it: 4 div4: 0 gain: 3  --
+    Light (lux):   3970 ALS (raw):  18248 IR (raw):     92   it: 4 div4: 1 gain: 0  --
+    Light (lux):   3814 ALS (raw):  35064 IR (raw):    176   it: 4 div4: 1 gain: 1  --
+    Light (lux):   4082 ALS (raw):  12381 IR (raw):     62   it: 4 div4: 1 gain: 2  --
+    Light (lux):   4052 ALS (raw):   9311 IR (raw):     47   it: 4 div4: 1 gain: 3  --
+    [...]
+    Test finished.

--- a/samples/sensor/veml6031/boards/olimex_stm32_e407.overlay
+++ b/samples/sensor/veml6031/boards/olimex_stm32_e407.overlay
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2025 Andreas Klinger
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&pinctrl {
+	i2c2_sda_pf0: i2c2_sda_pf0 {
+		pinmux = < 0xa04 >;
+		bias-pull-up;
+		drive-open-drain;
+	};
+	i2c2_scl_pf1: i2c2_scl_pf1 {
+		pinmux = < 0xa24 >;
+		bias-pull-up;
+		drive-open-drain;
+	};
+};
+
+&i2c2 {
+	pinctrl-0 = < &i2c2_scl_pf1 &i2c2_sda_pf0 >;
+	pinctrl-names = "default";
+	status = "okay";
+	light: light@29 {
+		compatible = "vishay,veml6031";
+		reg = <0x29>;
+	};
+};

--- a/samples/sensor/veml6031/prj.conf
+++ b/samples/sensor/veml6031/prj.conf
@@ -1,0 +1,1 @@
+CONFIG_SENSOR=y

--- a/samples/sensor/veml6031/sample.yaml
+++ b/samples/sensor/veml6031/sample.yaml
@@ -1,0 +1,10 @@
+sample:
+  name: VEML6031 Sensor Sample
+tests:
+  sample.sensor.veml6031:
+    harness: sensor
+    platform_allow: olimex_stm32_e407
+    integration_platforms:
+      - olimex_stm32_e407
+    tags: sensors
+    filter: dt_compat_enabled("vishay,veml6031")

--- a/samples/sensor/veml6031/src/main.c
+++ b/samples/sensor/veml6031/src/main.c
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2025 Andreas Klinger
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+
+#include <zephyr/sys/printk.h>
+#include <zephyr/sys_clock.h>
+#include <stdio.h>
+
+#include <zephyr/device.h>
+#include <zephyr/drivers/sensor.h>
+#include <zephyr/drivers/i2c.h>
+
+#include <zephyr/drivers/sensor/veml6031.h>
+
+static void read_with_attr(const struct device *dev, int it, int div4, int gain)
+{
+	int ret;
+	struct sensor_value light;
+	struct sensor_value als_raw;
+	struct sensor_value ir_raw;
+	struct sensor_value sen;
+
+	sen.val2 = 0;
+
+	sen.val1 = it;
+	ret = sensor_attr_set(dev, SENSOR_CHAN_LIGHT, SENSOR_ATTR_VEML6031_IT, &sen);
+	if (ret) {
+		printf("Failed to set it attribute ret: %d\n", ret);
+	}
+	sen.val1 = div4;
+	ret = sensor_attr_set(dev, SENSOR_CHAN_LIGHT, SENSOR_ATTR_VEML6031_DIV4, &sen);
+	if (ret) {
+		printf("Failed to set div4 attribute ret: %d\n", ret);
+	}
+	sen.val1 = gain;
+	ret = sensor_attr_set(dev, SENSOR_CHAN_LIGHT, SENSOR_ATTR_VEML6031_GAIN, &sen);
+	if (ret) {
+		printf("Failed to set gain attribute ret: %d\n", ret);
+	}
+
+	ret = sensor_sample_fetch(dev);
+	if ((ret < 0) && (ret != -E2BIG)) {
+		printf("sample update error. ret: %d\n", ret);
+	}
+
+	sensor_channel_get(dev, SENSOR_CHAN_LIGHT, &light);
+
+	sensor_channel_get(dev, SENSOR_CHAN_VEML6031_ALS_RAW_COUNTS, &als_raw);
+
+	sensor_channel_get(dev, SENSOR_CHAN_VEML6031_IR_RAW_COUNTS, &ir_raw);
+
+	printf("Light (lux): %6d ALS (raw): %6d IR (raw): %6d "
+	       "  it: %d div4: %d gain: %d  --  %s\n",
+	       light.val1, als_raw.val1, ir_raw.val1, it, div4, gain,
+	       ret == -E2BIG ? "OVERFLOW"
+	       : ret         ? "ERROR"
+			     : "");
+}
+
+static void read_with_all_attr(const struct device *dev)
+{
+	int it, div4, gain;
+
+	for (it = VEML6031_IT_3_125; it <= VEML6031_IT_400; it++) {
+		for (div4 = VEML6031_SIZE_4_4; div4 <= VEML6031_SIZE_1_4; div4++) {
+			for (gain = VEML6031_GAIN_1; gain <= VEML6031_GAIN_0_5; gain++) {
+				read_with_attr(dev, it, div4, gain);
+			}
+		}
+	}
+}
+
+int main(void)
+{
+	const struct device *const veml = DEVICE_DT_GET(DT_NODELABEL(light));
+
+	if (!device_is_ready(veml)) {
+		printk("sensor: device not ready.\n");
+		return 0;
+	}
+
+	printf("Test all attributes for a good guess of attribute usage away of saturation.\n");
+	read_with_all_attr(veml);
+	printf("Test finished.\n");
+
+	return 0;
+}

--- a/tests/drivers/build_all/sensor/i2c.dtsi
+++ b/tests/drivers/build_all/sensor/i2c.dtsi
@@ -1251,3 +1251,8 @@ test_i2c_xbr818: xbr818@aa {
 	int-gpios = <&test_gpio 0 0>;
 	i2c-en-gpios = <&test_gpio 0 0>;
 };
+
+test_i2c_veml6031: veml6031@ab {
+	compatible = "vishay,veml6031";
+	reg = <0xab>;
+};


### PR DESCRIPTION
This PR replaces the following one:
 drivers: sensor: Add Vishay VEML6031 Ambient Light Sensor #84563 

I got into trouble with my repository. Sorry for any inconveniences.


VEML6031 Sensor driver:

    add driver for Vishay VEML6031 High Accuracy Ambient Light Sensor.
    add new compatible "vishay,veml6031".
    support fetch and get.
    triggered mode and interrupt is not yet supported.

Sample application:

    Test all attribute combinations of Vishay sensor VEML6031 which is an
    ambient light sensor.
    Print out saturation case of sensor.
    Idea is to be able to find a good combination of attributes for an
    optimal working area.

