### PR TITLE
arch: arm: Replaced inline asm __volatile__ with volatile 

### DIFF
--- a/arch/arm/core/cortex_a_r/semihost.c
+++ b/arch/arm/core/cortex_a_r/semihost.c
@@ -19,10 +19,10 @@ long semihost_exec(enum semihost_instr instr, void *args)
 	register long ret __asm__ ("r0");
 
 	if (IS_ENABLED(CONFIG_ISA_THUMB2)) {
-		__asm__ __volatile__ ("svc 0xab"
+		__asm__ volatile ("svc 0xab"
 				      : "=r" (ret) : "r" (r0), "r" (r1) : "memory");
 	} else {
-		__asm__ __volatile__ ("svc 0x123456"
+		__asm__ volatile ("svc 0x123456"
 				      : "=r" (ret) : "r" (r0), "r" (r1) : "memory");
 	}
 	return ret;

--- a/arch/arm/core/cortex_m/semihost.c
+++ b/arch/arm/core/cortex_m/semihost.c
@@ -13,6 +13,6 @@ long semihost_exec(enum semihost_instr instr, void *args)
 	register void *r1 __asm__("r1") = args;
 	register int ret __asm__("r0");
 
-	__asm__ __volatile__("bkpt 0xab" : "=r"(ret) : "r"(r0), "r"(r1) : "memory");
+	__asm__ volatile("bkpt 0xab" : "=r"(ret) : "r"(r0), "r"(r1) : "memory");
 	return ret;
 }

--- a/arch/arm/core/mmu/arm_mmu.c
+++ b/arch/arm/core/mmu/arm_mmu.c
@@ -805,10 +805,10 @@ int z_arm_mmu_init(void)
 	}
 
 	/* Clear TTBR1 */
-	__asm__ __volatile__("mcr p15, 0, %0, c2, c0, 1" : : "r"(reg_val));
+	__asm__ volatile("mcr p15, 0, %0, c2, c0, 1" : : "r"(reg_val));
 
 	/* Write TTBCR: EAE, security not yet relevant, N[2:0] = 0 */
-	__asm__ __volatile__("mcr p15, 0, %0, c2, c0, 2"
+	__asm__ volatile("mcr p15, 0, %0, c2, c0, 2"
 			     : : "r"(reg_val));
 
 	/* Write TTBR0 */


### PR DESCRIPTION
IAR doesn't support the __volatile__ keyword, and since the toolchain.h isn't included by these arm-specific files and other arm-specific files already uses volatile, I've made them all use volatile.