### PR TITLE
boards: arm: fvp_baser_aemv8r: fix board name in docs

### DIFF
--- a/boards/arm/fvp_baser_aemv8r/doc/aarch32.rst
+++ b/boards/arm/fvp_baser_aemv8r/doc/aarch32.rst
@@ -82,7 +82,7 @@ Arm FVP emulated environment, for example, with the :zephyr:code-sample:`synchro
 .. zephyr-app-commands::
    :zephyr-app: samples/synchronization
    :host-os: unix
-   :board: fvp_baser_aemv8r_aarch32
+   :board: fvp_baser_aemv8r/fvp_aemv8r_aarch32
    :goals: build
 
 This will build an image with the synchronization sample app.

--- a/boards/arm/fvp_baser_aemv8r/doc/aarch64.rst
+++ b/boards/arm/fvp_baser_aemv8r/doc/aarch64.rst
@@ -91,7 +91,7 @@ Arm FVP emulated environment, for example, with the :zephyr:code-sample:`synchro
 .. zephyr-app-commands::
    :zephyr-app: samples/synchronization
    :host-os: unix
-   :board: fvp_baser_aemv8r
+   :board: fvp_baser_aemv8r/fvp_aemv8r_aarch64
    :goals: build
 
 This will build an image with the synchronization sample app.


### PR DESCRIPTION
Use the correct board names in example. Otherwise, the build would fail with ```Board qualifiers `` for board `fvp_baser_aemv8r` not found.  Please specify a valid board target.```