### PR TITLE
boards: nrf5340dk: add arduino headers to supported features

### DIFF
--- a/boards/nordic/nrf5340dk/nrf5340dk_nrf5340_cpuapp_ns.yaml
+++ b/boards/nordic/nrf5340dk/nrf5340dk_nrf5340_cpuapp_ns.yaml
@@ -8,6 +8,10 @@ toolchain:
 ram: 192
 flash: 192
 supported:
+  - arduino_gpio
+  - arduino_i2c
+  - arduino_serial
+  - arduino_spi
   - i2c
   - pwm
   - watchdog


### PR DESCRIPTION
Add the arduino headers to the supported features list for this board.