### PR TITLE
boards: nordic: *dk: don't enable `USE_SEGGER_RTT`

### DIFF
--- a/boards/nordic/nrf21540dk/nrf21540dk_nrf52840_defconfig
+++ b/boards/nordic/nrf21540dk/nrf21540dk_nrf52840_defconfig
@@ -6,9 +6,6 @@ CONFIG_ARM_MPU=y
 # Enable hardware stack protection
 CONFIG_HW_STACK_PROTECTION=y
 
-# Enable RTT
-CONFIG_USE_SEGGER_RTT=y
-
 # enable GPIO
 CONFIG_GPIO=y
 

--- a/boards/nordic/nrf52833dk/nrf52833dk_nrf52820_defconfig
+++ b/boards/nordic/nrf52833dk/nrf52833dk_nrf52820_defconfig
@@ -6,9 +6,6 @@ CONFIG_ARM_MPU=y
 # Enable hardware stack protection
 CONFIG_HW_STACK_PROTECTION=y
 
-# Enable RTT
-CONFIG_USE_SEGGER_RTT=y
-
 # enable GPIO
 CONFIG_GPIO=y
 

--- a/boards/nordic/nrf52833dk/nrf52833dk_nrf52833_defconfig
+++ b/boards/nordic/nrf52833dk/nrf52833dk_nrf52833_defconfig
@@ -6,9 +6,6 @@ CONFIG_ARM_MPU=y
 # Enable hardware stack protection
 CONFIG_HW_STACK_PROTECTION=y
 
-# Enable RTT
-CONFIG_USE_SEGGER_RTT=y
-
 # enable GPIO
 CONFIG_GPIO=y
 

--- a/boards/nordic/nrf52840dk/nrf52840dk_nrf52840_defconfig
+++ b/boards/nordic/nrf52840dk/nrf52840dk_nrf52840_defconfig
@@ -6,9 +6,6 @@ CONFIG_ARM_MPU=y
 # Enable hardware stack protection
 CONFIG_HW_STACK_PROTECTION=y
 
-# Enable RTT
-CONFIG_USE_SEGGER_RTT=y
-
 # enable GPIO
 CONFIG_GPIO=y
 

--- a/boards/nordic/nrf52dk/nrf52dk_nrf52832_defconfig
+++ b/boards/nordic/nrf52dk/nrf52dk_nrf52832_defconfig
@@ -6,9 +6,6 @@ CONFIG_ARM_MPU=y
 # Enable hardware stack protection
 CONFIG_HW_STACK_PROTECTION=y
 
-# Enable RTT
-CONFIG_USE_SEGGER_RTT=y
-
 # enable GPIO
 CONFIG_GPIO=y
 


### PR DESCRIPTION
Don't enable RTT by default on these development kits. They all have a dedicated physical serial port that is intended to be the primary serial comms channel.