### PR TITLE
dts: nordic: `hci_rng` disabled by default

### DIFF
--- a/dts/arm/nordic/nrf5340_cpuapp.dtsi
+++ b/dts/arm/nordic/nrf5340_cpuapp.dtsi
@@ -113,6 +113,11 @@
 	};
 };
 
+&rng_hci {
+	/* Application core has no accessible RNG peripheral */
+	status = "okay";
+};
+
 &nvic {
 	arm,num-irq-priority-bits = <3>;
 };

--- a/dts/vendor/nordic/nrf_common.dtsi
+++ b/dts/vendor/nordic/nrf_common.dtsi
@@ -32,7 +32,7 @@
 
 	rng_hci: entropy_bt_hci {
 		compatible = "zephyr,bt-hci-entropy";
-		status = "okay";
+		status = "disabled";
 	};
 
 	sw_pwm: sw-pwm {


### PR DESCRIPTION
As a software construct that depends upon Bluetooth being enabled, this device should not be enabled by default. Most nRF SoC's have internal `RNG` hardware that is much more efficient to access.