### PR TITLE
bluetooth: hci: SPI backend boot timeout

### DIFF
--- a/drivers/bluetooth/hci/Kconfig
+++ b/drivers/bluetooth/hci/Kconfig
@@ -81,6 +81,16 @@ config BT_SPI_INIT_PRIORITY
 	depends on BT_SPI
 	default 75
 
+config BT_SPI_BOOT_TIMEOUT_SEC
+	int "Seconds to wait for SPI device to report ready"
+	depends on BT_SPI_ZEPHYR || BT_SPI_BLUENRG
+	default 30
+	help
+	  Maximum duration for a HCI SPI Controller to report ready through the
+	  Zephyr Project defined `EVT_BLUE_INITIALIZED` HCI vendor event.
+	  Default is 30 seconds to support a bootloader image swap on the
+	  Controller.
+
 config BT_SPI_ZEPHYR
 	bool
 	default y

--- a/drivers/bluetooth/hci/spi.c
+++ b/drivers/bluetooth/hci/spi.c
@@ -416,7 +416,9 @@ static int bt_spi_open(const struct device *dev, bt_hci_recv_t recv)
 	k_thread_name_set(&spi_rx_thread_data, "bt_spi_rx_thread");
 
 	/* Device will let us know when it's ready */
-	k_sem_take(&sem_initialised, K_FOREVER);
+	if (k_sem_take(&sem_initialised, K_SECONDS(CONFIG_BT_SPI_BOOT_TIMEOUT_SEC)) < 0) {
+		return -EIO;
+	}
 
 	return 0;
 }


### PR DESCRIPTION
Add a timeout to the SPI boot process to ensure that `bt_enable` does not block forever but instead returns an error after an appropriately large delay. While 1 second would be sufficient under normal operation, we also want to give the controller time to perform any application upgrades via a bootloader.