### PR TITLE
boards: nrf51_blenano: fix GPIO for onboard LED

### DIFF
--- a/boards/particle/nrf51_blenano/nrf51_blenano.dts
+++ b/boards/particle/nrf51_blenano/nrf51_blenano.dts
@@ -29,7 +29,7 @@
 	leds {
 		compatible = "gpio-leds";
 		led0: led_0 {
-			gpios = <&gpio0 19 0>;
+			gpios = <&gpio0 19 GPIO_ACTIVE_LOW>;
 			label = "LED";
 		};
 	};


### PR DESCRIPTION
Make the onboard LED active-low as per schematic:
https://github.com/redbear/nRF5x/blob/master/nRF51822/pcb/schematic/BLENano_1.0_20141010.pdf