### PR TITLE
tests: shell_backend_uart: do not filter

### DIFF
--- a/tests/subsys/shell/shell_backend_uart/testcase.yaml
+++ b/tests/subsys/shell/shell_backend_uart/testcase.yaml
@@ -6,7 +6,6 @@ tests:
       - shell
       - backend
       - uart
-    filter: ( CONFIG_SHELL )
     platform_allow:
       - qemu_x86
       - qemu_riscv32


### PR DESCRIPTION
Filtering on something we set in the prj..conf does not do anything. We
have filter on platforms already.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
