### PR TITLE
posix: mem: remove imply MMU from POSIX options

### DIFF
--- a/lib/posix/options/Kconfig.mem
+++ b/lib/posix/options/Kconfig.mem
@@ -27,10 +27,11 @@ config POSIX_SHARED_MEMORY_OBJECTS
 
 config POSIX_MAPPED_FILES
 	bool "POSIX memory-mapped files"
-	# disable Xtensa for now until linker issues are resolved
-	imply MMU if (CPU_HAS_MMU && !XTENSA)
 	help
 	  Select 'y' here and Zephyr will provide support for mmap(), msync(), and munmap().
+
+	  Note: This feature depends on hardware MMU support. If the underlying platform does not
+	  support an MMU, then affected POSIX API functions may return -1 and set errno to ENOTSUP.
 
 	  For more information, please see
 	  https://pubs.opengroup.org/onlinepubs/9699919799.orig/functions/V2_chap02.html
@@ -43,16 +44,22 @@ config POSIX_MEMLOCK
 	help
 	  Select 'y' here and Zephyr will provide support for mlockall() and munlockall().
 
+	  Note: This feature depends on hardware MMU support as well as DEMAND_PAGING. If the
+	  underlying platform does not support an MMU or DEMAND_PAGING, then affected POSIX API
+	  functions will return -1 and set errno to ENOTSUP.
+
 	  For more information, please see
 	  https://pubs.opengroup.org/onlinepubs/9699919799.orig/functions/V2_chap02.html
 	  https://pubs.opengroup.org/onlinepubs/9699919799/xrat/V4_port.html#tag_24_03_04
 
 config POSIX_MEMLOCK_RANGE
 	bool "POSIX range memory locking"
-	imply MMU if (CPU_HAS_MMU && ARCH_HAS_DEMAND_PAGING)
 	imply DEMAND_PAGING
 	help
 	  Select 'y' here and Zephyr will provide support for mlock() and munlock().
+
+	  Note: This feature depends on hardware MMU support. If the underlying platform does not
+	  support an MMU, then affected POSIX API functions will return -1 and set errno to ENOTSUP.
 
 	  For more information, please see
 	  https://pubs.opengroup.org/onlinepubs/9699919799.orig/functions/V2_chap02.html

--- a/tests/posix/xsi_realtime/testcase.yaml
+++ b/tests/posix/xsi_realtime/testcase.yaml
@@ -13,10 +13,6 @@ common:
   platform_exclude:
     # linker_zephyr_pre0.cmd:140: syntax error (??)
     - qemu_xtensa/dc233c
-    # CONFIG_MMU=y but no arch_mem_map() or arch_mem_unmap()
-    - intel_ish_5_4_1
-    - intel_ish_5_6_0
-    - intel_ish_5_8_0
     - native_sim
     - native_sim/native/64
 tests:


### PR DESCRIPTION
With MMU being converted to a non-user-configurable option in #85834, we can rely it exclusively to know whether `arch_mem_map()` and `arch_mem_unmap()` are available and we can remove the workarounds in POSIX at the Kconfig level.

Fixes #85305