### PR TITLE
drivers: spi: Added LPSS DMA support for SPI

### DIFF
--- a/drivers/spi/Kconfig.pw
+++ b/drivers/spi/Kconfig.pw
@@ -15,4 +15,14 @@ config SPI_PW_INTERRUPT
 	help
 	  Enable Interrupt support for the SPI Driver.
 
+config SPI_PW_LPSS_DMA
+	bool "USE SPI DMA for Asynchronous Transfers"
+	select DMA
+	select DMA_INTEL_LPSS
+	depends on SPI_PW_INTERRUPT
+	help
+	  This option enables SPI DMA feature to be used for asynchrounous
+	  data transfers. All Tx operaton are done using dma channel 0 and
+	  all Rx operations are done using dma channel 1.
+
 endif # SPI_PW

--- a/drivers/spi/spi_pw.c
+++ b/drivers/spi/spi_pw.c
@@ -20,6 +20,11 @@ BUILD_ASSERT(IS_ENABLED(CONFIG_PCIE), "DT need CONFIG_PCIE");
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(spi_pw, CONFIG_SPI_LOG_LEVEL);
 
+#if defined(CONFIG_SPI_PW_LPSS_DMA)
+#include <zephyr/drivers/dma.h>
+#include <zephyr/drivers/dma/dma_intel_lpss.h>
+#endif
+
 #include "spi_pw.h"
 
 static uint32_t spi_pw_reg_read(const struct device *dev, uint32_t offset)
@@ -207,12 +212,17 @@ static void spi_pw_rx_thld_set(const struct device *dev,
 {
 	uint32_t reg_data;
 
-	/* Rx threshold */
-	reg_data = spi_pw_reg_read(dev, PW_SPI_REG_SIRF);
-	reg_data &= (uint32_t) ~(PW_SPI_WM_MASK);
-	reg_data |= PW_SPI_SIRF_WM_DFLT;
-	if (spi->ctx.rx_len && spi->ctx.rx_len < spi->fifo_depth) {
-		reg_data = spi->ctx.rx_len - 1;
+	if (IS_ENABLED(CONFIG_SPI_PW_LPSS_DMA)) {
+		reg_data = 0;
+	} else {
+
+		/* Rx threshold */
+		reg_data = spi_pw_reg_read(dev, PW_SPI_REG_SIRF);
+		reg_data &= (uint32_t) ~(PW_SPI_WM_MASK);
+		reg_data |= PW_SPI_SIRF_WM_DFLT;
+		if (spi->ctx.rx_len && spi->ctx.rx_len < spi->fifo_depth) {
+			reg_data = spi->ctx.rx_len - 1;
+		}
 	}
 	spi_pw_reg_write(dev, PW_SPI_REG_SIRF, reg_data);
 }
@@ -320,6 +330,146 @@ static void spi_pw_config_clk(const struct device *dev,
 	ctrlr0 |= (scr << PW_SPI_SCR_SHIFT);
 	spi_pw_reg_write(dev, PW_SPI_REG_CTRLR0, ctrlr0);
 }
+
+#ifdef CONFIG_SPI_PW_LPSS_DMA
+static void spi_pw_idma_intr_enable(const struct device *dev, bool enable)
+{
+	uint32_t reg;
+
+	reg = spi_pw_reg_read(dev, PW_SPI_REG_CTRLR1);
+
+	if (enable) {
+		reg |= PW_SPI_IDMA_INTR;
+		spi_pw_reg_write(dev, PW_SPI_REG_CTRLR1, reg);
+	} else {
+		reg &= ~(PW_SPI_IDMA_INTR);
+		spi_pw_reg_write(dev, PW_SPI_REG_CTRLR1, reg);
+	}
+}
+
+static void cb_idma_transfer(const struct device *dma, void *user_data,
+			 uint32_t channel, int status)
+{
+	const struct device *dev = (const struct device *)user_data;
+	struct spi_pw_data *spi = dev->data;
+
+	/* See tx or rx finished */
+	if (channel == DMA_INTEL_LPSS_TX_CHAN) {
+		spi->dma_tx_finished = true;
+
+		/* Waiting for TX FIFO empty */
+		while (is_pw_ssp_busy(dev)) {
+		}
+	} else if (channel == DMA_INTEL_LPSS_RX_CHAN) {
+		spi->dma_rx_finished = true;
+	}
+	/* All tx and rx finished */
+	if ((spi->dma_tx_finished == true) &&
+	    (spi->dma_rx_finished == true)) {
+		spi_pw_idma_intr_enable(dev, false);
+		spi_pw_intr_disable(dev);
+		spi_pw_ssp_disable(dev);
+		spi_pw_cs_ctrl_enable(dev, false);
+		spi_context_complete(&spi->ctx, dev, status ? 0 : -EIO);
+	}
+}
+
+static inline void *spi_pw_dr_phy_addr(const struct device *dev)
+{
+	struct spi_pw_data *spi = dev->data;
+	/* Physical FIFO addr */
+	return (void *) (spi->phy_addr + PW_SPI_REG_SSDR);
+}
+
+static int32_t spi_pw_idma_transfer(const struct device *dev,
+				     uint8_t *data_out,
+				     uint8_t *data_in,
+				     uint32_t num)
+{
+	struct spi_pw_data *spi = dev->data;
+	const struct spi_pw_config *info = dev->config;
+	int ret;
+	struct dma_config dma_cfg = { 0 };
+	struct dma_block_config dma_block_cfg = { 0 };
+
+	/* Initialize tx/rx channel, tx/rx len, */
+	spi->dma_tx_finished = false;
+	spi->dma_rx_finished = false;
+
+	if (!device_is_ready(info->dma_dev)) {
+		LOG_DBG("DMA device is not ready");
+		return  -ENODEV;
+	}
+
+	dma_cfg.dma_slot = 0U;
+	dma_cfg.channel_direction = MEMORY_TO_PERIPHERAL;
+	dma_cfg.source_data_size = 1U;
+	dma_cfg.dest_data_size = 1U;
+	dma_cfg.source_burst_length = 1U;
+	dma_cfg.dest_burst_length = 1U;
+	dma_cfg.dma_callback = cb_idma_transfer;
+	dma_cfg.user_data = (void *)dev;
+	dma_cfg.complete_callback_en = 0U;
+	dma_cfg.error_callback_en = 1U;
+	dma_cfg.block_count = 1U;
+	dma_cfg.head_block = &dma_block_cfg;
+
+	dma_block_cfg.block_size = num;
+	dma_block_cfg.source_address = (uint64_t)data_out;
+	dma_block_cfg.dest_address = (uint64_t)spi_pw_dr_phy_addr(dev);
+
+	if (dma_config(info->dma_dev, DMA_INTEL_LPSS_TX_CHAN, &dma_cfg)) {
+		LOG_DBG("Error transfer");
+		return  -EIO;
+	}
+
+	if (dma_start(info->dma_dev, DMA_INTEL_LPSS_TX_CHAN)) {
+		LOG_DBG("Error trnasfer");
+		return  -EIO;
+	}
+
+	if (!device_is_ready(info->dma_dev)) {
+		LOG_DBG("DMA device is not ready");
+		return  -ENODEV;
+	}
+
+	dma_cfg.dma_slot = 1U;
+	dma_cfg.channel_direction = PERIPHERAL_TO_MEMORY;
+	dma_cfg.source_data_size = 1U;
+	dma_cfg.dest_data_size = 1U;
+	dma_cfg.source_burst_length = 1U;
+	dma_cfg.dest_burst_length = 1U;
+	dma_cfg.dma_callback = cb_idma_transfer;
+	dma_cfg.user_data = (void *)dev;
+	dma_cfg.complete_callback_en = 0U;
+	dma_cfg.error_callback_en = 1U;
+	dma_cfg.block_count = 1U;
+	dma_cfg.head_block = &dma_block_cfg;
+
+	dma_block_cfg.block_size = num;
+	dma_block_cfg.dest_address = (uint64_t)data_in;
+	dma_block_cfg.source_address = (uint64_t)spi_pw_dr_phy_addr(dev);
+
+	if (dma_config(info->dma_dev, DMA_INTEL_LPSS_RX_CHAN, &dma_cfg)) {
+		return  -EIO;
+	}
+
+	if (dma_start(info->dma_dev, DMA_INTEL_LPSS_RX_CHAN)) {
+		return  -EIO;
+	}
+
+	dma_stop(info->dma_dev, 1);
+
+	/* enable ssp interrupts */
+	spi_pw_intr_enable(dev, true);
+
+	/* Enable dma intr */
+	spi_pw_idma_intr_enable(dev, true);
+
+	return 0;
+}
+
+#else
 
 static void spi_pw_completed(const struct device *dev, int err)
 {
@@ -539,6 +689,7 @@ out:
 
 	return err;
 }
+#endif
 
 static int spi_pw_configure(const struct device *dev,
 			    const struct spi_pw_config *info,
@@ -658,6 +809,18 @@ static int transceive(const struct device *dev,
 	spi_pw_ssp_enable(dev);
 
 #ifdef CONFIG_SPI_PW_INTERRUPT
+#ifdef CONFIG_SPI_PW_LPSS_DMA
+	uint8_t *data_out = NULL, *data_in = NULL;
+	uint32_t transfer_bytes = 0;
+
+	/* DMA operation/transfer handling */
+	data_out = (uint8_t *) spi->ctx.tx_buf;
+	data_in = (uint8_t *) spi->ctx.rx_buf;
+	transfer_bytes = spi->ctx.tx_len;
+
+	LOG_DBG("DMA Mode");
+	err = spi_pw_idma_transfer(dev, data_out, data_in, transfer_bytes);
+#else
 	LOG_DBG("Interrupt Mode");
 
 	/* Enable interrupts */
@@ -668,6 +831,7 @@ static int transceive(const struct device *dev,
 	}
 
 	err = spi_context_wait_for_completion(&spi->ctx);
+#endif
 #else
 	LOG_DBG("Polling Mode");
 
@@ -727,10 +891,16 @@ static int spi_pw_release(const struct device *dev,
 static void spi_pw_isr(const void *arg)
 {
 	const struct device *dev = (const struct device *)arg;
+#ifdef CONFIG_SPI_PW_LPSS_DMA
+	const struct spi_pw_config *info = dev->config;
+
+	dma_intel_lpss_isr(info->dma_dev);
+#else
 	int err;
 
 	err = spi_pw_transfer(dev);
 	spi_pw_completed(dev, err);
+#endif
 }
 #endif
 
@@ -774,7 +944,24 @@ static int spi_pw_init(const struct device *dev)
 		pcie_set_cmd(info->pcie->bdf,
 			     PCIE_CONF_CMDSTAT_MASTER,
 			     true);
+#if defined(CONFIG_SPI_PW_LPSS_DMA)
+		uintptr_t base;
 
+		base = DEVICE_MMIO_GET(dev) + DMA_INTEL_LPSS_OFFSET;
+		dma_intel_lpss_set_base(info->dma_dev, base);
+		dma_intel_lpss_setup(info->dma_dev);
+
+		pcie_set_cmd(info->pcie->bdf, PCIE_CONF_CMDSTAT_MASTER, true);
+		/* Assign physical & virtual address to dma instance */
+		spi->phy_addr = mbar.phys_addr;
+		spi->base_addr = (uint32_t)(DEVICE_MMIO_GET(dev) + PW_SPI_IDMA_OFFSET);
+		sys_write32((uint32_t)spi->phy_addr,
+			    DEVICE_MMIO_GET(dev) + DMA_INTEL_LPSS_REMAP_LOW);
+		sys_write32((uint32_t)(spi->phy_addr >> DMA_INTEL_LPSS_ADDR_RIGHT_SHIFT),
+			    DEVICE_MMIO_GET(dev) + DMA_INTEL_LPSS_REMAP_HI);
+		LOG_DBG("spi inst phy addr: [0x%lx], mmio addr: [0x%lx]",
+				spi->phy_addr, spi->base_addr);
+#endif
 	} else {
 		DEVICE_MMIO_MAP(dev, K_MEM_CACHE_NONE);
 	}
@@ -824,6 +1011,12 @@ static int spi_pw_init(const struct device *dev)
 
 #ifdef CONFIG_SPI_PW_INTERRUPT
 
+#define SPI_CONFIG_DMA_INIT(n)                                          \
+	COND_CODE_1(CONFIG_SPI_PW_LPSS_DMA,                             \
+	(COND_CODE_1(DT_INST_NODE_HAS_PROP(n, dmas),                    \
+	(.dma_dev = DEVICE_DT_GET(DT_INST_DMAS_CTLR_BY_IDX(n, 0)),),    \
+	())), ())
+
 #define SPI_INTEL_IRQ_FLAGS_SENSE0(n) 0
 #define SPI_INTEL_IRQ_FLAGS_SENSE1(n) DT_INST_IRQ(n, sense)
 #define SPI_INTEL_IRQ_FLAGS(n) \
@@ -870,6 +1063,7 @@ static int spi_pw_init(const struct device *dev)
 		.irq_config = spi_##n##_irq_init,		     \
 		.clock_freq = DT_INST_PROP(n, clock_frequency),	     \
 		INIT_PCIE(n)					     \
+		SPI_CONFIG_DMA_INIT(n)			             \
 	};							     \
 	SPI_DEVICE_DT_INST_DEFINE(n, spi_pw_init, NULL,		     \
 			      &spi_##n##_data, &spi_##n##_config,    \

--- a/drivers/spi/spi_pw.h
+++ b/drivers/spi/spi_pw.h
@@ -11,6 +11,13 @@
 
 #include "spi_context.h"
 
+/* PCIe config space registers */
+#define PCH_GSPI_STATUS_CMD             0x04
+#define PCH_GSPI_CTRL                   0x230
+
+/* DMA offset */
+#define PW_SPI_IDMA_OFFSET              0x800
+
 /* lpss penwell spi registers */
 #define PW_SPI_REG_CTRLR0               0x00
 #define PW_SPI_REG_CTRLR1               0x04
@@ -144,6 +151,21 @@
 /* nval mask [30:16] */
 #define PW_SPI_CLKS_NVAL_MASK           (BIT_MASK(15) << 16)
 
+/* Resets */
+#define PW_SPI_RESET_DMA_BIT            0x2
+
+/* DMA finish Disable */
+#define PW_SPI_DIS_DMA_FINISH_BIT       0x0
+
+/* DMA intr bits */
+#define PW_SPI_IDMA_RSRE_BIT            BIT(20)
+#define PW_SPI_IDMA_TSRE_BIT            BIT(21)
+#define PW_SPI_IDMA_TRAIL_BIT           BIT(22)
+
+#define PW_SPI_IDMA_INTR                (PW_SPI_IDMA_RSRE_BIT | \
+					 PW_SPI_IDMA_TSRE_BIT | \
+					 PW_SPI_IDMA_TRAIL_BIT)
+
 /* SPI chip select control */
 #define PW_SPI_CS_MODE_BIT              0
 #define PW_SPI_CS_STATE_BIT             1
@@ -208,6 +230,9 @@ struct spi_pw_config {
 #if DT_ANY_INST_ON_BUS_STATUS_OKAY(pcie)
 	struct pcie_dev *pcie;
 #endif
+#ifdef CONFIG_SPI_PW_LPSS_DMA
+	const struct device *dma_dev;
+#endif
 };
 
 struct spi_pw_data {
@@ -219,6 +244,13 @@ struct spi_pw_data {
 	uint8_t cs_output;
 	uint32_t id;
 	uint8_t fifo_depth;
+#ifdef CONFIG_SPI_PW_LPSS_DMA
+	uintptr_t phy_addr;
+	uintptr_t base_addr;
+	/* For dma transfer */
+	bool dma_tx_finished;
+	bool dma_rx_finished;
+#endif
 };
 
 #endif /* ZEPHYR_DRIVERS_SPI_SPI_PW_H_ */

--- a/dts/x86/intel/raptor_lake_s.dtsi
+++ b/dts/x86/intel/raptor_lake_s.dtsi
@@ -225,6 +225,12 @@
 			status = "disabled";
 		};
 
+		spi0_dma: spi0_dma {
+			compatible = "intel,lpss";
+			#dma-cells = <1>;
+			status = "okay";
+		};
+
 		spi0: spi0 {
 			compatible = "intel,penwell-spi";
 			vendor-id = <0x8086>;
@@ -238,7 +244,15 @@
 			clock-frequency = <100000000>;
 			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
+			dmas = <&spi0_dma 0>;
+
 			status = "okay";
+		};
+
+		spi1_dma: spi1_dma {
+			compatible = "intel,lpss";
+			#dma-cells = <1>;
+			status = "disabled";
 		};
 
 		spi1: spi1 {
@@ -254,6 +268,14 @@
 			clock-frequency = <100000000>;
 			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
+			dmas = <&spi1_dma 0>;
+
+			status = "disabled";
+		};
+
+		spi2_dma: spi2_dma {
+			compatible = "intel,lpss";
+			#dma-cells = <1>;
 			status = "disabled";
 		};
 
@@ -270,6 +292,8 @@
 			clock-frequency = <100000000>;
 			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
+			dmas = <&spi2_dma 0>;
+
 			status = "disabled";
 		};
 


### PR DESCRIPTION
Enabled intel LPSS DMA interface using dw common to support usage of internal DMA in LPSS SPI to transfer and
receive data.