### PR TITLE
modules: tf-m: fix build verbosity

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -353,7 +353,7 @@ manifest:
       groups:
         - tee
     - name: trusted-firmware-m
-      revision: 2f138475047d566f1446f62657aa546b0e0b52c2
+      revision: 918f32d9fce5e0ee59fc33844b5317b7626ce37a
       path: modules/tee/tf-m/trusted-firmware-m
       groups:
         - tee


### PR DESCRIPTION
Only set CMAKE_INSTALL_MESSAGE in a single location, remove the unconditional overrides of the value in other locations.

This prevents dozens of rather pointless messages appearing in the build log when CONFIG_TFM_BUILD_LOG_QUIET is set.
```
Installing: /home/jordan/code/workspace/build/nrf5340dk/...
```