### PR TITLE
modules: hal_nxp: Add empty file to support CONFIG_BUILD_ONLY_NO_BLOBS

### DIFF
--- a/modules/hal_nxp/bt_controller/CMakeLists.txt
+++ b/modules/hal_nxp/bt_controller/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 NXP
+# Copyright 2024-2025 NXP
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -8,7 +8,9 @@ set(hal_nxp_dir           ${ZEPHYR_HAL_NXP_MODULE_DIR})
 set(hal_nxp_blobs_dir     ${hal_nxp_dir}/zephyr/blobs)
 set(blob_gen_file         ${ZEPHYR_BINARY_DIR}/include/generated/bt_nxp_ctlr_fw.h)
 
-if(CONFIG_BT_NXP_NW612)
+if(CONFIG_BUILD_ONLY_NO_BLOBS)
+    set(blob_file src/no_blobs.h)
+elseif(CONFIG_BT_NXP_NW612)
     set(blob_file ${hal_nxp_blobs_dir}/iw612/uart_nw61x_se.h)
 endif()
 
@@ -16,6 +18,8 @@ if (NOT DEFINED blob_file)
     message(FATAL_ERROR "Unsupported controller. Please select a BT conntroller, refer to ./driver/bluetooth/hci/Kconfig.nxp")
 endif()
 
-zephyr_blobs_verify(FILES ${blob_file} REQUIRED)
+if(NOT CONFIG_BUILD_ONLY_NO_BLOBS)
+   zephyr_blobs_verify(FILES ${blob_file} REQUIRED)
+endif()
 
 configure_file(${blob_file} ${blob_gen_file} COPYONLY)

--- a/modules/hal_nxp/bt_controller/src/no_blobs.h
+++ b/modules/hal_nxp/bt_controller/src/no_blobs.h
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2024 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef __UART_BT_FW_H__
+#define __UART_BT_FW_H__
+
+
+const unsigned char *bt_fw_bin;
+unsigned int bt_fw_bin_len;
+
+#endif /* __UART_BT_FW_H__ */


### PR DESCRIPTION
Add empty file to support building with CONFIG_BUILD_ONLY_NO_BLOBS option.