### PR TITLE
modules: hal_nordic: nrfx: Use owned-channels property for DPPIC

### DIFF
--- a/dts/bindings/misc/nordic,nrf-dppic-local.yaml
+++ b/dts/bindings/misc/nordic,nrf-dppic-local.yaml
@@ -11,3 +11,9 @@ description: |
 compatible: "nordic,nrf-dppic-local"
 
 include: ["nordic,nrf-dppic.yaml", "nordic,nrf-dppic-links.yaml"]
+
+properties:
+  channels:
+    type: int
+    required: true
+    description: Number of channels implemented by the DPPIC instance.

--- a/dts/vendor/nordic/nrf54h20.dtsi
+++ b/dts/vendor/nordic/nrf54h20.dtsi
@@ -367,6 +367,7 @@
 			dppic020: dppic@22000 {
 				compatible = "nordic,nrf-dppic-local";
 				reg = <0x22000 0x1000>;
+				channels = <32>;
 				status = "disabled";
 			};
 

--- a/dts/vendor/nordic/nrf9280.dtsi
+++ b/dts/vendor/nordic/nrf9280.dtsi
@@ -250,6 +250,7 @@
 			dppic020: dppic@22000 {
 				compatible = "nordic,nrf-dppic-local";
 				reg = <0x22000 0x1000>;
+				channels = <32>;
 				status = "disabled";
 			};
 


### PR DESCRIPTION
The `owned-channels` property specifies which channels are assigned to a given target. Additionally, the `source-channels` or `sink-channels` property defines channels that can be used to forward an event outside the DPPI domain, otherwise they can only be used within it.