### PR TITLE
samples: boards: Fix typo in nucleo_wba55cg overlay

### DIFF
--- a/samples/boards/st/mco/boards/nucleo_wba55cg.overlay
+++ b/samples/boards/st/mco/boards/nucleo_wba55cg.overlay
@@ -24,7 +24,7 @@
 &mco1 {
 	status = "okay";
 	clocks = <&rcc STM32_SRC_LSE MCO1_SEL(MCO_SEL_LSE)>;
-	prescaler = <MCO1_PRE(MCO1_PRE_DIV_2)>;
+	prescaler = <MCO1_PRE(MCO_PRE_DIV_2)>;
 	pinctrl-0 = <&rcc_mco_pa8>;
 	pinctrl-names = "default";
 };


### PR DESCRIPTION
`s/MCO1_PRE_DIV_2/MCO_PRE_DIV_2/`

Fixes failure observed in weekly CI

```
west twister -p nucleo_wba55cg/stm32wba55xx -s sample.board.stm32.mco -v -i  
```
