### PR TITLE
cmake: allow using external gen_kobject_list implementation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -882,27 +882,17 @@ add_custom_command(
   DEPENDS ${PARSE_SYSCALLS_TARGET}
   )
 
-# This is passed into all calls to the gen_kobject_list.py script.
-set(gen_kobject_list_include_args --include-subsystem-list ${struct_tags_json})
+include(${ZEPHYR_BASE}/cmake/kobj.cmake)
 
 set(DRV_VALIDATION ${PROJECT_BINARY_DIR}/include/generated/zephyr/driver-validation.h)
-add_custom_command(
-  OUTPUT ${DRV_VALIDATION}
-  COMMAND
-  ${PYTHON_EXECUTABLE}
-  ${ZEPHYR_BASE}/scripts/build/gen_kobject_list.py
-  --validation-output ${DRV_VALIDATION}
-  ${gen_kobject_list_include_args}
-  $<$<BOOL:${CMAKE_VERBOSE_MAKEFILE}>:--verbose>
-  DEPENDS
-  ${ZEPHYR_BASE}/scripts/build/gen_kobject_list.py
-  ${PARSE_SYSCALLS_TARGET}
-  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+gen_kobject_list(
+  TARGET ${DRIVER_VALIDATION_H_TARGET}
+  OUTPUTS ${DRV_VALIDATION}
+  SCRIPT_ARGS --validation-output ${DRV_VALIDATION}
+  INCLUDES ${struct_tags_json}
   )
-add_custom_target(${DRIVER_VALIDATION_H_TARGET} DEPENDS ${DRV_VALIDATION})
 
-include(${ZEPHYR_BASE}/cmake/kobj.cmake)
-gen_kobj(KOBJ_INCLUDE_PATH)
+gen_kobject_list_headers(INCLUDES ${struct_tags_json})
 
 # Generate sections for kernel device subsystems
 set(
@@ -1099,7 +1089,6 @@ if(CONFIG_USERSPACE)
          NO_COVERAGE_FLAGS "${compiler_flags_priv}"
   )
 
-  set(GEN_KOBJ_LIST ${ZEPHYR_BASE}/scripts/build/gen_kobject_list.py)
   set(PROCESS_GPERF ${ZEPHYR_BASE}/scripts/build/process_gperf.py)
 endif()
 
@@ -1244,23 +1233,12 @@ if(CONFIG_USERSPACE)
   set(KOBJECT_PREBUILT_HASH_OUTPUT_SRC_PRE kobject_prebuilt_hash_preprocessed.c)
   set(KOBJECT_PREBUILT_HASH_OUTPUT_SRC     kobject_prebuilt_hash.c)
 
-  add_custom_command(
+  gen_kobject_list_gperf(
+    TARGET kobj_prebuilt_hash_list
     OUTPUT ${KOBJECT_PREBUILT_HASH_LIST}
-    COMMAND
-    ${PYTHON_EXECUTABLE}
-    ${GEN_KOBJ_LIST}
-    --kernel $<TARGET_FILE:${ZEPHYR_LINK_STAGE_EXECUTABLE}>
-    --gperf-output ${KOBJECT_PREBUILT_HASH_LIST}
-    ${gen_kobject_list_include_args}
-    $<$<BOOL:${CMAKE_VERBOSE_MAKEFILE}>:--verbose>
-    DEPENDS
-    ${ZEPHYR_LINK_STAGE_EXECUTABLE}
-    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    KERNEL_TARGET ${ZEPHYR_LINK_STAGE_EXECUTABLE}
+    INCLUDES ${struct_tags_json}
     )
-  add_custom_target(
-    kobj_prebuilt_hash_list
-    DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${KOBJECT_PREBUILT_HASH_LIST}
-  )
 
   add_custom_command(
     OUTPUT ${KOBJECT_PREBUILT_HASH_OUTPUT_SRC_PRE}
@@ -1444,23 +1422,12 @@ if(CONFIG_USERSPACE)
   # Use the script GEN_KOBJ_LIST to scan the kernel binary's
   # (${ZEPHYR_LINK_STAGE_EXECUTABLE}) DWARF information to produce a table of kernel
   # objects (KOBJECT_HASH_LIST) which we will then pass to gperf
-  add_custom_command(
+  gen_kobject_list_gperf(
+    TARGET kobj_hash_list
     OUTPUT ${KOBJECT_HASH_LIST}
-    COMMAND
-    ${PYTHON_EXECUTABLE}
-    ${GEN_KOBJ_LIST}
-    --kernel $<TARGET_FILE:${ZEPHYR_LINK_STAGE_EXECUTABLE}>
-    --gperf-output ${KOBJECT_HASH_LIST}
-    ${gen_kobject_list_include_args}
-    $<$<BOOL:${CMAKE_VERBOSE_MAKEFILE}>:--verbose>
-    DEPENDS
-    ${ZEPHYR_LINK_STAGE_EXECUTABLE}
-    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    KERNEL_TARGET ${ZEPHYR_LINK_STAGE_EXECUTABLE}
+    INCLUDES ${struct_tags_json}
     )
-  add_custom_target(
-    kobj_hash_list
-    DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${KOBJECT_HASH_LIST}
-  )
 
   # Use gperf to generate C code (KOBJECT_HASH_OUTPUT_SRC_PRE) which implements a
   # perfect hashtable based on KOBJECT_HASH_LIST

--- a/cmake/kobj.cmake
+++ b/cmake/kobj.cmake
@@ -1,6 +1,61 @@
 # SPDX-License-Identifier: Apache-2.0
 
-function(gen_kobj gen_dir_out)
+set(GEN_KOBJECT_LIST ${ZEPHYR_BASE}/scripts/build/gen_kobject_list.py)
+
+# Invokes gen_kobject_list.py with the given SCRIPT_ARGS, creating a TARGET that depends on the
+# script's OUTPUTS
+function(gen_kobject_list)
+  cmake_parse_arguments(PARSE_ARGV 0 arg
+    ""
+    "TARGET"
+    "OUTPUTS;SCRIPT_ARGS;INCLUDES;DEPENDS"
+  )
+  foreach(include ${arg_INCLUDES})
+    list(APPEND arg_SCRIPT_ARGS --include-subsystem-list ${include})
+  endforeach()
+  add_custom_command(
+    OUTPUT ${arg_OUTPUTS}
+    COMMAND
+      ${PYTHON_EXECUTABLE}
+      ${GEN_KOBJECT_LIST}
+      ${arg_SCRIPT_ARGS}
+      $<$<BOOL:${CMAKE_VERBOSE_MAKEFILE}>:--verbose>
+    DEPENDS
+      ${arg_DEPENDS}
+      ${GEN_KOBJECT_LIST}
+      ${PARSE_SYSCALLS_TARGET}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    )
+  add_custom_target(${arg_TARGET} DEPENDS ${arg_OUTPUTS})
+endfunction()
+
+# Generates a gperf header file named OUTPUT using the symbols found in the KERNEL_TARGET's output
+# binary. INCLUDES is a list of JSON files defining kernel subsystems and sockets.
+function(gen_kobject_list_gperf)
+  cmake_parse_arguments(PARSE_ARGV 0 arg
+    ""
+    "TARGET;OUTPUT;KERNEL_TARGET"
+    "INCLUDES"
+  )
+  gen_kobject_list(
+    TARGET ${arg_TARGET}
+    OUTPUTS ${arg_OUTPUT}
+    SCRIPT_ARGS
+      --kernel $<TARGET_FILE:${arg_KERNEL_TARGET}>
+      --gperf-output ${arg_OUTPUT}
+    INCLUDES ${arg_INCLUDES}
+    DEPENDS ${arg_KERNEL_TARGET}
+    )
+endfunction()
+
+# Generates header files describing the kernel subsystems defined by the JSON files in INCLUDES. The
+# variable named by GEN_DIR_OUT_VAR is set to the directory containing the header files.
+function(gen_kobject_list_headers)
+  cmake_parse_arguments(PARSE_ARGV 0 arg
+    ""
+    "GEN_DIR_OUT_VAR"
+    "INCLUDES"
+  )
   if (PROJECT_BINARY_DIR)
     set(gen_dir ${PROJECT_BINARY_DIR}/include/generated/zephyr)
   else ()
@@ -13,24 +68,18 @@ function(gen_kobj gen_dir_out)
 
   file(MAKE_DIRECTORY ${gen_dir})
 
-  add_custom_command(
-    OUTPUT ${KOBJ_TYPES} ${KOBJ_OTYPE} ${KOBJ_SIZE}
-    COMMAND
-    ${PYTHON_EXECUTABLE}
-    ${ZEPHYR_BASE}/scripts/build/gen_kobject_list.py
-    --kobj-types-output ${KOBJ_TYPES}
-    --kobj-otype-output ${KOBJ_OTYPE}
-    --kobj-size-output ${KOBJ_SIZE}
-    ${gen_kobject_list_include_args}
-    $<$<BOOL:${CMAKE_VERBOSE_MAKEFILE}>:--verbose>
-    DEPENDS
-    ${ZEPHYR_BASE}/scripts/build/gen_kobject_list.py
-    ${PARSE_SYSCALLS_TARGET}
-    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-    )
-  add_custom_target(${KOBJ_TYPES_H_TARGET} DEPENDS ${KOBJ_TYPES} ${KOBJ_OTYPE})
+  gen_kobject_list(
+    TARGET ${KOBJ_TYPES_H_TARGET}
+    OUTPUTS ${KOBJ_TYPES} ${KOBJ_OTYPE} ${KOBJ_SIZE}
+    SCRIPT_ARGS
+      --kobj-types-output ${KOBJ_TYPES}
+      --kobj-otype-output ${KOBJ_OTYPE}
+      --kobj-size-output ${KOBJ_SIZE}
+    INCLUDES ${arg_INCLUDES}
+  )
 
-  cmake_path(GET gen_dir PARENT_PATH gen_dir)
-  set(${gen_dir_out} ${gen_dir} PARENT_SCOPE)
-
+  if(arg_GEN_DIR_OUT_VAR)
+    cmake_path(GET gen_dir PARENT_PATH gen_dir)
+    set(${arg_GEN_DIR_OUT_VAR} ${gen_dir} PARENT_SCOPE)
+  endif()
 endfunction ()

--- a/cmake/kobj.cmake
+++ b/cmake/kobj.cmake
@@ -1,6 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
-set(GEN_KOBJECT_LIST ${ZEPHYR_BASE}/scripts/build/gen_kobject_list.py)
+find_program(GEN_KOBJECT_LIST NAMES gen_kobject_list gen_kobject_list.py PATHS ${ZEPHYR_BASE}/scripts/build)
+message(STATUS "Found gen_kobject_list: ${GEN_KOBJECT_LIST}")
+if(GEN_KOBJECT_LIST MATCHES "\.py$")
+  set(GEN_KOBJECT_LIST_INTERPRETER ${PYTHON_EXECUTABLE})
+endif()
 
 # Invokes gen_kobject_list.py with the given SCRIPT_ARGS, creating a TARGET that depends on the
 # script's OUTPUTS
@@ -16,7 +20,7 @@ function(gen_kobject_list)
   add_custom_command(
     OUTPUT ${arg_OUTPUTS}
     COMMAND
-      ${PYTHON_EXECUTABLE}
+      ${GEN_KOBJECT_LIST_INTERPRETER}
       ${GEN_KOBJECT_LIST}
       ${arg_SCRIPT_ARGS}
       $<$<BOOL:${CMAKE_VERBOSE_MAKEFILE}>:--verbose>

--- a/cmake/modules/unittest.cmake
+++ b/cmake/modules/unittest.cmake
@@ -57,7 +57,7 @@ target_link_libraries(testbinary PRIVATE test_interface)
 set(KOBJ_TYPES_H_TARGET kobj_types_h_target)
 include(${ZEPHYR_BASE}/cmake/kobj.cmake)
 add_dependencies(test_interface ${KOBJ_TYPES_H_TARGET})
-gen_kobj(KOBJ_GEN_DIR)
+gen_kobject_list_headers(GEN_DIR_OUT_VAR KOBJ_GEN_DIR)
 
 # Generates empty header files to build
 set(INCL_GENERATED_DIR ${APPLICATION_BINARY_DIR}/zephyr/include/generated/zephyr)


### PR DESCRIPTION
e.g. [this faster Rust rewrite](https://github.com/arbrauns/gen_kobject_list). Also generally clean up the invocations of `gen_kobject_list`.