### PR TITLE
boards: st: Fix README link in hal/stm32 module for stm32wbxx boards

### DIFF
--- a/boards/st/nucleo_wb55rg/doc/nucleo_wb55rg.rst
+++ b/boards/st/nucleo_wb55rg/doc/nucleo_wb55rg.rst
@@ -132,8 +132,8 @@ provides the following hardware capabilities:
 More information about STM32WB55RG can be found here:
 
 - `STM32WB55RG on www.st.com`_
-- `STM32WB5RG datasheet`_
-- `STM32WB5RG reference manual`_
+- `STM32WB55RG datasheet`_
+- `STM32WB55RG reference manual`_
 
 Supported Features
 ==================
@@ -180,10 +180,11 @@ Bluetooth and compatibility with STM32WB Copro Wireless Binaries
 To operate bluetooth on Nucleo WB55RG, Cortex-M0 core should be flashed with
 a valid STM32WB Coprocessor binaries (either 'Full stack' or 'HCI Layer').
 These binaries are delivered in STM32WB Cube packages, under
-Projects/STM32WB_Copro_Wireless_Binaries/STM32WB5x/
+``Projects/STM32WB_Copro_Wireless_Binaries/STM32WB5x/``
+
 For compatibility information with the various versions of these binaries,
-please check `modules/hal/stm32/lib/stm32wb/hci/README <https://github.com/zephyrproject-rtos/hal_stm32/blob/main/lib/stm32wb/hci/README>`__
-in the hal_stm32 repo.
+please check :module_file:`hal_stm32:lib/stm32wb/README.rst`.
+
 Note that since STM32WB Cube package V1.13.2, "full stack" binaries are not compatible
 anymore for a use in Zephyr and only "HCI Only" versions should be used on the M0
 side.
@@ -306,10 +307,10 @@ You can debug an application in the usual way.  Here is an example for the
 .. _STM32WB55RG on www.st.com:
    https://www.st.com/en/microcontrollers-microprocessors/stm32wb55rg.html
 
-.. _STM32WB5RG datasheet:
+.. _STM32WB55RG datasheet:
    https://www.st.com/resource/en/datasheet/stm32wb55rg.pdf
 
-.. _STM32WB5RG reference manual:
+.. _STM32WB55RG reference manual:
    https://www.st.com/resource/en/reference_manual/dm00318631.pdf
 
 .. _STM32CubeProgrammer:

--- a/boards/st/stm32wb5mm_dk/doc/stm32wb5mm_dk.rst
+++ b/boards/st/stm32wb5mm_dk/doc/stm32wb5mm_dk.rst
@@ -98,7 +98,7 @@ enable extended battery life, small coin-cell batteries, and energy harvesting.
     trimmed RC (±1%)
   - 2x PLL for system clock, USB, SAI, ADC
 
-More information about STM32WB55RG can be found here:
+More information about STM32WB5MMG can be found here:
 
 - `STM32WB5MM-DK on www.st.com`_
 - `STM32WB5MMG datasheet`_
@@ -132,8 +132,7 @@ These binaries are delivered in STM32WB Cube packages, under
 ``Projects/STM32WB_Copro_Wireless_Binaries/STM32WB5x/``.
 
 For compatibility information with the various versions of these binaries,
-please check `modules/hal/stm32/lib/stm32wb/hci/README`_
-in the ``hal_stm32`` repo.
+please check :module_file:`hal_stm32:lib/stm32wb/README.rst`.
 
 Note that since STM32WB Cube package V1.13.2, "full stack" binaries are not
 compatible anymore for a use in Zephyr and only "HCI Only" versions should be
@@ -244,9 +243,6 @@ You can debug an application in the usual way.  Here is an example for the
 
 .. _STM32WB5MMG datasheet:
    https://www.st.com/resource/en/datasheet/stm32wb5mmg.pdf
-
-.. _modules/hal/stm32/lib/stm32wb/hci/README:
-   https://github.com/zephyrproject-rtos/hal_stm32/blob/main/lib/stm32wb/hci/README
 
 .. _Hello_World:
    https://docs.zephyrproject.org/latest/samples/hello_world/README.html

--- a/boards/st/stm32wb5mmg/doc/stm32wb5mmg.rst
+++ b/boards/st/stm32wb5mmg/doc/stm32wb5mmg.rst
@@ -149,7 +149,7 @@ cut 2.2.
    and Bluetooth|reg| Low Energy
  - 48-bit EUI
 
-More information about STM32WB55RG can be found here:
+More information about STM32WB5MMG can be found here:
 
 - `STM32WB5MMG on www.st.com`_
 - `STM32WB5MMG datasheet`_
@@ -180,10 +180,11 @@ Bluetooth and compatibility with STM32WB Copro Wireless Binaries
 To operate bluetooth on STM32WB5MMG, Cortex-M0 core should be flashed with
 a valid STM32WB Coprocessor binaries (either 'Full stack' or 'HCI Layer').
 These binaries are delivered in STM32WB Cube packages, under
-Projects/STM32WB_Copro_Wireless_Binaries/STM32WB5x/
+``Projects/STM32WB_Copro_Wireless_Binaries/STM32WB5x/``
+
 For compatibility information with the various versions of these binaries,
-please check `modules/hal/stm32/lib/stm32wb/hci/README`_
-in the hal_stm32 repo.
+please check :module_file:`hal_stm32:lib/stm32wb/README.rst`.
+
 Note that since STM32WB Cube package V1.13.2, "full stack" binaries are not compatible
 anymore for a use in Zephyr and only "HCI Only" versions should be used on the M0
 side.
@@ -302,9 +303,6 @@ You can debug an application in the usual way.  Here is an example for the
 
 .. _STM32WB5MMG datasheet:
    https://www.st.com/resource/en/datasheet/stm32wb5mmg.pdf
-
-.. _modules/hal/stm32/lib/stm32wb/hci/README:
-  https://github.com/zephyrproject-rtos/hal_stm32/blob/main/lib/stm32wb/hci/README
 
 .. _STM32CubeProgrammer:
    https://www.st.com/en/development-tools/stm32cubeprog.html


### PR DESCRIPTION
Fix README link in hal/stm32 modules for stm32wbxx boards after being changed.