### PR TITLE
scripts: kconfig: kconfigfunctions: add `equal` function

### DIFF
--- a/scripts/kconfig/kconfigfunctions.py
+++ b/scripts/kconfig/kconfigfunctions.py
@@ -941,6 +941,12 @@ def substring(kconf, _, string, start, stop=None):
     else:
         return string[int(start):]
 
+def equal(kconf, _, val1, val2):
+    """
+    Return "y" if the two values are equal, otherwise "n"
+    """
+    return "y" if val1 == val2 else "n"
+
 def arith(kconf, name, *args):
     """
     The arithmetic operations on integers.
@@ -1068,6 +1074,7 @@ functions = {
         "normalize_upper": (normalize_upper, 1, 1),
         "shields_list_contains": (shields_list_contains, 1, 1),
         "substring": (substring, 2, 3),
+        "equal": (equal, 2, 2),
         "add": (arith, 1, 255),
         "sub": (arith, 1, 255),
         "mul": (arith, 1, 255),

--- a/tests/kconfig/functions/Kconfig
+++ b/tests/kconfig/functions/Kconfig
@@ -113,4 +113,20 @@ config KCONFIG_MAX_10_3_2
 	int
 	default $(max, 10, 3, 2)
 
+config KCONFIG_EQ_1_2
+	bool
+	default $(equal, 1, 2)
+
+config KCONFIG_EQ_2_2
+	bool
+	default $(equal, 2, 2)
+
+config KCONFIG_EQ_AB_CD
+	bool
+	default $(equal, ab, cd)
+
+config KCONFIG_EQ_EF_EF
+	bool
+	default $(equal, ef, ef)
+
 source "Kconfig.zephyr"

--- a/tests/kconfig/functions/src/main.c
+++ b/tests/kconfig/functions/src/main.c
@@ -45,4 +45,12 @@ ZTEST(test_kconfig_functions, test_min_max)
 	zassert_equal(CONFIG_KCONFIG_MAX_10_3_2, MAX(MAX(10, 3), 2));
 }
 
+ZTEST(test_kconfig_functions, test_equal)
+{
+	zassert_false(IS_ENABLED(CONFIG_KCONFIG_EQ_1_2));
+	zassert_true(IS_ENABLED(CONFIG_KCONFIG_EQ_2_2));
+	zassert_false(IS_ENABLED(CONFIG_KCONFIG_EQ_AB_CD));
+	zassert_true(IS_ENABLED(CONFIG_KCONFIG_EQ_EF_EF));
+}
+
 ZTEST_SUITE(test_kconfig_functions, NULL, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
Add a function to evaluate whether two parameters are equal to each other.

The intended use case for this is to determine in sysbuild whether an application is being compiled for TF-M. e.g.
```
BOARD_QUALIFIERS_LAST_TWO := $(substring,$(BOARD_QUALIFIERS),-2)

config SYSBUILD_IS_NS
	bool
	default "$(equal,$(BOARD_QUALIFIERS_LAST_TWO),ns)"
```
