### PR TITLE
soc: nordic: nrf54l: Setup power and clock only on secure build

### DIFF
--- a/drivers/counter/counter_nrfx_timer.c
+++ b/drivers/counter/counter_nrfx_timer.c
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+#include <soc.h>
 #include <zephyr/drivers/counter.h>
 #include <zephyr/drivers/clock_control/nrf_clock_control.h>
 #include <zephyr/devicetree.h>

--- a/include/zephyr/drivers/clock_control/nrf_clock_control.h
+++ b/include/zephyr/drivers/clock_control/nrf_clock_control.h
@@ -343,25 +343,6 @@ void nrf_clock_control_hfxo_release(void);
 
 #endif /* defined(CONFIG_CLOCK_CONTROL_NRF2) */
 
-/** @brief Get clock frequency that is used for the given node.
- *
- * Macro checks if node has clock property and if yes then if clock has clock_frequency property
- * then it is returned. If it has supported_clock_frequency property with the list of supported
- * frequencies then the last one is returned with assumption that they are ordered and the last
- * one is the highest. If node does not have clock then 16 MHz is returned which is the default
- * frequency.
- *
- * @param node Devicetree node.
- *
- * @return Frequency of the clock that is used for the node.
- */
-#define NRF_PERIPH_GET_FREQUENCY(node) \
-	COND_CODE_1(DT_CLOCKS_HAS_IDX(node, 0),							\
-		(COND_CODE_1(DT_NODE_HAS_PROP(DT_CLOCKS_CTLR(node), clock_frequency),		\
-			     (DT_PROP(DT_CLOCKS_CTLR(node), clock_frequency)),			\
-			     (DT_PROP_LAST(DT_CLOCKS_CTLR(node), supported_clock_frequency)))),	\
-		(NRFX_MHZ_TO_HZ(16)))
-
 #ifdef __cplusplus
 }
 #endif

--- a/soc/nordic/common/soc_nrf_common.h
+++ b/soc/nordic/common/soc_nrf_common.h
@@ -236,6 +236,25 @@
 		     DT_PINCTRL_HAS_NAME(node_id, sleep),		       \
 		     DT_NODE_PATH(node_id) " defined without sleep state")
 
+/** @brief Get clock frequency that is used for the given node.
+ *
+ * Macro checks if node has clock property and if yes then if clock has clock_frequency property
+ * then it is returned. If it has supported_clock_frequency property with the list of supported
+ * frequencies then the last one is returned with assumption that they are ordered and the last
+ * one is the highest. If node does not have clock then 16 MHz is returned which is the default
+ * frequency.
+ *
+ * @param node Devicetree node.
+ *
+ * @return Frequency of the clock that is used for the node.
+ */
+#define NRF_PERIPH_GET_FREQUENCY(node) \
+	COND_CODE_1(DT_CLOCKS_HAS_IDX(node, 0),							\
+		(COND_CODE_1(DT_NODE_HAS_PROP(DT_CLOCKS_CTLR(node), clock_frequency),		\
+			     (DT_PROP(DT_CLOCKS_CTLR(node), clock_frequency)),			\
+			     (DT_PROP_LAST(DT_CLOCKS_CTLR(node), supported_clock_frequency)))),	\
+		(NRFX_MHZ_TO_HZ(16)))
+
 #endif /* !_ASMLANGUAGE */
 
 #endif

--- a/soc/nordic/nrf54l/soc.c
+++ b/soc/nordic/nrf54l/soc.c
@@ -12,6 +12,9 @@
  * for the Nordic Semiconductor nRF54L family processor.
  */
 
+/* Include autoconf for cases when this file is used in special build (e.g. TFM) */
+#include <zephyr/autoconf.h>
+
 #include <zephyr/devicetree.h>
 #include <zephyr/kernel.h>
 #include <zephyr/devicetree.h>


### PR DESCRIPTION
Setup regulators and oscillators only on cpuapp secure target.