### PR TITLE
cmake: mwdt assembler option for imacros

### DIFF
--- a/cmake/compiler/arcmwdt/compiler_flags.cmake
+++ b/cmake/compiler/arcmwdt/compiler_flags.cmake
@@ -165,6 +165,9 @@ set_compiler_property(PROPERTY coverage "")
 # mwdt compiler flags for imacros. The specific header must be appended by user.
 set_compiler_property(PROPERTY imacros -imacros)
 
+# assembler compiler flags for imacros. The specific header must be appended by user.
+set_property(TARGET asm PROPERTY imacros -imacros)
+
 # Security canaries.
 #no support of -mstack-protector-guard=global"
 set_compiler_property(PROPERTY security_canaries -fstack-protector)


### PR DESCRIPTION
This is an untested example of something that might fix #85854 I do not have access to the toolchain, so I cant test it personally. 

It adds the -imacros property for assembler language to compensate for changes introduced in PR #84800.