### PR TITLE
doc: mgmt: mcumgr: consolidate TOC for SMP Groups

### DIFF
--- a/doc/services/device_mgmt/index.rst
+++ b/doc/services/device_mgmt/index.rst
@@ -15,18 +15,3 @@ Device Management
     dfu.rst
     ota.rst
     ec_host_cmd.rst
-
-SMP Groups
-==========
-
-.. toctree::
-    :maxdepth: 1
-
-    smp_groups/smp_group_0.rst
-    smp_groups/smp_group_1.rst
-    smp_groups/smp_group_2.rst
-    smp_groups/smp_group_3.rst
-    smp_groups/smp_group_8.rst
-    smp_groups/smp_group_9.rst
-    smp_groups/smp_group_10.rst
-    smp_groups/smp_group_63.rst

--- a/doc/services/device_mgmt/smp_protocol.rst
+++ b/doc/services/device_mgmt/smp_protocol.rst
@@ -220,3 +220,5 @@ Specifications of management groups supported by Zephyr
     smp_groups/smp_group_3.rst
     smp_groups/smp_group_8.rst
     smp_groups/smp_group_9.rst
+    smp_groups/smp_group_10.rst
+    smp_groups/smp_group_63.rst


### PR DESCRIPTION
Sphinx documents should not appear in multiple toctrees. Consolidate SMP Groups under SMP Protocol Specification.