### PR TITLE
dts: st: stm32u5: restore correct `clocks` on multi-bit devices

### DIFF
--- a/dts/arm/st/u5/stm32u5.dtsi
+++ b/dts/arm/st/u5/stm32u5.dtsi
@@ -304,7 +304,7 @@
 			compatible = "zephyr,memory-region", "st,stm32-backup-sram";
 			reg = <0x40036400 DT_SIZE_K(2)>;
 			/* BKPSRAMEN and RAMCFGEN clock enable */
-			clocks = <&rcc STM32_CLOCK(AHB1, 28U)>;
+			clocks = <&rcc STM32_CLOCK_BUS_AHB1 ((1 << 28) | (1 << 17))>;
 			zephyr,memory-region = "BACKUP_SRAM";
 			status = "disabled";
 		};

--- a/dts/arm/st/u5/stm32u595.dtsi
+++ b/dts/arm/st/u5/stm32u595.dtsi
@@ -108,7 +108,8 @@
 			num-bidir-endpoints = <9>;
 			ram-size = <4096>;
 			maximum-speed = "high-speed";
-			clocks = <&rcc STM32_CLOCK(AHB2, 14U)>;
+			/* Enable OTG_HS PHY and peripheral clocks (OTGHSPHYEN | OTGEN) */
+			clocks = <&rcc STM32_CLOCK_BUS_AHB2 ((1 << 15) | (1 << 14))>;
 			phys = <&otghs_phy>;
 			status = "disabled";
 		};


### PR DESCRIPTION
During the transition to STM32_CLOCK macro (in 57723cf), the `clocks` property of peripherals requiring more than one bit to be set were mistakenly modified. Commit 2c3294b079cf084c0f00bd18fb11d18a125cc3bc partially fixed these errors, but some nodes for the U5 series are still wrong.

Restore `clocks` on affected devices in corresponding STM32U5 DTSI.

Fixes: 57723cf40594545bbfc4aa36606ad9a838c4674a