### PR TITLE
boards: st: nucleo_n657x0_q: fix usart3 clock

### DIFF
--- a/boards/st/nucleo_n657x0_q/nucleo_n657x0_q_common.dtsi
+++ b/boards/st/nucleo_n657x0_q/nucleo_n657x0_q_common.dtsi
@@ -167,8 +167,8 @@
 };
 
 &usart3 {
-	clocks = <&rcc STM32_CLOCK(APB1, 17)>,
-		 <&rcc STM32_SRC_CKPER USART2_SEL(1)>;
+	clocks = <&rcc STM32_CLOCK(APB1, 18)>,
+		 <&rcc STM32_SRC_CKPER USART3_SEL(1)>;
 	pinctrl-0 = <&usart3_tx_pd8 &usart3_rx_pd9>;
 	pinctrl-names = "default";
 	current-speed = <115200>;


### PR DESCRIPTION
USART3 clock on the Nucleo-N657X0-Q was incorrectly configured (copy/paste from the DK board).

Fixes #85875