### PR TITLE
net: coap_client: expose has_ongoing_exchange function

### DIFF
--- a/include/zephyr/net/coap_client.h
+++ b/include/zephyr/net/coap_client.h
@@ -190,6 +190,23 @@ void coap_client_cancel_request(struct coap_client *client, struct coap_client_r
  */
 struct coap_client_option coap_client_option_initial_block2(void);
 
+/**
+ * @brief Check if client has ongoing exchange.
+ *
+ * @note Function not only considers ongoing requests, but also lifetime of completed requests
+ * (which provides graceful duplicates handling).
+ *
+ * @note For socket handling.
+ * Function does no consider a socket POLL that has started before this call,
+ * therefore it is recommended to wait out POLL timeout before closing socket
+ * (e.g. call coap_client_cancel_requests() which applies delay for timeout).
+ *
+ * @param client Pointer to the CoAP client instance.
+ *
+ * @return true if there is an ongoing exchange, false otherwise.
+ */
+bool coap_client_has_ongoing_exchange(struct coap_client *client);
+
 #ifdef __cplusplus
 }
 #endif

--- a/subsys/net/lib/coap/coap_client.c
+++ b/subsys/net/lib/coap/coap_client.c
@@ -1123,6 +1123,16 @@ struct coap_client_option coap_client_option_initial_block2(void)
 	return block2;
 }
 
+bool coap_client_has_ongoing_exchange(struct coap_client *client)
+{
+	if (client == NULL) {
+		LOG_ERR("Invalid (NULL) Client");
+		return false;
+	}
+
+	return has_ongoing_exchange(client);
+}
+
 K_THREAD_DEFINE(coap_client_recv_thread, CONFIG_COAP_CLIENT_STACK_SIZE,
 		coap_client_recv, NULL, NULL, NULL,
 		CONFIG_COAP_CLIENT_THREAD_PRIORITY, 0, 0);


### PR DESCRIPTION
The coap_client has a static/internal function, has_ongoing_exchange(), which can be an useful addition to the public API. This would provide a mechanism to determine when it is safe to close a socket gracefully.