### PR TITLE
ci: twister: upload junit.xml artifact

### DIFF
--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -236,14 +236,15 @@ jobs:
           junitparser merge artifacts/*/*/twister.xml junit.xml
           junit2html junit.xml junit.html
 
-      - name: Upload Unit Test Results in HTML
+      - name: Upload Unit Test Results
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: HTML Unit Test Results
+          name: Unit Test Results
           if-no-files-found: ignore
           path: |
             junit.html
+            junit.xml
 
       - name: Publish Unit Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2


### PR DESCRIPTION
The "raw" `junit.xml` is a useful artifact to make available to developers as it can be ingested by various tools (successfuly tested with [Allure](https://allurereport.org/)) to help dig into failures, look at evolution of test results over time, etc.