### PR TITLE
doc: releases: migration-guide: 4.1: list renamed xmc4xxx dts property

### DIFF
--- a/doc/releases/migration-guide-4.1.rst
+++ b/doc/releases/migration-guide-4.1.rst
@@ -164,6 +164,9 @@ Counter
 Controller Area Network (CAN)
 =============================
 
+* Renamed the :dtcompatible:`infineon,xmc4xxx-can-node` devicetree property ``clock_div8`` to
+  ``clock-div8`` (:github:`83782`).
+
 Display
 =======
 


### PR DESCRIPTION
List the renamed property (clock_div8 to clock-div8) for the infineon,xmc4xxx-can-node devicetree binding.