### PR TITLE
modules: hal_nordic: nrf_802154: enable constant latency

### DIFF
--- a/dts/common/nordic/nrf54l20.dtsi
+++ b/dts/common/nordic/nrf54l20.dtsi
@@ -677,6 +677,32 @@
 				status = "disabled";
 			};
 
+			power: power@10e000 {
+				compatible = "nordic,nrf-power";
+				reg = <0x10e000 0x1000>;
+				ranges = <0x0 0x10e000 0x1000>;
+				interrupts = <270 NRF_DEFAULT_IRQ_PRIORITY>;
+				status = "disabled";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				gpregret1: gpregret1@51c {
+					#address-cells = <1>;
+					#size-cells = <1>;
+					compatible = "nordic,nrf-gpregret";
+					reg = <0x51c 0x1>;
+					status = "disabled";
+				};
+
+				gpregret2: gpregret2@520 {
+					#address-cells = <1>;
+					#size-cells = <1>;
+					compatible = "nordic,nrf-gpregret";
+					reg = <0x520 0x1>;
+					status = "disabled";
+				};
+			};
+
 			regulators: regulator@120000 {
 				compatible = "nordic,nrf54l-regulators";
 				reg = <0x120000 0x1000>;

--- a/modules/hal_nordic/Kconfig
+++ b/modules/hal_nordic/Kconfig
@@ -36,6 +36,13 @@ menuconfig NRF_802154_RADIO_DRIVER
 
 if NRF_802154_RADIO_DRIVER
 
+config NRF_802154_CONSTLAT_CONTROL
+	def_bool y
+	depends on SOC_SERIES_NRF54LX && NRF_802154_SL_OPENSOURCE
+	select NRF_SYS_EVENT
+	help
+	  Allows the nRF 802.15.4 radio driver to manage the constant latency state.
+
 config NRF_802154_MULTIPROTOCOL_SUPPORT
 	bool
 	help


### PR DESCRIPTION
Added functionality to enable the constant latency mode in the nrf_802154 driver, alongside the HFXO.
Added the missing `power` node to nRF54L20 to allow the `NRFX_POWER` Kconfig to be enabled.