### PR TITLE
cmake: always store include paths with forward slashes

### DIFF
--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -81,6 +81,21 @@ include(CheckCXXCompilerFlag)
 #  zephyr_compile_options()     --->  target_compile_options()
 #
 
+# Internal function used to ensure paths passed to target_include_directories
+# are absolute and in standard CMake format (no backslashes).
+function(zephyr_cleanup_include_paths_internal out_list)
+  set(reserved_words SYSTEM AFTER BEFORE INTERFACE PUBLIC PRIVATE)
+  foreach(arg ${ARGV})
+    if(arg IN_LIST reserved_words)
+      list(APPEND cmake_args ${arg})
+    else()
+      cmake_path(SET cmake_path "${arg}")
+      cmake_path(ABSOLUTE_PATH cmake_path)
+      list(APPEND cmake_args "${cmake_path}")
+    endif()
+  endforeach()
+  set(${out_list} "${cmake_args}" PARENT_SCOPE)
+endfunction()
 
 # https://cmake.org/cmake/help/latest/command/target_sources.html
 function(zephyr_sources)
@@ -94,12 +109,14 @@ endfunction()
 
 # https://cmake.org/cmake/help/latest/command/target_include_directories.html
 function(zephyr_include_directories)
-  target_include_directories(zephyr_interface INTERFACE ${ARGV})
+  zephyr_cleanup_include_paths_internal(cleaned_args ${ARGV})
+  target_include_directories(zephyr_interface INTERFACE ${cleaned_args})
 endfunction()
 
 # https://cmake.org/cmake/help/latest/command/target_include_directories.html
 function(zephyr_system_include_directories)
-  target_include_directories(zephyr_interface SYSTEM INTERFACE ${ARGV})
+  zephyr_cleanup_include_paths_internal(cleaned_args ${ARGV})
+  target_include_directories(zephyr_interface SYSTEM INTERFACE ${cleaned_args})
 endfunction()
 
 # https://cmake.org/cmake/help/latest/command/target_compile_definitions.html


### PR DESCRIPTION
The `zephyr_include_directories()` and `zephyr_system_include_directories()` functions are used to add include paths to the `zephyr_interface` target. When `CONFIG_LLEXT_EDK` is enabled, these paths are eventually exported to the `build_info.yaml` file and must be in CMake-style format to avoid Windows backslashes being interpreted as escape characters.

This PR makes sure that the stored paths always use forward slashes (e.g. converting `C:\Users\...` into `C:/Users/...`) to avoid this kind of escaping issues.