### PR TITLE
cmake: Always use Dwarf 4 for IAR tools

### DIFF
--- a/cmake/compiler/iar/target.cmake
+++ b/cmake/compiler/iar/target.cmake
@@ -90,10 +90,8 @@ if("${IAR_TOOLCHAIN_VARIANT}" STREQUAL "iccarm")
     )
 endif()
 
-if(CONFIG_DEBUG)
-  # GCC defaults to Dwarf 5 output
-  list(APPEND IAR_ASM_FLAGS -gdwarf-4)
-endif()
+# IAR needs Dwarf 4 output
+list(APPEND IAR_ASM_FLAGS -gdwarf-4)
 
 if(DEFINED CONFIG_ARM_SECURE_FIRMWARE)
   list(APPEND IAR_COMMON_FLAGS --cmse)


### PR DESCRIPTION
The IAR linker does not handle Dwarf 5 and since it uses the GCC assembler for assembler files, we need to make sure the assembler output uses Dwarf 4.