### PR TITLE
tests: net: Fix conn_mgr_monitor tests 

### DIFF
--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -5127,8 +5127,13 @@ static void remove_ipv6_ifaddr(struct net_if *iface,
 #if defined(CONFIG_NET_IPV6_DAD)
 	if (!net_if_flag_is_set(iface, NET_IF_IPV6_NO_ND)) {
 		k_mutex_lock(&lock, K_FOREVER);
-		sys_slist_find_and_remove(&active_dad_timers,
-					  &ifaddr->dad_node);
+		if (sys_slist_find_and_remove(&active_dad_timers,
+					      &ifaddr->dad_node)) {
+			/* Addreess with active DAD timer would still have
+			 * stale entry in the neighbor cache.
+			 */
+			net_ipv6_nbr_rm(iface, &ifaddr->address.in6_addr);
+		}
 		k_mutex_unlock(&lock);
 	}
 #endif

--- a/tests/net/conn_mgr_conn/src/test_ifaces.c
+++ b/tests/net/conn_mgr_conn/src/test_ifaces.c
@@ -16,7 +16,7 @@
 static void test_iface_init(struct net_if *iface)
 {
 	/* Fake link layer address is needed to silence assertions inside the net core */
-	static uint8_t fake_lladdr[] = { 0x01 };
+	static uint8_t fake_lladdr[] = { 0x00, 0x00, 0x5E, 0x00, 0x53, 0x01 };
 
 	net_if_set_link_addr(iface, fake_lladdr, sizeof(fake_lladdr), NET_LINK_DUMMY);
 

--- a/tests/net/conn_mgr_monitor/src/test_ifaces.c
+++ b/tests/net/conn_mgr_monitor/src/test_ifaces.c
@@ -15,7 +15,7 @@
 static void test_iface_init(struct net_if *iface)
 {
 	/* Fake link layer address is needed to silence assertions inside the net core */
-	static uint8_t fake_lladdr[] = { 0x01 };
+	static uint8_t fake_lladdr[] = { 0x00, 0x00, 0x5E, 0x00, 0x53, 0x01 };
 
 	net_if_set_link_addr(iface, fake_lladdr, sizeof(fake_lladdr), NET_LINK_DUMMY);
 


### PR DESCRIPTION
Fix the root cause behind the test suite failure on `qemu_cortex_m3` (invalid L2 address used in tests).

Fix 2 other issues identified along the way:
 * clearing neighbor cache on IPv6 address removal
 * setting up DAD timer in case of NS sending failures

Fixes #85816