### PR TITLE
cfb: support text draw for non-vtiled displays

### DIFF
--- a/subsys/fb/cfb.c
+++ b/subsys/fb/cfb.c
@@ -78,7 +78,7 @@ static inline uint8_t get_glyph_byte(uint8_t *glyph_ptr, const struct cfb_font *
 				     uint8_t x, uint8_t y)
 {
 	if (fptr->caps & CFB_FONT_MONO_VPACKED) {
-		return glyph_ptr[x * (fptr->height / 8U) + y];
+		return glyph_ptr[(x * fptr->height + y) / 8];
 	} else if (fptr->caps & CFB_FONT_MONO_HPACKED) {
 		return glyph_ptr[y * (fptr->width) + x];
 	}
@@ -209,6 +209,62 @@ static uint8_t draw_char_vtmono(const struct char_framebuffer *fb,
 	return fptr->width;
 }
 
+/*
+ * Draw the monochrome character in the monochrome tiled framebuffer,
+ * a byte is interpreted as 8 pixels ordered horizontally among each other.
+ */
+static uint8_t draw_char_htmono(const struct char_framebuffer *fb,
+				uint8_t c, uint16_t x, uint16_t y,
+				bool draw_bg)
+{
+	const struct cfb_font *fptr = &(fb->fonts[fb->font_idx]);
+	const bool font_is_msbfirst = (fptr->caps & CFB_FONT_MSB_FIRST) != 0;
+	const bool display_is_msbfirst = (fb->screen_info & SCREEN_INFO_MONO_MSB_FIRST) != 0;
+	uint8_t *glyph_ptr;
+
+	if (c < fptr->first_char || c > fptr->last_char) {
+		c = ' ';
+	}
+
+	glyph_ptr = get_glyph_ptr(fptr, c);
+	if (!glyph_ptr) {
+		return 0;
+	}
+
+	for (size_t g_y = 0; g_y < fptr->height; g_y++) {
+		const int16_t fb_y = y + g_y;
+
+		for (size_t g_x = 0; g_x < fptr->width; g_x++) {
+			const int16_t fb_x = x + g_x;
+			const size_t fb_pixel_index = fb_y * fb->x_res + fb_x;
+			const size_t fb_byte_index = fb_pixel_index / 8;
+			uint8_t byte;
+			uint8_t pixel_value;
+
+			if (fb_x < 0 || fb->x_res <= fb_x || fb_y < 0 || fb->y_res <= fb_y) {
+				g_y++;
+				continue;
+			}
+
+			byte = get_glyph_byte(glyph_ptr, fptr, g_x, g_y);
+			if (font_is_msbfirst) {
+				byte = byte_reverse(byte);
+			}
+			pixel_value = byte & BIT(g_y % 8);
+
+			if (pixel_value) {
+				if (display_is_msbfirst) {
+					fb->buf[fb_byte_index] |= BIT(7 - (fb_x % 8));
+				} else {
+					fb->buf[fb_byte_index] |= BIT(fb_x % 8);
+				}
+			}
+		}
+	}
+
+	return fptr->width;
+}
+
 static inline void draw_point(struct char_framebuffer *fb, int16_t x, int16_t y)
 {
 	const bool need_reverse = ((fb->screen_info & SCREEN_INFO_MONO_MSB_FIRST) != 0);
@@ -277,21 +333,20 @@ static int draw_text(const struct device *dev, const char *const str, int16_t x,
 		return -EINVAL;
 	}
 
-	if ((fb->screen_info & SCREEN_INFO_MONO_VTILED)) {
-		const size_t len = strlen(str);
+	const size_t len = strlen(str);
 
-		for (size_t i = 0; i < len; i++) {
-			if ((x + fptr->width > fb->x_res) && wrap) {
-				x = 0U;
-				y += fptr->height;
-			}
-			x += fb->kerning + draw_char_vtmono(fb, str[i], x, y, wrap);
+	for (size_t i = 0; i < len; i++) {
+		if ((x + fptr->width > fb->x_res) && wrap) {
+			x = 0U;
+			y += fptr->height;
 		}
-		return 0;
+		if (fb->screen_info & SCREEN_INFO_MONO_VTILED) {
+			x += fb->kerning + draw_char_vtmono(fb, str[i], x, y, wrap);
+		} else {
+			x += fb->kerning + draw_char_htmono(fb, str[i], x, y, wrap);
+		}
 	}
-
-	LOG_ERR("Unsupported framebuffer configuration");
-	return -EINVAL;
+	return 0;
 }
 
 int cfb_draw_point(const struct device *dev, const struct cfb_position *pos)


### PR DESCRIPTION
Added support to draw text on non-vtiled displays