### PR TITLE
Cfb fixes

### DIFF
--- a/include/zephyr/display/cfb.h
+++ b/include/zephyr/display/cfb.h
@@ -28,7 +28,7 @@ extern "C" {
  */
 
 enum cfb_display_param {
-	CFB_DISPLAY_HEIGH		= 0,
+	CFB_DISPLAY_HEIGHT		= 0,
 	CFB_DISPLAY_WIDTH,
 	CFB_DISPLAY_PPT,
 	CFB_DISPLAY_ROWS,

--- a/samples/subsys/display/cfb/src/main.c
+++ b/samples/subsys/display/cfb/src/main.c
@@ -44,7 +44,7 @@ int main(void)
 	display_blanking_off(dev);
 
 	x_res = cfb_get_display_parameter(dev, CFB_DISPLAY_WIDTH);
-	y_res = cfb_get_display_parameter(dev, CFB_DISPLAY_HEIGH);
+	y_res = cfb_get_display_parameter(dev, CFB_DISPLAY_HEIGHT);
 	rows = cfb_get_display_parameter(dev, CFB_DISPLAY_ROWS);
 	ppt = cfb_get_display_parameter(dev, CFB_DISPLAY_PPT);
 

--- a/subsys/fb/cfb.c
+++ b/subsys/fb/cfb.c
@@ -493,7 +493,7 @@ int cfb_get_display_parameter(const struct device *dev,
 	const struct char_framebuffer *fb = &char_fb;
 
 	switch (param) {
-	case CFB_DISPLAY_HEIGH:
+	case CFB_DISPLAY_HEIGHT:
 		return fb->y_res;
 	case CFB_DISPLAY_WIDTH:
 		return fb->x_res;

--- a/subsys/fb/cfb.c
+++ b/subsys/fb/cfb.c
@@ -477,7 +477,7 @@ int cfb_framebuffer_finalize(const struct device *dev)
 		.pitch = fb->x_res,
 	};
 
-	if (!(fb->pixel_format & PIXEL_FORMAT_MONO10) != !(fb->inverted)) {
+	if ((fb->pixel_format == PIXEL_FORMAT_MONO10) == fb->inverted) {
 		cfb_invert(fb);
 		err = api->write(dev, 0, 0, &desc, fb->buf);
 		cfb_invert(fb);

--- a/subsys/fb/cfb_shell.c
+++ b/subsys/fb/cfb_shell.c
@@ -18,7 +18,7 @@
 #define HELP_NONE "[none]"
 #define HELP_INIT "call \"cfb init\" first"
 #define HELP_PRINT "<col: pos> <row: pos> \"<text>\""
-#define HELP_DRAW_POINT "<x> <y0>"
+#define HELP_DRAW_POINT "<x> <y>"
 #define HELP_DRAW_LINE "<x0> <y0> <x1> <y1>"
 #define HELP_DRAW_RECT "<x0> <y0> <x1> <y1>"
 #define HELP_INVERT "[<x> <y> <width> <height>]"
@@ -282,7 +282,7 @@ static int cmd_set_font(const struct shell *sh, size_t argc, char *argv[])
 		return err;
 	}
 
-	shell_print(sh, "Font idx=%d height=%d widht=%d set", idx, height,
+	shell_print(sh, "Font idx=%d height=%d width=%d set", idx, height,
 		    width);
 
 	return err;
@@ -396,8 +396,8 @@ static int cmd_get_param_height(const struct shell *sh, size_t argc,
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
 
-	shell_print(sh, "param: %s=%d", param_name[CFB_DISPLAY_HEIGH],
-		    cfb_get_display_parameter(dev, CFB_DISPLAY_HEIGH));
+	shell_print(sh, "param: %s=%d", param_name[CFB_DISPLAY_HEIGHT],
+		    cfb_get_display_parameter(dev, CFB_DISPLAY_HEIGHT));
 
 	return 0;
 }


### PR DESCRIPTION
* The condition for running special logic on monochrome displays was incorrect. On a mono01 display - the display was black after initialization
* Typo in `cfb_display_param` height param
* Typo in printing of width