### PR TITLE
boards: frdm_mcxw71: doc: fix sample command typo

### DIFF
--- a/boards/nxp/frdm_mcxw71/doc/index.rst
+++ b/boards/nxp/frdm_mcxw71/doc/index.rst
@@ -144,13 +144,13 @@ Openthread applications
    :zephyr-app: samples/net/sockets/echo_server
    :board: frdm_mcxw71
    :goals: build
-   :west-args: -- -DEXTRA_CONF_FILE=overlay-ot.conf
+   :gen-args: -DEXTRA_CONF_FILE=overlay-ot.conf
 
 .. zephyr-app-commands::
    :zephyr-app: samples/net/sockets/echo_client
    :board: frdm_mcxw71
    :goals: build
-   :west-args: -- -DEXTRA_CONF_FILE=overlay-ot.conf
+   :gen-args: -DEXTRA_CONF_FILE=overlay-ot.conf
 
 Application Flashing
 ====================


### PR DESCRIPTION
Changed from `:west-args:` to `:gen-args:` for specifying config file.

Rendered output changes from:

`west build -b frdm_mcxw71 -- -DEXTRA_CONF_FILE=overlay-ot.conf samples/net/sockets/echo_server`
to
`west build -b frdm_mcxw71 samples/net/sockets/echo_client -- -DEXTRA_CONF_FILE=overlay-ot.conf`