### PR TITLE
doc: ci: use ubuntu-24.04 runner

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -25,7 +25,7 @@ env:
 jobs:
   doc-file-check:
     name: Check for doc changes
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     if: >
       github.repository_owner == 'zephyrproject-rtos'
     outputs:
@@ -63,7 +63,7 @@ jobs:
     if: >
       github.repository_owner == 'zephyrproject-rtos' &&
         ( needs.doc-file-check.outputs.file_check == 'true' || github.event_name != 'pull_request' )
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 90
     concurrency:
       group: doc-build-html-${{ github.ref }}

--- a/lib/libc/minimal/include/sys/cdefs.h
+++ b/lib/libc/minimal/include/sys/cdefs.h
@@ -1,0 +1,4 @@
+/**
+ * This file is intentionally empty.
+ * It allows code including it to compile with the minimal libc.
+ */


### PR DESCRIPTION
Make CI run on latest Ubuntu LTS so that default Python version is effectively 3.12, allowing us to track latest Sphinx releases and to be closer to users' local environments which are most likely running Python >3.10 so would be using Sphinx 8.2.x while our CI would be stuck on 8.1.x.

First commit addresses an issue with lcov 2.x not being happy with empty header files when consolidating Doxygen coverage report -- also something that likely impacts users of latest Ubuntu LTS (and prob other distros!) but which CI never caught.

CI passes https://github.com/zephyrproject-rtos/zephyr/actions/runs/13409088440?pr=85908 but documentation isn't deployed to builds.zephyrproject.io due to workflow file being modified.