### PR TITLE
include: zephyr: mgmt: mcumgr: callbacks: Remove deprecated macro

### DIFF
--- a/doc/releases/migration-guide-4.1.rst
+++ b/doc/releases/migration-guide-4.1.rst
@@ -667,6 +667,8 @@ MCUmgr
   deprecated and replaced with :kconfig:option:`CONFIG_MCUBOOT_BOOTLOADER_MODE_SWAP_USING_MOVE`,
   applications should be updated to select this new symbol if they were selecting the old symbol.
 
+* The deprecated macro ``MGMT_CB_ERROR_RET`` has been removed.
+
 Modem
 =====
 

--- a/include/zephyr/mgmt/mcumgr/mgmt/callbacks.h
+++ b/include/zephyr/mgmt/mcumgr/mgmt/callbacks.h
@@ -76,9 +76,6 @@ enum mgmt_cb_return {
 	MGMT_CB_ERROR_ERR,
 };
 
-/* Deprecated after Zephyr 3.4, use MGMT_CB_ERROR_ERR instead */
-#define MGMT_CB_ERROR_RET __DEPRECATED_MACRO MGMT_CB_ERROR_ERR
-
 /**
  * @typedef mgmt_cb
  * @brief Function to be called on MGMT notification/event.


### PR DESCRIPTION
Removes a macro that was deprecated with Zephyr 3.4