### PR TITLE
drivers: pinctrl: silabs: Fix pin deallocation from digital bus

### DIFF
--- a/drivers/pinctrl/pinctrl_silabs_dbus.c
+++ b/drivers/pinctrl/pinctrl_silabs_dbus.c
@@ -40,7 +40,11 @@ int pinctrl_configure_pins(const pinctrl_soc_pin_t *pins, uint8_t pin_cnt, uintp
 		sys_write32(pins[i].port | FIELD_PREP(PIN_MASK, pins[i].pin), route_reg);
 
 		if (pins[i].en_bit != SILABS_PINCTRL_UNUSED) {
-			sys_set_bit(enable_reg, pins[i].en_bit);
+			if (pins[i].mode == gpioModeDisabled) {
+				sys_clear_bit(enable_reg, pins[i].en_bit);
+			} else {
+				sys_set_bit(enable_reg, pins[i].en_bit);
+			}
 		}
 	}
 


### PR DESCRIPTION
Fix the scenario where a pinctrl node intends to deallocate a pin from a peripheral. If the GPIO mode is disabled the DBUS route should be cleared, not set. This allows reuse of a pin for other purposes when a driver is suspended and the pinctrl sleep state is applied, as GPIOs are typically disabled in the sleep state.