### PR TITLE
samples: bluetooth: central_ht: Enable MIMXRT1170 EVKB for central_ht

### DIFF
--- a/samples/bluetooth/central_ht/boards/mimxrt1170_evk_mimxrt1176_cm7_B.conf
+++ b/samples/bluetooth/central_ht/boards/mimxrt1170_evk_mimxrt1176_cm7_B.conf
@@ -1,0 +1,2 @@
+#select NXP NW612 Chipset
+CONFIG_BT_NXP_NW612=y

--- a/samples/bluetooth/central_ht/boards/mimxrt1170_evk_mimxrt1176_cm7_B.overlay
+++ b/samples/bluetooth/central_ht/boards/mimxrt1170_evk_mimxrt1176_cm7_B.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright 2025 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	chosen {
+		zephyr,sram = &dtcm;
+	};
+};


### PR DESCRIPTION
add overlay file to set sram to dtcm.
add config file to use nxp NW612 chipset.