### PR TITLE
drivers: ethernet: phy: dm8806: Fix driver bindings

### DIFF
--- a/drivers/ethernet/phy/phy_dm8806.c
+++ b/drivers/ethernet/phy/phy_dm8806.c
@@ -673,9 +673,9 @@ static DEVICE_API(ethphy, phy_dm8806_api) = {
 	static const struct phy_dm8806_config phy_dm8806_config_##n = {                            \
 		.mdio = DEVICE_DT_GET(DT_INST_BUS(n)),                                             \
 		.phy_addr = DT_INST_REG_ADDR(n),                                                   \
-		.switch_addr = DT_PROP(DT_NODELABEL(dm8806_phy##n), reg_switch),                   \
-		.gpio_int = GPIO_DT_SPEC_INST_GET(n, interrupt_gpio),                              \
-		.gpio_rst = GPIO_DT_SPEC_INST_GET(n, reset_gpio),                                  \
+		.switch_addr = DT_INST_PROP(n, reg_switch),                                        \
+		.gpio_int = GPIO_DT_SPEC_INST_GET(n, int_gpios),                                   \
+		.gpio_rst = GPIO_DT_SPEC_INST_GET(n, reset_gpios),                                 \
 	}
 
 #define DM8806_PHY_INITIALIZE(n)                                                                   \

--- a/dts/bindings/ethernet/davicom,dm8806-phy.yaml
+++ b/dts/bindings/ethernet/davicom,dm8806-phy.yaml
@@ -29,6 +29,7 @@ properties:
       Absolute address is the address of the concrete register in MAC PHY0
       which is responsible for Ethernet Port0 in Davicom DM8806
   reg-switch:
+    type: int
     required: true
     description: |
       5-bit PHY address for Switch Per-Port Registers group of Davicom DM8806
@@ -48,9 +49,11 @@ properties:
       which is responsible for Ethernet Port0 in Davicom DM8806
   reset-gpios:
     type: phandle-array
+    required: true
     description: GPIO connected to MAC PHY reset signal pin. Reset is active low.
   int-gpios:
     type: phandle-array
+    required: true
     description: GPIO for   upt signal indicating MAC PHY state change.
   davicom,interface-type:
     type: string

--- a/tests/drivers/build_all/ethernet/app.overlay
+++ b/tests/drivers/build_all/ethernet/app.overlay
@@ -79,6 +79,15 @@
 					compatible = "adi,adin2111-phy";
 					status = "okay";
 				};
+				ethernet-phy@7 {
+					reg = <0x7>;
+					compatible = "davicom,dm8806-phy";
+					status = "okay";
+					reg-switch = <8>;
+					reset-gpios = <&test_gpio 0 0>;
+					int-gpios = <&test_gpio 0 0>;
+					davicom,interface-type = "rmii";
+				};
 			};
 		};
 	};


### PR DESCRIPTION
There were some driver bindings issues for the davicom dm8806 driver:
- Missing type for reg-switch binding
- Missing required: true for int/reset gpios
- Fix macro for reg-switch