### PR TITLE
hci_da1453x: fix polarity of reset gpio

### DIFF
--- a/drivers/bluetooth/hci/hci_da1453x.c
+++ b/drivers/bluetooth/hci/hci_da1453x.c
@@ -41,7 +41,7 @@ int bt_hci_transport_setup(const struct device *h4)
 	k_sleep(K_MSEC(DT_INST_PROP_OR(0, reset_assert_duration_ms, 0)));
 
 	/* Release the DA1453x from reset */
-	err = gpio_pin_set_dt(&bt_reset, 0);
+	err = gpio_pin_configure_dt(&bt_reset, GPIO_OUTPUT_INACTIVE);
 	if (err) {
 		return err;
 	}


### PR DESCRIPTION
Previously polarity was used during assert, but ignored on release, so inverted resets were never toggled.

Taken as part of #85337, might be useful to include in 4.1 as it is an obvious bug even though no mainline board uses it yet.