### PR TITLE
eth_nxp_enet_qos_mac: test and return early

### DIFF
--- a/drivers/ethernet/eth_nxp_enet_qos/eth_nxp_enet_qos_mac.c
+++ b/drivers/ethernet/eth_nxp_enet_qos/eth_nxp_enet_qos_mac.c
@@ -73,13 +73,14 @@ static int eth_nxp_enet_qos_tx(const struct device *dev, struct net_pkt *pkt)
 		frags_count++;
 		total_bytes += fragment->len;
 		fragment = fragment->frags;
+
+		if (total_bytes > config->hw_info.max_frame_len ||
+			frags_count > NUM_TX_BUFDESC) {
+			LOG_ERR("TX packet too large");
+			return -E2BIG;
+		}
 	}
 
-	if (total_bytes > config->hw_info.max_frame_len ||
-	    frags_count > NUM_TX_BUFDESC) {
-		LOG_ERR("TX packet too large");
-		return -E2BIG;
-	}
 
 	/* One TX at a time in the current implementation */
 	k_sem_take(&data->tx.tx_sem, K_FOREVER);


### PR DESCRIPTION
move the check inside the loop to return early

in my case it was stuck in the loop incrementing total_bytes until it becomes a negative number ...
To move the test will return early and avoid endless loop.

tested for MCXN947

this will solve the problem #85172 for me
