### PR TITLE
boards: mini_stm32h7b0: use board common CDC ACM UART configuration

### DIFF
--- a/boards/weact/mini_stm32h7b0/Kconfig.defconfig
+++ b/boards/weact/mini_stm32h7b0/Kconfig.defconfig
@@ -22,14 +22,6 @@ endif # LVGL
 
 endif # DISPLAY
 
-if USB_DEVICE_STACK
-
-config UART_CONSOLE
-	default CONSOLE
-
-config USB_DEVICE_INITIALIZE_AT_BOOT
-	default y
-
-endif # USB_DEVICE_STACK
+source "boards/common/usb/Kconfig.cdc_acm_serial.defconfig"
 
 endif # BOARD_MINI_STM32H7B0

--- a/boards/weact/mini_stm32h7b0/mini_stm32h7b0.dts
+++ b/boards/weact/mini_stm32h7b0/mini_stm32h7b0.dts
@@ -15,8 +15,6 @@
 	compatible = "weact,mini-stm32h7b0";
 
 	chosen {
-		zephyr,console = &usb_cdc_acm_uart;
-		zephyr,shell-uart = &usb_cdc_acm_uart;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,display = &st7735r_160x80;
@@ -132,12 +130,9 @@ zephyr_udc0: &usbotg_hs {
 	pinctrl-0 = <&usb_otg_hs_dm_pa11 &usb_otg_hs_dp_pa12>;
 	pinctrl-names = "default";
 	status = "okay";
-
-	usb_cdc_acm_uart: cdc_acm_uart {
-		compatible = "zephyr,cdc-acm-uart";
-	};
 };
 
+#include <../boards/common/usb/cdc_acm_serial.dtsi>
 
 &octospi1 {
 	pinctrl-names = "default";

--- a/boards/weact/mini_stm32h7b0/mini_stm32h7b0_defconfig
+++ b/boards/weact/mini_stm32h7b0/mini_stm32h7b0_defconfig
@@ -7,17 +7,5 @@ CONFIG_ARM_MPU=y
 # Enable HW stack protection
 CONFIG_HW_STACK_PROTECTION=y
 
-# Enable UART driver
-CONFIG_SERIAL=y
-
-# Enable console
-CONFIG_CONSOLE=y
-
 # Enable GPIO
 CONFIG_GPIO=y
-
-# Logger cannot use itself to log
-CONFIG_USB_CDC_ACM_LOG_LEVEL_OFF=y
-
-# Enable USB
-CONFIG_USB_DEVICE_STACK=y


### PR DESCRIPTION
Remove USB and CDC ACM configuration in favor of common configuraiton. This is a follow up to commit 272290bfee16 ("boards: use board common CDC ACM UART configuration") Support for this board was merged just before the common solution was introduced.