### PR TITLE
modem: Add helper functions for sending data and waiting for response

### DIFF
--- a/drivers/modem/modem_cmd_handler.c
+++ b/drivers/modem/modem_cmd_handler.c
@@ -570,13 +570,7 @@ int modem_cmd_send_ext(struct modem_iface *iface,
 	iface->write(iface, data->eol, data->eol_len);
 
 	if (sem) {
-		ret = k_sem_take(sem, timeout);
-
-		if (ret == 0) {
-			ret = data->last_error;
-		} else if (ret == -EAGAIN) {
-			ret = -ETIMEDOUT;
-		}
+		ret = modem_cmd_handler_await(data, sem, timeout);
 	}
 
 	if (!(flags & MODEM_NO_UNSET_CMDS)) {

--- a/drivers/modem/modem_cmd_handler.c
+++ b/drivers/modem/modem_cmd_handler.c
@@ -486,6 +486,20 @@ int modem_cmd_handler_update_cmds(struct modem_cmd_handler_data *data,
 	return 0;
 }
 
+int modem_cmd_send_data_nolock(struct modem_iface *iface,
+			       const uint8_t *buf, size_t len)
+{
+#if defined(CONFIG_MODEM_CONTEXT_VERBOSE_DEBUG)
+	if (len > 256) {
+		/* Truncate the message, since too long log messages gets dropped somewhere. */
+		LOG_HEXDUMP_DBG(buf, 256, "SENT DIRECT DATA (truncated)");
+	} else {
+		LOG_HEXDUMP_DBG(buf, len, "SENT DIRECT DATA");
+	}
+#endif
+	return iface->write(iface, buf, len);
+}
+
 int modem_cmd_send_ext(struct modem_iface *iface,
 		       struct modem_cmd_handler *handler,
 		       const struct modem_cmd *handler_cmds,

--- a/drivers/modem/modem_cmd_handler.c
+++ b/drivers/modem/modem_cmd_handler.c
@@ -486,6 +486,20 @@ int modem_cmd_handler_update_cmds(struct modem_cmd_handler_data *data,
 	return 0;
 }
 
+int modem_cmd_handler_await(struct modem_cmd_handler_data *data,
+			    struct k_sem *sem, k_timeout_t timeout)
+{
+	int ret = k_sem_take(sem, timeout);
+
+	if (ret == 0) {
+		ret = modem_cmd_handler_get_error(data);
+	} else if (ret == -EAGAIN) {
+		ret = -ETIMEDOUT;
+	}
+
+	return ret;
+}
+
 int modem_cmd_send_data_nolock(struct modem_iface *iface,
 			       const uint8_t *buf, size_t len)
 {

--- a/drivers/modem/modem_cmd_handler.h
+++ b/drivers/modem/modem_cmd_handler.h
@@ -159,6 +159,18 @@ int modem_cmd_handler_update_cmds(struct modem_cmd_handler_data *data,
 				  bool reset_error_flag);
 
 /**
+ * @brief  send data directly to interface w/o TX lock.
+ *
+ * This function just writes directly to the modem interface.
+ * Recommended to use to get verbose logging for all data sent to the interface.
+ * @param  iface: interface to use
+ * @param  buf: send buffer (not NULL terminated)
+ * @param  len: length of send buffer.
+ */
+int modem_cmd_send_data_nolock(struct modem_iface *iface,
+			       const uint8_t *buf, size_t len);
+
+/**
  * @brief  send AT command to interface with behavior defined by flags
  *
  * This function is similar to @ref modem_cmd_send, but it allows to choose a

--- a/drivers/modem/modem_cmd_handler.h
+++ b/drivers/modem/modem_cmd_handler.h
@@ -159,6 +159,21 @@ int modem_cmd_handler_update_cmds(struct modem_cmd_handler_data *data,
 				  bool reset_error_flag);
 
 /**
+ * @brief  Wait until semaphore is given
+ *
+ * This function does the same wait behavior as @ref modem_cmd_send, but can wait without sending
+ * any command first. Useful for waiting for asynchronous responses.
+ *
+ * @param  data: handler data to use
+ * @param  sem: wait for semaphore.
+ * @param  timeout: wait timeout.
+ *
+ * @retval 0 if ok, < 0 if error.
+ */
+int modem_cmd_handler_await(struct modem_cmd_handler_data *data,
+			    struct k_sem *sem, k_timeout_t timeout);
+
+/**
  * @brief  send data directly to interface w/o TX lock.
  *
  * This function just writes directly to the modem interface.

--- a/drivers/modem/modem_shell.c
+++ b/drivers/modem/modem_shell.c
@@ -30,7 +30,7 @@ struct modem_shell_user_data {
 #define ms_context		modem_context
 #define ms_max_context		CONFIG_MODEM_CONTEXT_MAX_NUM
 #define ms_send(ctx_, buf_, size_) \
-			(ctx_->iface.write(&ctx_->iface, buf_, size_))
+			(modem_cmd_send_data_nolock(&ctx_->iface, buf_, size_))
 #define ms_context_from_id	modem_context_from_id
 #define UART_DEV_NAME(ctx)	(ctx->iface.dev->name)
 #elif defined(CONFIG_MODEM_RECEIVER)

--- a/drivers/modem/quectel-bg9x.c
+++ b/drivers/modem/quectel-bg9x.c
@@ -484,8 +484,8 @@ static ssize_t send_socket_data(struct modem_socket *sock,
 	}
 
 	/* Write all data on the console and send CTRL+Z. */
-	mctx.iface.write(&mctx.iface, buf, buf_len);
-	mctx.iface.write(&mctx.iface, &ctrlz, 1);
+	modem_cmd_send_data_nolock(&mctx.iface, buf, buf_len);
+	modem_cmd_send_data_nolock(&mctx.iface, &ctrlz, 1);
 
 	/* Wait for 'SEND OK' or 'SEND FAIL' */
 	k_sem_reset(&mdata.sem_response);

--- a/drivers/modem/simcom-sim7080.c
+++ b/drivers/modem/simcom-sim7080.c
@@ -273,8 +273,8 @@ static ssize_t offload_sendto(void *obj, const void *buf, size_t len, int flags,
 	}
 
 	/* Send data */
-	mctx.iface.write(&mctx.iface, buf, len);
-	mctx.iface.write(&mctx.iface, &ctrlz, 1);
+	modem_cmd_send_data_nolock(&mctx.iface, buf, len);
+	modem_cmd_send_data_nolock(&mctx.iface, &ctrlz, 1);
 
 	/* Wait for the OK */
 	k_sem_reset(&mdata.sem_response);

--- a/drivers/modem/ublox-sara-r4.c
+++ b/drivers/modem/ublox-sara-r4.c
@@ -415,7 +415,7 @@ static ssize_t send_socket_data(void *obj,
 		if (len == 0) {
 			break;
 		}
-		mctx.iface.write(&mctx.iface, msg->msg_iov[i].iov_base, len);
+		modem_cmd_send_data_nolock(&mctx.iface, msg->msg_iov[i].iov_base, len);
 		buf_len -= len;
 	}
 
@@ -494,7 +494,7 @@ static ssize_t send_cert(struct modem_socket *sock,
 
 	/* slight pause per spec so that @ prompt is received */
 	k_sleep(MDM_PROMPT_CMD_DELAY);
-	mctx.iface.write(&mctx.iface, cert_data, cert_len);
+	modem_cmd_send_data_nolock(&mctx.iface, cert_data, cert_len);
 
 	ret = k_sem_take(&mdata.sem_response, K_MSEC(1000));
 

--- a/drivers/modem/ublox-sara-r4.c
+++ b/drivers/modem/ublox-sara-r4.c
@@ -486,11 +486,16 @@ static ssize_t send_cert(struct modem_socket *sock,
 		goto exit;
 	}
 
+	/* Reset response semaphore before sending data
+	 * So that we are sure that we won't use a previously pending one
+	 * And we won't miss the one that is going to be freed
+	 */
+	k_sem_reset(&mdata.sem_response);
+
 	/* slight pause per spec so that @ prompt is received */
 	k_sleep(MDM_PROMPT_CMD_DELAY);
 	mctx.iface.write(&mctx.iface, cert_data, cert_len);
 
-	k_sem_reset(&mdata.sem_response);
 	ret = k_sem_take(&mdata.sem_response, K_MSEC(1000));
 
 	if (ret == 0) {

--- a/drivers/modem/ublox-sara-r4.c
+++ b/drivers/modem/ublox-sara-r4.c
@@ -423,13 +423,8 @@ static ssize_t send_socket_data(void *obj,
 		ret = 0;
 		goto exit;
 	}
-	ret = k_sem_take(&mdata.sem_response, timeout);
 
-	if (ret == 0) {
-		ret = modem_cmd_handler_get_error(&mdata.cmd_handler_data);
-	} else if (ret == -EAGAIN) {
-		ret = -ETIMEDOUT;
-	}
+	ret = modem_cmd_handler_await(&mdata.cmd_handler_data, &mdata.sem_response, timeout);
 
 exit:
 	/* unset handler commands and ignore any errors */
@@ -496,13 +491,7 @@ static ssize_t send_cert(struct modem_socket *sock,
 	k_sleep(MDM_PROMPT_CMD_DELAY);
 	modem_cmd_send_data_nolock(&mctx.iface, cert_data, cert_len);
 
-	ret = k_sem_take(&mdata.sem_response, K_MSEC(1000));
-
-	if (ret == 0) {
-		ret = modem_cmd_handler_get_error(&mdata.cmd_handler_data);
-	} else if (ret == -EAGAIN) {
-		ret = -ETIMEDOUT;
-	}
+	ret = modem_cmd_handler_await(&mdata.cmd_handler_data, &mdata.sem_response, K_MSEC(1000));
 
 exit:
 	/* unset handler commands and ignore any errors */

--- a/drivers/wifi/esp_at/esp_offload.c
+++ b/drivers/wifi/esp_at/esp_offload.c
@@ -324,7 +324,7 @@ static int _sock_send(struct esp_socket *sock, struct net_pkt *pkt)
 	frag = pkt->frags;
 	while (frag && pkt_len) {
 		write_len = MIN(pkt_len, frag->len);
-		dev->mctx.iface.write(&dev->mctx.iface, frag->data, write_len);
+		modem_cmd_send_data_nolock(&dev->mctx.iface, frag->data, write_len);
 		pkt_len -= write_len;
 		frag = frag->frags;
 	}


### PR DESCRIPTION
Fix possible race condition, reset the response semaphore before we send
any data. In case we don't get scheduled back before the response is
processed.

Add helper function to send data on modem command handler interface.
This makes sure that when verbose logging is enabled all data is
actually logged.

Add a helper function that waits for a semaphore and handles the
error conditions that may arise.