### PR TITLE
runners: stm32cubeprogrammer: set download address

### DIFF
--- a/boards/common/stm32cubeprogrammer.board.cmake
+++ b/boards/common/stm32cubeprogrammer.board.cmake
@@ -1,4 +1,19 @@
 # SPDX-License-Identifier: Apache-2.0
 
 board_set_flasher_ifnset(stm32cubeprogrammer)
+
+# Compute image address in ROM
+dt_chosen(flash_node PROPERTY "zephyr,flash")
+dt_reg_addr(flash_reg PATH ${flash_node})
+
+IF(NOT SYSBUILD)
+  SET(flash_offset 0x0)
+ELSE()
+  dt_chosen(code_partition PROPERTY "zephyr,code-partition")
+  dt_reg_addr(flash_offset PATH ${code_partition})
+ENDIF()
+
+MATH(EXPR download_address "${flash_reg} + ${flash_offset}" OUTPUT_FORMAT HEXADECIMAL)
+
+board_runner_args(stm32cubeprogrammer --download-address=${download_address})
 board_finalize_runner_args(stm32cubeprogrammer)


### PR DESCRIPTION
For multi-image builds, the download address of each binary image must be passed to STM32CubeProgrammer.

This fixes the default builds of 'samples/sysbuild/with_mcuboot' for STM32-based boards.