### PR TITLE
gpio: shell: use the first nodelabel when available

### DIFF
--- a/drivers/gpio/gpio_shell.c
+++ b/drivers/gpio/gpio_shell.c
@@ -474,14 +474,28 @@ static int cmd_gpio_blink(const struct shell *sh, size_t argc, char **argv)
 	return 0;
 }
 
+static const char *gpio_device_name(const struct device *dev)
+{
+#ifdef CONFIG_DEVICE_DT_METADATA
+	const struct device_dt_nodelabels *nl = device_get_dt_nodelabels(dev);
+
+	if (nl != NULL && nl->num_nodelabels > 0) {
+		return nl->nodelabels[0];
+	}
+#endif
+	return dev->name;
+}
+
 static void device_name_get(size_t idx, struct shell_static_entry *entry)
 {
+	const struct device *dev = gpio_list[idx].dev;
+
 	if (idx >= ARRAY_SIZE(gpio_list)) {
 		entry->syntax = NULL;
 		return;
 	}
 
-	entry->syntax = gpio_list[idx].dev->name;
+	entry->syntax = gpio_device_name(dev);
 	entry->handler = NULL;
 	entry->help = "Device";
 	entry->subcmd = gpio_list[idx].subcmd;
@@ -599,7 +613,7 @@ static void pin_ordered(const struct pin_info *info, void *user_data)
 	shell_print(data->sh, "   %-12s %-8c %-16s %2u",
 		    data->next.line_name,
 		    data->next.reserved ? '*' : ' ',
-		    data->next.dev->name,
+		    gpio_device_name(data->next.dev),
 		    data->next.pin);
 
 	data->prev = data->next;


### PR DESCRIPTION
Use the first nodelabel rather than the node name when available for shell completion as well as "gpio info". This label is always set gpio nodes as that's what's used for references by device nodes, there may be some case where a node has multiple labels for some reason but for a human I reckon it still makes more sense to suggest a label rather than the address.

This means that the commands would use, for example "gpioa" rather than "gpio@58020000".

Fall back to the normal node name if there's no label set or if dt metadata is not enabled.