### PR TITLE
drivers: i2c: I2C_SAM0_TRANSFER_TIMEOUT depends on I2C_SAM0

### DIFF
--- a/drivers/i2c/Kconfig.sam0
+++ b/drivers/i2c/Kconfig.sam0
@@ -21,6 +21,7 @@ config I2C_SAM0_DMA_DRIVEN
 
 config I2C_SAM0_TRANSFER_TIMEOUT
 	int "Transfer timeout [ms]"
+	depends on I2C_SAM0
 	default 500
 	help
 	  Timeout in milliseconds used for each I2C transfer.


### PR DESCRIPTION
I2C_SAM0_TRANSFER_TIMEOUT should depend on I2C_SAM0.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
