### PR TITLE
sensor: adxl367 and adxl372: fix CI build-failure with streaming mode

### DIFF
--- a/drivers/sensor/adi/adxl367/adxl367_stream.c
+++ b/drivers/sensor/adi/adxl367/adxl367_stream.c
@@ -363,7 +363,7 @@ static void adxl367_process_fifo_samples_cb(struct rtio *r, const struct rtio_sq
 
 	((struct adxl367_fifo_data *)buf)->fifo_byte_count = read_len;
 
-	__ASSERT_NO_MSG(read_len % pkt_size == 0);
+	__ASSERT_NO_MSG(read_len % packet_size == 0);
 
 	uint8_t *read_buf = buf + sizeof(*hdr);
 

--- a/drivers/sensor/adi/adxl372/adxl372_decoder.c
+++ b/drivers/sensor/adi/adxl372/adxl372_decoder.c
@@ -50,7 +50,7 @@ static int adxl372_decode_stream(const uint8_t *buffer, struct sensor_chan_spec 
 	memset(data, 0, sizeof(struct sensor_three_axis_data));
 	data->header.base_timestamp_ns = enc_data->timestamp;
 	data->header.reading_count = 1;
-	data->header.shift = 11; /* Sensor shift */
+	data->shift = 11; /* Sensor shift */
 
 	buffer += sizeof(struct adxl372_fifo_data);
 

--- a/drivers/sensor/adi/adxl372/adxl372_stream.c
+++ b/drivers/sensor/adi/adxl372/adxl372_stream.c
@@ -249,7 +249,7 @@ static void adxl372_process_fifo_samples_cb(struct rtio *r, const struct rtio_sq
 
 	((struct adxl372_fifo_data *)buf)->fifo_byte_count = read_len;
 
-	__ASSERT_NO_MSG(read_len % pkt_size == 0);
+	__ASSERT_NO_MSG(read_len % sample_set_size == 0);
 
 	uint8_t *read_buf = buf + sizeof(*hdr);
 


### PR DESCRIPTION
### Description
This PR fixes two build-time issues:
1. Rename reference of non-existent variable `pkt_size`. Replaced for what (AFAIK) is the intended variable. CI occurrence: https://github.com/zephyrproject-rtos/zephyr/actions/runs/13398545323
2. Fix namespace reference of `shift` value: from `data->header.shift` to `data->shift`. CI occurrence: https://github.com/zephyrproject-rtos/zephyr/actions/runs/13401451399