### PR TITLE
sensor: st: lsm6dso: add activity/inactivity triggering

### DIFF
--- a/drivers/sensor/st/lsm6dso/lsm6dso.h
+++ b/drivers/sensor/st/lsm6dso/lsm6dso.h
@@ -101,6 +101,8 @@ struct lsm6dso_data {
 	struct gpio_callback gpio_cb;
 	sensor_trigger_handler_t handler_drdy_acc;
 	const struct sensor_trigger *trig_drdy_acc;
+	sensor_trigger_handler_t handler_delta_acc;
+	const struct sensor_trigger *trig_delta_acc;
 	sensor_trigger_handler_t handler_drdy_gyr;
 	const struct sensor_trigger *trig_drdy_gyr;
 	sensor_trigger_handler_t handler_drdy_temp;


### PR DESCRIPTION
ST's [LSM6DSO accelerometer](https://www.st.com/en/mems-and-sensors/lsm6dso.html) has activity/inactivity detection capabilities. This commit allows that feature to be used to trigger Zephyr applications.

We use the slope filter to detect changes between the two states, and this may be configured with `SENSOR_ATTR_SLOPE_TH` (m/s^2) and `SENSOR_ATTR_SLOPE_DUR` (n samples). Setting the threshold to 9.81 m/s^2 and the duration to 1 sample, my trigger handler is called when the device is shaken!