### PR TITLE
sensor: st: lsm6dso: Added devicetree configuration to interrupt pin

### DIFF
--- a/drivers/sensor/st/lsm6dso/lsm6dso.c
+++ b/drivers/sensor/st/lsm6dso/lsm6dso.c
@@ -873,7 +873,9 @@ static int lsm6dso_init(const struct device *dev)
 #define LSM6DSO_CFG_IRQ(inst)						\
 	.trig_enabled = true,						\
 	.gpio_drdy = GPIO_DT_SPEC_INST_GET(inst, irq_gpios),		\
-	.int_pin = DT_INST_PROP(inst, int_pin)
+	.int_pin = DT_INST_PROP(inst, int_pin),			\
+	.int_open_drain = DT_INST_NODE_HAS_PROP(inst, int_open_drain),	\
+	.int_active_low = DT_INST_NODE_HAS_PROP(inst, int_active_low)
 #else
 #define LSM6DSO_CFG_IRQ(inst)
 #endif /* CONFIG_LSM6DSO_TRIGGER */

--- a/drivers/sensor/st/lsm6dso/lsm6dso.h
+++ b/drivers/sensor/st/lsm6dso/lsm6dso.h
@@ -63,6 +63,8 @@ struct lsm6dso_config {
 	const struct gpio_dt_spec gpio_drdy;
 	uint8_t int_pin;
 	bool trig_enabled;
+	bool int_open_drain;
+	bool int_active_low;
 #endif /* CONFIG_LSM6DSO_TRIGGER */
 };
 

--- a/drivers/sensor/st/lsm6dso/lsm6dso_trigger.c
+++ b/drivers/sensor/st/lsm6dso/lsm6dso_trigger.c
@@ -306,6 +306,21 @@ int lsm6dso_init_interrupt(const struct device *dev)
 		return ret;
 	}
 
+	/* Configure interrupt drive and active level. */
+	lsm6dso_ctrl3_c_t ctrl3_c = {
+		.h_lactive = cfg->int_active_low,
+		.pp_od = cfg->int_open_drain,
+
+		/* This is the default value after reset. */
+		.if_inc = 1
+	};
+
+	ret = lsm6dso_write_reg(ctx, LSM6DSO_CTRL3_C, (uint8_t *)&ctrl3_c, 1);
+	if (ret < 0) {
+		LOG_ERR("Failed to write CTRL3_C");
+		return ret;
+	}
+
 	return gpio_pin_interrupt_configure_dt(&cfg->gpio_drdy,
 					       GPIO_INT_EDGE_TO_ACTIVE);
 }

--- a/dts/bindings/sensor/st,lsm6dso-common.yaml
+++ b/dts/bindings/sensor/st,lsm6dso-common.yaml
@@ -46,6 +46,16 @@ properties:
       mandatory and if not present it defaults to 1 which is the
       configuration at power-up.
 
+  int-open-drain:
+    type: boolean
+    description: |
+      Configure the interrupt pin as open-drain instead of push-pull.
+
+  int-active-low:
+    type: boolean
+    description: |
+      Configure the interrupt pin as active low instead of active high.
+
   accel-pm:
     type: int
     default: 0


### PR DESCRIPTION
We can modify the drive type (push-pull or open-drain) and polarity (active-high or active-low) on this accelerometer - and I needed to change this for my hardware! This PR will introduce this capability into the device tree.
