### PR TITLE
manifest: update hal_renesas to fix DCACHE issue

### DIFF
--- a/soc/renesas/ra/ra8d1/Kconfig.defconfig
+++ b/soc/renesas/ra/ra8d1/Kconfig.defconfig
@@ -10,7 +10,10 @@ config NUM_IRQS
 config FLASH_FILL_BUFFER_SIZE
 	default 128
 
+config DCACHE
+	default n
+
 config CACHE_MANAGEMENT
-	default y
+	default n
 
 endif # SOC_SERIES_RA8D1

--- a/soc/renesas/ra/ra8d1/soc.c
+++ b/soc/renesas/ra/ra8d1/soc.c
@@ -39,10 +39,12 @@ void soc_early_init_hook(void)
 	SystemCoreClock = BSP_MOCO_HZ;
 	g_protect_pfswe_counter = 0;
 
+#ifdef CONFIG_ICACHE
 	SCB->CCR = (uint32_t)CCR_CACHE_ENABLE;
 	barrier_dsync_fence_full();
 	barrier_isync_fence_full();
-
+#endif
+#if defined(CONFIG_DCACHE) && defined(CONFIG_CACHE_MANAGEMENT)
 	/* Apply Arm Cortex-M85 errata workarounds for D-Cache
 	 * Attributing all cacheable memory as write-through set FORCEWT bit in MSCR register.
 	 * Set bit 16 in ACTLR to 1.
@@ -58,4 +60,5 @@ void soc_early_init_hook(void)
 	barrier_isync_fence_full();
 
 	sys_cache_data_enable();
+#endif
 }

--- a/west.yml
+++ b/west.yml
@@ -219,7 +219,7 @@ manifest:
         - hal
     - name: hal_renesas
       path: modules/hal/renesas
-      revision: bcbd9fe909b9da739a2e61adddcc1a30fba7774d
+      revision: 1589073f4fb8a7d7e554a657a12393b6c1315a1a
       groups:
         - hal
     - name: hal_rpi_pico


### PR DESCRIPTION
When DCACHE was enabled as default for ek_ra8d1, Renesas Flash driver could not read or write. This PR aims to:
- Updates hal_renesas revision to fix this issue
- Disable DCACHE as default