### PR TITLE
Fixes dma scatter gather test nxp lpc dma

### DIFF
--- a/boards/nxp/lpcxpresso55s36/lpcxpresso55s36.yaml
+++ b/boards/nxp/lpcxpresso55s36/lpcxpresso55s36.yaml
@@ -17,6 +17,7 @@ supported:
   - arduino_gpio
   - can
   - dac
+  - dma
   - flash
   - gpio
   - pwm

--- a/tests/drivers/dma/scatter_gather/src/test_dma_sg.c
+++ b/tests/drivers/dma/scatter_gather/src/test_dma_sg.c
@@ -101,6 +101,7 @@ static int test_sg(void)
 	memset(dma_block_cfgs, 0, sizeof(dma_block_cfgs));
 	for (int i = 0; i < XFERS; i++) {
 		dma_block_cfgs[i].source_gather_en = 1U;
+		dma_block_cfgs[i].source_gather_interval = 1U*dma_cfg.dest_data_size;
 		dma_block_cfgs[i].block_size = CONFIG_DMA_SG_XFER_SIZE;
 #ifdef CONFIG_DMA_64BIT
 		dma_block_cfgs[i].source_address = (uint64_t)(tx_data);

--- a/tests/drivers/dma/scatter_gather/testcase.yaml
+++ b/tests/drivers/dma/scatter_gather/testcase.yaml
@@ -10,6 +10,7 @@ tests:
       - mimxrt1010_evk
       - mimxrt1060_evk/mimxrt1062/qspi
       - lpcxpresso55s36
+      - mimxrt685_evk/mimxrt685s/cm33
       - native_sim
       - native_sim/native/64
       - xmc45_relax_kit


### PR DESCRIPTION
for nxp_lpc_dma source_gather_interval need config in align with times of the data size, otherwise the src address will not inc after one transfer.

also enable lpcxpresso55s36 dma in its feature tag
and add mimxrt685 in the support list

fixes: #85403