### PR TITLE
llext: Disable small data sections on RISC-V

### DIFF
--- a/cmake/compiler/gcc/target_riscv.cmake
+++ b/cmake/compiler/gcc/target_riscv.cmake
@@ -98,8 +98,12 @@ set(LLEXT_REMOVE_FLAGS
 # Flags to be added to llext code compilation
 # mno-relax is needed to stop gcc from generating R_RISCV_ALIGN relocations,
 # which are currently not supported
+# -msmall-data-limit=0 disables the "small data" sections such as .sbss and .sdata
+# only one NOBITS sections is supported at a time, so having .sbss can cause
+# llext's not to be loadable
 set(LLEXT_APPEND_FLAGS
   -mabi=${riscv_mabi}
   -march=${riscv_march}
   -mno-relax
+  -msmall-data-limit=0
 )


### PR DESCRIPTION
On RISC-V, GCC and possibly other compilers include small globals in special "small data" sections like .sbss and .sdata. This allows accessing these globals using the global pointer register and an offset, which is faster than ordinary relocations. Currently, llext_load does not support multiple NOBIT sections. Thus, llext's that use both .bss and .sbss sections cannot be relocated. Also, the global pointer cannot be used in llext's, as it does not change when calling into or returning from an llext, making the optimization pointless for llext.
This commit disables the use of small data sections by adding the appropriate compiler flag when compiling llext's.
In addition to solving the aforementioned issue, this fixes llext's test_inspect on RISC-V.