### PR TITLE
manifest: Update hal_stm32 to add released binaries of stm32wb

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -238,7 +238,7 @@ manifest:
       groups:
         - hal
     - name: hal_stm32
-      revision: 04ccc7798343ff51509c5d5276e3bce4375f50e6
+      revision: 5dcc08c119d421fec7d67555fc7b0aa220288e56
       path: modules/hal/stm32
       groups:
         - hal


### PR DESCRIPTION
Update hal_stm32 to add the history of the released binaries to be flashed in the Cortex-M0 coprocessor.