### PR TITLE
tests: drivers: counter: basic_api: Fix failing build

### DIFF
--- a/tests/drivers/counter/counter_basic_api/testcase.yaml
+++ b/tests/drivers/counter/counter_basic_api/testcase.yaml
@@ -14,7 +14,6 @@ tests:
     depends_on: counter
     platform_allow:
       - nrf52840dk/nrf52840
-      - nrf52_bsim
     timeout: 400
     extra_configs:
       - CONFIG_ZERO_LATENCY_IRQS=y


### PR DESCRIPTION
nrf52_bsim target was failing to compile when drivers.counter.basic_api.nrf_zli was used. This target should never be used for that configuration because:
- bsim does not support Zero Latency Interrupts
- this configuration is strictly for nrf52840dk (dedicated overlay)