### PR TITLE
drivers: stepper: tests Various Driver Fixes

### DIFF
--- a/drivers/stepper/gpio_stepper_controller.c
+++ b/drivers/stepper/gpio_stepper_controller.c
@@ -289,6 +289,7 @@ static int gpio_stepper_set_micro_step_res(const struct device *dev,
 					   enum stepper_micro_step_resolution micro_step_res)
 {
 	struct gpio_stepper_data *data = dev->data;
+	int ret = 0;
 
 	K_SPINLOCK(&data->lock) {
 		switch (micro_step_res) {
@@ -298,10 +299,10 @@ static int gpio_stepper_set_micro_step_res(const struct device *dev,
 			break;
 		default:
 			LOG_ERR("Unsupported micro step resolution %d", micro_step_res);
-			return -ENOTSUP;
+			ret = -ENOTSUP;
 		}
 	}
-	return 0;
+	return ret;
 }
 
 static int gpio_stepper_get_micro_step_res(const struct device *dev,
@@ -327,6 +328,7 @@ static int gpio_stepper_set_event_callback(const struct device *dev,
 static int gpio_stepper_enable(const struct device *dev, bool enable)
 {
 	struct gpio_stepper_data *data = dev->data;
+	int ret = 0;
 
 	K_SPINLOCK(&data->lock) {
 
@@ -339,11 +341,11 @@ static int gpio_stepper_enable(const struct device *dev, bool enable)
 			const int err = power_down_coils(dev);
 
 			if (err != 0) {
-				return -EIO;
+				ret = -EIO;
 			}
 		}
 	}
-	return 0;
+	return ret;
 }
 
 static int gpio_stepper_init(const struct device *dev)

--- a/drivers/stepper/ti/drv8424.c
+++ b/drivers/stepper/ti/drv8424.c
@@ -212,7 +212,7 @@ static int drv8424_set_micro_step_res(const struct device *dev,
 		m1_value = 2;
 		break;
 	default:
-		return -EINVAL;
+		return -ENOTSUP;
 	};
 
 	ret = drv8424_set_microstep_pin(dev, &config->m0_pin, m0_value);


### PR DESCRIPTION
This draft PR contains several fixes for stepper drivers related to [PR 85658](https://github.com/zephyrproject-rtos/zephyr/pull/85658).

#### GPIO Stepper Controller

Fixes the spinlock related crashes of the driver. This is the only fix used in the mentioned PR, as without it, it was impossible to test the driver.

#### DRV8424

Fixes the incorrect return value when attempting to set an invalid microstep resolution.

#### TMC 22XX

Fixes the incorrect return value when attempting to set an invalid microstep resolution. In addition, fixes several bugs related to enable/disable behavior.

## Notes

While this fixes (as of the moment of making this PR) all issues of the drv8424 and tmc 22xx drivers related to the tests when using the counter timing source, it does not fix all issues of the gpio stepper controller or the work queue timing source.

This draft is mainly intended as a resource for fixing the drivers in corresponding PRs and thus is not intended to be merged itself.