### PR TITLE
boards nrf54l15bsim: Do not delete grtc clock properties

### DIFF
--- a/boards/native/nrf_bsim/nrf54l15bsim_nrf54l15_cpuapp.dts
+++ b/boards/native/nrf_bsim/nrf54l15bsim_nrf54l15_cpuapp.dts
@@ -68,8 +68,6 @@
 	/* Channels 7-11 reserved for Zero Latency IRQs, 3-4 for FLPR */
 	child-owned-channels = <3 4 7 8 9 10 11>;
 	status = "okay";
-	/delete-property/ clocks;
-	/delete-property/ clock-names;
 };
 
 &cpuapp_rram {


### PR DESCRIPTION
Revert the change to this file done in
865b2456c0d32d1f446107e59bdc7741088903e9
In which these clock properties were added to the GRTC binding but they were, at the same time, not added/removed for the simulated target.
The author indicates this was done due to some test failing, but at this point no test fails with these properties present also in the simulated target, and there is no understanding of why they would.
So let's avoid diverging the simulated target from the real one.