### PR TITLE
Update I2C driver and nodes for MAX32 SoCs

### DIFF
--- a/dts/arm/adi/max32/max32662.dtsi
+++ b/dts/arm/adi/max32/max32662.dtsi
@@ -24,6 +24,8 @@
 
 /delete-node/ &timer3;
 
+/delete-node/ &i2c2;
+
 /delete-node/ &rtc_counter;
 
 &adc {

--- a/dts/arm/adi/max32/max32670.dtsi
+++ b/dts/arm/adi/max32/max32670.dtsi
@@ -20,6 +20,10 @@
 	clock-frequency = <DT_FREQ_K(80)>;
 };
 
+&i2c2 {
+	clocks = <&gcr ADI_MAX32_CLOCK_BUS1 21>;
+};
+
 /delete-node/ &rtc_counter;
 
 /* MAX32670 extra peripherals. */

--- a/dts/arm/adi/max32/max32675.dtsi
+++ b/dts/arm/adi/max32/max32675.dtsi
@@ -20,6 +20,10 @@
 	clock-frequency = <DT_FREQ_K(80)>;
 };
 
+&i2c2 {
+	clocks = <&gcr ADI_MAX32_CLOCK_BUS1 21>;
+};
+
 /delete-node/ &clk_iso;
 /delete-node/ &uart1;
 /delete-node/ &rtc_counter;


### PR DESCRIPTION
This PR includes MAX32 I2C driver updates and I2C device tree changes for MAX32662, MAX32670 and MAX32675.

Signed-off-by: Tahsin Mutlugun <Tahsin.Mutlugun@analog.com>
Signed-off-by: Furkan Akkiz <hasanfurkan.akkiz@analog.com>
Signed-off-by: Mert Ekren <mert.ekren@analog.com>
Signed-off-by: Sadik Ozer <sadik.ozer@analog.com>