### PR TITLE
qemu/riscv: define RAM and Flash sizes to restore CI coverage

### DIFF
--- a/boards/qemu/riscv32/qemu_riscv32.yaml
+++ b/boards/qemu/riscv32/qemu_riscv32.yaml
@@ -8,6 +8,8 @@ toolchain:
   - zephyr
 supported:
   - netif
+ram: 262144
+flash: 32768
 testing:
   default: true
   ignore_tags:

--- a/boards/qemu/riscv32/qemu_riscv32_qemu_virt_riscv32_smp.yaml
+++ b/boards/qemu/riscv32/qemu_riscv32_qemu_virt_riscv32_smp.yaml
@@ -9,6 +9,8 @@ toolchain:
 supported:
   - netif
   - smp
+ram: 262144
+flash: 32768
 testing:
   default: true
   ignore_tags:

--- a/boards/qemu/riscv32e/qemu_riscv32e.yaml
+++ b/boards/qemu/riscv32e/qemu_riscv32e.yaml
@@ -8,6 +8,8 @@ toolchain:
   - zephyr
 supported:
   - netif
+ram: 262144
+flash: 32768
 testing:
   default: true
   ignore_tags:

--- a/boards/qemu/riscv64/qemu_riscv64.yaml
+++ b/boards/qemu/riscv64/qemu_riscv64.yaml
@@ -8,6 +8,8 @@ toolchain:
   - zephyr
 supported:
   - netif
+ram: 262144
+flash: 32768
 testing:
   default: true
   ignore_tags:

--- a/boards/qemu/riscv64/qemu_riscv64_qemu_virt_riscv64_smp.yaml
+++ b/boards/qemu/riscv64/qemu_riscv64_qemu_virt_riscv64_smp.yaml
@@ -9,6 +9,8 @@ toolchain:
 supported:
   - netif
   - smp
+ram: 262144
+flash: 32768
 testing:
   default: true
   ignore_tags:


### PR DESCRIPTION
Define RAM and Flash sizes for QEMU RISC-V boards in the board YAML. This is needed to ensure those boards are considered by Twister for tests that require a minimum amount of RAM and Flash.

#85078 recently introduced stricter filtering to optimize Twister runs. RISC-V was however not updated by commit 9da89edb102 and is thus currently not being tested for LLEXT (and probably other subsystems). ~~There's already an active breakage in LLEXT CI tests for RISC-V that will be fixed by #85977~~ EDIT: PR merged so the restored CI tests now pass. 