### PR TITLE
soc: Add DT_NODE_HAS_STATUS_OKAY check for swj_connector_init

### DIFF
--- a/soc/realtek/ec/rts5912/CMakeLists.txt
+++ b/soc/realtek/ec/rts5912/CMakeLists.txt
@@ -12,6 +12,6 @@ zephyr_sources_ifdef(CONFIG_PM
   power.c
   )
 
-zephyr_sources_ifdef(CONFIG_DT_HAS_SWJ_CONNECTOR_ENABLED debug_swj.c)
+zephyr_sources_ifdef(CONFIG_RTS5912_DEBUG_SWJ debug_swj.c)
 
 set(SOC_LINKER_SCRIPT ${ZEPHYR_BASE}/include/zephyr/arch/arm/cortex_m/scripts/linker.ld CACHE INTERNAL "")

--- a/soc/realtek/ec/rts5912/Kconfig
+++ b/soc/realtek/ec/rts5912/Kconfig
@@ -22,4 +22,11 @@ config RTS5912_ON_ENTER_CPU_IDLE_HOOK
 	  If needed, this hook can be used to prevent the CPU from actually
 	  entering sleep by skipping the WFE/WFI instruction.
 
+config RTS5912_DEBUG_SWJ
+	bool "Serial wire JTAG"
+	default y
+	depends on DT_HAS_SWJ_CONNECTOR_ENABLED
+	help
+	  Enables the serial wire JTAG connection on the RTS5912 EC.
+
 endif # SOC_SERIES_RTS5912

--- a/soc/realtek/ec/rts5912/soc.c
+++ b/soc/realtek/ec/rts5912/soc.c
@@ -28,6 +28,10 @@ bool z_arm_on_enter_cpu_idle(void)
  */
 void soc_early_init_hook(void)
 {
+	if (!IS_ENABLED(CONFIG_RTS5912_DEBUG_SWJ)) {
+		return;
+	}
+
 	int ret;
 
 	/* Apply device related preinit configuration */


### PR DESCRIPTION
Add conditional compilation check for swj_connector_init call in soc_early_init_hook to prevent link errors when swj_port is disabled in device tree. The code is now wrapped with
DT_NODE_HAS_STATUS_OKAY(SWJ_NODE) to ensure the function is only included when the corresponding device tree node is enabled.

This fixes the undefined reference link error that occurs when compiling with swj_port disabled in the device tree configuration.