### PR TITLE
drivers: gpio: gecko: Fix the condition for interrupt configuration

### DIFF
--- a/drivers/gpio/gpio_gecko.c
+++ b/drivers/gpio/gpio_gecko.c
@@ -292,10 +292,10 @@ static int gpio_gecko_pin_interrupt_configure(const struct device *dev,
 	} else {
 		/* Interrupt line is already in use */
 		if ((GPIO->IEN & BIT(pin)) != 0) {
-			/* TODO: Return an error only if request is done for
-			 * a pin from a different port.
-			 */
-			return -EBUSY;
+			/* Check if the interrupt is already configured for this port */
+			if (!(data->int_enabled_mask & BIT(pin))) {
+				return -EBUSY;
+			}
 		}
 
 		bool rising_edge = true;


### PR DESCRIPTION
The goal of this PR is to fix a fail test case that can be seen while running the test gpio_basic_api with a device that uses gpio_gecko driver.

This fix allows a user to reconfigure an interrupt on GPIO pin that is already configured but only if it's already configured for the same GPIO port.