### PR TITLE
cmake: Fix warning levels for IAR

### DIFF
--- a/cmake/compiler/iar/compiler_flags.cmake
+++ b/cmake/compiler/iar/compiler_flags.cmake
@@ -23,50 +23,60 @@ set_compiler_property(PROPERTY optimization_fast --no_size_constraints)
 # This section covers flags related to warning levels #
 #######################################################
 
-# Property for standard warning base in Zephyr, this will always be set when
-# compiling.
-set_compiler_property(PROPERTY warning_base
-  --diag_error=Pe223     # function "xxx" declared implicitly
-  --diag_warning=Pe054   # too few arguments in invocation of macro
-  --diag_warning=Pe144   # a value of type "void *" cannot be used to initialize an entity of type [...] "void (*)(struct onoff_manager *, int)"
-  --diag_warning=Pe167   # argument of type "void *" is incompatible with [...] "void (*)(void *, void *, void *)"
-  --diag_suppress=Pe1675 # unrecognized GCC pragma
-  --diag_suppress=Pe111  # statement is unreachable
-  --diag_suppress=Pe1143 # arithmetic on pointer to void or function type
-  --diag_suppress=Pe068) # integer conversion resulted in a change of sign)
+# -DW=... settings
+#
+# W=1 - warnings that may be relevant and does not occur too often
+# W=2 - warnings that occur quite often but may still be relevant
+# W=3 - the more obscure warnings, can most likely be ignored
 
+set(IAR_SUPPRESSED_WARNINGS)
 
-set(IAR_WARNING_DW_1
-  --diag_suppress=Pe188  # enumerated type mixed with another type
-  --diag_suppress=Pe128  # loop is not reachable
-  --diag_suppress=Pe550  # variable "res" was set but never used
-  --diag_suppress=Pe546  # transfer of control bypasses initialization
-  --diag_suppress=Pe186) # pointless comparison of unsigned integer with zero
+# Set basic suppressed warning first
 
-set(IAR_WARNING_DW2
-  --diag_suppress=Pe1097 # unknown attribute
-  --diag_suppress=Pe381  # extra ";" ignored
-  --diag_suppress=Pa082  # undefined behavior: the order of volatile accesses is undefined
-  --diag_suppress=Pa084  # pointless integer comparison, the result is always false
-  --diag_suppress=Pe185  # dynamic initialization in unreachable code )
-  --diag_suppress=Pe167  # argument of type "onoff_notify_fn" is incompatible with...
-  --diag_suppress=Pe144  # a value of type "void *" cannot be used to initialize...
-  --diag_suppress=Pe177  # function "xxx" was declared but never referenced
-  --diag_suppress=Pe513) # a value of type "void *" cannot be assigned to an entity of type "int (*)(int)"
+# Pe223: function "xxx" declared implicitly
+# Pe054: too few arguments in invocation of macro
+# Pe1675: unrecognized GCC pragma
+# Pe111: statement is unreachable
+# Pe1143: arithmetic on pointer to void or function type
+# Pe068: integer conversion resulted in a change of sign
+list(APPEND IAR_SUPPRESSED_WARNINGS
+     --diag_suppress=Pe068,Pe1143,Pe111,Pe1675,Pe054,Pe223)
 
-set(IAR_WARNING_DW3)
+# Since IAR does not turn on warnings we do this backwards
+# by not suppressing warnings on higher levels.
+if(NOT W MATCHES "3")
+  # Pe381: extra ";" ignored
+  list(APPEND IAR_SUPPRESSED_WARNINGS --diag_suppress=Pe381)
+endif()
+if(NOT W MATCHES "2" AND NOT W MATCHES "3")
+  # Pe1097: unknown attribute
+  # Pa082: undefined behavior: the order of volatile accesses is undefined
+  # Pa084: pointless integer comparison, the result is always false
+  # Pe185: dynamic initialization in unreachable code
+  # Pe167: argument of type "onoff_notify_fn" is incompatible with...
+  # Pe144: a value of type "void *" cannot be used to initialize...
+  # Pe177: function "xxx" was declared but never referenced
+  # Pe513: a value of type "void *" cannot be assigned to an
+  #        entity of type "int (*)(int)"
+  list(APPEND IAR_SUPPRESSED_WARNINGS
+       --diag_suppress=Pe513,Pe177,Pe144,Pe167,Pe185,Pa084,Pa082,Pe1097)
+endif()
+if(NOT W MATCHES "1" AND NOT W MATCHES "2" AND NOT W MATCHES "3")
+  # Pe188: enumerated type mixed with another type
+  # Pe128: loop is not reachable
+  # Pe550: variable "res" was set but never used
+  # Pe546: transfer of control bypasses initialization
+  # Pe186: pointless comparison of unsigned integer with zero
+  # Pe054: too few arguments in invocation of macro xxx
+  # Pe144: a value of type "void *" cannot be used to initialize an
+  #        entity of type [...] "void (*)(struct onoff_manager *, int)"
+  # Pe167: argument of type "void *" is incompatible with [...]
+  #        "void (*)(void *, void *, void *)"
+  list(APPEND IAR_SUPPRESSED_WARNINGS
+       --diag_suppress=Pe054,Pe186,Pe546,Pe550,Pe128,Pe188,Pe144,Pe167)
+endif()
 
-set_compiler_property(PROPERTY warning_dw_1
-  ${IAR_WARNING_DW_3}
-  ${IAR_WARNING_DW_2}
-  ${IAR_WARNING_DW_1})
-
-set_compiler_property(PROPERTY warning_dw_2
-  ${IAR_WARNING_DW3}
-  ${IAR_WARNING_DW2})
-
-# no suppressions
-set_compiler_property(PROPERTY warning_dw_3  ${IAR_WARNING_DW3})
+set_compiler_property(PROPERTY warning_base ${IAR_SUPPRESSED_WARNINGS})
 
 # Extended warning set supported by the compiler
 set_compiler_property(PROPERTY warning_extended)
@@ -77,7 +87,7 @@ set_compiler_property(PROPERTY warning_error_implicit_int)
 # Compiler flags to use when compiling according to MISRA
 set_compiler_property(PROPERTY warning_error_misra_sane)
 
-set_property(TARGET compiler PROPERTY warnings_as_errors  --warnings_are_errors)
+set_property(TARGET compiler PROPERTY warnings_as_errors --warnings_are_errors)
 
 ###########################################################################
 # This section covers flags related to C or C++ standards / standard libs #
@@ -151,7 +161,6 @@ set_compiler_property(PROPERTY freestanding)
 # Flag to include debugging symbol in compilation
 set_property(TARGET compiler PROPERTY debug --debug)
 set_property(TARGET compiler-cpp PROPERTY debug --debug)
-set_property(TARGET asm PROPERTY debug -gdwarf-4)
 
 set_compiler_property(PROPERTY no_common)
 

--- a/cmake/compiler/iar/target.cmake
+++ b/cmake/compiler/iar/target.cmake
@@ -76,8 +76,11 @@ if("${IAR_TOOLCHAIN_VARIANT}" STREQUAL "iccarm")
   list(APPEND IAR_COMMON_FLAGS
     --endian=little
     --cpu=${ICCARM_CPU}
-    -DRTT_USE_ASM=0       #WA for VAAK-232
-    --diag_suppress=Ta184  # Using zero sized arrays except for as last member of a struct is discouraged and dereferencing elements in such an array has undefined behavior
+    -DRTT_USE_ASM=0        # WA for VAAK-232
+    --diag_suppress=Ta184  # Using zero sized arrays except for as last
+                           # member of a struct is discouraged and
+                           # dereferencing elements in such an array has
+                           # undefined behavior
   )
 endif()
 
@@ -121,9 +124,7 @@ if("${IAR_TOOLCHAIN_VARIANT}" STREQUAL "iccarm")
       list(APPEND IAR_ASM_FLAGS -mfpu=${GCC_M_FPU})
     endif()
   endif()
-endif()
 
-if("${IAR_TOOLCHAIN_VARIANT}" STREQUAL "iccarm")
   if(CONFIG_IAR_LIBC)
     # Zephyr requires AEABI portability to ensure correct functioning of the C
     # library, for example error numbers, errno.h.


### PR DESCRIPTION
Rewrote the warning levels for toolchain IAR as IAR tools just turn off warnings, not on. 
Also did some minor cleanup for coding guidelines.