### PR TITLE
MAINTAINERS: ethernet: promote maass-hamburg to maintainer

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1417,12 +1417,13 @@ Release Notes:
     - drivers.espi
 
 "Drivers: Ethernet":
-  status: odd fixes
+  status: maintained
+  maintainers:
+    - maass-hamburg
   collaborators:
     - decsny
     - lmajewski
     - pdgendt
-    - maass-hamburg
   files:
     - drivers/ethernet/
     - include/zephyr/dt-bindings/ethernet/


### PR DESCRIPTION
promote maass-hamburg to maintainer of ethernet
drivers.

Signed-off-by: Fin Maaß <f.maass@vogl-electronic.com>