### PR TITLE
tests: drivers: spi: Tests SPI at 16 and 32 MHz on nRF54 devices

### DIFF
--- a/tests/drivers/spi/spi_loopback/boards/nrf54h20dk_nrf54h20_cpuapp_fast.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nrf54h20dk_nrf54h20_cpuapp_fast.overlay
@@ -7,9 +7,12 @@
 &pinctrl {
 	spi120_default: spi120_default {
 		group1 {
+			psels = <NRF_PSEL(SPIM_MISO, 7, 6)>;
+		};
+		group2 {
 			psels = <NRF_PSEL(SPIM_SCK, 7, 3)>,
-				<NRF_PSEL(SPIM_MISO, 7, 6)>,
 				<NRF_PSEL(SPIM_MOSI, 7, 7)>;
+			nordic,drive-mode = <NRF_DRIVE_E0E1>;
 		};
 	};
 
@@ -40,7 +43,7 @@
 		reg = <0>;
 		spi-max-frequency = <DT_FREQ_M(4)>;
 	};
-	fast@0 {
+	dut_fast: fast@0 {
 		compatible = "test-spi-loopback-fast";
 		reg = <0>;
 		spi-max-frequency = <DT_FREQ_M(8)>;

--- a/tests/drivers/spi/spi_loopback/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -7,9 +7,12 @@
 &pinctrl {
 	spi00_default: spi00_default {
 		group1 {
+			psels = <NRF_PSEL(SPIM_MISO, 2, 9)>;
+		};
+		group2 {
 			psels = <NRF_PSEL(SPIM_SCK, 2, 6)>,
-				<NRF_PSEL(SPIM_MISO, 2, 9)>,
 				<NRF_PSEL(SPIM_MOSI, 2, 8)>;
+			nordic,drive-mode = <NRF_DRIVE_E0E1>;
 		};
 	};
 
@@ -23,6 +26,8 @@
 	};
 };
 
+/delete-node/ &mx25r64;
+
 &spi00 {
 	status = "okay";
 	pinctrl-0 = <&spi00_default>;
@@ -35,7 +40,7 @@
 		reg = <0>;
 		spi-max-frequency = <DT_FREQ_M(2)>;
 	};
-	fast@0 {
+	dut_fast: fast@0 {
 		compatible = "test-spi-loopback-fast";
 		reg = <0>;
 		spi-max-frequency = <DT_FREQ_M(4)>;

--- a/tests/drivers/spi/spi_loopback/boards/nrf54l20pdk_nrf54l20_cpuapp.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nrf54l20pdk_nrf54l20_cpuapp.overlay
@@ -35,7 +35,7 @@
 		reg = <0>;
 		spi-max-frequency = <DT_FREQ_M(2)>;
 	};
-	fast@0 {
+	dut_fast: fast@0 {
 		compatible = "test-spi-loopback-fast";
 		reg = <0>;
 		spi-max-frequency = <DT_FREQ_M(4)>;

--- a/tests/drivers/spi/spi_loopback/boards/nrf_at_16mhz.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nrf_at_16mhz.overlay
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
+&dut_fast {
+	spi-max-frequency = <DT_FREQ_M(16)>;
+};

--- a/tests/drivers/spi/spi_loopback/boards/nrf_at_32mhz.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nrf_at_32mhz.overlay
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
+&dut_fast {
+	spi-max-frequency = <DT_FREQ_M(32)>;
+};

--- a/tests/drivers/spi/spi_loopback/boards/nrf_at_8mhz.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nrf_at_8mhz.overlay
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
+&dut_fast {
+	spi-max-frequency = <DT_FREQ_M(8)>;
+};

--- a/tests/drivers/spi/spi_loopback/testcase.yaml
+++ b/tests/drivers/spi/spi_loopback/testcase.yaml
@@ -217,10 +217,37 @@ tests:
     filter: CONFIG_DT_HAS_NXP_FLEXIO_ENABLED and
             CONFIG_DT_HAS_NXP_FLEXIO_SPI_ENABLED
     platform_allow: mimxrt1040_evk
-  drivers.spi.nrf_fast:
+  drivers.spi.nrf54h_fast_8mhz:
     extra_args: DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_fast.overlay"
     platform_allow:
       - nrf54h20dk/nrf54h20/cpuapp
+  drivers.spi.nrf54h_fast_16mhz:
+    extra_args:
+      - DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_fast.overlay"
+      - EXTRA_DTC_OVERLAY_FILE="boards/nrf_at_16mhz.overlay"
+    platform_allow:
+      - nrf54h20dk/nrf54h20/cpuapp
+  drivers.spi.nrf54h_fast_32mhz:
+    extra_args:
+      - DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_fast.overlay"
+      - EXTRA_DTC_OVERLAY_FILE="boards/nrf_at_32mhz.overlay"
+    platform_allow:
+      - nrf54h20dk/nrf54h20/cpuapp
+  drivers.spi.nrf54l_8mhz:
+    extra_args: EXTRA_DTC_OVERLAY_FILE="boards/nrf_at_8mhz.overlay"
+    platform_allow:
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54l20pdk/nrf54l20/cpuapp
+  drivers.spi.nrf54l_16mhz:
+    extra_args: EXTRA_DTC_OVERLAY_FILE="boards/nrf_at_16mhz.overlay"
+    platform_allow:
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54l20pdk/nrf54l20/cpuapp
+  drivers.spi.nrf54l_32mhz:
+    extra_args: EXTRA_DTC_OVERLAY_FILE="boards/nrf_at_32mhz.overlay"
+    platform_allow:
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54l20pdk/nrf54l20/cpuapp
   drivers.spi.ke1xz_flexio_spi.loopback:
     extra_args: DTC_OVERLAY_FILE="boards/frdm_ke1xz_flexio_spi.overlay"
     filter: CONFIG_DT_HAS_NXP_FLEXIO_ENABLED and


### PR DESCRIPTION
Extend spi_loopback test on nRF54 chip family.
Add configurations to run this test at 8/16/32 MHz.