### PR TITLE
drivers: ethernet: stm32: Allow disabling carrier checking

### DIFF
--- a/drivers/ethernet/Kconfig.stm32_hal
+++ b/drivers/ethernet/Kconfig.stm32_hal
@@ -70,8 +70,16 @@ config ETH_STM32_HAL_PHY_ADDRESS
 	help
 	  The phy address to use.
 
+config ETH_STM32_CARRIER_CHECK
+	bool "Check PHY carrier periodically"
+	default y
+	help
+	  Enables or disables checking of the PHY's carrier status.
+	  See also CONFIG_ETH_STM32_CARRIER_CHECK_RX_IDLE_TIMEOUT_MS
+
 config ETH_STM32_CARRIER_CHECK_RX_IDLE_TIMEOUT_MS
 	int "Carrier check timeout period (ms)"
+	depends on ETH_STM32_CARRIER_CHECK
 	default 500
 	range 100 30000
 	help


### PR DESCRIPTION
On Zephyr devices that has an Ethernet switch IC with the Zephyr device connected to the CPU port, there aren't necessarilly any register to check the link state on that port. If the check is kept on such devices, Zephyr will believe the link disappears
CONFIG_ETH_STM32_CARRIER_CHECK_RX_IDLE_TIMEOUT_MS after last message was received, until a new message is received. If the application tries to send data while the link is considered gone, sending returns an error, sometimes giving "iface is down".

It also seems conceptually meaningless to try determining link state on such devices, since as long as both the microcontroller and the switch IC is powered, the link should always be up.

This commit therefore introduces a new Kconfig to allow disabling the entire checking of link state, so that on devices where there is no relevant PHY register to read, the check can be disabled.