### PR TITLE
Bluetooth: CAP: Add cap_unicast_group API

### DIFF
--- a/doc/releases/release-notes-4.2.rst
+++ b/doc/releases/release-notes-4.2.rst
@@ -158,6 +158,12 @@ New APIs and options
     * :c:macro:`BT_BAP_PER_ADV_PARAM_BROADCAST_SLOW`
     * :c:func:`bt_csip_set_member_set_size_and_rank`
     * :c:func:`bt_csip_set_member_get_info`
+    * :c:func:`bt_bap_unicast_group_foreach_stream`
+    * :c:func:`bt_cap_unicast_group_create`
+    * :c:func:`bt_cap_unicast_group_reconfig`
+    * :c:func:`bt_cap_unicast_group_add_streams`
+    * :c:func:`bt_cap_unicast_group_delete`
+    * :c:func:`bt_cap_unicast_group_foreach_stream`
 
   * Host
 

--- a/include/zephyr/bluetooth/audio/bap.h
+++ b/include/zephyr/bluetooth/audio/bap.h
@@ -3,7 +3,7 @@
  * @brief Header for Bluetooth BAP.
  *
  * Copyright (c) 2020 Bose Corporation
- * Copyright (c) 2021-2024 Nordic Semiconductor ASA
+ * Copyright (c) 2021-2025 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -1719,6 +1719,32 @@ int bt_bap_unicast_group_add_streams(struct bt_bap_unicast_group *unicast_group,
  * @return Zero on success or (negative) error code otherwise.
  */
 int bt_bap_unicast_group_delete(struct bt_bap_unicast_group *unicast_group);
+
+/** Callback function for bt_bap_unicast_group_foreach_stream()
+ *
+ * @param stream     The audio stream
+ * @param user_data  User data
+ *
+ * @retval true Stop iterating.
+ * @retval false Continue iterating.
+ */
+typedef bool (*bt_bap_unicast_group_foreach_stream_func_t)(struct bt_bap_stream *stream,
+							   void *user_data);
+
+/**
+ * @brief Iterate through all streams in a unicast group
+ *
+ * @param unicast_group  The unicast group
+ * @param func           The callback function
+ * @param user_data      User specified data that sent to the callback function
+ *
+ * @retval 0 Success (even if no streams exists in the group).
+ * @retval -ECANCELED Iteration was stopped by the callback function before complete.
+ * @retval -EINVAL @p unicast_group or @p func were NULL.
+ */
+int bt_bap_unicast_group_foreach_stream(struct bt_bap_unicast_group *unicast_group,
+					bt_bap_unicast_group_foreach_stream_func_t func,
+					void *user_data);
 
 /** Unicast Client callback structure */
 struct bt_bap_unicast_client_cb {

--- a/samples/bluetooth/cap_initiator/src/cap_initiator_unicast.c
+++ b/samples/bluetooth/cap_initiator/src/cap_initiator_unicast.c
@@ -44,7 +44,7 @@ LOG_MODULE_REGISTER(cap_initiator_unicast, LOG_LEVEL_INF);
  */
 static struct bt_bap_lc3_preset unicast_preset_16_2_1 = BT_BAP_LC3_UNICAST_PRESET_16_2_1(
 	BT_AUDIO_LOCATION_MONO_AUDIO, BT_AUDIO_CONTEXT_TYPE_UNSPECIFIED);
-static struct bt_bap_unicast_group *unicast_group;
+static struct bt_cap_unicast_group *unicast_group;
 uint64_t total_rx_iso_packet_count; /* This value is exposed to test code */
 uint64_t total_unicast_tx_iso_packet_count; /* This value is exposed to test code */
 
@@ -336,16 +336,16 @@ static int discover_sources(void)
 
 static int unicast_group_create(void)
 {
-	struct bt_bap_unicast_group_stream_param source_stream_param = {
-		.qos = &unicast_preset_16_2_1.qos,
-		.stream = &peer.source_stream.bap_stream,
+	struct bt_cap_unicast_group_stream_param source_stream_param = {
+		.qos_cfg = &unicast_preset_16_2_1.qos,
+		.stream = &peer.source_stream,
 	};
-	struct bt_bap_unicast_group_stream_param sink_stream_param = {
-		.qos = &unicast_preset_16_2_1.qos,
-		.stream = &peer.sink_stream.bap_stream,
+	struct bt_cap_unicast_group_stream_param sink_stream_param = {
+		.qos_cfg = &unicast_preset_16_2_1.qos,
+		.stream = &peer.sink_stream,
 	};
-	struct bt_bap_unicast_group_stream_pair_param pair_params = {0};
-	struct bt_bap_unicast_group_param group_param = {0};
+	struct bt_cap_unicast_group_stream_pair_param pair_params = {0};
+	struct bt_cap_unicast_group_param group_param = {0};
 	int err;
 
 	if (peer.source_ep != NULL) {
@@ -359,7 +359,7 @@ static int unicast_group_create(void)
 	group_param.params_count = 1U;
 	group_param.params = &pair_params;
 
-	err = bt_bap_unicast_group_create(&group_param, &unicast_group);
+	err = bt_cap_unicast_group_create(&group_param, &unicast_group);
 	if (err != 0) {
 		LOG_ERR("Failed to create group: %d", err);
 		return err;
@@ -374,7 +374,7 @@ static int unicast_group_delete(void)
 {
 	int err;
 
-	err = bt_bap_unicast_group_delete(unicast_group);
+	err = bt_cap_unicast_group_delete(unicast_group);
 	if (err != 0) {
 		LOG_ERR("Failed to delete group: %d", err);
 		return err;

--- a/samples/bluetooth/tmap_central/src/cap_initiator.c
+++ b/samples/bluetooth/tmap_central/src/cap_initiator.c
@@ -313,15 +313,15 @@ static struct bt_bap_unicast_client_cb unicast_client_cbs = {
 	.endpoint = endpoint_cb,
 };
 
-static int unicast_group_create(struct bt_bap_unicast_group **out_unicast_group)
+static int unicast_group_create(struct bt_cap_unicast_group **out_unicast_group)
 {
 	int err = 0;
-	struct bt_bap_unicast_group_stream_param group_stream_params;
-	struct bt_bap_unicast_group_stream_pair_param pair_params;
-	struct bt_bap_unicast_group_param group_param;
+	struct bt_cap_unicast_group_stream_param group_stream_params;
+	struct bt_cap_unicast_group_stream_pair_param pair_params;
+	struct bt_cap_unicast_group_param group_param;
 
-	group_stream_params.qos = &unicast_preset_48_2_1.qos;
-	group_stream_params.stream = &unicast_streams[0].bap_stream;
+	group_stream_params.qos_cfg = &unicast_preset_48_2_1.qos;
+	group_stream_params.stream = &unicast_streams[0];
 	pair_params.tx_param = &group_stream_params;
 	pair_params.rx_param = NULL;
 
@@ -329,7 +329,7 @@ static int unicast_group_create(struct bt_bap_unicast_group **out_unicast_group)
 	group_param.params_count = 1;
 	group_param.params = &pair_params;
 
-	err = bt_bap_unicast_group_create(&group_param, out_unicast_group);
+	err = bt_cap_unicast_group_create(&group_param, out_unicast_group);
 	if (err != 0) {
 		printk("Failed to create group: %d\n", err);
 		return err;
@@ -444,7 +444,7 @@ int cap_initiator_init(void)
 int cap_initiator_setup(struct bt_conn *conn)
 {
 	int err = 0;
-	struct bt_bap_unicast_group *unicast_group;
+	struct bt_cap_unicast_group *unicast_group;
 
 	k_sem_reset(&sem_cas_discovery);
 	k_sem_reset(&sem_discover_sink);

--- a/tests/bluetooth/audio/cap_initiator/CMakeLists.txt
+++ b/tests/bluetooth/audio/cap_initiator/CMakeLists.txt
@@ -16,6 +16,7 @@ target_sources(testbinary
   PRIVATE
     src/main.c
     src/test_common.c
+    src/test_unicast_group.c
     src/test_unicast_start.c
     src/test_unicast_stop.c
 )

--- a/tests/bluetooth/audio/cap_initiator/src/test_unicast_group.c
+++ b/tests/bluetooth/audio/cap_initiator/src/test_unicast_group.c
@@ -1,0 +1,390 @@
+/* test_unicast_group.c - unit test for unicast group functions */
+
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <errno.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <zephyr/autoconf.h>
+#include <zephyr/bluetooth/audio/audio.h>
+#include <zephyr/bluetooth/audio/bap.h>
+#include <zephyr/bluetooth/audio/bap_lc3_preset.h>
+#include <zephyr/bluetooth/audio/cap.h>
+#include <zephyr/bluetooth/hci_types.h>
+#include <zephyr/bluetooth/iso.h>
+#include <zephyr/fff.h>
+#include <zephyr/sys/slist.h>
+#include <zephyr/sys/util.h>
+#include <sys/errno.h>
+
+#include "bap_endpoint.h"
+#include "test_common.h"
+#include "ztest_assert.h"
+#include "ztest_test.h"
+
+struct cap_initiator_test_unicast_group_fixture {
+	struct bt_cap_unicast_group_param *group_param;
+	struct bt_cap_unicast_group *unicast_group;
+	struct bt_bap_qos_cfg *qos_cfg;
+};
+
+static void *cap_initiator_test_unicast_group_setup(void)
+{
+	struct cap_initiator_test_unicast_group_fixture *fixture;
+
+	fixture = malloc(sizeof(*fixture));
+	zassert_not_null(fixture);
+
+	return fixture;
+}
+
+static void cap_initiator_test_unicast_group_before(void *f)
+{
+
+	struct cap_initiator_test_unicast_group_fixture *fixture = f;
+	struct bt_cap_unicast_group_stream_pair_param *pair_params;
+	struct bt_cap_unicast_group_stream_param *stream_params;
+	struct bt_cap_stream *cap_streams;
+	size_t pair_cnt = 0U;
+	size_t str_cnt = 0U;
+
+	memset(f, 0, sizeof(struct cap_initiator_test_unicast_group_fixture));
+
+	fixture->group_param = calloc(sizeof(struct bt_cap_unicast_group_param), 1);
+	zassert_not_null(fixture->group_param);
+	pair_params = calloc(sizeof(struct bt_cap_unicast_group_stream_pair_param),
+			     DIV_ROUND_UP(CONFIG_BT_BAP_UNICAST_CLIENT_GROUP_STREAM_COUNT, 2U));
+	zassert_not_null(pair_params);
+	stream_params = calloc(sizeof(struct bt_cap_unicast_group_stream_param),
+			       CONFIG_BT_BAP_UNICAST_CLIENT_GROUP_STREAM_COUNT);
+	zassert_not_null(stream_params);
+	cap_streams = calloc(sizeof(struct bt_cap_stream),
+			     CONFIG_BT_BAP_UNICAST_CLIENT_GROUP_STREAM_COUNT);
+	zassert_not_null(cap_streams);
+	fixture->qos_cfg = calloc(sizeof(struct bt_bap_qos_cfg), 1);
+	zassert_not_null(fixture->qos_cfg);
+
+	*fixture->qos_cfg = BT_BAP_QOS_CFG_UNFRAMED(10000u, 40u, 2u, 10u, 40000u); /* 16_2_1 */
+
+	while (str_cnt < CONFIG_BT_BAP_UNICAST_CLIENT_GROUP_STREAM_COUNT) {
+		stream_params[str_cnt].stream = &cap_streams[str_cnt];
+		stream_params[str_cnt].qos_cfg = fixture->qos_cfg;
+
+		if (str_cnt & 1) {
+			pair_params[pair_cnt].tx_param = &stream_params[str_cnt];
+		} else {
+			pair_params[pair_cnt].rx_param = &stream_params[str_cnt];
+		}
+
+		str_cnt++;
+		pair_cnt = str_cnt / 2U;
+	}
+
+	fixture->group_param->packing = BT_ISO_PACKING_SEQUENTIAL;
+	fixture->group_param->params_count = pair_cnt;
+	fixture->group_param->params = pair_params;
+}
+
+static void cap_initiator_test_unicast_group_after(void *f)
+{
+	struct cap_initiator_test_unicast_group_fixture *fixture = f;
+	struct bt_cap_unicast_group_param *group_param;
+
+	/* In the case of a test failing, we delete the group so that subsequent tests won't fail */
+	if (fixture->unicast_group != NULL) {
+		bt_cap_unicast_group_delete(fixture->unicast_group);
+	}
+
+	group_param = fixture->group_param;
+
+	free(group_param->params[0].rx_param->stream);
+	free(group_param->params[0].rx_param);
+	free(group_param->params);
+	free(group_param);
+	free(fixture->qos_cfg);
+}
+
+static void cap_initiator_test_unicast_group_teardown(void *f)
+{
+	free(f);
+}
+
+ZTEST_SUITE(cap_initiator_test_unicast_group, NULL, cap_initiator_test_unicast_group_setup,
+	    cap_initiator_test_unicast_group_before, cap_initiator_test_unicast_group_after,
+	    cap_initiator_test_unicast_group_teardown);
+
+static ZTEST_F(cap_initiator_test_unicast_group, test_initiator_unicast_group_create)
+{
+	int err = 0;
+
+	err = bt_cap_unicast_group_create(fixture->group_param, &fixture->unicast_group);
+	zassert_equal(err, 0, "Unexpected return value %d", err);
+}
+
+static ZTEST_F(cap_initiator_test_unicast_group,
+	       test_initiator_unicast_group_create_inval_null_param)
+{
+	int err = 0;
+
+	err = bt_cap_unicast_group_create(NULL, &fixture->unicast_group);
+	zassert_equal(err, -EINVAL, "Unexpected return value %d", err);
+}
+
+static ZTEST_F(cap_initiator_test_unicast_group,
+	       test_initiator_unicast_group_create_inval_null_rx_stream)
+{
+	int err = 0;
+
+	if (fixture->group_param->params[0].rx_param->stream == NULL) {
+		ztest_test_skip();
+	}
+	fixture->group_param->params[0].rx_param->stream = NULL;
+
+	err = bt_cap_unicast_group_create(fixture->group_param, &fixture->unicast_group);
+	zassert_equal(err, -EINVAL, "Unexpected return value %d", err);
+}
+
+static ZTEST_F(cap_initiator_test_unicast_group,
+	       test_initiator_unicast_group_create_inval_null_tx_stream)
+{
+	int err = 0;
+
+	if (fixture->group_param->params[0].tx_param->stream == NULL) {
+		ztest_test_skip();
+	}
+	fixture->group_param->params[0].tx_param->stream = NULL;
+
+	err = bt_cap_unicast_group_create(fixture->group_param, &fixture->unicast_group);
+	zassert_equal(err, -EINVAL, "Unexpected return value %d", err);
+}
+
+static ZTEST_F(cap_initiator_test_unicast_group,
+	       test_initiator_unicast_group_create_inval_too_many_streams)
+{
+	int err = 0;
+
+	fixture->group_param->params_count = CONFIG_BT_BAP_UNICAST_CLIENT_GROUP_STREAM_COUNT + 1;
+
+	err = bt_cap_unicast_group_create(fixture->group_param, &fixture->unicast_group);
+	zassert_equal(err, -EINVAL, "Unexpected return value %d", err);
+}
+
+static ZTEST_F(cap_initiator_test_unicast_group, test_initiator_unicast_group_reconfig)
+{
+	int err = 0;
+
+	err = bt_cap_unicast_group_create(fixture->group_param, &fixture->unicast_group);
+	zassert_equal(err, 0, "Unexpected return value %d", err);
+
+	err = bt_cap_unicast_group_reconfig(fixture->unicast_group, fixture->group_param);
+	zassert_equal(err, 0, "Unexpected return value %d", err);
+}
+
+static ZTEST_F(cap_initiator_test_unicast_group,
+	       test_initiator_unicast_group_reconfig_inval_null_group)
+{
+	int err = 0;
+
+	err = bt_cap_unicast_group_create(fixture->group_param, &fixture->unicast_group);
+	zassert_equal(err, 0, "Unexpected return value %d", err);
+
+	err = bt_cap_unicast_group_reconfig(NULL, fixture->group_param);
+	zassert_equal(err, -EINVAL, "Unexpected return value %d", err);
+}
+
+static ZTEST_F(cap_initiator_test_unicast_group,
+	       test_initiator_unicast_group_reconfig_inval_null_param)
+{
+	int err = 0;
+
+	err = bt_cap_unicast_group_create(fixture->group_param, &fixture->unicast_group);
+	zassert_equal(err, 0, "Unexpected return value %d", err);
+
+	err = bt_cap_unicast_group_reconfig(fixture->unicast_group, NULL);
+	zassert_equal(err, -EINVAL, "Unexpected return value %d", err);
+}
+
+static ZTEST_F(cap_initiator_test_unicast_group, test_initiator_unicast_group_add_streams)
+{
+	struct bt_cap_stream stream = {};
+	struct bt_cap_unicast_group_stream_param stream_param = {
+		.stream = &stream,
+		.qos_cfg = fixture->qos_cfg,
+	};
+	const struct bt_cap_unicast_group_stream_pair_param pair_param = {
+		.rx_param = &stream_param,
+	};
+	int err = 0;
+
+	err = bt_cap_unicast_group_create(fixture->group_param, &fixture->unicast_group);
+	zassert_equal(err, 0, "Unexpected return value %d", err);
+
+	err = bt_cap_unicast_group_add_streams(fixture->unicast_group, &pair_param, 1);
+	zassert_equal(err, 0, "Unexpected return value %d", err);
+}
+
+static ZTEST_F(cap_initiator_test_unicast_group,
+	       test_initiator_unicast_group_add_streams_inval_null_group)
+{
+	struct bt_cap_stream stream = {};
+	struct bt_cap_unicast_group_stream_param stream_param = {
+		.stream = &stream,
+		.qos_cfg = fixture->qos_cfg,
+	};
+	const struct bt_cap_unicast_group_stream_pair_param pair_param = {
+		.rx_param = &stream_param,
+	};
+	int err = 0;
+
+	err = bt_cap_unicast_group_create(fixture->group_param, &fixture->unicast_group);
+	zassert_equal(err, 0, "Unexpected return value %d", err);
+
+	err = bt_cap_unicast_group_add_streams(NULL, &pair_param, 1);
+	zassert_equal(err, -EINVAL, "Unexpected return value %d", err);
+}
+
+static ZTEST_F(cap_initiator_test_unicast_group,
+	       test_initiator_unicast_group_add_streams_inval_null_param)
+{
+	int err = 0;
+
+	err = bt_cap_unicast_group_create(fixture->group_param, &fixture->unicast_group);
+	zassert_equal(err, 0, "Unexpected return value %d", err);
+
+	err = bt_cap_unicast_group_add_streams(fixture->unicast_group, NULL, 1);
+	zassert_equal(err, -EINVAL, "Unexpected return value %d", err);
+}
+
+static ZTEST_F(cap_initiator_test_unicast_group,
+	       test_initiator_unicast_group_add_streams_inval_0_param)
+{
+	struct bt_cap_stream stream = {};
+	struct bt_cap_unicast_group_stream_param stream_param = {
+		.stream = &stream,
+		.qos_cfg = fixture->qos_cfg,
+	};
+	const struct bt_cap_unicast_group_stream_pair_param pair_param = {
+		.rx_param = &stream_param,
+	};
+	int err = 0;
+
+	err = bt_cap_unicast_group_create(fixture->group_param, &fixture->unicast_group);
+	zassert_equal(err, 0, "Unexpected return value %d", err);
+
+	err = bt_cap_unicast_group_add_streams(fixture->unicast_group, &pair_param, 0);
+	zassert_equal(err, -EINVAL, "Unexpected return value %d", err);
+}
+
+static ZTEST_F(cap_initiator_test_unicast_group, test_initiator_unicast_group_delete)
+{
+	int err = 0;
+
+	err = bt_cap_unicast_group_create(fixture->group_param, &fixture->unicast_group);
+	zassert_equal(err, 0, "Unexpected return value %d", err);
+
+	err = bt_cap_unicast_group_delete(fixture->unicast_group);
+	zassert_equal(err, 0, "Unexpected return value %d", err);
+	fixture->unicast_group = NULL;
+}
+
+static ZTEST_F(cap_initiator_test_unicast_group,
+	       test_initiator_unicast_group_delete_inval_null_group)
+{
+	int err = 0;
+
+	err = bt_cap_unicast_group_create(fixture->group_param, &fixture->unicast_group);
+	zassert_equal(err, 0, "Unexpected return value %d", err);
+
+	err = bt_cap_unicast_group_delete(NULL);
+	zassert_equal(err, -EINVAL, "Unexpected return value %d", err);
+}
+
+static ZTEST_F(cap_initiator_test_unicast_group,
+	       test_initiator_unicast_group_delete_inval_double_delete)
+{
+	int err = 0;
+
+	err = bt_cap_unicast_group_create(fixture->group_param, &fixture->unicast_group);
+	zassert_equal(err, 0, "Unexpected return value %d", err);
+
+	err = bt_cap_unicast_group_delete(fixture->unicast_group);
+	zassert_equal(err, 0, "Unexpected return value %d", err);
+
+	err = bt_cap_unicast_group_delete(fixture->unicast_group);
+	zassert_equal(err, -EINVAL, "Unexpected return value %d", err);
+	fixture->unicast_group = NULL;
+}
+
+static bool unicast_group_foreach_stream_cb(struct bt_cap_stream *cap_stream, void *user_data)
+{
+	size_t *cnt = user_data;
+
+	(*cnt)++;
+
+	return false;
+}
+
+static ZTEST_F(cap_initiator_test_unicast_group, test_initiator_unicast_group_foreach_stream)
+{
+	size_t expect_cnt = 0U;
+	size_t cnt = 0U;
+	int err;
+
+	err = bt_cap_unicast_group_create(fixture->group_param, &fixture->unicast_group);
+	zassert_equal(err, 0, "Unexpected return value %d", err);
+
+	err = bt_cap_unicast_group_foreach_stream(fixture->unicast_group,
+						  unicast_group_foreach_stream_cb, &cnt);
+	zassert_equal(err, 0, "Unexpected return value %d", err);
+
+	for (size_t i = 0; i < fixture->group_param->params_count; i++) {
+		if (fixture->group_param->params[i].rx_param != NULL) {
+			expect_cnt++;
+		}
+
+		if (fixture->group_param->params[i].tx_param != NULL) {
+			expect_cnt++;
+		}
+	}
+
+	zassert_equal(cnt, expect_cnt, "Unexpected cnt (%zu != %zu)", cnt, expect_cnt);
+}
+
+static ZTEST_F(cap_initiator_test_unicast_group,
+	       test_initiator_unicast_group_foreach_stream_inval_null_group)
+{
+	size_t expect_cnt = 0U;
+	size_t cnt = 0U;
+	int err;
+
+	err = bt_cap_unicast_group_create(fixture->group_param, &fixture->unicast_group);
+	zassert_equal(err, 0, "Unexpected return value %d", err);
+
+	err = bt_cap_unicast_group_foreach_stream(NULL, unicast_group_foreach_stream_cb, &cnt);
+	zassert_equal(err, -EINVAL, "Unexpected return value %d", err);
+
+	zassert_equal(cnt, expect_cnt, "Unexpected cnt (%zu != %zu)", cnt, expect_cnt);
+}
+
+static ZTEST_F(cap_initiator_test_unicast_group,
+	       test_initiator_unicast_group_foreach_stream_inval_null_func)
+{
+	size_t expect_cnt = 0U;
+	size_t cnt = 0U;
+	int err;
+
+	err = bt_cap_unicast_group_create(fixture->group_param, &fixture->unicast_group);
+	zassert_equal(err, 0, "Unexpected return value %d", err);
+
+	err = bt_cap_unicast_group_foreach_stream(fixture->unicast_group, NULL, &cnt);
+	zassert_equal(err, -EINVAL, "Unexpected return value %d", err);
+
+	zassert_equal(cnt, expect_cnt, "Unexpected cnt (%zu != %zu)", cnt, expect_cnt);
+}

--- a/tests/bluetooth/audio/mocks/src/kernel.c
+++ b/tests/bluetooth/audio/mocks/src/kernel.c
@@ -21,6 +21,8 @@
 #define FFF_FAKES_LIST(FAKE)                                                                       \
 	FAKE(z_timeout_remaining)                                                                  \
 	FAKE(k_work_cancel_delayable_sync)                                                         \
+	FAKE(k_sem_take)                                                                           \
+	FAKE(k_sem_give)
 
 /* List of k_work items to be worked. */
 static sys_slist_t work_pending;

--- a/tests/bsim/bluetooth/audio/src/cap_initiator_unicast_test.c
+++ b/tests/bsim/bluetooth/audio/src/cap_initiator_unicast_test.c
@@ -616,20 +616,20 @@ static void discover_cas(struct bt_conn *conn)
 	WAIT_FOR_FLAG(flag_discovered);
 }
 
-static void unicast_group_create(struct bt_bap_unicast_group **out_unicast_group)
+static void unicast_group_create(struct bt_cap_unicast_group **out_unicast_group)
 {
-	struct bt_bap_unicast_group_stream_param group_source_stream_params;
-	struct bt_bap_unicast_group_stream_param group_sink_stream_params;
-	struct bt_bap_unicast_group_stream_pair_param pair_params;
-	struct bt_bap_unicast_group_param group_param;
+	struct bt_cap_unicast_group_stream_param group_source_stream_params;
+	struct bt_cap_unicast_group_stream_param group_sink_stream_params;
+	struct bt_cap_unicast_group_stream_pair_param pair_params;
+	struct bt_cap_unicast_group_param group_param;
 	int err;
 
-	group_sink_stream_params.qos = &unicast_preset_16_2_1.qos;
+	group_sink_stream_params.qos_cfg = &unicast_preset_16_2_1.qos;
 	group_sink_stream_params.stream =
-		bap_stream_from_audio_test_stream(&unicast_client_sink_streams[0]);
-	group_source_stream_params.qos = &unicast_preset_16_2_1.qos;
+		cap_stream_from_audio_test_stream(&unicast_client_sink_streams[0]);
+	group_source_stream_params.qos_cfg = &unicast_preset_16_2_1.qos;
 	group_source_stream_params.stream =
-		bap_stream_from_audio_test_stream(&unicast_client_source_streams[0]);
+		cap_stream_from_audio_test_stream(&unicast_client_source_streams[0]);
 	pair_params.tx_param = &group_sink_stream_params;
 	pair_params.rx_param = &group_source_stream_params;
 
@@ -637,14 +637,14 @@ static void unicast_group_create(struct bt_bap_unicast_group **out_unicast_group
 	group_param.params_count = 1;
 	group_param.params = &pair_params;
 
-	err = bt_bap_unicast_group_create(&group_param, out_unicast_group);
+	err = bt_cap_unicast_group_create(&group_param, out_unicast_group);
 	if (err != 0) {
 		FAIL("Failed to create group: %d\n", err);
 		return;
 	}
 }
 
-static void unicast_audio_start(struct bt_bap_unicast_group *unicast_group, bool wait)
+static void unicast_audio_start(struct bt_cap_unicast_group *unicast_group, bool wait)
 {
 	struct bt_cap_unicast_audio_start_stream_param stream_param[2];
 	struct bt_cap_unicast_audio_start_param param;
@@ -761,7 +761,7 @@ static void unicast_audio_update(void)
 	WAIT_FOR_FLAG(flag_updated);
 }
 
-static void unicast_audio_stop(struct bt_bap_unicast_group *unicast_group)
+static void unicast_audio_stop(struct bt_cap_unicast_group *unicast_group)
 {
 	struct bt_cap_unicast_audio_stop_param param;
 	int err;
@@ -828,27 +828,27 @@ static void unicast_group_delete_inval(void)
 {
 	int err;
 
-	err = bt_bap_unicast_group_delete(NULL);
+	err = bt_cap_unicast_group_delete(NULL);
 	if (err == 0) {
-		FAIL("bt_bap_unicast_group_delete with NULL group did not fail\n");
+		FAIL("bt_cap_unicast_group_delete with NULL group did not fail\n");
 		return;
 	}
 }
 
-static void unicast_group_delete(struct bt_bap_unicast_group *unicast_group)
+static void unicast_group_delete(struct bt_cap_unicast_group *unicast_group)
 {
 	int err;
 
-	err = bt_bap_unicast_group_delete(unicast_group);
+	err = bt_cap_unicast_group_delete(unicast_group);
 	if (err != 0) {
 		FAIL("Failed to create group: %d\n", err);
 		return;
 	}
 
 	/* Verify that it cannot be deleted twice */
-	err = bt_bap_unicast_group_delete(unicast_group);
+	err = bt_cap_unicast_group_delete(unicast_group);
 	if (err == 0) {
-		FAIL("bt_bap_unicast_group_delete with already-deleted unicast group did not "
+		FAIL("bt_cap_unicast_group_delete with already-deleted unicast group did not "
 		     "fail\n");
 		return;
 	}
@@ -856,7 +856,7 @@ static void unicast_group_delete(struct bt_bap_unicast_group *unicast_group)
 
 static void test_main_cap_initiator_unicast(void)
 {
-	struct bt_bap_unicast_group *unicast_group;
+	struct bt_cap_unicast_group *unicast_group;
 	const size_t iterations = 2;
 
 	init();
@@ -909,7 +909,7 @@ static void test_main_cap_initiator_unicast(void)
 
 static void test_main_cap_initiator_unicast_inval(void)
 {
-	struct bt_bap_unicast_group *unicast_group;
+	struct bt_cap_unicast_group *unicast_group;
 
 	init();
 
@@ -948,7 +948,7 @@ static void test_main_cap_initiator_unicast_inval(void)
 
 static void test_cap_initiator_unicast_timeout(void)
 {
-	struct bt_bap_unicast_group *unicast_group;
+	struct bt_cap_unicast_group *unicast_group;
 	const k_timeout_t timeout = K_SECONDS(10);
 	const size_t iterations = 2;
 
@@ -1013,7 +1013,7 @@ static void unset_invalid_metadata_type(uint8_t type)
 
 static void test_cap_initiator_unicast_ase_error(void)
 {
-	struct bt_bap_unicast_group *unicast_group;
+	struct bt_cap_unicast_group *unicast_group;
 	const uint8_t inval_type = 0xFD;
 
 	init();
@@ -1071,12 +1071,12 @@ static int cap_initiator_ac_create_unicast_group(const struct cap_initiator_ac_p
 						 size_t snk_cnt,
 						 struct unicast_stream *src_uni_streams[],
 						 size_t src_cnt,
-						 struct bt_bap_unicast_group **unicast_group)
+						 struct bt_cap_unicast_group **unicast_group)
 {
-	struct bt_bap_unicast_group_stream_param snk_group_stream_params[CAP_AC_MAX_SNK] = {0};
-	struct bt_bap_unicast_group_stream_param src_group_stream_params[CAP_AC_MAX_SRC] = {0};
-	struct bt_bap_unicast_group_stream_pair_param pair_params[CAP_AC_MAX_PAIR] = {0};
-	struct bt_bap_unicast_group_param group_param = {0};
+	struct bt_cap_unicast_group_stream_param snk_group_stream_params[CAP_AC_MAX_SNK] = {0};
+	struct bt_cap_unicast_group_stream_param src_group_stream_params[CAP_AC_MAX_SRC] = {0};
+	struct bt_cap_unicast_group_stream_pair_param pair_params[CAP_AC_MAX_PAIR] = {0};
+	struct bt_cap_unicast_group_param group_param = {0};
 	struct bt_bap_qos_cfg *snk_qos[CAP_AC_MAX_SNK];
 	struct bt_bap_qos_cfg *src_qos[CAP_AC_MAX_SRC];
 	size_t snk_stream_cnt = 0U;
@@ -1097,14 +1097,14 @@ static int cap_initiator_ac_create_unicast_group(const struct cap_initiator_ac_p
 	 * and direction
 	 */
 	for (size_t i = 0U; i < snk_cnt; i++) {
-		snk_group_stream_params[i].qos = snk_qos[i];
+		snk_group_stream_params[i].qos_cfg = snk_qos[i];
 		snk_group_stream_params[i].stream =
-			bap_stream_from_audio_test_stream(&snk_uni_streams[i]->stream);
+			cap_stream_from_audio_test_stream(&snk_uni_streams[i]->stream);
 	}
 	for (size_t i = 0U; i < src_cnt; i++) {
-		src_group_stream_params[i].qos = src_qos[i];
+		src_group_stream_params[i].qos_cfg = src_qos[i];
 		src_group_stream_params[i].stream =
-			bap_stream_from_audio_test_stream(&src_uni_streams[i]->stream);
+			cap_stream_from_audio_test_stream(&src_uni_streams[i]->stream);
 	}
 
 	for (size_t i = 0U; i < param->conn_cnt; i++) {
@@ -1131,7 +1131,7 @@ static int cap_initiator_ac_create_unicast_group(const struct cap_initiator_ac_p
 	group_param.params = pair_params;
 	group_param.params_count = pair_cnt;
 
-	return bt_bap_unicast_group_create(&group_param, unicast_group);
+	return bt_cap_unicast_group_create(&group_param, unicast_group);
 }
 
 static int cap_initiator_ac_cap_unicast_start(const struct cap_initiator_ac_param *param,
@@ -1139,7 +1139,7 @@ static int cap_initiator_ac_cap_unicast_start(const struct cap_initiator_ac_para
 					      size_t snk_cnt,
 					      struct unicast_stream *src_uni_streams[],
 					      size_t src_cnt,
-					      struct bt_bap_unicast_group *unicast_group)
+					      struct bt_cap_unicast_group *unicast_group)
 {
 	struct bt_cap_unicast_audio_start_stream_param stream_params[CAP_AC_MAX_STREAM] = {0};
 	struct bt_audio_codec_cfg *snk_codec_cfgs[CAP_AC_MAX_SNK] = {0};
@@ -1271,7 +1271,7 @@ static int cap_initiator_ac_cap_unicast_start(const struct cap_initiator_ac_para
 }
 
 static int cap_initiator_ac_unicast(const struct cap_initiator_ac_param *param,
-				    struct bt_bap_unicast_group **unicast_group)
+				    struct bt_cap_unicast_group **unicast_group)
 {
 	/* Allocate params large enough for any params, but only use what is required */
 	struct unicast_stream *snk_uni_streams[CAP_AC_MAX_SNK];
@@ -1376,7 +1376,7 @@ static int cap_initiator_ac_unicast(const struct cap_initiator_ac_param *param,
 
 static void test_cap_initiator_ac(const struct cap_initiator_ac_param *param)
 {
-	struct bt_bap_unicast_group *unicast_group;
+	struct bt_cap_unicast_group *unicast_group;
 	bool expect_tx = false;
 	bool expect_rx = false;
 

--- a/tests/bsim/bluetooth/audio/src/gmap_ugg_test.c
+++ b/tests/bsim/bluetooth/audio/src/gmap_ugg_test.c
@@ -613,14 +613,14 @@ static int gmap_unicast_ac_create_unicast_group(const struct gmap_unicast_ac_par
 						size_t snk_cnt,
 						struct unicast_stream *src_uni_streams[],
 						size_t src_cnt,
-						struct bt_bap_unicast_group **unicast_group)
+						struct bt_cap_unicast_group **unicast_group)
 {
-	struct bt_bap_unicast_group_stream_param
+	struct bt_cap_unicast_group_stream_param
 		snk_group_stream_params[GMAP_UNICAST_AC_MAX_SNK] = {0};
-	struct bt_bap_unicast_group_stream_param
+	struct bt_cap_unicast_group_stream_param
 		src_group_stream_params[GMAP_UNICAST_AC_MAX_SRC] = {0};
-	struct bt_bap_unicast_group_stream_pair_param pair_params[GMAP_UNICAST_AC_MAX_PAIR] = {0};
-	struct bt_bap_unicast_group_param group_param = {0};
+	struct bt_cap_unicast_group_stream_pair_param pair_params[GMAP_UNICAST_AC_MAX_PAIR] = {0};
+	struct bt_cap_unicast_group_param group_param = {0};
 	size_t snk_stream_cnt = 0U;
 	size_t src_stream_cnt = 0U;
 	size_t pair_cnt = 0U;
@@ -631,14 +631,14 @@ static int gmap_unicast_ac_create_unicast_group(const struct gmap_unicast_ac_par
 	 * and direction
 	 */
 	for (size_t i = 0U; i < snk_cnt; i++) {
-		snk_group_stream_params[i].qos = &snk_uni_streams[i]->qos;
+		snk_group_stream_params[i].qos_cfg = &snk_uni_streams[i]->qos;
 		snk_group_stream_params[i].stream =
-			bap_stream_from_audio_test_stream(&snk_uni_streams[i]->stream);
+			cap_stream_from_audio_test_stream(&snk_uni_streams[i]->stream);
 	}
 	for (size_t i = 0U; i < src_cnt; i++) {
-		src_group_stream_params[i].qos = &src_uni_streams[i]->qos;
+		src_group_stream_params[i].qos_cfg = &src_uni_streams[i]->qos;
 		src_group_stream_params[i].stream =
-			bap_stream_from_audio_test_stream(&src_uni_streams[i]->stream);
+			cap_stream_from_audio_test_stream(&src_uni_streams[i]->stream);
 	}
 
 	for (size_t i = 0U; i < param->conn_cnt; i++) {
@@ -665,13 +665,13 @@ static int gmap_unicast_ac_create_unicast_group(const struct gmap_unicast_ac_par
 	group_param.params = pair_params;
 	group_param.params_count = pair_cnt;
 
-	return bt_bap_unicast_group_create(&group_param, unicast_group);
+	return bt_cap_unicast_group_create(&group_param, unicast_group);
 }
 
 static int gmap_ac_cap_unicast_start(const struct gmap_unicast_ac_param *param,
 				     struct unicast_stream *snk_uni_streams[], size_t snk_cnt,
 				     struct unicast_stream *src_uni_streams[], size_t src_cnt,
-				     struct bt_bap_unicast_group *unicast_group)
+				     struct bt_cap_unicast_group *unicast_group)
 {
 	struct bt_cap_unicast_audio_start_stream_param stream_params[GMAP_UNICAST_AC_MAX_STREAM] = {
 		0};
@@ -813,7 +813,7 @@ static int gmap_ac_cap_unicast_start(const struct gmap_unicast_ac_param *param,
 }
 
 static int gmap_ac_unicast(const struct gmap_unicast_ac_param *param,
-			   struct bt_bap_unicast_group **unicast_group)
+			   struct bt_cap_unicast_group **unicast_group)
 {
 	/* Allocate params large enough for any params, but only use what is required */
 	struct unicast_stream *snk_uni_streams[GMAP_UNICAST_AC_MAX_SNK];
@@ -900,7 +900,7 @@ static int gmap_ac_unicast(const struct gmap_unicast_ac_param *param,
 	return 0;
 }
 
-static void unicast_audio_stop(struct bt_bap_unicast_group *unicast_group)
+static void unicast_audio_stop(struct bt_cap_unicast_group *unicast_group)
 {
 	struct bt_cap_unicast_audio_stop_param param;
 	int err;
@@ -924,11 +924,11 @@ static void unicast_audio_stop(struct bt_bap_unicast_group *unicast_group)
 	memset(started_unicast_streams, 0, sizeof(started_unicast_streams));
 }
 
-static void unicast_group_delete(struct bt_bap_unicast_group *unicast_group)
+static void unicast_group_delete(struct bt_cap_unicast_group *unicast_group)
 {
 	int err;
 
-	err = bt_bap_unicast_group_delete(unicast_group);
+	err = bt_cap_unicast_group_delete(unicast_group);
 	if (err != 0) {
 		FAIL("Failed to create group: %d\n", err);
 		return;
@@ -937,7 +937,7 @@ static void unicast_group_delete(struct bt_bap_unicast_group *unicast_group)
 
 static void test_gmap_ugg_unicast_ac(const struct gmap_unicast_ac_param *param)
 {
-	struct bt_bap_unicast_group *unicast_group;
+	struct bt_cap_unicast_group *unicast_group;
 	bool expect_tx = false;
 	bool expect_rx = false;
 
@@ -1165,10 +1165,10 @@ static int test_gmap_ugg_broadcast_ac(const struct gmap_broadcast_ac_param *para
 	uint8_t stereo_data[] = {
 		BT_AUDIO_CODEC_DATA(BT_AUDIO_CODEC_CFG_CHAN_ALLOC,
 				    BT_AUDIO_LOCATION_FRONT_RIGHT | BT_AUDIO_LOCATION_FRONT_LEFT)};
-	uint8_t right_data[] = {BT_AUDIO_CODEC_DATA(BT_AUDIO_CODEC_CFG_CHAN_ALLOC,
-						    BT_AUDIO_LOCATION_FRONT_RIGHT)};
-	uint8_t left_data[] = {BT_AUDIO_CODEC_DATA(BT_AUDIO_CODEC_CFG_CHAN_ALLOC,
-						   BT_AUDIO_LOCATION_FRONT_LEFT)};
+	uint8_t right_data[] = {
+		BT_AUDIO_CODEC_DATA(BT_AUDIO_CODEC_CFG_CHAN_ALLOC, BT_AUDIO_LOCATION_FRONT_RIGHT)};
+	uint8_t left_data[] = {
+		BT_AUDIO_CODEC_DATA(BT_AUDIO_CODEC_CFG_CHAN_ALLOC, BT_AUDIO_LOCATION_FRONT_LEFT)};
 	struct bt_cap_initiator_broadcast_subgroup_param subgroup_param = {0};
 	struct bt_cap_initiator_broadcast_create_param create_param = {0};
 	struct bt_cap_initiator_broadcast_stream_param


### PR DESCRIPTION
Adds a new abstract struct for unicast group that is specific for CAP. The difference between this and the BAP unicast group, is that the parameters are CAP streams and thus ensuring that the streams in the group adhere to the additional requirements that CAP has on top of BAP.

Various samples, modules and tests have been updated to use the CAP struct and API.