### PR TITLE
drivers: udc: Fix log in "disable" function

### DIFF
--- a/drivers/usb/udc/udc_numaker.c
+++ b/drivers/usb/udc/udc_numaker.c
@@ -1561,7 +1561,7 @@ static int udc_numaker_enable(const struct device *dev)
 
 static int udc_numaker_disable(const struct device *dev)
 {
-	LOG_DBG("Enable device %p", dev);
+	LOG_DBG("Disable device %p", dev);
 
 	/* S/W disconnect */
 	numaker_usbd_sw_disconnect(dev);

--- a/drivers/usb/udc/udc_renesas_ra.c
+++ b/drivers/usb/udc/udc_renesas_ra.c
@@ -490,7 +490,7 @@ static int udc_renesas_ra_disable(const struct device *dev)
 		return -EIO;
 	}
 
-	LOG_DBG("Enable device %p", dev);
+	LOG_DBG("Disable device %p", dev);
 
 	return 0;
 }

--- a/drivers/usb/udc/udc_rpi_pico.c
+++ b/drivers/usb/udc/udc_rpi_pico.c
@@ -952,7 +952,7 @@ static int udc_rpi_pico_disable(const struct device *dev)
 	const struct rpi_pico_config *config = dev->config;
 
 	config->irq_disable_func(dev);
-	LOG_DBG("Enable device %p", dev);
+	LOG_DBG("Disable device %p", dev);
 
 	return 0;
 }

--- a/drivers/usb/udc/udc_skeleton.c
+++ b/drivers/usb/udc/udc_skeleton.c
@@ -209,7 +209,7 @@ static int udc_skeleton_enable(const struct device *dev)
 
 static int udc_skeleton_disable(const struct device *dev)
 {
-	LOG_DBG("Enable device %p", dev);
+	LOG_DBG("Disable device %p", dev);
 
 	return 0;
 }


### PR DESCRIPTION
udc_skeleton incorrectly logs "Enable device" in the function "udc_skeleton_disable", and some UDC drivers inherited this mistake.

Fix this by correcting the log message in all affected drivers.