### PR TITLE
Bluetooth: Mesh: Update Kconfig help about Mesh on System WQ

### DIFF
--- a/subsys/bluetooth/mesh/Kconfig
+++ b/subsys/bluetooth/mesh/Kconfig
@@ -126,10 +126,12 @@ config BT_MESH_WORKQ_SYS
 	  refer to BT_MESH_ADV_STACK_SIZE for the recommended minimum.
 
 	  When this option is enabled and the mesh tries to send a message,
-	  and the host ran out the HCI command buffers controlled by
-	  CONFIG_BT_BUF_CMD_TX_COUNT, the host returns -ENOBUFS immediately
-	  and the mesh drops the message transmission. To mitigate this
-	  issue, make sure to have sufficient number of HCI command buffers.
+	  and the host ran out of the HCI command buffers controlled by
+	  CONFIG_BT_BUF_CMD_TX_COUNT, the system work queue will be blocked
+	  until an HCI command buffer has been freed. This may cause a deadlock
+	  where the host cannot use the system workqueue to free the buffer
+	  that the mesh is waiting for. To mitigate this issue, make sure to
+	  have a sufficient number of HCI command buffers.
 	  When this option is enabled, the latency of sending mesh messages
 	  will be affected by other users on the system work queue, resulting in
 	  reduced reliability for sending mesh messages.


### PR DESCRIPTION
This updates the help text for the Kconfig option BT_MESH_WORKQ_SYS to take into account the change made in PR #84282 which causes the host to no longer return -ENOBUFS. Since the mesh will now instead block the work queue, a note has been added about a potential consequence of this.