### PR TITLE
cmake: segger: linker_script: handle section rtt_buff_data

### DIFF
--- a/modules/segger/CMakeLists.txt
+++ b/modules/segger/CMakeLists.txt
@@ -13,6 +13,8 @@ if(CONFIG_USE_SEGGER_RTT)
   zephyr_library_sources_ifdef(CONFIG_SEGGER_SYSTEMVIEW ${SEGGER_DIR}/SEGGER/SEGGER_SYSVIEW.c)
   # Using sort key AAA to ensure that we are placed at start of RAM
   zephyr_linker_sources_ifdef(CONFIG_SEGGER_RTT_SECTION_CUSTOM RAM_SECTIONS SORT_KEY aaa segger_rtt.ld)
+  zephyr_linker_section_ifdef(CONFIG_SEGGER_RTT_SECTION_CUSTOM NAME "rtt_buff_data" GROUP RAM_REGION ALIGN 4 NOINPUT)
+  zephyr_linker_section_configure(SECTION "rtt_buff_data" INPUT "${CONFIG_SEGGER_RTT_SECTION_CUSTOM_NAME}" SYMBOLS )
 endif()
 
 if(CONFIG_SEGGER_DEBUGMON)


### PR DESCRIPTION
The segger cmake linker script is out of date compared to segger_rtt.ld. This is causing linker failures with IAR when segger is enabled (on nrf hardware for example).