### PR TITLE
[Backport v4.0-branch] dts: st: stm32u5: restore correct `clocks` on multi-bit devices

### DIFF
--- a/dts/arm/st/u5/stm32u5.dtsi
+++ b/dts/arm/st/u5/stm32u5.dtsi
@@ -304,7 +304,7 @@
 			compatible = "zephyr,memory-region", "st,stm32-backup-sram";
 			reg = <0x40036400 DT_SIZE_K(2)>;
 			/* BKPSRAMEN and RAMCFGEN clock enable */
-			clocks = <&rcc STM32_CLOCK(AHB1, 28U)>;
+			clocks = <&rcc STM32_CLOCK_BUS_AHB1 ((1 << 28) | (1 << 17))>;
 			zephyr,memory-region = "BACKUP_SRAM";
 			status = "disabled";
 		};

--- a/dts/arm/st/u5/stm32u595.dtsi
+++ b/dts/arm/st/u5/stm32u595.dtsi
@@ -106,7 +106,8 @@
 			num-bidir-endpoints = <9>;
 			ram-size = <4096>;
 			maximum-speed = "high-speed";
-			clocks = <&rcc STM32_CLOCK(AHB2, 15U)>,
+			/* Enable OTG_HS PHY and peripheral clocks (OTGHSPHYEN | OTGEN) */
+			clocks = <&rcc STM32_CLOCK_BUS_AHB2 ((1 << 15) | (1 << 14))>,
 				 <&rcc STM32_SRC_HSI48 ICKLK_SEL(0)>;
 			phys = <&otghs_phy>;
 			status = "disabled";


### PR DESCRIPTION
Backport of #85874 to `v4.0-branch`.

Fixes: 57723cf40594545bbfc4aa36606ad9a838c4674a
Fixes: #86019

USB side confirmed working on Nucleo-U5A5ZJ-Q thanks to `samples/subsystem/usb/cdc_acm`.
Before backport, the following error is observed instead of proper behavior:
```
[00:00:23.593,000] <err> usb_dc_stm32: PCD_Init failed, 1
[00:00:23.593,000] <err> cdc_acm_echo: Failed to enable USB
```