### PR TITLE
dts: st: stm32u595: remove OTGHSPHY enable bit from usbotg_hs `clocks`

### DIFF
--- a/dts/arm/st/u5/stm32u595.dtsi
+++ b/dts/arm/st/u5/stm32u595.dtsi
@@ -108,8 +108,7 @@
 			num-bidir-endpoints = <9>;
 			ram-size = <4096>;
 			maximum-speed = "high-speed";
-			/* Enable OTG_HS PHY and peripheral clocks (OTGHSPHYEN | OTGEN) */
-			clocks = <&rcc STM32_CLOCK_BUS_AHB2 ((1 << 15) | (1 << 14))>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 14)>;
 			phys = <&otghs_phy>;
 			status = "disabled";
 		};


### PR DESCRIPTION
37bdc38ec6c687ec2468b14ce007c072867158d4 failed to take into account commit f72ef5c237240e4888b94ec2cccaec774be5ece1, and added the OTGHSPHYEN bit back into the OTGHS controller's `clocks` property. This should have no functional impact (due to how the USB driver is implemented), but ought to be removed anyways as duplicates information and is confusing.

Clean the DTSI for U595 and revert back OTGHS controller `clocks` such that it only contain the controller's clock enable bit, as it should.

---

This fixes my mistake in #85874, and should prevent any future issue in case the USB driver implementation changes. Confirmed working (both w/ and w/o patch) on Nucleo-U5A5ZJ-Q with `samples/subsystem/usb/cdc_acm`.
