### PR TITLE
dma: dma_mcux_lpc: fix scatter/gather src/dst increment

### DIFF
--- a/drivers/dma/dma_mcux_lpc.c
+++ b/drivers/dma/dma_mcux_lpc.c
@@ -402,7 +402,7 @@ static int dma_mcux_lpc_configure(const struct device *dev, uint32_t channel,
 	switch (config->channel_direction) {
 	case MEMORY_TO_MEMORY:
 		is_periph = false;
-		if (block_config->source_gather_en) {
+		if (block_config->source_gather_en && (block_config->source_gather_interval != 0)) {
 			src_inc = block_config->source_gather_interval / width;
 			/* The current controller only supports incrementing the
 			 * source and destination up to 4 time transfer width
@@ -412,7 +412,7 @@ static int dma_mcux_lpc_configure(const struct device *dev, uint32_t channel,
 			}
 		}
 
-		if (block_config->dest_scatter_en) {
+		if (block_config->dest_scatter_en && (block_config->dest_scatter_interval != 0)) {
 			dst_inc = block_config->dest_scatter_interval / width;
 			/* The current controller only supports incrementing the
 			 * source and destination up to 4 time transfer width

--- a/tests/drivers/dma/scatter_gather/testcase.yaml
+++ b/tests/drivers/dma/scatter_gather/testcase.yaml
@@ -8,6 +8,7 @@ tests:
       - intel_adsp/cavs25
       - frdm_k64f
       - mimxrt1010_evk
+      - mimxrt685_evk/mimxrt685s/cm33
       - mimxrt1060_evk/mimxrt1062/qspi
       - lpcxpresso55s36
       - native_sim


### PR DESCRIPTION
The logic for setting the src_inc and dst_inc would improperly set
these to zero when gatter/scatter was enabled but the respective
gatther_interval/scatter_interval was zero (which would imply
continuous operation).

Fixes: #85403

Signed-off-by: David Leach <david.leach@nxp.com>