### PR TITLE
boards: rakwireless: rak3172: Fix RF controller pins

### DIFF
--- a/boards/rakwireless/rak3172/rak3172.dts
+++ b/boards/rakwireless/rak3172/rak3172.dts
@@ -43,20 +43,16 @@
 
 &lptim1 {
 	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x80000000>,
-		 <&rcc STM32_SRC_LSI LPTIM1_SEL(1)>;
-	status = "okay";
-};
-
-&clk_lsi {
+		 <&rcc STM32_SRC_LSE LPTIM1_SEL(3)>;
 	status = "okay";
 };
 
 &pll {
 	div-m = <1>;
-	mul-n = <6>;
+	mul-n = <3>;
 	div-r = <2>;
 	div-q = <2>;
-	clocks = <&clk_hsi>;
+	clocks = <&clk_hse>;
 	status = "okay";
 };
 
@@ -99,7 +95,7 @@
 
 &rtc {
 	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00000400>,
-		 <&rcc STM32_SRC_LSI RTC_SEL(2)>;
+		 <&rcc STM32_SRC_LSE RTC_SEL(1)>;
 	status = "okay";
 };
 
@@ -112,10 +108,6 @@
 };
 
 &rng {
-	status = "okay";
-};
-
-&clk_hsi {
 	status = "okay";
 };
 

--- a/boards/rakwireless/rak3172/rak3172.dts
+++ b/boards/rakwireless/rak3172/rak3172.dts
@@ -6,6 +6,7 @@
 /dts-v1/;
 #include <st/wl/stm32wle5Xc.dtsi>
 #include <st/wl/stm32wle5ccux-pinctrl.dtsi>
+#include <arm/rakwireless/rak3172.dtsi>
 
 / {
 	model = "RAKWireless RAK3172 WisDuo LPWAN Module with a STM32WLE5CC SoC";
@@ -114,24 +115,8 @@
 	status = "okay";
 };
 
-&clk_lse {
-	clock-frequency = <32768>;
-};
-
 &clk_hsi {
 	status = "okay";
-};
-
-&subghzspi {
-	status = "okay";
-
-	lora: radio@0 {
-		status = "okay";
-		tx-enable-gpios = <&gpioc 13 GPIO_ACTIVE_LOW>; /* FE_CTRL1 */
-		rx-enable-gpios = <&gpiob 8 GPIO_ACTIVE_LOW>;  /* FE_CTRL2 */
-		power-amplifier-output = "rfo-lp";
-		rfo-lp-max-power = <14>;
-	};
 };
 
 &flash0 {

--- a/dts/arm/rakwireless/rak3172.dtsi
+++ b/dts/arm/rakwireless/rak3172.dtsi
@@ -7,10 +7,12 @@
 #include <st/wl/stm32wle5ccux-pinctrl.dtsi>
 
 &clk_hse {
+	status = "okay";
 	clock-frequency = <DT_FREQ_M(32)>;
 };
 
 &clk_lse {
+	status = "okay";
 	clock-frequency = <32768>;
 };
 

--- a/dts/arm/rakwireless/rak3172.dtsi
+++ b/dts/arm/rakwireless/rak3172.dtsi
@@ -18,8 +18,8 @@
 	status = "okay";
 	lora: radio@0 {
 		status = "okay";
-		tx-enable-gpios = <&gpiob 8 GPIO_ACTIVE_LOW>;
-		rx-enable-gpios = <&gpioc 13 GPIO_ACTIVE_LOW>;
+		tx-enable-gpios = <&gpioc 13 GPIO_ACTIVE_HIGH>; /* FE_CTRL1 */
+		rx-enable-gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;  /* FE_CTRL2 */
 		power-amplifier-output = "rfo-hp";
 		rfo-hp-max-power = <22>;
 	};


### PR DESCRIPTION
For correct setup, pins must be like below:
tx_enable(PC13) -> HIGH
rx_enable (PB8) -> LOW

However, the pin condition is like below for current settings,
tx_enable(PC13) -> LOW
rx_enable (PB8) -> HIGH

Fixing this problem.