### PR TITLE
ptp: clock.c: revise offset calculation

### DIFF
--- a/subsys/net/lib/ptp/clock.c
+++ b/subsys/net/lib/ptp/clock.c
@@ -509,7 +509,7 @@ int ptp_clock_management_msg_process(struct ptp_port *port, struct ptp_msg *msg)
 void ptp_clock_synchronize(uint64_t ingress, uint64_t egress)
 {
 	int64_t offset;
-	uint64_t delay = ptp_clk.current_ds.mean_delay >> 16;
+	int64_t delay = ptp_clk.current_ds.mean_delay >> 16;
 
 	ptp_clk.timestamp.t1 = egress;
 	ptp_clk.timestamp.t2 = ingress;
@@ -518,7 +518,7 @@ void ptp_clock_synchronize(uint64_t ingress, uint64_t egress)
 		return;
 	}
 
-	offset = ptp_clk.timestamp.t2 - ptp_clk.timestamp.t1 - delay;
+	offset = (int64_t)(ptp_clk.timestamp.t2 - ptp_clk.timestamp.t1) - delay;
 
 	/* If diff is too big, ptp_clk needs to be set first. */
 	if ((offset > (int64_t)NSEC_PER_SEC) || (offset < -(int64_t)NSEC_PER_SEC)) {
@@ -559,8 +559,9 @@ void ptp_clock_delay(uint64_t egress, uint64_t ingress)
 	ptp_clk.timestamp.t3 = egress;
 	ptp_clk.timestamp.t4 = ingress;
 
-	delay = ((ptp_clk.timestamp.t2 - ptp_clk.timestamp.t3) +
-		 (ptp_clk.timestamp.t4 - ptp_clk.timestamp.t1)) / 2;
+	delay = ((int64_t)(ptp_clk.timestamp.t2 - ptp_clk.timestamp.t3) +
+		 (int64_t)(ptp_clk.timestamp.t4 - ptp_clk.timestamp.t1)) /
+		2LL;
 
 	LOG_DBG("Delay %lldns", delay);
 	ptp_clk.current_ds.mean_delay = clock_ns_to_timeinterval(delay);


### PR DESCRIPTION
cast differences to signed int to allow
negative numbers

the PR solves #85832

I am using NUCLEO_H563ZI and NTS-Pico3 PTP/NTP box setup to IEEE1588/UDP/E2E profile.

With this patch the output of my tuned is:
```
[00:00:44.133,000] <dbg> ptp_port: port_delay_req_msg_transmit: Port 1 sends Delay_Req message
[00:00:44.133,000] <dbg> ptp_port: port_delay_req_timestamp_cb: Port 1 registered timestamp for 16 Delay_Req
[00:00:44.133,000] <dbg> ptp_msg: ptp_msg_post_recv: Port 1 received Delay_Resp message
[00:00:44.133,000] <dbg> ptp_clock: ptp_clock_delay: Delay -70824121ns
[00:00:44.557,000] <dbg> ptp_msg: ptp_msg_post_recv: Port 1 received Announce message
[00:00:44.558,000] <dbg> ptp_msg: ptp_msg_post_recv: Port 1 received Sync message
[00:00:44.558,000] <dbg> ptp_msg: ptp_msg_post_recv: Port 1 received Follow_Up message
[00:00:44.558,000] <dbg> ptp_clock: ptp_clock_synchronize: Offset -333266380ns
[00:00:45.558,000] <dbg> ptp_msg: ptp_msg_post_recv: Port 1 received Announce message
[00:00:45.558,000] <dbg> ptp_msg: ptp_msg_post_recv: Port 1 received Sync message
[00:00:45.558,000] <dbg> ptp_msg: ptp_msg_post_recv: Port 1 received Follow_Up message
[00:00:45.558,000] <dbg> ptp_clock: ptp_clock_synchronize: Offset -333355871ns
[00:00:46.133,000] <dbg> ptp_port: port_delay_req_msg_transmit: Port 1 sends Delay_Req message
[00:00:46.133,000] <dbg> ptp_port: port_delay_req_timestamp_cb: Port 1 registered timestamp for 17 Delay_Req
[00:00:46.135,000] <dbg> ptp_msg: ptp_msg_post_recv: Port 1 received Delay_Resp message
[00:00:46.135,000] <dbg> ptp_clock: ptp_clock_delay: Delay -70862043ns
[00:00:46.558,000] <dbg> ptp_msg: ptp_msg_post_recv: Port 1 received Announce message
[00:00:46.558,000] <dbg> ptp_msg: ptp_msg_post_recv: Port 1 received Sync message
[00:00:46.558,000] <dbg> ptp_msg: ptp_msg_post_recv: Port 1 received Follow_Up message
[00:00:46.558,000] <dbg> ptp_clock: ptp_clock_synchronize: Offset -333305141ns
TIME RECEIVER
### Current PTP time: 1740010897.197523897
### Current date and time: 2025-02-20 00:21:00 UTC
3 before sntp query### NTP Current date and time: 2025-02-20 00:21:00 UTC
```

unpatched it converts negative numbers to huge positives
```
[00:00:25.091,000] <dbg> ptp_msg: ptp_msg_post_recv: Port 1 received Announce message
[00:00:25.091,000] <dbg> ptp_msg: ptp_msg_post_recv: Port 1 received Sync message
[00:00:25.092,000] <dbg> ptp_msg: ptp_msg_post_recv: Port 1 received Follow_Up message
[00:00:25.092,000] <dbg> ptp_clock: ptp_clock_synchronize: Offset -333356873ns
[00:00:26.091,000] <dbg> ptp_msg: ptp_msg_post_recv: Port 1 received Announce message
[00:00:26.091,000] <dbg> ptp_msg: ptp_msg_post_recv: Port 1 received Sync message
[00:00:26.092,000] <dbg> ptp_msg: ptp_msg_post_recv: Port 1 received Follow_Up message
[00:00:26.092,000] <dbg> ptp_clock: ptp_clock_synchronize: Offset -333345154ns
[00:00:26.730,000] <dbg> ptp_port: port_delay_req_msg_transmit: Port 1 sends Delay_Req message
[00:00:26.730,000] <dbg> ptp_port: port_delay_req_timestamp_cb: Port 1 registered timestamp for 9 Delay_Req
[00:00:26.731,000] <dbg> ptp_msg: ptp_msg_post_recv: Port 1 received Delay_Resp message
[00:00:26.731,000] <dbg> ptp_clock: ptp_clock_delay: Delay 9223372036794592757ns
[00:00:27.091,000] <dbg> ptp_msg: ptp_msg_post_recv: Port 1 received Announce message
[00:00:27.092,000] <dbg> ptp_msg: ptp_msg_post_recv: Port 1 received Sync message
[00:00:27.092,000] <dbg> ptp_msg: ptp_msg_post_recv: Port 1 received Follow_Up message
[00:00:27.092,000] <dbg> ptp_clock: ptp_clock_synchronize: Offset -333348588ns
[00:00:28.092,000] <dbg> ptp_msg: ptp_msg_post_recv: Port 1 received Announce message
[00:00:28.092,000] <dbg> ptp_msg: ptp_msg_post_recv: Port 1 received Sync message
[00:00:28.092,000] <dbg> ptp_msg: ptp_msg_post_recv: Port 1 received Follow_Up message
[00:00:28.092,000] <dbg> ptp_clock: ptp_clock_synchronize: Offset -333352543ns
[00:00:28.730,000] <dbg> ptp_port: port_delay_req_msg_transmit: Port 1 sends Delay_Req message
[00:00:28.730,000] <dbg> ptp_port: port_delay_req_timestamp_cb: Port 1 registered timestamp for 10 Delay_Req
[00:00:28.731,000] <dbg> ptp_msg: ptp_msg_post_recv: Port 1 received Delay_Resp message
[00:00:28.731,000] <dbg> ptp_clock: ptp_clock_delay: Delay 9223372036794540300ns
TIME RECEIVER
### Current PTP time: 1740152028.139151765
### Current date and time: 2025-02-21 15:33:11 UTC
3 before sntp query### NTP Current date and time: 2025-02-20 00:27:33 UTC
```

my PTP example modification is something like:
```
	while(1) {

		get_current_status();

		const struct device *clk = net_eth_get_ptp_clock(net_if_get_by_index(1));
		struct net_ptp_time tm;
		ptp_clock_get(clk, &tm);
		printk("### Current PTP time: %llu.%09u\n", tm.second, tm.nanosecond);

		struct tm *ptm;
		time_t tai_time = tm.second - 37; // Convert TAI to UTC by subtracting leap seconds
		ptm = gmtime(&tai_time);
		printk("### Current date and time: %04d-%02d-%02d %02d:%02d:%02d UTC\n",
			   ptm->tm_year + 1900, ptm->tm_mon + 1, ptm->tm_mday,
			   ptm->tm_hour, ptm->tm_min, ptm->tm_sec);

 	   printk("3 before sntp query");
		if(sntp_query(&ctx, 4 * MSEC_PER_SEC, &sntp_time) >= 0) {
			time_t now = sntp_time.seconds;
			struct tm now_tm;
			gmtime_r(&now, &now_tm);
			printk("### NTP Current date and time: %04d-%02d-%02d %02d:%02d:%02d UTC\n",
				now_tm.tm_year + 1900, now_tm.tm_mon + 1, now_tm.tm_mday,
				now_tm.tm_hour, now_tm.tm_min, now_tm.tm_sec);
		} else {
			printk("### error on SNTP");
		}



		k_sleep(K_SECONDS(5));
	}
```
