### PR TITLE
Boards: Add missing stemma qt connector definitions to some boards.

### DIFF
--- a/boards/adafruit/qt_py_esp32s3/adafruit_qt_py_esp32s3_procpu.dts
+++ b/boards/adafruit/qt_py_esp32s3/adafruit_qt_py_esp32s3_procpu.dts
@@ -42,6 +42,15 @@
 			zephyr,code = <INPUT_KEY_0>;
 		};
 	};
+
+	stemma_connector: stemma_connector {
+		compatible = "stemma-qt-connector";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map = <0 0 &gpio1 7 0>,
+			   <1 0 &gpio1 8 0>;
+	};
 };
 
 &usb_serial {

--- a/boards/adafruit/qt_py_rp2040/adafruit_qt_py_rp2040.dts
+++ b/boards/adafruit/qt_py_rp2040/adafruit_qt_py_rp2040.dts
@@ -27,6 +27,15 @@
 		watchdog0 = &wdt0;
 		led-strip = &ws2812;
 	};
+
+	stemma_connector: stemma_connector {
+		compatible = "stemma-qt-connector";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map = <0 0 &gpio0 23 0>,
+			   <1 0 &gpio0 22 0>;
+	};
 };
 
 &flash0 {


### PR DESCRIPTION
This adds the STEMMA-QT connector to the device tree of the Adafruit QT Py RP2040 and the Adafruit QT Py ESP32s3. The connector definition didn't exist when making the device tree originally.

References:
QT Py RP2040: https://learn.adafruit.com/adafruit-qt-py-2040/pinouts
QT Py ESP32s3: https://learn.adafruit.com/adafruit-qt-py-esp32-s3/pinouts