### PR TITLE
adc: add microvolt conversion functions

### DIFF
--- a/drivers/adc/adc_common.c
+++ b/drivers/adc/adc_common.c
@@ -6,36 +6,52 @@
 
 #include <zephyr/drivers/adc.h>
 
-int adc_gain_invert(enum adc_gain gain,
-		    int32_t *value)
+struct gain_desc {
+	uint8_t mul;
+	uint8_t div;
+};
+static const struct gain_desc gains[] = {
+	[ADC_GAIN_1_6] = {.mul = 6, .div = 1},
+	[ADC_GAIN_1_5] = {.mul = 5, .div = 1},
+	[ADC_GAIN_1_4] = {.mul = 4, .div = 1},
+	[ADC_GAIN_2_7] = {.mul = 7, .div = 2},
+	[ADC_GAIN_1_3] = {.mul = 3, .div = 1},
+	[ADC_GAIN_2_5] = {.mul = 5, .div = 2},
+	[ADC_GAIN_1_2] = {.mul = 2, .div = 1},
+	[ADC_GAIN_2_3] = {.mul = 3, .div = 2},
+	[ADC_GAIN_4_5] = {.mul = 5, .div = 4},
+	[ADC_GAIN_1] = {.mul = 1, .div = 1},
+	[ADC_GAIN_2] = {.mul = 1, .div = 2},
+	[ADC_GAIN_3] = {.mul = 1, .div = 3},
+	[ADC_GAIN_4] = {.mul = 1, .div = 4},
+	[ADC_GAIN_6] = {.mul = 1, .div = 6},
+	[ADC_GAIN_8] = {.mul = 1, .div = 8},
+	[ADC_GAIN_12] = {.mul = 1, .div = 12},
+	[ADC_GAIN_16] = {.mul = 1, .div = 16},
+	[ADC_GAIN_24] = {.mul = 1, .div = 24},
+	[ADC_GAIN_32] = {.mul = 1, .div = 32},
+	[ADC_GAIN_64] = {.mul = 1, .div = 64},
+	[ADC_GAIN_128] = {.mul = 1, .div = 128},
+};
+
+int adc_gain_invert(enum adc_gain gain, int32_t *value)
 {
-	struct gain_desc {
-		uint8_t mul;
-		uint8_t div;
-	};
-	static const struct gain_desc gains[] = {
-		[ADC_GAIN_1_6] = {.mul = 6, .div = 1},
-		[ADC_GAIN_1_5] = {.mul = 5, .div = 1},
-		[ADC_GAIN_1_4] = {.mul = 4, .div = 1},
-		[ADC_GAIN_2_7] = {.mul = 7, .div = 2},
-		[ADC_GAIN_1_3] = {.mul = 3, .div = 1},
-		[ADC_GAIN_2_5] = {.mul = 5, .div = 2},
-		[ADC_GAIN_1_2] = {.mul = 2, .div = 1},
-		[ADC_GAIN_2_3] = {.mul = 3, .div = 2},
-		[ADC_GAIN_4_5] = {.mul = 5, .div = 4},
-		[ADC_GAIN_1] = {.mul = 1, .div = 1},
-		[ADC_GAIN_2] = {.mul = 1, .div = 2},
-		[ADC_GAIN_3] = {.mul = 1, .div = 3},
-		[ADC_GAIN_4] = {.mul = 1, .div = 4},
-		[ADC_GAIN_6] = {.mul = 1, .div = 6},
-		[ADC_GAIN_8] = {.mul = 1, .div = 8},
-		[ADC_GAIN_12] = {.mul = 1, .div = 12},
-		[ADC_GAIN_16] = {.mul = 1, .div = 16},
-		[ADC_GAIN_24] = {.mul = 1, .div = 24},
-		[ADC_GAIN_32] = {.mul = 1, .div = 32},
-		[ADC_GAIN_64] = {.mul = 1, .div = 64},
-		[ADC_GAIN_128] = {.mul = 1, .div = 128},
-	};
+	int rv = -EINVAL;
+
+	if ((uint8_t)gain < ARRAY_SIZE(gains)) {
+		const struct gain_desc *gdp = &gains[gain];
+
+		if ((gdp->mul != 0) && (gdp->div != 0)) {
+			*value = (gdp->mul * *value) / gdp->div;
+			rv = 0;
+		}
+	}
+
+	return rv;
+}
+
+int adc_gain_invert_64(enum adc_gain gain, int64_t *value)
+{
 	int rv = -EINVAL;
 
 	if ((uint8_t)gain < ARRAY_SIZE(gains)) {

--- a/include/zephyr/drivers/adc.h
+++ b/include/zephyr/drivers/adc.h
@@ -71,8 +71,25 @@ enum adc_gain {
  * @retval 0 if the gain was successfully reversed
  * @retval -EINVAL if the gain could not be interpreted
  */
-int adc_gain_invert(enum adc_gain gain,
-		    int32_t *value);
+int adc_gain_invert(enum adc_gain gain, int32_t *value);
+
+/**
+ * @brief Invert the application of gain to a measurement value.
+ *
+ * For example, if the gain passed in is ADC_GAIN_1_6 and the
+ * referenced value is 10, the value after the function returns is 60.
+ *
+ * @param gain the gain used to amplify the input signal.
+ *
+ * @param value a pointer to a value that initially has the effect of
+ * the applied gain but has that effect removed when this function
+ * successfully returns.  If the gain cannot be reversed the value
+ * remains unchanged.
+ *
+ * @retval 0 if the gain was successfully reversed
+ * @retval -EINVAL if the gain could not be interpreted
+ */
+int adc_gain_invert_64(enum adc_gain gain, int64_t *value);
 
 /** @brief ADC references. */
 enum adc_reference {

--- a/tests/drivers/adc/adc_rescale/src/main.c
+++ b/tests/drivers/adc/adc_rescale/src/main.c
@@ -57,6 +57,7 @@ static int test_task_voltage_divider(void)
 {
 	int ret;
 	int32_t calculated_voltage = 0;
+	int32_t calculated_microvolts;
 	int32_t input_mv = 1000;
 	const struct voltage_divider_dt_spec adc_node_0 =
 		VOLTAGE_DIVIDER_DT_SPEC_GET(ADC_TEST_NODE_0);
@@ -72,9 +73,14 @@ static int test_task_voltage_divider(void)
 
 	ret = adc_read_dt(&adc_node_0.port, &sequence);
 	zassert_equal(ret, 0, "adc_read() failed with code %d", ret);
+	calculated_microvolts = calculated_voltage;
 
 	ret = adc_raw_to_millivolts_dt(&adc_node_0.port, &calculated_voltage);
 	zassert_equal(ret, 0, "adc_raw_to_millivolts_dt() failed with code %d", ret);
+
+	ret = adc_raw_to_microvolts_dt(&adc_node_0.port, &calculated_microvolts);
+	zassert_equal(ret, 0, "adc_raw_to_microvolts_dt() failed with code %d", ret);
+	zassert_equal(calculated_microvolts / 1000, calculated_voltage);
 
 	ret = voltage_divider_scale_dt(&adc_node_0, &calculated_voltage);
 	zassert_equal(ret, 0, "divider_scale_voltage_dt() failed with code %d", ret);
@@ -97,6 +103,7 @@ static int test_task_current_sense_shunt(void)
 {
 	int ret;
 	int32_t calculated_current = 0;
+	int32_t calculated_microvolts;
 	int32_t input_mv = 3000;
 	const struct current_sense_shunt_dt_spec adc_node_1 =
 		CURRENT_SENSE_SHUNT_DT_SPEC_GET(ADC_TEST_NODE_1);
@@ -112,9 +119,14 @@ static int test_task_current_sense_shunt(void)
 
 	ret = adc_read_dt(&adc_node_1.port, &sequence);
 	zassert_equal(ret, 0, "adc_read() failed with code %d", ret);
+	calculated_microvolts = calculated_current;
 
 	ret = adc_raw_to_millivolts_dt(&adc_node_1.port, &calculated_current);
 	zassert_equal(ret, 0, "adc_raw_to_millivolts_dt() failed with code %d", ret);
+
+	ret = adc_raw_to_microvolts_dt(&adc_node_1.port, &calculated_microvolts);
+	zassert_equal(ret, 0, "adc_raw_to_microvolts_dt() failed with code %d", ret);
+	zassert_equal(calculated_microvolts / 1000, calculated_current);
 
 	current_sense_shunt_scale_dt(&adc_node_1, &calculated_current);
 
@@ -137,6 +149,7 @@ static int test_task_current_sense_amplifier(void)
 {
 	int ret;
 	int32_t calculated_current = 0;
+	int32_t calculated_microvolts;
 	int32_t input_mv = 3000;
 	const struct current_sense_amplifier_dt_spec adc_node_2 =
 		CURRENT_SENSE_AMPLIFIER_DT_SPEC_GET(ADC_TEST_NODE_2);
@@ -152,9 +165,14 @@ static int test_task_current_sense_amplifier(void)
 
 	ret = adc_read_dt(&adc_node_2.port, &sequence);
 	zassert_equal(ret, 0, "adc_read() failed with code %d", ret);
+	calculated_microvolts = calculated_current;
 
 	ret = adc_raw_to_millivolts_dt(&adc_node_2.port, &calculated_current);
 	zassert_equal(ret, 0, "adc_raw_to_millivolts_dt() failed with code %d", ret);
+
+	ret = adc_raw_to_microvolts_dt(&adc_node_2.port, &calculated_microvolts);
+	zassert_equal(ret, 0, "adc_raw_to_microvolts_dt() failed with code %d", ret);
+	zassert_equal(calculated_microvolts / 1000, calculated_current);
 
 	current_sense_amplifier_scale_dt(&adc_node_2, &calculated_current);
 


### PR DESCRIPTION
Add a family of functions that convert to microvolts instead of millivolts. The resolution of an ADC with a 600 mV reference and a 12 bit output (nRF SAADC for example) is an order of magnitude better than millivolts (0.146 mV), even before considering non-unity gains.