### PR TITLE
sensor: current_amp: add a noise threshold

### DIFF
--- a/drivers/sensor/current_amp/current_amp.c
+++ b/drivers/sensor/current_amp/current_amp.c
@@ -6,6 +6,8 @@
 
 #define DT_DRV_COMPAT current_sense_amplifier
 
+#include <stdlib.h>
+
 #include <zephyr/drivers/adc.h>
 #include <zephyr/drivers/adc/current_sense_amplifier.h>
 #include <zephyr/drivers/gpio.h>
@@ -51,6 +53,10 @@ static int get(const struct device *dev, enum sensor_channel chan, struct sensor
 
 	if (chan != SENSOR_CHAN_CURRENT) {
 		return -ENOTSUP;
+	}
+
+	if (abs(raw_val) < config->noise_threshold) {
+		return sensor_value_from_micro(val, 0);
 	}
 
 	ret = adc_raw_to_millivolts_dt(&config->port, &raw_val);

--- a/dts/bindings/iio/afe/current-sense-amplifier.yaml
+++ b/dts/bindings/iio/afe/current-sense-amplifier.yaml
@@ -51,3 +51,10 @@ properties:
     description: |
       Enable calibration of the current sense amplifier.
       This is used to calibrate the ADC prior to taking measurements.
+
+  zephyr,noise-threshold:
+    type: int
+    default: 0
+    description: |
+     Raw ADC readings below this threshold are treated as noise and
+     reported as 0 uA. The default value of 0 disables the threshold.

--- a/include/zephyr/drivers/adc/current_sense_amplifier.h
+++ b/include/zephyr/drivers/adc/current_sense_amplifier.h
@@ -11,11 +11,12 @@
 #include <zephyr/drivers/gpio.h>
 
 struct current_sense_amplifier_dt_spec {
-	const struct adc_dt_spec port;
+	struct adc_dt_spec port;
+	struct gpio_dt_spec power_gpio;
 	uint32_t sense_milli_ohms;
 	uint16_t sense_gain_mult;
 	uint16_t sense_gain_div;
-	struct gpio_dt_spec power_gpio;
+	uint16_t noise_threshold;
 	bool enable_calibration;
 };
 
@@ -32,10 +33,11 @@ struct current_sense_amplifier_dt_spec {
 #define CURRENT_SENSE_AMPLIFIER_DT_SPEC_GET(node_id)                                               \
 	{                                                                                          \
 		.port = ADC_DT_SPEC_GET(node_id),                                                  \
+		.power_gpio = GPIO_DT_SPEC_GET_OR(node_id, power_gpios, {0}),                      \
 		.sense_milli_ohms = DT_PROP(node_id, sense_resistor_milli_ohms),                   \
 		.sense_gain_mult = DT_PROP(node_id, sense_gain_mult),                              \
 		.sense_gain_div = DT_PROP(node_id, sense_gain_div),                                \
-		.power_gpio = GPIO_DT_SPEC_GET_OR(node_id, power_gpios, {0}),                      \
+		.noise_threshold = DT_PROP(node_id, zephyr_noise_threshold),                       \
 		.enable_calibration = DT_PROP_OR(node_id, enable_calibration, false),              \
 	}
 


### PR DESCRIPTION
ADC output values can have noise, even if the input is 0V. Add a noise threshold so that raw ADC readings below the threshold can be zeroed out. By default the threshold is disabled.