### PR TITLE
TF-M: Enable/disable BL1 over zephyr

### DIFF
--- a/modules/trusted-firmware-m/CMakeLists.txt
+++ b/modules/trusted-firmware-m/CMakeLists.txt
@@ -18,6 +18,14 @@ set(TFM_VALID_PARTITIONS
 if (CONFIG_BUILD_WITH_TFM)
   # PSA API awareness for the Non-Secure application
   target_compile_definitions(app PRIVATE "TFM_PSA_API")
+
+  if(CONFIG_TFM_BL1)
+    list(APPEND TFM_CMAKE_ARGS -DBL1:BOOL=ON)
+    if(CONFIG_TFM_BL2_SIGNING_KEY_PATH)
+      list(APPEND TFM_CMAKE_ARGS -DTFM_BL2_SIGNING_KEY_PATH=${CONFIG_TFM_BL2_SIGNING_KEY_PATH})
+    endif()
+  endif()
+
   if (CONFIG_TFM_SFN)
     list(APPEND TFM_CMAKE_ARGS -DCONFIG_TFM_SPM_BACKEND="SFN")
   else() # CONFIG_TFM_IPC

--- a/modules/trusted-firmware-m/CMakeLists.txt
+++ b/modules/trusted-firmware-m/CMakeLists.txt
@@ -170,6 +170,10 @@ if (CONFIG_BUILD_WITH_TFM)
     set(BL2_ELF_FILE ${TFM_BINARY_DIR}/bin/bl2.elf)
     set(BL2_BIN_FILE ${TFM_BINARY_DIR}/bin/bl2.bin)
     set(BL2_HEX_FILE ${TFM_BINARY_DIR}/bin/bl2.hex)
+    if(CONFIG_TFM_BL1)
+      set(BL2_SIGNED_BIN_FILE ${TFM_BINARY_DIR}/bin/bl2_signed.bin)
+      set(BL2_SIGNED_HEX_FILE ${TFM_BINARY_DIR}/bin/bl2_signed.hex)
+    endif()
   endif()
   set(TFM_S_ELF_FILE ${TFM_BINARY_DIR}/bin/tfm_s.elf)
   set(TFM_S_BIN_FILE ${TFM_BINARY_DIR}/bin/tfm_s.bin)
@@ -187,6 +191,8 @@ if (CONFIG_BUILD_WITH_TFM)
     ${BL2_ELF_FILE}
     ${BL2_BIN_FILE}
     ${BL2_HEX_FILE}
+    $<$<BOOL:${CONFIG_TFM_BL1}>:${BL2_SIGNED_BIN_FILE}>
+    $<$<BOOL:${CONFIG_TFM_BL1}>:${BL2_SIGNED_HEX_FILE}>
     ${TFM_S_ELF_FILE}
     ${TFM_S_BIN_FILE}
     ${TFM_S_HEX_FILE}
@@ -332,6 +338,10 @@ if (CONFIG_BUILD_WITH_TFM)
       BL2_BIN_FILE ${BL2_BIN_FILE}
       BL2_HEX_FILE ${BL2_HEX_FILE}
       )
+      if(CONFIG_TFM_BL1)
+        set_target_properties(tfm PROPERTIES BL2_SIGNED_BIN_FILE ${BL2_SIGNED_BIN_FILE})
+        set_target_properties(tfm PROPERTIES BL2_SIGNED_HEX_FILE ${BL2_SIGNED_HEX_FILE})
+      endif()
   endif()
 
   # Set TFM S/NS executable file paths as target properties on 'tfm'
@@ -491,7 +501,8 @@ if (CONFIG_BUILD_WITH_TFM)
 
       COMMAND ${PYTHON_EXECUTABLE} ${ZEPHYR_BASE}/scripts/build/mergehex.py
         -o ${MERGED_FILE}
-        $<TARGET_PROPERTY:tfm,BL2_HEX_FILE>
+        $<$<BOOL:${CONFIG_TFM_BL1}>:$<TARGET_PROPERTY:tfm,BL2_SIGNED_HEX_FILE>>
+        $<$<NOT:$<BOOL:${CONFIG_TFM_BL1}>>:$<TARGET_PROPERTY:tfm,BL2_HEX_FILE>>
         ${S_NS_SIGNED_FILE}
     )
 
@@ -517,7 +528,8 @@ if (CONFIG_BUILD_WITH_TFM)
 
       COMMAND ${PYTHON_EXECUTABLE} ${ZEPHYR_BASE}/scripts/build/mergehex.py
         -o ${MERGED_FILE}
-        $<TARGET_PROPERTY:tfm,BL2_HEX_FILE>
+        $<$<BOOL:${CONFIG_TFM_BL1}>:$<TARGET_PROPERTY:tfm,BL2_SIGNED_HEX_FILE>>
+        $<$<NOT:$<BOOL:${CONFIG_TFM_BL1}>>:$<TARGET_PROPERTY:tfm,BL2_HEX_FILE>>
         ${S_SIGNED_FILE}
         ${NS_SIGNED_FILE}
     )

--- a/modules/trusted-firmware-m/Kconfig.tfm
+++ b/modules/trusted-firmware-m/Kconfig.tfm
@@ -206,6 +206,12 @@ config TFM_IMAGE_VERSION_NS
 	help
 	  Version of the non-secure image.
 
+config TFM_BL1
+	bool "Add BL1 to TFM"
+	help
+	  TFM is designed to run with BL1 in a certain configuration.
+	  This config adds BL1 to the build - built via TFM's build system.
+
 config TFM_BL2
 	bool "Add MCUboot to TFM"
 	depends on !TFM_BL2_NOT_SUPPORTED
@@ -239,6 +245,18 @@ config TFM_CONNECTION_BASED_SERVICE_API
 	  Note: This is an auto-generated configuration in the TF-M build
 	  system. When this option is not enabled in the TF-M build system this
 	  will result in compilation error.
+
+
+if TFM_BL1
+
+config TFM_BL2_SIGNING_KEY_PATH
+	string "Path to private key used to sign BL2 firmware images."
+	help
+	  Path to binary BL2 signing private key
+	  Default is ${ZEPHYR_TRUSTED_FIRMWARE_M_MODULE_DIR}/bl1/bl1_2/bl1_dummy_rotpk
+	  if it has not been changed on TF-M side for your board
+
+endif # TFM_BL1
 
 if TFM_BL2
 


### PR DESCRIPTION
This PR adds,
- CONFIG_TFM_BL1
- CONFIG_TFM_BL2_SIGNING_KEY_PATH
config parameters which exist in the tf-m project, here:
- https://github.com/zephyrproject-rtos/trusted-firmware-m/blob/main/bl1/Kconfig#L8
- https://github.com/zephyrproject-rtos/trusted-firmware-m/blob/main/bl1/config/bl1_config_default.cmake#L12

The first commit define above flag in zephyr and pass them to tf-m during build, this allow to drive them over zephyr,

if BL1 has been enabled it requires BL2 has been signed, if it is been signed tfm_merged.hex shall include signed version of bl2 
(bl2_**signed**.hex) instead unsigned one (bl2.hex), the second commit add this feature.

@MaureenHelm @microbuilder  fyi.