### PR TITLE
soc: npcx: make pm state setting functions overridable

### DIFF
--- a/soc/nuvoton/npcx/common/power.c
+++ b/soc/nuvoton/npcx/common/power.c
@@ -199,7 +199,7 @@ static void npcx_power_enter_system_sleep(int slp_mode, int wk_mode)
 }
 
 /* Invoke when enter "Suspend/Low Power" mode. */
-void pm_state_set(enum pm_state state, uint8_t substate_id)
+__weak void pm_state_set(enum pm_state state, uint8_t substate_id)
 {
 	if (state != PM_STATE_SUSPEND_TO_IDLE) {
 		LOG_DBG("Unsupported power state %u", state);
@@ -228,7 +228,7 @@ void pm_state_set(enum pm_state state, uint8_t substate_id)
 }
 
 /* Handle soc specific activity after exiting "Suspend/Low Power" mode. */
-void pm_state_exit_post_ops(enum pm_state state, uint8_t substate_id)
+__weak void pm_state_exit_post_ops(enum pm_state state, uint8_t substate_id)
 {
 	if (state != PM_STATE_SUSPEND_TO_IDLE) {
 		LOG_DBG("Unsupported power state %u", state);


### PR DESCRIPTION
This change makes PM state setting functions in SOC level weak so they can be overridden by board/app level.