### PR TITLE
soc:esp32: Add config allow MbedTLS heap and LVGL Frambuffer use SPI RAM

### DIFF
--- a/soc/espressif/common/Kconfig.spiram
+++ b/soc/espressif/common/Kconfig.spiram
@@ -149,6 +149,15 @@ config ESP_MBEDTLS_HEAP_ALLOC_SPIRAM
 	help
 	  If enable this will place mbedtls_heap into spi ram
 
+config ESP_LVGL_FRAMEBUFFER_ALLOC_SPIRAM
+	bool "Place LVGL Framebuffer into spiram"
+	depends on ESP_SPIRAM
+	depends on LV_Z_BUFFER_ALLOC_STATIC
+	select LV_Z_VDB_CUSTOM_SECTION
+	default n
+	help
+	  If enable this will place LVGL framebuffer into spi ram
+
 if SOC_SERIES_ESP32
 
 menu "PSRAM clock and cs IO for ESP32-DOWD"

--- a/soc/espressif/common/Kconfig.spiram
+++ b/soc/espressif/common/Kconfig.spiram
@@ -140,6 +140,15 @@ config SPIRAM_ECC_ENABLE
 	  Enable MSPI Error-Correcting Code function when accessing SPIRAM.
 	  If enabled, 1/16 of the SPI RAM total size will be reserved for error-correcting code.
 
+config ESP_MBEDTLS_HEAP_ALLOC_SPIRAM
+	bool "Place MbedTLS heap into spiram"
+	depends on ESP_SPIRAM
+	depends on MBEDTLS_ENABLE_HEAP
+	select MBEDTLS_HEAP_CUSTOM_SECTION
+	default n
+	help
+	  If enable this will place mbedtls_heap into spi ram
+
 if SOC_SERIES_ESP32
 
 menu "PSRAM clock and cs IO for ESP32-DOWD"

--- a/soc/espressif/esp32/default.ld
+++ b/soc/espressif/esp32/default.ld
@@ -821,7 +821,10 @@ SECTIONS
 
     . = ALIGN(16);
     _ext_ram_noinit_end = ABSOLUTE(.);
-
+#ifdef CONFIG_ESP_MBEDTLS_HEAP_ALLOC_SPIRAM
+    *(.mbedtls_heap)
+    . = ALIGN(16);
+#endif /* CONFIG_ESP_MBEDTLS_HEAP_ALLOC_SPIRAM */
     _ext_ram_bss_start = ABSOLUTE(.);
 
     *(.ext_ram.bss*)

--- a/soc/espressif/esp32/default.ld
+++ b/soc/espressif/esp32/default.ld
@@ -825,6 +825,10 @@ SECTIONS
     *(.mbedtls_heap)
     . = ALIGN(16);
 #endif /* CONFIG_ESP_MBEDTLS_HEAP_ALLOC_SPIRAM */
+#ifdef CONFIG_ESP_LVGL_FRAMEBUFFER_ALLOC_SPIRAM
+    *(.lvgl_buf)
+    . = ALIGN(16);
+#endif /* CONFIG_ESP_LVGL_FRAMEBUFFER_ALLOC_SPIRAM */
     _ext_ram_bss_start = ABSOLUTE(.);
 
     *(.ext_ram.bss*)

--- a/soc/espressif/esp32s2/default.ld
+++ b/soc/espressif/esp32s2/default.ld
@@ -803,6 +803,10 @@ SECTIONS
     *(.mbedtls_heap)
     . = ALIGN(16);
 #endif /* CONFIG_ESP_MBEDTLS_HEAP_ALLOC_SPIRAM */
+#ifdef CONFIG_ESP_LVGL_FRAMEBUFFER_ALLOC_SPIRAM
+    *(.lvgl_buf)
+    . = ALIGN(16);
+#endif /* CONFIG_ESP_LVGL_FRAMEBUFFER_ALLOC_SPIRAM */
     _ext_ram_bss_start = ABSOLUTE(.);
 
     *(.ext_ram.bss*)

--- a/soc/espressif/esp32s2/default.ld
+++ b/soc/espressif/esp32s2/default.ld
@@ -799,7 +799,10 @@ SECTIONS
 
     . = ALIGN(16);
     _ext_ram_noinit_end = ABSOLUTE(.);
-
+#ifdef CONFIG_ESP_MBEDTLS_HEAP_ALLOC_SPIRAM
+    *(.mbedtls_heap)
+    . = ALIGN(16);
+#endif /* CONFIG_ESP_MBEDTLS_HEAP_ALLOC_SPIRAM */
     _ext_ram_bss_start = ABSOLUTE(.);
 
     *(.ext_ram.bss*)

--- a/soc/espressif/esp32s3/default.ld
+++ b/soc/espressif/esp32s3/default.ld
@@ -1012,7 +1012,10 @@ SECTIONS
 #endif /* CONFIG_ESP32_WIFI_NET_ALLOC_SPIRAM */
     . = ALIGN(16);
     _ext_ram_noinit_end = ABSOLUTE(.);
-
+#ifdef CONFIG_ESP_MBEDTLS_HEAP_ALLOC_SPIRAM
+    *(.mbedtls_heap)
+    . = ALIGN(16);
+#endif /* CONFIG_ESP_MBEDTLS_HEAP_ALLOC_SPIRAM */
     _ext_ram_bss_start = ABSOLUTE(.);
     *(.ext_ram.bss*)
     . = ALIGN(16);

--- a/soc/espressif/esp32s3/default.ld
+++ b/soc/espressif/esp32s3/default.ld
@@ -1016,6 +1016,10 @@ SECTIONS
     *(.mbedtls_heap)
     . = ALIGN(16);
 #endif /* CONFIG_ESP_MBEDTLS_HEAP_ALLOC_SPIRAM */
+#ifdef CONFIG_ESP_LVGL_FRAMEBUFFER_ALLOC_SPIRAM
+    *(.lvgl_buf)
+    . = ALIGN(16);
+#endif /* CONFIG_ESP_LVGL_FRAMEBUFFER_ALLOC_SPIRAM */
     _ext_ram_bss_start = ABSOLUTE(.);
     *(.ext_ram.bss*)
     . = ALIGN(16);


### PR DESCRIPTION
Add 2 follow Config Symbol: ESP_MBEDTLS_HEAP_ALLOC_SPIRAM and ESP_LVGL_FRAMEBUFFER_ALLOC_SPIRAM to allow user place heavy-ram usage mbedtls heap and lvgl frame buffer to SPI ram.
Tested with HTTP_get sample, with TLS enable.

Have not tested with LVGL yet, i have no LCD for now. Only sure it can compile with config enable

This is a replacement PR of https://github.com/zephyrproject-rtos/zephyr/pull/85979 because somehow i messed up my git repo :(