### PR TITLE
drivers: clock_control: add on/off stubs to clock,agilex

### DIFF
--- a/drivers/serial/uart_ns16550.c
+++ b/drivers/serial/uart_ns16550.c
@@ -621,7 +621,7 @@ static int uart_ns16550_configure(const struct device *dev,
 		}
 
 		ret = clock_control_on(dev_cfg->clock_dev, dev_cfg->clock_subsys);
-		if (ret != 0 && ret != -EALREADY) {
+		if (ret != 0 && ret != -EALREADY && ret != -ENOSYS) {
 			goto out;
 		}
 

--- a/include/zephyr/drivers/clock_control.h
+++ b/include/zephyr/drivers/clock_control.h
@@ -128,6 +128,10 @@ static inline int clock_control_on(const struct device *dev,
 	const struct clock_control_driver_api *api =
 		(const struct clock_control_driver_api *)dev->api;
 
+	if (api->on == NULL) {
+		return -ENOSYS;
+	}
+
 	return api->on(dev, sys);
 }
 
@@ -146,6 +150,10 @@ static inline int clock_control_off(const struct device *dev,
 {
 	const struct clock_control_driver_api *api =
 		(const struct clock_control_driver_api *)dev->api;
+
+	if (api->off == NULL) {
+		return -ENOSYS;
+	}
 
 	return api->off(dev, sys);
 }


### PR DESCRIPTION
This PR fixes a regression caused by: 88830a3b.

Due to the stubs not being present in the clock ctrl driver, the ns16550 driver jumped to offset 0x0 when referring to `api->on`.

Fixes #86062.