### PR TITLE
cmake: reports: Fix report targets

### DIFF
--- a/cmake/reports/CMakeLists.txt
+++ b/cmake/reports/CMakeLists.txt
@@ -35,9 +35,9 @@ add_custom_target(
   )
 
 if(CONFIG_BUILD_WITH_TFM)
-  foreach(report ram_report rom_report)
+  foreach(report ram rom)
     add_custom_target(
-      tfm_${report}
+      tfm_${report}_report
       ${PYTHON_EXECUTABLE}
       ${ZEPHYR_BASE}/scripts/footprint/size_report
       -k $<TARGET_PROPERTY:tfm,TFM_S_ELF_FILE>
@@ -46,7 +46,7 @@ if(CONFIG_BUILD_WITH_TFM)
       ${workspace_arg}
       -d ${report_depth}
       --json tfm_${report}.json
-      ${flag_for_${report}}
+      ${flag_for_${report}_report}
       DEPENDS tfm
       USES_TERMINAL
       WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
@@ -60,9 +60,9 @@ if(CONFIG_BUILD_WITH_TFM)
 endif()
 
 if(CONFIG_TFM_BL2)
-  foreach(report ram_report rom_report)
+  foreach(report ram rom)
     add_custom_target(
-      bl2_${report}
+      bl2_${report}_report
       ${PYTHON_EXECUTABLE}
       ${ZEPHYR_BASE}/scripts/footprint/size_report
       -k $<TARGET_PROPERTY:tfm,BL2_ELF_FILE>
@@ -71,7 +71,7 @@ if(CONFIG_TFM_BL2)
       ${workspace_arg}
       -d ${report_depth}
       --json bl2_${report}.json
-      ${flag_for_${report}}
+      ${flag_for_${report}_report}
       DEPENDS tfm
       USES_TERMINAL
       WORKING_DIRECTORY ${CMAKE_BINARY_DIR}

--- a/cmake/reports/CMakeLists.txt
+++ b/cmake/reports/CMakeLists.txt
@@ -11,7 +11,7 @@ elseif(DEFINED WEST_TOPDIR)
   set(workspace_arg "--workspace=${WEST_TOPDIR}")
 endif()
 
-foreach(report ram_report rom_report footprint)
+foreach(report ram_report rom_report)
   add_custom_target(
     ${report}
     ${PYTHON_EXECUTABLE}
@@ -29,8 +29,13 @@ foreach(report ram_report rom_report footprint)
     )
 endforeach()
 
+add_custom_target(
+  footprint
+  DEPENDS ram_report rom_report
+  )
+
 if(CONFIG_BUILD_WITH_TFM)
-  foreach(report ram_report rom_report footprint)
+  foreach(report ram_report rom_report)
     add_custom_target(
       tfm_${report}
       ${PYTHON_EXECUTABLE}
@@ -47,10 +52,15 @@ if(CONFIG_BUILD_WITH_TFM)
       WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
       )
   endforeach()
+
+  add_custom_target(
+    tfm_footprint
+    DEPENDS tfm_ram_report tfm_rom_report
+    )
 endif()
 
 if(CONFIG_TFM_BL2)
-  foreach(report ram_report rom_report footprint)
+  foreach(report ram_report rom_report)
     add_custom_target(
       bl2_${report}
       ${PYTHON_EXECUTABLE}
@@ -67,6 +77,11 @@ if(CONFIG_TFM_BL2)
       WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
       )
   endforeach()
+
+  add_custom_target(
+    bl2_footprint
+    DEPENDS bl2_ram_report bl2_rom_report
+    )
 endif()
 
 find_program(PUNCOVER puncover)


### PR DESCRIPTION
Fixes report targets where tfm_* and bl2_* targets wrongly generates a footprint file by having a common target which consists of RAM and ROM report targets