### PR TITLE
twister: in case of samples, test on integration platforms if defined

### DIFF
--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -44,7 +44,7 @@ jobs:
       CCACHE_IGNOREOPTIONS: '-specs=* --specs=*'
       BSIM_OUT_PATH: /opt/bsim/
       BSIM_COMPONENTS_PATH: /opt/bsim/components
-      TWISTER_COMMON: '--no-detailed-test-id --force-color --inline-logs -v -N -M --retry-failed 3 --timeout-multiplier 2 '
+      TWISTER_COMMON: ' --test-config tests/test_config_ci.yaml --no-detailed-test-id --force-color --inline-logs -v -N -M --retry-failed 3 --timeout-multiplier 2 '
       WEEKLY_OPTIONS: ' -M --build-only --all --show-footprint --report-filtered'
       PR_OPTIONS: ' --clobber-output --integration'
       PUSH_OPTIONS: ' --clobber-output -M --show-footprint --report-filtered'

--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -786,11 +786,14 @@ class TestPlan:
                 if self.options.integration:
                     platform_scope = integration_platforms
                 else:
-                    # if not in integration mode, still add integration platforms to the list
+                    platform_scope = platforms
                     if not platform_filter:
-                        platform_scope = platforms + integration_platforms
-                    else:
-                        platform_scope = platforms
+                        tco = self.test_config.get('options', {})
+                        im = tco.get('integration_mode', [])
+                        if any(ts.id.startswith(i) for i in im):
+                            platform_scope = integration_platforms
+                        else:
+                            platform_scope += integration_platforms
             else:
                 platform_scope = platforms
 

--- a/scripts/schemas/twister/test-config-schema.yaml
+++ b/scripts/schemas/twister/test-config-schema.yaml
@@ -4,6 +4,15 @@
 
 type: map
 mapping:
+  "options":
+    type: map
+    required: false
+    mapping:
+      "integration_mode":
+        type: seq
+        required: false
+        sequence:
+          - type: str
   "platforms":
     type: map
     required: false

--- a/tests/test_config_ci.yaml
+++ b/tests/test_config_ci.yaml
@@ -1,0 +1,25 @@
+options:
+  integration_mode:
+    - sample.
+platforms:
+  override_default_platforms: false
+  increased_platform_scope: true
+levels:
+  - name: smoke
+    description: >
+      A plan to be used verifying basic zephyr features on hardware.
+    adds:
+      - kernel.threads.*
+      - kernel.timer.behavior
+      - arch.interrupt
+      - boards.*
+      - drivers.gpio.1pin
+      - drivers.console.uart
+      - drivers.entropy
+  - name: acceptance
+    description: >
+      More coverage
+    inherits:
+      - smoke
+    adds:
+      - kernel.*


### PR DESCRIPTION
Add option to force integration mode on a defined list of tests, for
example tests for sample that are identified with 'sample.'.

A sample per definition shall be tested on documented and supported
platforms listed in the sample documentation. Samples shall not be used
as tests to verify functionality of a feature on all available plaforms
in Zephyr.

To still allow testing on platforms not listed in the doc, and when such
platforms are covered by the provided filter, we should still be able to
build/run the tests on those platforms (not directly listed in
integration_platforms).

We detect a sample by its test identifier, i.e., it starts with 'sample.'.