### PR TITLE
STM32WB0: add RTC support

### DIFF
--- a/boards/st/nucleo_wb05kz/nucleo_wb05kz.dts
+++ b/boards/st/nucleo_wb05kz/nucleo_wb05kz.dts
@@ -67,6 +67,7 @@
 	};
 
 	aliases {
+		rtc = &rtc;
 		led0 = &blue_led_1;
 		led1 = &green_led_1;
 		led2 = &red_led_1;
@@ -103,6 +104,16 @@
 	clock-frequency = <DT_FREQ_M(64)>;
 	clksys-prescaler = <1>;
 	slow-clock = <&clk_lse>;
+};
+
+&rtc {
+	/**
+	 * STM32_SRC_LSE reflects the "slow-clock" selected on RCC node.
+	 * NO_SEL reflects STM32WB0's lack of RTC clock mux to configure.
+	 */
+	clocks = <&rcc STM32_CLOCK(APB0, 12)>,
+		<&rcc STM32_SRC_LSE NO_SEL>;
+	status = "okay";
 };
 
 &bt_hci_wb0 {

--- a/boards/st/nucleo_wb05kz/nucleo_wb05kz.yaml
+++ b/boards/st/nucleo_wb05kz/nucleo_wb05kz.yaml
@@ -16,6 +16,7 @@ supported:
   - gpio
   - i2c
   - pwm
+  - rtc
   - spi
   - bluetooth
 vendor: st

--- a/boards/st/nucleo_wb07cc/nucleo_wb07cc.dts
+++ b/boards/st/nucleo_wb07cc/nucleo_wb07cc.dts
@@ -66,6 +66,7 @@
 	};
 
 	aliases {
+		rtc = &rtc;
 		led0 = &blue_led_1;
 		led1 = &green_led_1;
 		led2 = &red_led_1;
@@ -102,6 +103,16 @@
 	clock-frequency = <DT_FREQ_M(64)>;
 	clksys-prescaler = <1>;
 	slow-clock = <&clk_lse>;
+};
+
+&rtc {
+	/**
+	 * STM32_SRC_LSE reflects the "slow-clock" selected on RCC node.
+	 * NO_SEL reflects STM32WB0's lack of RTC clock mux to configure.
+	 */
+	clocks = <&rcc STM32_CLOCK(APB0, 12)>,
+		<&rcc STM32_SRC_LSE NO_SEL>;
+	status = "okay";
 };
 
 &bt_hci_wb0 {

--- a/boards/st/nucleo_wb07cc/nucleo_wb07cc.yaml
+++ b/boards/st/nucleo_wb07cc/nucleo_wb07cc.yaml
@@ -16,6 +16,7 @@ supported:
   - gpio
   - i2c
   - pwm
+  - rtc
   - spi
   - bluetooth
 vendor: st

--- a/boards/st/nucleo_wb09ke/nucleo_wb09ke.dts
+++ b/boards/st/nucleo_wb09ke/nucleo_wb09ke.dts
@@ -67,6 +67,7 @@
 	};
 
 	aliases {
+		rtc = &rtc;
 		led0 = &blue_led_1;
 		led1 = &green_led_1;
 		led2 = &red_led_1;
@@ -103,6 +104,16 @@
 	clock-frequency = <DT_FREQ_M(64)>;
 	clksys-prescaler = <1>;
 	slow-clock = <&clk_lse>;
+};
+
+&rtc {
+	/**
+	 * STM32_SRC_LSE reflects the "slow-clock" selected on RCC node.
+	 * NO_SEL reflects STM32WB0's lack of RTC clock mux to configure.
+	 */
+	clocks = <&rcc STM32_CLOCK(APB0, 12)>,
+		<&rcc STM32_SRC_LSE NO_SEL>;
+	status = "okay";
 };
 
 &bt_hci_wb0 {

--- a/boards/st/nucleo_wb09ke/nucleo_wb09ke.yaml
+++ b/boards/st/nucleo_wb09ke/nucleo_wb09ke.yaml
@@ -16,6 +16,7 @@ supported:
   - gpio
   - i2c
   - pwm
+  - rtc
   - spi
   - bluetooth
 vendor: st

--- a/drivers/counter/Kconfig.stm32_rtc
+++ b/drivers/counter/Kconfig.stm32_rtc
@@ -7,6 +7,7 @@ menuconfig COUNTER_RTC_STM32
 	bool "STM32 Counter RTC driver"
 	default y if !RTC
 	depends on DT_HAS_ST_STM32_RTC_ENABLED
+	depends on !SOC_SERIES_STM32WB0X
 	select USE_STM32_LL_RTC
 	select USE_STM32_LL_PWR
 	select USE_STM32_LL_RCC

--- a/drivers/rtc/rtc_ll_stm32.c
+++ b/drivers/rtc/rtc_ll_stm32.c
@@ -78,7 +78,7 @@ LOG_MODULE_REGISTER(rtc_stm32, CONFIG_RTC_LOG_LEVEL);
 /* Timeout in microseconds used to wait for flags */
 #define RTC_TIMEOUT 1000000
 
-#ifdef CONFIG_RTC_ALARM
+#ifdef STM32_RTC_ALARM_ENABLED
 #define RTC_STM32_ALARMS_COUNT	DT_INST_PROP(0, alarms_count)
 
 #define RTC_STM32_ALRM_A	0U
@@ -95,7 +95,7 @@ LOG_MODULE_REGISTER(rtc_stm32, CONFIG_RTC_LOG_LEVEL);
 #else
 #define RTC_STM32_EXTI_LINE	0
 #endif /* DT_INST_NODE_HAS_PROP(0, alrm_exti_line) */
-#endif /* CONFIG_RTC_ALARM */
+#endif /* STM32_RTC_ALARM_ENABLED */
 
 #if defined(PWR_CR_DBP) || defined(PWR_CR1_DBP) || defined(PWR_DBPCR_DBP) || defined(PWR_DBPR_DBP)
 /*
@@ -120,7 +120,7 @@ struct rtc_stm32_config {
 #endif
 };
 
-#ifdef CONFIG_RTC_ALARM
+#ifdef STM32_RTC_ALARM_ENABLED
 struct rtc_stm32_alrm {
 	LL_RTC_AlarmTypeDef ll_rtc_alrm;
 	/* user-defined alarm mask, values from RTC_ALARM_TIME_MASK */
@@ -129,14 +129,14 @@ struct rtc_stm32_alrm {
 	void *user_data;
 	bool is_pending;
 };
-#endif /* CONFIG_RTC_ALARM */
+#endif /* STM32_RTC_ALARM_ENABLED */
 
 struct rtc_stm32_data {
 	struct k_mutex lock;
-#ifdef CONFIG_RTC_ALARM
+#ifdef STM32_RTC_ALARM_ENABLED
 	struct rtc_stm32_alrm rtc_alrm_a;
 	struct rtc_stm32_alrm rtc_alrm_b;
-#endif /* CONFIG_RTC_ALARM */
+#endif /* STM32_RTC_ALARM_ENABLED */
 };
 
 static int rtc_stm32_configure(const struct device *dev)
@@ -185,7 +185,7 @@ static int rtc_stm32_configure(const struct device *dev)
 	return err;
 }
 
-#ifdef CONFIG_RTC_ALARM
+#ifdef STM32_RTC_ALARM_ENABLED
 static inline ErrorStatus rtc_stm32_init_alarm(RTC_TypeDef *rtc, uint32_t format,
 					LL_RTC_AlarmTypeDef *ll_alarm_struct, uint16_t id)
 {
@@ -329,7 +329,7 @@ static void rtc_stm32_irq_config(const struct device *dev)
 		    rtc_stm32_isr, DEVICE_DT_INST_GET(0), 0);
 	irq_enable(DT_INST_IRQN(0));
 }
-#endif /* CONFIG_RTC_ALARM */
+#endif /* STM32_RTC_ALARM_ENABLED */
 
 static int rtc_stm32_init(const struct device *dev)
 {
@@ -421,7 +421,7 @@ static int rtc_stm32_init(const struct device *dev)
 	LL_PWR_DisableBkUpAccess();
 #endif /* RTC_STM32_BACKUP_DOMAIN_WRITE_PROTECTION */
 
-#ifdef CONFIG_RTC_ALARM
+#ifdef STM32_RTC_ALARM_ENABLED
 	rtc_stm32_irq_config(dev);
 
 	ll_func_exti_enable_rtc_alarm_it(RTC_STM32_EXTI_LINE);
@@ -430,7 +430,7 @@ static int rtc_stm32_init(const struct device *dev)
 	memset(&(data->rtc_alrm_a), 0, sizeof(struct rtc_stm32_alrm));
 	memset(&(data->rtc_alrm_b), 0, sizeof(struct rtc_stm32_alrm));
 	k_mutex_unlock(&data->lock);
-#endif /* CONFIG_RTC_ALARM */
+#endif /* STM32_RTC_ALARM_ENABLED */
 
 	return err;
 }
@@ -600,7 +600,7 @@ static int rtc_stm32_get_time(const struct device *dev, struct rtc_time *timeptr
 	return 0;
 }
 
-#ifdef CONFIG_RTC_ALARM
+#ifdef STM32_RTC_ALARM_ENABLED
 static void rtc_stm32_init_ll_alrm_struct(LL_RTC_AlarmTypeDef *p_rtc_alarm,
 					const struct rtc_time *timeptr, uint16_t mask)
 {
@@ -995,7 +995,7 @@ unlock:
 	k_mutex_unlock(&data->lock);
 	return ret;
 }
-#endif /* CONFIG_RTC_ALARM */
+#endif /* STM32_RTC_ALARM_ENABLED */
 
 #ifdef CONFIG_RTC_CALIBRATION
 #if !defined(CONFIG_SOC_SERIES_STM32F2X) && \
@@ -1078,13 +1078,13 @@ static int rtc_stm32_get_calibration(const struct device *dev, int32_t *calibrat
 static DEVICE_API(rtc, rtc_stm32_driver_api) = {
 	.set_time = rtc_stm32_set_time,
 	.get_time = rtc_stm32_get_time,
-#ifdef CONFIG_RTC_ALARM
+#ifdef STM32_RTC_ALARM_ENABLED
 	.alarm_get_supported_fields = rtc_stm32_alarm_get_supported_fields,
 	.alarm_set_time = rtc_stm32_alarm_set_time,
 	.alarm_get_time = rtc_stm32_alarm_get_time,
 	.alarm_set_callback = rtc_stm32_alarm_set_callback,
 	.alarm_is_pending = rtc_stm32_alarm_is_pending,
-#endif /* CONFIG_RTC_ALARM */
+#endif /* STM32_RTC_ALARM_ENABLED */
 #ifdef CONFIG_RTC_CALIBRATION
 #if !defined(CONFIG_SOC_SERIES_STM32F2X) && \
 	!(defined(CONFIG_SOC_SERIES_STM32L1X) && !defined(RTC_SMOOTHCALIB_SUPPORT))

--- a/drivers/rtc/rtc_ll_stm32.h
+++ b/drivers/rtc/rtc_ll_stm32.h
@@ -7,7 +7,23 @@
 #ifndef ZEPHYR_DRIVERS_RTC_RTC_LL_STM32_H_
 #define ZEPHYR_DRIVERS_RTC_RTC_LL_STM32_H_
 
-#ifdef CONFIG_RTC_ALARM
+/**
+ * ES0584 / ES0631 §2.5.2; ES0632 §2.6.2 (both Rev. 2)
+ * """
+ * RTC interrupts cannot be reliably used for real-time
+ * control functions, since some occurences of RTC
+ * interrupts may be missed.
+ * """
+ * Since alarm IRQs are unreliable, don't allow RTC alarm
+ * to be used on STM32WB0 series. For this, we have to
+ * create a #define only valid when both the Kconfig is
+ * enabled, and we're on a supported series. This must
+ * be done because the RTC driver has to build properly
+ * on all targets regardless of which Kconfig options have
+ * been enabled.
+ */
+#if defined(CONFIG_RTC_ALARM) && !defined(CONFIG_SOC_SERIES_STM32WB0X)
+#define STM32_RTC_ALARM_ENABLED	1
 
 /* STM32 RTC alarms, A & B, LL masks are equal */
 #define RTC_STM32_ALRM_MASK_ALL		LL_RTC_ALMA_MASK_ALL
@@ -44,6 +60,6 @@ static inline void ll_func_exti_clear_rtc_alarm_flag(uint32_t exti_line)
 	LL_EXTI_ClearFlag_0_31(exti_line);
 #endif /* CONFIG_SOC_SERIES_STM32H7X and CONFIG_CPU_CORTEX_M4 */
 }
-#endif /* CONFIG_RTC_ALARM */
+#endif /* CONFIG_RTC_ALARM && !CONFIG_SOC_SERIES_STM32WB0X */
 
 #endif	/* ZEPHYR_DRIVERS_RTC_RTC_LL_STM32_H_ */

--- a/dts/arm/st/wb0/stm32wb0.dtsi
+++ b/dts/arm/st/wb0/stm32wb0.dtsi
@@ -178,6 +178,14 @@
 			};
 		};
 
+		rtc: rtc@40004000 {
+			compatible = "st,stm32-rtc";
+			reg = <0x40004000 DT_SIZE_K(1)>;
+			interrupts = <11 0>;
+			clocks = <&rcc STM32_CLOCK(APB0, 12)>;
+			status = "disabled";
+		};
+
 		usart1: serial@41004000 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x41004000 DT_SIZE_K(1)>;


### PR DESCRIPTION
Add support for STM32WB0 series in the STM32 RTC driver, and enable it on all three WB0 boards currently supported in Zephyr. Only the real-time clock feature is supported - alarms are not supported due to `RTC interrupt not triggered in Run mode` erratum.

Tested OK using `samples/drivers/rtc/`.