### PR TITLE
STM32: Add Ethernet PHY mode and speed macros and update DTS requirements

### DIFF
--- a/boards/arduino/opta/arduino_opta_stm32h747xx_m7.dts
+++ b/boards/arduino/opta/arduino_opta_stm32h747xx_m7.dts
@@ -107,6 +107,7 @@ zephyr_udc0: &usbotg_fs {
 		&eth_txd0_pg13
 	>;
 	pinctrl-names = "default";
+	phy-connection-type = "rmii";
 	status = "okay";
 };
 

--- a/boards/arduino/portenta_h7/arduino_portenta_h7-common.dtsi
+++ b/boards/arduino/portenta_h7/arduino_portenta_h7-common.dtsi
@@ -222,6 +222,7 @@
 		      &eth_txd1_pg12
 		      &eth_txd0_pg13 >;
 	pinctrl-names = "default";
+	phy-connection-type = "rmii";
 	status = "okay";
 };
 

--- a/boards/olimex/stm32_e407/olimex_stm32_e407.dts
+++ b/boards/olimex/stm32_e407/olimex_stm32_e407.dts
@@ -127,4 +127,5 @@ zephyr_udc0: &usbotg_hs {
 		     &eth_txd0_pg13
 		     &eth_txd1_pg14>;
 	pinctrl-names = "default";
+	phy-connection-type = "rmii";
 };

--- a/boards/st/nucleo_f207zg/nucleo_f207zg.dts
+++ b/boards/st/nucleo_f207zg/nucleo_f207zg.dts
@@ -189,6 +189,7 @@ zephyr_udc0: &usbotg_fs {
 		     &eth_txd0_pg13
 		     &eth_txd1_pb13>;
 	pinctrl-names = "default";
+	phy-connection-type = "rmii";
 };
 
 &flash0 {

--- a/boards/st/nucleo_f429zi/nucleo_f429zi.dts
+++ b/boards/st/nucleo_f429zi/nucleo_f429zi.dts
@@ -186,6 +186,7 @@ zephyr_udc0: &usbotg_fs {
 		     &eth_txd0_pg13
 		     &eth_txd1_pb13>;
 	pinctrl-names = "default";
+	phy-connection-type = "rmii";
 };
 
 &flash0 {

--- a/boards/st/nucleo_f746zg/nucleo_f746zg.dts
+++ b/boards/st/nucleo_f746zg/nucleo_f746zg.dts
@@ -207,6 +207,7 @@ zephyr_udc0: &usbotg_fs {
 		     &eth_txd0_pg13
 		     &eth_txd1_pb13>;
 	pinctrl-names = "default";
+	phy-connection-type = "rmii";
 };
 
 &backup_sram {

--- a/boards/st/nucleo_f756zg/nucleo_f756zg.dts
+++ b/boards/st/nucleo_f756zg/nucleo_f756zg.dts
@@ -151,6 +151,7 @@ zephyr_udc0: &usbotg_fs {
 		     &eth_txd0_pg13
 		     &eth_txd1_pb13>;
 	pinctrl-names = "default";
+	phy-connection-type = "rmii";
 };
 
 &flash0 {

--- a/boards/st/nucleo_f767zi/nucleo_f767zi.dts
+++ b/boards/st/nucleo_f767zi/nucleo_f767zi.dts
@@ -198,6 +198,7 @@ zephyr_udc0: &usbotg_fs {
 		     &eth_txd0_pg13
 		     &eth_txd1_pb13>;
 	pinctrl-names = "default";
+	phy-connection-type = "rmii";
 };
 
 &flash0 {

--- a/boards/st/nucleo_h563zi/nucleo_h563zi.dts
+++ b/boards/st/nucleo_h563zi/nucleo_h563zi.dts
@@ -49,6 +49,7 @@
 		     &eth_txd0_pg13
 		     &eth_txd1_pb15>;
 	pinctrl-names = "default";
+	phy-connection-type = "rmii";
 };
 
 &mdio {

--- a/boards/st/nucleo_h723zg/nucleo_h723zg.dts
+++ b/boards/st/nucleo_h723zg/nucleo_h723zg.dts
@@ -178,6 +178,7 @@
 		     &eth_txd0_pg13
 		     &eth_txd1_pb13>;
 	pinctrl-names = "default";
+	phy-connection-type = "rmii";
 };
 
 &mdio {

--- a/boards/st/nucleo_h743zi/nucleo_h743zi.dts
+++ b/boards/st/nucleo_h743zi/nucleo_h743zi.dts
@@ -203,6 +203,7 @@ zephyr_udc0: &usbotg_fs {
 		     &eth_txd0_pg13
 		     &eth_txd1_pb13>;
 	pinctrl-names = "default";
+	phy-connection-type = "rmii";
 };
 
 &mdio {

--- a/boards/st/nucleo_h745zi_q/nucleo_h745zi_q_stm32h745xx_m7.dts
+++ b/boards/st/nucleo_h745zi_q/nucleo_h745zi_q_stm32h745xx_m7.dts
@@ -115,6 +115,7 @@
 		     &eth_txd0_pg13
 		     &eth_txd1_pb13>;
 	pinctrl-names = "default";
+	phy-connection-type = "rmii";
 };
 
 &mdio {

--- a/boards/st/nucleo_h753zi/nucleo_h753zi.dts
+++ b/boards/st/nucleo_h753zi/nucleo_h753zi.dts
@@ -182,6 +182,7 @@ zephyr_udc0: &usbotg_fs {
 		     &eth_txd0_pg13
 		     &eth_txd1_pb13>;
 	pinctrl-names = "default";
+	phy-connection-type = "rmii";
 };
 
 &mdio {

--- a/boards/st/nucleo_h755zi_q/nucleo_h755zi_q_stm32h755xx_m7.dts
+++ b/boards/st/nucleo_h755zi_q/nucleo_h755zi_q_stm32h755xx_m7.dts
@@ -114,6 +114,7 @@
 		     &eth_txd0_pg13
 		     &eth_txd1_pb13>;
 	pinctrl-names = "default";
+	phy-connection-type = "rmii";
 };
 
 &mdio {

--- a/boards/st/stm32f746g_disco/stm32f746g_disco.dts
+++ b/boards/st/stm32f746g_disco/stm32f746g_disco.dts
@@ -178,6 +178,7 @@ zephyr_udc0: &usbotg_fs {
 		     &eth_txd0_pg13
 		     &eth_txd1_pg14>;
 	pinctrl-names = "default";
+	phy-connection-type = "rmii";
 };
 
 &quadspi {

--- a/boards/st/stm32f7508_dk/stm32f7508_dk.dts
+++ b/boards/st/stm32f7508_dk/stm32f7508_dk.dts
@@ -174,6 +174,7 @@ zephyr_udc0: &usbotg_fs {
 		     &eth_txd0_pg13
 		     &eth_txd1_pg14>;
 	pinctrl-names = "default";
+	phy-connection-type = "rmii";
 };
 
 &quadspi {

--- a/boards/st/stm32f769i_disco/stm32f769i_disco.dts
+++ b/boards/st/stm32f769i_disco/stm32f769i_disco.dts
@@ -161,6 +161,7 @@ arduino_serial: &usart6 {};
 		     &eth_txd0_pg13
 		     &eth_txd1_pg14>;
 	pinctrl-names = "default";
+	phy-connection-type = "rmii";
 };
 
 &sdmmc2 {

--- a/boards/st/stm32h573i_dk/stm32h573i_dk.dts
+++ b/boards/st/stm32h573i_dk/stm32h573i_dk.dts
@@ -166,6 +166,7 @@
 		     &eth_txd0_pg13
 		     &eth_txd1_pg12>;
 	pinctrl-names = "default";
+	phy-connection-type = "rmii";
 };
 
 &mdio {

--- a/boards/st/stm32h735g_disco/stm32h735g_disco.dts
+++ b/boards/st/stm32h735g_disco/stm32h735g_disco.dts
@@ -138,6 +138,7 @@
 		     &eth_txd0_pb12
 		     &eth_txd1_pb13>;
 	pinctrl-names = "default";
+	phy-connection-type = "rmii";
 	status = "okay";
 };
 

--- a/boards/st/stm32h745i_disco/Kconfig.defconfig
+++ b/boards/st/stm32h745i_disco/Kconfig.defconfig
@@ -11,9 +11,6 @@ if NETWORKING
 config NET_L2_ETHERNET
 	default y
 
-config ETH_STM32_HAL_MII
-	default y
-
 # STM32H745I-DISCO have PHY connected to address 1
 config ETH_STM32_HAL_PHY_ADDRESS
 	default 1

--- a/boards/st/stm32h745i_disco/stm32h745i_disco_stm32h745xx_m7.dts
+++ b/boards/st/stm32h745i_disco/stm32h745i_disco_stm32h745xx_m7.dts
@@ -144,6 +144,7 @@
 		     &eth_txd0_pg13
 		     &eth_rx_er_pi10>;
 	pinctrl-names = "default";
+	phy-connection-type = "mii";
 };
 
 &mdio {

--- a/boards/st/stm32h747i_disco/stm32h747i_disco_stm32h747xx_m7.dts
+++ b/boards/st/stm32h747i_disco/stm32h747i_disco_stm32h747xx_m7.dts
@@ -144,6 +144,7 @@
 		     &eth_txd0_pg13
 		     &eth_txd1_pg12>;
 	pinctrl-names = "default";
+	phy-connection-type = "rmii";
 };
 
 &mdio {

--- a/boards/witte/linum/linum.dts
+++ b/boards/witte/linum/linum.dts
@@ -238,6 +238,7 @@ zephyr_udc0: &usbotg_fs {
 		     &eth_txd0_pg13
 		     &eth_txd1_pg14>;
 	pinctrl-names = "default";
+	phy-connection-type = "rmii";
 };
 
 &mdio {

--- a/doc/releases/migration-guide-4.2.rst
+++ b/doc/releases/migration-guide-4.2.rst
@@ -32,6 +32,9 @@ Boards
 Device Drivers and Devicetree
 *****************************
 
+* Removed Kconfig option ``ETH_STM32_HAL_MII`` (:github:`86074`).
+  PHY interface type is now selected via the ``phy-connection-type`` property in the device tree.
+
 Bluetooth
 *********
 

--- a/drivers/ethernet/Kconfig.stm32_hal
+++ b/drivers/ethernet/Kconfig.stm32_hal
@@ -70,11 +70,6 @@ config ETH_STM32_HAL_PHY_ADDRESS
 	help
 	  The phy address to use.
 
-config ETH_STM32_HAL_MII
-	bool "Use MII interface"
-	help
-	  Use the MII physical interface instead of RMII.
-
 config ETH_STM32_CARRIER_CHECK_RX_IDLE_TIMEOUT_MS
 	int "Carrier check timeout period (ms)"
 	default 500

--- a/drivers/ethernet/eth_stm32_hal.c
+++ b/drivers/ethernet/eth_stm32_hal.c
@@ -88,6 +88,12 @@ static const struct device *eth_stm32_phy_dev = DEVICE_PHY_BY_NAME(0);
 
 #endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_ethernet) */
 
+#define MAC_NODE DT_NODELABEL(mac)
+
+#define STM32_ETH_PHY_MODE(node_id) \
+	(DT_ENUM_HAS_VALUE(node_id, phy_connection_type, mii) ? \
+		ETH_MEDIA_INTERFACE_MII : ETH_MEDIA_INTERFACE_RMII)
+
 #define ETH_DMA_TX_TIMEOUT_MS	20U  /* transmit timeout in milliseconds */
 
 #if defined(CONFIG_ETH_STM32_HAL_USE_DTCM_FOR_DMA_BUFFER) && \
@@ -1311,6 +1317,10 @@ static const struct eth_stm32_hal_dev_cfg eth0_config = {
 	.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(0),
 };
 
+BUILD_ASSERT(DT_ENUM_HAS_VALUE(MAC_NODE, phy_connection_type, mii) ||
+	     DT_ENUM_HAS_VALUE(MAC_NODE, phy_connection_type, rmii),
+	     "Unsupported PHY connection type selected");
+
 static struct eth_stm32_hal_dev_data eth0_data = {
 	.heth = {
 		.Instance = (ETH_TypeDef *)DT_INST_REG_ADDR(0),
@@ -1330,8 +1340,7 @@ static struct eth_stm32_hal_dev_data eth0_data = {
 			.ChecksumMode = IS_ENABLED(CONFIG_ETH_STM32_HW_CHECKSUM) ?
 					ETH_CHECKSUM_BY_HARDWARE : ETH_CHECKSUM_BY_SOFTWARE,
 #endif /* !CONFIG_SOC_SERIES_STM32H7X */
-			.MediaInterface = IS_ENABLED(CONFIG_ETH_STM32_HAL_MII) ?
-					  ETH_MEDIA_INTERFACE_MII : ETH_MEDIA_INTERFACE_RMII,
+			.MediaInterface = STM32_ETH_PHY_MODE(MAC_NODE),
 		},
 	},
 };

--- a/dts/bindings/ethernet/st,stm32-ethernet-common.yaml
+++ b/dts/bindings/ethernet/st,stm32-ethernet-common.yaml
@@ -18,3 +18,5 @@ properties:
     required: true
   pinctrl-names:
     required: true
+  phy-connection-type:
+    required: true


### PR DESCRIPTION
- Added required property for phy-connection-type in the DTS .
- Updated the DTS file to include phy-connection-type with a default value of "rmii".
- Added MAC_NODE definition for easier reference to the MAC node.
- Simplified the STM32_ETH_PHY_MODE macro by removing redundant checks for RMII.
- The macro now defaults to ETH_MEDIA_INTERFACE_RMII if the phy_connection_type is not MII.
- Simplified the STM32_ETH_SPEED macro to always return ETH_SPEED_100M.
- Updated the eth_initialize function to use the STM32_ETH_SPEED macro for setting the speed.
- Updated the eth0_data initialization to use the STM32_ETH_PHY_MODE macro for setting the media interface.
- Updated migration guide 4.2 for STM32 HAL Ethernet changes


This change improves code readability and maintainability by reducing redundancy and simplifying the logic. It also ensures that the phy-connection-type is explicitly defined in the DTS file.