### PR TITLE
iar: toolchain: enable VLA for IAR

### DIFF
--- a/cmake/compiler/iar/target.cmake
+++ b/cmake/compiler/iar/target.cmake
@@ -81,6 +81,11 @@ if("${IAR_TOOLCHAIN_VARIANT}" STREQUAL "iccarm")
   )
 endif()
 
+# Enable VLA if CONFIG_MISRA_SANE is not set and warnings are not enabled.
+if(NOT CONFIG_MISRA_SANE AND NOT DEFINED W)
+  list(APPEND IAR_COMMON_FLAGS --vla)
+endif()
+
 # Minimal ASM compiler flags
 if("${IAR_TOOLCHAIN_VARIANT}" STREQUAL "iccarm")
   list(APPEND IAR_ASM_FLAGS

--- a/cmake/toolchain/iar/Kconfig.defconfig
+++ b/cmake/toolchain/iar/Kconfig.defconfig
@@ -3,9 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-config MISRA_SANE
-	default y
-
 config PICOLIBC_SUPPORTED
 	default n
 


### PR DESCRIPTION
Currently some subsystems outside the zephyr kernel use VLA:s such as bluetooth. We will enable it for now in the same kind of situations as gcc.

This is a small part of 
- https://github.com/zephyrproject-rtos/zephyr/pull/86002

that IAR would like to have for 4.1 since it fixes the bluetooth subsystem.

@LoveKarlsson @fabiobaltieri 