### PR TITLE
modules: hal_nordic: update version to include USBREG fix

### DIFF
--- a/drivers/usb/device/usb_dc_nrfx.c
+++ b/drivers/usb/device/usb_dc_nrfx.c
@@ -1892,7 +1892,6 @@ static int usb_init(void)
 	IRQ_CONNECT(USBREGULATOR_IRQn,
 		    DT_IRQ(DT_INST(0, nordic_nrf_clock), priority),
 		    nrfx_isr, nrfx_usbreg_irq_handler, 0);
-	irq_enable(USBREGULATOR_IRQn);
 #endif
 
 	static const nrfx_power_config_t power_config = {

--- a/drivers/usb/udc/udc_nrf.c
+++ b/drivers/usb/udc/udc_nrf.c
@@ -815,7 +815,6 @@ static int udc_nrf_init(const struct device *dev)
 	IRQ_CONNECT(USBREGULATOR_IRQn,
 		    DT_IRQ(DT_INST(0, nordic_nrf_clock), priority),
 		    nrfx_isr, nrfx_usbreg_irq_handler, 0);
-	irq_enable(USBREGULATOR_IRQn);
 #endif
 
 	IRQ_CONNECT(DT_INST_IRQN(0), DT_INST_IRQ(0, priority),
@@ -836,9 +835,6 @@ static int udc_nrf_shutdown(const struct device *dev)
 
 	nrfx_power_usbevt_disable();
 	nrfx_power_usbevt_uninit();
-#ifdef CONFIG_HAS_HW_NRF_USBREG
-	irq_disable(USBREGULATOR_IRQn);
-#endif
 
 	return 0;
 }

--- a/west.yml
+++ b/west.yml
@@ -193,7 +193,7 @@ manifest:
       groups:
         - hal
     - name: hal_nordic
-      revision: 1e1048562ff98563d492c8dcab1ee85775547abc
+      revision: 37ca068d7b013fb65a2acc9306bffa48a3e72839
       path: modules/hal/nordic
       groups:
         - hal


### PR DESCRIPTION
Update version to include USBREG HAL driver fix.

Do not enabled nRF USBREG interrupt.The drivers still use the USBREG HAL driver which enables/disables the interrupt by itself.

Fixes: #84661 (ASSERTION FAIL [m_drv_state == NRFX_DRV_STATE_POWERED_ON])