### PR TITLE
lwm2m: Do not enforce canonical CBOR deconding

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_rw_cbor.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rw_cbor.c
@@ -237,6 +237,8 @@ static int get_s64(struct lwm2m_input_context *in, int64_t *value)
 {
 	ZCBOR_STATE_D(states, 0, ICTX_BUF_R_PTR(in), ICTX_BUF_R_LEFT_SZ(in),  1, 0);
 
+	states->constant_state->enforce_canonical = false;
+
 	if (!zcbor_int64_decode(states, value)) {
 		LOG_WRN("unable to decode a 64-bit integer value");
 		return -EBADMSG;
@@ -252,6 +254,8 @@ static int get_s64(struct lwm2m_input_context *in, int64_t *value)
 static int get_s32(struct lwm2m_input_context *in, int32_t *value)
 {
 	ZCBOR_STATE_D(states, 0, ICTX_BUF_R_PTR(in), ICTX_BUF_R_LEFT_SZ(in),  1, 0);
+
+	states->constant_state->enforce_canonical = false;
 
 	if (!zcbor_int32_decode(states, value)) {
 		LOG_WRN("unable to decode a 32-bit integer value, err: %d",
@@ -269,6 +273,8 @@ static int get_s32(struct lwm2m_input_context *in, int32_t *value)
 static int get_float(struct lwm2m_input_context *in, double *value)
 {
 	ZCBOR_STATE_D(states, 0, ICTX_BUF_R_PTR(in), ICTX_BUF_R_LEFT_SZ(in),  1, 0);
+
+	states->constant_state->enforce_canonical = false;
 
 	if (!zcbor_float_decode(states, value)) {
 		LOG_ERR("unable to decode a floating-point value");
@@ -288,6 +294,8 @@ static int get_string(struct lwm2m_input_context *in, uint8_t *value, size_t buf
 	int len;
 
 	ZCBOR_STATE_D(states, 0, ICTX_BUF_R_PTR(in), ICTX_BUF_R_LEFT_SZ(in),  1, 0);
+
+	states->constant_state->enforce_canonical = false;
 
 	if (!zcbor_tstr_decode(states, &hndl)) {
 		LOG_WRN("unable to decode a string");
@@ -318,6 +326,8 @@ static int get_time_string(struct lwm2m_input_context *in, int64_t *value)
 
 	ZCBOR_STATE_D(states, 0, ICTX_BUF_R_PTR(in), ICTX_BUF_R_LEFT_SZ(in),  1, 0);
 
+	states->constant_state->enforce_canonical = false;
+
 	if (!zcbor_tstr_decode(states, &hndl)) {
 		return -EBADMSG;
 	}
@@ -335,6 +345,8 @@ static int get_time_string(struct lwm2m_input_context *in, int64_t *value)
 static int get_time_numerical(struct lwm2m_input_context *in, int64_t *value)
 {
 	ZCBOR_STATE_D(states, 0, ICTX_BUF_R_PTR(in), ICTX_BUF_R_LEFT_SZ(in),  1, 0);
+
+	states->constant_state->enforce_canonical = false;
 
 	if (!zcbor_int64_decode(states, value)) {
 		LOG_WRN("unable to decode seconds since Epoch");
@@ -354,6 +366,8 @@ static int get_time(struct lwm2m_input_context *in, time_t *value)
 	int64_t temp64;
 
 	ZCBOR_STATE_D(states, 0, ICTX_BUF_R_PTR(in), ICTX_BUF_R_LEFT_SZ(in),  1, 0);
+
+	states->constant_state->enforce_canonical = false;
 
 	success = zcbor_tag_decode(states, &tag);
 
@@ -405,6 +419,8 @@ static int get_bool(struct lwm2m_input_context *in, bool *value)
 {
 	ZCBOR_STATE_D(states, 0, ICTX_BUF_R_PTR(in), ICTX_BUF_R_LEFT_SZ(in),  1, 0);
 
+	states->constant_state->enforce_canonical = false;
+
 	if (!zcbor_bool_decode(states, value)) {
 		LOG_WRN("unable to decode a boolean value");
 		return -EBADMSG;
@@ -424,6 +440,8 @@ static int get_opaque(struct lwm2m_input_context *in, uint8_t *value, size_t buf
 	int ret;
 
 	ZCBOR_STATE_D(states, 1, ICTX_BUF_R_PTR(in), ICTX_BUF_R_LEFT_SZ(in),  1, 0);
+
+	states->constant_state->enforce_canonical = false;
 
 	/* Get the CBOR header only on first read. */
 	if (opaque->offset == 0) {

--- a/subsys/net/lib/lwm2m/lwm2m_senml_cbor_decode.c
+++ b/subsys/net/lib/lwm2m/lwm2m_senml_cbor_decode.c
@@ -212,6 +212,8 @@ static bool decode_lwm2m_senml(zcbor_state_t *state, struct lwm2m_senml *result)
 {
 	zcbor_log("%s\r\n", __func__);
 
+	state->constant_state->enforce_canonical = false;
+
 	bool res =
 		(((zcbor_list_start_decode(state) &&
 		   ((zcbor_multi_decode(


### PR DESCRIPTION
When receiving CBOR encoded data, we do not need to enforce canonical decoding.

See: https://github.com/zephyrproject-rtos/zephyr/pull/82318/files
