### PR TITLE
Fix misspellings of brief in doxygen

### DIFF
--- a/drivers/i3c/i3c_mcux.c
+++ b/drivers/i3c/i3c_mcux.c
@@ -198,7 +198,7 @@ static inline bool reg32_test(volatile uint32_t *reg, uint32_t mask)
 }
 
 /**
- * @breif Disable all interrupts.
+ * @brief Disable all interrupts.
  *
  * @param base Pointer to controller registers.
  *

--- a/tests/bluetooth/controller/ctrl_isoal/src/sub_sets/isoal_test_rx.c
+++ b/tests/bluetooth/controller/ctrl_isoal/src/sub_sets/isoal_test_rx.c
@@ -353,7 +353,7 @@ static uint32_t get_next_time_offset(uint32_t time_offset,
 }
 
 /**
- * @breif Wrapper to test time wrapping
+ * @brief Wrapper to test time wrapping
  * @param  time_now  Current time value
  * @param  time_diff Time difference (signed)
  * @return           Wrapped time after difference


### PR DESCRIPTION
fixes misspellings of the `brief` Doxygen clause in a couple files.