### PR TITLE
Add nrf twis device driver support to release notes

### DIFF
--- a/doc/releases/release-notes-4.1.rst
+++ b/doc/releases/release-notes-4.1.rst
@@ -544,6 +544,7 @@ New Drivers
 
 * :abbr:`I2C (Inter-Integrated Circuit)`
 
+   * :dtcompatible:`nordic,nrf-twis`
    * :dtcompatible:`nxp,ii2c`
    * :dtcompatible:`ti,omap-i2c`
    * :dtcompatible:`ti,tca9544a`


### PR DESCRIPTION
Note added nrf twis (i2c device role peripheral) device driver support