### PR TITLE
tests: posix: override qemu_x86_tiny by label

### DIFF
--- a/tests/posix/common/boards/qemu_x86_tiny.overlay
+++ b/tests/posix/common/boards/qemu_x86_tiny.overlay
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/ {
-	dram0: memory@0 {
-		reg = <0x100000 0x80000>;
-	};
+&dram0 {
+	reg = <0x100000 0x80000>;
 };


### PR DESCRIPTION
This changes the board override to track the nodelabel rather than the absolute node path, which happened to have changed in 0edc89c63bf breaking the test.

Verified with:

west build -p -b qemu_x86_tiny/atom tests/posix/common -T \ portability.posix.common.userspace