### PR TITLE
samples: drivers: i2c: rtio_loopback: change harness to console

### DIFF
--- a/samples/drivers/i2c/rtio_loopback/sample.yaml
+++ b/samples/drivers/i2c/rtio_loopback/sample.yaml
@@ -5,9 +5,12 @@ tests:
     tags:
       - rtio
       - i2c_target
-    harness: ztest
+    harness: console
     harness_config:
       fixture: i2c_bus_short
+      type: one_line
+      regex:
+        - "sample complete"
     platform_allow:
       - b_u585i_iot02a
       - nrf5340dk/nrf5340/cpuapp


### PR DESCRIPTION
The harness was set to ztest, but the sample requires the console harness to match on the "sample complete" line, its not actually using ztest.