### PR TITLE
scripts: west_commands: runners: fix west flash ignoring --no-reset

### DIFF
--- a/scripts/west_commands/run_common.py
+++ b/scripts/west_commands/run_common.py
@@ -416,7 +416,7 @@ def do_run_common_image(command, user_args, user_runner_args, used_cmds,
     # reset or not. If this is not specified in the board/soc file, leave it up to
     # the runner's default configuration to decide if a reset should occur.
     if runner_cls.capabilities().reset:
-        if board_image_count is not None:
+        if board_image_count is not None and board_image_count != defaultdict(ImagesFlashed):
             reset = True
 
             for cmd in used_cmds:


### PR DESCRIPTION
This modifies a line in run_common.py initially added to allow for a deferred reset when there are multiple images per board (introduced in a0267d2). This line was causing the `--reset` flag to be added as an argument even when the user may wish to provide the `--no-reset` flag. This would cause runners using the reset capability to always set `reset=True` even when not intended.

This was tested for the runner `stm32flash` which makes use of the reset runner capability.