### PR TITLE
drivers: sensor: scd4x: fix int overflow on val2 for temp and hum

### DIFF
--- a/drivers/sensor/sensirion/scd4x/scd4x.c
+++ b/drivers/sensor/sensirion/scd4x/scd4x.c
@@ -630,7 +630,7 @@ static int scd4x_channel_get(const struct device *dev, enum sensor_channel chan,
 			     struct sensor_value *val)
 {
 	const struct scd4x_data *data = dev->data;
-	int32_t tmp_val;
+	int64_t tmp_val;
 
 	switch ((enum sensor_channel)chan) {
 	case SENSOR_CHAN_AMBIENT_TEMP:


### PR DESCRIPTION
The scd4x_channel_get function converts raw word values to struct sensor_value's per the datasheet. The calulation for val2 of a struct sensor_value `val->val2 = ((tmp_val % 0xFFFF) * 1000000) / 0xFFFF;` can overflow the max of int32_t, resulting in an incorrect sensor_value.
Fix it by changing the type of tmp_val to int64_t.