### PR TITLE
scripts: requirements-compliance.txt: fix windows requirements

### DIFF
--- a/scripts/requirements-compliance.txt
+++ b/scripts/requirements-compliance.txt
@@ -8,8 +8,8 @@ junitparser>=2
 lxml
 pykwalify
 pylint>=3
-python-magic
 python-magic-bin; sys_platform == "win32"
+python-magic; sys_platform != "win32"
 ruff==0.8.1
 sphinx-lint
 unidiff


### PR DESCRIPTION
Modify the requirements-compliance.txt to exclude python-magic from windows system installation. On windows, the line: ""python-magic-bin; sys_platform == "win32""" already exists. Adding: python-magic on windows creates issues where the check_compliance.py script will either freeze or throw errors related to libmagic.