### PR TITLE
llext: Add option to garbage-collect unused syms

### DIFF
--- a/cmake/compiler/gcc/target.cmake
+++ b/cmake/compiler/gcc/target.cmake
@@ -138,3 +138,19 @@ list(APPEND CMAKE_REQUIRED_FLAGS
   -Wl,--entry=0 # Set an entry point to avoid a warning
   )
 string(REPLACE ";" " " CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS}")
+
+
+# otherwise, unexported symbols would be kept
+set(LLEXT_SYMBOL_GC_COMPILE_FLAGS
+  -fvisibility=hidden
+)
+
+# remove code/data sections that only contain unreferenced symbols
+# use sections with explicitly exported symbols (default visibility) as root
+# the linker script merges the function/data sections, as zephyr cannot currently handle
+# multiple sections
+set(LLEXT_SYMBOL_GC_LINK_FLAGS
+  -Wl,--gc-sections
+  -Wl,--gc-keep-exported
+  -T ${ZEPHYR_BASE}/subsys/llext/llext.ld
+)

--- a/cmake/compiler/gcc/target_arc.cmake
+++ b/cmake/compiler/gcc/target_arc.cmake
@@ -13,10 +13,16 @@ endif()
 set(LLEXT_REMOVE_FLAGS
   -fno-pic
   -fno-pie
-  -ffunction-sections
-  -fdata-sections
   -Os
 )
+
+if(NOT DEFINED(CONFIG_LLEXT_SYMBOL_GC))
+  list(APPEND LLEXT_REMOVE_FLAGS
+    -ffunction-sections
+    -fdata-sections
+  )
+endif()
+
 
 set(LLEXT_APPEND_FLAGS
   -mcpu=${GCC_ARC_TUNED_CPU} # Force compiler and linker match

--- a/cmake/compiler/gcc/target_arm.cmake
+++ b/cmake/compiler/gcc/target_arm.cmake
@@ -52,10 +52,15 @@ list(APPEND TOOLCHAIN_LD_FLAGS NO_SPLIT ${ARM_C_FLAGS})
 set(LLEXT_REMOVE_FLAGS
   -fno-pic
   -fno-pie
-  -ffunction-sections
-  -fdata-sections
   -Os
 )
+
+if(NOT DEFINED(CONFIG_LLEXT_SYMBOL_GC))
+  list(APPEND LLEXT_REMOVE_FLAGS
+    -ffunction-sections
+    -fdata-sections
+  )
+endif()
 
 # Flags to be added to llext code compilation
 set(LLEXT_APPEND_FLAGS

--- a/cmake/compiler/gcc/target_arm64.cmake
+++ b/cmake/compiler/gcc/target_arm64.cmake
@@ -20,10 +20,15 @@ list(APPEND TOOLCHAIN_LD_FLAGS  -mabi=lp64)
 set(LLEXT_REMOVE_FLAGS
   -fno-pic
   -fno-pie
-  -ffunction-sections
-  -fdata-sections
   -Os
 )
+
+if(NOT DEFINED(CONFIG_LLEXT_SYMBOL_GC))
+  list(APPEND LLEXT_REMOVE_FLAGS
+    -ffunction-sections
+    -fdata-sections
+  )
+endif()
 
 list(APPEND LLEXT_EDK_REMOVE_FLAGS
   --sysroot=.*

--- a/cmake/compiler/gcc/target_riscv.cmake
+++ b/cmake/compiler/gcc/target_riscv.cmake
@@ -89,11 +89,16 @@ list(APPEND TOOLCHAIN_LD_FLAGS NO_SPLIT -mabi=${riscv_mabi} -march=${riscv_march
 set(LLEXT_REMOVE_FLAGS
   -fno-pic
   -fno-pie
-  -ffunction-sections
-  -fdata-sections
   -g.*
   -Os
 )
+
+if(NOT DEFINED(CONFIG_LLEXT_SYMBOL_GC))
+  list(APPEND LLEXT_REMOVE_FLAGS
+    -ffunction-sections
+    -fdata-sections
+  )
+endif()
 
 # Flags to be added to llext code compilation
 # mno-relax is needed to stop gcc from generating R_RISCV_ALIGN relocations,

--- a/cmake/compiler/gcc/target_xtensa.cmake
+++ b/cmake/compiler/gcc/target_xtensa.cmake
@@ -3,11 +3,16 @@
 # Flags not supported by llext linker
 # (regexps are supported and match whole word)
 set(LLEXT_REMOVE_FLAGS
-  -ffunction-sections
-  -fdata-sections
   -Os
   -mcpu=.*
 )
+
+if(NOT DEFINED(CONFIG_LLEXT_SYMBOL_GC))
+  list(APPEND LLEXT_REMOVE_FLAGS
+    -ffunction-sections
+    -fdata-sections
+  )
+endif()
 
 # Flags to be added to llext code compilation
 set(LLEXT_APPEND_FLAGS

--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -5573,6 +5573,9 @@ endfunction()
 # in the Zephyr build, but with some important modifications. The list of
 # flags to remove and flags to append is controlled respectively by the
 # LLEXT_REMOVE_FLAGS and LLEXT_APPEND_FLAGS global variables.
+# In case Link-Time Optimization (LTO) is enabled (CONFIG_LLEXT_SYMBOL_GC),
+# the additional toolchain-specific flags controlled by the
+# LLEXT_LTO_COMPILE_FLAGS and LLEXT_LTO_LINK_FLAGS are added as well.
 #
 # The following custom properties of <target_name> are defined and can be
 # retrieved using the get_target_property() function:
@@ -5664,6 +5667,17 @@ function(add_llext_target target_name)
       ${LLEXT_APPEND_FLAGS}
     )
 
+  endif()
+
+  # toolchain-specific options for garbage collection
+  if(CONFIG_LLEXT_SYMBOL_GC)
+	target_compile_options(
+		${llext_lib_target} PRIVATE
+		${LLEXT_SYMBOL_GC_COMPILE_FLAGS}
+	)
+	target_link_options(${llext_lib_target} PRIVATE
+		${LLEXT_SYMBOL_GC_LINK_FLAGS}
+	)
   endif()
 
   target_compile_definitions(${llext_lib_target} PRIVATE

--- a/include/zephyr/llext/symbol.h
+++ b/include/zephyr/llext/symbol.h
@@ -91,8 +91,9 @@ struct llext_symtable {
 #ifdef LL_EXTENSION_BUILD
 /* Extension build: add exported symbols to llext table */
 #define Z_LL_EXTENSION_SYMBOL_NAMED(sym_ident, sym_name)			\
-	static const struct llext_const_symbol					\
+	const struct llext_const_symbol						\
 			Z_GENERIC_SECTION(.exported_sym) __used			\
+			__attribute__((__visibility__("default")))		\
 			__llext_sym_ ## sym_name = {				\
 		.name = STRINGIFY(sym_name), .addr = (const void *)&sym_ident,	\
 	}

--- a/subsys/llext/Kconfig
+++ b/subsys/llext/Kconfig
@@ -120,6 +120,25 @@ config LLEXT_IMPORT_ALL_GLOBALS
 	  used by the main application. This is useful to load basic extensions
 	  that have been compiled without the full Zephyr EDK.
 
+config LLEXT_SYMBOL_GC
+	depends on !XTENSA
+	bool "Enable symbol garbage collection for extensions"
+	help
+	  Enables garbage collection for symbols in llexts.
+	  This can reduce code size in extensions that statically link
+	  libraries or have many unused functions for any reason.
+
+	  Symbol GC requires toolchain-specific compiler flags to operate.
+	  Currently, these flags are only provided for gcc.
+
+	  GC needs to be used with care in conjunction with LLEXT_IMPORT_ALL_GLOBALS.
+	  GC uses the explicitly exported symbols (EXPORT_SYMBOL) as root for garbage
+	  collection. Thus, any non-exported symbol that is not used within the
+	  extension might be removed. Note that this applies to function and data
+	  symbols alike.
+
+
+
 module = LLEXT
 module-str = llext
 source "subsys/logging/Kconfig.template.log_config"

--- a/subsys/llext/llext.ld
+++ b/subsys/llext/llext.ld
@@ -1,0 +1,21 @@
+SECTIONS {
+    .text : {
+        *(.text .text.*);
+    }
+
+    .bss : SUBALIGN(8) {
+        *(.bss .bss.*)
+    }
+
+    .data : SUBALIGN(8) {
+        *(.data .data.*)
+    }
+
+    .rodata : SUBALIGN(8) {
+        *(.rodata .rodata.*)
+    }
+
+    .export_sym : SUBALIGN(8) {
+    	*(.export_sym)
+    }
+}

--- a/tests/subsys/llext/testcase.yaml
+++ b/tests/subsys/llext/testcase.yaml
@@ -91,6 +91,24 @@ tests:
       - CONFIG_LLEXT_STORAGE_WRITABLE=y
       - CONFIG_LLEXT_TYPE_ELF_RELOCATABLE=y
 
+  # we test garbage collection with all currently available arches
+  llext.writable_relocatable_gc:
+    arch_allow:
+      - arm
+      - riscv
+      - arc
+    platform_exclude:
+      - qemu_arc/qemu_arc_hs5x     # See #80949
+      - nsim/nsim_hs5x             # See #80949
+      - nsim/nsim_hs5x/smp         # See #80949
+      - nsim/nsim_hs5x/smp/12cores # See #80949
+    filter: not CONFIG_MPU and not CONFIG_MMU
+    extra_conf_files: ['no_mem_protection.conf']
+    extra_configs:
+      - CONFIG_LLEXT_STORAGE_WRITABLE=y
+      - CONFIG_LLEXT_TYPE_ELF_RELOCATABLE=y
+      - CONFIG_LLEXT_SYMBOL_GC=y
+
   # Test the Symbol Link Identifier (SLID) linking feature on writable
   # storage to cover both ARM and Xtensa architectures on the same test.
   llext.writable_slid_linking:


### PR DESCRIPTION
This commit adds a new configuration LLEXT_SYMBOL_GC. It enables link-time garbage collection for symbols in llexts. This can reduce code size in extensions that statically link libraries or have many unused functions for any reason. The implementation relies on gcc-specific linker flags for the actual garbage collection. To this end, the compiler is instructed to separate functions and global data into individual sections. The linker can then remove sections that are not referenced by the GC roots, which currently consist of the sections that contain the explicitly exported symbols.
Additionally, a linker script for llext extensions was added - its purpose is to merge the function and data sections after the link, as llext currently cannot handle having multiple text/data sections. 
This feature is currently not supported on Xtensa.