### PR TITLE
drivers: watchdog: gecko: Fix timeout period inconsistency with EM1

### DIFF
--- a/drivers/watchdog/wdt_gecko.c
+++ b/drivers/watchdog/wdt_gecko.c
@@ -98,6 +98,10 @@ static int wdt_gecko_setup(const struct device *dev, uint8_t options)
 		return -EINVAL;
 	}
 
+#if defined(_WDOG_CFG_EM1RUN_MASK)
+	data->wdog_config.em1Run =
+		(options & WDT_OPT_PAUSE_IN_SLEEP) == 0U;
+#endif
 	data->wdog_config.em2Run =
 		(options & WDT_OPT_PAUSE_IN_SLEEP) == 0U;
 	data->wdog_config.em3Run =


### PR DESCRIPTION
Default watchdog initialization disable counting in EM1, EM2 and EM3 modes. If user use the WDT_OPT_PAUSE_IN_SLEEP flag via the watchdog api, all 3 EM modes must take this flag into account to avoid wdt count being frozen if we don't want to.

Fixes #86114