### PR TITLE
soc: nxp: rw: Update system core clock frequency

### DIFF
--- a/soc/nxp/rw/soc.c
+++ b/soc/nxp/rw/soc.c
@@ -134,6 +134,8 @@ __weak __ramfunc void clock_init(void)
 	CLOCK_SetClkDiv(kCLOCK_DivSystickClk, 1U);
 	CLOCK_AttachClk(kSYSTICK_DIV_to_SYSTICK_CLK);
 
+	SystemCoreClockUpdate();
+
 	/* Set PLL FRG clock to 20MHz. */
 	CLOCK_SetClkDiv(kCLOCK_DivPllFrgClk, 13U);
 


### PR DESCRIPTION
After updating the main_clk, need to update the frequency tracked in HAL MCUXpresso SDK framework for other drivers.

Fixes #86116 