### PR TITLE
boards: nxp: mimxrt595_evk: leave INPUTMUX and DMA clocks enabled

### DIFF
--- a/boards/nxp/mimxrt595_evk/board.c
+++ b/boards/nxp/mimxrt595_evk/board.c
@@ -352,7 +352,6 @@ static int mimxrt595_evk_init(void)
 	INPUTMUX_EnableSignal(INPUTMUX,
 			kINPUTMUX_I3c1TxToDmac1Ch31RequestEna, true);
 #endif /* dma1 */
-	INPUTMUX_Deinit(INPUTMUX);
 
 #ifdef CONFIG_REBOOT
 	/*


### PR DESCRIPTION
Calling INPUTMUX_Deinit() disables clocks to DMA and INPUTMUX, and causes issues with DMA.

Fixes #86118 