### PR TITLE
Bluetoth: Host: Fix buffer allocation warnings in system workqueue

### DIFF
--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -730,7 +730,11 @@ static struct net_buf *bt_att_chan_create_pdu(struct bt_att_chan *chan, uint8_t 
 		timeout = BT_ATT_TIMEOUT;
 		break;
 	default:
-		timeout = K_FOREVER;
+		if (k_current_get() == k_work_queue_thread_get(&k_sys_work_q)) {
+			timeout = K_NO_WAIT;
+		} else {
+			timeout = K_FOREVER;
+		}
 	}
 
 	/* This will reserve headspace for lower layers */

--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -674,6 +674,11 @@ struct net_buf *bt_l2cap_create_pdu_timeout(struct net_buf_pool *pool,
 					    size_t reserve,
 					    k_timeout_t timeout)
 {
+	if (!K_TIMEOUT_EQ(timeout, K_NO_WAIT) &&
+	    k_current_get() == k_work_queue_thread_get(&k_sys_work_q)) {
+		timeout = K_NO_WAIT;
+	}
+
 	return bt_conn_create_pdu_timeout(pool,
 					  sizeof(struct bt_l2cap_hdr) + reserve,
 					  timeout);


### PR DESCRIPTION
The buffer allocation in conn.c will trigger warnings if we try to use anything else than K_NO_WAIT for the timeout when called from within the system workqueue.

The calls in l2cap.c and att.c which may pass non-zero timeouts already have proper handling for failed allocations, so make sure we use K_NO_WAIT to avoid unnecessary warnings from conn.c.