### PR TITLE
drivers: uart: wch_usart: Fix typo in USART_WCH_IRQ_HANDLER

### DIFF
--- a/drivers/serial/uart_wch_usart.c
+++ b/drivers/serial/uart_wch_usart.c
@@ -312,7 +312,7 @@ static DEVICE_API(uart, usart_wch_driver_api) = {
 #define USART_WCH_IRQ_HANDLER(idx)                                                                 \
 	static void usart_wch_irq_config_func_##idx(const struct device *dev)                      \
 	{                                                                                          \
-		IRQ_CONNECT(DT_INST_IRQN(idx), DT_INST_IRQ(index, priority), usart_wch_isr,        \
+		IRQ_CONNECT(DT_INST_IRQN(idx), DT_INST_IRQ(idx, priority), usart_wch_isr,        \
 			    DEVICE_DT_INST_GET(idx), 0);                                           \
 		irq_enable(DT_INST_IRQN(idx));                                                     \
 	}


### PR DESCRIPTION
Previously, `USART_WCH_IRQ_HANDLER` used `DT_INST_IRQ(index, priority)`, which incorrectly referenced `index` instead of `idx`. This issue went undetected because `IRQ_CONNECT` drops the priority value on all boards supported by this driver.

Fix by using `DT_INST_IRQ(idx, priority)`.