### PR TITLE
modules: openthread: platform: optimize stack usage in crypto_psa

### DIFF
--- a/modules/openthread/platform/crypto_psa.c
+++ b/modules/openthread/platform/crypto_psa.c
@@ -226,7 +226,7 @@ otError otPlatCryptoHmacSha256Init(otCryptoContext *aContext)
 	}
 
 	operation = aContext->mContext;
-	*operation = psa_mac_operation_init();
+	memset(operation, 0, sizeof(*operation));
 
 	return OT_ERROR_NONE;
 }
@@ -347,7 +347,7 @@ otError otPlatCryptoSha256Init(otCryptoContext *aContext)
 	}
 
 	operation = aContext->mContext;
-	*operation = psa_hash_operation_init();
+	memset(operation, 0, sizeof(*operation));
 
 	return OT_ERROR_NONE;
 }


### PR DESCRIPTION
A PSA crypto operation object can be initialized in multiple ways according to the documentation. For example,
1. Using a dedicated psa_xxx_operation_init() function that returns an initialized object.
2. Using memset() to zero out the operation object.

For some PSA crypto driver implementations, using the first method causes an excessive stack usage if the operation object is large and psa_xxx_operation_init() is not inlined. Instead, it is better to stick to memset() for this purpose.