### PR TITLE
drivers: bluetooth: hci_nxp: fix unexpected command complete event

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -203,7 +203,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: 2a1d73aeb863a73bb06ba8b236de7da6d3e31847
+      revision: 3fc5f811fb8c0bdd90a8d965c50707172ce80d05
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
As the previous version of the MCXW71 BLE Controller wasn't sending a command complete event after setting the BD address, we used a workaround to directly send the HCI command without using zephyr's API.
Now, on the latest version of MCXW72 this issue is fixed, so we need to use `bt_hci_cmd_send_sync` to properly expect the command complete event.
If we fix the issue for MCXW72, we also need to update the MCXW71 BLE controller blob to expect the same behavior.

fixes #86152