### PR TITLE
drivers: wifi: AIROC: add support of new devices

### DIFF
--- a/drivers/wifi/infineon/Kconfig.airoc
+++ b/drivers/wifi/infineon/Kconfig.airoc
@@ -35,6 +35,9 @@ config AIROC_WIFI_BUS_SPI
 	help
 	  Enable SPI bus support
 
+config AIROC_WIFI6
+	bool
+
 config AIROC_WIFI_EVENT_TASK_STACK_SIZE
 	int "Event Task Stack Size"
 	default 4096
@@ -47,6 +50,14 @@ config AIROC_WLAN_MFG_FIRMWARE
 	bool "WLAN Manufacturing Firmware"
 	help
 	  Enable WLAN Manufacturing Firmware.
+
+config WHD_WIFI_COUNTRY
+	string "Wifi couuntry option"
+	default "WHD_COUNTRY_UNITED_STATES" if CYW55572 || CYW55500
+	default "WHD_COUNTRY_AUSTRALIA"
+	help
+	  Sets the country, this will operate in for wifi initialization
+	  parameters. See the wifi-host-driver's whd_country_code_t for legal options.
 
 config AIROC_WIFI_CUSTOM
 	bool "Custom CYW43xx device/module"
@@ -80,6 +91,13 @@ config CYW43012
 	  More information about CYW43012 device you can find on
 	  https://www.infineon.com/cms/en/product/wireless-connectivity/airoc-wi-fi-plus-bluetooth-combos/cyw43012/
 
+config CYW43022
+	bool "CYW43022"
+	help
+	  Enable Infineon AIROC CYW43022 Wi-Fi connectivity,
+	  More information about CYW43022 device you can find on
+	  https://www.infineon.com/cms/en/product/wireless-connectivity/airoc-wi-fi-plus-bluetooth-combos/wi-fi-5-802.11ac/cyw43022/
+
 config CYW43438
 	bool "CYW43438"
 	help
@@ -93,6 +111,23 @@ config CYW43439
 	  Enable Infineon AIROC CYW43439 Wi-Fi connectivity,
 	  More information about CYW43439 device you can find on
 	  https://www.infineon.com/cms/en/product/wireless-connectivity/airoc-wi-fi-plus-bluetooth-combos/cyw43439/
+
+config CYW55500
+	bool "CYW55500"
+	select AIROC_WIFI6
+	help
+	  Enable Infineon AIROC CYW55500 Wi-Fi connectivity,
+	  More information about CYW55500 device you can find on
+	  https://www.infineon.com/cms/en/product/wireless-connectivity/airoc-wi-fi-plus-bluetooth-combos/wi-fi-6-6e-802.11ax/cyw55511/
+
+config CYW55572
+	bool "CYW55572"
+	select AIROC_WIFI6
+	help
+	  Enable Infineon AIROC CYW55572 Wi-Fi connectivity,
+	  More information about CYW55572 device you can find on
+	  https://www.infineon.com/cms/en/product/wireless-connectivity/airoc-wi-fi-plus-bluetooth-combos/wi-fi-6-6e-802.11ax/cyw55572/
+
 endchoice
 
 choice CYW43012_MODULE
@@ -109,6 +144,19 @@ config CYW43012_MURATA_1LV
 
 	  Detailed information about Murata Type 1LV module you can find on
 	  https://www.murata.com/en-us/products/connectivitymodule/wi-fi-bluetooth/overview/lineup/type1lv
+endchoice
+
+choice CYW43022_MODULE
+	prompt "Select CYW43022 module"
+	depends on CYW43022 && !AIROC_WIFI_CUSTOM
+
+config CYW43022CUB
+	bool "CYW43022CUB"
+	help
+	  Infineon CYW43022CUB M2 module
+
+	  Detailed information about CYW43022CUB module you can find on
+	  https://www.infineon.com/cms/en/product/wireless-connectivity/airoc-wi-fi-plus-bluetooth-combos/wi-fi-5-802.11ac/cyw43022/
 endchoice
 
 choice CYW4343W_MODULE
@@ -131,13 +179,30 @@ choice CYW4373_MODULE
 	prompt "Select CYW4373 module"
 	depends on CYW4373 && !AIROC_WIFI_CUSTOM
 
+
+config CYW4373_MURATA_2AE
+	bool "CYW4373_MURATA_2AE"
+	help
+	  Murata Type 2AE modules based on Infineon CYW4373 combo chipset
+
+	  Detailed information about Murata Type 2AE module you can find on
+	  https://www.murata.com/en-us/products/connectivitymodule/wi-fi-bluetooth/overview/lineup/type2ae
+
+config CYW4373_MURATA_2BC
+	bool "CYW4373_MURATA_2BC"
+	help
+	  Murata Type 2BC modules based on Infineon CYW4373 combo chipset
+
+	  Detailed information about Murata Type 2BC module you can find on
+	  https://www.murata.com/en-us/products/connectivitymodule/wi-fi-bluetooth/overview/lineup/type2bc
+
 config CYW4373_STERLING_LWB5PLUS
 	bool "STERLING-LWB5plus"
 	help
 	  Ezurio Sterling LWB5+ 802.11ac / Bluetooth 5.0 M.2 Carrier Board
 	  (E-Type Key w/ SDIO/UART)
 
-	  Detailed information about Type Sterling LWB5+ module you can find on
+	  Detailed information about Sterling LWB5+ module you can find on
 	  https://www.ezurio.com/wireless-modules/wifi-modules-bluetooth/sterling-lwb5-plus-wifi-5-bluetooth-5-module
 endchoice
 
@@ -155,6 +220,34 @@ config CYW43439_MURATA_1YN
 
 	  Detailed information about Murata Type 1YN module you can find on
 	  https://www.murata.com/en-us/products/connectivitymodule/wi-fi-bluetooth/overview/lineup/type1yn
+
+config CYW43439_STERLING_LWBPLUS
+	bool "STERLING-LWBplus"
+	help
+	  Ezurio Sterling-LWB+ WiFi 4 with Bluetooth 5.2 module
+	  Detailed information about this module you can find on
+	  https://www.ezurio.com/wireless-modules/wifi-modules-bluetooth/sterling-lwb-wifi-4-and-bluetooth-52-modules
+
+endchoice
+
+choice CYW55500_MODULE
+	prompt "Select CYW55500 module"
+	depends on CYW55500 && !AIROC_WIFI_CUSTOM
+
+config CYW955513SDM2WLIPA_SM
+	bool "CYW955513SDM2WLIPA_SM"
+	help
+	  Infineon CYW955513SDM2WLIPA (SM) module
+endchoice
+
+choice CYW55572_MODULE
+	prompt "Select CYW55572 module"
+	depends on CYW55572 && !AIROC_WIFI_CUSTOM
+
+config CYW955573M2IPA1_SM
+	bool "CYW955573M2IPA1_SM"
+	help
+	  Infineon CYW955573M2IPA1 (SM) module
 endchoice
 
 endif # AIROC_WIFI

--- a/drivers/wifi/infineon/airoc_whd_hal_common.c
+++ b/drivers/wifi/infineon/airoc_whd_hal_common.c
@@ -64,19 +64,29 @@ int airoc_wifi_power_on(const struct device *dev)
  * Implement WHD memory wrappers
  */
 
-void *whd_mem_malloc(size_t size)
+inline void *whd_mem_malloc(size_t size)
 {
 	return k_malloc(size);
 }
 
-void *whd_mem_calloc(size_t nitems, size_t size)
+inline void *whd_mem_calloc(size_t nitems, size_t size)
 {
 	return k_calloc(nitems, size);
 }
 
-void whd_mem_free(void *ptr)
+inline void whd_mem_free(void *ptr)
 {
 	k_free(ptr);
+}
+
+inline void whd_mem_memcpy(void *dest, const void *src, size_t len)
+{
+	memcpy(dest, src, len);
+}
+
+inline void whd_mem_memset(void *buf, int val, size_t len)
+{
+	memset(buf, val, len);
 }
 
 #ifdef __cplusplus

--- a/drivers/wifi/infineon/airoc_whd_hal_sdio.c
+++ b/drivers/wifi/infineon/airoc_whd_hal_sdio.c
@@ -73,6 +73,11 @@ int airoc_wifi_init_primary(const struct device *dev, whd_interface_t *interface
 	}
 
 	/* Init SDIO functions */
+	ret = sdio_init_func(&data->card, &data->card.func0, BUS_FUNCTION);
+	if (ret) {
+		LOG_ERR("sdio_enable_func BUS_FUNCTION, error: %x", ret);
+		return ret;
+	}
 	ret = sdio_init_func(&data->card, &data->sdio_func1, BACKPLANE_FUNCTION);
 	if (ret) {
 		LOG_ERR("sdio_enable_func BACKPLANE_FUNCTION, error: %x", ret);
@@ -91,6 +96,11 @@ int airoc_wifi_init_primary(const struct device *dev, whd_interface_t *interface
 	ret = sdio_set_block_size(&data->sdio_func2, SDIO_64B_BLOCK);
 	if (ret) {
 		LOG_ERR("Can't set block size for WLAN_FUNCTION, error: %x", ret);
+		return ret;
+	}
+	ret = sdio_set_block_size(&data->card.func0, data->card.func0.cis.max_blk_size);
+	if (ret) {
+		LOG_ERR("Can't set block size for BUS_FUNCTION, error: %x", ret);
 		return ret;
 	}
 

--- a/drivers/wifi/infineon/airoc_wifi.c
+++ b/drivers/wifi/infineon/airoc_wifi.c
@@ -152,11 +152,15 @@ static int convert_whd_security_to_zephyr(whd_security_t security)
 	case WHD_SECURITY_OPEN:
 		zephyr_security = WIFI_SECURITY_TYPE_NONE;
 		break;
+
 	case WHD_SECURITY_WEP_PSK:
 		zephyr_security = WIFI_SECURITY_TYPE_WEP;
 		break;
 
 	case WHD_SECURITY_WPA3_WPA2_PSK:
+		zephyr_security = WIFI_SECURITY_TYPE_WPA_AUTO_PERSONAL;
+		break;
+
 	case WHD_SECURITY_WPA2_AES_PSK:
 		zephyr_security = WIFI_SECURITY_TYPE_PSK;
 		break;
@@ -199,7 +203,7 @@ static void scan_callback(whd_scan_result_t **result_ptr, void *user_data, whd_s
 {
 	struct airoc_wifi_data *data = user_data;
 	whd_scan_result_t whd_scan_result;
-	struct wifi_scan_result zephyr_scan_result;
+	struct wifi_scan_result zephyr_scan_result = {0};
 
 	if (status == WHD_SCAN_COMPLETED_SUCCESSFULLY || status == WHD_SCAN_ABORTED) {
 		data->scan_rslt_cb(data->iface, 0, NULL);
@@ -548,6 +552,11 @@ static int airoc_mgmt_connect(const struct device *dev, struct wifi_connect_req_
 		ret = -EAGAIN;
 		LOG_ERR("Could not scan device");
 		goto error;
+	}
+
+	if (usr_result.security == WHD_SECURITY_WPA3_WPA2_PSK)
+	{
+		usr_result.security = WHD_SECURITY_WPA2_AES_PSK;
 	}
 
 	/* Connect to the network */

--- a/drivers/wifi/infineon/airoc_wifi.c
+++ b/drivers/wifi/infineon/airoc_wifi.c
@@ -154,9 +154,12 @@ static int convert_whd_security_to_zephyr(whd_security_t security)
 		break;
 
 	case WHD_SECURITY_WEP_PSK:
+	case WHD_SECURITY_WEP_SHARED:
 		zephyr_security = WIFI_SECURITY_TYPE_WEP;
 		break;
 
+	case WHD_SECURITY_WPA2_WPA_MIXED_PSK:
+	case WHD_SECURITY_WPA2_WPA_AES_PSK:
 	case WHD_SECURITY_WPA3_WPA2_PSK:
 		zephyr_security = WIFI_SECURITY_TYPE_WPA_AUTO_PERSONAL;
 		break;
@@ -173,6 +176,8 @@ static int convert_whd_security_to_zephyr(whd_security_t security)
 		zephyr_security = WIFI_SECURITY_TYPE_SAE;
 		break;
 
+	case WHD_SECURITY_WPA_TKIP_PSK:
+	case WHD_SECURITY_WPA_MIXED_PSK:
 	case WHD_SECURITY_WPA_AES_PSK:
 		zephyr_security = WIFI_SECURITY_TYPE_WPA_PSK;
 		break;
@@ -184,6 +189,45 @@ static int convert_whd_security_to_zephyr(whd_security_t security)
 		break;
 	}
 	return zephyr_security;
+}
+
+static whd_security_t convert_zephyr_security_to_whd(int security)
+{
+	whd_security_t whd_security = WIFI_SECURITY_TYPE_UNKNOWN;
+
+	switch (security) {
+	case WIFI_SECURITY_TYPE_NONE:
+		whd_security = WHD_SECURITY_OPEN;
+		break;
+
+	case WIFI_SECURITY_TYPE_WEP:
+		whd_security = WHD_SECURITY_WEP_PSK;
+		break;
+
+	case WIFI_SECURITY_TYPE_WPA_AUTO_PERSONAL:
+		whd_security = WHD_SECURITY_WPA3_WPA2_PSK;
+		break;
+
+	case WIFI_SECURITY_TYPE_PSK:
+		whd_security = WHD_SECURITY_WPA2_AES_PSK;
+		break;
+
+	case WIFI_SECURITY_TYPE_PSK_SHA256:
+		whd_security = WIFI_SECURITY_TYPE_PSK_SHA256;
+		break;
+
+	case WIFI_SECURITY_TYPE_SAE:
+		whd_security = WHD_SECURITY_WPA3_SAE;
+		break;
+
+	case WIFI_SECURITY_TYPE_WPA_PSK:
+		whd_security = WHD_SECURITY_WPA_AES_PSK;
+		break;
+
+	default:
+		break;
+	}
+	return whd_security;
 }
 
 static void parse_scan_result(whd_scan_result_t *p_whd_result, struct wifi_scan_result *p_zy_result)
@@ -506,8 +550,9 @@ static int airoc_mgmt_scan(const struct device *dev, struct wifi_scan_params *pa
 static int airoc_mgmt_connect(const struct device *dev, struct wifi_connect_req_params *params)
 {
 	struct airoc_wifi_data *data = (struct airoc_wifi_data *)dev->data;
-	whd_ssid_t ssid = {0};
 	int ret = 0;
+	whd_scan_result_t scan_result;
+	whd_scan_result_t usr_result = {0};
 
 	if (k_sem_take(&data->sema_common, K_MSEC(AIROC_WIFI_WAIT_SEMA_MS)) != 0) {
 		return -EAGAIN;
@@ -525,38 +570,35 @@ static int airoc_mgmt_connect(const struct device *dev, struct wifi_connect_req_
 		goto error;
 	}
 
-	ssid.length = params->ssid_length;
-	memcpy(ssid.value, params->ssid, params->ssid_length);
+	usr_result.SSID.length = params->ssid_length;
+	memcpy(usr_result.SSID.value, params->ssid, params->ssid_length);
 
-	whd_scan_result_t scan_result;
-	whd_scan_result_t usr_result = {0};
+	if ((params->security == WIFI_SECURITY_TYPE_NONE) && (params->psk_length > 0)) {
+		/* Try to scan ssid to define security */
 
-	usr_result.SSID.length = ssid.length;
-	memcpy(usr_result.SSID.value, ssid.value, ssid.length);
+		if (whd_wifi_scan(airoc_sta_if, WHD_SCAN_TYPE_ACTIVE, WHD_BSS_TYPE_ANY, NULL, NULL,
+				  NULL, NULL, airoc_wifi_scan_cb_search, &scan_result,
+				  &(usr_result)) != WHD_SUCCESS) {
+			LOG_ERR("Failed start scan");
+			ret = -EAGAIN;
+			goto error;
+		}
 
-	if (whd_wifi_scan(airoc_sta_if, WHD_SCAN_TYPE_ACTIVE, WHD_BSS_TYPE_ANY, NULL, NULL, NULL,
-			  NULL, airoc_wifi_scan_cb_search, &scan_result,
-			  &(usr_result)) != WHD_SUCCESS) {
-		LOG_ERR("Failed start scan");
-		ret = -EAGAIN;
-		goto error;
-	}
-
-	if (k_sem_take(&airoc_wifi_data.sema_scan, K_MSEC(AIROC_WIFI_SCAN_TIMEOUT_MS)) != 0) {
-		whd_wifi_stop_scan(airoc_sta_if);
-		ret = -EAGAIN;
-		goto error;
+		if (k_sem_take(&airoc_wifi_data.sema_scan, K_MSEC(AIROC_WIFI_SCAN_TIMEOUT_MS)) !=
+		    0) {
+			whd_wifi_stop_scan(airoc_sta_if);
+			ret = -EAGAIN;
+			goto error;
+		}
+	} else {
+		/* Get security from user, convert it to  */
+		usr_result.security = convert_zephyr_security_to_whd(params->security);
 	}
 
 	if (usr_result.security == WHD_SECURITY_UNKNOWN) {
 		ret = -EAGAIN;
 		LOG_ERR("Could not scan device");
 		goto error;
-	}
-
-	if (usr_result.security == WHD_SECURITY_WPA3_WPA2_PSK)
-	{
-		usr_result.security = WHD_SECURITY_WPA2_AES_PSK;
 	}
 
 	/* Connect to the network */

--- a/modules/hal_infineon/wifi-host-driver/CMakeLists.txt
+++ b/modules/hal_infineon/wifi-host-driver/CMakeLists.txt
@@ -2,15 +2,21 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+if(CONFIG_AIROC_WIFI6)
+    set(whd_wifi_ver COMPONENT_WIFI6)
+else()
+    set(whd_wifi_ver COMPONENT_WIFI5)
+endif()
+
 set(hal_dir                  ${ZEPHYR_HAL_INFINEON_MODULE_DIR})
 set(hal_wifi_dir             ${hal_dir}/wifi-host-driver)
-set(hal_wifi_dir_resources   ${hal_dir}/wifi-host-driver/WiFi_Host_Driver/resources)
+set(hal_wifi_dir_resources   ${hal_dir}/wifi-host-driver/WHD/${whd_wifi_ver}/resources)
 
 set(hal_blobs_dir            ${hal_dir}/zephyr/blobs/img/whd/resources)
 set(blob_gen_dir             ${ZEPHYR_BINARY_DIR}/include/generated)
 
-set(cyw43xx_fw_bin_gen_inc   ${blob_gen_dir}/cyw43xx_fw_blob.inc)
-set(cyw43xx_clm_bin_gen_inc  ${blob_gen_dir}/cyw43xx_clm_blob.inc)
+set(airoc_wifi_fw_bin_gen_inc   ${blob_gen_dir}/airoc_wifi_fw_blob.inc)
+set(airoc_wifi_clm_bin_gen_inc  ${blob_gen_dir}/airoc_wifi_clm_blob.inc)
 
 #########################################################################################
 # Wi-Fi Host driver
@@ -19,153 +25,152 @@ if(CONFIG_AIROC_WLAN_MFG_FIRMWARE)
   zephyr_compile_definitions(WLAN_MFG_FIRMWARE)
 endif()
 
+zephyr_compile_definitions(CY_WIFI_COUNTRY=$<UPPER_CASE:${CONFIG_WHD_WIFI_COUNTRY}>)
+
 # Add WHD includes
 zephyr_include_directories(${hal_wifi_dir})
-zephyr_include_directories(${hal_wifi_dir}/WiFi_Host_Driver/inc)
-zephyr_include_directories(${hal_wifi_dir}/WiFi_Host_Driver/src)
-zephyr_include_directories(${hal_wifi_dir}/WiFi_Host_Driver/src/include)
-zephyr_include_directories(${hal_wifi_dir}/WiFi_Host_Driver/resources/resource_imp)
+zephyr_include_directories(${hal_wifi_dir}/WHD/${whd_wifi_ver}/inc)
+zephyr_include_directories(${hal_wifi_dir}/WHD/${whd_wifi_ver}/src)
+zephyr_include_directories(${hal_wifi_dir}/WHD/${whd_wifi_ver}/src/include)
+zephyr_include_directories(${hal_wifi_dir}/WHD/${whd_wifi_ver}/src/bus_protocols)
+zephyr_include_directories(${hal_wifi_dir}/WHD/${whd_wifi_ver}/resources/resource_imp)
 
 # src
-zephyr_library_sources(${hal_wifi_dir}/WiFi_Host_Driver/src/whd_ap.c)
-zephyr_library_sources(${hal_wifi_dir}/WiFi_Host_Driver/src/whd_buffer_api.c)
-zephyr_library_sources(${hal_wifi_dir}/WiFi_Host_Driver/src/whd_cdc_bdc.c)
-zephyr_library_sources(${hal_wifi_dir}/WiFi_Host_Driver/src/whd_chip.c)
-zephyr_library_sources(${hal_wifi_dir}/WiFi_Host_Driver/src/whd_chip_constants.c)
-zephyr_library_sources(${hal_wifi_dir}/WiFi_Host_Driver/src/whd_clm.c)
-zephyr_library_sources(${hal_wifi_dir}/WiFi_Host_Driver/src/whd_debug.c)
-zephyr_library_sources(${hal_wifi_dir}/WiFi_Host_Driver/src/whd_events.c)
-zephyr_library_sources(${hal_wifi_dir}/WiFi_Host_Driver/src/whd_logging.c)
-zephyr_library_sources(${hal_wifi_dir}/WiFi_Host_Driver/src/whd_management.c)
-zephyr_library_sources(${hal_wifi_dir}/WiFi_Host_Driver/src/whd_network_if.c)
-zephyr_library_sources(${hal_wifi_dir}/WiFi_Host_Driver/src/whd_resource_if.c)
-zephyr_library_sources(${hal_wifi_dir}/WiFi_Host_Driver/src/whd_sdpcm.c)
-zephyr_library_sources(${hal_wifi_dir}/WiFi_Host_Driver/src/whd_thread.c)
-zephyr_library_sources(${hal_wifi_dir}/WiFi_Host_Driver/src/whd_utils.c)
-zephyr_library_sources(${hal_wifi_dir}/WiFi_Host_Driver/src/whd_wifi.c)
-zephyr_library_sources(${hal_wifi_dir}/WiFi_Host_Driver/src/whd_wifi_api.c)
-zephyr_library_sources(${hal_wifi_dir}/WiFi_Host_Driver/src/whd_wifi_p2p.c)
+zephyr_library_sources(${hal_wifi_dir}/WHD/${whd_wifi_ver}/src/whd_ap.c)
+zephyr_library_sources(${hal_wifi_dir}/WHD/${whd_wifi_ver}/src/whd_buffer_api.c)
+zephyr_library_sources(${hal_wifi_dir}/WHD/${whd_wifi_ver}/src/whd_cdc_bdc.c)
+zephyr_library_sources(${hal_wifi_dir}/WHD/${whd_wifi_ver}/src/whd_chip.c)
+zephyr_library_sources(${hal_wifi_dir}/WHD/${whd_wifi_ver}/src/whd_chip_constants.c)
+zephyr_library_sources(${hal_wifi_dir}/WHD/${whd_wifi_ver}/src/whd_clm.c)
+zephyr_library_sources(${hal_wifi_dir}/WHD/${whd_wifi_ver}/src/whd_debug.c)
+zephyr_library_sources(${hal_wifi_dir}/WHD/${whd_wifi_ver}/src/whd_events.c)
+zephyr_library_sources(${hal_wifi_dir}/WHD/${whd_wifi_ver}/src/whd_logging.c)
+zephyr_library_sources(${hal_wifi_dir}/WHD/${whd_wifi_ver}/src/whd_management.c)
+zephyr_library_sources(${hal_wifi_dir}/WHD/${whd_wifi_ver}/src/whd_network_if.c)
+zephyr_library_sources(${hal_wifi_dir}/WHD/${whd_wifi_ver}/src/whd_proto.c)
+zephyr_library_sources(${hal_wifi_dir}/WHD/${whd_wifi_ver}/src/whd_resource_if.c)
+zephyr_library_sources(${hal_wifi_dir}/WHD/${whd_wifi_ver}/src/whd_sdpcm.c)
+zephyr_library_sources(${hal_wifi_dir}/WHD/${whd_wifi_ver}/src/whd_thread.c)
+zephyr_library_sources(${hal_wifi_dir}/WHD/${whd_wifi_ver}/src/whd_utils.c)
+zephyr_library_sources(${hal_wifi_dir}/WHD/${whd_wifi_ver}/src/whd_wifi.c)
+zephyr_library_sources(${hal_wifi_dir}/WHD/${whd_wifi_ver}/src/whd_wifi_api.c)
+zephyr_library_sources(${hal_wifi_dir}/WHD/${whd_wifi_ver}/src/whd_wifi_p2p.c)
 
 # src/bus_protocols
-zephyr_library_sources(${hal_wifi_dir}/WiFi_Host_Driver/src/bus_protocols/whd_bus.c)
-zephyr_library_sources(${hal_wifi_dir}/WiFi_Host_Driver/src/bus_protocols/whd_bus_common.c)
-zephyr_library_sources_ifdef(CONFIG_AIROC_WIFI_BUS_SDIO
-  ${hal_wifi_dir}/WiFi_Host_Driver/src/bus_protocols/whd_bus_sdio_protocol.c)
-zephyr_library_sources_ifdef(CONFIG_AIROC_WIFI_BUS_SPI
-  ${hal_wifi_dir}/WiFi_Host_Driver/src/bus_protocols/whd_bus_spi_protocol.c)
+zephyr_library_sources(${hal_wifi_dir}/WHD/${whd_wifi_ver}/src/bus_protocols/whd_bus.c)
+zephyr_library_sources(${hal_wifi_dir}/WHD/${whd_wifi_ver}/src/bus_protocols/whd_bus_common.c)
+zephyr_library_sources(${hal_wifi_dir}/WHD/${whd_wifi_ver}/src/bus_protocols/whd_bus_sdio_protocol.c)
 
 # resources/resource_imp
-zephyr_library_sources(${hal_wifi_dir}/WiFi_Host_Driver/resources/resource_imp/whd_resources.c)
+zephyr_library_sources(${hal_wifi_dir}/WHD/${whd_wifi_ver}/resources/resource_imp/whd_resources.c)
+
+############################################################################################################
+## WIFI 5 devices
+############################################################################################################
+
+# Specific defines for CYW43022 devices
+if(CONFIG_CYW43022)
+  zephyr_compile_definitions(BLHS_SUPPORT)
+  zephyr_compile_definitions(ULP_SUPPORT)
+  zephyr_compile_definitions(DM_43022C1)
+endif()
 
 # CYW43012 firmware
 if(CONFIG_CYW43012 AND NOT CONFIG_AIROC_WIFI_CUSTOM)
-  zephyr_include_directories(${hal_wifi_dir}/WiFi_Host_Driver/resources/firmware/COMPONENT_43012)
-
   # firmware
   if(CONFIG_AIROC_WLAN_MFG_FIRMWARE)
-    set(cyw43xx_fw_bin     ${hal_blobs_dir}/firmware/COMPONENT_43012/43012C0-mfgtest.bin)
-    zephyr_library_sources(${hal_wifi_dir_resources}/firmware/COMPONENT_43012/43012C0-mfgtest_bin.c)
+    zephyr_library_sources(${hal_blobs_dir}/firmware/COMPONENT_43012/43012C0-mfgtest_bin.c)
   else()
-    set(cyw43xx_fw_bin     ${hal_blobs_dir}/firmware/COMPONENT_43012/43012C0.bin)
-    zephyr_library_sources(${hal_wifi_dir_resources}/firmware/COMPONENT_43012/43012C0_bin.c)
+    zephyr_library_sources(${hal_blobs_dir}/firmware/COMPONENT_43012/43012C0_bin.c)
+  endif()
+endif()
+
+# CYW43022 firmware
+if(CONFIG_CYW43022 AND NOT CONFIG_AIROC_WIFI_CUSTOM)
+  # firmware
+  if(CONFIG_AIROC_WLAN_MFG_FIRMWARE)
+    zephyr_library_sources(${hal_blobs_dir}/firmware/COMPONENT_43022/COMPONENT_SM/43022C1-mfgtest_bin.c)
+  else()
+    zephyr_library_sources(${hal_blobs_dir}/firmware/COMPONENT_43022/COMPONENT_SM/43022C1_bin.c)
   endif()
 endif()
 
 # CYW4343W firmware
 if(CONFIG_CYW4343W AND NOT CONFIG_AIROC_WIFI_CUSTOM)
-  zephyr_include_directories(${hal_wifi_dir_resources}/firmware/COMPONENT_4343W)
-
   # firmware
   if(CONFIG_AIROC_WLAN_MFG_FIRMWARE)
-    set(cyw43xx_fw_bin     ${hal_blobs_dir}/firmware/COMPONENT_4343W/4343WA1-mfgtest.bin)
-    zephyr_library_sources(${hal_wifi_dir_resources}/firmware/COMPONENT_4343W/4343WA1-mfgtest_bin.c)
+    zephyr_library_sources(${hal_blobs_dir}/firmware/COMPONENT_4343W/4343WA1-mfgtest_bin.c)
   else()
-    set(cyw43xx_fw_bin     ${hal_blobs_dir}/firmware/COMPONENT_4343W/4343WA1.bin)
-    zephyr_library_sources(${hal_wifi_dir_resources}/firmware/COMPONENT_4343W/4343WA1_bin.c)
+    zephyr_library_sources(${hal_blobs_dir}/firmware/COMPONENT_4343W/4343WA1_bin.c)
   endif()
 endif()
 
 # CYW43438 firmware/clm
 if(CONFIG_CYW43438 AND NOT CONFIG_AIROC_WIFI_CUSTOM)
-  zephyr_include_directories(${hal_wifi_dir_resources}/firmware/COMPONENT_43438)
-  zephyr_include_directories(${hal_wifi_dir_resources}/clm/COMPONENT_43438)
-
   # firmware/clm
   if(CONFIG_AIROC_WLAN_MFG_FIRMWARE)
-    set(cyw43xx_fw_bin     ${hal_blobs_dir}/firmware/COMPONENT_43438/43438A1-mfgtest.bin)
-    set(cyw43xx_clm_bin    ${hal_blobs_dir}/clm/COMPONENT_43438/43438A1-mfgtest.clm_blob)
-
-    zephyr_library_sources(${hal_wifi_dir_resources}/firmware/COMPONENT_43438/43438A1-mfgtest_bin.c)
-    zephyr_library_sources(${hal_wifi_dir_resources}/clm/COMPONENT_43438/43438A1-mfgtest_clm_blob.c)
+    zephyr_library_sources(${hal_blobs_dir}/firmware/COMPONENT_43438/43438A1-mfgtest_bin.c)
+    zephyr_library_sources(${hal_blobs_dir}/clm/COMPONENT_43438/43438A1-mfgtest_clm_blob.c)
   else()
-    set(cyw43xx_fw_bin     ${hal_blobs_dir}/firmware/COMPONENT_43438/43438A1.bin)
-    set(cyw43xx_clm_bin    ${hal_blobs_dir}/clm/COMPONENT_43438/43438A1.clm_blob)
-
-    zephyr_library_sources(${hal_wifi_dir_resources}/firmware/COMPONENT_43438/43438A1_bin.c)
-    zephyr_library_sources(${hal_wifi_dir_resources}/clm/COMPONENT_43438/43438A1_clm_blob.c)
+    zephyr_library_sources(${hal_blobs_dir}/firmware/COMPONENT_43438/43438A1_bin.c)
+    zephyr_library_sources(${hal_blobs_dir}/clm/COMPONENT_43438/43438A1_clm_blob.c)
   endif()
 
 endif()
 
 # CYW43439 firmware
 if(CONFIG_CYW43439 AND NOT CONFIG_AIROC_WIFI_CUSTOM)
-  zephyr_include_directories(${hal_wifi_dir_resources}/firmware/COMPONENT_43439)
-
   # firmware
   if(CONFIG_AIROC_WLAN_MFG_FIRMWARE)
-    set(cyw43xx_fw_bin     ${hal_blobs_dir}/firmware/COMPONENT_43439/43439A0-mfgtest.bin)
-    zephyr_library_sources(${hal_wifi_dir_resources}/firmware/COMPONENT_43439/43439A0-mfgtest_bin.c)
+    zephyr_library_sources(${hal_blobs_dir}/firmware/COMPONENT_43439/43439A0-mfgtest_bin.c)
   else()
-    set(cyw43xx_fw_bin     ${hal_blobs_dir}/firmware/COMPONENT_43439/43439a0.bin)
-    zephyr_library_sources(${hal_wifi_dir_resources}/firmware/COMPONENT_43439/43439a0_bin.c)
+    zephyr_library_sources(${hal_blobs_dir}/firmware/COMPONENT_43439/43439a0_bin.c)
   endif()
 endif()
 
 # CYW4373 firmware
 if(CONFIG_CYW4373 AND NOT CONFIG_AIROC_WIFI_CUSTOM)
-  zephyr_include_directories(${hal_wifi_dir_resources}/firmware/COMPONENT_4373)
-
   # firmware
   if(CONFIG_AIROC_WLAN_MFG_FIRMWARE)
-    set(cyw43xx_fw_bin     ${hal_blobs_dir}/firmware/COMPONENT_4373/4373A0-mfgtest.bin)
-    zephyr_library_sources(${hal_wifi_dir_resources}/firmware/COMPONENT_4373/4373A0-mfgtest_bin.c)
+    zephyr_library_sources(${hal_blobs_dir}/firmware/COMPONENT_4373/4373A0-mfgtest_bin.c)
   else()
-    set(cyw43xx_fw_bin     ${hal_blobs_dir}/firmware/COMPONENT_4373/4373A0.bin)
-    zephyr_library_sources(${hal_wifi_dir_resources}/firmware/COMPONENT_4373/4373A0_bin.c)
+    zephyr_library_sources(${hal_blobs_dir}/firmware/COMPONENT_4373/4373A0_bin.c)
   endif()
 endif()
 
-
 # CYW43012_MURATA_1LV clm/nvram
 if(CONFIG_CYW43012_MURATA_1LV AND NOT CONFIG_AIROC_WIFI_CUSTOM)
-  zephyr_include_directories(${hal_wifi_dir}/WiFi_Host_Driver/resources/clm/COMPONENT_43012)
-
   # clm
   if(CONFIG_AIROC_WLAN_MFG_FIRMWARE)
-    set(cyw43xx_clm_bin    ${hal_blobs_dir}/clm/COMPONENT_43012/43012C0-mfgtest.clm_blob)
-
-    zephyr_library_sources(${hal_wifi_dir_resources}/clm/COMPONENT_43012/43012C0-mfgtest_clm_blob.c)
+    zephyr_library_sources(${hal_blobs_dir}/clm/COMPONENT_43012/43012C0-mfgtest_clm_blob.c)
   else()
-    set(cyw43xx_clm_bin    ${hal_blobs_dir}/clm/COMPONENT_43012/43012C0.clm_blob)
-
-    zephyr_library_sources(${hal_wifi_dir_resources}/clm/COMPONENT_43012/43012C0_clm_blob.c)
+    zephyr_library_sources(${hal_blobs_dir}/clm/COMPONENT_43012/43012C0_clm_blob.c)
   endif()
 
   # nvram
   zephyr_include_directories(${hal_wifi_dir_resources}/nvram/COMPONENT_43012/COMPONENT_MURATA-1LV)
 endif()
 
-# CYW4343W_MURATA_1DX clm/nvram
-if(CONFIG_CYW4343W_MURATA_1DX AND NOT CONFIG_AIROC_WIFI_CUSTOM)
-  zephyr_include_directories(${hal_wifi_dir_resources}/clm/COMPONENT_4343W)
-
+# CYW43022CUB clm/nvram
+if(CONFIG_CYW43022CUB AND NOT CONFIG_AIROC_WIFI_CUSTOM)
   # clm
   if(CONFIG_AIROC_WLAN_MFG_FIRMWARE)
-    set(cyw43xx_clm_bin    ${hal_blobs_dir}/clm/COMPONENT_4343W/4343WA1-mfgtest.clm_blob)
-    zephyr_library_sources(${hal_wifi_dir_resources}/clm/COMPONENT_4343W/4343WA1-mfgtest_clm_blob.c)
+    zephyr_library_sources(${hal_blobs_dir}/clm/COMPONENT_43022/43022C1-mfgtest_clm_blob.c)
   else()
-    set(cyw43xx_clm_bin    ${hal_blobs_dir}/clm/COMPONENT_4343W/4343WA1.clm_blob)
-    zephyr_library_sources(${hal_wifi_dir_resources}/clm/COMPONENT_4343W/4343WA1_clm_blob.c)
+    zephyr_library_sources(${hal_blobs_dir}/clm/COMPONENT_43022/43022C1_clm_blob.c)
+  endif()
+
+  # nvram
+  zephyr_include_directories(${hal_wifi_dir_resources}/nvram/COMPONENT_43022/COMPONENT_CYW43022CUB)
+endif()
+
+# CYW4343W_MURATA_1DX clm/nvram
+if(CONFIG_CYW4343W_MURATA_1DX AND NOT CONFIG_AIROC_WIFI_CUSTOM)
+  # clm
+  if(CONFIG_AIROC_WLAN_MFG_FIRMWARE)
+    zephyr_library_sources(${hal_blobs_dir}/clm/COMPONENT_4343W/4343WA1-mfgtest_clm_blob.c)
+  else()
+    zephyr_library_sources(${hal_blobs_dir}/clm/COMPONENT_4343W/4343WA1_clm_blob.c)
   endif()
 
   # nvram
@@ -174,46 +179,135 @@ endif()
 
 # CYW43439_MURATA_1YN
 if(CONFIG_CYW43439_MURATA_1YN AND NOT CONFIG_AIROC_WIFI_CUSTOM)
-  zephyr_include_directories(${hal_wifi_dir_resources}/clm/COMPONENT_43439)
-
   # clm
   if(CONFIG_AIROC_WLAN_MFG_FIRMWARE)
-    set(cyw43xx_clm_bin    ${hal_blobs_dir}/clm/COMPONENT_43439/43439A0-mfgtest.clm_blob)
-    zephyr_library_sources(${hal_wifi_dir_resources}/clm/COMPONENT_43439/43439A0-mfgtest_clm_blob.c)
+    zephyr_library_sources(${hal_blobs_dir}/clm/COMPONENT_43439/43439A0-mfgtest_clm_blob.c)
   else()
-    set(cyw43xx_clm_bin    ${hal_blobs_dir}/clm/COMPONENT_43439/43439A0.clm_blob)
-    zephyr_library_sources(${hal_wifi_dir_resources}/clm/COMPONENT_43439/43439A0_clm_blob.c)
+    zephyr_library_sources(${hal_blobs_dir}/clm/COMPONENT_43439/43439A0_clm_blob.c)
   endif()
 
   # nvram
   zephyr_include_directories(${hal_wifi_dir_resources}/nvram/COMPONENT_43439/COMPONENT_MURATA-1YN)
 endif()
 
-# CYW4373_STERLING_LWB5PLUS
-if(CONFIG_CYW4373_STERLING_LWB5PLUS AND NOT CONFIG_AIROC_WIFI_CUSTOM)
-  zephyr_include_directories(${hal_wifi_dir_resources}/clm/COMPONENT_4373/COMPONENT_STERLING-LWB5plus)
-
+# CYW43439_STERLING_LWBPLUS
+if(CONFIG_CYW43439_STERLING_LWBPLUS AND NOT CONFIG_AIROC_WIFI_CUSTOM)
   # clm
   if(CONFIG_AIROC_WLAN_MFG_FIRMWARE)
-    set(cyw43xx_clm_bin    ${hal_blobs_dir}/clm/COMPONENT_4373/COMPONENT_STERLING-LWB5plus/4373A0-mfgtest.clm_blob)
-    zephyr_library_sources(${hal_wifi_dir_resources}/clm/COMPONENT_4373/COMPONENT_STERLING-LWB5plus/4373A0-mfgtest_clm_blob.c)
+    zephyr_library_sources(${hal_blobs_dir}/clm/COMPONENT_43439/43439A0-mfgtest_clm_blob.c)
   else()
-    set(cyw43xx_clm_bin    ${hal_blobs_dir}/clm/COMPONENT_4373/4373A0.clm_blob)
-    zephyr_library_sources(${hal_wifi_dir_resources}/clm/COMPONENT_4373/COMPONENT_STERLING-LWB5plus/4373A0_clm_blob.c)
+    zephyr_library_sources(${hal_blobs_dir}/clm/COMPONENT_43439/43439A0_clm_blob.c)
+  endif()
+
+  # nvram
+  zephyr_include_directories(${hal_wifi_dir_resources}/nvram/COMPONENT_43439/COMPONENT_STERLING-LWBplus)
+endif()
+
+# CYW4373_STERLING_LWB5PLUS
+if(CONFIG_CYW4373_STERLING_LWB5PLUS AND NOT CONFIG_AIROC_WIFI_CUSTOM)
+  # clm
+  if(CONFIG_AIROC_WLAN_MFG_FIRMWARE)
+    zephyr_library_sources(${hal_blobs_dir}/clm/COMPONENT_4373/COMPONENT_STERLING-LWB5plus/4373A0-mfgtest_clm_blob.c)
+  else()
+    zephyr_library_sources(${hal_blobs_dir}/clm/COMPONENT_4373/COMPONENT_STERLING-LWB5plus/4373A0_clm_blob.c)
   endif()
 
   # nvram
   zephyr_include_directories(${hal_wifi_dir_resources}/nvram/COMPONENT_4373/COMPONENT_STERLING-LWB5plus)
 endif()
 
+# CYW4373_MURATA-2AE
+if(CONFIG_CYW4373_MURATA_2AE AND NOT CONFIG_AIROC_WIFI_CUSTOM)
+  # clm
+  if(CONFIG_AIROC_WLAN_MFG_FIRMWARE)
+    zephyr_library_sources(${hal_blobs_dir}/clm/COMPONENT_4373/COMPONENT_MURATA-2AE/4373A0-mfgtest_clm_blob.c)
+  else()
+    zephyr_library_sources(${hal_blobs_dir}/clm/COMPONENT_4373/COMPONENT_MURATA-2AE/4373A0_clm_blob.c)
+  endif()
+
+  # nvram
+  zephyr_include_directories(${hal_wifi_dir_resources}/nvram/COMPONENT_4373/COMPONENT_MURATA-2AE)
+endif()
+
+# CYW4373_MURATA-2BC
+if(CONFIG_CYW4373_MURATA_2BC AND NOT CONFIG_AIROC_WIFI_CUSTOM)
+  # clm
+  if(CONFIG_AIROC_WLAN_MFG_FIRMWARE)
+    zephyr_library_sources(${hal_blobs_dir}/clm/COMPONENT_4373/COMPONENT_MURATA-2BC/4373A0-mfgtest_clm_blob.c)
+  else()
+    zephyr_library_sources(${hal_blobs_dir}/clm/COMPONENT_4373/COMPONENT_MURATA-2BC/4373A0_clm_blob.c)
+  endif()
+
+  # nvram
+  zephyr_include_directories(${hal_wifi_dir_resources}/nvram/COMPONENT_4373/COMPONENT_MURATA-2BC)
+endif()
+
+############################################################################################################
+## WIFI 6 devices
+############################################################################################################
+
+# Specific defines for CYW555xx devices
+if(CONFIG_CYW55500 OR CONFIG_CYW55572)
+  zephyr_compile_definitions(BLHS_SUPPORT)
+endif()
+
+# CYW55500 firmware
+if(CONFIG_CYW55500 AND NOT CONFIG_AIROC_WIFI_CUSTOM)
+  # firmware
+  if(CONFIG_AIROC_WLAN_MFG_FIRMWARE)
+    zephyr_library_sources(${hal_blobs_dir}/firmware/COMPONENT_55500/COMPONENT_SM/55500A1-mfgtest_bin.c)
+  else()
+    zephyr_library_sources(${hal_blobs_dir}/firmware/COMPONENT_55500/COMPONENT_SM/55500A1_bin.c)
+  endif()
+endif()
+
+# CYW55572 firmware
+if(CONFIG_CYW55572 AND NOT CONFIG_AIROC_WIFI_CUSTOM)
+  # firmware
+  if(CONFIG_AIROC_WLAN_MFG_FIRMWARE)
+    zephyr_library_sources(${hal_blobs_dir}/firmware/COMPONENT_55572/COMPONENT_SM/55572A1-mfgtest_bin.c)
+  else()
+    zephyr_library_sources(${hal_blobs_dir}/firmware/COMPONENT_55572/COMPONENT_SM/55572A1_bin.c)
+  endif()
+endif()
+
+
+# CYW955513SDM2WLIPA_SM
+if(CONFIG_CYW955513SDM2WLIPA_SM AND NOT CONFIG_AIROC_WIFI_CUSTOM)
+
+  # clm
+  if(CONFIG_AIROC_WLAN_MFG_FIRMWARE)
+    zephyr_library_sources(${hal_blobs_dir}/clm/COMPONENT_55500/55500A1-mfgtest_clm_blob.c)
+  else()
+    zephyr_library_sources(${hal_blobs_dir}/clm/COMPONENT_55500/55500A1_clm_blob.c)
+  endif()
+
+  # nvram
+  zephyr_include_directories(${hal_wifi_dir_resources}/nvram/COMPONENT_55500/COMPONENT_CYW955513SDM2WLIPA)
+endif()
+
+# CYW955573M2IPA1_SM
+if(CONFIG_CYW955573M2IPA1_SM AND NOT CONFIG_AIROC_WIFI_CUSTOM)
+
+  # clm
+  if(CONFIG_AIROC_WLAN_MFG_FIRMWARE)
+    zephyr_library_sources(${hal_blobs_dir}/clm/COMPONENT_55572/55572A1-mfgtest_clm_blob.c)
+  else()
+    zephyr_library_sources(${hal_blobs_dir}/clm/COMPONENT_55572/55572A1_clm_blob.c)
+  endif()
+
+  # nvram
+  zephyr_include_directories(${hal_wifi_dir_resources}/nvram/COMPONENT_55572/COMPONENT_CYW955573M2IPA1)
+endif()
+
 # generate FW inc_blob from fw_bin
-if(EXISTS ${cyw43xx_fw_bin})
-  message(INFO " generate include of blob FW file: ${cyw43xx_fw_bin}")
-  generate_inc_file_for_target(app ${cyw43xx_fw_bin} ${cyw43xx_fw_bin_gen_inc})
+if(EXISTS ${airoc_wifi_fw_bin})
+  message(INFO " generate include of blob FW file: ${airoc_wifi_fw_bin}")
+  generate_inc_file_for_target(app ${airoc_wifi_fw_bin} ${airoc_wifi_fw_bin_gen_inc})
 endif()
 
 # generate CLM inc_blob from clm_bin
-if(EXISTS ${cyw43xx_clm_bin})
-  message(INFO " generate include of blob CLM file: ${cyw43xx_clm_bin}")
-  generate_inc_file_for_target(app ${cyw43xx_clm_bin} ${cyw43xx_clm_bin_gen_inc})
+if(EXISTS ${airoc_wifi_clm_bin})
+  message(INFO " generate include of blob CLM file: ${airoc_wifi_clm_bin}")
+  generate_inc_file_for_target(app ${airoc_wifi_clm_bin} ${airoc_wifi_clm_bin_gen_inc})
 endif()

--- a/west.yml
+++ b/west.yml
@@ -183,7 +183,7 @@ manifest:
       groups:
         - hal
     - name: hal_infineon
-      revision: 9df9d40571b25171cb752459c6dd96bd83ec8570
+      revision: 6890899e0db2cbcd3a562b41b7e9e0a2a9040ed0
       path: modules/hal/infineon
       groups:
         - hal


### PR DESCRIPTION
- add support Wi-Fi Host Driver (WHD) 4.2.1
- add Country configuration from Kconfig

Support new devices:
 -- CYW43022
 -- CYW55500 (WIFI6)
 -- CYW55572 (WIFI6)

Support new modules:
 -- CYW43022CUB
 -- CYW955573M2IPA1_SM
 -- CYW955513SDM2WLIPA_SM
 -- CYW4373_MURATA_2BC
 -- CYW4373_MURATA_2AE
 -- CYW43439_STERLING_LWBPLUS