### PR TITLE
drivers: Wrap driver instances in device API macro

### DIFF
--- a/drivers/charger/charger_pf1550.c
+++ b/drivers/charger/charger_pf1550.c
@@ -660,7 +660,7 @@ static int pf1550_init(const struct device *dev)
 	return 0;
 }
 
-static const struct charger_driver_api pf1550_driver_api = {
+static DEVICE_API(charger, pf1550_driver_api) = {
 	.get_property = pf1550_get_prop,
 	.set_property = pf1550_set_prop,
 	.charge_enable = pf1550_set_enabled,

--- a/drivers/regulator/regulator_pf1550.c
+++ b/drivers/regulator/regulator_pf1550.c
@@ -378,11 +378,11 @@ static int regulator_pf1550_common_init(const struct device *dev)
 	return 0;
 }
 
-static const struct regulator_parent_driver_api parent_api = {
+static DEVICE_API(regulator_parent, parent_api) = {
 	.ship_mode = regulator_pf1550_power_off,
 };
 
-static const struct regulator_driver_api api = {
+static DEVICE_API(regulator, api) = {
 	.enable = regulator_pf1550_enable,
 	.disable = regulator_pf1550_disable,
 	.count_voltages = regulator_pf1550_count_voltages,


### PR DESCRIPTION
Still a few missing for the 4.1 release.

Use the device API macro to place the driver API instance into an iterable section.