### PR TITLE
STM32WB0: add proper start address to boards

### DIFF
--- a/boards/st/nucleo_wb05kz/board.cmake
+++ b/boards/st/nucleo_wb05kz/board.cmake
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # keep first
-board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=sw")
+board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=sw" "--start-address=0x10000000")
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)

--- a/boards/st/nucleo_wb07cc/board.cmake
+++ b/boards/st/nucleo_wb07cc/board.cmake
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # keep first
-board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=sw" "--start-address=0x10040000")
+board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=sw" "--start-address=0x10000000")
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)

--- a/boards/st/nucleo_wb09ke/board.cmake
+++ b/boards/st/nucleo_wb09ke/board.cmake
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # keep first
-board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=sw")
+board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=sw" "--start-address=0x10000000")
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)


### PR DESCRIPTION
Nucleo-WB05KZ and Nucleo-WB09KE are lacking the `--start-address` argument for STM32CubeProgrammer runner, which makes them begin execution in limbo then HardFault.

Nucleo-WB07CC has `--start-address=0x10040000`, which makes it begin execution directly in user flash. This skips the bootloader code which performs some bookkeeping (notably, updating RAM_VR.ResetReason). As a result, `RAM_VR.ResetReason` and `RCC->CSR` will hold invalid values until PORRESET, or two regular RESET cycles occur (only 1 for `RCC->CSR`).

Force all three boards to begin execution in bootloader after flashing via STM32CubeProgrammer to ensure proper system behavior at all times.

#### Example logs (using `hello_world` sample modified to print additional information)
Before patch:
```
*** Booting Zephyr OS build v4.1.0-rc1-208-g4e594fd87ff1 ***	<-- post-flash boot
Hello World! nucleo_wb05kz/stm32wb05
RAM_VR.ResetReason=0x47702001 RCC->CSR=0x14000000
*** Booting Zephyr OS build v4.1.0-rc1-208-g4e594fd87ff1 ***	<-- press RESET a first time
Hello World! nucleo_wb05kz/stm32wb05
RAM_VR.ResetReason=0x14000000 RCC->CSR=0x00000000
*** Booting Zephyr OS build v4.1.0-rc1-208-g4e594fd87ff1 ***	<-- press RESET a second time
Hello World! nucleo_wb05kz/stm32wb05
RAM_VR.ResetReason=0x04000000 RCC->CSR=0x00000000
```

After patch:
```
*** Booting Zephyr OS build v4.1.0-rc1-208-g4e594fd87ff1 ***    <-- post-flash boot
Hello World! nucleo_wb05kz/stm32wb05
RAM_VR.ResetReason=0x14000000 RCC->CSR=0x00000000
*** Booting Zephyr OS build v4.1.0-rc1-208-g4e594fd87ff1 ***	<-- press RESET a first time
Hello World! nucleo_wb05kz/stm32wb05
RAM_VR.ResetReason=0x04000000 RCC->CSR=0x00000000
*** Booting Zephyr OS build v4.1.0-rc1-208-g4e594fd87ff1 ***	<-- press RESET a second time
Hello World! nucleo_wb05kz/stm32wb05
RAM_VR.ResetReason=0x04000000 RCC->CSR=0x00000000
```