### PR TITLE
doc: ci: reduce documentation build job count

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -18,9 +18,7 @@ env:
   # so we fetch that through pip.
   CMAKE_VERSION: 3.20.5
   DOXYGEN_VERSION: 1.12.0
-  # Job count is set to 2 less than the vCPU count of 16 because the total available RAM is 32GiB
-  # and each sphinx-build process may use more than 2GiB of RAM.
-  JOB_COUNT: 14
+  JOB_COUNT: 4
 
 jobs:
   doc-file-check:


### PR DESCRIPTION
Reduce the number of parallel jobs for documentation build since we use GH-hosted runner with only 4 vCPUs and 16GiB of RAM.