### PR TITLE
workflow: ci: Run samples always only on integration_platforms

### DIFF
--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -45,7 +45,7 @@ jobs:
       BSIM_OUT_PATH: /opt/bsim/
       BSIM_COMPONENTS_PATH: /opt/bsim/components
       TWISTER_COMMON: '--no-detailed-test-id --force-color --inline-logs -v -N -M --retry-failed 3 --timeout-multiplier 2 '
-      WEEKLY_OPTIONS: ' -M --build-only --all --show-footprint --report-filtered'
+      WEEKLY_OPTIONS: ' -M --build-only --show-footprint --report-filtered'
       PR_OPTIONS: ' --clobber-output --integration'
       PUSH_OPTIONS: ' --clobber-output -M --show-footprint --report-filtered'
       COMMIT_RANGE: ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}
@@ -135,8 +135,9 @@ jobs:
         run: |
           export ZEPHYR_BASE=${PWD}
           export ZEPHYR_TOOLCHAIN_VARIANT=zephyr
-          ./scripts/twister --subset ${{matrix.subset}}/${{ strategy.job-total }} ${TWISTER_COMMON} ${PUSH_OPTIONS}
+          ./scripts/twister -T tests --subset ${{matrix.subset}}/${{ strategy.job-total }} ${TWISTER_COMMON} ${PUSH_OPTIONS}
           if [ "${{matrix.subset}}" = "1" ]; then
+            ./scripts/twister -T samples --integration --outdir samples_build ${TWISTER_COMMON} ${PUSH_OPTIONS}
             ./scripts/zephyr_module.py --twister-out module_tests.args
             if [ -s module_tests.args ]; then
               ./scripts/twister +module_tests.args --outdir module_tests ${TWISTER_COMMON} ${PUSH_OPTIONS}
@@ -165,8 +166,10 @@ jobs:
         run: |
           export ZEPHYR_BASE=${PWD}
           export ZEPHYR_TOOLCHAIN_VARIANT=zephyr
-          ./scripts/twister --subset ${{matrix.subset}}/${{ strategy.job-total }} ${TWISTER_COMMON} ${WEEKLY_OPTIONS}
+          # tests are built on all platforms
+          ./scripts/twister -T tests --all --subset ${{matrix.subset}}/${{ strategy.job-total }} ${TWISTER_COMMON} ${WEEKLY_OPTIONS}
           if [ "${{matrix.subset}}" = "1" ]; then
+            ./scripts/twister -T samples --integration --outdir samples_build ${TWISTER_COMMON} ${WEEKLY_OPTIONS}
             ./scripts/zephyr_module.py --twister-out module_tests.args
             if [ -s module_tests.args ]; then
               ./scripts/twister +module_tests.args --outdir module_tests ${TWISTER_COMMON} ${WEEKLY_OPTIONS}
@@ -187,6 +190,7 @@ jobs:
           path: |
             twister-out/twister.xml
             twister-out/twister.json
+            samples_build/twister.xml
             module_tests/twister.xml
             testplan.json
 


### PR DESCRIPTION
A sample per definition shall be tested on documented and supported platforms listed in the sample documentation. Samples shall not be used as tests to verify functionality of a feature on all available plaforms in Zephyr.