### PR TITLE
STM32WB0: add independent watchdog support

### DIFF
--- a/boards/st/nucleo_wb05kz/nucleo_wb05kz.dts
+++ b/boards/st/nucleo_wb05kz/nucleo_wb05kz.dts
@@ -75,6 +75,7 @@
 		sw0 = &user_button_1;
 		sw1 = &user_button_2;
 		sw2 = &user_button_3;
+		watchdog0 = &iwdg;
 	};
 };
 
@@ -113,6 +114,10 @@
 	 */
 	clocks = <&rcc STM32_CLOCK(APB0, 12)>,
 		<&rcc STM32_SRC_LSE NO_SEL>;
+	status = "okay";
+};
+
+&iwdg {
 	status = "okay";
 };
 

--- a/boards/st/nucleo_wb05kz/nucleo_wb05kz.yaml
+++ b/boards/st/nucleo_wb05kz/nucleo_wb05kz.yaml
@@ -18,5 +18,6 @@ supported:
   - pwm
   - rtc
   - spi
+  - watchdog
   - bluetooth
 vendor: st

--- a/boards/st/nucleo_wb07cc/nucleo_wb07cc.dts
+++ b/boards/st/nucleo_wb07cc/nucleo_wb07cc.dts
@@ -74,6 +74,7 @@
 		sw0 = &user_button_1;
 		sw1 = &user_button_2;
 		sw2 = &user_button_3;
+		watchdog0 = &iwdg;
 	};
 };
 
@@ -112,6 +113,10 @@
 	 */
 	clocks = <&rcc STM32_CLOCK(APB0, 12)>,
 		<&rcc STM32_SRC_LSE NO_SEL>;
+	status = "okay";
+};
+
+&iwdg {
 	status = "okay";
 };
 

--- a/boards/st/nucleo_wb07cc/nucleo_wb07cc.yaml
+++ b/boards/st/nucleo_wb07cc/nucleo_wb07cc.yaml
@@ -18,5 +18,6 @@ supported:
   - pwm
   - rtc
   - spi
+  - watchdog
   - bluetooth
 vendor: st

--- a/boards/st/nucleo_wb09ke/nucleo_wb09ke.dts
+++ b/boards/st/nucleo_wb09ke/nucleo_wb09ke.dts
@@ -75,6 +75,7 @@
 		sw0 = &user_button_1;
 		sw1 = &user_button_2;
 		sw2 = &user_button_3;
+		watchdog0 = &iwdg;
 	};
 };
 
@@ -113,6 +114,10 @@
 	 */
 	clocks = <&rcc STM32_CLOCK(APB0, 12)>,
 		<&rcc STM32_SRC_LSE NO_SEL>;
+	status = "okay";
+};
+
+&iwdg {
 	status = "okay";
 };
 

--- a/boards/st/nucleo_wb09ke/nucleo_wb09ke.yaml
+++ b/boards/st/nucleo_wb09ke/nucleo_wb09ke.yaml
@@ -18,5 +18,6 @@ supported:
   - pwm
   - rtc
   - spi
+  - watchdog
   - bluetooth
 vendor: st

--- a/dts/arm/st/wb0/stm32wb0.dtsi
+++ b/dts/arm/st/wb0/stm32wb0.dtsi
@@ -283,6 +283,13 @@
 			generation-delay-ns = <1250>; /* 1.25us */
 			status = "disabled";
 		};
+
+		iwdg: watchdog@40003000 {
+			compatible = "st,stm32-watchdog";
+			reg = <0x40003000 DT_SIZE_K(1)>;
+			clocks = <&rcc STM32_CLOCK(APB0, 14)>;
+			status = "disabled";
+		};
 	};
 
 	bt_hci_wb0: bt_hci_wb0 {


### PR DESCRIPTION
Add minimal support for the IWDG peripheral of STM32WB0 series in existing driver.

Only the bare minimum required to have the same features as on other series has been implemented. Deeper modifications of the driver to take into account STM32WB0 specifics (e.g. window support) can be implemented by a future PR.

Tested OK with (modified) `samples/drivers/watchdog` on all supported STM32WB0 hardware.