### PR TITLE
drivers: udc_stm32: handle ZLP flag for control transfers as well

### DIFF
--- a/drivers/usb/udc/udc_stm32.c
+++ b/drivers/usb/udc/udc_stm32.c
@@ -351,7 +351,7 @@ static void handle_msg_data_in(struct udc_stm32_data *priv, uint8_t epnum)
 		return;
 	}
 
-	if (udc_ep_buf_has_zlp(buf) && ep != USB_CONTROL_EP_IN) {
+	if (udc_ep_buf_has_zlp(buf)) {
 		udc_ep_buf_clear_zlp(buf);
 		HAL_PCD_EP_Transmit(&priv->pcd, ep, buf->data, 0);
 


### PR DESCRIPTION
I mistakenly assumed in the commit 6aaad0a5cd23
("drivers: udc_stm32: handle ZLP flag") that the HAL driver would handle ZLP flag in control transfers itself, but that does not seem to be the case.

Fixes: #84998

Tested on stm32f723e-disco (FS only, pity this board does not configure HS), nucleo_g431rb, nucleo_f413zh.