### PR TITLE
Fix PDF build for Zephyr 4.1 release

### DIFF
--- a/doc/_extensions/zephyr/domain/__init__.py
+++ b/doc/_extensions/zephyr/domain/__init__.py
@@ -1126,7 +1126,11 @@ def install_static_assets_as_needed(
 
 
 def load_board_catalog_into_domain(app: Sphinx) -> None:
-    board_catalog = get_catalog(generate_hw_features=app.config.zephyr_generate_hw_features)
+    board_catalog = get_catalog(
+        generate_hw_features=(
+            app.builder.format == "html" and app.config.zephyr_generate_hw_features
+        )
+    )
     app.env.domaindata["zephyr"]["boards"] = board_catalog["boards"]
     app.env.domaindata["zephyr"]["vendors"] = board_catalog["vendors"]
     app.env.domaindata["zephyr"]["socs"] = board_catalog["socs"]

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,6 +1,6 @@
 # DOC: used to generate docs
 
-sphinx
+sphinx<8.2.0
 sphinx_rtd_theme~=3.0
 sphinx-tabs
 sphinxcontrib-svg2pdfconverter


### PR DESCRIPTION
- Pin to Sphinx < 8.2.0 which was just released and apparently has regressions in image conversion stuff used in the PDF build
- Ensure PDF build doesn't bother with populating list of supported HW features in the board catalog since board docs are not really included in anything but HTML output.