### PR TITLE
More essential thread abort fixery

### DIFF
--- a/arch/arm64/core/fatal.c
+++ b/arch/arm64/core/fatal.c
@@ -414,8 +414,6 @@ void z_arm64_fatal_error(unsigned int reason, struct arch_esf *esf)
 #endif /* CONFIG_EXCEPTION_DEBUG */
 
 	z_fatal_error(reason, esf);
-
-	CODE_UNREACHABLE;
 }
 
 /**

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -434,7 +434,9 @@ static ALWAYS_INLINE void z_thread_halt(struct k_thread *thread, k_spinlock_key_
 		halt_thread(thread, terminate ? _THREAD_DEAD : _THREAD_SUSPENDED);
 		if ((thread == _current) && !arch_is_in_isr()) {
 			if (z_is_thread_essential(thread)) {
+				k_spin_unlock(&_sched_spinlock, key);
 				k_panic();
+				key = k_spin_lock(&_sched_spinlock);
 			}
 			z_swap(&_sched_spinlock, key);
 			__ASSERT(!terminate, "aborted _current back from dead");

--- a/tests/kernel/threads/thread_apis/src/test_essential_thread.c
+++ b/tests/kernel/threads/thread_apis/src/test_essential_thread.c
@@ -112,6 +112,22 @@ ZTEST(threads_lifecycle, test_essential_thread_abort)
 	k_msleep(100);
 	k_thread_abort(&kthread_thread1);
 	zassert_true(fatal_error_signaled, "fatal error was not signaled");
+}
+
+ZTEST(threads_lifecycle, test_essential_thread_abort_self)
+{
+	/* This test case needs to be able to handle a k_panic() call
+	 * that aborts the current thread inside of the panic handler
+	 * itself.  That's putting a lot of strain on the arch layer
+	 * to handle things that haven't traditionally been required.
+	 * These ones aren't there yet.
+	 *
+	 * But run it for everyone else to catch regressions in the
+	 * code we are actually trying to test.
+	 */
+	if (IS_ENABLED(CONFIG_RISCV) || IS_ENABLED(CONFIG_X86) || IS_ENABLED(CONFIG_SPARC)) {
+		ztest_test_skip();
+	}
 
 	fatal_error_signaled = false;
 	k_thread_create(&kthread_thread1, kthread_stack, STACKSIZE,


### PR DESCRIPTION
Nothing is ever simple.  It turns out that there was a bug in the test code that was failing to actually exercise self-abort case (because the handled panic had the effect of terminating the test thread!).  Fixing that showed up a fairly obvious locking mistake, but also a **ton** of architectures that turn out to be simply not ready to handle a thread that panics after having aborted itself. 

In one of those (arm64) I was able to find and fix a relatively straightforward goof.  The other three will need some attention.  I think (!) it's down to the exception exit code relying on stuff that got cleaned up already by the abort, but I'm not sure.  The arm64 one was an easy code generation thing due to a stray CODE_UNREACHABLE.

Basically: this is a partial fix for https://github.com/zephyrproject-rtos/zephyr/issues/86043