### PR TITLE
drivers: nxp_flexio_spi: Fix transfer failures

### DIFF
--- a/drivers/spi/spi_mcux_flexio.c
+++ b/drivers/spi/spi_mcux_flexio.c
@@ -102,11 +102,11 @@ static int spi_mcux_flexio_isr(void *user_data)
 	const struct spi_mcux_flexio_config *config = dev->config;
 	struct spi_mcux_flexio_data *data = dev->data;
 
-#if defined(CONFIG_SOC_SERIES_KE1XZ)
 	/* Wait until data transfer complete. */
-	WAIT_FOR((0U == (FLEXIO_SPI_GetStatusFlags(config->flexio_spi)
-		& (uint32_t)kFLEXIO_SPI_TxBufferEmptyFlag)), 100, NULL);
-#endif
+	WAIT_FOR((3U == (FLEXIO_SPI_GetStatusFlags(config->flexio_spi)
+		& (uint32_t)(kFLEXIO_SPI_TxBufferEmptyFlag | kFLEXIO_SPI_RxBufferFullFlag))),
+		100, NULL);
+
 	FLEXIO_SPI_MasterTransferHandleIRQ(config->flexio_spi, &data->handle);
 
 	return 0;


### PR DESCRIPTION
This fixes failures seen with the SPI loopback test. The fix waits for the TX and RX side to be complete i.e when RX SHIFTBUF has been loaded from the RX Shifter and the TX SHIFTBUF has transferred to the TX Shifter.
Fixes https://github.com/zephyrproject-rtos/zephyr/issues/77992
