### PR TITLE
rtio: workq: Default workqueue to two threads with SPI/I2C/I3C

### DIFF
--- a/subsys/rtio/Kconfig.workq
+++ b/subsys/rtio/Kconfig.workq
@@ -22,6 +22,7 @@ config RTIO_WORKQ_STACK_SIZE
 
 config RTIO_WORKQ_THREADS_POOL
 	int "Number of threads to use for processing work-items"
+	default 2 if SPI_RTIO || I2C_RTIO || I3C_RTIO
 	default 1
 
 config RTIO_WORKQ_POOL_ITEMS


### PR DESCRIPTION
As to facilitate work items preemption: common for sensor read ops. Default is kept the same.

e.g:
- Sensor read (submitted through workqueue).
- SPI read (submitted through workqueue using default handler).

This requires at least 2 thread pools to allow SPI read to complete, to then come back and complete sensor reading.