### PR TITLE
boards: remove `BT_CTLR` usage

### DIFF
--- a/boards/nordic/nrf54l09pdk/Kconfig.defconfig
+++ b/boards/nordic/nrf54l09pdk/Kconfig.defconfig
@@ -3,9 +3,6 @@
 
 if BOARD_NRF54L09PDK_NRF54L09_CPUAPP
 
-config BT_CTLR
-	default BT
-
 config ROM_START_OFFSET
 	default 0x800 if BOOTLOADER_MCUBOOT
 

--- a/boards/others/promicro_nrf52840/Kconfig.defconfig
+++ b/boards/others/promicro_nrf52840/Kconfig.defconfig
@@ -23,7 +23,4 @@ config FLASH_LOAD_OFFSET
 	default 0x1000
 	depends on BOARD_HAS_NRF5_BOOTLOADER && (MCUBOOT || !USE_DT_CODE_PARTITION)
 
-config BT_CTLR
-	default BT
-
 endif # BOARD_PROMICRO_NRF52840


### PR DESCRIPTION
Remove usage of the `BT_CTLR` symbol, as it is now deprecated.