### PR TITLE
mgmt: hawkbit: remove `imply HWINFO`

### DIFF
--- a/subsys/mgmt/hawkbit/Kconfig
+++ b/subsys/mgmt/hawkbit/Kconfig
@@ -19,7 +19,6 @@ menuconfig HAWKBIT
 	select MPU_ALLOW_FLASH_WRITE
 	select IMG_ENABLE_IMAGE_CHECK
 	select IMG_ERASE_PROGRESSIVELY
-	imply HWINFO if !HAWKBIT_CUSTOM_DEVICE_ID
 	help
 	  hawkBit is a domain independent back-end framework for polling out
 	  software updates to constrained edge devices as well as more powerful
@@ -113,11 +112,20 @@ config HAWKBIT_STATUS_BUFFER_SIZE
 	  json strings, that are sent to the hawkBit server. It might
 	  be increased if the custom attributes are used extensively.
 
+choice HAWKBIT_DEVICE_ID_SOURCE
+	prompt "Source of the Hawkbit device ID"
+
+config HAWKBIT_HWINFO_DEVICE_ID
+	bool "Device ID through HWINFO module"
+	depends on HWINFO
+
 config HAWKBIT_CUSTOM_DEVICE_ID
 	bool "Custom device id through callback function"
 	help
 	  Be able to customize the device id during runtime to a custom value,
 	  by configuring the callback function. See `hawkbit_set_device_identity_cb`
+
+endchoice
 
 config HAWKBIT_DEVICE_ID_MAX_LENGTH
 	int "Maximum length of the device id"

--- a/subsys/mgmt/hawkbit/hawkbit_device.c
+++ b/subsys/mgmt/hawkbit/hawkbit_device.c
@@ -19,7 +19,7 @@ bool hawkbit_get_device_identity(char *id, int id_max_len)
 
 static bool hawkbit_get_device_identity_default(char *id, int id_max_len)
 {
-#ifdef CONFIG_HWINFO
+#ifdef CONFIG_HAWKBIT_HWINFO_DEVICE_ID
 	uint8_t hwinfo_id[DEVICE_ID_BIN_MAX_SIZE];
 	ssize_t length;
 
@@ -32,12 +32,12 @@ static bool hawkbit_get_device_identity_default(char *id, int id_max_len)
 	length = bin2hex(hwinfo_id, (size_t)length, id, id_max_len);
 
 	return length > 0;
-#else /* CONFIG_HWINFO */
+#else /* CONFIG_HAWKBIT_HWINFO_DEVICE_ID */
 	ARG_UNUSED(id);
 	ARG_UNUSED(id_max_len);
 
 	return false;
-#endif /* CONFIG_HWINFO */
+#endif /* CONFIG_HAWKBIT_HWINFO_DEVICE_ID */
 }
 
 #ifdef CONFIG_HAWKBIT_CUSTOM_DEVICE_ID


### PR DESCRIPTION
Changing `depends on HWINFO` to `imply HWINFO` in ef9cc18f re-introduces the Kconfig dependency loops that were originally resolved in 31201a7f Move the dependency to a choice symbol which determines where the Hawkbit ID comes from.