### PR TITLE
samples: boards: bbc: add microbit_v2 board to pong example

### DIFF
--- a/samples/boards/bbc/microbit/pong/boards/bbc_microbit_v2.overlay
+++ b/samples/boards/bbc/microbit/pong/boards/bbc_microbit_v2.overlay
@@ -1,0 +1,6 @@
+/ {
+	zephyr,user {
+		/* period cell corresponds to initial period */
+		pwms = <&pwm1 0 PWM_USEC(1500) PWM_POLARITY_NORMAL>;
+	};
+};


### PR DESCRIPTION
Adding board bbc_microbit_v2 overlay to pong example. This change mainly enables to buzzer functionality of the example.