### PR TITLE
boards: renesas: ek_ra6m4: added mikrobus node labels

### DIFF
--- a/boards/renesas/ek_ra6m4/ek_ra6m4-pinctrl.dtsi
+++ b/boards/renesas/ek_ra6m4/ek_ra6m4-pinctrl.dtsi
@@ -12,6 +12,14 @@
 		};
 	};
 
+	sci7_default: sci7_default {
+		group1 {
+			/* tx rx */
+			psels = <RA_PSEL(RA_PSEL_SCI_7, 6, 13)>,
+			<RA_PSEL(RA_PSEL_SCI_7, 6, 14)>;
+		};
+	};
+
 	iic1_default: iic1_default {
 		group1 {
 			/* SCL1 SDA1 */

--- a/boards/renesas/ek_ra6m4/ek_ra6m4.dts
+++ b/boards/renesas/ek_ra6m4/ek_ra6m4.dts
@@ -41,6 +41,29 @@
 		};
 	};
 
+	mikrobus_header: mikrobus-connector {
+		compatible = "mikro-bus";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map =	<0 0 &ioport0 0 0>,	/* AN  */
+				<1 0 &ioport1 15 0>,	/* RST */
+				<2 0 &ioport2 5 0>,	/* CS   */
+				<3 0 &ioport2 4 0>,	/* SCK  */
+				<4 0 &ioport2 2 0>,	/* MISO */
+				<5 0 &ioport2 3 0>,	/* MOSI */
+							/* +3.3V */
+							/* GND */
+				<6 0 &ioport4 8 0>,	/* PWM  */
+				<7 0 &ioport4 9 0>,	/* INT  */
+				<8 0 &ioport6 14 0>,	/* RX   */
+				<9 0 &ioport6 13 0>,	/* TX   */
+				<10 0 &ioport5 12 0>,	/* SCL  */
+				<11 0 &ioport5 11 0>;	/* SDA  */
+							/* +5V */
+							/* GND */
+	};
+
 	buttons {
 		compatible = "gpio-keys";
 		button0: s1 {
@@ -72,6 +95,16 @@
 	};
 };
 
+&sci7 {
+	pinctrl-0 = <&sci7_default>;
+	pinctrl-names = "default";
+	status = "okay";
+	uart7: uart {
+		current-speed = <115200>;
+		status = "okay";
+	};
+};
+
 &iic1 {
 	status = "okay";
 	#address-cells = <1>;
@@ -93,7 +126,23 @@
 	status = "okay";
 };
 
+&ioport1 {
+	status = "okay";
+};
+
+&ioport2 {
+	status = "okay";
+};
+
 &ioport4 {
+	status = "okay";
+};
+
+&ioport5 {
+	status = "okay";
+};
+
+&ioport6 {
 	status = "okay";
 };
 
@@ -190,3 +239,7 @@
 		status = "okay";
 	};
 };
+
+mikrobus_serial: &uart7 {};
+mikrobus_i2c: &iic1 {};
+mikrobus_spi: &spi0 {};


### PR DESCRIPTION
Added mikrobus_serial, mikrobus_i2c, mikrobus_spi and mikrobus_header node labels to EK-RA6M4 device tree board definition, allowing compatible shield boards to be used.