### PR TITLE
dts: arm: renesas: fixed duplicate interrupt numbers

### DIFF
--- a/dts/arm/renesas/ra/ra6/ra6-cm33-common.dtsi
+++ b/dts/arm/renesas/ra/ra6/ra6-cm33-common.dtsi
@@ -121,7 +121,7 @@
 
 		sci9: sci9@40118900 {
 			compatible = "renesas,ra-sci";
-			interrupts = <24 1>, <25 1>, <26 1>, <27 1>;
+			interrupts = <74 1>, <75 1>, <76 1>, <77 1>;
 			interrupt-names = "rxi", "txi", "tei", "eri";
 			reg = <0x40118900 0x100>;
 			clocks = <&pclka MSTPB 22>;
@@ -152,7 +152,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			channel = <0>;
-			interrupts = <28 1>, <29 1>, <30 1>, <31 1>;
+			interrupts = <78 1>, <79 1>, <80 1>, <81 1>;
 			interrupt-names = "rxi", "txi", "tei", "eri";
 			reg = <0x4011a000 0x100>;
 			status = "disabled";
@@ -163,7 +163,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			channel = <1>;
-			interrupts = <32 1>, <33 1>, <34 1>, <35 1>;
+			interrupts = <82 1>, <83 1>, <84 1>, <85 1>;
 			interrupt-names = "rxi", "txi", "tei", "eri";
 			reg = <0x4011a100 0x100>;
 			status = "disabled";


### PR DESCRIPTION
The following pairs of peripherals mistakenly used the same interrupts numbers, causing issues if both are used: sci6/sci9, spi0/sci7 and spi1/sci8.