### PR TITLE
drivers: sensor: bosch: bme680: fix: overflowed value return value

### DIFF
--- a/drivers/sensor/bosch/bme680/bme680.c
+++ b/drivers/sensor/bosch/bme680/bme680.c
@@ -207,7 +207,9 @@ static uint8_t bme680_calc_gas_wait(uint16_t dur)
 			dur = dur / 4;
 			factor += 1;
 		}
-		durval = dur + (factor * 64);
+		const uint16_t max_duration = dur + (factor * 64);
+
+		durval = CLAMP(max_duration, 0, 0xff);
 	}
 
 	return durval;


### PR DESCRIPTION
- Check if the value exceeds the limits of the variable

Fixes #84751 