### PR TITLE
samples: sensor: thermometer: extend sample to support frdm_rw612

### DIFF
--- a/boards/nxp/frdm_rw612/frdm_rw612_common.dtsi
+++ b/boards/nxp/frdm_rw612/frdm_rw612_common.dtsi
@@ -17,6 +17,7 @@
 		i2c-0 = &flexcomm2;
 		pwm-0 = &sctimer;
 		sw0 = &user_button_0;
+		ambient-temp0 = &p3t1755;
 	};
 
 	chosen {
@@ -255,6 +256,12 @@ arduino_i2c: &flexcomm2 {
 	#size-cells = <0>;
 	pinctrl-0 = <&pinmux_flexcomm2_i2c>;
 	pinctrl-names = "default";
+
+	p3t1755: p3t1755@48 {
+		compatible = "nxp,p3t1755";
+		reg = <0x48>;
+		status = "okay";
+	};
 };
 
 zephyr_mipi_dbi_spi: &lcdic {

--- a/samples/sensor/thermometer/sample.yaml
+++ b/samples/sensor/thermometer/sample.yaml
@@ -18,6 +18,7 @@ tests:
       - frdm_k22f             # tcn75a
       - robokit1              # ntc_thermistor
       - adi_eval_adin1110ebz  # adt7420
+      - frdm_rw612            # p3t1755
     extra_args:
       - platform:mimxrt1180_evk/mimxrt1189/cm33:SHIELD=p3t1755dp_ard_i2c
       - platform:mimxrt1180_evk/mimxrt1189/cm7:SHIELD=p3t1755dp_ard_i2c


### PR DESCRIPTION
Now sample extended to support on board p3t1755 temperature sensor
on frdm_rw612 board.

Signed-off-by: Dipak Shetty <shetty.dipak@gmx.com>