### PR TITLE
drivers: video: introduce VIDEO_FOURCC_TO_STR

### DIFF
--- a/include/zephyr/drivers/video.h
+++ b/include/zephyr/drivers/video.h
@@ -834,6 +834,24 @@ void video_closest_frmival(const struct device *dev, enum video_endpoint_id ep,
 #define VIDEO_FOURCC_FROM_STR(str) VIDEO_FOURCC((str)[0], (str)[1], (str)[2], (str)[3])
 
 /**
+ * @brief Convert a four-character-code to a four-character-string
+ *
+ * Convert a four-character code as defined by @ref VIDEO_FOURCC into a string that can be used
+ * anywhere, such as in debug logs with the %s print formatter.
+ *
+ * @param fourcc The 32-bit four-character-code integer to be converted, in CPU-native endinaness.
+ * @return Four-character-string built out of it.
+ */
+#define VIDEO_FOURCC_TO_STR(fourcc)                                                                \
+	((char[]){                                                                                 \
+		(char)((fourcc) & 0xFF),                                                           \
+		(char)(((fourcc) >> 8) & 0xFF),                                                    \
+		(char)(((fourcc) >> 16) & 0xFF),                                                   \
+		(char)(((fourcc) >> 24) & 0xFF),                                                   \
+		'\0'                                                                               \
+	})
+
+/**
  * @name Bayer formats (R, G, B channels).
  *
  * The full color information is spread over multiple pixels.

--- a/samples/drivers/video/capture/src/main.c
+++ b/samples/drivers/video/capture/src/main.c
@@ -120,11 +120,10 @@ int main(void)
 	while (caps.format_caps[i].pixelformat) {
 		const struct video_format_cap *fcap = &caps.format_caps[i];
 		/* fourcc to string */
-		LOG_INF("  %c%c%c%c width [%u; %u; %u] height [%u; %u; %u]",
-		       (char)fcap->pixelformat, (char)(fcap->pixelformat >> 8),
-		       (char)(fcap->pixelformat >> 16), (char)(fcap->pixelformat >> 24),
-		       fcap->width_min, fcap->width_max, fcap->width_step, fcap->height_min,
-		       fcap->height_max, fcap->height_step);
+		LOG_INF("  %s width [%u; %u; %u] height [%u; %u; %u]",
+		       VIDEO_FOURCC_TO_STR(fcap->pixelformat),
+		       fcap->width_min, fcap->width_max, fcap->width_step,
+		       fcap->height_min, fcap->height_max, fcap->height_step);
 		i++;
 	}
 
@@ -147,9 +146,8 @@ int main(void)
 		fmt.pixelformat = VIDEO_FOURCC_FROM_STR(CONFIG_VIDEO_PIXEL_FORMAT);
 	}
 
-	LOG_INF("- Video format: %c%c%c%c %ux%u", (char)fmt.pixelformat,
-	       (char)(fmt.pixelformat >> 8), (char)(fmt.pixelformat >> 16),
-	       (char)(fmt.pixelformat >> 24), fmt.width, fmt.height);
+	LOG_INF("- Video format: %s %ux%u",
+		VIDEO_FOURCC_TO_STR(fmt.pixelformat), fmt.width, fmt.height);
 
 	if (video_set_format(video_dev, VIDEO_EP_OUT, &fmt)) {
 		LOG_ERR("Unable to set format");

--- a/samples/drivers/video/tcpserversink/src/main.c
+++ b/samples/drivers/video/tcpserversink/src/main.c
@@ -94,9 +94,8 @@ int main(void)
 		return 0;
 	}
 
-	printk("Video device detected, format: %c%c%c%c %ux%u\n", (char)fmt.pixelformat,
-	       (char)(fmt.pixelformat >> 8), (char)(fmt.pixelformat >> 16),
-	       (char)(fmt.pixelformat >> 24), fmt.width, fmt.height);
+	printk("Video device detected, format: %s %ux%u\n",
+		VIDEO_FOURCC_TO_STR(fmt.pixelformat), fmt.width, fmt.height);
 
 	if (caps.min_line_count != LINE_COUNT_HEIGHT) {
 		LOG_ERR("Partial framebuffers not supported by this sample");


### PR DESCRIPTION
This adds a macro to generate a C99 compound literal string, which allow to use it in debug log messages, such as:
`LOG_DBG("The pixel format is '%s'", VIDEO_FOURCC_STR(fmt->pixelformat));`

The [previous proposal](https://github.com/zephyrproject-rtos/zephyr/pull/79476) was more awkward: `printf("video format: " PRIvfmt, PRIvfmt_arg(&fmt));`