### PR TITLE
boards: nucleo_h753zi: fix board model string

### DIFF
--- a/boards/st/nucleo_h753zi/nucleo_h753zi.dts
+++ b/boards/st/nucleo_h753zi/nucleo_h753zi.dts
@@ -11,7 +11,7 @@
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 
 / {
-	model = "STMicroelectronics STM32H743ZI-NUCLEO board";
+	model = "STMicroelectronics STM32H753ZI-NUCLEO board";
 	compatible = "st,stm32h753zi-nucleo";
 
 	chosen {


### PR DESCRIPTION
Correct the board model string from STM32H743ZI to STM32H753ZI in the devicetree.