### PR TITLE
doc: releases: Add missing item of Renesas vendor

### DIFF
--- a/doc/releases/release-notes-4.1.rst
+++ b/doc/releases/release-notes-4.1.rst
@@ -323,6 +323,7 @@ New Boards
 
 * Renesas Electronics Corporation
 
+   * :zephyr:board:`ek_ra2l1` (``ek_ra2l1``)
    * :zephyr:board:`ek_ra4l1` (``ek_ra4l1``)
    * :zephyr:board:`ek_ra4m1` (``ek_ra4m1``)
    * :zephyr:board:`fpb_ra4e1` (``fpb_ra4e1``)
@@ -433,6 +434,7 @@ New Drivers
    * :dtcompatible:`nordic,nrf-hsfll-global`
    * :dtcompatible:`nuvoton,npcm-pcc`
    * :dtcompatible:`realtek,rts5912-sccon`
+   * :dtcompatible:`renesas,rz-cpg`
    * :dtcompatible:`st,stm32n6-cpu-clock-mux`
    * :dtcompatible:`st,stm32n6-hse-clock`
    * :dtcompatible:`st,stm32n6-ic-clock-mux`


### PR DESCRIPTION
Add missing item of Renesas vendor in 4.1 release note
- Add information about EK-RA2L1 support.
- Add information about RZ CPG driver support.