### PR TITLE
dts: cpu: Make descriptions consistent

### DIFF
--- a/dts/bindings/cpu/arm,cortex-a53.yaml
+++ b/dts/bindings/cpu/arm,cortex-a53.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2019 Carlo Caione <ccaione@baylibre.com>
 # SPDX-License-Identifier: Apache-2.0
 
-description: This is a representation of ARM Cortex-A53 CPU.
+description: ARM Cortex-A53 CPU
 
 compatible: "arm,cortex-a53"
 

--- a/dts/bindings/cpu/arm,cortex-a55.yaml
+++ b/dts/bindings/cpu/arm,cortex-a55.yaml
@@ -1,7 +1,7 @@
 # Copyright 2022 NXP
 # SPDX-License-Identifier: Apache-2.0
 
-description: This is a representation of ARM Cortex-A55 CPU.
+description: ARM Cortex-A55 CPU
 
 compatible: "arm,cortex-a55"
 

--- a/dts/bindings/cpu/arm,cortex-a72.yaml
+++ b/dts/bindings/cpu/arm,cortex-a72.yaml
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-description: This is a representation of ARM Cortex-A72 CPU.
+description: ARM Cortex-A72 CPU
 
 compatible: "arm,cortex-a72"
 

--- a/dts/bindings/cpu/arm,cortex-a76.yaml
+++ b/dts/bindings/cpu/arm,cortex-a76.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2022 Intel Corp.
 # SPDX-License-Identifier: Apache-2.0
 
-description: This is a representation of ARM Cortex-A76 CPU.
+description: ARM Cortex-A76 CPU
 
 compatible: "arm,cortex-a76"
 

--- a/dts/bindings/cpu/arm,cortex-r52.yaml
+++ b/dts/bindings/cpu/arm,cortex-r52.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2021 Arm Limited (or its affiliates). All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-description: This is a representation of ARM Cortex-R52 CPU.
+description: ARM Cortex-R52 CPU
 
 compatible: "arm,cortex-r52"
 

--- a/dts/bindings/cpu/arm,cortex-r82.yaml
+++ b/dts/bindings/cpu/arm,cortex-r82.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2021 Arm Limited (or its affiliates). All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-description: This is a representation of ARM Cortex-R82 CPU.
+description: ARM Cortex-R82 CPU
 
 compatible: "arm,cortex-r82"
 

--- a/dts/bindings/cpu/gaisler,leon3.yaml
+++ b/dts/bindings/cpu/gaisler,leon3.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2021 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-description: A representation for Gaisler LEON3 CPU.
+description: Gaisler LEON3 CPU
 
 compatible: "gaisler,leon3"
 

--- a/dts/bindings/cpu/qemu,riscv-virt.yaml
+++ b/dts/bindings/cpu/qemu,riscv-virt.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-description: QEMU RISC-V virt machine CPU node
+description: QEMU RISC-V virt machine CPU
 
 compatible: "qemu,riscv-virt"
 

--- a/dts/bindings/cpu/zephyr,native-posix-cpu.yaml
+++ b/dts/bindings/cpu/zephyr,native-posix-cpu.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2021 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-description: A representation for native_posix CPU.
+description: native_posix CPU
 
 compatible: "zephyr,native-posix-cpu"
 


### PR DESCRIPTION
Streamline the description field for CPU bindings by removing inappropriate use of terminology such as "This is a representation of...", or mentions to "node".