### PR TITLE
drivers: Correct value of event macro for all Renesas SoC

### DIFF
--- a/drivers/adc/adc_renesas_ra.c
+++ b/drivers/adc/adc_renesas_ra.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Renesas Electronics Corporation
+ * Copyright (c) 2024-2025 Renesas Electronics Corporation
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -319,11 +319,12 @@ static int adc_ra_init(const struct device *dev)
 	return 0;
 }
 
+#define EVENT_ADC_SCAN_END(idx) BSP_PRV_IELS_ENUM(CONCAT(EVENT_ADC, idx, _SCAN_END))
+
 #define IRQ_CONFIGURE_FUNC(idx)                                                                    \
 	static void adc_ra_configure_func_##idx(void)                                              \
 	{                                                                                          \
-		R_ICU->IELSR[DT_INST_IRQ_BY_NAME(idx, scanend, irq)] =                             \
-			ELC_EVENT_ADC##idx##_SCAN_END;                                             \
+		R_ICU->IELSR[DT_INST_IRQ_BY_NAME(idx, scanend, irq)] = EVENT_ADC_SCAN_END(idx);    \
 		IRQ_CONNECT(DT_INST_IRQ_BY_NAME(idx, scanend, irq),                                \
 			    DT_INST_IRQ_BY_NAME(idx, scanend, priority), adc_ra_isr,               \
 			    DEVICE_DT_INST_GET(idx), 0);                                           \

--- a/drivers/can/can_renesas_ra.c
+++ b/drivers/can/can_renesas_ra.c
@@ -1011,8 +1011,8 @@ static DEVICE_API(can, can_renesas_ra_driver_api) = {
 };
 
 #define CAN_RENESAS_RA_GLOBAL_IRQ_INIT()                                                           \
-	R_ICU->IELSR_b[VECTOR_NUMBER_CAN_GLERR].IELS = ELC_EVENT_CAN_GLERR;                        \
-	R_ICU->IELSR_b[VECTOR_NUMBER_CAN_RXF].IELS = ELC_EVENT_CAN_RXF;                            \
+	R_ICU->IELSR_b[VECTOR_NUMBER_CAN_GLERR].IELS = BSP_PRV_IELS_ENUM(EVENT_CAN_GLERR);         \
+	R_ICU->IELSR_b[VECTOR_NUMBER_CAN_RXF].IELS = BSP_PRV_IELS_ENUM(EVENT_CAN_RXF);             \
 	IRQ_CONNECT(VECTOR_NUMBER_CAN_GLERR,                                                       \
 		    DT_IRQ_BY_NAME(DT_INST(0, renesas_ra_canfd_global), glerr, priority),          \
 		    canfd_error_isr, NULL, 0);                                                     \
@@ -1074,22 +1074,18 @@ DEVICE_DT_DEFINE(DT_COMPAT_GET_ANY_STATUS_OKAY(renesas_ra_canfd_global), can_ren
 		 NULL, NULL, &g_can_renesas_ra_global_cfg, PRE_KERNEL_2, CONFIG_CAN_INIT_PRIORITY,
 		 NULL)
 
-#define _ELC_EVENT_CAN_COMFRX(channel) ELC_EVENT_CAN##channel##_COMFRX
-#define _ELC_EVENT_CAN_TX(channel)     ELC_EVENT_CAN##channel##_TX
-#define _ELC_EVENT_CAN_CHERR(channel)  ELC_EVENT_CAN##channel##_CHERR
-
-#define ELC_EVENT_CAN_COMFRX(channel) _ELC_EVENT_CAN_COMFRX(channel)
-#define ELC_EVENT_CAN_TX(channel)     _ELC_EVENT_CAN_TX(channel)
-#define ELC_EVENT_CAN_CHERR(channel)  _ELC_EVENT_CAN_CHERR(channel)
+#define EVENT_CAN_COMFRX(channel) BSP_PRV_IELS_ENUM(CONCAT(EVENT_CAN, channel, _COMFRX))
+#define EVENT_CAN_TX(channel)     BSP_PRV_IELS_ENUM(CONCAT(EVENT_CAN, channel, _TX))
+#define EVENT_CAN_CHERR(channel)  BSP_PRV_IELS_ENUM(CONCAT(EVENT_CAN, channel, _CHERR))
 
 #define CAN_RENESAS_RA_CHANNEL_IRQ_INIT(index)                                                     \
 	{                                                                                          \
 		R_ICU->IELSR_b[DT_INST_IRQ_BY_NAME(index, rx, irq)].IELS =                         \
-			ELC_EVENT_CAN_COMFRX(DT_INST_PROP(index, channel));                        \
+			EVENT_CAN_COMFRX(DT_INST_PROP(index, channel));                            \
 		R_ICU->IELSR_b[DT_INST_IRQ_BY_NAME(index, tx, irq)].IELS =                         \
-			ELC_EVENT_CAN_TX(DT_INST_PROP(index, channel));                            \
+			EVENT_CAN_TX(DT_INST_PROP(index, channel));                                \
 		R_ICU->IELSR_b[DT_INST_IRQ_BY_NAME(index, err, irq)].IELS =                        \
-			ELC_EVENT_CAN_CHERR(DT_INST_PROP(index, channel));                         \
+			EVENT_CAN_CHERR(DT_INST_PROP(index, channel));                             \
                                                                                                    \
 		IRQ_CONNECT(DT_INST_IRQ_BY_NAME(index, rx, irq),                                   \
 			    DT_INST_IRQ_BY_NAME(index, rx, priority), canfd_common_fifo_rx_isr,    \

--- a/drivers/counter/counter_renesas_ra_agt.c
+++ b/drivers/counter/counter_renesas_ra_agt.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Renesas Electronics Corporation
+ * Copyright (c) 2024-2025 Renesas Electronics Corporation
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -535,11 +535,8 @@ static DEVICE_API(counter, ra_agt_driver_api) = {
 
 #define TIMER(idx) DT_INST_PARENT(idx)
 
-#define _ELC_EVENT_AGT_INT(channel)       ELC_EVENT_AGT##channel##_INT
-#define _ELC_EVENT_AGT_COMPARE_A(channel) ELC_EVENT_AGT##channel##_COMPARE_A
-
-#define ELC_EVENT_AGT_INT(channel)       _ELC_EVENT_AGT_INT(channel)
-#define ELC_EVENT_AGT_COMPARE_A(channel) _ELC_EVENT_AGT_COMPARE_A(channel)
+#define EVENT_AGT_INT(channel)       BSP_PRV_IELS_ENUM(CONCAT(EVENT_AGT, channel, _INT))
+#define EVENT_AGT_COMPARE_A(channel) BSP_PRV_IELS_ENUM(CONCAT(EVENT_AGT, channel, _COMPARE_A))
 
 #define AGT_DEVICE_INIT_RA(n)                                                                      \
 	static const struct counter_ra_agt_config ra_agt_config_##n = {                            \
@@ -570,14 +567,14 @@ static DEVICE_API(counter, ra_agt_driver_api) = {
 	static int counter_ra_agt_##n##_init(const struct device *dev)                             \
 	{                                                                                          \
 		R_ICU->IELSR[DT_IRQ_BY_NAME(TIMER(n), agti, irq)] =                                \
-			ELC_EVENT_AGT_INT(DT_PROP(TIMER(n), channel));                             \
+			EVENT_AGT_INT(DT_PROP(TIMER(n), channel));                                 \
 		IRQ_CONNECT(DT_IRQ_BY_NAME(TIMER(n), agti, irq),                                   \
 			    DT_IRQ_BY_NAME(TIMER(n), agti, priority), counter_ra_agt_agti_isr,     \
 			    DEVICE_DT_INST_GET(n), 0);                                             \
 		irq_enable(DT_IRQ_BY_NAME(TIMER(n), agti, irq));                                   \
                                                                                                    \
 		R_ICU->IELSR[DT_IRQ_BY_NAME(TIMER(n), agtcmai, irq)] =                             \
-			ELC_EVENT_AGT_COMPARE_A(DT_PROP(TIMER(n), channel));                       \
+			EVENT_AGT_COMPARE_A(DT_PROP(TIMER(n), channel));                           \
 		IRQ_CONNECT(DT_IRQ_BY_NAME(TIMER(n), agtcmai, irq),                                \
 			    DT_IRQ_BY_NAME(TIMER(n), agtcmai, priority),                           \
 			    counter_ra_agt_agtcmai_isr, DEVICE_DT_INST_GET(n), 0);                 \

--- a/drivers/display/display_renesas_ra.c
+++ b/drivers/display/display_renesas_ra.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Renesas Electronics Corporation
+ * Copyright (c) 2024-2025 Renesas Electronics Corporation
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -275,7 +275,8 @@ static int display_init(const struct device *dev)
 #define IRQ_CONFIGURE_FUNC(id)                                                                     \
 	static void glcdc_renesas_ra_configure_func_##id(void)                                     \
 	{                                                                                          \
-		R_ICU->IELSR[DT_INST_IRQ_BY_NAME(id, line, irq)] = ELC_EVENT_GLCDC_LINE_DETECT;    \
+		R_ICU->IELSR[DT_INST_IRQ_BY_NAME(id, line, irq)] =                                 \
+			BSP_PRV_IELS_ENUM(EVENT_GLCDC_LINE_DETECT);                                \
 		IRQ_CONNECT(DT_INST_IRQ_BY_NAME(id, line, irq),                                    \
 			    DT_INST_IRQ_BY_NAME(id, line, priority), renesas_ra_glcdc_isr,         \
 			    DEVICE_DT_INST_GET(id), 0);                                            \

--- a/drivers/ethernet/eth_renesas_ra.c
+++ b/drivers/ethernet/eth_renesas_ra.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Renesas Electronics Corporation
+ * Copyright (c) 2024-2025 Renesas Electronics Corporation
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -370,7 +370,7 @@ static void renesas_ra_eth_thread(void *p1, void *p2, void *p3)
 	}
 }
 
-#define ELC_EVENT_EDMAC_EINT(channel) ELC_EVENT_EDMAC##channel##_EINT
+#define EVENT_EDMAC_EINT(channel) BSP_PRV_IELS_ENUM(CONCAT(EVENT_EDMAC, channel, _EINT))
 
 /* Bindings to the platform */
 int renesas_ra_eth_init(const struct device *dev)
@@ -391,7 +391,7 @@ int renesas_ra_eth_init(const struct device *dev)
 		return -EINVAL;
 	}
 
-	R_ICU->IELSR[DT_INST_IRQN(0)] = ELC_EVENT_EDMAC_EINT(0);
+	R_ICU->IELSR[DT_INST_IRQN(0)] = EVENT_EDMAC_EINT(0);
 
 	IRQ_CONNECT(DT_INST_IRQN(0), DT_INST_IRQ(0, priority), renesas_ra_eth_isr,
 		    DEVICE_DT_INST_GET(0), 0);

--- a/drivers/flash/flash_hp_ra.c
+++ b/drivers/flash/flash_hp_ra.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Renesas Electronics Corporation
+ * Copyright (c) 2024-2025 Renesas Electronics Corporation
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -378,8 +378,10 @@ static void flash_controller_ra_irq_config_func(const struct device *dev)
 {
 	ARG_UNUSED(dev);
 
-	R_ICU->IELSR[DT_IRQ_BY_NAME(DT_DRV_INST(0), frdyi, irq)] = ELC_EVENT_FCU_FRDYI;
-	R_ICU->IELSR[DT_IRQ_BY_NAME(DT_DRV_INST(0), fiferr, irq)] = ELC_EVENT_FCU_FIFERR;
+	R_ICU->IELSR[DT_IRQ_BY_NAME(DT_DRV_INST(0), frdyi, irq)] =
+		BSP_PRV_IELS_ENUM(EVENT_FCU_FRDYI);
+	R_ICU->IELSR[DT_IRQ_BY_NAME(DT_DRV_INST(0), fiferr, irq)] =
+		BSP_PRV_IELS_ENUM(EVENT_FCU_FIFERR);
 
 	IRQ_CONNECT(DT_IRQ_BY_NAME(DT_DRV_INST(0), frdyi, irq),
 		    DT_IRQ_BY_NAME(DT_DRV_INST(0), frdyi, priority), fcu_frdyi_isr,

--- a/drivers/i2c/i2c_renesas_ra_iic.c
+++ b/drivers/i2c/i2c_renesas_ra_iic.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Renesas Electronics Corporation
+ * Copyright (c) 2024-2025 Renesas Electronics Corporation
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -479,15 +479,10 @@ static DEVICE_API(i2c, i2c_ra_iic_driver_api) = {
 	.transfer = i2c_ra_iic_transfer,
 };
 
-#define _ELC_EVENT_IIC_RXI(channel) ELC_EVENT_IIC##channel##_RXI
-#define _ELC_EVENT_IIC_TXI(channel) ELC_EVENT_IIC##channel##_TXI
-#define _ELC_EVENT_IIC_TEI(channel) ELC_EVENT_IIC##channel##_TEI
-#define _ELC_EVENT_IIC_ERI(channel) ELC_EVENT_IIC##channel##_ERI
-
-#define ELC_EVENT_IIC_RXI(channel) _ELC_EVENT_IIC_RXI(channel)
-#define ELC_EVENT_IIC_TXI(channel) _ELC_EVENT_IIC_TXI(channel)
-#define ELC_EVENT_IIC_TEI(channel) _ELC_EVENT_IIC_TEI(channel)
-#define ELC_EVENT_IIC_ERI(channel) _ELC_EVENT_IIC_ERI(channel)
+#define EVENT_IIC_RXI(channel) BSP_PRV_IELS_ENUM(CONCAT(EVENT_IIC, channel, _RXI))
+#define EVENT_IIC_TXI(channel) BSP_PRV_IELS_ENUM(CONCAT(EVENT_IIC, channel, _TXI))
+#define EVENT_IIC_TEI(channel) BSP_PRV_IELS_ENUM(CONCAT(EVENT_IIC, channel, _TEI))
+#define EVENT_IIC_ERI(channel) BSP_PRV_IELS_ENUM(CONCAT(EVENT_IIC, channel, _ERI))
 
 #define I2C_RA_IIC_INIT(index)                                                                     \
                                                                                                    \
@@ -496,13 +491,13 @@ static DEVICE_API(i2c, i2c_ra_iic_driver_api) = {
 	static void i2c_ra_iic_irq_config_func##index(const struct device *dev)                    \
 	{                                                                                          \
 		R_ICU->IELSR[DT_INST_IRQ_BY_NAME(index, rxi, irq)] =                               \
-			ELC_EVENT_IIC_RXI(DT_INST_PROP(index, channel));                           \
+			EVENT_IIC_RXI(DT_INST_PROP(index, channel));                               \
 		R_ICU->IELSR[DT_INST_IRQ_BY_NAME(index, txi, irq)] =                               \
-			ELC_EVENT_IIC_TXI(DT_INST_PROP(index, channel));                           \
+			EVENT_IIC_TXI(DT_INST_PROP(index, channel));                               \
 		R_ICU->IELSR[DT_INST_IRQ_BY_NAME(index, tei, irq)] =                               \
-			ELC_EVENT_IIC_TEI(DT_INST_PROP(index, channel));                           \
+			EVENT_IIC_TEI(DT_INST_PROP(index, channel));                               \
 		R_ICU->IELSR[DT_INST_IRQ_BY_NAME(index, eri, irq)] =                               \
-			ELC_EVENT_IIC_ERI(DT_INST_PROP(index, channel));                           \
+			EVENT_IIC_ERI(DT_INST_PROP(index, channel));                               \
                                                                                                    \
 		IRQ_CONNECT(DT_INST_IRQ_BY_NAME(index, rxi, irq),                                  \
 			    DT_INST_IRQ_BY_NAME(index, rxi, priority), iic_master_rxi_isr,         \

--- a/drivers/mipi_dsi/dsi_renesas_ra.c
+++ b/drivers/mipi_dsi/dsi_renesas_ra.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Renesas Electronics Corporation
+ * Copyright (c) 2024-2025 Renesas Electronics Corporation
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -211,12 +211,14 @@ static int mipi_dsi_renesas_ra_init(const struct device *dev)
 #define IRQ_CONFIGURE_FUNC(id)                                                                     \
 	static void mipi_dsi_ra_configure_func_##id(void)                                          \
 	{                                                                                          \
-		R_ICU->IELSR[DT_INST_IRQ_BY_NAME(id, sq0, irq)] = ELC_EVENT_MIPIDSI_SEQ0;          \
+		R_ICU->IELSR[DT_INST_IRQ_BY_NAME(id, sq0, irq)] =                                  \
+			BSP_PRV_IELS_ENUM(EVENT_MIPIDSI_SEQ0);                                     \
 		IRQ_CONNECT(DT_INST_IRQ_BY_NAME(id, sq0, irq),                                     \
 			    DT_INST_IRQ_BY_NAME(id, sq0, priority), mipi_dsi_seq0,                 \
 			    DEVICE_DT_INST_GET(id), 0);                                            \
 		irq_enable(DT_INST_IRQ_BY_NAME(id, sq0, irq));                                     \
-		R_ICU->IELSR[DT_INST_IRQ_BY_NAME(id, ferr, irq)] = ELC_EVENT_MIPIDSI_FERR;         \
+		R_ICU->IELSR[DT_INST_IRQ_BY_NAME(id, ferr, irq)] =                                 \
+			BSP_PRV_IELS_ENUM(EVENT_MIPIDSI_FERR);                                     \
 		IRQ_CONNECT(DT_INST_IRQ_BY_NAME(id, ferr, irq),                                    \
 			    DT_INST_IRQ_BY_NAME(id, ferr, priority), mipi_dsi_ferr,                \
 			    DEVICE_DT_INST_GET(id), 0);                                            \

--- a/drivers/misc/renesas_ra_external_interrupt/renesas_ra_external_interrupt.c
+++ b/drivers/misc/renesas_ra_external_interrupt/renesas_ra_external_interrupt.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Renesas Electronics Corporation
+ * Copyright (c) 2024-2025 Renesas Electronics Corporation
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -152,7 +152,7 @@ static int gpio_ra_interrupt_init(const struct device *dev)
 	static int gpio_ra_irq_init##index(const struct device *dev)                               \
 	{                                                                                          \
 		R_ICU->IELSR[DT_INST_IRQ(index, irq)] =                                            \
-			UTIL_CAT(ELC_EVENT_ICU_IRQ, DT_INST_PROP(index, channel));                 \
+			BSP_PRV_IELS_ENUM(UTIL_CAT(EVENT_ICU_IRQ, DT_INST_PROP(index, channel)));  \
 		IRQ_CONNECT(DT_INST_IRQ(index, irq), DT_INST_IRQ(index, priority), gpio_ra_isr,    \
 			    DEVICE_DT_INST_GET(index), 0);                                         \
 		return gpio_ra_interrupt_init(dev);                                                \

--- a/drivers/pwm/pwm_renesas_ra.c
+++ b/drivers/pwm/pwm_renesas_ra.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Renesas Electronics Corporation
+ * Copyright (c) 2024-2025 Renesas Electronics Corporation
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -485,11 +485,10 @@ static int pwm_renesas_ra_init(const struct device *dev)
 	return 0;
 }
 
-#define _ELC_EVENT_GPT_CAPTURE_COMPARE_A(channel) ELC_EVENT_GPT##channel##_CAPTURE_COMPARE_A
-#define _ELC_EVENT_GPT_COUNTER_OVERFLOW(channel)  ELC_EVENT_GPT##channel##_COUNTER_OVERFLOW
-
-#define ELC_EVENT_GPT_CAPTURE_COMPARE_A(channel) _ELC_EVENT_GPT_CAPTURE_COMPARE_A(channel)
-#define ELC_EVENT_GPT_COUNTER_OVERFLOW(channel)  _ELC_EVENT_GPT_COUNTER_OVERFLOW(channel)
+#define EVENT_GPT_CAPTURE_COMPARE_A(channel)                                                       \
+	BSP_PRV_IELS_ENUM(CONCAT(EVENT_GPT, channel, _CAPTURE_COMPARE_A))
+#define EVENT_GPT_COUNTER_OVERFLOW(channel)                                                        \
+	BSP_PRV_IELS_ENUM(CONCAT(EVENT_GPT, channel, _COUNTER_OVERFLOW))
 
 #ifdef CONFIG_PWM_CAPTURE
 #define PWM_RA_IRQ_CONFIG_INIT(index)                                                              \
@@ -546,8 +545,8 @@ static int pwm_renesas_ra_init(const struct device *dev)
 				.cycle_end_irq = DT_INST_IRQ_BY_NAME(index, overflow, irq),        \
 			},                                                                         \
 		.extend_cfg = g_timer1_extend_##index,                                             \
-		.capture_a_event = ELC_EVENT_GPT_CAPTURE_COMPARE_A(DT_INST_PROP(index, channel)),  \
-		.overflow_event = ELC_EVENT_GPT_COUNTER_OVERFLOW(DT_INST_PROP(index, channel)),    \
+		.capture_a_event = EVENT_GPT_CAPTURE_COMPARE_A(DT_INST_PROP(index, channel)),      \
+		.overflow_event = EVENT_GPT_COUNTER_OVERFLOW(DT_INST_PROP(index, channel)),        \
 	};                                                                                         \
 	static const struct pwm_renesas_ra_config pwm_renesas_ra_config_##index = {                \
 		.pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(index),                                   \

--- a/drivers/sdhc/sdhc_renesas_ra.c
+++ b/drivers/sdhc/sdhc_renesas_ra.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Renesas Electronics Corporation
+ * Copyright (c) 2024-2025 Renesas Electronics Corporation
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -591,24 +591,20 @@ static DEVICE_API(sdhc, sdhc_api) = {
 	.get_host_props = sdhc_ra_get_host_props,
 };
 
-#define _ELC_EVENT_SDMMC_ACCS(channel)    ELC_EVENT_SDHIMMC##channel##_ACCS
-#define _ELC_EVENT_SDMMC_CARD(channel)    ELC_EVENT_SDHIMMC##channel##_CARD
-#define _ELC_EVENT_SDMMC_DMA_REQ(channel) ELC_EVENT_SDHIMMC##channel##_DMA_REQ
-
-#define ELC_EVENT_SDMMC_ACCS(channel)    _ELC_EVENT_SDMMC_ACCS(channel)
-#define ELC_EVENT_SDMMC_CARD(channel)    _ELC_EVENT_SDMMC_CARD(channel)
-#define ELC_EVENT_SDMMC_DMA_REQ(channel) _ELC_EVENT_SDMMC_DMA_REQ(channel)
+#define EVENT_SDMMC_ACCS(channel)    BSP_PRV_IELS_ENUM(CONCAT(EVENT_SDHIMMC, channel, _ACCS))
+#define EVENT_SDMMC_CARD(channel)    BSP_PRV_IELS_ENUM(CONCAT(EVENT_SDHIMMC, channel, _CARD))
+#define EVENT_SDMMC_DMA_REQ(channel) BSP_PRV_IELS_ENUM(CONCAT(EVENT_SDHIMMC, channel, _DMA_REQ))
 
 #define RA_SDMMC_IRQ_CONFIG_INIT(index)                                                            \
 	do {                                                                                       \
 		ARG_UNUSED(dev);                                                                   \
                                                                                                    \
 		R_ICU->IELSR[DT_INST_IRQ_BY_NAME(index, accs, irq)] =                              \
-			ELC_EVENT_SDMMC_ACCS(DT_INST_PROP(index, channel));                        \
+			EVENT_SDMMC_ACCS(DT_INST_PROP(index, channel));                            \
 		R_ICU->IELSR[DT_INST_IRQ_BY_NAME(index, card, irq)] =                              \
-			ELC_EVENT_SDMMC_CARD(DT_INST_PROP(index, channel));                        \
+			EVENT_SDMMC_CARD(DT_INST_PROP(index, channel));                            \
 		R_ICU->IELSR[DT_INST_IRQ_BY_NAME(index, dma_req, irq)] =                           \
-			ELC_EVENT_SDMMC_DMA_REQ(DT_INST_PROP(index, channel));                     \
+			EVENT_SDMMC_DMA_REQ(DT_INST_PROP(index, channel));                         \
                                                                                                    \
 		IRQ_CONNECT(DT_INST_IRQ_BY_NAME(index, accs, irq),                                 \
 			    DT_INST_IRQ_BY_NAME(index, accs, priority), ra_sdmmc_accs_isr,         \

--- a/drivers/serial/uart_renesas_ra8_sci_b.c
+++ b/drivers/serial/uart_renesas_ra8_sci_b.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Renesas Electronics Corporation
+ * Copyright (c) 2024-2025 Renesas Electronics Corporation
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -995,28 +995,23 @@ static void uart_ra_sci_b_eri_isr(const struct device *dev)
 
 #endif /* defined(CONFIG_UART_INTERRUPT_DRIVEN) || defined(CONFIG_UART_ASYNC_API) */
 
-#define _ELC_EVENT_SCI_RXI(channel) ELC_EVENT_SCI##channel##_RXI
-#define _ELC_EVENT_SCI_TXI(channel) ELC_EVENT_SCI##channel##_TXI
-#define _ELC_EVENT_SCI_TEI(channel) ELC_EVENT_SCI##channel##_TEI
-#define _ELC_EVENT_SCI_ERI(channel) ELC_EVENT_SCI##channel##_ERI
-
-#define ELC_EVENT_SCI_RXI(channel) _ELC_EVENT_SCI_RXI(channel)
-#define ELC_EVENT_SCI_TXI(channel) _ELC_EVENT_SCI_TXI(channel)
-#define ELC_EVENT_SCI_TEI(channel) _ELC_EVENT_SCI_TEI(channel)
-#define ELC_EVENT_SCI_ERI(channel) _ELC_EVENT_SCI_ERI(channel)
+#define EVENT_SCI_RXI(channel) BSP_PRV_IELS_ENUM(CONCAT(EVENT_SCI, channel, _RXI))
+#define EVENT_SCI_TXI(channel) BSP_PRV_IELS_ENUM(CONCAT(EVENT_SCI, channel, _TXI))
+#define EVENT_SCI_TEI(channel) BSP_PRV_IELS_ENUM(CONCAT(EVENT_SCI, channel, _TEI))
+#define EVENT_SCI_ERI(channel) BSP_PRV_IELS_ENUM(CONCAT(EVENT_SCI, channel, _ERI))
 
 #if defined(CONFIG_UART_INTERRUPT_DRIVEN) || defined(CONFIG_UART_ASYNC_API)
 
 #define UART_RA_SCI_B_IRQ_CONFIG_INIT(index)                                                       \
 	do {                                                                                       \
 		R_ICU->IELSR[DT_IRQ_BY_NAME(DT_INST_PARENT(index), rxi, irq)] =                    \
-			ELC_EVENT_SCI_RXI(DT_INST_PROP(index, channel));                           \
+			EVENT_SCI_RXI(DT_INST_PROP(index, channel));                               \
 		R_ICU->IELSR[DT_IRQ_BY_NAME(DT_INST_PARENT(index), txi, irq)] =                    \
-			ELC_EVENT_SCI_TXI(DT_INST_PROP(index, channel));                           \
+			EVENT_SCI_TXI(DT_INST_PROP(index, channel));                               \
 		R_ICU->IELSR[DT_IRQ_BY_NAME(DT_INST_PARENT(index), tei, irq)] =                    \
-			ELC_EVENT_SCI_TEI(DT_INST_PROP(index, channel));                           \
+			EVENT_SCI_TEI(DT_INST_PROP(index, channel));                               \
 		R_ICU->IELSR[DT_IRQ_BY_NAME(DT_INST_PARENT(index), eri, irq)] =                    \
-			ELC_EVENT_SCI_ERI(DT_INST_PROP(index, channel));                           \
+			EVENT_SCI_ERI(DT_INST_PROP(index, channel));                               \
                                                                                                    \
 		IRQ_CONNECT(DT_IRQ_BY_NAME(DT_INST_PARENT(index), rxi, irq),                       \
 			    DT_IRQ_BY_NAME(DT_INST_PARENT(index), rxi, priority),                  \
@@ -1108,6 +1103,10 @@ static void uart_ra_sci_b_eri_isr(const struct device *dev)
 #define UART_RA_SCI_B_DTC_INIT(index)
 #endif
 
+#define FLOW_CTRL_PARAMETER(index)                                                                 \
+	COND_CODE_1(DT_INST_PROP(index, hw_flow_control),                                          \
+	(UART_CFG_FLOW_CTRL_RTS_CTS), (UART_CFG_FLOW_CTRL_NONE))
+
 #define UART_RA_SCI_B_INIT(index)                                                                  \
 	PINCTRL_DT_DEFINE(DT_INST_PARENT(index));                                                  \
                                                                                                    \
@@ -1123,9 +1122,7 @@ static void uart_ra_sci_b_eri_isr(const struct device *dev)
 				.parity = UART_CFG_PARITY_NONE,                                    \
 				.stop_bits = UART_CFG_STOP_BITS_1,                                 \
 				.data_bits = UART_CFG_DATA_BITS_8,                                 \
-				.flow_ctrl = COND_CODE_1(DT_INST_PROP(index, hw_flow_control),     \
-							 (UART_CFG_FLOW_CTRL_RTS_CTS),             \
-							 (UART_CFG_FLOW_CTRL_NONE)),               \
+				.flow_ctrl = FLOW_CTRL_PARAMETER(index),                           \
 			},                                                                         \
 		.fsp_config =                                                                      \
 			{                                                                          \

--- a/drivers/spi/spi_b_renesas_ra8.c
+++ b/drivers/spi/spi_b_renesas_ra8.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Renesas Electronics Corporation
+ * Copyright (c) 2024-2025 Renesas Electronics Corporation
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -402,10 +402,9 @@ static int ra_spi_b_release(const struct device *dev, const struct spi_config *c
 
 static DEVICE_API(spi, ra_spi_driver_api) = {.transceive = ra_spi_b_transceive,
 #ifdef CONFIG_SPI_ASYNC
-							.transceive_async =
-								ra_spi_b_transceive_async,
+					     .transceive_async = ra_spi_b_transceive_async,
 #endif /* CONFIG_SPI_ASYNC */
-							.release = ra_spi_b_release};
+					     .release = ra_spi_b_release};
 
 static spi_b_clock_source_t ra_spi_b_clock_name(const struct device *clock_dev)
 {
@@ -604,15 +603,10 @@ static void ra_spi_eri_isr(const struct device *dev)
 }
 #endif
 
-#define _ELC_EVENT_SPI_RXI(channel) ELC_EVENT_SPI##channel##_RXI
-#define _ELC_EVENT_SPI_TXI(channel) ELC_EVENT_SPI##channel##_TXI
-#define _ELC_EVENT_SPI_TEI(channel) ELC_EVENT_SPI##channel##_TEI
-#define _ELC_EVENT_SPI_ERI(channel) ELC_EVENT_SPI##channel##_ERI
-
-#define ELC_EVENT_SPI_RXI(channel) _ELC_EVENT_SPI_RXI(channel)
-#define ELC_EVENT_SPI_TXI(channel) _ELC_EVENT_SPI_TXI(channel)
-#define ELC_EVENT_SPI_TEI(channel) _ELC_EVENT_SPI_TEI(channel)
-#define ELC_EVENT_SPI_ERI(channel) _ELC_EVENT_SPI_ERI(channel)
+#define EVENT_SPI_RXI(channel) BSP_PRV_IELS_ENUM(CONCAT(EVENT_SPI, channel, _RXI))
+#define EVENT_SPI_TXI(channel) BSP_PRV_IELS_ENUM(CONCAT(EVENT_SPI, channel, _TXI))
+#define EVENT_SPI_TEI(channel) BSP_PRV_IELS_ENUM(CONCAT(EVENT_SPI, channel, _TEI))
+#define EVENT_SPI_ERI(channel) BSP_PRV_IELS_ENUM(CONCAT(EVENT_SPI, channel, _ERI))
 
 #if defined(CONFIG_SPI_B_INTERRUPT)
 
@@ -621,13 +615,13 @@ static void ra_spi_eri_isr(const struct device *dev)
 		ARG_UNUSED(dev);                                                                   \
                                                                                                    \
 		R_ICU->IELSR[DT_INST_IRQ_BY_NAME(index, rxi, irq)] =                               \
-			ELC_EVENT_SPI_RXI(DT_INST_PROP(index, channel));                           \
+			EVENT_SPI_RXI(DT_INST_PROP(index, channel));                               \
 		R_ICU->IELSR[DT_INST_IRQ_BY_NAME(index, txi, irq)] =                               \
-			ELC_EVENT_SPI_TXI(DT_INST_PROP(index, channel));                           \
+			EVENT_SPI_TXI(DT_INST_PROP(index, channel));                               \
 		R_ICU->IELSR[DT_INST_IRQ_BY_NAME(index, tei, irq)] =                               \
-			ELC_EVENT_SPI_TEI(DT_INST_PROP(index, channel));                           \
+			EVENT_SPI_TEI(DT_INST_PROP(index, channel));                               \
 		R_ICU->IELSR[DT_INST_IRQ_BY_NAME(index, eri, irq)] =                               \
-			ELC_EVENT_SPI_ERI(DT_INST_PROP(index, channel));                           \
+			EVENT_SPI_ERI(DT_INST_PROP(index, channel));                               \
                                                                                                    \
 		IRQ_CONNECT(DT_INST_IRQ_BY_NAME(index, rxi, irq),                                  \
 			    DT_INST_IRQ_BY_NAME(index, rxi, priority), ra_spi_rxi_isr,             \

--- a/drivers/spi/spi_renesas_ra.c
+++ b/drivers/spi/spi_renesas_ra.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Renesas Electronics Corporation
+ * Copyright (c) 2024-2025 Renesas Electronics Corporation
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -462,9 +462,9 @@ static int ra_spi_release(const struct device *dev, const struct spi_config *con
 
 static DEVICE_API(spi, ra_spi_driver_api) = {.transceive = ra_spi_transceive,
 #ifdef CONFIG_SPI_ASYNC
-							.transceive_async = ra_spi_transceive_async,
+					     .transceive_async = ra_spi_transceive_async,
 #endif /* CONFIG_SPI_ASYNC */
-							.release = ra_spi_release};
+					     .release = ra_spi_release};
 
 static int spi_ra_init(const struct device *dev)
 {
@@ -664,15 +664,10 @@ static void ra_spi_eri_isr(const struct device *dev)
 }
 #endif
 
-#define _ELC_EVENT_SPI_RXI(channel) ELC_EVENT_SPI##channel##_RXI
-#define _ELC_EVENT_SPI_TXI(channel) ELC_EVENT_SPI##channel##_TXI
-#define _ELC_EVENT_SPI_TEI(channel) ELC_EVENT_SPI##channel##_TEI
-#define _ELC_EVENT_SPI_ERI(channel) ELC_EVENT_SPI##channel##_ERI
-
-#define ELC_EVENT_SPI_RXI(channel) _ELC_EVENT_SPI_RXI(channel)
-#define ELC_EVENT_SPI_TXI(channel) _ELC_EVENT_SPI_TXI(channel)
-#define ELC_EVENT_SPI_TEI(channel) _ELC_EVENT_SPI_TEI(channel)
-#define ELC_EVENT_SPI_ERI(channel) _ELC_EVENT_SPI_ERI(channel)
+#define EVENT_SPI_RXI(channel) BSP_PRV_IELS_ENUM(CONCAT(EVENT_SPI, channel, _RXI))
+#define EVENT_SPI_TXI(channel) BSP_PRV_IELS_ENUM(CONCAT(EVENT_SPI, channel, _TXI))
+#define EVENT_SPI_TEI(channel) BSP_PRV_IELS_ENUM(CONCAT(EVENT_SPI, channel, _TEI))
+#define EVENT_SPI_ERI(channel) BSP_PRV_IELS_ENUM(CONCAT(EVENT_SPI, channel, _ERI))
 
 #if defined(CONFIG_SPI_INTERRUPT)
 
@@ -681,13 +676,13 @@ static void ra_spi_eri_isr(const struct device *dev)
 		ARG_UNUSED(dev);                                                                   \
                                                                                                    \
 		R_ICU->IELSR[DT_INST_IRQ_BY_NAME(index, rxi, irq)] =                               \
-			ELC_EVENT_SPI_RXI(DT_INST_PROP(index, channel));                           \
+			EVENT_SPI_RXI(DT_INST_PROP(index, channel));                               \
 		R_ICU->IELSR[DT_INST_IRQ_BY_NAME(index, txi, irq)] =                               \
-			ELC_EVENT_SPI_TXI(DT_INST_PROP(index, channel));                           \
+			EVENT_SPI_TXI(DT_INST_PROP(index, channel));                               \
 		R_ICU->IELSR[DT_INST_IRQ_BY_NAME(index, tei, irq)] =                               \
-			ELC_EVENT_SPI_TEI(DT_INST_PROP(index, channel));                           \
+			EVENT_SPI_TEI(DT_INST_PROP(index, channel));                               \
 		R_ICU->IELSR[DT_INST_IRQ_BY_NAME(index, eri, irq)] =                               \
-			ELC_EVENT_SPI_ERI(DT_INST_PROP(index, channel));                           \
+			EVENT_SPI_ERI(DT_INST_PROP(index, channel));                               \
                                                                                                    \
 		IRQ_CONNECT(DT_INST_IRQ_BY_NAME(index, rxi, irq),                                  \
 			    DT_INST_IRQ_BY_NAME(index, rxi, priority), ra_spi_rxi_isr,             \

--- a/drivers/usb/udc/udc_renesas_ra.c
+++ b/drivers/usb/udc/udc_renesas_ra.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Renesas Electronics Corporation
+ * Copyright (c) 2024-2025 Renesas Electronics Corporation
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -687,16 +687,16 @@ static int udc_renesas_ra_driver_preinit(const struct device *dev)
 
 #if DT_HAS_COMPAT_STATUS_OKAY(renesas_ra_usbhs)
 	if (priv->udc_cfg.hs_irq != (IRQn_Type)BSP_IRQ_DISABLED) {
-		R_ICU->IELSR[priv->udc_cfg.hs_irq] = ELC_EVENT_USBHS_USB_INT_RESUME;
+		R_ICU->IELSR[priv->udc_cfg.hs_irq] = BSP_PRV_IELS_ENUM(EVENT_USBHS_USB_INT_RESUME);
 	}
 #endif
 
 	if (priv->udc_cfg.irq != (IRQn_Type)BSP_IRQ_DISABLED) {
-		R_ICU->IELSR[priv->udc_cfg.irq] = ELC_EVENT_USBFS_INT;
+		R_ICU->IELSR[priv->udc_cfg.irq] = BSP_PRV_IELS_ENUM(EVENT_USBFS_INT);
 	}
 
 	if (priv->udc_cfg.irq_r != (IRQn_Type)BSP_IRQ_DISABLED) {
-		R_ICU->IELSR[priv->udc_cfg.irq_r] = ELC_EVENT_USBFS_RESUME;
+		R_ICU->IELSR[priv->udc_cfg.irq_r] = BSP_PRV_IELS_ENUM(EVENT_USBFS_RESUME);
 	}
 
 	config->make_thread(dev);

--- a/west.yml
+++ b/west.yml
@@ -219,7 +219,7 @@ manifest:
         - hal
     - name: hal_renesas
       path: modules/hal/renesas
-      revision: 1589073f4fb8a7d7e554a657a12393b6c1315a1a
+      revision: 3204903bdc5eda6869a40363560a69369c8d0e22
       groups:
         - hal
     - name: hal_rpi_pico


### PR DESCRIPTION
Correct Event macro to input correct value for IELSR register for all Renesas SoC