### PR TITLE
soc: miv: polarfire: Increase NUM_IRQS to cover 1st and 2nd level irqs

### DIFF
--- a/soc/microchip/miv/polarfire/Kconfig.defconfig
+++ b/soc/microchip/miv/polarfire/Kconfig.defconfig
@@ -23,6 +23,6 @@ config MAX_IRQ_PER_AGGREGATOR
 	default 186
 
 config NUM_IRQS
-	default 186
+	default 199
 
 endif # SOC_SERIES_POLARFIRE


### PR DESCRIPTION
It was detected by test_sw_isr_irq_parent_table_idx in arch.interrupt:

ASSERTION FAIL [table_idx < (186 - 0)] @ WEST_TOPDIR/zephyr/arch/common/multilevel_irq.c:91 table_idx(186) < IRQ_TABLE_SIZE(186)

NUM_IRQS was previously set to the same value as MAX_IRQ_PER_AGGREGATOR and it didn't take into account the number of 1st level interrupts specified by 2ND_LVL_ISR_TBL_OFFSET. In the generated __sw_isr_table, Level 2 interrupts start at the offset specified by 2ND_LVL_ISR_TBL_OFFSET.

For PolarFire SoC, upper interrupt sources for PLIC correspond to Bus Error Unit and Fabric Interface. They are currently not used by platforms in Zephyr, so the previous value of NUM_IRQS hasn't caused issues for regular applications.

As it doesn't look like an explicit memory optimization, increase NUM_IRQS to allow kernel interrupt tests to pass.

Note:

2ND_LVL_ISR_TBL_OFFSET=13 and NUM_IRQS=199 don't include additional 48 Local Interrupts supported by cores. In total, there are 64 bits in Machine Interrupt Pending Register (mip) which can be used to configure 1st level interrupts.

As a further extension to the platform, values could be extended to 2ND_LVL_ISR_TBL_OFFSET=64 and NUM_IRQS=250. This commit increases NUM_IRQS by a minimal value required to pass kernel interrupt tests.

Link: https://ww1.microchip.com/downloads/aemDocuments/documents/FPGA/ProductDocuments/ReferenceManuals/PolarFire_SoC_FPGA_MSS_Technical_Reference_Manual_VC.pdf

Fixes #86219