### PR TITLE
drivers: wifi: siwx91x: Fix scan logic to reject unsupported bands and channels

### DIFF
--- a/drivers/wifi/siwx91x/siwx91x_wifi.h
+++ b/drivers/wifi/siwx91x/siwx91x_wifi.h
@@ -18,6 +18,7 @@ struct siwx91x_dev {
 	struct net_if *iface;
 	sl_mac_address_t macaddr;
 	enum wifi_iface_state state;
+	enum wifi_iface_state scan_prev_state;
 	scan_result_cb_t scan_res_cb;
 	uint16_t scan_max_bss_cnt;
 


### PR DESCRIPTION
- Rejected scan if only band is not 2.4Ghz.
- Ignored 5GHz channels if provided in channel bitmap.
- Overrode the WIFI_MGMT_SCAN_CHAN_MAX_MANUAL parameter to 50.