### PR TITLE
hal: infineon: handle gcc flag

### DIFF
--- a/cmake/compiler/arcmwdt/compiler_flags.cmake
+++ b/cmake/compiler/arcmwdt/compiler_flags.cmake
@@ -208,8 +208,9 @@ if(CONFIG_ARCMWDT_LIBC)
   set_property(TARGET asm APPEND PROPERTY required "-I${NOSTDINC}")
 endif()
 
-# Remove after testing that -Wshadow works
+# Update after testing that -Wshadow and -Wno-array-bounds works
 set_compiler_property(PROPERTY warning_shadow_variables)
+set_compiler_property(PROPERTY warning_no_array_bounds)
 
 set_compiler_property(PROPERTY no_builtin -fno-builtin)
 set_compiler_property(PROPERTY no_builtin_malloc -fno-builtin-malloc)

--- a/cmake/compiler/compiler_flags_template.cmake
+++ b/cmake/compiler/compiler_flags_template.cmake
@@ -141,6 +141,8 @@ set_compiler_property(PROPERTY no_global_merge)
 
 # Compiler flag for warning about shadow variables
 set_compiler_property(PROPERTY warning_shadow_variables)
+# Compiler flag for disabling warning about array bounds
+set_compiler_property(PROPERTY warning_no_array_bounds)
 
 # Compiler flags to avoid recognizing built-in functions
 set_compiler_property(PROPERTY no_builtin)

--- a/cmake/compiler/gcc/compiler_flags.cmake
+++ b/cmake/compiler/gcc/compiler_flags.cmake
@@ -249,6 +249,7 @@ set_compiler_property(PROPERTY no_position_independent
 set_compiler_property(PROPERTY no_global_merge "")
 
 set_compiler_property(PROPERTY warning_shadow_variables -Wshadow)
+set_compiler_property(PROPERTY warning_no_array_bounds -Wno-array-bounds)
 
 set_compiler_property(PROPERTY no_builtin -fno-builtin)
 set_compiler_property(PROPERTY no_builtin_malloc -fno-builtin-malloc)

--- a/cmake/compiler/iar/compiler_flags.cmake
+++ b/cmake/compiler/iar/compiler_flags.cmake
@@ -166,6 +166,10 @@ set_property(TARGET asm PROPERTY required)
 
 # Compiler flag for disabling pointer arithmetic warnings
 set_compiler_property(PROPERTY warning_no_pointer_arithmetic)
+# Compiler flag for warning about shadow variables
+set_compiler_property(PROPERTY warning_shadow_variables)
+# Compiler flag for disabling warning about array bounds
+set_compiler_property(PROPERTY warning_no_array_bounds)
 
 # Compiler flags for disabling position independent code / executable
 set_compiler_property(PROPERTY no_position_independent)

--- a/modules/hal_infineon/CMakeLists.txt
+++ b/modules/hal_infineon/CMakeLists.txt
@@ -4,7 +4,7 @@
 
 if(CONFIG_HAS_XMCLIB OR CONFIG_SOC_FAMILY_PSOC6_LEGACY OR CONFIG_SOC_FAMILY_INFINEON_CAT1)
   zephyr_library_named(modules_hal_infineon)
-  zephyr_library_compile_options(-Wno-array-bounds)
+  zephyr_library_compile_options($<TARGET_PROPERTY:compiler,warning_no_array_bounds>)
 endif()
 
 ## Add PDL sources for XMC devices


### PR DESCRIPTION
Move -Wno-array-bounds from being hardcoded to a compiler property