### PR TITLE
dts: arm: nxp: i.MX RT10xx move die-temp0 from chosen to aliases

### DIFF
--- a/dts/arm/nxp/nxp_rt10xx.dtsi
+++ b/dts/arm/nxp/nxp_rt10xx.dtsi
@@ -14,9 +14,12 @@
 #include <zephyr/dt-bindings/memory-controller/nxp,flexram.h>
 
 / {
+	aliases {
+		die-temp0 = &tempmon;
+	};
+
 	chosen {
 		zephyr,entropy = &trng;
-		die-temp0 = &tempmon;
 	};
 
 	cpus {

--- a/samples/sensor/die_temp_polling/boards/mimxrt1064_evk.overlay
+++ b/samples/sensor/die_temp_polling/boards/mimxrt1064_evk.overlay
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2025 SECO Mind Srl
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&tempmon {
+	status = "okay";
+};


### PR DESCRIPTION
Move `die-temp0` to the aliases section making it possible to run the `die_temp_polling` sample on NXP i.MX RT10xx boards.
Closes #86227.