### PR TITLE
tests: bluetooth: tester: Fix invalid check in oob_data_request

### DIFF
--- a/tests/bluetooth/tester/src/btp_gap.c
+++ b/tests/bluetooth/tester/src/btp_gap.c
@@ -368,7 +368,7 @@ static void oob_data_request(struct bt_conn *conn,
 	switch (oob_info->type) {
 	case BT_CONN_OOB_LE_SC:
 	{
-		if (!IS_ENABLED(CONFIG_BT_SMP_SC_PAIR_ONLY)) {
+		if (IS_ENABLED(CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY)) {
 			LOG_ERR("OOB LE SC not supported");
 			break;
 		}
@@ -412,7 +412,7 @@ static void oob_data_request(struct bt_conn *conn,
 	}
 
 	case BT_CONN_OOB_LE_LEGACY:
-		if (!IS_ENABLED(CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY)) {
+		if (IS_ENABLED(CONFIG_BT_SMP_SC_PAIR_ONLY)) {
 			LOG_ERR("OOB LE Legacy not supported");
 			break;
 		}


### PR DESCRIPTION
CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY disables all but legacy OOB pairing (including LE SC) and is not intended for enabling/disabling support for legacy OOB pairing. bt_le_oob_set_legacy_tk() depends on CONFIG_BT_SMP_SC_PAIR_ONLY so just use same check here.

For BT_CONN_OOB_LE_SC only supported way to disable LE SC OOB is
to force BT_SMP_OOB_LEGACY_PAIR_ONLY which disables all pairing
except legacy OOB support.