### PR TITLE
west.yml: MCUboot synchronization from upstream

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -303,7 +303,7 @@ manifest:
       groups:
         - crypto
     - name: mcuboot
-      revision: 346f7374ff4467e40b5594658f8ac67a5e9813c9
+      revision: 1b2fc096d9a683a7481b13749d01ca8fa78e7afd
       path: bootloader/mcuboot
       groups:
         - bootloader


### PR DESCRIPTION
Update Zephyr fork of MCUboot to revision:
  1b2fc096d9a683a7481b13749d01ca8fa78e7afd
    
Brings following Zephyr relevant fixes:
    
  - 1b2fc096 boot: Reuse pointers for flash_area objects from state
  - d00b11dc boot: bootutil: Take into account scratch trailer when computing max image size
  - d1a3b953 boot: bootutil: Ensure the whole trailer is erased when it is large
  - 66d41e73 boot: bootutil: Fix scratch trailer overwritten if image trailer is large
  - 8975d5c4 boot: bootutil: Fix underflow in swap-scratch when trailer is large
  - a43167e3 zephyr: fix Mbed TLS configuration header file selection
  - fbd2267e boot: bootutil: Fix invalid last sector computation for swap-scratch
  - 7330df7c boot: bootutil: Fix last sector index computation for swap-offset
  - 429e2fea boot: zephyr: kconfig: Add new defaults option for FIH
  - 602cb459 Fix path for DT example
  - 3ff75490 zephyr: Add Kconfig option CONFIG_BOOT_KEY_IMPORT_BYPASS_ASN
  - f2b6def9 zephyr: Enable building ed25519 PSA variant with Zephyr

Notes on process:
 1) The MCUboot update from [mcu-tools/mcuboot/main](https://github.com/mcu-tools/mcuboot/tree/main) with the SHA used in west.yaml is already synchronized to [zephyrproject-rtos/mcuboot/upstream-sync](https://github.com/zephyrproject-rtos/mcuboot/tree/upstream-sync) branch, and is available in the Zephyr fork of MCUboot.
 2) The [DNM] on this PR should be kept until the PR passes all tests and is accepted.
 3) Once the PR passes all tests and gets accepted, the upstream-sync branch should be fast-forward merged to [zephyrproject-rtos/mcuboot/main](https://github.com/zephyrproject-rtos/mcuboot/tree/main) branch and [DNM] should be removed.
 4) After the main branch gets updated, this PR does not require further changes and should be merged as is.