### PR TITLE
tests: drivers: adc: Fix silabs overlays

### DIFF
--- a/tests/drivers/adc/adc_accuracy_test/boards/xg24_dk2601b.overlay
+++ b/tests/drivers/adc/adc_accuracy_test/boards/xg24_dk2601b.overlay
@@ -9,8 +9,8 @@
 / {
 	zephyr,user {
 		io-channels = <&adc0 4>;
-		reference_mv = <(3300 / 4)>;
-		expected_accuracy = <32>;
+		reference-mv = <(3300 / 4)>;
+		expected-accuracy = <32>;
 	};
 };
 

--- a/tests/drivers/adc/adc_accuracy_test/boards/xg27_dk2602a.overlay
+++ b/tests/drivers/adc/adc_accuracy_test/boards/xg27_dk2602a.overlay
@@ -9,8 +9,8 @@
 / {
 	zephyr,user {
 		io-channels = <&adc0 4>;
-		reference_mv = <(3300 / 4)>;
-		expected_accuracy = <32>;
+		reference-mv = <(3300 / 4)>;
+		expected-accuracy = <32>;
 	};
 };
 


### PR DESCRIPTION
Fix typo in overlays for silabs boards that prevented tests from running.

Before:

```
INFO    - 2 of 2 executed test configurations passed (100.00%), 0 built (not run), 0 failed, 0 errored, with no warnings in 37.21 seconds.
INFO    - 6 of 8 executed test cases passed (75.00%), 2 blocked on 1 out of total 948 platforms (0.11%).
```

```
<testcase classname="drivers.adc.accuracy.ref_volt" name="drivers.adc.accuracy.ref_volt.adc_accuracy_test.ref_to_adc" time="0.00">
	<failure type="failure" message="passed" />
</testcase>
<testcase classname="drivers.adc.accuracy.ref_volt" name="drivers.adc.accuracy.ref_volt.adc_accuracy_test.dac_to_adc" time="0.00">
	<failure type="failure" message="passed" />
</testcase>
```

After:

```
INFO    - 2 of 2 executed test configurations passed (100.00%), 0 built (not run), 0 failed, 0 errored, with no warnings in 37.52 seconds.
INFO    - 7 of 7 executed test cases passed (100.00%) on 1 out of total 948 platforms (0.11%).
```

```
<testcase classname="drivers.adc.accuracy.ref_volt" name="drivers.adc.accuracy.ref_volt.adc_accuracy_test.ref_to_adc" time="2.97" />
```
