### PR TITLE
logging: frontend_stmesp: Fix string addresses from remote core

### DIFF
--- a/drivers/misc/coresight/nrf_etr.c
+++ b/drivers/misc/coresight/nrf_etr.c
@@ -203,13 +203,13 @@ static void trace_point_process(struct log_frontend_stmesp_demux_trace_point *pa
 	static const char *tp_d32 = "%d %08x";
 	const char *dname = stm_m_name[packet->major];
 	static const char *sname = "tp";
-	const char **lptr;
+	const char *lptr;
 
 	if (packet->id >= CONFIG_LOG_FRONTEND_STMESP_TURBO_LOG_BASE) {
-		TYPE_SECTION_GET(const char *, log_stmesp_ptr,
-				 packet->id - CONFIG_LOG_FRONTEND_STMESP_TURBO_LOG_BASE, &lptr);
-		uint8_t level = (uint8_t)((*lptr)[0]) - (uint8_t)'0';
-		const char *ptr = *lptr + 1;
+		lptr = log_frontend_stmesp_demux_str_get(packet->major,
+				packet->id - CONFIG_LOG_FRONTEND_STMESP_TURBO_LOG_BASE);
+		uint8_t level = (uint8_t)(lptr[0]) - (uint8_t)'0';
+		const char *ptr = lptr + 1;
 		static const union cbprintf_package_hdr desc0 = {
 			.desc = {.len = 2 /* hdr + fmt */}};
 		static const union cbprintf_package_hdr desc1 = {

--- a/include/zephyr/logging/log_frontend_stmesp.h
+++ b/include/zephyr/logging/log_frontend_stmesp.h
@@ -106,16 +106,17 @@ TYPE_SECTION_START_EXTERN(const char *, log_stmesp_ptr);
  * @param _source Pointer to the source structure.
  * @param ... String.
  */
+
 #define LOG_FRONTEND_STMESP_LOG0(_source, ...)                                                     \
 	do {                                                                                       \
 		static const char _str[] __in_section(_log_stmesp_str, static, _)                  \
 			__used __noasan __aligned(sizeof(uint32_t)) = GET_ARG_N(1, __VA_ARGS__);   \
 		static const char *_str_ptr __in_section(_log_stmesp_ptr, static, _)               \
 			__used __noasan = _str;                                                    \
-		uint32_t idx =                                                                     \
+		uint32_t _idx =                                                                    \
 			((uintptr_t)&_str_ptr - (uintptr_t)TYPE_SECTION_START(log_stmesp_ptr)) /   \
 			sizeof(void *);                                                            \
-		log_frontend_stmesp_log0(_source, idx);                                            \
+		log_frontend_stmesp_log0(_source, _idx);                                           \
 	} while (0)
 
 /** @brief Macro for handling a turbo log message with one argument.
@@ -129,10 +130,10 @@ TYPE_SECTION_START_EXTERN(const char *, log_stmesp_ptr);
 			__used __noasan __aligned(sizeof(uint32_t)) = GET_ARG_N(1, __VA_ARGS__);   \
 		static const char *_str_ptr __in_section(_log_stmesp_ptr, static, _)               \
 			__used __noasan = _str;                                                    \
-		uint32_t idx =                                                                     \
+		uint32_t _idx =                                                                    \
 			((uintptr_t)&_str_ptr - (uintptr_t)TYPE_SECTION_START(log_stmesp_ptr)) /   \
 			sizeof(void *);                                                            \
-		log_frontend_stmesp_log1(_source, idx, (uintptr_t)(GET_ARG_N(2, __VA_ARGS__)));    \
+		log_frontend_stmesp_log1(_source, _idx, (uintptr_t)(GET_ARG_N(2, __VA_ARGS__)));   \
 	} while (0)
 
 #ifdef __cplusplus

--- a/include/zephyr/logging/log_frontend_stmesp_demux.h
+++ b/include/zephyr/logging/log_frontend_stmesp_demux.h
@@ -290,6 +290,7 @@ void log_frontend_stmesp_demux_free(union log_frontend_stmesp_demux_packet packe
  *         cannot be retrieved.
  */
 const char *log_frontend_stmesp_demux_sname_get(uint32_t m_id, uint16_t s_id);
+const char *log_frontend_stmesp_demux_str_get(uint32_t m_id, uint16_t s_id);
 
 /** @brief Check if there are any started but not completed log messages.
  *

--- a/subsys/logging/frontends/log_frontend_stmesp.c
+++ b/subsys/logging/frontends/log_frontend_stmesp.c
@@ -581,7 +581,8 @@ void log_frontend_panic(void)
 
 void log_frontend_init(void)
 {
-#if defined(CONFIG_LOG_FRONTEND_STPESP_TURBO_SOURCE_PORT_ID) && !defined(CONFIG_NRF_ETR)
+#if	defined(CONFIG_LOG_FRONTEND_STPESP_TURBO_SOURCE_PORT_ID) && !defined(CONFIG_NRF_ETR) && \
+	!defined(CONFIG_LOG_MSG_APPEND_RO_STRING_LOC)
 	/* Send location of section with constant source data. It is used by the
 	 * application core to retrieve source names of log messages coming from
 	 * coprocessors (FLPR and PPR).

--- a/subsys/logging/frontends/log_frontend_stmesp.c
+++ b/subsys/logging/frontends/log_frontend_stmesp.c
@@ -589,10 +589,13 @@ void log_frontend_init(void)
 	TYPE_SECTION_START_EXTERN(struct log_source_const_data, log_const);
 	STMESP_Type *stm_esp;
 	uintptr_t log_const_start;
+	uintptr_t log_str_start;
 
 	(void)stmesp_get_port(CONFIG_LOG_FRONTEND_STPESP_TURBO_SOURCE_PORT_ID, &stm_esp);
 	log_const_start = (uintptr_t)TYPE_SECTION_START(log_const);
+	log_str_start = (uintptr_t)TYPE_SECTION_START(log_stmesp_ptr);
 	STM_D32(stm_esp, log_const_start, false, true);
+	STM_D32(stm_esp, log_str_start, false, true);
 #endif
 }
 


### PR DESCRIPTION
When decoding logs from a remote core with memory that APP can access, wrong address of an array with string addresses was used. Log message contains index of a string and APP strings array was used instead of remote core. Extend STMESP logging so that address of string array of a remote core is send during startup to the APP and APP is using this array to decode strings from remote cores. Bug applies only to PPR and FLPR as APP has no access to RAD memory.