### PR TITLE
cmake: do not double escape double quote

### DIFF
--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -3037,9 +3037,9 @@ endfunction()
 # This function extends the CMake string function by providing additional
 # manipulation arguments to CMake string.
 #
-# ESCAPE:   Ensure that any single '\' in the input string is escaped with the
-#           escape char '\'. For example the string 'foo\bar' will be escaped
-#           so that it becomes 'foo\\bar'.
+# ESCAPE:   Ensure that any single '\', except '\"', in the input string is
+#           escaped with the escape char '\'. For example the string 'foo\bar'
+#           will be escaped so that it becomes 'foo\\bar'.
 #           Backslashes which are already escaped will not be escaped further,
 #           for example 'foo\\bar' will not be modified.
 #           This is useful for handling of windows path separator in strings or
@@ -3084,7 +3084,7 @@ function(zephyr_string)
     # If a single '\' is discovered, such as 'foo\bar', then it must be escaped like: 'foo\\bar'
     # \\1 and \\2 are keeping the match patterns, the \\\\ --> \\ meaning an escaped '\',
     # which then becomes a single '\' in the final string.
-    string(REGEX REPLACE "([^\\][\\])([^\\])" "\\1\\\\\\2" work_string "${ZEPHYR_STRING_UNPARSED_ARGUMENTS}")
+    string(REGEX REPLACE "([^\\][\\])([^\\\"])" "\\1\\\\\\2" work_string "${ZEPHYR_STRING_UNPARSED_ARGUMENTS}")
   endif()
 
   set(${return_arg} ${work_string} PARENT_SCOPE)


### PR DESCRIPTION
Fixes: #86167 

Do not escape single escaped quote `\"`.
A single escape quote in CMake indicates the use of literal `"`. Escaping those results in `\\"` which is a literal `\` and a quote which encapsulates a string.
This is a result we do not want.
Therefore, exempt the `\"` sequence from further escaping.