### PR TITLE
driver: flash: mcux_flexspi_nor: fix faulty init value for IS25LP

### DIFF
--- a/drivers/flash/flash_mcux_flexspi_nor.c
+++ b/drivers/flash/flash_mcux_flexspi_nor.c
@@ -995,28 +995,15 @@ static int flash_flexspi_nor_check_jedec(struct flash_flexspi_nor_data *data,
 
 	/* Switch on manufacturer and vendor ID */
 	switch (vendor_id & 0xFFFFFF) {
-	case 0x16609d: /* IS25LP032 flash, needs P[4:3] cleared with same method as IS25WP */
+	case 0x16609d: /* IS25LP032 */
 	case 0x17609d: /* IS25LP064 */
 	case 0x18609d: /* IS25LP128 */
-		read_params = 0xE0U;
-		ret = flash_flexspi_nor_is25_clear_read_param(data, flexspi_lut, &read_params);
-		if (ret < 0) {
-			while (1) {
-				/*
-				 * Spin here, this flash won't configure correctly.
-				 * We can't print a warning, as we are unlikely to
-				 * be able to XIP at this point.
-				 */
-			}
-		}
-		/* Still return an error- we want the JEDEC configuration to run */
-		return -ENOTSUP;
 	case 0x16709d: /* IS25WP032 */
 	case 0x17709d: /* IS25WP064 */
 	case 0x18709d: /* IS25WP128 */
 		/*
-		 * IS25WP flash. We can support this flash with the JEDEC probe,
-		 * but we need to insure P[6:3] are at the default value
+		 * IS25WP/IS25LP flash. We can support this flash with the JEDEC probe,
+		 * but we need to insure P[6:3]/P[4:3] are at the default value
 		 */
 		read_params = 0;
 		ret = flash_flexspi_nor_is25_clear_read_param(data, flexspi_lut, &read_params);


### PR DESCRIPTION
The mcux_flexspi_nor driver uses an switch case based on JEDEC-ID in order to init different nor flash chips.
When using the flash IS25LPxx, the driver inits a "param_read" to "0xE0U". However, for the IS25WPxx series, the same value is initialized to 0.

Based on a review of the datasheets, there is no indication that these chips should have different initialization values. To ensure consistency and correct behavior across both the IS25LP and IS25WP flash families, this commit updates the switch case to use the same initialization across both variants.