### PR TITLE
Fix few weekly build/warning fails for mpfs_icicle

### DIFF
--- a/boards/microchip/mpfs_icicle/Kconfig.defconfig
+++ b/boards/microchip/mpfs_icicle/Kconfig.defconfig
@@ -1,0 +1,10 @@
+# Copyright 2025 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+if BOARD_MPFS_ICICLE
+
+choice SPI_NOR_SFDP
+	default SPI_NOR_SFDP_RUNTIME
+endchoice
+
+endif

--- a/drivers/flash/spi_nor.c
+++ b/drivers/flash/spi_nor.c
@@ -1279,7 +1279,7 @@ static int spi_nor_process_sfdp(const struct device *dev)
 	while (php != phpe) {
 		uint16_t id = jesd216_param_id(php);
 
-		LOG_INF("PH%u: %04x rev %u.%u: %u DW @ %x",
+		LOG_INF("PH%" PRIdPTR ": %04x rev %u.%u: %u DW @ %x",
 			(php - hp->phdr), id, php->rev_major, php->rev_minor,
 			php->len_dw, jesd216_param_addr(php));
 
@@ -1405,7 +1405,7 @@ static int setup_pages_layout(const struct device *dev)
 
 	data->layout.pages_size = layout_page_size;
 	data->layout.pages_count = flash_size / layout_page_size;
-	LOG_DBG("layout %u x %u By pages", data->layout.pages_count, data->layout.pages_size);
+	LOG_DBG("layout %zu x %zu By pages", data->layout.pages_count, data->layout.pages_size);
 #elif defined(CONFIG_SPI_NOR_SFDP_DEVICETREE)
 	const struct spi_nor_config *cfg = dev->config;
 	const struct flash_pages_layout *layout = &cfg->layout;


### PR DESCRIPTION
Fixes "static assertion failed: \"jedec,spi-nor jedec-id required for non-runtime SFDP" errors for the board and a couple of warnings that popped up after that.