### PR TITLE
twister: Remove unrecognised sections test

### DIFF
--- a/doc/releases/release-notes-4.2.rst
+++ b/doc/releases/release-notes-4.2.rst
@@ -55,6 +55,9 @@ Removed APIs and options
 
 * Removed the deprecated ``include/zephyr/net/buf.h`` header file.
 
+* Removed the ``--disable-unrecognized-section-test`` Twister option. Test has been removed and the
+  option became the default behavior.
+
 Deprecated APIs and options
 
 * The scheduler Kconfig options CONFIG_SCHED_DUMB and CONFIG_WAITQ_DUMB were

--- a/scripts/pylib/twister/twisterlib/environment.py
+++ b/scripts/pylib/twister/twisterlib/environment.py
@@ -483,12 +483,6 @@ structure in the main Zephyr tree: boards/<vendor>/<board_name>/""")
         action="store_true",
         help="Collect and report ROM/RAM section sizes for each test image built.")
 
-    parser.add_argument(
-        "--disable-unrecognized-section-test",
-        action="store_true",
-        default=False,
-        help="Don't error on unrecognized sections in the binary images.")
-
     footprint_group.add_argument(
         "--footprint-from-buildlog",
         action = "store_true",

--- a/scripts/pylib/twister/twisterlib/reports.py
+++ b/scripts/pylib/twister/twisterlib/reports.py
@@ -633,18 +633,11 @@ class Reporting:
             )
             logger.info("-+" * 40)
 
-    def summary(self, results, ignore_unrecognized_sections, duration):
+    def summary(self, results, duration):
         failed = 0
         run = 0
         for instance in self.instances.values():
             if instance.status == TwisterStatus.FAIL:
-                failed += 1
-            elif not ignore_unrecognized_sections and instance.metrics.get("unrecognized"):
-                logger.error(
-                    f"{Fore.RED}FAILED{Fore.RESET}:"
-                    f" {instance.name} has unrecognized binary sections:"
-                    f" {instance.metrics.get('unrecognized', [])!s}"
-                )
                 failed += 1
 
             # FIXME: need a better way to identify executed tests

--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -1794,7 +1794,6 @@ class ProjectBuilder(FilterBuilder):
             instance.metrics["used_rom"] = 0
             instance.metrics["available_rom"] = 0
             instance.metrics["available_ram"] = 0
-            instance.metrics["unrecognized"] = []
         return build_result
 
     @staticmethod
@@ -1810,13 +1809,11 @@ class ProjectBuilder(FilterBuilder):
                 instance.metrics["used_rom"] = size_calc.get_used_rom()
                 instance.metrics["available_rom"] = size_calc.get_available_rom()
                 instance.metrics["available_ram"] = size_calc.get_available_ram()
-                instance.metrics["unrecognized"] = size_calc.unrecognized_sections()
             else:
                 instance.metrics["used_ram"] = 0
                 instance.metrics["used_rom"] = 0
                 instance.metrics["available_rom"] = 0
                 instance.metrics["available_ram"] = 0
-                instance.metrics["unrecognized"] = []
             instance.metrics["handler_time"] = instance.execution_time
 
 class TwisterRunner:
@@ -1892,7 +1889,6 @@ class TwisterRunner:
                 else:
                     inst.metrics.update(self.instances[inst.name].metrics)
                     inst.metrics["handler_time"] = inst.execution_time
-                    inst.metrics["unrecognized"] = []
                     self.instances[inst.name] = inst
 
             print("")

--- a/scripts/pylib/twister/twisterlib/size_calc.py
+++ b/scripts/pylib/twister/twisterlib/size_calc.py
@@ -154,17 +154,6 @@ class SizeCalculator:
         """
         return self.used_rom
 
-    def unrecognized_sections(self):
-        """Get a list of sections inside the binary that weren't recognized
-
-        @return list of unrecognized section names
-        """
-        slist = []
-        for v in self.sections:
-            if not v["recognized"]:
-                slist.append(v["name"])
-        return slist
-
     def get_available_ram(self) -> int:
         """Get the total available RAM.
 
@@ -251,7 +240,6 @@ class SizeCalculator:
 
             # Add section to memory use totals (for both non-XIP and XIP scenarios)
             # Unrecognized section names are not included in the calculations.
-            recognized = True
 
             # If build.log file exists, check errors (unrecognized sections
             # in ELF file).
@@ -262,8 +250,6 @@ class SizeCalculator:
                     continue
                 else:
                     stype = "unknown"
-                    if name not in self.extra_sections:
-                        recognized = False
             else:
                 if name in SizeCalculator.alloc_sections:
                     self.used_ram += size
@@ -279,12 +265,10 @@ class SizeCalculator:
                     stype = "ro"
                 else:
                     stype = "unknown"
-                    if name not in self.extra_sections:
-                        recognized = False
 
             self.sections.append({"name": name, "load_addr": load_addr,
                                   "size": size, "virt_addr": virt_addr,
-                                  "type": stype, "recognized": recognized})
+                                  "type": stype})
 
     def _analyze_elf_file(self) -> None:
         self._check_elf_file()

--- a/scripts/pylib/twister/twisterlib/twister_main.py
+++ b/scripts/pylib/twister/twisterlib/twister_main.py
@@ -181,7 +181,7 @@ def twister(options: argparse.Namespace, default_options: argparse.Namespace):
     if options.verbose > 1:
         runner.results.summary()
 
-    report.summary(runner.results, options.disable_unrecognized_section_test, duration)
+    report.summary(runner.results, duration)
 
     report.coverage_status = True
     if options.coverage and not options.disable_coverage_aggregation:

--- a/scripts/tests/twister/test_runner.py
+++ b/scripts/tests/twister/test_runner.py
@@ -2411,7 +2411,6 @@ def test_projectbuilder_gather_metrics(
         assert instance_mock.metrics['used_rom'] == 0
         assert instance_mock.metrics['available_rom'] == 0
         assert instance_mock.metrics['available_ram'] == 0
-        assert instance_mock.metrics['unrecognized'] == []
 
 
 TESTDATA_16 = [
@@ -2463,15 +2462,12 @@ def test_projectbuilder_calc_size(
                size_calc_mock.get_available_rom()
         assert instance_mock.metrics['available_ram'] == \
                size_calc_mock.get_available_ram()
-        assert instance_mock.metrics['unrecognized'] == \
-               size_calc_mock.unrecognized_sections()
 
     if expect_zeroes:
         assert instance_mock.metrics['used_ram'] == 0
         assert instance_mock.metrics['used_rom'] == 0
         assert instance_mock.metrics['available_rom'] == 0
         assert instance_mock.metrics['available_ram'] == 0
-        assert instance_mock.metrics['unrecognized'] == []
 
     if expect_calcs or expect_zeroes:
         assert instance_mock.metrics['handler_time'] == \
@@ -2574,8 +2570,7 @@ def test_twisterrunner_run(
     assert tr.instances['dummy instance'].metrics == {
         'k': 'v',
         'k2': 'v2',
-        'handler_time': 30,
-        'unrecognized': []
+        'handler_time': 30
     }
 
     assert results_mock().error == 0


### PR DESCRIPTION
The section lists that govern whether the ELF section is recognised or not are out of date.

A programming bug has rendered the unrecognised section check unrunnable for years.

Fix was attempted in #71051, but lack of updated section lists made the revival of the unrecognised section check counter-productive and undesired.

Thus, the practically dead code of the unrecognised section check is removed in this PR.

