### PR TITLE
license: Remove non-copyrightable license

### DIFF
--- a/misc/generated/configs.c.in
+++ b/misc/generated/configs.c.in
@@ -1,7 +1,3 @@
-/*
- * SPDX-License-Identifier: Apache-2.0
- */
-
 /* file is auto-generated, do not modify ! */
 
 #include <zephyr/toolchain.h>


### PR DESCRIPTION
The generated configs.c is technically not copyrightable since it's using the configs selected by the end user which might not fall under the Apache license. This license header in the generated file is causing us issues downstream from a legal perspective. It's important to note that other generated files in Zephyr don't include the copyright header.

Fixes #86259