### PR TITLE
Sensor: ICM45686: Add Streaming Mode

### DIFF
--- a/drivers/sensor/tdk/icm45686/CMakeLists.txt
+++ b/drivers/sensor/tdk/icm45686/CMakeLists.txt
@@ -13,3 +13,6 @@ zephyr_library_sources_ifdef(CONFIG_SENSOR_ASYNC_API
 zephyr_library_sources_ifdef(CONFIG_ICM45686_TRIGGER
 	icm45686_trigger.c
 )
+zephyr_library_sources_ifdef(CONFIG_ICM45686_STREAM
+	icm45686_stream.c
+)

--- a/drivers/sensor/tdk/icm45686/Kconfig
+++ b/drivers/sensor/tdk/icm45686/Kconfig
@@ -27,12 +27,14 @@ config ICM45686_TRIGGER_GLOBAL_THREAD
 	bool "Use global thread"
 	depends on GPIO
 	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_INVENSENSE_ICM45686),int-gpios)
+	depends on !ICM45686_STREAM
 	select ICM45686_TRIGGER
 
 config ICM45686_TRIGGER_OWN_THREAD
 	bool "Use own thread"
 	depends on GPIO
 	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_INVENSENSE_ICM45686),int-gpios)
+	depends on !ICM45686_STREAM
 	select ICM45686_TRIGGER
 
 endchoice
@@ -53,5 +55,12 @@ config ICM45686_THREAD_STACK_SIZE
 	default 1024
 	help
 	  The thread stack size.
+
+config ICM45686_STREAM
+	bool "Streaming mode"
+	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_INVENSENSE_ICM45686),int-gpios)
+	help
+	  Enable streaming of sensor data.
 
 endif # ICM45686

--- a/drivers/sensor/tdk/icm45686/icm45686.c
+++ b/drivers/sensor/tdk/icm45686/icm45686.c
@@ -22,6 +22,7 @@
 #include "icm45686_bus.h"
 #include "icm45686_decoder.h"
 #include "icm45686_trigger.h"
+#include "icm45686_stream.h"
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(ICM45686, CONFIG_SENSOR_LOG_LEVEL);
@@ -67,46 +68,46 @@ static int icm45686_channel_get(const struct device *dev,
 
 	switch (chan) {
 	case SENSOR_CHAN_ACCEL_X:
-		icm45686_accel_ms(data->edata.header.accel_fs, data->edata.payload.accel.x,
+		icm45686_accel_ms(data->edata.header.accel_fs, data->edata.payload.accel.x, false,
 				  &val->val1, &val->val2);
 		break;
 	case SENSOR_CHAN_ACCEL_Y:
-		icm45686_accel_ms(data->edata.header.accel_fs, data->edata.payload.accel.y,
+		icm45686_accel_ms(data->edata.header.accel_fs, data->edata.payload.accel.y, false,
 				  &val->val1, &val->val2);
 		break;
 	case SENSOR_CHAN_ACCEL_Z:
-		icm45686_accel_ms(data->edata.header.accel_fs, data->edata.payload.accel.z,
+		icm45686_accel_ms(data->edata.header.accel_fs, data->edata.payload.accel.z, false,
 				  &val->val1, &val->val2);
 		break;
 	case SENSOR_CHAN_GYRO_X:
-		icm45686_gyro_rads(data->edata.header.gyro_fs, data->edata.payload.gyro.x,
+		icm45686_gyro_rads(data->edata.header.gyro_fs, data->edata.payload.gyro.x, false,
 				   &val->val1, &val->val2);
 		break;
 	case SENSOR_CHAN_GYRO_Y:
-		icm45686_gyro_rads(data->edata.header.gyro_fs, data->edata.payload.gyro.y,
+		icm45686_gyro_rads(data->edata.header.gyro_fs, data->edata.payload.gyro.y, false,
 				   &val->val1, &val->val2);
 		break;
 	case SENSOR_CHAN_GYRO_Z:
-		icm45686_gyro_rads(data->edata.header.gyro_fs, data->edata.payload.gyro.z,
+		icm45686_gyro_rads(data->edata.header.gyro_fs, data->edata.payload.gyro.z, false,
 				   &val->val1, &val->val2);
 		break;
 	case SENSOR_CHAN_DIE_TEMP:
 		icm45686_temp_c(data->edata.payload.temp, &val->val1, &val->val2);
 		break;
 	case SENSOR_CHAN_ACCEL_XYZ:
-		icm45686_accel_ms(data->edata.header.accel_fs, data->edata.payload.accel.x,
+		icm45686_accel_ms(data->edata.header.accel_fs, data->edata.payload.accel.x, false,
 				  &val[0].val1, &val[0].val2);
-		icm45686_accel_ms(data->edata.header.accel_fs, data->edata.payload.accel.y,
+		icm45686_accel_ms(data->edata.header.accel_fs, data->edata.payload.accel.y, false,
 				  &val[1].val1, &val[1].val2);
-		icm45686_accel_ms(data->edata.header.accel_fs, data->edata.payload.accel.z,
+		icm45686_accel_ms(data->edata.header.accel_fs, data->edata.payload.accel.z, false,
 				  &val[2].val1, &val[2].val2);
 		break;
 	case SENSOR_CHAN_GYRO_XYZ:
-		icm45686_gyro_rads(data->edata.header.gyro_fs, data->edata.payload.gyro.x,
+		icm45686_gyro_rads(data->edata.header.gyro_fs, data->edata.payload.gyro.x, false,
 				   &val->val1, &val->val2);
-		icm45686_gyro_rads(data->edata.header.gyro_fs, data->edata.payload.gyro.y,
+		icm45686_gyro_rads(data->edata.header.gyro_fs, data->edata.payload.gyro.y, false,
 				   &val[1].val1, &val[1].val2);
-		icm45686_gyro_rads(data->edata.header.gyro_fs, data->edata.payload.gyro.z,
+		icm45686_gyro_rads(data->edata.header.gyro_fs, data->edata.payload.gyro.z, false,
 				   &val[2].val1, &val[2].val2);
 		break;
 	default:
@@ -214,6 +215,8 @@ static void icm45686_submit(const struct device *dev, struct rtio_iodev_sqe *iod
 
 	if (!cfg->is_streaming) {
 		icm45686_submit_one_shot(dev, iodev_sqe);
+	} else if (IS_ENABLED(CONFIG_ICM45686_STREAM)) {
+		icm45686_stream_submit(dev, iodev_sqe);
 	} else {
 		LOG_ERR("Streaming not supported");
 		rtio_iodev_sqe_err(iodev_sqe, -ENOTSUP);
@@ -354,6 +357,12 @@ static int icm45686_init(const struct device *dev)
 			LOG_ERR("Failed to initialize triggers: %d", err);
 			return err;
 		}
+	} else if (IS_ENABLED(CONFIG_ICM45686_STREAM)) {
+		err = icm45686_stream_init(dev);
+		if (err) {
+			LOG_ERR("Failed to initialize streaming: %d", err);
+			return err;
+		}
 	}
 
 	LOG_DBG("Init OK");
@@ -393,12 +402,12 @@ static int icm45686_init(const struct device *dev)
 				.odr = DT_INST_PROP(inst, gyro_odr),				   \
 				.lpf = DT_INST_PROP_OR(inst, gyro_lpf, 0),			   \
 			},									   \
+			.fifo_watermark = DT_INST_PROP_OR(inst, fifo_watermark, 0),		   \
 		},										   \
 		.int_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, int_gpios, {0}),			   \
 	};											   \
 	static struct icm45686_data icm45686_data_##inst = {					   \
 		.edata.header = {								   \
-			.is_fifo = false,							   \
 			.accel_fs = DT_INST_PROP(inst, accel_fs),				   \
 			.gyro_fs = DT_INST_PROP(inst, gyro_fs),					   \
 		},										   \

--- a/drivers/sensor/tdk/icm45686/icm45686.c
+++ b/drivers/sensor/tdk/icm45686/icm45686.c
@@ -67,46 +67,46 @@ static int icm45686_channel_get(const struct device *dev,
 
 	switch (chan) {
 	case SENSOR_CHAN_ACCEL_X:
-		icm45686_accel_ms(&data->edata, data->edata.payload.accel.x,
+		icm45686_accel_ms(data->edata.header.accel_fs, data->edata.payload.accel.x,
 				  &val->val1, &val->val2);
 		break;
 	case SENSOR_CHAN_ACCEL_Y:
-		icm45686_accel_ms(&data->edata, data->edata.payload.accel.y,
+		icm45686_accel_ms(data->edata.header.accel_fs, data->edata.payload.accel.y,
 				  &val->val1, &val->val2);
 		break;
 	case SENSOR_CHAN_ACCEL_Z:
-		icm45686_accel_ms(&data->edata, data->edata.payload.accel.z,
+		icm45686_accel_ms(data->edata.header.accel_fs, data->edata.payload.accel.z,
 				  &val->val1, &val->val2);
 		break;
 	case SENSOR_CHAN_GYRO_X:
-		icm45686_gyro_rads(&data->edata, data->edata.payload.gyro.x,
+		icm45686_gyro_rads(data->edata.header.gyro_fs, data->edata.payload.gyro.x,
 				   &val->val1, &val->val2);
 		break;
 	case SENSOR_CHAN_GYRO_Y:
-		icm45686_gyro_rads(&data->edata, data->edata.payload.gyro.y,
+		icm45686_gyro_rads(data->edata.header.gyro_fs, data->edata.payload.gyro.y,
 				   &val->val1, &val->val2);
 		break;
 	case SENSOR_CHAN_GYRO_Z:
-		icm45686_gyro_rads(&data->edata, data->edata.payload.gyro.z,
+		icm45686_gyro_rads(data->edata.header.gyro_fs, data->edata.payload.gyro.z,
 				   &val->val1, &val->val2);
 		break;
 	case SENSOR_CHAN_DIE_TEMP:
 		icm45686_temp_c(data->edata.payload.temp, &val->val1, &val->val2);
 		break;
 	case SENSOR_CHAN_ACCEL_XYZ:
-		icm45686_accel_ms(&data->edata, data->edata.payload.accel.x,
+		icm45686_accel_ms(data->edata.header.accel_fs, data->edata.payload.accel.x,
 				  &val[0].val1, &val[0].val2);
-		icm45686_accel_ms(&data->edata, data->edata.payload.accel.y,
+		icm45686_accel_ms(data->edata.header.accel_fs, data->edata.payload.accel.y,
 				  &val[1].val1, &val[1].val2);
-		icm45686_accel_ms(&data->edata, data->edata.payload.accel.z,
+		icm45686_accel_ms(data->edata.header.accel_fs, data->edata.payload.accel.z,
 				  &val[2].val1, &val[2].val2);
 		break;
 	case SENSOR_CHAN_GYRO_XYZ:
-		icm45686_gyro_rads(&data->edata, data->edata.payload.gyro.x,
+		icm45686_gyro_rads(data->edata.header.gyro_fs, data->edata.payload.gyro.x,
 				   &val->val1, &val->val2);
-		icm45686_gyro_rads(&data->edata, data->edata.payload.gyro.y,
+		icm45686_gyro_rads(data->edata.header.gyro_fs, data->edata.payload.gyro.y,
 				   &val[1].val1, &val[1].val2);
-		icm45686_gyro_rads(&data->edata, data->edata.payload.gyro.z,
+		icm45686_gyro_rads(data->edata.header.gyro_fs, data->edata.payload.gyro.z,
 				   &val[2].val1, &val[2].val2);
 		break;
 	default:

--- a/drivers/sensor/tdk/icm45686/icm45686.h
+++ b/drivers/sensor/tdk/icm45686/icm45686.h
@@ -95,14 +95,14 @@ struct icm45686_config {
 	struct gpio_dt_spec int_gpio;
 };
 
-static inline void icm45686_accel_ms(struct icm45686_encoded_data *edata,
+static inline void icm45686_accel_ms(uint8_t fs,
 				     int32_t in,
 				     int32_t *out_ms,
 				     int32_t *out_ums)
 {
 	int64_t sensitivity;
 
-	switch (edata->header.accel_fs) {
+	switch (fs) {
 	case ICM45686_DT_ACCEL_FS_32:
 		sensitivity = 32768 / 32;
 		break;
@@ -132,14 +132,14 @@ static inline void icm45686_accel_ms(struct icm45686_encoded_data *edata,
 	*out_ums = (in_ms - (*out_ms * sensitivity * 1000000LL)) / sensitivity;
 }
 
-static inline void icm45686_gyro_rads(struct icm45686_encoded_data *edata,
+static inline void icm45686_gyro_rads(uint8_t fs,
 				      int32_t in,
 				      int32_t *out_rads,
 				      int32_t *out_urads)
 {
 	int64_t sensitivity_x10;
 
-	switch (edata->header.gyro_fs) {
+	switch (fs) {
 	case ICM45686_DT_GYRO_FS_4000:
 		sensitivity_x10 = 32768 * 10 / 4000;
 		break;

--- a/drivers/sensor/tdk/icm45686/icm45686.h
+++ b/drivers/sensor/tdk/icm45686/icm45686.h
@@ -35,17 +35,50 @@ struct icm45686_encoded_payload {
 	};
 };
 
+struct icm45686_encoded_fifo_payload {
+	union {
+		uint8_t buf[20];
+		struct {
+			uint8_t header;
+			struct {
+				int16_t x;
+				int16_t y;
+				int16_t z;
+			} accel;
+			struct {
+				int16_t x;
+				int16_t y;
+				int16_t z;
+			} gyro;
+			int16_t temp;
+			uint16_t timestamp;
+			struct {
+				uint8_t gyro_x : 4;
+				uint8_t accel_x : 4;
+				uint8_t gyro_y : 4;
+				uint8_t accel_y : 4;
+				uint8_t gyro_z : 4;
+				uint8_t accel_z : 4;
+			} lsb;
+		} __attribute__((__packed__));
+	};
+};
+
 struct icm45686_encoded_header {
 	uint64_t timestamp;
 	uint8_t accel_fs : 4;
 	uint8_t gyro_fs : 4;
-	uint8_t is_fifo : 1;
+	uint8_t events : 3;
 	uint8_t channels : 7;
+	uint16_t fifo_count;
 };
 
 struct icm45686_encoded_data {
 	struct icm45686_encoded_header header;
-	struct icm45686_encoded_payload payload;
+	union {
+		struct icm45686_encoded_payload payload;
+		struct icm45686_encoded_fifo_payload fifo_payload;
+	};
 };
 
 struct icm45686_triggers {
@@ -65,6 +98,38 @@ struct icm45686_triggers {
 #endif
 };
 
+struct icm45686_stream {
+	struct gpio_callback cb;
+	const struct device *dev;
+	struct rtio_iodev_sqe *iodev_sqe;
+	atomic_t in_progress;
+	struct {
+		struct {
+			bool drdy : 1;
+			bool fifo_ths : 1;
+			bool fifo_full : 1;
+		} enabled;
+		struct {
+			enum sensor_stream_data_opt drdy;
+			enum sensor_stream_data_opt fifo_ths;
+			enum sensor_stream_data_opt fifo_full;
+		} opt;
+		bool drdy : 1;
+		bool fifo_ths : 1;
+		bool fifo_full : 1;
+	} settings;
+	struct {
+		uint64_t timestamp;
+		uint8_t int_status;
+		uint16_t fifo_count;
+		struct {
+			bool drdy : 1;
+			bool fifo_ths : 1;
+			bool fifo_full : 1;
+		} events;
+	} data;
+};
+
 struct icm45686_data {
 	struct {
 		struct rtio_iodev *iodev;
@@ -74,6 +139,8 @@ struct icm45686_data {
 	struct icm45686_encoded_data edata;
 #if defined(CONFIG_ICM45686_TRIGGER)
 	struct icm45686_triggers triggers;
+#elif defined(CONFIG_ICM45686_STREAM)
+	struct icm45686_stream stream;
 #endif /* CONFIG_ICM45686_TRIGGER */
 };
 
@@ -91,32 +158,35 @@ struct icm45686_config {
 			uint8_t odr : 4;
 			uint8_t lpf : 3;
 		} gyro;
+		uint16_t fifo_watermark;
 	} settings;
 	struct gpio_dt_spec int_gpio;
 };
 
 static inline void icm45686_accel_ms(uint8_t fs,
 				     int32_t in,
+				     bool high_res,
 				     int32_t *out_ms,
 				     int32_t *out_ums)
 {
 	int64_t sensitivity;
+	uint64_t full_scale_range_lsb = high_res ? 524288 : 32768;
 
 	switch (fs) {
 	case ICM45686_DT_ACCEL_FS_32:
-		sensitivity = 32768 / 32;
+		sensitivity = full_scale_range_lsb / 32;
 		break;
 	case ICM45686_DT_ACCEL_FS_16:
-		sensitivity = 32768 / 16;
+		sensitivity = full_scale_range_lsb / 16;
 		break;
 	case ICM45686_DT_ACCEL_FS_8:
-		sensitivity = 32768 / 8;
+		sensitivity = full_scale_range_lsb / 8;
 		break;
 	case ICM45686_DT_ACCEL_FS_4:
-		sensitivity = 32768 / 4;
+		sensitivity = full_scale_range_lsb / 4;
 		break;
 	case ICM45686_DT_ACCEL_FS_2:
-		sensitivity = 32768 / 2;
+		sensitivity = full_scale_range_lsb / 2;
 		break;
 	default:
 		CODE_UNREACHABLE;
@@ -134,38 +204,40 @@ static inline void icm45686_accel_ms(uint8_t fs,
 
 static inline void icm45686_gyro_rads(uint8_t fs,
 				      int32_t in,
+				      bool high_res,
 				      int32_t *out_rads,
 				      int32_t *out_urads)
 {
 	int64_t sensitivity_x10;
+	uint64_t full_scale_range_lsb = high_res ? 524288 : 32768;
 
 	switch (fs) {
 	case ICM45686_DT_GYRO_FS_4000:
-		sensitivity_x10 = 32768 * 10 / 4000;
+		sensitivity_x10 = full_scale_range_lsb * 10 / 4000;
 		break;
 	case ICM45686_DT_GYRO_FS_2000:
-		sensitivity_x10 = 32768 * 10 / 2000;
+		sensitivity_x10 = full_scale_range_lsb * 10 / 2000;
 		break;
 	case ICM45686_DT_GYRO_FS_1000:
-		sensitivity_x10 = 32768 * 10 / 1000;
+		sensitivity_x10 = full_scale_range_lsb * 10 / 1000;
 		break;
 	case ICM45686_DT_GYRO_FS_500:
-		sensitivity_x10 = 32768 * 10 / 500;
+		sensitivity_x10 = full_scale_range_lsb * 10 / 500;
 		break;
 	case ICM45686_DT_GYRO_FS_250:
-		sensitivity_x10 = 32768 * 10 / 250;
+		sensitivity_x10 = full_scale_range_lsb * 10 / 250;
 		break;
 	case ICM45686_DT_GYRO_FS_125:
-		sensitivity_x10 = 32768 * 10 / 125;
+		sensitivity_x10 = full_scale_range_lsb * 10 / 125;
 		break;
 	case ICM45686_DT_GYRO_FS_62_5:
-		sensitivity_x10 = 32768 * 10 * 10 / 625;
+		sensitivity_x10 = full_scale_range_lsb * 10 * 10 / 625;
 		break;
 	case ICM45686_DT_GYRO_FS_31_25:
-		sensitivity_x10 = 32768 * 10 * 100 / 3125;
+		sensitivity_x10 = full_scale_range_lsb * 10 * 100 / 3125;
 		break;
 	case ICM45686_DT_GYRO_FS_15_625:
-		sensitivity_x10 = 32768 * 10 * 1000 / 15625;
+		sensitivity_x10 = full_scale_range_lsb * 10 * 1000 / 15625;
 		break;
 	default:
 		CODE_UNREACHABLE;

--- a/drivers/sensor/tdk/icm45686/icm45686_decoder.c
+++ b/drivers/sensor/tdk/icm45686/icm45686_decoder.c
@@ -106,13 +106,13 @@ int icm45686_convert_raw_to_q31(struct icm45686_encoded_data *edata,
 	case SENSOR_CHAN_ACCEL_X:
 	case SENSOR_CHAN_ACCEL_Y:
 	case SENSOR_CHAN_ACCEL_Z:
-		icm45686_accel_ms(edata, reading, &whole, &fraction);
+		icm45686_accel_ms(edata->header.accel_fs, reading, &whole, &fraction);
 		break;
 	case SENSOR_CHAN_GYRO_XYZ:
 	case SENSOR_CHAN_GYRO_X:
 	case SENSOR_CHAN_GYRO_Y:
 	case SENSOR_CHAN_GYRO_Z:
-		icm45686_gyro_rads(edata, reading, &whole, &fraction);
+		icm45686_gyro_rads(edata->header.gyro_fs, reading, &whole, &fraction);
 		break;
 	case SENSOR_CHAN_DIE_TEMP:
 		icm45686_temp_c(reading, &whole, &fraction);

--- a/drivers/sensor/tdk/icm45686/icm45686_decoder.c
+++ b/drivers/sensor/tdk/icm45686/icm45686_decoder.c
@@ -9,6 +9,7 @@
 #include <zephyr/drivers/sensor_clock.h>
 
 #include "icm45686.h"
+#include "icm45686_reg.h"
 #include "icm45686_decoder.h"
 
 #include <zephyr/logging/log.h>
@@ -106,13 +107,13 @@ int icm45686_convert_raw_to_q31(struct icm45686_encoded_data *edata,
 	case SENSOR_CHAN_ACCEL_X:
 	case SENSOR_CHAN_ACCEL_Y:
 	case SENSOR_CHAN_ACCEL_Z:
-		icm45686_accel_ms(edata->header.accel_fs, reading, &whole, &fraction);
+		icm45686_accel_ms(edata->header.accel_fs, reading, false, &whole, &fraction);
 		break;
 	case SENSOR_CHAN_GYRO_XYZ:
 	case SENSOR_CHAN_GYRO_X:
 	case SENSOR_CHAN_GYRO_Y:
 	case SENSOR_CHAN_GYRO_Z:
-		icm45686_gyro_rads(edata->header.gyro_fs, reading, &whole, &fraction);
+		icm45686_gyro_rads(edata->header.gyro_fs, reading, false, &whole, &fraction);
 		break;
 	case SENSOR_CHAN_DIE_TEMP:
 		icm45686_temp_c(reading, &whole, &fraction);
@@ -209,7 +210,7 @@ int icm45686_encode(const struct device *dev,
 		return err;
 	}
 
-	edata->header.is_fifo = false;
+	edata->header.events = 0;
 	edata->header.accel_fs = dev_config->settings.accel.fs;
 	edata->header.gyro_fs = dev_config->settings.gyro.fs;
 	edata->header.timestamp = sensor_clock_cycles_to_ns(cycles);
@@ -229,12 +230,12 @@ static int icm45686_decoder_get_frame_count(const uint8_t *buffer,
 
 	uint8_t channel_request = icm45686_encode_channel(chan_spec.chan_type);
 
-	if ((!edata->header.is_fifo) &&
-	    (edata->header.channels & channel_request) != channel_request) {
+	if ((edata->header.channels & channel_request) != channel_request) {
 		return -ENODATA;
 	}
 
-	if (!edata->header.is_fifo) {
+	if (!edata->header.events ||
+	    (edata->header.events & REG_INT1_STATUS0_DRDY(true))) {
 		switch (chan_spec.chan_type) {
 		case SENSOR_CHAN_ACCEL_X:
 		case SENSOR_CHAN_ACCEL_Y:
@@ -252,7 +253,20 @@ static int icm45686_decoder_get_frame_count(const uint8_t *buffer,
 		}
 	}
 
-	LOG_ERR("FIFO Data frame not supported");
+	if (edata->header.events & REG_INT1_STATUS0_FIFO_THS(true) ||
+	    edata->header.events & REG_INT1_STATUS0_FIFO_FULL(true)) {
+		switch (chan_spec.chan_type) {
+		case SENSOR_CHAN_ACCEL_XYZ:
+		case SENSOR_CHAN_GYRO_XYZ:
+		case SENSOR_CHAN_DIE_TEMP:
+			*frame_count = edata->header.fifo_count;
+			return 0;
+		/** We're skipping individual axis for fifo packets */
+		default:
+			return -ENOTSUP;
+		}
+	}
+
 	return -1;
 }
 
@@ -369,6 +383,163 @@ static int icm45686_one_shot_decode(const uint8_t *buffer,
 	}
 }
 
+static q31_t icm45686_fifo_read_temp_from_packet(const uint8_t *pkt)
+{
+	struct icm45686_encoded_fifo_payload *fdata = (struct icm45686_encoded_fifo_payload *)pkt;
+
+	int32_t whole;
+	uint32_t fraction;
+	int64_t intermediate;
+	int8_t shift;
+	int err;
+
+	err = icm45686_get_shift(SENSOR_CHAN_DIE_TEMP, 0, 0, &shift);
+	if (err != 0) {
+		return -1;
+	}
+
+	icm45686_temp_c(fdata->temp, &whole, &fraction);
+
+	intermediate = ((int64_t)whole * INT64_C(1000000) + fraction);
+	if (shift < 0) {
+		intermediate =
+			intermediate * ((int64_t)INT32_MAX + 1) * (1 << -shift) / INT64_C(1000000);
+	} else if (shift > 0) {
+		intermediate =
+			intermediate * ((int64_t)INT32_MAX + 1) / ((1 << shift) * INT64_C(1000000));
+	}
+
+	return CLAMP(intermediate, INT32_MIN, INT32_MAX);
+}
+
+static int icm45686_fifo_read_imu_from_packet(const uint8_t *pkt,
+					      bool is_accel,
+					      uint8_t axis_offset,
+					      q31_t *out)
+{
+	uint32_t unsigned_value;
+	int32_t signed_value;
+	int offset = 1 + (axis_offset * 2)  + (is_accel ? 0 : 6);
+	uint32_t mask = is_accel ? GENMASK(7, 4) : GENMASK(3, 0);
+	uint8_t accel_fs = ICM45686_DT_ACCEL_FS_32;
+	uint8_t gyro_fs = ICM45686_DT_GYRO_FS_4000;
+
+	int32_t whole;
+	int32_t fraction;
+	int64_t intermediate;
+	int8_t shift;
+
+	unsigned_value = (pkt[offset] | (pkt[offset + 1] << 8));
+	if (unsigned_value == FIFO_NO_DATA) {
+		return -ENODATA;
+	}
+
+	unsigned_value = (unsigned_value << 4) |
+			 ((pkt[17 + axis_offset] & mask) >> (is_accel ? 4 : 0));
+	signed_value = sign_extend(unsigned_value, 19);
+
+	if (!is_accel) {
+		icm45686_get_shift(SENSOR_CHAN_GYRO_XYZ, accel_fs, gyro_fs, &shift);
+		icm45686_gyro_rads(gyro_fs, signed_value, true, &whole, &fraction);
+	} else {
+		icm45686_get_shift(SENSOR_CHAN_ACCEL_XYZ, accel_fs, gyro_fs, &shift);
+		icm45686_accel_ms(accel_fs, signed_value, true, &whole, &fraction);
+	}
+
+	intermediate = ((int64_t)whole * INT64_C(1000000) + fraction);
+	if (shift < 0) {
+		intermediate =
+			intermediate * ((int64_t)INT32_MAX + 1) * (1 << -shift) / INT64_C(1000000);
+	} else if (shift > 0) {
+		intermediate =
+			intermediate * ((int64_t)INT32_MAX + 1) / ((1 << shift) * INT64_C(1000000));
+	}
+
+	*out = CLAMP(intermediate, INT32_MIN, INT32_MAX);
+
+	return 0;
+}
+
+static int icm45686_fifo_decode(const uint8_t *buffer,
+				struct sensor_chan_spec chan_spec,
+				uint32_t *fit,
+				uint16_t max_count,
+				void *data_out)
+{
+	struct icm45686_encoded_data *edata = (struct icm45686_encoded_data *)buffer;
+	struct icm45686_encoded_fifo_payload *frame_begin = &edata->fifo_payload;
+	int count = 0;
+	int err;
+
+	if (*fit >= edata->header.fifo_count || chan_spec.chan_idx != 0) {
+		return 0;
+	}
+
+	while (count < max_count && (*fit < edata->header.fifo_count)) {
+		struct icm45686_encoded_fifo_payload *fdata = &frame_begin[*fit];
+
+		/** This driver assumes 20-byte fifo packets, with both accel and gyro,
+		 * and no auxiliary sensors.
+		 */
+		__ASSERT(!(fdata->header & FIFO_HEADER_EXT_HEADER_EN(true)) &&
+			(fdata->header & FIFO_HEADER_ACCEL_EN(true)) &&
+			(fdata->header & FIFO_HEADER_GYRO_EN(true)) &&
+			(fdata->header & FIFO_HEADER_HIRES_EN(true)),
+			"Unsupported FIFO packet format");
+
+		switch (chan_spec.chan_type) {
+		case SENSOR_CHAN_ACCEL_XYZ:
+		case SENSOR_CHAN_GYRO_XYZ: {
+			struct sensor_three_axis_data *out = data_out;
+			bool is_accel = chan_spec.chan_type == SENSOR_CHAN_ACCEL_XYZ;
+
+			icm45686_get_shift(chan_spec.chan_type,
+					   edata->header.accel_fs,
+					   edata->header.gyro_fs,
+					   &out->shift);
+
+			out->header.base_timestamp_ns = edata->header.timestamp;
+
+			err = icm45686_fifo_read_imu_from_packet((uint8_t *)fdata,
+								 is_accel,
+								 0,
+								 &out->readings[count].x);
+			err |= icm45686_fifo_read_imu_from_packet((uint8_t *)fdata,
+								  is_accel,
+								  1,
+								  &out->readings[count].y);
+			err |= icm45686_fifo_read_imu_from_packet((uint8_t *)fdata,
+								  is_accel,
+								  2,
+								  &out->readings[count].z);
+			if (err != 0) {
+				count--;
+			}
+			break;
+		}
+		case SENSOR_CHAN_DIE_TEMP: {
+			struct sensor_q31_data *out = data_out;
+
+			icm45686_get_shift(chan_spec.chan_type,
+					edata->header.accel_fs,
+					edata->header.gyro_fs,
+					&out->shift);
+
+			out->header.base_timestamp_ns = edata->header.timestamp;
+			out->readings[count].temperature =
+				icm45686_fifo_read_temp_from_packet((uint8_t *)fdata);
+			break;
+		}
+		default:
+			return 0;
+		}
+		*fit = *fit + 1;
+		count++;
+	}
+
+	return count;
+}
+
 static int icm45686_decoder_decode(const uint8_t *buffer,
 				   struct sensor_chan_spec chan_spec,
 				   uint32_t *fit,
@@ -377,8 +548,9 @@ static int icm45686_decoder_decode(const uint8_t *buffer,
 {
 	struct icm45686_encoded_data *edata = (struct icm45686_encoded_data *)buffer;
 
-	if (edata->header.is_fifo) {
-		return -ENOTSUP;
+	if (edata->header.events & REG_INT1_STATUS0_FIFO_THS(true) ||
+	    edata->header.events & REG_INT1_STATUS0_FIFO_FULL(true)) {
+		return icm45686_fifo_decode(buffer, chan_spec, fit, max_count, data_out);
 	} else {
 		return icm45686_one_shot_decode(buffer, chan_spec, fit, max_count, data_out);
 	}
@@ -386,6 +558,19 @@ static int icm45686_decoder_decode(const uint8_t *buffer,
 
 static bool icm45686_decoder_has_trigger(const uint8_t *buffer, enum sensor_trigger_type trigger)
 {
+	struct icm45686_encoded_data *edata = (struct icm45686_encoded_data *)buffer;
+
+	switch (trigger) {
+	case SENSOR_TRIG_DATA_READY:
+		return edata->header.events & REG_INT1_STATUS0_DRDY(true);
+	case SENSOR_TRIG_FIFO_WATERMARK:
+		return edata->header.events & REG_INT1_STATUS0_FIFO_THS(true);
+	case SENSOR_TRIG_FIFO_FULL:
+		return edata->header.events & REG_INT1_STATUS0_FIFO_FULL(true);
+	default:
+		break;
+	}
+
 	return false;
 }
 

--- a/drivers/sensor/tdk/icm45686/icm45686_reg.h
+++ b/drivers/sensor/tdk/icm45686/icm45686_reg.h
@@ -32,6 +32,9 @@
 #define REG_TEMP_DATA1_UI			0x0C
 #define REG_TEMP_DATA0_UI			0x0D
 #define REG_PWR_MGMT0				0x10
+#define REG_FIFO_COUNT_0			0x12
+#define REG_FIFO_COUNT_1			0x13
+#define REG_FIFO_DATA				0x14
 #define REG_INT1_CONFIG0			0x16
 #define REG_INT1_CONFIG1			0x17
 #define REG_INT1_CONFIG2			0x18
@@ -39,6 +42,12 @@
 #define REG_INT1_STATUS1			0x1A
 #define REG_ACCEL_CONFIG0			0x1B
 #define REG_GYRO_CONFIG0			0x1C
+#define REG_FIFO_CONFIG0			0x1D
+#define REG_FIFO_CONFIG1_0			0x1E
+#define REG_FIFO_CONFIG1_1			0x1F
+#define REG_FIFO_CONFIG2			0x20
+#define REG_FIFO_CONFIG3			0x21
+#define REG_FIFO_CONFIG4			0x22
 #define REG_DRIVE_CONFIG0			0x32
 #define REG_WHO_AM_I				0x72
 #define REG_IREG_ADDR_15_8			0x7C
@@ -84,9 +93,38 @@
 #define REG_INT1_STATUS0_FIFO_THS(val)			(((val) & BIT_MASK(1)) << 1)
 #define REG_INT1_STATUS0_FIFO_FULL(val)			((val) & BIT_MASK(1))
 
+#define REG_FIFO_CONFIG0_FIFO_MODE_BYPASS		0
+#define REG_FIFO_CONFIG0_FIFO_MODE_STREAM		1
+#define REG_FIFO_CONFIG0_FIFO_MODE_STOP_ON_FULL		2
+
+#define REG_FIFO_CONFIG0_FIFO_DEPTH_2K			0x07
+#define REG_FIFO_CONFIG0_FIFO_DEPTH_8K			0x1F
+
+#define REG_FIFO_CONFIG0_FIFO_MODE(val)			(((val) & BIT_MASK(2)) << 6)
+#define REG_FIFO_CONFIG0_FIFO_DEPTH(val)		((val) & BIT_MASK(6))
+
+#define REG_FIFO_CONFIG1_0_FIFO_WM_THS(val)		((val) & BIT_MASK(8))
+#define REG_FIFO_CONFIG1_1_FIFO_WM_THS(val)		(((val) >> 8) & BIT_MASK(8))
+
+#define REG_FIFO_CONFIG2_FIFO_FLUSH(val)		(((val) & BIT_MASK(1)) << 7)
+#define REG_FIFO_CONFIG2_FIFO_WM_GT_THS(val)		(((val) & BIT_MASK(1)) << 3)
+
+#define REG_FIFO_CONFIG3_FIFO_HIRES_EN(val)		(((val) & BIT_MASK(1)) << 3)
+#define REG_FIFO_CONFIG3_FIFO_GYRO_EN(val)		(((val) & BIT_MASK(1)) << 2)
+#define REG_FIFO_CONFIG3_FIFO_ACCEL_EN(val)		(((val) & BIT_MASK(1)) << 1)
+#define REG_FIFO_CONFIG3_FIFO_EN(val)			((val) & BIT_MASK(1))
+
 /* Misc. Defines */
 #define WHO_AM_I_ICM45686 0xE9
 
 #define REG_IREG_PREPARE_WRITE_ARRAY(base, reg, val)	{((base) >> 8) & 0xFF, reg, val}
+
+#define FIFO_HEADER_EXT_HEADER_EN(val)			(((val) & BIT_MASK(1)) << 7)
+#define FIFO_HEADER_ACCEL_EN(val)			(((val) & BIT_MASK(1)) << 6)
+#define FIFO_HEADER_GYRO_EN(val)			(((val) & BIT_MASK(1)) << 5)
+#define FIFO_HEADER_HIRES_EN(val)			(((val) & BIT_MASK(1)) << 4)
+
+#define FIFO_NO_DATA					0x8000
+#define FIFO_COUNT_MAX_HIGH_RES				104
 
 #endif /* ZEPHYR_DRIVERS_SENSOR_ICM45686_REG_H_ */

--- a/drivers/sensor/tdk/icm45686/icm45686_stream.c
+++ b/drivers/sensor/tdk/icm45686/icm45686_stream.c
@@ -1,0 +1,645 @@
+/*
+ * Copyright (c) 2023 Google LLC
+ * Copyright (c) 2025 Croxel Inc.
+ * Copyright (c) 2025 CogniPilot Foundation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/drivers/sensor.h>
+#include <zephyr/drivers/sensor_clock.h>
+#include <zephyr/rtio/rtio.h>
+#include <zephyr/sys/atomic.h>
+
+#include "icm45686.h"
+#include "icm45686_bus.h"
+#include "icm45686_stream.h"
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(ICM45686_STREAM, CONFIG_SENSOR_LOG_LEVEL);
+
+static struct sensor_stream_trigger *get_read_config_trigger(const struct sensor_read_config *cfg,
+							     enum sensor_trigger_type trig)
+{
+	for (int i = 0; i < cfg->count; ++i) {
+		if (cfg->triggers[i].trigger == trig) {
+			return &cfg->triggers[i];
+		}
+	}
+	LOG_DBG("Unsupported trigger (%d)", trig);
+	return NULL;
+}
+
+static inline bool should_flush_fifo(const struct sensor_read_config *read_cfg,
+				     uint8_t int_status)
+{
+	struct sensor_stream_trigger *trig_fifo_ths = get_read_config_trigger(
+		read_cfg,
+		SENSOR_TRIG_FIFO_WATERMARK);
+	struct sensor_stream_trigger *trig_fifo_full = get_read_config_trigger(
+		read_cfg,
+		SENSOR_TRIG_FIFO_FULL);
+
+	bool fifo_ths = int_status & REG_INT1_STATUS0_FIFO_THS(true);
+	bool fifo_full = int_status & REG_INT1_STATUS0_FIFO_FULL(true);
+
+	if ((trig_fifo_ths && trig_fifo_ths->opt == SENSOR_STREAM_DATA_DROP && fifo_ths) ||
+	    (trig_fifo_full && trig_fifo_full->opt == SENSOR_STREAM_DATA_DROP && fifo_full)) {
+		return true;
+	}
+
+	return false;
+}
+
+static inline bool should_read_fifo(const struct sensor_read_config *read_cfg,
+				    uint8_t int_status)
+{
+	struct sensor_stream_trigger *trig_fifo_ths = get_read_config_trigger(
+		read_cfg,
+		SENSOR_TRIG_FIFO_WATERMARK);
+	struct sensor_stream_trigger *trig_fifo_full = get_read_config_trigger(
+		read_cfg,
+		SENSOR_TRIG_FIFO_FULL);
+
+	bool fifo_ths = int_status & REG_INT1_STATUS0_FIFO_THS(true);
+	bool fifo_full = int_status & REG_INT1_STATUS0_FIFO_FULL(true);
+
+	if ((trig_fifo_ths && trig_fifo_ths->opt == SENSOR_STREAM_DATA_INCLUDE && fifo_ths) ||
+	    (trig_fifo_full && trig_fifo_full->opt == SENSOR_STREAM_DATA_INCLUDE && fifo_full)) {
+		return true;
+	}
+
+	return false;
+}
+
+static inline bool should_read_data(const struct sensor_read_config *read_cfg,
+				    uint8_t int_status)
+{
+	struct sensor_stream_trigger *trig_drdy = get_read_config_trigger(
+		read_cfg,
+		SENSOR_TRIG_DATA_READY);
+
+	bool drdy = int_status & REG_INT1_STATUS0_DRDY(true);
+
+	if (trig_drdy && trig_drdy->opt == SENSOR_STREAM_DATA_INCLUDE && drdy) {
+		return true;
+	}
+
+	return false;
+}
+
+static void icm45686_complete_result(struct rtio *ctx,
+				     const struct rtio_sqe *sqe,
+				     void *arg)
+{
+	const struct device *dev = (const struct device *)arg;
+	struct icm45686_data *data = dev->data;
+
+	struct rtio_iodev_sqe *iodev_sqe = data->stream.iodev_sqe;
+
+	memset(&data->stream.data, 0, sizeof(data->stream.data));
+
+	rtio_iodev_sqe_ok(iodev_sqe, 0);
+}
+
+static void icm45686_handle_event_actions(struct rtio *ctx,
+					  const struct rtio_sqe *sqe,
+					  void *arg)
+{
+	const struct device *dev = (const struct device *)arg;
+	struct icm45686_data *data = dev->data;
+	const struct sensor_read_config *read_cfg = data->stream.iodev_sqe->sqe.iodev->data;
+	uint8_t int_status = data->stream.data.int_status;
+	int err;
+
+	data->stream.data.events.drdy = int_status & REG_INT1_STATUS0_DRDY(true);
+	data->stream.data.events.fifo_ths = int_status & REG_INT1_STATUS0_FIFO_THS(true);
+	data->stream.data.events.fifo_full = int_status & REG_INT1_STATUS0_FIFO_FULL(true);
+
+	__ASSERT(data->stream.data.fifo_count > 0 &&
+		 data->stream.data.fifo_count <= FIFO_COUNT_MAX_HIGH_RES,
+		 "Invalid fifo count: %d", data->stream.data.fifo_count);
+
+	struct icm45686_encoded_data *buf;
+	uint32_t buf_len;
+	uint32_t buf_len_required = sizeof(struct icm45686_encoded_header);
+
+	/** We just need the header to communicate the events occurred during
+	 * this SQE. Only include more data if the associated trigger needs it.
+	 */
+	if (should_read_fifo(read_cfg, int_status)) {
+		buf_len_required += (data->stream.data.fifo_count *
+				     sizeof(struct icm45686_encoded_fifo_payload));
+	} else if (should_read_data(read_cfg, int_status)) {
+		buf_len_required += sizeof(struct icm45686_encoded_payload);
+	}
+
+	err = rtio_sqe_rx_buf(data->stream.iodev_sqe,
+			      buf_len_required,
+			      buf_len_required,
+			      (uint8_t **)&buf,
+			      &buf_len);
+	__ASSERT(err == 0, "Failed to acquire buffer (len: %d) for encoded data: %d. "
+			   "Please revisit RTIO queue sizing and look for "
+			   "bottlenecks during sensor data processing",
+			   buf_len_required, err);
+
+	/** Still throw an error even if asserts are off */
+	if (err) {
+		struct rtio_iodev_sqe *iodev_sqe = data->stream.iodev_sqe;
+
+		LOG_ERR("Failed to acquire buffer for encoded data: %d", err);
+
+		data->stream.iodev_sqe = NULL;
+		rtio_iodev_sqe_err(iodev_sqe, err);
+		return;
+	}
+
+	LOG_DBG("Alloc buf - required: %d, alloc: %d", buf_len_required, buf_len);
+
+	buf->header.timestamp = data->stream.data.timestamp;
+	buf->header.fifo_count = 0;
+	buf->header.channels = 0;
+	buf->header.events = REG_INT1_STATUS0_DRDY(data->stream.data.events.drdy) |
+			     REG_INT1_STATUS0_FIFO_THS(data->stream.data.events.fifo_ths) |
+			     REG_INT1_STATUS0_FIFO_FULL(data->stream.data.events.fifo_full);
+
+	if (should_read_fifo(read_cfg, int_status)) {
+
+		struct rtio_sqe *data_wr_sqe = rtio_sqe_acquire(ctx);
+		struct rtio_sqe *data_rd_sqe = rtio_sqe_acquire(ctx);
+		uint8_t read_reg;
+
+		if (!data_wr_sqe || !data_rd_sqe) {
+			struct rtio_iodev_sqe *iodev_sqe = data->stream.iodev_sqe;
+
+			LOG_ERR("Failed to acquire RTIO SQEs");
+
+			data->stream.iodev_sqe = NULL;
+			rtio_iodev_sqe_err(iodev_sqe, -ENOMEM);
+			return;
+		}
+
+		/** In FIFO data, the scale is fixed, irrespective of
+		 * the configured settings.
+		 */
+		buf->header.accel_fs = ICM45686_DT_ACCEL_FS_32;
+		buf->header.gyro_fs = ICM45686_DT_GYRO_FS_4000;
+		buf->header.channels = 0x7F; /* Signal all channels are available */
+		buf->header.fifo_count = data->stream.data.fifo_count;
+
+		read_reg = REG_FIFO_DATA | REG_SPI_READ_BIT;
+		rtio_sqe_prep_tiny_write(data_wr_sqe,
+					 data->rtio.iodev,
+					 RTIO_PRIO_HIGH,
+					 &read_reg,
+					 1,
+					 NULL);
+		data_wr_sqe->flags |= RTIO_SQE_TRANSACTION;
+
+		rtio_sqe_prep_read(data_rd_sqe,
+				   data->rtio.iodev,
+				   RTIO_PRIO_HIGH,
+				   (uint8_t *)&buf->fifo_payload,
+				   (buf->header.fifo_count *
+				   sizeof(struct icm45686_encoded_fifo_payload)),
+				   NULL);
+		data_rd_sqe->flags |= RTIO_SQE_CHAINED;
+
+	} else if (should_flush_fifo(read_cfg, int_status)) {
+
+		struct rtio_sqe *write_sqe = rtio_sqe_acquire(ctx);
+
+		if (!write_sqe) {
+			struct rtio_iodev_sqe *iodev_sqe = data->stream.iodev_sqe;
+
+			LOG_ERR("Failed to acquire RTIO SQE");
+
+			data->stream.iodev_sqe = NULL;
+			rtio_iodev_sqe_err(iodev_sqe, -ENOMEM);
+			return;
+		}
+
+		uint8_t write_reg[] = {
+			REG_FIFO_CONFIG2,
+			REG_FIFO_CONFIG2_FIFO_FLUSH(true) |
+			REG_FIFO_CONFIG2_FIFO_WM_GT_THS(true)
+		};
+
+		rtio_sqe_prep_tiny_write(write_sqe,
+					 data->rtio.iodev,
+					 RTIO_PRIO_HIGH,
+					 write_reg,
+					 sizeof(write_reg),
+					 NULL);
+		write_sqe->flags |= RTIO_SQE_CHAINED;
+
+	} else if (should_read_data(read_cfg, int_status)) {
+
+		buf->header.accel_fs = data->edata.header.accel_fs;
+		buf->header.gyro_fs = data->edata.header.gyro_fs;
+		buf->header.channels = 0x7F; /* Signal all channels are available */
+
+		struct rtio_sqe *write_sqe = rtio_sqe_acquire(ctx);
+		struct rtio_sqe *read_sqe = rtio_sqe_acquire(ctx);
+
+		if (!write_sqe || !read_sqe) {
+			struct rtio_iodev_sqe *iodev_sqe = data->stream.iodev_sqe;
+
+			LOG_ERR("Failed to acquire RTIO SQEs");
+
+			data->stream.iodev_sqe = NULL;
+			rtio_iodev_sqe_err(iodev_sqe, -ENOMEM);
+			return;
+		}
+
+		uint8_t read_reg = REG_ACCEL_DATA_X1_UI | REG_SPI_READ_BIT;
+
+		rtio_sqe_prep_tiny_write(write_sqe,
+					 data->rtio.iodev,
+					 RTIO_PRIO_HIGH,
+					 &read_reg,
+					 1,
+					 NULL);
+		write_sqe->flags |= RTIO_SQE_TRANSACTION;
+
+		rtio_sqe_prep_read(read_sqe,
+				   data->rtio.iodev,
+				   RTIO_PRIO_HIGH,
+				   buf->payload.buf,
+				   sizeof(buf->payload.buf),
+				   NULL);
+		read_sqe->flags |= RTIO_SQE_CHAINED;
+	}
+
+	struct rtio_cqe *cqe;
+
+	do {
+		cqe = rtio_cqe_consume(ctx);
+		if (cqe != NULL) {
+			err = cqe->result;
+			rtio_cqe_release(ctx, cqe);
+		}
+	} while (cqe != NULL);
+
+	struct rtio_sqe *cb_sqe = rtio_sqe_acquire(ctx);
+
+	if (!cb_sqe) {
+		LOG_ERR("Failed to acquire RTIO SQE for completion callback");
+		rtio_iodev_sqe_err(data->stream.iodev_sqe, -ENOMEM);
+		return;
+	}
+
+	rtio_sqe_prep_callback_no_cqe(cb_sqe,
+				      icm45686_complete_result,
+				      (void *)dev,
+				      data->stream.iodev_sqe);
+
+	rtio_submit(ctx, 0);
+}
+
+static void icm45686_event_handler(const struct device *dev)
+{
+	struct icm45686_data *data = dev->data;
+	uint8_t val = 0;
+	uint64_t cycles;
+	int err;
+
+	if (!data->stream.iodev_sqe ||
+	    FIELD_GET(RTIO_SQE_CANCELED, data->stream.iodev_sqe->sqe.flags)) {
+		LOG_WRN("Callback triggered with no streaming submission - Disabling interrupts");
+
+		struct rtio_sqe *write_sqe = rtio_sqe_acquire(data->rtio.ctx);
+		uint8_t wr_data[] = {REG_INT1_CONFIG0, 0x00};
+
+		rtio_sqe_prep_tiny_write(write_sqe,
+					 data->rtio.iodev,
+					 RTIO_PRIO_HIGH,
+					 wr_data,
+					 sizeof(wr_data),
+					 NULL);
+		rtio_submit(data->rtio.ctx, 0);
+
+		data->stream.settings.enabled.drdy = false;
+		data->stream.settings.enabled.fifo_ths = false;
+		data->stream.settings.enabled.fifo_full = false;
+		return;
+	} else if (!atomic_cas(&data->stream.in_progress, 0, 1)) {
+		/** There's an on-going */
+		return;
+	}
+
+	err = sensor_clock_get_cycles(&cycles);
+	if (err) {
+		struct rtio_iodev_sqe *iodev_sqe = data->stream.iodev_sqe;
+
+		LOG_ERR("Failed to get timestamp: %d", err);
+
+		data->stream.iodev_sqe = NULL;
+		rtio_iodev_sqe_err(iodev_sqe, err);
+		return;
+	}
+
+	data->stream.data.timestamp = sensor_clock_cycles_to_ns(cycles);
+
+	/** Prepare an asynchronous read of the INT status register */
+	struct rtio_sqe *write_sqe = rtio_sqe_acquire(data->rtio.ctx);
+	struct rtio_sqe *read_sqe = rtio_sqe_acquire(data->rtio.ctx);
+	struct rtio_sqe *write_fifo_ct_sqe = rtio_sqe_acquire(data->rtio.ctx);
+	struct rtio_sqe *read_fifo_ct_sqe = rtio_sqe_acquire(data->rtio.ctx);
+	struct rtio_sqe *complete_sqe = rtio_sqe_acquire(data->rtio.ctx);
+
+	if (!write_sqe || !read_sqe || !complete_sqe) {
+		struct rtio_iodev_sqe *iodev_sqe = data->stream.iodev_sqe;
+
+		LOG_ERR("Failed to acquire RTIO SQEs");
+
+		data->stream.iodev_sqe = NULL;
+		rtio_iodev_sqe_err(iodev_sqe, -ENOMEM);
+		return;
+	}
+
+	/** Directly read Status Register to determine what triggered the event */
+	val = REG_INT1_STATUS0 | REG_SPI_READ_BIT;
+	rtio_sqe_prep_tiny_write(write_sqe,
+				 data->rtio.iodev,
+				 RTIO_PRIO_HIGH,
+				 &val,
+				 1,
+				 NULL);
+	write_sqe->flags |= RTIO_SQE_TRANSACTION;
+
+	rtio_sqe_prep_read(read_sqe,
+			   data->rtio.iodev,
+			   RTIO_PRIO_HIGH,
+			   &data->stream.data.int_status,
+			   1,
+			   NULL);
+	read_sqe->flags |= RTIO_SQE_CHAINED;
+
+	/** Preemptively read FIFO count so we can decide on the next callback
+	 * how much FIFO data we'd read (if needed).
+	 */
+	val = REG_FIFO_COUNT_0 | REG_SPI_READ_BIT;
+	rtio_sqe_prep_tiny_write(write_fifo_ct_sqe,
+				 data->rtio.iodev,
+				 RTIO_PRIO_HIGH,
+				 &val,
+				 1,
+				 NULL);
+	write_fifo_ct_sqe->flags |= RTIO_SQE_TRANSACTION;
+
+	rtio_sqe_prep_read(read_fifo_ct_sqe,
+			   data->rtio.iodev,
+			   RTIO_PRIO_HIGH,
+			   (uint8_t *)&data->stream.data.fifo_count,
+			   2,
+			   NULL);
+	read_fifo_ct_sqe->flags |= RTIO_SQE_CHAINED;
+
+	rtio_sqe_prep_callback_no_cqe(complete_sqe,
+				      icm45686_handle_event_actions,
+				      (void *)dev,
+				      data->stream.iodev_sqe);
+
+	rtio_submit(data->rtio.ctx, 0);
+}
+
+static void icm45686_gpio_callback(const struct device *gpio_dev,
+				   struct gpio_callback *cb,
+				   uint32_t pins)
+{
+	struct icm45686_stream *stream = CONTAINER_OF(cb,
+						      struct icm45686_stream,
+						      cb);
+	const struct device *dev = stream->dev;
+
+	icm45686_event_handler(dev);
+}
+
+static inline bool settings_changed(const struct icm45686_stream *a,
+				    const struct icm45686_stream *b)
+{
+	return (a->settings.enabled.drdy != b->settings.enabled.drdy) ||
+	       (a->settings.opt.drdy != b->settings.opt.drdy) ||
+	       (a->settings.enabled.fifo_ths != b->settings.enabled.fifo_ths) ||
+	       (a->settings.opt.fifo_ths != b->settings.opt.fifo_ths) ||
+	       (a->settings.enabled.fifo_full != b->settings.enabled.fifo_full) ||
+	       (a->settings.opt.fifo_full != b->settings.opt.fifo_full);
+}
+
+void icm45686_stream_submit(const struct device *dev,
+			    struct rtio_iodev_sqe *iodev_sqe)
+{
+	const struct sensor_read_config *read_cfg = iodev_sqe->sqe.iodev->data;
+	struct icm45686_data *data = dev->data;
+	const struct icm45686_config *cfg = dev->config;
+	uint8_t val = 0;
+	int err;
+
+	/** This separate struct is required due to the streaming API using a
+	 * multi-shot RTIO submission: meaning, re-submitting itself after
+	 * completion; hence, we don't have context to determine if this was
+	 * the first submission that kicked things off. We're then, inferring
+	 * this by comparing if the read-config has changed, and only restart
+	 * in such case.
+	 */
+	struct icm45686_stream stream = {0};
+
+	for (size_t i = 0 ; i  < read_cfg->count ; i++) {
+		switch (read_cfg->triggers[i].trigger) {
+		case SENSOR_TRIG_DATA_READY:
+			stream.settings.enabled.drdy = true;
+			stream.settings.opt.drdy = read_cfg->triggers[i].opt;
+			break;
+		case SENSOR_TRIG_FIFO_WATERMARK:
+			stream.settings.enabled.fifo_ths = true;
+			stream.settings.opt.fifo_ths = read_cfg->triggers[i].opt;
+			break;
+		case SENSOR_TRIG_FIFO_FULL:
+			stream.settings.enabled.fifo_full = true;
+			stream.settings.opt.fifo_full = read_cfg->triggers[i].opt;
+			break;
+		default:
+			LOG_ERR("Unsupported trigger (%d)", read_cfg->triggers[i].trigger);
+			rtio_iodev_sqe_err(iodev_sqe, -ENOTSUP);
+			return;
+		}
+	}
+
+	__ASSERT(stream.settings.enabled.drdy ^
+		 ((stream.settings.enabled.fifo_ths || stream.settings.enabled.fifo_full)),
+		 "DRDY should not be enabled alongside FIFO triggers");
+
+	__ASSERT(!stream.settings.enabled.fifo_ths ||
+		 (stream.settings.enabled.fifo_ths && cfg->settings.fifo_watermark),
+		 "FIFO watermark trigger requires a watermark level. Please "
+		 "configure it on the device-tree");
+
+	/* Store context for next submission (handled within callbacks) */
+	data->stream.iodev_sqe = iodev_sqe;
+
+	(void)atomic_clear(&data->stream.in_progress);
+
+	if (settings_changed(&data->stream, &stream)) {
+
+		data->stream.settings = stream.settings;
+
+		/* Disable all interrupts before re-configuring */
+		err = icm45686_bus_write(dev, REG_INT1_CONFIG0, &val, 1);
+		if (err) {
+			LOG_ERR("Failed to disable interrupts on INT1_CONFIG0: %d", err);
+			data->stream.iodev_sqe = NULL;
+			rtio_iodev_sqe_err(iodev_sqe, err);
+			return;
+		}
+
+		/* Read flags to clear them */
+		err = icm45686_bus_read(dev, REG_INT1_STATUS0, &val, 1);
+		if (err) {
+			LOG_ERR("Failed to read INT1_STATUS0: %d", err);
+			data->stream.iodev_sqe = NULL;
+			rtio_iodev_sqe_err(iodev_sqe, err);
+			return;
+		}
+
+		val = REG_FIFO_CONFIG3_FIFO_EN(false) |
+		      REG_FIFO_CONFIG3_FIFO_ACCEL_EN(false) |
+		      REG_FIFO_CONFIG3_FIFO_GYRO_EN(false) |
+		      REG_FIFO_CONFIG3_FIFO_HIRES_EN(false);
+		err = icm45686_bus_write(dev, REG_FIFO_CONFIG3, &val, 1);
+		if (err) {
+			LOG_ERR("Failed to disable all FIFO settings: %d", err);
+			data->stream.iodev_sqe = NULL;
+			rtio_iodev_sqe_err(iodev_sqe, err);
+			return;
+		}
+
+		val = REG_INT1_CONFIG0_STATUS_EN_DRDY(data->stream.settings.enabled.drdy) |
+		      REG_INT1_CONFIG0_STATUS_EN_FIFO_THS(data->stream.settings.enabled.fifo_ths) |
+		      REG_INT1_CONFIG0_STATUS_EN_FIFO_FULL(data->stream.settings.enabled.fifo_full);
+		err = icm45686_bus_write(dev, REG_INT1_CONFIG0, &val, 1);
+		if (err) {
+			LOG_ERR("Failed to configure INT1_CONFIG0: %d", err);
+			data->stream.iodev_sqe = NULL;
+			rtio_iodev_sqe_err(iodev_sqe, err);
+			return;
+		}
+
+		val = REG_FIFO_CONFIG0_FIFO_MODE(REG_FIFO_CONFIG0_FIFO_MODE_BYPASS) |
+		      REG_FIFO_CONFIG0_FIFO_DEPTH(REG_FIFO_CONFIG0_FIFO_DEPTH_2K);
+		err = icm45686_bus_write(dev, REG_FIFO_CONFIG0, &val, 1);
+		if (err) {
+			LOG_ERR("Failed to disable FIFO: %d", err);
+			data->stream.iodev_sqe = NULL;
+			rtio_iodev_sqe_err(iodev_sqe, err);
+			return;
+		}
+
+		if (data->stream.settings.enabled.fifo_ths ||
+		    data->stream.settings.enabled.fifo_full) {
+			uint16_t fifo_ths = data->stream.settings.enabled.fifo_ths ?
+					    cfg->settings.fifo_watermark : 0;
+
+			val = REG_FIFO_CONFIG2_FIFO_WM_GT_THS(true) |
+			      REG_FIFO_CONFIG2_FIFO_FLUSH(true);
+			err = icm45686_bus_write(dev, REG_FIFO_CONFIG2, &val, 1);
+			if (err) {
+				LOG_ERR("Failed to configure greater-than FIFO threshold: %d", err);
+				data->stream.iodev_sqe = NULL;
+				rtio_iodev_sqe_err(iodev_sqe, err);
+				return;
+			}
+
+			err = icm45686_bus_write(dev, REG_FIFO_CONFIG1_0, (uint8_t *)&fifo_ths, 2);
+			if (err) {
+				LOG_ERR("Failed to configure FIFO watermark: %d", err);
+				data->stream.iodev_sqe = NULL;
+				rtio_iodev_sqe_err(iodev_sqe, err);
+				return;
+			}
+
+			val = REG_FIFO_CONFIG0_FIFO_MODE(REG_FIFO_CONFIG0_FIFO_MODE_STREAM) |
+			      REG_FIFO_CONFIG0_FIFO_DEPTH(REG_FIFO_CONFIG0_FIFO_DEPTH_2K);
+			err = icm45686_bus_write(dev, REG_FIFO_CONFIG0, &val, 1);
+			if (err) {
+				LOG_ERR("Failed to disable FIFO: %d", err);
+				data->stream.iodev_sqe = NULL;
+				rtio_iodev_sqe_err(iodev_sqe, err);
+				return;
+			}
+
+			val = REG_FIFO_CONFIG3_FIFO_EN(true) |
+			      REG_FIFO_CONFIG3_FIFO_ACCEL_EN(true) |
+			      REG_FIFO_CONFIG3_FIFO_GYRO_EN(true) |
+			      REG_FIFO_CONFIG3_FIFO_HIRES_EN(true);
+			err = icm45686_bus_write(dev, REG_FIFO_CONFIG3, &val, 1);
+			if (err) {
+				LOG_ERR("Failed to enable FIFO: %d", err);
+				data->stream.iodev_sqe = NULL;
+				rtio_iodev_sqe_err(iodev_sqe, err);
+				return;
+			}
+		}
+	}
+}
+
+int icm45686_stream_init(const struct device *dev)
+{
+	const struct icm45686_config *cfg = dev->config;
+	struct icm45686_data *data = dev->data;
+	uint8_t val = 0;
+	int err;
+
+	/** Needed to get back the device handle from the callback context */
+	data->stream.dev = dev;
+
+	(void)atomic_clear(&data->stream.in_progress);
+
+	if (!cfg->int_gpio.port) {
+		LOG_ERR("Interrupt GPIO not supplied");
+		return -ENODEV;
+	}
+
+	if (!gpio_is_ready_dt(&cfg->int_gpio)) {
+		LOG_ERR("Interrupt GPIO not ready");
+		return -ENODEV;
+	}
+
+	err = gpio_pin_configure_dt(&cfg->int_gpio, GPIO_INPUT);
+	if (err) {
+		LOG_ERR("Failed to configure interrupt GPIO");
+		return -EIO;
+	}
+
+	gpio_init_callback(&data->stream.cb,
+			   icm45686_gpio_callback,
+			   BIT(cfg->int_gpio.pin));
+
+	err = gpio_add_callback(cfg->int_gpio.port, &data->stream.cb);
+	if (err) {
+		LOG_ERR("Failed to add interrupt callback");
+		return -EIO;
+	}
+
+	err = gpio_pin_interrupt_configure_dt(&cfg->int_gpio,
+					      GPIO_INT_EDGE_TO_ACTIVE);
+	if (err) {
+		LOG_ERR("Failed to configure interrupt");
+	}
+
+	err = icm45686_bus_write(dev, REG_INT1_CONFIG0, &val, 1);
+	if (err) {
+		LOG_ERR("Failed to disable all INTs");
+	}
+
+	val = REG_INT1_CONFIG2_EN_OPEN_DRAIN(false) |
+	      REG_INT1_CONFIG2_EN_ACTIVE_HIGH(true);
+
+	err = icm45686_bus_write(dev, REG_INT1_CONFIG2, &val, 1);
+	if (err) {
+		LOG_ERR("Failed to configure INT as push-pull: %d", err);
+	}
+
+	return 0;
+}

--- a/drivers/sensor/tdk/icm45686/icm45686_stream.h
+++ b/drivers/sensor/tdk/icm45686/icm45686_stream.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2025 Croxel Inc.
+ * Copyright (c) 2025 CogniPilot Foundation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_DRIVERS_SENSOR_ICM45686_STREAM_H_
+#define ZEPHYR_DRIVERS_SENSOR_ICM45686_STREAM_H_
+
+int icm45686_stream_init(const struct device *dev);
+
+void icm45686_stream_submit(const struct device *dev,
+			    struct rtio_iodev_sqe *iodev_sqe);
+
+#endif /* ZEPHYR_DRIVERS_SENSOR_ICM45686_STREAM_H_ */

--- a/dts/bindings/sensor/invensense,icm45686.yaml
+++ b/dts/bindings/sensor/invensense,icm45686.yaml
@@ -160,3 +160,11 @@ properties:
       - 4 # ICM45686_DT_GYRO_LPF_BW_1_32
       - 5 # ICM45686_DT_GYRO_LPF_BW_1_64
       - 6 # ICM45686_DT_GYRO_LPF_BW_1_128
+
+  fifo-watermark:
+    type: int
+    default: 0
+    description: |
+      Specify the FIFO watermark level in frame count.
+      Default is power-up configuration (disabled).
+      Valid range: 0 - 104


### PR DESCRIPTION
### Description
This PR is a follow-on of #85963, in which the Streaming mode is enabled for the following triggers:
- Data Ready.
- FIFO Watermark.
- FIFO Full.

> [!NOTE]
> This PR Depends on:
> - Basic driver functionality: #85963.
> - SPI RTIO fix: #86169

### Testing
This has been tested with the Sensor Shell, in the following targets:
- nrf52840dk/nrf52840
- frdm_mcxn947/mcxn947/cpu0

Screenshot of IMU running at 6400 Hz with FIFO watermark on FRDM-MCXN947:
![image](https://github.com/user-attachments/assets/098b61bc-9e5f-4708-b2a8-218bbe70bb2d)

