### PR TITLE
dts: wifi: Simplify the description of the binding

### DIFF
--- a/dts/bindings/wifi/nordic,nrf70-coex.yaml
+++ b/dts/bindings/wifi/nordic,nrf70-coex.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-  This is a representation of an external radio coexistence setup for coexistence
+  An external radio coexistence setup for coexistence
   with nRF70 WiFi chips.
 
 properties:

--- a/dts/bindings/wifi/nordic,nrf70-qspi.yaml
+++ b/dts/bindings/wifi/nordic,nrf70-qspi.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-description: This is a representation of the nRF70 Wi-Fi chip.
+description: nRF70 Wi-Fi chip with QSPI interface.
 
 include: ["nordic,nrf70.yaml", "base.yaml"]
 

--- a/dts/bindings/wifi/nordic,nrf70-spi.yaml
+++ b/dts/bindings/wifi/nordic,nrf70-spi.yaml
@@ -1,6 +1,6 @@
 # Copyright (c) 2024 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-description: This is a representation of the nRF70 Wi-Fi chip.
+description: nRF70 Wi-Fi chip with SPI interface.
 
 include: ["nordic,nrf70.yaml", "spi-device.yaml"]

--- a/dts/bindings/wifi/nordic,nrf7000-coex.yaml
+++ b/dts/bindings/wifi/nordic,nrf7000-coex.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-description: This is a representation of the nRF7000 Wi-Fi chip with COEX interface.
+description: nRF7000 Wi-Fi chip with COEX interface.
 
 compatible: nordic,nrf7000-coex
 

--- a/dts/bindings/wifi/nordic,nrf7000-qspi.yaml
+++ b/dts/bindings/wifi/nordic,nrf7000-qspi.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-description: This is a representation of the nRF7002 Wi-Fi chip with QSPI interface.
+description: nRF7002 Wi-Fi chip with QSPI interface.
 
 compatible: nordic,nrf7000-qspi
 

--- a/dts/bindings/wifi/nordic,nrf7000-spi.yaml
+++ b/dts/bindings/wifi/nordic,nrf7000-spi.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-description: This is a representation of the nRF7002 Wi-Fi chip with SPI interface.
+description: nRF7002 Wi-Fi chip with SPI interface.
 
 compatible: nordic,nrf7000-spi
 

--- a/dts/bindings/wifi/nordic,nrf7001-coex.yaml
+++ b/dts/bindings/wifi/nordic,nrf7001-coex.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-description: This is a representation of the nRF7001 Wi-Fi chip with COEX interface.
+description: nRF7001 Wi-Fi chip with COEX interface.
 
 compatible: nordic,nrf7001-coex
 

--- a/dts/bindings/wifi/nordic,nrf7001-qspi.yaml
+++ b/dts/bindings/wifi/nordic,nrf7001-qspi.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-description: This is a representation of the nRF7002 Wi-Fi chip with QSPI interface.
+description: nRF7002 Wi-Fi chip with QSPI interface.
 
 compatible: nordic,nrf7001-qspi
 

--- a/dts/bindings/wifi/nordic,nrf7001-spi.yaml
+++ b/dts/bindings/wifi/nordic,nrf7001-spi.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-description: This is a representation of the nRF7002 Wi-Fi chip with SPI interface.
+description: nRF7002 Wi-Fi chip with SPI interface.
 
 compatible: nordic,nrf7001-spi
 

--- a/dts/bindings/wifi/nordic,nrf7002-coex.yaml
+++ b/dts/bindings/wifi/nordic,nrf7002-coex.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-description: This is a representation of the nRF7002 Wi-Fi chip with COEX interface.
+description: nRF7002 Wi-Fi chip with COEX interface.
 
 compatible: nordic,nrf7002-coex
 

--- a/dts/bindings/wifi/nordic,nrf7002-qspi.yaml
+++ b/dts/bindings/wifi/nordic,nrf7002-qspi.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-description: This is a representation of the nRF7002 Wi-Fi chip with QSPI interface.
+description: nRF7002 Wi-Fi chip with QSPI interface.
 
 compatible: nordic,nrf7002-qspi
 

--- a/dts/bindings/wifi/nordic,nrf7002-spi.yaml
+++ b/dts/bindings/wifi/nordic,nrf7002-spi.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-description: This is a representation of the nRF7002 Wi-Fi chip with SPI interface.
+description: nRF7002 Wi-Fi chip with SPI interface.
 
 compatible: nordic,nrf7002-spi
 

--- a/dts/bindings/wifi/wifi-tx-power-2g.yaml
+++ b/dts/bindings/wifi/wifi-tx-power-2g.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-  This is a representation of the Wi-Fi transmit power ceilings
+  Wi-Fi transmit power ceilings
   i.e., maximum transmit power allowed for 2.4GHz band. Based on the
   RF performance of the device, the transmit power can be limited
   for different data rates and sub-bands to get the best performance.

--- a/dts/bindings/wifi/wifi-tx-power-5g.yaml
+++ b/dts/bindings/wifi/wifi-tx-power-5g.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-  This is a representation of the Wi-Fi transmit power ceilings
+  Wi-Fi transmit power ceilings
   i.e., maximum transmit power allowed for 5GHz band. Based on the
   RF performance of the device, the transmit power can be limited
   for different data rates and sub-bands to get the best performance.


### PR DESCRIPTION
Remove redundant descriptions in Wi-Fi bindings, such as "This is a representation of".