### PR TITLE
dts: cache: Simplify the description of the binding

### DIFF
--- a/dts/bindings/cache/andestech,l2c.yaml
+++ b/dts/bindings/cache/andestech,l2c.yaml
@@ -4,8 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-description:
-  This is a representation of AndesTech L2 cache node
+description: AndesTech L2 cache
 
 compatible: "andestech,l2c"
 


### PR DESCRIPTION
Remove redundant descriptions in cache bindings, such as "This is a representation of" and "... node".