### PR TITLE
twister: rename platform.py

### DIFF
--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -27,8 +27,8 @@ from queue import Empty, Queue
 import psutil
 from twisterlib.environment import ZEPHYR_BASE, strip_ansi_sequences
 from twisterlib.error import TwisterException
-from twisterlib.platform import Platform
 from twisterlib.statuses import TwisterStatus
+from twisterlib.twister_platform import Platform
 
 sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts/pylib/build_helpers"))
 from domains import Domains

--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -46,10 +46,10 @@ from twisterlib.coverage import run_coverage_instance
 from twisterlib.environment import TwisterEnv
 from twisterlib.harness import Ctest, HarnessImporter, Pytest
 from twisterlib.log_helper import log_command
-from twisterlib.platform import Platform
 from twisterlib.testinstance import TestInstance
 from twisterlib.testplan import change_skip_to_error_if_integration
 from twisterlib.testsuite import TestSuite
+from twisterlib.twister_platform import Platform
 
 try:
     from yaml import CSafeLoader as SafeLoader

--- a/scripts/pylib/twister/twisterlib/testinstance.py
+++ b/scripts/pylib/twister/twisterlib/testinstance.py
@@ -30,10 +30,10 @@ from twisterlib.handlers import (
     QEMUWinHandler,
     SimulationHandler,
 )
-from twisterlib.platform import Platform
 from twisterlib.size_calc import SizeCalculator
 from twisterlib.statuses import TwisterStatus
 from twisterlib.testsuite import TestCase, TestSuite
+from twisterlib.twister_platform import Platform
 
 logger = logging.getLogger('twister')
 logger.setLevel(logging.DEBUG)

--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -30,11 +30,11 @@ except ImportError:
 import scl
 from twisterlib.config_parser import TwisterConfigParser
 from twisterlib.error import TwisterRuntimeError
-from twisterlib.platform import Platform, generate_platforms
 from twisterlib.quarantine import Quarantine
 from twisterlib.statuses import TwisterStatus
 from twisterlib.testinstance import TestInstance
 from twisterlib.testsuite import TestSuite, scan_testsuite_path
+from twisterlib.twister_platform import Platform, generate_platforms
 from zephyr_module import parse_modules
 
 logger = logging.getLogger('twister')

--- a/scripts/pylib/twister/twisterlib/twister_platform.py
+++ b/scripts/pylib/twister/twisterlib/twister_platform.py
@@ -53,9 +53,7 @@ class Platform:
     )
 
     def __init__(self):
-        """Constructor.
-
-        """
+        """Constructor."""
 
         self.name = ""
         self.aliases = []
@@ -137,10 +135,8 @@ class Platform:
         self.type = variant_data.get('type', data.get('type', self.type))
 
         self.simulators = [
-            Simulator(data) for data in variant_data.get(
-                'simulation',
-                data.get('simulation', self.simulators)
-            )
+            Simulator(data)
+            for data in variant_data.get('simulation', data.get('simulation', self.simulators))
         ]
         default_sim = self.simulator_by_name(None)
         if default_sim:
@@ -151,21 +147,22 @@ class Platform:
             self.supported_toolchains = []
 
         support_toolchain_variants = {
-          # we don't provide defaults for 'arc' intentionally: some targets can't be built with GNU
-          # toolchain ("zephyr", "cross-compile" options) and for some targets we haven't provided
-          # MWDT compiler / linker options in corresponding SoC file in Zephyr, so these targets
-          # can't be built with ARC MWDT toolchain ("arcmwdt" option) by Zephyr build system Instead
-          # for 'arc' we rely on 'toolchain' option in board yaml configuration.
-          "arm": ["zephyr", "gnuarmemb", "armclang", "llvm"],
-          "arm64": ["zephyr", "cross-compile"],
-          "mips": ["zephyr"],
-          "nios2": ["zephyr"],
-          "riscv": ["zephyr", "cross-compile"],
-          "posix": ["host", "llvm"],
-          "sparc": ["zephyr"],
-          "x86": ["zephyr", "llvm"],
-          # Xtensa is not listed on purpose, since there is no single toolchain
-          # that is supported on all board targets for xtensa.
+            # We don't provide defaults for 'arc' intentionally: some targets can't be built with
+            # GNU toolchain ("zephyr", "cross-compile" options) and for some targets we haven't
+            # provided MWDT compiler / linker options in corresponding SoC file in Zephyr, so
+            # these targets can't be built with ARC MWDT toolchain ("arcmwdt" option)
+            # by Zephyr build system.
+            # Instead for 'arc' we rely on 'toolchain' option in board yaml configuration.
+            "arm": ["zephyr", "gnuarmemb", "armclang", "llvm"],
+            "arm64": ["zephyr", "cross-compile"],
+            "mips": ["zephyr"],
+            "nios2": ["zephyr"],
+            "riscv": ["zephyr", "cross-compile"],
+            "posix": ["host", "llvm"],
+            "sparc": ["zephyr"],
+            "x86": ["zephyr", "llvm"],
+            # Xtensa is not listed on purpose, since there is no single toolchain
+            # that is supported on all board targets for xtensa.
         }
 
         if self.arch in support_toolchain_variants:
@@ -204,8 +201,13 @@ def generate_platforms(board_roots, soc_roots, arch_roots):
     dir2data = {}
     legacy_files = []
 
-    lb_args = Namespace(board_roots=board_roots, soc_roots=soc_roots, arch_roots=arch_roots,
-                        board=None, board_dir=None)
+    lb_args = Namespace(
+        board_roots=board_roots,
+        soc_roots=soc_roots,
+        arch_roots=arch_roots,
+        board=None,
+        board_dir=None,
+    )
 
     for board in list_boards.find_v2_boards(lb_args).values():
         for board_dir in board.directories:
@@ -238,8 +240,11 @@ def generate_platforms(board_roots, soc_roots, arch_roots):
                     else:
                         target = f"{board.name}/{qual}"
                         alias2target[target] = target
-                        if '/' not in qual and len(board.socs) == 1 \
-                                and rev.name == board.revision_default:
+                        if (
+                            '/' not in qual
+                            and len(board.socs) == 1
+                            and rev.name == board.revision_default
+                        ):
                             alias2target[f"{board.name}"] = target
 
                     target2board[target] = board

--- a/scripts/tests/twister/pytest_integration/test_harness_pytest.py
+++ b/scripts/tests/twister/pytest_integration/test_harness_pytest.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from twisterlib.harness import Pytest
 from twisterlib.testsuite import TestSuite
 from twisterlib.testinstance import TestInstance
-from twisterlib.platform import Platform
+from twisterlib.twister_platform import Platform
 
 
 @pytest.fixture

--- a/scripts/tests/twister/test_platform.py
+++ b/scripts/tests/twister/test_platform.py
@@ -17,7 +17,7 @@ from pykwalify.errors import SchemaError
 ZEPHYR_BASE = os.getenv("ZEPHYR_BASE")
 sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts/pylib/twister"))
 
-from twisterlib.platform import Platform, Simulator, generate_platforms
+from twisterlib.twister_platform import Platform, Simulator, generate_platforms
 
 
 TESTDATA_1 = [

--- a/scripts/tests/twister/test_testinstance.py
+++ b/scripts/tests/twister/test_testinstance.py
@@ -16,7 +16,7 @@ import mock
 ZEPHYR_BASE = os.getenv("ZEPHYR_BASE")
 sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts/pylib/twister"))
 
-from pylib.twister.twisterlib.platform import Simulator
+from twisterlib.twister_platform import Simulator
 from twisterlib.statuses import TwisterStatus
 from twisterlib.testinstance import TestInstance
 from twisterlib.error import BuildError

--- a/scripts/tests/twister/test_testplan.py
+++ b/scripts/tests/twister/test_testplan.py
@@ -20,7 +20,7 @@ from twisterlib.statuses import TwisterStatus
 from twisterlib.testplan import TestPlan, change_skip_to_error_if_integration
 from twisterlib.testinstance import TestInstance
 from twisterlib.testsuite import TestSuite
-from twisterlib.platform import Platform
+from twisterlib.twister_platform import Platform
 from twisterlib.quarantine import Quarantine
 from twisterlib.error import TwisterRuntimeError
 


### PR DESCRIPTION
Changed platform.py to twister_platform.py.
On some OSes, like Windows, the platform name collides with built-in platform module and causes errors with pickling used in Black Box tests.