### PR TITLE
boards: amd: Add support for AMD Versal NET RPU

### DIFF
--- a/boards/amd/versalnet_rpu/Kconfig.versalnet_rpu
+++ b/boards/amd/versalnet_rpu/Kconfig.versalnet_rpu
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2025 Advanced Micro Devices, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+config BOARD_VERSALNET_RPU
+	select SOC_AMD_VERSALNET_RPU

--- a/boards/amd/versalnet_rpu/board.cmake
+++ b/boards/amd/versalnet_rpu/board.cmake
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2025 Advanced Micro Devices, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+include(${ZEPHYR_BASE}/boards/common/xsdb.board.cmake)

--- a/boards/amd/versalnet_rpu/board.yml
+++ b/boards/amd/versalnet_rpu/board.yml
@@ -1,0 +1,6 @@
+board:
+  name: versalnet_rpu
+  full_name: Versal NET RPU development board
+  vendor: amd
+  socs:
+  - name: amd_versalnet_rpu

--- a/boards/amd/versalnet_rpu/doc/index.rst
+++ b/boards/amd/versalnet_rpu/doc/index.rst
@@ -1,0 +1,73 @@
+.. zephyr:board:: versalnet_rpu
+
+Overview
+********
+This configuration provides support for the RPU(R52), real-time processing unit on Xilinx
+Versal Net SOC, it can operate as following:
+
+* Two independent R52 cores with their own TCMs (tightly coupled memories)
+* Or as a single dual lock step unit with the TCM.
+
+This processing unit is based on an ARM Cortex-R52 CPU, it also enables the following devices:
+
+* ARM GIC v3 Interrupt Controller
+* Global Timer Counter
+* SBSA UART
+
+Hardware
+********
+Supported Features
+==================
+
+.. zephyr:board-supported-hw::
+
+Devices
+========
+System Timer
+------------
+
+This board configuration uses a system timer tick frequency of 100 MHz.
+
+Serial Port
+-----------
+
+This board configuration uses a single serial communication channel with the
+on-chip UART0.
+
+Memories
+--------
+
+Although Flash, DDR and OCM memory regions are defined in the DTS file,
+all the code plus data of the application will be loaded in the sram0 region,
+which points to the DDR memory. The ocm0 memory area is currently available
+for usage, although nothing is placed there by default.
+
+Known Problems or Limitations
+==============================
+
+The following platform features are unsupported:
+
+* Only the first core of the R52 subsystem is supported.
+
+Programming and Debugging
+*************************
+
+Build and flash in the usual way. Here is an example for the :zephyr:code-sample:`hello_world` application.
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :board: versalnet_rpu
+   :goals: build flash
+
+You should see the following message on the console:
+
+.. code-block:: console
+
+   Hello World!
+
+
+References
+**********
+
+1. ARMv8-R Architecture Reference Manual (ARM DDI 0568A.c ID110520)
+2. Cortex-R52 and Cortex-R52F Technical Reference Manual (ARM DDI r1p4 100026_0104_01_en)

--- a/boards/amd/versalnet_rpu/support/xsdb.cfg
+++ b/boards/amd/versalnet_rpu/support/xsdb.cfg
@@ -1,0 +1,44 @@
+# Copyright (c) 2025 Advanced Micro Devices, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+proc load_image args  {
+	set elf_file [lindex $args 0]
+
+	if { [info exists ::env(HW_SERVER_URL)] } {
+		connect -url $::env(HW_SERVER_URL)
+	} else {
+		connect
+	}
+
+	after 100
+	targets -set -nocase -filter {name =~ "Versal*"}
+	after 100
+	rst -system
+	after 100
+
+	if { [info exists ::env(PDI_FILE_PATH)] } {
+		device program $::env(PDI_FILE_PATH)
+	} else {
+		puts "Error: env variable PDI_FILE_PATH is not set"
+		exit
+	}
+
+	after 100
+	targets -set -nocase -filter {name =~ "DPC"}
+	after 100
+	# Configure timestamp generator to run global timer gracefully
+	# Ideally these registers should be set from bootloader (cdo)
+	mwr -force 0xeb5b0000 0x1
+	mwr -force 0xeb5b0020 100000000
+	after 100
+
+	targets -set -nocase -filter {name =~ "*Cortex-R52 #0.0"}
+	rst -proc
+	after 100
+	dow -force $elf_file
+	con
+	exit
+}
+
+load_image {*}$argv

--- a/boards/amd/versalnet_rpu/versalnet_rpu.dts
+++ b/boards/amd/versalnet_rpu/versalnet_rpu.dts
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2025, Advanced Micro Devices, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/dts-v1/;
+#include <arm/xilinx/versalnet_r52.dtsi>
+
+/ {
+	chosen {
+		zephyr,sram = &sram0;
+		zephyr,console = &uart0;
+		zephyr,shell-uart = &uart0;
+		zephyr,ocm = &ocm;
+	};
+};
+
+&cpu0 {
+	 clock-frequency = <100000000>;
+};
+
+&soc {
+	sram0: memory@0 {
+		compatible = "mmio-sram";
+		reg = <0x00000 DT_SIZE_M(2048)>;
+	};
+};
+
+&ocm {
+	status = "okay";
+};
+
+&uart1 {
+	status = "okay";
+	current-speed = <115200>;
+	clock-frequency = <100000000>;
+};
+
+&uart0 {
+	status = "okay";
+	current-speed = <115200>;
+	clock-frequency = <100000000>;
+};

--- a/boards/amd/versalnet_rpu/versalnet_rpu.yaml
+++ b/boards/amd/versalnet_rpu/versalnet_rpu.yaml
@@ -1,0 +1,10 @@
+identifier: versalnet_rpu
+name: AMD Development board for Versal NET RPU
+arch: arm
+toolchain:
+  - zephyr
+testing:
+  ignore_tags:
+    - net
+    - bluetooth
+vendor: amd

--- a/boards/amd/versalnet_rpu/versalnet_rpu_defconfig
+++ b/boards/amd/versalnet_rpu/versalnet_rpu_defconfig
@@ -1,0 +1,9 @@
+# Enable UART driver
+CONFIG_SERIAL=y
+
+# Enable console
+CONFIG_CONSOLE=y
+CONFIG_UART_CONSOLE=y
+
+# Enable serial port
+CONFIG_UART_PL011=y

--- a/dts/arm/xilinx/versalnet_r52.dtsi
+++ b/dts/arm/xilinx/versalnet_r52.dtsi
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2025, Advanced Micro Devices, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/dts-v1/;
+
+#include <mem.h>
+#include <arm/armv8-r.dtsi>
+#include <zephyr/dt-bindings/interrupt-controller/arm-gic.h>
+#include <amd/versalnet.dtsi>
+
+/ {
+	model = "Versal NET RPU";
+	cpus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		cpu0: cpu@0 {
+			device_type = "cpu";
+			compatible = "arm,cortex-r52";
+			reg = <0>;
+		};
+	};
+
+	arch_timer: timer {
+		compatible = "arm,armv8-timer";
+		interrupts = <GIC_PPI 13 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+			     <GIC_PPI 14 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+			     <GIC_PPI 11 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+			     <GIC_PPI 10 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+		interrupt-parent = <&gic>;
+		status = "okay";
+	};
+};
+
+&soc {
+	interrupt-parent = <&gic>;
+
+	gic: interrupt-controller@e2000000 {
+		compatible = "arm,gic-v3", "arm,gic";
+		reg = <0xe2000000 0x10000>,
+					<0xe2100000 0x80000>;
+		interrupt-controller;
+		#interrupt-cells = <4>;
+		status = "okay";
+	};
+};

--- a/dts/common/amd/versalnet.dtsi
+++ b/dts/common/amd/versalnet.dtsi
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2025, Advanced Micro Devices, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	soc: soc {
+		ocm: memory@bbf00000 {
+			compatible = "zephyr,memory-region";
+			reg = <0xbbf00000 DT_SIZE_M(1)>;
+			status = "disabled";
+			zephyr,memory-region = "OCM";
+		};
+
+		uart0: uart@f1920000 {
+			compatible = "arm,sbsa-uart";
+			reg = <0xf1920000 0x4c>;
+			status = "disabled";
+			interrupt-names = "irq_0";
+			interrupts = <GIC_SPI 25 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+		};
+
+		uart1: uart@f1930000 {
+			compatible = "arm,sbsa-uart";
+			reg = <0xf1930000 0x1000>;
+			status = "disabled";
+			interrupt-names = "irq_1";
+			interrupts = <GIC_SPI 26 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+		};
+	};
+};

--- a/soc/xlnx/versalnet/CMakeLists.txt
+++ b/soc/xlnx/versalnet/CMakeLists.txt
@@ -1,0 +1,19 @@
+#
+# Copyright (c) 2025 Advanced Micro Devices, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+zephyr_sources(
+  soc.c
+)
+zephyr_sources_ifdef(
+  CONFIG_ARM_MPU
+  arm_mpu_regions.c
+)
+
+zephyr_include_directories(.)
+
+if(CONFIG_SOC_AMD_VERSALNET_RPU)
+  set(SOC_LINKER_SCRIPT ${ZEPHYR_BASE}/include/zephyr/arch/arm/cortex_a_r/scripts/linker.ld CACHE INTERNAL "")
+endif()

--- a/soc/xlnx/versalnet/Kconfig
+++ b/soc/xlnx/versalnet/Kconfig
@@ -1,0 +1,15 @@
+#
+# Copyright (c) 2025 Advanced Micro Devices, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+config SOC_AMD_VERSALNET_RPU
+	select ARM
+	select ARM_ARCH_TIMER
+	select CPU_CORTEX_R52
+	select SOC_EARLY_INIT_HOOK
+	select CPU_HAS_DCLS
+	select GIC_SINGLE_SECURITY_STATE
+	select CPU_HAS_ARM_MPU
+	select ARM_MPU

--- a/soc/xlnx/versalnet/Kconfig.defconfig
+++ b/soc/xlnx/versalnet/Kconfig.defconfig
@@ -1,0 +1,25 @@
+#
+# Copyright (c) 2025 Advanced Micro Devices, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+if SOC_AMD_VERSALNET
+
+if SOC_AMD_VERSALNET_RPU
+
+CONFIG_CACHE_MANAGEMENT=y
+CONFIG_ARM_ARCH_TIMER=y
+CONFIG_CACHE_MANAGEMENT=y
+
+config NUM_IRQS
+	# must be >= the highest interrupt number used
+	# - include the UART interrupts
+	default 256
+
+config SYS_CLOCK_HW_CYCLES_PER_SEC
+	default $(dt_node_int_prop_int,/cpus/cpu@0,clock-frequency)
+
+endif # SOC_AMD_VERSALNET_RPU
+
+endif # SOC_AMD_VERSALNET

--- a/soc/xlnx/versalnet/Kconfig.soc
+++ b/soc/xlnx/versalnet/Kconfig.soc
@@ -1,0 +1,20 @@
+#
+# Copyright (c) 2025 Advanced Micro Devices, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+config SOC_AMD_VERSALNET
+	bool
+
+config SOC_AMD_VERSALNET_RPU
+	bool
+	select SOC_AMD_VERSALNET
+	help
+	  AMD Versal NET SoC
+
+config SOC_FAMILY
+	default "amd_versalnet" if SOC_AMD_VERSALNET
+
+config SOC
+	default "amd_versalnet_rpu" if SOC_AMD_VERSALNET_RPU

--- a/soc/xlnx/versalnet/arm_mpu_regions.c
+++ b/soc/xlnx/versalnet/arm_mpu_regions.c
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2025 Advanced Micro Devices, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/linker/linker-defs.h>
+#include <zephyr/arch/arm/mpu/arm_mpu.h>
+
+#define DEVICE_REGION_START	0xE2000000U
+#define DEVICE_REGION_END	0xF8000000U
+
+static const struct arm_mpu_region mpu_regions[] = {
+	MPU_REGION_ENTRY("vector",
+			 (uintptr_t)_vector_start,
+			 REGION_RAM_TEXT_ATTR((uintptr_t)_vector_end)),
+
+	MPU_REGION_ENTRY("SRAM_TEXT",
+			 (uintptr_t)__text_region_start,
+			 REGION_RAM_TEXT_ATTR((uintptr_t)__rodata_region_start)),
+
+	MPU_REGION_ENTRY("SRAM_RODATA",
+			 (uintptr_t)__rodata_region_start,
+			 REGION_RAM_RO_ATTR((uintptr_t)__rodata_region_end)),
+
+	MPU_REGION_ENTRY("SRAM_DATA",
+			 (uintptr_t)__rom_region_end,
+			 REGION_RAM_ATTR((uintptr_t)__kernel_ram_end)),
+
+	MPU_REGION_ENTRY("DEVICE",
+			 DEVICE_REGION_START,
+			 REGION_DEVICE_ATTR(DEVICE_REGION_END)),
+};
+
+const struct arm_mpu_config mpu_config = {
+	.num_regions = ARRAY_SIZE(mpu_regions),
+	.mpu_regions = mpu_regions,
+};

--- a/soc/xlnx/versalnet/soc.c
+++ b/soc/xlnx/versalnet/soc.c
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2025 Advanced Micro Devices, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/cache.h>
+#include <zephyr/device.h>
+#include <zephyr/kernel.h>
+
+void soc_early_init_hook(void)
+{
+	if (IS_ENABLED(CONFIG_ICACHE)) {
+		if (!(__get_SCTLR() & SCTLR_I_Msk)) {
+			L1C_InvalidateICacheAll();
+			__set_SCTLR(__get_SCTLR() | SCTLR_I_Msk);
+			barrier_isync_fence_full();
+		}
+	}
+
+	if (IS_ENABLED(CONFIG_DCACHE)) {
+		if (!(__get_SCTLR() & SCTLR_C_Msk)) {
+			L1C_InvalidateDCacheAll();
+			__set_SCTLR(__get_SCTLR() | SCTLR_C_Msk);
+			barrier_dsync_fence_full();
+		}
+	}
+}

--- a/soc/xlnx/versalnet/soc.h
+++ b/soc/xlnx/versalnet/soc.h
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2025 Advanced Micro Devices, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef _SOC_XLNX_VERSALNET_SOC_H_
+#define _SOC_XLNX_VERSALNET_SOC_H_
+
+/* Define CMSIS configurations */
+#define __GIC_PRESENT 0
+#define __TIM_PRESENT 0
+
+#endif /* _SOC_XLNX_VERSALNET_SOC_H_ */

--- a/soc/xlnx/versalnet/soc.yml
+++ b/soc/xlnx/versalnet/soc.yml
@@ -1,0 +1,4 @@
+family:
+- name: amd_versalnet
+  socs:
+  - name: amd_versalnet_rpu


### PR DESCRIPTION
Add support for the RPU, real-time processing unit on Versal NET SoC. It is based on Cortext-R52 processor.

The patch contains initial wiring and configuration for generic board with OCM(1MB) and DDR(2G) memories, cpu, interrupt controller, global timer and UART.

versalnet.dtsi contains common peripherals integrated into Versal NET SoC, and versalnet_r52.dtsi has peripherals which are private to Cortex-R52 processor.

CC: @mubinsyed 