### PR TITLE
cmake: toolchain: Removed config FP16 from IAR kconfig.default

### DIFF
--- a/cmake/toolchain/iar/Kconfig.defconfig
+++ b/cmake/toolchain/iar/Kconfig.defconfig
@@ -9,9 +9,6 @@ config PICOLIBC_SUPPORTED
 config TOOLCHAIN_HAS_BUILTIN_FFS
 	default n
 
-config FP16
-	default y
-
 config IAR_LIBC_SUPPORTED
 	default y
 


### PR DESCRIPTION
Removed config FP16 from kconfig.default as it is set by the arch/cpu.