### PR TITLE
net: http_client: Fix handling of poll error revents

### DIFF
--- a/subsys/net/lib/http/http_client.c
+++ b/subsys/net/lib/http/http_client.c
@@ -502,8 +502,16 @@ static int http_wait_data(int sock, struct http_request *req, const k_timepoint_
 			ret = -errno;
 			goto error;
 		}
-		if (fds[0].revents & (ZSOCK_POLLERR | ZSOCK_POLLNVAL)) {
-			ret = -errno;
+
+		if (fds[0].revents & ZSOCK_POLLERR) {
+			int sock_err;
+			socklen_t optlen = sizeof(sock_err);
+
+			(void)zsock_getsockopt(sock, SOL_SOCKET, SO_ERROR, &sock_err, &optlen);
+			ret = -sock_err;
+			goto error;
+		} else if (fds[0].revents & ZSOCK_POLLNVAL) {
+			ret = -EBADF;
 			goto error;
 		} else if (fds[0].revents & ZSOCK_POLLHUP) {
 			/* Connection closed */


### PR DESCRIPTION
Fix handling of poll setting socket error flag.
In this case errno is no set, so should not be the return value either. Instead retrieve the socket error for SOCKERR and return EBADF for SOCKNVAL.