### PR TITLE
board: due: change pinctrl header to match soc

### DIFF
--- a/boards/arduino/due/arduino_due-pinctrl.dtsi
+++ b/boards/arduino/due/arduino_due-pinctrl.dtsi
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/pinctrl/sam3XXh-pinctrl.h>
+#include <dt-bindings/pinctrl/sam3XXe-pinctrl.h>
 
 &pinctrl {
 	twi0_default: twi0_default {


### PR DESCRIPTION
Arduino Due uses Atmel SAM3X8E, not SAM3X8H, so pinctrl should call the appropriate header.
