### PR TITLE
soc: nordic: nrf54h: Add option to use NFCT pins as GPIOs

### DIFF
--- a/dts/arm/nordic/nrf54h20_cpuapp.dtsi
+++ b/dts/arm/nordic/nrf54h20_cpuapp.dtsi
@@ -59,3 +59,7 @@ wdt011: &cpuapp_wdt011 {};
 &grtc {
 	interrupts = <109 NRF_DEFAULT_IRQ_PRIORITY>;
 };
+
+&nfct {
+	compatible = "nordic,nrf-nfct-v2";
+};

--- a/dts/bindings/net/wireless/nordic,nrf-nfct-v2.yaml
+++ b/dts/bindings/net/wireless/nordic,nrf-nfct-v2.yaml
@@ -1,0 +1,18 @@
+# Copyright (c) 2025 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+description: Nordic nRF family NFCT (Near Field Communication Tag)
+
+compatible: "nordic,nrf-nfct-v2"
+
+include: nordic,nrf-nfct.yaml
+
+properties:
+  nfct-pins-as-gpios:
+    type: boolean
+    description: |
+      When enabled this property will configure pins dedicated to NFCT
+      peripheral as regular GPIOs. This property must be applied in cpuapp
+      if NFCT pins are intended to be used as regular GPIOs by any core.
+
+      NFC pins in nRF54H series: P2.10 and P2.11

--- a/soc/nordic/nrf54h/soc.c
+++ b/soc/nordic/nrf54h/soc.c
@@ -18,6 +18,7 @@
 #include <hal/nrf_lrcconf.h>
 #include <hal/nrf_spu.h>
 #include <hal/nrf_memconf.h>
+#include <hal/nrf_nfct.h>
 #include <soc/nrfx_coredep.h>
 #include <soc_lrcconf.h>
 #include <dmm.h>
@@ -150,6 +151,11 @@ static int nordicsemi_nrf54h_init(void)
 
 	nrf_spu_periph_perm_dmasec_set(spu, nrf_address_slave_get(ccm030_addr), true);
 #endif
+
+	if (DT_NODE_HAS_STATUS(DT_NODELABEL(nfct), disabled) &&
+	    DT_PROP_OR(DT_NODELABEL(nfct), nfct_pins_as_gpios, 0)) {
+		nrf_nfct_pad_config_enable_set(NRF_NFCT, false);
+	}
 
 	return 0;
 }


### PR DESCRIPTION
Protection circuit must be disabled to use NFCT antenna pins as GPIOs. It can be done by adding nfct-pins-as-gpios to nfct node in the devicetree in cpuapp. Node must be disabled as NFCT is not used. In legacy platforms same property was added to uicr node because that information was stored in UICR. In nrf54h20 it is not part of UICR so property is part of nfct node.