### PR TITLE
dts: arm: atmel: sam3x: add gpio header

### DIFF
--- a/dts/arm/atmel/sam3x.dtsi
+++ b/dts/arm/atmel/sam3x.dtsi
@@ -6,6 +6,7 @@
 
 #include <arm/armv7-m.dtsi>
 #include <zephyr/dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/clock/atmel_sam_pmc.h>
 
 / {


### PR DESCRIPTION
The gpio header is missing, which will lead to failures when declaring GPIO down the line in board overlays.