### PR TITLE
tests/samples: Use native_sim instead of native_posix (part N)

### DIFF
--- a/samples/subsys/debug/fuzz/sample.yaml
+++ b/samples/subsys/debug/fuzz/sample.yaml
@@ -1,10 +1,10 @@
 sample:
-  description: native_posix-based libfuzzer example
+  description: native_sim-based libfuzzer example
   name: fuzz
 tests:
   sample.debug.fuzz:
     toolchain_allow: llvm
-    platform_allow: native_posix/native/64
+    platform_allow: native_sim/native/64
     harness: console
     harness_config:
       type: one_line

--- a/samples/subsys/fs/zms/sample.yaml
+++ b/samples/subsys/fs/zms/sample.yaml
@@ -4,7 +4,11 @@ sample:
 tests:
   sample.zms.basic:
     tags: zms
-    depends_on: zms
     platform_allow:
       - qemu_x86
       - native_sim
+    harness: console
+    harness_config:
+      type: one_line
+      regex:
+        - "Sample code finished Successfully"

--- a/samples/subsys/fs/zms/sample.yaml
+++ b/samples/subsys/fs/zms/sample.yaml
@@ -7,4 +7,4 @@ tests:
     depends_on: zms
     platform_allow:
       - qemu_x86
-      - native_posix
+      - native_sim


### PR DESCRIPTION
Remove the last 2 straggler tests which still set native_posix as their test platform instead of native_sim.
This is a continuation to https://github.com/zephyrproject-rtos/zephyr/issues/65059

While at it fix the filter for samples/subsys/fs/zms and add a runtime check.

Note that in 4.2 we are removing native_posix all together (https://github.com/zephyrproject-rtos/zephyr/issues/76895)