### PR TITLE
scripts: Restructure imports

### DIFF
--- a/scripts/pylib/twister/twisterlib/config_parser.py
+++ b/scripts/pylib/twister/twisterlib/config_parser.py
@@ -7,8 +7,8 @@ import copy
 import warnings
 from typing import Any
 
-import scl
-from twisterlib.error import ConfigurationError
+import pylib.twister.scl as scl
+from pylib.twister.twisterlib.error import ConfigurationError
 
 
 def extract_fields_from_arg_list(

--- a/scripts/pylib/twister/twisterlib/environment.py
+++ b/scripts/pylib/twister/twisterlib/environment.py
@@ -21,10 +21,10 @@ from importlib import metadata
 from pathlib import Path
 
 import zephyr_module
-from twisterlib.constants import SUPPORTED_SIMS
-from twisterlib.coverage import supported_coverage_formats
-from twisterlib.error import TwisterRuntimeError
-from twisterlib.log_helper import log_command
+from pylib.twister.twisterlib.constants import SUPPORTED_SIMS
+from pylib.twister.twisterlib.coverage import supported_coverage_formats
+from pylib.twister.twisterlib.error import TwisterRuntimeError
+from pylib.twister.twisterlib.log_helper import log_command
 
 logger = logging.getLogger('twister')
 logger.setLevel(logging.DEBUG)

--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -25,13 +25,11 @@ from pathlib import Path
 from queue import Empty, Queue
 
 import psutil
-from twisterlib.environment import ZEPHYR_BASE, strip_ansi_sequences
-from twisterlib.error import TwisterException
-from twisterlib.platform import Platform
-from twisterlib.statuses import TwisterStatus
-
-sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts/pylib/build_helpers"))
-from domains import Domains
+from pylib.build_helpers.domains import Domains
+from pylib.twister.twisterlib.environment import ZEPHYR_BASE, strip_ansi_sequences
+from pylib.twister.twisterlib.error import TwisterException
+from pylib.twister.twisterlib.platform import Platform
+from pylib.twister.twisterlib.statuses import TwisterStatus
 
 try:
     import serial

--- a/scripts/pylib/twister/twisterlib/hardwaremap.py
+++ b/scripts/pylib/twister/twisterlib/hardwaremap.py
@@ -11,10 +11,10 @@ import re
 from multiprocessing import Lock, Value
 from pathlib import Path
 
-import scl
+import pylib.twister.scl as scl
 import yaml
 from natsort import natsorted
-from twisterlib.environment import ZEPHYR_BASE
+from pylib.twister.twisterlib.environment import ZEPHYR_BASE
 
 try:
     # Use the C LibYAML parser if available, rather than the Python parser.

--- a/scripts/pylib/twister/twisterlib/harness.py
+++ b/scripts/pylib/twister/twisterlib/harness.py
@@ -18,14 +18,14 @@ from enum import Enum
 
 import junitparser.junitparser as junit
 import yaml
+from pylib.twister.twisterlib.constants import SUPPORTED_SIMS_IN_PYTEST
+from pylib.twister.twisterlib.environment import PYTEST_PLUGIN_INSTALLED, ZEPHYR_BASE
+from pylib.twister.twisterlib.error import ConfigurationError, StatusAttributeError
+from pylib.twister.twisterlib.handlers import Handler, terminate_process
+from pylib.twister.twisterlib.reports import ReportStatus
+from pylib.twister.twisterlib.statuses import TwisterStatus
+from pylib.twister.twisterlib.testinstance import TestInstance
 from pytest import ExitCode
-from twisterlib.constants import SUPPORTED_SIMS_IN_PYTEST
-from twisterlib.environment import PYTEST_PLUGIN_INSTALLED, ZEPHYR_BASE
-from twisterlib.error import ConfigurationError, StatusAttributeError
-from twisterlib.handlers import Handler, terminate_process
-from twisterlib.reports import ReportStatus
-from twisterlib.statuses import TwisterStatus
-from twisterlib.testinstance import TestInstance
 
 logger = logging.getLogger('twister')
 logger.setLevel(logging.DEBUG)

--- a/scripts/pylib/twister/twisterlib/package.py
+++ b/scripts/pylib/twister/twisterlib/package.py
@@ -7,7 +7,7 @@ import json
 import os
 import tarfile
 
-from twisterlib.statuses import TwisterStatus
+from pylib.twister.twisterlib.statuses import TwisterStatus
 
 
 class Artifacts:

--- a/scripts/pylib/twister/twisterlib/platform.py
+++ b/scripts/pylib/twister/twisterlib/platform.py
@@ -13,9 +13,9 @@ from argparse import Namespace
 from itertools import groupby
 
 import list_boards
-import scl
-from twisterlib.constants import SUPPORTED_SIMS
-from twisterlib.environment import ZEPHYR_BASE
+import pylib.twister.scl as scl
+from pylib.twister.twisterlib.constants import SUPPORTED_SIMS
+from pylib.twister.twisterlib.environment import ZEPHYR_BASE
 
 logger = logging.getLogger('twister')
 logger.setLevel(logging.DEBUG)

--- a/scripts/pylib/twister/twisterlib/reports.py
+++ b/scripts/pylib/twister/twisterlib/reports.py
@@ -14,7 +14,7 @@ from enum import Enum
 from pathlib import Path
 
 from colorama import Fore
-from twisterlib.statuses import TwisterStatus
+from pylib.twister.twisterlib.statuses import TwisterStatus
 
 logger = logging.getLogger('twister')
 logger.setLevel(logging.DEBUG)

--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -26,38 +26,35 @@ from colorama import Fore
 from elftools.elf.elffile import ELFFile
 from elftools.elf.sections import SymbolTableSection
 from packaging import version
-from twisterlib.cmakecache import CMakeCache
-from twisterlib.environment import canonical_zephyr_base
-from twisterlib.error import BuildError, ConfigurationError, StatusAttributeError
-from twisterlib.log_helper import setup_logging
-from twisterlib.statuses import TwisterStatus
+from pylib.twister.twisterlib.cmakecache import CMakeCache
+from pylib.twister.twisterlib.environment import canonical_zephyr_base
+from pylib.twister.twisterlib.error import BuildError, ConfigurationError, StatusAttributeError
+from pylib.twister.twisterlib.log_helper import setup_logging
+from pylib.twister.twisterlib.statuses import TwisterStatus
 
 if version.parse(elftools.__version__) < version.parse('0.24'):
     sys.exit("pyelftools is out of date, need version 0.24 or later")
 
 # Job server only works on Linux for now.
 if sys.platform == 'linux':
-    from twisterlib.jobserver import GNUMakeJobClient, GNUMakeJobServer, JobClient
+    from pylib.twister.twisterlib.jobserver import GNUMakeJobClient, GNUMakeJobServer, JobClient
 
-from twisterlib.environment import ZEPHYR_BASE
-
-sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts/pylib/build_helpers"))
-from domains import Domains
-from twisterlib.coverage import run_coverage_instance
-from twisterlib.environment import TwisterEnv
-from twisterlib.harness import Ctest, HarnessImporter, Pytest
-from twisterlib.log_helper import log_command
-from twisterlib.platform import Platform
-from twisterlib.testinstance import TestInstance
-from twisterlib.testplan import change_skip_to_error_if_integration
-from twisterlib.testsuite import TestSuite
+from pylib.build_helpers.domains import Domains
+from pylib.twister.twisterlib.coverage import run_coverage_instance
+from pylib.twister.twisterlib.environment import TwisterEnv
+from pylib.twister.twisterlib.harness import Ctest, HarnessImporter, Pytest
+from pylib.twister.twisterlib.log_helper import log_command
+from pylib.twister.twisterlib.platform import Platform
+from pylib.twister.twisterlib.testinstance import TestInstance
+from pylib.twister.twisterlib.testplan import change_skip_to_error_if_integration
+from pylib.twister.twisterlib.testsuite import TestSuite
 
 try:
     from yaml import CSafeLoader as SafeLoader
 except ImportError:
     from yaml import SafeLoader
 
-import expr_parser
+import pylib.twister.expr_parser
 from anytree import Node, RenderTree
 
 logger = logging.getLogger('twister')
@@ -853,7 +850,7 @@ class FilterBuilder(CMake):
                         edt = pickle.load(f)
                 else:
                     edt = None
-                ret = expr_parser.parse(self.testsuite.filter, filter_data, edt)
+                ret = pylib.twister.expr_parser.parse(self.testsuite.filter, filter_data, edt)
 
             except (ValueError, SyntaxError) as se:
                 sys.stderr.write(f"Failed processing {self.testsuite.yamlfile}\n")
@@ -1968,7 +1965,7 @@ class TwisterRunner:
                 if instance.testsuite.filter:
                     instance.filter_stages = self.get_cmake_filter_stages(
                         instance.testsuite.filter,
-                        expr_parser.reserved.keys()
+                        pylib.twister.expr_parser.reserved.keys()
                     )
 
                 if test_only and instance.run:

--- a/scripts/pylib/twister/twisterlib/size_calc.py
+++ b/scripts/pylib/twister/twisterlib/size_calc.py
@@ -10,7 +10,7 @@ import re
 import subprocess
 import sys
 
-from twisterlib.error import TwisterRuntimeError
+from pylib.twister.twisterlib.error import TwisterRuntimeError
 
 logger = logging.getLogger('twister')
 logger.setLevel(logging.DEBUG)

--- a/scripts/pylib/twister/twisterlib/testinstance.py
+++ b/scripts/pylib/twister/twisterlib/testinstance.py
@@ -15,14 +15,14 @@ import os
 import random
 from enum import Enum
 
-from twisterlib.constants import (
+from pylib.twister.twisterlib.constants import (
     SUPPORTED_SIMS,
     SUPPORTED_SIMS_IN_PYTEST,
     SUPPORTED_SIMS_WITH_EXEC,
 )
-from twisterlib.environment import TwisterEnv
-from twisterlib.error import BuildError, StatusAttributeError
-from twisterlib.handlers import (
+from pylib.twister.twisterlib.environment import TwisterEnv
+from pylib.twister.twisterlib.error import BuildError, StatusAttributeError
+from pylib.twister.twisterlib.handlers import (
     BinaryHandler,
     DeviceHandler,
     Handler,
@@ -30,10 +30,10 @@ from twisterlib.handlers import (
     QEMUWinHandler,
     SimulationHandler,
 )
-from twisterlib.platform import Platform
-from twisterlib.size_calc import SizeCalculator
-from twisterlib.statuses import TwisterStatus
-from twisterlib.testsuite import TestCase, TestSuite
+from pylib.twister.twisterlib.platform import Platform
+from pylib.twister.twisterlib.size_calc import SizeCalculator
+from pylib.twister.twisterlib.statuses import TwisterStatus
+from pylib.twister.twisterlib.testsuite import TestCase, TestSuite
 
 logger = logging.getLogger('twister')
 logger.setLevel(logging.DEBUG)

--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -27,14 +27,14 @@ try:
 except ImportError:
     print("Install the anytree module to use the --test-tree option")
 
-import scl
-from twisterlib.config_parser import TwisterConfigParser
-from twisterlib.error import TwisterRuntimeError
-from twisterlib.platform import Platform, generate_platforms
-from twisterlib.quarantine import Quarantine
-from twisterlib.statuses import TwisterStatus
-from twisterlib.testinstance import TestInstance
-from twisterlib.testsuite import TestSuite, scan_testsuite_path
+import pylib.twister.scl as scl
+from pylib.twister.twisterlib.config_parser import TwisterConfigParser
+from pylib.twister.twisterlib.error import TwisterRuntimeError
+from pylib.twister.twisterlib.platform import Platform, generate_platforms
+from pylib.twister.twisterlib.quarantine import Quarantine
+from pylib.twister.twisterlib.statuses import TwisterStatus
+from pylib.twister.twisterlib.testinstance import TestInstance
+from pylib.twister.twisterlib.testsuite import TestSuite, scan_testsuite_path
 from zephyr_module import parse_modules
 
 logger = logging.getLogger('twister')

--- a/scripts/pylib/twister/twisterlib/testsuite.py
+++ b/scripts/pylib/twister/twisterlib/testsuite.py
@@ -12,10 +12,14 @@ import re
 from enum import Enum
 from pathlib import Path
 
-from twisterlib.environment import canonical_zephyr_base
-from twisterlib.error import StatusAttributeError, TwisterException, TwisterRuntimeError
-from twisterlib.mixins import DisablePyTestCollectionMixin
-from twisterlib.statuses import TwisterStatus
+from pylib.twister.twisterlib.environment import canonical_zephyr_base
+from pylib.twister.twisterlib.error import (
+    StatusAttributeError,
+    TwisterException,
+    TwisterRuntimeError,
+)
+from pylib.twister.twisterlib.mixins import DisablePyTestCollectionMixin
+from pylib.twister.twisterlib.statuses import TwisterStatus
 
 logger = logging.getLogger('twister')
 logger.setLevel(logging.DEBUG)

--- a/scripts/pylib/twister/twisterlib/twister_main.py
+++ b/scripts/pylib/twister/twisterlib/twister_main.py
@@ -12,15 +12,15 @@ import time
 
 import colorama
 from colorama import Fore
-from twisterlib.coverage import run_coverage
-from twisterlib.environment import TwisterEnv
-from twisterlib.hardwaremap import HardwareMap
-from twisterlib.log_helper import setup_logging
-from twisterlib.package import Artifacts
-from twisterlib.reports import Reporting
-from twisterlib.runner import TwisterRunner
-from twisterlib.statuses import TwisterStatus
-from twisterlib.testplan import TestPlan
+from pylib.twister.twisterlib.coverage import run_coverage
+from pylib.twister.twisterlib.environment import TwisterEnv
+from pylib.twister.twisterlib.hardwaremap import HardwareMap
+from pylib.twister.twisterlib.log_helper import setup_logging
+from pylib.twister.twisterlib.package import Artifacts
+from pylib.twister.twisterlib.reports import Reporting
+from pylib.twister.twisterlib.runner import TwisterRunner
+from pylib.twister.twisterlib.statuses import TwisterStatus
+from pylib.twister.twisterlib.testplan import TestPlan
 
 logger = logging.getLogger("twister")
 logger.setLevel(logging.DEBUG)

--- a/scripts/tests/build_helpers/test_domains.py
+++ b/scripts/tests/build_helpers/test_domains.py
@@ -6,48 +6,45 @@
 Tests for domains.py classes
 """
 
-import mock
 import os
-import pytest
-import sys
-
-ZEPHYR_BASE = os.getenv("ZEPHYR_BASE")
-sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts/pylib/build_helpers"))
-
-import domains
-
 from contextlib import nullcontext
+from unittest import mock
 
+import pylib.build_helpers.domains
+import pytest
 
 TESTDATA_1 = [
     ('', False, 1, ['domains.yaml file not found: domains.yaml']),
     (
-"""
+        """
 default: None
 build_dir: some/dir
 domains: []
 """,
-        True, None, []
+        True,
+        None,
+        [],
     ),
 ]
 
+
 @pytest.mark.parametrize(
-    'f_contents, f_exists, exit_code, expected_logs',
-    TESTDATA_1,
-    ids=['no file', 'valid']
+    'f_contents, f_exists, exit_code, expected_logs', TESTDATA_1, ids=['no file', 'valid']
 )
 def test_from_file(caplog, f_contents, f_exists, exit_code, expected_logs):
     def mock_open(*args, **kwargs):
         if f_exists:
             return mock.mock_open(read_data=f_contents)(args, kwargs)
-        raise FileNotFoundError(f'domains.yaml not found.')
+        raise FileNotFoundError('domains.yaml not found.')
 
     init_mock = mock.Mock(return_value=None)
 
-    with mock.patch('domains.Domains.__init__', init_mock), \
-         mock.patch('builtins.open', mock_open), \
-         pytest.raises(SystemExit) if exit_code else nullcontext() as s_exit:
-        result = domains.Domains.from_file('domains.yaml')
+    with (
+        mock.patch('pylib.build_helpers.domains.Domains.__init__', init_mock),
+        mock.patch('builtins.open', mock_open),
+        pytest.raises(SystemExit) if exit_code else nullcontext() as s_exit,
+    ):
+        result = pylib.build_helpers.domains.Domains.from_file('domains.yaml')
 
     if exit_code:
         assert str(s_exit.value) == str(exit_code)
@@ -60,7 +57,7 @@ def test_from_file(caplog, f_contents, f_exists, exit_code, expected_logs):
 
 TESTDATA_2 = [
     (
-"""
+        """
 default: some default
 build_dir: my/dir
 domains:
@@ -70,10 +67,14 @@ domains:
   build_dir: dir/3
 flash_order: I don\'t think this is correct
 """,
-        1, None, None, None, None
+        1,
+        None,
+        None,
+        None,
+        None,
     ),
     (
-"""
+        """
 build_dir: build/dir
 domains:
 - name: a domain
@@ -89,16 +90,16 @@ flash_order:
         'build/dir',
         [('default_domain', 'dir/2'), ('a domain', 'dir/1')],
         ('default_domain', 'dir/2'),
-        {'a domain': ('a domain', 'dir/1'),
-         'default_domain': ('default_domain', 'dir/2')}
+        {'a domain': ('a domain', 'dir/1'), 'default_domain': ('default_domain', 'dir/2')},
     ),
 ]
 
+
 @pytest.mark.parametrize(
-    'data, exit_code, expected_build_dir, expected_flash_order,' \
+    'data, exit_code, expected_build_dir, expected_flash_order,'
     ' expected_default, expected_domains',
     TESTDATA_2,
-    ids=['invalid', 'valid']
+    ids=['invalid', 'valid'],
 )
 def test_from_yaml(
     caplog,
@@ -107,14 +108,16 @@ def test_from_yaml(
     expected_build_dir,
     expected_flash_order,
     expected_default,
-    expected_domains
+    expected_domains,
 ):
     def mock_domain(name, build_dir, *args, **kwargs):
         return name, build_dir
 
-    with mock.patch('domains.Domain', side_effect=mock_domain), \
-         pytest.raises(SystemExit) if exit_code else nullcontext() as exit_st:
-        doms = domains.Domains.from_yaml(data)
+    with (
+        mock.patch('domains.Domain', side_effect=mock_domain),
+        pytest.raises(SystemExit) if exit_code else nullcontext() as exit_st,
+    ):
+        doms = pylib.build_helpers.domains.Domains.from_yaml(data)
 
     if exit_code:
         assert str(exit_st.value) == str(exit_code)
@@ -130,38 +133,20 @@ def test_from_yaml(
 
 
 TESTDATA_3 = [
-    (
-        None,
-        True,
-        [('some', os.path.join('dir', '2')),
-         ('order', os.path.join('dir', '1'))]
-    ),
-    (
-        None,
-        False,
-        [('order', os.path.join('dir', '1')),
-         ('some', os.path.join('dir', '2'))]
-    ),
-    (
-        ['some'],
-        False,
-        [('some', os.path.join('dir', '2'))]
-    ),
+    (None, True, [('some', os.path.join('dir', '2')), ('order', os.path.join('dir', '1'))]),
+    (None, False, [('order', os.path.join('dir', '1')), ('some', os.path.join('dir', '2'))]),
+    (['some'], False, [('some', os.path.join('dir', '2'))]),
 ]
+
 
 @pytest.mark.parametrize(
     'names, default_flash_order, expected_result',
     TESTDATA_3,
-    ids=['order only', 'no parameters', 'valid']
+    ids=['order only', 'no parameters', 'valid'],
 )
-def test_get_domains(
-    caplog,
-    names,
-    default_flash_order,
-    expected_result
-):
-    doms = domains.Domains(
-"""
+def test_get_domains(caplog, names, default_flash_order, expected_result):
+    doms = pylib.build_helpers.domains.Domains(
+        """
 domains:
 - name: dummy
   build_dir: dummy
@@ -169,13 +154,10 @@ default: dummy
 build_dir: dummy
 """
     )
-    doms._flash_order = [
-        ('some', os.path.join('dir', '2')),
-        ('order', os.path.join('dir', '1'))
-    ]
+    doms._flash_order = [('some', os.path.join('dir', '2')), ('order', os.path.join('dir', '1'))]
     doms._domains = {
         'order': ('order', os.path.join('dir', '1')),
-        'some': ('some', os.path.join('dir', '2'))
+        'some': ('some', os.path.join('dir', '2')),
     }
 
     result = doms.get_domains(names, default_flash_order)
@@ -183,36 +165,18 @@ build_dir: dummy
     assert result == expected_result
 
 
-
 TESTDATA_3 = [
-    (
-        'other',
-        1,
-        ['domain "other" not found, valid domains are: order, some'],
-        None
-    ),
-    (
-        'some',
-        None,
-        [],
-        ('some', os.path.join('dir', '2'))
-    ),
+    ('other', 1, ['domain "other" not found, valid domains are: order, some'], None),
+    ('some', None, [], ('some', os.path.join('dir', '2'))),
 ]
 
+
 @pytest.mark.parametrize(
-    'name, exit_code, expected_logs, expected_result',
-    TESTDATA_3,
-    ids=['domain not found', 'valid']
+    'name, exit_code, expected_logs, expected_result', TESTDATA_3, ids=['domain not found', 'valid']
 )
-def test_get_domain(
-    caplog,
-    name,
-    exit_code,
-    expected_logs,
-    expected_result
-):
-    doms = domains.Domains(
-"""
+def test_get_domain(caplog, name, exit_code, expected_logs, expected_result):
+    doms = pylib.build_helpers.domains.Domains(
+        """
 domains:
 - name: dummy
   build_dir: dummy
@@ -220,13 +184,10 @@ default: dummy
 build_dir: dummy
 """
     )
-    doms._flash_order = [
-        ('some', os.path.join('dir', '2')),
-        ('order', os.path.join('dir', '1'))
-    ]
+    doms._flash_order = [('some', os.path.join('dir', '2')), ('order', os.path.join('dir', '1'))]
     doms._domains = {
         'order': ('order', os.path.join('dir', '1')),
-        'some': ('some', os.path.join('dir', '2'))
+        'some': ('some', os.path.join('dir', '2')),
     }
 
     with pytest.raises(SystemExit) if exit_code else nullcontext() as s_exit:
@@ -244,7 +205,7 @@ def test_domain():
     name = 'Domain Name'
     build_dir = 'build/dir'
 
-    domain = domains.Domain(name, build_dir)
+    domain = pylib.build_helpers.domains.Domain(name, build_dir)
 
     assert domain.name == name
     assert domain.build_dir == build_dir

--- a/scripts/tests/twister/conftest.py
+++ b/scripts/tests/twister/conftest.py
@@ -14,9 +14,9 @@ pytest_plugins = ["pytester"]
 ZEPHYR_BASE = os.getenv("ZEPHYR_BASE")
 sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts/pylib/twister"))
 sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts"))
-from twisterlib.testplan import TestPlan
-from twisterlib.testinstance import TestInstance
-from twisterlib.environment import TwisterEnv, add_parse_arguments, parse_arguments
+from pylib.twister.twisterlib.testplan import TestPlan
+from pylib.twister.twisterlib.testinstance import TestInstance
+from pylib.twister.twisterlib.environment import TwisterEnv, add_parse_arguments, parse_arguments
 
 def new_get_toolchain(*args, **kwargs):
     return 'zephyr'

--- a/scripts/tests/twister/test_cmakecache.py
+++ b/scripts/tests/twister/test_cmakecache.py
@@ -11,7 +11,7 @@ import pytest
 
 from contextlib import nullcontext
 
-from twisterlib.cmakecache import CMakeCacheEntry, CMakeCache
+from pylib.twister.twisterlib.cmakecache import CMakeCacheEntry, CMakeCache
 
 
 TESTDATA_1 = [

--- a/scripts/tests/twister/test_environment.py
+++ b/scripts/tests/twister/test_environment.py
@@ -14,7 +14,7 @@ import shutil
 
 from contextlib import nullcontext
 
-import twisterlib.environment
+import pylib.twister.twisterlib.environment
 
 
 TESTDATA_1 = [
@@ -167,7 +167,7 @@ def test_parse_arguments_errors(
             return f'dummy/path/{name}'
 
     with mock.patch('sys.argv', ['twister'] + args):
-        parser = twisterlib.environment.add_parse_arguments()
+        parser = pylib.twister.twisterlib.environment.add_parse_arguments()
 
     if which_dict:
         which_dict['path'] = {name: shutil.which(name) \
@@ -178,11 +178,11 @@ def test_parse_arguments_errors(
             if os_name is not None else nullcontext(), \
          mock.patch('shutil.which', which_mock) \
             if which_dict else nullcontext(), \
-         mock.patch('twisterlib.environment' \
+         mock.patch('pylib.twister.twisterlib.environment' \
                     '.PYTEST_PLUGIN_INSTALLED', pytest_plugin) \
             if pytest_plugin is not None else nullcontext():
         with pytest.raises(SystemExit) as exit_info:
-            twisterlib.environment.parse_arguments(parser, args)
+            pylib.twister.twisterlib.environment.parse_arguments(parser, args)
 
     assert exit_info.value.code == 1
     assert expected_error in ' '.join(caplog.text.split())
@@ -194,7 +194,7 @@ def test_parse_arguments_errors_size():
     args = ['--size', 'dummy.elf']
 
     with mock.patch('sys.argv', ['twister'] + args):
-        parser = twisterlib.environment.add_parse_arguments()
+        parser = pylib.twister.twisterlib.environment.add_parse_arguments()
 
     mock_calc_parent = mock.Mock()
     mock_calc_parent.child = mock.Mock(return_value=mock.Mock())
@@ -204,7 +204,7 @@ def test_parse_arguments_errors_size():
 
     with mock.patch('twisterlib.size_calc.SizeCalculator', mock_calc):
         with pytest.raises(SystemExit) as exit_info:
-            twisterlib.environment.parse_arguments(parser, args)
+            pylib.twister.twisterlib.environment.parse_arguments(parser, args)
 
     assert exit_info.value.code == 0
 
@@ -216,10 +216,10 @@ def test_parse_arguments_warnings(caplog):
     args = ['--allow-installed-plugin']
 
     with mock.patch('sys.argv', ['twister'] + args):
-        parser = twisterlib.environment.add_parse_arguments()
+        parser = pylib.twister.twisterlib.environment.add_parse_arguments()
 
-    with mock.patch('twisterlib.environment.PYTEST_PLUGIN_INSTALLED', True):
-        twisterlib.environment.parse_arguments(parser, args)
+    with mock.patch('pylib.twister.twisterlib.environment.PYTEST_PLUGIN_INSTALLED', True):
+        pylib.twister.twisterlib.environment.parse_arguments(parser, args)
 
     assert 'You work with installed version of' \
            ' pytest-twister-harness plugin.' in ' '.join(caplog.text.split())
@@ -241,9 +241,9 @@ def test_parse_arguments(zephyr_base, additional_args):
            additional_args + ['--', 'dummy_extra_1', 'dummy_extra_2']
 
     with mock.patch('sys.argv', ['twister'] + args):
-        parser = twisterlib.environment.add_parse_arguments()
+        parser = pylib.twister.twisterlib.environment.add_parse_arguments()
 
-    options = twisterlib.environment.parse_arguments(parser, args)
+    options = pylib.twister.twisterlib.environment.parse_arguments(parser, args)
 
     assert os.path.join(zephyr_base, 'tests') in options.testsuite_root
     assert os.path.join(zephyr_base, 'samples') in options.testsuite_root
@@ -323,7 +323,7 @@ def test_twisterenv_init(options, expected_env):
             return original_abspath(path)
 
     with mock.patch('os.path.abspath', side_effect=mocked_abspath):
-        twister_env = twisterlib.environment.TwisterEnv(options=options)
+        twister_env = pylib.twister.twisterlib.environment.TwisterEnv(options=options)
 
     assert twister_env.generator_cmd == expected_env.generator_cmd
     assert twister_env.generator == expected_env.generator
@@ -350,7 +350,7 @@ def test_twisterenv_discover():
             return original_abspath(path)
 
     with mock.patch('os.path.abspath', side_effect=mocked_abspath):
-        twister_env = twisterlib.environment.TwisterEnv(options=options)
+        twister_env = pylib.twister.twisterlib.environment.TwisterEnv(options=options)
 
     mock_datetime = mock.Mock(
         now=mock.Mock(
@@ -361,14 +361,14 @@ def test_twisterenv_discover():
     )
 
     with mock.patch.object(
-            twisterlib.environment.TwisterEnv,
+            pylib.twister.twisterlib.environment.TwisterEnv,
             'check_zephyr_version',
             mock.Mock()) as mock_czv, \
          mock.patch.object(
-            twisterlib.environment.TwisterEnv,
+            pylib.twister.twisterlib.environment.TwisterEnv,
             'get_toolchain',
             mock.Mock()) as mock_gt, \
-         mock.patch('twisterlib.environment.datetime', mock_datetime):
+         mock.patch('pylib.twister.twisterlib.environment.datetime', mock_datetime):
         twister_env.discover()
 
     mock_czv.assert_called_once()
@@ -454,7 +454,7 @@ def test_twisterenv_check_zephyr_version(
             return original_abspath(path)
 
     with mock.patch('os.path.abspath', side_effect=mocked_abspath):
-        twister_env = twisterlib.environment.TwisterEnv(options=options)
+        twister_env = pylib.twister.twisterlib.environment.TwisterEnv(options=options)
 
     with mock.patch('subprocess.run', mock.Mock(side_effect=mock_run)):
         twister_env.check_zephyr_version()
@@ -532,7 +532,7 @@ def test_twisterenv_run_cmake_script(
          mock.patch('subprocess.Popen', mock.Mock(side_effect=mock_popen)), \
          pytest.raises(Exception) \
             if not find_cmake else nullcontext() as exception:
-        results = twisterlib.environment.TwisterEnv.run_cmake_script(args)
+        results = pylib.twister.twisterlib.environment.TwisterEnv.run_cmake_script(args)
 
     assert 'Running cmake script dummy/script/path' in caplog.text
 
@@ -582,10 +582,10 @@ def test_get_toolchain(caplog, script_result, exit_value, expected_log):
             return original_abspath(path)
 
     with mock.patch('os.path.abspath', side_effect=mocked_abspath):
-        twister_env = twisterlib.environment.TwisterEnv(options=options)
+        twister_env = pylib.twister.twisterlib.environment.TwisterEnv(options=options)
 
     with mock.patch.object(
-            twisterlib.environment.TwisterEnv,
+            pylib.twister.twisterlib.environment.TwisterEnv,
             'run_cmake_script',
             mock.Mock(return_value=script_result)), \
          pytest.raises(SystemExit) \

--- a/scripts/tests/twister/test_errors.py
+++ b/scripts/tests/twister/test_errors.py
@@ -10,9 +10,10 @@ import os
 import pytest
 
 from pathlib import Path
-from twisterlib.error import StatusAttributeError
-from twisterlib.error import ConfigurationError
-from twisterlib.harness import Test
+
+from pylib.twister.twisterlib.error import StatusAttributeError
+from pylib.twister.twisterlib.error import ConfigurationError
+from pylib.twister.twisterlib.harness import Test
 
 
 def test_configurationerror():

--- a/scripts/tests/twister/test_handlers.py
+++ b/scripts/tests/twister/test_handlers.py
@@ -21,20 +21,20 @@ from serial import SerialException
 from subprocess import CalledProcessError, TimeoutExpired
 from types import SimpleNamespace
 
-import twisterlib.harness
+import pylib.twister.twisterlib.harness
 
 ZEPHYR_BASE = os.getenv("ZEPHYR_BASE")
 
-from twisterlib.error import TwisterException
-from twisterlib.statuses import TwisterStatus
-from twisterlib.handlers import (
+from pylib.twister.twisterlib.error import TwisterException
+from pylib.twister.twisterlib.statuses import TwisterStatus
+from pylib.twister.twisterlib.handlers import (
     Handler,
     BinaryHandler,
     DeviceHandler,
     QEMUHandler,
     SimulationHandler
 )
-from twisterlib.hardwaremap import (
+from pylib.twister.twisterlib.hardwaremap import (
     DUT
 )
 
@@ -117,7 +117,7 @@ def test_imports(
          mock.patch.dict('sys.modules', modules_mock, clear=True), \
          mock.patch('sys.meta_path', meta_path_mock), \
          pytest.raises(expected_error) if expected_error else nullcontext():
-        reload(twisterlib.handlers)
+        reload(pylib.twister.twisterlib.handlers)
 
     out, _ = capfd.readouterr()
     assert all([expected_out in out for expected_out in expected_outs])
@@ -130,7 +130,7 @@ def test_handler_final_handle_actions(mocked_instance):
     handler = Handler(mocked_instance, 'build', mock.Mock())
     handler.suite_name_check = True
 
-    harness = twisterlib.harness.Test()
+    harness = pylib.twister.twisterlib.harness.Test()
     harness.status = TwisterStatus.NONE
     harness.detected_suite_names = mock.Mock()
     harness.matched_run_id = False
@@ -1273,7 +1273,7 @@ def test_devicehandler_create_serial_connection(
     handler = DeviceHandler(mocked_instance, 'build', mock.Mock(timeout_multiplier=1))
     missing_mock = mock.Mock()
     handler.instance.add_missing_case_status = missing_mock
-    twisterlib.handlers.terminate_process = mock.Mock()
+    pylib.twister.twisterlib.handlers.terminate_process = mock.Mock()
 
     dut = DUT()
     dut.available = 0
@@ -1303,7 +1303,7 @@ def test_devicehandler_create_serial_connection(
         missing_mock.assert_called_once_with('blocked', 'Serial Device Error')
 
     if terminate_ser_pty_process:
-        twisterlib.handlers.terminate_process.assert_called_once()
+        pylib.twister.twisterlib.handlers.terminate_process.assert_called_once()
         ser_pty_process.communicate.assert_called_once()
 
 
@@ -1461,7 +1461,7 @@ def test_devicehandler_handle(
     handler._update_instance_info = mock.Mock()
     handler._final_handle_actions = mock.Mock()
     handler.make_dut_available = mock.Mock()
-    twisterlib.handlers.terminate_process = mock.Mock()
+    pylib.twister.twisterlib.handlers.terminate_process = mock.Mock()
     handler.instance.platform.name = 'IPName'
 
     harness = mock.Mock()
@@ -1578,7 +1578,7 @@ def test_qemuhandler_get_default_domain_build_dir(
     handler.instance.sysbuild = self_sysbuild
     handler.build_dir = self_build_dir
 
-    with mock.patch('domains.Domains.from_file', from_file_mock):
+    with mock.patch('pylib.build_helpers.domains.Domains.from_file', from_file_mock):
         result = handler.get_default_domain_build_dir()
 
     assert result == expected
@@ -1931,11 +1931,11 @@ def test_qemuhandler_thread(
          mock.patch('os.unlink', mock.Mock()), \
          mock.patch('os.mkfifo', mock.Mock()), \
          mock.patch('os.kill', mock.Mock()), \
-         mock.patch('twisterlib.handlers.QEMUHandler._get_cpu_time',
+         mock.patch('pylib.twister.twisterlib.handlers.QEMUHandler._get_cpu_time',
                     mock_cputime), \
-         mock.patch('twisterlib.handlers.QEMUHandler._thread_get_fifo_names',
+         mock.patch('pylib.twister.twisterlib.handlers.QEMUHandler._thread_get_fifo_names',
                     mock_thread_get_fifo_names), \
-         mock.patch('twisterlib.handlers.QEMUHandler.' \
+         mock.patch('pylib.twister.twisterlib.handlers.QEMUHandler.' \
                     '_thread_update_instance_info',
                     mock_thread_update_instance_info):
         QEMUHandler._thread(

--- a/scripts/tests/twister/test_hardwaremap.py
+++ b/scripts/tests/twister/test_hardwaremap.py
@@ -12,7 +12,7 @@ import sys
 
 from pathlib import Path
 
-from twisterlib.hardwaremap import(
+from pylib.twister.twisterlib.hardwaremap import(
     DUT,
     HardwareMap
 )
@@ -443,11 +443,11 @@ def test_hardwaremap_scan(
     with mock.patch('platform.system', return_value=system), \
          mock.patch('serial.tools.list_ports.comports',
                     return_value=comports_mock), \
-         mock.patch('twisterlib.hardwaremap.Path.resolve',
+         mock.patch('pylib.twister.twisterlib.hardwaremap.Path.resolve',
                     autospec=True, side_effect=mock_resolve), \
-         mock.patch('twisterlib.hardwaremap.Path.iterdir',
+         mock.patch('pylib.twister.twisterlib.hardwaremap.Path.iterdir',
                     autospec=True, side_effect=mock_iterdir), \
-         mock.patch('twisterlib.hardwaremap.Path.exists',
+         mock.patch('pylib.twister.twisterlib.hardwaremap.Path.exists',
                     autospec=True, side_effect=mock_exists):
         mocked_hm.scan(persistent)
 
@@ -672,7 +672,7 @@ def test_hardwaremap_save(mocked_hm, hwm, expected_dump):
 
     with mock.patch('os.path.exists', return_value=hwm is not None), \
          mock.patch('builtins.open', open_mock), \
-         mock.patch('twisterlib.hardwaremap.yaml.dump', dump_mock):
+         mock.patch('pylib.twister.twisterlib.hardwaremap.yaml.dump', dump_mock):
         mocked_hm.save('hwm.yaml')
 
     dump_mock.assert_called_once_with(expected_dump, mock.ANY, Dumper=mock.ANY,

--- a/scripts/tests/twister/test_harness.py
+++ b/scripts/tests/twister/test_harness.py
@@ -6,19 +6,14 @@
 """
 This test file contains testsuites for the Harness classes of twister
 """
+
 import mock
-import sys
 import os
 import pytest
 import re
 import logging as logger
 
-# ZEPHYR_BASE = os.getenv("ZEPHYR_BASE")
-from conftest import ZEPHYR_BASE
-
-sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts/pylib/twister"))
-
-from twisterlib.harness import (
+from pylib.twister.twisterlib.harness import (
     Bsim,
     Console,
     Gtest,
@@ -29,9 +24,9 @@ from twisterlib.harness import (
     Robot,
     Test,
 )
-from twisterlib.statuses import TwisterStatus
-from twisterlib.testsuite import TestSuite
-from twisterlib.testinstance import TestInstance
+from pylib.twister.twisterlib.statuses import TwisterStatus
+from pylib.twister.twisterlib.testinstance import TestInstance
+from pylib.twister.twisterlib.testsuite import TestSuite
 
 GTEST_START_STATE = " RUN      "
 GTEST_PASS_STATE = "       OK "

--- a/scripts/tests/twister/test_jobserver.py
+++ b/scripts/tests/twister/test_jobserver.py
@@ -19,7 +19,12 @@ from selectors import EVENT_READ
 # Job server only works on Linux for now.
 pytestmark = pytest.mark.skipif(sys.platform != 'linux', reason='JobServer only works on Linux.')
 if sys.platform == 'linux':
-    from twisterlib.jobserver import GNUMakeJobClient, GNUMakeJobServer, JobClient, JobHandle
+    from pylib.twister.twisterlib.jobserver import (
+        GNUMakeJobClient,
+        GNUMakeJobServer,
+        JobClient,
+        JobHandle
+    )
     from fcntl import F_GETFL
 
 
@@ -254,7 +259,7 @@ def test_gnumakejobclient_from_environ(
 
     with mock.patch('fcntl.fcntl', mock_fcntl), \
          mock.patch('os.close', mock.Mock()), \
-         mock.patch('twisterlib.jobserver.GNUMakeJobClient.__init__',
+         mock.patch('pylib.twister.twisterlib.jobserver.GNUMakeJobClient.__init__',
                     gmjc_init_mock), \
          pytest.raises(SystemExit) if exit_code is not None else \
          nullcontext() as se:
@@ -407,7 +412,7 @@ def test_gnumakejobclient_pass_fds(jobs, use_inheritable_pipe, expected_fds):
         nonlocal fds
         fds = gmjc.pass_fds()
 
-    with mock.patch('twisterlib.jobserver.GNUMakeJobClient.__del__',
+    with mock.patch('pylib.twister.twisterlib.jobserver.GNUMakeJobClient.__del__',
                     mock.Mock()), \
          mock.patch('selectors.DefaultSelector', selector_mock):
         deleter()

--- a/scripts/tests/twister/test_log_helper.py
+++ b/scripts/tests/twister/test_log_helper.py
@@ -12,7 +12,7 @@ import pytest
 
 from importlib import reload
 
-import twisterlib.log_helper
+import pylib.twister.twisterlib.log_helper
 
 
 TESTDATA = [
@@ -33,9 +33,9 @@ def test_log_command(caplog, system, expected_log):
     args = ['dummy', 'command', '-flag']
 
     with mock.patch('platform.system', return_value=system):
-        reload(twisterlib.log_helper)
-        twisterlib.log_helper.log_command(logger, message, args)
+        reload(pylib.twister.twisterlib.log_helper)
+        pylib.twister.twisterlib.log_helper.log_command(logger, message, args)
 
-    reload(twisterlib.log_helper)
+    reload(pylib.twister.twisterlib.log_helper)
 
     assert expected_log in caplog.text

--- a/scripts/tests/twister/test_platform.py
+++ b/scripts/tests/twister/test_platform.py
@@ -6,18 +6,14 @@
 '''
 This test file contains tests for platform.py module of twister
 '''
-import sys
-import os
+
 import mock
 import pytest
 
 from contextlib import nullcontext
 from pykwalify.errors import SchemaError
 
-ZEPHYR_BASE = os.getenv("ZEPHYR_BASE")
-sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts/pylib/twister"))
-
-from twisterlib.platform import Platform, Simulator, generate_platforms
+from pylib.twister.twisterlib.platform import Platform, Simulator, generate_platforms
 
 
 TESTDATA_1 = [

--- a/scripts/tests/twister/test_quarantine.py
+++ b/scripts/tests/twister/test_quarantine.py
@@ -11,9 +11,11 @@ import os
 import pytest
 import textwrap
 
-from twisterlib.quarantine import QuarantineException, \
-                                  QuarantineElement, \
-                                  QuarantineData
+from pylib.twister.twisterlib.quarantine import (
+    QuarantineException,
+    QuarantineElement,
+    QuarantineData
+)
 
 
 TESTDATA_1 = [

--- a/scripts/tests/twister/test_runner.py
+++ b/scripts/tests/twister/test_runner.py
@@ -22,13 +22,11 @@ from elftools.elf.sections import SymbolTableSection
 from typing import List
 
 ZEPHYR_BASE = os.getenv("ZEPHYR_BASE")
-sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts/pylib/twister"))
 
-from twisterlib.statuses import TwisterStatus
-from twisterlib.error import BuildError
-from twisterlib.harness import Pytest
-
-from twisterlib.runner import (
+from pylib.twister.twisterlib.statuses import TwisterStatus
+from pylib.twister.twisterlib.error import BuildError
+from pylib.twister.twisterlib.harness import Pytest
+from pylib.twister.twisterlib.runner import (
     CMake,
     ExecutionCounter,
     FilterBuilder,
@@ -332,7 +330,7 @@ def test_cmake_run_build(
 
     with mock.patch('sys.platform', sys_platform), \
          mock.patch('shutil.which', return_value=cmake_path), \
-         mock.patch('twisterlib.runner.change_skip_to_error_if_integration',
+         mock.patch('pylib.twister.twisterlib.runner.change_skip_to_error_if_integration',
                     change_mock), \
          mock.patch('builtins.open', mock.mock_open()), \
          mock.patch('subprocess.Popen', popen_mock):
@@ -478,9 +476,9 @@ def test_cmake_run_cmake(
 
     with mock.patch('sys.platform', sys_platform), \
          mock.patch('shutil.which', return_value=cmake_path), \
-         mock.patch('twisterlib.runner.change_skip_to_error_if_integration',
+         mock.patch('pylib.twister.twisterlib.runner.change_skip_to_error_if_integration',
                     change_mock), \
-         mock.patch('twisterlib.runner.canonical_zephyr_base',
+         mock.patch('pylib.twister.twisterlib.runner.canonical_zephyr_base',
                     'zephyr_base'), \
          mock.patch('builtins.open', mock.mock_open()), \
          mock.patch('subprocess.Popen', popen_mock):
@@ -735,12 +733,12 @@ def test_filterbuilder_parse_generated(
 
     environ_mock = {'env_dummy': True}
 
-    with mock.patch('twisterlib.runner.Domains.from_file',
+    with mock.patch('pylib.twister.twisterlib.runner.Domains.from_file',
                     mock_domains_from_file), \
-         mock.patch('twisterlib.runner.CMakeCache.from_file',
+         mock.patch('pylib.twister.twisterlib.runner.CMakeCache.from_file',
                     mock_cmakecache_from_file), \
+         mock.patch('pylib.twister.expr_parser.parse', mock_parser), \
          mock.patch('builtins.open', mock_open), \
-         mock.patch('expr_parser.parse', mock_parser), \
          mock.patch('pickle.load', mock_pickle), \
          mock.patch('os.path.exists', return_value=edt_exists), \
          mock.patch('os.environ', environ_mock), \
@@ -866,7 +864,7 @@ def test_projectbuilder_log_info_file(
 
     with mock.patch('os.path.exists', mock_exists), \
          mock.patch('os.path.getsize', mock_getsize), \
-         mock.patch('twisterlib.runner.ProjectBuilder.log_info', log_info_mock):
+         mock.patch('pylib.twister.twisterlib.runner.ProjectBuilder.log_info', log_info_mock):
         pb.log_info_file(None)
 
     log_info_mock.assert_called_with(expected_log, mock.ANY)
@@ -1671,7 +1669,7 @@ def test_projectbuilder_determine_testcases(
 
     pb = ProjectBuilder(instance_mock, mocked_env, mocked_jobserver)
 
-    with mock.patch('twisterlib.runner.ELFFile', elf_mock), \
+    with mock.patch('pylib.twister.twisterlib.runner.ELFFile', elf_mock), \
          mock.patch('builtins.open', mock.mock_open()):
         pb.determine_testcases(results_mock)
 
@@ -1997,7 +1995,7 @@ def test_projectbuilder_sanitize_zephyr_base_from_files(
 
     with mock.patch('os.path.exists', mock_exists), \
          mock.patch('builtins.open', mock_open), \
-         mock.patch('twisterlib.runner.canonical_zephyr_base',
+         mock.patch('pylib.twister.twisterlib.runner.canonical_zephyr_base',
                     'canonical/zephyr/base'):
         pb._sanitize_zephyr_base_from_files()
 
@@ -2348,7 +2346,7 @@ def test_projectbuilder_run(
     pb.defconfig = defconfig
     pb.parse_generated = mock.Mock()
 
-    with mock.patch('twisterlib.runner.HarnessImporter.get_harness',
+    with mock.patch('pylib.twister.twisterlib.runner.HarnessImporter.get_harness',
                     mock_harness):
         pb.run()
 
@@ -2554,13 +2552,13 @@ def test_twisterrunner_run(
         results_mock().iteration += value * (-1 if decrement else 1)
     results_mock().iteration_increment = iteration_increment
 
-    with mock.patch('twisterlib.runner.ExecutionCounter', results_mock), \
-         mock.patch('twisterlib.runner.BaseManager', manager_mock), \
-         mock.patch('twisterlib.runner.GNUMakeJobClient.from_environ',
+    with mock.patch('pylib.twister.twisterlib.runner.ExecutionCounter', results_mock), \
+         mock.patch('pylib.twister.twisterlib.runner.BaseManager', manager_mock), \
+         mock.patch('pylib.twister.twisterlib.runner.GNUMakeJobClient.from_environ',
                     mock_client_from_environ), \
-         mock.patch('twisterlib.runner.GNUMakeJobServer',
+         mock.patch('pylib.twister.twisterlib.runner.GNUMakeJobServer',
                     gnumakejobserver_mock), \
-         mock.patch('twisterlib.runner.JobClient', jobclient_mock), \
+         mock.patch('pylib.twister.twisterlib.runner.JobClient', jobclient_mock), \
          mock.patch('multiprocessing.cpu_count', return_value=8), \
          mock.patch('sys.platform', platform), \
          mock.patch('time.sleep', mock.Mock()), \
@@ -2803,7 +2801,7 @@ def test_twisterrunner_pipeline_mgr(mocked_jobserver, platform):
     results_mock = mock.Mock()
 
     with mock.patch('sys.platform', platform), \
-         mock.patch('twisterlib.runner.ProjectBuilder',\
+         mock.patch('pylib.twister.twisterlib.runner.ProjectBuilder',\
                     return_value=mock.Mock()) as pb:
         tr.pipeline_mgr(pipeline_mock, done_queue_mock, lock_mock, results_mock)
 
@@ -2835,7 +2833,7 @@ def test_twisterrunner_execute(caplog):
     pipeline_mock = mock.Mock()
     done_mock = mock.Mock()
 
-    with mock.patch('twisterlib.runner.Process', process_mock):
+    with mock.patch('pylib.twister.twisterlib.runner.Process', process_mock):
         tr.execute(pipeline_mock, done_mock)
 
     assert 'Execution interrupted' in caplog.text

--- a/scripts/tests/twister/test_testinstance.py
+++ b/scripts/tests/twister/test_testinstance.py
@@ -7,22 +7,21 @@
 Tests for testinstance class
 """
 
-from contextlib import nullcontext
-import os
-import sys
-import pytest
 import mock
+import os
+import pytest
+
+from contextlib import nullcontext
 
 ZEPHYR_BASE = os.getenv("ZEPHYR_BASE")
-sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts/pylib/twister"))
 
+from pylib.twister.expr_parser import reserved
+from pylib.twister.twisterlib.error import BuildError
+from pylib.twister.twisterlib.handlers import QEMUHandler
 from pylib.twister.twisterlib.platform import Simulator
-from twisterlib.statuses import TwisterStatus
-from twisterlib.testinstance import TestInstance
-from twisterlib.error import BuildError
-from twisterlib.runner import TwisterRunner
-from twisterlib.handlers import QEMUHandler
-from expr_parser import reserved
+from pylib.twister.twisterlib.runner import TwisterRunner
+from pylib.twister.twisterlib.statuses import TwisterStatus
+from pylib.twister.twisterlib.testinstance import TestInstance
 
 
 TESTDATA_PART_1 = [
@@ -586,7 +585,7 @@ def test_testinstance_calculate_sizes(testinstance, from_buildlog, expected_buil
     sc_mock = mock.Mock()
     mock_sc = mock.Mock(return_value=sc_mock)
 
-    with mock.patch('twisterlib.testinstance.SizeCalculator', mock_sc):
+    with mock.patch('pylib.twister.twisterlib.testinstance.SizeCalculator', mock_sc):
         res = testinstance.calculate_sizes(from_buildlog, expected_warning)
 
     assert res == sc_mock

--- a/scripts/tests/twister/test_testplan.py
+++ b/scripts/tests/twister/test_testplan.py
@@ -6,23 +6,23 @@
 '''
 This test file contains testsuites for testsuite.py module of twister
 '''
-import sys
-import os
+
 import mock
+import os
 import pytest
+import sys
 
 from contextlib import nullcontext
 
 ZEPHYR_BASE = os.getenv("ZEPHYR_BASE")
-sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts/pylib/twister"))
 
-from twisterlib.statuses import TwisterStatus
-from twisterlib.testplan import TestPlan, change_skip_to_error_if_integration
-from twisterlib.testinstance import TestInstance
-from twisterlib.testsuite import TestSuite
-from twisterlib.platform import Platform
-from twisterlib.quarantine import Quarantine
-from twisterlib.error import TwisterRuntimeError
+from pylib.twister.twisterlib.error import TwisterRuntimeError
+from pylib.twister.twisterlib.platform import Platform
+from pylib.twister.twisterlib.quarantine import Quarantine
+from pylib.twister.twisterlib.statuses import TwisterStatus
+from pylib.twister.twisterlib.testinstance import TestInstance
+from pylib.twister.twisterlib.testplan import TestPlan, change_skip_to_error_if_integration
+from pylib.twister.twisterlib.testsuite import TestSuite
 
 
 def test_testplan_add_testsuites_short(class_testplan):
@@ -777,8 +777,8 @@ def test_testplan_load(
     testplan.generate_subset = mock.Mock()
     testplan.apply_filters = mock.Mock()
 
-    with mock.patch('twisterlib.testinstance.TestInstance.create_overlay', mock.Mock()), \
-         mock.patch('twisterlib.testinstance.TestInstance.check_runnable', return_value=True), \
+    with mock.patch('pylib.twister.twisterlib.testinstance.TestInstance.create_overlay', mock.Mock()), \
+         mock.patch('pylib.twister.twisterlib.testinstance.TestInstance.check_runnable', return_value=True), \
          pytest.raises(exception) if exception else nullcontext():
         testplan.load()
 
@@ -855,7 +855,7 @@ def test_testplan_handle_modules():
     modules = [mock.Mock(meta={'name': 'name1'}),
                mock.Mock(meta={'name': 'name2'})]
 
-    with mock.patch('twisterlib.testplan.parse_modules', return_value=modules):
+    with mock.patch('pylib.twister.twisterlib.testplan.parse_modules', return_value=modules):
         testplan.handle_modules()
 
     assert testplan.modules == ['name1', 'name2']
@@ -1136,7 +1136,7 @@ def test_testplan_add_configurations(
             type(platform).name = mock.PropertyMock(return_value=platform.aliases[0])
             yield platform
 
-    with mock.patch('twisterlib.testplan.generate_platforms', mock_gen_plat):
+    with mock.patch('pylib.twister.twisterlib.testplan.generate_platforms', mock_gen_plat):
         testplan.add_configurations()
 
     if expected_defaults is not None:
@@ -1500,8 +1500,8 @@ def test_testplan_load_from_file(caplog, device_testing, expected_tfilter):
     check_runnable_mock = mock.Mock(return_value=True)
 
     with mock.patch('builtins.open', mock.mock_open(read_data=testplan_data)), \
-         mock.patch('twisterlib.testinstance.TestInstance.check_runnable', check_runnable_mock), \
-         mock.patch('twisterlib.testinstance.TestInstance.create_overlay', mock.Mock()):
+         mock.patch('pylib.twister.twisterlib.testinstance.TestInstance.check_runnable', check_runnable_mock), \
+         mock.patch('pylib.twister.twisterlib.testinstance.TestInstance.create_overlay', mock.Mock()):
         testplan.load_from_file('dummy.yaml', filter_platform)
 
     expected_instances = {

--- a/scripts/tests/twister/test_testsuite.py
+++ b/scripts/tests/twister/test_testsuite.py
@@ -10,15 +10,13 @@ import mmap
 import mock
 import os
 import pytest
-import sys
 
 from contextlib import nullcontext
 
 ZEPHYR_BASE = os.getenv('ZEPHYR_BASE')
-sys.path.insert(0, os.path.join(ZEPHYR_BASE, 'scripts', 'pylib', 'twister'))
 
-from twisterlib.statuses import TwisterStatus
-from twisterlib.testsuite import (
+from pylib.twister.twisterlib.statuses import TwisterStatus
+from pylib.twister.twisterlib.testsuite import (
     _find_src_dir_path,
     _get_search_area_boundary,
     find_c_files_in,
@@ -28,7 +26,7 @@ from twisterlib.testsuite import (
     TestCase,
     TestSuite
 )
-from twisterlib.error import TwisterException, TwisterRuntimeError
+from pylib.twister.twisterlib.error import TwisterException, TwisterRuntimeError
 
 
 TESTDATA_1 = [
@@ -655,9 +653,9 @@ def test_scan_testsuite_path(
 
         return result
 
-    with mock.patch('twisterlib.testsuite._find_src_dir_path', mock_fsdp), \
-         mock.patch('twisterlib.testsuite.find_c_files_in', mock_find), \
-         mock.patch('twisterlib.testsuite.scan_file', mock_sf), \
+    with mock.patch('pylib.twister.twisterlib.testsuite._find_src_dir_path', mock_fsdp), \
+         mock.patch('pylib.twister.twisterlib.testsuite.find_c_files_in', mock_find), \
+         mock.patch('pylib.twister.twisterlib.testsuite.scan_file', mock_sf), \
          mock.patch('os.stat', mock_stat), \
          pytest.raises(type(expected_exception)) if \
           expected_exception else nullcontext() as exception:

--- a/scripts/tests/twister/test_twister.py
+++ b/scripts/tests/twister/test_twister.py
@@ -8,24 +8,22 @@ This test file contains foundational testcases for Twister tool
 """
 
 import os
-import sys
 import mock
 import pytest
 
 from pathlib import Path
 
 ZEPHYR_BASE = os.getenv("ZEPHYR_BASE")
-sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts/pylib/twister"))
 
-import scl
-from twisterlib.error import ConfigurationError
-from twisterlib.testplan import TwisterConfigParser
+import pylib.twister.scl
+from pylib.twister.twisterlib.error import ConfigurationError
+from pylib.twister.twisterlib.testplan import TwisterConfigParser
 
 def test_yamlload():
     """ Test to check if loading the non-existent files raises the errors """
     filename = 'testcase_nc.yaml'
     with pytest.raises(FileNotFoundError):
-        scl.yaml_load(filename)
+        pylib.twister.scl.yaml_load(filename)
 
 
 @pytest.mark.parametrize("filename, schema",
@@ -34,7 +32,7 @@ def test_yamlload():
 def test_correct_schema(filename, schema, test_data):
     """ Test to validate the testsuite schema"""
     filename = test_data + filename
-    schema = scl.yaml_load(ZEPHYR_BASE +'/scripts/schemas/twister//' + schema)
+    schema = pylib.twister.scl.yaml_load(ZEPHYR_BASE +'/scripts/schemas/twister//' + schema)
     data = TwisterConfigParser(filename, schema)
     data.load()
     assert data
@@ -46,15 +44,15 @@ def test_correct_schema(filename, schema, test_data):
 def test_incorrect_schema(filename, schema, test_data):
     """ Test to validate the exception is raised for incorrect testsuite schema"""
     filename = test_data + filename
-    schema = scl.yaml_load(ZEPHYR_BASE +'/scripts/schemas/twister//' + schema)
+    schema = pylib.twister.scl.yaml_load(ZEPHYR_BASE +'/scripts/schemas/twister//' + schema)
     with pytest.raises(Exception) as exception:
-        scl.yaml_load_verify(filename, schema)
+        pylib.twister.scl.yaml_load_verify(filename, schema)
         assert str(exception.value) == "Schema validation failed"
 
 def test_testsuite_config_files():
     """ Test to validate conf and overlay files are extracted properly """
     filename = Path(ZEPHYR_BASE) / "scripts/tests/twister/test_data/test_data_with_deprecation_warnings.yaml"
-    schema = scl.yaml_load(Path(ZEPHYR_BASE) / "scripts/schemas/twister/testsuite-schema.yaml")
+    schema = pylib.twister.scl.yaml_load(Path(ZEPHYR_BASE) / "scripts/schemas/twister/testsuite-schema.yaml")
     data = TwisterConfigParser(filename, schema)
     data.load()
 

--- a/scripts/tests/twister_blackbox/__init__.py
+++ b/scripts/tests/twister_blackbox/__init__.py
@@ -1,0 +1,4 @@
+#!/usr/bin/env python3
+# Copyright (c) 2025 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/scripts/tests/twister_blackbox/test_addon.py
+++ b/scripts/tests/twister_blackbox/test_addon.py
@@ -16,8 +16,8 @@ import shutil
 import subprocess
 import sys
 
-from conftest import ZEPHYR_BASE, TEST_DATA, sample_filename_mock, testsuite_filename_mock
-from twisterlib.testplan import TestPlan
+from .conftest import ZEPHYR_BASE, TEST_DATA, sample_filename_mock, testsuite_filename_mock
+from pylib.twister.twisterlib.testplan import TestPlan
 
 
 class TestAddon:
@@ -211,9 +211,9 @@ class TestAddon:
     @mock.patch.object(TestPlan, 'SAMPLE_FILENAME', sample_filename_mock)
     def test_allow_installed_plugin(self, caplog, out_path, allow_flags, do_install,
                                     expected_exit_value, expected_logs):
-        environment_twister_module = importlib.import_module('twisterlib.environment')
-        harness_twister_module = importlib.import_module('twisterlib.harness')
-        runner_twister_module = importlib.import_module('twisterlib.runner')
+        environment_twister_module = importlib.import_module('pylib.twister.twisterlib.environment')
+        harness_twister_module = importlib.import_module('pylib.twister.twisterlib.harness')
+        runner_twister_module = importlib.import_module('pylib.twister.twisterlib.runner')
 
         pth_path = os.path.join(ZEPHYR_BASE, 'scripts', 'pylib', 'pytest-twister-harness')
         check_installed_command = [sys.executable, '-m', 'pip', 'list']

--- a/scripts/tests/twister_blackbox/test_config.py
+++ b/scripts/tests/twister_blackbox/test_config.py
@@ -7,15 +7,14 @@ Blackbox tests for twister's command line functions related to test configuratio
 """
 
 import importlib
+import json
 import mock
 import os
 import pytest
 import sys
-import json
 
-# pylint: disable=no-name-in-module
-from conftest import ZEPHYR_BASE, TEST_DATA, testsuite_filename_mock
-from twisterlib.testplan import TestPlan
+from .conftest import ZEPHYR_BASE, TEST_DATA, testsuite_filename_mock
+from pylib.twister.twisterlib.testplan import TestPlan
 
 
 class TestConfig:

--- a/scripts/tests/twister_blackbox/test_coverage.py
+++ b/scripts/tests/twister_blackbox/test_coverage.py
@@ -13,9 +13,9 @@ import pytest
 import sys
 import json
 
-# pylint: disable=duplicate-code, disable=no-name-in-module
-from conftest import TEST_DATA, ZEPHYR_BASE, testsuite_filename_mock, clear_log_in_test
-from twisterlib.testplan import TestPlan
+# pylint: disable=duplicate-code
+from .conftest import TEST_DATA, ZEPHYR_BASE, testsuite_filename_mock, clear_log_in_test
+from pylib.twister.twisterlib.testplan import TestPlan
 
 
 @mock.patch.object(TestPlan, 'TESTSUITE_FILENAME', testsuite_filename_mock)

--- a/scripts/tests/twister_blackbox/test_device.py
+++ b/scripts/tests/twister_blackbox/test_device.py
@@ -13,9 +13,8 @@ import pytest
 import sys
 import re
 
-# pylint: disable=no-name-in-module
-from conftest import ZEPHYR_BASE, TEST_DATA, testsuite_filename_mock
-from twisterlib.testplan import TestPlan
+from .conftest import ZEPHYR_BASE, TEST_DATA, testsuite_filename_mock
+from pylib.twister.twisterlib.testplan import TestPlan
 
 
 class TestDevice:

--- a/scripts/tests/twister_blackbox/test_disable.py
+++ b/scripts/tests/twister_blackbox/test_disable.py
@@ -13,8 +13,8 @@ import os
 import sys
 import re
 
-from conftest import ZEPHYR_BASE, TEST_DATA, testsuite_filename_mock
-from twisterlib.testplan import TestPlan
+from .conftest import ZEPHYR_BASE, TEST_DATA, testsuite_filename_mock
+from pylib.twister.twisterlib.testplan import TestPlan
 
 
 @mock.patch.object(TestPlan, 'TESTSUITE_FILENAME', testsuite_filename_mock)

--- a/scripts/tests/twister_blackbox/test_error.py
+++ b/scripts/tests/twister_blackbox/test_error.py
@@ -13,10 +13,9 @@ import pytest
 import sys
 import re
 
-# pylint: disable=no-name-in-module
-from conftest import ZEPHYR_BASE, TEST_DATA, testsuite_filename_mock
-from twisterlib.testplan import TestPlan
-from twisterlib.error import TwisterRuntimeError
+from .conftest import ZEPHYR_BASE, TEST_DATA, testsuite_filename_mock
+from pylib.twister.twisterlib.testplan import TestPlan
+from pylib.twister.twisterlib.error import TwisterRuntimeError
 
 
 class TestError:

--- a/scripts/tests/twister_blackbox/test_filter.py
+++ b/scripts/tests/twister_blackbox/test_filter.py
@@ -14,9 +14,8 @@ import sys
 import json
 import re
 
-# pylint: disable=no-name-in-module
-from conftest import ZEPHYR_BASE, TEST_DATA, testsuite_filename_mock
-from twisterlib.testplan import TestPlan
+from .conftest import ZEPHYR_BASE, TEST_DATA, testsuite_filename_mock
+from pylib.twister.twisterlib.testplan import TestPlan
 
 
 class TestFilter:

--- a/scripts/tests/twister_blackbox/test_footprint.py
+++ b/scripts/tests/twister_blackbox/test_footprint.py
@@ -14,10 +14,9 @@ import pytest
 import sys
 import re
 
-# pylint: disable=no-name-in-module
-from conftest import ZEPHYR_BASE, TEST_DATA, testsuite_filename_mock, clear_log_in_test
-from twisterlib.statuses import TwisterStatus
-from twisterlib.testplan import TestPlan
+from .conftest import ZEPHYR_BASE, TEST_DATA, testsuite_filename_mock, clear_log_in_test
+from pylib.twister.twisterlib.statuses import TwisterStatus
+from pylib.twister.twisterlib.testplan import TestPlan
 
 
 @mock.patch.object(TestPlan, 'TESTSUITE_FILENAME', testsuite_filename_mock)

--- a/scripts/tests/twister_blackbox/test_hardwaremap.py
+++ b/scripts/tests/twister_blackbox/test_hardwaremap.py
@@ -11,10 +11,8 @@ import os
 import pytest
 import sys
 
-from conftest import ZEPHYR_BASE, testsuite_filename_mock, clear_log_in_test
-from twisterlib.testplan import TestPlan
-
-sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts/pylib/twister/twisterlib"))
+from .conftest import ZEPHYR_BASE, testsuite_filename_mock, clear_log_in_test
+from pylib.twister.twisterlib.testplan import TestPlan
 
 @mock.patch.object(TestPlan, 'TESTSUITE_FILENAME', testsuite_filename_mock)
 class TestHardwaremap:

--- a/scripts/tests/twister_blackbox/test_outfile.py
+++ b/scripts/tests/twister_blackbox/test_outfile.py
@@ -15,9 +15,8 @@ import pytest
 import sys
 import tarfile
 
-# pylint: disable=no-name-in-module
-from conftest import ZEPHYR_BASE, TEST_DATA, sample_filename_mock, testsuite_filename_mock
-from twisterlib.testplan import TestPlan
+from .conftest import ZEPHYR_BASE, TEST_DATA, sample_filename_mock, testsuite_filename_mock
+from pylib.twister.twisterlib.testplan import TestPlan
 
 
 @mock.patch.object(TestPlan, 'TESTSUITE_FILENAME', testsuite_filename_mock)

--- a/scripts/tests/twister_blackbox/test_output.py
+++ b/scripts/tests/twister_blackbox/test_output.py
@@ -14,9 +14,8 @@ import pytest
 import sys
 import json
 
-# pylint: disable=no-name-in-module
-from conftest import ZEPHYR_BASE, TEST_DATA, testsuite_filename_mock, clear_log_in_test
-from twisterlib.testplan import TestPlan
+from .conftest import ZEPHYR_BASE, TEST_DATA, testsuite_filename_mock, clear_log_in_test
+from pylib.twister.twisterlib.testplan import TestPlan
 
 
 @mock.patch.object(TestPlan, 'TESTSUITE_FILENAME', testsuite_filename_mock)

--- a/scripts/tests/twister_blackbox/test_platform.py
+++ b/scripts/tests/twister_blackbox/test_platform.py
@@ -14,9 +14,8 @@ import pytest
 import sys
 import json
 
-# pylint: disable=no-name-in-module
-from conftest import ZEPHYR_BASE, TEST_DATA, testsuite_filename_mock
-from twisterlib.testplan import TestPlan
+from .conftest import ZEPHYR_BASE, TEST_DATA, testsuite_filename_mock
+from pylib.twister.twisterlib.testplan import TestPlan
 
 
 @mock.patch.object(TestPlan, 'TESTSUITE_FILENAME', testsuite_filename_mock)

--- a/scripts/tests/twister_blackbox/test_printouts.py
+++ b/scripts/tests/twister_blackbox/test_printouts.py
@@ -13,15 +13,14 @@ import pytest
 import sys
 import re
 
-# pylint: disable=no-name-in-module
-from conftest import (
+from .conftest import (
     TEST_DATA,
     ZEPHYR_BASE,
     clear_log_in_test,
     sample_filename_mock,
     testsuite_filename_mock
 )
-from twisterlib.testplan import TestPlan
+from pylib.twister.twisterlib.testplan import TestPlan
 
 
 @mock.patch.object(TestPlan, 'TESTSUITE_FILENAME', testsuite_filename_mock)

--- a/scripts/tests/twister_blackbox/test_quarantine.py
+++ b/scripts/tests/twister_blackbox/test_quarantine.py
@@ -15,8 +15,8 @@ import sys
 import json
 
 # pylint: disable=duplicate-code
-from conftest import ZEPHYR_BASE, TEST_DATA, testsuite_filename_mock
-from twisterlib.testplan import TestPlan
+from .conftest import ZEPHYR_BASE, TEST_DATA, testsuite_filename_mock
+from pylib.twister.twisterlib.testplan import TestPlan
 
 
 class TestQuarantine:

--- a/scripts/tests/twister_blackbox/test_report.py
+++ b/scripts/tests/twister_blackbox/test_report.py
@@ -17,10 +17,9 @@ import re
 
 from lxml import etree
 
-# pylint: disable=no-name-in-module
-from conftest import TEST_DATA, ZEPHYR_BASE, testsuite_filename_mock, clear_log_in_test
-from twisterlib.statuses import TwisterStatus
-from twisterlib.testplan import TestPlan
+from .conftest import TEST_DATA, ZEPHYR_BASE, testsuite_filename_mock, clear_log_in_test
+from pylib.twister.twisterlib.statuses import TwisterStatus
+from pylib.twister.twisterlib.testplan import TestPlan
 
 
 @mock.patch.object(TestPlan, 'TESTSUITE_FILENAME', testsuite_filename_mock)

--- a/scripts/tests/twister_blackbox/test_runner.py
+++ b/scripts/tests/twister_blackbox/test_runner.py
@@ -15,9 +15,8 @@ import re
 import sys
 import time
 
-# pylint: disable=no-name-in-module
-from conftest import TEST_DATA, ZEPHYR_BASE, testsuite_filename_mock, clear_log_in_test
-from twisterlib.testplan import TestPlan
+from .conftest import TEST_DATA, ZEPHYR_BASE, testsuite_filename_mock, clear_log_in_test
+from pylib.twister.twisterlib.testplan import TestPlan
 
 
 @mock.patch.object(TestPlan, 'TESTSUITE_FILENAME', testsuite_filename_mock)

--- a/scripts/tests/twister_blackbox/test_shuffle.py
+++ b/scripts/tests/twister_blackbox/test_shuffle.py
@@ -13,9 +13,8 @@ import pytest
 import sys
 import json
 
-# pylint: disable=no-name-in-module
-from conftest import ZEPHYR_BASE, TEST_DATA, testsuite_filename_mock
-from twisterlib.testplan import TestPlan
+from .conftest import ZEPHYR_BASE, TEST_DATA, testsuite_filename_mock
+from pylib.twister.twisterlib.testplan import TestPlan
 
 
 class TestShuffle:

--- a/scripts/tests/twister_blackbox/test_testlist.py
+++ b/scripts/tests/twister_blackbox/test_testlist.py
@@ -13,9 +13,8 @@ import pytest
 import sys
 import json
 
-# pylint: disable=no-name-in-module
-from conftest import ZEPHYR_BASE, TEST_DATA, testsuite_filename_mock, clear_log_in_test
-from twisterlib.testplan import TestPlan
+from .conftest import ZEPHYR_BASE, TEST_DATA, testsuite_filename_mock, clear_log_in_test
+from pylib.twister.twisterlib.testplan import TestPlan
 
 
 class TestTestlist:

--- a/scripts/tests/twister_blackbox/test_testplan.py
+++ b/scripts/tests/twister_blackbox/test_testplan.py
@@ -13,10 +13,9 @@ import pytest
 import sys
 import json
 
-# pylint: disable=no-name-in-module
-from conftest import ZEPHYR_BASE, TEST_DATA, testsuite_filename_mock
-from twisterlib.testplan import TestPlan
-from twisterlib.error import TwisterRuntimeError
+from .conftest import ZEPHYR_BASE, TEST_DATA, testsuite_filename_mock
+from pylib.twister.twisterlib.testplan import TestPlan
+from pylib.twister.twisterlib.error import TwisterRuntimeError
 
 
 class TestTestPlan:

--- a/scripts/tests/twister_blackbox/test_tooling.py
+++ b/scripts/tests/twister_blackbox/test_tooling.py
@@ -14,9 +14,9 @@ import pytest
 import sys
 import json
 
-from conftest import ZEPHYR_BASE, TEST_DATA, sample_filename_mock, testsuite_filename_mock
-from twisterlib.statuses import TwisterStatus
-from twisterlib.testplan import TestPlan
+from .conftest import ZEPHYR_BASE, TEST_DATA, sample_filename_mock, testsuite_filename_mock
+from pylib.twister.twisterlib.statuses import TwisterStatus
+from pylib.twister.twisterlib.testplan import TestPlan
 
 
 class TestTooling:

--- a/scripts/twister
+++ b/scripts/twister
@@ -200,11 +200,12 @@ if not ZEPHYR_BASE:
 
     print(f'ZEPHYR_BASE unset, using "{ZEPHYR_BASE}"')
 
-sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts/pylib/twister/"))
-sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts/pylib/build_helpers"))
-
-from twisterlib.environment import add_parse_arguments, parse_arguments, python_version_guard
-from twisterlib.twister_main import main
+from pylib.twister.twisterlib.environment import (
+  add_parse_arguments,
+  parse_arguments,
+  python_version_guard
+)
+from pylib.twister.twisterlib.twister_main import main
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Change all relative imports into relative imports using the fact that we have to have `ZEPHYR_BASE/scripts` in our PATH.

This allows us to not use `sys.path.insert()` as well as protects us from some ImportErrors that I have encountered when running Black Box tests on Windows.