### PR TITLE
cmake: compiler: Added property flag for optimization fast

### DIFF
--- a/cmake/compiler/arcmwdt/compiler_flags.cmake
+++ b/cmake/compiler/arcmwdt/compiler_flags.cmake
@@ -14,7 +14,8 @@ list(APPEND CXX_EXCLUDED_OPTIONS
 set_compiler_property(PROPERTY no_optimization -O0)
 set_compiler_property(PROPERTY optimization_debug -O0)
 set_compiler_property(PROPERTY optimization_speed -O2)
-set_compiler_property(PROPERTY optimization_size  -Os)
+set_compiler_property(PROPERTY optimization_size -Os)
+set_compiler_property(PROPERTY optimization_fast -O3)
 
 #######################################################
 # This section covers flags related to warning levels #

--- a/cmake/compiler/compiler_flags_template.cmake
+++ b/cmake/compiler/compiler_flags_template.cmake
@@ -15,6 +15,8 @@ set_compiler_property(PROPERTY optimization_size)
 
 set_compiler_property(PROPERTY optimization_size_aggressive)
 
+set_compiler_property(PROPERTY optimization_fast)
+
 #######################################################
 # This section covers flags related to warning levels #
 #######################################################

--- a/cmake/compiler/gcc/compiler_flags.cmake
+++ b/cmake/compiler/gcc/compiler_flags.cmake
@@ -21,6 +21,7 @@ endif()
 set_compiler_property(PROPERTY optimization_speed -O2)
 set_compiler_property(PROPERTY optimization_size  -Os)
 set_compiler_property(PROPERTY optimization_size_aggressive -Oz)
+set_compiler_property(PROPERTY optimization_fast -Ofast)
 
 if(CMAKE_C_COMPILER_VERSION GREATER_EQUAL "4.5.0")
   set_compiler_property(PROPERTY optimization_lto -flto=auto)

--- a/cmake/compiler/iar/compiler_flags.cmake
+++ b/cmake/compiler/iar/compiler_flags.cmake
@@ -17,6 +17,8 @@ set_compiler_property(PROPERTY optimization_size -Ohz)
 
 set_compiler_property(PROPERTY optimization_size_aggressive -Ohz)
 
+set_compiler_property(PROPERTY optimization_fast --no_size_constraints)
+
 #######################################################
 # This section covers flags related to warning levels #
 #######################################################

--- a/modules/cmsis-dsp/CMakeLists.txt
+++ b/modules/cmsis-dsp/CMakeLists.txt
@@ -8,7 +8,7 @@ if(CONFIG_CMSIS_DSP)
 
   zephyr_library()
 
-  zephyr_library_compile_options(-Ofast)
+  zephyr_library_compile_options($<TARGET_PROPERTY:compiler,optimization_fast>)
 
   zephyr_include_directories(
     ${CMSIS_DSP_DIR}/Include
@@ -46,8 +46,6 @@ if(CONFIG_CMSIS_DSP)
       zephyr_library_compile_options($<$<STREQUAL:${CMAKE_C_COMPILER_ID},ARMClang>:-flax-vector-conversions=none>)
     endif()
   endif()
-
-  zephyr_library_compile_options(-Ofast)
 
   zephyr_compile_definitions_ifndef(CONFIG_ARM __GNUC_PYTHON__)
 

--- a/modules/cmsis-nn/CMakeLists.txt
+++ b/modules/cmsis-nn/CMakeLists.txt
@@ -8,7 +8,7 @@ if(CONFIG_CMSIS_NN)
 
   zephyr_library()
 
-  zephyr_library_compile_options(-Ofast)
+  zephyr_library_compile_options($<TARGET_PROPERTY:compiler,optimization_fast>)
 
   zephyr_include_directories(${CMSIS_NN_DIR}/Include)
 


### PR DESCRIPTION
CMSIS modules dsp and nn sets the optimization flag -Ofast for their libraries. I've now made a new compiler property optimization_fast to avoid using ifdefs in the cmsis CMakeLists.txt files.

I've update GCC and arcmwdt (not sure if arcmwdt supports -Ofast)