### PR TITLE
net: coap_client: Stop lifetime on piggybacked Ack

### DIFF
--- a/subsys/net/lib/coap/coap_client.c
+++ b/subsys/net/lib/coap/coap_client.c
@@ -995,7 +995,15 @@ fail:
 		report_callback_error(internal_req, ret);
 	}
 	if (!internal_req->is_observe) {
-		release_internal_request(internal_req);
+		if (response_type == COAP_TYPE_ACK) {
+			/* This is piggybacked ACK,
+			 * no need to wait for lifetime to expire, all data is already transferred
+			 * and acknowledged
+			 */
+			reset_internal_request(internal_req);
+		} else {
+			release_internal_request(internal_req);
+		}
 	}
 	return ret;
 }


### PR DESCRIPTION
When we receive piggybacked Ack, it means that we have received all information for this request.
There is no need to track exchange lifetime anymore.

Once we reset the internal request, it is free to be used for the application. So if we only have few requests allocated, it would be slow to send those as get_free_request() only gives request structures that don't have a lifetime left.