### PR TITLE
runners: esp32: Fix board arguments

### DIFF
--- a/boards/common/esp32.board.cmake
+++ b/boards/common/esp32.board.cmake
@@ -13,4 +13,4 @@ board_runner_args(openocd  --gdb-init "thb main")
 set(ESP_IDF_PATH ${ZEPHYR_HAL_ESPRESSIF_MODULE_DIR})
 assert(ESP_IDF_PATH "ESP_IDF_PATH is not set")
 
-board_finalize_runner_args(esp32 "--esp-idf-path=${ESP_IDF_PATH}")
+board_runner_args(esp32 "--esp-idf-path=${ESP_IDF_PATH}")

--- a/soc/espressif/common/CMakeLists.txt
+++ b/soc/espressif/common/CMakeLists.txt
@@ -12,7 +12,7 @@ math(EXPR esptoolpy_flashsize "${CONFIG_FLASH_SIZE} / 0x100000")
 
 # Get UART baudrate from DT
 dt_chosen(dts_shell_uart PROPERTY "zephyr,shell-uart")
-if(${dts_shell_uart})
+if(DEFINED dts_shell_uart AND dts_shell_uart)
   dt_prop(monitor_baud PATH ${dts_shell_uart} PROPERTY "current-speed")
 endif()
 
@@ -51,10 +51,10 @@ else()
 endif()
 
 dt_reg_addr(image_off PATH ${dts_partition_path})
-board_finalize_runner_args(esp32 "--esp-app-address=${image_off}")
-board_finalize_runner_args(esp32 "--esp-flash-size=${esptoolpy_flashsize}MB")
-board_finalize_runner_args(esp32 "--esp-flash-freq=${CONFIG_ESPTOOLPY_FLASHFREQ}")
-board_finalize_runner_args(esp32 "--esp-flash-mode=${CONFIG_ESPTOOLPY_FLASHMODE}")
+board_runner_args(esp32 "--esp-app-address=${image_off}")
+board_runner_args(esp32 "--esp-flash-size=${esptoolpy_flashsize}MB")
+board_runner_args(esp32 "--esp-flash-freq=${CONFIG_ESPTOOLPY_FLASHFREQ}")
+board_runner_args(esp32 "--esp-flash-mode=${CONFIG_ESPTOOLPY_FLASHMODE}")
 board_finalize_runner_args(esp32 "--esp-monitor-baud=${monitor_baud}")
 
 message("-- Image partition ${dts_partition_path}")


### PR DESCRIPTION
Fix board arguments to properly build runners.yaml and set esp-monitor-baud.