### PR TITLE
drivers: adc: iadc_gecko: Enable device power management

### DIFF
--- a/boards/silabs/radio_boards/xg24_rb4187c/xg24_rb4187c.yaml
+++ b/boards/silabs/radio_boards/xg24_rb4187c/xg24_rb4187c.yaml
@@ -8,6 +8,7 @@ toolchain:
   - zephyr
   - gnuarmemb
 supported:
+  - adc
   - bluetooth
   - gpio
   - uart

--- a/tests/drivers/adc/adc_accuracy_test/boards/xg24_rb4187c.overlay
+++ b/tests/drivers/adc/adc_accuracy_test/boards/xg24_rb4187c.overlay
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2025 Silicon Laboratories Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "dt-bindings/adc/silabs-adc.h"
+
+/ {
+	zephyr,user {
+		io-channels = <&adc0 4>;
+		reference-mv = <(3300 / 4)>;
+		expected-accuracy = <32>;
+	};
+};
+
+&adc0 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	channel@4 {
+		reg = <4>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+		zephyr,input-positive = <IADC_INPUT_AVDD>;
+	};
+};

--- a/tests/drivers/adc/adc_accuracy_test/testcase.yaml
+++ b/tests/drivers/adc/adc_accuracy_test/testcase.yaml
@@ -38,6 +38,7 @@ tests:
       - ek_ra4m3
       - ek_ra4w1
       - xg24_dk2601b
+      - xg24_rb4187c
       - xg27_dk2602a
     integration_platforms:
       - frdm_kl25z

--- a/tests/drivers/adc/adc_api/boards/xg24_rb4187c.overlay
+++ b/tests/drivers/adc/adc_api/boards/xg24_rb4187c.overlay
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2025 Silicon Laboratories Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "dt-bindings/adc/silabs-adc.h"
+
+/ {
+	zephyr,user {
+		io-channels = <&adc0 0>, <&adc0 1>;
+	};
+};
+
+&adc0 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+		zephyr,input-positive = <IADC_INPUT_IOVDD>;
+	};
+
+	channel@1 {
+		reg = <1>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+		zephyr,input-positive = <IADC_INPUT_GND>;
+	};
+};


### PR DESCRIPTION
Use `pm_device_driver_init()` for initialization to enable device power management for the IADC driver.