### PR TITLE
sample: zms: add ZMS sample Kconfig

### DIFF
--- a/samples/subsys/fs/zms/Kconfig
+++ b/samples/subsys/fs/zms/Kconfig
@@ -1,0 +1,16 @@
+# Copyright 2025 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+mainmenu "ZMS sample configuration"
+
+config MAX_ITERATIONS
+	int "The number of iterations that the sample writes the all set of data."
+	default 300
+	range 1 300
+
+config DELETE_ITERATION
+	int "The number of iterations after the sample delete all set of data and verify that it has been deleted."
+	default 10
+	range 1 MAX_ITERATIONS
+
+source "Kconfig.zephyr"

--- a/samples/subsys/fs/zms/README.rst
+++ b/samples/subsys/fs/zms/README.rst
@@ -20,7 +20,7 @@ Overview
  A loop is executed where we mount the storage system, and then write all set
  of data.
 
- Each DELETE_ITERATION period, we delete all set of data and verify that it has been deleted.
+ Each CONFIG_DELETE_ITERATION period, we delete all set of data and verify that it has been deleted.
  We generate as well incremented ID/value pairs, we store them until storage is full, then we
  delete them and verify that storage is empty.
 

--- a/samples/subsys/fs/zms/src/main.c
+++ b/samples/subsys/fs/zms/src/main.c
@@ -26,9 +26,6 @@ static struct zms_fs fs;
 #define CNT_ID        2
 #define LONG_DATA_ID  3
 
-#define MAX_ITERATIONS   300
-#define DELETE_ITERATION 10
-
 static int delete_and_verify_items(struct zms_fs *fs, uint32_t id)
 {
 	int rc = 0;
@@ -112,7 +109,7 @@ int main(void)
 	fs.sector_size = info.size;
 	fs.sector_count = 3U;
 
-	for (i = 0; i < MAX_ITERATIONS; i++) {
+	for (i = 0; i < CONFIG_MAX_ITERATIONS; i++) {
 		rc = zms_mount(&fs);
 		if (rc) {
 			printk("Storage Init failed, rc=%d\n", rc);
@@ -195,8 +192,8 @@ int main(void)
 			break;
 		}
 
-		/* Each DELETE_ITERATION delete all basic items */
-		if (!(i % DELETE_ITERATION) && (i)) {
+		/* Each CONFIG_DELETE_ITERATION delete all basic items */
+		if (!(i % CONFIG_DELETE_ITERATION) && (i)) {
 			rc = delete_basic_items(&fs);
 			if (rc) {
 				break;
@@ -204,7 +201,7 @@ int main(void)
 		}
 	}
 
-	if (i != MAX_ITERATIONS) {
+	if (i != CONFIG_MAX_ITERATIONS) {
 		printk("Error: Something went wrong at iteration %u rc=%d\n", i, rc);
 		return 0;
 	}


### PR DESCRIPTION
- adds ability to change the ZMS sample MAX_ITERATIONS and DELETE_ITERATION parameters via Kconfig without manually modifying the source code.
- adds ability to reduce flash memory wear on real devices by reducing the number of write iterations.