### PR TITLE
fix trace32 west runner timeout on NXP mr_canhubk3 board

### DIFF
--- a/boards/nxp/mr_canhubk3/doc/index.rst
+++ b/boards/nxp/mr_canhubk3/doc/index.rst
@@ -279,11 +279,12 @@ Applications for the ``mr_canhubk3`` board can be built in the usual way as
 documented in :ref:`build_an_application`.
 
 This board configuration supports `Lauterbach TRACE32`_, `SEGGER J-Link`_ and `pyOCD`_
-West runners for flashing and debugging applications. Follow the steps described
-in :ref:`lauterbach-trace32-debug-host-tools`, :ref:`jlink-debug-host-tools` and
-:ref:`pyocd-debug-host-tools`,
-to setup the flash and debug host tools for these runners, respectively. The
-default runner is J-Link.
+West runners for flashing and debugging. Follow the steps described in
+:ref:`lauterbach-trace32-debug-host-tools`, :ref:`jlink-debug-host-tools` and
+:ref:`pyocd-debug-host-tools`, to set up the required host tools.
+The default runner is J-Link.
+
+If using TRACE32, ensure you have version >= 2024.09 installed.
 
 Flashing
 ========

--- a/boards/nxp/mr_canhubk3/support/startup.cmm
+++ b/boards/nxp/mr_canhubk3/support/startup.cmm
@@ -51,7 +51,7 @@ TrOnchip.Set BUSERR OFF
 SYStem.Up
 
 ; Init SRAM
-DO ~~/demo/arm/hardware/s32k3/scripts/init_sram.cmm
+DO ~~/demo/arm/hardware/s32k3/misc/init_sram.cmm
 
 ; Only declares flash, does not execute flash programming
 DO ~~/demo/arm/flash/s32k3.cmm PREPAREONLY
@@ -97,7 +97,7 @@ IF ("&loadTo"=="flash")
 ELSE
 (
   ; Init ITCM
-  DO ~~/demo/arm/hardware/s32k3/scripts/init_itcm.cmm
+  DO ~~/demo/arm/hardware/s32k3/misc/init_itcm.cmm
 
   Data.LOAD.Elf &elfFile
 )


### PR DESCRIPTION
Update path to TRACE32 demo scripts for S32K3 to the latest version, so that `west flash/debug -r trace32` can work again. Document the TRACE32 host tool version required by this board.

Fixes #86302