### PR TITLE
drivers: comparator: silabs: Enable device power management

### DIFF
--- a/tests/drivers/comparator/gpio_loopback/boards/xg24_rb4187c.overlay
+++ b/tests/drivers/comparator/gpio_loopback/boards/xg24_rb4187c.overlay
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2025 Silicon Laboratories Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/comparator/silabs-acmp.h>
+#include <zephyr/dt-bindings/pinctrl/silabs/xg24-pinctrl.h>
+
+/ {
+	aliases {
+		test-comp = &acmp0;
+	};
+
+	zephyr,user {
+		test-gpios = <&gpioc 3 GPIO_ACTIVE_HIGH>;
+	};
+
+};
+
+&pinctrl {
+	acmp0_default: acmp0_default {
+		group0 {
+			silabs,analog-bus = <ABUS_CDODD0_ACMP0>;
+		};
+	};
+};
+
+&acmp0 {
+	pinctrl-0 = <&acmp0_default>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	hysteresis-mode = "disabled";
+	accuracy-mode = "high";
+	input-range = "full";
+	input-positive = <ACMP_INPUT_PC3>;
+	input-negative = <ACMP_INPUT_VREFDIV1V25>;
+	vref-divider = <63>;
+};

--- a/tests/drivers/comparator/gpio_loopback/testcase.yaml
+++ b/tests/drivers/comparator/gpio_loopback/testcase.yaml
@@ -11,6 +11,7 @@ tests:
   drivers.comparator.gpio_loopback.silabs_acmp:
     platform_allow:
       - xg24_dk2601b
+      - xg24_rb4187c
       - xg29_rb4412a
   drivers.comparator.gpio_loopback.mcux_acmp:
     platform_allow:


### PR DESCRIPTION
Use `pm_device_driver_init()` for initialization to enable device power management for the ACMP driver.