### PR TITLE
scripts: Add invariant log closing

### DIFF
--- a/scripts/pylib/twister/twisterlib/log_helper.py
+++ b/scripts/pylib/twister/twisterlib/log_helper.py
@@ -12,10 +12,6 @@ import shlex
 
 _WINDOWS = platform.system() == 'Windows'
 
-
-logger = logging.getLogger("twister")
-logger.setLevel(logging.DEBUG)
-
 def log_command(logger, msg, args):
     '''Platform-independent helper for logging subprocess invocations.
     Will log a command string that can be copy/pasted into a POSIX
@@ -26,6 +22,9 @@ def log_command(logger, msg, args):
     :param msg: message to associate with the command
     :param args: argument list as passed to subprocess module
     '''
+    logger = logging.getLogger("twister")
+    logger.setLevel(logging.DEBUG)
+
     msg = f'{msg}: %s'
     if _WINDOWS:
         logger.debug(msg, str(args))
@@ -33,6 +32,9 @@ def log_command(logger, msg, args):
         logger.debug(msg, shlex.join(args))
 
 def setup_logging(outdir, log_file, log_level, timestamps):
+    logger = logging.getLogger("twister")
+    logger.setLevel(logging.DEBUG)
+
     # create file handler which logs even debug messages
     if log_file:
         file_handler = logging.FileHandler(log_file)
@@ -60,3 +62,19 @@ def setup_logging(outdir, log_file, log_level, timestamps):
     # add the handlers to logger
     logger.addHandler(console_handler)
     logger.addHandler(file_handler)
+
+
+def close_logging():
+    logger = logging.getLogger("twister")
+    handlers = logger.handlers[:]
+
+    for handler in handlers:
+        logger.removeHandler(handler)
+        handler.close()
+
+    loggers = [logging.getLogger(name) for name in logging.root.manager.loggerDict]
+    for logg in loggers:
+        handls = logg.handlers[:]
+        for handl in handls:
+            logg.removeHandler(handl)
+            handl.close()

--- a/scripts/pylib/twister/twisterlib/twister_main.py
+++ b/scripts/pylib/twister/twisterlib/twister_main.py
@@ -15,21 +15,19 @@ from colorama import Fore
 from twisterlib.coverage import run_coverage
 from twisterlib.environment import TwisterEnv
 from twisterlib.hardwaremap import HardwareMap
-from twisterlib.log_helper import setup_logging
+from twisterlib.log_helper import close_logging, setup_logging
 from twisterlib.package import Artifacts
 from twisterlib.reports import Reporting
 from twisterlib.runner import TwisterRunner
 from twisterlib.statuses import TwisterStatus
 from twisterlib.testplan import TestPlan
 
-logger = logging.getLogger("twister")
-logger.setLevel(logging.DEBUG)
 
 def init_color(colorama_strip):
     colorama.init(strip=colorama_strip)
 
 
-def main(options: argparse.Namespace, default_options: argparse.Namespace):
+def twister(options: argparse.Namespace, default_options: argparse.Namespace):
     start_time = time.time()
 
     # Configure color output
@@ -78,6 +76,7 @@ def main(options: argparse.Namespace, default_options: argparse.Namespace):
             fp.write(previous_results)
 
     setup_logging(options.outdir, options.log_file, options.log_level, options.timestamps)
+    logger = logging.getLogger("twister")
 
     env = TwisterEnv(options, default_options)
     env.discover()
@@ -222,3 +221,11 @@ def main(options: argparse.Namespace, default_options: argparse.Namespace):
 
     logger.info("Run completed")
     return 0
+
+
+def main(options: argparse.Namespace, default_options: argparse.Namespace):
+    try:
+        return_code = twister(options, default_options)
+    finally:
+        close_logging()
+    return return_code

--- a/scripts/tests/twister_blackbox/conftest.py
+++ b/scripts/tests/twister_blackbox/conftest.py
@@ -84,4 +84,10 @@ def provide_out(tmp_path, request):
     # After
     # We're operating in temp, so it is not strictly necessary
     # but the files can get large quickly as we do not need them after the test.
+    loggers = [logging.getLogger(name) for name in logging.root.manager.loggerDict]
+    for logg in loggers:
+        handls = logg.handlers[:]
+        for handl in handls:
+            logg.removeHandler(handl)
+            handl.close()
     shutil.rmtree(out_container_path)


### PR DESCRIPTION
If Twister or Black Box tests failed, crashed, etc., log handles could linger and crash test cleanup. 
Adding log closing to a `finally` section should prevent those issues.

Loggers should not be set up as globals, as it makes testing much harder.
Running multiple Twisters may cause for the logfiles to be still "in use".

When exiting main, close all logfiles and remove their handlers from all loggers.
Do that for conftest as well.