### PR TITLE
shields: fix x_nucleo_iks01a3 overlay

### DIFF
--- a/boards/shields/x_nucleo_iks01a3/x_nucleo_iks01a3.overlay
+++ b/boards/shields/x_nucleo_iks01a3/x_nucleo_iks01a3.overlay
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/gpio.h>
+
 / {
 	aliases {
 		magn0 = &lis2mdl_1e_x_nucleo_iks01a3;


### PR DESCRIPTION
This overlay is using the `GPIO_ACTIVE_HIGH`/`GPIO_ACTIVE_LOW` macros, but not including the header file that defines it.

Found by CI when building #86309 for the Arduino Due board, which does not include the file by default.