### PR TITLE
dts: atmel: add spi node for arduino due

### DIFF
--- a/boards/arduino/due/arduino_due-pinctrl.dtsi
+++ b/boards/arduino/due/arduino_due-pinctrl.dtsi
@@ -53,6 +53,14 @@
 		};
 	};
 
+	spi0_default: spi0_default {
+		group1 {
+			pinmux = <PA25A_SPI0_MISO>,
+				 <PA26A_SPI0_MOSI>,
+				 <PA27A_SPI0_SPCK>;
+		};
+	};
+
 	pwm0_default: pwm0_default {
 		group1 {
 			pinmux = <PC4B_PWM_PWML1>,

--- a/boards/arduino/due/arduino_due.dts
+++ b/boards/arduino/due/arduino_due.dts
@@ -58,6 +58,13 @@
 	pinctrl-names = "default";
 };
 
+&spi0 {
+	status = "okay";
+	pinctrl-0 = <&spi0_default>;
+	pinctrl-names = "default";
+	cs-gpios = <&pioa 28 GPIO_ACTIVE_LOW>;
+};
+
 &uart {
 	status = "okay";
 	current-speed = <115200>;

--- a/dts/arm/atmel/sam3x.dtsi
+++ b/dts/arm/atmel/sam3x.dtsi
@@ -50,6 +50,26 @@
 			reg = <0x20070000 0x18000>;
 		};
 
+		spi0: spi@40008000 {
+			compatible = "atmel,sam-spi";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x40008000 0x4000>;
+			interrupts = <24 0>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 24>;
+			status = "disabled";
+		};
+
+		spi1: spi@4000c000 {
+			compatible = "atmel,sam-spi";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x4000c000 0x4000>;
+			interrupts = <25 0>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 25>;
+			status = "disabled";
+		};
+
 		/* Only used for HWINFO device ID */
 		eefc: flash-controller@400e0a00 {
 			compatible = "atmel,sam-flash-controller";


### PR DESCRIPTION
Add SPI0 node and associated pincontrols in Arduino Due device tree.