### PR TITLE
modules: optional: Bring in release fixes for Rust

### DIFF
--- a/submanifests/optional.yaml
+++ b/submanifests/optional.yaml
@@ -60,7 +60,7 @@ manifest:
       groups:
         - optional
     - name: zephyr-lang-rust
-      revision: 49c6712fe53b5b82e5c09e94548a4a51a021acfe
+      revision: 37dc7fac3fb0372bc0e78e022bef87fcce68c48d
       path: modules/lang/rust
       remote: upstream
       groups:


### PR DESCRIPTION
This update fixes a few things that are breaking CI:

- Rust 1.85 changes the type of `core::ffi::c_char` to match the native platform. On some platforms, this causes a compile error in printk.  Fix this by using the `c_char` type directly instead of assuming it is either signed or unsigned

- Disable RiscV SMP targest in the samples and tests.  These haven't been a focus, an appear to have locking problems causing various deadlocks and test failures.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/86310