### PR TITLE
fs: nvs: move `FLASH_PAGE_LAYOUT` to `depends on`

### DIFF
--- a/subsys/fs/nvs/Kconfig
+++ b/subsys/fs/nvs/Kconfig
@@ -6,8 +6,8 @@
 config NVS
 	bool "Non-volatile Storage"
 	depends on FLASH
+	depends on FLASH_PAGE_LAYOUT
 	select CRC
-	select FLASH_PAGE_LAYOUT
 	help
 	  Enable support of Non-volatile Storage.
 


### PR DESCRIPTION
`FLASH_PAGE_LAYOUT` has a hardware dependency on `FLASH_HAS_PAGE_LAYOUT` which is not present for all boards. Forcing this symbol to `y` when the hardware doesn't support it results in build errors at the Kconfig stage.

`FLASH_PAGE_LAYOUT` is enabled by default when `FLASH_HAS_PAGE_LAYOUT` is true, so this change will not require any user changes.

Fixes #86326