### PR TITLE
dts: bindings: dai: Change the property names in the DTS

### DIFF
--- a/boards/mediatek/mt8186/afe-mt8186.dts
+++ b/boards/mediatek/mt8186/afe-mt8186.dts
@@ -1,7 +1,7 @@
 	afe_dl1: afe_dl1 {
 		compatible = "mediatek,afe";
-		afe_name = "DL1";
-		dai_id = <0>;
+		afe-name = "DL1";
+		dai-id = <0>;
 		downlink;
 		base = <0x11210050 0x11210054>;
 		cur = <0x11210058 0x1121005c>;
@@ -14,8 +14,8 @@
 
 	afe_dl2: afe_dl2 {
 		compatible = "mediatek,afe";
-		afe_name = "DL2";
-		dai_id = <1>;
+		afe-name = "DL2";
+		dai-id = <1>;
 		downlink;
 		base = <0x1121006c 0x11210070>;
 		cur = <0x11210074 0x11210078>;
@@ -28,22 +28,22 @@
 
 	afe_ul1: afe_ul1 {
 		compatible = "mediatek,afe";
-		afe_name = "UL1";
-		dai_id = <2>;
+		afe-name = "UL1";
+		dai-id = <2>;
 		base = <0x11210378 0x1121037c>;
 		cur = <0x11210380 0x11210384>;
 		end = <0x11210388 0x1121038c>;
 		fs = <0x11210374 24 4>;
 		mono = <0x11210374 8 1>;
-		quad_ch = <0x11210374 11 1>;
+		quad-ch = <0x11210374 11 1>;
 		enable = <0x11210010 31 1>;
 		hd = <0x11210374 0 1>;
 	};
 
 	afe_ul2: afe_ul2 {
 		compatible = "mediatek,afe";
-		afe_name = "UL2";
-		dai_id = <3>;
+		afe-name = "UL2";
+		dai-id = <3>;
 		base = <0x11210860 0x11210864>;
 		cur = <0x11210868 0x1121086c>;
 		end = <0x11210870 0x11210874>;

--- a/boards/mediatek/mt8188/afe-mt8188.dts
+++ b/boards/mediatek/mt8188/afe-mt8188.dts
@@ -1,7 +1,7 @@
 	afe_dl2: afe_dl2 {
 		compatible = "mediatek,afe";
-		afe_name = "DL2";
-		dai_id = <0>;
+		afe-name = "DL2";
+		dai-id = <0>;
 		downlink;
 		base = <0x00000000 0x10b11250>;
 		cur = <0x00000000 0x10b11254>;
@@ -11,14 +11,14 @@
 		hd = <0x10b1125c 5 1>;
 		msb = <0x10b1192c 18 1>;
 		msb2 = <0x10b11930 18 1>;
-		agent_disable = <0x10b10014 18 1>;
-		ch_num = <0x10b1125c 0 5>;
+		agent-disable = <0x10b10014 18 1>;
+		ch-num = <0x10b1125c 0 5>;
 	};
 
 	afe_dl3: afe_dl3 {
 		compatible = "mediatek,afe";
-		afe_name = "DL3";
-		dai_id = <1>;
+		afe-name = "DL3";
+		dai-id = <1>;
 		downlink;
 		base = <0x00000000 0x10b11260>;
 		cur = <0x00000000 0x10b11264>;
@@ -28,40 +28,40 @@
 		hd = <0x10b1126c 5 1>;
 		msb = <0x10b1192c 19 1>;
 		msb2 = <0x10b11930 19 1>;
-		agent_disable = <0x10b10014 19 1>;
-		ch_num = <0x10b1126c 0 5>;
+		agent-disable = <0x10b10014 19 1>;
+		ch-num = <0x10b1126c 0 5>;
 	};
 
 	afe_ul4: afe_ul4 {
 		compatible = "mediatek,afe";
-		afe_name = "UL4";
-		dai_id = <2>;
+		afe-name = "UL4";
+		dai-id = <2>;
 		base = <0x00000000 0x10b11330>;
 		cur = <0x00000000 0x10b11334>;
 		end = <0x00000000 0x10b11338>;
 		fs = <0x10b115a8 15 5>;
 		mono = <0x10b1133c 1 1>;
-		int_odd = <0x10b1133c 0 1>;
+		int-odd = <0x10b1133c 0 1>;
 		enable = <0x10b11200 4 1>;
 		hd = <0x10b1133c 5 1>;
 		msb = <0x10b1192c 3 1>;
 		msb2 = <0x10b11930 3 1>;
-		agent_disable = <0x10b10014 3 1>;
+		agent-disable = <0x10b10014 3 1>;
 	};
 
 	afe_ul5: afe_ul5 {
 		compatible = "mediatek,afe";
-		afe_name = "UL5";
-		dai_id = <3>;
+		afe-name = "UL5";
+		dai-id = <3>;
 		base = <0x00000000 0x10b11340>;
 		cur = <0x00000000 0x10b11344>;
 		end = <0x00000000 0x10b11348>;
 		fs = <0x10b115a8 20 5>;
 		mono = <0x10b1134c 1 1>;
-		int_odd = <0x10b1134c 0 1>;
+		int-odd = <0x10b1134c 0 1>;
 		enable = <0x10b11200 5 1>;
 		hd = <0x10b1134c 5 1>;
 		msb = <0x10b1192c 4 1>;
 		msb2 = <0x10b11930 4 1>;
-		agent_disable = <0x10b10014 4 1>;
+		agent-disable = <0x10b10014 4 1>;
 	};

--- a/boards/mediatek/mt8195/afe-mt8195.dts
+++ b/boards/mediatek/mt8195/afe-mt8195.dts
@@ -1,7 +1,7 @@
 	afe_dl2: afe_dl2 {
 		compatible = "mediatek,afe";
-		afe_name = "DL2";
-		dai_id = <0>;
+		afe-name = "DL2";
+		dai-id = <0>;
 		downlink;
 		base = <0x00000000 0x10891250>;
 		cur = <0x00000000 0x10891254>;
@@ -11,14 +11,14 @@
 		hd = <0x1089125c 5 1>;
 		msb = <0x1089192c 18 1>;
 		msb2 = <0x10891930 18 1>;
-		agent_disable = <0x10890014 18 1>;
-		ch_num = <0x1089125c 0 5>;
+		agent-disable = <0x10890014 18 1>;
+		ch-num = <0x1089125c 0 5>;
 	};
 
 	afe_dl3: afe_dl3 {
 		compatible = "mediatek,afe";
-		afe_name = "DL3";
-		dai_id = <1>;
+		afe-name = "DL3";
+		dai-id = <1>;
 		downlink;
 		base = <0x00000000 0x10891260>;
 		cur = <0x00000000 0x10891264>;
@@ -28,14 +28,14 @@
 		hd = <0x1089126c 5 1>;
 		msb = <0x1089192c 19 1>;
 		msb2 = <0x10891930 19 1>;
-		agent_disable = <0x10890014 19 1>;
-		ch_num = <0x1089126c 0 5>;
+		agent-disable = <0x10890014 19 1>;
+		ch-num = <0x1089126c 0 5>;
 	};
 
 	afe_ul4: afe_ul4 {
 		compatible = "mediatek,afe";
-		afe_name = "UL4";
-		dai_id = <2>;
+		afe-name = "UL4";
+		dai-id = <2>;
 		base = <0x00000000 0x10891330>;
 		cur = <0x00000000 0x10891334>;
 		end = <0x00000000 0x10891338>;
@@ -45,13 +45,13 @@
 		hd = <0x1089133c 5 1>;
 		msb = <0x1089192c 3 1>;
 		msb2 = <0x10891930 3 1>;
-		agent_disable = <0x10890014 3 1>;
+		agent-disable = <0x10890014 3 1>;
 	};
 
 	afe_ul5: afe_ul5 {
 		compatible = "mediatek,afe";
-		afe_name = "UL5";
-		dai_id = <3>;
+		afe-name = "UL5";
+		dai-id = <3>;
 		base = <0x00000000 0x10891340>;
 		cur = <0x00000000 0x10891344>;
 		end = <0x00000000 0x10891348>;
@@ -61,5 +61,5 @@
 		hd = <0x1089134c 5 1>;
 		msb = <0x1089192c 4 1>;
 		msb2 = <0x10891930 4 1>;
-		agent_disable = <0x10890014 4 1>;
+		agent-disable = <0x10890014 4 1>;
 	};

--- a/boards/mediatek/mt8196/afe-mt8196.dts
+++ b/boards/mediatek/mt8196/afe-mt8196.dts
@@ -1,7 +1,7 @@
 	afe_dl1: afe_dl1 {
 		compatible = "mediatek,afe";
-		afe_name = "DL1";
-		dai_id = <1>;
+		afe-name = "DL1";
+		dai-id = <1>;
 		downlink;
 		base = <0x1a114470 0x1a114474>;
 		cur = <0x1a114478 0x1a11447c>;
@@ -14,8 +14,8 @@
 
 	afe_dl_24ch: afe_dl_24ch {
 		compatible = "mediatek,afe";
-		afe_name = "DL_24CH";
-		dai_id = <0>;
+		afe-name = "DL_24CH";
+		dai-id = <0>;
 		downlink;
 		base = <0x1a114620 0x1a114624>;
 		cur = <0x1a114628 0x1a11462c>;
@@ -23,13 +23,13 @@
 		fs = <0x1a114640 8 5>;
 		enable = <0x1a114640 31 1>;
 		hd = <0x1a114640 0 1>;
-		ch_num = <0x1a114640 24 6>;
+		ch-num = <0x1a114640 24 6>;
 	};
 
 	afe_ul0: afe_ul0 {
 		compatible = "mediatek,afe";
-		afe_name = "UL0";
-		dai_id = <2>;
+		afe-name = "UL0";
+		dai-id = <2>;
 		base = <0x1a114d60 0x1a114d64>;
 		cur = <0x1a114d68 0x1a114d6c>;
 		end = <0x1a114d70 0x1a114d74>;
@@ -41,8 +41,8 @@
 
 	afe_ul1: afe_ul1 {
 		compatible = "mediatek,afe";
-		afe_name = "UL1";
-		dai_id = <3>;
+		afe-name = "UL1";
+		dai-id = <3>;
 		base = <0x1a114d90 0x1a114d94>;
 		cur = <0x1a114d98 0x1a114d9c>;
 		end = <0x1a114da0 0x1a114da4>;
@@ -54,8 +54,8 @@
 
 	afe_ul2: afe_ul2 {
 		compatible = "mediatek,afe";
-		afe_name = "UL2";
-		dai_id = <4>;
+		afe-name = "UL2";
+		dai-id = <4>;
 		base = <0x1a114dc0 0x1a114dc4>;
 		cur = <0x1a114dc8 0x1a114dcc>;
 		end = <0x1a114dd0 0x1a114dd4>;

--- a/doc/releases/migration-guide-4.2.rst
+++ b/doc/releases/migration-guide-4.2.rst
@@ -41,13 +41,21 @@ Boards
 * The config option :kconfig:option:`CONFIG_NATIVE_POSIX_SLOWDOWN_TO_REAL_TIME` has been deprecated
   in favor of :kconfig:option:`CONFIG_NATIVE_SIM_SLOWDOWN_TO_REAL_TIME`.
 
-* The DT binding :dtcompatible:`zephyr,native-posix-cpu` has been deprecated in favor of
-  :dtcompatible:`zephyr,native-sim-cpu`.
-
 * Zephyr now supports version 1.11.1 of the :zephyr:board:`neorv32`.
 
 Device Drivers and Devicetree
 *****************************
+
+DAI
+===
+
+* Renamed the devicetree property ``dai_id`` to ``dai-id``.
+* Renamed the devicetree property ``afe_name`` to ``afe-name``.
+* Renamed the devicetree property ``agent_disable`` to ``agent-disable``.
+* Renamed the devicetree property ``ch_num`` to ``ch-num``.
+* Renamed the devicetree property ``mono_invert`` to ``mono-invert``.
+* Renamed the devicetree property ``quad_ch`` to ``quad-ch``.
+* Renamed the devicetree property ``int_odd`` to ``int-odd``.
 
 Counter
 =======
@@ -73,11 +81,6 @@ Ethernet
 * Removed Kconfig option ``ETH_STM32_HAL_MII`` (:github:`86074`).
   PHY interface type is now selected via the ``phy-connection-type`` property in the device tree.
 
-* ``ethernet_native_posix`` has been renamed ``ethernet_native_tap``, and with it its
-  kconfig options: :kconfig:option:`CONFIG_ETH_NATIVE_POSIX` and its related options have been
-  deprecated in favor of :kconfig:option:`CONFIG_ETH_NATIVE_TAP` (:github:`86578`).
-
-
 GPIO
 ====
 
@@ -87,41 +90,8 @@ GPIO
   now left as a placeholder and mapper.
   The labels have also been changed along, so no changes are necessary for regular use.
 
-Serial
-=======
-
-* ``uart_native_posix`` has been renamed ``uart_native_pty``, and with it its
-  kconfig options and DT binding. :dtcompatible:`zephyr,native-posix-uart`  has been deprecated
-  in favor of :dtcompatible:`zephyr,native-pty-uart`.
-  :kconfig:option:`CONFIG_UART_NATIVE_POSIX` and its related options with
-  :kconfig:option:`CONFIG_UART_NATIVE_PTY`.
-  The choice :kconfig:option:`CONFIG_NATIVE_UART_0` has been replaced with
-  :kconfig:option:`CONFIG_UART_NATIVE_PTY_0`, but now, it is also possible to select if a UART is
-  connected to the process stdin/out instead of a PTY at runtime with the command line option
-  ``--<uart_name>_stdinout``.
-  :kconfig:option:`CONFIG_NATIVE_UART_AUTOATTACH_DEFAULT_CMD` has been replaced with
-  :kconfig:option:`CONFIG_UART_NATIVE_PTY_AUTOATTACH_DEFAULT_CMD`.
-  :kconfig:option:`CONFIG_UART_NATIVE_WAIT_PTS_READY_ENABLE` has been deprecated. The functionality
-  it enabled is now always enabled as there is no drawbacks from it.
-  :kconfig:option:`CONFIG_UART_NATIVE_POSIX_PORT_1_ENABLE` has been deprecated. This option does
-  nothing now. Instead users should instantiate as many :dtcompatible:`zephyr,native-pty-uart` nodes
-  as native PTY UART instances they want. (:github:`86739`)
-
-Timer
-=====
-
-* ``native_posix_timer`` has been renamed ``native_sim_timer``, and so its kconfig option
-  :kconfig:option:`CONFIG_NATIVE_POSIX_TIMER` has been deprecated in favor of
-  :kconfig:option:`CONFIG_NATIVE_SIM_TIMER`, (:github:`86612`).
-
 Bluetooth
 *********
-
-Bluetooth Audio
-===============
-
-* ``CONFIG_BT_CSIP_SET_MEMBER_NOTIFIABLE`` has been renamed to
-  :kconfig:option:`CONFIG_BT_CSIP_SET_MEMBER_SIRK_NOTIFIABLE``. (:github:`86763``)
 
 Bluetooth Host
 ==============

--- a/dts/bindings/dai/mediatek,afe.yaml
+++ b/dts/bindings/dai/mediatek,afe.yaml
@@ -5,11 +5,11 @@ compatible: "mediatek,afe"
 include: base.yaml
 
 properties:
-  dai_id:
+  dai-id:
     type: int
     required: true
     description: Host-defined SOF DAI index.  Must match the Linux kernel driver.
-  afe_name:
+  afe-name:
     type: string
     required: true
   downlink:
@@ -34,7 +34,7 @@ properties:
   enable:
     type: array
     description: Channel enable flag
-  agent_disable:
+  agent-disable:
     type: array
     description: Channel disable flag
   fs:
@@ -43,19 +43,19 @@ properties:
   hd:
     type: array
     description: Sample format register
-  ch_num:
+  ch-num:
     type: array
     description: Channel count register
   mono:
     type: array
     description: Mono flag register
-  mono_invert:
+  mono-invert:
     type: boolean
     description: Sense/meaning of mono flag
-  quad_ch:
+  quad-ch:
     type: array
     description: Quad channel flag register
-  int_odd:
+  int-odd:
     type: array
   msb:
     type: array


### PR DESCRIPTION
Rename the following properties in bindings and DTS:

-- dai_id =>dai-id
-- afe_name => afe-name
-- agent_disable => agent-disable
-- ch_num => ch-num
-- mono_invert => mono-invert
-- quad_ch => quad-ch
-- int_odd => int-odd