### PR TITLE
dts: bindings: espi: Change the property names in the DTS

### DIFF
--- a/boards/microchip/mec1501modular_assy6885/mec1501modular_assy6885.dts
+++ b/boards/microchip/mec1501modular_assy6885/mec1501modular_assy6885.dts
@@ -68,9 +68,9 @@
 
 &espi0 {
 	status = "okay";
-	io_girq = <19>;
-	vw_girqs = <24 25>;
-	pc_girq = <15>;
+	io-girq = <19>;
+	vw-girqs = <24 25>;
+	pc-girq = <15>;
 	pinctrl-0 = < &espi_reset_n_gpio061 &espi_cs_n_gpio066
 		  &espi_alert_n_gpio063 &espi_clk_gpio065
 		  &espi_io0_gpio070 &espi_io1_gpio071

--- a/boards/microchip/mec15xxevb_assy6853/mec15xxevb_assy6853.dts
+++ b/boards/microchip/mec15xxevb_assy6853/mec15xxevb_assy6853.dts
@@ -121,9 +121,9 @@
 
 &espi0 {
 	status = "okay";
-	io_girq = <19>;
-	vw_girqs = <24 25>;
-	pc_girq = <15>;
+	io-girq = <19>;
+	vw-girqs = <24 25>;
+	pc-girq = <15>;
 	pinctrl-0 = < &espi_reset_n_gpio061 &espi_cs_n_gpio066
 		  &espi_alert_n_gpio063 &espi_clk_gpio065
 		  &espi_io0_gpio070 &espi_io1_gpio071

--- a/doc/releases/migration-guide-4.2.rst
+++ b/doc/releases/migration-guide-4.2.rst
@@ -100,6 +100,18 @@ Ethernet
   kconfig options: :kconfig:option:`CONFIG_ETH_NATIVE_POSIX` and its related options have been
   deprecated in favor of :kconfig:option:`CONFIG_ETH_NATIVE_TAP` (:github:`86578`).
 
+Enhanced Serial Peripheral Interface (eSPI)
+===========================================
+
+* Renamed the devicetree property ``io_girq`` to ``io-girq``.
+* Renamed the devicetree property ``vw_girqs`` to ``vw-girqs``.
+* Renamed the devicetree property ``pc_girq`` to ``pc-girq``.
+* Renamed the devicetree property ``poll_timeout`` to ``poll-timeout``.
+* Renamed the devicetree property ``poll_interval`` to ``poll-interval``.
+* Renamed the devicetree property ``consec_rd_timeout`` to ``consec-rd-timeout``.
+* Renamed the devicetree property ``sus_chk_delay`` to ``sus-chk-delay``.
+* Renamed the devicetree property ``sus_rsm_interval`` to ``sus-rsm-interval``.
+
 GPIO
 ====
 

--- a/dts/bindings/espi/microchip,xec-espi-saf.yaml
+++ b/dts/bindings/espi/microchip,xec-espi-saf.yaml
@@ -13,26 +13,26 @@ properties:
     description: mmio register space
     required: true
 
-  io_girq:
+  io-girq:
     type: int
     description: soc group irq index for eSPI I/O
 
-  poll_timeout:
+  poll-timeout:
     type: int
     description: poll flash busy timeout in 32KHz periods
 
-  poll_interval:
+  poll-interval:
     type: int
     description: interval between flash busy poll in 20 ns units
 
-  consec_rd_timeout:
+  consec-rd-timeout:
     type: int
     description: timeout after last read to resume supended operations in 20 ns units
 
-  sus_chk_delay:
+  sus-chk-delay:
     type: int
     description: hold off poll after suspend in 20 ns units
 
-  sus_rsm_interval:
+  sus-rsm-interval:
     type: int
     description: force suspended erase or program to resume in 32KHz periods

--- a/dts/bindings/espi/microchip,xec-espi.yaml
+++ b/dts/bindings/espi/microchip,xec-espi.yaml
@@ -12,17 +12,17 @@ properties:
     description: mmio register space
     required: true
 
-  io_girq:
+  io-girq:
     type: int
     description: soc group irq index for eSPI I/O
     required: true
 
-  vw_girqs:
+  vw-girqs:
     type: array
     description: soc group irq indexes for eSPI virtual wires channel
     required: true
 
-  pc_girq:
+  pc-girq:
     type: int
     description: soc group irq index for eSPI peripheral channel
     required: true


### PR DESCRIPTION
Rename the following properties in bindings and DTS:

-- io_girq =>io-girq
-- vw_girqs => vw-girqs
-- pc_girq => pc-girq
-- poll_timeout => poll-timeout
-- poll_interval => poll-interval
-- consec_rd_timeout => consec-rd-timeout
-- sus_chk_delay => sus-chk-delay
-- sus_rsm_interval => sus-rsm-interval