### PR TITLE
boards: ambiq: apollo4p_blue_kxr_evb: update Bluetooth configuration to fix building issue

### DIFF
--- a/boards/ambiq/apollo4p_blue_kxr_evb/Kconfig.defconfig
+++ b/boards/ambiq/apollo4p_blue_kxr_evb/Kconfig.defconfig
@@ -19,6 +19,9 @@ config MAIN_STACK_SIZE
 config BT_BUF_ACL_TX_COUNT
 	default 14
 
+config BT_BUF_EVT_RX_COUNT
+	default 15
+
 config BT_BUF_CMD_TX_SIZE
 	default $(UINT8_MAX)
 


### PR DESCRIPTION
There is new added build_assert in the Bluetooth host stack to require CONFIG_BT_BUF_EVT_RX_COUNT larger than CONFIG_BT_BUF_ACL_TX_COUNT (https://github.com/zephyrproject-rtos/zephyr/pull/83774). Update the specific Bluetooth configurations to fix the build assert of Bluetooth samples.

```
C:/ambiqcodes/ambiqzephyr/zephyr/include/zephyr/bluetooth/buf.h:123:1: note: in expansion of macro 'BUILD_ASSERT'
  123 | BUILD_ASSERT(CONFIG_BT_BUF_EVT_RX_COUNT > CONFIG_BT_BUF_ACL_TX_COUNT,
      | ^~~~~~~~~~~~
ninja: build stopped: subcommand failed.
```