### PR TITLE
drivers: serial: Add clock source selection feature to MAX32 UART

### DIFF
--- a/drivers/serial/uart_max32.c
+++ b/drivers/serial/uart_max32.c
@@ -293,6 +293,12 @@ static int uart_max32_init(const struct device *dev)
 		return ret;
 	}
 
+	ret = Wrap_MXC_UART_SetClockSource(regs, cfg->perclk.clk_src);
+	if (ret != 0) {
+		LOG_ERR("Cannot set UART clock source");
+		return ret;
+	}
+
 	ret = pinctrl_apply_state(cfg->pctrl, PINCTRL_STATE_DEFAULT);
 	if (ret) {
 		return ret;

--- a/tests/drivers/uart/uart_async_api/boards/max78002evkit_max78002_m4.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/max78002evkit_max78002_m4.overlay
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2025 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+dut: &uart1 {
+	status = "okay";
+	pinctrl-0 = <&uart1_tx_p0_13 &uart1_rx_p0_12>;
+	pinctrl-names = "default";
+
+	dmas = <&dma0 1 MAX78_DMA_SLOT_UART1_TX>, <&dma0 2 MAX78_DMA_SLOT_UART1_RX>;
+	dma-names = "tx", "rx";
+
+	current-speed = <115200>;
+	data-bits = <8>;
+	parity = "none";
+};

--- a/west.yml
+++ b/west.yml
@@ -142,7 +142,7 @@ manifest:
       groups:
         - fs
     - name: hal_adi
-      revision: 633fcecf3717aaa22079cf6121627a879f24df51
+      revision: 67b88309c327d207e87bb7af6e37c704cd9d5b9d
       path: modules/hal/adi
       groups:
         - hal


### PR DESCRIPTION
This PR adds clock source selection feature to MAX32 UART driver. Also, it enables 'uart_async_api' test for MAX78002EVKIT board.