### PR TITLE
nRF54H20 FLL16M clock: Remove closed loop mode

### DIFF
--- a/drivers/clock_control/clock_control_nrf2_fll16m.c
+++ b/drivers/clock_control/clock_control_nrf2_fll16m.c
@@ -21,7 +21,7 @@ BUILD_ASSERT(DT_NUM_INST_STATUS_OKAY(DT_DRV_COMPAT) == 1,
 #define FLAG_HFXO_STARTED BIT(FLAGS_COMMON_BITS)
 
 #define FLL16M_MODE_OPEN_LOOP   0
-#define FLL16M_MODE_CLOSED_LOOP 1
+#define FLL16M_MODE_CLOSED_LOOP 1 /* <-- DO NOT IMPLEMENT, CAN CAUSE HARDWARE BUG */
 #define FLL16M_MODE_BYPASS      2
 #define FLL16M_MODE_DEFAULT     FLL16M_MODE_OPEN_LOOP
 #define FLL16M_MODE_LOOP_MASK   BIT(0)
@@ -33,7 +33,6 @@ BUILD_ASSERT(FLL16M_MODE_CLOSED_LOOP == NRF_LRCCONF_CLK_SRC_CLOSED_LOOP);
 
 #define FLL16M_HFXO_ACCURACY DT_PROP(FLL16M_HFXO_NODE, accuracy_ppm)
 #define FLL16M_OPEN_LOOP_ACCURACY DT_INST_PROP(0, open_loop_accuracy_ppm)
-#define FLL16M_CLOSED_LOOP_BASE_ACCURACY DT_INST_PROP(0, closed_loop_base_accuracy_ppm)
 #define FLL16M_MAX_ACCURACY FLL16M_HFXO_ACCURACY
 
 #define BICR (NRF_BICR_Type *)DT_REG_ADDR(DT_NODELABEL(bicr))
@@ -46,9 +45,6 @@ static struct clock_options {
 	{
 		.accuracy = FLL16M_OPEN_LOOP_ACCURACY,
 		.mode = FLL16M_MODE_OPEN_LOOP,
-	},
-	{
-		.mode = FLL16M_MODE_CLOSED_LOOP,
 	},
 	{
 		/* Bypass mode uses HFXO */
@@ -229,27 +225,6 @@ static int api_get_rate_fll16m(const struct device *dev,
 static int fll16m_init(const struct device *dev)
 {
 	struct fll16m_dev_data *dev_data = dev->data;
-	nrf_bicr_lfosc_mode_t lfosc_mode;
-
-	clock_options[1].accuracy = FLL16M_CLOSED_LOOP_BASE_ACCURACY;
-
-	/* Closed-loop mode uses LFXO as source if present, HFXO otherwise */
-	lfosc_mode = nrf_bicr_lfosc_mode_get(BICR);
-
-	if (lfosc_mode != NRF_BICR_LFOSC_MODE_UNCONFIGURED &&
-	    lfosc_mode != NRF_BICR_LFOSC_MODE_DISABLED) {
-		int ret;
-		uint16_t accuracy;
-
-		ret = lfosc_get_accuracy(&accuracy);
-		if (ret < 0) {
-			return ret;
-		}
-
-		clock_options[1].accuracy += accuracy;
-	} else {
-		clock_options[1].accuracy += FLL16M_HFXO_ACCURACY;
-	}
 
 	return clock_config_init(&dev_data->clk_cfg,
 				 ARRAY_SIZE(dev_data->clk_cfg.onoff),

--- a/dts/bindings/clock/nordic,nrf-fll16m.yaml
+++ b/dts/bindings/clock/nordic,nrf-fll16m.yaml
@@ -18,7 +18,6 @@ description: |
 
     fll16m {
             open-loop-accuracy-ppm = <20000>;
-            closed-loop-base-accuracy-ppm = <5000>;
             clocks = <&hfxo>, <&lfxo>;
             clock-names = "hfxo", "lfxo";
     };
@@ -34,9 +33,3 @@ properties:
   open-loop-accuracy-ppm:
     type: int
     description: Clock accuracy in parts per million if open-loop clock source is used.
-
-  closed-loop-base-accuracy-ppm:
-    type: int
-    description: |
-      Base clock accuracy in parts per million if closed-loop clock source is used.
-      The actual accuracy is this property plus the accuracy of the HFXO or LFXO.

--- a/dts/vendor/nordic/nrf54h20.dtsi
+++ b/dts/vendor/nordic/nrf54h20.dtsi
@@ -177,7 +177,6 @@
 			#clock-cells = <0>;
 			clock-frequency = <DT_FREQ_M(16)>;
 			open-loop-accuracy-ppm = <20000>;
-			closed-loop-base-accuracy-ppm = <5000>;
 			clocks = <&hfxo>, <&lfxo>;
 			clock-names = "hfxo", "lfxo";
 		};

--- a/tests/drivers/clock_control/nrf_clock_control/src/main.c
+++ b/tests/drivers/clock_control/nrf_clock_control/src/main.c
@@ -43,11 +43,6 @@ const struct nrf_clock_spec test_clk_specs_fll16m[] = {
 	},
 	{
 		.frequency = MHZ(16),
-		.accuracy = 5020,
-		.precision = NRF_CLOCK_CONTROL_PRECISION_DEFAULT,
-	},
-	{
-		.frequency = MHZ(16),
 		.accuracy = 30,
 		.precision = NRF_CLOCK_CONTROL_PRECISION_DEFAULT,
 	},


### PR DESCRIPTION
Remove the closed loop mode implementation for the fll16m clock. Closed loop causes a hardware bug resulting in increased current consumption if SoC experiences high, but within spec, temperatures.