### PR TITLE
arch: arm: fix spelling of "exceptions"

### DIFF
--- a/arch/arm/core/cortex_m/isr_wrapper.c
+++ b/arch/arm/core/cortex_m/isr_wrapper.c
@@ -68,7 +68,7 @@ void _isr_wrapper(void)
 #if defined(CONFIG_ARM_CUSTOM_INTERRUPT_CONTROLLER)
 	int32_t irq_number = z_soc_irq_get_active();
 #else
-	/* _sw_isr_table does not map the expections, only the interrupts. */
+	/* _sw_isr_table does not map the exceptions, only the interrupts. */
 	int32_t irq_number = __get_IPSR();
 #endif
 	irq_number -= 16;

--- a/arch/arm64/core/vector_table.S
+++ b/arch/arm64/core/vector_table.S
@@ -63,7 +63,7 @@ _ASM_FILE_PROLOGUE
 	stp	x12, x13, [sp, ___esf_t_x12_x13_OFFSET]
 	stp	x14, x15, [sp, ___esf_t_x14_x15_OFFSET]
 #ifdef CONFIG_ARM64_SAFE_EXCEPTION_STACK
-	/* The expection from el1 does not need to save x16, x17, x18 and lr */
+	/* The exception from el1 does not need to save x16, x17, x18 and lr */
 	.if	\el == el0
 #endif
 	stp	x16, x17, [sp, ___esf_t_x16_x17_OFFSET]


### PR DESCRIPTION
Minor typo: s/expections/exceptions/