### PR TITLE
soc: nordic: nrf54l: Fix num of irq for nRF54L09

### DIFF
--- a/soc/nordic/nrf54l/Kconfig.defconfig.nrf54l09_enga_cpuapp
+++ b/soc/nordic/nrf54l/Kconfig.defconfig.nrf54l09_enga_cpuapp
@@ -6,7 +6,7 @@
 if SOC_NRF54L09_ENGA_CPUAPP
 
 config NUM_IRQS
-	default 274
+	default 271
 
 config IEEE802154_NRF5
 	default IEEE802154


### PR DESCRIPTION
Change number of IRQ parameter for nRF54L09 devices.