### PR TITLE
Deprecate native_posix->sim transitional headers

### DIFF
--- a/boards/native/native_sim/native_posix_compat.h
+++ b/boards/native/native_sim/native_posix_compat.h
@@ -15,6 +15,9 @@
 #ifndef BOARDS_POSIX_NATIVE_SIM_NATIVE_POSIX_COMPAT_H
 #define BOARDS_POSIX_NATIVE_SIM_NATIVE_POSIX_COMPAT_H
 
+#warning "This transitional header is now deprecated and will be removed by v4.4. "\
+	 "Use nsi_hw_scheduler.h instead."
+
 #include <stdint.h>
 #include <zephyr/toolchain.h>
 #include "nsi_hw_scheduler.h"

--- a/boards/native/native_sim/timer_model.h
+++ b/boards/native/native_sim/timer_model.h
@@ -7,6 +7,9 @@
 #ifndef BOARDS_POSIX_NATIVE_SIM_TIMER_MODEL_H
 #define BOARDS_POSIX_NATIVE_SIM_TIMER_MODEL_H
 
+#warning "This transitional header is now deprecated and will be removed by v4.4. "\
+	 "Use nsi_timer_model.h instead."
+
 /*
  * To support the native_posix timer driver
  * we provide a header with the same name as in native_posix

--- a/drivers/timer/native_posix_timer.c
+++ b/drivers/timer/native_posix_timer.c
@@ -15,7 +15,8 @@
 #include <zephyr/init.h>
 #include <zephyr/drivers/timer/system_timer.h>
 #include <zephyr/sys_clock.h>
-#include "timer_model.h"
+#include "nsi_hw_scheduler.h"
+#include "nsi_timer_model.h"
 #include "soc.h"
 #include <zephyr/arch/posix/posix_trace.h>
 
@@ -29,12 +30,12 @@ static uint64_t last_tick_time;
  */
 uint32_t sys_clock_cycle_get_32(void)
 {
-	return hwm_get_time();
+	return nsi_hws_get_time();
 }
 
 uint64_t sys_clock_cycle_get_64(void)
 {
-	return hwm_get_time();
+	return nsi_hws_get_time();
 }
 
 /**
@@ -45,7 +46,7 @@ static void np_timer_isr(const void *arg)
 {
 	ARG_UNUSED(arg);
 
-	uint64_t now = hwm_get_time();
+	uint64_t now = nsi_hws_get_time();
 	int32_t elapsed_ticks = (now - last_tick_time)/tick_period;
 
 	last_tick_time += elapsed_ticks*tick_period;
@@ -104,7 +105,7 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
  */
 uint32_t sys_clock_elapsed(void)
 {
-	return (hwm_get_time() - last_tick_time)/tick_period;
+	return (nsi_hws_get_time() - last_tick_time)/tick_period;
 }
 
 /**
@@ -128,7 +129,7 @@ static int sys_clock_driver_init(void)
 
 	tick_period = 1000000ul / CONFIG_SYS_CLOCK_TICKS_PER_SEC;
 
-	last_tick_time = hwm_get_time();
+	last_tick_time = nsi_hws_get_time();
 	hwtimer_enable(tick_period);
 
 	IRQ_CONNECT(TIMER_TICK_IRQ, 1, np_timer_isr, 0, 0);

--- a/tests/boards/native_sim/rtc/src/main.c
+++ b/tests/boards/native_sim/rtc/src/main.c
@@ -12,7 +12,8 @@
 #include <stdio.h>
 #include <time.h>
 
-#include "timer_model.h"
+#include <nsi_hw_scheduler.h>
+#include <nsi_timer_model.h>
 #include "native_rtc.h"
 
 #include <stdio.h>

--- a/tests/net/lib/coap_client/src/main.c
+++ b/tests/net/lib/coap_client/src/main.c
@@ -9,7 +9,7 @@
 #include <zephyr/misc/lorem_ipsum.h>
 #include <zephyr/ztest.h>
 #if defined(CONFIG_NATIVE_SIM_SLOWDOWN_TO_REAL_TIME)
-#include "timer_model.h"
+#include "nsi_timer_model.h"
 #endif
 #include "stubs.h"
 

--- a/tests/net/lib/lwm2m/lwm2m_engine/src/main.c
+++ b/tests/net/lib/lwm2m/lwm2m_engine/src/main.c
@@ -14,7 +14,7 @@
 
 #include "stubs.h"
 #if defined(CONFIG_NATIVE_SIM_SLOWDOWN_TO_REAL_TIME)
-#include "timer_model.h"
+#include "nsi_timer_model.h"
 #endif
 
 #define LOG_LEVEL	LOG_LEVEL_DBG


### PR DESCRIPTION
As native_posix has been removed, we do not need to use the native_posix => native_sim transitional headers anymore, so let's do so.
Also let's mark them as deprecated.
Note: This headers are quite low level, so I do not think they warrant an entry in the migration guide.

Should be merged after https://github.com/zephyrproject-rtos/zephyr/pull/86305 (therefore the DNM label)

(The CI failures are expected, as this PR assumes native_posix does not exist anymore, after https://github.com/zephyrproject-rtos/zephyr/pull/86305 is merged, native_posix won't fail anymore)