### PR TITLE
tests/subsys/fs/nvs: Fix flakiness due to not init'ed data

### DIFF
--- a/tests/subsys/fs/nvs/src/main.c
+++ b/tests/subsys/fs/nvs/src/main.c
@@ -659,6 +659,7 @@ ZTEST_F(nvs, test_nvs_gc_corrupt_close_ate)
 	close_ate.id = 0xffff;
 	close_ate.offset = fixture->fs.sector_size - sizeof(struct nvs_ate) * 5;
 	close_ate.len = 0;
+	close_ate.part = 0xff;
 	close_ate.crc8 = 0xff; /* Incorrect crc8 */
 
 	ate.id = 0x1;
@@ -667,6 +668,7 @@ ZTEST_F(nvs, test_nvs_gc_corrupt_close_ate)
 #ifdef CONFIG_NVS_DATA_CRC
 	ate.len += sizeof(data_crc);
 #endif
+	ate.part = 0xff;
 	ate.crc8 = crc8_ccitt(0xff, &ate,
 			      offsetof(struct nvs_ate, crc8));
 
@@ -722,12 +724,14 @@ ZTEST_F(nvs, test_nvs_gc_corrupt_ate)
 	close_ate.id = 0xffff;
 	close_ate.offset = fixture->fs.sector_size / 2;
 	close_ate.len = 0;
+	close_ate.part = 0xff;
 	close_ate.crc8 = crc8_ccitt(0xff, &close_ate,
 				    offsetof(struct nvs_ate, crc8));
 
 	corrupt_ate.id = 0xdead;
 	corrupt_ate.offset = 0;
 	corrupt_ate.len = 20;
+	corrupt_ate.part = 0xff;
 	corrupt_ate.crc8 = 0xff; /* Incorrect crc8 */
 
 	/* Mark sector 0 as closed */


### PR DESCRIPTION
This test has been seen failing at random (though not often). A valgrind check showed the nvs_ate structures were being CRC'ed with not-initialized data, and checked later (assuming the CRC would be different than a constant).
This may have been the cause of the test failures, so let's initialize the whole structure to prevent the CRC value from depending on random memory/stack content.