### PR TITLE
Add console harness to check log message in sample.usbd.dfu test

### DIFF
--- a/samples/subsys/usb/dfu-next/sample.yaml
+++ b/samples/subsys/usb/dfu-next/sample.yaml
@@ -4,6 +4,11 @@ common:
   min_ram: 64
   depends_on:
     - usbd
+  harness: console
+  harness_config:
+    type: one_line
+    regex:
+      - "USB DFU sample is initialized"
 tests:
   sample.usbd.dfu:
     integration_platforms:


### PR DESCRIPTION
- Added harness configuration to the sample.usbd.dfu test to avoid failing results on the bench report.
- Configured the console harness with a one_line type and a regex pattern to match the "USB DFU sample is initialized" log message.
- Ensures the test passes if the expected log message is found in the console output.

Fixes: #85314