### PR TITLE
tests: zms: allow to build & run on real platforms

### DIFF
--- a/tests/subsys/fs/zms/Kconfig
+++ b/tests/subsys/fs/zms/Kconfig
@@ -1,0 +1,16 @@
+# Copyright 2025 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+mainmenu "ZMS test configuration"
+
+config TEST_ZMS_SIMULATOR
+	bool "Enable ZMS tests designed to be run using a flash-simulator"
+	default y if BOARD_QEMU_X86 || ARCH_POSIX
+	help
+	  If y, enables ZMS tests designed to be run using a flash-simulator,
+	  which provide functionality for flash property customization
+	  and emulating errors in flash operation in parallel to
+	  the regular flash API.
+	  The tests must be run only on qemu_x86 or native_sim target.
+
+source "Kconfig.zephyr"


### PR DESCRIPTION
- Allows to build and run ZMS tests on real platforms.
- Enables ZMS tests designed for a flash-simulator only when built for qemu_x86 or native_sim targets.