### PR TITLE
tests: kernel: Fixed disabling of __deprecated macros

### DIFF
--- a/tests/kernel/pipe/deprecated/pipe/CMakeLists.txt
+++ b/tests/kernel/pipe/deprecated/pipe/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.20.0)
-set(CMAKE_C_FLAGS "-D__deprecated='' -D__DEPRECATED_MACRO=''")
+set(CMAKE_C_FLAGS "-D__deprecated=\"/* deprecated */\" -D__DEPRECATED_MACRO=\"/* deprecated_macro*/\"")
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(pipe)
 

--- a/tests/kernel/pipe/deprecated/pipe_api/CMakeLists.txt
+++ b/tests/kernel/pipe/deprecated/pipe_api/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.20.0)
-set(CMAKE_C_FLAGS "-D__deprecated='' -D__DEPRECATED_MACRO=''")
+set(CMAKE_C_FLAGS "-D__deprecated=\"/* deprecated */\" -D__DEPRECATED_MACRO=\"/* deprecated_macro*/\"")
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(pipe_api)
 


### PR DESCRIPTION
When disabling the __deprecated macros in tests/kernel/pipe/deprecated, the macros was set to ''. For IAR tools this was expanded to '' which caused a compilation error.

I have replaced them with /* deprecated */ which should work for all toolchains.