### PR TITLE
toolchain: Rebase PERFOPT_ALIGN on top of ALIGN(x)

### DIFF
--- a/include/zephyr/toolchain/common.h
+++ b/include/zephyr/toolchain/common.h
@@ -101,36 +101,19 @@
   #if defined(CONFIG_X86)
 
     #ifdef PERF_OPT
-      #define PERFOPT_ALIGN .balign 16
+      #define PERFOPT_ALIGN ALIGN(16)
     #else
-      #define PERFOPT_ALIGN .balign  1
+      #define PERFOPT_ALIGN ALIGN(1)
     #endif
 
-  #elif defined(CONFIG_ARM) || defined(CONFIG_ARM64)
-
-    #define PERFOPT_ALIGN .balign  4
-
-  #elif defined(CONFIG_ARC)
-
-    /* .align assembler directive is supposed by all ARC toolchains and it is
-     * implemented in a same way across ARC toolchains.
-     */
-    #define PERFOPT_ALIGN .align  4
-
-  #elif defined(CONFIG_RISCV) ||  defined(CONFIG_XTENSA) || \
-	  defined(CONFIG_MIPS) || defined(CONFIG_RX)
-    #define PERFOPT_ALIGN .balign 4
-
+  #elif defined(CONFIG_ARM) || defined(CONFIG_ARM64) || \
+	defined(CONFIG_NIOS2) || defined(CONFIG_RISCV) || \
+	defined(CONFIG_XTENSA) || defined(CONFIG_MIPS) || \
+	defined(CONFIG_ARC) || defined(CONFIG_SPARC)
+    #define PERFOPT_ALIGN ALIGN(4)
   #elif defined(CONFIG_ARCH_POSIX)
-
-  #elif defined(CONFIG_SPARC)
-
-    #define PERFOPT_ALIGN .align  4
-
   #else
-
     #error Architecture unsupported
-
   #endif
 
   #define GC_SECTION(sym) SECTION .text.##sym, "ax"


### PR DESCRIPTION
Rebased PERFOPT_ALIGN implementation on top of the newly introduced macro
ALIGN(x).

Requires ~#85758~ to be merged first.