### PR TITLE
soc: stm32: handle CCM in LINKER_GENERATOR

### DIFF
--- a/include/zephyr/linker/linker-defs.h
+++ b/include/zephyr/linker/linker-defs.h
@@ -161,7 +161,7 @@ extern char __gcov_bss_size[];
 extern char _end[];
 
 #if (DT_NODE_HAS_STATUS_OKAY(DT_CHOSEN(zephyr_ccm)))
-extern char __ccm_data_rom_start[];
+extern char __ccm_data_load_start[];
 extern char __ccm_start[];
 extern char __ccm_data_start[];
 extern char __ccm_data_end[];

--- a/kernel/xip.c
+++ b/kernel/xip.c
@@ -32,7 +32,7 @@ void z_data_copy(void)
 		       __ramfunc_end - __ramfunc_region_start);
 #endif /* CONFIG_ARCH_HAS_RAMFUNC_SUPPORT */
 #if DT_NODE_HAS_STATUS_OKAY(DT_CHOSEN(zephyr_ccm))
-	z_early_memcpy(&__ccm_data_start, &__ccm_data_rom_start,
+	z_early_memcpy(&__ccm_data_start, &__ccm_data_load_start,
 		       __ccm_data_end - __ccm_data_start);
 #endif
 #if DT_NODE_HAS_STATUS_OKAY(DT_CHOSEN(zephyr_itcm))

--- a/samples/boards/st/ccm/src/main.c
+++ b/samples/boards/st/ccm/src/main.c
@@ -125,7 +125,7 @@ int main(void)
 	printf("Initialised DATA area     : [%p, %p)\n",
 		&__ccm_data_start, &__ccm_data_end);
 	printf("Start of DATA in FLASH    : %p\n",
-		&__ccm_data_rom_start);
+		&__ccm_data_load_start);
 
 	check_initial_var_values();
 

--- a/soc/st/stm32/common/CMakeLists.txt
+++ b/soc/st/stm32/common/CMakeLists.txt
@@ -7,7 +7,14 @@ zephyr_sources(
 	soc_config.c
 )
 
-zephyr_linker_sources_ifdef(CONFIG_STM32_CCM SECTIONS ccm.ld)
+if(DEFINED CONFIG_STM32_CCM)
+  zephyr_linker_group(NAME CCM_REGION VMA CCM LMA ROM_REGION)
+  zephyr_linker_section(NAME .ccm_bss GROUP CCM_REGION SUBALIGN 4 TYPE BSS )
+  zephyr_linker_section(NAME .ccm_noinit GROUP CCM_REGION SUBALIGN 4 TYPE NOLOAD NOINIT)
+  zephyr_linker_section(NAME .ccm_data GROUP CCM_REGION SUBALIGN 4)
+
+  zephyr_linker_sources(SECTIONS ccm.ld)
+endif()
 
 zephyr_sources_ifdef(CONFIG_STM32_BACKUP_SRAM stm32_backup_sram.c)
 zephyr_linker_sources_ifdef(CONFIG_STM32_BACKUP_SRAM SECTIONS stm32_backup_sram.ld)

--- a/soc/st/stm32/common/ccm.ld
+++ b/soc/st/stm32/common/ccm.ld
@@ -29,6 +29,6 @@ GROUP_START(CCM)
 
 	__ccm_end = .;
 
-	__ccm_data_rom_start = LOADADDR(_CCM_DATA_SECTION_NAME);
+	__ccm_data_load_start = LOADADDR(_CCM_DATA_SECTION_NAME);
 
 GROUP_END(CCM)


### PR DESCRIPTION
Currently, the soc/stm32/ccm.ld is not handled in
CMAKE_LINKER_GENERATOR.

This commit adds support, making STM32 supportable by alternative linkers such as AC6 and IAR.

Should this be added to same place as dtcm and itcm?

This commit also renames a variable to match all other LOADADDR symbols.
It should be investigated to make sure noone out of tree depends on `__ccm_data_rom_start`