### PR TITLE
drivers: flash: flash_mcux_flexspi_nor: Remove special treatment for …

### DIFF
--- a/drivers/flash/flash_mcux_flexspi_nor.c
+++ b/drivers/flash/flash_mcux_flexspi_nor.c
@@ -986,7 +986,6 @@ static int flash_flexspi_nor_check_jedec(struct flash_flexspi_nor_data *data,
 {
 	int ret;
 	uint32_t vendor_id;
-	uint32_t read_params;
 
 	ret = flash_flexspi_nor_read_id_helper(data, (uint8_t *)&vendor_id);
 	if (ret < 0) {
@@ -998,19 +997,6 @@ static int flash_flexspi_nor_check_jedec(struct flash_flexspi_nor_data *data,
 	case 0x16609d: /* IS25LP032 flash, needs P[4:3] cleared with same method as IS25WP */
 	case 0x17609d: /* IS25LP064 */
 	case 0x18609d: /* IS25LP128 */
-		read_params = 0xE0U;
-		ret = flash_flexspi_nor_is25_clear_read_param(data, flexspi_lut, &read_params);
-		if (ret < 0) {
-			while (1) {
-				/*
-				 * Spin here, this flash won't configure correctly.
-				 * We can't print a warning, as we are unlikely to
-				 * be able to XIP at this point.
-				 */
-			}
-		}
-		/* Still return an error- we want the JEDEC configuration to run */
-		return -ENOTSUP;
 	case 0x16709d: /* IS25WP032 */
 	case 0x17709d: /* IS25WP064 */
 	case 0x18709d: /* IS25WP128 */
@@ -1018,7 +1004,7 @@ static int flash_flexspi_nor_check_jedec(struct flash_flexspi_nor_data *data,
 		 * IS25WP flash. We can support this flash with the JEDEC probe,
 		 * but we need to insure P[6:3] are at the default value
 		 */
-		read_params = 0;
+		uint32_t read_params = 0;
 		ret = flash_flexspi_nor_is25_clear_read_param(data, flexspi_lut, &read_params);
 		if (ret < 0) {
 			while (1) {


### PR DESCRIPTION
…IS25LP

Unclear where 0xE0 came from, but it isn't working with the IE25LP chips that I'm working with. Now it uses the same code path for IE25LP and IE25WP.

0xE0 was introduced along with support for the IE25LP chip in commit e8e43b6. Would be great if @danieldegrasse could take a look since that was his commit!