### PR TITLE
boards: adi: Fix incorrect gpio voltage select flags

### DIFF
--- a/boards/adi/max32662evkit/max32662evkit.dts
+++ b/boards/adi/max32662evkit/max32662evkit.dts
@@ -149,5 +149,5 @@
 	status = "okay";
 	pinctrl-0 = <&spi1a_mosi_p0_8 &spi1a_sck_p0_17>;
 	pinctrl-names = "default";
-	cs-gpios = <&gpio0 18 (GPIO_ACTIVE_LOW | MAX32_VSEL_VDDIOH)>;
+	cs-gpios = <&gpio0 18 GPIO_ACTIVE_LOW>;
 };

--- a/boards/adi/max32672evkit/max32672evkit.dts
+++ b/boards/adi/max32672evkit/max32672evkit.dts
@@ -154,7 +154,7 @@
 	status = "okay";
 	pinctrl-0 = <&spi0a_mosi_p0_3 &spi0a_miso_p0_2 &spi0a_sck_p0_4>;
 	pinctrl-names = "default";
-	cs-gpios = <&gpio0 5 (GPIO_ACTIVE_LOW | MAX32_VSEL_VDDIOH)>;
+	cs-gpios = <&gpio0 5 GPIO_ACTIVE_LOW>;
 };
 
 &rtc_counter {

--- a/boards/adi/max32680evkit/max32680evkit_max32680_m4.dts
+++ b/boards/adi/max32680evkit/max32680evkit_max32680_m4.dts
@@ -163,7 +163,7 @@
 	status = "okay";
 	pinctrl-0 = <&spi0a_mosi_p0_5 &spi0a_miso_p0_6 &spi0a_sck_p0_7>;
 	pinctrl-names = "default";
-	cs-gpios = <&gpio0 4 (GPIO_ACTIVE_LOW | MAX32_VSEL_VDDIOH)>;
+	cs-gpios = <&gpio0 4 (GPIO_ACTIVE_LOW | MAX32_GPIO_VSEL_VDDIOH)>;
 };
 
 &w1 {


### PR DESCRIPTION
Fixes several adi boards that incorrectly used pinctrl flags instead of gpio flags in their devicetrees. For max32662evkit and max32672evkit, the flags are removed entirely because these socs don't support gpio voltage selection.