### PR TITLE
boards: nxp: frdm_mcxc242: Free Ram Region for USB Testing

### DIFF
--- a/boards/nxp/frdm_mcxc242/Kconfig.defconfig
+++ b/boards/nxp/frdm_mcxc242/Kconfig.defconfig
@@ -1,0 +1,16 @@
+#
+# Copyright 2025 NXP
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+if BOARD_FRDM_MCXC242
+
+if USB_CDC_ACM
+
+config USB_CDC_ACM_RINGBUF_SIZE
+	default 256
+
+endif #USB_CDC_ACM
+
+endif #BOARD_FRDM_MCXC242


### PR DESCRIPTION
[Fixes #86385]
Frees ram region on the frdm_mcxc242 to allow
usb samples to run on this platform due to the
constraint of 16KB ram space for this platform.

Default logging for this platform to minimal mode due to memory constraints, full logging takes up a significant chunk of the system RAM