### PR TITLE
dts: gpio: Simplify the description of the binding

### DIFF
--- a/dts/bindings/gpio/altr,pio-1.0.yaml
+++ b/dts/bindings/gpio/altr,pio-1.0.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-description: Altera PIO node
+description: Altera PIO
 
 compatible: "altr,pio-1.0"
 

--- a/dts/bindings/gpio/ambiq,gpio-bank.yaml
+++ b/dts/bindings/gpio/ambiq,gpio-bank.yaml
@@ -2,7 +2,7 @@
 # Copyright (c) 2023 Ambiq Micro Inc. <www.ambiq.com>
 # SPDX-License-Identifier: Apache-2.0
 
-description: Ambiq GPIO bank node
+description: Ambiq GPIO bank
 
 compatible: "ambiq,gpio-bank"
 

--- a/dts/bindings/gpio/andestech,atcgpio100.yaml
+++ b/dts/bindings/gpio/andestech,atcgpio100.yaml
@@ -1,8 +1,7 @@
 # Copyright (c) 2021, Andes Technology Corporation.
 # SPDX-License-Identifier: Apache-2.0
 
-description:
-  This is a representation of Andes Technology atcgpio100 GPIO node
+description: Andes Technology ATCGPIO100 GPIO Controller.
 
 compatible: "andestech,atcgpio100"
 

--- a/dts/bindings/gpio/atmel,sam-gpio.yaml
+++ b/dts/bindings/gpio/atmel,sam-gpio.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2021-2023, Gerson Fernando Budke <nandojve@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
 
-description: SAM GPIO PORT node
+description: SAM GPIO Port
 
 compatible: "atmel,sam-gpio"
 

--- a/dts/bindings/gpio/atmel,sam4l-gpio.yaml
+++ b/dts/bindings/gpio/atmel,sam4l-gpio.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2021-2023, Gerson Fernando Budke <nandojve@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
 
-description: SAM4L GPIO PORT node
+description: SAM4L GPIO Port
 
 compatible: "atmel,sam4l-gpio"
 

--- a/dts/bindings/gpio/cypress,cy8c95xx-gpio-port.yaml
+++ b/dts/bindings/gpio/cypress,cy8c95xx-gpio-port.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2021 Synopsys
 # SPDX-License-Identifier: Apache-2.0
 
-description: Cypress cy8c95xx GPIO port node
+description: Cypress cy8c95xx GPIO Port
 
 compatible: "cypress,cy8c95xx-gpio-port"
 

--- a/dts/bindings/gpio/cypress,cy8c95xx-gpio.yaml
+++ b/dts/bindings/gpio/cypress,cy8c95xx-gpio.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2021 Synopsys
 # SPDX-License-Identifier: Apache-2.0
 
-description: Cypress cy8c95xx GPIO node
+description: Cypress cy8c95xx GPIO
 
 compatible: "cypress,cy8c95xx-gpio"
 

--- a/dts/bindings/gpio/cypress,psoc6-gpio.yaml
+++ b/dts/bindings/gpio/cypress,psoc6-gpio.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2020-2021 ATL Electronics
 # SPDX-License-Identifier: Apache-2.0
 
-description: Cypress GPIO PORT node
+description: Cypress GPIO Port
 
 compatible: "cypress,psoc6-gpio"
 

--- a/dts/bindings/gpio/ene,kb1200-gpio.yaml
+++ b/dts/bindings/gpio/ene,kb1200-gpio.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-    ENE KB1200 GPIO(General purpose IO) Port node
+    ENE KB1200 GPIO Port
 
     The GPIO controller provides group control of GPIO functions. Each port
     group contains 32 pins. GPIO_00~GPIO_1F belong to the Port0 group,

--- a/dts/bindings/gpio/gd,gd32-gpio.yaml
+++ b/dts/bindings/gpio/gd,gd32-gpio.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2021 Teslabs Engineering S.L.
 # SPDX-License-Identifier: Apache-2.0
 
-description: GD32 GPIO node
+description: GD32 GPIO
 
 compatible: "gd,gd32-gpio"
 

--- a/dts/bindings/gpio/infineon,cat1-gpio.yaml
+++ b/dts/bindings/gpio/infineon,cat1-gpio.yaml
@@ -4,7 +4,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-description: Infineon CAT1 GPIO PORT node
+description: Infineon CAT1 GPIO Port
 
 compatible: "infineon,cat1-gpio"
 

--- a/dts/bindings/gpio/infineon,xmc4xxx-gpio.yaml
+++ b/dts/bindings/gpio/infineon,xmc4xxx-gpio.yaml
@@ -1,4 +1,4 @@
-description: INFINEON XMC4XXX GPIO PORT node
+description: INFINEON XMC4XXX GPIO Port
 
 compatible: "infineon,xmc4xxx-gpio"
 

--- a/dts/bindings/gpio/intel,gpio.yaml
+++ b/dts/bindings/gpio/intel,gpio.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2018-2019 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-description: Intel GPIO node
+description: Intel GPIO
 
 compatible: "intel,gpio"
 

--- a/dts/bindings/gpio/ite,it8801-gpio.yaml
+++ b/dts/bindings/gpio/ite,it8801-gpio.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 ITE Corporation. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-description: ITE IT8801 I2C-based GPIO device driver
+description: ITE IT8801 I2C-based GPIO
 
 compatible: "ite,it8801-gpio"
 

--- a/dts/bindings/gpio/ite,it8xxx2-gpio-v2.yaml
+++ b/dts/bindings/gpio/ite,it8xxx2-gpio-v2.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 ITE Corporation. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-description: This binding gives a base representation of the ITE gpio
+description: ITE IT8xxx2 GPIO V2
 
 compatible: "ite,it8xxx2-gpio-v2"
 

--- a/dts/bindings/gpio/ite,it8xxx2-gpio.yaml
+++ b/dts/bindings/gpio/ite,it8xxx2-gpio.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2020 ITE Corporation. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-description: This binding gives a base representation of the ITE gpio
+description: ITE IT8xxx2 GPIO
 
 compatible: "ite,it8xxx2-gpio"
 

--- a/dts/bindings/gpio/ite,it8xxx2-gpiokscan.yaml
+++ b/dts/bindings/gpio/ite,it8xxx2-gpiokscan.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2022 ITE Corporation. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-description: This binding gives a base representation of the ITE kscan pins as gpio
+description: ITE IT8xxx2 Kscan Pins as GPIO
 
 compatible: "ite,it8xxx2-gpiokscan"
 

--- a/dts/bindings/gpio/linaro,96b-lscon-1v8.yaml
+++ b/dts/bindings/gpio/linaro,96b-lscon-1v8.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2019 Linaro Ltd.
 # SPDX-License-Identifier: Apache-2.0
 
-description: Represents GPIO pin nodes exposed on the 96Boards 1.8v low-speed header
+description: GPIO Pin exposed on the 96Boards 1.8v low-speed header
 
 compatible: "linaro,96b-lscon-1v8"
 

--- a/dts/bindings/gpio/linaro,96b-lscon-3v3.yaml
+++ b/dts/bindings/gpio/linaro,96b-lscon-3v3.yaml
@@ -1,8 +1,7 @@
 # Copyright (c) 2019 Linaro Ltd.
 # SPDX-License-Identifier: Apache-2.0
 
-description: |
-    Represents GPIO pin nodes exposed on the 96Boards 3.3v low-speed header
+description: GPIO Pin exposed on the 96Boards 3.3v low-speed header
 
 compatible: "linaro,96b-lscon-3v3"
 

--- a/dts/bindings/gpio/microchip,mcp23008.yaml
+++ b/dts/bindings/gpio/microchip,mcp23008.yaml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-description: This is a representation of the Microchip MCP23008 I2C GPIO Expander.
+description: Microchip MCP23008 I2C GPIO Expander.
 
 compatible: "microchip,mcp23008"
 

--- a/dts/bindings/gpio/microchip,mcp23009.yaml
+++ b/dts/bindings/gpio/microchip,mcp23009.yaml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-description: This is a representation of the Microchip MCP23009 I2C GPIO Expander.
+description: Microchip MCP23009 I2C GPIO Expander.
 
 compatible: "microchip,mcp23009"
 

--- a/dts/bindings/gpio/microchip,mcp23016.yaml
+++ b/dts/bindings/gpio/microchip,mcp23016.yaml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-description: This is a representation of the Microchip MCP23016 I2C GPIO Expander.
+description: Microchip MCP23016 I2C GPIO Expander.
 
 compatible: "microchip,mcp23016"
 

--- a/dts/bindings/gpio/microchip,mcp23017.yaml
+++ b/dts/bindings/gpio/microchip,mcp23017.yaml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-description: This is a representation of the Microchip MCP23017 I2C GPIO Expander.
+description: Microchip MCP23017 I2C GPIO Expander.
 
 compatible: "microchip,mcp23017"
 

--- a/dts/bindings/gpio/microchip,mcp23018.yaml
+++ b/dts/bindings/gpio/microchip,mcp23018.yaml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-description: This is a representation of the Microchip MCP23018 I2C GPIO Expander.
+description: Microchip MCP23018 I2C GPIO Expander.
 
 compatible: "microchip,mcp23018"
 

--- a/dts/bindings/gpio/microchip,mcp23s08.yaml
+++ b/dts/bindings/gpio/microchip,mcp23s08.yaml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-description: This is a representation of the Microchip MCP23S08 SPI GPIO Expander.
+description: Microchip MCP23S08 SPI GPIO Expander.
 
 compatible: "microchip,mcp23s08"
 

--- a/dts/bindings/gpio/microchip,mcp23s09.yaml
+++ b/dts/bindings/gpio/microchip,mcp23s09.yaml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-description: This is a representation of the Microchip MCP23S09 SPI GPIO Expander.
+description: Microchip MCP23S09 SPI GPIO Expander.
 
 compatible: "microchip,mcp23s09"
 

--- a/dts/bindings/gpio/microchip,mcp23s17.yaml
+++ b/dts/bindings/gpio/microchip,mcp23s17.yaml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-description: This is a representation of the Microchip MCP23S17 SPI GPIO Expander.
+description: Microchip MCP23S17 SPI GPIO Expander.
 
 compatible: "microchip,mcp23s17"
 

--- a/dts/bindings/gpio/microchip,mcp23s18.yaml
+++ b/dts/bindings/gpio/microchip,mcp23s18.yaml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-description: This is a representation of the Microchip MCP23S18 SPI GPIO Expander.
+description: Microchip MCP23S18 SPI GPIO Expander.
 
 compatible: "microchip,mcp23s18"
 

--- a/dts/bindings/gpio/microchip,mec5-gpio.yaml
+++ b/dts/bindings/gpio/microchip,mec5-gpio.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024, Microchip Technology Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-description: Microchip MEC5 GPIO node
+description: Microchip MEC5 GPIO
 
 compatible: "microchip,mec5-gpio"
 

--- a/dts/bindings/gpio/microchip,mpfs-gpio.yaml
+++ b/dts/bindings/gpio/microchip,mpfs-gpio.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2022 Microchip Technology Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-description: Microchip PolarFire SoC GPIO node
+description: Microchip PolarFire SoC GPIO
 
 compatible: "microchip,mpfs-gpio"
 

--- a/dts/bindings/gpio/microchip,xec-gpio-v2.yaml
+++ b/dts/bindings/gpio/microchip,xec-gpio-v2.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2019, Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-description: Microchip CEC/MEC GPIO V2 node
+description: Microchip CEC/MEC GPIO V2
 
 compatible: "microchip,xec-gpio-v2"
 

--- a/dts/bindings/gpio/microchip,xec-gpio.yaml
+++ b/dts/bindings/gpio/microchip,xec-gpio.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2019, Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-description: Microchip CEC/MEC GPIO node
+description: Microchip CEC/MEC GPIO
 
 compatible: "microchip,xec-gpio"
 

--- a/dts/bindings/gpio/nordic,nrf-gpio.yaml
+++ b/dts/bindings/gpio/nordic,nrf-gpio.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2018, marc-cpdesign
 # SPDX-License-Identifier: Apache-2.0
 
-description: NRF5 GPIO node
+description: NRF5 GPIO
 
 compatible: "nordic,nrf-gpio"
 

--- a/dts/bindings/gpio/nordic,nrf-gpiote.yaml
+++ b/dts/bindings/gpio/nordic,nrf-gpiote.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2018, marc-cpdesign
 # SPDX-License-Identifier: Apache-2.0
 
-description: NRF5 GPIOTE node
+description: NRF5 GPIOTE
 
 compatible: "nordic,nrf-gpiote"
 

--- a/dts/bindings/gpio/nuvoton,npcx-gpio.yaml
+++ b/dts/bindings/gpio/nuvoton,npcx-gpio.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2020 Nuvoton Technology Corporation.
 # SPDX-License-Identifier: Apache-2.0
 
-description: Nuvoton, NPCX-GPIO node
+description: Nuvoton, NPCX-GPIO
 
 compatible: "nuvoton,npcx-gpio"
 

--- a/dts/bindings/gpio/nuvoton,numaker-gpio.yaml
+++ b/dts/bindings/gpio/nuvoton,numaker-gpio.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Nuvoton Technology Corporation.
 # SPDX-License-Identifier: Apache-2.0
 
-description: Nuvoton, Numaker-GPIO node
+description: Nuvoton Numaker GPIO
 
 compatible: "nuvoton,numaker-gpio"
 

--- a/dts/bindings/gpio/nuvoton,numicro-gpio.yaml
+++ b/dts/bindings/gpio/nuvoton,numicro-gpio.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2022 SEAL AG
 # SPDX-License-Identifier: Apache-2.0
 
-description: Nuvoton NuMicro GPIO node
+description: Nuvoton NuMicro GPIO
 
 compatible: "nuvoton,numicro-gpio"
 

--- a/dts/bindings/gpio/nxp,imx-gpio.yaml
+++ b/dts/bindings/gpio/nxp,imx-gpio.yaml
@@ -1,7 +1,7 @@
 # Copyright 2017, 2024 NXP
 # SPDX-License-Identifier: Apache-2.0
 
-description: i.MX GPIO node
+description: i.MX GPIO
 
 compatible: "nxp,imx-gpio"
 

--- a/dts/bindings/gpio/nxp,imx-rgpio.yaml
+++ b/dts/bindings/gpio/nxp,imx-rgpio.yaml
@@ -1,7 +1,7 @@
 # Copyright 2024 NXP
 # SPDX-License-Identifier: Apache-2.0
 
-description: i.MX RGPIO node
+description: i.MX RGPIO
 
 compatible: "nxp,imx-rgpio"
 

--- a/dts/bindings/gpio/nxp,kinetis-gpio.yaml
+++ b/dts/bindings/gpio/nxp,kinetis-gpio.yaml
@@ -1,4 +1,4 @@
-description: Kinetis GPIO node
+description: Kinetis GPIO
 
 compatible: "nxp,kinetis-gpio"
 

--- a/dts/bindings/gpio/nxp,lpc-gpio.yaml
+++ b/dts/bindings/gpio/nxp,lpc-gpio.yaml
@@ -6,7 +6,7 @@
 # base address. It is the ports that are
 # functionally gpio devices.
 
-description: LPC GPIO node
+description: LPC GPIO
 
 compatible: "nxp,lpc-gpio"
 

--- a/dts/bindings/gpio/nxp,lpc11u6x-gpio.yaml
+++ b/dts/bindings/gpio/nxp,lpc11u6x-gpio.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2020 Seagate Technology LLC
 # SPDX-License-Identifier: Apache-2.0
 
-description: NXP LPC11U6X GPIO node
+description: NXP LPC11U6X GPIO
 
 compatible: "nxp,lpc11u6x-gpio"
 

--- a/dts/bindings/gpio/nxp,pca6416.yaml
+++ b/dts/bindings/gpio/nxp,pca6416.yaml
@@ -1,7 +1,7 @@
 # Copyright 2024-2025 NXP
 # SPDX-License-Identifier: Apache-2.0
 
-description: Base binding for PCA6416 I2C-based GPIO expander
+description: PCA6416 I2C-based GPIO expander
 
 compatible: "nxp,pca6416"
 

--- a/dts/bindings/gpio/nxp,pca9538.yaml
+++ b/dts/bindings/gpio/nxp,pca9538.yaml
@@ -1,7 +1,9 @@
 # Copyright 2024 NXP
 # SPDX-License-Identifier: Apache-2.0
-description: NXP PCA9538 I2C GPIO expander node
-compatible: nxp,pca9538
+description: NXP PCA9538 I2C GPIO expander
+
+compatible: "nxp,pca9538"
+
 include: nxp,pca_series.yaml
 
 properties:

--- a/dts/bindings/gpio/nxp,pca9539.yaml
+++ b/dts/bindings/gpio/nxp,pca9539.yaml
@@ -1,7 +1,9 @@
 # Copyright 2024 NXP
 # SPDX-License-Identifier: Apache-2.0
-description: NXP PCA9539 I2C GPIO expander node
-compatible: nxp,pca9539
+description: NXP PCA9539 I2C GPIO expander
+
+compatible: "nxp,pca9539"
+
 include: nxp,pca_series.yaml
 
 properties:

--- a/dts/bindings/gpio/nxp,pca9554.yaml
+++ b/dts/bindings/gpio/nxp,pca9554.yaml
@@ -1,7 +1,9 @@
 # Copyright 2024 NXP
 # SPDX-License-Identifier: Apache-2.0
-description: NXP PCA9554 I2C GPIO expander node
-compatible: nxp,pca9554
+description: NXP PCA9554 I2C GPIO expander
+
+compatible: "nxp,pca9554"
+
 include: nxp,pca_series.yaml
 
 properties:

--- a/dts/bindings/gpio/nxp,pca9555.yaml
+++ b/dts/bindings/gpio/nxp,pca9555.yaml
@@ -1,7 +1,9 @@
 # Copyright 2024 NXP
 # SPDX-License-Identifier: Apache-2.0
-description: NXP PCA9555 I2C GPIO expander node
-compatible: nxp,pca9555
+description: NXP PCA9555 I2C GPIO expander
+
+compatible: "nxp,pca9555"
+
 include: nxp,pca_series.yaml
 
 properties:

--- a/dts/bindings/gpio/nxp,pca_series.yaml
+++ b/dts/bindings/gpio/nxp,pca_series.yaml
@@ -1,7 +1,7 @@
 # Copyright 2024 NXP
 # SPDX-License-Identifier: Apache-2.0
 
-description: Base binding for PCA series I2C-based GPIO expander
+description: PCA series I2C-based GPIO expander
 
 include: [gpio-controller.yaml, i2c-device.yaml]
 

--- a/dts/bindings/gpio/nxp,pcal6524.yaml
+++ b/dts/bindings/gpio/nxp,pcal6524.yaml
@@ -1,7 +1,9 @@
 # Copyright 2024 NXP
 # SPDX-License-Identifier: Apache-2.0
-description: NXP PCAL6524 I2C GPIO expander node
-compatible: nxp,pcal6524
+description: NXP PCAL6524 I2C GPIO expander
+
+compatible: "nxp,pcal6524"
+
 include: nxp,pca_series.yaml
 
 properties:

--- a/dts/bindings/gpio/nxp,pcal6534.yaml
+++ b/dts/bindings/gpio/nxp,pcal6534.yaml
@@ -1,7 +1,9 @@
 # Copyright 2024 NXP
 # SPDX-License-Identifier: Apache-2.0
-description: NXP PCAL6534 I2C GPIO expander node
-compatible: nxp,pcal6534
+description: NXP PCAL6534 I2C GPIO expander
+
+compatible: "nxp,pcal6534"
+
 include: nxp,pca_series.yaml
 
 properties:

--- a/dts/bindings/gpio/openisa,rv32m1-gpio.yaml
+++ b/dts/bindings/gpio/openisa,rv32m1-gpio.yaml
@@ -1,4 +1,4 @@
-description: OpenISA GPIO node
+description: OpenISA GPIO
 
 compatible: "openisa,rv32m1-gpio"
 

--- a/dts/bindings/gpio/quicklogic,eos-s3-gpio.yaml
+++ b/dts/bindings/gpio/quicklogic,eos-s3-gpio.yaml
@@ -1,4 +1,4 @@
-description: EOS S3 GPIO node
+description: EOS S3 GPIO
 
 compatible: "quicklogic,eos-s3-gpio"
 

--- a/dts/bindings/gpio/renesas,ra-gpio-ioport.yaml
+++ b/dts/bindings/gpio/renesas,ra-gpio-ioport.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Renesas Electronics Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-description: Renesas RA GPIO IO port
+description: Renesas RA GPIO I/O Port
 
 compatible: "renesas,ra-gpio-ioport"
 

--- a/dts/bindings/gpio/renesas,rz-gpio.yaml
+++ b/dts/bindings/gpio/renesas,rz-gpio.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-  Reneses RZ  GPIO controller node.
+  Reneses RZ  GPIO controller.
   Sample of usage:
     gpio-consumer{
           out-gpio = <&gpio8 2 (GPIO_PULL_UP);

--- a/dts/bindings/gpio/renesas,smartbond-gpio.yaml
+++ b/dts/bindings/gpio/renesas,smartbond-gpio.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2022 Renesas Electronics Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-description: Renesas SmartBond(tm) GPIO node
+description: Renesas SmartBond(tm) GPIO
 
 compatible: "renesas,smartbond-gpio"
 

--- a/dts/bindings/gpio/richtek,rt1718s-gpio-port.yaml
+++ b/dts/bindings/gpio/richtek,rt1718s-gpio-port.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-    Richtek RT1718S TCPC chip GPIO port
+    Richtek RT1718S TCPC chip GPIO Port
 
     "richtek,rt1718s-gpio-port" node handles GPIO feature of the RT1718S TCPC
     chip.

--- a/dts/bindings/gpio/rohm,bd8lb600fs-gpio.yaml
+++ b/dts/bindings/gpio/rohm,bd8lb600fs-gpio.yaml
@@ -6,7 +6,7 @@
 #
 
 description: |
-    This is a representation of the Rohm BD8LB600FS SPI Gpio Expander.
+    Rohm BD8LB600FS SPI GPIO Expander.
     Multiple instances may be daisy chained, which can be configured
     via the number of supported GPIOs.
 

--- a/dts/bindings/gpio/semtech,sx1509b.yaml
+++ b/dts/bindings/gpio/semtech,sx1509b.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2018, Aapo Vienamo
 # SPDX-License-Identifier: Apache-2.0
 
-description: SX1509B GPIO node
+description: SX1509B GPIO
 
 compatible: "semtech,sx1509b"
 

--- a/dts/bindings/gpio/sensry,sy1xx-gpio.yaml
+++ b/dts/bindings/gpio/sensry,sy1xx-gpio.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 sensry.io
 # SPDX-License-Identifier: Apache-2.0
 
-description: Sensry SY1XX GPIO PORT node
+description: Sensry SY1XX GPIO Port
 
 compatible: "sensry,sy1xx-gpio"
 

--- a/dts/bindings/gpio/sifive,gpio0.yaml
+++ b/dts/bindings/gpio/sifive,gpio0.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2018, SiFive Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-description: SiFive GPIO node
+description: SiFive GPIO
 
 compatible: "sifive,gpio0"
 

--- a/dts/bindings/gpio/silabs,gecko-gpio-port.yaml
+++ b/dts/bindings/gpio/silabs,gecko-gpio-port.yaml
@@ -1,4 +1,4 @@
-description: SiLabs Gecko GPIO port node
+description: SiLabs Gecko GPIO Port
 
 compatible: "silabs,gecko-gpio-port"
 

--- a/dts/bindings/gpio/silabs,gecko-gpio.yaml
+++ b/dts/bindings/gpio/silabs,gecko-gpio.yaml
@@ -1,4 +1,4 @@
-description: SiLabs Gecko GPIO node
+description: SiLabs Gecko GPIO
 
 compatible: "silabs,gecko-gpio"
 

--- a/dts/bindings/gpio/silabs,si32-gpio.yaml
+++ b/dts/bindings/gpio/silabs,si32-gpio.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-description: Si32 GPIO node
+description: Si32 GPIO
 
 compatible: "silabs,si32-gpio"
 

--- a/dts/bindings/gpio/silabs,siwx91x-gpio-port.yaml
+++ b/dts/bindings/gpio/silabs,siwx91x-gpio-port.yaml
@@ -1,4 +1,4 @@
-description: Silabs SiWx91x GPIO port node
+description: Silabs SiWx91x GPIO Port
 
 compatible: "silabs,siwx91x-gpio-port"
 

--- a/dts/bindings/gpio/silabs,siwx91x-gpio-uulp.yaml
+++ b/dts/bindings/gpio/silabs,siwx91x-gpio-uulp.yaml
@@ -1,4 +1,4 @@
-description: Silabs SiWx91x UULP (ultra ultra low power) GPIO port node
+description: Silabs SiWx91x UULP (ultra ultra low power) GPIO Port
 
 compatible: "silabs,siwx91x-gpio-uulp"
 

--- a/dts/bindings/gpio/silabs,siwx91x-gpio.yaml
+++ b/dts/bindings/gpio/silabs,siwx91x-gpio.yaml
@@ -1,4 +1,4 @@
-description: Silabs SiWx91x GPIO node
+description: Silabs SiWx91x GPIO
 
 compatible: "silabs,siwx91x-gpio"
 

--- a/dts/bindings/gpio/snps,creg-gpio.yaml
+++ b/dts/bindings/gpio/snps,creg-gpio.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2021 Synopsys, Inc. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-description: Synopsys CREG GPIO node
+description: Synopsys CREG GPIO
 
 compatible: "snps,creg-gpio"
 

--- a/dts/bindings/gpio/snps,designware-gpio.yaml
+++ b/dts/bindings/gpio/snps,designware-gpio.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2018 Synopsys, Inc. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-description: Synopsys DesignWare GPIO node
+description: Synopsys DesignWare GPIO
 
 compatible: "snps,designware-gpio"
 

--- a/dts/bindings/gpio/st,stm32-gpio.yaml
+++ b/dts/bindings/gpio/st,stm32-gpio.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2018, Linaro Limited
 # SPDX-License-Identifier: Apache-2.0
 
-description: STM32 GPIO controller
+description: STM32 GPIO Controller
 
 compatible: "st,stm32-gpio"
 

--- a/dts/bindings/gpio/telink,b91-gpio.yaml
+++ b/dts/bindings/gpio/telink,b91-gpio.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2021, Telink Semiconductor
 # SPDX-License-Identifier: Apache-2.0
 
-description: Telink B91 GPIO node
+description: Telink B91 GPIO
 
 compatible: "telink,b91-gpio"
 

--- a/dts/bindings/gpio/ti,ads1x4s0x-gpio.yaml
+++ b/dts/bindings/gpio/ti,ads1x4s0x-gpio.yaml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-description: TI ADS114S0x GPIO controller binding
+description: TI ADS114S0x GPIO Controller
 
 compatible: "ti,ads1x4s0x-gpio"
 

--- a/dts/bindings/gpio/ti,cc13xx-cc26xx-gpio.yaml
+++ b/dts/bindings/gpio/ti,cc13xx-cc26xx-gpio.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2019 Brett Witherspoon
 # SPDX-License-Identifier: Apache-2.0
 
-description: TI SimpleLink CC13xx / CC26xx GPIO node
+description: TI SimpleLink CC13xx / CC26xx GPIO
 
 compatible: "ti,cc13xx-cc26xx-gpio"
 

--- a/dts/bindings/gpio/ti,cc23x0-gpio.yaml
+++ b/dts/bindings/gpio/ti,cc23x0-gpio.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-description: TI SimpleLink CC23X0 GPIO node
+description: TI SimpleLink CC23X0 GPIO
 
 compatible: "ti,cc23x0-gpio"
 

--- a/dts/bindings/gpio/ti,cc32xx-gpio.yaml
+++ b/dts/bindings/gpio/ti,cc32xx-gpio.yaml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-description: TI CC32XX GPIO node
+description: TI CC32XX GPIO
 
 compatible: "ti,cc32xx-gpio"
 

--- a/dts/bindings/gpio/ti,davinci-gpio-nexus.yaml
+++ b/dts/bindings/gpio/ti,davinci-gpio-nexus.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-description: GPIO controller for Davinci and Keystone devices
+description: GPIO Controller for Davinci and Keystone devices
 
 compatible: "ti,davinci-gpio-nexus"
 

--- a/dts/bindings/gpio/ti,davinci-gpio.yaml
+++ b/dts/bindings/gpio/ti,davinci-gpio.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-description: GPIO controller for Davinci and Keystone devices.
+description: GPIO Controller for Davinci and Keystone devices.
 
 compatible: "ti,davinci-gpio"
 

--- a/dts/bindings/gpio/ti,lmp90xxx-gpio.yaml
+++ b/dts/bindings/gpio/ti,lmp90xxx-gpio.yaml
@@ -1,4 +1,4 @@
-description: TI LMP90xxx GPIO controller binding
+description: TI LMP90xxx GPIO Controller
 
 compatible: "ti,lmp90xxx-gpio"
 

--- a/dts/bindings/gpio/ti,stellaris-gpio.yaml
+++ b/dts/bindings/gpio/ti,stellaris-gpio.yaml
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-description: TI Stellaris GPIO node
+description: TI Stellaris GPIO
 
 compatible: "ti,stellaris-gpio"
 

--- a/dts/bindings/gpio/ti,tca9538.yaml
+++ b/dts/bindings/gpio/ti,tca9538.yaml
@@ -2,7 +2,7 @@
 # Copyright (c) 2021, Laird Connectivity
 # SPDX-License-Identifier: Apache-2.0
 
-description: TCA9538 GPIO node
+description: TCA9538 GPIO
 
 compatible: "ti,tca9538"
 

--- a/dts/bindings/gpio/xlnx,ps-gpio-bank.yaml
+++ b/dts/bindings/gpio/xlnx,ps-gpio-bank.yaml
@@ -4,7 +4,7 @@
 #
 
 description: |
-  Xilinx Zynq-7000/ZynqMP MIO/EMIO GPIO controller bank node.
+  Xilinx Zynq-7000/ZynqMP MIO/EMIO GPIO Controller bank.
 
   Each node of this type specified in the devicetree represents
   a bank of the MIO/EMIO GPIO controller integrated in the Processor

--- a/dts/bindings/gpio/xlnx,ps-gpio.yaml
+++ b/dts/bindings/gpio/xlnx,ps-gpio.yaml
@@ -4,7 +4,7 @@
 #
 
 description: |
-  Xilinx Zynq-7000/ZynqMP MIO/EMIO GPIO controller node.
+  Xilinx Zynq-7000/ZynqMP MIO/EMIO GPIO Controller.
 
   This GPIO controller is contained in both the Xilinx Zynq-7000 and
   ZynqMP (UltraScale) SoCs. It interfaces both I/O pins of the SoC,

--- a/dts/bindings/gpio/xlnx,xps-gpio-1.00.a-gpio2.yaml
+++ b/dts/bindings/gpio/xlnx,xps-gpio-1.00.a-gpio2.yaml
@@ -1,4 +1,4 @@
-description: Xilinx AXI GPIO IP GPIO2 node
+description: Xilinx AXI GPIO IP GPIO2
 
 compatible: "xlnx,xps-gpio-1.00.a-gpio2"
 

--- a/dts/bindings/gpio/xlnx,xps-gpio-1.00.a.yaml
+++ b/dts/bindings/gpio/xlnx,xps-gpio-1.00.a.yaml
@@ -1,4 +1,4 @@
-description: Xilinx AXI GPIO IP node
+description: Xilinx AXI GPIO IP
 
 compatible: "xlnx,xps-gpio-1.00.a"
 


### PR DESCRIPTION
Remove redundant descriptions in GPIO bindings, such as "This is a representation of".