### PR TITLE
dts: i2c: Simplify the description of the binding

### DIFF
--- a/dts/bindings/i2c/andestech,atciic100.yaml
+++ b/dts/bindings/i2c/andestech,atciic100.yaml
@@ -4,8 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-description:
-  This is a representation of AndesTech atciic100 I2C node
+description: AndesTech ATCIIC100 I2C
 
 compatible: "andestech,atciic100"
 

--- a/dts/bindings/i2c/atmel,sam-i2c-twi.yaml
+++ b/dts/bindings/i2c/atmel,sam-i2c-twi.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2017 Piotr Mienkowski
 # SPDX-License-Identifier: Apache-2.0
 
-description: Atmel SAM Family I2C (TWI) node
+description: Atmel SAM Family I2C (TWI)
 
 compatible: "atmel,sam-i2c-twi"
 

--- a/dts/bindings/i2c/atmel,sam-i2c-twihs.yaml
+++ b/dts/bindings/i2c/atmel,sam-i2c-twihs.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2017 Piotr Mienkowski
 # SPDX-License-Identifier: Apache-2.0
 
-description: Atmel SAM Family I2C (TWIHS) node
+description: Atmel SAM Family I2C (TWIHS)
 
 compatible: "atmel,sam-i2c-twihs"
 

--- a/dts/bindings/i2c/atmel,sam-i2c-twim.yaml
+++ b/dts/bindings/i2c/atmel,sam-i2c-twim.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-  Atmel SAM4L Family I2C (TWIM) node
+  Atmel SAM4L Family I2C (TWIM)
 
   The Atmel Two-wire Master Interface (TWIM) interconnects components on a
   unique two-wire bus, made up of one clock line and one data line with speeds

--- a/dts/bindings/i2c/atmel,sam0-i2c.yaml
+++ b/dts/bindings/i2c/atmel,sam0-i2c.yaml
@@ -2,7 +2,7 @@
 # Copyright (c) 2024 Gerson Fernando Budke <nandojve@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
 
-description: Atmel SAM0 series SERCOM I2C node
+description: Atmel SAM0 series SERCOM I2C
 
 compatible: "atmel,sam0-i2c"
 

--- a/dts/bindings/i2c/fsl,imx21-i2c.yaml
+++ b/dts/bindings/i2c/fsl,imx21-i2c.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2018 Linaro Limited
 # SPDX-License-Identifier: Apache-2.0
 
-description: i.MX I2C node
+description: i.MX I2C
 
 compatible: "fsl,imx21-i2c"
 

--- a/dts/bindings/i2c/microchip,mpfs-i2c.yaml
+++ b/dts/bindings/i2c/microchip,mpfs-i2c.yaml
@@ -4,8 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-description:
-  Microchip MPFS I2C Controller Device Tree Bindings
+description: Microchip MPFS I2C Controller
 
 compatible: "microchip,mpfs-i2c"
 

--- a/dts/bindings/i2c/nuvoton,npcx-i2c-ctrl.yaml
+++ b/dts/bindings/i2c/nuvoton,npcx-i2c-ctrl.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2020 Nuvoton Technology Corporation.
 # SPDX-License-Identifier: Apache-2.0
 
-description: Nuvoton, NPCX-I2C controller node
+description: Nuvoton NPCX-I2C controller
 
 compatible: "nuvoton,npcx-i2c-ctrl"
 

--- a/dts/bindings/i2c/nuvoton,npcx-i2c-port.yaml
+++ b/dts/bindings/i2c/nuvoton,npcx-i2c-port.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2020 Nuvoton Technology Corporation.
 # SPDX-License-Identifier: Apache-2.0
 
-description: Nuvoton, NPCX-I2C port pads node
+description: Nuvoton NPCX-I2C port pads
 
 compatible: "nuvoton,npcx-i2c-port"
 

--- a/dts/bindings/i2c/nxp,ii2c.yaml
+++ b/dts/bindings/i2c/nxp,ii2c.yaml
@@ -1,7 +1,7 @@
 # Copyright 2024-2025 NXP
 # SPDX-License-Identifier: Apache-2.0
 
-description: NXP II2C node
+description: NXP II2C
 
 compatible: "nxp,ii2c"
 

--- a/dts/bindings/i2c/nxp,kinetis-i2c.yaml
+++ b/dts/bindings/i2c/nxp,kinetis-i2c.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2017 Linaro Limited
 # SPDX-License-Identifier: Apache-2.0
 
-description: Kinetis I2C node
+description: Kinetis I2C
 
 compatible: "nxp,kinetis-i2c"
 

--- a/dts/bindings/i2c/nxp,lpc-i2c.yaml
+++ b/dts/bindings/i2c/nxp,lpc-i2c.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2019 NXP
 # SPDX-License-Identifier: Apache-2.0
 
-description: LPC I2C node
+description: LPC I2C
 
 compatible: "nxp,lpc-i2c"
 

--- a/dts/bindings/i2c/silabs,gecko-i2c.yaml
+++ b/dts/bindings/i2c/silabs,gecko-i2c.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2018 Diego Sueiro <diego.sueiro@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
 
-description: Silabs Gecko I2C node
+description: Silabs Gecko I2C
 
 compatible: "silabs,gecko-i2c"
 

--- a/dts/bindings/i2c/snps,designware-i2c.yaml
+++ b/dts/bindings/i2c/snps,designware-i2c.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2018 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-description: Synopsys DesignWare I2C node
+description: Synopsys DesignWare I2C
 
 compatible: "snps,designware-i2c"
 

--- a/dts/bindings/i2c/ti,cc13xx-cc26xx-i2c.yaml
+++ b/dts/bindings/i2c/ti,cc13xx-cc26xx-i2c.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2019 Brett Witherspoon
 # SPDX-License-Identifier: Apache-2.0
 
-description: TI CC13xx / CC26xx I2C node
+description: TI CC13xx / CC26xx I2C
 
 compatible: "ti,cc13xx-cc26xx-i2c"
 

--- a/dts/bindings/i2c/ti,tca9544a.yaml
+++ b/dts/bindings/i2c/ti,tca9544a.yaml
@@ -1,6 +1,6 @@
 # Binding for TI TCA9544A, compatible with NXP PCA9544A
 
-description: Texas Instruments TCA9544A binding
+description: Texas Instruments TCA9544A
 
 compatible: "ti,tca9544a"
 

--- a/dts/bindings/i2c/ti,tca9546a.yaml
+++ b/dts/bindings/i2c/ti,tca9546a.yaml
@@ -1,6 +1,6 @@
 # Binding for TI TCA9546A, compatible with NXP PCA9546A
 
-description: Texas Instruments TCA9546A binding
+description: Texas Instruments TCA9546A
 
 compatible: "ti,tca9546a"
 

--- a/dts/bindings/i2c/ti,tca9548a.yaml
+++ b/dts/bindings/i2c/ti,tca9548a.yaml
@@ -1,6 +1,6 @@
 # Binding for TI TCA9548A, compatible with NXP PCA9548A
 
-description: Texas Instruments TCA9548A binding
+description: Texas Instruments TCA9548A
 
 compatible: "ti,tca9548a"
 


### PR DESCRIPTION
Remove redundant descriptions in I2C bindings, such as "This is a representation of" and "... node".