### PR TITLE
dts: mbox: Simplify the description of the binding

### DIFF
--- a/dts/bindings/mbox/andestech,mbox-plic-sw.yaml
+++ b/dts/bindings/mbox/andestech,mbox-plic-sw.yaml
@@ -4,8 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-description: |
-  This is a representation of AndesTech MBOX PLIC-SW node
+description: AndesTech MBOX PLIC-SW
 
 compatible: "andestech,mbox-plic-sw"
 

--- a/dts/bindings/mbox/espressif,mbox-esp32.yaml
+++ b/dts/bindings/mbox/espressif,mbox-esp32.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Felipe Neves
 # SPDX-License-Identifier: Apache-2.0
 
-description: ESP32 soft mailbox bindings
+description: ESP32 soft mailbox
 
 compatible: "espressif,mbox-esp32"
 

--- a/dts/bindings/mbox/linaro,ivshmem-mbox.yaml
+++ b/dts/bindings/mbox/linaro,ivshmem-mbox.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Felipe Neves
 # SPDX-License-Identifier: Apache-2.0
 
-description: Inter VM shared memory based mailbox binding
+description: Inter VM shared memory based mailbox
 
 compatible: "linaro,ivshmem-mbox"
 


### PR DESCRIPTION
Remove redundant descriptions in MBOX bindings, such as "This is a representation of", "... node" and "... binding".