### PR TITLE
dts: misc: Simplify the description of the binding

### DIFF
--- a/dts/bindings/misc/ene,kb1200-gcfg.yaml
+++ b/dts/bindings/misc/ene,kb1200-gcfg.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 ENE Technology Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-description: ENE, General Configuration node
+description: ENE, General Configuration
 
 compatible: "ene,kb1200-gcfg"
 

--- a/dts/bindings/misc/ene,kb1200-pmu.yaml
+++ b/dts/bindings/misc/ene,kb1200-pmu.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 ENE Technology Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-description: ENE, Power Manager node
+description: ENE, Power Manager
 
 compatible: "ene,kb1200-pmu"
 

--- a/dts/bindings/misc/intel,timeaware-gpio.yaml
+++ b/dts/bindings/misc/intel,timeaware-gpio.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-description: Intel TGPIO node
+description: Intel TGPIO
 
 compatible: "intel,timeaware-gpio"
 

--- a/dts/bindings/misc/nuvoton,npcx-soc-id.yaml
+++ b/dts/bindings/misc/nuvoton,npcx-soc-id.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2021 Nuvoton Technology Corporation.
 # SPDX-License-Identifier: Apache-2.0
 
-description: Nuvoton, NPCX soc ID node
+description: Nuvoton, NPCX soc ID
 
 compatible: "nuvoton,npcx-soc-id"
 

--- a/dts/bindings/misc/nxp,rdc.yaml
+++ b/dts/bindings/misc/nxp,rdc.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-  NXP i.MX Resource Domain Controller (RDC) node.
+  NXP i.MX Resource Domain Controller (RDC).
   The RDC provides robust support for the isolation of destination
   memory mapped locations such as peripherals and memory to a single
   core, a bus master, or set of cores and bus masters.

--- a/dts/bindings/misc/nxp,s32-emios.yaml
+++ b/dts/bindings/misc/nxp,s32-emios.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-  NXP S32 Enhanced Modular IO SubSystem (eMIOS) node for S32 SoCs.
+  Enhanced Modular IO SubSystem (eMIOS) for NXP S32 SoCs.
   eMIOS provides independent unified channels (UCs), some of channels
   have internal counter that either can be used independently or used
   as a reference timebase (master bus) for other channels.

--- a/dts/bindings/misc/nxp,s32-lcu.yaml
+++ b/dts/bindings/misc/nxp,s32-lcu.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-  NXP S32 Logic control Unit node for S32 SoCs.
+  Logic control Unit for NXP S32 SoCs.
   LCU selects multiple inputs from timers, Pulse Width Modulation
   signals, and Input/Output (I/O) pads, and combines them
   using a programmable logic function to create output waveforms

--- a/dts/bindings/misc/nxp,s32-trgmux.yaml
+++ b/dts/bindings/misc/nxp,s32-trgmux.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-  NXP S32 Trigger Multiplexing Control node for S32 SoCs.
+  Trigger Multiplexing Control for NXP S32 SoCs.
   The device supports the triggering scheme between peripherals.
   The supported trigger sources and destination can be found in
   the device Ref Manual

--- a/dts/bindings/misc/zephyr,swdp-gpio.yaml
+++ b/dts/bindings/misc/zephyr,swdp-gpio.yaml
@@ -3,8 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-  This is a representation of the Serial Wire Debug Port interface
-  implementation by GPIO bit-banging.
+  Serial Wire Debug Port interface implementation by GPIO bit-banging.
 
   Schematic using dual-supply bus transceiver and separate dout and dnoe pins
 


### PR DESCRIPTION
Remove redundant descriptions in MISC bindings, such as "This is a representation of" and "... node".