### PR TITLE
dts: net: wireless: Simplify the description of the binding

### DIFF
--- a/dts/bindings/net/wireless/generic-fem-two-ctrl-pins.yaml
+++ b/dts/bindings/net/wireless/generic-fem-two-ctrl-pins.yaml
@@ -2,8 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-    This is a representation of generic radio Front-End Module (FEM)
-    that has a two-pin control interface (CTX, CRX).
+    Generic radio Front-End Module (FEM) with a two-pin
+    control interface (CTX, CRX).
 
     The CTX control pin is used to enable the Power Amplifier (PA) in
     the transmit path. This is therefore sometimes referred to as

--- a/dts/bindings/net/wireless/nordic,nrf21540-fem.yaml
+++ b/dts/bindings/net/wireless/nordic,nrf21540-fem.yaml
@@ -3,7 +3,7 @@
 
 
 description: |
-    This is a representation of the nRF21540 Radio Front-End module.
+    nRF21540 Radio Front-End module.
 
     See the "nordic,nrf21540-fem-spi" binding to configure the SPI
     interface. The SPI interface should be configured as a child node

--- a/dts/bindings/net/wireless/ti,cc13xx-cc26xx-radio.yaml
+++ b/dts/bindings/net/wireless/ti,cc13xx-cc26xx-radio.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2022 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-description: TI SimpleLink CC13xx / CC26xx radio node
+description: TI SimpleLink CC13xx / CC26xx radio
 
 compatible: "ti,cc13xx-cc26xx-radio"
 


### PR DESCRIPTION
Remove redundant descriptions in net/wireless bindings, such as "This is a representation of" and "... node".