### PR TITLE
Driver: HCI: set BT_NXP_NW612 as default

### DIFF
--- a/drivers/bluetooth/hci/Kconfig.nxp
+++ b/drivers/bluetooth/hci/Kconfig.nxp
@@ -71,6 +71,12 @@ endif # BT_NXP
 
 if BT_H4_NXP_CTLR
 
+choice BT_NXP_MODULE
+	# All NXP Bluetooth modules controlled by BT_H4_NXP_CTLR should be added to this section
+	# similar with BT_NXP_NW612.
+	prompt "NXP Bluetooth Module"
+	default BT_NXP_NW612
+
 config BT_NXP_NW612
 	bool "NW612 firmware for NXP IW612 Chipset"
 	help
@@ -82,5 +88,7 @@ config BT_NXP_NW612
 	  wireless-connectivity/wi-fi-plus-bluetooth-plus-802-15-4/2-4-5-ghz-
 	  dual-band-1x1-wi-fi-6-802-11ax-plus-bluetooth-5-4-plus-802-15-4-tri-
 	  radio-solution:IW612.
+
+endchoice # BT_NXP_MODULE
 
 endif # BT_H4_NXP_CTLR


### PR DESCRIPTION
Add a choice `BT_NXP_MODULE` to make sure only one controller can be selected if the multiple controllers are supported.

And set the BT_NXP_NW612 as the default controller.