### PR TITLE
boards: adafruit: fix reversed rel wheel events on Macropad RP2040

### DIFF
--- a/boards/adafruit/macropad_rp2040/adafruit_macropad_rp2040.dts
+++ b/boards/adafruit/macropad_rp2040/adafruit_macropad_rp2040.dts
@@ -112,12 +112,18 @@
 
 	encoder {
 		compatible = "gpio-qdec";
-		gpios = <&gpio0 17 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>,
-			<&gpio0 18 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+		gpios = <&gpio0 18 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>,
+			<&gpio0 17 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
 		zephyr,axis = <INPUT_REL_WHEEL>;
 		steps-per-period = <4>;
 		sample-time-us = <2000>;
 		idle-timeout-ms = <200>;
+	};
+
+	lvgl_encoder_input {
+		compatible = "zephyr,lvgl-encoder-input";
+		rotation-input-code = <INPUT_REL_WHEEL>;
+		button-input-code = <INPUT_KEY_ENTER>;
 	};
 
 	stemma_connector: stemma_connector {

--- a/boards/adafruit/macropad_rp2040/doc/index.rst
+++ b/boards/adafruit/macropad_rp2040/doc/index.rst
@@ -30,59 +30,7 @@ Hardware
 Supported Features
 ******************
 
-The ``adafruit_macropad_rp2040`` board target supports the following hardware features:
-
-.. list-table::
-   :header-rows: 1
-
-   * - Peripheral
-     - Kconfig option
-     - Devicetree compatible
-   * - NVIC
-     - N/A
-     - :dtcompatible:`arm,v6m-nvic`
-   * - UART
-     - :kconfig:option:`CONFIG_SERIAL`
-     - :dtcompatible:`raspberrypi,pico-uart`
-   * - GPIO
-     - :kconfig:option:`CONFIG_GPIO`
-     - :dtcompatible:`raspberrypi,pico-gpio`
-   * - ADC
-     - :kconfig:option:`CONFIG_ADC`
-     - :dtcompatible:`raspberrypi,pico-adc`
-   * - I2C
-     - :kconfig:option:`CONFIG_I2C`
-     - :dtcompatible:`snps,designware-i2c`
-   * - SPI
-     - :kconfig:option:`CONFIG_SPI`
-     - :dtcompatible:`raspberrypi,pico-spi`
-   * - USB Device
-     - :kconfig:option:`CONFIG_USB_DEVICE_STACK`
-     - :dtcompatible:`raspberrypi,pico-usbd`
-   * - HWINFO
-     - :kconfig:option:`CONFIG_HWINFO`
-     - N/A
-   * - Watchdog Timer (WDT)
-     - :kconfig:option:`CONFIG_WATCHDOG`
-     - :dtcompatible:`raspberrypi,pico-watchdog`
-   * - PWM
-     - :kconfig:option:`CONFIG_PWM`
-     - :dtcompatible:`raspberrypi,pico-pwm`
-   * - Flash
-     - :kconfig:option:`CONFIG_FLASH`
-     - :dtcompatible:`raspberrypi,pico-flash-controller`
-   * - UART (PIO)
-     - :kconfig:option:`CONFIG_SERIAL`
-     - :dtcompatible:`raspberrypi,pico-uart-pio`
-   * - Display
-     - :kconfig:option:`CONFIG_DISPLAY`
-     - :dtcompatible:`sinowealth,sh1106`
-   * - LED Strip (12 pixels)
-     - :kconfig:option:`CONFIG_LED_STRIP`
-     - :dtcompatible:`worldsemi,ws2812-rpi_pico-pio`
-   * - Rotary Encoder
-     - :kconfig:option:`CONFIG_INPUT`
-     - :dtcompatible:`gpio-qdec`
+.. zephyr:board-supported-hw::
 
 Programming and Debugging
 *************************


### PR DESCRIPTION
Inverts the two rotA/rotB GPIOs so that the direction of the rel wheel events is correct.

Also adds a zephyr,lvgl-encoder-input node to make the encoder available to LVGL users.
