### PR TITLE
drivers: mipi_dsi: add mipi msg flags input for mipi_dsi api

### DIFF
--- a/drivers/display/display_ili9806e_dsi.c
+++ b/drivers/display/display_ili9806e_dsi.c
@@ -212,7 +212,7 @@ static int ili9806e_write_reg(const struct device *dev, uint8_t reg, const uint8
 	int ret;
 	const struct ili9806e_config *cfg = dev->config;
 
-	ret = mipi_dsi_dcs_write(cfg->mipi_dsi, cfg->channel, reg, buf, len);
+	ret = mipi_dsi_dcs_write(cfg->mipi_dsi, cfg->channel, reg, buf, len, MIPI_DSI_MSG_USE_LPM);
 	if (ret < 0) {
 		LOG_ERR("Failed writing reg: 0x%x result: (%d)", reg, ret);
 		return ret;

--- a/drivers/mipi_dsi/mipi_dsi.c
+++ b/drivers/mipi_dsi/mipi_dsi.c
@@ -8,15 +8,15 @@
 
 #include <zephyr/drivers/mipi_dsi.h>
 
-ssize_t mipi_dsi_generic_read(const struct device *dev, uint8_t channel,
-			      const void *params, size_t nparams,
-			      void *buf, size_t len)
+ssize_t mipi_dsi_generic_read(const struct device *dev, uint8_t channel, const void *params,
+			      size_t nparams, void *buf, size_t len, uint16_t flags)
 {
 	struct mipi_dsi_msg msg = {
 		.tx_len = nparams,
 		.tx_buf = params,
 		.rx_len = len,
-		.rx_buf = buf
+		.rx_buf = buf,
+		.flags = flags,
 	};
 
 	switch (nparams) {
@@ -39,12 +39,13 @@ ssize_t mipi_dsi_generic_read(const struct device *dev, uint8_t channel,
 	return mipi_dsi_transfer(dev, channel, &msg);
 }
 
-ssize_t mipi_dsi_generic_write(const struct device *dev, uint8_t channel,
-			       const void *buf, size_t len)
+ssize_t mipi_dsi_generic_write(const struct device *dev, uint8_t channel, const void *buf,
+			       size_t len, uint16_t flags)
 {
 	struct mipi_dsi_msg msg = {
 		.tx_buf = buf,
-		.tx_len = len
+		.tx_len = len,
+		.flags = flags,
 	};
 
 	switch (len) {
@@ -68,26 +69,28 @@ ssize_t mipi_dsi_generic_write(const struct device *dev, uint8_t channel,
 	return mipi_dsi_transfer(dev, channel, &msg);
 }
 
-ssize_t mipi_dsi_dcs_read(const struct device *dev, uint8_t channel,
-			  uint8_t cmd, void *buf, size_t len)
+ssize_t mipi_dsi_dcs_read(const struct device *dev, uint8_t channel, uint8_t cmd, void *buf,
+			  size_t len, uint16_t flags)
 {
 	struct mipi_dsi_msg msg = {
 		.type = MIPI_DSI_DCS_READ,
 		.cmd = cmd,
 		.rx_buf = buf,
-		.rx_len = len
+		.rx_len = len,
+		.flags = flags,
 	};
 
 	return mipi_dsi_transfer(dev, channel, &msg);
 }
 
-ssize_t mipi_dsi_dcs_write(const struct device *dev, uint8_t channel,
-			   uint8_t cmd, const void *buf, size_t len)
+ssize_t mipi_dsi_dcs_write(const struct device *dev, uint8_t channel, uint8_t cmd, const void *buf,
+			   size_t len, uint16_t flags)
 {
 	struct mipi_dsi_msg msg = {
 		.cmd = cmd,
 		.tx_buf = buf,
-		.tx_len = len
+		.tx_len = len,
+		.flags = flags,
 	};
 
 	switch (len) {

--- a/include/zephyr/drivers/mipi_dsi.h
+++ b/include/zephyr/drivers/mipi_dsi.h
@@ -173,12 +173,12 @@ static inline ssize_t mipi_dsi_transfer(const struct device *dev,
  * @param nparams Number of parameters.
  * @param buf Buffer where read data will be stored.
  * @param len Length of the reception buffer.
+ * @param flags Flags controlling message transmission.
  *
  * @return Size of the read data on success, negative on error.
  */
-ssize_t mipi_dsi_generic_read(const struct device *dev, uint8_t channel,
-			      const void *params, size_t nparams,
-			      void *buf, size_t len);
+ssize_t mipi_dsi_generic_read(const struct device *dev, uint8_t channel, const void *params,
+			      size_t nparams, void *buf, size_t len, uint16_t flags);
 
 /**
  * @brief MIPI-DSI generic write.
@@ -186,12 +186,13 @@ ssize_t mipi_dsi_generic_read(const struct device *dev, uint8_t channel,
  * @param dev MIPI-DSI host device.
  * @param channel Device channel (VID).
  * @param buf Transmission buffer.
- * @param len Length of the transmission buffer
+ * @param len Length of the transmission buffer.
+ * @param flags Flags controlling message transmission.
  *
  * @return Size of the written data on success, negative on error.
  */
-ssize_t mipi_dsi_generic_write(const struct device *dev, uint8_t channel,
-			       const void *buf, size_t len);
+ssize_t mipi_dsi_generic_write(const struct device *dev, uint8_t channel, const void *buf,
+			       size_t len, uint16_t flags);
 
 /**
  * @brief MIPI-DSI DCS read.
@@ -201,11 +202,12 @@ ssize_t mipi_dsi_generic_write(const struct device *dev, uint8_t channel,
  * @param cmd DCS command.
  * @param buf Buffer where read data will be stored.
  * @param len Length of the reception buffer.
+ * @param flags Flags controlling message transmission.
  *
  * @return Size of the read data on success, negative on error.
  */
-ssize_t mipi_dsi_dcs_read(const struct device *dev, uint8_t channel,
-			  uint8_t cmd, void *buf, size_t len);
+ssize_t mipi_dsi_dcs_read(const struct device *dev, uint8_t channel, uint8_t cmd, void *buf,
+			  size_t len, uint16_t flags);
 
 /**
  * @brief MIPI-DSI DCS write.
@@ -214,13 +216,13 @@ ssize_t mipi_dsi_dcs_read(const struct device *dev, uint8_t channel,
  * @param channel Device channel (VID).
  * @param cmd DCS command.
  * @param buf Transmission buffer.
- * @param len Length of the transmission buffer
+ * @param len Length of the transmission buffer.
+ * @param flags Flags controlling message transmission.
  *
  * @return Size of the written data on success, negative on error.
  */
-ssize_t mipi_dsi_dcs_write(const struct device *dev, uint8_t channel,
-			   uint8_t cmd, const void *buf, size_t len);
-
+ssize_t mipi_dsi_dcs_write(const struct device *dev, uint8_t channel, uint8_t cmd, const void *buf,
+			   size_t len, uint16_t flags);
 
 /**
  * @brief Detach a device from the MIPI-DSI bus

--- a/tests/drivers/mipi_dsi/api/src/main.c
+++ b/tests/drivers/mipi_dsi/api/src/main.c
@@ -26,23 +26,22 @@ ZTEST(mipi_dsi_api, test_generic)
 	ssize_t ret;
 
 	param[0] = MIPI_DCS_SET_DISPLAY_ON;
-	ret = mipi_dsi_generic_write(mipi_dev, CONFIG_MIPI_DSI_TEST_CHANNEL, param, 1);
+	ret = mipi_dsi_generic_write(mipi_dev, CONFIG_MIPI_DSI_TEST_CHANNEL, param, 1, 0);
 	zassert(ret >= 0, "Failed to write", NULL);
 
 	param[0] = MIPI_DCS_SET_DISPLAY_BRIGHTNESS;
 	param[1] = 200;
-	ret = mipi_dsi_generic_write(mipi_dev, CONFIG_MIPI_DSI_TEST_CHANNEL, param, 2);
+	ret = mipi_dsi_generic_write(mipi_dev, CONFIG_MIPI_DSI_TEST_CHANNEL, param, 2, 0);
 	zassert(ret >= 0, "Failed to write", NULL);
 
 	memset(rx_buf, 0, sizeof(rx_buf));
 
 	param[0] = MIPI_DCS_GET_DISPLAY_BRIGHTNESS;
-	ret = mipi_dsi_generic_read(mipi_dev, CONFIG_MIPI_DSI_TEST_CHANNEL, param, 1, rx_buf, 2);
+	ret = mipi_dsi_generic_read(mipi_dev, CONFIG_MIPI_DSI_TEST_CHANNEL, param, 1, rx_buf, 2, 0);
 
 	if (ret != -ENOTSUP) {
 		zassert(ret >= 0, "Failed to do a generic read", NULL);
 	}
-
 }
 
 /**
@@ -54,20 +53,20 @@ ZTEST(mipi_dsi_api, test_dcs)
 	uint8_t param[2];
 	ssize_t ret;
 
-	ret = mipi_dsi_dcs_write(mipi_dev, CONFIG_MIPI_DSI_TEST_CHANNEL,
-				 MIPI_DCS_SET_DISPLAY_ON, NULL, 0);
+	ret = mipi_dsi_dcs_write(mipi_dev, CONFIG_MIPI_DSI_TEST_CHANNEL, MIPI_DCS_SET_DISPLAY_ON,
+				 NULL, 0, 0);
 	zassert(ret >= 0, "Failed to write", NULL);
 
 	param[0] = 200;
 	ret = mipi_dsi_dcs_write(mipi_dev, CONFIG_MIPI_DSI_TEST_CHANNEL,
-				 MIPI_DCS_SET_DISPLAY_BRIGHTNESS, param, 1);
+				 MIPI_DCS_SET_DISPLAY_BRIGHTNESS, param, 1, 0);
 	zassert(ret >= 0, "Failed to write", NULL);
 
 	memset(rx_buf, 0, sizeof(rx_buf));
 
 	param[0] = MIPI_DCS_GET_DISPLAY_BRIGHTNESS;
 	ret = mipi_dsi_dcs_read(mipi_dev, CONFIG_MIPI_DSI_TEST_CHANNEL,
-				MIPI_DCS_GET_DISPLAY_BRIGHTNESS, rx_buf, 2);
+				MIPI_DCS_GET_DISPLAY_BRIGHTNESS, rx_buf, 2, 0);
 
 	if (ret != -ENOTSUP) {
 		zassert(ret >= 0, "Failed to do a dcs read", NULL);


### PR DESCRIPTION
The `mipi_dsi_*_read/write` currently does not provide message flags for mipi_dsi_transfer, which prevents devices that need to transmit/receive LP messages from using APIs other than mipi_dsi_transfer.

This PR is to improve the mipi_dsi API by adding an additional message flag input parameter for the `mipi_dsi_*_read/write`.