### PR TITLE
arm64: reset: disable cache and MMU for safety

### DIFF
--- a/arch/arm64/core/reset.S
+++ b/arch/arm64/core/reset.S
@@ -58,9 +58,10 @@ SECTION_SUBSEC_FUNC(TEXT,_reset_section,__reset_prep_c)
 	b	out
 #endif /* CONFIG_ARMV8_R */
 2:
-	/* Disable alignment fault checking */
+	/* Disable alignment fault checking, disable D-Cache, I-Cache, MMU for safety */
 	mrs	x0, sctlr_el2
-	bic	x0, x0, SCTLR_A_BIT
+	mov	x1, #(SCTLR_A_BIT | SCTLR_C_BIT | SCTLR_M_BIT | SCTLR_I_BIT)
+	bic	x0, x0, x1
 	msr	sctlr_el2, x0
 	isb
 


### PR DESCRIPTION
When Zephyr boot from EL2, D-Cache, I-Cache and MMU should be disabled by default, but in some cases, for example use U-Boot "go" command to boot Zephyr Image, Cache and MMU are already been enabled by U-Boot. So disable them at reset code to make it safety when the code goes into C code.