### PR TITLE
sys_clock: header: fix typo in NSEC_PER_USEC comment

### DIFF
--- a/include/zephyr/sys_clock.h
+++ b/include/zephyr/sys_clock.h
@@ -79,7 +79,7 @@ typedef struct {
  */
 #define K_TIMEOUT_EQ(a, b) ((a).ticks == (b).ticks)
 
-/** number of nanoseconds per micorsecond */
+/** number of nanoseconds per microsecond */
 #define NSEC_PER_USEC 1000U
 
 /** number of nanoseconds per millisecond */


### PR DESCRIPTION
Commit c910dc81a614("sys_clock: header: minor cleanup and doxygenization") introduced a typo in the documentation comment above NSEC_PER_USEC.  Fix that.