### PR TITLE
manifest: Update nRF hw models to latest

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -318,7 +318,7 @@ manifest:
       groups:
         - tools
     - name: nrf_hw_models
-      revision: 73a5d5827a94820be65b7d276d28173ec10bab9f
+      revision: b84bd7314a239f818e78f6927f5673247816df53
       path: modules/bsim_hw_models/nrf_hw_models
     - name: nrf_wifi
       revision: e35f707a782b7c4c0eb83a3b06ca4e6eb693f29f


### PR DESCRIPTION
Update the HW models module to:
b84bd7314a239f818e78f6927f5673247816df53

Including the following:
b84bd73 UART PTY backend: Correct a few comments
f945d62 RADIO 54: Fix reset value of TIMING register
9fd4133 MDK nrfx_erratas.h: Ensure backwards compatibility with old nrfx versions
85061b1 MDK: Provide empty replacement for nrf_erratas.h
