### PR TITLE
boards: s32z: improve boards docs

### DIFF
--- a/boards/nxp/s32z2xxdc2/doc/index.rst
+++ b/boards/nxp/s32z2xxdc2/doc/index.rst
@@ -64,6 +64,10 @@ The boards support the following hardware features:
 +-----------+------------+-------------------------------------+
 | QSPI      | on-chip    | flash                               |
 +-----------+------------+-------------------------------------+
+| STM       | on-chip    | counter                             |
++-----------+------------+-------------------------------------+
+| PIT       | on-chip    | counter                             |
++-----------+------------+-------------------------------------+
 
 Other hardware features are not currently supported by the port.
 
@@ -242,13 +246,11 @@ the terminal:
 
    Hello World! s32z2xxdc2
 
-To debug with Lauterbach TRACE32 softare run instead:
+To debug with Lauterbach TRACE32 software run instead:
 
-.. zephyr-app-commands::
-   :zephyr-app: samples/hello_world
-   :board: s32z2xxdc2/s32z270/rtu0
-   :goals: build debug -r trace32
-   :compact:
+.. code-block:: console
+
+   west debug -r trace32
 
 Flashing
 ========
@@ -261,7 +263,8 @@ SRAM and run.
 .. zephyr-app-commands::
    :zephyr-app: samples/hello_world
    :board: s32z2xxdc2/s32z270/rtu0
-   :goals: build flash -r trace32
+   :goals: build flash
+   :flash-args: -r trace32
    :compact:
 
 .. note::
@@ -273,11 +276,9 @@ SRAM and run.
 To imitate a similar behavior using NXP S32 Debug Probe runner, you can run the
 ``debug`` command with GDB in batch mode:
 
-.. zephyr-app-commands::
-   :zephyr-app: samples/hello_world
-   :board: s32z2xxdc2/s32z270/rtu0
-   :goals: build debug --tool-opt='--batch'
-   :compact:
+.. code-block:: console
+
+   west debug --tool-opt='--batch'
 
 RTU and Core Configuration
 ==========================
@@ -334,7 +335,7 @@ line:
 
 .. code-block:: console
 
-   west debug --startup-args elfFile=<elf_path> rtu=<rtu_id> core=<core_id> lockstep=<yes/no>
+   west debug -r trace32 --startup-args elfFile=<elf_path> rtu=<rtu_id> core=<core_id> lockstep=<yes/no>
 
 Where ``<elf_path>`` is the path to the Zephyr application ELF in the output
 directory.


### PR DESCRIPTION
Document missing supported features and correct the commands used for west flash/debug.