### PR TITLE
boards: nordic: nrf54l15dk: Fix wrong cpuflpr build command

### DIFF
--- a/boards/nordic/nrf54l15dk/doc/index.rst
+++ b/boards/nordic/nrf54l15dk/doc/index.rst
@@ -97,14 +97,13 @@ built, flashed, and debugged in the usual way. See
 building and running.
 
 Applications for the ``nrf54l15dk/nrf54l15/cpuflpr`` board target need
-to be built as multicore configuration with code snippet called ``vpr_launcher``
-for the application core.
+to be built using sysbuild to include the ``vpr_launcher`` image for the application core.
 
 Enter the following command to compile ``hello_world`` for the FLPR core:
 
 .. code-block:: console
 
-   west build -p -b nrf54l15dk/nrf54l15/cpuflpr --sysbuild -- -DSB_VPR_LAUNCHER=y
+   west build -p -b nrf54l15dk/nrf54l15/cpuflpr --sysbuild
 
 
 Flashing


### PR DESCRIPTION
Fixes an issue with a build command that is wrong and removes outdated information