### PR TITLE
soc: amd: acp_6_0: Fix bleeding Kconfig

### DIFF
--- a/soc/amd/acp_6_0/Kconfig.soc
+++ b/soc/amd/acp_6_0/Kconfig.soc
@@ -3,7 +3,6 @@
 
 config SOC_ACP_6_0
 	bool
-	default "BOARD_ACP_6_0_ADSP"
 
 config SOC
 	default "acp_6_0" if SOC_ACP_6_0


### PR DESCRIPTION
Fixes a wrongly defined Kconfig