### PR TITLE
net: mdns: adding option for custom mDNS addressing

### DIFF
--- a/subsys/net/lib/dns/Kconfig
+++ b/subsys/net/lib/dns/Kconfig
@@ -175,6 +175,19 @@ config MDNS_RESPONDER
 
 if MDNS_RESPONDER
 
+config MDNS_RESPONDER_PORT
+	int "Multicast/UDP port for mDNS"
+	default 5353
+	help
+	  RFC6732 assigned port is 5353, but in case some wants to divert.
+
+config MDNS_RESPONDER_MCAST_IP
+	int "The lower 16 bits for the multicast IP address"
+	default 251
+	help
+	  RFC6732 assigned lower bits are 251, but in case some wants to divert.
+	  It will change the well-known address ff02::fb and 224.0.0.251.
+
 config MDNS_RESPONDER_TTL
 	int "Time-to-Live of returned DNS name"
 	default 600

--- a/subsys/net/lib/dns/mdns_responder.c
+++ b/subsys/net/lib/dns/mdns_responder.c
@@ -52,7 +52,7 @@ LOG_MODULE_REGISTER(net_mdns_responder, CONFIG_MDNS_RESPONDER_LOG_LEVEL);
 
 extern void dns_dispatcher_svc_handler(struct net_socket_service_event *pev);
 
-#define MDNS_LISTEN_PORT 5353
+#define MDNS_LISTEN_PORT CONFIG_MDNS_RESPONDER_PORT
 
 #define MDNS_TTL CONFIG_MDNS_RESPONDER_TTL /* In seconds */
 
@@ -127,7 +127,7 @@ static void create_ipv6_addr(struct sockaddr_in6 *addr)
 
 	/* Well known IPv6 ff02::fb address */
 	net_ipv6_addr_create(&addr->sin6_addr,
-			     0xff02, 0, 0, 0, 0, 0, 0, 0x00fb);
+			     0xff02, 0, 0, 0, 0, 0, 0, CONFIG_MDNS_RESPONDER_MCAST_IP & 0xFFFF);
 }
 
 static void create_ipv4_addr(struct sockaddr_in *addr)
@@ -136,7 +136,7 @@ static void create_ipv4_addr(struct sockaddr_in *addr)
 	addr->sin_port = htons(MDNS_LISTEN_PORT);
 
 	/* Well known IPv4 224.0.0.251 address */
-	addr->sin_addr.s_addr = htonl(0xE00000FB);
+	addr->sin_addr.s_addr = htonl(0xE0000000 | (CONFIG_MDNS_RESPONDER_MCAST_IP & 0xFFFF));
 }
 
 #if defined(CONFIG_MDNS_RESPONDER_PROBE)


### PR DESCRIPTION
For applications which want to use a similar discovery as mDNS but want to keep it private, a custom multicast port and address can be selected.

In large systems with many consumer applications, a mDNS resolver could get flooded with requests, resulting in poor performance. This patch would allow to make use of the same tools but maintain protected from flooding by third party devices.