### PR TITLE
wifi: fix -Wignored-qualifiers warning

### DIFF
--- a/include/zephyr/net/wifi.h
+++ b/include/zephyr/net/wifi.h
@@ -295,7 +295,7 @@ enum wifi_frequency_bandwidths {
 	WIFI_FREQ_BANDWIDTH_UNKNOWN
 };
 
-const char *const wifi_bandwidth_txt(enum wifi_frequency_bandwidths bandwidth);
+const char *wifi_bandwidth_txt(enum wifi_frequency_bandwidths bandwidth);
 
 /** Max SSID length */
 #define WIFI_SSID_MAX_LEN 32

--- a/subsys/net/l2/wifi/wifi_mgmt.c
+++ b/subsys/net/l2/wifi/wifi_mgmt.c
@@ -143,7 +143,7 @@ const char *wifi_band_txt(enum wifi_frequency_bands band)
 	}
 }
 
-const char *const wifi_bandwidth_txt(enum wifi_frequency_bandwidths bandwidth)
+const char *wifi_bandwidth_txt(enum wifi_frequency_bandwidths bandwidth)
 {
 	switch (bandwidth) {
 	case WIFI_FREQ_BANDWIDTH_20MHZ:


### PR DESCRIPTION
Including wifi.h with -Wignored-qualifiers warning enabled gives a warning. Fix this warning

See related similar https://github.com/zephyrproject-rtos/zephyr/pull/82739