### PR TITLE
drivers: counter: Add counter_reset function

### DIFF
--- a/doc/releases/release-notes-4.2.rst
+++ b/doc/releases/release-notes-4.2.rst
@@ -81,6 +81,10 @@ New APIs and options
 
     * :c:func:`bt_le_get_local_features`
 
+* Counter
+
+  * :c:func:`counter_reset`
+
 New Boards
 **********
 

--- a/drivers/counter/counter_native_sim.c
+++ b/drivers/counter/counter_native_sim.c
@@ -124,6 +124,14 @@ static int ctr_get_value(const struct device *dev, uint32_t *ticks)
 	return 0;
 }
 
+static int ctr_reset(const struct device *dev)
+{
+	ARG_UNUSED(dev);
+
+	hw_counter_reset();
+	return 0;
+}
+
 static uint32_t ctr_get_pending_int(const struct device *dev)
 {
 	ARG_UNUSED(dev);
@@ -237,6 +245,7 @@ static DEVICE_API(counter, ctr_api) = {
 	.start = ctr_start,
 	.stop = ctr_stop,
 	.get_value = ctr_get_value,
+	.reset = ctr_reset,
 	.set_alarm = ctr_set_alarm,
 	.cancel_alarm = ctr_cancel_alarm,
 	.set_top_value = ctr_set_top_value,

--- a/drivers/counter/counter_nrfx_timer.c
+++ b/drivers/counter/counter_nrfx_timer.c
@@ -152,6 +152,14 @@ static int get_value(const struct device *dev, uint32_t *ticks)
 	return 0;
 }
 
+static int reset(const struct device *dev)
+{
+	const struct counter_nrfx_config *config = dev->config;
+
+	nrf_timer_task_trigger(config->timer, NRF_TIMER_TASK_CLEAR);
+	return 0;
+}
+
 static uint32_t ticks_add(uint32_t val1, uint32_t val2, uint32_t top)
 {
 	uint32_t to_top;
@@ -446,6 +454,7 @@ static DEVICE_API(counter, counter_nrfx_driver_api) = {
 	.start = start,
 	.stop = stop,
 	.get_value = get_value,
+	.reset = reset,
 	.set_alarm = set_alarm,
 	.cancel_alarm = cancel_alarm,
 	.set_top_value = set_top_value,

--- a/include/zephyr/drivers/counter.h
+++ b/include/zephyr/drivers/counter.h
@@ -427,7 +427,7 @@ static inline int z_impl_counter_get_value_64(const struct device *dev,
 				(struct counter_driver_api *)dev->api;
 
 	if (!api->get_value_64) {
-		return -ENOTSUP;
+		return -ENOSYS;
 	}
 
 	return api->get_value_64(dev, ticks);
@@ -650,7 +650,7 @@ static inline uint32_t z_impl_counter_get_top_value(const struct device *dev)
  * @param flags		See @ref COUNTER_GUARD_PERIOD_FLAGS.
  *
  * @retval 0 if successful.
- * @retval -ENOTSUP if function or flags are not supported.
+ * @retval -ENOSYS if function or flags are not supported.
  * @retval -EINVAL if ticks value is invalid.
  */
 __syscall int counter_set_guard_period(const struct device *dev,
@@ -664,7 +664,7 @@ static inline int z_impl_counter_set_guard_period(const struct device *dev,
 				(struct counter_driver_api *)dev->api;
 
 	if (!api->set_guard_period) {
-		return -ENOTSUP;
+		return -ENOSYS;
 	}
 
 	return api->set_guard_period(dev, ticks, flags);

--- a/include/zephyr/drivers/counter.h
+++ b/include/zephyr/drivers/counter.h
@@ -215,6 +215,7 @@ typedef int (*counter_api_get_value)(const struct device *dev,
 				     uint32_t *ticks);
 typedef int (*counter_api_get_value_64)(const struct device *dev,
 			uint64_t *ticks);
+typedef int (*counter_api_reset)(const struct device *dev);
 typedef int (*counter_api_set_alarm)(const struct device *dev,
 				     uint8_t chan_id,
 				     const struct counter_alarm_cfg *alarm_cfg);
@@ -236,6 +237,7 @@ __subsystem struct counter_driver_api {
 	counter_api_stop stop;
 	counter_api_get_value get_value;
 	counter_api_get_value_64 get_value_64;
+	counter_api_reset reset;
 	counter_api_set_alarm set_alarm;
 	counter_api_cancel_alarm cancel_alarm;
 	counter_api_set_top_value set_top_value;
@@ -429,6 +431,27 @@ static inline int z_impl_counter_get_value_64(const struct device *dev,
 	}
 
 	return api->get_value_64(dev, ticks);
+}
+
+/**
+ * @brief Reset the counter to the initial value.
+ * @param dev Pointer to the device structure for the driver instance.
+ *
+ * @retval 0 If successful.
+ * @retval -errno Negative error code on failure resetting the counter value.
+ */
+__syscall int counter_reset(const struct device *dev);
+
+static inline int z_impl_counter_reset(const struct device *dev)
+{
+	const struct counter_driver_api *api =
+				(struct counter_driver_api *)dev->api;
+
+	if (!api->reset) {
+		return -ENOSYS;
+	}
+
+	return api->reset(dev);
 }
 
 /**

--- a/tests/drivers/counter/counter_basic_api/src/test_counter.c
+++ b/tests/drivers/counter/counter_basic_api/src/test_counter.c
@@ -882,7 +882,7 @@ static bool late_detection_capable(const struct device *dev)
 	int err = counter_set_guard_period(dev, guard,
 					COUNTER_GUARD_PERIOD_LATE_TO_SET);
 
-	if (err == -ENOTSUP) {
+	if (err == -ENOSYS) {
 		return false;
 	}
 


### PR DESCRIPTION
Add a counter_reset function to the counter subsystem
to reset the counter value to zero. Introduce
a reset interface at the driver layer to implement
the counter_reset function.

Closes: #32157