### PR TITLE
boards: microchip: mpfs_icicle: Remove flash from ignore_tags

### DIFF
--- a/boards/microchip/mpfs_icicle/mpfs_icicle_polarfire_e51.yaml
+++ b/boards/microchip/mpfs_icicle/mpfs_icicle_polarfire_e51.yaml
@@ -9,5 +9,4 @@ testing:
   ignore_tags:
     - net
     - bluetooth
-    - flash
 vendor: microchip

--- a/boards/microchip/mpfs_icicle/mpfs_icicle_polarfire_u54.yaml
+++ b/boards/microchip/mpfs_icicle/mpfs_icicle_polarfire_u54.yaml
@@ -9,5 +9,4 @@ testing:
   ignore_tags:
     - net
     - bluetooth
-    - flash
 vendor: microchip

--- a/boards/microchip/mpfs_icicle/mpfs_icicle_polarfire_u54_smp.yaml
+++ b/boards/microchip/mpfs_icicle/mpfs_icicle_polarfire_u54_smp.yaml
@@ -9,5 +9,4 @@ testing:
   ignore_tags:
     - net
     - bluetooth
-    - flash
 vendor: microchip


### PR DESCRIPTION
With a fix from #86246 samples built for mpfs_icicle no longer error on "jedec,spi-nor jedec-id required for non-runtime SFDP".

I ran Zephyr tests in Renode emulator with the fix from #86246 and there were no regressions after removing flash tag.

Depends on #86246.