### PR TITLE
usb: device_next: Do not add serial number without HWINFO

### DIFF
--- a/include/zephyr/usb/usbd.h
+++ b/include/zephyr/usb/usbd.h
@@ -631,6 +631,7 @@ static inline void *usbd_class_get_private(const struct usbd_class_data *const c
  * @param d_name   String descriptor node identifier.
  */
 #define USBD_DESC_SERIAL_NUMBER_DEFINE(d_name)					\
+	BUILD_ASSERT(IS_ENABLED(CONFIG_HWINFO), "HWINFO not enabled");		\
 	static struct usbd_desc_node d_name = {					\
 		.str = {							\
 			.utype = USBD_DUT_STRING_SERIAL_NUMBER,			\

--- a/samples/subsys/usb/common/sample_usbd_init.c
+++ b/samples/subsys/usb/common/sample_usbd_init.c
@@ -36,7 +36,8 @@ USBD_DEVICE_DEFINE(sample_usbd,
 USBD_DESC_LANG_DEFINE(sample_lang);
 USBD_DESC_MANUFACTURER_DEFINE(sample_mfr, CONFIG_SAMPLE_USBD_MANUFACTURER);
 USBD_DESC_PRODUCT_DEFINE(sample_product, CONFIG_SAMPLE_USBD_PRODUCT);
-USBD_DESC_SERIAL_NUMBER_DEFINE(sample_sn);
+IF_ENABLED(CONFIG_HWINFO, (USBD_DESC_SERIAL_NUMBER_DEFINE(sample_sn)));
+
 /* doc string instantiation end */
 
 USBD_DESC_CONFIG_DEFINE(fs_cfg_desc, "FS Configuration");
@@ -116,7 +117,9 @@ struct usbd_context *sample_usbd_setup_device(usbd_msg_cb_t msg_cb)
 		return NULL;
 	}
 
-	err = usbd_add_descriptor(&sample_usbd, &sample_sn);
+	IF_ENABLED(CONFIG_HWINFO, (
+		err = usbd_add_descriptor(&sample_usbd, &sample_sn);
+	))
 	if (err) {
 		LOG_ERR("Failed to initialize SN descriptor (%d)", err);
 		return NULL;

--- a/subsys/usb/device_next/app/cdc_acm_serial.c
+++ b/subsys/usb/device_next/app/cdc_acm_serial.c
@@ -27,7 +27,7 @@ USBD_DEVICE_DEFINE(cdc_acm_serial,
 USBD_DESC_LANG_DEFINE(cdc_acm_serial_lang);
 USBD_DESC_MANUFACTURER_DEFINE(cdc_acm_serial_mfr, CONFIG_CDC_ACM_SERIAL_MANUFACTURER_STRING);
 USBD_DESC_PRODUCT_DEFINE(cdc_acm_serial_product, CONFIG_CDC_ACM_SERIAL_PRODUCT_STRING);
-USBD_DESC_SERIAL_NUMBER_DEFINE(cdc_acm_serial_sn);
+IF_ENABLED(CONFIG_HWINFO, (USBD_DESC_SERIAL_NUMBER_DEFINE(cdc_acm_serial_sn)));
 
 USBD_DESC_CONFIG_DEFINE(fs_cfg_desc, "FS Configuration");
 USBD_DESC_CONFIG_DEFINE(hs_cfg_desc, "HS Configuration");
@@ -95,7 +95,9 @@ static int cdc_acm_serial_init_device(void)
 		return err;
 	}
 
-	err = usbd_add_descriptor(&cdc_acm_serial, &cdc_acm_serial_sn);
+	IF_ENABLED(CONFIG_HWINFO, (
+		err = usbd_add_descriptor(&cdc_acm_serial, &cdc_acm_serial_sn);
+	))
 	if (err) {
 		LOG_ERR("Failed to initialize SN descriptor (%d)", err);
 		return err;

--- a/subsys/usb/device_next/usbd_shell.c
+++ b/subsys/usb/device_next/usbd_shell.c
@@ -43,7 +43,7 @@ static struct usbd_shell_speed {
 USBD_DESC_LANG_DEFINE(lang);
 USBD_DESC_MANUFACTURER_DEFINE(mfr, "ZEPHYR");
 USBD_DESC_PRODUCT_DEFINE(product, "Zephyr USBD foobaz");
-USBD_DESC_SERIAL_NUMBER_DEFINE(sn);
+IF_ENABLED(CONFIG_HWINFO, (USBD_DESC_SERIAL_NUMBER_DEFINE(sn)));
 
 /* Default device descriptors and context used in the shell. */
 USBD_DEVICE_DEFINE(sh_uds_ctx, DEVICE_DT_GET(DT_NODELABEL(zephyr_udc0)),
@@ -117,7 +117,9 @@ static int cmd_usbd_default_strings(const struct shell *sh,
 	err = usbd_add_descriptor(my_uds_ctx, &lang);
 	err |= usbd_add_descriptor(my_uds_ctx, &mfr);
 	err |= usbd_add_descriptor(my_uds_ctx, &product);
-	err |= usbd_add_descriptor(my_uds_ctx, &sn);
+	IF_ENABLED(CONFIG_HWINFO, (
+		err |= usbd_add_descriptor(my_uds_ctx, &sn);
+	))
 
 	if (err) {
 		shell_error(sh, "dev: Failed to add default string descriptors, %d", err);


### PR DESCRIPTION
For many devices iSerialNumber is not required. The only device class currently supported in Zephyr that requires iSerialNumber is MSC. If the serial number is not available then iSerialNumber must be 0. Failure to read the string descriptor for non-zero iSerialNumber fails USB Command Verifier Chapter 9 tests.

When USBD_DESC_SERIAL_NUMBER_DEFINE() was used without CONFIG_HWINFO then it did lead to runtime failure when requesting the string (thus failing certification).

Fail USBD_DESC_SERIAL_NUMBER_DEFINE() at build-time if CONFIG_HWINFO is not set to prevent the surprise at runtime. Only define serial number descriptors if CONFIG_HWINFO is enabled.