### PR TITLE
samples: hello_world: set minimum flash requirement to 16K

### DIFF
--- a/samples/hello_world/sample.yaml
+++ b/samples/hello_world/sample.yaml
@@ -4,6 +4,7 @@ sample:
   name: hello world
 common:
   min_ram: 2
+  min_flash: 16
   tags: introduction
   integration_platforms:
     - native_sim


### PR DESCRIPTION
Default in Twister is 32K, but 16K is a more "reasonable" goal and allows to build hello_world against some of the most constrained boards in-tree.

This allows to check that hello world builds for a few more targets (and effectively allows these to have an accurate list of "supported features"  in the board catalog). Namely, the following board targets are not filtered anymore:

```
2025-02-28 15:01:33,337 - twister - DEBUG - stm32f030_demo/stm32f030x6 samples/hello_world/sample.basic.helloworld        [33mFILTERED[39m: Not enough FLASH
2025-02-28 15:01:33,337 - twister - DEBUG - nucleo_l011k4/stm32l011xx samples/hello_world/sample.basic.helloworld        [33mFILTERED[39m: Not enough FLASH
2025-02-28 15:01:33,337 - twister - DEBUG - ch32v003evt/ch32v003      samples/hello_world/sample.basic.helloworld        [33mFILTERED[39m: Not enough FLASH
```