### PR TITLE
subsys: random: Correct Mutex define

### DIFF
--- a/subsys/random/random_ctr_drbg.c
+++ b/subsys/random/random_ctr_drbg.c
@@ -24,7 +24,7 @@
 static const struct device *entropy_dev;
 static const unsigned char drbg_seed[] = CONFIG_CS_CTR_DRBG_PERSONALIZATION;
 static bool ctr_initialised;
-static struct k_mutex ctr_lock;
+static K_MUTEX_DEFINE(ctr_lock);
 
 static mbedtls_ctr_drbg_context ctr_ctx;
 


### PR DESCRIPTION
Correct Mutex ctr_lock defination as the wrong defination lead to sysworkq task not acquiring this mutex during bt init, which lead to BLE didn't work as described in issue https://github.com/zephyrproject-rtos/zephyr/issues/86444.