### PR TITLE
mbox: temporary workaround for missing ic-msg

### DIFF
--- a/drivers/mbox/mbox_nrf_vevif_task_tx.c
+++ b/drivers/mbox/mbox_nrf_vevif_task_tx.c
@@ -5,12 +5,14 @@
 
 #define DT_DRV_COMPAT nordic_nrf_vevif_task_tx
 
+#include <zephyr/kernel.h>
 #include <zephyr/devicetree.h>
 #include <zephyr/drivers/mbox.h>
 
 #include <haly/nrfy_vpr.h>
 
 #define TASKS_IDX_MAX NRF_VPR_TASKS_TRIGGER_MAX
+#define VEVIF_RETRIGGER_DELAY_USEC 12
 
 struct mbox_vevif_task_tx_conf {
 	NRF_VPR_Type *vpr;
@@ -38,6 +40,12 @@ static int vevif_task_tx_send(const struct device *dev, uint32_t id, const struc
 	}
 
 	nrfy_vpr_task_trigger(config->vpr, nrfy_vpr_trigger_task_get(id));
+
+#ifdef CONFIG_SOC_NRF54H20
+	k_busy_wait(VEVIF_RETRIGGER_DELAY_USEC);
+
+	nrfy_vpr_task_trigger(config->vpr, nrfy_vpr_trigger_task_get(id));
+#endif /* CONFIG_SOC_NRF54H20 */
 
 	return 0;
 }


### PR DESCRIPTION
When a LD sends an ic-msg to SCFW - it happens that sometimes that SCFW does not handle the request.
For the moment the problem is solved by sending a second vevif event shortly after the initial request.