### PR TITLE
Bluetooth: SDP: Ignore the unexpected response

### DIFF
--- a/subsys/bluetooth/host/classic/sdp.c
+++ b/subsys/bluetooth/host/classic/sdp.c
@@ -2117,6 +2117,11 @@ static int sdp_client_receive(struct bt_l2cap_chan *chan, struct net_buf *buf)
 		return 0;
 	}
 
+	if (session->param == NULL) {
+		LOG_WRN("No request in progress");
+		return 0;
+	}
+
 	switch (hdr->op_code) {
 	case BT_SDP_SVC_SEARCH_RSP:
 		return sdp_client_receive_ss(session, buf);


### PR DESCRIPTION
The response should not be handled if there is not a request has been sent.

Ignore the response if the `session->param` is `NULL`.