### PR TITLE
Bluetooth: SDP: Notify upper layer if the response data len is 0

### DIFF
--- a/subsys/bluetooth/host/classic/sdp.c
+++ b/subsys/bluetooth/host/classic/sdp.c
@@ -1857,7 +1857,7 @@ static void sdp_client_notify_result(struct bt_sdp_client *session,
 	uint16_t rec_len;
 	uint8_t user_ret;
 
-	if (state == UUID_NOT_RESOLVED) {
+	if ((state == UUID_NOT_RESOLVED) || (session->rec_buf->len == 0U)) {
 		result.resp_buf = NULL;
 		result.next_record_hint = false;
 		session->param->func(conn, &result, session->param);


### PR DESCRIPTION
In current implementation, the SDP discovery complete event is not notified when the response data length is 0.

Notify the discovery complete event if the response length is 0.