### PR TITLE
drivers: Bluetooth: nxp: not power off BLE controller when bt disable

### DIFF
--- a/drivers/bluetooth/hci/hci_nxp.c
+++ b/drivers/bluetooth/hci/hci_nxp.c
@@ -513,12 +513,6 @@ static int bt_nxp_close(const struct device *dev)
 		if (ret) {
 			LOG_ERR("Failed to reset BLE controller");
 		}
-		k_sleep(K_SECONDS(1));
-
-		ret = PLATFORM_TerminateBle();
-		if (ret < 0) {
-			LOG_ERR("Failed to shutdown BLE controller");
-		}
 	}
 	hci->recv = NULL;
 


### PR DESCRIPTION
remove the power off BLE controller function PLATFORM_TerminateBle() from driver