### PR TITLE
dts/arm/antmicro/myra: add Fujitsu FRAM node

### DIFF
--- a/boards/antmicro/myra_sip_baseboard/myra_sip_baseboard.dts
+++ b/boards/antmicro/myra_sip_baseboard/myra_sip_baseboard.dts
@@ -55,6 +55,7 @@
 		volt-sensor0 = &vref;
 		volt-sensor1 = &vbat;
 		rtc = &rtc;
+		eeprom-0 = &mb85rs1mt;
 	};
 };
 

--- a/boards/antmicro/myra_sip_baseboard/myra_sip_baseboard.yaml
+++ b/boards/antmicro/myra_sip_baseboard/myra_sip_baseboard.yaml
@@ -19,6 +19,7 @@ supported:
   - can
   - rtc
   - sensors
+  - eeprom
 testing:
   timeout_multiplier: 3
   renode:

--- a/dts/arm/antmicro/myra.dtsi
+++ b/dts/arm/antmicro/myra.dtsi
@@ -14,4 +14,12 @@
 		     &spi2_miso_pb14 &spi2_mosi_pb15>;
 	pinctrl-names = "default";
 	status = "okay";
+
+	mb85rs1mt: mb85rs1mt@0 {
+		status = "okay";
+		compatible = "fujitsu,mb85rsxx";
+		reg = <0>;
+		spi-max-frequency = <DT_FREQ_M(25)>;
+		size = <DT_SIZE_K(128)>;
+	};
 };


### PR DESCRIPTION
This PR:
* adds Fujitsu FRAM devicetree node in Myra SiP's devicetree
* adds the Twister `eeprom` test tag in Myra SiP Baseboard supported tags list