### PR TITLE
cmake: linker: dont place device tree memories at absolute addresses

### DIFF
--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -4795,7 +4795,7 @@ function(zephyr_linker_dts_section)
 
   dt_reg_addr(addr PATH ${DTS_SECTION_PATH})
 
-  zephyr_linker_section(NAME ${name} ADDRESS ${addr} VMA ${name} TYPE NOLOAD)
+  zephyr_linker_section(NAME ${name} VMA ${name} TYPE NOLOAD)
 
 endfunction()
 


### PR DESCRIPTION
In CMAKE_LINKER_GENERATOR linker scripts, avoid placing the device tree memories at an absolute address. This avoids placing both `.rom_start` AND `SSRAM1` at the same address on `mps2/an521/cpu0`.

This seems fine according to ld (since one placement is empty) but causes a currently non-suppressable error in IAR linker.

I am a bit unclear about the reason for this construction.
Is it to be able to do attribute(section("SSRAM1")) after having configured the device tree, then that is very handy. But doesn't really require specific ADDRESS.

Or are there use cases I am not thinking about here?