### PR TITLE
iar: toolchain: Implement IAR static init routine

### DIFF
--- a/cmake/linker/iar/linker_flags.cmake
+++ b/cmake/linker/iar/linker_flags.cmake
@@ -4,8 +4,11 @@
 
 # Override the default CMake's IAR ILINK linker signature
 
-string(APPEND CMAKE_C_LINK_FLAGS --no-wrap-diagnostics  )
+string(APPEND CMAKE_C_LINK_FLAGS --no-wrap-diagnostics)
 
+if(CONFIG_IAR_DATA_INIT)
+  string(APPEND CMAKE_C_LINK_FLAGS " --redirect z_data_copy=__iar_data_init3")
+endif()
 foreach(lang C CXX ASM)
   set(commands "--log modules,libraries,initialization,redirects,sections")
   set(CMAKE_${lang}_LINK_EXECUTABLE

--- a/cmake/linker/iar/target.cmake
+++ b/cmake/linker/iar/target.cmake
@@ -10,6 +10,10 @@ find_program(CMAKE_LINKER
   NO_DEFAULT_PATH
 )
 
+if(CONFIG_IAR_DATA_INIT)
+  zephyr_linker_section(NAME .iar.init_table KVMA RAM_REGION GROUP RODATA_REGION)
+endif()
+
 add_custom_target(${IAR_LINKER})
 set(ILINK_THUMB_CALLS_WARNING_SUPPRESSED)
 set(IAR_LIB_USED)
@@ -61,6 +65,8 @@ macro(configure_linker_script linker_script_gen linker_pass_define)
       ${STEERING_FILE_ARG}
       -DCONFIG_LINKER_LAST_SECTION_ID=${CONFIG_LINKER_LAST_SECTION_ID}
       -DCONFIG_LINKER_LAST_SECTION_ID_PATTERN=${CONFIG_LINKER_LAST_SECTION_ID_PATTERN}
+      -DCONFIG_IAR_DATA_INIT=${CONFIG_IAR_DATA_INIT}
+      -DCONFIG_IAR_ZEPHYR_INIT=${CONFIG_IAR_ZEPHYR_INIT}
       -DOUT_FILE=${CMAKE_CURRENT_BINARY_DIR}/${linker_script_gen}
       ${IAR_LIB_USED}
       -P ${ZEPHYR_BASE}/cmake/linker/iar/config_file_script.cmake

--- a/cmake/toolchain/iar/Kconfig
+++ b/cmake/toolchain/iar/Kconfig
@@ -9,7 +9,30 @@ choice LINKER_SCRIPT
 	default CMAKE_LINKER_GENERATOR
 endchoice
 
-menu "IAR library options"
+menu "IAR options"
+
+choice IAR_INIT
+	bool "Static initialization method"
+	depends on XIP
+	default IAR_ZEPHYR_INIT
+
+config IAR_DATA_INIT
+	bool "IAR"
+	select SKIP_BSS_CLEAR # IAR handles zeroing.
+	help
+	  IAR handles initialization of static variables.
+	  Instead of `z_prep_c` calling Zephyrs `z_data_copy`
+	  we call IARs own proprietary initialization method
+	  which can save time and space.
+
+config IAR_ZEPHYR_INIT
+	bool "Zephyr"
+	help
+	  Zephyr handles initialization of static variables.
+	  This is the regular `z_data_copy`.
+
+endchoice
+
 
 config IAR_SEMIHOSTING
 	bool "Use the IAR semihosting implementation."

--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -1071,8 +1071,10 @@ flagged.
         "HEAP_MEM_POOL_ADD_SIZE_", # Used as an option matching prefix
         "HUGETLBFS",          # Linux, in boards/xtensa/intel_adsp_cavs25/doc
         "IAR_BUFFERED_WRITE",
+        "IAR_DATA_INIT",
         "IAR_LIBCPP",
         "IAR_SEMIHOSTING",
+        "IAR_ZEPHYR_INIT",
         "IPC_SERVICE_ICMSG_BOND_NOTIFY_REPEAT_TO_MS", # Used in ICMsg tests for intercompatibility
                                                       # with older versions of the ICMsg.
         "LIBGCC_RTLIB",


### PR DESCRIPTION
This will implement a way of doing static initialization the "IAR" way. This is done by calling `__iar_data_init3` which handles all static initialization that is mentioned in the linker file "initialize by copy".