### PR TITLE
samples: sensor: add sample for SHT4X

### DIFF
--- a/samples/sensor/sht4x/CMakeLists.txt
+++ b/samples/sensor/sht4x/CMakeLists.txt
@@ -1,0 +1,10 @@
+# Copyright (c) 2025 Antmicro <www.antmicro.com>
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(sht4x)
+
+FILE(GLOB app_sources src/*.c)
+target_sources(app PRIVATE ${app_sources})

--- a/samples/sensor/sht4x/Kconfig
+++ b/samples/sensor/sht4x/Kconfig
@@ -1,0 +1,36 @@
+# Copyright (c) 2025 Antmicro <www.antmicro.com>
+# SPDX-License-Identifier: Apache-2.0
+
+mainmenu "SHT4X sample application"
+
+config APP_USE_HEATER
+	bool "Use the Heater on the SHT4X"
+	help
+	  Maximum duty cycle for using the heater is 5%
+
+config APP_HEATER_HUMIDITY_THRESH
+	int "RH [%] threshold above which the heater will be activated"
+	range 0 99
+	default 65
+	depends on APP_USE_HEATER
+
+config APP_HEATER_PULSE_POWER
+	int "Heater Power Setting"
+	range 0 2
+	default 2
+	depends on APP_USE_HEATER
+	help
+	  0 -> High power heater pulse -> ~200 mW  @3.3V
+	  1 -> Medium power heater pulse -> ~110 mW  @3.3V
+	  2 -> Low power heater pulse -> ~20 mW  @3.3V
+
+config APP_HEATER_PULSE_DURATION_LONG
+	bool "Use long pulse duration Heater setting"
+	default y
+	depends on APP_USE_HEATER
+	help
+	  Say 'Y' if you want to use the long pulse duration setting. This sets the pulse time to
+	  1.1s. Say 'N' if you want to use the short pulse duration setting, which sets the pulse
+	  time to 0.11s.
+
+source "Kconfig.zephyr"

--- a/samples/sensor/sht4x/README.rst
+++ b/samples/sensor/sht4x/README.rst
@@ -1,0 +1,54 @@
+.. _sht4x:
+
+SHT4X: High Accuracy Digital I2C Humidity Sensor
+#################################################
+
+Description
+***********
+
+This sample application periodically reads the ambient temperature and humidity
+from an SHT4X device. The result is written to the console.
+
+The SHT4X sensor has an optional heater that can be useful for specific
+environments or applications (refer to the datasheet for more information).
+To utilize the heater, check the Kconfig options for this application.
+
+References
+**********
+
+ - `SHT4X sensor <https://sensirion.com/products/catalog/SHT45>`_
+
+Wiring
+******
+
+This sample uses the SHT4X sensor controlled via the I2C interface.
+Connect Supply: **VDD**, **GND** and Interface: **SDA**, **SCL**.
+The supply voltage can be in the 1.7V to 3.6V range.
+Depending on the baseboard used, the **SDA** and **SCL** lines may require Pull-Up
+resistors.
+
+Building and Running
+********************
+
+This project outputs sensor data to the console. It requires an SHT4X
+sensor. It should work with any platform featuring an I2C peripheral
+interface. This example includes a device tree overlay
+for the :zephyr:board:`blackpill_f411ce` board.
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/sensor/sht4x
+   :board: blackpill_f411ce
+   :goals: build flash
+
+Sample Output
+=============
+
+.. code-block:: console
+
+        *** Booting Zephyr OS build v2.6.0-rc1-315-g50d8d1187138  ***
+        SHT4X: 23.64 Temp. [C] ; 30.74 RH [%]
+        SHT4X: 23.66 Temp. [C] ; 32.16 RH [%]
+        SHT4X: 23.63 Temp. [C] ; 30.83 RH [%]
+
+The datasheet states that the sensor measures temperature and humidity in degrees Celsius
+and percent relative humidity respectively.

--- a/samples/sensor/sht4x/boards/blackpill_f411ce.overlay
+++ b/samples/sensor/sht4x/boards/blackpill_f411ce.overlay
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2025 Antmicro <www.antmicro.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&i2c1 {
+	status = "okay";
+	clock-frequency = <I2C_BITRATE_FAST>;
+	sht4x@44 {
+		status = "okay";
+		compatible = "sensirion,sht4x";
+		reg = <0x44>;
+		repeatability = <2>;
+	};
+};

--- a/samples/sensor/sht4x/prj.conf
+++ b/samples/sensor/sht4x/prj.conf
@@ -1,0 +1,9 @@
+# Copyright (c) 2025 Antmicro <www.antmicro.com>
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_CBPRINTF_FP_SUPPORT=y
+CONFIG_I2C=y
+CONFIG_SENSOR=y
+CONFIG_PM_DEVICE=y
+CONFIG_LOG=y
+CONFIG_SENSOR_LOG_LEVEL_DBG=y

--- a/samples/sensor/sht4x/sample.yaml
+++ b/samples/sensor/sht4x/sample.yaml
@@ -1,0 +1,13 @@
+# Copyright (c) 2025 Antmicro <www.antmicro.com>
+# SPDX-License-Identifier: Apache-2.0
+
+sample:
+  name: SHT4X Sensor Sample
+tests:
+  sample.sensor.sht4x:
+    build_only: true
+    platform_allow:
+      - blackpill_f411ce
+      - myra_sip_baseboard
+    tags:
+      - sensors

--- a/samples/sensor/sht4x/src/main.c
+++ b/samples/sensor/sht4x/src/main.c
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2025 Antmicro <www.antmicro.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/sensor.h>
+#include <stdio.h>
+
+#include <zephyr/drivers/sensor/sht4x.h>
+
+#if !DT_HAS_COMPAT_STATUS_OKAY(sensirion_sht4x)
+#error "No sensirion,sht4x compatible node found in the device tree"
+#endif
+
+int main(void)
+{
+	const struct device *const sht = DEVICE_DT_GET_ANY(sensirion_sht4x);
+	struct sensor_value temp, hum;
+
+	if (!device_is_ready(sht)) {
+		printf("Device %s is not ready.\n", sht->name);
+		return 0;
+	}
+
+#if CONFIG_APP_USE_HEATER
+	struct sensor_value heater_p;
+	struct sensor_value heater_d;
+
+	heater_p.val1 = CONFIG_APP_HEATER_PULSE_POWER;
+	heater_d.val1 = !!CONFIG_APP_HEATER_PULSE_DURATION_LONG;
+	sensor_attr_set(sht, SENSOR_CHAN_ALL, SENSOR_ATTR_SHT4X_HEATER_POWER, &heater_p);
+	sensor_attr_set(sht, SENSOR_CHAN_ALL, SENSOR_ATTR_SHT4X_HEATER_DURATION, &heater_d);
+#endif
+
+	while (true) {
+		if (sensor_sample_fetch(sht)) {
+			printf("Failed to fetch sample from SHT4X device\n");
+			return 0;
+		}
+
+		sensor_channel_get(sht, SENSOR_CHAN_AMBIENT_TEMP, &temp);
+		sensor_channel_get(sht, SENSOR_CHAN_HUMIDITY, &hum);
+
+#if CONFIG_APP_USE_HEATER
+		/*
+		 * Conditions in which it makes sense to activate the heater
+		 * are application/environment specific.
+		 *
+		 * The heater should not be used above SHT4X_HEATER_MAX_TEMP (65 °C)
+		 * as stated in the datasheet.
+		 *
+		 * The temperature data will not be updated here for obvious reasons.
+		 **/
+		if (hum.val1 > CONFIG_APP_HEATER_HUMIDITY_THRESH &&
+		    temp.val1 < SHT4X_HEATER_MAX_TEMP) {
+			printf("Activating heater.\n");
+
+			if (sht4x_fetch_with_heater(sht)) {
+				printf("Failed to fetch sample from SHT4X device\n");
+				return 0;
+			}
+
+			sensor_channel_get(sht, SENSOR_CHAN_HUMIDITY, &hum);
+		}
+#endif
+
+		printf("SHT4X: %.2f Temp. [C] ; %0.2f RH [%%]\n", sensor_value_to_double(&temp),
+		       sensor_value_to_double(&hum));
+
+#if CONFIG_APP_USE_HEATER && !CONFIG_APP_HEATER_PULSE_DURATION
+		k_sleep(K_MSEC(20000));
+#else
+		k_sleep(K_MSEC(2000));
+#endif
+	}
+}


### PR DESCRIPTION
This PR adds a new sample for the SHT4X sensor. As for now, the SHT4X sensor does not have a dedicated sample.