### PR TITLE
driver: wifi: siwx917: Fix the return case gracefully

### DIFF
--- a/drivers/wifi/siwx91x/siwx91x_wifi.c
+++ b/drivers/wifi/siwx91x/siwx91x_wifi.c
@@ -306,6 +306,7 @@ static int siwx91x_send(const struct device *dev, struct net_pkt *pkt)
 
 	ret = sl_wifi_send_raw_data_frame(SL_WIFI_CLIENT_INTERFACE, buf->data, pkt_len);
 	if (ret) {
+		net_buf_unref(buf);
 		return -EIO;
 	}
 


### PR DESCRIPTION
Freeing the buf when sl_wifi_send_raw_data_frame() api returns the error instead of success