### PR TITLE
logging: Added config to disable vla in statements

### DIFF
--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -621,6 +621,13 @@ config MISRA_SANE
 	  standard for safety reasons.  Specifically variable length
 	  arrays are not permitted (and gcc will enforce this).
 
+config TOOLCHAIN_SUPPORTS_VLA_IN_STATEMENTS
+	bool
+	default y
+	help
+	  Hidden symbol to state if the toolchain can handle vla in
+	  statements.
+
 endmenu
 
 choice

--- a/cmake/toolchain/iar/Kconfig.defconfig
+++ b/cmake/toolchain/iar/Kconfig.defconfig
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+config TOOLCHAIN_SUPPORTS_VLA_IN_STATEMENTS
+	default n
 
 config PICOLIBC_SUPPORTED
 	default n

--- a/subsys/logging/Kconfig.misc
+++ b/subsys/logging/Kconfig.misc
@@ -19,6 +19,7 @@ config LOG_TEST_CLEAR_MESSAGE_SPACE
 config LOG_USE_VLA
 	bool "Using variable length arrays"
 	default y if !MISRA_SANE
+	depends on TOOLCHAIN_SUPPORTS_VLA_IN_STATEMENTS
 	help
 	  Using VLA slightly decreases stack usage in some cases it may not be
 	  supported. Note that VLA are used for arrays which size is resolved at


### PR DESCRIPTION
The config LOG_USE_VLA depends on that MISRA_SANE is not set. Unfortunately the IAR toolchain can't handle vla:s inside a statement, which the LOG_USE_VLA macro does.

I've added a new, hidden config to check if vla is ok inside statements, SUPPORT_VLA_IN_STATEMENTS. Default is always y, but a toolchain can override it so that VLA is not used by Z_LOG_MSG_ON_STACK_ALLOC.