### PR TITLE
logging: add autostart configuration for ADSP mtrace backend

### DIFF
--- a/subsys/logging/backends/Kconfig.adsp_mtrace
+++ b/subsys/logging/backends/Kconfig.adsp_mtrace
@@ -11,6 +11,13 @@ config LOG_BACKEND_ADSP_MTRACE
 
 if LOG_BACKEND_ADSP_MTRACE
 
+config LOG_BACKEND_ADSP_MTRACE_AUTOSTART
+	bool "Automatically start mtrace backend"
+	default n
+	help
+	  When enabled, automatically start the mtrace backend on
+	  application start.
+
 backend = ADSP_MTRACE
 backend-str = adsp_mtrace
 source "subsys/logging/Kconfig.template.log_format_config"

--- a/subsys/logging/backends/log_backend_adsp_mtrace.c
+++ b/subsys/logging/backends/log_backend_adsp_mtrace.c
@@ -214,7 +214,8 @@ const struct log_backend_api log_backend_adsp_mtrace_api = {
 	.init = init,
 };
 
-LOG_BACKEND_DEFINE(log_backend_adsp_mtrace, log_backend_adsp_mtrace_api, true);
+LOG_BACKEND_DEFINE(log_backend_adsp_mtrace, log_backend_adsp_mtrace_api,
+		   IS_ENABLED(CONFIG_LOG_BACKEND_ADSP_MTRACE_AUTOSTART));
 
 void adsp_mtrace_log_init(adsp_mtrace_log_hook_t hook)
 {


### PR DESCRIPTION
**Issue Overview**
During the debugging of a performance drop related to IPC timeouts on the MTL platform, it was observed that excessive logging was significantly impacting system performance. Specifically, a repetitive log message was flooding the logs:
```txt
...
[    0.543095] <inf> host_comp: host_get_copy_bytes_normal: comp:2 0x40005 no bytes to copy, available samples: 0, free_samples: 7680
[    0.546126] <inf> host_comp: host_get_copy_bytes_normal: comp:2 0x40005 no bytes to copy, available samples: 0, free_samples: 7680
[    0.549146] <inf> host_comp: host_get_copy_bytes_normal: comp:2 0x40005 no bytes to copy, available samples: 0, free_samples: 7680
[    0.552168] <inf> host_comp: host_get_copy_bytes_normal: comp:2 0x40005 no bytes to copy, available samples: 0, free_samples: 7680
[    0.555190] <inf> host_comp: host_get_copy_bytes_normal: comp:2 0x40005 no bytes to copy, available samples: 0, free_samples: 7680
[    0.558210] <inf> host_comp: host_get_copy_bytes_normal: comp:2 0x40005 no bytes to copy, available samples: 0, free_samples: 7680
[    0.561248] <inf> host_comp: host_get_copy_bytes_normal: comp:2 0x40005 no bytes to copy, available samples: 0, free_samples: 7680
[    0.564266] <inf> host_comp: host_get_copy_bytes_normal: comp:2 0x40005 no bytes to copy, available samples: 0, free_samples: 7680
...
```

This log message was repeated numerous times, obscuring other critical log entries and degrading system performance. Notably, the test consistently failed regardless of whether logs were actively collected, as logging in SOF is typically enabled via an IPC message. However, when the log level was changed from 'info' to 'debug', the test passed, highlighting the performance implications of logging even when not explicitly enabled.

**Root Cause Analysis**
Upon investigation, it was discovered that even when logs were not enabled via IPC, they were still being collected in the memory window. This unnecessary collection of logs, even when not required, was causing performance degradation.

**Proposed Solution**
To address this issue, a new configuration option, LOG_BACKEND_ADSP_MTRACE_AUTOSTART, has been introduced. By default, this option is set to 'n', meaning the ADSP mtrace backend will not start automatically unless explicitly enabled. This ensures that logs are not collected unless they are explicitly enabled via IPC, thereby mitigating the performance impact.

**Impact of the Change**
With the autostart disabled, the system will not collect logs unless explicitly enabled, which should improve performance during normal operation. However, this change may result in the loss of some boot flow messages, as seen in the comparison of logs with autostart enabled and disabled.

`CONFIG_LOG_BACKEND_ADSP_MTRACE_AUTOSTART=y`:
```txt
[    0.000000] <inf> init: print_version_banner: FW ABI 0x301d001 DBG ABI 0x5003000 tags SOF:v2.12-rc1-226-gd57e1ab21357-dirty zephyr:v4.0.0-5260-gfe29c40a9366 src hash 0xeac97b98 (ref hash 0xeac97b98)
[    0.000000] <inf> clock: clock_set_freq: clock 0 set freq 20000000Hz freq_idx 0 old 1
[    0.000000] <inf> clock: clock_set_freq: clock 1 set freq 20000000Hz freq_idx 0 old 1
[    0.000000] <inf> clock: clock_set_freq: clock 2 set freq 20000000Hz freq_idx 0 old 1
*** Booting Zephyr OS build v4.0.0-5260-gfe29c40a9366 ***
[    0.000001] <inf> ipc: telemetry_init: Telemetry enabled. May affect performance
[    0.000001] <inf> main: sof_app_main: SOF on intel_adsp
[    0.000001] <inf> main: sof_app_main: SOF initialized
[    0.000005] <inf> ipc: ipc_cmd: rx	: 0x43000000|0x30701000
[    0.000010] <inf> ipc: ipc_cmd: rx	: 0x43000000|0x30801000
[    0.000011] <inf> ipc: ipc_cmd: rx	: 0x44000000|0x3070000c
[    0.000011] <wrn> basefw_intel: basefw_set_fw_config: returning success for Set FW_CONFIG without handling it
[    0.000011] <inf> ipc: ipc_cmd: rx	: 0x44000000|0x31400008
[    0.002023] <inf> ipc: ipc_cmd: rx	: 0x44000000|0x30600064
[    0.002560] <wrn> mtrace: ipc4_logging_enable_logs: mtrace log backend already active
[    0.008268] <inf> ipc: ipc_cmd: rx	: 0x44000000|0x3070000c
[    0.009738] <wrn> basefw_intel: basefw_set_fw_config: returning success for Set FW_CONFIG without handling it
[    0.022920] <inf> ipc: ipc_cmd: rx	: 0x18010000|0x0
[    0.024275] <inf> dma: sof_dma_get: dma_get() ID 0 sref = 1 busy channels 0
[    0.026168] <inf> clock: clock_set_freq: clock 0 set freq 393216000Hz freq_idx 1 old 0
[    0.026425] <inf> clock: clock_set_freq: clock 1 set freq 393216000Hz freq_idx 1 old 0
[    0.026681] <inf> clock: clock_set_freq: clock 2 set freq 393216000Hz freq_idx 1 old 0
[    0.045496] <inf> dma: sof_dma_put: dma_put(), dma = 0x400b5948, sref = 0
[    0.045806] <inf> clock: clock_set_freq: clock 0 set freq 20000000Hz freq_idx 0 old 1
[    0.047706] <inf> clock: clock_set_freq: clock 1 set freq 20000000Hz freq_idx 0 old 1
[    0.049603] <inf> clock: clock_set_freq: clock 2 set freq 20000000Hz freq_idx 0 old 1
[    0.051443] <inf> lib_manager: lib_manager_load_library: loaded library id: 1
[    0.066716] <inf> ipc: ipc_cmd: rx	: 0x47000000|0x0
[    0.191770] <inf> ipc: ipc_cmd: rx	: 0x11000004|0x0
[    0.193200] <inf> pipe: pipeline_new: pipeline new pipe_id 0 priority 0
[    0.201655] <inf> ipc: ipc_cmd: rx	: 0x40000005|0x30e
[    0.203311] <inf> dai_intel_dmic: dai_dmic_probe: dmic_probe()
```
`CONFIG_LOG_BACKEND_ADSP_MTRACE_AUTOSTART=n`:
```txt
[    0.003936] <inf> ipc: ipc_cmd: rx	: 0x44000000|0x3070000c
[    0.005411] <wrn> basefw_intel: basefw_set_fw_config: returning success for Set FW_CONFIG without handling it
[    0.016996] <inf> ipc: ipc_cmd: rx	: 0x18010000|0x0
[    0.018351] <inf> dma: sof_dma_get: dma_get() ID 0 sref = 1 busy channels 0
[    0.020243] <inf> clock: clock_set_freq: clock 0 set freq 393216000Hz freq_idx 1 old 0
[    0.020501] <inf> clock: clock_set_freq: clock 1 set freq 393216000Hz freq_idx 1 old 0
[    0.020758] <inf> clock: clock_set_freq: clock 2 set freq 393216000Hz freq_idx 1 old 0
[    0.039608] <inf> dma: sof_dma_put: dma_put(), dma = 0x400b5948, sref = 0
[    0.039918] <inf> clock: clock_set_freq: clock 0 set freq 20000000Hz freq_idx 0 old 1
[    0.041820] <inf> clock: clock_set_freq: clock 1 set freq 20000000Hz freq_idx 0 old 1
[    0.043716] <inf> clock: clock_set_freq: clock 2 set freq 20000000Hz freq_idx 0 old 1
[    0.045556] <inf> lib_manager: lib_manager_load_library: loaded library id: 1
[    0.063005] <inf> ipc: ipc_cmd: rx	: 0x47000000|0x0
[    0.187356] <inf> ipc: ipc_cmd: rx	: 0x11000004|0x0
[    0.188623] <inf> pipe: pipeline_new: pipeline new pipe_id 0 priority 0
[    0.195903] <inf> ipc: ipc_cmd: rx	: 0x40000005|0x30e
[    0.197556] <inf> dai_intel_dmic: dai_dmic_probe: dmic_probe()
```

In the SOF debug overlay, the autostart option will be enabled to facilitate detailed logging for debugging purposes. However, for other builds, it should remain disabled to optimize performance. Developers can enable this option in a custom build if detailed logs are required for debugging purposes.