### PR TITLE
boards: madmachine: enable flexspi for external flash

### DIFF
--- a/boards/madmachine/mm_feather/mm_feather.dts
+++ b/boards/madmachine/mm_feather/mm_feather.dts
@@ -56,6 +56,7 @@
 
 
 &flexspi {
+	status = "okay";
 	reg = <0x402a8000 0x4000>, <0x60000000 DT_SIZE_M(8)>;
 	is25wp064: is25wp064@0 {
 		compatible = "nxp,imx-flexspi-nor";

--- a/boards/madmachine/mm_swiftio/mm_swiftio.dts
+++ b/boards/madmachine/mm_swiftio/mm_swiftio.dts
@@ -56,6 +56,7 @@
 
 
 &flexspi {
+	status = "okay";
 	reg = <0x402a8000 0x4000>, <0x60000000 DT_SIZE_M(8)>;
 	is25wp064: is25wp064@0 {
 		compatible = "nxp,imx-flexspi-nor";


### PR DESCRIPTION
MM boards are currently broken (can't even build hello world) due to flexspi not being enabled in the device tree, causing external flash to not be available.