### PR TITLE
tests: udc: fix the test for controllers with maximum number of endpoints

### DIFF
--- a/tests/drivers/udc/testcase.yaml
+++ b/tests/drivers/udc/testcase.yaml
@@ -7,6 +7,10 @@ tests:
     depends_on: usbd
     integration_platforms:
       - nrf52840dk/nrf52840
+      - frdm_k64f
+      - nucleo_f413zh
+      - mimxrt1050_evk/mimxrt1052/hyperflash
+      - rpi_pico
     platform_exclude:
       - nrf54h20dk/nrf54h20/cpuapp
   drivers.usb.udc.build_only:


### PR DESCRIPTION
Do not use FALSE_EP_ADDR in API calls to enable/disable an endpoint as
we already support controllers with the maximum possible number of
endpoints where FALSE_EP_ADDR is a valid endpoint address.

Expand the list of integration platforms.

Fixes: #85025