### PR TITLE
log: fix log_flush()

### DIFF
--- a/subsys/logging/Kconfig.mode
+++ b/subsys/logging/Kconfig.mode
@@ -74,3 +74,15 @@ config LOG_DEFAULT_MINIMAL
 config LOG_MULTIDOMAIN
 	bool "Multi-domain logger"
 	select LOG_TIMESTAMP_64BIT
+
+if LOG_MODE_DEFERRED
+
+config LOG_FLUSH_SLEEP_US
+	int "Sleep time when flushing the log queue, microseconds"
+	range 100 100000
+	default 10000
+	help
+	  In deferred logging mode this is the time, used in
+	  log_flush() on each sleep iteration in microseconds.
+
+endif # LOG_MODE_DEFERRED

--- a/subsys/logging/log_core.c
+++ b/subsys/logging/log_core.c
@@ -1003,7 +1003,8 @@ void log_flush(void)
 {
 	if (IS_ENABLED(CONFIG_LOG_PROCESS_THREAD)) {
 		while (atomic_get(&buffered_cnt)) {
-			k_sleep(K_MSEC(10));
+			log_thread_trigger();
+			k_sleep(K_USEC(CONFIG_LOG_FLUSH_SLEEP_US));
 		}
 	} else {
 		while (LOG_PROCESS()) {


### PR DESCRIPTION
The logging thread is usually woken up by a timer, if the timer period is longer than 10ms, log_flush() can iterate multiple times needlessly, while waiting for the next timer. Instead wake up the logging thread to let it flush the queue immediately. Besides a hard-coded polling period of 10ms is too long for some applications, make it a Kconfig parameter.