### PR TITLE
MAINTAINERS.yml: update maintainer and collaborators for Xen platform

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -2321,11 +2321,9 @@ EC Host Commands:
 Xen Platform:
   status: maintained
   maintainers:
-    - povergoing
-  collaborators:
-    - SgrrZhf
-    - lorc
     - firscity
+  collaborators:
+    - lorc
     - luca-fancellu
   files:
     - include/zephyr/xen/


### PR DESCRIPTION
During the review of Xen drivers enhancements, it was found that @povergoing (previous maintainer) and @SgrrZhf (one of the collaborators) are no longer active on GitHub. After discussions with other collaborators (@lorc and @luca-fancellu) and in PR #82810, we decided to assign these activities to me as one of the main developers for this part of Zephyr.