### PR TITLE
tests: settings: improve coverage using simulators

### DIFF
--- a/tests/subsys/settings/file/testcase.yaml
+++ b/tests/subsys/settings/file/testcase.yaml
@@ -13,7 +13,7 @@ tests:
       - s32z2xxdc2@D/s32z270/rtu0
       - s32z2xxdc2@D/s32z270/rtu1
     integration_platforms:
-      - nrf52840dk/nrf52840
+      - native_sim
     tags:
       - settings
       - file

--- a/tests/subsys/settings/functional/fcb/testcase.yaml
+++ b/tests/subsys/settings/functional/fcb/testcase.yaml
@@ -11,7 +11,7 @@ tests:
       - s32z2xxdc2@D/s32z270/rtu0
       - s32z2xxdc2@D/s32z270/rtu1
     integration_platforms:
-      - nrf52840dk/nrf52840
+      - native_sim
     tags:
       - settings
       - fcb

--- a/tests/subsys/settings/functional/nvs/testcase.yaml
+++ b/tests/subsys/settings/functional/nvs/testcase.yaml
@@ -2,24 +2,30 @@ tests:
   settings.functional.nvs:
     platform_allow:
       - qemu_x86
+      - mps2/an385
       - native_sim
       - native_sim/native/64
       - s32z2xxdc2/s32z270/rtu0
       - s32z2xxdc2/s32z270/rtu1
       - s32z2xxdc2@D/s32z270/rtu0
       - s32z2xxdc2@D/s32z270/rtu1
+    integration_platforms:
+      - mps2/an385
     tags:
       - settings
       - nvs
   settings.functional.nvs.chosen:
     extra_args: DTC_OVERLAY_FILE=./chosen.overlay
     platform_allow:
+      - mps2/an385
       - native_sim
       - native_sim/native/64
       - s32z2xxdc2/s32z270/rtu0
       - s32z2xxdc2/s32z270/rtu1
       - s32z2xxdc2@D/s32z270/rtu0
       - s32z2xxdc2@D/s32z270/rtu1
+    integration_platforms:
+      - mps2/an385
     tags:
       - settings
       - nvs
@@ -32,8 +38,9 @@ tests:
       - s32z2xxdc2/s32z270/rtu1
       - s32z2xxdc2@D/s32z270/rtu0
       - s32z2xxdc2@D/s32z270/rtu1
+      - mps2/an385
     integration_platforms:
-      - nrf52840dk/nrf52840
+      - mps2/an385
     tags:
       - settings
       - nvs

--- a/tests/subsys/settings/nvs/testcase.yaml
+++ b/tests/subsys/settings/nvs/testcase.yaml
@@ -1,6 +1,6 @@
 tests:
   settings.nvs:
-    depends_on: nvs
+    filter: dt_label_with_parent_compat_enabled("storage_partition", "fixed-partitions")
     min_ram: 32
     tags:
       - settings

--- a/tests/subsys/settings/performance/testcase.yaml
+++ b/tests/subsys/settings/performance/testcase.yaml
@@ -7,6 +7,9 @@ tests:
     platform_allow:
       - nrf52840dk/nrf52840
       - nrf54l15dk/nrf54l15/cpuapp
+      - mps2/an385
+    integration_platforms:
+      - mps2/an385
     min_ram: 32
     tags:
       - settings
@@ -23,6 +26,9 @@ tests:
     platform_allow:
       - nrf52840dk/nrf52840
       - nrf54l15dk/nrf54l15/cpuapp
+      - mps2/an385
+    integration_platforms:
+      - mps2/an385
     min_ram: 32
     tags:
       - settings
@@ -36,10 +42,8 @@ tests:
       - CONFIG_SETTINGS_ZMS=y
       - CONFIG_ZMS_LOOKUP_CACHE=y
       - CONFIG_ZMS_LOOKUP_CACHE_SIZE=512
-    platform_allow: nrf52840dk/nrf52840
-    platform_exclude:
-      - native_sim
-      - qemu_x86
+    platform_allow:
+      - nrf52840dk/nrf52840
     min_ram: 32
     tags:
       - settings
@@ -56,10 +60,8 @@ tests:
       - CONFIG_NVS_LOOKUP_CACHE_SIZE=512
       - CONFIG_SETTINGS_NVS_NAME_CACHE=y
       - CONFIG_SETTINGS_NVS_NAME_CACHE_SIZE=512
-    platform_allow: nrf52840dk/nrf52840
-    platform_exclude:
-      - native_sim
-      - qemu_x86
+    platform_allow:
+      - nrf52840dk/nrf52840
     min_ram: 32
     tags:
       - settings

--- a/tests/subsys/settings/zms/testcase.yaml
+++ b/tests/subsys/settings/zms/testcase.yaml
@@ -1,6 +1,6 @@
 tests:
   settings.zms:
-    depends_on: zms
+    filter: dt_label_with_parent_compat_enabled("storage_partition", "fixed-partitions")
     min_ram: 32
     tags:
       - settings


### PR DESCRIPTION
- **tests: zms: remove bogus filter using depends_on**
- **tests: settings: where possible, use simulators for integration platforms**
