### PR TITLE
lsm6dsv16x sensor: add SENSOR_ATTR_GBIAS attribute (SFLP)

### DIFF
--- a/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x.c
+++ b/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x.c
@@ -165,7 +165,7 @@ static int lsm6dsv16x_accel_set_fs_raw(const struct device *dev, uint8_t fs)
 	return 0;
 }
 
-static int lsm6dsv16x_accel_set_odr_raw(const struct device *dev, uint8_t odr)
+int lsm6dsv16x_accel_set_odr_raw(const struct device *dev, uint8_t odr)
 {
 	const struct lsm6dsv16x_config *cfg = dev->config;
 	stmdev_ctx_t *ctx = (stmdev_ctx_t *)&cfg->ctx;
@@ -194,7 +194,7 @@ static int lsm6dsv16x_gyro_set_fs_raw(const struct device *dev, uint8_t fs)
 	return 0;
 }
 
-static int lsm6dsv16x_gyro_set_odr_raw(const struct device *dev, uint8_t odr)
+int lsm6dsv16x_gyro_set_odr_raw(const struct device *dev, uint8_t odr)
 {
 	const struct lsm6dsv16x_config *cfg = dev->config;
 	stmdev_ctx_t *ctx = (stmdev_ctx_t *)&cfg->ctx;
@@ -457,6 +457,10 @@ static int lsm6dsv16x_attr_set(const struct device *dev,
 
 		return lsm6dsv16x_shub_config(dev, chan, attr, val);
 #endif /* CONFIG_LSM6DSV16X_SENSORHUB */
+#ifdef CONFIG_LSM6DSV16X_STREAM
+	case SENSOR_CHAN_GBIAS_XYZ:
+		return lsm6dsv16x_gbias_config(dev, chan, attr, val);
+#endif /* CONFIG_LSM6DSV16X_STREAM */
 	default:
 		LOG_WRN("attr_set() not supported on this channel.");
 		return -ENOTSUP;
@@ -645,6 +649,10 @@ static int lsm6dsv16x_attr_get(const struct device *dev, enum sensor_channel cha
 		return lsm6dsv16x_accel_get_config(dev, chan, attr, val);
 	case SENSOR_CHAN_GYRO_XYZ:
 		return lsm6dsv16x_gyro_get_config(dev, chan, attr, val);
+#ifdef CONFIG_LSM6DSV16X_STREAM
+	case SENSOR_CHAN_GBIAS_XYZ:
+		return lsm6dsv16x_gbias_get_config(dev, chan, attr, val);
+#endif /* CONFIG_LSM6DSV16X_STREAM */
 	default:
 		LOG_WRN("attr_get() not supported on this channel.");
 		return -ENOTSUP;

--- a/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x.c
+++ b/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x.c
@@ -198,11 +198,13 @@ static int lsm6dsv16x_gyro_set_odr_raw(const struct device *dev, uint8_t odr)
 {
 	const struct lsm6dsv16x_config *cfg = dev->config;
 	stmdev_ctx_t *ctx = (stmdev_ctx_t *)&cfg->ctx;
+	struct lsm6dsv16x_data *data = dev->data;
 
 	if (lsm6dsv16x_gy_data_rate_set(ctx, odr) < 0) {
 		return -EIO;
 	}
 
+	data->gyro_freq = odr;
 	return 0;
 }
 
@@ -1162,7 +1164,6 @@ static int lsm6dsv16x_init_chip(const struct device *dev)
 
 	odr = cfg->gyro_odr;
 	LOG_DBG("gyro odr is %d", odr);
-	lsm6dsv16x->gyro_freq = odr;
 	if (lsm6dsv16x_gyro_set_odr_raw(dev, odr) < 0) {
 		LOG_ERR("failed to set gyroscope odr %d", odr);
 		return -EIO;

--- a/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x.h
+++ b/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x.h
@@ -169,6 +169,9 @@ struct lsm6dsv16x_data {
 	uint8_t bus_type : 2; /* I2C is 0, SPI is 1, I3C is 2 */
 	uint8_t sflp_batch_odr : 3;
 	uint8_t reserved : 1;
+	int32_t gbias_x_udps;
+	int32_t gbias_y_udps;
+	int32_t gbias_z_udps;
 #endif
 
 #ifdef CONFIG_LSM6DSV16X_TRIGGER
@@ -210,6 +213,9 @@ static inline uint8_t lsm6dsv16x_bus_reg(struct lsm6dsv16x_data *data, uint8_t x
 #define LSM6DSV16X_FIFO_ITEM_LEN 7
 #define LSM6DSV16X_FIFO_SIZE(x) (x * LSM6DSV16X_FIFO_ITEM_LEN)
 #endif
+
+int lsm6dsv16x_accel_set_odr_raw(const struct device *dev, uint8_t odr);
+int lsm6dsv16x_gyro_set_odr_raw(const struct device *dev, uint8_t odr);
 
 #if defined(CONFIG_LSM6DSV16X_SENSORHUB)
 int lsm6dsv16x_shub_init(const struct device *dev);

--- a/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x_rtio.h
+++ b/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x_rtio.h
@@ -12,6 +12,11 @@
 #include <zephyr/device.h>
 #include <zephyr/rtio/rtio.h>
 
+int lsm6dsv16x_gbias_config(const struct device *dev, enum sensor_channel chan,
+			    enum sensor_attribute attr,
+			    const struct sensor_value *val);
+int lsm6dsv16x_gbias_get_config(const struct device *dev, enum sensor_channel chan,
+				enum sensor_attribute attr, struct sensor_value *val);
 void lsm6dsv16x_submit(const struct device *sensor, struct rtio_iodev_sqe *iodev_sqe);
 
 void lsm6dsv16x_submit_stream(const struct device *sensor, struct rtio_iodev_sqe *iodev_sqe);

--- a/samples/sensor/stream_fifo/src/main.c
+++ b/samples/sensor/stream_fifo/src/main.c
@@ -230,12 +230,28 @@ static void check_sensor_is_off(const struct device *dev)
 
 int main(void)
 {
+	struct sensor_value gbias[3];
+
 	for (size_t i = 0; i < ARRAY_SIZE(sensors); i++) {
 		if (!device_is_ready(sensors[i])) {
 			printk("sensor: device %s not ready.\n", sensors[i]->name);
 			return 0;
 		}
 		check_sensor_is_off(sensors[i]);
+
+		/*
+		 * Set GBIAS as 0.5 rad/s, -1 rad/s, 0.2 rad/s
+		 *
+		 * (here application should initialize gbias x/y/z with latest values
+		 * calculated from previous run and probably saved to non volatile memory)
+		 */
+		gbias[0].val1 = 0;
+		gbias[0].val2 = 500000;
+		gbias[1].val1 = -1;
+		gbias[1].val2 = 0;
+		gbias[2].val1 = 0;
+		gbias[2].val2 = 200000;
+		sensor_attr_set(sensors[i], SENSOR_CHAN_GBIAS_XYZ, SENSOR_ATTR_OFFSET, gbias);
 
 		k_thread_create(&thread_id[i], thread_stack[i], TASK_STACK_SIZE, print_stream,
 			(void *)sensors[i], (void *)iodevs[i], NULL, K_PRIO_COOP(5),


### PR DESCRIPTION
Use SENSOR_ATTR_OFFSET attribute to initialize the Sensor Fusion GBIAS. This is useful when the device is not still (e.g. hold in hand) and so the gyroscope calibration does not run. 
The real application should restore latest valid values taken from non-volatile memory.
