### PR TITLE
[Coverity CID: 392529] Dereference after null check in subsys/bluetooth/controller/ll_sw/ull_adv_sync.c

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
@@ -1412,7 +1412,7 @@ static void ull_adv_sync_copy_pdu_header(struct pdu_adv *target_pdu,
 
 #if defined(CONFIG_BT_CTLR_DF_ADV_CTE_TX)
 		if (source_hdr->ext_hdr.cte_info) {
-			if (!skip_fields->cte_info) {
+			if (skip_fields != NULL && !skip_fields->cte_info) {
 				memcpy(target_dptr, source_dptr, sizeof(struct pdu_cte_info));
 				target_dptr += sizeof(struct pdu_cte_info);
 				target_hdr->ext_hdr.cte_info = 1U;
@@ -1423,7 +1423,7 @@ static void ull_adv_sync_copy_pdu_header(struct pdu_adv *target_pdu,
 
 #if defined(CONFIG_BT_CTLR_ADV_PERIODIC_ADI_SUPPORT)
 		if (source_hdr->ext_hdr.adi) {
-			if (!skip_fields->adi) {
+			if (skip_fields != NULL && !skip_fields->adi) {
 				memcpy(target_dptr, source_dptr, sizeof(struct pdu_adv_adi));
 				target_dptr += sizeof(struct pdu_adv_adi);
 				target_hdr->ext_hdr.adi = 1U;
@@ -1434,7 +1434,7 @@ static void ull_adv_sync_copy_pdu_header(struct pdu_adv *target_pdu,
 
 #if defined(CONFIG_BT_CTLR_ADV_SYNC_PDU_LINK)
 		if (source_hdr->ext_hdr.aux_ptr) {
-			if (!skip_fields->aux_ptr) {
+			if (skip_fields != NULL && !skip_fields->aux_ptr) {
 				memcpy(target_dptr, source_dptr, sizeof(struct pdu_adv_aux_ptr));
 				target_dptr += sizeof(struct pdu_adv_aux_ptr);
 				target_hdr->ext_hdr.aux_ptr = 1U;
@@ -1446,7 +1446,7 @@ static void ull_adv_sync_copy_pdu_header(struct pdu_adv *target_pdu,
 		/* SyncInfo is RFU for periodic advertising */
 
 		if (source_hdr->ext_hdr.tx_pwr) {
-			if (!skip_fields->tx_pwr) {
+			if (skip_fields != NULL && !skip_fields->tx_pwr) {
 				*target_dptr = *source_dptr;
 				target_dptr++;
 				target_hdr->ext_hdr.tx_pwr = 1U;

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
@@ -55,6 +55,8 @@
 
 #include "hal/debug.h"
 
+xyz
+
 #if defined(CONFIG_BT_CTLR_ADV_SYNC_PDU_LINK)
 /* First PDU contains up to PDU_AC_EXT_AD_DATA_LEN_MAX, next ones PDU_AC_EXT_PAYLOAD_SIZE_MAX */
 #define PAYLOAD_BASED_FRAG_COUNT \

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
@@ -55,8 +55,6 @@
 
 #include "hal/debug.h"
 
-xyz
-
 #if defined(CONFIG_BT_CTLR_ADV_SYNC_PDU_LINK)
 /* First PDU contains up to PDU_AC_EXT_AD_DATA_LEN_MAX, next ones PDU_AC_EXT_PAYLOAD_SIZE_MAX */
 #define PAYLOAD_BASED_FRAG_COUNT \


### PR DESCRIPTION
Bluetooth: Controller: Fix coverity issue 392529 

[Coverity CID: 392529] Dereference after null check in 
subsys/bluetooth/controller/ll_sw/ull_adv_sync.c

Fixes [#74738](https://github.com/zephyrproject-rtos/zephyr/issues/74738).

Signed-off-by: Greg Priest gregjzab@yahoo.com