### PR TITLE
subsys/usb: hid: added consumer control report

### DIFF
--- a/include/zephyr/usb/class/hid.h
+++ b/include/zephyr/usb/class/hid.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2018 Intel Corporation
  * Copyright (c) 2018,2021 Nordic Semiconductor ASA
+ * Copyright (c) 2025, Muhammad Waleed Badar
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -141,6 +142,8 @@ extern "C" {
 #define HID_USAGE_GEN_LEDS		0x08
 /** HID Button Usage page */
 #define HID_USAGE_GEN_BUTTON		0x09
+/** HID Consumer Usage page */
+#define HID_USAGE_GEN_CONSUMER		0x0C
 
 /** HID Generic Desktop Undefined Usage ID */
 #define HID_USAGE_GEN_DESKTOP_UNDEFINED	0x00
@@ -162,6 +165,8 @@ extern "C" {
 #define HID_USAGE_GEN_DESKTOP_Y		0x31
 /** HID Generic Desktop Wheel Usage ID */
 #define HID_USAGE_GEN_DESKTOP_WHEEL	0x38
+/** HID Consumer Usage page ID */
+#define HID_USAGE_GEN_CONSUMER_CONTROL	0x01
 
 /**
  * @}
@@ -513,6 +518,23 @@ extern "C" {
 }
 
 /**
+ * @brief Simple HID consumer report descriptor.
+ */
+#define HID_CONSUMER_REPORT_DESC() {				\
+	HID_USAGE_PAGE(HID_USAGE_GEN_CONSUMER),                 \
+	HID_USAGE(HID_USAGE_GEN_CONSUMER_CONTROL),              \
+	HID_COLLECTION(HID_COLLECTION_APPLICATION),         \
+		HID_LOGICAL_MIN8(0),                            \
+		HID_LOGICAL_MAX16(0xFF, 0xFF),                  \
+		HID_USAGE_MIN8(0),                              \
+		HID_USAGE_MAX16(0xFF, 0xFF),                    \
+		HID_REPORT_COUNT(1),                            \
+		HID_REPORT_SIZE(16),                            \
+		HID_INPUT(0x00),                                \
+	HID_END_COLLECTION,                                 \
+}
+
+/**
  * @brief HID keyboard button codes.
  */
 enum hid_kbd_code {
@@ -637,6 +659,73 @@ enum hid_kbd_led {
 	HID_KBD_LED_SCROLL_LOCK	= 0x04,
 	HID_KBD_LED_COMPOSE	= 0x08,
 	HID_KBD_LED_KANA	= 0x10,
+};
+
+/**
+ * @brief HID consumer control codes.
+ */
+enum hid_consumer_control {
+	/* System Controls */
+	HID_CONSUMER_POWER	= 0x30,
+	HID_CONSUMER_RESET	= 0x31,
+	HID_CONSUMER_SLEEP	= 0x32,
+	HID_CONSUMER_SLEEP_AFTER	= 0x33,
+	HID_CONSUMER_SLEEP_MODE		= 0x34,
+	HID_CONSUMER_ILLUMINATION	= 0x35,
+	/* Menu Navigation Controls */
+	HID_CONSUMER_MENU		= 0x40,
+	HID_CONSUMER_MENU_PICK		= 0x41,
+	HID_CONSUMER_MENU_UP		= 0x42,
+	HID_CONSUMER_MENU_DOWN		= 0x43,
+	HID_CONSUMER_MENU_LEFT		= 0x44,
+	HID_CONSUMER_MENU_RIGHT		= 0x45,
+	HID_CONSUMER_MENU_ESCAPE	= 0x46,
+	HID_CONSUMER_MENU_VALUE_INC	= 0x47,
+	HID_CONSUMER_MENU_VALUE_DEC	= 0x48,
+	/* Media Playback Controls */
+	HID_CONSUMER_PLAY	= 0xB0,
+	HID_CONSUMER_PAUSE	= 0xB1,
+	HID_CONSUMER_RECORD	= 0xB2,
+	HID_CONSUMER_FAST_FORWARD	= 0xB3,
+	HID_CONSUMER_REWIND	= 0xB4,
+	HID_CONSUMER_SCAN_NEXT_TRACK	= 0xB5,
+	HID_CONSUMER_SCAN_PREV_TRACK	= 0xB6,
+	HID_CONSUMER_STOP	= 0xB7,
+	HID_CONSUMER_EJECT	= 0xB8,
+	HID_CONSUMER_RANDOM_PLAY	= 0xB9,
+	HID_CONSUMER_SELECT_DISC	= 0xBA,
+	HID_CONSUMER_ENTER_DISC	= 0xBB,
+	HID_CONSUMER_REPEAT		= 0xBC,
+	HID_CONSUMER_TRACKING	= 0xBD,
+	HID_CONSUMER_TRACK_NORMAL	= 0xBE,
+	HID_CONSUMER_SLOW_TRACKING	= 0xBF,
+	HID_CONSUMER_FRAME_FORWARD	= 0xC0,
+	HID_CONSUMER_FRAME_BACK	= 0xC1,
+	HID_CONSUMER_MARK		= 0xC2,
+	HID_CONSUMER_CLEAR_MARK	= 0xC3,
+	HID_CONSUMER_REPEAT_FROM_MARK	= 0xC4,
+	HID_CONSUMER_RETURN_TO_MARK		= 0xC5,
+	HID_CONSUMER_SEARCH_MARK_FWD	= 0xC6,
+	HID_CONSUMER_SEARCH_MARK_BACK	= 0xC7,
+	HID_CONSUMER_COUNTER_RESET	= 0xC8,
+	HID_CONSUMER_SHOW_COUNTER	= 0xC9,
+	HID_CONSUMER_TRACKING_INC	= 0xCA,
+	HID_CONSUMER_TRACKING_DEC	= 0xCB,
+	HID_CONSUMER_STOP_EJECT	= 0xCC,
+	HID_CONSUMER_PLAY_PAUSE	= 0xCD,
+	HID_CONSUMER_PLAY_SKIP	= 0xCE,
+	/* Audio Control */
+	HID_CONSUMER_VOLUME		= 0xE0,
+	HID_CONSUMER_BALANCE	= 0xE1,
+	HID_CONSUMER_MUTE		= 0xE2,
+	HID_CONSUMER_BASS		= 0xE3,
+	HID_CONSUMER_TREBLE		= 0xE4,
+	HID_CONSUMER_BASS_BOOST	= 0xE5,
+	HID_CONSUMER_SURROUND_MODE	= 0xE6,
+	HID_CONSUMER_LOUDNESS	= 0xE7,
+	HID_CONSUMER_MPX		= 0xE8,
+	HID_CONSUMER_VOL_UP		= 0xE9,
+	HID_CONSUMER_VOL_DOWN	= 0xEA,
 };
 
 /**


### PR DESCRIPTION
Added Consumer Control Report Descriptor macro
and consumer control codes for consumer devices.

![image](https://github.com/user-attachments/assets/0de15bec-586f-4831-8875-f16beec2b5e4)
Reference: https://www.usb.org/sites/default/files/documents/hut1_12v2.pdf