### PR TITLE
drivers: sensor: tmp1075: remove redundant module name in log message

### DIFF
--- a/drivers/sensor/ti/tmp1075/tmp1075.c
+++ b/drivers/sensor/ti/tmp1075/tmp1075.c
@@ -170,7 +170,7 @@ static int setup_interrupts(const struct device *dev)
 	int result;
 
 	if (!gpio_is_ready_dt(alert_gpio)) {
-		LOG_ERR("tmp1075: gpio controller %s not ready", alert_gpio->port->name);
+		LOG_ERR("gpio controller %s not ready", alert_gpio->port->name);
 		return -ENODEV;
 	}
 


### PR DESCRIPTION
The tmp1075 driver already registers a log module using LOG_MODULE_REGISTER(TMP1075, CONFIG_SENSOR_LOG_LEVEL). This ensures that all log messages are prefixed with "TMP1075". The existing LOG_ERR message redundantly includes "tmp1075", which is unnecessary.

Remove the redundant module name to keep log messages concise.