### PR TITLE
doc: Update Graphviz font configuration

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -338,6 +338,9 @@ graphviz_dot_args = [
     "-Ncolor=gray60",
     "-Nfontcolor=gray25",
     "-Ecolor=gray60",
+    "-Gfontname=system-ui,-apple-system,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif",
+    "-Nfontname=system-ui,-apple-system,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif",
+    "-Efontname=SFMono-Regular,Menlo,Monaco,Consolas,Liberation Mono,Courier New,Courier,monospace",
 ]
 
 # -- Options for sphinx_copybutton ----------------------------------------


### PR DESCRIPTION
Customize Graphviz dot rendering to use same font stack as our Sphinx theme.

fixes #75121

### Before

<img width="833" alt="image" src="https://github.com/user-attachments/assets/c143a4ca-c9f1-47f4-9d6c-f42d20ff8dbc" />


### After

<img width="852" alt="image" src="https://github.com/user-attachments/assets/3eda7982-6830-41ef-9c2e-dbf7e4803cd8" />
