### PR TITLE
doc: make graphviz diagrams look good in dark theme

### DIFF
--- a/doc/_static/css/custom.css
+++ b/doc/_static/css/custom.css
@@ -922,6 +922,10 @@ dark-mode-toggle::part(toggleLabel){
   font-size: unset;
 }
 
+div.graphviz > object {
+    filter: var(--graphviz-filter);
+}
+
 /* Home page grid display */
 .grid {
     list-style-type: none !important;

--- a/doc/_static/css/dark.css
+++ b/doc/_static/css/dark.css
@@ -93,4 +93,6 @@
     --btn-neutral-background-color: #404040;
     --btn-neutral-hover-background-color: #505050;
     --footer-color: #aaa;
+
+    --graphviz-filter: invert(0.9) brightness(1.2);
 }

--- a/doc/_static/css/light.css
+++ b/doc/_static/css/light.css
@@ -91,4 +91,6 @@
     --btn-neutral-background-color: #f3f6f6;
     --btn-neutral-hover-background-color: #e5ebeb;
     --footer-color: #808080;
+
+    --graphviz-filter: none;
 }


### PR DESCRIPTION
Add CSS filter to invert colors in dark mode and make graphviz diagram more aligned with the overall look&feel of the page.

https://builds.zephyrproject.io/zephyr/pr/86509/docs/connectivity/bluetooth/api/audio/bluetooth-le-audio-arch.html#le-audio-stack
https://builds.zephyrproject.io/zephyr/pr/86509/docs/hardware/peripherals/dma.html#channel-state-machine-expectations

![image](https://github.com/user-attachments/assets/76dd2fa3-5195-48ff-8035-1703b32173ab)


fixes #75119