### PR TITLE
drivers: sensor: shell: fix logically deadcode issue

### DIFF
--- a/drivers/sensor/sensor_shell.c
+++ b/drivers/sensor/sensor_shell.c
@@ -283,7 +283,7 @@ static int parse_sensor_value(const char *val_str, struct sensor_value *out)
 {
 	const bool is_negative = val_str[0] == '-';
 	const char *decimal_pos = strchr(val_str, '.');
-	long value;
+	int64_t value;
 	char *endptr;
 
 	/* Parse int portion */


### PR DESCRIPTION
sca finds the code to be logically dead considering the size of long to be 4 bytes.
- Solution: use uint64_t type for the variable `value`.