### PR TITLE
sys: util_macro: introduce toggle bit function

### DIFF
--- a/include/zephyr/sys/util_macro.h
+++ b/include/zephyr/sys/util_macro.h
@@ -49,7 +49,7 @@ extern "C" {
 #define BIT64(_n) (1ULL << (_n))
 
 /**
- * @brief Toggle a bit
+ * @brief Toggle a specific bit of the given variable.
  *
  * The argument @p var is a variable whose value is written to as a
  * side effect.

--- a/include/zephyr/sys/util_macro.h
+++ b/include/zephyr/sys/util_macro.h
@@ -49,6 +49,17 @@ extern "C" {
 #define BIT64(_n) (1ULL << (_n))
 
 /**
+ * @brief Toggle a bit
+ *
+ * The argument @p var is a variable whose value is written to as a
+ * side effect.
+ *
+ * @param var Variable to be altered
+ * @param bit Bit number
+ */
+#define TOGGLE_BIT(var, bit) ((var) ^= BIT(bit))
+
+/**
  * @brief Set or clear a bit depending on a boolean value
  *
  * The argument @p var is a variable whose value is written to as a

--- a/tests/unit/util/main.c
+++ b/tests/unit/util/main.c
@@ -655,6 +655,18 @@ ZTEST(util, test_IS_SHIFTED_BIT_MASK)
 	zassert_true(IS_SHIFTED_BIT_MASK(0x8000000000000000ULL, 63));
 }
 
+ZTEST(util, test_TOGGLE_BIT)
+{
+	uint32_t var_toggle_bit_14 = 0x11004000UL;
+	uint32_t var_toggle_bit_31 = 0x80000111UL;
+
+	zassert_equal(TOGGLE_BIT(var_toggle_bit_14, 14), 0x11000000UL);
+	zassert_equal(TOGGLE_BIT(var_toggle_bit_14, 14), 0x11004000UL);
+
+	zassert_equal(TOGGLE_BIT(var_toggle_bit_31, 31), 0x00000111UL);
+	zassert_equal(TOGGLE_BIT(var_toggle_bit_31, 31), 0x80000111UL);
+}
+
 ZTEST(util, test_DIV_ROUND_UP)
 {
 	zassert_equal(DIV_ROUND_UP(0, 1), 0);


### PR DESCRIPTION
introduce toggle bit function

It seems that this function is already defined stm32 hal. Is this function better suited in `util_macro.h`
```
/__w/zephyr/modules/hal/stm32/stm32cube/stm32wb0x/soc/stm32wb0x.h:167: error: "TOGGLE_BIT" redefined [-Werror]
  167 | #define TOGGLE_BIT(REG, BIT)  ((REG) ^= (BIT))
```