### PR TITLE
dts: bindings: i2c: ti,tca954x-base: fix example syntax

### DIFF
--- a/dts/bindings/i2c/ti,tca954x-base.yaml
+++ b/dts/bindings/i2c/ti,tca954x-base.yaml
@@ -20,7 +20,7 @@ description: |
           reset-gpios = <&gpio5 3 GPIO_ACTIVE_LOW>;
 
           mux_i2c@0 {
-              compatible: "ti,tca9546a-channel"
+              compatible = "ti,tca9546a-channel";
               reg = <0>;
               #address-cells = <1>;
               #size-cells = <0>;
@@ -32,7 +32,7 @@ description: |
           };
 
           mux_i2c@1 {
-            compatible: "ti,tca9546a-channel"
+              compatible = "ti,tca9546a-channel";
               reg = <1>;
               #address-cells = <1>;
               #size-cells = <0>;


### PR DESCRIPTION
Fix the syntax in the device tree binding example by replacing `:` with `=` in the `compatible` property. This ensures consistency with the standard device tree syntax.