### PR TITLE
Add rt700 wwdt support for cm33_cpu0

### DIFF
--- a/boards/nxp/mimxrt700_evk/board.c
+++ b/boards/nxp/mimxrt700_evk/board.c
@@ -428,6 +428,10 @@ void board_early_init_hook(void)
 	CLOCK_EnableUsbhs0PhyPllClock(kCLOCK_Usbphy480M, usbClockFreq);
 	CLOCK_EnableUsbhs0Clock(kCLOCK_Usb480M, usbClockFreq);
 #endif
+
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(wwdt0))
+	CLOCK_AttachClk(kLPOSC_to_WWDT0);
+#endif
 }
 
 static void GlikeyWriteEnable(GLIKEY_Type *base, uint8_t idx)

--- a/boards/nxp/mimxrt700_evk/doc/index.rst
+++ b/boards/nxp/mimxrt700_evk/doc/index.rst
@@ -90,6 +90,8 @@ the hardware features below.
 +-----------+------------+-------------------------------------+
 | USB       | on-chip    | USB device                          |
 +-----------+------------+-------------------------------------+
+| WWDT      | on-chip    | watchdog                            |
++-----------+------------+-------------------------------------+
 
 The default configuration can be found in the defconfig file:
 

--- a/boards/nxp/mimxrt700_evk/mimxrt700_evk_mimxrt798s_cm33_cpu0.dts
+++ b/boards/nxp/mimxrt700_evk/mimxrt700_evk_mimxrt798s_cm33_cpu0.dts
@@ -20,6 +20,7 @@
 		led1 = &blue_led;
 		sw0 = &user_button_1;
 		sw1 = &user_button_2;
+		watchdog0 = &wwdt0;
 	};
 
 	chosen {
@@ -157,6 +158,10 @@ zephyr_udc0: &usb0 {
 	tx-d-cal = <7>;
 	tx-cal-45-dp-ohms = <6>;
 	tx-cal-45-dm-ohms = <6>;
+};
+
+&wwdt0 {
+	status = "okay";
 };
 
 p3t1755dp_ard_i2c_interface: &flexcomm8_lpi2c8 {};

--- a/boards/nxp/mimxrt700_evk/mimxrt700_evk_mimxrt798s_cm33_cpu0.yaml
+++ b/boards/nxp/mimxrt700_evk/mimxrt700_evk_mimxrt798s_cm33_cpu0.yaml
@@ -21,4 +21,5 @@ supported:
   - spi
   - adc
   - usb_device
+  - watchdog
 vendor: nxp

--- a/drivers/watchdog/wdt_mcux_wwdt.c
+++ b/drivers/watchdog/wdt_mcux_wwdt.c
@@ -83,7 +83,8 @@ static int mcux_wwdt_install_timeout(const struct device *dev,
 	}
 
 #if defined(CONFIG_SOC_MIMXRT685S_CM33) || defined(CONFIG_SOC_MIMXRT595S_CM33) \
-	|| defined(CONFIG_SOC_SERIES_MCXN)
+	|| defined(CONFIG_SOC_SERIES_MCXN) || defined(CONFIG_SOC_MIMXRT798S_CM33_CPU0) \
+	|| defined(CONFIG_SOC_MIMXRT798S_CM33_CPU1)
 	clock_freq = CLOCK_GetWdtClkFreq(0);
 #elif defined(CONFIG_SOC_SERIES_RW6XX)
 	clock_freq = CLOCK_GetWdtClkFreq();

--- a/dts/arm/nxp/nxp_rt7xx_cm33_cpu0.dtsi
+++ b/dts/arm/nxp/nxp_rt7xx_cm33_cpu0.dtsi
@@ -1051,6 +1051,22 @@
 		interrupts = <34 0>;
 		status = "disabled";
 	};
+
+	wwdt0: watchdog@e000 {
+		compatible = "nxp,lpc-wwdt";
+		reg = <0xe000 0x1000>;
+		interrupts = <42 0>;
+		status = "disabled";
+		clk-divider = <1>;
+	};
+
+	wwdt1: watchdog@2e000 {
+		compatible = "nxp,lpc-wwdt";
+		reg = <0x2e000 0x1000>;
+		interrupts = <43 0>;
+		status = "disabled";
+		clk-divider = <1>;
+	};
 };
 
 &systick {

--- a/tests/drivers/watchdog/wdt_basic_api/testcase.yaml
+++ b/tests/drivers/watchdog/wdt_basic_api/testcase.yaml
@@ -23,6 +23,7 @@ tests:
       - panb511evb/nrf54l15/cpuapp
       - panb511evb/nrf54l15/cpuflpr
       - panb511evb/nrf54l15/cpuflpr/xip
+      - mimxrt700_evk/mimxrt798s/cm33_cpu1
   drivers.watchdog.stm32wwdg:
     filter: dt_compat_enabled("st,stm32-window-watchdog") or dt_compat_enabled("st,stm32-watchdog")
     extra_args: DTC_OVERLAY_FILE="boards/stm32_wwdg.overlay"


### PR DESCRIPTION
Enable wwdt0 as watchdog0.
Test wdt_basic_api case passed(Only support cm33_cpu0 core).
