### PR TITLE
drivers: charger: unify log level

### DIFF
--- a/drivers/charger/charger_bq24190.c
+++ b/drivers/charger/charger_bq24190.c
@@ -18,7 +18,7 @@
 #include "zephyr/logging/log.h"
 #include <zephyr/drivers/gpio.h>
 
-LOG_MODULE_REGISTER(ti_bq24190);
+LOG_MODULE_REGISTER(ti_bq24190, CONFIG_CHARGER_LOG_LEVEL);
 
 struct bq24190_config {
 	struct i2c_dt_spec i2c;

--- a/drivers/charger/charger_max20335.c
+++ b/drivers/charger/charger_max20335.c
@@ -15,7 +15,7 @@
 #include <zephyr/sys/linear_range.h>
 
 #include "zephyr/logging/log.h"
-LOG_MODULE_REGISTER(max20335_charger);
+LOG_MODULE_REGISTER(max20335_charger, CONFIG_CHARGER_LOG_LEVEL);
 
 #define MAX20335_REG_STATUSA 0x02
 #define MAX20335_REG_STATUSB 0x03

--- a/drivers/charger/emul_sbs_charger.c
+++ b/drivers/charger/emul_sbs_charger.c
@@ -17,7 +17,7 @@
 
 #include "sbs_charger.h"
 
-LOG_MODULE_REGISTER(sbs_sbs_charger);
+LOG_MODULE_REGISTER(sbs_sbs_charger, CONFIG_CHARGER_LOG_LEVEL);
 
 /** Static configuration for the emulator */
 struct sbs_charger_emul_cfg {

--- a/drivers/charger/sbs_charger.c
+++ b/drivers/charger/sbs_charger.c
@@ -17,7 +17,7 @@ struct sbs_charger_config {
 	struct i2c_dt_spec i2c;
 };
 
-LOG_MODULE_REGISTER(sbs_charger);
+LOG_MODULE_REGISTER(sbs_charger, CONFIG_CHARGER_LOG_LEVEL);
 
 static int sbs_cmd_reg_read(const struct device *dev, uint8_t reg_addr, uint16_t *val)
 {


### PR DESCRIPTION
Instead of using `CONFIG_LOG_DEFAULT_LEVEL`, use explicitly charger log level `CONFIG_CHARGER_LOG_LEVEL` for all hardware charger supported.