### PR TITLE
drivers: retained_mem: Fix using multiple nRF retained memory regions

### DIFF
--- a/drivers/retained_mem/retained_mem_nrf_ram_ctrl.c
+++ b/drivers/retained_mem/retained_mem_nrf_ram_ctrl.c
@@ -12,7 +12,7 @@
 
 #define _BUILD_MEM_REGION(node_id)		    \
 	{.dt_addr = DT_REG_ADDR(DT_PARENT(node_id)),\
-	 .dt_size = DT_REG_SIZE(DT_PARENT(node_id))}
+	 .dt_size = DT_REG_SIZE(DT_PARENT(node_id))},
 
 struct ret_mem_region {
 	uintptr_t dt_addr;


### PR DESCRIPTION
Fixes an error when using multiple nRF retained memory regions caused by a missing separating comma.