### PR TITLE
ci: Expand multiplatform smoke test

### DIFF
--- a/.github/workflows/hello_world_multiplatform.yaml
+++ b/.github/workflows/hello_world_multiplatform.yaml
@@ -20,6 +20,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
+env:
+  PYTHONIOENCODING: utf-8
+
 jobs:
   build:
     strategy:
@@ -61,7 +64,7 @@ jobs:
           app-path: zephyr
           toolchains: all
 
-      - name: Build firmware
+      - name: Build firmware No. 1 - basic
         working-directory: zephyr
         shell: bash
         run: |
@@ -71,6 +74,117 @@ jobs:
             EXTRA_TWISTER_FLAGS="-P native_sim --short-build-path -O/tmp/twister-out"
           fi
           ./scripts/twister --runtime-artifact-cleanup --force-color --inline-logs -T samples/hello_world -T samples/cpp/hello_world -v $EXTRA_TWISTER_FLAGS
+
+      - name: Build firmware No. 2 - save and load with emulation only
+        working-directory: zephyr
+        shell: bash
+        run: |
+          if [ "${{ runner.os }}" = "macOS" ]; then
+            EXTRA_TWISTER_FLAGS="-P native_sim --build-only"
+          elif [ "${{ runner.os }}" = "Windows" ]; then
+            EXTRA_TWISTER_FLAGS="-P native_sim --short-build-path -O/tmp/twister-out"
+          fi
+          BASIC_FLAGS="--runtime-artifact-cleanup --force-color --inline-logs -T samples/hello_world -T samples/cpp/hello_world -v $EXTRA_TWISTER_FLAGS"
+          ./scripts/twister --save-tests tests.file $BASIC_FLAGS
+          ./scripts/twister --load-tests tests.file --emulation-only $BASIC_FLAGS
+          rm tests.file
+
+      - name: Build firmware No. 3 - print out test plan
+        working-directory: zephyr
+        shell: bash
+        run: |
+          if [ "${{ runner.os }}" = "macOS" ]; then
+            EXTRA_TWISTER_FLAGS="-P native_sim --build-only"
+          elif [ "${{ runner.os }}" = "Windows" ]; then
+            EXTRA_TWISTER_FLAGS="-P native_sim --short-build-path -O/tmp/twister-out"
+          fi
+          BASIC_FLAGS="--runtime-artifact-cleanup --force-color --inline-logs -v $EXTRA_TWISTER_FLAGS"
+          ./scripts/twister --test-tree -T tests/kernel/spinlock $BASIC_FLAGS
+
+      - name: Build firmware No. 4 - integration, exclude tag, filter, shuffle, dry run
+        working-directory: zephyr
+        shell: bash
+        run: |
+          if [ "${{ runner.os }}" = "macOS" ]; then
+            EXTRA_TWISTER_FLAGS="-P native_sim --build-only"
+          elif [ "${{ runner.os }}" = "Windows" ]; then
+            EXTRA_TWISTER_FLAGS="-P native_sim --short-build-path -O/tmp/twister-out"
+          fi
+          BASIC_FLAGS="--runtime-artifact-cleanup --force-color --inline-logs -v $EXTRA_TWISTER_FLAGS"
+          ./scripts/twister --dry-run --integration --subset 1/3 --shuffle-tests --shuffle-tests-seed 1 --filter runnable --exclude-tag audio --exclude-tag driver $BASIC_FLAGS
+
+      - name: Build firmware No. 5 - test, arch, vendor, exclude-platform, platform-reports
+        working-directory: zephyr
+        shell: bash
+        run: |
+          if [ "${{ runner.os }}" = "macOS" ]; then
+            EXTRA_TWISTER_FLAGS="-P native_sim --build-only"
+          elif [ "${{ runner.os }}" = "Windows" ]; then
+            EXTRA_TWISTER_FLAGS="-P native_sim --short-build-path -O/tmp/twister-out"
+          fi
+          BASIC_FLAGS="--runtime-artifact-cleanup --force-color --inline-logs -v $EXTRA_TWISTER_FLAGS"
+          ./scripts/twister --test kernel.multiprocessing.spinlock --arch x86 --exclude-platform qemu_x86_64 --vendor qemu --platform-reports $BASIC_FLAGS
+
+      - name: Build firmware No. 6 - subtest, platform, rom-ram report, ROM footprint report from buildlog, size report
+        working-directory: zephyr
+        shell: bash
+        run: |
+          if [ "${{ runner.os }}" = "macOS" ]; then
+            EXTRA_TWISTER_FLAGS="-P native_sim --build-only"
+          elif [ "${{ runner.os }}" = "Windows" ]; then
+            EXTRA_TWISTER_FLAGS="-P native_sim --short-build-path -O/tmp/twister-out"
+          fi
+          BASIC_FLAGS="--runtime-artifact-cleanup --force-color --inline-logs -v $EXTRA_TWISTER_FLAGS"
+          ./scripts/twister --sub-test kernel.multiprocessing.spinlock.minimallibc.spinlock.spinlock_basic --platform qemu_x86 --create-rom-ram-report --footprint-report ROM --enable-size-report --footprint-from-buildlog $BASIC_FLAGS
+
+      - name: Build firmware No. 7 - list tags
+        working-directory: zephyr
+        shell: bash
+        run: |
+          if [ "${{ runner.os }}" = "macOS" ]; then
+            EXTRA_TWISTER_FLAGS="-P native_sim --build-only"
+          elif [ "${{ runner.os }}" = "Windows" ]; then
+            EXTRA_TWISTER_FLAGS="-P native_sim --short-build-path -O/tmp/twister-out"
+          fi
+          BASIC_FLAGS="--runtime-artifact-cleanup --force-color --inline-logs -v $EXTRA_TWISTER_FLAGS"
+          ./scripts/twister --sub-test kernel.multiprocessing.spinlock.minimallibc.spinlock.spinlock_basic --list-tags $BASIC_FLAGS
+
+      - name: Build firmware No. 8 - list tests
+        working-directory: zephyr
+        shell: bash
+        run: |
+          if [ "${{ runner.os }}" = "macOS" ]; then
+            EXTRA_TWISTER_FLAGS="-P native_sim --build-only"
+          elif [ "${{ runner.os }}" = "Windows" ]; then
+            EXTRA_TWISTER_FLAGS="-P native_sim --short-build-path -O/tmp/twister-out"
+          fi
+          BASIC_FLAGS="--runtime-artifact-cleanup --force-color --inline-logs -v $EXTRA_TWISTER_FLAGS"
+          ./scripts/twister -T tests/posix/common --list-tests $BASIC_FLAGS
+
+      - name: Build firmware No. 9 - report flags - dir, name, suffix, summary, all-options, filtered
+        working-directory: zephyr
+        shell: bash
+        run: |
+          if [ "${{ runner.os }}" = "macOS" ]; then
+            EXTRA_TWISTER_FLAGS="-P native_sim --build-only"
+          elif [ "${{ runner.os }}" = "Windows" ]; then
+            EXTRA_TWISTER_FLAGS="-P native_sim --short-build-path -O/tmp/twister-out"
+          fi
+          BASIC_FLAGS="--runtime-artifact-cleanup --force-color --inline-logs -v $EXTRA_TWISTER_FLAGS"
+          ./scripts/twister --sub-test kernel.multiprocessing.spinlock.minimallibc.spinlock.spinlock_basic --platform qemu_x86 --report-dir . --report-name test_name --report-suffix suffix --report-summary 0 --report-all-options --report-filtered $BASIC_FLAGS
+
+      - name: Build firmware No. 10 - force platform and toolchain, log level, timestamps, logfile
+        working-directory: zephyr
+        shell: bash
+        run: |
+          if [ "${{ runner.os }}" = "macOS" ]; then
+            EXTRA_TWISTER_FLAGS="-P native_sim --build-only"
+          elif [ "${{ runner.os }}" = "Windows" ]; then
+            EXTRA_TWISTER_FLAGS="-P native_sim --short-build-path -O/tmp/twister-out"
+          fi
+          BASIC_FLAGS="--runtime-artifact-cleanup --force-color --inline-logs -v $EXTRA_TWISTER_FLAGS"
+          ./scripts/twister --sub-test kernel.multiprocessing.spinlock.minimallibc.spinlock.spinlock_basic --force-platform --platform qemu_x86 --force-toolchain --log-level WARNING --log-file log.file $BASIC_FLAGS
+          rm log.file
 
       - name: Upload artifacts
         if: failure()


### PR DESCRIPTION
Add a few different calls, with different flag setup.
Covers over 1/3 of flags in this configuration.