### PR TITLE
drivers: sensor: ams_as5600: Rewrite driver to enhance configuration

### DIFF
--- a/drivers/sensor/ams/ams_as5600/ams_as5600.c
+++ b/drivers/sensor/ams/ams_as5600/ams_as5600.c
@@ -1,100 +1,656 @@
 /*
  * Copyright (c) 2022, Felipe Neves
+ * Copyright (c) 2025, Cameron Ewing
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #define DT_DRV_COMPAT ams_as5600
 
-#include <errno.h>
-#include <zephyr/sys/__assert.h>
-#include <zephyr/sys/util.h>
 #include <zephyr/device.h>
-#include <zephyr/init.h>
+#include <zephyr/devicetree.h>
 #include <zephyr/drivers/sensor.h>
 #include <zephyr/drivers/i2c.h>
+#include <zephyr/drivers/sensor/ams_as5600.h>
+
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(ams_as5600, CONFIG_SENSOR_LOG_LEVEL);
 
-#define AS5600_ANGLE_REGISTER_H 0x0E
-#define AS5600_FULL_ANGLE		360
-#define AS5600_PULSES_PER_REV	4096
-#define AS5600_MILLION_UNIT	1000000
+#if DT_NUM_INST_STATUS_OKAY(DT_DRV_COMPAT) == 0
+#warning "AMS AS5600 driver enabled without any devices"
+#endif
 
-struct as5600_dev_cfg {
-	struct i2c_dt_spec i2c_port;
-};
+#define AS5600_FULL_ANGLE     360
+#define AS5600_PULSES_PER_REV 4096
+#define AS5600_MILLION_UNIT   1000000
 
-/* Device run time data */
-struct as5600_dev_data {
-	uint16_t position;
-};
-
-static int as5600_fetch(const struct device *dev, enum sensor_channel chan)
+/**
+ * @brief Set a bitfield within a byte buffer.
+ *
+ * This function modifies a specific bitfield within a byte buffer by first clearing
+ * the bits specified by the mask and then setting them to the provided value.
+ *
+ * @param buf Pointer to the byte buffer to be modified.
+ * @param value The value to set the bitfield to.
+ * @param shift The number of bits to shift the value to the correct position.
+ * @param mask The bitmask specifying the bitfield to be modified.
+ */
+static inline void as5600_set_bitfield(uint8_t *buf, int32_t value, uint8_t shift, uint8_t mask)
 {
-	struct as5600_dev_data *dev_data = dev->data;
-	const struct as5600_dev_cfg *dev_cfg = dev->config;
-
-	uint8_t read_data[2] = {0, 0};
-	uint8_t angle_reg = AS5600_ANGLE_REGISTER_H;
-
-	int err = i2c_write_read_dt(&dev_cfg->i2c_port,
-						&angle_reg,
-						1,
-						&read_data,
-						sizeof(read_data));
-
-	/* invalid readings preserves the last good value */
-	if (!err) {
-		dev_data->position = ((uint16_t)read_data[0] << 8) | read_data[1];
-	}
-
-	return err;
+	*buf &= ~mask;
+	*buf |= (value << shift) & mask;
 }
 
-static int as5600_get(const struct device *dev, enum sensor_channel chan,
-			struct sensor_value *val)
+/**
+ * @brief Convert a value to a register format.
+ *
+ * This function converts a given 12-bit value to bytes and stores it in the provided buffer.
+ *
+ * @param buf Pointer to the buffer where the register value will be stored.
+ * @param val Pointer to the value to be converted.
+ * @param mask Mask to be applied to the value during conversion.
+ */
+static inline void as5600_12bit_to_reg(uint8_t *buf, int32_t value)
 {
-	struct as5600_dev_data *dev_data = dev->data;
+	buf[0] = (value >> 8) & 0x0F;
+	buf[1] = value & 0xFF;
+}
 
-	if (chan == SENSOR_CHAN_ROTATION) {
-		val->val1 = ((int32_t)dev_data->position * AS5600_FULL_ANGLE) /
-							AS5600_PULSES_PER_REV;
+/**
+ * @brief Fetch a sample from the AS5600 sensor for a specific channel.
+ *
+ * This function retrieves a sample from the AS5600 sensor and stores it in the
+ * appropriate data structure for the specified sensor channel.
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param chan The sensor channel to fetch the sample for.
+ *
+ * @return 0 if successful, a negative error code otherwise.
+ */
+static int as5600_sample_fetch_chan(const struct device *dev, enum sensor_channel chan)
+{
+	struct as5600_data *data = dev->data;
+	const struct as5600_config *config = dev->config;
 
-		val->val2 = (((int32_t)dev_data->position * AS5600_FULL_ANGLE) %
-			     AS5600_PULSES_PER_REV) * (AS5600_MILLION_UNIT / AS5600_PULSES_PER_REV);
-	} else {
+	uint8_t buf[4];
+	int err;
+
+	switch (chan) {
+	case SENSOR_CHAN_ALL: {
+		/* Reads are split due to the special behavior of the Angle registers */
+
+		err = i2c_burst_read_dt(&config->i2c, AS5600_RAW_STEPS_H, buf, AS5600_TWO_REG);
+		if (err < 0) {
+			return err;
+		}
+
+		err = i2c_burst_read_dt(&config->i2c, AS5600_FILTERED_STEPS_H, &buf[2],
+					AS5600_TWO_REG);
+		if (err < 0) {
+			return err;
+		}
+
+		data->raw_steps = AS5600_REG_TO_12BIT(buf[0], AS5600_12BIT_H_MASK, buf[1]);
+		data->filtered_steps = AS5600_REG_TO_12BIT(buf[2], AS5600_12BIT_H_MASK, buf[3]);
+
+		err = i2c_burst_read_dt(&config->i2c, AS5600_AGC, buf, 3);
+		if (err < 0) {
+			return err;
+		}
+
+		data->agc = buf[0];
+		data->magnitude = AS5600_REG_TO_12BIT(buf[1], AS5600_12BIT_H_MASK, buf[2]);
+
+		return 0;
+	}
+
+	/* Match original implementation: use the filtered step count for calculating rotation */
+	case SENSOR_CHAN_ROTATION: {
+		err = i2c_burst_read_dt(&config->i2c, AS5600_FILTERED_STEPS_H, buf, AS5600_TWO_REG);
+		if (err < 0) {
+			return err;
+		}
+
+		data->filtered_steps = AS5600_REG_TO_12BIT(buf[0], AS5600_12BIT_H_MASK, buf[1]);
+		return 0;
+	}
+
+	default:
+		break;
+	}
+
+	switch ((enum as5600_sensor_channel)chan) {
+	case AS5600_SENSOR_CHAN_RAW_STEPS: {
+		err = i2c_burst_read_dt(&config->i2c, AS5600_RAW_STEPS_H, buf, AS5600_TWO_REG);
+		if (err < 0) {
+			return err;
+		}
+
+		data->raw_steps = AS5600_REG_TO_12BIT(buf[0], AS5600_12BIT_H_MASK, buf[1]);
+		break;
+	}
+
+	case AS5600_SENSOR_CHAN_FILTERED_STEPS: {
+		err = i2c_burst_read_dt(&config->i2c, AS5600_FILTERED_STEPS_H, buf, AS5600_TWO_REG);
+		if (err < 0) {
+			return err;
+		}
+
+		data->filtered_steps = AS5600_REG_TO_12BIT(buf[0], AS5600_12BIT_H_MASK, buf[1]);
+		break;
+	}
+
+	case AS5600_SENSOR_CHAN_AGC: {
+		err = i2c_reg_read_byte_dt(&config->i2c, AS5600_AGC, &buf[0]);
+		if (err < 0) {
+			return err;
+		}
+
+		data->agc = buf[0];
+		break;
+	}
+
+	case AS5600_SENSOR_CHAN_MAGNITUDE: {
+		err = i2c_burst_read_dt(&config->i2c, AS5600_MAGNITUDE_H, buf, AS5600_TWO_REG);
+		if (err < 0) {
+			return err;
+		}
+
+		data->magnitude = AS5600_REG_TO_12BIT(buf[0], AS5600_12BIT_H_MASK, buf[1]);
+		break;
+	}
+
+	default:
 		return -ENOTSUP;
 	}
 
 	return 0;
 }
 
-static int as5600_initialize(const struct device *dev)
+/**
+ * @brief Get the sensor value for a specific channel from the internal data.
+ *
+ * This function retrieves the sensor value for a specified channel and stores it
+ * in the provided sensor_value structure.
+ *
+ * Device specific sensor channels are defined in the sensor header file.
+ *
+ * @param dev Pointer to the device structure.
+ * @param chan The sensor channel to retrieve the value from.
+ * @param val Pointer to the sensor_value structure where the value will be stored.
+ *
+ * @return 0 on success, -ENOTSUP if the channel is not supported.
+ */
+static int as5600_channel_get(const struct device *dev, enum sensor_channel chan,
+			      struct sensor_value *val)
 {
-	struct as5600_dev_data *const dev_data = dev->data;
+	struct as5600_data *data = dev->data;
 
-	dev_data->position = 0;
+	/* Matches original implementation: angular range is not accounted for */
+	if (chan == SENSOR_CHAN_ROTATION) {
+		val->val1 =
+			((int32_t)data->filtered_steps * AS5600_FULL_ANGLE) / AS5600_PULSES_PER_REV;
 
-	LOG_INF("Device %s initialized", dev->name);
+		val->val2 = (((int32_t)data->filtered_steps * AS5600_FULL_ANGLE) %
+			     AS5600_PULSES_PER_REV) *
+			    (AS5600_MILLION_UNIT / AS5600_PULSES_PER_REV);
+		return 0;
+	}
+
+	switch ((enum as5600_sensor_channel)chan) {
+	case AS5600_SENSOR_CHAN_RAW_STEPS:
+		val->val1 = data->raw_steps;
+		break;
+
+	case AS5600_SENSOR_CHAN_FILTERED_STEPS:
+		val->val1 = data->filtered_steps;
+		break;
+
+	case AS5600_SENSOR_CHAN_AGC:
+		val->val1 = data->agc;
+		break;
+
+	case AS5600_SENSOR_CHAN_MAGNITUDE:
+		val->val1 = data->magnitude;
+		break;
+
+	default:
+		return -ENOTSUP;
+	}
+
+	val->val2 = 0;
+	return 0;
+}
+
+/**
+ * @brief Get device attributes/configuration
+ *
+ * This function retrieves the specified attribute of the AS5600 sensor.
+ * The passed channel is ignored as the attributes are global to the device.
+ *
+ * Device specific attributes are defined in the sensor header file.
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param chan Ignored.
+ * @param attr The attribute to retrieve.
+ * @param val Pointer to the sensor_value structure to store the retrieved value.
+ *
+ * @return 0 if successful, negative error code otherwise.
+ *
+ */
+static int as5600_attr_get(const struct device *dev, enum sensor_channel chan,
+			   enum sensor_attribute attr, struct sensor_value *val)
+{
+	ARG_UNUSED(chan);
+	const struct as5600_config *config = dev->config;
+
+	uint8_t buf[AS5600_TWO_REG];
+	int err;
+
+	if (attr == SENSOR_ATTR_HYSTERESIS) {
+		err = i2c_reg_read_byte_dt(&config->i2c, AS5600_CONF_L, &buf[0]);
+		if (err < 0) {
+			return err;
+		}
+
+		val->val1 = AS5600_BITFIELD_TO_VAL(buf[0], AS5600_CONF_L_HYST, 2);
+		val->val2 = 0;
+		return 0;
+	}
+
+	switch ((enum as5600_sensor_attribute)attr) {
+
+	case AS5600_ATTR_BURNS:
+		err = i2c_reg_read_byte_dt(&config->i2c, AS5600_ZMCO, &buf[0]);
+		if (err < 0) {
+			return err;
+		}
+
+		val->val1 = AS5600_BITFIELD_TO_VAL(buf[0], AS5600_ZMCO_MASK, 0);
+		break;
+	case AS5600_ATTR_START_POSITION:
+		err = i2c_burst_read_dt(&config->i2c, AS5600_ZPOS_H, &buf[0], AS5600_TWO_REG);
+		if (err < 0) {
+			return err;
+		}
+
+		val->val1 = AS5600_REG_TO_12BIT(buf[0], AS5600_12BIT_H_MASK, buf[1]);
+		break;
+
+	case AS5600_ATTR_END_POSITION:
+		err = i2c_burst_read_dt(&config->i2c, AS5600_MPOS_H, &buf[0], AS5600_TWO_REG);
+		if (err < 0) {
+			return err;
+		}
+
+		val->val1 = AS5600_REG_TO_12BIT(buf[0], AS5600_12BIT_H_MASK, buf[1]);
+		break;
+
+	case AS5600_ATTR_ANGULAR_RANGE:
+		err = i2c_burst_read_dt(&config->i2c, AS5600_MANG_H, &buf[0], AS5600_TWO_REG);
+		if (err < 0) {
+			return err;
+		}
+
+		val->val1 = AS5600_REG_TO_12BIT(buf[0], AS5600_12BIT_H_MASK, buf[1]);
+		break;
+
+	case AS5600_ATTR_POWER_MODE:
+		err = i2c_reg_read_byte_dt(&config->i2c, AS5600_CONF_L, &buf[0]);
+		if (err < 0) {
+			return err;
+		}
+
+		val->val1 = AS5600_BITFIELD_TO_VAL(buf[0], AS5600_CONF_L_PM, 0);
+		break;
+
+	case AS5600_ATTR_OUTPUT_STAGE:
+		err = i2c_reg_read_byte_dt(&config->i2c, AS5600_CONF_L, &buf[0]);
+		if (err < 0) {
+			return err;
+		}
+
+		val->val1 = AS5600_BITFIELD_TO_VAL(buf[0], AS5600_CONF_L_OUTS, 4);
+		break;
+
+	case AS5600_ATTR_PWM_FREQ:
+		err = i2c_reg_read_byte_dt(&config->i2c, AS5600_CONF_L, &buf[0]);
+		if (err < 0) {
+			return err;
+		}
+
+		val->val1 = AS5600_BITFIELD_TO_VAL(buf[0], AS5600_CONF_L_PWMF, 6);
+		break;
+
+	case AS5600_ATTR_SLOW_FILTER:
+		err = i2c_reg_read_byte_dt(&config->i2c, AS5600_CONF_H, &buf[0]);
+		if (err < 0) {
+			return err;
+		}
+
+		val->val1 = AS5600_BITFIELD_TO_VAL(buf[0], AS5600_CONF_H_SF, 0);
+		break;
+
+	case AS5600_ATTR_FAST_FILTER_THRESHOLD:
+		err = i2c_reg_read_byte_dt(&config->i2c, AS5600_CONF_H, &buf[0]);
+		if (err < 0) {
+			return err;
+		}
+
+		val->val1 = AS5600_BITFIELD_TO_VAL(buf[0], AS5600_CONF_H_FTH, 2);
+		break;
+
+	case AS5600_ATTR_WATCH_DOG:
+		err = i2c_reg_read_byte_dt(&config->i2c, AS5600_CONF_H, &buf[0]);
+		if (err < 0) {
+			return err;
+		}
+
+		val->val1 = AS5600_BITFIELD_TO_VAL(buf[0], AS5600_CONF_H_WD, 5);
+		break;
+
+	case AS5600_ATTR_I2CADDR:
+		err = i2c_reg_read_byte_dt(&config->i2c, AS5600_I2CADDR, &buf[0]);
+		if (err < 0) {
+			return err;
+		}
+
+		val->val1 = AS5600_BITFIELD_TO_VAL(buf[0], AS5600_I2CADDR_MASK, 1);
+		break;
+
+	case AS5600_ATTR_STATUS:
+		err = i2c_reg_read_byte_dt(&config->i2c, AS5600_STATUS, &buf[0]);
+		if (err < 0) {
+			return err;
+		}
+
+		val->val1 = AS5600_BITFIELD_TO_VAL(buf[0], AS5600_STATUS_MASK, 3);
+		break;
+
+	default:
+		return -ENOTSUP;
+	}
+
+	val->val2 = 0;
+	return 0;
+};
+
+/**
+ * @brief Set sensor attribute for the AS5600 sensor.
+ *
+ * This function sets a specific attribute for the AS5600 sensor ignoring the channel as all
+ * attributes are global for this sensor.
+ *
+ * Device specific attributes are defined in the sensor header file.
+ *
+ * NOTE: END_POSITION and ANGULAR_RANGE are mutually exclusive.
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param chan The sensor channel to set the attribute for.
+ * @param attr The sensor attribute to set.
+ * @param val Pointer to the value to set the attribute to.
+ *
+ * @return 0 if successful, -ENOTSUP for read only registers, negative errno code if failure.
+ */
+static int as5600_attr_set(const struct device *dev, enum sensor_channel chan,
+			   enum sensor_attribute attr, const struct sensor_value *val)
+{
+	ARG_UNUSED(chan);
+	const struct as5600_config *config = dev->config;
+	uint8_t buf[AS5600_TWO_REG];
+	int err;
+
+	if (attr == SENSOR_ATTR_HYSTERESIS) {
+		err = i2c_reg_read_byte_dt(&config->i2c, AS5600_CONF_L, &buf[0]);
+		if (err < 0) {
+			return err;
+		}
+
+		as5600_set_bitfield(&buf[0], val->val1, 2, AS5600_CONF_L_HYST);
+
+		err = i2c_reg_write_byte_dt(&config->i2c, AS5600_CONF_L, buf[0]);
+		return err;
+	}
+
+	switch ((enum as5600_sensor_attribute)attr) {
+
+	case AS5600_ATTR_START_POSITION:
+		as5600_12bit_to_reg(&buf[0], val->val1);
+
+		err = i2c_burst_write_dt(&config->i2c, AS5600_ZPOS_H, &buf[0], AS5600_TWO_REG);
+		return err;
+
+	case AS5600_ATTR_END_POSITION:
+		as5600_12bit_to_reg(&buf[0], val->val1);
+
+		err = i2c_burst_write_dt(&config->i2c, AS5600_MPOS_H, &buf[0], AS5600_TWO_REG);
+		return err;
+
+	case AS5600_ATTR_ANGULAR_RANGE:
+		as5600_12bit_to_reg(&buf[0], val->val1);
+
+		err = i2c_burst_write_dt(&config->i2c, AS5600_MANG_H, &buf[0], AS5600_TWO_REG);
+		return err;
+
+	case AS5600_ATTR_POWER_MODE:
+		err = i2c_reg_read_byte_dt(&config->i2c, AS5600_CONF_L, &buf[0]);
+		if (err < 0) {
+			return err;
+		}
+
+		as5600_set_bitfield(&buf[0], val->val1, 0, AS5600_CONF_L_PM);
+
+		err = i2c_reg_write_byte_dt(&config->i2c, AS5600_CONF_L, buf[0]);
+		return err;
+
+	case AS5600_ATTR_OUTPUT_STAGE:
+		err = i2c_reg_read_byte_dt(&config->i2c, AS5600_CONF_L, &buf[0]);
+		if (err < 0) {
+			return err;
+		}
+
+		as5600_set_bitfield(&buf[0], val->val1, 4, AS5600_CONF_L_OUTS);
+
+		err = i2c_reg_write_byte_dt(&config->i2c, AS5600_CONF_L, buf[0]);
+		return err;
+
+	case AS5600_ATTR_PWM_FREQ:
+		err = i2c_reg_read_byte_dt(&config->i2c, AS5600_CONF_L, &buf[0]);
+		if (err < 0) {
+			return err;
+		}
+
+		as5600_set_bitfield(&buf[0], val->val1, 6, AS5600_CONF_L_PWMF);
+
+		err = i2c_reg_write_byte_dt(&config->i2c, AS5600_CONF_L, buf[0]);
+		return err;
+
+	case AS5600_ATTR_SLOW_FILTER:
+		err = i2c_reg_read_byte_dt(&config->i2c, AS5600_CONF_H, &buf[0]);
+		if (err < 0) {
+			return err;
+		}
+
+		as5600_set_bitfield(&buf[0], val->val1, 0, AS5600_CONF_H_SF);
+
+		err = i2c_reg_write_byte_dt(&config->i2c, AS5600_CONF_H, buf[0]);
+		return err;
+
+	case AS5600_ATTR_FAST_FILTER_THRESHOLD:
+		err = i2c_reg_read_byte_dt(&config->i2c, AS5600_CONF_H, &buf[0]);
+		if (err < 0) {
+			return err;
+		}
+
+		as5600_set_bitfield(&buf[0], val->val1, 2, AS5600_CONF_H_FTH);
+
+		err = i2c_reg_write_byte_dt(&config->i2c, AS5600_CONF_H, buf[0]);
+		return err;
+
+	case AS5600_ATTR_WATCH_DOG:
+		err = i2c_reg_read_byte_dt(&config->i2c, AS5600_CONF_H, &buf[0]);
+		if (err < 0) {
+			return err;
+		}
+
+		as5600_set_bitfield(&buf[0], val->val1, 5, AS5600_CONF_H_WD);
+
+		err = i2c_reg_write_byte_dt(&config->i2c, AS5600_CONF_H, buf[0]);
+		return err;
+
+	case AS5600_ATTR_BURNS:
+	case AS5600_ATTR_STATUS:
+	case AS5600_ATTR_I2CADDR:
+		LOG_WRN("Attribute %d is read only", attr);
+	default:
+		return -ENOTSUP;
+	}
+};
+
+DEVICE_API(sensor, as5600_api) = {
+	.sample_fetch = &as5600_sample_fetch_chan,
+	.channel_get = &as5600_channel_get,
+	.attr_get = &as5600_attr_get,
+	.attr_set = &as5600_attr_set,
+};
+
+/**
+ * @brief Initialize the AS5600 sensor device.
+ *
+ * This function initializes the AS5600 sensor device. If the device is not configured
+ * in the device tree, it will be initialized with its power-on reset settings.
+ * This function does not verify the device settings. If the device was previously burned
+ * settings may not be applied. The user is expected to confirm that the settings were
+ * applied correctly.
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ *
+ * @return 0 if successful, or a negative error code on failure.
+ */
+static int as5600_init(const struct device *dev)
+{
+	const struct as5600_config *config = dev->config;
+	const struct i2c_dt_spec *i2c = &config->i2c;
+
+	int err;
+	struct sensor_value val;
+	uint8_t conf[AS5600_TWO_REG];
+
+	/* Check the I2C address from the device */
+	err = as5600_attr_get(dev, SENSOR_CHAN_ALL, AS5600_ATTR_I2CADDR, &val);
+	if (err < 0) {
+		LOG_ERR("Could not read I2C address");
+		return err;
+	}
+
+	if (val.val1 != i2c->addr) {
+		LOG_ERR("I2C address is incorrect. Found 0x%x, Expected 0x%x", val.val1,
+			config->i2c.addr);
+		return -EINVAL;
+	}
+
+	/* End Position and Angular Range are mutually exclusive, Error if both are set */
+	if ((config->end_position != AS5600_UNCONFIGURED_2_REG) &&
+	    (config->angular_range != AS5600_UNCONFIGURED_2_REG)) {
+		LOG_ERR("End Position and Angular Range are mutually exclusive");
+		return -EINVAL;
+	}
+
+	/* Apply the device tree settings to the sensor if configured, otherwise use power on reset
+	 * values
+	 */
+
+	err = i2c_burst_read_dt(i2c, AS5600_CONF_H, conf, AS5600_TWO_REG);
+	if (err < 0) {
+		LOG_ERR("Could not read CONF registers");
+		return err;
+	}
+
+	if (config->power_mode != AS5600_UNCONFIGURED_1_REG) {
+		as5600_set_bitfield(&conf[1], config->power_mode, 0, AS5600_CONF_L_PM);
+	}
+
+	if (config->hysteresis != AS5600_UNCONFIGURED_1_REG) {
+		as5600_set_bitfield(&conf[1], config->hysteresis, 2, AS5600_CONF_L_HYST);
+	}
+
+	if (config->output_stage != AS5600_UNCONFIGURED_1_REG) {
+		as5600_set_bitfield(&conf[1], config->output_stage, 4, AS5600_CONF_L_OUTS);
+	}
+
+	if (config->pwm_frequency != AS5600_UNCONFIGURED_1_REG) {
+		as5600_set_bitfield(&conf[1], config->pwm_frequency, 6, AS5600_CONF_L_PWMF);
+	}
+
+	if (config->slow_filter != AS5600_UNCONFIGURED_1_REG) {
+		as5600_set_bitfield(&conf[0], config->slow_filter, 0, AS5600_CONF_H_SF);
+	}
+
+	if (config->fast_filter_threshold != AS5600_UNCONFIGURED_1_REG) {
+		as5600_set_bitfield(&conf[0], config->fast_filter_threshold, 2, AS5600_CONF_H_FTH);
+	}
+
+	if (config->watch_dog != AS5600_UNCONFIGURED_1_REG) {
+		as5600_set_bitfield(&conf[0], config->watch_dog, 5, AS5600_CONF_H_WD);
+	}
+
+	err = i2c_burst_write_dt(i2c, AS5600_CONF_H, conf, AS5600_TWO_REG);
+	if (err < 0) {
+		LOG_ERR("Could not write CONF registers");
+		return err;
+	}
+
+	if (config->start_position != AS5600_UNCONFIGURED_2_REG) {
+		as5600_12bit_to_reg(conf, config->start_position);
+
+		err = i2c_burst_write_dt(i2c, AS5600_ZPOS_H, conf, AS5600_TWO_REG);
+		if (err < 0) {
+			LOG_ERR("Could not write ZPOS registers");
+			return err;
+		}
+	}
+
+	if (config->end_position != AS5600_UNCONFIGURED_2_REG) {
+		as5600_12bit_to_reg(conf, config->end_position);
+
+		err = i2c_burst_write_dt(i2c, AS5600_MPOS_H, conf, AS5600_TWO_REG);
+		if (err < 0) {
+			LOG_ERR("Could not write MPOS registers");
+			return err;
+		}
+	}
+
+	if (config->angular_range != AS5600_UNCONFIGURED_2_REG) {
+		as5600_12bit_to_reg(conf, config->angular_range);
+
+		err = i2c_burst_write_dt(i2c, AS5600_MANG_H, conf, AS5600_TWO_REG);
+		if (err < 0) {
+			LOG_ERR("Could not write MANG registers");
+			return err;
+		}
+	}
 
 	return 0;
 }
 
-static DEVICE_API(sensor, as5600_driver_api) = {
-	.sample_fetch = as5600_fetch,
-	.channel_get = as5600_get,
-};
-
-#define AS5600_INIT(n)						\
-	static struct as5600_dev_data as5600_data##n;		\
-	static const struct as5600_dev_cfg as5600_cfg##n = {\
-		.i2c_port = I2C_DT_SPEC_INST_GET(n)	\
-	};	\
-									\
-	SENSOR_DEVICE_DT_INST_DEFINE(n, as5600_initialize, NULL,	\
-			    &as5600_data##n, &as5600_cfg##n, \
-			    POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,	\
-			    &as5600_driver_api);
+#define AS5600_INIT(n)                                                                             \
+	static struct as5600_data as5600_data##n;                                                  \
+	static const struct as5600_config as5600_config##n = {                                     \
+		.i2c = I2C_DT_SPEC_INST_GET(n),                                                    \
+		.start_position = DT_INST_PROP_OR(n, start_position, AS5600_UNCONFIGURED_2_REG),   \
+		.end_position = DT_INST_PROP_OR(n, end_position, AS5600_UNCONFIGURED_2_REG),       \
+		.angular_range = DT_INST_PROP_OR(n, angular_range, AS5600_UNCONFIGURED_2_REG),     \
+		.power_mode = DT_INST_ENUM_IDX_OR(n, power_mode, AS5600_UNCONFIGURED_1_REG),       \
+		.hysteresis = DT_INST_ENUM_IDX_OR(n, hysteresis, AS5600_UNCONFIGURED_1_REG),       \
+		.output_stage = DT_INST_ENUM_IDX_OR(n, output_stage, AS5600_UNCONFIGURED_1_REG),   \
+		.pwm_frequency = DT_INST_ENUM_IDX_OR(n, pwm_frequency, AS5600_UNCONFIGURED_1_REG), \
+		.slow_filter = DT_INST_ENUM_IDX_OR(n, slow_filter, AS5600_UNCONFIGURED_1_REG),     \
+		.fast_filter_threshold =                                                           \
+			DT_INST_ENUM_IDX_OR(n, fast_filter_threshold, AS5600_UNCONFIGURED_1_REG),  \
+		.watch_dog = DT_INST_ENUM_IDX_OR(n, watch_dog, AS5600_UNCONFIGURED_1_REG),         \
+	};                                                                                         \
+                                                                                                   \
+	SENSOR_DEVICE_DT_INST_DEFINE(n, as5600_init, NULL, &as5600_data##n, &as5600_config##n,     \
+				     POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY, &as5600_api);
 
 DT_INST_FOREACH_STATUS_OKAY(AS5600_INIT)

--- a/dts/bindings/sensor/ams,as5600.yaml
+++ b/dts/bindings/sensor/ams,as5600.yaml
@@ -1,9 +1,156 @@
 # Copyright (c) 2022, Felipe Neves
+# Copyright (c) 2025, Cameron Ewing
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
     AMS (Austria Mikro Systeme) AS5600 Angular position sensor
 
+    Datasheet: https://look.ams-osram.com/m/7059eac7531a86fd/original/AS5600-DS000365.pdf
+
 compatible: "ams,as5600"
 
 include: [sensor-device.yaml, i2c-device.yaml]
+
+properties:
+  start-position:
+    description: |
+      Start position (min. 0; max. 4095).
+      Difference between Start and End position must be at least 18 degrees (205 steps).
+
+      Ref: Datasheet page 21.
+    type: int
+
+  end-position:
+    description: |
+      End position (min. 0; max. 4095).
+      Difference between Start and End position must be at least 18 degrees (205 steps).
+      Mutually exclusive with angular-range.
+
+      Ref: Datasheet page 21,25.
+    type: int
+
+  angular-range:
+    description: |
+      Maximum angular range (min. 205; max. 4096).
+      Mutually exclusive with end-position.
+
+      Ref: Datasheet page 21,24,25.
+    type: int
+
+  power-mode:
+    description: |
+      Configure the power mode and polling time of AS5600.
+
+      Value | Power Mode | Polling Time | Max Supply Current
+      0:      NOM,         Always On,     6.5mA
+      1:      LPM1,        5ms,           3.4mA
+      2:      LPM2,        20ms,          1.8mA
+      3:      LPM3,        100ms,         1.5mA
+
+      Ref: Datasheet page 5.
+    type: int
+    enum:
+      - 0
+      - 1
+      - 2
+      - 3
+
+  hysteresis:
+    description: |
+      Configure the LSB hysteresis of the Scaled Angle output (min. 0; max. 3).
+
+      Ref: Datasheet page 31.
+    type: int
+    enum:
+      - 0
+      - 1
+      - 2
+      - 3
+
+  output-stage:
+    description: |
+      Configure output of angle reading over the OUT pin.
+      NOTE: AS5600L only supports digital PWM output and pulls OUT high for any other configured
+      output stage.
+
+      Value | Output Stage
+      0:      Analog output (Full range from 0% to 100% of GND -> VDD)
+      1:      Analog output (Reduced range from 10% to 90% of GND -> VDD)
+      2:      Digital PWM output
+
+      Ref: Datasheet page 24.
+    type: int
+    enum:
+      - 0
+      - 1
+      - 2
+
+  pwm-frequency:
+    description: |
+      Configure the digital PWM signalling frequency in Hz.
+
+      Value | PWM Frequency
+      0:      115 Hz
+      1:      230 Hz
+      2:      460 Hz
+      3:      920 Hz
+
+      Ref: Datasheet page 19.
+    type: int
+    enum:
+      - 0
+      - 1
+      - 2
+      - 3
+
+  slow-filter:
+    description: |
+      Configure the slow step response filter.
+
+      Value | Step Response Delay | Output Noise
+      0:      2.2 ms,               0.015 degrees
+      1:      1.1 ms,               0.021 degrees
+      2:      0.55 ms,              0.030 degrees
+      3:      0.286 ms,             0.043 degrees
+
+      Ref: Datasheet page 28.
+    type: int
+    enum:
+      - 0
+      - 1
+      - 2
+      - 3
+
+  fast-filter-threshold:
+    description: |
+      Configure the fast step response filter threshold.
+
+      Value | Slow to Fast Transition | Fast to Slow Transition
+      0:      Slow Filter Only
+      1:      6 LSB,                    1 LSB
+      2:      7 LSB,                    1 LSB
+      3:      9 LSB,                    1 LSB
+      4:      18 LSB,                   2 LSB
+      5:      21 LSB,                   2 LSB
+      6:      24 LSB,                   2 LSB
+      7:      10 LSB,                   4 LSB
+
+      Ref: Datasheet page 29.
+    type: int
+    enum:
+      - 0
+      - 1
+      - 2
+      - 3
+      - 4
+      - 5
+      - 6
+      - 7
+
+  watchdog:
+    description: |
+      Configure the low power watchdog.
+      Automatically enter LPM3 after 1 minute if the angle stays within 4 LSB of the last reading.
+
+      Ref: Datasheet page 31.
+    type: boolean

--- a/include/zephyr/drivers/sensor/ams_as5600.h
+++ b/include/zephyr/drivers/sensor/ams_as5600.h
@@ -1,0 +1,188 @@
+/*
+ * Copyright (c) 2025 Cameron Ewing
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_DRIVERS_SENSOR_AS5600_AS5600_H_
+#define ZEPHYR_DRIVERS_SENSOR_AS5600_AS5600_H_
+
+#include <zephyr/drivers/sensor.h>
+#include <zephyr/drivers/i2c.h>
+
+/* Register Addresses */
+#define AS5600_ZMCO             0x00
+#define AS5600_ZPOS_H           0x01
+#define AS5600_ZPOS_L           0x02
+#define AS5600_MPOS_H           0x03
+#define AS5600_MPOS_L           0x04
+#define AS5600_MANG_H           0x05
+#define AS5600_MANG_L           0x06
+#define AS5600_CONF_H           0x07
+#define AS5600_CONF_L           0x08
+#define AS5600_STATUS           0x0B
+#define AS5600_RAW_STEPS_H      0x0C
+#define AS5600_RAW_STEPS_L      0x0D
+#define AS5600_FILTERED_STEPS_H 0x0E
+#define AS5600_FILTERED_STEPS_L 0x0F
+#define AS5600_AGC              0x1A
+#define AS5600_MAGNITUDE_H      0x1B
+#define AS5600_MAGNITUDE_L      0x1C
+#define AS5600_I2CADDR          0x20
+#define AS5600_I2CUPDT          0x21
+#define AS5600_BURN             0xFF
+
+/* Register Masks */
+#define AS5600_ZMCO_MASK    (BIT(1) | BIT(0))
+#define AS5600_12BIT_H_MASK (BIT(3) | BIT(2) | BIT(1) | BIT(0))
+#define AS5600_CONF_H_MASK  (BIT(5) | BIT(4) | BIT(3) | BIT(2) | BIT(1) | BIT(0))
+#define AS5600_STATUS_MASK  (BIT(5) | BIT(4) | BIT(3))
+#define AS5600_I2CADDR_MASK (BIT(7) | BIT(6) | BIT(5) | BIT(4) | BIT(3) | BIT(2) | BIT(1))
+
+/* Configuration Masks
+ * CONF_H:  Watch Dog:5 | Fast Filter Threshold:4:2 | Slow Filter:1:0
+ */
+#define AS5600_CONF_H_SF   (BIT(1) | BIT(0))
+#define AS5600_CONF_H_FTH  (BIT(4) | BIT(3) | BIT(2))
+#define AS5600_CONF_H_WD   (BIT(5))
+/* CONF_L:  PWM Frequency:7:6 | Output Stage:5:4 | Hysteresis:3:2 | Power Mode:1:0 */
+#define AS5600_CONF_L_PM   (BIT(1) | BIT(0))
+#define AS5600_CONF_L_HYST (BIT(3) | BIT(2))
+#define AS5600_CONF_L_OUTS (BIT(5) | BIT(4))
+#define AS5600_CONF_L_PWMF (BIT(7) | BIT(6))
+
+/* Status Masks
+ * STATUS:  Magnet Detected:5 | Magnet Too Weak:4 | Magnet Too Strong:3
+ */
+#define AS5600_STATUS_MH (BIT(3))
+#define AS5600_STATUS_ML (BIT(4))
+#define AS5600_STATUS_MD (BIT(5))
+
+/* Burn Commands */
+#define AS5600_BURN_ANGLE   0x80
+#define AS5600_BURN_SETTING 0x40
+
+/* Register Sizes */
+#define AS5600_TWO_REG 2
+
+/* Unconfigured configuration value */
+#define AS5600_UNCONFIGURED_2_REG USHRT_MAX
+#define AS5600_UNCONFIGURED_1_REG UCHAR_MAX
+
+/* Combine two 8-bit registers into a 12-bit value using supplied mask and values */
+#define AS5600_REG_TO_12BIT(reg_h, mask_h, reg_l) (((reg_h & mask_h) << 8) | reg_l)
+
+/* Mask and shift bitfield right using supplied register, mask, and shift */
+#define AS5600_BITFIELD_TO_VAL(reg, mask, shift) ((reg & mask) >> shift)
+
+/* Mask and shift a value left into a bitfield using supplied value, mask, and shift */
+#define AS5600_VAL_TO_BITFIELD(val, mask, shift) ((val << shift) & mask)
+
+/* Sensor Channels */
+enum as5600_sensor_channel {
+	AS5600_SENSOR_CHAN_RAW_STEPS = SENSOR_CHAN_PRIV_START,
+	AS5600_SENSOR_CHAN_FILTERED_STEPS,
+	AS5600_SENSOR_CHAN_AGC,
+	AS5600_SENSOR_CHAN_MAGNITUDE,
+	AS5600_SENSOR_CHAN_END,
+};
+
+/* Sensor Attributes
+ *
+ * NOTE: END_POSITION and ANGULAR_RANGE are mutually exclusive:
+ * The last set value will be used and the other will be cleared to 0 on the device.
+ */
+enum as5600_sensor_attribute {
+	AS5600_ATTR_BURNS = SENSOR_ATTR_PRIV_START, /* Read only */
+	AS5600_ATTR_START_POSITION,                 /* Read / Write */
+	AS5600_ATTR_END_POSITION,                   /* Read / Write */
+	AS5600_ATTR_ANGULAR_RANGE,                  /* Read / Write */
+	AS5600_ATTR_POWER_MODE,                     /* Read / Write */
+	AS5600_ATTR_OUTPUT_STAGE,                   /* Read / Write */
+	AS5600_ATTR_PWM_FREQ,                       /* Read / Write */
+	AS5600_ATTR_SLOW_FILTER,                    /* Read / Write */
+	AS5600_ATTR_FAST_FILTER_THRESHOLD,          /* Read / Write */
+	AS5600_ATTR_WATCH_DOG,                      /* Read / Write */
+	AS5600_ATTR_I2CADDR,                        /* Read / Write */
+	AS5600_ATTR_STATUS,                         /* Read only */
+	AS5600_ATTR_END,
+};
+
+enum as5600_hysteresis {
+	AS5600_HYSTERESIS_0,
+	AS5600_HYSTERESIS_1,
+	AS5600_HYSTERESIS_2,
+	AS5600_HYSTERESIS_3,
+};
+
+enum as5600_power_mode {
+	AS5600_POWER_MODE_NOM,
+	AS5600_POWER_MODE_LPM1,
+	AS5600_POWER_MODE_LPM2,
+	AS5600_POWER_MODE_LPM3,
+};
+
+enum as5600_output_stage {
+	AS5600_OUTPUT_STAGE_ANALOG,
+	AS5600_OUTPUT_STAGE_REDUCED,
+	AS5600_OUTPUT_STAGE_PWM,
+};
+
+enum as5600_pwm_frequency {
+	AS5600_PWM_FREQ_115HZ,
+	AS5600_PWM_FREQ_230HZ,
+	AS5600_PWM_FREQ_460HZ,
+	AS5600_PWM_FREQ_920HZ,
+};
+
+enum as5600_slow_filter {
+	AS5600_SLOW_FILTER_16,
+	AS5600_SLOW_FILTER_8,
+	AS5600_SLOW_FILTER_4,
+	AS5600_SLOW_FILTER_2,
+};
+
+enum as5600_fast_filter_threshold {
+	AS5600_FAST_FILTER_THRESHOLD_OFF,
+	AS5600_FAST_FILTER_THRESHOLD_6_1,
+	AS5600_FAST_FILTER_THRESHOLD_7_1,
+	AS5600_FAST_FILTER_THRESHOLD_9_1,
+	AS5600_FAST_FILTER_THRESHOLD_18_2,
+	AS5600_FAST_FILTER_THRESHOLD_21_2,
+	AS5600_FAST_FILTER_THRESHOLD_24_2,
+	AS5600_FAST_FILTER_THRESHOLD_10_4,
+};
+
+enum as5600_status {
+	AS5600_STATUS_MAGNET_DETECTED = 0b100,
+	AS5600_STATUS_MAGNET_TOO_WEAK = 0b110,
+	AS5600_STATUS_MAGNET_TOO_STRONG = 0b101,
+};
+
+enum as5600_watch_dog {
+	AS5600_WATCH_DOG_DISABLE,
+	AS5600_WATCH_DOG_ENABLE,
+};
+
+struct as5600_config {
+	const struct i2c_dt_spec i2c;
+	const uint16_t start_position;
+	const uint16_t end_position;
+	const uint16_t angular_range;
+	const enum as5600_power_mode power_mode;
+	const enum as5600_hysteresis hysteresis;
+	const enum as5600_output_stage output_stage;
+	const enum as5600_pwm_frequency pwm_frequency;
+	const enum as5600_slow_filter slow_filter;
+	const enum as5600_fast_filter_threshold fast_filter_threshold;
+	const enum as5600_watch_dog watch_dog;
+};
+
+struct as5600_data {
+	uint16_t raw_steps;
+	uint16_t filtered_steps;
+	uint8_t agc;
+	uint16_t magnitude;
+};
+
+#endif /* ZEPHYR_DRIVERS_SENSOR_AS5600_AS5600_H_ */


### PR DESCRIPTION
This is a complete rewrite of the existing AS5600 driver. Device registers and configuration are supported through the fetch and get API using channels and attributes. The device tree binding was updated to cover all configurable options of the device. The device is now initialized to the state defined in the device tree on init or its power on reset state if a setting is not configured.

This rewrite referenced the [AS5600 datasheet](https://look.ams-osram.com/m/7059eac7531a86fd/original/AS5600-DS000365.pdf) and has been tested against hardware. 

This is my first time touching Zephyr and I would greatly appreciate any and all feedback! I understand large PRs are not recommended but I wasn't sure how to split this up and am certainly willing to adjust and split this into multiple PRs. 