### PR TITLE
edtlib: binding: Add a title keyword

### DIFF
--- a/doc/_scripts/gen_devicetree_rest.py
+++ b/doc/_scripts/gen_devicetree_rest.py
@@ -580,7 +580,14 @@ def print_binding_page(binding, base_names, vnd_lookup, driver_sources,dup_compa
 
     {bus_help}
     ''', string_io)
-    print(to_code_block(binding.description.strip()), file=string_io)
+
+    if binding.title:
+        description = ("\n\n"
+                       .join([binding.title, binding.description])
+                       .strip())
+    else:
+        description = binding.description.strip()
+    print(to_code_block(description), file=string_io)
 
     # Properties.
     print_block('''\

--- a/doc/build/dts/bindings-syntax.rst
+++ b/doc/build/dts/bindings-syntax.rst
@@ -19,6 +19,16 @@ like this:
 
 .. code-block:: yaml
 
+   # When the description text is too long, this field can
+   # be used to improve readability, e.g.:
+   #
+   # title: Binding the device's hardware model.
+   #
+   # description |
+   #   A piece of content with 20 lines.
+   #   ...
+   title: Concise title for the long description [optional]
+
    # A high level description of the device the binding applies to:
    description: |
       This is the Vendomatic company's foo-device.
@@ -57,6 +67,14 @@ like this:
      # values are 'gpio', 'pwm', and 'dma'. See below for more information.
 
 These keys are explained in the following sections.
+
+.. _dt-bindings-title:
+
+Title
+*****
+
+Short description of the bound device, typically the hardware model.
+(It's optional.)
 
 .. _dt-bindings-description:
 

--- a/doc/build/dts/bindings-upstream.rst
+++ b/doc/build/dts/bindings-upstream.rst
@@ -83,6 +83,8 @@ style:
 
 .. code-block:: yaml
 
+   title: I'm sure you need a short title.
+
    description: |
      My very long string
      goes here.

--- a/scripts/dts/python-devicetree/tests/test-bindings/defaults.yaml
+++ b/scripts/dts/python-devicetree/tests/test-bindings/defaults.yaml
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
+title: Test binding
+
 description: Property default value test
 
 compatible: "defaults"

--- a/scripts/dts/python-devicetree/tests/test_edtlib.py
+++ b/scripts/dts/python-devicetree/tests/test_edtlib.py
@@ -531,6 +531,20 @@ def test_bus():
     assert str(edt.get_node("/buses/foo-bus/node1/nested").binding_path) == \
         hpath("test-bindings/device-on-foo-bus.yaml")
 
+def test_binding_top_key():
+    fname2path = {'include.yaml': 'test-bindings-include/include.yaml',
+                  'include-2.yaml': 'test-bindings-include/include-2.yaml'}
+
+    with from_here():
+        binding = edtlib.Binding("test-bindings/defaults.yaml", fname2path)
+    title = binding.title
+    description = binding.description
+    compatible = binding.compatible
+
+    assert title == "Test binding"
+    assert description == "Property default value test"
+    assert compatible == "defaults"
+
 def test_child_binding():
     '''Test 'child-binding:' in bindings'''
     with from_here():


### PR DESCRIPTION
Add a 'title' keyword to the binding to provide a short description of the binding, while 'description' serves as the long description.

fixes: #86265