### PR TITLE
drivers: i3c: fix multiple issues in common code, shell, and CCC

### DIFF
--- a/drivers/i3c/i3c_ccc.c
+++ b/drivers/i3c/i3c_ccc.c
@@ -255,6 +255,7 @@ int i3c_ccc_do_entas(const struct i3c_device_desc *target, uint8_t as)
 
 	ccc_tgt_payload.addr = target->dynamic_addr;
 	ccc_tgt_payload.rnw = 0;
+	ccc_tgt_payload.data_len = 0;
 
 	ccc_payload.ccc.id = I3C_CCC_ENTAS(as, false);
 	ccc_payload.targets.payloads = &ccc_tgt_payload;

--- a/drivers/i3c/i3c_common.c
+++ b/drivers/i3c/i3c_common.c
@@ -1088,6 +1088,8 @@ int i3c_bus_init(const struct device *dev, const struct i3c_dev_list *dev_list)
 	if (need_aasa) {
 		ret = i3c_ccc_do_setaasa_all(dev);
 		if (ret != 0) {
+			LOG_ERR("failed to perform setaasa");
+		} else {
 			for (i = 0; i < dev_list->num_i3c; i++) {
 				struct i3c_device_desc *desc = &dev_list->i3c[i];
 				/*

--- a/drivers/i3c/i3c_shell.c
+++ b/drivers/i3c/i3c_shell.c
@@ -1430,7 +1430,7 @@ static int cmd_i3c_ccc_getstatus(const struct shell *sh, size_t argc, char **arg
 	if (argc > 3) {
 		fmt = GETSTATUS_FORMAT_2;
 		defbyte = strtol(argv[3], NULL, 16);
-		if (defbyte != GETSTATUS_FORMAT_2_TGTSTAT || defbyte != GETSTATUS_FORMAT_2_PRECR) {
+		if (defbyte != GETSTATUS_FORMAT_2_TGTSTAT && defbyte != GETSTATUS_FORMAT_2_PRECR) {
 			shell_error(sh, "Invalid defining byte.");
 			return -EINVAL;
 		}
@@ -2075,9 +2075,9 @@ static int cmd_i3c_ibi_tir(const struct shell *sh, size_t argc, char **argv)
 		return -ENODEV;
 	}
 
-	data_length = argc - 3;
+	data_length = argc - 2;
 	for (i = 0; i < data_length; i++) {
-		buf[i] = (uint8_t)strtol(argv[3 + i], NULL, 16);
+		buf[i] = (uint8_t)strtol(argv[2 + i], NULL, 16);
 	}
 
 	request.ibi_type = I3C_IBI_TARGET_INTR;


### PR DESCRIPTION
This pr fixed several i3c issues, including
- drivers: i3c: common: fix the setaasa flow
- drivers: i3c: shell: fix the judgement/argc count for getstatus/ibi tir
- drivers: i3c: ccc: add missing data length for entas