### PR TITLE
drivers: wifi: siwx91x: Add power-save support

### DIFF
--- a/drivers/wifi/siwx91x/Kconfig.siwx91x
+++ b/drivers/wifi/siwx91x/Kconfig.siwx91x
@@ -14,6 +14,24 @@ config WIFI_SILABS_SIWX91X
 
 if WIFI_SILABS_SIWX91X
 
+config WIFI_SILABS_SIWX91X_ENHANCED_MAX_PSP
+	bool "Enhanced Max PSP Support"
+	default y
+	help
+	  Enable this option to allow the device to configure
+	  Enhanced Maximum Power Save (PSP) support during
+	  device initialization.
+
+	  **Advantages:**
+	  - Reduces power consumption during low traffic periods.
+	  - Automatically transitions to Fast PSP for improved responsiveness
+	    when traffic is high.
+
+	  **Limitations:**
+	  - Initially uses PS-Poll frames for power management, even if the
+	    user configures NULL frame-based.
+	  - Switches to NULL frame-based only when traffic increases.
+
 choice
 	prompt "Network stack"
 	default WIFI_SILABS_SIWX91X_NET_STACK_NATIVE

--- a/drivers/wifi/siwx91x/siwx91x_wifi.c
+++ b/drivers/wifi/siwx91x/siwx91x_wifi.c
@@ -1305,7 +1305,6 @@ static int siwx91x_try_set_listen_interval(struct siwx91x_dev *sidev,
 					   uint16_t bcn_listen_interval)
 {
 	if (!siwx91x_is_device_connected(sidev)) {
-		LOG_ERR("Listen interval works after connection");
 		return -EACCES;
 	}
 
@@ -1315,6 +1314,7 @@ static int siwx91x_try_set_listen_interval(struct siwx91x_dev *sidev,
 static void siwx91x_clear_listen_interval(struct siwx91x_dev *sidev)
 {
 	sidev->bcn_listen_interval = 0;
+	sidev->listen_interval_wakeup = false;
 }
 
 static void siwx91x_set_dtim_ps_profile(sl_wifi_performance_profile_t *sl_ps_profile)
@@ -1326,12 +1326,22 @@ static void siwx91x_set_dtim_ps_profile(sl_wifi_performance_profile_t *sl_ps_pro
 static int siwx91x_set_listen_interval_ps_profile(struct siwx91x_dev *sidev,
 						  sl_wifi_performance_profile_t *sl_ps_profile)
 {
+	int status;
+
 	sl_ps_profile->dtim_aligned_type = 0;
 	if (sl_ps_profile->profile == HIGH_PERFORMANCE) {
 		return 0;
 	}
 
-	return siwx91x_try_set_listen_interval(sidev, sl_ps_profile, sidev->bcn_listen_interval);
+	status = siwx91x_try_set_listen_interval(sidev, sl_ps_profile, sidev->bcn_listen_interval);
+	if (status == -EACCES) {
+		sidev->listen_interval_wakeup = true;
+		sl_ps_profile->profile = HIGH_PERFORMANCE;
+		LOG_WRN("listen interval reflect after connection");
+		return 0;
+	}
+
+	return status;
 }
 
 static int siwx91x_set_ps_param_timeout(sl_wifi_performance_profile_t *sl_ps_profile,
@@ -1380,6 +1390,7 @@ static int siwx91x_set_ps_profile(struct siwx91x_dev *sidev,
 		sl_ps_profile->profile = sidev->ps_profile;
 		break;
 	case WIFI_PS_DISABLED:
+		sidev->listen_interval_wakeup = false;
 		if (sl_ps_profile->profile == HIGH_PERFORMANCE) {
 			return -EALREADY;
 		}
@@ -1429,9 +1440,15 @@ static int siwx91x_set_power_save(const struct device *dev, struct wifi_ps_param
 		if (!sl_ps_profile.dtim_aligned_type && params->enabled) {
 			status = siwx91x_try_set_listen_interval(sidev, &sl_ps_profile,
 								 sidev->bcn_listen_interval);
-			if (status < 0) {
+			if (status == -EACCES) {
+				sidev->listen_interval_wakeup = true;
+				LOG_WRN("listen interval reflect after connection");
+				return 0;
+			} else if (status < 0) {
 				return status;
 			}
+
+			sidev->listen_interval_wakeup = false;
 		}
 		break;
 
@@ -1498,10 +1515,33 @@ static int siwx91x_set_power_save(const struct device *dev, struct wifi_ps_param
 	return 0;
 }
 
+static int validate_ps_listen_interval(const struct device *dev)
+{
+	struct siwx91x_dev *sidev = dev->data;
+	struct wifi_ps_params params = {
+		.type = WIFI_PS_PARAM_STATE,
+		.enabled = WIFI_PS_ENABLED,
+	};
+	int ret;
+
+	if (!sidev->listen_interval_wakeup) {
+		return 0;
+	}
+
+	ret = siwx91x_set_power_save(dev, &params);
+	if (ret < 0) {
+		LOG_ERR("Failed to enable PS after device connection: %d", ret);
+		return ret;
+	}
+
+	return 0;
+}
+
 static unsigned int siwx91x_on_join(sl_wifi_event_t event,
 				    char *result, uint32_t result_size, void *arg)
 {
 	struct siwx91x_dev *sidev = arg;
+	const struct device *dev = sidev->iface->if_dev->dev;
 
 	if (*result != 'C') {
 		/* TODO: report the real reason of failure */
@@ -1520,6 +1560,7 @@ static unsigned int siwx91x_on_join(sl_wifi_event_t event,
 	siwx91x_on_join_ipv4(sidev);
 	siwx91x_on_join_ipv6(sidev);
 
+	validate_ps_listen_interval(dev);
 	return 0;
 }
 

--- a/drivers/wifi/siwx91x/siwx91x_wifi.c
+++ b/drivers/wifi/siwx91x/siwx91x_wifi.c
@@ -264,31 +264,6 @@ static enum wifi_mfp_options siwx91x_set_sta_mfp_option(sl_wifi_security_t secur
 	return WIFI_MFP_UNKNOWN;
 }
 
-static unsigned int siwx91x_on_join(sl_wifi_event_t event,
-				    char *result, uint32_t result_size, void *arg)
-{
-	struct siwx91x_dev *sidev = arg;
-
-	if (*result != 'C') {
-		/* TODO: report the real reason of failure */
-		wifi_mgmt_raise_connect_result_event(sidev->iface, WIFI_STATUS_CONN_FAIL);
-		sidev->state = WIFI_STATE_INACTIVE;
-		return 0;
-	}
-
-	wifi_mgmt_raise_connect_result_event(sidev->iface, WIFI_STATUS_CONN_SUCCESS);
-	sidev->state = WIFI_STATE_COMPLETED;
-
-	if (IS_ENABLED(CONFIG_WIFI_SILABS_SIWX91X_NET_STACK_NATIVE)) {
-		net_if_dormant_off(sidev->iface);
-	}
-
-	siwx91x_on_join_ipv4(sidev);
-	siwx91x_on_join_ipv6(sidev);
-
-	return 0;
-}
-
 static int siwx91x_status(const struct device *dev, struct wifi_iface_status *status)
 {
 	sl_wifi_interface_t interface = sl_wifi_get_default_interface();
@@ -1519,6 +1494,31 @@ static int siwx91x_set_power_save(const struct device *dev, struct wifi_ps_param
 		LOG_ERR("Failed to set power save profile: 0x%x", status);
 		return -EIO;
 	}
+
+	return 0;
+}
+
+static unsigned int siwx91x_on_join(sl_wifi_event_t event,
+				    char *result, uint32_t result_size, void *arg)
+{
+	struct siwx91x_dev *sidev = arg;
+
+	if (*result != 'C') {
+		/* TODO: report the real reason of failure */
+		wifi_mgmt_raise_connect_result_event(sidev->iface, WIFI_STATUS_CONN_FAIL);
+		sidev->state = WIFI_STATE_INACTIVE;
+		return 0;
+	}
+
+	wifi_mgmt_raise_connect_result_event(sidev->iface, WIFI_STATUS_CONN_SUCCESS);
+	sidev->state = WIFI_STATE_COMPLETED;
+
+	if (IS_ENABLED(CONFIG_WIFI_SILABS_SIWX91X_NET_STACK_NATIVE)) {
+		net_if_dormant_off(sidev->iface);
+	}
+
+	siwx91x_on_join_ipv4(sidev);
+	siwx91x_on_join_ipv6(sidev);
 
 	return 0;
 }

--- a/drivers/wifi/siwx91x/siwx91x_wifi.c
+++ b/drivers/wifi/siwx91x/siwx91x_wifi.c
@@ -1268,15 +1268,95 @@ static int siwx91x_get_version(const struct device *dev, struct wifi_version *pa
 	return 0;
 }
 
+static int siwx91x_get_connected_ap_beacon_interval_ms(void)
+{
+	sl_wifi_operational_statistics_t sl_stat;
+	int beacon_interval;
+	sl_status_t status;
+
+	status = sl_wifi_get_operational_statistics(SL_WIFI_CLIENT_INTERFACE, &sl_stat);
+	if (status != SL_STATUS_OK) {
+		return -EAGAIN;
+	}
+
+	beacon_interval = sys_get_le16(sl_stat.beacon_interval);
+	beacon_interval = beacon_interval * 1024 / 1000;
+	return beacon_interval;
+}
+
+static int siwx91x_convert_li_bcn_unit_to_ms(uint16_t bcn_listen_interval)
+{
+	int beacon_interval;
+	int listen_interval_ms;
+
+	beacon_interval = siwx91x_get_connected_ap_beacon_interval_ms();
+	if (beacon_interval < 0) {
+		LOG_ERR("Failed to get beacon interval: %d", beacon_interval);
+		return -EAGAIN;
+	}
+
+	listen_interval_ms = bcn_listen_interval * beacon_interval;
+	return listen_interval_ms;
+}
+
+static int siwx91x_set_listen_interval(sl_wifi_performance_profile_t *sl_ps_profile,
+				       uint16_t bcn_listen_interval)
+{
+	int listen_interval;
+
+	listen_interval = siwx91x_convert_li_bcn_unit_to_ms(bcn_listen_interval);
+	if (listen_interval < 0) {
+		return listen_interval;
+	}
+
+	if (listen_interval > SIWX91X_PS_MAX_LISTEN_INTERVAL_MS) {
+		LOG_WRN("Listen interval exceeded, capping to %d",
+			SIWX91X_PS_MAX_LISTEN_INTERVAL_MS);
+		listen_interval = SIWX91X_PS_MAX_LISTEN_INTERVAL_MS;
+	}
+
+	sl_ps_profile->listen_interval = listen_interval;
+
+	if (listen_interval == 0) {
+		sl_ps_profile->dtim_aligned_type = 1;
+		LOG_WRN("Listen interval is zero, enabling DTIM-based wakeup");
+	}
+
+	return 0;
+}
+
+static int siwx91x_try_set_listen_interval(struct siwx91x_dev *sidev,
+					   sl_wifi_performance_profile_t *sl_ps_profile,
+					   uint16_t bcn_listen_interval)
+{
+	if (!siwx91x_is_device_connected(sidev)) {
+		LOG_ERR("Listen interval works after connection");
+		return -EACCES;
+	}
+
+	return siwx91x_set_listen_interval(sl_ps_profile, sidev->bcn_listen_interval);
+}
+
+static void siwx91x_clear_listen_interval(struct siwx91x_dev *sidev)
+{
+	sidev->bcn_listen_interval = 0;
+}
+
 static void siwx91x_set_dtim_ps_profile(sl_wifi_performance_profile_t *sl_ps_profile)
 {
 	sl_ps_profile->dtim_aligned_type = 1;
 	sl_ps_profile->listen_interval = 0;
 }
 
-static void siwx91x_set_listen_interval_ps_profile(sl_wifi_performance_profile_t *sl_ps_profile)
+static int siwx91x_set_listen_interval_ps_profile(struct siwx91x_dev *sidev,
+						  sl_wifi_performance_profile_t *sl_ps_profile)
 {
 	sl_ps_profile->dtim_aligned_type = 0;
+	if (sl_ps_profile->profile == HIGH_PERFORMANCE) {
+		return 0;
+	}
+
+	return siwx91x_try_set_listen_interval(sidev, sl_ps_profile, sidev->bcn_listen_interval);
 }
 
 static int siwx91x_set_ps_param_timeout(sl_wifi_performance_profile_t *sl_ps_profile,
@@ -1370,6 +1450,14 @@ static int siwx91x_set_power_save(const struct device *dev, struct wifi_ps_param
 		} else if (status < 0) {
 			return status;
 		}
+
+		if (!sl_ps_profile.dtim_aligned_type && params->enabled) {
+			status = siwx91x_try_set_listen_interval(sidev, &sl_ps_profile,
+								 sidev->bcn_listen_interval);
+			if (status < 0) {
+				return status;
+			}
+		}
 		break;
 
 	case WIFI_PS_PARAM_MODE:
@@ -1380,11 +1468,18 @@ static int siwx91x_set_power_save(const struct device *dev, struct wifi_ps_param
 		}
 		break;
 
+	case WIFI_PS_PARAM_LISTEN_INTERVAL:
+		sidev->bcn_listen_interval = params->listen_interval;
+		return 0;
 	case WIFI_PS_PARAM_WAKEUP_MODE:
 		if (params->wakeup_mode == WIFI_PS_WAKEUP_MODE_DTIM) {
+			siwx91x_clear_listen_interval(sidev);
 			siwx91x_set_dtim_ps_profile(&sl_ps_profile);
 		} else if (params->wakeup_mode == WIFI_PS_WAKEUP_MODE_LISTEN_INTERVAL) {
-			siwx91x_set_listen_interval_ps_profile(&sl_ps_profile);
+			status = siwx91x_set_listen_interval_ps_profile(sidev, &sl_ps_profile);
+			if (status < 0) {
+				return status;
+			}
 		}
 		break;
 
@@ -1413,7 +1508,9 @@ static int siwx91x_set_power_save(const struct device *dev, struct wifi_ps_param
 		sl_ps_profile.profile = sidev->ps_profile;
 		break;
 	default:
-		return -ENOTSUP;
+		params->fail_reason = WIFI_PS_PARAM_FAIL_CMD_EXEC_FAIL;
+		LOG_ERR("Invalid command");
+		return -EINVAL;
 	}
 
 	status = sl_wifi_set_performance_profile(&sl_ps_profile);
@@ -1431,6 +1528,7 @@ static int siwx91x_get_power_save_config(const struct device *dev, struct wifi_p
 	sl_wifi_performance_profile_t sl_ps_profile;
 	struct siwx91x_dev *sidev = dev->data;
 	sl_wifi_interface_t interface;
+	uint16_t beacon_interval;
 	sl_status_t status;
 
 	__ASSERT(config, "config cannot be NULL");
@@ -1472,6 +1570,12 @@ static int siwx91x_get_power_save_config(const struct device *dev, struct wifi_p
 		config->ps_params.wakeup_mode = WIFI_PS_WAKEUP_MODE_DTIM;
 	} else {
 		config->ps_params.wakeup_mode = WIFI_PS_WAKEUP_MODE_LISTEN_INTERVAL;
+
+		beacon_interval = siwx91x_get_connected_ap_beacon_interval_ms();
+		if (beacon_interval > 0) {
+			config->ps_params.listen_interval =
+				sl_ps_profile.listen_interval / beacon_interval;
+		}
 	}
 
 	/* Device supports only legacy power-save mode */

--- a/drivers/wifi/siwx91x/siwx91x_wifi.c
+++ b/drivers/wifi/siwx91x/siwx91x_wifi.c
@@ -36,6 +36,15 @@ enum {
 	DEMAND_TWT = 2,
 };
 
+static bool siwx91x_is_device_connected(struct siwx91x_dev *sidev)
+{
+	if (sidev->state == WIFI_STATE_COMPLETED) {
+		return true;
+	}
+
+	return false;
+}
+
 static int siwx91x_nwp_reboot_if_required(const struct device *dev, uint8_t oper_mode)
 {
 	struct siwx91x_dev *sidev = dev->data;
@@ -726,7 +735,7 @@ static int siwx91x_connect(const struct device *dev, struct wifi_connect_req_par
 	enum wifi_mfp_options mfp_conf;
 	int ret = 0;
 
-	if (sidev->state == WIFI_STATE_COMPLETED) {
+	if (siwx91x_is_device_connected(sidev)) {
 		ret = siwx91x_disconnect_if_required(dev, params);
 		if (ret < 0) {
 			wifi_mgmt_raise_connect_result_event(sidev->iface, WIFI_STATUS_CONN_FAIL);
@@ -974,7 +983,7 @@ static int siwx91x_scan(const struct device *dev, struct wifi_scan_params *z_sca
 	}
 
 	if (sidev->state != WIFI_STATE_DISCONNECTED && sidev->state != WIFI_STATE_INACTIVE &&
-	    sidev->state != WIFI_STATE_COMPLETED) {
+	    !siwx91x_is_device_connected(sidev)) {
 		LOG_ERR("Command given in invalid state");
 		return -EBUSY;
 	}
@@ -984,7 +993,7 @@ static int siwx91x_scan(const struct device *dev, struct wifi_scan_params *z_sca
 		return -EINVAL;
 	}
 
-	if (sidev->state == WIFI_STATE_COMPLETED) {
+	if (siwx91x_is_device_connected(sidev)) {
 		siwx91x_configure_scan_dwell_time(SL_WIFI_SCAN_TYPE_ADV_SCAN,
 						  z_scan_config->dwell_time_active,
 						  z_scan_config->dwell_time_passive,
@@ -1620,7 +1629,7 @@ static int siwx91x_set_twt(const struct device *dev, struct wifi_twt_params *par
 	}
 
 	if (sidev->state != WIFI_STATE_DISCONNECTED && sidev->state != WIFI_STATE_INACTIVE &&
-	    sidev->state != WIFI_STATE_COMPLETED) {
+	    !siwx91x_is_device_connected(sidev)) {
 		LOG_ERR("Command given in invalid state");
 		return -EBUSY;
 	}

--- a/drivers/wifi/siwx91x/siwx91x_wifi.h
+++ b/drivers/wifi/siwx91x/siwx91x_wifi.h
@@ -24,6 +24,7 @@ struct siwx91x_dev {
 	uint16_t scan_max_bss_cnt;
 	sl_si91x_performance_profile_t ps_profile;
 	uint16_t bcn_listen_interval;
+	bool listen_interval_wakeup;
 	uint8_t max_num_sta;
 	bool reboot_needed;
 	bool hidden_ssid;

--- a/drivers/wifi/siwx91x/siwx91x_wifi.h
+++ b/drivers/wifi/siwx91x/siwx91x_wifi.h
@@ -23,6 +23,7 @@ struct siwx91x_dev {
 	scan_result_cb_t scan_res_cb;
 	uint16_t scan_max_bss_cnt;
 	sl_si91x_performance_profile_t ps_profile;
+	uint16_t bcn_listen_interval;
 	uint8_t max_num_sta;
 	bool reboot_needed;
 	bool hidden_ssid;

--- a/drivers/wifi/siwx91x/siwx91x_wifi.h
+++ b/drivers/wifi/siwx91x/siwx91x_wifi.h
@@ -12,6 +12,7 @@
 
 #include "sl_ieee802_types.h"
 #include "sl_si91x_types.h"
+#include "sl_wifi_device.h"
 #include "sl_si91x_protocol_types.h"
 
 struct siwx91x_dev {
@@ -21,6 +22,7 @@ struct siwx91x_dev {
 	enum wifi_iface_state scan_prev_state;
 	scan_result_cb_t scan_res_cb;
 	uint16_t scan_max_bss_cnt;
+	sl_si91x_performance_profile_t ps_profile;
 	uint8_t max_num_sta;
 	bool reboot_needed;
 	bool hidden_ssid;

--- a/soc/silabs/silabs_siwx91x/siwg917/nwp.c
+++ b/soc/silabs/silabs_siwx91x/siwg917/nwp.c
@@ -68,9 +68,13 @@ static void siwx91x_configure_sta_mode(sl_si91x_boot_configuration_t *boot_confi
 	}
 
 #ifdef CONFIG_WIFI_SILABS_SIWX91X
-	boot_config->ext_tcp_ip_feature_bit_map = SL_SI91X_CONFIG_FEAT_EXTENSION_VALID;
-	boot_config->config_feature_bit_map = SL_SI91X_ENABLE_ENHANCED_MAX_PSP;
-	boot_config->ext_custom_feature_bit_map |= SL_SI91X_EXT_FEAT_IEEE_80211W |
+		boot_config->ext_tcp_ip_feature_bit_map = SL_SI91X_CONFIG_FEAT_EXTENSION_VALID;
+		if (IS_ENABLED(CONFIG_WIFI_SILABS_SIWX91X_ENHANCED_MAX_PSP)) {
+			boot_config->config_feature_bit_map = SL_SI91X_ENABLE_ENHANCED_MAX_PSP;
+		}
+
+		boot_config->ext_custom_feature_bit_map |=
+			SL_SI91X_EXT_FEAT_IEEE_80211W |
 			SL_SI91X_EXT_FEAT_FRONT_END_SWITCH_PINS_ULP_GPIO_4_5_0;
 #endif
 


### PR DESCRIPTION
Added power-save mode support to optimize station wake-up timing
and reduce power consumption. The device currently supports
only legacy power-save mode.

Implemented power-save features:
- ` ps ON/OFF`	     : By default, the device operates in
		                fast PSP mode.
- `ps_listen_interval `: Moves to DTIM wakeup if set to zero.
- `ps_exit_strategy   `: Updates mode if enabled; otherwise, follows
		                   the configured exit strategy when power-save
		                   is enabled.
- `ps_wakeup_mode     `: Configures the wake-up behavior.
- `ps_timeout         `: Defines the timeout duration for power-save mode.