### PR TITLE
samples: sensor: accel_trig: add arduino_gpio req + platform_allow entry

### DIFF
--- a/samples/sensor/accel_trig/sample.yaml
+++ b/samples/sensor/accel_trig/sample.yaml
@@ -49,6 +49,9 @@ tests:
       - CONFIG_SAMPLE_TAP_DETECTION=y
     depends_on:
       - arduino_i2c
+      - arduino_gpio
+    platform_allow:
+      - nrf52dk/nrf52832
     integration_platforms:
       - nrf52dk/nrf52832
   sample.sensor.accel_trig.generic-tap:


### PR DESCRIPTION
sample.sensor.accel_trig.shield-tap has a DT overlay that expects the presence of an arduino_header, so add the appropriate dependency to only build the sample against supported boards.

As per samples guidelines, use platform_allow to limit CI to run only on a configuration that's actually been tested (and is documented in the README)

This fixes failures observed in weekly CI.