### PR TITLE
drivers: wifi: nxp: fix the wrong security type print of WPA2

### DIFF
--- a/drivers/wifi/nxp/nxp_wifi_drv.c
+++ b/drivers/wifi/nxp/nxp_wifi_drv.c
@@ -1042,6 +1042,8 @@ static inline enum wifi_security_type nxp_wifi_key_mgmt_to_zephyr(int key_mgmt, 
 		return WIFI_SECURITY_TYPE_PSK;
 	case WLAN_KEY_MGMT_PSK_SHA256:
 		return WIFI_SECURITY_TYPE_PSK_SHA256;
+	case WLAN_KEY_MGMT_PSK | WLAN_KEY_MGMT_PSK_SHA256:
+		return WIFI_SECURITY_TYPE_PSK;
 	case WLAN_KEY_MGMT_SAE:
 		if (pwe == 1) {
 			return WIFI_SECURITY_TYPE_SAE_H2E;


### PR DESCRIPTION
For embedded supplicant case, when connects to WPA2 AP, driver will set the key_mgmt to 'WLAN_KEY_MGMT_PSK | WLAN_KEY_MGMT_PSK_SHA256', as mfp is default WIFI_MFP_OPTIONAL. Therefore, when using 'wifi status' to get the security type, when the key_mgmt is 'WLAN_KEY_MGMT_PSK | WLAN_KEY_MGMT_PSK_SHA256', the security type should be 'WIFI_SECURITY_TYPE_PSK'.