### PR TITLE
west: boards: add board revision support in format string

### DIFF
--- a/scripts/west_commands/boards.py
+++ b/scripts/west_commands/boards.py
@@ -49,6 +49,8 @@ class Boards(WestCommand):
 
             - name: board name
             - full_name: board full name (typically, its commercial name)
+            - revision_default: board default revision
+            - revisions: list of board revisions
             - qualifiers: board qualifiers (will be empty for legacy boards)
             - arch: board architecture (deprecated)
                     (arch is ambiguous for boards described in new hw model)
@@ -93,16 +95,32 @@ class Boards(WestCommand):
         for board in list_boards.find_boards(args):
             if name_re is not None and not name_re.search(board.name):
                 continue
+
+            if board.revisions:
+                revisions_list = ' '.join([rev.name for rev in board.revisions])
+            else:
+                revisions_list = 'None'
+
             self.inf(args.format.format(name=board.name, arch=board.arch,
+                                        revision_default=board.revision_default,
+                                        revisions=revisions_list,
                                         dir=board.dir, hwm=board.hwm, qualifiers=''))
 
         for board in list_boards.find_v2_boards(args).values():
             if name_re is not None and not name_re.search(board.name):
                 continue
+
+            if board.revisions:
+                revisions_list = ' '.join([rev.name for rev in board.revisions])
+            else:
+                revisions_list = 'None'
+
             self.inf(
                 args.format.format(
                     name=board.name,
                     full_name=board.full_name,
+                    revision_default=board.revision_default,
+                    revisions=revisions_list,
                     dir=board.dir,
                     hwm=board.hwm,
                     vendor=board.vendor,


### PR DESCRIPTION
The following board revision properties can now be used as part of the format string in the west boards \-f \.\.\. command.

- board.revisions with format {revisions}
- board.revision_default with format {revision_default}