### PR TITLE
boards: nxp: mimxrt1060_evk.dtsi: remove redundant empty line

### DIFF
--- a/boards/nxp/mimxrt1060_evk/mimxrt1060_evk.dtsi
+++ b/boards/nxp/mimxrt1060_evk/mimxrt1060_evk.dtsi
@@ -268,7 +268,6 @@ arduino_spi: &lpspi1 {
 	dma-names = "rx", "tx";
 	pinctrl-0 = <&pinmux_lpspi3>;
 	pinctrl-names = "default";
-
 };
 
 &sai1 {


### PR DESCRIPTION
Remove a redundant empty line from the LPSPI3 declaration.