### PR TITLE
drivers: can_mcp251xfd: Add XSTBY option

### DIFF
--- a/drivers/can/can_mcp251xfd.c
+++ b/drivers/can/can_mcp251xfd.c
@@ -1394,6 +1394,12 @@ static inline int mcp251xfd_init_iocon_reg(const struct device *dev)
 		tmp |= MCP251XFD_REG_IOCON_SOF;
 	}
 
+	if (dev_cfg->xstby_enable) {
+		tmp &= ~MCP251XFD_REG_IOCON_TRIS0;
+		tmp &= ~MCP251XFD_REG_IOCON_PM0;
+		tmp |= MCP251XFD_REG_IOCON_XSTBYEN;
+	}
+
 	*reg = sys_cpu_to_le32(tmp);
 
 	return  mcp251xfd_write(dev, MCP251XFD_REG_IOCON, MCP251XFD_REG_SIZE);
@@ -1749,6 +1755,7 @@ static DEVICE_API(can, mcp251xfd_api_funcs) = {
 		.int_gpio_dt = GPIO_DT_SPEC_INST_GET(inst, int_gpios),                             \
                                                                                                    \
 		.sof_on_clko = DT_INST_PROP(inst, sof_on_clko),                                    \
+		.xstby_enable = DT_INST_PROP(inst, xstby_enable),                                  \
 		.clko_div = DT_INST_ENUM_IDX(inst, clko_div),                                      \
 		.pll_enable = DT_INST_PROP(inst, pll_enable),                                      \
 		.timestamp_prescaler = DT_INST_PROP(inst, timestamp_prescaler),                    \

--- a/drivers/can/can_mcp251xfd.h
+++ b/drivers/can/can_mcp251xfd.h
@@ -524,6 +524,7 @@ struct mcp251xfd_config {
 
 	/* IO Config */
 	bool sof_on_clko;
+	bool xstby_enable;
 	bool pll_enable;
 	uint8_t clko_div;
 

--- a/dts/bindings/can/microchip,mcp251xfd.yaml
+++ b/dts/bindings/can/microchip,mcp251xfd.yaml
@@ -65,6 +65,10 @@ properties:
       is not set, then an internal clock (typically 40MHz or 20MHz) will be
       output on CLKO pin instead.
 
+  xstby-enable:
+    type: boolean
+    description: Enables standby pin control on GPIO0.
+
   clko-div:
     type: int
     description: The factor to divide the system clock for CLKO pin.


### PR DESCRIPTION
Adds ability to enable the XSTBY functionality on GPIO0 pin, if enabled in devicetree.