### PR TITLE
net: if: Release the interface lock early in IPv6 RS timeout handler

### DIFF
--- a/include/zephyr/net/net_if.h
+++ b/include/zephyr/net/net_if.h
@@ -96,6 +96,8 @@ struct net_if_addr {
 		struct {
 			/** Duplicate address detection (DAD) timer */
 			sys_snode_t dad_node;
+
+			/** DAD start time */
 			uint32_t dad_start;
 
 			/** How many times we have done DAD */

--- a/include/zephyr/net/net_if.h
+++ b/include/zephyr/net/net_if.h
@@ -108,6 +108,8 @@ struct net_if_addr {
 		struct {
 			/** Address conflict detection (ACD) timer. */
 			sys_snode_t acd_node;
+
+			/** ACD timeout value. */
 			k_timepoint_t acd_timeout;
 
 			/** ACD probe/announcement counter. */

--- a/include/zephyr/net/net_if.h
+++ b/include/zephyr/net/net_if.h
@@ -97,6 +97,9 @@ struct net_if_addr {
 			/** Duplicate address detection (DAD) timer */
 			sys_snode_t dad_node;
 
+			/** DAD needed list node */
+			sys_snode_t dad_need_node;
+
 			/** DAD start time */
 			uint32_t dad_start;
 

--- a/include/zephyr/net/net_if.h
+++ b/include/zephyr/net/net_if.h
@@ -112,6 +112,9 @@ struct net_if_addr {
 			/** Address conflict detection (ACD) timer. */
 			sys_snode_t acd_node;
 
+			/** ACD needed list node */
+			sys_snode_t acd_need_node;
+
 			/** ACD timeout value. */
 			k_timepoint_t acd_timeout;
 

--- a/include/zephyr/net/net_if.h
+++ b/include/zephyr/net/net_if.h
@@ -158,6 +158,9 @@ struct net_if_mcast_addr {
 	/** IP address */
 	struct net_addr address;
 
+	/** Rejoining multicast groups list node */
+	sys_snode_t rejoin_node;
+
 #if defined(CONFIG_NET_IPV4_IGMPV3)
 	/** Sources to filter on */
 	struct net_addr sources[CONFIG_NET_IF_MCAST_IPV4_SOURCE_COUNT];

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -1541,6 +1541,8 @@ void net_if_start_rs(struct net_if *iface)
 		goto out;
 	}
 
+	net_if_unlock(iface);
+
 	NET_DBG("Starting ND/RS for iface %p", iface);
 
 	if (!net_ipv6_start_rs(iface)) {
@@ -1556,6 +1558,7 @@ void net_if_start_rs(struct net_if *iface)
 		}
 	}
 
+	return;
 out:
 	net_if_unlock(iface);
 }


### PR DESCRIPTION
The net_if.c:rs_timeout() is sending a new IPv6 router solicitation message to network by calling net_if_start_rs(). That function will then acquire iface->lock and call net_ipv6_start_rs() which will try to send the RS message and acquire TX send lock.
During this RS send, we might receive TCP data that could try to send an ack to peer. This will then in turn cause also TX lock to be acquired. Depending on timing, the lock ordering between rx thread and system workq might mix which could lead to deadlock. Fix this issue by releasing the iface->lock before starting the RS sending process. The net_if_start_rs() does not really need to keep the interface lock for a long time as it is the only one sending the RS message.

Fixes #86499