### PR TITLE
doc: settings: ZMS is the recommended back-end for settings

### DIFF
--- a/doc/services/storage/fcb/fcb.rst
+++ b/doc/services/storage/fcb/fcb.rst
@@ -9,7 +9,7 @@ beginning.
 
 .. note::
 
-   As of Zephyr release 2.1 the :ref:`NVS <nvs_api>` storage API is
+   As of Zephyr release 4.1 the :ref:`ZMS <zms_api>` storage API is
    recommended over FCB for use as a back-end for the :ref:`settings API
    <settings_api>`.
 

--- a/doc/services/storage/settings/index.rst
+++ b/doc/services/storage/settings/index.rst
@@ -23,8 +23,8 @@ For an example of the settings subsystem refer to :zephyr:code-sample:`settings`
 
 .. note::
 
-   As of Zephyr release 2.1 the recommended backend for non-filesystem
-   storage is :ref:`NVS <nvs_api>`.
+   As of Zephyr release 4.1 the recommended backend for non-filesystem
+   storage is :ref:`ZMS <zms_api>`.
 
 Handlers
 ********


### PR DESCRIPTION
- Starting Zephyr release 4.1, the ZMS storage API is recommended for use as a back-end for the Settings.
- It's valid after ef4e8dd5c3f8186ab62d28d92bd3f31ddefade61 , choice SETTINGS_BACKEND was set to the first default SETTINGS_ZMS.