### PR TITLE
west: runners: Add support for multiple device IDs

### DIFF
--- a/scripts/west_commands/runners/nrfjprog.py
+++ b/scripts/west_commands/runners/nrfjprog.py
@@ -31,6 +31,14 @@ class NrfJprogBinaryRunner(NrfBinaryRunner):
         return 'nrfjprog'
 
     @classmethod
+    def capabilities(cls):
+        return NrfBinaryRunner._capabilities()
+
+    @classmethod
+    def dev_id_help(cls) -> str:
+        return NrfBinaryRunner._dev_id_help()
+
+    @classmethod
     def tool_opt_help(cls) -> str:
         return 'Additional options for nrfjprog, e.g. "--clockspeed"'
 

--- a/scripts/west_commands/runners/nrfutil.py
+++ b/scripts/west_commands/runners/nrfutil.py
@@ -34,6 +34,15 @@ class NrfUtilBinaryRunner(NrfBinaryRunner):
         return 'nrfutil'
 
     @classmethod
+    def capabilities(cls):
+        return NrfBinaryRunner._capabilities(mult_dev_ids=True)
+
+    @classmethod
+    def dev_id_help(cls) -> str:
+        return NrfBinaryRunner._dev_id_help() + \
+               '''.\n This option can be specified multiple times'''
+
+    @classmethod
     def tool_opt_help(cls) -> str:
         return 'Additional options for nrfutil, e.g. "--log-level"'
 
@@ -107,6 +116,12 @@ class NrfUtilBinaryRunner(NrfBinaryRunner):
         self._op_id += 1
         self._ops.append(op)
 
+    def _format_dev_ids(self):
+        if isinstance(self.dev_id, list):
+            return ','.join(self.dev_id)
+        else:
+            return self.dev_id
+
     def _append_batch(self, op, json_file):
         _op = op['operation']
         op_type = _op['type']
@@ -151,7 +166,7 @@ class NrfUtilBinaryRunner(NrfBinaryRunner):
             precmd = ['--x-ext-mem-config-file', self.ext_mem_config_file]
 
         self._exec(precmd + ['x-execute-batch', '--batch-path', f'{json_file}',
-                             '--serial-number', f'{self.dev_id}'])
+                             '--serial-number', self._format_dev_ids()])
 
     def do_exec_op(self, op, force=False):
         self.logger.debug(f'Executing op: {op}')


### PR DESCRIPTION
In order to enable the use case where the underlying flash tool supports bulk-flashing using multiple device IDs, augment the core runner class with this new runner capability and implement it in the nrfutil runner, since the nrfutil tool supports it natively.