### PR TITLE
Various fixes for IPv4 autoconf

### DIFF
--- a/include/zephyr/net/ipv4_autoconf.h
+++ b/include/zephyr/net/ipv4_autoconf.h
@@ -13,9 +13,10 @@
 
 /** Current state of IPv4 Autoconfiguration */
 enum net_ipv4_autoconf_state {
-	NET_IPV4_AUTOCONF_INIT,     /**< Initialization state */
-	NET_IPV4_AUTOCONF_ASSIGNED, /**< Assigned state */
-	NET_IPV4_AUTOCONF_RENEW,    /**< Renew state */
+	NET_IPV4_AUTOCONF_INIT,         /**< Initialization state */
+	NET_IPV4_AUTOCONF_RENEW,        /**< Renew state */
+	NET_IPV4_AUTOCONF_ALLOCATING,   /**< Allocating state */
+	NET_IPV4_AUTOCONF_ASSIGNED,     /**< Assigned state */
 };
 
 struct net_if;

--- a/subsys/net/ip/ipv4_autoconf.c
+++ b/subsys/net/ip/ipv4_autoconf.c
@@ -40,6 +40,8 @@ static inline void ipv4_autoconf_addr_set(struct net_if_ipv4_autoconf *ipv4auto)
 		ipv4auto->requested_ip.s4_addr[2],
 		ipv4auto->requested_ip.s4_addr[3]);
 
+	ipv4auto->state = NET_IPV4_AUTOCONF_ALLOCATING;
+
 	/* Add IPv4 address to the interface, this will trigger conflict detection. */
 	if (!net_if_ipv4_addr_add(ipv4auto->iface, &ipv4auto->requested_ip,
 				  NET_ADDR_AUTOCONF, 0)) {
@@ -51,8 +53,6 @@ static inline void ipv4_autoconf_addr_set(struct net_if_ipv4_autoconf *ipv4auto)
 	net_if_ipv4_set_netmask_by_addr(ipv4auto->iface,
 					&ipv4auto->requested_ip,
 					&netmask);
-
-	ipv4auto->state = NET_IPV4_AUTOCONF_ASSIGNED;
 }
 
 static void acd_event_handler(struct net_mgmt_event_callback *cb,

--- a/subsys/net/ip/ipv4_autoconf.c
+++ b/subsys/net/ip/ipv4_autoconf.c
@@ -28,10 +28,11 @@ static inline void ipv4_autoconf_addr_set(struct net_if_ipv4_autoconf *ipv4auto)
 	struct in_addr netmask = { { { 255, 255, 0, 0 } } };
 
 	if (ipv4auto->state == NET_IPV4_AUTOCONF_INIT) {
+		/* RFC3927 2.1 allowed address range: 169.254.1.0 - 169.254.254.255 */
 		ipv4auto->requested_ip.s4_addr[0] = 169U;
 		ipv4auto->requested_ip.s4_addr[1] = 254U;
-		ipv4auto->requested_ip.s4_addr[2] = sys_rand8_get() % 254;
-		ipv4auto->requested_ip.s4_addr[3] = sys_rand8_get() % 254;
+		ipv4auto->requested_ip.s4_addr[2] = 1 + (sys_rand8_get() % 254);
+		ipv4auto->requested_ip.s4_addr[3] = sys_rand8_get();
 	}
 
 	NET_DBG("%s: Starting probe for 169.254.%d.%d",


### PR DESCRIPTION
- Fixes allowed address range
- Do not set address as assigned until conflict detection is done
- Introduce locking to avoid race conditions when changing state