### PR TITLE
twister: add --check to validate test metadata

### DIFF
--- a/scripts/pylib/twister/twisterlib/constants.py
+++ b/scripts/pylib/twister/twisterlib/constants.py
@@ -16,5 +16,22 @@ SUPPORTED_SIMS = [
     "custom",
     "simics",
 ]
+SUPPORTED_RUNNABLE_HARNESS = [
+    'console',
+    'ztest',
+    'power',
+    'pytest',
+    'test',
+    'gtest',
+    'robot',
+    'ctest',
+    'shell',
+]
+SUPPORTED_BUILDABLE_HARNESS = [
+    'bsim',
+]
+
+SUPPORTED_HARNESS = SUPPORTED_RUNNABLE_HARNESS + SUPPORTED_BUILDABLE_HARNESS
+
 SUPPORTED_SIMS_IN_PYTEST = ['native', 'qemu']
 SUPPORTED_SIMS_WITH_EXEC = ['nsim', 'mdb-nsim', 'renode', 'tsim', 'native', 'simics', 'custom']

--- a/scripts/pylib/twister/twisterlib/environment.py
+++ b/scripts/pylib/twister/twisterlib/environment.py
@@ -302,6 +302,10 @@ Artificially long but functional example:
         configuration and is mutual exclusive with --enable-valgrind.
         """)
 
+    parser.add_argument(
+        "--check", action="store_true",
+        help="Run the code through the check target.")
+
     # Start of individual args place them in alpha-beta order
 
     board_root_list = [f"{ZEPHYR_BASE}/boards", f"{ZEPHYR_BASE}/subsys/testsuite/boards"]

--- a/scripts/pylib/twister/twisterlib/testinstance.py
+++ b/scripts/pylib/twister/twisterlib/testinstance.py
@@ -34,6 +34,7 @@ from twisterlib.platform import Platform
 from twisterlib.size_calc import SizeCalculator
 from twisterlib.statuses import TwisterStatus
 from twisterlib.testsuite import TestCase, TestSuite
+from twisterlib.constants import SUPPORTED_RUNNABLE_HARNESS
 
 logger = logging.getLogger('twister')
 
@@ -218,17 +219,7 @@ class TestInstance:
     def testsuite_runnable(testsuite, fixtures):
         can_run = False
         # console harness allows us to run the test and capture data.
-        if testsuite.harness in [
-            'console',
-            'ztest',
-            'pytest',
-            'power',
-            'test',
-            'gtest',
-            'robot',
-            'ctest',
-            'shell'
-            ]:
+        if testsuite.harness in SUPPORTED_RUNNABLE_HARNESS:
             can_run = True
             # if we have a fixture that is also being supplied on the
             # command-line, then we need to run the test, not just build it.

--- a/scripts/pylib/twister/twisterlib/testinstance.py
+++ b/scripts/pylib/twister/twisterlib/testinstance.py
@@ -16,6 +16,7 @@ import random
 from enum import Enum
 
 from twisterlib.constants import (
+    SUPPORTED_RUNNABLE_HARNESS,
     SUPPORTED_SIMS,
     SUPPORTED_SIMS_IN_PYTEST,
     SUPPORTED_SIMS_WITH_EXEC,
@@ -34,7 +35,6 @@ from twisterlib.platform import Platform
 from twisterlib.size_calc import SizeCalculator
 from twisterlib.statuses import TwisterStatus
 from twisterlib.testsuite import TestCase, TestSuite
-from twisterlib.constants import SUPPORTED_RUNNABLE_HARNESS
 
 logger = logging.getLogger('twister')
 

--- a/scripts/pylib/twister/twisterlib/twister_main.py
+++ b/scripts/pylib/twister/twisterlib/twister_main.py
@@ -140,7 +140,10 @@ def twister(options: argparse.Namespace, default_options: argparse.Namespace):
         hwm.dump(filtered=tplan.selected_platforms)
         print("")
 
-    if options.dry_run:
+    if options.check:
+        tplan.checker.report()
+
+    if options.dry_run or options.check:
         duration = time.time() - start_time
         logger.info(f"Completed in {duration} seconds")
         return 0

--- a/scripts/schemas/twister/test-config-schema.yaml
+++ b/scripts/schemas/twister/test-config-schema.yaml
@@ -13,6 +13,22 @@ mapping:
         required: false
         sequence:
           - type: str
+  "qa":
+    type: map
+    required: false
+    mapping:
+      "max_platform_allow":
+        type: int
+        required: false
+      "max_integration_platforms":
+        type: int
+        required: false
+      "max_scenarios":
+        type: int
+        required: false
+      "max_platform_exclude":
+        type: int
+        required: false
   "platforms":
     type: map
     required: false

--- a/scripts/tests/twister/test_config_parser.py
+++ b/scripts/tests/twister/test_config_parser.py
@@ -8,12 +8,18 @@ Tests for config_parser.py
 """
 
 import os
-import pytest
-import mock
-import scl
-
-from twisterlib.config_parser import TwisterConfigParser, extract_fields_from_arg_list, ConfigurationError
 from contextlib import nullcontext
+from unittest import mock
+
+import pykwalify
+import pytest
+import scl
+from twisterlib.config_parser import (
+    ConfigurationError,
+    TwisterConfigParser,
+    extract_fields_from_arg_list,
+)
+
 
 def test_extract_single_field_from_string_argument():
     target_fields = {"FIELD1"}
@@ -72,7 +78,8 @@ def test_load_yaml_with_extra_args_and_retrieve_scenario_data(zephyr_base):
     scenario_common = parser.common
 
     assert scenario_data['tags'] == {'tag1', 'tag2'}
-    assert scenario_data['extra_args'] == ['--CONF_FILE=file1.conf', '--OVERLAY_CONFIG=config1.conf']
+    assert scenario_data['extra_args'] == [
+        '--CONF_FILE=file1.conf', '--OVERLAY_CONFIG=config1.conf']
     assert scenario_common == {'filter': 'filter2'}
 
 
@@ -141,7 +148,7 @@ def test_default_values(zephyr_base):
         ('key: val', 'map', 'key: val', None),   # do-nothing cast
         ('test', 'int', ValueError, None),
         ('test', 'unknown', ConfigurationError, None),
-        ([ '1', '2', '3' ], 'set', { '1', '2', '2','3' }, None),
+        ([ '1', '2', '3' ], 'set', { '1', '2', '3' }, None),
     ],
     ids=['str to str', 'str to float', 'str to int', 'str to bool', 'str to map',
          'invalid', 'to unknown', "list to set"]
@@ -153,8 +160,9 @@ def test_cast_value(zephyr_base, value, typestr, expected, expected_warning):
     )
 
     parser = TwisterConfigParser("config.yaml", loaded_schema)
-    with mock.patch('warnings.warn') as warn_mock:
-        with pytest.raises(expected) if isinstance(expected, type) and issubclass(expected, Exception) else nullcontext():
+    with mock.patch('warnings.warn') as warn_mock:  # noqa: SIM117
+        with pytest.raises(expected) if isinstance(expected, type) \
+            and issubclass(expected, Exception) else nullcontext():
             result = parser._cast_value(value, typestr)
             assert result == expected
             if expected_warning:
@@ -175,7 +183,7 @@ def test_load_invalid_test_config_yaml(zephyr_base):
 
     with mock.patch('builtins.open', mock.mock_open(read_data=yaml_data)):
         parser = TwisterConfigParser(filename, loaded_schema)
-        with pytest.raises(Exception):
+        with pytest.raises(pykwalify.errors.SchemaError):
             parser.load()
 
 

--- a/scripts/tests/twister/test_testplan.py
+++ b/scripts/tests/twister/test_testplan.py
@@ -1127,10 +1127,10 @@ def test_testplan_add_configurations(
         assert [tmp_path] == arch_roots
 
         platforms = [
-            mock.Mock(aliases=['p1e1/unit_testing', 'p1e1'], twister=False, default=False),
-            mock.Mock(aliases=['p1e2/unit_testing', 'p1e2'], twister=True, default=False),
-            mock.Mock(aliases=['p2/unit_testing', 'p2'], twister=True, default=True),
-            mock.Mock(aliases=['p3/unit_testing', 'p3'], twister=True, default=True),
+            mock.Mock(aliases=['p1e1/unit_testing', 'p1e1'], twister=False, default=False, supported=[]),
+            mock.Mock(aliases=['p1e2/unit_testing', 'p1e2'], twister=True, default=False, supported=[]),
+            mock.Mock(aliases=['p2/unit_testing', 'p2'], twister=True, default=True, supported=[]),
+            mock.Mock(aliases=['p3/unit_testing', 'p3'], twister=True, default=True, supported=[]),
         ]
         for platform in platforms:
             type(platform).name = mock.PropertyMock(return_value=platform.aliases[0])
@@ -1310,6 +1310,7 @@ tests:
     )
 
     testplan = TestPlan(env=env)
+    testplan.supported_features = []
 
     res = testplan.add_testsuites(testsuite_filter)
 

--- a/tests/test_config.yaml
+++ b/tests/test_config.yaml
@@ -1,6 +1,11 @@
 platforms:
   override_default_platforms: false
   increased_platform_scope: true
+qa:
+  max_platform_allow: 10
+  max_integration_platforms: 5
+  max_scenarios: 10
+  max_platform_exclude: 5
 levels:
   - name: smoke
     description: >


### PR DESCRIPTION

for example, running this 
```./scripts/twister -T samples/ --check```

will result in:
```
QA      - filter with no integration platforms in samples/posix/gettimeofday/sample.posix.gettimeofday
QA      - skip set in samples/tfm_integration/psa_crypto/sample.psa_crypto
QA      - Too many excluded platforms in samples/userspace/shared_mem/sample.kernel.memory_protection.shared_mem: 6
QA      - platform_allow in samples/kernel/bootargs/sample.kernel.bootargs.multiboot without integration_platforms
QA      - build_only set in samples/sensor/mpu6050/sample.sensor.mpu6050
QA      - build_only set in samples/sensor/6dof_motion_drdy/sample.sensor.6dof_motion_drdy
QA      - build_only set in samples/sensor/mhz19b/sample.sensor.mhz19b
QA      - filter with no integration platforms in samples/sensor/mhz19b/sample.sensor.mhz19b
QA      - platform_allow in samples/sensor/clock/sample.sensor.clock.counter without integration_platforms
QA      - platform_allow in samples/sensor/clock/sample.sensor.clock.rtc without integration_platforms
QA      - filter with no integration platforms in samples/sensor/clock/sample.sensor.clock.system
QA      - build_only set in samples/sensor/max17262/sample.sensor.max17262
QA      - build_only set in samples/sensor/vl53l0x/sample.sensor.vl53l0x
QA      - filter with no integration platforms in samples/sensor/bmg160/sample.sensor.bmg160
QA      - Too many excluded platforms in samples/sensor/accel_trig/sample.sensor.accel_trig: 7
QA      - build_only set in samples/sensor/mcux_lpcmp/sample.sensor.mcux_lpcmp.no_trigger
QA      - build_only set in samples/sensor/icm42605/sample.sensor.icm42605
QA      - filter with no integration platforms in samples/sensor/tmp108/sample.sensor.tmp108
QA      - build_only set in samples/sensor/sht3xd/sample.sensor.sht3xd
QA      - build_only set in samples/sensor/sht3xd/sample.sensor.sht3xd.trigger
QA      - filter with no integration platforms in samples/sensor/max44009/sample.sensor.max44009
QA      - build_only set in samples/sensor/tdk_apex/sample.sensor.icm42670.apex
QA      - filter with no integration platforms in samples/sensor/lps22hh/sample.sensor.lps22hh
QA      - build_only set in samples/sensor/ms5837/sample.sensor.ms5837
QA      - filter with no integration platforms in samples/sensor/th02/sample.sensor.th02
QA      - Too many integration platforms in samples/sensor/accel_polling/sample.sensor.accel_polling: 15
QA      - filter with no integration platforms in samples/sensor/tmp112/sample.sensor.tmp112
QA      - filter with no integration platforms in samples/sensor/co2_polling/sample.sensor.co2
QA      - Unsupported depends_on {'uart_interrupt_driven', 'serial'} in samples/sensor/co2_polling/sample.sensor.co2
QA      - filter with no integration platforms in samples/sensor/max6675/sample.sensor.max6675
QA      - build_only set in samples/sensor/ina219/sample.drivers.ina219
QA      - filter with no integration platforms in samples/sensor/sx9500/sample.sensor.sx9500
QA      - filter with no integration platforms in samples/sensor/stream_fifo/sample.sensor.stream_fifo
QA      - build_only set in samples/sensor/lsm6dso_i2c_on_i3c/sample.sensor.lsm6dso.i2c_on_i3c_bus
QA      - filter with no integration platforms in samples/sensor/lsm6dso_i2c_on_i3c/sample.sensor.lsm6dso.i2c_on_i3c_bus
QA      - build_only set in samples/sensor/grow_r502a/sample.sensor.grow_r502a
QA      - filter with no integration platforms in samples/sensor/grow_r502a/sample.sensor.grow_r502a
QA      - Unsupported depends_on {'lis2dh', 'i2c'} in samples/sensor/lis2dh/sample.sensor.lis2dh
QA      - filter with no integration platforms in samples/sensor/veaa_x_3/sample.sensor.veaa_x_3
QA      - build_only set in samples/sensor/sgp40_sht4x/sample.sensor.sgp40_sht4x
QA      - build_only set in samples/sensor/mcux_acmp/sample.sensor.mcux_acmp.no_trigger
QA      - build_only set in samples/sensor/amg88xx/sample.sensor.amg88xx.amg88xx_grid_eye_eval_shield
QA      - build_only set in samples/sensor/amg88xx/sample.sensor.amg88xx.amg88xx_eval_kit
QA      - filter with no integration platforms in samples/sensor/qdec/sample.sensor.qdec_sensor
QA      - platform_allow in samples/sensor/qdec/sample.sensor.sam_qdec_sensor without integration_platforms
QA      - Unsupported depends_on {'spi', 'bme280'} in samples/sensor/bme280/sample.sensor.bme280.spi
QA      - filter with no integration platforms in samples/sensor/soc_voltage/sample.sensor.soc_voltage
QA      - build_only set in samples/sensor/lps22hh_i3c/sample.sensor.lps22hh.i3c
QA      - filter with no integration platforms in samples/sensor/lps22hh_i3c/sample.sensor.lps22hh.i3c
```



Note: many of the limits and guards are arbitrary, they will be configurable somewhere.