### PR TITLE
imx95: Add GPIO support Cortex-M7 target

### DIFF
--- a/boards/nxp/imx95_evk/doc/index.rst
+++ b/boards/nxp/imx95_evk/doc/index.rst
@@ -94,6 +94,8 @@ The Zephyr ``imx95_evk/mimx9596/m7`` board target supports the following hardwar
 +-----------+------------+-------------------------------------+
 | SPI       | on-chip    | spi                                 |
 +-----------+------------+-------------------------------------+
+| GPIO      | on-chip    | gpio                                |
++-----------+------------+-------------------------------------+
 
 The Zephyr ``imx95_evk/mimx9596/a55`` and ``imx95_evk/mimx9596/a55/smp`` board targets support
 the following hardware features:

--- a/dts/arm/nxp/nxp_imx95_m7.dtsi
+++ b/dts/arm/nxp/nxp_imx95_m7.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 NXP
+ * Copyright 2024-2025 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -7,6 +7,7 @@
 #include <arm/armv7-m.dtsi>
 #include <zephyr/dt-bindings/clock/imx95_clock.h>
 #include <dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
 #include <mem.h>
 
 / {
@@ -75,6 +76,51 @@
 		dtcm: dtcm@20000000 {
 			compatible = "nxp,imx-dtcm";
 			reg = <0x20000000 DT_SIZE_K(256)>;
+		};
+
+		gpio1: gpio@47400000 {
+			compatible = "nxp,imx-rgpio";
+			reg = <0x47400000 DT_SIZE_K(64)>;
+			interrupts = <10 0>, <11 0>;
+			gpio-controller;
+			#gpio-cells = <2>;
+			ngpios = <16>;
+		};
+
+		gpio2: gpio@43810000 {
+			compatible = "nxp,imx-rgpio";
+			reg = <0x43810000 DT_SIZE_K(64)>;
+			interrupts = <49 0>, <50 0>;
+			gpio-controller;
+			#gpio-cells = <2>;
+			ngpios = <32>;
+		};
+
+		gpio3: gpio@43820000 {
+			compatible = "nxp,imx-rgpio";
+			reg = <0x43820000 DT_SIZE_K(64)>;
+			interrupts = <51 0>, <52 0>;
+			gpio-controller;
+			#gpio-cells = <2>;
+			ngpios = <32>;
+		};
+
+		gpio4: gpio@43840000 {
+			compatible = "nxp,imx-rgpio";
+			reg = <0x43840000 DT_SIZE_K(64)>;
+			interrupts = <53 0>, <54 0>;
+			gpio-controller;
+			#gpio-cells = <2>;
+			ngpios = <30>;
+		};
+
+		gpio5: gpio@43850000 {
+			compatible = "nxp,imx-rgpio";
+			reg = <0x43850000 DT_SIZE_K(64)>;
+			interrupts = <55 0>, <56 0>;
+			gpio-controller;
+			#gpio-cells = <2>;
+			ngpios = <18>;
 		};
 
 		edma2: dma@42000000 {
@@ -418,4 +464,147 @@
 
 &nvic {
 	arm,num-irq-priority-bits = <4>;
+};
+
+&gpio1 {
+	pinmux = <&iomuxc_i2c1_scl_gpio_io_bit_gpio1_io_bit0>,
+		<&iomuxc_i2c1_sda_gpio_io_bit_gpio1_io_bit1>,
+		<&iomuxc_i2c2_scl_gpio_io_bit_gpio1_io_bit2>,
+		<&iomuxc_i2c2_sda_gpio_io_bit_gpio1_io_bit3>,
+		<&iomuxc_uart1_rxd_gpio_io_bit_gpio1_io_bit4>,
+		<&iomuxc_uart1_txd_gpio_io_bit_gpio1_io_bit5>,
+		<&iomuxc_uart2_rxd_gpio_io_bit_gpio1_io_bit6>,
+		<&iomuxc_uart2_txd_gpio_io_bit_gpio1_io_bit7>,
+		<&iomuxc_pdm_clk_gpio_io_bit_gpio1_io_bit8>,
+		<&iomuxc_pdm_bit_stream0_gpio_io_bit_gpio1_io_bit9>,
+		<&iomuxc_pdm_bit_stream1_gpio_io_bit_gpio1_io_bit10>,
+		<&iomuxc_sai1_txfs_gpio_io_bit_gpio1_io_bit11>,
+		<&iomuxc_sai1_txc_gpio_io_bit_gpio1_io_bit12>,
+		<&iomuxc_sai1_txd0_gpio_io_bit_gpio1_io_bit13>,
+		<&iomuxc_sai1_rxd0_gpio_io_bit_gpio1_io_bit14>,
+		<&iomuxc_wdog_any_gpio_io_bit_gpio1_io_bit15>;
+};
+
+&gpio2 {
+	pinmux = <&iomuxc_gpio_io00_gpio_io_bit_gpio2_io_bit0>,
+		<&iomuxc_gpio_io01_gpio_io_bit_gpio2_io_bit1>,
+		<&iomuxc_gpio_io02_gpio_io_bit_gpio2_io_bit2>,
+		<&iomuxc_gpio_io03_gpio_io_bit_gpio2_io_bit3>,
+		<&iomuxc_gpio_io04_gpio_io_bit_gpio2_io_bit4>,
+		<&iomuxc_gpio_io05_gpio_io_bit_gpio2_io_bit5>,
+		<&iomuxc_gpio_io06_gpio_io_bit_gpio2_io_bit6>,
+		<&iomuxc_gpio_io07_gpio_io_bit_gpio2_io_bit7>,
+		<&iomuxc_gpio_io08_gpio_io_bit_gpio2_io_bit8>,
+		<&iomuxc_gpio_io09_gpio_io_bit_gpio2_io_bit9>,
+		<&iomuxc_gpio_io10_gpio_io_bit_gpio2_io_bit10>,
+		<&iomuxc_gpio_io11_gpio_io_bit_gpio2_io_bit11>,
+		<&iomuxc_gpio_io12_gpio_io_bit_gpio2_io_bit12>,
+		<&iomuxc_gpio_io13_gpio_io_bit_gpio2_io_bit13>,
+		<&iomuxc_gpio_io14_gpio_io_bit_gpio2_io_bit14>,
+		<&iomuxc_gpio_io15_gpio_io_bit_gpio2_io_bit15>,
+		<&iomuxc_gpio_io16_gpio_io_bit_gpio2_io_bit16>,
+		<&iomuxc_gpio_io17_gpio_io_bit_gpio2_io_bit17>,
+		<&iomuxc_gpio_io18_gpio_io_bit_gpio2_io_bit18>,
+		<&iomuxc_gpio_io19_gpio_io_bit_gpio2_io_bit19>,
+		<&iomuxc_gpio_io20_gpio_io_bit_gpio2_io_bit20>,
+		<&iomuxc_gpio_io21_gpio_io_bit_gpio2_io_bit21>,
+		<&iomuxc_gpio_io22_gpio_io_bit_gpio2_io_bit22>,
+		<&iomuxc_gpio_io23_gpio_io_bit_gpio2_io_bit23>,
+		<&iomuxc_gpio_io24_gpio_io_bit_gpio2_io_bit24>,
+		<&iomuxc_gpio_io25_gpio_io_bit_gpio2_io_bit25>,
+		<&iomuxc_gpio_io26_gpio_io_bit_gpio2_io_bit26>,
+		<&iomuxc_gpio_io27_gpio_io_bit_gpio2_io_bit27>,
+		<&iomuxc_gpio_io28_gpio_io_bit_gpio2_io_bit28>,
+		<&iomuxc_gpio_io29_gpio_io_bit_gpio2_io_bit29>,
+		<&iomuxc_gpio_io30_gpio_io_bit_gpio2_io_bit30>,
+		<&iomuxc_gpio_io31_gpio_io_bit_gpio2_io_bit31>;
+};
+
+&gpio3 {
+	pinmux = <&iomuxc_sd2_cd_b_gpio_io_bit_gpio3_io_bit0>,
+		<&iomuxc_sd2_clk_gpio_io_bit_gpio3_io_bit1>,
+		<&iomuxc_sd2_cmd_gpio_io_bit_gpio3_io_bit2>,
+		<&iomuxc_sd2_data0_gpio_io_bit_gpio3_io_bit3>,
+		<&iomuxc_sd2_data1_gpio_io_bit_gpio3_io_bit4>,
+		<&iomuxc_sd2_data2_gpio_io_bit_gpio3_io_bit5>,
+		<&iomuxc_sd2_data3_gpio_io_bit_gpio3_io_bit6>,
+		<&iomuxc_sd2_reset_b_gpio_io_bit_gpio3_io_bit7>,
+		<&iomuxc_sd1_clk_gpio_io_bit_gpio3_io_bit8>,
+		<&iomuxc_sd1_cmd_gpio_io_bit_gpio3_io_bit9>,
+		<&iomuxc_sd1_data0_gpio_io_bit_gpio3_io_bit10>,
+		<&iomuxc_sd1_data1_gpio_io_bit_gpio3_io_bit11>,
+		<&iomuxc_sd1_data2_gpio_io_bit_gpio3_io_bit12>,
+		<&iomuxc_sd1_data3_gpio_io_bit_gpio3_io_bit13>,
+		<&iomuxc_sd1_data4_gpio_io_bit_gpio3_io_bit14>,
+		<&iomuxc_sd1_data5_gpio_io_bit_gpio3_io_bit15>,
+		<&iomuxc_sd1_data6_gpio_io_bit_gpio3_io_bit16>,
+		<&iomuxc_sd1_data7_gpio_io_bit_gpio3_io_bit17>,
+		<&iomuxc_sd1_strobe_gpio_io_bit_gpio3_io_bit18>,
+		<&iomuxc_sd2_vselect_gpio_io_bit_gpio3_io_bit19>,
+		<&iomuxc_sd3_clk_gpio_io_bit_gpio3_io_bit20>,
+		<&iomuxc_sd3_cmd_gpio_io_bit_gpio3_io_bit21>,
+		<&iomuxc_sd3_data0_gpio_io_bit_gpio3_io_bit22>,
+		<&iomuxc_sd3_data1_gpio_io_bit_gpio3_io_bit23>,
+		<&iomuxc_sd3_data2_gpio_io_bit_gpio3_io_bit24>,
+		<&iomuxc_sd3_data3_gpio_io_bit_gpio3_io_bit25>,
+		<&iomuxc_ccm_clko1_gpio_io_bit_gpio3_io_bit26>,
+		<&iomuxc_ccm_clko2_gpio_io_bit_gpio3_io_bit27>,
+		<&iomuxc_dap_tdi_gpio_io_bit_gpio3_io_bit28>,
+		<&iomuxc_dap_tms_swdio_gpio_io_bit_gpio3_io_bit29>,
+		<&iomuxc_dap_tclk_swclk_gpio_io_bit_gpio3_io_bit30>,
+		<&iomuxc_dap_tdo_traceswo_gpio_io_bit_gpio3_io_bit31>;
+};
+
+&gpio4 {
+	pinmux = <&iomuxc_enet1_mdc_gpio_io_bit_gpio4_io_bit0>,
+		<&iomuxc_enet1_mdio_gpio_io_bit_gpio4_io_bit1>,
+		<&iomuxc_enet1_td3_gpio_io_bit_gpio4_io_bit2>,
+		<&iomuxc_enet1_td2_gpio_io_bit_gpio4_io_bit3>,
+		<&iomuxc_enet1_td1_gpio_io_bit_gpio4_io_bit4>,
+		<&iomuxc_enet1_td0_gpio_io_bit_gpio4_io_bit5>,
+		<&iomuxc_enet1_tx_ctl_gpio_io_bit_gpio4_io_bit6>,
+		<&iomuxc_enet1_txc_gpio_io_bit_gpio4_io_bit7>,
+		<&iomuxc_enet1_rx_ctl_gpio_io_bit_gpio4_io_bit8>,
+		<&iomuxc_enet1_rxc_gpio_io_bit_gpio4_io_bit9>,
+		<&iomuxc_enet1_rd0_gpio_io_bit_gpio4_io_bit10>,
+		<&iomuxc_enet1_rd1_gpio_io_bit_gpio4_io_bit11>,
+		<&iomuxc_enet1_rd2_gpio_io_bit_gpio4_io_bit12>,
+		<&iomuxc_enet1_rd3_gpio_io_bit_gpio4_io_bit13>,
+		<&iomuxc_enet2_mdc_gpio_io_bit_gpio4_io_bit14>,
+		<&iomuxc_enet2_mdio_gpio_io_bit_gpio4_io_bit15>,
+		<&iomuxc_enet2_td3_gpio_io_bit_gpio4_io_bit16>,
+		<&iomuxc_enet2_td2_gpio_io_bit_gpio4_io_bit17>,
+		<&iomuxc_enet2_td1_gpio_io_bit_gpio4_io_bit18>,
+		<&iomuxc_enet2_td0_gpio_io_bit_gpio4_io_bit19>,
+		<&iomuxc_enet2_tx_ctl_gpio_io_bit_gpio4_io_bit20>,
+		<&iomuxc_enet2_txc_gpio_io_bit_gpio4_io_bit21>,
+		<&iomuxc_enet2_rx_ctl_gpio_io_bit_gpio4_io_bit22>,
+		<&iomuxc_enet2_rxc_gpio_io_bit_gpio4_io_bit23>,
+		<&iomuxc_enet2_rd0_gpio_io_bit_gpio4_io_bit24>,
+		<&iomuxc_enet2_rd1_gpio_io_bit_gpio4_io_bit25>,
+		<&iomuxc_enet2_rd2_gpio_io_bit_gpio4_io_bit26>,
+		<&iomuxc_enet2_rd3_gpio_io_bit_gpio4_io_bit27>,
+		<&iomuxc_ccm_clko3_gpio_io_bit_gpio4_io_bit28>,
+		<&iomuxc_ccm_clko4_gpio_io_bit_gpio4_io_bit29>;
+};
+
+&gpio5 {
+	pinmux = <&iomuxc_xspi1_data0_gpio_io_bit_gpio5_io_bit0>,
+		<&iomuxc_xspi1_data1_gpio_io_bit_gpio5_io_bit1>,
+		<&iomuxc_xspi1_data2_gpio_io_bit_gpio5_io_bit2>,
+		<&iomuxc_xspi1_data3_gpio_io_bit_gpio5_io_bit3>,
+		<&iomuxc_xspi1_data4_gpio_io_bit_gpio5_io_bit4>,
+		<&iomuxc_xspi1_data5_gpio_io_bit_gpio5_io_bit5>,
+		<&iomuxc_xspi1_data6_gpio_io_bit_gpio5_io_bit6>,
+		<&iomuxc_xspi1_data7_gpio_io_bit_gpio5_io_bit7>,
+		<&iomuxc_xspi1_dqs_gpio_io_bit_gpio5_io_bit8>,
+		<&iomuxc_xspi1_sclk_gpio_io_bit_gpio5_io_bit9>,
+		<&iomuxc_xspi1_ss0_b_gpio_io_bit_gpio5_io_bit10>,
+		<&iomuxc_xspi1_ss1_b_gpio_io_bit_gpio5_io_bit11>,
+		<&iomuxc_gpio_io32_gpio_io_bit_gpio5_io_bit12>,
+		<&iomuxc_gpio_io33_gpio_io_bit_gpio5_io_bit13>,
+		<&iomuxc_gpio_io34_gpio_io_bit_gpio5_io_bit14>,
+		<&iomuxc_gpio_io35_gpio_io_bit_gpio5_io_bit15>,
+		<&iomuxc_gpio_io36_gpio_io_bit_gpio5_io_bit16>,
+		<&iomuxc_gpio_io37_gpio_io_bit_gpio5_io_bit17>;
 };

--- a/soc/nxp/imx/imx9/imx95/pinctrl_soc.h
+++ b/soc/nxp/imx/imx9/imx95/pinctrl_soc.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 NXP
+ * Copyright 2024-2025 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -27,23 +27,23 @@ extern "C" {
 #define IOMUXC_CFGREG   (IOMUXC_BASE + 0x204)
 #define IOMUXC_DAISYREG (IOMUXC_BASE + 0x408)
 
-#define IOMUXC_INPUT_SCHMITT_ENABLE_SHIFT IOMUXC_SW_PAD_CTL_PAD_HYS_SHIFT
-#define IOMUXC_DRIVE_OPEN_DRAIN_SHIFT     IOMUXC_SW_PAD_CTL_PAD_OD_SHIFT
-#define IOMUXC_BIAS_PULL_DOWN_SHIFT       IOMUXC_SW_PAD_CTL_PAD_PD_SHIFT
-#define IOMUXC_BIAS_PULL_UP_SHIFT         IOMUXC_SW_PAD_CTL_PAD_PU_SHIFT
-#define IOMUXC_SLEW_RATE_SHIFT            IOMUXC_SW_PAD_CTL_PAD_FSEL1_SHIFT
-#define IOMUXC_DRIVE_STRENGTH_SHIFT       IOMUXC_SW_PAD_CTL_PAD_DSE_SHIFT
+#define MCUX_IMX_INPUT_SCHMITT_ENABLE_SHIFT IOMUXC_SW_PAD_CTL_PAD_HYS_SHIFT
+#define MCUX_IMX_DRIVE_OPEN_DRAIN_SHIFT     IOMUXC_SW_PAD_CTL_PAD_OD_SHIFT
+#define MCUX_IMX_BIAS_PULL_DOWN_SHIFT       IOMUXC_SW_PAD_CTL_PAD_PD_SHIFT
+#define MCUX_IMX_BIAS_PULL_UP_SHIFT         IOMUXC_SW_PAD_CTL_PAD_PU_SHIFT
+#define MCUX_IMX_SLEW_RATE_SHIFT            IOMUXC_SW_PAD_CTL_PAD_FSEL1_SHIFT
+#define MCUX_IMX_DRIVE_STRENGTH_SHIFT       IOMUXC_SW_PAD_CTL_PAD_DSE_SHIFT
 
 #define IOMUXC_INPUT_ENABLE_SHIFT 23 /* Shift to a bit not used by IOMUXC_SW_PAD_CTL */
 #define IOMUXC_INPUT_ENABLE(x)    ((x >> IOMUXC_INPUT_ENABLE_SHIFT) & 0x1)
 
 #define Z_PINCTRL_IOMUXC_PINCFG_INIT(node_id)                                                      \
-	((DT_PROP(node_id, input_schmitt_enable) << IOMUXC_INPUT_SCHMITT_ENABLE_SHIFT) |           \
-	 (DT_PROP(node_id, drive_open_drain) << IOMUXC_DRIVE_OPEN_DRAIN_SHIFT) |                   \
-	 (DT_PROP(node_id, bias_pull_down) << IOMUXC_BIAS_PULL_DOWN_SHIFT) |                       \
-	 (DT_PROP(node_id, bias_pull_up) << IOMUXC_BIAS_PULL_UP_SHIFT) |                           \
-	 (DT_ENUM_IDX(node_id, slew_rate) << IOMUXC_SLEW_RATE_SHIFT) |                             \
-	 ((~(0xff << DT_ENUM_IDX(node_id, drive_strength))) << IOMUXC_DRIVE_STRENGTH_SHIFT) |      \
+	((DT_PROP(node_id, input_schmitt_enable) << MCUX_IMX_INPUT_SCHMITT_ENABLE_SHIFT) |         \
+	 (DT_PROP(node_id, drive_open_drain) << MCUX_IMX_DRIVE_OPEN_DRAIN_SHIFT) |                 \
+	 (DT_PROP(node_id, bias_pull_down) << MCUX_IMX_BIAS_PULL_DOWN_SHIFT) |                     \
+	 (DT_PROP(node_id, bias_pull_up) << MCUX_IMX_BIAS_PULL_UP_SHIFT) |                         \
+	 (DT_ENUM_IDX(node_id, slew_rate) << MCUX_IMX_SLEW_RATE_SHIFT) |                           \
+	 ((~(0xff << DT_ENUM_IDX(node_id, drive_strength))) << MCUX_IMX_DRIVE_STRENGTH_SHIFT) |    \
 	 (DT_PROP(node_id, input_enable) << IOMUXC_INPUT_ENABLE_SHIFT))
 
 /* This struct must be present. It is used by the mcux gpio driver */
@@ -63,7 +63,7 @@ struct pinctrl_soc_pin {
 typedef struct pinctrl_soc_pin pinctrl_soc_pin_t;
 
 /* This definition must be present. It is used by the mcux gpio driver */
-#define IOMUXC_PINMUX(node_id)                                                                     \
+#define MCUX_IMX_PINMUX(node_id)                                                                   \
 	{                                                                                          \
 		.mux_register = DT_PROP_BY_IDX(node_id, pinmux, 0),                                \
 		.config_register = DT_PROP_BY_IDX(node_id, pinmux, 4),                             \
@@ -73,7 +73,7 @@ typedef struct pinctrl_soc_pin pinctrl_soc_pin_t;
 	}
 
 #define Z_PINCTRL_PINMUX(group_id, pin_prop, idx)                                                  \
-	IOMUXC_PINMUX(DT_PHANDLE_BY_IDX(group_id, pin_prop, idx))
+	MCUX_IMX_PINMUX(DT_PHANDLE_BY_IDX(group_id, pin_prop, idx))
 
 #define Z_PINCTRL_STATE_PIN_INIT(group_id, pin_prop, idx)                                          \
 	{                                                                                          \


### PR DESCRIPTION
Adds GPIO definitions in Cortex M7 DTSI

Update pinctrl_soc.h definitions to match imx-rgpio driver