### PR TITLE
dts: bindings: stm32: Fix few inconsistencies

### DIFF
--- a/dts/bindings/interrupt-controller/st,stm32g0-exti.yaml
+++ b/dts/bindings/interrupt-controller/st,stm32g0-exti.yaml
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-        STM32 controller
+        STM32G0 External Interrupt controller
         This compatible stands for all interrupt-controller blocks with two
         dedicated Rising and Falling interrupt pending registers.
 

--- a/dts/bindings/interrupt-controller/st,stm32h7rs-exti.yaml
+++ b/dts/bindings/interrupt-controller/st,stm32h7rs-exti.yaml
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-        STM32 controller
+        STM32H7RS External Interrupt controller
         This compatible stands for the stm32H7RS interrupt-controller block
         with two dedicated Rising and Falling interrupt pending registers
 

--- a/dts/bindings/timer/st,stm32-lptim.yaml
+++ b/dts/bindings/timer/st,stm32-lptim.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-  STM32 lptim : low power timer
+  STM32 Low Power Timer (LPTIM)
   The lptim node to be used for counting ticks during lowpower modes
   must be named stm32_lp_tick_source in the DTS, as follows:
   stm32_lp_tick_source: &lptim1 {


### PR DESCRIPTION
Quick fix at easily spotted inconsistencies in STM32 bindings descriptions.