### PR TITLE
boards: stm32: stm32l562e_dk: Add JLink support to board.cmake

### DIFF
--- a/boards/st/stm32l562e_dk/board.cmake
+++ b/boards/st/stm32l562e_dk/board.cmake
@@ -15,8 +15,10 @@ endif()
 # keep first
 board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw")
 board_runner_args(pyocd "--target=stm32l562qeixq")
+board_runner_args(jlink "--device=STM32L562QE" "--speed=4000")
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)


### PR DESCRIPTION
Add JLink runner configuration for the STM32L562E-DK board