### PR TITLE
dts: nxp: mcxa156: Fix invalid FlexPWM1 address

### DIFF
--- a/dts/arm/nxp/nxp_mcxa156.dtsi
+++ b/dts/arm/nxp/nxp_mcxa156.dtsi
@@ -309,9 +309,9 @@
 			};
 		};
 
-		flexpwm1: flexpwm@d0000 {
+		flexpwm1: flexpwm@400aa000 {
 			compatible = "nxp,flexpwm";
-			reg = <0xd0000 0x1000>;
+			reg = <0x400aa000 0x1000>;
 			interrupt-names = "RELOAD-ERROR", "FAULT";
 			interrupts = <79 0>, <80 0>;
 			flexpwm1_pwm0: pwm0 {


### PR DESCRIPTION
It seems that this DTS entry has been copied from another DTS. 

The address of FlexPWM1 conflicts right now with the flash memory space.

[Edited the title and this comment following the discussion below]