### PR TITLE
kernel: arch: x86_64: Add directed IPI support

### DIFF
--- a/arch/x86/Kconfig
+++ b/arch/x86/Kconfig
@@ -83,6 +83,7 @@ config X86_64
 	select X86_MMX
 	select X86_SSE
 	select X86_SSE2
+	select ARCH_HAS_DIRECTED_IPIS
 
 menu "x86 Features"
 

--- a/arch/x86/core/intel64/smp.c
+++ b/arch/x86/core/intel64/smp.c
@@ -38,3 +38,16 @@ void arch_sched_broadcast_ipi(void)
 {
 	z_loapic_ipi(0, LOAPIC_ICR_IPI_OTHERS, CONFIG_SCHED_IPI_VECTOR);
 }
+
+void arch_sched_directed_ipi(uint32_t cpu_bitmap)
+{
+	unsigned int num_cpus = arch_num_cpus();
+
+	for (unsigned int i = 0; i < num_cpus; i++) {
+		if ((cpu_bitmap & BIT(i)) == 0) {
+			continue;
+		}
+
+		z_loapic_ipi(i, LOAPIC_ICR_IPI_SPECIFIC, CONFIG_SCHED_IPI_VECTOR);
+	}
+}

--- a/include/zephyr/drivers/interrupt_controller/loapic.h
+++ b/include/zephyr/drivers/interrupt_controller/loapic.h
@@ -43,6 +43,7 @@
 
 #define LOAPIC_ICR_BUSY		0x00001000	/* delivery status: 1 = busy */
 
+#define LOAPIC_ICR_IPI_SPECIFIC 0x00004000U     /* target IPI to specific CPU */
 #define LOAPIC_ICR_IPI_OTHERS	0x000C4000U	/* normal IPI to other CPUs */
 #define LOAPIC_ICR_IPI_INIT	0x00004500U
 #define LOAPIC_ICR_IPI_STARTUP	0x00004600U

--- a/tests/kernel/ipi_optimize/boards/qemu_x86_64.conf
+++ b/tests/kernel/ipi_optimize/boards/qemu_x86_64.conf
@@ -1,0 +1,4 @@
+# Copyright (c) 2022 Carlo Caione <ccaione@baylibre.com>
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_MP_MAX_NUM_CPUS=4

--- a/tests/kernel/ipi_optimize/boards/qemu_x86_64.overlay
+++ b/tests/kernel/ipi_optimize/boards/qemu_x86_64.overlay
@@ -1,0 +1,19 @@
+/* Copyright 2022 Carlo Caione <ccaione@baylibre.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	cpus {
+		cpu@2 {
+			device_type = "cpu";
+			compatible = "intel,x86_64";
+			reg = <2>;
+		};
+
+		cpu@3 {
+			device_type = "cpu";
+			compatible = "intel,x86_64";
+			reg = <3>;
+		};
+	};
+};


### PR DESCRIPTION
Adds directed IPI support to x86/intel64. IPIs that are broadcasted go to every other CPU in the system, while those that are directed only go to the specified CPU(s).  With directed IPIs, x86_64 SMP platforms can further reduce the number of IPIs sent (and consequently processed) in the system when CONFIG_IPI_OPTIMIZE is enabled.