### PR TITLE
doc: Update direct ISR documentation

### DIFF
--- a/doc/kernel/services/interrupts.rst
+++ b/doc/kernel/services/interrupts.rst
@@ -325,9 +325,10 @@ for some low-latency use-cases. Specifically:
   potentially make a scheduling decision.
 
 Zephyr supports so-called 'direct' interrupts, which are installed via
-:c:macro:`IRQ_DIRECT_CONNECT`. These direct interrupts have some special
-implementation requirements and a reduced feature set; see the definition
-of :c:macro:`IRQ_DIRECT_CONNECT` for details.
+:c:macro:`IRQ_DIRECT_CONNECT` and whose handlers are declared using
+:c:macro:`ISR_DIRECT_DECLARE`. These direct interrupts have some special
+implementation requirements and a reduced feature set; see the definitions
+of :c:macro:`IRQ_DIRECT_CONNECT` and :c:macro:`ISR_DIRECT_DECLARE` for details.
 
 The following code demonstrates a direct ISR:
 


### PR DESCRIPTION
Updates the direct ISR documentation to make it more clear that direct ISR handlers should be declared using ISR_DIRECT_DECLARE().

Fixes #85683