### PR TITLE
console: winstream: add missing Kconfig dependency

### DIFF
--- a/drivers/console/Kconfig
+++ b/drivers/console/Kconfig
@@ -284,6 +284,8 @@ config WINSTREAM_CONSOLE
 
 	  See the WINSTREAM Kconfig help for more information.
 
+if WINSTREAM_CONSOLE
+
 config WINSTREAM_CONSOLE_STATIC
 	bool "Use static/linkable memory for the winstream console"
 	default y if !SOC_FAMILY_INTEL_ADSP
@@ -299,5 +301,7 @@ config WINSTREAM_CONSOLE_STATIC_SIZE
 	default 32768
 	help
 	  Size of winstream console buffer, in bytes
+
+endif # WINSTREAM_CONSOLE
 
 endif # CONSOLE


### PR DESCRIPTION
Add a missed dependency to all sub-symbols of `WINSTREAM_CONSOLE`.
Missed in #82993.
