### PR TITLE
portability: cmsis: Max-num limits to not apply to statically created objects

### DIFF
--- a/subsys/portability/cmsis_rtos_v2/Kconfig
+++ b/subsys/portability/cmsis_rtos_v2/Kconfig
@@ -16,23 +16,20 @@ config CMSIS_RTOS_V2
 
 if CMSIS_RTOS_V2
 config CMSIS_V2_THREAD_MAX_COUNT
-	int "Maximum thread count in CMSIS RTOS V2 application"
+	int "Maximum thread count in CMSIS RTOS V2 application with dynamic control blocks"
 	default 15
 	range 0 $(UINT8_MAX)
 	help
-	  Mention max number of threads in CMSIS RTOS V2 compliant application.
-	  There's a limitation on the number of threads due to memory
-	  related constraints.
+	  Max number of threads in CMSIS RTOS V2 application that can be created with
+		dynamically allocated control block.
 
 config CMSIS_V2_THREAD_DYNAMIC_MAX_COUNT
-	int "Maximum dynamic thread count in CMSIS RTOS V2 application"
+	int "Maximum thread count in CMSIS RTOS V2 application with dynamic stack"
 	default 0
 	range 0 $(UINT8_MAX)
 	help
-	  Mention max number of dynamic threads in CMSIS RTOS V2 compliant
-	  application. There's a limitation on the number of threads due to memory
-	  related constraints. Dynamic threads are a subset of all other CMSIS
-	  threads i.e. they also count towards that maximum too.
+	  Max number of threads in CMSIS RTOS V2 application that can be created with
+		dynamically allocated stack.
 
 config CMSIS_V2_THREAD_MAX_STACK_SIZE
 	int "Max stack size threads can be allocated in CMSIS RTOS V2 application"

--- a/subsys/portability/cmsis_rtos_v2/Kconfig
+++ b/subsys/portability/cmsis_rtos_v2/Kconfig
@@ -46,32 +46,36 @@ config CMSIS_V2_THREAD_DYNAMIC_STACK_SIZE
 	  Mention dynamic stack size threads are allocated in CMSIS RTOS V2 application.
 
 config CMSIS_V2_TIMER_MAX_COUNT
-	int "Maximum timer count in CMSIS RTOS V2 application"
+	int "Maximum dynamically-allocated timers in CMSIS RTOS V2 application"
 	default 5
 	range 0 $(UINT8_MAX)
 	help
-	  Mention maximum number of timers in CMSIS RTOS V2 compliant application.
+	  Mention maximum number of timers in CMSIS RTOS V2 compliant application that can
+		be created with dynamically allocated control block.
 
 config CMSIS_V2_MUTEX_MAX_COUNT
-	int "Maximum mutex count in CMSIS RTOS V2 application"
+	int "Maximum dynamically-allocated mutexes in CMSIS RTOS V2 application"
 	default 5
 	range 0 $(UINT8_MAX)
 	help
-	  Mention max number of mutexes in CMSIS RTOS V2 compliant application.
+	  Mention max number of mutexes in CMSIS RTOS V2 compliant application that can
+		be created with dynamically allocated control block.
 
 config CMSIS_V2_SEMAPHORE_MAX_COUNT
-	int "Maximum semaphore count in CMSIS RTOS V2 application"
+	int "Maximum dynamically-allocated semaphores in CMSIS RTOS V2 application"
 	default 5
 	range 0 $(UINT8_MAX)
 	help
-	  Mention max number of semaphores in CMSIS RTOS V2 compliant application.
+	  Mention max number of semaphores in CMSIS RTOS V2 compliant application that can
+		be created with dynamically allocated control block.
 
 config CMSIS_V2_MEM_SLAB_MAX_COUNT
-	int "Maximum mem slab count in CMSIS RTOS V2 application"
+	int "Maximum dynamically-allocated mempools in CMSIS RTOS V2 application"
 	default 5
 	range 0 $(UINT8_MAX)
 	help
-	  Mention maximum number of memory slabs in CMSIS RTOS V2 compliant application.
+	  Mention maximum number of memory slabs in CMSIS RTOS V2 compliant application that can
+		be created with dynamically allocated control block.
 
 config CMSIS_V2_MEM_SLAB_MAX_DYNAMIC_SIZE
 	int "Maximum dynamic mem slab/pool size in CMSIS RTOS V2 application"
@@ -80,11 +84,12 @@ config CMSIS_V2_MEM_SLAB_MAX_DYNAMIC_SIZE
 	  Mention maximum dynamic size of memory slabs/pools in CMSIS RTOS V2 compliant application.
 
 config CMSIS_V2_MSGQ_MAX_COUNT
-	int "Maximum message queue count in CMSIS RTOS V2 application"
+	int "Maximum dynamically-allocated message queues in CMSIS RTOS V2 application"
 	default 5
 	range 0 $(UINT8_MAX)
 	help
-	  Mention maximum number of message queues in CMSIS RTOS V2 compliant application.
+	  Mention maximum number of message queues in CMSIS RTOS V2 compliant application that can
+		be created with dynamically allocated control block.
 
 config CMSIS_V2_MSGQ_MAX_DYNAMIC_SIZE
 	int "Maximum dynamic message queue size in CMSIS RTOS V2 application"
@@ -93,9 +98,10 @@ config CMSIS_V2_MSGQ_MAX_DYNAMIC_SIZE
 	  Mention maximum dynamic size of message queues in CMSIS RTOS V2 compliant application.
 
 config CMSIS_V2_EVT_FLAGS_MAX_COUNT
-	int "Maximum event flags count in CMSIS RTOS V2 application"
+	int "Maximum dynamically-allocated event flags count in CMSIS RTOS V2 application"
 	default 5
 	range 0 $(UINT8_MAX)
 	help
-	  Mention maximum number of event flags in CMSIS RTOS V2 compliant application.
+	  Mention maximum number of event flags in CMSIS RTOS V2 compliant application that can
+		be created with dynamically allocated control block.
 endif

--- a/subsys/portability/cmsis_rtos_v2/thread.c
+++ b/subsys/portability/cmsis_rtos_v2/thread.c
@@ -26,10 +26,11 @@ static const osThreadAttr_t init_thread_attrs = {
 };
 
 static sys_dlist_t thread_list;
-static atomic_t thread_num;
 
 static atomic_t num_dynamic_cb;
+#if CONFIG_CMSIS_V2_THREAD_MAX_COUNT != 0
 static struct cmsis_rtos_thread_cb cmsis_rtos_thread_cb_pool[CONFIG_CMSIS_V2_THREAD_MAX_COUNT];
+#endif
 
 static atomic_t num_dynamic_stack;
 #if CONFIG_CMSIS_V2_THREAD_DYNAMIC_MAX_COUNT != 0
@@ -106,14 +107,8 @@ osThreadId_t osThreadNew(osThreadFunc_t threadfunc, void *arg, const osThreadAtt
 	static uint32_t one_time;
 	void *stack;
 	size_t stack_size;
-	uint32_t this_thread_num;
-	uint32_t this_dynamic_cb;
 
 	if (k_is_in_isr()) {
-		return NULL;
-	}
-
-	if (thread_num >= CONFIG_CMSIS_V2_THREAD_MAX_COUNT) {
 		return NULL;
 	}
 
@@ -139,9 +134,6 @@ osThreadId_t osThreadNew(osThreadFunc_t threadfunc, void *arg, const osThreadAtt
 	BUILD_ASSERT(osPriorityISR <= CONFIG_NUM_PREEMPT_PRIORITIES,
 		     "Configure NUM_PREEMPT_PRIORITIES to at least osPriorityISR");
 
-	BUILD_ASSERT(CONFIG_CMSIS_V2_THREAD_DYNAMIC_MAX_COUNT <= CONFIG_CMSIS_V2_THREAD_MAX_COUNT,
-		     "Number of dynamic threads cannot exceed max number of threads.");
-
 	BUILD_ASSERT(CONFIG_CMSIS_V2_THREAD_DYNAMIC_STACK_SIZE <=
 			     CONFIG_CMSIS_V2_THREAD_MAX_STACK_SIZE,
 		     "Default dynamic thread stack size cannot exceed max stack size");
@@ -150,18 +142,18 @@ osThreadId_t osThreadNew(osThreadFunc_t threadfunc, void *arg, const osThreadAtt
 
 	__ASSERT((cv2_prio >= osPriorityIdle) && (cv2_prio <= osPriorityISR), "invalid priority\n");
 
-	if (attr->stack_mem != NULL) {
-		if (attr->stack_size == 0) {
-			return NULL;
-		}
+	if (attr->stack_mem != NULL && attr->stack_size == 0) {
+		return NULL;
 	}
 
-	this_thread_num = atomic_inc(&thread_num);
-
+#if CONFIG_CMSIS_V2_THREAD_MAX_COUNT != 0
 	if (attr->cb_mem == NULL) {
+		uint32_t this_dynamic_cb;
 		this_dynamic_cb = atomic_inc(&num_dynamic_cb);
 		tid = &cmsis_rtos_thread_cb_pool[this_dynamic_cb];
-	} else {
+	} else
+#endif
+	{
 		tid = (struct cmsis_rtos_thread_cb *)attr->cb_mem;
 	}
 

--- a/tests/subsys/portability/cmsis_rtos_v2/src/mutex.c
+++ b/tests/subsys/portability/cmsis_rtos_v2/src/mutex.c
@@ -186,4 +186,16 @@ ZTEST(cmsis_mutex, test_mutex_static_allocation)
 
 	zassert_true(osMutexDelete(id) == osOK, "osMutexDelete failed");
 }
+
+ZTEST(cmsis_mutex, test_mutex_static_multiple_new)
+{
+	osMutexId_t id;
+
+	for (int i = 0; i < 100; ++i) {
+		id = osMutexNew(&mutex_attrs2);
+		zassert_not_null(id, "Failed creating mutex using static cb");
+
+		zassert_true(osMutexDelete(id) == osOK, "osMutexDelete failed");
+	}
+}
 ZTEST_SUITE(cmsis_mutex, NULL, NULL, NULL, NULL, NULL);

--- a/tests/subsys/portability/cmsis_rtos_v2/src/thread_apis.c
+++ b/tests/subsys/portability/cmsis_rtos_v2/src/thread_apis.c
@@ -417,4 +417,34 @@ ZTEST(cmsis_thread_apis, test_thread_apis_join_after_exit)
 	status = osThreadJoin(id);
 	zassert_equal(status, osOK, "osThreadJoin failed with status=%d!", status);
 }
+
+static K_THREAD_STACK_DEFINE(test_stack9, STACKSZ);
+static struct cmsis_rtos_thread_cb test_cb9;
+static const osThreadAttr_t os_thread9_attr = {
+	.name = "Thread9",
+	.attr_bits = osThreadJoinable,
+	.cb_mem = &test_cb9,
+	.cb_size = sizeof(test_cb9),
+	.stack_mem = &test_stack9,
+	.stack_size = STACKSZ,
+	.priority = osPriorityNormal,
+};
+static void thread9(void *argument)
+{
+	osThreadExit();
+}
+ZTEST(cmsis_thread_apis, test_thread_apis_multiple_new_static)
+{
+	osThreadId_t id;
+	osStatus_t status;
+
+	for (int i = 0; i < 100; i++) {
+		id = osThreadNew(thread9, NULL, &os_thread9_attr);
+		zassert_not_null(id,
+				 "Failed to create thread with osThreadNew using static cb/stack");
+
+		status = osThreadJoin(id);
+		zassert_equal(status, osOK, "osThreadJoin failed with status=%d!", status);
+	}
+}
 ZTEST_SUITE(cmsis_thread_apis, NULL, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
## Description

No limit on the maximum number of RTOS objects is prescribed by CMSIS-RTOSv2 API. As such, remove this artificial limitation from Zephyr port of CMSIS-RTOSv2 API too.

* Allow any number of threads to be created as long as their stacks and control blocks are statically allocated. Earlier, KConfig `CONFIG_CMSIS_V2_THREAD_MAX_COUNT` limited this.
* Repurpose KConfig `CONFIG_CMSIS_V2_THREAD_MAX_COUNT` to specify the limit on the number of threads with dynamically-allocated control blocks and `CONFIG_CMSIS_V2_THREAD_DYNAMIC_MAX_COUNT` to specify the limit on the number of dynamically-allocated stacks.
* Clarify in the documentation all maximum limits for all other RTOS objects also applies only when control block is dynamically allocated.

## Test Plan

* Added new tests which would have failed previously.
* All tests pass locally when running with `west build tests/subsys/portability/cmsis_rtos_v2 --board=nrf52dk/nrf52832 --pristine && west flash`


