### PR TITLE
drivers: adc: Remove channel_count property for Renesas RA driver

### DIFF
--- a/dts/arm/renesas/ra/ra4/r7fa4e10x.dtsi
+++ b/dts/arm/renesas/ra/ra4/r7fa4e10x.dtsi
@@ -48,7 +48,6 @@
 		};
 
 		adc@40170000 {
-			channel-count = <9>;
 			channel-available-mask = <0x1381f>;
 		};
 

--- a/dts/arm/renesas/ra/ra4/r7fa4e2b93cfm.dtsi
+++ b/dts/arm/renesas/ra/ra4/r7fa4e2b93cfm.dtsi
@@ -58,7 +58,6 @@
 		};
 
 		adc@40170000 {
-			channel-count = <12>;
 			channel-available-mask = <0x139f7>;
 		};
 

--- a/dts/arm/renesas/ra/ra4/r7fa4l1bx.dtsi
+++ b/dts/arm/renesas/ra/ra4/r7fa4l1bx.dtsi
@@ -240,7 +240,6 @@
 			reg = <0x40170000 0x100>;
 			#io-channel-cells = <1>;
 			vref-mv = <3300>;
-			channel-count = <16>;
 			channel-available-mask = <0x3fe007f>;
 			status = "disabled";
 		};

--- a/dts/arm/renesas/ra/ra4/r7fa4m1ab3cfp.dtsi
+++ b/dts/arm/renesas/ra/ra4/r7fa4m1ab3cfp.dtsi
@@ -70,7 +70,6 @@
 
 		adc@4005c000 {
 			interrupts = <20 1>;
-			channel-count = <25>;
 			channel-available-mask = <0x3ff7fff>;
 		};
 

--- a/dts/arm/renesas/ra/ra4/r7fa4m2ax.dtsi
+++ b/dts/arm/renesas/ra/ra4/r7fa4m2ax.dtsi
@@ -96,7 +96,6 @@
 		};
 
 		adc@40170000 {
-			channel-count = <13>;
 			channel-available-mask = <0x139ff>;
 		};
 

--- a/dts/arm/renesas/ra/ra4/r7fa4m3ax.dtsi
+++ b/dts/arm/renesas/ra/ra4/r7fa4m3ax.dtsi
@@ -104,12 +104,10 @@
 		};
 
 		adc@40170000 {
-			channel-count = <12>;
 			channel-available-mask = <0x33ff>;
 		};
 
 		adc@40170200 {
-			channel-count = <10>;
 			channel-available-mask = <0x7f0007>;
 		};
 

--- a/dts/arm/renesas/ra/ra4/r7fa4w1ad2cng.dtsi
+++ b/dts/arm/renesas/ra/ra4/r7fa4w1ad2cng.dtsi
@@ -43,7 +43,6 @@
 
 		adc@4005c000 {
 			interrupts = <20 1>;
-			channel-count = <8>;
 			channel-available-mask = <0x1a0670>;
 		};
 

--- a/dts/arm/renesas/ra/ra6/r7fa6e10x.dtsi
+++ b/dts/arm/renesas/ra/ra6/r7fa6e10x.dtsi
@@ -95,7 +95,6 @@
 		};
 
 		adc@40170000 {
-			channel-count = <11>;
 			channel-available-mask = <0x31ff>;
 		};
 

--- a/dts/arm/renesas/ra/ra6/r7fa6e2bx.dtsi
+++ b/dts/arm/renesas/ra/ra6/r7fa6e2bx.dtsi
@@ -36,7 +36,6 @@
 		};
 
 		adc@40170000 {
-			channel-count = <12>;
 			channel-available-mask = <0x139f7>;
 		};
 

--- a/dts/arm/renesas/ra/ra6/r7fa6m1ad3cfp.dtsi
+++ b/dts/arm/renesas/ra/ra6/r7fa6m1ad3cfp.dtsi
@@ -39,12 +39,10 @@
 		};
 
 		adc@4005c000 {
-			channel-count = <11>;
 			channel-available-mask = <0x1700ef>;
 		};
 
 		adc@4005c200 {
-			channel-count = <8>;
 			channel-available-mask = <0x300e7>;
 		};
 	};

--- a/dts/arm/renesas/ra/ra6/r7fa6m2ax.dtsi
+++ b/dts/arm/renesas/ra/ra6/r7fa6m2ax.dtsi
@@ -61,12 +61,10 @@
 		};
 
 		adc@4005c000 {
-			channel-count = <13>;
 			channel-available-mask = <0x1f00ff>;
 		};
 
 		adc@4005c200 {
-			channel-count = <9>;
 			channel-available-mask = <0x700e7>;
 		};
 

--- a/dts/arm/renesas/ra/ra6/r7fa6m3ax.dtsi
+++ b/dts/arm/renesas/ra/ra6/r7fa6m3ax.dtsi
@@ -120,12 +120,10 @@
 		};
 
 		adc@4005c000 {
-			channel-count = <13>;
 			channel-available-mask = <0x1f00ff>;
 		};
 
 		adc@4005c200 {
-			channel-count = <11>;
 			channel-available-mask = <0xf00ef>;
 		};
 

--- a/dts/arm/renesas/ra/ra6/r7fa6m4ax.dtsi
+++ b/dts/arm/renesas/ra/ra6/r7fa6m4ax.dtsi
@@ -128,12 +128,10 @@
 		};
 
 		adc@40170000 {
-			channel-count = <12>;
 			channel-available-mask = <0x33ff>;
 		};
 
 		adc@40170200 {
-			channel-count = <10>;
 			channel-available-mask = <0x7f0007>;
 		};
 

--- a/dts/arm/renesas/ra/ra6/r7fa6m5xh.dtsi
+++ b/dts/arm/renesas/ra/ra6/r7fa6m5xh.dtsi
@@ -210,12 +210,10 @@
 		};
 
 		adc@40170000 {
-			channel-count = <13>;
 			channel-available-mask = <0x37ff>;
 		};
 
 		adc@40170200 {
-			channel-count = <16>;
 			channel-available-mask = <0x1fff0007>;
 		};
 

--- a/dts/arm/renesas/ra/ra8/ra8x1.dtsi
+++ b/dts/arm/renesas/ra/ra8/ra8x1.dtsi
@@ -290,7 +290,6 @@
 			reg = <0x40332000 0x100>;
 			#io-channel-cells = <1>;
 			vref-mv = <3300>;
-			channel-count = <12>;
 			channel-available-mask = <0xf01f7>;
 			status = "disabled";
 		};
@@ -302,7 +301,6 @@
 			reg = <0x40332200 0x100>;
 			#io-channel-cells = <1>;
 			vref-mv = <3300>;
-			channel-count = <13>;
 			channel-available-mask = <0x7f0077>;
 			status = "disabled";
 		};

--- a/dts/bindings/adc/renesas,ra-adc.yaml
+++ b/dts/bindings/adc/renesas,ra-adc.yaml
@@ -16,11 +16,6 @@ properties:
     required: true
     description: ADC reference voltage (Unit:mV)
 
-  channel-count:
-    type: int
-    required: true
-    description: The number of ADC channels
-
   "#io-channel-cells":
     const: 1
 


### PR DESCRIPTION
Currently, in Renesas ADC driver, channel_count is used as the maximum index of the channels can be supported.
However, the value input in dts of "channel_count" represents the total number of supported channels.

After consideration, we have decided to remove this reduntant property.