### PR TITLE
boards: renesas: Modify the default pinsel for adc0 on ek_ra4l1

### DIFF
--- a/boards/renesas/ek_ra4l1/ek_ra4l1-pinctrl.dtsi
+++ b/boards/renesas/ek_ra4l1/ek_ra4l1-pinctrl.dtsi
@@ -25,7 +25,7 @@
 	adc0_default: adc0_default {
 		group1 {
 			/* input */
-			psels = <RA_PSEL(RA_PSEL_ADC, 0, 2)>;
+			psels = <RA_PSEL(RA_PSEL_ADC, 0, 3)>;
 			renesas,analog-enable;
 		};
 	};

--- a/tests/drivers/adc/adc_accuracy_test/boards/ek_ra4l1.overlay
+++ b/tests/drivers/adc/adc_accuracy_test/boards/ek_ra4l1.overlay
@@ -6,7 +6,7 @@
 
 / {
 	zephyr,user {
-		io-channels = <&adc0 0>;
+		io-channels = <&adc0 1>;
 		reference-mv = <3300>;
 		expected-accuracy = <32>;
 	};
@@ -17,8 +17,8 @@
 	#size-cells = <0>;
 	status = "okay";
 
-	channel@0 {
-		reg = <0>;
+	channel@1 {
+		reg = <1>;
 		zephyr,gain = "ADC_GAIN_1";
 		zephyr,reference = "ADC_REF_INTERNAL";
 		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;

--- a/tests/drivers/adc/adc_api/boards/ek_ra4l1.overlay
+++ b/tests/drivers/adc/adc_api/boards/ek_ra4l1.overlay
@@ -7,7 +7,7 @@
 
 / {
 	zephyr,user {
-		io-channels = <&adc0 0>, <&adc0 2>;
+		io-channels = <&adc0 1>, <&adc0 2>;
 	};
 };
 
@@ -16,8 +16,8 @@
 	#address-cells = <1>;
 	#size-cells = <0>;
 
-	channel@0 {
-		reg = <0>;
+	channel@1 {
+		reg = <1>;
 		zephyr,gain = "ADC_GAIN_1";
 		zephyr,reference = "ADC_REF_INTERNAL";
 		zephyr,resolution = <12>;


### PR DESCRIPTION
Currently, we set P002 (AN000) as the default pin selection for ADC0 on ek_ra4l1. However, after testing the ADC function with this pin selection, the ADC function does not work on this pin.

The main reason is P002 is used for the I2C I/O Port Expander and is connected to a 10kΩ pull-up resistor.

For the solution, we will select the P003 (AN001) as default pinsel for adc0.

- [x] This PR need #86601 to be merged first 