### PR TITLE
net: dns: Join mDNS multicast group for resolving

### DIFF
--- a/subsys/net/lib/dns/resolve.c
+++ b/subsys/net/lib/dns/resolve.c
@@ -25,6 +25,8 @@ LOG_MODULE_REGISTER(net_dns_resolve, CONFIG_DNS_RESOLVER_LOG_LEVEL);
 #include <zephyr/net/net_ip.h>
 #include <zephyr/net/net_pkt.h>
 #include <zephyr/net/net_mgmt.h>
+#include <zephyr/net/igmp.h>
+#include <zephyr/net/mld.h>
 #include <zephyr/net/dns_resolve.h>
 #include <zephyr/net/socket_service.h>
 #include "../../ip/net_private.h"
@@ -148,6 +150,34 @@ static bool server_is_llmnr(sa_family_t family, struct sockaddr *addr)
 	return false;
 }
 
+static void join_ipv4_mcast_group(struct net_if *iface, void *user_data)
+{
+	struct sockaddr *addr = user_data;
+	int ret;
+
+	ret = net_ipv4_igmp_join(iface, &net_sin(addr)->sin_addr, NULL);
+	if (ret < 0 && ret != -EALREADY) {
+		NET_DBG("Cannot join %s mDNS group (%d)", "IPv4", ret);
+	} else {
+		NET_DBG("Joined %s mDNS group %s", "IPv4",
+			net_sprint_ipv4_addr(&net_sin(addr)->sin_addr));
+	}
+}
+
+static void join_ipv6_mcast_group(struct net_if *iface, void *user_data)
+{
+	struct sockaddr *addr = user_data;
+	int ret;
+
+	ret = net_ipv6_mld_join(iface, &net_sin6(addr)->sin6_addr);
+	if (ret < 0 && ret != -EALREADY) {
+		NET_DBG("Cannot join %s mDNS group (%d)", "IPv6", ret);
+	} else {
+		NET_DBG("Joined %s mDNS group %s", "IPv6",
+			net_sprint_ipv6_addr(&net_sin6(addr)->sin6_addr));
+	}
+}
+
 static void dns_postprocess_server(struct dns_resolve_context *ctx, int idx)
 {
 	struct sockaddr *addr = &ctx->servers[idx].dns_server;
@@ -180,6 +210,26 @@ static void dns_postprocess_server(struct dns_resolve_context *ctx, int idx)
 				net_sin(addr)->sin_port = htons(53);
 			}
 		}
+
+		/* Join the mDNS multicast group if responder is not enabled,
+		 * because it will join the group itself.
+		 */
+		if (!IS_ENABLED(CONFIG_MDNS_RESPONDER) && ctx->servers[idx].is_mdns) {
+			struct in_addr mcast_addr = { { { 224, 0, 0, 251 } } };
+
+			if (net_sin(addr)->sin_addr.s_addr == mcast_addr.s_addr) {
+				struct net_if *iface;
+
+				iface = net_if_get_by_index(ctx->servers[idx].if_index);
+				if (iface == NULL) {
+					/* Join all interfaces */
+					net_if_foreach(join_ipv4_mcast_group, addr);
+				} else {
+					/* Join specific interface */
+					join_ipv4_mcast_group(iface, addr);
+				}
+			}
+		}
 	} else {
 		ctx->servers[idx].is_mdns = server_is_mdns(AF_INET6, addr);
 		if (!ctx->servers[idx].is_mdns) {
@@ -196,6 +246,25 @@ static void dns_postprocess_server(struct dns_resolve_context *ctx, int idx)
 				net_sin6(addr)->sin6_port = htons(5355);
 			} else {
 				net_sin6(addr)->sin6_port = htons(53);
+			}
+		}
+
+		if (!IS_ENABLED(CONFIG_MDNS_RESPONDER) && ctx->servers[idx].is_mdns) {
+			struct in6_addr mcast_addr = { { { 0xff, 0x02, 0, 0, 0, 0, 0, 0,
+						0, 0, 0, 0, 0, 0, 0, 0xfb } } };
+
+			if (memcmp(&net_sin6(addr)->sin6_addr, &mcast_addr,
+				   sizeof(struct in6_addr)) == 0) {
+				struct net_if *iface;
+
+				iface = net_if_get_by_index(ctx->servers[idx].if_index);
+				if (iface == NULL) {
+					/* Join all interfaces */
+					net_if_foreach(join_ipv6_mcast_group, addr);
+				} else {
+					/* Join specific interface */
+					join_ipv6_mcast_group(iface, addr);
+				}
 			}
 		}
 	}

--- a/tests/net/lib/dns_resolve/src/main.c
+++ b/tests/net/lib/dns_resolve/src/main.c
@@ -762,4 +762,55 @@ ZTEST(dns_resolve, test_dns_query_ipv6_numeric)
 	}
 }
 
+#define MDNS_IPV4_ADDR "224.0.0.251:5353"
+#define MDNS_IPV6_ADDR "[ff02::fb]:5353"
+
+ZTEST(dns_resolve, test_mdns_ipv4_igmp_group)
+{
+	struct net_if_mcast_addr *maddr;
+	struct sockaddr_in addr4;
+	bool st;
+
+	/* Skip this test if mDNS responder is enabled because it will join
+	 * multicast group automatically.
+	 */
+	Z_TEST_SKIP_IFDEF(CONFIG_MDNS_RESPONDER);
+	Z_TEST_SKIP_IFNDEF(CONFIG_NET_IPV4);
+	Z_TEST_SKIP_IFNDEF(CONFIG_NET_IPV4_IGMP);
+
+	st = net_ipaddr_parse(MDNS_IPV4_ADDR, sizeof(MDNS_IPV4_ADDR) - 1,
+			      (struct sockaddr *)&addr4);
+	zassert_true(st, "Cannot parse IPv4 address");
+
+	maddr = net_if_ipv4_maddr_lookup(&addr4.sin_addr, NULL);
+	zassert_not_null(maddr, "IPv4 mDNS address not found");
+
+	st = net_if_ipv4_maddr_is_joined(maddr);
+	zassert_true(st, "IPv4 mDNS group not joined");
+}
+
+ZTEST(dns_resolve, test_mdns_ipv6_mld_group)
+{
+	struct net_if_mcast_addr *maddr;
+	struct sockaddr_in6 addr6;
+	bool st;
+
+	/* Skip this test if mDNS responder is enabled because it will join
+	 * multicast group automatically.
+	 */
+	Z_TEST_SKIP_IFDEF(CONFIG_MDNS_RESPONDER);
+	Z_TEST_SKIP_IFNDEF(CONFIG_NET_IPV6);
+	Z_TEST_SKIP_IFNDEF(CONFIG_NET_IPV6_MLD);
+
+	st = net_ipaddr_parse(MDNS_IPV6_ADDR, sizeof(MDNS_IPV6_ADDR) - 1,
+			      (struct sockaddr *)&addr6);
+	zassert_true(st, "Cannot parse IPv6 address");
+
+	maddr = net_if_ipv6_maddr_lookup(&addr6.sin6_addr, NULL);
+	zassert_not_null(maddr, "IPv6 mDNS address not found");
+
+	st = net_if_ipv6_maddr_is_joined(maddr);
+	zassert_true(st, "IPv6 mDNS group not joined");
+}
+
 ZTEST_SUITE(dns_resolve, NULL, test_init, NULL, NULL, NULL);

--- a/tests/net/lib/dns_resolve/testcase.yaml
+++ b/tests/net/lib/dns_resolve/testcase.yaml
@@ -18,3 +18,9 @@ tests:
   net.dns.resolve.no_ipv6:
     extra_args: CONF_FILE=prj-no-ipv6.conf
     min_ram: 16
+  net.mdns.resolve:
+    extra_configs:
+      - CONFIG_MDNS_RESOLVER=y
+      - CONFIG_MDNS_RESPONDER=n
+      - CONFIG_NET_IPV6_MLD=y
+      - CONFIG_NET_IPV4_IGMP=y


### PR DESCRIPTION
If mDNS resolver is enabled but mDNS responder is not, then mDNS multicast address group is not joined. This would prevent the mDNS resolver to receive the responses. Fix this by joining the mDNS multicast group if mDNS responder is not enabled (because the responder will join the group itself).

Fixes #86477
