### PR TITLE
drivers: i2c: Add an i2c_configure_dt function

### DIFF
--- a/doc/releases/release-notes-4.2.rst
+++ b/doc/releases/release-notes-4.2.rst
@@ -57,6 +57,10 @@ Deprecated APIs and options
 New APIs and options
 ====================
 
+* I2C
+
+  * :c:func:`i2c_configure_dt`.
+
 ..
   Link to new APIs here, in a group if you think it's necessary, no need to get
   fancy just list the link, that should contain the documentation. If you feel

--- a/include/zephyr/drivers/i2c.h
+++ b/include/zephyr/drivers/i2c.h
@@ -723,6 +723,25 @@ static inline int z_impl_i2c_configure(const struct device *dev,
 }
 
 /**
+ * @brief Configure operation of a host controller.
+ *
+ * This is equivalent to:
+ *
+ *     i2c_configure(spec->bus, dev_config);
+ *
+ * @param spec I2C specification from devicetree.
+ * @param dev_config Bit-packed 32-bit value to the device runtime configuration
+ * for the I2C controller.
+ *
+ * @return a value from i2c_configure()
+ */
+static inline int i2c_configure_dt(const struct i2c_dt_spec *spec,
+						uint32_t dev_config)
+{
+	return i2c_configure(spec->bus, dev_config);
+}
+
+/**
  * @brief Get configuration of a host controller.
  *
  * This routine provides a way to get current configuration. It is allowed to


### PR DESCRIPTION
I prefer using a format like `gpio_pin_configure_dt(&spec, ...)` rather than `i2c_configure(spec.bus, ...)`. I believe I'm not the only one who has thought about this.