### PR TITLE
dts: espressif: Streamline devicetree binding descriptions

### DIFF
--- a/dts/bindings/adc/espressif,esp32-adc.yaml
+++ b/dts/bindings/adc/espressif,esp32-adc.yaml
@@ -3,7 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-  Espressif ESP32 ADC
+  ESP32 ADC.
+
   Possible available resolutions depends on the used chip.
     - ESP32     < 9,10,11,12 >
     - ESP32-S2  < 12 >

--- a/dts/bindings/can/espressif,esp32-twai.yaml
+++ b/dts/bindings/can/espressif,esp32-twai.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2022 Henrik Brix Andersen <henrik@brixandersen.dk>
 # SPDX-License-Identifier: Apache-2.0
 
-description: Espressif ESP32 Two-Wire Automotive Interface (TWAI)
+description: ESP32 Two-Wire Automotive Interface (TWAI)
 
 compatible: "espressif,esp32-twai"
 

--- a/dts/bindings/counter/espressif,esp32-rtc-timer.yaml
+++ b/dts/bindings/counter/espressif,esp32-rtc-timer.yaml
@@ -3,7 +3,7 @@
 
 description: |
 
-        Espressif's Counter Driver based on RTC Main Timer.
+        ESP32 Counter Driver based on RTC Main Timer.
 
         Any reset/sleep mode, except for the power-up reset, will not
         stop or reset the RTC Timer. This behavior may be handy when

--- a/dts/bindings/counter/espressif,esp32-timer.yaml
+++ b/dts/bindings/counter/espressif,esp32-timer.yaml
@@ -2,7 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-        Espressif's general-purpose Timers.
+        ESP32 general-purpose timers.
+
         Each Timer is part of a Timer Group and the number of available Timers
         is SoC-dependent.
 

--- a/dts/bindings/cpu/espressif,xtensa-lx6.yaml
+++ b/dts/bindings/cpu/espressif,xtensa-lx6.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Espressif Systems (Shanghai) Co., Ltd.
 # SPDX-License-Identifier: Apache-2.0
 
-description: Espressif Xtensa CPU
+description: Espressif Xtensa LX6 CPU
 
 compatible: "espressif,xtensa-lx6"
 

--- a/dts/bindings/cpu/espressif,xtensa-lx7.yaml
+++ b/dts/bindings/cpu/espressif,xtensa-lx7.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Espressif Systems (Shanghai) Co., Ltd.
 # SPDX-License-Identifier: Apache-2.0
 
-description: Espressif Xtensa CPU
+description: Espressif Xtensa LX7 CPU
 
 compatible: "espressif,xtensa-lx7"
 

--- a/dts/bindings/dac/espressif,esp32-dac.yaml
+++ b/dts/bindings/dac/espressif,esp32-dac.yaml
@@ -2,8 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-    Espressif Digital to Analog converter (DAC) control node
-    is part of the RTC low-power domain and belongs to the SENSE
+    ESP32 Digital to Analog converter (DAC)
+
+    Part of the RTC low-power domain and belongs to the SENSE
     peripherals set. RTC peripherals has GPIOs controlled by the
     RTCIO mux, which is separated from the main IO mux.
 

--- a/dts/bindings/dma/espressif,esp32-gdma.yaml
+++ b/dts/bindings/dma/espressif,esp32-gdma.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-  Espressif's GDMA (General Direct Memory Access) Node
+  ESP32 GDMA (General Direct Memory Access)
 
   General Direct Memory Access (GDMA) is a feature that allows
   peripheral-to-memory, memory-to-peripheral, and memory-to-memory

--- a/dts/bindings/flash_controller/espressif,esp32-flash-controller.yaml
+++ b/dts/bindings/flash_controller/espressif,esp32-flash-controller.yaml
@@ -1,4 +1,4 @@
-description: ESP32 Family flash controller
+description: ESP32 flash controller
 
 compatible: "espressif,esp32-flash-controller"
 

--- a/dts/bindings/input/espressif,esp32-touch-sensor.yaml
+++ b/dts/bindings/input/espressif,esp32-touch-sensor.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-  Zephyr input touch sensor parent node
+  ESP32 touch sensor input
 
   This defines a group of touch sensors that can generate input events. Each touch
   sensor is defined in a child node of the touch-sensor node and defines a specific key

--- a/dts/bindings/mdio/espressif,esp32-mdio.yaml
+++ b/dts/bindings/mdio/espressif,esp32-mdio.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2022 Grant Ramsay <grant.ramsay@hotmail.com>
 # SPDX-License-Identifier: Apache-2.0
 
-description: ESP32 MDIO Driver node
+description: ESP32 MDIO controller
 
 compatible: "espressif,esp32-mdio"
 

--- a/dts/bindings/memory-controllers/espressif,esp32-psram.yaml
+++ b/dts/bindings/memory-controllers/espressif,esp32-psram.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2025 Espressif Systems (Shanghai) Co., Ltd.
 # SPDX-License-Identifier: Apache-2.0
 
-description: ESP32 Family pseudo-static RAM controller
+description: ESP32 pseudo-static RAM controller
 
 compatible: "espressif,esp32-psram"
 

--- a/dts/bindings/pinctrl/espressif,esp32-pinctrl.yaml
+++ b/dts/bindings/pinctrl/espressif,esp32-pinctrl.yaml
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
+    ESP32 pin controller
+
     Espressif's pin controller is in charge of controlling pin configurations, pin
     functionalities and pin properties as defined by pin states. In its turn, pin
     states are composed by groups of pre-defined pin muxing definitions and user

--- a/dts/bindings/pwm/espressif,esp32-ledc.yaml
+++ b/dts/bindings/pwm/espressif,esp32-ledc.yaml
@@ -3,7 +3,7 @@
 
 description: |
 
-  Espressif's LEDC controller Node
+  ESP32 LED Control (LEDC)
 
   The LEDC controller is primarily designed to control the intensity of LEDs, although it can be
   used to generate PWM signals for other purposes as well.

--- a/dts/bindings/pwm/espressif,esp32-mcpwm.yaml
+++ b/dts/bindings/pwm/espressif,esp32-mcpwm.yaml
@@ -3,7 +3,7 @@
 
 description: |
 
-  Espressif's Motor Control Pulse Width Modulator (MCPWM) controller Node
+  ESP32 Motor Control Pulse Width Modulator (MCPWM)
 
   The MCPWM peripheral is intended for motor and power control.
   It provides six PWM outputs that can be set up to operate in several topologies

--- a/dts/bindings/rng/espressif,esp32-trng.yaml
+++ b/dts/bindings/rng/espressif,esp32-trng.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-    Espressif ESP32 TRNG (True Random Number Generator).
+    ESP32 TRNG (True Random Number Generator).
 
     The TRNG uses the noise in the Wi-Fi/BT RF system. When Wi-Fi and BT are
     disabled, the random number generator will give out pseudo-random numbers.

--- a/dts/bindings/sdhc/espressif,esp32-sdhc-slot.yaml
+++ b/dts/bindings/sdhc/espressif,esp32-sdhc-slot.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Espressif Systems (Shanghai) Co., Ltd.
 # SPDX-License-Identifier: Apache-2.0
 
-description: Espressif ESP32 SDHC controller slot
+description: ESP32 SDHC controller slot
 
 compatible: "espressif,esp32-sdhc-slot"
 

--- a/dts/bindings/sdhc/espressif,esp32-sdhc.yaml
+++ b/dts/bindings/sdhc/espressif,esp32-sdhc.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Espressif Systems (Shanghai) Co., Ltd.
 # SPDX-License-Identifier: Apache-2.0
 
-description: Espressif ESP32 SDHC controller
+description: ESP32 SDHC controller
 
 compatible: "espressif,esp32-sdhc"
 

--- a/dts/bindings/sensor/espressif,esp32-pcnt.yaml
+++ b/dts/bindings/sensor/espressif,esp32-pcnt.yaml
@@ -3,7 +3,7 @@
 
 description: |
 
-  Espressif's Pulse Counter Mode (PCNT) controller Node
+  ESP32 Pulse Counter (PCNT)
 
   The pulse counter module is designed to count the number of
   rising and/or falling edges of an input signal.

--- a/dts/bindings/sensor/espressif,esp32-temp.yaml
+++ b/dts/bindings/sensor/espressif,esp32-temp.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2022 Espressif Systems (Shanghai) Co., Ltd.
 # SPDX-License-Identifier: Apache-2.0
 
-description: ESP32 family temperature sensor node
+description: ESP32 temperature sensor
 
 compatible: "espressif,esp32-temp"
 

--- a/dts/bindings/timer/espressif,esp32-systimer.yaml
+++ b/dts/bindings/timer/espressif,esp32-systimer.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2021 Espressif Systems (Shanghai) Co., Ltd.
 # SPDX-License-Identifier: Apache-2.0
 
-description: Espressif ESP32 Systimer peripheral
+description: ESP32 System Timer
 
 compatible: "espressif,esp32-systimer"
 

--- a/dts/bindings/video/espressif,esp32-cam.yaml
+++ b/dts/bindings/video/espressif,esp32-cam.yaml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-description: esp32 LCD CAM Peripheral interface
+description: ESP32 LCD CAM Peripheral interface
 
 compatible: "espressif,esp32-lcd-cam"
 

--- a/dts/bindings/watchdog/espressif,esp32-watchdog.yaml
+++ b/dts/bindings/watchdog/espressif,esp32-watchdog.yaml
@@ -2,7 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-    ESP32 watchdog. ESP32 contains 3x Watchdog timers, 2x Main System Watchdog
+    ESP32 watchdog.
+
+    ESP32 contains 3x Watchdog timers, 2x Main System Watchdog
     Timer (MWDT), 1x RTC Watchdog Timer (RWDT). RWDT is not supported yet.
 
 compatible: "espressif,esp32-watchdog"

--- a/dts/bindings/watchdog/espressif,esp32-xt-wdt.yaml
+++ b/dts/bindings/watchdog/espressif,esp32-xt-wdt.yaml
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
+    ESP32 XT Watchdog Timer.
+
     This watchdog timer can detect oscillation failure of the RTC_SLOW_CLK_SRC_XTAL32K.
     When such a failure is detected the hardware automatically switch to
     ESP32_RTC_SLOW_CLK_SRC_RC_SLOW.

--- a/dts/bindings/wifi/espressif,esp-at.yaml
+++ b/dts/bindings/wifi/espressif,esp-at.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2019 Tobias Svehagen
 # SPDX-License-Identifier: Apache-2.0
 
-description: Espressif ESP8266/ESP32 WiFi modem (AT Commands)
+description: ESP8266/ESP32 WiFi modem (AT Commands)
 
 compatible: "espressif,esp-at"
 

--- a/dts/bindings/wifi/espressif,esp32-wifi.yaml
+++ b/dts/bindings/wifi/espressif,esp32-wifi.yaml
@@ -1,6 +1,6 @@
 # Copyright (c) 2022 Espressif Systems (Shanghai) Co., Ltd.
 # SPDX-License-Identifier: Apache-2.0
 
-description: Espressif ESP32 SoC WiFi
+description: ESP32 SoC Wi-Fi
 
 compatible: "espressif,esp32-wifi"


### PR DESCRIPTION
Ensure consistent (and concise) short descriptions of all the `esp*.yaml` bindings