### PR TITLE
include: common: sys_bitops: Specify sign when bitshifting

### DIFF
--- a/include/zephyr/arch/common/sys_bitops.h
+++ b/include/zephyr/arch/common/sys_bitops.h
@@ -25,21 +25,21 @@ static ALWAYS_INLINE void sys_set_bit(mem_addr_t addr, unsigned int bit)
 {
 	uint32_t temp = *(volatile uint32_t *)addr;
 
-	*(volatile uint32_t *)addr = temp | (1 << bit);
+	*(volatile uint32_t *)addr = temp | (1U << bit);
 }
 
 static ALWAYS_INLINE void sys_clear_bit(mem_addr_t addr, unsigned int bit)
 {
 	uint32_t temp = *(volatile uint32_t *)addr;
 
-	*(volatile uint32_t *)addr = temp & ~(1 << bit);
+	*(volatile uint32_t *)addr = temp & ~(1U << bit);
 }
 
 static ALWAYS_INLINE int sys_test_bit(mem_addr_t addr, unsigned int bit)
 {
 	uint32_t temp = *(volatile uint32_t *)addr;
 
-	return temp & (1 << bit);
+	return temp & (1U << bit);
 }
 
 static ALWAYS_INLINE void sys_set_bits(mem_addr_t addr, unsigned int mask)


### PR DESCRIPTION
When left-shifting '1' by 31, the result is undefined. This is something ASAN detects.

Solve this by explicitly defining that the integer is unsigned.