### PR TITLE
dts: stm32: Streamline devicetree binding descriptions

### DIFF
--- a/dts/bindings/adc/st,stm32-adc.yaml
+++ b/dts/bindings/adc/st,stm32-adc.yaml
@@ -2,7 +2,7 @@
 # Copyright (c) 2018, Song Qiang <songqiang1304521@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
 
-description: ST STM32 family ADC
+description: STM32 ADC
 
 compatible: "st,stm32-adc"
 

--- a/dts/bindings/adc/st,stm32f1-adc.yaml
+++ b/dts/bindings/adc/st,stm32f1-adc.yaml
@@ -3,7 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-        ST STM32F1 family ADC
+        STM32F1 ADC
+
         This compatible stands for all ADC blocks similar to the one on STM32F1,
         like STM32F37x.
         Remove the st,adc-clock-source and st,adc-prescaler property.

--- a/dts/bindings/adc/st,stm32f4-adc.yaml
+++ b/dts/bindings/adc/st,stm32f4-adc.yaml
@@ -3,7 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-        ST STM32F4 family ADC
+        STM32F4 ADC
+
         This compatible stands for all ADC blocks similar to the one on STM32F4,
         like F2, F7 or L1.
 

--- a/dts/bindings/adc/st,stm32n6-adc.yaml
+++ b/dts/bindings/adc/st,stm32n6-adc.yaml
@@ -3,7 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-        ST STM32N6 ADC
+        STM32N6 ADC
+
         This compatible stands for STM32N6 ADC.
 
 compatible: "st,stm32n6-adc"

--- a/dts/bindings/adc/st,stm32wb0-adc.yaml
+++ b/dts/bindings/adc/st,stm32wb0-adc.yaml
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-description: STM32WB0 series Analog-to-Digital Converter
+description: STM32WB0 Analog-to-Digital Converter
 
 compatible: "st,stm32wb0-adc"
 

--- a/dts/bindings/can/st,stm32-fdcan.yaml
+++ b/dts/bindings/can/st,stm32-fdcan.yaml
@@ -1,4 +1,4 @@
-description: ST STM32 FDCAN CAN FD controller
+description: STM32 FDCAN CAN FD controller
 
 compatible: "st,stm32-fdcan"
 

--- a/dts/bindings/can/st,stm32h7-fdcan.yaml
+++ b/dts/bindings/can/st,stm32h7-fdcan.yaml
@@ -1,4 +1,4 @@
-description: ST STM32H7 series FDCAN CAN FD controller
+description: STM32H7 series FDCAN CAN FD controller
 
 compatible: "st,stm32h7-fdcan"
 

--- a/dts/bindings/clock/st,stm32-clock-mux.yaml
+++ b/dts/bindings/clock/st,stm32-clock-mux.yaml
@@ -3,6 +3,7 @@
 
 description: |
         STM32 Clock multiplexer
+
         Describes a clock multiplexer, such as per_ck on STM32H7 or
         CLK48 on STM32WB.
         The only property of this node is to select a clock input.

--- a/dts/bindings/clock/st,stm32-rcc.yaml
+++ b/dts/bindings/clock/st,stm32-rcc.yaml
@@ -2,7 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-  STM32 Reset and Clock controller node.
+  STM32 RCC (Reset and Clock controller).
+
   This node is in charge of system clock ('SYSCLK') source selection and controlling
   clocks for AHB (Advanced High Performance) and APB (Advanced Peripheral) bus domains.
 

--- a/dts/bindings/clock/st,stm32c0-hsi-clock.yaml
+++ b/dts/bindings/clock/st,stm32c0-hsi-clock.yaml
@@ -2,7 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-  STM32 HSI Clock node description for STM32C0 devices
+  STM32C0 HSI Clock.
+
   On STM32C0, HSI is a 48MHz fixed clock.
 
   It also produces a HSISYS secondary clk which can be used as system clock

--- a/dts/bindings/clock/st,stm32f0-pll-clock.yaml
+++ b/dts/bindings/clock/st,stm32f0-pll-clock.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-  Main PLL node binding for STM32F0 and STM32F3 devices.
+  STM32F0/F3 Main PLL.
 
   Takes one of clk_hse or clk_hsi as input clock.
 

--- a/dts/bindings/clock/st,stm32f0-rcc.yaml
+++ b/dts/bindings/clock/st,stm32f0-rcc.yaml
@@ -2,7 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-  STM32F0 and G0 Reset and Clock controller node.
+  STM32F0/G0 RCC (Reset and Clock controller).
+
   For more description confere st,stm32-rcc.yaml
 
 compatible: "st,stm32f0-rcc"

--- a/dts/bindings/clock/st,stm32f1-clock-mco.yaml
+++ b/dts/bindings/clock/st,stm32f1-clock-mco.yaml
@@ -7,7 +7,7 @@
 compatible: "st,stm32f1-clock-mco"
 
 description: |
-        STM32 F1 series Microcontroller Clock Output (MCO)
+        STM32F1 Microcontroller Clock Output (MCO)
 
         The STM32F1 MCO is similar to other series but has no configurable
         prescaler before the output. However, note that certain inputs of

--- a/dts/bindings/clock/st,stm32f1-pll-clock.yaml
+++ b/dts/bindings/clock/st,stm32f1-pll-clock.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-  Main PLL node binding for low-, medium-, high- and XL-density STM32F1 devices.
+  STM32F1 Main PLL for low-, medium-, high- and XL-density devices.
 
   Takes one of 'clk_hse', 'clk_hse / 2' (when 'xtpre' is set) or 'clk_hsi / 2'
   as input clock.

--- a/dts/bindings/clock/st,stm32f1-rcc.yaml
+++ b/dts/bindings/clock/st,stm32f1-rcc.yaml
@@ -2,7 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-  STM32F1 and STM32F37x Reset and Clock controller node.
+  STM32F1/F3/7x RCC (Reset and Clock controller).
+
   Adds the ADC prescaler to the standard generic STM32 RCC.
   For more description confere st,stm32-rcc.yaml
 

--- a/dts/bindings/clock/st,stm32f100-pll-clock.yaml
+++ b/dts/bindings/clock/st,stm32f100-pll-clock.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-  Main PLL node binding for STM32F100 devices
+  STM32F100 Main PLL.
 
   Takes one of clk_hse or clk_hsi as input clock.
   When clk_hsi is used a fixed prescaler is applied. When input clock is hse or

--- a/dts/bindings/clock/st,stm32f105-pll-clock.yaml
+++ b/dts/bindings/clock/st,stm32f105-pll-clock.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-  Main PLL node binding for Connectivity line devices (STM32F105/STM32F107)
+  STM32F105/F107 Main PLL.
 
   Takes one of clk_hse, pll2 or clk_hsi as input clock.
   When clk_hsi is used a fixed prescaler is applied. When input clock is hse or

--- a/dts/bindings/clock/st,stm32f105-pll2-clock.yaml
+++ b/dts/bindings/clock/st,stm32f105-pll2-clock.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-  PLL2 node binding for Connectivity line devices (STM32F105/STM32F107)
+  STM32F105/F107 PLL2.
 
   Takes clk_hse as input clock, using prediv as prescaler.
 

--- a/dts/bindings/clock/st,stm32f2-pll-clock.yaml
+++ b/dts/bindings/clock/st,stm32f2-pll-clock.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-  STM32F2 Main PLL node binding:
+  STM32F2 Main PLL.
 
   Takes one of clk_hse or clk_hsi as input clock.
 

--- a/dts/bindings/clock/st,stm32f3-rcc.yaml
+++ b/dts/bindings/clock/st,stm32f3-rcc.yaml
@@ -2,7 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-  STM32F3 Reset and Clock controller node.
+  STM32F3 RCC (Reset and Clock controller).
+
   Adds the STM32F3 ADC prescaler to the standard generic STM32 RCC.
   For more description confere st,stm32-rcc.yaml
 

--- a/dts/bindings/clock/st,stm32f4-pll-clock.yaml
+++ b/dts/bindings/clock/st,stm32f4-pll-clock.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-  STM32F4 Main PLL node binding:
+  STM32F4 Main PLL.
 
   Takes one of clk_hse or clk_hsi as input clock, with an
   input frequency from 1 to 2 MHz. PLLM factor is used to set the input clock

--- a/dts/bindings/clock/st,stm32f4-plli2s-clock.yaml
+++ b/dts/bindings/clock/st,stm32f4-plli2s-clock.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-  STM32F4 PLL I2S node binding:
+  STM32F4 PLL I2S.
 
   Takes same input as Main PLL. PLLM factor and PLL source are common with Main PLL
 

--- a/dts/bindings/clock/st,stm32f411-plli2s-clock.yaml
+++ b/dts/bindings/clock/st,stm32f411-plli2s-clock.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-  STM32F411 PLL I2S node binding:
+  STM32F411 PLL I2S.
 
   Fully configurable I2S dedicated PLL.
 

--- a/dts/bindings/clock/st,stm32f7-pll-clock.yaml
+++ b/dts/bindings/clock/st,stm32f7-pll-clock.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-  STM32F7 Main PLL node binding:
+  STM32F7 Main PLL.
 
   Takes one of clk_hse or clk_hsi as input clock.
 

--- a/dts/bindings/clock/st,stm32g0-hsi-clock.yaml
+++ b/dts/bindings/clock/st,stm32g0-hsi-clock.yaml
@@ -2,7 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-  STM32 HSI Clock node description for STM32G0 devices
+  STM32G0 HSI Clock.
+
   On STM32G0, HSI is a 16MHz fixed clock.
 
   It also produces a HSISYS secondary clk which can be used as system clock

--- a/dts/bindings/clock/st,stm32g0-pll-clock.yaml
+++ b/dts/bindings/clock/st,stm32g0-pll-clock.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-  PLL node binding for STM32G0 devices
+  STM32G0 main PLL.
 
   It can take one of clk_hse or clk_hsi as input clock, with
   an input frequency from 2.66 to 16 MHz. PLLM factor is used to set the input

--- a/dts/bindings/clock/st,stm32g4-pll-clock.yaml
+++ b/dts/bindings/clock/st,stm32g4-pll-clock.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-  PLL node binding for STM32G4 devices
+  STM32G4 main PLL.
 
   It can take one of clk_hse or clk_hsi as input clock, with
   an input frequency from 2.66 to 16 MHz. PLLM factor is used to set the input

--- a/dts/bindings/clock/st,stm32h7-pll-clock.yaml
+++ b/dts/bindings/clock/st,stm32h7-pll-clock.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-  PLL node binding for STM32H7 devices
+  STM32H7 main PLL.
 
   It can be used to describe 3 different PLLs: PLL1 (Main PLL), PLL2 and PLL3.
   Only PLL1 and PLL3 are supported for now.

--- a/dts/bindings/clock/st,stm32h7-rcc.yaml
+++ b/dts/bindings/clock/st,stm32h7-rcc.yaml
@@ -2,7 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-  STM32 Reset and Clock controller node for STM32H7 devices
+  STM32H7 RCC (Reset and Clock controller).
+
   This node is in charge of system clock ('SYSCLK') source selection and
   System Clock Generation.
 

--- a/dts/bindings/clock/st,stm32h7rs-pll-clock.yaml
+++ b/dts/bindings/clock/st,stm32h7rs-pll-clock.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-  PLL node binding for STM32H7RS devices
+  STM32H7RS main PLL.
 
   It can be used to describe 3 different PLLs: PLL1 (Main PLL), PLL2 and PLL3.
 

--- a/dts/bindings/clock/st,stm32h7rs-rcc.yaml
+++ b/dts/bindings/clock/st,stm32h7rs-rcc.yaml
@@ -2,7 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-  STM32 Reset and Clock controller node for STM32H7RS devices
+  STM32H7RS RCC (Reset and Clock controller).
+
   This node is in charge of system clock ('SYSCLK') source selection and
   System Clock Generation.
 

--- a/dts/bindings/clock/st,stm32l0-msi-clock.yaml
+++ b/dts/bindings/clock/st,stm32l0-msi-clock.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2021, Linaro ltd
 # SPDX-License-Identifier: Apache-2.0
 
-description: STM32L0 and STM32L1 Multi Speed Internal Clock
+description: STM32L0/L1 Multi Speed Internal Clock
 
 compatible: "st,stm32l0-msi-clock"
 

--- a/dts/bindings/clock/st,stm32l0-pll-clock.yaml
+++ b/dts/bindings/clock/st,stm32l0-pll-clock.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-  STM32L0 and STM32L1 Main PLL node binding:
+  STM32L0/L1 Main PLL.
 
   Takes one of clk_hse, clk_hsi or clk_msi as input clock, with an
   input frequency from 2 to 24 MHz.

--- a/dts/bindings/clock/st,stm32l4-pll-clock.yaml
+++ b/dts/bindings/clock/st,stm32l4-pll-clock.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-  PLL node binding for STM32L4 and STM32L5 devices
+  STM32L4/L5 main PLL.
 
   It can be used to describe 3 different PLLs: PLL, PLLSAI1 and PLLSAI2.
   Only main PLL is supported for now.

--- a/dts/bindings/clock/st,stm32mp1-rcc.yaml
+++ b/dts/bindings/clock/st,stm32mp1-rcc.yaml
@@ -2,7 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-  STM32MP1 Reset and Clock controller node.
+  STM32MP1 RCC (Reset and Clock controller).
+
   On STM32MP1 platforms, clock control configuration is performed on A9 side.
   As a consequence, the only property to be set in devicetree node is the
   clock-frequency (mlhclk_ck).

--- a/dts/bindings/clock/st,stm32n6-cpu-clock-mux.yaml
+++ b/dts/bindings/clock/st,stm32n6-cpu-clock-mux.yaml
@@ -2,9 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-  STM32N6 CPU Clock
+  STM32N6 CPU Clock.
+
   Describes the STM32N6 CPU clock multiplexer. On STM32N6, this is the CPU
   clock that feeds the SysTick.
+
   For instance:
   &cpusw {
     clocks = <&rcc STM32_SRC_IC1 CPU_SEL(3)>;

--- a/dts/bindings/clock/st,stm32n6-ic-clock-mux.yaml
+++ b/dts/bindings/clock/st,stm32n6-ic-clock-mux.yaml
@@ -2,8 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-  STM32N6 Divider IC multiplexer
-  This node select a clock input and a divider.
+  STM32N6 Divider IC multiplexer.
+
+  This node selects a clock input and a divider.
+
   For instance:
     &ic6 {
       pll-src = <2>;

--- a/dts/bindings/clock/st,stm32n6-pll-clock.yaml
+++ b/dts/bindings/clock/st,stm32n6-pll-clock.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-  PLL node binding for STM32N6 devices
+  STM32N6 main PLL.
 
   It can be used to describe 4 different PLLs: PLL1, PLL2, PLL3 and PLL4.
 

--- a/dts/bindings/clock/st,stm32n6-rcc.yaml
+++ b/dts/bindings/clock/st,stm32n6-rcc.yaml
@@ -2,7 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-  STM32 Reset and Clock controller node for STM32N6 devices
+  STM32N6 RCC (Reset and Clock controller).
+
   This node is in charge of system clock ('SYSCLK') source selection and
   System Clock Generation.
 

--- a/dts/bindings/clock/st,stm32u0-pll-clock.yaml
+++ b/dts/bindings/clock/st,stm32u0-pll-clock.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-  STM32U0 Main PLL node binding:
+  STM32U0 Main PLL.
 
   Takes one of clk_hse, clk_hsi or clk_msi as input clock, with
   an input frequency from 2.66 to 16 MHz. PLLM factor is used to set the input

--- a/dts/bindings/clock/st,stm32u5-pll-clock.yaml
+++ b/dts/bindings/clock/st,stm32u5-pll-clock.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-  PLL node binding for STM32U5 devices
+  STM32U5 PLL.
 
   It can be used to describe 3 different PLLs: PLL1, PLL2 and PLL3.
 

--- a/dts/bindings/clock/st,stm32u5-rcc.yaml
+++ b/dts/bindings/clock/st,stm32u5-rcc.yaml
@@ -2,7 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-  STM32U5 Reset and Clock controller node.
+  STM32U5 RCC (Reset and Clock controller).
+
   For more description confere st,stm32-rcc.yaml
 
 compatible: "st,stm32u5-rcc"

--- a/dts/bindings/clock/st,stm32wb-rcc.yaml
+++ b/dts/bindings/clock/st,stm32wb-rcc.yaml
@@ -3,6 +3,7 @@
 
 description: |
   STM32WB Reset and Clock controller node.
+
   For more description confere st,stm32-rcc.yaml
 
 compatible: "st,stm32wb-rcc"

--- a/dts/bindings/clock/st,stm32wb0-rcc.yaml
+++ b/dts/bindings/clock/st,stm32wb0-rcc.yaml
@@ -2,7 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-  STM32WB0 Reset and Clock controller node for STM32WB0 devices
+  STM32WB0 RCC (Reset and Clock controller).
+
   This node is in charge of the system clock ('SYSCLK') source
   selection and generation.
 

--- a/dts/bindings/clock/st,stm32wba-pll-clock.yaml
+++ b/dts/bindings/clock/st,stm32wba-pll-clock.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-  PLL node binding for STM32WBA devices
+  STM32WBA PLL.
 
   It can be used to describe PLL1
 

--- a/dts/bindings/clock/st,stm32wba-rcc.yaml
+++ b/dts/bindings/clock/st,stm32wba-rcc.yaml
@@ -2,7 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-  STM32 Reset and Clock controller node.
+  STM32WBA RCC (Reset and Clock controller).
+
   This node is in charge of system clock ('SYSCLK') source selection and controlling
   clocks for AHB (Advanced High Performance) and APB (Advanced Peripheral) bus domains.
 

--- a/dts/bindings/clock/st,stm32wl-rcc.yaml
+++ b/dts/bindings/clock/st,stm32wl-rcc.yaml
@@ -2,7 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-  STM32WL Reset and Clock controller node.
+  STM32WL RCC (Reset and Clock controller).
+
   For more description confere st,stm32-rcc.yaml
 
 compatible: "st,stm32wl-rcc"

--- a/dts/bindings/dac/st,stm32-dac.yaml
+++ b/dts/bindings/dac/st,stm32-dac.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2020 Libre Solar Technologies GmbH
 # SPDX-License-Identifier: Apache-2.0
 
-description: ST STM32 family DAC
+description: STM32 family DAC
 
 compatible: "st,stm32-dac"
 

--- a/dts/bindings/dma/st,stm32u5-dma.yaml
+++ b/dts/bindings/dma/st,stm32u5-dma.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-  STM32 DMA controller for the stm32U5 soc family
+  STM32U5 DMA controller.
 
   It is present on stm32U5 devices as a GP DMA
   This controller includes several channels with different requests.

--- a/dts/bindings/ethernet/st,stm32h7-ethernet.yaml
+++ b/dts/bindings/ethernet/st,stm32h7-ethernet.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-  ST STM32H7 Ethernet
+  STM32H7 Ethernet
 
   This binding file describes the device tree properties required to configure
   and use the Ethernet controller on STM32H7 and STM32H5 series microcontrollers.

--- a/dts/bindings/flash_controller/st,stm32f1-flash-controller.yaml
+++ b/dts/bindings/flash_controller/st,stm32f1-flash-controller.yaml
@@ -1,4 +1,4 @@
-description: STM32 F1 flash controller
+description: STM32F1 flash controller
 
 compatible: "st,stm32f1-flash-controller"
 

--- a/dts/bindings/flash_controller/st,stm32f2-flash-controller.yaml
+++ b/dts/bindings/flash_controller/st,stm32f2-flash-controller.yaml
@@ -1,4 +1,4 @@
-description: STM32 F2 flash controller
+description: STM32F2 flash controller
 
 compatible: "st,stm32f2-flash-controller"
 

--- a/dts/bindings/flash_controller/st,stm32f4-flash-controller.yaml
+++ b/dts/bindings/flash_controller/st,stm32f4-flash-controller.yaml
@@ -1,4 +1,4 @@
-description: STM32 F4 flash controller
+description: STM32F4 flash controller
 
 compatible: "st,stm32f4-flash-controller"
 

--- a/dts/bindings/flash_controller/st,stm32f7-flash-controller.yaml
+++ b/dts/bindings/flash_controller/st,stm32f7-flash-controller.yaml
@@ -1,4 +1,4 @@
-description: STM32 F7 flash controller
+description: STM32F7 flash controller
 
 compatible: "st,stm32f7-flash-controller"
 

--- a/dts/bindings/flash_controller/st,stm32g0-flash-controller.yaml
+++ b/dts/bindings/flash_controller/st,stm32g0-flash-controller.yaml
@@ -1,4 +1,4 @@
-description: STM32 G0 flash controller
+description: STM32G0 flash controller
 
 compatible: "st,stm32g0-flash-controller"
 

--- a/dts/bindings/flash_controller/st,stm32g4-flash-controller.yaml
+++ b/dts/bindings/flash_controller/st,stm32g4-flash-controller.yaml
@@ -1,4 +1,4 @@
-description: STM32 G4 flash controller
+description: STM32G4 flash controller
 
 compatible: "st,stm32g4-flash-controller"
 

--- a/dts/bindings/flash_controller/st,stm32h7-flash-controller.yaml
+++ b/dts/bindings/flash_controller/st,stm32h7-flash-controller.yaml
@@ -1,4 +1,4 @@
-description: STM32 H7 flash controller
+description: STM32H7 flash controller
 
 compatible: "st,stm32h7-flash-controller"
 

--- a/dts/bindings/flash_controller/st,stm32l4-flash-controller.yaml
+++ b/dts/bindings/flash_controller/st,stm32l4-flash-controller.yaml
@@ -1,4 +1,4 @@
-description: STM32 L4 flash controller
+description: STM32L4 flash controller
 
 compatible: "st,stm32l4-flash-controller"
 

--- a/dts/bindings/flash_controller/st,stm32l5-flash-controller.yaml
+++ b/dts/bindings/flash_controller/st,stm32l5-flash-controller.yaml
@@ -1,4 +1,4 @@
-description: STM32 L5 flash controller
+description: STM32L5 flash controller
 
 compatible: "st,stm32l5-flash-controller"
 

--- a/dts/bindings/flash_controller/st,stm32wb-flash-controller.yaml
+++ b/dts/bindings/flash_controller/st,stm32wb-flash-controller.yaml
@@ -1,4 +1,4 @@
-description: STM32 WB flash controller
+description: STM32WB flash controller
 
 compatible: "st,stm32wb-flash-controller"
 

--- a/dts/bindings/flash_controller/st,stm32wba-flash-controller.yaml
+++ b/dts/bindings/flash_controller/st,stm32wba-flash-controller.yaml
@@ -1,4 +1,4 @@
-description: STM32 WBA flash controller
+description: STM32WBA flash controller
 
 compatible: "st,stm32wba-flash-controller"
 

--- a/dts/bindings/gpio/st,stm32-gpio.yaml
+++ b/dts/bindings/gpio/st,stm32-gpio.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2018, Linaro Limited
 # SPDX-License-Identifier: Apache-2.0
 
-description: STM32 GPIO node
+description: STM32 GPIO controller
 
 compatible: "st,stm32-gpio"
 

--- a/dts/bindings/interrupt-controller/st,stm32-exti.yaml
+++ b/dts/bindings/interrupt-controller/st,stm32-exti.yaml
@@ -1,4 +1,4 @@
-description: STMicroelectronics STM32 family External Interrupt Controller
+description: STM32 External Interrupt Controller
 
 compatible: "st,stm32-exti"
 

--- a/dts/bindings/interrupt-controller/st,stm32g0-exti.yaml
+++ b/dts/bindings/interrupt-controller/st,stm32g0-exti.yaml
@@ -3,7 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-        STM32 controller
+        STM32G0 External Interrupt Controller
+
         This compatible stands for all interrupt-controller blocks with two
         dedicated Rising and Falling interrupt pending registers.
 

--- a/dts/bindings/interrupt-controller/st,stm32h7rs-exti.yaml
+++ b/dts/bindings/interrupt-controller/st,stm32h7rs-exti.yaml
@@ -3,7 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-        STM32 controller
+        STM32H7RS External Interrupt Controller
+
         This compatible stands for the stm32H7RS interrupt-controller block
         with two dedicated Rising and Falling interrupt pending registers
 

--- a/dts/bindings/lora/st,stm32wl-subghz-radio.yaml
+++ b/dts/bindings/lora/st,stm32wl-subghz-radio.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2021 Fabio Baltieri
 # SPDX-License-Identifier: Apache-2.0
 
-description: STM32WL SUBGHZ Radio
+description: STM32WL Sub-GHz Radio
 
 compatible: "st,stm32wl-subghz-radio"
 

--- a/dts/bindings/mdio/st,stm32-mdio.yaml
+++ b/dts/bindings/mdio/st,stm32-mdio.yaml
@@ -2,7 +2,7 @@
 # Copyright (c) 2024 Analog Devices Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-description: ST MDIO Features
+description: STM32 MDIO Controller
 
 compatible: "st,stm32-mdio"
 

--- a/dts/bindings/memory-controllers/st,stm32h7-fmc.yaml
+++ b/dts/bindings/memory-controllers/st,stm32h7-fmc.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-  STM32 Flexible Memory Controller (FMC).
+  STM32H7 Flexible Memory Controller (FMC).
 
   The FMC allows to interface with static-memory mapped external devices such as
   SRAM, NOR Flash, NAND Flash, SDRAM...

--- a/dts/bindings/mmc/st,stm32-sdmmc.yaml
+++ b/dts/bindings/mmc/st,stm32-sdmmc.yaml
@@ -1,4 +1,4 @@
-description: stm32 sdmmc disk access
+description: STM32 SDMMC Disk Access
 
 compatible: "st,stm32-sdmmc"
 

--- a/dts/bindings/mtd/st,stm32-nv-flash.yaml
+++ b/dts/bindings/mtd/st,stm32-nv-flash.yaml
@@ -1,7 +1,8 @@
 description: |
-  STM32 flash memory. This binding is for the flash memory itself, not
-  the flash controller peripheral. For that, see the
-  "st,stm32-flash-controller" binding.
+  STM32 flash memory.
+
+  This binding is for the flash memory itself, not the flash controller peripheral.
+  For that, see the "st,stm32-flash-controller" binding.
 
 include: soc-nv-flash.yaml
 

--- a/dts/bindings/mtd/st,stm32f4-nv-flash.yaml
+++ b/dts/bindings/mtd/st,stm32f4-nv-flash.yaml
@@ -1,5 +1,5 @@
 description: |
-  ST STM32F4 family flash memory.
+  STM32F4 flash memory.
 
 include: st,stm32-nv-flash.yaml
 

--- a/dts/bindings/mtd/st,stm32l0-nv-flash.yaml
+++ b/dts/bindings/mtd/st,stm32l0-nv-flash.yaml
@@ -1,5 +1,5 @@
 description: |
-  ST STM32L0 family flash memory.
+  STM32L0 flash memory.
 
 include: st,stm32-nv-flash.yaml
 

--- a/dts/bindings/ospi/st,stm32-ospi.yaml
+++ b/dts/bindings/ospi/st,stm32-ospi.yaml
@@ -2,8 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-    STM32 OSPI device representation. Enabling a stm32 octospi node in a board
-    description would typically requires this:
+    STM32 OSPI Controller.
+
+    Enabling a stm32 octospi node in a board description would typically requires this:
 
         &octospi {
             pinctrl-0 = <&octospi_clk_pe9 &octospi_ncs_pe10 &octospi_dqs_pe11

--- a/dts/bindings/phy/st,stm32u5-otghs-phy.yaml
+++ b/dts/bindings/phy/st,stm32u5-otghs-phy.yaml
@@ -3,6 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
+    STM32U5 OTG HS PHY.
+
     This binding is to be used by the STM32U5xx transceivers which are built-in
     with USB HS PHY IP and a configurable HSE clock source.
 

--- a/dts/bindings/pinctrl/st,stm32-pinctrl.yaml
+++ b/dts/bindings/pinctrl/st,stm32-pinctrl.yaml
@@ -2,7 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-    STM32 Pin controller Node
+    STM32 Pin controller.
+
     Based on pincfg-node.yaml binding.
 
     Note: `bias-disable` and `drive-push-pull` are default pin configurations.

--- a/dts/bindings/pinctrl/st,stm32f1-pinctrl.yaml
+++ b/dts/bindings/pinctrl/st,stm32f1-pinctrl.yaml
@@ -2,7 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-    STM32F1 Pin controller Node
+    STM32F1 Pin controller.
+
     Based on pincfg-node.yaml binding.
 
     Note: `bias-disable` and `drive-push-pull` are default pin configurations.

--- a/dts/bindings/qspi/st,stm32-qspi.yaml
+++ b/dts/bindings/qspi/st,stm32-qspi.yaml
@@ -2,8 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-    STM32 QSPI device representation. A stm32 quadspi node would typically
-    looks to this:
+    STM32 QSPI Controller.
+
+    An stm32 quadspi node would typically look like this:
 
         &quadspi {
             pinctrl-0 = <&quadspi_clk_pe10 &quadspi_ncs_pe11

--- a/dts/bindings/reset/st,stm32-rcc-rctl.yaml
+++ b/dts/bindings/reset/st,stm32-rcc-rctl.yaml
@@ -2,7 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-  STM32 Reset and Clock Control (RCC) node.
+  STM32 Reset and Clock Control (RCC) Controller.
+
   This node is in charge of reset control for AHB (Advanced High Performance)
   and APB (Advanced Peripheral) bus domains.
 

--- a/dts/bindings/sensor/st,stm32-digi-temp.yaml
+++ b/dts/bindings/sensor/st,stm32-digi-temp.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024, Aurelien Jarno
 # SPDX-License-Identifier: Apache-2.0
 
-description: STM32 family Digital Temperature Sensor node
+description: STM32 Digital Temperature Sensor.
 
 compatible: "st,stm32-digi-temp"
 

--- a/dts/bindings/sensor/st,stm32-temp.yaml
+++ b/dts/bindings/sensor/st,stm32-temp.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2021, Eug Krashtan
 # SPDX-License-Identifier: Apache-2.0
 
-description: STM32 family TEMP node
+description: STM32 Internal Temperature Sensor.
 
 compatible: "st,stm32-temp"
 

--- a/dts/bindings/sensor/st,stm32-vbat.yaml
+++ b/dts/bindings/sensor/st,stm32-vbat.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2022 STMicroelectronics
 # SPDX-License-Identifier: Apache-2.0
 
-description: STM32 family VBAT node
+description: STM32 VBAT
 
 include: sensor-device.yaml
 

--- a/dts/bindings/sensor/st,stm32-vref.yaml
+++ b/dts/bindings/sensor/st,stm32-vref.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Kenneth J. Miller <ken@miller.ec>
 # SPDX-License-Identifier: Apache-2.0
 
-description: STM32 family VREF+ node
+description: STM32 VREF+.
 
 compatible: "st,stm32-vref"
 

--- a/dts/bindings/sensor/st,stm32c0-temp-cal.yaml
+++ b/dts/bindings/sensor/st,stm32c0-temp-cal.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-    STM32 family TEMP node for production calibrated sensors with a single calibration temperature.
+  STM32 TEMP for production calibrated sensors with a single calibration temperature.
 
 compatible: "st,stm32c0-temp-cal"
 

--- a/dts/bindings/spi/st,stm32-spi-host-cmd.yaml
+++ b/dts/bindings/spi/st,stm32-spi-host-cmd.yaml
@@ -3,6 +3,7 @@
 
 description: |
         Host Command version of STM32 SPI controller.
+
         All properties are the same, but a different driver is used.
 
 compatible: "st,stm32-spi-host-cmd"

--- a/dts/bindings/spi/st,stm32h7-spi.yaml
+++ b/dts/bindings/spi/st,stm32h7-spi.yaml
@@ -2,7 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-        STM32H7 SPI controller
+        STM32H7 SPI controller.
+
         This compatible stands for all SPI hardware blocks matching the
         version available in STM32H7 SoCs.
         This version of STM32 SPI hardware block could be identified by the

--- a/dts/bindings/tcpc/st,stm32-ucpd.yaml
+++ b/dts/bindings/tcpc/st,stm32-ucpd.yaml
@@ -2,8 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-    ST STM32 family USB Type-C / Power Delivery. The default values were
-    taken from the LL_UCPD_StructInit function defined in the HAL.
+    STM32 USB Type-C / Power Delivery.
+
+    The default values were taken from the LL_UCPD_StructInit function defined in the HAL.
 
 compatible: "st,stm32-ucpd"
 

--- a/dts/bindings/timer/st,stm32-lptim.yaml
+++ b/dts/bindings/timer/st,stm32-lptim.yaml
@@ -2,7 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-  STM32 lptim : low power timer
+  STM32 low-power timer (LPTIM).
+
   The lptim node to be used for counting ticks during lowpower modes
   must be named stm32_lp_tick_source in the DTS, as follows:
   stm32_lp_tick_source: &lptim1 {

--- a/dts/bindings/usb/st,stm32f4-fsotg.yaml
+++ b/dts/bindings/usb/st,stm32f4-fsotg.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 #
-description: STM32F4 SoC series OTG_FS DWC2 compatible controller
+description: STM32F4 OTG_FS DWC2 compatible controller.
 
 compatible: "st,stm32f4-fsotg"
 

--- a/dts/bindings/video/st,stm32-dcmi.yaml
+++ b/dts/bindings/video/st,stm32-dcmi.yaml
@@ -5,7 +5,8 @@
 #
 
 description: |
-    STMicroelectronics STM32 Digital Camera Memory Interface (DCMI).
+    STM32 Digital Camera Memory Interface (DCMI).
+
     Example of node configuration at board level:
 
     &dcmi {

--- a/dts/bindings/xspi/st,stm32-xspi.yaml
+++ b/dts/bindings/xspi/st,stm32-xspi.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-    STM32 XSPI device representation. Enabling a stm32 xspi node in a board
+    STM32 XSPI Controller.
 
 compatible: "st,stm32-xspi"
 


### PR DESCRIPTION
Ensure consistent (and concise) short descriptions of all the st,*.yaml bindings.