### PR TITLE
zephyr_code_relocate() now supports the NOCOPY_DATA flag to inhibit data relocation

### DIFF
--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -1446,13 +1446,15 @@ endmacro()
 # zephyr_code_relocate(LIBRARY my_lib SRAM)
 #
 # The following optional arguments are supported:
-# - NOCOPY: this flag indicates that the file data does not need to be copied
+# - NOCOPY: this flag indicates that the file's text section does not need to be copied
 #   at boot time (For example, for flash XIP).
+# - NOCOPY_DATA: this flag indicates that the file's data section (read-write data)
+#   does not need to be copied at boot time (For example, if it is directly loaded into SRAM).
 # - NOKEEP: suppress the generation of KEEP() statements in the linker script,
 #   to allow any unused code in the given files/library to be discarded.
 # - PHDR [program_header]: add program header. Used on Xtensa platforms.
 function(zephyr_code_relocate)
-  set(options NOCOPY NOKEEP)
+  set(options NOCOPY NOCOPY_DATA NOKEEP)
   set(single_args LIBRARY LOCATION PHDR FILTER)
   set(multi_args FILES)
   cmake_parse_arguments(CODE_REL "${options}" "${single_args}"
@@ -1515,6 +1517,11 @@ function(zephyr_code_relocate)
     set(flag_list COPY)
   else()
     set(flag_list NOCOPY)
+  endif()
+  if(NOT CODE_REL_NOCOPY_DATA)
+    list(APPEND flag_list COPYDATA)
+  else()
+    list(APPEND flag_list NOCOPYDATA)
   endif()
   if(CODE_REL_NOKEEP)
     list(APPEND flag_list NOKEEP)

--- a/doc/kernel/code-relocation.rst
+++ b/doc/kernel/code-relocation.rst
@@ -139,8 +139,8 @@ you can pass ``NOKEEP`` to your ``zephyr_code_relocate()`` call.
 The example above will help ensure that any unused code found in the .text
 sections of ``file1.c`` will not stick to SRAM2.
 
-NOCOPY flag
-===========
+NOCOPY and NOCOPY_DATA flags
+============================
 
 When a ``NOCOPY`` option is passed to the ``zephyr_code_relocate()`` function,
 the relocation code is not generated in ``code_relocation.c``. This flag can be
@@ -149,12 +149,23 @@ XIP area.
 
 This example will place the .text section of the ``xip_external_flash.c`` file
 to the ``EXTFLASH`` memory region where it will be executed from (XIP). The
-.data will be relocated as usual into SRAM.
+.data will be relocated as usual into SRAM, since flash in XIP mode does not
+allow random write access and variables do not have to persist.
 
   .. code-block:: none
 
      zephyr_code_relocate(FILES src/xip_external_flash.c LOCATION EXTFLASH_TEXT NOCOPY)
      zephyr_code_relocate(FILES src/xip_external_flash.c LOCATION SRAM_DATA)
+
+You can additionally specify ``NOCOPY_DATA`` if you do not want .data to be copied into SRAM.
+This can be useful if it is already loaded into SRAM, e.g. by the Linux kernel
+using the `remoteproc framework <https://docs.kernel.org/staging/remoteproc.html>`_.
+The following example demonstrates how to place an entire file into the SRAM section without
+copying.
+
+  .. code-block:: none
+
+     zephyr_code_relocate(FILES src/file1.c LOCATION SRAM NOCOPY NOCOPY_DATA)
 
 Relocating libraries
 ====================


### PR DESCRIPTION
This helps when building firmwares for coprocessors, where the image is loaded completely into SRAM in Linux-land using the remoteproc framework.

For a motivation of this change, see #86530.