### PR TITLE
IPC: Applied `unlikely` to unlikely code paths

### DIFF
--- a/subsys/ipc/ipc_service/lib/icmsg.c
+++ b/subsys/ipc/ipc_service/lib/icmsg.c
@@ -279,7 +279,7 @@ static bool callback_process(struct icmsg_data_t *dev_data)
 			}
 		}
 
-		if (len_available == 0) {
+		if (unlikely(len_available == 0)) {
 			/* Unlikely, no data in buffer. */
 			return false;
 		}

--- a/subsys/ipc/ipc_service/lib/pbuf.c
+++ b/subsys/ipc/ipc_service/lib/pbuf.c
@@ -261,7 +261,7 @@ int pbuf_read(struct pbuf *pb, char *buf, uint16_t len)
 
 	uint32_t occupied_space = idx_occupied(blen, wr_idx, rd_idx);
 
-	if (occupied_space < plen + PBUF_PACKET_LEN_SZ) {
+	if (unlikely(occupied_space < plen + PBUF_PACKET_LEN_SZ)) {
 		/* This should never happen. */
 		return -EAGAIN;
 	}


### PR DESCRIPTION
The unlikely branches has been marked with the `unlikely` macro.
This improves performance by lowering their priority during branch-prediction.