### PR TITLE
bluetooth: host: ecc: Change log level debug

### DIFF
--- a/subsys/bluetooth/host/ecc.c
+++ b/subsys/bluetooth/host/ecc.c
@@ -265,7 +265,7 @@ int bt_pub_key_gen(struct bt_pub_key_cb *new_cb)
 
 	SYS_SLIST_FOR_EACH_CONTAINER(&pub_key_cb_slist, cb, node) {
 		if (cb == new_cb) {
-			LOG_WRN("Callback already registered");
+			LOG_DBG("Callback already registered");
 			return -EALREADY;
 		}
 	}


### PR DESCRIPTION
This commit changes log level for already registered callback from warning to debug as this is cause unnecessary noise and doesn't indicate actual issue. Caller gets a certain error code for this case which can be handled properly.