### PR TITLE
net: http: server: The detail length of wildcard detail was wrong

### DIFF
--- a/subsys/net/lib/http/Kconfig
+++ b/subsys/net/lib/http/Kconfig
@@ -163,7 +163,8 @@ config HTTP_SERVER_WEBSOCKET
 
 config HTTP_SERVER_RESOURCE_WILDCARD
 	bool "Allow wildcard matching of resources"
-	select FNMATCH
+	# The POSIX_C_LIB_EXT will get fnmatch() support
+	select POSIX_C_LIB_EXT
 	help
 	  Allow user to specify wildcards when setting up resource strings.
 	  This means that instead of specifying multiple resources with exact

--- a/subsys/net/lib/http/http_server_core.c
+++ b/subsys/net/lib/http/http_server_core.c
@@ -762,7 +762,7 @@ struct http_resource_detail *get_resource_detail(const struct http_service_desc 
 
 			ret = fnmatch(resource->resource, path, (FNM_PATHNAME | FNM_LEADING_DIR));
 			if (ret == 0) {
-				*path_len = strlen(resource->resource);
+				*path_len = path_len_without_query(path);
 				return resource->detail;
 			}
 		}

--- a/tests/net/lib/http_server/common/src/main.c
+++ b/tests/net/lib/http_server/common/src/main.c
@@ -77,6 +77,8 @@ HTTP_RESOURCE_DEFINE(resource_6, service_D, "/fo*", RES(1));
 HTTP_RESOURCE_DEFINE(resource_7, service_D, "/f[ob]o3.html", RES(1));
 HTTP_RESOURCE_DEFINE(resource_8, service_D, "/fb?3.htm", RES(0));
 HTTP_RESOURCE_DEFINE(resource_9, service_D, "/f*4.html", RES(3));
+HTTP_RESOURCE_DEFINE(resource_11, service_D, "/foo/*", RES(3));
+HTTP_RESOURCE_DEFINE(resource_12, service_D, "/foo/b?r", RES(3));
 
 /* Default resource in case of no match */
 static uint16_t service_E_port = 8080;
@@ -373,6 +375,25 @@ ZTEST(http_service, test_HTTP_RESOURCE_WILDCARD)
 	res = CHECK_PATH(service_A, "/fbo3.htm", &len);
 	zassert_is_null(res, "Resource found");
 	zassert_equal(len, 0, "Length set");
+
+	res = CHECK_PATH(service_D, "/foo/bar", &len);
+	zassert_not_null(res, "Resource not found");
+	zassert_true(len == (sizeof("/foo/bar") - 1), "Length not set correctly");
+	zassert_equal(res, RES(3), "Resource mismatch");
+
+	res = CHECK_PATH(service_D, "/foo/bar?param=value", &len);
+	zassert_not_null(res, "Resource not found");
+	zassert_true(len == (sizeof("/foo/bar") - 1), "Length not set correctly");
+	zassert_equal(res, RES(3), "Resource mismatch");
+
+	res = CHECK_PATH(service_D, "/bar?foo=value", &len);
+	zassert_is_null(res, "Resource found");
+	zassert_equal(len, 0, "Length set");
+
+	res = CHECK_PATH(service_D, "/foo/bar?param=value", &len);
+	zassert_not_null(res, "Resource not found");
+	zassert_true(len == (sizeof("/foo/bar") - 1), "Length not set correctly");
+	zassert_equal(res, RES(3), "Resource mismatch");
 }
 
 ZTEST(http_service, test_HTTP_RESOURCE_DEFAULT)


### PR DESCRIPTION
* The path length of the detail resource was not set properly.
* Also replace `CONFIG_FNMATCH` by `CONFIG_POSIX_C_LIB_EXT` as the former is deprecated.

