### PR TITLE
dts: arm: nxp: add DAC support for RT11xx

### DIFF
--- a/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm4.dts
+++ b/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm4.dts
@@ -35,8 +35,17 @@
 		device_type = "memory";
 		reg = <0x80000000 DT_SIZE_M(64)>;
 	};
+
+	zephyr,user {
+		dac = <&dac>;
+		dac-channel-id = <0>;
+		dac-resolution = <12>;
+	};
 };
 
+&dac {
+	status = "okay";
+};
 
 &lpuart1 {
 	status = "okay";

--- a/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm4.yaml
+++ b/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm4.yaml
@@ -14,6 +14,7 @@ toolchain:
 ram: 128
 flash: 128
 supported:
+  - dac
   - dma
   - flash
   - gpio

--- a/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm4_B.yaml
+++ b/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm4_B.yaml
@@ -14,6 +14,7 @@ toolchain:
 ram: 128
 flash: 128
 supported:
+  - dac
   - dma
   - flash
   - gpio

--- a/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm7.dts
+++ b/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm7.dts
@@ -75,6 +75,16 @@
 		gpio-map =	<9 0 &gpio11 15 0>,	/* Pin 9, RESETB */
 				<17 0 &gpio9 25  0>;	/* Pin 17, PWDN */
 	};
+
+	zephyr,user {
+		dac = <&dac>;
+		dac-channel-id = <0>;
+		dac-resolution = <12>;
+	};
+};
+
+&dac {
+	status = "okay";
 };
 
 zephyr_lcdif: &lcdif {};

--- a/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm7.yaml
+++ b/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm7.yaml
@@ -17,6 +17,7 @@ supported:
   - adc
   - can
   - counter
+  - dac
   - display
   - dma
   - flash

--- a/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm7_B.yaml
+++ b/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm7_B.yaml
@@ -17,6 +17,7 @@ supported:
   - adc
   - can
   - counter
+  - dac
   - dma
   - flash
   - gpio

--- a/drivers/dac/CMakeLists.txt
+++ b/drivers/dac/CMakeLists.txt
@@ -6,6 +6,7 @@ zephyr_library()
 
 zephyr_library_sources_ifdef(CONFIG_DAC_MCUX_LPDAC	dac_mcux_lpdac.c)
 zephyr_library_sources_ifdef(CONFIG_DAC_MCUX_DAC	dac_mcux_dac.c)
+zephyr_library_sources_ifdef(CONFIG_DAC_MCUX_DAC12	dac_mcux_dac12.c)
 zephyr_library_sources_ifdef(CONFIG_DAC_MCUX_DAC32	dac_mcux_dac32.c)
 zephyr_library_sources_ifdef(CONFIG_DAC_STM32		dac_stm32.c)
 zephyr_library_sources_ifdef(CONFIG_DAC_SAM		dac_sam.c)

--- a/drivers/dac/Kconfig.mcux
+++ b/drivers/dac/Kconfig.mcux
@@ -11,6 +11,13 @@ config DAC_MCUX_DAC
 	help
 	  Enable the driver for the NXP Kinetis MCUX DAC.
 
+config DAC_MCUX_DAC12
+	bool "NXP MCUX DAC12 driver"
+	default y
+	depends on DT_HAS_NXP_DAC12_ENABLED
+	help
+	  Enable the driver for the NXP MCUX DAC12.
+
 config DAC_MCUX_DAC32
 	bool "NXP Kinetis MCUX DAC32 driver"
 	default y

--- a/drivers/dac/dac_mcux_dac12.c
+++ b/drivers/dac/dac_mcux_dac12.c
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2020 Henrik Brix Andersen <henrik@brixandersen.dk>
+ * Copyright (c) 2023, NXP
+ * Copyright (c) 2025 PHYTEC America LLC
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT nxp_dac12
+
+#include <zephyr/kernel.h>
+#include <zephyr/drivers/dac.h>
+#include <zephyr/logging/log.h>
+
+#include <fsl_dac12.h>
+
+LOG_MODULE_REGISTER(dac_mcux_dac12, CONFIG_DAC_LOG_LEVEL);
+
+struct mcux_dac12_config {
+	DAC_Type *base;
+	dac12_reference_voltage_source_t reference;
+	bool buffered;
+};
+
+struct mcux_dac12_data {
+	bool configured;
+};
+
+static int mcux_dac12_channel_setup(const struct device *dev,
+				    const struct dac_channel_cfg *channel_cfg)
+{
+	const struct mcux_dac12_config *config = dev->config;
+	struct mcux_dac12_data *data = dev->data;
+	dac12_config_t dac12_config;
+
+	if (channel_cfg->channel_id != 0) {
+		LOG_ERR("unsupported channel %d", channel_cfg->channel_id);
+		return -ENOTSUP;
+	}
+
+	if (channel_cfg->resolution != 12) {
+		LOG_ERR("unsupported resolution %d", channel_cfg->resolution);
+		return -ENOTSUP;
+	}
+
+	if (channel_cfg->internal) {
+		LOG_ERR("Internal channels not supported");
+		return -ENOTSUP;
+	}
+
+	DAC12_GetDefaultConfig(&dac12_config);
+	dac12_config.referenceVoltageSource = config->reference;
+
+	DAC12_Init(config->base, &dac12_config);
+	DAC12_Enable(config->base, true);
+
+	data->configured = true;
+
+	return 0;
+}
+
+static int mcux_dac12_write_value(const struct device *dev, uint8_t channel, uint32_t value)
+{
+	const struct mcux_dac12_config *config = dev->config;
+	struct mcux_dac12_data *data = dev->data;
+
+	if (!data->configured) {
+		LOG_ERR("channel not initialized");
+		return -EINVAL;
+	}
+
+	if (channel != 0) {
+		LOG_ERR("unsupported channel %d", channel);
+		return -ENOTSUP;
+	}
+
+	if (value >= 4096) {
+		LOG_ERR("value %d out of range", value);
+		return -EINVAL;
+	}
+
+	DAC12_SetData(config->base, value);
+
+	return 0;
+}
+
+static const struct dac_driver_api mcux_dac12_driver_api = {
+	.channel_setup = mcux_dac12_channel_setup,
+	.write_value = mcux_dac12_write_value,
+};
+
+#define TO_DAC12_VREF_SRC(val) _DO_CONCAT(kDAC12_ReferenceVoltageSourceAlt, val)
+
+#define MCUX_DAC12_INIT(n) \
+	static struct mcux_dac12_data mcux_dac12_data_##n;		\
+									\
+	static const struct mcux_dac12_config mcux_dac12_config_##n = {	\
+		.base = (DAC_Type *)DT_INST_REG_ADDR(n),		\
+		.reference =						\
+		TO_DAC12_VREF_SRC(DT_INST_PROP(n, voltage_reference)),	\
+		.buffered = DT_INST_PROP(n, buffered),			\
+	};								\
+									\
+	DEVICE_DT_INST_DEFINE(n, NULL, NULL,				\
+			&mcux_dac12_data_##n,				\
+			&mcux_dac12_config_##n,				\
+			POST_KERNEL, CONFIG_DAC_INIT_PRIORITY,		\
+			&mcux_dac12_driver_api);
+
+DT_INST_FOREACH_STATUS_OKAY(MCUX_DAC12_INIT)

--- a/dts/arm/nxp/nxp_rt11xx.dtsi
+++ b/dts/arm/nxp/nxp_rt11xx.dtsi
@@ -88,6 +88,15 @@
 	};
 
 	soc {
+		dac: dac@40064000 {
+			compatible = "nxp,dac12";
+			reg = <0x40064000 0x4000>;
+			interrupts = <63 0>;
+			voltage-reference = <2>;
+			status = "disabled";
+			#io-channel-cells = <1>;
+		};
+
 		flexspi: spi@400cc000 {
 			compatible = "nxp,imx-flexspi";
 			reg = <0x400cc000 0x4000>;

--- a/dts/arm/nxp/nxp_rt11xx_cm4.dtsi
+++ b/dts/arm/nxp/nxp_rt11xx_cm4.dtsi
@@ -62,6 +62,11 @@
 	};
 };
 
+&dac {
+	dmas = <&edma_lpsr0 0 189>;
+	dma-names = "tx";
+};
+
 &sai1 {
 	dmas = <&edma_lpsr0 0 54>, <&edma_lpsr0 0 55>;
 	dma-names = "rx", "tx";

--- a/dts/arm/nxp/nxp_rt11xx_cm7.dtsi
+++ b/dts/arm/nxp/nxp_rt11xx_cm7.dtsi
@@ -94,6 +94,10 @@
 	};
 };
 
+&dac {
+	dmas = <&edma0 0 189>;
+	dma-names = "tx";
+};
 
 &sai1 {
 	dmas = <&edma0 0 54>, <&edma0 0 55>;

--- a/dts/bindings/dac/nxp,dac12.yaml
+++ b/dts/bindings/dac/nxp,dac12.yaml
@@ -1,0 +1,28 @@
+# Copyright (c) 2020 Henrik Brix Andersen <henrik@brixandersen.dk>
+# Copyright (c) 2025 PHYTEC America LLC
+# SPDX-License-Identifier: Apache-2.0
+
+description: NXP MCUX DAC12
+
+compatible: "nxp,dac12"
+
+include: dac-controller.yaml
+
+properties:
+  reg:
+    required: true
+
+  voltage-reference:
+    type: int
+    required: true
+    description: DAC voltage reference select
+
+  buffered:
+    type: boolean
+    description: Enable output buffer
+
+  "#io-channel-cells":
+    const: 1
+
+io-channel-cells:
+  - output

--- a/modules/hal_nxp/mcux/mcux-sdk-ng/drivers/drivers.cmake
+++ b/modules/hal_nxp/mcux/mcux-sdk-ng/drivers/drivers.cmake
@@ -57,6 +57,7 @@ set_variable_ifdef(CONFIG_CAN_MCUX_FLEXCAN_FD   CONFIG_MCUX_COMPONENT_driver.fle
 set_variable_ifdef(CONFIG_COUNTER_NXP_PIT       CONFIG_MCUX_COMPONENT_driver.pit)
 set_variable_ifdef(CONFIG_COUNTER_MCUX_RTC      CONFIG_MCUX_COMPONENT_driver.rtc)
 set_variable_ifdef(CONFIG_DAC_MCUX_DAC          CONFIG_MCUX_COMPONENT_driver.dac)
+set_variable_ifdef(CONFIG_DAC_MCUX_DAC12        CONFIG_MCUX_COMPONENT_driver.dac12)
 set_variable_ifdef(CONFIG_DAC_MCUX_DAC32        CONFIG_MCUX_COMPONENT_driver.dac32)
 set_variable_ifdef(CONFIG_DMA_MCUX_EDMA         CONFIG_MCUX_COMPONENT_driver.dmamux)
 set_variable_ifdef(CONFIG_DMA_MCUX_EDMA_V3      CONFIG_MCUX_COMPONENT_driver.dmamux)

--- a/tests/drivers/dac/dac_api/src/test_dac.c
+++ b/tests/drivers/dac/dac_api/src/test_dac.c
@@ -106,6 +106,12 @@
 #define DAC_RESOLUTION  12
 #define DAC_CHANNEL_ID  0
 
+#elif defined(CONFIG_BOARD_MIMXRT1170_EVK)
+
+#define DAC_DEVICE_NODE		DT_NODELABEL(dac)
+#define DAC_RESOLUTION	12
+#define DAC_CHANNEL_ID	0
+
 #else
 #error "Unsupported board."
 #endif


### PR DESCRIPTION
Add driver shim for the NXP Digital-to-Analog (DAC12) module and add DAC support for RT11xx SOCs.