### PR TITLE
tests: Bluetooth: Mark generated qualification file as binaries

### DIFF
--- a/tests/bluetooth/qualification/.gitattributes
+++ b/tests/bluetooth/qualification/.gitattributes
@@ -1,0 +1,2 @@
+*.pts binary
+*.bqw binary

--- a/tests/bluetooth/qualification/ICS_Zephyr_Bluetooth_Host.bqw
+++ b/tests/bluetooth/qualification/ICS_Zephyr_Bluetooth_Host.bqw
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Qualification xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" DN="Q332723" DesignName="Zephyr Host" PathType="NewDesignNoDns" TCRL="85" xmlns="http://qualification.bluetooth.com">
   <References />
-  <Products>
+  <Products> TEST
     <Product Name="Zephyr Host" Description="host" Model="main" Website="" PublishDate="2024-11-26T00:00:00" />
   </Products>
   <Layers>

--- a/tests/bluetooth/qualification/ICS_Zephyr_Bluetooth_Host.pts
+++ b/tests/bluetooth/qualification/ICS_Zephyr_Bluetooth_Host.pts
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<project>
+<project>  TEST
   <qdid>332723</qdid>
   <name>Zephyr Host</name>
   <pics>


### PR DESCRIPTION
Those are generated files and shall not be modified to match codestyle requirements.