### PR TITLE
dts: boards: npcx*: Select `shell-uart`

### DIFF
--- a/boards/nuvoton/npcx4m8f_evb/npcx4m8f_evb.dts
+++ b/boards/nuvoton/npcx4m8f_evb/npcx4m8f_evb.dts
@@ -16,6 +16,7 @@
 	chosen {
 		zephyr,sram = &sram0;
 		zephyr,console = &uart1;
+		zephyr,shell-uart = &uart1;
 		zephyr,flash = &flash0;
 		zephyr,keyboard-scan = &kscan_input;
 	};

--- a/boards/nuvoton/npcx7m6fb_evb/npcx7m6fb_evb.dts
+++ b/boards/nuvoton/npcx7m6fb_evb/npcx7m6fb_evb.dts
@@ -15,6 +15,7 @@
 	chosen {
 		zephyr,sram = &sram0;
 		zephyr,console = &uart1;
+		zephyr,shell-uart = &uart1;
 		zephyr,flash = &flash0;
 		zephyr,keyboard-scan = &kscan_input;
 	};

--- a/boards/nuvoton/npcx9m6f_evb/npcx9m6f_evb.dts
+++ b/boards/nuvoton/npcx9m6f_evb/npcx9m6f_evb.dts
@@ -15,6 +15,7 @@
 	chosen {
 		zephyr,sram = &sram0;
 		zephyr,console = &uart1;
+		zephyr,shell-uart = &uart1;
 		zephyr,flash = &flash0;
 		zephyr,keyboard-scan = &kscan_input;
 	};


### PR DESCRIPTION
These patches set the `shell-uart` value in the Device Tree's `chosen` node. Without these changes, the `shell_module` sample does not output anything to the UART.