### PR TITLE
samples: usb: uac2: Warn about Windows driver issues

### DIFF
--- a/samples/subsys/usb/uac2_explicit_feedback/README.rst
+++ b/samples/subsys/usb/uac2_explicit_feedback/README.rst
@@ -15,6 +15,12 @@ The device running this sample presents itself to the host as a Full-Speed
 Asynchronous USB Audio 2 class device supporting 48 kHz 16-bit 2-channel
 (stereo) playback.
 
+.. warning::
+   Microsoft Windows USB Audio 2.0 driver available since Windows 10,
+   release 1703 expects Full-Speed explicit feedback endpoint wMaxPacketSize to
+   be equal 4, which violates the USB 2.0 Specification.
+   See https://aka.ms/AArvnax for Windows Feedback Hub report.
+
 Explicit Feedback
 *****************
 

--- a/samples/subsys/usb/uac2_implicit_feedback/README.rst
+++ b/samples/subsys/usb/uac2_implicit_feedback/README.rst
@@ -12,6 +12,10 @@ This sample demonstrates how to implement USB asynchronous bidirectional audio
 with implicit feedback. The host adjusts number of stereo samples sent for
 headphones playback based on the number of mono microphone samples received.
 
+.. warning::
+   Microsoft Windows USB Audio 2.0 driver available since Windows 10,
+   release 1703 does not support implicit feedback.
+
 Requirements
 ************
 


### PR DESCRIPTION
The UAC2 samples do not work with Windows UAC2 driver because:
  * driver does not support implicit feedback
  * driver expects wMaxPacketSize equal 4 on Full-Speed device

The only correct place to solve these issues is the Windows UAC2 driver.

Resolves: #77212