### PR TITLE
sample: vl53l0x: make sample testable

### DIFF
--- a/samples/sensor/vl53l0x/sample.yaml
+++ b/samples/sensor/vl53l0x/sample.yaml
@@ -2,8 +2,16 @@ sample:
   name: Sample for MEMS sensors VL53L0X
 tests:
   sample.sensor.vl53l0x:
-    build_only: true
     depends_on:
       - i2c
       - vl53l0x
-    tags: sensors
+    tags:
+      - sensors
+    integration_platforms:
+      - disco_l475_iot1
+    harness: console
+    harness_config:
+      type: multi_line
+      regex:
+        - "prox is .*"
+        - "distance is .*"


### PR DESCRIPTION
No reason for this sample to be build_only, it can run and be verified
just fine on the right platforms.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
