### PR TITLE
boards: seagate: legend: Add board revision configurations

### DIFF
--- a/boards/seagate/legend/board.yml
+++ b/boards/seagate/legend/board.yml
@@ -4,5 +4,10 @@ board:
   vendor: seagate
   revision:
     format: custom
+    default: "25hdd"
+    revisions:
+      - name: "25hdd"
+      - name: "25ssd"
+      - name: "35"
   socs:
     - name: stm32f070xb


### PR DESCRIPTION
board.yml file was missing the list of custom revisions of this board causing the impossibility to actually use this board in twister