### PR TITLE
tests: Bluetooth: Tester: VCP BSIM test

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -482,6 +482,7 @@ Bluetooth Host:
     - tests/bsim/bluetooth/hci_uart/
     - tests/bsim/bluetooth/ll/
     - tests/bsim/bluetooth/mesh/
+    - tests/bsim/bluetooth/tester/src/audio/
   labels:
     - "area: Bluetooth Host"
     - "area: Bluetooth"
@@ -536,6 +537,7 @@ Bluetooth Audio:
     - tests/bluetooth/audio/
     - tests/bsim/bluetooth/audio/
     - tests/bsim/bluetooth/audio_samples/
+    - tests/bsim/bluetooth/tester/src/audio/
     - tests/bluetooth/shell/audio.conf
     - tests/bluetooth/tester/overlay-le-audio.conf
     - tests/bluetooth/tester/overlay-bt_ll_sw_split.conf

--- a/tests/bluetooth/tester/testcase.yaml
+++ b/tests/bluetooth/tester/testcase.yaml
@@ -61,6 +61,17 @@ tests:
     tags: bluetooth
     harness: bluetooth
     sysbuild: true
+  bluetooth.general.tester_le_audio_bsim:
+    build_only: true
+    platform_allow:
+      - nrf52_bsim/native
+      - nrf5340bsim/nrf5340/cpuapp
+    extra_args:
+      - EXTRA_CONF_FILE="overlay-le-audio.conf"
+    harness: bsim
+    harness_config:
+      bsim_exe_name: tests_bluetooth_tester_le_audio_prj_conf
+    sysbuild: true
   bluetooth.general.tester_mesh:
     build_only: true
     platform_allow:

--- a/tests/bsim/bluetooth/tester/CMakeLists.txt
+++ b/tests/bsim/bluetooth/tester/CMakeLists.txt
@@ -24,6 +24,8 @@ zephyr_include_directories(
 target_sources(app PRIVATE
   src/bsim_btp.c
   src/test_main.c
+  src/audio/vcp_central.c
+  src/audio/vcp_peripheral.c
   src/host/gap_central.c
   src/host/gap_peripheral.c
 )

--- a/tests/bsim/bluetooth/tester/src/audio/vcp_central.c
+++ b/tests/bsim/bluetooth/tester/src/audio/vcp_central.c
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <stddef.h>
+#include <stdint.h>
+
+#include <zephyr/bluetooth/addr.h>
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/net_buf.h>
+#include <zephyr/sys/util_macro.h>
+
+#include "babblekit/testcase.h"
+#include "bstests.h"
+
+#include "btp/btp.h"
+#include "bsim_btp.h"
+
+LOG_MODULE_REGISTER(bsim_vcp_central, CONFIG_BSIM_BTTESTER_LOG_LEVEL);
+
+static void test_vcp_central(void)
+{
+	char addr_str[BT_ADDR_LE_STR_LEN];
+	bt_addr_le_t remote_addr;
+
+	bsim_btp_uart_init();
+
+	bsim_btp_wait_for_evt(BTP_SERVICE_ID_CORE, BTP_CORE_EV_IUT_READY, NULL);
+
+	bsim_btp_core_register(BTP_SERVICE_ID_GAP);
+	bsim_btp_core_register(BTP_SERVICE_ID_VCP);
+	bsim_btp_core_register(BTP_SERVICE_ID_VOCS);
+	bsim_btp_core_register(BTP_SERVICE_ID_AICS);
+
+	bsim_btp_gap_start_discovery(BTP_GAP_DISCOVERY_FLAG_LE);
+	bsim_btp_wait_for_gap_device_found(&remote_addr);
+	bt_addr_le_to_str(&remote_addr, addr_str, sizeof(addr_str));
+	LOG_INF("Found remote device %s", addr_str);
+
+	bsim_btp_gap_stop_discovery();
+	bsim_btp_gap_connect(&remote_addr, BTP_GAP_ADDR_TYPE_IDENTITY);
+	bsim_btp_wait_for_gap_device_connected(NULL);
+	LOG_INF("Device %s connected", addr_str);
+
+	bsim_btp_gap_pair(&remote_addr);
+	bsim_btp_wait_for_gap_sec_level_changed(NULL, NULL);
+
+	bsim_btp_vcp_discover(&remote_addr);
+	bsim_btp_wait_for_vcp_discovered(NULL);
+
+	const uint8_t new_vol = 123;
+	uint8_t ev_vol;
+
+	bsim_btp_vcp_ctlr_set_vol(&remote_addr, new_vol);
+	bsim_btp_wait_for_vcp_state(NULL, &ev_vol);
+	TEST_ASSERT(ev_vol == new_vol, "%u != %u", ev_vol, new_vol);
+
+	const int16_t new_offset = -5;
+	int16_t ev_offset;
+
+	bsim_btp_vocs_state_set(&remote_addr, new_offset);
+	bsim_btp_wait_for_vocs_state(NULL, &ev_offset);
+	TEST_ASSERT(ev_offset == new_offset, "%d != %d", ev_offset, new_offset);
+
+	const int8_t new_gain = 5;
+	int8_t ev_gain;
+
+	bsim_btp_aics_set_gain(&remote_addr, new_gain);
+	bsim_btp_wait_for_aics_state(NULL, &ev_gain);
+	TEST_ASSERT(ev_gain == new_gain, "%d != %d", ev_gain, new_gain);
+
+	bsim_btp_gap_disconnect(&remote_addr);
+	bsim_btp_wait_for_gap_device_disconnected(NULL);
+	LOG_INF("Device %s disconnected", addr_str);
+
+	TEST_PASS("PASSED\n");
+}
+
+static const struct bst_test_instance test_sample[] = {
+	{
+		.test_id = "vcp_central",
+		.test_descr = "Smoketest for the VCP central BT Tester behavior",
+		.test_main_f = test_vcp_central,
+	},
+	BSTEST_END_MARKER,
+};
+
+struct bst_test_list *test_vcp_central_install(struct bst_test_list *tests)
+{
+	return bst_add_tests(tests, test_sample);
+}

--- a/tests/bsim/bluetooth/tester/src/audio/vcp_peripheral.c
+++ b/tests/bsim/bluetooth/tester/src/audio/vcp_peripheral.c
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <stddef.h>
+#include <stdint.h>
+
+#include <zephyr/bluetooth/addr.h>
+#include <zephyr/bluetooth/gap.h>
+#include <zephyr/bluetooth/hci_types.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/sys/util_macro.h>
+
+#include "babblekit/testcase.h"
+#include "bstests.h"
+
+#include "btp/btp.h"
+#include "bsim_btp.h"
+
+LOG_MODULE_REGISTER(bsim_vcp_peripheral, CONFIG_BSIM_BTTESTER_LOG_LEVEL);
+
+static void test_vcp_peripheral(void)
+{
+	char addr_str[BT_ADDR_LE_STR_LEN];
+	bt_addr_le_t remote_addr;
+
+	bsim_btp_uart_init();
+
+	bsim_btp_wait_for_evt(BTP_SERVICE_ID_CORE, BTP_CORE_EV_IUT_READY, NULL);
+
+	bsim_btp_core_register(BTP_SERVICE_ID_GAP);
+	bsim_btp_core_register(BTP_SERVICE_ID_VCS);
+	bsim_btp_core_register(BTP_SERVICE_ID_VOCS);
+	bsim_btp_core_register(BTP_SERVICE_ID_AICS);
+
+	bsim_btp_gap_set_discoverable(BTP_GAP_GENERAL_DISCOVERABLE);
+	bsim_btp_gap_start_advertising(0U, 0U, NULL, BT_HCI_OWN_ADDR_PUBLIC);
+	bsim_btp_wait_for_gap_device_connected(&remote_addr);
+	bt_addr_le_to_str(&remote_addr, addr_str, sizeof(addr_str));
+	LOG_INF("Device %s connected", addr_str);
+	bsim_btp_wait_for_gap_device_disconnected(NULL);
+	LOG_INF("Device %s disconnected", addr_str);
+
+	TEST_PASS("PASSED\n");
+}
+
+static const struct bst_test_instance test_sample[] = {
+	{
+		.test_id = "vcp_peripheral",
+		.test_descr = "Smoketest for the VCP peripheral BT Tester behavior",
+		.test_main_f = test_vcp_peripheral,
+	},
+	BSTEST_END_MARKER,
+};
+
+struct bst_test_list *test_vcp_peripheral_install(struct bst_test_list *tests)
+{
+	return bst_add_tests(tests, test_sample);
+}

--- a/tests/bsim/bluetooth/tester/src/bsim_btp.c
+++ b/tests/bsim/bluetooth/tester/src/bsim_btp.c
@@ -192,6 +192,8 @@ static bool is_valid_gap_packet_len(const struct btp_hdr *hdr, struct net_buf_si
 		}
 	case BTP_GAP_EV_PERIODIC_TRANSFER_RECEIVED:
 		return buf_simple->len == sizeof(struct btp_gap_ev_periodic_transfer_received_ev);
+	case BTP_GAP_EV_ENCRYPTION_CHANGE:
+		return buf_simple->len == sizeof(struct btp_gap_encryption_change_ev);
 	default:
 		LOG_ERR("Unhandled opcode 0x%02X", hdr->opcode);
 		return false;

--- a/tests/bsim/bluetooth/tester/src/test_main.c
+++ b/tests/bsim/bluetooth/tester/src/test_main.c
@@ -9,10 +9,14 @@
 
 extern struct bst_test_list *test_gap_central_install(struct bst_test_list *tests);
 extern struct bst_test_list *test_gap_peripheral_install(struct bst_test_list *tests);
+extern struct bst_test_list *test_vcp_central_install(struct bst_test_list *tests);
+extern struct bst_test_list *test_vcp_peripheral_install(struct bst_test_list *tests);
 
 bst_test_install_t test_installers[] = {
 	test_gap_central_install,
 	test_gap_peripheral_install,
+	test_vcp_central_install,
+	test_vcp_peripheral_install,
 	NULL,
 };
 

--- a/tests/bsim/bluetooth/tester/tests_scripts/vcp.sh
+++ b/tests/bsim/bluetooth/tester/tests_scripts/vcp.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Copyright 2025 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+# Smoketest for VCP BTP commands with the BT tester
+
+simulation_id="tester_vcp"
+verbosity_level=2
+EXECUTE_TIMEOUT=100
+
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
+cd ${BSIM_OUT_PATH}/bin
+
+UART_DIR=/tmp/bs_${USER}/${simulation_id}/
+UART_PER=${UART_DIR}/peripheral
+UART_CEN=${UART_DIR}/central
+
+# Central BT Tester
+Execute ./bs_${BOARD_TS}_tests_bluetooth_tester_le_audio_prj_conf \
+  -v=${verbosity_level} -s=${simulation_id} -rs=10 -d=0 -RealEncryption=1 \
+  -uart0_fifob_rxfile=${UART_CEN}.tx -uart0_fifob_txfile=${UART_CEN}.rx
+
+# Central Upper Tester
+Execute ./bs_nrf52_bsim_native_tests_bsim_bluetooth_tester_prj_conf \
+  -v=${verbosity_level} -s=${simulation_id} -rs=21 -d=10 -RealEncryption=1 -testid=vcp_central \
+  -nosim -uart0_fifob_rxfile=${UART_CEN}.rx -uart0_fifob_txfile=${UART_CEN}.tx
+
+# Peripheral BT Tester
+Execute ./bs_${BOARD_TS}_tests_bluetooth_tester_le_audio_prj_conf \
+  -v=${verbosity_level} -s=${simulation_id} -rs=32 -d=1 -RealEncryption=1 \
+  -uart0_fifob_rxfile=${UART_PER}.tx -uart0_fifob_txfile=${UART_PER}.rx
+
+# Peripheral Upper Tester
+Execute ./bs_nrf52_bsim_native_tests_bsim_bluetooth_tester_prj_conf \
+  -v=${verbosity_level} -s=${simulation_id} -rs=43 -d=11 -RealEncryption=1 -testid=vcp_peripheral \
+  -nosim -uart0_fifob_rxfile=${UART_PER}.rx -uart0_fifob_txfile=${UART_PER}.tx
+
+Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} -D=2 -sim_length=20e6 $@
+
+wait_for_background_jobs # Wait for all programs in background and return != 0 if any fails


### PR DESCRIPTION
Adds BSIM testing of the VCP features of the BT Tester.

Part of https://github.com/zephyrproject-rtos/zephyr/issues/86073