### PR TITLE
doc: css: update board.css to prevent text overflow

### DIFF
--- a/doc/_extensions/zephyr/domain/static/css/board.css
+++ b/doc/_extensions/zephyr/domain/static/css/board.css
@@ -165,6 +165,7 @@
             width:190px;
             white-space: nowrap;
             text-overflow: ellipsis;
+            overflow: hidden;
         }
     }
 }


### PR DESCRIPTION
Ensure no scrollbar is ever shown when compatible overflows and gets ellipsized.