### PR TITLE
boards: nxp: Update USB testing label to point to usb_next

### DIFF
--- a/boards/nxp/mimxrt1180_evk/mimxrt1180_evk_mimxrt1189_cm33.yaml
+++ b/boards/nxp/mimxrt1180_evk/mimxrt1180_evk_mimxrt1189_cm33.yaml
@@ -27,6 +27,6 @@ supported:
   - dma
   - spi
   - watchdog
-  - usb_device
+  - usbd
   - sdhc
 vendor: nxp


### PR DESCRIPTION
The legacy USB device stack is not supported on RT1180 platform.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/85266