### PR TITLE
boards: others: promicro_nrf52840: fix pwm binding

### DIFF
--- a/boards/others/promicro_nrf52840/promicro_nrf52840-pinctrl.dtsi
+++ b/boards/others/promicro_nrf52840/promicro_nrf52840-pinctrl.dtsi
@@ -68,13 +68,13 @@
 
 	pwm0_default: pwm0_default {
 		group1 {
-			psels = <NRF_PSEL(PWM_OUT0, 0, 17)>;
+			psels = <NRF_PSEL(PWM_OUT0, 0, 15)>;
 		};
 	};
 
 	pwm0_sleep: pwm0_sleep {
 		group1 {
-			psels = <NRF_PSEL(PWM_OUT0, 0, 17)>;
+			psels = <NRF_PSEL(PWM_OUT0, 0, 15)>;
 			low-power-enable;
 		};
 	};


### PR DESCRIPTION
Tiny PR to fix small bug.

The binding was set to 17 instead of 15