### PR TITLE
drivers: flash: spi_nor: fix few printf format warnings again

### DIFF
--- a/drivers/flash/spi_nor.c
+++ b/drivers/flash/spi_nor.c
@@ -1279,8 +1279,8 @@ static int spi_nor_process_sfdp(const struct device *dev)
 	while (php != phpe) {
 		uint16_t id = jesd216_param_id(php);
 
-		LOG_INF("PH%" PRIdPTR ": %04x rev %u.%u: %u DW @ %x",
-			(php - hp->phdr), id, php->rev_major, php->rev_minor,
+		LOG_INF("PH%u: %04x rev %u.%u: %u DW @ %x",
+			(int)(php - hp->phdr), id, php->rev_major, php->rev_minor,
 			php->len_dw, jesd216_param_addr(php));
 
 		if (id == JESD216_SFDP_PARAM_ID_BFP) {


### PR DESCRIPTION
Looks like 9d5ebb3cbc3 introduced a new warning when building with runtime sfdp on 32 bit platforms. Fix it for good by just casting the operation to int and go back to use %u.

Tested with:

west build -p -b gd32f450z_eval samples/drivers/flash_shell \
	-DCONFIG_SPI_NOR_SFDP_RUNTIME=y
west build -p -b mpfs_icicle/polarfire/u54 samples/drivers/flash_shell