### PR TITLE
scripts: west: runners: stm32cubeprogrammer: Fix stm32n6 dfu flashing

### DIFF
--- a/scripts/west_commands/runners/stm32cubeprogrammer.py
+++ b/scripts/west_commands/runners/stm32cubeprogrammer.py
@@ -273,8 +273,12 @@ class STM32CubeProgrammerBinaryRunner(ZephyrBinaryRunner):
         if self._use_elf:
             # Use elf file if instructed to do so.
             dl_file = self.cfg.elf_file
-        elif self.cfg.bin_file is not None and self._download_address is not None:
-            # Use bin file if a binary is available and --download-address provided
+        elif (self.cfg.bin_file is not None and
+               (self._download_address is not None or
+                  (str(self._port).startswith("usb") and self._download_modifiers is not None))):
+            # Use bin file if a binary is available and
+            # --download-address provided
+            # or flashing by dfu (port=usb and download-modifier used)
             dl_file = self.cfg.bin_file
         elif self.cfg.hex_file is not None:
             # Neither --use-elf nor --download-address are present:


### PR DESCRIPTION
Rework of the flashing algorithm broke the STM32N6 dfu flashing.

Add the case of using usb port and download-modifier (new n6 specific option) as a new case of using the bin file for flashing.