### PR TITLE
kernel: make order_key field in thread conditional

### DIFF
--- a/include/zephyr/kernel/thread.h
+++ b/include/zephyr/kernel/thread.h
@@ -105,7 +105,9 @@ struct _thread_base {
 	int prio_deadline;
 #endif /* CONFIG_SCHED_DEADLINE */
 
+#if defined(CONFIG_SCHED_SCALABLE) || defined(CONFIG_WAITQ_SCALABLE)
 	uint32_t order_key;
+#endif
 
 #ifdef CONFIG_SMP
 	/* True for the per-CPU idle threads */

--- a/kernel/CMakeLists.txt
+++ b/kernel/CMakeLists.txt
@@ -80,10 +80,14 @@ list(APPEND kernel_files
   system_work_q.c
   work.c
   condvar.c
-  priority_queues.c
   thread.c
   sched.c
   )
+
+if (CONFIG_SCHED_SCALABLE OR CONFIG_WAITQ_SCALABLE)
+list(APPEND kernel_files priority_queues.c)
+endif()
+
 # FIXME: Once the prior pipe implementation is removed, this should be included in the above list
 if(NOT CONFIG_PIPES)
 list(APPEND kernel_files pipe.c)

--- a/kernel/include/priority_q.h
+++ b/kernel/include/priority_q.h
@@ -10,8 +10,6 @@
 #include <zephyr/sys/math_extras.h>
 #include <zephyr/sys/dlist.h>
 
-bool z_priq_rb_lessthan(struct rbnode *a, struct rbnode *b);
-
 /* Dumb Scheduling */
 #if defined(CONFIG_SCHED_DUMB)
 #define _priq_run_init		z_priq_dumb_init
@@ -185,8 +183,11 @@ static ALWAYS_INLINE struct k_thread *z_priq_dumb_mask_best(sys_dlist_t *pq)
 }
 #endif /* CONFIG_SCHED_CPU_MASK */
 
+#if defined(CONFIG_SCHED_SCALABLE) || defined(CONFIG_WAITQ_SCALABLE)
 static ALWAYS_INLINE void z_priq_rb_init(struct _priq_rb *pq)
 {
+	bool z_priq_rb_lessthan(struct rbnode *a, struct rbnode *b);
+
 	*pq = (struct _priq_rb) {
 		.tree = {
 			.lessthan_fn = z_priq_rb_lessthan,
@@ -244,6 +245,7 @@ static ALWAYS_INLINE struct k_thread *z_priq_rb_best(struct _priq_rb *pq)
 	}
 	return thread;
 }
+#endif
 
 struct prio_info {
 	uint8_t offset_prio;


### PR DESCRIPTION
The 'order_key' field in the thread structure '_thread_base' is only required when CONFIG_SCHED_SCALABLE and/or CONFIG_WAITQ_SCALABLE are enabled (neither of which is a default setting). Making the existence of this field conditional slightly reduces the size of the k_thread structure when neither of those Kconfig options are selected.