### PR TITLE
drivers: spi_nxp_lpspi: Fix slave select and add pcsActiveHighOrLow

### DIFF
--- a/drivers/spi/spi_nxp_lpspi/spi_nxp_lpspi_common.c
+++ b/drivers/spi/spi_nxp_lpspi/spi_nxp_lpspi_common.c
@@ -56,7 +56,7 @@ int spi_mcux_configure(const struct device *dev, const struct spi_config *spi_cf
 		return -EINVAL;
 	}
 
-	if (spi_cfg->slave > LPSPI_CHIP_SELECT_COUNT) {
+	if (spi_cfg->slave > (LPSPI_CHIP_SELECT_COUNT - 1)) {
 		LOG_ERR("Peripheral %d select exceeds max %d", spi_cfg->slave,
 			LPSPI_CHIP_SELECT_COUNT - 1);
 		return -EINVAL;
@@ -103,6 +103,9 @@ int spi_mcux_configure(const struct device *dev, const struct spi_config *spi_cf
 	master_config.pcsToSckDelayInNanoSec = config->pcs_sck_delay;
 	master_config.lastSckToPcsDelayInNanoSec = config->sck_pcs_delay;
 	master_config.betweenTransferDelayInNanoSec = config->transfer_delay;
+	master_config.whichPcs = spi_cfg->slave + kLPSPI_Pcs0;
+	master_config.pcsActiveHighOrLow = (spi_cfg->operation & SPI_CS_ACTIVE_HIGH)
+				    ? kLPSPI_PcsActiveHigh : kLPSPI_PcsActiveLow;
 	master_config.pinCfg = config->data_pin_config;
 	master_config.dataOutConfig = config->output_config ? kLpspiDataOutTristate :
 							      kLpspiDataOutRetained;


### PR DESCRIPTION
1. Set correct slave chip select instead of hardcoding to pcs 0.
2. Add pcsActiveHighOrLow configuration for handling active-high/low CS.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/86689