### PR TITLE
boards: raspberrypi: Make use of the newly generated features tables

### DIFF
--- a/boards/raspberrypi/rpi_4b/doc/index.rst
+++ b/boards/raspberrypi/rpi_4b/doc/index.rst
@@ -10,24 +10,8 @@ see <https://www.raspberrypi.com/documentation/computers/raspberry-pi.html>
 
 Supported Features
 ==================
-The Raspberry Pi 4 Model B board configuration supports the following
-hardware features:
 
-.. list-table::
-   :header-rows: 1
-
-   * - Peripheral
-     - Kconfig option
-     - Devicetree compatible
-   * - GIC-400
-     - N/A
-     - :dtcompatible:`arm,gic-v2`
-   * - GPIO
-     - :kconfig:option:`CONFIG_GPIO`
-     - :dtcompatible:`brcm,bcm2711-gpio`
-   * - UART (Mini UART)
-     - :kconfig:option:`CONFIG_SERIAL`
-     - :dtcompatible:`brcm,bcm2711-aux-uart`
+.. zephyr:board-supported-hw::
 
 Other hardware features have not been enabled yet for this board.
 

--- a/boards/raspberrypi/rpi_5/doc/index.rst
+++ b/boards/raspberrypi/rpi_5/doc/index.rst
@@ -29,29 +29,7 @@ Hardware
 Supported Features
 ==================
 
-The Raspberry Pi 5 board configuration supports the following hardware features:
-
-.. list-table::
-   :header-rows: 1
-
-   * - Peripheral
-     - Kconfig option
-     - Devicetree compatible
-   * - GIC-400
-     - N/A
-     - :dtcompatible:`arm,gic-v2`
-   * - GPIO
-     - :kconfig:option:`CONFIG_GPIO`
-     - :dtcompatible:`raspberrypi,rp1-gpio`
-   * - GPIO (Internal)
-     - :kconfig:option:`CONFIG_GPIO`
-     - :dtcompatible:`brcm,brcmstb-gpio`
-   * - UART
-     - :kconfig:option:`CONFIG_SERIAL`
-     - :dtcompatible:`arm,pl011`
-   * - PCIE
-     - :kconfig:option:`CONFIG_PCIE`
-     - :dtcompatible:`brcm,brcmstb-pcie`
+.. zephyr:board-supported-hw::
 
 Not all hardware features are supported yet. See `Raspberry Pi hardware`_ for the complete list of hardware features.
 

--- a/boards/raspberrypi/rpi_pico/doc/index.rst
+++ b/boards/raspberrypi/rpi_pico/doc/index.rst
@@ -48,51 +48,7 @@ Hardware
 Supported Features
 ==================
 
-The ``rpi_pico`` board configuration supports the following
-hardware features:
-
-.. list-table::
-   :header-rows: 1
-
-   * - Peripheral
-     - Kconfig option
-     - Devicetree compatible
-   * - NVIC
-     - N/A
-     - :dtcompatible:`arm,v6m-nvic`
-   * - UART
-     - :kconfig:option:`CONFIG_SERIAL`
-     - :dtcompatible:`raspberrypi,pico-uart`
-   * - GPIO
-     - :kconfig:option:`CONFIG_GPIO`
-     - :dtcompatible:`raspberrypi,pico-gpio`
-   * - ADC
-     - :kconfig:option:`CONFIG_ADC`
-     - :dtcompatible:`raspberrypi,pico-adc`
-   * - I2C
-     - :kconfig:option:`CONFIG_I2C`
-     - :dtcompatible:`snps,designware-i2c`
-   * - SPI
-     - :kconfig:option:`CONFIG_SPI`
-     - :dtcompatible:`raspberrypi,pico-spi`
-   * - USB Device
-     - :kconfig:option:`CONFIG_USB_DEVICE_STACK`
-     - :dtcompatible:`raspberrypi,pico-usbd`
-   * - HWINFO
-     - :kconfig:option:`CONFIG_HWINFO`
-     - N/A
-   * - Watchdog Timer (WDT)
-     - :kconfig:option:`CONFIG_WATCHDOG`
-     - :dtcompatible:`raspberrypi,pico-watchdog`
-   * - PWM
-     - :kconfig:option:`CONFIG_PWM`
-     - :dtcompatible:`raspberrypi,pico-pwm`
-   * - Flash
-     - :kconfig:option:`CONFIG_FLASH`
-     - :dtcompatible:`raspberrypi,pico-flash-controller`
-   * - Clock controller
-     - :kconfig:option:`CONFIG_CLOCK_CONTROL`
-     - :dtcompatible:`raspberrypi,pico-clock-controller`
+.. zephyr:board-supported-hw::
 
 .. _rpi_pico_pin_mapping:
 

--- a/boards/raspberrypi/rpi_pico2/doc/index.rst
+++ b/boards/raspberrypi/rpi_pico2/doc/index.rst
@@ -30,51 +30,7 @@ Hardware
 Supported Features
 ==================
 
-The ``rpi_pico2/rp2350a/m33`` board target supports the following
-hardware features:
-
-.. list-table::
-   :header-rows: 1
-
-   * - Peripheral
-     - Kconfig option
-     - Devicetree compatible
-   * - NVIC
-     - N/A
-     - :dtcompatible:`arm,v8m-nvic`
-   * - ADC
-     - :kconfig:option:`CONFIG_ADC`
-     - :dtcompatible:`raspberrypi,pico-adc`
-   * - Clock controller
-     - :kconfig:option:`CONFIG_CLOCK_CONTROL`
-     - :dtcompatible:`raspberrypi,pico-clock-controller`
-   * - Counter
-     - :kconfig:option:`CONFIG_COUNTER`
-     - :dtcompatible:`raspberrypi,pico-timer`
-   * - DMA
-     - :kconfig:option:`CONFIG_DMA`
-     - :dtcompatible:`raspberrypi,pico-dma`
-   * - GPIO
-     - :kconfig:option:`CONFIG_GPIO`
-     - :dtcompatible:`raspberrypi,pico-gpio`
-   * - HWINFO
-     - :kconfig:option:`CONFIG_HWINFO`
-     - N/A
-   * - I2C
-     - :kconfig:option:`CONFIG_I2C`
-     - :dtcompatible:`snps,designware-i2c`
-   * - PWM
-     - :kconfig:option:`CONFIG_PWM`
-     - :dtcompatible:`raspberrypi,pico-pwm`
-   * - SPI
-     - :kconfig:option:`CONFIG_SPI`
-     - :dtcompatible:`raspberrypi,pico-spi`
-   * - UART
-     - :kconfig:option:`CONFIG_SERIAL`
-     - :dtcompatible:`raspberrypi,pico-uart`
-   * - UART (PIO)
-     - :kconfig:option:`CONFIG_SERIAL`
-     - :dtcompatible:`raspberrypi,pico-uart-pio`
+.. zephyr:board-supported-hw::
 
 Connections and IOs
 ===================


### PR DESCRIPTION
Replace the manually maintained features table by the tables generated from device tree boards description.

This replicates ST's approach from e5db751.