### PR TITLE
dts:arm:st:l4 - Added dcmi support for stm32l4

### DIFF
--- a/dts/arm/st/l4/stm32l4.dtsi
+++ b/dts/arm/st/l4/stm32l4.dtsi
@@ -512,6 +512,15 @@
 				reg = <0x5>;
 			};
 		};
+		dcmi: dcmi@50050000 {
+			compatible = "st,stm32-dcmi";
+			reg = <0x50050000 0x400>;
+			interrupts = <85 0>;
+			interrupt-names = "dcmi";
+			clocks = <&rcc STM32_CLOCK(AHB2, 14U)>;
+			status = "disabled";
+		};
+		
 	};
 
 	die_temp: dietemp {


### PR DESCRIPTION
1. Added dcmi support for stm32l4 based microcontrollers
2. Tested this support with stm32l4r9i-disco with ov5640 , will create a pr for that with a sample project

Reference manual (RM0432) page 97 for dcmi register address and size
Reference manual (RM0432) page 289 for dcmi clock bus and enr bit position

Signed-off-by: Aditya Ganesh <adityaganesh2k@gmail.com>
