### PR TITLE
drivers: dac: Add support DAC for Renesas RA4

### DIFF
--- a/boards/renesas/ek_ra4l1/ek_ra4l1-pinctrl.dtsi
+++ b/boards/renesas/ek_ra4l1/ek_ra4l1-pinctrl.dtsi
@@ -30,6 +30,14 @@
 		};
 	};
 
+	dac0_default: dac0_default {
+		group1 {
+			/* output */
+			psels = <RA_PSEL(RA_PSEL_DAC, 0, 4)>;
+			renesas,analog-enable;
+		};
+	};
+
 	pwm1_default: pwm1_default {
 		group1 {
 			/* GTIOC1A GTIOC1B */

--- a/boards/renesas/ek_ra4l1/ek_ra4l1.dts
+++ b/boards/renesas/ek_ra4l1/ek_ra4l1.dts
@@ -141,6 +141,12 @@
 	pinctrl-names = "default";
 };
 
+&dac0 {
+	pinctrl-0 = <&dac0_default>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
 &port_irq6 {
 	interrupts = <14 12>;
 	status = "okay";

--- a/boards/renesas/ek_ra4m1/ek_ra4m1-pinctrl.dtsi
+++ b/boards/renesas/ek_ra4m1/ek_ra4m1-pinctrl.dtsi
@@ -30,6 +30,14 @@
 		};
 	};
 
+	dac0_default: dac0_default {
+		group1 {
+			/* output */
+			psels = <RA_PSEL(RA_PSEL_DAC, 0, 14)>;
+			renesas,analog-enable;
+		};
+	};
+
 	pwm1_default: pwm1_default {
 		group1 {
 			/* GTIOC1A GTIOC1B */

--- a/boards/renesas/ek_ra4m1/ek_ra4m1.dts
+++ b/boards/renesas/ek_ra4m1/ek_ra4m1.dts
@@ -102,6 +102,12 @@
 	pinctrl-names = "default";
 };
 
+&dac0 {
+	pinctrl-0 = <&dac0_default>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
 &port_irq0 {
 	interrupts = <27 12>;
 	status = "okay";

--- a/boards/renesas/ek_ra4w1/ek_ra4w1-pinctrl.dtsi
+++ b/boards/renesas/ek_ra4w1/ek_ra4w1-pinctrl.dtsi
@@ -30,6 +30,14 @@
 		};
 	};
 
+	dac0_default: dac0_default {
+		group1 {
+			/* output */
+			psels = <RA_PSEL(RA_PSEL_DAC, 0, 14)>;
+			renesas,analog-enable;
+		};
+	};
+
 	pwm1_default: pwm1_default {
 		group1 {
 			/* GTIOC1A GTIOC1B */

--- a/boards/renesas/ek_ra4w1/ek_ra4w1.dts
+++ b/boards/renesas/ek_ra4w1/ek_ra4w1.dts
@@ -90,6 +90,12 @@
 	pinctrl-names = "default";
 };
 
+&dac0 {
+	pinctrl-0 = <&dac0_default>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
 &port_irq4 {
 	interrupts = <27 12>;
 	status = "okay";

--- a/boards/renesas/fpb_ra4e1/fpb_ra4e1-pinctrl.dtsi
+++ b/boards/renesas/fpb_ra4e1/fpb_ra4e1-pinctrl.dtsi
@@ -39,6 +39,14 @@
 		};
 	};
 
+	dac0_default: dac0_default {
+		group1 {
+			/* output */
+			psels = <RA_PSEL(RA_PSEL_DAC, 0, 14)>;
+			renesas,analog-enable;
+		};
+	};
+
 	pwm1_default: pwm1_default {
 		group1 {
 			/* GTIOC1A GTIOC1B */

--- a/boards/renesas/fpb_ra4e1/fpb_ra4e1.dts
+++ b/boards/renesas/fpb_ra4e1/fpb_ra4e1.dts
@@ -120,6 +120,12 @@
 	pinctrl-names = "default";
 };
 
+&dac0 {
+	pinctrl-0 = <&dac0_default>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
 &port_irq1 {
 	interrupts = <41 12>;
 	status = "okay";

--- a/boards/renesas/voice_ra4e1/voice_ra4e1-pinctrl.dtsi
+++ b/boards/renesas/voice_ra4e1/voice_ra4e1-pinctrl.dtsi
@@ -19,4 +19,12 @@
 			drive-strength = "high";
 		};
 	};
+
+	dac0_default: dac0_default {
+		group1 {
+			/* output */
+			psels = <RA_PSEL(RA_PSEL_DAC, 0, 14)>;
+			renesas,analog-enable;
+		};
+	};
 };

--- a/boards/renesas/voice_ra4e1/voice_ra4e1.dts
+++ b/boards/renesas/voice_ra4e1/voice_ra4e1.dts
@@ -138,3 +138,9 @@
 &wdt {
 	status = "okay";
 };
+
+&dac0 {
+	pinctrl-0 = <&dac0_default>;
+	pinctrl-names = "default";
+	status = "okay";
+};

--- a/drivers/dac/dac_renesas_ra.c
+++ b/drivers/dac/dac_renesas_ra.c
@@ -14,6 +14,10 @@
 
 LOG_MODULE_REGISTER(dac_renesas_ra, CONFIG_DAC_LOG_LEVEL);
 
+#define HAS_CHARGEPUMP       DT_PROP(DT_PARENT(DT_DRV_INST(0)), has_chargepump)
+#define HAS_OUTPUT_AMPLIFIER DT_PROP(DT_PARENT(DT_DRV_INST(0)), has_output_amplifier)
+#define HAS_INTERNAL_OUTPUT  DT_PROP(DT_PARENT(DT_DRV_INST(0)), has_internal_output)
+
 struct dac_renesas_ra_config {
 	const struct pinctrl_dev_config *pcfg;
 };
@@ -46,7 +50,9 @@ static int dac_renesas_ra_channel_setup(const struct device *dev,
 					const struct dac_channel_cfg *channel_cfg)
 {
 	struct dac_renesas_ra_data *data = dev->data;
+#if (HAS_OUTPUT_AMPLIFIER || HAS_CHARGEPUMP || HAS_INTERNAL_OUTPUT)
 	dac_extended_cfg_t *config_extend = (dac_extended_cfg_t *)data->f_config.p_extend;
+#endif
 	fsp_err_t fsp_err;
 
 	if (channel_cfg->channel_id != 0) {
@@ -66,9 +72,9 @@ static int dac_renesas_ra_channel_setup(const struct device *dev,
 		}
 	}
 
-#if DT_PROP(DT_PARENT(DT_DRV_INST(0)), has_output_amplifier)
+#if HAS_OUTPUT_AMPLIFIER
 	config_extend->output_amplifier_enabled = channel_cfg->buffered;
-#elif DT_PROP(DT_PARENT(DT_DRV_INST(0)), has_chargepump)
+#elif HAS_CHARGEPUMP
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(moco))
 	config_extend->enable_charge_pump = channel_cfg->buffered;
 #else
@@ -84,7 +90,7 @@ static int dac_renesas_ra_channel_setup(const struct device *dev,
 	}
 #endif
 
-#if DT_PROP(DT_PARENT(DT_DRV_INST(0)), has_internal_output)
+#if HAS_INTERNAL_OUTPUT
 	config_extend->internal_output_enabled = channel_cfg->internal;
 #else
 	if (channel_cfg->internal) {

--- a/dts/arm/renesas/ra/ra4/r7fa4e10x.dtsi
+++ b/dts/arm/renesas/ra/ra4/r7fa4e10x.dtsi
@@ -11,6 +11,7 @@
 /delete-node/ &spi1;
 /delete-node/ &agt4;
 /delete-node/ &adc1;
+/delete-node/ &dac1;
 /delete-node/ &iic1;
 /delete-node/ &pwm0;
 
@@ -258,4 +259,8 @@
 	port-irq5-pins = <1 10>;
 	port-irq6-pins = <9>;
 	port-irq7-pins = <8>;
+};
+
+&dac_global {
+	has-output-amplifier;
 };

--- a/dts/arm/renesas/ra/ra4/r7fa4l1bx.dtsi
+++ b/dts/arm/renesas/ra/ra4/r7fa4l1bx.dtsi
@@ -244,6 +244,21 @@
 			status = "disabled";
 		};
 
+		dac_global: dac_global@40171000 {
+			compatible = "renesas,ra-dac-global";
+			reg = <0x40171000 0x10c4>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			has-davrefcr;
+
+			dac0: dac@0 {
+				compatible = "renesas,ra-dac";
+				#io-channel-cells = <1>;
+				reg = <0>;
+				status = "disabled";
+			};
+		};
+
 		iic0: iic0@4009f000 {
 			compatible = "renesas,ra-iic";
 			channel = <0>;

--- a/dts/arm/renesas/ra/ra4/r7fa4m1ax.dtsi
+++ b/dts/arm/renesas/ra/ra4/r7fa4m1ax.dtsi
@@ -333,3 +333,7 @@
 &pwm3 {
 	clocks = <&pclkd MSTPD 6>;
 };
+
+&dac_global {
+	has-davrefcr;
+};

--- a/dts/arm/renesas/ra/ra4/r7fa4w1ad2cng.dtsi
+++ b/dts/arm/renesas/ra/ra4/r7fa4w1ad2cng.dtsi
@@ -237,3 +237,7 @@
 &pwm3 {
 	clocks = <&pclkd MSTPD 5>;
 };
+
+&dac_global {
+	has-davrefcr;
+};

--- a/dts/arm/renesas/ra/ra4/ra4-cm4-common.dtsi
+++ b/dts/arm/renesas/ra/ra4/ra4-cm4-common.dtsi
@@ -218,6 +218,21 @@
 			status = "disabled";
 		};
 
+		dac_global: dac_global@4005e000 {
+			compatible = "renesas,ra-dac-global";
+			reg = <0x4005e000 0x10c4>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			dac0: dac@0 {
+				compatible = "renesas,ra-dac";
+				#io-channel-cells = <1>;
+				reg = <0>;
+				status = "disabled";
+			};
+		};
+
 		iic0: iic0@40053000 {
 			compatible = "renesas,ra-iic";
 			channel = <0>;

--- a/dts/bindings/dac/renesas,ra-dac-global.yaml
+++ b/dts/bindings/dac/renesas,ra-dac-global.yaml
@@ -10,16 +10,24 @@ include: [base.yaml]
 properties:
   has-internal-output:
     type: boolean
-    description: True if the SoC supports the internal output feature in the DAC HWIP
+    description: |
+      True if the SoC supports the "internal output" feature in the DAC HWIP.
+      Note: If the SoC doesn't support this "internal output" features,
+            it cannot support the "internal" feature.
 
   has-output-amplifier:
     type: boolean
-    description: True if the SoC supports the output amplifier feature in the DAC HWIP
+    description: |
+      True if the SoC supports the "output amplifier" feature in the DAC HWIP.
 
   has-chargepump:
     type: boolean
-    description: True if the SoC supports the chargepump feature in the DAC HWIP
+    description: |
+      True if the SoC supports the "chargepump" feature in the DAC HWIP.
+      Note: If the SoC doesn't support the "output amplifier" and "charge pump" features,
+            it cannot support the "buffer" feature.
 
   has-davrefcr:
     type: boolean
-    description: True if the SoC supports the D/A VREF configuration in the DAC HWIP
+    description: |
+      True if the SoC supports the D/A VREF configuration in the DAC HWIP.

--- a/samples/drivers/dac/Kconfig
+++ b/samples/drivers/dac/Kconfig
@@ -1,6 +1,7 @@
 # Private config options for dac sample
 
 # Copyright (c) 2025 NXP
+# Copyright (c) 2025 Renesas Electronics Corporation
 # SPDX-License-Identifier: Apache-2.0
 
 mainmenu "DAC sample application"
@@ -14,3 +15,8 @@ config DAC_SAMPLE_RUN
 	default y if $(dt_node_has_prop,/$(ZEPHYR_USER),dac)
 	help
 	  platform supports dac sample
+
+config DAC_BUFFER_NOT_SUPPORT
+	bool "DAC on board/SoC does not support output buffer mode"
+	help
+	  If this config is turned on, the sample will run with no output buffer enabled

--- a/samples/drivers/dac/boards/ek_ra4l1.conf
+++ b/samples/drivers/dac/boards/ek_ra4l1.conf
@@ -1,0 +1,4 @@
+# Copyright (c) 2025 Renesas Electronics Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_DAC_BUFFER_NOT_SUPPORT=y

--- a/samples/drivers/dac/boards/ek_ra4l1.overlay
+++ b/samples/drivers/dac/boards/ek_ra4l1.overlay
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	zephyr,user {
+		dac = <&dac0>;
+		dac-channel-id = <0>;
+		dac-resolution = <12>;
+	};
+};

--- a/samples/drivers/dac/boards/ek_ra4m1.conf
+++ b/samples/drivers/dac/boards/ek_ra4m1.conf
@@ -1,0 +1,4 @@
+# Copyright (c) 2025 Renesas Electronics Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_DAC_BUFFER_NOT_SUPPORT=y

--- a/samples/drivers/dac/boards/ek_ra4m1.overlay
+++ b/samples/drivers/dac/boards/ek_ra4m1.overlay
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	zephyr,user {
+		dac = <&dac0>;
+		dac-channel-id = <0>;
+		dac-resolution = <12>;
+	};
+};

--- a/samples/drivers/dac/boards/ek_ra4w1.conf
+++ b/samples/drivers/dac/boards/ek_ra4w1.conf
@@ -1,0 +1,4 @@
+# Copyright (c) 2025 Renesas Electronics Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_DAC_BUFFER_NOT_SUPPORT=y

--- a/samples/drivers/dac/boards/ek_ra4w1.overlay
+++ b/samples/drivers/dac/boards/ek_ra4w1.overlay
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	zephyr,user {
+		dac = <&dac0>;
+		dac-channel-id = <0>;
+		dac-resolution = <12>;
+	};
+};

--- a/samples/drivers/dac/boards/fpb_ra4e1.overlay
+++ b/samples/drivers/dac/boards/fpb_ra4e1.overlay
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	zephyr,user {
+		dac = <&dac0>;
+		dac-channel-id = <0>;
+		dac-resolution = <12>;
+	};
+};

--- a/samples/drivers/dac/boards/voice_ra4e1.overlay
+++ b/samples/drivers/dac/boards/voice_ra4e1.overlay
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	zephyr,user {
+		dac = <&dac0>;
+		dac-channel-id = <0>;
+		dac-resolution = <12>;
+	};
+};

--- a/samples/drivers/dac/src/main.c
+++ b/samples/drivers/dac/src/main.c
@@ -28,7 +28,11 @@ static const struct device *const dac_dev = DEVICE_DT_GET(DAC_NODE);
 static const struct dac_channel_cfg dac_ch_cfg = {
 	.channel_id  = DAC_CHANNEL_ID,
 	.resolution  = DAC_RESOLUTION,
-	.buffered = true
+#if defined(CONFIG_DAC_BUFFER_NOT_SUPPORT)
+	.buffered = false,
+#else
+	.buffered = true,
+#endif /* CONFIG_DAC_BUFFER_NOT_SUPPORT */
 };
 
 int main(void)

--- a/tests/drivers/dac/dac_api/Kconfig
+++ b/tests/drivers/dac/dac_api/Kconfig
@@ -1,0 +1,11 @@
+# Copyright (c) 2025 Renesas Electronics Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+mainmenu "DAC API test"
+
+source "Kconfig.zephyr"
+
+config DAC_BUFFER_NOT_SUPPORT
+	bool "DAC on board/SoC does not support output buffer mode"
+	help
+	  If this config is turned on, the test will run with no output buffer enabled

--- a/tests/drivers/dac/dac_api/boards/ek_ra4l1.conf
+++ b/tests/drivers/dac/dac_api/boards/ek_ra4l1.conf
@@ -1,0 +1,4 @@
+# Copyright (c) 2025 Renesas Electronics Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_DAC_BUFFER_NOT_SUPPORT=y

--- a/tests/drivers/dac/dac_api/boards/ek_ra4m1.conf
+++ b/tests/drivers/dac/dac_api/boards/ek_ra4m1.conf
@@ -1,0 +1,4 @@
+# Copyright (c) 2025 Renesas Electronics Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_DAC_BUFFER_NOT_SUPPORT=y

--- a/tests/drivers/dac/dac_api/boards/ek_ra4w1.conf
+++ b/tests/drivers/dac/dac_api/boards/ek_ra4w1.conf
@@ -1,0 +1,4 @@
+# Copyright (c) 2025 Renesas Electronics Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_DAC_BUFFER_NOT_SUPPORT=y

--- a/tests/drivers/dac/dac_api/src/test_dac.c
+++ b/tests/drivers/dac/dac_api/src/test_dac.c
@@ -110,9 +110,13 @@
 #endif
 
 static const struct dac_channel_cfg dac_ch_cfg = {
-	.channel_id  = DAC_CHANNEL_ID,
-	.resolution  = DAC_RESOLUTION,
-	.buffered = true
+	.channel_id = DAC_CHANNEL_ID,
+	.resolution = DAC_RESOLUTION,
+#if defined(CONFIG_DAC_BUFFER_NOT_SUPPORT)
+	.buffered = false,
+#else
+	.buffered = true,
+#endif /* CONFIG_DAC_BUFFER_NOT_SUPPORT */
 };
 
 const struct device *get_dac_device(void)

--- a/tests/drivers/dac/dac_loopback/Kconfig
+++ b/tests/drivers/dac/dac_loopback/Kconfig
@@ -1,0 +1,11 @@
+# Copyright (c) 2025 Renesas Electronics Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+mainmenu "DAC Loopback test"
+
+source "Kconfig.zephyr"
+
+config DAC_BUFFER_NOT_SUPPORT
+	bool "DAC on board/SoC does not support output buffer mode"
+	help
+	  If this config is turned on, the test will run with no output buffer enabled

--- a/tests/drivers/dac/dac_loopback/boards/ek_ra4l1.conf
+++ b/tests/drivers/dac/dac_loopback/boards/ek_ra4l1.conf
@@ -1,0 +1,4 @@
+# Copyright (c) 2025 Renesas Electronics Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_DAC_BUFFER_NOT_SUPPORT=y

--- a/tests/drivers/dac/dac_loopback/boards/ek_ra4m1.conf
+++ b/tests/drivers/dac/dac_loopback/boards/ek_ra4m1.conf
@@ -1,0 +1,4 @@
+# Copyright (c) 2025 Renesas Electronics Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_DAC_BUFFER_NOT_SUPPORT=y

--- a/tests/drivers/dac/dac_loopback/boards/ek_ra4w1.conf
+++ b/tests/drivers/dac/dac_loopback/boards/ek_ra4w1.conf
@@ -1,0 +1,4 @@
+# Copyright (c) 2025 Renesas Electronics Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_DAC_BUFFER_NOT_SUPPORT=y

--- a/tests/drivers/dac/dac_loopback/src/test_dac.c
+++ b/tests/drivers/dac/dac_loopback/src/test_dac.c
@@ -176,7 +176,13 @@
 #define ADC_GAIN             ADC_GAIN_1
 #define ADC_REFERENCE        ADC_REF_INTERNAL
 #define ADC_ACQUISITION_TIME ADC_ACQ_TIME_DEFAULT
-#define ADC_CHANNEL_ID       0
+#if defined(CONFIG_BOARD_EK_RA4L1)
+#define ADC_CHANNEL_ID 1
+#elif defined(CONFIG_BOARD_EK_RA4W1)
+#define ADC_CHANNEL_ID 4
+#else
+#define ADC_CHANNEL_ID 0
+#endif
 
 #else
 #error "Unsupported board."
@@ -185,7 +191,11 @@
 static const struct dac_channel_cfg dac_ch_cfg = {
 	.channel_id = DAC_CHANNEL_ID,
 	.resolution = DAC_RESOLUTION,
-	.buffered = true
+#if defined(CONFIG_DAC_BUFFER_NOT_SUPPORT)
+	.buffered = false,
+#else
+	.buffered = true,
+#endif /* CONFIG_DAC_BUFFER_NOT_SUPPORT */
 };
 
 static const struct adc_channel_cfg adc_ch_cfg = {


### PR DESCRIPTION
Add support DAC for Renesas:
- ek_ra4m1
- ek_ra4w1
- ek_ra4l1
- fpb_ra4e1
- voice_ra4e1

- [x] This PR need #86602 to be merged first