### PR TITLE
FRDM-RW612: LED hsgpio0 is GPIO_ACTIVE_LOW

### DIFF
--- a/boards/nxp/frdm_rw612/frdm_rw612_common.dtsi
+++ b/boards/nxp/frdm_rw612/frdm_rw612_common.dtsi
@@ -30,7 +30,7 @@
 	leds {
 		compatible = "gpio-leds";
 		green_led: led_1 {
-			gpios = <&hsgpio0 12 0>;
+			gpios = <&hsgpio0 12 GPIO_ACTIVE_LOW>;
 		};
 	};
 };


### PR DESCRIPTION
## LED Configuration Issue on FRDM-RW612

The LED on the FRDM-RW612 is currently configured incorrectly. It should be set as `GPIO_ACTIVE_LOW`. 

### Example

In the [HTTP Server sample application](https://github.com/zephyrproject-rtos/zephyr/tree/main/samples/net/sockets/http_server), the LED turns on when the "Turn Off" button is pressed. This behavior indicates that the LED configuration needs to be adjusted to function as intended.