### PR TITLE
new pinctrl DTSI files definition for the stm32 devices

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -238,7 +238,7 @@ manifest:
       groups:
         - hal
     - name: hal_stm32
-      revision: b3e05b628764352ee21ba23ac39418f8c953bc51
+      revision: edd82557d92d85a9e79c9568a562600c712dfb52
       path: modules/hal/stm32
       groups:
         - hal


### PR DESCRIPTION
This PR is taking the new pinctrl files https://github.com/zephyrproject-rtos/hal_stm32/pull/265



Only the stm32wba and the stm32U5 declare a the swj_port
On the stm32H5 : the swj_port node is not declared  ; if it should be, note that  the ..\modules\hal\stm32\dts\st\h5  defines a **debug_njtrst_pb4**  or **debug_jtrst_pb4** depending on the stm32h5xx device



