### PR TITLE
Minor fixes for various bindings' description

### DIFF
--- a/dts/bindings/binding-types.txt
+++ b/dts/bindings/binding-types.txt
@@ -76,8 +76,8 @@ memory-controllers	Memory controller
 memory-window	Memory window
 mfd	Multi-Function Device
 mhu	Mailbox Handling Unit
-mipi-dbi	Mobile Industry Processor Interface Display Bus Interface
-mipi-dsi	Mobile Industry Processor Interface Display Serial Interface
+mipi-dbi	MIPI-DBI (Mobile Industry Processor Interface Display Bus Interface)
+mipi-dsi	MIPI-DSI (Mobile Industry Processor Interface Display Serial Interface)
 misc	Miscellaneous
 mm	Memory management
 mmc	MMC (MultiMedia Card)

--- a/dts/bindings/gpio/arduino-mkr-header.yaml
+++ b/dts/bindings/gpio/arduino-mkr-header.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-    GPIO pins exposing on Arduino MKR headers.
+    GPIO pins exposed on Arduino MKR headers.
 
     The Arduino MKR layout provides two headers on both edges of the board.
 

--- a/dts/bindings/gpio/grove-header.yaml
+++ b/dts/bindings/gpio/grove-header.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-    GPIO pins exposing on Grove 4 pins headers.
+    GPIO pins exposed on Grove 4 pins headers.
 
     This binding provides a nexus mapping for 2 pins as depicted below.
 

--- a/dts/bindings/input/gpio-keys.yaml
+++ b/dts/bindings/input/gpio-keys.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-  Zephyr Input GPIO KEYS parent node
+  Group of GPIO-bound input keys.
 
   This defines a group of buttons that can generate input events. Each button
   is defined in a child node of the gpio-keys node and defines a specific key

--- a/dts/bindings/led/gpio-leds.yaml
+++ b/dts/bindings/led/gpio-leds.yaml
@@ -2,9 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-  This allows you to define a group of LEDs. Each LED in the group is
-  controlled by a GPIO. Each LED is defined in a child node of the
-  gpio-leds node.
+  Group of GPIO-controlled LEDs.
+
+  Each LED is defined in a child node of the gpio-leds node.
 
   Here is an example which defines three LEDs in the node /leds:
 

--- a/dts/bindings/led/pwm-leds.yaml
+++ b/dts/bindings/led/pwm-leds.yaml
@@ -1,7 +1,10 @@
 # Copyright (c) 2018, Linaro Limited
 # SPDX-License-Identifier: Apache-2.0
 
-description: PWM LEDs parent node
+description: |
+  Group of PWM-controlled LEDs.
+
+  Each LED is defined in a child node of the pwm-leds node.
 
 compatible: "pwm-leds"
 

--- a/dts/bindings/mtd/fixed-partitions.yaml
+++ b/dts/bindings/mtd/fixed-partitions.yaml
@@ -1,6 +1,5 @@
 description: |
-  This binding is used to describe fixed partitions of a flash (or
-  other nonvolatile storage) memory.
+  Fixed partitions of a flash (or other non-volatile storage) memory.
 
   Here is an example:
 

--- a/dts/bindings/sensor/invensense,icm42688.yaml
+++ b/dts/bindings/sensor/invensense,icm42688.yaml
@@ -4,7 +4,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-    ICM-42688 motion tracking device
+    ICM-42688 motion tracking device.
+
     When setting the accel-pm, accel-range, accel-odr, gyro-pm, gyro-range,
     gyro-odr properties in a .dts or .dtsi file you may include icm42688.h
     and use the macros defined there.


### PR DESCRIPTION
Fix MIPI acronyms not being defined the same way
as other acronyms.

Fix/clarify descriptions for several Devicetree bindings.
