### PR TITLE
scripts: support number of jobs and verbosity in west build.

### DIFF
--- a/doc/build/sysbuild/index.rst
+++ b/doc/build/sysbuild/index.rst
@@ -143,6 +143,25 @@ As mentioned above, you can run sysbuild via ``west build`` or ``cmake``.
       an extra CMake argument. ``APP_DIR`` is the path to the main Zephyr
       application managed by sysbuild.
 
+      .. tip::
+
+         The environment variables, ``CMAKE_BUILD_PARALLEL_LEVEL`` and ``VERBOSE``, can be used to
+         control the build process when using sysbuild with CMake and ninja.
+
+         To set number of jobs for ninja for all sysbuild images, set the CMAKE_BUILD_PARALLEL_LEVEL
+         environment variable and invoke the build with ``cmake --build``, for example:
+
+         .. code-block:: shell
+
+            CMAKE_BUILD_PARALLEL_LEVEL=<n> cmake --build .
+
+         For verbose output of all images, use:
+
+         .. code-block:: shell
+
+            VERBOSE=1 cmake --build .
+
+
 Configuration namespacing
 *************************
 


### PR DESCRIPTION
Fixes: #79099

Calling `west build --build-opt="-v" --build-opt="-j=<n>"` passes the build options to `cmake --build ... -- <build-opt>` which again is passed to the native build tool, such as ninja or make.

However, when ExternalProjects are used in CMake, such as in TF-M or sysbuild builds then those extra build options are only passed to the first image build and not those build as external projects.

CMake supports environment variables for those flags, so translate verbosity and number of jobs to those environment variables and thereby support those flags for all images when specified by the user.