### PR TITLE
tests: drivers: uart: Add support uart_async_api for Renesas RA2 boards

### DIFF
--- a/tests/drivers/uart/uart_async_api/boards/ek_ra2a1.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/ek_ra2a1.overlay
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&pinctrl {
+	sci1_default: sci1_default {
+		group1 {
+			/* tx rx */
+			psels = <RA_PSEL(RA_PSEL_SCI_1, 4, 10)>,
+			<RA_PSEL(RA_PSEL_SCI_1, 4, 11)>;
+		};
+	};
+};
+
+&sci1 {
+	pinctrl-0 = <&sci1_default>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	dut: uart {
+		current-speed = <115200>;
+		status = "okay";
+	};
+};

--- a/tests/drivers/uart/uart_async_api/boards/ek_ra2l1.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/ek_ra2l1.overlay
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&pinctrl {
+	sci9_default: sci9_default {
+		group1 {
+			/* tx rx */
+			psels = <RA_PSEL(RA_PSEL_SCI_9, 2, 3)>,
+			<RA_PSEL(RA_PSEL_SCI_9, 2, 2)>;
+		};
+	};
+};
+
+&sci9 {
+	pinctrl-0 = <&sci9_default>;
+	pinctrl-names = "default";
+	interrupts = <28 1>, <29 1>, <30 1>, <31 1>;
+	interrupt-names = "rxi", "txi", "tei", "eri";
+	status = "okay";
+
+	dut: uart {
+		current-speed = <115200>;
+		status = "okay";
+	};
+};


### PR DESCRIPTION
Add support uart_async_api for Renesas ek_ra2l1, ek_ra2a1