### PR TITLE
drivers: sensor: explorir_m: tranceive improvements

### DIFF
--- a/drivers/sensor/explorir_m/explorir_m.c
+++ b/drivers/sensor/explorir_m/explorir_m.c
@@ -39,7 +39,7 @@ LOG_MODULE_REGISTER(explorir_m_sensor, CONFIG_SENSOR_LOG_LEVEL);
 
 #define EXPLORIR_M_BUFFER_LENGTH 16
 
-#define EXPLORIR_M_MAX_RESPONSE_DELAY 200 /* Add margin to the specified 100 in datasheet */
+#define EXPLORIR_M_MAX_RESPONSE_DELAY 300 /* Add margin to the specified 100 in datasheet */
 #define EXPLORIR_M_CO2_VALID_DELAY    1200
 
 struct explorir_m_data {


### PR DESCRIPTION
Improve transceive and increase max response delay.

Measured delay between calibrate command and calibrate response:
![Screenshot from 2025-03-10 09-09-48](https://github.com/user-attachments/assets/7f2d8949-6af2-48ff-aea0-b64201ae8471)
