### PR TITLE
Fix SD_OCR_PWR_BUSY_FLAG related break condition at line 136

### DIFF
--- a/subsys/sd/sdmmc.c
+++ b/subsys/sd/sdmmc.c
@@ -133,7 +133,7 @@ static int sdmmc_send_ocr(struct sd_card *card, int ocr)
 				break;
 			}
 		} else {
-			if ((cmd.response[0U] & SD_OCR_PWR_BUSY_FLAG)) {
+			if (!(cmd.response[0U] & SD_OCR_PWR_BUSY_FLAG)) {
 				break;
 			}
 		}


### PR DESCRIPTION
I think the break condition related to SD_OCR_PWR_BUSY_FLAG at line 136 should have an inverted logic, considering the comment few lines above, if the intention is to break from the loop once the flag will have been cleared by the card