### PR TITLE
sample/test cleanup and filter fixes

### DIFF
--- a/samples/arch/mpu/mpu_test/sample.yaml
+++ b/samples/arch/mpu/mpu_test/sample.yaml
@@ -7,3 +7,5 @@ tests:
     tags:
       - mpu
     harness: shell
+    integration_platforms:
+      - mps2/an385

--- a/samples/basic/blinky_pwm/sample.yaml
+++ b/samples/basic/blinky_pwm/sample.yaml
@@ -3,6 +3,8 @@ sample:
 tests:
   sample.basic.blink_led:
     filter: dt_alias_exists("pwm-led0") and dt_compat_enabled("pwm-leds")
+    integration_platforms:
+      - esp32c3_devkitm
     tags:
       - drivers
       - pwm

--- a/samples/boards/st/backup_sram/sample.yaml
+++ b/samples/boards/st/backup_sram/sample.yaml
@@ -6,3 +6,7 @@ tests:
     depends_on: backup_sram
     build_only: true
     filter: dt_compat_enabled("st,stm32-backup-sram")
+    vendor_allow:
+      - st
+    integration_platforms:
+      - nucleo_f207zg/stm32f207xx

--- a/samples/boards/st/h7_dual_core/sample.yaml
+++ b/samples/boards/st/h7_dual_core/sample.yaml
@@ -3,6 +3,9 @@ sample:
   name: stm32_h7_dual_core
 tests:
   sample.boards.stm32.h7_dual_core:
-    depends_on: mailbox
     build_only: true
+    vendor_allow:
+      - st
     filter: dt_compat_enabled("st,stm32-hsem-mailbox")
+    integration_platforms:
+      - stm32h747i_disco/stm32h747xx/m4

--- a/samples/drivers/gnss/sample.yaml
+++ b/samples/drivers/gnss/sample.yaml
@@ -9,4 +9,5 @@ tests:
       - drivers
       - gnss
     filter: dt_alias_exists("gnss")
-    depends_on: gnss
+    integration_platforms:
+      - mimxrt1062_fmurt6

--- a/samples/drivers/i2s/output/sample.yaml
+++ b/samples/drivers/i2s/output/sample.yaml
@@ -5,7 +5,8 @@ common:
   tags:
     - drivers
     - i2s
-  depends_on: i2s
 tests:
   sample.drivers.i2s.output:
     filter: dt_alias_exists("i2s-tx")
+    integration_platforms:
+      - mimxrt1060_evk@B/mimxrt1062/qspi

--- a/samples/drivers/kscan/sample.yaml
+++ b/samples/drivers/kscan/sample.yaml
@@ -14,3 +14,5 @@ tests:
       fixture: fixture_connect_keyboard
     depends_on: kscan
     filter: dt_chosen_enabled("zephyr,keyboard-scan")
+    integration_platforms:
+      - mec1501modular_assy6885

--- a/samples/drivers/led/is31fl3733/sample.yaml
+++ b/samples/drivers/led/is31fl3733/sample.yaml
@@ -6,3 +6,5 @@ tests:
     filter: dt_compat_enabled("issi,is31fl3733")
     tags: LED
     depends_on: i2c
+    integration_platforms:
+      - frdm_k22f

--- a/samples/drivers/led/pwm/sample.yaml
+++ b/samples/drivers/led/pwm/sample.yaml
@@ -7,6 +7,8 @@ tests:
     tags: LED
     depends_on: pwm
     platform_exclude: reel_board
+    integration_platforms:
+      - frdm_k22f
     timeout: 20
     harness: console
     harness_config:

--- a/samples/drivers/mspi/mspi_flash/sample.yaml
+++ b/samples/drivers/mspi/mspi_flash/sample.yaml
@@ -20,3 +20,5 @@ tests:
         - "Attempting to write 4 bytes"
         - "Data read matches data written. Good!!"
     depends_on: mspi
+    integration_platforms:
+      - apollo3p_evb

--- a/samples/drivers/spi_flash_at45/sample.yaml
+++ b/samples/drivers/spi_flash_at45/sample.yaml
@@ -1,44 +1,27 @@
 sample:
   name: SPI Flash AT45 Sample
+common:
+  depends_on: spi
+  filter: dt_compat_enabled("atmel,at45")
+  integration_platforms:
+    - sam4l_wm400_cape
+  tags:
+    - spi
+    - flash
 tests:
   sample.drivers.spi.flash.at45.build:
-    tags:
-      - spi
-      - flash
-    depends_on: spi
-    filter: dt_compat_enabled("atmel,at45")
     build_only: true
   sample.drivers.spi.flash.at45.build.page_layout:
     extra_args: EXTRA_CONF_FILE="overlay-page_layout.conf"
-    tags:
-      - spi
-      - flash
-    depends_on: spi
-    filter: dt_compat_enabled("atmel,at45")
     build_only: true
   sample.drivers.spi.flash.at45.build.pm:
     extra_args: EXTRA_CONF_FILE="overlay-pm.conf"
-    tags:
-      - spi
-      - flash
-    depends_on: spi
-    filter: dt_compat_enabled("atmel,at45")
     build_only: true
   sample.drivers.spi.flash.at45.build.page_layout_pm:
     extra_args: EXTRA_CONF_FILE="overlay-page_layout.conf;overlay-pm.conf"
-    tags:
-      - spi
-      - flash
-    depends_on: spi
-    filter: dt_compat_enabled("atmel,at45")
     build_only: true
   sample.drivers.spi.flash.at45:
     extra_args: EXTRA_CONF_FILE="overlay-page_layout.conf;overlay-pm.conf"
-    tags:
-      - spi
-      - flash
-    depends_on: spi
-    filter: dt_compat_enabled("atmel,at45")
     harness: console
     harness_config:
       type: multi_line

--- a/samples/net/prometheus/sample.yaml
+++ b/samples/net/prometheus/sample.yaml
@@ -16,5 +16,7 @@ common:
     - native_posix/native/64
   # Exclude CONFIG_HAS_RENESAS_RA_FSP as Renesas RA HAL has build error with mbedtls Socket
   filter: not CONFIG_HAS_RENESAS_RA_FSP
+  integration_platforms:
+    - qemu_x86
 tests:
   sample.net.prometheus: {}

--- a/samples/net/wpan_serial/sample.yaml
+++ b/samples/net/wpan_serial/sample.yaml
@@ -15,6 +15,8 @@ tests:
       - thingy53/nrf5340/cpuapp/ns
       - raytac_mdbt53_db_40/nrf5340/cpuapp/ns
       - raytac_mdbt53_db_40/nrf5340/cpuapp
+    integration_platforms:
+      - usb_kw24d512
   sample.net.wpan_serial.frdm_cr20a:
     extra_args: SHIELD=frdm_cr20a
     platform_allow: frdm_k64f

--- a/samples/sensor/co2_polling/sample.yaml
+++ b/samples/sensor/co2_polling/sample.yaml
@@ -5,6 +5,5 @@ tests:
     harness: sensor
     tags: sensors
     filter: dt_alias_exists("co2")
-    depends_on:
-      - serial
-      - uart_interrupt_driven
+    integration_platforms:
+      - nucleo_h563zi

--- a/samples/sensor/th02/sample.yaml
+++ b/samples/sensor/th02/sample.yaml
@@ -6,3 +6,5 @@ tests:
     tags: sensors
     depends_on: i2c
     filter: dt_compat_enabled("hoperf,th02") and dt_compat_enabled("seeed,grove-lcd-rgb")
+    integration_platforms:
+      - frdm_k64f

--- a/samples/sensor/veaa_x_3/sample.yaml
+++ b/samples/sensor/veaa_x_3/sample.yaml
@@ -8,3 +8,5 @@ tests:
     depends_on:
       - adc
       - dac
+    integration_platforms:
+      - nucleo_h563zi

--- a/samples/shields/x_nucleo_53l0a1/sample.yaml
+++ b/samples/shields/x_nucleo_53l0a1/sample.yaml
@@ -6,3 +6,5 @@ tests:
     tags: shield
     depends_on: arduino_i2c
     filter: dt_enabled_alias_with_parent_compat("sw0", "gpio-keys")
+    integration_platforms:
+      - nucleo_g431rb/stm32g431xx

--- a/samples/subsys/bindesc/read_bindesc/sample.yaml
+++ b/samples/subsys/bindesc/read_bindesc/sample.yaml
@@ -11,3 +11,5 @@ tests:
     tags: bindesc
     filter: dt_chosen_enabled("zephyr,flash-controller") and CONFIG_FLASH_HAS_DRIVER_ENABLED
       and CONFIG_ARCH_SUPPORTS_ROM_START
+    integration_platforms:
+      - mps2/an385

--- a/samples/subsys/shell/fs/sample.yaml
+++ b/samples/subsys/shell/fs/sample.yaml
@@ -18,7 +18,7 @@ tests:
       - s32z2xxdc2@D/s32z270/rtu0
       - s32z2xxdc2@D/s32z270/rtu1
     integration_platforms:
-      - reel_board
+      - native_sim
   sample.filesystem.shell.fuse:
     platform_allow:
       - native_sim

--- a/tests/arch/x86/cpu_scrubs_regs/testcase.yaml
+++ b/tests/arch/x86/cpu_scrubs_regs/testcase.yaml
@@ -8,3 +8,5 @@ tests:
       - userspace
       - scrub
       - registers
+    integration_platforms:
+      - qemu_x86

--- a/tests/drivers/pinctrl/nrf/testcase.yaml
+++ b/tests/drivers/pinctrl/nrf/testcase.yaml
@@ -3,6 +3,9 @@ tests:
     tags:
       - drivers
       - pinctrl
-    depends_on:
-      - pinctrl
-      - nrf
+    vendor_allow:
+      - nordic
+    platform_exclude:
+      - thingy53/nrf5340/cpunet
+    integration_platforms:
+      - qemu_cortex_m0/nrf51822

--- a/tests/subsys/dfu/img_util/testcase.yaml
+++ b/tests/subsys/dfu/img_util/testcase.yaml
@@ -4,7 +4,7 @@ common:
     - native_sim
     - native_sim/native/64
   integration_platforms:
-    - nrf52840dk/nrf52840
+    - native_sim
 tests:
   dfu.image_util:
     tags: dfu_image_util

--- a/tests/subsys/dfu/mcuboot/testcase.yaml
+++ b/tests/subsys/dfu/mcuboot/testcase.yaml
@@ -6,4 +6,4 @@ tests:
       - native_sim/native/64
     tags: dfu_mcuboot
     integration_platforms:
-      - nrf52840dk/nrf52840
+      - native_sim

--- a/tests/subsys/dfu/mcuboot_multi/testcase.yaml
+++ b/tests/subsys/dfu/mcuboot_multi/testcase.yaml
@@ -6,4 +6,4 @@ tests:
       - native_sim/native/64
     tags: dfu_mcuboot
     integration_platforms:
-      - nrf52840dk/nrf52840
+      - native_sim

--- a/tests/subsys/fs/fcb/testcase.yaml
+++ b/tests/subsys/fs/fcb/testcase.yaml
@@ -9,12 +9,16 @@ tests:
       - mr_canhubk3
     tags: flash_circural_buffer
     integration_platforms:
-      - nrf52840dk/nrf52840
+      - native_sim
   filesystem.fcb.no_erase:
     platform_allow:
       - nrf54l09pdk/nrf54l09/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l20pdk/nrf54l20/cpuapp
+      - native_sim
+    integration_platforms:
+      - nrf54l09pdk/nrf54l09/cpuapp
+      - native_sim
   filesystem.fcb.native_sim.no_erase:
     extra_args: CONFIG_FLASH_SIMULATOR_EXPLICIT_ERASE=n
     platform_allow: native_sim
@@ -28,7 +32,7 @@ tests:
       - mr_canhubk3
     tags: flash_circural_buffer
     integration_platforms:
-      - nrf52840dk/nrf52840
+      - native_sim
     extra_args: CONFIG_FCB_ALLOW_FIXED_ENDMARKER=y
   filesystem.fcb.native_sim.fcb_0x00:
     extra_args: DTC_OVERLAY_FILE=boards/native_sim_ev_0x00.overlay

--- a/tests/subsys/fs/littlefs/testcase.yaml
+++ b/tests/subsys/fs/littlefs/testcase.yaml
@@ -9,7 +9,7 @@ common:
     - mimxrt1060_evk/mimxrt1062/qspi
     - mr_canhubk3
   integration_platforms:
-    - nrf52840dk/nrf52840
+    - native_sim
   modules:
     - littlefs
 tests:

--- a/tests/subsys/jwt/testcase.yaml
+++ b/tests/subsys/jwt/testcase.yaml
@@ -5,7 +5,7 @@ common:
   timeout: 120
   tags: jwt
   integration_platforms:
-    - frdm_k64f
+    - qemu_x86
   extra_configs:
     - CONFIG_TEST_RANDOM_GENERATOR=y
 tests:


### PR DESCRIPTION
- **tests: use simulators in integration platforms**
- **samples: mh7_dual_core: remove depends_on mailbox**
- **samples: gnss: no board has this feature, improve filtering**
- **samples: co2: fix filtering and use integration_platforms**
- **tests: pinctrl: improve filtering and let tesrt build/run**
- **tests/samples: use integration platforms where possible**
