### PR TITLE
Bluetooth: SSP: Reply a negative rsp if binding flags are mismatched

### DIFF
--- a/subsys/bluetooth/host/classic/ssp.c
+++ b/subsys/bluetooth/host/classic/ssp.c
@@ -683,14 +683,6 @@ void bt_hci_io_capa_req(struct net_buf *buf)
 	}
 #endif
 
-	resp_buf = bt_hci_cmd_create(BT_HCI_OP_IO_CAPABILITY_REPLY,
-				     sizeof(*cp));
-	if (!resp_buf) {
-		LOG_ERR("Out of command buffers");
-		bt_conn_unref(conn);
-		return;
-	}
-
 	/*
 	 * Set authentication requirements when acting as pairing initiator to
 	 * 'dedicated bond' with MITM protection set if local IO capa
@@ -718,11 +710,37 @@ void bt_hci_io_capa_req(struct net_buf *buf)
 		}
 	} else {
 		auth = ssp_get_auth(conn);
+
+		/*
+		 * Core v6.0, Vol 3, Part C, Section 4.3.1 Non-bondable mode
+		 * When a Bluetooth device is in non-bondable mode it shall not accept a
+		 * pairing request that results in bonding. Devices in non-bondable mode
+		 * may accept connections that do not request or require bonding.
+		 *
+		 * If the peer supports bonding mode, but the local is in non-bondable
+		 * mode, it will send a negative response with error code
+		 * `BT_HCI_ERR_PAIRING_NOT_ALLOWED`.
+		 */
+		if (!atomic_test_bit(conn->flags, BT_CONN_BR_BONDABLE) &&
+		    (conn->br.remote_auth > BT_HCI_NO_BONDING_MITM)) {
+			LOG_WRN("Invalid remote bonding requirements");
+			io_capa_neg_reply(&evt->bdaddr,
+					  BT_HCI_ERR_PAIRING_NOT_ALLOWED);
+			bt_conn_unref(conn);
+			return;
+		}
 	}
 
 	if (!atomic_test_bit(conn->flags, BT_CONN_BR_BONDABLE)) {
 		/* If bondable is false, clear bonding flag. */
 		auth = BT_HCI_SET_NO_BONDING(auth);
+	}
+
+	resp_buf = bt_hci_cmd_create(BT_HCI_OP_IO_CAPABILITY_REPLY, sizeof(*cp));
+	if (!resp_buf) {
+		LOG_ERR("Out of command buffers");
+		bt_conn_unref(conn);
+		return;
 	}
 
 	cp = net_buf_add(resp_buf, sizeof(*cp));


### PR DESCRIPTION
If the remote is in bondable mode, but the local is in non-bondable mode, the local host shall respond to an IO capability request with a negative response.

In current implementation, it does not check the bonding flags of the both sides are consistent.

Fix the issue by checking the consistency of bonding flags of the both sides. If they are not consistent, send a negative IO capability response with the reason pairing not allowed.