### PR TITLE
Bluetooth: SSP: `bt_conn_unref` is missing if pairing is not accepted

### DIFF
--- a/subsys/bluetooth/host/classic/ssp.c
+++ b/subsys/bluetooth/host/classic/ssp.c
@@ -676,8 +676,8 @@ void bt_hci_io_capa_req(struct net_buf *buf)
 
 		err = bt_auth->pairing_accept(conn, NULL);
 		if (err != BT_SECURITY_ERR_SUCCESS) {
-			io_capa_neg_reply(&evt->bdaddr,
-					  BT_HCI_ERR_PAIRING_NOT_ALLOWED);
+			io_capa_neg_reply(&evt->bdaddr, BT_HCI_ERR_PAIRING_NOT_ALLOWED);
+			bt_conn_unref(conn);
 			return;
 		}
 	}


### PR DESCRIPTION
The `conn` is found by using function `bt_conn_lookup_addr_br()`, it should be released by calling `bt_conn_unref()`. But `bt_conn_unref()` is missing in the case that the pairing is not accepted.

Release the `conn` by calling `bt_conn_unref()` before exiting the function `bt_hci_io_capa_req`.