### PR TITLE
tests: Bluetooth: Tester: Do not send MICP Mute ev on write cb

### DIFF
--- a/tests/bluetooth/tester/src/audio/btp_micp.c
+++ b/tests/bluetooth/tester/src/audio/btp_micp.c
@@ -99,7 +99,6 @@ static void micp_mic_ctlr_mute_written_cb(struct bt_micp_mic_ctlr *mic_ctlr, int
 	struct bt_conn *conn;
 
 	bt_micp_mic_ctlr_conn_get(mic_ctlr, &conn);
-	btp_send_micp_mute_state_ev(conn, err, mute_state);
 
 	LOG_DBG("MICP Mute Written cb (%d))", err);
 }
@@ -109,7 +108,6 @@ static void micp_mic_ctlr_unmute_written_cb(struct bt_micp_mic_ctlr *mic_ctlr, i
 	struct bt_conn *conn;
 
 	bt_micp_mic_ctlr_conn_get(mic_ctlr, &conn);
-	btp_send_micp_mute_state_ev(conn, err, mute_state);
 
 	LOG_DBG("MICP Mute Unwritten cb (%d))", err);
 }


### PR DESCRIPTION
When the BT Tester gets the write response, it should not send the state change event, as the write response may come before the notifications, and in which case the state may not have changed.

The BT Tester should always wait for the state change notification before sending the event.