### PR TITLE
drivers: udc: udc_skeleton: fix call to K_THREAD_STACK_DEFINE

### DIFF
--- a/drivers/usb/udc/udc_skeleton.c
+++ b/drivers/usb/udc/udc_skeleton.c
@@ -363,7 +363,8 @@ static const struct udc_api udc_skeleton_api = {
  * driver, even if your platform does not require it.
  */
 #define UDC_SKELETON_DEVICE_DEFINE(n)						\
-	K_THREAD_STACK_DEFINE(udc_skeleton_stack_##n, CONFIG_UDC_SKELETON);	\
+	K_THREAD_STACK_DEFINE(udc_skeleton_stack_##n,				\
+			      CONFIG_UDC_SKELETON_STACK_SIZE);			\
 										\
 	static void udc_skeleton_thread_##n(void *dev, void *arg1, void *arg2)	\
 	{									\


### PR DESCRIPTION
The udc_skeleton driver incorrectly calls `K_THREAD_STACK_DEFINE` with `CONFIG_UDC_SKELETON` instead of `CONFIG_UDC_SKELETON_STACK_SIZE`. This causes stack overflows when developing a driver based on this code.

Fix the call to `K_THREAD_STACK_DEFINE`.