### PR TITLE
Fix button support for frdm_mcxw71

### DIFF
--- a/boards/nxp/frdm_mcxw71/frdm_mcxw71.dts
+++ b/boards/nxp/frdm_mcxw71/frdm_mcxw71.dts
@@ -56,7 +56,7 @@
 		compatible = "gpio-keys";
 		user_button_0: button_0 {
 			label = "User SW2";
-			gpios = <&gpioc 6 GPIO_ACTIVE_LOW>;
+			gpios = <&gpioc 6 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
 			zephyr,code = <INPUT_KEY_0>;
 			status = "okay";
 		};


### PR DESCRIPTION
Fixes #86735
SW2 Needed the GPIO_PULL_UP flag to be set.