### PR TITLE
doc: scripts: board catalog: skip "zephyr,xxx" compats

### DIFF
--- a/doc/_scripts/gen_boards_catalog.py
+++ b/doc/_scripts/gen_boards_catalog.py
@@ -263,6 +263,10 @@ def get_catalog(generate_hw_features=False):
                     if node.matching_compat is None:
                         continue
 
+                    # skip "zephyr,xxx" compatibles
+                    if node.matching_compat.startswith("zephyr,"):
+                        continue
+
                     description = DeviceTreeUtils.get_cached_description(node)
                     filename = node.filename
                     lineno = node.lineno


### PR DESCRIPTION
Skip "zephyr,xxx" compats when collecting data for the new Supported Features table, since they don't represent hardware features.