### PR TITLE
samples: adc: Change atmel samv71 adc reference

### DIFF
--- a/samples/drivers/adc/adc_dt/boards/sam_v71_xult_samv71q21.overlay
+++ b/samples/drivers/adc/adc_dt/boards/sam_v71_xult_samv71q21.overlay
@@ -18,7 +18,8 @@
 	channel@0 {
 		reg = <0>;
 		zephyr,gain = "ADC_GAIN_1";
-		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,reference = "ADC_REF_EXTERNAL0";
+		zephyr,vref-mv = <3300>;
 		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
 		zephyr,resolution = <12>;
 	};
@@ -26,7 +27,8 @@
 	channel@8 {
 		reg = <8>;
 		zephyr,gain = "ADC_GAIN_1";
-		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,reference = "ADC_REF_EXTERNAL0";
+		zephyr,vref-mv = <3300>;
 		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
 		zephyr,resolution = <12>;
 	};

--- a/samples/drivers/adc/adc_sequence/boards/sam_v71_xult_samv71q21.overlay
+++ b/samples/drivers/adc/adc_sequence/boards/sam_v71_xult_samv71q21.overlay
@@ -17,14 +17,16 @@
 	channel@0 {
 		reg = <0>;
 		zephyr,gain = "ADC_GAIN_1";
-		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,reference = "ADC_REF_EXTERNAL0";
+		zephyr,vref-mv = <3300>;
 		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
 	};
 
 	channel@8 {
 		reg = <8>;
 		zephyr,gain = "ADC_GAIN_1";
-		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,reference = "ADC_REF_EXTERNAL0";
+		zephyr,vref-mv = <3300>;
 		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
 	};
 };


### PR DESCRIPTION
Changed reference to ADC_REF_EXTERNAL0 as it is the only value supported by current driver implementation and 3v3 external reference is connected on the board.