### PR TITLE
scripts and soc: Mark MD5 and SHA1 usage as not for security

### DIFF
--- a/scripts/pylib/twister/twisterlib/testinstance.py
+++ b/scripts/pylib/twister/twisterlib/testinstance.py
@@ -152,7 +152,7 @@ class TestInstance:
             with open(run_id_file) as fp:
                 run_id = fp.read()
         else:
-            hash_object = hashlib.md5(self.name.encode())
+            hash_object = hashlib.md5(self.name.encode(), usedforsecurity=False)
             random_str = f"{random.getrandbits(64)}".encode()
             hash_object.update(random_str)
             run_id = hash_object.hexdigest()

--- a/scripts/west_commands/runners/intel_adsp.py
+++ b/scripts/west_commands/runners/intel_adsp.py
@@ -90,7 +90,7 @@ class IntelAdspBinaryRunner(ZephyrBinaryRunner):
 
     def flash(self, **kwargs):
         'Generate a hash string for appending to the sending ri file'
-        hash_object = hashlib.md5(self.bin_fw.encode())
+        hash_object = hashlib.md5(self.bin_fw.encode(), usedforsecurity=False)
         random_str = f"{random.getrandbits(64)}".encode()
         hash_object.update(random_str)
         send_bin_fw = str(self.bin_fw + "." + hash_object.hexdigest())

--- a/scripts/west_commands/zspdx/scanner.py
+++ b/scripts/west_commands/zspdx/scanner.py
@@ -115,7 +115,7 @@ def calculateVerificationCode(pkg):
     hashes.sort()
     filelist = "".join(hashes)
 
-    hSHA1 = hashlib.sha1()
+    hSHA1 = hashlib.sha1(usedforsecurity=False)
     hSHA1.update(filelist.encode('utf-8'))
     return hSHA1.hexdigest()
 

--- a/scripts/west_commands/zspdx/util.py
+++ b/scripts/west_commands/zspdx/util.py
@@ -16,9 +16,9 @@ def getHashes(filePath):
     Returns: tuple of (SHA1, SHA256, MD5) hashes for filePath, or
              None if file is not found.
     """
-    hSHA1 = hashlib.sha1()
+    hSHA1 = hashlib.sha1(usedforsecurity=False)
     hSHA256 = hashlib.sha256()
-    hMD5 = hashlib.md5()
+    hMD5 = hashlib.md5(usedforsecurity=False)
 
     log.dbg(f"  - getting hashes for {filePath}")
 

--- a/soc/intel/intel_adsp/tools/cavstool_client.py
+++ b/soc/intel/intel_adsp/tools/cavstool_client.py
@@ -62,7 +62,8 @@ class cavstool_client():
         fname = os.path.basename(filename)
         fsize = os.path.getsize(filename)
 
-        md5_tx = hashlib.md5(open(filename,'rb').read()).hexdigest()
+        md5_tx = hashlib.md5(open(filename,'rb').read(),
+                             usedforsecurity=False).hexdigest()
 
         # Pack the header and the expecting packed size is 78 bytes.
         # The header by convention includes:

--- a/soc/intel/intel_adsp/tools/remote-fw-service.py
+++ b/soc/intel/intel_adsp/tools/remote-fw-service.py
@@ -77,7 +77,7 @@ class adsp_request_handler(socketserver.BaseRequestHandler):
             return None
 
         # Check the MD5 of the firmware
-        md5_rx = hashlib.md5(total).hexdigest()
+        md5_rx = hashlib.md5(total, usedforsecurity=False).hexdigest()
         md5_tx = md5_tx_b.decode('utf-8')
 
         if md5_tx != md5_rx:


### PR DESCRIPTION
MD5 and SHA1 are not supposed to be used nowadays on security context. Some ancillary scripts in tree do use them, but for verification only - or where externally mandated, such the SPDX tool.

This patch marks those usages as `usedforsecurity=False`, which helps clarify intent.