### PR TITLE
MAINTAINERS: NXP: separate NXP Robotics from mainline

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3913,7 +3913,7 @@ NXP Platforms (Robotics Products):
     - boards/nxp/rddrone_fmuk66/
     - boards/nxp/mr_canhubk3/
   labels:
-    - "platform: NXP"
+    - "platform: NXP Robotics"
   description: NXP Robotics Module Platform Products
 
 Microchip MEC Platforms:


### PR DESCRIPTION
Added a "platform: NXP Robotics" label to avoid duplicate NXP areas from having the same label. This was causing the wrong assignees to be automatically assigned to issues labeled with "platform: NXP"