### PR TITLE
Sensor: PAT9136: Add Optical Flow Sensor

### DIFF
--- a/drivers/sensor/pixart/Kconfig
+++ b/drivers/sensor/pixart/Kconfig
@@ -4,4 +4,5 @@
 
 # zephyr-keep-sorted-start
 source "drivers/sensor/pixart/paa3905/Kconfig"
+source "drivers/sensor/pixart/pat9136/Kconfig"
 # zephyr-keep-sorted-stop

--- a/drivers/sensor/pixart/pat9136/CMakeLists.txt
+++ b/drivers/sensor/pixart/pat9136/CMakeLists.txt
@@ -2,5 +2,8 @@
 # Copyright (c) 2025 CogniPilot Foundation
 # SPDX-License-Identifier: Apache-2.0
 
-add_subdirectory_ifdef(CONFIG_PAA3905 paa3905)
-add_subdirectory_ifdef(CONFIG_PAT9136 pat9136)
+zephyr_library()
+zephyr_library_sources(
+	pat9136.c
+	pat9136_decoder.c
+)

--- a/drivers/sensor/pixart/pat9136/CMakeLists.txt
+++ b/drivers/sensor/pixart/pat9136/CMakeLists.txt
@@ -7,3 +7,7 @@ zephyr_library_sources(
 	pat9136.c
 	pat9136_decoder.c
 )
+
+zephyr_library_sources_ifdef(CONFIG_PAT9136_STREAM
+	pat9136_stream.c
+)

--- a/drivers/sensor/pixart/pat9136/Kconfig
+++ b/drivers/sensor/pixart/pat9136/Kconfig
@@ -1,0 +1,14 @@
+# Copyright (c) 2025 Croxel Inc.
+# Copyright (c) 2025 CogniPilot Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+config PAT9136
+	bool "Optical Flow Sensor PAT9136"
+	default y
+	depends on DT_HAS_PIXART_PAT9136_ENABLED
+	select SPI
+	select SPI_RTIO
+	select RTIO_WORKQ
+	select SENSOR_ASYNC_API
+	help
+	  Enable driver for PAT9136 Optical Flow sensor.

--- a/drivers/sensor/pixart/pat9136/Kconfig
+++ b/drivers/sensor/pixart/pat9136/Kconfig
@@ -12,3 +12,13 @@ config PAT9136
 	select SENSOR_ASYNC_API
 	help
 	  Enable driver for PAT9136 Optical Flow sensor.
+
+if PAT9136
+
+config PAT9136_STREAM
+	bool "Streaming mode"
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_PIXART_PAT9136),int-gpios)
+	help
+	  Enable streaming mode for the PAT9136 sensor.
+
+endif # PAT9136

--- a/drivers/sensor/pixart/pat9136/pat9136.c
+++ b/drivers/sensor/pixart/pat9136/pat9136.c
@@ -1,0 +1,453 @@
+/*
+ * Copyright (c) 2025 Croxel Inc.
+ * Copyright (c) 2025 CogniPilot Foundation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT pixart_pat9136
+
+#include <zephyr/drivers/sensor.h>
+#include <zephyr/drivers/spi.h>
+#include <zephyr/rtio/rtio.h>
+#include <zephyr/rtio/work.h>
+#include <zephyr/sys/check.h>
+
+#include "pat9136.h"
+#include "pat9136_reg.h"
+#include "pat9136_bus.h"
+#include "pat9136_decoder.h"
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(PAT9136, CONFIG_SENSOR_LOG_LEVEL);
+
+struct reg_val_pair {
+	uint8_t reg;
+	uint8_t val;
+	bool op_read;
+	int (*handler)(const struct device *dev, const struct reg_val_pair *self);
+};
+
+static int perform_reg_ops(const struct device *dev, const struct reg_val_pair *ops, size_t len)
+{
+	int err;
+
+	for (size_t i = 0 ; i < len ; i++) {
+
+		/* Copying in order to allow reading data back and keeping the ops array const. */
+		struct reg_val_pair op = ops[i];
+
+		if (op.op_read) {
+			err = pat9136_bus_read(dev, op.reg, &op.val, 1);
+		} else {
+			err = pat9136_bus_write(dev, op.reg, &op.val, 1);
+		}
+
+		if (err) {
+			LOG_ERR("Failed op: %s, idx: %d, reg: 0x%02X, val: 0x%02X",
+				op.op_read ? "read" : "write", i,
+				op.reg, op.val);
+			return err;
+		}
+
+		if (op.handler) {
+			err = op.handler(dev, &op);
+			if (err) {
+				LOG_ERR("Failed to handle op: %d", err);
+				return err;
+			}
+		}
+	}
+
+	return 0;
+}
+
+static void pat9136_complete_result(struct rtio *ctx,
+				    const struct rtio_sqe *sqe,
+				    void *arg)
+{
+	struct rtio_iodev_sqe *iodev_sqe = (struct rtio_iodev_sqe *)sqe->userdata;
+	struct rtio_cqe *cqe;
+	int err = 0;
+
+	do {
+		cqe = rtio_cqe_consume(ctx);
+		if (cqe != NULL) {
+			err = cqe->result;
+			rtio_cqe_release(ctx, cqe);
+		}
+	} while (cqe != NULL);
+
+	if (err) {
+		rtio_iodev_sqe_err(iodev_sqe, err);
+	} else {
+		rtio_iodev_sqe_ok(iodev_sqe, 0);
+	}
+
+	LOG_DBG("One-shot fetch completed");
+}
+
+static void pat9136_submit_one_shot(const struct device *dev, struct rtio_iodev_sqe *iodev_sqe)
+{
+	const struct sensor_read_config *cfg = iodev_sqe->sqe.iodev->data;
+	const struct sensor_chan_spec *const channels = cfg->channels;
+	const size_t num_channels = cfg->count;
+	uint32_t min_buf_len = sizeof(struct pat9136_encoded_data);
+	int err;
+	uint8_t *buf;
+	uint32_t buf_len;
+	struct pat9136_encoded_data *edata;
+	struct pat9136_data *data = dev->data;
+
+	err = rtio_sqe_rx_buf(iodev_sqe, min_buf_len, min_buf_len, &buf, &buf_len);
+	CHECKIF(err) {
+		LOG_ERR("Failed to get a read buffer of size %u bytes", min_buf_len);
+		rtio_iodev_sqe_err(iodev_sqe, err);
+		return;
+	}
+
+	edata = (struct pat9136_encoded_data *)buf;
+
+	err = pat9136_encode(dev, channels, num_channels, buf);
+	if (err != 0) {
+		LOG_ERR("Failed to encode sensor data");
+		rtio_iodev_sqe_err(iodev_sqe, err);
+		return;
+	}
+
+	struct rtio_sqe *write_sqe = rtio_sqe_acquire(data->rtio.ctx);
+	struct rtio_sqe *read_sqe = rtio_sqe_acquire(data->rtio.ctx);
+
+	CHECKIF(!write_sqe || !read_sqe) {
+		LOG_ERR("Failed to acquire RTIO SQEs");
+		rtio_iodev_sqe_err(iodev_sqe, -ENOMEM);
+		return;
+	}
+
+	uint8_t val = REG_BURST_READ | REG_SPI_READ_BIT;
+
+	rtio_sqe_prep_tiny_write(write_sqe,
+				 data->rtio.iodev,
+				 RTIO_PRIO_HIGH,
+				 &val,
+				 1,
+				 NULL);
+	write_sqe->flags |= RTIO_SQE_TRANSACTION;
+
+	rtio_sqe_prep_read(read_sqe,
+			   data->rtio.iodev,
+			   RTIO_PRIO_HIGH,
+			   edata->buf,
+			   sizeof(edata->buf),
+			   NULL);
+	read_sqe->flags |= RTIO_SQE_CHAINED;
+
+	/** Chip only supports "burst reads" for the Data, and hence we can't
+	 * just perform a multi-byte read here. Hence, we're iterating over all
+	 * resolution registers.
+	 */
+	for (size_t i = 0 ; i < sizeof(edata->header.resolution.buf) ; i++) {
+		struct rtio_sqe *res_write_sqe = rtio_sqe_acquire(data->rtio.ctx);
+		struct rtio_sqe *res_read_sqe = rtio_sqe_acquire(data->rtio.ctx);
+
+		CHECKIF(!res_write_sqe || !res_read_sqe) {
+			LOG_ERR("Failed to acquire RTIO SQEs");
+			rtio_iodev_sqe_err(iodev_sqe, -ENOMEM);
+			return;
+		}
+
+		val = (REG_RESOLUTION_X_LOWER + i) | REG_SPI_READ_BIT;
+
+		rtio_sqe_prep_tiny_write(res_write_sqe,
+					 data->rtio.iodev,
+					 RTIO_PRIO_HIGH,
+					 &val,
+					 1,
+					 NULL);
+		res_write_sqe->flags |= RTIO_SQE_TRANSACTION;
+
+		rtio_sqe_prep_read(res_read_sqe,
+				   data->rtio.iodev,
+				   RTIO_PRIO_HIGH,
+				   (uint8_t *)&edata->header.resolution.buf[i],
+				   1,
+				   NULL);
+		res_read_sqe->flags |= RTIO_SQE_CHAINED;
+	}
+
+	struct rtio_sqe *cb_sqe = rtio_sqe_acquire(data->rtio.ctx);
+
+	CHECKIF(!cb_sqe) {
+		LOG_ERR("Failed to acquire RTIO SQEs");
+		rtio_iodev_sqe_err(iodev_sqe, -ENOMEM);
+		return;
+	}
+
+	rtio_sqe_prep_callback_no_cqe(cb_sqe,
+				      pat9136_complete_result,
+				      NULL,
+				      iodev_sqe);
+
+
+	rtio_submit(data->rtio.ctx, 0);
+}
+
+static void pat9136_submit(const struct device *dev, struct rtio_iodev_sqe *iodev_sqe)
+{
+	const struct sensor_read_config *cfg = iodev_sqe->sqe.iodev->data;
+
+	if (!cfg->is_streaming) {
+		pat9136_submit_one_shot(dev, iodev_sqe);
+	} else {
+		LOG_ERR("Streaming not supported");
+		rtio_iodev_sqe_err(iodev_sqe, -ENOTSUP);
+	}
+}
+
+static DEVICE_API(sensor, pat9136_driver_api) = {
+	.submit = pat9136_submit,
+	.get_decoder = pat9136_get_decoder,
+};
+
+static int conditional_write_fn(const struct device *dev, const struct reg_val_pair *self)
+{
+	struct reg_val_pair cond_write[] = {
+		{.reg = 0x58, .val = 0},
+		{.reg = 0x57, .val = 0},
+	};
+
+	if (self->val & BIT(7)) {
+		cond_write[0].val = 0x04;
+		cond_write[1].val = 0x80;
+	} else {
+		cond_write[0].val = 0x84;
+		cond_write[1].val = 0x00;
+	}
+
+	return perform_reg_ops(dev, cond_write, ARRAY_SIZE(cond_write));
+}
+
+static int delay_100ms_fn(const struct device *dev, const struct reg_val_pair *self)
+{
+	k_sleep(K_MSEC(100));
+
+	return 0;
+}
+
+static int pat9136_init_sequence(const struct device *dev)
+{
+	const static struct reg_val_pair paa9136_init_sequence[] = {
+		{.reg = 0x3A, .val = 0x5A}, {.reg = 0x7F, .val = 0x00}, {.reg = 0x40, .val = 0x80},
+		{.reg = 0x7F, .val = 0x14}, {.reg = 0x4D, .val = 0x00}, {.reg = 0x53, .val = 0x0D},
+		{.reg = 0x4B, .val = 0x20}, {.reg = 0x42, .val = 0xBC}, {.reg = 0x43, .val = 0x74},
+		{.reg = 0x58, .val = 0x4C}, {.reg = 0x79, .val = 0x00}, {.reg = 0x7F, .val = 0x0E},
+		{.reg = 0x54, .val = 0x04}, {.reg = 0x7F, .val = 0x0E}, {.reg = 0x55, .val = 0x0D},
+		{.reg = 0x58, .val = 0xD5}, {.reg = 0x56, .val = 0xFB}, {.reg = 0x57, .val = 0xEB},
+		{.reg = 0x7F, .val = 0x15},
+
+		/** Per datasheet, depending on the value read for this register,
+		 * the written content will vary:
+		 * - BIT(7) = 0 -> reg(0x58) = 0x04, reg(0x57) = 0x80.
+		 * - BIT(7) = 1 -> reg(0x58) = 0x84, reg(0x57) = 0x00.
+		 */
+		{
+			.reg = 0x58,
+			.op_read = true,
+			.handler = conditional_write_fn,
+		},
+
+		{.reg = 0x7F, .val = 0x07}, {.reg = 0x40, .val = 0x43}, {.reg = 0x7F, .val = 0x13},
+		{.reg = 0x49, .val = 0x20}, {.reg = 0x7F, .val = 0x14}, {.reg = 0x54, .val = 0x02},
+		{.reg = 0x7F, .val = 0x15}, {.reg = 0x60, .val = 0x00}, {.reg = 0x7F, .val = 0x06},
+		{.reg = 0x74, .val = 0x50}, {.reg = 0x7B, .val = 0x02}, {.reg = 0x7F, .val = 0x00},
+		{.reg = 0x64, .val = 0x74}, {.reg = 0x65, .val = 0x03}, {.reg = 0x72, .val = 0x0E},
+		{.reg = 0x73, .val = 0x00}, {.reg = 0x7F, .val = 0x14}, {.reg = 0x61, .val = 0x3E},
+		{.reg = 0x62, .val = 0x1E}, {.reg = 0x63, .val = 0x1E}, {.reg = 0x7F, .val = 0x15},
+		{.reg = 0x69, .val = 0x1E}, {.reg = 0x7F, .val = 0x07}, {.reg = 0x40, .val = 0x40},
+		{.reg = 0x7F, .val = 0x00}, {.reg = 0x61, .val = 0x00}, {.reg = 0x7F, .val = 0x15},
+		{.reg = 0x63, .val = 0x00}, {.reg = 0x62, .val = 0x00}, {.reg = 0x7F, .val = 0x00},
+		{.reg = 0x61, .val = 0xAD}, {.reg = 0x7F, .val = 0x15}, {.reg = 0x5D, .val = 0x2C},
+
+		/** Per datasheet, on this write we need to wait for 100-ms before moving on */
+		{
+			.reg = 0x5E,
+			.val = 0xC4,
+			.op_read = false,
+			.handler = delay_100ms_fn,
+		},
+
+		{.reg = 0x5D, .val = 0x04}, {.reg = 0x5E, .val = 0xEC},
+		{.reg = 0x7F, .val = 0x05}, {.reg = 0x42, .val = 0x48}, {.reg = 0x43, .val = 0xE7},
+		{.reg = 0x7F, .val = 0x06}, {.reg = 0x71, .val = 0x03}, {.reg = 0x7F, .val = 0x09},
+		{.reg = 0x60, .val = 0x1C}, {.reg = 0x61, .val = 0x1E}, {.reg = 0x62, .val = 0x02},
+		{.reg = 0x63, .val = 0x04}, {.reg = 0x64, .val = 0x1E}, {.reg = 0x65, .val = 0x1F},
+		{.reg = 0x66, .val = 0x01}, {.reg = 0x67, .val = 0x02}, {.reg = 0x68, .val = 0x02},
+		{.reg = 0x69, .val = 0x01}, {.reg = 0x6A, .val = 0x1F}, {.reg = 0x6B, .val = 0x1E},
+		{.reg = 0x6C, .val = 0x04}, {.reg = 0x6D, .val = 0x02}, {.reg = 0x6E, .val = 0x1E},
+		{.reg = 0x6F, .val = 0x1C}, {.reg = 0x7F, .val = 0x05}, {.reg = 0x45, .val = 0x94},
+		{.reg = 0x45, .val = 0x14}, {.reg = 0x44, .val = 0x45}, {.reg = 0x45, .val = 0x17},
+		{.reg = 0x7F, .val = 0x09}, {.reg = 0x47, .val = 0x4F}, {.reg = 0x4F, .val = 0x00},
+		{.reg = 0x52, .val = 0x04}, {.reg = 0x7F, .val = 0x0C}, {.reg = 0x4E, .val = 0x00},
+		{.reg = 0x5B, .val = 0x00}, {.reg = 0x7F, .val = 0x0D}, {.reg = 0x71, .val = 0x92},
+		{.reg = 0x70, .val = 0x07}, {.reg = 0x73, .val = 0x92}, {.reg = 0x72, .val = 0x07},
+		{.reg = 0x7F, .val = 0x00}, {.reg = 0x5B, .val = 0x20}, {.reg = 0x48, .val = 0x13},
+		{.reg = 0x49, .val = 0x00}, {.reg = 0x4A, .val = 0x13}, {.reg = 0x4B, .val = 0x00},
+		{.reg = 0x47, .val = 0x01}, {.reg = 0x54, .val = 0x55}, {.reg = 0x5A, .val = 0x50},
+		{.reg = 0x66, .val = 0x03}, {.reg = 0x67, .val = 0x00}, {.reg = 0x7F, .val = 0x07},
+		{.reg = 0x40, .val = 0x43}, {.reg = 0x7F, .val = 0x05}, {.reg = 0x4D, .val = 0x00},
+		{.reg = 0x6D, .val = 0x96}, {.reg = 0x55, .val = 0x62}, {.reg = 0x59, .val = 0x21},
+		{.reg = 0x5F, .val = 0xD8}, {.reg = 0x6A, .val = 0x22}, {.reg = 0x7F, .val = 0x07},
+		{.reg = 0x42, .val = 0x30}, {.reg = 0x43, .val = 0x00}, {.reg = 0x7F, .val = 0x06},
+		{.reg = 0x4C, .val = 0x01}, {.reg = 0x54, .val = 0x02}, {.reg = 0x62, .val = 0x01},
+		{.reg = 0x7F, .val = 0x09}, {.reg = 0x41, .val = 0x01}, {.reg = 0x4F, .val = 0x00},
+		{.reg = 0x7F, .val = 0x0A}, {.reg = 0x4C, .val = 0x18}, {.reg = 0x51, .val = 0x8F},
+		{.reg = 0x7F, .val = 0x07}, {.reg = 0x40, .val = 0x40}, {.reg = 0x7F, .val = 0x00},
+		{.reg = 0x40, .val = 0x80}, {.reg = 0x7F, .val = 0x09}, {.reg = 0x40, .val = 0x03},
+		{.reg = 0x44, .val = 0x08}, {.reg = 0x4F, .val = 0x08}, {.reg = 0x7F, .val = 0x0A},
+		{.reg = 0x51, .val = 0x8E}, {.reg = 0x7F, .val = 0x00}, {.reg = 0x66, .val = 0x11},
+		{.reg = 0x67, .val = 0x08},
+	};
+
+	return perform_reg_ops(dev, paa9136_init_sequence, ARRAY_SIZE(paa9136_init_sequence));
+}
+
+static int pat9136_set_resolution(const struct device *dev)
+{
+	const struct pat9136_config *cfg = dev->config;
+	struct reg_val_pair paa9136_resolution_ops[] = {
+		{.reg = REG_RESOLUTION_X_LOWER, .val = cfg->resolution & 0xFF},
+		{.reg = REG_RESOLUTION_X_UPPER, .val = 0},
+		{.reg = REG_RESOLUTION_Y_LOWER, .val = cfg->resolution & 0xFF},
+		{.reg = REG_RESOLUTION_Y_UPPER, .val = 0},
+		{.reg = REG_RESOLUTION_SET, .val = 0x01},
+	};
+
+	return perform_reg_ops(dev, paa9136_resolution_ops, ARRAY_SIZE(paa9136_resolution_ops));
+}
+
+static int pat9136_configure(const struct device *dev)
+{
+	int err;
+	uint8_t val;
+	uint8_t motion_data[6];
+
+	/* Clear device config by issuing a software reset request */
+	val = POWER_UP_RESET_VAL;
+	err = pat9136_bus_write(dev, REG_POWER_UP_RESET, &val, 1);
+	if (err) {
+		LOG_ERR("Failed to write Power up reset reg");
+		return err;
+	}
+	k_sleep(K_MSEC(50));
+
+	/* Clear observation register and read back the register, */
+	uint8_t retries = 3;
+
+	do {
+		val = 0x00;
+		err = pat9136_bus_write(dev, REG_OBSERVATION, &val, 1);
+		if (err) {
+			LOG_ERR("Failed to read Product ID");
+			return err;
+		}
+		k_sleep(K_MSEC(1));
+
+		err = pat9136_bus_read(dev, REG_OBSERVATION, &val, 1);
+		if (err) {
+			LOG_ERR("Failed to read observation register");
+			return err;
+		}
+		if (REG_OBSERVATION_READ_IS_VALID(val)) {
+			break;
+		}
+	} while (err == 0 && (retries-- > 0));
+
+	if (!REG_OBSERVATION_READ_IS_VALID(val)) {
+		LOG_ERR("Invalid observation register value: 0x%02X", val);
+		return -EIO;
+	}
+
+	/** Load performance optimization settings */
+	err = pat9136_init_sequence(dev);
+	if (err) {
+		LOG_ERR("Failed to init sequence");
+		return err;
+	}
+
+	/* Set resolution */
+	err = pat9136_set_resolution(dev);
+	if (err) {
+		LOG_ERR("Failed to set resolution");
+		return err;
+	}
+
+	/* Read reg's 0x02-0x06 to clear motion data. */
+	err = pat9136_bus_read(dev, REG_MOTION, motion_data, sizeof(motion_data));
+	if (err) {
+		LOG_ERR("Failed to read motion data");
+		return err;
+	}
+
+	return 0;
+}
+
+static int pat9136_init(const struct device *dev)
+{
+	int err;
+	uint8_t val;
+
+	/* Power-up sequence delay */
+	k_sleep(K_MSEC(50));
+
+	/* Read Product ID */
+	err = pat9136_bus_read(dev, REG_PRODUCT_ID, &val, 1);
+	if (err) {
+		LOG_ERR("Failed to read Product ID");
+		return err;
+	} else if (val != PRODUCT_ID) {
+		LOG_ERR("Invalid Product ID: 0x%02X", val);
+		return -EIO;
+	}
+
+	err = pat9136_configure(dev);
+	if (err) {
+		LOG_ERR("Failed to configure");
+		return err;
+	}
+
+	return 0;
+}
+
+#define PAT9136_INIT(inst)									   \
+												   \
+	BUILD_ASSERT(DT_PROP(DT_DRV_INST(inst), resolution) >= 0 &&				   \
+		     DT_PROP(DT_DRV_INST(inst), resolution) <= 0xC7,				   \
+		     "Resolution must be in range 0-199");					   \
+												   \
+	RTIO_DEFINE(pat9136_rtio_ctx_##inst, 16, 16);						   \
+	SPI_DT_IODEV_DEFINE(pat9136_bus_##inst,							   \
+			    DT_DRV_INST(inst),							   \
+			    SPI_OP_MODE_MASTER | SPI_WORD_SET(8) | SPI_TRANSFER_MSB,		   \
+			    0U);								   \
+												   \
+	static const struct pat9136_config pat9136_cfg_##inst = {				   \
+		.resolution = DT_INST_PROP(inst, resolution),					   \
+	};											   \
+												   \
+	static struct pat9136_data pat9136_data_##inst = {					   \
+		.rtio = {									   \
+			.iodev = &pat9136_bus_##inst,						   \
+			.ctx = &pat9136_rtio_ctx_##inst,					   \
+		},										   \
+	};											   \
+												   \
+	SENSOR_DEVICE_DT_INST_DEFINE(inst,							   \
+				     pat9136_init,						   \
+				     NULL,							   \
+				     &pat9136_data_##inst,					   \
+				     &pat9136_cfg_##inst,					   \
+				     POST_KERNEL,						   \
+				     CONFIG_SENSOR_INIT_PRIORITY,				   \
+				     &pat9136_driver_api);
+
+DT_INST_FOREACH_STATUS_OKAY(PAT9136_INIT)

--- a/drivers/sensor/pixart/pat9136/pat9136.c
+++ b/drivers/sensor/pixart/pat9136/pat9136.c
@@ -434,6 +434,9 @@ static int pat9136_init(const struct device *dev)
 	BUILD_ASSERT(DT_PROP(DT_DRV_INST(inst), resolution) >= 0 &&				   \
 		     DT_PROP(DT_DRV_INST(inst), resolution) <= 0xC7,				   \
 		     "Resolution must be in range 0-199");					   \
+	BUILD_ASSERT(DT_PROP(DT_DRV_INST(inst), cooldown_timer_ms) <				   \
+		     DT_PROP(DT_DRV_INST(inst), backup_timer_ms),				   \
+		     "Cooldown timer must be less than backup timer");				   \
 												   \
 	RTIO_DEFINE(pat9136_rtio_ctx_##inst, 16, 16);						   \
 	SPI_DT_IODEV_DEFINE(pat9136_bus_##inst,							   \
@@ -444,6 +447,7 @@ static int pat9136_init(const struct device *dev)
 	static const struct pat9136_config pat9136_cfg_##inst = {				   \
 		.int_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, int_gpios, {0}),			   \
 		.backup_timer_period = DT_PROP(DT_DRV_INST(inst), backup_timer_ms),		   \
+		.cooldown_timer_period = DT_PROP(DT_DRV_INST(inst), cooldown_timer_ms),		   \
 		.resolution = DT_INST_PROP(inst, resolution),					   \
 	};											   \
 												   \

--- a/drivers/sensor/pixart/pat9136/pat9136.h
+++ b/drivers/sensor/pixart/pat9136/pat9136.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2025 Croxel Inc.
+ * Copyright (c) 2025 CogniPilot Foundation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_DRIVERS_SENSOR_PAT9136_H_
+#define ZEPHYR_DRIVERS_SENSOR_PAT9136_H_
+
+#include <stdint.h>
+#include <zephyr/drivers/sensor.h>
+#include <zephyr/rtio/rtio.h>
+
+struct pat9136_encoded_data {
+	struct {
+		uint64_t timestamp;
+		uint8_t channels : 6;
+		union {
+			uint8_t buf[4];
+			struct {
+				uint16_t x;
+				uint16_t y;
+			} __attribute__((__packed__));
+		} resolution;
+	} header;
+	union {
+		uint8_t buf[12];
+		struct {
+			uint8_t motion;
+			uint8_t observation;
+			struct {
+				int16_t x;
+				int16_t y;
+			} delta;
+			uint8_t squal;
+			uint8_t raw_sum;
+			uint8_t raw_max;
+			uint8_t raw_min;
+			uint16_t shutter;
+		} __attribute__((__packed__));
+	};
+};
+
+struct pat9136_data {
+	struct {
+		struct rtio_iodev *iodev;
+		struct rtio *ctx;
+	} rtio;
+};
+
+struct pat9136_config {
+	uint16_t resolution;
+};
+
+#endif /* ZEPHYR_DRIVERS_SENSOR_PAT9136_H_ */

--- a/drivers/sensor/pixart/pat9136/pat9136.h
+++ b/drivers/sensor/pixart/pat9136/pat9136.h
@@ -9,6 +9,7 @@
 #define ZEPHYR_DRIVERS_SENSOR_PAT9136_H_
 
 #include <stdint.h>
+#include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/sensor.h>
 #include <zephyr/rtio/rtio.h>
 
@@ -16,6 +17,10 @@ struct pat9136_encoded_data {
 	struct {
 		uint64_t timestamp;
 		uint8_t channels : 6;
+		struct {
+			bool drdy : 1;
+			bool motion : 1;
+		} events;
 		union {
 			uint8_t buf[4];
 			struct {
@@ -42,15 +47,37 @@ struct pat9136_encoded_data {
 	};
 };
 
+struct pat9136_stream {
+	struct gpio_callback cb;
+	const struct device *dev;
+	struct rtio_iodev_sqe *iodev_sqe;
+	struct k_timer timer;
+	struct {
+		struct {
+			bool drdy : 1;
+			bool motion : 1;
+		} enabled;
+		struct {
+			enum sensor_stream_data_opt drdy;
+			enum sensor_stream_data_opt motion;
+		} opt;
+	} settings;
+};
+
 struct pat9136_data {
 	struct {
 		struct rtio_iodev *iodev;
 		struct rtio *ctx;
 	} rtio;
+#if defined(CONFIG_PAT9136_STREAM)
+	struct pat9136_stream stream;
+#endif /* CONFIG_PAT9136_STREAM */
 };
 
 struct pat9136_config {
+	struct gpio_dt_spec int_gpio;
 	uint16_t resolution;
+	uint32_t backup_timer_period;
 };
 
 #endif /* ZEPHYR_DRIVERS_SENSOR_PAT9136_H_ */

--- a/drivers/sensor/pixart/pat9136/pat9136.h
+++ b/drivers/sensor/pixart/pat9136/pat9136.h
@@ -51,7 +51,13 @@ struct pat9136_stream {
 	struct gpio_callback cb;
 	const struct device *dev;
 	struct rtio_iodev_sqe *iodev_sqe;
-	struct k_timer timer;
+	struct {
+		struct k_timer backup;
+		struct {
+			atomic_t armed;
+			struct k_timer timer;
+		} cooldown;
+	} timer;
 	struct {
 		struct {
 			bool drdy : 1;
@@ -78,6 +84,7 @@ struct pat9136_config {
 	struct gpio_dt_spec int_gpio;
 	uint16_t resolution;
 	uint32_t backup_timer_period;
+	uint32_t cooldown_timer_period;
 };
 
 #endif /* ZEPHYR_DRIVERS_SENSOR_PAT9136_H_ */

--- a/drivers/sensor/pixart/pat9136/pat9136_bus.h
+++ b/drivers/sensor/pixart/pat9136/pat9136_bus.h
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2025 Croxel Inc.
+ * Copyright (c) 2025 CogniPilot Foundation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_DRIVERS_SENSOR_PAT9136_BUS_H_
+#define ZEPHYR_DRIVERS_SENSOR_PAT9136_BUS_H_
+
+#include <stdint.h>
+#include <zephyr/rtio/rtio.h>
+
+#include "pat9136.h"
+#include "pat9136_reg.h"
+
+static inline int pat9136_bus_read(const struct device *dev,
+				   uint8_t reg,
+				   uint8_t *buf,
+				   uint16_t len)
+{
+	struct pat9136_data *data = dev->data;
+	struct rtio *ctx = data->rtio.ctx;
+	struct rtio_iodev *iodev = data->rtio.iodev;
+	struct rtio_sqe *write_sqe = rtio_sqe_acquire(ctx);
+	struct rtio_sqe *read_sqe = rtio_sqe_acquire(ctx);
+	struct rtio_cqe *cqe;
+	int err;
+
+	if (!write_sqe || !read_sqe) {
+		return -ENOMEM;
+	}
+
+	reg = reg | REG_SPI_READ_BIT;
+
+	rtio_sqe_prep_write(write_sqe, iodev, RTIO_PRIO_HIGH, &reg, 1, NULL);
+	write_sqe->flags |= RTIO_SQE_TRANSACTION;
+	rtio_sqe_prep_read(read_sqe, iodev, RTIO_PRIO_HIGH, buf, len, NULL);
+
+	err = rtio_submit(ctx, 2);
+	if (err) {
+		return err;
+	}
+
+	do {
+		cqe = rtio_cqe_consume(ctx);
+		if (cqe != NULL) {
+			err = cqe->result;
+			rtio_cqe_release(ctx, cqe);
+		}
+	} while (cqe != NULL);
+
+	return err;
+}
+
+static inline int pat9136_bus_write(const struct device *dev,
+				    uint8_t reg,
+				    const uint8_t *buf,
+				    uint16_t len)
+{
+	struct pat9136_data *data = dev->data;
+	struct rtio *ctx = data->rtio.ctx;
+	struct rtio_iodev *iodev = data->rtio.iodev;
+	struct rtio_sqe *write_reg_sqe = rtio_sqe_acquire(ctx);
+	struct rtio_sqe *write_buf_sqe = rtio_sqe_acquire(ctx);
+	struct rtio_cqe *cqe;
+	int err;
+
+	if (!write_reg_sqe || !write_buf_sqe) {
+		return -ENOMEM;
+	}
+
+	reg = reg | REG_SPI_WRITE_BIT;
+
+	rtio_sqe_prep_write(write_reg_sqe, iodev, RTIO_PRIO_HIGH, &reg, 1, NULL);
+	write_reg_sqe->flags |= RTIO_SQE_TRANSACTION;
+	rtio_sqe_prep_write(write_buf_sqe, iodev, RTIO_PRIO_HIGH, buf, len, NULL);
+
+	err = rtio_submit(ctx, 2);
+	if (err) {
+		return err;
+	}
+
+	do {
+		cqe = rtio_cqe_consume(ctx);
+		if (cqe != NULL) {
+			err = cqe->result;
+			rtio_cqe_release(ctx, cqe);
+		}
+	} while (cqe != NULL);
+
+	return err;
+}
+
+#endif /* ZEPHYR_DRIVERS_SENSOR_PAT9136_BUS_H_ */

--- a/drivers/sensor/pixart/pat9136/pat9136_decoder.c
+++ b/drivers/sensor/pixart/pat9136/pat9136_decoder.c
@@ -1,0 +1,338 @@
+/*
+ * Copyright (c) 2025 Croxel Inc.
+ * Copyright (c) 2025 CogniPilot Foundation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/drivers/sensor_clock.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/drivers/sensor/pat9136.h>
+
+#include "pat9136.h"
+#include "pat9136_reg.h"
+#include "pat9136_decoder.h"
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(PAT9136_DECODER, CONFIG_SENSOR_LOG_LEVEL);
+
+#define DT_DRV_COMPAT pixart_pat9136
+
+static int pat9136_get_shift(uint16_t channel,
+			     uint16_t res_x,
+			     uint16_t res_y,
+			     int8_t *shift)
+{
+	/** Table generated based on calculation of required bits:
+	 * - resolution_cpi (per datasheet) = (1 + resolution) * 100
+	 * - value_mm = value * 25.4 / resolution_cpi
+	 *  - Bits Required = round_up( Log2(value_mm) )
+	 */
+	struct {
+		uint16_t min;
+		uint16_t max;
+		int8_t shift;
+	} const static shift_based_on_ranges[] = {
+		{.min = 0, .max = 0, .shift = 14},
+		{.min = 1, .max = 1, .shift = 13},
+		{.min = 2, .max = 3, .shift = 12},
+		{.min = 4, .max = 7, .shift = 11},
+		{.min = 8, .max = 15, .shift = 10},
+		{.min = 16, .max = 31, .shift = 9},
+		{.min = 32, .max = 63, .shift = 8},
+		{.min = 64, .max = 127, .shift = 7},
+		{.min = 128, .max = 199, .shift = 6},
+	};
+	/** Going with lowest resolution to be able to represent biggest value */
+	uint16_t resolution = MIN(res_x, res_y);
+
+	switch (channel) {
+	case SENSOR_CHAN_POS_DX:
+	case SENSOR_CHAN_POS_DY:
+	case SENSOR_CHAN_POS_DXYZ:
+		*shift = 31;
+		return 0;
+	case SENSOR_CHAN_POS_DX_MM:
+	case SENSOR_CHAN_POS_DY_MM:
+	case SENSOR_CHAN_POS_DXYZ_MM:
+		for (size_t i = 0 ; i < ARRAY_SIZE(shift_based_on_ranges) ; i++) {
+			if (resolution >= shift_based_on_ranges[i].min &&
+			    resolution <= shift_based_on_ranges[i].max) {
+				*shift = shift_based_on_ranges[i].shift;
+				return 0;
+			}
+		}
+	default:
+		return -EINVAL;
+	}
+
+	return -EIO;
+}
+
+static void pat9136_convert_raw_to_q31(struct pat9136_encoded_data *edata,
+				       uint16_t chan,
+				       int32_t reading,
+				       q31_t *out)
+{
+	int8_t shift;
+	uint32_t resolution_setting = MIN(edata->header.resolution.x,
+					  edata->header.resolution.y);
+	int64_t intermediate;
+
+	(void)pat9136_get_shift(chan,
+				resolution_setting,
+				resolution_setting,
+				&shift);
+
+	switch (chan) {
+	case SENSOR_CHAN_POS_DX:
+	case SENSOR_CHAN_POS_DY:
+		*out = (q31_t)reading;
+		return;
+	case SENSOR_CHAN_POS_DX_MM:
+	case SENSOR_CHAN_POS_DY_MM: {
+		uint32_t resolution = (chan == SENSOR_CHAN_POS_DX_MM) ?
+				      (edata->header.resolution.x + 1) * 100 :
+				      (edata->header.resolution.y + 1) * 100;
+
+		intermediate = (((int64_t)reading * INT64_C(1000000) * 25.4));
+		intermediate /= resolution;
+
+		intermediate *= ((int64_t)INT32_MAX + 1) / ((1 << shift) * INT64_C(1000000));
+
+		*out = CLAMP(intermediate, INT32_MIN, INT32_MAX);
+
+		return;
+	}
+	default:
+		CODE_UNREACHABLE;
+	}
+}
+
+uint8_t pat9136_encode_channel(uint16_t chan)
+{
+	switch (chan) {
+	case SENSOR_CHAN_POS_DX:
+		return BIT(0);
+	case SENSOR_CHAN_POS_DY:
+		return BIT(1);
+	case SENSOR_CHAN_POS_DXYZ:
+		return BIT(2);
+	case SENSOR_CHAN_POS_DX_MM:
+		return BIT(3);
+	case SENSOR_CHAN_POS_DY_MM:
+		return BIT(4);
+	case SENSOR_CHAN_POS_DXYZ_MM:
+		return BIT(5);
+	case SENSOR_CHAN_ALL:
+		return BIT_MASK(6);
+	default:
+		return 0;
+	}
+}
+
+static bool is_data_valid(const struct pat9136_encoded_data *edata)
+{
+	if (!REG_MOTION_DETECTED(edata->motion)) {
+		LOG_WRN("Invalid data - No motion detected");
+		return false;
+	}
+
+	if (!REG_OBSERVATION_READ_IS_VALID(edata->observation)) {
+		LOG_WRN("Invalid data - Observation read is not valid");
+		return false;
+	}
+
+	return true;
+}
+
+static int pat9136_decoder_get_frame_count(const uint8_t *buffer,
+					   struct sensor_chan_spec chan_spec,
+					   uint16_t *frame_count)
+{
+	struct pat9136_encoded_data *edata = (struct pat9136_encoded_data *)buffer;
+
+	if (chan_spec.chan_idx != 0) {
+		return -ENOTSUP;
+	}
+
+	uint8_t channel_request = pat9136_encode_channel(chan_spec.chan_type);
+
+	if (((edata->header.channels & channel_request) != channel_request) ||
+	    !is_data_valid(edata)) {
+		return -ENODATA;
+	}
+
+	switch (chan_spec.chan_type) {
+	case SENSOR_CHAN_POS_DX:
+	case SENSOR_CHAN_POS_DY:
+	case SENSOR_CHAN_POS_DXYZ:
+	case SENSOR_CHAN_POS_DX_MM:
+	case SENSOR_CHAN_POS_DY_MM:
+	case SENSOR_CHAN_POS_DXYZ_MM:
+		*frame_count = 1;
+		return 0;
+	default:
+		return -ENOTSUP;
+	}
+
+	return -1;
+}
+
+static int pat9136_decoder_get_size_info(struct sensor_chan_spec chan_spec,
+					 size_t *base_size,
+					 size_t *frame_size)
+{
+	switch (chan_spec.chan_type) {
+	case SENSOR_CHAN_POS_DX:
+	case SENSOR_CHAN_POS_DY:
+	case SENSOR_CHAN_POS_DX_MM:
+	case SENSOR_CHAN_POS_DY_MM:
+		*base_size = sizeof(struct sensor_q31_data);
+		*frame_size = sizeof(struct sensor_q31_sample_data);
+		return 0;
+	case SENSOR_CHAN_POS_DXYZ:
+	case SENSOR_CHAN_POS_DXYZ_MM:
+		*base_size = sizeof(struct sensor_three_axis_data);
+		*frame_size = sizeof(struct sensor_three_axis_data);
+		return 0;
+	default:
+		return -ENOTSUP;
+	}
+}
+
+static int pat9136_decoder_decode(const uint8_t *buffer,
+				  struct sensor_chan_spec chan_spec,
+				  uint32_t *fit,
+				  uint16_t max_count,
+				  void *data_out)
+{
+	struct pat9136_encoded_data *edata = (struct pat9136_encoded_data *)buffer;
+	uint8_t channel_request;
+
+	if (*fit != 0) {
+		return 0;
+	}
+
+	if (max_count == 0 || chan_spec.chan_idx != 0) {
+		return -EINVAL;
+	}
+
+	switch (chan_spec.chan_type) {
+	case SENSOR_CHAN_POS_DX_MM:
+	case SENSOR_CHAN_POS_DY_MM:
+	case SENSOR_CHAN_POS_DX:
+	case SENSOR_CHAN_POS_DY: {
+		channel_request = pat9136_encode_channel(chan_spec.chan_type);
+		if (((edata->header.channels & channel_request) != channel_request) ||
+		    !is_data_valid(edata)) {
+			LOG_ERR("No data available");
+			return -ENODATA;
+		}
+
+		struct sensor_q31_data *out = (struct sensor_q31_data *)data_out;
+		int16_t raw_value = (chan_spec.chan_type == SENSOR_CHAN_POS_DX ||
+				     chan_spec.chan_type == SENSOR_CHAN_POS_DX_MM) ?
+				    edata->delta.x :
+				    edata->delta.y;
+
+		out->header.base_timestamp_ns = edata->header.timestamp;
+		out->header.reading_count = 1;
+
+		(void)pat9136_get_shift(chan_spec.chan_type,
+					edata->header.resolution.x,
+					edata->header.resolution.y,
+					&out->shift);
+
+		(void)pat9136_convert_raw_to_q31(edata,
+						 chan_spec.chan_type,
+						 raw_value,
+						 &out->readings->value);
+
+		*fit = 1;
+		return 1;
+	}
+	case SENSOR_CHAN_POS_DXYZ_MM:
+	case SENSOR_CHAN_POS_DXYZ: {
+		channel_request = pat9136_encode_channel(chan_spec.chan_type);
+		if (((edata->header.channels & channel_request) != channel_request) ||
+		    !is_data_valid(edata)) {
+			LOG_ERR("No data available");
+			return -ENODATA;
+		}
+
+		struct sensor_three_axis_data *out = (struct sensor_three_axis_data *)data_out;
+
+		out->header.base_timestamp_ns = edata->header.timestamp;
+		out->header.reading_count = 1;
+
+		(void)pat9136_get_shift(chan_spec.chan_type,
+					edata->header.resolution.x,
+					edata->header.resolution.y,
+					&out->shift);
+
+		(void)pat9136_convert_raw_to_q31(edata,
+						 chan_spec.chan_type - 3,
+						 edata->delta.x,
+						 &out->readings[0].x);
+		(void)pat9136_convert_raw_to_q31(edata,
+						 chan_spec.chan_type - 2,
+						 edata->delta.y,
+						 &out->readings[0].y);
+		out->readings[0].z = 0;
+
+		*fit = 1;
+		return 1;
+	}
+	default:
+		return -EINVAL;
+	}
+
+	return -1;
+}
+
+static bool pat9136_decoder_has_trigger(const uint8_t *buffer, enum sensor_trigger_type trigger)
+{
+	return false;
+}
+
+SENSOR_DECODER_API_DT_DEFINE() = {
+	.get_frame_count = pat9136_decoder_get_frame_count,
+	.get_size_info = pat9136_decoder_get_size_info,
+	.decode = pat9136_decoder_decode,
+	.has_trigger = pat9136_decoder_has_trigger,
+};
+
+int pat9136_get_decoder(const struct device *dev,
+	const struct sensor_decoder_api **decoder)
+{
+	ARG_UNUSED(dev);
+	*decoder = &SENSOR_DECODER_NAME();
+
+	return 0;
+}
+
+int pat9136_encode(const struct device *dev,
+		   const struct sensor_chan_spec *const channels,
+		   size_t num_channels,
+		   uint8_t *buf)
+{
+	struct pat9136_encoded_data *edata = (struct pat9136_encoded_data *)buf;
+	uint64_t cycles;
+	int err;
+
+	edata->header.channels = 0;
+
+	for (size_t i = 0 ; i < num_channels; i++) {
+		edata->header.channels |= pat9136_encode_channel(channels[i].chan_type);
+	}
+
+	err = sensor_clock_get_cycles(&cycles);
+	if (err != 0) {
+		return err;
+	}
+
+	edata->header.timestamp = sensor_clock_cycles_to_ns(cycles);
+
+	return 0;
+}

--- a/drivers/sensor/pixart/pat9136/pat9136_decoder.c
+++ b/drivers/sensor/pixart/pat9136/pat9136_decoder.c
@@ -293,7 +293,16 @@ static int pat9136_decoder_decode(const uint8_t *buffer,
 
 static bool pat9136_decoder_has_trigger(const uint8_t *buffer, enum sensor_trigger_type trigger)
 {
-	return false;
+	struct pat9136_encoded_data *edata = (struct pat9136_encoded_data *)buffer;
+
+	switch (trigger) {
+	case SENSOR_TRIG_DATA_READY:
+		return edata->header.events.drdy;
+	case SENSOR_TRIG_MOTION:
+		return edata->header.events.motion;
+	default:
+		return false;
+	}
 }
 
 SENSOR_DECODER_API_DT_DEFINE() = {
@@ -322,6 +331,8 @@ int pat9136_encode(const struct device *dev,
 	int err;
 
 	edata->header.channels = 0;
+	edata->header.events.drdy = 0;
+	edata->header.events.motion = 0;
 
 	for (size_t i = 0 ; i < num_channels; i++) {
 		edata->header.channels |= pat9136_encode_channel(channels[i].chan_type);

--- a/drivers/sensor/pixart/pat9136/pat9136_decoder.h
+++ b/drivers/sensor/pixart/pat9136/pat9136_decoder.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2025 Croxel Inc.
+ * Copyright (c) 2025 CogniPilot Foundation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_DRIVERS_SENSOR_PAT9136_DECODER_H_
+#define ZEPHYR_DRIVERS_SENSOR_PAT9136_DECODER_H_
+
+#include <stdint.h>
+#include <zephyr/drivers/sensor.h>
+#include "pat9136.h"
+
+int pat9136_encode(const struct device *dev,
+		   const struct sensor_chan_spec *const channels,
+		   size_t num_channels,
+		   uint8_t *buf);
+
+uint8_t pat9136_encode_channel(uint16_t chan);
+
+int pat9136_get_decoder(const struct device *dev,
+			const struct sensor_decoder_api **decoder);
+
+#endif /* ZEPHYR_DRIVERS_SENSOR_PAT9136_DECODER_H_ */

--- a/drivers/sensor/pixart/pat9136/pat9136_reg.h
+++ b/drivers/sensor/pixart/pat9136/pat9136_reg.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2025 Croxel Inc.
+ * Copyright (c) 2025 CogniPilot Foundation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_DRIVERS_SENSOR_PAT9136_REG_H_
+#define ZEPHYR_DRIVERS_SENSOR_PAT9136_REG_H_
+
+#define REG_SPI_READ_BIT			0
+#define REG_SPI_WRITE_BIT			BIT(7)
+
+/* Registers */
+#define REG_PRODUCT_ID				0x00
+#define REG_MOTION				0x02
+#define REG_OBSERVATION				0x15
+#define REG_BURST_READ				0x16
+#define REG_POWER_UP_RESET			0x3A
+#define REG_RESOLUTION_SET			0x47
+#define REG_RESOLUTION_X_LOWER			0x48
+#define REG_RESOLUTION_X_UPPER			0x49
+#define REG_RESOLUTION_Y_LOWER			0x4A
+#define REG_RESOLUTION_Y_UPPER			0x4B
+
+/* Misc. Defines */
+#define PRODUCT_ID				0x4F
+#define POWER_UP_RESET_VAL			0x5A
+
+#define REG_MOTION_DETECTED(val)		((val) & BIT(7))
+
+#define REG_OBSERVATION_READ_IS_VALID(val)	(((val) == 0xB7) || ((val) == 0xBF))
+
+#endif /* ZEPHYR_DRIVERS_SENSOR_PAT9136_REG_H_ */

--- a/drivers/sensor/pixart/pat9136/pat9136_stream.c
+++ b/drivers/sensor/pixart/pat9136/pat9136_stream.c
@@ -1,0 +1,385 @@
+/*
+ * Copyright (c) 2025 Croxel Inc.
+ * Copyright (c) 2025 CogniPilot Foundation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/drivers/sensor.h>
+#include <zephyr/drivers/sensor_clock.h>
+#include <zephyr/sys/check.h>
+#include <zephyr/rtio/rtio.h>
+#include <zephyr/rtio/work.h>
+#include <zephyr/drivers/sensor/pat9136.h>
+
+#include "pat9136.h"
+#include "pat9136_reg.h"
+#include "pat9136_stream.h"
+#include "pat9136_decoder.h"
+#include "pat9136_bus.h"
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(PAT9136_STREAM, CONFIG_SENSOR_LOG_LEVEL);
+
+static void start_drdy_backup_timer(const struct device *dev)
+{
+	struct pat9136_data *data = dev->data;
+	const struct pat9136_config *cfg = dev->config;
+
+	k_timer_start(&data->stream.timer,
+		      K_MSEC(cfg->backup_timer_period),
+		      K_NO_WAIT);
+}
+
+static void pat9136_complete_result(struct rtio *ctx,
+				    const struct rtio_sqe *sqe,
+				    void *arg)
+{
+	const struct device *dev = (const struct device *)arg;
+	struct pat9136_data *data = dev->data;
+	struct rtio_iodev_sqe *iodev_sqe = data->stream.iodev_sqe;
+	struct pat9136_encoded_data *edata = sqe->userdata;
+
+	data->stream.iodev_sqe = NULL;
+
+	edata->header.events.drdy = true &&
+				    data->stream.settings.enabled.drdy;
+	edata->header.events.motion = REG_MOTION_DETECTED(edata->motion) &&
+				      data->stream.settings.enabled.motion;
+	edata->header.channels = 0;
+
+	if ((data->stream.settings.enabled.drdy &&
+	      data->stream.settings.opt.drdy == SENSOR_STREAM_DATA_INCLUDE) ||
+	    (data->stream.settings.enabled.motion &&
+	      data->stream.settings.opt.motion == SENSOR_STREAM_DATA_INCLUDE)) {
+		edata->header.channels |= pat9136_encode_channel(SENSOR_CHAN_POS_DXYZ);
+		edata->header.channels |= pat9136_encode_channel(SENSOR_CHAN_POS_DXYZ_MM);
+	}
+
+	if (data->stream.settings.enabled.drdy) {
+		start_drdy_backup_timer(dev);
+	}
+
+	/** Attempt chip recovery if erratic behavior is detected  */
+	if (!REG_OBSERVATION_READ_IS_VALID(edata->observation)) {
+
+		LOG_WRN("CHIP OK register indicates issues. Attempting chip recovery: 0x%02X",
+			edata->observation);
+
+		rtio_iodev_sqe_err(iodev_sqe, -EAGAIN);
+	} else {
+		rtio_iodev_sqe_ok(iodev_sqe, 0);
+	}
+}
+
+static void pat9136_stream_get_data(const struct device *dev)
+{
+	struct pat9136_data *data = dev->data;
+	uint64_t cycles;
+	int err;
+
+	CHECKIF(!data->stream.iodev_sqe) {
+		LOG_WRN("No RTIO submission with an INT GPIO event");
+		return;
+	}
+
+	struct pat9136_encoded_data *buf;
+	uint32_t buf_len;
+	uint32_t buf_len_required = sizeof(struct pat9136_encoded_data);
+
+	err = rtio_sqe_rx_buf(data->stream.iodev_sqe,
+			      buf_len_required,
+			      buf_len_required,
+			      (uint8_t **)&buf,
+			      &buf_len);
+	__ASSERT(err == 0, "Failed to acquire buffer (len: %d) for encoded data: %d. "
+			   "Please revisit RTIO queue sizing and look for "
+			   "bottlenecks during sensor data processing",
+			   buf_len_required, err);
+
+	/** Still throw an error even if asserts are off */
+	if (err) {
+		struct rtio_iodev_sqe *iodev_sqe = data->stream.iodev_sqe;
+
+		LOG_ERR("Failed to acquire buffer for encoded data: %d", err);
+
+		data->stream.iodev_sqe = NULL;
+		rtio_iodev_sqe_err(iodev_sqe, err);
+		return;
+	}
+
+	struct rtio_sqe *write_res_x_sqe = rtio_sqe_acquire(data->rtio.ctx);
+	struct rtio_sqe *read_res_x_sqe = rtio_sqe_acquire(data->rtio.ctx);
+	struct rtio_sqe *write_res_y_sqe = rtio_sqe_acquire(data->rtio.ctx);
+	struct rtio_sqe *read_res_y_sqe = rtio_sqe_acquire(data->rtio.ctx);
+	struct rtio_sqe *write_sqe = rtio_sqe_acquire(data->rtio.ctx);
+	struct rtio_sqe *read_sqe = rtio_sqe_acquire(data->rtio.ctx);
+	struct rtio_sqe *cb_sqe = rtio_sqe_acquire(data->rtio.ctx);
+	uint8_t val;
+
+	err = sensor_clock_get_cycles(&cycles);
+	CHECKIF(err) {
+		struct rtio_iodev_sqe *iodev_sqe = data->stream.iodev_sqe;
+
+		LOG_ERR("Failed to get timestamp: %d", err);
+
+		data->stream.iodev_sqe = NULL;
+		rtio_iodev_sqe_err(iodev_sqe, err);
+		return;
+	}
+	buf->header.timestamp = sensor_clock_cycles_to_ns(cycles);
+
+	CHECKIF(!write_res_x_sqe || !read_res_x_sqe ||
+		!write_res_y_sqe || !read_res_y_sqe ||
+		!write_sqe || !read_sqe || !cb_sqe) {
+		LOG_ERR("Failed to acquire RTIO SQE's. Dropping all pending SQE's");
+		rtio_sqe_drop_all(data->rtio.ctx);
+
+		data->stream.iodev_sqe = NULL;
+		rtio_iodev_sqe_err(data->stream.iodev_sqe, -ENOMEM);
+		return;
+	}
+
+	/* X Resolution used for decoding DXY in mm */
+	{
+		val = REG_RESOLUTION_X_LOWER | REG_SPI_READ_BIT;
+
+		rtio_sqe_prep_tiny_write(write_res_x_sqe,
+					 data->rtio.iodev,
+					 RTIO_PRIO_HIGH,
+					 &val,
+					 1,
+					 NULL);
+		write_res_x_sqe->flags |= RTIO_SQE_TRANSACTION;
+
+		rtio_sqe_prep_read(read_res_x_sqe,
+				   data->rtio.iodev,
+				   RTIO_PRIO_HIGH,
+				   &buf->header.resolution.buf[0],
+				   1,
+				   NULL);
+		read_res_x_sqe->flags |= RTIO_SQE_CHAINED;
+	}
+
+	/* Y Resolution used for decoding DY in mm */
+	{
+		val = REG_RESOLUTION_Y_LOWER | REG_SPI_READ_BIT;
+
+		rtio_sqe_prep_tiny_write(write_res_y_sqe,
+					 data->rtio.iodev,
+					 RTIO_PRIO_HIGH,
+					 &val,
+					 1,
+					 NULL);
+		write_res_y_sqe->flags |= RTIO_SQE_TRANSACTION;
+
+		rtio_sqe_prep_read(read_res_y_sqe,
+				   data->rtio.iodev,
+				   RTIO_PRIO_HIGH,
+				   &buf->header.resolution.buf[2],
+				   1,
+				   NULL);
+		read_res_y_sqe->flags |= RTIO_SQE_CHAINED;
+	}
+
+	/* Pull out data */
+	{
+		val = REG_BURST_READ | REG_SPI_READ_BIT;
+
+		rtio_sqe_prep_tiny_write(write_sqe,
+					 data->rtio.iodev,
+					 RTIO_PRIO_HIGH,
+					 &val,
+					 1,
+					 NULL);
+		write_sqe->flags |= RTIO_SQE_TRANSACTION;
+
+		rtio_sqe_prep_read(read_sqe,
+				   data->rtio.iodev,
+				   RTIO_PRIO_HIGH,
+				   buf->buf,
+				   sizeof(buf->buf),
+				   NULL);
+		read_sqe->flags |= RTIO_SQE_CHAINED;
+	}
+
+	rtio_sqe_prep_callback_no_cqe(cb_sqe,
+				      pat9136_complete_result,
+				      (void *)dev,
+				      buf);
+
+	rtio_submit(data->rtio.ctx, 0);
+}
+
+static void pat9136_gpio_callback(const struct device *gpio_dev,
+				  struct gpio_callback *cb,
+				  uint32_t pins)
+{
+	struct pat9136_stream *stream = CONTAINER_OF(cb,
+						     struct pat9136_stream,
+						     cb);
+	const struct device *dev = stream->dev;
+	const struct pat9136_config *cfg = dev->config;
+	int err;
+
+	/* Disable interrupts */
+	err = gpio_pin_interrupt_configure_dt(&cfg->int_gpio,
+					      GPIO_INT_MODE_DISABLED);
+	if (err) {
+		LOG_ERR("Failed to disable interrupt");
+		return;
+	}
+
+	pat9136_stream_get_data(dev);
+}
+
+static void pat9136_stream_drdy_timeout(struct k_timer *timer)
+{
+	struct pat9136_stream *stream = CONTAINER_OF(timer,
+						     struct pat9136_stream,
+						     timer);
+	const struct device *dev = stream->dev;
+	const struct pat9136_config *cfg = dev->config;
+	int err;
+
+	/* Disable interrupts */
+	err = gpio_pin_interrupt_configure_dt(&cfg->int_gpio,
+					      GPIO_INT_MODE_DISABLED);
+	if (err) {
+		LOG_ERR("Failed to disable interrupt");
+		return;
+	}
+
+	pat9136_stream_get_data(dev);
+}
+
+static inline bool settings_changed(const struct pat9136_stream *a,
+				    const struct pat9136_stream *b)
+{
+	return (a->settings.enabled.drdy != b->settings.enabled.drdy) ||
+	       (a->settings.opt.drdy != b->settings.opt.drdy) ||
+	       (a->settings.enabled.motion != b->settings.enabled.motion) ||
+	       (a->settings.opt.motion != b->settings.opt.motion);
+}
+
+void pat9136_stream_submit(const struct device *dev,
+			   struct rtio_iodev_sqe *iodev_sqe)
+{
+	const struct sensor_read_config *read_config = iodev_sqe->sqe.iodev->data;
+	struct pat9136_data *data = dev->data;
+	const struct pat9136_config *cfg = dev->config;
+	int err;
+
+	/** This separate struct is required due to the streaming API using a
+	 * multi-shot RTIO submission: meaning, re-submitting itself after
+	 * completion; hence, we don't have context to determine if this was
+	 * the first submission that kicked things off. We're then, inferring
+	 * this by comparing if the read-config has changed, and only restart
+	 * in such case.
+	 */
+	struct pat9136_stream stream = {0};
+
+	for (size_t i = 0 ; i < read_config->count ; i++) {
+		switch (read_config->channels[i].chan_type) {
+		case SENSOR_TRIG_DATA_READY:
+			stream.settings.enabled.drdy = true;
+			stream.settings.opt.drdy = read_config->triggers[i].opt;
+			break;
+		case SENSOR_TRIG_MOTION:
+			stream.settings.enabled.motion = true;
+			stream.settings.opt.motion = read_config->triggers[i].opt;
+			break;
+		default:
+			LOG_ERR("Unsupported trigger (%d)", read_config->triggers[i].trigger);
+			rtio_iodev_sqe_err(iodev_sqe, -ENOTSUP);
+			return;
+		}
+	}
+
+	/* Store context for next submission (handled within callbacks) */
+	data->stream.iodev_sqe = iodev_sqe;
+
+	if (settings_changed(&data->stream, &stream)) {
+		uint8_t motion_data[6];
+
+		data->stream.settings = stream.settings;
+
+		/* Disable interrupts */
+		err = gpio_pin_interrupt_configure_dt(&cfg->int_gpio,
+						      GPIO_INT_MODE_DISABLED);
+		if (err) {
+			LOG_ERR("Failed to disable interrupt");
+			data->stream.iodev_sqe = NULL;
+			rtio_iodev_sqe_err(iodev_sqe, err);
+			return;
+		}
+
+		/* Read reg's 0x02-0x06 to clear motion data. */
+		err = pat9136_bus_read(dev, REG_MOTION, motion_data, sizeof(motion_data));
+		if (err) {
+			LOG_ERR("Failed to read motion data");
+			data->stream.iodev_sqe = NULL;
+			rtio_iodev_sqe_err(iodev_sqe, err);
+			return;
+		}
+	}
+
+	/* Re-enable interrupts */
+	err = gpio_pin_interrupt_configure_dt(&cfg->int_gpio,
+						GPIO_INT_LEVEL_ACTIVE);
+	if (err) {
+		LOG_ERR("Failed to enable interrupt");
+		data->stream.iodev_sqe = NULL;
+		rtio_iodev_sqe_err(iodev_sqe, err);
+		return;
+	}
+
+	/** Back-up timer allows us to keep checking in with the sensor in
+	 * spite of not having any motion. This results in allowing sensor
+	 * recovery if falling in erratic state.
+	 */
+	if (data->stream.settings.enabled.drdy) {
+		start_drdy_backup_timer(dev);
+	}
+}
+
+int pat9136_stream_init(const struct device *dev)
+{
+	const struct pat9136_config *cfg = dev->config;
+	struct pat9136_data *data = dev->data;
+	int err;
+
+	/** Needed to get back the device handle from the callback context */
+	data->stream.dev = dev;
+
+	if (!cfg->int_gpio.port) {
+		LOG_ERR("Interrupt GPIO not supplied");
+		return -ENODEV;
+	}
+
+	if (!gpio_is_ready_dt(&cfg->int_gpio)) {
+		LOG_ERR("Interrupt GPIO not ready");
+		return -ENODEV;
+	}
+
+	err = gpio_pin_configure_dt(&cfg->int_gpio, GPIO_INPUT);
+	if (err) {
+		LOG_ERR("Failed to configure interrupt GPIO");
+		return -EIO;
+	}
+
+	gpio_init_callback(&data->stream.cb,
+			   pat9136_gpio_callback,
+			   BIT(cfg->int_gpio.pin));
+
+	err = gpio_add_callback(cfg->int_gpio.port, &data->stream.cb);
+	if (err) {
+		LOG_ERR("Failed to add interrupt callback");
+		return -EIO;
+	}
+
+	k_timer_init(&data->stream.timer, pat9136_stream_drdy_timeout, NULL);
+
+	return err;
+}

--- a/drivers/sensor/pixart/pat9136/pat9136_stream.h
+++ b/drivers/sensor/pixart/pat9136/pat9136_stream.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2025 Croxel Inc.
+ * Copyright (c) 2025 CogniPilot Foundation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/drivers/sensor.h>
+#include <zephyr/rtio/rtio.h>
+
+#ifndef ZEPHYR_DRIVERS_SENSOR_PAT9136_STREAM_H_
+#define ZEPHYR_DRIVERS_SENSOR_PAT9136_STREAM_H_
+
+int pat9136_stream_init(const struct device *dev);
+
+void pat9136_stream_submit(const struct device *dev,
+			   struct rtio_iodev_sqe *iodev_sqe);
+
+#endif /* ZEPHYR_DRIVERS_SENSOR_PAT9136_STREAM_H_ */

--- a/dts/bindings/sensor/pixart,pat9136.yaml
+++ b/dts/bindings/sensor/pixart,pat9136.yaml
@@ -33,3 +33,13 @@ properties:
       even if no motion is present, when Data-Ready streaming trigger is
       configured.
       Default is 1000X the fastest frame rate (20,000 fps).
+
+  cooldown-timer-ms:
+    type: int
+    default: 10
+    description: |
+      The cooldown timer in milliseconds used to prevent flooding the system
+      with interrupts (potentially at max 20,000 fps) while Data-Ready
+      streaming trigger is configured.
+      Default is 200X the fastest frame rate (20,000 fps).
+      Must be less than backup-timer-ms.

--- a/dts/bindings/sensor/pixart,pat9136.yaml
+++ b/dts/bindings/sensor/pixart,pat9136.yaml
@@ -17,3 +17,19 @@ properties:
       (CPI), following the formula CPI = (1 + resolution) * 100.
       Valid range is 0 to 199.
       Default is value set during Performance Optimization Settings.
+
+  int-gpios:
+    type: phandle-array
+    description: |
+      The INT signal default configuration is active-low. The
+      property value should ensure the flags properly describe the
+      signal that is presented to the driver.
+
+  backup-timer-ms:
+    type: int
+    default: 50
+    description: |
+      The back-up timer in milliseconds used to ensure sensor interaction
+      even if no motion is present, when Data-Ready streaming trigger is
+      configured.
+      Default is 1000X the fastest frame rate (20,000 fps).

--- a/dts/bindings/sensor/pixart,pat9136.yaml
+++ b/dts/bindings/sensor/pixart,pat9136.yaml
@@ -1,0 +1,19 @@
+# Copyright (c) 2025 Croxel Inc.
+# Copyright (c) 2025 CogniPilot Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+description: PAT9136 optical flow sensor
+
+compatible: "pixart,pat9136"
+
+include: [sensor-device.yaml, spi-device.yaml]
+
+properties:
+  resolution:
+    type: int
+    default: 19
+    description: |
+      The resolution of the sensor which indirectly results in counts per inch
+      (CPI), following the formula CPI = (1 + resolution) * 100.
+      Valid range is 0 to 199.
+      Default is value set during Performance Optimization Settings.

--- a/include/zephyr/drivers/sensor/pat9136.h
+++ b/include/zephyr/drivers/sensor/pat9136.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2025 Croxel Inc.
+ * Copyright (c) 2025 CogniPilot Foundation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_SENSOR_PAT9136_H_
+#define ZEPHYR_INCLUDE_DRIVERS_SENSOR_PAT9136_H_
+
+#include <zephyr/drivers/sensor.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** This sensor does have the ability to provide DXY in meaningful units, and
+ * since the standard channels' unit is in points (SENSOR_CHAN_POS_DX,
+ * SENSOR_CHAN_POS_DY, SENSOR_CHAN_POS_DXYZ), we've captured the following
+ * channels to provide an alternative for this sensor.
+ */
+enum sensor_channel_pat9136 {
+	/** Position change on the X axis, in millimeters. */
+	SENSOR_CHAN_POS_DX_MM = SENSOR_CHAN_PRIV_START + 1,
+	/** Position change on the Y axis, in millimeters. */
+	SENSOR_CHAN_POS_DY_MM,
+	/** Position change on the X, Y and Z axis, in millimeters.
+	 * Added additional offset so the channels X and Y can be accessed
+	 * relative to XYZ in spite of not supporting DZ.
+	 */
+	SENSOR_CHAN_POS_DXYZ_MM = SENSOR_CHAN_POS_DY_MM + 2,
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_SENSOR_PAT9136_H_ */

--- a/tests/drivers/build_all/sensor/spi.dtsi
+++ b/tests/drivers/build_all/sensor/spi.dtsi
@@ -413,3 +413,10 @@ paa3905: paa3905@32 {
 	reg = <0x32>;
 	int-gpios = <&test_gpio 0 0>;
 };
+
+test_spi_pat9136: pat9136@33 {
+	compatible = "pixart,pat9136";
+	reg = <0x33>;
+	spi-max-frequency = <0>;
+	int-gpios = <&test_gpio 0 0>;
+};


### PR DESCRIPTION
### Description
This PR introduces an Optical Flow Sensor, capable of tracking motion changes in XY plane.
Includes the following features:
- Read/Decode API support.
- Add private channels for getting DXY in millimeters.
- Streaming support, for the following triggers:
    - Data Ready.
    - Motion detected.
- Streaming support contains two software timers:
    - One for cooldown (preventing app to be flooded with interrupts at 20,000 fps) and
    - The other for back-up timer readout guarantee data-readout within a certain period (backup-timer), even if no motion is registered.


> [!NOTE]
> This PR Depends on:
> - SPI RTIO fix: #86169
> - PR establishing Pixart directories: #86644

### Testing
This has been tested with the Sensor Shell, both read/decode as well as streaming with the Robokit.