### PR TITLE
modules: nrf_wifi: Fix license

### DIFF
--- a/modules/nrf_wifi/bus/CMakeLists.txt
+++ b/modules/nrf_wifi/bus/CMakeLists.txt
@@ -1,7 +1,7 @@
 #
 # Copyright (c) 2024 Nordic Semiconductor ASA
 #
-# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-License-Identifier: Apache-2.0
 #
 
 # Check if ZEPHYR_BASE is set


### PR DESCRIPTION
Fix the license type to Apache 2.0, it was a left over during transition from BSD.