### PR TITLE
dts: dai: Simplify the description of the binding

### DIFF
--- a/dts/bindings/dai/intel,adsp-dmic-vss.yaml
+++ b/dts/bindings/dai/intel,adsp-dmic-vss.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-description: Intel DMIC Vendor SHIM controller
+description: Intel DMIC Vendor SHIM Controller
 
 compatible: "intel,adsp-dmic-vss"
 

--- a/dts/bindings/dai/intel,dai-dmic.yaml
+++ b/dts/bindings/dai/intel,dai-dmic.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-description: Intel Digital PDM Microphone (DMIC) node
+description: Intel Digital PDM Microphone (DMIC)
 
 compatible: "intel,dai-dmic"
 

--- a/dts/bindings/dai/nxp,dai-esai.yaml
+++ b/dts/bindings/dai/nxp,dai-esai.yaml
@@ -1,7 +1,7 @@
 # Copyright 2024 NXP
 # SPDX-License-Identifier: Apache-2.0
 
-description: NXP Enhanced Serial Audio Interface (ESAI) node
+description: NXP Enhanced Serial Audio Interface (ESAI)
 
 compatible: "nxp,dai-esai"
 

--- a/dts/bindings/dai/nxp,dai-micfil.yaml
+++ b/dts/bindings/dai/nxp,dai-micfil.yaml
@@ -1,7 +1,7 @@
 # Copyright 2023 NXP
 # SPDX-License-Identifier: Apache-2.0
 
-description: NXP PDM MICFIL node
+description: NXP PDM MICFIL
 
 compatible: "nxp,dai-micfil"
 

--- a/dts/bindings/dai/nxp,dai-sai.yaml
+++ b/dts/bindings/dai/nxp,dai-sai.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-  NXP Synchronous Audio Interface (SAI) node
+  NXP Synchronous Audio Interface (SAI)
 
   Below you may find some configuration examples:
 


### PR DESCRIPTION
Remove redundant descriptions in DAI bindings, such as "... node".