### PR TITLE
dts: pinctrl: Simplify the description of the binding

### DIFF
--- a/dts/bindings/pinctrl/adi,max32-pinctrl.yaml
+++ b/dts/bindings/pinctrl/adi,max32-pinctrl.yaml
@@ -2,9 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-  MAX32 Pin controller Node
-  Based on pincfg-node.yaml binding.
+  MAX32 Pin Controller
 
+  Based on pincfg-node.yaml binding.
   Note: `bias-disable`  are default pin configurations.
 
 compatible: "adi,max32-pinctrl"

--- a/dts/bindings/pinctrl/atmel,sam-pinctrl.yaml
+++ b/dts/bindings/pinctrl/atmel,sam-pinctrl.yaml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-  Atmel SAM Pinctrl container node
+  Atmel SAM Pinctrl Container
 
   The Atmel SAM pin controller is a singleton node responsible for controlling
   pin function selection and pin properties. For example, you can use this node

--- a/dts/bindings/pinctrl/atmel,sam0-pinctrl.yaml
+++ b/dts/bindings/pinctrl/atmel,sam0-pinctrl.yaml
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-  Atmel SAM0 Pinctrl container node
+  Atmel SAM0 Pinctrl Container
 
   The Atmel SAM0 pin controller is a singleton node responsible for controlling
   pin function selection and pin properties. For example, you can use this node

--- a/dts/bindings/pinctrl/infineon,cat1-pinctrl.yaml
+++ b/dts/bindings/pinctrl/infineon,cat1-pinctrl.yaml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-  Infineon CAT1 Pinctrl container node
+  Infineon CAT1 Pinctrl Container
 
   This is a singleton node responsible for controlling the pin function selection
   and pin properties. For example, you can use this node to route

--- a/dts/bindings/pinctrl/ite,it8xxx2-pinctrl-func.yaml
+++ b/dts/bindings/pinctrl/ite,it8xxx2-pinctrl-func.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2022 ITE Corporation. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-description: ITE IT8XXX2 pin controller function node
+description: ITE IT8XXX2 Pin Controller
 
 compatible: "ite,it8xxx2-pinctrl-func"
 

--- a/dts/bindings/pinctrl/microchip,mec5-pinctrl.yaml
+++ b/dts/bindings/pinctrl/microchip,mec5-pinctrl.yaml
@@ -2,7 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-    Microchip XEC Pin controller Node
+    Microchip XEC Pin controller
+
     Based on pincfg-node.yaml binding.
     The MCHP XEC pin controller is a singleton node responsible for controlling
     pin function selection and pin properties. For example, you can use this

--- a/dts/bindings/pinctrl/microchip,xec-pinctrl.yaml
+++ b/dts/bindings/pinctrl/microchip,xec-pinctrl.yaml
@@ -3,7 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-    Microchip XEC Pin controller Node
+    Microchip XEC Pin Controller
+
     Based on pincfg-node.yaml binding.
     The MCHP XEC pin controller is a singleton node responsible for controlling
     pin function selection and pin properties. For example, you can use this

--- a/dts/bindings/pinctrl/nuvoton,npcx-scfg.yaml
+++ b/dts/bindings/pinctrl/nuvoton,npcx-scfg.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2020 Nuvoton Technology Corporation.
 # SPDX-License-Identifier: Apache-2.0
 
-description: Nuvoton, NPCX System Configuration (Pinmux, 1.8V support and so on) node
+description: Nuvoton NPCX System Configuration (Pinmux, 1.8V support and so on)
 
 compatible: "nuvoton,npcx-scfg"
 

--- a/dts/bindings/pinctrl/nxp,imx-gpr.yaml
+++ b/dts/bindings/pinctrl/nxp,imx-gpr.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-  i.MX IOMUXC node
+  i.MX IOMUXC
 
   The specifier space "pinmux" of this binding should have two cells describing
   the resources needed from the GPR registers.

--- a/dts/bindings/pinctrl/nxp,mci-io-mux.yaml
+++ b/dts/bindings/pinctrl/nxp,mci-io-mux.yaml
@@ -2,7 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-  MCI IO MUX pin control node. This node defines pin configurations in pin
+  MCI IO MUX Pin Controller
+
+  This node defines pin configurations in pin
   groups, and has the 'pinctrl' node identifier in the SOC's devicetree. Each
   group within the pin configuration defines a peripheral's pin configuration.
   Each numbered subgroup represents pins with shared configuration for that

--- a/dts/bindings/pinctrl/nxp,port-pinctrl.yaml
+++ b/dts/bindings/pinctrl/nxp,port-pinctrl.yaml
@@ -2,7 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-  NXP PORT pinctrl node. This node will define pin configurations in pin
+  NXP PORT Pin Controller
+
+  This node will define pin configurations in pin
   groups, and has the 'pinctrl' node identifier in the SOC's devicetree. Each
   group within the pin configuration defines the pin configuration for a
   peripheral, and each numbered subgroup in the pin group defines all the pins

--- a/dts/bindings/pinctrl/nxp,port-pinmux.yaml
+++ b/dts/bindings/pinctrl/nxp,port-pinmux.yaml
@@ -1,4 +1,4 @@
-description: NXP PORT pinmux node
+description: NXP PORT Pin Controller
 
 compatible: "nxp,port-pinmux"
 

--- a/dts/bindings/pinctrl/nxp,rt-iocon-pinctrl.yaml
+++ b/dts/bindings/pinctrl/nxp,rt-iocon-pinctrl.yaml
@@ -2,7 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-  RT600/RT500 pin control node. This node defines pin configurations in pin
+  RT600/RT500 Pin Controller
+
+  This node defines pin configurations in pin
   groups, and has the 'pinctrl' node identifier in the SOC's devicetree. Each
   group within the pin configuration defines a peripheral's pin configuration.
   Each numbered subgroup represents pins with shared configuration for that

--- a/dts/bindings/pinctrl/nxp,s32k3-pinctrl.yaml
+++ b/dts/bindings/pinctrl/nxp,s32k3-pinctrl.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-  NXP S32 pinctrl node for S32K3 SoCs.
+  NXP S32 Pin Controller for S32K3 SoCs
 
   The NXP S32 pin controller is a singleton node responsible for controlling
   the pin function selection and pin properties. This node, labeled 'pinctrl' in

--- a/dts/bindings/pinctrl/nxp,s32ze-pinctrl.yaml
+++ b/dts/bindings/pinctrl/nxp,s32ze-pinctrl.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-  NXP S32 pinctrl node for S32Z/E SoCs.
+  NXP S32 Pin Controller for S32Z/E SoCs
 
   The NXP S32 pin controller is a singleton node responsible for controlling
   the pin function selection and pin properties. This node, labeled 'pinctrl' in

--- a/dts/bindings/pinctrl/openisa,rv32m1-pinctrl.yaml
+++ b/dts/bindings/pinctrl/openisa,rv32m1-pinctrl.yaml
@@ -3,7 +3,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-  OpenISA RV32M1 pinctrl node. This node will define pin configurations in pin groups,
+  OpenISA RV32M1 Pin Controller
+
+  This node will define pin configurations in pin groups,
   and has the 'pinctrl' node identifier in the SOC's devicetree. Each group
   within the pin configuration defines the pin configuration for a peripheral,
   and each numbered subgroup in the pin group defines all the pins for that

--- a/dts/bindings/pinctrl/openisa,rv32m1-pinmux.yaml
+++ b/dts/bindings/pinctrl/openisa,rv32m1-pinmux.yaml
@@ -1,4 +1,4 @@
-description: RV32M1 pinmux node
+description: RV32M1 pinmux
 
 compatible: "openisa,rv32m1-pinmux"
 

--- a/dts/bindings/pinctrl/realtek,rts5912-pinctrl.yaml
+++ b/dts/bindings/pinctrl/realtek,rts5912-pinctrl.yaml
@@ -3,8 +3,7 @@
 # Copyright (c) 2024 Realtek Semiconductor Corporation, SIBG-SD7
 #
 
-description: |
-     This binding gives a base representation of the pins configuration
+description: Realtek RTS5912 Pin Controller
 
 compatible: "realtek,rts5912-pinctrl"
 

--- a/dts/bindings/pinctrl/renesas,rcar-pfc.yaml
+++ b/dts/bindings/pinctrl/renesas,rcar-pfc.yaml
@@ -2,7 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-    Renesas R-Car Pin Function Controller node
+    Renesas R-Car Pin Function Controller
+
     This binding gives a base representation of the R-Car pins configuration.
     The R-Car pin controller is a singleton node responsible for controlling
     pin function selection and pin properties. For example, you can use this

--- a/dts/bindings/pinctrl/silabs,si32-pinctrl.yaml
+++ b/dts/bindings/pinctrl/silabs,si32-pinctrl.yaml
@@ -2,8 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-description: |
-  Silabs Si32 pinctrl node
+description: Silabs Si32 Pin Controller
 
 compatible: "silabs,si32-pinctrl"
 

--- a/dts/bindings/pinctrl/ti,cc13xx-cc26xx-pinctrl.yaml
+++ b/dts/bindings/pinctrl/ti,cc13xx-cc26xx-pinctrl.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-    TI SimpleLink CC13xx / CC26xx pinctrl node.
+    TI SimpleLink CC13xx / CC26xx Pin Controller
 
     Device pin configuration should be placed in the child nodes of this node.
     Populate the 'pinmux' field with a pair consisting of a pin number and its IO

--- a/dts/bindings/pinctrl/ti,cc23x0-pinctrl.yaml
+++ b/dts/bindings/pinctrl/ti,cc23x0-pinctrl.yaml
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-    TI SimpleLink CC23X0 pinctrl node.
+    TI SimpleLink CC23X0 Pin Controller
 
     Device pin configuration should be placed in the child nodes of this node.
     Populate the 'pinmux' field with a pair consisting of a pin number and its IO

--- a/dts/bindings/pinctrl/ti,k3-pinctrl.yaml
+++ b/dts/bindings/pinctrl/ti,k3-pinctrl.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-  TI K3 pinctrl node.
+  TI K3 Pin Controller
 
   Pins can be configured using the following macro "K3_PINMUX(offset, value, mux_mode)".
   offset - the pin attribute register offset from the base address.

--- a/dts/bindings/pinctrl/xlnx,pinctrl-zynqmp.yaml
+++ b/dts/bindings/pinctrl/xlnx,pinctrl-zynqmp.yaml
@@ -2,8 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-  Xilinx ZynqMP SoC pinctrl node. It allows configuration of pin assignments
-  for the supported peripherals.
+  Xilinx ZynqMP SoC Pin Controller
+
+  It allows configuration of pin assignments for the supported peripherals.
 
   See Zynq UltraScale+ Devices Register Reference (UG1087) for details regarding
   valid pin assignments


### PR DESCRIPTION
Remove redundant descriptions in pinctrl bindings, such as "... node".