### PR TITLE
drivers: hci: ipc: Make IPC endpoint bound timeout configurable

### DIFF
--- a/drivers/bluetooth/hci/Kconfig
+++ b/drivers/bluetooth/hci/Kconfig
@@ -58,6 +58,14 @@ config BT_HCI_IPC_SEND_RETRY_DELAY_US
 	  When a single tick (CONFIG_SYS_CLOCK_TICKS_PER_SEC) is bigger then
 	  the retry delay the k_busy_wait function is used. Set with care.
 
+config BT_HCI_IPC_ENDPOINT_BOUND_TIMEOUT_MS
+	int "HCI IPC binding timeout value in milliseconds"
+	depends on BT_HCI_IPC
+	default 2000
+	help
+	  Timeout value that HCI will wait for an IPC endpoint to be bound,
+	  in milliseconds.
+
 config BT_SPI
 	bool
 	select SPI

--- a/drivers/bluetooth/hci/ipc.c
+++ b/drivers/bluetooth/hci/ipc.c
@@ -24,7 +24,7 @@ BUILD_ASSERT(!IS_ENABLED(CONFIG_BT_CONN) || IS_ENABLED(CONFIG_BT_HCI_ACL_FLOW_CO
 
 #define DT_DRV_COMPAT zephyr_bt_hci_ipc
 
-#define IPC_BOUND_TIMEOUT_IN_MS K_MSEC(1000)
+#define IPC_BOUND_TIMEOUT_IN_MS K_MSEC(CONFIG_BT_HCI_IPC_ENDPOINT_BOUND_TIMEOUT_MS)
 
 /* The retry of ipc_service_send function requires a small (tens of us) delay.
  * In order to ensure proper delay k_usleep is used when the system clock is


### PR DESCRIPTION
The HCI IPC endpoint bound timeout value was hardcoded and set to 1000 ms. This value may be differ between platforms, for exampel due to extended boot time.
The default value used was a bit short for multicore SoCs that usually may wait for some other service reposnes for similar time. That may lead to timeout error while other end of an endpoint was slightly late. Change the default duration to 2000 ms to give more room for possible delays.