### PR TITLE
doc: litex: add zephyr:board-supported-hw directive

### DIFF
--- a/boards/enjoydigital/litex_vexriscv/doc/index.rst
+++ b/boards/enjoydigital/litex_vexriscv/doc/index.rst
@@ -42,6 +42,11 @@ using the
 `Zephyr on LiteX VexRiscv <https://github.com/litex-hub/zephyr-on-litex-vexriscv>`_
 reference platform. You can also use the official LiteX SoC Builder.
 
+Supported Features
+******************
+
+.. zephyr:board-supported-hw::
+
 Bitstream generation
 ********************
 


### PR DESCRIPTION
add zephyr:board-supported-hw directive to specify the supported hardware
features of the litex_vexriscv board.
