### PR TITLE
c++: allow removing inline comments from `devicetree_generated.h` 

### DIFF
--- a/doc/develop/languages/cpp/index.rst
+++ b/doc/develop/languages/cpp/index.rst
@@ -36,8 +36,17 @@ The C++ standard requires the ``main()`` function to have the return type of
 has to be selected. Zephyr ignores the return value from main, so applications
 should not return status information and should, instead, return zero.
 
+If you need to access data from the device tree in C++ files, add the following
+argument to the ``west build`` command to prevent compile-time macro expansion
+issues:
+
+.. code-block:: console
+
+   EXTRA_GEN_DEFINES_ARGS=--no-inline-comments
+
 .. note::
-    Do not use C++ for kernel, driver, or system initialization code.
+
+   Do not use C++ for kernel, driver, or system initialization code.
 
 Language Features
 *****************

--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -32,8 +32,10 @@ from devicetree import edtlib
 def main():
     global header_file
     global flash_area_num
+    global no_inline_comments
 
     args = parse_args()
+    no_inline_comments = args.no_inline_comments
 
     edtlib_logger.setup_edtlib_logging()
 
@@ -136,6 +138,8 @@ def parse_args() -> argparse.Namespace:
                         help="path to write header to")
     parser.add_argument("--edt-pickle",
                         help="path to read pickled edtlib.EDT object from")
+    parser.add_argument("--no-inline-comments", action="store_true",
+                        help="remove comments from #define lines")
 
     return parser.parse_args()
 
@@ -1015,6 +1019,9 @@ def out_define(
     # unless told not to.
 
     warn = fr' __WARN("{deprecation_msg}")' if deprecation_msg else ""
+
+    if no_inline_comments:
+        val = re.sub("\\s*/\\*.*?\\*/\\s*", "", str(val))
 
     if width:
         s = f"#define {macro.ljust(width)}{warn} {val}"

--- a/tests/lib/cpp/cxx/app.overlay
+++ b/tests/lib/cpp/cxx/app.overlay
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  *
  * Application overlay for creating a fake device instance we can use to
- * test. Subset of tests/kernel/device/app.overlay and other app.overlay
- * files.
+ * test. Nested devices have been used to avoid cross-platform issues by
+ * forcing a specific 'reg' property size on child nodes.
  */
 
 / {
@@ -19,5 +19,19 @@
 		status = "okay";
 
 		zephyr,deferred-init;
+	};
+
+	test_ctrl: ctrl {
+		compatible = "fake-cpp-driver";
+		status = "okay";
+
+		#address-cells = < 1 >;
+		#size-cells = < 0 >;
+
+		test_dev2_reg_addr: dev2@2 {
+			reg = < 2 >;
+			compatible = "fake-cpp-driver";
+			status = "okay";
+		};
 	};
 };

--- a/tests/lib/cpp/cxx/src/main.cpp
+++ b/tests/lib/cpp/cxx/src/main.cpp
@@ -153,3 +153,22 @@ PM_DEVICE_DT_DEFINE(DT_NODELABEL(test_dev0_boot), fake_pm_action);
 
 DEVICE_DT_DEFINE(DT_NODELABEL(test_dev0_boot), NULL,
 		 PM_DEVICE_DT_GET(DT_NODELABEL(test_dev0_boot)), NULL, NULL, POST_KERNEL, 34, NULL);
+
+/*
+ * Test preprocessor comment removal. The reg value is defined as 2 in the
+ * device tree, but gen_defines.py by default outputs an entry that includes a
+ * trailing comment, such as:
+ *
+ *     #define DT_N_S_ctrl_S_dev2_2_REG_IDX_0_VAL_ADDRESS 2 / * 0x2 * /
+ *
+ * That comment, when present, confuses the C++ preprocessor and results in
+ * issues like the following:
+ *
+ *     error: pasting "/ * 0x2 * /" and "U" does not give a valid preprocessing token
+ *
+ * or, in this synthetic test case:
+ *
+ *     error: unable to find numeric literal operator 'operator""UU'
+ */
+#define VALUE_FROM_DT DT_REG_ADDR(DT_NODELABEL(test_dev2_reg_addr))
+BUILD_ASSERT(UINT32_C(VALUE_FROM_DT) == 2U);

--- a/tests/lib/cpp/cxx/testcase.yaml
+++ b/tests/lib/cpp/cxx/testcase.yaml
@@ -4,6 +4,8 @@ common:
   integration_platforms:
     - mps2/an385
     - qemu_cortex_a53
+  extra_args:
+    - EXTRA_GEN_DEFINES_ARGS=--no-inline-comments
 
 tests:
   cpp.main.minimal:


### PR DESCRIPTION
Preprocessor macros that paste together a number with a suffix, like `UINT32_C`, do not currently work properly in C++ code for some types of device tree data, such as the `reg` property. This is because `gen_defines.py` adds inline comments to those entries in the `devicetree_generated.h` files, and this confuses  the C++ preprocessor during macro expansion, resulting in errors like the following:
```
error: pasting "/* 0x12345678 */" and "U" does not give a valid preprocessing token
```
or, in the synthetic test case added in this PR:
```
  error: unable to find numeric literal operator 'operator""UU'
```
This may be verified by running `twister -T tests/lib/cpp/cxx` on just the first commit of this PR, as done in [this CI run](https://github.com/zephyrproject-rtos/zephyr/actions/runs/13722494936/job/38381301835?pr=86770#step:12:1628). Also, an actual example in a downstream project: https://github.com/arduino/ArduinoCore-zephyr/issues/80#issuecomment-2699193343 . 

This PR fixes the issue by adding an option to the `gen_defines.py`, using it in the C++ test and mentioning it in [the C++ documentation page](https://builds.zephyrproject.io/zephyr/pr/86758/docs/develop/languages/cpp/index.html#enabling-c-support) for downstream users.
