### PR TITLE
drivers: eth: phy: adin2111 correct logger name and includes

### DIFF
--- a/drivers/ethernet/phy/phy_adin2111.c
+++ b/drivers/ethernet/phy/phy_adin2111.c
@@ -5,21 +5,20 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/logging/log.h>
-
-LOG_MODULE_REGISTER(phy_adin, CONFIG_PHY_LOG_LEVEL);
-
 #include <errno.h>
 #include <stdint.h>
 #include <stdbool.h>
 #include <zephyr/kernel.h>
 #include <zephyr/device.h>
-#include <zephyr/sys/util.h>
-#include <zephyr/net/phy.h>
-#include <zephyr/net/mii.h>
-#include <zephyr/net/mdio.h>
 #include <zephyr/drivers/mdio.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/net/mdio.h>
+#include <zephyr/net/mii.h>
+#include <zephyr/net/phy.h>
+#include <zephyr/sys/util.h>
 #include "phy_adin2111_priv.h"
+
+LOG_MODULE_REGISTER(phy_adin, CONFIG_PHY_LOG_LEVEL);
 
 /* PHYs out of reset check retry delay */
 #define ADIN2111_PHY_AWAIT_DELAY_POLL_US			15U

--- a/drivers/ethernet/phy/phy_adin2111.c
+++ b/drivers/ethernet/phy/phy_adin2111.c
@@ -19,6 +19,7 @@ LOG_MODULE_REGISTER(phy_adin, CONFIG_PHY_LOG_LEVEL);
 #include <zephyr/net/mii.h>
 #include <zephyr/net/mdio.h>
 #include <zephyr/drivers/mdio.h>
+#include "phy_adin2111_priv.h"
 
 /* PHYs out of reset check retry delay */
 #define ADIN2111_PHY_AWAIT_DELAY_POLL_US			15U

--- a/drivers/ethernet/phy/phy_adin2111.c
+++ b/drivers/ethernet/phy/phy_adin2111.c
@@ -7,7 +7,7 @@
 
 #include <zephyr/logging/log.h>
 
-LOG_MODULE_REGISTER(DT_DRV_COMPAT, CONFIG_PHY_LOG_LEVEL);
+LOG_MODULE_REGISTER(phy_adin, CONFIG_PHY_LOG_LEVEL);
 
 #include <errno.h>
 #include <stdint.h>


### PR DESCRIPTION
After #82693 refactoring the logger name is `DT_DRV_COMPAT` instead of `adi_adin2111_phy` or `adi_adin1100_phy`.

This PR changes the logger name to `phy_adin`, adds the missing private header and sorts the includes.