### PR TITLE
drivers: timer: nrf_rtc_timer: do not start LFCLK unless CLOCK_CONTROL

### DIFF
--- a/drivers/timer/nrf_rtc_timer.c
+++ b/drivers/timer/nrf_rtc_timer.c
@@ -726,13 +726,6 @@ void sys_clock_disable(void)
 
 static int sys_clock_driver_init(void)
 {
-	static const enum nrf_lfclk_start_mode mode =
-		IS_ENABLED(CONFIG_SYSTEM_CLOCK_NO_WAIT) ?
-			CLOCK_CONTROL_NRF_LF_START_NOWAIT :
-			(IS_ENABLED(CONFIG_SYSTEM_CLOCK_WAIT_FOR_AVAILABILITY) ?
-			CLOCK_CONTROL_NRF_LF_START_AVAILABLE :
-			CLOCK_CONTROL_NRF_LF_START_STABLE);
-
 	int_event_disable_rtc();
 
 	/* TODO: replace with counter driver to access RTC */
@@ -763,7 +756,16 @@ static int sys_clock_driver_init(void)
 
 	compare_set(0, initial_timeout, sys_clock_timeout_handler, NULL, false);
 
+#if defined(CONFIG_CLOCK_CONTROL_NRF)
+	static const enum nrf_lfclk_start_mode mode =
+		IS_ENABLED(CONFIG_SYSTEM_CLOCK_NO_WAIT) ?
+			CLOCK_CONTROL_NRF_LF_START_NOWAIT :
+			(IS_ENABLED(CONFIG_SYSTEM_CLOCK_WAIT_FOR_AVAILABILITY) ?
+			CLOCK_CONTROL_NRF_LF_START_AVAILABLE :
+			CLOCK_CONTROL_NRF_LF_START_STABLE);
+
 	z_nrf_clock_control_lf_on(mode);
+#endif
 
 	return 0;
 }


### PR DESCRIPTION
Do not start the LF clock unless `CONFIG_CLOCK_CONTROL_NRF` is enabled.
This is similar to how it's done in Nordic's GRTC driver.

Authored-by: Krzysztof Chruściński <krzysztof.chruscinski@nordicsemi.no>