### PR TITLE
Bluetooth: SSP: Fix MITM flag incorrect issue in pairing

### DIFF
--- a/subsys/bluetooth/host/classic/l2cap_br.c
+++ b/subsys/bluetooth/host/classic/l2cap_br.c
@@ -1192,6 +1192,20 @@ failed:
 	return -EADDRNOTAVAIL;
 }
 
+bt_security_t bt_l2cap_br_get_max_sec_level(void)
+{
+	struct bt_l2cap_server *server;
+	bt_security_t sec_level = BT_SECURITY_L0;
+
+	SYS_SLIST_FOR_EACH_CONTAINER(&br_servers, server, node) {
+		if (sec_level < server->sec_level) {
+			sec_level = server->sec_level;
+		}
+	}
+
+	return sec_level;
+}
+
 int bt_l2cap_br_server_register(struct bt_l2cap_server *server)
 {
 	int err;

--- a/subsys/bluetooth/host/classic/l2cap_br_internal.h
+++ b/subsys/bluetooth/host/classic/l2cap_br_internal.h
@@ -217,3 +217,5 @@ struct net_buf *bt_l2cap_create_pdu_timeout(struct net_buf_pool *pool,
 
 #define bt_l2cap_create_pdu(_pool, _reserve) \
 	bt_l2cap_create_pdu_timeout(_pool, _reserve, K_FOREVER)
+
+bt_security_t bt_l2cap_br_get_max_sec_level(void);


### PR DESCRIPTION
There is a case that if the local is a peripheral and a L2CAP server with the security level 3，the mitm should be set to make sure the security level can reach level 3.

But in current implementation, the MITM is not set because the MITM of `Authentication_Requirements` parameter of remote is not set. And the security level will be level 2 after the security pairing procedure complete.

Add a function `bt_l2cap_br_get_max_sec_level` to get the max level of the registered servers.

Force set the MITM bit if the max level is bigger than level 2 and pairing method is not `just works`.