### PR TITLE
[DNM] c++: showcase gen_defines.py macro expansion issue

### DIFF
--- a/tests/lib/cpp/cxx/app.overlay
+++ b/tests/lib/cpp/cxx/app.overlay
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  *
  * Application overlay for creating a fake device instance we can use to
- * test. Subset of tests/kernel/device/app.overlay and other app.overlay
- * files.
+ * test. Nested devices have been used to avoid cross-platform issues by
+ * forcing a specific 'reg' property size on child nodes.
  */
 
 / {
@@ -19,5 +19,19 @@
 		status = "okay";
 
 		zephyr,deferred-init;
+	};
+
+	test_ctrl: ctrl {
+		compatible = "fake-cpp-driver";
+		status = "okay";
+
+		#address-cells = < 1 >;
+		#size-cells = < 0 >;
+
+		test_dev2_reg_addr: dev2@2 {
+			reg = < 2 >;
+			compatible = "fake-cpp-driver";
+			status = "okay";
+		};
 	};
 };

--- a/tests/lib/cpp/cxx/src/main.cpp
+++ b/tests/lib/cpp/cxx/src/main.cpp
@@ -153,3 +153,22 @@ PM_DEVICE_DT_DEFINE(DT_NODELABEL(test_dev0_boot), fake_pm_action);
 
 DEVICE_DT_DEFINE(DT_NODELABEL(test_dev0_boot), NULL,
 		 PM_DEVICE_DT_GET(DT_NODELABEL(test_dev0_boot)), NULL, NULL, POST_KERNEL, 34, NULL);
+
+/*
+ * Test preprocessor comment removal. The reg value is defined as 2 in the
+ * device tree, but gen_defines.py by default outputs an entry that includes a
+ * trailing comment, such as:
+ *
+ *     #define DT_N_S_ctrl_S_dev2_2_REG_IDX_0_VAL_ADDRESS 2 / * 0x2 * /
+ *
+ * That comment, when present, confuses the C++ preprocessor and results in
+ * issues like the following:
+ *
+ *     error: pasting "/ * 0x2 * /" and "U" does not give a valid preprocessing token
+ *
+ * or, in this synthetic test case:
+ *
+ *     error: unable to find numeric literal operator 'operator""UU'
+ */
+#define VALUE_FROM_DT DT_REG_ADDR(DT_NODELABEL(test_dev2_reg_addr))
+BUILD_ASSERT(UINT32_C(VALUE_FROM_DT) == 2U);


### PR DESCRIPTION
This PR showcases the issue fixed by #86758; it is the first commit of that series.