### PR TITLE
kernel: fix compilation with CONFIG_TIMER_READS_ITS_FREQUENCY_AT_RUNTIME

### DIFF
--- a/include/zephyr/sys_clock.h
+++ b/include/zephyr/sys_clock.h
@@ -154,11 +154,12 @@ typedef struct {
 
 /** @endcond */
 
+#ifndef CONFIG_TIMER_READS_ITS_FREQUENCY_AT_RUNTIME
 #if defined(CONFIG_SYS_CLOCK_EXISTS) && \
 	(CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC == 0)
 #error "SYS_CLOCK_HW_CYCLES_PER_SEC must be non-zero!"
 #endif
-
+#endif /* CONFIG_TIMER_READS_ITS_FREQUENCY_AT_RUNTIME */
 
 /* kernel clocks */
 

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -813,6 +813,7 @@ config SYS_CLOCK_TICKS_PER_SEC
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	int "System clock's h/w timer frequency"
+	default 0 if TIMER_READS_ITS_FREQUENCY_AT_RUNTIME
 	help
 	  This option specifies the frequency of the hardware timer used for the
 	  system clock (in Hz). This option is set by the SOC's or board's Kconfig file


### PR DESCRIPTION
Fix compilation with CONFIG_TIMER_READS_ITS_FREQUENCY_AT_RUNTIME=y and CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC unset at the board/SoC level.

```
In file included from /home/brix/Projects/zephyrproject/zephyr/include/zephyr/kernel_includes.h:38,
                 from /home/brix/Projects/zephyrproject/zephyr/include/zephyr/kernel.h:17,
                 from /home/brix/Projects/zephyrproject/zephyr/arch/riscv/core/offsets/offsets.c:17:
/home/brix/Projects/zephyrproject/zephyr/include/zephyr/sys_clock.h:158:45: error: operator '==' has no left operand
  158 |         (CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC == 0)
      |                                             ^~
/home/brix/Projects/zephyrproject/zephyr/include/zephyr/sys_clock.h:179:45: error: operator '%' has no left operand
  179 |         (CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC % CONFIG_SYS_CLOCK_TICKS_PER_SEC)
      |                                             ^
```