### PR TITLE
boards: nxp: MCXW: Add zephyr,bt-c2h-uart dts property

### DIFF
--- a/boards/nxp/frdm_mcxw71/frdm_mcxw71.dts
+++ b/boards/nxp/frdm_mcxw71/frdm_mcxw71.dts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 NXP
+ * Copyright 2024-2025 NXP
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -30,6 +30,7 @@
 		zephyr,uart-pipe = &lpuart0;
 		zephyr,canbus = &flexcan0;
 		zephyr,uart-mcumgr = &lpuart0;
+		zephyr,bt-c2h-uart = &lpuart0;
 	};
 
 	user_led {

--- a/boards/nxp/frdm_mcxw72/frdm_mcxw72_mcxw727c_cpu0.dts
+++ b/boards/nxp/frdm_mcxw72/frdm_mcxw72_mcxw727c_cpu0.dts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 NXP
+ * Copyright 2024-2025 NXP
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -27,6 +27,7 @@
 		zephyr,shell-uart = &lpuart1;
 		zephyr,uart-pipe = &lpuart0;
 		zephyr,canbus = &flexcan0;
+		zephyr,bt-c2h-uart = &lpuart0;
 	};
 
 	user_led {

--- a/boards/nxp/mcxw72_evk/mcxw72_evk_mcxw727c_cpu0.dts
+++ b/boards/nxp/mcxw72_evk/mcxw72_evk_mcxw727c_cpu0.dts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 NXP
+ * Copyright 2024-2025 NXP
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -27,6 +27,7 @@
 		zephyr,shell-uart = &lpuart1;
 		zephyr,uart-pipe = &lpuart0;
 		zephyr,canbus = &flexcan0;
+		zephyr,bt-c2h-uart = &lpuart0;
 	};
 
 	user_led {


### PR DESCRIPTION
Adding the property to support the hci_uart application.
I prefer defining this in the dts files rather than the app overlays.
