### PR TITLE
Misc cleanup following native posix removal

### DIFF
--- a/arch/posix/Kconfig
+++ b/arch/posix/Kconfig
@@ -27,7 +27,7 @@ config ARCH_POSIX_LIBFUZZER
 	help
 	  Build as an LLVM libfuzzer target. Requires
 	  support from the toolchain (currently only clang works, and
-	  only on native_{posix,sim}[//64]), and should normally be used in
+	  only on native_sim[//64]), and should normally be used in
 	  concert with some of CONFIG_ASAN/UBSAN/MSAN for validation.
 	  The application needs to implement the
 	  LLVMFuzzerTestOneInput() entry point, which runs in the host

--- a/arch/posix/include/posix_cheats.h
+++ b/arch/posix/include/posix_cheats.h
@@ -16,8 +16,8 @@
  * If you do see a link error telling you that zap_something is undefined, it is
  * likely that you forgot to select the corresponding Zephyr POSIX API.
  *
- * This header is included automatically when targeting some POSIX ARCH boards
- * (for ex. native_posix).
+ * This header is included automatically when targeting old POSIX ARCH boards
+ * based on the CONFIG_NATIVE_APPLICATION architecture.
  * It will be included in _all_ Zephyr and application source files
  * (it is passed with the option "-include" to the compiler call)
  *

--- a/boards/native/native_sim/cmdline_common.h
+++ b/boards/native/native_sim/cmdline_common.h
@@ -6,6 +6,9 @@
 #ifndef BOARDS_POSIX_NATIVE_SIM_CMDLINE_COMMON_H
 #define BOARDS_POSIX_NATIVE_SIM_CMDLINE_COMMON_H
 
+#warning "This transitional header is now deprecated and will be removed by v4.4. "\
+	 "Use nsi_cmdline.h instead."
+
 /*
  * To support native_posix drivers which register their own arguments
  * we provide a header with the same name as in native_posix

--- a/boards/native/native_sim/native_sim.dts
+++ b/boards/native/native_sim/native_sim.dts
@@ -54,7 +54,7 @@
 		#size-cells = <0>;
 
 		cpu0: cpu@0 {
-			compatible = "zephyr,native-posix-cpu";
+			compatible = "zephyr,native-sim-cpu";
 			reg = <0>;
 		};
 	};

--- a/doc/connectivity/networking/api/sockets.rst
+++ b/doc/connectivity/networking/api/sockets.rst
@@ -23,7 +23,7 @@ compatible API implementation for Zephyr:
   names like ``close()``, which may be part of libc or other POSIX
   compatibility libraries.
   If enabled by :kconfig:option:`CONFIG_POSIX_API`, it will also
-  expose native POSIX names.
+  expose POSIX compatible APIs.
 
 BSD Sockets compatible API is enabled using :kconfig:option:`CONFIG_NET_SOCKETS`
 config option and implements the following operations: ``socket()``, ``close()``,

--- a/drivers/bluetooth/hci/Kconfig
+++ b/drivers/bluetooth/hci/Kconfig
@@ -172,13 +172,13 @@ config BT_SILABS_SIWX91X
 
 config BT_USERCHAN
 	bool
-	depends on (BOARD_NATIVE_POSIX || BOARD_NATIVE_SIM)
+	depends on BOARD_NATIVE_SIM
 	default y
 	depends on DT_HAS_ZEPHYR_BT_HCI_USERCHAN_ENABLED
 	help
 	  This driver provides access to the local Linux host's Bluetooth
 	  adapter using a User Channel HCI socket to the Linux kernel. It
-	  is only intended to be used with the native POSIX build of Zephyr.
+	  is only intended to be used with the native_sim[//64] build of Zephyr.
 	  The Bluetooth adapter must be powered off in order for Zephyr to
 	  be able to use it.
 

--- a/drivers/can/can_native_linux_adapt.h
+++ b/drivers/can/can_native_linux_adapt.h
@@ -5,7 +5,7 @@
  */
 
 /** @file
- * @brief Private functions for native posix canbus driver.
+ * @brief Private functions for native_linux canbus driver.
  */
 
 #ifndef ZEPHYR_DRIVERS_CAN_NATIVE_LINUX_ADAPT_H_

--- a/dts/bindings/cpu/zephyr,native-sim-cpu.yaml
+++ b/dts/bindings/cpu/zephyr,native-sim-cpu.yaml
@@ -1,0 +1,8 @@
+# Copyright (c) 2021 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+description: native_sim CPU
+
+compatible: "zephyr,native-sim-cpu"
+
+include: cpu.yaml

--- a/include/zephyr/drivers/console/native_posix_console.h
+++ b/include/zephyr/drivers/console/native_posix_console.h
@@ -7,6 +7,9 @@
 #ifndef ZEPHYR_INCLUDE_DRIVERS_CONSOLE_NATIVE_POSIX_CONSOLE_H_
 #define ZEPHYR_INCLUDE_DRIVERS_CONSOLE_NATIVE_POSIX_CONSOLE_H_
 
+#warning "This header is now deprecated and will be removed by v4.4. "\
+	 "Use posix_arch_console.h instead."
+
 /*
  * This header is left for compatibility with old applications
  * The console for native_posix is now provided by the posix_arch_console driver

--- a/include/zephyr/linker/common-rom/common-rom-init.ld
+++ b/include/zephyr/linker/common-rom/common-rom-init.ld
@@ -11,12 +11,11 @@
 		 * last element is NULL.
 		 *
 		 * The __CTOR_LIST__ and __CTOR_END__ symbols are always defined
-		 * to result in an empty list. This is necessary to fix an issue
-		 * where the glibc process initialization code on native_posix
-		 * platforms calls constructors before Zephyr loads (issue #39347).
-		 *
-		 * Zephyr's start-up code uses the __ZEPHYR_CTOR_LIST__ and
-		 * __ZEHPYR_CTOR_END__ symbols, so these need to be correctly set.
+		 * to result in an empty list.
+		 * Instead, Zephyr's start-up code uses the __ZEPHYR_CTOR_LIST__ and
+		 * __ZEHPYR_CTOR_END__ symbols.
+		 * In this way, in native_simulator based targets, the host glibc process
+		 * initialization code will not call the constructors before Zephyr loads.
 		 */
 #ifdef CONFIG_64BIT
 		. = ALIGN(8);
@@ -50,7 +49,7 @@
 		* startup code from calling any global constructors before Zephyr loads.
 		*
 		* Zephyr's start-up code uses the __zephyr_init_array_start and
-		* __zephyr_init_array_end sybmols, so these need to be set correctly.
+		* __zephyr_init_array_end symbols, so these need to be set correctly.
 		*/
 		. = ALIGN(4);
 		__init_array_start = .;

--- a/lib/os/fdtable.c
+++ b/lib/os/fdtable.c
@@ -550,9 +550,7 @@ static ssize_t stdinout_read_vmeth(void *obj, void *buffer, size_t count)
 
 static ssize_t stdinout_write_vmeth(void *obj, const void *buffer, size_t count)
 {
-#if defined(CONFIG_BOARD_NATIVE_POSIX)
-	return zvfs_write(1, buffer, count, NULL);
-#elif defined(CONFIG_NEWLIB_LIBC) || defined(CONFIG_ARCMWDT_LIBC)
+#if defined(CONFIG_NEWLIB_LIBC) || defined(CONFIG_ARCMWDT_LIBC)
 	return z_impl_zephyr_write_stdout(buffer, count);
 #else
 	return 0;

--- a/subsys/bluetooth/common/Kconfig
+++ b/subsys/bluetooth/common/Kconfig
@@ -264,7 +264,7 @@ config BT_HCI_VS_FATAL_ERROR
 config BT_HCI_VS_EXT_DETECT
 	bool "Use heuristics to guess HCI vendor extensions support in advance"
 	depends on BT_HCI_VS && !HAS_BT_CTLR
-	default y if BOARD_QEMU_X86 || BOARD_QEMU_CORTEX_M3 || BOARD_NATIVE_POSIX || BOARD_NATIVE_SIM
+	default y if BOARD_QEMU_X86 || BOARD_QEMU_CORTEX_M3 || BOARD_NATIVE_SIM
 	help
 	  Use some heuristics to try to guess in advance whether the controller
 	  supports the HCI vendor extensions in advance, in order to prevent

--- a/subsys/bluetooth/controller/hci/hci_driver.c
+++ b/subsys/bluetooth/controller/hci/hci_driver.c
@@ -287,7 +287,7 @@ void hci_recv_fifo_reset(void)
 	 * reinitialize the queue so it is empty, we use the cancel wait and
 	 * initialize the queue. As the Tx thread and Rx thread are co-operative
 	 * we should be relatively safe doing the below.
-	 * Added k_sched_lock and k_sched_unlock, as native_posix seems to
+	 * Added k_sched_lock and k_sched_unlock, as native_sim seems to
 	 * swap to waiting thread on call to k_fifo_cancel_wait!.
 	 */
 	k_sched_lock();

--- a/tests/cmake/hwm/board_extend/oot_root/boards/native/native_sim_extend/native_sim_native_one.dts
+++ b/tests/cmake/hwm/board_extend/oot_root/boards/native/native_sim_extend/native_sim_native_one.dts
@@ -52,7 +52,7 @@
 		#size-cells = <0>;
 
 		cpu0: cpu@0 {
-			compatible = "zephyr,native-posix-cpu";
+			compatible = "zephyr,native-sim-cpu";
 			reg = <0>;
 		};
 	};

--- a/tests/kernel/context/src/main.c
+++ b/tests/kernel/context/src/main.c
@@ -57,7 +57,7 @@
 #elif defined(CONFIG_SPARC)
 #elif defined(CONFIG_MIPS)
 #elif defined(CONFIG_ARCH_POSIX)
-#if defined(CONFIG_BOARD_NATIVE_POSIX) || defined(CONFIG_BOARD_NATIVE_SIM)
+#if defined(CONFIG_BOARD_NATIVE_SIM)
 #define TICK_IRQ TIMER_TICK_IRQ
 #else
 /*

--- a/tests/subsys/pm/policy_api/app.overlay
+++ b/tests/subsys/pm/policy_api/app.overlay
@@ -6,7 +6,7 @@
 / {
 	cpus {
 		cpu1: cpu@1 {
-			compatible = "zephyr,native-posix-cpu";
+			compatible = "zephyr,native-sim-cpu";
 			reg = <1>;
 			cpu-power-states = <&state2>;
 		};


### PR DESCRIPTION
Following
* #86305 

A few miscellaneous cleanups, including:
* Removing/replacing mentions of native_posix in comments and kconfig help messages
* Removing an ifdef'ed line which is now dead code (ifdef native_posix)
* Deprecating 2 transitional headers which were missed in #86353
* Replacing zephyr,native-posix-cpu with zephyr,native-sim-cpu

The last one I intend to mention it in the migration guide, but like the others like this, I intend to bulk them in a separate PR for all drivers after all the PRs changing the drivers are in.