### PR TITLE
tests: posix: add one integration platform per suite

### DIFF
--- a/tests/posix/barriers/testcase.yaml
+++ b/tests/posix/barriers/testcase.yaml
@@ -7,6 +7,8 @@ common:
   platform_key:
     - arch
     - simulation
+  integration_platforms:
+    - qemu_cortex_a53
   min_flash: 64
   min_ram: 32
 tests:

--- a/tests/posix/c_lib_ext/testcase.yaml
+++ b/tests/posix/c_lib_ext/testcase.yaml
@@ -8,6 +8,8 @@ common:
   platform_key:
     - arch
     - simulation
+  integration_platforms:
+    - qemu_cortex_m0
   min_flash: 64
   min_ram: 32
 tests:

--- a/tests/posix/eventfd/testcase.yaml
+++ b/tests/posix/eventfd/testcase.yaml
@@ -7,6 +7,8 @@ common:
   platform_key:
     - arch
     - simulation
+  integration_platforms:
+    - qemu_riscv64
 tests:
   portability.posix.eventfd: {}
   portability.posix.eventfd.minimal:

--- a/tests/posix/fs/testcase.yaml
+++ b/tests/posix/fs/testcase.yaml
@@ -13,6 +13,9 @@ common:
   platform_key:
     - arch
     - simulation
+  integration_platforms:
+    - qemu_x86
+    - qemu_riscv64
 tests:
   portability.posix.fs: {}
   portability.posix.fs.minimal:

--- a/tests/posix/headers/testcase.yaml
+++ b/tests/posix/headers/testcase.yaml
@@ -7,6 +7,8 @@ common:
   platform_key:
     - arch
     - simulation
+  integration_platforms:
+    - qemu_x86_64
 tests:
   portability.posix.headers.with_posix_api:
     extra_configs:

--- a/tests/posix/net/testcase.yaml
+++ b/tests/posix/net/testcase.yaml
@@ -5,7 +5,7 @@ common:
     - iface
     - net
     - posix
-  # 1 tier0 platform per supported architecture (dependent on netif support)
+  # dependent on netif support
   integration_platforms:
     - mps2/an385
     - qemu_x86

--- a/tests/posix/rwlocks/testcase.yaml
+++ b/tests/posix/rwlocks/testcase.yaml
@@ -7,6 +7,8 @@ common:
   platform_key:
     - arch
     - simulation
+  integration_platforms:
+    - qemu_riscv64
   min_flash: 64
   min_ram: 32
 tests:

--- a/tests/posix/semaphores/testcase.yaml
+++ b/tests/posix/semaphores/testcase.yaml
@@ -7,6 +7,8 @@ common:
   platform_key:
     - arch
     - simulation
+  integration_platforms:
+    - qemu_x86_64
   min_flash: 64
   min_ram: 32
 tests:

--- a/tests/posix/signals/testcase.yaml
+++ b/tests/posix/signals/testcase.yaml
@@ -7,6 +7,8 @@ common:
   platform_key:
     - arch
     - simulation
+  integration_platforms:
+    - qemu_riscv64
   min_flash: 64
   min_ram: 32
 tests:

--- a/tests/posix/single_process/testcase.yaml
+++ b/tests/posix/single_process/testcase.yaml
@@ -7,6 +7,8 @@ common:
   platform_key:
     - arch
     - simulation
+  integration_platforms:
+    - qemu_riscv64
   min_flash: 64
   min_ram: 32
 tests:

--- a/tests/posix/spinlocks/testcase.yaml
+++ b/tests/posix/spinlocks/testcase.yaml
@@ -7,6 +7,8 @@ common:
   platform_key:
     - arch
     - simulation
+  integration_platforms:
+    - qemu_x86_64
   min_flash: 64
   min_ram: 32
 tests:

--- a/tests/posix/xsi_streams/testcase.yaml
+++ b/tests/posix/xsi_streams/testcase.yaml
@@ -7,6 +7,8 @@ common:
   platform_key:
     - arch
     - simulation
+  integration_platforms:
+    - qemu_riscv64
   min_flash: 64
   min_ram: 32
 tests:

--- a/tests/posix/xsi_system_logging/testcase.yaml
+++ b/tests/posix/xsi_system_logging/testcase.yaml
@@ -6,6 +6,8 @@ common:
   platform_key:
     - arch
     - simulation
+  integration_platforms:
+    - qemu_riscv64
   min_flash: 64
   min_ram: 32
 tests:


### PR DESCRIPTION
Add one integration platform per testsuite to reduce the number of issues reported by the qa log level introduced in #86571.

Some exceptions: 
* threading tests
* timer tests
* tests involving mmu

It would be ideal to continue running those tests broadly at least until the `common` testsuite has been split up into specific option group testsuites.

Closes #86633
