### PR TITLE
drivers: i2c: tca954x: add support for idle disconnect

### DIFF
--- a/drivers/i2c/i2c_tca954x.c
+++ b/drivers/i2c/i2c_tca954x.c
@@ -18,6 +18,7 @@ struct tca954x_root_config {
 	struct i2c_dt_spec i2c;
 	uint8_t nchans;
 	const struct gpio_dt_spec reset_gpios;
+	bool idle_disconnect;
 };
 
 struct tca954x_root_data {
@@ -95,6 +96,11 @@ static int tca954x_transfer(const struct device *dev,
 	}
 
 	res = i2c_transfer(config->i2c.bus, msgs, num_msgs, addr);
+
+	if(config->idle_disconnect) {
+		/* Deselect active channel */
+		res = tca954x_set_channel(down_cfg->root, 0);
+	}
 
 end_trans:
 	k_mutex_unlock(&data->lock);
@@ -186,6 +192,7 @@ BUILD_ASSERT(CONFIG_I2C_TCA954X_CHANNEL_INIT_PRIO > CONFIG_I2C_TCA954X_ROOT_INIT
 		.nchans = ch,							  \
 		.reset_gpios = GPIO_DT_SPEC_GET_OR(			          \
 				DT_INST(inst, ti_tca##n##a), reset_gpios, {0}),	  \
+		.idle_disconnect = DT_INST_PROP_OR(inst, i2c-mux-idle-disconnect, 0),	\
 	};								          \
 	static struct tca954x_root_data tca##n##a_data_##inst = {		  \
 		.lock = Z_MUTEX_INITIALIZER(tca##n##a_data_##inst.lock),	  \

--- a/dts/bindings/i2c/ti,tca954x-base.yaml
+++ b/dts/bindings/i2c/ti,tca954x-base.yaml
@@ -52,6 +52,13 @@ properties:
     description: |
       GPIO connected to the controller RESET pin. This pin is active-low.
 
+  i2c-mux-idle-disconnect:
+    type: boolean
+    description: |
+      Forces mux to disconnect all children in idle state. This is
+      necessary for example, if there are several multiplexers on the bus and
+      the devices behind them use same I2C addresses.
+
 child-binding:
   description: TCA954x I2C switch channel node
   include: [i2c-controller.yaml]


### PR DESCRIPTION
Add support for an optional "idle disconnect" feature in the TCA954x I2C multiplexer. When enabled via the `i2c-mux-idle-disconnect` device tree property, the driver will disconnect all channels after each transfer. This helps avoid address conflicts when multiple multiplexers are present on the same I2C bus.

This implementation is inspired by the Linux kernel driver for PCA954x I2C multiplexers.