### PR TITLE
drivers: i2c: tca954x: add support for idle disconnect

### DIFF
--- a/dts/bindings/i2c/ti,tca954x-base.yaml
+++ b/dts/bindings/i2c/ti,tca954x-base.yaml
@@ -52,6 +52,13 @@ properties:
     description: |
       GPIO connected to the controller RESET pin. This pin is active-low.
 
+  i2c-mux-idle-disconnect:
+    type: boolean
+    description: |
+      Forces mux to disconnect all children in idle state. This is
+      necessary for example, if there are several multiplexers on the bus and
+      the devices behind them use same I2C addresses.
+
 child-binding:
   description: TCA954x I2C switch channel node
   include: [i2c-controller.yaml]


### PR DESCRIPTION
Add support for an optional "idle disconnect" feature in the TCA954x I2C multiplexer. When enabled via the `i2c-mux-idle-disconnect` device tree property, the driver will disconnect all channels after each transfer. This helps avoid address conflicts when multiple multiplexers are present on the same I2C bus.

This implementation is inspired by the Linux kernel driver for PCA954x I2C multiplexers.