### PR TITLE
boards: st: disco_l475_iot1: fix flash partition overlap

### DIFF
--- a/boards/st/disco_l475_iot1/disco_l475_iot1.dts
+++ b/boards/st/disco_l475_iot1/disco_l475_iot1.dts
@@ -228,9 +228,9 @@
 			read-only;
 		};
 
-		slot0_partition: partition@1000 {
+		slot0_partition: partition@10000 {
 			label = "image-0";
-			reg = <0x1000 DT_SIZE_K(928)>;
+			reg = <0x10000 DT_SIZE_K(928)>;
 		};
 
 		storage_partition: partition@f8000 {


### PR DESCRIPTION
Fix a partition overlap in the flash node on the `disco_l475_iot1` board.