### PR TITLE
display: modules: tests: Introduce L8 (Y8, Grayscale) Pixel Format

### DIFF
--- a/include/zephyr/drivers/display.h
+++ b/include/zephyr/drivers/display.h
@@ -46,6 +46,8 @@ enum display_pixel_format {
 	PIXEL_FORMAT_ARGB_8888		= BIT(3), /**< 32-bit ARGB */
 	PIXEL_FORMAT_RGB_565		= BIT(4), /**< 16-bit RGB */
 	PIXEL_FORMAT_BGR_565		= BIT(5), /**< 16-bit BGR */
+	PIXEL_FORMAT_L_8		= BIT(6), /**< 8-bit Grayscale/Luminance, equivalent to */
+						  /**< GRAY, GREY, GRAY8, Y8, R8, etc...        */
 };
 
 /**
@@ -61,7 +63,8 @@ enum display_pixel_format {
 	(((fmt & PIXEL_FORMAT_MONO10) >> 2) * 1U) +				\
 	(((fmt & PIXEL_FORMAT_ARGB_8888) >> 3) * 32U) +				\
 	(((fmt & PIXEL_FORMAT_RGB_565) >> 4) * 16U) +				\
-	(((fmt & PIXEL_FORMAT_BGR_565) >> 5) * 16U))
+	(((fmt & PIXEL_FORMAT_BGR_565) >> 5) * 16U) +				\
+	(((fmt & PIXEL_FORMAT_L_8) >> 6) * 8U))
 
 /**
  * @brief Display screen information

--- a/include/zephyr/dt-bindings/display/panel.h
+++ b/include/zephyr/dt-bindings/display/panel.h
@@ -23,12 +23,13 @@
  * since enum definitions are not supported by devicetree tooling.
  */
 
-#define PANEL_PIXEL_FORMAT_RGB_888		(0x1 << 0)
-#define PANEL_PIXEL_FORMAT_MONO01		(0x1 << 1) /* 0=Black 1=White */
-#define PANEL_PIXEL_FORMAT_MONO10		(0x1 << 2) /* 1=Black 0=White */
-#define PANEL_PIXEL_FORMAT_ARGB_8888		(0x1 << 3)
-#define PANEL_PIXEL_FORMAT_RGB_565		(0x1 << 4)
-#define PANEL_PIXEL_FORMAT_BGR_565		(0x1 << 5)
+#define PANEL_PIXEL_FORMAT_RGB_888   (0x1 << 0)
+#define PANEL_PIXEL_FORMAT_MONO01    (0x1 << 1) /* 0=Black 1=White */
+#define PANEL_PIXEL_FORMAT_MONO10    (0x1 << 2) /* 1=Black 0=White */
+#define PANEL_PIXEL_FORMAT_ARGB_8888 (0x1 << 3)
+#define PANEL_PIXEL_FORMAT_RGB_565   (0x1 << 4)
+#define PANEL_PIXEL_FORMAT_BGR_565   (0x1 << 5)
+#define PANEL_PIXEL_FORMAT_L_8       (0x1 << 6)
 
 /**
  * @}

--- a/modules/lvgl/CMakeLists.txt
+++ b/modules/lvgl/CMakeLists.txt
@@ -313,6 +313,7 @@ zephyr_library_sources(
     lvgl.c
     lvgl_display.c
     lvgl_display_mono.c
+    lvgl_display_8bit.c
     lvgl_display_16bit.c
     lvgl_display_24bit.c
     lvgl_display_32bit.c

--- a/modules/lvgl/include/lvgl_display.h
+++ b/modules/lvgl/include/lvgl_display.h
@@ -30,6 +30,7 @@ struct lvgl_display_flush {
 };
 
 void lvgl_flush_cb_mono(lv_display_t *display, const lv_area_t *area, uint8_t *px_map);
+void lvgl_flush_cb_8bit(lv_display_t *display, const lv_area_t *area, uint8_t *px_map);
 void lvgl_flush_cb_16bit(lv_display_t *display, const lv_area_t *area, uint8_t *px_map);
 void lvgl_flush_cb_24bit(lv_display_t *display, const lv_area_t *area, uint8_t *px_map);
 void lvgl_flush_cb_32bit(lv_display_t *display, const lv_area_t *area, uint8_t *px_map);

--- a/modules/lvgl/lvgl.c
+++ b/modules/lvgl/lvgl.c
@@ -146,6 +146,9 @@ static int lvgl_allocate_rendering_buffers(lv_display_t *display)
 	case PIXEL_FORMAT_RGB_565:
 		buf_size = 2 * buf_nbr_pixels;
 		break;
+	case PIXEL_FORMAT_L_8:
+		buf_size = buf_nbr_pixels;
+		break;
 	case PIXEL_FORMAT_MONO01:
 	case PIXEL_FORMAT_MONO10:
 		buf_size = buf_nbr_pixels / 8 + 8;

--- a/modules/lvgl/lvgl_display.c
+++ b/modules/lvgl/lvgl_display.c
@@ -96,6 +96,12 @@ int set_lvgl_rendering_cb(lv_display_t *display)
 		lv_display_add_event_cb(display, lvgl_rounder_cb, LV_EVENT_INVALIDATE_AREA,
 					display);
 		break;
+	case PIXEL_FORMAT_L_8:
+		lv_display_set_color_format(display, LV_COLOR_FORMAT_L8);
+		lv_display_set_flush_cb(display, lvgl_flush_cb_8bit);
+		lv_display_add_event_cb(display, lvgl_rounder_cb, LV_EVENT_INVALIDATE_AREA,
+					display);
+		break;
 	case PIXEL_FORMAT_MONO01:
 	case PIXEL_FORMAT_MONO10:
 		lv_display_set_color_format(display, LV_COLOR_FORMAT_I1);

--- a/modules/lvgl/lvgl_display_8bit.c
+++ b/modules/lvgl/lvgl_display_8bit.c
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2025 MASSDRIVER EI (massdriver.space)
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <lvgl.h>
+#include "lvgl_display.h"
+
+void lvgl_flush_cb_8bit(lv_display_t *display, const lv_area_t *area, uint8_t *px_map)
+{
+	uint16_t w = area->x2 - area->x1 + 1;
+	uint16_t h = area->y2 - area->y1 + 1;
+	struct lvgl_display_flush flush;
+
+	flush.display = display;
+	flush.x = area->x1;
+	flush.y = area->y1;
+	flush.desc.buf_size = w * h;
+	flush.desc.width = w;
+	flush.desc.pitch = w;
+	flush.desc.height = h;
+	flush.buf = (void *)px_map;
+
+	lvgl_flush_display(&flush);
+}

--- a/samples/drivers/display/src/main.c
+++ b/samples/drivers/display/src/main.c
@@ -158,6 +158,13 @@ static void fill_buffer_mono(enum corner corner, uint8_t grey,
 	memset(buf, color, buf_size);
 }
 
+static inline void fill_buffer_l_8(enum corner corner, uint8_t grey, uint8_t *buf, size_t buf_size)
+{
+	for (size_t idx = 0; idx < buf_size; idx += 1) {
+		*(uint8_t *)(buf + idx) = grey;
+	}
+}
+
 static inline void fill_buffer_mono01(enum corner corner, uint8_t grey,
 				      uint8_t *buf, size_t buf_size)
 {
@@ -261,6 +268,10 @@ int main(void)
 		bg_color = 0xFFu;
 		fill_buffer_fnc = fill_buffer_bgr565;
 		buf_size *= 2;
+		break;
+	case PIXEL_FORMAT_L_8:
+		bg_color = 0xFFu;
+		fill_buffer_fnc = fill_buffer_l_8;
 		break;
 	case PIXEL_FORMAT_MONO01:
 		bg_color = 0xFFu;

--- a/tests/drivers/display/display_read_write/src/main.c
+++ b/tests/drivers/display/display_read_write/src/main.c
@@ -34,6 +34,7 @@ static inline uint8_t bytes_per_pixel(enum display_pixel_format pixel_format)
 	case PIXEL_FORMAT_RGB_565:
 	case PIXEL_FORMAT_BGR_565:
 		return 2;
+	case PIXEL_FORMAT_L_8:
 	case PIXEL_FORMAT_MONO01:
 	case PIXEL_FORMAT_MONO10:
 	default:

--- a/tests/lib/gui/lvgl/src/main.c
+++ b/tests/lib/gui/lvgl/src/main.c
@@ -104,8 +104,9 @@ void *setup_lvgl(void)
 
 #if CONFIG_LV_COLOR_DEPTH_1 == 1
 	display_set_pixel_format(display_dev, PIXEL_FORMAT_MONO10);
-#elif CONFIG_LV_COLOR_DEPTH_8 == 1 || CONFIG_LV_COLOR_DEPTH_24 == 1
-	/* No 8bit display pixel format not supported */
+#elif CONFIG_LV_COLOR_DEPTH_8 == 1
+	display_set_pixel_format(display_dev, PIXEL_FORMAT_L_8);
+#elif CONFIG_LV_COLOR_DEPTH_24 == 1
 	display_set_pixel_format(display_dev, PIXEL_FORMAT_RGB_888);
 #elif CONFIG_LV_COLOR_DEPTH_16 == 1
 	display_set_pixel_format(display_dev, PIXEL_FORMAT_RGB_565);


### PR DESCRIPTION
This introduces a greyscale pixel format supported by LVGL.

## Why
Some displays need a greyscale format, like SSD1327 (for which the current driver uses undocumented features that do not work on all displays), SSD1320, SSD1322, ST75256 etc...

## LVGL
LVGL supports rendering to a 8-bit greyscale pixel format, so it has been chosen as the base format to feed those displays/.
