### PR TITLE
Fix packet length correction for ethernet packet

### DIFF
--- a/subsys/net/l2/ethernet/ethernet.c
+++ b/subsys/net/l2/ethernet/ethernet.c
@@ -122,6 +122,14 @@ static inline void ethernet_update_length(struct net_if *iface,
 					  struct net_pkt *pkt)
 {
 	uint16_t len;
+#ifdef CONFIG_NET_VLAN
+	const uint16_t min_len =
+		NET_ETH_MINIMAL_FRAME_SIZE - (net_pkt_vlan_tag(pkt) != NET_VLAN_TAG_UNSPEC
+						      ? sizeof(struct net_eth_vlan_hdr)
+						      : sizeof(struct net_eth_hdr));
+#else
+	const uint16_t min_len = NET_ETH_MINIMAL_FRAME_SIZE - sizeof(struct net_eth_hdr);
+#endif
 
 	/* Let's check IP payload's length. If it's smaller than 46 bytes,
 	 * i.e. smaller than minimal Ethernet frame size minus ethernet
@@ -137,7 +145,7 @@ static inline void ethernet_update_length(struct net_if *iface,
 		return;
 	}
 
-	if (len < NET_ETH_MINIMAL_FRAME_SIZE - sizeof(struct net_eth_hdr)) {
+	if (len < min_len) {
 		struct net_buf *frag;
 
 		for (frag = pkt->frags; frag; frag = frag->frags) {

--- a/subsys/net/l2/ethernet/ethernet.c
+++ b/subsys/net/l2/ethernet/ethernet.c
@@ -131,8 +131,10 @@ static inline void ethernet_update_length(struct net_if *iface,
 
 	if (net_pkt_family(pkt) == AF_INET) {
 		len = ntohs(NET_IPV4_HDR(pkt)->len);
-	} else {
+	} else if (net_pkt_family(pkt) == AF_INET6) {
 		len = ntohs(NET_IPV6_HDR(pkt)->len) + NET_IPV6H_LEN;
+	} else {
+		return;
 	}
 
 	if (len < NET_ETH_MINIMAL_FRAME_SIZE - sizeof(struct net_eth_hdr)) {

--- a/tests/net/socket/af_packet/src/main.c
+++ b/tests/net/socket/af_packet/src/main.c
@@ -389,6 +389,38 @@ ZTEST(socket_packet, test_packet_sockets_dgram)
 	zassert_mem_equal(data_to_send, data_to_receive, sizeof(data_to_send),
 			  "Data mismatch");
 
+	/* Send specially crafted payload to mimic IPv4 and IPv6 length field,
+	 * to ckeck correct length returned.
+	 */
+	uint8_t payload_ip_length[64], receive_ip_length[64];
+
+	memset(payload_ip_length, 0, sizeof(payload_ip_length));
+	/* Set ipv4 and ipv6 length fields to represent IP payload with the
+	 * length of 1 byte.
+	 */
+	payload_ip_length[3] = 21;
+	payload_ip_length[5] = 1;
+
+	ret = zsock_sendto(sock2, payload_ip_length, sizeof(payload_ip_length), 0,
+			   (const struct sockaddr *)&dst, sizeof(struct sockaddr_ll));
+	zassert_equal(ret, sizeof(payload_ip_length), "Cannot send all data (%d)", -errno);
+
+	k_msleep(10);
+
+	memset(&src, 0, sizeof(src));
+	errno = 0;
+	iter = 0;
+	do {
+		ret = zsock_recvfrom(sock2, receive_ip_length, sizeof(receive_ip_length), 0,
+				     (struct sockaddr *)&src, &addrlen);
+		k_msleep(10);
+		iter++;
+	} while (ret < 0 && errno == EAGAIN && iter < max_iter);
+
+	zassert_equal(ret, ARRAY_SIZE(payload_ip_length), "Cannot receive all data (%d)", -errno);
+	zassert_mem_equal(payload_ip_length, receive_ip_length, sizeof(payload_ip_length),
+			  "Data mismatch");
+
 	zsock_close(sock1);
 	zsock_close(sock2);
 }


### PR DESCRIPTION
This PRs fixes to issue with the packet length changing of ethernet packets:
 * The length is not altered with information by a layer3 header, if the family is not IPv4 or IPv6.
 *  The VLAN header is taken into account if VLAN is used.