### PR TITLE
boards: fix few incorrect ft5336 polarities

### DIFF
--- a/boards/m5stack/m5stack_core2/m5stack_core2_procpu.dts
+++ b/boards/m5stack/m5stack_core2/m5stack_core2_procpu.dts
@@ -190,7 +190,7 @@
 	ft5336_touch: ft5336@38 {
 		compatible = "focaltech,ft5336";
 		reg = <0x38>;
-		int-gpios = <&gpio1 7 0>;
+		int-gpios = <&gpio1 7 GPIO_ACTIVE_LOW>;
 	};
 };
 

--- a/boards/nxp/rd_rw612_bga/dts/goworld_16880_lcm.overlay
+++ b/boards/nxp/rd_rw612_bga/dts/goworld_16880_lcm.overlay
@@ -89,6 +89,6 @@
 		compatible = "focaltech,ft5336";
 		reg = <0x38>;
 		reset-gpios = <&hsgpio0 15 GPIO_ACTIVE_LOW>;
-		int-gpios = <&hsgpio0 11 GPIO_ACTIVE_HIGH>;
+		int-gpios = <&hsgpio0 11 GPIO_ACTIVE_LOW>;
 	};
 };

--- a/boards/shields/st_b_lcd40_dsi1_mb1166/st_b_lcd40_dsi1_mb1166.overlay
+++ b/boards/shields/st_b_lcd40_dsi1_mb1166/st_b_lcd40_dsi1_mb1166.overlay
@@ -59,7 +59,7 @@
 	ft5336: ft5336@38 {
 		compatible = "focaltech,ft5336";
 		reg = <0x38>;
-		int-gpios = <&dsi_lcd_qsh_030 4 0>;
+		int-gpios = <&dsi_lcd_qsh_030 4 GPIO_ACTIVE_LOW>;
 		status = "okay";
 	};
 };

--- a/boards/shields/st_b_lcd40_dsi1_mb1166/st_b_lcd40_dsi1_mb1166_a09.overlay
+++ b/boards/shields/st_b_lcd40_dsi1_mb1166/st_b_lcd40_dsi1_mb1166_a09.overlay
@@ -59,7 +59,7 @@
 	ft5336: ft5336@38 {
 		compatible = "focaltech,ft5336";
 		reg = <0x38>;
-		int-gpios = <&dsi_lcd_qsh_030 4 0>;
+		int-gpios = <&dsi_lcd_qsh_030 4 GPIO_ACTIVE_LOW>;
 		status = "okay";
 	};
 };

--- a/boards/st/stm32f746g_disco/stm32f746g_disco.dts
+++ b/boards/st/stm32f746g_disco/stm32f746g_disco.dts
@@ -105,7 +105,7 @@
 	ft5336: ft5336@38 {
 		compatible = "focaltech,ft5336";
 		reg = <0x38>;
-		int-gpios = <&gpioi 13 0>;
+		int-gpios = <&gpioi 13 GPIO_ACTIVE_LOW>;
 	};
 };
 

--- a/boards/st/stm32f7508_dk/stm32f7508_dk.dts
+++ b/boards/st/stm32f7508_dk/stm32f7508_dk.dts
@@ -105,7 +105,7 @@
 	ft5336: ft5336@38 {
 		compatible = "focaltech,ft5336";
 		reg = <0x38>;
-		int-gpios = <&gpioi 13 0>;
+		int-gpios = <&gpioi 13 GPIO_ACTIVE_LOW>;
 	};
 };
 

--- a/boards/st/stm32f769i_disco/stm32f769i_disco.dts
+++ b/boards/st/stm32f769i_disco/stm32f769i_disco.dts
@@ -139,7 +139,7 @@ arduino_serial: &usart6 {};
 	ft6202: ft6202@2a {
 		compatible = "focaltech,ft5336";
 		reg = <0x2a>;
-		int-gpios = <&gpioi 13 0>;
+		int-gpios = <&gpioi 13 GPIO_ACTIVE_LOW>;
 	};
 };
 

--- a/boards/st/stm32h7b3i_dk/stm32h7b3i_dk.dts
+++ b/boards/st/stm32h7b3i_dk/stm32h7b3i_dk.dts
@@ -169,7 +169,7 @@
 	ft5336: ft5336@38 {
 		compatible = "focaltech,ft5336";
 		reg = <0x38>;
-		int-gpios = <&gpioh 2 0>;
+		int-gpios = <&gpioh 2 GPIO_ACTIVE_LOW>;
 	};
 };
 


### PR DESCRIPTION
The interrupt pin is active low, not sure how any of these could have worked correctly, maybe they've only been tested in polling mode.

Fixes #86816