### PR TITLE
net: lib: sockets: fix socket_service thread stuck by mistake

### DIFF
--- a/subsys/net/lib/sockets/sockets_inet.c
+++ b/subsys/net/lib/sockets/sockets_inet.c
@@ -1564,7 +1564,9 @@ static int zsock_poll_update_ctx(struct net_context *ctx,
 	ARG_UNUSED(ctx);
 
 	if (pfd->events & ZSOCK_POLLIN) {
-		if ((*pev)->state != K_POLL_STATE_NOT_READY || sock_is_eof(ctx)) {
+		if (((*pev)->state != K_POLL_STATE_NOT_READY &&
+		     (*pev)->state != K_POLL_STATE_CANCELLED) ||
+		    sock_is_eof(ctx)) {
 			pfd->revents |= ZSOCK_POLLIN;
 		}
 		(*pev)++;


### PR DESCRIPTION
Use Wi-Fi connecting to Qualcomm IPQ8074 AP, and run the UDP RX traffic with Zperf, but zperf does not return the throughput number after traffic completion nor any session started prints. After traffic completion, ping from STA to AP and vice versa does not work. The socket_service thread is found blocked forever at zsock_wait_data() after dns_dispatcher_svc_handler() is called via trigger_work(). The root cause of this issue is:
STA received one DHCPv4 packet containing DHCPV4_OPTIONS_DNS_SERVER, it will create DNS socket and registered to socket_service. Then STA received another IPv6 router advertisement packet containing NET_ICMPV6_ND_OPT_RDNSS, it will close socket and change the state of poll_events to K_POLL_STATE_CANCELLED(8), then registered to socket_service with same fd. In socket_service thread, zsock_poll() called zsock_poll_update_ctx() when handled ZFD_IOCTL_POLL_UPDATE, and it checked the state of poll_events was not K_POLL_STATE_NOT_READY(0), then it will set pfd->revents to '|= ZSOCK_POLLIN'. Finally trigger_work() can be called as 'ctx.events[i].revents > 0' is matched.

The fix of this issue is that, in zsock_poll_update_ctx(), it should check the state of poll_events is neither K_POLL_STATE_NOT_READY nor K_POLL_STATE_CANCELLED before setting revents as ZSOCK_POLLIN, to avoid trigger_work be unexpectedly called.