### PR TITLE
drivers: nrf_wifi: Fix return value for getting current reg domain

### DIFF
--- a/drivers/wifi/nrf_wifi/src/fmac_main.c
+++ b/drivers/wifi/nrf_wifi/src/fmac_main.c
@@ -357,6 +357,7 @@ int nrf_wifi_reg_domain(const struct device *dev, struct wifi_reg_domain *reg_do
 			goto out;
 		}
 
+		ret = 0;
 		goto out;
 	}
 #endif


### PR DESCRIPTION
It is observed that the regulatory domain API returns a failure even when it has successfully completed its task. This change addresses a minor fix to return the proper value to the user when attempting to set the regulatory domain.