### PR TITLE
tests: ztest: rd_rw612_bga: add ZTEST_NO_YIELD

### DIFF
--- a/boards/nxp/rd_rw612_bga/Kconfig.defconfig
+++ b/boards/nxp/rd_rw612_bga/Kconfig.defconfig
@@ -37,4 +37,7 @@ config NET_L2_ETHERNET
 
 endif # DT_HAS_NXP_ENET_MAC_ENABLED && NETWORKING
 
+config ZTEST_NO_YIELD
+	default y if (ZTEST && PM)
+
 endif # BOARD_RD_RW612_BGA


### PR DESCRIPTION
Add ZTEST_NO_YIELD to keep test case output consist. The log may missing, as the soc goes to low power.