### PR TITLE
i2c: stm32: Fix return type declaration of 2 private functions

### DIFF
--- a/drivers/i2c/i2c_ll_stm32.h
+++ b/drivers/i2c/i2c_ll_stm32.h
@@ -93,10 +93,10 @@ struct i2c_stm32_data {
 #endif
 };
 
-int32_t stm32_i2c_transaction(const struct device *dev,
+int stm32_i2c_transaction(const struct device *dev,
 			    struct i2c_msg msg, uint8_t *next_msg_flags,
 			    uint16_t periph);
-int32_t stm32_i2c_configure_timing(const struct device *dev, uint32_t clk);
+int stm32_i2c_configure_timing(const struct device *dev, uint32_t clk);
 int i2c_stm32_runtime_configure(const struct device *dev, uint32_t config);
 int i2c_stm32_get_config(const struct device *dev, uint32_t *config);
 

--- a/drivers/i2c/i2c_ll_stm32_v1.c
+++ b/drivers/i2c/i2c_ll_stm32_v1.c
@@ -993,7 +993,7 @@ end:
 }
 #endif /* CONFIG_I2C_STM32_INTERRUPT */
 
-int32_t stm32_i2c_configure_timing(const struct device *dev, uint32_t clock)
+int stm32_i2c_configure_timing(const struct device *dev, uint32_t clock)
 {
 	const struct i2c_stm32_config *cfg = dev->config;
 	struct i2c_stm32_data *data = dev->data;


### PR DESCRIPTION
Return type should be int, no need for int32_t.