### PR TITLE
Bluetooth: Controller: Fix dependency for connected ISO Kconfigs

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -1018,6 +1018,8 @@ config BT_CTLR_CENTRAL_ISO
 
 config BT_CTLR_CENTRAL_ISO
 	bool "LE Connected Isochronous Stream Central (Split Link Layer) [EXPERIMENTAL]" if BT_LL_SW_SPLIT
+	depends on BT_CTLR_CENTRAL_ISO_SUPPORT && BT_ISO_CENTRAL
+	default y if BT_ISO_CENTRAL
 	select BT_CTLR_SET_HOST_FEATURE
 	select EXPERIMENTAL if BT_LL_SW_SPLIT
 
@@ -1031,6 +1033,8 @@ config BT_CTLR_PERIPHERAL_ISO
 
 config BT_CTLR_PERIPHERAL_ISO
 	bool "LE Connected Isochronous Stream Peripheral (Split Link Layer) [EXPERIMENTAL]" if BT_LL_SW_SPLIT
+	depends on BT_CTLR_PERIPHERAL_ISO_SUPPORT && BT_ISO_PERIPHERAL
+	default y if BT_ISO_PERIPHERAL
 	select BT_CTLR_SET_HOST_FEATURE
 	select EXPERIMENTAL if BT_LL_SW_SPLIT
 


### PR DESCRIPTION
The options for BT_CTLR_CENTRAL_ISO and
BT_CTLR_PERIPHERAL_ISO did not have the proper defaults not dependencies when BT_LL_SW_SPLIT=y

fixes https://github.com/zephyrproject-rtos/zephyr/issues/72425