### PR TITLE
boards: silabs: xg24_rb4187c: Add SPI and I2C buses

### DIFF
--- a/boards/silabs/radio_boards/xg24_rb4187c/doc/index.rst
+++ b/boards/silabs/radio_boards/xg24_rb4187c/doc/index.rst
@@ -34,71 +34,13 @@ documents:
 Supported Features
 ==================
 
-The board configuration supports the following hardware features:
-
-+-----------+------------+-------------------------------------+
-| Interface | Controller | Driver/Component                    |
-+===========+============+=====================================+
-| MPU       | on-chip    | memory protection unit              |
-+-----------+------------+-------------------------------------+
-| NVIC      | on-chip    | nested vector interrupt controller  |
-+-----------+------------+-------------------------------------+
-| SYSTICK   | on-chip    | systick                             |
-+-----------+------------+-------------------------------------+
-| COUNTER   | on-chip    | stimer                              |
-+-----------+------------+-------------------------------------+
-| FLASH     | on-chip    | flash memory                        |
-+-----------+------------+-------------------------------------+
-| GPIO      | on-chip    | gpio                                |
-+-----------+------------+-------------------------------------+
-| UART      | on-chip    | serial                              |
-+-----------+------------+-------------------------------------+
-| DMA       | on-chip    | ldma                                |
-+-----------+------------+-------------------------------------+
-| I2C       | on-chip    | i2c                                 |
-+-----------+------------+-------------------------------------+
-| TRNG      | on-chip    | semailbox                           |
-+-----------+------------+-------------------------------------+
-| WATCHDOG  | on-chip    | watchdog                            |
-+-----------+------------+-------------------------------------+
-| ACMP      | on-chip    | comparator                          |
-+-----------+------------+-------------------------------------+
-
-Other hardware features are currently not supported by the port.
-
-Connections and IOs
-===================
-
-In the following table, the column **Name** contains Pin names. For example, PA2
-means Pin number 2 on PORTA, as used in the board's datasheets and manuals.
-
-+-------+-------------+-------------------------------------+
-| Name  | Function    | Usage                               |
-+=======+=============+=====================================+
-| PB2   | GPIO        | LED0                                |
-+-------+-------------+-------------------------------------+
-| PB4   | GPIO        | LED1                                |
-+-------+-------------+-------------------------------------+
-| PB1   | GPIO        | Push Button 0                       |
-+-------+-------------+-------------------------------------+
-| PB3   | GPIO        | Push Button 1                       |
-+-------+-------------+-------------------------------------+
-| PB0   | GPIO        | Board Controller Enable             |
-|       |             | VCOM_ENABLE                         |
-+-------+-------------+-------------------------------------+
-| PA8   | USART0_TX   | UART Console VCOM_TX US0_TX         |
-+-------+-------------+-------------------------------------+
-| PA9   | USART0_RX   | UART Console VCOM_RX US0_RX         |
-+-------+-------------+-------------------------------------+
-
-The default configuration can be found in
-:zephyr_file:`boards/silabs/radio_boards/xg24_rb4187c/xg24_rb4187c_defconfig`
+.. zephyr:board-supported-hw::
 
 System Clock
 ============
 
-The EFR32MG24 SoC is configured to use the 39 MHz external oscillator on the
-board.
+The EFR32MG24 SoC is configured to use the HFRCODPLL oscillator at 78 MHz as the system clock,
+locked to the 39 MHz external crystal oscillator on the board.
 
 Serial Port
 ===========

--- a/boards/silabs/radio_boards/xg24_rb4187c/xg24_rb4187c-pinctrl.dtsi
+++ b/boards/silabs/radio_boards/xg24_rb4187c/xg24_rb4187c-pinctrl.dtsi
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2023 Antmicro <www.antmicro.com>
+ * Copyright (c) 2025 Silicon Laboratories Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -17,6 +18,27 @@
 			pins = <USART0_RX_PA9>;
 			input-enable;
 			silabs,input-filter;
+		};
+	};
+
+	eusart1_default: eusart1_default {
+		group0 {
+			pins = <EUSART1_TX_PC1>, <EUSART1_SCLK_PC3>;
+			drive-push-pull;
+			output-high;
+		};
+		group1 {
+			pins = <EUSART1_RX_PC2>;
+			input-enable;
+			silabs,input-filter;
+		};
+	};
+
+	i2c0_default: i2c0_default {
+		group0 {
+			pins = <I2C0_SCL_PC5>, <I2C0_SDA_PC7>;
+			drive-open-drain;
+			bias-pull-up;
 		};
 	};
 };

--- a/boards/silabs/radio_boards/xg24_rb4187c/xg24_rb4187c.dts
+++ b/boards/silabs/radio_boards/xg24_rb4187c/xg24_rb4187c.dts
@@ -22,6 +22,7 @@
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_partition;
 		zephyr,bt-hci = &bt_hci_silabs;
+		zephyr,display = &ls0xx_ls013b7dh03;
 	};
 
 	/* These aliases are provided for compatibility with samples */
@@ -31,6 +32,7 @@
 		sw0 = &button0;
 		sw1 = &button1;
 		watchdog0 = &wdog0;
+		dht0 = &si7021;
 	};
 
 	leds {
@@ -59,6 +61,12 @@
 		};
 	};
 
+	sensor_enable: sensor_enable {
+		compatible = "regulator-fixed";
+		regulator-name = "sensor_enable";
+		enable-gpios = <&gpiod 3 GPIO_ACTIVE_HIGH>;
+		status = "okay";
+	};
 };
 
 &cpu0 {
@@ -116,6 +124,53 @@
 	pinctrl-0 = <&usart0_default>;
 	pinctrl-names = "default";
 	status = "okay";
+};
+
+&eusart1 {
+	compatible = "silabs,eusart-spi";
+	pinctrl-0 = <&eusart1_default>;
+	pinctrl-names = "default";
+	clock-frequency = <DT_FREQ_M(10)>;
+	cs-gpios = <&gpioc 8 GPIO_ACTIVE_HIGH>, <&gpioc 4 GPIO_ACTIVE_LOW>;
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	ls0xx_ls013b7dh03: ls0xx@0 {
+		compatible = "sharp,ls0xx";
+		spi-max-frequency = <DT_FREQ_K(1100)>;
+		reg = <0>;
+		width = <128>;
+		height = <128>;
+		extcomin-gpios = <&gpioc 6 GPIO_ACTIVE_HIGH>;
+		extcomin-frequency = <60>;
+		disp-en-gpios = <&gpioc 9 GPIO_ACTIVE_HIGH>;
+	};
+
+	mx25r80: mx25r8035f@1 {
+		compatible = "jedec,spi-nor";
+		reg = <1>;
+		spi-max-frequency = <DT_FREQ_M(33)>;
+		size = <DT_SIZE_M(8)>;
+		jedec-id = [c2 28 14];
+		has-dpd;
+		dpd-wakeup-sequence = <30000 20 35000>;
+		mxicy,mx25r-power-mode = "low-power";
+		zephyr,pm-device-runtime-auto;
+	};
+};
+
+&i2c0 {
+	pinctrl-0 = <&i2c0_default>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	si7021: si7021@40 {
+		compatible = "silabs,si7006";
+		reg = <0x40>;
+		vin-supply = <&sensor_enable>;
+		status = "okay";
+	};
 };
 
 &gpio {

--- a/tests/drivers/uart/uart_async_api/boards/xg24_rb4187c.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/xg24_rb4187c.overlay
@@ -9,9 +9,9 @@
  */
 / {
 	chosen {
-		zephyr,console = &eusart1;
-		zephyr,shell-uart = &eusart1;
-		zephyr,uart-pipe = &eusart1;
+		zephyr,console = &eusart0;
+		zephyr,shell-uart = &eusart0;
+		zephyr,uart-pipe = &eusart0;
 	};
 };
 
@@ -28,14 +28,14 @@
 			silabs,input-filter;
 		};
 	};
-	eusart1_default: eusart1_default {
+	eusart0_default: eusart0_default {
 		group0 {
-			pins = <EUSART1_TX_PA8>;
+			pins = <EUSART0_TX_PA8>;
 			drive-push-pull;
 			output-high;
 		};
 		group1 {
-			pins = <EUSART1_RX_PA9>;
+			pins = <EUSART0_RX_PA9>;
 			input-enable;
 			silabs,input-filter;
 		};
@@ -50,10 +50,10 @@ dut: &usart0 {
 	pinctrl-names = "default";
 };
 
-&eusart1 {
+&eusart0 {
 	compatible = "silabs,eusart-uart";
 	current-speed = <115200>;
-	pinctrl-0 = <&eusart1_default>;
+	pinctrl-0 = <&eusart0_default>;
 	pinctrl-names = "default";
 	status = "okay";
 };


### PR DESCRIPTION
Add DTS configuration for SPI and I2C buses on the board. Make use of the new zephyr:board-supported-hw Sphinx directive to automate the list of supported features in the board documentation.