### PR TITLE
drivers: sensor: hs400x: Fix measurement time

### DIFF
--- a/drivers/sensor/renesas/hs400x/hs400x.c
+++ b/drivers/sensor/renesas/hs400x/hs400x.c
@@ -80,9 +80,9 @@ static int hs400x_sample_fetch(const struct device *dev, enum sensor_channel cha
 
 	/*
 	 * According to datasheet maximum time to make temperature and humidity
-	 * measurements is 33ms, add a little safety margin...
+	 * measurements is 1.7 ms, add a little safety margin...
 	 */
-	k_msleep(50);
+	k_msleep(3);
 
 	rc = hs400x_read_sample(dev, &data->t_sample, &data->rh_sample);
 	if (rc < 0) {


### PR DESCRIPTION
According to the [datasheet](https://www.renesas.com/en/document/dst/hs40xx-datasheet?r=1575071#%5B%7B%22num%22%3A75%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C46%2C770%2C0%5D), maximum conversion time for both humidity and temperature at 14 bits resolution is 1.7 ms.