### PR TITLE
github: Update security page for v4.1.0 release

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -11,9 +11,9 @@ updates:
 At this time, with the latest release of v4.0, the supported
 versions are:
 
-  - v4.0: Current release
-  - v3.7: Prior release and Current LTS
-  - v2.7: Prior LTS
+  - v4.1: Current release
+  - v4.0: Prior release
+  - v3.7: Current LTS
 
 ## Reporting process
 


### PR DESCRIPTION
Updates the GitHub security page with the current supported versions after the v4.1.0 release.