### PR TITLE
lorawan: pass callback pointer to callback invocation

### DIFF
--- a/doc/releases/migration-guide-4.2.rst
+++ b/doc/releases/migration-guide-4.2.rst
@@ -305,6 +305,13 @@ SPI
 Other subsystems
 ****************
 
+LoRa
+====
+
+* The :c:member:`lorawan_downlink_cb.cb` callback is now passed a pointer to the parent
+  :c:struct:`lorawan_downlink_cb` instance as the first parameter. This callback pointer can be used
+    to reference outer user-defined data structure using :c:macro:`CONTAINER_OF` macro.
+
 ZBus
 ====
 

--- a/include/zephyr/lorawan/lorawan.h
+++ b/include/zephyr/lorawan/lorawan.h
@@ -170,6 +170,24 @@ struct lorawan_join_config {
 /** Flag to indicate receiving on any port */
 #define LW_RECV_PORT_ANY UINT16_MAX
 
+struct lorawan_downlink_cb;
+
+/**
+ * @brief Defines the downlink callback handler function signature.
+ *
+ * @param cb Pointer to registered callback
+ * @param port Port message was sent on
+ * @param flags Downlink data flags (see @ref lorawan_dl_flags)
+ * @param rssi Received signal strength in dBm
+ * @param snr Signal to Noise ratio in dBm
+ * @param len Length of data received, will be 0 for ACKs
+ * @param data Data received, will be NULL for ACKs
+ */
+typedef void (*lorawan_downlink_cb_t)(struct lorawan_downlink_cb *cb,
+				      uint8_t port, uint8_t flags,
+				      int16_t rssi, int8_t snr,
+				      uint8_t len, const uint8_t *data);
+
 /**
  * @brief LoRaWAN downlink callback parameters
  */
@@ -187,16 +205,8 @@ struct lorawan_downlink_cb {
 	 *
 	 * @note Callbacks are run on the system workqueue,
 	 *       and should therefore be as short as possible.
-	 *
-	 * @param port Port message was sent on
-	 * @param flags Downlink data flags (see @ref lorawan_dl_flags)
-	 * @param rssi Received signal strength in dBm
-	 * @param snr Signal to Noise ratio in dBm
-	 * @param len Length of data received, will be 0 for ACKs
-	 * @param data Data received, will be NULL for ACKs
 	 */
-	void (*cb)(uint8_t port, uint8_t flags, int16_t rssi, int8_t snr, uint8_t len,
-		   const uint8_t *data);
+	lorawan_downlink_cb_t cb;
 	/** Node for callback list */
 	sys_snode_t node;
 };

--- a/samples/subsys/lorawan/class_a/src/main.c
+++ b/samples/subsys/lorawan/class_a/src/main.c
@@ -27,7 +27,8 @@ LOG_MODULE_REGISTER(lorawan_class_a);
 
 char data[] = {'h', 'e', 'l', 'l', 'o', 'w', 'o', 'r', 'l', 'd'};
 
-static void dl_callback(uint8_t port, uint8_t flags, int16_t rssi, int8_t snr, uint8_t len,
+static void dl_callback(struct lorawan_downlink_cb *cb,
+			uint8_t port, uint8_t flags, int16_t rssi, int8_t snr, uint8_t len,
 			const uint8_t *hex_data)
 {
 	LOG_INF("Port %d, Pending %d, RSSI %ddB, SNR %ddBm, Time %d", port,

--- a/samples/subsys/lorawan/fuota/src/main.c
+++ b/samples/subsys/lorawan/fuota/src/main.c
@@ -24,7 +24,8 @@ LOG_MODULE_REGISTER(lorawan_fuota, CONFIG_LORAWAN_SERVICES_LOG_LEVEL);
 
 char data[] = {'h', 'e', 'l', 'l', 'o', 'w', 'o', 'r', 'l', 'd'};
 
-static void downlink_info(uint8_t port, uint8_t flags, int16_t rssi, int8_t snr, uint8_t len,
+static void downlink_info(struct lorawan_downlink_cb *cb,
+			  uint8_t port, uint8_t flags, int16_t rssi, int8_t snr, uint8_t len,
 			  const uint8_t *data)
 {
 	LOG_INF("Received from port %d, flags %d, RSSI %ddB, SNR %ddBm", port, flags, rssi, snr);

--- a/subsys/lorawan/lorawan.c
+++ b/subsys/lorawan/lorawan.c
@@ -185,7 +185,8 @@ static void mcps_indication_handler(McpsIndication_t *mcps_indication)
 	SYS_SLIST_FOR_EACH_CONTAINER(&dl_callbacks, cb, node) {
 		if ((cb->port == LW_RECV_PORT_ANY) ||
 		    (cb->port == mcps_indication->Port)) {
-			cb->cb(mcps_indication->Port, flags, mcps_indication->Rssi,
+			cb->cb(cb,
+			       mcps_indication->Port, flags, mcps_indication->Rssi,
 			       mcps_indication->Snr, mcps_indication->BufferSize,
 			       mcps_indication->Buffer);
 		}

--- a/subsys/lorawan/lorawan_emul.c
+++ b/subsys/lorawan/lorawan_emul.c
@@ -43,7 +43,7 @@ void lorawan_emul_send_downlink(uint8_t port, bool data_pending, int16_t rssi, i
 	/* Iterate over all registered downlink callbacks */
 	SYS_SLIST_FOR_EACH_CONTAINER(&dl_callbacks, cb, node) {
 		if ((cb->port == LW_RECV_PORT_ANY) || (cb->port == port)) {
-			cb->cb(port, data_pending, rssi, snr, len, data);
+			cb->cb(cb, port, data_pending, rssi, snr, len, data);
 		}
 	}
 }

--- a/subsys/lorawan/services/clock_sync.c
+++ b/subsys/lorawan/services/clock_sync.c
@@ -90,7 +90,8 @@ static inline k_timeout_t clock_sync_calc_periodicity(void)
 	return K_SECONDS(ctx.periodicity - 30 + sys_rand32_get() % 61);
 }
 
-static void clock_sync_package_callback(uint8_t port, uint8_t flags, int16_t rssi, int8_t snr,
+static void clock_sync_package_callback(struct lorawan_downlink_cb *cb,
+					uint8_t port, uint8_t flags, int16_t rssi, int8_t snr,
 					uint8_t len, const uint8_t *rx_buf)
 {
 	uint8_t tx_buf[3 * MAX_CLOCK_SYNC_ANS_LEN];

--- a/subsys/lorawan/services/frag_transport.c
+++ b/subsys/lorawan/services/frag_transport.c
@@ -104,7 +104,8 @@ static void (*finished_cb)(void);
 /* Callback to handle descriptor field */
 static transport_descriptor_cb descriptor_cb;
 
-static void frag_transport_package_callback(uint8_t port, uint8_t flags, int16_t rssi, int8_t snr,
+static void frag_transport_package_callback(struct lorawan_downlink_cb *cb,
+					    uint8_t port, uint8_t flags, int16_t rssi, int8_t snr,
 					    uint8_t len, const uint8_t *rx_buf)
 {
 	uint8_t tx_buf[FRAG_TRANSPORT_MAX_CMDS_PER_PACKAGE * FRAG_TRANSPORT_MAX_ANS_LEN];

--- a/subsys/lorawan/services/multicast.c
+++ b/subsys/lorawan/services/multicast.c
@@ -107,7 +107,8 @@ static int32_t multicast_schedule_class_c_session(uint8_t id, uint32_t session_t
 	return time_to_start;
 }
 
-static void multicast_package_callback(uint8_t port, uint8_t flags, int16_t rssi, int8_t snr,
+static void multicast_package_callback(struct lorawan_downlink_cb *cb,
+				       uint8_t port, uint8_t flags, int16_t rssi, int8_t snr,
 				       uint8_t len, const uint8_t *rx_buf)
 {
 	uint8_t tx_buf[MAX_MULTICAST_CMDS_PER_PACKAGE * MAX_MULTICAST_ANS_LEN];

--- a/subsys/mgmt/mcumgr/transport/src/smp_lorawan.c
+++ b/subsys/mgmt/mcumgr/transport/src/smp_lorawan.c
@@ -16,7 +16,8 @@
 
 LOG_MODULE_REGISTER(smp_lorawan, CONFIG_MCUMGR_TRANSPORT_LORAWAN_LOG_LEVEL);
 
-static void smp_lorawan_downlink(uint8_t port, uint8_t flags, int16_t rssi, int8_t snr,
+static void smp_lorawan_downlink(struct lorawan_downlink_cb *cb,
+				 uint8_t port, uint8_t flags, int16_t rssi, int8_t snr,
 				 uint8_t len, const uint8_t *hex_data);
 
 static int smp_lorawan_uplink(struct net_buf *nb);
@@ -122,9 +123,11 @@ static void smp_lorawan_uplink_thread(void *p1, void *p2, void *p3)
 }
 #endif
 
-static void smp_lorawan_downlink(uint8_t port, uint8_t flags, int16_t rssi, int8_t snr,
+static void smp_lorawan_downlink(struct lorawan_downlink_cb *cb,
+				 uint8_t port, uint8_t flags, int16_t rssi, int8_t snr,
 				 uint8_t len, const uint8_t *hex_data)
 {
+	ARG_UNUSED(cb);
 	ARG_UNUSED(flags);
 	ARG_UNUSED(rssi);
 	ARG_UNUSED(snr);


### PR DESCRIPTION
This allows to make use of `CONTAINER_OF()` macro when registered `struct lorawan_downlink_cb` is
part of another structure.