### PR TITLE
net: sockets: Fix IPPROTO_RAW wrongly used with AF_PACKET

### DIFF
--- a/subsys/net/ip/connection.c
+++ b/subsys/net/ip/connection.c
@@ -664,7 +664,7 @@ enum net_verdict net_conn_input(struct net_pkt *pkt,
 			return NET_DROP;
 		}
 	} else if (IS_ENABLED(CONFIG_NET_SOCKETS_PACKET) && pkt_family == AF_PACKET) {
-		if (proto != ETH_P_ALL && proto != IPPROTO_RAW) {
+		if (proto != ETH_P_ALL && proto != ETH_P_ECAT && proto != ETH_P_IEEE802154) {
 			return NET_DROP;
 		}
 	} else if (IS_ENABLED(CONFIG_NET_SOCKETS_CAN) && pkt_family == AF_CAN) {
@@ -753,7 +753,7 @@ enum net_verdict net_conn_input(struct net_pkt *pkt,
 			 * check in this case.
 			 */
 			if (IS_ENABLED(CONFIG_NET_SOCKETS_PACKET) && pkt_family == AF_PACKET) {
-				if (proto != ETH_P_ALL && proto != IPPROTO_RAW) {
+				if (proto != ETH_P_ALL && proto != ETH_P_ECAT && proto != ETH_P_IEEE802154) {
 					continue; /* wrong protocol */
 				}
 			} else {

--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -2564,7 +2564,9 @@ skip_alloc:
 
 		net_pkt_cursor_init(pkt);
 
-		if (net_context_get_proto(context) == IPPROTO_RAW) {
+		if ((net_context_get_family(context) == AF_INET || 
+		     net_context_get_family(context) == AF_INET6) &&
+		    net_context_get_proto(context) == IPPROTO_RAW) {
 			char type = (NET_IPV6_HDR(pkt)->vtc & 0xf0);
 			struct sockaddr_ll *ll_addr;
 

--- a/subsys/net/lib/sockets/sockets_packet.c
+++ b/subsys/net/lib/sockets/sockets_packet.c
@@ -53,7 +53,7 @@ static int zpacket_socket(int family, int type, int proto)
 
 	if (proto == 0) {
 		if (type == SOCK_RAW) {
-			proto = IPPROTO_RAW;
+			proto = ETH_P_ALL;
 		}
 	} else {
 		/* For example in Linux, the protocol parameter can be given
@@ -492,8 +492,7 @@ static bool packet_is_supported(int family, int type, int proto)
 		proto = ntohs(proto);
 		return proto == ETH_P_ALL
 		  || proto == ETH_P_ECAT
-		  || proto == ETH_P_IEEE802154
-		  || proto == IPPROTO_RAW;
+		  || proto == ETH_P_IEEE802154;
 
 	case SOCK_DGRAM:
 		return proto > 0;

--- a/tests/net/socket/af_packet_ipproto_raw/src/main.c
+++ b/tests/net/socket/af_packet_ipproto_raw/src/main.c
@@ -111,16 +111,16 @@ static void *test_setup(void)
 	return NULL;
 }
 
-ZTEST(net_sckt_packet_raw_ip, test_sckt_raw_packet_raw_ip)
+ZTEST(net_sckt_packet_raw, test_sckt_raw_packet)
 {
-	/* A test case for testing socket combo: AF_PACKET & SOCK_RAW & IPPROTO_RAW: */
+	/* A test case for testing socket combo: AF_PACKET & SOCK_RAW & ETH_P_ALL: */
 	struct net_if *iface = net_if_get_first_by_type(&NET_L2_GET_NAME(DUMMY));
 	int recv_data_len, ret;
 	struct sockaddr_ll dst = { 0 };
 	char receive_buffer[128];
 	int sock;
 
-	sock = zsock_socket(AF_PACKET, SOCK_RAW, htons(IPPROTO_RAW));
+	sock = zsock_socket(AF_PACKET, SOCK_RAW, htons(ETH_P_ALL));
 	zassert_true(sock >= 0, "Could not create a socket");
 
 	dst.sll_ifindex = net_if_get_by_iface(iface);
@@ -143,4 +143,4 @@ ZTEST(net_sckt_packet_raw_ip, test_sckt_raw_packet_raw_ip)
 	zsock_close(sock);
 }
 
-ZTEST_SUITE(net_sckt_packet_raw_ip, NULL, test_setup, NULL, NULL, NULL);
+ZTEST_SUITE(net_sckt_packet_raw, NULL, test_setup, NULL, NULL, NULL);


### PR DESCRIPTION
The issue described in #86827 indicates that IPPROTO_RAW should only be used with AF_INET/AF_INET6 sockets via SOCK_RAW, not with AF_PACKET sockets. IPPROTO_RAW is a protocol type for IP frames, not an Ethernet frame type.

I think this should fix the issue.

Summary of changes:
1. Changes the default protocol for AF_PACKET sockets with SOCK_RAW from IPPROTO_RAW to ETH_P_ALL
2. Removes IPPROTO_RAW from the list of valid protocols in packet_is_supported
3. Adds a check in net_context.c to avoid using IPPROTO_RAW code path for AF_PACKET sockets
4. Updates connection.c to use proper Ethernet protocol types
5. Updates the test case to use ETH_P_ALL instead of IPPROTO_RAW

These changes ensure that IPPROTO_RAW is only used with AF_INET and AF_INET6 sockets, not with AF_PACKET sockets, which aligns with how Linux handles these socket types and protocols.

Fixes #86827