### PR TITLE
net: if: set NET_ADDR_PREFERRED before network event if !IPV4_ACD and/or !IPV6_DAD

### DIFF
--- a/samples/net/sockets/echo_server/sample.yaml
+++ b/samples/net/sockets/echo_server/sample.yaml
@@ -137,11 +137,21 @@ tests:
     integration_platforms:
       - qemu_x86
   sample.net.sockets.echo_server.nsos:
+    harness: console
     platform_allow:
       - native_sim
       - native_sim/native/64
     extra_args:
       - EXTRA_CONF_FILE="overlay-nsos.conf"
+    harness_config:
+      type: multi_line
+      ordered: false
+      regex:
+        - "Network connected"
+        - "Waiting for TCP.*IPv4"
+        - "Waiting for TCP.*IPv6"
+        - "Waiting for UDP.*IPv4"
+        - "Waiting for UDP.*IPv6"
   sample.net.sockets.echo_server.802154.subg:
     extra_args: EXTRA_CONF_FILE="overlay-802154-subg.conf"
     platform_allow: beagleconnect_freedom

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -4370,13 +4370,7 @@ out:
 	net_if_unlock(iface);
 }
 #else
-void net_if_ipv4_start_acd(struct net_if *iface, struct net_if_addr *ifaddr)
-{
-	ARG_UNUSED(iface);
-
-	ifaddr->addr_state = NET_ADDR_PREFERRED;
-}
-
+#define net_if_ipv4_start_acd(...)
 #define net_if_start_acd(...)
 #endif /* CONFIG_NET_IPV4_ACD */
 
@@ -4457,7 +4451,8 @@ struct net_if_addr *net_if_ipv4_addr_add(struct net_if *iface,
 			net_sprint_ipv4_addr(addr),
 			net_addr_type2str(addr_type));
 
-		if (!(l2_flags_get(iface) & NET_L2_POINT_TO_POINT) &&
+		if (IS_ENABLED(CONFIG_NET_IPV4_ACD) &&
+		    !(l2_flags_get(iface) & NET_L2_POINT_TO_POINT) &&
 		    !net_ipv4_is_addr_loopback(addr)) {
 			/* ACD is started after the lock is released. */
 			;

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -1470,12 +1470,7 @@ static inline void iface_ipv6_dad_init(void)
 }
 
 #else
-static inline void net_if_ipv6_start_dad(struct net_if *iface,
-					 struct net_if_addr *ifaddr)
-{
-	ifaddr->addr_state = NET_ADDR_PREFERRED;
-}
-
+#define net_if_ipv6_start_dad(...)
 #define iface_ipv6_dad_init(...)
 #endif /* CONFIG_NET_IPV6_DAD */
 
@@ -1817,11 +1812,7 @@ static void address_start_timer(struct net_if_addr *ifaddr, uint32_t vlifetime)
 }
 #else /* CONFIG_NET_NATIVE_IPV6 */
 #define address_start_timer(...)
-static inline void net_if_ipv6_start_dad(struct net_if *iface,
-					 struct net_if_addr *ifaddr)
-{
-	ifaddr->addr_state = NET_ADDR_PREFERRED;
-}
+#define net_if_ipv6_start_dad(...)
 #define join_mcast_nodes(...)
 #endif /* CONFIG_NET_NATIVE_IPV6 */
 
@@ -2038,7 +2029,8 @@ struct net_if_addr *net_if_ipv6_addr_add(struct net_if *iface,
 			net_sprint_ipv6_addr(addr),
 			net_addr_type2str(addr_type));
 
-		if (!(l2_flags_get(iface) & NET_L2_POINT_TO_POINT) &&
+		if (IS_ENABLED(CONFIG_NET_IPV6_DAD) &&
+		    !(l2_flags_get(iface) & NET_L2_POINT_TO_POINT) &&
 		    !net_ipv6_is_addr_loopback(addr) &&
 		    !net_if_flag_is_set(iface, NET_IF_IPV6_NO_ND)) {
 			/* The groups are joined without locks held */


### PR DESCRIPTION
Set `NET_ADDR_PREFERRED` before network event is generated, so that conn_mgr properly generates
`NET_EVENT_L4_CONNECTED` event.

Fixes: 1a5e13a79b98 ("net: if: Release the interface lock early when
  starting IPv4 ACD")

Tested with and with following snippet:
```
	if (mgmt_event == NET_EVENT_L4_IPV4_CONNECTED) {
		LOG_INF("IPv4 connected");
	}

	if (mgmt_event == NET_EVENT_L4_IPV4_DISCONNECTED) {
		LOG_INF("IPv4 disconnected");
	}

	if (mgmt_event == NET_EVENT_L4_IPV6_CONNECTED) {
		LOG_INF("IPv6 connected");
	}

	if (mgmt_event == NET_EVENT_L4_IPV6_DISCONNECTED) {
		LOG_INF("IPv6 disconnected");
	}
```
to have more events generated. Used `west build -p -b native_sim/native/64 zephyr/samples/net/sockets/echo_server -- -DEXTRA_CONF_FILE=overlay-nsos.conf` for testing.

Before this patch:
```
[00:00:00.000,000] <inf> net_config: Initializing network
[00:00:00.000,000] <inf> net_config: IPv4 address: 192.0.2.1
[00:00:00.000,000] <inf> net_echo_server_sample: Run echo server
[00:00:00.000,000] <inf> net_echo_server_sample: Waiting network to be connected
[00:00:00.000,000] <inf> net_echo_server_sample: IPv6 disconnected
[00:00:00.000,000] <inf> net_echo_server_sample: IPv4 disconnected
```
after those patches:
```
[00:00:00.000,000] <inf> net_config: Initializing network
[00:00:00.000,000] <inf> net_config: IPv4 address: 192.0.2.1
[00:00:00.000,000] <inf> net_echo_server_sample: Run echo server
[00:00:00.000,000] <inf> net_echo_server_sample: Network connected
[00:00:00.000,000] <inf> net_echo_server_sample: IPv6 connected
[00:00:00.000,000] <inf> net_echo_server_sample: IPv4 connected
[00:00:00.000,000] <inf> net_echo_server_sample: Starting...
[00:00:00.000,000] <inf> net_echo_server_sample: Waiting for TCP connection on port 4242 (IPv6)...
[00:00:00.000,000] <inf> net_echo_server_sample: Waiting for TCP connection on port 4242 (IPv4)...
[00:00:00.000,000] <inf> net_echo_server_sample: Waiting for UDP packets on port 4242 (IPv6)...
[00:00:00.000,000] <inf> net_echo_server_sample: Waiting for UDP packets on port 4242 (IPv4)...
```

Fixes: #87223