### PR TITLE
linker: device_state : add alignment setting

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -524,6 +524,12 @@ config ARCH_IRQ_VECTOR_TABLE_ALIGN
 	  to be aligned to architecture specific size.  The default
 	  size is 0 for no alignment.
 
+config ARCH_DEVICE_STATE_ALIGN
+	int "Alignment size of device state"
+	default 4
+	help
+	  This option controls alignment size of device state.
+
 choice IRQ_VECTOR_TABLE_TYPE
 	prompt "IRQ vector table type"
 	depends on GEN_IRQ_VECTOR_TABLE

--- a/include/zephyr/linker/common-ram.ld
+++ b/include/zephyr/linker/common-ram.ld
@@ -41,11 +41,13 @@ ITERABLE_SECTION_RAM(scmi_protocol, Z_LINK_ITERABLE_SUBALIGN)
 
         SECTION_DATA_PROLOGUE(device_states,,)
         {
+		. = ALIGN(CONFIG_ARCH_DEVICE_STATE_ALIGN);
 		/* Device states used by the device objects. */
                 PLACE_SYMBOL_HERE(__device_states_start);
 		KEEP(*(".z_devstate"));
 		KEEP(*(".z_devstate.*"));
                 PLACE_SYMBOL_HERE(__device_states_end);
+		. = ALIGN(CONFIG_ARCH_DEVICE_STATE_ALIGN);
         } GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 
 #ifdef CONFIG_PM_DEVICE


### PR DESCRIPTION
the device_state need realocate when boot as second core.
as the relocation does not know the alignment, this could
be a case that the next data is mis-place after relocation.

fix this by add a alignment in device_state section.

still need revert https://github.com/zephyrproject-rtos/zephyr/commit/aec0355380e20ba5ea4cdf98d476a7113a138673
reported in https://github.com/zephyrproject-rtos/zephyr/pull/86871

fixes: https://github.com/zephyrproject-rtos/zephyr/issues/82841
