### PR TITLE
manifest: nrf_wifi: Pull in change to include reg chan info

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -321,7 +321,7 @@ manifest:
       revision: b84bd7314a239f818e78f6927f5673247816df53
       path: modules/bsim_hw_models/nrf_hw_models
     - name: nrf_wifi
-      revision: 396059ca7a6162d07276c5797adbb1311b81cd78
+      revision: 0cd3bb2291a7dd22f4cdb1a4cd935a213c2bbfab
       path: modules/lib/nrf_wifi
     - name: open-amp
       revision: 52bb1783521c62c019451cee9b05b8eda9d7425f


### PR DESCRIPTION
Pull in change to include reg chan info along with reg domain in the GET_REG_DOMAIN event for the radio test and offloaded raw TX modes.