### PR TITLE
doc/releases/migration-guide-4.2: Mention native_posix renames

### DIFF
--- a/doc/releases/migration-guide-4.2.rst
+++ b/doc/releases/migration-guide-4.2.rst
@@ -32,16 +32,42 @@ Boards
 * The config option :kconfig:option:`CONFIG_NATIVE_POSIX_SLOWDOWN_TO_REAL_TIME` has been deprecated
   in favor of :kconfig:option:`CONFIG_NATIVE_SIM_SLOWDOWN_TO_REAL_TIME`.
 
+* The DT binding :dtcompatible:`zephyr,native-posix-cpu` has been deprecated in favor of
+  :dtcompatible:`zephyr,native-sim-cpu`.
+
 * Zephyr now supports version 1.11.1 of the :zephyr:board:`neorv32`.
 
 Device Drivers and Devicetree
 *****************************
+
+Counter
+=======
+
+* ``counter_native_posix`` has been renamed ``counter_native_sim``, and with it its
+  kconfig options and DT binding. :dtcompatible:`zephyr,native-posix-counter`  has been deprecated
+  in favor of :dtcompatible:`zephyr,native-sim-counter`.
+  And :kconfig:option:`CONFIG_COUNTER_NATIVE_POSIX` and its related options with
+  :kconfig:option:`CONFIG_COUNTER_NATIVE_SIM` (:github:`86616`).
+
+Entropy
+=======
+
+* ``fake_entropy_native_posix`` has been renamed ``fake_entropy_native_sim``, and with it its
+  kconfig options and DT binding. :dtcompatible:`zephyr,native-posix-rng`  has been deprecated
+  in favor of :dtcompatible:`zephyr,native-sim-rng`.
+  And :kconfig:option:`CONFIG_FAKE_ENTROPY_NATIVE_POSIX` and its related options with
+  :kconfig:option:`CONFIG_FAKE_ENTROPY_NATIVE_SIM` (:github:`86615`).
 
 Ethernet
 ========
 
 * Removed Kconfig option ``ETH_STM32_HAL_MII`` (:github:`86074`).
   PHY interface type is now selected via the ``phy-connection-type`` property in the device tree.
+
+* ``ethernet_native_posix`` has been renamed ``ethernet_native_tap``, and with it its
+  kconfig options: :kconfig:option:`CONFIG_ETH_NATIVE_POSIX` and its related options have been
+  deprecated in favor of :kconfig:option:`CONFIG_ETH_NATIVE_TAP` (:github:`86578`).
+
 
 GPIO
 ====
@@ -51,6 +77,33 @@ GPIO
   :dtcompatible:`raspberrypi,rpi-gpio-port`, and :dtcompatible:`raspberrypi,rpi-gpio` is
   now left as a placeholder and mapper.
   The labels have also been changed along, so no changes are necessary for regular use.
+
+Serial
+=======
+
+* ``uart_native_posix`` has been renamed ``uart_native_pty``, and with it its
+  kconfig options and DT binding. :dtcompatible:`zephyr,native-posix-uart`  has been deprecated
+  in favor of :dtcompatible:`zephyr,native-pty-uart`.
+  :kconfig:option:`CONFIG_UART_NATIVE_POSIX` and its related options with
+  :kconfig:option:`CONFIG_UART_NATIVE_PTY`.
+  The choice :kconfig:option:`CONFIG_NATIVE_UART_0` has been replaced with
+  :kconfig:option:`CONFIG_UART_NATIVE_PTY_0`, but now, it is also possible to select if a UART is
+  connected to the process stdin/out instead of a PTY at runtime with the command line option
+  ``--<uart_name>_stdinout``.
+  :kconfig:option:`CONFIG_NATIVE_UART_AUTOATTACH_DEFAULT_CMD` has been replaced with
+  :kconfig:option:`CONFIG_UART_NATIVE_PTY_AUTOATTACH_DEFAULT_CMD`.
+  :kconfig:option:`CONFIG_UART_NATIVE_WAIT_PTS_READY_ENABLE` has been deprecated. The functionality
+  it enabled is now always enabled as there is no drawbacks from it.
+  :kconfig:option:`CONFIG_UART_NATIVE_POSIX_PORT_1_ENABLE` has been deprecated. This option does
+  nothing now. Instead users should instantiate as many :dtcompatible:`zephyr,native-pty-uart` nodes
+  as native PTY UART instances they want. (:github:`86739`)
+
+Timer
+=====
+
+* ``native_posix_timer`` has been renamed ``native_sim_timer``, and so its kconfig option
+  :kconfig:option:`CONFIG_NATIVE_POSIX_TIMER` has been deprecated in favor of
+  :kconfig:option:`CONFIG_NATIVE_SIM_TIMER`, (:github:`86612`).
 
 Bluetooth
 *********


### PR DESCRIPTION
Mention all native_posix drivers renames in the migration guide.

Aggregated migration guide changes for:
  * https://github.com/zephyrproject-rtos/zephyr/pull/86612
  * https://github.com/zephyrproject-rtos/zephyr/pull/86616
  * https://github.com/zephyrproject-rtos/zephyr/pull/86615
  * https://github.com/zephyrproject-rtos/zephyr/pull/86739
  * https://github.com/zephyrproject-rtos/zephyr/pull/86578
  * https://github.com/zephyrproject-rtos/zephyr/pull/86785

~Do not merge until the PRs whose changes it documents have been merged.~