### PR TITLE
cmake: add tfm / tfa image information to build info

### DIFF
--- a/modules/trusted-firmware-a/CMakeLists.txt
+++ b/modules/trusted-firmware-a/CMakeLists.txt
@@ -8,6 +8,9 @@ if (CONFIG_BUILD_WITH_TFA)
 
   include(ExternalProject)
 
+  set(tfa_image_info MAP "name: tfa, source-dir: ${ZEPHYR_TRUSTED_FIRMWARE_A_MODULE_DIR}")
+  build_info(images VALUE ${tfa_image_info})
+
   ExternalProject_Add(
     tfa
     SOURCE_DIR ${ZEPHYR_TRUSTED_FIRMWARE_A_MODULE_DIR}

--- a/modules/trusted-firmware-m/CMakeLists.txt
+++ b/modules/trusted-firmware-m/CMakeLists.txt
@@ -294,6 +294,9 @@ if (CONFIG_BUILD_WITH_TFM)
 	# threads. Which is num_cores+2 on Ninja and MAKEFLAGS with Make.
   endif()
 
+  set(tfm_image_info MAP "name: tfm, source-dir: ${ZEPHYR_TRUSTED_FIRMWARE_M_MODULE_DIR}")
+  build_info(images VALUE ${tfm_image_info})
+
   ExternalProject_Add(
     tfm
     SOURCE_DIR ${ZEPHYR_TRUSTED_FIRMWARE_M_MODULE_DIR}


### PR DESCRIPTION
Support for list of images in build info was added with commit 4061311da3ee2ad8f048bf3e94cfb42a8681b6b1 and is used by sysbuild.

Zephyr itself also uses CMake's External Project feature when including TF-M or TF-A in a Zephyr build.

Populate build info with TF-M / TF-A information when said image is included in the build.