### PR TITLE
net: ip: Do not use IPPROTO_RAW for AF_PACKET sockets

### DIFF
--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -2564,7 +2564,7 @@ skip_alloc:
 
 		net_pkt_cursor_init(pkt);
 
-		if (net_context_get_proto(context) == IPPROTO_RAW) {
+		if (net_context_get_proto(context) == 0) {
 			char type = (NET_IPV6_HDR(pkt)->vtc & 0xf0);
 			struct sockaddr_ll *ll_addr;
 

--- a/subsys/net/ip/net_core.c
+++ b/subsys/net/ip/net_core.c
@@ -126,9 +126,10 @@ static inline enum net_verdict process_data(struct net_pkt *pkt,
 
 	if (IS_ENABLED(CONFIG_NET_IP) && (family == AF_INET || family == AF_INET6 ||
 					  family == AF_UNSPEC || family == AF_PACKET)) {
-		/* L2 processed, now we can pass IPPROTO_RAW to packet socket:
+		/* L2 processed, now we can pass either IPPROTO_RAW or
+		 * protocol 0 (any protocol for AF_PACKET) to packet socket:
 		 */
-		ret = net_packet_socket_input(pkt, IPPROTO_RAW);
+		ret = net_packet_socket_input(pkt, (family == AF_PACKET) ? 0 : IPPROTO_RAW);
 		if (ret != NET_CONTINUE) {
 			return ret;
 		}

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -512,7 +512,7 @@ enum net_verdict net_if_try_send_data(struct net_if *iface, struct net_pkt *pkt,
 	/* Bypass the IP stack with SOCK_RAW/IPPROTO_RAW sockets */
 	if (IS_ENABLED(CONFIG_NET_SOCKETS_PACKET) &&
 	    context && net_context_get_type(context) == SOCK_RAW &&
-	    net_context_get_proto(context) == IPPROTO_RAW) {
+	    net_context_get_proto(context) == 0) {
 		goto done;
 	}
 


### PR DESCRIPTION
The AF_PACKET socket protocol field needs to be according to ETH_P_* values (defined in include/net/ethernet.h) and not for IPPROTO_RAW which is only for AF_INET or AF_INET6 family.

Fixes #86827