### PR TITLE
dts: bindings: neorv32: use vendor prefix

### DIFF
--- a/doc/releases/release-notes-3.2.rst
+++ b/doc/releases/release-notes-3.2.rst
@@ -1112,7 +1112,7 @@ Devicetree
     * :dtcompatible:`microchip,xec-espi`
     * :dtcompatible:`microchip,xec-i2c`
     * :dtcompatible:`microchip,xec-qmspi`
-    * :dtcompatible:`neorv32-machine-timer`
+    * :dtcompatible:`neorv32,machine-timer`
     * :dtcompatible:`nordic,nrf-ieee802154`
     * :dtcompatible:`nuclei,systimer`
     * :dtcompatible:`nuvoton,npcx-leakage-io`

--- a/doc/releases/release-notes-3.2.rst
+++ b/doc/releases/release-notes-3.2.rst
@@ -1613,7 +1613,7 @@ MCUboot
 * Edited the DFU detection's GPIO-pin configuration to be done through DTS using the ``mcuboot-button0`` pin alias.
 * Edited the LED usage to prefer DTS' ``mcuboot-led0`` alias over the ``bootloader-led0`` alias.
 * Removed :c:func:`device_get_binding()` usage in favor of :c:func:`DEVICE_DT_GET()`.
-* Added support for generic `watchdog0` alias.
+* Added support for generic ``watchdog0`` alias.
 * Enabled watchdog feed by default.
 * Dropped the :kconfig:option:`CONFIG_BOOT_IMAGE_ACCESS_HOOKS_FILE` option.
   The inclusion of the Hooks implementation file is now up to the project's customization.

--- a/doc/releases/release-notes-3.5.rst
+++ b/doc/releases/release-notes-3.5.rst
@@ -2180,7 +2180,7 @@ Libraries / Subsystems
     the heap.
   * Added a new type of observer called Message Subscriber. ZBus' VDED will send a copy of the
     message during the publication/notification process.
-  * Changed the VDED delivery sequence. Check the ref:`documentation<zbus delivery sequence>`.
+  * Changed the VDED delivery sequence. Check the :ref:`documentation <zbus delivery sequence>`.
   * ZBus runtime observers now rely on the heap instead of a memory pool.
   * Added new iterable section iterators APIs (for channels and observers) can now receive a
     ``user_data`` pointer to keep context between the function calls.
@@ -2322,8 +2322,8 @@ Documentation
 Tests and Samples
 *****************
 
-* Created common sample for file systems (`fs_sample`). It originates from sample for FAT
-  (`fat_fs`) and supports both FAT and ext2 file systems.
+* Created common sample for file systems (``fs_sample``). It originates from sample for FAT
+  (``fat_fs``) and supports both FAT and ext2 file systems.
 
 * Created the zbus confirmed channel sample to demonstrate how to implement a delivery-guaranteed
   channel using subscribers.

--- a/doc/releases/release-notes-3.5.rst
+++ b/doc/releases/release-notes-3.5.rst
@@ -1022,7 +1022,7 @@ Bindings
     * The ``riscv,isa`` property used by RISC-V CPU bindings no longer has an
       ``enum`` value.
 
-    * :dtcompatible:`neorv32-cpu`:
+    * :dtcompatible:`neorv32,cpu`:
 
           * new property: ``mmu-type``
           * new property: ``riscv,isa``

--- a/dts/bindings/cpu/neorv32,cpu.yaml
+++ b/dts/bindings/cpu/neorv32,cpu.yaml
@@ -3,6 +3,6 @@
 
 description: NEORV32 RISC-V CPU
 
-compatible: "neorv32-cpu"
+compatible: "neorv32,cpu"
 
 include: riscv,cpus.yaml

--- a/dts/bindings/gpio/neorv32,gpio.yaml
+++ b/dts/bindings/gpio/neorv32,gpio.yaml
@@ -1,6 +1,6 @@
 description: NEORV32 GPIO
 
-compatible: "neorv32-gpio"
+compatible: "neorv32,gpio"
 
 include: [gpio-controller.yaml, base.yaml]
 

--- a/dts/bindings/rng/neorv32,trng.yaml
+++ b/dts/bindings/rng/neorv32,trng.yaml
@@ -1,6 +1,6 @@
 description: NEORV32 True Random Number Generator (TRNG)
 
-compatible: "neorv32-trng"
+compatible: "neorv32,trng"
 
 include: base.yaml
 

--- a/dts/bindings/serial/neorv32,uart.yaml
+++ b/dts/bindings/serial/neorv32,uart.yaml
@@ -1,6 +1,6 @@
 description: NEORV32 UART
 
-compatible: "neorv32-uart"
+compatible: "neorv32,uart"
 
 include: uart-controller.yaml
 

--- a/dts/bindings/vendor-prefixes.txt
+++ b/dts/bindings/vendor-prefixes.txt
@@ -452,6 +452,7 @@ myir	MYIR Tech Limited
 national	National Semiconductor
 nec	NEC LCD Technologies, Ltd.
 neonode	Neonode Inc.
+neorv32	NEORV32 RISC-V Processor
 netgear	NETGEAR
 netlogic	Broadcom Corporation (formerly NetLogic Microsystems)
 netron-dy	Netron DY

--- a/dts/riscv/neorv32.dtsi
+++ b/dts/riscv/neorv32.dtsi
@@ -19,7 +19,7 @@
 		#size-cells = <0>;
 
 		cpu0: cpu@0 {
-			compatible = "neorv32-cpu", "riscv";
+			compatible = "neorv32,cpu", "riscv";
 			reg = <0>;
 			device_type = "cpu";
 
@@ -74,13 +74,13 @@
 		};
 
 		bootrom: rom@ffe00000 {
-			compatible = "neorv32-bootrom", "mmio-sram";
+			compatible = "neorv32,bootrom", "mmio-sram";
 			status = "disabled";
 			reg = <0xffe00000 0x10000>;
 		};
 
 		clint: clint@fff40000 {
-			compatible = "neorv32-clint", "sifive,clint0";
+			compatible = "neorv32,clint", "sifive,clint0";
 			status = "disabled";
 			reg = <0xfff40000 0x10000>;
 			interrupts-extended = <&intc 3>;
@@ -95,7 +95,7 @@
 		};
 
 		uart0: serial@fff50000 {
-			compatible = "neorv32-uart";
+			compatible = "neorv32,uart";
 			status = "disabled";
 			reg = <0xfff50000 0x10000>;
 			interrupts = <2>, <3>;
@@ -104,7 +104,7 @@
 		};
 
 		uart1: serial@fff60000 {
-			compatible = "neorv32-uart";
+			compatible = "neorv32,uart";
 			status = "disabled";
 			reg = <0xfff60000 0x10000>;
 			interrupts = <4>, <5>;
@@ -113,14 +113,14 @@
 		};
 
 		trng: rng@fffa0000 {
-			compatible = "neorv32-trng";
+			compatible = "neorv32,trng";
 			status = "disabled";
 			reg = <0xfffa0000 0x10000>;
 			syscon = <&sysinfo>;
 		};
 
 		gpio: gpio@fffc0000 {
-			compatible = "neorv32-gpio";
+			compatible = "neorv32,gpio";
 			status = "disabled";
 			reg = <0xfffc0000 0x10000>;
 			syscon = <&sysinfo>;


### PR DESCRIPTION
Use vendor prefix "neorv32" for all peripherals provided by the NEORV32 RISV-V Processor project.