### PR TITLE
include: spi: Restore warning in spi_config structure documentation

### DIFF
--- a/include/zephyr/drivers/spi.h
+++ b/include/zephyr/drivers/spi.h
@@ -297,6 +297,10 @@ typedef uint16_t spi_operation_t;
 
 /**
  * @brief SPI controller configuration structure
+ *
+ * @warning Most drivers use pointer comparison to determine whether a passed
+ * configuration is different from one used in a previous transaction.
+ * Changes to fields in the structure may not be detected.
  */
 struct spi_config {
 	/** @brief Bus frequency in Hertz. */


### PR DESCRIPTION
It was added in commit 7a8a4c9b3e02356cedc22936b2726bbaf5d2be30, but then, presumably unintentionally, was removed in commit 4c4e2c5213c523b34d3a4f5e4ddd1c5b49f7f374.