### PR TITLE
NXP LPSPI: Some bug fixes to the interrupt-based driver

### DIFF
--- a/drivers/spi/spi_nxp_lpspi/spi_nxp_lpspi.c
+++ b/drivers/spi/spi_nxp_lpspi/spi_nxp_lpspi.c
@@ -115,7 +115,7 @@ static inline uint32_t lpspi_next_tx_word(const struct device *dev, int offset)
 	uint32_t next_word = 0;
 
 	for (uint8_t i = 0; i < num_bytes; i++) {
-		next_word |= *byte << (BITS_PER_BYTE * i);
+		next_word |= byte[i] << (BITS_PER_BYTE * i);
 	}
 
 	return next_word;

--- a/drivers/spi/spi_nxp_lpspi/spi_nxp_lpspi.c
+++ b/drivers/spi/spi_nxp_lpspi/spi_nxp_lpspi.c
@@ -238,7 +238,8 @@ static int transceive(const struct device *dev, const struct spi_config *spi_cfg
 	LPSPI_Type *base = (LPSPI_Type *)DEVICE_MMIO_NAMED_GET(dev, reg_base);
 	struct spi_mcux_data *data = dev->data;
 	struct lpspi_driver_data *lpspi_data = (struct lpspi_driver_data *)data->driver_data;
-	int ret;
+	struct spi_context *ctx = &data->ctx;
+	int ret = 0;
 
 	spi_context_lock(&data->ctx, asynchronous, cb, userdata, spi_cfg);
 
@@ -246,14 +247,14 @@ static int transceive(const struct device *dev, const struct spi_config *spi_cfg
 	if (lpspi_data->word_size_bytes > 4) {
 		LOG_ERR("Maximum 4 byte word size");
 		ret = -EINVAL;
-		return ret;
+		goto error;
 	}
 
-	spi_context_buffers_setup(&data->ctx, tx_bufs, rx_bufs, lpspi_data->word_size_bytes);
+	spi_context_buffers_setup(ctx, tx_bufs, rx_bufs, lpspi_data->word_size_bytes);
 
 	ret = spi_mcux_configure(dev, spi_cfg);
 	if (ret) {
-		return ret;
+		goto error;
 	}
 
 	LPSPI_FlushFifo(base, true, true);
@@ -261,7 +262,7 @@ static int transceive(const struct device *dev, const struct spi_config *spi_cfg
 	LPSPI_DisableInterrupts(base, (uint32_t)kLPSPI_AllInterruptEnable);
 
 	LOG_DBG("Starting LPSPI transfer");
-	spi_context_cs_control(&data->ctx, true);
+	spi_context_cs_control(ctx, true);
 
 	LPSPI_SetFifoWatermarks(base, 0, 0);
 	LPSPI_Enable(base, true);
@@ -277,7 +278,11 @@ static int transceive(const struct device *dev, const struct spi_config *spi_cfg
 	LPSPI_EnableInterrupts(base, (uint32_t)kLPSPI_TxInterruptEnable |
 				     (uint32_t)kLPSPI_RxInterruptEnable);
 
-	return spi_context_wait_for_completion(&data->ctx);
+	return spi_context_wait_for_completion(ctx);
+
+error:
+	spi_context_release(ctx, ret);
+	return ret;
 }
 
 static int spi_mcux_transceive_sync(const struct device *dev, const struct spi_config *spi_cfg,


### PR DESCRIPTION
There are two bugs I saw while doing code analysis:
1) The TX word formation for multi-byte words is wrong due to a typo that does not increment the byte pointer
2) There is a resource leak of the spi context in the transceive function due to not releasing upon error

Fixes #86930