### PR TITLE
net: lwm2m: encapsulate ring buffer internals

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_message_handling.c
+++ b/subsys/net/lib/lwm2m/lwm2m_message_handling.c
@@ -1403,9 +1403,7 @@ static int lwm2m_read_cached_data(struct lwm2m_message *msg,
 		read_info = &msg->cache_info->read_info[msg->cache_info->entry_size];
 		/* Store original timeseries ring buffer get states for failure handling */
 		read_info->cache_data = cached_data;
-		read_info->original_get_base = cached_data->rb.get.base;
-		read_info->original_get_head = cached_data->rb.get.head;
-		read_info->original_get_tail = cached_data->rb.get.tail;
+		read_info->original_rb_get = cached_data->rb.get;
 		msg->cache_info->entry_size++;
 		if (msg->cache_info->entry_limit) {
 			length = MIN(length, msg->cache_info->entry_limit);
@@ -3079,12 +3077,8 @@ static bool lwm2m_timeseries_data_rebuild(struct lwm2m_message *msg, int error_c
 
 	/* Put Ring buffer back to original */
 	for (int i = 0; i < cache_temp->entry_size; i++) {
-		cache_temp->read_info[i].cache_data->rb.get.head =
-			cache_temp->read_info[i].original_get_head;
-		cache_temp->read_info[i].cache_data->rb.get.tail =
-			cache_temp->read_info[i].original_get_tail;
-		cache_temp->read_info[i].cache_data->rb.get.base =
-			cache_temp->read_info[i].original_get_base;
+		cache_temp->read_info[i].cache_data->rb.get =
+			cache_temp->read_info[i].original_rb_get;
 	}
 
 	if (cache_temp->entry_limit) {

--- a/subsys/net/lib/lwm2m/lwm2m_registry.h
+++ b/subsys/net/lib/lwm2m/lwm2m_registry.h
@@ -219,9 +219,7 @@ struct lwm2m_time_series_resource {
 
 struct lwm2m_cache_read_entry {
 	struct lwm2m_time_series_resource *cache_data;
-	int32_t original_get_head;
-	int32_t original_get_tail;
-	int32_t original_get_base;
+	struct ring_buf_index original_rb_get;
 };
 
 struct lwm2m_cache_read_info {


### PR DESCRIPTION
Use struct ring_buf_index as a whole, don't access its constituants.

Signed-off-by: Nicolas Pitre <npitre@baylibre.com>
