### PR TITLE
drivers: eSPI: microchip: Port80 Multibyte

### DIFF
--- a/drivers/espi/Kconfig.xec
+++ b/drivers/espi/Kconfig.xec
@@ -104,6 +104,13 @@ config ESPI_XEC_PERIPHERAL_HOST_CMD_PARAM_SIZE
 config ESPI_PERIPHERAL_8042_KBC
 	default y
 
+config ESPI_XEC_P80_MULTIBYTE
+	bool "Host can write 1/2/4 bytes of Port80 data in a eSPI transaction"
+	depends on ESPI_XEC_V2 && ESPI_PERIPHERAL_DEBUG_PORT_80
+	help
+	  EC can accept 1/2/4 bytes of Port 80 data written from the Host in an
+	  eSPI transaction.
+
 if ESPI_PERIPHERAL_CHANNEL
 
 config ESPI_PERIPHERAL_XEC_MAILBOX


### PR DESCRIPTION
Updated p80bd0_isr to receive Port 80 bytes and concatenate them before sending to the application.