### PR TITLE
arch: x86: remove arch specific dependencies from DYNAMIC_BOOTARGS

### DIFF
--- a/arch/x86/core/CMakeLists.txt
+++ b/arch/x86/core/CMakeLists.txt
@@ -21,6 +21,8 @@ zephyr_library_sources_ifdef(CONFIG_X86_MMU x86_mmu.c)
 zephyr_library_sources_ifdef(CONFIG_USERSPACE userspace.c)
 zephyr_library_sources_ifdef(CONFIG_ARCH_CACHE cache.c)
 
+zephyr_library_sources_ifdef(CONFIG_DYNAMIC_BOOTARGS bootargs.c)
+
 zephyr_library_sources_ifdef(CONFIG_X86_VERY_EARLY_CONSOLE early_serial.c)
 
 zephyr_library_sources_ifdef(CONFIG_THREAD_LOCAL_STORAGE tls.c)

--- a/arch/x86/core/bootargs.c
+++ b/arch/x86/core/bootargs.c
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2025 Cadence Design Systems, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+
+#if defined(CONFIG_MULTIBOOT_INFO)
+
+__pinned_noinit char multiboot_cmdline[CONFIG_BOOTARGS_ARGS_BUFFER_SIZE];
+
+const char *get_bootargs(void)
+{
+	return multiboot_cmdline;
+}
+
+#elif defined(CONFIG_X86_EFI)
+
+__pinned_noinit char efi_bootargs[CONFIG_BOOTARGS_ARGS_BUFFER_SIZE];
+
+const char *get_bootargs(void)
+{
+	return efi_bootargs;
+}
+
+#endif

--- a/arch/x86/core/efi.c
+++ b/arch/x86/core/efi.c
@@ -18,10 +18,6 @@ static uint64_t __aligned(64) efi_stack[1024];
 
 struct efi_boot_arg *efi;
 
-#ifdef CONFIG_DYNAMIC_BOOTARGS
-__pinned_noinit char efi_bootargs[CONFIG_BOOTARGS_ARGS_BUFFER_SIZE];
-#endif
-
 void *efi_get_acpi_rsdp(void)
 {
 	if (efi == NULL) {
@@ -173,10 +169,3 @@ int arch_printk_char_out(int c)
 	return efi_console_putchar(c);
 }
 #endif
-
-#ifdef CONFIG_DYNAMIC_BOOTARGS
-const char *get_bootargs(void)
-{
-	return efi_bootargs;
-}
-#endif /* CONFIG_DYNAMIC_BOOTARGS */

--- a/arch/x86/core/multiboot.c
+++ b/arch/x86/core/multiboot.c
@@ -11,15 +11,6 @@
 
 struct multiboot_info multiboot_info;
 
-#ifdef CONFIG_DYNAMIC_BOOTARGS
-__pinned_noinit char multiboot_cmdline[CONFIG_BOOTARGS_ARGS_BUFFER_SIZE];
-
-const char *get_bootargs(void)
-{
-	return multiboot_cmdline;
-}
-#endif /* CONFIG_DYNAMIC_BOOTARGS */
-
 /*
  * called very early in the boot process to fetch data out of the multiboot
  * info struct. we need to grab the relevant data before any dynamic memory

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -1060,7 +1060,7 @@ config BOOTARGS
 
 config DYNAMIC_BOOTARGS
 	bool "Support dynamic bootargs"
-	depends on BOOTARGS && (MULTIBOOT_INFO || BUILD_OUTPUT_EFI)
+	depends on BOOTARGS
 	help
 	  Enables dynamic bootargs support.
 


### PR DESCRIPTION
CONFIG_DYNAMIC_BOOTARGS currently depends on CONFIG_MULTIBOOT_INFO and CONFIG_BUILD_OUTPUT_EFI which are x86 specific.

This change removes those dependencies so that another architecture can use CONFIG_DYNAMIC_BOOTARGS without the x86 specifc features.