### PR TITLE
Add myself as collaborator for TI K3 and Beagle boards

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -299,6 +299,7 @@ BeagleBoard Platforms:
     - ayush1325
     - con-pax
     - vaishnavachath
+    - glneo
   files:
     - boards/beagle/
   labels:

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -4245,6 +4245,7 @@ TI K3 Platforms:
   collaborators:
     - gramsay0
     - dnltz
+    - glneo
   files:
     - boards/ti/*am62*/
     - drivers/*/*davinci*


### PR DESCRIPTION
This change adds @glneo as a collaborator for TI K3 and BeagleBoard platforms.