### PR TITLE
cmake: modules: Refer to log file based on CMake version

### DIFF
--- a/cmake/modules/kernel.cmake
+++ b/cmake/modules/kernel.cmake
@@ -142,8 +142,12 @@ enable_language(ASM)
 # Verify that the toolchain can compile a dummy file, if it is not we
 # won't be able to test for compatibility with certain C flags.
 zephyr_check_compiler_flag(C "" toolchain_is_ok)
+set(log_file "CMakeConfigureLog.yaml")
+if(CMAKE_VERSION VERSION_LESS "3.26.0")
+  set(log_file "CMakeError.log")
+endif()
 assert(toolchain_is_ok "The toolchain is unable to build a dummy C file.\
- Move ${USER_CACHE_DIR}, re-run and look at CMakeError.log")
+ Move ${USER_CACHE_DIR}, re-run and look at ${log_file}")
 
 include(${ZEPHYR_BASE}/cmake/target_toolchain_flags.cmake)
 


### PR DESCRIPTION
Starting with cmake 3.26, the log file used for configure-time checks
has changed:

https://cmake.org/cmake/help/latest/release/3.26.html#configure-log