### PR TITLE
doc: Remove disabled row styling from table of supported HW features

### DIFF
--- a/doc/_extensions/zephyr/domain/__init__.py
+++ b/doc/_extensions/zephyr/domain/__init__.py
@@ -871,8 +871,6 @@ class BoardSupportedHardwareDirective(SphinxDirective):
 
                 for i, (key, value) in enumerate(items):
                     row = nodes.row()
-                    if value.get("disabled_nodes", []) and not value.get("okay_nodes", []):
-                        row["classes"].append("disabled")
 
                     # TYPE column
                     if i == 0:

--- a/doc/_extensions/zephyr/domain/static/css/board.css
+++ b/doc/_extensions/zephyr/domain/static/css/board.css
@@ -133,11 +133,6 @@
         }
     }
 
-    /* Disabled feature styling */
-    tr.disabled {
-        opacity: 0.3;
-    }
-
     /* Column widths and specific styling */
     .type {
         font-weight: 600;

--- a/doc/_extensions/zephyr/domain/static/css/board.css
+++ b/doc/_extensions/zephyr/domain/static/css/board.css
@@ -110,6 +110,7 @@
     th {
         background: var(--navbar-background-color);
         color: var(--navbar-level-1-color);
+        border: none !important;
         font-weight: 600;
         text-transform: uppercase;
         font-size: 0.8em;


### PR DESCRIPTION
Grayed out rows in the table of supported HW features are more confusing than helpful (this has been reported by many users in a very short period of time).
The yellow/green indicators with the count for each feature are enough to communicate the initial status.

<img width="863" alt="image" src="https://github.com/user-attachments/assets/7dbcd8d8-6387-4c36-9025-0b3652b4a323" />
