### PR TITLE
bluetooth: coex: increase BT_LONG_WQ  stack to fix coex app hang

### DIFF
--- a/soc/nxp/rw/Kconfig.defconfig
+++ b/soc/nxp/rw/Kconfig.defconfig
@@ -29,6 +29,7 @@ config MAIN_STACK_SIZE
 	default 2560
 
 config BT_LONG_WQ_STACK_SIZE
+	default 5120 if (WIFI || IEEE802154)
 	default 2560
 
 config SYSTEM_WORKQUEUE_STACK_SIZE


### PR DESCRIPTION
Currently, coex application (wifi +ble + ot) for rw is enable the mbedtls and PAS feature, this causes BT_LONG_WQ thread to use more stack size. So we need to increase the default stack size of BT_LONG_WQ when build with wifi or ot.