### PR TITLE
hostap: AP enable is not allowed if unsupported security type

### DIFF
--- a/modules/hostap/src/supp_api.c
+++ b/modules/hostap/src/supp_api.c
@@ -2466,6 +2466,10 @@ int hapd_config_network(struct hostapd_iface *iface,
 				goto out;
 			}
 #endif
+		} else {
+			wpa_printf(MSG_ERROR, "Security type %d is not supported",
+				   params->security);
+			goto out;
 		}
 	} else {
 		if (!hostapd_cli_cmd_v("set wpa 0")) {


### PR DESCRIPTION
is configured

Return error if any of unsupported type is configured and softAP will not be started.