### PR TITLE
WPA Enterprise AP scan results update

### DIFF
--- a/drivers/wifi/nxp/nxp_wifi_drv.c
+++ b/drivers/wifi/nxp/nxp_wifi_drv.c
@@ -716,7 +716,7 @@ static int nxp_wifi_process_results(unsigned int count)
 		res.security = WIFI_SECURITY_TYPE_NONE;
 
 		if (scan_result.wpa2_entp) {
-			res.security = WIFI_SECURITY_TYPE_EAP_TLS;
+			res.security = WIFI_SECURITY_TYPE_EAP;
 		}
 		if (scan_result.wpa2) {
 			res.security = WIFI_SECURITY_TYPE_PSK;
@@ -730,13 +730,13 @@ static int nxp_wifi_process_results(unsigned int count)
 
 		if (scan_result.wpa3_entp) {
 			res.wpa3_ent_type = WIFI_WPA3_ENTERPRISE_ONLY;
-			res.security = WIFI_SECURITY_TYPE_EAP_TLS;
+			res.security = WIFI_SECURITY_TYPE_EAP;
 		} else if (scan_result.wpa3_1x_sha256) {
 			res.wpa3_ent_type = WIFI_WPA3_ENTERPRISE_SUITEB;
-			res.security = WIFI_SECURITY_TYPE_EAP_TLS;
+			res.security = WIFI_SECURITY_TYPE_EAP;
 		} else if (scan_result.wpa3_1x_sha384) {
 			res.wpa3_ent_type = WIFI_WPA3_ENTERPRISE_SUITEB_192;
-			res.security = WIFI_SECURITY_TYPE_EAP_TLS;
+			res.security = WIFI_SECURITY_TYPE_EAP;
 		}
 
 		if (scan_result.ap_mfpr) {

--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -208,7 +208,8 @@ static void handle_wifi_scan_result(struct net_mgmt_event_callback *cb)
 	   entry->rssi,
 	   ((entry->wpa3_ent_type) ?
 		wifi_wpa3_enterprise_txt(entry->wpa3_ent_type)
-		 : wifi_security_txt(entry->security)),
+		 : (entry->security == WIFI_SECURITY_TYPE_EAP ? "WPA2 Enterprise"
+		 : wifi_security_txt(entry->security))),
 	   ((entry->mac_length) ?
 		   net_sprint_ll_addr_buf(entry->mac, WIFI_MAC_ADDR_LEN,
 					  mac_string_buf,


### PR DESCRIPTION
Update WPA2 Enterprise AP security to "WPA2 Enterprise" in scan results.