### PR TITLE
samples: boards: st: adapt the mco to the nucleo_wba55

### DIFF
--- a/samples/boards/st/mco/boards/nucleo_f411re.overlay
+++ b/samples/boards/st/mco/boards/nucleo_f411re.overlay
@@ -8,6 +8,11 @@
 	status = "okay";
 };
 
+/* Enable HSI as it will be output on MCO pin by this sample */
+&clk_hsi {
+	status = "okay";
+};
+
 /* see RefMan RM0383 */
 &mco1 {
 	/* Select One of the line below for clock source */

--- a/samples/boards/st/mco/boards/nucleo_wba55cg.overlay
+++ b/samples/boards/st/mco/boards/nucleo_wba55cg.overlay
@@ -8,17 +8,17 @@
 &clk_lse {
 	status = "okay";
 };
-/* MCO use same pin like usart1 RX - disable usart */
+
 / {
 	chosen {
-		zephyr,bt-c2h-uart = &lpuart1;
-		zephyr,uart-pipe = &lpuart1;
-		zephyr,console = &lpuart1;
-		zephyr,shell-uart = &lpuart1;
+		zephyr,console = &usart1;
+		zephyr,shell-uart = &usart1;
 	};
 };
+
 &usart1 {
-	status = "disabled";
+	/* Do not use the console RX pin : dedicated to the MCO */
+	pinctrl-0 = <&usart1_tx_pb12 &analog_pa8>;
 };
 
 &mco1 {

--- a/samples/boards/st/mco/sample.yaml
+++ b/samples/boards/st/mco/sample.yaml
@@ -2,6 +2,7 @@ sample:
   name: STM32 microcontroller clock output (MCO) example
 tests:
   sample.board.stm32.mco:
+    build_only: true
     platform_allow:
       - nucleo_f411re
       - nucleo_f446ze


### PR DESCRIPTION
The stm32wba55 nucleo board has the PB8 output pin for the MCO, it cannot be used for the console RX
signal. This PR is routing the PB8 to the MCO instead of the usart1 during this sample execution

To allow the    /samples/boards/st/mco execution on the nucleo_wba55cg, just remove the RX pin of the console
--> this is the MCO output 
The console usart1 is kept functional on it TX pin, the usart1 Rx pin is not really used for this application
