### PR TITLE
bluetooth: mesh: set subscription address on response

### DIFF
--- a/subsys/bluetooth/mesh/cfg_srv.c
+++ b/subsys/bluetooth/mesh/cfg_srv.c
@@ -1429,6 +1429,7 @@ static int mod_sub_va_add(const struct bt_mesh_model *model,
 		/* Tried to add existing subscription */
 		status = STATUS_SUCCESS;
 		(void)bt_mesh_va_del(va->uuid);
+		sub_addr = va->addr;
 		goto send_status;
 	}
 


### PR DESCRIPTION
This fixes an issue where a subsequent Config Model Subscription Add message with the same virtual address UUID would result in a Config Model Subscription Status message with the Address field incorrectly set to 0.