### PR TITLE
Bluetooth: SMP_BR: Derive LTK after LK refreshed

### DIFF
--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -2271,6 +2271,17 @@ static void hci_encrypt_key_refresh_complete(struct net_buf *buf)
 			bt_conn_unref(conn);
 			return;
 		}
+
+		if (IS_ENABLED(CONFIG_BT_SMP)) {
+			/*
+			 * Start SMP over BR/EDR if we are pairing and are
+			 * central on the link
+			 */
+			if (atomic_test_bit(conn->flags, BT_CONN_BR_PAIRED) &&
+			    conn->role == BT_CONN_ROLE_CENTRAL) {
+				bt_smp_br_send_pairing_req(conn);
+			}
+		}
 	}
 #endif /* CONFIG_BT_CLASSIC */
 


### PR DESCRIPTION
When the link key of BR is upgraded, the encrypt key refresh event will be notified. The link key is upgraded from weak to strong. The LTK of LE should be derived from strong link key.

Start SMP pairing procedure to try to derive LTK from LK.