### PR TITLE
manifest: net-tools: Update to remove native_posix mentions

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -313,7 +313,7 @@ manifest:
         - debug
       revision: 33e5c23cbedda5ba12dbe50c4baefb362a791001
     - name: net-tools
-      revision: 93acc8bac4661e74e695eb1aea94c7c5262db2e2
+      revision: 986bfeb040df3d9029366de8aea4ce1f84e93780
       path: tools/net-tools
       groups:
         - tools


### PR DESCRIPTION
Update net-tools to the latest version which replaces mentions of native_posix with native_sim.