### PR TITLE
drivers: udc_dwc2: Set control endpoint CNAK only when necessary

### DIFF
--- a/drivers/usb/udc/udc_dwc2.c
+++ b/drivers/usb/udc/udc_dwc2.c
@@ -668,7 +668,32 @@ static void dwc2_prep_rx(const struct device *dev, struct net_buf *buf,
 
 	/* Clear NAK and set endpoint enable */
 	doepctl = sys_read32(doepctl_reg);
-	doepctl |= USB_DWC2_DEPCTL_EPENA | USB_DWC2_DEPCTL_CNAK;
+	doepctl |= USB_DWC2_DEPCTL_EPENA;
+	if (cfg->addr == USB_CONTROL_EP_OUT) {
+		struct udc_data *data = dev->data;
+
+		/* During OUT Data Stage every packet has to have CNAK set.
+		 * In Buffer DMA mode the OUT endpoint is armed during IN Data
+		 * Stage to accept either Status stage or new SETUP token. The
+		 * Status stage (premature or not) can only be received if CNAK
+		 * was set. In Completer mode the OUT endpoint armed during OUT
+		 * Status stage needs CNAK.
+		 *
+		 * Setting CNAK in other cases opens up possibility for Buffer
+		 * DMA controller to lock up completely if the endpoint is
+		 * enabled (to receive SETUP data) when the host is transmitting
+		 * subsequent control transfer OUT Data Stage packet (SETUP DATA
+		 * is unconditionally ACKed regardless of software state).
+		 */
+		if (data->stage == CTRL_PIPE_STAGE_DATA_OUT ||
+		    data->stage == CTRL_PIPE_STAGE_DATA_IN ||
+		    data->stage == CTRL_PIPE_STAGE_STATUS_OUT) {
+			doepctl |= USB_DWC2_DEPCTL_CNAK;
+		}
+	} else {
+		/* Non-control endpoint, set CNAK for all transfers */
+		doepctl |= USB_DWC2_DEPCTL_CNAK;
+	}
 
 	if (dwc2_ep_is_iso(cfg)) {
 		xfersize = USB_MPS_TO_TPL(cfg->mps);


### PR DESCRIPTION
SETUP data is unconditionally ACKed by the controller. Other DATA packets sent to OUT control endpoint 0 (i.e. OUT Data Stage packets and OUT Status Stage packet) are ACKed by the device only if the endpoint was enabled with CNAK bit set.

In Buffer DMA mode controller will lock up in following scenario:
  * OUT EP0 is not enabled, e.g. OUT Status Stage has finished
  * Host starts Control Write transfer, i.e. sends SETUP DATA0 and device ACKs (regardless if endpoint is enabled or not)
  * host sends OUT Data Stage (OUT DATA1)
      - software enables endpoint to be able to receive next SETUP data while host is transmitting the OUT token. If CNAK bit is set alongside the EPENA bit, the device will ACK the OUT Data Stage. If CNAK bit is not set, the device will NAK the OUT Data Stage.

When the lockup occurs, from host perspective the OUT Data Stage packet was successfully transmitted. This can result in host starting IN Status Stage if there was only one OUT Data Stage packet. This in turn results in device never getting the DOEPTINT0 SetUp interrupt. Besides just not getting the SetUp interrupt, any subsequent control transfer won't be noticed by device at all.

The lockup was first observed while stress testing. The host was issuing endless sequence of Control Write, Control Read, Control Write, Control Read, ... commands. When the controller did lock up in Buffer DMA mode, from host perspective the device was timing out all control transfers.

Avoid the Buffer DMA lockup by setting CNAK bit only when necessary.