### PR TITLE
llext: skip MMU flag adjustment for pre-located extensions 

### DIFF
--- a/include/zephyr/llext/llext.h
+++ b/include/zephyr/llext/llext.h
@@ -125,6 +125,7 @@ struct llext {
 	unsigned int sect_cnt;
 	elf_shdr_t *sect_hdrs;
 	bool sect_hdrs_on_heap;
+	bool mmu_permissions_set;
 	/** @endcond */
 };
 
@@ -152,7 +153,8 @@ struct llext_load_param {
 	 * the memory buffer, when calculating relocation targets. It also
 	 * means, that the application will take care to place the extension at
 	 * those pre-defined addresses, so the LLEXT core doesn't have to do any
-	 * allocation and copying internally.
+	 * allocation and copying internally. Any MMU permission adjustment will
+	 * be done by the application too.
 	 */
 	bool pre_located;
 

--- a/subsys/llext/llext_load.c
+++ b/subsys/llext/llext_load.c
@@ -756,7 +756,9 @@ int do_llext_load(struct llext_loader *ldr, struct llext *ext,
 		goto out;
 	}
 
-	llext_adjust_mmu_permissions(ext);
+	if (!ldr_parm->pre_located) {
+		llext_adjust_mmu_permissions(ext);
+	}
 
 out:
 	/*

--- a/subsys/llext/llext_mem.c
+++ b/subsys/llext/llext_mem.c
@@ -220,6 +220,8 @@ void llext_adjust_mmu_permissions(struct llext *ext)
 		sys_cache_data_flush_range(addr, size);
 		k_mem_update_flags(addr, size, flags);
 	}
+
+	ext->mmu_permissions_set = true;
 #endif
 }
 
@@ -227,7 +229,7 @@ void llext_free_regions(struct llext *ext)
 {
 	for (int i = 0; i < LLEXT_MEM_COUNT; i++) {
 #ifdef CONFIG_MMU
-		if (ext->mem_size[i] != 0) {
+		if (ext->mmu_permissions_set && ext->mem_size[i] != 0) {
 			/* restore default RAM permissions */
 			k_mem_update_flags(ext->mem[i],
 					   ROUND_UP(ext->mem_size[i], LLEXT_PAGE_SIZE),


### PR DESCRIPTION
When loading or unloading extensions we try to adjust the MMU configuration for the used memory area. This is both unneeded for cases where the mapping is done using a TLB and it actually causes system crashes. Disable that on PTL.