### PR TITLE
drivers: udc_ambiq: do not include DWC2 hardware header and do not leak UDC_AMBIQ_MAX_QMESSAGES 

### DIFF
--- a/drivers/usb/udc/Kconfig.ambiq
+++ b/drivers/usb/udc/Kconfig.ambiq
@@ -11,16 +11,16 @@ config UDC_AMBIQ
 	help
 	  Enable USB Device Controller Driver.
 
+if UDC_AMBIQ
+
 config UDC_AMBIQ_STACK_SIZE
 	int "UDC AMBIQ driver internal thread stack size"
-	depends on UDC_AMBIQ
 	default 2048
 	help
 	  AMBIQ driver internal thread stack size.
 
 config UDC_AMBIQ_THREAD_PRIORITY
 	int "UDC AMBIQ driver thread priority"
-	depends on UDC_AMBIQ
 	default 8
 	help
 	  AMBIQ driver thread priority.
@@ -32,3 +32,5 @@ config UDC_AMBIQ_MAX_QMESSAGES
 	default 8
 	help
 	  AMBIQ maximum number of ISR event messages.
+
+endif # UDC_AMBIQ

--- a/drivers/usb/udc/udc_ambiq.c
+++ b/drivers/usb/udc/udc_ambiq.c
@@ -18,7 +18,6 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/irq.h>
 #include "udc_common.h"
-#include <usb_dwc2_hw.h>
 
 LOG_MODULE_REGISTER(udc_ambiq, CONFIG_UDC_DRIVER_LOG_LEVEL);
 


### PR DESCRIPTION
Do not include DWC2 hardware header and do not leak UDC_AMBIQ_MAX_QMESSAGES.