### PR TITLE
USB STM32: Refactor maximum speed initialization

### DIFF
--- a/dts/arm/st/f0/stm32f042.dtsi
+++ b/dts/arm/st/f0/stm32f042.dtsi
@@ -72,6 +72,7 @@
 			interrupt-names = "usb";
 			num-bidir-endpoints = <8>;
 			ram-size = <1024>;
+			maximum-speed = "full-speed";
 			phys = <&usb_fs_phy>;
 			clocks = <&rcc STM32_CLOCK(APB1, 23U)>,
 				 <&rcc STM32_SRC_PLLCLK USB_SEL(1)>;

--- a/dts/arm/st/f0/stm32f070.dtsi
+++ b/dts/arm/st/f0/stm32f070.dtsi
@@ -43,6 +43,7 @@
 			interrupt-names = "usb";
 			num-bidir-endpoints = <8>;
 			ram-size = <1024>;
+			maximum-speed = "full-speed";
 			phys = <&usb_fs_phy>;
 			clocks = <&rcc STM32_CLOCK(APB1, 23U)>,
 				 <&rcc STM32_SRC_PLLCLK USB_SEL(1)>;

--- a/dts/arm/st/f0/stm32f072.dtsi
+++ b/dts/arm/st/f0/stm32f072.dtsi
@@ -25,6 +25,7 @@
 			interrupt-names = "usb";
 			num-bidir-endpoints = <8>;
 			ram-size = <1024>;
+			maximum-speed = "full-speed";
 			phys = <&usb_fs_phy>;
 			clocks = <&rcc STM32_CLOCK(APB1, 23U)>,
 				 <&rcc STM32_SRC_PLLCLK USB_SEL(1)>;

--- a/dts/arm/st/f1/stm32f103X8.dtsi
+++ b/dts/arm/st/f1/stm32f103X8.dtsi
@@ -42,6 +42,7 @@
 			interrupt-names = "usb";
 			num-bidir-endpoints = <8>;
 			ram-size = <512>;
+			maximum-speed = "full-speed";
 			status = "disabled";
 			clocks = <&rcc STM32_CLOCK(APB1, 23U)>;
 			phys = <&usb_fs_phy>;

--- a/dts/arm/st/f1/stm32f105.dtsi
+++ b/dts/arm/st/f1/stm32f105.dtsi
@@ -146,6 +146,7 @@
 			num-bidir-endpoints = <4>;
 			ram-size = <1280>;
 			clocks = <&rcc STM32_CLOCK(AHB1, 12U)>;
+			maximum-speed = "full-speed";
 			phys = <&otgfs_phy>;
 			status = "disabled";
 		};

--- a/dts/arm/st/f3/stm32f3.dtsi
+++ b/dts/arm/st/f3/stm32f3.dtsi
@@ -258,6 +258,7 @@
 			interrupt-names = "usb";
 			num-bidir-endpoints = <8>;
 			ram-size = <512>;
+			maximum-speed = "full-speed";
 			phys = <&usb_fs_phy>;
 			clocks = <&rcc STM32_CLOCK(APB1, 23U)>;
 			status = "disabled";

--- a/dts/arm/st/g0/stm32g0b0.dtsi
+++ b/dts/arm/st/g0/stm32g0b0.dtsi
@@ -99,6 +99,7 @@
 			interrupt-names = "usb";
 			num-bidir-endpoints = <8>;
 			ram-size = <2048>;
+			maximum-speed = "full-speed";
 			phys = <&usb_fs_phy>;
 			clocks = <&rcc STM32_CLOCK(APB1, 13U)>,
 				 <&rcc STM32_SRC_HSI48 USB_SEL(0)>;

--- a/dts/arm/st/g0/stm32g0b1.dtsi
+++ b/dts/arm/st/g0/stm32g0b1.dtsi
@@ -143,6 +143,7 @@
 			interrupt-names = "usb";
 			num-bidir-endpoints = <8>;
 			ram-size = <2048>;
+			maximum-speed = "full-speed";
 			phys = <&usb_fs_phy>;
 			clocks = <&rcc STM32_CLOCK(APB1, 13U)>,
 				 <&rcc STM32_SRC_HSI48 USB_SEL(0)>;

--- a/dts/arm/st/g4/stm32g4.dtsi
+++ b/dts/arm/st/g4/stm32g4.dtsi
@@ -621,6 +621,7 @@
 			interrupt-names = "usb", "usbhp";
 			num-bidir-endpoints = <8>;
 			ram-size = <1024>;
+			maximum-speed = "full-speed";
 			phys = <&usb_fs_phy>;
 			clocks = <&rcc STM32_CLOCK(APB1, 23U)>,
 				 <&rcc STM32_SRC_HSI48 CLK48_SEL(0)>;

--- a/dts/arm/st/h5/stm32h5.dtsi
+++ b/dts/arm/st/h5/stm32h5.dtsi
@@ -635,6 +635,7 @@
 			interrupt-names = "usb";
 			num-bidir-endpoints = <8>;
 			ram-size = <2048>;
+			maximum-speed = "full-speed";
 			phys = <&usb_fs_phy>;
 			clocks = <&rcc STM32_CLOCK(APB2, 24U)>,
 				 <&rcc STM32_SRC_HSI48 USB_SEL(3)>;

--- a/dts/arm/st/l5/stm32l5.dtsi
+++ b/dts/arm/st/l5/stm32l5.dtsi
@@ -693,6 +693,7 @@
 			interrupt-names = "usb";
 			num-bidir-endpoints = <8>;
 			ram-size = <1024>;
+			maximum-speed = "full-speed";
 			status = "disabled";
 			clocks = <&rcc STM32_CLOCK(APB1_2, 21U)>,
 				 <&rcc STM32_SRC_HSI48 CLK48_SEL(0)>;

--- a/dts/arm/st/u0/stm32u073.dtsi
+++ b/dts/arm/st/u0/stm32u073.dtsi
@@ -55,6 +55,7 @@
 			interrupt-names = "usb";
 			num-bidir-endpoints = <8>;
 			ram-size = <1024>;
+			maximum-speed = "full-speed";
 			phys = <&usb_fs_phy>;
 			clocks = <&rcc STM32_CLOCK(APB1, 13U)>;
 			status = "disabled";

--- a/dts/arm/st/u5/stm32u545.dtsi
+++ b/dts/arm/st/u5/stm32u545.dtsi
@@ -21,6 +21,7 @@
 			interrupt-names = "usb";
 			num-bidir-endpoints = <8>;
 			ram-size = <1024>;
+			maximum-speed = "full-speed";
 			status = "disabled";
 			clocks = <&rcc STM32_CLOCK(APB2, 24U)>,
 				 <&rcc STM32_SRC_HSI48 ICKLK_SEL(0)>;

--- a/dts/arm/st/wb/stm32wb.dtsi
+++ b/dts/arm/st/wb/stm32wb.dtsi
@@ -487,6 +487,7 @@
 			interrupt-names = "usb", "usbhp";
 			num-bidir-endpoints = <8>;
 			ram-size = <1024>;
+			maximum-speed = "full-speed";
 			phys = <&usb_fs_phy>;
 			clocks = <&rcc STM32_CLOCK(APB1, 26U)>,
 				 <&rcc STM32_SRC_HSI48 CLK48_SEL(0)>;


### PR DESCRIPTION
This pull request refactors the initialization of the maximum USB speed for STM32 devices:

- Simplify the "usb_dc_stm32_get_maximum_speed" function by adding a  property if not present in device tree.
- Updated "usb_dc_stm32_get_maximum_speed" function to use "DT_INST_STRING_UPPER_TOKEN(0, maximum_speed)" for setting the USB speed.
- Removed redundant speed initialization.