### PR TITLE
soc/cdns/sample_controller32: align `CONFIG_PRIVILEGED_STACK_SIZE`

### DIFF
--- a/soc/cdns/sample_controller32/Kconfig.defconfig
+++ b/soc/cdns/sample_controller32/Kconfig.defconfig
@@ -1,0 +1,11 @@
+# Copyright (c) 2025 Antmicro <www.antmicro.com>
+# SPDX-License-Identifier: Apache-2.0
+
+if SOC_XTENSA_SAMPLE_CONTROLLER32
+
+# CONFIG_PRIVILEGED_STACK_SIZE must be aligned as specified by XCHAL_MPU_ALIGN.
+# For `sample_controller32`, that value is equal to 4096
+config PRIVILEGED_STACK_SIZE
+	default 4096 if XTENSA_MPU
+
+endif # SOC_XTENSA_SAMPLE_CONTROLLER32


### PR DESCRIPTION
This PR aligns the value of `CONFIG_PRIVILEGED_STACK_SIZE` to the alignment specified by the value of `XCHAL_MPU_ALIGN`, which for `sample_controller32` is equal to 4096.

Without this, the Hello World sample fails to build on the `qemu_xtensa/sample_controller32/mpu` target.