### PR TITLE
Bluetooth: Mesh: Disable PB-GATT on PB-ADV link

### DIFF
--- a/subsys/bluetooth/mesh/pb_adv.c
+++ b/subsys/bluetooth/mesh/pb_adv.c
@@ -1071,6 +1071,12 @@ static int prov_link_accept(const struct prov_bearer_cb *cb, void *cb_data)
 	return 0;
 }
 
+static void prov_link_cancel(void)
+{
+	bt_mesh_beacon_disable();
+	bt_mesh_scan_disable();
+}
+
 static void prov_link_close(enum prov_bearer_link_status status)
 {
 	int err;
@@ -1109,6 +1115,7 @@ const struct prov_bearer bt_mesh_pb_adv = {
 	.type = BT_MESH_PROV_ADV,
 	.link_open = prov_link_open,
 	.link_accept = prov_link_accept,
+	.link_cancel = prov_link_cancel,
 	.link_close = prov_link_close,
 	.send = prov_send_adv,
 	.clear_tx = prov_clear_tx,

--- a/subsys/bluetooth/mesh/pb_gatt.c
+++ b/subsys/bluetooth/mesh/pb_gatt.c
@@ -198,6 +198,11 @@ static int link_accept(const struct prov_bearer_cb *cb, void *cb_data)
 
 	return 0;
 }
+
+static void link_cancel(void)
+{
+	(void)bt_mesh_pb_gatt_srv_disable();
+}
 #endif
 
 static void buf_send_end(struct bt_conn *conn, void *user_data)
@@ -246,6 +251,7 @@ const struct prov_bearer bt_mesh_pb_gatt = {
 #endif
 #if defined(CONFIG_BT_MESH_PB_GATT)
 	.link_accept = link_accept,
+	.link_cancel = link_cancel,
 #endif
 	.send = buf_send,
 	.clear_tx = clear_tx,

--- a/subsys/bluetooth/mesh/prov_bearer.h
+++ b/subsys/bluetooth/mesh/prov_bearer.h
@@ -76,6 +76,12 @@ struct prov_bearer {
 	 */
 	int (*link_accept)(const struct prov_bearer_cb *cb, void *cb_data);
 
+	/** @brief Disable link establishment as a provisionee.
+	 *
+	 *  Stops accepting link open messages and sending unprovisioned beacons.
+	 */
+	void (*link_cancel)(void);
+
 	/** @brief Send a packet on an established link.
 	 *
 	 *  @param buf     Payload buffer. Requires @ref

--- a/subsys/bluetooth/mesh/rpr_srv.c
+++ b/subsys/bluetooth/mesh/rpr_srv.c
@@ -1359,6 +1359,12 @@ static int node_refresh_link_accept(const struct prov_bearer_cb *cb,
 	return 0;
 }
 
+static void node_refresh_link_cancel(void)
+{
+	srv.refresh.cb = NULL;
+	srv.refresh.cb_data = NULL;
+}
+
 static void node_refresh_tx_complete(int err, void *cb_data)
 {
 	if (err) {
@@ -1408,6 +1414,7 @@ const struct prov_bearer pb_remote_srv = {
 	.type = BT_MESH_PROV_REMOTE,
 
 	.link_accept = node_refresh_link_accept,
+	.link_cancel = node_refresh_link_cancel,
 	.send = node_refresh_buf_send,
 	.clear_tx = node_refresh_clear_tx,
 };

--- a/subsys/bluetooth/mesh/settings.c
+++ b/subsys/bluetooth/mesh/settings.c
@@ -104,10 +104,6 @@ static int mesh_commit(void)
 		return 0;
 	}
 
-	if (IS_ENABLED(CONFIG_BT_MESH_PB_GATT)) {
-		(void)bt_mesh_pb_gatt_srv_disable();
-	}
-
 	bt_mesh_net_settings_commit();
 	bt_mesh_model_settings_commit();
 

--- a/tests/bsim/bluetooth/mesh/src/test_provision.c
+++ b/tests/bsim/bluetooth/mesh/src/test_provision.c
@@ -109,7 +109,7 @@ static void test_args_parse(int argc, char *argv[])
 			.dest = &prov_bearer,
 			.type = 'i',
 			.name = "{invalid, PB-ADV, PB-GATT}",
-			.option = "prov-brearer",
+			.option = "prov-bearer",
 			.descript = "Provisioning bearer that is to be used."
 		},
 	};

--- a/tests/bsim/bluetooth/mesh/src/test_provision.c
+++ b/tests/bsim/bluetooth/mesh/src/test_provision.c
@@ -42,6 +42,8 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #define WAIT_TIME 120 /*seconds*/
 #define IS_RPR_PRESENT  (CONFIG_BT_MESH_RPR_SRV && CONFIG_BT_MESH_RPR_CLI)
 #define IMPOSTER_MODEL_ID 0xe000
+/* Rough estimate of the time it should take the provisionee to stop sending unprov beacons. */
+#define PROV_DELTA_THRESH_MS 100
 
 enum test_flags {
 	IS_PROVISIONER,
@@ -101,6 +103,7 @@ static uint32_t link_close_timestamp;
 
 /* Set prov_bearer to non-zero invalid value. */
 static bt_mesh_prov_bearer_t prov_bearer = 0xF8;
+static bt_mesh_prov_bearer_t prov_to_use;
 
 static void test_args_parse(int argc, char *argv[])
 {
@@ -108,9 +111,17 @@ static void test_args_parse(int argc, char *argv[])
 		{
 			.dest = &prov_bearer,
 			.type = 'i',
-			.name = "{invalid, PB-ADV, PB-GATT}",
+			.name = "{invalid, PB-ADV, PB-GATT, (PB-ADV | PB-GATT)}",
 			.option = "prov-bearer",
 			.descript = "Provisioning bearer that is to be used."
+		},
+		{
+			.dest = &prov_to_use,
+			.type = 'i',
+			.name = "{PB-ADV, PB-GATT}",
+			.option = "prov-to-use",
+			.descript = "Provisioning bearer that is to be used in the case that "
+				    "multiple provisioning bearers are enabled in prov_bearer."
 		},
 	};
 
@@ -279,6 +290,42 @@ static void test_terminate(void)
 	}
 }
 
+static uint64_t prov_started_time_ms;
+static uint8_t prov_uuid[16];
+
+static void provision(uint8_t uuid[16], bt_mesh_prov_bearer_t bearer)
+{
+	int err;
+
+	switch (bearer) {
+	case BT_MESH_PROV_ADV:
+		err = bt_mesh_provision_adv(uuid, 0, prov_addr, 0);
+		break;
+	case BT_MESH_PROV_GATT:
+		err = bt_mesh_provision_gatt(uuid, 0, prov_addr, 0);
+		break;
+	default:
+		err = -ENOTSUP;
+	}
+
+	if (!err) {
+		LOG_INF("Provisioning over %s started.",
+			bearer == BT_MESH_PROV_ADV ? "PB-ADV" : "PB-GATT");
+		prov_started_time_ms = k_uptime_get();
+		memcpy(prov_uuid, uuid, 16);
+	}
+}
+
+static void provisionee_beacon_check(uint8_t uuid[16], bt_mesh_prov_bearer_t bearer)
+{
+	if (memcmp(uuid, prov_uuid, 16) == 0) {
+		ASSERT_FALSE_MSG((prov_started_time_ms &&
+				  (k_uptime_delta(&prov_started_time_ms) > PROV_DELTA_THRESH_MS)),
+				 "Received %s beacon from provisionee after provisioning started.",
+				 bearer == BT_MESH_PROV_ADV ? "PB-ADV" : "PB-GATT");
+	}
+}
+
 static void unprovisioned_beacon(uint8_t uuid[16],
 				 bt_mesh_prov_oob_info_t oob_info,
 				 uint32_t *uri_hash)
@@ -290,7 +337,12 @@ static void unprovisioned_beacon(uint8_t uuid[16],
 	if (uuid_to_provision && memcmp(uuid, uuid_to_provision, 16)) {
 		return;
 	}
-	bt_mesh_provision_adv(uuid, 0, prov_addr, 0);
+
+	provisionee_beacon_check(uuid, BT_MESH_PROV_ADV);
+
+	if (!prov_to_use || prov_to_use == BT_MESH_PROV_ADV) {
+		provision(uuid, BT_MESH_PROV_ADV);
+	}
 }
 
 static void unprovisioned_beacon_gatt(uint8_t uuid[16], bt_mesh_prov_oob_info_t oob_info)
@@ -303,7 +355,11 @@ static void unprovisioned_beacon_gatt(uint8_t uuid[16], bt_mesh_prov_oob_info_t 
 		return;
 	}
 
-	bt_mesh_provision_gatt(uuid, 0, prov_addr, 0);
+	provisionee_beacon_check(uuid, BT_MESH_PROV_GATT);
+
+	if (!prov_to_use || prov_to_use == BT_MESH_PROV_GATT) {
+		provision(uuid, BT_MESH_PROV_GATT);
+	}
 }
 
 static void prov_complete(uint16_t net_idx, uint16_t addr)
@@ -328,6 +384,8 @@ static void prov_node_added(uint16_t net_idx, uint8_t uuid[16], uint16_t addr,
 {
 	LOG_INF("Device 0x%04x provisioned", prov_addr);
 	current_dev_addr = prov_addr++;
+	prov_started_time_ms = 0;
+	memset(prov_uuid, 0, 16);
 	k_sem_give(&prov_sem);
 }
 
@@ -344,6 +402,7 @@ static void prov_reset(void)
 
 static bt_mesh_input_action_t gact;
 static uint8_t gsize;
+static bool oob_wait_unprov_int;
 static int input(bt_mesh_input_action_t act, uint8_t size)
 {
 	/* The test system requests the input OOB data earlier than
@@ -354,7 +413,9 @@ static int input(bt_mesh_input_action_t act, uint8_t size)
 	gact = act;
 	gsize = size;
 
-	k_work_reschedule(&oob_timer, K_SECONDS(1));
+	k_work_reschedule(&oob_timer, oob_wait_unprov_int
+					      ? K_SECONDS(CONFIG_BT_MESH_UNPROV_BEACON_INT + 1)
+					      : K_SECONDS(1));
 
 	return 0;
 }
@@ -741,6 +802,49 @@ static void test_provisioner_oob_public_key(void)
 static void test_provisioner_oob_auth_no_oob_public_key(void)
 {
 	oob_provisioner(true, false);
+
+	PASS();
+}
+
+static void test_provisioner_pb_cancel(void)
+{
+	k_sem_init(&prov_sem, 0, 1);
+
+	bt_mesh_device_setup(&prov, &comp);
+
+	ASSERT_OK(bt_mesh_cdb_create(test_net_key));
+
+	ASSERT_OK(bt_mesh_provision(test_net_key, 0, 0, 0, 0x0001, dev_key));
+
+	prov.static_val = 0;
+	prov.static_val_len = 0;
+	prov.output_size = 0;
+	prov.output_actions = 0;
+	prov.input_size = 8;
+	prov.input_actions = BT_MESH_ENTER_NUMBER;
+
+	ASSERT_OK(k_sem_take(&prov_sem, K_SECONDS(20)));
+
+	PASS();
+}
+
+static void test_device_pb_cancel(void)
+{
+	oob_wait_unprov_int = true;
+	k_sem_init(&prov_sem, 0, 1);
+
+	bt_mesh_device_setup(&prov, &comp);
+
+	prov.static_val = 0;
+	prov.static_val_len = 0;
+	prov.output_size = 0;
+	prov.output_actions = 0;
+	prov.input_size = 8;
+	prov.input_actions = BT_MESH_ENTER_NUMBER;
+
+	ASSERT_OK(bt_mesh_prov_enable(prov_bearer));
+
+	ASSERT_OK(k_sem_take(&prov_sem, K_SECONDS(20)));
 
 	PASS();
 }
@@ -1809,6 +1913,7 @@ static const struct bst_test_instance test_connect[] = {
 	TEST_CASE_WBACKCHANNEL(device, oob_public_key,
 			       "Device: provisioning use oob public key"),
 	TEST_CASE(device, reprovision, "Device: provisioning, reprovision"),
+	TEST_CASE_WBACKCHANNEL(device, pb_cancel, "Device: provisioning, cancel prov bearers."),
 #if IS_RPR_PRESENT
 	TEST_CASE(device, pb_remote_server_unproved,
 		  "Device: used for remote provisioning, starts unprovisioned"),
@@ -1839,6 +1944,8 @@ static const struct bst_test_instance test_connect[] = {
 	TEST_CASE(
 		provisioner, reprovision,
 		"Provisioner: provisioning, resetting and reprovisioning multiple times."),
+	TEST_CASE_WBACKCHANNEL(
+		provisioner, pb_cancel, "Provisioner: provisioning, cancel prov bearers."),
 #if IS_RPR_PRESENT
 	TEST_CASE(provisioner, pb_remote_client_reprovision,
 		  "Provisioner: pb-remote provisioning, resetting and reprov-ing multiple times."),

--- a/tests/bsim/bluetooth/mesh/tests_scripts/provision/pb_cancel.sh
+++ b/tests/bsim/bluetooth/mesh/tests_scripts/provision/pb_cancel.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Copyright 2025 Nordic Semiconductor
+# SPDX-License-Identifier: Apache-2.0
+
+source $(dirname "${BASH_SOURCE[0]}")/../../_mesh_test.sh
+
+# Test that PB-ADV and PB-GATT unprovisioned beacons are cancelled when a provisioning link is
+# opened.
+# Test procedure:
+# 1. The provisioner self-provisions and starts scanning for unprovisioned devices.
+# 2. The provisionee enables both the PB-ADV and PB-GATT bearers.
+# 3. The provisioner finds the unprovisioned device and provisions it with OOB authentication.
+#    The OOB authentication is delayed by CONFIG_BT_MESH_UNPROV_BEACON_INT + 1 seconds to ensure
+#    that the provisioner has time observe that PB-ADV and PB-GATT beacons are cancelled.
+# 4. The provisioning procedure completes.
+
+overlay=overlay_gatt_conf_overlay_psa_conf
+RunTest mesh_prov_pb_cancel_adv \
+	prov_provisioner_pb_cancel \
+	prov_device_pb_cancel \
+	-- -argstest prov-bearer=3 prov-to-use=1
+
+overlay=overlay_gatt_conf_overlay_psa_conf
+RunTest mesh_prov_pb_cancel_gatt \
+	prov_provisioner_pb_cancel \
+	prov_device_pb_cancel \
+	-- -argstest prov-bearer=3 prov-to-use=2

--- a/tests/bsim/bluetooth/mesh/tests_scripts/provision/pb_remote_parallel.sh
+++ b/tests/bsim/bluetooth/mesh/tests_scripts/provision/pb_remote_parallel.sh
@@ -16,7 +16,7 @@ RunTest mesh_prov_pb_remote_parallel \
 	prov_device_pb_remote_server_unproved \
 	prov_device_no_oob \
 	prov_device_no_oob \
-	-- -argstest prov-brearer=1
+	-- -argstest prov-bearer=1
 
 overlay=overlay_psa_conf
 RunTest mesh_prov_pb_remote_parallel_psa \
@@ -24,4 +24,4 @@ RunTest mesh_prov_pb_remote_parallel_psa \
 	prov_device_pb_remote_server_unproved \
 	prov_device_no_oob \
 	prov_device_no_oob \
-	-- -argstest prov-brearer=1
+	-- -argstest prov-bearer=1

--- a/tests/bsim/bluetooth/mesh/tests_scripts/provision/pb_remote_reprovision.sh
+++ b/tests/bsim/bluetooth/mesh/tests_scripts/provision/pb_remote_reprovision.sh
@@ -16,11 +16,11 @@ RunTest mesh_prov_pb_remote_reprovision \
 	prov_provisioner_pb_remote_client_reprovision \
 	prov_device_pb_remote_server_unproved \
 	prov_device_reprovision \
-	-- -argstest prov-brearer=1
+	-- -argstest prov-bearer=1
 
 overlay=overlay_psa_conf
 RunTest mesh_prov_pb_remote_reprovision_psa \
 	prov_provisioner_pb_remote_client_reprovision \
 	prov_device_pb_remote_server_unproved \
 	prov_device_reprovision \
-	-- -argstest prov-brearer=1
+	-- -argstest prov-bearer=1

--- a/tests/bsim/bluetooth/mesh/tests_scripts/provision/pb_remote_timeout.sh
+++ b/tests/bsim/bluetooth/mesh/tests_scripts/provision/pb_remote_timeout.sh
@@ -27,10 +27,10 @@ source $(dirname "${BASH_SOURCE[0]}")/../../_mesh_test.sh
 RunTest mesh_prov_pb_remote_provisioning_timeout \
 	prov_provisioner_pb_remote_client_provision_timeout \
 	prov_device_pb_remote_server_unproved_unresponsive \
-	prov_device_unresponsive -- -argstest prov-brearer=1
+	prov_device_unresponsive -- -argstest prov-bearer=1
 
 overlay=overlay_psa_conf
 RunTest mesh_prov_pb_remote_provisioning_timeout_psa \
 	prov_provisioner_pb_remote_client_provision_timeout \
 	prov_device_pb_remote_server_unproved_unresponsive \
-	prov_device_unresponsive -- -argstest prov-brearer=1
+	prov_device_unresponsive -- -argstest prov-bearer=1

--- a/tests/bsim/bluetooth/mesh/tests_scripts/provision/prov_multi.sh
+++ b/tests/bsim/bluetooth/mesh/tests_scripts/provision/prov_multi.sh
@@ -12,7 +12,7 @@ RunTest mesh_prov_pb_adv_multi \
 	prov_device_no_oob \
 	prov_device_no_oob \
 	prov_device_no_oob \
-	-- -argstest prov-brearer=1
+	-- -argstest prov-bearer=1
 
 overlay=overlay_gatt_conf_overlay_psa_conf
 RunTest mesh_prov_pb_gatt_multi \
@@ -20,7 +20,7 @@ RunTest mesh_prov_pb_gatt_multi \
 	prov_device_no_oob \
 	prov_device_no_oob \
 	prov_device_no_oob \
-	-- -argstest prov-brearer=2
+	-- -argstest prov-bearer=2
 
 overlay=overlay_psa_conf
 RunTest mesh_prov_pb_adv_multi_psa \
@@ -28,4 +28,4 @@ RunTest mesh_prov_pb_adv_multi_psa \
 	prov_device_no_oob \
 	prov_device_no_oob \
 	prov_device_no_oob \
-	-- -argstest prov-brearer=1
+	-- -argstest prov-bearer=1

--- a/tests/bsim/bluetooth/mesh/tests_scripts/provision/prov_no_oob.sh
+++ b/tests/bsim/bluetooth/mesh/tests_scripts/provision/prov_no_oob.sh
@@ -7,16 +7,16 @@ source $(dirname "${BASH_SOURCE[0]}")/../../_mesh_test.sh
 RunTest mesh_prov_pb_adv_on_oob \
 	prov_device_no_oob \
 	prov_provisioner_no_oob \
-	-- -argstest prov-brearer=1
+	-- -argstest prov-bearer=1
 
 overlay=overlay_gatt_conf_overlay_psa_conf
 RunTest mesh_prov_pb_gatt_on_oob \
 	prov_device_no_oob \
 	prov_provisioner_no_oob \
-	-- -argstest prov-brearer=2
+	-- -argstest prov-bearer=2
 
 overlay=overlay_psa_conf
 RunTest mesh_prov_pb_adv_on_oob_psa \
 	prov_device_no_oob \
 	prov_provisioner_no_oob \
-	-- -argstest prov-brearer=1
+	-- -argstest prov-bearer=1

--- a/tests/bsim/bluetooth/mesh/tests_scripts/provision/prov_oob_auth_ib_pk.sh
+++ b/tests/bsim/bluetooth/mesh/tests_scripts/provision/prov_oob_auth_ib_pk.sh
@@ -7,14 +7,14 @@ source $(dirname "${BASH_SOURCE[0]}")/../../_mesh_test.sh
 # Test provisioning with OOB authentication and with inband public key
 RunTest mesh_prov_pb_adv_oob_auth \
 	prov_device_oob_auth prov_provisioner_oob_auth \
-	-- -argstest prov-brearer=1
+	-- -argstest prov-bearer=1
 
 overlay=overlay_gatt_conf_overlay_psa_conf
 RunTest mesh_prov_pb_gatt_oob_auth \
 	prov_device_oob_auth prov_provisioner_oob_auth \
-	-- -argstest prov-brearer=2
+	-- -argstest prov-bearer=2
 
 overlay=overlay_psa_conf
 RunTest mesh_prov_pb_adv_oob_auth_psa \
 	prov_device_oob_auth prov_provisioner_oob_auth \
-	-- -argstest prov-brearer=1
+	-- -argstest prov-bearer=1

--- a/tests/bsim/bluetooth/mesh/tests_scripts/provision/prov_oob_auth_ignore_oob_pk.sh
+++ b/tests/bsim/bluetooth/mesh/tests_scripts/provision/prov_oob_auth_ignore_oob_pk.sh
@@ -8,14 +8,14 @@ source $(dirname "${BASH_SOURCE[0]}")/../../_mesh_test.sh
 # but provisioner doesn't have OOB public key
 RunTest mesh_prov_pb_adv_device_w_oob_pk_prvnr_wt_pk \
 	prov_device_oob_public_key prov_provisioner_oob_auth_no_oob_public_key \
-	-- -argstest prov-brearer=1
+	-- -argstest prov-bearer=1
 
 overlay=overlay_gatt_conf_overlay_psa_conf
 RunTest mesh_prov_pb_gatt_device_w_oob_pk_prvnr_wt_pk \
 	prov_device_oob_public_key prov_provisioner_oob_auth_no_oob_public_key \
-	-- -argstest prov-brearer=2
+	-- -argstest prov-bearer=2
 
 overlay=overlay_psa_conf
 RunTest mesh_prov_pb_adv_device_w_oob_pk_prvnr_wt_pk_psa \
 	prov_device_oob_public_key prov_provisioner_oob_auth_no_oob_public_key \
-	-- -argstest prov-brearer=1
+	-- -argstest prov-bearer=1

--- a/tests/bsim/bluetooth/mesh/tests_scripts/provision/prov_oob_auth_oob_pk.sh
+++ b/tests/bsim/bluetooth/mesh/tests_scripts/provision/prov_oob_auth_oob_pk.sh
@@ -7,14 +7,14 @@ source $(dirname "${BASH_SOURCE[0]}")/../../_mesh_test.sh
 # Test provisioning with OOB authentication and with OOB public key
 RunTest mesh_prov_pb_adv_oob_public_key \
 	prov_device_oob_public_key prov_provisioner_oob_public_key \
-	-- -argstest prov-brearer=1
+	-- -argstest prov-bearer=1
 
 overlay=overlay_gatt_conf_overlay_psa_conf
 RunTest mesh_prov_pb_gatt_oob_public_key \
 	prov_device_oob_public_key prov_provisioner_oob_public_key \
-	-- -argstest prov-brearer=2
+	-- -argstest prov-bearer=2
 
 overlay=overlay_psa_conf
 RunTest mesh_prov_pb_adv_oob_public_key_psa \
 	prov_device_oob_public_key prov_provisioner_oob_public_key \
-	-- -argstest prov-brearer=1
+	-- -argstest prov-bearer=1

--- a/tests/bsim/bluetooth/mesh/tests_scripts/provision/prov_reprovision.sh
+++ b/tests/bsim/bluetooth/mesh/tests_scripts/provision/prov_reprovision.sh
@@ -7,16 +7,16 @@ source $(dirname "${BASH_SOURCE[0]}")/../../_mesh_test.sh
 RunTest mesh_prov_pb_adv_repr \
 	prov_device_reprovision \
 	prov_provisioner_reprovision \
-	-- -argstest prov-brearer=1
+	-- -argstest prov-bearer=1
 
 overlay=overlay_gatt_conf_overlay_psa_conf
 RunTest mesh_prov_pb_gatt_repr \
 	prov_device_reprovision \
 	prov_provisioner_reprovision \
-	-- -argstest prov-brearer=2
+	-- -argstest prov-bearer=2
 
 overlay=overlay_psa_conf
 RunTest mesh_prov_pb_adv_repr_psa \
 	prov_device_reprovision \
 	prov_provisioner_reprovision \
-	-- -argstest prov-brearer=1
+	-- -argstest prov-bearer=1


### PR DESCRIPTION
Previously, PB-GATT unprovisioned advs would continue being sent if a device is provisioned or in the process of being provisioned (an active provisioning link) over PB-ADV.

PB-GATT advs are now stopped when a PB-ADV provisioning link is established. If the link closes without the device being provisioned, the PB-GATT advs will be re-enabled.