### PR TITLE
dts: counter: Remove old kinetis lptmr binding

### DIFF
--- a/drivers/counter/Kconfig.mcux_lptmr
+++ b/drivers/counter/Kconfig.mcux_lptmr
@@ -6,17 +6,6 @@
 config COUNTER_MCUX_LPTMR
 	bool "MCUX LPTMR driver"
 	default y
-	depends on DT_HAS_NXP_LPTMR_ENABLED || \
-		   COUNTER_MCUX_KINETIS_LPTMR
+	depends on DT_HAS_NXP_LPTMR_ENABLED
 	help
 	  Enable support for the MCUX Low Power Timer (LPTMR).
-
-config COUNTER_MCUX_KINETIS_LPTMR
-	bool
-	default y
-	depends on DT_HAS_NXP_KINETIS_LPTMR_ENABLED
-	select DEPRECATED
-	help
-	  The compatible string "nxp,kinetis-lptmr" should
-	  be switched to "nxp,lptmr" in DT. The former will
-	  be removed eventually.

--- a/drivers/counter/counter_mcux_lptmr.c
+++ b/drivers/counter/counter_mcux_lptmr.c
@@ -4,14 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define DT_DRV_COMPAT nxp_lptmr
+
 #include <zephyr/devicetree.h>
 #include <zephyr/sys/util.h>
-#if DT_HAS_COMPAT_STATUS_OKAY(nxp_kinetis_lptmr)
-#define DT_DRV_COMPAT nxp_kinetis_lptmr
-#else
-#define DT_DRV_COMPAT nxp_lptmr
-#endif
-
 #include <zephyr/drivers/counter.h>
 #include <zephyr/irq.h>
 #include <fsl_lptmr.h>

--- a/drivers/timer/Kconfig.mcux_lptmr
+++ b/drivers/timer/Kconfig.mcux_lptmr
@@ -6,21 +6,10 @@
 config MCUX_LPTMR_TIMER
 	bool "MCUX LPTMR timer"
 	default n
-	depends on DT_HAS_NXP_KINETIS_LPTMR_ENABLED || \
-		   MCUX_KINETIS_LPTMR
+	depends on DT_HAS_NXP_LPTMR_ENABLED
 	depends on !COUNTER_MCUX_LPTMR
 	select SYSTEM_TIMER_HAS_DISABLE_SUPPORT
 	help
 	  This module implements a kernel device driver for the NXP MCUX Low
 	  Power Timer (LPTMR) and provides the standard "system clock driver"
 	  interfaces.
-
-config MCUX_KINETIS_LPTMR
-	bool
-	default y
-	depends on DT_HAS_NXP_KINETIS_LPTMR_ENABLED
-	select DEPRECATED
-	help
-	  The compatible string "nxp,kinetis-lptmr" should
-	  be switched to "nxp,lptmr" in DT. The former will
-	  be removed eventually.

--- a/drivers/timer/Kconfig.mcux_lptmr
+++ b/drivers/timer/Kconfig.mcux_lptmr
@@ -5,7 +5,7 @@
 
 config MCUX_LPTMR_TIMER
 	bool "MCUX LPTMR timer"
-	default y
+	default n
 	depends on DT_HAS_NXP_KINETIS_LPTMR_ENABLED || \
 		   MCUX_KINETIS_LPTMR
 	depends on !COUNTER_MCUX_LPTMR

--- a/drivers/timer/mcux_lptmr_timer.c
+++ b/drivers/timer/mcux_lptmr_timer.c
@@ -4,15 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/devicetree.h>
-#if DT_HAS_COMPAT_STATUS_OKAY(nxp_kinetis_lptmr)
-#define DT_DRV_COMPAT nxp_kinetis_lptmr
-#else
 #define DT_DRV_COMPAT nxp_lptmr
-#endif
 
 #include <zephyr/init.h>
 #include <zephyr/drivers/timer/system_timer.h>
+#include <zephyr/devicetree.h>
 #include <zephyr/kernel.h>
 #include <zephyr/sys/time_units.h>
 #include <fsl_lptmr.h>

--- a/dts/bindings/counter/nxp,kinetis-lptmr.yaml
+++ b/dts/bindings/counter/nxp,kinetis-lptmr.yaml
@@ -1,8 +1,0 @@
-# Copyright 2024 NXP
-# SPDX-License-Identifier: Apache-2.0
-
-description: Deprecated compatible for NXP LPTMR
-
-compatible: "nxp,kinetis-lptmr"
-
-include: nxp,lptmr.yaml

--- a/soc/nxp/imxrt/imxrt118x/Kconfig.defconfig
+++ b/soc/nxp/imxrt/imxrt118x/Kconfig.defconfig
@@ -3,6 +3,9 @@
 
 if SOC_SERIES_IMXRT118X
 
+config CORTEX_M_SYSTICK
+	default n if MCUX_LPTMR_TIMER
+
 config NUM_IRQS
 	default 239
 

--- a/soc/nxp/mcx/mcxa/Kconfig.defconfig
+++ b/soc/nxp/mcx/mcxa/Kconfig.defconfig
@@ -3,6 +3,9 @@
 
 if SOC_SERIES_MCXA
 
+config CORTEX_M_SYSTICK
+	default n if MCUX_LPTMR_TIMER
+
 config NUM_IRQS
 	default 88
 

--- a/soc/nxp/mcx/mcxc/Kconfig.defconfig
+++ b/soc/nxp/mcx/mcxc/Kconfig.defconfig
@@ -3,6 +3,9 @@
 
 if SOC_SERIES_MCXC
 
+config CORTEX_M_SYSTICK
+	default n if MCUX_LPTMR_TIMER
+
 config NUM_IRQS
 	default 32
 

--- a/soc/nxp/mcx/mcxn/Kconfig.defconfig
+++ b/soc/nxp/mcx/mcxn/Kconfig.defconfig
@@ -3,6 +3,9 @@
 
 if SOC_SERIES_MCXN
 
+config CORTEX_M_SYSTICK
+	default n if MCUX_LPTMR_TIMER
+
 config MFD
 	default y if DT_HAS_NXP_LP_FLEXCOMM_ENABLED
 

--- a/soc/nxp/mcx/mcxw/Kconfig.defconfig
+++ b/soc/nxp/mcx/mcxw/Kconfig.defconfig
@@ -3,6 +3,9 @@
 
 if SOC_SERIES_MCXW
 
+config CORTEX_M_SYSTICK
+	default n if MCUX_LPTMR_TIMER
+
 config NUM_IRQS
 	default 77 if SOC_MCXW727C
 	default 75


### PR DESCRIPTION
Remove deprecated nxp,kinetis-lptmr compatible string which is superseded by nxp,lptmr compatible due to removing family specific name.

part of #77070