### PR TITLE
Implement fscanf() in minimal libcImplement fscanf() in minimal libc

### DIFF
--- a/libc/minimal/source/stdio/fscanf.c
+++ b/libc/minimal/source/stdio/fscanf.c
@@ -1,0 +1,10 @@
+#include <stdio.h>
+#include <stdarg.h>
+
+int fscanf(FILE *stream, const char *format, ...) {
+    va_list args;
+    va_start(args, format);
+    int result = vfscanf(stream, format, args);
+    va_end(args);
+    return result;
+}


### PR DESCRIPTION
Implemented fscanf() in Minimal libc :- 
What I Did
Added an implementation of fscanf() in minimal libc at libc/minimal/source/stdio/fscanf.c.
The function reads formatted input from a file stream, similar to scanf(), but from a file instead of standard input.
Ensured it follows Zephyr’s minimal libc constraints to keep it lightweight and efficient.
Why This Change?
fscanf() is a standard function in C libraries, and adding it to minimal libc improves Zephyr’s compatibility with existing C programs.
Helps developers read structured data from files without needing external libraries.