### PR TITLE
cmake: remove BUILD type in function description.

### DIFF
--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -1587,8 +1587,8 @@ function(pow2round n)
   set(${n} ${${n}} PARENT_SCOPE)
 endfunction()
 
-# Function to create a build string based on BOARD, BOARD_REVISION, and BUILD
-# type.
+# Function to create a build string based on BOARD, BOARD_REVISION, and
+# BOARD_QUALIFIER.
 #
 # This is a common function to ensure that build strings are always created
 # in a uniform way.


### PR DESCRIPTION
Build type was removed in 763a49f082171499442eed6b617f78f33c4e42a5 but the function description was not updated accordingly.

Remove build type from the function description.

Add board qualifier as that is missing.