### PR TITLE
NXP LPSPI: Refactoring to remove dependency of HAL in XFER drivers

### DIFF
--- a/drivers/spi/spi_nxp_lpspi/Kconfig
+++ b/drivers/spi/spi_nxp_lpspi/Kconfig
@@ -1,4 +1,4 @@
-# Copyright 2018, 2024 NXP
+# Copyright 2018, 2024-2025 NXP
 # SPDX-License-Identifier: Apache-2.0
 
 config SPI_MCUX_LPSPI
@@ -8,24 +8,32 @@ config SPI_MCUX_LPSPI
 	depends on CLOCK_CONTROL
 	select PINCTRL
 	help
-	  Enable support for NXP LPSPI.
+	  Enable driver support for NXP LPSPI.
 
 if SPI_MCUX_LPSPI
 
 config SPI_MCUX_LPSPI_DMA
-	bool "MCUX LPSPI SPI DMA Support"
+	bool "NXP LPSPI DMA-based Driver"
 	default y
 	select DMA
 	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_NXP_LPSPI),dmas)
 	help
-	  Enable the SPI DMA mode for SPI instances
-	  that enable dma channels in their device tree node.
+	  Enable DMA-based transfers for LPSPI peripherals
+	  that have a dmas property specified in their DT node.
+	  The DMA based driver prioritizes bandwidth over latency, due to
+	  DMA being more efficient for larger data transfers, to avoid CPU
+	  having to be utilized to do the work. However, setting up a DMA
+	  transfer is more complicated setup than just starting the transfer
+	  immediately with CPU, so there could be more latency between
+	  the point of requesting a transfer and when it actually starts.
 
 config SPI_MCUX_LPSPI_CPU
-	bool "NXP MCUX LPSPI driver"
+	bool "NXP LPSPI CPU-based driver"
 	default y
 	depends on $(dt_compat_any_not_has_prop,$(DT_COMPAT_NXP_LPSPI),dmas) || !SPI_MCUX_LPSPI_DMA
 	help
-	  Use the CPU-based LPSPI driver.
+	  Enable "normal" CPU based SPI driver for LPSPI.
+	  This has lower latency than DMA-based driver but over the
+	  longer transfers will likely have less bandwidth and use more CPU time.
 
 endif # SPI_MCUX_LPSPI

--- a/drivers/spi/spi_nxp_lpspi/spi_nxp_lpspi_common.c
+++ b/drivers/spi/spi_nxp_lpspi/spi_nxp_lpspi_common.c
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(spi_mcux_lpspi_common, CONFIG_SPI_LOG_LEVEL);
+LOG_MODULE_REGISTER(spi_lpspi_common, CONFIG_SPI_LOG_LEVEL);
 
 #include "spi_nxp_lpspi_priv.h"
 #include <fsl_lpspi.h>
@@ -61,9 +61,9 @@ void lpspi_wait_tx_fifo_empty(const struct device *dev)
 	}
 }
 
-int spi_mcux_release(const struct device *dev, const struct spi_config *spi_cfg)
+int spi_lpspi_release(const struct device *dev, const struct spi_config *spi_cfg)
 {
-	struct spi_mcux_data *data = dev->data;
+	struct lpspi_data *data = dev->data;
 
 	spi_context_unlock_unconditionally(&data->ctx);
 
@@ -103,8 +103,8 @@ static inline int lpspi_validate_xfer_args(const struct spi_config *spi_cfg)
 
 int spi_mcux_configure(const struct device *dev, const struct spi_config *spi_cfg)
 {
-	const struct spi_mcux_config *config = dev->config;
-	struct spi_mcux_data *data = dev->data;
+	const struct lpspi_config *config = dev->config;
+	struct lpspi_data *data = dev->data;
 	struct spi_context *ctx = &data->ctx;
 	bool already_configured = spi_context_configured(ctx, spi_cfg);
 	LPSPI_Type *base = (LPSPI_Type *)DEVICE_MMIO_NAMED_GET(dev, reg_base);
@@ -198,8 +198,8 @@ static void lpspi_module_system_init(LPSPI_Type *base)
 int spi_nxp_init_common(const struct device *dev)
 {
 	LPSPI_Type *base = (LPSPI_Type *)DEVICE_MMIO_NAMED_GET(dev, reg_base);
-	const struct spi_mcux_config *config = dev->config;
-	struct spi_mcux_data *data = dev->data;
+	const struct lpspi_config *config = dev->config;
+	struct lpspi_data *data = dev->data;
 	int err = 0;
 
 	DEVICE_MMIO_NAMED_MAP(dev, reg_base, K_MEM_CACHE_NONE | K_MEM_DIRECT_MAP);

--- a/drivers/spi/spi_nxp_lpspi/spi_nxp_lpspi_common.c
+++ b/drivers/spi/spi_nxp_lpspi/spi_nxp_lpspi_common.c
@@ -8,6 +8,7 @@
 LOG_MODULE_REGISTER(spi_mcux_lpspi_common, CONFIG_SPI_LOG_LEVEL);
 
 #include "spi_nxp_lpspi_priv.h"
+#include <fsl_lpspi.h>
 
 #if defined(LPSPI_RSTS) || defined(LPSPI_CLOCKS)
 static LPSPI_Type *const lpspi_bases[] = LPSPI_BASE_PTRS;
@@ -170,8 +171,8 @@ int spi_mcux_configure(const struct device *dev, const struct spi_config *spi_cf
 	master_config.pcsActiveHighOrLow = (spi_cfg->operation & SPI_CS_ACTIVE_HIGH)
 				    ? kLPSPI_PcsActiveHigh : kLPSPI_PcsActiveLow;
 	master_config.pinCfg = config->data_pin_config;
-	master_config.dataOutConfig = config->output_config ? kLpspiDataOutTristate :
-							      kLpspiDataOutRetained;
+	master_config.dataOutConfig = config->tristate_output ? kLpspiDataOutTristate :
+								kLpspiDataOutRetained;
 
 	LPSPI_MasterInit(base, &master_config, clock_freq);
 	LPSPI_SetDummyData(base, 0);

--- a/drivers/spi/spi_nxp_lpspi/spi_nxp_lpspi_priv.h
+++ b/drivers/spi/spi_nxp_lpspi/spi_nxp_lpspi_priv.h
@@ -24,6 +24,8 @@
 #define LPSPI_CHIP_SELECT_COUNT   4
 #define LPSPI_MIN_FRAME_SIZE_BITS 8
 
+#define LPSPI_INTERRUPT_BITS GENMASK(8, 13)
+
 /* Required by DEVICE_MMIO_NAMED_* macros */
 #define DEV_CFG(_dev)  ((const struct spi_mcux_config *)(_dev)->config)
 #define DEV_DATA(_dev) ((struct spi_mcux_data *)(_dev)->data)


### PR DESCRIPTION
This PR contains some of the changes from #85010 that are split into separate commits to make them more reviewable.

These changes are particularly important so that people can contribute to the main transfer driver files  without having conflicts with #85010.