### PR TITLE
samples: Bluetooth: bap_broadcast_source nRF5340 audio dk + nRF21540 FEM

### DIFF
--- a/samples/bluetooth/bap_broadcast_source/boards/nrf5340_audio_dk_nrf5340_cpuapp_nrf21540_ek.overlay
+++ b/samples/bluetooth/bap_broadcast_source/boards/nrf5340_audio_dk_nrf5340_cpuapp_nrf21540_ek.overlay
@@ -1,0 +1,25 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include "../app.overlay"
+
+/ {
+	gpio_fwd: nrf-gpio-forwarder {
+		compatible = "nordic,nrf-gpio-forwarder";
+		status = "okay";
+
+		nrf21540-gpio-if {
+			gpios = <&arduino_header 11 0>, /* tx-en-gpios */
+				<&arduino_header 9  0>, /* rx-en-gpios */
+				<&arduino_header 15 0>,	/* pdn-gpios */
+				<&arduino_header 10 0>, /* ant-sel-gpios */
+				<&arduino_header 8  0>; /* mode-gpios */
+		};
+
+		nrf21540-spi-if {
+			gpios = <&arduino_header 16 0>, /* cs-gpios */
+				<&gpio0          8  0>, /* SPIM_SCK */
+				<&gpio0          10 0>, /* SPIM_MISO */
+				<&gpio0          9  0>; /* SPIM_MOSI */
+		};
+	};
+};

--- a/samples/bluetooth/bap_broadcast_source/sample.yaml
+++ b/samples/bluetooth/bap_broadcast_source/sample.yaml
@@ -14,6 +14,17 @@ tests:
       - nrf5340dk/nrf5340/cpuapp
     tags: bluetooth
     sysbuild: true
+  sample.bluetooth.bap_broadcast_source.nrf5340_audio_dk_cpuapp.fem:
+    harness: bluetooth
+    platform_allow:
+      - nrf5340_audio_dk/nrf5340/cpuapp
+    integration_platforms:
+      - nrf5340_audio_dk/nrf5340/cpuapp
+    extra_args:
+      - DTC_OVERLAY_FILE=boards/nrf5340_audio_dk_nrf5340_cpuapp_nrf21540_ek.overlay
+      - hci_ipc_DTC_OVERLAY_FILE=boards/nrf5340_audio_dk_nrf5340_cpunet_nrf21540_ek.overlay
+    tags: bluetooth
+    sysbuild: true
   sample.bluetooth.bap_broadcast_source.bt_ll_sw_split:
     harness: bluetooth
     platform_allow:


### PR DESCRIPTION
Added overlay file to support nRF5340 audio dk + nRF21540 FEM.

Build the hci_ipc with corresponding overlay file to use the nRF21540 FEM with the bap_broadcast_source sample on nRF5340 audio kit.

Related to commit 35ad6530382d ("samples: Bluetooth:
hci_uart/hci_ipc: CI coverage for nRF53+nRF21 FEM").

Building using `west` with `--sysbuild`
```
west build -b nrf5340_audio_dk/nrf5340/cpuapp --sysbuild  samples/bluetooth/bap_broadcast_source  -DDTC_OVERLAY_FILE=boards/nrf5340_audio_dk_nrf5340_cpuapp_nrf21540_ek.overlay -Dhci_ipc_DTC_OVERLAY_FILE=boards/nrf5340_audio_dk_nrf5340_cpunet_nrf21540_ek.overlay
```