### PR TITLE
tests: zbus/hlp_priority_boost: use 1cpu setup

### DIFF
--- a/tests/subsys/zbus/hlp_priority_boost/src/main.c
+++ b/tests/subsys/zbus/hlp_priority_boost/src/main.c
@@ -177,4 +177,5 @@ ZTEST(hlp_priority_boost, test_priority_elevation)
 	zassert_true(prio == 8, "The priority must be 8, but it is %d", prio);
 }
 
-ZTEST_SUITE(hlp_priority_boost, NULL, NULL, NULL, NULL, NULL);
+ZTEST_SUITE(hlp_priority_boost, NULL, NULL,
+	    ztest_simple_1cpu_before, ztest_simple_1cpu_after, NULL);


### PR DESCRIPTION
The zbus hlp_priority_boost test requires thread priority boosting. If it is running SMP, it is possible that the message has already been processed before the check for priority boosting is done, thus failing the test. So change the test to use 1 CPU only.

Fixes #79197