### PR TITLE
tests: lib: multi_heap: fix stack overflow

### DIFF
--- a/tests/lib/multi_heap/src/test_mheap_api.c
+++ b/tests/lib/multi_heap/src/test_mheap_api.c
@@ -11,7 +11,8 @@
 #include "test_mheap.h"
 
 #define MALLOC_IN_THREAD_STACK_SIZE (512 + CONFIG_TEST_EXTRA_STACK_SIZE)
-#define INCREMENTAL_FILL_STACK_SIZE (512 + (BLK_NUM_MAX * sizeof(void *) * 2))
+#define INCREMENTAL_FILL_STACK_SIZE (512 + CONFIG_TEST_EXTRA_STACK_SIZE + \
+				     (BLK_NUM_MAX * sizeof(void *) * 2))
 #define OVERFLOW_SIZE    SIZE_MAX
 
 #define NMEMB   8


### PR DESCRIPTION
Some platforms, notably ARM64, need more than 512 bytes of breathing
room on the stack. Very weird and difficult-to-track memory corruptions
were caused by test_mheap_realloc without this.

