### PR TITLE
soc: neorv32: add option for reading clock frequency from sysinfo at boot

### DIFF
--- a/boards/others/neorv32/doc/index.rst
+++ b/boards/others/neorv32/doc/index.rst
@@ -27,9 +27,10 @@ using :ref:`devicetree overlays <use-dt-overlays>`.
 System Clock
 ============
 
-The default board configuration assumes a system clock of 18 MHz. The clock
-frequency can be overridden by changing the ``clock-frequency`` property of the
-``cpu0`` devicetree node.
+The default board configuration reads the system clock frequency from the NEORV32 SYSINFO module,
+which results in a small run-time overhead. If the clock frequency is known at build time, this
+behavior can be overridden by setting the ``clock-frequency`` property of the ``cpu0`` devicetree
+node.
 
 CPU
 ===

--- a/boards/others/neorv32/neorv32.dts
+++ b/boards/others/neorv32/neorv32.dts
@@ -7,7 +7,6 @@
 /dts-v1/;
 
 #include <neorv32.dtsi>
-#include <freq.h>
 #include <mem.h>
 
 / {
@@ -56,7 +55,6 @@
 
 &cpu0 {
 	riscv,isa = "rv32im_zicsr_zifencei";
-	clock-frequency = <DT_FREQ_M(18)>;
 };
 
 &bootrom {

--- a/soc/neorv32/Kconfig
+++ b/soc/neorv32/Kconfig
@@ -19,4 +19,15 @@ config SOC_NEORV32_VERSION
 	  identical to that of the NEORV32 Machine implementation ID (mimpid)
 	  register.
 
+config SOC_NEORV32_READ_FREQUENCY_AT_RUNTIME
+	bool "Read the NEORV32 clock frequency at runtime"
+	default y
+	depends on !$(dt_node_has_prop,/cpus/cpu@0,clock-frequency)
+	select SOC_EARLY_INIT_HOOK
+	select TIMER_READS_ITS_FREQUENCY_AT_RUNTIME
+	help
+	  If enabled, the NEORV32 clock frequency will be read from SYSINFO during boot. This
+	  results in small overhead, which can be avoided by setting the clock-frequency property of
+	  the cpu@0 devicetree node if the frequency is known at build-time.
+
 endif # SOC_NEORV32

--- a/soc/neorv32/Kconfig.defconfig
+++ b/soc/neorv32/Kconfig.defconfig
@@ -4,7 +4,7 @@
 if SOC_NEORV32
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
-	default $(dt_node_int_prop_int,/cpus/cpu@0,clock-frequency) if RISCV_MACHINE_TIMER
+	default $(dt_node_int_prop_int,/cpus/cpu@0,clock-frequency) if !SOC_NEORV32_READ_FREQUENCY_AT_RUNTIME
 
 config NUM_IRQS
 	default 32

--- a/soc/neorv32/soc.c
+++ b/soc/neorv32/soc.c
@@ -7,11 +7,22 @@
 #include <zephyr/irq.h>
 #include <soc.h>
 
-#if defined(CONFIG_RISCV_SOC_INTERRUPT_INIT)
+#ifdef CONFIG_SOC_NEORV32_READ_FREQUENCY_AT_RUNTIME
+extern int z_clock_hw_cycles_per_sec;
+
+void soc_early_init_hook(void)
+{
+	uint32_t base = DT_REG_ADDR(DT_NODELABEL(sysinfo));
+
+	z_clock_hw_cycles_per_sec = sys_read32(base + NEORV32_SYSINFO_CLK);
+}
+#endif /* CONFIG_SOC_NEORV32_READ_FREQUENCY_AT_RUNTIME */
+
+#ifdef CONFIG_RISCV_SOC_INTERRUPT_INIT
 void soc_interrupt_init(void)
 {
 	(void)arch_irq_lock();
 
 	csr_write(mie, 0);
 }
-#endif
+#endif /* CONFIG_RISCV_SOC_INTERRUPT_INIT */


### PR DESCRIPTION
- Add Kconfig option for reading the NEORV32 clock frequency from SYSINFO at boot time.
- Default to reading the clock frequency from SYSINFO at boot time to make the NEORV32 board compatible with a wider range of NEORV32 implementations.
