### PR TITLE
tests: kernel/pipe_api: move local k_pipe var to global

### DIFF
--- a/tests/kernel/pipe/pipe_api/src/basic.c
+++ b/tests/kernel/pipe/pipe_api/src/basic.c
@@ -17,9 +17,10 @@ static void mkrandom(uint8_t *buffer, size_t size)
 
 K_PIPE_DEFINE(test_define, 256, 4);
 
+static struct k_pipe pipe;
+
 ZTEST(k_pipe_basic, test_init)
 {
-	struct k_pipe pipe;
 	uint8_t buffer[10];
 
 	k_pipe_init(&pipe, buffer, sizeof(buffer));
@@ -28,7 +29,6 @@ ZTEST(k_pipe_basic, test_init)
 
 ZTEST(k_pipe_basic, test_write_read_one)
 {
-	struct k_pipe pipe;
 	uint8_t buffer[10];
 	uint8_t data = 0x55;
 	uint8_t read_data;
@@ -43,7 +43,6 @@ ZTEST(k_pipe_basic, test_write_read_one)
 
 ZTEST(k_pipe_basic, test_write_read_multiple)
 {
-	struct k_pipe pipe;
 	uint8_t buffer[10];
 	uint8_t data = 0x55;
 	uint8_t read_data;
@@ -59,7 +58,6 @@ ZTEST(k_pipe_basic, test_write_read_multiple)
 
 ZTEST(k_pipe_basic, test_write_full)
 {
-	struct k_pipe pipe;
 	uint8_t buffer[10];
 	uint8_t data[10];
 
@@ -72,7 +70,6 @@ ZTEST(k_pipe_basic, test_write_full)
 
 ZTEST(k_pipe_basic, test_read_empty)
 {
-	struct k_pipe pipe;
 	uint8_t buffer[10];
 	uint8_t read_data;
 
@@ -83,7 +80,6 @@ ZTEST(k_pipe_basic, test_read_empty)
 
 ZTEST(k_pipe_basic, test_read_write_full)
 {
-	struct k_pipe pipe;
 	uint8_t buffer[10];
 	uint8_t input[10];
 	uint8_t res[10];
@@ -100,7 +96,6 @@ ZTEST(k_pipe_basic, test_read_write_full)
 
 ZTEST(k_pipe_basic, test_read_write_wrapp_around)
 {
-	struct k_pipe pipe;
 	uint8_t buffer[12];
 	uint8_t input[8];
 	uint8_t res[16];
@@ -126,7 +121,6 @@ ZTEST(k_pipe_basic, test_read_write_wrapp_around)
 
 ZTEST(k_pipe_basic, test_reset)
 {
-	struct k_pipe pipe;
 	uint8_t buffer[10];
 	uint8_t data = 0x55;
 	uint8_t read_data;
@@ -144,7 +138,6 @@ ZTEST(k_pipe_basic, test_reset)
 
 ZTEST(k_pipe_basic, test_close)
 {
-	struct k_pipe pipe;
 	uint8_t buffer[12];
 	uint8_t input[8];
 	uint8_t res[16];

--- a/tests/kernel/pipe/pipe_api/src/concurrency.c
+++ b/tests/kernel/pipe/pipe_api/src/concurrency.c
@@ -16,6 +16,7 @@ static const int partial_wait_time = 2000;
 #define DUMMY_DATA_SIZE 16
 static struct k_thread thread;
 static K_THREAD_STACK_DEFINE(stack, 1024);
+static struct k_pipe pipe;
 
 static void thread_close(void *arg1, void *arg2, void *arg3)
 {
@@ -46,7 +47,6 @@ static void thread_read(void *arg1, void *arg2, void *arg3)
 ZTEST(k_pipe_concurrency, test_close_on_read)
 {
 	k_tid_t tid;
-	struct k_pipe pipe;
 	uint8_t buffer[DUMMY_DATA_SIZE];
 	uint8_t res;
 
@@ -64,7 +64,6 @@ ZTEST(k_pipe_concurrency, test_close_on_read)
 ZTEST(k_pipe_concurrency, test_close_on_write)
 {
 	k_tid_t tid;
-	struct k_pipe pipe;
 	uint8_t buffer[DUMMY_DATA_SIZE];
 	uint8_t garbage[DUMMY_DATA_SIZE];
 
@@ -85,7 +84,6 @@ ZTEST(k_pipe_concurrency, test_close_on_write)
 ZTEST(k_pipe_concurrency, test_reset_on_read)
 {
 	k_tid_t tid;
-	struct k_pipe pipe;
 	uint8_t buffer[DUMMY_DATA_SIZE];
 	uint8_t res;
 
@@ -106,7 +104,6 @@ ZTEST(k_pipe_concurrency, test_reset_on_read)
 ZTEST(k_pipe_concurrency, test_reset_on_write)
 {
 	k_tid_t tid;
-	struct k_pipe pipe;
 	uint8_t buffer[DUMMY_DATA_SIZE];
 	uint8_t garbage[DUMMY_DATA_SIZE];
 
@@ -129,7 +126,6 @@ ZTEST(k_pipe_concurrency, test_reset_on_write)
 ZTEST(k_pipe_concurrency, test_partial_read)
 {
 	k_tid_t tid;
-	struct k_pipe pipe;
 	uint8_t buffer[DUMMY_DATA_SIZE];
 	uint8_t garbage[DUMMY_DATA_SIZE];
 	size_t write_size = sizeof(garbage)/2;
@@ -149,7 +145,6 @@ ZTEST(k_pipe_concurrency, test_partial_read)
 ZTEST(k_pipe_concurrency, test_partial_write)
 {
 	k_tid_t tid;
-	struct k_pipe pipe;
 	uint8_t buffer[DUMMY_DATA_SIZE];
 	uint8_t garbage[DUMMY_DATA_SIZE];
 	size_t read_size = sizeof(garbage)/2;

--- a/tests/kernel/pipe/pipe_api/src/stress.c
+++ b/tests/kernel/pipe/pipe_api/src/stress.c
@@ -18,10 +18,11 @@ LOG_MODULE_REGISTER(k_k_pipe_stress, LOG_LEVEL_INF);
 
 ZTEST_SUITE(k_pipe_stress, NULL, NULL, NULL, NULL, NULL);
 
+static struct k_pipe pipe;
+
 ZTEST(k_pipe_stress, test_write)
 {
 	int rc;
-	struct k_pipe pipe;
 	const size_t len = WRITE_LEN;
 	uint8_t buffer[WRITE_LEN];
 	uint8_t buf[WRITE_LEN];
@@ -43,7 +44,6 @@ ZTEST(k_pipe_stress, test_write)
 ZTEST(k_pipe_stress, test_read)
 {
 	int rc;
-	struct k_pipe pipe;
 	const size_t len = READ_LEN;
 	uint8_t buffer[READ_LEN];
 	uint8_t buf[READ_LEN];


### PR DESCRIPTION
When CONFIG_KERNEL_COHERENCE is enabled, pend_locked() asserts when wait_q is not in coherent memory. The k_pipes used in the pipe_api tests are declared locally within the test. They are located within the thread stacks and those wait_q inside k_pipe struct are thus not considered in coherent memory. To make them work, replace the local ones with a global k_pipe object. Since each test initializes the pipe object locally, the tests are not functionally changed.

Fixes #84235