### PR TITLE
rtio: Transactions assume valid next list nodes

### DIFF
--- a/subsys/rtio/rtio_executor.c
+++ b/subsys/rtio/rtio_executor.c
@@ -84,6 +84,10 @@ void rtio_executor_submit(struct rtio *r)
 				    "Expected chained or transaction flag, not both");
 #endif
 			node = mpsc_pop(&iodev_sqe->r->sq);
+
+			__ASSERT(node != NULL,
+				    "Expected a valid submission in the queue while in a transaction or chain");
+
 			next = CONTAINER_OF(node, struct rtio_iodev_sqe, q);
 
 			/* If the current submission was cancelled before submit,


### PR DESCRIPTION
Add an assert ensuring programming errors where the executor code assumes there is a next node in the list for transaction/chained submissions.

Fixes #84771 