### PR TITLE
device: Update SYS_INIT_NAMED(), Z_DEVICE_INIT_ENTRY_DEFINE()  to be C++ compatible

### DIFF
--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -1241,7 +1241,8 @@ device_get_dt_nodelabels(const struct device *dev)
 	static const Z_DECL_ALIGN(struct init_entry) __used __noasan Z_INIT_ENTRY_SECTION(         \
 		level, prio, Z_DEVICE_INIT_SUB_PRIO(node_id))                                      \
 		Z_INIT_ENTRY_NAME(DEVICE_NAME_GET(dev_id)) = {                                     \
-			.dev = (const struct device *)&DEVICE_NAME_GET(dev_id)                     \
+			.init_fn = NULL,                                                           \
+			.dev = (const struct device *)&DEVICE_NAME_GET(dev_id),                    \
 		}
 
 /**

--- a/include/zephyr/init.h
+++ b/include/zephyr/init.h
@@ -166,7 +166,7 @@ struct init_entry {
 #define SYS_INIT_NAMED(name, init_fn_, level, prio)                                       \
 	static const Z_DECL_ALIGN(struct init_entry)                                      \
 		Z_INIT_ENTRY_SECTION(level, prio, 0) __used __noasan                      \
-		Z_INIT_ENTRY_NAME(name) = {.init_fn = (init_fn_)}                         \
+		Z_INIT_ENTRY_NAME(name) = {.init_fn = (init_fn_), .dev = NULL}            \
 
 /** @} */
 


### PR DESCRIPTION
In #84394, `struct init_entry` was modified to remove an unneeded union. The `SYS_INIT_NAMED()` macro was adjusted accordingly, but is no longer C++ compatible due to the partial designated initializer.

Add an explicit value (NULL) for the other field (`dev`) in that struct.

Additional change (second commit): the `Z_DEVICE_INIT_ENTRY_DEFINE()` macro uses a designated initializer to define a struct. Ensure all members of `struct init_entry` are defined in order for C++ compatibility.
