### PR TITLE
Fixing HL7800 Timeout Issue in modem_cellular Example

### DIFF
--- a/drivers/modem/modem_cellular.c
+++ b/drivers/modem/modem_cellular.c
@@ -154,6 +154,7 @@ struct modem_cellular_config {
 	const struct device *uart;
 	struct gpio_dt_spec power_gpio;
 	struct gpio_dt_spec reset_gpio;
+	struct gpio_dt_spec wake_gpio;
 	uint16_t power_pulse_duration_ms;
 	uint16_t reset_pulse_duration_ms;
 	uint16_t startup_time_ms;
@@ -599,6 +600,10 @@ static int modem_cellular_on_idle_state_enter(struct modem_cellular_data *data)
 	const struct modem_cellular_config *config =
 		(const struct modem_cellular_config *)data->dev->config;
 
+	if (modem_cellular_gpio_is_enabled(&config->wake_gpio)) {
+		gpio_pin_set_dt(&config->wake_gpio, 0);
+	}
+
 	if (modem_cellular_gpio_is_enabled(&config->reset_gpio)) {
 		gpio_pin_set_dt(&config->reset_gpio, 1);
 	}
@@ -662,6 +667,10 @@ static int modem_cellular_on_idle_state_leave(struct modem_cellular_data *data)
 		gpio_pin_set_dt(&config->reset_gpio, 0);
 	}
 
+	if (modem_cellular_gpio_is_enabled(&config->wake_gpio)) {
+		gpio_pin_set_dt(&config->wake_gpio, 1);
+	}
+
 	return 0;
 }
 
@@ -669,6 +678,10 @@ static int modem_cellular_on_reset_pulse_state_enter(struct modem_cellular_data 
 {
 	const struct modem_cellular_config *config =
 		(const struct modem_cellular_config *)data->dev->config;
+
+	if (modem_cellular_gpio_is_enabled(&config->wake_gpio)) {
+		gpio_pin_set_dt(&config->wake_gpio, 0);
+	}
 
 	gpio_pin_set_dt(&config->reset_gpio, 1);
 	modem_cellular_start_timer(data, K_MSEC(config->reset_pulse_duration_ms));
@@ -698,6 +711,11 @@ static int modem_cellular_on_reset_pulse_state_leave(struct modem_cellular_data 
 		(const struct modem_cellular_config *)data->dev->config;
 
 	gpio_pin_set_dt(&config->reset_gpio, 0);
+
+	if (modem_cellular_gpio_is_enabled(&config->wake_gpio)) {
+		gpio_pin_set_dt(&config->wake_gpio, 1);
+	}
+
 	modem_cellular_stop_timer(data);
 	return 0;
 }
@@ -1715,6 +1733,10 @@ static int modem_cellular_init(const struct device *dev)
 
 	k_sem_init(&data->suspended_sem, 0, 1);
 
+	if (modem_cellular_gpio_is_enabled(&config->wake_gpio)) {
+		gpio_pin_configure_dt(&config->wake_gpio, GPIO_OUTPUT_INACTIVE);
+	}
+
 	if (modem_cellular_gpio_is_enabled(&config->power_gpio)) {
 		gpio_pin_configure_dt(&config->power_gpio, GPIO_OUTPUT_INACTIVE);
 	}
@@ -2127,10 +2149,16 @@ MODEM_CHAT_SCRIPT_DEFINE(u_blox_lara_r6_periodic_chat_script,
 
 #if DT_HAS_COMPAT_STATUS_OKAY(swir_hl7800)
 MODEM_CHAT_SCRIPT_CMDS_DEFINE(swir_hl7800_init_chat_script_cmds,
-			      MODEM_CHAT_SCRIPT_CMD_RESP_NONE("AT", 100),
-			      MODEM_CHAT_SCRIPT_CMD_RESP_NONE("AT", 100),
-			      MODEM_CHAT_SCRIPT_CMD_RESP_NONE("AT", 100),
-			      MODEM_CHAT_SCRIPT_CMD_RESP_NONE("AT", 100),
+			      MODEM_CHAT_SCRIPT_CMD_RESP_NONE("AT", 1000),
+			      MODEM_CHAT_SCRIPT_CMD_RESP_NONE("AT", 1000),
+			      MODEM_CHAT_SCRIPT_CMD_RESP_NONE("AT", 1000),
+			      MODEM_CHAT_SCRIPT_CMD_RESP_NONE("AT", 1000),
+			      /* Turn off sleep mode */
+			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+KSLEEP=2", ok_match),
+			      /* Turn off PSM */
+			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+CPSMS=0", ok_match),
+			      /* Turn off eDRX */
+			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+CEDRXS=0", ok_match),
 			      MODEM_CHAT_SCRIPT_CMD_RESP("ATE0", ok_match),
 			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+CFUN=1", ok_match),
 			      MODEM_CHAT_SCRIPT_CMD_RESP_MULT("AT+CGACT=0", allow_match),
@@ -2388,6 +2416,7 @@ MODEM_CHAT_SCRIPT_DEFINE(sqn_gm02s_periodic_chat_script,
 		.uart = DEVICE_DT_GET(DT_INST_BUS(inst)),                                          \
 		.power_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, mdm_power_gpios, {}),                 \
 		.reset_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, mdm_reset_gpios, {}),                 \
+		.wake_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, mdm_wake_gpios, {}),                   \
 		.power_pulse_duration_ms = (power_ms),                                             \
 		.reset_pulse_duration_ms = (reset_ms),                                             \
 		.startup_time_ms  = (startup_ms),                                                  \


### PR DESCRIPTION
Problem Description
The modem_cellular example did not work with the HL7800 modem until the wake-up pin (MDM_WAKE) / (mdm_wake_gpios) was properly configured. Before this fix, the modem failed to respond correctly and resulted in timeout errors during initialization.

Root Cause
By default, the HL7800 modem might enter sleep mode or PSM (Power Saving Mode), preventing it from properly initializing or responding to AT commands. The modem_cellular driver did not explicitly configure the wake-up pin, which is essential to bring the modem to an active state before communication begins.

Fix Implemented
1. Check if the wake-up pin  is enabled in the device tree
2. Configure the wake-up pin as an output and set it high to ensure the modem is active 
3. Additional improvement: I made changes to modem_cellular to wait for the KSUP URC message before sending any commands and disable sleep modes (PSM/eDRX) at startup. This ensures the modem remains responsive during initialization and operation.

Note: We discussed this issue on the [[Discord modem channel](https://discord.com/channels/720317445772017664/905450375677636649/1349117316683661322)], and the conclusion was not to implement the wake-up pin configuration but to rely on the modem’s previous ksleep configuration, as there may not be enough time to disable sleep by sending an AT command. According to the AT command guide (attached below), if the delay is set to 0, the modem can enter sleep mode immediately after rebooting, meaning we won't have time to run an AT command to disable modem sleep. This is why I had to implement the wake-up pin configuration.

![image](https://github.com/user-attachments/assets/9b629c2e-ceb7-4dfb-ae7e-84dcaed88824)

Proposed PR Changes

- Modify modem_cellular to automatically configure the wake-up pin on startup.
- Disable sleep modes (PSM/eDRX) at initialization to avoid unexpected modem behavior.
- Further improvement: I updated the `modem_cellular` to wait for the KSUP URC message, which indicates that the modem is ready to receive AT commands, before sending any commands. This ensures we don't rely on sending a random number of AT commands.