### PR TITLE
driver: i3c: i3c_dw: PM support, pinctrl, I2C fixes and other updates

### DIFF
--- a/drivers/i3c/Kconfig.dw
+++ b/drivers/i3c/Kconfig.dw
@@ -6,7 +6,7 @@ module = I3C_DW
 module-str = i3c-dw
 source "subsys/logging/Kconfig.template.log_config"
 
-config I3C_DW
+menuconfig I3C_DW
 	bool "DW I3C support"
 	select I3C_IBI_WORKQUEUE if I3C_USE_IBI
 	depends on DT_HAS_SNPS_DESIGNWARE_I3C_ENABLED
@@ -14,3 +14,11 @@ config I3C_DW
 	default y
 	help
 	  Enable the Synopsys Designware I3C driver
+
+if I3C_DW
+
+config I3C_DW_RW_TIMEOUT_MS
+	int "Set the Read/Write timeout in milliseconds"
+	default 100
+
+endif # I3C_DW

--- a/drivers/i3c/i3c_dw.c
+++ b/drivers/i3c/i3c_dw.c
@@ -841,7 +841,7 @@ static int dw_i3c_xfers(const struct device *dev, struct i3c_device_desc *target
 
 	start_xfer(dev);
 
-	ret = k_sem_take(&data->sem_xfer, K_MSEC(1000));
+	ret = k_sem_take(&data->sem_xfer, K_MSEC(CONFIG_I3C_DW_RW_TIMEOUT_MS));
 	if (ret) {
 		LOG_ERR("%s: Semaphore err (%d)", dev->name, ret);
 		goto error;
@@ -1000,7 +1000,7 @@ static int dw_i3c_i2c_transfer(const struct device *dev, struct i3c_i2c_device_d
 
 	start_xfer(dev);
 
-	ret = k_sem_take(&data->sem_xfer, K_MSEC(1000));
+	ret = k_sem_take(&data->sem_xfer, K_MSEC(CONFIG_I3C_DW_RW_TIMEOUT_MS));
 	if (ret) {
 		LOG_ERR("%s: Semaphore err (%d)", dev->name, ret);
 		goto error;
@@ -1239,7 +1239,7 @@ static int dw_i3c_target_ibi_raise_hj(const struct device *dev)
 	sys_write32(sys_read32(config->regs + SLV_EVENT_STATUS) | SLV_EVENT_STATUS_HJ_EN,
 		    config->regs + SLV_EVENT_STATUS);
 
-	ret = k_sem_take(&data->sem_hj, K_MSEC(1000));
+	ret = k_sem_take(&data->sem_hj, K_MSEC(CONFIG_I3C_DW_RW_TIMEOUT_MS));
 	if (ret) {
 		return ret;
 	}
@@ -1741,7 +1741,7 @@ static int dw_i3c_do_ccc(const struct device *dev, struct i3c_ccc_payload *paylo
 
 	start_xfer(dev);
 
-	ret = k_sem_take(&data->sem_xfer, K_MSEC(1000));
+	ret = k_sem_take(&data->sem_xfer, K_MSEC(CONFIG_I3C_DW_RW_TIMEOUT_MS));
 	if (ret) {
 		LOG_ERR("%s: Semaphore err (%d)", dev->name, ret);
 		goto error;
@@ -1895,7 +1895,7 @@ static int dw_i3c_do_daa(const struct device *dev)
 		      COMMAND_PORT_CMD(I3C_CCC_ENTDAA) | COMMAND_PORT_ADDR_ASSGN_CMD;
 
 	start_xfer(dev);
-	ret = k_sem_take(&data->sem_xfer, K_MSEC(1000));
+	ret = k_sem_take(&data->sem_xfer, K_MSEC(CONFIG_I3C_DW_RW_TIMEOUT_MS));
 
 	pm_device_busy_clear(dev);
 	k_mutex_unlock(&data->mt);

--- a/drivers/i3c/i3c_dw.c
+++ b/drivers/i3c/i3c_dw.c
@@ -2312,8 +2312,10 @@ static int dw_i3c_init(const struct device *dev)
 		if (ret) {
 			return ret;
 		}
-		/* Perform bus initialization */
-		ret = i3c_bus_init(dev, &config->common.dev_list);
+		/* Perform bus initialization - skip if no I3C devices are known. */
+		if (config->common.dev_list.num_i3c > 0) {
+			ret = i3c_bus_init(dev, &config->common.dev_list);
+		}
 		/* Bus Initialization Complete, allow HJ ACKs */
 		sys_write32(sys_read32(config->regs + DEVICE_CTRL) & ~(DEV_CTRL_HOT_JOIN_NACK),
 			    config->regs + DEVICE_CTRL);


### PR DESCRIPTION
This PR collects a number of somewhat dependent changes:

* General PM support
* Pinctrl support
* Support an arbitrary number of I2C devices
* Configurable transfer timeout (reduced to 100ms by default)
* Skip I3C initialization on buses with only I2C devices
