### PR TITLE
Bluetooth: L2CAP_BR: CID of data sending is invalid

### DIFF
--- a/subsys/bluetooth/host/classic/l2cap_br.c
+++ b/subsys/bluetooth/host/classic/l2cap_br.c
@@ -307,7 +307,14 @@ int bt_l2cap_br_send_cb(struct bt_conn *conn, uint16_t cid, struct net_buf *buf,
 {
 	struct bt_l2cap_hdr *hdr;
 	struct bt_l2cap_chan *ch = bt_l2cap_br_lookup_tx_cid(conn, cid);
-	struct bt_l2cap_br_chan *br_chan = CONTAINER_OF(ch, struct bt_l2cap_br_chan, chan);
+	struct bt_l2cap_br_chan *br_chan;
+
+	if (ch == NULL) {
+		LOG_WRN("CID %d is not found on conn %p", cid, conn);
+		return -ESHUTDOWN;
+	}
+
+	br_chan = CONTAINER_OF(ch, struct bt_l2cap_br_chan, chan);
 
 	LOG_DBG("chan %p buf %p len %zu", br_chan, buf, buf->len);
 


### PR DESCRIPTION
There is a corner case that the channel is in disconnecting status, due to there is a disconnect request sent from peer. At this time, the channel is status is `BT_L2CAP_CONNECTED`. But it has been removed from `conn->channels` by calling the function `l2cap_br_remove_tx_cid`.
And the disconnect event is notified upper layer via the callback `ops->disconnected`. The thread of the callback context is blocked due to the the calling of `printk` in the callback function.

Then the pending lower priority thread, sending the data in this l2cap channel, is activated. Then in the function
`bt_l2cap_br_send_cb`, a NULL pointer will be got according to the given CID. And unexpected behavior happens when accessing a NULL pointer, since the invalid channel pointer is not checked in function `bt_l2cap_br_send_cb`.

Check the channel pointer after function `bt_l2cap_br_lookup_tx_cid` called. If the channel pointer is invalid, return error code `-ESHUTDOWN` directly.