### PR TITLE
Bluetooth: L2CAP_BR: Code format

### DIFF
--- a/subsys/bluetooth/host/classic/l2cap_br.c
+++ b/subsys/bluetooth/host/classic/l2cap_br.c
@@ -901,8 +901,7 @@ static int l2cap_br_conn_req_reply(struct bt_l2cap_chan *chan, uint16_t result)
 	return 0;
 }
 
-#if defined(CONFIG_BT_L2CAP_DYNAMIC_CHANNEL)
-#if defined(CONFIG_BT_L2CAP_LOG_LEVEL_DBG)
+#if defined(CONFIG_BT_L2CAP_DYNAMIC_CHANNEL) && defined(CONFIG_BT_L2CAP_LOG_LEVEL_DBG)
 void bt_l2cap_br_chan_set_state_debug(struct bt_l2cap_chan *chan,
 				   bt_l2cap_chan_state_t state,
 				   const char *func, int line)
@@ -954,8 +953,7 @@ void bt_l2cap_br_chan_set_state(struct bt_l2cap_chan *chan,
 {
 	BR_CHAN(chan)->state = state;
 }
-#endif /* CONFIG_BT_L2CAP_LOG_LEVEL_DBG */
-#endif /* CONFIG_BT_L2CAP_DYNAMIC_CHANNEL */
+#endif /* CONFIG_BT_L2CAP_LOG_LEVEL_DBG && CONFIG_BT_L2CAP_DYNAMIC_CHANNEL*/
 
 void bt_l2cap_br_chan_del(struct bt_l2cap_chan *chan)
 {


### PR DESCRIPTION
Change 
```
#if defined(CONFIG_BT_L2CAP_DYNAMIC_CHANNEL) 
#if defined(CONFIG_BT_L2CAP_LOG_LEVEL_DBG)
```

to `#if defined(CONFIG_BT_L2CAP_DYNAMIC_CHANNEL) && defined(CONFIG_BT_L2CAP_LOG_LEVEL_DBG)`.