### PR TITLE
twister: Cleanup twister loggers

### DIFF
--- a/scripts/pylib/twister/twisterlib/coverage.py
+++ b/scripts/pylib/twister/twisterlib/coverage.py
@@ -15,7 +15,6 @@ import sys
 import tempfile
 
 logger = logging.getLogger('twister')
-logger.setLevel(logging.DEBUG)
 
 supported_coverage_formats = {
     "gcovr": ["html", "xml", "csv", "txt", "coveralls", "sonarqube"],

--- a/scripts/pylib/twister/twisterlib/environment.py
+++ b/scripts/pylib/twister/twisterlib/environment.py
@@ -27,7 +27,6 @@ from twisterlib.error import TwisterRuntimeError
 from twisterlib.log_helper import log_command
 
 logger = logging.getLogger('twister')
-logger.setLevel(logging.DEBUG)
 
 ZEPHYR_BASE = os.getenv("ZEPHYR_BASE")
 if not ZEPHYR_BASE:

--- a/scripts/pylib/twister/twisterlib/error.py
+++ b/scripts/pylib/twister/twisterlib/error.py
@@ -6,7 +6,7 @@ import logging
 import traceback
 
 logger = logging.getLogger('twister')
-logger.setLevel(logging.DEBUG)
+
 
 class TwisterException(Exception):
     def __init__(self, message="TwisterException"):

--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -47,7 +47,6 @@ except ImportError as capture_error:
         raise capture_error
 
 logger = logging.getLogger('twister')
-logger.setLevel(logging.DEBUG)
 
 
 def terminate_process(proc):

--- a/scripts/pylib/twister/twisterlib/hardwaremap.py
+++ b/scripts/pylib/twister/twisterlib/hardwaremap.py
@@ -30,7 +30,6 @@ except ImportError:
     print("Install tabulate python module with pip to use --device-testing option.")
 
 logger = logging.getLogger('twister')
-logger.setLevel(logging.DEBUG)
 
 
 class DUT:

--- a/scripts/pylib/twister/twisterlib/harness.py
+++ b/scripts/pylib/twister/twisterlib/harness.py
@@ -28,7 +28,6 @@ from twisterlib.statuses import TwisterStatus
 from twisterlib.testinstance import TestInstance
 
 logger = logging.getLogger('twister')
-logger.setLevel(logging.DEBUG)
 
 _WINDOWS = platform.system() == 'Windows'
 

--- a/scripts/pylib/twister/twisterlib/jobserver.py
+++ b/scripts/pylib/twister/twisterlib/jobserver.py
@@ -14,7 +14,7 @@ import subprocess
 import sys
 
 logger = logging.getLogger('twister')
-logger.setLevel(logging.DEBUG)
+
 
 class JobHandle:
     """Small object to handle claim of a job."""

--- a/scripts/pylib/twister/twisterlib/log_helper.py
+++ b/scripts/pylib/twister/twisterlib/log_helper.py
@@ -12,6 +12,7 @@ import shlex
 
 _WINDOWS = platform.system() == 'Windows'
 
+
 def log_command(logger, msg, args):
     '''Platform-independent helper for logging subprocess invocations.
     Will log a command string that can be copy/pasted into a POSIX

--- a/scripts/pylib/twister/twisterlib/platform.py
+++ b/scripts/pylib/twister/twisterlib/platform.py
@@ -18,7 +18,6 @@ from twisterlib.constants import SUPPORTED_SIMS
 from twisterlib.environment import ZEPHYR_BASE
 
 logger = logging.getLogger('twister')
-logger.setLevel(logging.DEBUG)
 
 
 class Simulator:

--- a/scripts/pylib/twister/twisterlib/reports.py
+++ b/scripts/pylib/twister/twisterlib/reports.py
@@ -17,7 +17,6 @@ from colorama import Fore
 from twisterlib.statuses import TwisterStatus
 
 logger = logging.getLogger('twister')
-logger.setLevel(logging.DEBUG)
 
 
 class ReportStatus(str, Enum):

--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -61,7 +61,6 @@ import expr_parser
 from anytree import Node, RenderTree
 
 logger = logging.getLogger('twister')
-logger.setLevel(logging.DEBUG)
 
 
 class ExecutionCounter:

--- a/scripts/pylib/twister/twisterlib/size_calc.py
+++ b/scripts/pylib/twister/twisterlib/size_calc.py
@@ -13,7 +13,7 @@ import sys
 from twisterlib.error import TwisterRuntimeError
 
 logger = logging.getLogger('twister')
-logger.setLevel(logging.DEBUG)
+
 
 class SizeCalculator:
     alloc_sections = [

--- a/scripts/pylib/twister/twisterlib/testinstance.py
+++ b/scripts/pylib/twister/twisterlib/testinstance.py
@@ -36,7 +36,7 @@ from twisterlib.statuses import TwisterStatus
 from twisterlib.testsuite import TestCase, TestSuite
 
 logger = logging.getLogger('twister')
-logger.setLevel(logging.DEBUG)
+
 
 class TestInstance:
     """Class representing the execution of a particular TestSuite on a platform

--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -38,7 +38,6 @@ from twisterlib.testsuite import TestSuite, scan_testsuite_path
 from zephyr_module import parse_modules
 
 logger = logging.getLogger('twister')
-logger.setLevel(logging.DEBUG)
 
 ZEPHYR_BASE = os.getenv("ZEPHYR_BASE")
 if not ZEPHYR_BASE:

--- a/scripts/pylib/twister/twisterlib/testsuite.py
+++ b/scripts/pylib/twister/twisterlib/testsuite.py
@@ -18,7 +18,6 @@ from twisterlib.mixins import DisablePyTestCollectionMixin
 from twisterlib.statuses import TwisterStatus
 
 logger = logging.getLogger('twister')
-logger.setLevel(logging.DEBUG)
 
 class ScanPathResult:
     """Result of the scan_tesuite_path function call.

--- a/scripts/tests/twister/conftest.py
+++ b/scripts/tests/twister/conftest.py
@@ -4,12 +4,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 '''Common fixtures for use in testing the twister tool.'''
-
+import logging
 import os
 import sys
 import pytest
 
 pytest_plugins = ["pytester"]
+logging.getLogger("twister").setLevel(logging.DEBUG)  # requires for testing twister
 
 ZEPHYR_BASE = os.getenv("ZEPHYR_BASE")
 sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts/pylib/twister"))

--- a/scripts/tests/twister_blackbox/conftest.py
+++ b/scripts/tests/twister_blackbox/conftest.py
@@ -12,6 +12,8 @@ import os
 import pytest
 import sys
 
+logging.getLogger("twister").setLevel("DEBUG")  # requires for testing twister
+
 ZEPHYR_BASE = os.getenv('ZEPHYR_BASE')
 TEST_DATA = os.path.join(ZEPHYR_BASE, 'scripts', 'tests',
                         'twister_blackbox', 'test_data')


### PR DESCRIPTION
Removed logger.setLevel(...) from all twister modules, becasue there should be only one place where twister loggers are configured, and the log level should be set in that place.
This should be done in twister_main.py in setup_logging function.