### PR TITLE
devicetree: Add DT_NODELABEL_C_TOKEN_* macros

### DIFF
--- a/doc/build/dts/macros.bnf
+++ b/doc/build/dts/macros.bnf
@@ -428,6 +428,8 @@ other-macro =/ %s"DT_COMPAT_HAS_OKAY_" dt-name
 ; property to a fixed-partitions node. See the flash map API docs
 ; for an example.
 other-macro =/ %s"DT_COMPAT_" dt-name %s"_LABEL_" dt-name
+; Get the node label of the phandle
+other-macro =/ %s"DT_N_NODELABEL_" %s"DT_N" path-id "_IDX_" DIGIT "_C_TOKEN"
 
 ; --------------------------------------------------------------------
 ; alternate-id: another way to specify a node besides a path-id

--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -117,6 +117,12 @@ Libraries / Subsystems
     LoRaWAN 1.0.x Class A directly on top of the LoRa radio driver, without
     the Semtech LoRaMac-node dependency.  Currently supports the EU868 region.
 
+Devicetree
+**********
+
+  * :c:macro:`DT_NODELABEL_C_TOKEN`
+  * :c:macro:`DT_NODELABEL_C_TOKEN_BY_IDX`
+
 Other notable changes
 *********************
 

--- a/dts/bindings/test/vnd,phandle-holder.yaml
+++ b/dts/bindings/test/vnd,phandle-holder.yaml
@@ -10,6 +10,7 @@ include: [base.yaml]
 properties:
   ph: {type: "phandle"}
   phs: {type: "phandles"}
+  ph-conn: {type: "phandle"}
   phs-or: {type: "phandles"}
   pha-gpios: {type: "phandle-array"}
   gpios: {type: "phandle-array"}

--- a/include/zephyr/devicetree.h
+++ b/include/zephyr/devicetree.h
@@ -197,6 +197,57 @@
 #define DT_NODELABEL(label) DT_CAT(DT_N_NODELABEL_, label)
 
 /**
+ * @brief Get the C symbolic name of a node identifier by index
+ *
+ * Example devicetree fragment:
+ *
+ * @code{.dts}
+ *     n1: node-1 {
+ *             foo = <&n2 &n3>;
+ *     };
+ *
+ *     n2: n2_1: node-2 { ... };
+ *     n3: &n2:  node-3 { ... };
+ * @endcode
+ *
+ * Above, `foo` has type phandles and has two elements:
+ *
+ * - index 0 has phandle `&n2`, which is `node-2`'s phandle
+ * - index 1 has phandle `&n3`, which is `node-3`'s phandle
+ *
+ * Example usage:
+ *
+ * @code{.c}
+ *     #define N1 DT_NODELABEL(n1)
+ *
+ *     DT_NODELABEL_C_TOKEN_BY_IDX(DT_PHANDLE_BY_IDX(N1, foo, 0), 0) // n2
+ *     DT_NODELABEL_C_TOKEN_BY_IDX(DT_PHANDLE_BY_IDX(N1, foo, 0), 1) // n2_1
+ *     DT_NODELABEL_C_TOKEN_BY_IDX(DT_PHANDLE_BY_IDX(N1, foo, 1), 0) // n2
+ *     DT_NODELABEL_C_TOKEN_BY_IDX(DT_PHANDLE_BY_IDX(N1, foo, 1), 1) // n2_1
+ *     DT_NODELABEL_C_TOKEN_BY_IDX(DT_PHANDLE_BY_IDX(N1, foo, 1), 2) // n3
+ * @endcode
+ *
+ * @param node_id node identifier
+ * @param idx index into @p node_id
+ * @return C symbolic name of the node for the given index
+ * @note The @p idx retrieves node labels in left-to-right order, as shown
+ *       in the example.
+ */
+#define DT_NODELABEL_C_TOKEN_BY_IDX(node_id, idx) \
+	DT_CAT5(DT_N_NODELABEL_, node_id, _IDX_, idx, _C_TOKEN)
+
+/**
+ * @brief Get the C symbolic name for a node identifier
+ *
+ * This is equivalent to DT_NODELABEL_C_TOKEN_BY_IDX(node_id, 0).
+ *
+ * @param node_id node identifier
+ * @return C symbolic name of the node
+ */
+#define DT_NODELABEL_C_TOKEN(node_id) \
+	DT_NODELABEL_C_TOKEN_BY_IDX(node_id, 0)
+
+/**
  * @brief Get a node identifier from /aliases
  *
  * This macro's argument is a property of the `/aliases` node. It

--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -245,6 +245,10 @@ def write_idents_and_existence(node: edtlib.Node) -> None:
     # Node labels
     idents.extend(f"N_NODELABEL_{str2ident(label)}" for label in node.labels)
 
+    # Node label tokens
+    for i, label in enumerate(node.labels):
+        out_dt_define(f"N_NODELABEL_DT_{node.z_path_id}_IDX_{i}_C_TOKEN", label)
+
     out_comment("Existence and alternate IDs:")
     out_dt_define(f"{node.z_path_id}_EXISTS", 1)
 

--- a/tests/lib/devicetree/api/app.overlay
+++ b/tests/lib/devicetree/api/app.overlay
@@ -70,6 +70,7 @@
 			 */
 			ph = <&test_gpio_1>;
 			phs = <&test_i2c &test_spi>;
+			ph-conn = <&test_connector>;
 			phs-or = <&test_enum_default_0 &test_enum_default_1>;
 			gpios = <&test_gpio_1 10 20>, <&test_gpio_2 30 40>;
 			pha-gpios = <&test_gpio_1 50 60>, <0>, <&test_gpio_3 70>,
@@ -232,7 +233,7 @@
 			status = "okay";
 		};
 
-		test_i2c: i2c@11112222 {
+		test_i2c: test_i2c1: i2c@11112222 {
 			#address-cells = <1>;
 			#size-cells = <0>;
 			compatible = "vnd,i2c";
@@ -327,7 +328,7 @@
 			status = "okay";
 		};
 
-		test_spi: spi@33334444 {
+		test_spi: test_spi1: spi@33334444 {
 			#address-cells = <1>;
 			#size-cells = <0>;
 			compatible = "vnd,spi";
@@ -1174,3 +1175,5 @@
 		};
 	};
 };
+
+test_connector: &test_i2c {};

--- a/tests/lib/devicetree/api/src/main.c
+++ b/tests/lib/devicetree/api/src/main.c
@@ -502,6 +502,45 @@ ZTEST(devicetree_api, test_has_nodelabel)
 		      1, "");
 }
 
+ZTEST(devicetree_api, test_nodelabel_c_token)
+{
+#define TEST_PHS_IDX(i) DT_PHANDLE_BY_IDX(TEST_PH, phs, i)
+
+	/* DT_NODELABEL_C_TOKEN */
+	const char *test_nodelabel = STRINGIFY(
+		DT_NODELABEL_C_TOKEN(
+			DT_PHANDLE(TEST_PH, gpios)));
+	zassert_equal(test_nodelabel, "test_nodelabel");
+	const char *test_i2c = STRINGIFY(
+		DT_NODELABEL_C_TOKEN(TEST_PHS_IDX(0)));
+	zassert_equal(test_i2c, "test_i2c");
+	const char *test_spi = STRINGIFY(
+		DT_NODELABEL_C_TOKEN(TEST_PHS_IDX(1)));
+	zassert_equal(test_spi, "test_spi");
+	const char *test_phandles = STRINGIFY(
+		DT_NODELABEL_C_TOKEN(TEST_PH));
+	zassert_equal(test_phandles, "test_phandles");
+
+	/* DT_NODELABEL_C_TOKEN_BY_IDX */
+	const char *test_i2c0 = STRINGIFY(
+		DT_NODELABEL_C_TOKEN_BY_IDX(TEST_PHS_IDX(0), 0));
+	zassert_equal(test_i2c0, "test_i2c");
+	const char *test_spi0 = STRINGIFY(
+		DT_NODELABEL_C_TOKEN_BY_IDX(TEST_PHS_IDX(1), 0));
+	zassert_equal(test_spi0, "test_spi");
+	const char *test_i2c1 = STRINGIFY(
+		DT_NODELABEL_C_TOKEN_BY_IDX(TEST_PHS_IDX(0), 1));
+	zassert_equal(test_i2c1, "test_i2c1");
+	const char *test_spi1 = STRINGIFY(
+		DT_NODELABEL_C_TOKEN_BY_IDX(TEST_PHS_IDX(1), 1));
+	zassert_equal(test_spi1, "test_spi1");
+	const char *test_connector = STRINGIFY(
+		DT_NODELABEL_C_TOKEN_BY_IDX(DT_PHANDLE(TEST_PH, ph_conn), 2));
+	zassert_equal(test_connector, "test_connector");
+
+#undef TEST_PHS_IDX
+}
+
 ZTEST(devicetree_api, test_has_compat)
 {
 	unsigned int compats;


### PR DESCRIPTION
Add the DT_NODELABEL_C_TOKEN and
DT_NODELABEL_C_TOKEN_BY_IDX macros to retrieve
the C symbolic name of a node.

Closes: #67046