### PR TITLE
boards: nordic: Add QSPI nrfutil config

### DIFF
--- a/boards/nordic/nrf52840dk/board.cmake
+++ b/boards/nordic/nrf52840dk/board.cmake
@@ -1,5 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
+if(CONFIG_SOC_NRF52840_QIAA)
+  board_runner_args(nrfutil "--ext-mem-config-file=${BOARD_DIR}/support/nrf52840dk_qspi_nrfutil_config.json")
+endif()
+
 board_runner_args(jlink "--device=nRF52840_xxAA" "--speed=4000")
 board_runner_args(pyocd "--target=nrf52840" "--frequency=4000000")
 include(${ZEPHYR_BASE}/boards/common/nrfutil.board.cmake)

--- a/boards/nordic/nrf52840dk/support/nrf52840dk_qspi_nrfutil_config.json
+++ b/boards/nordic/nrf52840dk/support/nrf52840dk_qspi_nrfutil_config.json
@@ -1,0 +1,22 @@
+{
+  "firmware_config": {
+    "peripheral": "QSPI"
+  },
+  "pins": {
+    "sck": 19,
+    "csn": 17,
+    "io0": 20,
+    "io1": 21,
+    "io2": 22,
+    "io3": 23
+  },
+  "flash_size": 8388608,
+  "sck_frequency": 8000000,
+  "address_mode": "MODE24BIT",
+  "readoc": "READ4IO",
+  "writeoc": "PP4IO",
+  "pp_size": "PPSIZE256",
+  "sck_delay": 128,
+  "rx_delay": 2,
+  "page_size": 4096
+}

--- a/boards/nordic/nrf5340dk/board.cmake
+++ b/boards/nordic/nrf5340dk/board.cmake
@@ -5,6 +5,7 @@ if(CONFIG_BOARD_NRF5340DK_NRF5340_CPUAPP_NS)
 endif()
 
 if(CONFIG_BOARD_NRF5340DK_NRF5340_CPUAPP OR CONFIG_BOARD_NRF5340DK_NRF5340_CPUAPP_NS)
+  board_runner_args(nrfutil "--ext-mem-config-file=${BOARD_DIR}/support/nrf5340dk_qspi_nrfutil_config.json")
   board_runner_args(jlink "--device=nrf5340_xxaa_app" "--speed=4000")
 endif()
 

--- a/boards/nordic/nrf5340dk/support/nrf5340dk_qspi_nrfutil_config.json
+++ b/boards/nordic/nrf5340dk/support/nrf5340dk_qspi_nrfutil_config.json
@@ -1,0 +1,22 @@
+{
+  "firmware_config": {
+    "peripheral": "QSPI"
+  },
+  "pins": {
+    "sck": 17,
+    "csn": 18,
+    "io0": 13,
+    "io1": 14,
+    "io2": 15,
+    "io3": 16
+  },
+  "flash_size": 8388608,
+  "sck_frequency": 8000000,
+  "address_mode": "MODE24BIT",
+  "readoc": "READ4IO",
+  "writeoc": "PP4IO",
+  "pp_size": "PPSIZE256",
+  "sck_delay": 128,
+  "rx_delay": 2,
+  "page_size": 4096
+}

--- a/boards/nordic/nrf7002dk/board.cmake
+++ b/boards/nordic/nrf7002dk/board.cmake
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 if(CONFIG_BOARD_NRF7002DK_NRF5340_CPUAPP OR CONFIG_BOARD_NRF7002DK_NRF5340_CPUAPP_NRF7001)
+  board_runner_args(nrfutil "--ext-mem-config-file=${BOARD_DIR}/support/nrf7002dk_spi_nrfutil_config.json")
   board_runner_args(jlink "--device=nrf5340_xxaa_app" "--speed=4000")
 elseif(CONFIG_BOARD_NRF7002DK_NRF5340_CPUNET)
   board_runner_args(jlink "--device=nrf5340_xxaa_net" "--speed=4000")

--- a/boards/nordic/nrf7002dk/support/nrf7002dk_spi_nrfutil_config.json
+++ b/boards/nordic/nrf7002dk/support/nrf7002dk_spi_nrfutil_config.json
@@ -1,0 +1,17 @@
+{
+  "firmware_config": {
+    "peripheral": "SPIM0"
+  },
+  "pins": {
+    "sck": 8,
+    "csn": 11,
+    "io0": 9,
+    "io1": 10,
+    "io2": 4294967295,
+    "io3": 4294967295
+  },
+  "flash_size": 8388608,
+  "page_size": 4096,
+  "sck_frequency": 8000000,
+  "address_mode": "MODE24BIT"
+}

--- a/boards/nordic/thingy53/board.cmake
+++ b/boards/nordic/thingy53/board.cmake
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 if(CONFIG_BOARD_THINGY53_NRF5340_CPUAPP OR CONFIG_BOARD_THINGY53_NRF5340_CPUAPP_NS)
+  board_runner_args(nrfutil "--ext-mem-config-file=${BOARD_DIR}/support/thingy53_qspi_nrfutil_config.json")
   board_runner_args(jlink "--device=nrf5340_xxaa_app" "--speed=4000")
 elseif(CONFIG_BOARD_THINGY53_NRF5340_CPUNET)
   board_runner_args(jlink "--device=nrf5340_xxaa_net" "--speed=4000")

--- a/boards/nordic/thingy53/support/thingy53_qspi_nrfutil_config.json
+++ b/boards/nordic/thingy53/support/thingy53_qspi_nrfutil_config.json
@@ -1,0 +1,22 @@
+{
+  "firmware_config": {
+    "peripheral": "QSPI"
+  },
+  "pins": {
+    "sck": 17,
+    "csn": 18,
+    "io0": 13,
+    "io1": 14,
+    "io2": 15,
+    "io3": 16
+  },
+  "flash_size": 8388608,
+  "sck_frequency": 8000000,
+  "address_mode": "MODE24BIT",
+  "readoc": "READ2IO",
+  "writeoc": "PP",
+  "pp_size": "PPSIZE256",
+  "sck_delay": 128,
+  "rx_delay": 2,
+  "page_size": 4096
+}


### PR DESCRIPTION
Adds a configuration file which is used with nrfutil to allow programming QSPI on the device