### PR TITLE
include: zephyr: net: Add NULL checks for phy API calls

### DIFF
--- a/include/zephyr/net/phy.h
+++ b/include/zephyr/net/phy.h
@@ -7,6 +7,7 @@
 /*
  * Copyright (c) 2021 IP-Logix Inc.
  * Copyright 2022 NXP
+ * Copyright (c) 2025 Aerlync Labs Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -23,6 +24,7 @@
  */
 #include <zephyr/types.h>
 #include <zephyr/device.h>
+#include <errno.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -209,6 +211,10 @@ static inline int phy_configure_link(const struct device *dev, enum phy_link_spe
 {
 	const struct ethphy_driver_api *api = (const struct ethphy_driver_api *)dev->api;
 
+	if (api->cfg_link == NULL) {
+		return -ENOSYS;
+	}
+
 	return api->cfg_link(dev, speeds);
 }
 
@@ -228,6 +234,10 @@ static inline int phy_configure_link(const struct device *dev, enum phy_link_spe
 static inline int phy_get_link_state(const struct device *dev, struct phy_link_state *state)
 {
 	const struct ethphy_driver_api *api = (const struct ethphy_driver_api *)dev->api;
+
+	if (api->get_link == NULL) {
+		return -ENOSYS;
+	}
 
 	return api->get_link(dev, state);
 }
@@ -251,6 +261,10 @@ static inline int phy_link_callback_set(const struct device *dev, phy_callback_t
 {
 	const struct ethphy_driver_api *api = (const struct ethphy_driver_api *)dev->api;
 
+	if (api->link_cb_set == NULL) {
+		return -ENOSYS;
+	}
+
 	return api->link_cb_set(dev, callback, user_data);
 }
 
@@ -270,6 +284,10 @@ static inline int phy_read(const struct device *dev, uint16_t reg_addr, uint32_t
 {
 	const struct ethphy_driver_api *api = (const struct ethphy_driver_api *)dev->api;
 
+	if (api->read == NULL) {
+		return -ENOSYS;
+	}
+
 	return api->read(dev, reg_addr, value);
 }
 
@@ -288,6 +306,10 @@ static inline int phy_read(const struct device *dev, uint16_t reg_addr, uint32_t
 static inline int phy_write(const struct device *dev, uint16_t reg_addr, uint32_t value)
 {
 	const struct ethphy_driver_api *api = (const struct ethphy_driver_api *)dev->api;
+
+	if (api->write == NULL) {
+		return -ENOSYS;
+	}
 
 	return api->write(dev, reg_addr, value);
 }
@@ -310,6 +332,10 @@ static inline int phy_read_c45(const struct device *dev, uint8_t devad, uint16_t
 {
 	const struct ethphy_driver_api *api = (const struct ethphy_driver_api *)dev->api;
 
+	if (api->read_c45 == NULL) {
+		return -ENOSYS;
+	}
+
 	return api->read_c45(dev, devad, regad, data);
 }
 
@@ -331,6 +357,10 @@ static inline int phy_write_c45(const struct device *dev, uint8_t devad, uint16_
 {
 	const struct ethphy_driver_api *api = (const struct ethphy_driver_api *)dev->api;
 
+	if (api->write_c45 == NULL) {
+		return -ENOSYS;
+	}
+
 	return api->write_c45(dev, devad, regad, data);
 }
 
@@ -348,6 +378,10 @@ static inline int phy_write_c45(const struct device *dev, uint8_t devad, uint16_
 static inline int phy_set_plca_cfg(const struct device *dev, struct phy_plca_cfg *plca_cfg)
 {
 	const struct ethphy_driver_api *api = (const struct ethphy_driver_api *)dev->api;
+
+	if (api->set_plca_cfg == NULL) {
+		return -ENOSYS;
+	}
 
 	return api->set_plca_cfg(dev, plca_cfg);
 }
@@ -367,6 +401,10 @@ static inline int phy_get_plca_cfg(const struct device *dev, struct phy_plca_cfg
 {
 	const struct ethphy_driver_api *api = (const struct ethphy_driver_api *)dev->api;
 
+	if (api->get_plca_cfg == NULL) {
+		return -ENOSYS;
+	}
+
 	return api->get_plca_cfg(dev, plca_cfg);
 }
 
@@ -384,6 +422,10 @@ static inline int phy_get_plca_cfg(const struct device *dev, struct phy_plca_cfg
 static inline int phy_get_plca_sts(const struct device *dev, bool *plca_status)
 {
 	const struct ethphy_driver_api *api = (const struct ethphy_driver_api *)dev->api;
+
+	if (api->get_plca_sts == NULL) {
+		return -ENOSYS;
+	}
 
 	return api->get_plca_sts(dev, plca_status);
 }


### PR DESCRIPTION
Add missing NULL checks to the APIs in phy.h
Signed-off-by: Sayooj K Karun <sayooj@aerlync.com>