### PR TITLE
samples: subsys: setting does not apply to sector size of 128K

### DIFF
--- a/samples/subsys/settings/README.rst
+++ b/samples/subsys/settings/README.rst
@@ -18,6 +18,7 @@ Requirements
 
 * A board with settings support, for instance: nrf52840dk/nrf52840
 * Or qemu_x86 target
+* A nvs_sector_size <= 0xFFFF
 
 Building and Running
 ********************

--- a/samples/subsys/settings/sample.yaml
+++ b/samples/subsys/settings/sample.yaml
@@ -7,6 +7,15 @@ tests:
     timeout: 10
     filter: dt_label_with_parent_compat_enabled("storage_partition", "fixed-partitions")
     platform_exclude:
+      - nucleo_h723zg
+      - stm32h735g_disco
+      - nucleo_h743zi
+      - stm32h745i_disco/stm32h745xx/m7
+      - nucleo_h745zi_q/stm32h745xx/m7
+      - stm32h747i_disco/stm32h747xx/m7
+      - stm32h750b_dk
+      - nucleo_h753zi
+      - nucleo_h755zi_q/stm32h755xx/m7
       - qemu_cortex_m0/nrf51822
     integration_platforms:
       - native_sim


### PR DESCRIPTION
Exclude the stm32h7 target boards to this samples/subsys/settings because it does not apply for flash sector flash size larger than 64K : all those stm32h7   MCUs have sector size of 128K 
The settings_subsys_init will fails (-33 DOM errno ) when it checks nvs_sector


Will fix the error when running the samples/subsys/settings/  on   nucleo_h743zi :
```
*** Booting Zephyr OS build v4.1.0-345-gf6a44f2dc5ab ***                                        
                                                                                                
*** Settings usage example ***                                                                  
                                                                                                                       
settings subsys initialization: fail (err -33)                                                  
 
```