### PR TITLE
soc: nordic: nRF54L: Move a few options from boards to the SoC defini…

### DIFF
--- a/boards/nordic/nrf54l09pdk/nrf54l09pdk_nrf54l09_cpuapp_defconfig
+++ b/boards/nordic/nrf54l09pdk/nrf54l09pdk_nrf54l09_cpuapp_defconfig
@@ -16,14 +16,3 @@ CONFIG_ARM_MPU=y
 
 # Enable hardware stack protection
 CONFIG_HW_STACK_PROTECTION=y
-
-# MPU-based null-pointer dereferencing detection cannot
-# be applied as the (0x0 - 0x400) is unmapped for this target.
-CONFIG_NULL_POINTER_EXCEPTION_DETECTION_NONE=y
-
-# Enable Cache
-CONFIG_CACHE_MANAGEMENT=y
-CONFIG_EXTERNAL_CACHE=y
-
-# Start SYSCOUNTER on driver init
-CONFIG_NRF_GRTC_START_SYSCOUNTER=y

--- a/boards/nordic/nrf54l15dk/nrf54l15dk_nrf54l05_cpuapp_defconfig
+++ b/boards/nordic/nrf54l15dk/nrf54l15dk_nrf54l05_cpuapp_defconfig
@@ -16,14 +16,3 @@ CONFIG_ARM_MPU=y
 
 # Enable hardware stack protection
 CONFIG_HW_STACK_PROTECTION=y
-
-# MPU-based null-pointer dereferencing detection cannot
-# be applied as the (0x0 - 0x400) is unmapped for this target.
-CONFIG_NULL_POINTER_EXCEPTION_DETECTION_NONE=y
-
-# Enable Cache
-CONFIG_CACHE_MANAGEMENT=y
-CONFIG_EXTERNAL_CACHE=y
-
-# Start SYSCOUNTER on driver init
-CONFIG_NRF_GRTC_START_SYSCOUNTER=y

--- a/boards/nordic/nrf54l15dk/nrf54l15dk_nrf54l10_cpuapp_defconfig
+++ b/boards/nordic/nrf54l15dk/nrf54l15dk_nrf54l10_cpuapp_defconfig
@@ -16,14 +16,3 @@ CONFIG_ARM_MPU=y
 
 # Enable hardware stack protection
 CONFIG_HW_STACK_PROTECTION=y
-
-# MPU-based null-pointer dereferencing detection cannot
-# be applied as the (0x0 - 0x400) is unmapped for this target.
-CONFIG_NULL_POINTER_EXCEPTION_DETECTION_NONE=y
-
-# Enable Cache
-CONFIG_CACHE_MANAGEMENT=y
-CONFIG_EXTERNAL_CACHE=y
-
-# Start SYSCOUNTER on driver init
-CONFIG_NRF_GRTC_START_SYSCOUNTER=y

--- a/boards/nordic/nrf54l15dk/nrf54l15dk_nrf54l15_cpuapp_defconfig
+++ b/boards/nordic/nrf54l15dk/nrf54l15dk_nrf54l15_cpuapp_defconfig
@@ -16,14 +16,3 @@ CONFIG_ARM_MPU=y
 
 # Enable hardware stack protection
 CONFIG_HW_STACK_PROTECTION=y
-
-# MPU-based null-pointer dereferencing detection cannot
-# be applied as the (0x0 - 0x400) is unmapped for this target.
-CONFIG_NULL_POINTER_EXCEPTION_DETECTION_NONE=y
-
-# Enable Cache
-CONFIG_CACHE_MANAGEMENT=y
-CONFIG_EXTERNAL_CACHE=y
-
-# Start SYSCOUNTER on driver init
-CONFIG_NRF_GRTC_START_SYSCOUNTER=y

--- a/boards/nordic/nrf54l20pdk/nrf54l20pdk_nrf54l20_cpuapp_defconfig
+++ b/boards/nordic/nrf54l20pdk/nrf54l20pdk_nrf54l20_cpuapp_defconfig
@@ -16,14 +16,3 @@ CONFIG_ARM_MPU=y
 
 # Enable hardware stack protection
 CONFIG_HW_STACK_PROTECTION=y
-
-# MPU-based null-pointer dereferencing detection cannot
-# be applied as the (0x0 - 0x400) is unmapped for this target.
-CONFIG_NULL_POINTER_EXCEPTION_DETECTION_NONE=y
-
-# Enable Cache
-CONFIG_CACHE_MANAGEMENT=y
-CONFIG_EXTERNAL_CACHE=y
-
-# Start SYSCOUNTER on driver init
-CONFIG_NRF_GRTC_START_SYSCOUNTER=y

--- a/soc/nordic/nrf54l/Kconfig.defconfig
+++ b/soc/nordic/nrf54l/Kconfig.defconfig
@@ -12,8 +12,25 @@ if ARM
 config CORTEX_M_SYSTICK
 	default !NRF_GRTC_TIMER
 
+# Start SYSCOUNTER on driver init
+config NRF_GRTC_START_SYSCOUNTER
+	default NRF_GRTC_TIMER
+
 config CACHE_NRF_CACHE
 	default y if EXTERNAL_CACHE
+
+config CACHE_MANAGEMENT
+	default y
+
+choice CACHE_TYPE
+	default EXTERNAL_CACHE
+endchoice
+
+# MPU-based null-pointer dereferencing detection cannot
+# be applied as the (0x0 - 0x400) is unmapped for this target.
+choice NULL_POINTER_EXCEPTION_DETECTION
+	default NULL_POINTER_EXCEPTION_DETECTION_NONE
+endchoice
 
 endif # ARM
 


### PR DESCRIPTION
…tion

A few option defaults that were so far defined in the board _defconfig files are actually entirely SoC family (nRF54L) dependant, so it makes much more sense to have them defined at the SoC family level in order for all boards based on these SoCs to automatically inherit them.