### PR TITLE
Bluetooth: CSIP: Remove bt_csip_set_member_get_sirk

### DIFF
--- a/doc/connectivity/bluetooth/shell/audio/cap.rst
+++ b/doc/connectivity/bluetooth/shell/audio/cap.rst
@@ -28,7 +28,7 @@ register callbacks.
      lock          :Lock the set
      release       :Release the set [force]
      sirk          :Set the currently used SIRK <sirk>
-     get_sirk      :Get the currently used SIRK
+     get_info      :Get CSIS info
      sirk_rsp      :Set the response used in SIRK requests <accept, accept_enc,
                     reject, oob>
 
@@ -55,10 +55,14 @@ This command can get the currently used SIRK.
 
 .. code-block:: console
 
-   uart:~$ cap_acceptor get_sirk
-   SIRK
-   36 04 9a dc 66 3a a1 a1 |6...f:..
-   1d 9a 2f 41 01 73 3e 01 |../A.s>.
+   uart:~$ cap_acceptor get_info
+   Info for 0x2003b0c8
+           SIRK
+   00000000: 20 37 0a 00 95 c4 04 20  00 00 00 00 f1 79 09 00 | 7.....  .....y..|
+           Set size: 2
+           Rank: 1
+           Lockable: true
+           Locked: false
 
 CAP Initiator
 *************

--- a/doc/releases/migration-guide-4.2.rst
+++ b/doc/releases/migration-guide-4.2.rst
@@ -275,6 +275,9 @@ Bluetooth Audio
 * ``CONFIG_BT_CSIP_SET_MEMBER_NOTIFIABLE`` has been renamed to
   :kconfig:option:`CONFIG_BT_CSIP_SET_MEMBER_SIRK_NOTIFIABLE``. (:github:`86763``)
 
+* ``bt_csip_set_member_get_sirk`` has been removed. Use :c:func:`bt_csip_set_member_get_info` to get
+  the SIRK (and other information). (:github:`86996`)
+
 Bluetooth HCI
 =============
 

--- a/include/zephyr/bluetooth/audio/csip.h
+++ b/include/zephyr/bluetooth/audio/csip.h
@@ -230,15 +230,6 @@ int bt_csip_set_member_sirk(struct bt_csip_set_member_svc_inst *svc_inst,
 			    const uint8_t sirk[BT_CSIP_SIRK_SIZE]);
 
 /**
- * @brief Get the SIRK of a service instance
- *
- * @param[in]  svc_inst  Pointer to the registered Coordinated Set Identification Service.
- * @param[out] sirk      Array to store the SIRK in.
- */
-int bt_csip_set_member_get_sirk(struct bt_csip_set_member_svc_inst *svc_inst,
-				uint8_t sirk[BT_CSIP_SIRK_SIZE]);
-
-/**
  * @brief Set a new size and rank for a service instance
  *
  * This function can be used to dynamically change the size and rank of a service instance.

--- a/subsys/bluetooth/audio/csip_set_member.c
+++ b/subsys/bluetooth/audio/csip_set_member.c
@@ -1064,24 +1064,6 @@ int bt_csip_set_member_sirk(struct bt_csip_set_member_svc_inst *svc_inst,
 	return 0;
 }
 
-int bt_csip_set_member_get_sirk(struct bt_csip_set_member_svc_inst *svc_inst,
-				uint8_t sirk[BT_CSIP_SIRK_SIZE])
-{
-	CHECKIF(svc_inst == NULL) {
-		LOG_DBG("NULL svc_inst");
-		return -EINVAL;
-	}
-
-	CHECKIF(sirk == NULL) {
-		LOG_DBG("NULL SIRK");
-		return -EINVAL;
-	}
-
-	memcpy(sirk, svc_inst->sirk.value, BT_CSIP_SIRK_SIZE);
-
-	return 0;
-}
-
 int bt_csip_set_member_set_size_and_rank(struct bt_csip_set_member_svc_inst *svc_inst, uint8_t size,
 					 uint8_t rank)
 {

--- a/subsys/bluetooth/audio/shell/cap_acceptor.c
+++ b/subsys/bluetooth/audio/shell/cap_acceptor.c
@@ -264,25 +264,37 @@ static int cmd_cap_acceptor_sirk(const struct shell *sh, size_t argc, char *argv
 	return 0;
 }
 
-static int cmd_cap_acceptor_get_sirk(const struct shell *sh, size_t argc, char *argv[])
+static int cmd_cap_acceptor_get_info(const struct shell *sh, size_t argc, char *argv[])
 {
+	struct bt_csip_set_member_set_info info;
 	uint8_t sirk[BT_CSIP_SIRK_SIZE];
 	int err;
 
 	if (cap_csip_svc_inst == NULL) {
-		shell_error(sh, "CSIS not registered");
+		shell_error(sh, "CSIS not registered yet");
 
 		return -ENOEXEC;
 	}
 
-	err = bt_csip_set_member_get_sirk(cap_csip_svc_inst, sirk);
+	err = bt_csip_set_member_get_info(cap_csip_svc_inst, &info);
 	if (err != 0) {
 		shell_error(sh, "Failed to get SIRK: %d", err);
 		return -ENOEXEC;
 	}
 
-	shell_print(sh, "SIRK");
+	shell_print(sh, "Info for %p", cap_csip_svc_inst);
+	shell_print(sh, "\tSIRK");
 	shell_hexdump(sh, sirk, sizeof(sirk));
+	shell_print(sh, "\tSet size: %u", info.set_size);
+	shell_print(sh, "\tRank: %u", info.rank);
+	shell_print(sh, "\tLockable: %s", info.lockable ? "true" : "false");
+	shell_print(sh, "\tLocked: %s", info.locked ? "true" : "false");
+	if (info.locked) {
+		char addr_str[BT_ADDR_LE_STR_LEN];
+
+		bt_addr_le_to_str(&info.lock_client_addr, addr_str, sizeof(addr_str));
+		shell_print(sh, "\tLock owner: %s", addr_str);
+	}
 
 	return 0;
 }
@@ -322,14 +334,12 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 	SHELL_CMD_ARG(release, NULL, "Release the set [force]", cmd_cap_acceptor_release, 1, 1),
 	SHELL_CMD_ARG(sirk, NULL, "Set the currently used SIRK <sirk>", cmd_cap_acceptor_sirk, 2,
 		      0),
-	SHELL_CMD_ARG(get_sirk, NULL, "Get the currently used SIRK", cmd_cap_acceptor_get_sirk, 1,
-		      0),
+	SHELL_CMD_ARG(get_info, NULL, "Get CSIS info", cmd_cap_acceptor_get_info, 1, 0),
 	SHELL_CMD_ARG(sirk_rsp, NULL,
 		      "Set the response used in SIRK requests "
 		      "<accept, accept_enc, reject, oob>",
 		      cmd_cap_acceptor_sirk_rsp, 2, 0),
-	SHELL_SUBCMD_SET_END
-);
+	SHELL_SUBCMD_SET_END);
 
 SHELL_CMD_ARG_REGISTER(cap_acceptor, &cap_acceptor_cmds, "Bluetooth CAP acceptor shell commands",
 		       cmd_cap_acceptor, 1, 1);

--- a/subsys/bluetooth/audio/shell/csip_set_member.c
+++ b/subsys/bluetooth/audio/shell/csip_set_member.c
@@ -258,7 +258,6 @@ static int cmd_csip_set_member_set_size_and_rank(const struct shell *sh, size_t 
 static int cmd_csip_set_member_get_info(const struct shell *sh, size_t argc, char *argv[])
 {
 	struct bt_csip_set_member_set_info info;
-	uint8_t sirk[BT_CSIP_SIRK_SIZE];
 	int err;
 
 	if (svc_inst == NULL) {
@@ -275,7 +274,7 @@ static int cmd_csip_set_member_get_info(const struct shell *sh, size_t argc, cha
 
 	shell_print(sh, "Info for %p", svc_inst);
 	shell_print(sh, "\tSIRK");
-	shell_hexdump(sh, sirk, sizeof(sirk));
+	shell_hexdump(sh, info.sirk, sizeof(info.sirk));
 	shell_print(sh, "\tSet size: %u", info.set_size);
 	shell_print(sh, "\tRank: %u", info.rank);
 	shell_print(sh, "\tLockable: %s", info.lockable ? "true" : "false");

--- a/tests/bsim/bluetooth/audio/src/csip_set_member_test.c
+++ b/tests/bsim/bluetooth/audio/src/csip_set_member_test.c
@@ -81,7 +81,7 @@ static void test_sirk(void)
 {
 	const uint8_t new_sirk[] = {0xff, 0xcc, 0x72, 0xdd, 0x86, 0x8c, 0xcd, 0xce,
 				    0x22, 0xfd, 0xa1, 0x21, 0x09, 0x7d, 0x7d, 0x45};
-	uint8_t tmp_sirk[BT_CSIP_SIRK_SIZE];
+	struct bt_csip_set_member_set_info info;
 	int err;
 
 	printk("Setting new SIRK\n");
@@ -92,14 +92,14 @@ static void test_sirk(void)
 	}
 
 	printk("Getting new SIRK\n");
-	err = bt_csip_set_member_get_sirk(svc_inst, tmp_sirk);
+	err = bt_csip_set_member_get_info(svc_inst, &info);
 	if (err != 0) {
 		FAIL("Failed to get SIRK: %d\n", err);
 		return;
 	}
 
-	if (memcmp(new_sirk, tmp_sirk, BT_CSIP_SIRK_SIZE) != 0) {
-		FAIL("The SIRK set and the SIRK set were different\n");
+	if (memcmp(new_sirk, info.sirk, BT_CSIP_SIRK_SIZE) != 0) {
+		FAIL("The SIRK set and the set SIRK were different\n");
 		return;
 	}
 


### PR DESCRIPTION
The bt_csip_set_member_get_sirk function is superseded by bt_csip_set_member_get_info and uses of it has been replaced.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/86991