### PR TITLE
manifest: microchip: Update Microchip HAL to latest MEC5 changes

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -188,7 +188,7 @@ manifest:
       groups:
         - hal
     - name: hal_microchip
-      revision: 8ea892e6ade63b0b20f9adc76cb5fea774eba3a3
+      revision: 15ca19705e4bff2d147a2a13d0198fcf8e4c8b4a
       path: modules/hal/microchip
       groups:
         - hal


### PR DESCRIPTION
We updated the MEC5 portion of hal_microchip. Update Zephyr west manifest to use the updated HAL.