### PR TITLE
linker: Allow for 999 priority levels in init levels

### DIFF
--- a/cmake/linker/iar/config_file_script.cmake
+++ b/cmake/linker/iar/config_file_script.cmake
@@ -649,7 +649,7 @@ function(section_to_string)
       set(TEMP "${TEMP} { section ${first_index_section_name} },\n")
     endif()
 
-    # block init_100 with alphabetical order { section .z_init_EARLY?_}
+    # block init_100 with alphabetical order { section .z_init_EARLY_?_}
     set(TEMP "${TEMP}\n  block ${name_clean}_${idx}")
     if(DEFINED offset AND NOT offset EQUAL 0 )
       list(APPEND block_attr "size = ${offset}")

--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -5240,8 +5240,8 @@ endfunction()
 # This is useful content such as struct devices.
 #
 # For example: zephyr_linker_section_obj_level(SECTION init LEVEL PRE_KERNEL_1)
-# will create an input section matching `.z_init_PRE_KERNEL_1_?_` and
-# `.z_init_PRE_KERNEL_1_??_`.
+# will create an input section matching `.z_init_PRE_KERNEL_1_?_`,
+# `.z_init_PRE_KERNEL_1_??_`, and `.z_init_PRE_KERNEL_1_???_`.
 #
 # SECTION <section>: Section in which the objects shall be placed
 # LEVEL <level>    : Priority level, all input sections matching the level
@@ -5272,6 +5272,11 @@ function(zephyr_linker_section_obj_level)
   zephyr_linker_section_configure(
     SECTION ${OBJ_SECTION}
     INPUT ".z_${OBJ_SECTION}_${OBJ_LEVEL}_??_*"
+    KEEP SORT NAME
+  )
+  zephyr_linker_section_configure(
+    SECTION ${OBJ_SECTION}
+    INPUT ".z_${OBJ_SECTION}_${OBJ_LEVEL}_???_*"
     KEEP SORT NAME
   )
 endfunction()

--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -5240,8 +5240,8 @@ endfunction()
 # This is useful content such as struct devices.
 #
 # For example: zephyr_linker_section_obj_level(SECTION init LEVEL PRE_KERNEL_1)
-# will create an input section matching `.z_init_PRE_KERNEL_1?_` and
-# `.z_init_PRE_KERNEL_1??_`.
+# will create an input section matching `.z_init_PRE_KERNEL_1_?_` and
+# `.z_init_PRE_KERNEL_1_??_`.
 #
 # SECTION <section>: Section in which the objects shall be placed
 # LEVEL <level>    : Priority level, all input sections matching the level
@@ -5265,13 +5265,13 @@ function(zephyr_linker_section_obj_level)
 
   zephyr_linker_section_configure(
     SECTION ${OBJ_SECTION}
-    INPUT ".z_${OBJ_SECTION}_${OBJ_LEVEL}?_*"
+    INPUT ".z_${OBJ_SECTION}_${OBJ_LEVEL}_?_*"
     SYMBOLS __${OBJ_SECTION}_${OBJ_LEVEL}_start
     KEEP SORT NAME
   )
   zephyr_linker_section_configure(
     SECTION ${OBJ_SECTION}
-    INPUT ".z_${OBJ_SECTION}_${OBJ_LEVEL}??_*"
+    INPUT ".z_${OBJ_SECTION}_${OBJ_LEVEL}_??_*"
     KEEP SORT NAME
   )
 endfunction()

--- a/doc/kernel/drivers/index.rst
+++ b/doc/kernel/drivers/index.rst
@@ -366,7 +366,7 @@ initialization levels:
 
 Within each initialization level you may specify a priority level, relative to
 other devices in the same initialization level. The priority level is specified
-as an integer value in the range 0 to 99; lower values indicate earlier
+as an integer value in the range 0 to 999; lower values indicate earlier
 initialization.  The priority level must be a decimal integer literal without
 leading zeroes or sign (e.g. 32), or an equivalent symbolic name (e.g.
 ``\#define MY_INIT_PRIO 32``); symbolic expressions are *not* permitted (e.g.

--- a/include/zephyr/init.h
+++ b/include/zephyr/init.h
@@ -108,9 +108,9 @@ struct init_entry {
  * linker scripts to sort them according to the specified
  * level/priority/sub-priority.
  */
-#define Z_INIT_ENTRY_SECTION(level, prio, sub_prio)                           \
-	__attribute__((__section__(                                           \
-		".z_init_" #level STRINGIFY(prio)"_" STRINGIFY(sub_prio)"_")))
+#define Z_INIT_ENTRY_SECTION(level, prio, sub_prio)                                                \
+	__attribute__((                                                                            \
+		__section__(".z_init_" #level "_" STRINGIFY(prio)"_" STRINGIFY(sub_prio)"_")))
 
 /** @endcond */
 

--- a/include/zephyr/init.h
+++ b/include/zephyr/init.h
@@ -41,7 +41,7 @@ extern "C" {
  * - `SMP`: Only available if @kconfig{CONFIG_SMP} is enabled, specific for
  *   SMP.
  *
- * Initialization priority can take a value in the range of 0 to 99.
+ * Initialization priority can take a value in the range of 0 to 999.
  *
  * @note The same infrastructure is used by devices.
  * @{

--- a/include/zephyr/linker/devicetree_regions.h
+++ b/include/zephyr/linker/devicetree_regions.h
@@ -211,6 +211,7 @@
  *
  * @param node_id devicetree node identifier
  */
+/* clang-format off */
 #define _SECTION_DECLARE(node_id)								\
 	LINKER_DT_NODE_REGION_NAME_TOKEN(node_id) (NOLOAD) :					\
 	{											\
@@ -221,6 +222,7 @@
 	} > LINKER_DT_NODE_REGION_NAME_TOKEN(node_id)						\
 	_DT_SECTION_SIZE(node_id) = _DT_SECTION_END(node_id) - _DT_SECTION_START(node_id);	\
 	_DT_SECTION_LOAD(node_id) = LOADADDR(LINKER_DT_NODE_REGION_NAME_TOKEN(node_id));
+/* clang-format on */
 
 /** @endcond */
 

--- a/include/zephyr/linker/iterable_sections.h
+++ b/include/zephyr/linker/iterable_sections.h
@@ -12,6 +12,7 @@
  * @{
  */
 
+/* clang-format off */
 #define Z_LINK_ITERABLE(struct_type) \
 	_CONCAT(_##struct_type, _list_start) = .; \
 	KEEP(*(SORT_BY_NAME(._##struct_type.static.*))); \
@@ -34,6 +35,7 @@
 	_CONCAT(_##struct_type, _list_start) = .; \
 	*(SORT_BY_NAME(._##struct_type.static.*)); \
 	_CONCAT(_##struct_type, _list_end) = .
+/* clang-format on */
 
 #define Z_LINK_ITERABLE_SUBALIGN CONFIG_LINKER_ITERABLE_SUBALIGN
 

--- a/include/zephyr/linker/linker-defs.h
+++ b/include/zephyr/linker/linker-defs.h
@@ -44,10 +44,12 @@
  * (sorted by priority). Ensure the objects aren't discarded if there is
  * no direct reference to them
  */
+/* clang-format off */
 #define CREATE_OBJ_LEVEL(object, level)				\
 		__##object##_##level##_start = .;		\
 		KEEP(*(SORT(.z_##object##_##level?_*)));	\
 		KEEP(*(SORT(.z_##object##_##level??_*)));
+/* clang-format on */
 
 /*
  * link in shell initialization objects for all modules that use shell and

--- a/include/zephyr/linker/linker-defs.h
+++ b/include/zephyr/linker/linker-defs.h
@@ -47,8 +47,8 @@
 /* clang-format off */
 #define CREATE_OBJ_LEVEL(object, level)				\
 		__##object##_##level##_start = .;		\
-		KEEP(*(SORT(.z_##object##_##level?_*)));	\
-		KEEP(*(SORT(.z_##object##_##level??_*)));
+		KEEP(*(SORT(.z_##object##_##level##_?_*)));	\
+		KEEP(*(SORT(.z_##object##_##level##_??_*)));
 /* clang-format on */
 
 /*

--- a/include/zephyr/linker/linker-defs.h
+++ b/include/zephyr/linker/linker-defs.h
@@ -48,7 +48,8 @@
 #define CREATE_OBJ_LEVEL(object, level)				\
 		__##object##_##level##_start = .;		\
 		KEEP(*(SORT(.z_##object##_##level##_?_*)));	\
-		KEEP(*(SORT(.z_##object##_##level##_??_*)));
+		KEEP(*(SORT(.z_##object##_##level##_??_*)));	\
+		KEEP(*(SORT(.z_##object##_##level##_???_*)));
 /* clang-format on */
 
 /*

--- a/tests/kernel/device/src/main.c
+++ b/tests/kernel/device/src/main.c
@@ -270,10 +270,11 @@ SYS_INIT(init_fn, APPLICATION, 0);
 SYS_INIT_NAMED(init1, init_fn, APPLICATION, 1);
 SYS_INIT_NAMED(init2, init_fn, APPLICATION, 2);
 SYS_INIT_NAMED(init3, init_fn, APPLICATION, 2);
+SYS_INIT_NAMED(init4, init_fn, APPLICATION, 99);
 
 ZTEST(device, test_sys_init_multiple)
 {
-	zassert_equal(sys_init_counter, 4, "");
+	zassert_equal(sys_init_counter, 5, "");
 }
 
 /* this is for storing sequence during initialization */

--- a/tests/kernel/device/src/main.c
+++ b/tests/kernel/device/src/main.c
@@ -271,10 +271,11 @@ SYS_INIT_NAMED(init1, init_fn, APPLICATION, 1);
 SYS_INIT_NAMED(init2, init_fn, APPLICATION, 2);
 SYS_INIT_NAMED(init3, init_fn, APPLICATION, 2);
 SYS_INIT_NAMED(init4, init_fn, APPLICATION, 99);
+SYS_INIT_NAMED(init5, init_fn, APPLICATION, 999);
 
 ZTEST(device, test_sys_init_multiple)
 {
-	zassert_equal(sys_init_counter, 5, "");
+	zassert_equal(sys_init_counter, 6, "");
 }
 
 /* this is for storing sequence during initialization */


### PR DESCRIPTION
Some projects may have needs for more than 99 priority levels, so add a third linker input section for each obj level.