### PR TITLE
misc: Remove invalid extern "C" linkage for main

### DIFF
--- a/include/zephyr/types.h
+++ b/include/zephyr/types.h
@@ -48,11 +48,26 @@ typedef union {
 #endif /* Z_THREAD_LOCAL */
 
 #ifdef __cplusplus
-/* Zephyr requires an int main(void) signature with C linkage for the application main if present */
+
+#if (!__STDC_HOSTED__)
+/*
+ * Zephyr requires an int main(void) signature with C linkage for the
+ * application main if present. gcc, and clang when building in 'hosted' mode
+ * will correctly assume this. But, when building freestanding, clang does not
+ * treat main() specially, and by default name mangles its symbol, which
+ * results in the linker not linking from the kernel init code into this
+ * name mangled app main().
+ *
+ * At the same time, according to the C++ standard Section 6.9.3.1 of
+ * ISO/IEC 14882:2024, main cannot be explicitly declared to have "C" linkage.
+ * This restriction is relaxed for freestanding code, as main is not treated
+ * specially in these circumstances.
+ * Therefore, let's include the prototype when we are not building the code as
+ * freestanding/not-hosted.
+ */
 extern int main(void);
 #endif
 
-#ifdef __cplusplus
 }
 #endif
 


### PR DESCRIPTION
`extern "C"` is not a valid language linkage for declaring `int main(...)`, as per the ISO C++ Standard Specification. This fixes the violations of -Wmain, and brings Zephyr closer to valid C++.
    
See the C++ standard wording here:
https://eel.is/c++draft/basic.start.main#3.sentence-5
    
See also the clang warning -Wmain:
https://clang.llvm.org/docs/DiagnosticsReference.html#wmain
    
This only applies to C++ as these linkage declarations only exist inside `__cplusplus` guards.

Signed-off-by: Jordan R Abrahams-Whitehead <ajordanr@google.com>