### PR TITLE
tests: spi_loopback: Fix frdm_ke17z overlay

### DIFF
--- a/tests/drivers/spi/spi_loopback/boards/frdm_ke17z.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/frdm_ke17z.overlay
@@ -9,14 +9,14 @@
  */
 
 &lpspi0 {
-	slow@0 {
+	slow@1 {
 		compatible = "test-spi-loopback-slow";
-		reg = <0>;
+		reg = <1>;
 		spi-max-frequency = <500000>;
 	};
-	fast@0 {
+	fast@1 {
 		compatible = "test-spi-loopback-fast";
-		reg = <0>;
+		reg = <1>;
 		spi-max-frequency = <16000000>;
 	};
 };

--- a/tests/drivers/spi/spi_loopback/boards/frdm_ke17z512.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/frdm_ke17z512.overlay
@@ -9,14 +9,14 @@
  */
 
 &lpspi0 {
-	slow@0 {
+	slow@2 {
 		compatible = "test-spi-loopback-slow";
-		reg = <0>;
+		reg = <2>;
 		spi-max-frequency = <500000>;
 	};
-	fast@0 {
+	fast@2 {
 		compatible = "test-spi-loopback-fast";
-		reg = <0>;
+		reg = <2>;
 		spi-max-frequency = <16000000>;
 	};
 };


### PR DESCRIPTION
The ke17z overlay for this test is incorrect in that the chip select line sent to the spi pins on the header is PCS1, not PCS0. This is having no functional effect on the test right now but soon I am trying to implement a chip select test, and regardless it helps to have the CS actually toggle right now for debugging purposes.

Also, I checked the frdm_ke17z512 and it looks like the board pinctrl file is configuring for PCS2, so I fixed that as well because it looks also like the same mistake, but I don't have that hardware.