### PR TITLE
tests: thread_metric: Fix cooperative for SMP

### DIFF
--- a/tests/benchmarks/thread_metric/src/tm_cooperative_scheduling_test.c
+++ b/tests/benchmarks/thread_metric/src/tm_cooperative_scheduling_test.c
@@ -80,13 +80,14 @@ int main(void)
 
 void tm_cooperative_scheduling_initialize(void)
 {
+	int prio = CONFIG_MAIN_THREAD_PRIORITY;
 
-	/* Create all 5 threads at priority 3.  */
-	tm_thread_create(0, 3, tm_cooperative_thread_0_entry);
-	tm_thread_create(1, 3, tm_cooperative_thread_1_entry);
-	tm_thread_create(2, 3, tm_cooperative_thread_2_entry);
-	tm_thread_create(3, 3, tm_cooperative_thread_3_entry);
-	tm_thread_create(4, 3, tm_cooperative_thread_4_entry);
+	/* Create all 5 threads at the same priority as the main thread.  */
+	tm_thread_create(0, prio, tm_cooperative_thread_0_entry);
+	tm_thread_create(1, prio, tm_cooperative_thread_1_entry);
+	tm_thread_create(2, prio, tm_cooperative_thread_2_entry);
+	tm_thread_create(3, prio, tm_cooperative_thread_3_entry);
+	tm_thread_create(4, prio, tm_cooperative_thread_4_entry);
 
 	/* Resume all 5 threads.  */
 	tm_thread_resume(0);


### PR DESCRIPTION
The thread metric cooperative benchmark had a subtle flaw on SMP enabled systems. The reporting/main thread was running at a higher priority than the "cooperative" threads. When that reporting thread woke up from its 30 second sleep, there was a chance that it would change the ordering of the "cooperative" threads before the test expected it.

This ordering change is not present on UP systems as the current thread is always in the ready queue. However, on SMP systems the current thread is not in the ready queue and is re-added to the end of the list when it is preempted by a higher priority thread.

To work around this, we make the priority of the main/reporting thread to be the same as the "cooperative" threads. Thus when the reporting thread wakes, it is added to the end of list and no longer introduces an unexpected schedule point.