### PR TITLE
Revert "manifest: nrf_wifi: Pull in change to include reg chan info"

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -321,7 +321,7 @@ manifest:
       revision: b84bd7314a239f818e78f6927f5673247816df53
       path: modules/bsim_hw_models/nrf_hw_models
     - name: nrf_wifi
-      revision: 0cd3bb2291a7dd22f4cdb1a4cd935a213c2bbfab
+      revision: 396059ca7a6162d07276c5797adbb1311b81cd78
       path: modules/lib/nrf_wifi
     - name: open-amp
       revision: 52bb1783521c62c019451cee9b05b8eda9d7425f


### PR DESCRIPTION
This reverts commit a34198b2a243334f63cf8487bae19a7105f10fc1
Causes "'struct nrf_wifi_off_raw_tx_fmac_dev_ctx' has no member named 'country_code'" compilation error in CI on
nrf7002dk_nrf5340_cpuapp

Fixes: #87079