### PR TITLE
drivers: stepper: minor kconfig corrections

### DIFF
--- a/drivers/stepper/Kconfig.gpio
+++ b/drivers/stepper/Kconfig.gpio
@@ -5,4 +5,5 @@
 config GPIO_STEPPER
 	bool "Activate driver for gpio stepper control"
 	depends on DT_HAS_ZEPHYR_GPIO_STEPPER_ENABLED
+	select GPIO
 	default y

--- a/drivers/stepper/ti/Kconfig
+++ b/drivers/stepper/ti/Kconfig
@@ -1,8 +1,14 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024 Navimatix GmbH
 # SPDX-License-Identifier: Apache-2.0
 
-config STEPPER_TI
+menuconfig STEPPER_TI
 	bool
 	depends on STEPPER
 
+if STEPPER_TI
+
+comment "TI Stepper Drivers"
+
 rsource "Kconfig.drv8424"
+
+endif # STEPPER_TI

--- a/drivers/stepper/ti/Kconfig.drv8424
+++ b/drivers/stepper/ti/Kconfig.drv8424
@@ -5,7 +5,7 @@ config DRV8424
 	bool "TI DRV8424 stepper motor driver"
 	default y
 	depends on DT_HAS_TI_DRV8424_ENABLED
-	select STEPPER_TI
+	select GPIO
 	select STEP_DIR_STEPPER
 	select STEPPER_STEP_DIR_GENERATE_ISR_SAFE_EVENTS
 	help

--- a/tests/drivers/stepper/stepper_api/testcase.yaml
+++ b/tests/drivers/stepper/stepper_api/testcase.yaml
@@ -21,9 +21,8 @@ tests:
       - platform:native_sim/native/64:DTC_OVERLAY_FILE="boards/native_sim_ti_drv8424.overlay"
       - platform:nucleo_f767zi/stm32f767xx:DTC_OVERLAY_FILE="boards/nucleo_f767zi_ti_drv8424.overlay"
     extra_configs:
-      - CONFIG_GPIO=y
       - CONFIG_COUNTER=y
-      - CONFIG_STEPPER_STEP_DIR_GENERATE_ISR_SAFE_EVENTS=y
+      - CONFIG_STEPPER_TI=y
     platform_allow:
       - native_sim/native/64
       - nucleo_f767zi/stm32f767xx
@@ -32,8 +31,6 @@ tests:
       - platform:native_sim/native/64:DTC_OVERLAY_FILE="boards/native_sim_zephyr_gpio_stepper.overlay"
       - platform:nucleo_g071rb/stm32g071xx:DTC_OVERLAY_FILE="boards/nucleo_g071rb_zephyr_gpio_stepper.overlay"
       - platform:qemu_x86_64/atom:DTC_OVERLAY_FILE="boards/qemu_x86_64_zephyr_gpio_stepper.overlay"
-    extra_configs:
-      - CONFIG_GPIO=y
     platform_allow:
       - native_sim/native/64
       - nucleo_g071rb/stm32g071xx


### PR DESCRIPTION
TI DRV8424 and zephyr gpio-stepper can be triggered only via GPIO hence adding select GPIO in driver kconfigs.

##### Note:

We have a mixed pattern on how we use kconfigs, trying to address this issue through this PR.