### PR TITLE
MAINTAINERS: add jbehrensnx as collaborator in stepper driver subsystem

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -2129,6 +2129,7 @@ Release Notes:
     - dipakgmx
     - fabiobaltieri
     - faxe1008
+    - jbehrensnx
   files:
     - drivers/stepper/
     - include/zephyr/drivers/stepper.h


### PR DESCRIPTION
In regards to the contributions to stepper driver subsystem, i would like to propose Jan Behrens as collaborator in stepper driver subsystem

@jbehrensnx Your approval is required :-)