### PR TITLE
fs: zms: Clarify that the file system needs re-mounting after "clearing"

### DIFF
--- a/include/zephyr/fs/zms.h
+++ b/include/zephyr/fs/zms.h
@@ -92,7 +92,8 @@ struct zms_fs {
 int zms_mount(struct zms_fs *fs);
 
 /**
- * @brief Clear the ZMS file system from device.
+ * @brief Clear the ZMS file system from device. The ZMS file system must be re-mounted after this
+ * operation.
  *
  * @param fs Pointer to the file system.
  *


### PR DESCRIPTION
It was not clear that zms_clear both cleared and unmounted the fs.