### PR TITLE
bluetooth: host: Remove experimental flag from LE Connection Subrating

### DIFF
--- a/doc/releases/release-notes-4.2.rst
+++ b/doc/releases/release-notes-4.2.rst
@@ -85,6 +85,8 @@ New APIs and options
 
     * :c:func:`bt_le_get_local_features`
 
+    * LE Connection Subrating is no longer experimental.
+
 New Boards
 **********
 

--- a/subsys/bluetooth/Kconfig
+++ b/subsys/bluetooth/Kconfig
@@ -182,8 +182,7 @@ config BT_PATH_LOSS_MONITORING
 	  Bluetooth Core specification, Version 5.4 | Vol 6, Part B, Section 4.6.32.
 
 config BT_SUBRATING
-	bool "LE Connection Subrating [EXPERIMENTAL]"
-	select EXPERIMENTAL
+	bool "LE Connection Subrating"
 	depends on !HAS_BT_CTLR || BT_CTLR_SUBRATING_SUPPORT
 	help
 	  Enable support for LE Connection Subrating feature that is defined in the


### PR DESCRIPTION
The API has not changed since it was introduced so should no longer be considered experimental.