### PR TITLE
manifest: nrf_wifi: Pull fix for CI failure

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -321,7 +321,7 @@ manifest:
       revision: b84bd7314a239f818e78f6927f5673247816df53
       path: modules/bsim_hw_models/nrf_hw_models
     - name: nrf_wifi
-      revision: 0cd3bb2291a7dd22f4cdb1a4cd935a213c2bbfab
+      revision: pull/32/head
       path: modules/lib/nrf_wifi
     - name: open-amp
       revision: 52bb1783521c62c019451cee9b05b8eda9d7425f


### PR DESCRIPTION
Pull in fix for CI failure in Offloaded raw TX mode caused due to commit 0cd3bb2291a7dd22f4cdb1a4cd935a213c2bbfab in nrf_wifi