### PR TITLE
drivers: entropy: mcux_trng: Add PM device action

### DIFF
--- a/drivers/entropy/entropy_mcux_trng.c
+++ b/drivers/entropy/entropy_mcux_trng.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2017 Linaro Limited.
+ * Copyright 2025 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -9,6 +10,7 @@
 #include <zephyr/device.h>
 #include <zephyr/drivers/entropy.h>
 #include <zephyr/random/random.h>
+#include <zephyr/pm/device.h>
 #include <zephyr/init.h>
 
 #include "fsl_trng.h"
@@ -53,8 +55,29 @@ static int entropy_mcux_trng_init(const struct device *dev)
 	return 0;
 }
 
+#ifdef CONFIG_PM_DEVICE
+static int entropy_mcux_trng_pm_action(const struct device *dev, enum pm_device_action action)
+{
+	switch (action) {
+	case PM_DEVICE_ACTION_RESUME:
+		break;
+	case PM_DEVICE_ACTION_SUSPEND:
+		break;
+	case PM_DEVICE_ACTION_TURN_OFF:
+		break;
+	case PM_DEVICE_ACTION_TURN_ON:
+		entropy_mcux_trng_init(dev);
+		break;
+	default:
+		return -ENOTSUP;
+	}
+	return 0;
+}
+#endif /*CONFIG_PM_DEVICE*/
+
+PM_DEVICE_DT_INST_DEFINE(0, entropy_mcux_trng_pm_action);
 DEVICE_DT_INST_DEFINE(0,
-		    entropy_mcux_trng_init, NULL, NULL,
+		    entropy_mcux_trng_init, PM_DEVICE_DT_INST_GET(0), NULL,
 		    &entropy_mcux_config,
 		    PRE_KERNEL_1, CONFIG_ENTROPY_INIT_PRIORITY,
 		    &entropy_mcux_trng_api_funcs);


### PR DESCRIPTION
The entropy driver shall re-init trng when
a power state turns off the device.