### PR TITLE
samples: dac: sam: Add missing pin configuration for sam_v71_xult

### DIFF
--- a/samples/drivers/dac/boards/sam_v71_xult_samv71q21.overlay
+++ b/samples/drivers/dac/boards/sam_v71_xult_samv71q21.overlay
@@ -5,3 +5,17 @@
 		dac-resolution = <12>;
 	};
 };
+
+&dacc{
+	status = "okay";
+	pinctrl-0 = <&dac_default>;
+	pinctrl-names = "default";
+};
+
+&pinctrl{
+	dac_default: dac_default{
+		group1 {
+			pinmux = <PB13X_DACC_DAC0>;
+		};
+	};
+};

--- a/samples/drivers/dac/boards/sam_v71_xult_samv71q21b.overlay
+++ b/samples/drivers/dac/boards/sam_v71_xult_samv71q21b.overlay
@@ -5,3 +5,17 @@
 		dac-resolution = <12>;
 	};
 };
+
+&dacc{
+	status = "okay";
+	pinctrl-0 = <&dac_default>;
+	pinctrl-names = "default";
+};
+
+&pinctrl{
+	dac_default: dac_default{
+		group1 {
+			pinmux = <PB13X_DACC_DAC0>;
+		};
+	};
+};


### PR DESCRIPTION
DAC pins are not defined for SAM V71(B) Xplained Ultra - this was causing device initialization to fail. This commit fixes that.