### PR TITLE
ci: Use Ubuntu 24 in GH actions

### DIFF
--- a/.github/workflows/scripts_tests.yml
+++ b/.github/workflows/scripts_tests.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.10', '3.11', '3.12', '3.13']
-        os: [ubuntu-20.04]
+        os: [ubuntu-24.04]
     steps:
       - name: checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Ubuntu 20.04 will be deprecated soon