### PR TITLE
ci: set_assignee: don't always pick next area when submitter = assignee

### DIFF
--- a/scripts/set_assignees.py
+++ b/scripts/set_assignees.py
@@ -136,7 +136,13 @@ def process_pr(gh, maintainer_file, number):
             if pr.user.login in area.maintainers:
                 # submitter = assignee, try to pick next area and
                 # assign someone else other than the submitter
-                continue
+                # when there also other maintainers for the area
+                # assign them
+                if len(area.maintainers) > 1:
+                    assignees = area.maintainers.copy()
+                    assignees.remove(pr.user.login)
+                else:
+                    continue
             else:
                 assignees = area.maintainers
 


### PR DESCRIPTION
we don't want to pick the next area when there
are other maintainers available in the same area.

Usefull for areas with more than one maintainer, like Networking.