### PR TITLE
mcumgr/img_mgmt: Allow erase pending image by default

### DIFF
--- a/subsys/mgmt/mcumgr/grp/img_mgmt/Kconfig
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt/Kconfig
@@ -85,6 +85,7 @@ config MCUMGR_GRP_IMG_ALLOW_CONFIRM_NON_ACTIVE_IMAGE_ANY
 if !MCUBOOT_BOOTLOADER_MODE_DIRECT_XIP
 config MCUMGR_GRP_IMG_ALLOW_ERASE_PENDING
 	bool "Allow to erase pending slot"
+	default y
 	help
 	  Allows erasing secondary slot which is marked for test or confirmed; this allows
 	  erasing slots that have been set for next boot but the device has not


### PR DESCRIPTION
Allows erasing secondary slot which is marked for test or confirmed. This is safe as bootloader doesn't make any action on boot-setup yet.

Erase of such pending image might considered like the case when it was never downloaded as well.

This allow user to not stuck with pending irremovable image.