### PR TITLE
sample: nvs: add NVS sample Kconfig

### DIFF
--- a/samples/subsys/nvs/Kconfig
+++ b/samples/subsys/nvs/Kconfig
@@ -1,0 +1,28 @@
+# Copyright 2025 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+mainmenu "NVS Sample Configuration"
+
+config NVS_SAMPLE_MAX_REBOOT
+	int "Maximum reboot counter value"
+	default 5
+	range 1 1000
+	help
+	  Maximum number of reboots to perform before resetting the counter.
+
+config NVS_SAMPLE_REBOOT_COUNTDOWN
+	int "Reboot countdown value (in iterations)"
+	default 5
+	range 1 60
+	help
+	  Number of countdown iterations to wait before rebooting the device.
+	  Each iteration takes NVS_SAMPLE_SLEEP_TIME milliseconds.
+
+config NVS_SAMPLE_SLEEP_TIME
+	int "Sleep time between reboot countdown iterations (in milliseconds)"
+	default 100
+	range 10 10000
+	help
+	  Duration in milliseconds to sleep between reboot countdown iterations.
+
+source "Kconfig.zephyr"

--- a/samples/subsys/nvs/src/main.c
+++ b/samples/subsys/nvs/src/main.c
@@ -52,12 +52,6 @@ static struct nvs_fs fs;
 #define NVS_PARTITION_DEVICE	FIXED_PARTITION_DEVICE(NVS_PARTITION)
 #define NVS_PARTITION_OFFSET	FIXED_PARTITION_OFFSET(NVS_PARTITION)
 
-/* 1000 msec = 1 sec */
-#define SLEEP_TIME      100
-/* maximum reboot counts, make high enough to trigger sector change (buffer */
-/* rotation). */
-#define MAX_REBOOT 400
-
 #define ADDRESS_ID 1
 #define KEY_ID 2
 #define RBT_CNT_ID 3
@@ -192,11 +186,11 @@ int main(void)
 		}
 	}
 
-	cnt = 5;
+	cnt = CONFIG_NVS_SAMPLE_REBOOT_COUNTDOWN;
 	while (1) {
-		k_msleep(SLEEP_TIME);
-		if (reboot_counter < MAX_REBOOT) {
-			if (cnt == 5) {
+		k_msleep(CONFIG_NVS_SAMPLE_SLEEP_TIME);
+		if (reboot_counter < CONFIG_NVS_SAMPLE_MAX_REBOOT) {
+			if (cnt == CONFIG_NVS_SAMPLE_REBOOT_COUNTDOWN) {
 				/* print some history information about
 				 * the reboot counter
 				 * Check the counter history in flash
@@ -230,7 +224,7 @@ int main(void)
 				(void)nvs_write(
 					&fs, RBT_CNT_ID, &reboot_counter,
 					sizeof(reboot_counter));
-				if (reboot_counter == MAX_REBOOT) {
+				if (reboot_counter == CONFIG_NVS_SAMPLE_MAX_REBOOT) {
 					printk("Doing last reboot...\n");
 				}
 				sys_reboot(0);


### PR DESCRIPTION
- adds the ability to change the NVS sample "Maximum reboot counter", "Reboot countdown" and its "Sleep time" parameters via Kconfig, without manually modifying the source code.
- reduces the default number of resets to 5 (was 400).
- adds the ability to reduce flash memory wear on real devices  by reducing the number of write iterations.
