### PR TITLE
Bluetooth: BR: Add a function bt_br_bond_exists()

### DIFF
--- a/doc/releases/release-notes-4.2.rst
+++ b/doc/releases/release-notes-4.2.rst
@@ -85,6 +85,7 @@ New APIs and options
 
     * :c:func:`bt_le_get_local_features`
     * :c:func:`bt_le_bond_exists`
+    * :c:func:`bt_br_bond_exists`
 
 New Boards
 **********

--- a/include/zephyr/bluetooth/classic/classic.h
+++ b/include/zephyr/bluetooth/classic/classic.h
@@ -201,6 +201,14 @@ int bt_br_set_discoverable(bool enable, bool limited);
  */
 int bt_br_set_connectable(bool enable);
 
+/** @brief Check if a Bluetooth classic device address is bonded.
+ *
+ *  @param addr Bluetooth classic device address.
+ *
+ *  @return true if @p addr is bonded
+ */
+bool bt_br_bond_exists(const bt_addr_t *addr);
+
 /**
  * @}
  */

--- a/subsys/bluetooth/host/classic/br.c
+++ b/subsys/bluetooth/host/classic/br.c
@@ -1233,3 +1233,11 @@ int bt_br_set_discoverable(bool enable, bool limited)
 
 	return 0;
 }
+
+bool bt_br_bond_exists(const bt_addr_t *addr)
+{
+	struct bt_keys_link_key *key = bt_keys_find_link_key(addr);
+
+	/* if there are any keys stored then device is bonded */
+	return key != NULL;
+}


### PR DESCRIPTION
Add a function `bt_br_bond_exists()` to check if the address of the classic device has been bonded.