### PR TITLE
tests: Bluetooth: Tester: Fix bad memset in btb_bap_broadcast

### DIFF
--- a/tests/bluetooth/tester/src/audio/btp_bap_broadcast.c
+++ b/tests/bluetooth/tester/src/audio/btp_bap_broadcast.c
@@ -89,7 +89,7 @@ static int btp_bap_broadcast_local_source_free(struct btp_bap_broadcast_local_so
 		return -EINVAL;
 	}
 
-	memset(&source, 0, sizeof(*source));
+	memset(source, 0, sizeof(*source));
 
 	return 0;
 }


### PR DESCRIPTION
btp_bap_broadcast_local_source_free used &source, but since source was already a pointer, it should just use source.