### PR TITLE
usb: device: use the user configured endpoint addr

### DIFF
--- a/subsys/usb/device/usb_descriptor.c
+++ b/subsys/usb/device/usb_descriptor.c
@@ -243,58 +243,26 @@ int usb_get_str_descriptor_idx(void *ptr)
  * Validate endpoint address and Update the endpoint descriptors at runtime,
  * the result depends on the capabilities of the driver and the number and
  * type of endpoints.
- * The default endpoint address is stored in endpoint descriptor and
- * usb_ep_cfg_data, so both variables bEndpointAddress and ep_addr need
- * to be updated.
  */
 static int usb_validate_ep_cfg_data(struct usb_ep_descriptor * const ep_descr,
-				    struct usb_cfg_data * const cfg_data,
-				    uint32_t *requested_ep)
+				    struct usb_cfg_data * const cfg_data)
 {
-	for (unsigned int i = 0; i < cfg_data->num_endpoints; i++) {
-		struct usb_ep_cfg_data *ep_data = cfg_data->endpoint;
+	struct usb_ep_cfg_data *ep_data = cfg_data->endpoint;
 
-		/*
-		 * Trying to find the right entry in the usb_ep_cfg_data.
-		 */
+	for (unsigned int i = 0; i < cfg_data->num_endpoints; i++) {
 		if (ep_descr->bEndpointAddress != ep_data[i].ep_addr) {
 			continue;
 		}
 
-		for (uint8_t idx = 1; idx < 16U; idx++) {
-			struct usb_dc_ep_cfg_data ep_cfg;
+		struct usb_dc_ep_cfg_data ep_cfg;
 
-			ep_cfg.ep_type = (ep_descr->bmAttributes &
-					  USB_EP_TRANSFER_TYPE_MASK);
-			ep_cfg.ep_mps = sys_le16_to_cpu(ep_descr->wMaxPacketSize);
-			ep_cfg.ep_addr = ep_descr->bEndpointAddress;
-			if (ep_cfg.ep_addr & USB_EP_DIR_IN) {
-				if ((*requested_ep & (1U << (idx + 16U)))) {
-					continue;
-				}
+		ep_cfg.ep_type = (ep_descr->bmAttributes & USB_EP_TRANSFER_TYPE_MASK);
+		ep_cfg.ep_mps = sys_le16_to_cpu(ep_descr->wMaxPacketSize);
+		ep_cfg.ep_addr = ep_descr->bEndpointAddress;
 
-				ep_cfg.ep_addr = (USB_EP_DIR_IN | idx);
-			} else {
-				if ((*requested_ep & (1U << (idx)))) {
-					continue;
-				}
-
-				ep_cfg.ep_addr = idx;
-			}
-			if (!usb_dc_ep_check_cap(&ep_cfg)) {
-				LOG_DBG("Fixing EP address %x -> %x",
-					ep_descr->bEndpointAddress,
-					ep_cfg.ep_addr);
-				ep_descr->bEndpointAddress = ep_cfg.ep_addr;
-				ep_data[i].ep_addr = ep_cfg.ep_addr;
-				if (ep_cfg.ep_addr & USB_EP_DIR_IN) {
-					*requested_ep |= (1U << (idx + 16U));
-				} else {
-					*requested_ep |= (1U << idx);
-				}
-				LOG_DBG("endpoint 0x%x", ep_data[i].ep_addr);
-				return 0;
-			}
+		if (!usb_dc_ep_check_cap(&ep_cfg)) {
+			LOG_DBG("endpoint 0x%x", ep_data[i].ep_addr);
+			return 0;
 		}
 	}
 	return -1;
@@ -421,7 +389,6 @@ static int usb_fix_descriptor(struct usb_desc_header *head)
 	struct usb_ep_descriptor *ep_descr = NULL;
 	uint8_t numof_ifaces = 0U;
 	uint8_t str_descr_idx = 0U;
-	uint32_t requested_ep = BIT(16) | BIT(0);
 
 	while (head->bLength != 0U) {
 		switch (head->bDescriptorType) {
@@ -469,9 +436,7 @@ static int usb_fix_descriptor(struct usb_desc_header *head)
 
 			LOG_DBG("Endpoint descriptor %p", head);
 			ep_descr = (struct usb_ep_descriptor *)head;
-			if (usb_validate_ep_cfg_data(ep_descr,
-						     cfg_data,
-						     &requested_ep)) {
+			if (usb_validate_ep_cfg_data(ep_descr, cfg_data)) {
 				LOG_ERR("Failed to validate endpoints");
 				return -1;
 			}


### PR DESCRIPTION
instead of starting at the first possible address, and using the first possible endpoint address, use the endpoint address that is configured by the user.
