### PR TITLE
west.yml: MCUboot synchronization from upstream

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -303,7 +303,7 @@ manifest:
       groups:
         - crypto
     - name: mcuboot
-      revision: 1b2fc096d9a683a7481b13749d01ca8fa78e7afd
+      revision: c8470fb145f8aff92696d05396fb77c3b8068b32
       path: bootloader/mcuboot
       groups:
         - bootloader


### PR DESCRIPTION
Update Zephyr fork of MCUboot to revision:
  c8470fb145f8aff92696d05396fb77c3b8068b32

Brings following Zephyr relevant fixes:

  - 2f294d1f zephyr: Use flash_area_flatten in bs_custom_storage_erase
  - 2346d69c zephyr: Add support for devices without erase and reduced erases
  - 2a2b562b bootutil: Add support for devices without erase and reduced erases
  - 1ead4a67 boot: zephyr: kconfig: Remove superflous default n lines
  - e5d8640c zephyr: Add missing selection for allowed SHA algorithms
  - f523c60d zephyr: Fix ED25519 compilation with mbedTLS
  - 0ba80ffb zephyr: Prevent selecting MBEDTLS_ASN1_PARSE_C when not needed
  - ec86244a zephyr: Do not compile ASN1 code when bypassed
  - a01ca4cf bootutil: Fix ASN1 bypass not building
  - 4535ad98 boot: Additional flash_area_open removals
  - c0bb1337 boot: zephyr: boards: Add frdm-mcxn236 configuration

Notes on process:
 1) The MCUboot update from [mcu-tools/mcuboot/main](https://github.com/mcu-tools/mcuboot/tree/main) with the SHA used in west.yaml is already synchronized to [zephyrproject-rtos/mcuboot/upstream-sync](https://github.com/zephyrproject-rtos/mcuboot/tree/upstream-sync) branch, and is available in the Zephyr fork of MCUboot.
 2) The [DNM] on this PR should be kept until the PR passes all tests and is accepted.
 3) Once the PR passes all tests and gets accepted, the upstream-sync branch should be fast-forward merged to [zephyrproject-rtos/mcuboot/main](https://github.com/zephyrproject-rtos/mcuboot/tree/main) branch and [DNM] should be removed.
 4) After the main branch gets updated, this PR does not require further changes and should be merged as is.