### PR TITLE
bluetooth: host: Fixed missing guard for BT_SETTINGS_DEFINE

### DIFF
--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -5888,6 +5888,7 @@ static int ccc_set(const char *name, size_t len_rd, settings_read_cb read_cb,
 	return 0;
 }
 
+#ifdef CONFIG_BT_SETTINGS
 static int ccc_set_cb(const char *name, size_t len_rd, settings_read_cb read_cb,
 		      void *cb_arg)
 {
@@ -5900,6 +5901,7 @@ static int ccc_set_cb(const char *name, size_t len_rd, settings_read_cb read_cb,
 }
 
 BT_SETTINGS_DEFINE(ccc, "ccc", ccc_set_cb, NULL);
+#endif /* CONFIG_BT_SETTINGS */
 
 static int ccc_set_direct(const char *key, size_t len, settings_read_cb read_cb,
 			  void *cb_arg, void *param)


### PR DESCRIPTION
While linking with the IAR linker using generated linker scripts, and with errors if unhandled sections are encountered, many of the bluetooth tests failed because CONFIG_SETTINGS was not set.

The section that was not handled was
'._settings_handler_static.static.settings_handler_bt_ccc_'

Now it's only set if CONFIG_SETTINGS is set.