### PR TITLE
intel_adsp: ace30: mm: Set write permissions during memory mapping

### DIFF
--- a/drivers/mm/mm_drv_intel_adsp_mtl_tlb.c
+++ b/drivers/mm/mm_drv_intel_adsp_mtl_tlb.c
@@ -850,7 +850,7 @@ static void adsp_mm_save_context(void *storage_buffer)
 
 #ifdef CONFIG_MMU
 			arch_mem_map(UINT_TO_POINTER(phys_addr), phys_addr, CONFIG_MM_DRV_PAGE_SIZE,
-				     K_MEM_CACHE_WB);
+				     K_MEM_CACHE_WB | K_MEM_PERM_RW);
 #endif
 
 			/* Invalidate cache to avoid stalled data


### PR DESCRIPTION
The adsp_mm_save_context function was previously mapping memory without explicitly setting write permissions, which could lead to a "store prohibited" exception when attempting to write to the memory. This patch adds the K_MEM_PERM_RW flag to the arch_mem_map call to ensure that the memory is mapped with write permissions.

This change resolves the issue of accessing memory without the necessary permissions, preventing potential exceptions and ensuring correct memory operations. The issue was found when running the firmware on a simulation with the MMU enabled.