### PR TITLE
arch: x86: Restrict direct IPI support

### DIFF
--- a/arch/x86/Kconfig
+++ b/arch/x86/Kconfig
@@ -83,7 +83,7 @@ config X86_64
 	select X86_MMX
 	select X86_SSE
 	select X86_SSE2
-	select ARCH_HAS_DIRECTED_IPIS
+	select ARCH_HAS_DIRECTED_IPIS if !X2APIC
 
 menu "x86 Features"
 


### PR DESCRIPTION
It has been discovered that direct IPI support does not work correctly when CONFIG_X2APIC is enabled. Until that can be fixed, restrict this feature on x86 to platforms that do not enable CONFIG_X2APIC.

Fixes #87046