### PR TITLE
Add Display support for FRDM_RW612 board

### DIFF
--- a/boards/nxp/frdm_rw612/Kconfig.defconfig
+++ b/boards/nxp/frdm_rw612/Kconfig.defconfig
@@ -8,4 +8,21 @@ if BOARD_FRDM_RW612
 config NET_L2_ETHERNET
 	default y if DT_HAS_NXP_ENET_MAC_ENABLED && NETWORKING
 
+if LVGL
+
+# Enable DMA for LCDIC
+config MIPI_DBI_NXP_LCDIC_DMA
+	default y if MIPI_DBI
+
+# Increase descriptor count. LVGL will allocate a 30KB buffer,
+# and the SPI driver sets up RX and TX side. Since LPC DMA has
+# 1KB limit per descriptor, we need 60
+config DMA_MCUX_LPC_NUMBER_OF_DESCRIPTORS
+	default 60
+
+config LV_Z_FLUSH_THREAD
+	default y
+
+endif # LVGL
+
 endif # BOARD_FRDM_RW612

--- a/boards/nxp/frdm_rw612/doc/index.rst
+++ b/boards/nxp/frdm_rw612/doc/index.rst
@@ -69,6 +69,9 @@ Supported Features
 +-----------+------------+-----------------------------------+
 | Wi-Fi     | on-chip    | Wi-Fi                             |
 +-----------+------------+-----------------------------------+
+| LCDIC     | on-chip    | mipi-dbi. Tested with             |
+|           |            | :ref:`lcd_par_s035`               |
++-----------+------------+-----------------------------------+
 
 The default configuration can be found in the defconfig file:
 

--- a/boards/nxp/frdm_rw612/frdm_rw612-pinctrl.dtsi
+++ b/boards/nxp/frdm_rw612/frdm_rw612-pinctrl.dtsi
@@ -60,4 +60,16 @@
 			slew-rate = "normal";
 		};
 	};
+
+	pinmux_lcdic: pinmux_lcdic {
+		group0 {
+			pinmux = <IO_MUX_LCD_SPI_IO44
+				IO_MUX_LCD_SPI_IO45
+				IO_MUX_LCD_SPI_IO46
+				IO_MUX_LCD_SPI_IO47
+				IO_MUX_LCD_SPI_IO48
+				IO_MUX_LCD_SPI_IO49>;
+			slew-rate = "ultra";
+		};
+	};
 };

--- a/boards/nxp/frdm_rw612/frdm_rw612_common.dtsi
+++ b/boards/nxp/frdm_rw612/frdm_rw612_common.dtsi
@@ -45,6 +45,15 @@
 			status = "okay";
 		};
 	};
+
+	nxp_lcd_pmod_connector: lcd-pmod-connector {
+		compatible = "nxp,lcd-pmod";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xfffffff0>;
+		gpio-map-pass-thru = <0 0xf>;
+		gpio-map = <10  0 &hsgpio1 12 0>,  /* Pin 10, LCD and touch reset */
+			   <12  0 &hsgpio0 18 0>;  /* Pin 11, LCD touch INT */
+	};
 };
 
 &flexcomm3 {
@@ -239,4 +248,14 @@ arduino_i2c: &flexcomm2 {
 	#size-cells = <0>;
 	pinctrl-0 = <&pinmux_flexcomm2_i2c>;
 	pinctrl-names = "default";
+};
+
+zephyr_mipi_dbi_spi: &lcdic {
+	status = "okay";
+	pinctrl-0 = <&pinmux_lcdic>;
+	pinctrl-names = "default";
+};
+
+nxp_pmod_touch_panel_i2c: &arduino_i2c {
+	status = "okay";
 };

--- a/boards/shields/lcd_par_s035/Kconfig.shield
+++ b/boards/shields/lcd_par_s035/Kconfig.shield
@@ -2,4 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config SHIELD_LCD_PAR_S035
-	def_bool $(shields_list_contains,lcd_par_s035_8080)
+	def_bool $(shields_list_contains,lcd_par_s035_spi) ||\
+		$(shields_list_contains,lcd_par_s035_8080)

--- a/boards/shields/lcd_par_s035/boards/frdm_rw612.overlay
+++ b/boards/shields/lcd_par_s035/boards/frdm_rw612.overlay
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2025 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&lcdic {
+	/* Enable byte swapping */
+	nxp,swap-bytes;
+	/* Raise the timer0 ratio to enable longer reset delay */
+	nxp,timer0-ratio = <15>;
+	/* Lower timer1 ratio to enable shorter TE delay */
+	nxp,timer1-ratio = <0>;
+};

--- a/boards/shields/lcd_par_s035/doc/index.rst
+++ b/boards/shields/lcd_par_s035/doc/index.rst
@@ -16,14 +16,13 @@ Requirements
 ************
 
 This shield can only be used with FRDM-X evaluation kits with a parallel LCD
-connector or a PMOD connector. Currently only the parallel LCD connector is
-enabled.
+connector or a PMOD connector.
 
 Programming
 ***********
 
-Set ``--shield lcd_par_s035_8080`` when you invoke ``west build``. For
-example:
+Set ``--shield lcd_par_s035_8080`` or ``--shield lcd_par_s035_spi`` when you
+invoke ``west build``. For example:
 
 .. zephyr-app-commands::
    :zephyr-app: samples/drivers/display

--- a/boards/shields/lcd_par_s035/lcd_par_s035_spi.overlay
+++ b/boards/shields/lcd_par_s035/lcd_par_s035_spi.overlay
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2025 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/mipi_dbi/mipi_dbi.h>
+#include <zephyr/dt-bindings/spi/spi.h>
+
+/{
+	chosen {
+		zephyr,display = &st7796s;
+		zephyr,touch = &gt911_lcd_par_s035;
+	};
+
+	lvgl_pointer {
+		compatible = "zephyr,lvgl-pointer-input";
+		input = <&gt911_lcd_par_s035>;
+		swap-xy;
+		invert-y;
+	};
+};
+
+&nxp_pmod_touch_panel_i2c {
+	status = "okay";
+
+	gt911_lcd_par_s035: gt911-lcd_par_s035@5d {
+		compatible = "goodix,gt911";
+		reg = <0x5d>;
+		irq-gpios = <&nxp_lcd_pmod_connector 12 GPIO_ACTIVE_HIGH>;
+	};
+};
+
+&zephyr_mipi_dbi_spi {
+	status = "okay";
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	st7796s: st7796s@0 {
+		compatible = "sitronix,st7796s";
+		reg = <0>;
+		/*
+		 * Display supports minimum write cycle time of 66ns. This
+		 * means we can clock the LCDIC module at 30MHz, as
+		 * the minimum write duration will be 2x the module
+		 * clock. Note that this frequency is too fast for reading
+		 * from the display module
+		 */
+		mipi-max-frequency = <30000000>;
+		mipi-mode = "MIPI_DBI_MODE_SPI_4WIRE";
+		duplex = <SPI_HALF_DUPLEX>;
+		height = <320>;
+		width = <480>;
+		invert-mode = "1-dot";
+		frmctl1 = [80 10];
+		bpc = [1F 50 00 20];
+		dfc = [8A 07 3B];
+		pwr1 = [80 64];
+		pwr2 = <0x13>;
+		pwr3 = <0xA7>;
+		vcmpctl = <0x09>;
+		doca = [40 8A 00 00 29 19 A5 33];
+		pgc = [F0 06 0B 07 06 05 2E 33 47 3A 17 16 2E 31];
+		ngc = [F0 09 0D 09 08 23 2E 33 46 38 13 13 2C 32];
+		madctl = <0x28>;
+		color-invert;
+	};
+};

--- a/dts/bindings/gpio/nxp,lcd-pmod.yaml
+++ b/dts/bindings/gpio/nxp,lcd-pmod.yaml
@@ -1,0 +1,26 @@
+# Copyright 2025 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+
+compatible: "nxp,lcd-pmod"
+
+description: |
+    GPIO pins exposed on NXP LCD pmod interface (e.g., used on LCD-PAR-035 panel).
+    These pins are exposed on a 12 pin connector. The pins have the
+    following assignments:
+
+      Pin Number    Usage
+      1             VCC
+      2             VCC
+      3             GND
+      4             GND
+      5             LCD PMOD interface WR pin
+      6             LCD touch controller I2C SCL
+      7             LCD PMOD interface D/C pin
+      8             LCD touch controller I2C SDA
+      9             LCD PMOD interface MOSI pin
+      10            LCD and touch reset
+      11            LCD PMOD interface CS pin
+      12            LCD touch interrupt
+
+include: [gpio-nexus.yaml, base.yaml]

--- a/samples/drivers/display/sample.yaml
+++ b/samples/drivers/display/sample.yaml
@@ -107,4 +107,5 @@ tests:
       - platform:frdm_mcxn947/mcxn947/cpu0:SHIELD=lcd_par_s035_8080
       - platform:frdm_mcxn236/mcxn236:SHIELD=lcd_par_s035_8080
       - platform:frdm_mcxa156/mcxa156:SHIELD=lcd_par_s035_8080
+      - platform:frdm_rw612:SHIELD=lcd_par_s035_spi
       - platform:ek_ra8d1:SHIELD=rtkmipilcdb00000be


### PR DESCRIPTION
Add support for the LCD-PAR display to communicate over the SPI bus which is available on the PMOD connection interface. This is used on the FRDM-RW612 board.