### PR TITLE
video: Drop video endpoint id in video APIs

### DIFF
--- a/doc/releases/migration-guide-4.2.rst
+++ b/doc/releases/migration-guide-4.2.rst
@@ -508,6 +508,8 @@ Video
   :c:func:`video_set_frmival`.
   See (:github:`89627`).
 
+* video_endpoint_id enum has been dropped. It is no longer a parameter in any video API.
+
 Other subsystems
 ****************
 

--- a/doc/releases/migration-guide-4.2.rst
+++ b/doc/releases/migration-guide-4.2.rst
@@ -510,6 +510,12 @@ Video
 
 * video_endpoint_id enum has been dropped. It is no longer a parameter in any video API.
 
+* video_buf_type enum has been added. It is a required parameter in the following video APIs:
+
+  ``set_stream``
+  ``video_stream_start``
+  ``video_stream_stop``
+
 Other subsystems
 ****************
 

--- a/drivers/video/gc2145.c
+++ b/drivers/video/gc2145.c
@@ -1093,7 +1093,7 @@ static int gc2145_get_fmt(const struct device *dev, struct video_format *fmt)
 	return 0;
 }
 
-static int gc2145_set_stream(const struct device *dev, bool enable)
+static int gc2145_set_stream(const struct device *dev, bool enable, enum video_buf_type type)
 {
 	const struct gc2145_config *cfg = dev->config;
 

--- a/drivers/video/gc2145.c
+++ b/drivers/video/gc2145.c
@@ -1040,8 +1040,7 @@ static uint8_t gc2145_check_connection(const struct device *dev)
 	return 0;
 }
 
-static int gc2145_set_fmt(const struct device *dev, enum video_endpoint_id ep,
-			  struct video_format *fmt)
+static int gc2145_set_fmt(const struct device *dev, struct video_format *fmt)
 {
 	struct gc2145_data *drv_data = dev->data;
 	size_t res = ARRAY_SIZE(fmts);
@@ -1085,8 +1084,7 @@ static int gc2145_set_fmt(const struct device *dev, enum video_endpoint_id ep,
 	return 0;
 }
 
-static int gc2145_get_fmt(const struct device *dev, enum video_endpoint_id ep,
-			  struct video_format *fmt)
+static int gc2145_get_fmt(const struct device *dev, struct video_format *fmt)
 {
 	struct gc2145_data *drv_data = dev->data;
 
@@ -1103,8 +1101,7 @@ static int gc2145_set_stream(const struct device *dev, bool enable)
 		      : gc2145_write_reg(&cfg->i2c, 0xf2, 0x00);
 }
 
-static int gc2145_get_caps(const struct device *dev, enum video_endpoint_id ep,
-			   struct video_caps *caps)
+static int gc2145_get_caps(const struct device *dev, struct video_caps *caps)
 {
 	caps->format_caps = fmts;
 	return 0;
@@ -1188,7 +1185,7 @@ static int gc2145_init(const struct device *dev)
 	fmt.height = RESOLUTION_QVGA_H;
 	fmt.pitch = RESOLUTION_QVGA_W * 2;
 
-	ret = gc2145_set_fmt(dev, VIDEO_EP_OUT, &fmt);
+	ret = gc2145_set_fmt(dev, &fmt);
 	if (ret) {
 		LOG_ERR("Unable to configure default format");
 		return ret;

--- a/drivers/video/mt9m114.c
+++ b/drivers/video/mt9m114.c
@@ -458,7 +458,7 @@ static int mt9m114_get_fmt(const struct device *dev, struct video_format *fmt)
 	return 0;
 }
 
-static int mt9m114_set_stream(const struct device *dev, bool enable)
+static int mt9m114_set_stream(const struct device *dev, bool enable, enum video_buf_type type)
 {
 	return enable ? mt9m114_set_state(dev, MT9M114_SYS_STATE_START_STREAMING)
 		      : mt9m114_set_state(dev, MT9M114_SYS_STATE_ENTER_SUSPEND);

--- a/drivers/video/mt9m114.c
+++ b/drivers/video/mt9m114.c
@@ -397,8 +397,7 @@ static int mt9m114_set_output_format(const struct device *dev, int pixel_format)
 	return ret;
 }
 
-static int mt9m114_set_fmt(const struct device *dev, enum video_endpoint_id ep,
-			   struct video_format *fmt)
+static int mt9m114_set_fmt(const struct device *dev, struct video_format *fmt)
 {
 	struct mt9m114_data *drv_data = dev->data;
 	int ret;
@@ -450,8 +449,7 @@ static int mt9m114_set_fmt(const struct device *dev, enum video_endpoint_id ep,
 	return mt9m114_set_state(dev, MT9M114_SYS_STATE_ENTER_CONFIG_CHANGE);
 }
 
-static int mt9m114_get_fmt(const struct device *dev, enum video_endpoint_id ep,
-			   struct video_format *fmt)
+static int mt9m114_get_fmt(const struct device *dev, struct video_format *fmt)
 {
 	struct mt9m114_data *drv_data = dev->data;
 
@@ -466,8 +464,7 @@ static int mt9m114_set_stream(const struct device *dev, bool enable)
 		      : mt9m114_set_state(dev, MT9M114_SYS_STATE_ENTER_SUSPEND);
 }
 
-static int mt9m114_get_caps(const struct device *dev, enum video_endpoint_id ep,
-			    struct video_caps *caps)
+static int mt9m114_get_caps(const struct device *dev, struct video_caps *caps)
 {
 	caps->format_caps = fmts;
 	return 0;
@@ -563,7 +560,7 @@ static int mt9m114_init(const struct device *dev)
 	fmt.height = 272;
 	fmt.pitch = fmt.width * 2;
 
-	ret = mt9m114_set_fmt(dev, VIDEO_EP_OUT, &fmt);
+	ret = mt9m114_set_fmt(dev, &fmt);
 	if (ret) {
 		LOG_ERR("Unable to configure default format");
 		return -EIO;

--- a/drivers/video/ov2640.c
+++ b/drivers/video/ov2640.c
@@ -880,7 +880,7 @@ static int ov2640_get_fmt(const struct device *dev, struct video_format *fmt)
 	return 0;
 }
 
-static int ov2640_set_stream(const struct device *dev, bool enable)
+static int ov2640_set_stream(const struct device *dev, bool enable, enum video_buf_type type)
 {
 	return 0;
 }

--- a/drivers/video/ov2640.c
+++ b/drivers/video/ov2640.c
@@ -829,8 +829,7 @@ uint8_t ov2640_check_connection(const struct device *dev)
 	return ret;
 }
 
-static int ov2640_set_fmt(const struct device *dev,
-			enum video_endpoint_id ep, struct video_format *fmt)
+static int ov2640_set_fmt(const struct device *dev, struct video_format *fmt)
 {
 	struct ov2640_data *drv_data = dev->data;
 	uint16_t width, height;
@@ -872,8 +871,7 @@ static int ov2640_set_fmt(const struct device *dev,
 	return -ENOTSUP;
 }
 
-static int ov2640_get_fmt(const struct device *dev,
-			enum video_endpoint_id ep, struct video_format *fmt)
+static int ov2640_get_fmt(const struct device *dev, struct video_format *fmt)
 {
 	struct ov2640_data *drv_data = dev->data;
 
@@ -887,9 +885,7 @@ static int ov2640_set_stream(const struct device *dev, bool enable)
 	return 0;
 }
 
-static int ov2640_get_caps(const struct device *dev,
-			   enum video_endpoint_id ep,
-			   struct video_caps *caps)
+static int ov2640_get_caps(const struct device *dev, struct video_caps *caps)
 {
 	caps->format_caps = fmts;
 	return 0;
@@ -1037,7 +1033,7 @@ static int ov2640_init(const struct device *dev)
 	fmt.width = SVGA_HSIZE;
 	fmt.height = SVGA_VSIZE;
 	fmt.pitch = SVGA_HSIZE * 2;
-	ret = ov2640_set_fmt(dev, VIDEO_EP_OUT, &fmt);
+	ret = ov2640_set_fmt(dev, &fmt);
 	if (ret) {
 		LOG_ERR("Unable to configure default format");
 		return -EIO;

--- a/drivers/video/ov5640.c
+++ b/drivers/video/ov5640.c
@@ -767,8 +767,7 @@ static int ov5640_set_fmt_dvp(const struct ov5640_config *cfg)
 	return 0;
 }
 
-static int ov5640_set_frmival(const struct device *dev, enum video_endpoint_id ep,
-			      struct video_frmival *frmival)
+static int ov5640_set_frmival(const struct device *dev, struct video_frmival *frmival)
 {
 	const struct ov5640_config *cfg = dev->config;
 	struct ov5640_data *drv_data = dev->data;
@@ -823,8 +822,7 @@ static int ov5640_set_frmival(const struct device *dev, enum video_endpoint_id e
 	return 0;
 }
 
-static int ov5640_set_fmt(const struct device *dev, enum video_endpoint_id ep,
-			  struct video_format *fmt)
+static int ov5640_set_fmt(const struct device *dev, struct video_format *fmt)
 {
 	struct ov5640_data *drv_data = dev->data;
 	const struct ov5640_config *cfg = dev->config;
@@ -906,11 +904,10 @@ static int ov5640_set_fmt(const struct device *dev, enum video_endpoint_id ep,
 	def_frmival.denominator = drv_data->cur_mode->def_frmrate;
 	def_frmival.numerator = 1;
 
-	return ov5640_set_frmival(dev, ep, &def_frmival);
+	return ov5640_set_frmival(dev, &def_frmival);
 }
 
-static int ov5640_get_fmt(const struct device *dev, enum video_endpoint_id ep,
-			  struct video_format *fmt)
+static int ov5640_get_fmt(const struct device *dev, struct video_format *fmt)
 {
 	struct ov5640_data *drv_data = dev->data;
 
@@ -919,8 +916,7 @@ static int ov5640_get_fmt(const struct device *dev, enum video_endpoint_id ep,
 	return 0;
 }
 
-static int ov5640_get_caps(const struct device *dev, enum video_endpoint_id ep,
-			   struct video_caps *caps)
+static int ov5640_get_caps(const struct device *dev, struct video_caps *caps)
 {
 	caps->format_caps = ov5640_is_dvp(dev) ? dvp_fmts : csi2_fmts;
 	return 0;
@@ -1177,8 +1173,7 @@ static int ov5640_get_volatile_ctrl(const struct device *dev, uint32_t id)
 	return 0;
 }
 
-static int ov5640_get_frmival(const struct device *dev, enum video_endpoint_id ep,
-			      struct video_frmival *frmival)
+static int ov5640_get_frmival(const struct device *dev, struct video_frmival *frmival)
 {
 	struct ov5640_data *drv_data = dev->data;
 
@@ -1192,8 +1187,7 @@ static int ov5640_get_frmival(const struct device *dev, enum video_endpoint_id e
 	return 0;
 }
 
-static int ov5640_enum_frmival(const struct device *dev, enum video_endpoint_id ep,
-			       struct video_frmival_enum *fie)
+static int ov5640_enum_frmival(const struct device *dev, struct video_frmival_enum *fie)
 {
 	uint8_t i = 0;
 
@@ -1430,7 +1424,7 @@ static int ov5640_init(const struct device *dev)
 		fmt.height = 720;
 	}
 	fmt.pitch = fmt.width * 2;
-	ret = ov5640_set_fmt(dev, VIDEO_EP_OUT, &fmt);
+	ret = ov5640_set_fmt(dev, &fmt);
 	if (ret) {
 		LOG_ERR("Unable to configure default format");
 		return -EIO;

--- a/drivers/video/ov5640.c
+++ b/drivers/video/ov5640.c
@@ -922,7 +922,7 @@ static int ov5640_get_caps(const struct device *dev, struct video_caps *caps)
 	return 0;
 }
 
-static int ov5640_set_stream(const struct device *dev, bool enable)
+static int ov5640_set_stream(const struct device *dev, bool enable, enum video_buf_type type)
 {
 	const struct ov5640_config *cfg = dev->config;
 

--- a/drivers/video/ov7670.c
+++ b/drivers/video/ov7670.c
@@ -353,15 +353,13 @@ static const struct ov7670_reg ov7670_init_regtbl[] = {
 	{0xb8, 0x0a},
 };
 
-static int ov7670_get_caps(const struct device *dev, enum video_endpoint_id ep,
-			   struct video_caps *caps)
+static int ov7670_get_caps(const struct device *dev, struct video_caps *caps)
 {
 	caps->format_caps = fmts;
 	return 0;
 }
 
-static int ov7670_set_fmt(const struct device *dev, enum video_endpoint_id ep,
-			  struct video_format *fmt)
+static int ov7670_set_fmt(const struct device *dev, struct video_format *fmt)
 {
 	const struct ov7670_config *config = dev->config;
 	struct ov7670_data *data = dev->data;
@@ -446,8 +444,7 @@ static int ov7670_set_fmt(const struct device *dev, enum video_endpoint_id ep,
 	return -ENOTSUP;
 }
 
-static int ov7670_get_fmt(const struct device *dev, enum video_endpoint_id ep,
-			  struct video_format *fmt)
+static int ov7670_get_fmt(const struct device *dev, struct video_format *fmt)
 {
 	struct ov7670_data *data = dev->data;
 
@@ -558,7 +555,7 @@ static int ov7670_init(const struct device *dev)
 	fmt.width = 640;
 	fmt.height = 480;
 	fmt.pitch = fmt.width * 2;
-	ret = ov7670_set_fmt(dev, VIDEO_EP_OUT, &fmt);
+	ret = ov7670_set_fmt(dev, &fmt);
 	if (ret < 0) {
 		return ret;
 	}

--- a/drivers/video/ov7670.c
+++ b/drivers/video/ov7670.c
@@ -573,7 +573,7 @@ static int ov7670_init(const struct device *dev)
 	return ov7670_init_controls(dev);
 }
 
-static int ov7670_set_stream(const struct device *dev, bool enable)
+static int ov7670_set_stream(const struct device *dev, bool enable, enum video_buf_type type)
 {
 	return 0;
 }

--- a/drivers/video/ov7725.c
+++ b/drivers/video/ov7725.c
@@ -515,7 +515,7 @@ static int ov7725_get_fmt(const struct device *dev, struct video_format *fmt)
 	return 0;
 }
 
-static int ov7725_set_stream(const struct device *dev, bool enable)
+static int ov7725_set_stream(const struct device *dev, bool enable, enum video_buf_type type)
 {
 	return 0;
 }

--- a/drivers/video/ov7725.c
+++ b/drivers/video/ov7725.c
@@ -417,9 +417,7 @@ static int ov7725_set_clock(const struct device *dev,
 	return -1;
 }
 
-static int ov7725_set_fmt(const struct device *dev,
-			  enum video_endpoint_id ep,
-			  struct video_format *fmt)
+static int ov7725_set_fmt(const struct device *dev, struct video_format *fmt)
 {
 	struct ov7725_data *drv_data = dev->data;
 	const struct ov7725_config *cfg = dev->config;
@@ -508,9 +506,7 @@ static int ov7725_set_fmt(const struct device *dev,
 					((width & 3U) << 0U));
 }
 
-static int ov7725_get_fmt(const struct device *dev,
-			  enum video_endpoint_id ep,
-			  struct video_format *fmt)
+static int ov7725_get_fmt(const struct device *dev, struct video_format *fmt)
 {
 	struct ov7725_data *drv_data = dev->data;
 
@@ -537,9 +533,7 @@ static const struct video_format_cap fmts[] = {
 	{ 0 }
 };
 
-static int ov7725_get_caps(const struct device *dev,
-			   enum video_endpoint_id ep,
-			   struct video_caps *caps)
+static int ov7725_get_caps(const struct device *dev, struct video_caps *caps)
 {
 	caps->format_caps = fmts;
 	return 0;
@@ -599,7 +593,7 @@ static int ov7725_init(const struct device *dev)
 	fmt.width = 640;
 	fmt.height = 480;
 	fmt.pitch = 640 * 2;
-	ret = ov7725_set_fmt(dev, VIDEO_EP_OUT, &fmt);
+	ret = ov7725_set_fmt(dev, &fmt);
 	if (ret) {
 		LOG_ERR("Unable to configure default format");
 		return -EIO;

--- a/drivers/video/video_common.c
+++ b/drivers/video/video_common.c
@@ -125,8 +125,7 @@ void video_closest_frmival_stepwise(const struct video_frmival_stepwise *stepwis
 			     stepwise->step.denominator * desired->denominator;
 }
 
-void video_closest_frmival(const struct device *dev, enum video_endpoint_id ep,
-			   struct video_frmival_enum *match)
+void video_closest_frmival(const struct device *dev, struct video_frmival_enum *match)
 {
 	struct video_frmival desired = match->discrete;
 	struct video_frmival_enum fie = {.format = match->format};
@@ -136,7 +135,7 @@ void video_closest_frmival(const struct device *dev, enum video_endpoint_id ep,
 	__ASSERT(match->type != VIDEO_FRMIVAL_TYPE_STEPWISE,
 		 "cannot find range matching the range, only a value matching the range");
 
-	for (fie.index = 0; video_enum_frmival(dev, ep, &fie) == 0; fie.index++) {
+	for (fie.index = 0; video_enum_frmival(dev, &fie) == 0; fie.index++) {
 		struct video_frmival tmp = {0};
 		uint64_t diff_nsec = 0;
 		uint64_t tmp_nsec;

--- a/drivers/video/video_emul_imager.c
+++ b/drivers/video/video_emul_imager.c
@@ -227,45 +227,30 @@ err:
 	return ret;
 }
 
-static int emul_imager_set_frmival(const struct device *dev, enum video_endpoint_id ep,
-				   struct video_frmival *frmival)
+static int emul_imager_set_frmival(const struct device *dev, struct video_frmival *frmival)
 {
 	struct emul_imager_data *data = dev->data;
 	struct video_frmival_enum fie = {.format = &data->fmt, .discrete = *frmival};
 
-	if (ep != VIDEO_EP_OUT && ep != VIDEO_EP_ALL) {
-		return -EINVAL;
-	}
-
-	video_closest_frmival(dev, ep, &fie);
+	video_closest_frmival(dev, &fie);
 	LOG_DBG("Applying frame interval number %u", fie.index);
 	return emul_imager_set_mode(dev, &emul_imager_modes[data->fmt_id][fie.index]);
 }
 
-static int emul_imager_get_frmival(const struct device *dev, enum video_endpoint_id ep,
-				   struct video_frmival *frmival)
+static int emul_imager_get_frmival(const struct device *dev, struct video_frmival *frmival)
 {
 	struct emul_imager_data *data = dev->data;
-
-	if (ep != VIDEO_EP_OUT && ep != VIDEO_EP_ALL) {
-		return -EINVAL;
-	}
 
 	frmival->numerator = 1;
 	frmival->denominator = data->mode->fps;
 	return 0;
 }
 
-static int emul_imager_enum_frmival(const struct device *dev, enum video_endpoint_id ep,
-				    struct video_frmival_enum *fie)
+static int emul_imager_enum_frmival(const struct device *dev, struct video_frmival_enum *fie)
 {
 	const struct emul_imager_mode *mode;
 	size_t fmt_id;
 	int ret;
-
-	if (ep != VIDEO_EP_OUT && ep != VIDEO_EP_ALL) {
-		return -EINVAL;
-	}
 
 	ret = video_format_caps_index(fmts, fie->format, &fmt_id);
 	if (ret < 0) {
@@ -281,16 +266,11 @@ static int emul_imager_enum_frmival(const struct device *dev, enum video_endpoin
 	return mode->fps == 0;
 }
 
-static int emul_imager_set_fmt(const struct device *const dev, enum video_endpoint_id ep,
-			       struct video_format *fmt)
+static int emul_imager_set_fmt(const struct device *const dev, struct video_format *fmt)
 {
 	struct emul_imager_data *data = dev->data;
 	size_t fmt_id;
 	int ret;
-
-	if (ep != VIDEO_EP_OUT && ep != VIDEO_EP_ALL) {
-		return -EINVAL;
-	}
 
 	if (memcmp(&data->fmt, fmt, sizeof(data->fmt)) == 0) {
 		return 0;
@@ -323,26 +303,16 @@ static int emul_imager_set_fmt(const struct device *const dev, enum video_endpoi
 	return 0;
 }
 
-static int emul_imager_get_fmt(const struct device *dev, enum video_endpoint_id ep,
-			       struct video_format *fmt)
+static int emul_imager_get_fmt(const struct device *dev, struct video_format *fmt)
 {
 	struct emul_imager_data *data = dev->data;
-
-	if (ep != VIDEO_EP_OUT && ep != VIDEO_EP_ALL) {
-		return -EINVAL;
-	}
 
 	*fmt = data->fmt;
 	return 0;
 }
 
-static int emul_imager_get_caps(const struct device *dev, enum video_endpoint_id ep,
-				struct video_caps *caps)
+static int emul_imager_get_caps(const struct device *dev, struct video_caps *caps)
 {
-	if (ep != VIDEO_EP_OUT && ep != VIDEO_EP_ALL) {
-		return -EINVAL;
-	}
-
 	caps->format_caps = fmts;
 	return 0;
 }
@@ -400,7 +370,7 @@ int emul_imager_init(const struct device *dev)
 	fmt.height = fmts[0].height_min;
 	fmt.pitch = fmt.width * 2;
 
-	ret = emul_imager_set_fmt(dev, VIDEO_EP_OUT, &fmt);
+	ret = emul_imager_set_fmt(dev, &fmt);
 	if (ret < 0) {
 		LOG_ERR("Failed to set to default format %x %ux%u",
 			fmt.pixelformat, fmt.width, fmt.height);

--- a/drivers/video/video_emul_imager.c
+++ b/drivers/video/video_emul_imager.c
@@ -317,7 +317,7 @@ static int emul_imager_get_caps(const struct device *dev, struct video_caps *cap
 	return 0;
 }
 
-static int emul_imager_set_stream(const struct device *dev, bool enable)
+static int emul_imager_set_stream(const struct device *dev, bool enable, enum video_buf_type type)
 {
 	return emul_imager_write_reg(dev, EMUL_IMAGER_REG_CTRL, enable ? 1 : 0);
 }

--- a/drivers/video/video_emul_rx.c
+++ b/drivers/video/video_emul_rx.c
@@ -86,12 +86,13 @@ static int emul_rx_get_caps(const struct device *dev, struct video_caps *caps)
 	return video_get_caps(cfg->source_dev, caps);
 }
 
-static int emul_rx_set_stream(const struct device *dev, bool enable)
+static int emul_rx_set_stream(const struct device *dev, bool enable, enum video_buf_type type)
 {
 	const struct emul_rx_config *cfg = dev->config;
 
 	/* A real hardware driver would first start / stop its own peripheral */
-	return enable ? video_stream_start(cfg->source_dev) : video_stream_stop(cfg->source_dev);
+	return enable ? video_stream_start(cfg->source_dev, type)
+		      : video_stream_stop(cfg->source_dev, type);
 }
 
 static void emul_rx_worker(struct k_work *work)

--- a/drivers/video/video_esp32_dvp.c
+++ b/drivers/video/video_esp32_dvp.c
@@ -334,9 +334,6 @@ static int video_esp32_flush(const struct device *dev, enum video_endpoint_id ep
 	struct video_buffer *vbuf = NULL;
 
 	if (cancel) {
-		if (data->is_streaming) {
-			video_esp32_set_stream(dev, false);
-		}
 		if (data->active_vbuf) {
 			k_fifo_put(&data->fifo_out, data->active_vbuf);
 			data->active_vbuf = NULL;

--- a/drivers/video/video_esp32_dvp.c
+++ b/drivers/video/video_esp32_dvp.c
@@ -136,7 +136,7 @@ void video_esp32_dma_rx_done(const struct device *dev, void *user_data, uint32_t
 	video_esp32_reload_dma(data);
 }
 
-static int video_esp32_set_stream(const struct device *dev, bool enable)
+static int video_esp32_set_stream(const struct device *dev, bool enable, enum video_buf_type type)
 {
 	const struct video_esp32_config *cfg = dev->config;
 	struct video_esp32_data *data = dev->data;
@@ -149,7 +149,7 @@ static int video_esp32_set_stream(const struct device *dev, bool enable)
 	if (!enable) {
 		LOG_DBG("Stop streaming");
 
-		if (video_stream_stop(cfg->source_dev)) {
+		if (video_stream_stop(cfg->source_dev, type)) {
 			return -EIO;
 		}
 
@@ -233,7 +233,7 @@ static int video_esp32_set_stream(const struct device *dev, bool enable)
 
 	cam_hal_start_streaming(&data->hal);
 
-	if (video_stream_start(cfg->source_dev)) {
+	if (video_stream_start(cfg->source_dev, type)) {
 		return -EIO;
 	}
 	data->is_streaming = true;

--- a/drivers/video/video_mcux_csi.c
+++ b/drivers/video/video_mcux_csi.c
@@ -194,7 +194,8 @@ static int video_mcux_csi_get_fmt(const struct device *dev, struct video_format 
 	return -EIO;
 }
 
-static int video_mcux_csi_set_stream(const struct device *dev, bool enable)
+static int video_mcux_csi_set_stream(const struct device *dev, bool enable,
+				     enum video_buf_type type)
 {
 	const struct video_mcux_csi_config *config = dev->config;
 	struct video_mcux_csi_data *data = dev->data;
@@ -206,11 +207,11 @@ static int video_mcux_csi_set_stream(const struct device *dev, bool enable)
 			return -EIO;
 		}
 
-		if (config->source_dev && video_stream_start(config->source_dev)) {
+		if (config->source_dev && video_stream_start(config->source_dev, type)) {
 			return -EIO;
 		}
 	} else {
-		if (config->source_dev && video_stream_stop(config->source_dev)) {
+		if (config->source_dev && video_stream_stop(config->source_dev, type)) {
 			return -EIO;
 		}
 

--- a/drivers/video/video_mcux_csi.c
+++ b/drivers/video/video_mcux_csi.c
@@ -32,7 +32,7 @@ struct video_mcux_csi_data {
 	csi_handle_t csi_handle;
 	struct k_fifo fifo_in;
 	struct k_fifo fifo_out;
-	struct k_poll_signal *signal;
+	struct k_poll_signal *sig;
 };
 
 static void __frame_done_cb(CSI_Type *base, csi_handle_t *handle, status_t status, void *user_data)
@@ -92,8 +92,8 @@ static void __frame_done_cb(CSI_Type *base, csi_handle_t *handle, status_t statu
 
 done:
 	/* Trigger Event */
-	if (IS_ENABLED(CONFIG_POLL) && data->signal) {
-		k_poll_signal_raise(data->signal, result);
+	if (IS_ENABLED(CONFIG_POLL) && data->sig) {
+		k_poll_signal_raise(data->sig, result);
 	}
 
 	return;
@@ -246,8 +246,8 @@ static int video_mcux_csi_flush(const struct device *dev, bool cancel)
 
 		while ((vbuf = k_fifo_get(&data->fifo_in, K_NO_WAIT))) {
 			k_fifo_put(&data->fifo_out, vbuf);
-			if (IS_ENABLED(CONFIG_POLL) && data->signal) {
-				k_poll_signal_raise(data->signal, VIDEO_BUF_ABORTED);
+			if (IS_ENABLED(CONFIG_POLL) && data->sig) {
+				k_poll_signal_raise(data->sig, VIDEO_BUF_ABORTED);
 			}
 		}
 	}
@@ -371,15 +371,15 @@ static int video_mcux_csi_init(const struct device *dev)
 }
 
 #ifdef CONFIG_POLL
-static int video_mcux_csi_set_signal(const struct device *dev, struct k_poll_signal *signal)
+static int video_mcux_csi_set_signal(const struct device *dev, struct k_poll_signal *sig)
 {
 	struct video_mcux_csi_data *data = dev->data;
 
-	if (data->signal && signal != NULL) {
+	if (data->sig && sig != NULL) {
 		return -EALREADY;
 	}
 
-	data->signal = signal;
+	data->sig = sig;
 
 	return 0;
 }

--- a/drivers/video/video_mcux_mipi_csi2rx.c
+++ b/drivers/video/video_mcux_mipi_csi2rx.c
@@ -141,7 +141,7 @@ static int mipi_csi2rx_get_fmt(const struct device *dev, struct video_format *fm
 	return 0;
 }
 
-static int mipi_csi2rx_set_stream(const struct device *dev, bool enable)
+static int mipi_csi2rx_set_stream(const struct device *dev, bool enable, enum video_buf_type type)
 {
 	const struct mipi_csi2rx_config *config = dev->config;
 
@@ -149,11 +149,11 @@ static int mipi_csi2rx_set_stream(const struct device *dev, bool enable)
 		struct mipi_csi2rx_data *drv_data = dev->data;
 
 		CSI2RX_Init((MIPI_CSI2RX_Type *)config->base, &drv_data->csi2rxConfig);
-		if (video_stream_start(config->sensor_dev)) {
+		if (video_stream_start(config->sensor_dev, type)) {
 			return -EIO;
 		}
 	} else {
-		if (video_stream_stop(config->sensor_dev)) {
+		if (video_stream_stop(config->sensor_dev, type)) {
 			return -EIO;
 		}
 		CSI2RX_Deinit((MIPI_CSI2RX_Type *)config->base);

--- a/drivers/video/video_mcux_smartdma.c
+++ b/drivers/video/video_mcux_smartdma.c
@@ -95,7 +95,8 @@ static void nxp_video_sdma_callback(const struct device *dev, void *user_data,
 	data->buf_reload_flag = !data->buf_reload_flag;
 }
 
-static int nxp_video_sdma_set_stream(const struct device *dev, bool enable)
+static int nxp_video_sdma_set_stream(const struct device *dev, bool enable,
+				     enum video_buf_type type)
 {
 	const struct nxp_video_sdma_config *config = dev->config;
 	struct nxp_video_sdma_data *data = dev->data;
@@ -162,7 +163,7 @@ static int nxp_video_sdma_enqueue(const struct device *dev, struct video_buffer 
 	k_fifo_put(&data->fifo_in, vbuf);
 	if (data->stream_starved) {
 		/* Kick SmartDMA off */
-		nxp_video_sdma_set_stream(dev, true);
+		nxp_video_sdma_set_stream(dev, true, vbuf->type);
 	}
 	return 0;
 }

--- a/drivers/video/video_stm32_dcmi.c
+++ b/drivers/video/video_stm32_dcmi.c
@@ -250,14 +250,15 @@ static int video_stm32_dcmi_get_fmt(const struct device *dev, struct video_forma
 	(capture_rate) == 4 ? DCMI_CR_ALTERNATE_4_FRAME :				\
 	DCMI_CR_ALL_FRAME)
 
-static int video_stm32_dcmi_set_stream(const struct device *dev, bool enable)
+static int video_stm32_dcmi_set_stream(const struct device *dev, bool enable,
+				       enum video_buf_type type)
 {
 	struct video_stm32_dcmi_data *data = dev->data;
 	const struct video_stm32_dcmi_config *config = dev->config;
 	int err;
 
 	if (!enable) {
-		err = video_stream_stop(config->sensor_dev);
+		err = video_stream_stop(config->sensor_dev, type);
 		if (err < 0) {
 			return err;
 		}
@@ -292,7 +293,7 @@ static int video_stm32_dcmi_set_stream(const struct device *dev, bool enable)
 		return -EIO;
 	}
 
-	return video_stream_start(config->sensor_dev);
+	return video_stream_start(config->sensor_dev, type);
 }
 
 static int video_stm32_dcmi_enqueue(const struct device *dev, struct video_buffer *vbuf)

--- a/drivers/video/video_sw_generator.c
+++ b/drivers/video/video_sw_generator.c
@@ -63,15 +63,10 @@ static const struct video_format_cap fmts[] = {{
 					       },
 					       {0}};
 
-static int video_sw_generator_set_fmt(const struct device *dev, enum video_endpoint_id ep,
-				      struct video_format *fmt)
+static int video_sw_generator_set_fmt(const struct device *dev, struct video_format *fmt)
 {
 	struct video_sw_generator_data *data = dev->data;
 	int i = 0;
-
-	if (ep != VIDEO_EP_OUT && ep != VIDEO_EP_ALL) {
-		return -EINVAL;
-	}
 
 	for (i = 0; i < ARRAY_SIZE(fmts); ++i) {
 		if (fmt->pixelformat == fmts[i].pixelformat && fmt->width >= fmts[i].width_min &&
@@ -91,14 +86,9 @@ static int video_sw_generator_set_fmt(const struct device *dev, enum video_endpo
 	return 0;
 }
 
-static int video_sw_generator_get_fmt(const struct device *dev, enum video_endpoint_id ep,
-				      struct video_format *fmt)
+static int video_sw_generator_get_fmt(const struct device *dev, struct video_format *fmt)
 {
 	struct video_sw_generator_data *data = dev->data;
-
-	if (ep != VIDEO_EP_OUT && ep != VIDEO_EP_ALL) {
-		return -EINVAL;
-	}
 
 	*fmt = data->fmt;
 
@@ -179,28 +169,19 @@ static void __buffer_work(struct k_work *work)
 	k_yield();
 }
 
-static int video_sw_generator_enqueue(const struct device *dev, enum video_endpoint_id ep,
-				      struct video_buffer *vbuf)
+static int video_sw_generator_enqueue(const struct device *dev, struct video_buffer *vbuf)
 {
 	struct video_sw_generator_data *data = dev->data;
-
-	if (ep != VIDEO_EP_OUT && ep != VIDEO_EP_ALL) {
-		return -EINVAL;
-	}
 
 	k_fifo_put(&data->fifo_in, vbuf);
 
 	return 0;
 }
 
-static int video_sw_generator_dequeue(const struct device *dev, enum video_endpoint_id ep,
-				      struct video_buffer **vbuf, k_timeout_t timeout)
+static int video_sw_generator_dequeue(const struct device *dev, struct video_buffer **vbuf,
+				      k_timeout_t timeout)
 {
 	struct video_sw_generator_data *data = dev->data;
-
-	if (ep != VIDEO_EP_OUT && ep != VIDEO_EP_ALL) {
-		return -EINVAL;
-	}
 
 	*vbuf = k_fifo_get(&data->fifo_out, timeout);
 	if (*vbuf == NULL) {
@@ -210,8 +191,7 @@ static int video_sw_generator_dequeue(const struct device *dev, enum video_endpo
 	return 0;
 }
 
-static int video_sw_generator_flush(const struct device *dev, enum video_endpoint_id ep,
-				    bool cancel)
+static int video_sw_generator_flush(const struct device *dev, bool cancel)
 {
 	struct video_sw_generator_data *data = dev->data;
 	struct video_buffer *vbuf;
@@ -233,8 +213,7 @@ static int video_sw_generator_flush(const struct device *dev, enum video_endpoin
 	return 0;
 }
 
-static int video_sw_generator_get_caps(const struct device *dev, enum video_endpoint_id ep,
-				       struct video_caps *caps)
+static int video_sw_generator_get_caps(const struct device *dev, struct video_caps *caps)
 {
 	caps->format_caps = fmts;
 	caps->min_vbuf_count = 0;
@@ -246,8 +225,7 @@ static int video_sw_generator_get_caps(const struct device *dev, enum video_endp
 }
 
 #ifdef CONFIG_POLL
-static int video_sw_generator_set_signal(const struct device *dev, enum video_endpoint_id ep,
-					 struct k_poll_signal *signal)
+static int video_sw_generator_set_signal(const struct device *dev, struct k_poll_signal *signal)
 {
 	struct video_sw_generator_data *data = dev->data;
 
@@ -261,8 +239,7 @@ static int video_sw_generator_set_signal(const struct device *dev, enum video_en
 }
 #endif
 
-static int video_sw_generator_set_frmival(const struct device *dev, enum video_endpoint_id ep,
-					  struct video_frmival *frmival)
+static int video_sw_generator_set_frmival(const struct device *dev, struct video_frmival *frmival)
 {
 	struct video_sw_generator_data *data = dev->data;
 
@@ -279,8 +256,7 @@ static int video_sw_generator_set_frmival(const struct device *dev, enum video_e
 	return 0;
 }
 
-static int video_sw_generator_get_frmival(const struct device *dev, enum video_endpoint_id ep,
-					  struct video_frmival *frmival)
+static int video_sw_generator_get_frmival(const struct device *dev, struct video_frmival *frmival)
 {
 	struct video_sw_generator_data *data = dev->data;
 
@@ -290,14 +266,9 @@ static int video_sw_generator_get_frmival(const struct device *dev, enum video_e
 	return 0;
 }
 
-static int video_sw_generator_enum_frmival(const struct device *dev, enum video_endpoint_id ep,
-					   struct video_frmival_enum *fie)
+static int video_sw_generator_enum_frmival(const struct device *dev, struct video_frmival_enum *fie)
 {
 	int i = 0;
-
-	if (ep != VIDEO_EP_OUT || fie->index) {
-		return -EINVAL;
-	}
 
 	while (fmts[i].pixelformat && (fmts[i].pixelformat != fie->format->pixelformat)) {
 		i++;

--- a/drivers/video/video_sw_generator.c
+++ b/drivers/video/video_sw_generator.c
@@ -95,7 +95,8 @@ static int video_sw_generator_get_fmt(const struct device *dev, struct video_for
 	return 0;
 }
 
-static int video_sw_generator_set_stream(const struct device *dev, bool enable)
+static int video_sw_generator_set_stream(const struct device *dev, bool enable,
+					 enum video_buf_type type)
 {
 	struct video_sw_generator_data *data = dev->data;
 

--- a/include/zephyr/drivers/video.h
+++ b/include/zephyr/drivers/video.h
@@ -206,22 +206,6 @@ struct video_frmival_enum {
 };
 
 /**
- * @brief video_endpoint_id enum
- *
- * Identify the video device endpoint.
- */
-enum video_endpoint_id {
-	/** Targets some part of the video device not bound to an endpoint */
-	VIDEO_EP_NONE = -1,
-	/** Targets all input or output endpoints of the device */
-	VIDEO_EP_ALL = -2,
-	/** Targets all input endpoints of the device: those consuming data */
-	VIDEO_EP_IN = -3,
-	/** Targets all output endpoints of the device: those producing data */
-	VIDEO_EP_OUT = -4,
-};
-
-/**
  * @brief video_event enum
  *
  * Identify video event.
@@ -238,8 +222,7 @@ enum video_signal_result {
  *
  * See video_set_format() for argument descriptions.
  */
-typedef int (*video_api_set_format_t)(const struct device *dev, enum video_endpoint_id ep,
-				      struct video_format *fmt);
+typedef int (*video_api_set_format_t)(const struct device *dev, struct video_format *fmt);
 
 /**
  * @typedef video_api_get_format_t
@@ -247,8 +230,7 @@ typedef int (*video_api_set_format_t)(const struct device *dev, enum video_endpo
  *
  * See video_get_format() for argument descriptions.
  */
-typedef int (*video_api_get_format_t)(const struct device *dev, enum video_endpoint_id ep,
-				      struct video_format *fmt);
+typedef int (*video_api_get_format_t)(const struct device *dev, struct video_format *fmt);
 
 /**
  * @typedef video_api_set_frmival_t
@@ -256,8 +238,7 @@ typedef int (*video_api_get_format_t)(const struct device *dev, enum video_endpo
  *
  * See video_set_frmival() for argument descriptions.
  */
-typedef int (*video_api_set_frmival_t)(const struct device *dev, enum video_endpoint_id ep,
-				       struct video_frmival *frmival);
+typedef int (*video_api_set_frmival_t)(const struct device *dev, struct video_frmival *frmival);
 
 /**
  * @typedef video_api_get_frmival_t
@@ -265,8 +246,7 @@ typedef int (*video_api_set_frmival_t)(const struct device *dev, enum video_endp
  *
  * See video_get_frmival() for argument descriptions.
  */
-typedef int (*video_api_get_frmival_t)(const struct device *dev, enum video_endpoint_id ep,
-				       struct video_frmival *frmival);
+typedef int (*video_api_get_frmival_t)(const struct device *dev, struct video_frmival *frmival);
 
 /**
  * @typedef video_api_enum_frmival_t
@@ -274,8 +254,7 @@ typedef int (*video_api_get_frmival_t)(const struct device *dev, enum video_endp
  *
  * See video_enum_frmival() for argument descriptions.
  */
-typedef int (*video_api_enum_frmival_t)(const struct device *dev, enum video_endpoint_id ep,
-					struct video_frmival_enum *fie);
+typedef int (*video_api_enum_frmival_t)(const struct device *dev, struct video_frmival_enum *fie);
 
 /**
  * @typedef video_api_enqueue_t
@@ -283,8 +262,7 @@ typedef int (*video_api_enum_frmival_t)(const struct device *dev, enum video_end
  *
  * See video_enqueue() for argument descriptions.
  */
-typedef int (*video_api_enqueue_t)(const struct device *dev, enum video_endpoint_id ep,
-				   struct video_buffer *buf);
+typedef int (*video_api_enqueue_t)(const struct device *dev, struct video_buffer *buf);
 
 /**
  * @typedef video_api_dequeue_t
@@ -292,8 +270,8 @@ typedef int (*video_api_enqueue_t)(const struct device *dev, enum video_endpoint
  *
  * See video_dequeue() for argument descriptions.
  */
-typedef int (*video_api_dequeue_t)(const struct device *dev, enum video_endpoint_id ep,
-				   struct video_buffer **buf, k_timeout_t timeout);
+typedef int (*video_api_dequeue_t)(const struct device *dev, struct video_buffer **buf,
+				   k_timeout_t timeout);
 
 /**
  * @typedef video_api_flush_t
@@ -302,7 +280,7 @@ typedef int (*video_api_dequeue_t)(const struct device *dev, enum video_endpoint
  *
  * See video_flush() for argument descriptions.
  */
-typedef int (*video_api_flush_t)(const struct device *dev, enum video_endpoint_id ep, bool cancel);
+typedef int (*video_api_flush_t)(const struct device *dev, bool cancel);
 
 /**
  * @typedef video_api_set_stream_t
@@ -332,8 +310,7 @@ typedef int (*video_api_ctrl_t)(const struct device *dev, uint32_t cid);
  *
  * See video_get_caps() for argument descriptions.
  */
-typedef int (*video_api_get_caps_t)(const struct device *dev, enum video_endpoint_id ep,
-				    struct video_caps *caps);
+typedef int (*video_api_get_caps_t)(const struct device *dev, struct video_caps *caps);
 
 /**
  * @typedef video_api_set_signal_t
@@ -341,8 +318,7 @@ typedef int (*video_api_get_caps_t)(const struct device *dev, enum video_endpoin
  *
  * See video_set_signal() for argument descriptions.
  */
-typedef int (*video_api_set_signal_t)(const struct device *dev, enum video_endpoint_id ep,
-				      struct k_poll_signal *signal);
+typedef int (*video_api_set_signal_t)(const struct device *dev, struct k_poll_signal *signal);
 
 __subsystem struct video_driver_api {
 	/* mandatory callbacks */
@@ -368,7 +344,6 @@ __subsystem struct video_driver_api {
  * Configure video device with a specific format.
  *
  * @param dev Pointer to the device structure for the driver instance.
- * @param ep Endpoint ID.
  * @param fmt Pointer to a video format struct.
  *
  * @retval 0 Is successful.
@@ -376,8 +351,7 @@ __subsystem struct video_driver_api {
  * @retval -ENOTSUP If format is not supported.
  * @retval -EIO General input / output error.
  */
-static inline int video_set_format(const struct device *dev, enum video_endpoint_id ep,
-				   struct video_format *fmt)
+static inline int video_set_format(const struct device *dev, struct video_format *fmt)
 {
 	const struct video_driver_api *api = (const struct video_driver_api *)dev->api;
 
@@ -385,7 +359,7 @@ static inline int video_set_format(const struct device *dev, enum video_endpoint
 		return -ENOSYS;
 	}
 
-	return api->set_format(dev, ep, fmt);
+	return api->set_format(dev, fmt);
 }
 
 /**
@@ -394,13 +368,11 @@ static inline int video_set_format(const struct device *dev, enum video_endpoint
  * Get video device current video format.
  *
  * @param dev Pointer to the device structure for the driver instance.
- * @param ep Endpoint ID.
  * @param fmt Pointer to video format struct.
  *
  * @retval pointer to video format
  */
-static inline int video_get_format(const struct device *dev, enum video_endpoint_id ep,
-				   struct video_format *fmt)
+static inline int video_get_format(const struct device *dev, struct video_format *fmt)
 {
 	const struct video_driver_api *api = (const struct video_driver_api *)dev->api;
 
@@ -408,7 +380,7 @@ static inline int video_get_format(const struct device *dev, enum video_endpoint
 		return -ENOSYS;
 	}
 
-	return api->get_format(dev, ep, fmt);
+	return api->get_format(dev, fmt);
 }
 
 /**
@@ -420,7 +392,6 @@ static inline int video_get_format(const struct device *dev, enum video_endpoint
  * capabilities. They must instead modify the interval to match what the hardware can provide.
  *
  * @param dev Pointer to the device structure for the driver instance.
- * @param ep Endpoint ID.
  * @param frmival Pointer to a video frame interval struct.
  *
  * @retval 0 If successful.
@@ -428,8 +399,7 @@ static inline int video_get_format(const struct device *dev, enum video_endpoint
  * @retval -EINVAL If parameters are invalid.
  * @retval -EIO General input / output error.
  */
-static inline int video_set_frmival(const struct device *dev, enum video_endpoint_id ep,
-				    struct video_frmival *frmival)
+static inline int video_set_frmival(const struct device *dev, struct video_frmival *frmival)
 {
 	const struct video_driver_api *api = (const struct video_driver_api *)dev->api;
 
@@ -437,7 +407,7 @@ static inline int video_set_frmival(const struct device *dev, enum video_endpoin
 		return -ENOSYS;
 	}
 
-	return api->set_frmival(dev, ep, frmival);
+	return api->set_frmival(dev, frmival);
 }
 
 /**
@@ -446,7 +416,6 @@ static inline int video_set_frmival(const struct device *dev, enum video_endpoin
  * Get current frame interval of the video device.
  *
  * @param dev Pointer to the device structure for the driver instance.
- * @param ep Endpoint ID.
  * @param frmival Pointer to a video frame interval struct.
  *
  * @retval 0 If successful.
@@ -454,8 +423,7 @@ static inline int video_set_frmival(const struct device *dev, enum video_endpoin
  * @retval -EINVAL If parameters are invalid.
  * @retval -EIO General input / output error.
  */
-static inline int video_get_frmival(const struct device *dev, enum video_endpoint_id ep,
-				    struct video_frmival *frmival)
+static inline int video_get_frmival(const struct device *dev, struct video_frmival *frmival)
 {
 	const struct video_driver_api *api = (const struct video_driver_api *)dev->api;
 
@@ -463,7 +431,7 @@ static inline int video_get_frmival(const struct device *dev, enum video_endpoin
 		return -ENOSYS;
 	}
 
-	return api->get_frmival(dev, ep, frmival);
+	return api->get_frmival(dev, frmival);
 }
 
 /**
@@ -476,7 +444,6 @@ static inline int video_get_frmival(const struct device *dev, enum video_endpoin
  * used to iterate through the supported frame intervals list.
  *
  * @param dev Pointer to the device structure for the driver instance.
- * @param ep Endpoint ID.
  * @param fie Pointer to a video frame interval enumeration struct.
  *
  * @retval 0 If successful.
@@ -484,8 +451,7 @@ static inline int video_get_frmival(const struct device *dev, enum video_endpoin
  * @retval -EINVAL If parameters are invalid.
  * @retval -EIO General input / output error.
  */
-static inline int video_enum_frmival(const struct device *dev, enum video_endpoint_id ep,
-				     struct video_frmival_enum *fie)
+static inline int video_enum_frmival(const struct device *dev, struct video_frmival_enum *fie)
 {
 	const struct video_driver_api *api = (const struct video_driver_api *)dev->api;
 
@@ -493,7 +459,7 @@ static inline int video_enum_frmival(const struct device *dev, enum video_endpoi
 		return -ENOSYS;
 	}
 
-	return api->enum_frmival(dev, ep, fie);
+	return api->enum_frmival(dev, fie);
 }
 
 /**
@@ -503,15 +469,13 @@ static inline int video_enum_frmival(const struct device *dev, enum video_endpoi
  * endpoint incoming queue.
  *
  * @param dev Pointer to the device structure for the driver instance.
- * @param ep Endpoint ID.
  * @param buf Pointer to the video buffer.
  *
  * @retval 0 Is successful.
  * @retval -EINVAL If parameters are invalid.
  * @retval -EIO General input / output error.
  */
-static inline int video_enqueue(const struct device *dev, enum video_endpoint_id ep,
-				struct video_buffer *buf)
+static inline int video_enqueue(const struct device *dev, struct video_buffer *buf)
 {
 	const struct video_driver_api *api = (const struct video_driver_api *)dev->api;
 
@@ -519,7 +483,7 @@ static inline int video_enqueue(const struct device *dev, enum video_endpoint_id
 		return -ENOSYS;
 	}
 
-	return api->enqueue(dev, ep, buf);
+	return api->enqueue(dev, buf);
 }
 
 /**
@@ -529,7 +493,6 @@ static inline int video_enqueue(const struct device *dev, enum video_endpoint_id
  * endpoint outgoing queue.
  *
  * @param dev Pointer to the device structure for the driver instance.
- * @param ep Endpoint ID.
  * @param buf Pointer a video buffer pointer.
  * @param timeout Timeout
  *
@@ -537,8 +500,8 @@ static inline int video_enqueue(const struct device *dev, enum video_endpoint_id
  * @retval -EINVAL If parameters are invalid.
  * @retval -EIO General input / output error.
  */
-static inline int video_dequeue(const struct device *dev, enum video_endpoint_id ep,
-				struct video_buffer **buf, k_timeout_t timeout)
+static inline int video_dequeue(const struct device *dev, struct video_buffer **buf,
+				k_timeout_t timeout)
 {
 	const struct video_driver_api *api = (const struct video_driver_api *)dev->api;
 
@@ -546,7 +509,7 @@ static inline int video_dequeue(const struct device *dev, enum video_endpoint_id
 		return -ENOSYS;
 	}
 
-	return api->dequeue(dev, ep, buf, timeout);
+	return api->dequeue(dev, buf, timeout);
 }
 
 /**
@@ -557,13 +520,12 @@ static inline int video_dequeue(const struct device *dev, enum video_endpoint_id
  * through the video function.
  *
  * @param dev Pointer to the device structure for the driver instance.
- * @param ep Endpoint ID.
  * @param cancel If true, cancel buffer processing instead of waiting for
  *        completion.
  *
  * @retval 0 Is successful, -ERRNO code otherwise.
  */
-static inline int video_flush(const struct device *dev, enum video_endpoint_id ep, bool cancel)
+static inline int video_flush(const struct device *dev, bool cancel)
 {
 	const struct video_driver_api *api = (const struct video_driver_api *)dev->api;
 
@@ -571,7 +533,7 @@ static inline int video_flush(const struct device *dev, enum video_endpoint_id e
 		return -ENOSYS;
 	}
 
-	return api->flush(dev, ep, cancel);
+	return api->flush(dev, cancel);
 }
 
 /**
@@ -616,7 +578,7 @@ static inline int video_stream_stop(const struct device *dev)
 	}
 
 	ret = api->set_stream(dev, false);
-	video_flush(dev, VIDEO_EP_ALL, true);
+	video_flush(dev, true);
 
 	return ret;
 }
@@ -625,13 +587,11 @@ static inline int video_stream_stop(const struct device *dev)
  * @brief Get the capabilities of a video endpoint.
  *
  * @param dev Pointer to the device structure for the driver instance.
- * @param ep Endpoint ID.
  * @param caps Pointer to the video_caps struct to fill.
  *
  * @retval 0 Is successful, -ERRNO code otherwise.
  */
-static inline int video_get_caps(const struct device *dev, enum video_endpoint_id ep,
-				 struct video_caps *caps)
+static inline int video_get_caps(const struct device *dev, struct video_caps *caps)
 {
 	const struct video_driver_api *api = (const struct video_driver_api *)dev->api;
 
@@ -639,7 +599,7 @@ static inline int video_get_caps(const struct device *dev, enum video_endpoint_i
 		return -ENOSYS;
 	}
 
-	return api->get_caps(dev, ep, caps);
+	return api->get_caps(dev, caps);
 }
 
 /**
@@ -717,13 +677,11 @@ void video_print_ctrl(const struct device *const dev, const struct video_ctrl_qu
  * unregisters any previously registered signal.
  *
  * @param dev Pointer to the device structure for the driver instance.
- * @param ep Endpoint ID.
  * @param signal Pointer to k_poll_signal
  *
  * @retval 0 Is successful, -ERRNO code otherwise.
  */
-static inline int video_set_signal(const struct device *dev, enum video_endpoint_id ep,
-				   struct k_poll_signal *signal)
+static inline int video_set_signal(const struct device *dev, struct k_poll_signal *signal)
 {
 	const struct video_driver_api *api = (const struct video_driver_api *)dev->api;
 
@@ -731,7 +689,7 @@ static inline int video_set_signal(const struct device *dev, enum video_endpoint
 		return -ENOSYS;
 	}
 
-	return api->set_signal(dev, ep, signal);
+	return api->set_signal(dev, signal);
 }
 
 /**
@@ -813,11 +771,9 @@ void video_closest_frmival_stepwise(const struct video_frmival_stepwise *stepwis
  * - @c match->index to the index of the closest frame interval.
  *
  * @param dev Video device to query.
- * @param ep Video endpoint ID to query.
  * @param match Frame interval enumerator with the query, and loaded with the result.
  */
-void video_closest_frmival(const struct device *dev, enum video_endpoint_id ep,
-			   struct video_frmival_enum *match);
+void video_closest_frmival(const struct device *dev, struct video_frmival_enum *match);
 
 /**
  * @defgroup video_pixel_formats Video pixel formats

--- a/include/zephyr/drivers/video.h
+++ b/include/zephyr/drivers/video.h
@@ -341,7 +341,7 @@ typedef int (*video_api_get_caps_t)(const struct device *dev, struct video_caps 
  *
  * See video_set_signal() for argument descriptions.
  */
-typedef int (*video_api_set_signal_t)(const struct device *dev, struct k_poll_signal *signal);
+typedef int (*video_api_set_signal_t)(const struct device *dev, struct k_poll_signal *sig);
 
 __subsystem struct video_driver_api {
 	/* mandatory callbacks */
@@ -706,11 +706,11 @@ void video_print_ctrl(const struct device *const dev, const struct video_ctrl_qu
  * unregisters any previously registered signal.
  *
  * @param dev Pointer to the device structure for the driver instance.
- * @param signal Pointer to k_poll_signal
+ * @param sig Pointer to k_poll_signal
  *
  * @retval 0 Is successful, -ERRNO code otherwise.
  */
-static inline int video_set_signal(const struct device *dev, struct k_poll_signal *signal)
+static inline int video_set_signal(const struct device *dev, struct k_poll_signal *sig)
 {
 	const struct video_driver_api *api = (const struct video_driver_api *)dev->api;
 
@@ -718,7 +718,7 @@ static inline int video_set_signal(const struct device *dev, struct k_poll_signa
 		return -ENOSYS;
 	}
 
-	return api->set_signal(dev, signal);
+	return api->set_signal(dev, sig);
 }
 
 /**

--- a/samples/drivers/video/capture/src/main.c
+++ b/samples/drivers/video/capture/src/main.c
@@ -95,6 +95,7 @@ int main(void)
 	struct video_caps caps;
 	struct video_frmival frmival;
 	struct video_frmival_enum fie;
+	enum video_buf_type type = VIDEO_BUF_TYPE_OUTPUT;
 	unsigned int frame = 0;
 	size_t bsize;
 	int i = 0;
@@ -119,6 +120,7 @@ int main(void)
 	LOG_INF("Video device: %s", video_dev->name);
 
 	/* Get capabilities */
+	caps.type = type;
 	if (video_get_caps(video_dev, &caps)) {
 		LOG_ERR("Unable to retrieve video capabilities");
 		return 0;
@@ -136,6 +138,7 @@ int main(void)
 	}
 
 	/* Get default/native format */
+	fmt.type = type;
 	if (video_get_format(video_dev, &fmt)) {
 		LOG_ERR("Unable to retrieve video format");
 		return 0;
@@ -238,12 +241,12 @@ int main(void)
 			LOG_ERR("Unable to alloc video buffer");
 			return 0;
 		}
-
+		buffers[i]->type = type;
 		video_enqueue(video_dev, buffers[i]);
 	}
 
 	/* Start video capture */
-	if (video_stream_start(video_dev)) {
+	if (video_stream_start(video_dev, type)) {
 		LOG_ERR("Unable to start capture (interface)");
 		return 0;
 	}
@@ -251,6 +254,7 @@ int main(void)
 	LOG_INF("Capture started");
 
 	/* Grab video frames */
+	vbuf->type = type;
 	while (1) {
 		err = video_dequeue(video_dev, &vbuf, K_FOREVER);
 		if (err) {

--- a/samples/drivers/video/capture/src/main.c
+++ b/samples/drivers/video/capture/src/main.c
@@ -119,7 +119,7 @@ int main(void)
 	LOG_INF("Video device: %s", video_dev->name);
 
 	/* Get capabilities */
-	if (video_get_caps(video_dev, VIDEO_EP_OUT, &caps)) {
+	if (video_get_caps(video_dev, &caps)) {
 		LOG_ERR("Unable to retrieve video capabilities");
 		return 0;
 	}
@@ -136,7 +136,7 @@ int main(void)
 	}
 
 	/* Get default/native format */
-	if (video_get_format(video_dev, VIDEO_EP_OUT, &fmt)) {
+	if (video_get_format(video_dev, &fmt)) {
 		LOG_ERR("Unable to retrieve video format");
 		return 0;
 	}
@@ -157,12 +157,12 @@ int main(void)
 	LOG_INF("- Video format: %s %ux%u",
 		VIDEO_FOURCC_TO_STR(fmt.pixelformat), fmt.width, fmt.height);
 
-	if (video_set_format(video_dev, VIDEO_EP_OUT, &fmt)) {
+	if (video_set_format(video_dev, &fmt)) {
 		LOG_ERR("Unable to set format");
 		return 0;
 	}
 
-	if (!video_get_frmival(video_dev, VIDEO_EP_OUT, &frmival)) {
+	if (!video_get_frmival(video_dev, &frmival)) {
 		LOG_INF("- Default frame rate : %f fps",
 		       1.0 * frmival.denominator / frmival.numerator);
 	}
@@ -170,7 +170,7 @@ int main(void)
 	LOG_INF("- Supported frame intervals for the default format:");
 	memset(&fie, 0, sizeof(fie));
 	fie.format = &fmt;
-	while (video_enum_frmival(video_dev, VIDEO_EP_OUT, &fie) == 0) {
+	while (video_enum_frmival(video_dev, &fie) == 0) {
 		if (fie.type == VIDEO_FRMIVAL_TYPE_DISCRETE) {
 			LOG_INF("   %u/%u ", fie.discrete.numerator, fie.discrete.denominator);
 		} else {
@@ -239,7 +239,7 @@ int main(void)
 			return 0;
 		}
 
-		video_enqueue(video_dev, VIDEO_EP_OUT, buffers[i]);
+		video_enqueue(video_dev, buffers[i]);
 	}
 
 	/* Start video capture */
@@ -252,7 +252,7 @@ int main(void)
 
 	/* Grab video frames */
 	while (1) {
-		err = video_dequeue(video_dev, VIDEO_EP_OUT, &vbuf, K_FOREVER);
+		err = video_dequeue(video_dev, &vbuf, K_FOREVER);
 		if (err) {
 			LOG_ERR("Unable to dequeue video buf");
 			return 0;
@@ -271,7 +271,7 @@ int main(void)
 		video_display_frame(display_dev, vbuf, fmt);
 #endif
 
-		err = video_enqueue(video_dev, VIDEO_EP_OUT, vbuf);
+		err = video_enqueue(video_dev, vbuf);
 		if (err) {
 			LOG_ERR("Unable to requeue video buf");
 			return 0;

--- a/samples/drivers/video/capture_to_lvgl/src/main.c
+++ b/samples/drivers/video/capture_to_lvgl/src/main.c
@@ -50,7 +50,7 @@ int main(void)
 	LOG_INF("- Device name: %s", video_dev->name);
 
 	/* Get capabilities */
-	if (video_get_caps(video_dev, VIDEO_EP_OUT, &caps)) {
+	if (video_get_caps(video_dev, &caps)) {
 		LOG_ERR("Unable to retrieve video capabilities");
 		return 0;
 	}
@@ -68,7 +68,7 @@ int main(void)
 	}
 
 	/* Get default/native format */
-	if (video_get_format(video_dev, VIDEO_EP_OUT, &fmt)) {
+	if (video_get_format(video_dev, &fmt)) {
 		LOG_ERR("Unable to retrieve video format");
 		return 0;
 	}
@@ -79,7 +79,7 @@ int main(void)
 	fmt.pitch = fmt.width * 2;
 	fmt.pixelformat = VIDEO_PIX_FMT_RGB565;
 
-	if (video_set_format(video_dev, VIDEO_EP_OUT, &fmt)) {
+	if (video_set_format(video_dev, &fmt)) {
 		LOG_ERR("Unable to set up video format");
 		return 0;
 	}
@@ -103,7 +103,7 @@ int main(void)
 			return 0;
 		}
 
-		video_enqueue(video_dev, VIDEO_EP_OUT, buffers[i]);
+		video_enqueue(video_dev, buffers[i]);
 	}
 
 	/* Set controls */
@@ -142,7 +142,7 @@ int main(void)
 	while (1) {
 		int err;
 
-		err = video_dequeue(video_dev, VIDEO_EP_OUT, &vbuf, K_FOREVER);
+		err = video_dequeue(video_dev, &vbuf, K_FOREVER);
 		if (err) {
 			LOG_ERR("Unable to dequeue video buf");
 			return 0;
@@ -153,7 +153,7 @@ int main(void)
 
 		lv_task_handler();
 
-		err = video_enqueue(video_dev, VIDEO_EP_OUT, vbuf);
+		err = video_enqueue(video_dev, vbuf);
 		if (err) {
 			LOG_ERR("Unable to requeue video buf");
 			return 0;

--- a/samples/drivers/video/capture_to_lvgl/src/main.c
+++ b/samples/drivers/video/capture_to_lvgl/src/main.c
@@ -23,6 +23,7 @@ int main(void)
 	const struct device *display_dev;
 	struct video_format fmt;
 	struct video_caps caps;
+	enum video_buf_type type = VIDEO_BUF_TYPE_OUTPUT;
 	const struct device *video_dev;
 	size_t bsize;
 	int i = 0;
@@ -50,6 +51,7 @@ int main(void)
 	LOG_INF("- Device name: %s", video_dev->name);
 
 	/* Get capabilities */
+	caps.type = type;
 	if (video_get_caps(video_dev, &caps)) {
 		LOG_ERR("Unable to retrieve video capabilities");
 		return 0;
@@ -68,6 +70,7 @@ int main(void)
 	}
 
 	/* Get default/native format */
+	fmt.type = type;
 	if (video_get_format(video_dev, &fmt)) {
 		LOG_ERR("Unable to retrieve video format");
 		return 0;
@@ -102,7 +105,7 @@ int main(void)
 			LOG_ERR("Unable to alloc video buffer");
 			return 0;
 		}
-
+		buffers[i]->type = type;
 		video_enqueue(video_dev, buffers[i]);
 	}
 
@@ -119,7 +122,7 @@ int main(void)
 	}
 
 	/* Start video capture */
-	if (video_stream_start(video_dev)) {
+	if (video_stream_start(video_dev, type)) {
 		LOG_ERR("Unable to start capture (interface)");
 		return 0;
 	}
@@ -139,6 +142,7 @@ int main(void)
 	LOG_INF("- Capture started");
 
 	/* Grab video frames */
+	vbuf->type = type;
 	while (1) {
 		int err;
 

--- a/samples/drivers/video/tcpserversink/src/main.c
+++ b/samples/drivers/video/tcpserversink/src/main.c
@@ -42,6 +42,7 @@ int main(void)
 	int i, ret, sock, client;
 	struct video_format fmt;
 	struct video_caps caps;
+	enum video_buf_type type = VIDEO_BUF_TYPE_OUTPUT;
 #if DT_HAS_CHOSEN(zephyr_camera)
 	const struct device *const video = DEVICE_DT_GET(DT_CHOSEN(zephyr_camera));
 
@@ -83,12 +84,14 @@ int main(void)
 	}
 
 	/* Get capabilities */
+	caps.type = type;
 	if (video_get_caps(video, &caps)) {
 		LOG_ERR("Unable to retrieve video capabilities");
 		return 0;
 	}
 
 	/* Get default/native format */
+	fmt.type = type;
 	if (video_get_format(video, &fmt)) {
 		LOG_ERR("Unable to retrieve video format");
 		return 0;
@@ -109,6 +112,7 @@ int main(void)
 			LOG_ERR("Unable to alloc video buffer");
 			return 0;
 		}
+		buffers[i]->type = type;
 	}
 
 	/* Connection loop */
@@ -129,7 +133,7 @@ int main(void)
 		}
 
 		/* Start video capture */
-		if (video_stream_start(video)) {
+		if (video_stream_start(video, type)) {
 			LOG_ERR("Unable to start video");
 			return 0;
 		}
@@ -138,6 +142,7 @@ int main(void)
 
 		/* Capture loop */
 		i = 0;
+		vbuf->type = type;
 		do {
 			ret = video_dequeue(video, &vbuf, K_FOREVER);
 			if (ret) {
@@ -159,7 +164,7 @@ int main(void)
 		} while (!ret);
 
 		/* stop capture */
-		if (video_stream_stop(video)) {
+		if (video_stream_stop(video, type)) {
 			LOG_ERR("Unable to stop video");
 			return 0;
 		}

--- a/samples/drivers/video/tcpserversink/src/main.c
+++ b/samples/drivers/video/tcpserversink/src/main.c
@@ -83,13 +83,13 @@ int main(void)
 	}
 
 	/* Get capabilities */
-	if (video_get_caps(video, VIDEO_EP_OUT, &caps)) {
+	if (video_get_caps(video, &caps)) {
 		LOG_ERR("Unable to retrieve video capabilities");
 		return 0;
 	}
 
 	/* Get default/native format */
-	if (video_get_format(video, VIDEO_EP_OUT, &fmt)) {
+	if (video_get_format(video, &fmt)) {
 		LOG_ERR("Unable to retrieve video format");
 		return 0;
 	}
@@ -125,7 +125,7 @@ int main(void)
 
 		/* Enqueue Buffers */
 		for (i = 0; i < ARRAY_SIZE(buffers); i++) {
-			video_enqueue(video, VIDEO_EP_OUT, buffers[i]);
+			video_enqueue(video, buffers[i]);
 		}
 
 		/* Start video capture */
@@ -139,7 +139,7 @@ int main(void)
 		/* Capture loop */
 		i = 0;
 		do {
-			ret = video_dequeue(video, VIDEO_EP_OUT, &vbuf, K_FOREVER);
+			ret = video_dequeue(video, &vbuf, K_FOREVER);
 			if (ret) {
 				LOG_ERR("Unable to dequeue video buf");
 				return 0;
@@ -155,7 +155,7 @@ int main(void)
 				close(client);
 			}
 
-			(void)video_enqueue(video, VIDEO_EP_OUT, vbuf);
+			(void)video_enqueue(video, vbuf);
 		} while (!ret);
 
 		/* stop capture */
@@ -166,7 +166,7 @@ int main(void)
 
 		/* Flush remaining buffers */
 		do {
-			ret = video_dequeue(video, VIDEO_EP_OUT, &vbuf, K_NO_WAIT);
+			ret = video_dequeue(video, &vbuf, K_NO_WAIT);
 		} while (!ret);
 
 	} while (1);

--- a/tests/drivers/video/api/src/video_emul.c
+++ b/tests/drivers/video/api/src/video_emul.c
@@ -28,7 +28,7 @@ ZTEST(video_common, test_video_format)
 	struct video_caps caps = {0};
 	struct video_format fmt = {0};
 
-	zexpect_ok(video_get_caps(imager_dev, VIDEO_EP_OUT, &caps));
+	zexpect_ok(video_get_caps(imager_dev, &caps));
 
 	/* Test all the formats listed in the caps, the min and max values */
 	for (size_t i = 0; caps.format_caps[i].pixelformat != 0; i++) {
@@ -36,40 +36,40 @@ ZTEST(video_common, test_video_format)
 
 		fmt.height = caps.format_caps[i].height_min;
 		fmt.width = caps.format_caps[i].width_min;
-		zexpect_ok(video_set_format(imager_dev, VIDEO_EP_OUT, &fmt));
-		zexpect_ok(video_get_format(imager_dev, VIDEO_EP_OUT, &fmt));
+		zexpect_ok(video_set_format(imager_dev, &fmt));
+		zexpect_ok(video_get_format(imager_dev, &fmt));
 		zexpect_equal(fmt.pixelformat, caps.format_caps[i].pixelformat);
 		zexpect_equal(fmt.width, caps.format_caps[i].width_min);
 		zexpect_equal(fmt.height, caps.format_caps[i].height_min);
 
 		fmt.height = caps.format_caps[i].height_max;
 		fmt.width = caps.format_caps[i].width_min;
-		zexpect_ok(video_set_format(imager_dev, VIDEO_EP_OUT, &fmt));
-		zexpect_ok(video_get_format(imager_dev, VIDEO_EP_OUT, &fmt));
+		zexpect_ok(video_set_format(imager_dev, &fmt));
+		zexpect_ok(video_get_format(imager_dev, &fmt));
 		zexpect_equal(fmt.pixelformat, caps.format_caps[i].pixelformat);
 		zexpect_equal(fmt.width, caps.format_caps[i].width_max);
 		zexpect_equal(fmt.height, caps.format_caps[i].height_min);
 
 		fmt.height = caps.format_caps[i].height_min;
 		fmt.width = caps.format_caps[i].width_max;
-		zexpect_ok(video_set_format(imager_dev, VIDEO_EP_OUT, &fmt));
-		zexpect_ok(video_get_format(imager_dev, VIDEO_EP_OUT, &fmt));
+		zexpect_ok(video_set_format(imager_dev, &fmt));
+		zexpect_ok(video_get_format(imager_dev, &fmt));
 		zexpect_equal(fmt.pixelformat, caps.format_caps[i].pixelformat);
 		zexpect_equal(fmt.width, caps.format_caps[i].width_min);
 		zexpect_equal(fmt.height, caps.format_caps[i].height_max);
 
 		fmt.height = caps.format_caps[i].height_max;
 		fmt.width = caps.format_caps[i].width_max;
-		zexpect_ok(video_set_format(imager_dev, VIDEO_EP_OUT, &fmt));
-		zexpect_ok(video_get_format(imager_dev, VIDEO_EP_OUT, &fmt));
+		zexpect_ok(video_set_format(imager_dev, &fmt));
+		zexpect_ok(video_get_format(imager_dev, &fmt));
 		zexpect_equal(fmt.pixelformat, caps.format_caps[i].pixelformat);
 		zexpect_equal(fmt.width, caps.format_caps[i].width_max);
 		zexpect_equal(fmt.height, caps.format_caps[i].height_max);
 	}
 
 	fmt.pixelformat = 0x00000000;
-	zexpect_not_ok(video_set_format(imager_dev, VIDEO_EP_OUT, &fmt));
-	zexpect_ok(video_get_format(imager_dev, VIDEO_EP_OUT, &fmt));
+	zexpect_not_ok(video_set_format(imager_dev, &fmt));
+	zexpect_ok(video_get_format(imager_dev, &fmt));
 	zexpect_not_equal(fmt.pixelformat, 0x00000000, "should not store wrong formats");
 }
 
@@ -79,14 +79,14 @@ ZTEST(video_common, test_video_frmival)
 	struct video_frmival_enum fie = {.format = &fmt};
 
 	/* Pick the current format for testing the frame interval enumeration */
-	zexpect_ok(video_get_format(imager_dev, VIDEO_EP_OUT, &fmt));
+	zexpect_ok(video_get_format(imager_dev, &fmt));
 
 	/* Do a first enumeration of frame intervals, expected to work */
-	zexpect_ok(video_enum_frmival(imager_dev, VIDEO_EP_OUT, &fie));
+	zexpect_ok(video_enum_frmival(imager_dev, &fie));
 	zexpect_equal(fie.index, 0, "fie's index should not increment on its own");
 
 	/* Test that every value of the frame interval enumerator can be applied */
-	for (fie.index = 0; video_enum_frmival(imager_dev, VIDEO_EP_OUT, &fie) == 0; fie.index++) {
+	for (fie.index = 0; video_enum_frmival(imager_dev, &fie) == 0; fie.index++) {
 		struct video_frmival q, a;
 		uint32_t min, max, step;
 
@@ -109,8 +109,8 @@ ZTEST(video_common, test_video_frmival)
 
 			/* Test every supported frame interval */
 			for (q.numerator = min; q.numerator <= max; q.numerator += step) {
-				zexpect_ok(video_set_frmival(imager_dev, VIDEO_EP_OUT, &q));
-				zexpect_ok(video_get_frmival(imager_dev, VIDEO_EP_OUT, &a));
+				zexpect_ok(video_set_frmival(imager_dev, &q));
+				zexpect_ok(video_get_frmival(imager_dev, &a));
 				zexpect_equal(video_frmival_nsec(&q), video_frmival_nsec(&a),
 					      "query %u/%u (%u nsec) answer %u/%u (%u nsec, sw)",
 					      q.numerator, q.denominator, video_frmival_nsec(&q),
@@ -120,8 +120,8 @@ ZTEST(video_common, test_video_frmival)
 		case VIDEO_FRMIVAL_TYPE_DISCRETE:
 			/* There is just one frame interval to test */
 			memcpy(&q, &fie.discrete, sizeof(q));
-			zexpect_ok(video_set_frmival(imager_dev, VIDEO_EP_OUT, &q));
-			zexpect_ok(video_get_frmival(imager_dev, VIDEO_EP_OUT, &a));
+			zexpect_ok(video_set_frmival(imager_dev, &q));
+			zexpect_ok(video_get_frmival(imager_dev, &a));
 
 			zexpect_equal(video_frmival_nsec(&fie.discrete), video_frmival_nsec(&a),
 				      "query %u/%u (%u nsec) answer %u/%u (%u nsec, discrete)",
@@ -150,14 +150,14 @@ ZTEST(video_common, test_video_vbuf)
 	struct video_buffer *vbuf = NULL;
 
 	/* Get a list of supported format */
-	zexpect_ok(video_get_caps(rx_dev, VIDEO_EP_OUT, &caps));
+	zexpect_ok(video_get_caps(rx_dev, &caps));
 
 	/* Pick set first format, just to use something supported */
 	fmt.pixelformat = caps.format_caps[0].pixelformat;
 	fmt.width = caps.format_caps[0].width_max;
 	fmt.height = caps.format_caps[0].height_max;
 	fmt.pitch = fmt.width * 2;
-	zexpect_ok(video_set_format(rx_dev, VIDEO_EP_OUT, &fmt));
+	zexpect_ok(video_set_format(rx_dev, &fmt));
 
 	/* Allocate a buffer, assuming prj.conf gives enough memory for it */
 	vbuf = video_buffer_alloc(fmt.pitch * fmt.height, K_NO_WAIT);
@@ -167,21 +167,21 @@ ZTEST(video_common, test_video_vbuf)
 	zexpect_ok(video_stream_start(rx_dev));
 
 	/* Enqueue a first buffer */
-	zexpect_ok(video_enqueue(rx_dev, VIDEO_EP_OUT, vbuf));
+	zexpect_ok(video_enqueue(rx_dev, vbuf));
 
 	/* Receive the completed buffer */
-	zexpect_ok(video_dequeue(rx_dev, VIDEO_EP_OUT, &vbuf, K_FOREVER));
+	zexpect_ok(video_dequeue(rx_dev, &vbuf, K_FOREVER));
 	zexpect_not_null(vbuf);
 	zexpect_equal(vbuf->bytesused, vbuf->size);
 
 	/* Enqueue back the same buffer */
-	zexpect_ok(video_enqueue(rx_dev, VIDEO_EP_OUT, vbuf));
+	zexpect_ok(video_enqueue(rx_dev, vbuf));
 
 	/* Process the remaining buffers */
-	zexpect_ok(video_flush(rx_dev, VIDEO_EP_OUT, false));
+	zexpect_ok(video_flush(rx_dev, false));
 
 	/* Expect the buffer to immediately be available */
-	zexpect_ok(video_dequeue(rx_dev, VIDEO_EP_OUT, &vbuf, K_FOREVER));
+	zexpect_ok(video_dequeue(rx_dev, &vbuf, K_FOREVER));
 	zexpect_not_null(vbuf);
 	zexpect_equal(vbuf->bytesused, vbuf->size);
 


### PR DESCRIPTION
In the video framework, the **`video_endpoint_id`** parameter put in each API function has nothing to do with its meaning and has no usage. They should be removed.

Currently, video drivers in Zephyr upstream are all "typical" video devices e.g., camera sensor, receiver, encoders, etc. which have only **one buffer queue** and does not need to distinguish which buffer queue it operates on. However, devices like ISP, PxP fall into another catergory which (Linux) calls **m2m** devices. For this kind of devices, the driver needs two separate buffer queues and hence needs to distinguish between input (which Linux calls "output") and output (which Linux calls "capture") side.

To support this kind of devices, such as [this PR](https://github.com/zephyrproject-rtos/zephyr/pull/87007) and the NXP PxP, add a **video_buf_type** to distinguish the buffer queue:

- get_caps(), set/get_format(), enqueue()/dequeue() : the buffer type is embeded in the video_caps, video_format and video_buffer structs itself.
- video_stream_start/stop() : buffer type is sent as a parameter
- set/get_ctrl() : no need as control IDs are already different for input and output (and also, we rarely has to set controls on both input and output)
- set/get/enum_frmival() : N/A.