### PR TITLE
doc: _extensions: handle custom bindings in board catalog

### DIFF
--- a/doc/_extensions/zephyr/domain/__init__.py
+++ b/doc/_extensions/zephyr/domain/__init__.py
@@ -957,7 +957,7 @@ class BoardSupportedHardwareDirective(SphinxDirective):
                         reftype="dtcompatible",
                         reftarget=key,
                         refexplicit=False,
-                        refwarn=True,
+                        refwarn=(not value.get("custom_binding", False)),
                     )
                     xref += nodes.literal(text=key)
                     compatible_entry += nodes.paragraph("", "", xref)

--- a/doc/_scripts/gen_boards_catalog.py
+++ b/doc/_scripts/gen_boards_catalog.py
@@ -254,11 +254,13 @@ def get_catalog(generate_hw_features=False):
                         continue
 
                     binding_path = Path(node.binding_path)
-                    binding_type = (
-                        binding_path.relative_to(ZEPHYR_BINDINGS).parts[0]
-                        if binding_path.is_relative_to(ZEPHYR_BINDINGS)
-                        else "misc"
-                    )
+                    is_custom_binding = False
+                    if binding_path.is_relative_to(ZEPHYR_BINDINGS):
+                        binding_type = binding_path.relative_to(ZEPHYR_BINDINGS).parts[0]
+                    else:
+                        binding_type = "misc"
+                        is_custom_binding = True
+
 
                     if node.matching_compat is None:
                         continue
@@ -292,6 +294,7 @@ def get_catalog(generate_hw_features=False):
 
                     feature_data = {
                         "description": description,
+                        "custom_binding": is_custom_binding,
                         "locations": locations,
                         "okay_nodes": [],
                         "disabled_nodes": [],


### PR DESCRIPTION
Boards might have local bindings for which generating links using the dtcompatible role doesn't work -- update the code accordingly so that we can still provide a description of these custom bindings in the table of supported features (but with no hyperlink).

With this PR, a board such as xg24_dk2601b which defines a [custom binding](https://github.com/zephyrproject-rtos/zephyr/blob/25f3de75a29a9267467de1df0baed5f6478332c8/boards/silabs/dev_kits/xg24_dk2601b/dts/bindings/silabs%2Cgecko-wake-up-trigger.yaml) now has a proper entry (but no link!) where, without this PR, a warning would have been generated.

![image](https://github.com/user-attachments/assets/7109a741-aa53-4efa-a2bd-00df20dc13b7)
