### PR TITLE
OpenOCD fixes for MAX32

### DIFF
--- a/boards/common/openocd-adi-max32.boards.cmake
+++ b/boards/common/openocd-adi-max32.boards.cmake
@@ -34,6 +34,7 @@ endif()
 
 board_runner_args(openocd --cmd-pre-init "source [find interface/${MAX32_INTERFACE_CFG}]")
 board_runner_args(openocd --cmd-pre-init "source [find target/${MAX32_TARGET_CFG}]")
+board_runner_args(openocd "--target-handle=_CHIPNAME.cpu")
 
 if(CONFIG_SOC_FAMILY_MAX32_M4)
   board_runner_args(openocd --cmd-pre-init "allow_low_pwr_dbg")

--- a/scripts/west_commands/runners/openocd.py
+++ b/scripts/west_commands/runners/openocd.py
@@ -232,7 +232,8 @@ class OpenOcdBinaryRunner(ZephyrBinaryRunner):
         out = self.check_output([self.openocd_cmd[0], '--version'],
                                 stderr=subprocess.STDOUT).decode()
 
-        version_match = re.search(r"Open On-Chip Debugger v?(\d+.\d+.\d+)", out)
+        # Account for version info format of ADI fork of OpenOCD as well
+        version_match = re.search(r"Open On-Chip Debugger.* v?(\d+.\d+.\d+)[ \n]", out)
         version = version_match.group(1).split('.')
 
         return [to_num(i) for i in version]


### PR DESCRIPTION
Upstream OpenOCD support for MAX32 devices is in the process of [being upstreamed](https://review.openocd.org/c/openocd/+/8794), but in the meantime, the version of OpenOCD bundled in [Code Fusion Studio](https://www.analog.com/en/resources/evaluation-hardware-and-software/embedded-development-software/codefusion-studio.html#software-requirement) uses a modified first line for the version information, e.g.:

```
Open On-Chip Debugger (Analog Devices 0.12.0-1.1.1)  OpenOCD 0.12.0 (2024-08-27-17:25)
Licensed under GNU GPL v2
Report bugs to <processor.tools.support@analog.com>
```

Which causes issues when `west debug`-ing with `CONFIG_DEBUG_THREAD_INFO=y` is set.

This PR:

* Adjusts the version regex to be more forgiving
* Sets the OpenOCD target handle for MAX32 devices so that `west debug` works as expected.

Tested with the MAX32625PICO CMSIS-DAP device shipped with the MAX32690EVKit.