### PR TITLE
drivers: i3c: stm32: fix clock init for i2c fast mode plus

### DIFF
--- a/drivers/i3c/i3c_stm32.c
+++ b/drivers/i3c/i3c_stm32.c
@@ -473,15 +473,16 @@ static int i3c_stm32_calc_scll_od_sclh_i2c(const struct device *dev, uint32_t i2
 						1000000000ull) -
 				   1;
 			*sclh_i2c = DIV_ROUND_UP(i3c_clock, i2c_bus_freq) - *scll_od - 2;
+			if (*sclh_i2c <
+				  (DIV_ROUND_UP(STM32_I3C_SCLH_I2C_MIN_FM_NS * i3c_clock,
+							    1000000000ull) - 1)
+			   ) {
+				LOG_ERR("Cannot find a combination of SCLL_OD and SCLH_I2C at "
+					"current I3C clock frequency for FM I2C bus");
+				return -EINVAL;
+			}
 		}
 
-		if (*sclh_i2c <
-		    DIV_ROUND_UP(STM32_I3C_SCLH_I2C_MIN_FM_NS * i3c_clock, 1000000000ull) - 1) {
-			LOG_ERR("Cannot find a combination of SCLL_OD and SCLH_I2C at current I3C "
-				"clock "
-				"frequency for FM I2C bus");
-			return -EINVAL;
-		}
 	} else {
 		if (config->drv_cfg.dev_list.num_i2c > 0) {
 			enum i3c_bus_mode mode = i3c_bus_mode(&config->drv_cfg.dev_list);


### PR DESCRIPTION
The logic of clock initialization for i2c fast mode (FM) and fast mode plus (FMP) is as follows:
 1 compute how many system clock cycles for SCL to be low
 2 compute how many system clock cycles for SCL to be high by
   subtracting the low duration computed above from the SCL period
 3 verify the high duration computed in 2 is larger than a minimum
The bug is that the step 3 for the FMP is compared with the minimum value for FM, and causes it to fail.

The fix corrects the bug.