### PR TITLE
doc: Initial implementation of CMake reference doc

### DIFF
--- a/.ruff-excludes.toml
+++ b/.ruff-excludes.toml
@@ -14,6 +14,21 @@
 "./boards/microchip/mec172xevb_assy6906/support/mec172x_remote_flasher.py" = [
     "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
 ]
+"./doc/_extensions/moderncmakedomain/cmake.py" = [
+    "B904",     # https://docs.astral.sh/ruff/rules/raise-without-from-inside-except
+    "B905",     # https://docs.astral.sh/ruff/rules/zip-without-explicit-strict
+    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
+    "SIM115",   # https://docs.astral.sh/ruff/rules/open-file-with-context-handler
+    "SIM201",   # https://docs.astral.sh/ruff/rules/negate-equal-op
+    "UP006",    # https://docs.astral.sh/ruff/rules/non-pep585-annotation
+    "UP015",    # https://docs.astral.sh/ruff/rules/redundant-open-modes
+    "UP024",    # https://docs.astral.sh/ruff/rules/os-error-alias
+    "UP035",    # https://docs.astral.sh/ruff/rules/deprecated-import
+]
+"./doc/_extensions/moderncmakedomain/colors.py" = [
+    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
+    "UP009",    # https://docs.astral.sh/ruff/rules/utf8-encoding-declaration
+]
 "./doc/_scripts/redirects.py" = [
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
 ]
@@ -723,6 +738,8 @@
 exclude = [
     "./arch/x86/zefi/zefi.py",
     "./boards/microchip/mec172xevb_assy6906/support/mec172x_remote_flasher.py",
+    "./doc/_extensions/moderncmakedomain/cmake.py",
+    "./doc/_extensions/moderncmakedomain/colors.py",
     "./doc/_scripts/gen_devicetree_rest.py",
     "./doc/_scripts/redirects.py",
     "./doc/conf.py",

--- a/cmake/modules/arch.cmake
+++ b/cmake/modules/arch.cmake
@@ -2,26 +2,27 @@
 #
 # Copyright (c) 2023, Nordic Semiconductor ASA
 
-#
-# Configure ARCH settings based on KConfig settings and arch root.
-#
-# This CMake module will set the following variables in the build system based
-# on board directory and arch root.
-#
-# If no implementation is available for the current arch an error will be raised.
-#
-# Outcome:
-# The following variables will be defined when this CMake module completes:
-#
-# - ARCH:      Name of the arch in use.
-# - ARCH_DIR:  Directory containing the arch implementation.
-# - ARCH_ROOT: ARCH_ROOT with ZEPHYR_BASE appended
-#
-# Variable dependencies:
-# - ARCH_ROOT: CMake list of arch roots containing arch implementations
-#
-# Variables set by this module and not mentioned above are considered internal
-# use only and may be removed, renamed, or re-purposed without prior notice.
+#[=======================================================================[.rst:
+arch
+****
+
+Configure arch settings based on Kconfig settings and arch root.
+
+This CMake module will set the following variables in the build system based on board directory and
+arch root.
+
+If no implementation is available for the current arch, an error will be raised.
+
+Variables
+=========
+
+The following variables will be defined when this CMake module completes:
+
+* :cmake:variable:`ARCH`
+* :cmake:variable:`ARCH_DIR`
+* :cmake:variable:`ARCH_ROOT`
+
+#]=======================================================================]
 
 include_guard(GLOBAL)
 

--- a/cmake/modules/basic_settings.cmake
+++ b/cmake/modules/basic_settings.cmake
@@ -2,22 +2,29 @@
 #
 # Copyright (c) 2022, Nordic Semiconductor ASA
 
-# Setup basic settings for a Zephyr project.
-#
-# Basic settings are:
-# - sysbuild defined configuration settings
-#
-# Details for sysbuild settings:
-#
-# Sysbuild is a higher level build system used by Zephyr.
-# Sysbuild allows users to build multiple samples for a given system.
-#
-# For this to work, sysbuild manages other Zephyr CMake build systems by setting
-# dedicated build variables.
-# This CMake modules loads the sysbuild cache variables as target properties on
-# a sysbuild_cache target.
-#
-# This ensures that quotes and lists are correctly preserved.
+#[=======================================================================[.rst:
+basic_settings
+**************
+
+Setup basic settings for a Zephyr project.
+
+Basic settings are:
+
+* Sysbuild defined configuration settings
+
+Details for sysbuild settings:
+
+Sysbuild is a higher level build system used by Zephyr.
+Sysbuild allows users to build multiple samples for a given system.
+
+For this to work, sysbuild manages other Zephyr CMake build systems by setting
+dedicated build variables.
+This CMake module loads the sysbuild cache variables as target properties on
+a ``sysbuild_cache`` target.
+
+This ensures that quotes and lists are correctly preserved.
+
+#]=======================================================================]
 
 include_guard(GLOBAL)
 

--- a/cmake/modules/boards.cmake
+++ b/cmake/modules/boards.cmake
@@ -2,50 +2,77 @@
 #
 # Copyright (c) 2021, Nordic Semiconductor ASA
 
-# Validate board and setup boards target.
-#
-# This CMake module will validate the BOARD argument as well as splitting the
-# BOARD argument into <BOARD> and <BOARD_REVISION>.
-#
-# If a board implementation is not found for the specified board an error will
-# be raised and list of valid boards will be printed.
-#
-# If user provided board is a board alias, the board will be adjusted to real
-# board name.
-#
-# If board name is deprecated, then board will be adjusted to new board name and
-# a deprecation warning will be printed to the user.
-#
-# Outcome:
-# The following variables will be defined when this CMake module completes:
-#
-# - BOARD:                       Board, without revision field.
-# - BOARD_REVISION:              Board revision
-# - BOARD_QUALIFIERS:            Board qualifiers
-# - NORMALIZED_BOARD_QUALIFIERS: Board qualifiers in lower-case format where slashes have been
-#                                replaced with underscores
-# - NORMALIZED_BOARD_TARGET:     Board target in lower-case format where slashes have been
-#                                replaced with underscores
-# - BOARD_DIR:                   Board directory with the implementation for selected board
-# - ARCH_DIR:                    Arch dir for extracted from selected board
-# - BOARD_ROOT:                  BOARD_ROOT with ZEPHYR_BASE appended
-#
-# The following targets will be defined when this CMake module completes:
-# - boards: when invoked, a list of valid boards will be printed
-#
-# Required variables:
-# - BOARD: Board name, including any optional revision field, for example: `foo` or `foo@1.0.0`
-#
-# Optional variables:
-# - BOARD_ROOT: CMake list of board roots containing board implementations
-# - ARCH_ROOT:  CMake list of arch roots containing arch implementations
-#
-# Optional environment variables:
-# - ZEPHYR_BOARD_ALIASES: Environment setting pointing to a CMake file
-#                         containing board aliases.
-#
-# Variables set by this module and not mentioned above are for internal
-# use only, and may be removed, renamed, or re-purposed without prior notice.
+#[=======================================================================[.rst:
+boards
+######
+
+Validate board and setup boards target.
+
+This CMake module will validate the :cmake:variable:`BOARD` argument as well as splitting it into
+``<BOARD>`` and ``<BOARD_REVISION>``.
+
+If a board implementation is not found for the specified board an error will be raised and list of
+valid boards will be printed.
+
+If user provided board is a board alias, the board will be adjusted to real board name.
+
+If board name is deprecated, then board will be adjusted to new board name and a deprecation warning
+will be printed to the user.
+
+Required variables
+******************
+
+* :cmake:variable:`BOARD`
+
+Optional variables
+******************
+
+* :cmake:variable:`BOARD_ROOT`
+* :cmake:variable:`ARCH_ROOT`
+
+Variables
+*********
+
+The following variables will be defined when this CMake module completes:
+
+* :cmake:variable:`BOARD`
+* :cmake:variable:`BOARD_REVISION`
+* :cmake:variable:`BOARD_QUALIFIERS`
+* :cmake:variable:`NORMALIZED_BOARD_QUALIFIERS`
+* :cmake:variable:`NORMALIZED_BOARD_TARGET`
+* :cmake:variable:`BOARD_DIR`
+* :cmake:variable:`ARCH_DIR`
+* :cmake:variable:`BOARD_ROOT`
+
+Targets
+********
+
+The following targets will be defined when this CMake module completes:
+
+* ``boards``
+
+   When invoked, a list of valid boards will be printed.
+
+Optional environment variables
+******************************
+
+:envvar:`ZEPHYR_BOARD_ALIASES`
+
+  Environment setting pointing to a CMake file containing board aliases.
+
+Example usage
+*************
+
+.. code-block:: cmake
+
+   # BOARD is normally given on the command line, for example:
+   #   west build -b nrf52840dk/nrf52840
+   include(boards)
+
+   message(STATUS "Building for ${BOARD} (${NORMALIZED_BOARD_TARGET})")
+   message(STATUS "Board files are in ${BOARD_DIR}")
+
+#]=======================================================================]
 
 include_guard(GLOBAL)
 

--- a/cmake/modules/configuration_files.cmake
+++ b/cmake/modules/configuration_files.cmake
@@ -2,26 +2,31 @@
 #
 # Copyright (c) 2021, Nordic Semiconductor ASA
 
-# Zephyr build system configuration files.
-#
-# Locate the Kconfig and DT config files that are to be used.
-# Also, locate the appropriate application config directory.
-#
-# Outcome:
-# The following variables will be defined when this CMake module completes:
-#
-# - CONF_FILE:              List of Kconfig fragments
-# - EXTRA_CONF_FILE:        List of additional Kconfig fragments
-# - DTC_OVERLAY_FILE:       List of devicetree overlay files
-# - EXTRA_DTC_OVERLAY_FILE  List of additional devicetree overlay files
-# - DTS_EXTRA_CPPFLAGS      List of additional devicetree preprocessor defines
-# - APPLICATION_CONFIG_DIR: Root folder for application configuration
-#
-# If any of the above variables are already set when this CMake module is
-# loaded, then no changes to the variable will happen.
-#
-# Variables set by this module and not mentioned above are considered internal
-# use only and may be removed, renamed, or re-purposed without prior notice.
+#[=======================================================================[.rst:
+configuration_files
+###################
+
+Locate the Kconfig and DT config files that are to be used.
+Also, locate the appropriate application config directory.
+
+Variables
+*********
+
+The following variables will be defined when this CMake module completes:
+
+* :cmake:variable:`CONF_FILE`
+* :cmake:variable:`EXTRA_CONF_FILE`
+* :cmake:variable:`DTC_OVERLAY_FILE`
+* :cmake:variable:`EXTRA_DTC_OVERLAY_FILE`
+* :cmake:variable:`DTS_EXTRA_CPPFLAGS`
+* :cmake:variable:`APPLICATION_CONFIG_DIR`
+
+If any of the above variables are already set when this CMake module is
+loaded, then no changes to the variable will happen.
+
+Variables set by this module and not mentioned above are considered internal
+use only and may be removed, renamed, or re-purposed without prior notice.
+#]=======================================================================]
 
 include_guard(GLOBAL)
 

--- a/cmake/modules/doc.cmake
+++ b/cmake/modules/doc.cmake
@@ -2,18 +2,23 @@
 #
 # Copyright (c) 2021, Nordic Semiconductor ASA
 
-# This CMake module will load all Zephyr CMake modules required for a
-# documentation build.
-#
-# The following CMake modules will be loaded:
-# - extensions
-# - python
-# - west
-# - root
-# - zephyr_module
-#
-# Outcome:
-# The Zephyr package required for documentation build setup.
+#[=======================================================================[.rst:
+doc
+###
+
+This CMake module will load all Zephyr CMake modules required for a documentation build.
+
+The following CMake modules will be loaded:
+
+* :cmake:module:`extensions`
+* :cmake:module:`python`
+* :cmake:module:`west`
+* ``root``
+* ``zephyr_module``
+
+Outcome:
+The Zephyr package required for documentation build setup.
+#]=======================================================================]
 
 include_guard(GLOBAL)
 

--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -9,6 +9,32 @@ include(yaml)
 include(CheckCCompilerFlag)
 include(CheckCXXCompilerFlag)
 
+
+#[=======================================================================[.rst:
+extensions
+##########
+
+Zephyr's CMake extension commands.
+
+This module defines the commands that Zephyr applications, Zephyr modules, and the build system
+itself use to describe what they build.
+
+Many commands come in an ``_ifdef`` and an ``_ifndef`` flavour, taking a Kconfig option as their
+first argument, so that build rules can be made conditional without wrapping them in an ``if()``
+block.
+
+This module is loaded as part of ``find_package(Zephyr)``, which means that every command documented
+below is available in the :file:`CMakeLists.txt` of any Zephyr application or module.
+
+.. contents::
+   :backlinks: entry
+   :local:
+
+#]=======================================================================]
+
+
+
+
 ########################################################
 # Table of contents
 ########################################################
@@ -41,49 +67,69 @@ include(CheckCXXCompilerFlag)
 # 7.2 add_llext_* build control functions
 # 8. Script mode handling
 
-########################################################
-# 1. Zephyr-aware extensions
-########################################################
-# 1.1. zephyr_*
-#
-# The following methods are for modifying the CMake library[0] called
-# "zephyr". zephyr is a catch-all CMake library for source files that
-# can be built purely with the include paths, defines, and other
-# compiler flags that all zephyr source files use.
-# [0] https://cmake.org/cmake/help/latest/manual/cmake-buildsystem.7.html
-#
-# Example usage:
-# zephyr_sources(
-#   random_esp32.c
-#   utils.c
-# )
-#
-# Is short for:
-# target_sources(zephyr PRIVATE
-#   ${CMAKE_CURRENT_SOURCE_DIR}/random_esp32.c
-#   ${CMAKE_CURRENT_SOURCE_DIR}/utils.c
-# )
-#
-# As a very high-level introduction here are two call graphs that are
-# purposely minimalistic and incomplete.
-#
-#  zephyr_library_cc_option()
-#           |
-#           v
-#  zephyr_library_compile_options()  -->  target_compile_options()
-#
-#
-#  zephyr_cc_option()           --->  target_cc_option()
-#                                          |
-#                                          v
-#  zephyr_cc_option_fallback()  --->  target_cc_option_fallback()
-#                                          |
-#                                          v
-#  zephyr_compile_options()     --->  target_compile_options()
-#
+#[=======================================================================[.rst:
+Zephyr-aware extensions
+***********************
+
+``zephyr_*``
+============
+
+The following methods are for modifying the `CMake library`_ called ``zephyr``. ``zephyr`` is a
+catch-all CMake library for source files that can be built purely with the include paths, defines,
+and other compiler flags that all zephyr source files use.
+
+.. _CMake library: https://cmake.org/cmake/help/latest/manual/cmake-buildsystem.7.html
+
+Example usage:
+
+.. code-block:: cmake
+
+   zephyr_sources(
+     random_esp32.c
+     utils.c
+   )
+
+Is short for:
+
+.. code-block:: cmake
+
+   target_sources(zephyr PRIVATE
+     ${CMAKE_CURRENT_SOURCE_DIR}/random_esp32.c
+     ${CMAKE_CURRENT_SOURCE_DIR}/utils.c
+   )
+
+As a very high-level introduction, here are two call graphs that are
+purposely minimalistic and incomplete.
+
+::
+
+ zephyr_library_cc_option()
+          |
+          v
+ zephyr_library_compile_options()  -->  target_compile_options()
+
+::
+
+ zephyr_cc_option()           --->  target_cc_option()
+                                         |
+                                         v
+ zephyr_cc_option_fallback()  --->  target_cc_option_fallback()
+                                         |
+                                         v
+ zephyr_compile_options()     --->  target_compile_options()
+
+#]=======================================================================]
 
 
-# https://cmake.org/cmake/help/latest/command/target_sources.html
+#[=======================================================================[.rst:
+.. cmake:signature:: zephyr_sources(<sources>...)
+
+   Add sources to the ``zephyr`` library.
+
+   See :cmake:command:`target_sources <command:target_sources>` for details.
+
+
+#]=======================================================================]
 function(zephyr_sources)
   foreach(arg ${ARGV})
     if(IS_DIRECTORY ${arg})
@@ -93,22 +139,46 @@ function(zephyr_sources)
   endforeach()
 endfunction()
 
-# https://cmake.org/cmake/help/latest/command/target_include_directories.html
+#[=======================================================================[.rst:
+.. cmake:signature:: zephyr_include_directories(<dirs>...)
+
+   Add include directories to the ``zephyr`` library.
+
+   See :cmake:command:`target_include_directories <command:target_include_directories>` for details.
+#]=======================================================================]
 function(zephyr_include_directories)
   target_include_directories(zephyr_interface INTERFACE ${ARGV})
 endfunction()
 
-# https://cmake.org/cmake/help/latest/command/target_include_directories.html
+#[=======================================================================[.rst:
+.. cmake:signature:: zephyr_system_include_directories(<dirs>...)
+
+   Add system include directories to the ``zephyr`` library.
+
+   See :cmake:command:`target_include_directories <command:target_include_directories>` for details.
+#]=======================================================================]
 function(zephyr_system_include_directories)
   target_include_directories(zephyr_interface SYSTEM INTERFACE ${ARGV})
 endfunction()
 
-# https://cmake.org/cmake/help/latest/command/target_compile_definitions.html
+#[=======================================================================[.rst:
+.. cmake:signature:: zephyr_compile_definitions(<defs>...)
+
+   Add compile definitions to the ``zephyr`` library.
+
+   See :cmake:command:`target_compile_definitions <command:target_compile_definitions>` for details.
+#]=======================================================================]
 function(zephyr_compile_definitions)
   target_compile_definitions(zephyr_interface INTERFACE ${ARGV})
 endfunction()
 
-# https://cmake.org/cmake/help/latest/command/target_compile_options.html
+#[=======================================================================[.rst:
+.. cmake:signature:: zephyr_compile_options(<options>...)
+
+   Add compile options to the ``zephyr`` library.
+
+   See :cmake:command:`target_compile_options <command:target_compile_options>` for details.
+#]=======================================================================]
 function(zephyr_compile_options)
   if(ARGV0 STREQUAL "PROPERTY")
     set(property $<TARGET_PROPERTY:compiler,${ARGV1}>)
@@ -127,7 +197,13 @@ function(zephyr_compile_options)
   endif()
 endfunction()
 
-# https://cmake.org/cmake/help/latest/command/target_link_libraries.html
+#[=======================================================================[.rst:
+.. cmake:signature:: zephyr_link_libraries(<item>...)
+
+   Add link libraries to the ``zephyr`` library.
+
+   See :cmake:command:`target_link_libraries <command:target_link_libraries>` for details.
+#]=======================================================================]
 function(zephyr_link_libraries)
   if(ARGV0 STREQUAL "PROPERTY")
     set(property $<TARGET_PROPERTY:linker,${ARGV1}>)
@@ -146,21 +222,58 @@ function(zephyr_link_libraries)
   endif()
 endfunction()
 
+#[=======================================================================[.rst:
+
+.. cmake:signature:: zephyr_libc_link_libraries(<item> ...)
+
+   Add link libraries to the ``zephyr`` library's :cmake:prop_tgt:`LIBC_LINK_LIBRARIES` property.
+
+   This function allows subsystems to define libraries which get added to the
+   link command after all other libraries and modules. It's useful when using
+   a toolchain library, like libc or libgcc, as those can get added when
+   processing the 'lib' directory, before any module libraries and hence might
+   not get used to resolve symbols from modules.
+#]=======================================================================]
 function(zephyr_libc_link_libraries)
   set_property(TARGET zephyr_interface APPEND PROPERTY LIBC_LINK_LIBRARIES ${ARGV})
 endfunction()
 
-# See this file section 3.1. target_cc_option
+#[=======================================================================[.rst:
+
+.. cmake:signature:: zephyr_cc_option(<option>...)
+
+   Add compiler options to the ``zephyr`` library, if supported by the compiler.
+
+   This function checks if the compiler supports each option. If supported,
+   it adds the option to the 'zephyr' library.
+
+#]=======================================================================]
 function(zephyr_cc_option)
   foreach(arg ${ARGV})
     target_cc_option(zephyr_interface INTERFACE ${arg})
   endforeach()
 endfunction()
 
+#[=======================================================================[.rst:
+.. cmake:signature:: zephyr_cc_option_fallback(<option1> <option2>)
+
+   Add a compiler option to the ``zephyr`` library, falling back to a second option if the first is
+   not supported.
+
+   This function checks if the compiler supports ``<option1>``. If so, it is added.
+   Otherwise, it checks ``<option2>`` and adds it if supported.
+#]=======================================================================]
 function(zephyr_cc_option_fallback option1 option2)
     target_cc_option_fallback(zephyr_interface INTERFACE ${option1} ${option2})
 endfunction()
 
+#[=======================================================================[.rst:
+.. cmake:signature:: zephyr_ld_options(<options>...)
+
+   Add linker options to the ``zephyr`` library.
+
+   See :cmake:command:`target_ld_options() <command:target_ld_options>` for details.
+#]=======================================================================]
 function(zephyr_ld_options)
     target_ld_options(zephyr_interface INTERFACE ${ARGV})
 endfunction()
@@ -201,6 +314,17 @@ endfunction()
 # zephyr_get_include_directories_for_lang(ASM x)
 # writes "-Isome_dir;-Isome/other/dir" to x
 
+#[=======================================================================[.rst:
+.. cmake:signature:: zephyr_get_include_directories_for_lang_as_string(<lang> <var> [STRIP_PREFIX])
+
+   Get include directories for a specific language as a string.
+
+   Writes the include directories for language ``<lang>`` to variable ``<var>`` as a string.
+
+   ``<lang>`` can be one of ``C``, ``CXX``, or ``ASM``.
+
+   ``STRIP_PREFIX`` can be specified to omit the prefix from the result.
+#]=======================================================================]
 function(zephyr_get_include_directories_for_lang_as_string lang i)
   zephyr_get_include_directories_for_lang(${lang} list_of_flags DELIMITER " " ${ARGN})
 
@@ -209,6 +333,17 @@ function(zephyr_get_include_directories_for_lang_as_string lang i)
   set(${i} ${str_of_flags} PARENT_SCOPE)
 endfunction()
 
+#[=======================================================================[.rst:
+.. cmake:signature:: zephyr_get_system_include_directories_for_lang_as_string(<lang> <var> [STRIP_PREFIX])
+
+   Get system include directories for a specific language as a string.
+
+   Writes the system include directories for language ``<lang>`` to variable ``<var>`` as a string.
+
+   ``<lang>`` can be one of ``C``, ``CXX``, or ``ASM``.
+
+   ``STRIP_PREFIX`` can be specified to omit the prefix from the result.
+#]=======================================================================]
 function(zephyr_get_system_include_directories_for_lang_as_string lang i)
   zephyr_get_system_include_directories_for_lang(${lang} list_of_flags DELIMITER " " ${ARGN})
 
@@ -217,6 +352,17 @@ function(zephyr_get_system_include_directories_for_lang_as_string lang i)
   set(${i} ${str_of_flags} PARENT_SCOPE)
 endfunction()
 
+#[=======================================================================[.rst:
+.. cmake:signature:: zephyr_get_compile_definitions_for_lang_as_string(<lang> <var> [STRIP_PREFIX])
+
+   Get compile definitions for a specific language as a string.
+
+   Writes the compile definitions for language ``<lang>`` to variable ``<var>`` as a string.
+
+   ``<lang>`` can be one of ``C``, ``CXX``, or ``ASM``.
+
+   ``STRIP_PREFIX`` can be specified to omit the prefix from the result.
+#]=======================================================================]
 function(zephyr_get_compile_definitions_for_lang_as_string lang i)
   zephyr_get_compile_definitions_for_lang(${lang} list_of_flags DELIMITER " " ${ARGN})
 
@@ -225,6 +371,17 @@ function(zephyr_get_compile_definitions_for_lang_as_string lang i)
   set(${i} ${str_of_flags} PARENT_SCOPE)
 endfunction()
 
+#[=======================================================================[.rst:
+.. cmake:signature:: zephyr_get_compile_options_for_lang_as_string(<lang> <var> [STRIP_PREFIX])
+
+   Get compile options for a specific language as a string.
+
+   Writes the compile options for language ``<lang>`` to variable ``<var>`` as a string.
+
+   ``<lang>`` can be one of ``C``, ``CXX``, or ``ASM``.
+
+   ``STRIP_PREFIX`` can be specified to omit the prefix from the result.
+#]=======================================================================]
 function(zephyr_get_compile_options_for_lang_as_string lang i)
   zephyr_get_compile_options_for_lang(${lang} list_of_flags DELIMITER " ")
 
@@ -233,6 +390,18 @@ function(zephyr_get_compile_options_for_lang_as_string lang i)
   set(${i} ${str_of_flags} PARENT_SCOPE)
 endfunction()
 
+#[=======================================================================[.rst:
+.. cmake:signature:: zephyr_get_include_directories_for_lang(<lang> <var> [STRIP_PREFIX])
+
+   Get include directories for a specific language as a list.
+
+   Writes the include directories for language ``<lang>`` to variable ``<var>`` as a list.
+
+   ``<lang>`` can be one of ``C``, ``CXX``, or ``ASM``.
+
+   ``STRIP_PREFIX`` can be specified to omit the prefix from the result.
+
+#]=======================================================================]
 function(zephyr_get_include_directories_for_lang lang i)
   zephyr_get_parse_args(args ${ARGN})
   get_property(flags TARGET zephyr_interface PROPERTY INTERFACE_INCLUDE_DIRECTORIES)
@@ -251,6 +420,17 @@ function(zephyr_get_include_directories_for_lang lang i)
   set(${i} ${result_output_list} PARENT_SCOPE)
 endfunction()
 
+#[=======================================================================[.rst:
+.. cmake:signature:: zephyr_get_system_include_directories_for_lang(<lang> <var> [STRIP_PREFIX])
+
+   Get system include directories for a specific language as a list.
+
+   Writes the system include directories for language ``<lang>`` to variable ``<var>`` as a list.
+
+   ``<lang>`` can be one of ``C``, ``CXX``, or ``ASM``.
+
+   ``STRIP_PREFIX`` can be specified to omit the prefix from the result.
+#]=======================================================================]
 function(zephyr_get_system_include_directories_for_lang lang i)
   zephyr_get_parse_args(args ${ARGN})
   get_property(flags TARGET zephyr_interface PROPERTY INTERFACE_SYSTEM_INCLUDE_DIRECTORIES)
@@ -264,6 +444,17 @@ function(zephyr_get_system_include_directories_for_lang lang i)
   set(${i} ${result_output_list} PARENT_SCOPE)
 endfunction()
 
+#[=======================================================================[.rst:
+.. cmake:signature:: zephyr_get_compile_definitions_for_lang(<lang> <var> [STRIP_PREFIX])
+
+   Get compile definitions for a specific language as a list.
+
+   Writes the compile definitions for language ``<lang>`` to variable ``<var>`` as a list.
+
+   ``<lang>`` can be one of ``C``, ``CXX``, or ``ASM``.
+
+   ``STRIP_PREFIX`` can be specified to omit the prefix from the result.
+#]=======================================================================]
 function(zephyr_get_compile_definitions_for_lang lang i)
   zephyr_get_parse_args(args ${ARGN})
   get_property(flags TARGET zephyr_interface PROPERTY INTERFACE_COMPILE_DEFINITIONS)
@@ -277,6 +468,17 @@ function(zephyr_get_compile_definitions_for_lang lang i)
   set(${i} ${result_output_list} PARENT_SCOPE)
 endfunction()
 
+#[=======================================================================[.rst:
+.. cmake:signature:: zephyr_get_compile_options_for_lang(<lang> <var> [STRIP_PREFIX])
+
+   Get compile options for a specific language as a list.
+
+   Writes the compile options for language ``<lang>`` to variable ``<var>`` as a list.
+
+   ``<lang>`` can be one of ``C``, ``CXX``, or ``ASM``.
+
+   ``STRIP_PREFIX`` can be specified to omit the prefix from the result.
+#]=======================================================================]
 function(zephyr_get_compile_options_for_lang lang i)
   zephyr_get_parse_args(args ${ARGN})
   get_property(flags TARGET zephyr_interface PROPERTY INTERFACE_COMPILE_OPTIONS)
@@ -400,34 +602,47 @@ macro(get_property_and_add_prefix result target property prefix)
   endforeach()
 endmacro()
 
-# 1.2 zephyr_library_*
-#
-# Zephyr libraries use CMake's library concept and a set of
-# assumptions about how zephyr code is organized to cut down on
-# boilerplate code.
-#
-# A Zephyr library can be constructed by the function zephyr_library
-# or zephyr_library_named. The constructors create a CMake library
-# with a name accessible through the variable ZEPHYR_CURRENT_LIBRARY.
-#
-# The variable ZEPHYR_CURRENT_LIBRARY should seldom be needed since
-# the zephyr libraries have methods that modify the libraries. These
-# methods have the signature: zephyr_library_<target-function>
-#
-# The methods are wrappers around the CMake target_* functions. See
-# https://cmake.org/cmake/help/latest/manual/cmake-commands.7.html for
-# documentation on the underlying target_* functions.
-#
-# The methods modify the CMake target_* API to reduce boilerplate;
-#  PRIVATE is assumed
-#  The target is assumed to be ZEPHYR_CURRENT_LIBRARY
-#
-# When a flag that is given through the zephyr_* API conflicts with
-# the zephyr_library_* API then precedence will be given to the
-# zephyr_library_* API. In other words, local configuration overrides
-# global configuration.
 
-# Constructor with a directory-inferred name
+#[=======================================================================[.rst:
+
+``zephyr_library_*``
+====================
+
+Zephyr libraries use CMake's library concept and a set of
+assumptions about how zephyr code is organized to cut down on
+boilerplate code.
+
+A Zephyr library can be constructed by the function :cmake:command:`zephyr_library`
+or :cmake:command:`zephyr_library_named`. The constructors create a CMake library
+with a name accessible through the variable :cmake:variable:`ZEPHYR_CURRENT_LIBRARY`.
+
+The variable :cmake:variable:`ZEPHYR_CURRENT_LIBRARY` should seldom be needed since
+the zephyr libraries have methods that modify the libraries. These
+methods have the signature: :samp:`zephyr_library_{<target-function>}`.
+
+The methods are wrappers around the CMake ``target_*`` functions. See
+:cmake:manual:`manual:cmake-commands(7)` for documentation on the underlying
+``target_*`` functions.
+
+The methods modify the CMake ``target_*`` API to reduce boilerplate; ``PRIVATE`` is assumed.
+
+The target is assumed to be :cmake:variable:`ZEPHYR_CURRENT_LIBRARY`
+
+When a flag that is given through the ``zephyr_*`` API conflicts with
+the ``zephyr_library_*`` API then precedence will be given to the
+``zephyr_library_*`` API. In other words, local configuration overrides
+global configuration.
+
+#]=======================================================================]
+
+#[=======================================================================[.rst:
+
+.. cmake:signature:: zephyr_library()
+
+   Create a Zephyr library with a directory-inferred name. This sets the
+   :cmake:variable:`ZEPHYR_CURRENT_LIBRARY` variable to the inferred name.
+
+#]=======================================================================]
 macro(zephyr_library)
   zephyr_check_no_arguments(zephyr_library ${ARGN})
 
@@ -456,7 +671,14 @@ macro(zephyr_library_get_current_dir_lib_name base lib_name)
   set(${lib_name} ${name})
 endmacro()
 
-# Constructor with an explicitly given name.
+#[=======================================================================[.rst:
+
+.. cmake:signature:: zephyr_library_named(<name>)
+
+   Create a Zephyr library with an explicitly given name.  This sets the
+   :cmake:variable:`ZEPHYR_CURRENT_LIBRARY` variable to the given name.
+
+#]=======================================================================]
 macro(zephyr_library_named name)
   zephyr_check_no_arguments(zephyr_library_named ${ARGN})
 
@@ -470,43 +692,46 @@ macro(zephyr_library_named name)
   target_link_libraries(${name} PUBLIC zephyr_interface)
 endmacro()
 
-# Provides amend functionality to a Zephyr library for out-of-tree usage.
-#
-# Usage:
-#   zephyr_library_amend([<dir>])
-#
-# When called from a Zephyr module, the corresponding zephyr library defined
-# within Zephyr will be looked up.
-#
-# <dir>: Use '<dir>' as out-of-tree base directory from where the Zephyr
-#        library name shall be generated.
-#        <dir> can be used in cases where the structure for the library is not
-#        placed directly at the ZEPHYR_MODULE's root directory or for cases
-#        where the module integration file is located in a 'MODULE_EXT_ROOT'.
-#
-# Note, in order to ensure correct library when amending, the folder structure
-# in the Zephyr module or '<dir>' base directory must resemble the structure
-# used in Zephyr, as example:
-#
-# Example: to amend the zephyr library created in
-# ZEPHYR_BASE/drivers/entropy/CMakeLists.txt
-# add the following file:
-# ZEPHYR_MODULE/drivers/entropy/CMakeLists.txt
-# with content:
-# zephyr_library_amend()
-# zephyr_library_sources(...)
-#
-# It is also possible to use generator expression when amending to Zephyr
-# libraries.
-#
-# For example, in case it is required to expose the Zephyr library's folder as
-# include path then the following is possible:
-# zephyr_library_amend()
-# zephyr_library_include_directories($<TARGET_PROPERTY:SOURCE_DIR>)
-#
-# See the CMake documentation for more target properties or generator
-# expressions.
-#
+#[=======================================================================[.rst:
+
+.. cmake:signature:: zephyr_library_amend([<dir>])
+
+   Provides amend functionality to a Zephyr library for out-of-tree usage.
+
+   When called from a Zephyr module, the corresponding zephyr library defined
+   within Zephyr will be looked up.
+
+   ``<dir>``: Use ``<dir>`` as out-of-tree base directory from where the Zephyr
+   library name shall be generated.
+   ``<dir>`` can be used in cases where the structure for the library is not
+   placed directly at the ZEPHYR_MODULE's root directory or for cases
+   where the module integration file is located in a 'MODULE_EXT_ROOT'.
+
+   Note, in order to ensure correct library when amending, the folder structure
+   in the Zephyr module or ``<dir>`` base directory must resemble the structure
+   used in Zephyr, as example:
+
+   Example: to amend the zephyr library created in ``ZEPHYR_BASE/drivers/entropy/CMakeLists.txt``,
+   add a ``ZEPHYR_MODULE/drivers/entropy/CMakeLists.txt`` file with the following content:
+
+   .. code-block:: cmake
+
+      zephyr_library_amend()
+      zephyr_library_sources(...)
+
+   It is also possible to use generator expression when amending to Zephyr libraries.
+
+   For example, in case it is required to expose the Zephyr library's folder as
+   include path then the following is possible:
+
+   .. code-block:: cmake
+
+      zephyr_library_amend()
+      zephyr_library_include_directories($<TARGET_PROPERTY:SOURCE_DIR>)
+
+   See the CMake documentation for more target properties or generator expressions.
+
+#]=======================================================================]
 macro(zephyr_library_amend)
   # This is a macro because we need to ensure the ZEPHYR_CURRENT_LIBRARY and
   # following zephyr_library_* calls are executed within the scope of the
@@ -533,22 +758,57 @@ endfunction()
 # Note, paths passed to this function must be relative in order
 # to support the library relocation feature of zephyr_code_relocate
 #
+
+#[=======================================================================[.rst:
+
+.. cmake:signature:: zephyr_library_sources(<source> ...)
+
+   Add source files to the current Zephyr library.
+
+#]=======================================================================]
 function(zephyr_library_sources source)
   target_sources(${ZEPHYR_CURRENT_LIBRARY} PRIVATE ${source} ${ARGN})
 endfunction()
 
+#[=======================================================================[.rst:
+.. cmake:signature:: zephyr_library_include_directories(<include_dir> ...)
+
+   Add include directories to the current Zephyr library.
+
+#]=======================================================================]
 function(zephyr_library_include_directories)
   target_include_directories(${ZEPHYR_CURRENT_LIBRARY} PRIVATE ${ARGN})
 endfunction()
 
+#[=======================================================================[.rst:
+
+.. cmake:signature:: zephyr_library_link_libraries(<item> ...)
+
+   Add link libraries to the current Zephyr library.
+
+#]=======================================================================]
 function(zephyr_library_link_libraries item)
   target_link_libraries(${ZEPHYR_CURRENT_LIBRARY} PUBLIC ${item} ${ARGN})
 endfunction()
 
+#[=======================================================================[.rst:
+
+.. cmake:signature:: zephyr_library_compile_definitions(<item> ...)
+
+   Add compile definitions to the current Zephyr library.
+
+#]=======================================================================]
 function(zephyr_library_compile_definitions item)
   target_compile_definitions(${ZEPHYR_CURRENT_LIBRARY} PRIVATE ${item} ${ARGN})
 endfunction()
 
+#[=======================================================================[.rst:
+
+.. cmake:signature:: zephyr_library_compile_options(<item> ...)
+
+   Add compile options to the current Zephyr library.
+
+#]=======================================================================]
 function(zephyr_library_compile_options item)
   # The compiler is relied upon for sane behaviour when flags are in
   # conflict. Compilers generally give precedence to flags given late
@@ -573,6 +833,14 @@ function(zephyr_library_compile_options item)
   target_link_libraries(${ZEPHYR_CURRENT_LIBRARY} PRIVATE ${lib_name})
 endfunction()
 
+#[=======================================================================[.rst:
+
+.. cmake:signature:: zephyr_library_cc_option(<option> ...)
+
+   Add compile options to the current Zephyr library if the C compiler
+   supports them. Unsupported options are ignored.
+
+#]=======================================================================]
 function(zephyr_library_cc_option)
   foreach(option ${ARGV})
     string(MAKE_C_IDENTIFIER check${option} check)
@@ -584,14 +852,29 @@ function(zephyr_library_cc_option)
   endforeach()
 endfunction()
 
+#[=======================================================================[.rst:
+
+.. cmake:signature:: zephyr_library_add_dependencies(<item> ...)
+
+   Add dependencies to the current Zephyr library.
+
+   See :cmake:command:`add_dependencies() <command:add_dependencies>` for more information.
+
+#]=======================================================================]
 function(zephyr_library_add_dependencies)
   add_dependencies(${ZEPHYR_CURRENT_LIBRARY} ${ARGN})
 endfunction()
 
-# Add the existing CMake library 'library' to the global list of
-# Zephyr CMake libraries. This is done automatically by the
-# constructor but must be called explicitly on CMake libraries that do
-# not use a zephyr library constructor.
+#[=======================================================================[.rst:
+
+.. cmake:signature:: zephyr_append_cmake_library(<library>)
+
+   Add the existing CMake library 'library' to the global list of
+   Zephyr CMake libraries. This is done automatically by the
+   constructor but must be called explicitly on CMake libraries that do
+   not use a zephyr library constructor.
+
+#]=======================================================================]
 function(zephyr_append_cmake_library library)
   if(TARGET zephyr_pre0)
     message(WARNING
@@ -605,8 +888,14 @@ function(zephyr_append_cmake_library library)
   set_property(GLOBAL APPEND PROPERTY ZEPHYR_LIBS ${library})
 endfunction()
 
-# Add the imported library 'library_name', located at 'library_path' to the
-# global list of Zephyr CMake libraries.
+#[=======================================================================[.rst:
+
+.. cmake:signature:: zephyr_library_import(<library_name> <library_path>)
+
+   Add the imported library 'library_name', located at 'library_path' to the
+   global list of Zephyr CMake libraries.
+
+#]=======================================================================]
 function(zephyr_library_import library_name library_path)
   add_library(${library_name} STATIC IMPORTED GLOBAL)
   set_target_properties(${library_name}
@@ -616,13 +905,18 @@ function(zephyr_library_import library_name library_path)
   zephyr_append_cmake_library(${library_name})
 endfunction()
 
-# Place the current zephyr library in the application memory partition.
-#
-# The partition argument is the name of the partition where the library shall
-# be placed.
-#
-# Note: Ensure the given partition has been defined using
-#       K_APPMEM_PARTITION_DEFINE in source code.
+#[=======================================================================[.rst:
+
+.. cmake:signature:: zephyr_library_app_memory(<partition>)
+
+   Place the current zephyr library in the application memory partition.
+
+   The partition argument is the name of the partition where the library shall
+   be placed.
+
+   Note: Ensure the given partition has been defined using
+   :c:macro:`K_APPMEM_PARTITION_DEFINE` in source code.
+#]=======================================================================]
 function(zephyr_library_app_memory partition)
   set_property(TARGET zephyr_property_target
                APPEND PROPERTY COMPILE_OPTIONS
@@ -653,44 +947,69 @@ function(zephyr_library_property)
   endforeach()
 endfunction()
 
-# 1.2.1 zephyr_interface_library_*
-#
-# A Zephyr interface library is a thin wrapper over a CMake INTERFACE
-# library. The most important responsibility of this abstraction is to
-# ensure that when a user KConfig-enables a library then the header
-# files of this library will be accessible to the 'app' library.
-#
-# This is done because when a user uses Kconfig to enable a library he
-# expects to be able to include its header files and call its
-# functions out-of-the box.
-#
-# A Zephyr interface library should be used when there exists some
-# build information (include directories, defines, compiler flags,
-# etc.) that should be applied to a set of Zephyr libraries and 'app'
-# might be one of these libraries.
-#
-# Zephyr libraries must explicitly call
-# zephyr_library_link_libraries(<interface_library>) to use this build
-# information. 'app' is treated as a special case for usability
-# reasons; a Kconfig option (CONFIG_APP_LINK_WITH_<interface_library>)
-# should exist for each interface_library and will determine if 'app'
-# links with the interface_library.
-#
-# This API has a constructor like the zephyr_library API has, but it
-# does not have wrappers over the other cmake target functions.
+#[=======================================================================[.rst:
+``zephyr_interface_library_*``
+------------------------------
+
+A Zephyr interface library is a thin wrapper over a CMake ``INTERFACE``
+library. The most important responsibility of this abstraction is to
+ensure that when a user KConfig-enables a library then the header
+files of this library will be accessible to the 'app' library.
+
+This is done because when a user uses Kconfig to enable a library he
+expects to be able to include its header files and call its
+functions out-of-the box.
+
+A Zephyr interface library should be used when there exists some
+build information (include directories, defines, compiler flags,
+etc.) that should be applied to a set of Zephyr libraries and 'app'
+might be one of these libraries.
+
+Zephyr libraries must explicitly call
+:cmake:command:`zephyr_library_link_libraries(<interface_library>)` to use this build
+information. 'app' is treated as a special case for usability
+reasons; a Kconfig option (CONFIG_APP_LINK_WITH_<interface_library>)
+should exist for each interface_library and will determine if 'app'
+links with the interface_library.
+
+This API has a constructor like the zephyr_library API has, but it
+does not have wrappers over the other cmake target functions.
+
+.. cmake:signature:: zephyr_interface_library_named(<name>)
+
+   Create a Zephyr interface library with a given name.
+
+#]=======================================================================]
+
 macro(zephyr_interface_library_named name)
   add_library(${name} INTERFACE)
   set_property(GLOBAL APPEND PROPERTY ZEPHYR_INTERFACE_LIBS ${name})
 endmacro()
 
-# 1.3 generate_inc_*
+#[=======================================================================[.rst:
+``generate_inc_*``
+==================
 
-# These functions are useful if there is a need to generate a file
-# that can be included into the application at build time. The file
-# can also be compressed automatically when embedding it.
-#
-# See tests/application_development/gen_inc_file for an example of
-# usage.
+These functions are useful if there is a need to generate a file
+that can be included into the application at build time. The file
+can also be compressed automatically when embedding it.
+
+See :zephyr_file:`tests/application_development/gen_inc_file` for an example of usage.
+
+.. cmake:signature:: generate_inc_file(<source_file> <generated_file> ...)
+
+   Generate a file that can be included into the application at build time.
+
+   ``source_file``
+     The source file to be converted to hex
+
+   ``generated_file``
+     The generated file
+
+   ``...``
+     Extra arguments are passed to file2hex.py
+
+#]=======================================================================]
 function(generate_inc_file
     source_file    # The source file to be converted to hex
     generated_file # The generated file
@@ -787,22 +1106,24 @@ function(generate_shell_aliases_inc_file_for_target
   generate_shell_aliases_inc_file_for_gen_target(${target} ${source_file} ${generated_file} ${generated_target_name})
 endfunction()
 
-# 1.4. board_*
-#
-# This section is for extensions related to Zephyr board handling.
-#
-# Zephyr board extensions current contains:
-# - Board runners
-# - Board revision
+#[=======================================================================[.rst:
+``board_*``
+===========
 
-# Zephyr board runners:
-#   Zephyr board runner extension functions control Zephyr's board runners
-#   from the build system. The Zephyr build system has targets for
-#   flashing and debugging supported boards. These are wrappers around a
-#   "runner" Python subpackage that is part of Zephyr's "west" tool.
-#
-# This section provides glue between CMake and the Python code that
-# manages the runners.
+This section is for extensions related to Zephyr board handling.
+
+Zephyr board runners
+--------------------
+
+Zephyr board runner extension functions control Zephyr's board runners
+from the build system. The Zephyr build system has targets for
+flashing and debugging supported boards. These are wrappers around a
+"runner" Python subpackage that is part of Zephyr's "west" tool.
+
+ This section provides glue between CMake and the Python code that
+ manages the runners.
+
+]=======================================================================]
 
 set(TYPES "FLASH" "DEBUG" "SIM" "ROBOT")
 function(_board_check_runner_type type) # private helper
@@ -811,20 +1132,29 @@ function(_board_check_runner_type type) # private helper
   endif()
 endfunction()
 
-# This function sets the runner for the board unconditionally.  It's
-# meant to be used from application CMakeLists.txt files.
-#
-# NOTE: Usually board_set_xxx_ifnset() is best in board.cmake files.
-#       This lets the user set the runner at cmake time, or in their
-#       own application's CMakeLists.txt.
-#
-# Usage:
-#   board_set_runner(FLASH pyocd)
-#
-# This would set the board's flash runner to "pyocd".
-#
-# In general, "type" is FLASH, DEBUG, SIM or ROBOT and "runner" is
-# the name of a runner.
+#[=======================================================================[.rst:
+
+.. cmake:signature:: board_set_runner(<type> <runner>)
+
+   This function sets the runner for the board unconditionally.
+   It's meant to be used from application's :file:`CMakeLists.txt` files.
+
+   NOTE: Usually :cmake:command:`board_set_xxx_ifnset()` is best in :file:`board.cmake` files.
+         This lets the user set the runner at cmake time, or in their own application's
+         :file:`CMakeLists.txt`.
+
+   Example usage:
+
+   .. code-block:: cmake
+
+      board_set_runner(FLASH pyocd)
+
+   This would set the board's flash runner to "pyocd".
+
+   In general, "type" is FLASH, DEBUG, SIM or ROBOT and "runner" is
+   the name of a runner.
+
+#]=======================================================================]
 function(board_set_runner type runner)
   _board_check_runner_type(${type})
   if(DEFINED BOARD_${type}_RUNNER)
@@ -833,10 +1163,17 @@ function(board_set_runner type runner)
   set(BOARD_${type}_RUNNER ${runner} PARENT_SCOPE)
 endfunction()
 
-# This macro is like board_set_runner(), but will only make a change
-# if that runner is currently not set.
-#
-# See also board_set_flasher_ifnset() and board_set_debugger_ifnset().
+#[=======================================================================[.rst:
+
+.. cmake:signature:: board_set_runner_ifnset(<type> <runner>)
+
+   This macro is like :cmake:command:`board_set_runner()`, but will only make a change
+   if that runner is currently not set.
+
+   See also :cmake:command:`board_set_flasher_ifnset()` and
+   :cmake:command:`board_set_debugger_ifnset()`.
+
+#]=======================================================================]
 macro(board_set_runner_ifnset type runner)
   _board_check_runner_type(${type})
   # This is a macro because set_ifndef() works at parent scope.
@@ -845,32 +1182,68 @@ macro(board_set_runner_ifnset type runner)
   set_ifndef(BOARD_${type}_RUNNER ${runner})
 endmacro()
 
-# A convenience macro for board_set_runner(FLASH ${runner}).
+#[=======================================================================[.rst:
+
+.. cmake:signature:: board_set_flasher(<runner>)
+
+   A convenience macro for :cmake:command:`board_set_runner(FLASH ${runner})`.
+
+#]=======================================================================]
 macro(board_set_flasher runner)
   board_set_runner(FLASH ${runner})
 endmacro()
 
-# A convenience macro for board_set_runner(DEBUG ${runner}).
+#[=======================================================================[.rst:
+
+.. cmake:signature:: board_set_debugger(<runner>)
+
+   A convenience macro for :cmake:command:`board_set_runner(DEBUG ${runner})`.
+
+#]=======================================================================]
 macro(board_set_debugger runner)
   board_set_runner(DEBUG ${runner})
 endmacro()
 
-# A convenience macro for board_set_runner_ifnset(FLASH ${runner}).
+#[=======================================================================[.rst:
+
+.. cmake:signature:: board_set_flasher_ifnset(<runner>)
+
+   A convenience macro for :cmake:command:`board_set_runner_ifnset(FLASH ${runner})`.
+
+#]=======================================================================]
 macro(board_set_flasher_ifnset runner)
   board_set_runner_ifnset(FLASH ${runner})
 endmacro()
 
-# A convenience macro for board_set_runner_ifnset(DEBUG ${runner}).
+#[=======================================================================[.rst:
+
+.. cmake:signature:: board_set_debugger_ifnset(<runner>)
+
+   A convenience macro for :cmake:command:`board_set_runner_ifnset(DEBUG ${runner})`.
+
+#]=======================================================================]
 macro(board_set_debugger_ifnset runner)
   board_set_runner_ifnset(DEBUG ${runner})
 endmacro()
 
-# A convenience macro for board_set_runner_ifnset(ROBOT ${runner}).
+#[=======================================================================[.rst:
+
+.. cmake:signature:: board_set_robot_runner_ifnset(<runner>)
+
+   A convenience macro for :cmake:command:`board_set_runner_ifnset(ROBOT ${runner})`.
+
+#]=======================================================================]
 macro(board_set_robot_runner_ifnset runner)
   board_set_runner_ifnset(ROBOT ${runner})
 endmacro()
 
-# A convenience macro for board_set_runner_ifnset(SIM ${runner}).
+#[=======================================================================[.rst:
+
+.. cmake:signature:: board_set_sim_runner_ifnset(<runner>)
+
+   A convenience macro for :cmake:command:`board_set_runner_ifnset(SIM ${runner})`.
+
+#]=======================================================================]
 macro(board_set_sim_runner_ifnset runner)
   board_set_runner_ifnset(SIM ${runner})
 endmacro()
@@ -897,6 +1270,41 @@ endmacro()
 #
 # Any explicitly provided settings given by this function override
 # defaults provided by the build system.
+
+#[=======================================================================[.rst:
+
+.. cmake:signature:: board_runner_args(<runner> <args>...)
+
+   This function is intended for board.cmake files and application CMakeLists.txt files.
+
+   Usage from board.cmake files:
+
+   .. code-block:: cmake
+
+      board_runner_args(runner "--some-arg=val1" "--another-arg=val2")
+
+   The build system will then ensure the command line used to create the runner contains::
+
+      --some-arg=val1 --another-arg=val2
+
+   Within application CMakeLists.txt files, ensure that all calls to
+   :cmake:command:`board_runner_args()` are part of a macro named
+   :cmake:command:`app_set_runner_args()`, like this, which is defined
+   before calling :cmake:command:`find_package(Zephyr)`:.
+
+   .. code-block:: cmake
+
+      macro(app_set_runner_args)
+        board_runner_args(runner "--some-app-setting=value")
+      endmacro()
+
+   The build system tests for the existence of the macro and will invoke it at the appropriate time
+   if it is defined.
+
+   Any explicitly provided settings given by this function override defaults provided by the build
+   system.
+
+#]=======================================================================]
 function(board_runner_args runner)
   string(MAKE_C_IDENTIFIER ${runner} runner_id)
   # Note the "_EXPLICIT_" here, and see below.
@@ -947,6 +1355,13 @@ function(board_finalize_runner_args runner)
   set_property(GLOBAL APPEND PROPERTY ZEPHYR_RUNNERS ${runner})
 endfunction()
 
+#[=======================================================================[.rst:
+
+.. cmake:signature:: board_set_rimage_target(<target>)
+
+   Set the rimage target for the current board.
+
+#]=======================================================================]
 function(board_set_rimage_target target)
   set(RIMAGE_TARGET ${target} CACHE STRING "rimage target")
   zephyr_check_cache(RIMAGE_TARGET)
@@ -985,66 +1400,80 @@ function(board_finalize_emu_args emu)
   set_property(GLOBAL APPEND PROPERTY ZEPHYR_EMUS ${emu})
 endfunction()
 
-# Zephyr board revision:
-#
-# This section provides a function for revision checking.
+#[=======================================================================[.rst:
 
-# Usage:
-#   board_check_revision(FORMAT <LETTER | NUMBER | MAJOR.MINOR.PATCH>
-#                        [EXACT]
-#                        [DEFAULT_REVISION <revision>]
-#                        [HIGHEST_REVISION <revision>]
-#   )
-#
-# Zephyr board extension function.
-#
-# This function can be used in `boards/<board>/revision.cmake` to check a user
-# requested revision against available board revisions.
-#
-# The function will check the revision from `-DBOARD=<board>@<revision>` that
-# is provided by the user according to the arguments.
-# When `EXACT` is not specified, this function will set the Zephyr build system
-# variable `ACTIVE_BOARD_REVISION` with the selected revision.
-#
-# FORMAT <LETTER | NUMBER | MAJOR.MINOR.PATCH>: Specify the revision format.
-#         LETTER:             Revision format is a single letter from A - Z.
-#         NUMBER:             Revision format is a single integer number.
-#         MAJOR.MINOR.PATCH:  Revision format is three numbers, separated by `.`,
-#                             `x.y.z`. Trailing zeroes may be omitted on the
-#                             command line, which means:
-#                             1.0.0 == 1.0 == 1
-#
-# OPTIONAL: Revision specifier is optional. If revision is not provided the base
-#           board will be used. If both `EXACT` and `OPTIONAL` are given, then
-#           specifying the revision is optional, but if it is given then the
-#           `EXACT` requirements apply. Mutually exclusive with `DEFAULT_REVISION`.
-#
-# EXACT: Revision is required to be an exact match. As example, available revisions are:
-#        0.1.0 and 0.3.0, and user provides 0.2.0, then an error is reported
-#        when `EXACT` is given.
-#        If `EXACT` is not provided, then closest lower revision will be selected
-#        as the active revision, which in the example will be `0.1.0`.
-#
-# DEFAULT_REVISION: Provides a default revision to use when user has not selected
-#                   a revision number. If no default revision is provided then
-#                   user will be printed with an error if no revision is given
-#                   on the command line.
-#
-# HIGHEST_REVISION: Allows to specify highest valid revision for a board.
-#                   This can be used to ensure that a newer board cannot be used
-#                   with an older Zephyr. As example, if current board supports
-#                   revisions 0.x.0-0.99.99 and 1.0.0-1.99.99, and it is expected
-#                   that current board implementation will not work with board
-#                   revision 2.0.0, then HIGHEST_REVISION can be set to 1.99.99,
-#                   and user will be printed with an error if using
-#                   `<board>@2.0.0` or higher.
-#                   This field is not needed when `EXACT` is used.
-#
-# VALID_REVISIONS:  A list of valid revisions for this board.
-#                   If this argument is not provided, then each Kconfig fragment
-#                   of the form ``<board>_<revision>.conf`` in the board folder
-#                   will be used as a valid revision for the board.
-#
+Zephyr board revision
+---------------------
+
+This section provides a function for revision checking.
+
+.. cmake:signature:: board_check_revision(FORMAT <LETTER | NUMBER | MAJOR.MINOR.PATCH>
+                                           [EXACT]
+                                           [DEFAULT_REVISION <revision>]
+                                           [HIGHEST_REVISION <revision>]
+                                           [VALID_REVISIONS <revision> ...]
+                                          )
+
+   Zephyr board extension function.
+
+   This function can be used in :samp:`boards/{board}/revision.cmake` to check a user
+   requested revision against available board revisions.
+
+   The function will check the revision from :samp:`-DBOARD={board}@{revision}` that
+   is provided by the user according to the arguments.
+   When ``EXACT`` is not specified, this function will set the Zephyr build system
+   variable :cmake:variable:`ACTIVE_BOARD_REVISION` with the selected revision.
+
+   FORMAT <LETTER | NUMBER | MAJOR.MINOR.PATCH>
+     Specify the revision format.
+
+     LETTER
+       Revision format is a single letter from A - Z.
+
+     NUMBER
+       Revision format is a single integer number.
+
+     MAJOR.MINOR.PATCH
+       Revision format is three numbers, separated by ``.``, ``x.y.z``.
+       Trailing zeroes may be omitted on the command line, which means that 1.0.0 == 1.0 == 1.
+
+   OPTIONAL
+     Revision specifier is optional.
+
+     If revision is not provided the base board will be used. If both ``EXACT`` and ``OPTIONAL``
+     are given, then specifying the revision is optional, but if it is given then the ``EXACT``
+     requirements apply. Mutually exclusive with ``DEFAULT_REVISION``.
+
+   EXACT
+     Revision is required to be an exact match.
+
+     As example, available revisions are: 0.1.0 and 0.3.0, and user provides 0.2.0, then an error is
+     reported when ``EXACT`` is given. If ``EXACT`` is not provided, then closest lower revision will
+     be selected as the active revision, which in the example will be 0.1.0.
+
+   DEFAULT_REVISION
+     Provides a default revision to use when user has not selected a revision number.
+
+     If no default revision is provided then user will be printed with an error if no revision is
+     given on the command line.
+
+   HIGHEST_REVISION
+     Allows to specify highest valid revision for a board.
+
+     This can be used to ensure that a newer board cannot be used with an older Zephyr. As example,
+     if current board supports revisions 0.x.0-0.99.99 and 1.0.0-1.99.99, and it is expected that
+     current board implementation will not work with board revision 2.0.0, then ``HIGHEST_REVISION``
+     can be set to 1.99.99, and user will be printed with an error if using `<board>@2.0.0` or
+     higher. This field is not needed when ``EXACT`` is used.
+
+   VALID_REVISIONS
+     A list of valid revisions for this board.
+
+     If this argument is not provided, then each Kconfig fragment of the form
+     :samp:`{board}_{revision}.conf` in the board folder will be used as a valid revision for the
+     board.
+
+#]=======================================================================]
 function(board_check_revision)
   set(options OPTIONAL EXACT)
   set(single_args FORMAT DEFAULT_REVISION HIGHEST_REVISION)
@@ -1159,7 +1588,10 @@ function(board_check_revision)
   set(ACTIVE_BOARD_REVISION ${ACTIVE_BOARD_REVISION} PARENT_SCOPE)
 endfunction()
 
-# 1.5. Misc.
+#[=======================================================================[.rst:
+Misc.
+=====
+#]=======================================================================]
 
 # zephyr_check_compiler_flag is a part of Zephyr's toolchain
 # infrastructure. It should be used when testing toolchain
@@ -1635,22 +2067,23 @@ function(check_dtc_flag flag ok)
   endif()
 endfunction()
 
-# Function to round number to next power of two.
-#
-# Usage:
-#   pow2round(<variable>)
-#
-# Example:
-# set(test 2)
-# pow2round(test)
-# # test is still 2
-#
-# set(test 5)
-# pow2round(test)
-# # test is now 8
-#
-# Arguments:
-# n   = Variable containing the number to round
+#[=======================================================================[.rst:
+.. cmake:signature:: pow2round(<variable>)
+
+   Round number to next power of two.
+
+   Example usage:
+
+   .. code-block:: cmake
+
+      set(test 2)
+      pow2round(test)
+      # test is still 2
+
+      set(test 5)
+      pow2round(test)
+      # test is now 8
+#]=======================================================================]
 function(pow2round n)
   math(EXPR x "${${n}} & (${${n}} - 1)")
   if(${x} EQUAL 0)
@@ -1667,74 +2100,82 @@ function(pow2round n)
   set(${n} ${${n}} PARENT_SCOPE)
 endfunction()
 
-# Function to create a build string based on BOARD, BOARD_REVISION, and
-# BOARD_QUALIFIER.
-#
-# This is a common function to ensure that build strings are always created
-# in a uniform way.
-# A single string is returned containing the full build string constructed from
-# all arguments.
-#
-# When MERGE is supplied a list of build strings will be returned with the full
-# build string as first item in the list.
-# The full order of build strings returned in the list will be:
-# - Normalized board target build string, this includes qualifiers and revision
-# - Build string with board variants removed in addition
-# - Build string with cpuset removed in addition
-# - Build string with soc removed in addition
-#
-# If REVISION is supplied or obtained as system wide setting a build string
-# with the sanitized revision string will be added in addition to the
-# non-revisioned entry for each entry.
-#
-# Usage:
-#   zephyr_build_string(<out-variable>
-#                       BOARD <board>
-#                       [SHORT <out-variable>]
-#                       [BOARD_QUALIFIERS <qualifiers>]
-#                       [BOARD_REVISION <revision>]
-#                       [MERGE [REVERSE]]
-#   )
-#   zephyr_build_string(<out-variable>
-#                       BOARD_QUALIFIERS <qualifiers>
-#                       [MERGE [REVERSE]]
-#   )
-#
-# <out-variable>:            Output variable where the build string will be returned.
-# SHORT <out-variable>:      Output variable where the shortened build string will be returned.
-# BOARD <board>:             Board name to use when creating the build string.
-# BOARD_REVISION <revision>: Board revision to use when creating the build string.
-# MERGE:                     Return a list of build strings instead of a single build string.
-# REVERSE:                   Reverse the list before returning it.
-#
-# Examples
-# calling
-#   zephyr_build_string(build_string BOARD alpha)
-# will return the string `alpha` in `build_string` parameter.
-#
-# calling
-#   zephyr_build_string(build_string BOARD alpha BOARD_REVISION 1.0.0)
-# will return the string `alpha_1_0_0` in `build_string` parameter.
-#
-# calling
-#   zephyr_build_string(build_string BOARD alpha BOARD_QUALIFIERS /soc/bar)
-# will return the string `alpha_soc_bar` in `build_string` parameter.
-#
-# calling
-#   zephyr_build_string(build_string BOARD alpha BOARD_REVISION 1.0.0 BOARD_QUALIFIERS /soc/bar MERGE)
-# will return a list of the following strings
-# `alpha_soc_bar_1_0_0;alpha_soc_bar` in `build_string` parameter.
-#
-# calling
-#   zephyr_build_string(build_string SHORT short_build_string BOARD alpha BOARD_REVISION 1.0.0 BOARD_QUALIFIERS /soc/bar MERGE)
-# will return two lists of the following strings
-# `alpha_soc_bar_1_0_0;alpha_soc_bar` in `build_string` parameter.
-# `alpha_bar_1_0_0;alpha_bar` in `short_build_string` parameter.
-#
-# calling
-#   zephyr_build_string(build_string BOARD_QUALIFIERS /soc/bar/foo)
-# will return the string `soc_bar_foo` in `build_string` parameter.
-#
+#[=======================================================================[.rst:
+.. cmake:signature:: zephyr_build_string(outvar [BOARD board]
+                                                [SHORT short_outvar]
+                                                [BOARD_QUALIFIERS qualifiers]
+                                                [BOARD_REVISION revision]
+                                                [MERGE] [REVERSE])
+   :break: verbatim
+
+   Create a build string based on ``BOARD``, ``BOARD_REVISION``, and ``BOARD_QUALIFIER``. This is a
+   common function to ensure that build strings are always created in a uniform way.
+
+   When ``MERGE`` is supplied a list of build strings will be returned with the full build string as
+   first item in the list. The full order of build strings returned in the list will be:
+
+   * Normalized board target build string, this includes qualifiers and revision ;
+   * Build string with board variants removed in addition ;
+   * Build string with cpuset removed in addition ;
+   * Build string with soc removed in addition.
+
+   If ``REVISION`` is supplied or obtained as system wide setting a build string with the sanitized
+   revision string will be added in addition to the non-revisioned entry for each entry.
+
+   ``outvar``
+     Output variable where the build string will be returned.
+
+   ``BOARD board``
+     Board name to use when creating the build string.
+
+   ``SHORT short_outvar``
+     Output variable where the shortened build string will be returned.
+
+   ``BOARD_QUALIFIERS qualifiers``
+     Board qualifiers to use.
+
+   ``BOARD_REVISION revision``
+     Board revision to use.
+
+   ``MERGE``
+     Return a list of build strings instead of a single build string.
+
+   ``REVERSE``
+     Reverse the list before returning it.
+
+   Example usage:
+
+   .. code-block:: cmake
+
+      zephyr_build_string(build_string BOARD alpha)
+      # Returns "alpha" in build_string
+
+      zephyr_build_string(build_string BOARD alpha
+                                       BOARD_REVISION 1.0.0)
+      # Returns "alpha_1_0_0" in build_string
+
+      zephyr_build_string(build_string BOARD alpha
+                                       BOARD_QUALIFIERS /soc/bar)
+      # Returns "alpha_soc_bar" in build_string
+
+      zephyr_build_string(build_string BOARD alpha
+                                       BOARD_REVISION 1.0.0
+                                       BOARD_QUALIFIERS /soc/bar
+                                       MERGE)
+      # Returns list "alpha_soc_bar_1_0_0;alpha_soc_bar" in build_string
+
+      zephyr_build_string(build_string SHORT short_build_string
+                                       BOARD alpha
+                                       BOARD_REVISION 1.0.0
+                                       BOARD_QUALIFIERS /soc/bar
+                                       MERGE)
+      # Returns list "alpha_soc_bar_1_0_0;alpha_soc_bar" in build_string
+      # Returns list "alpha_bar_1_0_0;alpha_bar" in short_build_string
+
+      zephyr_build_string(build_string BOARD_QUALIFIERS /soc/bar/foo)
+      # Returns "soc_bar_foo" in build_string
+
+#]=======================================================================]
 function(zephyr_build_string outvar)
   set(options MERGE REVERSE)
   set(single_args BOARD BOARD_QUALIFIERS BOARD_REVISION SHORT)
@@ -1811,7 +2252,14 @@ function(zephyr_build_string outvar)
   set(${outvar} ${${outvar}} PARENT_SCOPE)
 endfunction()
 
-# Function to add one or more directories to the include list passed to the syscall generator.
+#[=======================================================================[.rst:
+.. cmake:signature:: zephyr_syscall_include_directories(<directories>...)
+
+   Add one or more directories to the include list passed to the syscall generator.
+
+   ``<directories>...``
+     One or more directories to add.
+#]=======================================================================]
 function(zephyr_syscall_include_directories)
   foreach(one_dir ${ARGV})
     if(EXISTS ${one_dir})
@@ -1831,7 +2279,14 @@ function(zephyr_syscall_include_directories)
   endforeach()
 endfunction()
 
-# Function to add header file(s) to the list to be passed to syscall generator.
+#[=======================================================================[.rst:
+.. cmake:signature:: zephyr_syscall_header(<headers>...)
+
+   Add one or more header files to the list passed to the syscall generator.
+
+   ``<headers>...``
+     One or more header files to add.
+#]=======================================================================]
 function(zephyr_syscall_header)
   foreach(one_file ${ARGV})
     if(EXISTS ${one_file})
@@ -1851,23 +2306,50 @@ function(zephyr_syscall_header)
   endforeach()
 endfunction()
 
-# Function to add header file(s) to the list to be passed to syscall generator
-# if condition is true.
+#[=======================================================================[.rst:
+.. cmake:signature:: zephyr_syscall_header_ifdef(feature_toggle <headers>...)
+
+   Add one or more header files to the list passed to the syscall generator if``feature_toggle`` is
+   true.
+
+   ``feature_toggle``
+     The name of the boolean variable to check.
+
+   ``<headers>...``
+     One or more header files to add.
+#]=======================================================================]
 function(zephyr_syscall_header_ifdef feature_toggle)
   if(${${feature_toggle}})
     zephyr_syscall_header(${ARGN})
   endif()
 endfunction()
 
-# Verify blobs fetched using west. If the sha256 checksum isn't valid, a warning/
-# fatal error message is printed (depends on REQUIRED flag).
-#
-# Usage:
-#   zephyr_blobs_verify(<MODULE module|FILES file [files...]> [REQUIRED])
-#
-# Example:
-# zephyr_blobs_verify(MODULE my_module REQUIRED) # verify all blobs in my_module and fail on error
-# zephyr_blobs_verify(FILES img/file.bin)        # verify a single file and print on error
+#[=======================================================================[.rst:
+.. cmake:signature:: zephyr_blobs_verify(<MODULE module | FILES file [files...]> [REQUIRED])
+
+   Verify blobs fetched using west. If the sha256 checksum isn't valid, a warning/fatal error
+   message is printed (level depends on ``REQUIRED`` flag).
+
+   ``MODULE module``
+     Verify all blobs in the given module.
+
+   ``FILES file [files...]``
+     Verify the specified files.
+
+   ``REQUIRED``
+     If specified, a fatal error is raised if the verification fails. Otherwise, a warning is
+     printed.
+
+   Example usage:
+
+   .. code-block:: cmake
+
+      # Verify all blobs in my_module and fail on error
+      zephyr_blobs_verify(MODULE my_module REQUIRED)
+
+      # Verify a single file and print on error
+      zephyr_blobs_verify(FILES img/file.bin)
+#]=======================================================================]
 function(zephyr_blobs_verify)
   cmake_parse_arguments(BLOBS_VERIFY "REQUIRED" "MODULE" "FILES" ${ARGN})
 
@@ -2116,29 +2598,35 @@ function(zephyr_heap_kasan_enable_directory dir)
 endfunction()
 
 
-########################################################
-# 2. Kconfig-aware extensions
-########################################################
-#
-# Kconfig is a configuration language developed for the Linux
-# kernel. The below functions integrate CMake with Kconfig.
-#
+#[=======================================================================[.rst:
+Kconfig-aware extensions
+************************
 
-# 2.1 Misc
-#
-# import_kconfig(<prefix> <kconfig_fragment> [<keys>] [TARGET <target>])
-#
-# Parse a KConfig fragment (typically with extension .config) and
-# introduce all the symbols that are prefixed with 'prefix' into the
-# CMake namespace. List all created variable names in the 'keys'
-# output variable if present.
-#
-# <prefix>          : symbol prefix of settings in the Kconfig fragment.
-# <kconfig_fragment>: absolute path to the config fragment file.
-# <keys>            : output variable which will be populated with variable
-#                     names loaded from the kconfig fragment.
-# TARGET <target>   : set all symbols on <target> instead of adding them to the
-#                     CMake namespace.
+:ref:`Kconfig <kconfig>` is a configuration language developed for the Linux kernel.
+The below functions integrate CMake with Kconfig.
+
+Misc
+====
+
+.. cmake:signature:: import_kconfig(prefix kconfig_fragment [keys] [TARGET target])
+
+   Parse a KConfig fragment (typically with extension .config) and introduce all the symbols that
+   are prefixed with ``prefix`` into the CMake namespace. List all created variable names in the
+   ``keys`` output variable if present.
+
+   ``prefix``
+     symbol prefix of settings in the Kconfig fragment.
+
+   ``kconfig_fragment``
+     absolute path to the config fragment file.
+
+   ``keys``
+     output variable which will be populated with variable
+     names loaded from the kconfig fragment.
+
+   ``TARGET``
+     set all symbols on ``target`` instead of adding them to the CMake namespace.
+#]=======================================================================]
 function(import_kconfig prefix kconfig_fragment)
   cmake_parse_arguments(IMPORT_KCONFIG "" "TARGET" "" ${ARGN})
   file(
@@ -2208,13 +2696,13 @@ function(import_kconfig prefix kconfig_fragment)
   endif()
 endfunction()
 
-########################################################
-# 3. CMake-generic extensions
-########################################################
-#
-# These functions extend the CMake API in a way that is not particular
-# to Zephyr. Primarily they work around limitations in the CMake
-# language to allow cleaner build scripts.
+#[=======================================================================[.rst:
+CMake-generic extensions
+************************
+
+These functions extend the CMake API in a way that is not particular to Zephyr.
+Primarily, they work around limitations in the CMake language to allow cleaner build scripts.
+#]=======================================================================]
 
 # 3.1. *_ifdef
 #
@@ -2248,6 +2736,13 @@ endfunction()
 # ifdef functions are added on an as-need basis. See
 # https://cmake.org/cmake/help/latest/manual/cmake-commands.7.html for
 # a list of available functions.
+
+#[=======================================================================[.rst:
+.. cmake:command:: add_subdirectory_ifdef
+
+   This function adds a subdirectory to the build if ``feature_toggle`` is enabled.
+#]=======================================================================]
+
 function(add_subdirectory_ifdef feature_toggle source_dir)
   if(${${feature_toggle}})
     add_subdirectory(${source_dir} ${ARGN})
@@ -2852,50 +3347,114 @@ function(check_set_compiler_property)
 endfunction()
 
 
-# 3.4. Debugging CMake
+#[=======================================================================[.rst:
+Debugging CMake
+===============
 
-# Usage:
-#   print(BOARD)
-#
-# will print: "BOARD: nrf52dk"
+.. cmake:signature:: print(arg)
+
+   Print the value of a variable.
+
+   Example usage:
+
+   .. code-block:: cmake
+
+      print(BOARD)
+      # will print: "BOARD: nrf52dk"
+#]=======================================================================]
 function(print arg)
   message(STATUS "${arg}: ${${arg}}")
 endfunction()
 
-# Usage:
-#   assert(ZEPHYR_TOOLCHAIN_VARIANT "ZEPHYR_TOOLCHAIN_VARIANT not set.")
-#
-# will cause a FATAL_ERROR and print an error message if the first
-# expression is false
+#[=======================================================================[.rst:
+.. cmake:signature:: assert(test comment)
+
+   Assert that a condition is true.
+
+   This macro will cause a fatal error and print an error message if the first
+   expression is false.
+
+   ``test``
+     The boolean expression to test.
+
+   ``comment``
+     The error message to print if the assertion fails.
+
+   Example usage:
+
+   .. code-block:: cmake
+
+     assert(ZEPHYR_TOOLCHAIN_VARIANT "ZEPHYR_TOOLCHAIN_VARIANT not set.")
+#]=======================================================================]
 macro(assert test comment)
   if(NOT ${test})
     message(FATAL_ERROR "Assertion failed: ${comment}")
   endif()
 endmacro()
 
-# Usage:
-#   assert_not(OBSOLETE_VAR "OBSOLETE_VAR has been removed; use NEW_VAR instead")
-#
-# will cause a FATAL_ERROR and print an error message if the first
-# expression is true
+#[=======================================================================[.rst:
+.. cmake:signature:: assert_not(test comment)
+
+   Assert that a condition is false.
+
+   This macro will cause a fatal error and print an error message if the first
+   expression is true.
+
+   ``test``
+     The boolean expression to test.
+
+   ``comment``
+     The error message to print if the assertion fails.
+
+   Example usage:
+
+   .. code-block:: cmake
+
+     assert_not(OBSOLETE_VAR "OBSOLETE_VAR has been removed; use NEW_VAR instead")
+#]=======================================================================]
 macro(assert_not test comment)
   if(${test})
     message(FATAL_ERROR "Assertion failed: ${comment}")
   endif()
 endmacro()
 
-# Usage:
-#   assert_exists(CMAKE_READELF)
-#
-# will cause a FATAL_ERROR if there is no file or directory behind the
-# variable
+#[=======================================================================[.rst:
+.. cmake:signature:: assert_exists(var)
+
+   Assert that a file or directory exists.
+
+   This macro will cause a fatal error if the file or directory pointed to by
+   the variable does not exist.
+
+   ``var``
+     The name of the variable containing the path to check.
+
+   Example usage:
+
+   .. code-block:: cmake
+
+     assert_exists(CMAKE_READELF)
+#]=======================================================================]
 macro(assert_exists var)
   if(NOT EXISTS ${${var}})
     message(FATAL_ERROR "No such file or directory: ${var}: '${${var}}'")
   endif()
 endmacro()
 
-# 3.5. File system management
+#[=======================================================================[.rst:
+File system management
+======================
+
+.. cmake:signature:: generate_unique_target_name_from_filename(filename target_name)
+
+   Generate a unique target name from a filename.
+
+   ``filename``
+     The filename to generate a unique name from.
+
+   ``target_name``
+     The name of the variable to store the generated target name in.
+#]=======================================================================]
 function(generate_unique_target_name_from_filename filename target_name)
   get_filename_component(basename ${filename} NAME)
   string(REPLACE "." "_" x ${basename})
@@ -2906,60 +3465,72 @@ function(generate_unique_target_name_from_filename filename target_name)
   set(${target_name} gen_${x}_${unique_chars} PARENT_SCOPE)
 endfunction()
 
-# Usage:
-#   zephyr_file(<mode> <arg> ...)
-#
-# Zephyr file function extension.
-# This function currently supports the following <modes>
-#
-# APPLICATION_ROOT <path>: Check all paths in provided variable, and convert
-#                          those paths that are defined with `-D<path>=<val>`
-#                          to absolute path, relative from `APPLICATION_SOURCE_DIR`
-#                          Issue an error for any relative path not specified
-#                          by user with `-D<path>`
-#                          BASE_DIR <base-dir>: convert paths relative to <base-dir>
-#                                               instead of `APPLICATION_SOURCE_DIR`
-#
-# returns an updated list of absolute paths
-#
-# Usage:
-#   zephyr_file(CONF_FILES <paths> [DTS <list>] [KCONF <list>]
-#               [BOARD <board> [BOARD_REVISION <revision>] | NAMES <name> ...]
-#               [SUFFIX <suffix>] [REQUIRED]
-#   )
-#
-# CONF_FILES <paths>: Find all configuration files in the list of paths and
-#                     return them in a list. If paths is empty then no configuration
-#                     files are returned. Configuration files will be:
-#                     - DTS:       Overlay files (.overlay)
-#                     - Kconfig:   Config fragments (.conf)
-#                     - defconfig: defconfig files (_defconfig)
-#                     The conf file search will return existing configuration
-#                     files for the current board.
-#                     CONF_FILES takes the following additional arguments:
-#                     BOARD <board>:             Find configuration files for specified board.
-#                     BOARD_REVISION <revision>: Find configuration files for specified board
-#                                                revision. Requires BOARD to be specified.
-#
-#                                                If no board is given the current BOARD and
-#                                                BOARD_REVISION will be used, unless NAMES are
-#                                                specified.
-#
-#                     NAMES <name1> [name2] ...  List of file names to look for and instead of
-#                                                creating file names based on board settings.
-#                                                Only the first match found in <paths> will be
-#                                                returned in the <list>
-#                     DTS <list>:    List to append DTS overlay files in <path> to
-#                     KCONF <list>:  List to append Kconfig fragment files in <path> to
-#                     DEFCONF <list>: List to append _defconfig files in <path> to
-#                     SUFFIX <name>: Suffix name to check for instead of the default name
-#                                    but with a fallback to the default name if not found.
-#                                    For example:
-#                                    SUFFIX fish, will look for <file>_fish.conf and use
-#                                    if found but will use <file>.conf if not found
-#                     REQUIRED:      Option to indicate that the <list> specified by DTS or KCONF
-#                                    must contain at least one element, else an error will be raised.
-#
+#[=======================================================================[.rst:
+.. cmake:signature:: zephyr_file(APPLICATION_ROOT <path> [BASE_DIR <base-dir>])
+                     zephyr_file(CONF_FILES <paths> [DTS <list>]
+                                 [KCONF <list>] [DEFCONF <list>]
+                                 [BOARD <board> [BOARD_REVISION <revision>] | NAMES <name> ...]
+                                 [SUFFIX <suffix>] [REQUIRED])
+
+   Zephyr file function extension.
+   This function currently supports the following modes:
+
+   ``APPLICATION_ROOT``
+     Check all paths in provided variable, and convert those paths that are defined with
+     ``-D<path>=<val>`` to absolute path, relative from ``APPLICATION_SOURCE_DIR``.
+     Issue an error for any relative path not specified by user with ``-D<path>``.
+
+     ``BASE_DIR <base-dir>``
+       Convert paths relative to ``<base-dir>`` instead of ``APPLICATION_SOURCE_DIR``.
+
+     Returns an updated list of absolute paths.
+
+   ``CONF_FILES``
+     Find all configuration files in the list of paths and return them in a list.
+     If paths is empty then no configuration files are returned.
+
+     Configuration files will be:
+
+     * ``DTS``:       Overlay files (``.overlay``)
+     * ``Kconfig``:   Config fragments (``.conf``)
+     * ``defconfig``: defconfig files (``_defconfig``)
+
+     The conf file search will return existing configuration files for the current board.
+
+     ``CONF_FILES`` takes the following additional arguments:
+
+     ``BOARD <board>``
+       Find configuration files for specified board.
+
+     ``BOARD_REVISION <revision>``
+       Find configuration files for specified board revision. Requires ``BOARD`` to be specified.
+       If no board is given the current ``BOARD`` and ``BOARD_REVISION`` will be used,
+       unless ``NAMES`` are specified.
+
+     ``NAMES <name1> [name2] ...``
+       List of file names to look for and instead of creating file names based on board settings.
+       Only the first match found in ``<paths>`` will be returned in the ``<list>``.
+
+     ``DTS <list>``
+       List to append DTS overlay files in ``<path>`` to.
+
+     ``KCONF <list>``
+       List to append Kconfig fragment files in ``<path>`` to.
+
+     ``DEFCONF <list>``
+       List to append _defconfig files in ``<path>`` to.
+
+     ``SUFFIX <name>``
+       Suffix name to check for instead of the default name but with a fallback to the
+       default name if not found.
+
+       For example: ``SUFFIX fish``, will look for ``<file>_fish.conf`` and use if found
+       but will use ``<file>.conf`` if not found.
+
+     ``REQUIRED``
+       Option to indicate that the ``<list>`` specified by ``DTS`` or ``KCONF`` must contain
+       at least one element, else an error will be raised.
+#]=======================================================================]
 function(zephyr_file)
   set(file_options APPLICATION_ROOT CONF_FILES)
   if((ARGC EQUAL 0) OR (NOT (ARGV0 IN_LIST file_options)))
@@ -3210,11 +3781,26 @@ Relative paths are only allowed with `-D${ARGV1}=<path>`")
   endif()
 endfunction()
 
-# Usage:
-#   zephyr_file_copy(<oldname> <newname> [ONLY_IF_DIFFERENT])
-#
-# Deprecated: this function only existed because 'file(COPY_FILE ...)' was
-# not available with CMake 3.20; call 'file(COPY_FILE ...)' directly instead.
+#[=======================================================================[.rst:
+
+.. cmake:signature:: zephyr_file_copy(<oldname> <newname> [ONLY_IF_DIFFERENT])
+
+   Zephyr file copy extension.
+
+   Deprecated: this function only existed because
+   :cmake:command:`file(COPY_FILE...) <command:file(copy_file)>` was not available with
+   CMake 3.20; call ``file(COPY_FILE ...)`` directly instead.
+
+   ``oldname``
+     Old file name.
+
+   ``newname``
+     New file name.
+
+   ``ONLY_IF_DIFFERENT``
+     Only copy if the files are different.
+
+#]=======================================================================]
 function(zephyr_file_copy oldname newname)
   message(DEPRECATION
           "zephyr_file_copy() is deprecated, use file(COPY_FILE ...) instead."
@@ -3231,17 +3817,23 @@ endfunction()
 # Usage:
 #   zephyr_file_suffix(<filename> SUFFIX <suffix>)
 #
-# Zephyr file add suffix extension.
-# This function will check the provided filename or list of filenames to see if they have a
-# `_<suffix>` extension to them and if so, updates the supplied variable/list with the new
-# path/paths.
-#
-# <filename>: Variable (singular or list) of absolute path filename(s) which should be checked
-#             and updated if there is a filename which has the <suffix> present.
-# <suffix>: The suffix to test for and append to the end of the provided filename.
-#
-# Returns an updated variable of absolute path(s)
-#
+#[=======================================================================[.rst:
+.. cmake:signature:: zephyr_file_suffix(<filename> SUFFIX <suffix>)
+
+   Update the filename(s) with the suffix if a file with the suffix exists.
+
+   This function checks the provided filename or list of filenames to see if a
+   file with the ``_<suffix>`` extension exists. If so, it updates the supplied
+   variable/list with the new path/paths.
+
+   ``<filename>``
+     Variable (singular or list) of absolute path filename(s).
+
+   ``<suffix>``
+     The suffix to test for and append to the end of the provided filename.
+
+   Returns an updated variable of absolute path(s).
+#]=======================================================================]
 function(zephyr_file_suffix filename)
   set(single_args SUFFIX)
   cmake_parse_arguments(SFILE "" "${single_args}" "" ${ARGN})
@@ -3278,33 +3870,39 @@ function(zephyr_file_suffix filename)
   endif()
 endfunction()
 
-# Usage:
-#   zephyr_string(<mode> <out-var> <input> ...)
-#
-# Zephyr string function extension.
-# This function extends the CMake string function by providing additional
-# manipulation options for the <mode> argument:
-#
-# ESCAPE: Ensure that every character of the input arguments is considered
-#         by CMake as a literal by prefixing the escape character '\' where
-#         appropriate. This is useful for handling Windows path separators in
-#         strings, or when it is desired to write "\n" as an actual string of
-#         four characters instead of a single newline.
-#         Note that this operation must be performed exactly once during the
-#         lifetime of a string, or previous escape characters will be treated
-#         as literals and escaped further.
-#
-# SANITIZE: Ensure that the output string does not contain any special
-#           characters. Special characters, such as -, +, =, $, etc. are
-#           converted to underscores '_'. Multiple arguments are concatenated.
-#
-# SANITIZE TOUPPER: Ensure that the output string does not contain any special
-#                   characters. Special characters, such as -, +, =, $, etc.
-#                   are converted to underscores '_'. Multiple arguments are
-#                   concatenated.
-#                   The sanitized string will be returned in UPPER case.
-#
-# Returns the updated string in <out-var>.
+#[=======================================================================[.rst:
+Others
+======
+
+.. cmake:signature:: zephyr_string(ESCAPE <out-var> <input> ...)
+                     zephyr_string(SANITIZE <out-var> <input> ...)
+                     zephyr_string(SANITIZE TOUPPER <out-var> <input> ...)
+
+   Zephyr string function extension.
+
+   This function extends the CMake :cmake:command:`string <command:string>` function by providing
+   additional manipulation options for the ``<mode>`` argument, namely:
+
+   ``ESCAPE``
+     Ensure that every character of the input arguments is considered by CMake as a literal by
+     prefixing the escape character ``\`` where appropriate. This is useful for handling Windows
+     path separators in strings, or when it is desired to write ``\n`` as an actual string of four
+     characters instead of a single newline. Note that this operation must be performed exactly once
+     during the lifetime of a string, or previous escape characters will be treated as literals and
+     escaped further.
+
+   ``SANITIZE``
+     Ensure that the output string does not contain any special characters. Special characters, such
+     as ``-``, ``+``, ``=``, ``$``, etc. are converted to underscores ``_``. Multiple arguments are
+     concatenated.
+
+   ``SANITIZE TOUPPER``
+     Ensure that the output string does not contain any special characters. Special characters, such
+     as ``-``, ``+``, ``=``, ``$``, etc. are converted to underscores ``_``. Multiple arguments are
+     concatenated. The sanitized string will be returned in UPPER case.
+
+   Returns the updated string in ``<out-var>``.
+#]=======================================================================]
 function(zephyr_string)
   set(options SANITIZE TOUPPER ESCAPE)
   cmake_parse_arguments(ZEPHYR_STRING "${options}" "" "" ${ARGN})
@@ -3337,28 +3935,24 @@ function(zephyr_string)
   set(${return_arg} ${work_string} PARENT_SCOPE)
 endfunction()
 
-# Usage:
-#    zephyr_list(TRANSFORM <list> <ACTION>
-#                [OUTPUT_VARIABLE <output variable])
-#
-# Example:
-#
-#    zephyr_list(TRANSFORM my_input_var NORMALIZE_PATHS
-#                OUTPUT_VARIABLE my_input_as_list)
-#
-# Like CMake's list(TRANSFORM ...). This is intended as a placeholder
-# for storing current and future Zephyr-related extensions for list
-# processing.
-#
-# <ACTION>: This currently must be NORMALIZE_PATHS. This action
-#           converts the argument list <list> to a ;-list with
-#           CMake path names, after passing its contents through
-#           a configure_file() transformation. The input list
-#           may be whitespace- or semicolon-separated.
-#
-# OUTPUT_VARIABLE: the result is normally stored in place, but
-#                  an alternative variable to store the result
-#                  can be provided with this.
+#[=======================================================================[.rst:
+.. cmake:signature:: zephyr_list(TRANSFORM <list> <ACTION> [OUTPUT_VARIABLE <output variable>])
+
+   Zephyr list function extension.
+
+   Like CMake's :cmake:command:`list(TRANSFORM ...) <command:list(transform)>` this is intended as a
+   placeholder for storing current and future Zephyr-related extensions for list processing.
+
+   ``<ACTION>``
+     This currently must be ``NORMALIZE_PATHS``. This action converts the argument list ``<list>``
+     to a ``;``-list with CMake path names, after passing its contents through a
+     :cmake:command:`configure_file <command:configure_file>` transformation. The input list may be
+     whitespace- or semicolon-separated.
+
+   ``OUTPUT_VARIABLE``
+     the result is normally stored in place, but an alternative variable to store the result can be
+     provided with this.
+#]=======================================================================]
 function(zephyr_list transform list_var action)
   # Parse arguments.
   if(NOT "${transform}" STREQUAL "TRANSFORM")
@@ -3414,42 +4008,46 @@ function(zephyr_var_name variable scope out)
   endif()
 endfunction()
 
-# Usage:
-#   zephyr_get(<variable> [MERGE [REVERSE]] [SYSBUILD [LOCAL|GLOBAL]] [VAR <var1> ...])
-#
-# Return the value of <variable> as local scoped variable of same name. If MERGE
-# is supplied, will return a list of found items. If REVERSE is supplied
-# together with MERGE, the order of the list will be reversed before being
-# returned. Reverse will happen before the list is returned and hence it will
-# not change the order of precedence in which the list itself is constructed.
-#
-# VAR can be used either to store the result in a variable with a different
-# name, or to look for values from multiple variables.
-# zephyr_get(FOO VAR FOO_A FOO_B)
-# zephyr_get(FOO MERGE VAR FOO_A FOO_B)
-#
-# zephyr_get() is a common function to provide a uniform way of supporting
-# build settings that can be set from sysbuild, CMakeLists.txt, CMake cache, or
-# in environment.
-#
-# The order of precedence for variables defined in multiple scopes:
-# - Sysbuild defined when sysbuild is used.
-#   Sysbuild variables can be defined as global or local to specific image.
-#   Examples:
-#   - BOARD is considered a global sysbuild cache variable
-#   - blinky_BOARD is considered a local sysbuild cache variable only for the
-#     blinky image.
-#   If no sysbuild scope is specified, GLOBAL is assumed.
-#   If using MERGE then SYSBUILD GLOBAL will get both the local and global
-#   sysbuild scope variables (in that order, if both exist).
-# - CMake cache, set by `-D<var>=<value>` or `set(<var> <val> CACHE ...)
-# - Environment
-# - Locally in CMakeLists.txt before 'find_package(Zephyr)'
-#
-# For example, if ZEPHYR_TOOLCHAIN_VARIANT is set in environment but locally
-# overridden by setting ZEPHYR_TOOLCHAIN_VARIANT directly in the CMake cache
-# using `-DZEPHYR_TOOLCHAIN_VARIANT=<val>`, then the value from the cache is
-# returned.
+#[=======================================================================[.rst:
+.. cmake:signature:: zephyr_get(<variable> [MERGE [REVERSE]] [SYSBUILD [LOCAL|GLOBAL]] [VAR <var1> ...])
+
+   Return the value of ``<variable>`` as local scoped variable of same name.
+
+   If ``MERGE`` is supplied, will return a list of found items.
+
+   If ``REVERSE`` is supplied together with ``MERGE``, the order of the list will be reversed before
+   being returned. Reverse will happen before the list is returned and hence it will not change the
+   order of precedence in which the list itself is constructed.
+
+   ``VAR`` can be used either to store the result in a variable with a different name, or to look
+   for values from multiple variables. ::
+
+      zephyr_get(FOO VAR FOO_A FOO_B)
+      zephyr_get(FOO MERGE VAR FOO_A FOO_B)
+
+   ``zephyr_get()`` is a common function to provide a uniform way of supporting build settings that
+   can be set from sysbuild, CMakeLists.txt, CMake cache, or in environment.
+
+   The order of precedence for variables defined in multiple scopes:
+
+   - Sysbuild defined when sysbuild is used. Sysbuild variables can be defined as global or local to
+     specific image. Examples:
+
+     - ``BOARD`` is considered a global sysbuild cache variable
+     - ``blinky_BOARD`` is considered a local sysbuild cache variable only for the blinky image.
+
+     If no sysbuild scope is specified, ``GLOBAL`` is assumed. If using ``MERGE`` then ``SYSBUILD
+     GLOBAL`` will get both the local and global sysbuild scope variables (in that order, if both
+     exist).
+
+   - CMake cache, set by ``-D<var>=<value>`` or ``set(<var> <val> CACHE ...)``
+   - Environment
+   - Locally in CMakeLists.txt before ``find_package(Zephyr)``
+
+   For example, if :envvar:`ZEPHYR_TOOLCHAIN_VARIANT` is set in environment but locally overridden
+   by setting :cmake:variable:`ZEPHYR_TOOLCHAIN_VARIANT` directly in the CMake cache using
+   ``-DZEPHYR_TOOLCHAIN_VARIANT=<val>``, then the value from the cache is returned.
+#]=======================================================================]
 function(zephyr_get variable)
   cmake_parse_arguments(GET_VAR "MERGE;REVERSE" "SYSBUILD" "VAR" ${ARGN})
 
@@ -3553,13 +4151,14 @@ function(zephyr_get variable)
   endif()
 endfunction(zephyr_get variable)
 
-# Usage:
-#   zephyr_create_scope(<scope>)
-#
-# Create a new scope for creation of scoped variables.
-#
-# <scope>: Name of new scope.
-#
+#[=======================================================================[.rst:
+.. cmake:signature:: zephyr_create_scope(<scope>)
+
+   Create a new scope for the creation of scoped variables.
+
+   ``<scope>``
+     Name of new scope.
+#]=======================================================================]
 function(zephyr_create_scope scope)
   zephyr_scope_exists(scope_defined ${scope})
   if(scope_defined)
@@ -3569,15 +4168,18 @@ function(zephyr_create_scope scope)
   set_property(GLOBAL PROPERTY scope:${scope} TRUE)
 endfunction()
 
-# Usage:
-#   zephyr_scope_exists(<result> <scope>)
-#
-# Check if <scope> exists.
-#
-# <result>: Variable to set with result.
-#           TRUE if scope exists, FALSE otherwise.
-# <scope> : Name of scope.
-#
+#[=======================================================================[.rst:
+.. cmake:signature:: zephyr_scope_exists(<result> <scope>)
+
+   Check if ``<scope>`` exists.
+
+   ``<result>``
+     Variable to set with result.
+     ``TRUE`` if scope exists, ``FALSE`` otherwise.
+
+   ``<scope>``
+     Name of scope.
+#]=======================================================================]
 function(zephyr_scope_exists result scope)
   get_property(scope_defined GLOBAL PROPERTY scope:${scope})
   if(scope_defined)
@@ -3589,19 +4191,21 @@ function(zephyr_scope_exists result scope)
   endif()
 endfunction()
 
-# Usage:
-#   zephyr_get_scoped(<output> <scope> <var>)
-#
-# Get the current value of <var> in a specific <scope>, as defined by a
-# previous zephyr_set() call. The value will be stored in the <output> var.
-#
-# Note: the scope `cache` will return the CMake cache value of the variable set
-#       in current CMake run. (cache values from earlier runs are ignored).
-#
-# <output> : Variable to store the value in
-# <scope>  : Scope for the variable look up
-# <var>    : Name to look up in the specific scope
-#
+#[=======================================================================[.rst:
+.. cmake:signature:: zephyr_get_scoped(<output> <scope> <var>)
+
+   Get the current value of ``<var>`` in a specific ``<scope>``, as defined by a
+   previous :cmake:command:`zephyr_set()` call. The value will be stored in the ``<output>`` var.
+
+   ``<output>``
+     Variable to store the value in
+
+   ``<scope>``
+     Scope for the variable look up
+
+   ``<var>``
+     Name to look up in the specific scope
+#]=======================================================================]
 function(zephyr_get_scoped output scope var)
   zephyr_scope_exists(scope_defined ${scope})
   if(NOT scope_defined)
@@ -3616,22 +4220,27 @@ function(zephyr_get_scoped output scope var)
   endif()
 endfunction()
 
-# Usage:
-#   zephyr_set(<variable> <value> SCOPE <scope> [APPEND])
-#
-# Zephyr extension of CMake set which allows a variable to be set in a specific
-# scope. The scope is used on later zephyr_get() invocation for precedence
-# handling when a variable it set in multiple scopes.
-#
-# Note: the scope `cache` sets the CMake cache value of the variable but cache
-#       values from earlier CMake runs are ignored.
-#
-# <variable>   : Name of variable
-# <value>      : Value of variable, multiple values will create a list.
-#                The SCOPE argument identifies the end of value list.
-# SCOPE <scope>: Name of scope for the variable
-# APPEND       : Append values to the already existing variable in <scope>
-#
+#[=======================================================================[.rst:
+.. cmake:signature:: zephyr_set(<variable> <value> SCOPE <scope> [APPEND])
+
+   Zephyr extension of CMake set which allows a variable to be set in a specific scope.
+
+   The scope is used on later :cmake:command:`zephyr_get` invocation for precedence handling when a
+   variable it set in multiple scopes.
+
+   ``<variable>``
+     Name of variable
+
+   ``<value>``
+     Value of variable, multiple values will create a list. The ``SCOPE`` argument identifies the
+     end of value list.
+
+   ``SCOPE <scope>``
+     Name of scope for the variable
+
+   ``APPEND``
+     Append values to the already existing variable in ``<scope>``
+#]=======================================================================]
 function(zephyr_set variable)
   cmake_parse_arguments(SET_VAR "APPEND" "SCOPE" "" ${ARGN})
 
@@ -3656,51 +4265,56 @@ function(zephyr_set variable)
   endif()
 endfunction()
 
-# Usage:
-#   zephyr_check_cache(<variable> [REQUIRED])
-#
-# Check the current CMake cache for <variable> and warn the user if the value
-# is being modified.
-#
-# This can be used to ensure the user does not accidentally try to change
-# Zephyr build variables, such as:
-# - BOARD
-# - SHIELD
-#
-# variable: Name of <variable> to check and set, for example BOARD.
-# REQUIRED: Optional flag. If specified, then an unset <variable> will be
-#           treated as an error.
-# WATCH: Optional flag. If specified, watch the variable and print a warning if
-#        the variable is later being changed.
-#
-# Details:
-#   <variable> can be set by 3 sources.
-#   - Using CMake argument, -D<variable>
-#   - Using an environment variable
-#   - In the project CMakeLists.txt before `find_package(Zephyr)`.
-#
-#   CLI has the highest precedence, then comes environment variables,
-#   and then finally CMakeLists.txt.
-#
-#   The value defined on the first CMake invocation will be stored in the CMake
-#   cache as CACHED_<variable>. This allows the Zephyr build system to detect
-#   when a user reconfigures a sticky variable.
-#
-#   A user can ignore all the precedence rules if the same source is always used
-#   E.g. always specifies -D<variable>= on the command line,
-#   always has an environment <variable> set, or always has a set(<variable> foo)
-#   line in his CMakeLists.txt and avoids mixing sources.
-#
-#   The selected <variable> can be accessed through the variable '<variable>' in
-#   following Zephyr CMake code.
-#
-#   If the user tries to change <variable> to a new value, then a warning will
-#   be printed, and the previously cached value (CACHED_<variable>) will be
-#   used, as it has precedence.
-#
-#   Together with the warning, user is informed that in order to change
-#   <variable> the build directory must be cleaned.
-#
+#[=======================================================================[.rst:
+.. cmake:signature:: zephyr_check_cache(<variable> [REQUIRED] [WATCH])
+
+   Check the current CMake cache for ``<variable>`` and warn the user if the value is being
+   modified.
+
+   This can be used to ensure the user does not accidentally try to change Zephyr build variables,
+   such as:
+
+   - ``BOARD``
+   - ``SHIELD``
+
+   ``<variable>``
+     Name of ``<variable>`` to check and set, for example ``BOARD``.
+
+   ``REQUIRED``
+     Optional flag. If specified, then an unset ``<variable>`` will be treated as an error.
+
+   ``WATCH``
+     Optional flag. If specified, watch the variable and print a warning if the variable is later
+     being changed.
+
+   **Details**:
+
+   ``<variable>`` can be set by 3 sources.
+
+   - Using CMake argument, ``-D<variable>``
+   - Using an environment variable
+   - In the project CMakeLists.txt before ``find_package(Zephyr)``.
+
+   CLI has the highest precedence, then comes environment variables, and then finally
+   CMakeLists.txt.
+
+   The value defined on the first CMake invocation will be stored in the CMake cache as
+   ``CACHED_<variable>``. This allows the Zephyr build system to detect when a user reconfigures a
+   sticky variable.
+
+   A user can ignore all the precedence rules if the same source is always used E.g. always
+   specifies ``-D<variable>=`` on the command line, always has an environment ``<variable>`` set, or
+   always has a set(``<variable>`` foo) line in his CMakeLists.txt and avoids mixing sources.
+
+   The selected ``<variable>`` can be accessed through the variable '``<variable>``' in following
+   Zephyr CMake code.
+
+   If the user tries to change ``<variable>`` to a new value, then a warning will be printed, and
+   the previously cached value (``CACHED_<variable>``) will be used, as it has precedence.
+
+   Together with the warning, user is informed that in order to change ``<variable>`` the build
+   directory must be cleaned.
+#]=======================================================================]
 function(zephyr_check_cache variable)
   cmake_parse_arguments(CACHE_VAR "REQUIRED;WATCH" "" "" ${ARGN})
   string(TOLOWER ${variable} variable_text)
@@ -3807,17 +4421,19 @@ function(zephyr_variable_set_too_late variable access value current_list_file)
   endif()
 endfunction()
 
-# Usage:
-#   zephyr_get_targets(<directory> <types> <targets>)
-#
-# Get build targets for a given directory and sub-directories.
-#
-# This functions will traverse the build tree, starting from <directory>.
-# It will read the `BUILDSYSTEM_TARGETS` for each directory in the build tree
-# and return the build types matching the <types> list.
-# Example of types: OBJECT_LIBRARY, STATIC_LIBRARY, INTERFACE_LIBRARY, UTILITY.
-#
-# returns a list of targets in <targets> matching the required <types>.
+#[=======================================================================[.rst:
+.. cmake:signature:: zephyr_get_targets(<directory> <types> <targets>)
+
+   Get build targets for a given directory and sub-directories.
+
+   This functions will traverse the build tree, starting from ``<directory>``. It will read the
+   ``BUILDSYSTEM_TARGETS`` for each directory in the build tree and return the build types matching
+   the ``<types>`` list.
+
+   Example of types: ``OBJECT_LIBRARY``, ``STATIC_LIBRARY``, ``INTERFACE_LIBRARY``, ``UTILITY``.
+
+   Returns a list of targets in ``<targets>`` matching the required ``<types>``.
+#]=======================================================================]
 function(zephyr_get_targets directory types targets)
     get_property(sub_directories DIRECTORY ${directory} PROPERTY SUBDIRECTORIES)
     get_property(dir_targets DIRECTORY ${directory} PROPERTY BUILDSYSTEM_TARGETS)
@@ -3864,16 +4480,22 @@ function(test_sysbuild)
   endif()
 endfunction()
 
-# Usage:
-#   target_byproducts(TARGET <target> BYPRODUCTS <file> [<file>...])
-#
-# Specify additional BYPRODUCTS that this target produces.
-#
-# This function allows the build system to specify additional byproducts to
-# target created with `add_executable()`. When linking an executable the linker
-# may produce additional files, like map files. Those files are not known to the
-# build system. This function makes it possible to describe such additional
-# byproducts in an easy manner.
+#[=======================================================================[.rst:
+.. cmake:signature:: target_byproducts(TARGET <target> BYPRODUCTS <file> ...)
+
+   Specify additional ``BYPRODUCTS`` that this target produces.
+
+   This function allows the build system to specify additional byproducts to target created with
+   :cmake:command:`add_executable <command-add_executable>`. When linking an executable the linker
+   may produce additional files, like map files. Those files are not known to the build system. This
+   function makes it possible to describe such additional byproducts in an easy manner.
+
+   ``TARGET <target>``
+     The target to add byproducts to.
+
+   ``BYPRODUCTS <file> ...``
+     List of byproducts that the target produces.
+#]=======================================================================]
 function(target_byproducts)
   cmake_parse_arguments(TB "" "TARGET" "BYPRODUCTS" ${ARGN})
 
@@ -3888,24 +4510,25 @@ function(target_byproducts)
   )
 endfunction()
 
-# Usage:
-#   topological_sort(TARGETS <target> [<target> ...]
-#                    PROPERTY_NAME <property>
-#                    RESULT <out-variable>)
-#
-# This function performs topological sorting of CMake targets using a specific
-# <property>, which dictates target dependencies. A fatal error occurs if the
-# provided dependencies cannot be met, e.g., if they contain cycles.
-#
-# TARGETS:       List of target names.
-# PROPERTY_NAME: Name of the target property to be used when sorting. For every
-#                target listed in TARGETS, this property must contain a list
-#                (possibly empty) of other targets, which this target depends on
-#                for a particular purpose. The property must not contain any
-#                target which is not also found in TARGETS.
-# RESULT:        Output variable, where the topologically sorted list of target
-#                names will be returned.
-#
+#[=======================================================================[.rst:
+.. cmake:signature:: topological_sort(TARGETS <target> ... PROPERTY_NAME <property> RESULT <out-variable>)
+
+   This function performs topological sorting of CMake targets using a specific ``<property>``,
+   which dictates target dependencies. A fatal error occurs if the provided dependencies cannot be
+   met, e.g., if they contain cycles.
+
+   ``TARGETS <target> ...``
+     List of target names.
+
+   ``PROPERTY_NAME <property>``
+     Name of the target property to be used when sorting. For every target listed in ``TARGETS``,
+     this property must contain a list (possibly empty) of other targets, which this target depends
+     on for a particular purpose. The property must not contain any
+     target which is not also found in ``TARGETS``.
+
+   ``RESULT <out-variable>``
+     Output variable, where the topologically sorted list of target names will be returned.
+#]=======================================================================]
 function(topological_sort)
   cmake_parse_arguments(TS "" "RESULT;PROPERTY_NAME" "TARGETS" ${ARGN})
 
@@ -3958,28 +4581,39 @@ function(topological_sort)
   set(${TS_RESULT} "${sorted_targets}" PARENT_SCOPE)
 endfunction()
 
-# Usage:
-#   build_info(<tag>... VALUE <value>...)
-#   build_info(<tag>... PATH  <path>...)
-#
-# This function populates the build_info.yml info file with exchangeable build
-# information related to the current build.
-#
-# Example:
-#   build_info(devicetree files VALUE file1.dts file2.dts file3.dts)
-# Will update the 'devicetree files' key in the build info yaml with the list
-# of files, file1.dts file2.dts file3.dts.
-#
-#   build_info(vendor-specific foo VALUE bar)
-# Will place the vendor specific key 'foo' with value 'bar' in the vendor specific section
-# of the build info file.
-#
-# <tag>...: One of the pre-defined valid CMake keys supported by build info or vendor-specific.
-#           See 'scripts/schemas/build-schema.yaml' CMake section for valid tags.
-# VALUE <value>... : value(s) to place in the build_info.yml file.
-# PATH  <path>... : path(s) to place in the build_info.yml file. All paths are converted to CMake
-#                   style. If no conversion is required, for example when paths are already
-#                   guaranteed to be CMake style, then VALUE can also be used.
+#[=======================================================================[.rst:
+.. cmake:signature:: build_info(<tag>... VALUE <value>...)
+                     build_info(<tag>... PATH  <path>...)
+
+   Populates the ``build_info.yml`` info file with exchangeable build
+   information related to the current build.
+
+   Example usage:
+
+   .. code-block:: cmake
+
+      # This will update the 'devicetree.files' key in the build info yaml with the list of files
+      # file1.dts, file2.dts, file3.dts
+      build_info(devicetree files VALUE file1.dts file2.dts file3.dts)
+
+   .. code-block:: cmake
+
+      # This will place the vendor specific 'foo' key with value 'bar' in the vendor-specific
+      # section of the build info file.
+      build_info(vendor-specific foo VALUE bar)
+
+   ``<tag>...``
+     One of the pre-defined valid CMake keys supported by build info or vendor-specific. See
+     :zephyr_file:`scripts/schemas/build-schema.yaml`, ``cmake`` section, for valid tags.
+
+   ``VALUE <value>...``
+     Value(s) to place in the build_info.yml file.
+
+   ``PATH  <path>...``
+     Path(s) to place in the build_info.yml file. All paths are converted to CMake style. If no
+     conversion is required, for example when paths are already guaranteed to be CMake style, then
+     ``VALUE`` can also be used.
+#]=======================================================================]
 function(build_info)
   set(convert_path FALSE)
   set(arg_list ${ARGV})
@@ -4046,54 +4680,64 @@ function(build_info)
   yaml_set(NAME build_info KEY cmake ${keys} ${type} "${values}" ${genex_flag})
 endfunction()
 
-########################################################
-# 4. Devicetree extensions
-########################################################
-# 4.1. dt_*
-#
-# The following methods are for retrieving devicetree information in CMake.
-#
-# Notes:
-#
-# - In CMake, we refer to the nodes using the node's path, therefore
-#   there is no dt_path(...) function for obtaining a node identifier
-#   like there is in the C devicetree.h API.
-#
-# - As another difference from the C API, you can generally use an
-#   alias at the beginning of a path interchangeably with the full
-#   path to the aliased node in these functions. The usage comments
-#   will make this clear in each case.
-#
-# - These methods are also available to sysbuild. To retrieve the DT
-#   information of some <image>, after its CMake configuration step,
-#   the dt_* function call must include a "TARGET <image>" argument.
+#[=======================================================================[.rst:
+Devicetree extensions
+*********************
 
-# Usage:
-#   dt_nodelabel(<var> NODELABEL <label> [REQUIRED] [TARGET <target>])
-#
-# Function for retrieving the node path for the node having nodelabel
-# <label>.
-#
-# Example devicetree fragment:
-#
-#   / {
-#           soc {
-#                   nvic: interrupt-controller@e000e100  { ... };
-#           };
-#   };
-#
-# Example usage:
-#
-#   # Sets 'nvic_path' to "/soc/interrupt-controller@e000e100"
-#   dt_nodelabel(nvic_path NODELABEL "nvic")
-#
-# The node's path will be returned in the <var> parameter.
-# <var> will be undefined if node does not exist.
-#
-# <var>              : Return variable where the node path will be stored
-# NODELABEL <label>  : Node label
-# REQUIRED           : Generate a fatal error if the node-label is not found
-# TARGET <target>    : Optional target to retrieve devicetree information from
+``dt_*``
+========
+
+The following methods are for retrieving devicetree information in CMake.
+
+Notes:
+
+* In CMake, we refer to the nodes using the node's path, therefore there is no ``dt_path(...)``
+  function for obtaining a node identifier like there is in the C devicetree.h API.
+
+* As another difference from the C API, you can generally use an alias at the beginning of a path
+  interchangeably with the full path to the aliased node in these functions. The usage comments will
+  make this clear in each case.
+
+* These methods are also available to sysbuild. To retrieve the DT information of some <image>,
+  after its CMake configuration step, the ``dt_*`` function call must include a ``TARGET <image>``
+  argument.
+
+.. cmake:signature:: dt_nodelabel(<var> NODELABEL <label> [REQUIRED] [TARGET <target>])
+
+   Function for retrieving the node path for the node having nodelabel ``<label>``.
+
+   The node's path will be returned in the ``<var>`` parameter. ``<var>`` will be undefined if node
+   does not exist.
+
+   ``<var>``
+     Return variable where the node path will be stored
+
+   ``NODELABEL <label>``
+     Node label
+
+   ``REQUIRED``
+     Generate a fatal error if the node-label is not found
+
+   ``TARGET <target>``
+     Optional target to retrieve devicetree information from
+
+   Example devicetree fragment:
+
+   .. code-block:: devicetree
+
+     / {
+        soc {
+            nvic: interrupt-controller@e000e100  { ... };
+        };
+     };
+
+   Example usage:
+
+   .. code-block:: cmake
+
+     # Sets 'nvic_path' to "/soc/interrupt-controller@e000e100"
+     dt_nodelabel(nvic_path NODELABEL "nvic")
+#]=======================================================================]
 function(dt_nodelabel var)
   set(options "REQUIRED")
   set(req_single_args "NODELABEL")
@@ -4125,27 +4769,37 @@ function(dt_nodelabel var)
   set(${var} ${${var}} PARENT_SCOPE)
 endfunction()
 
-# Usage:
-#   dt_alias(<var> PROPERTY <prop> [REQUIRED] [TARGET <target>])
-#
-# Get a node path for an /aliases node property.
-#
-# Example usage:
-#
-#   # The full path to the 'led0' alias is returned in 'path'.
-#   dt_alias(path PROPERTY "led0")
-#
-#   # The variable 'path' will be left undefined for a nonexistent
-#   # alias "does-not-exist".
-#   dt_alias(path PROPERTY "does-not-exist")
-#
-# The node's path will be returned in the <var> parameter. The
-# variable will be left undefined if the alias does not exist.
-#
-# <var>           : Return variable where the node path will be stored
-# PROPERTY <prop> : The alias to check
-# REQUIRED        : Generate a fatal error if the alias is not found
-# TARGET <target> : Optional target to retrieve devicetree information from
+#[=======================================================================[.rst:
+.. cmake:signature:: dt_alias(<var> PROPERTY <prop> [REQUIRED] [TARGET <target>])
+
+   Get a node path for an ``/aliases`` node property.
+
+   The node's path will be returned in the ``<var>`` parameter. The variable will be left undefined
+   if the alias does not exist.
+
+   ``<var>``
+     Return variable where the node path will be stored
+
+   ``PROPERTY <prop>``
+     The alias to check
+
+   ``REQUIRED``
+     Generate a fatal error if the alias is not found
+
+   ``TARGET <target>``
+     Optional target to retrieve devicetree information from
+
+   Example usage:
+
+   .. code-block:: cmake
+
+      # The full path to the 'led0' alias is returned in 'path'.
+      dt_alias(path PROPERTY "led0")
+
+      # The variable 'path' will be left undefined for a nonexistent
+      # alias "does-not-exist".
+      dt_alias(path PROPERTY "does-not-exist")
+#]=======================================================================]
 function(dt_alias var)
   set(options "REQUIRED")
   set(req_single_args "PROPERTY")
@@ -4177,23 +4831,28 @@ function(dt_alias var)
   set(${var} ${${var}} PARENT_SCOPE)
 endfunction()
 
-# Usage:
-#   dt_node_exists(<var> PATH <path> [TARGET <target>])
-#
-# Tests whether a node with path <path> exists in the devicetree.
-#
-# The <path> value may be any of these:
-#
-# - absolute path to a node, like '/foo/bar'
-# - a node alias, like 'my-alias'
-# - a node alias followed by a path to a child node, like 'my-alias/child-node'
-#
-# The result of the check, either TRUE or FALSE, will be returned in
-# the <var> parameter.
-#
-# <var>           : Return variable where the check result will be returned
-# PATH <path>     : Node path
-# TARGET <target> : Optional target to retrieve devicetree information from
+#[=======================================================================[.rst:
+.. cmake:signature:: dt_node_exists(<var> PATH <path> [TARGET <target>])
+
+   Tests whether a node with path ``<path>`` exists in the devicetree.
+
+   The ``<path>`` value may be any of these:
+
+   * absolute path to a node, like ``/foo/bar``
+   * a node alias, like ``my-alias``
+   * a node alias followed by a path to a child node, like ``my-alias/child-node``
+
+   The result of the check, either TRUE or FALSE, will be returned in the ``<var>`` parameter.
+
+   ``<var>``
+     Return variable where the check result will be returned
+
+   ``PATH <path>``
+     Node path
+
+   ``TARGET <target>``
+     Optional target to retrieve devicetree information from
+#]=======================================================================]
 function(dt_node_exists var)
   set(req_single_args "PATH")
   set(single_args "TARGET")
@@ -4221,28 +4880,36 @@ function(dt_node_exists var)
   endif()
 endfunction()
 
-# Usage:
-#   dt_node_has_status(<var> PATH <path> STATUS <status> [TARGET <target>])
-#
-# Tests whether <path> refers to a node which:
-# - exists in the devicetree, and
-# - has a status property matching the <status> argument
-#   (a missing status or an “ok” status is treated as if it
-#    were “okay” instead)
-#
-# The <path> value may be any of these:
-#
-# - absolute path to a node, like '/foo/bar'
-# - a node alias, like 'my-alias'
-# - a node alias followed by a path to a child node, like 'my-alias/child-node'
-#
-# The result of the check, either TRUE or FALSE, will be returned in
-# the <var> parameter.
-#
-# <var>           : Return variable where the check result will be returned
-# PATH <path>     : Node path
-# STATUS <status> : Status to check
-# TARGET <target> : Optional target to retrieve devicetree information from
+#[=======================================================================[.rst:
+.. cmake:signature:: dt_node_has_status(<var> PATH <path> STATUS <status> [TARGET <target>])
+
+   Tests whether ``<path>`` refers to a node which:
+
+   * exists in the devicetree, and
+   * has a status property matching the ``<status>`` argument (a missing status or an "ok" status is
+     treated as if it were "okay" instead)
+
+   The ``<path>`` value may be any of these:
+
+   * absolute path to a node, like '/foo/bar'
+   * a node alias, like 'my-alias'
+   * a node alias followed by a path to a child node, like 'my-alias/child-node'
+
+   The result of the check, either TRUE or FALSE, will be returned in
+   the ``<var>`` parameter.
+
+   ``<var>``
+     Return variable where the check result will be returned
+
+   ``PATH <path>``
+     Node path
+
+   ``STATUS <status>``
+     Status to check
+
+   ``TARGET <target>``
+     Optional target to retrieve devicetree information from
+#]=======================================================================]
 function(dt_node_has_status var)
   set(req_single_args "PATH;STATUS")
   set(single_args "TARGET")
@@ -4281,58 +4948,70 @@ function(dt_node_has_status var)
   endif()
 endfunction()
 
-# Usage:
-#
-#   dt_prop(<var> PATH <path> PROPERTY <prop> [INDEX <idx>] [REQUIRED] [TARGET <target>])
-#
-# Get a devicetree property value. The value will be returned in the
-# <var> parameter.
-#
-# The <path> value may be any of these:
-#
-# - absolute path to a node, like '/foo/bar'
-# - a node alias, like 'my-alias'
-# - a node alias followed by a path to a child node, like 'my-alias/child-node'
-#
-# This function currently only supports properties with the following
-# devicetree binding types: string, int, boolean, array, uint8-array,
-# string-array, path.
-#
-# For array valued properties (including uint8-array and
-# string-array), the entire array is returned as a CMake list unless
-# INDEX is given. If INDEX is given, just the array element at index
-# <idx> is returned.
-#
-# The property value will be returned in the <var> parameter if the
-# node exists and has a property <prop> with one of the above types.
-# <var> will be undefined otherwise.
-#
-# To test if the property is defined before using it, use DEFINED on
-# the return <var>, like this:
-#
-#   dt_prop(reserved_ranges PATH "/soc/gpio@deadbeef" PROPERTY "gpio-reserved-ranges")
-#   if(DEFINED reserved_ranges)
-#     # Node exists and has the "gpio-reserved-ranges" property.
-#   endif()
-#
-# To distinguish a missing node from a missing property, combine
-# dt_prop() and dt_node_exists(), like this:
-#
-#   dt_node_exists(node_exists PATH "/soc/gpio@deadbeef")
-#   dt_prop(reserved_ranges    PATH "/soc/gpio@deadbeef" PROPERTY "gpio-reserved-ranges")
-#   if(DEFINED reserved_ranges)
-#     # Node "/soc/gpio@deadbeef" exists and has the "gpio-reserved-ranges" property
-#   elseif(node_exists)
-#     # Node exists, but doesn't have the property, or the property has an unsupported type.
-#   endif()
-#
-# <var>          : Return variable where the property value will be stored
-# PATH <path>    : Node path
-# PROPERTY <prop>: Property for which a value should be returned, as it
-#                  appears in the DTS source
-# INDEX <idx>    : Optional index when retrieving a value in an array property
-# REQUIRED       : Generate a fatal error if the property is not found
-# TARGET <target>: Optional target to retrieve devicetree information from
+#[=======================================================================[.rst:
+.. cmake:signature:: dt_prop(<var> PATH <path> PROPERTY <prop> [INDEX <idx>] [REQUIRED] [TARGET <target>])
+
+   Get a devicetree property value. The value will be returned in the
+   ``<var>`` parameter.
+
+   The ``<path>`` value may be any of these:
+
+   * absolute path to a node, like '/foo/bar'
+   * a node alias, like 'my-alias'
+   * a node alias followed by a path to a child node, like 'my-alias/child-node'
+
+   This function currently only supports properties with the following devicetree binding types:
+   string, int, boolean, array, uint8-array, string-array, path.
+
+   For array valued properties (including uint8-array and string-array), the entire array is
+   returned as a CMake list unless ``INDEX`` is given. If ``INDEX`` is given, just the array element
+   at index ``<idx>`` is returned.
+
+   The property value will be returned in the ``<var>`` parameter if the node exists and has a
+   property ``<prop>`` with one of the above types. ``<var>`` will be undefined otherwise.
+
+   ``<var>``
+     Return variable where the property value will be stored
+
+   ``PATH <path>``
+     Node path
+
+   ``PROPERTY <prop>``
+     Property for which a value should be returned, as it
+     appears in the DTS source
+
+   ``INDEX <idx>``
+     Optional index when retrieving a value in an array property
+
+   ``REQUIRED``
+     Generate a fatal error if the property is not found
+
+   ``TARGET <target>``
+     Optional target to retrieve devicetree information from
+
+   To test if the property is defined before using it, use ``DEFINED`` on the return ``<var>``, like
+   this:
+
+   .. code-block:: cmake
+
+      dt_prop(reserved_ranges PATH "/soc/gpio@deadbeef" PROPERTY "gpio-reserved-ranges")
+      if(DEFINED reserved_ranges)
+        # Node exists and has the "gpio-reserved-ranges" property.
+      endif()
+
+   To distinguish a missing node from a missing property, combine :cmake:command:`dt_prop` and
+   :cmake:command:`dt_node_exists`, like this:
+
+   .. code-block:: cmake
+
+      dt_node_exists(node_exists PATH "/soc/gpio@deadbeef")
+      dt_prop(reserved_ranges    PATH "/soc/gpio@deadbeef" PROPERTY "gpio-reserved-ranges")
+      if(DEFINED reserved_ranges)
+        # Node "/soc/gpio@deadbeef" exists and has the "gpio-reserved-ranges" property
+      elseif(node_exists)
+        # Node exists, but doesn't have the property, or the property has an unsupported type.
+      endif()
+#]=======================================================================]
 function(dt_prop var)
   set(options "REQUIRED")
   set(req_single_args "PATH;PROPERTY")
@@ -4379,22 +5058,27 @@ function(dt_prop var)
   endif()
 endfunction()
 
-# Usage:
-#
-#   dt_comp_path(<var> COMPATIBLE <compatible> [INDEX <idx>] [TARGET <target>])
-#
-# Get a list of paths for the nodes with the given compatible. The value will
-# be returned in the <var> parameter.
-# <var> will be undefined if no such compatible exists.
-#
-# For details and considerations about the format of <path> and the returned
-# parameter refer to dt_prop().
-#
-# <var>                  : Return variable where the property value will be stored
-# COMPATIBLE <compatible>: Compatible for which the list of paths should be
-#                          returned, as it appears in the DTS source
-# INDEX <idx>            : Optional index when retrieving a value in an array property
-# TARGET <target>        : Optional target to retrieve devicetree information from
+#[=======================================================================[.rst:
+.. cmake:signature:: dt_comp_path(<var> COMPATIBLE <compatible> [INDEX <idx>] [TARGET <target>])
+
+   Get a list of paths for the nodes with the given compatible. The value will be returned in the
+   ``<var>`` parameter. ``<var>`` will be undefined if no such compatible exists.
+
+   For details and considerations about the format of ``<path>`` and the returned parameter refer to
+   :cmake:command:`dt_prop`.
+
+   ``<var>``
+     Return variable where the property value will be stored
+
+   ``COMPATIBLE <compatible>``
+     Compatible for which the list of paths should be returned, as it appears in the DTS source
+
+   ``INDEX <idx>``
+     Optional index when retrieving a value in an array property
+
+   ``TARGET <target>``
+     Optional target to retrieve devicetree information from
+#]=======================================================================]
 
 function(dt_comp_path var)
   set(req_single_args "COMPATIBLE")
@@ -4437,23 +5121,28 @@ function(dt_comp_path var)
   endif()
 endfunction()
 
-# Usage:
-#   dt_num_regs(<var> PATH <path> [TARGET <target>])
-#
-# Get the number of register blocks in the node's reg property;
-# this may be zero.
-#
-# The value will be returned in the <var> parameter.
-#
-# The <path> value may be any of these:
-#
-# - absolute path to a node, like '/foo/bar'
-# - a node alias, like 'my-alias'
-# - a node alias followed by a path to a child node, like 'my-alias/child-node'
-#
-# <var>          : Return variable where the property value will be stored
-# PATH <path>    : Node path
-# TARGET <target>: Optional target to retrieve devicetree information from
+#[=======================================================================[.rst:
+.. cmake:signature:: dt_num_regs(<var> PATH <path> [TARGET <target>])
+
+   Get the number of register blocks in the node's ``reg`` property; this may be zero.
+
+   The value will be returned in the ``<var>`` parameter.
+
+   The ``<path>`` value may be any of these:
+
+   * absolute path to a node, like '/foo/bar'
+   * a node alias, like 'my-alias'
+   * a node alias followed by a path to a child node, like 'my-alias/child-node'
+
+   ``<var>``
+     Return variable where the property value will be stored
+
+   ``PATH <path>``
+     Node path
+
+   ``TARGET <target>``
+     Optional target to retrieve devicetree information from
+#]=======================================================================]
 function(dt_num_regs var)
   set(req_single_args "PATH")
   set(single_args "TARGET")
@@ -4479,31 +5168,42 @@ function(dt_num_regs var)
   set(${var} ${${var}} PARENT_SCOPE)
 endfunction()
 
-# Usage:
-#   dt_reg_addr(<var> PATH <path> [INDEX <idx>] [NAME <name>] [TARGET <target>])
-#
-# Get the base address of the register block at index <idx>, or with
-# name <name>. If <idx> and <name> are both omitted, the value at
-# index 0 will be returned. Do not give both <idx> and <name>.
-#
-# The value will be returned in the <var> parameter.
-#
-# The <path> value may be any of these:
-#
-# - absolute path to a node, like '/foo/bar'
-# - a node alias, like 'my-alias'
-# - a node alias followed by a path to a child node, like 'my-alias/child-node'
-#
-# Results can be:
-# - The base address of the register block
-# - <var> will be undefined if node does not exists or does not have a register
-#   block at the requested index or with the requested name
-#
-# <var>          : Return variable where the address value will be stored
-# PATH <path>    : Node path
-# INDEX <idx>    : Register block index number
-# NAME <name>    : Register block name
-# TARGET <target>: Optional target to retrieve devicetree information from
+#[=======================================================================[.rst:
+.. cmake:signature:: dt_reg_addr(<var> PATH <path> [INDEX <idx>] [NAME <name>] [TARGET <target>])
+
+   Get the base address of the register block at index ``<idx>``, or with name ``<name>``. If
+   ``<idx>`` and ``<name>`` are both omitted, the value at index 0 will be returned. Do not give
+   both ``<idx>`` and ``<name>``.
+
+   The value will be returned in the ``<var>`` parameter.
+
+   The ``<path>`` value may be any of these:
+
+   * absolute path to a node, like '/foo/bar'
+   * a node alias, like 'my-alias'
+   * a node alias followed by a path to a child node, like 'my-alias/child-node'
+
+   Results can be:
+
+   * The base address of the register block
+   * ``<var>`` will be undefined if node does not exists or does not have a register block at the
+     requested index or with the requested name
+
+   ``<var>``
+     Return variable where the address value will be stored
+
+   ``PATH <path>``
+     Node path
+
+   ``INDEX <idx>``
+     Register block index number
+
+   ``NAME <name>``
+     Register block name
+
+   ``TARGET <target>``
+     Optional target to retrieve devicetree information from
+#]=======================================================================]
 function(dt_reg_addr var)
   set(req_single_args "PATH")
   set(single_args "INDEX;NAME;TARGET")
@@ -4548,26 +5248,36 @@ function(dt_reg_addr var)
   set(${var} ${${var}} PARENT_SCOPE)
 endfunction()
 
-# Usage:
-#   dt_reg_size(<var> PATH <path> [INDEX <idx>] [NAME <name>] [TARGET <target>])
-#
-# Get the size of the register block at index <idx>, or with
-# name <name>. If <idx> and <name> are both omitted, the value at
-# index 0 will be returned. Do not give both <idx> and <name>.
-#
-# The value will be returned in the <value> parameter.
-#
-# The <path> value may be any of these:
-#
-# - absolute path to a node, like '/foo/bar'
-# - a node alias, like 'my-alias'
-# - a node alias followed by a path to a child node, like 'my-alias/child-node'
-#
-# <var>          : Return variable where the size value will be stored
-# PATH <path>    : Node path
-# INDEX <idx>    : Register block index number
-# NAME <name>    : Register block name
-# TARGET <target>: Optional target to retrieve devicetree information from
+#[=======================================================================[.rst:
+.. cmake:signature:: dt_reg_size(<var> PATH <path> [INDEX <idx>] [NAME <name>] [TARGET <target>])
+
+   Get the size of the register block at index ``<idx>``, or with name ``<name>``. If ``<idx>`` and
+   ``<name>`` are both omitted, the value at index 0 will be returned. Do not give both ``<idx>``
+   and ``<name>``.
+
+   The value will be returned in the ``<value>`` parameter.
+
+   The ``<path>`` value may be any of these:
+
+   * absolute path to a node, like '/foo/bar'
+   * a node alias, like 'my-alias'
+   * a node alias followed by a path to a child node, like 'my-alias/child-node'
+
+   ``<var>``
+     Return variable where the size value will be stored
+
+   ``PATH <path>``
+     Node path
+
+   ``INDEX <idx>``
+     Register block index number
+
+   ``NAME <name>``
+     Register block name
+
+   ``TARGET <target>``
+     Optional target to retrieve devicetree information from
+#]=======================================================================]
 function(dt_reg_size var)
   set(req_single_args "PATH")
   set(single_args "INDEX;NAME;TARGET")
@@ -4612,32 +5322,41 @@ function(dt_reg_size var)
   set(${var} ${${var}} PARENT_SCOPE)
 endfunction()
 
-# Usage:
-#   dt_has_chosen(<var> PROPERTY <prop> [TARGET <target>])
-#
-# Test if the devicetree's /chosen node has a given property
-# <prop> which contains the path to a node.
-#
-# Example devicetree fragment:
-#
-#       chosen {
-#               foo = &bar;
-#       };
-#
-# Example usage:
-#
-#       # Sets 'result' to TRUE
-#       dt_has_chosen(result PROPERTY "foo")
-#
-#       # Sets 'result' to FALSE
-#       dt_has_chosen(result PROPERTY "baz")
-#
-# The result of the check, either TRUE or FALSE, will be stored in the
-# <var> parameter.
-#
-# <var>           : Return variable
-# PROPERTY <prop> : Chosen property
-# TARGET <target> : Optional target to retrieve devicetree information from
+#[=======================================================================[.rst:
+.. cmake:signature:: dt_has_chosen(<var> PROPERTY <prop> [TARGET <target>])
+
+   Test if the devicetree's /chosen node has a given property ``<prop>`` which contains the path to
+   a node.
+
+   The result of the check, either TRUE or FALSE, will be stored in the ``<var>`` parameter.
+
+   ``<var>``
+     Return variable
+
+   ``PROPERTY <prop>``
+     Chosen property
+
+   ``TARGET <target>``
+     Optional target to retrieve devicetree information from
+
+   Example devicetree fragment:
+
+   .. code-block:: devicetree
+
+       chosen {
+               foo = &bar;
+       };
+
+   Example usage:
+
+   .. code-block:: cmake
+
+       # Sets 'result' to TRUE
+       dt_has_chosen(result PROPERTY "foo")
+
+       # Sets 'result' to FALSE
+       dt_has_chosen(result PROPERTY "baz")
+#]=======================================================================]
 function(dt_has_chosen var)
   set(req_single_args "PROPERTY")
   set(single_args "TARGET")
@@ -4666,17 +5385,23 @@ function(dt_has_chosen var)
   endif()
 endfunction()
 
-# Usage:
-#   dt_chosen(<var> PROPERTY <prop> [TARGET <target>])
-#
-# Get a node path for a /chosen node property.
-#
-# The node's path will be returned in the <var> parameter. The
-# variable will be left undefined if the chosen node does not exist.
-#
-# <var>           : Return variable where the node path will be stored
-# PROPERTY <prop> : Chosen property
-# TARGET <target> : Optional target to retrieve devicetree information from
+#[=======================================================================[.rst:
+.. cmake:signature:: dt_chosen(<var> PROPERTY <prop> [TARGET <target>])
+
+   Get a node path for a ``/chosen`` node property.
+
+   The node's path will be returned in the ``<var>`` parameter. The variable will be left undefined
+   if the chosen node does not exist.
+
+   ``<var>``
+     Return variable where the node path will be stored
+
+   ``PROPERTY <prop>``
+     Chosen property
+
+   ``TARGET <target>``
+     Optional target to retrieve devicetree information from
+#]=======================================================================]
 function(dt_chosen var)
   set(req_single_args "PROPERTY")
   set(single_args "TARGET")
@@ -4795,29 +5520,42 @@ function(dt_path_internal_exists var path target)
   endif()
 endfunction()
 
-# 4.2. *_if_dt_node
-#
-# This section is similar to the extensions named *_ifdef, except
-# actions are performed if the devicetree contains some node.
-# *_if_dt_node functions may be added as needed, or if they are likely
-# to be useful for user applications.
+#[=======================================================================[.rst:
+``*_if_dt_node``
+================
 
-# Add item(s) to a target's SOURCES list if a devicetree node exists.
-#
-# Example usage:
-#
-#   # If the devicetree alias "led0" refers to a node, this
-#   # adds "blink_led.c" to the sources list for the "app" target.
-#   target_sources_if_dt_node("led0" app PRIVATE blink_led.c)
-#
-#   # If the devicetree path "/soc/serial@4000" is a node, this
-#   # adds "uart.c" to the sources list for the "lib" target,
-#   target_sources_if_dt_node("/soc/serial@4000" lib PRIVATE uart.c)
-#
-# <path>    : Path to devicetree node to check
-# <target>  : Build system target whose sources to add to
-# <scope>   : Scope to add items to
-# <item>    : Item (or items) to add to the target
+This section is similar to the extensions named ``*_ifdef``, except actions are performed if the
+devicetree contains some node. ``*_if_dt_node`` functions may be added as needed, or if they are
+likely to be useful for user applications.
+
+.. cmake:signature:: target_sources_if_dt_node(<path> <target> <scope> <item>...)
+
+   Add item(s) to a target's SOURCES list if a devicetree node exists.
+
+   ``<path>``
+     Path to devicetree node to check
+
+   ``<target>``
+     Build system target whose sources to add to
+
+   ``<scope>``
+     Scope to add items to
+
+   ``<item>``
+     Item (or items) to add to the target
+
+   Example usage:
+
+   .. code-block:: cmake
+
+      # If the devicetree alias "led0" refers to a node, this
+      # adds "blink_led.c" to the sources list for the "app" target.
+      target_sources_if_dt_node("led0" app PRIVATE blink_led.c)
+
+      # If the devicetree path "/soc/serial@4000" is a node, this
+      # adds "uart.c" to the sources list for the "lib" target,
+      target_sources_if_dt_node("/soc/serial@4000" lib PRIVATE uart.c)
+#]=======================================================================]
 function(target_sources_if_dt_node path target scope item)
   dt_node_exists(check PATH "${path}")
   if(${check})
@@ -4825,51 +5563,52 @@ function(target_sources_if_dt_node path target scope item)
   endif()
 endfunction()
 
-########################################################
-# 4.3 zephyr_dt_*
-#
-# The following methods are common code for dealing
-# with devicetree related files in CMake.
-#
-# Note that functions related to accessing the
-# *contents* of the devicetree belong in section 4.1.
-# This section is just for DT file processing at
-# configuration time.
-########################################################
+#[=======================================================================[.rst:
+``zephyr_dt_*``
+===============
 
-# Usage:
-#   zephyr_dt_preprocess(CPP <path> [<argument...>]
-#                        SOURCE_FILES <file...>
-#                        OUT_FILE <file>
-#                        [DEPS_FILE <file>]
-#                        [EXTRA_CPPFLAGS <flag...>]
-#                        [INCLUDE_DIRECTORIES <dir...>]
-#                        [WORKING_DIRECTORY <dir>]
-#
-# Preprocess one or more devicetree source files. The preprocessor
-# symbol __DTS__ will be defined. If the preprocessor command fails, a
-# fatal error occurs.
-#
-# Mandatory arguments:
-#
-# CPP <path> [<argument...>]: path to C preprocessor, followed by any
-#                             additional arguments
-#
-# SOURCE_FILES <file...>: The source files to run the preprocessor on.
-#                         These will, in effect, be concatenated in order
-#                         and used as the preprocessor input.
-#
-# OUT_FILE <file>: Where to store the preprocessor output.
-#
-# Optional arguments:
-#
-# DEPS_FILE <file>: If set, generate a dependency file here.
-#
-# EXTRA_CPPFLAGS <flag...>: Additional flags to pass the preprocessor.
-#
-# INCLUDE_DIRECTORIES <dir...>: Additional #include file directories.
-#
-# WORKING_DIRECTORY <dir>: where to run the preprocessor.
+The following methods are common code for dealing with devicetree related files in CMake.
+
+Note that functions related to accessing the *contents* of the devicetree belong in section 4.1.
+This section is just for DT file processing at configuration time.
+
+.. cmake:signature:: zephyr_dt_preprocess(CPP <path> [<argument...>]
+                                          SOURCE_FILES <file...>
+                                          OUT_FILE <file> [DEPS_FILE <file>
+                                          [EXTRA_CPPFLAGS <flag...>]
+                                          [INCLUDE_DIRECTORIES <dir...>]
+                                          [WORKING_DIRECTORY <dir>])
+   :break: verbatim
+
+   Preprocess one or more devicetree source files. The preprocessor symbol ``__DTS__`` will be
+   defined. If the preprocessor command fails, a fatal error occurs.
+
+   Mandatory arguments:
+
+   ``CPP <path> [<argument...>]``
+     path to C preprocessor, followed by any additional arguments
+
+   ``SOURCE_FILES <file...>``
+     The source files to run the preprocessor on. These will, in effect, be concatenated in order
+     and used as the preprocessor input.
+
+   ``OUT_FILE <file>``
+     Where to store the preprocessor output.
+
+   Optional arguments:
+
+   ``DEPS_FILE <file>``
+     If set, generate a dependency file here.
+
+   ``EXTRA_CPPFLAGS <flag...>``
+     Additional flags to pass the preprocessor.
+
+   ``INCLUDE_DIRECTORIES <dir...>``
+     Additional #include file directories.
+
+   ``WORKING_DIRECTORY <dir>``
+     where to run the preprocessor.
+#]=======================================================================]
 function(zephyr_dt_preprocess)
   set(req_single_args "OUT_FILE")
   set(single_args "DEPS_FILE;WORKING_DIRECTORY")
@@ -4926,19 +5665,21 @@ function(zephyr_dt_preprocess)
   endif()
 endfunction()
 
-# Usage:
-#   zephyr_dt_import(EDT_PICKLE_FILE <file> TARGET <target>)
-#
-# Parse devicetree information and make it available to CMake, so that
-# it can be accessed by the dt_* CMake extensions from section 4.1.
-#
-# This requires running a Python script, which can take the output of
-# edtlib and generate a CMake source file from it. If that script fails,
-# a fatal error occurs.
-#
-# EDT_PICKLE_FILE <file> : Input edtlib.EDT object in pickle format
-# TARGET <target>        : Target to populate with devicetree properties
-#
+#[=======================================================================[.rst:
+.. cmake:signature:: zephyr_dt_import(EDT_PICKLE_FILE <file> TARGET <target>)
+
+   Parse devicetree information and make it available to CMake, so that it can be accessed by the
+   ``dt_*`` CMake extensions from section 4.1.
+
+   This requires running a Python script, which can take the output of edtlib and generate a CMake
+   source file from it. If that script fails, a fatal error occurs.
+
+   ``EDT_PICKLE_FILE <file>``
+     Input edtlib.EDT object in pickle format
+
+   ``TARGET <target>``
+     Target to populate with devicetree properties
+#]=======================================================================]
 function(zephyr_dt_import)
   set(req_single_args "EDT_PICKLE_FILE;TARGET")
   cmake_parse_arguments(arg "" "${req_single_args}" "" ${ARGN})
@@ -4969,46 +5710,51 @@ function(zephyr_dt_import)
   include(${gen_dts_cmake_output})
 endfunction()
 
-########################################################
-# 5. Zephyr linker functions
-########################################################
-# 5.1. zephyr_linker*
-#
-# The following methods are for defining linker structure using CMake functions.
-#
-# This allows Zephyr developers to define linker sections and their content and
-# have this configuration rendered into an appropriate linker script based on
-# the toolchain in use.
-# For example:
-# ld linker scripts with GNU ld
-# ARM scatter files with ARM linker.
-#
-# Example usage:
-# zephyr_linker_section(
-#   NAME my_data
-#   VMA  RAM
-#   LMA  FLASH
-# )
-#
-# and to configure special input sections for the section
-# zephyr_linker_section_configure(
-#   SECTION my_data
-#   INPUT   "my_custom_data"
-#   KEEP
-# )
+#[=======================================================================[.rst:
+Zephyr linker functions
+***********************
 
+``zephyr_linker*``
+==================
 
-# Usage:
-#   zephyr_linker([FORMAT <format>]
-#     [ENTRY <entry symbol>]
-#   )
-#
-# Zephyr linker general settings.
-# This function specifies general settings for the linker script to be generated.
-#
-# FORMAT <format>:            The output format of the linked executable.
-# ENTRY <entry symbolformat>: The code entry symbol.
-#
+The following methods are for defining linker structure using CMake functions.
+
+This allows Zephyr developers to define linker sections and their content and have this
+configuration rendered into an appropriate linker script based on the toolchain in use.
+
+For example:
+
+- ld linker scripts with GNU ld
+- ARM scatter files with ARM linker.
+
+Example usage:
+
+.. code-block:: cmake
+
+   zephyr_linker_section(
+     NAME my_data
+     VMA  RAM
+     LMA  FLASH
+   )
+
+   # and to configure special input sections for the section
+   zephyr_linker_section_configure(
+     SECTION my_data
+     INPUT   "my_custom_data"
+     KEEP
+   )
+
+.. cmake:signature:: zephyr_linker([FORMAT <format>] [ENTRY <entry_symbol>])
+
+   Zephyr linker general settings.
+   This function specifies general settings for the linker script to be generated.
+
+   ``FORMAT <format>``
+     The output format of the linked executable.
+
+   ``ENTRY <entry_symbol>``
+     The code entry symbol.
+#]=======================================================================]
 function(zephyr_linker)
   set(single_args "ENTRY;FORMAT")
   cmake_parse_arguments(LINKER "" "${single_args}" "" ${ARGN})
@@ -5038,32 +5784,42 @@ function(zephyr_linker)
   endif()
 endfunction()
 
-# Usage:
-#   zephyr_linker_memory(NAME <name> START <address> SIZE <size> [FLAGS <flags>])
-#
-# Zephyr linker memory.
-# This function specifies a memory region for the platform in use.
-#
-# Note:
-#   This function should generally be called with values obtained from
-#   devicetree or Kconfig.
-#
-# NAME <name>    : Name of the memory region, for example FLASH.
-# START <address>: Start address of the memory region.
-#                  Start address can be given as decimal or hex value.
-# SIZE <size>    : Size of the memory region.
-#                  Size can be given as decimal value, hex value, or decimal with postfix k or m.
-#                  All the following are valid values:
-#                    1048576, 0x10000, 1024k, 1024K, 1m, and 1M.
-# FLAGS <flags>  : Flags describing properties of the memory region.
-#                  r: Read-only region
-#                  w: Read-write region
-#                  x: Executable region
-#                  a: Allocatable region
-#                  i: Initialized region
-#                  l: Same as ‘i’
-#                  !: Invert the sense of any of the attributes that follow
-#                  The flags may be combined like: rx, rx!w.
+#[=======================================================================[.rst:
+.. cmake:signature:: zephyr_linker_memory(NAME <name> START <address> SIZE <size> [FLAGS <flags>])
+
+   Zephyr linker memory.
+   This function specifies a memory region for the platform in use.
+
+   .. note::
+     This function should generally be called with values obtained from devicetree or Kconfig.
+
+   ``NAME <name>``
+     Name of the memory region, for example FLASH.
+
+   ``START <address>``
+     Start address of the memory region.
+     Start address can be given as decimal or hex value.
+
+   ``SIZE <size>``
+     Size of the memory region.
+
+     Size can be given as decimal value, hex value, or decimal with postfix k or m.
+     All the following are valid values:
+     ``1048576``, ``0x10000``, ``1024k``, ``1024K``, ``1m``, and ``1M``.
+
+   ``FLAGS <flags>``
+     Flags describing properties of the memory region.
+
+     * ``r``: Read-only region
+     * ``w``: Read-write region
+     * ``x``: Executable region
+     * ``a``: Allocatable region
+     * ``i``: Initialized region
+     * ``l``: Same as ``i``
+     * ``!``: Invert the sense of any of the attributes that follow
+
+     The flags may be combined like: ``rx``, ``rx!w``.
+#]=======================================================================]
 function(zephyr_linker_memory)
   set(req_single_args "NAME;SIZE;START")
   set(single_args "FLAGS")
@@ -5093,34 +5849,38 @@ function(zephyr_linker_memory)
   )
 endfunction()
 
-# Usage:
-#   zephyr_linker_memory_ifdef(<setting> NAME <name> START <address> SIZE <size> [FLAGS <flags>])
-#
-# Will create memory region if <setting> is enabled.
-#
-# <setting>: Setting to check for True value before invoking
-#            zephyr_linker_memory()
-#
-# See zephyr_linker_memory() description for other supported arguments.
-#
+#[=======================================================================[.rst:
+.. cmake:signature:: zephyr_linker_memory_ifdef(<setting> NAME <name>
+                                                START <address>
+                                                SIZE <size>
+                                                [FLAGS <flags>])
+
+   Will create memory region if ``<setting>`` is enabled.
+
+   ``<setting>``
+     Setting to check for True value before invoking :cmake:command:`zephyr_linker_memory`
+
+   See :cmake:command:`zephyr_linker_memory` description for other supported arguments.
+#]=======================================================================]
 macro(zephyr_linker_memory_ifdef feature_toggle)
   if(${${feature_toggle}})
     zephyr_linker_memory(${ARGN})
   endif()
 endmacro()
 
-# Usage:
-#   zephyr_linker_dts_section(PATH <path>)
-#
-# Zephyr linker devicetree memory section from path.
-#
-# This function specifies an output section for the platform in use based on its
-# devicetree configuration.
-#
-# The section will only be defined if the devicetree exists and has status okay.
-#
-# PATH <path>      : Devicetree node path.
-#
+#[=======================================================================[.rst:
+.. cmake:signature:: zephyr_linker_dts_section(PATH <path>)
+
+   Zephyr linker devicetree memory section from path.
+
+   This function specifies an output section for the platform in use based on its devicetree
+   configuration.
+
+   The section will only be defined if the devicetree exists and has status okay.
+
+   ``PATH <path>``
+     Devicetree node path.
+#]=======================================================================]
 function(zephyr_linker_dts_section)
   set(single_args "PATH")
   cmake_parse_arguments(DTS_SECTION "" "${single_args}" "" ${ARGN})
@@ -5156,25 +5916,30 @@ function(zephyr_linker_dts_section)
 
 endfunction()
 
-# Usage:
-#   zephyr_linker_dts_memory(PATH <path>)
-#   zephyr_linker_dts_memory(NODELABEL <nodelabel>)
-#   zephyr_linker_dts_memory(CHOSEN <prop>)
-#
-# Zephyr linker devicetree memory.
-# This function specifies a memory region for the platform in use based on its
-# devicetree configuration.
-#
-# The memory will only be defined if the devicetree node or a devicetree node
-# matching the nodelabel exists and has status okay.
-#
-# Only one of PATH, NODELABEL, and CHOSEN parameters may be given.
-#
-# PATH <path>      : Devicetree node identifier.
-# NODELABEL <label>: Node label
-# CHOSEN <prop>    : Chosen property, add memory section described by the
-#                    /chosen property if it exists.
-#
+#[=======================================================================[.rst:
+.. cmake:signature:: zephyr_linker_dts_memory(PATH <path>)
+                     zephyr_linker_dts_memory(NODELABEL <nodelabel>)
+                     zephyr_linker_dts_memory(CHOSEN <prop>)
+
+   Zephyr linker devicetree memory.
+
+   This function specifies a memory region for the platform in use based on its
+   devicetree configuration.
+
+   The memory will only be defined if the devicetree node or a devicetree node
+   matching the nodelabel exists and has status okay.
+
+   Only one of ``PATH``, ``NODELABEL``, and ``CHOSEN`` parameters may be given.
+
+   ``PATH <path>``
+     Devicetree node identifier.
+
+   ``NODELABEL <label>``
+     Node label
+
+   ``CHOSEN <prop>``
+     Chosen property, add memory section described by the ``/chosen`` property if it exists.
+#]=======================================================================]
 function(zephyr_linker_dts_memory)
   set(single_args "CHOSEN;PATH;NODELABEL")
   cmake_parse_arguments(DTS_MEMORY "" "${single_args}" "" ${ARGN})
@@ -5243,78 +6008,98 @@ function(zephyr_linker_dts_memory)
   endif()
 endfunction()
 
-# Usage:
-#   zephyr_linker_group(NAME <name> [VMA <region|group>] [LMA <region|group>] [SYMBOL <SECTION>])
-#   zephyr_linker_group(NAME <name> GROUP <group> [SYMBOL <SECTION>])
-#
-# Zephyr linker group.
-# This function specifies a group inside a memory region or another group.
-#
-# The group ensures that all section inside the group are located together inside
-# the specified group.
-#
-# This also allows for section placement inside a given group without the section
-# itself needing the precise knowledge regarding the exact memory region this
-# section will be placed in, as that will be determined by the group setup.
-#
-# Each group will define the following linker symbols:
-# __<name>_start      : Start address of the group
-# __<name>_end        : End address of the group
-# __<name>_size       : Size of the group
-#
-# Note: <name> will be converted to lower casing for linker symbols definitions.
-#
-# NAME <name>         : Name of the group.
-# VMA <region|group>  : VMA Memory region or group to be used for this group.
-#                       If a group is used then the VMA region of that group will be used.
-# LMA <region|group>  : Memory region or group to be used for this group.
-# GROUP <group>       : Place the new group inside the existing group <group>
-# SYMBOL <SECTION>    : Specify that start symbol of the region should be identical
-#                       to the start address of the first section in the group.
-#
-# Note: VMA and LMA are mutual exclusive with GROUP
-#
-# Example:
-#   zephyr_linker_memory(NAME memA START ... SIZE ... FLAGS ...)
-#   zephyr_linker_group(NAME groupA LMA memA)
-#   zephyr_linker_group(NAME groupB LMA groupA)
-#
-# will create two groups in same memory region as groupB will inherit the LMA
-# from groupA:
-#
-# +-----------------+
-# | memory region A |
-# |                 |
-# | +-------------+ |
-# | | groupA      | |
-# | +-------------+ |
-# |                 |
-# | +-------------+ |
-# | | groupB      | |
-# | +-------------+ |
-# |                 |
-# +-----------------+
-#
-# whereas
-#   zephyr_linker_memory(NAME memA START ... SIZE ... FLAGS ...)
-#   zephyr_linker_group(NAME groupA LMA memA)
-#   zephyr_linker_group(NAME groupB GROUP groupA)
-#
-# will create groupB inside groupA:
-#
-# +---------------------+
-# | memory region A     |
-# |                     |
-# | +-----------------+ |
-# | | groupA          | |
-# | |                 | |
-# | | +-------------+ | |
-# | | | groupB      | | |
-# | | +-------------+ | |
-# | |                 | |
-# | +-----------------+ |
-# |                     |
-# +---------------------+
+#[=======================================================================[.rst:
+.. cmake:signature:: zephyr_linker_group(NAME <name> [VMA <region|group>] [LMA <region|group>] [GROUP <group>] [SYMBOL <SECTION>])
+
+   Zephyr linker group.
+   This function specifies a group inside a memory region or another group.
+
+   The group ensures that all section inside the group are located together inside
+   the specified group.
+
+   This also allows for section placement inside a given group without the section
+   itself needing the precise knowledge regarding the exact memory region this
+   section will be placed in, as that will be determined by the group setup.
+
+   Each group will define the following linker symbols:
+
+   * :samp:`__{name}_start`: Start address of the group
+   * :samp:`__{name}_end`: End address of the group
+   * :samp:`__{name}_size`: Size of the group
+
+   Note: ``<name>`` will be converted to lower casing for linker symbols definitions.
+
+   ``NAME <name>``
+     Name of the group.
+
+   ``VMA <region|group>``
+     VMA Memory region or group to be used for this group.
+     If a group is used then the VMA region of that group will be used.
+
+   ``LMA <region|group>``
+     Memory region or group to be used for this group.
+
+   ``GROUP <group>``
+     Place the new group inside the existing group ``<group>``
+
+   ``SYMBOL <SECTION>``
+     Specify that start symbol of the region should be identical
+     to the start address of the first section in the group.
+
+   Note: ``VMA`` and ``LMA`` are mutual exclusive with ``GROUP``
+
+   Example:
+
+   .. code-block:: cmake
+
+      zephyr_linker_memory(NAME memA START ... SIZE ... FLAGS ...)
+      zephyr_linker_group(NAME groupA LMA memA)
+      zephyr_linker_group(NAME groupB LMA groupA)
+
+   will create two groups in same memory region as groupB will inherit the LMA
+   from groupA:
+
+   .. code-block:: text
+
+      +-----------------+
+      | memory region A |
+      |                 |
+      | +-------------+ |
+      | | groupA      | |
+      | +-------------+ |
+      |                 |
+      | +-------------+ |
+      | | groupB      | |
+      | +-------------+ |
+      |                 |
+      | +-------------+ |
+
+   whereas
+
+   .. code-block:: cmake
+
+      zephyr_linker_memory(NAME memA START ... SIZE ... FLAGS ...)
+      zephyr_linker_group(NAME groupA LMA memA)
+      zephyr_linker_group(NAME groupB GROUP groupA)
+
+   will create groupB inside groupA:
+
+   .. code-block:: text
+
+      +---------------------+
+      | memory region A     |
+      |                     |
+      | +-----------------+ |
+      | | groupA          | |
+      | |                 | |
+      | | +-------------+ | |
+      | | | groupB      | | |
+      | | +-------------+ | |
+      | |                 | |
+      | +-----------------+ |
+      |                     |
+      +---------------------+
+#]=======================================================================]
 function(zephyr_linker_group)
   set(single_args "NAME;GROUP;LMA;SYMBOL;VMA")
   set(symbol_values SECTION)
@@ -5347,83 +6132,98 @@ function(zephyr_linker_group)
   )
 endfunction()
 
-# Usage:
-#   zephyr_linker_section(NAME <name> [GROUP <group>]
-#                         [VMA <region|group>] [LMA <region|group>]
-#                         [ADDRESS <address>] [ALIGN <alignment>]
-#                         [SUBALIGN <alignment>] [FLAGS <flags>]
-#                         [MIN_SIZE <minimum size>] [MAX_SIZE <maximum size>]
-#                         [HIDDEN] [NOINPUT] [NOINIT]
-#                         [PASS [NOT] [<name>]]
-#   )
-#
-# Zephyr linker output section.
-# This function specifies an output section for the linker.
-#
-# When using zephyr_linker_section(NAME <name>) an output section with <name>
-# will be configured. This section will default include input sections of the
-# same name, unless NOINPUT is specified.
-# This means the section named `foo` will default include the sections matching
-# `foo` and `foo.*`
-# Each output section will define the following linker symbols:
-# __<name>_start      : Start address of the section
-# __<name>_end        : End address of the section
-# __<name>_size       : Size of the section
-# __<name>_load_start : Load address of the section, if VMA = LMA then this
-#                       value will be identical to `__<name>_start`
-#
-# The location of the output section can be controlled using LMA, VMA, and
-# address parameters
-#
-# NAME <name>         : Name of the output section.
-# VMA <region|group>  : VMA Memory region or group where code / data is located runtime (VMA)
-#                       If <group> is used here it means the section will use the
-#                       same VMA memory region as <group> but will not be placed
-#                       inside the group itself, see also GROUP argument.
-# KVMA <region|group> : Kernel VMA Memory region or group where code / data is located runtime (VMA)
-#                       When MMU is active and Kernel VM base and offset is different
-#                       from SRAM base and offset, then the region defined by KVMA will
-#                       be used as VMA.
-#                       If <group> is used here it means the section will use the
-#                       same VMA memory region as <group> but will not be placed
-#                       inside the group itself, see also GROUP argument.
-# LMA <region|group>  : Memory region or group where code / data is loaded (LMA)
-#                       If VMA is different from LMA, the code / data will be loaded
-#                       from LMA into VMA at bootup, this is usually the case for
-#                       global or static variables that are loaded in rom and copied
-#                       to ram at boot time.
-#                       If <group> is used here it means the section will use the
-#                       same LMA memory region as <group> but will not be placed
-#                       inside the group itself, see also GROUP argument.
-# GROUP <group>       : Place this section inside the group <group>
-# ADDRESS <address>   : Specific address to use for this section.
-# ALIGN_WITH_INPUT    : The alignment difference between VMA and LMA is kept
-#                       intact for this section.
-# ALIGN <alignment>   : Align the execution address with alignment.
-# SUBALIGN <alignment>: Align input sections with alignment value.
-# ENDALIGN <alignment>: Align the end so that next output section will start aligned.
-#                       This only has effect on Scatter scripts.
-#  Note: Regarding all alignment attributes. Not all linkers may handle alignment
-#        in identical way. For example the Scatter file will align both load and
-#        execution address (LMA and VMA) to be aligned when given the ALIGN attribute.
-# MIN_SIZE <size>     : Pad section so that it at least <size> bytes in size.
-# MAX_SIZE <size>     : Check that the sections is not larger than <size> bytes.
-# NOINPUT             : No default input sections will be defined, to setup input
-#                       sections for section <name>, the corresponding
-#                       `zephyr_linker_section_configure()` must be used.
-# PASS [NOT] [<name> ..]: Linker pass where this section should be active.
-#                       By default a section will be present during all linker
-#                       passes.
-#                       PASS [<p1>] [<p2>...] makes the section present only in
-#                       the given passes. Empty list means no passes.
-#                       PASS NOT [<p1>] [<p2>...] makes the section present in
-#                       all but the given passes. Empty list means all passes.
-# TYPE <type>         : Tag section for special treatment.
-#                       NOLOAD, BSS - Ensure that the section is NOLOAD
-#                       LINKER_SCRIPT_FOOTER - One single section to be
-#                                              generated last
-# Note: VMA and LMA are mutual exclusive with GROUP
-#
+#[=======================================================================[.rst:
+.. cmake:signature:: zephyr_linker_section(NAME <name> [GROUP <group>] [VMA <region|group>] [LMA <region|group>] [ADDRESS <address>] [ALIGN <alignment>] [SUBALIGN <alignment>] [FLAGS <flags>] [MIN_SIZE <size>] [MAX_SIZE <size>] [HIDDEN] [NOINPUT] [NOINIT] [PASS [NOT] <name>...])
+
+   Zephyr linker output section. This function specifies an output section for the linker.
+
+   When using ``zephyr_linker_section(NAME <name>)`` an output section with ``<name>`` will be
+   configured. This section will default include input sections of the same name, unless ``NOINPUT``
+   is specified. This means the section named ``foo`` will default include the sections matching
+   ``foo`` and ``foo.*`` Each output section will define the following linker symbols:
+
+   * :samp:`__{name}_start`: Start address of the section
+   * :samp:`__{name}_end`: End address of the section
+   * :samp:`__{name}_size`: Size of the section
+   * :samp:`__{name}_load_start`: Load address of the section, if VMA = LMA then this value will be
+     identical to :samp:`__{name}_start`
+
+   The location of the output section can be controlled using LMA, VMA, and
+   address parameters
+
+   ``NAME <name>``
+     Name of the output section.
+
+   ``VMA <region|group>``
+     VMA Memory region or group where code / data is located runtime (VMA) If ``<group>`` is used
+     here it means the section will use the same VMA memory region as ``<group>`` but will not be
+     placed inside the group itself, see also ``GROUP`` argument.
+
+   ``KVMA <region|group>``
+     Kernel VMA Memory region or group where code / data is located runtime (VMA) When MMU is active
+     and Kernel VM base and offset is different from SRAM base and offset, then the region defined
+     by KVMA will be used as VMA. If ``<group>`` is used here it means the section will use the same
+     VMA memory region as ``<group>`` but will not be placed inside the group itself, see also
+     ``GROUP`` argument.
+
+   ``LMA <region|group>``
+     Memory region or group where code / data is loaded (LMA) If VMA is different from LMA, the code
+     / data will be loaded from LMA into VMA at bootup, this is usually the case for global or
+     static variables that are loaded in rom and copied to ram at boot time. If ``<group>`` is used
+     here it means the section will use the same LMA memory region as ``<group>`` but will not be
+     placed inside the group itself, see also ``GROUP`` argument.
+
+   ``GROUP <group>``
+     Place this section inside the group ``<group>``
+
+   ``ADDRESS <address>``
+     Specific address to use for this section.
+
+   ``ALIGN_WITH_INPUT``
+     The alignment difference between VMA and LMA is kept intact for this section.
+
+   ``ALIGN <alignment>``
+     Align the execution address with alignment.
+
+   ``SUBALIGN <alignment>``
+     Align input sections with alignment value.
+
+   ``ENDALIGN <alignment>``
+     Align the end so that next output section will start aligned. This only has effect on Scatter
+     scripts.
+
+   Note: Regarding all alignment attributes. Not all linkers may handle alignment in identical way.
+   For example the Scatter file will align both load and execution address (LMA and VMA) to be
+   aligned when given the ALIGN attribute.
+
+   ``MIN_SIZE <size>``
+     Pad section so that it at least ``<size>`` bytes in size.
+
+   ``MAX_SIZE <size>``
+     Check that the sections is not larger than ``<size>`` bytes.
+
+   ``NOINPUT``
+     No default input sections will be defined, to setup input sections for section ``<name>``, the
+     corresponding :cmake:command:`zephyr_linker_section_configure` must be used.
+
+   ``PASS [NOT] <name>...``
+     Linker pass where this section should be active. By default a section will be present during
+     all linker passes.
+
+     ``PASS <p1> <p2>...`` makes the section present only in the given passes. Empty list means no
+     passes.
+
+     ``PASS NOT <p1> <p2>...`` makes the section present in all but the given passes. Empty list
+     means all passes.
+
+   ``TYPE <type>``
+     Tag section for special treatment.
+
+     * ``NOLOAD``, ``BSS`` - Ensure that the section is NOLOAD
+     * ``LINKER_SCRIPT_FOOTER`` - One single section to be generated last
+
+   Note: ``VMA`` and ``LMA`` are mutual exclusive with ``GROUP``
+#]=======================================================================]
 function(zephyr_linker_section)
   set(options     "ALIGN_WITH_INPUT;HIDDEN;NOINIT;NOINPUT")
   set(single_args "ADDRESS;ALIGN;ENDALIGN;GROUP;KVMA;LMA;NAME;SUBALIGN;TYPE;VMA;MIN_SIZE;MAX_SIZE")
@@ -5481,69 +6281,105 @@ function(zephyr_linker_section)
   )
 endfunction()
 
-# Usage:
-#   zephyr_linker_section_ifdef(<setting>
-#                               NAME <name> [VMA <region>] [LMA <region>]
-#                               [ADDRESS <address>] [ALIGN <alignment>]
-#                               [SUBALIGN <alignment>] [FLAGS <flags>]
-#                               [HIDDEN] [NOINPUT] [NOINIT]
-#                               [PASS <no> [<no>...]
-#   )
-#
-# Will create an output section if <setting> is enabled.
-#
-# <setting>: Setting to check for True value before invoking
-#            zephyr_linker_section()
-#
-# See zephyr_linker_section() description for other supported arguments.
-#
+#[=======================================================================[.rst:
+.. cmake:signature:: zephyr_linker_section_ifdef(<setting> NAME <name>
+                                                 [GROUP <group>]
+                                                 [VMA <region|group>]
+                                                 [LMA <region|group>]
+                                                 [ADDRESS <address>]
+                                                 [ALIGN <alignment>]
+                                                 [SUBALIGN <alignment>]
+                                                 [FLAGS <flags>]
+                                                 [MIN_SIZE <size>]
+                                                 [MAX_SIZE <size>]
+                                                 [HIDDEN]
+                                                 [NOINPUT]
+                                                 [NOINIT]
+                                                 [PASS [NOT] <name>...])
+   :break: verbatim
+
+   Will create an output section if ``<setting>`` is enabled.
+
+   ``<setting>``
+     Setting to check for True value before invoking :cmake:command:`zephyr_linker_section`
+
+   See :cmake:command:`zephyr_linker_section` description for other supported arguments.
+#]=======================================================================]
 macro(zephyr_linker_section_ifdef feature_toggle)
   if(${${feature_toggle}})
     zephyr_linker_section(${ARGN})
   endif()
 endmacro()
 
-# Usage:
-#   zephyr_iterable_section(NAME <name> [GROUP <group>]
-#                           [VMA <region|group>] [LMA <region|group>]
-#                           [ALIGN_WITH_INPUT] [SUBALIGN <alignment>]
-#   )
-#
-#
-# Define an output section which will set up an iterable area
-# of equally-sized data structures. For use with STRUCT_SECTION_ITERABLE.
-# Input sections will be sorted by name in lexicographical order.
-#
-# Each list for an input section will define the following linker symbols:
-# _<name>_list_start: Start of the iterable list
-# _<name>_list_end  : End of the iterable list
-#
-# The output section will be named `<name>_area` and define the following linker
-# symbols:
-# __<name>_area_start      : Start address of the section
-# __<name>_area_end        : End address of the section
-# __<name>_area_size       : Size of the section
-# __<name>_area_load_start : Load address of the section, if VMA = LMA then this
-#                            value will be identical to `__<name>_area_start`
-#
-# NAME <name>         : Name of the struct type, the output section be named
-#                       accordingly as: <name>_area.
-# VMA <region|group>  : VMA Memory region where code / data is located runtime (VMA)
-# LMA <region|group>  : Memory region where code / data is loaded (LMA)
-#                       If VMA is different from LMA, the code / data will be loaded
-#                       from LMA into VMA at bootup, this is usually the case for
-#                       global or static variables that are loaded in rom and copied
-#                       to ram at boot time.
-# GROUP <group>       : Place this section inside the group <group>
-# ADDRESS <address>   : Specific address to use for this section.
-# ALIGN_WITH_INPUT    : The alignment difference between VMA and LMA is kept
-#                       intact for this section.
-# NUMERIC             : Use numeric sorting.
-# SUBALIGN <alignment>: Force input alignment with size <alignment>
-#  Note: Regarding all alignment attributes. Not all linkers may handle alignment
-#        in identical way. For example the Scatter file will align both load and
-#        execution address (LMA and VMA) to be aligned when given the ALIGN attribute.
-#/
+#[=======================================================================[.rst:
+
+.. cmake:signature::
+   zephyr_iterable_section(NAME <name> [GROUP <group>]
+                           [VMA <region|group>] [LMA <region|group>]
+                           [ALIGN_WITH_INPUT] [SUBALIGN <alignment>])
+   :break: verbatim
+
+   Define an output section which will set up an iterable area of equally-sized data structures. For
+   use with :c:macro:`STRUCT_SECTION_ITERABLE`. Input sections will be sorted by name in
+   lexicographical order.
+
+   Each list for an input section will define the following linker symbols:
+
+   - ``_<name>_list_start``: Start of the iterable list
+   - ``_<name>_list_end``: End of the iterable list
+
+   The output section will be named `<name>_area` and define the following linker symbols:
+
+   +-----------------------------------+-----------------------------------------------------------+
+   | Symbol                            | Description                                               |
+   +===================================+===========================================================+
+   | :samp:`__{name}_area_start`       | Start address of the section                              |
+   +-----------------------------------+-----------------------------------------------------------+
+   | :samp:`__{name}_area_end`         | End address of the section                                |
+   +-----------------------------------+-----------------------------------------------------------+
+   | :samp:`__{name}_area_size`        | Size of the section                                       |
+   +-----------------------------------+-----------------------------------------------------------+
+   | :samp:`__{name}_area_load_start`  | Load address of the section, if VMA = LMA then this       |
+   |                                   | value will be identical to :samp:`__{name}_area_start`    |
+   +-----------------------------------+-----------------------------------------------------------+
+
+   The options are:
+
+   ``NAME <name>``
+     Name of the struct type, the output section be named
+     accordingly as: <name>_area.
+
+   ``VMA <region|group>``
+     VMA Memory region where code / data is located runtime (VMA)
+
+   ``LMA <region|group>``
+     Memory region where code / data is loaded (LMA)
+     If VMA is different from LMA, the code / data will be loaded from LMA into VMA at bootup, this
+     is usually the case for global or static variables that are loaded in rom and copied to ram at
+     boot time.
+
+   ``GROUP <group>``
+     Place this section inside the group <group>
+
+   ``ADDRESS <address>``
+     Specific address to use for this section.
+
+   ``ALIGN_WITH_INPUT``
+     The alignment difference between VMA and LMA is kept
+     in tact for this section.
+
+   ``NUMERIC``
+     Use numeric sorting.
+
+   ``SUBALIGN <alignment>``
+     Force input alignment with size <alignment>
+
+   .. note:: Regarding all alignment attributes. Not all linkers may handle alignment
+             in identical way. For example the Scatter file will align both load and
+             execution address (LMA and VMA) to be aligned when given the ALIGN attribute.
+
+#]=======================================================================]
+
 function(zephyr_iterable_section)
   # ToDo - Should we use ROM, RAM, etc as arguments ?
   set(options     "ALIGN_WITH_INPUT;NUMERIC")
@@ -5591,24 +6427,27 @@ function(zephyr_iterable_section)
   )
 endfunction()
 
-# Usage:
-#   zephyr_linker_section_obj_level(SECTION <section> LEVEL <level>)
-#
-# generate a symbol to mark the start of the objects array for
-# the specified object and level, then link all of those objects
-# (sorted by priority). Ensure the objects aren't discarded if there is
-# no direct reference to them.
-#
-# This is useful content such as struct devices.
-#
-# For example: zephyr_linker_section_obj_level(SECTION init LEVEL PRE_KERNEL_1)
-# will create an input section matching `.z_init_PRE_KERNEL_P_1_SUB_?_`,
-# `.z_init_PRE_KERNEL_P_1_SUB_??_`, and `.z_init_PRE_KERNEL_P_1_SUB_???_`.
-#
-# SECTION <section>: Section in which the objects shall be placed
-# LEVEL <level>    : Priority level, all input sections matching the level
-#                    will be sorted.
-#
+#[=======================================================================[.rst:
+.. cmake:signature:: zephyr_linker_section_obj_level(SECTION <section> LEVEL <level>)
+
+   Generate a symbol to mark the start of the objects array for
+   the specified object and level, then link all of those objects
+   (sorted by priority). Ensure the objects aren't discarded if there is
+   no direct reference to them.
+
+   This is useful content such as struct devices.
+
+   For example: ``zephyr_linker_section_obj_level(SECTION init LEVEL PRE_KERNEL_1)``
+   will create an input section matching ``.z_init_PRE_KERNEL_P_1_SUB_?_``,
+   ``.z_init_PRE_KERNEL_P_1_SUB_??_``, and ``.z_init_PRE_KERNEL_P_1_SUB_???_``.
+
+   ``SECTION <section>``
+     Section in which the objects shall be placed
+
+   ``LEVEL <level>``
+     Priority level, all input sections matching the level
+     will be sorted.
+#]=======================================================================]
 function(zephyr_linker_section_obj_level)
   set(single_args "SECTION;LEVEL")
   cmake_parse_arguments(OBJ "" "${single_args}" "" ${ARGN})
@@ -5643,51 +6482,75 @@ function(zephyr_linker_section_obj_level)
   )
 endfunction()
 
-# Usage:
-#   zephyr_linker_section_configure(SECTION <section> [ALIGN <alignment>]
-#                                   [PASS [NOT] <name>] [PRIO <no>] [SORT <sort>]
-#                                   [MIN_SIZE <minimum size>] [MAX_SIZE <maximum size>]
-#                                   [ANY] [FIRST] [KEEP] [INPUT <input>] [SYMBOLS [<start>[<end>]]]
-#   )
-#
-# Configure an output section with additional input sections.
-# An output section can be configured with additional input sections besides its
-# default section.
-# For example, to add the input section `foo` to the output section bar, with KEEP
-# attribute, call:
-#   zephyr_linker_section_configure(SECTION bar INPUT foo KEEP)
-#
-# ALIGN <alignment>   : Will align the input section placement inside the load
-#                       region with <alignment>
-# FIRST               : The first input section in the list should be marked as
-#                       first section in output.
-# SORT <NAME>         : Sort the input sections according to <type>.
-#                       Currently only `NAME` is supported.
-# MIN_SIZE <size>     : Pad section so that it at least <size> bytes in size.
-# MAX_SIZE <size>     : Check that the sections is not larger than <size> bytes.
-# KEEP                : Do not eliminate input section during linking
-# PRIO                : The priority of the input section. Per default, input
-#                       sections order is not guaranteed by all linkers, but
-#                       using priority Zephyr CMake linker will create sections
-#                       such that order can be guaranteed. All unprioritized
-#                       sections will internally be given a CMake process order
-#                       priority counting from 100, so first unprioritized section
-#                       is handled internal prio 100, next 101, and so on.
-#                       To ensure a specific input section come before those,
-#                       you may use `PRIO 50`, `PRIO 20` and so on.
-#                       To ensure an input section is at the end, it is advised
-#                       to use `PRIO 200` and above.
-# PASS [NOT] [<pass>..]: Control in which linker passes this piece is present
-#                       See zephyr_linker_section(PASS) for details.
-# FLAGS <flags>       : Special section flags such as "+RO", +XO, "+ZI".
-# ANY                 : ANY section flag in scatter file.
-#                       The FLAGS and ANY arguments only has effect for scatter files.
-# INPUT <input>       : Input section name or list of input section names.
-#                       <input> is either just a section name ".data*" or
-#                       <file-pattern>(<section-patterns>... )
-#                       <file-pattern> is [library.a:]file
-#                       e.g. foo.a:bar.o(.data*)
-#
+#[=======================================================================[.rst:
+.. cmake:signature:: zephyr_linker_section_configure(SECTION <section> [ALIGN <alignment>] [PASS [NOT] <name>] [PRIO <no>] [SORT <sort>] [MIN_SIZE <size>] [MAX_SIZE <size>] [ANY] [FIRST] [KEEP] [INPUT <input>] [SYMBOLS [<start> [<end>]]])
+
+   Configure an output section with additional input sections.
+   An output section can be configured with additional input sections besides its
+   default section.
+   For example, to add the input section ``foo`` to the output section bar, with ``KEEP``
+   attribute, call:
+   ``zephyr_linker_section_configure(SECTION bar INPUT foo KEEP)``
+
+   ``SECTION <section>``
+     The output section to configure
+
+   ``ALIGN <alignment>``
+     Will align the input section placement inside the load
+     region with ``<alignment>``
+
+   ``FIRST``
+     The first input section in the list should be marked as
+     first section in output.
+
+   ``SORT <NAME>``
+     Sort the input sections according to ``<type>``.
+     Currently only ``NAME`` is supported.
+
+   ``MIN_SIZE <size>``
+     Pad section so that it at least ``<size>`` bytes in size.
+
+   ``MAX_SIZE <size>``
+     Check that the sections is not larger than ``<size>`` bytes.
+
+   ``KEEP``
+     Do not eliminate input section during linking
+
+   ``PRIO``
+     The priority of the input section. Per default, input
+     sections order is not guaranteed by all linkers, but
+     using priority Zephyr CMake linker will create sections
+     such that order can be guaranteed. All unprioritized
+     sections will internally be given a CMake process order
+     priority counting from 100, so first unprioritized section
+     is handled internal prio 100, next 101, and so on.
+     To ensure a specific input section come before those,
+     you may use ``PRIO 50``, ``PRIO 20`` and so on.
+     To ensure an input section is at the end, it is advised
+     to use ``PRIO 200`` and above.
+
+   ``PASS [NOT] <pass>...``
+     Control in which linker passes this piece is present
+     See :cmake:command:`zephyr_linker_section` PASS for details.
+
+   ``FLAGS <flags>``
+     Special section flags such as "+RO", +XO, "+ZI".
+     The FLAGS and ANY arguments only has effect for scatter files.
+
+   ``ANY``
+     ANY section flag in scatter file.
+     The FLAGS and ANY arguments only has effect for scatter files.
+
+   ``INPUT <input>``
+     Input section name or list of input section names.
+     ``<input>`` is either just a section name ".data*" or
+     ``<file-pattern>(<section-patterns>... )``
+     ``<file-pattern>`` is ``[library.a:]file``
+     e.g. ``foo.a:bar.o(.data*)``
+
+   ``SYMBOLS <start> <end>``
+     Generate start and end symbols for the input section.
+#]=======================================================================]
 function(zephyr_linker_section_configure)
   set(options     "ANY;FIRST;KEEP")
   set(single_args "ALIGN;OFFSET;PRIO;SECTION;SORT;MIN_SIZE;MAX_SIZE")
@@ -5719,23 +6582,29 @@ function(zephyr_linker_section_configure)
   )
 endfunction()
 
-# Usage:
-#   zephyr_linker_symbol(SYMBOL <name> EXPR <expr>)
-#
-# Add additional user defined symbol to the generated linker script.
-#
-# SYMBOL <name>: Symbol name to be available.
-# EXPR <expr>  : Expression that defines the symbol. Due to linker limitations
-#                all expressions should only contain simple math, such as
-#                `+, -, *` and similar. The expression will go directly into the
-#                linker, and all `@<symbol>@` will be replaced with the referred
-#                symbol.
-#
-# Example:
-#   To create a new symbol `bar` pointing to the start VMA address of section
-#   `foo` + 1024, one can write:
-#     zephyr_linker_symbol(SYMBOL bar EXPR "(@foo@ + 1024)")
-#
+#[=======================================================================[.rst:
+.. cmake:signature:: zephyr_linker_symbol(SYMBOL <name> EXPR <expr>)
+
+   Add additional user defined symbol to the generated linker script.
+
+   ``SYMBOL <name>``
+     Symbol name to be available.
+
+   ``EXPR <expr>``
+     Expression that defines the symbol. Due to linker limitations
+     all expressions should only contain simple math, such as
+     ``+, -, *`` and similar. The expression will go directly into the
+     linker, and all ``@<symbol>@`` will be replaced with the referred
+     symbol.
+
+   Example:
+     To create a new symbol ``bar`` pointing to the start VMA address of section
+     ``foo`` + 1024, one can write:
+
+     .. code-block:: cmake
+
+        zephyr_linker_symbol(SYMBOL bar EXPR "(@foo@ + 1024)")
+#]=======================================================================]
 function(zephyr_linker_symbol)
   set(single_args "EXPR;SYMBOL")
   cmake_parse_arguments(SYMBOL "" "${single_args}" "" ${ARGN})
@@ -5755,19 +6624,27 @@ function(zephyr_linker_symbol)
   )
 endfunction()
 
-# Usage:
-#   zephyr_linker_include_generated(CMAKE|KCONFIG|HEADER <name> [PASS [NOT] <pass>])
-#
-# Add file that is generated at build-time to be included when running the
-# linker script generator.
-#
-# CMAKE <name>     : includes the given cmake file
-# KCONFIG <name>   : import_kconfig() the given Kconfig file. gives
-#                    @variable@ access to all the CONFIG_FOO settings
-# HEADER <name>    : finds all #define FOO value in name. Plain regex, no
-#                    proper preprocessing.
-# PASS [NOT] [<pass>]: Rule for which PASSES to include file.
-#                    see zephyr_linker_section(PASS)
+#[=======================================================================[.rst:
+.. cmake:signature:: zephyr_linker_include_generated((CMAKE | KCONFIG | HEADER) <name> [PASS [NOT] <pass>...])
+
+   Add file that is generated at build-time to be included when running the
+   linker script generator.
+
+   ``CMAKE <name>``
+     includes the given cmake file
+
+   ``KCONFIG <name>``
+     import_kconfig() the given Kconfig file. gives
+     ``@variable@`` access to all the CONFIG_FOO settings
+
+   ``HEADER <name>``
+     finds all #define FOO value in name. Plain regex, no
+     proper preprocessing.
+
+   ``PASS [NOT] <pass>...``
+     Rule for which PASSES to include file.
+     see :cmake:command:`zephyr_linker_section` PASS
+#]=======================================================================]
 function(zephyr_linker_include_generated)
   set(single_args "KCONFIG;HEADER;CMAKE")
   set(multi_args "PASS")
@@ -5791,19 +6668,22 @@ function(zephyr_linker_include_generated)
                APPEND PROPERTY INCLUDES "{${INCLUDE}}")
 endfunction()
 
-# Usage:
-#   zephyr_linker_include_var(VAR <name> [VALUE <value>] [PASS [NOT] <pass>])
-#
-# Save the value of <name> for when the generator is running at build-time.
-# If VALUE isn't set, the current value of the variable is used
-#
-# Save the value of <name> for when the generator is running at build-time.
-# If VALUE isn't set, the current value of the variable is used
-#
-# VAR <name>       : Variable to be set
-# VALUE <value>    : The value
-# PASS [NOT] <pass>: Rule for which PASSES to include variable see
-#                    zephyr_linker_section(PASS) for details.
+#[=======================================================================[.rst:
+.. cmake:signature:: zephyr_linker_include_var(VAR <name> [VALUE <value>] [PASS [NOT] <pass>...])
+
+   Save the value of ``<name>`` for when the generator is running at build-time.
+   If ``VALUE`` isn't set, the current value of the variable is used.
+
+   ``VAR <name>``
+     Variable to be set
+
+   ``VALUE <value>``
+     The value
+
+   ``PASS [NOT] <pass>...``
+     Rule for which PASSES to include variable see
+     :cmake:command:`zephyr_linker_section` PASS for details.
+#]=======================================================================]
 function(zephyr_linker_include_var)
   set(single_args "VAR;VALUE")
   set(multi_args "PASS")
@@ -5827,12 +6707,14 @@ function(zephyr_linker_include_var)
               APPEND PROPERTY VARIABLES "{${VAR}}")
 endfunction()
 
-# Usage:
-#   zephyr_linker_generate_linker_settings_file(file_name)
-#
-# Generate a file for the settings to the linker file generator script.
-# file_name      : File to be created
-#
+#[=======================================================================[.rst:
+.. cmake:signature:: zephyr_linker_generate_linker_settings_file(<file_name>)
+
+   Generate a file for the settings to the linker file generator script.
+
+   ``<file_name>``
+     File to be created
+#]=======================================================================]
 function(zephyr_linker_generate_linker_settings_file FILE)
   file(GENERATE OUTPUT ${FILE} CONTENT
          "set(FORMAT \"$<TARGET_PROPERTY:linker,FORMAT>\" CACHE INTERNAL \"\")\n
@@ -5877,39 +6759,58 @@ function(zephyr_linker_check_pass_param PASSES)
   endif()
 endfunction()
 
-########################################################
-# 6. Function helper macros
-########################################################
-#
-# Set of CMake macros to facilitate argument processing when defining functions.
-#
+#[=======================================================================[.rst:
+Function helper macros
+**********************
 
-#
-# Helper macro for verifying that at least one of the required arguments has
-# been provided by the caller.
-#
-# A FATAL_ERROR will be raised if not one of the required arguments has been
-# passed by the caller.
-#
-# Usage:
-#   zephyr_check_arguments_required(<function_name> <prefix> <arg1> [<arg2> ...])
-#
+Set of CMake macros to facilitate argument processing when defining functions.
+
+.. cmake:signature:: zephyr_check_arguments_required(<function_name> <prefix> <arg1> [<arg2> ...])
+
+   Helper macro for verifying that at least one of the required arguments has been provided by the
+   caller.
+
+   A ``FATAL_ERROR`` will be raised if not one of the required arguments has been passed by the
+   caller.
+
+   ``<function_name>``
+     Name of the function the check is performed for.
+     Used in error message generation.
+
+   ``<prefix>``
+     Prefix used in :cmake:command:`cmake_parse_arguments <command:cmake_parse_arguments>`, usually
+     ``arg`` or the function name in uppercase.
+
+   ``<arg>``
+     One or more arguments to check.
+#]=======================================================================]
 macro(zephyr_check_arguments_required function prefix)
   set(check_defined DEFINED)
   zephyr_check_flags_required(${function} ${prefix} ${ARGN})
   set(check_defined)
 endmacro()
 
-#
-# Helper macro for verifying that at least one of the required arguments has
-# been provided by the caller. Arguments with empty values are allowed.
-#
-# A FATAL_ERROR will be raised if not one of the required arguments has been
-# passed by the caller.
-#
-# Usage:
-#   zephyr_check_arguments_required_allow_empty(<function_name> <prefix> <arg1> [<arg2> ...])
-#
+#[=======================================================================[.rst:
+.. cmake:signature:: zephyr_check_arguments_required_allow_empty(<function_name>
+                                                                 <prefix>
+                                                                 <arg1> [<arg2> ...])
+
+   Helper macro for verifying that at least one of the required arguments has been provided by the
+   caller. Arguments with empty values are allowed.
+
+   A ``FATAL_ERROR`` will be raised if not one of the required arguments has been passed by the caller.
+
+   ``<function_name>``
+     Name of the function the check is performed for.
+     Used in error message generation.
+
+   ``<prefix>``
+     Prefix used in :cmake:command:`cmake_parse_arguments <command:cmake_parse_arguments>`, usually
+     ``arg`` or the function name in uppercase.
+
+   ``<arg>``
+     One or more arguments to check.
+#]=======================================================================]
 macro(zephyr_check_arguments_required_allow_empty function prefix)
   set(check_defined DEFINED)
   set(allow_empty TRUE)
@@ -5918,16 +6819,28 @@ macro(zephyr_check_arguments_required_allow_empty function prefix)
   set(check_defined)
 endmacro()
 
-#
-# Helper macro for verifying that at least one of the required flags has
-# been provided by the caller.
-#
-# A FATAL_ERROR will be raised if not one of the required arguments has been
-# passed by the caller.
-#
-# Usage:
-#   zephyr_check_flags_required(<function_name> <prefix> <flag1> [<flag2> ...])
-#
+#[=======================================================================[.rst:
+.. cmake:signature:: zephyr_check_flags_required(<function_name>
+                                                  <prefix>
+                                                  <flag1> [<flag2> ...])
+
+   Helper macro for verifying that at least one of the required flags has been provided by the
+   caller.
+
+   A ``FATAL_ERROR`` will be raised if not one of the required arguments has been passed by the
+   caller.
+
+   ``<function_name>``
+     Name of the function the check is performed for.
+     Used in error message generation.
+
+   ``<prefix>``
+     Prefix used in :cmake:command:`cmake_parse_arguments <command:cmake_parse_arguments>`, usually
+     ``arg`` or the function name in uppercase.
+
+   ``<flag>``
+     One or more flags to check.
+#]=======================================================================]
 macro(zephyr_check_flags_required function prefix)
   set(required_found FALSE)
   foreach(required ${ARGN})
@@ -5943,15 +6856,26 @@ macro(zephyr_check_flags_required function prefix)
   endif()
 endmacro()
 
-#
-# Helper macro for verifying that all the required arguments have been
-# provided by the caller.
-#
-# A FATAL_ERROR will be raised if one of the required arguments is missing.
-#
-# Usage:
-#   zephyr_check_arguments_required_all(<function_name> <prefix> <arg1> [<arg2> ...])
-#
+#[=======================================================================[.rst:
+.. cmake:signature:: zephyr_check_arguments_required_all(<function_name>
+                                                          <prefix>
+                                                          <arg1> [<arg2> ...])
+
+   Helper macro for verifying that all the required arguments have been provided by the caller.
+
+   A ``FATAL_ERROR`` will be raised if one of the required arguments is missing.
+
+   ``<function_name>``
+     Name of the function the check is performed for.
+     Used in error message generation.
+
+   ``<prefix>``
+     Prefix used in :cmake:command:`cmake_parse_arguments <command:cmake_parse_arguments>`, usually
+     ``arg`` or the function name in uppercase.
+
+   ``<arg>``
+     One or more arguments to check.
+#]=======================================================================]
 macro(zephyr_check_arguments_required_all function prefix)
   foreach(required ${ARGN})
     if(NOT DEFINED ${prefix}_${required})
@@ -5960,30 +6884,56 @@ macro(zephyr_check_arguments_required_all function prefix)
   endforeach()
 endmacro()
 
-#
-# Helper macro for verifying that none of the mutual exclusive arguments are
-# provided together.
-#
-# A FATAL_ERROR will be raised if any of the arguments are given together.
-#
-# Usage:
-#   zephyr_check_arguments_exclusive(<function_name> <prefix> <arg1> <arg2> [<arg3> ...])
-#
+#[=======================================================================[.rst:
+.. cmake:signature:: zephyr_check_arguments_exclusive(<function_name>
+                                                        <prefix>
+                                                        <arg1>
+                                                        <arg2>
+                                                        [<arg3> ...])
+
+   Helper macro for verifying that none of the mutual exclusive arguments are provided together.
+
+   A ``FATAL_ERROR`` will be raised if any of the arguments are given together.
+
+   ``<function_name>``
+     Name of the function the check is performed for.
+     Used in error message generation.
+
+   ``<prefix>``
+     Prefix used in :cmake:command:`cmake_parse_arguments <command:cmake_parse_arguments>`, usually
+     ``arg`` or the function name in uppercase.
+
+   ``<arg>``
+     One or more arguments to check.
+#]=======================================================================]
 macro(zephyr_check_arguments_exclusive function prefix)
   set(check_defined DEFINED)
   zephyr_check_flags_exclusive(${function} ${prefix} ${ARGN})
   set(check_defined)
 endmacro()
 
-#
-# Helper macro for verifying that none of the mutual exclusive flags are
-# provided together.
-#
-# A FATAL_ERROR will be raised if any of the flags are given together.
-#
-# Usage:
-#   zephyr_check_flags_exclusive(<function_name> <prefix> <flag1> <flag2> [<flag3> ...])
-#
+#[=======================================================================[.rst:
+.. cmake:signature:: zephyr_check_flags_exclusive(<function_name>
+                                                  <prefix>
+                                                  <flag1>
+                                                  <flag2>
+                                                  [<flag3> ...])
+
+   Helper macro for verifying that none of the mutual exclusive flags are provided together.
+
+   A ``FATAL_ERROR`` will be raised if any of the flags are given together.
+
+   ``<function_name>``
+     Name of the function the check is performed for.
+     Used in error message generation.
+
+   ``<prefix>``
+     Prefix used in :cmake:command:`cmake_parse_arguments <command:cmake_parse_arguments>`, usually
+     ``arg`` or the function name in uppercase.
+
+   ``<flag>``
+     One or more flags to check.
+#]=======================================================================]
 macro(zephyr_check_flags_exclusive function prefix)
   set(args_defined)
   foreach(arg ${ARGN})
@@ -6000,33 +6950,90 @@ macro(zephyr_check_flags_exclusive function prefix)
   endif()
 endmacro()
 
-#
-# Helper macro for verifying that no unexpected arguments are provided.
-#
-# A FATAL_ERROR will be raised if any unexpected argument is given.
-#
-# Usage:
-#   zephyr_check_no_arguments(<function_name> ${ARGN})
-#
+#[=======================================================================[.rst:
+.. cmake:signature:: zephyr_check_no_arguments(<function_name> <arg1> [<arg2> ...])
+
+   Helper macro for verifying that no unexpected arguments are provided.
+
+   A ``FATAL_ERROR`` will be raised if any unexpected argument is given.
+
+   ``<function_name>``
+     Name of the function the check is performed for.
+     Used in error message generation.
+
+   ``<arg>``
+     One or more arguments to check.
+#]=======================================================================]
 macro(zephyr_check_no_arguments function)
   if(${ARGC} GREATER 1)
     message(FATAL_ERROR "${function} called with unexpected argument(s): ${ARGN}")
   endif()
 endmacro()
 
-########################################################
-# 7. Linkable loadable extensions (llext)
-########################################################
-#
-# These functions simplify the creation and management of linkable
-# loadable extensions (llexts).
-#
+#[=======================================================================[.rst:
+Linkable loadable extensions (llext)
+************************************
 
-# 7.1 Configuration functions
-#
-# The following functions simplify access to the compilation/link stage
-# properties of an llext using the same API of the target_* functions.
-#
+These functions simplify the creation and management of :ref:`llext`.
+
+Configuration functions
+=======================
+
+The following functions simplify access to the compilation/link stage properties of an llext using
+the same API as CMake's ``target_*`` functions.
+
+.. cmake:signature:: llext_compile_definitions(target_name <defs>...)
+
+   Add compile definitions to the llext target.
+
+   ``target_name``
+     Name of the llext target.
+
+   ``<defs>``
+     Arguments passed to :cmake:command:`target_compile_definitions
+     <command:target_compile_definitions>`.
+
+.. cmake:signature:: llext_compile_features(target_name <features>...)
+
+   Add compile features to the llext target.
+
+   ``target_name``
+     Name of the llext target.
+
+   ``<features>``
+     Arguments passed to :cmake:command:`target_compile_features <command:target_compile_features>`.
+
+.. cmake:signature:: llext_compile_options(target_name <options>...)
+
+   Add compile options to the llext target.
+
+   ``target_name``
+     Name of the llext target.
+
+   ``<options>``
+     Arguments passed to :cmake:command:`target_compile_options <command:target_compile_options>`.
+
+.. cmake:signature:: llext_include_directories(target_name <dirs>...)
+
+   Add include directories to the llext target.
+
+   ``target_name``
+     Name of the llext target.
+
+   ``<dirs>``
+     Arguments passed to :cmake:command:`target_include_directories
+     <command:target_include_directories>`.
+
+.. cmake:signature:: llext_link_options(target_name <options>...)
+
+   Add link options to the llext target.
+
+   ``target_name``
+     Name of the llext target.
+
+   ``<options>``
+     Arguments passed to :cmake:command:`target_link_options <command:target_link_options>`.
+#]=======================================================================]
 
 function(llext_compile_definitions target_name)
   target_compile_definitions(${target_name}_llext_lib PRIVATE ${ARGN})
@@ -6048,46 +7055,46 @@ function(llext_link_options target_name)
   target_link_options(${target_name}_llext_lib PRIVATE ${ARGN})
 endfunction()
 
-# 7.2 Build control functions
-#
-# The following functions add targets and subcommands to the build system
-# to compile and link an llext.
-#
+#[=======================================================================[.rst:
+Build control functions
+=======================
 
-# Usage:
-#   add_llext_target(<target_name>
-#                    OUTPUT  <output_file>
-#                    SOURCES <source_files>
-#   )
-#
-# Add a custom target that compiles a set of source files to a .llext file.
-#
-# Output and source files must be specified using the OUTPUT and SOURCES
-# arguments. Only one source file is supported when LLEXT_TYPE_ELF_OBJECT is
-# selected, since there is no linking step in that case.
-#
-# The llext code will be compiled with mostly the same C compiler flags used
-# in the Zephyr build, but with some important modifications. The list of
-# flags to remove and flags to append is controlled respectively by the
-# LLEXT_REMOVE_FLAGS and LLEXT_APPEND_FLAGS global variables.
-#
-# The following custom properties of <target_name> are defined and can be
-# retrieved using the get_target_property() function:
-#
-# - lib_target  Target name for the source compilation and/or link step.
-# - lib_output  The binary file resulting from compilation and/or
-#               linking steps.
-# - pkg_input   The file to be used as input for the packaging step.
-# - pkg_output  The final .llext file.
-#
-# Example usage:
-#   add_llext_target(hello_world
-#     OUTPUT  ${PROJECT_BINARY_DIR}/hello_world.llext
-#     SOURCES ${PROJECT_SOURCE_DIR}/src/llext/hello_world.c
-#   )
-# will compile the source file src/llext/hello_world.c to a file
-# named "${PROJECT_BINARY_DIR}/hello_world.llext".
-#
+The following functions add targets and subcommands to the build system
+to compile and link an llext.
+
+.. cmake:signature:: add_llext_target(target_name OUTPUT <output_file> SOURCES <source_files>)
+
+   Add a custom target that compiles a set of source files to a .llext file.
+
+   Output and source files must be specified using the ``OUTPUT`` and ``SOURCES`` arguments. Only
+   one source file is supported when :kconfig:option:`CONFIG_LLEXT_TYPE_ELF_OBJECT` is selected,
+   since there is no linking step in that case.
+
+   The llext code will be compiled with mostly the same C compiler flags used in the Zephyr build,
+   but with some important modifications. The list of flags to remove and flags to append is
+   controlled respectively by the :cmake:variable:`LLEXT_REMOVE_FLAGS` and
+   :cmake:variable:`LLEXT_APPEND_FLAGS` global variables.
+
+   The following custom properties of ``target_name`` are defined and can be retrieved using the
+   :cmake:command:`get_target_property <command:get_target_property>` function:
+
+   * ``lib_target``: Target name for the source compilation and/or link step.
+   * ``lib_output``: The binary file resulting from compilation and/or linking steps.
+   * ``pkg_input``: The file to be used as input for the packaging step.
+   * ``pkg_output``: The final .llext file.
+
+   Example usage:
+
+   .. code-block:: cmake
+
+      add_llext_target(hello_world
+        OUTPUT  ${PROJECT_BINARY_DIR}/hello_world.llext
+        SOURCES ${PROJECT_SOURCE_DIR}/src/llext/hello_world.c
+      )
+
+   This will compile the source file :file:`src/llext/hello_world.c`` to a file named
+   :file:`${PROJECT_BINARY_DIR}/hello_world.llext`.
+#]=======================================================================]
 function(add_llext_target target_name)
   set(single_args OUTPUT)
   set(multi_args SOURCES)
@@ -6296,29 +7303,32 @@ function(add_llext_target target_name)
   )
 endfunction()
 
-# Usage:
-#   add_llext_command(
-#     TARGET <target_name>
-#     PRE_BUILD | POST_BUILD | POST_PKG
-#     COMMAND <command> [...]
-#   )
-#
-# Add a custom command to an llext target that will be executed during
-# the build. The command will be executed at the specified build step and
-# can refer to <target>'s properties for build-specific details.
-#
-# The different build steps are:
-# - PRE_BUILD:  Before the llext code is linked, if the architecture uses
-#               dynamic libraries. This step can access `lib_target` and
-#               its own properties.
-# - POST_BUILD: After the llext code is built, but before packaging
-#               it in an .llext file. This step is expected to create a
-#               `pkg_input` file by reading the contents of `lib_output`.
-# - POST_PKG:   After the .llext file has been created. This can operate on
-#               the final llext file `pkg_output`.
-#
-# Anything else after COMMAND will be passed to add_custom_command() as-is
-# (including multiple commands and other options).
+#[=======================================================================[.rst:
+.. cmake:signature:: add_llext_command(TARGET <target_name> PRE_BUILD <command> [...])
+                     add_llext_command(TARGET <target_name> POST_BUILD <command> [...])
+                     add_llext_command(TARGET <target_name> POST_PKG <command> [...])
+
+   Add a custom command to an llext target that will be executed during
+   the build. The command will be executed at the specified build step and
+   can refer to ``<target>``'s properties for build-specific details.
+
+   The different build steps are:
+
+   ``PRE_BUILD``
+     Before the llext code is linked, if the architecture uses dynamic libraries. This step can
+     access ``lib_target`` and its own properties.
+
+   ``POST_BUILD``
+     After the llext code is built, but before packaging it in an .llext file. This step is expected
+     to create a ``pkg_input`` file by reading the contents of ``lib_output``.
+
+   ``POST_PKG``
+     After the .llext file has been created. This can operate on the final llext file
+     ``pkg_output``.
+
+   Anything else after ``COMMAND`` will be passed to :cmake:command:`add_custom_command
+   <command:add_custom_command>` as-is (including multiple commands and other options).
+#]=======================================================================]
 function(add_llext_command)
   set(options     PRE_BUILD POST_BUILD POST_PKG)
   set(single_args TARGET)

--- a/cmake/modules/git.cmake
+++ b/cmake/modules/git.cmake
@@ -1,5 +1,54 @@
 # SPDX-License-Identifier: Apache-2.0
 
+#[=======================================================================[.rst:
+git
+***
+
+Provides Git-related functionality for the Zephyr build system.
+
+This module provides functions for interacting with Git repositories
+within the Zephyr build system.
+
+Commands
+========
+
+.. cmake:command:: git_describe
+
+   Get a short Git description associated with a directory.
+
+   .. code-block:: cmake
+
+     git_describe(DIR OUTPUT)
+
+   This function runs ``git describe --abbrev=12 --always`` in the specified
+   directory and stores the result in the provided output variable.
+
+   ``DIR``
+     The directory to run the git command in.
+
+   ``OUTPUT``
+     The variable name where the git description will be stored.
+     If the git command fails, this variable will not be set.
+
+   The function will output status messages if:
+
+   * The :command:`git` command fails (error message)
+   * The :command:`git` command produces warnings (warning message)
+
+Example Usage
+-------------
+
+.. code-block:: cmake
+
+   include(git)
+
+   git_describe(${CMAKE_CURRENT_SOURCE_DIR} GIT_DESCRIPTION)
+   if(DEFINED GIT_DESCRIPTION)
+     message(STATUS "Git description: ${GIT_DESCRIPTION}")
+   endif()
+
+#]=======================================================================]
+
 include_guard(GLOBAL)
 
 find_package(Git QUIET)

--- a/cmake/modules/kconfig.cmake
+++ b/cmake/modules/kconfig.cmake
@@ -2,6 +2,53 @@
 
 include_guard(GLOBAL)
 
+#[=======================================================================[.rst:
+kconfig
+*******
+
+This module contains the Kconfig configuration logic.
+
+It provides the following targets:
+
+* ``menuconfig``: Run the Kconfig menuconfig tool.
+* ``guiconfig``: Run the Kconfig guiconfig tool.
+* ``hardenconfig``: Run the Kconfig hardenconfig tool.
+* ``traceconfig``: Run the Kconfig traceconfig tool.
+
+Variables
+=========
+
+After loading this module, the following global variables are defined:
+
+.. cmake:variable:: KCONFIG_ROOT
+
+   Path to the Kconfig root file.
+   Default: ``${ZEPHYR_BASE}/Kconfig``.
+
+.. cmake:variable:: AUTOCONF_H
+
+   Path to the generated autoconf header file.
+   Default: ``${PROJECT_BINARY_DIR}/include/generated/zephyr/autoconf.h``.
+
+.. cmake:variable:: DOTCONFIG
+
+   Path to the generated .config file.
+   Default: ``${PROJECT_BINARY_DIR}/.config``.
+
+.. cmake:variable:: EXTRA_KCONFIG_TARGETS
+
+   List of extra Kconfig targets to add.
+
+.. cmake:variable:: EXTRA_KCONFIG_TARGET_COMMAND_FOR_<target>
+
+   Command to run for the extra Kconfig target.
+
+The Kconfig fragments this module reads are selected by :cmake:variable:`CONF_FILE` and
+:cmake:variable:`EXTRA_CONF_FILE`, which are resolved by the :cmake:module:`configuration_files`
+module.
+
+#]=======================================================================]
+
 include(extensions)
 include(python)
 

--- a/cmake/modules/kernel.cmake
+++ b/cmake/modules/kernel.cmake
@@ -2,23 +2,66 @@
 #
 # Copyright (c) 2021, Nordic Semiconductor ASA
 
-# Zephyr Kernel CMake module.
-#
-# This is the main Zephyr Kernel CMake module which is responsible for creation
-# of Zephyr libraries and the Zephyr executable.
-#
-# This CMake module creates 'project(Zephyr-Kernel)'
-#
-# It defines properties to use while configuring libraries to be built as well
-# as using add_subdirectory() to add the main <ZEPHYR_BASE>/CMakeLists.txt file.
-#
-# Outcome:
-# - Zephyr build system.
-# - Zephyr project
-#
-# Important libraries:
-# - app: This is the main application library where the application can add
-#        source files that must be included when building Zephyr
+#[=======================================================================[.rst:
+kernel
+******
+
+Main Zephyr Kernel CMake module.
+
+This module is responsible for creating Zephyr libraries and the Zephyr executable.
+It creates a CMake project named `Zephyr-Kernel` and defines properties used while
+configuring libraries to be built.
+
+Variables
+=========
+
+After loading this module, the following global variables are defined:
+
+.. cmake:variable:: ZEPHYR_LIBS
+
+   Global list of all Zephyr CMake libraries that should be linked in.
+   :cmake:command:`zephyr_library()` appends libraries to this list.
+
+.. cmake:variable:: ZEPHYR_INTERFACE_LIBS
+
+   Global list of all Zephyr interface libraries that should be linked in.
+   :cmake:command:`zephyr_interface_library_named()` appends libraries to this list.
+
+.. cmake:variable:: GENERATED_APP_SOURCE_FILES
+
+   Source files that are generated after Zephyr has been linked once.
+   May include dev_handles.c etc.
+
+.. cmake:variable:: GENERATED_KERNEL_OBJECT_FILES
+
+   Object files that are generated after symbol addresses are fixed.
+   May include mmu tables, etc.
+
+.. cmake:variable:: GENERATED_KERNEL_SOURCE_FILES
+
+   Source files that are generated after symbol addresses are fixed.
+   May include isr_tables.c etc.
+
+Targets
+=======
+
+.. cmake:variable:: code_data_relocation_target
+
+   Custom target for code data relocation.
+
+
+.. cmake:variable:: app
+
+   CMake library containing all the application code.
+   Modified by the entry point ${APPLICATION_SOURCE_DIR}/CMakeLists.txt.
+
+Usage
+=====
+
+This module is not intended for direct loading, but should be loaded through
+:cmake:command:`find_package(Zephyr)`. It won't load any Zephyr CMake modules by itself.
+
+#]=======================================================================]
 
 include_guard(GLOBAL)
 

--- a/cmake/modules/python.cmake
+++ b/cmake/modules/python.cmake
@@ -1,5 +1,55 @@
 # SPDX-License-Identifier: Apache-2.0
 
+#[=======================================================================[.rst:
+python
+######
+
+Configure Python for use in Zephyr build system.
+
+This module finds and configures Python for use in the Zephyr build system.
+It ensures a compatible Python version is available and sets up necessary
+environment variables and CMake variables.
+
+Variables
+*********
+
+The :cmake:variable:`PYTHON_MINIMUM_REQUIRED` variable is used to specify the minimum required
+Python version.
+
+The following variables will be defined when this CMake module completes:
+
+* :cmake:variable:`PYTHON_EXECUTABLE`
+
+Search Process
+==============
+
+The module searches for Python in the following order:
+
+1. Using the ``Python3_EXECUTABLE`` if already defined
+2. Using the ``WEST_PYTHON`` if defined
+3. Searching for "python" or "python3" in the system PATH and virtual environment
+4. Using CMake's ``find_package(Python3)`` mechanism
+
+The module verifies that any found Python meets the minimum version requirement.
+
+Windows-Specific Configuration
+==============================
+
+On Windows systems, the module sets the ``PYTHONIOENCODING`` environment variable
+to "utf-8" to ensure consistent encoding behavior when Python is invoked from CMake.
+
+Example Usage
+=============
+
+.. code-block:: cmake
+
+   include(python)
+
+   # Now PYTHON_EXECUTABLE can be used to invoke Python scripts
+   execute_process(COMMAND ${PYTHON_EXECUTABLE} my_script.py)
+
+#]=======================================================================]
+
 include_guard(GLOBAL)
 
 # On Windows, instruct Python to output UTF-8 even when not

--- a/cmake/modules/soc.cmake
+++ b/cmake/modules/soc.cmake
@@ -2,20 +2,27 @@
 #
 # Copyright (c) 2021, Nordic Semiconductor ASA
 
-# Configure SoC settings based on Kconfig settings.
-#
-# This CMake module will set the following variables in the build system based
-# on Kconfig settings for the selected SoC.
-#
-# Outcome:
-# The following variables will be defined when this CMake module completes:
-#
-# - SOC_FULL_DIR: Full directory of where the SoC files are located
-# - SOC_DIRECTORIES: List of directories where SoC files which include this SoC are located
-# - SOC_TOOLCHAIN_NAME: Optional toolchain name of the SoC
-#
-# Variables set by this module and not mentioned above are considered internal
-# use only and may be removed, renamed, or re-purposed without prior notice.
+#[=======================================================================[.rst:
+soc
+***
+
+Configure SoC settings based on Kconfig settings.
+
+This CMake module will set the following variables in the build system based on Kconfig settings
+for the selected SoC.
+
+Variables
+=========
+
+The following variables will be defined when this CMake module completes:
+
+* ``SOC_FULL_DIR``: Full directory of where the SoC files are located
+* ``SOC_DIRECTORIES``: List of directories where SoC files which include this SoC are located
+* ``SOC_TOOLCHAIN_NAME``: Optional toolchain name of the SoC
+
+Variables set by this module and not mentioned above are considered internal use only and may be
+removed, renamed, or re-purposed without prior notice.
+#]=======================================================================]
 
 include_guard(GLOBAL)
 

--- a/cmake/modules/west.cmake
+++ b/cmake/modules/west.cmake
@@ -2,6 +2,23 @@
 
 include_guard(GLOBAL)
 
+#[=======================================================================[.rst:
+west
+****
+
+This module finds and configures the ``west`` meta-tool for use in the Zephyr build system.
+It ensures that west is available and correctly configured.
+
+Variables
+=========
+
+The following variables will be defined when this CMake module completes:
+
+* :cmake:variable:`WEST`
+* :cmake:variable:`WEST_TOPDIR`
+
+#]=======================================================================]
+
 include(python)
 
 # west is an optional dependency. We need to run west using the same

--- a/doc/_extensions/moderncmakedomain/REUSE.toml
+++ b/doc/_extensions/moderncmakedomain/REUSE.toml
@@ -1,0 +1,8 @@
+version = 1
+
+[[annotations]]
+path = [
+    "*",
+]
+SPDX-License-Identifier = "BSD-3-Clause"
+SPDX-FileCopyrightText = "Copyright 2000-2026 Kitware, Inc. and Contributors"

--- a/doc/_extensions/moderncmakedomain/__init__.py
+++ b/doc/_extensions/moderncmakedomain/__init__.py
@@ -1,0 +1,5 @@
+from .cmake import setup
+
+__version__ = "3.29.0"
+
+__all__ = ["__version__", "setup"]

--- a/doc/_extensions/moderncmakedomain/cmake.py
+++ b/doc/_extensions/moderncmakedomain/cmake.py
@@ -1,0 +1,774 @@
+# Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
+# file Copyright.txt or https://cmake.org/licensing for details.
+
+# BEGIN imports
+
+import os
+import re
+from dataclasses import dataclass
+from typing import Any, List, Tuple, Type, cast
+
+import sphinx
+
+# The following imports may fail if we don't have Sphinx 2.x or later.
+if sphinx.version_info >= (2,):
+    from docutils import io, nodes
+    from docutils.nodes import Element, Node, TextElement, system_message
+    from docutils.parsers.rst import Directive, directives
+    from docutils.transforms import Transform
+    from docutils.utils.code_analyzer import Lexer, LexerError
+
+    from sphinx import addnodes
+    from sphinx.directives import ObjectDescription, nl_escape_re
+    from sphinx.domains import Domain, ObjType
+    from sphinx.roles import XRefRole
+    from sphinx.util import logging, ws_re
+    from sphinx.util.docutils import ReferenceRole
+    from sphinx.util.nodes import make_refnode
+else:
+    # Sphinx 2.x is required.
+    assert sphinx.version_info >= (2,)
+
+# END imports
+
+# %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+# BEGIN pygments tweaks
+
+# Override much of pygments' CMakeLexer.
+# We need to parse CMake syntax definitions, not CMake code.
+
+# For hard test cases that use much of the syntax below, see
+# - module/FindPkgConfig.html
+#     (with "glib-2.0>=2.10 gtk+-2.0" and similar)
+# - module/ExternalProject.html
+#     (with http:// https:// git@; also has command options -E --build)
+# - manual/cmake-buildsystem.7.html
+#     (with nested $<..>; relative and absolute paths, "::")
+
+from pygments.lexer import bygroups  # noqa I100
+from pygments.lexers import CMakeLexer  # pylint: disable=no-name-in-module
+from pygments.token import (Comment, Name, Number, Operator, Punctuation,
+                            String, Text, Whitespace)
+
+# Notes on regular expressions below:
+# - [\.\+-] are needed for string constants like gtk+-2.0
+# - Unix paths are recognized by '/'; support for Windows paths may be added
+#   if needed
+# - (\\.) allows for \-escapes (used in manual/cmake-language.7)
+# - $<..$<..$>..> nested occurrence in cmake-buildsystem
+# - Nested variable evaluations are only supported in a limited capacity.
+#   Only one level of nesting is supported and at most one nested variable can
+#   be present.
+
+CMakeLexer.tokens["root"] = [
+  # fctn(
+  (r'\b(\w+)([ \t]*)(\()',
+   bygroups(Name.Function, Text, Name.Function), '#push'),
+  (r'\(', Name.Function, '#push'),
+  (r'\)', Name.Function, '#pop'),
+  (r'\[', Punctuation, '#push'),
+  (r'\]', Punctuation, '#pop'),
+  (r'[|;,.=*\-]', Punctuation),
+  # used in commands/source_group
+  (r'\\\\', Punctuation),
+  (r'[:]', Operator),
+  # used in FindPkgConfig.cmake
+  (r'[<>]=', Punctuation),
+  # $<...>
+  (r'\$<', Operator, '#push'),
+  # <expr>
+  (r'<[^<|]+?>(\w*\.\.\.)?', Name.Variable),
+  # ${..} $ENV{..}, possibly nested
+  (r'(\$\w*\{)([^\}\$]*)?(?:(\$\w*\{)([^\}]+?)(\}))?([^\}]*?)(\})',
+   bygroups(Operator, Name.Tag, Operator, Name.Tag, Operator, Name.Tag,
+            Operator)),
+  # DATA{ ...}
+  (r'([A-Z]+\{)(.+?)(\})', bygroups(Operator, Name.Tag, Operator)),
+  # URL, git@, ...
+  (r'[a-z]+(@|(://))((\\.)|[\w.+-:/\\])+', Name.Attribute),
+  # absolute path
+  (r'/\w[\w\.\+-/\\]*', Name.Attribute),
+  (r'/', Name.Attribute),
+  # relative path
+  (r'\w[\w\.\+-]*/[\w.+-/\\]*', Name.Attribute),
+  # initial A-Z, contains a-z
+  (r'[A-Z]((\\.)|[\w.+-])*[a-z]((\\.)|[\w.+-])*', Name.Builtin),
+  (r'@?[A-Z][A-Z0-9_]*', Name.Constant),
+  (r'[a-z_]((\\;)|(\\ )|[\w.+-])*', Name.Builtin),
+  (r'[0-9][0-9\.]*', Number),
+  # "string"
+  (r'(?s)"(\\"|[^"])*"', String),
+  (r'\.\.\.', Name.Variable),
+  # <..|..> is different from <expr>
+  (r'<', Operator, '#push'),
+  (r'>', Operator, '#pop'),
+  (r'\n', Whitespace),
+  (r'[ \t]+', Whitespace),
+  (r'#.*\n', Comment),
+  # fallback, for debugging only
+  #  (r'[^<>\])\}\|$"# \t\n]+', Name.Exception),
+]
+
+# END pygments tweaks
+
+# %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+logger = logging.getLogger(__name__)
+
+# RE to split multiple command signatures.
+sig_end_re = re.compile(r'(?<=[)])\n')
+
+
+@dataclass
+class ObjectEntry:
+    docname: str
+    objtype: str
+    node_id: str
+    name: str
+
+
+class CMakeModule(Directive):
+    required_arguments = 1
+    optional_arguments = 0
+    final_argument_whitespace = True
+    option_spec = {'encoding': directives.encoding}
+
+    def __init__(self, *args, **keys):
+        self.re_start = re.compile(r'^#\[(?P<eq>=*)\[\.rst:$')
+        Directive.__init__(self, *args, **keys)
+
+    def run(self):
+        settings = self.state.document.settings
+        if not settings.file_insertion_enabled:
+            raise self.warning(f'{self.name!r} directive disabled.')
+
+        env = self.state.document.settings.env
+        _, path = env.relfn2path(self.arguments[0])
+        path = os.path.normpath(path)
+        encoding = self.options.get('encoding', settings.input_encoding)
+        e_handler = settings.input_encoding_error_handler
+        try:
+            settings.record_dependencies.add(path)
+            f = io.FileInput(source_path=path, encoding=encoding,
+                             error_handler=e_handler)
+        except UnicodeEncodeError:
+            msg = (f'Problems with {self.name!r} directive path:\n'
+                   f'Cannot encode input file path {path!r} (wrong locale?).')
+            raise self.severe(msg)
+        except IOError as error:
+            msg = f'Problems with {self.name!r} directive path:\n{error}.'
+            raise self.severe(msg)
+        raw_lines = f.read().splitlines()
+        f.close()
+        rst = None
+        lines = []
+        for line in raw_lines:
+            if rst is not None and rst != '#':
+                # Bracket mode: check for end bracket
+                pos = line.find(rst)
+                if pos >= 0:
+                    if line[0] == '#':
+                        line = ''
+                    else:
+                        line = line[0:pos]
+                    rst = None
+            else:
+                # Line mode: check for .rst start (bracket or line)
+                m = self.re_start.match(line)
+                if m:
+                    rst = f']{m.group("eq")}]'
+                    line = ''
+                elif line == '#.rst:':
+                    rst = '#'
+                    line = ''
+                elif rst == '#':
+                    if line == '#' or line[:2] == '# ':
+                        line = line[2:]
+                    else:
+                        rst = None
+                        line = ''
+                elif rst is None:
+                    line = ''
+            lines.append(line)
+        if rst is not None and rst != '#':
+            raise self.warning(f'{self.name!r} found unclosed bracket '
+                               f'"#[{rst[1:-1]}[.rst:" in {path!r}')
+        self.state_machine.insert_input(lines, path)
+        return []
+
+
+class _cmake_index_entry:
+    def __init__(self, desc):
+        self.desc = desc
+
+    def __call__(self, title, targetid, main='main'):
+        return ('pair', f'{self.desc} ; {title}', targetid, main, None)
+
+
+_cmake_index_objs = {
+    'command':    _cmake_index_entry('command'),
+    'cpack_gen':  _cmake_index_entry('cpack generator'),
+    'envvar':     _cmake_index_entry('envvar'),
+    'generator':  _cmake_index_entry('generator'),
+    'genex':      _cmake_index_entry('genex'),
+    'guide':      _cmake_index_entry('guide'),
+    'manual':     _cmake_index_entry('manual'),
+    'module':     _cmake_index_entry('module'),
+    'policy':     _cmake_index_entry('policy'),
+    'prop_cache': _cmake_index_entry('cache property'),
+    'prop_dir':   _cmake_index_entry('directory property'),
+    'prop_gbl':   _cmake_index_entry('global property'),
+    'prop_inst':  _cmake_index_entry('installed file property'),
+    'prop_sf':    _cmake_index_entry('source file property'),
+    'prop_test':  _cmake_index_entry('test property'),
+    'prop_tgt':   _cmake_index_entry('target property'),
+    'variable':   _cmake_index_entry('variable'),
+    }
+
+
+class CMakeTransform(Transform):
+
+    # Run this transform early since we insert nodes we want
+    # treated as if they were written in the documents.
+    default_priority = 210
+
+    def __init__(self, document, startnode):
+        Transform.__init__(self, document, startnode)
+        self.titles = {}
+
+    def parse_title(self, docname):
+        """Parse a document title as the first line starting in [A-Za-z0-9<$]
+           or fall back to the document basename if no such line exists.
+           The cmake --help-*-list commands also depend on this convention.
+           Return the title or False if the document file does not exist.
+        """
+        settings = self.document.settings
+        env = settings.env
+        title = self.titles.get(docname)
+        if title is None:
+            fname = os.path.join(env.srcdir, docname+'.rst')
+            try:
+                f = open(fname, 'r', encoding=settings.input_encoding)
+            except IOError:
+                title = False
+            else:
+                for line in f:
+                    if len(line) > 0 and (line[0].isalnum() or
+                                          line[0] == '<' or line[0] == '$'):
+                        title = line.rstrip()
+                        break
+                f.close()
+                if title is None:
+                    title = os.path.basename(docname)
+            self.titles[docname] = title
+        return title
+
+    def apply(self):
+        env = self.document.settings.env
+
+        # Identify CMake domain objects from parent name
+        parts = env.docname.split('/')
+        objtype = None
+        tail = None
+        if len(parts) > 1 and parts[-2] in _cmake_index_objs:
+            objtype = parts[-2]
+            tail = parts[-1]
+
+        make_index_entry = _cmake_index_objs.get(objtype)
+        if make_index_entry:
+            title = self.parse_title(env.docname)
+            # Insert the object link target.
+            if objtype == 'command':
+                targetname = title.lower()
+            elif objtype == 'guide' and not tail.endswith('/index'):
+                targetname = tail
+            else:
+                if objtype == 'genex':
+                    m = CMakeXRefRole._re_genex.match(title)
+                    if m:
+                        title = m.group(1)
+                targetname = title
+            targetid = f'{objtype}:{targetname}'
+            targetnode = nodes.target('', '', ids=[targetid])
+            self.document.note_explicit_target(targetnode)
+            self.document.insert(0, targetnode)
+            # Insert the object index entry.
+            indexnode = addnodes.index()
+            indexnode['entries'] = [make_index_entry(title, targetid)]
+            self.document.insert(0, indexnode)
+
+            # Add to cmake domain object inventory
+            domain = cast(CMakeDomain, env.get_domain('cmake'))
+            domain.note_object(objtype, targetname, targetid, targetid)
+
+
+class CMakeObject(ObjectDescription):
+    def __init__(self, *args, **kwargs):
+        self.targetname = None
+        super().__init__(*args, **kwargs)
+
+    def handle_signature(self, sig, signode):
+        # called from sphinx.directives.ObjectDescription.run()
+        signode += addnodes.desc_name(sig, sig)
+        return sig
+
+    def add_target_and_index(self, name, sig, signode):
+        if self.objtype == 'command':
+            targetname = name.lower()
+        elif self.targetname:
+            targetname = self.targetname
+        else:
+            targetname = name
+        targetid = f'{self.objtype}:{targetname}'
+        if targetid not in self.state.document.ids:
+            signode['names'].append(targetid)
+            signode['ids'].append(targetid)
+            signode['first'] = not self.names
+            self.state.document.note_explicit_target(signode)
+
+            domain = cast(CMakeDomain, self.env.get_domain('cmake'))
+            domain.note_object(self.objtype, targetname, targetid, targetid,
+                               location=signode)
+
+        make_index_entry = _cmake_index_objs.get(self.objtype)
+        if make_index_entry:
+            self.indexnode['entries'].append(make_index_entry(name, targetid))
+
+
+class CMakeGenexObject(CMakeObject):
+    option_spec = {
+        'target': directives.unchanged,
+    }
+
+    def handle_signature(self, sig, signode):
+        name = super().handle_signature(sig, signode)
+
+        m = CMakeXRefRole._re_genex.match(sig)
+        if m:
+            name = m.group(1)
+
+        return name
+
+    def run(self):
+        target = self.options.get('target')
+        if target is not None:
+            self.targetname = target
+
+        return super().run()
+
+
+class CMakeSignatureObject(CMakeObject):
+    object_type = 'signature'
+
+    BREAK_ALL = 'all'
+    BREAK_SMART = 'smart'
+    BREAK_VERBATIM = 'verbatim'
+
+    BREAK_CHOICES = {BREAK_ALL, BREAK_SMART, BREAK_VERBATIM}
+
+    @staticmethod
+    def break_option(argument):
+        return directives.choice(argument, CMakeSignatureObject.BREAK_CHOICES)
+
+    option_spec = {
+        'target': directives.unchanged,
+        'break': break_option,
+    }
+
+    @staticmethod
+    def _break_signature_all(sig: str) -> str:
+        return ws_re.sub(' ', sig)
+
+    @staticmethod
+    def _break_signature_verbatim(sig: str) -> str:
+        lines = [ws_re.sub('\xa0', line.strip()) for line in sig.split('\n')]
+        return ' '.join(lines)
+
+    @staticmethod
+    def _break_signature_smart(sig: str) -> str:
+        tokens = []
+        for line in sig.split('\n'):
+            token = ''
+            delim = ''
+
+            for c in line.strip():
+                if not delim and ws_re.match(c):
+                    if token:
+                        tokens.append(ws_re.sub('\xa0', token))
+                        token = ''
+                else:
+                    if c == '[':
+                        delim += ']'
+                    elif c == '<':
+                        delim += '>'
+                    elif delim and c == delim[-1]:
+                        delim = delim[:-1]
+                    token += c
+
+            if token:
+                tokens.append(ws_re.sub('\xa0', token))
+
+        return ' '.join(tokens)
+
+    def __init__(self, *args, **kwargs):
+        self.targetnames = {}
+        self.break_style = CMakeSignatureObject.BREAK_SMART
+        super().__init__(*args, **kwargs)
+
+    def get_signatures(self) -> List[str]:
+        content = nl_escape_re.sub('', self.arguments[0])
+        lines = sig_end_re.split(content)
+
+        if self.break_style == CMakeSignatureObject.BREAK_VERBATIM:
+            fixup = CMakeSignatureObject._break_signature_verbatim
+        elif self.break_style == CMakeSignatureObject.BREAK_SMART:
+            fixup = CMakeSignatureObject._break_signature_smart
+        else:
+            fixup = CMakeSignatureObject._break_signature_all
+
+        return [fixup(line.strip()) for line in lines]
+
+    def handle_signature(self, sig, signode):
+        language = 'cmake'
+        classes = ['code', 'cmake', 'highlight']
+
+        node = addnodes.desc_name(sig, '', classes=classes)
+
+        try:
+            tokens = Lexer(sig, language, 'short')
+        except LexerError as error:
+            if self.state.document.settings.report_level > 2:
+                # Silently insert without syntax highlighting.
+                tokens = Lexer(sig, language, 'none')
+            else:
+                raise self.warning(error)
+
+        for classes, value in tokens:
+            if value == '\xa0':
+                node += nodes.inline(value, value, classes=['nbsp'])
+            elif classes:
+                node += nodes.inline(value, value, classes=classes)
+            else:
+                node += nodes.Text(value)
+
+        signode.clear()
+        signode += node
+
+        return sig
+
+    def add_target_and_index(self, name, sig, signode):
+        sig = sig.replace('\xa0', ' ')
+        if sig in self.targetnames:
+            sigargs = self.targetnames[sig]
+        else:
+            def extract_keywords(params):
+                for p in params:
+                    if p[0].isalpha():
+                        yield p
+                    else:
+                        return
+
+            keywords = extract_keywords(sig.split('(')[1].split())
+            sigargs = ' '.join(keywords)
+        command = sig.split('(')[0].lower()
+        targetname = sigargs.lower()
+        # Anchor each signature on its command name, qualified by the keyword
+        # arguments that distinguish overloaded signatures. The command name is
+        # unique, so this keeps keyword-less signatures from collapsing onto the
+        # same id and stops two commands that share a leading keyword from
+        # colliding. The id is kept in the 'command:' namespace (as the
+        # cmake:command directive does) so it cannot clash with section ids.
+        anchor = ' '.join(filter(None, [command, targetname]))
+        targetid = 'command:' + nodes.make_id(anchor)
+
+        if targetid not in self.state.document.ids:
+            signode['names'].append(anchor)
+            signode['ids'].append(targetid)
+            signode['first'] = not self.names
+            self.state.document.note_explicit_target(signode)
+
+            domain = cast(CMakeDomain, self.env.get_domain('cmake'))
+
+            # Register the keyword-qualified signature as a command object.
+            if sigargs:
+                refname = f'{command}({sigargs})'
+                refid = f'command:{command}({targetname})'
+                domain.note_object('command', name=refname, target_id=refid,
+                                   node_id=targetid, location=signode)
+
+            # Also register the bare command name so it can be referenced as
+            # :cmake:command:`<command>`, unless a dedicated cmake:command
+            # directive (or an earlier signature) already registered it.
+            bareid = f'command:{command}'
+            if bareid not in domain.data['objects']:
+                domain.note_object('command', name=command, target_id=bareid,
+                                   node_id=targetid, location=signode)
+
+    def run(self):
+        self.break_style = CMakeSignatureObject.BREAK_ALL
+
+        targets = self.options.get('target')
+        if targets is not None:
+            signatures = self.get_signatures()
+            targets = [t.strip() for t in targets.split('\n')]
+            for signature, target in zip(signatures, targets):
+                self.targetnames[signature] = target
+
+        self.break_style = (
+            self.options.get('break', CMakeSignatureObject.BREAK_SMART))
+
+        return super().run()
+
+
+class CMakeReferenceRole:
+    # See sphinx.util.nodes.explicit_title_re; \x00 escapes '<'.
+    _re = re.compile(r'^(.+?)(\s*)(?<!\x00)<(.*?)>$', re.DOTALL)
+
+    @staticmethod
+    def _escape_angle_brackets(text: str) -> str:
+        # CMake cross-reference targets frequently contain '<' so escape
+        # any explicit `<target>` with '<' not preceded by whitespace.
+        while True:
+            m = CMakeReferenceRole._re.match(text)
+            if m and len(m.group(2)) == 0:
+                text = f'{m.group(1)}\x00<{m.group(3)}>'
+            else:
+                break
+        return text
+
+    def __class_getitem__(cls, parent: Any):
+        class Class(parent):
+            def __call__(self, name: str, rawtext: str, text: str,
+                         *args, **kwargs
+                         ) -> Tuple[List[Node], List[system_message]]:
+                text = CMakeReferenceRole._escape_angle_brackets(text)
+                return super().__call__(name, rawtext, text, *args, **kwargs)
+        return Class
+
+
+class CMakeCRefRole(CMakeReferenceRole[ReferenceRole]):
+    nodeclass: Type[Element] = nodes.reference
+    innernodeclass: Type[TextElement] = nodes.literal
+    classes: List[str] = ['cmake', 'literal']
+
+    def run(self) -> Tuple[List[Node], List[system_message]]:
+        refnode = self.nodeclass(self.rawtext)
+        self.set_source_info(refnode)
+
+        refnode['refid'] = nodes.make_id(self.target)
+        refnode += self.innernodeclass(self.rawtext, self.title,
+                                       classes=self.classes)
+
+        return [refnode], []
+
+
+class CMakeXRefRole(CMakeReferenceRole[XRefRole]):
+
+    _re_sub = re.compile(r'^([^()\s]+)\s*\(([^()]*)\)$', re.DOTALL)
+    _re_genex = re.compile(r'^\$<([^<>:]+)(:[^<>]+)?>$', re.DOTALL)
+    _re_guide = re.compile(r'^([^<>/]+)/([^<>]*)$', re.DOTALL)
+
+    def __call__(self, typ, rawtext, text, *args, **kwargs):
+        if typ == 'cmake:command':
+            # Translate a CMake command cross-reference of the form:
+            #  `command_name(SUB_COMMAND)`
+            # to be its own explicit target:
+            #  `command_name(SUB_COMMAND) <command_name(SUB_COMMAND)>`
+            # so the XRefRole `fix_parens` option does not add more `()`.
+            m = CMakeXRefRole._re_sub.match(text)
+            if m:
+                text = f'{text} <{text}>'
+        elif typ == 'cmake:genex':
+            m = CMakeXRefRole._re_genex.match(text)
+            if m:
+                text = f'{text} <{m.group(1)}>'
+        elif typ == 'cmake:guide':
+            m = CMakeXRefRole._re_guide.match(text)
+            if m:
+                text = f'{m.group(2)} <{text}>'
+        return super().__call__(typ, rawtext, text, *args, **kwargs)
+
+    # We cannot insert index nodes using the result_nodes method
+    # because CMakeXRefRole is processed before substitution_reference
+    # nodes are evaluated so target nodes (with 'ids' fields) would be
+    # duplicated in each evaluated substitution replacement.  The
+    # docutils substitution transform does not allow this.  Instead we
+    # use our own CMakeXRefTransform below to add index entries after
+    # substitutions are completed.
+    #
+    # def result_nodes(self, document, env, node, is_ref):
+    #     pass
+
+
+class CMakeXRefTransform(Transform):
+
+    # Run this transform early since we insert nodes we want
+    # treated as if they were written in the documents, but
+    # after the sphinx (210) and docutils (220) substitutions.
+    default_priority = 221
+
+    # This helper supports docutils < 0.18, which is missing 'findall',
+    # and docutils == 0.18.0, which is missing 'traverse'.
+    def _document_findall_as_list(self, condition):
+        if hasattr(self.document, 'findall'):
+            # Fully iterate into a list so the caller can grow 'self.document'
+            # while iterating.
+            return list(self.document.findall(condition))
+
+        # Fallback to 'traverse' on old docutils, which returns a list.
+        return self.document.traverse(condition)
+
+    def apply(self):
+        env = self.document.settings.env
+
+        # Find CMake cross-reference nodes and add index and target
+        # nodes for them.
+        for ref in self._document_findall_as_list(addnodes.pending_xref):
+            if not ref['refdomain'] == 'cmake':
+                continue
+
+            objtype = ref['reftype']
+            make_index_entry = _cmake_index_objs.get(objtype)
+            if not make_index_entry:
+                continue
+
+            objname = ref['reftarget']
+            if objtype == 'guide' and CMakeXRefRole._re_guide.match(objname):
+                # Do not index cross-references to guide sections.
+                continue
+
+            if objtype == 'command':
+                # Index signature references to their parent command.
+                objname = objname.split('(')[0].lower()
+
+            targetnum = env.new_serialno(f'index-{objtype}:{objname}')
+
+            targetid = f'index-{targetnum}-{objtype}:{objname}'
+            targetnode = nodes.target('', '', ids=[targetid])
+            self.document.note_explicit_target(targetnode)
+
+            indexnode = addnodes.index()
+            indexnode['entries'] = [make_index_entry(objname, targetid, '')]
+            ref.replace_self([indexnode, targetnode, ref])
+
+
+class CMakeDomain(Domain):
+    """CMake domain."""
+    name = 'cmake'
+    label = 'CMake'
+    object_types = {
+        'command':    ObjType('command',    'command'),
+        'cpack_gen':  ObjType('cpack_gen',  'cpack_gen'),
+        'envvar':     ObjType('envvar',     'envvar'),
+        'generator':  ObjType('generator',  'generator'),
+        'genex':      ObjType('genex',      'genex'),
+        'guide':      ObjType('guide',      'guide'),
+        'variable':   ObjType('variable',   'variable'),
+        'module':     ObjType('module',     'module'),
+        'policy':     ObjType('policy',     'policy'),
+        'prop_cache': ObjType('prop_cache', 'prop_cache'),
+        'prop_dir':   ObjType('prop_dir',   'prop_dir'),
+        'prop_gbl':   ObjType('prop_gbl',   'prop_gbl'),
+        'prop_inst':  ObjType('prop_inst',  'prop_inst'),
+        'prop_sf':    ObjType('prop_sf',    'prop_sf'),
+        'prop_test':  ObjType('prop_test',  'prop_test'),
+        'prop_tgt':   ObjType('prop_tgt',   'prop_tgt'),
+        'manual':     ObjType('manual',     'manual'),
+    }
+    directives = {
+        'command':    CMakeObject,
+        'envvar':     CMakeObject,
+        'genex':      CMakeGenexObject,
+        'signature':  CMakeSignatureObject,
+        'variable':   CMakeObject,
+        # Other `object_types` cannot be created except by the `CMakeTransform`
+    }
+    roles = {
+        'cref':       CMakeCRefRole(),
+        'command':    CMakeXRefRole(fix_parens=True, lowercase=True),
+        'cpack_gen':  CMakeXRefRole(),
+        'envvar':     CMakeXRefRole(),
+        'generator':  CMakeXRefRole(),
+        'genex':      CMakeXRefRole(),
+        'guide':      CMakeXRefRole(),
+        'variable':   CMakeXRefRole(),
+        'module':     CMakeXRefRole(),
+        'policy':     CMakeXRefRole(),
+        'prop_cache': CMakeXRefRole(),
+        'prop_dir':   CMakeXRefRole(),
+        'prop_gbl':   CMakeXRefRole(),
+        'prop_inst':  CMakeXRefRole(),
+        'prop_sf':    CMakeXRefRole(),
+        'prop_test':  CMakeXRefRole(),
+        'prop_tgt':   CMakeXRefRole(),
+        'manual':     CMakeXRefRole(),
+    }
+    initial_data = {
+        'objects': {},  # fullname -> ObjectEntry
+    }
+
+    def clear_doc(self, docname):
+        to_clear = set()
+        for fullname, obj in self.data['objects'].items():
+            if obj.docname == docname:
+                to_clear.add(fullname)
+        for fullname in to_clear:
+            del self.data['objects'][fullname]
+
+    def merge_domaindata(self, docnames, otherdata):
+        """Merge domaindata from the workers/chunks when they return.
+
+        Called once per parallelization chunk.
+        Only used when sphinx is run in parallel mode.
+
+        :param docnames: a Set of the docnames that are part of the current
+                         chunk to merge
+        :param otherdata: the partial data calculated by the current chunk
+        """
+        for refname, obj in otherdata['objects'].items():
+            if obj.docname in docnames:
+                self.data['objects'][refname] = obj
+
+    def resolve_xref(self, env, fromdocname, builder,
+                     typ, target, node, contnode):
+        targetid = f'{typ}:{target}'
+        obj = self.data['objects'].get(targetid)
+
+        if obj is None and typ == 'command':
+            # If 'command(args)' wasn't found, try just 'command'.
+            # TODO: remove this fallback? warn?
+            # logger.warning(f'no match for {targetid}')
+            command = target.split('(')[0]
+            targetid = f'{typ}:{command}'
+            obj = self.data['objects'].get(targetid)
+
+        if obj is None:
+            # TODO: warn somehow?
+            return None
+
+        return make_refnode(builder, fromdocname, obj.docname, obj.node_id,
+                            contnode, target)
+
+    def note_object(self, objtype: str, name: str, target_id: str,
+                    node_id: str, location: Any = None):
+        if target_id in self.data['objects']:
+            other = self.data['objects'][target_id].docname
+            logger.warning(
+                f'CMake object {target_id!r} also described in {other!r}',
+                location=location)
+
+        self.data['objects'][target_id] = ObjectEntry(
+            self.env.docname, objtype, node_id, name)
+
+    def get_objects(self):
+        for refname, obj in self.data['objects'].items():
+            yield (refname, refname, obj.objtype, obj.docname, obj.node_id, 1)
+
+
+def setup(app):
+    app.add_directive('cmake-module', CMakeModule)
+    app.add_transform(CMakeTransform)
+    app.add_transform(CMakeXRefTransform)
+    app.add_domain(CMakeDomain)
+    return {"parallel_read_safe": True}

--- a/doc/_extensions/moderncmakedomain/colors.py
+++ b/doc/_extensions/moderncmakedomain/colors.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+
+from pygments.style import Style
+from pygments.token import Name, Comment, String, Number, Operator, Whitespace
+
+class CMakeTemplateStyle(Style):
+    """
+        for more token names, see pygments/styles.default
+    """
+
+    background_color = "#f8f8f8"
+    default_style = ""
+
+    styles = {
+        Whitespace:                "#bbbbbb",
+        Comment:                   "italic #408080",
+        Operator:                  "#555555",
+        String:                    "#217A21",
+        Number:                    "#105030",
+        Name.Builtin:              "#333333",          # anything lowercase
+        Name.Function:             "#007020",          # function
+        Name.Variable:             "#1080B0",          # <..>
+        Name.Tag:                  "#bb60d5",          # ${..}
+        Name.Constant:             "#4070a0",          # uppercase only
+        Name.Entity:               "italic #70A020",   # @..@
+        Name.Attribute:            "#906060",          # paths, URLs
+        Name.Label:                "#A0A000",          # anything left over
+        Name.Exception:            "bold #FF0000",     # for debugging only
+    }

--- a/doc/_static/css/custom.css
+++ b/doc/_static/css/custom.css
@@ -581,7 +581,9 @@ kbd, .kbd,
 
 /* Definition lists */
 .rst-content dl {
-    border-left: 4px solid var(--admonition-note-background-color);
+    /* Neutral gray, distinct from the accent color the headings use for their left border, so a
+       definition list is not mistaken for content nested under the preceding heading. */
+    border-left: 4px solid var(--code-border-color);
 }
 
 .rst-content dl:not(.field-list) > dt {

--- a/doc/_static/css/custom.css
+++ b/doc/_static/css/custom.css
@@ -606,6 +606,18 @@ kbd, .kbd,
     border: 4px solid var(--content-background-color);
 }
 
+/* Give CMake signatures and their nested parameter terms the code background, so the syntax
+   highlighting stays legible and the terms aren't left with the theme's too-bright default. */
+.rst-content dl.cmake > dt,
+.rst-content dl.cmake dd dl:not(.field-list) > dt {
+    background: var(--highlight-background-color) !important;
+    color: var(--highlight-default-color) !important;
+}
+
+.rst-content dl.cmake > dt .sig-name {
+    color: inherit !important;
+}
+
 /* Buttons */
 
 .btn-neutral {

--- a/doc/_static/css/custom.css
+++ b/doc/_static/css/custom.css
@@ -279,12 +279,14 @@ code,
     border-bottom: 1px solid var(--code-background-color) !important;
 }
 
-/* Code literals */
-a.internal code.literal {
+/* Code literals that are links in body content take the link color. Scoped to .rst-content so the
+   navigation sidebar (where code identifiers are section titles, not cross-references) is unaffected
+   and keeps the regular nav text color. */
+.rst-content a.internal code.literal {
     color: var(--link-color);
 }
 
-a.internal:visited code.literal {
+.rst-content a.internal:visited code.literal {
     color: var(--link-color-visited);
 }
 
@@ -557,6 +559,24 @@ kbd, .kbd,
 .rst-content section > h5 {
     border-color: transparent;
     font-weight: 100;
+}
+
+/* Section titles that are code identifiers would otherwise render as a small inline-code chip, both
+   in the body and the sidebar. Let the code inherit the surrounding size, weight and color so the
+   heading hierarchy and nav entries stay legible. */
+.rst-content section > h1 code,
+.rst-content section > h2 code,
+.rst-content section > h3 code,
+.rst-content section > h4 code,
+.rst-content section > h5 code,
+.rst-content section > h6 code,
+.wy-menu-vertical a code.literal {
+    font-size: inherit;
+    font-weight: inherit;
+    background: transparent;
+    border: 0;
+    padding: 0;
+    color: inherit;
 }
 
 /* Definition lists */

--- a/doc/build/cmake-ref/index.rst
+++ b/doc/build/cmake-ref/index.rst
@@ -1,0 +1,4 @@
+.. _cmake-reference:
+
+CMake Reference
+===============

--- a/doc/build/cmake-ref/index.rst
+++ b/doc/build/cmake-ref/index.rst
@@ -2,3 +2,50 @@
 
 CMake Reference
 ===============
+
+Core Build System & Hardware Modules
+------------------------------------
+
+.. toctree::
+   :maxdepth: 1
+   :glob:
+
+   module/arch
+   module/boards
+   module/configuration_files
+   module/soc
+   module/kernel
+   module/basic_settings
+   module/extensions
+   module/kconfig
+
+Utility & Tooling Modules
+-------------------------
+
+.. toctree::
+   :maxdepth: 1
+   :glob:
+
+   module/doc
+   module/python
+   module/west
+   module/git
+   module/yaml
+
+Target properties
+-----------------
+
+.. toctree::
+   :maxdepth: 1
+   :glob:
+
+   prop_tgt/*
+
+Variables
+---------
+
+.. toctree::
+   :maxdepth: 1
+   :glob:
+
+   variable/*

--- a/doc/build/cmake-ref/module/arch.rst
+++ b/doc/build/cmake-ref/module/arch.rst
@@ -1,0 +1,1 @@
+.. cmake-module:: /cmake/modules/arch.cmake

--- a/doc/build/cmake-ref/module/basic_settings.rst
+++ b/doc/build/cmake-ref/module/basic_settings.rst
@@ -1,0 +1,1 @@
+.. cmake-module:: /cmake/modules/basic_settings.cmake

--- a/doc/build/cmake-ref/module/boards.rst
+++ b/doc/build/cmake-ref/module/boards.rst
@@ -1,0 +1,1 @@
+.. cmake-module:: /cmake/modules/boards.cmake

--- a/doc/build/cmake-ref/module/configuration_files.rst
+++ b/doc/build/cmake-ref/module/configuration_files.rst
@@ -1,0 +1,1 @@
+.. cmake-module:: /cmake/modules/configuration_files.cmake

--- a/doc/build/cmake-ref/module/doc.rst
+++ b/doc/build/cmake-ref/module/doc.rst
@@ -1,0 +1,1 @@
+.. cmake-module:: /cmake/modules/doc.cmake

--- a/doc/build/cmake-ref/module/extensions.rst
+++ b/doc/build/cmake-ref/module/extensions.rst
@@ -1,0 +1,1 @@
+.. cmake-module:: /cmake/modules/extensions.cmake

--- a/doc/build/cmake-ref/module/git.rst
+++ b/doc/build/cmake-ref/module/git.rst
@@ -1,0 +1,1 @@
+.. cmake-module:: /cmake/modules/git.cmake

--- a/doc/build/cmake-ref/module/kconfig.rst
+++ b/doc/build/cmake-ref/module/kconfig.rst
@@ -1,0 +1,1 @@
+.. cmake-module:: /cmake/modules/kconfig.cmake

--- a/doc/build/cmake-ref/module/kernel.rst
+++ b/doc/build/cmake-ref/module/kernel.rst
@@ -1,0 +1,1 @@
+.. cmake-module:: /cmake/modules/kernel.cmake

--- a/doc/build/cmake-ref/module/python.rst
+++ b/doc/build/cmake-ref/module/python.rst
@@ -1,0 +1,1 @@
+.. cmake-module:: /cmake/modules/python.cmake

--- a/doc/build/cmake-ref/module/soc.rst
+++ b/doc/build/cmake-ref/module/soc.rst
@@ -1,0 +1,1 @@
+.. cmake-module:: /cmake/modules/soc.cmake

--- a/doc/build/cmake-ref/module/west.rst
+++ b/doc/build/cmake-ref/module/west.rst
@@ -1,0 +1,1 @@
+.. cmake-module:: /cmake/modules/west.cmake

--- a/doc/build/cmake-ref/module/yaml.rst
+++ b/doc/build/cmake-ref/module/yaml.rst
@@ -1,0 +1,1 @@
+.. cmake-module:: /cmake/modules/yaml.cmake

--- a/doc/build/cmake-ref/prop_tgt/LIBC_LINK_LIBRARIES.rst
+++ b/doc/build/cmake-ref/prop_tgt/LIBC_LINK_LIBRARIES.rst
@@ -1,0 +1,8 @@
+LIBC_LINK_LIBRARIES
+###################
+
+A list of libraries that are linked to the C standard library when it is built.
+This property is used to define additional dependencies that the C standard library may have on
+other libraries.
+
+See also: :cmake:command:`zephyr_libc_link_libraries`.

--- a/doc/build/cmake-ref/variable/ACTIVE_BOARD_REVISION.rst
+++ b/doc/build/cmake-ref/variable/ACTIVE_BOARD_REVISION.rst
@@ -1,0 +1,6 @@
+ACTIVE_BOARD_REVISION
+#####################
+
+The revision of the active board.
+
+See :cmake:module:`boards`.

--- a/doc/build/cmake-ref/variable/APPLICATION_CONFIG_DIR.rst
+++ b/doc/build/cmake-ref/variable/APPLICATION_CONFIG_DIR.rst
@@ -1,0 +1,6 @@
+APPLICATION_CONFIG_DIR
+######################
+
+Root folder for application configuration.
+
+See :cmake:module:`configuration_files`.

--- a/doc/build/cmake-ref/variable/ARCH.rst
+++ b/doc/build/cmake-ref/variable/ARCH.rst
@@ -1,0 +1,6 @@
+ARCH
+####
+
+Name of the architecture in use.
+
+See :cmake:module:`arch`.

--- a/doc/build/cmake-ref/variable/ARCH_DIR.rst
+++ b/doc/build/cmake-ref/variable/ARCH_DIR.rst
@@ -1,0 +1,6 @@
+ARCH_DIR
+########
+
+Directory containing the architecture implementation.
+
+See :cmake:module:`arch`.

--- a/doc/build/cmake-ref/variable/ARCH_ROOT.rst
+++ b/doc/build/cmake-ref/variable/ARCH_ROOT.rst
@@ -1,0 +1,7 @@
+ARCH_ROOT
+#########
+
+List of directories containing architecture implementations.
+This variable is updated to include :envvar:`ZEPHYR_BASE` appended.
+
+See :cmake:module:`arch`.

--- a/doc/build/cmake-ref/variable/BOARD.rst
+++ b/doc/build/cmake-ref/variable/BOARD.rst
@@ -1,0 +1,14 @@
+BOARD
+#####
+
+Input to :cmake:module:`boards`
+*******************************
+
+Board name, including any optional revision field, for example: ``foo`` or ``foo@1.0.0``.
+
+Output from :cmake:module:`boards`
+**********************************
+
+Board name, without revision field.
+
+See :cmake:module:`boards`.

--- a/doc/build/cmake-ref/variable/BOARD_DIR.rst
+++ b/doc/build/cmake-ref/variable/BOARD_DIR.rst
@@ -1,0 +1,6 @@
+BOARD_DIR
+#########
+
+Board directory with the implementation for selected board.
+
+See :cmake:module:`boards`.

--- a/doc/build/cmake-ref/variable/BOARD_QUALIFIERS.rst
+++ b/doc/build/cmake-ref/variable/BOARD_QUALIFIERS.rst
@@ -1,0 +1,6 @@
+BOARD_QUALIFIERS
+################
+
+Board qualifiers.
+
+See :cmake:module:`boards`.

--- a/doc/build/cmake-ref/variable/BOARD_REVISION.rst
+++ b/doc/build/cmake-ref/variable/BOARD_REVISION.rst
@@ -1,0 +1,6 @@
+BOARD_REVISION
+##############
+
+Board revision.
+
+See :cmake:module:`boards`.

--- a/doc/build/cmake-ref/variable/BOARD_ROOT.rst
+++ b/doc/build/cmake-ref/variable/BOARD_ROOT.rst
@@ -1,0 +1,15 @@
+BOARD_ROOT
+##########
+
+Input to :cmake:module:`boards`
+*******************************
+
+List of directories containing board implementations.
+
+Output from :cmake:module:`boards`
+**********************************
+
+List of directories containing board implementations.
+This variable is updated to include :envvar:`ZEPHYR_BASE` appended.
+
+See :cmake:module:`boards`.

--- a/doc/build/cmake-ref/variable/BSIM_COMPONENTS_PATH.rst
+++ b/doc/build/cmake-ref/variable/BSIM_COMPONENTS_PATH.rst
@@ -1,0 +1,6 @@
+BSIM_COMPONENTS_PATH
+####################
+
+Path to the BabbleSim components source folder.
+
+See :ref:`bsim`.

--- a/doc/build/cmake-ref/variable/BSIM_OUT_PATH.rst
+++ b/doc/build/cmake-ref/variable/BSIM_OUT_PATH.rst
@@ -1,0 +1,6 @@
+BSIM_OUT_PATH
+#############
+
+Path to the BabbleSim build output root path (under which libraries and binaries are kept).
+
+See :ref:`bsim`.

--- a/doc/build/cmake-ref/variable/CONF_FILE.rst
+++ b/doc/build/cmake-ref/variable/CONF_FILE.rst
@@ -1,0 +1,6 @@
+CONF_FILE
+#########
+
+List of Kconfig fragments.
+
+See :cmake:module:`configuration_files`.

--- a/doc/build/cmake-ref/variable/DTC_OVERLAY_FILE.rst
+++ b/doc/build/cmake-ref/variable/DTC_OVERLAY_FILE.rst
@@ -1,0 +1,6 @@
+DTC_OVERLAY_FILE
+################
+
+List of devicetree overlay files.
+
+See :cmake:module:`configuration_files`.

--- a/doc/build/cmake-ref/variable/DTS_EXTRA_CPPFLAGS.rst
+++ b/doc/build/cmake-ref/variable/DTS_EXTRA_CPPFLAGS.rst
@@ -1,0 +1,6 @@
+DTS_EXTRA_CPPFLAGS
+##################
+
+List of additional devicetree preprocessor defines.
+
+See :cmake:module:`configuration_files`.

--- a/doc/build/cmake-ref/variable/EXTRA_CONF_FILE.rst
+++ b/doc/build/cmake-ref/variable/EXTRA_CONF_FILE.rst
@@ -1,0 +1,6 @@
+EXTRA_CONF_FILE
+###############
+
+List of additional Kconfig fragments.
+
+See :cmake:module:`configuration_files`.

--- a/doc/build/cmake-ref/variable/EXTRA_DTC_OVERLAY_FILE.rst
+++ b/doc/build/cmake-ref/variable/EXTRA_DTC_OVERLAY_FILE.rst
@@ -1,0 +1,6 @@
+EXTRA_DTC_OVERLAY_FILE
+######################
+
+List of additional devicetree overlay files.
+
+See :cmake:module:`configuration_files`.

--- a/doc/build/cmake-ref/variable/LLEXT_APPEND_FLAGS.rst
+++ b/doc/build/cmake-ref/variable/LLEXT_APPEND_FLAGS.rst
@@ -1,0 +1,7 @@
+LLEXT_APPEND_FLAGS
+##################
+
+Global list of compiler flags to be added to compiler invocations when compiling extensions.
+Target and compiler dependent, usually set in toolchain files.
+
+See :cmake:command:`add_llext_target`.

--- a/doc/build/cmake-ref/variable/LLEXT_REMOVE_FLAGS.rst
+++ b/doc/build/cmake-ref/variable/LLEXT_REMOVE_FLAGS.rst
@@ -1,0 +1,8 @@
+LLEXT_REMOVE_FLAGS
+##################
+
+Global list of regular expressions describing compiler flags to be removed from compiler
+invocations when compiling extensions.
+Target and compiler dependent, usually set in toolchain files.
+
+See :cmake:command:`add_llext_target`.

--- a/doc/build/cmake-ref/variable/NORMALIZED_BOARD_QUALIFIERS.rst
+++ b/doc/build/cmake-ref/variable/NORMALIZED_BOARD_QUALIFIERS.rst
@@ -1,0 +1,6 @@
+NORMALIZED_BOARD_QUALIFIERS
+###########################
+
+Board qualifiers in lower-case format where slashes have been replaced with underscores.
+
+See :cmake:module:`boards`.

--- a/doc/build/cmake-ref/variable/NORMALIZED_BOARD_TARGET.rst
+++ b/doc/build/cmake-ref/variable/NORMALIZED_BOARD_TARGET.rst
@@ -1,0 +1,6 @@
+NORMALIZED_BOARD_TARGET
+#######################
+
+Board target in lower-case format where slashes have been replaced with underscores.
+
+See :cmake:module:`boards`.

--- a/doc/build/cmake-ref/variable/PYTHON_EXECUTABLE.rst
+++ b/doc/build/cmake-ref/variable/PYTHON_EXECUTABLE.rst
@@ -1,0 +1,7 @@
+PYTHON_EXECUTABLE
+#################
+
+Path to the Python executable that will be used by Zephyr.
+This is an alias to ``Python3_EXECUTABLE`` for backward compatibility.
+
+See :cmake:module:`python`.

--- a/doc/build/cmake-ref/variable/PYTHON_MINIMUM_REQUIRED.rst
+++ b/doc/build/cmake-ref/variable/PYTHON_MINIMUM_REQUIRED.rst
@@ -1,0 +1,6 @@
+PYTHON_MINIMUM_REQUIRED
+#######################
+
+The minimum required Python version (currently 3.12).
+
+See :cmake:module:`python`.

--- a/doc/build/cmake-ref/variable/USE_CCACHE.rst
+++ b/doc/build/cmake-ref/variable/USE_CCACHE.rst
@@ -1,0 +1,6 @@
+USE_CCACHE
+##########
+
+This variable can be set to ``0`` to explicitly disable the use of ccache, even if it is installed
+on the system. If set to any other value (or unset) and ccache is found on the system, it will be
+used for compilation and linking.

--- a/doc/build/cmake-ref/variable/WEST.rst
+++ b/doc/build/cmake-ref/variable/WEST.rst
@@ -1,0 +1,6 @@
+WEST
+####
+
+Path to the west executable.
+
+See :cmake:module:`west`.

--- a/doc/build/cmake-ref/variable/WEST_PYTHON.rst
+++ b/doc/build/cmake-ref/variable/WEST_PYTHON.rst
@@ -1,0 +1,6 @@
+WEST_PYTHON
+###########
+
+Path to the Python interpreter used by west.
+
+See :cmake:module:`west`.

--- a/doc/build/cmake-ref/variable/WEST_TOPDIR.rst
+++ b/doc/build/cmake-ref/variable/WEST_TOPDIR.rst
@@ -1,0 +1,6 @@
+WEST_TOPDIR
+###########
+
+Top-level directory of the west workspace.
+
+See :cmake:module:`west`.

--- a/doc/build/cmake-ref/variable/ZEPHYR_CURRENT_LIBRARY.rst
+++ b/doc/build/cmake-ref/variable/ZEPHYR_CURRENT_LIBRARY.rst
@@ -1,0 +1,4 @@
+ZEPHYR_CURRENT_LIBRARY
+######################
+
+The name of the current Zephyr library.

--- a/doc/build/cmake/index.rst
+++ b/doc/build/cmake/index.rst
@@ -46,6 +46,8 @@ paths of a target library.
 When introducing build system code using CMake or adding new CMake files,
 please follow the style guidelines outlined :ref:`here <cmake-style>`.
 
+The :ref:`cmake-reference` section provides a reference for all CMake commands,
+variables, and modules used by Zephyr and available to application developers.
 
 Build and Configuration Phases
 ==============================

--- a/doc/build/index.rst
+++ b/doc/build/index.rst
@@ -9,6 +9,7 @@ Build and Configuration Systems
 
 
    cmake/index.rst
+   cmake-ref/index.rst
    dts/index
    kconfig/index.rst
    snippets/index.rst

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -219,7 +219,7 @@ html_theme = "sphinx_rtd_theme"
 html_theme_options = {
     "logo_only": True,
     "prev_next_buttons_location": None,
-    "navigation_depth": 5,
+    "navigation_depth": 6,
 }
 html_baseurl = "https://docs.zephyrproject.org/latest/"
 html_title = "Zephyr Project Documentation"

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -257,6 +257,7 @@ html_context = {
         "API": f"{reference_prefix}/doxygen/html/index.html",
         "Kconfig Options": f"{reference_prefix}/kconfig.html",
         "Devicetree Bindings": f"{reference_prefix}/build/dts/api/bindings.html",
+        "CMake modules": f"{reference_prefix}/build/cmake-ref/index.html",
         "West Projects": f"{reference_prefix}/develop/manifest/index.html",
         "Glossary": f"{reference_prefix}/glossary.html",
     },
@@ -386,6 +387,7 @@ kconfig_zephyr_version = f"v{version}" if is_release else "main"
 external_content_contents = [
     (ZEPHYR_BASE / "doc", "[!_]*"),
     (ZEPHYR_BASE, "tests/**/*.pts"),
+    (ZEPHYR_BASE, "cmake/modules"),
 ]
 if not SKIP_EXTERNAL_CONTENT:
     external_content_contents += [

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -119,6 +119,7 @@ extensions = [
     "zephyr.api_overview",
     "zephyr.partial_build",
     "moderncmakedomain",
+    "sphinx.ext.intersphinx",
 ]
 
 # Only use image conversion when it is really needed, e.g. LaTeX build.
@@ -161,6 +162,10 @@ pygments_style = "sphinx"
 highlight_language = "none"
 
 todo_include_todos = False
+
+intersphinx_mapping = {
+    "cmake": ("https://cmake.org/cmake/help/latest", None),
+}
 
 nitpick_ignore = [
     # ignore C standard identifiers (they are not defined in Zephyr docs)

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -118,6 +118,7 @@ extensions = [
     "zephyr.domain",
     "zephyr.api_overview",
     "zephyr.partial_build",
+    "moderncmakedomain",
 ]
 
 # Only use image conversion when it is really needed, e.g. LaTeX build.

--- a/doc/contribute/documentation/guidelines.rst
+++ b/doc/contribute/documentation/guidelines.rst
@@ -698,6 +698,51 @@ Cross-referencing C documentation
 
    You may provide a custom link text, similar to the built-in :rst:role:`ref` role.
 
+Cross-referencing CMake documentation
+=====================================
+
+You may use the following roles to cross-reference the documentation of Zephyr's CMake modules,
+commands, and variables.
+
+.. rst:role:: cmake:module
+
+   This role is used to reference a CMake module. For example::
+
+      See :cmake:module:`extensions` for more information.
+
+   Will render as:
+
+      See :cmake:module:`extensions` for more information.
+
+.. rst:role:: cmake:command
+
+   This role is used to reference a CMake command. For example::
+
+      See :cmake:command:`yaml_load` for more information.
+
+   Will render as:
+
+      See :cmake:command:`yaml_load` for more information.
+
+   Commands documented by CMake itself are referenced through their fully qualified name, given as
+   an explicit link target::
+
+      See :cmake:command:`target_sources <command:target_sources>` for more information.
+
+   Will render as:
+
+      See :cmake:command:`target_sources <command:target_sources>` for more information.
+
+.. rst:role:: cmake:variable
+
+   This role is used to reference a CMake variable. For example::
+
+      See :cmake:variable:`CMAKE_C_COMPILER` for more information.
+
+   Will render as:
+
+      See :cmake:variable:`CMAKE_C_COMPILER` for more information.
+
 Visual Elements
 ***************
 

--- a/doc/hardware/porting/board_porting.rst
+++ b/doc/hardware/porting/board_porting.rst
@@ -898,8 +898,8 @@ The :makevar:`BOARD_REVISION` variable holds the revision value specified by the
 user.
 
 To signal to the build system that it should use a different revision than the
-one specified by the user, :file:`revision.cmake` can set the variable
-``ACTIVE_BOARD_REVISION`` to the revision to use instead. The corresponding
+one specified by the user, :file:`revision.cmake` can set the CMake variable
+:cmake:variable:`ACTIVE_BOARD_REVISION` to the revision to use instead. The corresponding
 Kconfig files and devicetree overlays must be named
 :file:`<board>_<ACTIVE_BOARD_REVISION>_defconfig` and
 :file:`<board>_<ACTIVE_BOARD_REVISION>.overlay`.

--- a/doc/index.html
+++ b/doc/index.html
@@ -376,6 +376,10 @@
     background-color: rgba(239, 68, 68, 0.2);
     color: #f87171;
   }
+  .ref-cmake {
+    background-color: rgba(244, 114, 182, 0.2);
+    color: #f472b6;
+  }
   .ref-glossary {
     background-color: rgba(249, 115, 22, 0.2);
     color: #fb923c;
@@ -609,6 +613,17 @@
           <p class="card-description">Available projects</p>
         </div>
         <i class="fa fa-arrow-right reference-arrow" style="color: #f87171"></i>
+      </a>
+
+      <a href="build/cmake-ref/index.html" class="reference-card">
+        <div class="icon-wrapper ref-cmake">
+          <i class="fa fa-wrench" aria-hidden="true" style="font-size: 1.25rem"></i>
+        </div>
+        <div class="reference-content">
+          <h3 class="card-title">CMake</h3>
+          <p class="card-description">Build system</p>
+        </div>
+        <i class="fa fa-arrow-right reference-arrow" style="color: #f472b6"></i>
       </a>
 
       <a href="glossary.html" class="reference-card">

--- a/doc/services/llext/build.rst
+++ b/doc/services/llext/build.rst
@@ -32,9 +32,9 @@ Building the extension
 ----------------------
 
 An extension can be defined in the app's ``CMakeLists.txt`` by invoking the
-``add_llext_target`` function, providing the target name, the output and the
-source files. Usage is similar to the standard ``add_custom_target`` CMake
-function:
+:cmake:command:`add_llext_target` function, providing the target name, the output and the
+source files. Usage is similar to the standard :cmake:command:`add_custom_target
+<command:add_custom_target>` CMake function:
 
 .. code-block:: cmake
 
@@ -83,11 +83,11 @@ during the extension build process to a fine degree. Each of the below
 functions takes the LLEXT target name as its first argument; it is otherwise
 functionally equivalent to the common Zephyr ``target_*`` version.
 
-* ``llext_compile_definitions``
-* ``llext_compile_features``
-* ``llext_compile_options``
-* ``llext_include_directories``
-* ``llext_link_options``
+* :cmake:command:`llext_compile_definitions`
+* :cmake:command:`llext_compile_features`
+* :cmake:command:`llext_compile_options`
+* :cmake:command:`llext_include_directories`
+* :cmake:command:`llext_link_options`
 
 Custom build steps
 ------------------


### PR DESCRIPTION
This adds a new CMake reference section aimed at documenting the various CMake goodies provided by our build system.

This uses the CMake Sphinx domain from upstream CMake (still need to work on the best way to use/import it, right now it's copied in our source tree, with a few tweaks to make it work with our directory structure which I will try to get accepted upstream).

The Sphinx domain allows cross-referencing entities (`:cmake:module:`, `:cmake:variable:`, `:cmake:command:`, etc.) which is of course a big plus compared to simply browsing the documentation in the .cmake files. This actually includes linking to _external_ docs from cmake.org (you can see an example of that [here](https://builds.zephyrproject.io/zephyr/pr/87083/docs/build/cmake-ref/module/extensions.html#transform)).

https://builds.zephyrproject.io/zephyr/pr/87083/docs/build/cmake-ref/index.html