### PR TITLE
soc: microchip: mec5: Disable PM in mec174x, mec175x, and mech172x

### DIFF
--- a/soc/microchip/mec/mec174x/Kconfig
+++ b/soc/microchip/mec/mec174x/Kconfig
@@ -11,7 +11,6 @@ config SOC_SERIES_MEC174X
 	select CPU_HAS_ARM_MPU
 	select HAS_SWO
 	select HAS_MEC5_HAL
-	select HAS_PM
 	select SOC_PREP_HOOK
 
 if SOC_SERIES_MEC174X

--- a/soc/microchip/mec/mec175x/Kconfig
+++ b/soc/microchip/mec/mec175x/Kconfig
@@ -11,7 +11,6 @@ config SOC_SERIES_MEC175X
 	select CPU_HAS_ARM_MPU
 	select HAS_SWO
 	select HAS_MEC5_HAL
-	select HAS_PM
 	select SOC_PREP_HOOK
 
 if SOC_SERIES_MEC175X

--- a/soc/microchip/mec/mech172x/Kconfig
+++ b/soc/microchip/mec/mech172x/Kconfig
@@ -11,7 +11,6 @@ config SOC_SERIES_MECH172X
 	select CPU_HAS_ARM_MPU
 	select HAS_SWO
 	select HAS_MEC5_HAL
-	select HAS_PM
 	select SOC_PREP_HOOK
 
 if SOC_SERIES_MECH172X


### PR DESCRIPTION
We disable power management by removing select HAS_PM. At this time these new SoC do not have any power management code. With HAS_PM selected the zephyr test runner will choose PM tests which fail to build.  PM support will be enabled in the future once we decide which of the many Zephyr PM implementations we will support.