### PR TITLE
debug: cpu_load: Extend support to RISCV architecture and nrf54h20 

### DIFF
--- a/arch/riscv/core/cpu_idle.c
+++ b/arch/riscv/core/cpu_idle.c
@@ -12,6 +12,7 @@ void arch_cpu_idle(void)
 {
 	sys_trace_idle();
 	__asm__ volatile("wfi");
+	sys_trace_idle_exit();
 	irq_unlock(MSTATUS_IEN);
 }
 #endif
@@ -21,6 +22,7 @@ void arch_cpu_atomic_idle(unsigned int key)
 {
 	sys_trace_idle();
 	__asm__ volatile("wfi");
+	sys_trace_idle_exit();
 	irq_unlock(key);
 }
 #endif

--- a/soc/nordic/nrf54h/power.c
+++ b/soc/nordic/nrf54h/power.c
@@ -175,17 +175,21 @@ void pm_state_set(enum pm_state state, uint8_t substate_id)
 {
 	if (state == PM_STATE_SUSPEND_TO_IDLE) {
 		__disable_irq();
+		sys_trace_idle();
 		s2idle_enter(substate_id);
 		/* Resume here. */
 		s2idle_exit(substate_id);
+		sys_trace_idle_exit();
 		__enable_irq();
 	}
 #if defined(CONFIG_PM_S2RAM)
 	else if (state == PM_STATE_SUSPEND_TO_RAM) {
 		__disable_irq();
+		sys_trace_idle();
 		s2ram_enter();
 		/* On resuming or error we return exactly *HERE* */
 		s2ram_exit();
+		sys_trace_idle_exit();
 		__enable_irq();
 	}
 #endif

--- a/subsys/debug/Kconfig
+++ b/subsys/debug/Kconfig
@@ -434,8 +434,8 @@ config CS_TRACE_DEFMT
 
 config CPU_LOAD
 	select TRACING
-	# Currently hooks are added only to Cortex M architecture.
-	depends on CPU_CORTEX_M
+	depends on CPU_CORTEX_M || RISCV
+	depends on !SMP
 	bool "CPU load measurement"
 
 # Workaround for not being able to have commas in macro arguments

--- a/tests/subsys/debug/cpu_load/testcase.yaml
+++ b/tests/subsys/debug/cpu_load/testcase.yaml
@@ -1,7 +1,9 @@
 common:
   tags: cpu_load
-  arch_allow: arm
-  filter: CONFIG_CPU_CORTEX_M
+  arch_allow:
+    - arm
+    - riscv
+  filter: CONFIG_CPU_LOAD
 tests:
   debug.cpu_load:
     integration_platforms:


### PR DESCRIPTION
Add `sys_trace_idle_exit` to RISCV cpu idle functions.
Add `sys_trace_idle` and `sys_trace_idle_exit` to nrf54h20 specific idle states.

Fixes #87090.