### PR TITLE
logging: Assign IDs to log backends early during log_core_init

### DIFF
--- a/subsys/logging/log_core.c
+++ b/subsys/logging/log_core.c
@@ -288,6 +288,14 @@ void log_core_init(void)
 	if (IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING)) {
 		z_log_runtime_filters_init();
 	}
+
+	STRUCT_SECTION_FOREACH(log_backend, backend) {
+		uint32_t id;
+		/* As first slot in filtering mask is reserved, backend ID has offset.*/
+		id = LOG_FILTER_FIRST_BACKEND_SLOT_IDX;
+		id += backend - log_backend_get(0);
+		log_backend_id_set(backend, id);
+	}
 }
 
 static uint32_t activate_foreach_backend(uint32_t mask)
@@ -331,12 +339,6 @@ static uint32_t z_log_init(bool blocking, bool can_sleep)
 	int backend_index = 0;
 
 	STRUCT_SECTION_FOREACH(log_backend, backend) {
-		uint32_t id;
-		/* As first slot in filtering mask is reserved, backend ID has offset.*/
-		id = LOG_FILTER_FIRST_BACKEND_SLOT_IDX;
-		id += backend - log_backend_get(0);
-		log_backend_id_set(backend, id);
-
 		/* Activate autostart backends */
 		if (backend->autostart) {
 			log_backend_init(backend);


### PR DESCRIPTION
This commit moves the assignment of backend IDs from the 'z_log_init' function to the earlier 'log_core_init' function. This ensures that backend IDs are assigned before they are used in the 'log_backend_enable' function, preventing incorrect settings of log dynamic filters.

This is part of fix of https://github.com/zephyrproject-rtos/zephyr/issues/86954.