### PR TITLE
drivers: serial: uart: neorv32: neorv32_uart_config_get() can be unused

### DIFF
--- a/drivers/serial/uart_neorv32.c
+++ b/drivers/serial/uart_neorv32.c
@@ -215,6 +215,7 @@ static int neorv32_uart_configure(const struct device *dev, const struct uart_co
 	return 0;
 }
 
+#ifdef CONFIG_UART_USE_RUNTIME_CONFIGURE
 static int neorv32_uart_config_get(const struct device *dev, struct uart_config *cfg)
 {
 	struct neorv32_uart_data *data = dev->data;
@@ -225,6 +226,7 @@ static int neorv32_uart_config_get(const struct device *dev, struct uart_config 
 
 	return 0;
 }
+#endif /* CONFIG_UART_USE_RUNTIME_CONFIGURE */
 
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 static int neorv32_uart_fifo_fill(const struct device *dev, const uint8_t *tx_data, int size)


### PR DESCRIPTION
Guard the neorv32_uart_config_get() function to avoid compilation warning with `CONFIG_UART_USE_RUNTIME_CONFIGURE=n`.

```
[ 91%] Building C object zephyr/drivers/serial/CMakeFiles/drivers__serial.dir/uart_neorv32.c.obj
/home/brix/Projects/zephyrproject/zephyr/drivers/serial/uart_neorv32.c:218:12: warning: 'neorv32_uart_config_get' defined but not used [-Wunused-function]
  218 | static int neorv32_uart_config_get(const struct device *dev, struct uart_config *cfg)
      |            ^~~~~~~~~~~~~~~~~~~~~~~

```