### PR TITLE
soc: neorv32: only allow reading frequency at runtime with a system clock

### DIFF
--- a/soc/neorv32/Kconfig
+++ b/soc/neorv32/Kconfig
@@ -23,6 +23,7 @@ config SOC_NEORV32_READ_FREQUENCY_AT_RUNTIME
 	bool "Read the NEORV32 clock frequency at runtime"
 	default y
 	depends on !$(dt_node_has_prop,/cpus/cpu@0,clock-frequency)
+	depends on SYS_CLOCK_EXISTS
 	select SOC_EARLY_INIT_HOOK
 	select TIMER_READS_ITS_FREQUENCY_AT_RUNTIME
 	help


### PR DESCRIPTION
`CONFIG_TIMER_READS_ITS_FREQUENCY_AT_RUNTIME` depends on `CONFIG_SYS_CLOCK_EXISTS`, so `CONFIG_SOC_NEORV32_READ_FREQUENCY_AT_RUNTIME` needs to depend on `CONFIG_SYS_CLOCK_EXISTS` for selecting it.