### PR TITLE
dts: arm: silabs: Fix issues with GPIO nodes

### DIFF
--- a/dts/arm/silabs/efr32bg22.dtsi
+++ b/dts/arm/silabs/efr32bg22.dtsi
@@ -53,6 +53,38 @@
 &gpio {
 	interrupts = <10 2 18 2>;
 	clocks = <&cmu CLOCK_GPIO CLOCK_BRANCH_PCLK>;
+
+	gpioa: gpio@5003c000 {
+		compatible = "silabs,gecko-gpio-port";
+		reg = <0x5003C000 0x30>;
+		gpio-controller;
+		#gpio-cells = <2>;
+		status = "disabled";
+	};
+
+	gpiob: gpio@5003c030 {
+		compatible = "silabs,gecko-gpio-port";
+		reg = <0x5003C030 0x30>;
+		gpio-controller;
+		#gpio-cells = <2>;
+		status = "disabled";
+	};
+
+	gpioc: gpio@5003c060 {
+		compatible = "silabs,gecko-gpio-port";
+		reg = <0x5003C060 0x30>;
+		gpio-controller;
+		#gpio-cells = <2>;
+		status = "disabled";
+	};
+
+	gpiod: gpio@5003c090 {
+		compatible = "silabs,gecko-gpio-port";
+		reg = <0x5003C090 0x30>;
+		gpio-controller;
+		#gpio-cells = <2>;
+		status = "disabled";
+	};
 };
 
 &dma0 {

--- a/dts/arm/silabs/efr32bg22.dtsi
+++ b/dts/arm/silabs/efr32bg22.dtsi
@@ -51,7 +51,8 @@
 };
 
 &gpio {
-	interrupts = <10 2 18 2>;
+	interrupts = <25 2>, <26 2>;
+	interrupt-names = "gpio_odd", "gpio_even";
 	clocks = <&cmu CLOCK_GPIO CLOCK_BRANCH_PCLK>;
 
 	gpioa: gpio@5003c000 {

--- a/dts/arm/silabs/efr32bg27.dtsi
+++ b/dts/arm/silabs/efr32bg27.dtsi
@@ -68,7 +68,8 @@
 };
 
 &gpio {
-	interrupts = <30 2 31 2>;
+	interrupts = <30 2>, <31 2>;
+	interrupt-names = "gpio_odd", "gpio_even";
 	clocks = <&cmu CLOCK_GPIO CLOCK_BRANCH_PCLK>;
 
 	gpioa: gpio@5003c030 {

--- a/dts/arm/silabs/efr32bg27.dtsi
+++ b/dts/arm/silabs/efr32bg27.dtsi
@@ -70,6 +70,38 @@
 &gpio {
 	interrupts = <30 2 31 2>;
 	clocks = <&cmu CLOCK_GPIO CLOCK_BRANCH_PCLK>;
+
+	gpioa: gpio@5003c030 {
+		compatible = "silabs,gecko-gpio-port";
+		reg = <0x5003C030 0x30>;
+		gpio-controller;
+		#gpio-cells = <2>;
+		status = "disabled";
+	};
+
+	gpiob: gpio@5003c060 {
+		compatible = "silabs,gecko-gpio-port";
+		reg = <0x5003C060 0x30>;
+		gpio-controller;
+		#gpio-cells = <2>;
+		status = "disabled";
+	};
+
+	gpioc: gpio@5003c090 {
+		compatible = "silabs,gecko-gpio-port";
+		reg = <0x5003C090 0x30>;
+		gpio-controller;
+		#gpio-cells = <2>;
+		status = "disabled";
+	};
+
+	gpiod: gpio@5003c0c0 {
+		compatible = "silabs,gecko-gpio-port";
+		reg = <0x5003C0C0 0x30>;
+		gpio-controller;
+		#gpio-cells = <2>;
+		status = "disabled";
+	};
 };
 
 &i2c0 {

--- a/dts/arm/silabs/efr32bg2x.dtsi
+++ b/dts/arm/silabs/efr32bg2x.dtsi
@@ -287,7 +287,6 @@
 		gpio: gpio@5003c000 {
 			compatible = "silabs,gecko-gpio";
 			reg = <0x5003C000 0x440>;
-			interrupt-names = "GPIO_EVEN", "GPIO_ODD";
 			ranges;
 			#address-cells = <1>;
 			#size-cells = <1>;

--- a/dts/arm/silabs/efr32bg2x.dtsi
+++ b/dts/arm/silabs/efr32bg2x.dtsi
@@ -288,51 +288,9 @@
 			compatible = "silabs,gecko-gpio";
 			reg = <0x5003C000 0x440>;
 			interrupt-names = "GPIO_EVEN", "GPIO_ODD";
-
 			ranges;
 			#address-cells = <1>;
 			#size-cells = <1>;
-
-			gpioa: gpio@5003c000 {
-				compatible = "silabs,gecko-gpio-port";
-				reg = <0x5003C000 0x30>;
-				gpio-controller;
-				#gpio-cells = <2>;
-				status = "disabled";
-			};
-
-			gpiob: gpio@5003c030 {
-				compatible = "silabs,gecko-gpio-port";
-				reg = <0x5003C030 0x30>;
-				gpio-controller;
-				#gpio-cells = <2>;
-				status = "disabled";
-			};
-
-			gpioc: gpio@5003c060 {
-				compatible = "silabs,gecko-gpio-port";
-				reg = <0x5003C060 0x30>;
-				gpio-controller;
-				#gpio-cells = <2>;
-				status = "disabled";
-			};
-
-			gpiod: gpio@5003c090 {
-				compatible = "silabs,gecko-gpio-port";
-				reg = <0x5003C090 0x30>;
-				gpio-controller;
-				#gpio-cells = <2>;
-				status = "disabled";
-			};
-
-			gpiof: gpio@5003c0c0 {
-				compatible = "silabs,gecko-gpio-port";
-				reg = <0x5003C0C0 0x30>;
-				gpio-controller;
-				#gpio-cells = <2>;
-				status = "disabled";
-			};
-
 		};
 
 		pinctrl: pin-controller@5003c440 {

--- a/dts/arm/silabs/xg29/xg29.dtsi
+++ b/dts/arm/silabs/xg29/xg29.dtsi
@@ -281,15 +281,7 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 
-			gpioa: gpio@5003c000 {
-				compatible = "silabs,gecko-gpio-port";
-				reg = <0x5003C000 0x30>;
-				gpio-controller;
-				#gpio-cells = <2>;
-				status = "disabled";
-			};
-
-			gpiob: gpio@5003c030 {
+			gpioa: gpio@5003c030 {
 				compatible = "silabs,gecko-gpio-port";
 				reg = <0x5003C030 0x30>;
 				gpio-controller;
@@ -297,7 +289,7 @@
 				status = "disabled";
 			};
 
-			gpioc: gpio@5003c060 {
+			gpiob: gpio@5003c060 {
 				compatible = "silabs,gecko-gpio-port";
 				reg = <0x5003C060 0x30>;
 				gpio-controller;
@@ -305,9 +297,17 @@
 				status = "disabled";
 			};
 
-			gpiod: gpio@5003c090 {
+			gpioc: gpio@5003c090 {
 				compatible = "silabs,gecko-gpio-port";
 				reg = <0x5003C090 0x30>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				status = "disabled";
+			};
+
+			gpiod: gpio@5003c0c0 {
+				compatible = "silabs,gecko-gpio-port";
+				reg = <0x5003C0C0 0x30>;
 				gpio-controller;
 				#gpio-cells = <2>;
 				status = "disabled";


### PR DESCRIPTION
The register addresses of GPIO ports on xg27 and xg29 were off by 0x30, since port A is offset from the beginning of the GPIO block on xg23 and later devices.

The nonexistant "port F" is removed from xg22 and xg27, Series 2 only has 4 GPIO ports.

The GPIO interrupt configuration for xg22 and xg27 was not valid, as the `arm,v8m-nvic` binding expects 2 cells per interrupt, and the interrupt numbers were wrong.