### PR TITLE
cmake: linker: Removed unnecessary regexp in link generator

### DIFF
--- a/cmake/linker_script/common/common-rom.cmake
+++ b/cmake/linker_script/common/common-rom.cmake
@@ -26,7 +26,7 @@ if(CONFIG_GEN_SW_ISR_TABLE AND NOT CONFIG_DYNAMIC_INTERRUPTS)
 endif()
 
 zephyr_linker_section(NAME initlevel_error KVMA RAM_REGION GROUP RODATA_REGION NOINPUT)
-zephyr_linker_section_configure(SECTION initlevel_error INPUT ".z_init_[_A-Z0-9]*" KEEP SORT NAME)
+zephyr_linker_section_configure(SECTION initlevel_error INPUT ".z_init_*" KEEP SORT NAME)
 # How to do cross linker ?
 # ASSERT(SIZEOF(initlevel_error) == 0, "Undefined initialization levels used.")
 

--- a/include/zephyr/linker/common-rom/common-rom-kernel-devices.ld
+++ b/include/zephyr/linker/common-rom/common-rom-kernel-devices.ld
@@ -67,7 +67,7 @@
 	/* verify we don't have rogue .z_init_<something> initlevel sections */
 	SECTION_PROLOGUE(initlevel_error,,)
 	{
-		KEEP(*(SORT(.z_init_[_A-Z0-9]*)))
+		KEEP(*(SORT(.z_init_*)))
 	}
 	ASSERT(SIZEOF(initlevel_error) == 0, "Undefined initialization levels used.")
 


### PR DESCRIPTION
In the linker script generator there was one error checking construct that used regexp and that ended up in the generated linker file, which caused parsing problems with the IAR linker. It was unnecessary.