### PR TITLE
doc: nrf5340_audio_dk: replace nrfjprog > nrfutil

### DIFF
--- a/boards/nordic/nrf5340_audio_dk/doc/index.rst
+++ b/boards/nordic/nrf5340_audio_dk/doc/index.rst
@@ -84,7 +84,7 @@ applications as usual (:ref:`build_an_application` and
 
    .. code-block:: console
 
-      west flash -H -r nrfjprog --skip-rebuild
+      west flash -H -r nrfutil --skip-rebuild
 
 .. note::
 


### PR DESCRIPTION
Replaced the `-r nrfjprog` option with `-r nrfutil` in the flashing instructions for the nRF5340 Audio DK board.
NCSDK-30139.