### PR TITLE
driver: wifi: siwx91x: Fix scan timeout

### DIFF
--- a/drivers/wifi/siwx91x/siwx91x_wifi.c
+++ b/drivers/wifi/siwx91x/siwx91x_wifi.c
@@ -242,25 +242,15 @@ static int siwx91x_scan(const struct device *dev, struct wifi_scan_params *z_sca
 
 	if (z_scan_config->scan_type == WIFI_SCAN_TYPE_ACTIVE) {
 		sl_scan_config.type = SL_WIFI_SCAN_TYPE_ACTIVE;
-
-		if (!z_scan_config->dwell_time_active) {
-			ret = sl_si91x_configure_timeout(SL_SI91X_CHANNEL_ACTIVE_SCAN_TIMEOUT,
-							 SL_WIFI_DEFAULT_ACTIVE_CHANNEL_SCAN_TIME);
-		} else {
-			ret = sl_si91x_configure_timeout(SL_SI91X_CHANNEL_ACTIVE_SCAN_TIMEOUT,
-							 z_scan_config->dwell_time_active);
-		}
-
-		if (ret != SL_STATUS_OK) {
-			return -EINVAL;
-		}
+		ret = sl_si91x_configure_timeout(SL_SI91X_CHANNEL_ACTIVE_SCAN_TIMEOUT,
+						 z_scan_config->dwell_time_active);
 	} else {
 		sl_scan_config.type = SL_WIFI_SCAN_TYPE_PASSIVE;
 		ret = sl_si91x_configure_timeout(SL_SI91X_CHANNEL_PASSIVE_SCAN_TIMEOUT,
 						 z_scan_config->dwell_time_passive);
-		if (ret != SL_STATUS_OK) {
-			return -EINVAL;
-		}
+	}
+	if (ret) {
+		return -EINVAL;
 	}
 
 	for (int i = 0; i < ARRAY_SIZE(z_scan_config->band_chan); i++) {


### PR DESCRIPTION
WiseConnect documentation says:

  Default value of 100 millisecs is used when SL_WIFI_DEFAULT_ACTIVE_CHANNEL_SCAN_TIME is passed

However, this is not true. Currently, DEFAULT_ACTIVE_CHANNEL_SCAN_TIME is 0xFFFF and the scan time is set to 65 seconds.

To have the default scan time, the value '0' must be used.

Fortunately, '0' is also the value we get when the user does not specify any default scan time. So the code can be simplified.