### PR TITLE
net: ip: Configurable IPv4 MTU

### DIFF
--- a/doc/releases/release-notes-4.2.rst
+++ b/doc/releases/release-notes-4.2.rst
@@ -102,6 +102,12 @@ New APIs and options
 
     * LE Connection Subrating is no longer experimental.
 
+* Networking:
+
+  * IPv4
+
+    * :kconfig:option:`CONFIG_NET_IPV4_MTU`
+
 * Stepper
 
   * :c:func:`stepper_stop()`

--- a/include/zephyr/net/net_ip.h
+++ b/include/zephyr/net/net_ip.h
@@ -496,7 +496,11 @@ enum net_ip_mtu {
 	/** IPv4 MTU length. We must be able to receive this size IPv4 packet
 	 * without fragmentation.
 	 */
+#if defined(CONFIG_NET_NATIVE_IPV4)
+	NET_IPV4_MTU = CONFIG_NET_IPV4_MTU,
+#else
 	NET_IPV4_MTU = 576,
+#endif
 };
 
 /** @brief Network packet priority settings described in IEEE 802.1Q Annex I.1 */

--- a/subsys/net/ip/Kconfig.ipv4
+++ b/subsys/net/ip/Kconfig.ipv4
@@ -42,6 +42,14 @@ config NET_IPV4_DEFAULT_NETMASK
 
 if NET_NATIVE_IPV4
 
+config NET_IPV4_MTU
+	int "Initial IPv4 MTU value"
+	default 576
+	range 576 1500
+	help
+	  The value should normally be 576 which is the minimum IPv4 packet
+	  size that implementations need to support without fragmentation.
+
 config NET_INITIAL_TTL
 	int "Initial IPv4 time to live value for unicast packets"
 	default 64


### PR DESCRIPTION
Allow to configure the initial IPv4 MTU needed to support packets without fragmentation.