### PR TITLE
soc: nxp: imxrt: add config ADJUST_DCDC for RT10xx

### DIFF
--- a/soc/nxp/imxrt/Kconfig
+++ b/soc/nxp/imxrt/Kconfig
@@ -171,6 +171,10 @@ config PM_MCUX_DCDC
 config PM_MCUX_PMU
 	bool "MCUX power management unit driver"
 
+config ADJUST_DCDC
+	default y
+	bool "Adjust internal DCDC output"
+
 config DCDC_VALUE
 	hex "DCDC value for VDD_SOC"
 

--- a/soc/nxp/imxrt/imxrt10xx/soc.c
+++ b/soc/nxp/imxrt/imxrt10xx/soc.c
@@ -151,14 +151,15 @@ __weak void clock_init(void)
 	/* Set PERIPH_CLK MUX to PERIPH_CLK2 */
 	CLOCK_SetMux(kCLOCK_PeriphMux, 0x1);
 
-	/* Setting the VDD_SOC value.
-	 */
+#if CONFIG_ADJUST_DCDC
+	/* Setting the VDD_SOC value */
 	DCDC->REG3 = (DCDC->REG3 & (~DCDC_REG3_TRG_MASK)) | DCDC_REG3_TRG(CONFIG_DCDC_VALUE);
 	/* Waiting for DCDC_STS_DC_OK bit is asserted */
 	while (DCDC_REG0_STS_DC_OK_MASK !=
 			(DCDC_REG0_STS_DC_OK_MASK & DCDC->REG0)) {
 		;
 	}
+#endif
 
 #ifdef CONFIG_INIT_ARM_PLL
 	CLOCK_InitArmPll(&armPllConfig); /* Configure ARM PLL to 1200M */

--- a/soc/nxp/imxrt/imxrt11xx/Kconfig
+++ b/soc/nxp/imxrt/imxrt11xx/Kconfig
@@ -69,8 +69,4 @@ config BYPASS_LDO_LPSR
 config ADJUST_LDO
 	bool "Adjust LDO setting"
 
-config ADJUST_DCDC
-	default y
-	bool "Adjust internal DCDC output"
-
 endif # SOC_SERIES_IMXRT11XX


### PR DESCRIPTION
There is a configuration of the DCDC in the clock_init for the RT10xx. The RT11xx has a kconfig flag ADJUST_DCDC to enable or disable DCDC adjust code. This flag is now also used for the RT10xx to be able to enable or disable the DCDC adjust code.