### PR TITLE
edtlib: tests: relicense various YAML sample files

### DIFF
--- a/scripts/dts/python-devicetree/tests/test-bindings-init/base.yaml
+++ b/scripts/dts/python-devicetree/tests/test-bindings-init/base.yaml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-License-Identifier: Apache-2.0
 #
 # Base include file for testing bindings initialization.
 #

--- a/scripts/dts/python-devicetree/tests/test-bindings-init/base_amend.yaml
+++ b/scripts/dts/python-devicetree/tests/test-bindings-init/base_amend.yaml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-License-Identifier: Apache-2.0
 #
 # Amends base properties specifications:
 # - extends property specifications by adding definitions,

--- a/scripts/dts/python-devicetree/tests/test-bindings-init/base_inherit.yaml
+++ b/scripts/dts/python-devicetree/tests/test-bindings-init/base_inherit.yaml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-License-Identifier: Apache-2.0
 #
 # Inherit base specifications without modification.
 

--- a/scripts/dts/python-devicetree/tests/test-bindings-init/base_multi.yaml
+++ b/scripts/dts/python-devicetree/tests/test-bindings-init/base_multi.yaml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-License-Identifier: Apache-2.0
 #
 # Includes base bindings at multiple levels (binding,
 # child-binding, grandchild-binding):

--- a/scripts/dts/python-devicetree/tests/test-bindings-init/compat_desc.yaml
+++ b/scripts/dts/python-devicetree/tests/test-bindings-init/compat_desc.yaml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-License-Identifier: Apache-2.0
 #
 # Test inheritance rules applied to compatible strings
 # and bindings descriptions.

--- a/scripts/dts/python-devicetree/tests/test-bindings-init/compat_desc_base.yaml
+++ b/scripts/dts/python-devicetree/tests/test-bindings-init/compat_desc_base.yaml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-License-Identifier: Apache-2.0
 #
 # Base file for testing inheritance rules applied to
 # compatible strings and bindings descriptions.

--- a/scripts/dts/python-devicetree/tests/test-bindings-init/compat_desc_multi.yaml
+++ b/scripts/dts/python-devicetree/tests/test-bindings-init/compat_desc_multi.yaml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-License-Identifier: Apache-2.0
 #
 # Test consequences of inclusion order on inherited
 # compatible strings and descriptions.

--- a/scripts/dts/python-devicetree/tests/test-bindings-init/diamond.yaml
+++ b/scripts/dts/python-devicetree/tests/test-bindings-init/diamond.yaml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-License-Identifier: Apache-2.0
 #
 # Binding file for testing diamond inheritance (top-bottom).
 #

--- a/scripts/dts/python-devicetree/tests/test-bindings-init/filter_allows_notblocked.yaml
+++ b/scripts/dts/python-devicetree/tests/test-bindings-init/filter_allows_notblocked.yaml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-License-Identifier: Apache-2.0
 #
 # This binding file allows a property which is not blocked
 # in simple_blocklist.yaml: we should end up with this property.

--- a/scripts/dts/python-devicetree/tests/test-bindings-init/filter_among_allowed.yaml
+++ b/scripts/dts/python-devicetree/tests/test-bindings-init/filter_among_allowed.yaml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-License-Identifier: Apache-2.0
 #
 # This binding file allows only properties that are not allowed
 # in simple_allowlist.yaml: we should end up with no property at all.

--- a/scripts/dts/python-devicetree/tests/test-bindings-init/filter_among_notblocked.yaml
+++ b/scripts/dts/python-devicetree/tests/test-bindings-init/filter_among_notblocked.yaml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-License-Identifier: Apache-2.0
 #
 # This binding file blocks all properties not blocked
 # in simple_filter.yaml: we should end up with no property at all.

--- a/scripts/dts/python-devicetree/tests/test-bindings-init/invalid_child_propconst.yaml
+++ b/scripts/dts/python-devicetree/tests/test-bindings-init/invalid_child_propconst.yaml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-License-Identifier: Apache-2.0
 #
 # This binding should not try to override the "const:" value
 # in a property specification inherited from an included file.

--- a/scripts/dts/python-devicetree/tests/test-bindings-init/invalid_child_propdefault.yaml
+++ b/scripts/dts/python-devicetree/tests/test-bindings-init/invalid_child_propdefault.yaml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-License-Identifier: Apache-2.0
 #
 # This binding should not try to override the "default:" value
 # in a property specification inherited from an included file.

--- a/scripts/dts/python-devicetree/tests/test-bindings-init/invalid_child_propenum.yaml
+++ b/scripts/dts/python-devicetree/tests/test-bindings-init/invalid_child_propenum.yaml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-License-Identifier: Apache-2.0
 #
 # This binding should not try to change the "enum:" values
 # in a property specification inherited from an included file.

--- a/scripts/dts/python-devicetree/tests/test-bindings-init/invalid_child_propreq.yaml
+++ b/scripts/dts/python-devicetree/tests/test-bindings-init/invalid_child_propreq.yaml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-License-Identifier: Apache-2.0
 #
 # This binding should not try to override "required: true"
 # in a property specification inherited from an included file.

--- a/scripts/dts/python-devicetree/tests/test-bindings-init/invalid_child_proptype.yaml
+++ b/scripts/dts/python-devicetree/tests/test-bindings-init/invalid_child_proptype.yaml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-License-Identifier: Apache-2.0
 #
 # This binding should not try to override the "type:"
 # of an inherited property.

--- a/scripts/dts/python-devicetree/tests/test-bindings-init/invalid_grandchild_propconst.yaml
+++ b/scripts/dts/python-devicetree/tests/test-bindings-init/invalid_grandchild_propconst.yaml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-License-Identifier: Apache-2.0
 #
 # This binding should not try to override the "const:" value
 # in a property specification inherited from an included file.

--- a/scripts/dts/python-devicetree/tests/test-bindings-init/invalid_grandchild_propdefault.yaml
+++ b/scripts/dts/python-devicetree/tests/test-bindings-init/invalid_grandchild_propdefault.yaml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-License-Identifier: Apache-2.0
 #
 # This binding should not try to override the "default:" value
 # in a property specification inherited from an included file.

--- a/scripts/dts/python-devicetree/tests/test-bindings-init/invalid_grandchild_propenum.yaml
+++ b/scripts/dts/python-devicetree/tests/test-bindings-init/invalid_grandchild_propenum.yaml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-License-Identifier: Apache-2.0
 #
 # This binding should not try to change the "enum:" values
 # in a property specification inherited from an included file.

--- a/scripts/dts/python-devicetree/tests/test-bindings-init/invalid_grandchild_propreq.yaml
+++ b/scripts/dts/python-devicetree/tests/test-bindings-init/invalid_grandchild_propreq.yaml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-License-Identifier: Apache-2.0
 #
 # This binding should not try to override "required: true"
 # in a property specification inherited from an included file.

--- a/scripts/dts/python-devicetree/tests/test-bindings-init/invalid_grandchild_proptype.yaml
+++ b/scripts/dts/python-devicetree/tests/test-bindings-init/invalid_grandchild_proptype.yaml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-License-Identifier: Apache-2.0
 #
 # This binding should not try to override the "type:"
 # of an inherited property.

--- a/scripts/dts/python-devicetree/tests/test-bindings-init/invalid_propconst.yaml
+++ b/scripts/dts/python-devicetree/tests/test-bindings-init/invalid_propconst.yaml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-License-Identifier: Apache-2.0
 #
 # This binding should not try to override the "const:" value
 # in a property specification inherited from an included file.

--- a/scripts/dts/python-devicetree/tests/test-bindings-init/invalid_propdefault.yaml
+++ b/scripts/dts/python-devicetree/tests/test-bindings-init/invalid_propdefault.yaml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-License-Identifier: Apache-2.0
 #
 # This binding should not try to override the "default:" value
 # in a property specification inherited from an included file.

--- a/scripts/dts/python-devicetree/tests/test-bindings-init/invalid_propenum.yaml
+++ b/scripts/dts/python-devicetree/tests/test-bindings-init/invalid_propenum.yaml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-License-Identifier: Apache-2.0
 #
 # This binding should not try to change the "enum:" values
 # in a property specification inherited from an included file.

--- a/scripts/dts/python-devicetree/tests/test-bindings-init/invalid_propreq.yaml
+++ b/scripts/dts/python-devicetree/tests/test-bindings-init/invalid_propreq.yaml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-License-Identifier: Apache-2.0
 #
 # This binding should not try to override "required: true"
 # in a property specification inherited from an included file.

--- a/scripts/dts/python-devicetree/tests/test-bindings-init/invalid_proptype.yaml
+++ b/scripts/dts/python-devicetree/tests/test-bindings-init/invalid_proptype.yaml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-License-Identifier: Apache-2.0
 #
 # This binding should not try to override the "type:"
 # of an inherited property.

--- a/scripts/dts/python-devicetree/tests/test-bindings-init/simple.yaml
+++ b/scripts/dts/python-devicetree/tests/test-bindings-init/simple.yaml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-License-Identifier: Apache-2.0
 #
 # Base properties for testing property filters propagation
 # up to the grandchild-binding level.

--- a/scripts/dts/python-devicetree/tests/test-bindings-init/simple_allowlist.yaml
+++ b/scripts/dts/python-devicetree/tests/test-bindings-init/simple_allowlist.yaml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-License-Identifier: Apache-2.0
 #
 # Filter inherited property specifications
 # up to the grandchild-binding level.

--- a/scripts/dts/python-devicetree/tests/test-bindings-init/simple_blocklist.yaml
+++ b/scripts/dts/python-devicetree/tests/test-bindings-init/simple_blocklist.yaml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-License-Identifier: Apache-2.0
 #
 # Filter inherited property specifications
 # up to the grandchild-binding level.

--- a/scripts/dts/python-devicetree/tests/test-bindings-init/simple_inherit.yaml
+++ b/scripts/dts/python-devicetree/tests/test-bindings-init/simple_inherit.yaml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-License-Identifier: Apache-2.0
 #
 # Inherits property specifications without modification.
 

--- a/scripts/dts/python-devicetree/tests/test-bindings-init/thing.yaml
+++ b/scripts/dts/python-devicetree/tests/test-bindings-init/thing.yaml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-License-Identifier: Apache-2.0
 #
 # Right (included last) YAML file for testing diamond inheritance.
 #

--- a/scripts/dts/python-devicetree/tests/test-bindings-init/vnd,thing.yaml
+++ b/scripts/dts/python-devicetree/tests/test-bindings-init/vnd,thing.yaml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-License-Identifier: Apache-2.0
 #
 # Top level binding file (device binding) for testing
 # descriptions and compatible strings.


### PR DESCRIPTION
Relicense to Apache-2.0 the YAML test files introduced by commit ee5c520.

I didn't touch the test files I' not the author of.  @mbolivar may know why the BSD-3-clause was chosen for ~these~ the other files at this time, and whether relicensing them is possible.

References:
- #79900
- #86577 