### PR TITLE
drivers: gpio: shell: fix warning

### DIFF
--- a/drivers/gpio/gpio_shell.c
+++ b/drivers/gpio/gpio_shell.c
@@ -222,7 +222,7 @@ static int get_sh_gpio(const struct shell *sh, char **argv, struct sh_gpio *gpio
 	return 0;
 }
 
-static int cmd_gpio_conf(const struct shell *sh, size_t argc, char **argv, void *data)
+static int cmd_gpio_conf(const struct shell *sh, size_t argc, char **argv)
 {
 	gpio_flags_t flags = 0;
 	gpio_flags_t vendor_specific;


### PR DESCRIPTION
A warning is generated due to a cast-function-type. Remove the unused arg.

The Warning
```
/zephyr/zephyr/include/zephyr/shell/shell.h:493:14: error: cast between incompatible function types from 'int (*)(const struct shell *, size_t,  char **, void *)' {aka 'int (*)(const struct shell *, unsigned int,  char **, void *)'} to 'int (*)(const struct shell *, size_t,  char **)' {aka 'int (*)(const struct shell *, unsigned int,  char **)'} [-Werror=cast-function-type]
  493 |   .handler = (shell_cmd_handler)((_expr) ? _handler : NULL), \
      |              ^
zephyr/zephyr/include/zephyr/shell/shell.h:326:3: note: in definition of macro 'SHELL_STATIC_SUBCMD_SET_CREATE'
  326 |   __VA_ARGS__      \
      |   ^~~~~~~~~~~
/zephyr/zephyr/include/zephyr/shell/shell.h:442:2: note: in expansion of macro 'SHELL_EXPR_CMD_ARG'
  442 |  SHELL_EXPR_CMD_ARG(1, syntax, subcmd, help, handler, mand, opt)
      |  ^~~~~~~~~~~~~~~~~~
/zephyr/zephyr/drivers/gpio/gpio_shell.c:659:2: note: in expansion of macro 'SHELL_CMD_ARG'
  659 |  SHELL_CMD_ARG(conf, &sub_gpio_dev,
      |  ^~~~~~~~~~~~~
cc1: all warnings being treated as errors
```