### PR TITLE
samples/drivers/mbox: Fix test regex

### DIFF
--- a/samples/drivers/mbox/sample.yaml
+++ b/samples/drivers/mbox/sample.yaml
@@ -5,21 +5,21 @@ common:
   tags: mbox
   timeout: 30
 tests:
-  sample.drivers.mbox.real_hw:
+  sample.drivers.mbox:
     filter: dt_compat_enabled("vnd,mbox-consumer")
     platform_exclude:
       - nrf54h20dk/nrf54h20/cpuapp
       - nrf54h20dk/nrf54h20/cpurad
       - nrf54l15dk/nrf54l15/cpuapp
     integration_platforms:
-      - nrf5340dk/nrf5340/cpuapp
+      - nrf5340bsim/nrf5340/cpuapp
     harness: console
     harness_config:
       type: multi_line
       ordered: false
       regex:
-        - "Pong \\(on channel\\)"
-        - "Ping \\(on channel\\)"
+        - "Pong \\(on channel.*\\)"
+        - "Ping \\(on channel.*\\)"
 
   sample.drivers.mbox.nrf54h20_app_ppr:
     platform_allow:


### PR DESCRIPTION
In 9d7ee123a54a920455322fa42a094c53e45e06d4
the regex used to verify the sample is doing what it should was changed in a way in which it cannot possibly pass.
Let's fix it.

While at it, in the same commit, the simulator version of the test was merged with the real_hw version, but the test name kept "real_hw" which is now misleading => let's fix it.

And let's set as integration platform the simulated target, so it can actually be runtime tested in CI.

To reproduce the issue run
`twister -p nrf5340bsim/nrf5340/cpuapp -T samples/drivers/mbox -s sample.drivers.mbox.real_hw`
and see it timeout