### PR TITLE
Boards: PHYTEC: Add i2c to phyBOARD Pollux

### DIFF
--- a/boards/phytec/phyboard_pollux/doc/index.rst
+++ b/boards/phytec/phyboard_pollux/doc/index.rst
@@ -6,11 +6,11 @@ phyBOARD-Pollux i.MX8M Plus
 Overview
 ********
 
-The phyBOARD-Pollux is based upon the phyCORE-i.MX8M Plus SOM which is based on
+The phyBOARD-Pollux is based upon the phyCORE-i.MX8M Plus SoM which is based on
 the NXP i.MX8M Plus SoC. The SoC includes four Coretex-A53 cores and one
 Coretex-M7 core for real time applications like Zephyr. The phyBOARD-Pollux
-can be used for various applications like SmartHomes, Industry 4.0, IoT etc.
-It features a lots of interfaces and computing capacity. It can be used as
+can be used for various applications like SmartHome, Industry 4.0, IoT etc.
+It features a lot of interfaces and computing capacity. It can be used as
 a reference, to develop or in the final product too.
 
 
@@ -52,7 +52,7 @@ More information about the board can be found at the `PHYTEC website`_.
 Supported Features
 ==================
 
-The Zephyr phyboard_polis board configuration supports the following hardware
+The ``phyboard_pollux/mimx8ml8/m7`` board configuration supports the following hardware
 features:
 
 +-----------+------------+------------------------------------+
@@ -72,6 +72,10 @@ features:
 | GPIO      | on-chip    | GPIO output                        |
 |           |            | GPIO input                         |
 +-----------+------------+------------------------------------+
+| I2C       | on-chip    | ii2c                               |
++-----------+------------+------------------------------------+
+| PCA95533  | I2C        | RGB LED via I2C2                   |
++-----------+------------+------------------------------------+
 
 The default configuration can be found in the defconfig file:
 :zephyr_file:`boards/phytec/phyboard_pollux/phyboard_pollux_mimx8ml8_m7_defconfig`.
@@ -83,7 +87,7 @@ Zephyr on the M7-Core.
 Connections and IOs
 ===================
 
-The following Compontens are tested and working correctly.
+The following components are tested and working correctly.
 
 UART
 ----
@@ -109,6 +113,38 @@ The pinmuxing for the GPIOs is the standard pinmuxing of the mimx8mp devicetree
 created by NXP and can be found at
 :zephyr_file:`dts/arm/nxp/nxp_imx8ml_m7.dtsi`. The Pinout of the phyBOARD-Polis
 can be found at the `PHYTEC website`_.
+
+I2C
+---
+
+There are multiple on-device I2C devices already connected to
+I2C busses.
+Some of these devices should not be used by the M7-Core if
+running the PHYTEC BSP on the A53-Core.
+
+Here is an overview of the on-device I2C devices:
+
++-----------------+-----------------+--------------------+--------------------+
+| I2C Device      | Address         | Usage              | Can be used by M7? |
++=================+=================+====================+====================+
+| PMIC            | 0x25@i2c1       | Power Management   | Should not be used |
++-----------------+-----------------+--------------------+--------------------+
+| EEPROM          | 0x51@i2c1       | EEPROM             | Should not be used |
+| (Atmel 24C32)   |                 | (U-Boot config)    |                    |
++-----------------+-----------------+--------------------+--------------------+
+| RTC (RV3028)    | 0x51@i2c1       | Real Time Clock    | Should not be used |
++-----------------+-----------------+--------------------+--------------------+
+| EEPROM          | 0x51@i2c2       | EEPROM             | yes                |
+| (Atmel 24C02)   |                 | (On carrier-board) |                    |
++-----------------+-----------------+--------------------+--------------------+
+| PCA9553         | 0x62@i2c2       | RGB LED            | yes                |
++-----------------+-----------------+--------------------+--------------------+
+
+.. note::
+  i2c1 is used by the A53-Core to communicate with the PMIC.
+  Because the PMIC is a crucial part of the system, i2c1 should be
+  used by the A53-Core only to avoid conflicts.
+
 
 Programming and Debugging
 *************************

--- a/boards/phytec/phyboard_pollux/phyboard_pollux-pinctrl.dtsi
+++ b/boards/phytec/phyboard_pollux/phyboard_pollux-pinctrl.dtsi
@@ -36,4 +36,52 @@
 			drive-strength = "x1";
 		};
 	};
+
+	i2c1_default: i2c1_default {
+		group0 {
+			pinmux = <&iomuxc_i2c1_scl_i2c_scl_i2c1_scl>,
+				<&iomuxc_i2c1_sda_i2c_sda_i2c1_sda>;
+			bias-pull-up;
+			input-schmitt-enable;
+			slew-rate = "slow";
+			drive-strength = "x4";
+			input-enable;
+		};
+	};
+
+	i2c2_default: i2c2_default {
+		group0 {
+			pinmux = <&iomuxc_i2c2_scl_i2c_scl_i2c2_scl>,
+				<&iomuxc_i2c2_sda_i2c_sda_i2c2_sda>;
+			bias-pull-up;
+			input-schmitt-enable;
+			slew-rate = "slow";
+			drive-strength = "x4";
+			input-enable;
+		};
+	};
+
+	i2c3_default: i2c3_default {
+		group0 {
+			pinmux = <&iomuxc_i2c3_scl_i2c_scl_i2c3_scl>,
+				<&iomuxc_i2c3_sda_i2c_sda_i2c3_sda>;
+			bias-pull-up;
+			input-schmitt-enable;
+			slew-rate = "slow";
+			drive-strength = "x4";
+			input-enable;
+		};
+	};
+
+	i2c4_default: i2c4_default {
+		group0 {
+			pinmux = <&iomuxc_i2c4_scl_i2c_scl_i2c4_scl>,
+				<&iomuxc_i2c4_sda_i2c_sda_i2c4_sda>;
+			bias-pull-up;
+			input-schmitt-enable;
+			slew-rate = "slow";
+			drive-strength = "x4";
+			input-enable;
+		};
+	};
 };

--- a/boards/phytec/phyboard_pollux/phyboard_pollux_mimx8ml8_m7.dts
+++ b/boards/phytec/phyboard_pollux/phyboard_pollux_mimx8ml8_m7.dts
@@ -7,6 +7,7 @@
 /dts-v1/;
 
 #include <nxp/nxp_imx8ml_m7.dtsi>
+#include <zephyr/dt-bindings/i2c/i2c.h>
 #include "phyboard_pollux-pinctrl.dtsi"
 
 / {
@@ -60,6 +61,47 @@
 	status = "okay";
 	current-speed = <115200>;
 	pinctrl-0 = <&uart4_default>;
+	pinctrl-names = "default";
+};
+
+/*
+ * Has PMIC and EEPROM connected to it.
+ * Used by u-boot and Linux.
+ */
+&i2c1 {
+	clock-frequency = <I2C_BITRATE_STANDARD>;
+	pinctrl-0 = <&i2c1_default>;
+	pinctrl-names = "default";
+};
+
+/*
+ * Has PCA9533 I2C expander and a EEPROM connected.
+ * There is no driver for the PCA9533 in zephyr yet.
+ * Accessible via X6(Expansion header) and X10(mini PCIe).
+ */
+&i2c2 {
+	clock-frequency = <I2C_BITRATE_STANDARD>;
+	pinctrl-0 = <&i2c2_default>;
+	pinctrl-names = "default";
+};
+
+/*
+ * Nothing connected.
+ * Accessible via connector X11 (phyCAM-M).
+ */
+&i2c3 {
+	clock-frequency = <I2C_BITRATE_STANDARD>;
+	pinctrl-0 = <&i2c3_default>;
+	pinctrl-names = "default";
+};
+
+/*
+ * Nothing connected.
+ * Accessible via connector X15(A/V), X24(Display) and X21(MIPI-DSI).
+ */
+&i2c4 {
+	clock-frequency = <I2C_BITRATE_STANDARD>;
+	pinctrl-0 = <&i2c4_default>;
 	pinctrl-names = "default";
 };
 

--- a/dts/arm/nxp/nxp_imx8ml_m7.dtsi
+++ b/dts/arm/nxp/nxp_imx8ml_m7.dtsi
@@ -170,6 +170,90 @@
 			status = "disabled";
 		};
 
+		i2c1: i2c@30a20000 {
+			compatible = "nxp,ii2c";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x30a20000 0x10000>;
+			interrupts = <35 0>;
+			clocks = <&ccm IMX_CCM_I2C1_CLK 0 0>;
+			rdc = <(RDC_DOMAIN_PERM(A7_DOMAIN_ID,\
+						RDC_DOMAIN_PERM_RW)|\
+					RDC_DOMAIN_PERM(M7_DOMAIN_ID,\
+						RDC_DOMAIN_PERM_RW))>;
+			status = "disabled";
+		};
+
+		i2c2: i2c@30a30000 {
+			compatible = "nxp,ii2c";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x30a30000 0x10000>;
+			interrupts = <36 0>;
+			clocks = <&ccm IMX_CCM_I2C2_CLK 0 0>;
+			rdc = <(RDC_DOMAIN_PERM(A7_DOMAIN_ID,\
+							RDC_DOMAIN_PERM_RW)|\
+					RDC_DOMAIN_PERM(M7_DOMAIN_ID,\
+							RDC_DOMAIN_PERM_RW))>;
+			status = "disabled";
+		};
+
+		i2c3: i2c@30a40000 {
+			compatible = "nxp,ii2c";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x30a40000 0x10000>;
+			interrupts = <37 0>;
+			clocks = <&ccm IMX_CCM_I2C3_CLK 0 0>;
+			rdc = <(RDC_DOMAIN_PERM(A7_DOMAIN_ID,\
+							RDC_DOMAIN_PERM_RW)|\
+					RDC_DOMAIN_PERM(M7_DOMAIN_ID,\
+							RDC_DOMAIN_PERM_RW))>;
+			status = "disabled";
+		};
+
+		i2c4: i2c@30a50000 {
+			compatible = "nxp,ii2c";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x30a50000 0x10000>;
+			interrupts = <38 0>;
+			clocks = <&ccm IMX_CCM_I2C4_CLK 0 0>;
+			rdc = <(RDC_DOMAIN_PERM(A7_DOMAIN_ID,\
+							RDC_DOMAIN_PERM_RW)|\
+					RDC_DOMAIN_PERM(M7_DOMAIN_ID,\
+							RDC_DOMAIN_PERM_RW))>;
+			status = "disabled";
+		};
+
+		i2c5: i2c@30ad0000 {
+			compatible = "nxp,ii2c";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x30ad0000 0x10000>;
+			interrupts = <76 0>;
+			clocks = <&ccm IMX_CCM_I2C5_CLK 0 0>;
+			rdc = <(RDC_DOMAIN_PERM(A7_DOMAIN_ID,\
+							RDC_DOMAIN_PERM_RW)|\
+					RDC_DOMAIN_PERM(M7_DOMAIN_ID,\
+							RDC_DOMAIN_PERM_RW))>;
+			status = "disabled";
+		};
+
+		i2c6: i2c@30ae0000 {
+			compatible = "nxp,ii2c";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x30ae0000 0x10000>;
+			interrupts = <77 0>;
+			clocks = <&ccm IMX_CCM_I2C6_CLK 0 0>;
+			rdc = <(RDC_DOMAIN_PERM(A7_DOMAIN_ID,\
+							RDC_DOMAIN_PERM_RW)|\
+					RDC_DOMAIN_PERM(M7_DOMAIN_ID,\
+							RDC_DOMAIN_PERM_RW))>;
+			status = "disabled";
+		};
+
 		mailbox0: mailbox@30ab0000 {
 			compatible = "nxp,imx-mu";
 			reg = <0x30ab0000 DT_SIZE_K(64)>;


### PR DESCRIPTION
This PR adds the i2c2 node to phyBOARD Pollux.
In order to do that this PR also adds i2c Devicetree nodes for the
`imx8ml_m7` SoC.

The documentation for phyBOARD Pollux was updated accordingly.
Correct functionality of the i2c interface was tested with i2c2 interface and
a i2c IO-Expander. Communication works correctly. 