### PR TITLE
samples: openamp: filter out esp32 appcpu core

### DIFF
--- a/samples/subsys/ipc/openamp/sample.yaml
+++ b/samples/subsys/ipc/openamp/sample.yaml
@@ -4,6 +4,7 @@ sample:
 tests:
   sample.ipc.openamp:
     filter: dt_chosen_enabled("zephyr,ipc") and dt_chosen_enabled("zephyr,ipc_shm")
+      and not (CONFIG_SOC_ESP32_APPCPU or CONFIG_SOC_ESP32S3_APPCPU)
     integration_platforms:
       - mps2/an521/cpu0
     tags:


### PR DESCRIPTION
ESP32xx appcpu board should only be built with procpu. Stand alone AMP support makes no sense.

This fixes build error in https://github.com/zephyrproject-rtos/zephyr/actions/runs/13809381148/job/38631543548?pr=83710. Issue started after #85997 due to `filter` changes.

