### PR TITLE
misc: Delete main forward declaration in types.h (NEEDS REBASE)

### DIFF
--- a/include/zephyr/types.h
+++ b/include/zephyr/types.h
@@ -48,12 +48,15 @@ typedef union {
 #endif /* Z_THREAD_LOCAL */
 
 #ifdef __cplusplus
-/* Zephyr requires an int main(void) signature with C linkage for the application main if present */
-extern int main(void);
-#endif
-
-#ifdef __cplusplus
 }
+
+/*
+ * Zephyr requires an int main(void) signature with C linkage for the
+ * application main if present. However, main cannot exist inside
+ * extern "C" linkage declarations, as that is forbidden by the C++
+ * standard. See Section 6.9.3.1 of ISO/IEC 14882:2024.
+ */
+extern int main(void);
 #endif
 
 #endif /* ZEPHYR_INCLUDE_ZEPHYR_TYPES_H_ */

--- a/include/zephyr/types.h
+++ b/include/zephyr/types.h
@@ -49,14 +49,6 @@ typedef union {
 
 #ifdef __cplusplus
 }
-
-/*
- * Zephyr requires an int main(void) signature with C linkage for the
- * application main if present. However, main cannot exist inside
- * extern "C" linkage declarations, as that is forbidden by the C++
- * standard. See Section 6.9.3.1 of ISO/IEC 14882:2024.
- */
-extern int main(void);
 #endif
 
 #endif /* ZEPHYR_INCLUDE_ZEPHYR_TYPES_H_ */


### PR DESCRIPTION
This is a Work in Progress, requested by Andy Ross (@andyross).

DELETE EVERYTHING ABOVE THE LINE AND UPDATE THE PR TITLE.
---

As pointed out by Andy Ross (https://github.com/andyross), this
main forward declaration does not make any sense whatsoever.

This commit deletes it as cleanup.

Signed-off-by: Jordan R Abrahams-Whitehead <ajordanr@google.com>