### PR TITLE
boards: linkw: fix west flash with minichlink

### DIFF
--- a/boards/wch/linkw/board.cmake
+++ b/boards/wch/linkw/board.cmake
@@ -1,8 +1,8 @@
 # Copyright (c) 2024 MASSDRIVER EI (massdriver.space)
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(openocd "--use-elf" "--cmd-reset-halt" "halt")
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
-
 board_runner_args(minichlink "--no-reset")
 include(${ZEPHYR_BASE}/boards/common/minichlink.board.cmake)
+
+board_runner_args(openocd "--use-elf" "--cmd-reset-halt" "halt")
+include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)

--- a/boards/wch/linkw/board.cmake
+++ b/boards/wch/linkw/board.cmake
@@ -4,5 +4,5 @@
 board_runner_args(openocd "--use-elf" "--cmd-reset-halt" "halt")
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
 
-board_runner_args(minichlink)
+board_runner_args(minichlink "--no-reset")
 include(${ZEPHYR_BASE}/boards/common/minichlink.board.cmake)


### PR DESCRIPTION
This fixes west flash for this board and should be present for every ch32v208 board.

Dependent on https://github.com/zephyrproject-rtos/zephyr/pull/87138