### PR TITLE
west: runners: Fix minichlink handling of dt_flash

### DIFF
--- a/scripts/west_commands/runners/minichlink.py
+++ b/scripts/west_commands/runners/minichlink.py
@@ -57,7 +57,7 @@ class MiniChLinkBinaryRunner(ZephyrBinaryRunner):
             minichlink=args.minichlink,
             erase=args.erase,
             reset=args.reset,
-            dt_flash=(args.dt_flash == "y"),
+            dt_flash=args.dt_flash,
             terminal=args.terminal,
         )
 


### PR DESCRIPTION
It was treating it as a string while it is a boolean