### PR TITLE
NXP LPSPI: Add support for Peripheral (slave) mode

### DIFF
--- a/boards/nxp/frdm_mcxa156/dts/lpspi1_header.overlay
+++ b/boards/nxp/frdm_mcxa156/dts/lpspi1_header.overlay
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2025 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&lpspi1 {
+	status = "okay";
+	pinctrl-0 = <&pinmux_lpspi1>;
+	pinctrl-names = "default";
+};
+
+&pinctrl {
+	/* J2 pins 12, 10, 8, 6 -> CLK, MISO, MOSI, PCS */
+	pinmux_lpspi1: pinmux_lpspi1 {
+		group0 {
+			pinmux = <LPSPI1_SDO_P2_13>,
+				 <LPSPI1_SCK_P2_12>,
+				 <LPSPI1_SDI_P2_16>,
+				 <LPSPI1_PCS1_P2_6>;
+			slew-rate = "fast";
+			drive-strength = "high";
+			input-enable;
+		};
+	};
+};

--- a/tests/drivers/spi/spi_controller_peripheral/boards/frdm_mcxa156.overlay
+++ b/tests/drivers/spi/spi_controller_peripheral/boards/frdm_mcxa156.overlay
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2025 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <lpspi1_header.overlay>
+
+/ {
+	zephyr,user {
+		peripheral-cs = <1>;
+	};
+};
+
+&lpspi0 {
+	dut_spi_dt: test-spi-dev@0 {
+		compatible = "vnd,spi-device";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+	};
+	transfer-delay = <100>;
+	sck-pcs-delay = <10>;
+	pcs-sck-delay = <10>;
+	/* lower the master interrupt priority so slave can interrupt */
+	interrupts = <28 1>;
+	label = "spi_master";
+};
+
+dut_spis: &lpspi1 {
+	label = "spi_slave";
+};

--- a/tests/drivers/spi/spi_controller_peripheral/src/main.c
+++ b/tests/drivers/spi/spi_controller_peripheral/src/main.c
@@ -28,7 +28,8 @@
 static struct spi_dt_spec spim = SPI_DT_SPEC_GET(DT_NODELABEL(dut_spi_dt), SPIM_OP, 0);
 static const struct device *spis_dev = DEVICE_DT_GET(DT_NODELABEL(dut_spis));
 static const struct spi_config spis_config = {
-	.operation = SPIS_OP
+	.operation = SPIS_OP,
+	.slave = DT_PROP_OR(DT_PATH(zephyr_user), peripheral_cs, 0),
 };
 
 static struct k_poll_signal async_sig = K_POLL_SIGNAL_INITIALIZER(async_sig);


### PR DESCRIPTION
This PR adds support for Peripheral mode into the NXP LPSPI interrupt-based driver.

So far, it is only tested on MCXA156, but this is a great start because due to the small fifo, it is probably the most difficult to enable on.

Fixes #57747