### PR TITLE
samples: task_wdt: Use wdt device if it is ready

### DIFF
--- a/samples/subsys/task_wdt/src/main.c
+++ b/samples/subsys/task_wdt/src/main.c
@@ -67,9 +67,11 @@ int main(void)
 
 	if (!device_is_ready(hw_wdt_dev)) {
 		printk("Hardware watchdog not ready; ignoring it.\n");
+		ret = task_wdt_init(NULL);
+	} else {
+		ret = task_wdt_init(hw_wdt_dev);
 	}
 
-	ret = task_wdt_init(hw_wdt_dev);
 	if (ret != 0) {
 		printk("task wdt init failure: %d\n", ret);
 		return 0;


### PR DESCRIPTION
hw_wdt_dev may not be NULL and the device not be ready to be used. If that is the case we explicitely initialize task_wdt_init with NULL and do not use hw watchdog.