### PR TITLE
soc: nxp: Remove RAMLOADER Kconfig, use DT instead

### DIFF
--- a/soc/nxp/common/Kconfig.rom_loader
+++ b/soc/nxp/common/Kconfig.rom_loader
@@ -1,21 +1,22 @@
 # Copyright 2024 NXP
 # SPDX-License-Identifier: Apache-2.0
 
-config NXP_FLEXSPI_ROM_RAMLOADER
-	bool "Create output image that NXP ROM can load from FlexSPI to ram"
-	select BUILD_OUTPUT_HEX
-	depends on !FLASH_MCUX_FLEXSPI_XIP
-	help
-	  Builds an output image that the BootROM can load from the
-	  FlexSPI boot device into RAM region. The image will be loaded
-	  from FLEXSPI into the region specified by `zephyr,flash` node.
-
-if NXP_FLEXSPI_ROM_RAMLOADER
-
+FLEXSPI_COMPAT := nxp,imx-flexspi
 FLASH_CHOSEN := zephyr,flash
 FLASH_BASE := $(dt_chosen_reg_addr_hex,$(FLASH_CHOSEN))
 FLEXSPI_BASE := $(dt_nodelabel_reg_addr_hex,flexspi,1)
+FLASH_CHOSEN_PATH := $(dt_chosen_path,$(FLASH_CHOSEN))
+FLASH_CHOSEN_PARENT := $(dt_node_parent,$(FLASH_CHOSEN_PATH))
+FLASH_CHOSEN_PARENT_IS_FLEXSPI := $(dt_node_has_compat,$(FLASH_CHOSEN_PARENT),$(FLEXSPI_COMPAT))
+FLEXSPI_PATH := $(dt_nodelabel_path,flexspi)
+FLEXSPI_IS_ENABLED := $(dt_path_enabled,$(FLEXSPI_PATH))
+
+if !$(FLASH_CHOSEN_PARENT_IS_FLEXSPI) && $(FLEXSPI_IS_ENABLED)
+
+config BUILD_OUTPUT_HEX
+	default "y"
+
 config BUILD_OUTPUT_ADJUST_LMA
 	default "$(FLEXSPI_BASE) - $(FLASH_BASE)"
 
-endif # NXP_FLEXSPI_ROM_RAMLOADER
+endif


### PR DESCRIPTION
Previously I added in https://github.com/zephyrproject-rtos/zephyr/pull/5523 the ability to change code location based on DT. Since then the feature has been growing more useful once we found out that there is a ROM feature to load the code to different places on boot. I tried to add a chosen node to describe this boot code location in https://github.com/zephyrproject-rtos/zephyr/pull/55288 but it was rejected by previous DT maintainer. So instead we introduced a Kconfig in https://github.com/zephyrproject-rtos/zephyr/pull/61615 as an alternative to do this feature. This is awkward because now user needs to control both Kconfig and DT changes just to control one feature. Also, that Kconfig is actually under the hood only controlling based on a specific DT nodelabel, which is not apparent especially if there are multiple flexSPI.

This PR is a proposal to impove user experience for NXP RT parts by removing the NXP_FLEXSPI_ROM_RAMLOADER Kconfig and instead only using DT to control this feature, instead of both DT and Kconfig, without introducing a new chosen node.

Basically, the code will be always be loaded to the flexspi flash if the flexspi node is enabled, and otherwise the VMA will always match the LMA. Currently still only works with the same specific nodelabel but at least this is more obvious now. We could change the `flexspi` labelled nodes to `flexspi0` on RT1170 at SOC level and then add the `flexspi` label at board level to either of the flexspi in order to choose which one is the load area, since we can't put a new chosen node.

Here is an example of how to map the old behavior to the new: 
VMA in flexspi space, LMA in flexspi space -> zephyr,flash set to flash chip and flexspi node enabled
VMA in RAM, LMA in RAM -> zephyr,flash set to RAM and flexspi node disabled
VMA in RAM, LMA in flexspi space -> zephyr,flash set to RAM and flexspi node enabled

If people are in support of this change then I will write a documentation page for it and link on the RT board pages.