### PR TITLE
Fix Xilinx UART PS serial driver

### DIFF
--- a/drivers/serial/uart_xlnx_ps.c
+++ b/drivers/serial/uart_xlnx_ps.c
@@ -25,7 +25,6 @@
 #include <zephyr/kernel.h>
 #include <zephyr/arch/cpu.h>
 #include <zephyr/types.h>
-#include <soc.h>
 
 #include <zephyr/init.h>
 #include <zephyr/toolchain.h>

--- a/drivers/serial/uart_xlnx_ps.c
+++ b/drivers/serial/uart_xlnx_ps.c
@@ -254,7 +254,7 @@ static void set_baudrate(const struct device *dev, uint32_t baud_rate)
 			} else {
 				bauderr = tmpbaud - baud;
 			}
-			if (((bauderr * 100) / baud) < 3) {
+			if (((bauderr * 1000) / baud) < 3) {
 				break;
 			}
 		}


### PR DESCRIPTION
This PR fixes the set_baudrate function and its search mechanics when searching for pre-scaler parameters utilised to control the buad rate of the UART device. The stop condition was ill-conditioned. Thus, it was changed from 3 percent to 3 permille error rate on the baud rate. This was tested on an AMD Zynq Ultrascale+ MPSoC (ZU3EG).

Furthermore, an include was removed from the same driver as it seemed redundant. This include tightly couples the device to the SoC. The driver compiles fine without this include. This was tested while compiling the driver for the xenvm board.
