### PR TITLE
portability: cmsis: Reduce control block size by not copying object's name

### DIFF
--- a/include/zephyr/portability/cmsis_types.h
+++ b/include/zephyr/portability/cmsis_types.h
@@ -26,7 +26,6 @@ struct cmsis_rtos_thread_cb {
 	struct k_poll_signal poll_signal;
 	struct k_poll_event poll_event;
 	uint32_t signal_results;
-	char name[CMSIS_OBJ_NAME_MAX_LEN];
 	uint32_t attr_bits;
 };
 

--- a/include/zephyr/portability/cmsis_types.h
+++ b/include/zephyr/portability/cmsis_types.h
@@ -11,9 +11,6 @@
 #include <zephyr/kernel.h>
 #include <zephyr/portability/cmsis_os2.h>
 
-/** @brief Size for names of RTOS objects. */
-#define CMSIS_OBJ_NAME_MAX_LEN 16
-
 /**
  * @brief Control block for a CMSIS-RTOSv2 thread.
  *
@@ -40,7 +37,7 @@ struct cmsis_rtos_timer_cb {
 	osTimerType_t type;
 	uint32_t status;
 	bool is_cb_dynamic_allocation;
-	char name[CMSIS_OBJ_NAME_MAX_LEN];
+	const char *name;
 	void (*callback_function)(void *argument);
 	void *arg;
 };
@@ -54,7 +51,7 @@ struct cmsis_rtos_timer_cb {
 struct cmsis_rtos_mutex_cb {
 	struct k_mutex z_mutex;
 	bool is_cb_dynamic_allocation;
-	char name[CMSIS_OBJ_NAME_MAX_LEN];
+	const char *name;
 	uint32_t state;
 };
 
@@ -67,7 +64,7 @@ struct cmsis_rtos_mutex_cb {
 struct cmsis_rtos_semaphore_cb {
 	struct k_sem z_semaphore;
 	bool is_cb_dynamic_allocation;
-	char name[CMSIS_OBJ_NAME_MAX_LEN];
+	const char *name;
 };
 
 /**
@@ -81,7 +78,7 @@ struct cmsis_rtos_mempool_cb {
 	void *pool;
 	char is_dynamic_allocation;
 	bool is_cb_dynamic_allocation;
-	char name[CMSIS_OBJ_NAME_MAX_LEN];
+	const char *name;
 };
 
 /**
@@ -95,7 +92,7 @@ struct cmsis_rtos_msgq_cb {
 	void *pool;
 	char is_dynamic_allocation;
 	bool is_cb_dynamic_allocation;
-	char name[CMSIS_OBJ_NAME_MAX_LEN];
+	const char *name;
 };
 
 /**
@@ -109,7 +106,7 @@ struct cmsis_rtos_event_cb {
 	struct k_poll_event poll_event;
 	uint32_t signal_results;
 	bool is_cb_dynamic_allocation;
-	char name[CMSIS_OBJ_NAME_MAX_LEN];
+	const char *name;
 };
 
 #endif

--- a/subsys/portability/cmsis_rtos_v2/event_flags.c
+++ b/subsys/portability/cmsis_rtos_v2/event_flags.c
@@ -50,11 +50,7 @@ osEventFlagsId_t osEventFlagsNew(const osEventFlagsAttr_t *attr)
 			  &events->poll_signal);
 	events->signal_results = 0U;
 
-	if (attr->name == NULL) {
-		strncpy(events->name, init_event_flags_attrs.name, sizeof(events->name) - 1);
-	} else {
-		strncpy(events->name, attr->name, sizeof(events->name) - 1);
-	}
+	events->name = (attr->name == NULL) ? init_event_flags_attrs.name : attr->name;
 
 	return (osEventFlagsId_t)events;
 }
@@ -207,16 +203,16 @@ uint32_t osEventFlagsWait(osEventFlagsId_t ef_id, uint32_t flags, uint32_t optio
 
 /**
  * @brief Get name of an Event Flags object.
+ * This function may be called from Interrupt Service Routines.
  */
 const char *osEventFlagsGetName(osEventFlagsId_t ef_id)
 {
 	struct cmsis_rtos_event_cb *events = (struct cmsis_rtos_event_cb *)ef_id;
 
-	if (!k_is_in_isr() && (ef_id != NULL)) {
-		return events->name;
-	} else {
+	if (events == NULL) {
 		return NULL;
 	}
+	return events->name;
 }
 
 /**

--- a/subsys/portability/cmsis_rtos_v2/mempool.c
+++ b/subsys/portability/cmsis_rtos_v2/mempool.c
@@ -84,11 +84,7 @@ osMemoryPoolId_t osMemoryPoolNew(uint32_t block_count, uint32_t block_size,
 		return NULL;
 	}
 
-	if (attr->name == NULL) {
-		strncpy(mslab->name, init_mslab_attrs.name, sizeof(mslab->name) - 1);
-	} else {
-		strncpy(mslab->name, attr->name, sizeof(mslab->name) - 1);
-	}
+	mslab->name = (attr->name == NULL) ? init_mslab_attrs.name : attr->name;
 
 	return (osMemoryPoolId_t)mslab;
 }
@@ -152,16 +148,16 @@ osStatus_t osMemoryPoolFree(osMemoryPoolId_t mp_id, void *block)
 
 /**
  * @brief Get name of a Memory Pool object.
+ * This function may be called from Interrupt Service Routines.
  */
 const char *osMemoryPoolGetName(osMemoryPoolId_t mp_id)
 {
 	struct cmsis_rtos_mempool_cb *mslab = (struct cmsis_rtos_mempool_cb *)mp_id;
 
-	if (!k_is_in_isr() && (mslab != NULL)) {
-		return mslab->name;
-	} else {
+	if (mslab == NULL) {
 		return NULL;
 	}
+	return mslab->name;
 }
 
 /**

--- a/subsys/portability/cmsis_rtos_v2/msgq.c
+++ b/subsys/portability/cmsis_rtos_v2/msgq.c
@@ -79,11 +79,7 @@ osMessageQueueId_t osMessageQueueNew(uint32_t msg_count, uint32_t msg_size,
 
 	k_msgq_init(&msgq->z_msgq, msgq->pool, msg_size, msg_count);
 
-	if (attr->name == NULL) {
-		strncpy(msgq->name, init_msgq_attrs.name, sizeof(msgq->name) - 1);
-	} else {
-		strncpy(msgq->name, attr->name, sizeof(msgq->name) - 1);
-	}
+	msgq->name = (attr->name == NULL) ? init_msgq_attrs.name : attr->name;
 
 	return (osMessageQueueId_t)(msgq);
 }
@@ -222,16 +218,16 @@ uint32_t osMessageQueueGetSpace(osMessageQueueId_t msgq_id)
 
 /**
  * @brief Get name of a Message Queue object.
+ * This function may be called from Interrupt Service Routines.
  */
 const char *osMessageQueueGetName(osMessageQueueId_t msgq_id)
 {
 	struct cmsis_rtos_msgq_cb *msgq = (struct cmsis_rtos_msgq_cb *)msgq_id;
 
-	if (!k_is_in_isr() && (msgq_id != NULL)) {
-		return msgq->name;
-	} else {
+	if (msgq == NULL) {
 		return NULL;
 	}
+	return msgq->name;
 }
 
 /**

--- a/subsys/portability/cmsis_rtos_v2/mutex.c
+++ b/subsys/portability/cmsis_rtos_v2/mutex.c
@@ -51,11 +51,7 @@ osMutexId_t osMutexNew(const osMutexAttr_t *attr)
 	k_mutex_init(&mutex->z_mutex);
 	mutex->state = attr->attr_bits;
 
-	if (attr->name == NULL) {
-		strncpy(mutex->name, init_mutex_attrs.name, sizeof(mutex->name) - 1);
-	} else {
-		strncpy(mutex->name, attr->name, sizeof(mutex->name) - 1);
-	}
+	mutex->name = (attr->name == NULL) ? init_mutex_attrs.name : attr->name;
 
 	return (osMutexId_t)mutex;
 }
@@ -156,13 +152,16 @@ osThreadId_t osMutexGetOwner(osMutexId_t mutex_id)
 	return get_cmsis_thread_id(mutex->z_mutex.owner);
 }
 
+/**
+ * @brief Get name of a mutex.
+ * This function may be called from Interrupt Service Routines.
+ */
 const char *osMutexGetName(osMutexId_t mutex_id)
 {
 	struct cmsis_rtos_mutex_cb *mutex = (struct cmsis_rtos_mutex_cb *)mutex_id;
 
-	if (k_is_in_isr() || (mutex == NULL)) {
+	if (mutex == NULL) {
 		return NULL;
 	}
-
 	return mutex->name;
 }

--- a/subsys/portability/cmsis_rtos_v2/semaphore.c
+++ b/subsys/portability/cmsis_rtos_v2/semaphore.c
@@ -47,11 +47,7 @@ osSemaphoreId_t osSemaphoreNew(uint32_t max_count, uint32_t initial_count,
 
 	k_sem_init(&semaphore->z_semaphore, initial_count, max_count);
 
-	if (attr->name == NULL) {
-		strncpy(semaphore->name, init_sema_attrs.name, sizeof(semaphore->name) - 1);
-	} else {
-		strncpy(semaphore->name, attr->name, sizeof(semaphore->name) - 1);
-	}
+	semaphore->name = (attr->name == NULL) ? init_sema_attrs.name : attr->name;
 
 	return (osSemaphoreId_t)semaphore;
 }
@@ -148,13 +144,16 @@ osStatus_t osSemaphoreDelete(osSemaphoreId_t semaphore_id)
 	return osOK;
 }
 
+/**
+ * @brief Get name of a semaphore.
+ * This function may be called from Interrupt Service Routines.
+ */
 const char *osSemaphoreGetName(osSemaphoreId_t semaphore_id)
 {
 	struct cmsis_rtos_semaphore_cb *semaphore = (struct cmsis_rtos_semaphore_cb *)semaphore_id;
 
-	if (!k_is_in_isr() && (semaphore_id != NULL)) {
-		return semaphore->name;
-	} else {
+	if (semaphore == NULL) {
 		return NULL;
 	}
+	return semaphore->name;
 }

--- a/subsys/portability/cmsis_rtos_v2/thread.c
+++ b/subsys/portability/cmsis_rtos_v2/thread.c
@@ -192,37 +192,24 @@ osThreadId_t osThreadNew(osThreadFunc_t threadfunc, void *arg, const osThreadAtt
 	(void)k_thread_create(&tid->z_thread, stack, stack_size, zephyr_thread_wrapper, (void *)arg,
 			      NULL, threadfunc, prio, 0, K_NO_WAIT);
 
-	if (attr->name == NULL) {
-		strncpy(tid->name, init_thread_attrs.name, sizeof(tid->name) - 1);
-	} else {
-		strncpy(tid->name, attr->name, sizeof(tid->name) - 1);
-	}
-
-	k_thread_name_set(&tid->z_thread, tid->name);
+	const char *name = (attr->name == NULL) ? init_thread_attrs.name : attr->name;
+	k_thread_name_set(&tid->z_thread, name);
 
 	return (osThreadId_t)tid;
 }
 
 /**
  * @brief Get name of a thread.
+ * This function may be called from Interrupt Service Routines.
  */
 const char *osThreadGetName(osThreadId_t thread_id)
 {
-	const char *name = NULL;
+	struct cmsis_rtos_thread_cb *tid = (struct cmsis_rtos_thread_cb *)thread_id;
 
-	if (k_is_in_isr() || (thread_id == NULL)) {
-		name = NULL;
-	} else {
-		if (is_cmsis_rtos_v2_thread(thread_id) == NULL) {
-			name = NULL;
-		} else {
-			struct cmsis_rtos_thread_cb *tid = (struct cmsis_rtos_thread_cb *)thread_id;
-
-			name = k_thread_name_get(&tid->z_thread);
-		}
+	if (tid == NULL) {
+		return NULL;
 	}
-
-	return name;
+	return k_thread_name_get(&tid->z_thread);
 }
 
 /**

--- a/subsys/portability/cmsis_rtos_v2/timer.c
+++ b/subsys/portability/cmsis_rtos_v2/timer.c
@@ -67,11 +67,7 @@ osTimerId_t osTimerNew(osTimerFunc_t func, osTimerType_t type, void *argument,
 
 	k_timer_init(&timer->z_timer, zephyr_timer_wrapper, NULL);
 
-	if (attr->name == NULL) {
-		strncpy(timer->name, init_timer_attrs.name, sizeof(timer->name) - 1);
-	} else {
-		strncpy(timer->name, attr->name, sizeof(timer->name) - 1);
-	}
+	timer->name = (attr->name == NULL) ? init_timer_attrs.name : attr->name;
 
 	return (osTimerId_t)timer;
 }
@@ -153,15 +149,15 @@ osStatus_t osTimerDelete(osTimerId_t timer_id)
 
 /**
  * @brief Get name of a timer.
+ * This function may be called from Interrupt Service Routines.
  */
 const char *osTimerGetName(osTimerId_t timer_id)
 {
 	struct cmsis_rtos_timer_cb *timer = (struct cmsis_rtos_timer_cb *)timer_id;
 
-	if (k_is_in_isr() || (timer == NULL)) {
+	if (timer == NULL) {
 		return NULL;
 	}
-
 	return timer->name;
 }
 


### PR DESCRIPTION
## Description

All CMSIS-RTOSv2 objects can have a human-readable name to aid in debugging. However, copying the name string instead of storing a pointer to it bloats up the size of control block, and is not needed.

Changes:
* Defer thread name implementation onto Zephyr Thread API [`k_thread_name_set/get()`](https://docs.zephyrproject.org/apidoc/latest/group__thread__apis.html#gadebf45da56dee393164569742459dc0a).
* Allow all `os***GetName()` to work from ISRs, as expected by [CMSIS-RTOSv2 spec](https://arm-software.github.io/CMSIS_6/main/RTOS2/group__CMSIS__RTOS__ThreadMgmt.html#gac3230f3a55a297514b013ebf38f27e0a).
*  For all other objects, store thread name as a pointer passed by initialization attributes.

After this PR, the test application `tests/subsys/portability/cmsis_rtos_v2` takes up 144 less bytes of flash and 956 less bytes of RAM.

## Test Plan

* All tests pass locally when running with `west build tests/subsys/portability/cmsis_rtos_v2 --board=nrf52dk/nrf52832 --pristine && west flash`