### PR TITLE
dts: bindings: stepper remove property-allowlist from step-dir drivers

### DIFF
--- a/drivers/stepper/step_dir/step_dir_stepper_common.c
+++ b/drivers/stepper/step_dir/step_dir_stepper_common.c
@@ -16,10 +16,10 @@ static inline int step_dir_stepper_perform_step(const struct device *dev)
 
 	switch (data->direction) {
 	case STEPPER_DIRECTION_POSITIVE:
-		ret = gpio_pin_set_dt(&config->dir_pin, 1);
+		ret = gpio_pin_set_dt(&config->dir_pin, 1 ^ config->invert_direction);
 		break;
 	case STEPPER_DIRECTION_NEGATIVE:
-		ret = gpio_pin_set_dt(&config->dir_pin, 0);
+		ret = gpio_pin_set_dt(&config->dir_pin, 0 ^ config->invert_direction);
 		break;
 	default:
 		LOG_ERR("Unsupported direction: %d", data->direction);

--- a/drivers/stepper/step_dir/step_dir_stepper_common.h
+++ b/drivers/stepper/step_dir/step_dir_stepper_common.h
@@ -32,6 +32,7 @@ struct step_dir_stepper_common_config {
 	bool dual_edge;
 	const struct stepper_timing_source_api *timing_source;
 	const struct device *counter;
+	bool invert_direction;
 };
 
 /**
@@ -47,6 +48,7 @@ struct step_dir_stepper_common_config {
 		.dir_pin = GPIO_DT_SPEC_GET(node_id, dir_gpios),                                   \
 		.dual_edge = DT_PROP_OR(node_id, dual_edge_step, false),                           \
 		.counter = DEVICE_DT_GET_OR_NULL(DT_PHANDLE(node_id, counter)),                    \
+		.invert_direction = DT_PROP(node_id, invert_direction),                            \
 		.timing_source = COND_CODE_1(DT_NODE_HAS_PROP(node_id, counter),                   \
 						(&step_counter_timing_source_api),                 \
 						(&step_work_timing_source_api)),                   \

--- a/dts/bindings/stepper/adi/adi,tmc2209.yaml
+++ b/dts/bindings/stepper/adi/adi,tmc2209.yaml
@@ -19,12 +19,6 @@ compatible: "adi,tmc2209"
 
 include:
   - name: stepper-controller.yaml
-    property-allowlist:
-      - micro-step-res
-      - step-gpios
-      - dir-gpios
-      - en-gpios
-      - counter
 
 properties:
   msx-gpios:

--- a/dts/bindings/stepper/allegro/allegro,a4979.yml
+++ b/dts/bindings/stepper/allegro/allegro,a4979.yml
@@ -25,12 +25,6 @@ compatible: "allegro,a4979"
 
 include:
   - name: stepper-controller.yaml
-    property-allowlist:
-      - micro-step-res
-      - step-gpios
-      - dir-gpios
-      - en-gpios
-      - counter
 
 properties:
   m0-gpios:

--- a/dts/bindings/stepper/ti/ti,drv8424.yaml
+++ b/dts/bindings/stepper/ti/ti,drv8424.yaml
@@ -29,12 +29,6 @@ compatible: "ti,drv8424"
 
 include:
   - name: stepper-controller.yaml
-    property-allowlist:
-      - micro-step-res
-      - step-gpios
-      - dir-gpios
-      - en-gpios
-      - counter
 
 properties:
   fault-gpios:


### PR DESCRIPTION
remove property-allowlist and introduce invert-direction in step-dir-common