### PR TITLE
Fix domain check

### DIFF
--- a/samples/subsys/ipc/ipc_service/static_vrings/CMakeLists.txt
+++ b/samples/subsys/ipc/ipc_service/static_vrings/CMakeLists.txt
@@ -9,7 +9,9 @@ cmake_minimum_required(VERSION 3.20.0)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
+if(CONFIG_INCLUDE_REMOTE_DIR)
 set(REMOTE_ZEPHYR_DIR ${CMAKE_CURRENT_BINARY_DIR}/../remote/zephyr)
+endif()
 
 if(NOT (CONFIG_BOARD_NRF5340DK_NRF5340_CPUAPP OR
         CONFIG_BOARD_NRF5340BSIM_NRF5340_CPUAPP OR
@@ -20,8 +22,9 @@ if(NOT (CONFIG_BOARD_NRF5340DK_NRF5340_CPUAPP OR
         CONFIG_BOARD_MIMXRT1180_EVK_MIMXRT1189_CM33
        )
   )
-  message(FATAL_ERROR "${BOARD} is not supported for this sample")
+  message("${BOARD} is not supported for this sample")
 endif()
+
 
 project(ipc_service)
 

--- a/samples/subsys/ipc/ipc_service/static_vrings/sample.yaml
+++ b/samples/subsys/ipc/ipc_service/static_vrings/sample.yaml
@@ -2,7 +2,8 @@ sample:
   name: IPC Service example integration (OpenAMP static_vrings backend)
 tests:
   sample.ipc.static_vrings:
-    filter: dt_compat_enabled("zephyr,ipc-openamp-static-vrings")
+    filter: dt_compat_enabled("zephyr,ipc-openamp-static-vrings") and
+            dt_nodelabel_enabled("ipc0") and dt_nodelabel_enabled("ipc1")
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp
       - nrf5340bsim/nrf5340/cpuapp

--- a/samples/subsys/ipc/ipc_service/static_vrings/sysbuild.cmake
+++ b/samples/subsys/ipc/ipc_service/static_vrings/sysbuild.cmake
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 if("${SB_CONFIG_NET_CORE_BOARD}" STREQUAL "")
-	message(FATAL_ERROR
+	message(
 	"Target ${BOARD} not supported for this sample. "
 	"There is no remote board selected in Kconfig.sysbuild")
 endif()

--- a/samples/subsys/ipc/openamp/remote/sample.yaml
+++ b/samples/subsys/ipc/openamp/remote/sample.yaml
@@ -3,9 +3,7 @@ sample:
   name: OpenAMP example integration (remote)
 tests:
   sample.ipc.openamp.remote:
-    platform_allow:
-      - lpcxpresso54114/lpc54114/m0
-      - lpcxpresso55s69/lpc55s69/cpu1
+    filter: dt_chosen_enabled("zephyr,ipc") and dt_chosen_enabled("zephyr,ipc_shm")
     integration_platforms:
       - lpcxpresso54114/lpc54114/m0
     tags: ipm

--- a/samples/subsys/ipc/openamp/sample.yaml
+++ b/samples/subsys/ipc/openamp/sample.yaml
@@ -4,6 +4,7 @@ sample:
 tests:
   sample.ipc.openamp:
     filter: dt_chosen_enabled("zephyr,ipc") and dt_chosen_enabled("zephyr,ipc_shm")
+      and not (CONFIG_SOC_ESP32_APPCPU or CONFIG_SOC_ESP32S3_APPCPU)
     integration_platforms:
       - mps2/an521/cpu0
     tags:

--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -1351,7 +1351,7 @@ class ProjectBuilder(FilterBuilder):
         files_to_keep = self._get_binaries()
         files_to_keep.append(os.path.join('zephyr', 'runners.yaml'))
 
-        if self.instance.sysbuild:
+        if self.instance.sysbuild and self.instance.domains:
             files_to_keep.append('domains.yaml')
             for domain in self.instance.domains.get_domains():
                 files_to_keep += self._get_artifact_allow_list_for_domain(domain.name)
@@ -1391,7 +1391,7 @@ class ProjectBuilder(FilterBuilder):
         # Get binaries for a single-domain build
         binaries += self._get_binaries_from_runners()
         # Get binaries in the case of a multiple-domain build
-        if self.instance.sysbuild:
+        if self.instance.sysbuild and self.instance.domains:
             for domain in self.instance.domains.get_domains():
                 binaries += self._get_binaries_from_runners(domain.name)
 


### PR DESCRIPTION
for platforms that has the ipc feature, but does not configured for application like samples/subsys/ipc/openamp, the build will be filtered out. but if we enable the --prep-artifacts-for-testing, we need add protection to check the domains, as at this time it could be NULL.

fixes: #87163