### PR TITLE
soc: neorv32: list NEORV32 v1.11.2 as currently supported version

### DIFF
--- a/boards/others/neorv32/doc/index.rst
+++ b/boards/others/neorv32/doc/index.rst
@@ -13,7 +13,7 @@ For more information about the NEORV32, see the following websites:
 - `The NEORV32 RISC-V Processor Datasheet`_
 - `The NEORV32 RISC-V Processor User Guide`_
 
-The currently supported version is NEORV32 v1.11.1.
+The currently supported version is NEORV32 v1.11.2.
 
 Supported Features
 ==================

--- a/soc/neorv32/Kconfig
+++ b/soc/neorv32/Kconfig
@@ -13,7 +13,7 @@ if SOC_NEORV32
 
 config SOC_NEORV32_VERSION
 	hex
-	default 0x01110100
+	default 0x01110200
 	help
 	  The targeted NEORV32 version as BCD-coded number. The format is
 	  identical to that of the NEORV32 Machine implementation ID (mimpid)


### PR DESCRIPTION
List NEORV32 v1.11.2 as the currently supported version. No changes to the in-tree drivers needed for the changes between v1.11.1 and v1.11.2, but NEORV32 v1.11.2 contains several bug fixes to the RTL.