### PR TITLE
drivers: display: sdl: fixes for clear display function

### DIFF
--- a/drivers/display/display_sdl.c
+++ b/drivers/display/display_sdl.c
@@ -459,7 +459,8 @@ static int sdl_display_clear(const struct device *dev)
 		size = config->width * config->height * 2U;
 		break;
 	default:
-		LOG_ERR("Pixel format not supported");
+		__ASSERT_MSG_INFO("Pixel format not supported");
+		return -EINVAL;
 	}
 	LOG_DBG("size: %zu, bgcolor: %hhu", size, bgcolor);
 	memset(disp_data->buf, bgcolor, size);


### PR DESCRIPTION
Clear display only when display pixel format is actually supported since buffer size depends on it.