### PR TITLE
drivers: display: Fix variable not initialized warning

### DIFF
--- a/drivers/display/display_sdl.c
+++ b/drivers/display/display_sdl.c
@@ -460,6 +460,7 @@ static int sdl_display_clear(const struct device *dev)
 		break;
 	default:
 		LOG_ERR("Pixel format not supported");
+		return -ENOTSUP;
 	}
 	LOG_DBG("size: %zu, bgcolor: %hhu", size, bgcolor);
 	memset(disp_data->buf, bgcolor, size);


### PR DESCRIPTION
The `size` value in `sdl_display_clear` is used without initializing when an unknown pixel format is assigned.
Returning with -ENOTSUP error explicitly to suppress the warning.