### PR TITLE
tests: driver: spi: spi_loopback: Enable nocache memory on mimxrt700_evk cm33 cpu0 core

### DIFF
--- a/tests/drivers/spi/spi_loopback/boards/mimxrt700_evk_mimxrt798s_cm33_cpu0.conf
+++ b/tests/drivers/spi/spi_loopback/boards/mimxrt700_evk_mimxrt798s_cm33_cpu0.conf
@@ -1,0 +1,6 @@
+#
+# Copyright 2025 NXP
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+CONFIG_NOCACHE_MEMORY=y


### PR DESCRIPTION
Enable nocache memory on mimxrt700_evk cm33 cpu0 core