### PR TITLE
Bluetooth: conn: Make bt_conn_lookup_addr_br() public

### DIFF
--- a/doc/releases/release-notes-4.2.rst
+++ b/doc/releases/release-notes-4.2.rst
@@ -91,6 +91,7 @@ New APIs and options
     * :c:func:`bt_le_get_local_features`
     * :c:func:`bt_le_bond_exists`
     * :c:func:`bt_br_bond_exists`
+    * :c:func:`bt_conn_lookup_addr_br`
 
 * Display
 

--- a/include/zephyr/bluetooth/conn.h
+++ b/include/zephyr/bluetooth/conn.h
@@ -2618,6 +2618,19 @@ struct bt_br_conn_param {
 struct bt_conn *bt_conn_create_br(const bt_addr_t *peer,
 				  const struct bt_br_conn_param *param);
 
+/** @brief Look up an existing BR connection by address.
+ *
+ *  Look up an existing BR connection based on the remote address.
+ *
+ *  The caller gets a new reference to the connection object which must be
+ *  released with bt_conn_unref() once done using the object.
+ *
+ *  @param peer Remote address.
+ *
+ *  @return Connection object or NULL if not found.
+ */
+struct bt_conn *bt_conn_lookup_addr_br(const bt_addr_t *peer);
+
 #ifdef __cplusplus
 }
 #endif

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -2390,6 +2390,11 @@ struct bt_conn *bt_conn_lookup_addr_br(const bt_addr_t *peer)
 {
 	int i;
 
+	if (peer == NULL) {
+		LOG_DBG("Invalid peer address");
+		return NULL;
+	}
+
 	for (i = 0; i < ARRAY_SIZE(acl_conns); i++) {
 		struct bt_conn *conn = bt_conn_ref(&acl_conns[i]);
 

--- a/subsys/bluetooth/host/conn_internal.h
+++ b/subsys/bluetooth/host/conn_internal.h
@@ -423,9 +423,6 @@ void bt_sco_cleanup(struct bt_conn *sco_conn);
 /* Look up an existing sco connection by BT address */
 struct bt_conn *bt_conn_lookup_addr_sco(const bt_addr_t *peer);
 
-/* Look up an existing connection by BT address */
-struct bt_conn *bt_conn_lookup_addr_br(const bt_addr_t *peer);
-
 void bt_conn_disconnect_all(uint8_t id);
 
 /* Allocate new connection object */


### PR DESCRIPTION
Move the declaration of the function `bt_conn_lookup_addr_br()` from `conn_internal.h` to `conn.h`.