### PR TITLE
subsys/bluetooth att: Fix build warning with clang

### DIFF
--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -729,7 +729,7 @@ static struct net_buf *bt_att_chan_create_pdu(struct bt_att_chan *chan, uint8_t 
 		/* Use a timeout only when responding/confirming */
 		timeout = BT_ATT_TIMEOUT;
 		break;
-	default:
+	default: {
 		k_tid_t current_thread = k_current_get();
 
 		if (current_thread == k_work_queue_thread_get(&k_sys_work_q)) {
@@ -741,6 +741,7 @@ static struct net_buf *bt_att_chan_create_pdu(struct bt_att_chan *chan, uint8_t 
 		} else {
 			timeout = K_FOREVER;
 		}
+	}
 	}
 
 	/* This will reserve headspace for lower layers */


### PR DESCRIPTION
Fix the following warning
```
att.c:734:3: warning: label followed by a declaration is a C23 extension [-Wc23-extensions]
  734 |                 k_tid_t current_thread = k_current_get();
      |                 ^
```
By wrapping that code as a compound statement