### PR TITLE
doc: boards: renesas:  fix Sphinx directive typo

### DIFF
--- a/boards/renesas/rzn2l_rsk/doc/index.rst
+++ b/boards/renesas/rzn2l_rsk/doc/index.rst
@@ -52,7 +52,7 @@ Detailed hardware features for the board can be found at `RZ/N2L-RSK Website`_
 Supported Features
 ==================
 
-.. zephyr: board-supported-hw::
+.. zephyr:board-supported-hw::
 
 Connections and IOs
 ===================

--- a/boards/renesas/rzt2l_rsk/doc/index.rst
+++ b/boards/renesas/rzt2l_rsk/doc/index.rst
@@ -50,7 +50,7 @@ Detailed hardware features for the board can be found at `RZ/T2L-RSK Website`_
 Supported Features
 ==================
 
-.. zephyr: board-supported-hw::
+.. zephyr:board-supported-hw::
 
 Connections and IOs
 ===================


### PR DESCRIPTION
Remove a stray space in zephyr:board-supported-hw Sphinx directive