### PR TITLE
Bluetooth: A2DP: Add a parameter of the connected function.

### DIFF
--- a/include/zephyr/bluetooth/classic/a2dp.h
+++ b/include/zephyr/bluetooth/classic/a2dp.h
@@ -402,10 +402,11 @@ struct bt_a2dp_cb {
 	 *  In case the err parameter is non-zero it means that the
 	 *  connection establishment failed.
 	 *
+	 *  @param conn pointer to bt_conn structure.
 	 *  @param a2dp a2dp connection object.
 	 *  @param err error code.
 	 */
-	void (*connected)(struct bt_a2dp *a2dp, int err);
+	void (*connected)(struct bt_conn *conn, struct bt_a2dp *a2dp, int err);
 	/** @brief A a2dp connection has been disconnected.
 	 *
 	 *  This callback notifies the application that a a2dp connection

--- a/subsys/bluetooth/host/classic/a2dp.c
+++ b/subsys/bluetooth/host/classic/a2dp.c
@@ -94,7 +94,7 @@ static void a2dp_connected(struct bt_avdtp *session)
 	a2dp->a2dp_state = INTERNAL_STATE_AVDTP_CONNECTED;
 	/* notify a2dp app the connection. */
 	if ((a2dp_cb != NULL) && (a2dp_cb->connected != NULL)) {
-		a2dp_cb->connected(a2dp, 0);
+		a2dp_cb->connected(session->br_chan.chan.conn, a2dp, 0);
 	}
 }
 

--- a/subsys/bluetooth/host/classic/shell/a2dp.c
+++ b/subsys/bluetooth/host/classic/shell/a2dp.c
@@ -287,7 +287,7 @@ static void shell_a2dp_print_capabilities(struct bt_a2dp_ep_info *ep_info)
 	}
 }
 
-void app_connected(struct bt_a2dp *a2dp, int err)
+void app_connected(struct bt_conn *conn, struct bt_a2dp *a2dp, int err)
 {
 	if (!err) {
 		default_a2dp = a2dp;


### PR DESCRIPTION
If an A2DP SRC application is connected to two headphones, the current protocol stack's A2DP interface cannot differentiate between the two headphones. Adding a 'conn' pointer in the AVDTP signaling connected callback function can make it easier to identify the current A2DP communication peer device.