### PR TITLE
doc: lilygo: adopt zephyr:board-supported-hw directive

### DIFF
--- a/boards/lilygo/ttgo_lora32/doc/index.rst
+++ b/boards/lilygo/ttgo_lora32/doc/index.rst
@@ -15,39 +15,13 @@ It's available in two versions supporting two different frequency ranges and fea
 
 Some of the ESP32 I/O pins are accessible on the board's pin headers.
 
-Functional Description
-**********************
+Hardware
+********
 
-The following table below describes the key components, interfaces, and controls
-of the Lilygo TTGO LoRa32 board.
+Supported Features
+==================
 
-.. _SX127x: https://www.semtech.com/products/wireless-rf/lora-connect/sx1276#documentation
-.. _ESP32-PICO-D4: https://www.espressif.com/sites/default/files/documentation/esp32-pico-d4_datasheet_en.pdf
-.. _SSD1306: https://cdn-shop.adafruit.com/datasheets/SSD1306.pdf
-
-+------------------+-------------------------------------------------------------------------+
-| Key Component    | Description                                                             |
-+==================+=========================================================================+
-| ESP32-PICO-D4    | This `ESP32-PICO-D4`_ module provides complete Wi-Fi and Bluetooth      |
-|                  | functionalities and integrates a 4-MB SPI flash.                        |
-+------------------+-------------------------------------------------------------------------+
-| Diagnostic LED   | One user LED connected to the GPIO pin.                                 |
-+------------------+-------------------------------------------------------------------------+
-| USB Port         | USB interface. Power supply for the board as well as the                |
-|                  | serial communication interface between a computer and the board.        |
-|                  | Micro-USB type connector.                                               |
-+------------------+-------------------------------------------------------------------------+
-| Power Switch     | Sliding power switch.                                                   |
-+------------------+-------------------------------------------------------------------------+
-| OLED display     | Built-in OLED display \(`SSD1306`_, 0.96", 128x64 px\) controlled       |
-|                  | by I2C interface                                                        |
-+------------------+-------------------------------------------------------------------------+
-| SX1276/SX1278    | LoRa radio frontend chip, connected via SPI.                            |
-|                  | Use SX1276 for 433MHz and SX1276 for 868/915/923MHz.                    |
-+------------------+-------------------------------------------------------------------------+
-| TF card slot     | TF card slot wired to the SDHC interface of the MCU.                    |
-+------------------+-------------------------------------------------------------------------+
-
+.. zephyr:board-supported-hw::
 
 Start Application Development
 *****************************
@@ -61,7 +35,7 @@ System requirements
 Prerequisites
 =============
 
-Espressif HAL requires WiFi and Bluetooth binary blobs in order work. Run the command
+Espressif HAL requires WiFi and Bluetooth binary blobs in order to work. Run the command
 below to retrieve those files.
 
 .. code-block:: console
@@ -78,7 +52,7 @@ Building & Flashing
 Simple boot
 ===========
 
-The board could be loaded using the single binary image, without 2nd stage bootloader.
+The board could be loaded using a single binary image, without 2nd stage bootloader.
 It is the default option when building the application without additional configuration.
 
 .. note::
@@ -108,7 +82,7 @@ There are two options to be used when building an application:
 Sysbuild
 ========
 
-The sysbuild makes possible to build and flash all necessary images needed to
+The sysbuild makes it possible to build and flash all necessary images needed to
 bootstrap the board with the ESP32-PICO-D4 SoC.
 
 To build the sample application using sysbuild use the command:
@@ -193,7 +167,7 @@ message in the monitor:
 .. code-block:: console
 
    ***** Booting Zephyr OS vx.x.x-xxx-gxxxxxxxxxxxx *****
-   Hello World! ttgo_lora32
+   Hello World! ttgo_lora32/esp32/procpu
 
 Code samples
 ============
@@ -218,3 +192,5 @@ Related Documents
 - `ESP32-PICO-D4 Datasheet <https://www.espressif.com/sites/default/files/documentation/esp32-pico-d4_datasheet_en.pdf>`_ (PDF)
 - `ESP32 Datasheet <https://www.espressif.com/sites/default/files/documentation/esp32_datasheet_en.pdf>`_ (PDF)
 - `ESP32 Hardware Reference <https://docs.espressif.com/projects/esp-idf/en/latest/esp32/hw-reference/index.html>`_
+- `SX127x Datasheet <https://www.semtech.com/products/wireless-rf/lora-connect/sx1276#documentation>`_
+- `SSD1306 Datasheet <https://cdn-shop.adafruit.com/datasheets/SSD1306.pdf>`_ (PDF)

--- a/boards/lilygo/ttgo_t7v1_5/doc/index.rst
+++ b/boards/lilygo/ttgo_t7v1_5/doc/index.rst
@@ -13,38 +13,17 @@ It features the following integrated components:
 - JST GH 2-pin battery connector
 - LED
 
-Functional Description
-**********************
+Hardware
+********
+
 This board is based on the ESP32-WROVER-E module with 4MB of flash (there
 are models 16MB as well), WiFi and BLE support. It has a Micro-USB port for
 programming and debugging, integrated battery charging and an on-board antenna.
 
-Connections and IOs
-===================
+Supported Features
+==================
 
-The ``ttgo_t7v1_5/esp32/procpu`` board target supports the following hardware features:
-
-+-----------+------------+------------------+
-| Interface | Controller | Driver/Component |
-+===========+============+==================+
-| CPU       | ESP32      | arch/xtensa      |
-+-----------+------------+------------------+
-| GPIO      | on-chip    | gpio_esp32       |
-+-----------+------------+------------------+
-| UART      | on-chip    | uart_esp32       |
-+-----------+------------+------------------+
-| I2C       | on-chip    | i2c_esp32        |
-+-----------+------------+------------------+
-| SPI       | on-chip    | spi_esp32_spim   |
-+-----------+------------+------------------+
-| LoRa      | SX1276     | lora_sx127x      |
-+-----------+------------+------------------+
-| WiFi      | on-chip    | wifi_esp32       |
-+-----------+------------+------------------+
-| BLE       | on-chip    | bluetooth_esp32  |
-+-----------+------------+------------------+
-| Flash     | on-chip    | flash_esp32      |
-+-----------+------------+------------------+
+.. zephyr:board-supported-hw::
 
 System requirements
 *******************
@@ -52,7 +31,7 @@ System requirements
 Prerequisites
 =============
 
-Espressif HAL requires WiFi and Bluetooth binary blobs in order work. Run the command
+Espressif HAL requires WiFi and Bluetooth binary blobs in order to work. Run the command
 below to retrieve those files.
 
 .. code-block:: console
@@ -69,7 +48,7 @@ Building & Flashing
 Simple boot
 ===========
 
-The board could be loaded using the single binary image, without 2nd stage bootloader.
+The board could be loaded using a single binary image, without 2nd stage bootloader.
 It is the default option when building the application without additional configuration.
 
 .. note::
@@ -80,7 +59,7 @@ MCUboot bootloader
 ==================
 
 User may choose to use MCUboot bootloader instead. In that case the bootloader
-must be build (and flash) at least once.
+must be built (and flashed) at least once.
 
 There are two options to be used when building an application:
 
@@ -92,14 +71,14 @@ There are two options to be used when building an application:
    User can select the MCUboot bootloader by adding the following line
    to the board default configuration file.
 
-   .. code:: cfg
+   .. code-block:: cfg
 
       CONFIG_BOOTLOADER_MCUBOOT=y
 
 Sysbuild
 ========
 
-The sysbuild makes possible to build and flash all necessary images needed to
+The sysbuild makes it possible to build and flash all necessary images needed to
 bootstrap the board with the ESP32 SoC.
 
 To build the sample application using sysbuild use the command:
@@ -142,7 +121,7 @@ Manual build
 ============
 
 During the development cycle, it is intended to build & flash as quickly possible.
-For that reason, images can be build one at a time using traditional build.
+For that reason, images can be built one at a time using traditional build.
 
 The instructions following are relevant for both manual build and sysbuild.
 The only difference is the structure of the build directory.

--- a/boards/lilygo/ttgo_t8c3/doc/index.rst
+++ b/boards/lilygo/ttgo_t8c3/doc/index.rst
@@ -14,39 +14,18 @@ It features the following integrated components:
 - JST GH 2-pin battery connector
 - LED
 
-Functional Description
-**********************
+Hardware
+********
+
 This board is based on the ESP32-C3 with 4MB of flash, WiFi and BLE support. It
 has an USB-C port for programming and debugging, integrated battery charging
 and an on-board antenna. The fitted U.FL external antenna connector can be
 enabled by moving a 0-ohm resistor.
 
-Connections and IOs
-===================
+Supported Features
+==================
 
-The ``ttgo_t8c3`` board target supports the following hardware features:
-
-+-----------+------------+------------------+
-| Interface | Controller | Driver/Component |
-+===========+============+==================+
-| PMP       | on-chip    | arch/riscv       |
-+-----------+------------+------------------+
-| INTMTRX   | on-chip    | intc_esp32c3     |
-+-----------+------------+------------------+
-| PINMUX    | on-chip    | pinctrl_esp32    |
-+-----------+------------+------------------+
-| USB UART  | on-chip    | serial_esp32_usb |
-+-----------+------------+------------------+
-| GPIO      | on-chip    | gpio_esp32       |
-+-----------+------------+------------------+
-| UART      | on-chip    | uart_esp32       |
-+-----------+------------+------------------+
-| I2C       | on-chip    | i2c_esp32        |
-+-----------+------------+------------------+
-| SPI       | on-chip    | spi_esp32_spim   |
-+-----------+------------+------------------+
-| TWAI      | on-chip    | can_esp32_twai   |
-+-----------+------------+------------------+
+.. zephyr:board-supported-hw::
 
 Start Application Development
 *****************************
@@ -60,7 +39,7 @@ System requirements
 Prerequisites
 =============
 
-Espressif HAL requires WiFi and Bluetooth binary blobs in order work. Run the command
+Espressif HAL requires WiFi and Bluetooth binary blobs in order to work. Run the command
 below to retrieve those files.
 
 .. code-block:: console
@@ -77,7 +56,7 @@ Building & Flashing
 Simple boot
 ===========
 
-The board could be loaded using the single binary image, without 2nd stage bootloader.
+The board could be loaded using a single binary image, without 2nd stage bootloader.
 It is the default option when building the application without additional configuration.
 
 .. note::
@@ -107,7 +86,7 @@ There are two options to be used when building an application:
 Sysbuild
 ========
 
-The sysbuild makes possible to build and flash all necessary images needed to
+The sysbuild makes it possible to build and flash all necessary images needed to
 bootstrap the board with the ESP32-C3 SoC.
 
 To build the sample application using sysbuild use the command:

--- a/boards/lilygo/ttgo_t8s3/doc/index.rst
+++ b/boards/lilygo/ttgo_t8s3/doc/index.rst
@@ -15,51 +15,18 @@ It features the following integrated components:
 - JST SH 1.0mm 4-pin UART connector
 - SD card slot
 
-Functional Description
-**********************
+Hardware
+********
+
 This board is based on the ESP32-S3 with 16MB of flash, WiFi and BLE support. It
 has an USB-C port for programming and debugging, integrated battery charging
 and an on-board antenna. The fitted U.FL external antenna connector can be
 enabled by moving a 0-ohm resistor.
 
-Connections and IOs
-===================
+Supported Features
+==================
 
-The ``ttgo_t8s3`` board target supports the following hardware features:
-
-+------------+------------+-------------------------------------+
-| Interface  | Controller | Driver/Component                    |
-+============+============+=====================================+
-| UART       | on-chip    | serial port                         |
-+------------+------------+-------------------------------------+
-| GPIO       | on-chip    | gpio                                |
-+------------+------------+-------------------------------------+
-| PINMUX     | on-chip    | pinmux                              |
-+------------+------------+-------------------------------------+
-| USB-JTAG   | on-chip    | hardware interface                  |
-+------------+------------+-------------------------------------+
-| SPI Master | on-chip    | spi, sdmmc                          |
-+------------+------------+-------------------------------------+
-| TWAI/CAN   | on-chip    | can                                 |
-+------------+------------+-------------------------------------+
-| ADC        | on-chip    | adc                                 |
-+------------+------------+-------------------------------------+
-| Timers     | on-chip    | counter                             |
-+------------+------------+-------------------------------------+
-| Watchdog   | on-chip    | watchdog                            |
-+------------+------------+-------------------------------------+
-| TRNG       | on-chip    | entropy                             |
-+------------+------------+-------------------------------------+
-| LEDC       | on-chip    | pwm                                 |
-+------------+------------+-------------------------------------+
-| MCPWM      | on-chip    | pwm                                 |
-+------------+------------+-------------------------------------+
-| PCNT       | on-chip    | qdec                                |
-+------------+------------+-------------------------------------+
-| GDMA       | on-chip    | dma                                 |
-+------------+------------+-------------------------------------+
-| USB-CDC    | on-chip    | serial                              |
-+------------+------------+-------------------------------------+
+.. zephyr:board-supported-hw::
 
 Start Application Development
 *****************************
@@ -73,7 +40,7 @@ System requirements
 Prerequisites
 =============
 
-Espressif HAL requires WiFi and Bluetooth binary blobs in order work. Run the command
+Espressif HAL requires WiFi and Bluetooth binary blobs in order to work. Run the command
 below to retrieve those files.
 
 .. code-block:: console
@@ -90,7 +57,7 @@ Building & Flashing
 Simple boot
 ===========
 
-The board could be loaded using the single binary image, without 2nd stage bootloader.
+The board could be loaded using a single binary image, without 2nd stage bootloader.
 It is the default option when building the application without additional configuration.
 
 .. note::
@@ -120,7 +87,7 @@ There are two options to be used when building an application:
 Sysbuild
 ========
 
-The sysbuild makes possible to build and flash all necessary images needed to
+The sysbuild makes it possible to build and flash all necessary images needed to
 bootstrap the board with the ESP32 SoC.
 
 To build the sample application using sysbuild use the command:


### PR DESCRIPTION
Replace manually authored hardware features table with the new Zephyr board supported hardware directive which automatically generates an up-to-date table based on the boards' Devicetree.

https://builds.zephyrproject.io/zephyr/pr/87190/docs/boards/index.html#vendor=lilygo