### PR TITLE
MAINTAINERS: add tdk team as TDK Sensors maintainers and collaborators

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -4456,8 +4456,13 @@ Task Watchdog:
 TDK Sensors:
   status: maintained
   maintainers:
+    - afontaine-invn
+    - rbuisson-invn
+  collaborators:
     - teburd
     - MaureenHelm
+    - sriccardi-invn
+    - gjabouley-invn
   files:
     - drivers/sensor/tdk/
   labels:


### PR DESCRIPTION
We would like to take maintainership of TDK drivers as discussed:
 https://github.com/zephyrproject-rtos/zephyr/pull/85963

FYI @rbuisson-invn , @sriccardi-invn, @gjabouley-invn