### PR TITLE
Revert "drivers: gpio_cc13xx_cc26xx: Update for latest sdk"

### DIFF
--- a/drivers/gpio/gpio_cc13xx_cc26xx.c
+++ b/drivers/gpio/gpio_cc13xx_cc26xx.c
@@ -32,9 +32,6 @@
 /* the rest are for general (non-interrupt) config */
 #define IOCFG_GEN_MASK    (~IOCFG_INT_MASK)
 
-/* GPIO all DIOs mask */
-#define GPIO_DIO_ALL_MASK 0xFFFFFFFF
-
 struct gpio_cc13xx_cc26xx_data {
 	/* gpio_driver_data needs to be first */
 	struct gpio_driver_data common;
@@ -131,30 +128,33 @@ static int gpio_cc13xx_cc26xx_port_get_raw(const struct device *port,
 {
 	__ASSERT_NO_MSG(value != NULL);
 
-	*value = HWREG(GPIO_BASE + GPIO_O_DIN31_0) & GPIO_DIO_ALL_MASK;
+	*value = GPIO_readMultiDio(GPIO_DIO_ALL_MASK);
 
 	return 0;
 }
 
-static int gpio_cc13xx_cc26xx_port_set_bits_raw(const struct device *port, uint32_t mask)
-{
-	HWREG(GPIO_BASE + GPIO_O_DOUTSET31_0) = mask;
-
-	return 0;
-}
-
-static int gpio_cc13xx_cc26xx_port_clear_bits_raw(const struct device *port, uint32_t mask)
-{
-	HWREG(GPIO_BASE + GPIO_O_DOUTCLR31_0) = mask;
-
-	return 0;
-}
-
-static int gpio_cc13xx_cc26xx_port_set_masked_raw(const struct device *port, uint32_t mask,
+static int gpio_cc13xx_cc26xx_port_set_masked_raw(const struct device *port,
+						  uint32_t mask,
 						  uint32_t value)
 {
-	gpio_cc13xx_cc26xx_port_set_bits_raw(port, mask & value);
-	gpio_cc13xx_cc26xx_port_clear_bits_raw(port, mask & ~value);
+	GPIO_setMultiDio(mask & value);
+	GPIO_clearMultiDio(mask & ~value);
+
+	return 0;
+}
+
+static int gpio_cc13xx_cc26xx_port_set_bits_raw(const struct device *port,
+						uint32_t mask)
+{
+	GPIO_setMultiDio(mask);
+
+	return 0;
+}
+
+static int gpio_cc13xx_cc26xx_port_clear_bits_raw(const struct device *port,
+						  uint32_t mask)
+{
+	GPIO_clearMultiDio(mask);
 
 	return 0;
 }
@@ -162,7 +162,7 @@ static int gpio_cc13xx_cc26xx_port_set_masked_raw(const struct device *port, uin
 static int gpio_cc13xx_cc26xx_port_toggle_bits(const struct device *port,
 					       uint32_t mask)
 {
-	HWREG(GPIO_BASE + GPIO_O_DOUTTGL31_0) = mask;
+	GPIO_toggleMultiDio(mask);
 
 	return 0;
 }
@@ -209,16 +209,16 @@ static int gpio_cc13xx_cc26xx_manage_callback(const struct device *port,
 
 static uint32_t gpio_cc13xx_cc26xx_get_pending_int(const struct device *dev)
 {
-	return HWREG(GPIO_BASE + GPIO_O_EVFLAGS31_0) & GPIO_DIO_ALL_MASK;
+	return GPIO_getEventMultiDio(GPIO_DIO_ALL_MASK);
 }
 
 static void gpio_cc13xx_cc26xx_isr(const struct device *dev)
 {
 	struct gpio_cc13xx_cc26xx_data *data = dev->data;
 
-	uint32_t status = HWREG(GPIO_BASE + GPIO_O_EVFLAGS31_0) & GPIO_DIO_ALL_MASK;
+	uint32_t status = GPIO_getEventMultiDio(GPIO_DIO_ALL_MASK);
 
-	HWREG(GPIO_BASE + GPIO_O_EVFLAGS31_0) = status;
+	GPIO_clearEventMultiDio(status);
 
 	gpio_fire_callbacks(&data->callbacks, dev, status);
 }

--- a/samples/boards/ti/cc13x2_cc26x2/system_off/src/main.c
+++ b/samples/boards/ti/cc13x2_cc26x2/system_off/src/main.c
@@ -14,9 +14,6 @@
 
 #include <driverlib/ioc.h>
 
-/* GPIO all DIOs mask */
-#define GPIO_DIO_ALL_MASK 0xFFFFFFFF
-
 static const struct gpio_dt_spec sw0_gpio = GPIO_DT_SPEC_GET(DT_ALIAS(sw0), gpios);
 
 #define BUSY_WAIT_S 5U
@@ -59,8 +56,8 @@ int main(void)
 	printk("Powering off; press BUTTON1 to restart\n");
 
 	/* Clear GPIO interrupt */
-	status = HWREG(GPIO_BASE + GPIO_O_EVFLAGS31_0) & GPIO_DIO_ALL_MASK;
-	HWREG(GPIO_BASE + GPIO_O_EVFLAGS31_0) = status;
+	status = GPIO_getEventMultiDio(GPIO_DIO_ALL_MASK);
+	GPIO_clearEventMultiDio(status);
 
 	sys_poweroff();
 

--- a/west.yml
+++ b/west.yml
@@ -253,7 +253,7 @@ manifest:
       groups:
         - hal
     - name: hal_ti
-      revision: 46407c76196ca250c3f955376d52dc3ea25ba381
+      revision: 258652a3ac5d7df68ba8df20e4705c3bd98ede38
       path: modules/hal/ti
       groups:
         - hal


### PR DESCRIPTION
This reverts commit 99e7223a1ce73e7b52f614e0feda0b52a884c804.

Breaks CI with the following compilation error in SPI.c:52: error: 'SPI_MASTER' undeclared here (not in a function)

Failing tests (cc3220sf_launchxl/cc3220sf)
- sample.net.sockets.echo.offload.simplelink
- sample.net.sockets.http_get.offload.simplelink
- sample.net.wifi

@vaishnavachath @Ayush1325  a proper fix is of course most welcome if you can craft one in a timely manner :)