### PR TITLE
soc: st: stm32: build warning for `STM32_ENABLE_DEBUG_SLEEP_STOP`

### DIFF
--- a/soc/st/stm32/common/CMakeLists.txt
+++ b/soc/st/stm32/common/CMakeLists.txt
@@ -26,3 +26,10 @@ endif()
 if (CONFIG_STM32_WKUP_PINS)
   zephyr_sources(stm32_wkup_pins.c)
 endif()
+
+if (CONFIG_PM AND CONFIG_STM32_ENABLE_DEBUG_SLEEP_STOP)
+  message(WARNING "\
+SoC Power Management (CONFIG_PM) enabled but the DBGMCU is still enabled \
+(CONFIG_STM32_ENABLE_DEBUG_SLEEP_STOP). The SoC will use more power than expected \
+in STOP modes due to internal oscillators that remain active.")
+endif()


### PR DESCRIPTION
Add a warning in the build system if both `CONFIG_PM` and `STM32_ENABLE_DEBUG_SLEEP_STOP` are enabled at the same time. The first is likely only enabled if the SoC is intended to be driven into low power states to save power, while the later prevents the SoC from being as low power as it can be.

The sneaky select on `CONFIG_USE_SEGGER_RTT` cost me a day of my life chasing down clock configurations :)
https://github.com/zephyrproject-rtos/zephyr/blob/d6c59f0b4d1553d01297e6fcb7ae1d865a897732/modules/segger/Kconfig#L12-L15