### PR TITLE
scripts: west_commands: patch: Make checkum and metadata optional

### DIFF
--- a/scripts/schemas/patch-schema.yml
+++ b/scripts/schemas/patch-schema.yml
@@ -17,33 +17,29 @@ schema;patch-schema:
           required: true
           type: str
 
-        # The SHA-256 checksum of the patch file
-        # e.g. e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-        sha256sum:
-          required: true
-          type: str
-          pattern: "^[0-9a-f]{64}$"
-
         # The path of the module the patch is for, relative to the west workspace
         # e.g. zephyr, or bootloader/mcuboot
         module:
           required: true
           type: str
 
+        # The SHA-256 checksum of the patch file
+        # e.g. e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+        sha256sum:
+          type: str
+          pattern: "^[0-9a-f]{64}$"
+
         # The name of the primary author of the patch, e.g. Kermit D. Frog
         author:
-          required: true
           type: str
 
         # The email address of the primary author of the patch, e.g. itsnoteasy@being.gr
         email:
-          required: true
           type: str
           pattern: ".+@.+"
 
         # The date the patch was created, in ISO 8601 date format YYYY-MM-DD
         date:
-          required: true
           type: date
           format: "%Y-%m-%d"
 

--- a/scripts/west_commands/patch.py
+++ b/scripts/west_commands/patch.py
@@ -375,21 +375,22 @@ class Patch(WestCommand):
                 failed_patch = pth
                 break
 
-            self.dbg("checking patch integrity... ", end="")
-            expect_sha256 = patch_info["sha256sum"]
-            hasher = hashlib.sha256()
-            hasher.update(patch_file_data)
-            actual_sha256 = hasher.hexdigest()
-            if actual_sha256 != expect_sha256:
-                self.dbg("FAIL")
-                self.err(
-                    f"sha256 mismatch for {pth}:\n"
-                    f"expect: {expect_sha256}\n"
-                    f"actual: {actual_sha256}"
-                )
-                failed_patch = pth
-                break
-            self.dbg("OK")
+            expect_sha256 = patch_info.get("sha256sum")
+            if expect_sha256 is not None:
+                self.dbg("checking patch integrity... ", end="")
+                hasher = hashlib.sha256()
+                hasher.update(patch_file_data)
+                actual_sha256 = hasher.hexdigest()
+                if actual_sha256 != expect_sha256:
+                    self.dbg("FAIL")
+                    self.err(
+                        f"sha256 mismatch for {pth}:\n"
+                        f"expect: {expect_sha256}\n"
+                        f"actual: {actual_sha256}"
+                    )
+                    failed_patch = pth
+                    break
+                self.dbg("OK")
             patch_count += 1
             patch_file_data = None
 

--- a/scripts/west_commands/patch.py
+++ b/scripts/west_commands/patch.py
@@ -549,6 +549,9 @@ class Patch(WestCommand):
         if (topdir / module_name_or_path).is_dir():
             return Path(module_name_or_path)
 
+        if module_name_or_path == "zephyr":
+            return ZEPHYR_BASE
+
         all_modules = zephyr_module.parse_modules(ZEPHYR_BASE, self.manifest)
         for m in all_modules:
             if m.meta['name'] == module_name_or_path:


### PR DESCRIPTION
The checksum is mostly redundant as far as I can tell, at least in the case where the patch files are checked into the same git repo as the yml file. This makes it easier to manage patches manually.

Same goes for author/email/date metadata. This information is often just duplicated from the patch file, and not currently used in any in-tree tools as far as I can see.

Note: Also includes a commit to fix using `module: zephyr` in `get_module_path`.