### PR TITLE
samples: ipc: static_vrings: Exclude unsupported platforms

### DIFF
--- a/samples/subsys/ipc/ipc_service/static_vrings/sample.yaml
+++ b/samples/subsys/ipc/ipc_service/static_vrings/sample.yaml
@@ -4,6 +4,9 @@ tests:
   sample.ipc.static_vrings:
     filter: dt_compat_enabled("zephyr,ipc-openamp-static-vrings") and
             dt_nodelabel_enabled("ipc0") and dt_nodelabel_enabled("ipc1")
+    platform_exclude:
+      - nrf5340dk/nrf5340/cpuapp/ns
+      - nrf5340dk/nrf5340/cpunet
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp
       - nrf5340bsim/nrf5340/cpuapp


### PR DESCRIPTION
List of allowed platforms for this sample was changed in PR #85997. This enabled more platforms including those that are not needed. This commit excludes nrf5340/cpuapp_ns and nrf5340/cpunet platforms since they are not supported by this sample.