### PR TITLE
Bluetooth: Classic: Add a function bt_conn_get_dst_br()

### DIFF
--- a/doc/releases/release-notes-4.2.rst
+++ b/doc/releases/release-notes-4.2.rst
@@ -96,6 +96,7 @@ New APIs and options
     * :c:func:`bt_le_bond_exists`
     * :c:func:`bt_br_bond_exists`
     * :c:func:`bt_conn_lookup_addr_br`
+    * :c:func:`bt_conn_get_dst_br`
 
 * Display
 

--- a/include/zephyr/bluetooth/conn.h
+++ b/include/zephyr/bluetooth/conn.h
@@ -2631,6 +2631,14 @@ struct bt_conn *bt_conn_create_br(const bt_addr_t *peer,
  */
 struct bt_conn *bt_conn_lookup_addr_br(const bt_addr_t *peer);
 
+/** @brief Get destination (peer) address of a connection.
+ *
+ *  @param conn Connection object.
+ *
+ *  @return Destination address if @p conn is a valid @ref BT_CONN_TYPE_BR connection
+ */
+const bt_addr_t *bt_conn_get_dst_br(const struct bt_conn *conn);
+
 #ifdef __cplusplus
 }
 #endif

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -2497,6 +2497,20 @@ static int bt_hci_connect_br_cancel(struct bt_conn *conn)
 	return err;
 }
 
+const bt_addr_t *bt_conn_get_dst_br(const struct bt_conn *conn)
+{
+	if (conn == NULL) {
+		LOG_DBG("Invalid connect");
+		return NULL;
+	}
+
+	if (!bt_conn_is_type(conn, BT_CONN_TYPE_BR)) {
+		LOG_DBG("Invalid connection type: %u for %p", conn->type, conn);
+		return NULL;
+	}
+
+	return &conn->br.dst;
+}
 #endif /* CONFIG_BT_CLASSIC */
 
 #if defined(CONFIG_BT_SMP)


### PR DESCRIPTION
Add a function `bt_conn_get_dst_br()` to get the peer address of the classic connection.