### PR TITLE
tests: Bluetooth: Tester: BAP BSIM test

### DIFF
--- a/tests/bluetooth/tester/boards/nrf5340bsim_nrf5340_cpuapp.conf
+++ b/tests/bluetooth/tester/boards/nrf5340bsim_nrf5340_cpuapp.conf
@@ -16,3 +16,8 @@ CONFIG_UART_PIPE=n
 CONFIG_UART_INTERRUPT_DRIVEN=y
 
 CONFIG_SERIAL=y
+
+# Increase the number of RX buffers to a high amount to avoid issues with running out of buffers
+# Presumably this is due to the speed of BSIM and the "slowness" of the BSIM UART, since all
+# events (include ISO data received event) is sent in a blocking manner
+CONFIG_BT_ISO_RX_BUF_COUNT=30

--- a/tests/bluetooth/tester/testcase.yaml
+++ b/tests/bluetooth/tester/testcase.yaml
@@ -65,6 +65,14 @@ tests:
     build_only: true
     platform_allow:
       - nrf52_bsim/native
+    extra_args:
+      - EXTRA_CONF_FILE="overlay-le-audio.conf;overlay-bt_ll_sw_split.conf"
+    harness: bsim
+    harness_config:
+      bsim_exe_name: tests_bluetooth_tester_le_audio_prj_conf
+  bluetooth.general.tester_hci_ipc_le_audio_bsim:
+    build_only: true
+    platform_allow:
       - nrf5340bsim/nrf5340/cpuapp
     extra_args:
       - EXTRA_CONF_FILE="overlay-le-audio.conf"

--- a/tests/bsim/bluetooth/tester/CMakeLists.txt
+++ b/tests/bsim/bluetooth/tester/CMakeLists.txt
@@ -24,6 +24,8 @@ zephyr_include_directories(
 target_sources(app PRIVATE
   src/bsim_btp.c
   src/test_main.c
+  src/audio/bap_broadcast_sink.c
+  src/audio/bap_broadcast_source.c
   src/audio/bap_central.c
   src/audio/bap_peripheral.c
   src/audio/ccp_central.c

--- a/tests/bsim/bluetooth/tester/CMakeLists.txt
+++ b/tests/bsim/bluetooth/tester/CMakeLists.txt
@@ -24,6 +24,8 @@ zephyr_include_directories(
 target_sources(app PRIVATE
   src/bsim_btp.c
   src/test_main.c
+  src/audio/bap_central.c
+  src/audio/bap_peripheral.c
   src/audio/ccp_central.c
   src/audio/ccp_peripheral.c
   src/audio/csip_central.c

--- a/tests/bsim/bluetooth/tester/src/audio/bap_broadcast_sink.c
+++ b/tests/bsim/bluetooth/tester/src/audio/bap_broadcast_sink.c
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include <zephyr/bluetooth/addr.h>
+#include <zephyr/bluetooth/gap.h>
+#include <zephyr/bluetooth/hci_types.h>
+#include <zephyr/bluetooth/iso.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/sys/util_macro.h>
+
+#include "babblekit/testcase.h"
+#include "bstests.h"
+
+#include "btp/btp.h"
+#include "bsim_btp.h"
+
+LOG_MODULE_REGISTER(bsim_bap_broadcast_sink, CONFIG_BSIM_BTTESTER_LOG_LEVEL);
+
+static void test_bap_broadcast_sink(void)
+{
+	const uint16_t pa_sync_timeout = BT_GAP_PER_ADV_MAX_TIMEOUT;
+	char addr_str[BT_ADDR_LE_STR_LEN];
+	const uint16_t pa_sync_skip = 0U;
+	const uint8_t src_id = 0U; /* BASS receive state source ID */
+	bt_addr_le_t remote_addr;
+	uint32_t broadcast_id;
+	uint8_t adv_sid;
+	uint8_t bis_id;
+
+	bsim_btp_uart_init();
+
+	bsim_btp_wait_for_evt(BTP_SERVICE_ID_CORE, BTP_CORE_EV_IUT_READY, NULL);
+
+	bsim_btp_core_register(BTP_SERVICE_ID_GAP);
+	bsim_btp_core_register(BTP_SERVICE_ID_BAP);
+	bsim_btp_core_register(BTP_SERVICE_ID_PACS);
+
+	bsim_btp_bap_broadcast_sink_setup();
+	bsim_btp_bap_broadcast_scan_start();
+
+	bsim_btp_bap_broadcast_scan_start();
+	bsim_btp_wait_for_bap_baa_found(&remote_addr, &broadcast_id, &adv_sid);
+	bt_addr_le_to_str(&remote_addr, addr_str, sizeof(addr_str));
+	LOG_INF("Found remote device %s", addr_str);
+	bsim_btp_bap_broadcast_scan_stop();
+
+	bsim_btp_bap_broadcast_sink_sync(&remote_addr, broadcast_id, adv_sid, pa_sync_skip,
+					 pa_sync_timeout, false, src_id);
+	bsim_btp_wait_for_bap_bap_bis_found(&bis_id);
+	bsim_btp_bap_broadcast_sink_bis_sync(&remote_addr, broadcast_id,
+					     BT_ISO_BIS_INDEX_BIT(bis_id));
+	bsim_btp_wait_for_btp_bap_bis_synced();
+	bsim_btp_wait_for_bap_bis_stream_received();
+	bsim_btp_bap_broadcast_sink_stop(&remote_addr, broadcast_id);
+	bsim_btp_bap_broadcast_sink_release();
+
+	TEST_PASS("PASSED\n");
+}
+
+static const struct bst_test_instance test_sample[] = {
+	{
+		.test_id = "bap_broadcast_sink",
+		.test_descr = "Smoketest for the BAP Broadcast Sink BT Tester behavior",
+		.test_main_f = test_bap_broadcast_sink,
+	},
+	BSTEST_END_MARKER,
+};
+
+struct bst_test_list *test_bap_broadcast_sink_install(struct bst_test_list *tests)
+{
+	return bst_add_tests(tests, test_sample);
+}

--- a/tests/bsim/bluetooth/tester/src/audio/bap_broadcast_source.c
+++ b/tests/bsim/bluetooth/tester/src/audio/bap_broadcast_source.c
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <stddef.h>
+#include <stdint.h>
+
+#include <zephyr/bluetooth/addr.h>
+#include <zephyr/bluetooth/audio/audio.h>
+#include <zephyr/bluetooth/audio/lc3.h>
+#include <zephyr/bluetooth/hci_types.h>
+#include <zephyr/bluetooth/iso.h>
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/net_buf.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/sys/util_macro.h>
+
+#include "babblekit/testcase.h"
+#include "bstests.h"
+
+#include "btp/btp.h"
+#include "bsim_btp.h"
+
+LOG_MODULE_REGISTER(bsim_bap_broadcast_source, CONFIG_BSIM_BTTESTER_LOG_LEVEL);
+
+static void test_bap_broadcast_source(void)
+{
+	const uint8_t cc_data_16_2_1[] = BT_AUDIO_CODEC_CFG_LC3_DATA(
+		BT_AUDIO_CODEC_CFG_FREQ_16KHZ, BT_AUDIO_CODEC_CFG_DURATION_10,
+		BT_AUDIO_LOCATION_FRONT_LEFT, 40, 1);
+	const uint8_t coding_format = BT_HCI_CODING_FORMAT_LC3;
+	const uint8_t framing = BT_ISO_FRAMING_UNFRAMED;
+	const uint32_t presentation_delay = 40000U;
+	const uint32_t broadcast_id = 0x123456;
+	const uint8_t streams_per_subgroup = 1U;
+	const uint32_t sdu_interval = 10000U;
+	const uint16_t max_latency = 10U;
+	const uint16_t max_sdu = 40U;
+	const uint8_t subgroups = 1U;
+	const uint16_t cid = 0U; /* shall be 0 for LC3 */
+	const uint16_t vid = 0U; /* shall be 0 for LC3 */
+	const uint8_t rtn = 2U;
+
+	bsim_btp_uart_init();
+
+	bsim_btp_wait_for_evt(BTP_SERVICE_ID_CORE, BTP_CORE_EV_IUT_READY, NULL);
+
+	bsim_btp_core_register(BTP_SERVICE_ID_GAP);
+	bsim_btp_core_register(BTP_SERVICE_ID_BAP);
+
+	bsim_btp_bap_broadcast_source_setup_v2(broadcast_id, streams_per_subgroup, subgroups,
+					       sdu_interval, framing, max_sdu, rtn, max_latency,
+					       presentation_delay, coding_format, vid, cid,
+					       ARRAY_SIZE(cc_data_16_2_1), cc_data_16_2_1);
+	bsim_btp_bap_broadcast_adv_start(broadcast_id);
+	bsim_btp_bap_broadcast_source_start(broadcast_id);
+
+	TEST_PASS("PASSED\n");
+}
+
+static const struct bst_test_instance test_sample[] = {
+	{
+		.test_id = "bap_broadcast_source",
+		.test_descr = "Smoketest for the BAP broadcast source BT Tester behavior",
+		.test_main_f = test_bap_broadcast_source,
+	},
+	BSTEST_END_MARKER,
+};
+
+struct bst_test_list *test_bap_broadcast_source_install(struct bst_test_list *tests)
+{
+	return bst_add_tests(tests, test_sample);
+}

--- a/tests/bsim/bluetooth/tester/src/audio/bap_central.c
+++ b/tests/bsim/bluetooth/tester/src/audio/bap_central.c
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <stddef.h>
+#include <stdint.h>
+
+#include <zephyr/bluetooth/addr.h>
+#include <zephyr/bluetooth/audio/audio.h>
+#include <zephyr/bluetooth/audio/lc3.h>
+#include <zephyr/bluetooth/hci_types.h>
+#include <zephyr/bluetooth/iso.h>
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/net_buf.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/sys/util_macro.h>
+
+#include "babblekit/testcase.h"
+#include "bstests.h"
+
+#include "btp/btp.h"
+#include "bsim_btp.h"
+
+LOG_MODULE_REGISTER(bsim_bap_central, CONFIG_BSIM_BTTESTER_LOG_LEVEL);
+
+static void test_bap_central(void)
+{
+	uint8_t cc_data_16_2_1[] = BT_AUDIO_CODEC_CFG_LC3_DATA(BT_AUDIO_CODEC_CFG_FREQ_16KHZ,
+							       BT_AUDIO_CODEC_CFG_DURATION_10,
+							       BT_AUDIO_LOCATION_FRONT_LEFT, 40, 1);
+
+	char addr_str[BT_ADDR_LE_STR_LEN];
+	const uint8_t cig_id = 0U;
+	const uint8_t cis_id = 0U;
+	const uint32_t sdu_interval = 10000U;
+	const uint8_t framing = BT_ISO_FRAMING_UNFRAMED;
+	const uint16_t max_sdu = 40U;
+	const uint8_t rtn = 2U;
+	const uint16_t max_latency = 10U;
+	const uint32_t presentation_delay = 40000U;
+	bt_addr_le_t remote_addr;
+	uint8_t ase_id;
+
+	bsim_btp_uart_init();
+
+	bsim_btp_wait_for_evt(BTP_SERVICE_ID_CORE, BTP_CORE_EV_IUT_READY, NULL);
+
+	bsim_btp_core_register(BTP_SERVICE_ID_GAP);
+	bsim_btp_core_register(BTP_SERVICE_ID_BAP);
+	bsim_btp_core_register(BTP_SERVICE_ID_ASCS);
+	bsim_btp_core_register(BTP_SERVICE_ID_PACS);
+
+	bsim_btp_gap_start_discovery(BTP_GAP_DISCOVERY_FLAG_LE);
+	bsim_btp_wait_for_gap_device_found(&remote_addr);
+	bt_addr_le_to_str(&remote_addr, addr_str, sizeof(addr_str));
+	LOG_INF("Found remote device %s", addr_str);
+
+	bsim_btp_gap_stop_discovery();
+	bsim_btp_gap_connect(&remote_addr, BTP_GAP_ADDR_TYPE_IDENTITY);
+	bsim_btp_wait_for_gap_device_connected(NULL);
+	LOG_INF("Device %s connected", addr_str);
+
+	bsim_btp_gap_pair(&remote_addr);
+	bsim_btp_wait_for_gap_sec_level_changed(NULL, NULL);
+
+	bsim_btp_bap_discover(&remote_addr);
+	bsim_btp_wait_for_bap_ase_found(&ase_id);
+	bsim_btp_wait_for_bap_discovered();
+
+	bsim_btp_ascs_configure_codec(&remote_addr, ase_id, BT_HCI_CODING_FORMAT_LC3, 0U, 0U,
+				      ARRAY_SIZE(cc_data_16_2_1), cc_data_16_2_1);
+	bsim_btp_wait_for_ascs_operation_complete();
+
+	/* The CIS must be preconfigured before sending the request to the BAP unicast server */
+	bsim_btp_ascs_add_ase_to_cis(&remote_addr, ase_id, cig_id, cis_id);
+	btp_ascs_preconfigure_qos(cig_id, cis_id, sdu_interval, framing, max_sdu, rtn, max_latency,
+				  presentation_delay);
+
+	bsim_btp_ascs_configure_qos(&remote_addr, ase_id, cig_id, cis_id, sdu_interval, framing,
+				    max_sdu, rtn, max_latency, presentation_delay);
+	bsim_btp_wait_for_ascs_operation_complete();
+
+	bsim_btp_ascs_enable(&remote_addr, ase_id);
+	bsim_btp_wait_for_ascs_operation_complete();
+
+	bsim_btp_ascs_receiver_start_ready(&remote_addr, ase_id);
+	bsim_btp_wait_for_ascs_operation_complete();
+
+	bsim_btp_ascs_release(&remote_addr, ase_id);
+	bsim_btp_wait_for_ascs_operation_complete();
+
+	bsim_btp_gap_disconnect(&remote_addr);
+	bsim_btp_wait_for_gap_device_disconnected(NULL);
+	LOG_INF("Device %s disconnected", addr_str);
+
+	TEST_PASS("PASSED\n");
+}
+
+static const struct bst_test_instance test_sample[] = {
+	{
+		.test_id = "bap_central",
+		.test_descr = "Smoketest for the BAP central BT Tester behavior",
+		.test_main_f = test_bap_central,
+	},
+	BSTEST_END_MARKER,
+};
+
+struct bst_test_list *test_bap_central_install(struct bst_test_list *tests)
+{
+	return bst_add_tests(tests, test_sample);
+}

--- a/tests/bsim/bluetooth/tester/src/audio/bap_peripheral.c
+++ b/tests/bsim/bluetooth/tester/src/audio/bap_peripheral.c
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <stddef.h>
+#include <stdint.h>
+
+#include <zephyr/bluetooth/addr.h>
+#include <zephyr/bluetooth/gap.h>
+#include <zephyr/bluetooth/hci_types.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/sys/util_macro.h>
+
+#include "babblekit/testcase.h"
+#include "bstests.h"
+
+#include "btp/btp.h"
+#include "bsim_btp.h"
+
+LOG_MODULE_REGISTER(bsim_bap_peripheral, CONFIG_BSIM_BTTESTER_LOG_LEVEL);
+
+static void test_bap_peripheral(void)
+{
+	char addr_str[BT_ADDR_LE_STR_LEN];
+	bt_addr_le_t remote_addr;
+
+	bsim_btp_uart_init();
+
+	bsim_btp_wait_for_evt(BTP_SERVICE_ID_CORE, BTP_CORE_EV_IUT_READY, NULL);
+
+	bsim_btp_core_register(BTP_SERVICE_ID_GAP);
+	bsim_btp_core_register(BTP_SERVICE_ID_BAP);
+	bsim_btp_core_register(BTP_SERVICE_ID_ASCS);
+	bsim_btp_core_register(BTP_SERVICE_ID_PACS);
+
+	bsim_btp_gap_set_discoverable(BTP_GAP_GENERAL_DISCOVERABLE);
+	bsim_btp_gap_start_advertising(0U, 0U, NULL, BT_HCI_OWN_ADDR_PUBLIC);
+	bsim_btp_wait_for_gap_device_connected(&remote_addr);
+	bt_addr_le_to_str(&remote_addr, addr_str, sizeof(addr_str));
+	LOG_INF("Device %s connected", addr_str);
+	bsim_btp_wait_for_gap_device_disconnected(NULL);
+	LOG_INF("Device %s disconnected", addr_str);
+
+	TEST_PASS("PASSED\n");
+}
+
+static const struct bst_test_instance test_sample[] = {
+	{
+		.test_id = "bap_peripheral",
+		.test_descr = "Smoketest for the BAP peripheral BT Tester behavior",
+		.test_main_f = test_bap_peripheral,
+	},
+	BSTEST_END_MARKER,
+};
+
+struct bst_test_list *test_bap_peripheral_install(struct bst_test_list *tests)
+{
+	return bst_add_tests(tests, test_sample);
+}

--- a/tests/bsim/bluetooth/tester/src/bsim_btp.c
+++ b/tests/bsim/bluetooth/tester/src/bsim_btp.c
@@ -1103,6 +1103,8 @@ static bool is_valid_bap_packet_len(const struct btp_hdr *hdr, struct net_buf_si
 		return buf_simple->len == 0U;
 	case BTP_BAP_SEND_PAST:
 		return buf_simple->len == 0U;
+	case BTP_BAP_BROADCAST_SOURCE_SETUP_V2:
+		return buf_simple->len == sizeof(struct btp_bap_broadcast_source_setup_v2_rp);
 
 	/* events */
 	case BTP_BAP_EV_DISCOVERY_COMPLETED:
@@ -1131,6 +1133,8 @@ static bool is_valid_bap_packet_len(const struct btp_hdr *hdr, struct net_buf_si
 		} else {
 			return false;
 		}
+	case BTP_BAP_EV_BIS_SYNCED:
+		return buf_simple->len == sizeof(struct btp_bap_bis_synced_ev);
 	case BTP_BAP_EV_BIS_STREAM_RECEIVED:
 		if (hdr->len >= sizeof(struct btp_bap_stream_received_ev)) {
 			const struct btp_bap_bis_stream_received_ev *ev = net_buf_simple_pull_mem(
@@ -1156,7 +1160,7 @@ static bool is_valid_bap_packet_len(const struct btp_hdr *hdr, struct net_buf_si
 				uint8_t metadata_len;
 				uint32_t bis_sync;
 
-				if (buf_simple->len <= (sizeof(bis_sync) + sizeof(metadata_len))) {
+				if (buf_simple->len < (sizeof(bis_sync) + sizeof(metadata_len))) {
 					return false;
 				}
 

--- a/tests/bsim/bluetooth/tester/src/bsim_btp.h
+++ b/tests/bsim/bluetooth/tester/src/bsim_btp.h
@@ -24,6 +24,287 @@ void bsim_btp_uart_init(void);
 void bsim_btp_send_to_tester(const uint8_t *data, size_t len);
 void bsim_btp_wait_for_evt(uint8_t service, uint8_t opcode, struct net_buf **out_buf);
 
+static inline void bsim_btp_ascs_configure_codec(const bt_addr_le_t *address, uint8_t ase_id,
+						 uint8_t coding_format, uint16_t vid, uint16_t cid,
+						 uint8_t cc_ltvs_len, uint8_t cc_ltvs[])
+{
+	struct btp_ascs_configure_codec_cmd *cmd;
+	struct btp_hdr *cmd_hdr;
+
+	NET_BUF_SIMPLE_DEFINE(cmd_buffer, BTP_MTU);
+
+	cmd_hdr = net_buf_simple_add(&cmd_buffer, sizeof(*cmd_hdr));
+	cmd_hdr->service = BTP_SERVICE_ID_ASCS;
+	cmd_hdr->opcode = BTP_ASCS_CONFIGURE_CODEC;
+	cmd_hdr->index = BTP_INDEX;
+	cmd = net_buf_simple_add(&cmd_buffer, sizeof(*cmd));
+	bt_addr_le_copy(&cmd->address, address);
+	cmd->ase_id = ase_id;
+	cmd->coding_format = coding_format;
+	cmd->vid = sys_cpu_to_le16(vid);
+	cmd->cid = sys_cpu_to_le16(cid);
+	cmd->cc_ltvs_len = cc_ltvs_len;
+	if (cc_ltvs_len != 0) {
+		(void)net_buf_simple_add_mem(&cmd_buffer, cc_ltvs, cc_ltvs_len);
+	}
+
+	cmd_hdr->len = sys_cpu_to_le16(cmd_buffer.len - sizeof(*cmd_hdr));
+
+	bsim_btp_send_to_tester(cmd_buffer.data, cmd_buffer.len);
+}
+
+static inline void bsim_btp_ascs_configure_qos(const bt_addr_le_t *address, uint8_t ase_id,
+					       uint8_t cig_id, uint8_t cis_id,
+					       uint32_t sdu_interval, uint8_t framing,
+					       uint16_t max_sdu, uint8_t rtn, uint16_t max_latency,
+					       uint32_t presentation_delay)
+{
+	struct btp_ascs_configure_qos_cmd *cmd;
+	struct btp_hdr *cmd_hdr;
+
+	NET_BUF_SIMPLE_DEFINE(cmd_buffer, BTP_MTU);
+
+	cmd_hdr = net_buf_simple_add(&cmd_buffer, sizeof(*cmd_hdr));
+	cmd_hdr->service = BTP_SERVICE_ID_ASCS;
+	cmd_hdr->opcode = BTP_ASCS_CONFIGURE_QOS;
+	cmd_hdr->index = BTP_INDEX;
+	cmd = net_buf_simple_add(&cmd_buffer, sizeof(*cmd));
+	bt_addr_le_copy(&cmd->address, address);
+	cmd->ase_id = ase_id;
+	cmd->cig_id = cig_id;
+	cmd->cis_id = cis_id;
+	sys_put_le24(sdu_interval, cmd->sdu_interval);
+	cmd->framing = framing;
+	cmd->max_sdu = sys_cpu_to_le16(max_sdu);
+	cmd->retransmission_num = rtn;
+	cmd->max_transport_latency = sys_cpu_to_le16(max_latency);
+	sys_put_le24(presentation_delay, cmd->presentation_delay);
+
+	cmd_hdr->len = sys_cpu_to_le16(cmd_buffer.len - sizeof(*cmd_hdr));
+
+	bsim_btp_send_to_tester(cmd_buffer.data, cmd_buffer.len);
+}
+
+static inline void bsim_btp_ascs_enable(const bt_addr_le_t *address, uint8_t ase_id)
+{
+	struct btp_ascs_enable_cmd *cmd;
+	struct btp_hdr *cmd_hdr;
+
+	NET_BUF_SIMPLE_DEFINE(cmd_buffer, BTP_MTU);
+
+	cmd_hdr = net_buf_simple_add(&cmd_buffer, sizeof(*cmd_hdr));
+	cmd_hdr->service = BTP_SERVICE_ID_ASCS;
+	cmd_hdr->opcode = BTP_ASCS_ENABLE;
+	cmd_hdr->index = BTP_INDEX;
+	cmd = net_buf_simple_add(&cmd_buffer, sizeof(*cmd));
+	bt_addr_le_copy(&cmd->address, address);
+	cmd->ase_id = ase_id;
+
+	cmd_hdr->len = sys_cpu_to_le16(cmd_buffer.len - sizeof(*cmd_hdr));
+
+	bsim_btp_send_to_tester(cmd_buffer.data, cmd_buffer.len);
+}
+
+static inline void bsim_btp_ascs_receiver_start_ready(const bt_addr_le_t *address, uint8_t ase_id)
+{
+	struct btp_ascs_receiver_start_ready_cmd *cmd;
+	struct btp_hdr *cmd_hdr;
+
+	NET_BUF_SIMPLE_DEFINE(cmd_buffer, BTP_MTU);
+
+	cmd_hdr = net_buf_simple_add(&cmd_buffer, sizeof(*cmd_hdr));
+	cmd_hdr->service = BTP_SERVICE_ID_ASCS;
+	cmd_hdr->opcode = BTP_ASCS_RECEIVER_START_READY;
+	cmd_hdr->index = BTP_INDEX;
+	cmd = net_buf_simple_add(&cmd_buffer, sizeof(*cmd));
+	bt_addr_le_copy(&cmd->address, address);
+	cmd->ase_id = ase_id;
+
+	cmd_hdr->len = sys_cpu_to_le16(cmd_buffer.len - sizeof(*cmd_hdr));
+
+	bsim_btp_send_to_tester(cmd_buffer.data, cmd_buffer.len);
+}
+
+static inline void bsim_btp_ascs_receiver_stop_ready(const bt_addr_le_t *address, uint8_t ase_id)
+{
+	struct btp_ascs_receiver_stop_ready_cmd *cmd;
+	struct btp_hdr *cmd_hdr;
+
+	NET_BUF_SIMPLE_DEFINE(cmd_buffer, BTP_MTU);
+
+	cmd_hdr = net_buf_simple_add(&cmd_buffer, sizeof(*cmd_hdr));
+	cmd_hdr->service = BTP_SERVICE_ID_ASCS;
+	cmd_hdr->opcode = BTP_ASCS_RECEIVER_STOP_READY;
+	cmd_hdr->index = BTP_INDEX;
+	cmd = net_buf_simple_add(&cmd_buffer, sizeof(*cmd));
+	bt_addr_le_copy(&cmd->address, address);
+	cmd->ase_id = ase_id;
+
+	cmd_hdr->len = sys_cpu_to_le16(cmd_buffer.len - sizeof(*cmd_hdr));
+
+	bsim_btp_send_to_tester(cmd_buffer.data, cmd_buffer.len);
+}
+
+static inline void bsim_btp_ascs_disable(const bt_addr_le_t *address, uint8_t ase_id)
+{
+	struct btp_ascs_disable_cmd *cmd;
+	struct btp_hdr *cmd_hdr;
+
+	NET_BUF_SIMPLE_DEFINE(cmd_buffer, BTP_MTU);
+
+	cmd_hdr = net_buf_simple_add(&cmd_buffer, sizeof(*cmd_hdr));
+	cmd_hdr->service = BTP_SERVICE_ID_ASCS;
+	cmd_hdr->opcode = BTP_ASCS_DISABLE;
+	cmd_hdr->index = BTP_INDEX;
+	cmd = net_buf_simple_add(&cmd_buffer, sizeof(*cmd));
+	bt_addr_le_copy(&cmd->address, address);
+	cmd->ase_id = ase_id;
+
+	cmd_hdr->len = sys_cpu_to_le16(cmd_buffer.len - sizeof(*cmd_hdr));
+
+	bsim_btp_send_to_tester(cmd_buffer.data, cmd_buffer.len);
+}
+
+static inline void bsim_btp_ascs_release(const bt_addr_le_t *address, uint8_t ase_id)
+{
+	struct btp_ascs_release_cmd *cmd;
+	struct btp_hdr *cmd_hdr;
+
+	NET_BUF_SIMPLE_DEFINE(cmd_buffer, BTP_MTU);
+
+	cmd_hdr = net_buf_simple_add(&cmd_buffer, sizeof(*cmd_hdr));
+	cmd_hdr->service = BTP_SERVICE_ID_ASCS;
+	cmd_hdr->opcode = BTP_ASCS_RELEASE;
+	cmd_hdr->index = BTP_INDEX;
+	cmd = net_buf_simple_add(&cmd_buffer, sizeof(*cmd));
+	bt_addr_le_copy(&cmd->address, address);
+	cmd->ase_id = ase_id;
+
+	cmd_hdr->len = sys_cpu_to_le16(cmd_buffer.len - sizeof(*cmd_hdr));
+
+	bsim_btp_send_to_tester(cmd_buffer.data, cmd_buffer.len);
+}
+
+static inline void bsim_btp_wait_for_ascs_operation_complete(void)
+{
+	struct btp_ascs_operation_completed_ev *ev;
+	struct net_buf *buf;
+
+	bsim_btp_wait_for_evt(BTP_SERVICE_ID_ASCS, BTP_ASCS_EV_OPERATION_COMPLETED, &buf);
+	ev = net_buf_pull_mem(buf, sizeof(*ev));
+
+	net_buf_unref(buf);
+}
+
+static inline void bsim_btp_ascs_add_ase_to_cis(const bt_addr_le_t *address, uint8_t ase_id,
+						uint8_t cig_id, uint8_t cis_id)
+{
+	struct btp_ascs_add_ase_to_cis *cmd;
+	struct btp_hdr *cmd_hdr;
+
+	NET_BUF_SIMPLE_DEFINE(cmd_buffer, BTP_MTU);
+
+	cmd_hdr = net_buf_simple_add(&cmd_buffer, sizeof(*cmd_hdr));
+	cmd_hdr->service = BTP_SERVICE_ID_ASCS;
+	cmd_hdr->opcode = BTP_ASCS_ADD_ASE_TO_CIS;
+	cmd_hdr->index = BTP_INDEX;
+	cmd = net_buf_simple_add(&cmd_buffer, sizeof(*cmd));
+	bt_addr_le_copy(&cmd->address, address);
+	cmd->ase_id = ase_id;
+	cmd->cig_id = cig_id;
+	cmd->cis_id = cis_id;
+
+	cmd_hdr->len = sys_cpu_to_le16(cmd_buffer.len - sizeof(*cmd_hdr));
+
+	bsim_btp_send_to_tester(cmd_buffer.data, cmd_buffer.len);
+}
+
+static inline void btp_ascs_preconfigure_qos(uint8_t cig_id, uint8_t cis_id, uint32_t sdu_interval,
+					     uint8_t framing, uint16_t max_sdu, uint8_t rtn,
+					     uint16_t max_latency, uint32_t presentation_delay)
+{
+	struct btp_ascs_preconfigure_qos_cmd *cmd;
+	struct btp_hdr *cmd_hdr;
+
+	NET_BUF_SIMPLE_DEFINE(cmd_buffer, BTP_MTU);
+
+	cmd_hdr = net_buf_simple_add(&cmd_buffer, sizeof(*cmd_hdr));
+	cmd_hdr->service = BTP_SERVICE_ID_ASCS;
+	cmd_hdr->opcode = BTP_ASCS_PRECONFIGURE_QOS;
+	cmd_hdr->index = BTP_INDEX;
+	cmd = net_buf_simple_add(&cmd_buffer, sizeof(*cmd));
+	cmd->cig_id = cig_id;
+	cmd->cis_id = cis_id;
+	sys_put_le24(sdu_interval, cmd->sdu_interval);
+	cmd->framing = framing;
+	cmd->max_sdu = sys_cpu_to_le16(max_sdu);
+	cmd->retransmission_num = rtn;
+	cmd->max_transport_latency = sys_cpu_to_le16(max_latency);
+	sys_put_le24(presentation_delay, cmd->presentation_delay);
+
+	cmd_hdr->len = sys_cpu_to_le16(cmd_buffer.len - sizeof(*cmd_hdr));
+
+	bsim_btp_send_to_tester(cmd_buffer.data, cmd_buffer.len);
+}
+
+static inline void bsim_btp_wait_for_ascs_ase_state_changed(void)
+{
+	struct btp_ascs_ase_state_changed_ev *ev;
+	struct net_buf *buf;
+
+	bsim_btp_wait_for_evt(BTP_SERVICE_ID_ASCS, BTP_ASCS_EV_ASE_STATE_CHANGED, &buf);
+	ev = net_buf_pull_mem(buf, sizeof(*ev));
+
+	net_buf_unref(buf);
+}
+
+static inline void bsim_btp_bap_discover(const bt_addr_le_t *address)
+{
+	struct btp_bap_discover_cmd *cmd;
+	struct btp_hdr *cmd_hdr;
+
+	NET_BUF_SIMPLE_DEFINE(cmd_buffer, BTP_MTU);
+
+	cmd_hdr = net_buf_simple_add(&cmd_buffer, sizeof(*cmd_hdr));
+	cmd_hdr->service = BTP_SERVICE_ID_BAP;
+	cmd_hdr->opcode = BTP_BAP_DISCOVER;
+	cmd_hdr->index = BTP_INDEX;
+	cmd = net_buf_simple_add(&cmd_buffer, sizeof(*cmd));
+	bt_addr_le_copy(&cmd->address, address);
+
+	cmd_hdr->len = sys_cpu_to_le16(cmd_buffer.len - sizeof(*cmd_hdr));
+
+	bsim_btp_send_to_tester(cmd_buffer.data, cmd_buffer.len);
+}
+
+static inline void bsim_btp_wait_for_bap_discovered(void)
+{
+	struct btp_bap_discovery_completed_ev *ev;
+	struct net_buf *buf;
+
+	bsim_btp_wait_for_evt(BTP_SERVICE_ID_BAP, BTP_BAP_EV_DISCOVERY_COMPLETED, &buf);
+	ev = net_buf_pull_mem(buf, sizeof(*ev));
+
+	TEST_ASSERT(ev->status == BT_ATT_ERR_SUCCESS);
+
+	net_buf_unref(buf);
+}
+
+static inline void bsim_btp_wait_for_bap_ase_found(uint8_t *ase_id)
+{
+	struct btp_bap_ase_found_ev *ev;
+	struct net_buf *buf;
+
+	bsim_btp_wait_for_evt(BTP_SERVICE_ID_BAP, BTP_BAP_EV_ASE_FOUND, &buf);
+	ev = net_buf_pull_mem(buf, sizeof(*ev));
+
+	if (ase_id != NULL) {
+		*ase_id = ev->ase_id;
+	}
+
+	net_buf_unref(buf);
+}
+
 static inline void bsim_btp_ccp_discover(const bt_addr_le_t *address)
 {
 	struct btp_ccp_discover_tbs_cmd *cmd;
@@ -38,7 +319,7 @@ static inline void bsim_btp_ccp_discover(const bt_addr_le_t *address)
 	cmd = net_buf_simple_add(&cmd_buffer, sizeof(*cmd));
 	bt_addr_le_copy(&cmd->address, address);
 
-	cmd_hdr->len = cmd_buffer.len - sizeof(*cmd_hdr);
+	cmd_hdr->len = sys_cpu_to_le16(cmd_buffer.len - sizeof(*cmd_hdr));
 
 	bsim_btp_send_to_tester(cmd_buffer.data, cmd_buffer.len);
 }
@@ -61,7 +342,7 @@ static inline void bsim_btp_ccp_originate_call(const bt_addr_le_t *address, uint
 	cmd->uri_len = strlen(uri) + 1 /* NULL terminator */;
 	net_buf_simple_add_mem(&cmd_buffer, uri, cmd->uri_len);
 
-	cmd_hdr->len = cmd_buffer.len - sizeof(*cmd_hdr);
+	cmd_hdr->len = sys_cpu_to_le16(cmd_buffer.len - sizeof(*cmd_hdr));
 
 	bsim_btp_send_to_tester(cmd_buffer.data, cmd_buffer.len);
 }
@@ -125,7 +406,7 @@ static inline void bsim_btp_csip_discover(const bt_addr_le_t *address)
 	cmd = net_buf_simple_add(&cmd_buffer, sizeof(*cmd));
 	bt_addr_le_copy(&cmd->address, address);
 
-	cmd_hdr->len = cmd_buffer.len - sizeof(*cmd_hdr);
+	cmd_hdr->len = sys_cpu_to_le16(cmd_buffer.len - sizeof(*cmd_hdr));
 
 	bsim_btp_send_to_tester(cmd_buffer.data, cmd_buffer.len);
 }
@@ -144,7 +425,7 @@ static inline void bsim_btp_csip_set_coordinator_lock(void)
 	cmd = net_buf_simple_add(&cmd_buffer, sizeof(*cmd));
 	cmd->addr_cnt = 0U; /* Zephyr BT Tester only supports this value being 0 */
 
-	cmd_hdr->len = cmd_buffer.len - sizeof(*cmd_hdr);
+	cmd_hdr->len = sys_cpu_to_le16(cmd_buffer.len - sizeof(*cmd_hdr));
 
 	bsim_btp_send_to_tester(cmd_buffer.data, cmd_buffer.len);
 }
@@ -414,7 +695,7 @@ static inline void bsim_btp_hauc_init(void)
 
 	/* command is empty */
 
-	cmd_hdr->len = cmd_buffer.len - sizeof(*cmd_hdr);
+	cmd_hdr->len = sys_cpu_to_le16(cmd_buffer.len - sizeof(*cmd_hdr));
 
 	bsim_btp_send_to_tester(cmd_buffer.data, cmd_buffer.len);
 }
@@ -433,7 +714,7 @@ static inline void bsim_btp_hauc_discover(const bt_addr_le_t *address)
 	cmd = net_buf_simple_add(&cmd_buffer, sizeof(*cmd));
 	bt_addr_le_copy(&cmd->address, address);
 
-	cmd_hdr->len = cmd_buffer.len - sizeof(*cmd_hdr);
+	cmd_hdr->len = sys_cpu_to_le16(cmd_buffer.len - sizeof(*cmd_hdr));
 
 	bsim_btp_send_to_tester(cmd_buffer.data, cmd_buffer.len);
 }
@@ -545,7 +826,7 @@ static inline void bsim_btp_tmap_discover(const bt_addr_le_t *address)
 	cmd = net_buf_simple_add(&cmd_buffer, sizeof(*cmd));
 	bt_addr_le_copy(&cmd->address, address);
 
-	cmd_hdr->len = cmd_buffer.len - sizeof(*cmd_hdr);
+	cmd_hdr->len = sys_cpu_to_le16(cmd_buffer.len - sizeof(*cmd_hdr));
 
 	bsim_btp_send_to_tester(cmd_buffer.data, cmd_buffer.len);
 }

--- a/tests/bsim/bluetooth/tester/src/bsim_btp.h
+++ b/tests/bsim/bluetooth/tester/src/bsim_btp.h
@@ -289,6 +289,225 @@ static inline void bsim_btp_wait_for_bap_discovered(void)
 
 	net_buf_unref(buf);
 }
+static inline void bsim_btp_bap_broadcast_adv_start(uint32_t broadcast_id)
+{
+	struct btp_bap_broadcast_adv_start_cmd *cmd;
+	struct btp_hdr *cmd_hdr;
+
+	NET_BUF_SIMPLE_DEFINE(cmd_buffer, BTP_MTU);
+
+	cmd_hdr = net_buf_simple_add(&cmd_buffer, sizeof(*cmd_hdr));
+	cmd_hdr->service = BTP_SERVICE_ID_BAP;
+	cmd_hdr->opcode = BTP_BAP_BROADCAST_ADV_START;
+	cmd_hdr->index = BTP_INDEX;
+	cmd = net_buf_simple_add(&cmd_buffer, sizeof(*cmd));
+	sys_put_le24(broadcast_id, cmd->broadcast_id);
+
+	cmd_hdr->len = cmd_buffer.len - sizeof(*cmd_hdr);
+
+	bsim_btp_send_to_tester(cmd_buffer.data, cmd_buffer.len);
+}
+
+static inline void bsim_btp_bap_broadcast_source_start(uint32_t broadcast_id)
+{
+	struct btp_bap_broadcast_source_start_cmd *cmd;
+	struct btp_hdr *cmd_hdr;
+
+	NET_BUF_SIMPLE_DEFINE(cmd_buffer, BTP_MTU);
+
+	cmd_hdr = net_buf_simple_add(&cmd_buffer, sizeof(*cmd_hdr));
+	cmd_hdr->service = BTP_SERVICE_ID_BAP;
+	cmd_hdr->opcode = BTP_BAP_BROADCAST_SOURCE_START;
+	cmd_hdr->index = BTP_INDEX;
+	cmd = net_buf_simple_add(&cmd_buffer, sizeof(*cmd));
+	sys_put_le24(broadcast_id, cmd->broadcast_id);
+
+	cmd_hdr->len = cmd_buffer.len - sizeof(*cmd_hdr);
+
+	bsim_btp_send_to_tester(cmd_buffer.data, cmd_buffer.len);
+}
+
+static inline void bsim_btp_bap_broadcast_sink_setup(void)
+{
+	struct btp_hdr *cmd_hdr;
+
+	NET_BUF_SIMPLE_DEFINE(cmd_buffer, BTP_MTU);
+
+	cmd_hdr = net_buf_simple_add(&cmd_buffer, sizeof(*cmd_hdr));
+	cmd_hdr->service = BTP_SERVICE_ID_BAP;
+	cmd_hdr->opcode = BTP_BAP_BROADCAST_SINK_SETUP;
+	cmd_hdr->index = BTP_INDEX;
+
+	/* The command for this is empty */
+
+	cmd_hdr->len = cmd_buffer.len - sizeof(*cmd_hdr);
+
+	bsim_btp_send_to_tester(cmd_buffer.data, cmd_buffer.len);
+}
+
+static inline void bsim_btp_bap_broadcast_sink_release(void)
+{
+	struct btp_hdr *cmd_hdr;
+
+	NET_BUF_SIMPLE_DEFINE(cmd_buffer, BTP_MTU);
+
+	cmd_hdr = net_buf_simple_add(&cmd_buffer, sizeof(*cmd_hdr));
+	cmd_hdr->service = BTP_SERVICE_ID_BAP;
+	cmd_hdr->opcode = BTP_BAP_BROADCAST_SINK_RELEASE;
+	cmd_hdr->index = BTP_INDEX;
+
+	/* The command for this is empty */
+
+	cmd_hdr->len = cmd_buffer.len - sizeof(*cmd_hdr);
+
+	bsim_btp_send_to_tester(cmd_buffer.data, cmd_buffer.len);
+}
+
+static inline void bsim_btp_bap_broadcast_scan_start(void)
+{
+	struct btp_hdr *cmd_hdr;
+
+	NET_BUF_SIMPLE_DEFINE(cmd_buffer, BTP_MTU);
+
+	cmd_hdr = net_buf_simple_add(&cmd_buffer, sizeof(*cmd_hdr));
+	cmd_hdr->service = BTP_SERVICE_ID_BAP;
+	cmd_hdr->opcode = BTP_BAP_BROADCAST_SCAN_START;
+	cmd_hdr->index = BTP_INDEX;
+
+	/* The command for this is empty */
+
+	cmd_hdr->len = cmd_buffer.len - sizeof(*cmd_hdr);
+
+	bsim_btp_send_to_tester(cmd_buffer.data, cmd_buffer.len);
+}
+
+static inline void bsim_btp_bap_broadcast_scan_stop(void)
+{
+	struct btp_hdr *cmd_hdr;
+
+	NET_BUF_SIMPLE_DEFINE(cmd_buffer, BTP_MTU);
+
+	cmd_hdr = net_buf_simple_add(&cmd_buffer, sizeof(*cmd_hdr));
+	cmd_hdr->service = BTP_SERVICE_ID_BAP;
+	cmd_hdr->opcode = BTP_BAP_BROADCAST_SCAN_STOP;
+	cmd_hdr->index = BTP_INDEX;
+
+	/* The command for this is empty */
+
+	cmd_hdr->len = cmd_buffer.len - sizeof(*cmd_hdr);
+
+	bsim_btp_send_to_tester(cmd_buffer.data, cmd_buffer.len);
+}
+
+static inline void bsim_btp_bap_broadcast_sink_sync(const bt_addr_le_t *address,
+						    uint32_t broadcast_id, uint8_t advertiser_sid,
+						    uint16_t skip, uint16_t sync_timeout,
+						    bool past_avail, uint8_t src_id)
+{
+	struct btp_bap_broadcast_sink_sync_cmd *cmd;
+	struct btp_hdr *cmd_hdr;
+
+	NET_BUF_SIMPLE_DEFINE(cmd_buffer, BTP_MTU);
+
+	cmd_hdr = net_buf_simple_add(&cmd_buffer, sizeof(*cmd_hdr));
+	cmd_hdr->service = BTP_SERVICE_ID_BAP;
+	cmd_hdr->opcode = BTP_BAP_BROADCAST_SINK_SYNC;
+	cmd_hdr->index = BTP_INDEX;
+	cmd = net_buf_simple_add(&cmd_buffer, sizeof(*cmd));
+	bt_addr_le_copy(&cmd->address, address);
+	sys_put_le24(broadcast_id, cmd->broadcast_id);
+	cmd->advertiser_sid = advertiser_sid;
+	cmd->skip = sys_cpu_to_le16(skip);
+	cmd->sync_timeout = sys_cpu_to_le16(sync_timeout);
+	cmd->past_avail = past_avail ? 1U : 0U;
+	cmd->src_id = src_id;
+
+	cmd_hdr->len = cmd_buffer.len - sizeof(*cmd_hdr);
+
+	bsim_btp_send_to_tester(cmd_buffer.data, cmd_buffer.len);
+}
+
+static inline void bsim_btp_bap_broadcast_sink_stop(const bt_addr_le_t *address,
+						    uint32_t broadcast_id)
+{
+	struct btp_bap_broadcast_sink_stop_cmd *cmd;
+	struct btp_hdr *cmd_hdr;
+
+	NET_BUF_SIMPLE_DEFINE(cmd_buffer, BTP_MTU);
+
+	cmd_hdr = net_buf_simple_add(&cmd_buffer, sizeof(*cmd_hdr));
+	cmd_hdr->service = BTP_SERVICE_ID_BAP;
+	cmd_hdr->opcode = BTP_BAP_BROADCAST_SINK_STOP;
+	cmd_hdr->index = BTP_INDEX;
+	cmd = net_buf_simple_add(&cmd_buffer, sizeof(*cmd));
+	bt_addr_le_copy(&cmd->address, address);
+	sys_put_le24(broadcast_id, cmd->broadcast_id);
+
+	cmd_hdr->len = cmd_buffer.len - sizeof(*cmd_hdr);
+
+	bsim_btp_send_to_tester(cmd_buffer.data, cmd_buffer.len);
+}
+
+static inline void bsim_btp_bap_broadcast_sink_bis_sync(const bt_addr_le_t *address,
+							uint32_t broadcast_id,
+							uint32_t requested_bis_sync)
+{
+	struct btp_bap_broadcast_sink_bis_sync_cmd *cmd;
+	struct btp_hdr *cmd_hdr;
+
+	NET_BUF_SIMPLE_DEFINE(cmd_buffer, BTP_MTU);
+
+	cmd_hdr = net_buf_simple_add(&cmd_buffer, sizeof(*cmd_hdr));
+	cmd_hdr->service = BTP_SERVICE_ID_BAP;
+	cmd_hdr->opcode = BTP_BAP_BROADCAST_SINK_BIS_SYNC;
+	cmd_hdr->index = BTP_INDEX;
+	cmd = net_buf_simple_add(&cmd_buffer, sizeof(*cmd));
+	bt_addr_le_copy(&cmd->address, address);
+	sys_put_le24(broadcast_id, cmd->broadcast_id);
+	cmd->requested_bis_sync = sys_cpu_to_le32(requested_bis_sync);
+
+	cmd_hdr->len = cmd_buffer.len - sizeof(*cmd_hdr);
+
+	bsim_btp_send_to_tester(cmd_buffer.data, cmd_buffer.len);
+}
+
+static inline void bsim_btp_bap_broadcast_source_setup_v2(
+	uint32_t broadcast_id, uint8_t streams_per_subgroup, uint8_t subgroups,
+	uint32_t sdu_interval, uint8_t framing, uint16_t max_sdu, uint8_t rtn, uint16_t max_latency,
+	uint32_t presentation_delay, uint8_t coding_format, uint16_t vid, uint16_t cid,
+	uint8_t cc_ltvs_len, const uint8_t cc_ltvs[])
+{
+	struct btp_bap_broadcast_source_setup_v2_cmd *cmd;
+	struct btp_hdr *cmd_hdr;
+
+	NET_BUF_SIMPLE_DEFINE(cmd_buffer, BTP_MTU);
+
+	cmd_hdr = net_buf_simple_add(&cmd_buffer, sizeof(*cmd_hdr));
+	cmd_hdr->service = BTP_SERVICE_ID_BAP;
+	cmd_hdr->opcode = BTP_BAP_BROADCAST_SOURCE_SETUP_V2;
+	cmd_hdr->index = BTP_INDEX;
+	cmd = net_buf_simple_add(&cmd_buffer, sizeof(*cmd));
+	sys_put_le24(broadcast_id, cmd->broadcast_id);
+	cmd->streams_per_subgroup = streams_per_subgroup;
+	cmd->subgroups = subgroups;
+	sys_put_le24(sdu_interval, cmd->sdu_interval);
+	cmd->framing = framing;
+	cmd->max_sdu = sys_cpu_to_le16(max_sdu);
+	cmd->retransmission_num = rtn;
+	cmd->max_transport_latency = sys_cpu_to_le16(max_latency);
+	sys_put_le24(presentation_delay, cmd->presentation_delay);
+	cmd->coding_format = coding_format;
+	cmd->vid = sys_cpu_to_le16(vid);
+	cmd->cid = sys_cpu_to_le16(cid);
+	cmd->cc_ltvs_len = cc_ltvs_len;
+	if (cc_ltvs_len > 0U) {
+		(void)net_buf_simple_add_mem(&cmd_buffer, cc_ltvs, cc_ltvs_len);
+	}
+
+	cmd_hdr->len = cmd_buffer.len - sizeof(*cmd_hdr);
+
+	bsim_btp_send_to_tester(cmd_buffer.data, cmd_buffer.len);
+}
 
 static inline void bsim_btp_wait_for_bap_ase_found(uint8_t *ase_id)
 {
@@ -301,6 +520,67 @@ static inline void bsim_btp_wait_for_bap_ase_found(uint8_t *ase_id)
 	if (ase_id != NULL) {
 		*ase_id = ev->ase_id;
 	}
+
+	net_buf_unref(buf);
+}
+
+static inline void bsim_btp_wait_for_bap_baa_found(bt_addr_le_t *address, uint32_t *broadcast_id,
+						   uint8_t *advertiser_sid)
+{
+	struct btp_bap_baa_found_ev *ev;
+	struct net_buf *buf;
+
+	bsim_btp_wait_for_evt(BTP_SERVICE_ID_BAP, BTP_BAP_EV_BAA_FOUND, &buf);
+	ev = net_buf_pull_mem(buf, sizeof(*ev));
+
+	if (address != NULL) {
+		bt_addr_le_copy(address, &ev->address);
+	}
+
+	if (broadcast_id != NULL) {
+		*broadcast_id = sys_get_le24(ev->broadcast_id);
+	}
+
+	if (advertiser_sid != NULL) {
+		*advertiser_sid = ev->advertiser_sid;
+	}
+
+	net_buf_unref(buf);
+}
+
+static inline void bsim_btp_wait_for_bap_bap_bis_found(uint8_t *bis_id)
+{
+	struct btp_bap_bis_found_ev *ev;
+	struct net_buf *buf;
+
+	bsim_btp_wait_for_evt(BTP_SERVICE_ID_BAP, BTP_BAP_EV_BIS_FOUND, &buf);
+	ev = net_buf_pull_mem(buf, sizeof(*ev));
+
+	if (bis_id != NULL) {
+		*bis_id = ev->bis_id;
+	}
+
+	net_buf_unref(buf);
+}
+
+static inline void bsim_btp_wait_for_btp_bap_bis_synced(void)
+{
+	struct btp_bap_bis_synced_ev *ev;
+	struct net_buf *buf;
+
+	bsim_btp_wait_for_evt(BTP_SERVICE_ID_BAP, BTP_BAP_EV_BIS_SYNCED, &buf);
+	ev = net_buf_pull_mem(buf, sizeof(*ev));
+
+	net_buf_unref(buf);
+}
+
+static inline void bsim_btp_wait_for_bap_bis_stream_received(void)
+{
+	struct btp_bap_bis_stream_received_ev *ev;
+	struct net_buf *buf;
+
+	bsim_btp_wait_for_evt(BTP_SERVICE_ID_BAP, BTP_BAP_EV_BIS_STREAM_RECEIVED, &buf);
+	ev = net_buf_pull_mem(buf, sizeof(*ev));
 
 	net_buf_unref(buf);
 }

--- a/tests/bsim/bluetooth/tester/src/test_main.c
+++ b/tests/bsim/bluetooth/tester/src/test_main.c
@@ -7,6 +7,8 @@
 
 #include "bstests.h"
 
+extern struct bst_test_list *test_bap_central_install(struct bst_test_list *tests);
+extern struct bst_test_list *test_bap_peripheral_install(struct bst_test_list *tests);
 extern struct bst_test_list *test_ccp_central_install(struct bst_test_list *tests);
 extern struct bst_test_list *test_ccp_peripheral_install(struct bst_test_list *tests);
 extern struct bst_test_list *test_csip_central_install(struct bst_test_list *tests);
@@ -27,6 +29,8 @@ extern struct bst_test_list *test_iso_broadcaster_install(struct bst_test_list *
 extern struct bst_test_list *test_iso_sync_receiver_install(struct bst_test_list *tests);
 
 bst_test_install_t test_installers[] = {
+	test_bap_central_install,
+	test_bap_peripheral_install,
 	test_ccp_central_install,
 	test_ccp_peripheral_install,
 	test_csip_central_install,

--- a/tests/bsim/bluetooth/tester/src/test_main.c
+++ b/tests/bsim/bluetooth/tester/src/test_main.c
@@ -7,6 +7,8 @@
 
 #include "bstests.h"
 
+extern struct bst_test_list *test_bap_broadcast_sink_install(struct bst_test_list *tests);
+extern struct bst_test_list *test_bap_broadcast_source_install(struct bst_test_list *tests);
 extern struct bst_test_list *test_bap_central_install(struct bst_test_list *tests);
 extern struct bst_test_list *test_bap_peripheral_install(struct bst_test_list *tests);
 extern struct bst_test_list *test_ccp_central_install(struct bst_test_list *tests);
@@ -29,6 +31,8 @@ extern struct bst_test_list *test_iso_broadcaster_install(struct bst_test_list *
 extern struct bst_test_list *test_iso_sync_receiver_install(struct bst_test_list *tests);
 
 bst_test_install_t test_installers[] = {
+	test_bap_broadcast_sink_install,
+	test_bap_broadcast_source_install,
 	test_bap_central_install,
 	test_bap_peripheral_install,
 	test_ccp_central_install,

--- a/tests/bsim/bluetooth/tester/tests_scripts/bap.sh
+++ b/tests/bsim/bluetooth/tester/tests_scripts/bap.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Copyright 2025 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+# Smoketest for BAP BTP commands with the BT tester
+
+simulation_id="tester_bap"
+verbosity_level=2
+EXECUTE_TIMEOUT=100
+
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
+cd ${BSIM_OUT_PATH}/bin
+
+UART_DIR=/tmp/bs_${USER}/${simulation_id}/
+UART_PER=${UART_DIR}/peripheral
+UART_CEN=${UART_DIR}/central
+
+# Central BT Tester
+Execute ./bs_${BOARD_TS}_tests_bluetooth_tester_le_audio_prj_conf \
+  -v=${verbosity_level} -s=${simulation_id} -rs=10 -d=0 -RealEncryption=1 \
+  -uart0_fifob_rxfile=${UART_CEN}.tx -uart0_fifob_txfile=${UART_CEN}.rx
+
+# Central Upper Tester
+Execute ./bs_nrf52_bsim_native_tests_bsim_bluetooth_tester_prj_conf \
+  -v=${verbosity_level} -s=${simulation_id} -rs=21 -d=10 -RealEncryption=1 -testid=bap_central \
+  -nosim -uart0_fifob_rxfile=${UART_CEN}.rx -uart0_fifob_txfile=${UART_CEN}.tx
+
+# Peripheral BT Tester
+Execute ./bs_${BOARD_TS}_tests_bluetooth_tester_le_audio_prj_conf \
+  -v=${verbosity_level} -s=${simulation_id} -rs=32 -d=1 -RealEncryption=1 \
+  -uart0_fifob_rxfile=${UART_PER}.tx -uart0_fifob_txfile=${UART_PER}.rx
+
+# Peripheral Upper Tester
+Execute ./bs_nrf52_bsim_native_tests_bsim_bluetooth_tester_prj_conf \
+  -v=${verbosity_level} -s=${simulation_id} -rs=43 -d=11 -RealEncryption=1 -testid=bap_peripheral \
+  -nosim -uart0_fifob_rxfile=${UART_PER}.rx -uart0_fifob_txfile=${UART_PER}.tx
+
+Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} -D=2 -sim_length=20e6 $@
+
+wait_for_background_jobs # Wait for all programs in background and return != 0 if any fails

--- a/tests/bsim/bluetooth/tester/tests_scripts/bap_broadcast.sh
+++ b/tests/bsim/bluetooth/tester/tests_scripts/bap_broadcast.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Copyright 2025 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+# Smoketest for BAP BTP commands with the BT tester
+
+simulation_id="tester_bap_broadcast"
+verbosity_level=2
+EXECUTE_TIMEOUT=100
+
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
+cd ${BSIM_OUT_PATH}/bin
+
+UART_DIR=/tmp/bs_${USER}/${simulation_id}/
+UART_SNK=${UART_DIR}/sink
+UART_BCST=${UART_DIR}/broadcaster
+
+# Broadcaster BT Tester
+Execute ./bs_${BOARD_TS}_tests_bluetooth_tester_le_audio_prj_conf \
+  -v=${verbosity_level} -s=${simulation_id} -rs=10 -d=0 -RealEncryption=1 \
+  -uart0_fifob_rxfile=${UART_BCST}.tx -uart0_fifob_txfile=${UART_BCST}.rx
+
+# Broadcaster Upper Tester
+Execute ./bs_nrf52_bsim_native_tests_bsim_bluetooth_tester_prj_conf \
+  -v=${verbosity_level} -s=${simulation_id} -rs=21 -d=10 -RealEncryption=1 \
+  -testid=bap_broadcast_source \
+  -nosim -uart0_fifob_rxfile=${UART_BCST}.rx -uart0_fifob_txfile=${UART_BCST}.tx
+
+# Sink BT Tester
+Execute ./bs_${BOARD_TS}_tests_bluetooth_tester_le_audio_prj_conf \
+  -v=${verbosity_level} -s=${simulation_id} -rs=32 -d=1 -RealEncryption=1 \
+  -uart0_fifob_rxfile=${UART_SNK}.tx -uart0_fifob_txfile=${UART_SNK}.rx
+
+# Sink Upper Tester
+Execute ./bs_nrf52_bsim_native_tests_bsim_bluetooth_tester_prj_conf \
+  -v=${verbosity_level} -s=${simulation_id} -rs=43 -d=11 -RealEncryption=1 \
+  -testid=bap_broadcast_sink \
+  -nosim -uart0_fifob_rxfile=${UART_SNK}.rx -uart0_fifob_txfile=${UART_SNK}.tx
+
+Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} -D=2 -sim_length=20e6 $@
+
+wait_for_background_jobs # Wait for all programs in background and return != 0 if any fails

--- a/tests/bsim/bluetooth/tester/tests_scripts/bap_unicast.sh
+++ b/tests/bsim/bluetooth/tester/tests_scripts/bap_unicast.sh
@@ -4,7 +4,7 @@
 
 # Smoketest for BAP BTP commands with the BT tester
 
-simulation_id="tester_bap"
+simulation_id="tester_bap_unicast"
 verbosity_level=2
 EXECUTE_TIMEOUT=100
 


### PR DESCRIPTION
Add smoketests for BAP unicast and broadcast for the BT Tester in BSIM

Part of https://github.com/zephyrproject-rtos/zephyr/issues/86073