### PR TITLE
manifest: hostap: Pull fix for secure associations

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -274,7 +274,7 @@ manifest:
         - hal
     - name: hostap
       path: modules/lib/hostap
-      revision: 697fd2cf5cbbd0c5375fc34761b6a9d7489a67d2
+      revision: e83c94958cab8e2327c85e484f50cbf570f5ac3f
     - name: liblc3
       revision: 48bbd3eacd36e99a57317a0a4867002e0b09e183
       path: modules/lib/liblc3


### PR DESCRIPTION
commit 0e4cf09b55104b60909c2f5b0bcf4a0811513dbd has modified the protocol to be encoded in network order, pull the fix to convert to host order before using protocol field.