### PR TITLE
tests: ext2: reduce ram disk size for small.overlay

### DIFF
--- a/tests/subsys/fs/ext2/ramdisk_small.overlay
+++ b/tests/subsys/fs/ext2/ramdisk_small.overlay
@@ -9,6 +9,6 @@
 		compatible = "zephyr,ram-disk";
 		disk-name = "RAM";
 		sector-size = <512>;
-		sector-count = <400>;
+		sector-count = <220>;
 	};
 };


### PR DESCRIPTION
- Reduces the ram disc sector count from 400 to 220.
- Saves about 90KB of RAM. All tests still passed.
- Allows platforms with less RAM to run the ramdisc_small.overlay test.