### PR TITLE
doc: kernel: fatal: update "Build Assertions" section intro paragraph

### DIFF
--- a/doc/kernel/services/other/fatal.rst
+++ b/doc/kernel/services/other/fatal.rst
@@ -120,8 +120,8 @@ discouraged.
 Build Assertions
 ================
 
-Zephyr provides two macros for performing build-time assertion checks.
-These are evaluated completely at compile-time, and are always checked.
+Zephyr provides a macro for performing build-time assertion checks.
+It is evaluated completely at compile-time and always checked.
 
 BUILD_ASSERT()
 --------------


### PR DESCRIPTION
A long time ago, Zephyr had two macros that could be used for build-time assertions: BUILD_ASSERT() and BUILD_ASSERT_MSG(). The latter has been dropped in v2.7 and removed from the documentation; however, the intro paragraph of the "Build Assertions" section has never been updated to reflect this, and still confusingly claims that "Zephyr provides two macros for performing build-time assertions" when only BUILD_ASSERT() remains.

Update the introductory paragraph of "Build Assertions" section such that it makes sense now that only one build-time assertion macro exists.