### PR TITLE
net: lladdr: add default case to switch

### DIFF
--- a/include/zephyr/net/net_ip.h
+++ b/include/zephyr/net/net_ip.h
@@ -1539,6 +1539,8 @@ static inline bool net_ipv6_addr_based_on_ll(const struct in6_addr *addr,
 		}
 
 		break;
+	default:
+		return false;
 	}
 
 	return false;


### PR DESCRIPTION
This commit only eliminates warning message raised by GCC when option '-Wswitch-default' is used.