### PR TITLE
Bluetooth: Controller: Remove unneeded members from ull_hdr

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/lll.h
+++ b/subsys/bluetooth/controller/ll_sw/lll.h
@@ -32,10 +32,6 @@
 /* Intervals after which connection or sync establishment is considered lost */
 #define CONN_ESTAB_COUNTDOWN 6U
 
-#if defined(CONFIG_BT_CTLR_XTAL_ADVANCED)
-#define XON_BITMASK BIT(31) /* XTAL has been retained from previous prepare */
-#endif /* CONFIG_BT_CTLR_XTAL_ADVANCED */
-
 #if defined(CONFIG_BT_BROADCASTER)
 #if defined(CONFIG_BT_CTLR_ADV_SET)
 #define BT_CTLR_ADV_SET CONFIG_BT_CTLR_ADV_SET
@@ -213,19 +209,7 @@ struct ull_hdr {
 				*/
 
 	/* Event parameters */
-	/* TODO: The intention is to use the greater of the
-	 *       ticks_prepare_to_start or ticks_active_to_start as the prepare
-	 *       offset. At the prepare tick generate a software interrupt
-	 *       serviceable by application as the per role configurable advance
-	 *       radio event notification, usable for data acquisitions.
-	 *       ticks_preempt_to_start is the per role dynamic preempt offset,
-	 *       which shall be based on role's preparation CPU usage
-	 *       requirements.
-	 */
 	struct {
-		uint32_t ticks_active_to_start;
-		uint32_t ticks_prepare_to_start;
-		uint32_t ticks_preempt_to_start;
 		uint32_t ticks_slot;
 	};
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
@@ -612,16 +612,7 @@ void lll_abort_cb(struct lll_prepare_param *prepare_param, void *param)
 
 uint32_t lll_event_offset_get(struct ull_hdr *ull)
 {
-	if (0) {
-#if defined(CONFIG_BT_CTLR_XTAL_ADVANCED)
-	} else if (ull->ticks_prepare_to_start & XON_BITMASK) {
-		return MAX(ull->ticks_active_to_start,
-			   ull->ticks_preempt_to_start);
-#endif /* CONFIG_BT_CTLR_XTAL_ADVANCED */
-	} else {
-		return MAX(ull->ticks_active_to_start,
-			   ull->ticks_prepare_to_start);
-	}
+	return HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_XTAL_US);
 }
 
 uint32_t lll_preempt_calc(struct ull_hdr *ull, uint8_t ticker_id,
@@ -1108,9 +1099,8 @@ static uint32_t preempt_ticker_start(struct lll_event *first,
 		p = &next->prepare_param;
 		ull = HDR_LLL2ULL(p->param);
 		preempt_anchor = p->ticks_at_expire;
-		preempt_to = MAX(ull->ticks_active_to_start,
-				 ull->ticks_prepare_to_start) -
-			     ull->ticks_preempt_to_start;
+		preempt_to = HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_XTAL_US) -
+			     HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_PREEMPT_MIN_US);
 
 		ticks_at_preempt_new = preempt_anchor + preempt_to;
 		ticks_at_preempt_new &= HAL_TICKER_CNTR_MASK;
@@ -1134,9 +1124,8 @@ static uint32_t preempt_ticker_start(struct lll_event *first,
 		p = &first->prepare_param;
 		ull = HDR_LLL2ULL(p->param);
 		preempt_anchor = p->ticks_at_expire;
-		preempt_to = MAX(ull->ticks_active_to_start,
-				 ull->ticks_prepare_to_start) -
-			     ull->ticks_preempt_to_start;
+		preempt_to = HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_XTAL_US) -
+			     HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_PREEMPT_MIN_US);
 
 		ticks_at_preempt_new = preempt_anchor + preempt_to;
 		ticks_at_preempt_new &= HAL_TICKER_CNTR_MASK;

--- a/subsys/bluetooth/controller/ll_sw/openisa/lll/lll.c
+++ b/subsys/bluetooth/controller/ll_sw/openisa/lll/lll.c
@@ -385,16 +385,7 @@ int lll_clk_off(void)
 
 uint32_t lll_event_offset_get(struct ull_hdr *ull)
 {
-	if (0) {
-#if defined(CONFIG_BT_CTLR_XTAL_ADVANCED)
-	} else if (ull->ticks_prepare_to_start & XON_BITMASK) {
-		return MAX(ull->ticks_active_to_start,
-			   ull->ticks_preempt_to_start);
-#endif /* CONFIG_BT_CTLR_XTAL_ADVANCED */
-	} else {
-		return MAX(ull->ticks_active_to_start,
-			   ull->ticks_prepare_to_start);
-	}
+	return HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_XTAL_US);
 }
 
 uint32_t lll_preempt_calc(struct ull_hdr *ull, uint8_t ticker_id,
@@ -674,9 +665,8 @@ static uint32_t preempt_ticker_start(struct lll_event *evt,
 	p = &evt->prepare_param;
 	ull = HDR_LLL2ULL(p->param);
 	preempt_anchor = p->ticks_at_expire;
-	preempt_to = MAX(ull->ticks_active_to_start,
-			 ull->ticks_prepare_to_start) -
-		     ull->ticks_preempt_to_start;
+	preempt_to = HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_XTAL_US) -
+		     HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_PREEMPT_MIN_US);
 
 	/* Setup pre empt timeout */
 	ret = ticker_start(TICKER_INSTANCE_ID_CTLR,

--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -1275,16 +1275,9 @@ uint8_t ll_adv_enable(uint8_t enable)
 	/* Initialize ULL context before radio event scheduling is started. */
 	ull_hdr_init(&adv->ull);
 
-	/* TODO: active_to_start feature port */
-	adv->ull.ticks_active_to_start = 0;
-	adv->ull.ticks_prepare_to_start =
-		HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_XTAL_US);
-	adv->ull.ticks_preempt_to_start =
-		HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_PREEMPT_MIN_US);
 	adv->ull.ticks_slot = HAL_TICKER_US_TO_TICKS_CEIL(time_us);
 
-	ticks_slot_offset = MAX(adv->ull.ticks_active_to_start,
-				adv->ull.ticks_prepare_to_start);
+	ticks_slot_offset = HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_XTAL_US);
 
 	if (IS_ENABLED(CONFIG_BT_CTLR_LOW_LAT)) {
 		ticks_slot_overhead = ticks_slot_offset;

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
@@ -2521,17 +2521,10 @@ uint32_t ull_adv_aux_evt_init(struct ll_adv_aux_set *aux,
 
 	time_us = aux_time_min_get(aux);
 
-	/* TODO: active_to_start feature port */
-	aux->ull.ticks_active_to_start = 0;
-	aux->ull.ticks_prepare_to_start =
-		HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_XTAL_US);
-	aux->ull.ticks_preempt_to_start =
-		HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_PREEMPT_MIN_US);
 	aux->ull.ticks_slot = HAL_TICKER_US_TO_TICKS_CEIL(time_us);
 
 	if (IS_ENABLED(CONFIG_BT_CTLR_LOW_LAT)) {
-		ticks_slot_overhead = MAX(aux->ull.ticks_active_to_start,
-					  aux->ull.ticks_prepare_to_start);
+		ticks_slot_overhead = HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_XTAL_US);
 	} else {
 		ticks_slot_overhead = 0;
 	}
@@ -3328,9 +3321,8 @@ static void mfy_aux_offset_get(void *param)
 	/* Assertion check for delayed aux_offset calculations */
 	ticks_now = ticker_ticks_now_get();
 	ticks_elapsed = ticker_ticks_diff_get(ticks_now, ticks_current);
-	ticks_to_start = MAX(adv->ull.ticks_active_to_start,
-			     adv->ull.ticks_prepare_to_start) -
-			 adv->ull.ticks_preempt_to_start;
+	ticks_to_start = HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_XTAL_US) -
+			 HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_PREEMPT_MIN_US);
 	LL_ASSERT(ticks_elapsed < ticks_to_start);
 }
 

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_iso.c
@@ -260,9 +260,7 @@ static uint8_t big_create(uint8_t big_handle, uint8_t adv_handle, uint8_t num_bi
 	if (aux && aux->is_started) {
 		ticks_slot_aux = aux->ull.ticks_slot;
 		if (IS_ENABLED(CONFIG_BT_CTLR_LOW_LAT)) {
-			ticks_slot_overhead =
-				MAX(aux->ull.ticks_active_to_start,
-				    aux->ull.ticks_prepare_to_start);
+			ticks_slot_overhead = HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_XTAL_US);
 		} else {
 			ticks_slot_overhead = 0U;
 		}
@@ -275,9 +273,7 @@ static uint8_t big_create(uint8_t big_handle, uint8_t adv_handle, uint8_t num_bi
 		ticks_slot_aux = HAL_TICKER_US_TO_TICKS_CEIL(time_us);
 		if (IS_ENABLED(CONFIG_BT_CTLR_LOW_LAT)) {
 			/* Assume primary overheads may be inherited by aux */
-			ticks_slot_overhead =
-				MAX(adv->ull.ticks_active_to_start,
-				    adv->ull.ticks_prepare_to_start);
+			ticks_slot_overhead = HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_XTAL_US);
 		} else {
 			ticks_slot_overhead = 0U;
 		}
@@ -299,8 +295,7 @@ static uint8_t big_create(uint8_t big_handle, uint8_t adv_handle, uint8_t num_bi
 	}
 
 	if (IS_ENABLED(CONFIG_BT_CTLR_LOW_LAT)) {
-		ticks_slot_overhead = MAX(sync->ull.ticks_active_to_start,
-					  sync->ull.ticks_prepare_to_start);
+		ticks_slot_overhead = HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_XTAL_US);
 	} else {
 		ticks_slot_overhead = 0U;
 	}
@@ -1279,15 +1274,9 @@ static uint32_t adv_iso_start(struct ll_adv_iso_set *adv_iso,
 
 	slot_us = adv_iso_time_get(adv_iso, false);
 
-	adv_iso->ull.ticks_active_to_start = 0U;
-	adv_iso->ull.ticks_prepare_to_start =
-		HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_XTAL_US);
-	adv_iso->ull.ticks_preempt_to_start =
-		HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_PREEMPT_MIN_US);
 	adv_iso->ull.ticks_slot = HAL_TICKER_US_TO_TICKS_CEIL(slot_us);
 
-	ticks_slot_offset = MAX(adv_iso->ull.ticks_active_to_start,
-				adv_iso->ull.ticks_prepare_to_start);
+	ticks_slot_offset = HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_XTAL_US);
 	if (IS_ENABLED(CONFIG_BT_CTLR_LOW_LAT)) {
 		ticks_slot_overhead = ticks_slot_offset;
 	} else {

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
@@ -804,16 +804,9 @@ uint32_t ull_adv_sync_evt_init(struct ll_adv_set *adv,
 
 	time_us = sync_time_get(sync, pdu);
 
-	/* TODO: active_to_start feature port */
-	sync->ull.ticks_active_to_start = 0U;
-	sync->ull.ticks_prepare_to_start =
-		HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_XTAL_US);
-	sync->ull.ticks_preempt_to_start =
-		HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_PREEMPT_MIN_US);
 	sync->ull.ticks_slot = HAL_TICKER_US_TO_TICKS_CEIL(time_us);
 
-	ticks_slot_offset = MAX(sync->ull.ticks_active_to_start,
-				sync->ull.ticks_prepare_to_start);
+	ticks_slot_offset = HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_XTAL_US);
 	if (IS_ENABLED(CONFIG_BT_CTLR_LOW_LAT)) {
 		ticks_slot_overhead = ticks_slot_offset;
 	} else {

--- a/subsys/bluetooth/controller/ll_sw/ull_central.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_central.c
@@ -316,13 +316,6 @@ uint8_t ll_create_connection(uint16_t scan_interval, uint16_t scan_window,
 	conn_lll->tifs_hcto_us = EVENT_IFS_DEFAULT_US;
 	conn_lll->tifs_cis_us = EVENT_IFS_DEFAULT_US;
 
-	/* TODO: active_to_start feature port */
-	conn->ull.ticks_active_to_start = 0U;
-	conn->ull.ticks_prepare_to_start =
-		HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_XTAL_US);
-	conn->ull.ticks_preempt_to_start =
-		HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_PREEMPT_MIN_US);
-
 #if defined(CONFIG_BT_CTLR_CHECK_SAME_PEER_CONN)
 	/* Remember peer and own identity address */
 	conn->peer_id_addr_type = peer_addr_type;
@@ -802,8 +795,7 @@ void ull_central_setup(struct node_rx_pdu *rx, struct node_rx_ftr *ftr,
 
 	ll_rx_put_sched(link, rx);
 
-	ticks_slot_offset = MAX(conn->ull.ticks_active_to_start,
-				conn->ull.ticks_prepare_to_start);
+	ticks_slot_offset = HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_XTAL_US);
 	if (IS_ENABLED(CONFIG_BT_CTLR_LOW_LAT)) {
 		ticks_slot_overhead = ticks_slot_offset;
 	} else {

--- a/subsys/bluetooth/controller/ll_sw/ull_central_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_central_iso.c
@@ -600,11 +600,6 @@ ll_cig_parameters_commit_retry:
 	slot_us += EVENT_OVERHEAD_START_US + EVENT_OVERHEAD_END_US;
 
 	/* Populate the ULL hdr with event timings overheads */
-	cig->ull.ticks_active_to_start = 0U;
-	cig->ull.ticks_prepare_to_start =
-		HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_XTAL_US);
-	cig->ull.ticks_preempt_to_start =
-		HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_PREEMPT_MIN_US);
 	cig->ull.ticks_slot = HAL_TICKER_US_TO_TICKS_CEIL(slot_us);
 #endif /* !CONFIG_BT_CTLR_JIT_SCHEDULING */
 

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -2251,18 +2251,6 @@ void ull_conn_update_parameters(struct ll_conn *conn, uint8_t is_cu_proc, uint8_
 
 	ticks_at_expire = conn->llcp.prep.ticks_at_expire;
 
-#if defined(CONFIG_BT_CTLR_XTAL_ADVANCED)
-	/* restore to normal prepare */
-	if (conn->ull.ticks_prepare_to_start & XON_BITMASK) {
-		uint32_t ticks_prepare_to_start =
-			MAX(conn->ull.ticks_active_to_start, conn->ull.ticks_preempt_to_start);
-
-		conn->ull.ticks_prepare_to_start &= ~XON_BITMASK;
-
-		ticks_at_expire -= (conn->ull.ticks_prepare_to_start - ticks_prepare_to_start);
-	}
-#endif /* CONFIG_BT_CTLR_XTAL_ADVANCED */
-
 #if defined(CONFIG_BT_CTLR_PHY)
 	ready_delay_us = lll_radio_tx_ready_delay_get(lll->phy_tx,
 						      lll->phy_flags);
@@ -2353,10 +2341,7 @@ void ull_conn_update_parameters(struct ll_conn *conn, uint8_t is_cu_proc, uint8_
 
 	/* calculate the offset */
 	if (IS_ENABLED(CONFIG_BT_CTLR_LOW_LAT)) {
-		ticks_slot_overhead =
-			MAX(conn->ull.ticks_active_to_start,
-			    conn->ull.ticks_prepare_to_start);
-
+		ticks_slot_overhead = HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_XTAL_US);
 	} else {
 		ticks_slot_overhead = 0U;
 	}

--- a/subsys/bluetooth/controller/ll_sw/ull_conn_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_iso.c
@@ -1054,16 +1054,10 @@ void ull_conn_iso_start(struct ll_conn *conn, uint16_t cis_handle,
 		 */
 
 		/* Populate the ULL hdr with event timings overheads */
-		cig->ull.ticks_active_to_start = 0U;
-		cig->ull.ticks_prepare_to_start =
-			HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_XTAL_US);
-		cig->ull.ticks_preempt_to_start =
-			HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_PREEMPT_MIN_US);
 		cig->ull.ticks_slot = HAL_TICKER_US_TO_TICKS_CEIL(slot_us);
 	}
 
-	ticks_slot_offset = MAX(cig->ull.ticks_active_to_start,
-				cig->ull.ticks_prepare_to_start);
+	ticks_slot_offset = HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_XTAL_US);
 
 	if (IS_ENABLED(CONFIG_BT_CTLR_LOW_LAT)) {
 		ticks_slot_overhead = ticks_slot_offset;

--- a/subsys/bluetooth/controller/ll_sw/ull_peripheral.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_peripheral.c
@@ -400,16 +400,9 @@ void ull_periph_setup(struct node_rx_pdu *rx, struct node_rx_ftr *ftr,
 		slot_us += EVENT_OVERHEAD_START_US + EVENT_OVERHEAD_END_US;
 	}
 
-	/* TODO: active_to_start feature port */
-	conn->ull.ticks_active_to_start = 0U;
-	conn->ull.ticks_prepare_to_start =
-		HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_XTAL_US);
-	conn->ull.ticks_preempt_to_start =
-		HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_PREEMPT_MIN_US);
 	conn->ull.ticks_slot = HAL_TICKER_US_TO_TICKS_CEIL(slot_us);
 
-	ticks_slot_offset = MAX(conn->ull.ticks_active_to_start,
-				conn->ull.ticks_prepare_to_start);
+	ticks_slot_offset = HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_XTAL_US);
 	if (IS_ENABLED(CONFIG_BT_CTLR_LOW_LAT)) {
 		ticks_slot_overhead = ticks_slot_offset;
 	} else {

--- a/subsys/bluetooth/controller/ll_sw/ull_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan.c
@@ -411,16 +411,8 @@ uint8_t ull_scan_enable(struct ll_scan_set *scan)
 	ticks_interval = HAL_TICKER_US_TO_TICKS((uint64_t)lll->interval *
 						SCAN_INT_UNIT_US);
 
-	/* TODO: active_to_start feature port */
-	scan->ull.ticks_active_to_start = 0U;
-	scan->ull.ticks_prepare_to_start =
-		HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_XTAL_US);
-	scan->ull.ticks_preempt_to_start =
-		HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_PREEMPT_MIN_US);
-
 	if (IS_ENABLED(CONFIG_BT_CTLR_LOW_LAT)) {
-		ticks_slot_overhead = MAX(scan->ull.ticks_active_to_start,
-					  scan->ull.ticks_prepare_to_start);
+		ticks_slot_overhead = HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_XTAL_US);
 	} else {
 		ticks_slot_overhead = 0U;
 	}

--- a/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
@@ -872,19 +872,12 @@ void ull_scan_aux_setup(memq_link_t *link, struct node_rx_pdu *rx)
 		aux->rx_head = rx;
 	}
 
-	/* TODO: active_to_start feature port */
-	aux->ull.ticks_active_to_start = 0;
-	aux->ull.ticks_prepare_to_start =
-		HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_XTAL_US);
-	aux->ull.ticks_preempt_to_start =
-		HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_PREEMPT_MIN_US);
 	aux->ull.ticks_slot = HAL_TICKER_US_TO_TICKS_CEIL(
 		EVENT_OVERHEAD_START_US + ready_delay_us +
 		PDU_AC_MAX_US(PDU_AC_EXT_PAYLOAD_RX_SIZE, lll_aux->phy) +
 		EVENT_OVERHEAD_END_US);
 
-	ticks_slot_offset = MAX(aux->ull.ticks_active_to_start,
-				aux->ull.ticks_prepare_to_start);
+	ticks_slot_offset = HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_XTAL_US);
 	if (IS_ENABLED(CONFIG_BT_CTLR_LOW_LAT)) {
 		ticks_slot_overhead = ticks_slot_offset;
 	} else {
@@ -2760,19 +2753,12 @@ static void chain_start_ticker(struct ll_scan_aux_chain *chain, bool replace)
 
 	ready_delay_us = lll_radio_rx_ready_delay_get(chain->lll.phy, PHY_FLAGS_S8);
 
-	/* TODO: active_to_start feature port */
-	scan_aux_set.ull.ticks_active_to_start = 0;
-	scan_aux_set.ull.ticks_prepare_to_start =
-		HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_XTAL_US);
-	scan_aux_set.ull.ticks_preempt_to_start =
-		HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_PREEMPT_MIN_US);
 	scan_aux_set.ull.ticks_slot = HAL_TICKER_US_TO_TICKS_CEIL(
 		EVENT_OVERHEAD_START_US + ready_delay_us +
 		PDU_AC_MAX_US(PDU_AC_EXT_PAYLOAD_RX_SIZE, chain->lll.phy) +
 		EVENT_OVERHEAD_END_US);
 
-	ticks_slot_offset = MAX(scan_aux_set.ull.ticks_active_to_start,
-				scan_aux_set.ull.ticks_prepare_to_start);
+	ticks_slot_offset = HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_XTAL_US);
 	if (IS_ENABLED(CONFIG_BT_CTLR_LOW_LAT)) {
 		ticks_slot_overhead = ticks_slot_offset;
 	} else {

--- a/subsys/bluetooth/controller/ll_sw/ull_sched.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sched.c
@@ -180,8 +180,7 @@ void ull_sched_mfy_after_cen_offset_get(void *param)
 
 	conn = HDR_LLL2ULL(lll->conn);
 	if (IS_ENABLED(CONFIG_BT_CTLR_LOW_LAT)) {
-		ticks_slot_overhead = MAX(conn->ull.ticks_active_to_start,
-					  conn->ull.ticks_prepare_to_start);
+		ticks_slot_overhead = HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_XTAL_US);
 	} else {
 		ticks_slot_overhead = 0U;
 	}
@@ -204,12 +203,10 @@ void ull_sched_mfy_after_cen_offset_get(void *param)
 
 void ull_sched_mfy_win_offset_use(void *param)
 {
-	struct ll_conn *conn = param;
 	uint32_t ticks_slot_overhead;
 
 	if (IS_ENABLED(CONFIG_BT_CTLR_LOW_LAT)) {
-		ticks_slot_overhead = MAX(conn->ull.ticks_active_to_start,
-					  conn->ull.ticks_prepare_to_start);
+		ticks_slot_overhead = HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_XTAL_US);
 	} else {
 		ticks_slot_overhead = 0U;
 	}
@@ -508,25 +505,7 @@ static uint8_t after_match_slot_get(uint8_t user_id, uint32_t ticks_slot_abs,
 		ticks_to_expire_normal = ticks_to_expire;
 
 #if defined(CONFIG_BT_CTLR_LOW_LAT)
-#if defined(CONFIG_BT_CTLR_XTAL_ADVANCED)
-		if (hdr->ticks_prepare_to_start & XON_BITMASK) {
-			const uint32_t ticks_prepare_to_start =
-				MAX(hdr->ticks_active_to_start,
-				    hdr->ticks_preempt_to_start);
-
-			ticks_slot_abs_curr = hdr->ticks_prepare_to_start &
-					      ~XON_BITMASK;
-			ticks_to_expire_normal -= ticks_slot_abs_curr -
-						  ticks_prepare_to_start;
-		} else
-#endif /* CONFIG_BT_CTLR_XTAL_ADVANCED */
-		{
-			const uint32_t ticks_prepare_to_start =
-				MAX(hdr->ticks_active_to_start,
-				    hdr->ticks_prepare_to_start);
-
-			ticks_slot_abs_curr = ticks_prepare_to_start;
-		}
+		ticks_slot_abs_curr = HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_XTAL_US);
 #endif
 
 		ticks_slot_abs_curr += ticks_slot;

--- a/subsys/bluetooth/controller/ll_sw/ull_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sync.c
@@ -394,16 +394,9 @@ void ull_sync_setup_from_sync_transfer(struct ll_conn *conn, uint16_t service_da
 		slot_us += EVENT_OVERHEAD_START_US + EVENT_OVERHEAD_END_US;
 	}
 
-	/* TODO: active_to_start feature port */
-	sync->ull.ticks_active_to_start = 0U;
-	sync->ull.ticks_prepare_to_start =
-		HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_XTAL_US);
-	sync->ull.ticks_preempt_to_start =
-		HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_PREEMPT_MIN_US);
 	sync->ull.ticks_slot = HAL_TICKER_US_TO_TICKS_CEIL(slot_us);
 
-	ticks_slot_offset = MAX(sync->ull.ticks_active_to_start,
-				sync->ull.ticks_prepare_to_start);
+	ticks_slot_offset = HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_XTAL_US);
 	if (IS_ENABLED(CONFIG_BT_CTLR_LOW_LAT)) {
 		ticks_slot_overhead = ticks_slot_offset;
 	} else {
@@ -1138,16 +1131,9 @@ void ull_sync_setup(struct ll_scan_set *scan, uint8_t phy,
 		slot_us += EVENT_OVERHEAD_START_US + EVENT_OVERHEAD_END_US;
 	}
 
-	/* TODO: active_to_start feature port */
-	sync->ull.ticks_active_to_start = 0U;
-	sync->ull.ticks_prepare_to_start =
-		HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_XTAL_US);
-	sync->ull.ticks_preempt_to_start =
-		HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_PREEMPT_MIN_US);
 	sync->ull.ticks_slot = HAL_TICKER_US_TO_TICKS_CEIL(slot_us);
 
-	ticks_slot_offset = MAX(sync->ull.ticks_active_to_start,
-				sync->ull.ticks_prepare_to_start);
+	ticks_slot_offset = HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_XTAL_US);
 	if (IS_ENABLED(CONFIG_BT_CTLR_LOW_LAT)) {
 		ticks_slot_overhead = ticks_slot_offset;
 	} else {

--- a/subsys/bluetooth/controller/ll_sw/ull_sync_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sync_iso.c
@@ -651,16 +651,9 @@ void ull_sync_iso_setup(struct ll_sync_iso_set *sync_iso,
 		slot_us += EVENT_OVERHEAD_START_US + EVENT_OVERHEAD_END_US;
 	}
 
-	/* TODO: active_to_start feature port */
-	sync_iso->ull.ticks_active_to_start = 0U;
-	sync_iso->ull.ticks_prepare_to_start =
-		HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_XTAL_US);
-	sync_iso->ull.ticks_preempt_to_start =
-		HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_PREEMPT_MIN_US);
 	sync_iso->ull.ticks_slot = HAL_TICKER_US_TO_TICKS_CEIL(slot_us);
 
-	ticks_slot_offset = MAX(sync_iso->ull.ticks_active_to_start,
-				sync_iso->ull.ticks_prepare_to_start);
+	ticks_slot_offset = HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_XTAL_US);
 	if (IS_ENABLED(CONFIG_BT_CTLR_LOW_LAT)) {
 		ticks_slot_overhead = ticks_slot_offset;
 	} else {


### PR DESCRIPTION
Several members of the ull_hdr can be removed, saving 12 bytes from all ULL instances used (and a bit of code as well)

ticks_active_to_start is always 0 and can be removed completely

ticks_prepare_to_start is always set to
HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_XTAL_US), so replace usage of it by this constant

ticks_preempt_to_start is always set to
HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_PREEMPT_MIN_US), so replace usage of it by this constant

In addition, remove logic handling usage of XON_BITMASK since it was only used by the long removed legacy LL