### PR TITLE
drivers: counter: nrfx_timer: Use shutdown task if available

### DIFF
--- a/drivers/counter/counter_nrfx_timer.c
+++ b/drivers/counter/counter_nrfx_timer.c
@@ -110,7 +110,13 @@ static int stop(const struct device *dev)
 {
 	const struct counter_nrfx_config *config = dev->config;
 
+#if NRF_TIMER_HAS_SHUTDOWN
+	nrf_timer_task_trigger(config->timer, NRF_TIMER_TASK_SHUTDOWN);
+#else
 	nrf_timer_task_trigger(config->timer, NRF_TIMER_TASK_STOP);
+	nrf_timer_task_trigger(config->timer, NRF_TIMER_TASK_CLEAR);
+#endif
+
 #ifdef COUNTER_ANY_FAST
 	struct counter_nrfx_data *data = dev->data;
 


### PR DESCRIPTION
Add a workaround for NRF52 anomaly 78: "High current consumption when
using timer STOP task only". Use the SHUTDOWN task instead.

For consistency, CLEAR the timer timer after STOPPING on devices that
lack the SHUTDOWN task. This also aligns the behavior with
nrfx_timer_disable().

For devices with the SHUTDOWN task, this restores the behavior previous
to e92323f0c4a6aa30992b9e0568d788f71f5211f2.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/87224