### PR TITLE
Bluetooth: Host: Improve bluetooth documentation

### DIFF
--- a/include/zephyr/bluetooth/bluetooth.h
+++ b/include/zephyr/bluetooth/bluetooth.h
@@ -1,5 +1,6 @@
-/** @file
- *  @brief Bluetooth subsystem core APIs.
+/**
+ * @file
+ * @brief Bluetooth subsystem core APIs.
  */
 
 /*
@@ -13,12 +14,14 @@
 
 /**
  * @brief Bluetooth APIs
+ *
  * @details The Bluetooth Subsystem Core APIs provide essential functionalities
  *          to use and manage Bluetooth based communication. These APIs include
  *          APIs for Bluetooth stack initialization, device discovery,
  *          connection management, data transmission, profiles and services.
  *          These APIs support both classic Bluetooth and Bluetooth Low Energy
  *          (LE) operations.
+ *
  * @defgroup bluetooth Bluetooth APIs
  * @ingroup connectivity
  * @{
@@ -41,6 +44,7 @@ extern "C" {
 
 /**
  * @brief Generic Access Profile (GAP)
+ *
  * @details The Generic Access Profile (GAP) defines fundamental Bluetooth
  *          operations, including device discovery, pairing, and connection
  *          management. Zephyr's GAP implementation supports both classic
@@ -48,6 +52,7 @@ extern "C" {
  *          roles such as Broadcaster, Observer, Peripheral, and Central. These
  *          roles define the device's behavior in advertising, scanning, and
  *          establishing connections within Bluetooth networks.
+ *
  * @defgroup bt_gap Generic Access Profile (GAP)
  * @since 1.0
  * @version 1.0.0
@@ -84,21 +89,45 @@ struct bt_iso_biginfo;
 /* Don't require everyone to include direction.h */
 struct bt_df_per_adv_sync_iq_samples_report;
 
+/**
+ * @brief Info of the advertising sent event.
+ *
+ * @note Used in @ref bt_le_ext_adv_cb.
+ */
 struct bt_le_ext_adv_sent_info {
 	/** The number of advertising events completed. */
 	uint8_t num_sent;
 };
 
+/**
+ * @brief Info of the advertising connected event.
+ *
+ * @note Used in @ref bt_le_ext_adv_cb.
+ */
 struct bt_le_ext_adv_connected_info {
 	/** Connection object of the new connection */
 	struct bt_conn *conn;
 };
 
+/**
+ * @brief Info of the advertising scanned event.
+ *
+ * @note Used in @ref bt_le_ext_adv_cb.
+ */
 struct bt_le_ext_adv_scanned_info {
 	/** Active scanner LE address and type */
 	bt_addr_le_t *addr;
 };
 
+/**
+ * @brief Info of the PAwR subevents.
+ *
+ * @details When the Controller indicates it is ready to transmit one or more PAwR subevents,
+ * @ref bt_le_per_adv_data_request holds the information about the first subevent data and the
+ * number of subevents data can be set for.
+ *
+ * @note Used in @ref bt_le_ext_adv_cb.
+ */
 struct bt_le_per_adv_data_request {
 	/** The first subevent data can be set for */
 	uint8_t start;
@@ -107,6 +136,16 @@ struct bt_le_per_adv_data_request {
 	uint8_t count;
 };
 
+/**
+ * @brief Info about the PAwR responses received.
+ *
+ * @details When the Controller indicates that one or more synced devices have responded to a
+ * periodic advertising subevent indication, @ref bt_le_per_adv_response_info holds the information
+ * about the subevent in question, its status, TX power, RSSI of the response, the Constant Tone
+ * Extension of the advertisement, and the slot the response was received in.
+ *
+ * @note Used in @ref bt_le_ext_adv_cb.
+ */
 struct bt_le_per_adv_response_info {
 	/** The subevent the response was received in */
 	uint8_t subevent;
@@ -132,6 +171,26 @@ struct bt_le_per_adv_response_info {
 	uint8_t response_slot;
 };
 
+/**
+ * @brief Callback struct to notify about advertiser activity.
+ *
+ * @details The @ref bt_le_ext_adv_cb struct contains callback functions that are invoked in
+ * response to various events related to the advertising set. These events include:
+ *     - Completion of advertising data transmission
+ *     - Acceptance of a new connection
+ *     - Transmission of scan response data
+ *     - If privacy is enabled:
+ *         - Expiration of the advertising set's validity
+ *     - If PAwR (Periodic Advertising with Response) is enabled:
+ *         - Readiness to send one or more PAwR subevents, namely the LE Periodic Advertising
+ *           Subevent Data Request event
+ *         - Response of synced devices to a periodic advertising subevent indication has been
+ *           received, namely the LE Periodic Advertising Response Report event
+ *
+ * @note Must point to valid memory during the lifetime of the advertising set.
+ *
+ * @note Used in @ref bt_le_ext_adv_create.
+ */
 struct bt_le_ext_adv_cb {
 	/**
 	 * @brief The advertising set has finished sending adv data.
@@ -167,7 +226,7 @@ struct bt_le_ext_adv_cb {
 	 * packet.
 	 *
 	 * @param adv  The advertising set object.
-	 * @param addr Information about the scanned event.
+	 * @param info Information about the scanned event, namely the address.
 	 */
 	void (*scanned)(struct bt_le_ext_adv *adv,
 			struct bt_le_ext_adv_scanned_info *info);
@@ -176,13 +235,13 @@ struct bt_le_ext_adv_cb {
 	/**
 	 * @brief The RPA validity of the advertising set has expired.
 	 *
-	 * This callback notifies the application that the RPA validity of
-	 * the advertising set has expired. The user can use this callback
-	 * to synchronize the advertising payload update with the RPA rotation.
+	 * This callback notifies the application that the RPA validity of the advertising set has
+	 * expired. The user can use this callback to synchronize the advertising payload update
+	 * with the RPA rotation by for example envoking @ref bt_le_ext_adv_set_data upon callback.
 	 *
-	 * If rpa sharing is enabled and rpa expired cb of any adv-sets belonging
-	 * to same adv id returns false, then adv-sets will continue with old rpa
-	 * through out the rpa rotations.
+	 * If RPA sharing is enabled (see @kconfig{CONFIG_BT_RPA_SHARING}) and this RPA expired
+	 * callback of any adv-sets belonging to same adv id returns false, then adv-sets will
+	 * continue with the old RPA throughout the RPA rotations.
 	 *
 	 * @param adv  The advertising set object.
 	 *
@@ -194,7 +253,7 @@ struct bt_le_ext_adv_cb {
 
 #if defined(CONFIG_BT_PER_ADV_RSP)
 	/**
-	 * @brief The Controller indicates it is ready to transmit one or more subevent.
+	 * @brief The Controller indicates it is ready to transmit one or more PAwR subevents.
 	 *
 	 * This callback notifies the application that the controller has requested
 	 * data for upcoming subevents.
@@ -470,13 +529,16 @@ int bt_id_delete(uint8_t id);
 /**
  * @brief Bluetooth data.
  *
- * Description of different data types that can be encoded into
- * advertising data. Used to form arrays that are passed to the
- * bt_le_adv_start() function.
+ * @details Description of different AD Types that can be encoded into advertising data. Used to
+ * form arrays that are passed to the @ref bt_le_adv_start function. The @ref BT_DATA define can
+ * be used as a helpter to declare the elements of an @ref bt_data array.
  */
 struct bt_data {
+	/** Type of scan response data or advertisement data. */
 	uint8_t type;
+	/** Length of scan response data or advertisement data. */
 	uint8_t data_len;
+	/** Pointer to Scan response or advertisement data. */
 	const uint8_t *data;
 };
 
@@ -484,7 +546,7 @@ struct bt_data {
  * @brief Helper to declare elements of bt_data arrays
  *
  * This macro is mainly for creating an array of struct bt_data
- * elements which is then passed to e.g. @ref bt_le_adv_start().
+ * elements which is then passed to e.g. @ref bt_le_adv_start function.
  *
  * @param _type Type of advertising data field
  * @param _data Pointer to the data field payload
@@ -501,7 +563,7 @@ struct bt_data {
  * @brief Helper to declare elements of bt_data arrays
  *
  * This macro is mainly for creating an array of struct bt_data
- * elements which is then passed to e.g. @ref bt_le_adv_start().
+ * elements which is then passed to e.g. @ref bt_le_adv_start function.
  *
  * @param _type Type of advertising data field
  * @param _bytes Variable number of single-byte parameters
@@ -538,6 +600,17 @@ size_t bt_data_get_len(const struct bt_data data[], size_t data_count);
  */
 size_t bt_data_serialize(const struct bt_data *input, uint8_t *output);
 
+/**
+ * @brief Local Bluetooth LE controller features and capabilities.
+ *
+ * @details This struct provides details about the Bluetooth LE controller's supported features,
+ * states, and various other capabilities. It includes information on ACL and ISO data packet
+ * lengths, the controller's resolving list size, and the maximum advertising data length. This
+ * information can be obtained after enabling the Bluetooth stack with @ref bt_enable function.
+ *
+ * Refer to the Bluetooth Core Specification, Volume 6, Part B and Volume 4, Part E for detailed
+ * sections about each field's significance and values.
+ */
 struct bt_le_local_features {
 	/**
 	 * @brief Local LE controller supported features.
@@ -611,7 +684,7 @@ struct bt_le_local_features {
 int bt_le_get_local_features(struct bt_le_local_features *local_features);
 
 /** Advertising options */
-enum {
+enum advertising_options {
 	/** Convenience value when no options are specified. */
 	BT_LE_ADV_OPT_NONE = 0,
 
@@ -812,7 +885,8 @@ enum {
 	 *
 	 * @note Cannot be set if BT_LE_ADV_OPT_CODED is set.
 	 *
-	 * @note Requires @ref BT_LE_ADV_OPT_EXT_ADV.
+	 * @note Requires @ref BT_LE_ADV_OPT_EXT_ADV bit (see @ref advertising_options field)  to be
+	 * set as @ref bt_le_adv_param.options.
 	 */
 	BT_LE_ADV_OPT_NO_2M = BIT(11),
 
@@ -824,21 +898,24 @@ enum {
 	 * the trade-off of lower data rate and higher power consumption.
 	 * Connections will be established on LE Coded PHY.
 	 *
-	 * @note Requires @ref BT_LE_ADV_OPT_EXT_ADV
+	 * @note Requires @ref BT_LE_ADV_OPT_EXT_ADV bit (see @ref advertising_options field)  to be
+	 * set as @ref bt_le_adv_param.options.
 	 */
 	BT_LE_ADV_OPT_CODED = BIT(12),
 
 	/**
 	 * @brief Advertise without a device address (identity or RPA).
 	 *
-	 * @note Requires @ref BT_LE_ADV_OPT_EXT_ADV
+	 * @note Requires @ref BT_LE_ADV_OPT_EXT_ADV bit (see @ref advertising_options field)  to be
+	 * set as @ref bt_le_adv_param.options.
 	 */
 	BT_LE_ADV_OPT_ANONYMOUS = BIT(13),
 
 	/**
 	 * @brief Advertise with transmit power.
 	 *
-	 * @note Requires @ref BT_LE_ADV_OPT_EXT_ADV
+	 * @note Requires @ref BT_LE_ADV_OPT_EXT_ADV bit (see @ref advertising_options field)  to be
+	 * set as @ref bt_le_adv_param.options.
 	 */
 	BT_LE_ADV_OPT_USE_TX_POWER = BIT(14),
 
@@ -928,7 +1005,8 @@ struct bt_le_adv_param {
 	/**
 	 * @brief Advertising Set Identifier, valid range 0x00 - 0x0f.
 	 *
-	 * @note Requires @ref BT_LE_ADV_OPT_EXT_ADV
+	 * @note Requires @ref BT_LE_ADV_OPT_EXT_ADV bit (see @ref advertising_options field)  to be
+	 *set as @ref bt_le_adv_param.options.
 	 **/
 	uint8_t  sid;
 
@@ -938,27 +1016,34 @@ struct bt_le_adv_param {
 	 * Maximum advertising events the advertiser can skip before it must
 	 * send advertising data on the secondary advertising channel.
 	 *
-	 * @note Requires @ref BT_LE_ADV_OPT_EXT_ADV
+	 * @note Requires @ref BT_LE_ADV_OPT_EXT_ADV bit (see @ref advertising_options field)  to be
+	 * set as @ref bt_le_adv_param.options.
 	 */
 	uint8_t  secondary_max_skip;
 
-	/** Bit-field of advertising options */
+	/** @brief Bit-field of advertising options, see the @ref advertising_options field. */
 	uint32_t options;
 
-	/** Minimum Advertising Interval (N * 0.625 milliseconds)
-	 * Minimum Advertising Interval shall be less than or equal to the
-	 * Maximum Advertising Interval. The Minimum Advertising Interval and
-	 * Maximum Advertising Interval should not be the same value (as stated
-	 * in Bluetooth Core Spec 5.2, section 7.8.5)
+	/**
+	 * @brief Minimum Advertising Interval (N * 0.625 milliseconds)
+	 *
+	 * @details The Minimum Advertising Interval shall be less than or equal to the Maximum
+	 * Advertising Interval. The Minimum Advertising Interval and Maximum Advertising Interval
+	 * aren't recommended to be the same value to enable the Controller to determine the best
+	 * advertising interval given other activities.
+	 * (See Bluetooth Core Spec 6.0, Vol 4, Part E, section 7.8.5)
 	 * Range: 0x0020 to 0x4000
 	 */
 	uint32_t interval_min;
 
-	/** Maximum Advertising Interval (N * 0.625 milliseconds)
-	 * Minimum Advertising Interval shall be less than or equal to the
-	 * Maximum Advertising Interval. The Minimum Advertising Interval and
-	 * Maximum Advertising Interval should not be the same value (as stated
-	 * in Bluetooth Core Spec 5.2, section 7.8.5)
+	/**
+	 * @brief Maximum Advertising Interval (N * 0.625 milliseconds)
+	 *
+	 * @details The Maximum Advertising Interval shall be more than or equal to the Minimum
+	 * Advertising Interval. The Minimum Advertising Interval and Maximum Advertising Interval
+	 * aren't recommended to be the same value to enable the Controller to determine the best
+	 * advertising interval given other activities.
+	 * (See Bluetooth Core Spec 6.0, Vol 4, Part E, section 7.8.5)
 	 * Range: 0x0020 to 0x4000
 	 */
 	uint32_t interval_max;
@@ -990,18 +1075,33 @@ enum {
 	/**
 	 * @brief Advertise with transmit power.
 	 *
-	 * @note Requires @ref BT_LE_ADV_OPT_EXT_ADV
+	 * @note Requires @ref BT_LE_ADV_OPT_EXT_ADV bit (see @ref advertising_options field)  to be
+	 * set as @ref bt_le_adv_param.options.
 	 */
 	BT_LE_PER_ADV_OPT_USE_TX_POWER = BIT(1),
 
 	/**
 	 * @brief Advertise with included AdvDataInfo (ADI).
 	 *
-	 * @note Requires @ref BT_LE_ADV_OPT_EXT_ADV
+	 * @note Requires @ref BT_LE_ADV_OPT_EXT_ADV bit (see @ref advertising_options field)  to be
+	 * set as @ref bt_le_adv_param.options.
 	 */
 	BT_LE_PER_ADV_OPT_INCLUDE_ADI = BIT(2),
 };
 
+/**
+ * @brief Parameters for configuring periodic advertising.
+ *
+ * @details This struct is used to configure the parameters for periodic advertising, including the
+ * minimum and maximum advertising intervals, options, and settings for subevents if periodic
+ * advertising responses are supported. The intervals are specified in units of 1.25 ms, and the
+ * options field can be used to modify other advertising behaviors. For extended advertisers, the
+ * periodic advertising parameters can be set or updated using this structure. Some parameters are
+ * conditional based on whether the device supports periodic advertising responses (configured via
+ * @kconfig{CONFIG_BT_PER_ADV_RSP}).
+ *
+ * @note Used in @ref bt_le_per_adv_set_param function.
+ */
 struct bt_le_per_adv_param {
 	/**
 	 * @brief Minimum Periodic Advertising Interval (N * 1.25 ms)
@@ -1019,7 +1119,7 @@ struct bt_le_per_adv_param {
 	 */
 	uint16_t interval_max;
 
-	/** Bit-field of periodic advertising options */
+	/** Bit-field of periodic advertising options, see the @ref advertising_options field. */
 	uint32_t options;
 
 #if defined(CONFIG_BT_PER_ADV_RSP)
@@ -1107,42 +1207,57 @@ struct bt_le_per_adv_param {
 			BT_GAP_ADV_FAST_INT_MAX_2, NULL)                                           \
 	__DEPRECATED_MACRO
 
-/** @brief GAP recommended connectable advertising
+/**
+ * @brief GAP recommended connectable advertising parameters user-initiated
  *
- * This is the recommended default for when a person is likely
- * to be waiting the device to connect or be discovered.
+ * @details This define sets the recommended default for when an application is likely waiting for
+ * the device to be connected or discovered.
  *
- * Use a longer interval to conserve battery at the cost of
- * responsiveness. Consider entering a lower power state with
- * longer intervals after a timeout.
+ * GAP recommends advertisers use the advertising parameters set by @ref BT_LE_ADV_CONN_FAST_1 for
+ * user-initiated advertisements. This might mean any time a user interacts with a device, a press
+ * on a dedicated Bluetooth wakeup button, or anything in-between. Interpretation is left to the
+ * application developer.
  *
- * GAP recommends advertisers use this "when user-initiated".
- * The application developer decides what this means. It can by
- * any time the user interacts with the device, a press on a
- * dedicated Bluetooth wakeup button, or anything in-between.
+ * Following modes are considered in these parameter settings:
+ * - Undirected Connectable Mode
+ * - Limited Discoverable Mode and sending connectable undirected advertising events
+ * - General Discoverable Mode and sending connectable undirected advertising events
+ * - Directed Connectable Mode and sending low duty cycle directed advertising events
  *
- * This is the recommended setting for limited discoverable
- * mode.
+ * @note These parameters are merely a recommendation. For example the application might use a
+ * longer interval to conserve battery, which would be at the cost of responsiveness and it should
+ * be considered to enter a lower power state with longer intervals only after a timeout.
+ *
+ * @note This is the recommended setting for limited discoverable mode.
  *
  * See Bluetooth Core Specification:
- * - 3.C.A "Timers and Constants", T_GAP(adv_fast_interval1)
- * - 3.C.9.3.11 "Connection Establishment Timing parameters"
+ * - 6.0 Vol 3, Part C, Appendix A "Timers and Constants", T_GAP(adv_fast_interval1)
+ * - 6.0 Vol 3, Part C, Section 9.3.11 "Connection Establishment Timing parameters"
  */
+
 #define BT_LE_ADV_CONN_FAST_1                                                                      \
 	BT_LE_ADV_PARAM(BT_LE_ADV_OPT_CONN, BT_GAP_ADV_FAST_INT_MIN_1, BT_GAP_ADV_FAST_INT_MAX_1,  \
 			NULL)
 
-/** @brief Connectable advertising with
- * T_GAP(adv_fast_interval2)
+/**
+ * @brief GAP recommended connectable advertising parameters non-connectable advertising events
  *
- * The advertising interval corresponds to what was offered as
- * `BT_LE_ADV_CONN` in Zephyr 3.6 and earlier, but unlike
- * `BT_LE_ADV_CONN`, the host does not automatically resume the
- * advertiser after it results in a connection.
+ * @details This define sets the recommended default for user-initiated advertisements or sending
+ * non-connectable advertising events.
+ *
+ * Following modes are considered in these parameter settings:
+ * - Non-Discoverable Mode
+ * - Non-Connectable Mode
+ * - Limited Discoverable Mode
+ * - General Discoverable Mode
+ *
+ * The advertising interval corresponds to what was offered as @ref BT_LE_ADV_CONN in Zephyr 3.6 and
+ * earlier, but unlike @ref BT_LE_ADV_CONN, the host does not automatically resume the advertiser
+ * after it results in a connection.
  *
  * See Bluetooth Core Specification:
- * - 3.C.A "Timers and Constants", T_GAP(adv_fast_interval1)
- * - 3.C.9.3.11 "Connection Establishment Timing parameters"
+ * - 6.0 Vol 3, Part C, Appendix A "Timers and Constants", T_GAP(adv_fast_interval2)
+ * - 6.0 Vol 3, Part C, Section 9.3.11 "Connection Establishment Timing parameters"
  */
 #define BT_LE_ADV_CONN_FAST_2                                                                      \
 	BT_LE_ADV_PARAM(BT_LE_ADV_OPT_CONN, BT_GAP_ADV_FAST_INT_MIN_2, BT_GAP_ADV_FAST_INT_MAX_2,  \
@@ -1319,9 +1434,10 @@ struct bt_le_per_adv_param {
 /**
  * Helper to declare periodic advertising parameters inline
  *
- * @param _int_min     Minimum periodic advertising interval
- * @param _int_max     Maximum periodic advertising interval
- * @param _options     Periodic advertising properties bitfield.
+ * @param _int_min     Minimum periodic advertising interval, N * 0.625 milliseconds
+ * @param _int_max     Maximum periodic advertising interval, N * 0.625 milliseconds
+ * @param _options     Periodic advertising properties bitfield, see @ref advertising_options
+ *                     field.
  */
 #define BT_LE_PER_ADV_PARAM_INIT(_int_min, _int_max, _options) \
 { \
@@ -1333,9 +1449,10 @@ struct bt_le_per_adv_param {
 /**
  * Helper to declare periodic advertising parameters inline
  *
- * @param _int_min     Minimum periodic advertising interval
- * @param _int_max     Maximum periodic advertising interval
- * @param _options     Periodic advertising properties bitfield.
+ * @param _int_min     Minimum periodic advertising interval, N * 0.625 milliseconds
+ * @param _int_max     Maximum periodic advertising interval, N * 0.625 milliseconds
+ * @param _options     Periodic advertising properties bitfield, see @ref advertising_options
+ *                     field.
  */
 #define BT_LE_PER_ADV_PARAM(_int_min, _int_max, _options) \
 	((struct bt_le_per_adv_param[]) { \
@@ -1422,6 +1539,19 @@ int bt_le_ext_adv_create(const struct bt_le_adv_param *param,
 			 const struct bt_le_ext_adv_cb *cb,
 			 struct bt_le_ext_adv **adv);
 
+/**
+ * @brief Parameters for starting an extended advertising session.
+ *
+ * @details This struct provides the parameters to control the behavior of an extended advertising
+ * session, including the timeout and the number of advertising events to send. The timeout is
+ * specified in units of 10 ms, and the number of events determines how many times the advertising
+ * will be sent before stopping. If either the timeout or number of events is reached, the
+ * advertising session will be stopped, and the application will be notified via the advertiser sent
+ * callback. If both parameters are provided, the advertising session will stop when either limit is
+ * reached.
+ *
+ * @note Used in @ref bt_le_ext_adv_start function.
+ */
 struct bt_le_ext_adv_start_param {
 	/**
 	 * @brief Advertiser timeout (N * 10 ms).
@@ -1440,8 +1570,8 @@ struct bt_le_ext_adv_start_param {
 	/**
 	 * @brief Number of advertising events.
 	 *
-	 * Application will be notified by the advertiser sent callback.
-	 * Set to zero for no limit.
+	 * Application will be notified by the advertisement sent callback, once num_events are
+	 * reached. Set to zero for no limit.
 	 */
 	uint8_t  num_events;
 };
@@ -1624,6 +1754,16 @@ int bt_le_per_adv_set_param(struct bt_le_ext_adv *adv,
 int bt_le_per_adv_set_data(const struct bt_le_ext_adv *adv,
 			   const struct bt_data *ad, size_t ad_len);
 
+/**
+ * @brief Parameters for setting data for a specific periodic advertising with response subevent.
+ *
+ * @details This struct provides the necessary information to set the data for a specific subevent
+ * in a Periodic Advertising with Response (PAwR) scenario. It specifies the subevent number, the
+ * range of response slots to listen to, and the actual data to send. This is used to respond to
+ * data request from an advertiser by sending back the data in the specified subevent.
+ *
+ * @note Used in @ref bt_le_per_adv_set_subevent_data function.
+ */
 struct bt_le_per_adv_subevent_data_params {
 	/** The subevent to set data for */
 	uint8_t subevent;
@@ -1665,8 +1805,8 @@ int bt_le_per_adv_set_subevent_data(const struct bt_le_ext_adv *adv, uint8_t num
  * periodic advertising and extended advertising can be enabled in any order.
  *
  * Once periodic advertising has been enabled, it will continue advertising
- * until @ref bt_le_per_adv_stop() has been called, or if the advertising set
- * is deleted by @ref bt_le_ext_adv_delete(). Calling @ref bt_le_ext_adv_stop()
+ * until @ref bt_le_per_adv_stop function has been called, or if the advertising set
+ * is deleted by @ref bt_le_ext_adv_delete function. Calling @ref bt_le_ext_adv_stop function
  * will not stop the periodic advertising.
  *
  * @param adv      Advertising set object.
@@ -1688,6 +1828,18 @@ int bt_le_per_adv_start(struct bt_le_ext_adv *adv);
  */
 int bt_le_per_adv_stop(struct bt_le_ext_adv *adv);
 
+/**
+ * @brief Information about the successful synchronization with periodic advertising.
+ *
+ * @details This struct provides information about the periodic advertising sync once it has been
+ * successfully established. It includes the advertiser's address, SID, the advertising interval,
+ * PHY, and the synchronization state. It also contains details about the sync, such as service data
+ * and the peer device that transferred the sync.
+ * When using periodic advertising response (configured via @kconfig{CONFIG_BT_PER_ADV_SYNC_RSP}),
+ * additional details such as subevent information and response timings are provided.
+ *
+ * @note Used in @ref bt_le_per_adv_sync_cb structure.
+ */
 struct bt_le_per_adv_sync_synced_info {
 	/** Advertiser LE address and type. */
 	const bt_addr_le_t *addr;
@@ -1734,6 +1886,16 @@ struct bt_le_per_adv_sync_synced_info {
 #endif /* CONFIG_BT_PER_ADV_SYNC_RSP */
 };
 
+/**
+ * @brief Information about the termination of a periodic advertising sync.
+ *
+ * @details This struct provides information about the termination of a periodic advertising sync.
+ * It includes the advertiser’s address and SID, along with the reason for the sync termination.
+ * This information is provided in the callback when the sync is terminated, either due to a
+ * local or remote request, or due to missing data (e.g., out of range or lost sync).
+ *
+ * @note Used in @ref bt_le_per_adv_sync_cb structure.
+ */
 struct bt_le_per_adv_sync_term_info {
 	/** Advertiser LE address and type. */
 	const bt_addr_le_t *addr;
@@ -1745,6 +1907,17 @@ struct bt_le_per_adv_sync_term_info {
 	uint8_t reason;
 };
 
+/**
+ * @brief Information about a received periodic advertising report.
+ *
+ * @details This struct holds information about a periodic advertising event that has been received.
+ * It contains details such as the advertiser’s address, SID, transmit power, RSSI, CTE type, and
+ * additional information depending on the configuration (e.g., event counter and subevent in case
+ * of a subevent indication). This information is provided in the callback when periodic advertising
+ * data is received.
+ *
+ * @note Used in @ref bt_le_per_adv_sync_cb structure.
+ */
 struct bt_le_per_adv_sync_recv_info {
 	/** Advertiser LE address and type. */
 	const bt_addr_le_t *addr;
@@ -1769,11 +1942,28 @@ struct bt_le_per_adv_sync_recv_info {
 #endif /* CONFIG_BT_PER_ADV_SYNC_RSP */
 };
 
-
+/**
+ * @brief Information about the state of periodic advertising sync.
+ *
+ * @details This struct provides information about the current state of a periodic advertising sync.
+ * It indicates whether periodic advertising reception is enabled or not. It is typically used to
+ * report the state change via callbacks in the @ref bt_le_per_adv_sync_cb structure.
+ */
 struct bt_le_per_adv_sync_state_info {
 	/** True if receiving periodic advertisements, false otherwise. */
 	bool recv_enabled;
 };
+
+/**
+ * @brief Callback struct for periodic advertising sync events.
+ *
+ * @details This struct defines the callback functions that are invoked for various periodic
+ * advertising sync events. These include when the sync is successfully established, terminated,
+ * when data is received, state changes, BIG info reports, and IQ samples from the periodic
+ * advertising.
+ *
+ * @note Used in @ref bt_le_per_adv_sync_cb_register function.
+ */
 
 struct bt_le_per_adv_sync_cb {
 	/**
@@ -1892,6 +2082,17 @@ enum {
 	BT_LE_PER_ADV_SYNC_OPT_SYNC_ONLY_CONST_TONE_EXT = BIT(6),
 };
 
+/**
+ * @brief Parameters for creating a periodic advertising sync object.
+ *
+ * @details This struct contains the parameters required to create a periodic advertising sync
+ * object, which allows the system to synchronize with periodic advertising reports from an
+ * advertiser. It includes the advertiser's address, SID, sync options, event skip, and
+ * synchronization timeout.
+ *
+ * @note bt_le_per_adv_sync_param is used as a parameter in the @ref bt_le_per_adv_sync_create
+ * function to configure synchronization behavior.
+ */
 struct bt_le_per_adv_sync_param {
 	/**
 	 * @brief Periodic Advertiser Address
@@ -2117,6 +2318,16 @@ enum {
 	BT_LE_PER_ADV_SYNC_TRANSFER_OPT_FILTER_DUPLICATES = BIT(5),
 };
 
+/**
+ * @brief Parameters for periodic advertising sync transfer.
+ *
+ * @details This struct defines the parameters for configuring periodic advertising sync transfers
+ * (PASTs). It includes settings for the maximum event skip, synchronization timeout, and options
+ * for sync transfer.
+ *
+ * @note Used in the @ref bt_le_per_adv_sync_transfer_subscribe function to configure sync transfer
+ * settings.
+ */
 struct bt_le_per_adv_sync_transfer_param {
 	/**
 	 * @brief Maximum event skip
@@ -2643,7 +2854,7 @@ int bt_le_set_rpa_timeout(uint16_t new_rpa_timeout);
 /**
  * @brief Helper for parsing advertising (or EIR or OOB) data.
  *
- * A helper for parsing the basic data types used for Extended Inquiry
+ * A helper for parsing the basic AD Types used for Extended Inquiry
  * Response (EIR), Advertising Data (AD), and OOB data blocks. The most
  * common scenario is to call this helper on the advertising data
  * received in the callback that was given to bt_le_scan_start().
@@ -2766,23 +2977,33 @@ void bt_foreach_bond(uint8_t id, void (*func)(const struct bt_bond_info *info,
 					   void *user_data),
 		     void *user_data);
 
-/** @brief Configure vendor data path
+/**
+ * @brief Configure vendor data path
  *
- *  Request the Controller to configure the data transport path in a given direction between
- *  the Controller and the Host.
+ * @details Request the Controller to configure the data transport path in a given direction between
+ * the Controller and the Host.
  *
- *  @param dir            Direction to be configured, BT_HCI_DATAPATH_DIR_HOST_TO_CTLR or
+ * @param dir            Direction to be configured, BT_HCI_DATAPATH_DIR_HOST_TO_CTLR or
  *                        BT_HCI_DATAPATH_DIR_CTLR_TO_HOST
- *  @param id             Vendor specific logical transport channel ID, range
+ * @param id             Vendor specific logical transport channel ID, range
  *                        [BT_HCI_DATAPATH_ID_VS..BT_HCI_DATAPATH_ID_VS_END]
- *  @param vs_config_len  Length of additional vendor specific configuration data
- *  @param vs_config      Pointer to additional vendor specific configuration data
+ * @param vs_config_len  Length of additional vendor specific configuration data
+ * @param vs_config      Pointer to additional vendor specific configuration data
  *
- *  @return 0 in case of success or negative value in case of error.
+ * @return 0 in case of success or negative value in case of error.
  */
 int bt_configure_data_path(uint8_t dir, uint8_t id, uint8_t vs_config_len,
 			   const uint8_t *vs_config);
 
+/**
+ * @brief Parameters for synchronizing with specific periodic advertising subevents.
+ *
+ * @details This struct contains the parameters used to synchronize with a subset of subevents in
+ * periodic advertising. It includes the periodic advertising properties, the number of subevents
+ * to sync to, and the list of subevents that the controller should synchronize with.
+ *
+ * @note Used in @ref bt_le_per_adv_sync_subevent function to control synchronization.
+ */
 struct bt_le_per_adv_sync_subevent_params {
 	/** @brief Periodic Advertising Properties.
 	 *
@@ -2815,8 +3036,17 @@ struct bt_le_per_adv_sync_subevent_params {
 int bt_le_per_adv_sync_subevent(struct bt_le_per_adv_sync *per_adv_sync,
 				struct bt_le_per_adv_sync_subevent_params *params);
 
+/**
+ * @brief Parameters for sending a periodic advertising response.
+ *
+ * @details This struct contains the parameters used when sending a response to a periodic
+ * advertising request (see @ref bt_le_per_adv_set_response_data function). The response is sent
+ * in the specified subevent and response slot, and includes event and subevent counters
+ * to track the request the response corresponds to.
+ */
 struct bt_le_per_adv_response_params {
-	/** @brief The periodic event counter of the request the response is sent to.
+	/**
+	 * @brief The periodic event counter of the request the response is sent to.
 	 *
 	 * @ref bt_le_per_adv_sync_recv_info
 	 *
@@ -2826,7 +3056,8 @@ struct bt_le_per_adv_response_params {
 	 */
 	uint16_t request_event;
 
-	/** @brief The subevent counter of the request the response is sent to.
+	/**
+	 * @brief The subevent counter of the request the response is sent to.
 	 *
 	 * @ref bt_le_per_adv_sync_recv_info
 	 *
@@ -2856,15 +3087,16 @@ int bt_le_per_adv_set_response_data(struct bt_le_per_adv_sync *per_adv_sync,
 				    const struct bt_le_per_adv_response_params *params,
 				    const struct net_buf_simple *data);
 
-/** @brief Check if a device identified by a Bluetooth LE address is bonded.
+/**
+ * @brief Check if a device identified by a Bluetooth LE address is bonded.
  *
- *  Valid Bluetooth LE identity addresses are either public address or
- *  random static address.
+ * @details Valid Bluetooth LE identity addresses are either public address or random static
+ * address.
  *
- *  @param id   Local identity (typically @ref BT_ID_DEFAULT).
- *  @param addr Bluetooth LE device address.
+ * @param id   Local identity (typically @ref BT_ID_DEFAULT).
+ * @param addr Bluetooth LE device address.
  *
- *  @return true if @p addr is bonded with local @p id
+ * @return true if @p addr is bonded with local @p id
  */
 bool bt_le_bond_exists(uint8_t id, const bt_addr_le_t *addr);
 

--- a/include/zephyr/bluetooth/gatt.h
+++ b/include/zephyr/bluetooth/gatt.h
@@ -1641,7 +1641,7 @@ uint16_t bt_gatt_get_uatt_mtu(struct bt_conn *conn);
 
 /** @brief GATT Exchange MTU parameters
  *
- *  Used with @ref bt_gatt_exchange_mtu() to initiate an MTU exchange. The
+ *  Used with @ref bt_gatt_exchange_mtu function to initiate an MTU exchange. The
  *  response is handled in the callback @p func, which is called upon
  *  completion from the 'config BT_RECV_CONTEXT' context.
  *
@@ -1696,7 +1696,7 @@ struct bt_gatt_discover_params;
  *  The attribute object as well as its UUID and value objects are temporary and
  *  must be copied to in order to cache its information.
  *
- *  @note @ref bt_gatt_attr is given as an argument to bt_gatt_discover(), but
+ *  @note @ref bt_gatt_attr is given as an argument to @ref bt_gatt_discover function, but
  *  it's not a proper object of this type. @ref bt_gatt_attr.perm, and methods
  *  bt_gatt_attr.read() and bt_gatt_attr.write() are not available, and it's
  *  unsound to pass the pointer to GATT server APIs.


### PR DESCRIPTION
This commit imrpoves the bluetooth.h documentation by adding @briefs and @details to all the structs and enums lacking such, as well as clarifying the existing documentation.