### PR TITLE
boards: esp32: yaml: ignore bluetooth tests

### DIFF
--- a/boards/espressif/esp32c6_devkitc/esp32c6_devkitc.yaml
+++ b/boards/espressif/esp32c6_devkitc/esp32c6_devkitc.yaml
@@ -16,3 +16,6 @@ supported:
   - counter
   - entropy
   - i2c
+testing:
+  ignore_tags:
+    - bluetooth

--- a/boards/espressif/esp32s2_devkitc/esp32s2_devkitc.yaml
+++ b/boards/espressif/esp32s2_devkitc/esp32s2_devkitc.yaml
@@ -19,4 +19,7 @@ supported:
   - input
   - can
   - dma
+testing:
+  ignore_tags:
+    - bluetooth
 vendor: espressif

--- a/boards/espressif/esp32s2_saola/esp32s2_saola.yaml
+++ b/boards/espressif/esp32s2_saola/esp32s2_saola.yaml
@@ -17,4 +17,7 @@ supported:
   - counter
   - entropy
   - input
+testing:
+  ignore_tags:
+    - bluetooth
 vendor: espressif

--- a/boards/franzininho/esp32s2_franzininho/esp32s2_franzininho.yaml
+++ b/boards/franzininho/esp32s2_franzininho/esp32s2_franzininho.yaml
@@ -14,4 +14,5 @@ supported:
 testing:
   ignore_tags:
     - heap
+    - bluetooth
 vendor: franzininho


### PR DESCRIPTION
ESP32-S2 and ESP32-C6 does not have or support
bluetooth. Ignore any tests cases related to this peripheral.

This fixes CI errors like:
https://github.com/zephyrproject-rtos/zephyr/actions/runs/13864157503/job/38802723030?pr=84092
