### PR TITLE
Bluetooth: tester: Fix name of btp_ascs_ase_found_ev

### DIFF
--- a/tests/bluetooth/tester/src/audio/btp/btp_bap.h
+++ b/tests/bluetooth/tester/src/audio/btp/btp_bap.h
@@ -216,7 +216,7 @@ struct btp_bap_codec_cap_found_ev {
 } __packed;
 
 #define BTP_BAP_EV_ASE_FOUND			0x82
-struct btp_ascs_ase_found_ev {
+struct btp_bap_ase_found_ev {
 	bt_addr_le_t address;
 	uint8_t dir;
 	uint8_t ase_id;

--- a/tests/bluetooth/tester/src/audio/btp_bap_unicast.c
+++ b/tests/bluetooth/tester/src/audio/btp_bap_unicast.c
@@ -258,7 +258,7 @@ static void btp_send_pac_codec_found_ev(struct bt_conn *conn,
 static void btp_send_ase_found_ev(struct bt_conn *conn, struct bt_bap_ep *ep)
 {
 	struct bt_bap_ep_info info;
-	struct btp_ascs_ase_found_ev ev;
+	struct btp_bap_ase_found_ev ev;
 
 	bt_addr_le_copy(&ev.address, bt_conn_get_dst(conn));
 


### PR DESCRIPTION
The event is a BAP event, and has been renamed to
btp_bap_ase_found_ev.