### PR TITLE
Bluetooth: Host: Fix compilation with clang

### DIFF
--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -729,7 +729,7 @@ static struct net_buf *bt_att_chan_create_pdu(struct bt_att_chan *chan, uint8_t 
 		/* Use a timeout only when responding/confirming */
 		timeout = BT_ATT_TIMEOUT;
 		break;
-	default:
+	default: {
 		k_tid_t current_thread = k_current_get();
 
 		if (current_thread == k_work_queue_thread_get(&k_sys_work_q)) {
@@ -741,6 +741,7 @@ static struct net_buf *bt_att_chan_create_pdu(struct bt_att_chan *chan, uint8_t 
 		} else {
 			timeout = K_FOREVER;
 		}
+	}
 	}
 
 	/* This will reserve headspace for lower layers */


### PR DESCRIPTION
clang fails to build without this change:

subsys/bluetooth/host/att.c:733:3: error: expected expression
	k_tid_t current_thread = k_current_get();
	^
subsys/bluetooth/host/att.c:735:7: error: use of undeclared identifier 'current_thread'
	if (current_thread == k_work_queue_thread_get(&k_sys_work_q)) {
	    ^
subsys/bluetooth/host/att.c:738:14: error: use of undeclared identifier 'current_thread'
	} else if (current_thread == att_handle_rsp_thread) {
		   ^