### PR TITLE
tests: bluetooth: tester: Fix memset pointer

### DIFF
--- a/tests/bluetooth/tester/src/audio/btp_bap_broadcast.c
+++ b/tests/bluetooth/tester/src/audio/btp_bap_broadcast.c
@@ -88,7 +88,7 @@ static int btp_bap_broadcast_local_source_free(struct btp_bap_broadcast_local_so
 		return -EINVAL;
 	}
 
-	memset(&source, 0, sizeof(*source));
+	memset(source, 0, sizeof(*source));
 
 	return 0;
 }


### PR DESCRIPTION
Building with clang warns:

tests/bluetooth/tester/src/audio/btp_bap_broadcast.c:91:2: error:
'memset' will always overflow; destination buffer has size 4, but size
argument is 1324 [-Werror,-Wfortify-source]
        memset(&source, 0, sizeof(*source));
        ^

We were incorrectly memset'ing a pointer to the struct pointer, not the
pointer to the struct itself.