### PR TITLE
drivers: bbram: npcx: bypass npcx49nf errata rev1.5 No.2.30

### DIFF
--- a/drivers/bbram/Kconfig.npcx
+++ b/drivers/bbram/Kconfig.npcx
@@ -15,3 +15,12 @@ config BBRAM_NPCX_EMUL
 	depends on EMUL
 	help
 	  Enable the emulator for the NPCX BBRAM.
+
+config BBRAM_NPCX_STATUS_REG_WRITE_WORKAROUND
+	bool
+	default y if SOC_SERIES_NPCX4
+	help
+	  Workaround the issue documented in NPCX49nF errata rev1_5, No.2.30.
+	  A write operation to the BKUP_STS register might disable write to all
+	  the Battery-Backed RAM. The workaround is to read the BKUP_STS
+	  register after every write to this register.

--- a/drivers/bbram/bbram_npcx.c
+++ b/drivers/bbram/bbram_npcx.c
@@ -35,6 +35,12 @@ static int get_bit_and_reset(const struct device *dev, int mask)
 	DRV_STATUS(dev) &= ~mask;
 #else
 	DRV_STATUS(dev) = mask;
+
+	if (IS_ENABLED(CONFIG_BBRAM_NPCX_STATUS_REG_WRITE_WORKAROUND)) {
+		uint8_t __unused read_unused;
+
+		read_unused = DRV_STATUS(dev);
+	}
 #endif
 
 	return result;
@@ -71,7 +77,6 @@ static int bbram_npcx_read(const struct device *dev, size_t offset, size_t size,
 	if (size < 1 || offset + size > config->size || bbram_npcx_check_invalid(dev)) {
 		return -EINVAL;
 	}
-
 
 	bytecpy(data, ((uint8_t *)config->base_addr + offset), size);
 	return 0;


### PR DESCRIPTION
This commit workarounds the BBRAM status register write issue in npcx4:   
A write operation to the `BKUP_STS` register might disable write to all the Battery-Backed RAM (BBRM).  
The workaround is to perform a fake read from the `BKUP_STS` register after every write to this register.