### PR TITLE
Bluetooth: Add API to obtain ACL connection corresponding to a2dp

### DIFF
--- a/include/zephyr/bluetooth/classic/a2dp.h
+++ b/include/zephyr/bluetooth/classic/a2dp.h
@@ -616,6 +616,16 @@ int bt_a2dp_register_ep(struct bt_a2dp_ep *ep, uint8_t media_type, uint8_t sep_t
  */
 int bt_a2dp_register_cb(struct bt_a2dp_cb *cb);
 
+/** @brief Obtain the ACL connection corresponding to A2DP.
+ *
+ *  @param a2dp The A2DP instance.
+ *
+ *  @return Connection object associated with the A2DP context. The caller gets a new
+ *  reference to the connection object which must be released with bt_conn_unref()
+ *  once done using the object.
+ */
+struct bt_conn *bt_a2dp_get_conn(struct bt_a2dp *a2dp);
+
 /** @brief Discover remote endpoints.
  *
  *  @param a2dp The a2dp instance.

--- a/subsys/bluetooth/host/classic/a2dp.c
+++ b/subsys/bluetooth/host/classic/a2dp.c
@@ -14,6 +14,7 @@
 #include <errno.h>
 #include <zephyr/sys/atomic.h>
 #include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/check.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/printk.h>
 
@@ -1013,6 +1014,19 @@ int bt_a2dp_register_ep(struct bt_a2dp_ep *ep, uint8_t media_type, uint8_t sep_t
 	}
 
 	return 0;
+}
+
+struct bt_conn *bt_a2dp_get_conn(struct bt_a2dp *a2dp)
+{
+	CHECKIF(a2dp == NULL) {
+		return NULL;
+	}
+
+	if (!a2dp->session.br_chan.chan.conn) {
+		return NULL;
+	}
+
+	return bt_conn_ref(a2dp->session.br_chan.chan.conn);
 }
 
 int bt_a2dp_register_cb(struct bt_a2dp_cb *cb)


### PR DESCRIPTION
When connecting two devices with an application, it is necessary 
to differentiate which is the remote device.