### PR TITLE
adopt new count_bits util function tree-wide

### DIFF
--- a/drivers/adc/adc_sam.c
+++ b/drivers/adc/adc_sam.c
@@ -16,6 +16,7 @@
 
 #include <zephyr/logging/log.h>
 #include <zephyr/irq.h>
+#include <zephyr/sys/util.h>
 LOG_MODULE_REGISTER(adc_sam, CONFIG_ADC_LOG_LEVEL);
 
 #define SAM_ADC_NUM_CHANNELS 16
@@ -50,18 +51,6 @@ struct adc_sam_data {
 	/* Number of active channels to fill buffer */
 	uint8_t num_active_channels;
 };
-
-static uint8_t count_bits(uint32_t val)
-{
-	uint8_t res = 0;
-
-	while (val) {
-		res += val & 1U;
-		val >>= 1;
-	}
-
-	return res;
-}
 
 static int adc_sam_channel_setup(const struct device *dev,
 				 const struct adc_channel_cfg *channel_cfg)
@@ -156,7 +145,8 @@ static void adc_context_start_sampling(struct adc_context *ctx)
 	const struct adc_sam_config *const cfg = data->dev->config;
 	Adc *const adc = cfg->regs;
 
-	data->num_active_channels = count_bits(ctx->sequence.channels);
+	data->num_active_channels =
+		count_bits(&ctx->sequence.channels, sizeof(ctx->sequence.channels));
 
 	/* Disable all */
 	adc->ADC_CHDR = 0xffff;
@@ -222,7 +212,7 @@ static int start_read(const struct device *dev,
 		return -EINVAL;
 	}
 
-	data->num_active_channels = count_bits(channels);
+	data->num_active_channels = count_bits(&channels, sizeof(channels));
 
 	error = check_buffer_size(sequence, data->num_active_channels);
 	if (error) {

--- a/tests/kernel/common/src/bitarray.c
+++ b/tests/kernel/common/src/bitarray.c
@@ -355,29 +355,13 @@ void alloc_and_free_predefined(void)
 		     "sys_bitarray_alloc() failed bits comparison");
 }
 
-static inline size_t count_bits(uint32_t val)
-{
-	/* Implements Brian Kernighan’s Algorithm
-	 * to count bits.
-	 */
-
-	size_t cnt = 0;
-
-	while (val != 0) {
-		val = val & (val - 1);
-		cnt++;
-	}
-
-	return cnt;
-}
-
 size_t get_bitarray_popcnt(sys_bitarray_t *ba)
 {
 	size_t popcnt = 0;
 	unsigned int idx;
 
 	for (idx = 0; idx < ba->num_bundles; idx++) {
-		popcnt += count_bits(ba->bundles[idx]);
+		popcnt += count_bits(&ba->bundles[idx], sizeof(uint32_t));
 	}
 
 	return popcnt;


### PR DESCRIPTION
Adopt new count_bits helper from util.h everywhere a local equivalent was being used

Fixes conflicting definition errors seen in CI after #84022 was merged and causing many/most PRs to fail in CI