### PR TITLE
drivers: ambiq: Correct peripheral instance calculation

### DIFF
--- a/drivers/mspi/mspi_ambiq_ap3.c
+++ b/drivers/mspi/mspi_ambiq_ap3.c
@@ -26,6 +26,14 @@ LOG_MODULE_REGISTER(mspi_ambiq_ap3);
 #define PWRCTRL_MAX_WAIT_US  5
 #define MSPI_BUSY            BIT(2)
 
+#if defined(CONFIG_SOC_APOLLO3_BLUE)
+#define MSPI_BASE_ADDR       MSPI_BASE
+#define MSPI_ADDR_INTERVAL   1
+#else
+#define MSPI_BASE_ADDR       MSPI0_BASE
+#define MSPI_ADDR_INTERVAL   (MSPI1_BASE - MSPI0_BASE)
+#endif
+
 typedef int (*mspi_ambiq_pwr_func_t)(void);
 typedef void (*irq_config_func_t)(void);
 
@@ -1356,8 +1364,8 @@ static DEVICE_API(mspi, mspi_ambiq_driver_api) = {
 
 #define MSPI_CONFIG(n)                                                                           \
 	{                                                                                        \
-		.channel_num           = (DT_INST_REG_ADDR(n) - MSPI0_BASE) /                    \
-					 (DT_INST_REG_SIZE(n) * 4),                              \
+		.channel_num           = (DT_INST_REG_ADDR(n) - MSPI_BASE_ADDR) /                \
+									 MSPI_ADDR_INTERVAL,     \
 		.op_mode               = MSPI_OP_MODE_CONTROLLER,                                \
 		.duplex                = MSPI_HALF_DUPLEX,                                       \
 		.max_freq              = MSPI_MAX_FREQ,                                          \

--- a/drivers/spi/spi_ambiq_bleif.c
+++ b/drivers/spi/spi_ambiq_bleif.c
@@ -175,7 +175,7 @@ static int spi_ambiq_init(const struct device *dev)
 	}
 #endif /* CONFIG_SPI_AMBIQ_BLEIF_TIMING_TRACE */
 
-	ret = am_hal_ble_initialize((cfg->base - BLEIF_BASE) / cfg->size, &data->BLEhandle);
+	ret = am_hal_ble_initialize(0, &data->BLEhandle);
 	if (ret) {
 		return ret;
 	}

--- a/drivers/spi/spi_ambiq_spid.c
+++ b/drivers/spi/spi_ambiq_spid.c
@@ -22,10 +22,12 @@ LOG_MODULE_REGISTER(spi_ambiq_spid);
 #include "spi_context.h"
 #include <am_mcu_apollo.h>
 
+#define SPID_ADDR_INTERVAL 1
 struct spi_ambiq_config {
 	const struct gpio_dt_spec int_gpios;
 	uint32_t base;
 	int size;
+	int inst_idx;
 	const struct pinctrl_dev_config *pcfg;
 	void (*irq_config_func)(void);
 };
@@ -34,7 +36,6 @@ struct spi_ambiq_data {
 	struct spi_context ctx;
 	am_hal_ios_config_t ios_cfg;
 	void *ios_handler;
-	int inst_idx;
 	struct k_sem spim_wrcmp_sem;
 };
 
@@ -331,8 +332,7 @@ static int spi_ambiq_init(const struct device *dev)
 	const struct spi_ambiq_config *cfg = dev->config;
 	int ret = 0;
 
-	if (AM_HAL_STATUS_SUCCESS !=
-	    am_hal_ios_initialize((cfg->base - IOSLAVE_BASE) / cfg->size, &data->ios_handler)) {
+	if (AM_HAL_STATUS_SUCCESS != am_hal_ios_initialize(cfg->inst_idx, &data->ios_handler)) {
 		LOG_ERR("Fail to initialize SPID\n");
 		return -ENXIO;
 	}
@@ -400,12 +400,12 @@ static int spi_ambiq_pm_action(const struct device *dev, enum pm_device_action a
 	static struct spi_ambiq_data spi_ambiq_data##n = {                                         \
 		SPI_CONTEXT_INIT_LOCK(spi_ambiq_data##n, ctx),                                     \
 		SPI_CONTEXT_INIT_SYNC(spi_ambiq_data##n, ctx),                                     \
-		.spim_wrcmp_sem = Z_SEM_INITIALIZER(spi_ambiq_data##n.spim_wrcmp_sem, 0, 1),       \
-		.inst_idx = n};                                                                    \
+		.spim_wrcmp_sem = Z_SEM_INITIALIZER(spi_ambiq_data##n.spim_wrcmp_sem, 0, 1)};      \
 	static const struct spi_ambiq_config spi_ambiq_config##n = {                               \
 		.int_gpios = GPIO_DT_SPEC_INST_GET(n, int_gpios),                                  \
 		.base = DT_INST_REG_ADDR(n),                                                       \
 		.size = DT_INST_REG_SIZE(n),                                                       \
+		.inst_idx = (DT_INST_REG_ADDR(n) - IOSLAVE_BASE) / SPID_ADDR_INTERVAL,             \
 		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),                                         \
 		.irq_config_func = spi_irq_config_func_##n};                                       \
 	PM_DEVICE_DT_INST_DEFINE(n, spi_ambiq_pm_action);                                          \


### PR DESCRIPTION
This commit corrected ambiq peripheral instance calculations