### PR TITLE
ci: Update GitHub Actions workflows to follow principle of least privilege

### DIFF
--- a/.github/workflows/assigner.yml
+++ b/.github/workflows/assigner.yml
@@ -15,11 +15,17 @@ on:
     types:
     - labeled
 
+permissions:
+  contents: read
+
 jobs:
   assignment:
     name: Pull Request Assignment
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-22.04
+    permissions:
+      pull-requests: write # to add assignees to pull requests
+      issues: write        # to add assignees to issues
 
     steps:
     - name: Install Python dependencies

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -7,10 +7,17 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   backport:
     name: Backport
     runs-on: ubuntu-22.04
+    permissions:
+      contents: write       # to create/push backport branches
+      pull-requests: write  # to create backport PRs
+      issues: write         # to add labels to issue created if backport fails
     # Only react to merged PRs for security reasons.
     # See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target.
     if: >

--- a/.github/workflows/backport_issue_check.yml
+++ b/.github/workflows/backport_issue_check.yml
@@ -10,6 +10,9 @@ on:
     branches:
       - v*-branch
 
+permissions:
+  contents: read
+
 jobs:
   backport:
     name: Backport Issue Check
@@ -18,6 +21,8 @@ jobs:
       cancel-in-progress: true
     runs-on: ubuntu-22.04
     if: github.repository == 'zephyrproject-rtos/zephyr'
+    permissions:
+      issues: read # to check if associated issue exists for backport
 
     steps:
       - name: Check out source code

--- a/.github/workflows/bsim-tests-publish.yaml
+++ b/.github/workflows/bsim-tests-publish.yaml
@@ -5,11 +5,17 @@ on:
     workflows: ["BabbleSim Tests"]
     types:
       - completed
+
+permissions:
+  contents: read
+
 jobs:
   bsim-test-results:
     name: "Publish BabbleSim Test Results"
     runs-on: ubuntu-22.04
     if: github.event.workflow_run.conclusion != 'skipped'
+    permissions:
+      checks: write # to create the check run entry with test results
 
     steps:
       - name: Download artifacts

--- a/.github/workflows/bsim-tests.yaml
+++ b/.github/workflows/bsim-tests.yaml
@@ -28,6 +28,9 @@ on:
       - "drivers/serial/*nrfx*"
       - "tests/drivers/uart/**"
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
@@ -45,6 +48,9 @@ jobs:
       BSIM_OUT_PATH: /opt/bsim/
       BSIM_COMPONENTS_PATH: /opt/bsim/components
       EDTT_PATH: ../tools/edtt
+    permissions:
+      checks: write # to create the check run entry with test results
+
     steps:
       - name: Apply container owner mismatch workaround
         run: |

--- a/.github/workflows/bug_snapshot.yaml
+++ b/.github/workflows/bug_snapshot.yaml
@@ -13,6 +13,9 @@ on:
   # Run daily at 14:05
   - cron: '5 14 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   make_bugs_pickle:
     name: Make bugs pickle

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: '25 06,18 * * *'
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/coding_guidelines.yml
+++ b/.github/workflows/coding_guidelines.yml
@@ -2,6 +2,9 @@ name: Coding Guidelines
 
 on: pull_request
 
+permissions:
+  contents: read
+
 jobs:
   compliance_job:
     runs-on: ubuntu-22.04

--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -8,6 +8,9 @@ on:
     - reopened
     - synchronize
 
+permissions:
+  contents: read
+
 jobs:
   check_compliance:
     runs-on: ubuntu-22.04

--- a/.github/workflows/daily_test_version.yml
+++ b/.github/workflows/daily_test_version.yml
@@ -10,6 +10,9 @@ on:
     branches:
     - refs/tags/*
 
+permissions:
+  contents: read
+
 jobs:
   get_version:
     runs-on: ubuntu-22.04

--- a/.github/workflows/devicetree_checks.yml
+++ b/.github/workflows/devicetree_checks.yml
@@ -20,6 +20,9 @@ on:
     - 'scripts/dts/**'
     - '.github/workflows/devicetree_checks.yml'
 
+permissions:
+  contents: read
+
 jobs:
   devicetree-checks:
     name: Devicetree script tests

--- a/.github/workflows/do_not_merge.yml
+++ b/.github/workflows/do_not_merge.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [synchronize, opened, reopened, labeled, unlabeled]
 
+permissions:
+  contents: read
+
 jobs:
   do-not-merge:
     name: Prevent Merging

--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -11,6 +11,9 @@ on:
     - v*
   pull_request:
 
+permissions:
+  contents: read
+
 env:
   # NOTE: west docstrings will be extracted from the version listed here
   WEST_VERSION: 1.2.0

--- a/.github/workflows/doc-publish-pr.yml
+++ b/.github/workflows/doc-publish-pr.yml
@@ -10,6 +10,9 @@ on:
     types:
     - completed
 
+permissions:
+  contents: read
+
 jobs:
   doc-publish:
     name: Publish Documentation

--- a/.github/workflows/doc-publish.yml
+++ b/.github/workflows/doc-publish.yml
@@ -13,6 +13,9 @@ on:
     types:
     - completed
 
+permissions:
+  contents: read
+
 jobs:
   doc-publish:
     name: Publish Documentation

--- a/.github/workflows/errno.yml
+++ b/.github/workflows/errno.yml
@@ -6,6 +6,9 @@ on:
       - 'lib/libc/minimal/include/errno.h'
       - 'scripts/ci/errno.py'
 
+permissions:
+  contents: read
+
 jobs:
   check-errno:
     runs-on: ubuntu-22.04

--- a/.github/workflows/footprint-tracking.yml
+++ b/.github/workflows/footprint-tracking.yml
@@ -16,6 +16,9 @@ on:
       # same commit
       - 'v*'
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/greet_first_time_contributor.yml
+++ b/.github/workflows/greet_first_time_contributor.yml
@@ -6,10 +6,16 @@ on:
   pull_request_target:
     types: [opened, closed]
 
+permissions:
+  contents: read
+
 jobs:
   check_for_first_interaction:
     runs-on: ubuntu-22.04
     if: github.repository == 'zephyrproject-rtos/zephyr'
+    permissions:
+      pull-requests: write # to comment on pull requests
+      issues: write        # to comment on issues
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/hello_world_multiplatform.yaml
+++ b/.github/workflows/hello_world_multiplatform.yaml
@@ -16,6 +16,9 @@ on:
       - '.github/workflows/hello_world_multiplatform.yaml'
       - 'SDK_VERSION'
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/issue_count.yml
+++ b/.github/workflows/issue_count.yml
@@ -4,6 +4,9 @@ on:
   schedule:
   - cron: '*/10 * * * *'
 
+permissions:
+  contents: read
+
 env:
   OUTPUT_FILE_NAME: IssuesReport.md
   COMMITTER_EMAIL: actions@github.com

--- a/.github/workflows/license_check.yml
+++ b/.github/workflows/license_check.yml
@@ -2,6 +2,9 @@ name: Scancode
 
 on: [pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   scancode_job:
     runs-on: ubuntu-22.04

--- a/.github/workflows/manifest.yml
+++ b/.github/workflows/manifest.yml
@@ -2,9 +2,14 @@ name: Manifest
 on:
   pull_request_target:
 
+permissions:
+  contents: read
+
 jobs:
   contribs:
     runs-on: ubuntu-22.04
+    permissions:
+      pull-requests: write # to create/update pull request comments
     name: Manifest
     steps:
       - name: Checkout the code

--- a/.github/workflows/pylib_tests.yml
+++ b/.github/workflows/pylib_tests.yml
@@ -19,6 +19,9 @@ on:
     - 'scripts/pylib/build_helpers/**'
     - '.github/workflows/pylib_tests.yml'
 
+permissions:
+  contents: read
+
 jobs:
   pylib-tests:
     name: Misc. Pylib Unit Tests

--- a/.github/workflows/ready-to-merge.yml
+++ b/.github/workflows/ready-to-merge.yml
@@ -7,6 +7,9 @@ on:
         type: string
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   all_jobs_passed:
     name: all jobs passed

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,9 +6,14 @@ on:
       - 'v*'
       - '!v*rc*'
 
+permissions:
+  contents: read
+
 jobs:
   release:
     runs-on: ubuntu-22.04
+    permissions:
+      contents: write # to create GitHub release entry
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/scripts_tests.yml
+++ b/.github/workflows/scripts_tests.yml
@@ -19,6 +19,9 @@ on:
       - 'scripts/build/**'
       - '.github/workflows/scripts_tests.yml'
 
+permissions:
+  contents: read
+
 jobs:
   scripts-tests:
     name: Scripts tests

--- a/.github/workflows/stale-workflow-queue-cleanup.yml
+++ b/.github/workflows/stale-workflow-queue-cleanup.yml
@@ -7,6 +7,9 @@ on:
   # everyday at 15:00
   - cron: '0 15 * * *'
 
+permissions:
+  contents: read
+
 concurrency:
   group: stale-workflow-queue-cleanup
   cancel-in-progress: true
@@ -15,6 +18,8 @@ jobs:
   cleanup:
     name: Cleanup
     runs-on: ubuntu-22.04
+    permissions:
+      actions: write # to delete stale workflow runs
 
     steps:
     - name: Delete stale queued workflow runs

--- a/.github/workflows/stale_issue.yml
+++ b/.github/workflows/stale_issue.yml
@@ -3,11 +3,18 @@ on:
   schedule:
   - cron: "16 00 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   stale:
     name: Find Stale issues and PRs
     runs-on: ubuntu-22.04
     if: github.repository == 'zephyrproject-rtos/zephyr'
+    permissions:
+      pull-requests: write # to comment on stale pull requests
+      issues: write        # to comment on stale issues
+
     steps:
     - uses: actions/stale@v9
       with:

--- a/.github/workflows/stats_merged_prs.yml
+++ b/.github/workflows/stats_merged_prs.yml
@@ -6,6 +6,10 @@ on:
       - main
       - v*-branch
     types: [closed]
+
+permissions:
+  contents: read
+
 jobs:
   record_merged:
     if: github.event.pull_request.merged == true && github.repository == 'zephyrproject-rtos/zephyr'

--- a/.github/workflows/twister-prep.yaml
+++ b/.github/workflows/twister-prep.yaml
@@ -13,6 +13,9 @@ on:
         description: fullrun
         value: ${{ jobs.prep_push.outputs.fullrun != '' && jobs.prep_push.outputs.fullrun || jobs.prep_pr.outputs.size }}
 
+permissions:
+  contents: read
+
 jobs:
   prep_pr:
     if: github.repository_owner == 'zephyrproject-rtos' && github.event_name == 'pull_request_target'

--- a/.github/workflows/twister-publish.yaml
+++ b/.github/workflows/twister-publish.yaml
@@ -8,6 +8,9 @@ on:
     types:
       - completed
 
+permissions:
+  contents: read
+
 jobs:
   upload-to-elasticsearch:
     if: |

--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -15,6 +15,9 @@ on:
     # Run at 17:00 UTC on every Saturday
     - cron: '0 17 * * 6'
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
@@ -213,6 +216,8 @@ jobs:
     needs:
       - twister-build
     runs-on: ubuntu-22.04
+    permissions:
+      checks: write # to create the check run entry with Twister test results
     # the build-and-test job might be skipped, we don't need to run this job then
     if: success() || failure()
 

--- a/.github/workflows/twister_tests.yml
+++ b/.github/workflows/twister_tests.yml
@@ -26,6 +26,9 @@ on:
     - '.github/workflows/twister_tests.yml'
     - 'scripts/schemas/twister/'
 
+permissions:
+  contents: read
+
 jobs:
   twister-tests:
     name: Twister Unit Tests

--- a/.github/workflows/twister_tests_blackbox.yml
+++ b/.github/workflows/twister_tests_blackbox.yml
@@ -15,6 +15,9 @@ on:
     - 'scripts/tests/twister_blackbox/**'
     - '.github/workflows/twister_tests_blackbox.yml'
 
+permissions:
+  contents: read
+
 jobs:
   twister-tests:
     name: Twister Black Box Tests

--- a/.github/workflows/west_cmds.yml
+++ b/.github/workflows/west_cmds.yml
@@ -23,8 +23,11 @@ on:
     - 'scripts/west_commands/**'
     - '.github/workflows/west_cmds.yml'
 
+permissions:
+  contents: read
+
 jobs:
-  west-commnads:
+  west-commands:
     name: West Command Tests
     runs-on: ${{ matrix.os }}
     strategy:


### PR DESCRIPTION
Default to only giving `contents: read` permission in all workflows and then add additional permissions as needed at the job level.

This shall get us a 10/10 for the Token-Permissions category in the OpenSSF score card :)

Note for reviewers, actions/upload-artifact actions/download-artifact are apparently "special" and don't require extra permissions.