### PR TITLE
modules: hostap: enable DPP3 kconfig option

### DIFF
--- a/modules/hostap/Kconfig
+++ b/modules/hostap/Kconfig
@@ -347,6 +347,7 @@ config WIFI_NM_WPA_SUPPLICANT_DPP
 	bool "WFA Easy Connect DPP"
 	select DPP
 	select DPP2
+	select DPP3
 	select GAS
 	select GAS_SERVER
 	select OFFCHANNEL


### PR DESCRIPTION
DPP3 is must when we want to pass DPP certificate with different elliptical curves.