### PR TITLE
doc: nrf5340dk: replace nrfjprog with nrfutil

### DIFF
--- a/boards/nordic/nrf5340dk/doc/index.rst
+++ b/boards/nordic/nrf5340dk/doc/index.rst
@@ -269,7 +269,7 @@ applications as usual (:ref:`build_an_application` and
 
    .. code-block:: console
 
-      west flash -H -r nrfjprog --skip-rebuild
+      west flash -H -r nrfutil --skip-rebuild
 
 .. note::
 


### PR DESCRIPTION
Changed the runner in the west flash command to nrfutil. NCSDK-30157.