### PR TITLE
Bluetooth: Controller: Use event_offset = 2 for large CIG Sync Delays

### DIFF
--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -6007,6 +6007,7 @@ int hci_iso_handle(struct net_buf *buf, struct net_buf **evt)
 		struct ll_conn_iso_group *cig;
 		struct ll_iso_stream_hdr *hdr;
 		struct ll_iso_datapath *dp_in;
+		uint32_t sdu_interval;
 		uint8_t event_offset;
 
 		cis = ll_iso_stream_connected_get(handle);
@@ -6017,23 +6018,35 @@ int hci_iso_handle(struct net_buf *buf, struct net_buf **evt)
 		cig = cis->group;
 
 		/* We must ensure sufficient time for ISO-AL to fragment SDU and
-		 * deliver PDUs to the TX queue. By checking ull_ref_get, we
-		 * know if we are within the subevents of an ISO event. If so,
-		 * we can assume that we have enough time to deliver in the next
-		 * ISO event. If we're not active within the ISO event, we don't
-		 * know if there is enough time to deliver in the next event,
-		 * and for safety we set the target to current event + 2.
-		 *
-		 * For FT > 1, we have the opportunity to retransmit in later
+		 * deliver PDUs to the TX queue. We don't know if there is enough
+		 * time to deliver in the next event, and for safety we set the
+		 * target to current event + 2.
+		 */
+		event_offset = 2;
+
+		if (cig->lll.role) {
+			/* peripheral */
+			sdu_interval = cig->p_sdu_interval;
+		} else {
+			/* central */
+			sdu_interval = cig->c_sdu_interval;
+		}
+
+		/* By checking ull_ref_get, we know if we are within the subevents
+		 * of an ISO event. If so, we can assume that we have enough time
+		 * to deliver in the next ISO event, provided CIG sync delay is less
+		 * than an SDU interval
+		 */
+		if (ull_ref_get(&cig->ull) && cig->sync_delay < sdu_interval) {
+			event_offset -= 1;
+		}
+
+		/* For FT > 1, we have the opportunity to retransmit in later
 		 * event(s), in which case we have the option to target an
 		 * earlier event (this or next) because being late does not
 		 * instantly flush the payload.
 		 */
-
-		event_offset = ull_ref_get(&cig->ull) ? 1 : 2;
-
 		if (cis->lll.tx.ft > 1) {
-			/* FT > 1, target an earlier event */
 			event_offset -= 1;
 		}
 


### PR DESCRIPTION
For a CIG with a CIG Sync Delay larger than a SDU interval, we cannot be sure that we can target the very next ISO event when the CIG event is ongoing; Only reduce event_offset if CIG Sync Delay is smaller than an SDU interval