### PR TITLE
boards: frdm_mcxn236: enable MCUboot support

### DIFF
--- a/boards/nxp/frdm_mcxn236/Kconfig.defconfig
+++ b/boards/nxp/frdm_mcxn236/Kconfig.defconfig
@@ -1,0 +1,13 @@
+# Copyright 2025 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+if BOARD_FRDM_MCXN236
+
+if BOOTLOADER_MCUBOOT
+choice MCUBOOT_BOOTLOADER_MODE
+	# Board only supports MCUBoot via "upgrade only" method:
+	default MCUBOOT_BOOTLOADER_MODE_OVERWRITE_ONLY
+endchoice
+endif #BOOTLOADER_MCUBOOT
+
+endif

--- a/boards/nxp/frdm_mcxn236/Kconfig.sysbuild
+++ b/boards/nxp/frdm_mcxn236/Kconfig.sysbuild
@@ -1,0 +1,6 @@
+# Copyright 2025 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+choice MCUBOOT_MODE
+	default MCUBOOT_MODE_OVERWRITE_ONLY
+endchoice

--- a/boards/nxp/frdm_mcxn236/frdm_mcxn236.dtsi
+++ b/boards/nxp/frdm_mcxn236/frdm_mcxn236.dtsi
@@ -15,6 +15,7 @@
 		led2 = &blue_led;
 		sw0 = &user_button_2;
 		sw1 = &user_button_3;
+		mcuboot-button0 = &user_button_2;
 	};
 
 	leds {
@@ -115,20 +116,28 @@ nxp_8080_touch_panel_i2c: &flexcomm2_lpi2c2 {
 		#address-cells = <1>;
 		#size-cells = <1>;
 
+		/*
+		 * Partition sizes must be aligned
+		 * to the flash memory sector size of 8KB.
+		 */
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x00000000 DT_SIZE_K(64)>;
+			reg = <0x00000000 DT_SIZE_K(80)>;
 		};
-		/* Note slot 0 has one additional sector,
-		 * this is intended for use with the swap move algorithm
+		/* For the MCUBoot "upgrade only" method,
+		 * the slot sizes must be equal.
 		 */
-		slot0_partition: partition@10000 {
+		slot0_partition: partition@14000 {
 			label = "image-0";
-			reg = <0x00010000 DT_SIZE_K(480)>;
+			reg = <0x00014000 DT_SIZE_K(440)>;
 		};
-		slot1_partition: partition@88000 {
+		slot1_partition: partition@84000 {
 			label = "image-1";
-			reg = <0x0088000 DT_SIZE_K(472)>;
+			reg = <0x0084000 DT_SIZE_K(440)>;
+		};
+		storage_partition: partition@F0000 {
+			label = "storage";
+			reg = <0x000F0000 DT_SIZE_K(64)>;
 		};
 	};
 };


### PR DESCRIPTION
Enables MCUboot support for frdm-mcxn236.