### PR TITLE
Bluetooth: Controller: Select TICKER_LAZY_GET for PAST sender

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -887,6 +887,7 @@ endif # BT_CTLR_SYNC_PERIODIC
 config BT_CTLR_SYNC_TRANSFER_SENDER
 	bool "Periodic Advertising Sync Transfer sender"
 	depends on BT_CTLR_SYNC_TRANSFER_SENDER_SUPPORT
+	select BT_TICKER_LAZY_GET
 	default BT_PER_ADV_SYNC_TRANSFER_SENDER
 	help
 	  Enable support for the Periodic Advertising Sync Transfer control procedure


### PR DESCRIPTION
BT_CTLR_SYNC_TRANSFER_SENDER does not work without BT_TICKER_LAZY_GET; Add a select to the config