### PR TITLE
test: Bluetooth: BR: Add label `platform_allow`

### DIFF
--- a/tests/bluetooth/classic/sdp_c/testcase.yaml
+++ b/tests/bluetooth/classic/sdp_c/testcase.yaml
@@ -1,5 +1,8 @@
 tests:
   sdp.c:
+    platform_allow:
+      - native_sim
+      - mimxrt1170_evk@B/mimxrt1176/cm7
     integration_platforms:
       - native_sim
     tags:


### PR DESCRIPTION
Add label `platform_allow` to limit the allowed platforms.