### PR TITLE
net: mdns: Add support for iOS.

### DIFF
--- a/subsys/net/lib/dns/dns_pack.c
+++ b/subsys/net/lib/dns/dns_pack.c
@@ -592,6 +592,7 @@ int dns_unpack_query(struct dns_msg_t *dns_msg, struct net_buf *buf,
 		&& query_type != DNS_RR_TYPE_PTR
 		&& query_type != DNS_RR_TYPE_SRV
 		&& query_type != DNS_RR_TYPE_TXT
+		&& query_type != DNS_RR_TYPE_HTTPS
 		&& query_type != DNS_RR_TYPE_ANY) {
 		return -EINVAL;
 	}

--- a/subsys/net/lib/dns/dns_pack.h
+++ b/subsys/net/lib/dns/dns_pack.h
@@ -93,6 +93,7 @@ enum dns_rr_type {
 	DNS_RR_TYPE_TXT = 16,		/* TXT   */
 	DNS_RR_TYPE_AAAA = 28,		/* IPv6  */
 	DNS_RR_TYPE_SRV = 33,		/* SRV   */
+	DNS_RR_TYPE_HTTPS = 65,		/* HTTPS */
 	DNS_RR_TYPE_ANY = 0xff,		/* ANY (all records)   */
 };
 


### PR DESCRIPTION
Fixes: #86059

The query type used by iOS is HTTPS-65,
Adding HTTPS query type to support iOS.

Signed-off-by: Vineeta S Narkhede <VineetaSNarkhede@Eaton.com>