### PR TITLE
Revert count_bits

### DIFF
--- a/doc/releases/release-notes-4.2.rst
+++ b/doc/releases/release-notes-4.2.rst
@@ -102,10 +102,6 @@ New APIs and options
 
     * LE Connection Subrating is no longer experimental.
 
-* Other
-
-  * :c:func:`count_bits`
-
 New Boards
 **********
 

--- a/drivers/adc/adc_sam.c
+++ b/drivers/adc/adc_sam.c
@@ -16,7 +16,6 @@
 
 #include <zephyr/logging/log.h>
 #include <zephyr/irq.h>
-#include <zephyr/sys/util.h>
 LOG_MODULE_REGISTER(adc_sam, CONFIG_ADC_LOG_LEVEL);
 
 #define SAM_ADC_NUM_CHANNELS 16
@@ -51,6 +50,18 @@ struct adc_sam_data {
 	/* Number of active channels to fill buffer */
 	uint8_t num_active_channels;
 };
+
+static uint8_t count_bits(uint32_t val)
+{
+	uint8_t res = 0;
+
+	while (val) {
+		res += val & 1U;
+		val >>= 1;
+	}
+
+	return res;
+}
 
 static int adc_sam_channel_setup(const struct device *dev,
 				 const struct adc_channel_cfg *channel_cfg)
@@ -145,8 +156,7 @@ static void adc_context_start_sampling(struct adc_context *ctx)
 	const struct adc_sam_config *const cfg = data->dev->config;
 	Adc *const adc = cfg->regs;
 
-	data->num_active_channels =
-		count_bits(&ctx->sequence.channels, sizeof(ctx->sequence.channels));
+	data->num_active_channels = count_bits(ctx->sequence.channels);
 
 	/* Disable all */
 	adc->ADC_CHDR = 0xffff;
@@ -212,7 +222,7 @@ static int start_read(const struct device *dev,
 		return -EINVAL;
 	}
 
-	data->num_active_channels = count_bits(&channels, sizeof(channels));
+	data->num_active_channels = count_bits(channels);
 
 	error = check_buffer_size(sequence, data->num_active_channels);
 	if (error) {

--- a/include/zephyr/sys/util.h
+++ b/include/zephyr/sys/util.h
@@ -783,34 +783,6 @@ static inline void mem_xor_128(uint8_t dst[16], const uint8_t src1[16], const ui
 	mem_xor_n(dst, src1, src2, 16);
 }
 
-/**
- * @brief Returns the number of bits set in a value
- *
- * @param value The value to count number of bits set of
- * @param len The number of octets in @p value
- */
-static inline size_t count_bits(const void *value, size_t len)
-{
-	const uint8_t *value_u8 = (const uint8_t *)value;
-	size_t cnt = 0U;
-
-	for (size_t i = 0U; i < len; i++) {
-		if (value_u8[i] != 0U) {
-#ifdef POPCOUNT
-			cnt += POPCOUNT(value_u8[i]);
-#else
-			/* Implements Brian Kernighan’s Algorithm to count bits */
-			while (value_u8[i]) {
-				cnt += value_u8[i] & 1;
-				value_u8[i] >>= 1;
-			}
-#endif
-		}
-	}
-
-	return cnt;
-}
-
 #ifdef __cplusplus
 }
 #endif

--- a/samples/bluetooth/cap_acceptor/src/cap_acceptor_broadcast.c
+++ b/samples/bluetooth/cap_acceptor/src/cap_acceptor_broadcast.c
@@ -1,7 +1,7 @@
 /** @file
  *  @brief Bluetooth Common Audio Profile (CAP) Acceptor broadcast.
  *
- *  Copyright (c) 2024-2025 Nordic Semiconductor ASA
+ *  Copyright (c) 2024 Nordic Semiconductor ASA
  *
  *  SPDX-License-Identifier: Apache-2.0
  */
@@ -459,8 +459,7 @@ static int bis_sync_req_cb(struct bt_conn *conn,
 
 	LOG_INF("BIS sync request received for %p: 0x%08x", recv_state, bis_sync_req[0]);
 
-	if (new_bis_sync_req != BT_BAP_BIS_SYNC_NO_PREF &&
-	    count_bits(&new_bis_sync_req, sizeof(new_bis_sync_req)) > 1U) {
+	if (new_bis_sync_req != BT_BAP_BIS_SYNC_NO_PREF && POPCOUNT(new_bis_sync_req) > 1U) {
 		LOG_WRN("Rejecting BIS sync request for 0x%08X as we do not support that",
 			new_bis_sync_req);
 

--- a/subsys/bluetooth/audio/audio.c
+++ b/subsys/bluetooth/audio/audio.c
@@ -2,7 +2,6 @@
 
 /*
  * Copyright (c) 2022 Codecoup
- * Copyright (c) 2025 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -24,7 +23,6 @@
 #include <zephyr/bluetooth/hci_types.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/check.h>
-#include <zephyr/sys/util.h>
 #include <zephyr/toolchain.h>
 
 #include "audio_internal.h"
@@ -148,7 +146,18 @@ uint8_t bt_audio_get_chan_count(enum bt_audio_location chan_allocation)
 		return 1;
 	}
 
-	return count_bits(&chan_allocation, sizeof(chan_allocation));
+#ifdef POPCOUNT
+	return POPCOUNT(chan_allocation);
+#else
+	uint8_t cnt = 0U;
+
+	while (chan_allocation != 0U) {
+		cnt += chan_allocation & 1U;
+		chan_allocation >>= 1U;
+	}
+
+	return cnt;
+#endif
 }
 
 static bool valid_ltv_cb(struct bt_data *data, void *user_data)

--- a/subsys/bluetooth/audio/bap_broadcast_sink.c
+++ b/subsys/bluetooth/audio/bap_broadcast_sink.c
@@ -1071,6 +1071,22 @@ int bt_bap_broadcast_sink_create(struct bt_le_per_adv_sync *pa_sync, uint32_t br
 	return 0;
 }
 
+static uint8_t bit_count(uint32_t bitfield)
+{
+#ifdef POPCOUNT
+	return POPCOUNT(bitfield);
+#else
+	uint8_t cnt = 0U;
+
+	while (bitfield != 0U) {
+		cnt += bitfield & 1U;
+		bitfield >>= 1U;
+	}
+
+	return cnt;
+#endif
+}
+
 struct sync_base_info_data {
 	struct bt_audio_codec_cfg codec_cfgs[CONFIG_BT_BAP_BROADCAST_SNK_STREAM_COUNT];
 	struct bt_audio_codec_cfg *subgroup_codec_cfg;
@@ -1255,7 +1271,7 @@ int bt_bap_broadcast_sink_sync(struct bt_bap_broadcast_sink *sink, uint32_t inde
 	}
 
 	/* Validate that number of bits set is within supported range */
-	bis_count = count_bits(&indexes_bitfield, sizeof(indexes_bitfield));
+	bis_count = bit_count(indexes_bitfield);
 	if (bis_count > CONFIG_BT_BAP_BROADCAST_SNK_STREAM_COUNT) {
 		LOG_DBG("Cannot sync to more than %d streams (%u was requested)",
 			CONFIG_BT_BAP_BROADCAST_SNK_STREAM_COUNT, bis_count);

--- a/tests/bsim/bluetooth/audio/src/bap_broadcast_sink_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_broadcast_sink_test.c
@@ -801,7 +801,7 @@ static void test_broadcast_sync(const uint8_t broadcast_code[BT_ISO_BROADCAST_CO
 		return;
 	}
 
-	stream_sync_cnt = count_bits(&bis_index_bitfield, sizeof(bis_index_bitfield));
+	stream_sync_cnt = POPCOUNT(bis_index_bitfield);
 }
 
 static void test_broadcast_sync_inval(void)

--- a/tests/kernel/common/src/bitarray.c
+++ b/tests/kernel/common/src/bitarray.c
@@ -355,13 +355,29 @@ void alloc_and_free_predefined(void)
 		     "sys_bitarray_alloc() failed bits comparison");
 }
 
+static inline size_t count_bits(uint32_t val)
+{
+	/* Implements Brian Kernighan’s Algorithm
+	 * to count bits.
+	 */
+
+	size_t cnt = 0;
+
+	while (val != 0) {
+		val = val & (val - 1);
+		cnt++;
+	}
+
+	return cnt;
+}
+
 size_t get_bitarray_popcnt(sys_bitarray_t *ba)
 {
 	size_t popcnt = 0;
 	unsigned int idx;
 
 	for (idx = 0; idx < ba->num_bundles; idx++) {
-		popcnt += count_bits(&ba->bundles[idx], sizeof(uint32_t));
+		popcnt += count_bits(ba->bundles[idx]);
 	}
 
 	return popcnt;

--- a/tests/unit/util/main.c
+++ b/tests/unit/util/main.c
@@ -1,18 +1,13 @@
 /*
  * Copyright (c) 2019 Oticon A/S
- * Copyright (c) 2025 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <stdint.h>
-#include <stdio.h>
-#include <string.h>
-
 #include <zephyr/ztest.h>
 #include <zephyr/sys/util.h>
-#include <zephyr/ztest_assert.h>
-#include <zephyr/ztest_test.h>
+#include <stdio.h>
+#include <string.h>
 
 ZTEST(util, test_u8_to_dec) {
 	char text[4];
@@ -771,25 +766,6 @@ ZTEST(util, test_mem_xor_128)
 
 	mem_xor_128(dst, src1, src2);
 	zassert_mem_equal(expected_result, dst, 16);
-}
-
-ZTEST(util, test_count_bits)
-{
-	uint8_t zero = 0U;
-	uint8_t u8 = 29U;
-	uint16_t u16 = 29999U;
-	uint32_t u32 = 2999999999U;
-	uint64_t u64 = 123456789012345ULL;
-	uint8_t u8_arr[] = {u8, u8, u8, u8, u8, u8, u8, u8, u8, u8, u8, u8, u8, u8, u8, u8,
-			    u8, u8, u8, u8, u8, u8, u8, u8, u8, u8, u8, u8, u8, u8, u8, u8};
-
-	zassert_equal(count_bits(&zero, sizeof(zero)), 0);
-	zassert_equal(count_bits(&u8, sizeof(u8)), 4);
-	zassert_equal(count_bits(&u16, sizeof(u16)), 10);
-	zassert_equal(count_bits(&u32, sizeof(u32)), 20);
-	zassert_equal(count_bits(&u64, sizeof(u64)), 23);
-
-	zassert_equal(count_bits(u8_arr, sizeof(u8_arr)), 128);
 }
 
 ZTEST(util, test_CONCAT)


### PR DESCRIPTION
Reverts the commits for the count_bits util function, as there are mulitple name clashes, and the function should probably be renamed. 