### PR TITLE
cmake: support directory as argument to zephyr_library_amend().

### DIFF
--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -464,11 +464,21 @@ endmacro()
 
 # Provides amend functionality to a Zephyr library for out-of-tree usage.
 #
+# Usage:
+#   zephyr_library_amend([<dir>])
+#
 # When called from a Zephyr module, the corresponding zephyr library defined
 # within Zephyr will be looked up.
 #
-# Note, in order to ensure correct library when amending, the folder structure in the
-# Zephyr module must resemble the structure used in Zephyr, as example:
+# <dir>: Use '<dir>' as out-of-tree base directory from where the Zephyr
+#        library name shall be generated.
+#        <dir> can be used in cases where the structure for the library is not
+#        placed directly at the ZEPHYR_MODULE's root directory or for cases
+#        where the module integration file is located in a 'MODULE_EXT_ROOT'.
+#
+# Note, in order to ensure correct library when amending, the folder structure
+# in the Zephyr module or '<dir>' base directory must resemble the structure
+# used in Zephyr, as example:
 #
 # Example: to amend the zephyr library created in
 # ZEPHYR_BASE/drivers/entropy/CMakeLists.txt
@@ -497,7 +507,11 @@ macro(zephyr_library_amend)
     message(FATAL_ERROR "Function only available for Zephyr modules.")
   endif()
 
-  zephyr_library_get_current_dir_lib_name(${ZEPHYR_CURRENT_MODULE_DIR} lib_name)
+  if(${ARGC} EQUAL 1)
+    zephyr_library_get_current_dir_lib_name(${ARGV0} lib_name)
+  else()
+    zephyr_library_get_current_dir_lib_name(${ZEPHYR_CURRENT_MODULE_DIR} lib_name)
+  endif()
 
   set(ZEPHYR_CURRENT_LIBRARY ${lib_name})
 endmacro()


### PR DESCRIPTION
Extend `zephyr_library_amend()` to support an optional directory argument.
The current `zephyr_library_amend()` works well when used inside a Zephyr module with same structure, but fails when the macro is called from Zephyr module integration code is located in a Zephyr `MODULE_EXT_ROOT` because in this case the CMake code being executed is not present in the Zephyr module itself, in which case the dir name creation based on relative to module dir give wrong result.

For this use-case then support a base directory.
This also allows for use-cases in Zephyr modules where the directory structure matching Zephyr's own structure is placed in a sub-folder.