### PR TITLE
Bluetooth: Controller: Fix overhead check in ull_scan_aux for SLOT_AGNOSTIC

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
@@ -2055,6 +2055,10 @@ void ull_scan_aux_setup(memq_link_t *link, struct node_rx_pdu *rx)
 		uint32_t ticks_now;
 		uint32_t diff;
 
+#if defined(CONFIG_BT_TICKER_SLOT_AGNOSTIC)
+		/* CPU execution overhead to setup the radio for reception */
+		overhead_us = EVENT_OVERHEAD_START_US;
+#else /* !CONFIG_BT_TICKER_SLOT_AGNOSTIC */
 		/* CPU execution overhead to setup the radio for reception plus the
 		 * minimum prepare tick offset. And allow one additional event in
 		 * between as overhead (say, an advertising event in between got closed
@@ -2062,6 +2066,7 @@ void ull_scan_aux_setup(memq_link_t *link, struct node_rx_pdu *rx)
 		 */
 		overhead_us = (EVENT_OVERHEAD_END_US + EVENT_OVERHEAD_START_US +
 			       HAL_TICKER_TICKS_TO_US(HAL_TICKER_CNTR_CMP_OFFSET_MIN)) << 1;
+#endif /* !CONFIG_BT_TICKER_SLOT_AGNOSTIC */
 
 		ticks_now = ticker_ticks_now_get();
 		ticks_at_expire = ftr->ticks_anchor + ticks_aux_offset -


### PR DESCRIPTION
The current overhead check needlessly flushes some events for CONFIG_BT_TICKER_SLOT_AGNOSTIC resulting in some lost or incomplete advertising events; Use a lower overhead value for this configuration to avoid that