### PR TITLE
tests/bsim/run_parallel: Fail if an explicitly listed test is missing & fix missing tests

### DIFF
--- a/tests/bsim/bluetooth/compile.nrf5340bsim_nrf5340_cpuapp.sh
+++ b/tests/bsim/bluetooth/compile.nrf5340bsim_nrf5340_cpuapp.sh
@@ -17,7 +17,8 @@ ${ZEPHYR_BASE}/tests/bsim/bluetooth/host/compile.sh
 app=tests/bsim/bluetooth/ll/conn conf_file=prj_split_privacy.conf sysbuild=1  compile
 app=tests/bsim/bluetooth/ll/throughput sysbuild=1 compile
 app=tests/bsim/bluetooth/ll/multiple_id sysbuild=1 compile
-app=tests/bsim/bluetooth/ll/bis sysbuild=1 compile
+app=tests/bsim/bluetooth/ll/bis conf_overlay=overlay-sequential.conf sysbuild=1 compile
+app=tests/bsim/bluetooth/ll/bis conf_overlay=overlay-interleaved.conf sysbuild=1 compile
 app=tests/bsim/bluetooth/ll/bis conf_overlay=overlay-ticker_expire_info.conf sysbuild=1 compile
 app=tests/bsim/bluetooth/ll/cis conf_overlay=overlay-acl_group.conf sysbuild=1 compile
 

--- a/tests/bsim/bluetooth/compile.nrf54l15bsim_nrf54l15_cpuapp.sh
+++ b/tests/bsim/bluetooth/compile.nrf54l15bsim_nrf54l15_cpuapp.sh
@@ -15,7 +15,8 @@ source ${ZEPHYR_BASE}/tests/bsim/compile.source
 
 app=tests/bsim/bluetooth/ll/throughput compile
 app=tests/bsim/bluetooth/ll/multiple_id compile
-app=tests/bsim/bluetooth/ll/bis compile
+app=tests/bsim/bluetooth/ll/bis conf_overlay=overlay-sequential.conf compile
+app=tests/bsim/bluetooth/ll/bis conf_overlay=overlay-interleaved.conf  compile
 app=tests/bsim/bluetooth/ll/bis conf_overlay=overlay-ticker_expire_info.conf compile
 
 run_in_background ${ZEPHYR_BASE}/tests/bsim/bluetooth/samples/compile.sh

--- a/tests/bsim/bluetooth/tests.nrf5340bsim_nrf5340_cpuapp.txt
+++ b/tests/bsim/bluetooth/tests.nrf5340bsim_nrf5340_cpuapp.txt
@@ -3,7 +3,8 @@
 tests/bsim/bluetooth/ll/conn/tests_scripts/basic_conn_encrypted_split_privacy.sh
 tests/bsim/bluetooth/ll/throughput/
 tests/bsim/bluetooth/ll/multiple_id/
-tests/bsim/bluetooth/ll/bis/tests_scripts/broadcast_iso.sh
+tests/bsim/bluetooth/ll/bis/tests_scripts/broadcast_iso_interleaved.sh
+tests/bsim/bluetooth/ll/bis/tests_scripts/broadcast_iso_sequential.sh
 tests/bsim/bluetooth/ll/bis/tests_scripts/broadcast_iso_ticker_expire_info.sh
 tests/bsim/bluetooth/samples/central_hr_peripheral_hr/
 tests/bsim/bluetooth/audio_samples/

--- a/tests/bsim/bluetooth/tests.nrf54l15bsim_nrf54l15_cpuapp.txt
+++ b/tests/bsim/bluetooth/tests.nrf54l15bsim_nrf54l15_cpuapp.txt
@@ -2,7 +2,8 @@
 # This file is used in CI to select which tests are run
 tests/bsim/bluetooth/ll/throughput/
 tests/bsim/bluetooth/ll/multiple_id/
-tests/bsim/bluetooth/ll/bis/tests_scripts/broadcast_iso.sh
+tests/bsim/bluetooth/ll/bis/tests_scripts/broadcast_iso_interleaved.sh
+tests/bsim/bluetooth/ll/bis/tests_scripts/broadcast_iso_sequential.sh
 tests/bsim/bluetooth/ll/bis/tests_scripts/broadcast_iso_ticker_expire_info.sh
 tests/bsim/bluetooth/samples/central_hr_peripheral_hr/
 tests/bsim/bluetooth/audio_samples/

--- a/tests/bsim/ci.uart.sh
+++ b/tests/bsim/ci.uart.sh
@@ -21,8 +21,3 @@ echo " nRF54L15:"
 ${ZEPHYR_BASE}/scripts/twister -T tests/drivers/uart/ --force-color --inline-logs -v -M \
   -p nrf54l15bsim/nrf54l15/cpuapp --fixture gpio_loopback \
   -- -uart0_loopback -uart2_loopback
-
-echo "UART: Multi device tests"
-WORK_DIR=${ZEPHYR_BASE}/bsim_uart nice tests/bsim/drivers/uart/compile.sh
-RESULTS_FILE=${ZEPHYR_BASE}/bsim_out/bsim_results.uart.52.xml \
-SEARCH_PATH=tests/bsim/drivers/uart/ tests/bsim/run_parallel.sh

--- a/tests/bsim/run_parallel.sh
+++ b/tests/bsim/run_parallel.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Copyright 2018 Oticon A/S
 # SPDX-License-Identifier: Apache-2.0
+set -eo pipefail
 
 start=$SECONDS
 
@@ -51,7 +52,8 @@ elif [ -n "${TESTS_LIST}" ]; then
 	all_cases=${TESTS_LIST}
 else
 	SEARCH_PATH="${SEARCH_PATH:-.}"
-	all_cases=`find ${SEARCH_PATH} -name "*.sh" | grep -Ev "${sh_filter}"`
+	all_cases=`find ${SEARCH_PATH} -name "*.sh" | grep -Ev "${sh_filter}"` \
+	          || (echo "No tests found"; exit 1)
 	#we dont run ourselves
 fi
 
@@ -98,6 +100,7 @@ if [ `command -v parallel` ]; then
     ' ::: $all_cases >> $tmp_res_file ; err=$?
   fi
 else #fallback in case parallel is not installed
+  set +e
   for case in $all_cases; do
     echo "<testcase name=\"$case\" time=\"0\">" >> $tmp_res_file
     $case $@ &> $i.log


### PR DESCRIPTION
Instead of just printing a warning, fail (return != 0 to the shell) if a test is missing, or a pattern does not match any test

tests/bsim/bluetooth/ll/bis/tests_scripts/broadcast_iso.sh was split in two in 872b19321f11e272bdfb3fa07811d6482b0868b9 but for the 53 and 5340 it was forgotten in the list of tests to run.
Let's fix it.