### PR TITLE
tests: bluetooth: classic:sdp_c: Add platform_allow Restriction for BLE Tests to Exclude Specific Targets

### DIFF
--- a/tests/bluetooth/classic/sdp_c/testcase.yaml
+++ b/tests/bluetooth/classic/sdp_c/testcase.yaml
@@ -1,5 +1,8 @@
 tests:
   sdp.c:
+    platform_allow:
+      - native_sim
+      - native_sim/native/64
     integration_platforms:
       - native_sim
     tags:


### PR DESCRIPTION
This PR aims to address the issue of BLE test failures on certain targets by adding the platform_allow restriction.
Currently, tests are failing on specific targets such as arduino_portenta_h7.
Changes Made:

> Added the platform_allow directive to restrict the allowed targets for running BLE tests.
> The allowed targets are now limited to:

- native_sim
- native_sim/native/64