### PR TITLE
xtensa: mmu: Fix partition permission definitions

### DIFF
--- a/include/zephyr/arch/xtensa/xtensa_mmu.h
+++ b/include/zephyr/arch/xtensa/xtensa_mmu.h
@@ -63,8 +63,10 @@ typedef uint32_t k_mem_partition_attr_t;
 	((k_mem_partition_attr_t) {0})
 
 /* Execution-allowed attributes */
-#define K_MEM_PARTITION_P_RX_U_RX \
+#define K_MEM_PARTITION_P_RX_U_NA \
 	((k_mem_partition_attr_t) {XTENSA_MMU_PERM_X})
+#define K_MEM_PARTITION_P_RX_U_RX \
+	((k_mem_partition_attr_t) {XTENSA_MMU_PERM_X | XTENSA_MMU_MAP_USER})
 
 /**
  * @}


### PR DESCRIPTION
Fix `K_MEM_PARTITION_P_RX_U_RX` definition to allow code execution from userspace. Add `K_MEM_PARTITION_P_RX_U_NA` definition that allows code execution only by kernel.