### PR TITLE
logging: Fix compilation errors with clang++ when printing void*

### DIFF
--- a/include/zephyr/logging/log_msg.h
+++ b/include/zephyr/logging/log_msg.h
@@ -560,7 +560,7 @@ do { \
 
 /* Create local variable from input variable (expect for the first (fmt) argument). */
 #define Z_LOG_LOCAL_ARG_CREATE(idx, arg) \
-	COND_CODE_0(idx, (), (Z_AUTO_TYPE Z_LOG_LOCAL_ARG_NAME(idx, arg) = (arg) + 0))
+	COND_CODE_0(idx, (), (Z_AUTO_TYPE Z_LOG_LOCAL_ARG_NAME(idx, arg) = 0?(arg):(arg)))
 
 /* First level of processing creates stack variables to be passed for further processing.
  * This is done to prevent multiple evaluations of input arguments (in case argument


### PR DESCRIPTION
Arguments logged with %p casted to void * are working fine with gcc, g++
and clang. however with clang++ it causes compilation error that cannot
be suppressed: error: arithmetic on a pointer to void.

Link: https://docs.zephyrproject.org/latest/services/logging/index.html
Link: https://gcc.gnu.org/legacy-ml/gcc/2016-02/msg00266.html

Fixes: #87308

Signed-off-by: Maciej Kusio <rysiof@gmail.com>