### PR TITLE
kernel: edf: adding `k_thread_deadline_set_absolute`

### DIFF
--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -917,35 +917,52 @@ __syscall void k_thread_priority_set(k_tid_t thread, int prio);
  * @brief Set deadline expiration time for scheduler
  *
  * This sets the "deadline" expiration as a time delta from the
- * current time, in the same units used by k_cycle_get_32().  The
- * scheduler (when deadline scheduling is enabled) will choose the
+ * current time, in system ticks (the fundamental kernel timekeeping unit).
+ * The scheduler (when deadline scheduling is enabled) will choose the
  * next expiring thread when selecting between threads at the same
- * static priority.  Threads at different priorities will be scheduled
+ * static priority. Threads at different priorities will be scheduled
  * according to their static priority.
  *
- * @note Deadlines are stored internally using 32 bit unsigned
- * integers.  The number of cycles between the "first" deadline in the
- * scheduler queue and the "last" deadline must be less than 2^31 (i.e
- * a signed non-negative quantity).  Failure to adhere to this rule
- * may result in scheduled threads running in an incorrect deadline
- * order.
+ * @note Deadlines are stored internally using 32 bit signed integers.
+ * The number of system ticks between the "first" deadline in the scheduler
+ * queue and the "last" deadline must be less than 2^31 (i.e a signed
+ * non-negative quantity). Failure to adhere to this rule may result
+ * in scheduled threads running in an incorrect deadline order.
  *
  * @note Despite the API naming, the scheduler makes no guarantees
  * the thread WILL be scheduled within that deadline, nor does it take
  * extra metadata (like e.g. the "runtime" and "period" parameters in
  * Linux sched_setattr()) that allows the kernel to validate the
- * scheduling for achievability.  Such features could be implemented
+ * scheduling for achievability. Such features could be implemented
  * above this call, which is simply input to the priority selection
  * logic.
  *
  * @note You should enable @kconfig{CONFIG_SCHED_DEADLINE} in your project
  * configuration.
  *
- * @param thread A thread on which to set the deadline
- * @param deadline A time delta, in cycle units
+ * @param thread The thread on which to set the deadline.
+ * @param deadline The relative deadline value.
  *
  */
-__syscall void k_thread_deadline_set(k_tid_t thread, int deadline);
+__syscall void k_thread_deadline_set(k_tid_t thread, k_timeout_t deadline);
+
+/**
+ * @brief Set the absolute deadline expiration time for scheduler
+ *
+ * This sets the "deadline" of a thread in terms of the absolute point
+ * in time of which the thread should have completed its work by then.
+ * It is a complement for the k_thread_deadline_set API, which accepts
+ * a relative deadline and internally calculate the absolute value from
+ * it.
+ *
+ * @note You should enable @kconfig{CONFIG_SCHED_DEADLINE} in your project
+ * configuration.
+ *
+ * @param thread The thread on which to set the deadline.
+ * @param deadline The absolute deadline value.
+ *
+ */
+__syscall void k_thread_deadline_set_absolute(k_tid_t thread, k_timeout_t deadline);
 #endif
 
 /**

--- a/lib/os/p4wq.c
+++ b/lib/os/p4wq.c
@@ -19,8 +19,11 @@ struct device;
 static void set_prio(struct k_thread *th, struct k_p4wq_work *item)
 {
 	__ASSERT_NO_MSG(!IS_ENABLED(CONFIG_SMP) || !z_is_thread_queued(th));
+
+	k_timeout_t dl = K_CYC(item->deadline);
+
 	th->base.prio = item->priority;
-	th->base.prio_deadline = item->deadline;
+	th->base.prio_deadline = CLAMP(((int32_t)dl.ticks), 0, INT_MAX);
 }
 
 static bool rb_lessthan(struct rbnode *a, struct rbnode *b)

--- a/tests/kernel/sched/deadline/src/main.c
+++ b/tests/kernel/sched/deadline/src/main.c
@@ -94,7 +94,7 @@ ZTEST(suite_deadline, test_deadline)
 	 * minimize aliasing with "now"
 	 */
 	for (i = 0; i < NUM_THREADS; i++) {
-		k_thread_deadline_set(&worker_threads[i], thread_deadlines[i]);
+		k_thread_deadline_set(&worker_threads[i], K_CYC(thread_deadlines[i]));
 	}
 
 	zassert_true(n_exec == 0, "threads ran too soon");
@@ -204,7 +204,7 @@ ZTEST(suite_deadline, test_unqueued)
 
 	for (i = 0; i < NUM_THREADS; i++) {
 		thread_deadlines[i] = sys_rand32_get() & 0x3fffff00;
-		k_thread_deadline_set(&worker_threads[i], thread_deadlines[i]);
+		k_thread_deadline_set(&worker_threads[i], K_CYC(thread_deadlines[i]));
 	}
 
 	k_sleep(K_MSEC(50));
@@ -251,7 +251,7 @@ static void test_reschedule_helper1(void *p1, void *p2, void *p3)
 
 	zassert_true(expected_thread == _current, "");
 
-	k_thread_deadline_set(_current, MSEC_TO_CYCLES(1000));
+	k_thread_deadline_set(_current, K_MSEC(1000));
 
 	/* 3. Deadline changed, but there was no reschedule */
 
@@ -284,8 +284,8 @@ ZTEST(suite_deadline, test_thread_reschedule)
 			K_LOWEST_APPLICATION_THREAD_PRIO,
 			0, K_NO_WAIT);
 
-	k_thread_deadline_set(&worker_threads[0], MSEC_TO_CYCLES(500));
-	k_thread_deadline_set(&worker_threads[1], MSEC_TO_CYCLES(10));
+	k_thread_deadline_set(&worker_threads[0], K_MSEC(500));
+	k_thread_deadline_set(&worker_threads[1], K_MSEC(10));
 
 	expected_thread = &worker_threads[1];
 
@@ -309,8 +309,8 @@ ZTEST(suite_deadline, test_thread_reschedule)
 			K_LOWEST_APPLICATION_THREAD_PRIO,
 			0, K_NO_WAIT);
 
-	k_thread_deadline_set(&worker_threads[0], MSEC_TO_CYCLES(500));
-	k_thread_deadline_set(&worker_threads[1], MSEC_TO_CYCLES(10));
+	k_thread_deadline_set(&worker_threads[0], K_MSEC(500));
+	k_thread_deadline_set(&worker_threads[1], K_MSEC(10));
 
 	expected_thread = &worker_threads[1];
 


### PR DESCRIPTION
This PR modifies the Earliest Deadline First (EDF) API in two ways.

**First**, following the request of issue #87240, this commit extends the kernel API by adding an "absolute" thread deadline setter alongside the existing "relative" setter. Now the application can call whatever function suits it better:

```c
k_thread_deadline_set(thread, deadline)                   //for relative deadlines (the usual case)
k_thread_deadline_set_absolute(thread, deadline)    //for absolute deadlines (new API)
```

**Second**, in order to keep the API consistent with the remaining kernel functions, the deadline is now specified in `k_timeout_t` units rather than cycle units, so applications might use `K_MSEC`, `K_CYC`, etc, whatever suits them better.

I have conducted a few tests with the sample code presented in PR #80074, and other more complex scenes, and the modifications seem to be working alright.