### PR TITLE
dts: renesas: ra: remove all interrupts definition from SoC dtsi

### DIFF
--- a/boards/renesas/ek_ra8d1/ek_ra8d1.dts
+++ b/boards/renesas/ek_ra8d1/ek_ra8d1.dts
@@ -185,6 +185,8 @@
 &sci9 {
 	pinctrl-0 = <&sci9_default>;
 	pinctrl-names = "default";
+	interrupts = <0 12>, <1 12>, <2 12>, <3 12>;
+	interrupt-names = "rxi", "txi", "tei", "eri";
 	status = "okay";
 	uart9: uart {
 		current-speed = <115200>;
@@ -210,6 +212,14 @@
 &spi1 {
 	pinctrl-0 = <&spi1_default>;
 	pinctrl-names = "default";
+	interrupts = <4 12>, <5 12>, <6 12>, <7 12>;
+	interrupt-names = "rxi", "txi", "tei", "eri";
+	status = "okay";
+};
+
+&flash {
+	interrupts = <8 12>, <9 12>;
+	interrupt-names = "frdyi", "fiferr";
 	status = "okay";
 };
 
@@ -228,17 +238,21 @@
 
 &pwm7 {
 	pinctrl-0 = <&pwm7_default>;
-	interrupts = <40 1>, <41 1>;
+	interrupts = <10 12>, <11 12>;
 	interrupt-names = "gtioca", "overflow";
 	pinctrl-names = "default";
 	status = "okay";
 };
 
 &canfd_global {
+	interrupts = <12 12>, <13 12>;
+	interrupt-names = "rxf", "glerr";
 	status = "okay";
 	canfd0 {
 		pinctrl-0 = <&canfd0_default>;
 		pinctrl-names = "default";
+		interrupts = <14 12>, <15 12>, <16 12>;
+		interrupt-names = "err", "tx", "rx";
 		rx-max-filters = <16>;
 		status = "okay";
 	};
@@ -250,9 +264,12 @@
 	clock-frequency = <DT_FREQ_M(1)>;
 	pinctrl-0 = <&iic1_default>;
 	pinctrl-names = "default";
+	interrupts = <17 12>, <18 12>, <19 12>, <20 12>;
+	interrupt-names = "rxi", "txi", "tei", "eri";
 };
 
 &eth {
+	interrupts = <21 0>;
 	local-mac-address = [74 90 50 B0 5D E9];
 	status = "okay";
 	phy-handle = <&phy>;
@@ -273,6 +290,8 @@
 &usbhs {
 	pinctrl-0 = <&usbhs_default>;
 	pinctrl-names = "default";
+	interrupts = <22 12>;
+	interrupt-names = "usbhs-ir";
 	maximum-speed = "high-speed";
 	status = "okay";
 	zephyr_udc0: udc {
@@ -288,6 +307,8 @@
 	status = "okay";
 	pinctrl-0 = <&adc0_default>;
 	pinctrl-names = "default";
+	interrupts = <23 12>;
+	interrupt-names = "scanend";
 };
 
 &dac0 {
@@ -297,12 +318,12 @@
 };
 
 &port_irq12 {
-	interrupts = <88 12>;
+	interrupts = <24 12>;
 	status = "okay";
 };
 
 &port_irq13 {
-	interrupts = <89 12>;
+	interrupts = <25 12>;
 	status = "okay";
 };
 
@@ -348,6 +369,8 @@ pmod_sd_shield: &sdhc1 {};
 };
 
 &ulpt0 {
+	interrupt-names = "ulpti";
+	interrupts = <26 1>;
 	status = "okay";
 
 	timer {

--- a/boards/renesas/ek_ra8m1/ek_ra8m1.dts
+++ b/boards/renesas/ek_ra8m1/ek_ra8m1.dts
@@ -232,6 +232,8 @@
 &sci0 {
 	pinctrl-0 = <&sci0_default>;
 	pinctrl-names = "default";
+	interrupts = <0 12>, <1 12>, <2 12>, <3 12>;
+	interrupt-names = "rxi", "txi", "tei", "eri";
 	status = "okay";
 	uart0: uart {
 		current-speed = <115200>;
@@ -253,6 +255,8 @@
 &sci2 {
 	pinctrl-0 = <&sci2_default>;
 	pinctrl-names = "default";
+	interrupts = <4 12>, <5 12>, <6 12>, <7 12>;
+	interrupt-names = "rxi", "txi", "tei", "eri";
 	status = "okay";
 	uart2: uart {
 		current-speed = <115200>;
@@ -263,6 +267,8 @@
 &sci3 {
 	pinctrl-0 = <&sci3_default>;
 	pinctrl-names = "default";
+	interrupts = <8 12>, <9 12>, <10 12>, <11 12>;
+	interrupt-names = "rxi", "txi", "tei", "eri";
 	status = "okay";
 	uart3: uart {
 		current-speed = <115200>;
@@ -273,6 +279,8 @@
 &sci9 {
 	pinctrl-0 = <&sci9_default>;
 	pinctrl-names = "default";
+	interrupts = <12 12>, <13 12>, <14 12>, <15 12>;
+	interrupt-names = "rxi", "txi", "tei", "eri";
 	status = "okay";
 	uart9: uart {
 		current-speed = <115200>;
@@ -288,12 +296,16 @@ mikrobus_serial: &uart3 {};
 	clock-frequency = <DT_FREQ_M(1)>;
 	pinctrl-0 = <&iic1_default>;
 	pinctrl-names = "default";
+	interrupts = <16 12>, <17 12>, <18 1>, <19 12>;
+	interrupt-names = "rxi", "txi", "tei", "eri";
 };
 
 &adc0 {
 	status = "okay";
 	pinctrl-0 = <&adc0_default>;
 	pinctrl-names = "default";
+	interrupts = <20 12>;
+	interrupt-names = "scanend";
 	average-count = <4>;
 };
 
@@ -310,14 +322,22 @@ mikrobus_serial: &uart3 {};
 &spi1 {
 	pinctrl-0 = <&spi1_default>;
 	pinctrl-names = "default";
+	interrupts = <21 12>, <22 12>, <23 12>, <24 12>;
+	interrupt-names = "rxi", "txi", "tei", "eri";
 	status = "okay";
 };
 
 &pwm7 {
 	pinctrl-0 = <&pwm7_default>;
-	interrupts = <40 1>, <41 1>;
+	interrupts = <25 12>, <26 12>;
 	interrupt-names = "gtioca", "overflow";
 	pinctrl-names = "default";
+	status = "okay";
+};
+
+&flash {
+	interrupts = <27 1>, <28 1>;
+	interrupt-names = "frdyi", "fiferr";
 	status = "okay";
 };
 
@@ -335,10 +355,14 @@ mikrobus_serial: &uart3 {};
 };
 
 &canfd_global {
+	interrupts = <29 1>, <30 1>;
+	interrupt-names = "rxf", "glerr";
 	status = "okay";
 	canfd0 {
 		pinctrl-0 = <&canfd0_default>;
 		pinctrl-names = "default";
+		interrupts = <31 12>, <32 12>, <33 12>;
+		interrupt-names = "err", "tx", "rx";
 		phys = <&transceiver0>;
 		rx-max-filters = <16>;
 		status = "okay";
@@ -352,6 +376,7 @@ pmod_serial: &pmod1_serial {};
 pmod_header: &pmod1_header {};
 
 &eth {
+	interrupts = <34 0>;
 	local-mac-address = [74 90 50 B0 6D 5A];
 	status = "okay";
 	phy-handle = <&phy>;
@@ -372,6 +397,8 @@ pmod_header: &pmod1_header {};
 &usbhs {
 	pinctrl-0 = <&usbhs_default>;
 	pinctrl-names = "default";
+	interrupts = <35 12>;
+	interrupt-names = "usbhs-ir";
 	maximum-speed = "high-speed";
 	status = "okay";
 	zephyr_udc0: udc {
@@ -384,12 +411,12 @@ pmod_header: &pmod1_header {};
 };
 
 &port_irq12 {
-	interrupts = <88 12>;
+	interrupts = <36 12>;
 	status = "okay";
 };
 
 &port_irq13 {
-	interrupts = <89 12>;
+	interrupts = <37 12>;
 	status = "okay";
 };
 
@@ -406,6 +433,8 @@ pmod_sd_shield: &sdhc0 {};
 };
 
 &ulpt0 {
+	interrupt-names = "ulpti";
+	interrupts = <38 1>;
 	status = "okay";
 
 	timer {

--- a/boards/renesas/mck_ra8t1/mck_ra8t1.dts
+++ b/boards/renesas/mck_ra8t1/mck_ra8t1.dts
@@ -112,6 +112,8 @@
 &sci3 {
 	pinctrl-0 = <&sci3_default>;
 	pinctrl-names = "default";
+	interrupts = <0 12>, <1 12>, <2 12>, <3 12>;
+	interrupt-names = "rxi", "txi", "tei", "eri";
 	status = "okay";
 	uart3: uart {
 		current-speed = <115200>;
@@ -137,6 +139,14 @@
 &spi0 {
 	pinctrl-0 = <&spi0_default>;
 	pinctrl-names = "default";
+	interrupts = <4 12>, <5 12>, <6 12>, <7 12>;
+	interrupt-names = "rxi", "txi", "tei", "eri";
+	status = "okay";
+};
+
+&flash {
+	interrupts = <8 1>, <9 1>;
+	interrupt-names = "frdyi", "fiferr";
 	status = "okay";
 };
 
@@ -155,17 +165,21 @@
 
 &pwm2 {
 	pinctrl-0 = <&pwm2_default>;
-	interrupts = <40 1>, <41 1>;
+	interrupts = <10 12>, <11 12>;
 	interrupt-names = "gtioca", "overflow";
 	pinctrl-names = "default";
 	status = "okay";
 };
 
 &canfd_global {
+	interrupts = <12 12>, <13 12>;
+	interrupt-names = "rxf", "glerr";
 	status = "okay";
 	canfd1 {
 		pinctrl-0 = <&canfd1_default>;
 		pinctrl-names = "default";
+		interrupts = <14 12>, <15 12>, <16 12>;
+		interrupt-names = "err", "tx", "rx";
 		rx-max-filters = <16>;
 		status = "okay";
 	};
@@ -177,9 +191,12 @@
 	clock-frequency = <DT_FREQ_M(1)>;
 	pinctrl-0 = <&iic1_default>;
 	pinctrl-names = "default";
+	interrupts = <17 12>, <18 12>, <19 12>, <20 12>;
+	interrupt-names = "rxi", "txi", "tei", "eri";
 };
 
 &eth {
+	interrupts = <21 0>;
 	local-mac-address = [74 90 50 6D 81 75];
 	status = "okay";
 	phy-handle = <&phy>;
@@ -201,6 +218,8 @@
 	status = "okay";
 	pinctrl-0 = <&adc0_default>;
 	pinctrl-names = "default";
+	interrupts = <22 12>;
+	interrupt-names = "scanend";
 	average-count = <4>;
 };
 
@@ -213,6 +232,8 @@
 &sdhc0 {
 	compatible = "renesas,ra-sdhc";
 	pinctrl-0 = <&sdhc0_default>;
+	interrupt-names = "accs", "card", "dma-req";
+	interrupts = <23 12>, <24 12>, <25 12>;
 	enable-gpios = <&ioport3 11 GPIO_ACTIVE_HIGH>;
 	pinctrl-names = "default";
 	status = "okay";
@@ -226,6 +247,8 @@
 &usbfs {
 	pinctrl-0 = <&usbfs_default>;
 	pinctrl-names = "default";
+	interrupts = <26 12>, <27 12>;
+	interrupt-names = "usbfs-i", "usbfs-r";
 	maximum-speed = "full-speed";
 	status = "okay";
 	zephyr_udc0: udc {
@@ -238,6 +261,8 @@
 };
 
 &ulpt0 {
+	interrupt-names = "ulpti";
+	interrupts = <28 1>;
 	status = "okay";
 
 	timer {

--- a/dts/arm/renesas/ra/ra8/r7fa8d1xh.dtsi
+++ b/dts/arm/renesas/ra/ra8/r7fa8d1xh.dtsi
@@ -21,8 +21,6 @@
 			compatible = "renesas,ra-glcdc";
 			reg = <0x40342000 0x1454>;
 			clocks = <&lcdclk MSTPC 4>;
-			interrupts = <71 1>;
-			interrupt-names = "line";
 			status = "disabled";
 		};
 
@@ -31,8 +29,6 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40346000 0x2000>;
-			interrupts = <72 12>, <73 12>, <74 12>, <75 12>, <76 12>, <77 12>;
-			interrupt-names = "sq0", "sq1", "vm", "rcv", "ferr", "ppi";
 			clocks = <&lcdclk MSTPC 10>;
 			status = "disabled";
 		};
@@ -283,8 +279,6 @@
 		usbhs: usbhs@40351000 {
 			compatible = "renesas,ra-usbhs";
 			reg = <0x40351000 0x2000>;
-			interrupts = <54 12>;
-			interrupt-names = "usbhs-ir";
 			num-bidir-endpoints = <10>;
 			phys = <&usbhs_phy>;
 			phys-clock = <&uclk>, <&u60clk>;

--- a/dts/arm/renesas/ra/ra8/r7fa8m1xh.dtsi
+++ b/dts/arm/renesas/ra/ra8/r7fa8m1xh.dtsi
@@ -247,8 +247,6 @@
 		usbhs: usbhs@40351000 {
 			compatible = "renesas,ra-usbhs";
 			reg = <0x40351000 0x2000>;
-			interrupts = <54 12>;
-			interrupt-names = "usbhs-ir";
 			num-bidir-endpoints = <10>;
 			phys = <&usbhs_phy>;
 			phys-clock = <&uclk>, <&u60clk>;

--- a/dts/arm/renesas/ra/ra8/ra8x1.dtsi
+++ b/dts/arm/renesas/ra/ra8/ra8x1.dtsi
@@ -196,16 +196,12 @@
 		iic1: iic1@4025e100 {
 			compatible = "renesas,ra-iic";
 			channel = <1>;
-			interrupts = <91 1>, <92 1>, <93 1>, <94 1>;
-			interrupt-names = "rxi", "txi", "tei", "eri";
 			reg = <0x4025E100 0x100>;
 			status = "disabled";
 		};
 
 		sci0: sci0@40358000 {
 			compatible = "renesas,ra-sci";
-			interrupts = <4 1>, <5 1>, <6 1>, <7 1>;
-			interrupt-names = "rxi", "txi", "tei", "eri";
 			reg = <0x40358000 0x100>;
 			clocks = <&sciclk MSTPB 31>;
 			status = "disabled";
@@ -226,8 +222,6 @@
 
 		sci1: sci1@40358100 {
 			compatible = "renesas,ra-sci";
-			interrupts = <8 1>, <9 1>, <10 1>, <11 1>;
-			interrupt-names = "rxi", "txi", "tei", "eri";
 			reg = <0x40358100 0x100>;
 			clocks = <&sciclk MSTPB 30>;
 			status = "disabled";
@@ -248,8 +242,6 @@
 
 		sci2: sci2@40358200 {
 			compatible = "renesas,ra-sci";
-			interrupts = <12 1>, <13 1>, <14 1>, <15 1>;
-			interrupt-names = "rxi", "txi", "tei", "eri";
 			reg = <0x40358200 0x100>;
 			clocks = <&sciclk MSTPB 29>;
 			status = "disabled";
@@ -270,8 +262,6 @@
 
 		sci3: sci3@40358300 {
 			compatible = "renesas,ra-sci";
-			interrupts = <16 1>, <17 1>, <18 1>, <19 1>;
-			interrupt-names = "rxi", "txi", "tei", "eri";
 			reg = <0x40358300 0x100>;
 			clocks = <&sciclk MSTPB 28>;
 			status = "disabled";
@@ -292,8 +282,6 @@
 
 		sci4: sci4@40358400 {
 			compatible = "renesas,ra-sci";
-			interrupts = <20 1>, <21 1>, <22 1>, <23 1>;
-			interrupt-names = "rxi", "txi", "tei", "eri";
 			reg = <0x40358400 0x100>;
 			clocks = <&sciclk MSTPB 27>;
 			status = "disabled";
@@ -314,8 +302,6 @@
 
 		sci9: sci9@40358900 {
 			compatible = "renesas,ra-sci";
-			interrupts = <24 1>, <25 1>, <26 1>, <27 1>;
-			interrupt-names = "rxi", "txi", "tei", "eri";
 			reg = <0x40358900 0x100>;
 			clocks = <&sciclk MSTPB 22>;
 			status = "disabled";
@@ -339,14 +325,11 @@
 			reg = <0x40100000 0x20000>;
 			#address-cells = <1>;
 			#size-cells = <1>;
-			interrupts = <49 1>, <50 1>;
-			interrupt-names = "frdyi", "fiferr";
+			status = "disabled";
 		};
 
 		adc0: adc@40332000 {
 			compatible = "renesas,ra-adc";
-			interrupts = <38 1>;
-			interrupt-names = "scanend";
 			reg = <0x40332000 0x100>;
 			#io-channel-cells = <1>;
 			vref-mv = <3300>;
@@ -356,8 +339,6 @@
 
 		adc1: adc@40332200 {
 			compatible = "renesas,ra-adc";
-			interrupts = <39 1>;
-			interrupt-names = "scanend";
 			reg = <0x40332200 0x100>;
 			#io-channel-cells = <1>;
 			vref-mv = <3300>;
@@ -397,8 +378,6 @@
 			channel = <0>;
 			clocks = <&pclka MSTPB 19>;
 			clock-names = "spiclk";
-			interrupts = <28 1>, <29 1>, <30 1>, <31 1>;
-			interrupt-names = "rxi", "txi", "tei", "eri";
 			reg = <0x4035c000 0x100>;
 			status = "disabled";
 		};
@@ -410,8 +389,6 @@
 			channel = <1>;
 			clocks = <&pclka MSTPB 18>;
 			clock-names = "spiclk";
-			interrupts = <32 1>, <33 1>, <34 1>, <35 1>;
-			interrupt-names = "rxi", "txi", "tei", "eri";
 			reg = <0x4035c100 0x100>;
 			status = "disabled";
 		};
@@ -560,8 +537,6 @@
 			compatible = "renesas,ra-ulpt";
 			reg = <0x40220000 0x100>;
 			channel = <0>;
-			interrupt-names = "ulpti";
-			interrupts = <36 1>;
 			status = "disabled";
 
 			timer {
@@ -616,8 +591,6 @@
 			compatible = "renesas,ra-agt";
 			channel = <0>;
 			reg = <0x40221000 0x100>;
-			interrupts = <83 1>, <84 1>;
-			interrupt-names = "agti", "agtcmai";
 			renesas,count-source = "AGT_CLOCK_LOCO";
 			renesas,prescaler = <0>;
 			renesas,resolution = <16>;
@@ -633,8 +606,6 @@
 			compatible = "renesas,ra-agt";
 			channel = <1>;
 			reg = <0x40221100 0x100>;
-			interrupts = <85 1>, <86 1>;
-			interrupt-names = "agti", "agtcmai";
 			renesas,count-source = "AGT_CLOCK_LOCO";
 			renesas,prescaler = <0>;
 			renesas,resolution = <16>;
@@ -648,8 +619,6 @@
 
 		canfd_global: canfd_global@40380000 {
 			compatible = "renesas,ra-canfd-global";
-			interrupts = <40 1>, <41 1>;
-			interrupt-names = "rxf", "glerr";
 			clocks = <&pclka 0 0>, <&pclke 0 0>;
 			clock-names = "opclk", "ramclk";
 			dll-min-freq = <DT_FREQ_M(8)>;
@@ -660,8 +629,6 @@
 			canfd0: canfd0 {
 				compatible = "renesas,ra-canfd";
 				channel = <0>;
-				interrupts = <43 12>, <44 12>, <45 12>;
-				interrupt-names = "err", "tx", "rx";
 				clocks = <&canfdclk MSTPC 27>;
 				clock-names = "dllclk";
 				status = "disabled";
@@ -670,8 +637,6 @@
 			canfd1: canfd1 {
 				compatible = "renesas,ra-canfd";
 				channel = <1>;
-				interrupts = <46 1>, <47 1>, <48 1>;
-				interrupt-names = "err", "tx", "rx";
 				clocks = <&canfdclk MSTPC 26>;
 				clock-names = "dllclk";
 				status = "disabled";
@@ -681,7 +646,6 @@
 		eth: ethernet@40354100 {
 			compatible = "renesas,ra-ethernet";
 			reg = <0x40354100 0xfc>;
-			interrupts = <42 0>;
 			local-mac-address = [00 11 22 33 44 55];
 			phy-connection-type = "rmii";
 			status = "disabled";
@@ -848,8 +812,6 @@
 			max-bus-freq = <DT_FREQ_M(52)>;
 			clocks = <&pclkb MSTPC 12>;
 			reg = <0x40252000 0x0400>;
-			interrupt-names = "accs", "card", "dma-req";
-			interrupts = <57 12>, <58 12>, <59 12>;
 			status = "disabled";
 		};
 
@@ -876,8 +838,6 @@
 		usbfs: usbfs@40250000 {
 			compatible = "renesas,ra-usbfs";
 			reg = <0x40250000 0x2000>;
-			interrupts = <55 12>, <56 12>;
-			interrupt-names = "usbfs-i", "usbfs-r";
 			num-bidir-endpoints = <10>;
 			phys = <&usbfs_phy>;
 			phys-clock = <&uclk>;

--- a/samples/drivers/counter/alarm/boards/ek_ra8d1.overlay
+++ b/samples/drivers/counter/alarm/boards/ek_ra8d1.overlay
@@ -5,6 +5,8 @@
  */
 
 &agt0 {
+	interrupts = <94 12>, <95 12>;
+	interrupt-names = "agti", "agtcmai";
 	status = "okay";
 	renesas,prescaler = <4>;
 	counter0: counter {

--- a/samples/drivers/counter/alarm/boards/ek_ra8m1.overlay
+++ b/samples/drivers/counter/alarm/boards/ek_ra8m1.overlay
@@ -5,6 +5,8 @@
  */
 
 &agt0 {
+	interrupts = <94 12>, <95 12>;
+	interrupt-names = "agti", "agtcmai";
 	status = "okay";
 	renesas,prescaler = <4>;
 	counter0: counter {

--- a/samples/drivers/counter/alarm/boards/mck_ra8t1.overlay
+++ b/samples/drivers/counter/alarm/boards/mck_ra8t1.overlay
@@ -5,6 +5,8 @@
  */
 
 &agt0 {
+	interrupts = <94 12>, <95 12>;
+	interrupt-names = "agti", "agtcmai";
 	status = "okay";
 	renesas,prescaler = <4>;
 	counter0: counter {

--- a/tests/drivers/adc/adc_api/boards/ek_ra8d1.overlay
+++ b/tests/drivers/adc/adc_api/boards/ek_ra8d1.overlay
@@ -24,6 +24,8 @@
 &adc1 {
 	pinctrl-0 = <&adc1_default>;
 	pinctrl-names = "default";
+	interrupts = <95 12>;
+	interrupt-names = "scanend";
 	status = "okay";
 	#address-cells = <1>;
 	#size-cells = <0>;

--- a/tests/drivers/adc/adc_api/boards/ek_ra8m1.overlay
+++ b/tests/drivers/adc/adc_api/boards/ek_ra8m1.overlay
@@ -24,6 +24,8 @@
 &adc1 {
 	pinctrl-0 = <&adc1_default>;
 	pinctrl-names = "default";
+	interrupts = <95 12>;
+	interrupt-names = "scanend";
 	status = "okay";
 	#address-cells = <1>;
 	#size-cells = <0>;

--- a/tests/drivers/adc/adc_api/boards/mck_ra8t1.overlay
+++ b/tests/drivers/adc/adc_api/boards/mck_ra8t1.overlay
@@ -24,6 +24,8 @@
 &adc1 {
 	pinctrl-0 = <&adc1_default>;
 	pinctrl-names = "default";
+	interrupts = <95 12>;
+	interrupt-names = "scanend";
 	status = "okay";
 	#address-cells = <1>;
 	#size-cells = <0>;

--- a/tests/drivers/spi/spi_controller_peripheral/boards/ek_ra8m1.overlay
+++ b/tests/drivers/spi/spi_controller_peripheral/boards/ek_ra8m1.overlay
@@ -47,6 +47,8 @@
 };
 
 dut_spis: &spi1 {
+	interrupts = <92 12>, <93 12>, <94 12>, <95 12>;
+	interrupt-names = "rxi", "txi", "tei", "eri";
 	rx-dtc;
 	tx-dtc;
 	status = "okay";

--- a/tests/drivers/spi/spi_loopback/boards/ek_ra8m1.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/ek_ra8m1.overlay
@@ -18,6 +18,8 @@
 };
 
 &spi0 {
+	interrupts = <92 12>, <93 12>, <94 12>, <95 12>;
+	interrupt-names = "rxi", "txi", "tei", "eri";
 	rx-dtc;
 	tx-dtc;
 	pinctrl-0 = <&spi0_default>;

--- a/tests/drivers/uart/uart_async_api/boards/ek_ra8d1.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/ek_ra8d1.overlay
@@ -20,6 +20,8 @@
 &sci2 {
 	pinctrl-0 = <&sci2_default>;
 	pinctrl-names = "default";
+	interrupts = <92 12>, <93 12>, <94 12>, <95 12>;
+	interrupt-names = "rxi", "txi", "tei", "eri";
 	status = "okay";
 	dut: uart {
 		current-speed = <115200>;

--- a/tests/drivers/uart/uart_async_api/boards/mck_ra8t1.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/mck_ra8t1.overlay
@@ -20,6 +20,8 @@
 &sci4 {
 	pinctrl-0 = <&sci4_default>;
 	pinctrl-names = "default";
+	interrupts = <92 12>, <93 12>, <94 12>, <95 12>;
+	interrupt-names = "rxi", "txi", "tei", "eri";
 	status = "okay";
 	dut: uart {
 		current-speed = <115200>;

--- a/tests/subsys/fs/ext2/boards/ek_ra8d1.overlay
+++ b/tests/subsys/fs/ext2/boards/ek_ra8d1.overlay
@@ -4,6 +4,10 @@
  */
 
 &sdhc1 {
+	interrupt-names = "accs", "card", "dma-req";
+	interrupts = <94 12>, <95 12>, <96 12>;
+	status = "okay";
+
 	sdmmc {
 		partition {
 			compatible = "fixed-partitions";

--- a/tests/subsys/fs/ext2/boards/ek_ra8m1.overlay
+++ b/tests/subsys/fs/ext2/boards/ek_ra8m1.overlay
@@ -4,6 +4,10 @@
  */
 
 &sdhc0 {
+	interrupt-names = "accs", "card", "dma-req";
+	interrupts = <94 12>, <95 12>, <96 12>;
+	status = "okay";
+
 	sdmmc {
 		partition {
 			compatible = "fixed-partitions";


### PR DESCRIPTION
Because Renesas RA device have a dynamic link mechanism between IP event and the NVIC interrupt line, it is better to move all interrupts definition to board layers. If user would like to add overlay for enable a device node, they should refer to interrupts description in dts binding to add correct interrupts information (specifier, name, ...).

To add interrupts description, https://github.com/zephyrproject-rtos/zephyr/pull/87672 is being prepared.

This PR to remove all interrupts properties from RA8x1 device SoC dtsi, move it into <board>.dts and <board>.overlay for enabled node, affects the following boards:
- ek_ra8m1
- ek_ra8d1
- mck_ra8t1