### PR TITLE
test: Bluetooth: Classic: Rename SDP client test case

### DIFF
--- a/tests/bluetooth/classic/sdp_c/testcase.yaml
+++ b/tests/bluetooth/classic/sdp_c/testcase.yaml
@@ -1,5 +1,5 @@
 tests:
-  sdp.c:
+  bluetooth.classic.sdp.client:
     platform_allow:
       - native_sim
       - mimxrt1170_evk@B/mimxrt1176/cm7


### PR DESCRIPTION
Change the test case name from `sdp.c` to ` bluetooth.classic.sdp.client`