### PR TITLE
drivers: ambiq: Change the way to power on ambiq drivers

### DIFF
--- a/drivers/adc/adc_ambiq.c
+++ b/drivers/adc/adc_ambiq.c
@@ -21,8 +21,6 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(adc_ambiq, CONFIG_ADC_LOG_LEVEL);
 
-typedef int (*ambiq_adc_pwr_func_t)(void);
-#define PWRCTRL_MAX_WAIT_US   5
 /* Number of slots available. */
 #define AMBIQ_ADC_SLOT_NUMBER AM_HAL_ADC_MAX_SLOTS
 
@@ -32,7 +30,6 @@ struct adc_ambiq_config {
 	uint8_t num_channels;
 	void (*irq_config_func)(void);
 	const struct pinctrl_dev_config *pin_cfg;
-	ambiq_adc_pwr_func_t pwr_func;
 };
 
 struct adc_ambiq_data {
@@ -290,7 +287,7 @@ static int adc_ambiq_init(const struct device *dev)
 	}
 
 	/* power on ADC*/
-	ret = cfg->pwr_func();
+	ret = am_hal_adc_power_control(data->adcHandle, AM_HAL_SYSCTRL_WAKE, false);
 
 	/* Set up the ADC configuration parameters. These settings are reasonable
 	 *  for accurate measurements at a low sample rate.
@@ -404,14 +401,6 @@ static int adc_ambiq_pm_action(const struct device *dev, enum pm_device_action a
 #define ADC_AMBIQ_INIT(n)                                                                          \
 	PINCTRL_DT_INST_DEFINE(n);                                                                 \
 	ADC_AMBIQ_DRIVER_API(n);                                                                   \
-	static int pwr_on_ambiq_adc_##n(void)                                                      \
-	{                                                                                          \
-		uint32_t addr = DT_REG_ADDR(DT_INST_PHANDLE(n, ambiq_pwrcfg)) +                    \
-				DT_INST_PHA(n, ambiq_pwrcfg, offset);                              \
-		sys_write32((sys_read32(addr) | DT_INST_PHA(n, ambiq_pwrcfg, mask)), addr);        \
-		k_busy_wait(PWRCTRL_MAX_WAIT_US);                                                  \
-		return 0;                                                                          \
-	}                                                                                          \
 	static void adc_irq_config_func_##n(void)                                                  \
 	{                                                                                          \
 		IRQ_CONNECT(DT_INST_IRQN(n), DT_INST_IRQ(n, priority), adc_ambiq_isr,              \
@@ -429,7 +418,6 @@ static int adc_ambiq_pm_action(const struct device *dev, enum pm_device_action a
 		.num_channels = DT_PROP(DT_DRV_INST(n), channel_count),                            \
 		.irq_config_func = adc_irq_config_func_##n,                                        \
 		.pin_cfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),                                      \
-		.pwr_func = pwr_on_ambiq_adc_##n,                                                  \
 	};                                                                                         \
 	PM_DEVICE_DT_INST_DEFINE(n, adc_ambiq_pm_action);                                          \
 	DEVICE_DT_INST_DEFINE(n, &adc_ambiq_init, PM_DEVICE_DT_INST_GET(n), &adc_ambiq_data_##n,   \

--- a/drivers/serial/uart_pl011_ambiq.h
+++ b/drivers/serial/uart_pl011_ambiq.h
@@ -15,8 +15,6 @@
 #include "uart_pl011_registers.h"
 #include <am_mcu_apollo.h>
 
-#define PWRCTRL_MAX_WAIT_US 5
-
 static inline void pl011_ambiq_enable_clk(const struct device *dev)
 {
 	get_uart(dev)->cr |= PL011_CR_AMBIQ_CLKEN;

--- a/drivers/spi/spi_ambiq_spic.c
+++ b/drivers/spi/spi_ambiq_spic.c
@@ -41,16 +41,11 @@ LOG_MODULE_REGISTER(spi_ambiq);
 #define SPI_AMBIQ_MANUAL_CACHE_COHERENCY_REQUIRED 0
 #endif /* defined(CONFIG_DCACHE) && !defined(CONFIG_NOCACHE_MEMORY) */
 
-#define PWRCTRL_MAX_WAIT_US 5
-
-typedef int (*ambiq_spi_pwr_func_t)(void);
-
 struct spi_ambiq_config {
 	uint32_t base;
 	int size;
 	uint32_t clock_freq;
 	const struct pinctrl_dev_config *pcfg;
-	ambiq_spi_pwr_func_t pwr_func;
 	void (*irq_config_func)(void);
 };
 
@@ -517,7 +512,7 @@ static int spi_ambiq_init(const struct device *dev)
 		return -ENXIO;
 	}
 
-	ret = cfg->pwr_func();
+	ret = am_hal_iom_power_ctrl(data->iom_handler, AM_HAL_SYSCTRL_WAKE, false);
 
 	ret |= pinctrl_apply_state(cfg->pcfg, PINCTRL_STATE_DEFAULT);
 	ret |= spi_context_cs_configure_all(&data->ctx);
@@ -571,14 +566,6 @@ static int spi_ambiq_pm_action(const struct device *dev, enum pm_device_action a
 
 #define AMBIQ_SPI_INIT(n)                                                                          \
 	PINCTRL_DT_INST_DEFINE(n);                                                                 \
-	static int pwr_on_ambiq_spi_##n(void)                                                      \
-	{                                                                                          \
-		uint32_t addr = DT_REG_ADDR(DT_INST_PHANDLE(n, ambiq_pwrcfg)) +                    \
-				DT_INST_PHA(n, ambiq_pwrcfg, offset);                              \
-		sys_write32((sys_read32(addr) | DT_INST_PHA(n, ambiq_pwrcfg, mask)), addr);        \
-		k_busy_wait(PWRCTRL_MAX_WAIT_US);                                                  \
-		return 0;                                                                          \
-	}                                                                                          \
 	static void spi_irq_config_func_##n(void)                                                  \
 	{                                                                                          \
 		IRQ_CONNECT(DT_INST_IRQN(n), DT_INST_IRQ(n, priority), spi_ambiq_isr,              \
@@ -594,8 +581,7 @@ static int spi_ambiq_pm_action(const struct device *dev, enum pm_device_action a
 		.size = DT_INST_REG_SIZE(n),                                                       \
 		.clock_freq = DT_INST_PROP(n, clock_frequency),                                    \
 		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),                                         \
-		.irq_config_func = spi_irq_config_func_##n,                                        \
-		.pwr_func = pwr_on_ambiq_spi_##n};                                                 \
+		.irq_config_func = spi_irq_config_func_##n};                                       \
 	PM_DEVICE_DT_INST_DEFINE(n, spi_ambiq_pm_action);                                          \
 	SPI_DEVICE_DT_INST_DEFINE(n, spi_ambiq_init, PM_DEVICE_DT_INST_GET(n), &spi_ambiq_data##n, \
 				  &spi_ambiq_config##n, POST_KERNEL, CONFIG_SPI_INIT_PRIORITY,     \

--- a/dts/arm/ambiq/ambiq_apollo3_blue.dtsi
+++ b/dts/arm/ambiq/ambiq_apollo3_blue.dtsi
@@ -204,7 +204,6 @@
 			#size-cells = <0>;
 			interrupts = <4 0>;
 			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x8 0>;
 			zephyr,pm-device-runtime-auto;
 		};
 
@@ -215,7 +214,6 @@
 			#size-cells = <0>;
 			interrupts = <6 0>;
 			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x8 0x2>;
 			zephyr,pm-device-runtime-auto;
 		};
 
@@ -226,7 +224,6 @@
 			#size-cells = <0>;
 			interrupts = <7 0>;
 			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x8 0x4>;
 			zephyr,pm-device-runtime-auto;
 		};
 
@@ -237,7 +234,6 @@
 			#size-cells = <0>;
 			interrupts = <8 0>;
 			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x8 0x8>;
 			zephyr,pm-device-runtime-auto;
 		};
 
@@ -248,7 +244,6 @@
 			#size-cells = <0>;
 			interrupts = <9 0>;
 			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x8 0x10>;
 			zephyr,pm-device-runtime-auto;
 		};
 
@@ -259,7 +254,6 @@
 			#size-cells = <0>;
 			interrupts = <10 0>;
 			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x8 0x20>;
 			zephyr,pm-device-runtime-auto;
 		};
 
@@ -270,7 +264,6 @@
 			#size-cells = <0>;
 			interrupts = <11 0>;
 			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x8 0x40>;
 			zephyr,pm-device-runtime-auto;
 		};
 
@@ -281,7 +274,6 @@
 			#size-cells = <0>;
 			interrupts = <6 0>;
 			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x8 0x2>;
 			zephyr,pm-device-runtime-auto;
 		};
 
@@ -292,7 +284,6 @@
 			#size-cells = <0>;
 			interrupts = <7 0>;
 			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x8 0x4>;
 			zephyr,pm-device-runtime-auto;
 		};
 
@@ -303,7 +294,6 @@
 			#size-cells = <0>;
 			interrupts = <8 0>;
 			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x8 0x8>;
 			zephyr,pm-device-runtime-auto;
 		};
 
@@ -314,7 +304,6 @@
 			#size-cells = <0>;
 			interrupts = <9 0>;
 			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x8 0x10>;
 			zephyr,pm-device-runtime-auto;
 		};
 
@@ -325,7 +314,6 @@
 			#size-cells = <0>;
 			interrupts = <10 0>;
 			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x8 0x20>;
 			zephyr,pm-device-runtime-auto;
 		};
 
@@ -336,7 +324,6 @@
 			#size-cells = <0>;
 			interrupts = <11 0>;
 			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x8 0x40>;
 			zephyr,pm-device-runtime-auto;
 		};
 
@@ -349,7 +336,6 @@
 			internal-vref-mv = <1500>;
 			status = "disabled";
 			#io-channel-cells = <1>;
-			ambiq,pwrcfg = <&pwrcfg 0x8 0x200>;
 		};
 
 		mspi0: spi@40020000 {
@@ -359,7 +345,6 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x8 0x800>;
 		};
 
 		rtc0: rtc@40004240 {
@@ -377,7 +362,6 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x8 0x8000>;
 
 			bt_hci_apollo: bt-hci@0 {
 				compatible = "ambiq,bt-hci-spi";

--- a/dts/arm/ambiq/ambiq_apollo3p_blue.dtsi
+++ b/dts/arm/ambiq/ambiq_apollo3p_blue.dtsi
@@ -222,7 +222,6 @@
 			#size-cells = <0>;
 			interrupts = <4 0>;
 			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x8 0>;
 			zephyr,pm-device-runtime-auto;
 		};
 
@@ -233,7 +232,6 @@
 			#size-cells = <0>;
 			interrupts = <6 0>;
 			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x8 0x2>;
 			zephyr,pm-device-runtime-auto;
 		};
 
@@ -244,7 +242,6 @@
 			#size-cells = <0>;
 			interrupts = <7 0>;
 			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x8 0x4>;
 			zephyr,pm-device-runtime-auto;
 		};
 
@@ -255,7 +252,6 @@
 			#size-cells = <0>;
 			interrupts = <8 0>;
 			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x8 0x8>;
 			zephyr,pm-device-runtime-auto;
 		};
 
@@ -266,7 +262,6 @@
 			#size-cells = <0>;
 			interrupts = <9 0>;
 			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x8 0x10>;
 			zephyr,pm-device-runtime-auto;
 		};
 
@@ -277,7 +272,6 @@
 			#size-cells = <0>;
 			interrupts = <10 0>;
 			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x8 0x20>;
 			zephyr,pm-device-runtime-auto;
 		};
 
@@ -288,7 +282,6 @@
 			#size-cells = <0>;
 			interrupts = <11 0>;
 			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x8 0x40>;
 			zephyr,pm-device-runtime-auto;
 		};
 
@@ -299,7 +292,6 @@
 			#size-cells = <0>;
 			interrupts = <6 0>;
 			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x8 0x2>;
 			zephyr,pm-device-runtime-auto;
 		};
 
@@ -310,7 +302,6 @@
 			#size-cells = <0>;
 			interrupts = <7 0>;
 			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x8 0x4>;
 			zephyr,pm-device-runtime-auto;
 		};
 
@@ -321,7 +312,6 @@
 			#size-cells = <0>;
 			interrupts = <8 0>;
 			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x8 0x8>;
 			zephyr,pm-device-runtime-auto;
 		};
 
@@ -332,7 +322,6 @@
 			#size-cells = <0>;
 			interrupts = <9 0>;
 			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x8 0x10>;
 			zephyr,pm-device-runtime-auto;
 		};
 
@@ -343,7 +332,6 @@
 			#size-cells = <0>;
 			interrupts = <10 0>;
 			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x8 0x20>;
 			zephyr,pm-device-runtime-auto;
 		};
 
@@ -354,7 +342,6 @@
 			#size-cells = <0>;
 			interrupts = <11 0>;
 			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x8 0x40>;
 			zephyr,pm-device-runtime-auto;
 		};
 
@@ -367,7 +354,6 @@
 			internal-vref-mv = <1500>;
 			status = "disabled";
 			#io-channel-cells = <1>;
-			ambiq,pwrcfg = <&pwrcfg 0x8 0x200>;
 		};
 
 		mspi0: mspi@50014000 {
@@ -378,7 +364,6 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x8 0x800>;
 		};
 
 		mspi1: mspi@50015000 {
@@ -389,7 +374,6 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x8 0x1000>;
 		};
 
 		mspi2: mspi@50016000 {
@@ -400,7 +384,6 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x8 0x2000>;
 		};
 
 		rtc0: rtc@40004240 {
@@ -418,7 +401,6 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x8 0x8000>;
 
 			bt_hci_apollo: bt-hci@0 {
 				compatible = "ambiq,bt-hci-spi";

--- a/dts/arm/ambiq/ambiq_apollo4p.dtsi
+++ b/dts/arm/ambiq/ambiq_apollo4p.dtsi
@@ -160,7 +160,6 @@
 			#size-cells = <0>;
 			interrupts = <6 0>;
 			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x4 0x2>;
 		};
 
 		iom0_i2c: i2c@40050000 {
@@ -170,7 +169,6 @@
 			#size-cells = <0>;
 			interrupts = <6 0>;
 			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x4 0x2>;
 		};
 
 		iom1_spi: spi@40051000 {
@@ -180,7 +178,6 @@
 			#size-cells = <0>;
 			interrupts = <7 0>;
 			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x4 0x4>;
 		};
 
 		iom1_i2c: i2c@40051000 {
@@ -190,7 +187,6 @@
 			#size-cells = <0>;
 			interrupts = <7 0>;
 			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x4 0x4>;
 		};
 
 		iom2_spi: spi@40052000 {
@@ -200,7 +196,6 @@
 			#size-cells = <0>;
 			interrupts = <8 0>;
 			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x4 0x8>;
 		};
 
 		iom2_i2c: i2c@40052000 {
@@ -210,7 +205,6 @@
 			#size-cells = <0>;
 			interrupts = <8 0>;
 			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x4 0x8>;
 		};
 
 		iom3_spi: spi@40053000 {
@@ -220,7 +214,6 @@
 			#size-cells = <0>;
 			interrupts = <9 0>;
 			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x4 0x10>;
 		};
 
 		iom3_i2c: i2c@40053000 {
@@ -230,7 +223,6 @@
 			#size-cells = <0>;
 			interrupts = <9 0>;
 			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x4 0x10>;
 		};
 
 		iom4_spi: spi@40054000 {
@@ -240,7 +232,6 @@
 			#size-cells = <0>;
 			interrupts = <10 0>;
 			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x4 0x20>;
 		};
 
 		iom4_i2c: i2c@40054000 {
@@ -250,7 +241,6 @@
 			#size-cells = <0>;
 			interrupts = <10 0>;
 			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x4 0x20>;
 		};
 
 		iom5_spi: spi@40055000 {
@@ -260,7 +250,6 @@
 			#size-cells = <0>;
 			interrupts = <11 0>;
 			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x4 0x40>;
 		};
 
 		iom5_i2c: i2c@40055000 {
@@ -270,7 +259,6 @@
 			#size-cells = <0>;
 			interrupts = <11 0>;
 			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x4 0x40>;
 		};
 
 		iom6_spi: spi@40056000 {
@@ -280,7 +268,6 @@
 			#size-cells = <0>;
 			interrupts = <12 0>;
 			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x4 0x80>;
 		};
 
 		iom6_i2c: i2c@40056000 {
@@ -290,7 +277,6 @@
 			#size-cells = <0>;
 			interrupts = <12 0>;
 			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x4 0x80>;
 		};
 
 		iom7_spi: spi@40057000 {
@@ -300,7 +286,6 @@
 			#size-cells = <0>;
 			interrupts = <13 0>;
 			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x4 0x100>;
 		};
 
 		iom7_i2c: i2c@40057000 {
@@ -310,7 +295,6 @@
 			#size-cells = <0>;
 			interrupts = <13 0>;
 			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x4 0x100>;
 		};
 
 		adc0: adc@40038000 {
@@ -322,7 +306,6 @@
 			internal-vref-mv = <1190>;
 			status = "disabled";
 			#io-channel-cells = <1>;
-			ambiq,pwrcfg = <&pwrcfg 0x4 0x2000>;
 		};
 
 		mspi0: spi@40060000 {
@@ -332,7 +315,6 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x4 0x4000>;
 		};
 
 		mspi1: spi@40061000 {
@@ -342,7 +324,6 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x4 0x8000>;
 		};
 
 		mspi2: spi@40062000 {
@@ -352,7 +333,6 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x4 0x10000>;
 		};
 
 		rtc0: rtc@40004800 {
@@ -370,7 +350,6 @@
 			num-bidir-endpoints = <6>;
 			maximum-speed = "full-speed";
 			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x4 0x400000>;
 		};
 
 		pinctrl: pin-controller@40010000 {

--- a/dts/arm/ambiq/ambiq_apollo4p_blue.dtsi
+++ b/dts/arm/ambiq/ambiq_apollo4p_blue.dtsi
@@ -141,7 +141,6 @@
 			#size-cells = <0>;
 			interrupts = <6 0>;
 			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x4 0x2>;
 		};
 
 		spi1: spi@40051000 {
@@ -151,7 +150,6 @@
 			#size-cells = <0>;
 			interrupts = <7 0>;
 			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x4 0x4>;
 		};
 
 		spi2: spi@40052000 {
@@ -161,7 +159,6 @@
 			#size-cells = <0>;
 			interrupts = <8 0>;
 			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x4 0x8>;
 		};
 
 		spi3: spi@40053000 {
@@ -171,7 +168,6 @@
 			#size-cells = <0>;
 			interrupts = <9 0>;
 			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x4 0x10>;
 		};
 
 		spi4: spi@40054000 {
@@ -184,7 +180,6 @@
 			cs-gpios = <&gpio32_63 22 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
 			clock-frequency = <DT_FREQ_M(24)>;
 			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x4 0x20>;
 
 			bt_hci_apollo: bt-hci@0 {
 				compatible = "ambiq,bt-hci-spi";
@@ -203,7 +198,6 @@
 			#size-cells = <0>;
 			interrupts = <11 0>;
 			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x4 0x40>;
 		};
 
 		spi6: spi@40056000 {
@@ -213,7 +207,6 @@
 			#size-cells = <0>;
 			interrupts = <12 0>;
 			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x4 0x80>;
 		};
 
 		spi7: spi@40057000 {
@@ -223,7 +216,6 @@
 			#size-cells = <0>;
 			interrupts = <13 0>;
 			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x4 0x100>;
 		};
 
 		i2c0: i2c@40050000 {
@@ -233,7 +225,6 @@
 			#size-cells = <0>;
 			interrupts = <6 0>;
 			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x4 0x2>;
 		};
 
 		i2c1: i2c@40051000 {
@@ -243,7 +234,6 @@
 			#size-cells = <0>;
 			interrupts = <7 0>;
 			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x4 0x4>;
 		};
 
 		i2c2: i2c@40052000 {
@@ -253,7 +243,6 @@
 			#size-cells = <0>;
 			interrupts = <8 0>;
 			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x4 0x8>;
 		};
 
 		i2c3: i2c@40053000 {
@@ -263,7 +252,6 @@
 			#size-cells = <0>;
 			interrupts = <9 0>;
 			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x4 0x10>;
 		};
 
 		i2c4: i2c@40054000 {
@@ -273,7 +261,6 @@
 			#size-cells = <0>;
 			interrupts = <10 0>;
 			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x4 0x20>;
 		};
 
 		i2c5: i2c@40055000 {
@@ -283,7 +270,6 @@
 			#size-cells = <0>;
 			interrupts = <11 0>;
 			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x4 0x40>;
 		};
 
 		i2c6: i2c@40056000 {
@@ -293,7 +279,6 @@
 			#size-cells = <0>;
 			interrupts = <12 0>;
 			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x4 0x80>;
 		};
 
 		i2c7: i2c@40057000 {
@@ -303,7 +288,6 @@
 			#size-cells = <0>;
 			interrupts = <13 0>;
 			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x4 0x100>;
 		};
 
 		mspi0: spi@40060000 {
@@ -313,7 +297,6 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x4 0x4000>;
 		};
 
 		mspi1: spi@40061000 {
@@ -323,7 +306,6 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x4 0x8000>;
 		};
 
 		mspi2: spi@40062000 {
@@ -333,7 +315,6 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x4 0x10000>;
 		};
 
 		usb: usb@400b0000 {
@@ -343,7 +324,6 @@
 			num-bidir-endpoints = <6>;
 			maximum-speed = "full-speed";
 			status = "disabled";
-			ambiq,pwrcfg = <&pwrcfg 0x4 0x400000>;
 		};
 
 		rtc0: rtc@40004800 {

--- a/dts/bindings/adc/ambiq,adc.yaml
+++ b/dts/bindings/adc/ambiq,adc.yaml
@@ -5,7 +5,7 @@ description: Ambiq ADC node
 
 compatible: "ambiq,adc"
 
-include: [adc-controller.yaml, pinctrl-device.yaml, ambiq-pwrcfg.yaml]
+include: [adc-controller.yaml, pinctrl-device.yaml]
 properties:
   reg:
     required: true

--- a/dts/bindings/i2c/ambiq,i2c.yaml
+++ b/dts/bindings/i2c/ambiq,i2c.yaml
@@ -5,16 +5,13 @@ description: Ambiq I2C
 
 compatible: "ambiq,i2c"
 
-include: [i2c-controller.yaml, pinctrl-device.yaml, ambiq-pwrcfg.yaml]
+include: [i2c-controller.yaml, pinctrl-device.yaml]
 
 properties:
   reg:
     required: true
 
   interrupts:
-    required: true
-
-  ambiq,pwrcfg:
     required: true
 
   scl-gpios:

--- a/dts/bindings/mspi/ambiq,mspi-controller.yaml
+++ b/dts/bindings/mspi/ambiq,mspi-controller.yaml
@@ -5,16 +5,13 @@ description: Ambiq MSPI controller
 
 compatible: "ambiq,mspi-controller"
 
-include: [mspi-controller.yaml, pinctrl-device.yaml, ambiq-pwrcfg.yaml]
+include: [mspi-controller.yaml, pinctrl-device.yaml]
 
 properties:
   reg:
     required: true
 
   interrupts:
-    required: true
-
-  ambiq,pwrcfg:
     required: true
 
   ce-gpios:

--- a/dts/bindings/spi/ambiq,mspi.yaml
+++ b/dts/bindings/spi/ambiq,mspi.yaml
@@ -5,14 +5,11 @@ description: Ambiq MSPI
 
 compatible: "ambiq,mspi"
 
-include: [spi-controller.yaml, pinctrl-device.yaml, ambiq-pwrcfg.yaml]
+include: [spi-controller.yaml, pinctrl-device.yaml]
 
 properties:
   reg:
     required: true
 
   interrupts:
-    required: true
-
-  ambiq,pwrcfg:
     required: true

--- a/dts/bindings/spi/ambiq,spi-bleif.yaml
+++ b/dts/bindings/spi/ambiq,spi-bleif.yaml
@@ -8,11 +8,8 @@ description: |
 
 compatible: "ambiq,spi-bleif"
 
-include: [spi-controller.yaml, pinctrl-device.yaml, ambiq-pwrcfg.yaml]
+include: [spi-controller.yaml, pinctrl-device.yaml]
 
 properties:
   reg:
-    required: true
-
-  ambiq,pwrcfg:
     required: true

--- a/dts/bindings/spi/ambiq,spi.yaml
+++ b/dts/bindings/spi/ambiq,spi.yaml
@@ -5,7 +5,7 @@ description: Ambiq SPI
 
 compatible: "ambiq,spi"
 
-include: [spi-controller.yaml, pinctrl-device.yaml, ambiq-pwrcfg.yaml]
+include: [spi-controller.yaml, pinctrl-device.yaml]
 
 properties:
   reg:
@@ -15,7 +15,4 @@ properties:
     required: true
 
   clock-frequency:
-    required: true
-
-  ambiq,pwrcfg:
     required: true

--- a/dts/bindings/spi/ambiq,spid.yaml
+++ b/dts/bindings/spi/ambiq,spid.yaml
@@ -5,7 +5,7 @@ description: Ambiq SPI Device
 
 compatible: "ambiq,spid"
 
-include: [spi-controller.yaml, pinctrl-device.yaml, ambiq-pwrcfg.yaml]
+include: [spi-controller.yaml, pinctrl-device.yaml]
 
 properties:
   int-gpios:

--- a/dts/bindings/usb/ambiq,usb.yaml
+++ b/dts/bindings/usb/ambiq,usb.yaml
@@ -5,16 +5,13 @@ description: Ambiq USB
 
 compatible: "ambiq,usb"
 
-include: [usb-ep.yaml, pinctrl-device.yaml, ambiq-pwrcfg.yaml]
+include: [usb-ep.yaml, pinctrl-device.yaml]
 
 properties:
   reg:
     required: true
 
   interrupts:
-    required: true
-
-  ambiq,pwrcfg:
     required: true
 
   vddusb33-gpios:


### PR DESCRIPTION
This commit changes to use ambiq hal power control APIs to replace the previous register settings to power on ambiq drivers.