### PR TITLE
dts: Use a hyphen as the delimiter for binding properties

### DIFF
--- a/doc/releases/migration-guide-4.2.rst
+++ b/doc/releases/migration-guide-4.2.rst
@@ -196,6 +196,12 @@ Modem
   :kconfig:option:`CONFIG_MODEM_CMUX_WORK_BUFFER_SIZE` and :kconfig:option:`CONFIG_MODEM_CMUX_MTU`.
 
 
+LED
+===
+
+* Renamed the devicetree property ``log_scale_en`` to ``log-scale-en``.
+
+
 Stepper
 =======
 

--- a/dts/arm/silabs/siwg917.dtsi
+++ b/dts/arm/silabs/siwg917.dtsi
@@ -271,7 +271,7 @@
 			interrupt-names = "pwm";
 			clocks = <&clock0 SIWX91X_CLK_PWM>;
 			#pwm-cells = <2>;
-			silabs,ch_prescaler = <64 64 64 64>;
+			silabs,ch-prescaler = <64 64 64 64>;
 			status = "disabled";
 		};
 

--- a/dts/bindings/display/solomon,ssd1309fb-spi.yaml
+++ b/dts/bindings/display/solomon,ssd1309fb-spi.yaml
@@ -8,7 +8,7 @@ compatible: "solomon,ssd1309fb"
 include: ["solomon,ssd1306fb-common.yaml", "spi-device.yaml"]
 
 properties:
-  data_cmd-gpios:
+  data-cmd-gpios:
     type: phandle-array
     required: true
     description: D/C# pin.

--- a/dts/bindings/led/ti,lp50xx.yaml
+++ b/dts/bindings/led/ti,lp50xx.yaml
@@ -12,7 +12,7 @@ properties:
     type: boolean
     description: |
       If enabled the maximum current output is set to 35 mA (25.5 mA else).
-  log_scale_en:
+  log-scale-en:
     type: boolean
     description: |
       If enabled a logarithmic dimming scale curve is used for LED brightness

--- a/dts/bindings/pwm/silabs,siwx91x-pwm.yaml
+++ b/dts/bindings/pwm/silabs,siwx91x-pwm.yaml
@@ -12,7 +12,7 @@ properties:
   "#pwm-cells":
     const: 2
 
-  silabs,ch_prescaler:
+  silabs,ch-prescaler:
     type: array
     required: true
     description: |
@@ -26,7 +26,7 @@ properties:
       - 32
       - 64
 
-  silabs,pwm_polarity:
+  silabs,pwm-polarity:
     type: int
     required: true
     description: |

--- a/tests/drivers/pwm/pwm_api/boards/siwx917_rb4338a.overlay
+++ b/tests/drivers/pwm/pwm_api/boards/siwx917_rb4338a.overlay
@@ -26,6 +26,6 @@
 	pwm_channel1: pwm_channel1 {
 		pwms = <&pwm 0 1000000>;
 	};
-	silabs,pwm_polarity = <PWM_POLARITY_NORMAL>;
+	silabs,pwm-polarity = <PWM_POLARITY_NORMAL>;
 	status = "okay";
 };


### PR DESCRIPTION
Supplement the missing binding omitted during
the implementation of RFC-53506.