### PR TITLE
drivers: udc_dwc2: Disable endpoint while hibernated

### DIFF
--- a/drivers/usb/udc/udc_dwc2_vendor_quirks.h
+++ b/drivers/usb/udc/udc_dwc2_vendor_quirks.h
@@ -199,6 +199,11 @@ static inline int usbhs_enable_core(const struct device *dev)
 	}
 
 	wrapper->ENABLE = USBHS_ENABLE_PHY_Msk | USBHS_ENABLE_CORE_Msk;
+
+	/* Wait for PHY clock to start */
+	k_busy_wait(45);
+
+	/* Release DWC2 reset */
 	wrapper->TASKS_START = 1UL;
 
 	/* Wait for clock to start to avoid hang on too early register read */
@@ -218,7 +223,6 @@ static inline int usbhs_disable_core(const struct device *dev)
 	wrapper->INTENCLR = 1UL;
 
 	wrapper->ENABLE = 0UL;
-	wrapper->TASKS_START = 1UL;
 
 	return 0;
 }


### PR DESCRIPTION
When the endpoint is disabled while the core is hibernated, there are timeouts waiting for interrupts. It is not clear how the stack should behave when class and/or application wants to disable the endpoint while device is suspended. The problem was originally observed when the endpoints were disabled as a result of usbd_disable() call.

Avoid the timeouts by modifying the backup values instead of the real registers (which are not accessible when hibernated).

Split the 32-bit txf_set variable into two 16-bit variables (txf_set and pending_tx_flush) because maximum number of TxFIFO instances is 16. The txf_set variable is used as-is, while the pending_tx_flush is used to keep track of TxFIFOs that have to be flushed on hibernation exit.