### PR TITLE
net: core: Free packet properly if TTL/hop limit is 0

### DIFF
--- a/subsys/net/ip/net_core.c
+++ b/subsys/net/ip/net_core.c
@@ -391,6 +391,7 @@ int net_try_send_data(struct net_pkt *pkt, k_timeout_t timeout)
 		 * we just silently drop the packet by returning 0.
 		 */
 		if (status == -ENOMSG) {
+			net_pkt_unref(pkt);
 			ret = 0;
 			goto err;
 		}


### PR DESCRIPTION
We drop the packet if TTL or hop limit is 0, but we should also unref the packet in this case because we return 0 to the caller which is not then able to free the packet because it thinks that the packet was sent properly.

Fixes #87323