### PR TITLE
net: core: Do IPv4/6 packet checks only for those packet types

### DIFF
--- a/subsys/net/ip/net_core.c
+++ b/subsys/net/ip/net_core.c
@@ -215,7 +215,8 @@ static inline int check_ip(struct net_pkt *pkt)
 	family = net_pkt_family(pkt);
 	ret = 0;
 
-	if (IS_ENABLED(CONFIG_NET_IPV6) && family == AF_INET6) {
+	if (IS_ENABLED(CONFIG_NET_IPV6) && family == AF_INET6 &&
+	    net_pkt_ll_proto_type(pkt) == NET_ETH_PTYPE_IPV6) {
 		/* Drop IPv6 packet if hop limit is 0 */
 		if (NET_IPV6_HDR(pkt)->hop_limit == 0) {
 			NET_DBG("DROP: IPv6 hop limit");
@@ -288,7 +289,8 @@ static inline int check_ip(struct net_pkt *pkt)
 			goto drop;
 		}
 
-	} else if (IS_ENABLED(CONFIG_NET_IPV4) && family == AF_INET) {
+	} else if (IS_ENABLED(CONFIG_NET_IPV4) && family == AF_INET &&
+		   net_pkt_ll_proto_type(pkt) == NET_ETH_PTYPE_IP) {
 		/* Drop IPv4 packet if ttl is 0 */
 		if (NET_IPV4_HDR(pkt)->ttl == 0) {
 			NET_DBG("DROP: IPv4 ttl");

--- a/tests/net/ipv6_fragment/src/main.c
+++ b/tests/net/ipv6_fragment/src/main.c
@@ -2090,6 +2090,7 @@ ZTEST(net_ipv6_fragment, test_send_ipv6_fragment_without_hbho)
 					AF_UNSPEC, 0, ALLOC_TIMEOUT);
 	zassert_not_null(pkt, "packet");
 
+	net_pkt_set_ll_proto_type(pkt, NET_ETH_PTYPE_IPV6);
 	net_pkt_set_family(pkt, AF_INET6);
 	net_pkt_set_ip_hdr_len(pkt, sizeof(struct net_ipv6_hdr));
 	net_pkt_set_ipv6_ext_len(pkt, NET_IPV6_FRAGH_LEN); /* without hbho*/


### PR DESCRIPTION
The check_ip() in net_core.c did not check that the packet Ethernet type is either IPv4 or IPv6. This meant that we for example checked TTL also for ARP packets which is pointless as those are not IPv4 packets.

Fix this by checking the link layer protocol type of the packet to be either IPv4 or IPv6 before doing L3 checks.

Fixes #87327
