### PR TITLE
tests: ztest: enable ztest_no_yield for all in PM

### DIFF
--- a/boards/nxp/rd_rw612_bga/Kconfig.defconfig
+++ b/boards/nxp/rd_rw612_bga/Kconfig.defconfig
@@ -37,7 +37,4 @@ config NET_L2_ETHERNET
 
 endif # DT_HAS_NXP_ENET_MAC_ENABLED && NETWORKING
 
-config ZTEST_NO_YIELD
-	default y if (ZTEST && PM)
-
 endif # BOARD_RD_RW612_BGA

--- a/soc/nxp/imxrt/Kconfig.defconfig
+++ b/soc/nxp/imxrt/Kconfig.defconfig
@@ -35,10 +35,6 @@ config PM_MCUX_GPC
 	default y if HAS_MCUX_GPC
 	depends on SOC_SERIES_IMXRT11XX && PM
 
-# Don't allow SOC to sleep after tests complete when PM is enabled
-config ZTEST_NO_YIELD
-	default y if (ZTEST && PM)
-
 if SOC_SERIES_IMXRT10XX && PM
 
 config CODE_DATA_RELOCATION

--- a/soc/nxp/imxrt/imxrt5xx/Kconfig.defconfig
+++ b/soc/nxp/imxrt/imxrt5xx/Kconfig.defconfig
@@ -17,9 +17,6 @@ config ROM_START_OFFSET
 config NUM_IRQS
 	default 76
 
-config ZTEST_NO_YIELD
-	default y if (PM && ZTEST)
-
 if MBEDTLS
 #
 # MBEDTLS CTR_DRBG code path needs extra stack space for initialization than

--- a/soc/nxp/imxrt/imxrt6xx/Kconfig.defconfig
+++ b/soc/nxp/imxrt/imxrt6xx/Kconfig.defconfig
@@ -35,9 +35,6 @@ config ROM_START_OFFSET
 config NUM_IRQS
 	default 60
 
-config ZTEST_NO_YIELD
-	default y if (ZTEST && PM)
-
 if MBEDTLS
 #
 # MBEDTLS CTR_DRBG code path needs extra stack space for initialization than

--- a/soc/nxp/mcx/mcxn/Kconfig.defconfig
+++ b/soc/nxp/mcx/mcxn/Kconfig.defconfig
@@ -12,9 +12,6 @@ config NUM_IRQS
 config ROM_START_OFFSET
 	default 0x400 if BOOTLOADER_MCUBOOT
 
-config ZTEST_NO_YIELD
-	default y if (PM && ZTEST)
-
 config MCUX_LPTMR_TIMER
 	default n if (DT_HAS_NXP_OS_TIMER_ENABLED || DT_HAS_ARM_ARMV8M_SYSTICK_ENABLED)
 

--- a/subsys/testsuite/ztest/Kconfig
+++ b/subsys/testsuite/ztest/Kconfig
@@ -101,6 +101,7 @@ config ZTEST_ASSERT_HOOK
 
 config ZTEST_NO_YIELD
 	bool "Do not yield to the idle thread after tests complete"
+	default y if PM
 	help
 	  When the tests complete, do not yield to the idle thread and instead
 	  spin in a loop. This is useful for low power mode tests, where


### PR DESCRIPTION
if CONFIG_PM=y, board will enter low power,
which will cause problem for debugger.
So for ztest cases, we need enable this to avoid problem. This used to apply to soc/platform level, now remove them.