### PR TITLE
STM32 H7X: cleanup setting of power supply and voltage scaling

### DIFF
--- a/drivers/clock_control/clock_stm32_ll_h7.c
+++ b/drivers/clock_control/clock_stm32_ll_h7.c
@@ -249,27 +249,6 @@ static uint32_t get_hclk_frequency(void)
 
 static int32_t prepare_regulator_voltage_scale(void)
 {
-	/* Apply system power supply configuration */
-#if defined(SMPS) && defined(CONFIG_POWER_SUPPLY_DIRECT_SMPS)
-	LL_PWR_ConfigSupply(LL_PWR_DIRECT_SMPS_SUPPLY);
-#elif defined(SMPS) && defined(CONFIG_POWER_SUPPLY_SMPS_1V8_SUPPLIES_LDO)
-	LL_PWR_ConfigSupply(LL_PWR_SMPS_1V8_SUPPLIES_LDO);
-#elif defined(SMPS) && defined(CONFIG_POWER_SUPPLY_SMPS_2V5_SUPPLIES_LDO)
-	LL_PWR_ConfigSupply(LL_PWR_SMPS_2V5_SUPPLIES_LDO);
-#elif defined(SMPS) && defined(CONFIG_POWER_SUPPLY_SMPS_1V8_SUPPLIES_EXT_AND_LDO)
-	LL_PWR_ConfigSupply(LL_PWR_SMPS_1V8_SUPPLIES_EXT_AND_LDO);
-#elif defined(SMPS) && defined(CONFIG_POWER_SUPPLY_SMPS_2V5_SUPPLIES_EXT_AND_LDO)
-	LL_PWR_ConfigSupply(LL_PWR_SMPS_2V5_SUPPLIES_EXT_AND_LDO);
-#elif defined(SMPS) && defined(CONFIG_POWER_SUPPLY_SMPS_1V8_SUPPLIES_EXT)
-	LL_PWR_ConfigSupply(LL_PWR_SMPS_1V8_SUPPLIES_EXT);
-#elif defined(SMPS) && defined(CONFIG_POWER_SUPPLY_SMPS_2V5_SUPPLIES_EXT)
-	LL_PWR_ConfigSupply(LL_PWR_SMPS_2V5_SUPPLIES_EXT);
-#elif defined(CONFIG_POWER_SUPPLY_EXTERNAL_SOURCE)
-	LL_PWR_ConfigSupply(LL_PWR_EXTERNAL_SOURCE_SUPPLY);
-#else
-	LL_PWR_ConfigSupply(LL_PWR_LDO_SUPPLY);
-#endif
-
 	/* Make sure to put the CPU in highest Voltage scale during clock configuration */
 	/* Highest voltage is SCALE0 */
 	LL_PWR_SetRegulVoltageScaling(LL_PWR_REGU_VOLTAGE_SCALE0);
@@ -279,6 +258,7 @@ static int32_t prepare_regulator_voltage_scale(void)
 	while (LL_PWR_IsActiveFlag_VOS() == 0) {
 #endif
 	}
+
 	return 0;
 }
 
@@ -292,25 +272,6 @@ static int32_t optimize_regulator_voltage_scale(uint32_t sysclk_freq)
 	/* LL_PWR_REGULATOR_SCALE3 is lowest power consumption */
 	/* Must be done in accordance to the Maximum allowed frequency vs VOS*/
 	/* See RM0433 page 352 for more details */
-#if defined(SMPS) && defined(CONFIG_POWER_SUPPLY_DIRECT_SMPS)
-	LL_PWR_ConfigSupply(LL_PWR_DIRECT_SMPS_SUPPLY);
-#elif defined(SMPS) && defined(CONFIG_POWER_SUPPLY_SMPS_1V8_SUPPLIES_LDO)
-	LL_PWR_ConfigSupply(LL_PWR_SMPS_1V8_SUPPLIES_LDO);
-#elif defined(SMPS) && defined(CONFIG_POWER_SUPPLY_SMPS_2V5_SUPPLIES_LDO)
-	LL_PWR_ConfigSupply(LL_PWR_SMPS_2V5_SUPPLIES_LDO);
-#elif defined(SMPS) && defined(CONFIG_POWER_SUPPLY_SMPS_1V8_SUPPLIES_EXT_AND_LDO)
-	LL_PWR_ConfigSupply(LL_PWR_SMPS_1V8_SUPPLIES_EXT_AND_LDO);
-#elif defined(SMPS) && defined(CONFIG_POWER_SUPPLY_SMPS_2V5_SUPPLIES_EXT_AND_LDO)
-	LL_PWR_ConfigSupply(LL_PWR_SMPS_2V5_SUPPLIES_EXT_AND_LDO);
-#elif defined(SMPS) && defined(CONFIG_POWER_SUPPLY_SMPS_1V8_SUPPLIES_EXT)
-	LL_PWR_ConfigSupply(LL_PWR_SMPS_1V8_SUPPLIES_EXT);
-#elif defined(SMPS) && defined(CONFIG_POWER_SUPPLY_SMPS_2V5_SUPPLIES_EXT)
-	LL_PWR_ConfigSupply(LL_PWR_SMPS_2V5_SUPPLIES_EXT);
-#elif defined(CONFIG_POWER_SUPPLY_EXTERNAL_SOURCE)
-	LL_PWR_ConfigSupply(LL_PWR_EXTERNAL_SOURCE_SUPPLY);
-#else
-	LL_PWR_ConfigSupply(LL_PWR_LDO_SUPPLY);
-#endif
 	LL_PWR_SetRegulVoltageScaling(LL_PWR_REGU_VOLTAGE_SCALE0);
 #if defined(CONFIG_SOC_SERIES_STM32H7RSX)
 	while (LL_PWR_IsActiveFlag_VOSRDY() == 0) {
@@ -318,6 +279,7 @@ static int32_t optimize_regulator_voltage_scale(uint32_t sysclk_freq)
 	while (LL_PWR_IsActiveFlag_VOS() == 0) {
 #endif
 	};
+
 	return 0;
 }
 

--- a/soc/st/stm32/stm32h7x/soc_m7.c
+++ b/soc/st/stm32/stm32h7x/soc_m7.c
@@ -89,9 +89,6 @@ void soc_early_init_hook(void)
 #else
 	LL_PWR_ConfigSupply(LL_PWR_LDO_SUPPLY);
 #endif
-	LL_PWR_SetRegulVoltageScaling(LL_PWR_REGU_VOLTAGE_SCALE1);
-	while (LL_PWR_IsActiveFlag_VOS() == 0) {
-	}
 
 	/* Errata ES0392 Rev 8:
 	 * 2.2.9: Reading from AXI SRAM may lead to data read corruption


### PR DESCRIPTION
Currently, the H7 configures power supply and voltage scaling in multiple locations: SoC initialization and clock initialization. Different scaling factors are applied: SoC init sets it to 1, while clock init applies the boost scale of 0.

This setup functions correctly when the firmware boots without MCUboot, following the sequence: `3 (default) → 1 → 0`. However, when used with MCUboot, the sequence becomes `3 → 1 → 0 → 1 → 0`. If the bootloader configures the system clock to 480 MHz and jumps to the application with a scaling factor of 0, the application then sets it back to 1 during early SoC initialization. This results in an incorrect scaling factor for the configured system clock, with potentially unknown consequences.

Additionally, the power source is redundantly set in multiple places to the same value, whereas it could be configured just once in early SoC initialization.

This PR simplifies the process by setting the power source only once in early SoC initialization while leaving voltage scaling to the clock initialization phase.

It has been tested successfully on the H730, but further testing, especially on H7 configurations with both M7 and M4 cores, would be valuable.