### PR TITLE
drivers: input: sdl_touch: Link to a specific display

### DIFF
--- a/boards/native/native_sim/native_sim.dts
+++ b/boards/native/native_sim/native_sim.dts
@@ -196,6 +196,7 @@
 
 	input_sdl_touch: input-sdl-touch {
 		compatible = "zephyr,input-sdl-touch";
+		display = <&sdl_dc>;
 	};
 
 	can_loopback0: can_loopback0 {

--- a/drivers/display/display_sdl.c
+++ b/drivers/display/display_sdl.c
@@ -79,9 +79,10 @@ static int sdl_display_init(const struct device *dev)
 	}
 
 	int rc = sdl_display_init_bottom(config->height, config->width, sdl_display_zoom_pct,
-					 use_accelerator, &disp_data->window, &disp_data->renderer,
-					 &disp_data->mutex, &disp_data->texture,
-					 &disp_data->read_texture, &disp_data->background_texture,
+					 use_accelerator, &disp_data->window, dev,
+					 &disp_data->renderer, &disp_data->mutex,
+					 &disp_data->texture, &disp_data->read_texture,
+					 &disp_data->background_texture,
 					 CONFIG_SDL_DISPLAY_TRANSPARENCY_GRID_CELL_COLOR_1,
 					 CONFIG_SDL_DISPLAY_TRANSPARENCY_GRID_CELL_COLOR_2,
 					 CONFIG_SDL_DISPLAY_TRANSPARENCY_GRID_CELL_SIZE);

--- a/drivers/display/display_sdl_bottom.c
+++ b/drivers/display/display_sdl_bottom.c
@@ -14,10 +14,10 @@
 #include "nsi_tracing.h"
 
 int sdl_display_init_bottom(uint16_t height, uint16_t width, uint16_t zoom_pct,
-			    bool use_accelerator, void **window, void **renderer, void **mutex,
-			    void **texture, void **read_texture, void **background_texture,
-			    uint32_t transparency_grid_color1, uint32_t transparency_grid_color2,
-			    uint16_t transparency_grid_cell_size)
+			    bool use_accelerator, void **window, const void *window_user_data,
+			    void **renderer, void **mutex, void **texture, void **read_texture,
+			    void **background_texture, uint32_t transparency_grid_color1,
+			    uint32_t transparency_grid_color2, uint16_t transparency_grid_cell_size)
 {
 	*window = SDL_CreateWindow("Zephyr Display", SDL_WINDOWPOS_UNDEFINED,
 				   SDL_WINDOWPOS_UNDEFINED, width * zoom_pct / 100,
@@ -26,6 +26,7 @@ int sdl_display_init_bottom(uint16_t height, uint16_t width, uint16_t zoom_pct,
 		nsi_print_warning("Failed to create SDL window: %s", SDL_GetError());
 		return -1;
 	}
+	SDL_SetWindowData(*window, "zephyr_display", (void *)window_user_data);
 
 	if (use_accelerator) {
 		*renderer = SDL_CreateRenderer(*window, -1, SDL_RENDERER_ACCELERATED);

--- a/drivers/display/display_sdl_bottom.h
+++ b/drivers/display/display_sdl_bottom.h
@@ -21,9 +21,10 @@ extern "C" {
 /* Note: None of these functions are public interfaces. But internal to the SDL display driver */
 
 int sdl_display_init_bottom(uint16_t height, uint16_t width, uint16_t zoom_pct,
-			    bool use_accelerator, void **window, void **renderer, void **mutex,
-			    void **texture, void **read_texture, void **background_texture,
-			    uint32_t transparency_grid_color1, uint32_t transparency_grid_color2,
+			    bool use_accelerator, void **window, const void *window_user_data,
+			    void **renderer, void **mutex, void **texture, void **read_texture,
+			    void **background_texture, uint32_t transparency_grid_color1,
+			    uint32_t transparency_grid_color2,
 			    uint16_t transparency_grid_cell_size);
 void sdl_display_write_bottom(const uint16_t height, const uint16_t width, const uint16_t x,
 			      const uint16_t y, void *renderer, void *mutex, void *texture,

--- a/drivers/input/input_sdl_touch.c
+++ b/drivers/input/input_sdl_touch.c
@@ -41,7 +41,11 @@ static int sdl_init(const struct device *dev)
 	return 0;
 }
 
-static struct sdl_input_data sdl_data_0;
+#define INPUT_SDL_TOUCH_DEFINE(inst)                                                               \
+	static struct sdl_input_data sdl_data_##inst = {                                           \
+		.display_dev = DEVICE_DT_GET_OR_NULL(DT_INST_PHANDLE(inst, display)),              \
+	};                                                                                         \
+	DEVICE_DT_INST_DEFINE(inst, sdl_init, NULL, &sdl_data_##inst, NULL, POST_KERNEL,           \
+			      CONFIG_INPUT_INIT_PRIORITY, NULL);
 
-DEVICE_DT_INST_DEFINE(0, sdl_init, NULL, &sdl_data_0, NULL,
-		    POST_KERNEL, CONFIG_INPUT_INIT_PRIORITY, NULL);
+DT_INST_FOREACH_STATUS_OKAY(INPUT_SDL_TOUCH_DEFINE)

--- a/drivers/input/input_sdl_touch_bottom.c
+++ b/drivers/input/input_sdl_touch_bottom.c
@@ -8,9 +8,40 @@
 #include <SDL.h>
 #include "input_sdl_touch_bottom.h"
 
+static bool event_targets_display(SDL_Event *event, struct sdl_input_data *data)
+{
+	SDL_Window *window = NULL;
+	const void *display_dev;
+
+	if (!data->display_dev) {
+		return true;
+	}
+
+	if (event->type == SDL_MOUSEBUTTONDOWN || event->type == SDL_MOUSEBUTTONUP) {
+		window = SDL_GetWindowFromID(event->button.windowID);
+	} else if (event->type == SDL_MOUSEMOTION) {
+		window = SDL_GetWindowFromID(event->motion.windowID);
+	} else {
+		return false;
+	}
+
+	if (!window) {
+		return false;
+	}
+
+	/* Get the zephyr display associated with the window */
+	display_dev = SDL_GetWindowData(window, "zephyr_display");
+
+	return !display_dev || display_dev == data->display_dev;
+}
+
 static int sdl_filter(void *arg, SDL_Event *event)
 {
 	struct sdl_input_data *data = arg;
+
+	if (!event_targets_display(event, data)) {
+		return 1;
+	}
 
 	switch (event->type) {
 	case SDL_MOUSEBUTTONUP:

--- a/drivers/input/input_sdl_touch_bottom.h
+++ b/drivers/input/input_sdl_touch_bottom.h
@@ -22,6 +22,7 @@ extern "C" {
 
 struct sdl_input_data {
 	const void *dev; /* device structure pointer */
+	const void *display_dev;
 	void (*callback)(struct sdl_input_data *data);
 	int x;
 	int y;

--- a/dts/bindings/input/zephyr,input-sdl-touch.yaml
+++ b/dts/bindings/input/zephyr,input-sdl-touch.yaml
@@ -4,3 +4,8 @@
 description: SDL based emulated touch panel
 
 compatible: "zephyr,input-sdl-touch"
+
+properties:
+  display:
+    type: phandle
+    description: Handle to the display that the input events are raised for


### PR DESCRIPTION
During testing of https://github.com/zephyrproject-rtos/zephyr/pull/86815#discussion_r2002897824
I found that there is a piece missing in the simulator to test this: currently the input events are collected by all windows. Make it more consistent with "real" display where each display can have its own display touch input controller. This change is backwards compatible so it does not break downstream users.