### PR TITLE
boards: lpcxpresso55s36: fix declared memory region sizes

### DIFF
--- a/boards/nxp/lpcxpresso55s36/doc/index.rst
+++ b/boards/nxp/lpcxpresso55s36/doc/index.rst
@@ -14,7 +14,7 @@ Hardware
 ********
 
 - LPC55S36 Arm® Cortex®-M33 microcontroller running at up to 150 MHz
-- 256 KB flash and 96 KB SRAM on-chip
+- 256 KB flash and 112 KB SRAM on-chip
 - LPC-Link2 debug high speed USB probe with VCOM port
 - I2C and SPI USB bridging to the LPC device via LPC-Link2 probe
 - MikroElektronika Click expansion option

--- a/boards/nxp/lpcxpresso55s36/lpcxpresso55s36.yaml
+++ b/boards/nxp/lpcxpresso55s36/lpcxpresso55s36.yaml
@@ -8,8 +8,8 @@ identifier: lpcxpresso55s36
 name: NXP LPCXpresso55S36
 type: mcu
 arch: arm
-ram: 96
-flash: 256
+ram: 112
+flash: 246
 toolchain:
   - zephyr
   - gnuarmemb

--- a/dts/arm/nxp/nxp_lpc55S3x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S3x_common.dtsi
@@ -41,8 +41,9 @@
 	 * LPC55x36: RAMX: 16K, SRAM0: 16K, SRAM1: 16K, SRAM2: 32K, SRAM3: 32K, SRAM4: 16K
 	 */
 	sramx: memory@4000000 {
-		compatible = "mmio-sram";
+		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0x04000000 DT_SIZE_K(16)>;
+		zephyr,memory-region = "SRAMX";
 	};
 	sram0: memory@20000000 {
 		compatible = "mmio-sram";


### PR DESCRIPTION
- Fixes declared memory region sizes in .yaml and .rst.
- Adds SRAMX linker region.
- The lpcxpresso55s36 linker memory regions are: FLASH=246KB, RAM=112KB, SRAMX=16KB.