### PR TITLE
net: mdns_responder: Use memcpy instead of strncpy for iface name

### DIFF
--- a/subsys/net/lib/dns/mdns_responder.c
+++ b/subsys/net/lib/dns/mdns_responder.c
@@ -1368,7 +1368,8 @@ static int init_listener(void)
 				ifindex, ret);
 		} else {
 			memset(&if_req, 0, sizeof(if_req));
-			strncpy(if_req.ifr_name, name, sizeof(if_req.ifr_name) - 1);
+			memcpy(if_req.ifr_name, name,
+			       MIN(sizeof(name) - 1, sizeof(if_req.ifr_name) - 1));
 
 			ret = zsock_setsockopt(v6, SOL_SOCKET, SO_BINDTODEVICE,
 					       &if_req, sizeof(if_req));
@@ -1464,7 +1465,8 @@ static int init_listener(void)
 				ifindex, ret);
 		} else {
 			memset(&if_req, 0, sizeof(if_req));
-			strncpy(if_req.ifr_name, name, sizeof(if_req.ifr_name) - 1);
+			memcpy(if_req.ifr_name, name,
+			       MIN(sizeof(name) - 1, sizeof(if_req.ifr_name) - 1));
 
 			ret = zsock_setsockopt(v4, SOL_SOCKET, SO_BINDTODEVICE,
 					       &if_req, sizeof(if_req));


### PR DESCRIPTION
Following warning is printed if using strncpy(), so use memcpy() instead. Note that this is false positive as there is no error here but in order to avoid the warning, change the copy function.

subsys/net/lib/dns/mdns_responder.c:1371:25: warning: 'strncpy' output may be truncated copying 7 bytes from a string of length 8 [-Wstringop-truncation]
 1468 | strncpy(if_req.ifr_name, name, sizeof(if_req.ifr_name) - 1);
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

subsys/net/lib/dns/mdns_responder.c:1468:25: warning: 'strncpy' output may be truncated copying 7 bytes from a string of length 8 [-Wstringop-truncation]
 1468 | strncpy(if_req.ifr_name, name, sizeof(if_req.ifr_name) - 1);
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~