### PR TITLE
modules: mbedtls: Expose MBEDTLS_RSA_C

### DIFF
--- a/modules/mbedtls/Kconfig.mbedtls
+++ b/modules/mbedtls/Kconfig.mbedtls
@@ -44,6 +44,28 @@ menu "Ciphersuite configuration"
 
 comment "Supported key exchange modes"
 
+config MBEDTLS_RSA_C
+	bool "RSA base support"
+
+if MBEDTLS_RSA_C
+
+config MBEDTLS_PKCS1_V15
+	bool "RSA PKCS1 v1.5"
+
+config MBEDTLS_PKCS1_V21
+	bool "RSA PKCS1 v2.1"
+
+config MBEDTLS_GENPRIME_ENABLED
+	bool "Prime number generation code"
+
+endif # MBEDTLS_RSA_C
+
+config MBEDTLS_RSA_FULL
+	bool
+	select MBEDTLS_RSA_C
+	select MBEDTLS_PKCS1_V15
+	select MBEDTLS_PKCS1_V21
+
 config MBEDTLS_KEY_EXCHANGE_ALL_ENABLED
 	bool "All available ciphersuite modes"
 	select MBEDTLS_KEY_EXCHANGE_PSK_ENABLED
@@ -70,6 +92,7 @@ config MBEDTLS_KEY_EXCHANGE_ECDHE_PSK_ENABLED
 
 config MBEDTLS_KEY_EXCHANGE_RSA_PSK_ENABLED
 	bool "RSA-PSK based ciphersuite modes"
+	select MBEDTLS_RSA_FULL
 
 config MBEDTLS_PSK_MAX_LEN
 	int "Max size of TLS pre-shared keys"
@@ -82,6 +105,7 @@ config MBEDTLS_KEY_EXCHANGE_RSA_ENABLED
 	bool "RSA-only based ciphersuite modes"
 	default y if UOSCORE || UEDHOC
 	select MBEDTLS_MD
+	select MBEDTLS_RSA_FULL
 	select PSA_WANT_KEY_TYPE_RSA_PUBLIC_KEY if PSA_CRYPTO_CLIENT
 	select PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_IMPORT if PSA_CRYPTO_CLIENT
 	select PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_EXPORT if PSA_CRYPTO_CLIENT
@@ -89,9 +113,11 @@ config MBEDTLS_KEY_EXCHANGE_RSA_ENABLED
 
 config MBEDTLS_KEY_EXCHANGE_DHE_RSA_ENABLED
 	bool "DHE-RSA based ciphersuite modes"
+	select MBEDTLS_RSA_FULL
 
 config MBEDTLS_KEY_EXCHANGE_ECDHE_RSA_ENABLED
 	bool "ECDHE-RSA based ciphersuite modes"
+	select MBEDTLS_RSA_FULL
 	depends on MBEDTLS_ECDH_C
 
 config MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED
@@ -371,9 +397,6 @@ config MBEDTLS_CIPHER
 
 config MBEDTLS_MD
 	bool "generic message digest layer."
-
-config MBEDTLS_GENPRIME_ENABLED
-	bool "prime-number generation code."
 
 config MBEDTLS_ASN1_PARSE_C
 	bool "Support for ASN1 parser functions"

--- a/modules/mbedtls/configs/config-mbedtls.h
+++ b/modules/mbedtls/configs/config-mbedtls.h
@@ -368,20 +368,23 @@
 #define MBEDTLS_MD_C
 #endif
 
+#if defined(CONFIG_MBEDTLS_RSA_C)
+#define MBEDTLS_RSA_C
+#endif
+
+#if defined(CONFIG_MBEDTLS_PKCS1_V15)
+#define MBEDTLS_PKCS1_V15
+#endif
+
+#if defined(CONFIG_MBEDTLS_PKCS1_V15)
+#define MBEDTLS_PKCS1_V21
+#endif
+
 /* Automatic dependencies */
 
 #if defined(MBEDTLS_KEY_EXCHANGE_DHE_PSK_ENABLED) || \
     defined(MBEDTLS_KEY_EXCHANGE_DHE_RSA_ENABLED)
 #define MBEDTLS_DHM_C
-#endif
-
-#if defined(MBEDTLS_KEY_EXCHANGE_RSA_PSK_ENABLED) || \
-    defined(MBEDTLS_KEY_EXCHANGE_RSA_ENABLED) || \
-    defined(MBEDTLS_KEY_EXCHANGE_DHE_RSA_ENABLED) || \
-    defined(MBEDTLS_KEY_EXCHANGE_ECDHE_RSA_ENABLED)
-#define MBEDTLS_RSA_C
-#define MBEDTLS_PKCS1_V15
-#define MBEDTLS_PKCS1_V21
 #endif
 
 #if defined(MBEDTLS_KEY_EXCHANGE_RSA_PSK_ENABLED) || \


### PR DESCRIPTION
Allow enabling MBEDTLS_RSA_C without key exchange enabled. This allows to use RSA without enabling x509 support too.