### PR TITLE
doc: Renesas: adopt board-supported-hw directive

### DIFF
--- a/boards/renesas/da14695_dk_usb/doc/index.rst
+++ b/boards/renesas/da14695_dk_usb/doc/index.rst
@@ -1,4 +1,4 @@
-.. _da14695_dk_usb:
+.. zephyr:board:: da14695_dk_usb
 
 DA14695 Development Kit USB
 ###########################
@@ -26,29 +26,7 @@ the sleep clock is 32768 Hz. The frequency of the system clock is 32 MHz.
 Supported Features
 ==================
 
-The _da14695_dk_usb board configuration supports the following
-hardware features:
-
-+-----------+------------+----------------------+
-| Interface | Controller | Driver/Component     |
-+===========+============+======================+
-| FLASH     | on-chip    | flash                |
-+-----------+------------+----------------------+
-| GPIO      | on-chip    | gpio                 |
-+-----------+------------+----------------------+
-| MPU       | on-chip    | arch/arm             |
-+-----------+------------+----------------------+
-| NVIC      | on-chip    | arch/arm             |
-+-----------+------------+----------------------+
-| RTT       | Segger     | console              |
-+-----------+------------+----------------------+
-| UART      | on-chip    | serial               |
-+-----------+------------+----------------------+
-| SPI       | on-chip    | spi                  |
-+-----------+------------+----------------------+
-
-Other hardware features, including the Configurable MAC (CMAC) controller,
-are currently not supported by the port.
+.. zephyr:board-supported-hw::
 
 For more information about the DA14695 Development Kit see:
 

--- a/boards/renesas/da1469x_dk_pro/doc/index.rst
+++ b/boards/renesas/da1469x_dk_pro/doc/index.rst
@@ -1,4 +1,4 @@
-.. _da1469x_dk_pro:
+.. zephyr:board:: da1469x_dk_pro
 
 DA1469x Development Kit Pro
 ###########################
@@ -27,29 +27,7 @@ the sleep clock is 32768 Hz. The frequency of the system clock is 32 MHz.
 Supported Features
 ==================
 
-The _da1469x_dk_pro board configuration supports the following
-hardware features:
-
-+-----------+------------+----------------------+
-| Interface | Controller | Driver/Component     |
-+===========+============+======================+
-| FLASH     | on-chip    | flash                |
-+-----------+------------+----------------------+
-| GPIO      | on-chip    | gpio                 |
-+-----------+------------+----------------------+
-| MPU       | on-chip    | arch/arm             |
-+-----------+------------+----------------------+
-| NVIC      | on-chip    | arch/arm             |
-+-----------+------------+----------------------+
-| RTT       | Segger     | console              |
-+-----------+------------+----------------------+
-| UART      | on-chip    | serial               |
-+-----------+------------+----------------------+
-| SPI       | on-chip    | spi                  |
-+-----------+------------+----------------------+
-
-Other hardware features, including the Configurable MAC (CMAC) controller,
-are currently not supported by the port.
+.. zephyr:board-supported-hw::
 
 For more information about the DA14695 Development Kit see:
 


### PR DESCRIPTION
Replace the old manual supported features block with the awesome new directive.