### PR TITLE
boards: ezurio: Fix FEM name for BL654PA DVK

### DIFF
--- a/boards/ezurio/bl654_dvk/bl654_dvk_nrf52840_pa.dts
+++ b/boards/ezurio/bl654_dvk/bl654_dvk_nrf52840_pa.dts
@@ -9,7 +9,8 @@
 
 / {
 	/* Information from Nordic SDK-Based Application Development and SKY66112 datasheet */
-	sky66112_fem: fem {
+	nrf_radio_fem: fem {
+		status = "okay";
 		compatible = "generic-fem-two-ctrl-pins";
 		ctx-gpios = <&gpio1 2 GPIO_ACTIVE_HIGH>;
 		crx-gpios = <&gpio1 4 GPIO_ACTIVE_HIGH>;
@@ -21,5 +22,5 @@
 };
 
 &radio {
-	fem = <&sky66112_fem>;
+	fem = <&nrf_radio_fem>;
 };


### PR DESCRIPTION
For Kconfig auto-configuration of the FEM in the MPSL, the node in the device tree MUST be named "nrf_radio_fem".