### PR TITLE
bluetooth: mesh: check if subnet is valid before sending beacon

### DIFF
--- a/subsys/bluetooth/mesh/beacon.c
+++ b/subsys/bluetooth/mesh/beacon.c
@@ -471,6 +471,11 @@ static bool beacons_send_next(void)
 	struct bt_mesh_subnet *sub_first = bt_mesh_subnet_next(NULL);
 	struct bt_mesh_subnet *sub_next;
 
+	if (!sub_first) {
+		LOG_ERR("No network to send network beacon for!");
+		return false;
+	}
+
 	do {
 		sub_next = bt_mesh_subnet_next(beacon_send_sub_curr);
 		if (sub_next == sub_first && beacon_send_sub_curr != NULL) {


### PR DESCRIPTION
Check if the subnet exists before sending any subnet beacon on this subnet.

Due to this issue https://github.com/zephyrproject-rtos/zephyr/issues/87360 [bt_mesh_is_provisioned](https://github.com/zephyrproject-rtos/zephyr/blob/main/subsys/bluetooth/mesh/beacon.c#L496) return false true, and `beacons_send_next()` is called. To prevent erroneous network beacons check if the subnet is existing.