### PR TITLE
drivers: sensors: adxl367: fix clang compilation error

### DIFF
--- a/drivers/sensor/adi/adxl367/adxl367_decoder.c
+++ b/drivers/sensor/adi/adxl367/adxl367_decoder.c
@@ -75,7 +75,7 @@ static inline void adxl367_temp_convert_q31(q31_t *out, const uint8_t *buff,
 		}
 		break;
 
-	case ADXL367_14B_CHID:
+	case ADXL367_14B_CHID: {
 		uint16_t *tmp_buf = (uint16_t *)buff;
 
 		data_in = (int16_t)(((*tmp_buf >> 8) & 0xFF) | ((*tmp_buf << 8) & 0xFF00));
@@ -85,6 +85,7 @@ static inline void adxl367_temp_convert_q31(q31_t *out, const uint8_t *buff,
 			convert_value = 1;
 		}
 		break;
+	}
 
 	default:
 		break;
@@ -136,7 +137,7 @@ static inline void adxl367_accel_convert_q31(q31_t *out, const uint8_t *buff,
 		}
 		break;
 
-	case ADXL367_14B_CHID:
+	case ADXL367_14B_CHID: {
 		uint16_t *tmp_buf = (uint16_t *)buff;
 
 		data_in = (int16_t)(((*tmp_buf >> 8) & 0xFF) | ((*tmp_buf << 8) & 0xFF00));
@@ -146,6 +147,7 @@ static inline void adxl367_accel_convert_q31(q31_t *out, const uint8_t *buff,
 			convert_value = 1;
 		}
 		break;
+	}
 
 	default:
 		break;

--- a/drivers/sensor/adi/adxl367/adxl367_stream.c
+++ b/drivers/sensor/adi/adxl367/adxl367_stream.c
@@ -206,7 +206,7 @@ static void adxl367_process_fifo_samples_cb(struct rtio *r, const struct rtio_sq
 	case ADXL367_8B:
 		fifo_bytes = fifo_packet_cnt;
 		break;
-	case ADXL367_12B:
+	case ADXL367_12B: {
 		unsigned int fifo_bits = fifo_packet_cnt * sample_numb * 12;
 
 		if (fifo_bits % 8 == 0) {
@@ -235,7 +235,7 @@ static void adxl367_process_fifo_samples_cb(struct rtio *r, const struct rtio_sq
 			packet_size++;
 		}
 		break;
-
+	}
 	default:
 		fifo_bytes = fifo_packet_cnt * 2;
 		packet_size *= 2;


### PR DESCRIPTION
Added missing braces to case statements causing clang compilation errors