### PR TITLE
drivers: entropy: stm32: clear data available IRQ flag on WB09

### DIFF
--- a/drivers/entropy/entropy_stm32.h
+++ b/drivers/entropy/entropy_stm32.h
@@ -40,12 +40,11 @@ static inline void ll_rng_enable_it(RNG_TypeDef *RNGx)
 
 static inline uint32_t ll_rng_is_active_seis(RNG_TypeDef *RNGx)
 {
-#if defined(CONFIG_SOC_SERIES_STM32WB0X)
-#	if defined(CONFIG_SOC_STM32WB09XX)
-		return LL_RNG_IsActiveFlag_ENTROPY_ERR(RNGx);
-#	else
-		return LL_RNG_IsActiveFlag_FAULT(RNGx);
-#	endif
+#if defined(CONFIG_SOC_STM32WB09XX)
+	return LL_RNG_IsActiveFlag_ENTROPY_ERR(RNGx);
+#elif defined(CONFIG_SOC_SERIES_STM32WB0X)
+	/* STM32WB05 / STM32WB06 / STM32WB07 */
+	return LL_RNG_IsActiveFlag_FAULT(RNGx);
 #else
 	return LL_RNG_IsActiveFlag_SEIS(RNGx);
 #endif /* CONFIG_SOC_SERIES_STM32WB0X */
@@ -53,12 +52,11 @@ static inline uint32_t ll_rng_is_active_seis(RNG_TypeDef *RNGx)
 
 static inline void ll_rng_clear_seis(RNG_TypeDef *RNGx)
 {
-#if defined(CONFIG_SOC_SERIES_STM32WB0X)
-#	if defined(CONFIG_SOC_STM32WB09XX)
-		LL_RNG_SetResetHealthErrorFlags(RNGx, 1);
-#	else
-		LL_RNG_ClearFlag_FAULT(RNGx);
-#	endif
+#if defined(CONFIG_SOC_STM32WB09XX)
+	LL_RNG_SetResetHealthErrorFlags(RNGx, 1);
+#elif defined(CONFIG_SOC_SERIES_STM32WB0X)
+	/* STM32WB05 / STM32WB06 / STM32WB07 */
+	LL_RNG_ClearFlag_FAULT(RNGx);
 #else
 	LL_RNG_ClearFlag_SEIS(RNGx);
 #endif /* CONFIG_SOC_SERIES_STM32WB0X */
@@ -80,12 +78,11 @@ static inline uint32_t ll_rng_is_active_secs(RNG_TypeDef *RNGx)
 
 static inline uint32_t ll_rng_is_active_drdy(RNG_TypeDef *RNGx)
 {
-#if defined(CONFIG_SOC_SERIES_STM32WB0X)
-#	if defined(CONFIG_SOC_STM32WB09XX)
-		return LL_RNG_IsActiveFlag_VAL_READY(RNGx);
-#	else
-		return LL_RNG_IsActiveFlag_RNGRDY(RNGx);
-#	endif
+#if defined(CONFIG_SOC_STM32WB09XX)
+	return LL_RNG_IsActiveFlag_VAL_READY(RNGx);
+#elif defined(CONFIG_SOC_SERIES_STM32WB0X)
+	/* STM32WB05 / STM32WB06 / STM32WB07 */
+	return LL_RNG_IsActiveFlag_RNGRDY(RNGx);
 #else
 	return LL_RNG_IsActiveFlag_DRDY(RNGx);
 #endif /* CONFIG_SOC_SERIES_STM32WB0X */
@@ -93,12 +90,11 @@ static inline uint32_t ll_rng_is_active_drdy(RNG_TypeDef *RNGx)
 
 static inline uint16_t ll_rng_read_rand_data(RNG_TypeDef *RNGx)
 {
-#if defined(CONFIG_SOC_SERIES_STM32WB0X)
-#	if defined(CONFIG_SOC_STM32WB09XX)
-		return (uint16_t)LL_RNG_GetRndVal(RNGx);
-#	else
-		return LL_RNG_ReadRandData16(RNGx);
-#	endif
+#if defined(CONFIG_SOC_STM32WB09XX)
+	return (uint16_t)LL_RNG_GetRndVal(RNGx);
+#elif defined(CONFIG_SOC_SERIES_STM32WB0X)
+	/* STM32WB05 / STM32WB06 / STM32WB07 */
+	return LL_RNG_ReadRandData16(RNGx);
 #else
 	return (uint16_t)LL_RNG_ReadRandData32(RNGx);
 #endif /* CONFIG_SOC_SERIES_STM32WB0X */


### PR DESCRIPTION
The STM32WB09 TRNG does not clear `FIFO_FULL` IRQ flag in hardware once the FIFO is no longer full, a behavior which differs from all other series. This results in spurious IRQs, as the TRNG IRQ line effectively remains high forever once a single interrupt has been generated.

Clear the flag in software after reading from the FIFO on STM32WB09 SoC.

N.B.: the error IRQ flag is already handled properly, as this flag must also be cleared by software on other series.