### PR TITLE
video: drivers misc fixes

### DIFF
--- a/drivers/video/Kconfig.mcux_mipi_csi2rx
+++ b/drivers/video/Kconfig.mcux_mipi_csi2rx
@@ -8,3 +8,10 @@ config VIDEO_MCUX_MIPI_CSI2RX
 	default y
 	depends on DT_HAS_NXP_MIPI_CSI2RX_ENABLED
 	select VIDEO_MCUX_CSI
+
+config VIDEO_MCUX_MIPI_CSI2RX_INIT_PRIORITY
+	int "NXP MCUX CSI-2 Rx init priority"
+	default 61
+	depends on VIDEO_MCUX_MIPI_CSI2RX
+	help
+	  Initialization priority for the MIPI CSI-2 Rx device.

--- a/drivers/video/gc2145.c
+++ b/drivers/video/gc2145.c
@@ -1183,7 +1183,6 @@ static int gc2145_init(const struct device *dev)
 	fmt.pixelformat = VIDEO_PIX_FMT_RGB565;
 	fmt.width = RESOLUTION_QVGA_W;
 	fmt.height = RESOLUTION_QVGA_H;
-	fmt.pitch = RESOLUTION_QVGA_W * video_bits_per_pixel(fmt.pixelformat) / BITS_PER_BYTE;
 
 	ret = gc2145_set_fmt(dev, &fmt);
 	if (ret) {

--- a/drivers/video/gc2145.c
+++ b/drivers/video/gc2145.c
@@ -1183,7 +1183,7 @@ static int gc2145_init(const struct device *dev)
 	fmt.pixelformat = VIDEO_PIX_FMT_RGB565;
 	fmt.width = RESOLUTION_QVGA_W;
 	fmt.height = RESOLUTION_QVGA_H;
-	fmt.pitch = RESOLUTION_QVGA_W * 2;
+	fmt.pitch = RESOLUTION_QVGA_W * video_bits_per_pixel(fmt.pixelformat) / BITS_PER_BYTE;
 
 	ret = gc2145_set_fmt(dev, &fmt);
 	if (ret) {

--- a/drivers/video/mt9m114.c
+++ b/drivers/video/mt9m114.c
@@ -564,7 +564,7 @@ static int mt9m114_init(const struct device *dev)
 	fmt.pixelformat = VIDEO_PIX_FMT_RGB565;
 	fmt.width = 480;
 	fmt.height = 272;
-	fmt.pitch = fmt.width * 2;
+	fmt.pitch = fmt.width * video_bits_per_pixel(fmt.pixelformat) / BITS_PER_BYTE;
 
 	ret = mt9m114_set_fmt(dev, &fmt);
 	if (ret) {

--- a/drivers/video/mt9m114.c
+++ b/drivers/video/mt9m114.c
@@ -564,7 +564,6 @@ static int mt9m114_init(const struct device *dev)
 	fmt.pixelformat = VIDEO_PIX_FMT_RGB565;
 	fmt.width = 480;
 	fmt.height = 272;
-	fmt.pitch = fmt.width * video_bits_per_pixel(fmt.pixelformat) / BITS_PER_BYTE;
 
 	ret = mt9m114_set_fmt(dev, &fmt);
 	if (ret) {

--- a/drivers/video/mt9m114.c
+++ b/drivers/video/mt9m114.c
@@ -174,7 +174,7 @@ static struct mt9m114_reg mt9m114_1280_720[] = {
 	{MT9M114_CAM_STAT_AE_INITIAL_WINDOW_YEND, 2, 0x008F}, /* 143 */
 	{/* NULL terminated */}};
 
-static struct mt9m114_resolution_config resolutionConfigs[] = {
+static struct mt9m114_resolution_config resolution_configs[] = {
 	{.width = 480, .height = 272, .params = mt9m114_480_272},
 	{.width = 640, .height = 480, .params = mt9m114_640_480},
 	{.width = 1280, .height = 720, .params = mt9m114_1280_720},
@@ -432,10 +432,10 @@ static int mt9m114_set_fmt(const struct device *dev, struct video_format *fmt)
 	}
 
 	/* Set output resolution */
-	for (i = 0; i < ARRAY_SIZE(resolutionConfigs); i++) {
-		if (fmt->width == resolutionConfigs[i].width &&
-		    fmt->height == resolutionConfigs[i].height) {
-			ret = mt9m114_write_all(dev, resolutionConfigs[i].params);
+	for (i = 0; i < ARRAY_SIZE(resolution_configs); i++) {
+		if (fmt->width == resolution_configs[i].width &&
+		    fmt->height == resolution_configs[i].height) {
+			ret = mt9m114_write_all(dev, resolution_configs[i].params);
 			if (ret) {
 				LOG_ERR("Unable to set resolution");
 				return ret;

--- a/drivers/video/ov2640.c
+++ b/drivers/video/ov2640.c
@@ -1032,7 +1032,6 @@ static int ov2640_init(const struct device *dev)
 	fmt.pixelformat = VIDEO_PIX_FMT_RGB565;
 	fmt.width = SVGA_HSIZE;
 	fmt.height = SVGA_VSIZE;
-	fmt.pitch = SVGA_HSIZE * video_bits_per_pixel(fmt.pixelformat) / BITS_PER_BYTE;
 	ret = ov2640_set_fmt(dev, &fmt);
 	if (ret) {
 		LOG_ERR("Unable to configure default format");

--- a/drivers/video/ov2640.c
+++ b/drivers/video/ov2640.c
@@ -1032,7 +1032,7 @@ static int ov2640_init(const struct device *dev)
 	fmt.pixelformat = VIDEO_PIX_FMT_RGB565;
 	fmt.width = SVGA_HSIZE;
 	fmt.height = SVGA_VSIZE;
-	fmt.pitch = SVGA_HSIZE * 2;
+	fmt.pitch = SVGA_HSIZE * video_bits_per_pixel(fmt.pixelformat) / BITS_PER_BYTE;
 	ret = ov2640_set_fmt(dev, &fmt);
 	if (ret) {
 		LOG_ERR("Unable to configure default format");

--- a/drivers/video/ov5640.c
+++ b/drivers/video/ov5640.c
@@ -164,7 +164,6 @@ struct ov5640_ctrls {
 struct ov5640_data {
 	struct ov5640_ctrls ctrls;
 	struct video_format fmt;
-	uint64_t cur_pixrate;
 	uint16_t cur_frmrate;
 	const struct ov5640_mode_config *cur_mode;
 };
@@ -811,10 +810,9 @@ static int ov5640_set_frmival(const struct device *dev, struct video_frmival *fr
 	}
 
 	drv_data->cur_frmrate = best_match;
-	drv_data->cur_pixrate = drv_data->cur_mode->mipi_frmrate_config[ind].pixelrate;
 
 	/* Update pixerate control */
-	drv_data->ctrls.pixel_rate.val = drv_data->cur_pixrate;
+	drv_data->ctrls.pixel_rate.val64 = drv_data->cur_mode->mipi_frmrate_config[ind].pixelrate;
 
 	frmival->numerator = 1;
 	frmival->denominator = best_match;

--- a/drivers/video/ov5640.c
+++ b/drivers/video/ov5640.c
@@ -1021,15 +1021,18 @@ static int ov5640_set_ctrl_brightness(const struct device *dev, int value)
 {
 	const struct ov5640_config *cfg = dev->config;
 
-	struct ov5640_reg brightness_params[] = {{SDE_CTRL8_REG, value >= 0 ? 0x01 : 0x09},
-						 {SDE_CTRL7_REG, abs(value) & 0xff}};
 	int ret = ov5640_modify_reg(&cfg->i2c, SDE_CTRL0_REG, BIT(2), BIT(2));
 
 	if (ret) {
 		return ret;
 	}
 
-	return ov5640_write_multi_regs(&cfg->i2c, brightness_params, ARRAY_SIZE(brightness_params));
+	ret = ov5640_modify_reg(&cfg->i2c, SDE_CTRL8_REG, BIT(3), value >= 0 ? 0 : BIT(3));
+	if (ret < 0) {
+		return ret;
+	}
+
+	return ov5640_write_reg(&cfg->i2c, SDE_CTRL7_REG, (abs(value) << 4) & 0xf0);
 }
 
 static int ov5640_set_ctrl_contrast(const struct device *dev, int value)

--- a/drivers/video/ov5640.c
+++ b/drivers/video/ov5640.c
@@ -992,9 +992,13 @@ static int ov5640_set_ctrl_hue(const struct device *dev, int value)
 		sign = 0x02;
 	}
 
-	struct ov5640_reg hue_params[] = {{SDE_CTRL8_REG, sign},
-					  {SDE_CTRL1_REG, abs(cos_coef)},
-					  {SDE_CTRL2_REG, abs(sin_coef)}};
+	struct ov5640_reg hue_params[] = {{SDE_CTRL1_REG, abs(cos_coef) & 0xFF},
+					  {SDE_CTRL2_REG, abs(sin_coef) & 0xFF}};
+
+	ret = ov5640_modify_reg(&cfg->i2c, SDE_CTRL8_REG, 0x7F, sign);
+	if (ret < 0) {
+		return ret;
+	}
 
 	return ov5640_write_multi_regs(&cfg->i2c, hue_params, ARRAY_SIZE(hue_params));
 }

--- a/drivers/video/ov5640.c
+++ b/drivers/video/ov5640.c
@@ -1433,7 +1433,6 @@ static int ov5640_init(const struct device *dev)
 		fmt.width = 1280;
 		fmt.height = 720;
 	}
-	fmt.pitch = fmt.width * video_bits_per_pixel(fmt.pixelformat) / BITS_PER_BYTE;
 	ret = ov5640_set_fmt(dev, &fmt);
 	if (ret) {
 		LOG_ERR("Unable to configure default format");

--- a/drivers/video/ov5640.c
+++ b/drivers/video/ov5640.c
@@ -1045,6 +1045,11 @@ static int ov5640_set_ctrl_contrast(const struct device *dev, int value)
 		return ret;
 	}
 
+	ret = ov5640_modify_reg(&cfg->i2c, SDE_CTRL6_REG, BIT(2), value >= 0 ? 0 : BIT(2));
+	if (ret < 0) {
+		return ret;
+	}
+
 	return ov5640_write_reg(&cfg->i2c, SDE_CTRL6_REG, value & 0xff);
 }
 

--- a/drivers/video/ov5640.c
+++ b/drivers/video/ov5640.c
@@ -1433,7 +1433,7 @@ static int ov5640_init(const struct device *dev)
 		fmt.width = 1280;
 		fmt.height = 720;
 	}
-	fmt.pitch = fmt.width * 2;
+	fmt.pitch = fmt.width * video_bits_per_pixel(fmt.pixelformat) / BITS_PER_BYTE;
 	ret = ov5640_set_fmt(dev, &fmt);
 	if (ret) {
 		LOG_ERR("Unable to configure default format");

--- a/drivers/video/ov7670.c
+++ b/drivers/video/ov7670.c
@@ -554,7 +554,7 @@ static int ov7670_init(const struct device *dev)
 	fmt.pixelformat = VIDEO_PIX_FMT_YUYV;
 	fmt.width = 640;
 	fmt.height = 480;
-	fmt.pitch = fmt.width * 2;
+	fmt.pitch = fmt.width * video_bits_per_pixel(fmt.pixelformat) / BITS_PER_BYTE;
 	ret = ov7670_set_fmt(dev, &fmt);
 	if (ret < 0) {
 		return ret;

--- a/drivers/video/ov7670.c
+++ b/drivers/video/ov7670.c
@@ -554,7 +554,6 @@ static int ov7670_init(const struct device *dev)
 	fmt.pixelformat = VIDEO_PIX_FMT_YUYV;
 	fmt.width = 640;
 	fmt.height = 480;
-	fmt.pitch = fmt.width * video_bits_per_pixel(fmt.pixelformat) / BITS_PER_BYTE;
 	ret = ov7670_set_fmt(dev, &fmt);
 	if (ret < 0) {
 		return ret;

--- a/drivers/video/ov7725.c
+++ b/drivers/video/ov7725.c
@@ -592,7 +592,6 @@ static int ov7725_init(const struct device *dev)
 	fmt.pixelformat = VIDEO_PIX_FMT_RGB565;
 	fmt.width = 640;
 	fmt.height = 480;
-	fmt.pitch = fmt.width * video_bits_per_pixel(fmt.pixelformat) / BITS_PER_BYTE;
 	ret = ov7725_set_fmt(dev, &fmt);
 	if (ret) {
 		LOG_ERR("Unable to configure default format");

--- a/drivers/video/ov7725.c
+++ b/drivers/video/ov7725.c
@@ -592,7 +592,7 @@ static int ov7725_init(const struct device *dev)
 	fmt.pixelformat = VIDEO_PIX_FMT_RGB565;
 	fmt.width = 640;
 	fmt.height = 480;
-	fmt.pitch = 640 * 2;
+	fmt.pitch = fmt.width * video_bits_per_pixel(fmt.pixelformat) / BITS_PER_BYTE;
 	ret = ov7725_set_fmt(dev, &fmt);
 	if (ret) {
 		LOG_ERR("Unable to configure default format");

--- a/drivers/video/video_emul_imager.c
+++ b/drivers/video/video_emul_imager.c
@@ -368,7 +368,7 @@ int emul_imager_init(const struct device *dev)
 	fmt.pixelformat = fmts[0].pixelformat;
 	fmt.width = fmts[0].width_min;
 	fmt.height = fmts[0].height_min;
-	fmt.pitch = fmt.width * 2;
+	fmt.pitch = fmt.width * video_bits_per_pixel(fmt.pixelformat) / BITS_PER_BYTE;
 
 	ret = emul_imager_set_fmt(dev, &fmt);
 	if (ret < 0) {

--- a/drivers/video/video_emul_imager.c
+++ b/drivers/video/video_emul_imager.c
@@ -368,7 +368,6 @@ int emul_imager_init(const struct device *dev)
 	fmt.pixelformat = fmts[0].pixelformat;
 	fmt.width = fmts[0].width_min;
 	fmt.height = fmts[0].height_min;
-	fmt.pitch = fmt.width * video_bits_per_pixel(fmt.pixelformat) / BITS_PER_BYTE;
 
 	ret = emul_imager_set_fmt(dev, &fmt);
 	if (ret < 0) {

--- a/drivers/video/video_emul_rx.c
+++ b/drivers/video/video_emul_rx.c
@@ -67,7 +67,9 @@ static int emul_rx_set_fmt(const struct device *const dev, struct video_format *
 	}
 
 	/* Cache the format selected locally to use it for getting the size of the buffer  */
+	fmt->pitch = fmt->width * video_bits_per_pixel(fmt->pixelformat) / BITS_PER_BYTE;
 	data->fmt = *fmt;
+
 	return 0;
 }
 
@@ -215,6 +217,9 @@ int emul_rx_init(const struct device *dev)
 	if (ret < 0) {
 		return ret;
 	}
+
+	data->fmt.pitch =
+		data->fmt.width * video_bits_per_pixel(data->fmt.pixelformat) / BITS_PER_BYTE;
 
 	k_fifo_init(&data->fifo_in);
 	k_fifo_init(&data->fifo_out);

--- a/drivers/video/video_esp32_dvp.c
+++ b/drivers/video/video_esp32_dvp.c
@@ -269,6 +269,8 @@ static int video_esp32_get_fmt(const struct device *dev, struct video_format *fm
 		return ret;
 	}
 
+	fmt->pitch = fmt->width * video_bits_per_pixel(fmt->pixelformat) / BITS_PER_BYTE;
+
 	return 0;
 }
 
@@ -276,14 +278,22 @@ static int video_esp32_set_fmt(const struct device *dev, struct video_format *fm
 {
 	const struct video_esp32_config *cfg = dev->config;
 	struct video_esp32_data *data = dev->data;
+	int ret;
 
 	if (fmt == NULL) {
 		return -EINVAL;
 	}
 
+	ret = video_set_format(cfg->source_dev, fmt);
+	if (ret < 0) {
+		return ret;
+	}
+
+	fmt->pitch = fmt->width * video_bits_per_pixel(fmt->pixelformat) / BITS_PER_BYTE;
+
 	data->video_format = *fmt;
 
-	return video_set_format(cfg->source_dev, fmt);
+	return 0;
 }
 
 static int video_esp32_enqueue(const struct device *dev, struct video_buffer *vbuf)

--- a/drivers/video/video_mcux_csi.c
+++ b/drivers/video/video_mcux_csi.c
@@ -133,16 +133,11 @@ static int video_mcux_csi_set_fmt(const struct device *dev, struct video_format 
 {
 	const struct video_mcux_csi_config *config = dev->config;
 	struct video_mcux_csi_data *data = dev->data;
-	unsigned int bpp = video_bits_per_pixel(fmt->pixelformat) / BITS_PER_BYTE;
 	status_t ret;
 	struct video_format format = *fmt;
 
-	if (bpp == 0) {
-		return -EINVAL;
-	}
-
-	data->csi_config.bytesPerPixel = bpp;
-	data->csi_config.linePitch_Bytes = fmt->pitch;
+	data->csi_config.bytesPerPixel = video_bits_per_pixel(fmt->pixelformat) / BITS_PER_BYTE;
+	data->csi_config.linePitch_Bytes = fmt->width * data->csi_config.bytesPerPixel;
 #if defined(CONFIG_VIDEO_MCUX_MIPI_CSI2RX)
 	if (fmt->pixelformat != VIDEO_PIX_FMT_XRGB32 && fmt->pixelformat != VIDEO_PIX_FMT_XYUV32) {
 		return -ENOTSUP;
@@ -171,6 +166,8 @@ static int video_mcux_csi_set_fmt(const struct device *dev, struct video_format 
 	if (config->source_dev && video_set_format(config->source_dev, &format)) {
 		return -EIO;
 	}
+
+	fmt->pitch = data->csi_config.linePitch_Bytes;
 
 	return 0;
 }

--- a/drivers/video/video_mcux_csi.c
+++ b/drivers/video/video_mcux_csi.c
@@ -184,8 +184,8 @@ static int video_mcux_csi_get_fmt(const struct device *dev, struct video_format 
 #if defined(CONFIG_VIDEO_MCUX_MIPI_CSI2RX)
 		video_pix_fmt_convert(fmt, true);
 #endif
-		/* align CSI with source fmt */
-		return video_mcux_csi_set_fmt(dev, fmt);
+
+		return 0;
 	}
 
 	return -EIO;

--- a/drivers/video/video_mcux_mipi_csi2rx.c
+++ b/drivers/video/video_mcux_mipi_csi2rx.c
@@ -327,7 +327,8 @@ static int mipi_csi2rx_init(const struct device *dev)
 	};                                                                                         \
                                                                                                    \
 	DEVICE_DT_INST_DEFINE(n, &mipi_csi2rx_init, NULL, &mipi_csi2rx_data_##n,                   \
-			      &mipi_csi2rx_config_##n, POST_KERNEL, CONFIG_VIDEO_INIT_PRIORITY,    \
+			      &mipi_csi2rx_config_##n, POST_KERNEL,                                \
+			      CONFIG_VIDEO_MCUX_MIPI_CSI2RX_INIT_PRIORITY,                         \
 			      &mipi_csi2rx_driver_api);                                            \
                                                                                                    \
 	VIDEO_DEVICE_DEFINE(mipi_csi2rx_##n, DEVICE_DT_INST_GET(n), SOURCE_DEV(n));

--- a/drivers/video/video_mcux_smartdma.c
+++ b/drivers/video/video_mcux_smartdma.c
@@ -275,16 +275,7 @@ static int nxp_video_sdma_get_format(const struct device *dev, struct video_form
 	if ((fmt->pixelformat != fmts[0].pixelformat) ||
 	    (fmt->width != fmts[0].width_min) ||
 	    (fmt->height != fmts[0].height_min)) {
-		/* Update format of sensor */
-		fmt->pixelformat = fmts[0].pixelformat;
-		fmt->width = fmts[0].width_min;
-		fmt->height = fmts[0].height_min;
-		fmt->pitch = fmts[0].width_min * 2;
-		ret = video_set_format(config->sensor_dev, fmt);
-		if (ret < 0) {
-			LOG_ERR("Sensor device does not support RGB565");
-			return ret;
-		}
+		return -ENOTSUP;
 	}
 
 	fmt->pitch = fmt->width * video_bits_per_pixel(fmt->pixelformat) / BITS_PER_BYTE;

--- a/drivers/video/video_stm32_dcmi.c
+++ b/drivers/video/video_stm32_dcmi.c
@@ -197,6 +197,8 @@ static int video_stm32_dcmi_set_fmt(const struct device *dev, struct video_forma
 		return ret;
 	}
 
+	fmt->pitch = fmt->width * video_bits_per_pixel(fmt->pixelformat) / BITS_PER_BYTE;
+
 	data->fmt = *fmt;
 
 	return 0;
@@ -217,6 +219,8 @@ static int video_stm32_dcmi_get_fmt(const struct device *dev, struct video_forma
 	if (ret < 0) {
 		return ret;
 	}
+
+	fmt->pitch = fmt->width * video_bits_per_pixel(fmt->pixelformat) / BITS_PER_BYTE;
 
 	data->fmt = *fmt;
 

--- a/drivers/video/video_stm32_dcmi.c
+++ b/drivers/video/video_stm32_dcmi.c
@@ -186,27 +186,11 @@ static int stm32_dcmi_enable_clock(const struct device *dev)
 	return clock_control_on(dcmi_clock, (clock_control_subsys_t *)&config->pclken);
 }
 
-static inline int video_stm32_dcmi_is_fmt_valid(uint32_t pixelformat, uint32_t pitch,
-						uint32_t height)
-{
-	if (video_bits_per_pixel(pixelformat) / BITS_PER_BYTE == 0 ||
-	    pitch * height > CONFIG_VIDEO_BUFFER_POOL_SZ_MAX) {
-		return -EINVAL;
-	}
-
-	return 0;
-}
-
 static int video_stm32_dcmi_set_fmt(const struct device *dev, struct video_format *fmt)
 {
 	const struct video_stm32_dcmi_config *config = dev->config;
 	struct video_stm32_dcmi_data *data = dev->data;
 	int ret;
-
-	ret = video_stm32_dcmi_is_fmt_valid(fmt->pixelformat, fmt->pitch, fmt->height);
-	if (ret < 0) {
-		return ret;
-	}
 
 	ret = video_set_format(config->sensor_dev, fmt);
 	if (ret < 0) {
@@ -230,11 +214,6 @@ static int video_stm32_dcmi_get_fmt(const struct device *dev, struct video_forma
 
 	/* Align DCMI format with the one provided by the sensor */
 	ret = video_get_format(config->sensor_dev, fmt);
-	if (ret < 0) {
-		return ret;
-	}
-
-	ret = video_stm32_dcmi_is_fmt_valid(fmt->pixelformat, fmt->pitch, fmt->height);
 	if (ret < 0) {
 		return ret;
 	}
@@ -341,12 +320,6 @@ static int video_stm32_dcmi_enum_frmival(const struct device *dev, struct video_
 {
 	const struct video_stm32_dcmi_config *config = dev->config;
 	int ret;
-
-	ret = video_stm32_dcmi_is_fmt_valid(fie->format->pixelformat, fie->format->pitch,
-					    fie->format->height);
-	if (ret < 0) {
-		return ret;
-	}
 
 	ret = video_enum_frmival(config->sensor_dev, fie);
 	if (ret < 0) {

--- a/drivers/video/video_sw_generator.c
+++ b/drivers/video/video_sw_generator.c
@@ -81,6 +81,8 @@ static int video_sw_generator_set_fmt(const struct device *dev, struct video_for
 		return -ENOTSUP;
 	}
 
+	fmt->pitch = fmt->width * video_bits_per_pixel(fmt->pixelformat) / BITS_PER_BYTE;
+
 	data->fmt = *fmt;
 
 	return 0;

--- a/samples/drivers/video/capture/src/main.c
+++ b/samples/drivers/video/capture/src/main.c
@@ -150,7 +150,6 @@ int main(void)
 
 #if CONFIG_VIDEO_FRAME_WIDTH
 	fmt.width = CONFIG_VIDEO_FRAME_WIDTH;
-	fmt.pitch = fmt.width * video_bits_per_pixel(fmt.pixelformat) / BITS_PER_BYTE;
 #endif
 
 	if (strcmp(CONFIG_VIDEO_PIXEL_FORMAT, "")) {

--- a/samples/drivers/video/capture/src/main.c
+++ b/samples/drivers/video/capture/src/main.c
@@ -150,7 +150,7 @@ int main(void)
 
 #if CONFIG_VIDEO_FRAME_WIDTH
 	fmt.width = CONFIG_VIDEO_FRAME_WIDTH;
-	fmt.pitch = fmt.width * 2;
+	fmt.pitch = fmt.width * video_bits_per_pixel(fmt.pixelformat) / BITS_PER_BYTE;
 #endif
 
 	if (strcmp(CONFIG_VIDEO_PIXEL_FORMAT, "")) {

--- a/samples/drivers/video/capture_to_lvgl/src/main.c
+++ b/samples/drivers/video/capture_to_lvgl/src/main.c
@@ -79,7 +79,7 @@ int main(void)
 	/* Set format */
 	fmt.width = CONFIG_VIDEO_WIDTH;
 	fmt.height = CONFIG_VIDEO_HEIGHT;
-	fmt.pitch = fmt.width * 2;
+	fmt.pitch = fmt.width * video_bits_per_pixel(fmt.pixelformat) / BITS_PER_BYTE;
 	fmt.pixelformat = VIDEO_PIX_FMT_RGB565;
 
 	if (video_set_format(video_dev, &fmt)) {

--- a/samples/drivers/video/capture_to_lvgl/src/main.c
+++ b/samples/drivers/video/capture_to_lvgl/src/main.c
@@ -79,7 +79,6 @@ int main(void)
 	/* Set format */
 	fmt.width = CONFIG_VIDEO_WIDTH;
 	fmt.height = CONFIG_VIDEO_HEIGHT;
-	fmt.pitch = fmt.width * video_bits_per_pixel(fmt.pixelformat) / BITS_PER_BYTE;
 	fmt.pixelformat = VIDEO_PIX_FMT_RGB565;
 
 	if (video_set_format(video_dev, &fmt)) {

--- a/tests/drivers/video/api/src/video_common.c
+++ b/tests/drivers/video/api/src/video_common.c
@@ -36,40 +36,34 @@ ZTEST(video_common, test_video_format_caps_index)
 
 	fmt.width = 100;
 	fmt.height = 100;
-	fmt.pitch = 100 * 2;
 	ret = video_format_caps_index(fmts, &fmt, &idx);
 	zassert_ok(ret, "expecting minimum value to match");
 	zassert_equal(idx, YUYV_A);
 
 	fmt.width = 1000;
 	fmt.height = 1000;
-	fmt.pitch = 1000 * 2;
 	ret = video_format_caps_index(fmts, &fmt, &idx);
 	zassert_ok(ret, "expecting maximum value to match");
 	zassert_equal(idx, YUYV_A);
 
 	fmt.width = 1920;
 	fmt.height = 1080;
-	fmt.pitch = 1920 * 2;
 	ret = video_format_caps_index(fmts, &fmt, &idx);
 	zassert_ok(ret, "expecting exact match to work");
 	zassert_equal(idx, YUYV_B);
 
 	fmt.width = 1001;
 	fmt.height = 1000;
-	fmt.pitch = 1001 * 2;
 	ret = video_format_caps_index(fmts, &fmt, &idx);
 	zassert_not_ok(ret, "expecting 1 above maximum width to mismatch");
 
 	fmt.width = 1000;
 	fmt.height = 1001;
-	fmt.pitch = 1000 * 2;
 	ret = video_format_caps_index(fmts, &fmt, &idx);
 	zassert_not_ok(ret, "expecting 1 above maximum height to mismatch");
 
 	fmt.width = 1280;
 	fmt.height = 720;
-	fmt.pitch = 1280 * 2;
 	ret = video_format_caps_index(fmts, &fmt, &idx);
 	zassert_not_ok(ret);
 	zassert_not_ok(ret, "expecting wrong format to mismatch");
@@ -78,13 +72,11 @@ ZTEST(video_common, test_video_format_caps_index)
 
 	fmt.width = 1000;
 	fmt.height = 1000;
-	fmt.pitch = 1000 * 2;
 	ret = video_format_caps_index(fmts, &fmt, &idx);
 	zassert_not_ok(ret, "expecting wrong format to mismatch");
 
 	fmt.width = 1280;
 	fmt.height = 720;
-	fmt.pitch = 1280 * 2;
 	ret = video_format_caps_index(fmts, &fmt, &idx);
 	zassert_ok(ret, "expecting exact match to work");
 	zassert_equal(idx, RGB565);

--- a/tests/drivers/video/api/src/video_emul.c
+++ b/tests/drivers/video/api/src/video_emul.c
@@ -158,7 +158,6 @@ ZTEST(video_common, test_video_vbuf)
 	fmt.pixelformat = caps.format_caps[0].pixelformat;
 	fmt.width = caps.format_caps[0].width_max;
 	fmt.height = caps.format_caps[0].height_max;
-	fmt.pitch = fmt.width * video_bits_per_pixel(fmt.pixelformat) / BITS_PER_BYTE;
 	fmt.type = type;
 	zexpect_ok(video_set_format(rx_dev, &fmt));
 

--- a/tests/drivers/video/api/src/video_emul.c
+++ b/tests/drivers/video/api/src/video_emul.c
@@ -158,7 +158,7 @@ ZTEST(video_common, test_video_vbuf)
 	fmt.pixelformat = caps.format_caps[0].pixelformat;
 	fmt.width = caps.format_caps[0].width_max;
 	fmt.height = caps.format_caps[0].height_max;
-	fmt.pitch = fmt.width * 2;
+	fmt.pitch = fmt.width * video_bits_per_pixel(fmt.pixelformat) / BITS_PER_BYTE;
 	fmt.type = type;
 	zexpect_ok(video_set_format(rx_dev, &fmt));
 


### PR DESCRIPTION
- Some misc fixes in individual video drivers
- Moving the format pitch (bytesperline) which relating to image size from application into bridge drivers. The reason for that is the bridge (e.g., DMA, ISP) drivers actually handle the memory and know exactly the memory layout constraints (need alignment, padding, etc. or not). Application does not know this, it justs set the desired pixel format and resolution and must always read back this field to see what the driver actually sets. Also, drop format pitch setting in sensor drivers as this is not needed (and the sensor does not know this information neither). Some examples:

https://elixir.bootlin.com/linux/v6.11.1/source/drivers/media/platform/qcom/venus/vdec.c#L231
https://elixir.bootlin.com/linux/v6.11.1/source/drivers/media/platform/ti/omap3isp/ispvideo.c#L143
https://elixir.bootlin.com/linux/v6.11.1/source/drivers/staging/media/sunxi/sun6i-isp/sun6i_isp_capture.c#L404

- Decoupling get / set_fmt() in some bridge drivers
