### PR TITLE
Bluetooth: Host: Typecast logged pointers to (void *)

### DIFF
--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -247,7 +247,7 @@ static void att_tx_destroy(struct net_buf *buf)
 	struct bt_att_tx_meta_data *p_meta = bt_att_get_tx_meta_data(buf);
 	struct bt_att_tx_meta_data meta;
 
-	LOG_DBG("%p", buf);
+	LOG_DBG("%p", (void *)buf);
 
 	/* Destroy the buffer first, as the callback may attempt to allocate a
 	 * new one for another operation.
@@ -328,7 +328,7 @@ static void att_sent(void *user_data)
 
 	__ASSERT_NO_MSG(!bt_att_is_enhanced(att_chan));
 
-	LOG_DBG("conn %p chan %p", conn, chan);
+	LOG_DBG("conn %p chan %p", (void *)conn, (void *)chan);
 
 	/* For EATT, `bt_att_sent` is assigned to the `.sent` L2 callback.
 	 * L2CAP will then call it once the SDU has finished sending.
@@ -558,7 +558,7 @@ static int chan_req_send(struct bt_att_chan *chan, struct bt_att_req *req)
 		return -EMSGSIZE;
 	}
 
-	LOG_DBG("chan %p req %p len %zu", chan, req, net_buf_frags_len(req->buf));
+	LOG_DBG("chan %p req %p len %zu", (void *)chan, req, net_buf_frags_len(req->buf));
 
 	chan->req = req;
 
@@ -589,7 +589,7 @@ static void bt_att_sent(struct bt_l2cap_chan *ch)
 	struct bt_att *att = chan->att;
 	int err;
 
-	LOG_DBG("chan %p", chan);
+	LOG_DBG("chan %p", (void *)chan);
 
 	atomic_clear_bit(chan->flags, ATT_PENDING_SENT);
 
@@ -629,7 +629,7 @@ static void chan_rebegin_att_timeout(struct bt_att_tx_meta_data *user_data)
 	struct bt_att_tx_meta_data *data = user_data;
 	struct bt_att_chan *chan = data->att_chan;
 
-	LOG_DBG("chan %p chan->req %p", chan, chan->req);
+	LOG_DBG("chan %p chan->req %p", (void *)chan, chan->req);
 
 	if (!atomic_test_bit(chan->flags, ATT_CONNECTED)) {
 		LOG_ERR("ATT channel not connected");
@@ -653,7 +653,7 @@ static void chan_req_notif_sent(struct bt_att_tx_meta_data *user_data)
 	uint16_t attr_count = data->attr_count;
 	void *ud = data->user_data;
 
-	LOG_DBG("chan %p CID 0x%04X", chan, chan->chan.tx.cid);
+	LOG_DBG("chan %p CID 0x%04X", (void *)chan, chan->chan.tx.cid);
 
 	if (!atomic_test_bit(chan->flags, ATT_CONNECTED)) {
 		LOG_ERR("ATT channel not connected");
@@ -770,7 +770,7 @@ static struct net_buf *bt_att_chan_create_pdu(struct bt_att_chan *chan, uint8_t 
 
 static int bt_att_chan_send(struct bt_att_chan *chan, struct net_buf *buf)
 {
-	LOG_DBG("chan %p flags %lu code 0x%02x", chan, atomic_get(chan->flags),
+	LOG_DBG("chan %p flags %lu code 0x%02x", (void *)chan, atomic_get(chan->flags),
 		((struct bt_att_hdr *)buf->data)->code);
 
 	if (IS_ENABLED(CONFIG_BT_EATT) &&
@@ -911,7 +911,7 @@ static int bt_att_chan_req_send(struct bt_att_chan *chan,
 	__ASSERT_NO_MSG(req->func);
 	__ASSERT_NO_MSG(!chan->req);
 
-	LOG_DBG("req %p", req);
+	LOG_DBG("req %p", (void *)req);
 
 	return chan_req_send(chan, req);
 }
@@ -958,7 +958,7 @@ static uint8_t att_handle_rsp(struct bt_att_chan *chan, void *pdu, uint16_t len,
 	bt_att_func_t func = NULL;
 	void *params;
 
-	LOG_DBG("chan %p err %d len %u: %s", chan, err, len, bt_hex(pdu, len));
+	LOG_DBG("chan %p err %d len %u: %s", (void *)chan, err, len, bt_hex(pdu, len));
 
 	/* Cancel timeout if ongoing */
 	k_work_cancel_delayable(&chan->timeout_work);
@@ -2282,7 +2282,7 @@ static uint8_t att_prep_write_rsp(struct bt_att_chan *chan, uint16_t handle,
 		return 0;
 	}
 
-	LOG_DBG("buf %p handle 0x%04x offset %u", data.buf, handle, offset);
+	LOG_DBG("buf %p handle 0x%04x offset %u", (void *)data.buf, handle, offset);
 
 	/* Store buffer in the outstanding queue */
 	net_buf_slist_put(&chan->att->prep_queue, data.buf);
@@ -2336,7 +2336,7 @@ static uint8_t exec_write_reassemble(uint16_t handle, uint16_t offset,
 	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(list, entry, next, node) {
 		struct bt_attr_data *tmp_data = net_buf_user_data(entry);
 
-		LOG_DBG("entry %p handle 0x%04x, offset %u", entry, tmp_data->handle,
+		LOG_DBG("entry %p handle 0x%04x, offset %u", (void *)entry, tmp_data->handle,
 			tmp_data->offset);
 
 		if (tmp_data->handle == handle) {
@@ -2400,7 +2400,7 @@ static uint8_t att_exec_write_rsp(struct bt_att_chan *chan, uint8_t flags)
 		data = net_buf_user_data(buf);
 		handle = data->handle;
 
-		LOG_DBG("buf %p handle 0x%04x offset %u", buf, handle, data->offset);
+		LOG_DBG("buf %p handle 0x%04x offset %u", (void *)buf, handle, data->offset);
 
 		net_buf_simple_reset(&reassembled_data);
 		net_buf_simple_add_mem(&reassembled_data, buf->data, buf->len);
@@ -2724,7 +2724,7 @@ static uint8_t att_notify(struct bt_att_chan *chan, struct net_buf *buf)
 
 	handle = net_buf_pull_le16(buf);
 
-	LOG_DBG("chan %p handle 0x%04x", chan, handle);
+	LOG_DBG("chan %p handle 0x%04x", (void *)chan, handle);
 
 	bt_gatt_notification(chan->att->conn, handle, buf->data, buf->len);
 
@@ -2737,7 +2737,7 @@ static uint8_t att_indicate(struct bt_att_chan *chan, struct net_buf *buf)
 
 	handle = net_buf_pull_le16(buf);
 
-	LOG_DBG("chan %p handle 0x%04x", chan, handle);
+	LOG_DBG("chan %p handle 0x%04x", (void *)chan, handle);
 
 	bt_gatt_notification(chan->att->conn, handle, buf->data, buf->len);
 
@@ -2753,7 +2753,7 @@ static uint8_t att_indicate(struct bt_att_chan *chan, struct net_buf *buf)
 
 static uint8_t att_notify_mult(struct bt_att_chan *chan, struct net_buf *buf)
 {
-	LOG_DBG("chan %p", chan);
+	LOG_DBG("chan %p", (void *)chan);
 
 	bt_gatt_mult_notification(chan->att->conn, buf->data, buf->len);
 
@@ -2982,11 +2982,11 @@ static int bt_att_recv(struct bt_l2cap_chan *chan, struct net_buf *buf)
 	}
 
 	hdr = net_buf_pull_mem(buf, sizeof(*hdr));
-	LOG_DBG("Received ATT chan %p code 0x%02x len %zu", att_chan, hdr->code,
+	LOG_DBG("Received ATT chan %p code 0x%02x len %zu", (void *)att_chan, hdr->code,
 		net_buf_frags_len(buf));
 
 	if (conn->state != BT_CONN_CONNECTED) {
-		LOG_DBG("not connected: conn %p state %u", conn, conn->state);
+		LOG_DBG("not connected: conn %p state %u", (void *)conn, conn->state);
 		return 0;
 	}
 
@@ -3153,7 +3153,7 @@ static void att_chan_detach(struct bt_att_chan *chan)
 {
 	struct net_buf *buf;
 
-	LOG_DBG("chan %p", chan);
+	LOG_DBG("chan %p", (void *)chan);
 
 	sys_slist_find_and_remove(&chan->att->chans, &chan->node);
 
@@ -3209,7 +3209,8 @@ static struct bt_att_chan *att_get_fixed_chan(struct bt_conn *conn)
 
 static void att_chan_attach(struct bt_att *att, struct bt_att_chan *chan)
 {
-	LOG_DBG("att %p chan %p flags %lu", att, chan, atomic_get(chan->flags));
+	LOG_DBG("att %p chan %p flags %lu", (void *)att, (void *)chan,
+		atomic_get(chan->flags));
 
 	if (sys_slist_is_empty(&att->chans)) {
 		/* Init general queues when attaching the first channel */
@@ -3227,7 +3228,7 @@ static void bt_att_connected(struct bt_l2cap_chan *chan)
 	struct bt_att_chan *att_chan = ATT_CHAN(chan);
 	struct bt_l2cap_le_chan *le_chan = BT_L2CAP_LE_CHAN(chan);
 
-	LOG_DBG("chan %p cid 0x%04x", le_chan, le_chan->tx.cid);
+	LOG_DBG("chan %p cid 0x%04x", (void *)le_chan, le_chan->tx.cid);
 
 	atomic_set_bit(att_chan->flags, ATT_CONNECTED);
 
@@ -3244,7 +3245,7 @@ static void bt_att_disconnected(struct bt_l2cap_chan *chan)
 	struct bt_att *att = att_chan->att;
 	struct bt_l2cap_le_chan *le_chan = BT_L2CAP_LE_CHAN(chan);
 
-	LOG_DBG("chan %p cid 0x%04x", le_chan, le_chan->tx.cid);
+	LOG_DBG("chan %p cid 0x%04x", (void *)le_chan, le_chan->tx.cid);
 
 	if (!att_chan->att) {
 		LOG_DBG("Ignore disconnect on detached ATT chan");
@@ -3302,8 +3303,9 @@ static void bt_att_encrypt_change(struct bt_l2cap_chan *chan,
 	struct bt_conn *conn = le_chan->chan.conn;
 	uint8_t err;
 
-	LOG_DBG("chan %p conn %p handle %u sec_level 0x%02x status 0x%02x %s", le_chan, conn,
-		conn->handle, conn->sec_level, hci_status, bt_hci_err_to_str(hci_status));
+	LOG_DBG("chan %p conn %p handle %u sec_level 0x%02x status 0x%02x %s",
+		(void *)le_chan, (void *)conn, conn->handle, conn->sec_level, hci_status,
+		bt_hci_err_to_str(hci_status));
 
 	if (!att_chan->att) {
 		LOG_DBG("Ignore encrypt change on detached ATT chan");
@@ -3348,7 +3350,7 @@ static void bt_att_status(struct bt_l2cap_chan *ch, atomic_t *status)
 	struct bt_att_chan *chan = ATT_CHAN(ch);
 	sys_snode_t *node;
 
-	LOG_DBG("chan %p status %p", ch, status);
+	LOG_DBG("chan %p status %p", (void *)ch, status);
 
 	if (!atomic_test_bit(status, BT_L2CAP_STATUS_OUT)) {
 		return;
@@ -3382,7 +3384,7 @@ static void bt_att_released(struct bt_l2cap_chan *ch)
 {
 	struct bt_att_chan *chan = ATT_CHAN(ch);
 
-	LOG_DBG("chan %p", chan);
+	LOG_DBG("chan %p", (void *)chan);
 
 	k_mem_slab_free(&chan_slab, (void *)chan);
 }
@@ -3392,7 +3394,7 @@ static void bt_att_reconfigured(struct bt_l2cap_chan *l2cap_chan)
 {
 	struct bt_att_chan *att_chan = ATT_CHAN(l2cap_chan);
 
-	LOG_DBG("chan %p", att_chan);
+	LOG_DBG("chan %p", (void *)att_chan);
 
 	att_chan_mtu_updated(att_chan);
 }
@@ -3429,7 +3431,7 @@ static struct bt_att_chan *att_chan_new(struct bt_att *att, atomic_val_t flags)
 	}
 
 	if (k_mem_slab_alloc(&chan_slab, (void **)&chan, K_NO_WAIT)) {
-		LOG_WRN("No available ATT channel for conn %p", att->conn);
+		LOG_WRN("No available ATT channel for conn %p", (void *)att->conn);
 		return NULL;
 	}
 
@@ -3506,10 +3508,10 @@ static int bt_att_accept(struct bt_conn *conn, struct bt_l2cap_chan **ch)
 	struct bt_att *att;
 	struct bt_att_chan *chan;
 
-	LOG_DBG("conn %p handle %u", conn, conn->handle);
+	LOG_DBG("conn %p handle %u", (void *)conn, conn->handle);
 
 	if (k_mem_slab_alloc(&att_slab, (void **)&att, K_NO_WAIT)) {
-		LOG_ERR("No available ATT context for conn %p", conn);
+		LOG_ERR("No available ATT context for conn %p", (void *)conn);
 		return -ENOMEM;
 	}
 
@@ -3826,7 +3828,7 @@ static int bt_eatt_accept(struct bt_conn *conn, struct bt_l2cap_server *server,
 	struct bt_att_chan *att_chan = att_get_fixed_chan(conn);
 	struct bt_att *att = att_chan->att;
 
-	LOG_DBG("conn %p handle %u", conn, conn->handle);
+	LOG_DBG("conn %p handle %u", (void *)conn, conn->handle);
 
 	att_chan = att_chan_new(att, BIT(ATT_ENHANCED));
 	if (att_chan) {
@@ -3913,7 +3915,7 @@ uint16_t bt_att_get_uatt_mtu(struct bt_conn *conn)
 		}
 	}
 
-	LOG_WRN("No UATT channel found in %p", conn);
+	LOG_WRN("No UATT channel found in %p", (void *)conn);
 
 	return 0;
 }
@@ -3960,7 +3962,7 @@ struct bt_att_req *bt_att_req_alloc(k_timeout_t timeout)
 		return NULL;
 	}
 
-	LOG_DBG("req %p", req);
+	LOG_DBG("req %p", (void *)req);
 
 	memset(req, 0, sizeof(*req));
 
@@ -3969,7 +3971,7 @@ struct bt_att_req *bt_att_req_alloc(k_timeout_t timeout)
 
 void bt_att_req_free(struct bt_att_req *req)
 {
-	LOG_DBG("req %p", req);
+	LOG_DBG("req %p", (void *)req);
 
 	if (req->buf) {
 		net_buf_unref(req->buf);
@@ -4002,7 +4004,7 @@ int bt_att_req_send(struct bt_conn *conn, struct bt_att_req *req)
 {
 	struct bt_att *att;
 
-	LOG_DBG("conn %p req %p", conn, req);
+	LOG_DBG("conn %p req %p", (void *)conn, (void *)req);
 
 	__ASSERT_NO_MSG(conn);
 	__ASSERT_NO_MSG(req);
@@ -4042,7 +4044,7 @@ void bt_att_req_cancel(struct bt_conn *conn, struct bt_att_req *req)
 	struct bt_att *att;
 	struct bt_att_chan *chan, *tmp;
 
-	LOG_DBG("req %p", req);
+	LOG_DBG("req %p", (void *)req);
 
 	if (!conn || !req) {
 		return;

--- a/subsys/bluetooth/host/buf.c
+++ b/subsys/bluetooth/host/buf.c
@@ -213,7 +213,7 @@ struct net_buf *bt_buf_make_view(struct net_buf *view,
 
 	__ASSERT_NO_MSG(!bt_buf_has_view(parent));
 
-	LOG_DBG("make-view %p viewsize %zu meta %p", view, len, meta);
+	LOG_DBG("make-view %p viewsize %zu meta %p", (void *)view, len, (void *)meta);
 
 	net_buf_simple_clone(&parent->b, &view->b);
 	view->size = net_buf_headroom(parent) + len;
@@ -239,7 +239,7 @@ struct net_buf *bt_buf_make_view(struct net_buf *view,
 
 void bt_buf_destroy_view(struct net_buf *view, struct bt_buf_view_meta *meta)
 {
-	LOG_DBG("destroy-view %p meta %p", view, meta);
+	LOG_DBG("destroy-view %p meta %p", (void *)view, (void *)meta);
 	__ASSERT_NO_MSG(meta->parent);
 
 	/* "unclip" the parent buf */

--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -1283,7 +1283,7 @@ populate:
 			return -EINVAL;
 		}
 
-		LOG_DBG("attr %p handle 0x%04x uuid %s perm 0x%02x", attrs, attrs->handle,
+		LOG_DBG("attr %p handle 0x%04x uuid %s perm 0x%02x", (void *)attrs, attrs->handle,
 			bt_uuid_str(attrs->uuid), attrs->perm);
 	}
 
@@ -2186,7 +2186,7 @@ static void gatt_ccc_changed(const struct bt_gatt_attr *attr,
 		}
 	}
 
-	LOG_DBG("ccc %p value 0x%04x", ccc, value);
+	LOG_DBG("ccc %p value 0x%04x", (void *)ccc, value);
 
 	if (value != ccc->value) {
 		ccc->value = value;
@@ -2544,7 +2544,7 @@ static int gatt_notify(struct bt_conn *conn, uint16_t handle,
 		return -ENOMEM;
 	}
 
-	LOG_DBG("conn %p handle 0x%04x", conn, handle);
+	LOG_DBG("conn %p handle 0x%04x", (void *)conn, handle);
 
 	nfy = net_buf_add(buf, sizeof(*nfy) + params->len);
 	nfy->handle = sys_cpu_to_le16(handle);
@@ -2716,7 +2716,7 @@ static int gatt_indicate(struct bt_conn *conn, uint16_t handle,
 	ind->handle = sys_cpu_to_le16(handle);
 	memcpy(ind->value, params->data, params->len);
 
-	LOG_DBG("conn %p handle 0x%04x", conn, handle);
+	LOG_DBG("conn %p handle 0x%04x", (void *)conn, handle);
 
 	req->buf = buf;
 
@@ -2870,7 +2870,7 @@ struct bt_gatt_attr *bt_gatt_find_by_uuid(const struct bt_gatt_attr *attr,
 		/* If start_handle is 0 then `attr` is not in our database, and should not be used
 		 * as a starting point for the search
 		 */
-		LOG_DBG("Could not find handle of attr %p", attr);
+		LOG_DBG("Could not find handle of attr %p", (void *)attr);
 		return NULL;
 	}
 
@@ -3346,7 +3346,7 @@ static uint8_t update_ccc(const struct bt_gatt_attr *attr, uint16_t handle,
 			bt_security_t sec;
 
 			if (err == BT_ATT_ERR_WRITE_NOT_PERMITTED) {
-				LOG_WRN("CCC %p not writable", attr);
+				LOG_WRN("CCC %p not writable", (void *)attr);
 				continue;
 			}
 
@@ -3443,7 +3443,7 @@ static uint8_t disconnected_cb(const struct bt_gatt_attr *attr, uint16_t handle,
 			ccc->cfg_changed(attr, ccc->value);
 		}
 
-		LOG_DBG("ccc %p reset", ccc);
+		LOG_DBG("ccc %p reset", (void *)ccc);
 	}
 
 	return BT_GATT_ITER_CONTINUE;
@@ -3474,7 +3474,7 @@ bool bt_gatt_is_subscribed(struct bt_conn *conn,
 		/* The charactestic properties is the first byte of the attribute value */
 		len = attr->read(NULL, attr, &properties, sizeof(properties), 0);
 		if (len < 0) {
-			LOG_ERR("Failed to read attribute %p (err %zd)", attr, len);
+			LOG_ERR("Failed to read attribute %p (err %zd)", (void *)attr, len);
 			return false;
 		} else if (len != sizeof(properties)) {
 			LOG_ERR("Invalid read length: %zd", len);
@@ -3519,7 +3519,7 @@ bool bt_gatt_is_subscribed(struct bt_conn *conn,
 
 	len = attr->read(conn, attr, ccc_bits_encoded, sizeof(ccc_bits_encoded), 0);
 	if (len < 0) {
-		LOG_ERR("Failed to read attribute %p (err %zd)", attr, len);
+		LOG_ERR("Failed to read attribute %p (err %zd)", (void *)attr, len);
 		return false;
 	} else if (len != sizeof(ccc_bits_encoded)) {
 		LOG_ERR("Invalid read length: %zd", len);
@@ -5696,7 +5696,7 @@ static void add_subscriptions(struct bt_conn *conn)
 			err = gatt_resub_ccc(conn, params);
 			if (err < 0) {
 				LOG_WRN("conn %p params %p resub failed (err %d)",
-					(void *)conn, params, err);
+					(void *)conn, (void *)params, err);
 			}
 		}
 	}
@@ -5708,7 +5708,7 @@ static void gatt_exchange_mtu_func(struct bt_conn *conn, uint8_t err,
 				   struct bt_gatt_exchange_params *params)
 {
 	if (err) {
-		LOG_WRN("conn %p err 0x%02x", conn, err);
+		LOG_WRN("conn %p err 0x%02x", (void *)conn, err);
 	}
 }
 
@@ -5924,7 +5924,7 @@ void bt_gatt_connected(struct bt_conn *conn)
 {
 	struct conn_data data;
 
-	LOG_DBG("conn %p", conn);
+	LOG_DBG("conn %p", (void *)conn);
 
 	data.conn = conn;
 	data.sec = BT_SECURITY_L1;
@@ -6002,7 +6002,7 @@ void bt_gatt_encrypt_change(struct bt_conn *conn)
 {
 	struct conn_data data;
 
-	LOG_DBG("conn %p", conn);
+	LOG_DBG("conn %p", (void *)conn);
 
 	data.conn = conn;
 	data.sec = BT_SECURITY_L1;
@@ -6505,7 +6505,7 @@ int bt_gatt_clear(uint8_t id, const bt_addr_le_t *addr)
 
 void bt_gatt_disconnected(struct bt_conn *conn)
 {
-	LOG_DBG("conn %p", conn);
+	LOG_DBG("conn %p", (void *)conn);
 	bt_gatt_foreach_attr(0x0001, 0xffff, disconnected_cb, conn);
 
 #if defined(CONFIG_BT_GATT_NOTIFY_MULTIPLE)

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -323,7 +323,7 @@ struct net_buf *bt_hci_cmd_create(uint16_t opcode, uint8_t param_len)
 		return NULL;
 	}
 
-	LOG_DBG("buf %p", buf);
+	LOG_DBG("buf %p", (void *)buf);
 
 	net_buf_reserve(buf, BT_BUF_RESERVE);
 
@@ -393,7 +393,7 @@ int bt_hci_cmd_send_sync(uint16_t opcode, struct net_buf *buf,
 		}
 	}
 
-	LOG_DBG("buf %p opcode 0x%04x len %u", buf, opcode, buf->len);
+	LOG_DBG("buf %p opcode 0x%04x len %u", (void *)buf, opcode, buf->len);
 
 	/* This local sem is just for suspending the current thread until the
 	 * command is processed by the LL. It is given (and we are awaken) by
@@ -416,7 +416,7 @@ int bt_hci_cmd_send_sync(uint16_t opcode, struct net_buf *buf,
 
 		do {
 			cmd = k_fifo_peek_head(&bt_dev.cmd_tx_queue);
-			LOG_DBG("process cmd %p want %p", cmd, buf);
+			LOG_DBG("process cmd %p want %p", (void *)cmd, (void *)buf);
 
 			/* Wait for a response from the Bluetooth Controller.
 			 * The Controller may fail to respond if:
@@ -460,7 +460,7 @@ int bt_hci_cmd_send_sync(uint16_t opcode, struct net_buf *buf,
 		}
 	}
 
-	LOG_DBG("rsp %p opcode 0x%04x len %u", buf, opcode, buf->len);
+	LOG_DBG("rsp %p opcode 0x%04x len %u", (void *)buf, opcode, buf->len);
 
 	if (rsp) {
 		*rsp = buf;
@@ -630,7 +630,7 @@ static void hci_acl(struct net_buf *buf)
 	struct bt_conn *conn;
 	uint8_t flags;
 
-	LOG_DBG("buf %p", buf);
+	LOG_DBG("buf %p", (void *)buf);
 	if (buf->len < sizeof(*hdr)) {
 		LOG_ERR("Invalid HCI ACL packet size (%u)", buf->len);
 		net_buf_unref(buf);
@@ -2424,7 +2424,7 @@ static void hci_cmd_done(uint16_t opcode, uint8_t status, struct net_buf *evt_bu
 	struct net_buf *buf = NULL;
 
 	LOG_DBG("opcode 0x%04x status 0x%02x %s buf %p", opcode,
-		status, bt_hci_err_to_str(status), evt_buf);
+		status, bt_hci_err_to_str(status), (void *)evt_buf);
 
 	/* Unsolicited cmd complete. This does not complete a command.
 	 * The controller can send these for effect of the `ncmd` field.
@@ -3057,7 +3057,7 @@ static void hci_core_send_cmd(void)
 
 	bt_dev.sent_cmd = net_buf_ref(buf);
 
-	LOG_DBG("Sending command 0x%04x (buf %p) to driver", cmd(buf)->opcode, buf);
+	LOG_DBG("Sending command 0x%04x (buf %p) to driver", cmd(buf)->opcode, (void *)buf);
 
 	err = bt_send(buf);
 	if (err) {
@@ -4045,7 +4045,7 @@ static int hci_init(void)
 
 int bt_send(struct net_buf *buf)
 {
-	LOG_DBG("buf %p len %u type %u", buf, buf->len, bt_buf_get_type(buf));
+	LOG_DBG("buf %p len %u type %u", (void *)buf, buf->len, bt_buf_get_type(buf));
 
 	bt_monitor_send(bt_monitor_opcode(buf), buf->data, buf->len);
 
@@ -4116,7 +4116,7 @@ static int bt_recv_unsafe(struct net_buf *buf)
 {
 	bt_monitor_send(bt_monitor_opcode(buf), buf->data, buf->len);
 
-	LOG_DBG("buf %p len %u", buf, buf->len);
+	LOG_DBG("buf %p len %u", (void *)buf, buf->len);
 
 	switch (bt_buf_get_type(buf)) {
 #if defined(CONFIG_BT_CONN)
@@ -4232,7 +4232,7 @@ static void rx_work_handler(struct k_work *work)
 		return;
 	}
 
-	LOG_DBG("buf %p type %u len %u", buf, bt_buf_get_type(buf), buf->len);
+	LOG_DBG("buf %p type %u len %u", (void *)buf, bt_buf_get_type(buf), buf->len);
 
 	switch (bt_buf_get_type(buf)) {
 #if defined(CONFIG_BT_CONN)

--- a/subsys/bluetooth/host/hci_raw.c
+++ b/subsys/bluetooth/host/hci_raw.c
@@ -194,7 +194,7 @@ int bt_hci_recv(const struct device *dev, struct net_buf *buf)
 {
 	ARG_UNUSED(dev);
 
-	LOG_DBG("buf %p len %u", buf, buf->len);
+	LOG_DBG("buf %p len %u", (void *)buf, buf->len);
 
 	bt_monitor_send(bt_monitor_opcode(buf), buf->data, buf->len);
 
@@ -296,7 +296,7 @@ static uint8_t bt_send_ext(struct net_buf *buf)
 
 int bt_send(struct net_buf *buf)
 {
-	LOG_DBG("buf %p len %u", buf, buf->len);
+	LOG_DBG("buf %p len %u", (void *)buf, buf->len);
 
 	if (buf->len == 0) {
 		return BT_HCI_ERR_INVALID_PARAM;

--- a/subsys/bluetooth/host/id.c
+++ b/subsys/bluetooth/host/id.c
@@ -2139,7 +2139,7 @@ int bt_le_ext_adv_oob_get_local(struct bt_le_ext_adv *adv,
 int bt_le_oob_set_legacy_tk(struct bt_conn *conn, const uint8_t *tk)
 {
 	if (!bt_conn_is_type(conn, BT_CONN_TYPE_LE)) {
-		LOG_DBG("Invalid connection type: %u for %p", conn->type, conn);
+		LOG_DBG("Invalid connection type: %u for %p", conn->type, (void *)conn);
 		return -EINVAL;
 	}
 
@@ -2157,7 +2157,7 @@ int bt_le_oob_set_sc_data(struct bt_conn *conn,
 			  const struct bt_le_oob_sc_data *oobd_remote)
 {
 	if (!bt_conn_is_type(conn, BT_CONN_TYPE_LE)) {
-		LOG_DBG("Invalid connection type: %u for %p", conn->type, conn);
+		LOG_DBG("Invalid connection type: %u for %p", conn->type, (void *)conn);
 		return -EINVAL;
 	}
 
@@ -2173,8 +2173,8 @@ int bt_le_oob_get_sc_data(struct bt_conn *conn,
 			  const struct bt_le_oob_sc_data **oobd_remote)
 {
 	if (!bt_conn_is_type(conn, BT_CONN_TYPE_LE)) {
-		LOG_ERR("Invalid connection: %p", conn);
-		LOG_ERR("Invalid connection type: %u for %p", conn->handle, conn);
+		LOG_ERR("Invalid connection: %p", (void *)conn);
+		LOG_ERR("Invalid connection type: %u for %p", conn->handle, (void *)conn);
 		return -EINVAL;
 	}
 

--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -99,7 +99,7 @@ static void bt_iso_sent_cb(struct bt_conn *iso, void *user_data, int err)
 	struct bt_iso_chan *chan = iso->iso.chan;
 	struct bt_iso_chan_ops *ops;
 
-	__ASSERT(chan != NULL, "NULL chan for iso %p", iso);
+	__ASSERT(chan != NULL, "NULL chan for iso %p", (void *)iso);
 
 	ops = chan->ops;
 
@@ -116,7 +116,7 @@ void hci_iso(struct net_buf *buf)
 	struct bt_conn *iso;
 	uint8_t flags;
 
-	BT_ISO_DATA_DBG("buf %p", buf);
+	BT_ISO_DATA_DBG("buf %p", (void *)buf);
 
 	if (buf->len < sizeof(*hdr)) {
 		LOG_ERR("Invalid HCI ISO packet size (%u)", buf->len);
@@ -236,7 +236,7 @@ static void bt_iso_chan_add(struct bt_conn *iso, struct bt_iso_chan *chan)
 	iso->iso.chan = chan;
 	k_fifo_init(&iso->iso.txq);
 
-	LOG_DBG("iso %p chan %p", iso, chan);
+	LOG_DBG("iso %p chan %p", (void *)iso, (void *)chan);
 }
 
 static int validate_iso_setup_data_path_parms(const struct bt_iso_chan *chan, uint8_t dir,
@@ -265,19 +265,19 @@ static int validate_iso_setup_data_path_parms(const struct bt_iso_chan *chan, ui
 
 	iso = chan->iso;
 	if (iso == NULL) {
-		LOG_DBG("chan %p not associated with a CIS/BIS handle", chan);
+		LOG_DBG("chan %p not associated with a CIS/BIS handle", (void *)chan);
 
 		return -ENODEV;
 	}
 
 	if (!iso->iso.info.can_recv && dir == BT_HCI_DATAPATH_DIR_CTLR_TO_HOST) {
-		LOG_DBG("Invalid dir %u for chan %p that cannot receive data", dir, chan);
+		LOG_DBG("Invalid dir %u for chan %p that cannot receive data", dir, (void *)chan);
 
 		return -EINVAL;
 	}
 
 	if (!iso->iso.info.can_send && dir == BT_HCI_DATAPATH_DIR_HOST_TO_CTLR) {
-		LOG_DBG("Invalid dir %u for chan %p that cannot send data", dir, chan);
+		LOG_DBG("Invalid dir %u for chan %p that cannot send data", dir, (void *)chan);
 
 		return -EINVAL;
 	}
@@ -393,7 +393,7 @@ static int validate_iso_remove_data_path(const struct bt_iso_chan *chan, uint8_t
 
 	iso = chan->iso;
 	if (iso == NULL) {
-		LOG_DBG("chan %p not associated with a CIS/BIS handle", chan);
+		LOG_DBG("chan %p not associated with a CIS/BIS handle", (void *)chan);
 
 		return -ENODEV;
 	}
@@ -432,11 +432,12 @@ void bt_iso_connected(struct bt_conn *iso)
 	struct bt_iso_chan *chan;
 
 	if (iso == NULL || iso->type != BT_CONN_TYPE_ISO) {
-		LOG_DBG("Invalid parameters: iso %p iso->type %u", iso, iso ? iso->type : 0);
+		LOG_DBG("Invalid parameters: iso %p iso->type %u", (void *)iso,
+			iso ? iso->type : 0);
 		return;
 	}
 
-	LOG_DBG("%p", iso);
+	LOG_DBG("%p", (void *)iso);
 
 	chan = iso_chan(iso);
 	if (chan == NULL) {
@@ -454,9 +455,9 @@ void bt_iso_connected(struct bt_conn *iso)
 static void bt_iso_chan_disconnected(struct bt_iso_chan *chan, uint8_t reason)
 {
 	const uint8_t conn_type = chan->iso->iso.info.type;
-	LOG_DBG("%p, reason 0x%02x", chan, reason);
+	LOG_DBG("%p, reason 0x%02x", (void *)chan, reason);
 
-	__ASSERT(chan->iso != NULL, "NULL conn for iso chan %p", chan);
+	__ASSERT(chan->iso != NULL, "NULL conn for iso chan %p", (void *)chan);
 
 	bt_iso_chan_set_state(chan, BT_ISO_STATE_DISCONNECTED);
 	bt_conn_set_state(chan->iso, BT_CONN_DISCONNECT_COMPLETE);
@@ -511,11 +512,12 @@ void bt_iso_disconnected(struct bt_conn *iso)
 	struct bt_iso_chan *chan;
 
 	if (iso == NULL || iso->type != BT_CONN_TYPE_ISO) {
-		LOG_DBG("Invalid parameters: iso %p iso->type %u", iso, iso ? iso->type : 0);
+		LOG_DBG("Invalid parameters: iso %p iso->type %u", (void *)iso,
+			iso ? iso->type : 0);
 		return;
 	}
 
-	LOG_DBG("%p", iso);
+	LOG_DBG("%p", (void *)iso);
 
 	chan = iso_chan(iso);
 	if (chan == NULL) {
@@ -548,8 +550,8 @@ const char *bt_iso_chan_state_str(uint8_t state)
 void bt_iso_chan_set_state_debug(struct bt_iso_chan *chan, enum bt_iso_state state,
 				 const char *func, int line)
 {
-	LOG_DBG("chan %p iso %p %s -> %s", chan, chan->iso, bt_iso_chan_state_str(chan->state),
-		bt_iso_chan_state_str(state));
+	LOG_DBG("chan %p iso %p %s -> %s", (void *)chan, (void *)chan->iso,
+		bt_iso_chan_state_str(chan->state), bt_iso_chan_state_str(state));
 
 	/* check transitions validness */
 	switch (state) {
@@ -785,7 +787,7 @@ static bool iso_has_data(struct bt_conn *conn)
 static struct net_buf *iso_data_pull(struct bt_conn *conn, size_t amount, size_t *length)
 {
 #if defined(CONFIG_BT_ISO_TX)
-	BT_ISO_DATA_DBG("conn %p amount %d", conn, amount);
+	BT_ISO_DATA_DBG("conn %p amount %d", (void *)conn, amount);
 
 	/* Leave the PDU buffer in the queue until we have sent all its
 	 * fragments.
@@ -869,7 +871,7 @@ int conn_iso_send(struct bt_conn *conn, struct net_buf *buf, enum bt_iso_timesta
 	}
 
 	k_fifo_put(&conn->iso.txq, buf);
-	BT_ISO_DATA_DBG("%p put on list", buf);
+	BT_ISO_DATA_DBG("%p put on list", (void *)buf);
 
 	/* only one ISO channel per conn-object */
 	bt_conn_data_ready(conn);
@@ -884,20 +886,20 @@ static int validate_send(const struct bt_iso_chan *chan, const struct net_buf *b
 	uint16_t max_data_len;
 
 	CHECKIF(!chan || !buf) {
-		LOG_DBG("Invalid parameters: chan %p buf %p", chan, buf);
+		LOG_DBG("Invalid parameters: chan %p buf %p", (void *)chan, buf);
 		return -EINVAL;
 	}
 
-	BT_ISO_DATA_DBG("chan %p len %zu", chan, net_buf_frags_len(buf));
+	BT_ISO_DATA_DBG("chan %p len %zu", (void *)chan, net_buf_frags_len(buf));
 
 	if (chan->state != BT_ISO_STATE_CONNECTED) {
-		LOG_DBG("Channel %p not connected", chan);
+		LOG_DBG("Channel %p not connected", (void *)chan);
 		return -ENOTCONN;
 	}
 
 	iso_conn = chan->iso;
 	if (!iso_conn->iso.info.can_send) {
-		LOG_DBG("Channel %p not able to send", chan);
+		LOG_DBG("Channel %p not able to send", (void *)chan);
 		return -EINVAL;
 	}
 
@@ -914,14 +916,15 @@ static int validate_send(const struct bt_iso_chan *chan, const struct net_buf *b
 	}
 
 	if (buf->size < hdr_size) {
-		LOG_DBG("Channel %p cannot send ISO packet with buffer size %u", chan, buf->size);
+		LOG_DBG("Channel %p cannot send ISO packet with buffer size %u", (void *)chan,
+			buf->size);
 
 		return -EMSGSIZE;
 	}
 
 	max_data_len = iso_chan_max_data_len(chan);
 	if (buf->len > max_data_len) {
-		LOG_DBG("Channel %p cannot send %u octets, maximum %u", chan, buf->len,
+		LOG_DBG("Channel %p cannot send %u octets, maximum %u", (void *)chan, buf->len,
 			max_data_len);
 		return -EMSGSIZE;
 	}
@@ -940,7 +943,7 @@ int bt_iso_chan_send(struct bt_iso_chan *chan, struct net_buf *buf, uint16_t seq
 		return err;
 	}
 
-	BT_ISO_DATA_DBG("chan %p len %zu", chan, net_buf_frags_len(buf));
+	BT_ISO_DATA_DBG("chan %p len %zu", (void *)chan, net_buf_frags_len(buf));
 
 	hdr = net_buf_push(buf, sizeof(*hdr));
 	hdr->sn = sys_cpu_to_le16(seq_num);
@@ -965,7 +968,7 @@ int bt_iso_chan_send_ts(struct bt_iso_chan *chan, struct net_buf *buf, uint16_t 
 		return err;
 	}
 
-	BT_ISO_DATA_DBG("chan %p len %zu", chan, net_buf_frags_len(buf));
+	BT_ISO_DATA_DBG("chan %p len %zu", (void *)chan, net_buf_frags_len(buf));
 
 	hdr = net_buf_push(buf, sizeof(*hdr));
 	hdr->ts = sys_cpu_to_le32(ts);
@@ -1097,7 +1100,7 @@ int bt_iso_chan_disconnect(struct bt_iso_chan *chan)
 	int err;
 
 	CHECKIF(!chan) {
-		LOG_DBG("Invalid parameter: chan %p", chan);
+		LOG_DBG("Invalid parameter: chan %p", (void *)chan);
 		return -EINVAL;
 	}
 
@@ -1146,7 +1149,7 @@ int bt_iso_chan_disconnect(struct bt_iso_chan *chan)
 
 void bt_iso_cleanup_acl(struct bt_conn *iso)
 {
-	LOG_DBG("%p", iso);
+	LOG_DBG("%p", (void *)iso);
 
 	if (iso->iso.acl) {
 		bt_conn_unref(iso->iso.acl);
@@ -1172,7 +1175,7 @@ static void store_cis_info(const struct bt_hci_evt_le_cis_established *evt, stru
 	rx = chan->qos->rx;
 	tx = chan->qos->tx;
 
-	LOG_DBG("iso_chan %p tx %p rx %p", chan, tx, rx);
+	LOG_DBG("iso_chan %p tx %p rx %p", (void *)chan, (void *)tx, (void *)rx);
 
 	if (iso->role == BT_HCI_ROLE_PERIPHERAL) {
 		/* As of BT Core 6.0, we can only get the SDU size if the controller
@@ -1404,7 +1407,7 @@ void hci_le_cis_established_v2(struct net_buf *buf)
 int bt_iso_server_register(struct bt_iso_server *server)
 {
 	CHECKIF(!server) {
-		LOG_DBG("Invalid parameter: server %p", server);
+		LOG_DBG("Invalid parameter: server %p", (void *)server);
 		return -EINVAL;
 	}
 
@@ -1430,7 +1433,7 @@ int bt_iso_server_register(struct bt_iso_server *server)
 	}
 #endif /* CONFIG_BT_SMP */
 
-	LOG_DBG("%p", server);
+	LOG_DBG("%p", (void *)server);
 
 	iso_server = server;
 
@@ -1440,7 +1443,7 @@ int bt_iso_server_register(struct bt_iso_server *server)
 int bt_iso_server_unregister(struct bt_iso_server *server)
 {
 	CHECKIF(!server) {
-		LOG_DBG("Invalid parameter: server %p", server);
+		LOG_DBG("Invalid parameter: server %p", (void *)server);
 		return -EINVAL;
 	}
 
@@ -1460,11 +1463,12 @@ static int iso_accept(struct bt_conn *acl, struct bt_conn *iso)
 	int err;
 
 	CHECKIF(!iso || iso->type != BT_CONN_TYPE_ISO) {
-		LOG_DBG("Invalid parameters: iso %p iso->type %u", iso, iso ? iso->type : 0);
+		LOG_DBG("Invalid parameters: iso %p iso->type %u", (void *)iso,
+			iso ? iso->type : 0);
 		return -EINVAL;
 	}
 
-	LOG_DBG("%p", iso);
+	LOG_DBG("%p", (void *)iso);
 
 	accept_info.acl = acl;
 	accept_info.cig_id = iso->iso.cig_id;
@@ -2020,7 +2024,8 @@ static bool valid_cig_param(const struct bt_iso_cig_param *param, bool advanced,
 		}
 
 		if (cis->iso != NULL && !cis_is_in_cig(cig, cis)) {
-			LOG_DBG("cis_channels[%u]: already allocated to CIG %p", i, get_cig(cis));
+			LOG_DBG("cis_channels[%u]: already allocated to CIG %p",
+				i, (void *)get_cig(cis));
 			return false;
 		}
 
@@ -2031,7 +2036,7 @@ static bool valid_cig_param(const struct bt_iso_cig_param *param, bool advanced,
 
 		for (uint8_t j = 0; j < i; j++) {
 			if (cis == param->cis_channels[j]) {
-				LOG_DBG("ISO %p duplicated at index %u and %u", cis, i, j);
+				LOG_DBG("ISO %p duplicated at index %u and %u", (void *)cis, i, j);
 				return false;
 			}
 		}
@@ -2389,8 +2394,8 @@ void bt_iso_security_changed(struct bt_conn *acl, uint8_t hci_status)
 			param[param_count].iso_chan = iso_chan;
 			param_count++;
 		} else {
-			LOG_DBG("Failed to encrypt ACL %p for ISO %p: %u %s", acl, iso, hci_status,
-				bt_hci_err_to_str(hci_status));
+			LOG_DBG("Failed to encrypt ACL %p for ISO %p: %u %s", (void *)acl,
+				(void *)iso, hci_status, bt_hci_err_to_str(hci_status));
 
 			/* We utilize the disconnected callback to make the
 			 * upper layers aware of the error
@@ -2573,12 +2578,12 @@ int bt_iso_chan_connect(const struct bt_iso_connect_param *param, size_t count)
 	/* Validate input */
 	for (size_t i = 0; i < count; i++) {
 		CHECKIF(param[i].iso_chan == NULL) {
-			LOG_DBG("[%zu]: Invalid iso (%p)", i, param[i].iso_chan);
+			LOG_DBG("[%zu]: Invalid iso (%p)", i, (void *)param[i].iso_chan);
 			return -EINVAL;
 		}
 
 		CHECKIF(param[i].acl == NULL) {
-			LOG_DBG("[%zu]: Invalid acl (%p)", i, param[i].acl);
+			LOG_DBG("[%zu]: Invalid acl (%p)", i, (void *)param[i].acl);
 			return -EINVAL;
 		}
 
@@ -2764,7 +2769,7 @@ int bt_iso_big_register_cb(struct bt_iso_big_cb *cb)
 	}
 
 	if (sys_slist_find(&iso_big_cbs, &cb->_node, NULL)) {
-		LOG_DBG("cb %p is already registered", cb);
+		LOG_DBG("cb %p is already registered", (void *)cb);
 
 		return -EEXIST;
 	}
@@ -3141,7 +3146,7 @@ void hci_le_big_complete(struct net_buf *buf)
 	big = lookup_big_by_handle(evt->big_handle);
 	atomic_clear_bit(big->flags, BT_BIG_PENDING);
 
-	LOG_DBG("BIG[%u] %p completed, status 0x%02x %s", big->handle, big, evt->status,
+	LOG_DBG("BIG[%u] %p completed, status 0x%02x %s", big->handle, (void *)big, evt->status,
 		bt_hci_err_to_str(evt->status));
 
 	if (evt->status || evt->num_bis != big->num_bis) {
@@ -3187,7 +3192,7 @@ void hci_le_big_terminate(struct net_buf *buf)
 
 	big = lookup_big_by_handle(evt->big_handle);
 
-	LOG_DBG("BIG[%u] %p terminated", big->handle, big);
+	LOG_DBG("BIG[%u] %p terminated", big->handle, (void *)big);
 
 	big_disconnect(big, evt->reason);
 	cleanup_big(big);
@@ -3331,8 +3336,8 @@ void hci_le_big_sync_established(struct net_buf *buf)
 	big = lookup_big_by_handle(evt->big_handle);
 	atomic_clear_bit(big->flags, BT_BIG_SYNCING);
 
-	LOG_DBG("BIG[%u] %p sync established, status 0x%02x %s", big->handle, big, evt->status,
-		bt_hci_err_to_str(evt->status));
+	LOG_DBG("BIG[%u] %p sync established, status 0x%02x %s", big->handle, (void *)big,
+		evt->status, bt_hci_err_to_str(evt->status));
 
 	if (evt->status || evt->num_bis != big->num_bis) {
 		if (evt->status == BT_HCI_ERR_SUCCESS && evt->num_bis != big->num_bis) {
@@ -3377,7 +3382,7 @@ void hci_le_big_sync_lost(struct net_buf *buf)
 
 	big = lookup_big_by_handle(evt->big_handle);
 
-	LOG_DBG("BIG[%u] %p sync lost", big->handle, big);
+	LOG_DBG("BIG[%u] %p sync lost", big->handle, (void *)big);
 
 	big_disconnect(big, evt->reason);
 	cleanup_big(big);

--- a/subsys/bluetooth/host/keys.c
+++ b/subsys/bluetooth/host/keys.c
@@ -147,7 +147,7 @@ struct bt_keys *bt_keys_get_addr(uint8_t id, const bt_addr_le_t *addr)
 		keys->aging_counter = ++aging_counter_val;
 		last_keys_updated = keys;
 #endif  /* CONFIG_BT_KEYS_OVERWRITE_OLDEST */
-		LOG_DBG("created %p for %s", keys, bt_addr_le_str(addr));
+		LOG_DBG("created %p for %s", (void *)keys, bt_addr_le_str(addr));
 		return keys;
 	}
 

--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -903,7 +903,7 @@ static void bt_smp_br_connected(struct bt_l2cap_chan *chan)
 {
 	struct bt_smp_br *smp = CONTAINER_OF(chan, struct bt_smp_br, chan.chan);
 
-	LOG_DBG("chan %p cid 0x%04x", chan,
+	LOG_DBG("chan %p cid 0x%04x", (void *)chan,
 		CONTAINER_OF(chan, struct bt_l2cap_br_chan, chan)->tx.cid);
 
 	atomic_set_bit(smp->flags, SMP_FLAG_BR_CONNECTED);
@@ -921,7 +921,7 @@ static void bt_smp_br_disconnected(struct bt_l2cap_chan *chan)
 {
 	struct bt_smp_br *smp = CONTAINER_OF(chan, struct bt_smp_br, chan.chan);
 
-	LOG_DBG("chan %p cid 0x%04x", chan,
+	LOG_DBG("chan %p cid 0x%04x", (void *)chan,
 		CONTAINER_OF(chan, struct bt_l2cap_br_chan, chan)->tx.cid);
 
 	/* Channel disconnected callback is always called from a work handler
@@ -1595,7 +1595,7 @@ static int bt_smp_br_accept(struct bt_conn *conn, struct bt_l2cap_chan **chan)
 		return -ENOTSUP;
 	}
 
-	LOG_DBG("conn %p handle %u", conn, conn->handle);
+	LOG_DBG("conn %p handle %u", (void *)conn, conn->handle);
 
 	for (i = 0; i < ARRAY_SIZE(bt_smp_pool); i++) {
 		struct bt_smp_br *smp = &bt_smp_br_pool[i];
@@ -1614,7 +1614,7 @@ static int bt_smp_br_accept(struct bt_conn *conn, struct bt_l2cap_chan **chan)
 		return 0;
 	}
 
-	LOG_ERR("No available SMP context for conn %p", conn);
+	LOG_ERR("No available SMP context for conn %p", (void *)conn);
 
 	return -ENOMEM;
 }
@@ -4733,7 +4733,7 @@ static void bt_smp_connected(struct bt_l2cap_chan *chan)
 {
 	struct bt_smp *smp = CONTAINER_OF(chan, struct bt_smp, chan.chan);
 
-	LOG_DBG("chan %p cid 0x%04x", chan,
+	LOG_DBG("chan %p cid 0x%04x", (void *)chan,
 		CONTAINER_OF(chan, struct bt_l2cap_le_chan, chan)->tx.cid);
 
 	k_work_init_delayable(&smp->work, smp_timeout);
@@ -4748,7 +4748,7 @@ static void bt_smp_disconnected(struct bt_l2cap_chan *chan)
 	struct bt_smp *smp = CONTAINER_OF(chan, struct bt_smp, chan.chan);
 	struct bt_keys *keys = chan->conn->le.keys;
 
-	LOG_DBG("chan %p cid 0x%04x", chan,
+	LOG_DBG("chan %p cid 0x%04x", (void *)chan,
 		CONTAINER_OF(chan, struct bt_l2cap_le_chan, chan)->tx.cid);
 
 	/* Channel disconnected callback is always called from a work handler
@@ -4783,8 +4783,9 @@ static void bt_smp_encrypt_change(struct bt_l2cap_chan *chan,
 	struct bt_smp *smp = CONTAINER_OF(chan, struct bt_smp, chan.chan);
 	struct bt_conn *conn = chan->conn;
 
-	LOG_DBG("chan %p conn %p handle %u encrypt 0x%02x hci status 0x%02x %s", chan, conn,
-		conn->handle, conn->encrypt, hci_status, bt_hci_err_to_str(hci_status));
+	LOG_DBG("chan %p conn %p handle %u encrypt 0x%02x hci status 0x%02x %s",
+		(void *)chan, (void *)conn, conn->handle, conn->encrypt, hci_status,
+		bt_hci_err_to_str(hci_status));
 
 	if (!atomic_test_and_clear_bit(smp->flags, SMP_FLAG_ENC_PENDING)) {
 		/* We where not waiting for encryption procedure.
@@ -5500,7 +5501,7 @@ int bt_conn_set_bondable(struct bt_conn *conn, bool enable)
 	struct bt_smp *smp;
 
 	if (!bt_conn_is_type(conn, BT_CONN_TYPE_LE | BT_CONN_TYPE_BR)) {
-		LOG_DBG("Invalid connection type: %u for %p", conn->type, conn);
+		LOG_DBG("Invalid connection type: %u for %p", conn->type, (void *)conn);
 		return -EINVAL;
 	}
 
@@ -6143,7 +6144,7 @@ static int bt_smp_accept(struct bt_conn *conn, struct bt_l2cap_chan **chan)
 		.recv = bt_smp_recv,
 	};
 
-	LOG_DBG("conn %p handle %u", conn, conn->handle);
+	LOG_DBG("conn %p handle %u", (void *)conn, conn->handle);
 
 	for (i = 0; i < ARRAY_SIZE(bt_smp_pool); i++) {
 		struct bt_smp *smp = &bt_smp_pool[i];
@@ -6159,7 +6160,7 @@ static int bt_smp_accept(struct bt_conn *conn, struct bt_l2cap_chan **chan)
 		return 0;
 	}
 
-	LOG_ERR("No available SMP context for conn %p", conn);
+	LOG_ERR("No available SMP context for conn %p", (void *)conn);
 
 	return -ENOMEM;
 }

--- a/subsys/bluetooth/host/smp_null.c
+++ b/subsys/bluetooth/host/smp_null.c
@@ -77,7 +77,7 @@ static int bt_smp_accept(struct bt_conn *conn, struct bt_l2cap_chan **chan)
 		.recv = bt_smp_recv,
 	};
 
-	LOG_DBG("conn %p handle %u", conn, conn->handle);
+	LOG_DBG("conn %p handle %u", (void *)conn, conn->handle);
 
 	for (i = 0; i < ARRAY_SIZE(bt_smp_pool); i++) {
 		struct bt_l2cap_le_chan *smp = &bt_smp_pool[i];
@@ -93,7 +93,7 @@ static int bt_smp_accept(struct bt_conn *conn, struct bt_l2cap_chan **chan)
 		return 0;
 	}
 
-	LOG_ERR("No available SMP context for conn %p", conn);
+	LOG_ERR("No available SMP context for conn %p", (void *)conn);
 
 	return -ENOMEM;
 }


### PR DESCRIPTION
This eliminates the following clang warning:

clang-tidy: Suspicous usage of 'sizeof()' on an expression of pointer type

Additionally, it seems [implied by the logging subsystem documentation](https://docs.zephyrproject.org/latest/services/logging/index.html#recommendations) that certain pointers should be cast to (void *). The documentation doesn't state why, but I suspect it's because of the clang warning.

This is an alternate approach to #85775 which hasn't gotten any comment from logging subsystem maintainers.

Fixes #85775 