### PR TITLE
soc: atmel: samx7x: implement main oscillator bypass mode

### DIFF
--- a/soc/atmel/sam/common/Kconfig
+++ b/soc/atmel/sam/common/Kconfig
@@ -32,6 +32,18 @@ config SOC_ATMEL_SAM_EXT_MAINCK
 
 	  Says n here will use the internal fast RC oscillator running at 12 MHz.
 
+config SOC_ATMEL_SAM_EXT_MAINCK_BYPASS
+	bool "Use bypass mode for external crystal oscillator"
+	depends on SOC_ATMEL_SAM_EXT_MAINCK
+	help
+	  When bypass mode is enabled, the external crystal oscillator is bypassed,
+	  and the main clock is directly driven by an external clock signal.
+
+	  Says y here if you want to use an external clock signal directly instead
+	  of the crystal oscillator.
+
+	  Says n here to use the external crystal oscillator normally.
+
 menu "PLL A"
 
 config SOC_ATMEL_SAM_PLLA_MULA

--- a/soc/atmel/sam/samx7x/soc.c
+++ b/soc/atmel/sam/samx7x/soc.c
@@ -57,7 +57,9 @@ static ALWAYS_INLINE void clock_init(void)
 		 * this optimization is not deemed
 		 * critical now.
 		 */
-		soc_pmc_switch_mainck_to_xtal(false, 0xff);
+		bool bypass = IS_ENABLED(CONFIG_SOC_ATMEL_SAM_EXT_MAINCK_BYPASS);
+
+		soc_pmc_switch_mainck_to_xtal(bypass, 0xff);
 	}
 
 	/*


### PR DESCRIPTION
Enable support for using an external clock as the main clock. When bypass mode is enabled, the external crystal oscillator is bypassed, and the main clock is directly driven by an external clock signal.