### PR TITLE
MAINTAINERS: Add tests/bluetooth/classic/ to Classic

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -438,6 +438,7 @@ Bluetooth Host:
     - subsys/bluetooth/host/iso_internal.h
     - subsys/bluetooth/host/shell/iso.c
     - tests/bluetooth/audio/
+    - tests/bluetooth/classic/
     - tests/bluetooth/controller/
     - tests/bluetooth/mesh*/
     - tests/bluetooth/qualification/
@@ -534,6 +535,7 @@ Bluetooth Classic:
     - subsys/bluetooth/common/
     - subsys/bluetooth/host/classic/
     - include/zephyr/bluetooth/classic/
+    - tests/bluetooth/classic/
   labels:
     - "area: Bluetooth Classic"
     - "area: Bluetooth"


### PR DESCRIPTION
Add the tests/bluetooth/classic/ path to the Bluetooth Classic label and exclude it from the host (LE) label.