### PR TITLE
drivers: udc_dwc2: Optimize endpoint event clear

### DIFF
--- a/drivers/usb/udc/udc_dwc2.c
+++ b/drivers/usb/udc/udc_dwc2.c
@@ -2970,8 +2970,7 @@ static ALWAYS_INLINE void dwc2_thread_handler(void *const arg)
 
 		if (!priv->hibernated) {
 			LOG_DBG("New transfer(s) in the queue");
-			eps = k_event_test(&priv->xfer_new, UINT32_MAX);
-			k_event_clear(&priv->xfer_new, eps);
+			eps = k_event_clear(&priv->xfer_new, UINT32_MAX);
 		} else {
 			/* Events will be handled after hibernation exit */
 			eps = 0;
@@ -2993,8 +2992,7 @@ static ALWAYS_INLINE void dwc2_thread_handler(void *const arg)
 		k_event_clear(&priv->drv_evt, BIT(DWC2_DRV_EVT_EP_FINISHED));
 
 		if (!priv->hibernated) {
-			eps = k_event_test(&priv->xfer_finished, UINT32_MAX);
-			k_event_clear(&priv->xfer_finished, eps);
+			eps = k_event_clear(&priv->xfer_finished, UINT32_MAX);
 		} else {
 			/* Events will be handled after hibernation exit */
 			eps = 0;


### PR DESCRIPTION
There is no point in calling k_event_test() to determine what events are posted and then passing that value to k_event_clear(). Simply pass UINT32_MAX to k_event_clear() and use the return value to slightly reduce overhead.