### PR TITLE
Sy1xx/otp bootloader runner

### DIFF
--- a/boards/sensry/ganymed_bob/board.cmake
+++ b/boards/sensry/ganymed_bob/board.cmake
@@ -1,0 +1,5 @@
+# Copyright (c) 2025 sensry.io
+# SPDX-License-Identifier: Apache-2.0
+
+board_set_flasher_ifnset(sy1xx)
+board_finalize_runner_args(sy1xx)

--- a/scripts/west_commands/runners/__init__.py
+++ b/scripts/west_commands/runners/__init__.py
@@ -60,6 +60,7 @@ _names = [
     'spi_burn',
     'stm32cubeprogrammer',
     'stm32flash',
+    'sy1xx',
     'teensy',
     'trace32',
     'uf2',

--- a/scripts/west_commands/runners/sy1xx.py
+++ b/scripts/west_commands/runners/sy1xx.py
@@ -1,0 +1,74 @@
+# Copyright (c) 2025 sensry.io
+# SPDX-License-Identifier: Apache-2.0
+
+'''Runner for Sensry SY1xx Soc Flashing Tool.'''
+
+import importlib.util
+
+from runners.core import RunnerCaps, ZephyrBinaryRunner
+
+
+class Sy1xxBinaryRunner(ZephyrBinaryRunner):
+    '''Runner front-end for Sensry SY1xx Soc'''
+
+    def __init__(self, cfg, dev_id=None):
+        super().__init__(cfg)
+        print(cfg)
+        self.bin_file = cfg.bin_file
+        self.dev_id = dev_id
+
+    @classmethod
+    def name(cls):
+        return 'sy1xx'
+
+    @classmethod
+    def capabilities(cls):
+        return RunnerCaps(commands={'flash'}, dev_id=True)
+
+    @classmethod
+    def do_add_parser(cls, parser):
+        parser.set_defaults(dev_id='/dev/ttyUSB0')
+
+    @classmethod
+    def dev_id_help(cls) -> str:
+        return 'Device identifier such as /dev/ttyUSB0'
+
+    @classmethod
+    def do_create(cls, cfg, args):
+        # make sure the ganymed tools are installed
+        if importlib.util.find_spec('ganymed') is None:
+            raise RuntimeError("ganymed not found; can be installed with 'pip install ganymed'")
+
+        if not hasattr(args, "dev_id") or args.dev_id is None:
+            raise RuntimeError("missing --dev-id argument, such as /dev/ttyUSB0")
+
+        return Sy1xxBinaryRunner(cfg, args.dev_id)
+
+    def do_run(self, command, **kwargs):
+        if command == 'flash':
+            self.flash(**kwargs)
+
+    def flash(self, **kwargs):
+        self.logger.info(f'Flashing file: {self.bin_file} to {self.dev_id}')
+
+        from ganymed.bootloader import Bootloader
+
+        # convert binary to application ganymed-image
+        application_gnm = Bootloader.convert_zephyr_bin(self.bin_file)
+
+        # create the loader
+        flash_loader = Bootloader()
+
+        # connect to serial
+        flash_loader.connect(self.dev_id)
+
+        # set the controller into bootloader mode
+        flash_loader.enter_loading_mode()
+
+        # clear the internal flash
+        flash_loader.clear_mram()
+
+        # write the new binary
+        flash_loader.write_image(application_gnm)
+
+        self.logger.info('Flashing SY1xx finished. You may reset the device.')

--- a/scripts/west_commands/tests/test_imports.py
+++ b/scripts/west_commands/tests/test_imports.py
@@ -51,6 +51,7 @@ def test_runner_imports():
         'spi_burn',
         'stm32cubeprogrammer',
         'stm32flash',
+        'sy1xx',
         'teensy',
         'trace32',
         'uf2',


### PR DESCRIPTION
- With this commit we add a runner that is capable of flashing the sensry sy1xx socs via uart to support the onboard OTP bootloader.
- Added the sy1xx runner to the list for automated test.
- Adding support for using west flash to install new firmware on the ganymed-bob (sy1xx based soc) board.

