### PR TITLE
linker: update section names to be unambiguous

### DIFF
--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -5240,8 +5240,8 @@ endfunction()
 # This is useful content such as struct devices.
 #
 # For example: zephyr_linker_section_obj_level(SECTION init LEVEL PRE_KERNEL_1)
-# will create an input section matching `.z_init_PRE_KERNEL_1_?_`,
-# `.z_init_PRE_KERNEL_1_??_`, and `.z_init_PRE_KERNEL_1_???_`.
+# will create an input section matching `.z_init_PRE_KERNEL_P_1_SUB_?_`,
+# `.z_init_PRE_KERNEL_P_1_SUB_??_`, and `.z_init_PRE_KERNEL_P_1_SUB_???_`.
 #
 # SECTION <section>: Section in which the objects shall be placed
 # LEVEL <level>    : Priority level, all input sections matching the level
@@ -5265,18 +5265,18 @@ function(zephyr_linker_section_obj_level)
 
   zephyr_linker_section_configure(
     SECTION ${OBJ_SECTION}
-    INPUT ".z_${OBJ_SECTION}_${OBJ_LEVEL}_?_*"
+    INPUT ".z_${OBJ_SECTION}_${OBJ_LEVEL}_P_?_*"
     SYMBOLS __${OBJ_SECTION}_${OBJ_LEVEL}_start
     KEEP SORT NAME
   )
   zephyr_linker_section_configure(
     SECTION ${OBJ_SECTION}
-    INPUT ".z_${OBJ_SECTION}_${OBJ_LEVEL}_??_*"
+    INPUT ".z_${OBJ_SECTION}_${OBJ_LEVEL}_P_??_*"
     KEEP SORT NAME
   )
   zephyr_linker_section_configure(
     SECTION ${OBJ_SECTION}
-    INPUT ".z_${OBJ_SECTION}_${OBJ_LEVEL}_???_*"
+    INPUT ".z_${OBJ_SECTION}_${OBJ_LEVEL}_P_???_*"
     KEEP SORT NAME
   )
 endfunction()

--- a/include/zephyr/init.h
+++ b/include/zephyr/init.h
@@ -109,8 +109,8 @@ struct init_entry {
  * level/priority/sub-priority.
  */
 #define Z_INIT_ENTRY_SECTION(level, prio, sub_prio)                                                \
-	__attribute__((                                                                            \
-		__section__(".z_init_" #level "_" STRINGIFY(prio)"_" STRINGIFY(sub_prio)"_")))
+	__attribute__((__section__(                                                                \
+		".z_init_" #level "_P_" STRINGIFY(prio) "_SUB_" STRINGIFY(sub_prio)"_")))
 
 /** @endcond */
 

--- a/include/zephyr/linker/linker-defs.h
+++ b/include/zephyr/linker/linker-defs.h
@@ -47,9 +47,9 @@
 /* clang-format off */
 #define CREATE_OBJ_LEVEL(object, level)				\
 		__##object##_##level##_start = .;		\
-		KEEP(*(SORT(.z_##object##_##level##_?_*)));	\
-		KEEP(*(SORT(.z_##object##_##level##_??_*)));	\
-		KEEP(*(SORT(.z_##object##_##level##_???_*)));
+		KEEP(*(SORT(.z_##object##_##level##_P_?_*)));	\
+		KEEP(*(SORT(.z_##object##_##level##_P_??_*)));	\
+		KEEP(*(SORT(.z_##object##_##level##_P_???_*)));
 /* clang-format on */
 
 /*


### PR DESCRIPTION
Recently 0ae0c3dc449 allowed for three digit priorities, this resulted in objects potentially matching multiple sections, for example:

```
.z_init_PRE_KERNEL_2_0_0_
.z_init_PRE_KERNEL_2_?_*
.z_init_PRE_KERNEL_2_???_*
```

This does not seem to be detected by ld, but the IAR linker emits a warning.

Add some extra qualifiers in the object section name to make it unambiguous, this has the extra value of making it easier to interpret, for example going from:

`.z_init_POST_KERNEL_90_00012_`

to

`.z_init_POST_KERNEL_P_90_SUB_00012_`