### PR TITLE
drivers: pinctrl: wch_20x_30x_afio: fix afio remap

### DIFF
--- a/drivers/pinctrl/pinctrl_wch_20x_30x_afio.c
+++ b/drivers/pinctrl/pinctrl_wch_20x_30x_afio.c
@@ -30,7 +30,6 @@ int pinctrl_configure_pins(const pinctrl_soc_pin_t *pins, uint8_t pin_cnt, uintp
 		uint8_t pcfr_id = FIELD_GET(CH32V20X_V30X_PINCTRL_PCFR_ID_MASK, pins->config);
 		uint8_t remap = FIELD_GET(CH32V20X_V30X_PINCTRL_RM_MASK, pins->config);
 		GPIO_TypeDef *regs = wch_afio_pinctrl_regs[port];
-		uint32_t pcfr = pcfr_id == 0 ? AFIO->PCFR1 : AFIO->PCFR2;
 		uint8_t cfg = 0;
 
 		if (pins->output_high || pins->output_low) {
@@ -69,19 +68,21 @@ int pinctrl_configure_pins(const pinctrl_soc_pin_t *pins, uint8_t pin_cnt, uintp
 			}
 		}
 
-		pcfr |= remap << bit0;
+		if (remap != 0) {
+			RCC->APB2PCENR |= RCC_AFIOEN;
 
-		if (pcfr_id == 0) {
-			AFIO->PCFR1 = pcfr;
-		} else {
-			AFIO->PCFR2 = pcfr;
-		}
-
-		if (bit0 == CH32V20X_V30X_PINMUX_USART1_RM) {
-			pcfr = AFIO->PCFR2;
-			pcfr |= ((uint32_t)((remap >> 1) & 1)
-				 << (CH32V20X_V30X_PINMUX_USART1_RM1 & 0x1F));
-			AFIO->PCFR2 = pcfr;
+			if (pcfr_id == 0 && bit0 == CH32V20X_V30X_PINMUX_USART1_RM) {
+				AFIO->PCFR1 |= ((uint32_t)((remap >> 0) & 1)
+					<< (CH32V20X_V30X_PINMUX_USART1_RM & 0x1F));
+				AFIO->PCFR2 |= ((uint32_t)((remap >> 1) & 1)
+					<< (CH32V20X_V30X_PINMUX_USART1_RM1 & 0x1F));
+			} else {
+				if (pcfr_id == 0) {
+					AFIO->PCFR1 |= (uint32_t)remap << bit0;
+				} else {
+					AFIO->PCFR2 |= (uint32_t)remap << bit0;
+				}
+			}
 		}
 	}
 

--- a/drivers/pinctrl/pinctrl_wch_afio.c
+++ b/drivers/pinctrl/pinctrl_wch_afio.c
@@ -25,12 +25,7 @@ int pinctrl_configure_pins(const pinctrl_soc_pin_t *pins, uint8_t pin_cnt, uintp
 		uint8_t bit0 = (pins->config >> CH32V003_PINCTRL_RM_BASE_SHIFT) & 0x1F;
 		uint8_t remap = (pins->config >> CH32V003_PINCTRL_RM_SHIFT) & 0x3;
 		GPIO_TypeDef *regs = wch_afio_pinctrl_regs[port];
-		uint32_t pcfr1 = AFIO->PCFR1;
 		uint8_t cfg = 0;
-
-		if (remap != 0) {
-			RCC->APB2PCENR |= RCC_AFIOEN;
-		}
 
 		if (pins->output_high || pins->output_low) {
 			cfg |= (pins->slew_rate + 1);
@@ -63,16 +58,23 @@ int pinctrl_configure_pins(const pinctrl_soc_pin_t *pins, uint8_t pin_cnt, uintp
 			}
 		}
 
-		if (bit0 == CH32V003_PINMUX_I2C1_RM) {
-			pcfr1 |= ((remap & 1) << CH32V003_PINMUX_I2C1_RM) |
-				 (((remap >> 1) & 1) << CH32V003_PINMUX_I2C1_RM1);
-		} else if (bit0 == CH32V003_PINMUX_USART1_RM) {
-			pcfr1 |= ((remap & 1) << CH32V003_PINMUX_USART1_RM) |
-				 (((remap >> 1) & 1) << CH32V003_PINMUX_USART1_RM1);
-		} else {
-			pcfr1 |= remap << bit0;
+		if (remap != 0) {
+			RCC->APB2PCENR |= RCC_AFIOEN;
+
+			if (bit0 == CH32V003_PINMUX_I2C1_RM) {
+				AFIO->PCFR1 |= ((uint32_t)((remap >> 0) & 1)
+							<< CH32V003_PINMUX_I2C1_RM) |
+					       ((uint32_t)((remap >> 1) & 1)
+							<< CH32V003_PINMUX_I2C1_RM1);
+			} else if (bit0 == CH32V003_PINMUX_USART1_RM) {
+				AFIO->PCFR1 |= ((uint32_t)((remap >> 0) & 1)
+							<< CH32V003_PINMUX_USART1_RM) |
+					       ((uint32_t)((remap >> 1) & 1)
+							<< CH32V003_PINMUX_USART1_RM1);
+			} else {
+				AFIO->PCFR1 |= (uint32_t)remap << bit0;
+			}
 		}
-		AFIO->PCFR1 = pcfr1;
 	}
 
 	return 0;


### PR DESCRIPTION
Enable the AFIO clock before remap. Otherwise, remap will not work.
Same as #83353 