### PR TITLE
MAINTAINERS: Add Tronil as collaborator for Bluetooth Controller

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -364,9 +364,9 @@ Bluetooth Controller:
     - carlescufi
     - thoh-ot
     - ppryga
-    - mtpr-ot
     - wopu-ot
     - erbr-ot
+    - Tronil
   files:
     - doc/connectivity/bluetooth/bluetooth-ctlr-arch.rst
     - doc/connectivity/bluetooth/img/ctlr*


### PR DESCRIPTION
Also removes mtpr-ot from collaborators (account is no longer active)