### PR TITLE
drivers: spi: cc13xx_cc26xx: Allow clocks below 2 MHz

### DIFF
--- a/drivers/spi/spi_cc13xx_cc26xx.c
+++ b/drivers/spi/spi_cc13xx_cc26xx.c
@@ -81,8 +81,9 @@ static int spi_cc13xx_cc26xx_configure(const struct device *dev,
 		return -EINVAL;
 	}
 
-	if (config->frequency < 2000000) {
-		LOG_ERR("Frequencies lower than 2 MHz are not supported");
+	if (config->frequency < CPU_FREQ / (254 * (255 + 1))) {
+		LOG_ERR("Frequencies lower than %d Hz are not supported",
+			CPU_FREQ / (254 * (255 + 1)));
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
Remove unnecessary check that the SPI clock is being set to a frequency above 2 MHz to allow devices running at common lower frequencies (i.e. 1.2 MHz and 400 kHz).

Replace with check that the frequency is not below the minimum frequency supported by the chipset to prevent overflow error which can occur if the HAL sets a frequency too low resulting in a SPI clock much larger than expected.

Fixes #69986