### PR TITLE
tests: float_disable: honor custom ARM interrupt controllers

### DIFF
--- a/tests/kernel/fpu_sharing/float_disable/src/k_float_disable.c
+++ b/tests/kernel/fpu_sharing/float_disable/src/k_float_disable.c
@@ -207,6 +207,16 @@ static void sup_fp_thread_entry(void *p1, void *p2, void *p3)
 			break;
 		}
 	}
+#elif defined(CONFIG_ARM_CUSTOM_INTERRUPT_CONTROLLER)
+	for (i = CONFIG_NUM_IRQS - 1; i >= 0; i--) {
+		if (z_soc_irq_is_enabled(i) == 0) {
+			/*
+			 * Similar to NVIC, get an IRQ line that is not enabled
+			 * with the custom ARM controller
+			 */
+			break;
+		}
+	}
 #else
 	/*
 	 * SGIs are always enabled by default, so choose the last one


### PR DESCRIPTION
This patch allows checking for any custom ARM interrupt controller to get a non-enabled IRQ line instead of assuming that GIC is enabled.

Test was failing with this PR: https://github.com/zephyrproject-rtos/zephyr/pull/87321 due to the missing GIC_PPI_INT_BASE symbol. TI R5 SoCs use the custom interrupt controller VIM, so used the `z_soc_irq*` API here