### PR TITLE
drivers: adc: nrfx_saadc: Add channel configuration validation for nrf54h20

### DIFF
--- a/drivers/adc/adc_nrfx_saadc.c
+++ b/drivers/adc/adc_nrfx_saadc.c
@@ -318,8 +318,13 @@ static int adc_nrfx_channel_setup(const struct device *dev,
 	}
 
 	if (config.mode == NRF_SAADC_MODE_DIFFERENTIAL) {
+#if defined(CONFIG_NRF_PLATFORM_HALTIUM)
+		if ((input_negative > NRF_SAADC_AIN7) !=
+		    (channel_cfg->input_positive > NRF_SAADC_AIN7)) {
+#else
 		if (input_negative > NRF_SAADC_AIN7 ||
 		    input_negative < NRF_SAADC_AIN0) {
+#endif
 			return -EINVAL;
 		}
 
@@ -719,6 +724,27 @@ static DEVICE_API(adc, adc_nrfx_driver_api) = {
 #endif
 };
 
+#if defined(CONFIG_NRF_PLATFORM_HALTIUM)
+/* AIN8-AIN14 inputs are on 3v3 GPIO port and they cannot be mixed with other
+ * analog inputs (from 1v8 ports) in differential mode.
+ */
+#define CH_IS_3V3(val) (val >= NRF_SAADC_AIN8)
+
+#define MIXED_3V3_1V8_INPUTS(node)					\
+	(DT_NODE_HAS_PROP(node, zephyr_input_negative) &&		\
+	 (CH_IS_3V3(DT_PROP_OR(node, zephyr_input_negative, 0)) !=	\
+	  CH_IS_3V3(DT_PROP_OR(node, zephyr_input_positive, 0))))
+#else
+#define MIXED_3V3_1V8_INPUTS(node) false
+#endif
+
+#define VALIDATE_CHANNEL_CONFIG(node)					\
+	BUILD_ASSERT(MIXED_3V3_1V8_INPUTS(node) == false,		\
+		     "1v8 inputs cannot be mixed with 3v3 inputs");
+
+/* Validate configuration of all channels. */
+#define VALIDATE_CHANNELS_CONFIG(inst) DT_FOREACH_CHILD(DT_DRV_INST(inst), VALIDATE_CHANNEL_CONFIG)
+
 /*
  * There is only one instance on supported SoCs, so inst is guaranteed
  * to be 0 if any instance is okay. (We use adc_0 above, so the driver
@@ -731,6 +757,7 @@ static DEVICE_API(adc, adc_nrfx_driver_api) = {
 #define SAADC_INIT(inst)						\
 	BUILD_ASSERT((inst) == 0,					\
 		     "multiple instances not supported");		\
+	VALIDATE_CHANNELS_CONFIG(inst)					\
 	PM_DEVICE_DT_INST_DEFINE(0, saadc_pm_hook, 1);			\
 	DEVICE_DT_INST_DEFINE(0,					\
 			    init_saadc,					\

--- a/samples/drivers/adc/adc_sequence/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/samples/drivers/adc/adc_sequence/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -45,6 +45,7 @@
 		zephyr,reference = "ADC_REF_INTERNAL";
 		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
 		zephyr,input-positive = <NRF_SAADC_AIN9>; /* P9.01 */
+		zephyr,vref-mv = <3686>; /* 3.6V * 1024 */
 		zephyr,resolution = <12>;
 		zephyr,oversampling = <8>;
 	};

--- a/samples/drivers/adc/adc_sequence/src/main.c
+++ b/samples/drivers/adc/adc_sequence/src/main.c
@@ -64,7 +64,7 @@ int main(void)
 			printf("Could not setup channel #%d (%d)\n", i, err);
 			return 0;
 		}
-		if (channel_cfgs[i].reference == ADC_REF_INTERNAL) {
+		if ((vrefs_mv[i] == 0) && (channel_cfgs[i].reference == ADC_REF_INTERNAL)) {
 			vrefs_mv[i] = adc_ref_internal(adc);
 		}
 	}


### PR DESCRIPTION
nrf54h20 has AIN8-AIN14 sources which require special handling:

## When differential mode is used then AIN0-7 cannot be mixed with AIN8-13.

PR adds channel validation macro which checks at compile time if differential channel configuration is correct.

## Result must be multiplied by 3.6 to get the actual value

There is no good way of adding 3.6 multiplier in the driver so only sample is modified. Channel that is using AIN8-AIN14 sources shell use `vref-mv` property set to `referece_mv * 3.6`.