### PR TITLE
drivers: timer: ti_dmtimer: provide timer IRQ for tests

### DIFF
--- a/drivers/timer/ti_dmtimer.c
+++ b/drivers/timer/ti_dmtimer.c
@@ -21,6 +21,10 @@
 #define TIMER_IRQ_PRIO  DT_INST_IRQ(0, priority)
 #define TIMER_IRQ_FLAGS DT_INST_IRQ(0, flags)
 
+#if defined(CONFIG_TEST)
+const int32_t z_sys_timer_irq_for_test = TIMER_IRQ_NUM;
+#endif
+
 #define CYC_PER_TICK ((uint32_t)(sys_clock_hw_cycles_per_sec() / CONFIG_SYS_CLOCK_TICKS_PER_SEC))
 
 #define MAX_TICKS ((k_ticks_t)(UINT32_MAX / CYC_PER_TICK) - 1)


### PR DESCRIPTION
This patch allows ti_dmtimer to provide the symbol z_sys_timer_irq_for_test whenever tests are enabled. Not providing this results in failing some kernel test cases which require this symbol.