### PR TITLE
Bluetooth: Host: Remove unused include

### DIFF
--- a/subsys/bluetooth/host/direction.c
+++ b/subsys/bluetooth/host/direction.c
@@ -16,7 +16,6 @@
 #include <zephyr/bluetooth/direction.h>
 
 #include "hci_core.h"
-#include "scan.h"
 #include "conn_internal.h"
 #include "direction_internal.h"
 


### PR DESCRIPTION
There's no need for scan.h in direction.c.