### PR TITLE
boards: lpcxpresso55s28: fix low RAM region size

### DIFF
--- a/boards/nxp/lpcxpresso55s28/lpcxpresso55s28.yaml
+++ b/boards/nxp/lpcxpresso55s28/lpcxpresso55s28.yaml
@@ -8,8 +8,8 @@ identifier: lpcxpresso55s28
 name: NXP LPCXpresso55S28
 type: mcu
 arch: arm
-ram: 64
-flash: 256
+ram: 192
+flash: 512
 toolchain:
   - zephyr
   - gnuarmemb

--- a/dts/arm/nxp/nxp_lpc55S2x.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S2x.dtsi
@@ -34,3 +34,12 @@
 &iap {
 	status = "okay";
 };
+
+/*
+ * lpc55S_2x:
+ * Combine SRAM0, SRAM1, SRAM2 for total of 192K RAM
+ */
+&sram0 {
+	compatible = "mmio-sram";
+	reg = <0x20000000 DT_SIZE_K(192)>;
+};

--- a/dts/arm/nxp/nxp_lpc55S2x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S2x_common.dtsi
@@ -46,8 +46,9 @@
 	#size-cells = <1>;
 
 	sramx: memory@4000000 {
-		compatible = "mmio-sram";
+		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0x4000000 DT_SIZE_K(32)>;
+		zephyr,memory-region = "SRAMX";
 	};
 
 	sram0: memory@20000000 {
@@ -56,17 +57,16 @@
 	};
 
 	sram1: memory@20010000 {
-		compatible = "zephyr,memory-region", "mmio-sram";
+		compatible = "mmio-sram";
 		reg = <0x20010000 DT_SIZE_K(64)>;
-		zephyr,memory-region = "SRAM1";
 	};
 
 	sram2: memory@20020000 {
-		compatible = "zephyr,memory-region", "mmio-sram";
+		compatible = "mmio-sram";
 		reg = <0x20020000 DT_SIZE_K(64)>;
-		zephyr,memory-region = "SRAM2";
 	};
 
+	/* SRAM 4 is used by PowerQuad when enabled */
 	sram4: memory@20040000 {
 		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0x20040000 DT_SIZE_K(16)>;


### PR DESCRIPTION
- Fixes RAM region size to 192KB for lpcxpresso55s28. It was 64KB.
- Adds SRAMX linker region.