### PR TITLE
boards: nxp: lpcxpresso55sXX: set LinkServer as the default runner.

### DIFF
--- a/boards/nxp/lpcxpresso55s06/board.cmake
+++ b/boards/nxp/lpcxpresso55s06/board.cmake
@@ -8,5 +8,5 @@
 board_runner_args(linkserver  "--device=LPC55S06:LPCXpresso55S06")
 board_runner_args(jlink "--device=LPC55S06" "--reset-after-load")
 
-include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/linkserver.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/nxp/lpcxpresso55s06/doc/index.rst
+++ b/boards/nxp/lpcxpresso55s06/doc/index.rst
@@ -120,19 +120,17 @@ and :ref:`application_run` for more details).
 Configuring a Debug Probe
 =========================
 
-A debug probe is used for both flashing and debugging the board. This
-board is configured by default to use the LPC-Link2 CMSIS-DAP Onboard
-Debug Probe, however the :ref:`pyocd-debug-host-tools` does not yet
-support the LPC55S06 so you must reconfigure the board for one of the
-J-Link debug probe instead.
+LinkServer is the default runner for this board.
+A debug probe is used for both flashing and debugging the board. This board is
+configured by default to use the integrated :ref:`mcu-link-onboard-debug-probe`
+in the CMSIS-DAP mode. To use this probe with Zephyr, you need to install the
+:ref:`linkserver-debug-host-tools` and make sure they are in your search path.
+Refer to the detailed overview about :ref:`application_debugging` for additional
+information.
 
-First install the :ref:`jlink-debug-host-tools` and make sure they are
-in your search path.
-
-Then follow the instructions in
-:ref:`lpclink2-jlink-onboard-debug-probe` to program the J-Link
-firmware. Please make sure you have the latest firmware for this
-board.
+The integrated MCU-Link hardware can also be used as a J-Link probe with a
+firmware update, as described in :ref:`mcu-link-jlink-onboard-debug-probe`.
+The :ref:`jlink-debug-host-tools` should be available in this case.
 
 Configuring a Console
 =====================

--- a/boards/nxp/lpcxpresso55s16/board.cmake
+++ b/boards/nxp/lpcxpresso55s16/board.cmake
@@ -9,6 +9,6 @@ board_runner_args(linkserver  "--device=LPC55S16:LPCXpresso55S16")
 board_runner_args(jlink "--device=LPC55S16" "--reset-after-load")
 board_runner_args(pyocd "--target=lpc55s16")
 
-include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/linkserver.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)

--- a/boards/nxp/lpcxpresso55s16/doc/index.rst
+++ b/boards/nxp/lpcxpresso55s16/doc/index.rst
@@ -155,19 +155,17 @@ and :ref:`application_run` for more details).
 Configuring a Debug Probe
 =========================
 
-A debug probe is used for both flashing and debugging the board. This
-board is configured by default to use the LPC-Link2 CMSIS-DAP Onboard
-Debug Probe, however the :ref:`pyocd-debug-host-tools` does not yet
-support the LPC55S16 so you must reconfigure the board for one of the
-J-Link debug probe instead.
+LinkServer is the default runner for this board.
+A debug probe is used for both flashing and debugging the board. This board is
+configured by default to use the integrated :ref:`mcu-link-onboard-debug-probe`
+in the CMSIS-DAP mode. To use this probe with Zephyr, you need to install the
+:ref:`linkserver-debug-host-tools` and make sure they are in your search path.
+Refer to the detailed overview about :ref:`application_debugging` for additional
+information.
 
-First install the :ref:`jlink-debug-host-tools` and make sure they are
-in your search path.
-
-Then follow the instructions in
-:ref:`lpclink2-jlink-onboard-debug-probe` to program the J-Link
-firmware. Please make sure you have the latest firmware for this
-board.
+The integrated MCU-Link hardware can also be used as a J-Link probe with a
+firmware update, as described in :ref:`mcu-link-jlink-onboard-debug-probe`.
+The :ref:`jlink-debug-host-tools` should be available in this case.
 
 Configuring a Console
 =====================

--- a/boards/nxp/lpcxpresso55s28/board.cmake
+++ b/boards/nxp/lpcxpresso55s28/board.cmake
@@ -8,6 +8,6 @@ board_runner_args(linkserver  "--device=LPC55S28:LPCXpresso55S28")
 board_runner_args(pyocd "--target=lpc55s28")
 board_runner_args(jlink "--device=LPC55S28" "--reset-after-load")
 
-include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/linkserver.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)

--- a/boards/nxp/lpcxpresso55s28/doc/index.rst
+++ b/boards/nxp/lpcxpresso55s28/doc/index.rst
@@ -139,9 +139,17 @@ and :ref:`application_run` for more details).
 Configuring a Debug Probe
 =========================
 
-A debug probe is used for both flashing and debugging the board. This
-board is configured by default to use the LPC-Link2 CMSIS-DAP Onboard
-Debug Probe.
+LinkServer is the default runner for this board.
+A debug probe is used for both flashing and debugging the board. This board is
+configured by default to use the integrated :ref:`mcu-link-onboard-debug-probe`
+in the CMSIS-DAP mode. To use this probe with Zephyr, you need to install the
+:ref:`linkserver-debug-host-tools` and make sure they are in your search path.
+Refer to the detailed overview about :ref:`application_debugging` for additional
+information.
+
+The integrated MCU-Link hardware can also be used as a J-Link probe with a
+firmware update, as described in :ref:`mcu-link-jlink-onboard-debug-probe`.
+The :ref:`jlink-debug-host-tools` should be available in this case.
 
 Configuring a Console
 =====================

--- a/boards/nxp/lpcxpresso55s36/board.cmake
+++ b/boards/nxp/lpcxpresso55s36/board.cmake
@@ -8,6 +8,6 @@ board_runner_args(linkserver  "--device=LPC55S36:LPCXpresso55S36")
 board_runner_args(jlink "--device=LPC55S36" "--reset-after-load")
 board_runner_args(pyocd "--target=lpc55s36")
 
-include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/linkserver.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)

--- a/boards/nxp/lpcxpresso55s36/doc/index.rst
+++ b/boards/nxp/lpcxpresso55s36/doc/index.rst
@@ -159,12 +159,12 @@ and :ref:`application_run` for more details).
 Configuring a Debug Probe
 =========================
 
+LinkServer is the default runner for this board.
 A debug probe is used for both flashing and debugging the board. This board is
 configured by default to use the integrated :ref:`mcu-link-onboard-debug-probe`
 in the CMSIS-DAP mode. To use this probe with Zephyr, you need to install the
 :ref:`linkserver-debug-host-tools` and make sure they are in your search path.
-Then, use the ``linkserver`` runner option to flash and debug the board. Refer
-to the detailed overview about :ref:`application_debugging` for additional
+Refer to the detailed overview about :ref:`application_debugging` for additional
 information.
 
 The integrated MCU-Link hardware can also be used as a J-Link probe with a

--- a/boards/nxp/lpcxpresso55s69/doc/index.rst
+++ b/boards/nxp/lpcxpresso55s69/doc/index.rst
@@ -275,32 +275,15 @@ Configuring a Debug Probe
 
 LinkServer is the default runner for this board.
 A debug probe is used for both flashing and debugging the board. This board is
-configured by default to use the LPC-Link2 CMSIS-DAP Onboard Debug Probe,
-however the :ref:`pyocd-debug-host-tools` does not yet support this probe so you
-must reconfigure the board for one of the following debug probes instead.
+configured by default to use the integrated :ref:`mcu-link-onboard-debug-probe`
+in the CMSIS-DAP mode. To use this probe with Zephyr, you need to install the
+:ref:`linkserver-debug-host-tools` and make sure they are in your search path.
+Refer to the detailed overview about :ref:`application_debugging` for additional
+information.
 
-:ref:`lpclink2-jlink-onboard-debug-probe`
------------------------------------------
-
-Install the :ref:`jlink-debug-host-tools` and make sure they are in your search
-path.
-
-Follow the instructions in :ref:`lpclink2-jlink-onboard-debug-probe` to program
-the J-Link firmware. Please make sure you have the latest firmware for this
-board.
-
-:ref:`lpclink2-cmsis-onboard-debug-probe`
------------------------------------------
-
-        1. Install the :ref:`linkserver-debug-host-tools` and make sure they are in your search path.
-        2. To update the debug firmware, please follow the instructions on `LPCXPRESSO55S69 Debug Firmware`_
-
-:ref:`opensda-daplink-onboard-debug-probe`
-------------------------------------------
-
-PyOCD support for this board is ongoing and not yet available.
-To use DAPLink's flash memory programming on this board, follow the instructions
-for `updating LPCXpresso firmware`_.
+The integrated MCU-Link hardware can also be used as a J-Link probe with a
+firmware update, as described in :ref:`mcu-link-jlink-onboard-debug-probe`.
+The :ref:`jlink-debug-host-tools` should be available in this case.
 
 Configuring a Console
 =====================


### PR DESCRIPTION
- Sets LinkServer as the default runner for lpcxpresso55sXX boards.
- Unifies the "Configuring a Debug Probe" chapter for lpcxpresso55sXX boards.