### PR TITLE
samples: boards: Add mco support for nucleo_wl55jc board 

### DIFF
--- a/dts/arm/st/wl/stm32wl.dtsi
+++ b/dts/arm/st/wl/stm32wl.dtsi
@@ -106,6 +106,13 @@
 		};
 	};
 
+	mcos {
+		mco1: mco1 {
+			compatible = "st,stm32-clock-mco";
+			status = "disabled";
+		};
+	};
+
 	soc {
 		flash: flash-controller@58004000 {
 			compatible = "st,stm32-flash-controller", "st,stm32l4-flash-controller";

--- a/include/zephyr/dt-bindings/clock/stm32wl_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32wl_clock.h
@@ -44,6 +44,9 @@
 /** @brief RCC_BDCR register offset */
 #define BDCR_REG		0x90
 
+/** @brief RCC_CFGRx register offset */
+#define CFGR1_REG        0x08
+
 /** @brief Device domain clocks selection helpers */
 /** CCIPR devices */
 #define USART1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 3, 0, CCIPR_REG)
@@ -60,5 +63,27 @@
 #define RNG_SEL(val)		STM32_DT_CLOCK_SELECT((val), 3, 30, CCIPR_REG)
 /** BDCR devices */
 #define RTC_SEL(val)		STM32_DT_CLOCK_SELECT((val), 3, 8, BDCR_REG)
+/** CFGR1 devices */
+#define MCO1_SEL(val)       STM32_DT_CLOCK_SELECT(val, 0xF, 24, CFGR1_REG)
+#define MCO1_PRE(val)       STM32_DT_CLOCK_SELECT(val, 0x7, 28, CFGR1_REG)
+
+/* MCO prescaler : division factor */
+#define MCO_PRE_DIV_1  0
+#define MCO_PRE_DIV_2  1
+#define MCO_PRE_DIV_4  2
+#define MCO_PRE_DIV_8  3
+#define MCO_PRE_DIV_16 4
+
+/* MCO clock output */
+#define MCO_SEL_NOCLK     0
+#define MCO_SEL_SYSCLKPRE 1
+#define MCO_SEL_MSI       2
+#define MCO_SEL_HSI16     3
+#define MCO_SEL_HSE32     4
+#define MCO_SEL_PLL1RCLK  5
+#define MCO_SEL_LSI       6
+#define MCO_SEL_LSE       8
+#define MCO_SEL_PLL1PCLK  13
+#define MCO_SEL_PLL1QCLK  14
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32WL_CLOCK_H_ */

--- a/samples/boards/st/mco/boards/nucleo_wl55jc.overlay
+++ b/samples/boards/st/mco/boards/nucleo_wl55jc.overlay
@@ -1,0 +1,18 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2025 STMicroelectronics
+ */
+
+/* Enable the clock we are going to output */
+&clk_lse {
+	status = "okay";
+};
+
+&mco1 {
+	status = "okay";
+	clocks = <&rcc STM32_SRC_LSE MCO1_SEL(MCO_SEL_LSE)>;
+	prescaler = <MCO1_PRE(MCO_PRE_DIV_1)>;
+	pinctrl-0 = <&rcc_mco_pa8>;
+	pinctrl-names = "default";
+};

--- a/samples/boards/st/mco/sample.yaml
+++ b/samples/boards/st/mco/sample.yaml
@@ -9,6 +9,7 @@ tests:
       - stm32f746g_disco
       - nucleo_u5a5zj_q
       - nucleo_wba55cg
+      - nucleo_wl55jc
     integration_platforms:
       - stm32f746g_disco
     tags: board


### PR DESCRIPTION
# Description
This PR add mco support for stm32wl, and adapt the sampel for nucleo_wl55jc

# Test steps

- Run the mco sample using nucleo_wl55jc and check the signal on the mco pin (PA8).

Signed-off-by: Martdur <martin.durietz@gmail.com>