### PR TITLE
twister: Fix quarantine filtering simulations

### DIFF
--- a/doc/develop/test/twister.rst
+++ b/doc/develop/test/twister.rst
@@ -1491,10 +1491,11 @@ The current status of tests on the quarantine list can also be verified by addin
 ``--quarantine-verify`` to the above argument. This will make twister skip all tests
 which are not on the given list.
 
-A quarantine yaml has to be a sequence of dictionaries. Each dictionary has to have
-``scenarios`` and ``platforms`` entries listing combinations of scenarios and platforms
-to put under quarantine. In addition, an optional entry ``comment`` can be used, where
-some more details can be given (e.g. link to a reported issue). These comments will also
+A quarantine yaml is a sequence of dictionaries. Each dictionary must have
+at least one of the following keys: ``scenarios``, ``platforms``, ``architectures``
+or ``simulations``. A combination of these entries is allowed.
+An optional ``comment`` entry can be used to provide more details
+(e.g., a link to a reported issue). These comments will also
 be added to the output reports.
 
 When quarantining a class of tests or many scenarios in a single testsuite or
@@ -1518,15 +1519,15 @@ An example of entries in a quarantine yaml:
         - .*_cortex_.*
         - native_sim
 
-To exclude a platform, use the following syntax:
-
-.. code-block:: yaml
-
     - platforms:
-      - qemu_x86
-      comment: "broken qemu"
+        - qemu_x86
+      comment: "filter out qemu_x86"
 
-Additionally you can quarantine entire architectures or a specific simulator for executing tests.
+    - architectures:
+        - riscv
+
+    - simulations:
+        - armfvp
 
 Test Configuration
 ******************

--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -595,12 +595,14 @@ class TestPlan:
 
     def handle_quarantined_tests(self, instance: TestInstance, plat: Platform):
         if self.quarantine:
-            simulator = plat.simulator_by_name(self.options)
+            sim_name = plat.simulation
+            if sim_name != "na" and (simulator := plat.simulator_by_name(self.options.sim_name)):
+                sim_name = simulator.name
             matched_quarantine = self.quarantine.get_matched_quarantine(
                 instance.testsuite.id,
                 plat.name,
                 plat.arch,
-                simulator.name if simulator is not None else 'na'
+                sim_name
             )
             if matched_quarantine and not self.options.quarantine_verify:
                 instance.add_filter("Quarantine: " + matched_quarantine, Filters.QUARANTINE)


### PR DESCRIPTION
Quarantine filter was not correctly identifying the simulator name. Now it uses the simulator name from the Platform object, ensuring that quarantined tests are properly excluded or verified.

Tested with:
* mps2/an521/cpu0 supports two simulators: https://github.com/zephyrproject-rtos/zephyr/blob/main/boards/arm/mps2/mps2_an521_cpu0.yaml#L7

Create `quarantine.yaml` file:
```
cat quarantine.yaml
- simulations:
  - armfvp
  comment: "armfvp"
- simulations:
  - qemu
  comment: "qemu"
```
Check if quarantine works for the default simulations (qemu):
`./scripts/twister -T samples/hello_world -p mps2/an521/cpu0 -vv -ll debug -c --quarantine-list quarantine.yaml`
logged:
`DEBUG   - mps2/an521/cpu0           samples/hello_world/sample.basic.helloworld        FILTERED: Quarantine: qemu`

Check if quarantine works with non-default simulator (armfvp):
`./scripts/twister -T samples/hello_world -p mps2/an521/cpu0 -vv -ll debug -c --simulation armfvp --quarantine-list quarantine.yaml`
logged:
`DEBUG   - mps2/an521/cpu0           samples/hello_world/sample.basic.helloworld        FILTERED: Quarantine: armfvp`

Run with other simulations:
`./scripts/twister -T samples/hello_world -p qemu_x86 -p native_sim -vv -ll debug -c --quarantine-list quarantine.yaml`
logged
```
DEBUG   - qemu_x86/atom             samples/hello_world/sample.basic.helloworld        FILTERED: Quarantine: qemu
...
INFO    - 1/1 native_sim/native         samples/hello_world/sample.basic.helloworld        PASSED (native 2.623s <host>)
```

Issue introduced by: https://github.com/zephyrproject-rtos/zephyr/pull/79174
