### PR TITLE
Fix for debugging when trying to load to ram.

### DIFF
--- a/boards/nxp/mimxrt1170_evk/board.cmake
+++ b/boards/nxp/mimxrt1170_evk/board.cmake
@@ -6,7 +6,7 @@
 
 if(CONFIG_SOC_MIMXRT1176_CM7 OR CONFIG_SECOND_CORE_MCUX)
  board_runner_args(pyocd "--target=mimxrt1170_cm7")
- board_runner_args(jlink "--device=MIMXRT1176xxxA_M7" "--reset-after-load")
+ board_runner_args(jlink "--device=MIMXRT1176xxxA_M7")
  # ITCM is not defined in RT1170's LinkServer device file
  board_runner_args(linkserver "--override=/device/memory/-=\{\"location\":\"0x00000000\",\
                                \"size\":\"0x00040000\",\"type\":\"RAM\"\}")
@@ -28,6 +28,11 @@ elseif(CONFIG_SOC_MIMXRT1176_CM4)
   board_runner_args(linkserver "--device=MIMXRT1176xxxxx:MIMXRT1170-EVKB")
  endif()
  board_runner_args(linkserver "--core=cm4")
+endif()
+
+if(NOT SYSBUILD)
+  board_runner_args(jlink "--no-reset")
+  board_runner_args(linkserver "--no-reset")
 endif()
 
 include(${ZEPHYR_BASE}/boards/common/linkserver.board.cmake)

--- a/boards/nxp/mimxrt1170_evk/board.cmake
+++ b/boards/nxp/mimxrt1170_evk/board.cmake
@@ -7,9 +7,6 @@
 if(CONFIG_SOC_MIMXRT1176_CM7 OR CONFIG_SECOND_CORE_MCUX)
  board_runner_args(pyocd "--target=mimxrt1170_cm7")
  board_runner_args(jlink "--device=MIMXRT1176xxxA_M7")
- # ITCM is not defined in RT1170's LinkServer device file
- board_runner_args(linkserver "--override=/device/memory/-=\{\"location\":\"0x00000000\",\
-                               \"size\":\"0x00040000\",\"type\":\"RAM\"\}")
 
  if(${BOARD_REVISION} STREQUAL "A")
   board_runner_args(linkserver  "--device=MIMXRT1176xxxxx:MIMXRT1170-EVK")

--- a/scripts/west_commands/runners/linkserver.py
+++ b/scripts/west_commands/runners/linkserver.py
@@ -150,7 +150,10 @@ class LinkServerBinaryRunner(ZephyrBinaryRunner):
                            ['-ex', f'target remote {self.gdb_host}:{self.gdb_port}'])
 
                 if command == 'debug':
-                    gdb_cmd += [ '-ex', 'load', '-ex', 'monitor reset']
+                    # If the flash node points to ram, linkserver treats
+                    # the ram as inaccessible and does not flash.
+                    gdb_cmd += ['-ex', 'set mem inaccessible-by-default off']
+                    gdb_cmd += ['-ex', 'monitor reset', '-ex', 'load']
 
                 if command == 'attach':
                     linkserver_cmd += ['--attach']


### PR DESCRIPTION
Fixes #87422 
When users try to debug while flashing into ram,
JLink/Linkserver would fail to flash straight to ram. Each with their own issues. Both would reset after load which would flush the ram and point the PC to flash. Linkserver treated the ram as inaccessible, and the added memory region in board.cmake has the incorrect size for the region and is already included inside linkserver.