### PR TITLE
llext-edk: fix BOARD_TARGET variable generation to be Zephyr-compatible

### DIFF
--- a/cmake/llext-edk.cmake
+++ b/cmake/llext-edk.cmake
@@ -166,8 +166,7 @@ yaml_get(board_qualifiers NAME build_info KEY cmake board qualifiers)
 yaml_get(board_revision NAME build_info KEY cmake board revision)
 zephyr_build_string(normalized_board_target
     BOARD ${board_name}
-    BOARD_QUALIFIERS ${board_qualifiers}
-    BOARD_REVISION ${board_revision})
+    BOARD_QUALIFIERS ${board_qualifiers})
 
 set(llext_edk_name ${CONFIG_LLEXT_EDK_NAME})
 set(llext_edk ${PROJECT_BINARY_DIR}/${llext_edk_name})


### PR DESCRIPTION

The board revision is not part of the `NORMALIZED_BOARD_TARGET` variable as composed by Zephyr:

https://github.com/zephyrproject-rtos/zephyr/blob/d19abff47665165243c78aa8801ab302968487fa/cmake/modules/boards.cmake#L311-L312

... so it must also not be used in the EDK exported value to avoid mismatches. 

This fixes the new board information recently (post-4.1) added by #86655. The revision was already exported as a separate variable, so can still be used as a differentiator if needed.