### PR TITLE
Bluetooth: Mesh: Fix proxy advertiser handling with GATT server enabled

### DIFF
--- a/subsys/bluetooth/mesh/adv_ext.c
+++ b/subsys/bluetooth/mesh/adv_ext.c
@@ -317,11 +317,16 @@ static void start_proxy_sol_or_proxy_adv(struct bt_mesh_ext_adv *ext_adv)
 		}
 	}
 
-	if (IS_ENABLED(CONFIG_BT_MESH_GATT_SERVER) &&
-	    !atomic_test_and_set_bit(ext_adv->flags, ADV_FLAG_PROXY)) {
-		if (bt_mesh_adv_gatt_send()) {
-			atomic_clear_bit(ext_adv->flags, ADV_FLAG_PROXY);
+	if (IS_ENABLED(CONFIG_BT_MESH_GATT_SERVER)) {
+		if (stop_proxy_adv(ext_adv)) {
 			return;
+		}
+
+		if (!atomic_test_and_set_bit(ext_adv->flags, ADV_FLAG_PROXY)) {
+			if (bt_mesh_adv_gatt_send()) {
+				atomic_clear_bit(ext_adv->flags, ADV_FLAG_PROXY);
+				return;
+			}
 		}
 	}
 }


### PR DESCRIPTION
When the GATT server is enabled the proxy advertiser server need to be stopped. This solved a bug where the
Mesh Proxy Service is not restarted.
This fix is done to fix several failing PTS test that was failing when CONFIG_BT_MESH_ADV_EXT_GATT_SEPARATE was enabled. Calling the stop_proxy_adv was left out in a previous commit when doing code cleanup.