### PR TITLE
drivers: intc_ioapic: Fix Out of Bounds shift

### DIFF
--- a/drivers/interrupt_controller/intc_ioapic.c
+++ b/drivers/interrupt_controller/intc_ioapic.c
@@ -84,7 +84,7 @@ DEVICE_MMIO_TOPLEVEL_STATIC(ioapic_regs, DT_DRV_INST(0));
  * In either case, regardless how many CPUs in the system, 0xff implies that
  * it's intended to deliver to all possible 8 local APICs.
  */
-#define DEFAULT_RTE_DEST	(0xFF << 24)
+#define DEFAULT_RTE_DEST (0xFFU << 24)
 
 static __pinned_bss uint32_t ioapic_rtes;
 


### PR DESCRIPTION
Hexadecimal integer literals are signed if they can fit into a signed int, which causes undefined behavior.

This happens here because 0xFF can fit into a signed int and then gets left-shifted by 24, which causes undefined behavior for signed integers.