### PR TITLE
ESP32 related snippets

### DIFF
--- a/boards/espressif/common/board-variants.rst
+++ b/boards/espressif/common/board-variants.rst
@@ -1,0 +1,45 @@
+:orphan:
+
+.. espressif-board-variants
+
+Board variants using Snippets
+=============================
+
+ESP32 boards can be assembled with different modules using multiple combinations of SPI flash sizes, PSRAM sizes and PSRAM modes.
+The snippets under ``snippets/espressif`` provide a modular way to apply these variations at build time without duplicating board definitions.
+
+The following snippet-based variants are supported:
+
+===============  ========================
+Snippet name     Description
+===============  ========================
+*Flash memory size*
+-----------------------------------------
+``flash-4M``     Board with 4MB of flash
+``flash-8M``     Board with 8MB of flash
+``flash-16M``    Board with 16MB of flash
+``flash-32M``    Board with 32MB of flash
+---------------  ------------------------
+*PSRAM memory size*
+-----------------------------------------
+``psram-2M``     Board with 2MB of PSRAM
+``psram-4M``     Board with 4MB of PSRAM
+``psram-8M``     Board with 8MB of PSRAM
+---------------  ------------------------
+*PSRAM utilization*
+-----------------------------------------
+``psram-reloc``  Relocate flash to PSRAM
+``psram-wifi``   Wi-Fi buffers in PSRAM
+===============  ========================
+
+To apply a board variant, use the ``-S`` flag with west build:
+
+.. zephyr-app-commands::
+   :tool: west
+   :zephyr-app: samples/hello_world
+   :board: <esp_board_name_qualifier>
+   :goals: build
+   :west-args: -S flash-32M -S psram-4M
+   :compact:
+
+**Note:** These snippets are applicable to boards with compatible hardware support for the selected flash/PSRAM configuration.

--- a/boards/espressif/esp32_devkitc/doc/index.rst
+++ b/boards/espressif/esp32_devkitc/doc/index.rst
@@ -190,6 +190,9 @@ message in the monitor:
    ***** Booting Zephyr OS vx.x.x-xxx-gxxxxxxxxxxxx *****
    Hello World! esp32_devkitc
 
+.. include:: ../../../espressif/common/board-variants.rst
+   :start-after: espressif-board-variants
+
 Debugging
 *********
 

--- a/boards/espressif/esp32_ethernet_kit/doc/index.rst
+++ b/boards/espressif/esp32_ethernet_kit/doc/index.rst
@@ -551,6 +551,9 @@ message in the monitor:
    ***** Booting Zephyr OS vx.x.x-xxx-gxxxxxxxxxxxx *****
    Hello World! esp32_ethernet_kit
 
+.. include:: ../../../espressif/common/board-variants.rst
+   :start-after: espressif-board-variants
+
 Debugging
 *********
 

--- a/boards/espressif/esp32c3_devkitc/doc/index.rst
+++ b/boards/espressif/esp32c3_devkitc/doc/index.rst
@@ -182,6 +182,9 @@ message in the monitor:
    ***** Booting Zephyr OS vx.x.x-xxx-gxxxxxxxxxxxx *****
    Hello World! esp32c3_devkitc
 
+.. include:: ../../../espressif/common/board-variants.rst
+   :start-after: espressif-board-variants
+
 Debugging
 *********
 

--- a/boards/espressif/esp32c3_devkitm/doc/index.rst
+++ b/boards/espressif/esp32c3_devkitm/doc/index.rst
@@ -182,6 +182,9 @@ message in the monitor:
    ***** Booting Zephyr OS vx.x.x-xxx-gxxxxxxxxxxxx *****
    Hello World! esp32c3_devkitm
 
+.. include:: ../../../espressif/common/board-variants.rst
+   :start-after: espressif-board-variants
+
 Debugging
 *********
 

--- a/boards/espressif/esp32c3_rust/doc/index.rst
+++ b/boards/espressif/esp32c3_rust/doc/index.rst
@@ -227,6 +227,9 @@ message in the monitor:
    ***** Booting Zephyr OS vx.x.x-xxx-gxxxxxxxxxxxx *****
    Hello World! esp32c3_rust
 
+.. include:: ../../../espressif/common/board-variants.rst
+   :start-after: espressif-board-variants
+
 Debugging
 *********
 

--- a/boards/espressif/esp32c6_devkitc/doc/index.rst
+++ b/boards/espressif/esp32c6_devkitc/doc/index.rst
@@ -224,6 +224,9 @@ message in the monitor:
    ***** Booting Zephyr OS vx.x.x-xxx-gxxxxxxxxxxxx *****
    Hello World! esp32c6_devkitc/esp32c6/hpcore
 
+.. include:: ../../../espressif/common/board-variants.rst
+   :start-after: espressif-board-variants
+
 Debugging
 *********
 

--- a/boards/espressif/esp32s2_devkitc/doc/index.rst
+++ b/boards/espressif/esp32s2_devkitc/doc/index.rst
@@ -181,6 +181,9 @@ message in the monitor:
    ***** Booting Zephyr OS vx.x.x-xxx-gxxxxxxxxxxxx *****
    Hello World! esp32s2_devkitc
 
+.. include:: ../../../espressif/common/board-variants.rst
+   :start-after: espressif-board-variants
+
 Debugging
 *********
 

--- a/boards/espressif/esp32s2_saola/doc/index.rst
+++ b/boards/espressif/esp32s2_saola/doc/index.rst
@@ -181,6 +181,9 @@ message in the monitor:
    ***** Booting Zephyr OS vx.x.x-xxx-gxxxxxxxxxxxx *****
    Hello World! esp32s2_saola
 
+.. include:: ../../../espressif/common/board-variants.rst
+   :start-after: espressif-board-variants
+
 Debugging
 *********
 

--- a/boards/espressif/esp32s3_devkitc/doc/index.rst
+++ b/boards/espressif/esp32s3_devkitc/doc/index.rst
@@ -218,6 +218,9 @@ message in the monitor:
    ***** Booting Zephyr OS vx.x.x-xxx-gxxxxxxxxxxxx *****
    Hello World! esp32s3_devkitc
 
+.. include:: ../../../espressif/common/board-variants.rst
+   :start-after: espressif-board-variants
+
 Debugging
 *********
 

--- a/boards/espressif/esp32s3_devkitm/doc/index.rst
+++ b/boards/espressif/esp32s3_devkitm/doc/index.rst
@@ -218,6 +218,9 @@ message in the monitor:
    ***** Booting Zephyr OS vx.x.x-xxx-gxxxxxxxxxxxx *****
    Hello World! esp32s3_devkitm
 
+.. include:: ../../../espressif/common/board-variants.rst
+   :start-after: espressif-board-variants
+
 Debugging
 *********
 

--- a/boards/espressif/esp32s3_eye/doc/index.rst
+++ b/boards/espressif/esp32s3_eye/doc/index.rst
@@ -253,6 +253,9 @@ message in the monitor:
    ***** Booting Zephyr OS vx.x.x-xxx-gxxxxxxxxxxxx *****
    Hello World! esp32s3_eye/esp32s3/procpu
 
+.. include:: ../../../espressif/common/board-variants.rst
+   :start-after: espressif-board-variants
+
 Debugging
 *********
 

--- a/boards/espressif/esp8684_devkitm/doc/index.rst
+++ b/boards/espressif/esp8684_devkitm/doc/index.rst
@@ -188,6 +188,9 @@ message in the monitor:
    ***** Booting Zephyr OS vx.x.x-xxx-gxxxxxxxxxxxx *****
    Hello World! esp8684_devkitm
 
+.. include:: ../../../espressif/common/board-variants.rst
+   :start-after: espressif-board-variants
+
 Debugging
 *********
 

--- a/boards/espressif/esp_wrover_kit/doc/index.rst
+++ b/boards/espressif/esp_wrover_kit/doc/index.rst
@@ -581,6 +581,9 @@ message in the monitor:
    ***** Booting Zephyr OS vx.x.x-xxx-gxxxxxxxxxxxx *****
    Hello World! esp_wrover_kit
 
+.. include:: ../../../espressif/common/board-variants.rst
+   :start-after: espressif-board-variants
+
 Debugging
 *********
 

--- a/snippets/espressif/flash-16M/README.rst
+++ b/snippets/espressif/flash-16M/README.rst
@@ -1,0 +1,9 @@
+.. _espressif-flash-16M:
+
+Espressif Flash 16MB
+####################
+
+Overview
+********
+
+This snippet allows users to select the 16MB SPI flash variant of the ESP32 chips.

--- a/snippets/espressif/flash-16M/snippet.yml
+++ b/snippets/espressif/flash-16M/snippet.yml
@@ -1,0 +1,22 @@
+# Copyright 2025 Espressif Systems Shanghai
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: flash-16M
+
+boards:
+  /.*/esp32/.*/:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: soc/esp32_flash_16M.overlay
+  /.*/esp32s2/.*/:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: soc/esp32s2_flash_16M.overlay
+  /.*/esp32s3/.*/:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: soc/esp32s3_flash_16M.overlay
+  /.*/esp32c3/.*/:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: soc/esp32c3_flash_16M.overlay
+  /.*/esp32c6/.*/:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: soc/esp32c6_flash_16M.overlay

--- a/snippets/espressif/flash-16M/soc/esp32_flash_16M.overlay
+++ b/snippets/espressif/flash-16M/soc/esp32_flash_16M.overlay
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2025 Espressif Systems (Shanghai) Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/delete-node/ &flash0;
+
+#include <espressif/esp32/esp32_common.dtsi>
+#include <espressif/partitions_0x1000_amp_16M.dtsi>
+
+&flash0 {
+	reg = <0x0 DT_SIZE_M(16)>;
+};

--- a/snippets/espressif/flash-16M/soc/esp32c3_flash_16M.overlay
+++ b/snippets/espressif/flash-16M/soc/esp32c3_flash_16M.overlay
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2025 Espressif Systems (Shanghai) Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/delete-node/ &flash0;
+
+#include <espressif/esp32c3/esp32c3_common.dtsi>
+#include <espressif/partitions_0x0_default_16M.dtsi>
+
+&flash0 {
+	reg = <0x0 DT_SIZE_M(16)>;
+};

--- a/snippets/espressif/flash-16M/soc/esp32c6_flash_16M.overlay
+++ b/snippets/espressif/flash-16M/soc/esp32c6_flash_16M.overlay
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2025 Espressif Systems (Shanghai) Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/delete-node/ &flash0;
+
+#include <espressif/esp32c6/esp32c6_common.dtsi>
+#include <espressif/partitions_0x0_default_16M.dtsi>
+
+&flash0 {
+	reg = <0x0 DT_SIZE_M(16)>;
+};

--- a/snippets/espressif/flash-16M/soc/esp32s2_flash_16M.overlay
+++ b/snippets/espressif/flash-16M/soc/esp32s2_flash_16M.overlay
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2025 Espressif Systems (Shanghai) Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/delete-node/ &flash0;
+
+#include <espressif/esp32s2/esp32s2_common.dtsi>
+#include <espressif/partitions_0x0_amp_16M.dtsi>
+
+&flash0 {
+	reg = <0x0 DT_SIZE_M(16)>;
+};

--- a/snippets/espressif/flash-16M/soc/esp32s3_flash_16M.overlay
+++ b/snippets/espressif/flash-16M/soc/esp32s3_flash_16M.overlay
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2025 Espressif Systems (Shanghai) Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/delete-node/ &flash0;
+
+#include <espressif/esp32s3/esp32s3_common.dtsi>
+#include <espressif/partitions_0x0_amp_16M.dtsi>
+
+&flash0 {
+	reg = <0x0 DT_SIZE_M(16)>;
+};

--- a/snippets/espressif/flash-32M/README.rst
+++ b/snippets/espressif/flash-32M/README.rst
@@ -1,0 +1,9 @@
+.. _espressif-flash-32M:
+
+Espressif Flash 32MB
+####################
+
+Overview
+********
+
+This snippet allows users to select the 32MB SPI flash variant of the ESP32 chips.

--- a/snippets/espressif/flash-32M/snippet.yml
+++ b/snippets/espressif/flash-32M/snippet.yml
@@ -1,0 +1,22 @@
+# Copyright 2025 Espressif Systems Shanghai
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: flash-32M
+
+boards:
+  /.*/esp32/.*/:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: soc/esp32_flash_32M.overlay
+  /.*/esp32s2/.*/:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: soc/esp32s2_flash_32M.overlay
+  /.*/esp32s3/.*/:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: soc/esp32s3_flash_32M.overlay
+  /.*/esp32c3/.*/:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: soc/esp32c3_flash_32M.overlay
+  /.*/esp32c6/.*/:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: soc/esp32c6_flash_32M.overlay

--- a/snippets/espressif/flash-32M/soc/esp32_flash_32M.overlay
+++ b/snippets/espressif/flash-32M/soc/esp32_flash_32M.overlay
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2025 Espressif Systems (Shanghai) Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/delete-node/ &flash0;
+
+#include <espressif/esp32/esp32_common.dtsi>
+#include <espressif/partitions_0x1000_amp_32M.dtsi>
+
+&flash0 {
+	reg = <0x0 DT_SIZE_M(32)>;
+};

--- a/snippets/espressif/flash-32M/soc/esp32c3_flash_32M.overlay
+++ b/snippets/espressif/flash-32M/soc/esp32c3_flash_32M.overlay
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2025 Espressif Systems (Shanghai) Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/delete-node/ &flash0;
+
+#include <espressif/esp32c3/esp32c3_common.dtsi>
+#include <espressif/partitions_0x0_default_32M.dtsi>
+
+&flash0 {
+	reg = <0x0 DT_SIZE_M(32)>;
+};

--- a/snippets/espressif/flash-32M/soc/esp32c6_flash_32M.overlay
+++ b/snippets/espressif/flash-32M/soc/esp32c6_flash_32M.overlay
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2025 Espressif Systems (Shanghai) Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/delete-node/ &flash0;
+
+#include <espressif/esp32c6/esp32c6_common.dtsi>
+#include <espressif/partitions_0x0_default_32M.dtsi>
+
+&flash0 {
+	reg = <0x0 DT_SIZE_M(32)>;
+};

--- a/snippets/espressif/flash-32M/soc/esp32s2_flash_32M.overlay
+++ b/snippets/espressif/flash-32M/soc/esp32s2_flash_32M.overlay
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2025 Espressif Systems (Shanghai) Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/delete-node/ &flash0;
+
+#include <espressif/esp32s2/esp32s2_common.dtsi>
+#include <espressif/partitions_0x0_amp_32M.dtsi>
+
+&flash0 {
+	reg = <0x0 DT_SIZE_M(32)>;
+};

--- a/snippets/espressif/flash-32M/soc/esp32s3_flash_32M.overlay
+++ b/snippets/espressif/flash-32M/soc/esp32s3_flash_32M.overlay
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2025 Espressif Systems (Shanghai) Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/delete-node/ &flash0;
+
+#include <espressif/esp32s3/esp32s3_common.dtsi>
+#include <espressif/partitions_0x0_amp_32M.dtsi>
+
+&flash0 {
+	reg = <0x0 DT_SIZE_M(32)>;
+};

--- a/snippets/espressif/flash-4M/README.rst
+++ b/snippets/espressif/flash-4M/README.rst
@@ -1,0 +1,9 @@
+.. _espressif-flash-4M:
+
+Espressif Flash 4MB
+###################
+
+Overview
+********
+
+This snippet allows users to select the 4MB SPI flash variant of the ESP32 chips.

--- a/snippets/espressif/flash-4M/snippet.yml
+++ b/snippets/espressif/flash-4M/snippet.yml
@@ -1,0 +1,22 @@
+# Copyright 2025 Espressif Systems Shanghai
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: flash-4M
+
+boards:
+  /.*/esp32/.*/:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: soc/esp32_flash_4M.overlay
+  /.*/esp32s2/.*/:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: soc/esp32s2_flash_4M.overlay
+  /.*/esp32s3/.*/:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: soc/esp32s3_flash_4M.overlay
+  /.*/esp32c3/.*/:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: soc/esp32c3_flash_4M.overlay
+  /.*/esp32c6/.*/:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: soc/esp32c6_flash_4M.overlay

--- a/snippets/espressif/flash-4M/soc/esp32_flash_4M.overlay
+++ b/snippets/espressif/flash-4M/soc/esp32_flash_4M.overlay
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2025 Espressif Systems (Shanghai) Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/delete-node/ &flash0;
+
+#include <espressif/esp32/esp32_common.dtsi>
+#include <espressif/partitions_0x1000_amp_4M.dtsi>
+
+&flash0 {
+	reg = <0x0 DT_SIZE_M(4)>;
+};

--- a/snippets/espressif/flash-4M/soc/esp32c3_flash_4M.overlay
+++ b/snippets/espressif/flash-4M/soc/esp32c3_flash_4M.overlay
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2025 Espressif Systems (Shanghai) Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/delete-node/ &flash0;
+
+#include <espressif/esp32c3/esp32c3_common.dtsi>
+#include <espressif/partitions_0x0_default_4M.dtsi>
+
+&flash0 {
+	reg = <0x0 DT_SIZE_M(4)>;
+};

--- a/snippets/espressif/flash-4M/soc/esp32c6_flash_4M.overlay
+++ b/snippets/espressif/flash-4M/soc/esp32c6_flash_4M.overlay
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2025 Espressif Systems (Shanghai) Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/delete-node/ &flash0;
+
+#include <espressif/esp32c6/esp32c6_common.dtsi>
+#include <espressif/partitions_0x0_default_4M.dtsi>
+
+&flash0 {
+	reg = <0x0 DT_SIZE_M(4)>;
+};

--- a/snippets/espressif/flash-4M/soc/esp32s2_flash_4M.overlay
+++ b/snippets/espressif/flash-4M/soc/esp32s2_flash_4M.overlay
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2025 Espressif Systems (Shanghai) Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/delete-node/ &flash0;
+
+#include <espressif/esp32s2/esp32s2_common.dtsi>
+#include <espressif/partitions_0x0_amp_4M.dtsi>
+
+&flash0 {
+	reg = <0x0 DT_SIZE_M(4)>;
+};

--- a/snippets/espressif/flash-4M/soc/esp32s3_flash_4M.overlay
+++ b/snippets/espressif/flash-4M/soc/esp32s3_flash_4M.overlay
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2025 Espressif Systems (Shanghai) Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/delete-node/ &flash0;
+
+#include <espressif/esp32s3/esp32s3_common.dtsi>
+#include <espressif/partitions_0x0_amp_4M.dtsi>
+
+&flash0 {
+	reg = <0x0 DT_SIZE_M(4)>;
+};

--- a/snippets/espressif/flash-8M/README.rst
+++ b/snippets/espressif/flash-8M/README.rst
@@ -1,0 +1,9 @@
+.. _espressif-flash-8M:
+
+Espressif Flash 8MB
+###################
+
+Overview
+********
+
+This snippet allows users to select the 8MB SPI flash variant of the ESP32 chips.

--- a/snippets/espressif/flash-8M/snippet.yml
+++ b/snippets/espressif/flash-8M/snippet.yml
@@ -1,0 +1,22 @@
+# Copyright 2025 Espressif Systems Shanghai
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: flash-8M
+
+boards:
+  /.*/esp32/.*/:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: soc/esp32_flash_8M.overlay
+  /.*/esp32s2/.*/:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: soc/esp32s2_flash_8M.overlay
+  /.*/esp32s3/.*/:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: soc/esp32s3_flash_8M.overlay
+  /.*/esp32c3/.*/:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: soc/esp32c3_flash_8M.overlay
+  /.*/esp32c6/.*/:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: soc/esp32c6_flash_8M.overlay

--- a/snippets/espressif/flash-8M/soc/esp32_flash_8M.overlay
+++ b/snippets/espressif/flash-8M/soc/esp32_flash_8M.overlay
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2025 Espressif Systems (Shanghai) Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/delete-node/ &flash0;
+
+#include <espressif/esp32/esp32_common.dtsi>
+#include <espressif/partitions_0x1000_amp_8M.dtsi>
+
+&flash0 {
+	reg = <0x0 DT_SIZE_M(8)>;
+};

--- a/snippets/espressif/flash-8M/soc/esp32c3_flash_8M.overlay
+++ b/snippets/espressif/flash-8M/soc/esp32c3_flash_8M.overlay
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2025 Espressif Systems (Shanghai) Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/delete-node/ &flash0;
+
+#include <espressif/esp32c3/esp32c3_common.dtsi>
+#include <espressif/partitions_0x0_default_8M.dtsi>
+
+&flash0 {
+	reg = <0x0 DT_SIZE_M(8)>;
+};

--- a/snippets/espressif/flash-8M/soc/esp32c6_flash_8M.overlay
+++ b/snippets/espressif/flash-8M/soc/esp32c6_flash_8M.overlay
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2025 Espressif Systems (Shanghai) Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/delete-node/ &flash0;
+
+#include <espressif/esp32c6/esp32c6_common.dtsi>
+#include <espressif/partitions_0x0_default_8M.dtsi>
+
+&flash0 {
+	reg = <0x0 DT_SIZE_M(8)>;
+};

--- a/snippets/espressif/flash-8M/soc/esp32s2_flash_8M.overlay
+++ b/snippets/espressif/flash-8M/soc/esp32s2_flash_8M.overlay
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2025 Espressif Systems (Shanghai) Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/delete-node/ &flash0;
+
+#include <espressif/esp32s2/esp32s2_common.dtsi>
+#include <espressif/partitions_0x0_amp_8M.dtsi>
+
+&flash0 {
+	reg = <0x0 DT_SIZE_M(8)>;
+};

--- a/snippets/espressif/flash-8M/soc/esp32s3_flash_8M.overlay
+++ b/snippets/espressif/flash-8M/soc/esp32s3_flash_8M.overlay
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2025 Espressif Systems (Shanghai) Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/delete-node/ &flash0;
+
+#include <espressif/esp32s3/esp32s3_common.dtsi>
+#include <espressif/partitions_0x0_amp_8M.dtsi>
+
+&flash0 {
+	reg = <0x0 DT_SIZE_M(8)>;
+};

--- a/snippets/espressif/index.rst
+++ b/snippets/espressif/index.rst
@@ -1,0 +1,10 @@
+.. _espressif-snippets:
+
+Espressif snippets
+##################
+
+.. toctree::
+   :maxdepth: 1
+   :glob:
+
+   **/*

--- a/snippets/espressif/psram-2M/README.rst
+++ b/snippets/espressif/psram-2M/README.rst
@@ -1,0 +1,9 @@
+.. _espressif-psram-2M:
+
+Espressif PSRAM 2MB
+###################
+
+Overview
+********
+
+This snippet allows users to select the 2MB SPI PSRAM variant of the ESP32 chips.

--- a/snippets/espressif/psram-2M/esp_psram.conf
+++ b/snippets/espressif/psram-2M/esp_psram.conf
@@ -1,0 +1,5 @@
+# Copyright 2025 Espressif Systems Shanghai
+#
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_ESP_SPIRAM=y

--- a/snippets/espressif/psram-2M/snippet.yml
+++ b/snippets/espressif/psram-2M/snippet.yml
@@ -1,0 +1,8 @@
+# Copyright 2025 Espressif Systems Shanghai
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: psram-2M
+append:
+  EXTRA_CONF_FILE: esp_psram.conf
+  EXTRA_DTC_OVERLAY_FILE: soc/esp_psram_2M.overlay

--- a/snippets/espressif/psram-2M/soc/esp_psram_2M.overlay
+++ b/snippets/espressif/psram-2M/soc/esp_psram_2M.overlay
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2025 Espressif Systems (Shanghai) Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* 2MB PSRAM */
+&psram0 {
+	size = <DT_SIZE_M(2)>;
+};

--- a/snippets/espressif/psram-4M/README.rst
+++ b/snippets/espressif/psram-4M/README.rst
@@ -1,0 +1,9 @@
+.. _espressif-psram-4M:
+
+Espressif PSRAM 4MB
+###################
+
+Overview
+********
+
+This snippet allows users to select the 4MB SPI PSRAM variant of the ESP32 chips.

--- a/snippets/espressif/psram-4M/esp_psram.conf
+++ b/snippets/espressif/psram-4M/esp_psram.conf
@@ -1,0 +1,5 @@
+# Copyright 2025 Espressif Systems Shanghai
+#
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_ESP_SPIRAM=y

--- a/snippets/espressif/psram-4M/snippet.yml
+++ b/snippets/espressif/psram-4M/snippet.yml
@@ -1,0 +1,8 @@
+# Copyright 2025 Espressif Systems Shanghai
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: psram-4M
+append:
+  EXTRA_CONF_FILE: esp_psram.conf
+  EXTRA_DTC_OVERLAY_FILE: soc/esp_psram_4M.overlay

--- a/snippets/espressif/psram-4M/soc/esp_psram_4M.overlay
+++ b/snippets/espressif/psram-4M/soc/esp_psram_4M.overlay
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2025 Espressif Systems (Shanghai) Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* 4MB PSRAM */
+&psram0 {
+	size = <DT_SIZE_M(4)>;
+};

--- a/snippets/espressif/psram-8M/README.rst
+++ b/snippets/espressif/psram-8M/README.rst
@@ -1,0 +1,9 @@
+.. _espressif-psram-8M:
+
+Espressif PSRAM 8MB
+###################
+
+Overview
+********
+
+This snippet allows users to select the 8MB SPI PSRAM variant of the ESP32 chips.

--- a/snippets/espressif/psram-8M/esp_psram.conf
+++ b/snippets/espressif/psram-8M/esp_psram.conf
@@ -1,0 +1,5 @@
+# Copyright 2025 Espressif Systems Shanghai
+#
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_ESP_SPIRAM=y

--- a/snippets/espressif/psram-8M/snippet.yml
+++ b/snippets/espressif/psram-8M/snippet.yml
@@ -1,0 +1,8 @@
+# Copyright 2025 Espressif Systems Shanghai
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: psram-8M
+append:
+  EXTRA_CONF_FILE: esp_psram.conf
+  EXTRA_DTC_OVERLAY_FILE: soc/esp_psram_8M.overlay

--- a/snippets/espressif/psram-8M/soc/esp_psram_8M.overlay
+++ b/snippets/espressif/psram-8M/soc/esp_psram_8M.overlay
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2025 Espressif Systems (Shanghai) Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* 8MB PSRAM */
+&psram0 {
+	size = <DT_SIZE_M(8)>;
+};

--- a/snippets/espressif/psram-reloc/README.rst
+++ b/snippets/espressif/psram-reloc/README.rst
@@ -1,0 +1,9 @@
+.. _espressif-psram-reloc:
+
+Espressif PSRAM relocations
+###########################
+
+Overview
+********
+
+This snippet allows users to enable the flash sections to be relocated to PSRAM.

--- a/snippets/espressif/psram-reloc/esp-psram-reloc.conf
+++ b/snippets/espressif/psram-reloc/esp-psram-reloc.conf
@@ -1,0 +1,7 @@
+# Copyright 2025 Espressif Systems Shanghai
+#
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_ESP_SPIRAM=y
+CONFIG_SPIRAM_FETCH_INSTRUCTIONS=y
+CONFIG_SPIRAM_RODATA=y

--- a/snippets/espressif/psram-reloc/snippet.yml
+++ b/snippets/espressif/psram-reloc/snippet.yml
@@ -1,0 +1,7 @@
+# Copyright 2025 Espressif Systems Shanghai
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: psram-reloc
+append:
+  EXTRA_CONF_FILE: esp-psram-reloc.conf

--- a/snippets/espressif/psram-wifi/README.rst
+++ b/snippets/espressif/psram-wifi/README.rst
@@ -1,0 +1,9 @@
+.. _espressif-psram-wifi:
+
+Espressif PSRAM Wi-Fi buffers
+#############################
+
+Overview
+********
+
+This snippet allows users to configure Wi-Fi buffers to use PSRAM.

--- a/snippets/espressif/psram-wifi/esp-psram-wifi.conf
+++ b/snippets/espressif/psram-wifi/esp-psram-wifi.conf
@@ -1,0 +1,6 @@
+# Copyright 2025 Espressif Systems Shanghai
+#
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_ESP_WIFI_HEAP_SPIRAM=y
+CONFIG_ESP32_WIFI_NET_ALLOC_SPIRAM=y

--- a/snippets/espressif/psram-wifi/snippet.yml
+++ b/snippets/espressif/psram-wifi/snippet.yml
@@ -1,0 +1,7 @@
+# Copyright 2025 Espressif Systems Shanghai
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: psram-wifi
+append:
+  EXTRA_CONF_FILE: esp-psram-wifi.conf


### PR DESCRIPTION
Introduce snippets under `snippets/espressif` to handle configuration of
flash and PSRAM variants. This enables flexible selection of memory
variants for supported boards without proliferating board-specific
variants.

Using snippets is the right mechanism for this for several reasons:

- *Reusable across all boards:* Unlike board variants, snippets are
  global and composable. They avoid duplication by not requiring each
  board to define new variant files.
- *Supports multiple configurations for a single board:* Boards like
  `esp32s3_devkitm` can be assembled with different flash/PSRAM module
  combinations. Snippets allow these to be expressed modularly.
- *Scalable and clean:* Maintains a clean and minimal board support
  directory structure without an explosion of board variant directories.

**Why not Kconfig?**

Kconfig alone is insufficient here. While DTS symbols can be referenced
from Kconfig, conditional DTS inclusion *based on Kconfig options* is
not supported. We need the ability to conditionally add devicetree
overlays and configuration fragments, which snippets provide cleanly.

This approach aligns with the modular and composable philosophy of the
Zephyr build system.

The following configurations have been added:

- *Flash size* with appropriate partition selection
- *PSRAM size* and modes configuration 
- *PSRAM reloc* allows to relocate the flash code and rodata into a PSRAM
- *PSRAM wifi* related configuration cases

The goal is to provide a unified and simple way to maintain memory configuration that is frequently needed in development.
`west build -b <esp32s3_devkitm/esp32s3/procpu samples/net/wifi/shell -p -S "flash-32M psram-8M psram-reloc"`

All Espressif boards documentation has been updated to cover the board variant options using snippets.