### PR TITLE
mimxrt700_evk: Fix USB failures

### DIFF
--- a/boards/nxp/mimxrt700_evk/board.c
+++ b/boards/nxp/mimxrt700_evk/board.c
@@ -408,6 +408,9 @@ void board_early_init_hook(void)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(usb0)) && CONFIG_UDC_NXP_EHCI
+	/* Power on COM VDDN domain for USB */
+	POWER_DisablePD(kPDRUNCFG_DSR_VDDN_COM);
+
 	/* Power on usb ram array as need, powered USB0RAM array*/
 	POWER_DisablePD(kPDRUNCFG_APD_USB0_SRAM);
 	POWER_DisablePD(kPDRUNCFG_PPD_USB0_SRAM);
@@ -425,8 +428,10 @@ void board_early_init_hook(void)
 	CLOCK_EnableClock(kCLOCK_UsbphyRef);
 	RESET_PeripheralReset(kUSB0_RST_SHIFT_RSTn);
 	RESET_PeripheralReset(kUSBPHY0_RST_SHIFT_RSTn);
-	CLOCK_EnableUsbhs0PhyPllClock(kCLOCK_Usbphy480M, usbClockFreq);
-	CLOCK_EnableUsbhs0Clock(kCLOCK_Usb480M, usbClockFreq);
+	CLOCK_EnableUsbhs0PhyPllClock(kCLOCK_Usbphy480M,
+				DT_PROP_BY_PHANDLE(DT_NODELABEL(usb0), clocks, clock_frequency));
+	CLOCK_EnableUsbhs0Clock(kCLOCK_Usb480M,
+				DT_PROP_BY_PHANDLE(DT_NODELABEL(usb0), clocks, clock_frequency));
 #endif
 }
 

--- a/soc/nxp/imxrt/imxrt7xx/cm33/CMakeLists.txt
+++ b/soc/nxp/imxrt/imxrt7xx/cm33/CMakeLists.txt
@@ -5,6 +5,7 @@
 #
 
 zephyr_compile_definitions_ifdef(CONFIG_NXP_LP_FLEXCOMM LPFLEXCOMM_INIT_NOT_USED_IN_DRIVER=1)
+zephyr_compile_definitions_ifdef(CONFIG_UDC_DRIVER USB_DEVICE_CONFIG_BUFFER_PROPERTY_CACHEABLE=1)
 
 zephyr_compile_definitions(FSL_SDK_DRIVER_QUICK_ACCESS_ENABLE)
 


### PR DESCRIPTION
1. Update the USB clock init code
2. Pass a flag to USB HAL driver for cache management

Depends on https://github.com/zephyrproject-rtos/zephyr/pull/87433