### PR TITLE
tests: kernel: spinlock: Added busy wait of 5us

### DIFF
--- a/tests/kernel/spinlock/src/main.c
+++ b/tests/kernel/spinlock/src/main.c
@@ -83,7 +83,7 @@ static void bounce_once(int id, bool trylock)
 		}
 
 		k_spin_unlock(&bounce_lock, key);
-		k_busy_wait(100);
+		k_busy_wait(1);
 	}
 
 	if (!locked && bounce_done) {
@@ -99,7 +99,7 @@ static void bounce_once(int id, bool trylock)
 
 	for (i = 0; i < 5; i++) {
 		zassert_true(bounce_owner == id, "Locked data changed");
-		k_busy_wait(1);
+		k_busy_wait(5);
 	}
 
 	/* Release the lock */


### PR DESCRIPTION
This commit adds a busy wait of 5us in the
test_trylock testcase to address timing
inconsistencies observed on high clock speed
platforms.

Faster execution on these platforms causes the
lock to be acquired consistently, preventing
expected failure cases. Introducing a brief
busy wait adjusts timing, allowing failures to
occur as intended and ensuring consistent
test behavior across platforms.