### PR TITLE
manifest: hal_renesas: Update hal_renesas revision

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -219,7 +219,7 @@ manifest:
         - hal
     - name: hal_renesas
       path: modules/hal/renesas
-      revision: cbaf9b554988614ce11805a9b2f03f6bb0310b8b
+      revision: a959f1bbfc3ee7f99326e14b1f8e0aca8b9947eb
       groups:
         - hal
     - name: hal_rpi_pico


### PR DESCRIPTION
Update hal_renesas to the latest revision to fix the warning bleeding to other vendors
`CMake Warning at /home/pdgendt/zephyrproject/zephyr/CMakeLists.txt:1011 (message):`
`No SOURCES given to Zephyr library: ..__modules__hal__renesas__drivers`
`Excluding target from build.`
Fixes: #87454 