### PR TITLE
drivers: i3c: cleanup const

### DIFF
--- a/drivers/i3c/i3c_common.c
+++ b/drivers/i3c/i3c_common.c
@@ -399,11 +399,11 @@ int i3c_sec_get_basic_info(const struct device *dev, uint8_t dynamic_addr, uint8
 	const struct i3c_driver_config *config = dev->config;
 	int ret;
 
-	*(const struct device **)&temp_desc.bus = dev;
+	temp_desc.bus = dev;
 	temp_desc.dynamic_addr = dynamic_addr;
 	temp_desc.bcr = bcr;
 	temp_desc.dcr = dcr;
-	/* attach it first with a temperary value so we can at least get the pid */
+	/* attach it first with a temporary value so we can at least get the pid */
 	ret = i3c_attach_i3c_device(&temp_desc);
 	if (ret != 0) {
 		return ret;
@@ -415,7 +415,7 @@ int i3c_sec_get_basic_info(const struct device *dev, uint8_t dynamic_addr, uint8
 		return ret;
 	}
 
-	*(uint64_t *)&id = sys_get_be48(getpid.pid);
+	id.pid = sys_get_be48(getpid.pid);
 
 	/* try to see if we already have a device statically allocated */
 	desc = i3c_dev_list_find(&config->dev_list, &id);
@@ -425,8 +425,8 @@ int i3c_sec_get_basic_info(const struct device *dev, uint8_t dynamic_addr, uint8
 		if (!desc) {
 			return -ENOMEM;
 		}
-		*(uint64_t *)&desc->pid = id.pid;
-		*(uint16_t *)&temp_desc.static_addr = (uint16_t)static_addr;
+		desc->pid = id.pid;
+		temp_desc.static_addr = (uint16_t)static_addr;
 	}
 	desc->dynamic_addr = dynamic_addr;
 	desc->bcr = bcr;
@@ -462,8 +462,8 @@ int i3c_sec_i2c_attach(const struct device *dev, uint8_t static_addr, uint8_t lv
 			return -ENOMEM;
 		}
 		*(const struct device **)&i2c_desc->bus = dev;
-		*(uint16_t *)&i2c_desc->addr = (uint16_t)static_addr;
-		*(uint8_t *)&i2c_desc->lvr = lvr;
+		i2c_desc->addr = (uint16_t)static_addr;
+		i2c_desc->lvr = lvr;
 	}
 
 	ret = i3c_attach_i2c_device(i2c_desc);

--- a/include/zephyr/drivers/i3c.h
+++ b/include/zephyr/drivers/i3c.h
@@ -854,7 +854,7 @@ __subsystem struct i3c_driver_api {
  */
 struct i3c_device_id {
 	/** Device Provisioned ID */
-	const uint64_t pid:48;
+	uint64_t pid:48;
 };
 
 /**
@@ -890,13 +890,13 @@ struct i3c_device_desc {
 	sys_snode_t node;
 
 	/** I3C bus to which this target device is attached */
-	const struct device * const bus;
+	const struct device *bus;
 
 	/** Device driver instance of the I3C device */
-	const struct device * const dev;
+	const struct device *dev;
 
 	/** Device Provisioned ID */
-	const uint64_t pid;
+	uint64_t pid;
 
 	/**
 	 * Static address for this target device.
@@ -910,7 +910,7 @@ struct i3c_device_desc {
 	 * device (as both are to tell target device to use static
 	 * address as dynamic address).
 	 */
-	const uint8_t static_addr;
+	uint8_t static_addr;
 
 	/**
 	 * Initial dynamic address.
@@ -1107,13 +1107,13 @@ struct i3c_i2c_device_desc {
 	const struct device *bus;
 
 	/** Static address for this I2C device. */
-	const uint16_t addr;
+	uint16_t addr;
 
 	/**
 	 * Legacy Virtual Register (LVR)
 	 * @see @ref I3C_LVR
 	 */
-	const uint8_t lvr;
+	uint8_t lvr;
 
 	/** @cond INTERNAL_HIDDEN */
 	/**


### PR DESCRIPTION
There is const used in a few places and some hacks to get around that const. Just remove the const as well as remove the hacks.